### PR TITLE
fix(streaming): retry first-event timeouts safely

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Agent session configuration can carry an explicit first-event stream timeout while preserving provider defaults when the setting is absent.
 
 ## [0.12.0] - 2026-07-28
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -237,6 +237,8 @@ export interface AgentOptions {
 	requestMaxRetries?: number;
 	/** Provider stream replay retry budget. Counts retries, not the initial attempt. */
 	streamMaxRetries?: number;
+	/** Explicit first-event stream watchdog override in milliseconds. Set to 0 to disable. */
+	streamFirstEventTimeoutMs?: number;
 
 	/**
 	 * Provides tool execution context, resolved per tool call.
@@ -356,6 +358,7 @@ export class Agent {
 	#maxRetryDelayMs?: number;
 	#requestMaxRetries?: number;
 	#streamMaxRetries?: number;
+	#streamFirstEventTimeoutMs?: number;
 	#getToolContext?: (toolCall?: ToolCallContext) => AgentToolContext | undefined;
 	#cursorExecHandlers?: CursorExecHandlers;
 	#cursorOnToolResult?: CursorToolResultHandler;
@@ -430,6 +433,7 @@ export class Agent {
 		this.#maxRetryDelayMs = opts.maxRetryDelayMs;
 		this.#requestMaxRetries = opts.requestMaxRetries;
 		this.#streamMaxRetries = opts.streamMaxRetries;
+		this.#streamFirstEventTimeoutMs = opts.streamFirstEventTimeoutMs;
 		this.getApiKey = opts.getApiKey;
 		this.getAuthCredentialType = opts.getAuthCredentialType;
 		this.#onPayload = opts.onPayload;
@@ -673,6 +677,14 @@ export class Agent {
 
 	set streamMaxRetries(value: number | undefined) {
 		this.#streamMaxRetries = value;
+	}
+
+	get streamFirstEventTimeoutMs(): number | undefined {
+		return this.#streamFirstEventTimeoutMs;
+	}
+
+	set streamFirstEventTimeoutMs(value: number | undefined) {
+		this.#streamFirstEventTimeoutMs = value;
 	}
 
 	get state(): AgentState {
@@ -1444,6 +1456,7 @@ export class Agent {
 			maxRetryDelayMs: this.#maxRetryDelayMs,
 			requestMaxRetries: this.#requestMaxRetries,
 			streamMaxRetries: this.#streamMaxRetries,
+			streamFirstEventTimeoutMs: this.#streamFirstEventTimeoutMs,
 			...(fallbackManaged
 				? {
 						fallbackManaged: true,

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -28,6 +28,36 @@ function identityConverter(messages: AgentMessage[]): Message[] {
 }
 
 describe("agentLoop with AgentMessage", () => {
+	it("forwards first-event timeout overrides to provider stream options", async () => {
+		for (const testCase of [
+			{ name: "absent", timeout: undefined },
+			{ name: "zero", timeout: 0 },
+			{ name: "positive", timeout: 12_345 },
+		]) {
+			const mock = createMockModel({ responses: [{ content: ["ok"] }] });
+			const receivedTimeouts: Array<number | undefined> = [];
+			const stream = agentLoop(
+				[createUserMessage("Hello")],
+				{ systemPrompt: ["You are helpful."], messages: [], tools: [] },
+				{
+					model: mock.model,
+					convertToLlm: identityConverter,
+					...(testCase.timeout === undefined ? {} : { streamFirstEventTimeoutMs: testCase.timeout }),
+				},
+				undefined,
+				(model, context, options) => {
+					receivedTimeouts.push(options?.streamFirstEventTimeoutMs);
+					return mock.stream(model, context, options);
+				},
+			);
+
+			for await (const _event of stream) {
+				// drain
+			}
+
+			expect(receivedTimeouts, testCase.name).toEqual([testCase.timeout]);
+		}
+	});
 	it("should emit events with AgentMessage types", async () => {
 		const context: AgentContext = {
 			systemPrompt: ["You are helpful."],

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -6,6 +6,20 @@ import { createMockModel } from "@gajae-code/ai/providers/mock";
 import { createAssistantMessage } from "./helpers";
 
 describe("Agent", () => {
+	it("preserves first-event timeout options and runtime mutations", () => {
+		const absent = new Agent();
+		expect(absent.streamFirstEventTimeoutMs).toBeUndefined();
+
+		const explicitZero = new Agent({ streamFirstEventTimeoutMs: 0 });
+		expect(explicitZero.streamFirstEventTimeoutMs).toBe(0);
+
+		const positive = new Agent({ streamFirstEventTimeoutMs: 12_345 });
+		expect(positive.streamFirstEventTimeoutMs).toBe(12_345);
+		positive.streamFirstEventTimeoutMs = 0;
+		expect(positive.streamFirstEventTimeoutMs).toBe(0);
+		positive.streamFirstEventTimeoutMs = undefined;
+		expect(positive.streamFirstEventTimeoutMs).toBeUndefined();
+	});
 	it("should support steering message queueing", async () => {
 		const agent = new Agent();
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Provider streams now surface first-event watchdog expiry as a typed timeout so callers can apply bounded retry policy without parsing error prose.
 
 ## [0.12.0] - 2026-07-28
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -62,6 +62,7 @@ import { transportFailureFacts } from "../utils/fallback-transport";
 import { isFoundryEnabled } from "../utils/foundry";
 import { finalizeErrorMessage, type RawHttpRequestDump, rewriteCopilotError } from "../utils/http-inspector";
 import {
+	FirstEventTimeoutError,
 	getProviderFirstEventTimeoutFallbackMs,
 	getStreamFirstEventTimeoutMs,
 	getStreamIdleTimeoutMs,
@@ -1472,7 +1473,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 				// Retries reset output.content; drop stale block correlations from the aborted attempt.
 				blocksByAnthropicIndex.clear();
 				activeAbortTracker = createAbortSourceTracker(options?.signal);
-				const firstEventTimeoutAbortError = new Error(
+				const firstEventTimeoutAbortError = new FirstEventTimeoutError(
 					"Anthropic stream timed out while waiting for the first event",
 				);
 				const idleTimeoutAbortError = new Error("Anthropic stream stalled while waiting for the next event");
@@ -1781,8 +1782,9 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 					}
 					break;
 				} catch (streamError) {
-					const streamFailure = activeAbortTracker.getLocalAbortReason() ?? streamError;
-					if (sawProviderSafetyStop) {
+					const localAbortReason = activeAbortTracker.getLocalAbortReason();
+					const streamFailure = localAbortReason ?? streamError;
+					if (localAbortReason || sawProviderSafetyStop) {
 						throw streamFailure;
 					}
 					if (
@@ -1909,13 +1911,12 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 				delete (block as { index?: number }).index;
 				delete (block as { partialJson?: string }).partialJson;
 			}
-			const firstEventTimeoutError = activeAbortTracker.getLocalAbortReason();
+			const localAbortReason = activeAbortTracker.getLocalAbortReason();
 			output.stopReason = activeAbortTracker.wasCallerAbort() ? "aborted" : "error";
-			output.errorStatus = extractHttpStatusFromError(error);
-			output.transportFailure = transportFailureFacts(error);
+			output.errorStatus = extractHttpStatusFromError(localAbortReason ?? error);
+			output.transportFailure = transportFailureFacts(localAbortReason ?? error);
 			if (output.errorKind !== "provider_safety_stop" || !output.errorMessage) {
-				output.errorMessage =
-					firstEventTimeoutError?.message ?? (await finalizeErrorMessage(error, rawRequestDump));
+				output.errorMessage = localAbortReason?.message ?? (await finalizeErrorMessage(error, rawRequestDump));
 			}
 			output.errorMessage = rewriteCopilotError(output.errorMessage, error, model.provider);
 			output.duration = Date.now() - startTime;

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -22,7 +22,6 @@ import { AssistantMessageEventStream } from "../utils/event-stream";
 import { transportFailureFacts } from "../utils/fallback-transport";
 import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
 import {
-	createWatchdog,
 	getOpenAIStreamIdleTimeoutMs,
 	getStreamFirstEventTimeoutMs,
 	iterateWithIdleTimeout,
@@ -118,7 +117,6 @@ export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"
 		);
 		let rawRequestDump: RawHttpRequestDump | undefined;
 		const abortTracker = createAbortSourceTracker(options?.signal);
-		const firstEventTimeoutAbortError = new Error(AZURE_OPENAI_RESPONSES_FIRST_EVENT_TIMEOUT_MESSAGE);
 		const { requestAbortController, requestSignal } = abortTracker;
 
 		try {
@@ -127,7 +125,7 @@ export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"
 			const client = createClient(model, apiKey, options);
 			const { baseUrl } = resolveAzureConfig(model, options);
 			const params = buildParams(model, context, options, deploymentName, baseUrl);
-			const idleTimeoutMs = getOpenAIStreamIdleTimeoutMs();
+			const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getOpenAIStreamIdleTimeoutMs();
 			options?.onPayload?.(params);
 			rawRequestDump = {
 				provider: model.provider,
@@ -164,18 +162,17 @@ export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"
 				rawRequestDump = { ...rawRequestDump, body: params };
 				openaiStream = await client.responses.create(params, { signal: requestSignal });
 			}
-			const firstEventWatchdog = createWatchdog(
-				options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs),
-				() => abortTracker.abortLocally(firstEventTimeoutAbortError),
-			);
+			const firstEventTimeoutMs = options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs);
 			stream.push({ type: "start", partial: output });
 
 			await processResponsesStream(
 				iterateWithIdleTimeout(openaiStream, {
-					watchdog: firstEventWatchdog,
+					firstItemTimeoutMs: firstEventTimeoutMs,
+					firstItemErrorMessage: AZURE_OPENAI_RESPONSES_FIRST_EVENT_TIMEOUT_MESSAGE,
 					idleTimeoutMs,
 					errorMessage: "Azure OpenAI responses stream stalled while waiting for the next event",
 					onIdle: () => requestAbortController.abort(),
+					onFirstItemTimeout: () => requestAbortController.abort(),
 				}),
 				output,
 				stream,

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -48,9 +48,13 @@ import {
 	sanitizeOpenAIResponsesHistoryItemsForReplay,
 } from "../utils";
 import { AssistantMessageEventStream } from "../utils/event-stream";
-import { transportFailureFacts } from "../utils/fallback-transport";
+import { STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE, transportFailureFacts } from "../utils/fallback-transport";
 import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
-import { getOpenAIStreamIdleTimeoutMs, iterateWithIdleTimeout } from "../utils/idle-iterator";
+import {
+	getOpenAIStreamIdleTimeoutMs,
+	getStreamFirstEventTimeoutMs,
+	iterateWithIdleTimeout,
+} from "../utils/idle-iterator";
 import { parseStreamingJson } from "../utils/json-parse";
 import { resolveRetryBudget } from "../utils/retry-budget";
 import {
@@ -103,7 +107,6 @@ const CODEX_MAX_RETRIES = 5;
 const CODEX_RETRY_DELAY_MS = 500;
 const CODEX_WEBSOCKET_CONNECT_TIMEOUT_MS = 10000;
 const CODEX_WEBSOCKET_IDLE_TIMEOUT_MS = 300000;
-const CODEX_WEBSOCKET_FIRST_EVENT_TIMEOUT_MS = 15000;
 const CODEX_WEBSOCKET_RETRY_BUDGET = CODEX_MAX_RETRIES;
 const CODEX_WEBSOCKET_TRANSPORT_ERROR_PREFIX = "Codex websocket transport error";
 const CODEX_PREVIOUS_RESPONSE_STALE_CODES = new Set(["previous_response_not_found", "codex_previous_response_stale"]);
@@ -274,6 +277,7 @@ async function retryCodexInitialTransportWithoutToolChoice(
 
 interface CodexRequestSetup {
 	requestSignal: AbortSignal;
+	firstEventTimeoutMs: number | undefined;
 	wrapCodexSseStream: (source: AsyncGenerator<Record<string, unknown>>) => AsyncGenerator<Record<string, unknown>>;
 	requestAbortController: AbortController;
 }
@@ -355,16 +359,6 @@ function getCodexWebSocketIdleTimeoutMs(overrideMs?: number): number {
 	);
 }
 
-function getCodexWebSocketFirstEventTimeoutMs(idleTimeoutMs: number, overrideMs?: number): number {
-	return (
-		overrideMs ??
-		parseCodexPositiveInteger(
-			$env.PI_CODEX_WEBSOCKET_FIRST_EVENT_TIMEOUT_MS,
-			Math.min(CODEX_WEBSOCKET_FIRST_EVENT_TIMEOUT_MS, idleTimeoutMs),
-		)
-	);
-}
-
 function createCodexProviderSessionState(): CodexProviderSessionState {
 	const state: CodexProviderSessionState = {
 		webSocketSessions: new Map(),
@@ -391,8 +385,12 @@ function getCodexProviderSessionState(
 	return created;
 }
 
-function createCodexWebSocketTransportError(message: string): Error {
-	return new Error(`${CODEX_WEBSOCKET_TRANSPORT_ERROR_PREFIX}: ${message}`);
+function createCodexWebSocketTransportError(message: string, providerCode?: string): Error & { providerCode?: string } {
+	const error = new Error(`${CODEX_WEBSOCKET_TRANSPORT_ERROR_PREFIX}: ${message}`) as Error & {
+		providerCode?: string;
+	};
+	error.providerCode = providerCode;
+	return error;
 }
 
 function isCodexWebSocketFatalError(error: Error): boolean {
@@ -403,6 +401,13 @@ function isCodexWebSocketFatalError(error: Error): boolean {
 function isCodexWebSocketTransportError(error: unknown): boolean {
 	if (!(error instanceof Error)) return false;
 	return error.message.startsWith(CODEX_WEBSOCKET_TRANSPORT_ERROR_PREFIX);
+}
+
+function isCodexFirstEventTimeout(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		(error as { providerCode?: unknown }).providerCode === STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE
+	);
 }
 
 function isCodexWebSocketRetryableStreamError(error: unknown): boolean {
@@ -607,17 +612,22 @@ function createRequestSetup(options: OpenAICodexResponsesOptions | undefined): C
 	const requestSignal = options?.signal
 		? AbortSignal.any([options.signal, requestAbortController.signal])
 		: requestAbortController.signal;
+	const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getOpenAIStreamIdleTimeoutMs();
+	const firstEventTimeoutMs = options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs);
 	const wrapCodexSseStream = (
 		source: AsyncGenerator<Record<string, unknown>>,
 	): AsyncGenerator<Record<string, unknown>> =>
 		iterateWithIdleTimeout(source, {
-			idleTimeoutMs: options?.streamIdleTimeoutMs ?? getOpenAIStreamIdleTimeoutMs(),
+			idleTimeoutMs,
+			firstItemTimeoutMs: firstEventTimeoutMs,
+			firstItemErrorMessage: "OpenAI Codex SSE stream timed out while waiting for the first event",
 			errorMessage: "OpenAI Codex SSE stream stalled while waiting for the next event",
 			onIdle: () => requestAbortController.abort(),
+			onFirstItemTimeout: () => requestAbortController.abort(),
 			abortSignal: options?.signal,
 			isProgressItem: isCodexStreamProgressEvent,
 		});
-	return { requestAbortController, requestSignal, wrapCodexSseStream };
+	return { requestAbortController, requestSignal, firstEventTimeoutMs, wrapCodexSseStream };
 }
 
 async function buildCodexRequestContext(
@@ -838,6 +848,7 @@ async function openCodexWebSocketTransport(
 		websocketState,
 		requestSetup.requestSignal,
 		options,
+		requestSetup.firstEventTimeoutMs,
 	);
 	return { eventStream, requestBodyForState, transport: "websocket" };
 }
@@ -1478,7 +1489,7 @@ async function recoverCodexStreamError(
 	runtime: CodexStreamRuntime,
 	error: unknown,
 ): Promise<boolean> {
-	if (context.options?.fallbackManaged) return false;
+	if (isCodexFirstEventTimeout(error)) return false;
 	if (await tryRetryWithoutForcedToolChoice(context, runtime, error)) {
 		return true;
 	}
@@ -2196,7 +2207,6 @@ function headersToRecord(headers: Headers): Record<string, string> {
 
 interface CodexWebSocketConnectionOptions {
 	idleTimeoutMs: number;
-	firstEventTimeoutMs: number;
 	onHandshakeHeaders?: (headers: Headers) => void;
 }
 
@@ -2204,7 +2214,6 @@ class CodexWebSocketConnection {
 	#url: string;
 	#headers: Record<string, string>;
 	#idleTimeoutMs: number;
-	#firstEventTimeoutMs: number;
 	#onHandshakeHeaders?: (headers: Headers) => void;
 	#socket: Bun.WebSocket | null = null;
 	#queue: Array<Record<string, unknown> | Error | null> = [];
@@ -2216,7 +2225,6 @@ class CodexWebSocketConnection {
 		this.#url = url;
 		this.#headers = headers;
 		this.#idleTimeoutMs = options.idleTimeoutMs;
-		this.#firstEventTimeoutMs = options.firstEventTimeoutMs;
 		this.#onHandshakeHeaders = options.onHandshakeHeaders;
 	}
 
@@ -2346,6 +2354,7 @@ class CodexWebSocketConnection {
 	async *streamRequest(
 		request: Record<string, unknown>,
 		signal?: AbortSignal,
+		firstEventTimeoutMs?: number,
 	): AsyncGenerator<Record<string, unknown>> {
 		if (!this.#socket || this.#socket.readyState !== WebSocket.OPEN) {
 			throw createCodexWebSocketTransportError("websocket connection is unavailable");
@@ -2368,11 +2377,11 @@ class CodexWebSocketConnection {
 
 		try {
 			this.#socket.send(JSON.stringify(request));
-			let sawFirstEvent = false;
+			let sawFirstProgress = false;
 			let lastProgressAt = Date.now();
 			while (true) {
-				let timeoutMs = this.#firstEventTimeoutMs;
-				if (sawFirstEvent) {
+				let timeoutMs = firstEventTimeoutMs;
+				if (sawFirstProgress) {
 					timeoutMs = this.#idleTimeoutMs - (Date.now() - lastProgressAt);
 					if (timeoutMs <= 0) {
 						throw createCodexWebSocketTransportError("idle timeout waiting for websocket");
@@ -2380,7 +2389,8 @@ class CodexWebSocketConnection {
 				}
 				const next = await this.#nextMessage(
 					timeoutMs,
-					sawFirstEvent ? "idle timeout waiting for websocket" : "timeout waiting for first websocket event",
+					sawFirstProgress ? "idle timeout waiting for websocket" : "timeout waiting for first websocket event",
+					sawFirstProgress ? undefined : STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE,
 				);
 				if (next instanceof Error) {
 					throw next;
@@ -2388,8 +2398,8 @@ class CodexWebSocketConnection {
 				if (next === null) {
 					throw createCodexWebSocketTransportError("websocket closed before response completion");
 				}
-				sawFirstEvent = true;
 				if (isCodexStreamProgressEvent(next)) {
+					sawFirstProgress = true;
 					lastProgressAt = Date.now();
 				}
 				yield next;
@@ -2425,13 +2435,17 @@ class CodexWebSocketConnection {
 		if (waiter) waiter();
 	}
 
-	async #nextMessage(timeoutMs: number, timeoutReason: string): Promise<Record<string, unknown> | Error | null> {
+	async #nextMessage(
+		timeoutMs: number | undefined,
+		timeoutReason: string,
+		providerCode?: string,
+	): Promise<Record<string, unknown> | Error | null> {
 		while (this.#queue.length === 0) {
 			const { promise, resolve } = Promise.withResolvers<void>();
 			this.#waiters.push(resolve);
 			let timedOut = false;
 			let timeout: NodeJS.Timeout | undefined;
-			if (timeoutMs > 0) {
+			if (timeoutMs !== undefined && timeoutMs > 0) {
 				timeout = setTimeout(() => {
 					timedOut = true;
 					const waiterIndex = this.#waiters.indexOf(resolve);
@@ -2444,7 +2458,7 @@ class CodexWebSocketConnection {
 			await promise;
 			if (timeout) clearTimeout(timeout);
 			if (timedOut && this.#queue.length === 0) {
-				return createCodexWebSocketTransportError(timeoutReason);
+				return createCodexWebSocketTransportError(timeoutReason, providerCode);
 			}
 		}
 		return this.#queue.shift() ?? null;
@@ -2473,7 +2487,6 @@ async function getOrCreateCodexWebSocketConnection(
 	const idleTimeoutMs = getCodexWebSocketIdleTimeoutMs(options?.streamIdleTimeoutMs);
 	state.connection = new CodexWebSocketConnection(url, headerRecord, {
 		idleTimeoutMs,
-		firstEventTimeoutMs: getCodexWebSocketFirstEventTimeoutMs(idleTimeoutMs, options?.streamFirstEventTimeoutMs),
 		onHandshakeHeaders: handshakeHeaders => {
 			updateCodexSessionMetadataFromHeaders(state, handshakeHeaders);
 		},
@@ -2544,9 +2557,10 @@ async function openCodexWebSocketEventStream(
 	state: CodexWebSocketSessionState,
 	signal?: AbortSignal,
 	options?: Pick<OpenAICodexResponsesOptions, "streamFirstEventTimeoutMs" | "streamIdleTimeoutMs">,
+	firstEventTimeoutMs?: number,
 ): Promise<AsyncGenerator<Record<string, unknown>>> {
 	const connection = await getOrCreateCodexWebSocketConnection(state, url, headers, signal, options);
-	return connection.streamRequest(request, signal);
+	return connection.streamRequest(request, signal, firstEventTimeoutMs);
 }
 
 function createCodexHeaders(

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -47,7 +47,6 @@ import {
 	rewriteCopilotError,
 } from "../utils/http-inspector";
 import {
-	createWatchdog,
 	getOpenAIStreamIdleTimeoutMs,
 	getProviderFirstEventTimeoutFallbackMs,
 	getStreamFirstEventTimeoutMs,
@@ -457,7 +456,6 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 		const output: AssistantMessage = createInitialResponsesAssistantMessage(model.api, model.provider, model.id);
 		let rawRequestDump: RawHttpRequestDump | undefined;
 		const abortTracker = createAbortSourceTracker(options?.signal);
-		const firstEventTimeoutAbortError = new Error(OPENAI_COMPLETIONS_FIRST_EVENT_TIMEOUT_MESSAGE);
 		const { requestAbortController, requestSignal } = abortTracker;
 
 		try {
@@ -579,10 +577,8 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				model.provider === "alibaba-token-plan"
 					? ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS
 					: getProviderFirstEventTimeoutFallbackMs(model.provider);
-			const firstEventWatchdog = createWatchdog(
-				options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs, firstEventFallbackMs),
-				() => abortTracker.abortLocally(firstEventTimeoutAbortError),
-			);
+			const firstEventTimeoutMs =
+				options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs, firstEventFallbackMs);
 			if (premiumRequestsTotal !== undefined) {
 				output.usage.premiumRequests = premiumRequestsTotal;
 			}
@@ -769,10 +765,12 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 			};
 
 			for await (const chunk of iterateWithIdleTimeout(openaiStream, {
-				watchdog: firstEventWatchdog,
+				firstItemTimeoutMs: firstEventTimeoutMs,
+				firstItemErrorMessage: OPENAI_COMPLETIONS_FIRST_EVENT_TIMEOUT_MESSAGE,
 				idleTimeoutMs,
 				errorMessage: "OpenAI completions stream stalled while waiting for the next event",
 				onIdle: () => requestAbortController.abort(),
+				onFirstItemTimeout: () => requestAbortController.abort(),
 				abortSignal: options?.signal,
 				isProgressItem: isOpenAICompletionsProgressChunk,
 			})) {
@@ -983,14 +981,17 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 			stream.end();
 		} catch (error) {
 			for (const block of output.content) delete (block as any).index;
-			const firstEventTimeoutError = abortTracker.getLocalAbortReason();
+			const localAbortReason = abortTracker.getLocalAbortReason();
 			const capturedErrorResponse = getCapturedErrorResponse?.();
 			output.stopReason = abortTracker.wasCallerAbort() ? "aborted" : "error";
-			output.errorStatus = extractHttpStatusFromError(error) ?? capturedErrorResponse?.status;
-			output.transportFailure = transportFailureFacts(error, capturedErrorResponse);
+			output.errorStatus =
+				extractHttpStatusFromError(localAbortReason ?? error) ??
+				(localAbortReason ? undefined : capturedErrorResponse?.status);
+			output.transportFailure = localAbortReason
+				? transportFailureFacts(localAbortReason)
+				: transportFailureFacts(error, capturedErrorResponse);
 			output.errorMessage =
-				firstEventTimeoutError?.message ??
-				(await finalizeErrorMessage(error, rawRequestDump, capturedErrorResponse));
+				localAbortReason?.message ?? (await finalizeErrorMessage(error, rawRequestDump, capturedErrorResponse));
 			// Some providers via OpenRouter include extra details here.
 			const rawMetadata = (error as { error?: { metadata?: { raw?: string } } })?.error?.metadata?.raw;
 			if (rawMetadata) output.errorMessage += `\n${rawMetadata}`;

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -37,7 +37,6 @@ import { AssistantMessageEventStream } from "../utils/event-stream";
 import { transportFailureFacts } from "../utils/fallback-transport";
 import { finalizeErrorMessage, type RawHttpRequestDump, rewriteCopilotError } from "../utils/http-inspector";
 import {
-	createWatchdog,
 	getOpenAIStreamIdleTimeoutMs,
 	getStreamFirstEventTimeoutMs,
 	iterateWithIdleTimeout,
@@ -265,7 +264,6 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 		);
 		let rawRequestDump: RawHttpRequestDump | undefined;
 		const abortTracker = createAbortSourceTracker(options?.signal);
-		const firstEventTimeoutAbortError = new Error(OPENAI_RESPONSES_FIRST_EVENT_TIMEOUT_MESSAGE);
 		const { requestAbortController, requestSignal } = abortTracker;
 
 		try {
@@ -337,10 +335,8 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 			});
 			const firstEventFallbackMs =
 				model.provider === "alibaba-token-plan" ? ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS : undefined;
-			const firstEventWatchdog = createWatchdog(
-				options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs, firstEventFallbackMs),
-				() => abortTracker.abortLocally(firstEventTimeoutAbortError),
-			);
+			const firstEventTimeoutMs =
+				options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs, firstEventFallbackMs);
 			if (premiumRequestsTotal !== undefined) output.usage.premiumRequests = premiumRequestsTotal;
 			stream.push({ type: "start", partial: output });
 
@@ -348,9 +344,11 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 			await processResponsesStream(
 				iterateWithIdleTimeout(openaiStream, {
 					idleTimeoutMs,
-					watchdog: firstEventWatchdog,
+					firstItemTimeoutMs: firstEventTimeoutMs,
+					firstItemErrorMessage: OPENAI_RESPONSES_FIRST_EVENT_TIMEOUT_MESSAGE,
 					errorMessage: "OpenAI responses stream stalled while waiting for the next event",
 					onIdle: () => requestAbortController.abort(),
+					onFirstItemTimeout: () => requestAbortController.abort(),
 					abortSignal: options?.signal,
 					isProgressItem: isOpenAIResponsesProgressEvent,
 				}),
@@ -389,11 +387,11 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 			stream.end();
 		} catch (error) {
 			for (const block of output.content) delete (block as { index?: number }).index;
-			const firstEventTimeoutError = abortTracker.getLocalAbortReason();
+			const localAbortReason = abortTracker.getLocalAbortReason();
 			output.stopReason = abortTracker.wasCallerAbort() ? "aborted" : "error";
-			output.errorStatus = extractHttpStatusFromError(error);
-			output.transportFailure = transportFailureFacts(error);
-			output.errorMessage = firstEventTimeoutError?.message ?? (await finalizeErrorMessage(error, rawRequestDump));
+			output.errorStatus = extractHttpStatusFromError(localAbortReason ?? error);
+			output.transportFailure = transportFailureFacts(localAbortReason ?? error);
+			output.errorMessage = localAbortReason?.message ?? (await finalizeErrorMessage(error, rawRequestDump));
 			output.errorMessage = rewriteCopilotError(output.errorMessage, error, model.provider);
 			// Explicitly mark the poisoned-history rejection so the shared
 			// `invalid_prompt` contract is present even when the SDK error surfaces

--- a/packages/ai/src/providers/register-builtins.ts
+++ b/packages/ai/src/providers/register-builtins.ts
@@ -10,6 +10,7 @@
  * lazy wrappers below), so this file IS the main streaming path's provider
  * loader: heavy SDKs stay out of the CLI startup parse graph.
  */
+
 import type {
 	Api,
 	AssistantMessage,
@@ -21,6 +22,7 @@ import type {
 } from "../types";
 import { type AbortSourceTracker, createAbortSourceTracker } from "../utils/abort";
 import { AssistantMessageEventStream as EventStreamImpl } from "../utils/event-stream";
+import { transportFailureFacts } from "../utils/fallback-transport";
 import { getStreamFirstEventTimeoutMs, getStreamIdleTimeoutMs, iterateWithIdleTimeout } from "../utils/idle-iterator";
 import type { BedrockOptions } from "./amazon-bedrock";
 import type { AnthropicOptions } from "./anthropic";
@@ -261,6 +263,7 @@ function createLazyLoadErrorMessage<TApi extends Api>(
 	error: unknown,
 	stopReason: Extract<AssistantMessage["stopReason"], "aborted" | "error"> = "error",
 ): AssistantMessage {
+	const transportFailure = transportFailureFacts(error);
 	return {
 		role: "assistant",
 		content: [],
@@ -278,6 +281,7 @@ function createLazyLoadErrorMessage<TApi extends Api>(
 		stopReason,
 		errorMessage:
 			stopReason === "aborted" ? "Request was aborted" : error instanceof Error ? error.message : String(error),
+		...(transportFailure ? { transportFailure } : {}),
 		timestamp: Date.now(),
 	};
 }

--- a/packages/ai/src/utils/fallback-transport.ts
+++ b/packages/ai/src/utils/fallback-transport.ts
@@ -5,6 +5,9 @@ export interface FallbackTrigger {
 	retryAfterMs?: number;
 }
 
+/** Stable code for streams that time out before producing semantic progress. */
+export const STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE = "stream_first_event_timeout";
+
 export type TransportHeaders = Headers | Record<string, string | undefined>;
 
 /**
@@ -185,7 +188,8 @@ export function transportFailureFacts(
 		!isQuotaCode(normalizedCode) &&
 		!isAuthCode(normalizedCode) &&
 		!isRateLimitCode(normalizedCode) &&
-		!isContextOverflowCode(normalizedCode)
+		!isContextOverflowCode(normalizedCode) &&
+		normalizedCode !== STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE
 	) {
 		return undefined;
 	}
@@ -256,14 +260,17 @@ export function classifyFallbackTrigger(
 		parseRetryAfterMilliseconds(headers?.get("retry-after-ms") ?? null) ??
 		parseRetryAfterSeconds(headers?.get("retry-after") ?? null);
 	const code = (facts.openaiErrorCode ?? facts.anthropicErrorType ?? facts.providerCode)?.toLowerCase();
-	const triggerClass: FallbackTriggerClass = isQuotaCode(code)
-		? "quota"
-		: facts.status === 401 || facts.status === 403 || isAuthCode(code)
-			? "auth"
-			: facts.status === 429 || isRateLimitCode(code)
-				? "rate_limit"
-				: facts.status !== undefined && facts.status >= 500 && facts.status <= 599
-					? "server"
-					: "other";
+	const triggerClass: FallbackTriggerClass =
+		code === STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE
+			? "server"
+			: isQuotaCode(code)
+				? "quota"
+				: facts.status === 401 || facts.status === 403 || isAuthCode(code)
+					? "auth"
+					: facts.status === 429 || isRateLimitCode(code)
+						? "rate_limit"
+						: facts.status !== undefined && facts.status >= 500 && facts.status <= 599
+							? "server"
+							: "other";
 	return retryAfterMs === undefined ? { class: triggerClass } : { class: triggerClass, retryAfterMs };
 }

--- a/packages/ai/src/utils/idle-iterator.ts
+++ b/packages/ai/src/utils/idle-iterator.ts
@@ -1,4 +1,5 @@
 import { $env } from "@gajae-code/utils";
+import { STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE } from "./fallback-transport";
 
 const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 120_000;
 const DEFAULT_STREAM_FIRST_EVENT_TIMEOUT_MS = 100_000;
@@ -66,6 +67,14 @@ export function getStreamFirstEventTimeoutMs(
 }
 
 export type Watchdog = NodeJS.Timeout | undefined;
+export class FirstEventTimeoutError extends Error {
+	readonly providerCode = STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE;
+
+	constructor(message: string) {
+		super(message);
+		this.name = "FirstEventTimeoutError";
+	}
+}
 
 const dummyWatchdog = setTimeout(() => {}, 1);
 clearTimeout(dummyWatchdog);
@@ -228,9 +237,9 @@ export async function* iterateWithIdleTimeout<T>(
 					options.onFirstItemTimeout?.();
 				}
 				closeIterator();
-				throw new Error(
-					!awaitingFirstItem ? options.errorMessage : (options.firstItemErrorMessage ?? options.errorMessage),
-				);
+				throw awaitingFirstItem
+					? new FirstEventTimeoutError(options.firstItemErrorMessage ?? options.errorMessage)
+					: new Error(options.errorMessage);
 			}
 			if (outcome.kind === "error") {
 				throw outcome.error;

--- a/packages/ai/test/anthropic-stream-timeout.test.ts
+++ b/packages/ai/test/anthropic-stream-timeout.test.ts
@@ -136,14 +136,14 @@ afterEach(() => {
 	// No shared globals to restore; keep hook so the suite stays explicit.
 });
 
-describe("anthropic first-event timeout retries", () => {
-	it("retries when the provider never sends the first stream event", async () => {
+describe("anthropic first-event timeouts", () => {
+	it("surfaces the canonical first-event timeout without an internal provider replay", async () => {
 		let attempt = 0;
 		const create = ((_body: unknown, requestOptions?: { signal?: AbortSignal }) => {
 			attempt += 1;
 			return createAnthropicMockStream({
 				signal: requestOptions?.signal,
-				events: attempt === 1 ? undefined : createSuccessfulAnthropicEvents("retry recovered"),
+				events: attempt === 1 ? undefined : createSuccessfulAnthropicEvents("must not replay"),
 			}) as never;
 		}) as unknown as Anthropic["messages"]["create"];
 		const client = { messages: { create } } as Anthropic;
@@ -155,11 +155,11 @@ describe("anthropic first-event timeout retries", () => {
 			providerRetryWait,
 		}).result();
 
-		expect(attempt).toBe(2);
-		expect(providerRetryWait).toHaveBeenCalledWith(2000, undefined);
-		expect(result.stopReason).toBe("stop");
-		expect(result.content).toEqual([{ type: "text", text: "retry recovered" }]);
-		expect(result.responseId).toBe("msg_retry_success");
+		expect(attempt).toBe(1);
+		expect(providerRetryWait).not.toHaveBeenCalled();
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("Anthropic stream timed out while waiting for the first event");
+		expect(result.transportFailure?.providerCode).toBe("stream_first_event_timeout");
 	});
 
 	it("surfaces large retry-after Anthropic 429s instead of first-event timeouts", async () => {

--- a/packages/ai/test/idle-iterator.test.ts
+++ b/packages/ai/test/idle-iterator.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE, transportFailureFacts } from "../src/utils/fallback-transport";
+import { FirstEventTimeoutError, iterateWithIdleTimeout } from "../src/utils/idle-iterator";
+
+async function waitForTimerRegistration(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe("iterateWithIdleTimeout transport facts", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("normalizes the typed first-event timeout fact idempotently", () => {
+		const error = new FirstEventTimeoutError("first event timed out");
+		const facts = transportFailureFacts(error);
+
+		expect(error.providerCode).toBe(STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE);
+		expect(facts).toEqual({
+			kind: "transport",
+			status: undefined,
+			providerCode: STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE,
+			anthropicErrorType: undefined,
+			openaiErrorCode: undefined,
+			headers: undefined,
+		});
+		expect(transportFailureFacts(facts)).toEqual(facts);
+	});
+
+	it("keeps post-progress idle expiry distinct from first-event expiry", async () => {
+		vi.useFakeTimers();
+		const source = (async function* () {
+			yield "progress";
+			await new Promise<never>(() => {});
+		})();
+		const iterator = iterateWithIdleTimeout(source, {
+			firstItemTimeoutMs: 10,
+			idleTimeoutMs: 10,
+			errorMessage: "stream idle",
+		});
+
+		expect((await iterator.next()).value).toBe("progress");
+		const pending = iterator.next();
+		await waitForTimerRegistration();
+		vi.advanceTimersByTime(10);
+		const error = await pending.catch(error => error);
+
+		expect(error).toBeInstanceOf(Error);
+		expect(error).not.toBeInstanceOf(FirstEventTimeoutError);
+		expect(transportFailureFacts(error)).toBeUndefined();
+	});
+});

--- a/packages/ai/test/model-fallback-transport-facts.test.ts
+++ b/packages/ai/test/model-fallback-transport-facts.test.ts
@@ -76,6 +76,9 @@ describe("fallback transport facts", () => {
 		).toEqual({ class: "quota", retryAfterMs: 125 });
 		expect(classifyFallbackTrigger({ kind: "transport", status: 401 })).toEqual({ class: "auth" });
 		expect(classifyFallbackTrigger({ kind: "transport", status: 503 })).toEqual({ class: "server" });
+		expect(classifyFallbackTrigger({ kind: "transport", providerCode: "stream_first_event_timeout" })).toEqual({
+			class: "server",
+		});
 	});
 
 	it("normalizes provider transport metadata without parsing error text", () => {

--- a/packages/ai/test/openai-first-event-timeout.test.ts
+++ b/packages/ai/test/openai-first-event-timeout.test.ts
@@ -214,8 +214,11 @@ function createOpenAICompletionsSuccessResponse(modelId: string): Response {
 }
 
 async function expectFirstEventTimeout(
-	run: (streamFirstEventTimeoutMs: number) => Promise<{ stopReason: string; errorMessage?: string }>,
+	run: (
+		streamFirstEventTimeoutMs: number,
+	) => Promise<{ stopReason: string; errorMessage?: string; transportFailure?: { providerCode?: string } }>,
 	expectedMessage: string,
+	expectedProviderCode?: string,
 ): Promise<void> {
 	global.fetch = createHangingFetch();
 
@@ -223,6 +226,7 @@ async function expectFirstEventTimeout(
 
 	expect(result.stopReason).toBe("error");
 	expect(result.errorMessage).toBe(expectedMessage);
+	if (expectedProviderCode) expect(result.transportFailure?.providerCode).toBe(expectedProviderCode);
 }
 
 async function expectCallerAbort(
@@ -274,6 +278,7 @@ describe("OpenAI-family first-event timeouts", () => {
 					streamFirstEventTimeoutMs,
 				}).result(),
 			"OpenAI responses stream timed out while waiting for the first event",
+			"stream_first_event_timeout",
 		);
 	});
 
@@ -308,6 +313,7 @@ describe("OpenAI-family first-event timeouts", () => {
 					streamFirstEventTimeoutMs,
 				}).result(),
 			"OpenAI completions stream timed out while waiting for the first event",
+			"stream_first_event_timeout",
 		);
 	});
 
@@ -321,6 +327,7 @@ describe("OpenAI-family first-event timeouts", () => {
 					streamFirstEventTimeoutMs,
 				}).result(),
 			"Azure OpenAI responses stream timed out while waiting for the first event",
+			"stream_first_event_timeout",
 		);
 	});
 

--- a/packages/ai/test/register-builtins.test.ts
+++ b/packages/ai/test/register-builtins.test.ts
@@ -136,6 +136,7 @@ describe("register-builtins lazy streams", () => {
 		expect(providerSignal?.aborted).toBe(true);
 		expect(result.stopReason).toBe("error");
 		expect(result.errorMessage).toBe("Provider stream stalled while waiting for the next event");
+		expect(result.transportFailure).toBeUndefined();
 	});
 
 	it("preserves caller aborts while forwarding lazy provider streams", async () => {
@@ -312,6 +313,10 @@ describe("outer lazy-stream first-event watchdog (fake timers)", () => {
 		const result = await stream.result();
 		expect(result.stopReason).toBe("error");
 		expect(result.errorMessage).toBe("Provider stream timed out while waiting for the first event");
+		expect(result.transportFailure).toMatchObject({
+			kind: "transport",
+			providerCode: "stream_first_event_timeout",
+		});
 	});
 
 	it("unrelated providers still time out at the 120s shared default", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Ralplan supports opt-in automatic handoff to ultragoal or team through a durable runtime-owned final receipt, with read-only team preflight and PLANNING-STUCK dominance.
 - Subagent setup failures now retain a bounded, redacted cause through live progress, async snapshots, inspect/await, and terminal receipts instead of reporting an empty generic failure.
 - Telegram notification sound can be set to all, important, or none; the reference CLI exposes this with `--sound <all|important|none>`, defaulting to all. Important (ask/idle only) and none are explicit opt-ins for quieter notifications.
+- First-event provider timeouts are configurable and replayed only by AgentSession with a bounded attempt budget, progress-aware safety checks, and measured exhaustion details.
 
 ### Resume fixes
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1263,6 +1263,16 @@ export const SETTINGS_SCHEMA = {
 				"Maximum provider stream replay retries for replay-safe transient stream failures. Counts retries, not the first attempt. Set to 0 to disable provider stream retries.",
 		},
 	},
+	"retry.streamFirstEventTimeoutMs": {
+		type: "number",
+		default: 100_000,
+		validate: (value: number) => Number.isFinite(value) && value >= 0,
+		ui: {
+			tab: "model",
+			label: "First Event Timeout",
+			description: "Maximum wait for the first provider stream event, in ms. Set to 0 to disable the watchdog.",
+		},
+	},
 	"retry.fallbackChains": { type: "record", default: {} as Record<string, string[]> },
 	"retry.fallbackRevertPolicy": {
 		type: "enum",
@@ -3849,6 +3859,7 @@ export interface RetrySettings {
 	maxDelayMs: number;
 	requestMaxRetries: number;
 	streamMaxRetries: number;
+	streamFirstEventTimeoutMs: number;
 }
 
 export interface MemoriesSettings {

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -2633,6 +2633,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			maxRetryDelayMs: retrySettings.maxDelayMs,
 			requestMaxRetries: retrySettings.requestMaxRetries,
 			streamMaxRetries: retrySettings.streamMaxRetries,
+			streamFirstEventTimeoutMs: settings.has("retry.streamFirstEventTimeoutMs")
+				? retrySettings.streamFirstEventTimeoutMs
+				: undefined,
 			kimiApiFormat: settings.get("providers.kimiApiFormat") ?? "anthropic",
 			shouldPause: options.shouldPause,
 			preferWebsockets: preferOpenAICodexWebsockets,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -106,6 +106,7 @@ import {
 	classifyFallbackTrigger,
 	type FallbackAttemptToken,
 	type FallbackTriggerClass,
+	STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE,
 } from "@gajae-code/ai/utils/fallback-transport";
 import {
 	BTW_MAX_ANSWER_UTF8_BYTES,
@@ -1703,6 +1704,7 @@ export class AgentSession {
 	#resetRetryReplaySafety(): void {
 		this.#retryReplayEpoch++;
 		this.#retryReplayUnsafeEpoch = undefined;
+		this.#firstEventTimeoutRetryStartedAt = Date.now();
 		if (
 			this.#extensionRunner?.hasHandlers("context") ||
 			this.#extensionRunner?.hasHandlers("before_provider_request") ||
@@ -1736,6 +1738,7 @@ export class AgentSession {
 	// Retry state
 	#retryAbortController: AbortController | undefined = undefined;
 	#retryNowRequested = false;
+	#firstEventTimeoutRetryStartedAt: number | undefined;
 	#retryAttempt = 0;
 	#retryPromise: Promise<void> | undefined = undefined;
 	#retryResolve: (() => void) | undefined = undefined;
@@ -13315,6 +13318,10 @@ export class AgentSession {
 		return false;
 	}
 
+	#isTypedFirstEventTimeout(message: AssistantMessage): boolean {
+		return message.transportFailure?.providerCode?.toLowerCase() === STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE;
+	}
+
 	#isTerminalProviderFirstEventTimeout(message: AssistantMessage): boolean {
 		return this.#isKimiCodeFirstEventTimeout(message) || this.#isAlibabaTokenPlanFirstEventTimeout(message);
 	}
@@ -13440,6 +13447,7 @@ export class AgentSession {
 	#classifyErrorForRetry(message: AssistantMessage): RetryErrorClassification {
 		if (message.stopReason !== "error") return "none";
 		if (message.errorKind === "provider_safety_stop") return "terminal";
+		if (this.#isTypedFirstEventTimeout(message)) return "first_event_timeout";
 		if (!message.errorMessage) return "none";
 		const err = message.errorMessage;
 		// Provider safety refusals (e.g. Anthropic stop_reason "refusal" /
@@ -13480,10 +13488,8 @@ export class AgentSession {
 		if (this.#isTerminalProviderFirstEventTimeout(message)) {
 			return "terminal";
 		}
-		// A first-event timeout on ollama-cloud (the ollama-chat API) must not
-		// join the unbounded transient class: each continuation retry re-issues
-		// the full request to a remote, billable backend, so an unbounded loop
-		// can silently spike usage (#713). Bound it to retry.maxRetries instead.
+		// Legacy providers that have not yet stamped the typed timeout fact retain
+		// their existing bounded ollama-cloud behavior.
 		if (this.#isFirstEventTimeoutErrorMessage(err) && this.#shouldFailClosedOnFirstEventTimeout(message)) {
 			return "first_event_timeout";
 		}
@@ -13858,12 +13864,24 @@ export class AgentSession {
 		// user opt-out.
 		if (!managedFallback && !retrySettings.enabled) return false;
 		const classification = managedFallback ? undefined : this.#classifyErrorForRetry(message);
+		if (classification === "first_event_timeout") {
+			this.#firstEventTimeoutRetryStartedAt ??= Date.now();
+		}
+		// First-event timeouts are replay-safe only before any model progress,
+		// abort, or extension/provider lifecycle participation.
+		if (
+			classification === "first_event_timeout" &&
+			(!this.#hasCleanRetryReplaySafety || assistantMessageHasVisibleOrToolContent(message))
+		) {
+			return false;
+		}
 		// Bare defaults admit only clean, side-effect-free canonical stream watchdog failures.
 		if (!managedFallback && !legacyRetryConfigured) {
 			if (
-				hasBareDefaultRetryDisqualifyingFacts(message) ||
-				(classification !== "transient" && classification !== "first_event_timeout") ||
-				!BARE_DEFAULT_WATCHDOG_ERROR.test(message.errorMessage ?? "") ||
+				(!this.#isTypedFirstEventTimeout(message) &&
+					(hasBareDefaultRetryDisqualifyingFacts(message) ||
+						(classification !== "transient" && classification !== "first_event_timeout") ||
+						!BARE_DEFAULT_WATCHDOG_ERROR.test(message.errorMessage ?? ""))) ||
 				!this.#hasCleanRetryReplaySafety
 			) {
 				return false;
@@ -13898,6 +13916,10 @@ export class AgentSession {
 				this.#defaultFallbackExhaustedLastTurn = true;
 				controller.resetSticky();
 				return managedOutcome ? this.#managedFallbackExhaustionDecision(message, errorMessage) : false;
+			}
+			if (classification === "first_event_timeout") {
+				const elapsedMs = Date.now() - (this.#firstEventTimeoutRetryStartedAt ?? Date.now());
+				message.errorMessage = `First-event stream timeout exhausted after ${attemptsUsed} attempts; waited ${elapsedMs}ms total: ${message.errorMessage ?? "Unknown error"}`;
 			}
 			return false;
 		}
@@ -13962,7 +13984,12 @@ export class AgentSession {
 			await this.#emitSessionEvent({
 				type: "auto_retry_start",
 				attempt: this.#retryAttempt,
-				maxAttempts: managedFallback ? controller.maxAttempts : retrySettings.maxRetries,
+				maxAttempts:
+					classification === "first_event_timeout"
+						? retrySettings.maxRetries + 1
+						: managedFallback
+							? controller.maxAttempts
+							: retrySettings.maxRetries,
 				delayMs,
 				errorMessage,
 				unbounded: managedFallback ? false : legacyUnbounded,
@@ -13972,7 +13999,6 @@ export class AgentSession {
 			if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
 				this.agent.replaceMessages(messages.slice(0, -1));
 			}
-
 			try {
 				await scheduler.wait(delayMs, { signal: retryAbortController.signal });
 			} catch {

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -9,6 +9,7 @@ import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { ExtensionRunner } from "@gajae-code/coding-agent/extensibility/extensions/runner";
 import type { Extension } from "@gajae-code/coding-agent/extensibility/extensions/types";
+import { createAgentSession } from "@gajae-code/coding-agent/sdk";
 import { AgentSession, type AgentSessionEvent } from "@gajae-code/coding-agent/session/agent-session";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
@@ -1037,6 +1038,111 @@ describe("AgentSession resilient retry", () => {
 		expect(retryEndEvents).toHaveLength(1);
 		expect(retryEndEvents[0]).toMatchObject({ success: true });
 		expect(lastAssistant(session).stopReason).toBe("stop");
+	});
+	it("forwards only explicit first-event timeout settings to provider stream options", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled Anthropic test model to exist");
+
+		for (const testCase of [
+			{ name: "absent", setting: undefined, expected: undefined },
+			{ name: "zero", setting: 0, expected: 0 },
+			{ name: "positive", setting: 12_345, expected: 12_345 },
+		]) {
+			const capturedTimeouts: Array<number | undefined> = [];
+			const settings = Settings.isolated({
+				"compaction.enabled": false,
+				...(testCase.setting === undefined ? {} : { "retry.streamFirstEventTimeoutMs": testCase.setting }),
+			});
+			const { session: configuredSession } = await createAgentSession({
+				cwd: tempDir.path(),
+				agentDir: tempDir.path(),
+				model,
+				modelRegistry,
+				settings,
+				sessionManager: SessionManager.inMemory(),
+				disableExtensionDiscovery: true,
+				skills: [],
+				rules: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				toolNames: [],
+				workspaceTree: {
+					rootPath: tempDir.path(),
+					rendered: "",
+					truncated: false,
+					totalLines: 0,
+					agentsMdFiles: [],
+				},
+			});
+			session = configuredSession;
+			const mock = createMockModel({ responses: [{ content: ["ok"] }] });
+			configuredSession.agent.streamFn = (streamModel, context, options) => {
+				capturedTimeouts.push(options?.streamFirstEventTimeoutMs);
+				return mock.stream(streamModel, context, options);
+			};
+
+			expect(configuredSession.agent.streamFirstEventTimeoutMs, testCase.name).toBe(testCase.expected);
+			await configuredSession.prompt(`first-event timeout ${testCase.name}`);
+			await configuredSession.waitForIdle();
+			expect(capturedTimeouts, testCase.name).toEqual([testCase.expected]);
+
+			await configuredSession.dispose();
+			session = undefined;
+		}
+	}, 30_000);
+	it("replays typed first-event timeouts only up to retry.maxRetries + 1 total attempts", async () => {
+		const requestedModels: string[] = [];
+		session = buildStatusErrorSession({
+			errorMessage: "provider message is not used for timeout classification",
+			transportFailure: { kind: "transport", providerCode: "stream_first_event_timeout" },
+			requestedModels,
+			settingsOverrides: { "retry.maxRetries": 2 },
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents } = track(session);
+
+		await session.prompt("typed first-event timeout");
+		await session.waitForIdle();
+
+		expect(requestedModels).toHaveLength(3);
+		expect(retryStartEvents).toHaveLength(2);
+		expect(retryStartEvents.every(event => event.maxAttempts === 3 && event.unbounded === false)).toBe(true);
+		expect(lastAssistant(session).errorMessage).toMatch(/exhausted after 3 attempts; waited \d+ms total/);
+	});
+	it("replays a typed first-event timeout before progress and never after progress", async () => {
+		const noProgressModels: string[] = [];
+		session = buildStatusErrorSession({
+			errorMessage: "provider message is not used for timeout classification",
+			transportFailure: { kind: "transport", providerCode: "stream_first_event_timeout" },
+			recoveredContent: "recovered",
+			requestedModels: noProgressModels,
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+
+		await session.prompt("typed timeout before progress");
+		await session.waitForIdle();
+
+		expect(noProgressModels).toHaveLength(2);
+		expect(lastAssistant(session).stopReason).toBe("stop");
+		await session.dispose();
+		session = undefined;
+
+		const progressModels: string[] = [];
+		session = buildStatusErrorSession({
+			errorMessage: "provider message is not used for timeout classification",
+			transportFailure: { kind: "transport", providerCode: "stream_first_event_timeout" },
+			partialContent: "already streamed",
+			requestedModels: progressModels,
+		});
+
+		await session.prompt("typed timeout after progress");
+		await session.waitForIdle();
+
+		expect(progressModels).toHaveLength(1);
+		expect(lastAssistant(session).stopReason).toBe("error");
 	});
 	it("retries a bare-default watchdog with an empty extension runner", async () => {
 		const requestedModels: string[] = [];

--- a/packages/coding-agent/test/retry-budget-settings.test.ts
+++ b/packages/coding-agent/test/retry-budget-settings.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { reconcileSettingsSchema, SETTINGS_SCHEMA } from "../src/config/settings-schema";
 
 describe("retry budget settings schema", () => {
 	it("registers provider request and stream retry knobs with bounded defaults", async () => {
@@ -9,5 +10,31 @@ describe("retry budget settings schema", () => {
 		expect(schema).toContain("requestMaxRetries: number;");
 		expect(schema).toContain("streamMaxRetries: number;");
 		expect(schema).toContain("default: 5");
+	});
+
+	it("defines a finite nonnegative first-event timeout with a bounded default", () => {
+		const setting = SETTINGS_SCHEMA["retry.streamFirstEventTimeoutMs"];
+
+		expect(setting.type).toBe("number");
+		expect(setting.default).toBe(100_000);
+		expect(setting.validate?.(0)).toBe(true);
+		expect(setting.validate?.(12_345)).toBe(true);
+		for (const value of [-1, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, "invalid", null, {}]) {
+			const reconciled = reconcileSettingsSchema({ retry: { streamFirstEventTimeoutMs: value } });
+
+			expect(setting.validate?.(value as number), String(value)).toBe(false);
+			expect(reconciled.report.valid, String(value)).toBe(false);
+			expect(reconciled.report.issues).toContainEqual({
+				path: "retry.streamFirstEventTimeoutMs",
+				kind: "invalid",
+				detail: "Expected number.",
+			});
+		}
+		for (const value of [0, 1, 12_345]) {
+			const reconciled = reconcileSettingsSchema({ retry: { streamFirstEventTimeoutMs: value } });
+
+			expect(reconciled.report.valid).toBe(true);
+			expect(reconciled.settings.retry).toEqual({ streamFirstEventTimeoutMs: value });
+		}
 	});
 });

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -91,7 +91,15 @@ describe("Settings", () => {
 			warning.mockRestore();
 		}
 	});
+	it("distinguishes an absent first-event retry timeout from an explicit zero", () => {
+		const absent = Settings.isolated();
+		expect(absent.get("retry.streamFirstEventTimeoutMs")).toBe(100_000);
+		expect(absent.has("retry.streamFirstEventTimeoutMs")).toBe(false);
 
+		const explicitZero = Settings.isolated({ "retry.streamFirstEventTimeoutMs": 0 });
+		expect(explicitZero.get("retry.streamFirstEventTimeoutMs")).toBe(0);
+		expect(explicitZero.has("retry.streamFirstEventTimeoutMs")).toBe(true);
+	});
 	const writeCustomTheme = async (name: string, userMessageBg: string) => {
 		const themesDir = getCustomThemesDir(agentDir);
 		fs.mkdirSync(themesDir, { recursive: true });

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -947,6 +947,11 @@
 					"description": "Maximum provider stream replay retries for replay-safe transient stream failures. Counts retries, not the first attempt. Set to 0 to disable provider stream retries.",
 					"default": 5
 				},
+				"streamFirstEventTimeoutMs": {
+					"type": "number",
+					"description": "Maximum wait for the first provider stream event, in ms. Set to 0 to disable the watchdog.",
+					"default": 100000
+				},
 				"fallbackChains": {
 					"type": "object",
 					"additionalProperties": true,


### PR DESCRIPTION
## Summary
- add canonical first-event-timeout transport facts across provider paths
- make the first-event deadline configurable with explicit zero-disable behavior
- keep bounded replay in AgentSession with truthful attempt/elapsed diagnostics

## Verification
- AI, Agent, and Coding Agent type checks passed
- 130 focused tests passed
- schema check passed
- dev-base six-PR integration rehearsal: 1,074 tests passed

Fixes #3390