### PR TITLE
chore(schemas): regenerate config schema for session.resumeModelBehavior

### DIFF
--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -36,6 +36,16 @@
 						"disabled"
 					],
 					"default": "copy-retain"
+				},
+				"resumeModelBehavior": {
+					"type": "string",
+					"enum": [
+						"keepSessionModel",
+						"useCurrentDefault",
+						"ask"
+					],
+					"description": "When resuming a session: keep the model that session last used, switch to the currently configured default model, or ask (TUI only; falls back to keeping the session's model in headless/CLI resume).",
+					"default": "keepSessionModel"
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
## Problem

Root check is red on current dev (`84f4dc60`), independent of any PR's own diff — hit by #3422 and others:

```
$ bun scripts/generate-json-schemas.ts --check
Generated JSON Schemas are out of date: schemas/config.schema.json
Run `bun run generate-schemas` and commit the updated files.
```

## Attribution

PR #3293 (session resume model behavior), commits `86241e304` and `6bb42286f`, landed via merge `dae17134c`. They added the `session.resumeModelBehavior` setting to `packages/coding-agent/src/config/settings-schema.ts` but never regenerated the committed JSON Schema — **neither commit touches `schemas/` at all**.

## Fix

Purely the generator's own output — `bun run generate-schemas`, no manual edits:

```diff
+"resumeModelBehavior": {
+  "type": "string",
+  "enum": ["keepSessionModel", "useCurrentDefault", "ask"],
+  "description": "When resuming a session: keep the model that session last used, …",
+  "default": "keepSessionModel"
+}
```

Mirrors `settings-schema.ts:501-502` exactly. No behavior change: the schema is a generated artifact consumed by editor tooling and config validation.

## Verification on exact dev `84f4dc60`

- Only `schemas/config.schema.json` changes (`models.schema.json` rewritten byte-identical); drift is **additive: +10 / −0**
- `generate-json-schemas.ts --check` exits **0** (was 1)
- Regenerating twice is a no-op → output is **idempotent**
- `schemas/config.schema.json` parses as valid JSON
- `scripts/generate-json-schemas.test.ts`: **6 pass / 0 fail**

## Scope

Deliberately isolated. Does **not** bundle the SDK operation-inventory matrix mismatch, the SelectorController failures, or the Windows workflow path repair (#3430) — each is a separate contract with separate ownership.

## Dependents

Notify #3422 / #3429 / #3325 to rebase and re-run once merged.