### PR TITLE
fix(coding-agent): keep ralplan writes in owner session

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Coordinator MCP now reconciles canonical structured questions from every workflow stage without misclassifying row-level gate diagnostics as malformed pagination, and unwraps accepted SDK gate-answer envelopes before reporting the terminal resolution.
 - Queued named tool choices are revalidated against the live model and active tool set before each request, preventing first-turn eager todo, resolve, or yield flows from sending a stale forced choice after preflight tool changes.
+- Ralplan role-agent writes now resolve an existing run's immutable owner session instead of creating workflow state and artifacts under each Planner/Architect/Critic transcript session; conflicting explicit session ids fail closed, and receipts expose the owner `session_id`.
 - Subagent task panels now show the fast-mode glyph for the resolved provider in both live and completed states (#3402).
 - Auto-retry now strips the whole trailing run of failed assistant attempts before continuing. A turn wedged by an `invalid_prompt` repair leaves two error assistant messages behind, and dropping only the last one left an assistant tail that `agent.continue()` refuses, so the retry died with "Retry continuation failed to start" and the turn was lost.
 

--- a/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/ralplan/SKILL.md
@@ -41,16 +41,18 @@ Persist planning artifacts and handoffs through the ralplan CLI writer, never di
 Direct `write`, `edit`, or `ast_edit` calls against `.gjc/_session-{sessionid}/specs`, `.gjc/_session-{sessionid}/plans`, `.gjc/_session-{sessionid}/state`, or any other `.gjc/` path are forbidden unless an explicit force override is active.
 
 ```bash
-gjc ralplan --write --stage <type> --stage_n <N> --artifact "markdown file path or markdown string"
+gjc ralplan --write --session-id <owner-session-id> --run-id <run-id> --stage <type> --stage_n <N> --artifact "markdown file path or markdown string"
 # restricted role agents use:
-gjc ralplan --write --stage <type> --stage_n <N> --artifact-env GJC_RALPLAN_ARTIFACT
+gjc ralplan --write --session-id <owner-session-id> --run-id <run-id> --stage <type> --stage_n <N> --artifact-env GJC_RALPLAN_ARTIFACT
 ```
 
 Use stages `planner`, `architect`, `critic`, `revision`, `post-interview`, `adr`, or `final`; increment `--stage_n` each consensus pass. The writer accepts inline markdown, an artifact path prepared outside `.gjc/`, or `--artifact-env GJC_RALPLAN_ARTIFACT`, persists `stage-<NN>-<stage>.md` plus `index.jsonl` under `.gjc/_session-{sessionid}/plans/ralplan/<run-id>/`, and copies `final` to `pending-approval.md`. Ralplan mutation blocking is enforced in code; use temp directories (`os.tmpdir()`/`$TMPDIR`, `/tmp`, `/var/tmp`) only for oversized scratch artifacts, never the repo or `.gjc/`. Staging via the `write` tool or a quoted-delimiter bash heredoc (`cat > /tmp/plan.md <<'EOF' … EOF`) into those temp roots is tolerated by the planning-phase guard.
 
 Restricted read-only role agents (`planner`, `architect`, `critic`) must pass markdown through `GJC_RALPLAN_ARTIFACT` with `--artifact-env GJC_RALPLAN_ARTIFACT`; their restricted bash environment disables artifact file-path ingestion.
 
-RECEIPT-ONLY guideline: role agents (`planner`, `architect`, and `critic`) persist durable outputs via `gjc ralplan --write` and return ONLY the receipt fields (`run_id`, `path`, `sha256`) plus verdict/status routing fields; include `stage` and `stage_n` when available, and never return the full persisted body.
+RECEIPT-ONLY guideline: role agents (`planner`, `architect`, and `critic`) persist durable outputs via `gjc ralplan --write` and return ONLY the receipt fields (`session_id`, `run_id`, `path`, `sha256`) plus verdict/status routing fields; include `stage` and `stage_n` when available, and never return the full persisted body.
+
+The ralplan seed/write receipt's `session_id` is the immutable workflow owner session and `run_id` is the run identity. Include both in every Planner/Architect/Critic assignment and every parent-side revision/post-interview/ADR/final write. A role subagent's own session id is transcript/resume identity only and MUST NOT own ralplan state or artifacts.
 
 This skill runs GJC planning in consensus mode for the provided arguments.
 

--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -1,4 +1,5 @@
 import { createHash, randomBytes } from "node:crypto";
+import type { Dirent } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getConfigRootDir } from "@gajae-code/utils";
@@ -22,7 +23,7 @@ import {
 	RepositoryBindingError,
 } from "./repository-binding";
 import { GJC_RALPLAN_ARTIFACT_ENV, isRestrictedRoleAgentBash } from "./restricted-role-agent-bash";
-import { gjcRoot, modeStatePath, sessionPlansDir } from "./session-layout";
+import { gjcRoot, modeStatePath, sessionIdFromDirName, sessionPlansDir } from "./session-layout";
 import { resolveGjcSessionForWrite, writeSessionActivityMarker } from "./session-resolution";
 import { migrateWorkflowState } from "./state-migrations";
 import { runNativeStateCommand } from "./state-runtime";
@@ -1342,6 +1343,69 @@ async function persistRalplanFinalAdmission(
 	);
 }
 
+async function findExistingRalplanRunOwners(cwd: string, runId: string): Promise<string[]> {
+	let entries: Dirent<string>[];
+	try {
+		entries = await fs.readdir(gjcRoot(cwd), { withFileTypes: true });
+	} catch (error) {
+		const err = error as NodeJS.ErrnoException;
+		if (err.code === "ENOENT" || err.code === "ENOTDIR") return [];
+		throw error;
+	}
+
+	const owners = await Promise.all(
+		entries.map(async entry => {
+			if (!entry.isDirectory()) return undefined;
+			const sessionId = sessionIdFromDirName(entry.name);
+			if (!sessionId) return undefined;
+
+			const stateRead = await readExistingStateForMutation(ralplanStatePath(cwd, sessionId));
+			const stateOwnsRun =
+				stateRead.kind === "valid" &&
+				typeof stateRead.value.run_id === "string" &&
+				stateRead.value.run_id.trim() === runId;
+			if (stateOwnsRun) return sessionId;
+
+			try {
+				const stat = await fs.stat(path.join(sessionPlansDir(cwd, sessionId), "ralplan", runId));
+				return stat.isDirectory() ? sessionId : undefined;
+			} catch (error) {
+				const err = error as NodeJS.ErrnoException;
+				if (err.code === "ENOENT" || err.code === "ENOTDIR") return undefined;
+				throw error;
+			}
+		}),
+	);
+	return owners.filter((owner): owner is string => owner !== undefined).sort();
+}
+
+async function resolveArtifactSessionId(args: readonly string[], cwd: string, explicitRunId: string | undefined) {
+	const flagSessionId = flagValue(args, "--session-id");
+	const currentSession = resolveGjcSessionForWrite(cwd, {
+		flagValue: flagSessionId,
+		envSessionId: process.env.GJC_SESSION_ID,
+	});
+	if (!explicitRunId) return currentSession.gjcSessionId;
+
+	const owners = await findExistingRalplanRunOwners(cwd, explicitRunId);
+	if (owners.length === 0) return currentSession.gjcSessionId;
+	if (owners.length > 1) {
+		throw new RalplanCommandError(
+			2,
+			`ralplan run ${explicitRunId} has multiple owner sessions (${owners.join(", ")}); repair the fragmented run before writing`,
+		);
+	}
+
+	const ownerSessionId = owners[0]!;
+	if (flagSessionId !== undefined && currentSession.gjcSessionId !== ownerSessionId) {
+		throw new RalplanCommandError(
+			2,
+			`ralplan run ${explicitRunId} is owned by session ${ownerSessionId}, not ${currentSession.gjcSessionId}`,
+		);
+	}
+	return ownerSessionId;
+}
+
 async function resolveArtifactArgs(args: readonly string[], cwd: string): Promise<ResolvedArtifactArgs> {
 	const stage = flagValue(args, "--stage");
 	if (!stage) throw new RalplanCommandError(2, "--stage is required for ralplan --write");
@@ -1362,20 +1426,18 @@ async function resolveArtifactArgs(args: readonly string[], cwd: string): Promis
 		throw new RalplanCommandError(2, `--artifact-env must be ${GJC_RALPLAN_ARTIFACT_ENV}`);
 	}
 
-	const session = resolveGjcSessionForWrite(cwd, {
-		flagValue: flagValue(args, "--session-id"),
-		envSessionId: process.env.GJC_SESSION_ID,
-	});
-	const sessionId = session.gjcSessionId;
+	const explicitRunId = flagValue(args, "--run-id")?.trim();
+	if (explicitRunId) assertSafePathComponent(explicitRunId, "run-id");
+
+	const sessionId = await resolveArtifactSessionId(args, cwd, explicitRunId);
 	assertSafePathComponent(sessionId, "session-id");
 	const sessionIdRaw = sessionId;
 
 	// Precedence for run_id:
 	//   1. explicit --run-id flag
-	//   2. existing run_id field in .gjc/state[/sessions/<id>]/ralplan-state.json
-	//   3. explicit --session-id flag (use as run id)
+	//   2. existing run_id field in the resolved owner session's ralplan state
+	//   3. resolved owner session id
 	//   4. freshly generated default run id
-	const explicitRunId = flagValue(args, "--run-id")?.trim();
 	const runId = explicitRunId || (await readActiveRunId(cwd, sessionId)) || sessionIdRaw || defaultRunId();
 	assertSafePathComponent(runId, "run-id");
 
@@ -1967,6 +2029,7 @@ async function handleArtifactWrite(args: readonly string[], cwd: string): Promis
 			: undefined;
 
 	const payload: Record<string, unknown> = {
+		session_id: resolved.sessionId,
 		run_id: persisted.runId,
 		path: persisted.path,
 		stage: persisted.stage,
@@ -2009,6 +2072,7 @@ async function buildDeduplicatedResult(
 	persistedRoleState?: PersistedRoleStateUpdate,
 ): Promise<RalplanCommandResult> {
 	const payload: Record<string, unknown> = {
+		session_id: resolved.sessionId,
 		run_id: resolved.runId,
 		path: existing.path,
 		stage: resolved.stage,
@@ -2180,6 +2244,7 @@ async function handleConsensusHandoff(args: readonly string[], cwd: string): Pro
 	});
 
 	const summary = {
+		session_id: resolved.sessionId,
 		skill: "ralplan",
 		mode,
 		state_path: statePath,

--- a/packages/coding-agent/src/prompts/agent-fragments/ralplan-persistence.md
+++ b/packages/coding-agent/src/prompts/agent-fragments/ralplan-persistence.md
@@ -1,6 +1,7 @@
 Persistence (ralplan runs only):
-- Only when the assignment references a ralplan stage or `stage_n`, persist the full artifact through:
+- Only when the assignment references a ralplan stage or `stage_n`, it must also provide the ralplan owner `session_id` and `run_id`. If either identifier is missing, do not persist; return a compact error asking the caller to supply both.
+- Persist the full artifact through:
 
-  gjc ralplan --write --stage {{stage}} --stage_n <N> --artifact-env GJC_RALPLAN_ARTIFACT --json
+  gjc ralplan --write --session-id <owner-session-id> --run-id <run-id> --stage {{stage}} --stage_n <N> --artifact-env GJC_RALPLAN_ARTIFACT --json
 
-  Use the assignment-provided `stage_n`; on a duplicate-write error retry with the incremented N. Return the write receipt (`run_id`, `path`, `sha256`, `stage`, `stage_n`) and the role's compact verdict only. Otherwise, do not call `gjc ralplan --write`; return the full result in `yield.result.data`.
+  Use the assignment-provided owner `session_id`, `run_id`, and `stage_n`; never substitute the role subagent's own session id. On a duplicate-write error retry with the incremented N. Return the write receipt (`session_id`, `run_id`, `path`, `sha256`, `stage`, `stage_n`) and the role's compact verdict only. Otherwise, do not call `gjc ralplan --write`; return the full result in `yield.result.data`.

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -594,13 +594,16 @@ Project executor override body.
 		expect(ralplan).toBeDefined();
 		const content = ralplan?.content ?? "";
 
-		expect(content).toContain("gjc ralplan --write --stage <type> --stage_n <N> --artifact");
+		expect(content).toContain(
+			"gjc ralplan --write --session-id <owner-session-id> --run-id <run-id> --stage <type> --stage_n <N> --artifact",
+		);
 		expect(content).toContain("--stage planner");
 		expect(content).toContain("--stage architect");
 		expect(content).toContain("--stage critic");
 		expect(content).toContain("do not directly edit `.gjc/_session-{sessionid}/plans`");
 		expect(content).toContain("gjc state clear --force --mode ralplan");
 		expect(content).toContain('workflowGate: { stage: "ralplan", kind: "approval" }');
+		expect(content).toContain("A role subagent's own session id is transcript/resume identity only");
 		expect(content).toContain("RPC/headless clients receive a `ralplan`/`approval` workflow gate");
 		expect(content).toContain(
 			"Direct `write`, `edit`, or `ast_edit` calls against `.gjc/_session-{sessionid}/specs`, `.gjc/_session-{sessionid}/plans`, `.gjc/_session-{sessionid}/state`, or any other `.gjc/` path are forbidden",

--- a/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts
@@ -346,6 +346,95 @@ describe("native gjc ralplan runtime — --write artifact path", () => {
 		expect(JSON.parse(indexLine).sha256).toBe(payload.sha256);
 	});
 
+	it("keeps role-subagent writes in the seeded owner session", async () => {
+		const root = await tempDir();
+		const ownerSessionId = "owner-session";
+		const childSessionId = "planner-subagent-session";
+		const seed = await runNativeRalplanCommand(
+			["--session-id", ownerSessionId, "--json", "plan without fragmenting artifacts"],
+			root,
+		);
+		expect(seed.status).toBe(0);
+		const seedReceipt = JSON.parse(seed.stdout ?? "{}") as { session_id: string; run_id: string };
+		expect(seedReceipt).toMatchObject({ session_id: ownerSessionId, run_id: ownerSessionId });
+
+		const previousSessionId = process.env.GJC_SESSION_ID;
+		process.env.GJC_SESSION_ID = childSessionId;
+		try {
+			const result = await runNativeRalplanCommand(
+				[
+					"--write",
+					"--stage",
+					"planner",
+					"--stage_n",
+					"1",
+					"--artifact",
+					"# Owner-scoped plan",
+					"--run-id",
+					seedReceipt.run_id,
+					"--json",
+				],
+				root,
+			);
+			expect(result.status).toBe(0);
+			expect(JSON.parse(result.stdout ?? "{}")).toMatchObject({
+				session_id: ownerSessionId,
+				run_id: seedReceipt.run_id,
+			});
+		} finally {
+			process.env.GJC_SESSION_ID = previousSessionId;
+		}
+
+		const ownerArtifact = path.join(
+			sessionPlansDir(root, ownerSessionId),
+			"ralplan",
+			seedReceipt.run_id,
+			"stage-01-planner.md",
+		);
+		const childArtifact = path.join(
+			sessionPlansDir(root, childSessionId),
+			"ralplan",
+			seedReceipt.run_id,
+			"stage-01-planner.md",
+		);
+		expect(await fs.readFile(ownerArtifact, "utf-8")).toBe("# Owner-scoped plan\n");
+		expect(existsSync(childArtifact)).toBe(false);
+		expect(existsSync(modeStatePath(root, childSessionId, "ralplan"))).toBe(false);
+	});
+
+	it("rejects an explicit session that conflicts with an existing run owner", async () => {
+		const root = await tempDir();
+		const ownerSessionId = "owner-session";
+		const childSessionId = "critic-subagent-session";
+		const seed = await runNativeRalplanCommand(
+			["--session-id", ownerSessionId, "--json", "preserve immutable run ownership"],
+			root,
+		);
+		const { run_id: runId } = JSON.parse(seed.stdout ?? "{}") as { run_id: string };
+
+		const result = await runNativeRalplanCommand(
+			[
+				"--write",
+				"--session-id",
+				childSessionId,
+				"--run-id",
+				runId,
+				"--stage",
+				"critic",
+				"--stage_n",
+				"1",
+				"--artifact",
+				"# Critic",
+				"--json",
+			],
+			root,
+		);
+
+		expect(result.status).toBe(2);
+		expect(result.stderr).toContain(`run ${runId} is owned by session ${ownerSessionId}, not ${childSessionId}`);
+		expect(existsSync(modeStatePath(root, childSessionId, "ralplan"))).toBe(false);
+	});
+
 	it("--artifact <file> reads contents from disk", async () => {
 		const root = await tempDir();
 		const artifactPath = path.join(root, "draft.md");


### PR DESCRIPTION
## What

Keep all artifacts and state for a ralplan run under its immutable owner session, even when Planner/Architect/Critic role agents execute writes with their own `GJC_SESSION_ID`.

- Resolve an explicit `run_id` to an existing owner by seeded ralplan state or run artifacts.
- Reject conflicting explicit owners and already-fragmented ambiguous runs.
- Return `session_id` in seed, write, and deduplicated receipts.
- Require owner `session_id` and `run_id` in role-agent persistence assignments.
- Add runtime and bundled-definition regressions.

## Why

Role subagents have distinct transcript sessions. `gjc ralplan --write --run-id ...` previously preferred each role's ambient session, scattering one run across multiple `.gjc/_session-*` roots. Besides making the run difficult to observe, this split each session's `index.jsonl`, allowing iteration/review budget and join accounting to miss stages written by other roles.

## Testing

- `bun test packages/coding-agent/test/gjc-runtime/ralplan-runtime.test.ts packages/coding-agent/test/ralplan-decision-artifacts.test.ts packages/coding-agent/test/default-gjc-definitions.test.ts` (138 pass)
- `bun --cwd=packages/coding-agent run check`
- CLI smoke: seeded with `GJC_SESSION_ID=smoke-owner`, wrote from `GJC_SESSION_ID=smoke-child`, and confirmed only `.gjc/_session-smoke-owner` was created.

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:dedb295634a4161dc163ef1f8823b1bce3bd30f3 reviewer:human evidence:local-command
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit