### PR TITLE
fix(guard,deep-interview): block nested-shell mutations and emit runnable payload recovery

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/deep-interview-repair.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-repair.ts
@@ -166,9 +166,6 @@ const REPAIR_CODE_MESSAGES: Record<string, { message: string; recovery?: string 
 	DI_OUTPUT_LIMIT_EXCEEDED: { message: "The projected response exceeds the CLI output byte limit." },
 	DI_INPUT_MODE_CONFLICT: { message: "Draft-mode and raw-JSON flags cannot be mixed in one invocation." },
 };
-/** Recovery for invariants whose offending datum lives in the caller-editable payload. */
-const PAYLOAD_INVARIANT_RECOVERY =
-	"Correct the named invariant at the reported path so actual matches expected (gjc deep-interview draft edit --draft-id <id> --expected-draft-revision latest --op set --path <payload-path> --value <value> --json), rerun gjc deep-interview draft check --draft-id <id> --json until valid, then retry consume.";
 /** Recovery for invariants whose offending datum lives in persisted state, which drafts cannot edit. */
 const STATE_INVARIANT_RECOVERY =
 	"The violated invariant is in persisted state, not the draft payload. Inspect it (gjc deep-interview inspect --session-id <session> --selector summary|pending|recent-scored --json) and complete the missing lifecycle step (e.g. score earlier pending rounds first); if the state itself is corrupt, follow the documented state repair path via sanity-check — never edit .gjc state files directly.";
@@ -189,6 +186,30 @@ function isRequiredSetupPointer(pointer: string): boolean {
 	return requiredSetupPointers.has(pointer);
 }
 /**
+ * Render a runnable recovery for a payload invariant. `draft edit --op set`
+ * only accepts scalar leaves, and a missing array item must be scaffolded with
+ * `append` first, so the emitted command is chosen from the reported pointer's
+ * descriptor rather than always suggesting `set`.
+ */
+function payloadInvariantRecovery(detail: DeepInterviewInvariantDetail): string {
+	const rerun = "then rerun gjc deep-interview draft check --draft-id <id> --json until valid, and retry consume.";
+	const prefix = "gjc deep-interview draft edit --draft-id <id> --expected-draft-revision latest";
+	const value = detail.expected === undefined ? "<value>" : JSON.stringify(detail.expected);
+	// A trailing object segment (e.g. `/component_updates/2/scores`) is not a
+	// scalar leaf: the caller must append the item, then set each scalar under it.
+	const arrayItem = detail.path.match(/^(\/[A-Za-z_]+)\/(\d+)(\/.*)?$/);
+	if (arrayItem) {
+		const [, arrayPointer, indexText, rest] = arrayItem;
+		const leaf = rest && /\/[A-Za-z_]+$/.test(rest) && !rest.endsWith("/scores");
+		const setPart = leaf
+			? `${prefix} --op set --path ${detail.path} --value ${value} --json`
+			: `${prefix} --op append --path ${arrayPointer} --json` +
+				` (repeat until index ${indexText} exists), then set each required scalar under ${detail.path}/<dimension>`;
+		return `Fix ${detail.path} in the draft payload: ${setPart}, ${rerun}`;
+	}
+	return `Fix ${detail.path} in the draft payload (${prefix} --op set --path ${detail.path} --value ${value} --json), ${rerun}`;
+}
+/**
  * Invariant detail paths starting with `/state/` point at the persisted
  * envelope; everything else (`/global_scores/...`, `/triggers...`, `/fact_ops...`,
  * `/bookkeeping/...`, `/targeting`, `/ontology/...`) is payload-addressable.
@@ -204,7 +225,8 @@ function invariantRecovery(detail: DeepInterviewInvariantDetail): string {
 			: `set it back to ${existing} (gjc deep-interview draft edit --draft-id <id> --expected-draft-revision latest --op set --path ${detail.path} --value ${existing} --json)`;
 		return `State already initialized ${detail.path}; setup fields cannot be changed. To proceed, ${correction}, then rerun gjc deep-interview draft check --draft-id <id> --json.`;
 	}
-	return detail.path.startsWith("/state/") ? STATE_INVARIANT_RECOVERY : PAYLOAD_INVARIANT_RECOVERY;
+	if (detail.path.startsWith("/state/")) return STATE_INVARIANT_RECOVERY;
+	return payloadInvariantRecovery(detail);
 }
 function issue(code: string, detail?: DeepInterviewInvariantDetail) {
 	const known = REPAIR_CODE_MESSAGES[code];

--- a/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
@@ -535,7 +535,15 @@ function isPureGjcReadOnlyBashCommand(command: string): boolean {
 	return true;
 }
 
-function extractBashTargets(args: unknown): ExtractedTargets {
+/**
+ * Literal `sh|bash|zsh -c '<script>'` payloads. The nested script is a real
+ * command list, so its mutations must be extracted too; a quoted script never
+ * matches the top-level mutator patterns, which would otherwise read as safe.
+ */
+const BASH_NESTED_SHELL_RE =
+	/(?:^|[;&|\n])\s*(?:\w+=[^\s]+\s+)*(?:sudo\s+)?(?:[^\s;&|]*\/)?(?:ba|z|da)?sh\s+(?:-[A-Za-z]+\s+)*-[A-Za-z]*c\s+(?:(')([^']*)'|(")([^"]*)")/g;
+
+function extractBashTargets(args: unknown, depth = 0): ExtractedTargets {
 	const record = getRecord(args);
 	const command = safeString(record?.command);
 	const targets: ExtractedTargets = { paths: [], unknown: false };
@@ -547,6 +555,20 @@ function extractBashTargets(args: unknown): ExtractedTargets {
 	// workflow-sanctioned CLI is never blocked as unknown-target (#guard-vs-cli conflict).
 	if (isPureGjcReadOnlyBashCommand(command)) {
 		return targets;
+	}
+	// Recurse into literal nested shell scripts. A bounded depth keeps this
+	// terminating; anything deeper is not statically analyzable, so fail closed.
+	for (const match of command.matchAll(BASH_NESTED_SHELL_RE)) {
+		const script = match[2] ?? match[4] ?? "";
+		if (depth >= 2) {
+			targets.explicitMutation = true;
+			targets.unknown = true;
+			break;
+		}
+		const nested = extractBashTargets({ command: script }, depth + 1);
+		for (const nestedPath of nested.paths) addPath(targets, nestedPath);
+		if (nested.unknown) targets.unknown = true;
+		if (nested.explicitMutation) targets.explicitMutation = true;
 	}
 	const bunWriteCallCount = [...command.matchAll(BASH_BUN_WRITE_CALL_RE)].length;
 	let classifiedBunWriteCount = 0;

--- a/packages/coding-agent/test/deep-interview-draft-consume.test.ts
+++ b/packages/coding-agent/test/deep-interview-draft-consume.test.ts
@@ -818,6 +818,9 @@ describe("CLI-owned deep-interview draft consumption", () => {
 				expected: 0.5,
 				actual: 1,
 			});
+			// The printed recovery must name a runnable draft operation, never a bare
+			// `--op set` on an object path (which the draft editor rejects).
+			expect(String(issues[0].recovery)).toContain("--op set --path /global_scores/goal");
 			// consume fails with the identical named invariant
 			const failedConsume = await consume(env.cwd, "apply-round-result", result);
 			expect(failedConsume.status).not.toBe(0);

--- a/packages/coding-agent/test/workflow-mutation-guard.test.ts
+++ b/packages/coding-agent/test/workflow-mutation-guard.test.ts
@@ -869,6 +869,7 @@ describe("workflow mutation guard", () => {
 			'gjc deep-interview draft edit --draft-id abc --expected-draft-revision 1 --op set --path /question --value "What?" --json',
 			"gjc deep-interview draft edit --draft-id abc --expected-draft-revision 1 --op set --path /type --value brownfield --op set --path /codebase_context --value 'Release uses `bun run release`; output may contain >, <, |, and $(literal) as inert text.' --json",
 			'bun -e \'const p=Bun.spawnSync(["gjc","deep-interview","inspect","--selector","round","--json"]); process.stdout.write(p.stdout); process.stderr.write(p.stderr); process.exit(p.exitCode)\'',
+			"bash -c 'gjc deep-interview inspect --selector summary --json'",
 			'gjc deep-interview draft create --for apply-round-result --session-id s1 --json <<\'EOF\'\n{"unused": "stdin data with open( and writeFile( text"}\nEOF',
 		]) {
 			const decision = await getWorkflowMutationDecision({
@@ -893,6 +894,10 @@ describe("workflow mutation guard", () => {
 			'bun -e \'await Bun.write("src/product.ts", "x")\'',
 			"bun -e 'await Bun.write(`src/product.ts`, \"x\")'",
 			"bun -e 'await Bun.write(target, \"x\")'",
+			// A literal nested shell script is a real command list; its mutations count.
+			"bash -c 'rm src/product.ts'",
+			"sh -c 'touch src/product.ts'",
+			'zsh -c "echo x > src/product.ts"',
 			// redirection disqualifies the whitelist
 			"gjc deep-interview inspect --session-id s1 --json > src/product.ts",
 			// command substitution disqualifies


### PR DESCRIPTION
Two HIGH findings from the final review, both reproduced live before fixing.

1. Planning-phase guard bypass: `bash -c "rm src/product.ts"` and `sh -c "touch src/product.ts"` were ADMITTED during an active deep-interview phase, because a quoted nested script never matches the top-level mutator patterns and left no extracted target. extractBashTargets now recurses into literal `sh|bash|zsh -c` payloads (bounded depth, fail-closed beyond it). Verified: nested mutators now blocked with the real target; `bash -c "gjc deep-interview inspect ..."` still admitted.

2. Payload invariant recovery was unrunnable: it always printed `--op set --path <payload-path>`, but reported paths like `/component_updates/1/scores` are objects and `set` rejects non-leaf descriptors. Recovery is now operation-aware, emitting append-then-set-scalars for missing array items. Verified live: following the printed recovery verbatim takes the draft from invalid to valid.

Verification: 210 tests across 12 suites, tsc, biome, docs verifier, state-gates static, public-sync all pass.