### PR TITLE
fix: handle stale Codex named tool choices

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Provider streams now surface first-event watchdog expiry as a typed timeout so callers can apply bounded retry policy without parsing error prose.
+- Codex named-tool requests now recognize provider `Tool choice '<name>' not found in 'tools' parameter` errors as runtime capability failures and retry once without forcing the choice.
 
 ## [0.12.0] - 2026-07-28
 

--- a/packages/ai/src/utils/tool-choice-capability.ts
+++ b/packages/ai/src/utils/tool-choice-capability.ts
@@ -175,7 +175,8 @@ export function isForcedToolChoiceUnsupportedError(error: unknown, sentForcedToo
 			message,
 		) ||
 		/forces?\s+tool\s+use.*?(not\s+compatible|incompatible|not\s+supported)/is.test(message) ||
-		/does\s+not\s+support\s+forced\s+tool[_\s-]?choices?/is.test(message)
+		/does\s+not\s+support\s+forced\s+tool[_\s-]?choices?/is.test(message) ||
+		/tool[_\s-]?choices?\s+['"`][^'"`\r\n]+['"`]\s+not\s+found\s+in\s+['"`]tools['"`]\s+parameter\b/is.test(message)
 	);
 }
 

--- a/packages/ai/test/openai-codex-responses-tool-choice.test.ts
+++ b/packages/ai/test/openai-codex-responses-tool-choice.test.ts
@@ -105,29 +105,34 @@ describe("OpenAI Codex responses tool choice capability", () => {
 		expect(payload?.tools).toEqual(expect.any(Array));
 	});
 
-	it("retries once without forced tool_choice on semantic 400 and records runtime incapability", async () => {
+	it("retries once when Codex rejects a named tool choice missing from its tool list", async () => {
 		const bodies: Record<string, unknown>[] = [];
 		const testModel = model({ id: "runtime-codex" });
+		const todoContext = {
+			...testContext,
+			tools: [{ ...testContext.tools![0]!, name: "todo_write" }],
+		};
 		global.fetch = Object.assign(
 			async (_input: string | URL | Request, init?: RequestInit) => {
 				bodies.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
 				return bodies.length === 1
-					? createErrorResponse("tool_choice forces tool use is not compatible with this model")
+					? createErrorResponse("Tool choice 'todo_write' not found in 'tools' parameter.")
 					: okResponse(testModel.id);
 			},
 			{ preconnect: originalFetch.preconnect },
 		);
-		const stream = streamOpenAICodexResponses(testModel, testContext, {
+		const stream = streamOpenAICodexResponses(testModel, todoContext, {
 			apiKey: codexToken,
 			preferWebsockets: false,
-			toolChoice: { type: "function", function: { name: "search" } },
+			toolChoice: { type: "function", function: { name: "todo_write" } },
 			sessionId: "session-a",
 		});
 		const events = await collectEvents(stream);
 		const result = await stream.result();
 		expect(result.stopReason).toBe("stop");
 		expect(bodies).toHaveLength(2);
-		expect(bodies[0]?.tool_choice).toEqual({ type: "function", name: "search" });
+		expect(bodies[0]?.tool_choice).toEqual({ type: "function", name: "todo_write" });
+		expect(bodies[0]?.tools).toEqual([expect.objectContaining({ type: "function", name: "todo_write" })]);
 		expect(bodies[1]?.tool_choice).toBeUndefined();
 		expect(bodies[1]?.tools).toEqual(expect.any(Array));
 		expect(bodies[1]?.prompt_cache_key).toBe(bodies[0]?.prompt_cache_key);

--- a/packages/ai/test/tool-choice-capability.test.ts
+++ b/packages/ai/test/tool-choice-capability.test.ts
@@ -169,6 +169,15 @@ describe("isForcedToolChoiceUnsupportedError", () => {
 		).toBe(true);
 	});
 
+	it("matches named tool choices rejected by the provider tool list", () => {
+		expect(
+			isForcedToolChoiceUnsupportedError(
+				statusError(400, "Tool choice 'todo_write' not found in 'tools' parameter."),
+				true,
+			),
+		).toBe(true);
+	});
+
 	it("rejects non-400 errors", () => {
 		expect(
 			isForcedToolChoiceUnsupportedError(

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Coordinator MCP now reconciles canonical structured questions from every workflow stage without misclassifying row-level gate diagnostics as malformed pagination, and unwraps accepted SDK gate-answer envelopes before reporting the terminal resolution.
+- Queued named tool choices are revalidated against the live model and active tool set before each request, preventing first-turn eager todo, resolve, or yield flows from sending a stale forced choice after preflight tool changes.
 - Subagent task panels now show the fast-mode glyph for the resolved provider in both live and completed states (#3402).
 - Auto-retry now strips the whole trailing run of failed assistant attempts before continuing. A turn wedged by an `invalid_prompt` repair leaves two error assistant messages behind, and dropping only the last one left an assistant tail that `agent.continue()` refuses, so the retry died with "Retry continuation failed to start" and the turn was lost.
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2574,7 +2574,24 @@ export class AgentSession {
 
 	/** Advance the tool-choice queue and return the next directive for the upcoming LLM call. */
 	nextToolChoice(): ToolChoice | undefined {
-		return this.#toolChoiceQueue.nextToolChoice();
+		const choice = this.#toolChoiceQueue.nextToolChoice();
+		if (!choice || typeof choice === "string") return choice;
+
+		const toolName = choice.type === "tool" ? choice.name : "function" in choice ? choice.function.name : choice.name;
+		const activeTool = this.agent.state.tools.find(
+			tool => tool.name === toolName || tool.customWireName === toolName,
+		);
+		if (!activeTool) {
+			this.#toolChoiceQueue.degradeInFlight(`Tool "${toolName}" is no longer active.`);
+			return undefined;
+		}
+
+		const refreshed = buildNamedToolChoiceResult(activeTool.name, this.model);
+		if (!refreshed.exactNamed || !refreshed.choice) {
+			this.#toolChoiceQueue.degradeInFlight(refreshed.resolved?.reason ?? "Named tool choice is unavailable.");
+			return undefined;
+		}
+		return refreshed.choice;
 	}
 
 	/**

--- a/packages/coding-agent/test/agent-session-eager-todo.test.ts
+++ b/packages/coding-agent/test/agent-session-eager-todo.test.ts
@@ -236,6 +236,50 @@ describe("AgentSession eager todo enforcement", () => {
 		expect(observedCalls[0]?.messageTexts[0]).toContain("todo_write");
 	});
 
+	it("drops the eager choice when todo_write becomes inactive before the model call", async () => {
+		session.registerBeforeAgentStartContributor(async () => {
+			await session.setActiveToolsByName(["bash"]);
+			return undefined;
+		});
+
+		await session.prompt("list all work trees");
+
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]).toEqual({
+			toolChoice: undefined,
+			toolNames: ["bash"],
+			messageRoles: ["user", "user"],
+			messageTexts: [expect.any(String), "list all work trees"],
+			lastMessageRole: "user",
+			lastMessageText: "list all work trees",
+		});
+		expect(observedCalls[0]?.messageTexts[0]).toContain("todo_write");
+	});
+
+	it("drops the eager choice when the model loses named forcing before the model call", async () => {
+		const degradedModel = {
+			...session.model!,
+			compat: { ...(session.model!.compat ?? {}), supportsForcedToolChoice: false },
+		};
+		session.registerBeforeAgentStartContributor(async () => {
+			(session.agent.state as { model?: typeof degradedModel }).model = degradedModel;
+			return undefined;
+		});
+
+		await session.prompt("list all work trees");
+
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]).toEqual({
+			toolChoice: undefined,
+			toolNames: ["todo_write", "bash"],
+			messageRoles: ["user", "user"],
+			messageTexts: [expect.any(String), "list all work trees"],
+			lastMessageRole: "user",
+			lastMessageText: "list all work trees",
+		});
+		expect(observedCalls[0]?.messageTexts[0]).toContain("todo_write");
+	});
+
 	it("initializes todos once, then continues within the same user turn", async () => {
 		scriptedResponses = [
 			createToolCallAssistantMessage("todo_write", {


### PR DESCRIPTION
## Summary
- recognize Codex's production `Tool choice '<name>' not found in 'tools' parameter` 400 as a forced-tool-choice capability failure and retry once without `tool_choice`
- revalidate queued named choices against the current model and live active-tool set before each request
- add first-turn eager `todo_write`, active-tool change, model-switch, and provider retry regression coverage

## Verification
- `bun test packages/ai/test/tool-choice-capability.test.ts packages/ai/test/tool-choice-capability.redteam.test.ts packages/ai/test/openai-codex-responses-tool-choice.test.ts packages/coding-agent/test/agent-session-eager-todo.test.ts` (96 pass)
- `bun run check:types` in `packages/coding-agent`
- `bunx biome check` on changed TypeScript files
- `git diff --check upstream/dev...HEAD`