### PR TITLE
fix(session): deduplicate migrated global entries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 
 - Team Linux worker memory-guard replacement no longer holds the team task-mutation fence across the successor startup-ack wait, so concurrent `worker-startup-ack` can publish and selector-replacement no longer hangs under CI contention.
+- The global sessions dashboard and cross-workspace resume lookup now coalesce legacy and v2 transcript copies sharing one session id, preferring the canonical v2 copy instead of listing or resolving the migrated session twice.
 
 ### Added
 

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -4621,6 +4621,21 @@ async function collectSessionsFromFiles(files: string[], storage: SessionStorage
 	return sessions;
 }
 
+function isV2ManagedSession(session: SessionInfo): boolean {
+	return path.basename(path.dirname(session.path)).startsWith("v2-");
+}
+
+function deduplicateGlobalSessions(sessions: SessionInfo[]): SessionInfo[] {
+	const byId = new Map<string, SessionInfo>();
+	for (const session of sessions) {
+		const existing = byId.get(session.id);
+		if (!existing || (isV2ManagedSession(session) && !isV2ManagedSession(existing))) {
+			byId.set(session.id, session);
+		}
+	}
+	return [...byId.values()].sort((a, b) => b.modified.getTime() - a.modified.getTime());
+}
+
 export interface ResolvedSessionMatch {
 	session: SessionInfo;
 	scope: "local" | "global";
@@ -10540,7 +10555,7 @@ export class SessionManager {
 					});
 				for (const candidate of listing.owned) logicalFiles.add(candidate.path);
 			}
-			return await collectSessionsFromFiles([...logicalFiles], storage);
+			return deduplicateGlobalSessions(await collectSessionsFromFiles([...logicalFiles], storage));
 		} catch {
 			return [];
 		}

--- a/packages/coding-agent/test/sessions-dashboard.test.ts
+++ b/packages/coding-agent/test/sessions-dashboard.test.ts
@@ -9,7 +9,7 @@ import {
 } from "@gajae-code/coding-agent/modes/components/sessions-dashboard";
 import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/selector-controller";
 import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
-import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { resolveResumableSession, SessionManager } from "@gajae-code/coding-agent/session/session-manager";
 import { MemorySessionStorage, type SessionStorageWriter } from "@gajae-code/coding-agent/session/session-storage";
 import { getAgentDir, setAgentDir } from "@gajae-code/utils";
 
@@ -64,6 +64,13 @@ function snapshotDirectory(root: string): Array<{ path: string; content: string;
 			};
 		})
 		.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function legacySessionDirectoryName(cwd: string): string {
+	return `--${path
+		.resolve(cwd)
+		.replace(/^[/\\]/, "")
+		.replace(/[/\\:]/g, "-")}--`;
 }
 
 describe("sessions dashboard", () => {
@@ -252,6 +259,40 @@ describe("sessions dashboard", () => {
 			await new SelectorController({ ui, editor } as never).showSessionsDashboard();
 			expect(dashboard?.render(80).join("\n")).toContain("Newer");
 			expect(mutations.reduce((count, mutation) => count + mutation.mock.calls.length, 0)).toBe(0);
+			expect(snapshotDirectory(sessionsRoot)).toEqual(before);
+		} finally {
+			setAgentDir(originalAgentDir);
+			fs.rmSync(agentDir, { recursive: true, force: true });
+		}
+	});
+	it("coalesces legacy and v2 copies of one session id to the canonical v2 session", async () => {
+		const originalAgentDir = getAgentDir();
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "sessions-dashboard-migrated-"));
+		setAgentDir(agentDir);
+		try {
+			const sessionsRoot = path.join(agentDir, "sessions");
+			const cwd = path.join(agentDir, "workspace");
+			fs.mkdirSync(cwd, { recursive: true });
+			const v2File = path.join(SessionManager.getDefaultSessionDir(cwd, agentDir), "canonical.jsonl");
+			const legacyDir = path.join(sessionsRoot, legacySessionDirectoryName(cwd));
+			const legacyFile = path.join(legacyDir, "legacy.jsonl");
+			fs.mkdirSync(legacyDir, { recursive: true });
+			fs.writeFileSync(v2File, sessionText("migrated-session", cwd, "Canonical", "canonical copy"));
+			fs.writeFileSync(legacyFile, sessionText("migrated-session", cwd, "Legacy", "legacy copy"));
+			fs.utimesSync(v2File, new Date("2026-01-01T00:00:00.000Z"), new Date("2026-01-01T00:00:00.000Z"));
+			fs.utimesSync(legacyFile, new Date("2026-01-02T00:00:00.000Z"), new Date("2026-01-02T00:00:00.000Z"));
+			const foreignCwd = path.join(agentDir, "foreign-workspace");
+			fs.mkdirSync(foreignCwd);
+			const before = snapshotDirectory(sessionsRoot);
+
+			const matches = (await SessionManager.listAll()).filter(session => session.id === "migrated-session");
+
+			expect(matches).toHaveLength(1);
+			expect(matches[0]?.path).toBe(v2File);
+			expect(matches[0]?.firstMessage).toBe("canonical copy");
+			const resolved = await resolveResumableSession("migrated-session", foreignCwd, undefined, undefined, agentDir);
+			expect(resolved?.scope).toBe("global");
+			expect(resolved?.session.path).toBe(v2File);
 			expect(snapshotDirectory(sessionsRoot)).toEqual(before);
 		} finally {
 			setAgentDir(originalAgentDir);


### PR DESCRIPTION
## Problem

Managed-session migration can leave the same logical session available through both a legacy workspace directory and its v2 managed directory.

Scoped resume inventory already coalesces a migrated session correctly, but `SessionManager.listAll()` collects both physical transcripts. As a result:

- the global sessions dashboard can display one session twice;
- cross-workspace resume lookup can resolve the legacy copy;
- a newer legacy file can win even when a canonical v2 copy exists.

The behavior reproduces on released GJC v0.12.0 and current `dev`.

## Fix

Coalesce global inventory by session id after validated managed candidates have been collected:

- prefer a v2 managed transcript over its legacy copy;
- otherwise retain the newest valid entry;
- preserve global modified-time ordering after coalescing.

This is read-only inventory normalization. It does not migrate, rewrite, or delete either transcript.

## Compatibility

Scoped session listing is unchanged. Sessions with distinct ids remain independently visible, and valid legacy-only sessions remain available.

The change affects only duplicate global entries sharing one session id, where the v2 path is the canonical managed-session representation.

## Verification

A regression fixture creates legacy and v2 transcripts with the same session id and deliberately makes the legacy file newer. It verifies that:

- global inventory returns exactly one entry;
- the canonical v2 path and content win;
- cross-workspace resume resolves the v2 transcript;
- listing leaves all files unchanged.

Adversarial comparison:

| Source | Regression result |
| --- | --- |
| untouched `origin/dev` | fails: 2 entries returned |
| this branch | passes: 1 canonical v2 entry returned |

Focused verification:

```sh
bun test packages/coding-agent/test/sessions-dashboard.test.ts packages/coding-agent/test/session-manager/file-operations.test.ts packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts packages/coding-agent/test/modes/controllers/session-selector-delete.test.ts
bun --cwd=packages/coding-agent run check
bun run ci:test:smoke
bun run check:public-sync
bun --cwd=packages/coding-agent run build
```

Result: 55 focused tests passed; all listed checks passed.

Linux x64 verification additionally built both native variants and ran the dashboard regression plus the coding-agent check:

```sh
TARGET_VARIANTS="baseline modern" bun scripts/ci-build-native.ts
bun test packages/coding-agent/test/sessions-dashboard.test.ts
bun --cwd=packages/coding-agent run check
```

Result: 7 tests passed, 0 failed; check passed.

A pre-existing managed-session security test result was also compared directly on the same macOS host: clean `dev` and this branch both produced 37 passes, 1 skip, and the same 2 environment-sensitive failures.
