### PR TITLE
fix(ci): address workflow bun test files by explicit relative path

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -226,16 +226,16 @@ jobs:
       - name: Verify Windows workspace shim and doctor
         shell: pwsh
         run: |
-          bun test scripts/dev-link.test.ts
+          bun test ./scripts/dev-link.test.ts
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           bun run dev:doctor
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
       - name: Windows session-path canonicalization regression
         shell: pwsh
         run: |
-          bun test packages/coding-agent/test/session-manager/windows-canonical-path.test.ts
+          bun test ./packages/coding-agent/test/session-manager/windows-canonical-path.test.ts
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          bun test packages/coding-agent/test/session/resident-cache-win32-gate.windows.test.ts
+          bun test ./packages/coding-agent/test/session/resident-cache-win32-gate.windows.test.ts
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 
@@ -317,11 +317,11 @@ jobs:
       - name: Run Windows daemon provenance safety contract
         shell: pwsh
         run: |
-          bun test packages/coding-agent/test/daemon-control.test.ts --test-name-pattern 'incarnation|captured-owner|owner-lock|poll overlap|configured chat providers|hard Windows authority'
+          bun test ./packages/coding-agent/test/daemon-control.test.ts --test-name-pattern 'incarnation|captured-owner|owner-lock|poll overlap|configured chat providers|hard Windows authority'
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts --test-name-pattern 'Windows production preflight|Windows legacy cooperative handoff|promoted generation-3 hybrid|concurrent ensureTelegramDaemonRunning|stale dead-pid lock|lock written before|parent-format|transition lock|provisional|readiness|reload failure|pre-upgrade owner|current-generation live owner|v0.10.2|historical pretty|exact unlink|rollback preserves legacy unmanaged root|runDaemonInternal rewrites persisted owner pid|heartbeat fails closed'
+          bun test ./packages/coding-agent/test/notifications-telegram-daemon.test.ts --test-name-pattern 'Windows production preflight|Windows legacy cooperative handoff|promoted generation-3 hybrid|concurrent ensureTelegramDaemonRunning|stale dead-pid lock|lock written before|parent-format|transition lock|provisional|readiness|reload failure|pre-upgrade owner|current-generation live owner|v0.10.2|historical pretty|exact unlink|rollback preserves legacy unmanaged root|runDaemonInternal rewrites persisted owner pid|heartbeat fails closed'
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          bun test packages/natives/test/native.test.ts --test-name-pattern 'signals only the pinned root process'
+          bun test ./packages/natives/test/native.test.ts --test-name-pattern 'signals only the pinned root process'
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   # Native addon build runs at most once per run and publishes the built `.node`

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -130,7 +130,10 @@ describe("dev-ci canonical-plan workflow contract", () => {
 		expect(windowsJob).toContain("runs-on: windows-latest");
 		expect(windowsJob).toContain("needs.affected-plan.outputs.has_windows_session_path == 'true'");
 		expect(windowsJob).toContain("Windows session-path canonicalization regression");
-		expect(windowsJob).toContain("bun test packages/coding-agent/test/session-manager/windows-canonical-path.test.ts");
+		// The `./` prefix is load-bearing on Windows: without it Bun treats the argument
+		// as a name filter rather than a path, matches nothing, and exits 1. Pinned here
+		// and enforced workflow-wide by dev-ci-guard-topology.test.ts.
+		expect(windowsJob).toContain("bun test ./packages/coding-agent/test/session-manager/windows-canonical-path.test.ts");
 		// The required predicate must textually match the job gate so the aggregate
 		// invariant (windowsDoctor === required ? success : skipped) never fails closed.
 		const requiredLines = workflow.split("\n").filter(line => line.includes("CI_DEV_WINDOWS_DOCTOR_REQUIRED:"));

--- a/scripts/dev-ci-guard-topology.test.ts
+++ b/scripts/dev-ci-guard-topology.test.ts
@@ -173,4 +173,32 @@ describe("dev-ci Telegram daemon generation guard topology", () => {
 		expect(checkoutStep(guard.steps).with?.["fetch-depth"]).toBe(0);
 		expect(authorityFetch).not.toContain("--depth");
 	});
+	// Regression for the shared Windows CI blocker seen on PRs #3423/#3422/#3325 and
+	// the #3424/#3425/#3426/#3428 burst: `bun test <path>` only treats the argument as
+	// a path when it resolves; otherwise Bun silently degrades it to a *name filter*,
+	// matches zero files, and exits 1 with
+	//   note: To treat the "<path>" filter as a path, run "bun test ./<path>"
+	// On Windows runners the bare relative form failed to resolve, so
+	// `resident-cache-win32-gate.windows.test.ts` (added by #3344, 1439fd109) turned
+	// every affected PR red for a reason unrelated to its own diff. The `./` prefix
+	// forces unambiguous path interpretation on every platform.
+	//
+	// This pins the invariant for all workflow test invocations, not just the one that
+	// broke, so the next added Windows step cannot reintroduce the same class of
+	// failure. A bare-path invocation is also silently *wrong* rather than loud: a
+	// filter that matches nothing can pass locally on Linux and fail only on Windows.
+	test("every workflow bun test invocation addresses files by explicit relative path", async () => {
+		const source = await Bun.file(".github/workflows/dev-ci.yml").text();
+		const offenders: string[] = [];
+		for (const rawLine of source.split(/\r?\n/)) {
+			const line = rawLine.trim();
+			if (!line.startsWith("bun test ")) continue;
+			const [firstArg] = line.slice("bun test ".length).trim().split(/\s+/);
+			if (!firstArg || firstArg.startsWith("-")) continue; // whole-suite or flag-only run
+			if (firstArg.startsWith("./") || firstArg.startsWith("$")) continue;
+			offenders.push(line);
+		}
+		expect(offenders).toEqual([]);
+	});
+
 });


### PR DESCRIPTION
## Problem

Windows CI is red on **every** PR that trips the `windows-dev-doctor` gate, independent of that PR's own diff — confirmed on #3423, #3422, #3325 and the #3424/#3425/#3426/#3428 burst.

`dev:doctor` passes, `windows-canonical-path` passes, then the step exits 1 on:

```
bun test packages/coding-agent/test/session/resident-cache-win32-gate.windows.test.ts
```

## Root cause

`bun test <arg>` treats the argument as a path **only when it resolves**. Otherwise it silently degrades to a test-name *filter*, matches zero files, and exits 1 — while printing its own remedy:

```
The following filters did not match any test files in --cwd="…":
 packages/coding-agent/test/session/resident-cache-win32-gate.windows.test.ts
note: To treat the "…" filter as a path, run "bun test ./packages/…"
```

On Windows runners the bare relative form does not resolve, so the invocation became a filter matching nothing.

The test itself is correct and properly `describe.skipIf(process.platform !== "win32")`-gated — **only the invocation is wrong**. Surfaced when #3344 (`1439fd109`) added both the test and the workflow line that runs it.

## Fix

Prefix with `./` so the argument is unambiguously a path on every platform.

Applied to **all six** workflow invocations, not just the one that broke: the rest carry the identical latent fault, and the failure mode is *silent-wrong* rather than loud — a filter matching nothing passes on Linux and fails only on Windows.

No behavior change: same files, same `--test-name-pattern` filters, same fail-closed `$LASTEXITCODE` handling.

## Regression coverage

`scripts/dev-ci-guard-topology.test.ts` now asserts every `bun test` line in `dev-ci.yml` addresses files by a `./`-prefixed path, so a future Windows step cannot reintroduce this class.

**Verified non-vacuous** — reverting line 238 alone fails the selftest with the offending line:

```
+ "bun test packages/coding-agent/test/session/resident-cache-win32-gate.windows.test.ts"
(fail) every workflow bun test invocation addresses files by explicit relative path
 4 pass  1 fail
```

and restoring it passes (`5 pass / 0 fail`).

`scripts/ci-dev-affected.test.ts` pinned the old bare-path string; updated to the `./` form with a note on why the prefix is load-bearing.

## Verification on exact dev

- workflow-contract suites: **100 pass / 0 fail** across 3 files
- `check-workflow-yaml.ts`: all workflows parse
- `biome check .`: clean across 3226 files

## Dependents

Second of the two shared blockers (first was the Vertex unused import, #3419, merged as `333c28a`). Once this lands, #3423 / #3422 / #3325 / #3424 / #3425 / #3426 / #3428 should update and re-run.