### PR TITLE
fix(task): show subagent fast mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Subagent task and retained-result rows now show the fast-mode indicator for the actual effective provider/model, including runtime fallback and substitution changes.
 
 ### Fixed
 

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -155,6 +155,8 @@ export interface SubagentRecord {
 	effectiveModel?: string;
 	/** True when the requested model lacked credentials and the subagent fell back to the parent model. */
 	modelFellBack?: boolean;
+	/** Whether fast mode is effectively active for the subagent's current model. */
+	fastModeActive?: boolean;
 }
 
 /** Lightweight, manager-owned resume payload. The async layer treats `data` as opaque. */
@@ -661,16 +663,17 @@ export class AsyncJobManager {
 		this.#subagentRecords.set(record.subagentId, record);
 	}
 
-	/** Patch model metadata onto an existing subagent record (best-effort; no-op if unknown). */
+	/** Patch effective model metadata onto an existing subagent record (best-effort; no-op if unknown). */
 	updateSubagentModel(
 		subagentId: string,
-		model: { requestedModel?: string; effectiveModel?: string; modelFellBack?: boolean },
+		model: { requestedModel?: string; effectiveModel?: string; modelFellBack?: boolean; fastModeActive?: boolean },
 	): void {
 		const record = this.#subagentRecords.get(subagentId);
 		if (!record) return;
 		record.requestedModel = model.requestedModel;
 		record.effectiveModel = model.effectiveModel;
 		record.modelFellBack = model.modelFellBack;
+		record.fastModeActive = model.fastModeActive;
 	}
 
 	#recordFromResumeDescriptor(subagentId: string, filter?: AsyncJobFilter): SubagentRecord | undefined {
@@ -1095,6 +1098,9 @@ export class AsyncJobManager {
 		// Clear any retained progress from the previous run so a resumed subagent
 		// never renders the prior run's tool/output as live before it emits again.
 		this.#subagentProgress.delete(rec.subagentId);
+		// The prior run's provider may have differed or have since auto-disabled
+		// priority. Do not expose its glyph while the replacement is starting.
+		rec.fastModeActive = undefined;
 		const runner = this.#resolveResumeRunner(rec.subagentId);
 		const newJobId = runner?.(rec.subagentId, message, this.#resumeDescriptors.get(rec.subagentId));
 		if (!newJobId) return { ok: false, reason: "resume_failed" };

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -25,6 +25,8 @@ import {
 } from "../../config/model-registry";
 import {
 	formatModelSelectorValue,
+	formatModelString,
+	resolveAgentModelPatterns,
 	resolveConfiguredModelPatterns,
 	resolveModelRoleValue,
 	type ScopedModelSelection,
@@ -36,6 +38,8 @@ import { compareRankedProviders, type ProviderAuthState } from "../../config/pro
 import type { Settings } from "../../config/settings";
 import { type ThemeColor, theme } from "../../modes/theme/theme";
 import { formatModelOnboardingInlineHint } from "../../setup/model-onboarding-guidance";
+import { discoverAgents } from "../../task/discovery";
+import type { AgentDefinition } from "../../task/types";
 import { formatClampedModelSelector, getThinkingLevelMetadata, parseThinkingLevel } from "../../thinking";
 import { getConfiguredImageModel } from "../../tools/image-gen";
 import { getTabBarTheme } from "../shared";
@@ -95,6 +99,7 @@ interface RoleAssignment {
 	model: Model;
 	thinkingLevel: ThinkingLevel;
 }
+type RoleAgentDefinitions = ReadonlyArray<Pick<AgentDefinition, "name" | "model" | "thinkingLevel">>;
 
 export type ModelSelectorSelection =
 	| {
@@ -349,6 +354,7 @@ export class ModelSelectorComponent extends Container {
 	#selectedThinkingIndex: number = 0;
 	#assignmentState: "idle" | "assigning" = "idle";
 	#closeAfterAssignment = false;
+	#roleAgentDefinitions?: RoleAgentDefinitions;
 
 	// Preset landing state
 	#viewMode: ModelSelectorViewMode = "presets";
@@ -384,6 +390,7 @@ export class ModelSelectorComponent extends Container {
 			currentThinkingLevel?: ThinkingLevel;
 			activeModelProfile?: string;
 			configuredDefaultChain?: readonly string[];
+			agentDefinitions?: RoleAgentDefinitions;
 		},
 	) {
 		super();
@@ -400,6 +407,7 @@ export class ModelSelectorComponent extends Container {
 		this.#currentThinkingLevel = options?.currentThinkingLevel;
 		this.#activeModelProfile = options?.activeModelProfile;
 		this.#configuredDefaultChain = options?.configuredDefaultChain;
+		this.#roleAgentDefinitions = options?.agentDefinitions;
 		this.#isFastForProvider = options?.isFastForProvider ?? (() => false);
 		this.#isFastForSubagentProvider = options?.isFastForSubagentProvider ?? (() => false);
 		// Current-model EFFECTIVE fast state. Defaults to intent for the current
@@ -413,6 +421,16 @@ export class ModelSelectorComponent extends Container {
 
 		// Load current role assignments from settings
 		this.#loadRoleModels();
+		if (!this.#roleAgentDefinitions) {
+			void discoverAgents(this.#settings.getCwd()).then(
+				({ agents }) => {
+					this.#roleAgentDefinitions = agents;
+					this.refreshRoleAssignments();
+					this.#tui.requestRender();
+				},
+				() => {},
+			);
+		}
 
 		// Add top border
 		this.addChild(new DynamicBorder());
@@ -501,8 +519,21 @@ export class ModelSelectorComponent extends Container {
 		const agentModelOverrides = this.#settings.get("task.agentModelOverrides");
 		for (const role of GJC_MODEL_ASSIGNMENT_TARGET_IDS) {
 			const target = GJC_MODEL_ASSIGNMENT_TARGETS[role];
-			const roleValue =
+			const explicitOverride =
 				target.settingsPath === "modelRoles" ? this.#settings.getModelRole(role) : agentModelOverrides[role];
+			const roleAgent =
+				target.settingsPath === "task.agentModelOverrides"
+					? this.#roleAgentDefinitions?.find(agent => agent.name === role)
+					: undefined;
+			const roleValue = roleAgent
+				? resolveAgentModelPatterns({
+						settingsOverride: explicitOverride,
+						agentModel: roleAgent.model,
+						settings: this.#settings,
+						activeModelPattern: this.#currentModel ? formatModelString(this.#currentModel) : undefined,
+						fallbackModelPattern: normalizeModelSelectorValue(this.#settings.getModelRole("default"))[0],
+					})
+				: explicitOverride;
 			if (!roleValue) continue;
 
 			const resolved = resolveModelRoleValue(roleValue, allModels, {
@@ -516,7 +547,7 @@ export class ModelSelectorComponent extends Container {
 					thinkingLevel:
 						resolved.explicitThinkingLevel && resolved.thinkingLevel !== undefined
 							? resolved.thinkingLevel
-							: ThinkingLevel.Inherit,
+							: (roleAgent?.thinkingLevel ?? ThinkingLevel.Inherit),
 				};
 			}
 		}
@@ -1383,13 +1414,11 @@ export class ModelSelectorComponent extends Container {
 
 			const isSelected = i === this.#selectedIndex;
 
-			// Build role badges (inverted: color as background, black text)
+			// Build role badges (inverted: color as background, black text).
 			const roleBadgeTokens: string[] = [];
-			// Whether a non-subagent (modelRoles) badge on the CURRENT model row already
-			// rendered the current-model EFFECTIVE glyph. Only that case should suppress
-			// the standalone current glyph below — a subagent-only match must NOT, since
-			// subagent badges reflect the subagent tier, not the current model.
-			let currentModelEffectiveGlyphRendered = false;
+			// A model can fulfill multiple assignments, but is still one displayed row.
+			// Render its fast indicator once regardless of how many matching role badges it has.
+			let fastGlyphRendered = false;
 			for (const role of GJC_MODEL_ASSIGNMENT_TARGET_IDS) {
 				const roleInfo = GJC_MODEL_ASSIGNMENT_TARGETS[role];
 				const assigned = this.#roles[role];
@@ -1398,10 +1427,8 @@ export class ModelSelectorComponent extends Container {
 					const thinkingLabel = getThinkingLevelMetadata(assigned.thinkingLevel).label;
 
 					// Subagent roles (task.agentModelOverrides) run under task.serviceTier,
-					// so their ⚡ uses the effective subagent tier. A non-subagent
-					// (modelRoles) badge on the CURRENT model row uses the current-model
-					// effective predicate so a provider auto-disable hides the glyph;
-					// other modelRoles rows show pure intent.
+					// while non-subagent roles on the current row use the effective
+					// current-model predicate so provider auto-disable hides the glyph.
 					const isSubagentRole = roleInfo.settingsPath === "task.agentModelOverrides";
 					const isCurrentRow = this.#currentModel !== undefined && modelsAreEqual(this.#currentModel, item.model);
 					const roleFast = isSubagentRole
@@ -1409,19 +1436,15 @@ export class ModelSelectorComponent extends Container {
 						: isCurrentRow
 							? this.#isCurrentModelFastModeActive()
 							: this.#isFastForProvider(assigned.model.provider);
-					if (roleFast && isCurrentRow && !isSubagentRole) {
-						currentModelEffectiveGlyphRendered = true;
-					}
-					const fastSuffix = roleFast ? ` ${theme.icon.fast}` : "";
+					const fastSuffix = roleFast && !fastGlyphRendered ? ` ${theme.icon.fast}` : "";
+					if (roleFast) fastGlyphRendered = true;
 					roleBadgeTokens.push(`${badge} ${theme.fg("dim", `(${thinkingLabel})`)}${fastSuffix}`);
 				}
 			}
 			// Active/current non-role row: show the fast glyph on the session's current
-			// model row. Suppress only when a non-subagent current-row badge already
-			// rendered the current-model effective glyph (duplicate-glyph guard) — a
-			// subagent-only match must not hide the current model's own indicator.
+			// model row only when no role badge already supplied it.
 			if (
-				!currentModelEffectiveGlyphRendered &&
+				!fastGlyphRendered &&
 				this.#currentModel !== undefined &&
 				modelsAreEqual(this.#currentModel, item.model) &&
 				this.#isCurrentModelFastModeActive()

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -869,6 +869,31 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 	let lastAssistantModelString: string | undefined;
 	let activeProviderModelString: string | undefined;
 	let effectiveThinkingLevelForWarning: ThinkingLevel | undefined;
+	const syncFastModeActive = (effectiveModel?: string): void => {
+		if (!activeSession) return;
+		const sessionModel = activeSession.model ? formatModelString(activeSession.model) : undefined;
+		const actualModel = effectiveModel ?? sessionModel;
+		const isFastModeActive =
+			typeof activeSession.isFastModeActive === "function"
+				? activeSession.isFastModeActive.bind(activeSession)
+				: undefined;
+		const isFastForProvider =
+			typeof activeSession.isFastForProvider === "function"
+				? activeSession.isFastForProvider.bind(activeSession)
+				: () => false;
+		// AgentSession applies provider `disabledFeatures` before delivering its
+		// event. Its effective predicate is therefore authoritative for both the
+		// configured model and a provider fallback/substitution.
+		progress.fastModeActive = isFastModeActive
+			? isFastModeActive()
+			: isFastForProvider(providerNameFromModel(actualModel));
+		AsyncJobManager.instance()?.updateSubagentModel?.(options.subagentId ?? id, {
+			requestedModel: modelSubstitutionWarning?.requested ?? resolvedModelString,
+			effectiveModel: actualModel,
+			modelFellBack: modelSubstitutionWarning?.reason === "auth_unavailable",
+			fastModeActive: progress.fastModeActive,
+		});
+	};
 	let lastProviderProgressAtMs: number | undefined;
 	let sessionEventOrdinal = 0;
 	let retryStartOrdinal = 0;
@@ -1314,6 +1339,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 							});
 						}
 					}
+					syncFastModeActive(assistantModel);
+					flushProgress = true;
 				}
 				// Extract and accumulate usage (prefer message.usage, fallback to event.usage)
 				const messageUsage = getMessageUsage(event.message) || (event as AgentEvent & { usage?: unknown }).usage;
@@ -1662,6 +1689,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			);
 
 			activeSession = session;
+			syncFastModeActive();
+			scheduleProgress(true);
 			// Each subagent invocation owns a fresh controller; its configured chain
 			// is scoped to this child session and never shares parent sticky state.
 			// Auth-aware resolution can substitute the parent model only after every
@@ -1875,6 +1904,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				}
 				if (event.type === "model_fallback_switched") {
 					activeProviderModelString = event.to;
+					syncFastModeActive(event.to);
+					scheduleProgress(true);
 					forwardSubagentEvent(event);
 					return;
 				}
@@ -2167,6 +2198,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		contextWindow: progress.contextWindow,
 		modelOverride,
 		modelSubstitutionWarning,
+		fastModeActive: progress.fastModeActive,
 		error: exitCode !== 0 && stderr ? stderr : undefined,
 		aborted: wasAborted,
 		abortReason: finalAbortReason,

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -801,6 +801,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								progress.contextTokens = singleResult?.contextTokens;
 								progress.contextWindow = singleResult?.contextWindow;
 								progress.cost = singleResult?.usage?.cost.total ?? 0;
+								progress.fastModeActive = singleResult?.fastModeActive;
 								progress.extractedToolData = undefined;
 								progress.retryFailure = singleResult?.retryFailure
 									? {

--- a/packages/coding-agent/src/task/receipt.ts
+++ b/packages/coding-agent/src/task/receipt.ts
@@ -29,6 +29,8 @@ export interface TaskResultReceipt {
 	contextWindow?: number;
 	modelOverride?: string | string[];
 	modelSubstitutionWarning?: SingleResult["modelSubstitutionWarning"];
+	/** Whether fast mode was effectively active for the subagent's final model. */
+	fastModeActive?: SingleResult["fastModeActive"];
 	usage?: SingleResult["usage"];
 	cost?: number;
 	usageCostBreakdownComplete?: true;
@@ -246,6 +248,7 @@ export function buildTaskReceipt(raw: SingleResult): TaskResultReceipt {
 		contextWindow: raw.contextWindow,
 		modelOverride: raw.modelOverride,
 		modelSubstitutionWarning: raw.modelSubstitutionWarning,
+		...(raw.fastModeActive !== undefined ? { fastModeActive: raw.fastModeActive } : {}),
 		usage: raw.usage,
 		cost: raw.usage?.cost.total,
 		usageCostBreakdownComplete:

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -544,6 +544,7 @@ function renderAgentProgress(
 	 * countdown) so the output is a pure function of `progress` — required when the
 	 * caller caches these lines (the `subagent` await panel). */
 	staticTime = false,
+	showFastModeIndicator = true,
 ): string[] {
 	const lines: string[] = [];
 	const prefix = isLast ? theme.fg("dim", theme.tree.last) : theme.fg("dim", theme.tree.branch);
@@ -562,6 +563,7 @@ function renderAgentProgress(
 	const displayId = formatTaskId(progress.id);
 	const titlePart = description ? `${theme.bold(displayId)}: ${description}` : displayId;
 	let statusLine = `${prefix} ${theme.fg(iconColor, icon)} ${theme.fg("accent", titlePart)}`;
+	if (showFastModeIndicator && progress.fastModeActive) statusLine += ` ${theme.icon.fast}`;
 
 	// A provider recovery loop is operationally distinct from normal agent work.
 	if (progress.retryState && progress.status === "running") {
@@ -736,8 +738,11 @@ export function renderSubagentLiveProgress(
 	theme: Theme,
 	spinnerFrame?: number,
 	staticTime = false,
+	/** Whether to show the fast-mode glyph on the detail line. Await panels show
+	 * that glyph on their parent snapshot status row instead. */
+	showFastModeIndicator = true,
 ): string[] {
-	return renderAgentProgress(progress, true, expanded, theme, spinnerFrame, staticTime);
+	return renderAgentProgress(progress, true, expanded, theme, spinnerFrame, staticTime, showFastModeIndicator);
 }
 
 /**
@@ -867,6 +872,7 @@ function renderAgentResult(result: TaskResultReceipt, isLast: boolean, expanded:
 		iconColor,
 		theme,
 	)}`;
+	if (result.fastModeActive) statusLine += ` ${theme.icon.fast}`;
 	statusLine = appendAgentStats(
 		statusLine,
 		{

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -283,6 +283,8 @@ export interface AgentProgress {
 	durationMs: number;
 	modelOverride?: string | string[];
 	modelSubstitutionWarning?: ModelSubstitutionWarning;
+	/** Whether fast mode is effectively active for the subagent's current model. */
+	fastModeActive?: boolean;
 	/** Data extracted by registered subprocess tool handlers (keyed by tool name) */
 	extractedToolData?: Record<string, unknown[]>;
 	/**
@@ -346,6 +348,8 @@ export interface SingleResult {
 	contextWindow?: number;
 	modelOverride?: string | string[];
 	modelSubstitutionWarning?: ModelSubstitutionWarning;
+	/** Whether fast mode was effectively active for the subagent's final model. */
+	fastModeActive?: boolean;
 	error?: string;
 	aborted?: boolean;
 	abortReason?: string;

--- a/packages/coding-agent/src/tools/subagent-render.ts
+++ b/packages/coding-agent/src/tools/subagent-render.ts
@@ -163,7 +163,7 @@ function renderSubagentStatusLine(snapshot: SubagentSnapshot, theme: Theme, spin
 			)
 		: theme.fg("dim", snapshot.status);
 	const duration = theme.fg("dim", formatDuration(snapshot.durationMs));
-	return `${icon} ${id} ${status} ${duration}`;
+	return `${icon} ${id} ${status} ${duration}${snapshot.fastModeActive ? ` ${theme.icon.fast}` : ""}`;
 }
 
 // Heavy per-subagent body. The cache path uses staticTime=true; the bounded dynamic
@@ -210,7 +210,7 @@ function renderSubagentSnapshotBody(
 	// resurrect a live panel (AC5). `staticTime` keeps wall-clock displays out of
 	// cached lines when the body is served by the cache.
 	if (snapshot.progress && snapshot.liveProgressAvailable !== false) {
-		for (const pl of renderSubagentLiveProgress(snapshot.progress, expanded, theme, undefined, staticTime)) {
+		for (const pl of renderSubagentLiveProgress(snapshot.progress, expanded, theme, undefined, staticTime, false)) {
 			lines.push(`  ${pl}`);
 		}
 	} else if (snapshot.liveProgressAvailable && (snapshot.status === "running" || snapshot.status === "queued")) {

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -82,6 +82,8 @@ export interface SubagentSnapshot {
 	requestedModel?: string;
 	/** True when the requested model lacked credentials and fell back to the parent model. */
 	modelFellBack?: boolean;
+	/** Whether fast mode is effectively active for the subagent's current model. */
+	fastModeActive?: boolean;
 }
 
 export type SubagentAwaitOutcome = "completed" | "timed_out" | "interrupted";
@@ -695,6 +697,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		if (record.effectiveModel) fields.effectiveModel = record.effectiveModel;
 		if (record.requestedModel) fields.requestedModel = record.requestedModel;
 		if (record.modelFellBack) fields.modelFellBack = true;
+		if (record.fastModeActive !== undefined) fields.fastModeActive = record.fastModeActive;
 		return fields;
 	}
 
@@ -900,6 +903,7 @@ function canonicalizeSnapshotForSignature(snapshot: SubagentSnapshot): unknown {
 		effectiveModel: snapshot.effectiveModel ?? null,
 		requestedModel: snapshot.requestedModel ?? null,
 		modelFellBack: snapshot.modelFellBack ?? false,
+		fastModeActive: snapshot.fastModeActive ?? null,
 		// durationMs intentionally excluded (time-derived; would defeat idle gating).
 		progress: snapshot.progress ? canonicalizeProgressForSignature(snapshot.progress) : null,
 	};
@@ -927,6 +931,7 @@ function canonicalizeProgressForSignature(progress: AgentProgress): unknown {
 		cost: progress.cost,
 		modelOverride: progress.modelOverride ?? null,
 		modelSubstitutionWarning: progress.modelSubstitutionWarning ?? null,
+		fastModeActive: progress.fastModeActive ?? null,
 		// durationMs intentionally excluded (time-derived).
 		extractedToolData: progress.extractedToolData
 			? canonicalizeExtractedToolDataForSignature(progress.extractedToolData)

--- a/packages/coding-agent/test/async-job-manager.test.ts
+++ b/packages/coding-agent/test/async-job-manager.test.ts
@@ -374,6 +374,28 @@ describe("AsyncJobManager", () => {
 		await manager.waitForAll();
 		expect(manager.getJob(parentJobId)?.status).toBe("cancelled");
 	});
+	test("clears a prior fast-mode glyph before its resumed runner starts", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: async () => {} });
+		let fastModeActiveDuringResume: boolean | undefined;
+		manager.registerSubagentRecord({
+			subagentId: "0-Resume",
+			currentJobId: "prior-job",
+			historicalJobIds: [],
+			status: "paused",
+			sessionFile: "/tmp/0-Resume.jsonl",
+			resumable: true,
+			fastModeActive: true,
+		});
+		manager.setResumeRunner(subagentId => {
+			fastModeActiveDuringResume = manager.getSubagentRecord(subagentId)?.fastModeActive;
+			return manager.register("task", "resumed", async () => "done", { id: "resumed-job" });
+		});
+
+		expect(manager.resumeSubagent("0-Resume")).toMatchObject({ ok: true, status: "running" });
+		expect(fastModeActiveDuringResume).toBeUndefined();
+		expect(manager.getSubagentRecord("0-Resume")?.fastModeActive).toBeUndefined();
+		await manager.dispose({ timeoutMs: 100 });
+	});
 	test("retention-zero eviction runs onEvict and records a monitor tombstone", async () => {
 		let evictCount = 0;
 		const manager = new AsyncJobManager({ retentionMs: 0, onJobComplete: async () => {} });

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -12,6 +12,7 @@ import {
 	theme,
 } from "@gajae-code/coding-agent/modes/theme/theme";
 import type { TUI } from "@gajae-code/tui";
+import { loadBundledAgents } from "../src/task/agents";
 
 function normalizeRenderedText(text: string): string {
 	return (
@@ -685,10 +686,12 @@ describe("ModelSelector canonical model selection", () => {
 		selector.handleInput("\n");
 
 		const thinkingRendered = normalizeRenderedText(selector.render(220).join("\n"));
-		expect(thinkingRendered).toContain("Reasoning for Default");
-		expect(thinkingRendered).toContain("off");
-		expect(thinkingRendered).not.toContain("high");
-		expect(thinkingRendered).not.toContain("xhigh");
+		const reasoningHeading = "Reasoning for Default";
+		expect(thinkingRendered).toContain(reasoningHeading);
+		const reasoningChoices = thinkingRendered.slice(thinkingRendered.indexOf(reasoningHeading));
+		expect(reasoningChoices).toContain("off");
+		expect(reasoningChoices).not.toContain("high");
+		expect(reasoningChoices).not.toContain("xhigh");
 	});
 
 	test("does not prompt for non-reasoning OpenAI models", async () => {
@@ -737,11 +740,13 @@ function createFastSelector(args: {
 	isFastForSubagentProvider?: (provider?: string) => boolean;
 	isCurrentModelFastModeActive?: () => boolean;
 	currentModel?: Model;
+	agentDefinitions?: Array<{ name: string; model?: string[]; thinkingLevel?: ThinkingLevel }>;
 }): ModelSelectorComponent {
 	const { models, settings, isFastForProvider, currentModel } = args;
 	// Subagent roles default to the same predicate as the session unless a test
 	// exercises the session-vs-subagent tier divergence explicitly.
 	const isFastForSubagentProvider = args.isFastForSubagentProvider ?? isFastForProvider;
+	const agentDefinitions = args.agentDefinitions ?? loadBundledAgents();
 	const modelRegistry = {
 		getAll: () => models,
 		hasConfiguredProviderAuth: () => false,
@@ -759,7 +764,12 @@ function createFastSelector(args: {
 		scoped,
 		() => {},
 		() => {},
-		{ isFastForProvider, isFastForSubagentProvider, isCurrentModelFastModeActive: args.isCurrentModelFastModeActive },
+		{
+			isFastForProvider,
+			isFastForSubagentProvider,
+			isCurrentModelFastModeActive: args.isCurrentModelFastModeActive,
+			agentDefinitions,
+		},
 	);
 }
 
@@ -771,7 +781,7 @@ describe("ModelSelector fast-mode indicator", () => {
 		}
 	});
 
-	test("AC-1: renders fast glyph after DEFAULT and EXECUTOR badges for priority tier", async () => {
+	test("AC-1: renders one fast glyph for a shared DEFAULT and EXECUTOR row", async () => {
 		installTestTheme();
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
@@ -790,10 +800,10 @@ describe("ModelSelector fast-mode indicator", () => {
 		const iconFast = theme.icon.fast;
 		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
 		expect(rendered).toContain(`DEFAULT (low) ${iconFast}`);
-		expect(rendered).toContain(`EXECUTOR (high) ${iconFast}`);
-		// Duplicate-glyph guard: the current model already carries role glyphs, so no
-		// extra standalone active-row glyph is added.
-		expect(countOccurrences(rendered, iconFast)).toBe(2);
+		expect(rendered).toContain("EXECUTOR (high)");
+		expect(rendered).not.toContain(`EXECUTOR (high) ${iconFast}`);
+		// All matching assignments share one displayed model row.
+		expect(countOccurrences(rendered, iconFast)).toBe(1);
 		// Regression: each badge label and thinking label renders exactly once, in order.
 		expect(countOccurrences(rendered, "DEFAULT")).toBe(1);
 		expect(countOccurrences(rendered, "EXECUTOR")).toBe(1);
@@ -801,6 +811,132 @@ describe("ModelSelector fast-mode indicator", () => {
 		expect(rendered.indexOf("(low)")).toBeLessThan(rendered.indexOf(iconFast));
 	});
 
+	test("synthesizes inherited role-agent assignments with their effective thinking levels", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+		const settings = Settings.isolated({
+			modelRoles: { default: `${model.provider}/${model.id}:low` },
+		});
+		const selector = createFastSelector({
+			models: [model],
+			settings,
+			isFastForProvider: () => true,
+			currentModel: model,
+		});
+
+		await Bun.sleep(0);
+		installTestTheme();
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("DEFAULT (low)");
+		expect(rendered).toContain("EXECUTOR (medium)");
+		expect(rendered).toContain("ARCHITECT (high)");
+		expect(rendered).toContain("PLANNER (medium)");
+		expect(rendered).toContain("CRITIC (high)");
+		expect(countOccurrences(rendered, theme.icon.fast)).toBe(1);
+	});
+	test("uses discovered project/user role-agent definitions for inherited assignments", async () => {
+		installTestTheme();
+		const current = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!current) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+		const inherited = createOpenAIModel("openai", "gpt-discovered-executor");
+		const selector = createFastSelector({
+			models: [current, inherited],
+			settings: Settings.isolated({ modelRoles: { default: `${current.provider}/${current.id}:low` } }),
+			isFastForProvider: () => false,
+			currentModel: current,
+			agentDefinitions: [
+				{
+					name: "executor",
+					model: [`${inherited.provider}/${inherited.id}:high`],
+					thinkingLevel: ThinkingLevel.Medium,
+				},
+			],
+		});
+
+		await Bun.sleep(0);
+		installTestTheme();
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain(`${inherited.id} EXECUTOR (high)`);
+		expect(rendered).not.toContain(`${current.id} EXECUTOR`);
+	});
+
+	test("uses the effective subagent provider when rendering inherited fast glyphs", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+		const settings = Settings.isolated({});
+
+		const matchingSelector = createFastSelector({
+			models: [model],
+			settings,
+			isFastForProvider: () => false,
+			isFastForSubagentProvider: provider => provider === "anthropic",
+			currentModel: model,
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+		expect(countOccurrences(normalizeRenderedText(matchingSelector.render(220).join("\n")), theme.icon.fast)).toBe(1);
+
+		const nonMatchingSelector = createFastSelector({
+			models: [model],
+			settings,
+			isFastForProvider: () => false,
+			isFastForSubagentProvider: () => false,
+			currentModel: model,
+		});
+		await Bun.sleep(0);
+		installTestTheme();
+		expect(countOccurrences(normalizeRenderedText(nonMatchingSelector.render(220).join("\n")), theme.icon.fast)).toBe(
+			0,
+		);
+	});
+
+	test("explicit role-agent overrides replace inherited assignments", async () => {
+		installTestTheme();
+		const inherited = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!inherited) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+		const override = createOpenAIModel("openai", "gpt-5-role-override");
+		const settings = Settings.isolated({
+			"task.agentModelOverrides": { executor: `${override.provider}/${override.id}:high` },
+		});
+		const selector = createFastSelector({
+			models: [inherited, override],
+			settings,
+			isFastForProvider: () => false,
+			currentModel: inherited,
+		});
+
+		await Bun.sleep(0);
+		installTestTheme();
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("EXECUTOR (high)");
+		expect(rendered).toContain("ARCHITECT (high)");
+		expect(rendered).toContain("PLANNER (medium)");
+		expect(rendered).toContain("CRITIC (high)");
+		expect(rendered.indexOf(override.id)).toBeLessThan(rendered.indexOf("EXECUTOR"));
+	});
+
+	test("renders all five assignment badges with at most one fast glyph on a shared model row", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+		const selector = createFastSelector({
+			models: [model],
+			settings: Settings.isolated({ modelRoles: { default: `${model.provider}/${model.id}:low` } }),
+			isFastForProvider: () => true,
+			isFastForSubagentProvider: () => true,
+			currentModel: model,
+		});
+
+		await Bun.sleep(0);
+		installTestTheme();
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		for (const role of ["DEFAULT", "EXECUTOR", "ARCHITECT", "PLANNER", "CRITIC"]) {
+			expect(countOccurrences(rendered, role)).toBe(1);
+		}
+		expect(countOccurrences(rendered, theme.icon.fast)).toBe(1);
+	});
 	test("subagent role glyph reflects the subagent tier, not the session tier", async () => {
 		// Regression for #691 round-2 blocker: serviceTier=priority but
 		// task.serviceTier=none. DEFAULT (modelRoles) runs in the main session and is
@@ -877,7 +1013,7 @@ describe("ModelSelector fast-mode indicator", () => {
 		expect(rendered).not.toContain(iconFast);
 	});
 
-	test("AC-4: active non-role current model row shows fast glyph via currentModel", async () => {
+	test("AC-4: current model row still shows one fast glyph with inherited roles", async () => {
 		installTestTheme();
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!model) throw new Error("Expected model");
@@ -893,7 +1029,7 @@ describe("ModelSelector fast-mode indicator", () => {
 		const iconFast = theme.icon.fast;
 		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
 		expect(rendered).not.toContain("DEFAULT");
-		expect(rendered).not.toContain("EXECUTOR");
+		expect(rendered).toContain("EXECUTOR (medium)");
 		expect(rendered).toContain(iconFast);
 		expect(countOccurrences(rendered, iconFast)).toBe(1);
 	});

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { AgentBusyError, type AgentTelemetryConfig, type Tracer } from "@gajae-code/agent-core";
 import { type AssistantMessage, type AssistantMessageEvent, Effort, type Model } from "@gajae-code/ai";
+import { AsyncJobManager } from "../../src/async/job-manager";
 import { kNoAuth } from "../../src/config/model-registry";
 
 import { Settings } from "../../src/config/settings";
@@ -62,6 +63,8 @@ function createMockSession(
 			return state.messages;
 		},
 		extensionRunner: undefined,
+		isFastModeActive: () => false,
+		isFastForProvider: () => false,
 		sessionManager: {
 			appendSessionInit: () => {},
 		},
@@ -105,6 +108,7 @@ function mockCreateAgentSession(session: AgentSession) {
 describe("runSubprocess yield reminders", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
+		AsyncJobManager.resetForTests();
 	});
 
 	const baseAgent: AgentDefinition = {
@@ -210,6 +214,28 @@ describe("runSubprocess yield reminders", () => {
 				scope: "subagent",
 			}),
 		]);
+	});
+	it("falls back safely when a legacy session omits fast-mode methods", async () => {
+		const session = createMockSession(({ emit }) => {
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-legacy-fast",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+		});
+		delete (session as Partial<AgentSession>).isFastModeActive;
+		delete (session as Partial<AgentSession>).isFastForProvider;
+		mockCreateAgentSession(session);
+
+		const result = await runSubprocess({ ...baseOptions, id: "subagent-legacy-fast-mode", modelRegistry });
+
+		expect(result.exitCode).toBe(0);
+		expect(result.fastModeActive).toBe(false);
 	});
 
 	it("clears provider retry state on the first recovered assistant event", async () => {
@@ -494,6 +520,124 @@ describe("runSubprocess yield reminders", () => {
 
 		const retryStart = progressUpdates.find(update => update.event === "auto_retry_start");
 		expect(retryStart?.progress.retryState?.provider).toBe("fallback");
+		expect(result.exitCode).toBe(0);
+	});
+	it("uses AgentSession's effective fast-mode state after priority is auto-disabled", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: async () => {} });
+		AsyncJobManager.setInstance(manager);
+		manager.registerSubagentRecord({
+			subagentId: "subagent-fast-mode-off",
+			currentJobId: null,
+			historicalJobIds: [],
+			status: "running",
+			sessionFile: null,
+			resumable: false,
+		});
+		let fastModeActive = true;
+		const session = createMockSession(({ emit }) => {
+			const terminal = {
+				...createAssistantStopMessage("Result submitted."),
+				provider: "test",
+				model: "mock",
+				disabledFeatures: ["priority"],
+			};
+			// AgentSession consumes disabledFeatures before notifying subscribers.
+			fastModeActive = false;
+			emit({ type: "message_end", message: terminal });
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-fast-mode-off",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+		});
+		(session as unknown as { isFastModeActive: () => boolean }).isFastModeActive = () => fastModeActive;
+		mockCreateAgentSession(session);
+
+		const result = await runSubprocess({
+			...baseOptions,
+			id: "subagent-fast-mode-off",
+			modelOverride: "test/mock",
+			modelRegistry,
+		});
+
+		expect(result.fastModeActive).toBe(false);
+		expect(manager.getSubagentRecord("subagent-fast-mode-off")?.fastModeActive).toBe(false);
+		expect(result.exitCode).toBe(0);
+	});
+	it("uses effective fast mode after a fallback model switch", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: async () => {} });
+		AsyncJobManager.setInstance(manager);
+		manager.registerSubagentRecord({
+			subagentId: "subagent-fallback-fast-mode",
+			currentJobId: null,
+			historicalJobIds: [],
+			status: "running",
+			sessionFile: null,
+			resumable: false,
+		});
+		let currentEvent = "setup";
+		const progressUpdates: Array<{ event: string; progress: AgentProgress }> = [];
+		const eventBus = new EventBus();
+		eventBus.on(TASK_SUBAGENT_PROGRESS_CHANNEL, payload => {
+			progressUpdates.push({
+				event: currentEvent,
+				progress: structuredClone((payload as { progress: AgentProgress }).progress),
+			});
+		});
+
+		const primaryModel = { ...model, provider: "primary", id: "model" };
+		const session = createMockSession(
+			({ emit }) => {
+				currentEvent = "model_fallback_switched";
+				emit({
+					type: "model_fallback_switched",
+					eventId: "fallback-fast-mode",
+					from: "primary/model",
+					to: "fallback/model",
+					reason: "rate_limit",
+					role: "executor",
+					scope: "subagent",
+					activeIndex: 1,
+					chainLength: 2,
+					attemptsUsed: 1,
+				});
+				currentEvent = "tool_execution_end";
+				emit({
+					type: "tool_execution_end",
+					toolCallId: "tool-fallback-fast-mode",
+					toolName: "yield",
+					result: {
+						content: [{ type: "text", text: "Result submitted." }],
+						details: { status: "success", data: { provider: "fallback" } },
+					},
+					isError: false,
+				});
+			},
+			{ model: primaryModel },
+		);
+		(session as unknown as { isFastForProvider: (provider?: string) => boolean }).isFastForProvider = provider =>
+			provider === "fallback";
+		(session as unknown as { isFastModeActive: () => boolean }).isFastModeActive = () => false;
+		mockCreateAgentSession(session);
+
+		const result = await runSubprocess({
+			...baseOptions,
+			id: "subagent-fallback-fast-mode",
+			eventBus,
+			modelOverride: "test/mock",
+			modelRegistry,
+		});
+
+		expect(progressUpdates.find(update => update.event === "model_fallback_switched")?.progress.fastModeActive).toBe(
+			false,
+		);
+		expect(result.fastModeActive).toBe(false);
+		expect(manager.getSubagentRecord("subagent-fallback-fast-mode")?.fastModeActive).toBe(false);
 		expect(result.exitCode).toBe(0);
 	});
 

--- a/packages/coding-agent/test/task/receipt.test.ts
+++ b/packages/coding-agent/test/task/receipt.test.ts
@@ -155,6 +155,15 @@ describe("task result receipts", () => {
 		expect(receipt.outputRef).toBeUndefined();
 		expect(receipt.outputUnavailable).toBe(true);
 	});
+	it("preserves explicit fast-mode state from SingleResult receipts", () => {
+		const active = buildTaskReceipt(makeRaw({ fastModeActive: true }));
+		const inactive = buildTaskReceipt(makeRaw({ fastModeActive: false }));
+		const unknown = buildTaskReceipt(makeRaw());
+
+		expect(active.fastModeActive).toBe(true);
+		expect(inactive.fastModeActive).toBe(false);
+		expect("fastModeActive" in unknown).toBe(false);
+	});
 
 	it("surfaces model substitution warnings without raw output", () => {
 		const receipt = buildTaskReceipt(

--- a/packages/coding-agent/test/task/render-nested-live.test.ts
+++ b/packages/coding-agent/test/task/render-nested-live.test.ts
@@ -90,6 +90,22 @@ describe("task renderer: nested live rendering", () => {
 		);
 		return Bun.stripANSI(component.render(160).join("\n"));
 	}
+	async function renderBackgroundProgress(progress: AgentProgress[]): Promise<string> {
+		const theme = (await getThemeByName("red-claw"))!;
+		const details: TaskToolDetails = {
+			projectAgentsDir: null,
+			results: [],
+			totalDurationMs: 1234,
+			progress,
+			async: { state: "completed", jobId: "background-task", type: "task" },
+		};
+		const component = taskToolRenderer.renderResult(
+			{ content: [{ type: "text", text: "Background task complete" }], details },
+			{ expanded: false, isPartial: true, spinnerFrame: 0 },
+			theme,
+		);
+		return Bun.stripANSI(component.render(160).join("\n"));
+	}
 
 	async function renderResult(result: TaskResultReceipt): Promise<string> {
 		const theme = (await getThemeByName("red-claw"))!;
@@ -105,6 +121,50 @@ describe("task renderer: nested live rendering", () => {
 		);
 		return Bun.stripANSI(component.render(160).join("\n"));
 	}
+	it("renders the fast indicator for direct foreground task progress and results", async () => {
+		const iconFast = (await getThemeByName("red-claw"))!.icon.fast;
+		const live = await render(
+			makeRunningProgress({
+				id: "foreground-live",
+				description: "Foreground task is running",
+				fastModeActive: true,
+			}),
+		);
+		const terminal = await renderResult({
+			...makeCompletedSubResult("foreground-terminal", "Foreground task completed"),
+			fastModeActive: true,
+		});
+
+		expect(live).toContain(`Foreground task is running ${iconFast}`);
+		expect(terminal).toContain(`Foreground task completed ⟦done⟧ ${iconFast}`);
+	});
+	it("renders one fast glyph for qualifying terminal background progress only", async () => {
+		const iconFast = (await getThemeByName("red-claw"))!.icon.fast;
+		const text = await renderBackgroundProgress([
+			makeRunningProgress({
+				id: "background-fast",
+				description: "Fast terminal background task",
+				status: "completed",
+				fastModeActive: true,
+			}),
+			makeRunningProgress({
+				id: "background-not-fast",
+				description: "Non-fast terminal background task",
+				status: "completed",
+				fastModeActive: false,
+			}),
+			makeRunningProgress({
+				id: "background-unknown",
+				description: "Unknown terminal background task",
+				status: "completed",
+			}),
+		]);
+
+		expect(text.split(iconFast).length - 1).toBe(1);
+		expect(text.split("\n").find(line => line.includes("Fast terminal background task"))).toContain(iconFast);
+		expect(text.split("\n").find(line => line.includes("Non-fast terminal background task"))).not.toContain(iconFast);
+		expect(text.split("\n").find(line => line.includes("Unknown terminal background task"))).not.toContain(iconFast);
+	});
 
 	it("renders completed nested task results stored in extractedToolData.task while parent is in-progress", async () => {
 		const parent = makeRunningProgress({

--- a/packages/coding-agent/test/tools/subagent-render.test.ts
+++ b/packages/coding-agent/test/tools/subagent-render.test.ts
@@ -335,6 +335,56 @@ describe("subagentToolRenderer", () => {
 		expect(out).toContain("requested openai-codex/gpt-5.5");
 		expect(out).toContain("fell back");
 	});
+	it("renders one fast glyph for each live subagent row with fast mode active", () => {
+		const out = render({
+			subagents: [
+				snapshot({
+					id: "0-FastA",
+					fastModeActive: true,
+					liveProgressAvailable: true,
+					progress: progress({ id: "0-FastA", currentTool: "read", fastModeActive: true }),
+				}),
+				snapshot({
+					id: "0-FastB",
+					fastModeActive: true,
+					liveProgressAvailable: true,
+					progress: progress({ id: "0-FastB", currentTool: "bash", fastModeActive: true }),
+				}),
+				snapshot({
+					id: "0-Normal",
+					fastModeActive: false,
+					liveProgressAvailable: true,
+					progress: progress({ id: "0-Normal", currentTool: "bash", fastModeActive: false }),
+				}),
+				snapshot({
+					id: "0-Unknown",
+					liveProgressAvailable: true,
+					progress: progress({ id: "0-Unknown", currentTool: "edit" }),
+				}),
+			],
+		});
+
+		expect(out.split(theme.icon.fast).length - 1).toBe(2);
+		for (const id of ["0-FastA", "0-FastB"]) {
+			expect(out.split("\n").find(line => line.includes(id))).toContain(theme.icon.fast);
+		}
+	});
+
+	it("renders one fast glyph for each qualifying terminal subagent row", () => {
+		const out = render({
+			subagents: [
+				snapshot({ id: "0-FastDoneA", status: "completed", fastModeActive: true, resultText: "done" }),
+				snapshot({ id: "0-FastDoneB", status: "completed", fastModeActive: true, resultText: "done" }),
+				snapshot({ id: "0-NormalDone", status: "completed", fastModeActive: false, resultText: "done" }),
+				snapshot({ id: "0-UnknownDone", status: "completed", resultText: "done" }),
+			],
+		});
+
+		expect(out.split(theme.icon.fast).length - 1).toBe(2);
+		for (const id of ["0-FastDoneA", "0-FastDoneB"]) {
+			expect(out.split("\n").find(line => line.includes(id))).toContain(theme.icon.fast);
+		}
+	});
 });
 
 describe("interrupted await receipts", () => {

--- a/packages/coding-agent/test/tools/subagent.test.ts
+++ b/packages/coding-agent/test/tools/subagent.test.ts
@@ -123,6 +123,35 @@ describe("SubagentTool", () => {
 		expect(getText(result)).not.toContain("job-bash");
 		await manager.dispose({ timeoutMs: 100 });
 	});
+	it("maps manager-owned fast-mode state into snapshots without a global default", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession("0-Main"));
+		for (const subagentId of ["0-FastOn", "0-FastOff", "0-FastUnknown"]) {
+			manager.registerSubagentRecord({
+				subagentId,
+				ownerId: "0-Main",
+				currentJobId: null,
+				historicalJobIds: [],
+				status: "completed",
+				sessionFile: null,
+				resumable: false,
+			});
+		}
+		manager.updateSubagentModel("0-FastOn", { fastModeActive: true });
+		manager.updateSubagentModel("0-FastOff", { fastModeActive: false });
+
+		const result = await tool.execute("subagent-list-fast-mode", { action: "list" });
+		const snapshots = result.details?.subagents ?? [];
+		const active = snapshots.find(snapshot => snapshot.id === "0-FastOn");
+		const inactive = snapshots.find(snapshot => snapshot.id === "0-FastOff");
+		const unknown = snapshots.find(snapshot => snapshot.id === "0-FastUnknown");
+
+		expect(active?.fastModeActive).toBe(true);
+		expect(inactive?.fastModeActive).toBe(false);
+		expect(unknown).toBeDefined();
+		expect("fastModeActive" in unknown!).toBe(false);
+		await manager.dispose({ timeoutMs: 100 });
+	});
 
 	it("await retrieves completed subagent results and acknowledges delivery", async () => {
 		const manager = createManager();
@@ -508,6 +537,7 @@ describe("SubagentTool", () => {
 				status: "paused",
 				sessionFile: `/tmp/${subagentId}.jsonl`,
 				resumable: true,
+				fastModeActive: subagentId === "0-ResumeA" ? true : undefined,
 			});
 		}
 
@@ -525,6 +555,14 @@ describe("SubagentTool", () => {
 		expect(resumed).toEqual(["0-ResumeA"]);
 		expect(result.details?.subagents[0]?.status).toBe("running");
 		expect(result.details?.subagents[0]?.jobId).toBe("job-0-ResumeA");
+		expect(result.details?.subagents[0]?.fastModeActive).toBeUndefined();
+		await manager.getJob("job-0-ResumeA")?.promise;
+		const completed = await tool.execute("subagent-inspect-resumed-fast-mode", {
+			action: "inspect",
+			ids: ["0-ResumeA"],
+		});
+		expect(completed.details?.subagents[0]?.resultText).toContain("resumed");
+		expect(completed.details?.subagents[0]?.fastModeActive).toBeUndefined();
 		await manager.dispose({ timeoutMs: 100 });
 	});
 


### PR DESCRIPTION
## Summary
- propagate effective fast-mode state through execution, fallback, resume, manager, snapshot, receipt, and renderer boundaries
- render one fast indicator per qualifying live/terminal row
- make inherited role rows use the same project/user agent discovery precedence as task execution

## Verification
- Coding Agent check passed
- 165 focused tests passed
- dev-base six-PR integration rehearsal: 1,074 tests passed

Fixes #3402