### PR TITLE
fix(ai): drop the unused $env import from the Vertex provider

### DIFF
--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -1,4 +1,4 @@
-import { $credentialEnv, $env, $pickCredentialEnv } from "@gajae-code/utils";
+import { $credentialEnv, $pickCredentialEnv } from "@gajae-code/utils";
 import type { Context, Model, StreamFunction } from "../types";
 import type { AssistantMessageEventStream } from "../utils/event-stream";
 import { getVertexAccessToken } from "./google-auth";


### PR DESCRIPTION
## Problem

Root check is red on current dev (`0d202ee7`):

```
packages/ai/src/providers/google-vertex.ts:1:26 lint/correctness/noUnusedImports
  × Several of these imports are unused.
  > 1 │ import { $credentialEnv, $env, $pickCredentialEnv } from "@gajae-code/utils";
      │                          ^^^^
```

Reported via PR #3325 run 30372510772 (job 90321646318). The Telegram PR has **no diff** in this file — it was failing on a pre-existing dev defect, not its own change.

## Root cause: a semantic merge conflict

Introduced by merge `53deba2a1` (PR #3291), not by any single commit. Both parents still used `$env`:

| commit | change |
|---|---|
| `77cd61734` | `$env.GOOGLE_CLOUD_PROJECT` / `.GCLOUD_PROJECT` / `.GOOGLE_CLOUD_LOCATION` → `$pickCredentialEnv` / `$credentialEnv` |
| `43bba0dd2` | `$env.GOOGLE_CLOUD_API_KEY` → `$credentialEnv` |

Each side removed a *different subset* of the `$env` uses, while the merged import line kept the **union** of imported symbols. The textual merge was clean, so git raised no conflict and no pre-merge CI ever observed the combined tree — the last `$env` use disappeared only in the merge result.

Verified per-commit (`$env` uses in code, excluding the import line):

```
77cd61734  2 uses   43bba0dd2  1 use   53deba2a1 (merge)  0 uses
```

## Fix

`$env` now appears solely inside a doc comment explaining why trusted resolution exists, which is not a use. Remove exactly that symbol. `$credentialEnv` and `$pickCredentialEnv` remain used and are untouched.

One line, no behavior change.

## Verification (exact dev `0d202ee7`)

- `biome check packages/ai/src/providers/google-vertex.ts` → clean (was 1 error)
- `biome check .` → clean, 3216 files
- vertex / google / credential suites → **154 pass, 0 fail** across 18 files

## Follow-up

Telegram lane should re-run #3325 once this lands.