### PR TITLE
fix(ai): remove stale Vertex env import

### DIFF
--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -1,4 +1,4 @@
-import { $credentialEnv, $env, $pickCredentialEnv } from "@gajae-code/utils";
+import { $credentialEnv, $pickCredentialEnv } from "@gajae-code/utils";
 import type { Context, Model, StreamFunction } from "../types";
 import type { AssistantMessageEventStream } from "../utils/event-stream";
 import { getVertexAccessToken } from "./google-auth";


### PR DESCRIPTION
## Summary
- remove the stale unused `$env` import from the Google Vertex provider
- restore the repository-wide Biome/root-check gate on current `dev`

## Verification
- bun run check:tools
- bun --cwd=packages/ai run check