### PR TITLE
feat(deep-interview): unified gjc deep-interview surface with runtime-owned state

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -95,14 +95,14 @@ If this raw bundled skill is loaded by GJC's native skill loader through `/skill
 
 ## Corrupt current-session state recovery
 
-When deep-interview detects its own current-session state is corrupt, tampered, unreadable, or stale on resume, run `gjc state clear --force --mode deep-interview` before reseeding or restarting. Scope the clear to the current session via `--session-id`, the command payload, or `GJC_SESSION_ID`; it clears only deep-interview state for that session and never clears other skills or sessions.
+When deep-interview detects its own current-session state is corrupt, tampered, unreadable, or stale on resume, run `gjc deep-interview clear --force` before reseeding or restarting. Scope the clear to the current session via `--session-id` or `GJC_SESSION_ID`; it clears only deep-interview state for that session and never clears other skills or sessions.
 
 ## Phase 0: Resolve Ambiguity Threshold (blocking prerequisite)
 
 Complete this phase before Phase 1, before brownfield exploration, before GJC state persistence, before Round 0, and before any ambiguity scoring. Do not continue if the resolved threshold and source are unknown.
 
 1. **Prefer pre-resolved native state**:
-   - First inspect active deep-interview state with `gjc state deep-interview read --json`.
+   - First inspect active deep-interview state with `gjc deep-interview read --json`.
    - If state contains a finite numeric `threshold` and a non-empty `threshold_source`, use those values, set `<resolvedThreshold>`, `<resolvedThresholdPercent>`, and `<resolvedThresholdSource>`, and skip optional settings-file reads. This is the normal `/skill:deep-interview` path because the native hook already resolved settings quietly before loading the skill.
 2. **Only if native state lacks a resolved threshold, read threshold settings in runtime precedence order**:
    - YAML config first: read the **single** modern config path the environment selects — `$GJC_CODING_AGENT_DIR/config.yml` when `GJC_CODING_AGENT_DIR` is set, else `$GJC_CONFIG_DIR/agent/config.yml` when `GJC_CONFIG_DIR` is set, else `~/.gjc/agent/config.yml`. Do not cascade through the other YAML locations when the selected one is absent or invalid.
@@ -120,19 +120,19 @@ Deep Interview threshold: <resolvedThresholdPercent> (source: <resolvedThreshold
 
 5. **Carry threshold source forward mechanically**:
    - Substitute `<resolvedThreshold>`, `<resolvedThresholdPercent>`, and `<resolvedThresholdSource>` throughout the remaining instructions before continuing.
-   - Include `threshold_source` in the first `gjc state write` payload and preserve it on later state updates; do not edit `.gjc/_session-{sessionid}/state` files directly unless an explicit force override is active.
+   - Include `threshold_source` in the first `gjc deep-interview write` payload and preserve it on later state updates; do not edit `.gjc/_session-{sessionid}/state` files directly unless an explicit force override is active.
    - Include both threshold and source in the final spec metadata.
 - Read any `language` object from active deep-interview state and carry `language.instruction` forward mechanically. If absent, default to English unless `{{ARGUMENTS}}` makes another user/session language obvious or the user explicitly requests another language. Do not add language-specific special cases.
 
 ## Phase 0.5: Suitability Gate
 
-Run this gate after the Phase 0 threshold marker and before Phase 1, brownfield exploration, `gjc state write`, Round 0, ambiguity scoring, or spec writing.
+Run this gate after the Phase 0 threshold marker and before Phase 1, brownfield exploration, `gjc deep-interview write`, Round 0, ambiguity scoring, or spec writing.
 
 If the user request appended after this skill as the final `User:` line is already clear, bounded, low-risk, and asks for a quick fix, single change, known file/symbol edit, explicit command, or direct answer:
 
 1. **Stop deep-interview immediately**:
-   - First inspect current-session state with `gjc state read --mode deep-interview --json` (include `--session-id <current-session-id>` when available).
-   - Clear through `gjc state clear --force --mode deep-interview --json` only when the state is a newly seeded empty interview: no recorded `rounds`, no `spec_path`, no `handoff_from`, no final/pending spec, and no user-confirmed topology.
+   - First inspect current-session state with `gjc deep-interview read --json` (include `--session-id <current-session-id>` when available).
+   - Clear through `gjc deep-interview clear --force --json` only when the state is a newly seeded empty interview: no recorded `rounds`, no `spec_path`, no `handoff_from`, no final/pending spec, and no user-confirmed topology.
    - If state already contains rounds, a spec path, handoff metadata, pending approval, or confirmed topology, do not clear it. Preserve the active interview and ask the user whether to continue, cancel, or explicitly clear the workflow.
    - Do not initialize deep-interview state.
    - Do not run Round 0.
@@ -181,7 +181,7 @@ Run this phase only when the active deep-interview state or invocation indicates
    - Preferred: pass the spec markdown **inline** to the native deep-interview write command (`--write … --spec "<markdown>"`) — no scratch file is needed. The CLI is the only sanctioned writer for `.gjc/_session-{sessionid}/specs`.
    - Only if a spec is too large to pass inline, stage it with the `write` tool to a system temp directory (`os.tmpdir()`/`$TMPDIR`, `/tmp`, `/var/tmp`) outside the project tree, then pass that path to `--spec`. The planning phase-boundary block tolerates these neutral temp writes; never stage interview artifacts inside the repo or under `.gjc/`, and do not improvise repo-relative scratch files.
 
-4. **Initialize state** via `gjc state write`:
+4. **Initialize state** via `gjc deep-interview write --input '<json>'`:
 
 ```json
 {
@@ -535,7 +535,7 @@ Then apply the self-proofread once (DIPP-5) to narrative status text, generated 
 
 ### Step 2e: Update State
 
-Update state in two phases. The `ask` answer is first recorded by the runtime as an `answered` shell. Scoring then enriches the same round record to `scored` with global scores, per-component `topology.components[].clarity_scores`, `topology.components[].weakest_dimension`, trigger metadata, established-facts changes, ontology snapshot, `topology.last_targeted_component_id`, `auto_researched_rounds`, `auto_answered_rounds`, and `architect_failures`. When `deepInterview` ask metadata is present, no manual per-round `gjc state write` is required for the answer shell; only scoring enrichment/state maintenance remains. For scoring enrichment and state maintenance, use the native staged-transition path and keep every payload **incremental**: stage only the delta for the current round (`--for record-round` with just the one round record carrying its `round_key`; the runtime merges it into the existing transcript by durable key), only the changed facts (`--for update-facts`), or only the changed maintenance fields (`--for merge-state`). Never resend the whole `rounds` array or the full state envelope — earlier rounds are already persisted, resending them is wasteful and racy, and the merge preserves them without your copy. Optionally dry-run with `check`, then commit with `apply`. Ambiguity is **runtime-owned**: `apply` derives `current_ambiguity` from the latest scored round and clamps it to the deterministic floor; report the round's scores and your raw `ambiguity` on the round record, then read the effective value back from the `apply`/`check` output (`current_ambiguity`/`result_ambiguity`) instead of hand-setting `state.current_ambiguity`. The session resolves from `GJC_SESSION_ID` automatically; exactly one draft is pending at a time, and a revision conflict at `apply` invalidates the draft with typed recovery — re-stage the same small delta against current state, never do revision arithmetic. When the staged path is unavailable or metadata is absent, use the legacy `gjc state write` path to persist the new round and never patch `.gjc/_session-{sessionid}/state` directly unless an explicit force override is active.
+Update state in two phases. The `ask` answer is first recorded by the runtime as an `answered` shell. Scoring then enriches the same round record to `scored` with global scores, per-component `topology.components[].clarity_scores`, `topology.components[].weakest_dimension`, trigger metadata, established-facts changes, ontology snapshot, `topology.last_targeted_component_id`, `auto_researched_rounds`, `auto_answered_rounds`, and `architect_failures`. When `deepInterview` ask metadata is present, no manual per-round write is required for the answer shell; only scoring enrichment/state maintenance remains. For scoring enrichment and state maintenance, use the native `gjc deep-interview` surface and keep every payload **incremental**: stage only the delta for the current round (`stage --for record-round` with just the one round record carrying its `round_key`; the runtime merges it into the existing transcript by durable key), only the changed facts (`--for update-facts`; facts merge losslessly by `id` — a one-fact patch never erases prior facts), or only the changed maintenance fields (`--for merge-state`). Never resend the whole `rounds` array or the full state envelope — earlier rounds are already persisted, resending them is wasteful and racy, and the merge preserves them without your copy. Optionally dry-run with `check`, then commit with `apply`; for a simple immediate update, `gjc deep-interview write --input '<json>'` is the one-shot equivalent (incremental merge; add `--reset` only when deliberately replacing state — the locked intent contract survives a reset). Ambiguity is **runtime-owned**: `apply`/`write` derive `current_ambiguity` from the latest scored round and clamp it to the deterministic floor; report the round's scores and your raw `ambiguity` on the round record, then read the effective value back from the command output (`current_ambiguity`/`result_ambiguity`) instead of hand-setting `state.current_ambiguity`. The session resolves from `GJC_SESSION_ID` automatically; exactly one draft is pending at a time, and a revision conflict at `apply` invalidates the draft with typed recovery — re-stage the same small delta against current state, never do revision arithmetic. Never patch `.gjc/_session-{sessionid}/state` directly unless an explicit force override is active.
 Also recompute and persist `ambiguity_milestone` each round (detect band transitions for the Phase 3 panel), and persist `auto_answer_streak`, `refined_rounds`, `lateral_reviews`, and `lateral_panel_failures` alongside the existing fields.
 
 ### Step 2f: Check Tiered Confirmation Cadence
@@ -752,10 +752,10 @@ After the spec is written, mark it `pending approval` and present execution opti
 
 ### Phase 5b: Handoff before chain
 
-Before invoking `/skill:ralplan`, `/skill:team`, or `/skill:ultragoal`, the final spec must already be persisted through the native deep-interview write command. For ordinary user-selected handoff, mark deep-interview ready for the skill tool's chain guard:
+Before invoking `/skill:ralplan`, `/skill:team`, or `/skill:ultragoal`, the final spec must already be persisted through the native deep-interview write command (`gjc deep-interview --write --stage final …`). That command itself moves the workflow to the `handoff` phase, so no separate state write is needed for the skill tool's chain guard. Verify readiness with:
 
 ```
-gjc state deep-interview write --input '{"current_phase":"handoff"}' --json
+gjc deep-interview read --json
 ```
 
 For a preselected deliberate ralplan path, prefer the single sanctioned bridge command instead:
@@ -800,7 +800,7 @@ Skipping any stage is possible but reduces quality assurance:
 - Use `read/search/find exploration or a bounded read-only planner/architect subagent` for brownfield codebase exploration (run BEFORE asking user about codebase)
 - Use opus model (temperature 0.1) for ambiguity scoring — consistency is critical
 - Round 0 topology confirmation happens before ambiguity scoring; Phase 2 scoring must honor locked topology and rotate targeting across active components when more than one is present
-- Use `gjc state write` / `gjc state read` for interview state persistence; the initial and subsequent deep-interview state payloads must include `threshold_source` alongside `threshold`; do not edit `.gjc/_session-{sessionid}/state` directly without force override. For incremental scoring/maintenance updates, prefer the deep-interview staged-transition verbs (`stage --for <transition> --input '<json>'`, `check`, `apply`, `discard`) — stage only the current delta (one round record by `round_key`, changed facts, or changed fields), never the whole transcript; the session is inherited from `GJC_SESSION_ID`, revision CAS is runtime-owned, and the effective `current_ambiguity` is derived and clamped by the CLI at `apply` — read it from the command output rather than setting it yourself.
+- Use `gjc deep-interview write` / `gjc deep-interview read` for interview state persistence; the initial and subsequent deep-interview state payloads must include `threshold_source` alongside `threshold`; do not edit `.gjc/_session-{sessionid}/state` directly without force override. For incremental scoring/maintenance updates, prefer the staged-transition verbs (`stage --for <transition> --input '<json>'`, `check`, `apply`, `discard`) — stage only the current delta (one round record by `round_key`, changed facts, or changed fields), never the whole transcript; `write` is incremental by default and replaces only with an explicit `--reset`; the session is inherited from `GJC_SESSION_ID`, revision CAS is runtime-owned, and the effective `current_ambiguity` is derived and clamped by the CLI at `apply`/`write` — read it from the command output rather than setting it yourself.
 - Use the GJC workflow CLI to save the final spec at `.gjc/_session-{sessionid}/specs/deep-interview-{slug}.md` exactly; do not use `write`, `edit`, or `ast_edit` directly on `.gjc/` paths without force override.
 - Use public GJC workflow entrypoints to bridge to ralplan, ultragoal, or team only after explicit execution approval — never implement directly. Implementation handoff defaults to ultragoal; reserve team for when tmux-based interactive worker parallelization is genuinely required.
 - The lateral-review panel spawns read-only persona subagents (Task tool) in parallel with independent context; it is an assist layer, never an executor and never the completion authority
@@ -942,7 +942,7 @@ Optional settings in `.gjc/settings.json`:
 
 ## Resume
 
-If interrupted, run `/skill:deep-interview` again. The skill resumes from GJC workflow state via `gjc state read`; do not read or edit `.gjc/_session-{sessionid}/state` files directly unless an explicit force override is active.
+If interrupted, run `/skill:deep-interview` again. The skill resumes from GJC workflow state via `gjc deep-interview read`; do not read or edit `.gjc/_session-{sessionid}/state` files directly unless an explicit force override is active.
 
 ## Integration with staged team routing
 

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-stage.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-stage.ts
@@ -317,6 +317,38 @@ function draftIsStale(draft: DeepInterviewStageDraft, current: CurrentState): bo
 }
 
 /**
+ * Lossless keyed merge for `state.established_facts` under the staged surface.
+ * The generic envelope merge replaces the whole facts array; the staged contract
+ * is delta-only, so a one-fact patch must never erase prior confirmed/disputed
+ * facts (they carry the deterministic-floor evidence). Facts with an `id` merge
+ * field-wise by id; facts without an id are appended with exact-duplicate dedup.
+ * Staged deltas can never hard-delete a fact — dispute/supersede instead.
+ */
+function mergeEstablishedFacts(existing: readonly unknown[], incoming: readonly unknown[]): Record<string, unknown>[] {
+	const result: Record<string, unknown>[] = [];
+	const indexById = new Map<string, number>();
+	const add = (value: unknown): void => {
+		if (!isPlainObject(value)) return;
+		const id = typeof value.id === "string" && value.id.trim() !== "" ? value.id : undefined;
+		if (id !== undefined) {
+			const existingIndex = indexById.get(id);
+			if (existingIndex === undefined) {
+				indexById.set(id, result.length);
+				result.push({ ...value });
+			} else {
+				result[existingIndex] = { ...result[existingIndex], ...value };
+			}
+			return;
+		}
+		if (result.some(item => JSON.stringify(item) === JSON.stringify(value))) return;
+		result.push({ ...value });
+	};
+	for (const fact of existing) add(fact);
+	for (const fact of incoming) add(fact);
+	return result;
+}
+
+/**
  * The single merge both `check` and `apply` execute. `check` reports its result;
  * `apply` persists it. Divergence between the two is structurally impossible.
  *
@@ -347,7 +379,17 @@ function computeMergedEnvelope(
 	merged.version = WORKFLOW_STATE_VERSION;
 	if (typeof merged.current_phase !== "string" || !merged.current_phase) merged.current_phase = "interviewing";
 	merged.session_id = draft.session_id;
-	merged = deriveRuntimeAmbiguity(merged);
+	// Staged facts are deltas: re-merge against the prior facts losslessly so a
+	// one-fact patch cannot erase confirmed/disputed history (#3387 finding 2).
+	const mergedState = isPlainObject(merged.state) ? (merged.state as Record<string, unknown>) : undefined;
+	const priorState = isPlainObject(current.state) ? (current.state as Record<string, unknown>) : undefined;
+	if (mergedState && priorState && Array.isArray(priorState.established_facts)) {
+		mergedState.established_facts = mergeEstablishedFacts(
+			priorState.established_facts,
+			Array.isArray(mergedState.established_facts) ? mergedState.established_facts : [],
+		);
+	}
+	merged = deriveRuntimeAmbiguity(merged, current);
 	try {
 		assertDeepInterviewEnvelopeInputLimits(merged);
 	} catch (error) {
@@ -361,26 +403,39 @@ function computeMergedEnvelope(
 }
 
 /**
- * Derive `state.current_ambiguity` from the latest scored round, then enforce the
- * deterministic floor. The CLI — not the agent — owns the effective ambiguity.
+ * Derive `state.current_ambiguity` — the CLI, not the agent, owns the effective
+ * ambiguity. A staged `state.current_ambiguity` is never trusted directly:
+ * - with a valid latest scored round (finite numeric `round` AND finite
+ *   `ambiguity`), the value derives from that round;
+ * - with no valid scored evidence, the PRIOR persisted value is retained (a
+ *   fresh interview keeps its seeded 1.0 — a staged 0.01 cannot survive);
+ * then the deterministic floor is recomputed and clamped.
  */
-function deriveRuntimeAmbiguity(merged: Record<string, unknown>): Record<string, unknown> {
+function deriveRuntimeAmbiguity(
+	merged: Record<string, unknown>,
+	previousState: Record<string, unknown>,
+): Record<string, unknown> {
 	const state = isPlainObject(merged.state) ? (merged.state as Record<string, unknown>) : undefined;
 	if (state) {
 		const rounds = Array.isArray(state.rounds) ? state.rounds.filter(isPlainObject) : [];
 		let latestScored: Record<string, unknown> | undefined;
 		for (const round of rounds) {
-			if (round.lifecycle !== "scored" || typeof round.ambiguity !== "number") continue;
-			if (
-				!latestScored ||
-				(typeof round.round === "number" &&
-					typeof latestScored.round === "number" &&
-					round.round >= latestScored.round)
-			) {
-				latestScored = round;
-			}
+			if (round.lifecycle !== "scored") continue;
+			if (typeof round.ambiguity !== "number" || !Number.isFinite(round.ambiguity)) continue;
+			if (typeof round.round !== "number" || !Number.isFinite(round.round)) continue;
+			if (!latestScored || round.round >= (latestScored.round as number)) latestScored = round;
 		}
-		if (latestScored) state.current_ambiguity = latestScored.ambiguity;
+		if (latestScored) {
+			state.current_ambiguity = latestScored.ambiguity;
+		} else {
+			// No valid scored evidence in the merged state: the staged value is
+			// discarded and the prior runtime-owned value (seed default 1.0) holds.
+			const prior = isPlainObject(previousState.state)
+				? (previousState.state as Record<string, unknown>).current_ambiguity
+				: undefined;
+			if (typeof prior === "number" && Number.isFinite(prior)) state.current_ambiguity = prior;
+			else delete state.current_ambiguity;
+		}
 	}
 	return applyAmbiguityFloorToEnvelope(merged).envelope as Record<string, unknown>;
 }
@@ -655,10 +710,170 @@ async function handleDiscard(args: readonly string[], cwd: string): Promise<Reco
 }
 
 // -----------------------------------------------------------------------------
+// Direct verbs: read / write / clear / handoff
+// -----------------------------------------------------------------------------
+
+async function handleRead(args: readonly string[], cwd: string): Promise<Record<string, unknown>> {
+	const sessionId = resolveStageSession(args, cwd);
+	const current = await readCurrentState(cwd, sessionId);
+	if (!current.exists) {
+		return {
+			ok: true,
+			verb: "read",
+			session_id: sessionId,
+			exists: false,
+			state_path: statePathFor(cwd, sessionId),
+		};
+	}
+	const draftRead = await readDraft(cwd, sessionId);
+	return {
+		ok: true,
+		verb: "read",
+		session_id: sessionId,
+		exists: true,
+		state_path: statePathFor(cwd, sessionId),
+		revision: current.revision,
+		content_sha256: current.sha256,
+		envelope: current.value,
+		...(draftRead.kind === "valid"
+			? {
+					pending_draft: {
+						draft_id: draftRead.draft.draft_id,
+						transition: draftRead.draft.transition,
+						created_at: draftRead.draft.created_at,
+					},
+				}
+			: {}),
+	};
+}
+
+/**
+ * Direct write: an immediate stage+apply of one sanitized JSON payload —
+ * incremental merge by default, whole-state replacement with `--reset` (the
+ * locked intent contract survives a reset through the merge's immutability
+ * guard). Uses the same lock, sanitizer, merge, ambiguity derivation, and
+ * guarded revision-stamping writer as the staged path, so `write` cannot
+ * express anything `stage`+`apply` could not.
+ */
+async function handleWrite(args: readonly string[], cwd: string): Promise<Record<string, unknown>> {
+	const rawInput = flagValue(args, "--input");
+	if (rawInput === undefined || rawInput === "") {
+		throw new DeepInterviewStageError("DI_STAGE_USAGE", "--input '<json>' (or @file) is required for write");
+	}
+	const rawPayload = await parseJsonInput(rawInput, cwd);
+	const sessionId = resolveStageSession(args, cwd, rawPayload.session_id);
+	const reset = hasFlag(args, "--reset");
+	const { payload, ignoredKeys } = sanitizeStagedPayload(rawPayload);
+	assertCorePayloadSchema(payload);
+
+	const statePath = statePathFor(cwd, sessionId);
+	return withWorkflowStateLock(
+		statePath,
+		async () => {
+			const pendingDraft = await readDraft(cwd, sessionId);
+			if (pendingDraft.kind === "valid") {
+				throw new DeepInterviewStageError(
+					"DI_STAGE_DRAFT_EXISTS",
+					`a staged draft is pending (draft_id=${pendingDraft.draft.draft_id}); direct write would race it`,
+					"apply it (`gjc deep-interview apply`) or discard it (`gjc deep-interview discard`) first",
+				);
+			}
+			const current = await readCurrentState(cwd, sessionId);
+			const nowIso = new Date().toISOString();
+			const syntheticDraft: DeepInterviewStageDraft = {
+				version: DRAFT_VERSION,
+				draft_id: randomUUID(),
+				session_id: sessionId,
+				transition: "merge-state",
+				staged_against_revision: current.revision,
+				staged_against_sha256: current.sha256,
+				payload,
+				created_at: nowIso,
+			};
+			// --reset replaces: merge against an empty base but re-lock the intent
+			// contract from prior state through the merge's own immutability guard.
+			const base = reset
+				? (() => {
+						const priorState = isPlainObject(current.value.state)
+							? (current.value.state as Record<string, unknown>)
+							: {};
+						return priorState.intent_contract !== undefined
+							? { state: { intent_contract: priorState.intent_contract, intent_contract_required: true } }
+							: {};
+					})()
+				: current.value;
+			const merged = computeMergedEnvelope(base as Record<string, unknown>, syntheticDraft, nowIso);
+			merged.last_applied_draft_id = syntheticDraft.draft_id;
+			const written = await writeGuardedWorkflowEnvelopeAtomic(statePath, merged, {
+				cwd,
+				policy: "source",
+				expectedRevision: current.revision,
+				lockHeld: true,
+				receipt: {
+					cwd,
+					skill: "deep-interview",
+					owner: "gjc-runtime",
+					command: `gjc deep-interview write${reset ? " --reset" : ""}`,
+					sessionId,
+					nowIso,
+					mutationId: syntheticDraft.draft_id,
+				},
+				audit: {
+					category: "state",
+					verb: reset ? "write-reset" : "write-incremental",
+					owner: "gjc-runtime",
+					skill: "deep-interview",
+					sessionId,
+					mutationId: syntheticDraft.draft_id,
+				},
+			});
+			await writeSessionActivityMarker(cwd, sessionId, { writer: "deep-interview-stage", path: statePath });
+			const writtenState = isPlainObject(merged.state) ? (merged.state as Record<string, unknown>) : {};
+			return {
+				ok: true,
+				verb: "write",
+				mode: reset ? "reset" : "incremental",
+				session_id: sessionId,
+				applied_revision: written.revision,
+				state_path: statePath,
+				...(typeof writtenState.current_ambiguity === "number"
+					? { current_ambiguity: writtenState.current_ambiguity }
+					: {}),
+				...(ignoredKeys.length > 0 ? { ignored_runtime_owned_keys: ignoredKeys } : {}),
+			};
+		},
+		{ cwd },
+	);
+}
+
+/** Thin lifecycle passthroughs: same runtime plumbing, gjc deep-interview surface. */
+async function handleLifecyclePassthrough(
+	verb: "clear" | "handoff",
+	args: readonly string[],
+	cwd: string,
+): Promise<DeepInterviewStageCommandResult> {
+	const { runNativeStateCommand } = await import("./state-runtime");
+	const forwarded =
+		verb === "clear"
+			? ["clear", "--mode", "deep-interview", ...args]
+			: ["handoff", "--mode", "deep-interview", ...args];
+	return runNativeStateCommand([...forwarded], cwd);
+}
+
+// -----------------------------------------------------------------------------
 // Dispatch
 // -----------------------------------------------------------------------------
 
-export const DEEP_INTERVIEW_STAGE_VERBS = ["stage", "check", "apply", "discard"] as const;
+export const DEEP_INTERVIEW_STAGE_VERBS = [
+	"stage",
+	"check",
+	"apply",
+	"discard",
+	"read",
+	"write",
+	"clear",
+	"handoff",
+] as const;
 export type DeepInterviewStageVerb = (typeof DEEP_INTERVIEW_STAGE_VERBS)[number];
 
 export function isDeepInterviewStageVerb(value: string | undefined): value is DeepInterviewStageVerb {
@@ -686,6 +901,15 @@ export async function runDeepInterviewStageCommand(
 			case "discard":
 				summary = await handleDiscard(args, cwd);
 				break;
+			case "read":
+				summary = await handleRead(args, cwd);
+				break;
+			case "write":
+				summary = await handleWrite(args, cwd);
+				break;
+			case "clear":
+			case "handoff":
+				return await handleLifecyclePassthrough(verb, args, cwd);
 		}
 		const status = summary.ok === false ? 3 : 0;
 		const stdout = json

--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -782,6 +782,7 @@ async function persistActiveRunId(cwd: string, sessionId: string, runId: string,
 			existing.updated_at = new Date().toISOString();
 			await writeWorkflowEnvelopeAtomic(statePath, existing, {
 				cwd,
+				lockHeld: true,
 				receipt: { cwd, skill: "ralplan", owner: "gjc-runtime", command: "gjc ralplan persist-run-id", sessionId },
 				audit: { category: "state", verb: "write", owner: "gjc-runtime", skill: "ralplan", sessionId },
 			});
@@ -1036,6 +1037,7 @@ async function applyPersistedRoleStateUpdate(
 			existing.updated_at = new Date().toISOString();
 			await writeWorkflowEnvelopeAtomic(statePath, existing, {
 				cwd,
+				lockHeld: true,
 				receipt: {
 					cwd,
 					skill: "ralplan",
@@ -1083,6 +1085,7 @@ async function applyLaneVerdictUpdate(
 			existing.updated_at = new Date().toISOString();
 			await writeWorkflowEnvelopeAtomic(statePath, existing, {
 				cwd,
+				lockHeld: true,
 				receipt: { cwd, skill: "ralplan", owner: "gjc-runtime", command: "gjc ralplan lane-verdict", sessionId },
 				audit: { category: "state", verb: "write", owner: "gjc-runtime", skill: "ralplan", sessionId },
 			});

--- a/packages/coding-agent/src/gjc-runtime/state-writer.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-writer.ts
@@ -96,7 +96,6 @@ export interface GuardedStateWriterOptions extends StateWriterOptions {
 	policy: StateWritePolicy;
 	expectedRevision?: number;
 	sourceRevision?: number;
-	lockHeld?: boolean;
 }
 
 export type GuardedWriteResult =
@@ -114,6 +113,11 @@ export interface StateWriterOptions {
 	 * `withFileLock` defaults.
 	 */
 	lock?: FileLockOptions;
+	/**
+	 * Caller already holds the workflow state lock for this target path (via
+	 * `withWorkflowStateLock`). Skip re-acquisition to avoid self-deadlock.
+	 */
+	lockHeld?: boolean;
 }
 
 export class StateWriteConflictError extends Error {
@@ -681,63 +685,71 @@ export async function writeWorkflowEnvelopeAtomic(
 	options?: StateWriterOptions,
 ): Promise<string> {
 	const filePath = resolveGjcTarget(targetPath, cwdForOptions(options));
-	const withReceipt = withWorkflowReceipt(value, buildReceipt(options));
-	const stamped = stampWorkflowEnvelopeChecksum(withReceipt, filePath);
-	const parsed = RequiredOnWriteEnvelopeSchema.safeParse(stamped);
-	if (!parsed.success) {
-		throw new Error(
-			`Refusing to write invalid workflow state envelope to ${filePath}: ${parsed.error.issues
-				.map(issue => `${issue.path.join(".") || "<root>"}: ${issue.message}`)
-				.join("; ")}`,
-		);
-	}
-	// #658: internal runtime writers (ralplan/ultragoal/deep-interview/team) persist
-	// envelopes directly, bypassing the `gjc state` CLI transition gate (`isValidTransition`,
-	// historically the sole call site in state-runtime.ts). Re-assert that gate on every
-	// sanctioned envelope write so internal writes cannot persist invalid state-machine phase
-	// transitions silently. Forced writes (`gjc state ... --force`, reconcile repairs) carry
-	// `audit.forced` and bypass, mirroring the CLI's `use --force to bypass`.
-	//
-	// The gate governs ACTIVE workflow progression only. Deactivation/teardown writes
-	// (`active: false`, e.g. `gjc state clear`, which persists the universal `complete`
-	// sentinel that is not a per-skill manifest state) leave the transition graph and are
-	// intentionally exempt.
-	if (options?.audit?.forced !== true && parsed.data.active === true) {
-		const toPhase = parsed.data.current_phase.trim();
-		if (toPhase) {
-			// Lazy import: workflow-manifest dereferences CANONICAL_GJC_WORKFLOW_SKILLS at
-			// module load, and active-state -> state-writer -> workflow-manifest -> active-state
-			// is a load-time cycle. Importing at call time (after init) avoids the TDZ.
-			const { isKnownWorkflowState, isValidTransition } = await import("./workflow-manifest");
-			const skill = parsed.data.skill;
-			// Structural invariant (hard): a `current_phase` absent from the skill's manifest is
-			// never a legitimate internal write, matching the CLI/reconcile unknown-phase gate.
-			if (!isKnownWorkflowState(skill, toPhase)) {
-				throw new Error(
-					`Refusing to write unknown ${skill} phase "${toPhase}" to ${filePath}: not a known ${skill} manifest state (forced writes bypass via audit.forced)`,
-				);
-			}
-			// Transition invariant (#658, diagnostic-only safety net): resolve the prior phase
-			// (caller-supplied `audit.fromPhase`, else the active persisted envelope on disk) and
-			// flag edges the manifest does not define. Intentionally NON-blocking and audit-only
-			// — the CLI path already hard-fails invalid edges before reaching here, and legitimate
-			// internal repairs / ralplan short-mode stage skips move between valid states without a
-			// direct manifest edge. It records an `invalid_transition_detected` audit entry (no
-			// stderr) so such transitions are non-silent without breaking those flows.
-			const fromPhase = (options?.audit?.fromPhase ?? (await readPersistedPhase(filePath)))?.trim();
-			if (
-				fromPhase &&
-				fromPhase !== toPhase &&
-				isKnownWorkflowState(skill, fromPhase) &&
-				!isValidTransition(skill, fromPhase, toPhase)
-			) {
-				await recordInvalidWorkflowTransition({ filePath, skill, fromPhase, toPhase, options });
+	const write = async (): Promise<string> => {
+		const withReceipt = withWorkflowReceipt(value, buildReceipt(options));
+		const stamped = stampWorkflowEnvelopeChecksum(withReceipt, filePath);
+		const parsed = RequiredOnWriteEnvelopeSchema.safeParse(stamped);
+		if (!parsed.success) {
+			throw new Error(
+				`Refusing to write invalid workflow state envelope to ${filePath}: ${parsed.error.issues
+					.map(issue => `${issue.path.join(".") || "<root>"}: ${issue.message}`)
+					.join("; ")}`,
+			);
+		}
+		// #658: internal runtime writers (ralplan/ultragoal/deep-interview/team) persist
+		// envelopes directly, bypassing the `gjc state` CLI transition gate (`isValidTransition`,
+		// historically the sole call site in state-runtime.ts). Re-assert that gate on every
+		// sanctioned envelope write so internal writes cannot persist invalid state-machine phase
+		// transitions silently. Forced writes (`gjc state ... --force`, reconcile repairs) carry
+		// `audit.forced` and bypass, mirroring the CLI's `use --force to bypass`.
+		//
+		// The gate governs ACTIVE workflow progression only. Deactivation/teardown writes
+		// (`active: false`, e.g. `gjc state clear`, which persists the universal `complete`
+		// sentinel that is not a per-skill manifest state) leave the transition graph and are
+		// intentionally exempt.
+		if (options?.audit?.forced !== true && parsed.data.active === true) {
+			const toPhase = parsed.data.current_phase.trim();
+			if (toPhase) {
+				// Lazy import: workflow-manifest dereferences CANONICAL_GJC_WORKFLOW_SKILLS at
+				// module load, and active-state -> state-writer -> workflow-manifest -> active-state
+				// is a load-time cycle. Importing at call time (after init) avoids the TDZ.
+				const { isKnownWorkflowState, isValidTransition } = await import("./workflow-manifest");
+				const skill = parsed.data.skill;
+				// Structural invariant (hard): a `current_phase` absent from the skill's manifest is
+				// never a legitimate internal write, matching the CLI/reconcile unknown-phase gate.
+				if (!isKnownWorkflowState(skill, toPhase)) {
+					throw new Error(
+						`Refusing to write unknown ${skill} phase "${toPhase}" to ${filePath}: not a known ${skill} manifest state (forced writes bypass via audit.forced)`,
+					);
+				}
+				// Transition invariant (#658, diagnostic-only safety net): resolve the prior phase
+				// (caller-supplied `audit.fromPhase`, else the active persisted envelope on disk) and
+				// flag edges the manifest does not define. Intentionally NON-blocking and audit-only
+				// — the CLI path already hard-fails invalid edges before reaching here, and legitimate
+				// internal repairs / ralplan short-mode stage skips move between valid states without a
+				// direct manifest edge. It records an `invalid_transition_detected` audit entry (no
+				// stderr) so such transitions are non-silent without breaking those flows.
+				const fromPhase = (options?.audit?.fromPhase ?? (await readPersistedPhase(filePath)))?.trim();
+				if (
+					fromPhase &&
+					fromPhase !== toPhase &&
+					isKnownWorkflowState(skill, fromPhase) &&
+					!isValidTransition(skill, fromPhase, toPhase)
+				) {
+					await recordInvalidWorkflowTransition({ filePath, skill, fromPhase, toPhase, options });
+				}
 			}
 		}
-	}
-	await atomicWrite(filePath, jsonText(stamped));
-	await maybeAudit(filePath, options);
-	return filePath;
+		await atomicWrite(filePath, jsonText(stamped));
+		await maybeAudit(filePath, options);
+		return filePath;
+	};
+	// Serialize with every other writer of the same state path. Without this, a
+	// revision-preserving envelope write (seed/spec persistence) can interleave
+	// inside a staged apply's check-then-write window and be silently overwritten
+	// (#3387 architect finding 1). Callers already inside `withWorkflowStateLock`
+	// for this path pass `lockHeld: true`.
+	return options?.lockHeld ? write() : lockResolvedWorkflowTarget(filePath, write, options?.lock);
 }
 
 export async function writeTextAtomic(targetPath: string, text: string, options?: StateWriterOptions): Promise<string> {

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
@@ -114,7 +114,9 @@
           "stage",
           "check",
           "apply",
-          "discard"
+          "discard",
+          "read",
+          "write"
         ],
         "name": "session-id",
         "type": "string"
@@ -264,18 +266,28 @@
           "stage",
           "check",
           "apply",
-          "discard"
+          "discard",
+          "read",
+          "write"
         ],
         "name": "json",
         "type": "boolean"
       },
       {
         "appliesToVerbs": [
-          "stage"
+          "stage",
+          "write"
         ],
         "name": "input",
         "required": true,
         "type": "string"
+      },
+      {
+        "appliesToVerbs": [
+          "write"
+        ],
+        "name": "reset",
+        "type": "boolean"
       },
       {
         "appliesToVerbs": [
@@ -349,6 +361,14 @@
       },
       {
         "name": "discard",
+        "surface": "command-positional"
+      },
+      {
+        "name": "read",
+        "surface": "command-positional"
+      },
+      {
+        "name": "write",
         "surface": "command-positional"
       },
       {
@@ -584,7 +604,9 @@
           "stage",
           "check",
           "apply",
-          "discard"
+          "discard",
+          "read",
+          "write"
         ],
         "name": "session-id",
         "type": "string"
@@ -976,7 +998,9 @@
           "stage",
           "check",
           "apply",
-          "discard"
+          "discard",
+          "read",
+          "write"
         ],
         "name": "session-id",
         "type": "string"
@@ -1466,7 +1490,9 @@
           "stage",
           "check",
           "apply",
-          "discard"
+          "discard",
+          "read",
+          "write"
         ],
         "name": "session-id",
         "type": "string"

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
@@ -75,7 +75,18 @@ const COMMON_TYPED_ARGS: TypedArgSpec[] = [
 	{
 		name: "session-id",
 		type: "string",
-		appliesToVerbs: [...STATE_VERBS, "kickoff", "write-spec", "write-artifact", "stage", "check", "apply", "discard"],
+		appliesToVerbs: [
+			...STATE_VERBS,
+			"kickoff",
+			"write-spec",
+			"write-artifact",
+			"stage",
+			"check",
+			"apply",
+			"discard",
+			"read",
+			"write",
+		],
 	},
 	{ name: "thread-id", type: "string", appliesToVerbs: ["write", "clear", "handoff"] },
 	{ name: "turn-id", type: "string", appliesToVerbs: ["write", "clear", "handoff"] },
@@ -167,7 +178,7 @@ export const WORKFLOW_MANIFEST: Record<CanonicalGjcWorkflowSkill, SkillManifest>
 		verbs: [
 			...stateVerbs(),
 			...flagVerbs(["kickoff", "write-spec"]),
-			...positionalVerbs(["stage", "check", "apply", "discard"]),
+			...positionalVerbs(["stage", "check", "apply", "discard", "read", "write"]),
 			...plannedVerbs(PLANNED_ADMIN_VERBS),
 		],
 		typedArgs: [
@@ -181,8 +192,13 @@ export const WORKFLOW_MANIFEST: Record<CanonicalGjcWorkflowSkill, SkillManifest>
 			{ name: "spec", type: "string", required: true, appliesToVerbs: ["write-spec"] },
 			{ name: "handoff", type: "enum", enumValues: ["ralplan"], appliesToVerbs: ["write-spec"] },
 			{ name: "deliberate", type: "boolean", appliesToVerbs: ["write-spec"] },
-			{ name: "json", type: "boolean", appliesToVerbs: ["write-spec", "stage", "check", "apply", "discard"] },
-			{ name: "input", type: "string", required: true, appliesToVerbs: ["stage"] },
+			{
+				name: "json",
+				type: "boolean",
+				appliesToVerbs: ["write-spec", "stage", "check", "apply", "discard", "read", "write"],
+			},
+			{ name: "input", type: "string", required: true, appliesToVerbs: ["stage", "write"] },
+			{ name: "reset", type: "boolean", appliesToVerbs: ["write"] },
 			{
 				name: "for",
 				type: "enum",

--- a/packages/coding-agent/test/deep-interview-skill-contract.test.ts
+++ b/packages/coding-agent/test/deep-interview-skill-contract.test.ts
@@ -71,8 +71,8 @@ describe("deep-interview simple-request escape hatch", () => {
 
 		const suitabilityGate = steps.slice(suitabilityGateIndex, initializeIndex);
 		expect(suitabilityGate).toMatch(/clear,\s+bounded,\s+low-risk/i);
-		expect(suitabilityGate).toContain("gjc state read --mode deep-interview --json");
-		expect(suitabilityGate).toContain("gjc state clear --force --mode deep-interview");
+		expect(suitabilityGate).toContain("gjc deep-interview read --json");
+		expect(suitabilityGate).toContain("gjc deep-interview clear --force");
 		expect(suitabilityGate).toMatch(/newly seeded empty interview/i);
 		expect(suitabilityGate).toMatch(/no recorded `rounds`[\s\S]*no `spec_path`[\s\S]*no `handoff_from`/i);
 		expect(suitabilityGate).toMatch(/If state already contains rounds[\s\S]*do not clear it/i);

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -538,7 +538,14 @@ Project executor override body.
 		expect(content).toContain("`gjc ralplan` is a native CLI");
 		expect(content).toContain("Direct `.gjc/` file edits are forbidden unless an explicit force override is active");
 		expect(content).toContain("do not edit `.gjc/_session-{sessionid}/state` directly without force override");
-		expect(content).toContain("gjc state clear --force --mode deep-interview");
+		expect(content).toContain("gjc deep-interview clear --force");
+		expect(content).toContain("gjc deep-interview read --json");
+		expect(content).toContain("gjc deep-interview write --input");
+		expect(content).toContain("`--reset` only when deliberately replacing state");
+		expect(content).not.toContain("gjc state read");
+		expect(content).not.toContain("gjc state write");
+		expect(content).not.toContain("gjc state clear");
+		expect(content).not.toContain("gjc state deep-interview");
 		expect(content).toContain("default `0.05`");
 		expect(content).toContain("language.instruction");
 		expect(content).toContain(
@@ -560,7 +567,6 @@ Project executor override body.
 			"Skill(",
 			"gajae-code:",
 			"/gajae-code",
-			"gjc deep-interview",
 		]) {
 			expect(content).not.toContain(forbidden);
 		}

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-stage.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-stage.test.ts
@@ -59,8 +59,15 @@ describe("deep-interview staged transitions", () => {
 			"--input",
 			JSON.stringify({
 				state: {
-					rounds: [{ round: 1, round_key: "r1", question_text: "What output format?", lifecycle: "answered" }],
-					current_ambiguity: 0.42,
+					rounds: [
+						{
+							round: 1,
+							round_key: "r1",
+							question_text: "What output format?",
+							lifecycle: "scored",
+							ambiguity: 0.42,
+						},
+					],
 					free_form_note: "flexible fields survive",
 				},
 			}),
@@ -515,5 +522,235 @@ describe("deep-interview staged transitions", () => {
 		expect(parse(oversized.stderr)).toMatchObject({ ok: false, code: "DI_STAGE_INPUT_INVALID" });
 		const dirInput = await run(root, ["stage", "--for", "merge-state", "--input", `@${root}`, "--json"]);
 		expect(parse(dirInput.stderr)).toMatchObject({ ok: false, code: "DI_STAGE_INPUT_INVALID" });
+	});
+
+	it("retains prior ambiguity when a staged patch has no valid scored round", async () => {
+		const root = await tempDir();
+		await seed(root);
+		// Seeded state carries current_ambiguity 1.0; a bare hand-set 0.01 with no
+		// scored round must NOT survive.
+		await run(root, [
+			"stage",
+			"--for",
+			"merge-state",
+			"--input",
+			JSON.stringify({ state: { current_ambiguity: 0.01 } }),
+			"--json",
+		]);
+		const applied = parse((await run(root, ["apply", "--json"])).stdout);
+		expect(applied.current_ambiguity).toBe(1);
+		const after = await readState(root);
+		expect((after.state as Record<string, unknown>).current_ambiguity).toBe(1);
+	});
+
+	it("ignores malformed scored rounds when deriving ambiguity", async () => {
+		const root = await tempDir();
+		await seed(root);
+		await run(root, [
+			"stage",
+			"--for",
+			"record-round",
+			"--input",
+			JSON.stringify({
+				state: {
+					rounds: [
+						// Malformed: scored lifecycle but no numeric round.
+						{ round_key: "bogus", lifecycle: "scored", ambiguity: 0.01 },
+						{ round: 1, round_key: "r1", lifecycle: "scored", ambiguity: 0.55 },
+					],
+				},
+			}),
+			"--json",
+		]);
+		const applied = parse((await run(root, ["apply", "--json"])).stdout);
+		expect(applied.current_ambiguity).toBe(0.55);
+	});
+
+	it("preserves prior facts across a one-fact staged delta", async () => {
+		const root = await tempDir();
+		await seed(root);
+		// Establish two facts, one disputed (holds the floor at 0.10).
+		await run(root, [
+			"stage",
+			"--for",
+			"update-facts",
+			"--input",
+			JSON.stringify({
+				state: {
+					established_facts: [
+						{ id: "f1", statement: "confirmed fact", round: 1, disputed: false },
+						{ id: "f2", statement: "disputed fact", round: 1, disputed: true },
+					],
+				},
+			}),
+			"--json",
+		]);
+		await run(root, ["apply", "--json"]);
+		// Delta: add ONE new fact — f1/f2 must survive.
+		await run(root, [
+			"stage",
+			"--for",
+			"update-facts",
+			"--input",
+			JSON.stringify({
+				state: { established_facts: [{ id: "f3", statement: "new fact", round: 2, disputed: false }] },
+			}),
+			"--json",
+		]);
+		const applied = parse((await run(root, ["apply", "--json"])).stdout);
+		const after = await readState(root);
+		const facts = (after.state as Record<string, unknown>).established_facts as Record<string, unknown>[];
+		expect(facts.map(f => f.id).sort()).toEqual(["f1", "f2", "f3"]);
+		expect(facts.find(f => f.id === "f2")?.disputed).toBe(true);
+		// No scored round exists, so the prior seeded ambiguity (1.0) is retained;
+		// the disputed-fact floor is recorded as pressure evidence.
+		expect(applied.current_ambiguity).toBe(1);
+		const floorInfo = (after.state as Record<string, unknown>).ambiguity_floor as Record<string, unknown>;
+		expect(floorInfo.disputed_fact_count).toBe(1);
+		expect(floorInfo.floor).toBe(0.1);
+		// Field-wise update by id: supersede the disputed fact, floor releases.
+		await run(root, [
+			"stage",
+			"--for",
+			"update-facts",
+			"--input",
+			JSON.stringify({
+				state: { established_facts: [{ id: "f2", disputed: false, superseded_by: "f3" }] },
+			}),
+			"--json",
+		]);
+		await run(root, ["apply", "--json"]);
+		const final = await readState(root);
+		const finalFacts = (final.state as Record<string, unknown>).established_facts as Record<string, unknown>[];
+		expect(finalFacts.length).toBe(3);
+		const f2 = finalFacts.find(f => f.id === "f2");
+		expect(f2?.superseded_by).toBe("f3");
+		expect(f2?.statement).toBe("disputed fact");
+	});
+
+	it("serializes a sanctioned envelope writer against an in-flight apply", async () => {
+		const root = await tempDir();
+		await seed(root);
+		await run(root, [
+			"stage",
+			"--for",
+			"merge-state",
+			"--input",
+			JSON.stringify({ state: { note: "apply under contention" } }),
+			"--json",
+		]);
+		// Fire a sanctioned revision-preserving writer (re-seed) CONCURRENTLY with
+		// apply. With the writer-wide path lock, both serialize: whichever writes
+		// second sees the other's write. Legal outcomes: apply succeeds (seed ran
+		// first or second under the lock) or apply reports a typed conflict —
+		// never a silent overwrite of the later write or a torn state file.
+		const [applied, reseeded] = await Promise.all([
+			run(root, ["apply", "--json"]),
+			runNativeDeepInterviewCommand(["--json", "concurrent reseed"], root),
+		]);
+		expect(reseeded.status).toBe(0);
+		expect([0, 2]).toContain(applied.status);
+		if (applied.status === 2) {
+			expect(parse(applied.stderr)).toMatchObject({ ok: false, code: "DI_STAGE_REVISION_CONFLICT" });
+		}
+		// State file is intact and canonical afterwards regardless of ordering.
+		const after = await readState(root);
+		expect(after.skill).toBe("deep-interview");
+		expect(after.active).toBe(true);
+		const checked = await run(root, ["check", "--json"]);
+		// Any remaining draft is either consumed (NO_DRAFT) or stale-detected.
+		if (checked.status !== 0) {
+			const body = parse(checked.stderr ?? checked.stdout);
+			expect(["DI_STAGE_NO_DRAFT", "DI_STAGE_REVISION_CONFLICT"]).toContain(body.code as string);
+		}
+	});
+
+	it("read returns the envelope, revision, sha, and pending draft", async () => {
+		const root = await tempDir();
+		const missing = parse((await run(root, ["read", "--json"])).stdout);
+		expect(missing).toMatchObject({ ok: true, verb: "read", exists: false });
+		await seed(root);
+		await run(root, ["stage", "--for", "merge-state", "--input", JSON.stringify({ state: {} }), "--json"]);
+		const read = parse((await run(root, ["read", "--json"])).stdout);
+		expect(read.exists).toBe(true);
+		expect(typeof read.revision).toBe("number");
+		expect(typeof read.content_sha256).toBe("string");
+		expect((read.envelope as Record<string, unknown>).skill).toBe("deep-interview");
+		expect((read.pending_draft as Record<string, unknown>).transition).toBe("merge-state");
+	});
+
+	it("write merges incrementally by default and replaces with --reset", async () => {
+		const root = await tempDir();
+		await seed(root);
+		const first = parse(
+			(
+				await run(root, [
+					"write",
+					"--input",
+					JSON.stringify({
+						state: { note_a: "kept", established_facts: [{ id: "f1", statement: "fact", round: 1 }] },
+					}),
+					"--json",
+				])
+			).stdout,
+		);
+		expect(first).toMatchObject({ ok: true, verb: "write", mode: "incremental" });
+		const second = parse(
+			(await run(root, ["write", "--input", JSON.stringify({ state: { note_b: "added" } }), "--json"])).stdout,
+		);
+		expect(second.mode).toBe("incremental");
+		expect(second.applied_revision).toBeGreaterThan(first.applied_revision as number);
+		const merged = await readState(root);
+		const mergedState = merged.state as Record<string, unknown>;
+		// Incremental: both notes and prior facts survive.
+		expect(mergedState.note_a).toBe("kept");
+		expect(mergedState.note_b).toBe("added");
+		expect((mergedState.established_facts as unknown[]).length).toBe(1);
+		// Reset replaces free-form state.
+		const reset = parse(
+			(await run(root, ["write", "--reset", "--input", JSON.stringify({ state: { fresh: true } }), "--json"]))
+				.stdout,
+		);
+		expect(reset.mode).toBe("reset");
+		const after = await readState(root);
+		const afterState = after.state as Record<string, unknown>;
+		expect(afterState.fresh).toBe(true);
+		expect(afterState.note_a).toBeUndefined();
+		expect(afterState.note_b).toBeUndefined();
+	});
+
+	it("write refuses while a staged draft is pending and strips runtime-owned keys", async () => {
+		const root = await tempDir();
+		await seed(root);
+		await run(root, ["stage", "--for", "merge-state", "--input", JSON.stringify({ state: {} }), "--json"]);
+		const blocked = await run(root, ["write", "--input", JSON.stringify({ state: { x: 1 } }), "--json"]);
+		expect(parse(blocked.stderr)).toMatchObject({ ok: false, code: "DI_STAGE_DRAFT_EXISTS" });
+		await run(root, ["discard", "--json"]);
+		const smuggle = parse(
+			(
+				await run(root, [
+					"write",
+					"--input",
+					JSON.stringify({ current_phase: "handoff", skill: "ralplan", state: { y: 2 } }),
+					"--json",
+				])
+			).stdout,
+		);
+		expect(smuggle.ignored_runtime_owned_keys).toEqual(expect.arrayContaining(["current_phase", "skill"]));
+		const after = await readState(root);
+		expect(after.current_phase).toBe("interviewing");
+		expect(after.skill).toBe("deep-interview");
+	});
+
+	it("clear routes through the lifecycle plumbing", async () => {
+		const root = await tempDir();
+		await seed(root);
+		const cleared = await run(root, ["clear", "--force", "--json"]);
+		expect(cleared.status).toBe(0);
+		const read = parse((await run(root, ["read", "--json"])).stdout);
+		// Cleared state persists a terminal envelope (active:false) or none at all.
+		if (read.exists) {
+			expect((read.envelope as Record<string, unknown>).active).toBe(false);
+		}
 	});
 });


### PR DESCRIPTION
## Summary

Third follow-up in the #3380 chain (after #3386, #3387). Everything deep-interview now goes through one CLI surface, with runtime-owned invariants fixed per the architect re-review of #3387.

### Unified `gjc deep-interview` surface (no `gjc state` needed)

- `read` — envelope + revision + content sha + pending-draft summary
- `write --input '<json>'` — one-shot sanitized **incremental** merge; `--reset` replaces (the locked intent contract survives a reset); refuses while a staged draft is pending
- `stage`/`check`/`apply`/`discard` — staged transitions with runtime-owned revision+sha CAS
- `clear`/`handoff` — lifecycle passthroughs to the same runtime plumbing
- SKILL.md references only the `gjc deep-interview` path; contract tests now forbid `gjc state read/write/clear` in the skill

### Architect re-review P1 fixes (BLOCK → fixed)

1. **Writer-wide serialization** — `writeWorkflowEnvelopeAtomic` now takes the same per-path workflow lock as staged apply (`lockHeld` escape hatch; ralplan in-lock writers marked), closing the revision-preserving seed/spec interleave inside apply's check-then-write window.
2. **Ambiguity** — derived only from a finite valid latest scored round; with no valid scored evidence the prior persisted value is retained (a staged 0.01 cannot displace the seeded 1.0); malformed scored records cannot win selection.
3. **Lossless facts** — `established_facts` merge field-wise by `id`; a one-fact delta preserves prior confirmed/disputed facts and their deterministic-floor evidence; staged deltas cannot hard-delete facts.

## Verification

- 30 stage-surface tests (incremental merge, no-score ambiguity retention, malformed-score rejection, fact-delta preservation with floor evidence, concurrent sanctioned-writer serialization, read/write/reset/clear, replay no-op, session isolation, @file bounds)
- 253 tests across 9 deep-interview/state/ralplan suites
- live smoke: seed → write → read → write --reset → clear
- manifest drift check, skill-docs verifier (12 `gjc deep-interview` commands OK), package Biome clean