### PR TITLE
fix(skill-state): stop heredoc document bodies from false-blocking spec persistence during planning phases

### DIFF
--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -180,6 +180,7 @@ Run this phase only when the active deep-interview state or invocation indicates
    - Direct `.gjc/` file edits are forbidden unless an explicit force override is active; do not use `write`, `edit`, or `ast_edit` against `.gjc/_session-{sessionid}/specs`, `.gjc/_session-{sessionid}/plans`, `.gjc/_session-{sessionid}/state`, or other `.gjc/` paths during normal workflow operation.
    - Preferred: pass the spec markdown **inline** to the native deep-interview write command (`--write … --spec "<markdown>"`) — no scratch file is needed. The CLI is the only sanctioned writer for `.gjc/_session-{sessionid}/specs`.
    - Only if a spec is too large to pass inline, stage it with the `write` tool to a system temp directory (`os.tmpdir()`/`$TMPDIR`, `/tmp`, `/var/tmp`) outside the project tree, then pass that path to `--spec`. The planning phase-boundary block tolerates these neutral temp writes; never stage interview artifacts inside the repo or under `.gjc/`, and do not improvise repo-relative scratch files.
+   - When staging via bash instead of the `write` tool, a heredoc into a neutral temp path (`cat > /tmp/spec.md <<'EOF' … EOF`) is also tolerated; quote the heredoc delimiter (`<<'EOF'`) so the document body stays inert. Never stage into the repo or `.gjc/`, and prefer the `write` tool over bash for large bodies.
 
 4. **Initialize state** via `gjc deep-interview write --input '<json>'`:
 

--- a/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
@@ -45,7 +45,7 @@ gjc ralplan --write --stage <type> --stage_n <N> --artifact "markdown file path 
 gjc ralplan --write --stage <type> --stage_n <N> --artifact-env GJC_RALPLAN_ARTIFACT
 ```
 
-Use stages `planner`, `architect`, `critic`, `revision`, `post-interview`, `adr`, or `final`; increment `--stage_n` each consensus pass. The writer accepts inline markdown, an artifact path prepared outside `.gjc/`, or `--artifact-env GJC_RALPLAN_ARTIFACT`, persists `stage-<NN>-<stage>.md` plus `index.jsonl` under `.gjc/_session-{sessionid}/plans/ralplan/<run-id>/`, and copies `final` to `pending-approval.md`. Ralplan mutation blocking is enforced in code; use temp directories (`os.tmpdir()`/`$TMPDIR`, `/tmp`, `/var/tmp`) only for oversized scratch artifacts, never the repo or `.gjc/`.
+Use stages `planner`, `architect`, `critic`, `revision`, `post-interview`, `adr`, or `final`; increment `--stage_n` each consensus pass. The writer accepts inline markdown, an artifact path prepared outside `.gjc/`, or `--artifact-env GJC_RALPLAN_ARTIFACT`, persists `stage-<NN>-<stage>.md` plus `index.jsonl` under `.gjc/_session-{sessionid}/plans/ralplan/<run-id>/`, and copies `final` to `pending-approval.md`. Ralplan mutation blocking is enforced in code; use temp directories (`os.tmpdir()`/`$TMPDIR`, `/tmp`, `/var/tmp`) only for oversized scratch artifacts, never the repo or `.gjc/`. Staging via the `write` tool or a quoted-delimiter bash heredoc (`cat > /tmp/plan.md <<'EOF' … EOF`) into those temp roots is tolerated by the planning-phase guard.
 
 Restricted read-only role agents (`planner`, `architect`, `critic`) must pass markdown through `GJC_RALPLAN_ARTIFACT` with `--artifact-env GJC_RALPLAN_ARTIFACT`; their restricted bash environment disables artifact file-path ingestion.
 

--- a/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
@@ -503,11 +503,22 @@ function cutShellComment(syntaxLine: string): string {
 	return syntaxLine;
 }
 
+/** First command word of a pipeline-segment slice of a quote-masked opener line. */
+function firstCommandWord(segment: string): string {
+	for (const word of segment.trim().split(/\s+/)) {
+		if (!word || /^\w+=/.test(word) || word === "sudo") continue;
+		return word.split("/").pop()?.toLowerCase() ?? "";
+	}
+	return "";
+}
+
 /**
- * Classify the simple command that consumes the heredoc at offset `at` of the
- * comment-cut, quote-masked opener line. Only explicitly inert data consumers
- * qualify for body masking; stdin appliers fail closed; everything else
- * (interpreters, awk, unknown binaries) keeps its body live.
+ * Classify the command consuming the heredoc at offset `at` of the comment-cut,
+ * quote-masked opener line — including every DOWNSTREAM pipe stage, because
+ * `cat <<'EOF' | bash` hands the body to the interpreter even though `cat` is
+ * inert. Only a pipeline whose every stage is an explicitly inert data consumer
+ * qualifies for body masking; any stdin applier stage fails closed; anything
+ * else (interpreters, awk, unknown binaries) keeps the body live.
  */
 function heredocConsumerKind(syntaxLine: string, at: number): "data" | "mutating" | "other" {
 	let start = 0;
@@ -518,16 +529,30 @@ function heredocConsumerKind(syntaxLine: string, at: number): "data" | "mutating
 			break;
 		}
 	}
-	let command = "";
-	for (const word of syntaxLine.slice(start, at).trim().split(/\s+/)) {
-		if (!word || /^\w+=/.test(word) || word === "sudo") continue;
-		command = word;
-		break;
+	// The heredoc's own simple command plus every downstream `|` stage until the
+	// command list ends (`;`, `&&`, `||`, `&`, backtick, or subshell close).
+	const segments: string[] = [syntaxLine.slice(start, at)];
+	let cursor = at;
+	while (cursor < syntaxLine.length) {
+		const character = syntaxLine[cursor] ?? "";
+		if (character === ";" || character === "&" || character === "`" || character === ")") break;
+		if (character === "|") {
+			if (syntaxLine[cursor + 1] === "|") break;
+			let stageEnd = cursor + 1;
+			while (stageEnd < syntaxLine.length && !";|&`)".includes(syntaxLine[stageEnd] ?? "")) stageEnd++;
+			segments.push(syntaxLine.slice(cursor + 1, stageEnd));
+			cursor = stageEnd;
+			continue;
+		}
+		cursor++;
 	}
-	const base = command.split("/").pop()?.toLowerCase() ?? "";
-	if (HEREDOC_MUTATING_CONSUMERS.has(base)) return "mutating";
-	if (HEREDOC_DATA_CONSUMERS.has(base)) return "data";
-	return "other";
+	let kind: "data" | "mutating" | "other" = "data";
+	for (const segment of segments) {
+		const base = firstCommandWord(segment);
+		if (HEREDOC_MUTATING_CONSUMERS.has(base)) return "mutating";
+		if (!HEREDOC_DATA_CONSUMERS.has(base)) kind = "other";
+	}
+	return kind;
 }
 
 /**

--- a/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
@@ -60,6 +60,13 @@ const BASH_DD_OUTPUT_RE = /(?:^|[;&|\n])\s*(?:\w+=[^\s]+\s+)*(?:sudo\s+)?(?:[^\s
 /** Literal `sh|bash|zsh -c '<script>'` payloads whose nested script must also be scanned. */
 const BASH_NESTED_SHELL_RE =
 	/(?:^|[;&|\n])\s*(?:\w+=[^\s]+\s+)*(?:sudo\s+)?(?:[^\s;&|]*\/)?(?:ba|z|da)?sh\s+(?:-[A-Za-z]+\s+)*-[A-Za-z]*c\s+(?:(')([^']*)'|(")([^"]*)")/g;
+/** Heredoc opener (`<<`/`<<-` plus an optionally quoted delimiter); `<<<` here-strings excluded. */
+const BASH_HEREDOC_OPEN_RE = /(?<!<)<<(?!<)(-?)\s*(?:'([^'\s]+)'|"([^"\s]+)"|(\\)?([A-Za-z_][\w.-]*))/g;
+/** Opener-line interpreters that execute their stdin, making a heredoc body live shell/script code. */
+const BASH_HEREDOC_SCRIPT_CONSUMER_RE =
+	/(?:^|[\s;&|(`])(?:[^\s;&|()`]*\/)?(?:(?:ba|z|da|k)?sh|python3?|node|bun|deno|ruby|perl|php|eval|source|xargs|parallel)(?=[\s;&|)`<]|$)/i;
+/** Opener-line stdin appliers whose heredoc body mutates files in ways no body scan can model. */
+const BASH_HEREDOC_MUTATING_CONSUMER_RE = /(?:^|[\s;&|(`])(?:[^\s;&|()`]*\/)?(?:patch|ed|ex|sqlite3)(?=[\s;&|)`<]|$)/i;
 
 type ToolWithEditMode = AgentTool & {
 	mode?: unknown;
@@ -418,6 +425,69 @@ function isDeviceSinkPath(value: string): boolean {
 	return DEVICE_SINK_PATHS.has(cleanShellWord(value));
 }
 
+interface HeredocMaskResult {
+	masked: string;
+	/** An unquoted-delimiter heredoc body carried `$(…)`/backtick expansion — live code the scanner cannot model. */
+	opaqueExpansion: boolean;
+	/** The heredoc feeds a stdin applier (patch/ed/ex/sqlite3) whose body mutates files no scan can attribute. */
+	mutatingConsumer: boolean;
+}
+
+/**
+ * Blank out heredoc BODY lines so document payloads (markdown specs, plans,
+ * fixtures) piped to a data consumer (`cat <<'EOF' > /tmp/spec.md`) are not
+ * misread as shell commands: body text like `a > b` or stray apostrophes must
+ * not register redirection targets or unbalance the quote masker. Bodies stay
+ * UNMASKED (scanned as today) when the opener line feeds a script consumer
+ * (sh/python/patch/…), because there the body is live code. Unquoted-delimiter
+ * bodies still expand `$(…)`/backticks in real shells, so those flag
+ * `opaqueExpansion` and the caller fails closed. An unterminated heredoc is not
+ * statically maskable; the original text is returned so the scanner stays
+ * fail-closed rather than blind.
+ */
+function maskHeredocBodies(command: string): HeredocMaskResult {
+	if (!command.includes("<<")) return { masked: command, opaqueExpansion: false, mutatingConsumer: false };
+	const lines = command.split("\n");
+	const out: string[] = [];
+	let opaqueExpansion = false;
+	let mutatingConsumer = false;
+	for (let index = 0; index < lines.length; index++) {
+		const line = lines[index] ?? "";
+		out.push(line);
+		// Per-line quote masking decides whether a `<<` (and the consumer name) is
+		// real syntax or quoted data on this opener line.
+		const visible = maskSingleQuotedSpans(line);
+		const scriptConsumer = BASH_HEREDOC_SCRIPT_CONSUMER_RE.test(visible);
+		const mutatesFromStdin = BASH_HEREDOC_MUTATING_CONSUMER_RE.test(visible);
+		for (const match of line.matchAll(BASH_HEREDOC_OPEN_RE)) {
+			const at = match.index ?? 0;
+			if (visible.slice(at, at + 2) !== "<<") continue;
+			const delimiter = match[2] ?? match[3] ?? match[5] ?? "";
+			if (!delimiter) continue;
+			if (mutatesFromStdin) mutatingConsumer = true;
+			const quoted = match[2] !== undefined || match[3] !== undefined || match[4] !== undefined;
+			const stripTabs = match[1] === "-";
+			let end = -1;
+			for (let scan = index + 1; scan < lines.length; scan++) {
+				const candidate = stripTabs ? (lines[scan] ?? "").replace(/^\t+/, "") : (lines[scan] ?? "");
+				if (candidate === delimiter) {
+					end = scan;
+					break;
+				}
+			}
+			if (end === -1) return { masked: command, opaqueExpansion, mutatingConsumer };
+			for (let body = index + 1; body < end; body++) {
+				const bodyLine = lines[body] ?? "";
+				if (!quoted && /\$\(|`/.test(bodyLine)) opaqueExpansion = true;
+				out.push(scriptConsumer ? bodyLine : "");
+			}
+			out.push(lines[end] ?? "");
+			index = end;
+		}
+	}
+	return { masked: out.join("\n"), opaqueExpansion, mutatingConsumer };
+}
+
 function extractBashTargets(args: unknown, depth = 0): ExtractedTargets {
 	const record = getRecord(args);
 	const command = safeString(record?.command);
@@ -440,10 +510,21 @@ function extractBashTargets(args: unknown, depth = 0): ExtractedTargets {
 		if (nested.unknown) targets.unknown = true;
 		if (nested.explicitMutation) targets.explicitMutation = true;
 	}
+	// Heredoc bodies fed to data consumers are inert document payloads; mask them
+	// so spec/plan text cannot fake redirections. Script-consumer bodies survive
+	// the mask and are still scanned as live code below.
+	const heredoc = maskHeredocBodies(command);
+	if (heredoc.opaqueExpansion || heredoc.mutatingConsumer) {
+		targets.explicitMutation = true;
+		targets.unknown = true;
+	}
 	// Nested scripts were read from the raw text above; every scanner below works
 	// on the masked view so quoted argument data cannot look like a redirection.
-	const scanned = maskSingleQuotedSpans(command);
-	if (BASH_OPAQUE_INTERPRETER_WRITE_RE.test(command) || BASH_HEREDOC_OPAQUE_INTERPRETER_WRITE_RE.test(command)) {
+	const scanned = maskSingleQuotedSpans(heredoc.masked);
+	if (
+		BASH_OPAQUE_INTERPRETER_WRITE_RE.test(heredoc.masked) ||
+		BASH_HEREDOC_OPAQUE_INTERPRETER_WRITE_RE.test(heredoc.masked)
+	) {
 		targets.explicitMutation = true;
 		targets.unknown = true;
 	}
@@ -502,6 +583,9 @@ function extractBashTargets(args: unknown, depth = 0): ExtractedTargets {
 		for (const part of targetParts) {
 			const cleaned = cleanShellWord(part);
 			if (!cleaned || cleaned.startsWith("-")) continue;
+			// Redirection/heredoc operator words (`>/dev/null`, `<<'DOC'`, `2>&1`) are
+			// not argument paths; their targets are captured by the redirect scanners.
+			if (/^\d*[<>]/.test(cleaned)) continue;
 			addPath(targets, cleaned);
 		}
 	}

--- a/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
@@ -62,11 +62,33 @@ const BASH_NESTED_SHELL_RE =
 	/(?:^|[;&|\n])\s*(?:\w+=[^\s]+\s+)*(?:sudo\s+)?(?:[^\s;&|]*\/)?(?:ba|z|da)?sh\s+(?:-[A-Za-z]+\s+)*-[A-Za-z]*c\s+(?:(')([^']*)'|(")([^"]*)")/g;
 /** Heredoc opener (`<<`/`<<-` plus an optionally quoted delimiter); `<<<` here-strings excluded. */
 const BASH_HEREDOC_OPEN_RE = /(?<!<)<<(?!<)(-?)\s*(?:'([^'\s]+)'|"([^"\s]+)"|(\\)?([A-Za-z_][\w.-]*))/g;
-/** Opener-line interpreters that execute their stdin, making a heredoc body live shell/script code. */
-const BASH_HEREDOC_SCRIPT_CONSUMER_RE =
-	/(?:^|[\s;&|(`])(?:[^\s;&|()`]*\/)?(?:(?:ba|z|da|k)?sh|python3?|node|bun|deno|ruby|perl|php|eval|source|xargs|parallel)(?=[\s;&|)`<]|$)/i;
-/** Opener-line stdin appliers whose heredoc body mutates files in ways no body scan can model. */
-const BASH_HEREDOC_MUTATING_CONSUMER_RE = /(?:^|[\s;&|(`])(?:[^\s;&|()`]*\/)?(?:patch|ed|ex|sqlite3)(?=[\s;&|)`<]|$)/i;
+/** Consumers whose stdin is inert data: their heredoc bodies are safe to mask. Anything else stays live. */
+const HEREDOC_DATA_CONSUMERS = new Set([
+	"cat",
+	"tee",
+	"head",
+	"tail",
+	"wc",
+	"sort",
+	"uniq",
+	"tr",
+	"cut",
+	"grep",
+	"column",
+	"nl",
+	"fold",
+	"fmt",
+	"base64",
+	"md5sum",
+	"sha1sum",
+	"sha256sum",
+	"sha512sum",
+	"shasum",
+	"jq",
+	"yq",
+]);
+/** Stdin appliers whose heredoc body mutates files in ways no body scan can model. */
+const HEREDOC_MUTATING_CONSUMERS = new Set(["patch", "ed", "ex", "sqlite3"]);
 
 type ToolWithEditMode = AgentTool & {
 	mode?: unknown;
@@ -434,16 +456,79 @@ interface HeredocMaskResult {
 }
 
 /**
+ * Blank out double-quoted spans (like `maskSingleQuotedSpans`) so a `<<` inside
+ * `"…"` argument data is not misread as a heredoc opener. Unbalanced quotes
+ * return the original text so the caller stays fail-closed rather than blind.
+ */
+function maskDoubleQuotedSpans(text: string): string {
+	let masked = "";
+	let inDouble = false;
+	for (const character of text) {
+		if (character === '"') {
+			inDouble = !inDouble;
+			masked += character;
+			continue;
+		}
+		masked += inDouble && character !== "\n" ? " " : character;
+	}
+	return inDouble ? text : masked;
+}
+
+/**
+ * Cut a quote-masked line at an unquoted `#` comment start (line start or after
+ * whitespace/separator), so a `<<` inside comment text is never an opener.
+ */
+function cutShellComment(syntaxLine: string): string {
+	for (let index = 0; index < syntaxLine.length; index++) {
+		if (syntaxLine[index] !== "#") continue;
+		const previous = index === 0 ? "" : syntaxLine[index - 1];
+		if (previous === "" || previous === " " || previous === "\t" || ";|&(".includes(previous)) {
+			return syntaxLine.slice(0, index);
+		}
+	}
+	return syntaxLine;
+}
+
+/**
+ * Classify the simple command that consumes the heredoc at offset `at` of the
+ * comment-cut, quote-masked opener line. Only explicitly inert data consumers
+ * qualify for body masking; stdin appliers fail closed; everything else
+ * (interpreters, awk, unknown binaries) keeps its body live.
+ */
+function heredocConsumerKind(syntaxLine: string, at: number): "data" | "mutating" | "other" {
+	let start = 0;
+	for (let index = at - 1; index >= 0; index--) {
+		const character = syntaxLine[index] ?? "";
+		if (";|&(`".includes(character) || character === "\n") {
+			start = index + 1;
+			break;
+		}
+	}
+	let command = "";
+	for (const word of syntaxLine.slice(start, at).trim().split(/\s+/)) {
+		if (!word || /^\w+=/.test(word) || word === "sudo") continue;
+		command = word;
+		break;
+	}
+	const base = command.split("/").pop()?.toLowerCase() ?? "";
+	if (HEREDOC_MUTATING_CONSUMERS.has(base)) return "mutating";
+	if (HEREDOC_DATA_CONSUMERS.has(base)) return "data";
+	return "other";
+}
+
+/**
  * Blank out heredoc BODY lines so document payloads (markdown specs, plans,
- * fixtures) piped to a data consumer (`cat <<'EOF' > /tmp/spec.md`) are not
- * misread as shell commands: body text like `a > b` or stray apostrophes must
- * not register redirection targets or unbalance the quote masker. Bodies stay
- * UNMASKED (scanned as today) when the opener line feeds a script consumer
- * (sh/python/patch/…), because there the body is live code. Unquoted-delimiter
- * bodies still expand `$(…)`/backticks in real shells, so those flag
- * `opaqueExpansion` and the caller fails closed. An unterminated heredoc is not
- * statically maskable; the original text is returned so the scanner stays
- * fail-closed rather than blind.
+ * fixtures) piped to an explicitly inert data consumer (`cat <<'EOF' >
+ * /tmp/spec.md`) are not misread as shell commands: body text like `a > b` or
+ * stray apostrophes must not register redirection targets or unbalance the
+ * quote masker. Bodies stay UNMASKED (scanned as today) for every other
+ * consumer — interpreters, awk, unknown binaries — because there the body may
+ * be live code. Stdin appliers (patch/ed/ex/sqlite3) flag `mutatingConsumer`
+ * and the caller fails closed. Unquoted-delimiter bodies still expand
+ * `$(…)`/backticks in real shells, so masked ones flag `opaqueExpansion`. A
+ * `<<` inside a comment or a quoted span is not an opener. An unterminated
+ * heredoc is not statically maskable; the original text is returned so the
+ * scanner stays fail-closed rather than blind.
  */
 function maskHeredocBodies(command: string): HeredocMaskResult {
 	if (!command.includes("<<")) return { masked: command, opaqueExpansion: false, mutatingConsumer: false };
@@ -454,17 +539,16 @@ function maskHeredocBodies(command: string): HeredocMaskResult {
 	for (let index = 0; index < lines.length; index++) {
 		const line = lines[index] ?? "";
 		out.push(line);
-		// Per-line quote masking decides whether a `<<` (and the consumer name) is
-		// real syntax or quoted data on this opener line.
-		const visible = maskSingleQuotedSpans(line);
-		const scriptConsumer = BASH_HEREDOC_SCRIPT_CONSUMER_RE.test(visible);
-		const mutatesFromStdin = BASH_HEREDOC_MUTATING_CONSUMER_RE.test(visible);
+		// Quote masking + comment cutting decide whether a `<<` is real syntax or
+		// inert data on this opener line.
+		const syntax = cutShellComment(maskDoubleQuotedSpans(maskSingleQuotedSpans(line)));
 		for (const match of line.matchAll(BASH_HEREDOC_OPEN_RE)) {
 			const at = match.index ?? 0;
-			if (visible.slice(at, at + 2) !== "<<") continue;
+			if (syntax.slice(at, at + 2) !== "<<") continue;
 			const delimiter = match[2] ?? match[3] ?? match[5] ?? "";
 			if (!delimiter) continue;
-			if (mutatesFromStdin) mutatingConsumer = true;
+			const kind = heredocConsumerKind(syntax, at);
+			if (kind === "mutating") mutatingConsumer = true;
 			const quoted = match[2] !== undefined || match[3] !== undefined || match[4] !== undefined;
 			const stripTabs = match[1] === "-";
 			let end = -1;
@@ -476,10 +560,11 @@ function maskHeredocBodies(command: string): HeredocMaskResult {
 				}
 			}
 			if (end === -1) return { masked: command, opaqueExpansion, mutatingConsumer };
+			const maskBody = kind === "data" || kind === "mutating";
 			for (let body = index + 1; body < end; body++) {
 				const bodyLine = lines[body] ?? "";
-				if (!quoted && /\$\(|`/.test(bodyLine)) opaqueExpansion = true;
-				out.push(scriptConsumer ? bodyLine : "");
+				if (maskBody && !quoted && /\$\(|`/.test(bodyLine)) opaqueExpansion = true;
+				out.push(maskBody ? "" : bodyLine);
 			}
 			out.push(lines[end] ?? "");
 			index = end;

--- a/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
@@ -457,13 +457,27 @@ interface HeredocMaskResult {
 
 /**
  * Blank out double-quoted spans (like `maskSingleQuotedSpans`) so a `<<` inside
- * `"…"` argument data is not misread as a heredoc opener. Unbalanced quotes
- * return the original text so the caller stays fail-closed rather than blind.
+ * `"…"` argument data is not misread as a heredoc opener. A backslash-escaped
+ * `\"` never toggles the quote state — outside quotes it is a literal quote
+ * character, inside quotes it is escaped data — so `"a \" << \" b"` stays one
+ * masked span. Unbalanced quotes return the original text so the caller stays
+ * fail-closed rather than blind.
  */
 function maskDoubleQuotedSpans(text: string): string {
 	let masked = "";
 	let inDouble = false;
+	let escaped = false;
 	for (const character of text) {
+		if (escaped) {
+			escaped = false;
+			masked += inDouble && character !== "\n" ? " " : character;
+			continue;
+		}
+		if (character === "\\") {
+			escaped = true;
+			masked += inDouble ? " " : character;
+			continue;
+		}
 		if (character === '"') {
 			inDouble = !inDouble;
 			masked += character;

--- a/packages/coding-agent/test/workflow-mutation-guard.test.ts
+++ b/packages/coding-agent/test/workflow-mutation-guard.test.ts
@@ -347,6 +347,8 @@ describe("workflow mutation guard", () => {
 			"# <<'EOF'\nrm src/product.ts\nEOF",
 			// A `<<` inside double-quoted argument data is not an opener either.
 			'printf "%s" "<<\'EOF\'"\nrm src/product.ts\nEOF',
+			// Escaped quotes must not re-expose a quoted `<<` as an opener (Codex P1).
+			'cat "a \\" <<\'EOF\' \\" b"\nrm src/product.ts\nEOF',
 			// Unquoted delimiter + command substitution in body expands at runtime — fail closed.
 			"cat <<EOF > /tmp/out.md\n$(rm src/product.ts)\nEOF",
 			// Unterminated heredoc is unparseable — body scanned as before, mutation caught.

--- a/packages/coding-agent/test/workflow-mutation-guard.test.ts
+++ b/packages/coding-agent/test/workflow-mutation-guard.test.ts
@@ -341,6 +341,12 @@ describe("workflow mutation guard", () => {
 			"bash <<'EOF'\nrm src/product.ts\nEOF",
 			'python3 <<PY\nopen("src/product.ts", "w").write("x")\nPY',
 			"patch -p1 <<'EOF'\n--- a/src/product.ts\n+++ b/src/product.ts\nEOF",
+			// Unknown/non-allowlisted consumers keep their bodies live too (Codex P1).
+			"awk -f - <<'EOF'\nBEGIN { x } # rm src/product.ts via body\necho x > src/product.ts\nEOF",
+			// A `<<` inside a comment is not an opener; the following live line still mutates (Codex P1).
+			"# <<'EOF'\nrm src/product.ts\nEOF",
+			// A `<<` inside double-quoted argument data is not an opener either.
+			'printf "%s" "<<\'EOF\'"\nrm src/product.ts\nEOF',
 			// Unquoted delimiter + command substitution in body expands at runtime — fail closed.
 			"cat <<EOF > /tmp/out.md\n$(rm src/product.ts)\nEOF",
 			// Unterminated heredoc is unparseable — body scanned as before, mutation caught.

--- a/packages/coding-agent/test/workflow-mutation-guard.test.ts
+++ b/packages/coding-agent/test/workflow-mutation-guard.test.ts
@@ -319,6 +319,8 @@ describe("workflow mutation guard", () => {
 			`cat <<'EOF' > /tmp/plan-draft.md\n${specBody}\nEOF`,
 			`tee /tmp/spec.md >/dev/null <<'DOC'\n${specBody}\nDOC`,
 			`cat <<-'TABDOC' > /tmp/spec.md\n\tindented body a > b\n\tTABDOC`,
+			`cat <<'CNT' | wc -l\n${specBody}\nCNT`,
+			`cat <<'PIPE' | grep -c retrieval | sort\n${specBody}\nPIPE`,
 		]) {
 			const decision = await getWorkflowMutationDecision({
 				cwd,
@@ -349,6 +351,9 @@ describe("workflow mutation guard", () => {
 			'printf "%s" "<<\'EOF\'"\nrm src/product.ts\nEOF',
 			// Escaped quotes must not re-expose a quoted `<<` as an opener (Codex P1).
 			'cat "a \\" <<\'EOF\' \\" b"\nrm src/product.ts\nEOF',
+			// A downstream pipe stage can execute the body even when the opener is inert (Codex P1).
+			"cat <<'EOF' | bash\nrm src/product.ts\nEOF",
+			"cat <<'EOF' | grep -v noop | sh\nrm src/product.ts\nEOF",
 			// Unquoted delimiter + command substitution in body expands at runtime — fail closed.
 			"cat <<EOF > /tmp/out.md\n$(rm src/product.ts)\nEOF",
 			// Unterminated heredoc is unparseable — body scanned as before, mutation caught.

--- a/packages/coding-agent/test/workflow-mutation-guard.test.ts
+++ b/packages/coding-agent/test/workflow-mutation-guard.test.ts
@@ -297,6 +297,65 @@ describe("workflow mutation guard", () => {
 		}
 	});
 
+	it("does not misread heredoc document bodies as mutations during active deep-interview (#false-positive)", async () => {
+		const cwd = await makeTempRoot();
+		await writeActiveDeepInterview(cwd);
+
+		// Markdown spec bodies contain `>` quotes, `a > b` prose, apostrophes, and
+		// even shell-looking lines — all inert data when the heredoc feeds a data
+		// consumer writing to neutral temp scratch.
+		const specBody = [
+			"# Spec: Memory System",
+			"",
+			"- retrieval: session > project > global precedence",
+			"- don't hardcode `~/.gjc`; user's overrides matter",
+			"| Round | Prior → New | 66.5% → 62.3% |",
+			"rm -rf src is what we must never do",
+			"echo x > src/product.ts (quoted example, not a command)",
+		].join("\n");
+
+		for (const command of [
+			`cat > /tmp/mem-spec.md <<'SPECEOF'\n${specBody}\nSPECEOF\nwc -l /tmp/mem-spec.md`,
+			`cat <<'EOF' > /tmp/plan-draft.md\n${specBody}\nEOF`,
+			`tee /tmp/spec.md >/dev/null <<'DOC'\n${specBody}\nDOC`,
+			`cat <<-'TABDOC' > /tmp/spec.md\n\tindented body a > b\n\tTABDOC`,
+		]) {
+			const decision = await getWorkflowMutationDecision({
+				cwd,
+				sessionId: "session-a",
+				tool: tool("bash"),
+				args: { command },
+			});
+			expect(decision.blocked).toBe(false);
+		}
+	});
+
+	it("still blocks heredocs that mutate product paths or execute their body", async () => {
+		const cwd = await makeTempRoot();
+		await writeActiveDeepInterview(cwd);
+
+		for (const command of [
+			// Redirect target on the OPENER line is product code — blocked regardless of body.
+			"cat <<'EOF' > src/product.ts\ninert body\nEOF",
+			// Script consumers keep their bodies live: mutations inside count.
+			"bash <<'EOF'\nrm src/product.ts\nEOF",
+			'python3 <<PY\nopen("src/product.ts", "w").write("x")\nPY',
+			"patch -p1 <<'EOF'\n--- a/src/product.ts\n+++ b/src/product.ts\nEOF",
+			// Unquoted delimiter + command substitution in body expands at runtime — fail closed.
+			"cat <<EOF > /tmp/out.md\n$(rm src/product.ts)\nEOF",
+			// Unterminated heredoc is unparseable — body scanned as before, mutation caught.
+			"cat <<'EOF' > /tmp/out.md\necho x > src/product.ts",
+		]) {
+			const decision = await getWorkflowMutationDecision({
+				cwd,
+				sessionId: "session-a",
+				tool: tool("bash"),
+				args: { command },
+			});
+			expect(decision.blocked).toBe(true);
+		}
+	});
+
 	it("blocks mutating bash targets during active deep-interview", async () => {
 		const cwd = await makeTempRoot();
 		await writeActiveDeepInterview(cwd);


### PR DESCRIPTION
## Problem

During an active deep-interview (or ralplan) planning phase, persisting a spec to neutral temp scratch via a bash heredoc was falsely blocked:

```
cat > /tmp/mem-spec.md <<'SPECEOF'
# Deep Interview Spec ...
- retrieval: session > project > global precedence
| Round | Prior → New | 66.5% → 62.3% |
SPECEOF
```

→ `Deep-interview phase boundary: ... Mutation tools and patch execution are blocked ...`

The workflow-mutation guard's bash scanner treated heredoc **body** lines as live shell commands. Markdown prose (`a > b`, blockquote `>` lines, `rm`/`cp` mentions, apostrophes unbalancing the single-quote masker) registered as fake redirection/mutation targets — even though the only real write target was `/tmp`, which the guard already tolerates as neutral scratch.

## Fix

`packages/coding-agent/src/skill-state/workflow-mutation-guard.ts`:

- **`maskHeredocBodies()`**: parses `<<`/`<<-` openers (quoted/unquoted delimiters) and blanks body lines before scanning, so document payloads are inert. Opener-line redirect targets remain fully enforced (`cat <<'EOF' > src/product.ts` still blocks).
- **Fail-closed carve-outs preserved**:
  - script consumers on the opener line (`sh`/`python`/`node`/`eval`/`xargs`/…) keep their bodies live and scanned;
  - opaque stdin appliers (`patch`/`ed`/`ex`/`sqlite3`) force explicit-mutation + unknown → blocked;
  - unquoted-delimiter bodies containing `$(…)`/backticks (runtime expansion) → blocked;
  - unterminated heredocs return the original text → scanned as before.
- The `tee`-argument scanner no longer collects redirect operator words (`>/dev/null`, `<<'DOC'`) as paths.

## Skill guidance

- deep-interview `SKILL.md` §3.7 and ralplan `SKILL.md` now document that staging oversized artifacts into neutral temp roots via the `write` tool **or** a quoted-delimiter bash heredoc is a tolerated route, with the delimiter-quoting requirement stated explicitly.

## Tests

- New allow-suite mirroring the reported transcript shape (markdown with `>` prose, tables, `rm` mentions, apostrophes) — all pass through.
- New block-suite proving product-path openers, script-consumer bodies, `patch` heredocs, unquoted-`$()` bodies, and unterminated heredocs still block.
- `bun test test/workflow-mutation-guard.test.ts` → 30 pass; deep-interview gate/redteam suites → 62 pass; `tsc --noEmit` clean; `verify-gjc-skill-docs` clean (0 drift, 0 direct .gjc mutation examples).