### PR TITLE
test(ultragoal): resolve the nudge-budget user setting under home

### DIFF
--- a/packages/coding-agent/test/gjc-runtime/ultragoal-nudge-guard.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-nudge-guard.test.ts
@@ -314,20 +314,42 @@ describe("ultragoal nudge guard", () => {
 	});
 
 	// AC4: default budget is 10 and a project setting takes precedence over the user setting.
+	//
+	// The user-settings half runs in a child process. `GJC_CONFIG_DIR` is a config
+	// root *dirname under home* (PR #3327), not a full path, and `getConfigRootDir()`
+	// joins it onto `os.homedir()` — which an in-process test cannot redirect. Setting
+	// it to an absolute path here silently resolved nothing and the assertion only
+	// passed while the reader still treated the value as a full path.
 	it("AC4: nudge budget default is 10 and project overrides user", async () => {
 		const cwd = await tempDir();
 		const defaultResolved = await resolveUltragoalNudgeBudget(cwd);
 		expect(defaultResolved.budget).toBe(10);
-		const userDir = await tempDir();
-		await fs.mkdir(path.join(userDir, ".gjc"), { recursive: true });
-		await fs.writeFile(
-			path.join(userDir, ".gjc", "settings.json"),
-			JSON.stringify({ "gjc.ultragoal.nudgeBudget": 3 }),
-		);
-		process.env.GJC_CONFIG_DIR = path.join(userDir, ".gjc");
-		expect((await resolveUltragoalNudgeBudget(cwd)).budget).toBe(3);
+
+		const home = await tempDir();
+		await fs.mkdir(path.join(home, ".gjc"), { recursive: true });
+		await fs.writeFile(path.join(home, ".gjc", "settings.json"), JSON.stringify({ "gjc.ultragoal.nudgeBudget": 3 }));
+		const probe = path.join(import.meta.dir, "..", "fixtures", "config-root-settings-probe.ts");
+		const userOnly = Bun.spawn([process.execPath, probe], {
+			cwd,
+			env: { ...process.env, HOME: home, GJC_CONFIG_DIR: ".gjc" },
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const userOut = await new Response(userOnly.stdout).text();
+		expect(await userOnly.exited).toBe(0);
+		expect(JSON.parse(userOut.trim()).ultragoal.budget).toBe(3);
+
+		// A project setting still wins over that user setting.
 		await setProjectBudget(cwd, 7);
-		expect((await resolveUltragoalNudgeBudget(cwd)).budget).toBe(7);
+		const projectWins = Bun.spawn([process.execPath, probe], {
+			cwd,
+			env: { ...process.env, HOME: home, GJC_CONFIG_DIR: ".gjc" },
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const projectOut = await new Response(projectWins.stdout).text();
+		expect(await projectWins.exited).toBe(0);
+		expect(JSON.parse(projectOut.trim()).ultragoal.budget).toBe(7);
 	});
 
 	// AC4: budget 0 is an opt-out — the writer never appends and reports exhausted.


### PR DESCRIPTION
## Current-dev repair

`test:@gajae-code/coding-agent:shard-4-of-8` is failing on dev at `ultragoal-nudge-guard.test.ts:328` — expected a user nudge budget of `3`, received the default `10`. Reproduces deterministically in isolation on clean `origin/dev`.

## Root cause

PR **#3327** (`083527632`, "resolve workflow settings under the config root") correctly changed `resolveUltragoalNudgeBudget` to read `path.join(getConfigRootDir(), "settings.json")`. `GJC_CONFIG_DIR` is documented as a config-root **dirname under home**, and `getConfigRootDir()` joins it onto `os.homedir()`.

This test still assigned it an **absolute path**, which only worked while the reader treated the value as a full path.

| Commit | Result |
|---|---|
| `083527632^` (`8d09ffc0d`) | 17 pass / 0 fail |
| `083527632` (#3327) | 16 pass / **1 fail** |

The production change is right and the test was stale, so the test moves to the documented contract rather than the reader reverting to full paths.

## Fix

The user-settings half now runs in a child process with `HOME` pointed at a temp home and `GJC_CONFIG_DIR=.gjc`, reusing the `config-root-settings-probe.ts` fixture **#3327 already added for exactly this reason** — the value is read at module load, so an in-process test cannot redirect it.

No assertion was weakened. The test still pins all three cases: default `10`, user `3`, project `7`. The project-overrides-user half is preserved and now asserts through the same probe.

## Verification

- `ultragoal-nudge-guard.test.ts`: 1 fail → **17 pass / 0 fail**, 3 consecutive runs
- `config-root-home-relative.test.ts` + `ultragoal-runtime.test.ts`: **146 pass / 0 fail**
- `tsc -p tsconfig.tools.json --noEmit`: clean
- biome: clean on the changed file

Scope is one file, tests only. Dev's other current failures (`test:@gajae-code/stats`, and the `check:@gajae-code/coding-agent` Biome defect in `ralplan-runtime.ts` from #3364) are separate and left to their owners.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*