### PR TITLE
fix(deep-interview): intent-key guard, null-prose init, HUD sync, full help

### DIFF
--- a/packages/coding-agent/src/commands/deep-interview.ts
+++ b/packages/coding-agent/src/commands/deep-interview.ts
@@ -2,7 +2,22 @@ import { Command, Flags } from "@gajae-code/utils/cli";
 import { runNativeDeepInterviewCommand } from "../gjc-runtime/deep-interview-runtime";
 
 export default class DeepInterview extends Command {
-	static description = "Run native GJC deep-interview workflow";
+	static description = `Run native GJC deep-interview workflow.
+
+All deep-interview state operations go through this command — no gjc state needed:
+  read                Print the persisted envelope, revision, content sha, and any pending draft
+  write               One-shot incremental JSON merge into state (--reset replaces; the locked
+                      intent contract survives a reset)
+  stage               Stage one JSON transition draft (--for <transition> --input '<json>'|@file)
+  check               Dry-run the staged draft against current state (same merge apply performs)
+  apply               Commit the staged draft with runtime-owned revision+sha CAS
+  discard             Remove the pending draft
+  clear               Clear deep-interview state for the session (lifecycle passthrough)
+  handoff             Hand off to the next workflow skill (lifecycle passthrough)
+
+Ambiguity is runtime-owned: apply/write derive current_ambiguity from the latest valid scored
+round and clamp it to the deterministic floor. Sessions resolve from --session-id, payload
+session_id, or GJC_SESSION_ID.`;
 	static strict = false;
 	static flags = {
 		quick: Flags.boolean({ description: "Seed a quick deep-interview run" }),
@@ -14,6 +29,11 @@ export default class DeepInterview extends Command {
 		"session-id": Flags.string({
 			description: "Route state/spec handoff through a session-scoped .gjc/_session-{sessionid} directory",
 		}),
+		input: Flags.string({ description: "JSON payload (or @file) for the write/stage verbs" }),
+		for: Flags.string({
+			description: "Transition for stage: initialize-context | record-round | update-facts | merge-state",
+		}),
+		reset: Flags.boolean({ description: "With write: replace state instead of incremental merge" }),
 		write: Flags.boolean({ description: "Persist a final deep-interview spec through the sanctioned GJC CLI/API" }),
 		stage: Flags.string({ description: 'Spec stage for --write (currently "final")' }),
 		slug: Flags.string({ description: "Safe slug for .gjc/_session-{sessionid}/specs/deep-interview-<slug>.md" }),
@@ -27,6 +47,11 @@ export default class DeepInterview extends Command {
 	};
 	static examples = [
 		'$ gjc deep-interview --trace --standard "<idea>"',
+		"$ gjc deep-interview read --json",
+		'$ gjc deep-interview write --input \'{"state":{"threshold":0.05}}\' --json',
+		'$ gjc deep-interview stage --for record-round --input \'{"state":{"rounds":[{"round":1,"round_key":"r1"}]}}\' --json',
+		"$ gjc deep-interview check --json",
+		"$ gjc deep-interview apply --json",
 		"$ gjc deep-interview --write --stage final --slug my-feature --spec ./final-spec.md",
 		"$ gjc deep-interview --write --stage final --slug my-feature --spec ./final-spec.md --deliberate",
 	];

--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -538,6 +538,68 @@ Then apply the self-proofread once (DIPP-5) to narrative status text, generated 
 Update state in two phases. The `ask` answer is first recorded by the runtime as an `answered` shell. Scoring then enriches the same round record to `scored` with global scores, per-component `topology.components[].clarity_scores`, `topology.components[].weakest_dimension`, trigger metadata, established-facts changes, ontology snapshot, `topology.last_targeted_component_id`, `auto_researched_rounds`, `auto_answered_rounds`, and `architect_failures`. When `deepInterview` ask metadata is present, no manual per-round write is required for the answer shell; only scoring enrichment/state maintenance remains. For scoring enrichment and state maintenance, use the native `gjc deep-interview` surface and keep every payload **incremental**: stage only the delta for the current round (`stage --for record-round` with just the one round record carrying its `round_key`; the runtime merges it into the existing transcript by durable key), only the changed facts (`--for update-facts`; facts merge losslessly by `id` — a one-fact patch never erases prior facts), or only the changed maintenance fields (`--for merge-state`). Never resend the whole `rounds` array or the full state envelope — earlier rounds are already persisted, resending them is wasteful and racy, and the merge preserves them without your copy. Optionally dry-run with `check`, then commit with `apply`; for a simple immediate update, `gjc deep-interview write --input '<json>'` is the one-shot equivalent (incremental merge; add `--reset` only when deliberately replacing state — the locked intent contract survives a reset). Ambiguity is **runtime-owned**: `apply`/`write` derive `current_ambiguity` from the latest scored round and clamp it to the deterministic floor; report the round's scores and your raw `ambiguity` on the round record, then read the effective value back from the command output (`current_ambiguity`/`result_ambiguity`) instead of hand-setting `state.current_ambiguity`. The session resolves from `GJC_SESSION_ID` automatically; exactly one draft is pending at a time, and a revision conflict at `apply` invalidates the draft with typed recovery — re-stage the same small delta against current state, never do revision arithmetic. Never patch `.gjc/_session-{sessionid}/state` directly unless an explicit force override is active.
 Also recompute and persist `ambiguity_milestone` each round (detect band transitions for the Phase 3 panel), and persist `auto_answer_streak`, `refined_rounds`, `lateral_reviews`, and `lateral_panel_failures` alongside the existing fields.
 
+#### Delta payload schemas
+
+Every staged/write payload is one JSON object `{"state": { …delta only… }}`. Envelope lifecycle keys (`current_phase`, `active`, `skill`, `version`, `state_revision`, `receipt`, `updated_at`, `last_applied_draft_id`) are runtime-owned — if included they are stripped and reported back as `ignored_runtime_owned_keys`, never persisted. `state.intent_contract` and `state.intent_review` are recorder-owned: only the Round 0 / intent-review `ask` recorder can write them (they carry canonical digests and answer-hash bindings you cannot fabricate); a payload carrying them is stripped the same way — never hand-construct an intent contract.
+
+**`stage --for record-round`** — exactly one round record, merged into the transcript by `round_key`:
+
+```json
+{
+  "state": {
+    "rounds": [
+      {
+        "round": <n>,
+        "round_key": "<durable key from the answered shell>",
+        "lifecycle": "scored",
+        "ambiguity": <raw 0..1 score>,
+        "scores": { "goal": 0.9, "constraints": 0.8, "criteria": 0.9, "context": 0.85 },
+        "weakest_component_id": "<component id>",
+        "weakest_dimension": "goal|constraints|criteria|context",
+        "component_scores": { "<component-id>": { "goal": 0.9, "constraints": 0.8, "criteria": 0.9, "context": 0.85, "gaps": { } } },
+        "structured_scorer_output": { },
+        "ontology": { },
+        "ontology_stability": { }
+      }
+    ]
+  }
+}
+```
+
+Include only the one round being enriched; identity fields (`question_text`, `answer_hash`) already persisted on the shell never need resending — the merge preserves them and never downgrades `scored` back to `answered`.
+
+**`stage --for update-facts`** — only the changed fact records, merged field-wise by `id`:
+
+```json
+{
+  "state": {
+    "established_facts": [
+      { "id": "<fact-id>", "statement": "<fact>", "round": <n>, "disputed": false }
+    ]
+  }
+}
+```
+
+To dispute: send `{ "id": "<fact-id>", "disputed": true }`. To supersede: send `{ "id": "<old-id>", "disputed": false, "superseded_by": "<new-id>" }` plus the new fact record. A delta can never hard-delete a fact — unaddressed facts survive verbatim, so never resend the full facts array.
+
+**`stage --for merge-state`** — only the changed maintenance fields (shallow-merged into `state`; `null` deletes a key):
+
+```json
+{
+  "state": {
+    "ambiguity_milestone": "<band>",
+    "auto_answer_streak": <n>,
+    "refined_rounds": [<n>],
+    "lateral_reviews": [ { "round": <n>, "personas": [], "findings": "<summary>" } ],
+    "topology": { "components": [ … ], "last_targeted_component_id": "<id>" }
+  }
+}
+```
+
+`topology` and other object fields replace whole — include the full object when changing any part of it; `rounds` and `established_facts` are the only keyed-merge collections.
+
+**`write --input`** — same `{"state":{…}}` shape and same merge semantics as a staged `merge-state` apply, committed in one step. `write --reset --input` replaces the whole `state` with the payload (the locked `intent_contract` is re-attached automatically); use it only for deliberate re-initialization.
+
 ### Step 2f: Check Tiered Confirmation Cadence
 
 Confirmation cadence is tiered by round, adopted from ouroboros's ooo interview, while the hard safety cap is retained:

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-stage.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-stage.ts
@@ -4,6 +4,7 @@ import { WORKFLOW_STATE_VERSION } from "../skill-state/workflow-state-contract";
 import { applyAmbiguityFloorToEnvelope } from "./deep-interview-ambiguity";
 import {
 	assertDeepInterviewEnvelopeInputLimits,
+	assertDeepInterviewIntentManifest,
 	assertDeepInterviewStructuredResponseWithinLimit,
 	mergeDeepInterviewEnvelope,
 	normalizeDeepInterviewEnvelope,
@@ -172,6 +173,15 @@ const RUNTIME_OWNED_ENVELOPE_KEYS = [
 	"last_applied_draft_id",
 ] as const;
 
+/**
+ * Nested `state.*` keys owned by the Round-0 ask recorder. A staged/write
+ * payload can never set them: a fabricated contract (missing digest/
+ * confirmation binding) would poison state so every later merge fails
+ * `invalid intent contract`, bricking the interview until a destructive
+ * `clear --force`. The recorder is the only writer that can lock intent.
+ */
+const RECORDER_OWNED_STATE_KEYS = ["intent_contract", "intent_review"] as const;
+
 /** Strip runtime-owned keys from a staged payload; returns the ignored key names. */
 function sanitizeStagedPayload(payload: Record<string, unknown>): {
 	payload: Record<string, unknown>;
@@ -185,7 +195,42 @@ function sanitizeStagedPayload(payload: Record<string, unknown>): {
 			ignoredKeys.push(key);
 		}
 	}
+	if (isPlainObject(next.state)) {
+		const state = { ...(next.state as Record<string, unknown>) };
+		for (const key of RECORDER_OWNED_STATE_KEYS) {
+			if (key in state) {
+				delete state[key];
+				ignoredKeys.push(`state.${key}`);
+			}
+		}
+		next.state = state;
+	}
 	return { payload: next, ignoredKeys };
+}
+
+/**
+ * Self-heal a poisoned merge base: a persisted `state.intent_contract` that
+ * fails canonical validation can only come from a pre-guard poisoned write
+ * (the recorder always persists valid manifests). Left in place it makes
+ * every merge throw, bricking the interview. Drop it (and any equally
+ * unverifiable intent_review) from the base and report the repair.
+ */
+function healPoisonedIntentContract(base: Record<string, unknown>): {
+	base: Record<string, unknown>;
+	healed: boolean;
+} {
+	if (!isPlainObject(base.state)) return { base, healed: false };
+	const state = base.state as Record<string, unknown>;
+	if (state.intent_contract === undefined) return { base, healed: false };
+	try {
+		assertDeepInterviewIntentManifest(state.intent_contract);
+		return { base, healed: false };
+	} catch {
+		const healedState = { ...state };
+		delete healedState.intent_contract;
+		delete healedState.intent_review;
+		return { base: { ...base, state: healedState }, healed: true };
+	}
 }
 
 function parseTransition(raw: string | undefined): DeepInterviewStageTransition {
@@ -363,9 +408,12 @@ function computeMergedEnvelope(
 	draft: DeepInterviewStageDraft,
 	nowIso: string,
 ): Record<string, unknown> {
+	// A poisoned (unverifiable) intent contract in the persisted base would make
+	// every merge throw forever; heal it instead of bricking the interview.
+	const { base: healedCurrent, healed } = healPoisonedIntentContract(current);
 	let merged: Record<string, unknown>;
 	try {
-		merged = mergeDeepInterviewEnvelope(current, draft.payload) as Record<string, unknown>;
+		merged = mergeDeepInterviewEnvelope(healedCurrent, draft.payload) as Record<string, unknown>;
 	} catch (error) {
 		throw new DeepInterviewStageError(
 			"DI_STAGE_MERGE_REJECTED",
@@ -373,6 +421,7 @@ function computeMergedEnvelope(
 			"fix the payload and re-stage (`gjc deep-interview discard` then `stage`)",
 		);
 	}
+	if (healed) merged.intent_contract_healed_at = nowIso;
 	merged.skill = "deep-interview";
 	merged.active = true;
 	merged.updated_at = nowIso;

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-stage.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-stage.test.ts
@@ -753,4 +753,59 @@ describe("deep-interview staged transitions", () => {
 			expect((read.envelope as Record<string, unknown>).active).toBe(false);
 		}
 	});
+
+	it("strips recorder-owned intent keys from staged payloads", async () => {
+		const root = await tempDir();
+		await seed(root);
+		const staged = parse(
+			(
+				await run(root, [
+					"write",
+					"--input",
+					JSON.stringify({
+						state: {
+							intent_contract: { version: 1, status: "confirmed", items: [] },
+							intent_review: { version: 1, status: "approved" },
+							note: "payload with fabricated contract",
+						},
+					}),
+					"--json",
+				])
+			).stdout,
+		);
+		expect(staged.ok).toBe(true);
+		expect(staged.ignored_runtime_owned_keys).toEqual(
+			expect.arrayContaining(["state.intent_contract", "state.intent_review"]),
+		);
+		const after = await readState(root);
+		const state = after.state as Record<string, unknown>;
+		expect(state.intent_contract).toBeUndefined();
+		expect(state.intent_review).toBeUndefined();
+		expect(state.note).toBe("payload with fabricated contract");
+	});
+
+	it("self-heals a poisoned intent contract in persisted state instead of bricking", async () => {
+		const root = await tempDir();
+		await seed(root);
+		// Simulate the pre-guard poisoned write: an unverifiable contract already
+		// persisted (as happened in the dogfood run before the sanitizer existed).
+		const statePath = modeStatePath(root, TEST_SESSION_ID, "deep-interview");
+		const current = await readState(root);
+		(current.state as Record<string, unknown>).intent_contract = {
+			version: 1,
+			status: "confirmed",
+			items: [{ id: "artifact:roadmap", category: "artifact", statement: "roadmap" }],
+		};
+		await fs.writeFile(statePath, `${JSON.stringify(current, null, 2)}\n`, "utf-8");
+		// Any later delta write must succeed, not fail with `invalid intent contract`.
+		const written = parse(
+			(await run(root, ["write", "--input", JSON.stringify({ state: { note: "after poison" } }), "--json"])).stdout,
+		);
+		expect(written.ok).toBe(true);
+		const after = await readState(root);
+		const state = after.state as Record<string, unknown>;
+		expect(state.intent_contract).toBeUndefined();
+		expect(state.note).toBe("after poison");
+		expect(typeof after.intent_contract_healed_at).toBe("string");
+	});
 });


### PR DESCRIPTION
## Summary

Fourth follow-up in the #3380 chain (after #3386, #3387, #3393): two live dogfood defects, the architect round-3 WATCH findings, and the stale command help.

### Recorder-owned intent keys (dogfood brick fix)

A live interview bricked when the agent hand-constructed `state.intent_contract` in a `write` payload: no prior contract existed, so the merge's immutability guard never armed, the fabricated (digest-less) contract persisted, and every later merge failed `invalid intent contract` until a destructive `clear --force`.

- `state.intent_contract` / `state.intent_review` are now **recorder-owned**: stripped from every staged/`write` payload and reported in `ignored_runtime_owned_keys`. Only the Round-0 / intent-review `ask` recorder can lock intent.
- **Self-heal**: a persisted contract failing canonical validation is dropped from the merge base with an `intent_contract_healed_at` marker instead of failing every subsequent write.

### Null-prose first-try init (dogfood friction fix)

The skill's documented Phase 1 payload seeds nullable prose as `null` (`initial_context_summary: null`, …), but the bounded-input validator type-checked every present value as a string — so the documented init always failed once before the agent stripped nulls and retried. `null` is now accepted wherever prose is optional; only present non-null values are length-bounded. Regression: the exact skill-template payload succeeds on the first write.

### Architect round-3 WATCH findings (all three)

1. `write`/`apply` publish the committed envelope to the active-state/HUD mirror (`syncStageHud`); the ambiguity HUD chip refreshes after both paths (regression-tested).
2. Workflow manifest advertises direct `clear`/`handoff` positionals + `--json` applicability.
3. Lifecycle passthrough uses a static `runNativeStateCommand` import (no cycle; convention compliance).

### Full command help

`gjc deep-interview --help` now documents all 8 verbs (read/write/stage/check/apply/discard/clear/handoff), `--input`/`--for`/`--reset`, runtime-owned ambiguity, and session resolution.

### Delta payload schemas

SKILL.md Step 2e documents concrete JSON payload shapes for every staged transition, `write`/`write --reset`, dispute/supersede fact idioms, and the runtime-owned + recorder-owned key lists.

## Verification

- 34 stage-surface tests (fabricated-contract strip, poisoned-state self-heal, null-prose first-try init, HUD refresh after write+apply)
- 139 tests across 6 deep-interview suites
- manifest drift check green; skill-docs verifier green; changed-file Biome clean