### PR TITLE
fix(test): realign two goldens with the contracts their producers changed

### DIFF
--- a/packages/coding-agent/test/agent-session-fallback-upstream-count.e2e.test.ts
+++ b/packages/coding-agent/test/agent-session-fallback-upstream-count.e2e.test.ts
@@ -206,7 +206,14 @@ describe("AgentSession fallback upstream request counts", () => {
 	}
 
 	it("does not replay exported Alibaba lazy-stream timeouts for direct or managed-fallback requests", async () => {
-		const timeoutMessage = "Provider stream timed out while waiting for the first event";
+		// The first-event timeout message is per-API, not generic: #3046 unified the
+		// slow-provider timeout policy but gave each transport its own wording
+		// (openai-responses vs openai-completions). Pinning one literal silently
+		// asserted the pre-#3046 generic string, so derive it from the model's api.
+		const firstEventTimeoutMessage = (api: string): string =>
+			api === "openai-responses"
+				? "OpenAI responses stream timed out while waiting for the first event"
+				: "OpenAI completions stream timed out while waiting for the first event";
 		const originalTimeout = Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS;
 		Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS = "5";
 		try {
@@ -252,7 +259,7 @@ describe("AgentSession fallback upstream request counts", () => {
 					provider: model.provider,
 					api: model.api,
 					stopReason: "error",
-					errorMessage: timeoutMessage,
+					errorMessage: firstEventTimeoutMessage(model.api),
 				});
 				await session.dispose();
 				session = undefined;
@@ -293,7 +300,7 @@ describe("AgentSession fallback upstream request counts", () => {
 				role: "assistant",
 				provider: fallback.provider,
 				stopReason: "error",
-				errorMessage: timeoutMessage,
+				errorMessage: firstEventTimeoutMessage(fallback.api),
 			});
 		} finally {
 			if (originalTimeout === undefined) delete Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS;

--- a/packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts
@@ -132,6 +132,9 @@ describe("CONSUMER/KEY-FIELD MATRIX for compact handoff payloads", () => {
 			"repository_binding",
 			"created_at",
 			"pending_approval_path",
+			// #3428 (33dbf1e7c) added the configured auto-handoff admission to the
+			// final-stage receipt payload without extending this consumer key matrix.
+			"auto_handoff",
 		]);
 		expect(scrub(ralplanReceipt.stdout ?? "")).toMatchInlineSnapshot(`
 			"{
@@ -147,7 +150,13 @@ describe("CONSUMER/KEY-FIELD MATRIX for compact handoff payloads", () => {
 			    "displayPath": "/tmp/SCRUBBED"
 			  },
 			  "created_at": "<iso>",
-			  "pending_approval_path": "/tmp/SCRUBBED"
+			  "pending_approval_path": "/tmp/SCRUBBED",
+			  "auto_handoff": {
+			    "configuredTarget": "off",
+			    "effectiveTarget": "off",
+			    "degradationReason": null,
+			    "source": "default"
+			  }
 			}
 			"
 			`);


### PR DESCRIPTION
## Problem

Dev CI run 30386315507 failed two independent coding-agent shards. Both reproduce on **clean current dev `a4e6af7d`** with no local modifications, and neither is caused by the PR under test.

## shard-1 — `CONSUMER/KEY-FIELD MATRIX for compact handoff payloads`

PR #3428 (`33dbf1e7c`, "feat(ralplan): support configured auto handoff") added an `auto_handoff` admission block to the final-stage ralplan receipt payload (`ralplan-runtime.ts:1444`) but did not extend this test's consumer key matrix or its inline snapshot.

The payload change is **intentional** and correctly final-stage-scoped, so the *golden* is what is stale. Added `auto_handoff` to the `assertKeys` allowlist and regenerated the snapshot with `--update-snapshots`. Recorded diff is additive only:

```diff
-  "pending_approval_path": "/tmp/SCRUBBED"
+  "pending_approval_path": "/tmp/SCRUBBED",
+  "auto_handoff": {
+    "configuredTarget": "off",
+    "effectiveTarget": "off",
+    "degradationReason": null,
+    "source": "default"
+  }
```

## shard-4 — `does not replay exported Alibaba lazy-stream timeouts`

The test pinned a single literal — `"Provider stream timed out while waiting for the first event"` — for **both** models it exercises. #3046 ("unify slow-provider first-event timeout policy") gave each transport its own wording:

| model | api | message |
|---|---|---|
| `qwen3.8-max-preview` | `openai-responses` | `OpenAI responses stream timed out …` |
| `deepseek-v4-pro` | `openai-completions` | `OpenAI completions stream timed out …` |

One constant cannot match both, and the pinned string is a **pre-#3046 value no provider emits any more** — the assertion had silently stopped testing its intended contract. Replaced with a per-api helper; both assertion sites derive from `model.api` / `fallback.api`.

## Scope

Stale goldens only — **no product code changes**. Assertions are *realigned to the current contract, not weakened*: both remain exact-equality checks, and the key matrix still fails closed on any unexpected key.

Deliberately does **not** touch the five SelectorController session-deletion failures (canonical #3434) — separate behavioral contract, separate ownership.

## Verification on exact dev `a4e6af7d`

Before (clean dev): both `0 pass / 1 fail`. After:

- `state-handoff-thrift.test.ts`: **2 pass / 0 fail**
- `agent-session-fallback-upstream-count.e2e.test.ts`: **20 pass / 0 fail**