### PR TITLE
fix(tui): prevent absolute-path autocomplete OOM

### DIFF
--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -207,6 +207,7 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 		lines: string[],
 		cursorLine: number,
 		cursorCol: number,
+		signal?: AbortSignal,
 	): Promise<{ items: AutocompleteItem[]; prefix: string } | null> {
 		const currentLine = lines[cursorLine] || "";
 		const textBeforeCursor = currentLine.slice(0, cursorCol);
@@ -239,7 +240,7 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 		const slashPrefix = getSlashTokenPrefix(textBeforeCursor);
 		if (slashPrefix) {
 			const baseSuggestions = withoutSkillCommandSuggestions(
-				await this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol),
+				await this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol, signal),
 			);
 			if (isRootPathSuggestionResult(baseSuggestions)) return baseSuggestions;
 			const skillCommandSuggestions = this.#getSkillCommandSuggestions(textBeforeCursor, {
@@ -256,14 +257,15 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 			if (emojiSuggestions) return emojiSuggestions;
 		}
 
-		return this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol);
+		return this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol, signal);
 	}
 	getForceFileSuggestions(
 		lines: string[],
 		cursorLine: number,
 		cursorCol: number,
+		signal?: AbortSignal,
 	): Promise<{ items: AutocompleteItem[]; prefix: string } | null> {
-		return this.#baseProvider.getForceFileSuggestions(lines, cursorLine, cursorCol);
+		return this.#baseProvider.getForceFileSuggestions(lines, cursorLine, cursorCol, signal);
 	}
 
 	applyCompletion(

--- a/packages/coding-agent/test/prompt-action-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-autocomplete.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import type { SlashCommand } from "@gajae-code/tui";
 import { Editor } from "@gajae-code/tui/components/editor";
 import { defaultEditorTheme } from "../../tui/test/test-themes";
@@ -6,10 +9,10 @@ import { KeybindingsManager as AppKeybindingsManager } from "../src/config/keybi
 import { createPromptActionAutocompleteProvider } from "../src/modes/prompt-action-autocomplete";
 
 describe("prompt action autocomplete", () => {
-	function createNoopProvider(commands: SlashCommand[] = []) {
+	function createNoopProvider(commands: SlashCommand[] = [], basePath = "/tmp") {
 		return createPromptActionAutocompleteProvider({
 			commands,
-			basePath: "/tmp",
+			basePath,
 			keybindings: AppKeybindingsManager.inMemory(),
 			copyCurrentLine: () => {},
 			copyPrompt: () => {},
@@ -205,6 +208,26 @@ describe("prompt action autocomplete", () => {
 		expect(suggestions?.prefix).toBe("/");
 		expect(suggestions?.items.some(item => item.value.startsWith("/"))).toBe(true);
 		expect(suggestions?.items.map(item => item.value)).not.toContain("model");
+	});
+
+	it("forwards cancellation to the underlying file discovery provider", async () => {
+		const basePath = fs.mkdtempSync(path.join(os.tmpdir(), "prompt-action-autocomplete-cancel-"));
+		try {
+			fs.mkdirSync(path.join(basePath, "nested"), { recursive: true });
+			fs.writeFileSync(path.join(basePath, "nested", "signal-target.txt"), "nested\n");
+			fs.writeFileSync(path.join(basePath, "signaltarget-local.txt"), "fallback\n");
+			const provider = createNoopProvider([], basePath);
+			const line = "@signaltarget";
+
+			const activeResult = await provider.getSuggestions([line], 0, line.length);
+			expect(activeResult?.items.some(item => item.value.includes("signal-target.txt"))).toBe(true);
+
+			const controller = new AbortController();
+			controller.abort();
+			expect(await provider.getSuggestions([line], 0, line.length, controller.signal)).toBeNull();
+		} finally {
+			fs.rmSync(basePath, { recursive: true, force: true });
+		}
 	});
 
 	it("opens the composer autocomplete list from an adjacent inline slash", async () => {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- File mention autocomplete now cancels superseded searches and completes absolute or home-relative paths one directory segment at a time, preventing broad recursive scans from exhausting memory while typing `@` paths.
+
 ## [0.12.0] - 2026-07-28
 
 ### Changed

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fuzzyFind } from "@gajae-code/natives";
-import { getProjectDir } from "@gajae-code/utils";
+import { getProjectDir, untilAborted } from "@gajae-code/utils";
 
 const PATH_DELIMITERS = new Set([" ", "\t", '"', "'", "="]);
 
@@ -267,6 +267,7 @@ export interface AutocompleteProvider {
 		lines: string[],
 		cursorLine: number,
 		cursorCol: number,
+		signal?: AbortSignal,
 	): Promise<{
 		items: AutocompleteItem[];
 		prefix: string; // What we're matching against (e.g., "/" or "src/")
@@ -288,6 +289,12 @@ export interface AutocompleteProvider {
 
 	/** Get inline hint text to show as dim ghost text after the cursor */
 	getInlineHint?(lines: string[], cursorLine: number, cursorCol: number): string | null;
+	getForceFileSuggestions?(
+		lines: string[],
+		cursorLine: number,
+		cursorCol: number,
+		signal?: AbortSignal,
+	): Promise<{ items: AutocompleteItem[]; prefix: string } | null>;
 	/** Synchronously try to complete a slash command at the start of a line (no async I/O). */
 	/** Returns matched items and the full prefix, or null if not applicable. */
 	trySyncSlashCompletion?(textBeforeCursor: string): { items: AutocompleteItem[]; prefix: string } | null;
@@ -306,15 +313,21 @@ export interface AutocompleteProvider {
 export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	#commands: (SlashCommand | AutocompleteItem)[];
 	#basePath: string;
+	#homePath: string;
 	// Intentionally separate from pi-natives cache: this cache is a local,
 	// per-directory readdir fast-path for prefix completions. Global fuzzy
 	// discovery continues to use native fuzzyFind + shared scan cache.
 	#dirCache: Map<string, { entries: fs.Dirent[]; timestamp: number }> = new Map();
 	readonly #DIR_CACHE_TTL = 2000; // 2 seconds
 
-	constructor(commands: (SlashCommand | AutocompleteItem)[] = [], basePath: string = getProjectDir()) {
+	constructor(
+		commands: (SlashCommand | AutocompleteItem)[] = [],
+		basePath: string = getProjectDir(),
+		homePath: string = os.homedir(),
+	) {
 		this.#commands = commands;
 		this.#basePath = basePath;
+		this.#homePath = homePath;
 	}
 
 	#getCommandName(cmd: SlashCommand | AutocompleteItem): string {
@@ -381,6 +394,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		lines: string[],
 		cursorLine: number,
 		cursorCol: number,
+		signal?: AbortSignal,
 	): Promise<{ items: AutocompleteItem[]; prefix: string } | null> {
 		const currentLine = lines[cursorLine] || "";
 		const textBeforeCursor = currentLine.slice(0, cursorCol);
@@ -388,13 +402,16 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		// Check for @ file reference (fuzzy search) - must be after a delimiter or at start
 		const atPrefix = this.#extractAtPrefix(textBeforeCursor);
 		if (atPrefix) {
+			if (signal?.aborted) return null;
 			const { rawPrefix, isQuotedPrefix } = parsePathPrefix(atPrefix);
+			const usesBoundedPathCompletion = this.#isAbsoluteOrHomePrefix(rawPrefix);
 			const suggestions =
-				rawPrefix.length > 0
-					? await this.#getFuzzyFileSuggestions(rawPrefix, { isQuotedPrefix })
-					: await this.#getFileSuggestions("@");
-			if (suggestions.length === 0 && rawPrefix.length > 0) {
-				const fallback = await this.#getFileSuggestions(atPrefix);
+				rawPrefix.length > 0 && !usesBoundedPathCompletion
+					? await this.#getFuzzyFileSuggestions(rawPrefix, { isQuotedPrefix }, signal)
+					: await this.#getFileSuggestions(atPrefix, signal, { fuzzy: usesBoundedPathCompletion });
+			if (signal?.aborted) return null;
+			if (suggestions.length === 0 && rawPrefix.length > 0 && !usesBoundedPathCompletion) {
+				const fallback = await this.#getFileSuggestions(atPrefix, signal);
 				if (fallback.length === 0) return null;
 				return { items: fallback, prefix: atPrefix };
 			}
@@ -448,7 +465,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const slashPrefix = this.#extractSlashCommandPrefix(textBeforeCursor);
 		if (slashPrefix) {
 			if (pathMatch === slashPrefix && slashPrefix.startsWith("/")) {
-				pathSuggestions = await this.#getFileSuggestions(pathMatch);
+				pathSuggestions = await this.#getFileSuggestions(pathMatch, signal);
 				if (pathSuggestions.length > 0) {
 					return {
 						items: pathSuggestions,
@@ -468,7 +485,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 
 		// Check for file paths - triggered by Tab or if we detect a path pattern
 		if (pathMatch !== null) {
-			const suggestions = pathSuggestions ?? (await this.#getFileSuggestions(pathMatch));
+			const suggestions = pathSuggestions ?? (await this.#getFileSuggestions(pathMatch, signal));
 			if (suggestions.length === 0) return null;
 
 			// Check if we have an exact match that is a directory
@@ -525,14 +542,15 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		// Check if we're completing a file attachment (prefix starts with "@")
 		if (prefix.startsWith("@")) {
 			// This is a file attachment completion
-			const newLine = `${beforePrefix + item.value} ${afterCursor}`;
+			const suffix = item.value.endsWith("/") ? "" : " ";
+			const newLine = beforePrefix + item.value + suffix + afterCursor;
 			const newLines = [...lines];
 			newLines[cursorLine] = newLine;
 
 			return {
 				lines: newLines,
 				cursorLine,
-				cursorCol: beforePrefix.length + item.value.length + 1, // +1 for space
+				cursorCol: beforePrefix.length + item.value.length + suffix.length,
 			};
 		}
 
@@ -612,21 +630,27 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		return null;
 	}
 
+	#isAbsoluteOrHomePrefix(prefix: string): boolean {
+		return path.isAbsolute(prefix) || prefix === "~" || prefix.startsWith("~/");
+	}
+
 	// Expand home directory (~/) to actual home path
 	#expandHomePath(filePath: string): string {
 		if (filePath.startsWith("~/")) {
-			const expandedPath = path.join(os.homedir(), filePath.slice(2));
+			const expandedPath = path.join(this.#homePath, filePath.slice(2));
 			// Preserve trailing slash if original path had one
 			return filePath.endsWith("/") && !expandedPath.endsWith("/") ? `${expandedPath}/` : expandedPath;
 		} else if (filePath === "~") {
-			return os.homedir();
+			return this.#homePath;
 		}
 		return filePath;
 	}
 
 	async #resolveScopedFuzzyQuery(
 		rawQuery: string,
+		signal?: AbortSignal,
 	): Promise<{ baseDir: string; query: string; displayBase: string } | null> {
+		signal?.throwIfAborted();
 		const slashIndex = rawQuery.lastIndexOf("/");
 		if (slashIndex === -1) {
 			return null;
@@ -645,10 +669,11 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		}
 
 		try {
-			if (!(await fs.promises.stat(baseDir)).isDirectory()) {
+			if (!(await untilAborted(signal, fs.promises.stat(baseDir))).isDirectory()) {
 				return null;
 			}
 		} catch {
+			signal?.throwIfAborted();
 			return null;
 		}
 
@@ -662,7 +687,8 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		return `${displayBase}${relativePath}`;
 	}
 
-	async #getCachedDirEntries(searchDir: string): Promise<fs.Dirent[]> {
+	async #getCachedDirEntries(searchDir: string, signal?: AbortSignal): Promise<fs.Dirent[]> {
+		signal?.throwIfAborted();
 		const now = Date.now();
 		const cached = this.#dirCache.get(searchDir);
 
@@ -670,7 +696,8 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			return cached.entries;
 		}
 
-		const entries = await fs.promises.readdir(searchDir, { withFileTypes: true });
+		const entries = await untilAborted(signal, fs.promises.readdir(searchDir, { withFileTypes: true }));
+		signal?.throwIfAborted();
 		this.#dirCache.set(searchDir, { entries, timestamp: now });
 
 		if (this.#dirCache.size > 100) {
@@ -695,8 +722,13 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	}
 
 	// Get file/directory suggestions for a given path prefix
-	async #getFileSuggestions(prefix: string): Promise<AutocompleteItem[]> {
+	async #getFileSuggestions(
+		prefix: string,
+		signal?: AbortSignal,
+		options?: { fuzzy?: boolean },
+	): Promise<AutocompleteItem[]> {
 		try {
+			signal?.throwIfAborted();
 			let searchDir: string;
 			let searchPrefix: string;
 			const { rawPrefix, isAtPrefix, isQuotedPrefix } = parsePathPrefix(prefix);
@@ -706,6 +738,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			if (expandedPrefix.startsWith("~")) {
 				expandedPrefix = this.#expandHomePath(expandedPrefix);
 			}
+			const isExpandedAbsolute = path.isAbsolute(expandedPrefix);
 
 			const isRootPrefix =
 				rawPrefix === "" ||
@@ -718,15 +751,15 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 
 			if (isRootPrefix) {
 				// Complete from specified position
-				if (rawPrefix.startsWith("~") || expandedPrefix.startsWith("/")) {
+				if (rawPrefix.startsWith("~") || isExpandedAbsolute) {
 					searchDir = expandedPrefix;
 				} else {
 					searchDir = path.join(this.#basePath, expandedPrefix);
 				}
 				searchPrefix = "";
-			} else if (rawPrefix.endsWith("/")) {
+			} else if (/[\\/]$/.test(rawPrefix)) {
 				// If prefix ends with /, show contents of that directory
-				if (rawPrefix.startsWith("~") || expandedPrefix.startsWith("/")) {
+				if (rawPrefix.startsWith("~") || isExpandedAbsolute) {
 					searchDir = expandedPrefix;
 				} else {
 					searchDir = path.join(this.#basePath, expandedPrefix);
@@ -736,7 +769,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				// Split into directory and file prefix
 				const dir = path.dirname(expandedPrefix);
 				const file = path.basename(expandedPrefix);
-				if (rawPrefix.startsWith("~") || expandedPrefix.startsWith("/")) {
+				if (rawPrefix.startsWith("~") || isExpandedAbsolute) {
 					searchDir = dir;
 				} else {
 					searchDir = path.join(this.#basePath, dir);
@@ -744,11 +777,19 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				searchPrefix = file;
 			}
 
-			const entries = await this.#getCachedDirEntries(searchDir);
-			const suggestions: AutocompleteItem[] = [];
+			const entries = await this.#getCachedDirEntries(searchDir, signal);
+			const suggestions: Array<AutocompleteItem & { matchScore: number }> = [];
+			const normalizedSearchPrefix = searchPrefix.toLowerCase();
 
 			for (const entry of entries) {
-				if (!entry.name.toLowerCase().startsWith(searchPrefix.toLowerCase())) {
+				signal?.throwIfAborted();
+				const normalizedName = entry.name.toLowerCase();
+				const matchScore = options?.fuzzy
+					? fuzzyScore(normalizedSearchPrefix, normalizedName)
+					: normalizedName.startsWith(normalizedSearchPrefix)
+						? 1
+						: 0;
+				if (matchScore === 0) {
 					continue;
 				}
 				// Skip .git directory
@@ -761,8 +802,9 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				if (!isDirectory && entry.isSymbolicLink()) {
 					try {
 						const fullPath = path.join(searchDir, entry.name);
-						isDirectory = (await fs.promises.stat(fullPath)).isDirectory();
+						isDirectory = (await untilAborted(signal, fs.promises.stat(fullPath))).isDirectory();
 					} catch {
+						signal?.throwIfAborted();
 						// Broken symlink, file deleted between readdir and stat, or permission error
 						continue;
 					}
@@ -772,23 +814,18 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				const name = entry.name;
 				const displayPrefix = rawPrefix;
 
-				if (displayPrefix.endsWith("/")) {
+				if (/[\\/]$/.test(displayPrefix)) {
 					// If prefix ends with /, append entry to the prefix
 					relativePath = displayPrefix + name;
-				} else if (displayPrefix.includes("/")) {
+				} else if (/[\\/]/.test(displayPrefix)) {
 					// Preserve ~/ format for home directory paths
 					if (displayPrefix.startsWith("~/")) {
 						const homeRelativeDir = displayPrefix.slice(2); // Remove ~/
 						const dir = path.dirname(homeRelativeDir);
 						relativePath = `~/${dir === "." ? name : path.join(dir, name)}`;
-					} else if (displayPrefix.startsWith("/")) {
+					} else if (path.isAbsolute(displayPrefix)) {
 						// Absolute path - construct properly
-						const dir = path.dirname(displayPrefix);
-						if (dir === "/") {
-							relativePath = `/${name}`;
-						} else {
-							relativePath = `${dir}/${name}`;
-						}
+						relativePath = path.join(path.dirname(displayPrefix), name);
 					} else {
 						relativePath = path.join(path.dirname(displayPrefix), name);
 						if (displayPrefix.startsWith("./") && !relativePath.startsWith("./")) {
@@ -814,6 +851,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				suggestions.push({
 					value,
 					label: name + (isDirectory ? "/" : ""),
+					matchScore,
 				});
 			}
 
@@ -823,22 +861,33 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				const bIsDir = b.value.endsWith("/");
 				if (aIsDir && !bIsDir) return -1;
 				if (!aIsDir && bIsDir) return 1;
+				if (options?.fuzzy && a.matchScore !== b.matchScore) {
+					return b.matchScore - a.matchScore;
+				}
 				return a.label.localeCompare(b.label);
 			});
 
-			return suggestions;
+			return suggestions.map(({ matchScore: _matchScore, ...item }) => item);
 		} catch {
 			// Directory doesn't exist or not accessible
 			return [];
 		}
 	}
 
-	async #getFuzzyFileSuggestions(query: string, options: { isQuotedPrefix: boolean }): Promise<AutocompleteItem[]> {
+	async #getFuzzyFileSuggestions(
+		query: string,
+		options: { isQuotedPrefix: boolean },
+		signal?: AbortSignal,
+	): Promise<AutocompleteItem[]> {
 		try {
-			const scopedQuery = await this.#resolveScopedFuzzyQuery(query);
+			const scopedQuery = await this.#resolveScopedFuzzyQuery(query, signal);
+			signal?.throwIfAborted();
 			const searchPath = scopedQuery?.baseDir ?? this.#basePath;
 			const fuzzyQuery = scopedQuery?.query ?? query;
-			const result = await fuzzyFind(buildAutocompleteFuzzyDiscoveryProfile(fuzzyQuery, searchPath));
+			const result = await fuzzyFind({
+				...buildAutocompleteFuzzyDiscoveryProfile(fuzzyQuery, searchPath),
+				signal,
+			});
 			const lowerQuery = fuzzyQuery.toLowerCase();
 			const filteredMatches = result.matches.filter(entry => {
 				const p = entry.path.endsWith("/") ? entry.path.slice(0, -1) : entry.path;
@@ -879,7 +928,9 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		lines: string[],
 		cursorLine: number,
 		cursorCol: number,
+		signal?: AbortSignal,
 	): Promise<{ items: AutocompleteItem[]; prefix: string } | null> {
+		if (signal?.aborted) return null;
 		const currentLine = lines[cursorLine] || "";
 		const textBeforeCursor = currentLine.slice(0, cursorCol);
 
@@ -891,7 +942,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		// Force extract path prefix - this will always return something
 		const pathMatch = this.#extractPathPrefix(textBeforeCursor, true);
 		if (pathMatch !== null) {
-			const suggestions = await this.#getFileSuggestions(pathMatch);
+			const suggestions = await this.#getFileSuggestions(pathMatch, signal);
 			if (suggestions.length === 0) return null;
 
 			return {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1,5 +1,6 @@
 import { getProjectDir, logger, onDefaultTabWidthChange } from "@gajae-code/utils";
 import {
+	type AutocompleteItem,
 	type AutocompleteProvider,
 	type CombinedAutocompleteProvider,
 	extractSlashCommandTokenPrefix,
@@ -460,6 +461,7 @@ export class Editor implements Component, Focusable {
 	#autocompleteState: "regular" | "force" | null = null;
 	#autocompletePrefix: string = "";
 	#autocompleteRequestId: number = 0;
+	#autocompleteRequestController?: AbortController;
 	#autocompleteOrigin?: { docVersion: number; cursorLine: number; cursorCol: number };
 	#autocompleteMaxVisible: number = 5;
 	onAutocompleteUpdate?: () => void;
@@ -520,6 +522,8 @@ export class Editor implements Component, Focusable {
 	dispose(): void {
 		this.#disposeTabWidthListener?.();
 		this.#disposeTabWidthListener = undefined;
+		this.#abortAutocompleteRequest();
+		this.#clearAutocompleteTimeout();
 	}
 
 	setAutocompleteProvider(provider: AutocompleteProvider): void {
@@ -691,6 +695,7 @@ export class Editor implements Component, Focusable {
 	}
 	/** Internal setText that doesn't reset history state - used by navigateHistory */
 	#setTextInternal(text: string, cursorAnchor: HistoryCursorAnchor = "end"): void {
+		this.#cancelAutocomplete();
 		this.#undoStack.length = 0;
 		const lines = sanitizeLoadedText(text).split("\n");
 		this.#state.lines = lines.length === 0 ? [""] : lines;
@@ -1154,6 +1159,10 @@ export class Editor implements Component, Focusable {
 					this.handleInput(paste.remaining);
 				}
 			}
+			return;
+		}
+		if (!this.#autocompleteState && this.#autocompleteRequestController && kb.matches(data, "tui.select.cancel")) {
+			this.#cancelAutocomplete();
 			return;
 		}
 
@@ -1837,6 +1846,7 @@ export class Editor implements Component, Focusable {
 
 	// All the editor methods from before...
 	#insertCharacter(char: string): void {
+		this.#abortAutocompleteRequest();
 		this.#exitHistoryForEditing();
 		this.#resetKillSequence();
 		this.#recordUndoState();
@@ -1901,6 +1911,14 @@ export class Editor implements Component, Focusable {
 			// Auto-trigger for "#" prompt actions anywhere in the current token
 			else if (char === "#") {
 				this.#tryTriggerAutocomplete();
+			}
+			// Continue a home-relative @ mention after the standalone "~" marker.
+			else if (char === "~") {
+				const currentLine = this.#state.lines[this.#state.cursorLine] || "";
+				const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
+				if (textBeforeCursor.match(/(?:^|[\s])@[^\s]*$/)) {
+					this.#tryTriggerAutocomplete();
+				}
 			}
 			// Also auto-trigger when typing letters/path chars in a completable context
 			else if (/[a-zA-Z0-9.\-_/]/.test(char)) {
@@ -2037,6 +2055,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	#submitValue(): void {
+		this.#cancelAutocomplete();
 		this.#resetKillSequence();
 
 		const result = this.#expandPasteMarkers(this.#state.lines.join("\n")).trim();
@@ -2055,6 +2074,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	#handleBackspace(): void {
+		this.#abortAutocompleteRequest();
 		this.#historyIndex = -1; // Exit history browsing mode
 		this.#resetKillSequence();
 		this.#recordUndoState();
@@ -2088,6 +2108,11 @@ export class Editor implements Component, Focusable {
 
 		if (this.onChange) {
 			this.onChange(this.getText());
+		}
+
+		if (this.#isEditorEmpty()) {
+			this.#cancelAutocomplete();
+			return;
 		}
 
 		// Update or re-trigger autocomplete after backspace
@@ -2193,28 +2218,54 @@ export class Editor implements Component, Focusable {
 		return result;
 	}
 
+	#cancelAutocompleteAfterCursorMove(previousLine: number, previousCol: number): void {
+		if (previousLine === this.#state.cursorLine && previousCol === this.#state.cursorCol) {
+			return;
+		}
+
+		const hadPendingRequest =
+			this.#autocompleteRequestController !== undefined || this.#autocompleteTimeout !== undefined;
+		if (!hadPendingRequest) {
+			return;
+		}
+
+		const hadAutocomplete = this.#autocompleteState !== null;
+		this.#cancelAutocomplete();
+		if (hadAutocomplete) {
+			this.onAutocompleteUpdate?.();
+		}
+	}
+
 	#moveToLineStart(): void {
+		const { cursorLine, cursorCol } = this.#state;
 		this.#resetKillSequence();
 		this.#setCursorCol(0);
+		this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 	}
 
 	#moveToLineEnd(): void {
+		const { cursorLine, cursorCol } = this.#state;
 		this.#resetKillSequence();
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 		this.#setCursorCol(currentLine.length);
+		this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 	}
 
 	#moveToMessageStart(): void {
+		const { cursorLine, cursorCol } = this.#state;
 		this.#resetKillSequence();
 		this.#state.cursorLine = 0;
 		this.#setCursorCol(0);
+		this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 	}
 
 	#moveToMessageEnd(): void {
+		const { cursorLine, cursorCol } = this.#state;
 		this.#resetKillSequence();
 		this.#state.cursorLine = this.#state.lines.length - 1;
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 		this.#setCursorCol(currentLine.length);
+		this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 	}
 
 	#resetKillSequence(): void {
@@ -2535,6 +2586,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	#handleForwardDelete(): void {
+		this.#abortAutocompleteRequest();
 		this.#historyIndex = -1; // Exit history browsing mode
 		this.#resetKillSequence();
 		this.#recordUndoState();
@@ -2642,6 +2694,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	#moveCursor(deltaLine: number, deltaCol: number): void {
+		const { cursorLine, cursorCol } = this.#state;
 		this.#resetKillSequence();
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 		const needsVisualLines = deltaLine !== 0 || (deltaCol > 0 && this.#state.cursorCol >= currentLine.length);
@@ -2700,9 +2753,12 @@ export class Editor implements Component, Focusable {
 				}
 			}
 		}
+
+		this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 	}
 
 	#pageScroll(direction: -1 | 1): void {
+		const { cursorLine, cursorCol } = this.#state;
 		this.#resetKillSequence();
 		const visualLines = this.#buildVisualLineMap(this.#lastLayoutWidth);
 		const currentVisualLine = this.#findCurrentVisualLine(visualLines);
@@ -2710,9 +2766,11 @@ export class Editor implements Component, Focusable {
 		const targetVisualLine = Math.max(0, Math.min(visualLines.length - 1, currentVisualLine + direction * step));
 		if (targetVisualLine === currentVisualLine) return;
 		this.#moveToVisualLine(visualLines, currentVisualLine, targetVisualLine);
+		this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 	}
 
 	#moveWordBackwards(): void {
+		const { cursorLine, cursorCol } = this.#state;
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 
 		// If at start of line, move to end of previous line
@@ -2722,10 +2780,12 @@ export class Editor implements Component, Focusable {
 				const prevLine = this.#state.lines[this.#state.cursorLine] || "";
 				this.#setCursorCol(prevLine.length);
 			}
+			this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 			return;
 		}
 
 		this.#setCursorCol(moveWordLeft(currentLine, this.#state.cursorCol));
+		this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 	}
 
 	/**
@@ -2733,6 +2793,7 @@ export class Editor implements Component, Focusable {
 	 * Multi-line search. Case-sensitive. Skips the current cursor position.
 	 */
 	#jumpToChar(char: string, direction: "forward" | "backward"): void {
+		const { cursorLine, cursorCol } = this.#state;
 		this.#resetKillSequence();
 		const isForward = direction === "forward";
 		const lines = this.#state.lines;
@@ -2762,6 +2823,7 @@ export class Editor implements Component, Focusable {
 			if (idx !== -1) {
 				this.#state.cursorLine = lineIdx;
 				this.#setCursorCol(idx);
+				this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 				return;
 			}
 		}
@@ -2769,6 +2831,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	#moveWordForwards(): void {
+		const { cursorLine, cursorCol } = this.#state;
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 
 		// If at end of line, move to start of next line
@@ -2777,10 +2840,12 @@ export class Editor implements Component, Focusable {
 				this.#state.cursorLine++;
 				this.#setCursorCol(0);
 			}
+			this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 			return;
 		}
 
 		this.#setCursorCol(moveWordRight(currentLine, this.#state.cursorCol));
+		this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 	}
 
 	#hasOnlyWhitespaceBeforeCursorLine(): boolean {
@@ -2875,11 +2940,21 @@ export class Editor implements Component, Focusable {
 		const origin = this.#captureAutocompleteOrigin();
 		const requestId = ++this.#autocompleteRequestId;
 
-		const suggestions = await this.#autocompleteProvider.getSuggestions(
-			this.#state.lines,
-			this.#state.cursorLine,
-			this.#state.cursorCol,
-		);
+		const signal = this.#newAutocompleteRequestController().signal;
+		let suggestions: { items: AutocompleteItem[]; prefix: string } | null;
+		try {
+			suggestions = await this.#autocompleteProvider.getSuggestions(
+				this.#state.lines,
+				this.#state.cursorLine,
+				this.#state.cursorCol,
+				signal,
+			);
+		} catch (error) {
+			if (signal.aborted) return;
+			throw error;
+		} finally {
+			this.#finishAutocompleteRequest(signal);
+		}
 		if (requestId !== this.#autocompleteRequestId || !this.#isAutocompleteOriginCurrent(origin)) return;
 
 		if (suggestions && Array.isArray(suggestions.items) && suggestions.items.length > 0) {
@@ -2948,11 +3023,21 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 
 		const origin = this.#captureAutocompleteOrigin();
 		const requestId = ++this.#autocompleteRequestId;
-		const suggestions = await provider.getForceFileSuggestions(
-			this.#state.lines,
-			this.#state.cursorLine,
-			this.#state.cursorCol,
-		);
+		const signal = this.#newAutocompleteRequestController().signal;
+		let suggestions: { items: AutocompleteItem[]; prefix: string } | null;
+		try {
+			suggestions = await provider.getForceFileSuggestions(
+				this.#state.lines,
+				this.#state.cursorLine,
+				this.#state.cursorCol,
+				signal,
+			);
+		} catch (error) {
+			if (signal.aborted) return;
+			throw error;
+		} finally {
+			this.#finishAutocompleteRequest(signal);
+		}
 		if (requestId !== this.#autocompleteRequestId || !this.#isAutocompleteOriginCurrent(origin)) return;
 
 		if (suggestions && Array.isArray(suggestions.items) && suggestions.items.length > 0) {
@@ -2992,6 +3077,7 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 
 	#cancelAutocomplete(notifyCancel: boolean = false): void {
 		const wasAutocompleting = this.#autocompleteState !== null;
+		this.#abortAutocompleteRequest();
 		this.#clearAutocompleteTimeout();
 		this.#autocompleteRequestId += 1;
 		this.#autocompleteState = null;
@@ -3019,11 +3105,21 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 		const origin = this.#captureAutocompleteOrigin();
 		const requestId = ++this.#autocompleteRequestId;
 
-		const suggestions = await this.#autocompleteProvider.getSuggestions(
-			this.#state.lines,
-			this.#state.cursorLine,
-			this.#state.cursorCol,
-		);
+		const signal = this.#newAutocompleteRequestController().signal;
+		let suggestions: { items: AutocompleteItem[]; prefix: string } | null;
+		try {
+			suggestions = await this.#autocompleteProvider.getSuggestions(
+				this.#state.lines,
+				this.#state.cursorLine,
+				this.#state.cursorCol,
+				signal,
+			);
+		} catch (error) {
+			if (signal.aborted) return;
+			throw error;
+		} finally {
+			this.#finishAutocompleteRequest(signal);
+		}
 		if (requestId !== this.#autocompleteRequestId || !this.#isAutocompleteOriginCurrent(origin)) return;
 
 		if (suggestions && Array.isArray(suggestions.items) && suggestions.items.length > 0) {
@@ -3053,6 +3149,24 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 			clearTimeout(this.#autocompleteTimeout);
 			this.#autocompleteTimeout = undefined;
 		}
+	}
+
+	#abortAutocompleteRequest(): void {
+		this.#autocompleteRequestController?.abort();
+		this.#autocompleteRequestController = undefined;
+	}
+
+	#finishAutocompleteRequest(signal: AbortSignal): void {
+		if (this.#autocompleteRequestController?.signal === signal) {
+			this.#autocompleteRequestController = undefined;
+		}
+	}
+
+	#newAutocompleteRequestController(): AbortController {
+		this.#abortAutocompleteRequest();
+		const controller = new AbortController();
+		this.#autocompleteRequestController = controller;
+		return controller;
 	}
 
 	/**

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -133,6 +133,168 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(values).toContain("@../outside/nested/deeper/also-alpha.ts");
 			expect(values).not.toContain("@../outside/nested/deeper/zzz.ts");
 			expect(values.some(value => value.includes("alpha-local.ts"))).toBe(false);
+		});
+
+		it("cancels while resolving a scoped fuzzy-search directory", async () => {
+			const directoryStats = await fs.promises.stat(outsideDir);
+			const statStarted = Promise.withResolvers<void>();
+			const releaseStat = Promise.withResolvers<void>();
+			const statSpy = spyOn(fs.promises, "stat").mockImplementation((async () => {
+				statStarted.resolve();
+				await releaseStat.promise;
+				return directoryStats;
+			}) as unknown as typeof fs.promises.stat);
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = "@../outside/a";
+			const controller = new AbortController();
+			const pending = provider.getSuggestions([line], 0, line.length, controller.signal);
+
+			try {
+				await statStarted.promise;
+				controller.abort();
+				const timeout = Symbol("timeout");
+				const outcome = await Promise.race([pending, Bun.sleep(100).then(() => timeout)]);
+
+				expect(outcome).not.toBe(timeout);
+				expect(outcome).toBeNull();
+			} finally {
+				releaseStat.resolve();
+				statSpy.mockRestore();
+				await pending.catch(() => null);
+			}
+		});
+
+		describe("bounded absolute and home path completion", () => {
+			let mentionRoot: string;
+
+			beforeEach(() => {
+				mentionRoot = fs.mkdtempSync(path.join(os.tmpdir(), "autocomplete-absolute-test-"));
+				fs.mkdirSync(path.join(mentionRoot, "immediate-dir", "nested"), { recursive: true });
+				fs.writeFileSync(path.join(mentionRoot, "immediate-target.txt"), "immediate\n");
+				fs.writeFileSync(path.join(mentionRoot, "immediate-dir", "nested", "immediate-target.txt"), "nested\n");
+			});
+
+			afterEach(() => {
+				fs.rmSync(mentionRoot, { recursive: true, force: true });
+			});
+
+			it.each([
+				[
+					"absolute",
+					(root: string) => `@${path.join(root, "im")}`,
+					(root: string) => `@${path.join(root, "immediate-target.txt")}`,
+				],
+				[
+					"quoted absolute",
+					(root: string) => `@"${path.join(root, "im")}`,
+					(root: string) => `@"${path.join(root, "immediate-target.txt")}"`,
+				],
+				["home root", (_root: string) => "@~", (_root: string) => "@~/immediate-target.txt"],
+				["home child", (_root: string) => "@~/im", (_root: string) => "@~/immediate-target.txt"],
+				["quoted home child", (_root: string) => '@"~/im', (_root: string) => '@"~/immediate-target.txt"'],
+			])("enumerates only one directory segment for %s mentions", async (_name, inputFor, expectedFor) => {
+				const line = inputFor(mentionRoot);
+				const provider = new CombinedAutocompleteProvider([], baseDir, mentionRoot);
+				const result = await provider.getSuggestions([line], 0, line.length);
+				const values = result?.items.map(item => item.value) ?? [];
+
+				expect(values).toContain(expectedFor(mentionRoot));
+				expect(values.some(value => value.replaceAll("\\", "/").includes("/nested/"))).toBe(false);
+			});
+
+			it("preserves fuzzy matching within a bounded path segment", async () => {
+				fs.mkdirSync(path.join(mentionRoot, "Downloads"));
+				const provider = new CombinedAutocompleteProvider([], baseDir, mentionRoot);
+				const line = "@~/dwn";
+				const result = await provider.getSuggestions([line], 0, line.length);
+
+				expect(result?.items.map(item => item.value)).toContain("@~/Downloads/");
+			});
+
+			it("keeps bounded directory completions inside the mention token", async () => {
+				const provider = new CombinedAutocompleteProvider([], baseDir, mentionRoot);
+				const line = `@${path.join(mentionRoot, "immediate-d")}`;
+				const result = await provider.getSuggestions([line], 0, line.length);
+				const directory = result?.items.find(item => item.label === "immediate-dir/");
+
+				expect(directory).toBeDefined();
+				if (!result || !directory) throw new Error("expected immediate directory completion");
+
+				const applied = provider.applyCompletion([line], 0, line.length, directory, result.prefix);
+				const completedLine = `@${path.join(mentionRoot, "immediate-dir")}/`;
+
+				expect(applied.lines).toEqual([completedLine]);
+				expect(applied.cursorCol).toBe(completedLine.length);
+
+				const childResult = await provider.getSuggestions(applied.lines, applied.cursorLine, applied.cursorCol);
+				expect(childResult?.items.map(item => item.value)).toContain(`${completedLine}nested/`);
+			});
+
+			it("still terminates bounded file mentions with a space", async () => {
+				const provider = new CombinedAutocompleteProvider([], baseDir, mentionRoot);
+				const line = `@${path.join(mentionRoot, "immediate-t")}`;
+				const result = await provider.getSuggestions([line], 0, line.length);
+				const file = result?.items.find(item => item.label === "immediate-target.txt");
+
+				expect(file).toBeDefined();
+				if (!result || !file) throw new Error("expected immediate file completion");
+
+				const applied = provider.applyCompletion([line], 0, line.length, file, result.prefix);
+				const completedLine = `@${path.join(mentionRoot, "immediate-target.txt")} `;
+
+				expect(applied.lines).toEqual([completedLine]);
+				expect(applied.cursorCol).toBe(completedLine.length);
+			});
+
+			it("does not fall back to directory enumeration after native fuzzy cancellation", async () => {
+				fs.mkdirSync(path.join(mentionRoot, "nested"), { recursive: true });
+				fs.writeFileSync(path.join(mentionRoot, "nested", "signal-target.txt"), "signal\n");
+				fs.writeFileSync(path.join(mentionRoot, "signaltarget-local.txt"), "fallback\n");
+				const provider = new CombinedAutocompleteProvider([], mentionRoot, mentionRoot);
+				const line = "@signaltarget";
+
+				const activeResult = await provider.getSuggestions([line], 0, line.length);
+				expect(activeResult?.items.some(item => item.value.includes("signal-target.txt"))).toBe(true);
+
+				const controller = new AbortController();
+				controller.abort();
+				expect(await provider.getSuggestions([line], 0, line.length, controller.signal)).toBeNull();
+			});
+
+			it.each([
+				"regular",
+				"forced",
+			] as const)("cancels %s bounded path completion while directory enumeration is pending", async mode => {
+				const readdirStarted = Promise.withResolvers<void>();
+				const releaseReaddir = Promise.withResolvers<void>();
+				const readdirSpy = spyOn(fs.promises, "readdir").mockImplementation(async () => {
+					readdirStarted.resolve();
+					await releaseReaddir.promise;
+					return [];
+				});
+				const provider = new CombinedAutocompleteProvider([], mentionRoot, mentionRoot);
+				const line =
+					mode === "regular" ? `@${path.join(mentionRoot, "im")}` : `mention ${path.join(mentionRoot, "im")}`;
+				const controller = new AbortController();
+				const pending =
+					mode === "regular"
+						? provider.getSuggestions([line], 0, line.length, controller.signal)
+						: provider.getForceFileSuggestions([line], 0, line.length, controller.signal);
+
+				try {
+					await readdirStarted.promise;
+					controller.abort();
+					const timeout = Symbol("timeout");
+					const outcome = await Promise.race([pending, Bun.sleep(100).then(() => timeout)]);
+
+					expect(outcome).not.toBe(timeout);
+					expect(outcome).toBeNull();
+				} finally {
+					releaseReaddir.resolve();
+					readdirSpy.mockRestore();
+					await pending.catch(() => null);
+				}
+			});
 		});
 	});
 	describe("dot-slash path completion", () => {

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -6,6 +6,7 @@ import { __editorPerfCounters, Editor } from "@gajae-code/tui/components/editor"
 import { visibleWidth } from "@gajae-code/tui/utils";
 import { getDefaultTabWidth, setDefaultTabWidth } from "@gajae-code/utils";
 import { KeybindingsManager, setKeybindings, TUI_KEYBINDINGS } from "../src/keybindings";
+import { StdinBuffer } from "../src/stdin-buffer";
 import { defaultEditorTheme } from "./test-themes";
 
 describe("Editor component", () => {
@@ -317,6 +318,135 @@ describe("Editor component", () => {
 			editor.handleInput("@");
 
 			await expect(promise).resolves.toBe("@");
+		});
+
+		it("re-triggers file-reference autocomplete for @~ in one stdin chunk", async () => {
+			const editor = new Editor(defaultEditorTheme);
+			const stdin = new StdinBuffer();
+			const calls: string[] = [];
+
+			editor.setAutocompleteProvider({
+				async getSuggestions(lines, cursorLine, cursorCol) {
+					calls.push((lines[cursorLine] ?? "").slice(0, cursorCol));
+					return null;
+				},
+				applyCompletion(lines, cursorLine, cursorCol) {
+					return { lines, cursorLine, cursorCol };
+				},
+			});
+
+			stdin.on("data", sequence => editor.handleInput(sequence));
+			stdin.process(Buffer.from("@~"));
+			await Bun.sleep(0);
+
+			expect(calls).toEqual(["@", "@~"]);
+		});
+
+		it("aborts superseded autocomplete requests from a single stdin chunk and on dismissal", async () => {
+			const editor = new Editor(defaultEditorTheme);
+			const stdin = new StdinBuffer();
+			let calls = 0;
+			let active = 0;
+			let peakActive = 0;
+			let latestText = "";
+
+			editor.setAutocompleteProvider({
+				async getSuggestions(lines, cursorLine, cursorCol, signal) {
+					calls += 1;
+					latestText = (lines[cursorLine] ?? "").slice(0, cursorCol);
+					active += 1;
+					peakActive = Math.max(peakActive, active);
+					return new Promise((_resolve, reject) => {
+						signal?.addEventListener(
+							"abort",
+							() => {
+								active -= 1;
+								reject(signal.reason);
+							},
+							{ once: true },
+						);
+					});
+				},
+				applyCompletion(lines, cursorLine, cursorCol) {
+					return { lines, cursorLine, cursorCol };
+				},
+			});
+
+			stdin.on("data", sequence => editor.handleInput(sequence));
+			stdin.process(Buffer.from("@/isolated/path"));
+
+			expect(calls).toBeGreaterThan(1);
+			expect(latestText).toBe("@/isolated/path");
+			expect(peakActive).toBe(1);
+			expect(active).toBe(1);
+
+			editor.handleInput("\x1b");
+			expect(active).toBe(0);
+		});
+
+		it.each([
+			["left-arrow", (editor: Editor) => editor.handleInput("\x1b[D")],
+			["line-start", (editor: Editor) => editor.moveToLineStart()],
+			["word-left", (editor: Editor) => editor.handleInput("\x1bb")],
+		])("aborts an in-flight autocomplete request after %s navigation moves the cursor", async (_name, navigate) => {
+			const editor = new Editor(defaultEditorTheme);
+			const requestStarted = Promise.withResolvers<AbortSignal>();
+
+			editor.setAutocompleteProvider({
+				async getSuggestions(_lines, _cursorLine, _cursorCol, signal) {
+					if (!signal) throw new Error("expected autocomplete cancellation signal");
+					requestStarted.resolve(signal);
+					return new Promise((_resolve, reject) => {
+						signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+					});
+				},
+				applyCompletion(lines, cursorLine, cursorCol) {
+					return { lines, cursorLine, cursorCol };
+				},
+			});
+
+			editor.handleInput("@");
+			const signal = await requestStarted.promise;
+
+			try {
+				navigate(editor);
+				expect(editor.getCursor()).toEqual({ line: 0, col: 0 });
+				expect(signal.aborted).toBe(true);
+				expect(editor.isShowingAutocomplete()).toBe(false);
+			} finally {
+				editor.handleInput("\x1b");
+				await Bun.sleep(0);
+			}
+		});
+
+		it("keeps an in-flight autocomplete request when navigation is a no-op", async () => {
+			const editor = new Editor(defaultEditorTheme);
+			const requestStarted = Promise.withResolvers<AbortSignal>();
+
+			editor.setAutocompleteProvider({
+				async getSuggestions(_lines, _cursorLine, _cursorCol, signal) {
+					if (!signal) throw new Error("expected autocomplete cancellation signal");
+					requestStarted.resolve(signal);
+					return new Promise((_resolve, reject) => {
+						signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+					});
+				},
+				applyCompletion(lines, cursorLine, cursorCol) {
+					return { lines, cursorLine, cursorCol };
+				},
+			});
+
+			editor.handleInput("@");
+			const signal = await requestStarted.promise;
+
+			try {
+				editor.handleInput("\x1b[C");
+				expect(editor.getCursor()).toEqual({ line: 0, col: 1 });
+				expect(signal.aborted).toBe(false);
+			} finally {
+				editor.handleInput("\x1b");
+				await Bun.sleep(0);
+			}
 		});
 
 		it("triggers prompt-action autocomplete when typing hash", async () => {


### PR DESCRIPTION
## What

- Bound absolute (`@/...`) and home-relative (`@~`, `@~/...`) file-mention completion to the currently typed directory segment instead of starting a recursive fuzzy scan from `/` or the home directory, while keeping fuzzy matching within that segment.
- Propagate `AbortSignal` through the editor, TUI autocomplete provider, native fuzzy search, scoped directory resolution, and the coding-agent wrapper.
- Abort superseded, dismissed, or cursor-invalidated pending autocomplete work while preserving project-relative fuzzy discovery and settled stale-popup rejection.
- Keep directory selections inside the mention token for child-segment completion while file selections retain their terminating space.
- Add regression coverage for raw stdin chunks, bounded absolute/home completion, stalled filesystem operations, cursor navigation, completion application, and wrapper-level cancellation.

## Why

The TUI emits a pasted or terminal-sent chunk one code point at a time. Typing an absolute `@` path could therefore start many concurrent recursive fuzzy scans rooted at `/`; request IDs prevented stale results from being applied but did not stop the underlying work. On the affected macOS host, one input produced 57 overlapping requests and the process was killed after exhausting memory.

Absolute and home paths do not need workspace-wide discovery: each keystroke only needs the entries in the currently typed directory. Relative `@` queries still use the existing project-scoped fuzzy behavior.

## Testing

- Fail-before/pass-after regression tests for:
  - bounded absolute, quoted-absolute, `~`, and quoted home-child completion;
  - cancellation while scoped `stat`, `readdir`, or symlink `stat` work is pending;
  - same-chunk supersession, dismissal, and real cursor movement;
  - one-chunk `@~` retrigger, immediate-directory fuzzy matching, and directory/file selection boundaries;
  - no-op cursor movement and existing settled stale-popup behavior;
  - cancellation forwarding through the coding-agent autocomplete wrapper.
- `bun test packages/natives/test/native.test.ts packages/tui/test/autocomplete.test.ts packages/tui/test/editor.test.ts packages/coding-agent/test/prompt-action-autocomplete.test.ts packages/coding-agent/test/file-mentions.test.ts`
  - 270 passed, 0 failed.
- `bun --cwd=packages/tui test`
  - 937 passed, 6 opt-in PTY tests skipped, 0 failed.
- `bun --cwd=packages/tui run check`
- `bun --cwd=packages/coding-agent run check`
- Native addon build, CLI smoke, workspace checks, plugin/Docker/UI gates, and `git diff --check`.
- On the affected host, the fixed build remained responsive in an isolated tmux replay, produced suggestions, had no exit 137, and increased RSS by about 944 KiB.

The unsafe pre-fix live OOM replay was not repeated. Windows drive-letter completion was not exercised locally. Filesystem promises may continue inside the OS after cancellation, but callers stop awaiting them and no further autocomplete work is started.

The root `bun check` reaches an SDK rename guard that also fails on a clean exact `origin/dev` checkout because the tracked issue document `issues/21-session-resume-model-behavior-not-configurable.md` contains the historical string `src/sdk.ts`; this change does not touch that file or introduce the failure. The affected package checks and downstream gates pass.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:59aaf9eb8deb73f74b869457a8bdd3b2f31a9c29 reviewer:critic evidence:gjc-codex-auto-review
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (pre-existing exact-`origin/dev` SDK rename guard failure documented above)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
