### PR TITLE
fix(skill-state): harden heredoc masking against shadowing, escapes, continuations, and multiline quotes

### DIFF
--- a/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
@@ -578,11 +578,16 @@ function maskLineForSyntax(
 
 const DATA_CONSUMER_NAMES = new Set(HEREDOC_DATA_CONSUMERS);
 /**
- * Shell-evaluated payloads (`eval …`, `source …`, `. file`) can install a
- * shadow from data the syntax view has blanked (quoted strings, /dev/stdin);
- * one in COMMAND POSITION disables masking entirely (fail closed).
+ * Command-position words that force the fail-closed pass. `eval`/`source`/`.`
+ * can install a shadow from data the syntax view has blanked (quoted strings,
+ * /dev/stdin). `case` introduces pattern `)` terminators that desync the
+ * substitution-depth scanner (`$(case x in x) …;; esac)`), making comment
+ * detection unreliable — masking is disabled rather than guessing.
  */
-const SHELL_EVALUATED_COMMANDS = new Set(["eval", "source", "."]);
+const SHELL_EVALUATED_COMMANDS = new Set(["eval", "source", ".", "case"]);
+
+/** Wrappers whose next word is still the effective command (`builtin eval …`, `command cat …`). */
+const SHELL_COMMAND_WRAPPER_WORDS = new Set(["sudo", "builtin", "command", "exec", "nohup", "nice"]);
 
 /** Reserved words that introduce a nested command position (`if eval …`, `while eval …`). */
 const SHELL_RESERVED_PREFIX_WORDS = new Set([
@@ -605,7 +610,7 @@ function commandPositionWords(segment: string): string[] {
 	let expectCommand = true;
 	for (const word of segment.trim().split(/\s+/)) {
 		if (!word) continue;
-		if (expectCommand && (/^\w+=/.test(word) || word === "sudo")) continue;
+		if (expectCommand && (/^\w+=/.test(word) || SHELL_COMMAND_WRAPPER_WORDS.has(word.toLowerCase()))) continue;
 		if (SHELL_RESERVED_PREFIX_WORDS.has(word.toLowerCase())) {
 			// Reserved word keeps the NEXT word in command position.
 			expectCommand = true;
@@ -643,21 +648,31 @@ function hasShellEvaluatedCommand(dequotedView: string): boolean {
  */
 function hasDataConsumerShadow(dequotedView: string): boolean {
 	for (const segment of commandListSegments(dequotedView)) {
-		const words = segment.trim().split(/\s+/).filter(Boolean);
-		const first = words[0]?.toLowerCase() ?? "";
-		if (first === "function" && DATA_CONSUMER_NAMES.has(words[1]?.split("/").pop()?.toLowerCase() ?? "")) {
-			return true;
-		}
-		if (
-			first === "alias" &&
-			words.slice(1).some(word => DATA_CONSUMER_NAMES.has(word.split("=")[0]?.toLowerCase() ?? ""))
-		) {
-			return true;
+		const words = commandPositionWords(segment);
+		for (let index = 0; index < words.length; index++) {
+			const word = words[index] ?? "";
+			if (word === "function") {
+				// commandPositionWords stops after the first non-reserved word, so
+				// re-inspect the raw segment for the name following `function`.
+				const rawWords = segment.trim().split(/\s+/).filter(Boolean);
+				const at = rawWords.findIndex(raw => raw.toLowerCase() === "function");
+				const name = rawWords[at + 1]?.split("/").pop()?.toLowerCase() ?? "";
+				if (DATA_CONSUMER_NAMES.has(name)) return true;
+			}
+			if (word === "alias") {
+				const rawWords = segment.trim().split(/\s+/).filter(Boolean);
+				if (rawWords.some(raw => DATA_CONSUMER_NAMES.has(raw.split("=")[0]?.toLowerCase() ?? ""))) return true;
+			}
 		}
 	}
-	// `name()` / `name ()` at a command-list start (POSIX function definition).
+	// `name()` / `name ()` in command position — allow reserved-word prefixes
+	// (`then cat() { … }`) before the name (POSIX function definition).
 	const nameGroup = [...DATA_CONSUMER_NAMES].join("|");
-	return new RegExp(`(?:^|[;|&{(\`\\n])\\s*(?:${nameGroup})\\s*\\(\\s*\\)`, "i").test(dequotedView);
+	const reservedGroup = [...SHELL_RESERVED_PREFIX_WORDS].filter(word => /^\w+$/.test(word)).join("|");
+	return new RegExp(
+		`(?:^|[;|&{(\`\\n])\\s*(?:(?:${reservedGroup}|\\{|!)\\s+)*(?:${nameGroup})\\s*\\(\\s*\\)`,
+		"i",
+	).test(dequotedView);
 }
 
 /** First command word of a pipeline-segment slice of a quote-masked opener line. */

--- a/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
@@ -471,27 +471,43 @@ interface ShellQuoteState {
  * unquoted `#` at a word boundary starts a comment: the rest of the line is
  * blanked without touching quote state, so a stray quote inside a comment
  * cannot poison later lines. A `)` closing a `$(`/`<(`/`>(` substitution is
- * part of the current word (`x=$(true)#literal`), not a comment boundary. The
- * output is the same length as the input so match offsets stay aligned.
+ * part of the current word (`x=$(true)#literal`), not a comment boundary.
+ * `masked` is the same length as the input so match offsets stay aligned.
+ * `dequoted` applies bash-like QUOTE REMOVAL instead — quote/backslash marks
+ * drop, quoted word characters stay, quoted metacharacters neutralize to `_` —
+ * so obfuscated spellings (`e\val`, `'ev'al`) reassemble into their real
+ * command word without quoted data ever forming fake command boundaries.
  * `continued` reports an unescaped trailing backslash outside quotes (logical
  * line continuation).
  */
-function maskLineForSyntax(line: string, state: ShellQuoteState): { masked: string; continued: boolean } {
+function maskLineForSyntax(
+	line: string,
+	state: ShellQuoteState,
+): { masked: string; dequoted: string; continued: boolean } {
 	let masked = "";
+	let dequoted = "";
 	let escaped = false;
 	let previous = "";
+	// Quoted data keeps word characters (so `'ev'al` reassembles to `eval`) but
+	// neutralizes everything else to `_` so it can never form a command boundary.
+	const dequoteData = (character: string): string => (/[\w./-]/.test(character) ? character : "_");
 	for (const character of line) {
 		if (state.inSingle) {
-			if (character === "'") {
-				state.inSingle = false;
-				masked += "'";
-			} else masked += " ";
+			if (character === "'") state.inSingle = false;
+			else {
+				masked += " ";
+				dequoted += dequoteData(character);
+				previous = character;
+				continue;
+			}
+			masked += "'";
 			previous = character;
 			continue;
 		}
 		if (escaped) {
 			escaped = false;
 			masked += " ";
+			dequoted += dequoteData(character);
 			previous = character;
 			continue;
 		}
@@ -502,22 +518,28 @@ function maskLineForSyntax(line: string, state: ShellQuoteState): { masked: stri
 			continue;
 		}
 		if (state.inDouble) {
-			if (character === '"') {
-				state.inDouble = false;
-				masked += '"';
-			} else masked += " ";
+			if (character === '"') state.inDouble = false;
+			else {
+				masked += " ";
+				dequoted += dequoteData(character);
+				previous = character;
+				continue;
+			}
+			masked += '"';
 			previous = character;
 			continue;
 		}
 		if (character === "(" && (previous === "$" || previous === "<" || previous === ">")) {
 			state.substitutionDepth++;
 			masked += character;
+			dequoted += character;
 			previous = character;
 			continue;
 		}
 		if (character === ")" && state.substitutionDepth > 0) {
 			state.substitutionDepth--;
 			masked += character;
+			dequoted += character;
 			// Substitution close binds to the surrounding word: `#` after it is literal.
 			previous = "x";
 			continue;
@@ -528,7 +550,7 @@ function maskLineForSyntax(line: string, state: ShellQuoteState): { masked: stri
 		) {
 			// Comment: blank the remainder without evaluating quotes inside it.
 			masked += " ".repeat(line.length - masked.length);
-			return { masked, continued: false };
+			return { masked, dequoted, continued: false };
 		}
 		if (character === "'") {
 			state.inSingle = true;
@@ -543,9 +565,10 @@ function maskLineForSyntax(line: string, state: ShellQuoteState): { masked: stri
 			continue;
 		}
 		masked += character;
+		dequoted += character;
 		previous = character;
 	}
-	return { masked, continued: escaped };
+	return { masked, dequoted, continued: escaped };
 }
 
 const DATA_CONSUMER_NAMES = [...HEREDOC_DATA_CONSUMERS].join("|");
@@ -557,9 +580,23 @@ const DATA_CONSUMER_SHADOW_RE = new RegExp(
 /**
  * Shell-evaluated payloads (`eval …`, `source …`, `. file`) can install a
  * shadow from data the syntax view has blanked (quoted strings, /dev/stdin);
- * their presence in live syntax disables masking entirely (fail closed).
+ * one in COMMAND POSITION disables masking entirely (fail closed).
  */
-const SHELL_EVALUATED_PAYLOAD_RE = /(?:^|[\s;|&({`\n])(?:eval|source|\.)(?=[\s;|&)`\n]|$)/;
+const SHELL_EVALUATED_COMMANDS = new Set(["eval", "source", "."]);
+
+/**
+ * True when any command-position word of the dequoted syntax view is
+ * eval/source/`.` — command position means the first non-assignment,
+ * non-sudo word after a command separator (`;`, `|`, `&`, `(`, backtick,
+ * newline, or line start). `echo eval` and `find .` never match because
+ * their tokens sit in argument position.
+ */
+function hasShellEvaluatedCommand(dequotedView: string): boolean {
+	for (const list of dequotedView.split(/[;|&(`\n]/)) {
+		if (SHELL_EVALUATED_COMMANDS.has(firstCommandWord(list))) return true;
+	}
+	return false;
+}
 
 /** First command word of a pipeline-segment slice of a quote-masked opener line. */
 function firstCommandWord(segment: string): string {
@@ -633,19 +670,24 @@ function maskHeredocBodies(command: string): HeredocMaskResult {
 	const first = maskHeredocBodiesPass(command, false);
 	// Fail closed on live-syntax constructs that can install a shadow the syntax
 	// view cannot see: a function/alias definition of an allowlisted consumer
-	// name, or any shell-evaluated payload (`eval`/`source`/`.`) whose argument
-	// is blanked quoted data. Heredoc bodies and quoted/commented text are
-	// excluded, so a spec that merely DOCUMENTS `cat() { … }` stays inert.
-	if (DATA_CONSUMER_SHADOW_RE.test(first.syntaxView) || SHELL_EVALUATED_PAYLOAD_RE.test(first.syntaxView)) {
+	// name, or a command-position eval/source/`.` whose argument is blanked
+	// quoted data. Both run against the DEQUOTED view so quoting tricks
+	// (`e\val`, `'ev'al`) cannot hide the word, while heredoc bodies and
+	// comments stay excluded — a spec that merely DOCUMENTS `cat() { … }` or
+	// mentions "eval" in prose stays inert.
+	if (DATA_CONSUMER_SHADOW_RE.test(first.dequotedView) || hasShellEvaluatedCommand(first.dequotedView)) {
 		return maskHeredocBodiesPass(command, true).result;
 	}
 	return first.result;
 }
 
-function maskHeredocBodiesPass(command: string, shadowed: boolean): { result: HeredocMaskResult; syntaxView: string } {
+function maskHeredocBodiesPass(
+	command: string,
+	shadowed: boolean,
+): { result: HeredocMaskResult; dequotedView: string } {
 	const lines = command.split("\n");
 	const out: string[] = [];
-	const syntaxLines: string[] = [];
+	const dequotedLines: string[] = [];
 	const state: ShellQuoteState = { inSingle: false, inDouble: false, substitutionDepth: 0 };
 	let previousContinued = false;
 	let opaqueExpansion = false;
@@ -655,9 +697,9 @@ function maskHeredocBodiesPass(command: string, shadowed: boolean): { result: He
 		out.push(line);
 		// Cross-line quote masking decides whether a `<<` is real syntax or inert
 		// data — even when the enclosing quote opened on a previous line.
-		const { masked, continued } = maskLineForSyntax(line, state);
+		const { masked, dequoted, continued } = maskLineForSyntax(line, state);
 		const syntax = masked;
-		syntaxLines.push(syntax);
+		dequotedLines.push(dequoted);
 		const isContinuationLine = previousContinued;
 		previousContinued = continued;
 		for (const match of line.matchAll(BASH_HEREDOC_OPEN_RE)) {
@@ -684,7 +726,7 @@ function maskHeredocBodiesPass(command: string, shadowed: boolean): { result: He
 			if (end === -1) {
 				return {
 					result: { masked: command, opaqueExpansion, mutatingConsumer },
-					syntaxView: syntaxLines.join("\n"),
+					dequotedView: dequotedLines.join("\n"),
 				};
 			}
 			const maskBody = kind === "data" || kind === "mutating";
@@ -702,7 +744,7 @@ function maskHeredocBodiesPass(command: string, shadowed: boolean): { result: He
 	}
 	return {
 		result: { masked: out.join("\n"), opaqueExpansion, mutatingConsumer },
-		syntaxView: syntaxLines.join("\n"),
+		dequotedView: dequotedLines.join("\n"),
 	};
 }
 

--- a/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
@@ -507,7 +507,7 @@ function maskLineForSyntax(line: string, state: ShellQuoteState): { masked: stri
 		}
 		if (
 			character === "#" &&
-			(previous === "" || previous === " " || previous === "\t" || ";|&(".includes(previous))
+			(previous === "" || previous === " " || previous === "\t" || ";|&()".includes(previous))
 		) {
 			// Comment: blank the remainder without evaluating quotes inside it.
 			masked += " ".repeat(line.length - masked.length);
@@ -537,21 +537,6 @@ const DATA_CONSUMER_SHADOW_RE = new RegExp(
 	`(?:^|[\\s;|&({\`])(?:function\\s+(?:${DATA_CONSUMER_NAMES})\\b|(?:${DATA_CONSUMER_NAMES})\\s*\\(\\s*\\)|alias\\s+(?:${DATA_CONSUMER_NAMES})=)`,
 	"i",
 );
-
-/**
- * Cut a quote-masked line at an unquoted `#` comment start (line start or after
- * whitespace/separator), so a `<<` inside comment text is never an opener.
- */
-function cutShellComment(syntaxLine: string): string {
-	for (let index = 0; index < syntaxLine.length; index++) {
-		if (syntaxLine[index] !== "#") continue;
-		const previous = index === 0 ? "" : syntaxLine[index - 1];
-		if (previous === "" || previous === " " || previous === "\t" || ";|&(".includes(previous)) {
-			return syntaxLine.slice(0, index);
-		}
-	}
-	return syntaxLine;
-}
 
 /** First command word of a pipeline-segment slice of a quote-masked opener line. */
 function firstCommandWord(segment: string): string {
@@ -622,11 +607,21 @@ function heredocConsumerKind(syntaxLine: string, at: number): "data" | "mutating
  */
 function maskHeredocBodies(command: string): HeredocMaskResult {
 	if (!command.includes("<<")) return { masked: command, opaqueExpansion: false, mutatingConsumer: false };
-	// A function/alias definition of an allowlisted consumer name anywhere in the
-	// command means the name cannot be trusted; keep every body live (fail closed).
-	const shadowed = DATA_CONSUMER_SHADOW_RE.test(command);
+	const first = maskHeredocBodiesPass(command, false);
+	// A function/alias definition of an allowlisted consumer name in the COMMAND
+	// SYNTAX (heredoc bodies and quoted/commented text excluded — a spec that
+	// merely documents `cat() { … }` is inert) means the name cannot be trusted;
+	// redo the pass with masking disabled so every body stays live (fail closed).
+	if (DATA_CONSUMER_SHADOW_RE.test(first.syntaxView)) {
+		return maskHeredocBodiesPass(command, true).result;
+	}
+	return first.result;
+}
+
+function maskHeredocBodiesPass(command: string, shadowed: boolean): { result: HeredocMaskResult; syntaxView: string } {
 	const lines = command.split("\n");
 	const out: string[] = [];
+	const syntaxLines: string[] = [];
 	const state: ShellQuoteState = { inSingle: false, inDouble: false };
 	let previousContinued = false;
 	let opaqueExpansion = false;
@@ -637,7 +632,8 @@ function maskHeredocBodies(command: string): HeredocMaskResult {
 		// Cross-line quote masking decides whether a `<<` is real syntax or inert
 		// data — even when the enclosing quote opened on a previous line.
 		const { masked, continued } = maskLineForSyntax(line, state);
-		const syntax = cutShellComment(masked);
+		const syntax = masked;
+		syntaxLines.push(syntax);
 		const isContinuationLine = previousContinued;
 		previousContinued = continued;
 		for (const match of line.matchAll(BASH_HEREDOC_OPEN_RE)) {
@@ -661,7 +657,12 @@ function maskHeredocBodies(command: string): HeredocMaskResult {
 					break;
 				}
 			}
-			if (end === -1) return { masked: command, opaqueExpansion, mutatingConsumer };
+			if (end === -1) {
+				return {
+					result: { masked: command, opaqueExpansion, mutatingConsumer },
+					syntaxView: syntaxLines.join("\n"),
+				};
+			}
 			const maskBody = kind === "data" || kind === "mutating";
 			for (let body = index + 1; body < end; body++) {
 				const bodyLine = lines[body] ?? "";
@@ -670,11 +671,15 @@ function maskHeredocBodies(command: string): HeredocMaskResult {
 			}
 			out.push(lines[end] ?? "");
 			index = end;
-			// Heredoc bodies are data: they never affect the shell quote state.
+			// Heredoc bodies are data: they never affect the shell quote state or
+			// the syntax view used for shadow detection.
 			previousContinued = false;
 		}
 	}
-	return { masked: out.join("\n"), opaqueExpansion, mutatingConsumer };
+	return {
+		result: { masked: out.join("\n"), opaqueExpansion, mutatingConsumer },
+		syntaxView: syntaxLines.join("\n"),
+	};
 }
 
 function extractBashTargets(args: unknown, depth = 0): ExtractedTargets {

--- a/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
@@ -608,17 +608,28 @@ const SHELL_RESERVED_PREFIX_WORDS = new Set([
 function commandPositionWords(segment: string): string[] {
 	const words: string[] = [];
 	let expectCommand = true;
+	let afterWrapper = false;
 	for (const word of segment.trim().split(/\s+/)) {
 		if (!word) continue;
-		if (expectCommand && (/^\w+=/.test(word) || SHELL_COMMAND_WRAPPER_WORDS.has(word.toLowerCase()))) continue;
-		if (SHELL_RESERVED_PREFIX_WORDS.has(word.toLowerCase())) {
-			// Reserved word keeps the NEXT word in command position.
-			expectCommand = true;
-			continue;
+		if (expectCommand) {
+			if (/^\w+=/.test(word)) continue;
+			if (SHELL_COMMAND_WRAPPER_WORDS.has(word.toLowerCase())) {
+				// The wrapper's effective command follows, possibly after options/`--`.
+				afterWrapper = true;
+				continue;
+			}
+			// Wrapper options (`command -p`, `builtin --`) precede the real command.
+			if (afterWrapper && (word === "--" || word.startsWith("-"))) continue;
+			afterWrapper = false;
+			if (SHELL_RESERVED_PREFIX_WORDS.has(word.toLowerCase())) {
+				// Reserved word keeps the NEXT word in command position.
+				continue;
+			}
+			words.push(word.split("/").pop()?.toLowerCase() ?? "");
+			expectCommand = false;
 		}
-		if (!expectCommand) continue;
-		words.push(word.split("/").pop()?.toLowerCase() ?? "");
-		expectCommand = false;
+		// Argument position: only real list operators (handled by the segment
+		// split) restore command position — reserved-word TEXT here is data.
 	}
 	return words;
 }

--- a/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
@@ -459,8 +459,12 @@ interface HeredocMaskResult {
 interface ShellQuoteState {
 	inSingle: boolean;
 	inDouble: boolean;
-	/** Open `$(`/`<(`/`>(` substitutions: a `)` closing one is a word character, not an operator. */
-	substitutionDepth: number;
+	/**
+	 * Paren stack inside substitutions: `true` for a `$(`/`<(`/`>(` opener
+	 * (its `)` is a word character), `false` for a plain nested paren (its `)`
+	 * is an operator, so a following `#` starts a comment).
+	 */
+	parenStack: boolean[];
 }
 
 /**
@@ -531,22 +535,23 @@ function maskLineForSyntax(
 		}
 		if (
 			character === "(" &&
-			(previous === "$" || previous === "<" || previous === ">" || state.substitutionDepth > 0)
+			(previous === "$" || previous === "<" || previous === ">" || state.parenStack.length > 0)
 		) {
 			// Substitution opener, or any paren nested INSIDE one (e.g. `$((1))`,
 			// `$(f (x))`): both must be balanced before the substitution closes.
-			state.substitutionDepth++;
+			state.parenStack.push(previous === "$" || previous === "<" || previous === ">");
 			masked += character;
 			dequoted += character;
 			previous = character;
 			continue;
 		}
-		if (character === ")" && state.substitutionDepth > 0) {
-			state.substitutionDepth--;
+		if (character === ")" && state.parenStack.length > 0) {
+			const wasSubstitutionOpener = state.parenStack.pop() === true;
 			masked += character;
 			dequoted += character;
-			// Substitution close binds to the surrounding word: `#` after it is literal.
-			previous = "x";
+			// A substitution close binds to the surrounding word (`x=$(true)#lit`);
+			// a nested subshell close is an operator, so `#` after it comments.
+			previous = wasSubstitutionOpener ? "x" : ")";
 			continue;
 		}
 		if (
@@ -604,6 +609,9 @@ const SHELL_RESERVED_PREFIX_WORDS = new Set([
 	"!",
 ]);
 
+/** A redirection token (`</dev/null`, `2>err`, `>out`) — not a command word. */
+const SHELL_REDIRECTION_TOKEN_RE = /^\d*[<>]/;
+
 /** Command-position words of one command-list segment: the first real word plus words after reserved prefixes. */
 function commandPositionWords(segment: string): string[] {
 	const words: string[] = [];
@@ -613,13 +621,19 @@ function commandPositionWords(segment: string): string[] {
 		if (!word) continue;
 		if (expectCommand) {
 			if (/^\w+=/.test(word)) continue;
+			// Leading redirections precede the command word (`</dev/null eval …`).
+			if (SHELL_REDIRECTION_TOKEN_RE.test(word)) continue;
 			if (SHELL_COMMAND_WRAPPER_WORDS.has(word.toLowerCase())) {
 				// The wrapper's effective command follows, possibly after options/`--`.
 				afterWrapper = true;
 				continue;
 			}
-			// Wrapper options (`command -p`, `builtin --`) precede the real command.
-			if (afterWrapper && (word === "--" || word.startsWith("-"))) continue;
+			if (afterWrapper && (word === "--" || word.startsWith("-"))) {
+				// `command -v`/`-V` only DESCRIBES its operand — the rest is data.
+				if (/^-[a-zA-Z]*[vV]/.test(word)) return words;
+				// Other wrapper options (`command -p`, `builtin --`) precede the real command.
+				continue;
+			}
 			afterWrapper = false;
 			if (SHELL_RESERVED_PREFIX_WORDS.has(word.toLowerCase())) {
 				// Reserved word keeps the NEXT word in command position.
@@ -772,7 +786,7 @@ function maskHeredocBodiesPass(
 	const lines = command.split("\n");
 	const out: string[] = [];
 	const dequotedLines: string[] = [];
-	const state: ShellQuoteState = { inSingle: false, inDouble: false, substitutionDepth: 0 };
+	const state: ShellQuoteState = { inSingle: false, inDouble: false, parenStack: [] };
 	let previousContinued = false;
 	let opaqueExpansion = false;
 	let mutatingConsumer = false;

--- a/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
@@ -529,7 +529,12 @@ function maskLineForSyntax(
 			previous = character;
 			continue;
 		}
-		if (character === "(" && (previous === "$" || previous === "<" || previous === ">")) {
+		if (
+			character === "(" &&
+			(previous === "$" || previous === "<" || previous === ">" || state.substitutionDepth > 0)
+		) {
+			// Substitution opener, or any paren nested INSIDE one (e.g. `$((1))`,
+			// `$(f (x))`): both must be balanced before the substitution closes.
 			state.substitutionDepth++;
 			masked += character;
 			dequoted += character;
@@ -571,12 +576,7 @@ function maskLineForSyntax(
 	return { masked, dequoted, continued: escaped };
 }
 
-const DATA_CONSUMER_NAMES = [...HEREDOC_DATA_CONSUMERS].join("|");
-/** A function/alias (re)definition of an allowlisted data-consumer name — masking must not trust the name. */
-const DATA_CONSUMER_SHADOW_RE = new RegExp(
-	`(?:^|[\\s;|&({\`])(?:function\\s+(?:${DATA_CONSUMER_NAMES})\\b|(?:${DATA_CONSUMER_NAMES})\\s*\\(\\s*\\)|alias\\s+(?:${DATA_CONSUMER_NAMES})=)`,
-	"i",
-);
+const DATA_CONSUMER_NAMES = new Set(HEREDOC_DATA_CONSUMERS);
 /**
  * Shell-evaluated payloads (`eval …`, `source …`, `. file`) can install a
  * shadow from data the syntax view has blanked (quoted strings, /dev/stdin);
@@ -584,27 +584,85 @@ const DATA_CONSUMER_SHADOW_RE = new RegExp(
  */
 const SHELL_EVALUATED_COMMANDS = new Set(["eval", "source", "."]);
 
+/** Reserved words that introduce a nested command position (`if eval …`, `while eval …`). */
+const SHELL_RESERVED_PREFIX_WORDS = new Set([
+	"if",
+	"then",
+	"else",
+	"elif",
+	"while",
+	"until",
+	"do",
+	"time",
+	"coproc",
+	"{",
+	"!",
+]);
+
+/** Command-position words of one command-list segment: the first real word plus words after reserved prefixes. */
+function commandPositionWords(segment: string): string[] {
+	const words: string[] = [];
+	let expectCommand = true;
+	for (const word of segment.trim().split(/\s+/)) {
+		if (!word) continue;
+		if (expectCommand && (/^\w+=/.test(word) || word === "sudo")) continue;
+		if (SHELL_RESERVED_PREFIX_WORDS.has(word.toLowerCase())) {
+			// Reserved word keeps the NEXT word in command position.
+			expectCommand = true;
+			continue;
+		}
+		if (!expectCommand) continue;
+		words.push(word.split("/").pop()?.toLowerCase() ?? "");
+		expectCommand = false;
+	}
+	return words;
+}
+
+/** Command-list segments of a dequoted view (split at `;`, `|`, `&`, `(`, backtick, newline). */
+function commandListSegments(dequotedView: string): string[] {
+	return dequotedView.split(/[;|&(`\n]/);
+}
+
 /**
  * True when any command-position word of the dequoted syntax view is
- * eval/source/`.` — command position means the first non-assignment,
- * non-sudo word after a command separator (`;`, `|`, `&`, `(`, backtick,
- * newline, or line start). `echo eval` and `find .` never match because
- * their tokens sit in argument position.
+ * eval/source/`.` — including nested positions after reserved words
+ * (`if eval …`). `echo eval` and `find .` never match because their
+ * tokens sit in argument position.
  */
 function hasShellEvaluatedCommand(dequotedView: string): boolean {
-	for (const list of dequotedView.split(/[;|&(`\n]/)) {
-		if (SHELL_EVALUATED_COMMANDS.has(firstCommandWord(list))) return true;
+	return commandListSegments(dequotedView).some(segment =>
+		commandPositionWords(segment).some(word => SHELL_EVALUATED_COMMANDS.has(word)),
+	);
+}
+
+/**
+ * True when live syntax actually DECLARES a shadow of an allowlisted
+ * data-consumer name: `name()` at a command-list start, `function name`,
+ * or `alias name=…` — each in command position, so `echo function cat`
+ * (argument position) never matches.
+ */
+function hasDataConsumerShadow(dequotedView: string): boolean {
+	for (const segment of commandListSegments(dequotedView)) {
+		const words = segment.trim().split(/\s+/).filter(Boolean);
+		const first = words[0]?.toLowerCase() ?? "";
+		if (first === "function" && DATA_CONSUMER_NAMES.has(words[1]?.split("/").pop()?.toLowerCase() ?? "")) {
+			return true;
+		}
+		if (
+			first === "alias" &&
+			words.slice(1).some(word => DATA_CONSUMER_NAMES.has(word.split("=")[0]?.toLowerCase() ?? ""))
+		) {
+			return true;
+		}
 	}
-	return false;
+	// `name()` / `name ()` at a command-list start (POSIX function definition).
+	const nameGroup = [...DATA_CONSUMER_NAMES].join("|");
+	return new RegExp(`(?:^|[;|&{(\`\\n])\\s*(?:${nameGroup})\\s*\\(\\s*\\)`, "i").test(dequotedView);
 }
 
 /** First command word of a pipeline-segment slice of a quote-masked opener line. */
 function firstCommandWord(segment: string): string {
-	for (const word of segment.trim().split(/\s+/)) {
-		if (!word || /^\w+=/.test(word) || word === "sudo") continue;
-		return word.split("/").pop()?.toLowerCase() ?? "";
-	}
-	return "";
+	return commandPositionWords(segment)[0] ?? "";
 }
 
 /**
@@ -675,7 +733,7 @@ function maskHeredocBodies(command: string): HeredocMaskResult {
 	// (`e\val`, `'ev'al`) cannot hide the word, while heredoc bodies and
 	// comments stay excluded — a spec that merely DOCUMENTS `cat() { … }` or
 	// mentions "eval" in prose stays inert.
-	if (DATA_CONSUMER_SHADOW_RE.test(first.dequotedView) || hasShellEvaluatedCommand(first.dequotedView)) {
+	if (hasDataConsumerShadow(first.dequotedView) || hasShellEvaluatedCommand(first.dequotedView)) {
 		return maskHeredocBodiesPass(command, true).result;
 	}
 	return first.result;

--- a/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
@@ -455,38 +455,70 @@ interface HeredocMaskResult {
 	mutatingConsumer: boolean;
 }
 
+/** Quote state carried ACROSS physical lines so multiline quoted strings cannot fake heredoc openers. */
+interface ShellQuoteState {
+	inSingle: boolean;
+	inDouble: boolean;
+}
+
 /**
- * Blank out double-quoted spans (like `maskSingleQuotedSpans`) so a `<<` inside
- * `"…"` argument data is not misread as a heredoc opener. A backslash-escaped
- * `\"` never toggles the quote state — outside quotes it is a literal quote
- * character, inside quotes it is escaped data — so `"a \" << \" b"` stays one
- * masked span. Unbalanced quotes return the original text so the caller stays
- * fail-closed rather than blind.
+ * Mask one physical line for syntax analysis, carrying `state` across lines:
+ * quoted spans and backslash-escaped characters become spaces (they are data,
+ * never syntax), so a `<<` inside `"…"`/`'…'` — even when the quote opened on a
+ * PREVIOUS line — or an escaped separator like `\|` is never misread. The
+ * output is the same length as the input so match offsets stay aligned.
+ * `continued` reports an unescaped trailing backslash outside quotes (logical
+ * line continuation).
  */
-function maskDoubleQuotedSpans(text: string): string {
+function maskLineForSyntax(line: string, state: ShellQuoteState): { masked: string; continued: boolean } {
 	let masked = "";
-	let inDouble = false;
 	let escaped = false;
-	for (const character of text) {
+	for (const character of line) {
+		if (state.inSingle) {
+			if (character === "'") {
+				state.inSingle = false;
+				masked += "'";
+			} else masked += " ";
+			continue;
+		}
 		if (escaped) {
 			escaped = false;
-			masked += inDouble && character !== "\n" ? " " : character;
+			masked += " ";
 			continue;
 		}
 		if (character === "\\") {
 			escaped = true;
-			masked += inDouble ? " " : character;
+			masked += " ";
+			continue;
+		}
+		if (state.inDouble) {
+			if (character === '"') {
+				state.inDouble = false;
+				masked += '"';
+			} else masked += " ";
+			continue;
+		}
+		if (character === "'") {
+			state.inSingle = true;
+			masked += "'";
 			continue;
 		}
 		if (character === '"') {
-			inDouble = !inDouble;
-			masked += character;
+			state.inDouble = true;
+			masked += '"';
 			continue;
 		}
-		masked += inDouble && character !== "\n" ? " " : character;
+		masked += character;
 	}
-	return inDouble ? text : masked;
+	return { masked, continued: escaped };
 }
+
+const DATA_CONSUMER_NAMES = [...HEREDOC_DATA_CONSUMERS].join("|");
+/** A function/alias (re)definition of an allowlisted data-consumer name — masking must not trust the name. */
+const DATA_CONSUMER_SHADOW_RE = new RegExp(
+	`(?:^|[\\s;|&({\`])(?:function\\s+(?:${DATA_CONSUMER_NAMES})\\b|(?:${DATA_CONSUMER_NAMES})\\s*\\(\\s*\\)|alias\\s+(?:${DATA_CONSUMER_NAMES})=)`,
+	"i",
+);
 
 /**
  * Cut a quote-masked line at an unquoted `#` comment start (line start or after
@@ -565,28 +597,41 @@ function heredocConsumerKind(syntaxLine: string, at: number): "data" | "mutating
  * be live code. Stdin appliers (patch/ed/ex/sqlite3) flag `mutatingConsumer`
  * and the caller fails closed. Unquoted-delimiter bodies still expand
  * `$(…)`/backticks in real shells, so masked ones flag `opaqueExpansion`. A
- * `<<` inside a comment or a quoted span is not an opener. An unterminated
- * heredoc is not statically maskable; the original text is returned so the
- * scanner stays fail-closed rather than blind.
+ * `<<` inside a comment or a quoted span (including a quote opened on a
+ * previous line) is not an opener; a line-continued opener, a shadowed
+ * data-consumer name (`cat() { … }`), and an unterminated heredoc all keep
+ * their bodies live so the scanner stays fail-closed rather than blind.
  */
 function maskHeredocBodies(command: string): HeredocMaskResult {
 	if (!command.includes("<<")) return { masked: command, opaqueExpansion: false, mutatingConsumer: false };
+	// A function/alias definition of an allowlisted consumer name anywhere in the
+	// command means the name cannot be trusted; keep every body live (fail closed).
+	const shadowed = DATA_CONSUMER_SHADOW_RE.test(command);
 	const lines = command.split("\n");
 	const out: string[] = [];
+	const state: ShellQuoteState = { inSingle: false, inDouble: false };
+	let previousContinued = false;
 	let opaqueExpansion = false;
 	let mutatingConsumer = false;
 	for (let index = 0; index < lines.length; index++) {
 		const line = lines[index] ?? "";
 		out.push(line);
-		// Quote masking + comment cutting decide whether a `<<` is real syntax or
-		// inert data on this opener line.
-		const syntax = cutShellComment(maskDoubleQuotedSpans(maskSingleQuotedSpans(line)));
+		// Cross-line quote masking decides whether a `<<` is real syntax or inert
+		// data — even when the enclosing quote opened on a previous line.
+		const { masked, continued } = maskLineForSyntax(line, state);
+		const syntax = cutShellComment(masked);
+		const isContinuationLine = previousContinued;
+		previousContinued = continued;
 		for (const match of line.matchAll(BASH_HEREDOC_OPEN_RE)) {
 			const at = match.index ?? 0;
 			if (syntax.slice(at, at + 2) !== "<<") continue;
 			const delimiter = match[2] ?? match[3] ?? match[5] ?? "";
 			if (!delimiter) continue;
-			const kind = heredocConsumerKind(syntax, at);
+			let kind = heredocConsumerKind(syntax, at);
+			// A continued/continuation opener line hides part of the pipeline
+			// (`cat <<'EOF' \` / `| bash`); a shadowed consumer name is untrustworthy.
+			// Both downgrade masking eligibility, never block eligibility.
+			if (kind === "data" && (shadowed || continued || isContinuationLine)) kind = "other";
 			if (kind === "mutating") mutatingConsumer = true;
 			const quoted = match[2] !== undefined || match[3] !== undefined || match[4] !== undefined;
 			const stripTabs = match[1] === "-";
@@ -607,6 +652,8 @@ function maskHeredocBodies(command: string): HeredocMaskResult {
 			}
 			out.push(lines[end] ?? "");
 			index = end;
+			// Heredoc bodies are data: they never affect the shell quote state.
+			previousContinued = false;
 		}
 	}
 	return { masked: out.join("\n"), opaqueExpansion, mutatingConsumer };

--- a/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
@@ -455,10 +455,12 @@ interface HeredocMaskResult {
 	mutatingConsumer: boolean;
 }
 
-/** Quote state carried ACROSS physical lines so multiline quoted strings cannot fake heredoc openers. */
+/** Quote/substitution state carried ACROSS physical lines so multiline constructs cannot fake heredoc openers. */
 interface ShellQuoteState {
 	inSingle: boolean;
 	inDouble: boolean;
+	/** Open `$(`/`<(`/`>(` substitutions: a `)` closing one is a word character, not an operator. */
+	substitutionDepth: number;
 }
 
 /**
@@ -466,11 +468,13 @@ interface ShellQuoteState {
  * quoted spans and backslash-escaped characters become spaces (they are data,
  * never syntax), so a `<<` inside `"…"`/`'…'` — even when the quote opened on a
  * PREVIOUS line — or an escaped separator like `\|` is never misread. An
- * unquoted `#` starts a comment: the rest of the line is blanked without
- * touching quote state, so a stray quote inside a comment cannot poison later
- * lines. The output is the same length as the input so match offsets stay
- * aligned. `continued` reports an unescaped trailing backslash outside quotes
- * (logical line continuation).
+ * unquoted `#` at a word boundary starts a comment: the rest of the line is
+ * blanked without touching quote state, so a stray quote inside a comment
+ * cannot poison later lines. A `)` closing a `$(`/`<(`/`>(` substitution is
+ * part of the current word (`x=$(true)#literal`), not a comment boundary. The
+ * output is the same length as the input so match offsets stay aligned.
+ * `continued` reports an unescaped trailing backslash outside quotes (logical
+ * line continuation).
  */
 function maskLineForSyntax(line: string, state: ShellQuoteState): { masked: string; continued: boolean } {
 	let masked = "";
@@ -505,6 +509,19 @@ function maskLineForSyntax(line: string, state: ShellQuoteState): { masked: stri
 			previous = character;
 			continue;
 		}
+		if (character === "(" && (previous === "$" || previous === "<" || previous === ">")) {
+			state.substitutionDepth++;
+			masked += character;
+			previous = character;
+			continue;
+		}
+		if (character === ")" && state.substitutionDepth > 0) {
+			state.substitutionDepth--;
+			masked += character;
+			// Substitution close binds to the surrounding word: `#` after it is literal.
+			previous = "x";
+			continue;
+		}
 		if (
 			character === "#" &&
 			(previous === "" || previous === " " || previous === "\t" || ";|&()".includes(previous))
@@ -537,6 +554,12 @@ const DATA_CONSUMER_SHADOW_RE = new RegExp(
 	`(?:^|[\\s;|&({\`])(?:function\\s+(?:${DATA_CONSUMER_NAMES})\\b|(?:${DATA_CONSUMER_NAMES})\\s*\\(\\s*\\)|alias\\s+(?:${DATA_CONSUMER_NAMES})=)`,
 	"i",
 );
+/**
+ * Shell-evaluated payloads (`eval …`, `source …`, `. file`) can install a
+ * shadow from data the syntax view has blanked (quoted strings, /dev/stdin);
+ * their presence in live syntax disables masking entirely (fail closed).
+ */
+const SHELL_EVALUATED_PAYLOAD_RE = /(?:^|[\s;|&({`\n])(?:eval|source|\.)(?=[\s;|&)`\n]|$)/;
 
 /** First command word of a pipeline-segment slice of a quote-masked opener line. */
 function firstCommandWord(segment: string): string {
@@ -608,11 +631,12 @@ function heredocConsumerKind(syntaxLine: string, at: number): "data" | "mutating
 function maskHeredocBodies(command: string): HeredocMaskResult {
 	if (!command.includes("<<")) return { masked: command, opaqueExpansion: false, mutatingConsumer: false };
 	const first = maskHeredocBodiesPass(command, false);
-	// A function/alias definition of an allowlisted consumer name in the COMMAND
-	// SYNTAX (heredoc bodies and quoted/commented text excluded — a spec that
-	// merely documents `cat() { … }` is inert) means the name cannot be trusted;
-	// redo the pass with masking disabled so every body stays live (fail closed).
-	if (DATA_CONSUMER_SHADOW_RE.test(first.syntaxView)) {
+	// Fail closed on live-syntax constructs that can install a shadow the syntax
+	// view cannot see: a function/alias definition of an allowlisted consumer
+	// name, or any shell-evaluated payload (`eval`/`source`/`.`) whose argument
+	// is blanked quoted data. Heredoc bodies and quoted/commented text are
+	// excluded, so a spec that merely DOCUMENTS `cat() { … }` stays inert.
+	if (DATA_CONSUMER_SHADOW_RE.test(first.syntaxView) || SHELL_EVALUATED_PAYLOAD_RE.test(first.syntaxView)) {
 		return maskHeredocBodiesPass(command, true).result;
 	}
 	return first.result;
@@ -622,7 +646,7 @@ function maskHeredocBodiesPass(command: string, shadowed: boolean): { result: He
 	const lines = command.split("\n");
 	const out: string[] = [];
 	const syntaxLines: string[] = [];
-	const state: ShellQuoteState = { inSingle: false, inDouble: false };
+	const state: ShellQuoteState = { inSingle: false, inDouble: false, substitutionDepth: 0 };
 	let previousContinued = false;
 	let opaqueExpansion = false;
 	let mutatingConsumer = false;

--- a/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
@@ -617,12 +617,22 @@ function commandPositionWords(segment: string): string[] {
 	const words: string[] = [];
 	let expectCommand = true;
 	let afterWrapper = false;
+	let afterBareRedirection = false;
 	for (const word of segment.trim().split(/\s+/)) {
 		if (!word) continue;
+		// A bare redirection operator (`<`, `2>`) consumes the NEXT word as its target.
+		if (afterBareRedirection) {
+			afterBareRedirection = false;
+			continue;
+		}
 		if (expectCommand) {
 			if (/^\w+=/.test(word)) continue;
 			// Leading redirections precede the command word (`</dev/null eval …`).
-			if (SHELL_REDIRECTION_TOKEN_RE.test(word)) continue;
+			// A bare operator (`<`, `2>`) additionally consumes its separated target.
+			if (SHELL_REDIRECTION_TOKEN_RE.test(word)) {
+				if (/^\d*[<>]+$/.test(word)) afterBareRedirection = true;
+				continue;
+			}
 			if (SHELL_COMMAND_WRAPPER_WORDS.has(word.toLowerCase())) {
 				// The wrapper's effective command follows, possibly after options/`--`.
 				afterWrapper = true;

--- a/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
+++ b/packages/coding-agent/src/skill-state/workflow-mutation-guard.ts
@@ -465,30 +465,36 @@ interface ShellQuoteState {
  * Mask one physical line for syntax analysis, carrying `state` across lines:
  * quoted spans and backslash-escaped characters become spaces (they are data,
  * never syntax), so a `<<` inside `"…"`/`'…'` — even when the quote opened on a
- * PREVIOUS line — or an escaped separator like `\|` is never misread. The
- * output is the same length as the input so match offsets stay aligned.
- * `continued` reports an unescaped trailing backslash outside quotes (logical
- * line continuation).
+ * PREVIOUS line — or an escaped separator like `\|` is never misread. An
+ * unquoted `#` starts a comment: the rest of the line is blanked without
+ * touching quote state, so a stray quote inside a comment cannot poison later
+ * lines. The output is the same length as the input so match offsets stay
+ * aligned. `continued` reports an unescaped trailing backslash outside quotes
+ * (logical line continuation).
  */
 function maskLineForSyntax(line: string, state: ShellQuoteState): { masked: string; continued: boolean } {
 	let masked = "";
 	let escaped = false;
+	let previous = "";
 	for (const character of line) {
 		if (state.inSingle) {
 			if (character === "'") {
 				state.inSingle = false;
 				masked += "'";
 			} else masked += " ";
+			previous = character;
 			continue;
 		}
 		if (escaped) {
 			escaped = false;
 			masked += " ";
+			previous = character;
 			continue;
 		}
 		if (character === "\\") {
 			escaped = true;
 			masked += " ";
+			previous = character;
 			continue;
 		}
 		if (state.inDouble) {
@@ -496,19 +502,31 @@ function maskLineForSyntax(line: string, state: ShellQuoteState): { masked: stri
 				state.inDouble = false;
 				masked += '"';
 			} else masked += " ";
+			previous = character;
 			continue;
+		}
+		if (
+			character === "#" &&
+			(previous === "" || previous === " " || previous === "\t" || ";|&(".includes(previous))
+		) {
+			// Comment: blank the remainder without evaluating quotes inside it.
+			masked += " ".repeat(line.length - masked.length);
+			return { masked, continued: false };
 		}
 		if (character === "'") {
 			state.inSingle = true;
 			masked += "'";
+			previous = character;
 			continue;
 		}
 		if (character === '"') {
 			state.inDouble = true;
 			masked += '"';
+			previous = character;
 			continue;
 		}
 		masked += character;
+		previous = character;
 	}
 	return { masked, continued: escaped };
 }

--- a/packages/coding-agent/test/workflow-mutation-guard.test.ts
+++ b/packages/coding-agent/test/workflow-mutation-guard.test.ts
@@ -323,6 +323,10 @@ describe("workflow mutation guard", () => {
 			`cat <<'PIPE' | grep -c retrieval | sort\n${specBody}\nPIPE`,
 			// A stray quote inside a comment must not poison cross-line quote state (Codex P2).
 			`# don't trip on this apostrophe\ncat <<'CMT' > /tmp/spec.md\n${specBody}\nCMT`,
+			// `#` after `)` is a comment boundary too (Codex P2).
+			`(true)# don't trip here either\ncat <<'PRN' > /tmp/spec.md\n${specBody}\nPRN`,
+			// A spec body DOCUMENTING a shadow definition is inert data, not a real shadow (Codex P2).
+			`cat <<'SHD' > /tmp/spec.md\nexample: cat() { bash -s; } and alias cat=evil\n${specBody}\nSHD`,
 		]) {
 			const decision = await getWorkflowMutationDecision({
 				cwd,

--- a/packages/coding-agent/test/workflow-mutation-guard.test.ts
+++ b/packages/coding-agent/test/workflow-mutation-guard.test.ts
@@ -330,6 +330,8 @@ describe("workflow mutation guard", () => {
 			// eval/source/. in ARGUMENT position never trip the evaluated-payload fail-close (Codex P2).
 			`find . -name '*.md'\ncat <<'ARG' > /tmp/spec.md\n${specBody}\nARG`,
 			`echo eval source .\ncat <<'TOK' > /tmp/spec.md\n${specBody}\nTOK`,
+			// `function cat` in ARGUMENT position is not a shadow declaration (Codex P2).
+			`echo function cat\ncat <<'FNC' > /tmp/spec.md\n${specBody}\nFNC`,
 		]) {
 			const decision = await getWorkflowMutationDecision({
 				cwd,
@@ -369,6 +371,10 @@ describe("workflow mutation guard", () => {
 			"cat() { bash -s; }; cat <<'EOF'\nrm src/product.ts\nEOF",
 			// `)` closing a $() substitution is a word char, so `#` stays literal and the shadow stays live (Codex P1).
 			"x=$(true)#lit; cat() { bash -s; }; cat <<'EOF'\nrm src/product.ts\nEOF",
+			// Arithmetic $(( )) has nested parens: depth must stay balanced (Codex P1).
+			"x=$((1))#lit; cat() { bash -s; }\ncat <<'EOF'\nrm src/product.ts\nEOF",
+			// eval after a reserved word is still a command position (Codex P1).
+			"if eval 'cat(){ bash -s; }'; then :; fi\ncat <<'EOF'\nrm src/product.ts\nEOF",
 			// eval/source can install a shadow from quoted data the syntax view blanked (Codex P1).
 			"eval 'cat(){ bash -s; }'; cat <<'EOF'\nrm src/product.ts\nEOF",
 			"source /dev/stdin <<'DEF'\ncat(){ bash -s; }\nDEF\ncat <<'EOF'\nrm src/product.ts\nEOF",

--- a/packages/coding-agent/test/workflow-mutation-guard.test.ts
+++ b/packages/coding-agent/test/workflow-mutation-guard.test.ts
@@ -354,6 +354,14 @@ describe("workflow mutation guard", () => {
 			// A downstream pipe stage can execute the body even when the opener is inert (Codex P1).
 			"cat <<'EOF' | bash\nrm src/product.ts\nEOF",
 			"cat <<'EOF' | grep -v noop | sh\nrm src/product.ts\nEOF",
+			// Escaped `|` keeps `cat` as an ARGUMENT to bash -s, not a pipe stage (Codex P1).
+			"bash -s \\| cat <<'EOF'\nrm src/product.ts\nEOF",
+			// A shadowed allowlisted name executes the body through its function body (Codex P1).
+			"cat() { bash -s; }; cat <<'EOF'\nrm src/product.ts\nEOF",
+			// A line-continued opener hides the downstream interpreter stage (Codex P1).
+			"cat <<'EOF' \\\n| bash\nrm src/product.ts\nEOF",
+			// A multiline double-quoted string containing `cat <<'EOF'` is data, not an opener (Codex P1).
+			"printf '%s' \"\ncat <<'EOF'\n\" > /dev/null\nrm src/product.ts\nEOF",
 			// Unquoted delimiter + command substitution in body expands at runtime — fail closed.
 			"cat <<EOF > /tmp/out.md\n$(rm src/product.ts)\nEOF",
 			// Unterminated heredoc is unparseable — body scanned as before, mutation caught.

--- a/packages/coding-agent/test/workflow-mutation-guard.test.ts
+++ b/packages/coding-agent/test/workflow-mutation-guard.test.ts
@@ -327,6 +327,9 @@ describe("workflow mutation guard", () => {
 			`(true)# don't trip here either\ncat <<'PRN' > /tmp/spec.md\n${specBody}\nPRN`,
 			// A spec body DOCUMENTING a shadow definition is inert data, not a real shadow (Codex P2).
 			`cat <<'SHD' > /tmp/spec.md\nexample: cat() { bash -s; } and alias cat=evil\n${specBody}\nSHD`,
+			// eval/source/. in ARGUMENT position never trip the evaluated-payload fail-close (Codex P2).
+			`find . -name '*.md'\ncat <<'ARG' > /tmp/spec.md\n${specBody}\nARG`,
+			`echo eval source .\ncat <<'TOK' > /tmp/spec.md\n${specBody}\nTOK`,
 		]) {
 			const decision = await getWorkflowMutationDecision({
 				cwd,
@@ -369,6 +372,9 @@ describe("workflow mutation guard", () => {
 			// eval/source can install a shadow from quoted data the syntax view blanked (Codex P1).
 			"eval 'cat(){ bash -s; }'; cat <<'EOF'\nrm src/product.ts\nEOF",
 			"source /dev/stdin <<'DEF'\ncat(){ bash -s; }\nDEF\ncat <<'EOF'\nrm src/product.ts\nEOF",
+			// Quoted/escaped spellings of eval must still be recognized after quote removal (Codex P1).
+			"e\\val 'cat(){ bash -s; }'; cat <<'EOF'\nrm src/product.ts\nEOF",
+			"'ev'al 'cat(){ bash -s; }'; cat <<'EOF'\nrm src/product.ts\nEOF",
 			// A line-continued opener hides the downstream interpreter stage (Codex P1).
 			"cat <<'EOF' \\\n| bash\nrm src/product.ts\nEOF",
 			// A multiline double-quoted string containing `cat <<'EOF'` is data, not an opener (Codex P1).

--- a/packages/coding-agent/test/workflow-mutation-guard.test.ts
+++ b/packages/coding-agent/test/workflow-mutation-guard.test.ts
@@ -375,6 +375,12 @@ describe("workflow mutation guard", () => {
 			"x=$((1))#lit; cat() { bash -s; }\ncat <<'EOF'\nrm src/product.ts\nEOF",
 			// eval after a reserved word is still a command position (Codex P1).
 			"if eval 'cat(){ bash -s; }'; then :; fi\ncat <<'EOF'\nrm src/product.ts\nEOF",
+			// `builtin`/`command` wrappers still reach the evaluated command (Codex P1).
+			"builtin eval 'cat(){ bash -s; }'; cat <<'EOF'\nrm src/product.ts\nEOF",
+			// Function shadows after reserved words are still declarations (Codex P1).
+			"if true; then cat() { bash -s; }; fi\ncat <<'EOF'\nrm src/product.ts\nEOF",
+			// `case` pattern `)` desyncs the depth scanner — fail closed (Codex P1).
+			"x=$(case x in x) true;; esac)#lit; cat() { bash -s; }\ncat <<'EOF'\nrm src/product.ts\nEOF",
 			// eval/source can install a shadow from quoted data the syntax view blanked (Codex P1).
 			"eval 'cat(){ bash -s; }'; cat <<'EOF'\nrm src/product.ts\nEOF",
 			"source /dev/stdin <<'DEF'\ncat(){ bash -s; }\nDEF\ncat <<'EOF'\nrm src/product.ts\nEOF",

--- a/packages/coding-agent/test/workflow-mutation-guard.test.ts
+++ b/packages/coding-agent/test/workflow-mutation-guard.test.ts
@@ -332,6 +332,8 @@ describe("workflow mutation guard", () => {
 			`echo eval source .\ncat <<'TOK' > /tmp/spec.md\n${specBody}\nTOK`,
 			// `function cat` in ARGUMENT position is not a shadow declaration (Codex P2).
 			`echo function cat\ncat <<'FNC' > /tmp/spec.md\n${specBody}\nFNC`,
+			// `command -v eval` only DESCRIBES eval; it is not an evaluated command (Codex P2).
+			`command -v eval\ncat <<'CMV' > /tmp/spec.md\n${specBody}\nCMV`,
 		]) {
 			const decision = await getWorkflowMutationDecision({
 				cwd,
@@ -378,10 +380,14 @@ describe("workflow mutation guard", () => {
 			// `builtin`/`command` wrappers still reach the evaluated command (Codex P1).
 			"builtin eval 'cat(){ bash -s; }'; cat <<'EOF'\nrm src/product.ts\nEOF",
 			"command -- eval 'cat(){ bash -s; }'; cat <<'EOF'\nrm src/product.ts\nEOF",
+			// Leading redirections precede the command word (Codex P1).
+			"</dev/null eval 'cat(){ bash -s; }'; cat <<'EOF'\nrm src/product.ts\nEOF",
 			// Bash's `function name()` hybrid form is still a declaration (Codex P1).
 			"function cat() { bash -s; }; cat <<'EOF'\nrm src/product.ts\nEOF",
 			// Function shadows after reserved words are still declarations (Codex P1).
 			"if true; then cat() { bash -s; }; fi\ncat <<'EOF'\nrm src/product.ts\nEOF",
+			// A nested subshell's `)` is an operator: `#` after it comments out the fake opener (Codex P1).
+			"x=$( (true)# ; cat <<'EOF'\n)\nrm src/product.ts\nEOF",
 			// `case` pattern `)` desyncs the depth scanner — fail closed (Codex P1).
 			"x=$(case x in x) true;; esac)#lit; cat() { bash -s; }\ncat <<'EOF'\nrm src/product.ts\nEOF",
 			// eval/source can install a shadow from quoted data the syntax view blanked (Codex P1).

--- a/packages/coding-agent/test/workflow-mutation-guard.test.ts
+++ b/packages/coding-agent/test/workflow-mutation-guard.test.ts
@@ -377,6 +377,9 @@ describe("workflow mutation guard", () => {
 			"if eval 'cat(){ bash -s; }'; then :; fi\ncat <<'EOF'\nrm src/product.ts\nEOF",
 			// `builtin`/`command` wrappers still reach the evaluated command (Codex P1).
 			"builtin eval 'cat(){ bash -s; }'; cat <<'EOF'\nrm src/product.ts\nEOF",
+			"command -- eval 'cat(){ bash -s; }'; cat <<'EOF'\nrm src/product.ts\nEOF",
+			// Bash's `function name()` hybrid form is still a declaration (Codex P1).
+			"function cat() { bash -s; }; cat <<'EOF'\nrm src/product.ts\nEOF",
 			// Function shadows after reserved words are still declarations (Codex P1).
 			"if true; then cat() { bash -s; }; fi\ncat <<'EOF'\nrm src/product.ts\nEOF",
 			// `case` pattern `)` desyncs the depth scanner — fail closed (Codex P1).

--- a/packages/coding-agent/test/workflow-mutation-guard.test.ts
+++ b/packages/coding-agent/test/workflow-mutation-guard.test.ts
@@ -364,6 +364,11 @@ describe("workflow mutation guard", () => {
 			"bash -s \\| cat <<'EOF'\nrm src/product.ts\nEOF",
 			// A shadowed allowlisted name executes the body through its function body (Codex P1).
 			"cat() { bash -s; }; cat <<'EOF'\nrm src/product.ts\nEOF",
+			// `)` closing a $() substitution is a word char, so `#` stays literal and the shadow stays live (Codex P1).
+			"x=$(true)#lit; cat() { bash -s; }; cat <<'EOF'\nrm src/product.ts\nEOF",
+			// eval/source can install a shadow from quoted data the syntax view blanked (Codex P1).
+			"eval 'cat(){ bash -s; }'; cat <<'EOF'\nrm src/product.ts\nEOF",
+			"source /dev/stdin <<'DEF'\ncat(){ bash -s; }\nDEF\ncat <<'EOF'\nrm src/product.ts\nEOF",
 			// A line-continued opener hides the downstream interpreter stage (Codex P1).
 			"cat <<'EOF' \\\n| bash\nrm src/product.ts\nEOF",
 			// A multiline double-quoted string containing `cat <<'EOF'` is data, not an opener (Codex P1).

--- a/packages/coding-agent/test/workflow-mutation-guard.test.ts
+++ b/packages/coding-agent/test/workflow-mutation-guard.test.ts
@@ -321,6 +321,8 @@ describe("workflow mutation guard", () => {
 			`cat <<-'TABDOC' > /tmp/spec.md\n\tindented body a > b\n\tTABDOC`,
 			`cat <<'CNT' | wc -l\n${specBody}\nCNT`,
 			`cat <<'PIPE' | grep -c retrieval | sort\n${specBody}\nPIPE`,
+			// A stray quote inside a comment must not poison cross-line quote state (Codex P2).
+			`# don't trip on this apostrophe\ncat <<'CMT' > /tmp/spec.md\n${specBody}\nCMT`,
 		]) {
 			const decision = await getWorkflowMutationDecision({
 				cwd,

--- a/packages/coding-agent/test/workflow-mutation-guard.test.ts
+++ b/packages/coding-agent/test/workflow-mutation-guard.test.ts
@@ -380,8 +380,9 @@ describe("workflow mutation guard", () => {
 			// `builtin`/`command` wrappers still reach the evaluated command (Codex P1).
 			"builtin eval 'cat(){ bash -s; }'; cat <<'EOF'\nrm src/product.ts\nEOF",
 			"command -- eval 'cat(){ bash -s; }'; cat <<'EOF'\nrm src/product.ts\nEOF",
-			// Leading redirections precede the command word (Codex P1).
+			// Leading redirections precede the command word — attached or separated (Codex P1).
 			"</dev/null eval 'cat(){ bash -s; }'; cat <<'EOF'\nrm src/product.ts\nEOF",
+			"< /dev/null eval 'cat(){ bash -s; }'; cat <<'EOF'\nrm src/product.ts\nEOF",
 			// Bash's `function name()` hybrid form is still a declaration (Codex P1).
 			"function cat() { bash -s; }; cat <<'EOF'\nrm src/product.ts\nEOF",
 			// Function shadows after reserved words are still declarations (Codex P1).


### PR DESCRIPTION
Follow-up to #3415, which merged before its last commit landed. This carries the four P1 fixes Codex flagged on the merge commit (`0d202ee7`):

1. **Escaped separators** (`bash -s \| cat <<'EOF'`): new `maskLineForSyntax` masks backslash-escaped characters to spaces, so `\|` never splits a pipe stage — the segment classifies as `bash` and the body stays live.
2. **Shadowed consumers** (`cat() { bash -s; }; cat <<'EOF'`): `DATA_CONSUMER_SHADOW_RE` detects any function/alias definition of an allowlisted consumer name anywhere in the command and disables body masking for the whole command (fail closed).
3. **Line continuations** (`cat <<'EOF' \` / `| bash`): an opener on a continued or continuation line never masks — part of the pipeline is out of view.
4. **Multiline quoted strings** (`printf '%s' "…cat <<'EOF'…"`): single/double-quote state is now carried across physical lines, so a literal opener inside a multiline string is masked data, never a real opener.

All four bypasses have block-suite regression tests; the allow-suite (spec staging to `/tmp` via quoted-delimiter heredocs, inert pipelines like `cat <<'EOF' | wc -l`) is unchanged.

Verified: `bun test test/workflow-mutation-guard.test.ts` → 30 pass (217 asserts); deep-interview gate/redteam suites → 92 pass total; `tsc --noEmit` and biome clean.