### PR TITLE
perf(coding-agent): incrementally project observer sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Telegram notification sound can be set to all, important, or none; the reference CLI exposes this with `--sound <all|important|none>`, defaulting to all. Important (ask/idle only) and none are explicit opt-ins for quieter notifications.
 - First-event provider timeouts are configurable and replayed only by AgentSession with a bounded attempt budget, progress-aware safety checks, and measured exhaustion details.
 
+### Changed
+
+- Session Observer now incrementally projects append-only session messages and narrowly patches late tool results, avoiding repeated full-history transcript projection while preserving eager output parity and safe full-projection fallback for ambiguous source changes.
+
 ### Resume fixes
 
 - Eager todo initialization now gives the model the actual phased `todo_write` payload shape (`ops` → `init` → `list` → `phase`/`items`) instead of instructing it to send unsupported `content`, `details`, and status fields, preventing the first forced todo call from failing validation (#3403).

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -1,6 +1,6 @@
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
-import type { ToolResultMessage } from "@gajae-code/ai";
+import type { ToolCall, ToolResultMessage } from "@gajae-code/ai";
 import { matchesKey } from "@gajae-code/tui";
 import { formatDuration, formatNumber } from "@gajae-code/utils";
 import type { KeyId } from "../../config/keybindings";
@@ -19,7 +19,19 @@ import { type TranscriptViewerEntry, TranscriptViewerOverlay } from "./transcrip
 const FATAL_UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
 
 type FileIdentity = { dev: bigint; ino: bigint };
-type StableSnapshot = { identity: FileIdentity; size: number; prefix: Buffer; tail: Buffer };
+type StableSnapshot = {
+	identity: FileIdentity;
+	size: number;
+	prefix: Buffer;
+	tail: Buffer;
+	offsetReset: boolean;
+};
+type SnapshotReadResult =
+	| { status: "stable"; snapshot: StableSnapshot }
+	| { status: "unstable" }
+	| { status: "unavailable" };
+
+class UnstableSnapshotError extends Error {}
 type ObserverCache = {
 	path: string;
 	identity: FileIdentity;
@@ -27,7 +39,55 @@ type ObserverCache = {
 	prefixDigest: string;
 	entries: SessionMessageEntry[];
 	model?: string;
+	projectedCount: number;
+	projectedOutput: TranscriptViewerEntry[];
+	toolCallOutputIndex: Map<string, number>;
+	projectionSafe: boolean;
 };
+
+type ProjectionState = Pick<
+	ObserverCache,
+	"projectedCount" | "projectedOutput" | "toolCallOutputIndex" | "projectionSafe"
+>;
+type ProjectionUpdate = { state: ProjectionState; preserveLayoutCache: boolean };
+
+export const __sessionObserverProjectionCounters = {
+	enabled: false,
+	projectionFullRuns: 0,
+	projectionIncrementalRuns: 0,
+	sourceMessagesProjected: 0,
+	projectedEntriesAppended: 0,
+	resultPatchCount: 0,
+	snapshot() {
+		return {
+			projectionFullRuns: this.projectionFullRuns,
+			projectionIncrementalRuns: this.projectionIncrementalRuns,
+			sourceMessagesProjected: this.sourceMessagesProjected,
+			projectedEntriesAppended: this.projectedEntriesAppended,
+			resultPatchCount: this.resultPatchCount,
+		};
+	},
+	enable(): void {
+		this.enabled = true;
+	},
+	disable(): void {
+		this.enabled = false;
+	},
+	reset(): void {
+		this.projectionFullRuns = 0;
+		this.projectionIncrementalRuns = 0;
+		this.sourceMessagesProjected = 0;
+		this.projectedEntriesAppended = 0;
+		this.resultPatchCount = 0;
+	},
+};
+
+function recordProjectionCounter(
+	counter: keyof ReturnType<typeof __sessionObserverProjectionCounters.snapshot>,
+	amount = 1,
+): void {
+	if (__sessionObserverProjectionCounters.enabled) __sessionObserverProjectionCounters[counter] += amount;
+}
 
 /** Session-observer adapter. The shared viewer owns navigation and fold state. */
 export class SessionObserverOverlayComponent extends TranscriptViewerOverlay {
@@ -62,11 +122,21 @@ export class SessionObserverOverlayComponent extends TranscriptViewerOverlay {
 		this.#observeKeys = observeKeys;
 		this.#selectedSessionId = this.#mostRecent()?.id;
 		if (!this.#selectedSessionId) queueMicrotask(onDone);
-		this.refresh();
+		this.#refreshCurrentSource();
 	}
 
 	refreshFromRegistry(): void {
-		this.refresh();
+		this.#refreshCurrentSource();
+	}
+	#refreshCurrentSource(): void {
+		const session = this.#registry.getSessions().find(candidate => candidate.id === this.#selectedSessionId);
+		if (!session?.sessionFile) {
+			this.#clearSource();
+			this.refresh(undefined, false);
+			return;
+		}
+		const preserveLayoutCache = this.#load(session.sessionFile);
+		this.refresh(undefined, preserveLayoutCache);
 	}
 	override handleInput(keyData: string): void {
 		if (this.#observeKeys.some(key => matchesKey(keyData, key))) {
@@ -100,12 +170,10 @@ export class SessionObserverOverlayComponent extends TranscriptViewerOverlay {
 		this.#selectedSessionId = ids[(current + direction + ids.length) % ids.length];
 		this.#cache = undefined;
 		this.resetSourceState();
-		this.refresh();
+		this.#refreshCurrentSource();
 	}
 	#entries(): readonly TranscriptViewerEntry[] {
-		const session = this.#registry.getSessions().find(candidate => candidate.id === this.#selectedSessionId);
-		if (!session?.sessionFile) return [];
-		return entriesFromMessages(this.#load(session.sessionFile));
+		return this.#cache?.projectedOutput ?? [];
 	}
 	#headerLines(): string[] {
 		const session = this.#registry.getSessions().find(candidate => candidate.id === this.#selectedSessionId);
@@ -139,89 +207,240 @@ export class SessionObserverOverlayComponent extends TranscriptViewerOverlay {
 		if (progress.cost > 0) stats.push(`$${progress.cost.toFixed(2)}`);
 		return stats.length ? [theme.fg("dim", stats.join(theme.sep.dot))] : [];
 	}
-	#load(filePath: string): SessionMessageEntry[] {
+	#load(filePath: string): boolean {
 		if (this.#cache && this.#cache.path !== filePath) {
 			this.#cache = undefined;
 			this.resetSourceState();
 		}
 
 		const cache = this.#cache;
-		const snapshot = readStableSnapshot(filePath, cache?.completeOffset ?? 0);
-		if (!snapshot) {
-			// A cached offset may exceed a replaced (shorter) file's new size, in which case the
-			// offset-tail snapshot is null even though the replacement is readable. Without a
-			// render-time refresh, that null would drop the replacement entirely, so attempt one
-			// full stable snapshot at offset 0 and validate it before installing. Unreadable or
-			// invalid sources still fail closed and never keep presenting a prior file as current.
-			if (cache) {
-				const replacement = readStableSnapshot(filePath, 0);
-				const candidate = replacement ? cacheEntries(filePath, replacement) : null;
-				if (candidate) {
-					this.#cache = candidate;
-					this.resetSourceState();
-					return candidate.entries;
-				}
-				this.#clearSource();
-			}
-			return [];
+		const read = readStableSnapshot(filePath, cache?.completeOffset ?? 0);
+		if (read.status === "unstable") return cache !== undefined;
+		if (read.status === "unavailable") {
+			if (cache) this.#clearSource();
+			return false;
 		}
-
+		const snapshot = read.snapshot;
 		const canAppend =
 			cache &&
+			!snapshot.offsetReset &&
 			sameIdentity(cache.identity, snapshot.identity) &&
 			snapshot.size >= cache.completeOffset &&
 			digest(snapshot.prefix) === cache.prefixDigest;
 		if (canAppend) return this.#appendStable(cache, snapshot);
 
-		// A changed fd identity, changed committed bytes, or a shrink is a replacement.
-		// Validate the entire candidate before it replaces the visible transcript.
-		const replacement = readStableSnapshot(filePath, 0);
-		if (!replacement) {
-			this.#clearSource();
-			return [];
-		}
-		const candidate = cacheEntries(filePath, replacement);
+		const candidate = cacheEntries(filePath, asFullSnapshot(snapshot));
 		if (!candidate) {
 			this.#clearSource();
-			return [];
+			return false;
 		}
 		this.#cache = candidate;
 		if (cache) this.resetSourceState();
-		return candidate.entries;
+		return false;
 	}
-	#appendStable(cache: ObserverCache, snapshot: StableSnapshot): SessionMessageEntry[] {
+	#appendStable(cache: ObserverCache, snapshot: StableSnapshot): boolean {
 		const complete = completePrefix(snapshot.tail);
 		if (!complete) {
 			if (!isValidUtf8Prefix(snapshot.tail)) {
 				this.#clearSource();
-				return [];
+				return false;
 			}
-			return cache.entries;
+			return true;
 		}
 		const remainder = snapshot.tail.subarray(complete.bytes.length);
 		if (!isValidUtf8Prefix(remainder)) {
 			this.#clearSource();
-			return [];
+			return false;
 		}
 		const parsed = parseCompleteEntries(complete.bytes);
 		if (!parsed) {
 			this.#clearSource();
-			return [];
+			return false;
 		}
+		if (parsed.hasPatchRecords) {
+			const candidate = cacheEntries(cache.path, asFullSnapshot(snapshot));
+			if (!candidate) {
+				this.#clearSource();
+				return false;
+			}
+			this.#cache = candidate;
+			return false;
+		}
+
 		const entries = [...cache.entries, ...parsed.entries];
+		const projection = this.#appendProjection(cache, parsed.entries);
 		this.#cache = {
 			...cache,
 			completeOffset: cache.completeOffset + complete.bytes.length,
 			prefixDigest: digest(Buffer.concat([snapshot.prefix, complete.bytes])),
 			entries,
 			model: parsed.model ?? cache.model,
+			...projection.state,
 		};
-		return entries;
+		return projection.preserveLayoutCache;
+	}
+	#appendProjection(cache: ObserverCache, suffix: readonly SessionMessageEntry[]): ProjectionUpdate {
+		if (suffix.length === 0) {
+			return {
+				state: projectionState(cache),
+				preserveLayoutCache: true,
+			};
+		}
+		if (!cache.projectionSafe || cache.projectedCount !== cache.entries.length) {
+			return {
+				state: fullProjection([...cache.entries, ...suffix]),
+				preserveLayoutCache: false,
+			};
+		}
+
+		const projectedOutput = [...cache.projectedOutput];
+		const toolCallOutputIndex = new Map(cache.toolCallOutputIndex);
+		const patchedIds: string[] = [];
+		let appendedCount = 0;
+		let patchCount = 0;
+		for (const entry of suffix) {
+			const message = entry.message;
+			if (message.role === "toolResult") {
+				const index = toolCallOutputIndex.get(message.toolCallId);
+				const existing = index === undefined ? undefined : projectedOutput[index];
+				const source = existing?.payload.source;
+				const call = isToolProjectionSource(source) ? source.call : undefined;
+				if (index === undefined || !call) {
+					return {
+						state: fullProjection([...cache.entries, ...suffix]),
+						preserveLayoutCache: false,
+					};
+				}
+				projectedOutput[index] = toolEntry(call, message);
+				patchedIds.push(projectedOutput[index].id);
+				patchCount++;
+				continue;
+			}
+
+			const appended = entriesFromMessages([entry]);
+			for (const outputEntry of appended) {
+				if (outputEntry.id.startsWith("tool:")) {
+					const callId = outputEntry.id.slice("tool:".length);
+					if (toolCallOutputIndex.has(callId)) {
+						return {
+							state: fullProjection([...cache.entries, ...suffix]),
+							preserveLayoutCache: false,
+						};
+					}
+					toolCallOutputIndex.set(callId, projectedOutput.length);
+				}
+				projectedOutput.push(outputEntry);
+			}
+			appendedCount += appended.length;
+		}
+		if (patchedIds.length > 0) this.invalidateLayoutEntries(patchedIds);
+		recordProjectionCounter("projectionIncrementalRuns");
+		recordProjectionCounter("sourceMessagesProjected", suffix.length);
+		recordProjectionCounter("projectedEntriesAppended", appendedCount);
+		recordProjectionCounter("resultPatchCount", patchCount);
+		return {
+			state: {
+				projectedCount: cache.projectedCount + suffix.length,
+				projectedOutput,
+				toolCallOutputIndex,
+				projectionSafe: true,
+			},
+			preserveLayoutCache: true,
+		};
 	}
 	#clearSource(): void {
 		if (this.#cache) this.resetSourceState();
 		this.#cache = undefined;
 	}
+}
+
+type ToolProjectionSource = { call: ToolCall; result?: ToolResultMessage };
+
+function isToolProjectionSource(source: unknown): source is ToolProjectionSource {
+	if (!source || typeof source !== "object" || !("call" in source)) return false;
+	const call = source.call;
+	return Boolean(call && typeof call === "object" && "type" in call && call.type === "toolCall");
+}
+
+function projectionState(cache: ObserverCache): ProjectionState {
+	return {
+		projectedCount: cache.projectedCount,
+		projectedOutput: cache.projectedOutput,
+		toolCallOutputIndex: cache.toolCallOutputIndex,
+		projectionSafe: cache.projectionSafe,
+	};
+}
+
+function fullProjection(
+	entries: readonly SessionMessageEntry[],
+): Pick<ObserverCache, "projectedCount" | "projectedOutput" | "toolCallOutputIndex" | "projectionSafe"> {
+	const projectedOutput = entriesFromMessages(entries);
+	const toolCallOutputIndex = new Map<string, number>();
+	let projectionSafe = true;
+	const knownToolCallIds = new Set<string>();
+	const unresolvedToolResultIds = new Set<string>();
+	for (const entry of entries) {
+		const message = entry.message;
+		if (message.role === "assistant") {
+			for (const content of message.content) if (content.type === "toolCall") knownToolCallIds.add(content.id);
+		} else if (message.role === "toolResult") unresolvedToolResultIds.add(message.toolCallId);
+	}
+	for (const callId of knownToolCallIds) unresolvedToolResultIds.delete(callId);
+	if (unresolvedToolResultIds.size > 0) projectionSafe = false;
+	for (let index = 0; index < projectedOutput.length; index++) {
+		const id = projectedOutput[index].id;
+		if (!id.startsWith("tool:")) continue;
+		const callId = id.slice("tool:".length);
+		if (toolCallOutputIndex.has(callId)) projectionSafe = false;
+		else toolCallOutputIndex.set(callId, index);
+	}
+	recordProjectionCounter("projectionFullRuns");
+	recordProjectionCounter("sourceMessagesProjected", entries.length);
+	return { projectedCount: entries.length, projectedOutput, toolCallOutputIndex, projectionSafe };
+}
+
+function toolEntry(call: ToolCall, result?: ToolResultMessage): TranscriptViewerEntry {
+	const resultText =
+		result?.content
+			.filter(part => part.type === "text")
+			.map(part => part.text)
+			.join("\n")
+			.trim() ?? "";
+	const hasResult = result !== undefined;
+	const canonicalPayload = {
+		text: composeToolText({
+			name: call.name,
+			args: call.arguments,
+			intent: call.intent,
+			resultText,
+			isError: result?.isError ?? false,
+			hasResult,
+		}),
+		metadata: {
+			name: call.name,
+			arguments: call.arguments,
+			intent: call.intent,
+			resultText,
+			isError: result?.isError ?? false,
+			hasResult,
+			detailsData: result?.details,
+		},
+		source: { call, result },
+	};
+	return buildToolTranscriptEntry({
+		canonicalPayload,
+		renderDescriptor: createToolTranscriptRenderDescriptor({
+			name: call.name,
+			args: call.arguments,
+			intent: call.intent,
+			resultContent: resultText,
+			isError: result?.isError,
+			hasResult,
+			detailsData: result?.details,
+		}),
+		capabilities: { copyable: true, foldable: true, rawViewable: true },
+		identity: { id: `tool:${call.id}`, label: call.name, display: "full" },
+	});
 }
 
 /**
@@ -262,51 +481,7 @@ export function entriesFromMessages(entries: readonly SessionMessageEntry[]): Tr
 						payload: { text: content.text, metadata: {}, source: content },
 						foldable: true,
 					});
-				if (content.type === "toolCall") {
-					const result = results.get(content.id);
-					const resultText =
-						result?.content
-							.filter(part => part.type === "text")
-							.map(part => part.text)
-							.join("\n")
-							.trim() ?? "";
-					const canonicalPayload = {
-						text: composeToolText({
-							name: content.name,
-							args: content.arguments,
-							intent: content.intent,
-							resultText,
-							isError: result?.isError ?? false,
-							hasResult: results.has(content.id),
-						}),
-						metadata: {
-							name: content.name,
-							arguments: content.arguments,
-							intent: content.intent,
-							resultText,
-							isError: result?.isError ?? false,
-							hasResult: results.has(content.id),
-							detailsData: result?.details,
-						},
-						source: { call: content, result },
-					};
-					output.push(
-						buildToolTranscriptEntry({
-							canonicalPayload,
-							renderDescriptor: createToolTranscriptRenderDescriptor({
-								name: content.name,
-								args: content.arguments,
-								intent: content.intent,
-								resultContent: resultText,
-								isError: result?.isError,
-								hasResult: results.has(content.id),
-								detailsData: result?.details,
-							}),
-							capabilities: { copyable: true, foldable: true, rawViewable: true },
-							identity: { id: `tool:${content.id}`, label: content.name, display: "full" },
-						}),
-					);
-				}
+				if (content.type === "toolCall") output.push(toolEntry(content, results.get(content.id)));
 			});
 		}
 		if (message.role === "user" || message.role === "developer") {
@@ -335,15 +510,17 @@ function truncateThinking(text: string, expanded: boolean): string {
 	return text.length > limit ? `${text.slice(0, limit)}...` : text;
 }
 
-function readStableSnapshot(filePath: string, completeOffset: number): StableSnapshot | null {
+function readStableSnapshot(filePath: string, completeOffset: number): SnapshotReadResult {
 	let fd: number | undefined;
 	try {
 		fd = fs.openSync(filePath, "r");
 		const before = fs.fstatSync(fd, { bigint: true });
-		if (before.size > BigInt(Number.MAX_SAFE_INTEGER) || completeOffset > Number(before.size)) return null;
+		if (before.size > BigInt(Number.MAX_SAFE_INTEGER)) return { status: "unavailable" };
 		const size = Number(before.size);
-		const prefix = readExactly(fd, 0, completeOffset);
-		const tail = readExactly(fd, completeOffset, size - completeOffset);
+		const offsetReset = completeOffset > size;
+		const offset = offsetReset ? 0 : completeOffset;
+		const prefix = readExactly(fd, 0, offset);
+		const tail = readExactly(fd, offset, size - offset);
 		const after = fs.fstatSync(fd, { bigint: true });
 		if (
 			before.dev !== after.dev ||
@@ -352,13 +529,26 @@ function readStableSnapshot(filePath: string, completeOffset: number): StableSna
 			before.mtimeNs !== after.mtimeNs ||
 			before.ctimeNs !== after.ctimeNs
 		)
-			return null;
-		return { identity: { dev: before.dev, ino: before.ino }, size, prefix, tail };
-	} catch {
-		return null;
+			return { status: "unstable" };
+		return {
+			status: "stable",
+			snapshot: { identity: { dev: before.dev, ino: before.ino }, size, prefix, tail, offsetReset },
+		};
+	} catch (err) {
+		return err instanceof UnstableSnapshotError ? { status: "unstable" } : { status: "unavailable" };
 	} finally {
 		if (fd !== undefined) fs.closeSync(fd);
 	}
+}
+
+function asFullSnapshot(snapshot: StableSnapshot): StableSnapshot {
+	if (snapshot.prefix.length === 0) return snapshot;
+	return {
+		...snapshot,
+		prefix: Buffer.alloc(0),
+		tail: Buffer.concat([snapshot.prefix, snapshot.tail]),
+		offsetReset: true,
+	};
 }
 
 function readExactly(fd: number, position: number, length: number): Buffer {
@@ -366,7 +556,7 @@ function readExactly(fd: number, position: number, length: number): Buffer {
 	let offset = 0;
 	while (offset < length) {
 		const bytesRead = fs.readSync(fd, buffer, offset, length - offset, position + offset);
-		if (bytesRead === 0) throw new Error("Short session file read");
+		if (bytesRead === 0) throw new UnstableSnapshotError("Short session file read");
 		offset += bytesRead;
 	}
 	return buffer;
@@ -385,14 +575,28 @@ function completePrefix(bytes: Buffer): { bytes: Buffer } | undefined {
 	return newline < 0 ? undefined : { bytes: bytes.subarray(0, newline + 1) };
 }
 
-function parseCompleteEntries(bytes: Buffer): { entries: SessionMessageEntry[]; model?: string } | null {
+function parseCompleteEntries(
+	bytes: Buffer,
+): { entries: SessionMessageEntry[]; model?: string; hasPatchRecords: boolean } | null {
 	try {
 		const text = FATAL_UTF8_DECODER.decode(bytes);
-		for (const line of text.split("\n")) if (line.trim()) JSON.parse(line);
+		let hasPatchRecords = false;
+		for (const line of text.split("\n")) {
+			if (!line.trim()) continue;
+			const record: unknown = JSON.parse(line);
+			if (
+				record !== null &&
+				typeof record === "object" &&
+				"type" in record &&
+				(record.type === "entry_patch" || record.type === "header_patch")
+			)
+				hasPatchRecords = true;
+		}
 		const parsed = parseSessionEntries(text);
 		return {
 			entries: parsed.filter((entry): entry is SessionMessageEntry => entry.type === "message"),
 			model: modelFromEntries(parsed),
+			hasPatchRecords,
 		};
 	} catch {
 		return null;
@@ -428,6 +632,7 @@ function cacheEntries(filePath: string, snapshot: StableSnapshot): ObserverCache
 			completeOffset: 0,
 			prefixDigest: digest(Buffer.alloc(0)),
 			entries: [],
+			...fullProjection([]),
 		};
 	}
 	const remainder = snapshot.tail.subarray(complete.bytes.length);
@@ -441,5 +646,6 @@ function cacheEntries(filePath: string, snapshot: StableSnapshot): ObserverCache
 		prefixDigest: digest(complete.bytes),
 		entries: parsed.entries,
 		model: parsed.model,
+		...fullProjection(parsed.entries),
 	};
 }

--- a/packages/coding-agent/src/modes/components/transcript-viewer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/transcript-viewer-overlay.ts
@@ -116,11 +116,11 @@ export class TranscriptViewerOverlay extends Container {
 	get isFullscreen(): boolean {
 		return this.#fullscreen;
 	}
-	refresh(identityMap?: ReadonlyMap<string, string>): void {
+	refresh(identityMap?: ReadonlyMap<string, string>, preserveLayoutCache = false): void {
 		if (__transcriptViewerPerfCounters.enabled) __transcriptViewerPerfCounters.refreshRuns++;
-		// Same-id entries may carry new payloads and getDisplayText closures after a source
-		// refresh, so the entire layout cache is dropped before the entries are replaced.
-		this.#layoutCache.clear();
+		// Incremental sources explicitly invalidate same-id payload patches before requesting a
+		// preserving refresh. Other source changes conservatively drop all layout variants.
+		if (!preserveLayoutCache) this.#layoutCache.clear();
 		const previous = this.selectedEntryId;
 		const previousPosition = this.#selected;
 		const reconciledPrevious = previous ? (identityMap?.get(previous) ?? previous) : undefined;

--- a/packages/coding-agent/test/session-observer-overlay.test.ts
+++ b/packages/coding-agent/test/session-observer-overlay.test.ts
@@ -623,6 +623,79 @@ describe("SessionObserverOverlayComponent incremental projection", () => {
 			fs.rmSync(dir, { recursive: true, force: true });
 		}
 	});
+
+	test("resets projection state when cycling between observed sessions", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "observer-projection-cycle-"));
+		try {
+			const fileA = path.join(dir, "a.jsonl");
+			const fileB = path.join(dir, "b.jsonl");
+			const callA = assistantRecord("call-a", [
+				{ type: "toolCall", id: "shared-call", name: "read", arguments: { path: "a" } },
+			]);
+			const callB = assistantRecord("call-b", [
+				{ type: "toolCall", id: "shared-call", name: "read", arguments: { path: "b" } },
+			]);
+			fs.writeFileSync(
+				fileA,
+				source(
+					"a",
+					`${record("user-a", "session A only")}\n${callA}\n${toolResultRecord("result-a", "shared-call", "result A")}\n`,
+				),
+			);
+			fs.writeFileSync(
+				fileB,
+				source(
+					"b",
+					`${record("user-b", "session B only")}\n${callB}\n${toolResultRecord("result-b", "shared-call", "result B")}\n`,
+				),
+			);
+			const sessions: ObservableSession[] = [
+				{
+					id: "a",
+					kind: "subagent",
+					label: "Session A",
+					status: "active",
+					sessionFile: fileA,
+					lastUpdate: 2,
+				},
+				{
+					id: "b",
+					kind: "subagent",
+					label: "Session B",
+					status: "active",
+					sessionFile: fileB,
+					lastUpdate: 1,
+				},
+			];
+			const cycleRegistry = { getSessions: () => sessions } as unknown as SessionObserverRegistry;
+			const overlay = new SessionObserverOverlayComponent(cycleRegistry, () => {}, ["ctrl+s"]);
+			expect(rendered(overlay)).toContain("session A only");
+			fs.appendFileSync(fileA, `${record("append-a", "A appended")}\n`);
+			overlay.refreshFromRegistry();
+			expect(rendered(overlay)).toContain("A appended");
+
+			__sessionObserverProjectionCounters.reset();
+			__sessionObserverProjectionCounters.enable();
+			overlay.handleInput("]");
+			const cycled = rendered(overlay);
+			expect(cycled).toContain("session B only");
+			expect(cycled).toContain("result B");
+			expect(cycled).not.toContain("session A only");
+			expect(cycled).not.toContain("result A");
+			expect(__sessionObserverProjectionCounters.snapshot()).toMatchObject({
+				projectionFullRuns: 1,
+				projectionIncrementalRuns: 0,
+			});
+
+			fs.appendFileSync(fileB, `${record("append-b", "B appended once")}\n`);
+			overlay.refreshFromRegistry();
+			expect(occurrences(rendered(overlay), "B appended once")).toBe(1);
+			expect(__sessionObserverProjectionCounters.snapshot().projectionIncrementalRuns).toBe(1);
+		} finally {
+			__sessionObserverProjectionCounters.disable();
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
 });
 
 test("falls back to full projection for an appended v5 entry patch, then resumes incremental appends", () => {

--- a/packages/coding-agent/test/session-observer-overlay.test.ts
+++ b/packages/coding-agent/test/session-observer-overlay.test.ts
@@ -1,8 +1,16 @@
-import { beforeAll, describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, spyOn, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { SessionObserverOverlayComponent } from "../src/modes/components/session-observer-overlay";
+import {
+	__sessionObserverProjectionCounters,
+	entriesFromMessages,
+	SessionObserverOverlayComponent,
+} from "../src/modes/components/session-observer-overlay";
+import {
+	__transcriptViewerPerfCounters,
+	TranscriptViewerOverlay,
+} from "../src/modes/components/transcript-viewer-overlay";
 import { type ObservableSession, SessionObserverRegistry } from "../src/modes/session-observer-registry";
 import { initTheme } from "../src/modes/theme/theme";
 import {
@@ -60,6 +68,45 @@ function observer(file: string): SessionObserverOverlayComponent {
 		sessionFile: file,
 		lastUpdate: 1,
 	}), () => {}, ["ctrl+s"]);
+}
+
+function assistantRecord(id: string, content: unknown[]): string {
+	return messageRecord(id, {
+		role: "assistant",
+		content,
+		timestamp: Date.now(),
+		model: "test-model",
+	});
+}
+
+function toolResultRecord(id: string, toolCallId: string, text: string): string {
+	return messageRecord(id, {
+		role: "toolResult",
+		toolCallId,
+		toolName: "read",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp: Date.now(),
+	});
+}
+
+function modelChangeRecord(model: string): string {
+	return JSON.stringify({
+		type: "model_change",
+		id: `model-${model}`,
+		parentId: null,
+		model,
+		role: "default",
+		timestamp: new Date().toISOString(),
+	});
+}
+
+function parsedMessages(records: string): Parameters<typeof entriesFromMessages>[0] {
+	return records
+		.trim()
+		.split("\n")
+		.map(line => JSON.parse(line))
+		.filter(entry => entry.type === "message");
 }
 
 describe("SessionObserverOverlayComponent source snapshots", () => {
@@ -354,6 +401,313 @@ describe("SessionObserverOverlayComponent source snapshots", () => {
 			fs.rmSync(dir, { recursive: true, force: true });
 		}
 	});
+});
+
+test("preserves viewer state across a transient unstable append snapshot", () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "observer-transient-snapshot-"));
+	try {
+		const file = path.join(dir, "session.jsonl");
+		fs.writeFileSync(file, source("observed", `${record("seed", "one\ntwo\nthree\nfour\nfive")}\n`));
+		const overlay = observer(file);
+		overlay.handleInput("\r");
+		expect(rendered(overlay)).toContain("five");
+
+		const originalFstat = fs.fstatSync;
+		let calls = 0;
+		const mockFstat = ((fd: number, options?: fs.StatOptions) => {
+			calls++;
+			if (calls === 2) fs.appendFileSync(file, " ");
+			return originalFstat(fd, options);
+		}) as typeof fs.fstatSync;
+		const fstatSpy = spyOn(fs, "fstatSync").mockImplementation(mockFstat);
+		try {
+			overlay.refreshFromRegistry();
+		} finally {
+			fstatSpy.mockRestore();
+		}
+
+		expect(rendered(overlay)).toContain("five");
+		overlay.refreshFromRegistry();
+		expect(rendered(overlay)).toContain("five");
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("clears cached output when the selected registry session disappears", () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "observer-missing-session-"));
+	try {
+		const file = path.join(dir, "session.jsonl");
+		fs.writeFileSync(file, source("observed", `${record("seed", "stale transcript")}\n`));
+		let sessions: ObservableSession[] = [
+			{
+				id: "observed",
+				kind: "subagent",
+				label: "Observed",
+				status: "active",
+				sessionFile: file,
+				lastUpdate: 1,
+			},
+		];
+		const mutableRegistry = { getSessions: () => sessions } as SessionObserverRegistry;
+		const overlay = new SessionObserverOverlayComponent(mutableRegistry, () => {}, ["ctrl+s"]);
+		expect(rendered(overlay)).toContain("stale transcript");
+		sessions = [];
+		overlay.refreshFromRegistry();
+		const output = rendered(overlay);
+		expect(output).not.toContain("stale transcript");
+		expect(output).toContain("No transcript entries yet.");
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("treats a concurrent short read as unstable and preserves viewer state", () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "observer-short-read-"));
+	try {
+		const file = path.join(dir, "session.jsonl");
+		fs.writeFileSync(file, source("observed", `${record("seed", "one\ntwo\nthree\nfour\nfive")}\n`));
+		const overlay = observer(file);
+		overlay.handleInput("\r");
+		const originalRead = fs.readSync;
+		let reads = 0;
+		const mockRead = ((...args: unknown[]) => {
+			reads++;
+			if (reads === 1) return 0;
+			return Reflect.apply(originalRead, fs, args) as number;
+		}) as typeof fs.readSync;
+		const readSpy = spyOn(fs, "readSync").mockImplementation(mockRead);
+		try {
+			overlay.refreshFromRegistry();
+		} finally {
+			readSpy.mockRestore();
+		}
+		expect(rendered(overlay)).toContain("five");
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("SessionObserverOverlayComponent incremental projection", () => {
+	test("reuses a no-change projection and incrementally appends multi-output messages", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "observer-projection-append-"));
+		try {
+			const file = path.join(dir, "session.jsonl");
+			fs.writeFileSync(file, source("observed", `${record("seed", "seed")}\n`));
+			const overlay = observer(file);
+			__sessionObserverProjectionCounters.reset();
+			__sessionObserverProjectionCounters.enable();
+			__transcriptViewerPerfCounters.reset();
+			__transcriptViewerPerfCounters.enable();
+			overlay.render(80);
+			__transcriptViewerPerfCounters.reset();
+			overlay.refreshFromRegistry();
+			expect(__sessionObserverProjectionCounters.snapshot()).toEqual({
+				projectionFullRuns: 0,
+				projectionIncrementalRuns: 0,
+				sourceMessagesProjected: 0,
+				projectedEntriesAppended: 0,
+				resultPatchCount: 0,
+			});
+			expect(__transcriptViewerPerfCounters.snapshot()).toMatchObject({
+				layoutCacheHits: 1,
+				layoutCacheMisses: 0,
+			});
+
+			fs.appendFileSync(
+				file,
+				`${assistantRecord("assistant", [
+					{ type: "thinking", thinking: "considering" },
+					{ type: "text", text: "answer" },
+					{ type: "toolCall", id: "call-1", name: "read", arguments: { path: "one" } },
+				])}\n`,
+			);
+			overlay.refreshFromRegistry();
+			const output = rendered(overlay);
+			expect(output).toContain("considering");
+			expect(output).toContain("answer");
+			expect(output).toContain("read");
+			expect(__sessionObserverProjectionCounters.snapshot()).toMatchObject({
+				projectionFullRuns: 0,
+				projectionIncrementalRuns: 1,
+				sourceMessagesProjected: 1,
+				projectedEntriesAppended: 3,
+			});
+		} finally {
+			__sessionObserverProjectionCounters.disable();
+			__transcriptViewerPerfCounters.disable();
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("patches out-of-order tool results with eager byte parity and narrow layout invalidation", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "observer-projection-results-"));
+		try {
+			const file = path.join(dir, "session.jsonl");
+			const initial = `${record("seed", "seed")}\n${assistantRecord("assistant", [
+				{ type: "toolCall", id: "call-1", name: "read", arguments: { path: "one" } },
+				{ type: "toolCall", id: "call-2", name: "read", arguments: { path: "two" } },
+			])}\n`;
+			fs.writeFileSync(file, source("observed", initial));
+			const overlay = observer(file);
+			overlay.render(80);
+			__sessionObserverProjectionCounters.reset();
+			__sessionObserverProjectionCounters.enable();
+			__transcriptViewerPerfCounters.reset();
+			__transcriptViewerPerfCounters.enable();
+
+			const results = `${toolResultRecord("result-2", "call-2", "second result")}\n${toolResultRecord("result-1", "call-1", "first result")}\n`;
+			fs.appendFileSync(file, results);
+			overlay.refreshFromRegistry();
+			const actual = overlay.render(80).join("\n");
+			const layout = __transcriptViewerPerfCounters.snapshot();
+			const eagerEntries = entriesFromMessages(parsedMessages(`${initial}${results}`));
+			const eagerOverlay = new TranscriptViewerOverlay({
+				title: "Session Observer",
+				getEntries: () => eagerEntries,
+				onClose: () => {},
+				enterExpands: true,
+				initialSelection: "latest",
+				followTail: true,
+				maxExpandedLines: 100,
+				getHeaderLines: () => ["Observed [active] · test-model"],
+				footerControls:
+					"j/k:select  Enter:expand  PgUp/PgDn:page  [/]/←→:cycle agents  Esc/Ctrl+S:close  g/G:top/bottom",
+			});
+			const eager = eagerOverlay.render(80).join("\n");
+			expect(actual).toBe(eager);
+			expect(actual).toContain("first result");
+			expect(actual).toContain("second result");
+			expect(__sessionObserverProjectionCounters.snapshot()).toMatchObject({
+				projectionFullRuns: 0,
+				projectionIncrementalRuns: 1,
+				resultPatchCount: 2,
+			});
+			expect(layout.layoutCacheHits).toBeGreaterThan(0);
+			expect(layout.layoutCacheMisses).toBe(2);
+		} finally {
+			__sessionObserverProjectionCounters.disable();
+			__transcriptViewerPerfCounters.disable();
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("keeps orphan results on the eager path until resolved and rejects duplicate call ids", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "observer-projection-fallback-"));
+		try {
+			const file = path.join(dir, "session.jsonl");
+			fs.writeFileSync(file, source("observed", `${record("seed", "seed")}\n`));
+			const overlay = observer(file);
+			__sessionObserverProjectionCounters.reset();
+			__sessionObserverProjectionCounters.enable();
+			fs.appendFileSync(file, `${toolResultRecord("orphan", "missing", "orphan result")}\n`);
+			overlay.refreshFromRegistry();
+			expect(__sessionObserverProjectionCounters.snapshot().projectionFullRuns).toBe(1);
+
+			fs.appendFileSync(
+				file,
+				`${assistantRecord("resolved", [{ type: "toolCall", id: "missing", name: "read", arguments: {} }])}\n`,
+			);
+			overlay.refreshFromRegistry();
+			expect(rendered(overlay)).toContain("orphan result");
+			expect(__sessionObserverProjectionCounters.snapshot().projectionFullRuns).toBe(2);
+
+			fs.appendFileSync(
+				file,
+				`${assistantRecord("a1", [{ type: "toolCall", id: "duplicate", name: "read", arguments: {} }])}\n${assistantRecord("a2", [{ type: "toolCall", id: "duplicate", name: "read", arguments: {} }])}\n`,
+			);
+			overlay.refreshFromRegistry();
+			expect(__sessionObserverProjectionCounters.snapshot().projectionFullRuns).toBe(3);
+		} finally {
+			__sessionObserverProjectionCounters.disable();
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+test("falls back to full projection for an appended v5 entry patch, then resumes incremental appends", () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "observer-projection-entry-patch-"));
+	try {
+		const file = path.join(dir, "session.jsonl");
+		const header = JSON.stringify({
+			type: "session",
+			version: 5,
+			id: "observed",
+			timestamp: new Date().toISOString(),
+		});
+		fs.writeFileSync(file, `${header}\n${record("patched", "before patch")}\n`);
+		const overlay = observer(file);
+		expect(rendered(overlay)).toContain("before patch");
+		__sessionObserverProjectionCounters.reset();
+		__sessionObserverProjectionCounters.enable();
+
+		const patchedMessage = { role: "user", content: "after patch", timestamp: Date.now() };
+		fs.appendFileSync(
+			file,
+			`${JSON.stringify({ type: "entry_patch", entryId: "patched", patch: { message: patchedMessage } })}\n`,
+		);
+		overlay.refreshFromRegistry();
+		const patchedOutput = rendered(overlay);
+		expect(patchedOutput).toContain("after patch");
+		expect(patchedOutput).not.toContain("before patch");
+		expect(__sessionObserverProjectionCounters.snapshot()).toMatchObject({
+			projectionFullRuns: 1,
+			projectionIncrementalRuns: 0,
+		});
+
+		fs.appendFileSync(file, `${record("after-patch", "incremental after patch")}\n`);
+		overlay.refreshFromRegistry();
+		const finalOutput = rendered(overlay);
+		expect(finalOutput).toContain("after patch");
+		expect(occurrences(finalOutput, "incremental after patch")).toBe(1);
+		expect(__sessionObserverProjectionCounters.snapshot()).toMatchObject({
+			projectionFullRuns: 1,
+			projectionIncrementalRuns: 1,
+			sourceMessagesProjected: 2,
+		});
+	} finally {
+		__sessionObserverProjectionCounters.disable();
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("commits a standalone model change once and continues suffix projection", () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "observer-projection-model-change-"));
+	try {
+		const file = path.join(dir, "session.jsonl");
+		fs.writeFileSync(file, source("observed", `${record("seed", "seed")}\n`));
+		const overlay = observer(file);
+		__sessionObserverProjectionCounters.reset();
+		__sessionObserverProjectionCounters.enable();
+
+		fs.appendFileSync(file, `${modelChangeRecord("new-model")}\n`);
+		overlay.refreshFromRegistry();
+		expect(rendered(overlay)).toContain("new-model");
+		expect(__sessionObserverProjectionCounters.snapshot()).toEqual({
+			projectionFullRuns: 0,
+			projectionIncrementalRuns: 0,
+			sourceMessagesProjected: 0,
+			projectedEntriesAppended: 0,
+			resultPatchCount: 0,
+		});
+
+		fs.appendFileSync(file, `${record("after-model", "after model change")}\n`);
+		overlay.refreshFromRegistry();
+		const output = rendered(overlay);
+		expect(output).toContain("new-model");
+		expect(occurrences(output, "after model change")).toBe(1);
+		expect(__sessionObserverProjectionCounters.snapshot()).toMatchObject({
+			projectionFullRuns: 0,
+			projectionIncrementalRuns: 1,
+			sourceMessagesProjected: 1,
+			projectedEntriesAppended: 1,
+		});
+		overlay.refreshFromRegistry();
+		expect(__sessionObserverProjectionCounters.snapshot().projectionIncrementalRuns).toBe(1);
+	} finally {
+		__sessionObserverProjectionCounters.disable();
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
 });
 
 describe("SessionObserverOverlayComponent explicit refresh ownership", () => {


### PR DESCRIPTION
## What

- incrementally project append-only Session Observer message suffixes instead of rebuilding the complete observed history
- replace late tool-result entries through a stable tool-call output index and narrowly invalidate only affected layout variants
- preserve committed viewer/layout state across unchanged or transiently unstable snapshots, while failing closed for unavailable/replaced sources
- route v4/v5 entry/header patches through one captured full-snapshot eager projection before resuming incremental appends
- add deterministic projection counters and regression coverage for no-op refreshes, out-of-order/orphan/duplicate tool calls, patch records, model changes, transient reads, missing sessions, replacements, and session cycling

## Why

PR2a separated source refresh from paint and memoized entry layouts, but Session Observer still ran `entriesFromMessages()` over its full history after every append notification. This change makes projection work proportional to the appended suffix while preserving eager output parity and the PR2a interaction/state invariants.

The implementation deliberately stops at PR2b. PR2c viewport virtualization remains gated on attributed full-history layout-assembly evidence.

## Testing

- `bun --cwd=packages/coding-agent test test/transcript-viewer-overlay.test.ts test/session-observer-overlay.test.ts test/modes/controllers/event-controller-message-start.test.ts test/transcript-viewer-perf.test.ts test/transcript-adapter-parity.test.ts`
  - 65 pass, 0 fail, 269 expectations
- `bun --cwd=packages/coding-agent check`
  - Biome and TypeScript noEmit pass
- exact-head `git diff --check origin/dev...HEAD`
- independent Grok final review: APPROVE
- independent exact-head architect review: merge-approved

Performance on Apple M4 Pro, Bun 1.3.14, seven samples after one warm-up, real `SessionObserverOverlayComponent` append/refresh/render loop:

| Fixture | PR head median / p95 | origin/dev median / p95 | Improvement |
|---|---:|---:|---:|
| 100 initial + 20 appends | 1.974 / 2.380 ms | 2.933 / 4.132 ms | 32.7% / 42.4% |
| 10,000 initial + 10 appends | 27.677 / 27.968 ms | 71.880 / 80.725 ms | 61.5% / 65.4% |

Structural source-message visits fall from 2,210 to 20 (99.10%) and from 100,055 to 10 (99.99%). Timing remains advisory; RSS was inconclusive and no memory claim is made.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:84ebfe56d110f0338b24da68c9171c1da4bd28b1 reviewer:architect evidence:bun-focused-tests+package-check
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit