### PR TITLE
fix: expose subagent sessions to Session Observer

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Coordinator MCP now reconciles canonical structured questions from every workflow stage without misclassifying row-level gate diagnostics as malformed pagination, and unwraps accepted SDK gate-answer envelopes before reporting the terminal resolution.
 - Subagent task panels now show the fast-mode glyph for the resolved provider in both live and completed states (#3402).
 
+- Session Observer now receives persisted subagent session paths on lifecycle and progress events, so active ralplan reviewer transcripts render instead of remaining at `No transcript entries yet`.
+
 ## [0.12.0] - 2026-07-28
 ### Resume fixes
 

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -970,7 +970,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				task,
 				assignment,
 				progress: progressSnapshot,
-				sessionFile: null,
+				sessionFile: sessionFile ?? undefined,
 			});
 		}
 		lastProgressEmitMs = Date.now();
@@ -1714,7 +1714,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					agentSource: agent.source,
 					description: options.description,
 					status: "started",
-					sessionFile: null,
+					sessionFile: sessionFile ?? undefined,
 					index,
 				});
 			}
@@ -2162,7 +2162,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			agentSource: agent.source,
 			description: options.description,
 			status: progress.status as "completed" | "failed" | "aborted" | "paused",
-			sessionFile: null,
+			sessionFile: sessionFile ?? undefined,
 			index,
 		});
 	}

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -12,7 +12,14 @@ import type { AgentSession, AgentSessionEvent, ForkContextSeed, PromptOptions } 
 import type { AuthStorage } from "../../src/session/auth-storage";
 import { runSubprocess, SUBAGENT_WARNING_MISSING_YIELD } from "../../src/task/executor";
 
-import { type AgentDefinition, type AgentProgress, TASK_SUBAGENT_PROGRESS_CHANNEL } from "../../src/task/types";
+import {
+	type AgentDefinition,
+	type AgentProgress,
+	type SubagentLifecyclePayload,
+	type SubagentProgressPayload,
+	TASK_SUBAGENT_LIFECYCLE_CHANNEL,
+	TASK_SUBAGENT_PROGRESS_CHANNEL,
+} from "../../src/task/types";
 
 import { EventBus } from "../../src/utils/event-bus";
 
@@ -210,6 +217,44 @@ describe("runSubprocess yield reminders", () => {
 				scope: "subagent",
 			}),
 		]);
+	});
+
+	it("publishes the persisted session file for observer lifecycle and progress events", async () => {
+		const sessionFile = "/tmp/subagent-observer.jsonl";
+		const lifecycleEvents: SubagentLifecyclePayload[] = [];
+		const progressEvents: SubagentProgressPayload[] = [];
+		const eventBus = new EventBus();
+		eventBus.on(TASK_SUBAGENT_LIFECYCLE_CHANNEL, payload => {
+			lifecycleEvents.push(payload as SubagentLifecyclePayload);
+		});
+		eventBus.on(TASK_SUBAGENT_PROGRESS_CHANNEL, payload => {
+			progressEvents.push(payload as SubagentProgressPayload);
+		});
+		const session = createMockSession(({ emit }) => {
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-observer-session-file",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+		});
+		mockCreateAgentSession(session);
+
+		await runSubprocess({
+			...baseOptions,
+			id: "subagent-observer-session-file",
+			eventBus,
+			sessionFile,
+		});
+
+		expect(lifecycleEvents.map(event => event.status)).toEqual(["started", "completed"]);
+		expect(lifecycleEvents.every(event => event.sessionFile === sessionFile)).toBe(true);
+		expect(progressEvents.length).toBeGreaterThan(0);
+		expect(progressEvents.every(event => event.sessionFile === sessionFile)).toBe(true);
 	});
 
 	it("clears provider retry state on the first recovered assistant event", async () => {


### PR DESCRIPTION
## Summary
- forward each persisted subagent session path on lifecycle events
- forward the same path on progress events
- add regression coverage for both event channels

## Problem
Session Observer discovers subagents from task lifecycle/progress events, but the executor always emitted `sessionFile: null`. Active ralplan reviewers therefore appeared in the observer while their transcript pane stayed at `No transcript entries yet`.

## Verification
- `bun test packages/coding-agent/test/task/executor-subagent-reminders.test.ts` (27 pass)
- `bun --cwd=packages/coding-agent run check`