### PR TITLE
fix(coding-agent): surface subagent launch failures

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Subagent setup failures now retain a bounded, redacted cause through live progress, async snapshots, inspect/await, and terminal receipts instead of reporting an empty generic failure.
 
 ### Fixed
 

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -32,6 +32,8 @@ export interface AsyncJob {
 	promise: Promise<void>;
 	resultText?: string;
 	errorText?: string;
+	/** Safe, bounded cause when session setup failed before the LLM began work. */
+	setupFailureSummary?: string;
 	metadata?: AsyncJobMetadata;
 	/**
 	 * Registry id of the agent that registered the job (e.g. "0-Main",
@@ -69,9 +71,12 @@ export interface AsyncJobMetadata {
  * non-terminal and non-delivering: the run suspended at a safe boundary and the
  * subagent can be resumed from its persisted sessionFile. `completed` always
  * wins a race with a late pause because the run returns it once it has actually
- * finished.
+ * finished. A `failed` outcome retains a safe setup diagnostic for receipt rendering.
  */
-export type SubagentRunOutcome = { kind: "completed"; text: string } | { kind: "paused"; note?: string };
+export type SubagentRunOutcome =
+	| { kind: "completed"; text: string }
+	| { kind: "failed"; text: string; setupFailureSummary?: string }
+	| { kind: "paused"; note?: string };
 
 /** Canonical lifecycle of a subagent across pause/resume cycles. */
 export type SubagentLifecycle = "running" | "paused" | "queued" | "completed" | "failed" | "cancelled";
@@ -499,7 +504,7 @@ export class AsyncJobManager {
 					typeof result === "string" ? { kind: "completed", text: result } : result;
 
 				if (job.status === "cancelled") {
-					job.resultText = outcome.kind === "completed" ? outcome.text : outcome.note;
+					job.resultText = outcome.kind === "paused" ? outcome.note : outcome.text;
 					this.#runLifecycle(id, "terminal", job);
 					this.#scheduleEviction(id);
 					this.#markRecordTerminal(id, "cancelled");
@@ -514,6 +519,18 @@ export class AsyncJobManager {
 					this.#freezeEndTime(job);
 					if (outcome.note) job.resultText = outcome.note;
 					this.#markRecordPaused(id);
+					this.#drainResumeQueue();
+					return;
+				}
+				if (outcome.kind === "failed") {
+					job.status = "failed";
+					job.setupFailureSummary = outcome.setupFailureSummary;
+					this.#freezeEndTime(job);
+					job.errorText = outcome.text;
+					this.#enqueueDelivery(id, outcome.text);
+					this.#runLifecycle(id, "terminal", job);
+					this.#scheduleEviction(id);
+					this.#markRecordTerminal(id, "failed");
 					this.#drainResumeQueue();
 					return;
 				}

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -56,11 +56,13 @@ import { persistTaskTokenLog, taskTokenLogFromUsage } from "./token-log";
 import {
 	type AgentDefinition,
 	type AgentProgress,
+	createSetupFailureSummary,
 	hasCompleteUsageCostBreakdown,
 	MAX_OUTPUT_BYTES,
 	MAX_OUTPUT_LINES,
 	type ModelSubstitutionWarning,
 	type ReviewFinding,
+	type SetupFailureSummary,
 	type SingleResult,
 	TASK_SUBAGENT_EVENT_CHANNEL,
 	TASK_SUBAGENT_LIFECYCLE_CHANNEL,
@@ -873,6 +875,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 	let sessionEventOrdinal = 0;
 	let retryStartOrdinal = 0;
 	const seenAssistantMessages = new WeakSet<AgentMessage>();
+	let llmRequestStarted = false;
 	const seenAssistantMessageIdentities = new Set<string>();
 
 	// Accumulate usage incrementally from message_end events (no memory for streaming events)
@@ -1380,6 +1383,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		error?: string;
 		aborted?: boolean;
 		abortReason?: string;
+		setupFailure?: SetupFailureSummary;
 		durationMs: number;
 	}> => {
 		const sessionAbortController = new AbortController();
@@ -1387,6 +1391,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		let error: string | undefined;
 		let aborted = false;
 		let abortReasonText: string | undefined;
+		let setupFailure: SetupFailureSummary | undefined;
 		const checkAbort = () => {
 			if (abortSignal.aborted) {
 				aborted = abortReason === "signal" || runtimeLimitExceeded || abortReason === undefined;
@@ -1907,16 +1912,24 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				}
 			}
 			const runMode = options.runMode ?? "initial";
+			const markLlmRequestStarted = () => {
+				llmRequestStarted = true;
+			};
+			const promptOptions = {
+				attribution: "agent" as const,
+				// A prompt is an LLM request only after AgentSession accepts its
+				// preflight fence. Rejections remain setup failures.
+				onPreflightAccepted: markLlmRequestStarted,
+				onPreflightAcceptCommit: markLlmRequestStarted,
+			};
 			if (runMode === "message") {
-				await awaitAbortable(session.prompt(options.resumeMessage ?? "", { attribution: "agent" }));
+				await awaitAbortable(session.prompt(options.resumeMessage ?? "", promptOptions));
 				await awaitAbortable(session.waitForIdle());
 			} else if (runMode === "resume") {
-				await awaitAbortable(
-					session.prompt("Continue from the paused subagent session state.", { attribution: "agent" }),
-				);
+				await awaitAbortable(session.prompt("Continue from the paused subagent session state.", promptOptions));
 				await awaitAbortable(session.waitForIdle());
 			} else {
-				await awaitAbortable(session.prompt(task, { attribution: "agent" }));
+				await awaitAbortable(session.prompt(task, promptOptions));
 				await awaitAbortable(session.waitForIdle());
 			}
 
@@ -1993,6 +2006,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			exitCode = 1;
 			if (!abortSignal.aborted) {
 				error = err instanceof Error ? err.stack || err.message : String(err);
+				if (!llmRequestStarted) setupFailure = createSetupFailureSummary(err);
 			}
 		} finally {
 			if (abortSignal.aborted) {
@@ -2028,6 +2042,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			error,
 			aborted,
 			abortReason: aborted ? abortReasonText : undefined,
+			setupFailure,
 			durationMs: Date.now() - startTime,
 		};
 	};
@@ -2132,6 +2147,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				? yieldAbortReason
 				: (done.abortReason ?? (signal?.aborted ? resolveSignalAbortReason() : resolveAbortReasonText()))
 		: undefined;
+	progress.setupFailure = done.setupFailure;
 	progress.status = paused ? "paused" : wasAborted ? "aborted" : exitCode === 0 ? "completed" : "failed";
 	scheduleProgress(true);
 
@@ -2168,6 +2184,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		modelOverride,
 		modelSubstitutionWarning,
 		error: exitCode !== 0 && stderr ? stderr : undefined,
+		setupFailure: done.setupFailure,
 		aborted: wasAborted,
 		abortReason: finalAbortReason,
 		paused,

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -19,7 +19,7 @@ import type { AgentTool, AgentToolResult, AgentToolUpdateCallback } from "@gajae
 import type { Model, Usage } from "@gajae-code/ai";
 import { $pickenv, prompt, Snowflake } from "@gajae-code/utils";
 import type { ToolSession } from "..";
-import { AsyncJobManager, OwnerSubagentShutdownError, type ResumeRunner } from "../async";
+import { AsyncJobManager, OwnerSubagentShutdownError, type ResumeRunner, type SubagentRunOutcome } from "../async";
 import { resolveAgentModelPatterns } from "../config/model-resolver";
 import type { Theme } from "../modes/theme/theme";
 import planModeSubagentPrompt from "../prompts/system/plan-mode-subagent.md" with { type: "text" };
@@ -97,6 +97,23 @@ function isTaskResumeDescriptor(value: unknown): value is TaskResumeDescriptor {
 }
 function renderTaskAssignment(assignment: string, simpleMode: TaskSimpleMode): string {
 	return renderSubagentUserPrompt(assignment, simpleMode === "independent");
+}
+
+export function subagentRunOutcomeFromSingleResult(
+	finalText: string,
+	singleResult: Pick<SingleResult, "aborted" | "exitCode" | "paused" | "setupFailure"> | undefined,
+): string | SubagentRunOutcome {
+	if (singleResult?.paused) return { kind: "paused" };
+	if (singleResult && ((singleResult.aborted ?? false) || singleResult.exitCode !== 0)) {
+		return {
+			kind: "failed",
+			text: finalText,
+			...(singleResult.setupFailure && !singleResult.aborted
+				? { setupFailureSummary: singleResult.setupFailure.summary }
+				: {}),
+		};
+	}
+	return finalText;
 }
 function createUsageTotals(): Usage {
 	return {
@@ -655,15 +672,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						);
 						const finalText = result.content.find(part => part.type === "text")?.text ?? "(no output)";
 						const singleResult = result.details?.results[0];
-						if (singleResult?.paused) return { kind: "paused" };
-						// A resumed subprocess that aborted or exited non-zero is a failed
-						// resume, not a completed one. Throw the rendered failure summary
-						// (finalText) so the leg is reported failed instead of being
-						// returned as successful continuation.
-						if (singleResult && ((singleResult.aborted ?? false) || singleResult.exitCode !== 0)) {
-							throw new Error(finalText);
-						}
-						return finalText;
+						return subagentRunOutcomeFromSingleResult(finalText, singleResult);
 					},
 					{
 						id: `${descriptor.task.id}-resume-${Snowflake.next()}`,
@@ -809,6 +818,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 										}
 									: undefined;
 								progress.retryState = undefined;
+								progress.setupFailure = singleResult?.setupFailure;
 							}
 							completedJobs += 1;
 							if (singleResult && ((singleResult.aborted ?? false) || singleResult.exitCode !== 0)) {
@@ -831,10 +841,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 									`Background task batch complete: ${completedJobs}/${taskItems.length} finished.`,
 								);
 							}
-							if (singleResult?.paused) {
-								return { kind: "paused" };
-							}
-							return finalText;
+							return subagentRunOutcomeFromSingleResult(finalText, singleResult);
 						} catch (error) {
 							if (progress) {
 								progress.status = "failed";

--- a/packages/coding-agent/src/task/receipt.ts
+++ b/packages/coding-agent/src/task/receipt.ts
@@ -34,6 +34,7 @@ export interface TaskResultReceipt {
 	usageCostBreakdownComplete?: true;
 	branchName?: string;
 	retryFailure?: { attempt: number; errorSummary: string };
+	setupFailure?: { summary: string };
 	errorSummary?: string;
 	abortSummary?: string;
 	preview: string;
@@ -103,6 +104,9 @@ function normalizeReviewFindingSeverity(severity: unknown, priority: unknown): s
 
 function buildSafeSynopsis(raw: SingleResult, outputRef: TaskResultReceipt["outputRef"]): string {
 	const status = getStatus(raw);
+	if (raw.setupFailure) {
+		return `Task ${status} during setup: ${raw.setupFailure.summary}`;
+	}
 	if (raw.modelSubstitutionWarning) {
 		return `Task ${status}; requested model substituted from ${raw.modelSubstitutionWarning.requested} to ${raw.modelSubstitutionWarning.effective}.`;
 	}
@@ -254,7 +258,8 @@ export function buildTaskReceipt(raw: SingleResult): TaskResultReceipt {
 		retryFailure: raw.retryFailure
 			? { attempt: raw.retryFailure.attempt, errorSummary: "Retry failure recorded." }
 			: undefined,
-		errorSummary: raw.error ? "Error recorded." : undefined,
+		errorSummary: raw.setupFailure?.summary ?? (raw.error ? "Error recorded." : undefined),
+		setupFailure: raw.setupFailure ? { summary: raw.setupFailure.summary } : undefined,
 		abortSummary: raw.abortReason ? "Abort reason recorded." : undefined,
 		preview,
 		previewTruncated: false,

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -594,6 +594,10 @@ function renderAgentProgress(
 			)}`,
 		);
 	}
+	if (progress.setupFailure && progress.status !== "running") {
+		const summary = `Setup failure: ${truncateToWidth(replaceTabs(progress.setupFailure.summary), 80)}`;
+		lines.push(`${continuePrefix}${theme.tree.hook} ${theme.fg("error", summary)}`);
+	}
 
 	// Current tool (if running) or most recent completed tool
 	if (progress.status === "running") {

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -313,6 +313,8 @@ export interface AgentProgress {
 		attempt: number;
 		errorMessage: string;
 	};
+	/** Safe diagnostic retained in terminal progress when setup fails before the first LLM request. */
+	setupFailure?: SetupFailureSummary;
 	/**
 	 * Snapshot of the most recent `task` tool call's in-flight `TaskToolDetails`,
 	 * captured from `tool_execution_update`. Lets the parent UI surface live
@@ -321,6 +323,96 @@ export interface AgentProgress {
 	 * `extractedToolData.task` after that.
 	 */
 	inflightTaskDetails?: TaskToolDetails;
+}
+
+/** Bounded diagnostic retained when subagent setup fails before an LLM request starts. */
+export interface SetupFailureSummary {
+	summary: string;
+}
+
+const SETUP_FAILURE_SUMMARY_MAX_CHARS = 280;
+const SETUP_FAILURE_SUMMARY_MAX_BYTES = 1_024;
+const AUTHORIZATION_HEADER_VALUE_PATTERN = /(["']?(?:Proxy-)?Authorization\b["']?\s*:\s*)[^\r\n]*/gi;
+const COOKIE_HEADER_VALUE_PATTERN = /(["']?(?:Set-)?Cookie\b["']?\s*:\s*)[^\r\n]*/gi;
+const URL_CREDENTIAL_PATTERN = /([a-z][a-z0-9+.-]*:\/\/)[^/?#\s:@]+:[^@/?#\s]+@/gi;
+const API_KEY_LABEL_VALUE_PATTERN = /(["']?api\s+key["']?\s*:\s*)(?:"[^"]*"|'[^']*'|[^\s&]+)/gi;
+const SENSITIVE_SETUP_FAILURE_VALUE_PATTERN =
+	/(["']?(?:(?:[A-Za-z][A-Za-z0-9]*[_.-])*?)(?:access[_-]?token|refresh[_-]?token|session[_-]?token|id[_-]?token|api[_-]?key|client[_-]?secret|private[_-]?key|signing[_-]?key|secret|password|passwd|pwd|authorization|credential|token)(?:[_.-][A-Za-z0-9]+)*["']?)(\s*[=:]\s*)(?:"[^"]*"|'[^']*'|[^\s&]+)/gi;
+const BARE_PROVIDER_TOKEN_PATTERN =
+	/\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{20,}|sk-(?:proj-)?[A-Za-z0-9_-]{20,}|sk-ant-[A-Za-z0-9_-]{20,}|AIza[A-Za-z0-9_-]{35}|AKIA[A-Z0-9]{16})\b/g;
+const LOCAL_ABSOLUTE_PATH_PATTERN = /(^|[\s("'`=])((?:\/(?!\/)[^\s/:?"'`()[\]{},;<>]+){2,})/g;
+const WINDOWS_ABSOLUTE_PATH_PATTERN =
+	/(^|[\s("'`=])([A-Za-z]:\\(?:[^\\/:?"'`()[\]{},;<>\s]+\\)+[^\\/:?"'`()[\]{},;<>\s]+)/g;
+const LOCAL_FILE_URI_PATTERN = /\bfile:\/\/(?:localhost)?(?:\/[^\s/:?"'`()[\]{},;<>]+)+/gi;
+const SENSITIVE_PATH_BASENAME_PATTERN =
+	/(?:^|[_.-])(?:access[_-]?token|refresh[_-]?token|session[_-]?token|id[_-]?token|api[_-]?key|client[_-]?secret|private[_-]?key|signing[_-]?key|secrets?|password|passwd|pwd|authorization|credential|token)(?:[_.-]|$)|^(?:\.env(?:\..*)?|credentials?(?:\.[A-Za-z0-9_-]+)?|id_(?:rsa|ed25519)|.+\.(?:pem|p12|pfx|key))$|^(?:sk|pk|rk|gh[opsur]|github_pat|xox[baprs])[_-][A-Za-z0-9_-]+$/i;
+
+function redactPathBasename(path: string): string {
+	const basename = path.slice(Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\")) + 1);
+	return SENSITIVE_PATH_BASENAME_PATTERN.test(basename) ? "[redacted]" : basename;
+}
+
+function redactLocalAbsolutePath(_match: string, prefix: string, absolutePath: string): string {
+	return `${prefix}<path>/${redactPathBasename(absolutePath)}`;
+}
+
+function redactLocalFileUri(uri: string): string {
+	return `file://<path>/${redactPathBasename(uri)}`;
+}
+
+function normalizeSetupFailureText(value: string): string {
+	return value
+		.normalize("NFKC")
+		.replace(/\u001B(?:\[[0-?]*[ -/]*[@-~]|\][^\u0007\u001B]*(?:\u0007|\u001B\\))/g, "")
+		.replace(/[\u200B-\u200D\u2060\uFEFF]/g, "")
+		.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]/g, "")
+		.replace(/\t/g, " ");
+}
+
+function capSetupFailureSummary(value: string): string {
+	const ellipsis = "…";
+	const ellipsisBytes = Buffer.byteLength(ellipsis, "utf8");
+	const chunks: string[] = [];
+	let chars = 0;
+	let bytes = 0;
+	for (const codePoint of value) {
+		const codePointBytes = Buffer.byteLength(codePoint, "utf8");
+		if (chars + 1 > SETUP_FAILURE_SUMMARY_MAX_CHARS || bytes + codePointBytes > SETUP_FAILURE_SUMMARY_MAX_BYTES) {
+			while (
+				chunks.length > 0 &&
+				(chars + 1 > SETUP_FAILURE_SUMMARY_MAX_CHARS || bytes + ellipsisBytes > SETUP_FAILURE_SUMMARY_MAX_BYTES)
+			) {
+				const removed = chunks.pop()!;
+				chars -= 1;
+				bytes -= Buffer.byteLength(removed, "utf8");
+			}
+			return `${chunks.join("")}${ellipsis}`;
+		}
+		chunks.push(codePoint);
+		chars += 1;
+		bytes += codePointBytes;
+	}
+	return chunks.join("");
+}
+
+/** Create a bounded diagnostic that preserves a setup failure's cause without exposing credentials or local paths. */
+export function createSetupFailureSummary(error: unknown): SetupFailureSummary {
+	const message = normalizeSetupFailureText(error instanceof Error ? error.message : String(error));
+	const summary = message
+		.replace(AUTHORIZATION_HEADER_VALUE_PATTERN, "$1[redacted]")
+		.replace(COOKIE_HEADER_VALUE_PATTERN, "$1[redacted]")
+		.replace(URL_CREDENTIAL_PATTERN, "$1[redacted]@")
+		.replace(API_KEY_LABEL_VALUE_PATTERN, "$1[redacted]")
+		.replace(LOCAL_FILE_URI_PATTERN, redactLocalFileUri)
+		.replace(LOCAL_ABSOLUTE_PATH_PATTERN, redactLocalAbsolutePath)
+		.replace(WINDOWS_ABSOLUTE_PATH_PATTERN, redactLocalAbsolutePath)
+		.replace(SENSITIVE_SETUP_FAILURE_VALUE_PATTERN, "$1$2[redacted]")
+		.replace(BARE_PROVIDER_TOKEN_PATTERN, "[redacted]")
+		.replace(/\s+/g, " ")
+		.trim();
+	return {
+		summary: capSetupFailureSummary(summary) || "Subagent setup failed.",
+	};
 }
 
 /** Result from a single agent execution */
@@ -347,6 +439,8 @@ export interface SingleResult {
 	modelOverride?: string | string[];
 	modelSubstitutionWarning?: ModelSubstitutionWarning;
 	error?: string;
+	/** Safe diagnostic for a failure before the subagent sent its first LLM request. */
+	setupFailure?: SetupFailureSummary;
 	aborted?: boolean;
 	abortReason?: string;
 	paused?: boolean;

--- a/packages/coding-agent/src/tools/subagent-render.ts
+++ b/packages/coding-agent/src/tools/subagent-render.ts
@@ -192,6 +192,9 @@ function renderSubagentSnapshotBody(
 	}
 	if (snapshot.description) lines.push(`  ${theme.fg("dim", `Description: ${snapshot.description}`)}`);
 	if (snapshot.outputRef) lines.push(`  ${theme.fg("dim", `Output: ${snapshot.outputRef}`)}`);
+	if (snapshot.setupFailureSummary) {
+		lines.push(`  ${theme.fg("error", `Setup failure: ${snapshot.setupFailureSummary}`)}`);
+	}
 	if (snapshot.assignment) {
 		lines.push(`  ${theme.fg("dim", "Assignment:")}`);
 		for (const al of snapshot.assignment.split("\n")) lines.push(`    ${theme.fg("toolOutput", replaceTabs(al))}`);
@@ -312,8 +315,9 @@ export const subagentToolRenderer = {
 					);
 				}
 
-				snapshotSignatures ??= subagents.map(snapshot =>
-					subagentAwaitRenderedStateSignature([snapshot], result.details),
+				snapshotSignatures ??= subagents.map(
+					snapshot =>
+						`${subagentAwaitRenderedStateSignature([snapshot], result.details)}:${snapshot.setupFailureSummary ?? ""}`,
 				);
 				subagents.forEach((snapshot, index) => {
 					// Fresh per-subagent status line (cheap), then a cached or dynamic body.

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -65,6 +65,8 @@ export interface SubagentSnapshot {
 	durationMs: number;
 	resultText?: string;
 	errorText?: string;
+	/** Safe setup failure cause retained from the executor launch path. */
+	setupFailureSummary?: string;
 	resultPreview?: string;
 	outputRef?: string;
 	truncated?: boolean;
@@ -603,6 +605,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			}
 			if (snapshot.description) lines.push(`Description: ${snapshot.description}`);
 			if (snapshot.outputRef) lines.push(`Output: ${snapshot.outputRef}`);
+			if (snapshot.setupFailureSummary) lines.push(`Setup failure: ${snapshot.setupFailureSummary}`);
 			if (snapshot.assignment) lines.push("Assignment:", "```", snapshot.assignment, "```");
 			if (snapshot.steerMessage) {
 				lines.push(`Steer (${snapshot.steerState ?? "queued"}):`, "```", snapshot.steerMessage, "```");
@@ -730,6 +733,9 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 						resultPreview: output.preview,
 						truncated: output.truncated,
 					}
+				: {}),
+			...(job.setupFailureSummary
+				? { setupFailureSummary: sanitizeText(job.setupFailureSummary, RECEIPT_PREVIEW_WIDTH) }
 				: {}),
 			...(outputRef ? { outputRef } : {}),
 			...(runningTimeoutGuidance ? { guidance: runningTimeoutGuidance } : {}),

--- a/packages/coding-agent/test/task/render-nested-live.test.ts
+++ b/packages/coding-agent/test/task/render-nested-live.test.ts
@@ -297,6 +297,17 @@ describe("task renderer: nested live rendering", () => {
 		expect(text).toContain("Requested model substituted: openai-codex/gpt-5.3-codex -> openai-codex/gpt-5.5");
 		expect(text).not.toContain("Model override substituted");
 	});
+	it("renders a terminal setup failure in live progress", async () => {
+		const text = await render(
+			makeRunningProgress({
+				id: "3-SetupFailure",
+				status: "failed",
+				setupFailure: { summary: "Credential bootstrap rejected." },
+			}),
+		);
+
+		expect(text).toContain("Setup failure: Credential bootstrap rejected.");
+	});
 
 	it("renders requested model substitution in final results", async () => {
 		const text = await renderResult({

--- a/packages/coding-agent/test/tools/subagent.test.ts
+++ b/packages/coding-agent/test/tools/subagent.test.ts
@@ -3,8 +3,19 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { AsyncJobManager } from "../../src/async";
+import { kNoAuth } from "../../src/config/model-registry";
 import { Settings } from "../../src/config/settings";
+import { getThemeByName } from "../../src/modes/theme/theme";
+import * as sdkModule from "../../src/sdk";
+import type { AgentSession, PromptOptions } from "../../src/session/agent-session";
+import { subagentRunOutcomeFromSingleResult } from "../../src/task";
+import { runSubprocess } from "../../src/task/executor";
+import { buildTaskReceipt } from "../../src/task/receipt";
+import type { AgentDefinition } from "../../src/task/types";
+import { createSetupFailureSummary, type SingleResult } from "../../src/task/types";
 import { capCodePointsAndBytes, SubagentTool, type ToolSession } from "../../src/tools";
+import type { SubagentToolDetails } from "../../src/tools/subagent";
+import { subagentBodyCacheTestHooks, subagentToolRenderer } from "../../src/tools/subagent-render";
 
 function createSession(agentId = "0-Main"): ToolSession {
 	return {
@@ -149,6 +160,297 @@ describe("SubagentTool", () => {
 		expect(getText(result)).toContain("subagent result");
 		expect(manager.hasPendingDeliveries()).toBe(false);
 		await manager.dispose({ timeoutMs: 100 });
+	});
+	it("retains a bounded, redacted executor setup failure in async subagent receipts", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const secret = "TOP_SECRET_DO_NOT_LEAK";
+		const setupFailure = createSetupFailureSummary(
+			new Error(
+				`Agent session initialization failed: token=${secret} at /tmp/${secret}/session.jsonl ${"x".repeat(400)}`,
+			),
+		);
+		const singleResult = {
+			aborted: false,
+			exitCode: 1,
+			setupFailure,
+		} satisfies Pick<SingleResult, "aborted" | "exitCode" | "setupFailure">;
+		const jobId = manager.register(
+			"task",
+			"launching subagent",
+			async () => subagentRunOutcomeFromSingleResult("Subagent failed.", singleResult),
+			{
+				id: "job-setup-failure",
+				ownerId: "0-Main",
+				metadata: { subagent: { id: "0-SetupFailure", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+
+		await manager.getJob(jobId)?.promise;
+		const result = await tool.execute("subagent-setup-failure", { action: "inspect", ids: ["0-SetupFailure"] });
+		const snapshot = result.details?.subagents[0];
+
+		expect(snapshot?.status).toBe("failed");
+		expect(snapshot?.setupFailureSummary).toContain("Agent session initialization failed");
+		expect(snapshot?.setupFailureSummary).toContain("token=[redacted]");
+		expect(snapshot?.setupFailureSummary).not.toContain(secret);
+		expect(snapshot?.setupFailureSummary).not.toContain("/tmp/");
+		expect(snapshot?.setupFailureSummary?.length ?? 0).toBeLessThanOrEqual(280);
+		expect(getText(result)).toContain(`Setup failure: ${snapshot?.setupFailureSummary}`);
+		await manager.dispose({ timeoutMs: 100 });
+	});
+	it("renders setup failures and invalidates the static body cache when the cause changes", async () => {
+		const theme = await getThemeByName("red-claw");
+		if (!theme) throw new Error("Expected test theme");
+		const details = (setupFailureSummary: string): SubagentToolDetails => ({
+			subagents: [
+				{
+					id: "0-SetupFailure",
+					jobId: "job-setup-failure",
+					status: "failed",
+					label: "launching subagent",
+					agent: "executor",
+					agentSource: "bundled",
+					durationMs: 1,
+					setupFailureSummary,
+				},
+			],
+		});
+		const render = (value: SubagentToolDetails) =>
+			Bun.stripANSI(
+				subagentToolRenderer
+					.renderResult(
+						{ content: [{ type: "text", text: "" }], details: value },
+						{ expanded: true, isPartial: false },
+						theme,
+					)
+					.render(160)
+					.join("\n"),
+			);
+
+		subagentBodyCacheTestHooks.reset();
+		expect(render(details("Session setup rejected."))).toContain("Setup failure: Session setup rejected.");
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+		expect(render(details("Session setup rejected after credentials refresh."))).toContain(
+			"Setup failure: Session setup rejected after credentials refresh.",
+		);
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(2);
+	});
+	it("marks requests only after the real prompt preflight accepts in every run mode", async () => {
+		const agent: AgentDefinition = { name: "executor", description: "test", systemPrompt: "test", source: "bundled" };
+		const modes = ["initial", "resume", "message"] as const;
+		const run = async (runMode: (typeof modes)[number], accept: boolean) => {
+			const promptOptions: PromptOptions[] = [];
+			const session = {
+				agent: { state: { systemPrompt: ["test"] } },
+				sessionManager: { appendSessionInit: () => {} },
+				extensionRunner: undefined,
+				get messages() {
+					return [];
+				},
+				getActiveToolNames: () => ["read", "yield"],
+				setActiveToolsByName: async () => {},
+				setConfiguredModelChain: () => {},
+				seedDefaultFallbackResolution: () => {},
+				subscribe: () => () => {},
+				prompt: async (_text: string, options?: PromptOptions) => {
+					if (options) promptOptions.push(options);
+					if (accept) await options?.onPreflightAcceptCommit?.();
+					throw new Error(
+						accept ? "request failed after acceptance" : "preflight rejected: token=preflight-secret",
+					);
+				},
+				waitForIdle: async () => {},
+				getLastAssistantMessage: () => undefined,
+				abort: async () => {},
+				dispose: async () => {},
+			} as unknown as AgentSession;
+			const spy = vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue({ session } as never);
+			try {
+				const result = await runSubprocess({
+					cwd: "/tmp",
+					agent,
+					task: "do work",
+					index: 0,
+					id: `0-${runMode}-${accept ? "accepted" : "rejected"}`,
+					settings: Settings.isolated(),
+					modelRegistry: {
+						refresh: async () => {},
+						getAvailable: () => [],
+						getApiKey: async () => kNoAuth,
+					} as never,
+					enableLsp: false,
+					runMode,
+					resumeMessage: "continue",
+				});
+				expect(promptOptions).toHaveLength(1);
+				expect(promptOptions[0]?.onPreflightAccepted).toBeFunction();
+				expect(promptOptions[0]?.onPreflightAcceptCommit).toBeFunction();
+				return result;
+			} finally {
+				spy.mockRestore();
+			}
+		};
+
+		for (const mode of modes) {
+			const rejected = await run(mode, false);
+			expect(rejected.setupFailure?.summary).toContain("preflight rejected: token=[redacted]");
+			const accepted = await run(mode, true);
+			expect(accepted.setupFailure).toBeUndefined();
+		}
+	});
+	it("redacts complete authorization header values and query credentials", () => {
+		const secrets = [
+			"bearer-secret",
+			"basic-secret",
+			"arbitrary-secret",
+			"query-token",
+			"query-key",
+			"#GJC1_opaque_secret#",
+		];
+		const summary = createSetupFailureSummary(
+			new Error(
+				[
+					"Request failed",
+					"Authorization: Bearer bearer-secret",
+					"Authorization: Basic basic-secret",
+					"Authorization: Digest arbitrary-secret",
+					"GET /callback?access_token=query-token&api_key=query-key",
+					"token=[redacted]",
+					"credential=#GJC1_opaque_secret#",
+					"status=401",
+				].join("\n"),
+			),
+		).summary;
+
+		expect(summary).toBe(
+			"Request failed Authorization: [redacted] Authorization: [redacted] Authorization: [redacted] GET /callback?access_token=[redacted]&api_key=[redacted] token=[redacted] credential=[redacted] status=401",
+		);
+		for (const secret of secrets) expect(summary).not.toContain(secret);
+	});
+	it("redacts cookies, URL credentials, compound keys, and Unicode-obfuscated secrets within byte bounds", () => {
+		const secrets = ["cookie-secret", "url-secret", "client-secret", "unicode-secret"];
+		const summary = createSetupFailureSummary(
+			new Error(
+				`Cookie: session=cookie-secret; theme=dark\nGET https://user:url-secret@example.test/path clientSecret=client-secret to\u200bken=unicode-secret cache_key=ordinary ${"🧪".repeat(400)}`,
+			),
+		).summary;
+
+		expect(summary).toContain("Cookie: [redacted]");
+		expect(summary).toContain("https://[redacted]@example.test/path");
+		expect(summary).toContain("clientSecret=[redacted]");
+		expect(summary).toContain("token=[redacted]");
+		expect(summary).toContain("cache_key=ordinary");
+		expect(Buffer.byteLength(summary, "utf8")).toBeLessThanOrEqual(1_024);
+		expect(Array.from(summary).length).toBeLessThanOrEqual(281);
+		for (const secret of secrets) expect(summary).not.toContain(secret);
+	});
+	it("redacts underscore-delimited credential names and local paths without hiding prose", () => {
+		const secrets = ["github-token-secret", "openai-api-key-secret", "backup-token-secret"];
+		const summary = createSetupFailureSummary(
+			new Error(
+				[
+					"GITHUB_TOKEN=github-token-secret",
+					"OPENAI_API_KEY=openai-api-key-secret",
+					"GITHUB_TOKEN_BACKUP=backup-token-secret",
+					"failed opening /var/folders/zz/T/gjc/openai-api-key-secret/session.jsonl",
+					"and /opt/gjc/openai-api-key-secret/config.json",
+					"plain prose keeps / callback, 1/2, and /single",
+					"GET /callback?access_token=query-token&api_key=query-key",
+				].join("\n"),
+			),
+		).summary;
+
+		expect(summary).toBe(
+			"GITHUB_TOKEN=[redacted] OPENAI_API_KEY=[redacted] GITHUB_TOKEN_BACKUP=[redacted] failed opening <path>/session.jsonl and <path>/config.json plain prose keeps / callback, 1/2, and /single GET /callback?access_token=[redacted]&api_key=[redacted]",
+		);
+		for (const secret of secrets) expect(summary).not.toContain(secret);
+	});
+	it("redacts sensitive path basenames, local file URIs, and control-fragmented credential values", () => {
+		const pathSecret = "ghp_PATH_SECRET_DO_NOT_LEAK";
+		const valueSecret = "SECRET_SUFFIX_DO_NOT_LEAK";
+		const summary = createSetupFailureSummary(
+			new Error(
+				[
+					`wrote /Users/alice/${pathSecret}`,
+					`at file:///Users/alice/.config/${valueSecret}`,
+					`and file://localhost/private/${valueSecret}`,
+					"ordinary /Users/alice/project/config.json and file:///Users/alice/project/report.txt",
+					`token=prefix\u001b[31m${valueSecret}`,
+					`api_key=prefix\u0000${valueSecret}`,
+				].join("\n"),
+			),
+		).summary;
+
+		expect(summary).toContain("wrote <path>/[redacted]");
+		expect(summary).toContain("file://<path>/[redacted]");
+		expect(summary).toContain("ordinary <path>/config.json and file://<path>/report.txt");
+		expect(summary).toContain("token=[redacted]");
+		expect(summary).toContain("api_key=[redacted]");
+		expect(summary).not.toContain(pathSecret);
+		expect(summary).not.toContain("alice");
+		expect(summary).not.toContain(valueSecret);
+		expect(summary).not.toContain("prefix");
+	});
+	it("redacts spaced API-key labels, high-confidence provider tokens, Windows paths, and secret basenames", () => {
+		const providerToken = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ123456";
+		const summary = createSetupFailureSummary(
+			new Error(
+				`API key: api-key-secret provider ${providerToken} paths C:\\Users\\Alice\\secrets.json and C:\\work\\report.txt ordinary prose remains visible`,
+			),
+		).summary;
+
+		expect(summary).toBe(
+			"API key: [redacted] provider [redacted] paths <path>/[redacted] and <path>/report.txt ordinary prose remains visible",
+		);
+		expect(summary).not.toContain("api-key-secret");
+		expect(summary).not.toContain(providerToken);
+	});
+	it("prioritizes a setup failure in receipt delivery over a model substitution warning", () => {
+		const receipt = buildTaskReceipt({
+			index: 0,
+			id: "0-SetupFailure",
+			agent: "executor",
+			agentSource: "bundled",
+			task: "start",
+			exitCode: 1,
+			output: "",
+			stderr: "",
+			truncated: false,
+			durationMs: 0,
+			tokens: 0,
+			setupFailure: { summary: "Credential bootstrap rejected." },
+			modelSubstitutionWarning: {
+				requested: "openai-codex/gpt-5.3-codex",
+				effective: "openai-codex/gpt-5.5",
+				reason: "auth_unavailable",
+			},
+		} satisfies SingleResult);
+
+		expect(receipt.preview).toBe("Task failed during setup: Credential bootstrap rejected.");
+	});
+	it("maps initial and resumed producer failures identically without exposing post-request causes", () => {
+		const setupFailure = createSetupFailureSummary(new Error("Session initialization failed: token=secret"));
+		const preRequestFailure = {
+			aborted: false,
+			exitCode: 1,
+			setupFailure,
+		} satisfies Pick<SingleResult, "aborted" | "exitCode" | "setupFailure">;
+
+		const initial = subagentRunOutcomeFromSingleResult("Subagent failed.", preRequestFailure);
+		const resumed = subagentRunOutcomeFromSingleResult("Subagent failed.", preRequestFailure);
+		const postRequest = subagentRunOutcomeFromSingleResult("Subagent failed.", {
+			aborted: false,
+			exitCode: 1,
+		});
+
+		expect(initial).toEqual({
+			kind: "failed",
+			text: "Subagent failed.",
+			setupFailureSummary: "Session initialization failed: token=[redacted]",
+		});
+		expect(resumed).toEqual(initial);
+		expect(postRequest).toEqual({ kind: "failed", text: "Subagent failed." });
 	});
 
 	it("consumes a watched completion before unwatch can redeliver it", async () => {


### PR DESCRIPTION
## Summary
- classify preflight/session setup failures before an LLM request starts
- propagate bounded, hardened failure summaries through progress, snapshots, receipts, inspect/await, and render caches
- cover initial, resume, message, async, redaction, and renderer paths

## Verification
- `bun --cwd=packages/coding-agent run check`
- 70 focused tests passed
- dev-base six-PR integration rehearsal: 1,074 tests passed

Fixes #3389