### PR TITLE
fix(deep-interview): null-prose first-try init and HUD sync after write/apply

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/deep-interview-stage.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-stage.ts
@@ -1,5 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
+import { syncSkillActiveState } from "../skill-state/active-state";
+import { deriveDeepInterviewHud } from "../skill-state/workflow-hud";
 import { WORKFLOW_STATE_VERSION } from "../skill-state/workflow-state-contract";
 import { applyAmbiguityFloorToEnvelope } from "./deep-interview-ambiguity";
 import {
@@ -11,6 +13,7 @@ import {
 } from "./deep-interview-state";
 import { sessionStateDir } from "./session-layout";
 import { resolveGjcSessionForWrite, SessionResolutionError, writeSessionActivityMarker } from "./session-resolution";
+import { runNativeStateCommand } from "./state-runtime";
 import {
 	persistedStateRevision,
 	readExistingStateForMutation,
@@ -713,6 +716,7 @@ async function handleApply(args: readonly string[], cwd: string): Promise<Record
 			} catch {
 				// Swallow: state is committed; the next apply/discard settles the draft.
 			}
+			await syncStageHud(cwd, sessionId, merged);
 			const appliedState = isPlainObject(merged.state) ? (merged.state as Record<string, unknown>) : {};
 			return {
 				ok: true,
@@ -877,6 +881,7 @@ async function handleWrite(args: readonly string[], cwd: string): Promise<Record
 				},
 			});
 			await writeSessionActivityMarker(cwd, sessionId, { writer: "deep-interview-stage", path: statePath });
+			await syncStageHud(cwd, sessionId, merged);
 			const writtenState = isPlainObject(merged.state) ? (merged.state as Record<string, unknown>) : {};
 			return {
 				ok: true,
@@ -895,13 +900,34 @@ async function handleWrite(args: readonly string[], cwd: string): Promise<Record
 	);
 }
 
+/**
+ * Publish a committed envelope to the active-state/HUD mirror. Best-effort:
+ * the durable commit already happened; a projection failure must never fail
+ * the command (matches syncDeepInterviewHud in deep-interview-runtime.ts).
+ */
+async function syncStageHud(cwd: string, sessionId: string, envelope: Record<string, unknown>): Promise<void> {
+	try {
+		const phase = typeof envelope.current_phase === "string" ? envelope.current_phase : "interviewing";
+		await syncSkillActiveState({
+			cwd,
+			skill: "deep-interview",
+			active: phase !== "complete",
+			phase,
+			sessionId,
+			source: "gjc-deep-interview-native",
+			hud: deriveDeepInterviewHud(envelope, { phase }),
+		});
+	} catch {
+		// HUD sync is best-effort and must not change command semantics.
+	}
+}
+
 /** Thin lifecycle passthroughs: same runtime plumbing, gjc deep-interview surface. */
 async function handleLifecyclePassthrough(
 	verb: "clear" | "handoff",
 	args: readonly string[],
 	cwd: string,
 ): Promise<DeepInterviewStageCommandResult> {
-	const { runNativeStateCommand } = await import("./state-runtime");
 	const forwarded =
 		verb === "clear"
 			? ["clear", "--mode", "deep-interview", ...args]

--- a/packages/coding-agent/src/gjc-runtime/deep-interview-state.ts
+++ b/packages/coding-agent/src/gjc-runtime/deep-interview-state.ts
@@ -483,20 +483,23 @@ export function assertDeepInterviewEnvelopeInputLimits(envelope: Record<string, 
 		typeof envelope.state === "object" && envelope.state !== null && !Array.isArray(envelope.state)
 			? (envelope.state as Record<string, unknown>)
 			: {};
+	// `null` is legal everywhere prose is optional: the skill template seeds
+	// `initial_context_summary: null` and the merge treats `null` as a deletion
+	// marker, so only present non-null values are bounded.
 	for (const field of ["initial_idea", "initial_context", "initial_context_summary"] as const) {
 		const nestedValue = state[field];
-		if (nestedValue !== undefined)
+		if (nestedValue !== undefined && nestedValue !== null)
 			assertDeepInterviewInputWithinLimit(nestedValue as string, MAX_INITIAL_CONTEXT_LENGTH, `state.${field}`);
 		const topLevelValue = envelope[field];
-		if (topLevelValue !== undefined)
+		if (topLevelValue !== undefined && topLevelValue !== null)
 			assertDeepInterviewInputWithinLimit(topLevelValue as string, MAX_INITIAL_CONTEXT_LENGTH, field);
 	}
 	for (const field of ["user_response", "answer"] as const) {
 		const nestedValue = state[field];
-		if (nestedValue !== undefined)
+		if (nestedValue !== undefined && nestedValue !== null)
 			assertDeepInterviewInputWithinLimit(nestedValue as string, MAX_USER_RESPONSE_LENGTH, `state.${field}`);
 		const topLevelValue = envelope[field];
-		if (topLevelValue !== undefined)
+		if (topLevelValue !== undefined && topLevelValue !== null)
 			assertDeepInterviewInputWithinLimit(topLevelValue as string, MAX_USER_RESPONSE_LENGTH, field);
 	}
 	if (!Array.isArray(state.rounds)) return;
@@ -507,7 +510,7 @@ export function assertDeepInterviewEnvelopeInputLimits(envelope: Record<string, 
 			const value = record[field];
 			// A structured scorer may use an unrelated object-valued `answer`; only prose
 			// values in a legacy answer slot are user input subject to this cap.
-			if (value === undefined || (field === "answer" && typeof value !== "string")) continue;
+			if (value === undefined || value === null || (field === "answer" && typeof value !== "string")) continue;
 			assertDeepInterviewInputWithinLimit(
 				value as string,
 				MAX_USER_RESPONSE_LENGTH,

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
@@ -268,7 +268,9 @@
           "apply",
           "discard",
           "read",
-          "write"
+          "write",
+          "clear",
+          "handoff"
         ],
         "name": "json",
         "type": "boolean"
@@ -369,6 +371,14 @@
       },
       {
         "name": "write",
+        "surface": "command-positional"
+      },
+      {
+        "name": "clear",
+        "surface": "command-positional"
+      },
+      {
+        "name": "handoff",
         "surface": "command-positional"
       },
       {

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
@@ -178,7 +178,7 @@ export const WORKFLOW_MANIFEST: Record<CanonicalGjcWorkflowSkill, SkillManifest>
 		verbs: [
 			...stateVerbs(),
 			...flagVerbs(["kickoff", "write-spec"]),
-			...positionalVerbs(["stage", "check", "apply", "discard", "read", "write"]),
+			...positionalVerbs(["stage", "check", "apply", "discard", "read", "write", "clear", "handoff"]),
 			...plannedVerbs(PLANNED_ADMIN_VERBS),
 		],
 		typedArgs: [
@@ -195,7 +195,7 @@ export const WORKFLOW_MANIFEST: Record<CanonicalGjcWorkflowSkill, SkillManifest>
 			{
 				name: "json",
 				type: "boolean",
-				appliesToVerbs: ["write-spec", "stage", "check", "apply", "discard", "read", "write"],
+				appliesToVerbs: ["write-spec", "stage", "check", "apply", "discard", "read", "write", "clear", "handoff"],
 			},
 			{ name: "input", type: "string", required: true, appliesToVerbs: ["stage", "write"] },
 			{ name: "reset", type: "boolean", appliesToVerbs: ["write"] },

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-stage.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-stage.test.ts
@@ -808,4 +808,38 @@ describe("deep-interview staged transitions", () => {
 		expect(state.note).toBe("after poison");
 		expect(typeof after.intent_contract_healed_at).toBe("string");
 	});
+
+	it("accepts the documented initialize payload with null prose markers first try", async () => {
+		const root = await tempDir();
+		// The skill's Phase 1 template seeds nullable prose fields as null — this
+		// exact shape must succeed on the FIRST write, with no failed probe.
+		const written = parse(
+			(
+				await run(root, [
+					"write",
+					"--input",
+					JSON.stringify({
+						state: {
+							interview_id: "iv-1",
+							type: "brownfield",
+							initial_idea: "future roadmap discussion",
+							initial_context_summary: null,
+							rounds: [],
+							established_facts: [],
+							trace_summary: null,
+							codebase_context: null,
+							restated_goal: null,
+						},
+					}),
+					"--json",
+				])
+			).stdout,
+		);
+		expect(written.ok).toBe(true);
+		const after = await readState(root);
+		const state = after.state as Record<string, unknown>;
+		expect(state.initial_idea).toBe("future roadmap discussion");
+		// null markers delete/omit rather than persisting nulls or erroring.
+		expect(state.initial_context_summary ?? undefined).toBeUndefined();
+	});
 });

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-stage.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-stage.test.ts
@@ -842,4 +842,36 @@ describe("deep-interview staged transitions", () => {
 		// null markers delete/omit rather than persisting nulls or erroring.
 		expect(state.initial_context_summary ?? undefined).toBeUndefined();
 	});
+
+	it("refreshes the active-state/HUD projection after write and apply", async () => {
+		const root = await tempDir();
+		await seed(root);
+		const snapshotPath = path.join(root, ".gjc", `_session-${TEST_SESSION_ID}`, "state", "skill-active-state.json");
+		const readHudAmbiguity = async (): Promise<string | undefined> => {
+			const snapshot = JSON.parse(await fs.readFile(snapshotPath, "utf-8")) as Record<string, unknown>;
+			const skills = snapshot.active_skills as Record<string, unknown>[];
+			const entry = skills.find(s => s.skill === "deep-interview");
+			const chips = ((entry?.hud as Record<string, unknown> | undefined)?.chips ?? []) as Record<string, unknown>[];
+			return chips.find(c => c.label === "ambiguity")?.value as string | undefined;
+		};
+		// Direct write with a scored round updates the HUD projection.
+		await run(root, [
+			"write",
+			"--input",
+			JSON.stringify({ state: { rounds: [{ round: 1, round_key: "r1", lifecycle: "scored", ambiguity: 0.44 }] } }),
+			"--json",
+		]);
+		expect(await readHudAmbiguity()).toContain("44%");
+		// Staged apply refreshes it again.
+		await run(root, [
+			"stage",
+			"--for",
+			"record-round",
+			"--input",
+			JSON.stringify({ state: { rounds: [{ round: 2, round_key: "r2", lifecycle: "scored", ambiguity: 0.21 }] } }),
+			"--json",
+		]);
+		await run(root, ["apply", "--json"]);
+		expect(await readHudAmbiguity()).toContain("21%");
+	});
 });


### PR DESCRIPTION
## Summary

Fifth follow-up in the #3380 chain (after #3386, #3387, #3393, #3395): the two commits that were stranded when #3395 merged early — a dogfood friction fix plus the architect round-3 WATCH findings.

### Null-prose first-try init (dogfood friction fix)

The skill's documented Phase 1 initialize payload seeds nullable prose fields as `null` (`initial_context_summary: null`, `trace_summary: null`, …), but the bounded-input validator type-checked every present value as a string — so the documented init ALWAYS failed once (`state.initial_context_summary must be a string`) before the agent stripped nulls and retried. `null` is now accepted wherever prose is optional (it is the documented deletion/omission marker the merge already handles); only present non-null values are length-bounded. Regression: the exact skill-template payload succeeds on the FIRST write.

### Architect round-3 WATCH findings (all three)

1. **HUD sync** — `write`/`apply` now publish the committed envelope to the active-state/HUD mirror via `syncStageHud` (best-effort, matching `syncDeepInterviewHud`), so mode-state rounds/ambiguity can no longer be current while the HUD chip shows the seed value. Regression asserts the ambiguity chip refreshes after both a direct write and a staged apply.
2. **Manifest** — direct `clear`/`handoff` positionals and their `--json` applicability are now advertised (runtime already dispatched them); generated projection regenerated.
3. **Static import** — the lifecycle passthrough uses a top-level `runNativeStateCommand` import per the no-inline-import convention (`state-runtime` does not import this module; no cycle).

## Verification

- 34 stage-surface tests including the two new regressions (null-prose first-try init, HUD refresh after write+apply)
- default-definitions suite green (62 tests across both)
- manifest drift check green, changed-file Biome clean