### PR TITLE
fix(deep-interview): close final contract gaps

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -787,6 +787,37 @@ Skipping any stage is possible but reduces quality assurance:
   /triggers/N/status: enum(active|disputed|unresolved) required
 ```
 <!-- END GENERATED: deep-interview-draft-schemas -->
+
+<!-- BEGIN GENERATED: deep-interview-state-invariants (scripts/verify-deep-interview-docs.ts) -->
+### Stable state-invariant identifiers
+
+| Invariant | Description |
+| --- | --- |
+| `round_lifecycle_must_be_known` | Target round lifecycle must be answered, pending_scoring, or scored. |
+| `round_question_id_required` | Target round must carry a non-empty question_id. |
+| `state_type_must_be_interview_type` | state.type must be greenfield or brownfield. |
+| `global_scores_must_be_valid_scores` | Every required dimension in global_scores must be a number in [0,1]. |
+| `rounds_must_be_scored_in_order` | All earlier non-round-0 rounds must be scored before this round. |
+| `active_components_must_have_scores` | Every active topology component must have scores for all required dimensions. |
+| `global_scores_must_equal_component_min` | global_scores[d] must equal the minimum of that dimension across active component scores. |
+| `fact_op_id_required` | Every fact operation must carry a non-empty string id. |
+| `fact_add_requires_statement_and_new_id` | fact add requires a statement and an id that is not already established. |
+| `fact_dispute_requires_existing_fact` | fact dispute must reference an existing fact id. |
+| `fact_supersede_requires_existing_fact_and_target` | fact supersede must reference an existing fact id and an existing target_id. |
+| `trigger_fields_must_be_valid` | Trigger kind must be A-D, status known, name/component non-empty, and dimension valid for the interview type. |
+| `non_active_trigger_requires_rationale` | Disputed or unresolved triggers must carry a rationale. |
+| `trigger_contradicted_fact_must_exist` | trigger.contradictedFactId must reference an existing fact. |
+| `trigger_component_must_exist_in_topology` | trigger.component must reference a component present in the confirmed topology. |
+| `ontology_entities_must_be_well_formed` | Every ontology entity needs string id/name/type (name non-empty) plus fields and relationships arrays. |
+| `ontology_snapshot_rounds_must_increase` | The prior ontology snapshot round must be a safe integer smaller than the round being scored. |
+| `targeting_must_match_derived_target` | Optional targeting assertions must equal the natively derived target component/dimension. |
+| `bookkeeping_round_ids_must_reference_rounds` | bookkeeping.round_ids must be unique and reference durable round keys or round ids. |
+| `counter_deltas_must_be_safe_integers` | Every counter delta and existing counter value must be a safe integer. |
+| `threshold_must_be_valid_score` | state.threshold must be a number in [0,1] with 4-decimal precision. |
+| `threshold_units_must_match_threshold` | state.threshold_units must be a safe integer in [1,10000] equal to scoreToUnits(threshold). |
+| `active_trigger_requires_score_regression` | An active trigger requires a prior scored round whose dimension score did not improve and whose effective ambiguity increased. |
+| `envelope_schema_invalid` | The persisted deep-interview envelope failed native v1 schema validation at the reported path. |
+<!-- END GENERATED: deep-interview-state-invariants -->
 - Use the GJC workflow CLI to save the final spec at `.gjc/_session-{sessionid}/specs/deep-interview-{slug}.md` exactly; do not use `write`, `edit`, or `ast_edit` directly on `.gjc/` paths without force override.
 - Use public GJC workflow entrypoints to bridge to ralplan, ultragoal, or team only after explicit execution approval — never implement directly. Implementation handoff defaults to ultragoal; reserve team for when tmux-based interactive worker parallelization is genuinely required.
 - The lateral-review panel spawns read-only persona subagents (Task tool) in parallel with independent context; it is an assist layer, never an executor and never the completion authority

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-draft.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-draft.ts
@@ -18,7 +18,12 @@ import {
 	dryRunDeepInterviewRepairMutation,
 	runDeepInterviewRepairCommand,
 } from "./deep-interview-repair";
-import { canonicalDeepInterviewJson, validateDeepInterviewV1Envelope } from "./deep-interview-state";
+import {
+	canonicalDeepInterviewJson,
+	DeepInterviewInvariantError,
+	deepInterviewInvariantDetail,
+	validateDeepInterviewV1Envelope,
+} from "./deep-interview-state";
 import { modeStatePath } from "./session-layout";
 import {
 	isNativeDeepInterviewV1,
@@ -210,9 +215,11 @@ function draftIssue(errorCode: string): { code: string; message: string; recover
 
 function response(status: number, value: unknown): DeepInterviewDraftResult {
 	if (status === 0) return { status, stdout: `${JSON.stringify(value)}\n` };
+	const renderedIssue =
+		value && typeof value === "object" && !Array.isArray(value) ? value : draftIssue(String(value));
 	return {
 		status,
-		stderr: `${JSON.stringify({ ok: false, issue: draftIssue(String(value)) })}\n`,
+		stderr: `${JSON.stringify({ ok: false, issue: renderedIssue })}\n`,
 	};
 }
 const EDIT_OP_FLAGS = ["--op", "--path", "--value", "--value-file", "--null"] as const;
@@ -491,7 +498,8 @@ async function revision(cwd: string, session: string): Promise<{ revision: numbe
 	if (receipt === "checksum-mismatch") throw new Error("DI_RECEIPT_CHECKSUM_MISMATCH");
 	try {
 		if (isNativeDeepInterviewV1(observed.value)) validateDeepInterviewV1Envelope(observed.value);
-	} catch {
+	} catch (error) {
+		if (error instanceof DeepInterviewInvariantError) throw error;
 		throw new Error("DI_STATE_SCHEMA_INVALID");
 	}
 	if (
@@ -1069,6 +1077,15 @@ async function runDeepInterviewDraftCommandInternal(
 			return response(0, { ok: true, draft_id: id, consumed: true, receipt: draft.receipt });
 		});
 	} catch (error) {
+		if (error instanceof DeepInterviewInvariantError) {
+			return response(2, {
+				code: error.code,
+				message: `${error.invariant} violated at ${error.path}`,
+				recovery:
+					"The violated invariant is in persisted state. Run gjc deep-interview sanity-check --json and inspect the reported state path; never edit .gjc state files directly.",
+				...deepInterviewInvariantDetail(error),
+			});
+		}
 		return response(code(error) === "DI_STATE_REVISION_CONFLICT" ? 3 : 2, code(error));
 	}
 }

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-repair.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-repair.ts
@@ -8,6 +8,7 @@ import {
 	canonicalDeepInterviewJson,
 	type DeepInterviewFactOperation,
 	type DeepInterviewInvariantDetail,
+	DeepInterviewInvariantError,
 	type DeepInterviewResolution,
 	type DeepInterviewRoundResultV1,
 	deepInterviewAnswerIdentityEqual,
@@ -206,6 +207,7 @@ function errorResult(error: unknown): DeepInterviewRepairResult {
 							error.code === "DI_SHELL_CONFLICT"
 							? 4
 							: 3,
+						error.detail,
 					)
 				: new RepairError("DI_INTERNAL_ERROR", 3);
 	return {
@@ -1111,7 +1113,8 @@ export async function dryRunDeepInterviewRepairMutation(
 				: undefined;
 		const path = statePath(cwd, session);
 		const diagnostic = diagnoseDeepInterviewState(await readExistingStateForMutation(path), path);
-		if (diagnostic.code || !diagnostic.value) throw new RepairError(diagnostic.code ?? "DI_INTERNAL_ERROR", 3);
+		if (diagnostic.code || !diagnostic.value)
+			throw new RepairError(diagnostic.code ?? "DI_INTERNAL_ERROR", 3, diagnostic.detail);
 		// Revision binding: the dry-run must validate the exact revision the caller
 		// observed. If the state advanced between the caller's read and this reread,
 		// report the same retryable conflict a real consume would.
@@ -1592,7 +1595,9 @@ function inspectState(read: Record<string, unknown>, legacy: boolean): Record<st
 	try {
 		if (legacy) validateLegacyDeepInterviewEnvelope(read);
 		else validateDeepInterviewV1Envelope(read);
-	} catch {
+	} catch (error) {
+		if (error instanceof DeepInterviewInvariantError)
+			throw new RepairError(error.code, 3, deepInterviewInvariantDetail(error));
 		throw new RepairError("DI_STATE_SCHEMA_INVALID", 3);
 	}
 	return read.state as Record<string, unknown>;
@@ -1600,6 +1605,7 @@ function inspectState(read: Record<string, unknown>, legacy: boolean): Record<st
 
 type DeepInterviewDiagnostic = {
 	code?: string;
+	detail?: DeepInterviewInvariantDetail;
 	legacy: boolean;
 	state?: Record<string, unknown>;
 	value?: Record<string, unknown>;
@@ -1628,7 +1634,11 @@ function diagnoseDeepInterviewState(
 	try {
 		state = inspectState(read.value, legacy);
 	} catch (error) {
-		return { code: error instanceof RepairError ? error.code : "DI_STATE_SCHEMA_INVALID", legacy };
+		return {
+			code: error instanceof RepairError ? error.code : "DI_STATE_SCHEMA_INVALID",
+			detail: error instanceof RepairError ? error.detail : undefined,
+			legacy,
+		};
 	}
 
 	if (read.value.current_phase === "complete" || read.value.current_phase === "handoff" || read.value.active === false)
@@ -1659,7 +1669,7 @@ async function inspect(parsed: ParsedRepairCommand, cwd: string): Promise<DeepIn
 	const path = statePath(cwd, session);
 	const diagnostic = diagnoseDeepInterviewState(await readExistingStateForMutation(path), path);
 	if (diagnostic.code || !diagnostic.state || !diagnostic.value)
-		throw new RepairError(diagnostic.code ?? "DI_INTERNAL_ERROR", 3);
+		throw new RepairError(diagnostic.code ?? "DI_INTERNAL_ERROR", 3, diagnostic.detail);
 	const { legacy, state, value } = diagnostic;
 	const revision =
 		typeof value.state_revision === "number" && Number.isSafeInteger(value.state_revision) ? value.state_revision : 0;
@@ -1868,7 +1878,7 @@ async function sanity(parsed: ParsedRepairCommand, cwd: string): Promise<DeepInt
 	const { session } = validateMutation(parsed, ["--session-id"], false);
 	const path = statePath(cwd, session);
 	const diagnostic = diagnoseDeepInterviewState(await readExistingStateForMutation(path), path);
-	const issues = diagnostic.code ? [issue(diagnostic.code)] : [];
+	const issues = diagnostic.code ? [issue(diagnostic.code, diagnostic.detail)] : [];
 	return {
 		status: 0,
 		stdout: `${JSON.stringify({

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-state.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-state.ts
@@ -1732,8 +1732,17 @@ export function applyDeepInterviewRoundResultV1(
 	};
 }
 export function validateDeepInterviewV1Envelope(value: Record<string, unknown>): void {
-	const invalid = (): never => {
-		throw new Error("DI_STATE_SCHEMA_INVALID");
+	const invalid = (
+		path = "/state",
+		expected: unknown = "valid native deep-interview v1 state",
+		actual?: unknown,
+	): never => {
+		throw new DeepInterviewInvariantError("DI_STATE_SCHEMA_INVALID", {
+			invariant: "envelope_schema_invalid",
+			path,
+			expected,
+			...(actual === undefined ? {} : { actual }),
+		});
 	};
 	const validDate = (candidate: unknown): candidate is string =>
 		typeof candidate === "string" && Number.isFinite(Date.parse(candidate));
@@ -1747,10 +1756,12 @@ export function validateDeepInterviewV1Envelope(value: Record<string, unknown>):
 		}
 	};
 	const stateValue = value.state;
-	if (value.skill !== "deep-interview" || value.schema_version !== 1 || !isPlainObject(stateValue)) return invalid();
+	if (value.skill !== "deep-interview") return invalid("/skill", "deep-interview", value.skill);
+	if (value.schema_version !== 1) return invalid("/schema_version", 1, value.schema_version);
+	if (!isPlainObject(stateValue)) return invalid("/state", "object", stateValue);
 	const state = stateValue as Record<string, unknown>;
 	const type = state.type;
-	if (type !== "greenfield" && type !== "brownfield") return invalid();
+	if (type !== "greenfield" && type !== "brownfield") return invalid("/state/type", "greenfield | brownfield", type);
 	const dimensions: DeepInterviewDimension[] =
 		type === "brownfield" ? ["goal", "constraints", "criteria", "context"] : ["goal", "constraints", "criteria"];
 	const isDimension = (candidate: unknown): candidate is DeepInterviewDimension =>
@@ -1759,17 +1770,19 @@ export function validateDeepInterviewV1Envelope(value: Record<string, unknown>):
 	const factsValue = state.established_facts;
 	const threshold = state.threshold ?? value.threshold;
 	const thresholdUnits = state.threshold_units;
+	if (!validScore(threshold)) return invalid("/state/threshold", "score in [0,1] with 4-decimal precision", threshold);
 	if (
-		!validScore(threshold) ||
 		typeof thresholdUnits !== "number" ||
 		!Number.isSafeInteger(thresholdUnits) ||
 		thresholdUnits < 1 ||
-		thresholdUnits > 10_000 ||
-		scoreToUnits(threshold) !== thresholdUnits ||
-		!Array.isArray(roundsValue) ||
-		!Array.isArray(factsValue)
+		thresholdUnits > 10_000
 	)
-		return invalid();
+		return invalid("/state/threshold_units", "safe integer in [1,10000]", thresholdUnits);
+	const expectedThresholdUnits = scoreToUnits(threshold);
+	if (expectedThresholdUnits !== thresholdUnits)
+		return invalid("/state/threshold_units", expectedThresholdUnits, thresholdUnits);
+	if (!Array.isArray(roundsValue)) return invalid("/state/rounds", "array", roundsValue);
+	if (!Array.isArray(factsValue)) return invalid("/state/established_facts", "array", factsValue);
 	const rounds = roundsValue as unknown[];
 	const facts = factsValue as unknown[];
 

--- a/packages/coding-agent/src/gjc-runtime/state-writer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-writer.ts
@@ -11,7 +11,12 @@ import {
 	type WorkflowStateMutationOwner,
 	type WorkflowStateReceipt,
 } from "../skill-state/workflow-state-contract";
-import { validateDeepInterviewV1Envelope } from "./deep-interview-state";
+import {
+	type DeepInterviewInvariantDetail,
+	DeepInterviewInvariantError,
+	deepInterviewInvariantDetail,
+	validateDeepInterviewV1Envelope,
+} from "./deep-interview-state";
 import {
 	activeEntryPath as layoutActiveEntryPath,
 	activeSnapshotPath as layoutActiveSnapshotPath,
@@ -114,7 +119,10 @@ export type GuardedWorkflowEnvelopeTransformResult =
 	  };
 
 export class GuardedWorkflowEnvelopeError extends Error {
-	constructor(public readonly code: string) {
+	constructor(
+		public readonly code: string,
+		public readonly detail?: DeepInterviewInvariantDetail,
+	) {
 		super(code);
 		this.name = "GuardedWorkflowEnvelopeError";
 	}
@@ -734,7 +742,9 @@ export async function transformGuardedWorkflowEnvelopeAtomic(
 			try {
 				if (isNativeDeepInterviewV1(read.value)) validateDeepInterviewV1Envelope(read.value);
 				options.validate?.(read.value, legacy);
-			} catch {
+			} catch (error) {
+				if (error instanceof DeepInterviewInvariantError)
+					throw new GuardedWorkflowEnvelopeError(error.code, deepInterviewInvariantDetail(error));
 				throw new GuardedWorkflowEnvelopeError("DI_STATE_SCHEMA_INVALID");
 			}
 			const phase = read.value.current_phase;
@@ -749,7 +759,9 @@ export async function transformGuardedWorkflowEnvelopeAtomic(
 			try {
 				if (isNativeDeepInterviewV1(transformed.value)) validateDeepInterviewV1Envelope(transformed.value);
 				options.validate?.(transformed.value, false);
-			} catch {
+			} catch (error) {
+				if (error instanceof DeepInterviewInvariantError)
+					throw new GuardedWorkflowEnvelopeError(error.code, deepInterviewInvariantDetail(error));
 				throw new GuardedWorkflowEnvelopeError("DI_STATE_SCHEMA_INVALID");
 			}
 			const stamped = stampWorkflowEnvelopeRevisionAndChecksum(

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
@@ -274,7 +274,6 @@
           "draft create"
         ],
         "name": "session-id",
-        "required": true,
         "type": "string"
       },
       {
@@ -438,7 +437,6 @@
           "sanity-check"
         ],
         "name": "session-id",
-        "required": true,
         "type": "string"
       },
       {
@@ -450,7 +448,6 @@
         ],
         "compatibilityOnly": true,
         "name": "session-id",
-        "required": true,
         "type": "string"
       },
       {

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
@@ -195,7 +195,6 @@ export const WORKFLOW_MANIFEST: Record<CanonicalGjcWorkflowSkill, SkillManifest>
 			{
 				name: "session-id",
 				type: "string",
-				required: true,
 				appliesToVerbs: ["draft create"],
 			},
 			{
@@ -277,13 +276,11 @@ export const WORKFLOW_MANIFEST: Record<CanonicalGjcWorkflowSkill, SkillManifest>
 			{
 				name: "session-id",
 				type: "string",
-				required: true,
 				appliesToVerbs: ["inspect", "sanity-check"],
 			},
 			{
 				name: "session-id",
 				type: "string",
-				required: true,
 				compatibilityOnly: true,
 				appliesToVerbs: ["initialize-context", "confirm-topology", "record-answer", "apply-round-result"],
 			},

--- a/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
@@ -53,7 +53,7 @@ const BASH_MUTATION_COMMAND_RE =
 	/(?:^|[;&|\n])\s*(?:\w+=[^\s]+\s+)*(?:sudo\s+)?(?:(?:command|exec)\s+)?(?:[^\s;&|]*\/)?['"]?(?:tee|touch|rm|mkdir|cp|mv|install|truncate)['"]?\b([^;&|\n]*)|(?:^|[^<>])(?:>>?|\d>>?)\s*([^\s;&|]+)/gi;
 const BASH_IN_PLACE_MUTATION_COMMAND_RE = /(?:^|[;&|\n])\s*(?:\w+=[^\s]+\s+)*(?:sudo\s+)?(?:sed|perl)\b([^;&|\n]*)/gi;
 /** Literal filesystem targets passed to common interpreter write APIs. */
-const BASH_INTERPRETER_FILE_TARGET_RE = /(?:open|writeFile(?:Sync)?)\s*\(\s*["']([^"']+)["']/gi;
+const BASH_INTERPRETER_FILE_TARGET_RE = /(?:Bun\.write|open|writeFile(?:Sync)?)\s*\(\s*["']([^"']+)["']/gi;
 const BASH_DD_OUTPUT_RE = /(?:^|[;&|\n])\s*(?:\w+=[^\s]+\s+)*(?:sudo\s+)?(?:[^\s;&|]*\/)?dd\b([^;&|\n]*)/gi;
 /** `sort -o <file>` / `sort --output=<file>` writes the named file without any shell redirection. */
 const BASH_SORT_OUTPUT_RE =

--- a/packages/coding-agent/test/deep-interview-repair-cli.test.ts
+++ b/packages/coding-agent/test/deep-interview-repair-cli.test.ts
@@ -1409,10 +1409,34 @@ describe("deep-interview typed repair CLI", () => {
 				ok: false,
 				issue: {
 					code: "DI_STATE_SCHEMA_INVALID",
-					message: "The persisted deep-interview state violates a native v1 invariant.",
+					message: "envelope_schema_invalid violated at /state/threshold_units",
 					recovery:
-						"Fix the named invariant at the reported path (gjc deep-interview draft edit --draft-id <id> --expected-draft-revision latest --op set --path <path> --value <expected> --json), rerun gjc deep-interview draft check --draft-id <id> --json, then retry consume.",
+						"The violated invariant is in persisted state. Run gjc deep-interview sanity-check --json and inspect the reported state path; never edit .gjc state files directly.",
+					invariant: "envelope_schema_invalid",
+					path: "/state/threshold_units",
+					expected: 500,
+					actual: 499,
 				},
+			});
+			const sanity = await runDeepInterviewRepairCommand(["sanity-check", "--session-id", session, "--json"], cwd);
+			expect(JSON.parse(sanity.stdout!).issues[0]).toMatchObject({
+				code: "DI_STATE_SCHEMA_INVALID",
+				invariant: "envelope_schema_invalid",
+				path: "/state/threshold_units",
+				expected: 500,
+				actual: 499,
+			});
+			const inspect = await runDeepInterviewRepairCommand(
+				["inspect", "--session-id", session, "--selector", "summary", "--json"],
+				cwd,
+			);
+			expect(inspect.status).toBe(3);
+			expect(JSON.parse(inspect.stderr!).issue).toMatchObject({
+				code: "DI_STATE_SCHEMA_INVALID",
+				invariant: "envelope_schema_invalid",
+				path: "/state/threshold_units",
+				expected: 500,
+				actual: 499,
 			});
 		} finally {
 			await fs.rm(cwd, { recursive: true, force: true });

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -221,7 +221,7 @@ describe("default GJC definitions", () => {
 			{ name: "round", type: "number", required: false },
 			{ name: "round-id", type: "string", required: false },
 			{ name: "round-key", type: "string", required: false },
-			{ name: "session-id", type: "string", required: true },
+			{ name: "session-id", type: "string", required: false },
 		]);
 		expect(argsFor("draft edit")).toEqual([
 			{ name: "draft-id", type: "string", required: true },
@@ -262,7 +262,7 @@ describe("default GJC definitions", () => {
 			{ name: "expected-revision", type: "number", required: true },
 			{ name: "input-json", type: "object", required: true },
 			{ name: "schema-version", type: "number", required: true },
-			{ name: "session-id", type: "string", required: true },
+			{ name: "session-id", type: "string", required: false },
 		]);
 		expect(argsFor("confirm-topology", true)).toEqual(argsFor("initialize-context", true));
 		expect(argsFor("record-answer", true)).toEqual([
@@ -275,7 +275,7 @@ describe("default GJC definitions", () => {
 			{ name: "round", type: "number", required: true },
 			{ name: "round-id", type: "string", required: false },
 			{ name: "schema-version", type: "number", required: true },
-			{ name: "session-id", type: "string", required: true },
+			{ name: "session-id", type: "string", required: false },
 		]);
 		expect(argsFor("apply-round-result", true)).toEqual([
 			{ name: "expected-revision", type: "number", required: true },
@@ -284,7 +284,7 @@ describe("default GJC definitions", () => {
 			{ name: "round", type: "number", required: true },
 			{ name: "round-id", type: "string", required: false },
 			{ name: "schema-version", type: "number", required: true },
-			{ name: "session-id", type: "string", required: true },
+			{ name: "session-id", type: "string", required: false },
 		]);
 		expect(argsFor("inspect")).toEqual([
 			{ name: "cursor", type: "string", required: false },
@@ -292,11 +292,11 @@ describe("default GJC definitions", () => {
 			{ name: "limit", type: "number", required: false },
 			{ name: "round-key", type: "string", required: false },
 			{ name: "selector", type: "enum", required: true },
-			{ name: "session-id", type: "string", required: true },
+			{ name: "session-id", type: "string", required: false },
 		]);
 		expect(argsFor("sanity-check")).toEqual([
 			{ name: "json", type: "boolean", required: true },
-			{ name: "session-id", type: "string", required: true },
+			{ name: "session-id", type: "string", required: false },
 		]);
 		expect(argsFor("inspect", true)).toEqual([]);
 		expect(argsFor("sanity-check", true)).toEqual([]);

--- a/packages/coding-agent/test/workflow-mutation-guard.test.ts
+++ b/packages/coding-agent/test/workflow-mutation-guard.test.ts
@@ -890,6 +890,7 @@ describe("workflow mutation guard", () => {
 			// non-whitelisted writing segment alongside gjc
 			'gjc state read --json && python -c \'open("src/product.ts", "w").write("x")\'',
 			"gjc state read --json; tee src/product.ts",
+			'bun -e \'await Bun.write("src/product.ts", "x")\'',
 			// redirection disqualifies the whitelist
 			"gjc deep-interview inspect --session-id s1 --json > src/product.ts",
 			// command substitution disqualifies

--- a/scripts/verify-deep-interview-docs.ts
+++ b/scripts/verify-deep-interview-docs.ts
@@ -152,6 +152,7 @@ function main(): void {
 	const skillDoc = read(SKILL_DOC);
 
 	checkInvariantTable(REPAIR_CLI_DOC, repairDoc);
+	checkInvariantTable(SKILL_DOC, skillDoc);
 	checkDraftSchemas(REPAIR_CLI_DOC, repairDoc);
 	checkDraftSchemas(SKILL_DOC, skillDoc);
 	checkContractPhrases(REPAIR_CLI_DOC, repairDoc);


### PR DESCRIPTION
Final follow-up: preserve malformed-envelope invariant details/recovery, extract Bun.write targets, make session-id optional in manifest metadata, and verify invariant tables in both docs. Verification: 208 tests passed; TypeScript, Biome, docs/manifest/G002/rebrand/public-sync gates passed.