### PR TITLE
fix(prompts): honor explicit worktree delegation requests

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -26,6 +26,7 @@ Optimize for correctness first, maintainability second, and brevity third. Prefe
 - Clear work with non-trivial architecture or sequencing risk uses `/skill:ralplan --deliberate`; reconciliation must persist its final receipt before choosing approval or an admitted handoff. A valid non-off final runtime receipt enters the existing handoff chain; otherwise it stops pending approval.
 - Use `/skill:ultragoal` for durable goal ledgers and `/skill:team` for approved coordinated persistent work.
 - Delegate large implementation slices to `executor`; use `planner`, `architect`, or `critic` for bounded planning and review.
+- An explicit user request to use a worktree (for example, "use worktree") overrides direct editing: delegate implementation through `task` with `isolated: true`. This is the in-session counterpart of launching `gjc --worktree`; if task isolation is unavailable, report that conflict instead of editing in the parent session.
 - Active skills are authoritative: never ignore an invoked skill; read the full skill text and follow it exactly.
 - Before explicit execution approval or a valid non-off ralplan final runtime receipt, planning and interview workflows NEVER edit product source, run mutating shell commands, commit, push, open PRs, or delegate implementation.
 </routing>

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -28,7 +28,7 @@ Subagents have no conversation history. Every fact, file path, and direction the
 {{#if independentMode}}- `.inheritContext`: independent mode cannot inherit parent conversation. Omit it or set `"none"`; any non-`none` value is rejected before scheduling.{{/if}}
 {{#if customSchemaEnabled}}- `schema`: JTD schema for expected structured output (do not put format rules in assignments){{/if}}
 - `spawnPlan` (optional): required before any batch with more than 4 tasks; include whyParallel, whyNotLocal, independence, expectedReceiptShape, and maxInlineTokens.
-{{#if isolationEnabled}}- `isolated`: run in isolated env; use when tasks edit overlapping files{{/if}}
+{{#if isolationEnabled}}- `isolated`: run in an isolated environment; REQUIRED when the user explicitly requests a worktree (for example, "use worktree"), and use when tasks edit overlapping files{{/if}}
 </parameters>
 
 <rules>

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -488,12 +488,14 @@ Project executor override body.
 		expect(routing).toContain("`/skill:ultragoal`");
 		expect(routing).toContain("`/skill:team`");
 		expect(routing).toContain("Delegate large implementation slices to `executor`");
+		expect(routing).toContain('explicit user request to use a worktree (for example, "use worktree")');
+		expect(routing).toContain("delegate implementation through `task` with `isolated: true`");
 		expect(routing).toContain("read the full skill text and follow it exactly");
 		expect(routing).toContain("Before explicit execution approval or a valid non-off ralplan final runtime receipt");
 		expect(routing).toContain(
 			"reconciliation must persist its final receipt before choosing approval or an admitted handoff",
 		);
-		expect(routing.split("\n").filter(line => line.startsWith("-"))).toHaveLength(9);
+		expect(routing.split("\n").filter(line => line.startsWith("-"))).toHaveLength(10);
 		expect(decomposition).toMatch(/skip it for one-step or obvious two-step fixes/i);
 	});
 

--- a/packages/coding-agent/test/system-prompt-templates.test.ts
+++ b/packages/coding-agent/test/system-prompt-templates.test.ts
@@ -281,6 +281,16 @@ describe("system Handlebars prompt templates", () => {
 		expect(rendered).toContain("Clear, low-risk implementation requests use direct tools");
 		expect(rendered).toContain("Vague requirements use `/skill:deep-interview`");
 	});
+	test("system-prompt routes explicit worktree requests through isolated delegation", async () => {
+		const templatePath = path.join(systemPromptsDir, "system-prompt.md");
+		const template = await Bun.file(templatePath).text();
+		const rendered = prompt.render(template, baseRenderContext);
+
+		expect(rendered).toContain('explicit user request to use a worktree (for example, "use worktree")');
+		expect(rendered).toContain("delegate implementation through `task` with `isolated: true`");
+		expect(rendered).toContain("in-session counterpart of launching `gjc --worktree`");
+		expect(rendered).toContain("report that conflict instead of editing in the parent session");
+	});
 
 	test("keeps system and project as separate ordered blocks; volatile facts excluded from stable prefix", async () => {
 		await withTempDir(async dir => {

--- a/packages/coding-agent/test/tools/task-simple-mode.test.ts
+++ b/packages/coding-agent/test/tools/task-simple-mode.test.ts
@@ -110,6 +110,18 @@ describe("task.simple", () => {
 			expect(properties.spawnPlan).toBeDefined();
 		}
 	});
+	it("documents explicit worktree requests as isolated delegation", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+			agents: TEST_AGENTS,
+			projectAgentsDir: null,
+		});
+
+		const tool = await TaskTool.create(createSession({ "task.isolation.mode": "auto" }));
+
+		expect(tool.description).toContain(
+			'REQUIRED when the user explicitly requests a worktree (for example, "use worktree")',
+		);
+	});
 	it("hides IRC guidance when the IRC tool is not available", async () => {
 		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
 			agents: TEST_AGENTS,


### PR DESCRIPTION
## Summary

- treat explicit worktree wording such as `use worktree` as an override of direct editing
- route implementation through `task` with `isolated: true`, matching the in-session pattern of `gjc --worktree`
- fail closed when task isolation is unavailable instead of silently editing the parent session
- document the same contract in the task tool prompt and add regression coverage

## Verification

- `bun test packages/coding-agent/test/system-prompt-templates.test.ts packages/coding-agent/test/default-gjc-definitions.test.ts packages/coding-agent/test/tools/task-simple-mode.test.ts` (58 pass)
- `bun --cwd=packages/coding-agent run check`
- `bun scripts/check-visible-definitions.ts`
- `bun scripts/verify-g002-gates.ts`
- `bun scripts/rebrand-inventory.ts --strict`
- focused `biome check` and `git diff --check`

Signed-off-by: Probe Park <probe@users.noreply.github.com>