### PR TITLE
perf(coding-agent): cache transcript viewer layouts

### DIFF
--- a/artifacts/pr2a-session-observer-structural-performance.json
+++ b/artifacts/pr2a-session-observer-structural-performance.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": 1,
+  "kind": "deterministic-structural-performance",
+  "fixture": {
+    "entries": 100,
+    "navigationMoves": 10,
+    "width": 100
+  },
+  "navigation": {
+    "layoutCacheHits": 989,
+    "layoutCacheMisses": 11,
+    "refreshRuns": 0,
+    "rebuildRuns": 10,
+    "layoutHitRate": 0.989
+  },
+  "paintOnly": {
+    "layoutCacheHits": 0,
+    "layoutCacheMisses": 0,
+    "refreshRuns": 0,
+    "rebuildRuns": 0
+  },
+  "acceptance": {
+    "navigationRefreshRunsZero": true,
+    "paintRefreshRunsZero": true,
+    "paintRebuildRunsZero": true,
+    "layoutHitRateAtLeast90Percent": true
+  }
+}

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -28,6 +28,10 @@
 - Interactive `/resume` progress lease fails open when `statusContainer` or UI lacks child-mutation/render-commit surface, preserving headless/minimal controller contexts without weakening full TUI progress-before-switch (#3234 post-merge).
 - The documented `GJC_OPENAI_CODE_WEB_SEARCH_MODEL` environment variable now overrides the OpenAI-code web-search model; it is resolved GJC-first ahead of the legacy `PI_CODEX_WEB_SEARCH_MODEL` name (previously only the legacy name was read, so the documented name was a silent no-op).
 
+### Changed
+
+- Session Observer and the main transcript viewer no longer re-project and re-layout their full transcript on every paint. Source changes still refresh through registry/session-event notifications, while navigation rebuilds only affected layout variants; deterministic counters and replacement-safety coverage preserve selection, follow-tail, raw, expanded, fullscreen, mouse, theme, width, and source-replacement behavior.
+
 ### Added
 
 - Deterministic tests for session_switch await policy (selector defer vs default/branch await), control-drain ordering, host pre-response readiness gating, and resume progress lease-before-switch behavior (#2914).

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -148,8 +148,21 @@ export class SessionObserverOverlayComponent extends TranscriptViewerOverlay {
 		const cache = this.#cache;
 		const snapshot = readStableSnapshot(filePath, cache?.completeOffset ?? 0);
 		if (!snapshot) {
-			// An unreadable source is never allowed to keep presenting a prior file as current.
-			if (cache) this.#clearSource();
+			// A cached offset may exceed a replaced (shorter) file's new size, in which case the
+			// offset-tail snapshot is null even though the replacement is readable. Without a
+			// render-time refresh, that null would drop the replacement entirely, so attempt one
+			// full stable snapshot at offset 0 and validate it before installing. Unreadable or
+			// invalid sources still fail closed and never keep presenting a prior file as current.
+			if (cache) {
+				const replacement = readStableSnapshot(filePath, 0);
+				const candidate = replacement ? cacheEntries(filePath, replacement) : null;
+				if (candidate) {
+					this.#cache = candidate;
+					this.resetSourceState();
+					return candidate.entries;
+				}
+				this.#clearSource();
+			}
 			return [];
 		}
 

--- a/packages/coding-agent/src/modes/components/transcript-viewer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/transcript-viewer-overlay.ts
@@ -54,6 +54,34 @@ export type TranscriptViewerOverlayOptions = {
 
 type RenderedEntry = { lineStart: number; lineCount: number };
 
+export const __transcriptViewerPerfCounters = {
+	enabled: false,
+	layoutCacheHits: 0,
+	layoutCacheMisses: 0,
+	refreshRuns: 0,
+	rebuildRuns: 0,
+	snapshot() {
+		return {
+			layoutCacheHits: this.layoutCacheHits,
+			layoutCacheMisses: this.layoutCacheMisses,
+			refreshRuns: this.refreshRuns,
+			rebuildRuns: this.rebuildRuns,
+		};
+	},
+	enable(): void {
+		this.enabled = true;
+	},
+	disable(): void {
+		this.enabled = false;
+	},
+	reset(): void {
+		this.layoutCacheHits = 0;
+		this.layoutCacheMisses = 0;
+		this.refreshRuns = 0;
+		this.rebuildRuns = 0;
+	},
+};
+
 /** Message-agnostic, modal transcript browser over resolved projection entries. */
 export class TranscriptViewerOverlay extends Container {
 	#options: TranscriptViewerOverlayOptions;
@@ -73,6 +101,7 @@ export class TranscriptViewerOverlay extends Container {
 	#followTailPending = false;
 	#skipFollowTailOnce = false;
 	#followTailActive = false;
+	#layoutCache = new Map<string, Map<string, string[]>>();
 
 	constructor(options: TranscriptViewerOverlayOptions) {
 		super();
@@ -88,6 +117,10 @@ export class TranscriptViewerOverlay extends Container {
 		return this.#fullscreen;
 	}
 	refresh(identityMap?: ReadonlyMap<string, string>): void {
+		if (__transcriptViewerPerfCounters.enabled) __transcriptViewerPerfCounters.refreshRuns++;
+		// Same-id entries may carry new payloads and getDisplayText closures after a source
+		// refresh, so the entire layout cache is dropped before the entries are replaced.
+		this.#layoutCache.clear();
 		const previous = this.selectedEntryId;
 		const previousPosition = this.#selected;
 		const reconciledPrevious = previous ? (identityMap?.get(previous) ?? previous) : undefined;
@@ -109,9 +142,15 @@ export class TranscriptViewerOverlay extends Container {
 		this.#initialized = true;
 		this.#rebuild();
 	}
+	invalidateLayoutEntries(entryIds: readonly string[]): void {
+		for (const id of entryIds) this.#layoutCache.delete(id);
+	}
 	override render(width: number): string[] {
-		this.#width = Math.max(1, width);
-		this.refresh();
+		const nextWidth = Math.max(1, width);
+		const widthChanged = nextWidth !== this.#width;
+		this.#width = nextWidth;
+		if (widthChanged) this.#layoutCache.clear();
+		if (widthChanged || getMarkdownTheme() !== this.#mdTheme) this.#rebuild();
 		const defaultHeader = this.#fullscreen
 			? [theme.fg("accent", "Transcript block")]
 			: [theme.fg("accent", sanitizeText(this.#options.title ?? "Transcript"))];
@@ -179,6 +218,7 @@ export class TranscriptViewerOverlay extends Container {
 			if (this.#fullscreen) {
 				this.#fullscreen = false;
 				this.#scrollOffset = 0;
+				this.#rebuild();
 				this.#requestRender();
 			} else this.#options.onClose();
 			return;
@@ -208,6 +248,7 @@ export class TranscriptViewerOverlay extends Container {
 			this.#followTailActive = false;
 			this.#followTailPending = false;
 			this.#selected = 0;
+			this.#rebuild();
 			this.#scrollOffset = 0;
 			this.#requestRender();
 			return;
@@ -216,6 +257,7 @@ export class TranscriptViewerOverlay extends Container {
 			this.#followTailActive = true;
 			this.#followTailPending = true;
 			this.#selected = Math.max(0, count - 1);
+			this.#rebuild();
 			this.#scrollOffset = this.#lines.length;
 			this.#requestRender();
 			return;
@@ -228,6 +270,7 @@ export class TranscriptViewerOverlay extends Container {
 			this.#followTailActive = false;
 			this.#fullscreen = true;
 			this.#scrollOffset = 0;
+			this.#rebuild();
 			this.#requestRender();
 			return;
 		}
@@ -243,6 +286,7 @@ export class TranscriptViewerOverlay extends Container {
 			const entry = this.#entries[this.#selected];
 			if (entry?.rawViewable !== false) {
 				this.#raw.has(entry.id) ? this.#raw.delete(entry.id) : this.#raw.add(entry.id);
+				this.#rebuild();
 				this.#requestRender();
 			}
 		}
@@ -284,6 +328,7 @@ export class TranscriptViewerOverlay extends Container {
 		this.#followTailActive = false;
 		this.#followTailPending = false;
 		this.#selected = Math.max(0, Math.min(this.#selected + direction * 5, this.#entries.length - 1));
+		this.#rebuild();
 		this.#scrollOffset += direction * PAGE_SIZE;
 		this.#requestRender();
 	}
@@ -327,32 +372,58 @@ export class TranscriptViewerOverlay extends Container {
 		this.#options.requestRender?.();
 	}
 	#rebuild(): void {
+		if (__transcriptViewerPerfCounters.enabled) __transcriptViewerPerfCounters.rebuildRuns++;
+		// Theme is tracked by reference outside the variant key; a reference change clears
+		// the whole cache so plain and markdown layouts pick up new markdown colors.
+		const currentMdTheme = getMarkdownTheme();
+		if (currentMdTheme !== this.#mdTheme) {
+			this.#mdTheme = currentMdTheme;
+			this.#layoutCache.clear();
+		}
 		const lines: string[] = [];
 		this.#renderedEntries = [];
 		const display = this.#fullscreen ? this.#entries.slice(this.#selected, this.#selected + 1) : this.#entries;
 		const contentWidth = Math.max(1, this.#width - INDENT.length - 1);
 		for (const entry of display) {
 			const start = lines.length;
-			const selected = entry.id === this.selectedEntryId;
-			const expanded = this.#fullscreen || this.#expanded.has(entry.id);
-			const raw = this.#raw.has(entry.id);
-			lines.push("");
-			lines.push(
-				`${selected ? theme.fg("accent", "▶") : " "} ${theme.fg("muted", `[${sanitizeText(entry.label ?? entry.kind)}]`)}`,
-			);
-			if (
-				!raw &&
-				expanded &&
-				selected &&
-				entry.kind === "tool" &&
-				entry.richRenderEligible === true &&
-				entry.renderDescriptor
-			) {
-				for (const line of renderToolDisplayLines(entry.renderDescriptor, contentWidth, theme))
-					lines.push(`${INDENT}${line}`);
-				this.#renderedEntries.push({ lineStart: start, lineCount: lines.length - start });
-				continue;
+			const entryLines = this.#renderEntryLines(entry, contentWidth);
+			lines.push(...entryLines);
+			// Cumulative positions are recomputed from cached line lengths on every rebuild
+			// so PR2c can later separate virtual coordinates from materialized lines.
+			this.#renderedEntries.push({ lineStart: start, lineCount: entryLines.length });
+		}
+		this.#lines = lines.length ? lines : [theme.fg("dim", "No transcript entries yet.")];
+	}
+	#renderEntryLines(entry: TranscriptViewerEntry, contentWidth: number): string[] {
+		const selected = entry.id === this.selectedEntryId;
+		const expanded = this.#fullscreen || this.#expanded.has(entry.id);
+		const raw = this.#raw.has(entry.id);
+		const variantKey = `${expanded ? 1 : 0}|${raw ? 1 : 0}|${selected ? 1 : 0}|${contentWidth}`;
+		let variants = this.#layoutCache.get(entry.id);
+		if (variants) {
+			const cached = variants.get(variantKey);
+			if (cached) {
+				if (__transcriptViewerPerfCounters.enabled) __transcriptViewerPerfCounters.layoutCacheHits++;
+				return cached;
 			}
+		}
+		if (__transcriptViewerPerfCounters.enabled) __transcriptViewerPerfCounters.layoutCacheMisses++;
+		const lines: string[] = [];
+		lines.push("");
+		lines.push(
+			`${selected ? theme.fg("accent", "▶") : " "} ${theme.fg("muted", `[${sanitizeText(entry.label ?? entry.kind)}]`)}`,
+		);
+		if (
+			!raw &&
+			expanded &&
+			selected &&
+			entry.kind === "tool" &&
+			entry.richRenderEligible === true &&
+			entry.renderDescriptor
+		) {
+			for (const line of renderToolDisplayLines(entry.renderDescriptor, contentWidth, theme))
+				lines.push(`${INDENT}${line}`);
+		} else {
 			const text = sanitizeText(
 				(raw
 					? entry.payload.text
@@ -375,9 +446,13 @@ export class TranscriptViewerOverlay extends Container {
 				for (const line of preview) lines.push(`${INDENT}${truncateToWidth(line, contentWidth)}`);
 				if (text.split("\n").length > PREVIEW_LINES) lines.push(`${INDENT}${theme.fg("dim", "... more (Space)")}`);
 			}
-			this.#renderedEntries.push({ lineStart: start, lineCount: lines.length - start });
 		}
-		this.#lines = lines.length ? lines : [theme.fg("dim", "No transcript entries yet.")];
+		if (!variants) {
+			variants = new Map();
+			this.#layoutCache.set(entry.id, variants);
+		}
+		variants.set(variantKey, lines);
+		return lines;
 	}
 	#markdown(text: string, width: number): string[] {
 		return new Markdown(text, 0, 0, this.#mdTheme).render(width).map(line => `${INDENT}${line.trimEnd()}`);

--- a/packages/coding-agent/test/modes/controllers/event-controller-message-start.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-message-start.test.ts
@@ -27,6 +27,7 @@ function createContext(options: {
 	optimisticSignature?: string;
 	locallySubmittedSignatures?: string[];
 	injectedSignatures?: Array<[string, number]>;
+	transcriptViewerOpen?: boolean;
 }) {
 	let currentEditorText = options.editorText;
 	const setText = vi.fn((text: string) => {
@@ -38,6 +39,7 @@ function createContext(options: {
 	};
 	const addMessageToChat = vi.fn();
 	const updatePendingMessagesDisplay = vi.fn();
+	const refreshTranscriptViewer = vi.fn();
 	const ctx = {
 		isInitialized: true,
 		statusLine: { invalidate: vi.fn() },
@@ -56,9 +58,50 @@ function createContext(options: {
 		optimisticUserMessageSignature: options.optimisticSignature,
 		locallySubmittedUserSignatures: new Set<string>(options.locallySubmittedSignatures ?? []),
 		optimisticInjectedSignatures: new Map<string, number>(options.injectedSignatures ?? []),
+		...(options.transcriptViewerOpen !== undefined
+			? {
+					isTranscriptViewerOpen: () => options.transcriptViewerOpen === true,
+					refreshTranscriptViewer,
+				}
+			: {}),
 	} as unknown as InteractiveModeContext;
-	return { ctx, editor, setText, addMessageToChat, updatePendingMessagesDisplay };
+	return { ctx, editor, setText, addMessageToChat, updatePendingMessagesDisplay, refreshTranscriptViewer };
 }
+
+describe("EventController transcript viewer refresh ownership", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("refreshes the transcript viewer exactly once when it is open after handling message_start", async () => {
+		// After render() stopped refreshing unconditionally, EventController owns the
+		// explicit refresh trigger: a successful event refreshes the viewer exactly
+		// once, and only while it is open.
+		const message = createUserMessage("hello while viewer is open");
+		const { ctx, refreshTranscriptViewer } = createContext({
+			editorText: "draft",
+			transcriptViewerOpen: true,
+		});
+		const controller = new EventController(ctx);
+
+		await controller.handleEvent({ type: "message_start", message });
+
+		expect(refreshTranscriptViewer).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not refresh the transcript viewer when it is closed during message_start", async () => {
+		const message = createUserMessage("hello while viewer is closed");
+		const { ctx, refreshTranscriptViewer } = createContext({
+			editorText: "draft",
+			transcriptViewerOpen: false,
+		});
+		const controller = new EventController(ctx);
+
+		await controller.handleEvent({ type: "message_start", message });
+
+		expect(refreshTranscriptViewer).not.toHaveBeenCalled();
+	});
+});
 
 describe("EventController message_start (user role)", () => {
 	afterEach(() => {

--- a/packages/coding-agent/test/session-observer-overlay.test.ts
+++ b/packages/coding-agent/test/session-observer-overlay.test.ts
@@ -3,8 +3,16 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { SessionObserverOverlayComponent } from "../src/modes/components/session-observer-overlay";
-import type { ObservableSession, SessionObserverRegistry } from "../src/modes/session-observer-registry";
+import { type ObservableSession, SessionObserverRegistry } from "../src/modes/session-observer-registry";
 import { initTheme } from "../src/modes/theme/theme";
+import {
+	type AgentProgress,
+	type SubagentLifecyclePayload,
+	type SubagentProgressPayload,
+	TASK_SUBAGENT_LIFECYCLE_CHANNEL,
+	TASK_SUBAGENT_PROGRESS_CHANNEL,
+} from "../src/task/types";
+import { EventBus } from "../src/utils/event-bus";
 
 beforeAll(() => initTheme());
 
@@ -142,6 +150,49 @@ describe("SessionObserverOverlayComponent source snapshots", () => {
 			expect(output).toContain("middle new");
 			expect(output).toContain("tail");
 			expect(output).not.toContain("middle old");
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("recovers a strictly shorter valid in-place replacement from a cached larger offset", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "observer-shorter-valid-"));
+		try {
+			const file = path.join(dir, "session.jsonl");
+			const original = source(
+				"observed",
+				`${record("alpha", "alpha record content")}\n${record("beta", "beta record content longer")}\n`,
+			);
+			fs.writeFileSync(file, original);
+			const overlay = observer(file);
+			expect(rendered(overlay)).toContain("alpha record content");
+			expect(rendered(overlay)).toContain("beta record content longer");
+			const replacement = source("observed", `${record("new", "new")}\n`);
+			expect(Buffer.byteLength(replacement)).toBeLessThan(Buffer.byteLength(original));
+			fs.writeFileSync(file, replacement);
+			overlay.refreshFromRegistry();
+			const output = rendered(overlay);
+			expect(output).toContain("new");
+			expect(output).not.toContain("alpha record content");
+			expect(output).not.toContain("beta record content longer");
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("fails closed for a strictly shorter invalid UTF-8 in-place replacement", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "observer-shorter-invalid-utf8-"));
+		try {
+			const file = path.join(dir, "session.jsonl");
+			const original = source("observed", `${record("old", "old transcript")}\n`);
+			fs.writeFileSync(file, original);
+			const overlay = observer(file);
+			expect(rendered(overlay)).toContain("old transcript");
+			const invalid = Buffer.from([0xc3, 0x0a]);
+			expect(invalid.length).toBeLessThan(Buffer.byteLength(original));
+			fs.writeFileSync(file, invalid);
+			overlay.refreshFromRegistry();
+			expect(rendered(overlay)).not.toContain("old transcript");
 		} finally {
 			fs.rmSync(dir, { recursive: true, force: true });
 		}
@@ -299,6 +350,83 @@ describe("SessionObserverOverlayComponent source snapshots", () => {
 			expect(output).toContain("replacement transcript");
 			expect(output).not.toContain("old-model");
 			expect(output).not.toContain("stale tool result");
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("SessionObserverOverlayComponent explicit refresh ownership", () => {
+	test("surfaces an appended record through the registry onChange -> refreshFromRegistry wiring", () => {
+		// Integration of the production source-refresh chain: a real EventBus drives a
+		// real SessionObserverRegistry, and registry.onChange is wired to
+		// overlay.refreshFromRegistry exactly as SelectorController.showSessionObserver
+		// does. Because render() no longer refreshes unconditionally, this listener is
+		// the sole thing that pulls appended records into view.
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "observer-refresh-ownership-"));
+		try {
+			const file = path.join(dir, "session.jsonl");
+			fs.writeFileSync(file, source("observed", `${record("one", "seed record")}\n`));
+
+			const eventBus = new EventBus();
+			const registry = new SessionObserverRegistry();
+			registry.subscribeToEventBus(eventBus);
+
+			const lifecycle: SubagentLifecyclePayload = {
+				id: "observed",
+				agent: "executor",
+				agentSource: "bundled",
+				description: "Observed",
+				status: "started",
+				sessionFile: file,
+				index: 0,
+			};
+			// Seed the session via the lifecycle channel so the registry tracks it.
+			eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, lifecycle);
+
+			const overlay = new SessionObserverOverlayComponent(registry, () => {}, ["ctrl+s"]);
+			expect(rendered(overlay)).toContain("seed record");
+
+			// Mirror SelectorController.showSessionObserver's wiring verbatim.
+			const unsubscribe = registry.onChange(() => overlay.refreshFromRegistry());
+
+			fs.appendFileSync(file, `${record("two", "appended via ownership")}\n`);
+
+			const progress: AgentProgress = {
+				index: 0,
+				id: "observed",
+				agent: "executor",
+				agentSource: "bundled",
+				status: "running",
+				task: "test task",
+				recentTools: [],
+				recentOutput: [],
+				toolCount: 0,
+				tokens: 0,
+				cost: 0,
+				durationMs: 0,
+			};
+			const progressPayload: SubagentProgressPayload = {
+				index: 0,
+				agent: "executor",
+				agentSource: "bundled",
+				task: "test task",
+				progress,
+				sessionFile: file,
+			};
+			// Emitting an event (NOT a direct refreshFromRegistry call) must surface the
+			// freshly appended record through the onChange wiring alone.
+			eventBus.emit(TASK_SUBAGENT_PROGRESS_CHANNEL, progressPayload);
+			expect(rendered(overlay)).toContain("appended via ownership");
+
+			// Listener cleanup: once unsubscribed a further event must not refresh, so a
+			// third appended record stays invisible without any direct refresh call.
+			unsubscribe();
+			fs.appendFileSync(file, `${record("three", "post cleanup record")}\n`);
+			eventBus.emit(TASK_SUBAGENT_PROGRESS_CHANNEL, progressPayload);
+			expect(rendered(overlay)).not.toContain("post cleanup record");
+
+			registry.dispose();
 		} finally {
 			fs.rmSync(dir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/transcript-viewer-overlay.test.ts
+++ b/packages/coding-agent/test/transcript-viewer-overlay.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import * as path from "node:path";
 import { Agent } from "@gajae-code/agent-core";
 import type { AssistantMessage } from "@gajae-code/ai";
@@ -7,13 +7,15 @@ import { TempDir } from "@gajae-code/utils";
 import { ModelRegistry } from "../src/config/model-registry";
 import { createToolTranscriptRenderDescriptor } from "../src/modes/components/tool-transcript-format";
 import {
+	__transcriptViewerPerfCounters,
 	type TranscriptViewerEntry,
 	TranscriptViewerOverlay,
+	type TranscriptViewerOverlayOptions,
 	transcriptViewerEntries,
 } from "../src/modes/components/transcript-viewer-overlay";
 import { SelectorController } from "../src/modes/controllers/selector-controller";
 import { InteractiveMode } from "../src/modes/interactive-mode";
-import { initTheme } from "../src/modes/theme/theme";
+import { getThemeByName, initTheme, setThemeInstance, theme } from "../src/modes/theme/theme";
 import { TranscriptItemRegistry } from "../src/modes/transcript-item-registry";
 import { AgentSession } from "../src/session/agent-session";
 import { AuthStorage } from "../src/session/auth-storage";
@@ -453,3 +455,287 @@ function entryForOverlay(
 		...entryOverrides,
 	};
 }
+
+describe("PR2a: render/refresh separation and layout cache", () => {
+	beforeEach(() => {
+		__transcriptViewerPerfCounters.reset();
+		__transcriptViewerPerfCounters.disable();
+	});
+	afterEach(() => {
+		__transcriptViewerPerfCounters.reset();
+		__transcriptViewerPerfCounters.disable();
+	});
+
+	function buildViewer(
+		entries: readonly TranscriptViewerEntry[],
+		options: Partial<TranscriptViewerOverlayOptions> = {},
+	): TranscriptViewerOverlay {
+		return new TranscriptViewerOverlay({
+			getEntries: () => entries,
+			onClose: () => {},
+			...options,
+		});
+	}
+
+	test("render does not refresh or rebuild on repeated paint-only frames", () => {
+		const viewer = buildViewer([entryForOverlay("a", "alpha"), entryForOverlay("b", "beta")]);
+		viewer.render(80); // stabilize width at 80 (constructor already rebuilt at 80)
+		__transcriptViewerPerfCounters.enable();
+		__transcriptViewerPerfCounters.reset();
+		viewer.render(80);
+		viewer.render(80);
+		const snap = __transcriptViewerPerfCounters.snapshot();
+		expect(snap.refreshRuns).toBe(0);
+		expect(snap.rebuildRuns).toBe(0);
+		expect(snap.layoutCacheHits).toBe(0);
+		expect(snap.layoutCacheMisses).toBe(0);
+	});
+
+	test("j/k navigation moves selection and rebuilds so the cursor tracks", () => {
+		const viewer = buildViewer([
+			entryForOverlay("a", "alpha"),
+			entryForOverlay("b", "beta"),
+			entryForOverlay("c", "gamma"),
+		]);
+		viewer.render(80);
+		__transcriptViewerPerfCounters.enable();
+		__transcriptViewerPerfCounters.reset();
+		viewer.handleInput("j");
+		expect(viewer.selectedEntryId).toBe("b");
+		viewer.handleInput("j");
+		expect(viewer.selectedEntryId).toBe("c");
+		viewer.handleInput("k");
+		expect(viewer.selectedEntryId).toBe("b");
+		expect(__transcriptViewerPerfCounters.snapshot().rebuildRuns).toBe(3);
+		// Cursor marker must land on the currently-selected entry, proving the rebuild ran.
+		const rendered = viewer.render(80);
+		const cursorLines = rendered.filter(line => line.includes("▶"));
+		expect(cursorLines).toHaveLength(1);
+		expect(cursorLines[0]).toContain("[Custom]");
+	});
+
+	test("g/G jump to top and bottom with an explicit rebuild before scroll", () => {
+		const entries = Array.from({ length: 6 }, (_, index) => entryForOverlay(`e${index}`, `entry-${index}`));
+		const viewer = buildViewer(entries, { initialSelection: "latest" });
+		viewer.render(80);
+		expect(viewer.selectedEntryId).toBe("e5");
+		__transcriptViewerPerfCounters.enable();
+		__transcriptViewerPerfCounters.reset();
+		viewer.handleInput("g");
+		expect(viewer.selectedEntryId).toBe("e0");
+		viewer.handleInput("G");
+		expect(viewer.selectedEntryId).toBe("e5");
+		// Each of g and G rebuilds exactly once before requesting paint.
+		expect(__transcriptViewerPerfCounters.snapshot().rebuildRuns).toBe(2);
+		// The tail entry's body is still on screen after the G rebuild + scroll clamp.
+		expect(viewer.render(80).join("\n")).toContain("entry-5");
+	});
+
+	test("page up/down moves selection and keeps repeated paints stable", () => {
+		const entries = Array.from({ length: 20 }, (_, index) => entryForOverlay(`e${index}`, `entry-${index}`));
+		const viewer = buildViewer(entries);
+		viewer.render(80);
+		viewer.handleInput("G");
+		viewer.render(80); // apply the G-requested tail clamp before capturing the stable frame
+		const atTail = viewer.render(80).join("\n");
+		__transcriptViewerPerfCounters.enable();
+		__transcriptViewerPerfCounters.reset();
+		viewer.handleInput("\x1b[5~"); // pageUp
+		expect(__transcriptViewerPerfCounters.snapshot().rebuildRuns).toBe(1);
+		const paged = viewer.render(80).join("\n");
+		expect(paged).not.toStrictEqual(atTail);
+		// Paint-only frames after the page are byte-identical (no refresh, no rebuild).
+		__transcriptViewerPerfCounters.reset();
+		expect(viewer.render(80).join("\n")).toStrictEqual(paged);
+		expect(__transcriptViewerPerfCounters.snapshot().rebuildRuns).toBe(0);
+		// pageDown also rebuilds exactly once and restores the tail viewport byte-for-byte.
+		__transcriptViewerPerfCounters.reset();
+		viewer.handleInput("\x1b[6~"); // pageDown
+		expect(__transcriptViewerPerfCounters.snapshot().rebuildRuns).toBe(1);
+		expect(viewer.render(80).join("\n")).toStrictEqual(atTail);
+	});
+
+	test("raw toggle rebuilds so the entry body switches between markdown and raw", () => {
+		const viewer = buildViewer([entryForOverlay("a", "# heading\n\nbody text")]);
+		viewer.handleInput(" "); // expand -> markdown path
+		const markdown = viewer.render(80).join("\n");
+		__transcriptViewerPerfCounters.enable();
+		__transcriptViewerPerfCounters.reset();
+		viewer.handleInput("r");
+		expect(__transcriptViewerPerfCounters.snapshot().rebuildRuns).toBe(1);
+		const raw = viewer.render(80).join("\n");
+		expect(raw).not.toStrictEqual(markdown);
+		viewer.handleInput("r");
+		// Toggle back reproduces the original markdown byte-for-byte.
+		expect(viewer.render(80).join("\n")).toStrictEqual(markdown);
+	});
+
+	test("fullscreen enter and exit each rebuild so the display set changes between modes", () => {
+		const viewer = buildViewer([entryForOverlay("a", "alpha"), entryForOverlay("b", "beta")]);
+		viewer.render(80);
+		__transcriptViewerPerfCounters.enable();
+		__transcriptViewerPerfCounters.reset();
+		viewer.handleInput("\r");
+		expect(viewer.isFullscreen).toBe(true);
+		expect(__transcriptViewerPerfCounters.snapshot().rebuildRuns).toBe(1);
+		const fullscreen = viewer.render(80).join("\n");
+		viewer.handleInput("\x1b");
+		expect(viewer.isFullscreen).toBe(false);
+		expect(__transcriptViewerPerfCounters.snapshot().rebuildRuns).toBe(2);
+		const normal = viewer.render(80).join("\n");
+		expect(normal).not.toStrictEqual(fullscreen);
+	});
+
+	test("fullscreen scrolling does not rebuild or refresh (viewport slice only)", () => {
+		const longBody = Array.from({ length: 400 }, (_, index) => `line-${index}`).join("\n");
+		const viewer = buildViewer([entryForOverlay("a", longBody)]);
+		viewer.handleInput("\r"); // enter fullscreen
+		viewer.render(80); // stabilize width/state
+		__transcriptViewerPerfCounters.enable();
+		__transcriptViewerPerfCounters.reset();
+		viewer.handleInput("j");
+		viewer.handleInput("k");
+		viewer.handleInput("\x1b[6~"); // pageDown
+		viewer.handleInput("\x1b[5~"); // pageUp
+		const snap = __transcriptViewerPerfCounters.snapshot();
+		expect(snap.rebuildRuns).toBe(0);
+		expect(snap.refreshRuns).toBe(0);
+		expect(snap.layoutCacheHits).toBe(0);
+		expect(snap.layoutCacheMisses).toBe(0);
+		// The scroll offset actually moved, proving the slice window shifted without rebuilding.
+		const midScroll = viewer.render(80).join("\n");
+		viewer.handleInput("\x1b[6~"); // pageDown again
+		const furtherScroll = viewer.render(80).join("\n");
+		expect(furtherScroll).not.toStrictEqual(midScroll);
+	});
+
+	test("cache lifecycle: cold rebuild misses, stable navigation then hits", () => {
+		const entries = Array.from({ length: 5 }, (_, index) => entryForOverlay(`e${index}`, `entry-${index}`));
+		const viewer = buildViewer(entries);
+		viewer.render(80); // populate cache at width 80 (counters disabled)
+		__transcriptViewerPerfCounters.enable();
+		__transcriptViewerPerfCounters.reset();
+		viewer.render(120); // width change forces rebuild; cache empty at new width
+		let snap = __transcriptViewerPerfCounters.snapshot();
+		expect(snap.rebuildRuns).toBe(1);
+		expect(snap.layoutCacheMisses).toBe(5);
+		expect(snap.layoutCacheHits).toBe(0);
+		__transcriptViewerPerfCounters.reset();
+		viewer.handleInput("j"); // selected=1; the old selected (e0) needs its unselected variant and the newly selected (e1) needs its selected variant, so both miss
+		snap = __transcriptViewerPerfCounters.snapshot();
+		expect(snap.layoutCacheHits).toBe(3);
+		expect(snap.layoutCacheMisses).toBe(2);
+		__transcriptViewerPerfCounters.reset();
+		viewer.handleInput("k"); // selected=0; all variants pre-cached
+		snap = __transcriptViewerPerfCounters.snapshot();
+		expect(snap.layoutCacheHits).toBe(5);
+		expect(snap.layoutCacheMisses).toBe(0);
+	});
+
+	test("navigation with more than ten entries achieves at least 90% layout hits after the first rebuild", () => {
+		const entries = Array.from({ length: 20 }, (_, index) => entryForOverlay(`e${index}`, `entry-${index}`));
+		const viewer = buildViewer(entries);
+		viewer.render(80); // populate cache (counters disabled)
+		__transcriptViewerPerfCounters.enable();
+		__transcriptViewerPerfCounters.reset();
+		// Each move only misses the newly-selected variant; everything else hits.
+		viewer.handleInput("j");
+		viewer.handleInput("j");
+		viewer.handleInput("j");
+		viewer.handleInput("k");
+		viewer.handleInput("k");
+		viewer.handleInput("k");
+		const snap = __transcriptViewerPerfCounters.snapshot();
+		const total = snap.layoutCacheHits + snap.layoutCacheMisses;
+		expect(total).toBeGreaterThan(0);
+		expect(snap.layoutCacheHits / total).toBeGreaterThanOrEqual(0.9);
+	});
+
+	test("width change produces fresh cache misses for the new variant key", () => {
+		const viewer = buildViewer([entryForOverlay("a", "alpha"), entryForOverlay("b", "beta")]);
+		viewer.render(80);
+		__transcriptViewerPerfCounters.enable();
+		__transcriptViewerPerfCounters.reset();
+		viewer.render(120);
+		const snap = __transcriptViewerPerfCounters.snapshot();
+		expect(snap.rebuildRuns).toBe(1);
+		expect(snap.layoutCacheMisses).toBe(2);
+		expect(snap.layoutCacheHits).toBe(0);
+		__transcriptViewerPerfCounters.reset();
+		viewer.render(80);
+		const returned = __transcriptViewerPerfCounters.snapshot();
+		expect(returned.layoutCacheMisses).toBe(2);
+		expect(returned.layoutCacheHits).toBe(0);
+	});
+
+	test("theme reference change clears the cache and re-runs markdown layout", async () => {
+		const original = theme;
+		try {
+			const viewer = buildViewer([entryForOverlay("a", "# heading\n\nbody")]);
+			viewer.handleInput(" "); // expand -> markdown path uses mdTheme
+			viewer.render(80);
+			__transcriptViewerPerfCounters.enable();
+			__transcriptViewerPerfCounters.reset();
+			const other = await getThemeByName("blue-crab");
+			expect(other).toBeDefined();
+			setThemeInstance(other!);
+			viewer.render(80);
+			const snap = __transcriptViewerPerfCounters.snapshot();
+			expect(snap.rebuildRuns).toBe(1);
+			expect(snap.layoutCacheHits).toBe(0);
+			expect(snap.layoutCacheMisses).toBe(1);
+		} finally {
+			setThemeInstance(original);
+		}
+	});
+
+	test("refresh clears the cache so same-id changed closures cannot serve stale lines", () => {
+		let displayText = "original-content";
+		const entry: TranscriptViewerEntry = {
+			id: "x",
+			kind: "custom",
+			label: "Custom",
+			payload: { text: "raw-payload", metadata: {}, source: "raw-payload" },
+			foldable: true,
+			getDisplayText: () => displayText,
+		};
+		const viewer = new TranscriptViewerOverlay({
+			getEntries: () => [entry],
+			onClose: () => {},
+		});
+		viewer.handleInput(" "); // expand so getDisplayText feeds the markdown path
+		expect(viewer.render(80).join("\n")).toContain("original-content");
+		displayText = "updated-content";
+		viewer.refresh();
+		const after = viewer.render(80).join("\n");
+		expect(after).toContain("updated-content");
+		expect(after).not.toContain("original-content");
+	});
+
+	test("invalidateLayoutEntries drops every variant for the targeted ids", () => {
+		const viewer = buildViewer([entryForOverlay("a", "alpha"), entryForOverlay("b", "beta")]);
+		viewer.render(80); // populate cache: a's selected variant and b's unselected variant
+		// Warm every selected-state variant first. The initial render only caches the selected
+		// variant of `a` and the unselected variant of `b`; the first j/k warms the two missing
+		// variants (b's selected and a's unselected).
+		viewer.handleInput("j");
+		viewer.handleInput("k");
+		// With all variants warm, a no-invalidation j/k sequence hits every variant.
+		__transcriptViewerPerfCounters.enable();
+		__transcriptViewerPerfCounters.reset();
+		viewer.handleInput("j");
+		viewer.handleInput("k");
+		let snap = __transcriptViewerPerfCounters.snapshot();
+		expect(snap.layoutCacheMisses).toBe(0);
+		expect(snap.layoutCacheHits).toBe(4);
+		// Targeted invalidation drops only `a`'s variants; `b` stays fully cached, so only the
+		// two `a` variants repopulate across the next j/k.
+		__transcriptViewerPerfCounters.reset();
+		viewer.invalidateLayoutEntries(["a"]);
+		viewer.handleInput("j");
+		viewer.handleInput("k");
+		snap = __transcriptViewerPerfCounters.snapshot();
+		expect(snap.layoutCacheMisses).toBe(2);
+		expect(snap.layoutCacheHits).toBe(2);
+	});
+});


### PR DESCRIPTION
## Summary

- stop `TranscriptViewerOverlay.render()` from refreshing and projecting its source on every paint
- rebuild explicitly for navigation/raw/expand/fullscreen state changes and reuse per-entry layout variants across stable frames
- preserve explicit source refresh ownership through AgentSession events and Session Observer registry notifications, including shorter-file replacement recovery
- add deterministic refresh/rebuild/cache counters and record a 98.9% navigation layout-cache hit rate on the 100-entry fixture

## Why

The Session Observer and main transcript viewer previously performed full source projection plus full layout rendering on every paint. That made ordinary `j/k` and PgUp/PgDn navigation pay O(total history) projection/layout cost even when the source was unchanged.

PR2a separates source refresh from layout-only interaction. Paint-only frames now perform zero refreshes and zero rebuilds. Navigation still rebuilds cumulative positions, but nearly all entry layouts are reused from cache. PR2b projection incrementalization and PR2c viewport virtualization remain separate evidence-gated follow-ups.

## Refresh ownership audit

- main viewer: `EventController` refreshes an open viewer after AgentSession events; identity maps preserve provisional-to-durable selection
- observer: `SessionObserverRegistry.onChange()` refreshes after lifecycle/progress events
- session cycle and source replacement paths refresh explicitly
- `j/k`, PgUp/PgDn, `g/G`, raw, expand/collapse, fullscreen enter/exit, and mouse selection rebuild explicitly
- fullscreen scrolling changes only the existing line slice
- width and theme changes invalidate layout variants and rebuild

Integration tests cover both production refresh trigger chains without relying on render-time refresh.

## Performance evidence

`artifacts/pr2a-session-observer-structural-performance.json`:

- 100 entries, 10 navigation moves
- 989 layout cache hits / 11 misses (98.9%)
- navigation refresh runs: 0
- paint-only refresh runs: 0
- paint-only rebuild runs: 0

The cache intentionally trades bounded retained layout memory for lower CPU/allocation churn. It is cleared on source refresh, width change, and theme change. Timing and RSS remain advisory and are not promoted to release thresholds.

## Flicker boundary

The black-row flicker observed while scrolling is not addressed in this PR. The TUI differential renderer clears changed terminal rows before rewriting them; terminals or multiplexers that do not fully honor synchronized output may expose that intermediate state. That renderer-level investigation belongs in a separate `packages/tui` change so it does not obscure PR2a regression attribution.

## Verification

- `bun test test/transcript-viewer-overlay.test.ts test/session-observer-overlay.test.ts test/modes/controllers/event-controller-message-start.test.ts test/transcript-viewer-perf.test.ts test/transcript-adapter-parity.test.ts test/g001-toolrender-redteam.test.ts test/g002-ws1-redteam.test.ts test/g005-ws5-redteam.test.ts test/g006-ws2-redteam.test.ts test/g006-ws6-redteam.test.ts test/silent-abort-overlay-render.test.ts`
  - 95 passed, 0 failed, 485 assertions
- `bun check` from `packages/coding-agent`
  - Biome passed
  - TypeScript check passed

## Contribution checklist

- [x] targets `dev`
- [x] changelog entry added under `[Unreleased]`
- [x] focused tests run before broader package checks
- [x] shared viewer and observer refresh ownership audited and integration-tested
- [x] deterministic performance evidence included
- [x] PR2b, PR2c, payload eviction, and renderer flicker changes excluded