### PR TITLE
fix(sdk): classify resolveConfiguredDefaultModel as an internal seam

### DIFF
--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -125,6 +125,7 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 	"agent_session:getActiveModelProfile": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:getSessionDefaultModelSelector": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:recordResumeDefaultModel": "internal accessor/plumbing, not a user-facing control seam",
+	"agent_session:resolveConfiguredDefaultModel": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:setModelTemporary": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:setModelTemporaryForControl":
 		"internal Telegram control wrapper over the reviewed model.set seam, not an independent public SDK operation",

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -3864,6 +3864,17 @@
 		}
 	},
 	{
+		"sourceId": "agent_session:resolveConfiguredDefaultModel",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "internal accessor/plumbing, not a user-facing control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
 		"sourceId": "agent_session:recordResumeDefaultModel",
 		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
 		"sourceKind": "agent_session",


### PR DESCRIPTION
## Problem

Dev CI shard 2 fails on current dev (`20b0aedf`, run 30383265286 — and on every earlier completed run):

```
Pending review source seam: agent_session:resolveConfiguredDefaultModel.
Add it to SEAM_TO_SDK or LOCKED_EXCLUSIONS.
(fail) SDK operation inventory > accepts the committed generated matrix
```

Independent of any PR's diff — it is the only failure in that shard.

## Attribution

PR #3293 commit `6bb42286f` ("add ask mode for resume model prompt in TUI") added `AgentSession.resolveConfiguredDefaultModel()` without classifying it in the SDK operation inventory. The generator **fails closed** on any unreviewed seam, so the committed artifact drifted from `OPERATIONS`.

## Fix

Classified as a locked exclusion, matching its **two siblings from the same feature** — `getSessionDefaultModelSelector` and `recordResumeDefaultModel` — which carry the byte-identical rationale.

Justification for `exclude` over `include`: the method resolves what `modelRoles.default` currently points to, for the TUI's `session.resumeModelBehavior: "ask"` prompt. It is a local read over the **already-reviewed** model-role resolution path, takes no argument, and exposes no new capability. Publishing it as an SDK operation would widen the protocol surface without adding capability.

Artifact regenerated by the generator; no hand edits.

## Verification on exact dev `20b0aedf`

- `--check` exits **0** (was 1); `pending=0`
- **`include` stays 176** — no seam newly exposed to the public SDK; only `exclude` 155 → 156 and `pending` 1 → 0
- Generated diff additive: **+11 / −0**, placed adjacent to its sibling record
- Regenerating twice is a no-op → artifact is **idempotent**
- `sdk-operation-inventory.test.ts`: **17 pass / 0 fail** (was 16 pass / 1 fail)
- `sdk-operation-matrix.test.ts` (other consumer of the artifact): **4 pass / 0 fail**
- biome clean

## Scope

Exactly 1 commit, 2 files, no integration baggage. Deliberately does **not** touch the five SelectorController session-deletion/viewport/migration-fence failures in shard 7 — a separate behavioral contract under separate ownership.