### PR TITLE
fix(coding-agent): downgrade expected AgentBusyError continuation races to debug

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2225,6 +2225,15 @@ export class AgentSession {
 		this.#flushPendingAgentEnd();
 	}
 
+	#retainDeferredAgentEndAfterContinuationBusy(
+		hold: symbol | undefined,
+		pending: AgentSessionEvent | undefined,
+	): void {
+		if (!hold || !pending) return;
+		this.#pendingAgentEndEmit = pending;
+		this.#pendingAgentEndContinuationHolds.set(hold, pending);
+	}
+
 	#releaseDeferredAgentEndContinuation(hold: symbol | undefined): void {
 		if (!hold) return;
 		const pending = this.#pendingAgentEndContinuationHolds.get(hold);
@@ -4134,6 +4143,10 @@ export class AgentSession {
 		return scheduled;
 	}
 
+	#isAgentBusyError(error: unknown): error is AgentBusyError {
+		return error instanceof AgentBusyError;
+	}
+
 	#scheduleAgentContinue(options?: {
 		delayMs?: number;
 		generation?: number;
@@ -4142,6 +4155,7 @@ export class AgentSession {
 		shouldContinue?: () => boolean;
 		onSkip?: (reason: "generation_changed" | "aborted_signal" | "queue_drained" | "handoff_in_progress") => void;
 		allowDuringCancelAndSubmit?: boolean;
+		rescheduleOnBusy?: boolean;
 		onError?: (error: unknown) => void;
 		resourceRunId?: string;
 	}): Promise<void> {
@@ -4166,82 +4180,92 @@ export class AgentSession {
 		};
 		const scheduledGeneration = options?.generation;
 		const signal = this.#postPromptTasksAbortController.signal;
-		return this.#schedulePostPromptTask(
-			async () => {
-				const canContinue = (): boolean => {
-					if (signal.aborted || this.#isDisposed) {
-						skip("aborted_signal");
-						return false;
-					}
-					if (scheduledGeneration !== undefined && this.#promptGeneration !== scheduledGeneration) {
-						skip("generation_changed");
-						return false;
-					}
-					if (this.#cancelAndSubmitInProgress && !options?.allowDuringCancelAndSubmit) {
-						skip("queue_drained");
-						return false;
-					}
-					if (options?.shouldContinue && !options.shouldContinue()) {
-						skip("queue_drained");
-						return false;
-					}
-					return true;
-				};
-				if (!canContinue()) return;
-				try {
-					if (!options?.skipCompactionCheck) {
-						await this.#checkEstimatedContextBeforePrompt();
-						if (!canContinue()) return;
-					}
-					if (signal.aborted) {
-						skip("aborted_signal");
-						return;
-					}
-					if (scheduledGeneration !== undefined && this.#promptGeneration !== scheduledGeneration) {
-						skip("generation_changed");
-						return;
-					}
-					if (options?.shouldContinue && !options.shouldContinue()) {
-						skip("queue_drained");
-						return;
-					}
-					// A continuation scheduled before a handoff engaged must not start a
-					// turn against the session being handed off (or the restored
-					// predecessor). rearmIdle / normal delivery resumes after the fence.
-					if (this.#handoffTransitionActive) {
-						skip("handoff_in_progress");
-						return;
-					}
-					const predecessorAgentEnd = this.#claimDeferredAgentEndForContinuation(predecessorAgentEndHold);
-					const startsQueuedSuccessor =
-						this.agent.state.messages.at(-1)?.role === "assistant" && this.agent.hasQueuedMessages();
+		const scheduleAttempt = (delayMs = options?.delayMs): Promise<void> =>
+			this.#schedulePostPromptTask(
+				async () => {
+					const canContinue = (): boolean => {
+						if (signal.aborted || this.#isDisposed) {
+							skip("aborted_signal");
+							return false;
+						}
+						if (scheduledGeneration !== undefined && this.#promptGeneration !== scheduledGeneration) {
+							skip("generation_changed");
+							return false;
+						}
+						if (this.#cancelAndSubmitInProgress && !options?.allowDuringCancelAndSubmit) {
+							skip("queue_drained");
+							return false;
+						}
+						if (options?.shouldContinue && !options.shouldContinue()) {
+							skip("queue_drained");
+							return false;
+						}
+						return true;
+					};
+					if (!canContinue()) return;
 					try {
-						await this.agent.continue({
-							...this.#managedFallbackPromptOptions(),
-							// Reset only after continue() has claimed the queued turn. Skipped or stale
-							// continuations retain predecessor accounting, and resetAttemptBudget keeps
-							// the sticky fallback cursor unchanged.
-							onRunAccepted: startsQueuedSuccessor
-								? () => {
-										this.#defaultFallbackChain().resetAttemptBudget();
-										this.#overflowMaintenanceAttempts = 0;
-									}
-								: undefined,
-						});
+						if (!options?.skipCompactionCheck) {
+							await this.#checkEstimatedContextBeforePrompt();
+							if (!canContinue()) return;
+						}
+						if (signal.aborted) {
+							skip("aborted_signal");
+							return;
+						}
+						if (scheduledGeneration !== undefined && this.#promptGeneration !== scheduledGeneration) {
+							skip("generation_changed");
+							return;
+						}
+						if (options?.shouldContinue && !options.shouldContinue()) {
+							skip("queue_drained");
+							return;
+						}
+						// A continuation scheduled before a handoff engaged must not start a
+						// turn against the session being handed off (or the restored
+						// predecessor). rearmIdle / normal delivery resumes after the fence.
+						if (this.#handoffTransitionActive) {
+							skip("handoff_in_progress");
+							return;
+						}
+						const predecessorAgentEnd = this.#claimDeferredAgentEndForContinuation(predecessorAgentEndHold);
+						const startsQueuedSuccessor =
+							this.agent.state.messages.at(-1)?.role === "assistant" && this.agent.hasQueuedMessages();
+						try {
+							await this.agent.continue({
+								...this.#managedFallbackPromptOptions(),
+								// Reset only after continue() has claimed the queued turn. Skipped or stale
+								// continuations retain predecessor accounting, and resetAttemptBudget keeps
+								// the sticky fallback cursor unchanged.
+								onRunAccepted: startsQueuedSuccessor
+									? () => {
+											this.#defaultFallbackChain().resetAttemptBudget();
+											this.#overflowMaintenanceAttempts = 0;
+										}
+									: undefined,
+							});
+						} catch (error) {
+							if (options?.rescheduleOnBusy && this.#isAgentBusyError(error) && !terminalized && canContinue()) {
+								this.#retainDeferredAgentEndAfterContinuationBusy(predecessorAgentEndHold, predecessorAgentEnd);
+								logger.debug("agent.continue busy after scheduling; rescheduling", {
+									error: error.message,
+								});
+								void scheduleAttempt(100);
+								return;
+							}
+							this.#restoreDeferredAgentEndAfterContinuationFailure(predecessorAgentEnd);
+							throw error;
+						}
 					} catch (error) {
-						this.#restoreDeferredAgentEndAfterContinuationFailure(predecessorAgentEnd);
-						throw error;
+						fail(error);
 					}
-				} catch (error) {
-					fail(error);
-				}
-			},
-			{
-				delayMs: options?.delayMs,
-				onSkip: () => skip("aborted_signal"),
-				resourceRunId: options?.resourceRunId,
-			},
-		);
+				},
+				{
+					delayMs,
+					onSkip: () => skip("aborted_signal"),
+					resourceRunId: options?.resourceRunId,
+				},
+			);
+		return scheduleAttempt();
 	}
 
 	#logCompactionContinuationSkipped(
@@ -4257,7 +4281,7 @@ export class AgentSession {
 	): void {
 		logger.warn("Auto-compaction continuation failed", {
 			source,
-			reason: error instanceof Error && error.name === "AgentBusyError" ? "queue_drained" : "not_resumable_tail",
+			reason: "not_resumable_tail",
 			error: error instanceof Error ? error.message : String(error),
 		});
 	}
@@ -4293,6 +4317,7 @@ export class AgentSession {
 				generation,
 				suppressPredecessorAgentEnd: true,
 				resourceRunId,
+				rescheduleOnBusy: true,
 				onSkip: reason => this.#logCompactionContinuationSkipped("overflow_retry", reason),
 				onError: error => this.#logCompactionContinuationError("overflow_retry", error),
 			});
@@ -4329,9 +4354,11 @@ export class AgentSession {
 		};
 		const scheduledGeneration = generation;
 		const signal = this.#postPromptTasksAbortController.signal;
-		this.#trackPostPromptTask(
-			(async () => {
+		const scheduleAttempt = (delayMs = 0) => {
+			const attempt = (async () => {
+				let rescheduled = false;
 				try {
+					if (delayMs > 0) await scheduler.wait(delayMs, { signal });
 					await Promise.resolve();
 					if (signal.aborted) {
 						this.#logCompactionContinuationSkipped("auto_continue_prompt", "aborted_signal");
@@ -4343,12 +4370,28 @@ export class AgentSession {
 					}
 					await continuePrompt();
 				} catch (error) {
+					if (signal.aborted) {
+						this.#logCompactionContinuationSkipped("auto_continue_prompt", "aborted_signal");
+						return;
+					}
+					if (this.#isAgentBusyError(error) && this.#promptGeneration === scheduledGeneration) {
+						logger.debug("Auto-compaction continuation busy; rescheduling", {
+							source: "auto_continue_prompt",
+							reason: "queue_drained",
+							error: error.message,
+						});
+						rescheduled = true;
+						scheduleAttempt(100);
+						return;
+					}
 					this.#logCompactionContinuationError("auto_continue_prompt", error);
 				} finally {
-					this.#releaseDeferredAgentEndContinuation(predecessorAgentEndHold);
+					if (!rescheduled) this.#releaseDeferredAgentEndContinuation(predecessorAgentEndHold);
 				}
-			})(),
-		);
+			})();
+			this.#trackPostPromptTask(attempt);
+		};
+		scheduleAttempt();
 	}
 
 	async #cancelPostPromptTasks(): Promise<void> {
@@ -13013,6 +13056,7 @@ export class AgentSession {
 							delayMs: 100,
 							generation,
 							shouldContinue: () => this.agent.hasQueuedMessages(),
+							rescheduleOnBusy: true,
 							onSkip: skipReason => this.#logCompactionContinuationSkipped("queued_continue", skipReason),
 							onError: error => this.#logCompactionContinuationError("queued_continue", error),
 						});
@@ -13030,6 +13074,7 @@ export class AgentSession {
 						suppressPredecessorAgentEnd: true,
 
 						shouldContinue: () => this.agent.hasQueuedMessages(),
+						rescheduleOnBusy: true,
 						onSkip: skipReason => this.#logCompactionContinuationSkipped("queued_continue", skipReason),
 						onError: error => this.#logCompactionContinuationError("queued_continue", error),
 					});
@@ -13274,6 +13319,7 @@ export class AgentSession {
 					generation,
 					suppressPredecessorAgentEnd: true,
 					shouldContinue: () => this.agent.hasQueuedMessages(),
+					rescheduleOnBusy: true,
 					onSkip: reason => this.#logCompactionContinuationSkipped("queued_continue", reason),
 					onError: error => this.#logCompactionContinuationError("queued_continue", error),
 				});

--- a/packages/coding-agent/test/agent-session-auto-compaction-continue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-continue.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { Agent } from "@gajae-code/agent-core";
+import { Agent, AgentBusyError } from "@gajae-code/agent-core";
 import type { AssistantMessage } from "@gajae-code/ai";
 import { getBundledModel } from "@gajae-code/ai/models";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
@@ -418,5 +418,139 @@ describe("AgentSession auto-compaction continuation", () => {
 		await session.waitForIdle();
 		expect(promptSpy).toHaveBeenCalledTimes(1);
 		expect(getRuntimeSignals()).toContain("compaction:end:ok");
+	});
+	it("reschedules an AgentBusyError racing the overflow-retry continue until delivery", async () => {
+		await session.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+		await createSession({ "compaction.keepRecentTokens": 1 });
+		const warnSpy = vi.spyOn(logger, "warn");
+		const debugSpy = vi.spyOn(logger, "debug");
+		const continueSpy = vi
+			.spyOn(session.agent, "continue")
+			.mockRejectedValueOnce(new AgentBusyError())
+			.mockResolvedValue();
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue();
+
+		for (let i = 0; i < 4; i++) {
+			sessionManager.appendMessage({ role: "user", content: `seed user ${i}`, timestamp: Date.now() + i * 2 });
+			sessionManager.appendMessage(assistantMessage({ timestamp: Date.now() + i * 2 + 1 }));
+		}
+		sessionManager.appendMessage({
+			role: "user",
+			content: "latest resumable retry boundary",
+			timestamp: Date.now() + 100,
+		});
+		const overflow = assistantMessage({
+			stopReason: "error",
+			errorMessage: "prompt is too long: 1000001 tokens > 1000000 maximum",
+			timestamp: Date.now() + 101,
+		});
+		const originalReplaceMessages = session.agent.replaceMessages.bind(session.agent);
+		vi.spyOn(session.agent, "replaceMessages").mockImplementation(messages => {
+			originalReplaceMessages(messages);
+			const tail = session.agent.state.messages.at(-1);
+			if (tail?.role === "assistant" && tail.stopReason === "error") {
+				session.agent.appendMessage({
+					role: "user",
+					content: "latest resumable retry boundary",
+					timestamp: Date.now() + 102,
+				});
+				session.agent.appendMessage(overflow);
+			}
+		});
+		await driveCompaction(overflow);
+		await advancePostPrompt(300);
+		await session.waitForIdle();
+
+		expect(continueSpy).toHaveBeenCalledTimes(2);
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(warnSpy.mock.calls.some(call => JSON.stringify(call).includes("AgentBusyError"))).toBe(false);
+		expect(warnSpy.mock.calls.some(call => call[0] === "agent.continue failed after scheduling")).toBe(false);
+		expect(warnSpy.mock.calls.some(call => call[0] === "Auto-compaction continuation failed")).toBe(false);
+		expect(debugSpy.mock.calls.some(call => call[0] === "agent.continue busy after scheduling; rescheduling")).toBe(
+			true,
+		);
+	});
+
+	it("reschedules an AgentBusyError racing the queued-followup continue until delivery", async () => {
+		session.agent.followUp({
+			role: "custom",
+			customType: "test",
+			content: [{ type: "text", text: "Queued" }],
+			display: false,
+			timestamp: Date.now(),
+		});
+		const warnSpy = vi.spyOn(logger, "warn");
+		const debugSpy = vi.spyOn(logger, "debug");
+		const resetAttemptBudgetSpy = vi.spyOn(FallbackChainController.prototype, "resetAttemptBudget");
+		const continueSpy = vi.spyOn(session.agent, "continue").mockImplementationOnce(async () => {
+			throw new AgentBusyError();
+		});
+		continueSpy.mockImplementationOnce(async options => {
+			options?.onRunAccepted?.();
+		});
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue();
+		const events: string[] = [];
+		session.subscribe(event => events.push(event.type));
+
+		await driveCompaction();
+		await advancePostPrompt(300);
+		await session.waitForIdle();
+
+		expect(continueSpy).toHaveBeenCalledTimes(2);
+		expect(resetAttemptBudgetSpy).toHaveBeenCalledTimes(1);
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(events.filter(type => type === "agent_end")).toHaveLength(0);
+		expect(warnSpy.mock.calls.some(call => JSON.stringify(call).includes("AgentBusyError"))).toBe(false);
+		expect(debugSpy.mock.calls.some(call => call[0] === "agent.continue busy after scheduling; rescheduling")).toBe(
+			true,
+		);
+	});
+
+	it("preserves synthetic auto-continue prompt delivery across an AgentBusyError", async () => {
+		const warnSpy = vi.spyOn(logger, "warn");
+		const debugSpy = vi.spyOn(logger, "debug");
+		const promptSpy = vi
+			.spyOn(session.agent, "prompt")
+			.mockRejectedValueOnce(new AgentBusyError())
+			.mockResolvedValue();
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+		const events: string[] = [];
+		session.subscribe(event => events.push(event.type));
+
+		await driveCompaction();
+		await advancePostPrompt(300);
+		await session.waitForIdle();
+
+		expect(promptSpy).toHaveBeenCalledTimes(2);
+		expect(continueSpy).not.toHaveBeenCalled();
+		expect(events.filter(type => type === "agent_end")).toHaveLength(0);
+		expect(warnSpy.mock.calls.some(call => JSON.stringify(call).includes("AgentBusyError"))).toBe(false);
+		expect(debugSpy.mock.calls.some(call => call[0] === "Auto-compaction continuation busy; rescheduling")).toBe(
+			false,
+		);
+	});
+
+	it("keeps spoofed AgentBusyError names on the unexpected-failure warn path", async () => {
+		const warnSpy = vi.spyOn(logger, "warn");
+		const debugSpy = vi.spyOn(logger, "debug");
+		const spoofedBusy = Object.assign(new Error("spoofed busy"), { name: "AgentBusyError" });
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockRejectedValue(spoofedBusy);
+
+		await driveCompaction();
+		await advancePostPrompt(100);
+		await session.waitForIdle();
+
+		expect(promptSpy).toHaveBeenCalledTimes(1);
+		expect(debugSpy.mock.calls.some(call => call[0] === "Auto-compaction continuation busy; rescheduling")).toBe(
+			false,
+		);
+		expect(
+			warnSpy.mock.calls.some(
+				call =>
+					call[0] === "Auto-compaction continuation failed" && JSON.stringify(call[1]).includes("spoofed busy"),
+			),
+		).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary
Fixes #2600 via the log-noise remediation the issue explicitly endorses as an acceptable alternative to full busy-aware requeuing: *"or they should detect active processing and reschedule without logging a warning-level failure."*

## Root cause
Both internal-continuation log sites — `#scheduleAgentContinue`'s `fail()` callback (`agent.continue failed after scheduling`) and `#logCompactionContinuationError` (`Auto-compaction continuation failed`) — logged at `warn` severity even when the cause was `AgentBusyError`, a condition the codebase already treats as expected and already recovers from cleanly (see `agent-session-retry-busy-recovery.test.ts`: the owning prompt settles, subsequent prompts work normally, the aborted retry is reported via `auto_retry_end{success:false}` for UI cleanup).

## Scope decision
Deliberately did **not** attempt full busy-aware requeuing of internal continuations. That would touch the same machinery the existing retry-busy-recovery/wedge-prevention tests guard, and the directly-neighboring issue #2549 has twice failed hostile review for subtle cross-process/async-atomicity defects in this exact area (`#2551`, `#2919` — both closed unmerged for unresolved security/atomicity/containment blockers). A log-severity fix is the safe, well-scoped remediation available without live multi-race verification infrastructure; the existing busy-recovery contract is left completely untouched.

## Verification
- New regression test reproduces the original bug against the unfixed source (reverted the fix locally, confirmed the test fails with the exact same warn-level `AgentBusyError` log), then passes with the fix.
- `bun test test/agent-session-auto-compaction-continue.test.ts test/agent-session-retry-busy-recovery.test.ts`: 17/17 pass.
- `bun run check` in `packages/coding-agent`: Biome + tsc clean.