### PR TITLE
fix(test): type the deep-interview stage fact-count assertion

### DIFF
--- a/packages/coding-agent/test/gjc-runtime/deep-interview-stage.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-stage.test.ts
@@ -119,7 +119,7 @@ describe("deep-interview staged transitions", () => {
 		await run(root, ["apply", "--json"]);
 		const after = await readState(root);
 		const state = after.state as Record<string, unknown>;
-		expect((state.established_facts as unknown[]).length).toBe(checkSummary.result_fact_count);
+		expect((state.established_facts as unknown[]).length).toBe(checkSummary.result_fact_count as number);
 	});
 
 	it("rejects non-initialize staging against missing state", async () => {


### PR DESCRIPTION
Fixes the TS2769 `check:@gajae-code/coding-agent` failure that has broken the last three Dev CI runs on dev.

`checkSummary` is `Record<string, unknown>`, so passing `result_fact_count` directly to `toBe()` had no matching overload. Verified locally with `bun run check:types` (clean) and `bun test test/gjc-runtime/deep-interview-stage.test.ts`.