### PR TITLE
fix(deep-interview): close terminal guard gaps

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/deep-interview-draft.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-draft.ts
@@ -852,6 +852,7 @@ async function runDeepInterviewDraftCommandInternal(
 	cwd: string,
 	allowInternalConsume: boolean,
 ): Promise<DeepInterviewDraftResult> {
+	let recoverySessionId: string | undefined;
 	try {
 		const action = input[0];
 		if (
@@ -895,6 +896,7 @@ async function runDeepInterviewDraftCommandInternal(
 				const session = flags.get("--session-id") ?? process.env.GJC_SESSION_ID?.trim();
 				if (!session) throw new Error("DI_INVALID_ARGUMENT");
 				if (!DEEP_INTERVIEW_DRAFT_KINDS.includes(kind) || !ID.test(session)) throw new Error("DI_INVALID_ARGUMENT");
+				recoverySessionId = session;
 				const current = await revision(cwd, session);
 				const now = new Date();
 				const draft: Draft = {
@@ -941,6 +943,7 @@ async function runDeepInterviewDraftCommandInternal(
 			}
 			const id = required(flags, "--draft-id");
 			const draft = await read(cwd, id);
+			recoverySessionId = draft.session_id;
 			await cleanup(cwd);
 			if (action === "show") return response(0, { ok: true, draft });
 			if (action === "discard") {
@@ -1081,8 +1084,7 @@ async function runDeepInterviewDraftCommandInternal(
 			return response(2, {
 				code: error.code,
 				message: `${error.invariant} violated at ${error.path}`,
-				recovery:
-					"The violated invariant is in persisted state. Run gjc deep-interview sanity-check --json and inspect the reported state path; never edit .gjc state files directly.",
+				recovery: `The violated invariant is in persisted state. Run gjc deep-interview sanity-check --session-id ${recoverySessionId ?? "<session>"} --json and inspect the reported state path; never edit .gjc state files directly.`,
 				...deepInterviewInvariantDetail(error),
 			});
 		}

--- a/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
@@ -53,7 +53,10 @@ const BASH_MUTATION_COMMAND_RE =
 	/(?:^|[;&|\n])\s*(?:\w+=[^\s]+\s+)*(?:sudo\s+)?(?:(?:command|exec)\s+)?(?:[^\s;&|]*\/)?['"]?(?:tee|touch|rm|mkdir|cp|mv|install|truncate)['"]?\b([^;&|\n]*)|(?:^|[^<>])(?:>>?|\d>>?)\s*([^\s;&|]+)/gi;
 const BASH_IN_PLACE_MUTATION_COMMAND_RE = /(?:^|[;&|\n])\s*(?:\w+=[^\s]+\s+)*(?:sudo\s+)?(?:sed|perl)\b([^;&|\n]*)/gi;
 /** Literal filesystem targets passed to common interpreter write APIs. */
-const BASH_INTERPRETER_FILE_TARGET_RE = /(?:Bun\.write|open|writeFile(?:Sync)?)\s*\(\s*["']([^"']+)["']/gi;
+const BASH_INTERPRETER_FILE_TARGET_RE = /(?:open|writeFile(?:Sync)?)\s*\(\s*["']([^"']+)["']/gi;
+const BASH_BUN_WRITE_CALL_RE = /\bBun\.write\s*\(/g;
+const BASH_BUN_WRITE_STRING_TARGET_RE = /\bBun\.write\s*\(\s*["']([^"']+)["']/g;
+const BASH_BUN_WRITE_TEMPLATE_TARGET_RE = /\bBun\.write\s*\(\s*`([^`$\\]*)`/g;
 const BASH_DD_OUTPUT_RE = /(?:^|[;&|\n])\s*(?:\w+=[^\s]+\s+)*(?:sudo\s+)?(?:[^\s;&|]*\/)?dd\b([^;&|\n]*)/gi;
 /** `sort -o <file>` / `sort --output=<file>` writes the named file without any shell redirection. */
 const BASH_SORT_OUTPUT_RE =
@@ -544,6 +547,20 @@ function extractBashTargets(args: unknown): ExtractedTargets {
 	// workflow-sanctioned CLI is never blocked as unknown-target (#guard-vs-cli conflict).
 	if (isPureGjcReadOnlyBashCommand(command)) {
 		return targets;
+	}
+	const bunWriteCallCount = [...command.matchAll(BASH_BUN_WRITE_CALL_RE)].length;
+	let classifiedBunWriteCount = 0;
+	for (const matcher of [BASH_BUN_WRITE_STRING_TARGET_RE, BASH_BUN_WRITE_TEMPLATE_TARGET_RE]) {
+		for (const match of command.matchAll(matcher)) {
+			targets.explicitMutation = true;
+			classifiedBunWriteCount++;
+			const target = match[1]?.trim();
+			if (target && !isDeviceSinkPath(target)) addPath(targets, target);
+		}
+	}
+	if (classifiedBunWriteCount < bunWriteCallCount) {
+		targets.explicitMutation = true;
+		targets.unknown = true;
 	}
 	for (const match of command.matchAll(BASH_INTERPRETER_FILE_TARGET_RE)) {
 		targets.explicitMutation = true;

--- a/packages/coding-agent/test/deep-interview-repair-cli.test.ts
+++ b/packages/coding-agent/test/deep-interview-repair-cli.test.ts
@@ -1411,7 +1411,7 @@ describe("deep-interview typed repair CLI", () => {
 					code: "DI_STATE_SCHEMA_INVALID",
 					message: "envelope_schema_invalid violated at /state/threshold_units",
 					recovery:
-						"The violated invariant is in persisted state. Run gjc deep-interview sanity-check --json and inspect the reported state path; never edit .gjc state files directly.",
+						"The violated invariant is in persisted state. Run gjc deep-interview sanity-check --session-id malformed-native-draft --json and inspect the reported state path; never edit .gjc state files directly.",
 					invariant: "envelope_schema_invalid",
 					path: "/state/threshold_units",
 					expected: 500,

--- a/packages/coding-agent/test/workflow-mutation-guard.test.ts
+++ b/packages/coding-agent/test/workflow-mutation-guard.test.ts
@@ -891,6 +891,8 @@ describe("workflow mutation guard", () => {
 			'gjc state read --json && python -c \'open("src/product.ts", "w").write("x")\'',
 			"gjc state read --json; tee src/product.ts",
 			'bun -e \'await Bun.write("src/product.ts", "x")\'',
+			"bun -e 'await Bun.write(`src/product.ts`, \"x\")'",
+			"bun -e 'await Bun.write(target, \"x\")'",
 			// redirection disqualifies the whitelist
 			"gjc deep-interview inspect --session-id s1 --json > src/product.ts",
 			// command substitution disqualifies


### PR DESCRIPTION
Close terminal review gaps: detect Bun.write template/dynamic targets and include explicit session IDs in malformed-state draft recovery. Verification: 208 tests passed; TypeScript and Biome passed.