### PR TITLE
fix(ci): restore dev formatting and stats isolation

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -995,7 +995,8 @@ function persistedRoleStatePayload(update: PersistedRoleStateUpdate): Record<str
 	}
 	if (update.resumable !== undefined) payload[`${prefix}_resumable`] = update.resumable;
 	if (update.fallbackReason !== undefined) payload[`${prefix}_fallback_reason`] = update.fallbackReason;
-	if (update.fallbackAttemptedId !== undefined) payload[`${prefix}_fallback_attempted_id`] = update.fallbackAttemptedId;
+	if (update.fallbackAttemptedId !== undefined)
+		payload[`${prefix}_fallback_attempted_id`] = update.fallbackAttemptedId;
 	if (update.fallbackStageN !== undefined) payload[`${prefix}_fallback_stage_n`] = update.fallbackStageN;
 	if (update.fallbackReceiptPath !== undefined) {
 		payload[`${prefix}_fallback_receipt_path`] = update.fallbackReceiptPath;

--- a/packages/stats/test/behavior-backfill.test.ts
+++ b/packages/stats/test/behavior-backfill.test.ts
@@ -7,25 +7,31 @@ import { getAgentDir, getStatsDbPath, setAgentDir, TempDir } from "@gajae-code/u
 import { syncAllSessions } from "../src/aggregator";
 import { closeDb, getBehaviorOverall, getFileOffset, initDb } from "../src/db";
 
-const originalConfigDir = process.env.PI_CONFIG_DIR;
+const originalConfigDir = process.env.GJC_CONFIG_DIR;
+const originalAgentDirEnv = process.env.GJC_CODING_AGENT_DIR;
 const originalAgentDir = getAgentDir();
 let tempDir: TempDir | null = null;
 
 beforeEach(() => {
-	tempDir = TempDir.createSync("@pi-stats-behavior-backfill-");
-	const configDir = path.relative(os.homedir(), tempDir.join("config"));
-	process.env.PI_CONFIG_DIR = configDir;
-	setAgentDir(path.join(os.homedir(), configDir, "agent"));
+	tempDir = TempDir.createSync(path.join(os.homedir(), ".pi-stats-behavior-backfill-"));
+	const configDir = path.relative(os.homedir(), tempDir.path());
+	process.env.GJC_CONFIG_DIR = configDir;
+	setAgentDir(tempDir.join("test-agent"));
 });
 
 afterEach(() => {
 	closeDb();
 	if (originalConfigDir === undefined) {
-		delete process.env.PI_CONFIG_DIR;
+		delete process.env.GJC_CONFIG_DIR;
 	} else {
-		process.env.PI_CONFIG_DIR = originalConfigDir;
+		process.env.GJC_CONFIG_DIR = originalConfigDir;
 	}
 	setAgentDir(originalAgentDir);
+	if (originalAgentDirEnv === undefined) {
+		delete process.env.GJC_CODING_AGENT_DIR;
+	} else {
+		process.env.GJC_CODING_AGENT_DIR = originalAgentDirEnv;
+	}
 	tempDir?.removeSync();
 	tempDir = null;
 });

--- a/packages/stats/test/db-cost.test.ts
+++ b/packages/stats/test/db-cost.test.ts
@@ -7,25 +7,31 @@ import { getAgentDir, getStatsDbPath, setAgentDir, TempDir } from "@gajae-code/u
 import { closeDb, getRecentRequests, initDb, insertMessageStats } from "../src/db";
 import type { MessageStats } from "../src/types";
 
-const originalConfigDir = process.env.PI_CONFIG_DIR;
+const originalConfigDir = process.env.GJC_CONFIG_DIR;
+const originalAgentDirEnv = process.env.GJC_CODING_AGENT_DIR;
 const originalAgentDir = getAgentDir();
 let tempDir: TempDir | null = null;
 
 beforeEach(() => {
-	tempDir = TempDir.createSync("@pi-stats-db-");
-	const configDir = path.relative(os.homedir(), tempDir.join("config"));
-	process.env.PI_CONFIG_DIR = configDir;
-	setAgentDir(path.join(os.homedir(), configDir, "agent"));
+	tempDir = TempDir.createSync(path.join(os.homedir(), ".pi-stats-db-"));
+	const configDir = path.relative(os.homedir(), tempDir.path());
+	process.env.GJC_CONFIG_DIR = configDir;
+	setAgentDir(tempDir.join("test-agent"));
 });
 
 afterEach(() => {
 	closeDb();
 	if (originalConfigDir === undefined) {
-		delete process.env.PI_CONFIG_DIR;
+		delete process.env.GJC_CONFIG_DIR;
 	} else {
-		process.env.PI_CONFIG_DIR = originalConfigDir;
+		process.env.GJC_CONFIG_DIR = originalConfigDir;
 	}
 	setAgentDir(originalAgentDir);
+	if (originalAgentDirEnv === undefined) {
+		delete process.env.GJC_CODING_AGENT_DIR;
+	} else {
+		process.env.GJC_CODING_AGENT_DIR = originalAgentDirEnv;
+	}
 	tempDir?.removeSync();
 	tempDir = null;
 });

--- a/packages/stats/test/db-range.test.ts
+++ b/packages/stats/test/db-range.test.ts
@@ -6,25 +6,31 @@ import { getDashboardStats } from "../src/aggregator";
 import { closeDb, initDb, insertMessageStats } from "../src/db";
 import type { MessageStats } from "../src/types";
 
-const originalConfigDir = process.env.PI_CONFIG_DIR;
+const originalConfigDir = process.env.GJC_CONFIG_DIR;
+const originalAgentDirEnv = process.env.GJC_CODING_AGENT_DIR;
 const originalAgentDir = getAgentDir();
 let tempDir: TempDir | null = null;
 
 beforeEach(() => {
-	tempDir = TempDir.createSync("@pi-stats-db-range-");
-	const configDir = path.relative(os.homedir(), tempDir.join("config"));
-	process.env.PI_CONFIG_DIR = configDir;
-	setAgentDir(path.join(os.homedir(), configDir, "agent"));
+	tempDir = TempDir.createSync(path.join(os.homedir(), ".pi-stats-db-range-"));
+	const configDir = path.relative(os.homedir(), tempDir.path());
+	process.env.GJC_CONFIG_DIR = configDir;
+	setAgentDir(tempDir.join("test-agent"));
 });
 
 afterEach(() => {
 	closeDb();
 	if (originalConfigDir === undefined) {
-		delete process.env.PI_CONFIG_DIR;
+		delete process.env.GJC_CONFIG_DIR;
 	} else {
-		process.env.PI_CONFIG_DIR = originalConfigDir;
+		process.env.GJC_CONFIG_DIR = originalConfigDir;
 	}
 	setAgentDir(originalAgentDir);
+	if (originalAgentDirEnv === undefined) {
+		delete process.env.GJC_CODING_AGENT_DIR;
+	} else {
+		process.env.GJC_CODING_AGENT_DIR = originalAgentDirEnv;
+	}
 	tempDir?.removeSync();
 	tempDir = null;
 });

--- a/packages/stats/test/priority-premium-requests.test.ts
+++ b/packages/stats/test/priority-premium-requests.test.ts
@@ -8,25 +8,31 @@ import { syncAllSessions } from "../src/aggregator";
 import { closeDb, getOverallStats, getRecentRequests } from "../src/db";
 import { parseSessionFile } from "../src/parser";
 
-const originalConfigDir = process.env.PI_CONFIG_DIR;
+const originalConfigDir = process.env.GJC_CONFIG_DIR;
+const originalAgentDirEnv = process.env.GJC_CODING_AGENT_DIR;
 const originalAgentDir = getAgentDir();
 let tempDir: TempDir | null = null;
 
 beforeEach(() => {
-	tempDir = TempDir.createSync("@pi-stats-priority-");
-	const configDir = path.relative(os.homedir(), tempDir.join("config"));
-	process.env.PI_CONFIG_DIR = configDir;
-	setAgentDir(path.join(os.homedir(), configDir, "agent"));
+	tempDir = TempDir.createSync(path.join(os.homedir(), ".pi-stats-priority-"));
+	const configDir = path.relative(os.homedir(), tempDir.path());
+	process.env.GJC_CONFIG_DIR = configDir;
+	setAgentDir(tempDir.join("test-agent"));
 });
 
 afterEach(() => {
 	closeDb();
 	if (originalConfigDir === undefined) {
-		delete process.env.PI_CONFIG_DIR;
+		delete process.env.GJC_CONFIG_DIR;
 	} else {
-		process.env.PI_CONFIG_DIR = originalConfigDir;
+		process.env.GJC_CONFIG_DIR = originalConfigDir;
 	}
 	setAgentDir(originalAgentDir);
+	if (originalAgentDirEnv === undefined) {
+		delete process.env.GJC_CODING_AGENT_DIR;
+	} else {
+		process.env.GJC_CODING_AGENT_DIR = originalAgentDirEnv;
+	}
 	tempDir?.removeSync();
 	tempDir = null;
 });


### PR DESCRIPTION
## Summary
- apply the exact two-line Biome formatting output for `ralplan-runtime.ts`
- keep stats product code unchanged, but repair four stats test fixtures that latest `dev` proved were resolving `PI_CONFIG_DIR` with rejected `..` segments and falling back to the real `~/.gjc/stats.db`
- use canonical, home-relative `GJC_CONFIG_DIR` test roots so the full stats suite is deterministic and cannot read persistent user counts

## Evidence
- pristine latest-`dev` stats run after the native prerequisite reproduced persistent-data contamination: expected `2`/`4`, received `410803`/`410811`, plus duplicated behavior counts
- `bun --cwd=packages/stats test`: 42 pass, 0 fail, 164 assertions after isolation repair
- the earlier duplicate-count failures are therefore prior-head/test-isolation contamination, not a stats product defect; no stats runtime code changed

## Verification
- `bun run check:tools`
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/stats run check`
- `bun --cwd=packages/stats test`
- `bun run build`

Closes #3371

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*