### PR TITLE
Fix ralplan session_id handoff goldens

### DIFF
--- a/packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts
@@ -124,6 +124,7 @@ describe("CONSUMER/KEY-FIELD MATRIX for compact handoff payloads", () => {
 			displayPath: root,
 		});
 		assertKeys(ralplanReceiptPayload, [
+			"session_id",
 			"run_id",
 			"path",
 			"stage",
@@ -138,6 +139,7 @@ describe("CONSUMER/KEY-FIELD MATRIX for compact handoff payloads", () => {
 		]);
 		expect(scrub(ralplanReceipt.stdout ?? "")).toMatchInlineSnapshot(`
 			"{
+			  "session_id": "test-session",
 			  "run_id": "run-b",
 			  "path": "/tmp/SCRUBBED",
 			  "stage": "final",
@@ -172,6 +174,7 @@ describe("CONSUMER/KEY-FIELD MATRIX for compact handoff payloads", () => {
 		expect(deduplicatedPayload.deduplicated).toBe(true);
 		expect(deduplicatedPayload.repository_binding).toEqual(ralplanReceiptBinding);
 		assertKeys(deduplicatedPayload, [
+			"session_id",
 			"run_id",
 			"path",
 			"stage",
@@ -187,7 +190,7 @@ describe("CONSUMER/KEY-FIELD MATRIX for compact handoff payloads", () => {
 		const ralplanSeedPayload = parseRequiredJson(ralplanSeed.stdout, "ralplan seed stdout");
 		expect(ralplanSeedPayload.repository_binding).toEqual(ralplanReceiptBinding);
 		expect(scrub(ralplanSeed.stdout ?? "")).toMatchInlineSnapshot(`
-			"{"ok":true,"skill":"ralplan","mode":"short","state_path":"/tmp/SCRUBBED","run_id":"run-b","handoff":"/skill:ralplan","repository_binding":{"schema":"gjc.repository_binding.v1","worktreeRoot":"/tmp/SCRUBBED","commonDir":null,"displayPath":"/tmp/SCRUBBED"}}
+			"{"ok":true,"session_id":"test-session","skill":"ralplan","mode":"short","state_path":"/tmp/SCRUBBED","run_id":"run-b","handoff":"/skill:ralplan","repository_binding":{"schema":"gjc.repository_binding.v1","worktreeRoot":"/tmp/SCRUBBED","commonDir":null,"displayPath":"/tmp/SCRUBBED"}}
 			"
 			`);
 


### PR DESCRIPTION
## Summary
- Update the state-handoff thrift consumer matrix and inline goldens to include the required top-level `session_id` on ralplan compact write receipts.
- Update the ralplan seed compact golden to include top-level `session_id`.
- Producer contract left unchanged; no notification-ws-race or timeout/contract changes.

## Failure attribution
- Dev CI run 30391417182 at d6106044 failed only in `packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts` line 139 because PR #3439 added required top-level `session_id:test-session` to the ralplan compact handoff receipt while the consumer golden omitted it.

## Validation
- `bun test packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts` — 2 pass, 0 fail, 8 snapshots.
- `bunx biome check packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts` — checked 1 file, no fixes.
- `bun test packages/coding-agent/test/gjc-runtime` — 1145 pass, 0 fail.
- `bun run check:ts` — terminal non-green on unrelated pre-existing SDK rename scanner finding: `issues/21-session-resume-model-behavior-not-configurable.md:11: forbidden "src/sdk.ts"`; earlier emitted check phases and SDK receipts passed until that unrelated scanner.

Signed-off-by: Gajae CI Repair Agent <ci-repair@gajae.local>