### PR TITLE
fix(coding-agent): stop /btw from claiming invisible tools

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -37,6 +37,10 @@
 - Ralplan now bounds architect and critic re-review lanes independently through `gjc.ralplan.maxReviewPassesPerLane` (integer 1–10; default 1). Per-lane budget exhaustion emits a lane-specific `PLANNING-STUCK` exit 3, fails closed against on-disk artifact floors, and repairs crash-gap retries. Architect and critic `gjc ralplan --write` calls can optionally pass `--lane-verdict`, which drives HUD lane pass counts and the latest verdict; critic/architect prompts and the ralplan SKILL workflow now ratchet re-reviews through persisted receipts.
 - Ralplan consensus review lanes now persist same-session Architect and Critic subagent metadata (`--architect-id` / `--architect-resumable`, `--critic-id` / `--critic-resumable`) and resume those reviewers by default on pass 2+ with the mandatory re-review context bundle. Unavailable reviewer context falls back to a fresh lane spawn with role-scoped fallback metadata, preserving the existing sequential re-review cadence and receipt-only contract.
 
+### Fixed
+
+- `/btw` now explicitly refuses to claim invisible tool activity such as web searches, workflow gates, commands, or file reads. When a side-chat answer requires an unavailable action, it directs the user back to the main chat instead of implying the action ran.
+
 ## [0.11.11] - 2026-07-26
 
 ### Added

--- a/packages/coding-agent/src/prompts/system/btw-user.md
+++ b/packages/coding-agent/src/prompts/system/btw-user.md
@@ -1,3 +1,5 @@
 You are answering inside an ephemeral multi-turn side chat for the interactive session.
 Use only the sanitized visible-text conversation scope and prior side-chat turns provided as messages.
-Answer directly. Do not use tools or request hidden session state.
+Answer directly. Tools are unavailable in this side chat; do not use tools or request hidden session state.
+Never claim to browse or search the web, open a gate, run a command, read a file, or perform any other external action.
+If the answer requires an unavailable action, say that it cannot be done in /btw and tell the user to press Esc and ask in the main chat.

--- a/packages/coding-agent/test/modes/controllers/btw-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/btw-controller.test.ts
@@ -112,7 +112,11 @@ describe("BtwController", () => {
 		await Promise.resolve();
 
 		expect(dispatchedQuestion).toBe(sentinel);
-		expect(instructionFactory.mock.calls[0]?.[0]).not.toContain("PRIVATE_OVERRIDE");
+		const instruction = instructionFactory.mock.calls[0]?.[0];
+		expect(instruction).not.toContain("PRIVATE_OVERRIDE");
+		expect(instruction).toContain("Tools are unavailable in this side chat");
+		expect(instruction).toContain("Never claim to browse or search the web, open a gate");
+		expect(instruction).toContain("press Esc and ask in the main chat");
 	});
 
 	it("accepts an exact UTF-8 question limit and rejects one byte over", async () => {


### PR DESCRIPTION
## What

- make the `/btw` system instruction state that tools are unavailable
- forbid claims of invisible web searches, workflow gates, commands, or file reads
- redirect tool-dependent requests to the main chat
- lock the behavior with a prompt-contract regression and changelog entry

## Why

`/btw` already dispatches with `tools: []` and `toolChoice: none` to preserve its isolated, non-persistent privacy boundary. A model could still narrate that it searched the web or opened a gate, but no tool event existed for the TUI to render. Enabling tools would weaken the reviewed isolation contract, so this change makes the model report the limitation instead of implying that an action ran.

## Testing

- `bun test test/modes/controllers/btw-controller.test.ts test/agent-session-btw.test.ts test/agent-session-ephemeral-context.test.ts` (27 pass)
- `bun run check:types` (pass)
- `bunx biome check test/modes/controllers/btw-controller.test.ts` (pass)
- `git diff --check origin/dev...HEAD` (pass)
- `bun run check` reaches an unrelated pre-existing formatter failure in `src/gjc-runtime/ralplan-runtime.ts`; this branch matches `origin/dev` for that file

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:5d377595de53610e1d4b4f6470e88db7aed68b2dc2a12627e00d6946cafeec08 reviewer:human evidence:local-focused-tests-and-types
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (blocked by unchanged `origin/dev` formatter failure noted above)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR-head diff