### PR TITLE
fix(ultragoal): repair final-aggregate receipts minted without criticReview OKAY

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ultragoal-receipt-freshness.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-receipt-freshness.ts
@@ -290,6 +290,26 @@ export function findLedgerReceiptEvent(
 		}) ?? null
 	);
 }
+/**
+ * A final-aggregate receipt whose recorded ledger checkpoint quality gate is
+ * missing a clean `criticReview` OKAY can never satisfy the completion guard,
+ * yet is not "stale" under {@link validateReceiptFreshBase}. Detect it so an
+ * identical-evidence complete replay can re-verify and re-mint with a
+ * corrected gate instead of no-opping into a permanently blocked run.
+ */
+export function finalAggregateReceiptMissingCriticOkay(
+	ledger: readonly UltragoalLedgerEvent[],
+	receipt: UltragoalCompletionVerification,
+): boolean {
+	if (receipt.receiptKind !== "final-aggregate") return false;
+	const event = findLedgerReceiptEvent(ledger, receipt);
+	if (!event) return false;
+	const gate = event.qualityGateJson;
+	if (typeof gate !== "object" || gate === null || Array.isArray(gate)) return true;
+	const criticReview = (gate as Record<string, unknown>).criticReview;
+	if (typeof criticReview !== "object" || criticReview === null || Array.isArray(criticReview)) return true;
+	return (criticReview as Record<string, unknown>).verdict !== "OKAY";
+}
 
 export function validateReceiptFreshBase(input: {
 	plan: UltragoalPlan;

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -19,6 +19,7 @@ import {
 	computeCriticVerdictPlanGeneration,
 	computeUltragoalPlanGeneration,
 	countNonOkayTerminalCriticVerdicts,
+	finalAggregateReceiptMissingCriticOkay,
 	findFreshBatchCloseReceipt,
 	findLedgerReceiptEvent,
 	isCleanPauseCriticVerdictShape,
@@ -3091,8 +3092,13 @@ export async function checkpointUltragoalGoal(input: {
 	// receipt, the replay is a genuine re-verification: it must run the full
 	// quality gate and mint a fresh receipt, otherwise a completed goal with a
 	// context-staled receipt can never be repaired (different evidence is
-	// rejected on complete goals by design). A mutated goal row keeps the
-	// fail-loud tamper handling in the idempotent branch below.
+	// rejected on complete goals by design). A final-aggregate receipt whose
+	// recorded checkpoint gate lacks a clean criticReview OKAY is likewise
+	// repair-eligible: it is not "stale", but the completion guard rejects it
+	// forever (active_missing_critic_verdict), so a no-op replay would leave
+	// the run permanently unable to complete even after the terminal critic
+	// records OKAY. A mutated goal row keeps the fail-loud tamper handling in
+	// the idempotent branch below.
 	const staleCompleteReceiptReplay =
 		input.status === "complete" &&
 		goal.status === "complete" &&
@@ -3100,13 +3106,14 @@ export async function checkpointUltragoalGoal(input: {
 		Boolean(matchingIdempotentEvent) &&
 		(!goal.completionVerification ||
 			(goal.completionVerification.verifiedAt === goal.updatedAt &&
-				validateReceiptFreshBase({
+				(validateReceiptFreshBase({
 					plan,
 					ledger: ledgerBefore,
 					goal,
 					receipt: goal.completionVerification,
 					receiptKind: goal.completionVerification.receiptKind,
-				}) !== null));
+				}) !== null ||
+					finalAggregateReceiptMissingCriticOkay(ledgerBefore, goal.completionVerification))));
 	if (
 		goal.status === input.status &&
 		goal.evidence === evidence &&

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -3235,6 +3235,80 @@ describe("native GJC ultragoal runtime", () => {
 		).rejects.toThrow("changed after its completion receipt was verified");
 	});
 
+	it("re-mints on identical-evidence replay when the recorded final-aggregate gate lacks criticReview OKAY (#3365)", async () => {
+		const root = await tempDir();
+		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });
+		await startNextUltragoalGoal({ cwd: root });
+		await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "first goal verified",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+
+		// Simulate a legacy final-aggregate checkpoint minted before criticReview
+		// was required: strip criticReview from the recorded ledger gate and keep
+		// the receipt hashes internally consistent so the receipt is NOT stale —
+		// only the completion guard's criticReview check rejects it.
+		const goalsPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "goals.json");
+		const ledgerPath = path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "ledger.jsonl");
+		const saved = JSON.parse(await Bun.file(goalsPath).text());
+		const receipt = saved.goals[0].completionVerification;
+		let strippedHash = "";
+		const rewritten = (await Bun.file(ledgerPath).text())
+			.split("\n")
+			.filter(line => line.trim())
+			.map(line => {
+				const event = JSON.parse(line);
+				if (event.eventId === receipt.checkpointLedgerEventId) {
+					delete event.qualityGateJson.criticReview;
+					strippedHash = hashStructuredValue(event.qualityGateJson);
+					event.completionVerification.qualityGateHash = strippedHash;
+				}
+				return JSON.stringify(event);
+			});
+		await fs.writeFile(ledgerPath, `${rewritten.join("\n")}\n`);
+		receipt.qualityGateHash = strippedHash;
+		await fs.writeFile(goalsPath, `${JSON.stringify(saved, null, 2)}\n`);
+
+		// The receipt is fresh but the guard rejects it: without repair the run
+		// loops forever (the receipt validator reports active_missing_critic_verdict
+		// and the durable wrapper surfaces a non-complete state).
+		const brokenPlan = (await readUltragoalPlan(root))!;
+		const brokenLedger = await readUltragoalLedger(root);
+		expect(
+			validateCompletionReceipt({
+				plan: brokenPlan,
+				ledger: brokenLedger,
+				goal: brokenPlan.goals[0]!,
+				receiptKind: "final-aggregate",
+			}).state,
+		).toBe("active_missing_critic_verdict");
+		const blocked = await verifyUltragoalDurableCompletionState({ cwd: root, sessionId: TEST_SESSION_ID });
+		expect(blocked.state).not.toBe("active_verified_complete");
+		const checkpointsBefore = (await readUltragoalLedger(root)).filter(
+			event => event.event === "goal_checkpointed",
+		).length;
+
+		// The identical-evidence replay with a corrected gate (criticReview OKAY)
+		// must re-verify and re-mint instead of no-opping on the broken receipt.
+		const replayed = await checkpointUltragoalGoal({
+			cwd: root,
+			goalId: "G001",
+			status: "complete",
+			evidence: "first goal verified",
+			qualityGateJson: await passingLiveQualityGate(root),
+		});
+		expect(replayed.goals[0]?.completionVerification?.receiptKind).toBe("final-aggregate");
+		expect(replayed.goals[0]?.completionVerification?.receiptId).not.toBe(receipt.receiptId);
+		expect((await readUltragoalLedger(root)).filter(event => event.event === "goal_checkpointed")).toHaveLength(
+			checkpointsBefore + 1,
+		);
+		const durable = await verifyUltragoalDurableCompletionState({ cwd: root, sessionId: TEST_SESSION_ID });
+		expect(durable.state).toBe("active_verified_complete");
+	});
+
 	it("rejects a superseded final-aggregate receipt whose forged basis is mirrored onto the ledger event generation", async () => {
 		const root = await tempDir();
 		await createUltragoalPlan({ cwd: root, brief: "Ship the fix" });


### PR DESCRIPTION
## Problem

Observed live (session `019fa2eb`, contribution-prep `2026-07-28T03-00-10-602Z`): an ultragoal run kept looping on try-harder nudges when calling `goal({"op":"complete"})` **even after the terminal critic recorded a legitimate OKAY**.

Root cause chain:

1. The final-aggregate checkpoint (G006) was minted with a quality gate that had **no `criticReview`** (it landed before the critic's OKAY existed).
2. The completion guard (`validateCompletionReceipt`) only trusts the gate embedded in the recorded checkpoint ledger event and returns `active_missing_critic_verdict` forever — it never consults the separately recorded `critic_verdict OKAY` ledger event.
3. Both repair paths were dead ends:
   - **New evidence** → rejected: "Cannot checkpoint … with different evidence because its durable goals.json status is already complete" (by design).
   - **Identical evidence + corrected gate** → the idempotent-dedupe branch matched on `(goalId, status, evidence)` and **no-opped**, because a missing `criticReview` is a validation failure but not a *staleness* condition, so the `staleCompleteReceiptReplay` escape hatch never fired. The corrected gate was silently discarded while the CLI printed "All ultragoal goals are complete."
4. Result: durable state looked done, but `assertCanCompleteCurrentGoal` refused forever → infinite nudge loop.

## Fix

- **`ultragoal-receipt-freshness.ts`**: new `finalAggregateReceiptMissingCriticOkay(ledger, receipt)` — detects a final-aggregate receipt whose recorded ledger checkpoint gate lacks a clean `criticReview.verdict === "OKAY"`.
- **`ultragoal-runtime.ts`**: `checkpointUltragoalGoal`'s `staleCompleteReceiptReplay` eligibility now also fires for such receipts, so an identical-evidence replay re-runs the **full strict quality gate** (which requires `criticReview` OKAY at mint time) and re-mints a fresh, verifiable final-aggregate receipt.

Deliberately narrow:
- Validation is never weakened — only *replay eligibility* is widened; the corrected gate still passes every strict check before minting.
- The fail-loud tamper branch for mutated goal rows is untouched (mutated `updatedAt` still throws).
- Non-final / per-goal / deferred-member receipts are unaffected (predicate returns `false`).

## Tests

- New regression test: strips `criticReview` from a recorded ledger gate (keeping receipt hashes consistent so it is *not* stale), asserts the guard reports `active_missing_critic_verdict`, then proves the identical-evidence replay with a corrected gate re-mints and the durable state verifies `active_verified_complete`.
- `bun test` on the 5 ultragoal-related suites (runtime, nudge-guard, pause-guard-redteam, goal-tool, ask-guard): **198 pass / 0 fail** — including the existing forged-basis red-team and mutated-row tamper tests.
- `tsc --noEmit` and `biome check` clean.

## Red-team notes

- Forged-basis mirror attack: still rejected (predicate only widens replay eligibility, never receipt validation).
- Replay with a still-uncorrected gate: rejected by `readRequiredCompletionQualityGate` (final-aggregate requires `criticReview` OKAY), no receipt minted, durable state unchanged.
- Mutated goal row + identical evidence: still fails loud.