### PR TITLE
fix(telegram): launch lifecycle sessions safely on macOS

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Interactive TUI `/resume` commits a status-container progress lease before inspect/migration/switch work and clears it on every exit path, with generation-scoped render-commit wait that fails open when the terminal is stopped or unavailable (#2914).
 - Interactive `/resume` progress lease fails open when `statusContainer` or UI lacks child-mutation/render-commit surface, preserving headless/minimal controller contexts without weakening full TUI progress-before-switch (#3234 post-merge).
 - The documented `GJC_OPENAI_CODE_WEB_SEARCH_MODEL` environment variable now overrides the OpenAI-code web-search model; it is resolved GJC-first ahead of the legacy `PI_CODEX_WEB_SEARCH_MODEL` name (previously only the legacy name was read, so the documented name was a silent no-op).
+- Telegram `/session_create` and cold resume no longer route macOS or other non-Linux hosts through the Linux-only managed-owner supervisor. Non-Linux launches now bind success and cleanup to the exact tmux server, native session, and live pane process identities, scrub inherited managed-owner authority, and reject children that die during launch stabilization; Linux keeps its existing owner-isolation transaction.
 
 ### Added
 

--- a/packages/coding-agent/src/gjc-runtime/managed-owner-admission.ts
+++ b/packages/coding-agent/src/gjc-runtime/managed-owner-admission.ts
@@ -51,7 +51,7 @@ function ownerEnvironment(): {
 	const generation = process.env[MANAGED_OWNER_GENERATION_ENV]?.trim();
 	const runId = process.env[MANAGED_OWNER_RUN_ID_ENV]?.trim();
 	const incarnation = process.env[MANAGED_OWNER_INCARNATION_ENV]?.trim();
-	if (!stateDir && !sessionId && !generation && !runId && !incarnation) return null;
+	if (!stateDir && !generation && !runId && !incarnation) return null;
 	if (!stateDir || !sessionId || !generation || !runId || !incarnation || !path.isAbsolute(stateDir))
 		throw new Error("managed_owner_admission_metadata_invalid");
 	for (const [value, label] of [

--- a/packages/coding-agent/src/sdk/bus/lifecycle-control-runtime.ts
+++ b/packages/coding-agent/src/sdk/bus/lifecycle-control-runtime.ts
@@ -21,6 +21,8 @@ import {
 	MANAGED_OWNER_TRANSCRIPT_PATH_ENV,
 } from "../../gjc-runtime/managed-owner-admission";
 import {
+	MANAGED_OWNER_CHILD_TOKEN_ENV,
+	MANAGED_OWNER_COMMAND_ENV,
 	MANAGED_OWNER_INCARNATION_ENV,
 	MANAGED_OWNER_RUN_ID_ENV,
 	MANAGED_OWNER_SUPERVISOR_ARG,
@@ -56,6 +58,7 @@ import {
 	type GjcTmuxSessionStatus,
 	listGjcTmuxSessions,
 } from "../../gjc-runtime/tmux-sessions";
+import { processIncarnation } from "../broker/process-incarnation";
 import type {
 	LifecycleErrorReason,
 	ResumeCandidate,
@@ -76,6 +79,29 @@ import {
 	type ResumeEffectResult,
 } from "./lifecycle-orchestrator";
 import { listRecentSessions } from "./recent-activity";
+
+const directLifecycleManagedOwnerEnvUnsets = [
+	GJC_TMUX_OWNER_GENERATION_ENV,
+	GJC_TMUX_OWNER_STATE_DIR_ENV,
+	GJC_TMUX_OWNER_SERVER_KEY_ENV,
+	MANAGED_OWNER_COMMAND_ENV,
+	MANAGED_OWNER_RUN_ID_ENV,
+	MANAGED_OWNER_INCARNATION_ENV,
+	MANAGED_OWNER_CHILD_TOKEN_ENV,
+	MANAGED_OWNER_PREDECESSOR_TOKEN_ENV,
+	MANAGED_OWNER_PREDECESSOR_GENERATION_ENV,
+	MANAGED_OWNER_PREDECESSOR_RUN_ID_ENV,
+	MANAGED_OWNER_PREDECESSOR_INCARNATION_ENV,
+	MANAGED_OWNER_TRANSCRIPT_PATH_ENV,
+] as const;
+const directLifecycleStabilizationMs = 250;
+
+function directLifecycleEnvArguments(env: Record<string, string>): string {
+	return [
+		...directLifecycleManagedOwnerEnvUnsets.flatMap(name => ["-u", shellQuote(name)]),
+		...Object.entries(env).map(([key, value]) => `${key}=${shellQuote(value)}`),
+	].join(" ");
+}
 
 type NativeControlServerConstructor = new (
 	token: string,
@@ -857,74 +883,343 @@ async function completeLifecycleSpawnTransaction(input: {
 		throw error;
 	}
 }
+function directTmuxReceipt(
+	stdout: string,
+	sessionName: string,
+): { nativeSessionId: string; sessionName: string } | undefined {
+	const line = stdout.endsWith("\n") ? stdout.slice(0, -1) : stdout;
+	const [nativeSessionId, receivedName, ...rest] = line.split("\t");
+	return rest.length === 0 && /^\$\d+$/.test(nativeSessionId) && receivedName === sessionName
+		? { nativeSessionId, sessionName: receivedName }
+		: undefined;
+}
+
+type DirectTmuxBinding =
+	| { state: "bound"; serverPid: number; panePid: number; paneDead: boolean; paneDeadStatus: string }
+	| { state: "absent" }
+	| { state: "unverifiable" };
+
+function isKnownNoSessionDiagnostic(stderr: string): boolean {
+	const diagnostic = stderr.trim().toLowerCase();
+	return (
+		diagnostic.length > 0 &&
+		diagnostic.length <= 512 &&
+		/no server running|can't find session|no such session|unknown session/.test(diagnostic)
+	);
+}
+
+function directTmuxBinding(
+	tmux: string,
+	env: NodeJS.ProcessEnv,
+	cwd: string,
+	nativeSessionId: string,
+	sessionName: string,
+): DirectTmuxBinding {
+	const result = Bun.spawnSync(
+		[
+			tmux,
+			"display-message",
+			"-p",
+			"-t",
+			nativeSessionId,
+			"#{pid}\t#{session_id}\t#{session_name}\t#{pane_pid}\t#{pane_dead}\t#{pane_dead_status}",
+		],
+		{ stdout: "pipe", stderr: "pipe", env, cwd },
+	);
+	if (result.exitCode !== 0)
+		return isKnownNoSessionDiagnostic(result.stderr.toString()) ? { state: "absent" } : { state: "unverifiable" };
+	const output = result.stdout.toString();
+	const line = output.endsWith("\n") ? output.slice(0, -1) : output;
+	const [pid, receivedId, receivedName, panePid, paneDead, paneDeadStatus, ...rest] = line.split("\t");
+	return rest.length === 0 &&
+		/^\d+$/.test(pid) &&
+		Number(pid) > 0 &&
+		receivedId === nativeSessionId &&
+		receivedName === sessionName &&
+		/^\d+$/.test(panePid) &&
+		Number(panePid) > 0 &&
+		(paneDead === "0" || paneDead === "1")
+		? {
+				state: "bound",
+				serverPid: Number(pid),
+				panePid: Number(panePid),
+				paneDead: paneDead === "1",
+				paneDeadStatus,
+			}
+		: { state: "unverifiable" };
+}
+
+function directTmuxIdentityIsCurrent(input: {
+	tmux: string;
+	env: NodeJS.ProcessEnv;
+	cwd: string;
+	nativeSessionId: string;
+	sessionName: string;
+	serverPid: number;
+	serverIncarnation: string;
+	readProcessIncarnation: (pid: number) => string | undefined;
+}): boolean {
+	const binding = directTmuxBinding(input.tmux, input.env, input.cwd, input.nativeSessionId, input.sessionName);
+	return (
+		binding.state === "bound" &&
+		binding.serverPid === input.serverPid &&
+		input.readProcessIncarnation(input.serverPid) === input.serverIncarnation
+	);
+}
+function directTmuxPaneLivenessIsCurrent(input: {
+	tmux: string;
+	env: NodeJS.ProcessEnv;
+	cwd: string;
+	nativeSessionId: string;
+	sessionName: string;
+	serverPid: number;
+	serverIncarnation: string;
+	panePid: number;
+	paneIncarnation: string;
+	readProcessIncarnation: (pid: number) => string | undefined;
+}): boolean {
+	const binding = directTmuxBinding(input.tmux, input.env, input.cwd, input.nativeSessionId, input.sessionName);
+	return (
+		binding.state === "bound" &&
+		binding.serverPid === input.serverPid &&
+		input.readProcessIncarnation(input.serverPid) === input.serverIncarnation &&
+		!binding.paneDead &&
+		binding.panePid === input.panePid &&
+		input.readProcessIncarnation(input.panePid) === input.paneIncarnation
+	);
+}
+
+function directTmuxGuardedMutation(input: {
+	tmux: string;
+	env: NodeJS.ProcessEnv;
+	cwd: string;
+	nativeSessionId: string;
+	sessionName: string;
+	serverPid: number;
+	serverIncarnation: string;
+	readProcessIncarnation: (pid: number) => string | undefined;
+	commands: string;
+	success: string;
+}): boolean {
+	if (!directTmuxIdentityIsCurrent(input)) return false;
+	const result = Bun.spawnSync(
+		[
+			input.tmux,
+			"if-shell",
+			"-t",
+			input.nativeSessionId,
+			"-F",
+			lifecycleMetadataPredicate(input.serverPid, input.nativeSessionId, input.sessionName),
+			`${input.commands} ; display-message -p ${input.success}`,
+			"display-message -p __gjc_lifecycle_metadata_refused__",
+		],
+		{ stdout: "pipe", stderr: "pipe", env: input.env, cwd: input.cwd },
+	);
+	return result.exitCode === 0 && result.stdout.toString().trim() === input.success;
+}
+
+function cleanupDirectLifecycleAttempt(input: {
+	tmux: string;
+	env: NodeJS.ProcessEnv;
+	cwd: string;
+	nativeSessionId: string;
+	sessionName: string;
+	serverPid: number;
+	serverIncarnation: string;
+	readProcessIncarnation: (pid: number) => string | undefined;
+}): void {
+	if (
+		!directTmuxGuardedMutation({
+			...input,
+			commands: `kill-session -t '${input.nativeSessionId}'`,
+			success: "__gjc_lifecycle_cleanup_ok__",
+		})
+	)
+		throw cleanupUncertain();
+	if (directTmuxBinding(input.tmux, input.env, input.cwd, input.nativeSessionId, input.sessionName).state !== "absent")
+		throw cleanupUncertain();
+}
+
+async function completeNonLinuxLifecycleSpawn(input: {
+	tmux: string;
+	env: NodeJS.ProcessEnv;
+	sessionId: string;
+	cwd: string;
+	sessionName: string;
+	sessionStateFile: string;
+	command: string;
+	readProcessIncarnation: (pid: number) => string | undefined;
+}): Promise<void> {
+	let attempt:
+		| {
+				nativeSessionId: string;
+				sessionName: string;
+				serverPid: number;
+				serverIncarnation: string;
+				panePid?: number;
+				paneIncarnation?: string;
+		  }
+		| undefined;
+	let primaryError: unknown;
+	try {
+		const created = Bun.spawnSync(
+			[
+				input.tmux,
+				"new-session",
+				"-d",
+				"-P",
+				"-F",
+				"#{session_id}\t#{session_name}",
+				"-s",
+				input.sessionName,
+				"sh",
+				"-c",
+				input.command,
+			],
+			{ stdout: "pipe", stderr: "pipe", env: input.env, cwd: input.cwd },
+		);
+		const receipt = directTmuxReceipt(created.stdout.toString(), input.sessionName);
+		if (!receipt) throw new Error("gjc_lifecycle_tmux_launch_failed");
+		const binding = directTmuxBinding(input.tmux, input.env, input.cwd, receipt.nativeSessionId, receipt.sessionName);
+		const serverIncarnation = binding.state === "bound" && input.readProcessIncarnation(binding.serverPid);
+		const paneIncarnation =
+			binding.state === "bound" && !binding.paneDead && input.readProcessIncarnation(binding.panePid);
+		if (binding.state !== "bound" || !serverIncarnation) throw new Error("gjc_lifecycle_tmux_launch_failed");
+		attempt = { ...receipt, serverPid: binding.serverPid, serverIncarnation };
+		if (!binding.paneDead && paneIncarnation) {
+			attempt.panePid = binding.panePid;
+			attempt.paneIncarnation = paneIncarnation;
+		}
+		if (created.exitCode !== 0 || !directTmuxIdentityIsCurrent({ ...input, ...attempt }))
+			throw new Error("gjc_lifecycle_tmux_launch_failed");
+		const commands = buildGjcTmuxProfileCommands(attempt.nativeSessionId, input.env, {
+			sessionId: input.sessionId,
+			sessionStateFile: input.sessionStateFile,
+			project: input.cwd,
+		})
+			.map(command => command.args.map(tmuxCommandArgument).join(" "))
+			.join(" ; ");
+		if (
+			!directTmuxGuardedMutation({ ...input, ...attempt, commands, success: "__gjc_lifecycle_metadata_ok__" }) ||
+			!directTmuxIdentityIsCurrent({ ...input, ...attempt })
+		)
+			throw new Error("gjc_lifecycle_metadata_write_failed");
+		await Bun.sleep(directLifecycleStabilizationMs);
+		if (
+			attempt.panePid === undefined ||
+			attempt.paneIncarnation === undefined ||
+			!directTmuxPaneLivenessIsCurrent({
+				...input,
+				...attempt,
+				panePid: attempt.panePid,
+				paneIncarnation: attempt.paneIncarnation,
+			})
+		)
+			throw new Error("gjc_lifecycle_tmux_launch_liveness_failed");
+	} catch (error) {
+		primaryError = error;
+	}
+	if (primaryError === undefined) return;
+	let cleanupFailure: unknown;
+	if (attempt) {
+		try {
+			cleanupDirectLifecycleAttempt({ ...input, ...attempt });
+		} catch (error) {
+			cleanupFailure = error;
+		}
+	} else cleanupFailure = cleanupUncertain();
+	if (cleanupFailure !== undefined)
+		throw new AggregateError([primaryError, cleanupFailure], "gjc_lifecycle_cleanup_uncertain");
+	throw primaryError;
+}
 /** Real daemon-safe tmux launcher: canonical owner-isolation plan + GJC tags. */
 export function daemonSpawnCreate(
 	env: NodeJS.ProcessEnv = process.env,
-	opts: { ownerIsolationProbe?: OwnerIsolationProbe } = {},
+	opts: {
+		ownerIsolationProbe?: OwnerIsolationProbe;
+		platform?: NodeJS.Platform;
+		processIncarnation?: (pid: number) => string | undefined;
+	} = {},
 ) {
 	return async (
 		frame: SessionCreateFrame,
 		ids: { lifecycleRequestId: string; intendedSessionId: string; startupPromptRef?: string },
 	): Promise<CreateEffectResult> => {
-		const tmuxBinary = resolveGjcTmuxBinary({ env });
+		const tmuxBinary = resolveGjcTmuxBinary({ env, platform: opts.platform });
 		if (tmuxBinary.isPsmux) throw new Error("gjc_lifecycle_psmux_unsupported");
 		const tmux = tmuxBinary.command;
 		const name = tmuxSessionNameFor(ids.intendedSessionId);
 		const { cwd, args } = buildCreateArgv(frame, ids);
 		const sessionStateFile = lifecycleRuntimeStateFile(cwd, ids.intendedSessionId, name);
-		const stateDir = path.dirname(sessionStateFile);
-		const previousBaseline = await captureOwnerGenerationBaseline(stateDir, ids.intendedSessionId);
-		const predecessor = resolveManagedOwnerPredecessorSync(stateDir, ids.intendedSessionId, previousBaseline);
-		const generation = crypto.randomUUID();
-		const runId = crypto.randomUUID();
-		const incarnation = crypto.randomUUID();
-		// Detached: no interactive TTY needed (daemon-safe). These values contain
-		// only opaque ids and paths needed by the resident sidecar to publish its
-		// exact-owner terminal verdict.
-		const childEnv: Record<string, string> = {
+		const commonChildEnv: Record<string, string> = {
 			GJC_TMUX_LAUNCHED: "1",
 			GJC_NOTIFICATIONS: "1",
 			GJC_SESSION_ID: ids.intendedSessionId,
 			GJC_LIFECYCLE_REQUEST_ID: ids.lifecycleRequestId,
 			[GJC_COORDINATOR_SESSION_ID_ENV]: ids.intendedSessionId,
 			[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]: sessionStateFile,
-			[GJC_TMUX_OWNER_GENERATION_ENV]: generation,
-			[GJC_TMUX_OWNER_STATE_DIR_ENV]: stateDir,
-			[GJC_TMUX_OWNER_SERVER_KEY_ENV]: "default",
-			GJC_MANAGED_OWNER_COMMAND_JSON: JSON.stringify(["gjc", ...args]),
-			[MANAGED_OWNER_RUN_ID_ENV]: runId,
-			[MANAGED_OWNER_INCARNATION_ENV]: incarnation,
-			...(predecessor
-				? {
-						[MANAGED_OWNER_PREDECESSOR_TOKEN_ENV]: predecessor.predecessorToken,
-						[MANAGED_OWNER_PREDECESSOR_GENERATION_ENV]: predecessor.generation,
-						[MANAGED_OWNER_PREDECESSOR_RUN_ID_ENV]: predecessor.runId,
-						[MANAGED_OWNER_PREDECESSOR_INCARNATION_ENV]: predecessor.incarnation,
-						[MANAGED_OWNER_TRANSCRIPT_PATH_ENV]: env.GJC_SESSION_FILE ?? "",
-					}
-				: {}),
 		};
-		if (ids.startupPromptRef) childEnv.GJC_STARTUP_PROMPT_REF = ids.startupPromptRef;
-		const envPairs = Object.entries(childEnv)
-			.map(([key, value]) => `${key}=${shellQuote(value)}`)
-			.join(" ");
-		const command = `cd ${shellQuote(cwd)} && exec env ${envPairs} gjc ${shellQuote(MANAGED_OWNER_SUPERVISOR_ARG)}`;
-		await completeLifecycleSpawnTransaction({
-			tmux,
-			env,
-			sessionId: ids.intendedSessionId,
-			generation,
-			stateDir,
-			cwd,
-			sessionName: name,
-			sessionStateFile,
-			argv: [tmux, "new-session", "-d", "-P", "-F", "#{session_id}", "-s", name, "sh", "-c", command],
-			ownerIsolationProbe: opts.ownerIsolationProbe,
-			prepareSpawn: () => {
-				if (frame.target.kind === "plain_dir") fs.mkdirSync(cwd, { recursive: true });
-			},
-			previousBaseline,
-		});
+		if (ids.startupPromptRef) commonChildEnv.GJC_STARTUP_PROMPT_REF = ids.startupPromptRef;
+		if ((opts.platform ?? process.platform) === "linux") {
+			const stateDir = path.dirname(sessionStateFile);
+			const previousBaseline = await captureOwnerGenerationBaseline(stateDir, ids.intendedSessionId);
+			const predecessor = resolveManagedOwnerPredecessorSync(stateDir, ids.intendedSessionId, previousBaseline);
+			const generation = crypto.randomUUID();
+			const runId = crypto.randomUUID();
+			const incarnation = crypto.randomUUID();
+			const managedChildEnv: Record<string, string> = {
+				...commonChildEnv,
+				[GJC_TMUX_OWNER_GENERATION_ENV]: generation,
+				[GJC_TMUX_OWNER_STATE_DIR_ENV]: stateDir,
+				[GJC_TMUX_OWNER_SERVER_KEY_ENV]: "default",
+				[MANAGED_OWNER_COMMAND_ENV]: JSON.stringify(["gjc", ...args]),
+				[MANAGED_OWNER_RUN_ID_ENV]: runId,
+				[MANAGED_OWNER_INCARNATION_ENV]: incarnation,
+				...(predecessor
+					? {
+							[MANAGED_OWNER_PREDECESSOR_TOKEN_ENV]: predecessor.predecessorToken,
+							[MANAGED_OWNER_PREDECESSOR_GENERATION_ENV]: predecessor.generation,
+							[MANAGED_OWNER_PREDECESSOR_RUN_ID_ENV]: predecessor.runId,
+							[MANAGED_OWNER_PREDECESSOR_INCARNATION_ENV]: predecessor.incarnation,
+							[MANAGED_OWNER_TRANSCRIPT_PATH_ENV]: env.GJC_SESSION_FILE ?? "",
+						}
+					: {}),
+			};
+			const managedEnvPairs = Object.entries(managedChildEnv)
+				.map(([key, value]) => `${key}=${shellQuote(value)}`)
+				.join(" ");
+			const command = `cd ${shellQuote(cwd)} && exec env ${managedEnvPairs} gjc ${shellQuote(MANAGED_OWNER_SUPERVISOR_ARG)}`;
+			await completeLifecycleSpawnTransaction({
+				tmux,
+				env,
+				sessionId: ids.intendedSessionId,
+				generation,
+				stateDir,
+				cwd,
+				sessionName: name,
+				sessionStateFile,
+				argv: [tmux, "new-session", "-d", "-P", "-F", "#{session_id}", "-s", name, "sh", "-c", command],
+				ownerIsolationProbe: opts.ownerIsolationProbe,
+				prepareSpawn: () => {
+					if (frame.target.kind === "plain_dir") fs.mkdirSync(cwd, { recursive: true });
+				},
+				previousBaseline,
+			});
+		} else {
+			if (frame.target.kind === "plain_dir") fs.mkdirSync(cwd, { recursive: true });
+			const directEnvPairs = directLifecycleEnvArguments(commonChildEnv);
+			const directCommand = `cd ${shellQuote(cwd)} && exec env ${directEnvPairs} gjc ${args.map(shellQuote).join(" ")}`;
+			await completeNonLinuxLifecycleSpawn({
+				tmux,
+				env,
+				sessionId: ids.intendedSessionId,
+				cwd,
+				sessionName: name,
+				sessionStateFile,
+				command: directCommand,
+				readProcessIncarnation: opts.processIncarnation ?? processIncarnation,
+			});
+		}
 
 		return {
 			sessionId: ids.intendedSessionId,
@@ -1018,13 +1313,15 @@ export function daemonResumeSession(
 		sessionsRoot?: string;
 		listSessions?: (env: NodeJS.ProcessEnv) => GjcTmuxSessionStatus[];
 		ownerIsolationProbe?: OwnerIsolationProbe;
+		platform?: NodeJS.Platform;
+		processIncarnation?: (pid: number) => string | undefined;
 	} = {},
 ) {
 	return async (target: {
 		sessionIdOrPrefix: string;
 		path?: string;
 	}): Promise<ResumeEffectResult | { ambiguous: ResumeCandidate[] } | { notFound: true }> => {
-		const tmuxBinary = resolveGjcTmuxBinary({ env });
+		const tmuxBinary = resolveGjcTmuxBinary({ env, platform: opts.platform });
 		if (tmuxBinary.isPsmux) throw new Error("gjc_lifecycle_psmux_unsupported");
 		const live = (opts.listSessions?.(env) ?? listGjcTmuxSessions(env)).filter(
 			s => s.sessionId === target.sessionIdOrPrefix || s.sessionId?.startsWith(target.sessionIdOrPrefix),
@@ -1085,50 +1382,68 @@ export function daemonResumeSession(
 		const tmux = tmuxBinary.command;
 		const name = tmuxSessionNameFor(resumeId);
 		const sessionStateFile = lifecycleRuntimeStateFile(resolvedResumeCwd, resumeId, name);
-		const stateDir = path.dirname(sessionStateFile);
-		const previousBaseline = await captureOwnerGenerationBaseline(stateDir, resumeId);
-		const predecessor = resolveManagedOwnerPredecessorSync(stateDir, resumeId, previousBaseline);
-		const generation = crypto.randomUUID();
-		const runId = crypto.randomUUID();
-		const incarnation = crypto.randomUUID();
-		const childEnv: Record<string, string> = {
+		const commonChildEnv: Record<string, string> = {
 			GJC_TMUX_LAUNCHED: "1",
 			GJC_NOTIFICATIONS: "1",
 			[GJC_COORDINATOR_SESSION_ID_ENV]: resumeId,
 			[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]: sessionStateFile,
-			[GJC_TMUX_OWNER_GENERATION_ENV]: generation,
-			[GJC_TMUX_OWNER_STATE_DIR_ENV]: stateDir,
-			[GJC_TMUX_OWNER_SERVER_KEY_ENV]: "default",
-			GJC_MANAGED_OWNER_COMMAND_JSON: JSON.stringify(["gjc", "--resume", resumeId]),
-			[MANAGED_OWNER_RUN_ID_ENV]: runId,
-			[MANAGED_OWNER_INCARNATION_ENV]: incarnation,
-			...(predecessor
-				? {
-						[MANAGED_OWNER_PREDECESSOR_TOKEN_ENV]: predecessor.predecessorToken,
-						[MANAGED_OWNER_PREDECESSOR_GENERATION_ENV]: predecessor.generation,
-						[MANAGED_OWNER_PREDECESSOR_RUN_ID_ENV]: predecessor.runId,
-						[MANAGED_OWNER_PREDECESSOR_INCARNATION_ENV]: predecessor.incarnation,
-						[MANAGED_OWNER_TRANSCRIPT_PATH_ENV]: env.GJC_SESSION_FILE ?? "",
-					}
-				: {}),
 		};
-		const envPairs = Object.entries(childEnv)
-			.map(([key, value]) => `${key}=${shellQuote(value)}`)
-			.join(" ");
-		const command = `cd ${shellQuote(resolvedResumeCwd)} && exec env ${envPairs} gjc ${shellQuote(MANAGED_OWNER_SUPERVISOR_ARG)}`;
-		await completeLifecycleSpawnTransaction({
-			tmux,
-			env,
-			sessionId: resumeId,
-			generation,
-			stateDir,
-			cwd: resolvedResumeCwd,
-			sessionName: name,
-			sessionStateFile,
-			argv: [tmux, "new-session", "-d", "-P", "-F", "#{session_id}", "-s", name, "sh", "-c", command],
-			ownerIsolationProbe: opts.ownerIsolationProbe,
-			previousBaseline,
-		});
+		if ((opts.platform ?? process.platform) === "linux") {
+			const stateDir = path.dirname(sessionStateFile);
+			const previousBaseline = await captureOwnerGenerationBaseline(stateDir, resumeId);
+			const predecessor = resolveManagedOwnerPredecessorSync(stateDir, resumeId, previousBaseline);
+			const generation = crypto.randomUUID();
+			const runId = crypto.randomUUID();
+			const incarnation = crypto.randomUUID();
+			const managedChildEnv: Record<string, string> = {
+				...commonChildEnv,
+				[GJC_TMUX_OWNER_GENERATION_ENV]: generation,
+				[GJC_TMUX_OWNER_STATE_DIR_ENV]: stateDir,
+				[GJC_TMUX_OWNER_SERVER_KEY_ENV]: "default",
+				[MANAGED_OWNER_COMMAND_ENV]: JSON.stringify(["gjc", "--resume", resumeId]),
+				[MANAGED_OWNER_RUN_ID_ENV]: runId,
+				[MANAGED_OWNER_INCARNATION_ENV]: incarnation,
+				...(predecessor
+					? {
+							[MANAGED_OWNER_PREDECESSOR_TOKEN_ENV]: predecessor.predecessorToken,
+							[MANAGED_OWNER_PREDECESSOR_GENERATION_ENV]: predecessor.generation,
+							[MANAGED_OWNER_PREDECESSOR_RUN_ID_ENV]: predecessor.runId,
+							[MANAGED_OWNER_PREDECESSOR_INCARNATION_ENV]: predecessor.incarnation,
+							[MANAGED_OWNER_TRANSCRIPT_PATH_ENV]: env.GJC_SESSION_FILE ?? "",
+						}
+					: {}),
+			};
+			const managedEnvPairs = Object.entries(managedChildEnv)
+				.map(([key, value]) => `${key}=${shellQuote(value)}`)
+				.join(" ");
+			const command = `cd ${shellQuote(resolvedResumeCwd)} && exec env ${managedEnvPairs} gjc ${shellQuote(MANAGED_OWNER_SUPERVISOR_ARG)}`;
+			await completeLifecycleSpawnTransaction({
+				tmux,
+				env,
+				sessionId: resumeId,
+				generation,
+				stateDir,
+				cwd: resolvedResumeCwd,
+				sessionName: name,
+				sessionStateFile,
+				argv: [tmux, "new-session", "-d", "-P", "-F", "#{session_id}", "-s", name, "sh", "-c", command],
+				ownerIsolationProbe: opts.ownerIsolationProbe,
+				previousBaseline,
+			});
+		} else {
+			const directEnvPairs = directLifecycleEnvArguments(commonChildEnv);
+			const directCommand = `cd ${shellQuote(resolvedResumeCwd)} && exec env ${directEnvPairs} gjc ${shellQuote("--resume")} ${shellQuote(resumeId)}`;
+			await completeNonLinuxLifecycleSpawn({
+				tmux,
+				env,
+				sessionId: resumeId,
+				cwd: resolvedResumeCwd,
+				sessionName: name,
+				sessionStateFile,
+				command: directCommand,
+				readProcessIncarnation: opts.processIncarnation ?? processIncarnation,
+			});
+		}
 
 		return {
 			sessionId: resumeId,

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts
@@ -40,13 +40,15 @@ export const NOTIFICATION_PROTOCOL_VERSION = 3;
  * Generation 29 adds serving-epoch compatibility, sidecar heartbeat, root GC,
  * and Bot API cooldown structural fixes (#2956, #2960, #3048).
  * Generation 30 adds opt-in tool activity delivery, closed lifecycle phases,
- * and capability-versioned mixed-host compatibility.
+ * and capability-versioned mixed-host compatibility. Generation 31 rolls out
+ * non-Linux direct tmux lifecycle cleanup semantics.
  */
-export const DAEMON_GENERATION = 30;
+export const DAEMON_GENERATION = 31;
 
 /**
  * Serving-compatibility boundary for daemon lifecycle requests. Epoch 1 covers
  * all builds published before this field existed; epoch 2 covered generation 29;
- * bump this to force serving convergence and reload of compatible live predecessors.
+ * epoch 3 covered generation 30; bump this to force serving convergence and
+ * reload of compatible live predecessors.
  */
-export const SERVING_EPOCH = 3;
+export const SERVING_EPOCH = 4;

--- a/packages/coding-agent/test/gjc-runtime/managed-owner-admission.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/managed-owner-admission.test.ts
@@ -15,7 +15,20 @@ const admissionModule = path.join(
 	"gjc-runtime",
 	"managed-owner-admission.ts",
 );
+const managedOwnerEnvironmentKeys = [
+	"GJC_TMUX_OWNER_STATE_DIR",
+	"GJC_COORDINATOR_SESSION_ID",
+	"GJC_TMUX_OWNER_GENERATION",
+	"GJC_MANAGED_OWNER_RUN_ID",
+	"GJC_MANAGED_OWNER_INCARNATION",
+	"GJC_MANAGED_OWNER_CHILD_TOKEN",
+] as const;
 
+function managedOwnerEnvironment(overrides: Record<string, string> = {}): NodeJS.ProcessEnv {
+	const env = { ...process.env };
+	for (const name of managedOwnerEnvironmentKeys) delete env[name];
+	return { ...env, ...overrides };
+}
 async function admit(stateDir: string, token?: string): Promise<{ admitted: boolean; exitCode: number; root: string }> {
 	const script = `import { admitManagedOwnerBeforeCli } from ${JSON.stringify(admissionModule)}; const admission = await admitManagedOwnerBeforeCli(); console.log(JSON.stringify({ admitted: admission.kind !== "blocked", exitCode: process.exitCode ?? 0 }));`;
 	const child = Bun.spawn({
@@ -121,6 +134,33 @@ async function writeRecoveryEvidence(cwd: string): Promise<string> {
 }
 
 describe("managed owner admission", () => {
+	it("treats a coordinator session ID alone as fresh while rejecting partial owner metadata", async () => {
+		const script = `import { admitManagedOwnerBeforeCli } from ${JSON.stringify(admissionModule)}; const admission = await admitManagedOwnerBeforeCli(); console.log(JSON.stringify({ kind: admission.kind }));`;
+		const fresh = Bun.spawn({
+			cmd: [process.execPath, "-e", script],
+			cwd: repoRoot,
+			stdout: "pipe",
+			stderr: "pipe",
+			env: managedOwnerEnvironment({ GJC_COORDINATOR_SESSION_ID: "ordinary-coordinator-session" }),
+		});
+		const [freshStdout, freshExitCode] = await Promise.all([new Response(fresh.stdout).text(), fresh.exited]);
+		expect(freshExitCode).toBe(0);
+		expect(JSON.parse(freshStdout)).toEqual({ kind: "fresh" });
+
+		const partial = Bun.spawn({
+			cmd: [process.execPath, "-e", script],
+			cwd: repoRoot,
+			stdout: "pipe",
+			stderr: "pipe",
+			env: managedOwnerEnvironment({
+				GJC_COORDINATOR_SESSION_ID: "ordinary-coordinator-session",
+				GJC_TMUX_OWNER_GENERATION: "partial-generation",
+			}),
+		});
+		const [partialStderr, partialExitCode] = await Promise.all([new Response(partial.stderr).text(), partial.exited]);
+		expect(partialExitCode).not.toBe(0);
+		expect(partialStderr).toContain("managed_owner_admission_metadata_invalid");
+	});
 	it("admits only the exact token binding for the current session and generation", async () => {
 		const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-managed-admission-"));
 		try {

--- a/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
+++ b/packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts
@@ -1467,6 +1467,7 @@ describe("lifecycle control runtime", () => {
 			},
 			{
 				sessionsRoot: root,
+				platform: "linux",
 				ownerIsolationProbe: {
 					readCallerCgroup: async () =>
 						"0::/user.slice/user-1000.slice/user@1000.service/app.slice/gjc-lifecycle-test.scope\n",
@@ -1528,6 +1529,7 @@ describe("lifecycle control runtime", () => {
 				{ ...process.env, GJC_TMUX_COMMAND: tmux, TMUX_CALLS: callsFile },
 				{
 					listSessions: () => [liveSession],
+					platform: "linux",
 					ownerIsolationProbe: {
 						readCallerCgroup: async () => null,
 						probeServer: async () => ({ state: "unverifiable" }),
@@ -1543,6 +1545,7 @@ describe("lifecycle control runtime", () => {
 		await expect(
 			daemonResumeSession(process.env, {
 				listSessions: () => [liveSession],
+				platform: "linux",
 				ownerIsolationProbe: {
 					readCallerCgroup: async () => null,
 					probeServer: async () => ({ state: "unsafe" }),
@@ -1609,6 +1612,7 @@ describe("lifecycle control runtime", () => {
 			const result = await daemonSpawnCreate(
 				{ ...process.env, GJC_TMUX_COMMAND: tmux, TMUX_CALLS: callsFile },
 				{
+					platform: "linux",
 					ownerIsolationProbe: {
 						readCallerCgroup: async () => "/gjc-lifecycle-test.scope\n",
 						probeServer: async () =>
@@ -1702,6 +1706,7 @@ describe("lifecycle control runtime", () => {
 						GENERATION_FILE: generationFile,
 					},
 					{
+						platform: "linux",
 						ownerIsolationProbe: {
 							readCallerCgroup: async () => "/gjc-lifecycle-test.scope\n",
 							probeServer: async () =>
@@ -1760,6 +1765,7 @@ describe("lifecycle control runtime", () => {
 			daemonSpawnCreate(
 				{ ...process.env, GJC_TMUX_COMMAND: tmux },
 				{
+					platform: "linux",
 					ownerIsolationProbe: {
 						readCallerCgroup: async () => "/gjc-lifecycle-test.scope\n",
 						probeServer: async () =>
@@ -1804,7 +1810,7 @@ describe("lifecycle control runtime", () => {
 					await expect(
 						daemonSpawnCreate(
 							{ ...process.env, GJC_TMUX_COMMAND: tmux, TMUX_CALLS: callsFile },
-							{ ownerIsolationProbe: probe },
+							{ platform: "linux", ownerIsolationProbe: probe },
 						)(createFrame({ target: { kind: "existing_path", path: project } }), {
 							lifecycleRequestId: `create-${state}`,
 							intendedSessionId: `create-${state}`,
@@ -1814,7 +1820,7 @@ describe("lifecycle control runtime", () => {
 					await expect(
 						daemonSpawnCreate(
 							{ ...process.env, GJC_TMUX_COMMAND: tmux, TMUX_CALLS: callsFile },
-							{ ownerIsolationProbe: probe },
+							{ platform: "linux", ownerIsolationProbe: probe },
 						)(createFrame({ target: { kind: "plain_dir", path: uncreatedPlainDir } }), {
 							lifecycleRequestId: `plain-${state}`,
 							intendedSessionId: `plain-${state}`,
@@ -1824,7 +1830,7 @@ describe("lifecycle control runtime", () => {
 					await expect(
 						daemonResumeSession(
 							{ ...process.env, GJC_TMUX_COMMAND: tmux, TMUX_CALLS: callsFile },
-							{ sessionsRoot: root, listSessions: () => [], ownerIsolationProbe: probe },
+							{ platform: "linux", sessionsRoot: root, listSessions: () => [], ownerIsolationProbe: probe },
 						)({ sessionIdOrPrefix: "resume-123", path: project }),
 					).rejects.toThrow(`gjc_lifecycle_owner_server_${state}`);
 				}
@@ -1862,6 +1868,7 @@ describe("lifecycle control runtime", () => {
 					daemonSpawnCreate(
 						{ ...process.env, GJC_TMUX_COMMAND: tmux, TMUX_CALLS: callsFile },
 						{
+							platform: "linux",
 							ownerIsolationProbe: {
 								readCallerCgroup: async () => "/gjc-lifecycle-test.scope\n",
 								probeServer: async () => {
@@ -1926,6 +1933,7 @@ describe("lifecycle control runtime", () => {
 						{
 							sessionsRoot: root,
 							listSessions: () => [],
+							platform: "linux",
 							ownerIsolationProbe: {
 								readCallerCgroup: async () => "/gjc-lifecycle-test.scope\n",
 								probeServer: async () => {
@@ -2034,6 +2042,7 @@ describe("lifecycle control runtime", () => {
 						daemonSpawnCreate(
 							{ ...process.env, GJC_TMUX_COMMAND: tmux, TMUX_CALLS: calls, RECEIPT: receipt },
 							{
+								platform: "linux",
 								ownerIsolationProbe: {
 									readCallerCgroup: async () => "/gjc-lifecycle-test.scope\n",
 									probeServer: async () => ({
@@ -2095,6 +2104,7 @@ describe("lifecycle control runtime", () => {
 							KILL_FAIL: cleanup === "kill" ? "1" : "0",
 						},
 						{
+							platform: "linux",
 							ownerIsolationProbe: {
 								readCallerCgroup: async () => "/gjc-lifecycle-test.scope\n",
 								probeServer: async () => {
@@ -2157,6 +2167,7 @@ describe("lifecycle control runtime", () => {
 					daemonSpawnCreate(
 						{ ...process.env, GJC_TMUX_COMMAND: tmux, TMUX_CALLS: calls },
 						{
+							platform: "linux",
 							ownerIsolationProbe: {
 								readCallerCgroup: async () => "/gjc-lifecycle-test.scope\n",
 								probeServer: async () => ({
@@ -2210,6 +2221,7 @@ describe("lifecycle control runtime", () => {
 				daemonSpawnCreate(
 					{ ...process.env, GJC_TMUX_COMMAND: tmux },
 					{
+						platform: "linux",
 						ownerIsolationProbe: {
 							readCallerCgroup: async () => "/gjc-lifecycle-test.scope\n",
 							probeServer: async () => {
@@ -2258,5 +2270,496 @@ describe("lifecycle control runtime", () => {
 			findSession: () => undefined,
 		})({ sessionId: "exact-id", tmuxSession: "gjc_lc_exact-id", sessionStateFile: "/private/exact.json" });
 		expect(received).toEqual([["gjc_lc_exact-id", env, "exact-id", "/private/exact.json"]]);
+	});
+	posixTmuxIt("uses direct tagged tmux launch for injected non-Linux lifecycle creates", async () => {
+		const root = managedFixtureRoot("gjc-nonlinux-create-");
+		const calls = path.join(root, "tmux-calls.log");
+		const session = path.join(root, "tmux-session");
+		const tmux = path.join(root, "fake-tmux.sh");
+		const retainedOwnerEvidence = path.join(
+			root,
+			".gjc",
+			"_session-darwin-session",
+			"runtime",
+			"tmux-sessions",
+			"darwin-session",
+			"owner-lifecycle",
+			"generation.json",
+		);
+		fs.mkdirSync(path.dirname(retainedOwnerEvidence), { recursive: true });
+		fs.writeFileSync(retainedOwnerEvidence, "{corrupt");
+		fs.writeFileSync(
+			tmux,
+			[
+				"#!/usr/bin/env bash",
+				'printf "%s\\n" "$*" >> "$TMUX_CALLS"',
+				'if [ "$1" = "new-session" ]; then : > "$TMUX_SESSION"; printf \'$42\\tgjc_lc_darwin-session\\n\'; exit 0; fi',
+				'if [ "$1" = "display-message" ]; then test -f "$TMUX_SESSION" || exit 1; printf \'4242\t$42\tgjc_lc_darwin-session\t4343\t0\t\n\'; exit 0; fi',
+				'if [ "$1" = "if-shell" ]; then',
+				'  if [[ "$*" == *"__gjc_lifecycle_cleanup_ok__"* ]]; then rm -f "$TMUX_SESSION"; printf "__gjc_lifecycle_cleanup_ok__\\n"; else printf "__gjc_lifecycle_metadata_ok__\\n"; fi',
+				"  exit 0",
+				"fi",
+				"exit 0",
+				"",
+			].join("\n"),
+		);
+		fs.chmodSync(tmux, 0o755);
+		try {
+			const result = await daemonSpawnCreate(
+				{
+					...process.env,
+					GJC_TMUX_COMMAND: tmux,
+					TMUX_CALLS: calls,
+					TMUX_SESSION: session,
+					GJC_TMUX_OWNER_GENERATION: "stale-generation",
+					GJC_TMUX_OWNER_STATE_DIR: "/stale/state",
+					GJC_TMUX_OWNER_SERVER_KEY: "stale-server",
+					GJC_MANAGED_OWNER_COMMAND_JSON: '["stale"]',
+					GJC_MANAGED_OWNER_RUN_ID: "stale-run",
+					GJC_MANAGED_OWNER_INCARNATION: "stale-incarnation",
+					GJC_MANAGED_OWNER_CHILD_TOKEN: "stale-child",
+					GJC_MANAGED_OWNER_PREDECESSOR_TOKEN: "stale-predecessor",
+					GJC_MANAGED_OWNER_PREDECESSOR_GENERATION: "stale-predecessor-generation",
+					GJC_MANAGED_OWNER_PREDECESSOR_RUN_ID: "stale-predecessor-run",
+					GJC_MANAGED_OWNER_PREDECESSOR_INCARNATION: "stale-predecessor-incarnation",
+					GJC_MANAGED_OWNER_TRANSCRIPT_PATH: "/stale/transcript",
+				},
+				{
+					platform: "darwin",
+					processIncarnation: pid => (pid === 4242 ? "darwin:server" : pid === 4343 ? "darwin:pane" : undefined),
+				},
+			)(createFrame({ target: { kind: "existing_path", path: root } }), {
+				lifecycleRequestId: "darwin-request",
+				intendedSessionId: "darwin-session",
+				startupPromptRef: "darwin-prompt",
+			});
+
+			expect(result.sessionId).toBe("darwin-session");
+			const recorded = fs.readFileSync(calls, "utf8");
+			expect(recorded).toContain("new-session -d -P -F #{session_id}");
+			expect(recorded).toContain("gjc_lc_darwin-session sh -c");
+			expect(recorded).toContain("display-message -p -t $42 #{pid}");
+			expect(recorded).toContain("if-shell -t $42 -F");
+			expect(recorded).toContain("GJC_SESSION_ID='darwin-session'");
+			expect(recorded).toContain("GJC_LIFECYCLE_REQUEST_ID='darwin-request'");
+			expect(recorded).toContain("GJC_COORDINATOR_SESSION_STATE_FILE=");
+			expect(recorded).toContain("GJC_STARTUP_PROMPT_REF='darwin-prompt'");
+			expect(recorded).toContain("@gjc-session-id");
+			expect(recorded).not.toContain("@gjc-owner-generation");
+			expect(recorded).not.toContain("@gjc-owner-server-key");
+			for (const name of [
+				"GJC_TMUX_OWNER_GENERATION",
+				"GJC_TMUX_OWNER_STATE_DIR",
+				"GJC_TMUX_OWNER_SERVER_KEY",
+				"GJC_MANAGED_OWNER_COMMAND_JSON",
+				"GJC_MANAGED_OWNER_RUN_ID",
+				"GJC_MANAGED_OWNER_INCARNATION",
+				"GJC_MANAGED_OWNER_CHILD_TOKEN",
+				"GJC_MANAGED_OWNER_PREDECESSOR_TOKEN",
+				"GJC_MANAGED_OWNER_PREDECESSOR_GENERATION",
+				"GJC_MANAGED_OWNER_PREDECESSOR_RUN_ID",
+				"GJC_MANAGED_OWNER_PREDECESSOR_INCARNATION",
+				"GJC_MANAGED_OWNER_TRANSCRIPT_PATH",
+			])
+				expect(recorded).toContain(`-u '${name}'`);
+			expect(recorded).not.toContain("--internal-managed-owner-supervisor");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+	posixTmuxIt("uses direct tagged tmux launch for injected non-Linux cold resumes", async () => {
+		const root = managedFixtureRoot("gjc-nonlinux-resume-");
+		const calls = path.join(root, "tmux-calls.log");
+		const session = path.join(root, "tmux-session");
+		const tmux = path.join(root, "fake-tmux.sh");
+		const retainedOwnerEvidence = path.join(
+			root,
+			".gjc",
+			"_session-darwin-resume",
+			"runtime",
+			"tmux-sessions",
+			"darwin-resume",
+			"owner-lifecycle",
+			"generation.json",
+		);
+		fs.mkdirSync(path.dirname(retainedOwnerEvidence), { recursive: true });
+		fs.writeFileSync(retainedOwnerEvidence, "{corrupt");
+		fs.writeFileSync(
+			tmux,
+			[
+				"#!/usr/bin/env bash",
+				'printf "%s\\n" "$*" >> "$TMUX_CALLS"',
+				'if [ "$1" = "new-session" ]; then : > "$TMUX_SESSION"; printf \'$42\\tgjc_lc_darwin-resume\\n\'; exit 0; fi',
+				'if [ "$1" = "display-message" ]; then test -f "$TMUX_SESSION" || exit 1; printf \'4242\t$42\tgjc_lc_darwin-resume\t4343\t0\t\n\'; exit 0; fi',
+				'if [ "$1" = "if-shell" ]; then',
+				'  if [[ "$*" == *"__gjc_lifecycle_cleanup_ok__"* ]]; then rm -f "$TMUX_SESSION"; printf "__gjc_lifecycle_cleanup_ok__\\n"; else printf "__gjc_lifecycle_metadata_ok__\\n"; fi',
+				"  exit 0",
+				"fi",
+				"exit 0",
+				"",
+			].join("\n"),
+		);
+		fs.chmodSync(tmux, 0o755);
+		try {
+			await writeManagedSession(root, root, "darwin-resume");
+			const result = await daemonResumeSession(
+				{
+					...process.env,
+					GJC_TMUX_COMMAND: tmux,
+					TMUX_CALLS: calls,
+					TMUX_SESSION: session,
+					GJC_TMUX_OWNER_GENERATION: "stale-generation",
+					GJC_TMUX_OWNER_STATE_DIR: "/stale/state",
+					GJC_TMUX_OWNER_SERVER_KEY: "stale-server",
+					GJC_MANAGED_OWNER_COMMAND_JSON: '["stale"]',
+					GJC_MANAGED_OWNER_RUN_ID: "stale-run",
+					GJC_MANAGED_OWNER_INCARNATION: "stale-incarnation",
+					GJC_MANAGED_OWNER_CHILD_TOKEN: "stale-child",
+					GJC_MANAGED_OWNER_PREDECESSOR_TOKEN: "stale-predecessor",
+					GJC_MANAGED_OWNER_PREDECESSOR_GENERATION: "stale-predecessor-generation",
+					GJC_MANAGED_OWNER_PREDECESSOR_RUN_ID: "stale-predecessor-run",
+					GJC_MANAGED_OWNER_PREDECESSOR_INCARNATION: "stale-predecessor-incarnation",
+					GJC_MANAGED_OWNER_TRANSCRIPT_PATH: "/stale/transcript",
+				},
+				{
+					platform: "darwin",
+					sessionsRoot: root,
+					listSessions: () => [],
+					processIncarnation: pid => (pid === 4242 ? "darwin:server" : pid === 4343 ? "darwin:pane" : undefined),
+				},
+			)({ sessionIdOrPrefix: "darwin-resume" });
+
+			expect("mode" in result && result.mode).toBe("cold_restarted");
+			const recorded = fs.readFileSync(calls, "utf8");
+			expect(recorded).toContain("display-message -p -t $42");
+			expect(recorded).toContain("if-shell -t $42 -F");
+			expect(recorded).toContain("GJC_COORDINATOR_SESSION_ID='darwin-resume'");
+			expect(recorded).toContain("gjc '--resume' 'darwin-resume'");
+			for (const name of [
+				"GJC_TMUX_OWNER_GENERATION",
+				"GJC_TMUX_OWNER_STATE_DIR",
+				"GJC_TMUX_OWNER_SERVER_KEY",
+				"GJC_MANAGED_OWNER_COMMAND_JSON",
+				"GJC_MANAGED_OWNER_RUN_ID",
+				"GJC_MANAGED_OWNER_INCARNATION",
+				"GJC_MANAGED_OWNER_CHILD_TOKEN",
+				"GJC_MANAGED_OWNER_PREDECESSOR_TOKEN",
+				"GJC_MANAGED_OWNER_PREDECESSOR_GENERATION",
+				"GJC_MANAGED_OWNER_PREDECESSOR_RUN_ID",
+				"GJC_MANAGED_OWNER_PREDECESSOR_INCARNATION",
+				"GJC_MANAGED_OWNER_TRANSCRIPT_PATH",
+			])
+				expect(recorded).toContain(`-u '${name}'`);
+			expect(recorded).not.toContain("--internal-managed-owner-supervisor");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+	posixTmuxIt(
+		"rejects an injected non-Linux create when its session disappears during launch stabilization",
+		async () => {
+			const root = managedFixtureRoot("gjc-nonlinux-launch-liveness-");
+			const calls = path.join(root, "tmux-calls.log");
+			const session = path.join(root, "tmux-session");
+			const tmux = path.join(root, "fake-tmux.sh");
+			fs.writeFileSync(
+				tmux,
+				[
+					"#!/usr/bin/env bash",
+					'printf "%s\\n" "$*" >> "$TMUX_CALLS"',
+					'if [ "$1" = "new-session" ]; then : > "$TMUX_SESSION"; printf \'$42\\tgjc_lc_launch-liveness\\n\'; exit 0; fi',
+					'if [ "$1" = "display-message" ]; then test -f "$TMUX_SESSION" || { echo "can\'t find session" >&2; exit 1; }; printf \'4242\t$42\tgjc_lc_launch-liveness\t4343\t0\t\n\'; exit 0; fi',
+					'if [ "$1" = "if-shell" ]; then',
+					'  if [[ "$*" == *"__gjc_lifecycle_cleanup_ok__"* ]]; then rm -f "$TMUX_SESSION"; printf "__gjc_lifecycle_cleanup_ok__\\n"; else (sleep 0.01; rm -f "$TMUX_SESSION") >/dev/null 2>&1 & printf "__gjc_lifecycle_metadata_ok__\\n"; fi',
+					"  exit 0",
+					"fi",
+					"exit 0",
+					"",
+				].join("\n"),
+			);
+			fs.chmodSync(tmux, 0o755);
+			try {
+				try {
+					await daemonSpawnCreate(
+						{ ...process.env, GJC_TMUX_COMMAND: tmux, TMUX_CALLS: calls, TMUX_SESSION: session },
+						{
+							platform: "darwin",
+							processIncarnation: pid =>
+								pid === 4242 ? "darwin:server" : pid === 4343 ? "darwin:pane" : undefined,
+						},
+					)(createFrame({ target: { kind: "existing_path", path: root } }), {
+						lifecycleRequestId: "launch-liveness-request",
+						intendedSessionId: "launch-liveness",
+					});
+					throw new Error("expected lifecycle launch liveness failure");
+				} catch (error) {
+					expect(error).toBeInstanceOf(AggregateError);
+					if (!(error instanceof AggregateError)) throw error;
+					expect(error.message).toBe("gjc_lifecycle_cleanup_uncertain");
+					expect(error.errors[0]).toMatchObject({ message: "gjc_lifecycle_tmux_launch_liveness_failed" });
+					expect(error.errors[1]).toMatchObject({ message: "gjc_lifecycle_cleanup_uncertain" });
+				}
+				expect(fs.existsSync(session)).toBe(false);
+				expect(fs.readFileSync(calls, "utf8")).toContain("if-shell -t $42 -F");
+			} finally {
+				fs.rmSync(root, { recursive: true, force: true });
+			}
+		},
+	);
+	posixTmuxIt("rejects an injected non-Linux create when immediate exit retains a dead pane", async () => {
+		const root = managedFixtureRoot("gjc-nonlinux-dead-pane-");
+		const session = path.join(root, "tmux-session");
+		const tmux = path.join(root, "fake-tmux.sh");
+		fs.writeFileSync(
+			tmux,
+			[
+				"#!/usr/bin/env bash",
+				'if [ "$1" = "new-session" ]; then : > "$TMUX_SESSION"; printf \'$42\\tgjc_lc_dead-pane\\n\'; exit 0; fi',
+				'if [ "$1" = "display-message" ]; then',
+				'  test -f "$TMUX_SESSION" || { echo "can\'t find session" >&2; exit 1; }',
+				"  printf '4242\\t$42\\tgjc_lc_dead-pane\\t4343\\t1\\t0\\n'",
+				"  exit 0",
+				"fi",
+				'if [ "$1" = "if-shell" ]; then',
+				'  if [[ "$*" == *"__gjc_lifecycle_cleanup_ok__"* ]]; then rm -f "$TMUX_SESSION"; printf "__gjc_lifecycle_cleanup_ok__\\n"; else printf "__gjc_lifecycle_metadata_ok__\\n"; fi',
+				"  exit 0",
+				"fi",
+				"exit 0",
+				"",
+			].join("\n"),
+		);
+		fs.chmodSync(tmux, 0o755);
+		try {
+			await expect(
+				daemonSpawnCreate(
+					{ ...process.env, GJC_TMUX_COMMAND: tmux, TMUX_SESSION: session },
+					{
+						platform: "darwin",
+						processIncarnation: pid =>
+							pid === 4242 ? "darwin:server" : pid === 4343 ? "darwin:pane" : undefined,
+					},
+				)(createFrame({ target: { kind: "existing_path", path: root } }), {
+					lifecycleRequestId: "dead-pane-request",
+					intendedSessionId: "dead-pane",
+				}),
+			).rejects.toThrow("gjc_lifecycle_tmux_launch_liveness_failed");
+			expect(fs.existsSync(session)).toBe(false);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+	posixTmuxIt("rejects an injected non-Linux create when its pane PID incarnation changes", async () => {
+		const root = managedFixtureRoot("gjc-nonlinux-pane-replacement-");
+		const session = path.join(root, "tmux-session");
+		const probes = path.join(root, "tmux-probes");
+		const tmux = path.join(root, "fake-tmux.sh");
+		fs.writeFileSync(
+			tmux,
+			[
+				"#!/usr/bin/env bash",
+				'if [ "$1" = "new-session" ]; then : > "$TMUX_SESSION"; printf \'$42\\tgjc_lc_pane-replacement\\n\'; exit 0; fi',
+				'if [ "$1" = "display-message" ]; then',
+				'  test -f "$TMUX_SESSION" || { echo "can\'t find session" >&2; exit 1; }',
+				'  count=$(cat "$TMUX_PROBES" 2>/dev/null || echo 0); count=$((count + 1)); printf "%s" "$count" > "$TMUX_PROBES"',
+				"  printf '4242\\t$42\\tgjc_lc_pane-replacement\\t4343\\t0\\t\\n'",
+				"  exit 0",
+				"fi",
+				'if [ "$1" = "if-shell" ]; then',
+				'  if [[ "$*" == *"__gjc_lifecycle_cleanup_ok__"* ]]; then rm -f "$TMUX_SESSION"; printf "__gjc_lifecycle_cleanup_ok__\\n"; else printf "__gjc_lifecycle_metadata_ok__\\n"; fi',
+				"  exit 0",
+				"fi",
+				"exit 0",
+				"",
+			].join("\n"),
+		);
+		fs.chmodSync(tmux, 0o755);
+		try {
+			await expect(
+				daemonSpawnCreate(
+					{ ...process.env, GJC_TMUX_COMMAND: tmux, TMUX_SESSION: session, TMUX_PROBES: probes },
+					{
+						platform: "darwin",
+						processIncarnation: pid =>
+							pid === 4242
+								? "darwin:server"
+								: pid === 4343
+									? Number(fs.readFileSync(probes, "utf8")) >= 5
+										? "darwin:pane:replacement"
+										: "darwin:pane"
+									: undefined,
+					},
+				)(createFrame({ target: { kind: "existing_path", path: root } }), {
+					lifecycleRequestId: "pane-replacement-request",
+					intendedSessionId: "pane-replacement",
+				}),
+			).rejects.toThrow("gjc_lifecycle_tmux_launch_liveness_failed");
+			expect(fs.existsSync(session)).toBe(false);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	posixTmuxIt("cleans up the exact injected non-Linux session when profile metadata fails", async () => {
+		const root = managedFixtureRoot("gjc-nonlinux-metadata-cleanup-");
+		const calls = path.join(root, "tmux-calls.log");
+		const session = path.join(root, "tmux-session");
+		const tmux = path.join(root, "fake-tmux.sh");
+		fs.writeFileSync(
+			tmux,
+			[
+				"#!/usr/bin/env bash",
+				'printf "%s\\n" "$*" >> "$TMUX_CALLS"',
+				'if [ "$1" = "new-session" ]; then : > "$TMUX_SESSION"; printf \'$42\\tgjc_lc_metadata-cleanup\\n\'; exit 0; fi',
+				'if [ "$1" = "display-message" ]; then test -f "$TMUX_SESSION" || { echo "can\'t find session" >&2; exit 1; }; printf \'4242\t$42\tgjc_lc_metadata-cleanup\t4343\t0\t\n\'; exit 0; fi',
+				'if [ "$1" = "if-shell" ]; then',
+				'  if [[ "$*" == *"__gjc_lifecycle_cleanup_ok__"* ]]; then rm -f "$TMUX_SESSION"; printf "__gjc_lifecycle_cleanup_ok__\\n"; else printf "__gjc_lifecycle_metadata_refused__\\n"; fi',
+				"  exit 0",
+				"fi",
+				"exit 0",
+				"",
+			].join("\n"),
+		);
+		fs.chmodSync(tmux, 0o755);
+		try {
+			await expect(
+				daemonSpawnCreate(
+					{ ...process.env, GJC_TMUX_COMMAND: tmux, TMUX_CALLS: calls, TMUX_SESSION: session },
+					{
+						platform: "darwin",
+						processIncarnation: pid =>
+							pid === 4242 ? "darwin:server" : pid === 4343 ? "darwin:pane" : undefined,
+					},
+				)(createFrame({ target: { kind: "existing_path", path: root } }), {
+					lifecycleRequestId: "metadata-cleanup-request",
+					intendedSessionId: "metadata-cleanup",
+				}),
+			).rejects.toThrow("gjc_lifecycle_metadata_write_failed");
+
+			expect(fs.existsSync(session)).toBe(false);
+			expect(fs.readFileSync(calls, "utf8")).toContain("if-shell -t $42 -F");
+			expect(fs.readFileSync(calls, "utf8")).toContain("kill-session -t '$42'");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+	posixTmuxIt("fails closed when the post-kill direct tmux probe is unverifiable", async () => {
+		const root = managedFixtureRoot("gjc-nonlinux-post-kill-probe-");
+		const session = path.join(root, "tmux-session");
+		const tmux = path.join(root, "fake-tmux.sh");
+		fs.writeFileSync(
+			tmux,
+			[
+				"#!/usr/bin/env bash",
+				'if [ "$1" = "new-session" ]; then : > "$TMUX_SESSION"; printf \'$42\\tgjc_lc_post-kill-probe\\n\'; exit 0; fi',
+				'if [ "$1" = "display-message" ]; then',
+				"  test -f \"$TMUX_SESSION\" && { printf '4242\t$42\tgjc_lc_post-kill-probe\t4343\t0\t\n'; exit 0; }",
+				'  echo "connection refused" >&2; exit 1',
+				"fi",
+				'if [ "$1" = "if-shell" ]; then',
+				'  if [[ "$*" == *"__gjc_lifecycle_cleanup_ok__"* ]]; then rm -f "$TMUX_SESSION"; printf "__gjc_lifecycle_cleanup_ok__\\n"; else printf "__gjc_lifecycle_metadata_refused__\\n"; fi',
+				"  exit 0",
+				"fi",
+				"exit 0",
+				"",
+			].join("\n"),
+		);
+		fs.chmodSync(tmux, 0o755);
+		try {
+			await expect(
+				daemonSpawnCreate(
+					{ ...process.env, GJC_TMUX_COMMAND: tmux, TMUX_SESSION: session },
+					{
+						platform: "darwin",
+						processIncarnation: pid =>
+							pid === 4242 ? "darwin:server" : pid === 4343 ? "darwin:pane" : undefined,
+					},
+				)(createFrame({ target: { kind: "existing_path", path: root } }), {
+					lifecycleRequestId: "post-kill-probe-request",
+					intendedSessionId: "post-kill-probe",
+				}),
+			).rejects.toThrow("gjc_lifecycle_cleanup_uncertain");
+			expect(fs.existsSync(session)).toBe(false);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+	posixTmuxIt("surfaces injected non-Linux profile cleanup failure", async () => {
+		const root = managedFixtureRoot("gjc-nonlinux-metadata-cleanup-failure-");
+		const calls = path.join(root, "tmux-calls.log");
+		const session = path.join(root, "tmux-session");
+		const tmux = path.join(root, "fake-tmux.sh");
+		fs.writeFileSync(
+			tmux,
+			[
+				"#!/usr/bin/env bash",
+				'printf "%s\\n" "$*" >> "$TMUX_CALLS"',
+				'if [ "$1" = "new-session" ]; then : > "$TMUX_SESSION"; printf \'$42\\tgjc_lc_metadata-cleanup-failure\\n\'; exit 0; fi',
+				'if [ "$1" = "display-message" ]; then test -f "$TMUX_SESSION" || exit 1; printf \'4242\t$42\tgjc_lc_metadata-cleanup-failure\t4343\t0\t\n\'; exit 0; fi',
+				'if [ "$1" = "if-shell" ]; then',
+				'  if [[ "$*" == *"__gjc_lifecycle_cleanup_ok__"* ]]; then printf "__gjc_lifecycle_cleanup_refused__\\n"; else printf "__gjc_lifecycle_metadata_refused__\\n"; fi',
+				"  exit 0",
+				"fi",
+				"exit 0",
+				"",
+			].join("\n"),
+		);
+		fs.chmodSync(tmux, 0o755);
+		try {
+			try {
+				await daemonSpawnCreate(
+					{ ...process.env, GJC_TMUX_COMMAND: tmux, TMUX_CALLS: calls, TMUX_SESSION: session },
+					{
+						platform: "darwin",
+						processIncarnation: pid =>
+							pid === 4242 ? "darwin:server" : pid === 4343 ? "darwin:pane" : undefined,
+					},
+				)(createFrame({ target: { kind: "existing_path", path: root } }), {
+					lifecycleRequestId: "metadata-cleanup-failure-request",
+					intendedSessionId: "metadata-cleanup-failure",
+				});
+				throw new Error("expected lifecycle metadata cleanup failure");
+			} catch (error) {
+				expect(error).toBeInstanceOf(AggregateError);
+				if (!(error instanceof AggregateError)) throw error;
+				expect(error.message).toBe("gjc_lifecycle_cleanup_uncertain");
+				expect(error.errors).toHaveLength(2);
+				expect(error.errors[0]).toMatchObject({ message: "gjc_lifecycle_metadata_write_failed" });
+				expect(error.errors[1]).toMatchObject({ message: "gjc_lifecycle_cleanup_uncertain" });
+			}
+
+			expect(fs.existsSync(session)).toBe(true);
+			expect(fs.readFileSync(calls, "utf8")).toContain("if-shell -t $42 -F");
+			expect(fs.readFileSync(calls, "utf8")).toContain("kill-session -t '$42'");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+	posixTmuxIt("rejects injected non-Linux lifecycle creates when tmux does not retain the new session", async () => {
+		const root = managedFixtureRoot("gjc-nonlinux-launch-failure-");
+		const tmux = path.join(root, "fake-tmux.sh");
+		fs.writeFileSync(
+			tmux,
+			[
+				"#!/usr/bin/env bash",
+				'if [ "$1" = "new-session" ]; then exit 0; fi',
+				'if [ "$1" = "has-session" ]; then exit 1; fi',
+				"exit 0",
+				"",
+			].join("\n"),
+		);
+		fs.chmodSync(tmux, 0o755);
+		try {
+			await expect(
+				daemonSpawnCreate(
+					{ ...process.env, GJC_TMUX_COMMAND: tmux },
+					{ platform: "darwin", processIncarnation: pid => (pid === 4242 ? "darwin:server" : undefined) },
+				)(createFrame({ target: { kind: "existing_path", path: root } }), {
+					lifecycleRequestId: "failed-request",
+					intendedSessionId: "failed-session",
+				}),
+			).rejects.toThrow("gjc_lifecycle_cleanup_uncertain");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -2896,11 +2896,11 @@ describe("telegram daemon", () => {
 			}),
 		);
 	}
-	test("keeps wire protocol 3 while generation 30 adds capability-versioned tool activity", () => {
+	test("keeps wire protocol 3 while generation 31 rolls out lifecycle cleanup", () => {
 		expect(NOTIFICATION_PROTOCOL_VERSION).toBe(3);
-		// Generation 29 adds structural serving safeguards; generation 30 adds
-		// capability-versioned tool activity without changing the wire protocol.
-		expect(DAEMON_GENERATION).toBe(30);
+		// Generation 30 adds capability-versioned tool activity; generation 31
+		// rolls out lifecycle cleanup without changing the wire protocol.
+		expect(DAEMON_GENERATION).toBe(31);
 	});
 	test.each([
 		"1",
@@ -19116,9 +19116,9 @@ test("Telegram Bot API 429 cooldown clamps malformed retry_after values and does
 // ---------------------------------------------------------------------------
 
 describe("PR #3186 blockers", () => {
-	test("serving epoch 3 replaces pre-policy (epoch 1 and 2) daemons via isCurrentCompatibleOwner", () => {
+	test("serving epoch 4 replaces pre-policy (epochs 1 through 3) daemons via isCurrentCompatibleOwner", () => {
 		// Epoch 1: legacy daemon states that never published servingEpoch.
-		expect(SERVING_EPOCH).toBe(3);
+		expect(SERVING_EPOCH).toBe(4);
 		const freshInput = (servingEpoch?: number) => {
 			const state: DaemonState = {
 				pid: 999,
@@ -19146,12 +19146,14 @@ describe("PR #3186 blockers", () => {
 		};
 		// Epoch undefined (epoch 1) — not compatible.
 		expect(isCurrentCompatibleOwner(freshInput(undefined))).toBe(false);
-		// Epoch 2 — not compatible with epoch 3.
+		// Epoch 2 — not compatible with epoch 4.
 		expect(isCurrentCompatibleOwner(freshInput(2))).toBe(false);
-		// Epoch 3 — compatible.
-		expect(isCurrentCompatibleOwner(freshInput(3))).toBe(true);
-		// Future epoch 4 — still compatible (>= check).
+		// Epoch 3 — not compatible with epoch 4.
+		expect(isCurrentCompatibleOwner(freshInput(3))).toBe(false);
+		// Epoch 4 — compatible.
 		expect(isCurrentCompatibleOwner(freshInput(4))).toBe(true);
+		// Future epoch 5 — still compatible (>= check).
+		expect(isCurrentCompatibleOwner(freshInput(5))).toBe(true);
 	});
 
 	test("visible v1 starts are terminated with terminalization on policy transition", async () => {

--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -474,7 +474,7 @@
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:ownerPidFromOwnerId": "46691373b2bee01f28f3817a6aa6a7efffe880c2cea337c89155582c98d952bf",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:runDaemonInternal": "5404789ec163fe21f899db7258780b5134962e91ac955e7061016d3b55f25058",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:runDaemonSmoke": "6f085a667aa5c83de46d2d8945fb845c355fcbb43c46872342a44489203a5830",
-    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:DAEMON_GENERATION": "9d09da087722f9557bb50f49007b7a3230a0f3df8d89bbad104b8373b9633a5c",
+    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:DAEMON_GENERATION": "2422f78e1f8ad409cf640ccd7aa8fd94a8f899549c5d974a901911bb69e23c89",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:NOTIFICATION_PROTOCOL_VERSION": "b99289f651fedcf020d28dbaf6f07dd37e7e4a5f6dc1f5118b872112325f1e81",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts:DaemonProcessReference": "c3d13e3670a6245a1250c4ebfcd80a36dd8fc96c67ab64d9f979182bd117bc4e",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts:TelegramDaemonController": "d92bf5e0aea850d62c415092a8d9024d3d3571e0f2b8855d7e3fb418ec59a59c",


### PR DESCRIPTION
## What

- Keep the durable managed-owner supervisor and owner-isolation transaction Linux-only.
- Launch Telegram lifecycle create and cold resume directly through tmux on non-Linux hosts without reading Linux `/proc` start-time evidence.
- Fence non-Linux profile writes, launch acknowledgement, and cleanup to the exact tmux server, native session, live pane PID, and canonical process incarnations.
- Scrub inherited managed-owner authority and reject children that die or are replaced during launch stabilization.
- Advance the Telegram daemon generation to 31 and serving epoch to 4 while keeping notification protocol 3.

## Root cause

The shared lifecycle launcher routed macOS through the Linux managed-owner supervisor introduced by `3def7504`. The supervisor requires `readLinuxProcStartTime`, so macOS launches failed with `managed_owner_supervisor_start_time_unavailable` after Telegram had allocated a lifecycle session ID.

## Verification

Passed on macOS arm64 against upstream `dev` at `a5656354`:

- `bun test packages/coding-agent/test/notifications-lifecycle-control-runtime.test.ts packages/coding-agent/test/notifications-lifecycle-orchestrator.test.ts packages/coding-agent/test/notifications-lifecycle-commands.test.ts` — 107 passed
- focused coordinator-only managed-owner admission regression — passed
- focused daemon generation/serving epoch regressions — passed
- `bun scripts/telegram-daemon-generation-guard.ts --validate-current-tree`
- `bun test scripts/telegram-daemon-generation-guard.test.ts` — 41 passed
- isolated real tmux 3.7b QA: live child accepted with GJC metadata; all managed-owner variables scrubbed; immediate and 50 ms exits rejected; no temporary session/socket residue
- `git diff --check`

## Draft blockers outside this diff

Current clean upstream `dev` is not root-check green:

- `packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts` has an unchanged formatter violation introduced upstream.
- `verify-gjc-sdk-canonicalization.ts` rejects six unchanged sanctioned `team-runtime.ts` psmux fallback sites; the same result reproduces in a clean detached upstream worktree.

This draft does not alter either unrelated surface. Re-run the complete root check after the upstream baseline is repaired before marking ready.

## Coordination

PR #3271 also uses Telegram daemon generation 31. If it merges first, rebase this branch, allocate the next generation, refresh the semantic manifest, and rerun the generation guard before marking ready.
