### PR TITLE
test(team): give the two-worker memory-guard replacement test CI headroom

### DIFF
--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -3629,7 +3629,7 @@ describe("team worker memory guard wiring", () => {
 		expect(committedPaths).not.toContain(protectedPath);
 		expect(runGit(workerWorktree!, ["diff", "--cached", "--name-only"]).split(/\r?\n/)).toContain(protectedPath);
 		expect(task.claim?.owner).toBe("worker-2");
-	});
+	}, 20000);
 
 	it("caps Linux replacement retries and blocks the claimed task on the terminal failure", async () => {
 		cleanupRoot = await createGitRepo();


### PR DESCRIPTION
## Summary
Dev CI is red at c97da89c on `Affected path validation / test:@gajae-code/coding-agent:shard-2-of-8`: `team worker memory guard wiring > selects the hottest Linux worker, checkpoints it, and syncs config and manifest on replacement` timed out at bun:test's default 5000ms (run 30358765702 / job 90274588692).

## Root cause
This test spins up two real git worktrees, a fake tmux binary, and races a task claim + worker-startup-ack against `apply-worker-memory-guard` across real subprocesses. Locally it completes reliably in ~830-915ms across repeated runs (full-file run: 106 pass / 19s), well under 5s — but it has effectively no margin under CI shard contention (8 parallel shards sharing a runner), and it is the heaviest test in this describe block (its sibling, single-worker `caps Linux replacement retries...`, ran in 105ms in the same CI log).

## Fix
Give it the same explicit per-test timeout headroom the codebase already uses for heavier async tests elsewhere (e.g. `agent-session-compaction.test.ts` uses 120000/180000 for real LLM round trips). 20000ms here is ample margin for local subprocess/git I/O without masking a real hang.

## Verification
- `bun test test/gjc-runtime/team-runtime.test.ts -t "hottest Linux worker"` — 1 pass (3 consecutive runs, 832-915ms each)
- `bun test test/gjc-runtime/team-runtime.test.ts` (full file) — 106 pass, 0 fail
- `bun run check` in `packages/coding-agent` — Biome + tsc pass