### PR TITLE
fix(team): bump memory-guard replacement test timeout past CI contention margin

### DIFF
--- a/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/team-runtime.test.ts
@@ -3629,7 +3629,7 @@ describe("team worker memory guard wiring", () => {
 		expect(committedPaths).not.toContain(protectedPath);
 		expect(runGit(workerWorktree!, ["diff", "--cached", "--name-only"]).split(/\r?\n/)).toContain(protectedPath);
 		expect(task.claim?.owner).toBe("worker-2");
-	});
+	}, 20_000);
 
 	it("caps Linux replacement retries and blocks the claimed task on the terminal failure", async () => {
 		cleanupRoot = await createGitRepo();


### PR DESCRIPTION
Dev CI (run 30358765702) failed on `test:@gajae-code/coding-agent:shard-2-of-8` because `team worker memory guard wiring > selects the hottest Linux worker, checkpoints it, and syncs config and manifest on replacement` timed out at 5012ms against bun test's default 5000ms budget.

The test does real subprocess/git checkpoint work plus a 50ms-interval ack poll; it passes reliably in isolation (3/3 local runs) but is timing-sensitive under shard-parallel CI load. Bumping its explicit timeout to 20s gives headroom without touching runtime logic.

No functional code changed — single-line test-only diff, verified with a fresh `origin/dev`-based checkout (106/106 tests pass).