### PR TITLE
fix(todo): document eager payload shape

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Eager Todo initialization now instructs the real `ops`/`init.list` payload shape and verifies the canonical example through the production validator and tool.
 
 ### Fixed
 

--- a/packages/coding-agent/src/prompts/system/eager-todo.md
+++ b/packages/coding-agent/src/prompts/system/eager-todo.md
@@ -1,12 +1,15 @@
 <system-reminder>
 Before substantive work, create a phased todo.
 
-You MUST call `todo_write` first in this turn.
-You MUST initialize the todo list with a single `init` op.
-You MUST cover the entire request from investigation through implementation and verification — not just the next immediate step.
+You MUST call `todo_write` first in this turn. Initialize the full request with this canonical payload shape:
+
+```json
+{"ops":[{"op":"init","list":[{"phase":"Investigation","items":["Inspect relevant implementation and tests"]},{"phase":"Implementation","items":["Implement the requested code change"]},{"phase":"Verification","items":["Verify requested behavior with tests"]}]}]}
+```
+
+Cover the entire request from investigation through implementation and verification — not just the next immediate step.
 Task descriptions MUST be specific. A future turn MUST execute them without re-planning.
-You MUST keep task `content` to a short label (5-10 words). Put file paths, implementation steps, and specifics in `details`.
-You MUST keep exactly one task `in_progress` and all later tasks `pending`.
+Task content MUST be a short label (5-10 words). The first task is automatically promoted to in progress; remaining tasks begin pending.
 
 After `todo_write` succeeds, continue the request in the same turn.
 Do not call `todo_write` again unless task state materially changed.

--- a/packages/coding-agent/test/agent-session-eager-todo.test.ts
+++ b/packages/coding-agent/test/agent-session-eager-todo.test.ts
@@ -24,6 +24,11 @@ type ObservedPromptCall = {
 	lastMessageRole: AgentMessage["role"];
 	lastMessageText: string;
 };
+function extractFencedJson(text: string): unknown {
+	const match = text.match(/```json\n([\s\S]+?)\n```/u);
+	if (!match?.[1]) throw new Error("Expected a fenced JSON payload");
+	return JSON.parse(match[1]) as unknown;
+}
 
 function isTextContentBlock(value: unknown): value is TextContent {
 	if (!value || typeof value !== "object") return false;
@@ -97,6 +102,7 @@ describe("AgentSession eager todo enforcement", () => {
 	let authStorage: AuthStorage | undefined;
 	const observedCalls: ObservedPromptCall[] = [];
 	const volatilePromptContexts: AgentMessage[][] = [];
+	let todoWriteTool: TodoWriteTool;
 
 	beforeEach(async () => {
 		tempDir = TempDir.createSync("@pi-agent-session-eager-todo-");
@@ -127,7 +133,7 @@ describe("AgentSession eager todo enforcement", () => {
 			getSessionSpawns: () => "*",
 			settings,
 		};
-		const todoWriteTool = new TodoWriteTool(toolSession);
+		todoWriteTool = new TodoWriteTool(toolSession);
 		const mockBashTool: AgentTool = {
 			name: "bash",
 			label: "Bash",
@@ -213,6 +219,30 @@ describe("AgentSession eager todo enforcement", () => {
 		expect(observedCalls[0]?.messageTexts.filter(text => text.includes("list all work trees"))).toHaveLength(1);
 		expect(observedCalls[0]?.messageTexts[0]).not.toContain("list all work trees");
 		expect(session.formatSessionAsText()).not.toContain("<user-request>");
+	});
+	it("documents an executable canonical eager todo payload", async () => {
+		await session.prompt("refactor the parser module");
+
+		const reminder = observedCalls[0]?.messageTexts[0];
+		if (!reminder) throw new Error("Expected eager todo reminder");
+
+		const args = extractFencedJson(reminder);
+		const parsed = todoWriteTool.parameters.safeParse(args);
+		expect(parsed.success).toBe(true);
+		if (!parsed.success) throw new Error("Expected canonical eager todo payload to validate");
+
+		const result = await todoWriteTool.execute("canonical-eager-todo", parsed.data);
+		expect(result.isError).toBeUndefined();
+		expect(result.details?.phases.flatMap(phase => phase.tasks).map(task => task.status)).toEqual([
+			"in_progress",
+			"pending",
+			"pending",
+		]);
+
+		expect(reminder).not.toContain('"details"');
+		expect(reminder).not.toContain('"status"');
+		expect(reminder).not.toContain('"todos"');
+		expect(reminder).not.toMatch(/^\s*\{"op"/mu);
 	});
 
 	it("sends eager todo reminder without toolChoice when named forcing degrades", async () => {


### PR DESCRIPTION
## Summary
- make the eager Todo reminder use the real top-level `ops/init/list/phase/items` schema
- remove invalid writable status/details guidance
- validate and execute the embedded example through the real TodoWriteTool

## Verification
- Coding Agent check passed
- 11 eager-Todo tests passed
- dev-base six-PR integration rehearsal: 1,074 tests passed

Fixes #3403