### PR TITLE
fix(ai): flag Anthropic and Ollama tool calls truncated by max_tokens

### DIFF
--- a/artifacts/architecture-2383-eval.json
+++ b/artifacts/architecture-2383-eval.json
@@ -6,8 +6,8 @@
 	"source": {
 		"url": "https://platform.claude.com/docs/en/build-with-claude/prompt-caching",
 		"retrievedAt": "2026-07-18",
-		"providerSourceBlobOid": "8dace16954264312b4bb99e78236f868ea6c1b8d",
-		"providerSourceSha256": "7f521d452360fd79b07f6d8f0ba7ef75e531d2289d444fce37686b21a81577e9",
+		"providerSourceBlobOid": "19340326c24dbd246d2f11d53638c5d20bf4ee83",
+		"providerSourceSha256": "8a0f67389c102137d1c0dacd613ff573aaa00da77da709c30ab2fd89c1de6df2",
 		"inputFixtureSha256": "b1ca8d3183ca168140774f848ed414252178f7c5788d61243069862ae59c129b"
 	},
 	"derivationCommands": [

--- a/packages/agent/test/agent-loop-anthropic-truncated-toolcall.test.ts
+++ b/packages/agent/test/agent-loop-anthropic-truncated-toolcall.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { Messages } from "@anthropic-ai/sdk/resources/messages/messages";
+import type { AssistantMessageEventStream, Message, Model } from "@gajae-code/ai";
+import * as z from "zod/v4";
+import { streamAnthropic } from "../../ai/src/providers/anthropic";
+import type { Context as LocalContext, Model as LocalModel } from "../../ai/src/types";
+import { agentLoop } from "../src/agent-loop";
+import type { AgentContext, AgentLoopConfig, AgentMessage, AgentTool, StreamFn } from "../src/types";
+
+const model: Model<"anthropic-messages"> = {
+	id: "claude-sonnet-4-5",
+	name: "Claude Sonnet 4.5",
+	api: "anthropic-messages",
+	provider: "anthropic",
+	baseUrl: "https://api.anthropic.com",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 8_192,
+};
+
+type MockAnthropicEvent = Record<string, unknown>;
+type MockAnthropicStream = AsyncIterable<MockAnthropicEvent>;
+type MockAnthropicRequest = {
+	withResponse(): Promise<{
+		data: MockAnthropicStream;
+		response: Response;
+		request_id: string | null;
+	}>;
+};
+
+function createMockRequest(events: MockAnthropicEvent[]): MockAnthropicRequest {
+	const response = new Response(null, { status: 200, headers: { "request-id": "req_mock" } });
+	const stream: MockAnthropicStream = {
+		async *[Symbol.asyncIterator]() {
+			for (const event of events) yield event;
+		},
+	};
+	return {
+		async withResponse() {
+			return { data: stream, response, request_id: response.headers.get("request-id") };
+		},
+	};
+}
+
+function messageStart(id: string): MockAnthropicEvent {
+	return {
+		type: "message_start",
+		message: {
+			id,
+			usage: {
+				input_tokens: 1,
+				output_tokens: 0,
+				cache_read_input_tokens: 0,
+				cache_creation_input_tokens: 0,
+			},
+		},
+	};
+}
+
+function toolResponse(id: string, json: string, stopReason: "max_tokens" | "tool_use"): MockAnthropicEvent[] {
+	return [
+		messageStart(`msg_${id}`),
+		{
+			type: "content_block_start",
+			index: 0,
+			content_block: { type: "tool_use", id, name: "write_file", input: {} },
+		},
+		{
+			type: "content_block_delta",
+			index: 0,
+			delta: { type: "input_json_delta", partial_json: json },
+		},
+		{ type: "content_block_stop", index: 0 },
+		{ type: "message_delta", delta: { stop_reason: stopReason }, usage: { output_tokens: 1 } },
+		{ type: "message_stop" },
+	];
+}
+
+function duplicateToolResponse(id: string): MockAnthropicEvent[] {
+	return [
+		messageStart(`msg_${id}`),
+		{
+			type: "content_block_start",
+			index: 0,
+			content_block: { type: "tool_use", id, name: "write_file", input: {} },
+		},
+		{
+			type: "content_block_delta",
+			index: 0,
+			delta: { type: "input_json_delta", partial_json: '{"path":"a.ts","content":"partial' },
+		},
+		{
+			type: "content_block_start",
+			index: 0,
+			content_block: { type: "tool_use", id, name: "write_file", input: {} },
+		},
+		{
+			type: "content_block_delta",
+			index: 0,
+			delta: { type: "input_json_delta", partial_json: '{"path":"b.ts","content":"ok"}' },
+		},
+		{ type: "content_block_stop", index: 0 },
+		{ type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 1 } },
+		{ type: "message_stop" },
+	];
+}
+
+function textResponse(text: string): MockAnthropicEvent[] {
+	return [
+		messageStart("msg_done"),
+		{ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+		{ type: "content_block_delta", index: 0, delta: { type: "text_delta", text } },
+		{ type: "content_block_stop", index: 0 },
+		{ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 1 } },
+		{ type: "message_stop" },
+	];
+}
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(m => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("agentLoop with Anthropic truncated tool calls", () => {
+	it("refuses the repaired partial call and executes a later complete call", async () => {
+		const responses = [
+			toolResponse("tool_truncated", '{"path":"a.ts","content":"line1', "max_tokens"),
+			toolResponse("tool_complete", '{"path":"b.ts","content":"ok"}', "tool_use"),
+			textResponse("done"),
+		];
+		let responseIndex = 0;
+		const createSpy = vi.spyOn(Messages.prototype, "create").mockImplementation(() => {
+			const events = responses[responseIndex];
+			if (!events) throw new Error(`Unexpected Anthropic request ${responseIndex + 1}`);
+			responseIndex++;
+			return createMockRequest(events) as never;
+		});
+
+		const executed: Array<Record<string, unknown>> = [];
+		const toolSchema = z.object({ path: z.string(), content: z.string() });
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "write_file",
+			label: "Write",
+			description: "Write a file",
+			parameters: toolSchema,
+			async execute(_id, params) {
+				executed.push(params as Record<string, unknown>);
+				return { content: [{ type: "text", text: "wrote" }], details: {} };
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const config: AgentLoopConfig = { model, convertToLlm: identityConverter, fallbackManaged: true };
+		const streamFn: StreamFn = (providerModel, providerContext, options) =>
+			streamAnthropic(
+				providerModel as unknown as LocalModel<"anthropic-messages">,
+				providerContext as unknown as LocalContext,
+				{ apiKey: "sk-ant-test", signal: options?.signal, fallbackManaged: options?.fallbackManaged },
+			) as unknown as AssistantMessageEventStream;
+
+		const toolResults: Array<{ isError?: boolean; text: string }> = [];
+		const initialMessage: AgentMessage = { role: "user", content: "write the file", timestamp: Date.now() };
+		const stream = agentLoop([initialMessage], context, config, undefined, streamFn);
+		for await (const event of stream) {
+			if (event.type === "tool_execution_end") {
+				const first = event.result.content?.[0];
+				toolResults.push({ isError: event.isError, text: first?.type === "text" ? first.text : "" });
+			}
+		}
+		expect(responseIndex).toBe(responses.length);
+		expect(createSpy).toHaveBeenCalledTimes(responses.length);
+
+		expect(executed).toEqual([{ path: "b.ts", content: "ok" }]);
+		expect(toolResults).toHaveLength(2);
+		expect(toolResults[0].isError).toBe(true);
+		expect(toolResults[0].text).toContain("cut off");
+		expect(toolResults[0].text.toLowerCase()).toContain("re-issue");
+		expect(toolResults[1]).toEqual({ isError: false, text: "wrote" });
+	});
+
+	it("executes only the complete same-ID replacement after a malformed duplicate index", async () => {
+		const responses = [duplicateToolResponse("tool_shared"), textResponse("done")];
+		let responseIndex = 0;
+		vi.spyOn(Messages.prototype, "create").mockImplementation(() => {
+			const events = responses[responseIndex];
+			if (!events) throw new Error(`Unexpected Anthropic request ${responseIndex + 1}`);
+			responseIndex++;
+			return createMockRequest(events) as never;
+		});
+
+		const executed: Array<Record<string, unknown>> = [];
+		const toolSchema = z.object({ path: z.string(), content: z.string() });
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "write_file",
+			label: "Write",
+			description: "Write a file",
+			parameters: toolSchema,
+			async execute(_id, params) {
+				executed.push(params as Record<string, unknown>);
+				return { content: [{ type: "text", text: "wrote" }], details: {} };
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const config: AgentLoopConfig = { model, convertToLlm: identityConverter, fallbackManaged: true };
+		const streamFn: StreamFn = (providerModel, providerContext, options) =>
+			streamAnthropic(
+				providerModel as unknown as LocalModel<"anthropic-messages">,
+				providerContext as unknown as LocalContext,
+				{ apiKey: "sk-ant-test", signal: options?.signal, fallbackManaged: options?.fallbackManaged },
+			) as unknown as AssistantMessageEventStream;
+
+		const toolResults: Array<{ isError?: boolean; text: string }> = [];
+		const initialMessage: AgentMessage = { role: "user", content: "write the file", timestamp: Date.now() };
+		const stream = agentLoop([initialMessage], context, config, undefined, streamFn);
+		for await (const event of stream) {
+			if (event.type === "tool_execution_end") {
+				const first = event.result.content?.[0];
+				toolResults.push({ isError: event.isError, text: first?.type === "text" ? first.text : "" });
+			}
+		}
+
+		expect(responseIndex).toBe(2);
+		expect(executed).toEqual([{ path: "b.ts", content: "ok" }]);
+		expect(toolResults).toHaveLength(2);
+		expect(toolResults[0].isError).toBe(true);
+		expect(toolResults[0].text).toContain("cut off");
+		expect(toolResults[1]).toEqual({ isError: false, text: "wrote" });
+	});
+});

--- a/packages/agent/test/agent-loop-truncated-toolcall.test.ts
+++ b/packages/agent/test/agent-loop-truncated-toolcall.test.ts
@@ -35,7 +35,7 @@ describe("agentLoop: truncated tool-call guard", () => {
 							type: "toolCall",
 							id: "tc-1",
 							name: "write_file",
-							arguments: { path: "a.ts" }, // best-effort partial parse (missing `content`)
+							arguments: { path: "a.ts", content: "partial" }, // schema-valid repaired payload
 							incompleteArguments: true,
 						},
 					],

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,7 @@
 - The documented `GJC_NO_STRICT` environment variable now takes effect. `adaptSchemaForStrict` read only the legacy `PI_NO_STRICT`, so an operator hitting a provider that rejects strict function schemas set the documented name and strict mode stayed on. Both names are honoured, canonical name first, and `GJC_NO_STRICT` is now listed in the environment-variable reference rather than only in the schema-normalisation note.
 - The documented `GJC_AUTH_NO_BORROW` environment variable now takes effect. Only the legacy `PI_AUTH_NO_BORROW` was read, so an operator who followed the documentation to disable macOS native-app token borrowing still had a JWT read out of the Perplexity desktop application during login. Both names are now honoured, and the contract stays presence-based as documented so that setting it to `0` cannot silently re-enable borrowing.
 - The Azure client's `AZURE_OPENAI_API_KEY` fallback is now resolved from trusted environment sources only. It read the merged view that includes the caller's `cwd/.env`, so a repository could supply the credential the client authenticates with; provider credential resolution is documented as excluding the project `.env`, and this fallback now matches. An explicit caller-supplied key still takes precedence, and shell / user-level configuration is unchanged.
+- Anthropic and Ollama tool calls cut off by an output-token limit are now marked incomplete before dispatch, so repaired partial JSON is rejected instead of executing with truncated arguments.
 
 ## [0.12.0] - 2026-07-28
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -68,7 +68,7 @@ import {
 	getStreamIdleTimeoutMs,
 	iterateWithIdleTimeout,
 } from "../utils/idle-iterator";
-import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse";
+import { isCompleteJson, parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse";
 import { parseGitHubCopilotApiKey } from "../utils/oauth/github-copilot";
 import { notifyProviderResponse } from "../utils/provider-response";
 import { isCopilotTransientModelError } from "../utils/retry";
@@ -1423,6 +1423,8 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 			) & { index: number };
 			const blocks = output.content as Block[];
 			const blocksByAnthropicIndex = new Map<number, Block>();
+			const truncatedToolCalls = new Set<ToolCall>();
+			let sawTerminalStopReason = false;
 			// Derive from the ACTUAL request shape, not the option default: the request
 			// only sends `display: "summarized"` on specific paths (adaptive display is
 			// omitted for models where supportsAdaptiveThinkingDisplay is false). Defaulting
@@ -1440,8 +1442,14 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 				// finalize the orphaned block so no internal stream fields leak into output.
 				const orphaned = blocksByAnthropicIndex.get(anthropicIndex);
 				if (orphaned) {
-					if (orphaned.type === "toolCall" && orphaned.partialJson.trim()) {
-						orphaned.arguments = parseStreamingJson(orphaned.partialJson);
+					if (orphaned.type === "toolCall") {
+						if (!isCompleteJson(orphaned.partialJson)) {
+							orphaned.incompleteArguments = true;
+							truncatedToolCalls.add(orphaned);
+						}
+						if (orphaned.partialJson.trim()) {
+							orphaned.arguments = parseStreamingJson(orphaned.partialJson);
+						}
 					}
 					delete (orphaned as { index?: number }).index;
 					delete (orphaned as { partialJson?: string }).partialJson;
@@ -1458,6 +1466,8 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 				output.usage = createEmptyUsage(copilotDynamicHeaders?.premiumRequests);
 				output.stopReason = "stop";
 				firstTokenTime = undefined;
+				truncatedToolCalls.clear();
+				sawTerminalStopReason = false;
 			};
 			const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getStreamIdleTimeoutMs();
 			const firstEventFallbackMs = getProviderFirstEventTimeoutFallbackMs(model.provider);
@@ -1472,6 +1482,8 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 			while (true) {
 				// Retries reset output.content; drop stale block correlations from the aborted attempt.
 				blocksByAnthropicIndex.clear();
+				truncatedToolCalls.clear();
+				sawTerminalStopReason = false;
 				activeAbortTracker = createAbortSourceTracker(options?.signal);
 				const firstEventTimeoutAbortError = new FirstEventTimeoutError(
 					"Anthropic stream timed out while waiting for the first event",
@@ -1496,6 +1508,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 					let sawEvent = false;
 					let sawMessageStart = false;
 					let sawTerminalEnvelope = false;
+					let sawMessageStop = false;
 					const isProgressEvent = createAnthropicStreamProgressPredicate();
 
 					for await (const event of iterateWithIdleTimeout(anthropicStream, {
@@ -1509,9 +1522,13 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 						isProgressItem: isProgressEvent,
 					})) {
 						sawEvent = true;
+						if (sawMessageStop) {
+							throw createAnthropicStreamEnvelopeError("received event after message_stop");
+						}
 						if (sawProviderSafetyStop) {
 							if (event.type === "message_stop") {
 								sawTerminalEnvelope = true;
+								sawMessageStop = true;
 							}
 							continue;
 						}
@@ -1699,6 +1716,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 										partial: output,
 									});
 								} else if (block.type === "toolCall") {
+									if (!isCompleteJson(block.partialJson)) truncatedToolCalls.add(block);
 									if (block.partialJson.trim()) {
 										block.arguments = parseStreamingJson(block.partialJson);
 									}
@@ -1719,6 +1737,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 							if (rawStopReason) {
 								output.stopReason = isProviderSafetyStop ? "error" : mapStopReason(rawStopReason);
 								sawTerminalEnvelope = true;
+								sawTerminalStopReason = true;
 							}
 							if (isProviderSafetyStop) {
 								sawProviderSafetyStop = true;
@@ -1760,6 +1779,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 							calculateCost(model, output.usage);
 						} else if (event.type === "message_stop") {
 							sawTerminalEnvelope = true;
+							sawMessageStop = true;
 						}
 					}
 
@@ -1899,6 +1919,24 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 				}
 			}
 
+			for (const block of blocksByAnthropicIndex.values()) {
+				delete (block as { index?: number }).index;
+				if (block.type === "toolCall") {
+					truncatedToolCalls.add(block);
+					if (block.partialJson.trim()) {
+						block.arguments = parseStreamingJson(block.partialJson);
+					}
+					delete (block as { partialJson?: string }).partialJson;
+				}
+			}
+			blocksByAnthropicIndex.clear();
+			if (output.stopReason === "length" || !sawTerminalStopReason) {
+				for (const block of output.content) {
+					if (block.type === "toolCall" && truncatedToolCalls.has(block)) {
+						block.incompleteArguments = true;
+					}
+				}
+			}
 			output.duration = Date.now() - startTime;
 			if (firstTokenTime) output.ttft = firstTokenTime - startTime;
 			if (dropFastMode && resolveServiceTier(options?.serviceTier, model.provider) === "priority") {

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -18,7 +18,7 @@ import { normalizeSystemPrompts } from "../utils";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { transportFailureFacts } from "../utils/fallback-transport";
 import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
-import { parseStreamingJson } from "../utils/json-parse";
+import { isCompleteJson, parseStreamingJson } from "../utils/json-parse";
 import { resolveRetryBudget } from "../utils/retry-budget";
 import { flattenToolRootCombinators, toolWireSchema } from "../utils/schema";
 import {
@@ -26,6 +26,7 @@ import {
 	markToolChoiceIncapability,
 	resolveToolChoice,
 } from "../utils/tool-choice-capability";
+import { flagTruncatedToolCalls } from "./openai-responses-shared";
 import { transformMessages } from "./transform-messages";
 
 export interface OllamaChatOptions extends StreamOptions {
@@ -357,8 +358,10 @@ function endToolCallBlock(stream: AssistantMessageEventStream, output: Assistant
 		return;
 	}
 	const toolCall = block as InternalToolCallBlock;
-	if (toolCall.partialJson) {
-		toolCall.arguments = parseStreamingJson<Record<string, unknown>>(toolCall.partialJson);
+	if (toolCall.partialJson !== undefined) {
+		if (toolCall.partialJson.trim()) {
+			toolCall.arguments = parseStreamingJson<Record<string, unknown>>(toolCall.partialJson);
+		}
 		delete toolCall.partialJson;
 	}
 	stream.push({ type: "toolcall_end", contentIndex: index, toolCall, partial: output });
@@ -393,6 +396,8 @@ export const streamOllama: StreamFunction<"ollama-chat"> = (
 		let activeThinkingIndex: number | undefined;
 		let activeTextIndex: number | undefined;
 		const activeToolIndices = new Set<number>();
+		const unverifiableArgumentToolCallIds = new Set<string>();
+		let sawTerminalChunk = false;
 		try {
 			const apiKey = options.apiKey || getEnvApiKey(model.provider);
 			if (!apiKey) {
@@ -537,6 +542,7 @@ export const streamOllama: StreamFunction<"ollama-chat"> = (
 					for (const call of chunk.message.tool_calls) {
 						const name = call.function?.name ?? "unknown_tool";
 						const rawArgs = call.function?.arguments;
+						const unverifiableArguments = typeof rawArgs !== "string";
 						const partialJson = typeof rawArgs === "string" ? rawArgs : JSON.stringify(rawArgs ?? {});
 						const toolCall: InternalToolCallBlock = {
 							type: "toolCall",
@@ -545,6 +551,7 @@ export const streamOllama: StreamFunction<"ollama-chat"> = (
 							arguments: parseStreamingJson<Record<string, unknown>>(partialJson),
 							partialJson,
 						};
+						if (unverifiableArguments) unverifiableArgumentToolCallIds.add(toolCall.id);
 						output.content.push(toolCall);
 						const index = output.content.length - 1;
 						activeToolIndices.add(index);
@@ -561,6 +568,7 @@ export const streamOllama: StreamFunction<"ollama-chat"> = (
 					}
 				}
 				if (chunk.done) {
+					sawTerminalChunk = true;
 					if (activeThinkingIndex !== undefined) {
 						endThinkingBlock(stream, output, activeThinkingIndex);
 						activeThinkingIndex = undefined;
@@ -569,15 +577,35 @@ export const streamOllama: StreamFunction<"ollama-chat"> = (
 						endTextBlock(stream, output, activeTextIndex);
 						activeTextIndex = undefined;
 					}
+					output.stopReason = mapDoneReason(chunk.done_reason, output);
+					// Ollama still owns every partialJson buffer here; use the helper's
+					// finalized-call branch before endToolCallBlock deletes those buffers.
+					// Non-string arguments have no raw completion evidence, so a length stop
+					// must fail closed rather than trusting normalized or re-serialized values.
+					flagTruncatedToolCalls(
+						output,
+						output.stopReason,
+						block => !unverifiableArgumentToolCallIds.has(block.id),
+					);
+					if (chunk.done_reason === undefined) {
+						for (const block of output.content) {
+							if (block.type !== "toolCall") continue;
+							const partialJson = (block as InternalToolCallBlock).partialJson;
+							if (partialJson !== undefined && !isCompleteJson(partialJson)) block.incompleteArguments = true;
+						}
+					}
 					for (const index of activeToolIndices) {
 						endToolCallBlock(stream, output, index);
 					}
 					activeToolIndices.clear();
-					output.stopReason = mapDoneReason(chunk.done_reason, output);
 					output.usage.input = chunk.prompt_eval_count ?? 0;
 					output.usage.output = chunk.eval_count ?? 0;
 					output.usage.totalTokens = output.usage.input + output.usage.output;
+					break;
 				}
+			}
+			if (!sawTerminalChunk) {
+				throw new Error("Ollama stream ended before terminal done chunk");
 			}
 			output.duration = Date.now() - startTime;
 			if (firstTokenTime) {

--- a/packages/ai/test/anthropic-truncated-toolcall.test.ts
+++ b/packages/ai/test/anthropic-truncated-toolcall.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { Messages } from "@anthropic-ai/sdk/resources/messages/messages";
+import { streamAnthropic } from "../src/providers/anthropic";
+import type { AssistantMessage, Context, Model, ToolCall } from "../src/types";
+
+const model: Model<"anthropic-messages"> = {
+	id: "claude-sonnet-4-5",
+	name: "Claude Sonnet 4.5",
+	api: "anthropic-messages",
+	provider: "anthropic",
+	baseUrl: "https://api.anthropic.com",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 8_192,
+};
+
+const context: Context = {
+	messages: [{ role: "user", content: "Write the file", timestamp: Date.now() }],
+};
+
+type MockAnthropicEvent = Record<string, unknown>;
+type MockAnthropicStream = AsyncIterable<MockAnthropicEvent>;
+type MockAnthropicRequest = {
+	withResponse(): Promise<{
+		data: MockAnthropicStream;
+		response: Response;
+		request_id: string | null;
+	}>;
+};
+
+function createMockRequest(events: MockAnthropicEvent[]): MockAnthropicRequest {
+	const response = new Response(null, { status: 200, headers: { "request-id": "req_mock" } });
+	const stream: MockAnthropicStream = {
+		async *[Symbol.asyncIterator]() {
+			for (const event of events) yield event;
+		},
+	};
+	return {
+		async withResponse() {
+			return { data: stream, response, request_id: response.headers.get("request-id") };
+		},
+	};
+}
+
+function messageStart(id: string): MockAnthropicEvent {
+	return {
+		type: "message_start",
+		message: {
+			id,
+			usage: {
+				input_tokens: 1,
+				output_tokens: 0,
+				cache_read_input_tokens: 0,
+				cache_creation_input_tokens: 0,
+			},
+		},
+	};
+}
+
+function terminal(stopReason: "max_tokens" | "tool_use"): MockAnthropicEvent[] {
+	return [
+		{ type: "message_delta", delta: { stop_reason: stopReason }, usage: { output_tokens: 1 } },
+		{ type: "message_stop" },
+	];
+}
+
+function toolStart(index: number, id: string): MockAnthropicEvent {
+	return {
+		type: "content_block_start",
+		index,
+		content_block: { type: "tool_use", id, name: "write_file", input: {} },
+	};
+}
+
+function toolDelta(index: number, partialJson: string): MockAnthropicEvent {
+	return {
+		type: "content_block_delta",
+		index,
+		delta: { type: "input_json_delta", partial_json: partialJson },
+	};
+}
+
+async function run(events: MockAnthropicEvent[]): Promise<AssistantMessage> {
+	vi.spyOn(Messages.prototype, "create").mockImplementation(() => createMockRequest(events) as never);
+	const stream = streamAnthropic(model, context, { apiKey: "sk-ant-test", requestMaxRetries: 0, streamMaxRetries: 0 });
+	for await (const _event of stream) {
+		// Drain the provider stream.
+	}
+	return stream.result();
+}
+
+function toolCalls(message: AssistantMessage): ToolCall[] {
+	return message.content.filter((block): block is ToolCall => block.type === "toolCall");
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("Anthropic truncated tool calls", () => {
+	it("flags only the incomplete sibling when a max_tokens turn closes both blocks", async () => {
+		const result = await run([
+			messageStart("msg_siblings"),
+			toolStart(0, "tool_truncated"),
+			toolDelta(0, '{"path":"a.ts","content":"line1'),
+			{ type: "content_block_stop", index: 0 },
+			toolStart(1, "tool_complete"),
+			toolDelta(1, '{"path":"b.ts"}'),
+			{ type: "content_block_stop", index: 1 },
+			...terminal("max_tokens"),
+		]);
+
+		const tools = toolCalls(result);
+		expect(result.stopReason).toBe("length");
+		expect(tools).toHaveLength(2);
+		expect(tools[0].incompleteArguments).toBe(true);
+		expect(tools[1].incompleteArguments).toBeFalsy();
+	});
+
+	it("finalizes and flags an open block without leaking stream fields", async () => {
+		const result = await run([
+			messageStart("msg_open"),
+			toolStart(0, "tool_open"),
+			toolDelta(0, '{"path":"a.ts","content":"line1'),
+			...terminal("max_tokens"),
+		]);
+
+		const [tool] = toolCalls(result);
+		expect(tool?.incompleteArguments).toBe(true);
+		expect(tool && "partialJson" in tool).toBe(false);
+		expect(tool && "index" in tool).toBe(false);
+	});
+
+	it("preserves truncation evidence when a duplicate index orphans a block", async () => {
+		const result = await run([
+			messageStart("msg_orphan"),
+			toolStart(0, "tool_orphan"),
+			toolDelta(0, '{"path":"a.ts","content":"line1'),
+			toolStart(0, "tool_replacement"),
+			toolDelta(0, '{"path":"b.ts"}'),
+			{ type: "content_block_stop", index: 0 },
+			...terminal("max_tokens"),
+		]);
+
+		const tools = toolCalls(result);
+		expect(tools).toHaveLength(2);
+		expect(tools[0].id).toBe("tool_orphan");
+		expect(tools[0].incompleteArguments).toBe(true);
+		expect(tools[1].incompleteArguments).toBeFalsy();
+	});
+
+	it("does not transfer orphan truncation state to a same-ID replacement", async () => {
+		const result = await run([
+			messageStart("msg_same_id_orphan"),
+			toolStart(0, "tool_shared"),
+			toolDelta(0, '{"path":"a.ts","content":"line1'),
+			toolStart(0, "tool_shared"),
+			toolDelta(0, '{"path":"b.ts"}'),
+			{ type: "content_block_stop", index: 0 },
+			...terminal("max_tokens"),
+		]);
+
+		const tools = toolCalls(result);
+		expect(tools).toHaveLength(2);
+		expect(tools[0].id).toBe("tool_shared");
+		expect(tools[0].incompleteArguments).toBe(true);
+		expect(tools[1].id).toBe("tool_shared");
+		expect(tools[1].incompleteArguments).toBeFalsy();
+	});
+
+	it("keeps an incomplete same-ID orphan blocked on an explicit tool-use stop", async () => {
+		const result = await run([
+			messageStart("msg_same_id_tool_use"),
+			toolStart(0, "tool_shared"),
+			toolDelta(0, '{"path":"a.ts","content":"partial'),
+			toolStart(0, "tool_shared"),
+			toolDelta(0, '{"path":"b.ts","content":"ok"}'),
+			{ type: "content_block_stop", index: 0 },
+			...terminal("tool_use"),
+		]);
+
+		const tools = toolCalls(result);
+		expect(tools).toHaveLength(2);
+		expect(tools[0].arguments).toEqual({ path: "a.ts", content: "partial" });
+		expect(tools[0].incompleteArguments).toBe(true);
+		expect(tools[1].arguments).toEqual({ path: "b.ts", content: "ok" });
+		expect(tools[1].incompleteArguments).toBeFalsy();
+	});
+
+	it("flags incomplete arguments when message_stop omits the terminal reason", async () => {
+		const result = await run([
+			messageStart("msg_missing_reason"),
+			toolStart(0, "tool_missing_reason"),
+			toolDelta(0, '{"path":"a.ts","content":"line1'),
+			{ type: "content_block_stop", index: 0 },
+			{ type: "message_stop" },
+		]);
+
+		expect(result.stopReason).toBe("stop");
+		expect(toolCalls(result)[0]?.incompleteArguments).toBe(true);
+	});
+
+	it("rejects tool events that arrive after message_stop", async () => {
+		const result = await run([
+			messageStart("msg_post_terminal"),
+			...terminal("tool_use"),
+			toolStart(0, "tool_post_terminal"),
+			toolDelta(0, '{"path":"a.ts"}'),
+			{ type: "content_block_stop", index: 0 },
+		]);
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("received event after message_stop");
+		expect(toolCalls(result)).toHaveLength(0);
+	});
+
+	it("does not flag an empty argument buffer on a max_tokens turn", async () => {
+		const result = await run([
+			messageStart("msg_empty"),
+			toolStart(0, "tool_empty"),
+			{ type: "content_block_stop", index: 0 },
+			...terminal("max_tokens"),
+		]);
+
+		expect(toolCalls(result)[0]?.incompleteArguments).toBeFalsy();
+	});
+
+	it("does not flag incomplete JSON when the turn ends for tool use", async () => {
+		const result = await run([
+			messageStart("msg_tool_use"),
+			toolStart(0, "tool_use"),
+			toolDelta(0, '{"path":"a.ts","content":"line1'),
+			{ type: "content_block_stop", index: 0 },
+			...terminal("tool_use"),
+		]);
+
+		expect(result.stopReason).toBe("toolUse");
+		expect(toolCalls(result)[0]?.incompleteArguments).toBeFalsy();
+	});
+
+	it("finalizes but does not flag an open block when the turn ends for tool use", async () => {
+		const result = await run([
+			messageStart("msg_open_tool_use"),
+			toolStart(0, "tool_open_use"),
+			toolDelta(0, '{"path":"a.ts","content":"line1'),
+			...terminal("tool_use"),
+		]);
+
+		const [tool] = toolCalls(result);
+		expect(result.stopReason).toBe("toolUse");
+		expect(tool?.incompleteArguments).toBeFalsy();
+		expect(tool && "partialJson" in tool).toBe(false);
+		expect(tool && "index" in tool).toBe(false);
+	});
+});

--- a/packages/ai/test/json-parse.test.ts
+++ b/packages/ai/test/json-parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { parseJsonWithRepair, parseStreamingJson, repairJson } from "@gajae-code/ai/utils/json-parse";
+import { isCompleteJson, parseJsonWithRepair, parseStreamingJson, repairJson } from "@gajae-code/ai/utils/json-parse";
 
 describe("JSON repair", () => {
 	it("leaves valid string escapes unchanged", () => {
@@ -25,5 +25,25 @@ describe("JSON repair", () => {
 	});
 	it("returns an empty object for whitespace-only streaming JSON", () => {
 		expect(parseStreamingJson<Record<string, unknown>>(" \t\n\r")).toEqual({});
+	});
+});
+
+describe("isCompleteJson", () => {
+	it("treats empty and whitespace-only inputs as complete", () => {
+		expect(isCompleteJson("")).toBe(true);
+		expect(isCompleteJson("   ")).toBe(true);
+		expect(isCompleteJson(undefined)).toBe(true);
+	});
+
+	it("accepts complete JSON", () => {
+		expect(isCompleteJson('{"a":1}')).toBe(true);
+		expect(isCompleteJson("[1,2,3]")).toBe(true);
+		expect(isCompleteJson('"str"')).toBe(true);
+	});
+
+	it("rejects truncated JSON", () => {
+		expect(isCompleteJson('{"a":1')).toBe(false);
+		expect(isCompleteJson('{"path":"/etc/hosts","content":"line1')).toBe(false);
+		expect(isCompleteJson("[1,2,")).toBe(false);
 	});
 });

--- a/packages/ai/test/ollama-truncated-toolcall.test.ts
+++ b/packages/ai/test/ollama-truncated-toolcall.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { streamOllama } from "../src/providers/ollama";
+import type { AssistantMessage, Context, Model, ToolCall } from "../src/types";
+
+const originalFetch = global.fetch;
+
+const model = {
+	id: "qwen3:latest",
+	name: "Qwen 3",
+	api: "ollama-chat",
+	provider: "ollama",
+	baseUrl: "http://127.0.0.1:11434",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 32_768,
+	maxTokens: 8_192,
+} satisfies Model<"ollama-chat">;
+
+const context: Context = {
+	messages: [{ role: "user", content: "Write the file", timestamp: Date.now() }],
+};
+
+async function runChunks(chunks: unknown[]): Promise<AssistantMessage> {
+	global.fetch = vi.fn(
+		async () =>
+			new Response(`${chunks.map(chunk => JSON.stringify(chunk)).join("\n")}\n`, {
+				status: 200,
+				headers: { "Content-Type": "application/x-ndjson" },
+			}),
+	) as unknown as typeof fetch;
+
+	const stream = streamOllama(model, context, { apiKey: "test-key" });
+	for await (const _event of stream) {
+		// Drain the provider stream.
+	}
+	return stream.result();
+}
+
+async function run(
+	argumentsValue: Record<string, unknown> | string,
+	doneReason?: "length" | "tool_calls",
+): Promise<AssistantMessage> {
+	return runChunks([
+		{
+			message: {
+				role: "assistant",
+				content: "",
+				tool_calls: [{ function: { name: "write_file", arguments: argumentsValue } }],
+			},
+			done: false,
+		},
+		{ done: true, done_reason: doneReason, prompt_eval_count: 5, eval_count: 9 },
+	]);
+}
+
+function firstTool(message: AssistantMessage): ToolCall | undefined {
+	return message.content.find((block): block is ToolCall => block.type === "toolCall");
+}
+
+afterEach(() => {
+	global.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+describe("Ollama truncated tool calls", () => {
+	it("flags an incomplete string argument buffer on a length stop", async () => {
+		const result = await run('{"path":"a.ts","content":"line1', "length");
+		const tool = firstTool(result);
+
+		expect(result.stopReason).toBe("length");
+		expect(tool?.incompleteArguments).toBe(true);
+		expect(tool && "partialJson" in tool).toBe(false);
+	});
+
+	it("does not flag a complete argument buffer on a length stop", async () => {
+		const result = await run('{"path":"a.ts"}', "length");
+
+		expect(firstTool(result)?.incompleteArguments).toBeFalsy();
+	});
+
+	it("fails closed for object-shaped arguments on a length stop", async () => {
+		const result = await run({ path: "a.ts" }, "length");
+
+		expect(result.stopReason).toBe("length");
+		expect(firstTool(result)?.incompleteArguments).toBe(true);
+	});
+
+	it("fails closed for absent arguments on a length stop", async () => {
+		const result = await runChunks([
+			{
+				message: { role: "assistant", content: "", tool_calls: [{ function: { name: "no_args" } }] },
+				done: false,
+			},
+			{ done: true, done_reason: "length" },
+		]);
+
+		expect(firstTool(result)?.incompleteArguments).toBe(true);
+	});
+
+	it("fails closed for null arguments on a length stop", async () => {
+		const result = await runChunks([
+			{
+				message: {
+					role: "assistant",
+					content: "",
+					tool_calls: [{ function: { name: "no_args", arguments: null } }],
+				},
+				done: false,
+			},
+			{ done: true, done_reason: "length" },
+		]);
+
+		expect(firstTool(result)?.incompleteArguments).toBe(true);
+	});
+
+	it("does not flag object-shaped arguments on an explicit tool-use stop", async () => {
+		const result = await run({ path: "a.ts" }, "tool_calls");
+
+		expect(firstTool(result)?.incompleteArguments).toBeFalsy();
+	});
+
+	it("removes the private buffer for an empty no-argument string call", async () => {
+		const result = await run("", "tool_calls");
+		const tool = firstTool(result);
+
+		expect(tool?.incompleteArguments).toBeFalsy();
+		expect(tool && "partialJson" in tool).toBe(false);
+	});
+
+	it("does not flag an incomplete buffer when the stop reason is tool use", async () => {
+		const result = await run('{"path":"a.ts","content":"line1', "tool_calls");
+
+		expect(result.stopReason).toBe("toolUse");
+		expect(firstTool(result)?.incompleteArguments).toBeFalsy();
+	});
+
+	it("flags an incomplete string buffer when the terminal reason is omitted", async () => {
+		const result = await run('{"path":"a.ts","content":"line1');
+
+		expect(result.stopReason).toBe("toolUse");
+		expect(firstTool(result)?.incompleteArguments).toBe(true);
+	});
+
+	it("accepts a complete string buffer when the terminal reason is omitted", async () => {
+		const result = await run('{"path":"a.ts"}');
+
+		expect(result.stopReason).toBe("toolUse");
+		expect(firstTool(result)?.incompleteArguments).toBeFalsy();
+	});
+
+	it("fails closed when the stream ends before a terminal done chunk", async () => {
+		const result = await runChunks([
+			{
+				message: {
+					role: "assistant",
+					content: "",
+					tool_calls: [{ function: { name: "write_file", arguments: '{"path":"a.ts","content":"line1' } }],
+				},
+				done: false,
+			},
+		]);
+		const tool = firstTool(result);
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("ended before terminal done chunk");
+		expect(tool && "partialJson" in tool).toBe(false);
+	});
+
+	it("ignores tool-call chunks after the terminal done chunk", async () => {
+		const result = await runChunks([
+			{ message: { role: "assistant", content: "done" }, done: true, done_reason: "stop" },
+			{
+				message: {
+					role: "assistant",
+					content: "",
+					tool_calls: [{ function: { name: "late_tool", arguments: '{"path":"late.ts"}' } }],
+				},
+				done: false,
+			},
+		]);
+
+		expect(result.stopReason).toBe("stop");
+		expect(firstTool(result)).toBeUndefined();
+	});
+});

--- a/packages/ai/test/openai-responses-truncated-toolcall.test.ts
+++ b/packages/ai/test/openai-responses-truncated-toolcall.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { processResponsesStream } from "@gajae-code/ai/providers/openai-responses-shared";
 import type { AssistantMessage, Model, ToolCall } from "@gajae-code/ai/types";
-import { isCompleteJson } from "@gajae-code/ai/utils/json-parse";
 import type { ResponseStreamEvent } from "openai/resources/responses/responses";
 
 // A response cut short for length (`incomplete`) can stop mid-tool-call. The
@@ -207,25 +206,8 @@ describe("Responses provider: truncated tool-call detection", () => {
 
 		const tools = toolBlocks(output);
 		expect(tools).toHaveLength(1);
+		expect(tools[0].customWireName).toBe("apply_patch");
 		expect(tools[0].arguments).toEqual({ input: fullPatch });
 		expect(tools[0].incompleteArguments).toBeFalsy();
-	});
-});
-
-describe("isCompleteJson", () => {
-	test("treats empty / whitespace as complete (no-arg tools)", () => {
-		expect(isCompleteJson("")).toBe(true);
-		expect(isCompleteJson("   ")).toBe(true);
-		expect(isCompleteJson(undefined)).toBe(true);
-	});
-	test("accepts well-formed JSON", () => {
-		expect(isCompleteJson('{"a":1}')).toBe(true);
-		expect(isCompleteJson("[1,2,3]")).toBe(true);
-		expect(isCompleteJson('"str"')).toBe(true);
-	});
-	test("rejects truncated JSON", () => {
-		expect(isCompleteJson('{"a":1')).toBe(false);
-		expect(isCompleteJson('{"path":"/etc/hosts","content":"line1')).toBe(false);
-		expect(isCompleteJson("[1,2,")).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary

- preserve strict JSON-completeness evidence in the Anthropic adapter before `partialJson` is discarded, including closed, open, and duplicate-index orphaned tool blocks
- mark incomplete Anthropic calls only after the turn is known to have stopped for length, allowing the existing centralized agent-loop guard to reject them before tool execution
- map Ollama's stop reason before tool finalization and reuse `flagTruncatedToolCalls` while its raw string argument buffer is still available
- add provider, false-positive, cleanup, exact-request-bound, and real adapter-to-dispatch regression coverage
- refresh the deterministic Anthropic source-identity artifact and AI changelog

## Verification

- `bun test packages/ai/test/anthropic-truncated-toolcall.test.ts packages/agent/test/agent-loop-anthropic-truncated-toolcall.test.ts packages/ai/test/anthropic-stream-envelope.test.ts packages/ai/test/anthropic-cache-eval.integration.test.ts` — 35 passed
- `bun test packages/ai/test/ollama-truncated-toolcall.test.ts packages/ai/test/ollama-provider.test.ts packages/ai/test/ollama-tool-choice.test.ts` — 9 passed
- `bun test packages/agent/test/agent-loop-truncated-toolcall.test.ts packages/ai/test/json-parse.test.ts packages/ai/test/openai-responses-truncated-toolcall.test.ts packages/ai/test/openai-codex-truncated-toolcall.test.ts packages/ai/test/openai-completions-truncated-toolcall.test.ts` — 20 passed
- hermetic `packages/ai` suite with user endpoint overrides removed — 1977 passed, 337 environment-gated skips, 0 failed
- `bun run check` in `packages/agent` — Biome and TypeScript passed
- changed-file Biome and `git diff --check` passed

The `packages/ai` TypeScript package check is not a trustworthy local signal in this linked worktree because its shared `node_modules` resolves `@gajae-code/*` to the primary checkout, producing duplicate private-class and event-stream identities. Runtime suites, changed-file Biome, and the Agent package typecheck are clean; CI runs in a normal workspace layout.

## Scope and residual risk

This PR is **fail-closed containment for Anthropic and Ollama only**, not provider-independent incident closure.

Ollama containment applies only when the provider supplies `function.arguments` as a string, preserving a raw JSON buffer that can be checked before deletion. Object-shaped arguments are serialized as already-complete JSON and remain outside this partial-buffer detector.

Deferred follow-ups:

- writer stage-slot reclamation without weakening anti-clobber guarantees
- runtime-owned chunked/append artifact ingress for oversized restricted-role plans; this Tier owns deferred **AC7 / T10**: repeated identical truncation must remain bounded, execute zero tools, and persist zero ralplan receipts until a complete artifact ingress succeeds
- Bedrock capture-before-delete parity
- Cursor stop-reason plumbing before truncation detection
- correction of ralplan's `/tmp` guidance for restricted role agents

Already-poisoned ralplan stage slots remain immutable and require a fresh `--stage_n`. Semantically valid-but-shortened command strings are also outside a JSON-completeness detector's reach.
