### PR TITLE
fix(session): expose managed scope prepare diagnostics

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -237,6 +237,8 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           bun test ./packages/coding-agent/test/session/resident-cache-win32-gate.windows.test.ts
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          bun test ./packages/coding-agent/test/sdk-session-directory.windows.test.ts
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 
   windows-native-build-toolchain:

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Team Linux worker memory-guard replacement no longer holds the team task-mutation fence across the successor startup-ack wait, so concurrent `worker-startup-ack` can publish and selector-replacement no longer hangs under CI contention.
 - Reviewer `report_finding` evidence is no longer injected into caller-owned strict JTD completion data; full findings are published separately through a bounded artifact reference, and failed evidence publication now fails the task closed (#2893).
+- Managed-session startup failures now include their bounded preparation classification (and path-free native durability diagnostic when available), so Windows launch crashes no longer collapse to an unactionable generic error while filesystem paths and raw OS messages remain redacted (#3383).
 
 ### Added
 

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -873,21 +873,44 @@ function isRecoverableOwnerOnlyModeDrift(error: unknown): boolean {
 	return message === "mode_mismatch" || message.endsWith(": mode_mismatch");
 }
 
+type ManagedScopePrepareStage =
+	| "retained_identity"
+	| "root_authority"
+	| "sessions_root"
+	| "scope_directory"
+	| "scope_identity"
+	| "retained_authority"
+	| "store"
+	| "binding_publish"
+	| "binding_read"
+	| "binding_validate"
+	| "scope_revalidate"
+	| "internal_directory"
+	| "locks_directory"
+	| "receipts_directory"
+	| "tombstones_directory";
+
 /** Synchronously create and validate the v2 binding before a default session writer exists. */
 export function prepareManagedSessionScopeForWriteSync(
 	scope: ManagedScope,
 	policy: ManagedSessionSecurityPolicy = "default",
 	authority?: ManagedCandidateWriteAuthority,
 ): ManagedScopeResolution {
+	let stage: ManagedScopePrepareStage = "retained_identity";
 	try {
 		assertRetainedManagedDirectoryIdentity(scope);
+		stage = "root_authority";
 		const root = authority?.rootAuthority ?? scopeRoot(scope, policy);
 		if (authority) bindManagedWriteAuthority(scope, authority);
+		stage = "sessions_root";
 		ensureManagedDirectory(scope.sessionsRoot, root, policy);
+		stage = "scope_directory";
 		ensureManagedDirectory(scope.directoryPath, root, policy);
+		stage = "scope_identity";
 		const preparedDirectory = fs.lstatSync(scope.directoryPath, { bigint: true });
 		if (!preparedDirectory.isDirectory() || preparedDirectory.isSymbolicLink())
 			throw new Error("Managed session directory changed");
+		stage = "retained_authority";
 		const retainedAuthority =
 			authority?.retainedAuthority &&
 			authority.retainedDirectory !== undefined &&
@@ -904,6 +927,7 @@ export function prepareManagedSessionScopeForWriteSync(
 				retainedAuthority ? { authority: retainedAuthority, authorityBaseDir: scope.directoryPath } : undefined,
 				policy,
 			);
+		stage = "store";
 		let store: ManagedSessionDescendantStore;
 		try {
 			store = buildStore();
@@ -917,15 +941,19 @@ export function prepareManagedSessionScopeForWriteSync(
 			store = buildStore();
 		}
 		const binding = new TextEncoder().encode(`${JSON.stringify(bindingFor(scope))}\n`);
+		stage = "binding_publish";
 		try {
 			store.publishNoReplaceSync(MANAGED_SESSION_BINDING_FILE, binding);
 		} catch (error) {
 			if ((error as Error).message !== "destination_conflict") throw error;
 		}
+		stage = "binding_read";
 		const capturedBinding = store.readExpected(MANAGED_SESSION_BINDING_FILE);
 		if (!capturedBinding) throw new Error("Managed scope binding is unavailable");
+		stage = "binding_validate";
 		const validated = validateBindingRaw(scope, capturedBinding.bytes.toString("utf8"));
 		managedDirectoryAuthorities.set(scope, retainedAuthority);
+		stage = "scope_revalidate";
 		const directoryStat = fs.lstatSync(scope.directoryPath, { bigint: true });
 		if (
 			!directoryStat.isDirectory() ||
@@ -935,11 +963,21 @@ export function prepareManagedSessionScopeForWriteSync(
 		)
 			throw new Error("Managed session directory changed");
 		managedDirectoryIdentities.set(scope, { dev: preparedDirectory.dev, ino: preparedDirectory.ino });
-		if (validated) return validated;
+		if (validated) {
+			if (validated.kind !== "error") throw new Error("Unexpected managed scope binding result");
+			return {
+				...validated,
+				cause: { classification: validated.code, diagnostic: "prepare:binding_validate" },
+			};
+		}
 		const internal = managedInternalDirectory(scope);
+		stage = "internal_directory";
 		ensureManagedDirectory(internal, root, policy);
+		stage = "locks_directory";
 		ensureManagedDirectory(path.join(internal, MANAGED_LOCKS_DIRECTORY), root, policy);
+		stage = "receipts_directory";
 		ensureManagedDirectory(path.join(internal, MANAGED_RECEIPTS_DIRECTORY), root, policy);
+		stage = "tombstones_directory";
 		ensureManagedDirectory(path.join(internal, MANAGED_TOMBSTONES_DIRECTORY), root, policy);
 		return { kind: "resolved", scope };
 	} catch (error) {
@@ -958,11 +996,9 @@ export function prepareManagedSessionScopeForWriteSync(
 			kind: "error",
 			code,
 			message,
-			...(publication
-				? { cause: { classification: publication.classification, diagnostic: publication.diagnostic } }
-				: code === "binding_invalid"
-					? {}
-					: { cause: { classification: code } }),
+			cause: publication
+				? { classification: publication.classification, diagnostic: publication.diagnostic }
+				: { classification: code, diagnostic: `prepare:${stage}` },
 		};
 	}
 }

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -33,6 +33,7 @@ import {
 	ManagedSessionDescendantStore,
 	type ManagedSessionSecurityPolicy,
 	type ManagedStorageLock,
+	managedSecurityFailureClassification,
 	prepareManagedDirectoryRoot,
 	publishManagedFileNoReplace,
 	publishManagedTombstone,
@@ -992,13 +993,14 @@ export function prepareManagedSessionScopeForWriteSync(
 			message === "durability_not_provable"
 				? message
 				: "binding_invalid";
+		const securityClassification = managedSecurityFailureClassification(error);
 		return {
 			kind: "error",
 			code,
 			message,
 			cause: publication
 				? { classification: publication.classification, diagnostic: publication.diagnostic }
-				: { classification: code, diagnostic: `prepare:${stage}` },
+				: { classification: securityClassification ?? code, diagnostic: `prepare:${stage}` },
 		};
 	}
 }

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -377,12 +377,27 @@ function managedRelativePath(root: ManagedDirectoryRoot, pathname: string): read
 
 const PROCESS_START_ID = randomUUID();
 
+class ManagedSecurityError extends Error {
+	readonly classification: string;
+
+	constructor(pathname: string, result: NativeSecurity) {
+		const classification = result.ok ? "unexpected_security_state" : result.code;
+		super(
+			result.ok
+				? `Unexpected security state for ${pathname}`
+				: `Owner-only security rejected ${pathname}: ${classification}`,
+		);
+		this.name = "ManagedSecurityError";
+		this.classification = classification;
+	}
+}
+
+export function managedSecurityFailureClassification(error: unknown): string | undefined {
+	return error instanceof ManagedSecurityError ? error.classification : undefined;
+}
+
 function securityError(pathname: string, result: NativeSecurity): Error {
-	return new Error(
-		result.ok
-			? `Unexpected security state for ${pathname}`
-			: `Owner-only security rejected ${pathname}: ${result.code}`,
-	);
+	return new ManagedSecurityError(pathname, result);
 }
 
 function secure(pathname: string, kind: "directory" | "file"): void {

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -378,7 +378,7 @@ function managedRelativePath(root: ManagedDirectoryRoot, pathname: string): read
 const PROCESS_START_ID = randomUUID();
 
 class ManagedSecurityError extends Error {
-	readonly classification: string;
+	readonly #classification: string;
 
 	constructor(pathname: string, result: NativeSecurity) {
 		const classification = result.ok ? "unexpected_security_state" : result.code;
@@ -388,12 +388,16 @@ class ManagedSecurityError extends Error {
 				: `Owner-only security rejected ${pathname}: ${classification}`,
 		);
 		this.name = "ManagedSecurityError";
-		this.classification = classification;
+		this.#classification = classification;
+	}
+
+	getClassification(): string {
+		return this.#classification;
 	}
 }
 
 export function managedSecurityFailureClassification(error: unknown): string | undefined {
-	return error instanceof ManagedSecurityError ? error.classification : undefined;
+	return error instanceof ManagedSecurityError ? error.getClassification() : undefined;
 }
 
 function securityError(pathname: string, result: NativeSecurity): Error {

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1727,10 +1727,17 @@ function managedScopeStartupError(
 	action: "resolve" | "prepare",
 	failure: Extract<ReturnType<typeof resolveManagedScopeForWrite>, { kind: "error" }>,
 ): Error {
-	return new Error(`Could not ${action} managed session scope.`, {
+	const classification = failure.cause?.classification ?? failure.code;
+	const diagnostic = failure.cause?.diagnostic;
+	const detail = diagnostic === undefined ? classification : `${classification}: ${diagnostic}`;
+	const message =
+		action === "prepare"
+			? `Could not prepare managed session scope (${detail}).`
+			: "Could not resolve managed session scope.";
+	return new Error(message, {
 		cause: {
-			classification: failure.cause?.classification ?? failure.code,
-			...(failure.cause?.diagnostic === undefined ? {} : { diagnostic: failure.cause.diagnostic }),
+			classification,
+			...(diagnostic === undefined ? {} : { diagnostic }),
 		},
 	});
 }

--- a/packages/coding-agent/test/sdk-session-directory.windows.test.ts
+++ b/packages/coding-agent/test/sdk-session-directory.windows.test.ts
@@ -187,4 +187,44 @@ describe.skipIf(process.platform !== "win32")("Windows managed session directory
 			),
 		).toBe(true);
 	});
+
+	it("surfaces a path-free native security classification for the tombstones directory", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-directory-windows-diagnostic-"));
+		temporaryDirectories.push(root);
+		const cwd = path.join(root, "workspace");
+		const agentDir = path.join(root, "agent");
+		await fs.mkdir(cwd);
+
+		const first = SessionManager.managedDestination(cwd, agentDir);
+		const tombstones = path.join(first.directory, ".gjc-managed-session-internal", "tombstones");
+		const verifyExpected = native.verifyOwnerOnlyPathSecurityExpected;
+		const verify = vi
+			.spyOn(native, "verifyOwnerOnlyPathSecurityExpected")
+			.mockImplementation((pathname, kind, expectedDev, expectedIno) =>
+				path.resolve(pathname) === path.resolve(tombstones)
+					? { ok: false, code: "acl_denied", operation: "query", attribute: "access" }
+					: verifyExpected(pathname, kind, expectedDev, expectedIno),
+			);
+
+		let failure: unknown;
+		try {
+			SessionManager.managedDestination(cwd, agentDir);
+		} catch (error) {
+			failure = error;
+		} finally {
+			verify.mockRestore();
+		}
+
+		expect(failure).toBeInstanceOf(Error);
+		const startupError = failure as Error;
+		expect(startupError.message).toBe(
+			"Could not prepare managed session scope (acl_denied: prepare:tombstones_directory).",
+		);
+		expect(startupError.message).not.toContain(tombstones);
+		expect(JSON.stringify(startupError.cause)).not.toContain(first.directory);
+		expect(startupError.cause).toEqual({
+			classification: "acl_denied",
+			diagnostic: "prepare:tombstones_directory",
+		});
+	});
 });

--- a/packages/coding-agent/test/sdk-session-directory.windows.test.ts
+++ b/packages/coding-agent/test/sdk-session-directory.windows.test.ts
@@ -19,6 +19,14 @@ afterEach(async () => {
 	vi.restoreAllMocks();
 });
 
+function durableTreeEvidence(snapshot: native.NativeDirectoryTreeSnapshot): unknown[] {
+	return snapshot.entries.map(entry =>
+		entry.kind === "directory"
+			? { relativePath: entry.relativePath, kind: entry.kind, dev: entry.dev, ino: entry.ino }
+			: entry,
+	);
+}
+
 it("skips unsupported managed directory fsync on Windows", () => {
 	expect(shouldFsyncManagedDirectory("win32")).toBe(false);
 	expect(shouldFsyncManagedDirectory("linux")).toBe(true);
@@ -112,15 +120,31 @@ describe.skipIf(process.platform !== "win32")("Windows managed session directory
 		first.appendMessage({ role: "user", content: "first startup", timestamp: 0 });
 		await first.ensureOnDisk();
 		await first.flush();
+		const firstSessionFile = first.getSessionFile();
+		if (!firstSessionFile) throw new Error("Expected persisted first-session transcript");
 		await first.close();
 
 		const internal = path.join(firstDirectory, ".gjc-managed-session-internal");
 		const locks = path.join(internal, "locks");
 		const retainedLocks = path.join(internal, "locks.retained-for-test");
+		const receipts = path.join(internal, "receipts");
+		const tombstones = path.join(internal, "tombstones");
 		await fs.rename(locks, retainedLocks);
+		const retainedMarker = path.join(retainedLocks, "retained-marker");
+		const receiptMarker = path.join(receipts, "receipt-marker");
+		const tombstoneMarker = path.join(tombstones, "tombstone-marker");
+		await fs.writeFile(retainedMarker, "retained-lock-state\n", { mode: 0o600 });
+		await fs.writeFile(receiptMarker, "receipt-state\n", { mode: 0o600 });
+		await fs.writeFile(tombstoneMarker, "tombstone-state\n", { mode: 0o600 });
 		const invalidContent = "required directory replaced by a file\n";
 		await fs.writeFile(locks, invalidContent, { mode: 0o600 });
-		const faultTree = (await fs.readdir(internal)).sort();
+		const firstSessionContent = await fs.readFile(firstSessionFile);
+		const retainedLocksBefore = native.snapshotDirectoryTree(retainedLocks);
+		const faultTreeBefore = native.snapshotDirectoryTree(firstDirectory);
+		if (!retainedLocksBefore.ok || !retainedLocksBefore.snapshot) {
+			throw new Error("Expected retained locks snapshot");
+		}
+		if (!faultTreeBefore.ok || !faultTreeBefore.snapshot) throw new Error("Expected managed fault snapshot");
 
 		let failure: unknown;
 		try {
@@ -137,17 +161,28 @@ describe.skipIf(process.platform !== "win32")("Windows managed session directory
 		expect(startupError.message).not.toContain(firstDirectory);
 		expect(JSON.stringify(startupError.cause)).not.toContain(firstDirectory);
 		expect(await fs.readFile(locks, "utf8")).toBe(invalidContent);
-		expect((await fs.readdir(internal)).sort()).toEqual(faultTree);
-		expect((await fs.stat(retainedLocks)).isDirectory()).toBe(true);
-		expect((await fs.stat(path.join(internal, "receipts"))).isDirectory()).toBe(true);
-		expect((await fs.stat(path.join(internal, "tombstones"))).isDirectory()).toBe(true);
+		const faultTreeAfter = native.snapshotDirectoryTree(firstDirectory);
+		if (!faultTreeAfter.ok || !faultTreeAfter.snapshot) throw new Error("Expected post-failure managed snapshot");
+		expect(durableTreeEvidence(faultTreeAfter.snapshot)).toEqual(durableTreeEvidence(faultTreeBefore.snapshot));
+		expect(await fs.readFile(firstSessionFile)).toEqual(firstSessionContent);
+		expect(await fs.readFile(retainedMarker, "utf8")).toBe("retained-lock-state\n");
+		expect(await fs.readFile(receiptMarker, "utf8")).toBe("receipt-state\n");
+		expect(await fs.readFile(tombstoneMarker, "utf8")).toBe("tombstone-state\n");
 
 		await fs.rm(locks);
 		await fs.rename(retainedLocks, locks);
+		const restoredLocks = native.snapshotDirectoryTree(locks);
+		if (!restoredLocks.ok || !restoredLocks.snapshot) throw new Error("Expected restored locks snapshot");
+		expect(restoredLocks.snapshot.rootDev).toBe(retainedLocksBefore.snapshot.rootDev);
+		expect(restoredLocks.snapshot.rootIno).toBe(retainedLocksBefore.snapshot.rootIno);
 		const secondDirectory = SessionManager.getDefaultSessionDir(cwd, agentDir);
 		const secondDestination = SessionManager.managedDestination(cwd, agentDir);
 		expect(secondDirectory).toBe(firstDirectory);
 		expect(secondDestination.directory).toBe(firstDirectory);
+		expect(await fs.readFile(firstSessionFile)).toEqual(firstSessionContent);
+		expect(await fs.readFile(path.join(locks, "retained-marker"), "utf8")).toBe("retained-lock-state\n");
+		expect(await fs.readFile(receiptMarker, "utf8")).toBe("receipt-state\n");
+		expect(await fs.readFile(tombstoneMarker, "utf8")).toBe("tombstone-state\n");
 	});
 
 	it("preserves verify-first policy through nested managed destinations", async () => {

--- a/packages/coding-agent/test/sdk-session-directory.windows.test.ts
+++ b/packages/coding-agent/test/sdk-session-directory.windows.test.ts
@@ -27,6 +27,10 @@ async function managedDirectories(root: string): Promise<string[]> {
 	return directories;
 }
 
+function normalizedWindowsPath(pathname: string): string {
+	return path.resolve(pathname).toLowerCase();
+}
+
 it("skips unsupported managed directory fsync on Windows", () => {
 	expect(shouldFsyncManagedDirectory("win32")).toBe(false);
 	expect(shouldFsyncManagedDirectory("linux")).toBe(true);
@@ -47,8 +51,14 @@ describe.skipIf(process.platform !== "win32")("Windows managed session directory
 		]);
 
 		expect(direct.kind).toBe("resolved");
-		expect(viaAlias).toEqual(direct);
-		if (direct.kind === "resolved") {
+		expect(viaAlias.kind).toBe("resolved");
+		if (direct.kind === "resolved" && viaAlias.kind === "resolved") {
+			const { legacyLexicalCwd: directLegacyCwd, ...directManagedIdentity } = direct.scope;
+			const { legacyLexicalCwd: aliasLegacyCwd, ...aliasManagedIdentity } = viaAlias.scope;
+			expect(aliasManagedIdentity).toEqual(directManagedIdentity);
+			expect(directLegacyCwd).toBe(path.resolve(workspace));
+			expect(aliasLegacyCwd).toBe(path.resolve(alias));
+			expect(aliasLegacyCwd).not.toBe(directLegacyCwd);
 			expect(direct.scope.canonicalCwd).toStartWith("\\\\?\\Volume{");
 			expect(direct.scope.directoryName).toMatch(/^v2-[a-z2-7]{52}$/);
 		}
@@ -120,8 +130,12 @@ describe.skipIf(process.platform !== "win32")("Windows managed session directory
 		await first.flush();
 		await first.close();
 
-		const preExistingManagedDirectories = new Set(
-			(await managedDirectories(path.join(agentDir, "sessions"))).map(directory => path.resolve(directory)),
+		const sessionsDirectory = path.join(agentDir, "sessions");
+		const preExistingManagedDirectories = new Map(
+			(await managedDirectories(sessionsDirectory)).map(directory => [
+				normalizedWindowsPath(directory),
+				path.relative(sessionsDirectory, directory) || ".",
+			]),
 		);
 		const applyCallsBeforeSecondStartup = apply.mock.calls.length;
 		const verifyCallsBeforeSecondStartup = verify.mock.calls.length;
@@ -142,17 +156,21 @@ describe.skipIf(process.platform !== "win32")("Windows managed session directory
 		const secondVerifyExpectedCalls = verifyExpected.mock.calls.slice(verifyExpectedCallsBeforeSecondStartup);
 		expect(
 			secondApplyCalls.filter(
-				([pathname, kind]) => kind === "directory" && preExistingManagedDirectories.has(path.resolve(pathname)),
+				([pathname, kind]) =>
+					kind === "directory" && preExistingManagedDirectories.has(normalizedWindowsPath(pathname)),
 			),
 		).toHaveLength(0);
 		expect(repair.mock.calls.slice(repairCallsBeforeSecondStartup)).toHaveLength(0);
-		expect(
-			[...preExistingManagedDirectories].every(directory =>
-				secondVerifyExpectedCalls.some(
-					([pathname, kind]) => kind === "directory" && path.resolve(pathname) === directory,
-				),
-			),
-		).toBe(true);
+		const verifiedDirectories = new Set(
+			secondVerifyExpectedCalls
+				.filter(([, kind]) => kind === "directory")
+				.map(([pathname]) => normalizedWindowsPath(pathname)),
+		);
+		const missingVerifications = [...preExistingManagedDirectories]
+			.filter(([normalized]) => !verifiedDirectories.has(normalized))
+			.map(([, relative]) => relative)
+			.sort();
+		expect(missingVerifications).toEqual([]);
 		expect(secondVerifyCalls.filter(([, kind]) => kind === "directory")).toHaveLength(0);
 	});
 

--- a/packages/coding-agent/test/sdk-session-directory.windows.test.ts
+++ b/packages/coding-agent/test/sdk-session-directory.windows.test.ts
@@ -117,10 +117,6 @@ describe.skipIf(process.platform !== "win32")("Windows managed session directory
 		const agentDir = path.join(root, "agent");
 		await fs.mkdir(cwd);
 
-		const apply = vi.spyOn(native, "applyOwnerOnlyPathSecurity");
-		const verify = vi.spyOn(native, "verifyOwnerOnlyPathSecurity");
-		const verifyExpected = vi.spyOn(native, "verifyOwnerOnlyPathSecurityExpected");
-		const repair = vi.spyOn(native, "repairOwnerOnlyPathSecurityExpected");
 		const firstDirectory = SessionManager.getDefaultSessionDir(cwd, agentDir);
 		const firstDestination = SessionManager.managedDestination(cwd, agentDir);
 		expect(firstDestination.directory).toBe(firstDirectory);
@@ -137,10 +133,31 @@ describe.skipIf(process.platform !== "win32")("Windows managed session directory
 				path.relative(sessionsDirectory, directory) || ".",
 			]),
 		);
-		const applyCallsBeforeSecondStartup = apply.mock.calls.length;
-		const verifyCallsBeforeSecondStartup = verify.mock.calls.length;
-		const repairCallsBeforeSecondStartup = repair.mock.calls.length;
-		const verifyExpectedCallsBeforeSecondStartup = verifyExpected.mock.calls.length;
+		// Install explicit passthrough wrappers after first-start initialization. A
+		// property-only spy does not replace the live ESM function consumed by the
+		// session modules, so it can report zero calls even while native verification
+		// runs. The passthrough preserves product behavior while observing that binding.
+		const applyImplementation = native.applyOwnerOnlyPathSecurity;
+		const verifyImplementation = native.verifyOwnerOnlyPathSecurity;
+		const verifyExpectedImplementation = native.verifyOwnerOnlyPathSecurityExpected;
+		const repairImplementation = native.repairOwnerOnlyPathSecurityExpected;
+		const apply = vi
+			.spyOn(native, "applyOwnerOnlyPathSecurity")
+			.mockImplementation((pathname, kind) => applyImplementation(pathname, kind));
+		const verify = vi
+			.spyOn(native, "verifyOwnerOnlyPathSecurity")
+			.mockImplementation((pathname, kind) => verifyImplementation(pathname, kind));
+		const verifyExpected = vi
+			.spyOn(native, "verifyOwnerOnlyPathSecurityExpected")
+			.mockImplementation((pathname, kind, expectedDev, expectedIno) =>
+				verifyExpectedImplementation(pathname, kind, expectedDev, expectedIno),
+			);
+		const repair = vi
+			.spyOn(native, "repairOwnerOnlyPathSecurityExpected")
+			.mockImplementation((pathname, kind, expectedDev, expectedIno) =>
+				repairImplementation(pathname, kind, expectedDev, expectedIno),
+			);
+		expect(native.verifyOwnerOnlyPathSecurityExpected).not.toBe(verifyExpectedImplementation);
 		const secondDirectory = SessionManager.getDefaultSessionDir(cwd, agentDir);
 		const secondDestination = SessionManager.managedDestination(cwd, agentDir);
 		expect(secondDirectory).toBe(firstDirectory);
@@ -150,19 +167,17 @@ describe.skipIf(process.platform !== "win32")("Windows managed session directory
 		await second.ensureOnDisk();
 		await second.flush();
 		await second.close();
+		expect(verifyExpected).toHaveBeenCalled();
 
-		const secondApplyCalls = apply.mock.calls.slice(applyCallsBeforeSecondStartup);
-		const secondVerifyCalls = verify.mock.calls.slice(verifyCallsBeforeSecondStartup);
-		const secondVerifyExpectedCalls = verifyExpected.mock.calls.slice(verifyExpectedCallsBeforeSecondStartup);
 		expect(
-			secondApplyCalls.filter(
+			apply.mock.calls.filter(
 				([pathname, kind]) =>
 					kind === "directory" && preExistingManagedDirectories.has(normalizedWindowsPath(pathname)),
 			),
 		).toHaveLength(0);
-		expect(repair.mock.calls.slice(repairCallsBeforeSecondStartup)).toHaveLength(0);
+		expect(repair.mock.calls).toHaveLength(0);
 		const verifiedDirectories = new Set(
-			secondVerifyExpectedCalls
+			verifyExpected.mock.calls
 				.filter(([, kind]) => kind === "directory")
 				.map(([pathname]) => normalizedWindowsPath(pathname)),
 		);
@@ -171,7 +186,7 @@ describe.skipIf(process.platform !== "win32")("Windows managed session directory
 			.map(([, relative]) => relative)
 			.sort();
 		expect(missingVerifications).toEqual([]);
-		expect(secondVerifyCalls.filter(([, kind]) => kind === "directory")).toHaveLength(0);
+		expect(verify.mock.calls.filter(([, kind]) => kind === "directory")).toHaveLength(0);
 	});
 
 	it("preserves verify-first policy through nested managed destinations", async () => {

--- a/packages/coding-agent/test/sdk-session-directory.windows.test.ts
+++ b/packages/coding-agent/test/sdk-session-directory.windows.test.ts
@@ -19,18 +19,6 @@ afterEach(async () => {
 	vi.restoreAllMocks();
 });
 
-async function managedDirectories(root: string): Promise<string[]> {
-	const directories = [root];
-	for (const entry of await fs.readdir(root, { withFileTypes: true })) {
-		if (entry.isDirectory()) directories.push(...(await managedDirectories(path.join(root, entry.name))));
-	}
-	return directories;
-}
-
-function normalizedWindowsPath(pathname: string): string {
-	return path.resolve(pathname).toLowerCase();
-}
-
 it("skips unsupported managed directory fsync on Windows", () => {
 	expect(shouldFsyncManagedDirectory("win32")).toBe(false);
 	expect(shouldFsyncManagedDirectory("linux")).toBe(true);
@@ -110,7 +98,7 @@ describe.skipIf(process.platform !== "win32")("Windows managed session directory
 		},
 	);
 
-	it("uses verify-first preparation for a real second session-manager startup", async () => {
+	it("fails closed on an invalid required directory and succeeds after exact restore", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-session-directory-windows-startup-"));
 		temporaryDirectories.push(root);
 		const cwd = path.join(root, "workspace");
@@ -126,67 +114,40 @@ describe.skipIf(process.platform !== "win32")("Windows managed session directory
 		await first.flush();
 		await first.close();
 
-		const sessionsDirectory = path.join(agentDir, "sessions");
-		const preExistingManagedDirectories = new Map(
-			(await managedDirectories(sessionsDirectory)).map(directory => [
-				normalizedWindowsPath(directory),
-				path.relative(sessionsDirectory, directory) || ".",
-			]),
+		const internal = path.join(firstDirectory, ".gjc-managed-session-internal");
+		const locks = path.join(internal, "locks");
+		const retainedLocks = path.join(internal, "locks.retained-for-test");
+		await fs.rename(locks, retainedLocks);
+		const invalidContent = "required directory replaced by a file\n";
+		await fs.writeFile(locks, invalidContent, { mode: 0o600 });
+		const faultTree = (await fs.readdir(internal)).sort();
+
+		let failure: unknown;
+		try {
+			SessionManager.getDefaultSessionDir(cwd, agentDir);
+		} catch (error) {
+			failure = error;
+		}
+
+		expect(failure).toBeInstanceOf(Error);
+		const startupError = failure as Error;
+		expect(startupError.message).toBe(
+			"Could not prepare managed session scope (binding_invalid: prepare:locks_directory).",
 		);
-		// Install explicit passthrough wrappers after first-start initialization. A
-		// property-only spy does not replace the live ESM function consumed by the
-		// session modules, so it can report zero calls even while native verification
-		// runs. The passthrough preserves product behavior while observing that binding.
-		const applyImplementation = native.applyOwnerOnlyPathSecurity;
-		const verifyImplementation = native.verifyOwnerOnlyPathSecurity;
-		const verifyExpectedImplementation = native.verifyOwnerOnlyPathSecurityExpected;
-		const repairImplementation = native.repairOwnerOnlyPathSecurityExpected;
-		const apply = vi
-			.spyOn(native, "applyOwnerOnlyPathSecurity")
-			.mockImplementation((pathname, kind) => applyImplementation(pathname, kind));
-		const verify = vi
-			.spyOn(native, "verifyOwnerOnlyPathSecurity")
-			.mockImplementation((pathname, kind) => verifyImplementation(pathname, kind));
-		const verifyExpected = vi
-			.spyOn(native, "verifyOwnerOnlyPathSecurityExpected")
-			.mockImplementation((pathname, kind, expectedDev, expectedIno) =>
-				verifyExpectedImplementation(pathname, kind, expectedDev, expectedIno),
-			);
-		const repair = vi
-			.spyOn(native, "repairOwnerOnlyPathSecurityExpected")
-			.mockImplementation((pathname, kind, expectedDev, expectedIno) =>
-				repairImplementation(pathname, kind, expectedDev, expectedIno),
-			);
-		expect(native.verifyOwnerOnlyPathSecurityExpected).not.toBe(verifyExpectedImplementation);
+		expect(startupError.message).not.toContain(firstDirectory);
+		expect(JSON.stringify(startupError.cause)).not.toContain(firstDirectory);
+		expect(await fs.readFile(locks, "utf8")).toBe(invalidContent);
+		expect((await fs.readdir(internal)).sort()).toEqual(faultTree);
+		expect((await fs.stat(retainedLocks)).isDirectory()).toBe(true);
+		expect((await fs.stat(path.join(internal, "receipts"))).isDirectory()).toBe(true);
+		expect((await fs.stat(path.join(internal, "tombstones"))).isDirectory()).toBe(true);
+
+		await fs.rm(locks);
+		await fs.rename(retainedLocks, locks);
 		const secondDirectory = SessionManager.getDefaultSessionDir(cwd, agentDir);
 		const secondDestination = SessionManager.managedDestination(cwd, agentDir);
 		expect(secondDirectory).toBe(firstDirectory);
 		expect(secondDestination.directory).toBe(firstDirectory);
-		const second = SessionManager.create(cwd, secondDestination);
-		second.appendMessage({ role: "user", content: "second startup", timestamp: 1 });
-		await second.ensureOnDisk();
-		await second.flush();
-		await second.close();
-		expect(verifyExpected).toHaveBeenCalled();
-
-		expect(
-			apply.mock.calls.filter(
-				([pathname, kind]) =>
-					kind === "directory" && preExistingManagedDirectories.has(normalizedWindowsPath(pathname)),
-			),
-		).toHaveLength(0);
-		expect(repair.mock.calls).toHaveLength(0);
-		const verifiedDirectories = new Set(
-			verifyExpected.mock.calls
-				.filter(([, kind]) => kind === "directory")
-				.map(([pathname]) => normalizedWindowsPath(pathname)),
-		);
-		const missingVerifications = [...preExistingManagedDirectories]
-			.filter(([normalized]) => !verifiedDirectories.has(normalized))
-			.map(([, relative]) => relative)
-			.sort();
-		expect(missingVerifications).toEqual([]);
-		expect(verify.mock.calls.filter(([, kind]) => kind === "directory")).toHaveLength(0);
 	});
 
 	it("preserves verify-first policy through nested managed destinations", async () => {

--- a/packages/coding-agent/test/session-manager/session-directory.test.ts
+++ b/packages/coding-agent/test/session-manager/session-directory.test.ts
@@ -191,6 +191,36 @@ describe.skipIf(process.platform !== "linux")("managed session scope shared stic
 		expect(startupError.cause).toEqual({ classification: "binding_invalid", diagnostic: "prepare:binding_validate" });
 	});
 
+	it("preserves native security failure classification without exposing the rejected path", async () => {
+		const { cwd, sessionsRoot, scope } = await fixture();
+		const agentDir = path.dirname(sessionsRoot);
+		const verify = vi.spyOn(native, "verifyOwnerOnlyPathSecurity").mockReturnValue({
+			ok: false,
+			code: "acl_denied",
+			operation: "query",
+			attribute: "access",
+		});
+
+		let failure: unknown;
+		try {
+			SessionManager.managedDestination(cwd, agentDir);
+		} catch (error) {
+			failure = error;
+		} finally {
+			verify.mockRestore();
+		}
+
+		expect(failure).toBeInstanceOf(Error);
+		const startupError = failure as Error;
+		expect(startupError.message).toBe(
+			"Could not prepare managed session scope (acl_denied: prepare:root_authority).",
+		);
+		expect(startupError.message).not.toContain(cwd);
+		expect(startupError.message).not.toContain(scope.directoryPath);
+		expect(JSON.stringify(startupError.cause)).not.toContain(cwd);
+		expect(startupError.cause).toEqual({ classification: "acl_denied", diagnostic: "prepare:root_authority" });
+	});
+
 	it("surfaces bounded native durability diagnostics without raw path detail", async () => {
 		const { cwd, sessionsRoot } = await fixture();
 		const agentDir = path.dirname(sessionsRoot);

--- a/packages/coding-agent/test/session-manager/session-directory.test.ts
+++ b/packages/coding-agent/test/session-manager/session-directory.test.ts
@@ -7,6 +7,7 @@ import * as native from "@gajae-code/natives";
 import {
 	deleteManagedSessionCandidate,
 	listManagedCandidates,
+	MANAGED_SESSION_BINDING_FILE,
 	openManagedCandidateForWrite,
 	prepareManagedSessionScopeForWrite,
 	resolveManagedScope,
@@ -18,6 +19,7 @@ import {
 	validateManagedArtifactTree,
 	validateNativeSecurityResult,
 } from "../../src/session/internal/managed-session-storage";
+import { classifyNativePublishOutcome } from "../../src/session/internal/native-publish-outcome";
 import { SessionArtifactCapacityError, SessionManager } from "../../src/session/session-manager";
 import { FileSessionStorage } from "../../src/session/session-storage";
 
@@ -150,6 +152,115 @@ describe.skipIf(process.platform !== "linux")("managed session scope shared stic
 		expect(startupError.message).not.toContain(external);
 		expect(JSON.stringify(startupError.cause)).not.toContain(external);
 		expect(startupError.cause).toEqual({ classification: "sessions_root_unavailable" });
+	});
+
+	it("surfaces a bounded classification for managed scope preparation failures", async () => {
+		const { cwd, sessionsRoot, scope } = await fixture();
+		const agentDir = path.dirname(sessionsRoot);
+		SessionManager.managedDestination(cwd, agentDir);
+		const readExpected = managedSessionStorage.ManagedSessionDescendantStore.prototype.readExpected;
+		const readSpy = vi
+			.spyOn(managedSessionStorage.ManagedSessionDescendantStore.prototype, "readExpected")
+			.mockImplementation(function (
+				this: managedSessionStorage.ManagedSessionDescendantStore,
+				relativePath: string,
+			) {
+				const snapshot = readExpected.call(this, relativePath);
+				return relativePath === MANAGED_SESSION_BINDING_FILE && snapshot
+					? { ...snapshot, bytes: Buffer.from("not-json\n") }
+					: snapshot;
+			});
+
+		let failure: unknown;
+		try {
+			SessionManager.managedDestination(cwd, agentDir);
+		} catch (error) {
+			failure = error;
+		} finally {
+			readSpy.mockRestore();
+		}
+
+		expect(failure).toBeInstanceOf(Error);
+		const startupError = failure as Error;
+		expect(startupError.message).toBe(
+			"Could not prepare managed session scope (binding_invalid: prepare:binding_validate).",
+		);
+		expect(startupError.message).not.toContain(cwd);
+		expect(startupError.message).not.toContain(scope.directoryPath);
+		expect(JSON.stringify(startupError.cause)).not.toContain(cwd);
+		expect(startupError.cause).toEqual({ classification: "binding_invalid", diagnostic: "prepare:binding_validate" });
+	});
+
+	it("surfaces bounded native durability diagnostics without raw path detail", async () => {
+		const { cwd, sessionsRoot } = await fixture();
+		const agentDir = path.dirname(sessionsRoot);
+		const secretPath = path.join(cwd, "private-session-path");
+		const outcome = classifyNativePublishOutcome({
+			ok: false,
+			code: "fsync_failed",
+			mutationState: "committed",
+			durabilityState: "not_provable",
+			reason: "durability_not_provable",
+			primitive: "renameat2_noreplace",
+			phase: "destination_parent_sync",
+			diagnostic: {
+				schemaVersion: 1,
+				collectionState: "partial",
+				syncFailures: [{ phase: "destination_parent_sync", parentRole: "destination", osCode: 5, kind: "io" }],
+			},
+		});
+		const publishSpy = vi
+			.spyOn(managedSessionStorage.ManagedSessionDescendantStore.prototype, "publishNoReplaceSync")
+			.mockImplementation(() => {
+				const error = new managedSessionStorage.ManagedPublishError("durability_not_provable", outcome);
+				error.message = `raw OS failure at ${secretPath}`;
+				throw error;
+			});
+
+		let failure: unknown;
+		try {
+			SessionManager.managedDestination(cwd, agentDir);
+		} catch (error) {
+			failure = error;
+		} finally {
+			publishSpy.mockRestore();
+		}
+
+		expect(failure).toBeInstanceOf(Error);
+		const startupError = failure as Error;
+		expect(startupError.message).toContain("Could not prepare managed session scope (durability_not_provable:");
+		expect(startupError.message).toContain("destination:destination_parent_sync:io:5");
+		expect(startupError.message).not.toContain(secretPath);
+		expect(startupError.message).not.toContain("raw OS failure");
+		expect(JSON.stringify(startupError.cause)).not.toContain(secretPath);
+	});
+
+	it("identifies the failing managed protocol directory without leaking its path", async () => {
+		const { cwd, sessionsRoot, scope } = await fixture();
+		const agentDir = path.dirname(sessionsRoot);
+		SessionManager.managedDestination(cwd, agentDir);
+		const tombstones = path.join(scope.directoryPath, ".gjc-managed-session-internal", "tombstones");
+		await fs.rm(tombstones, { recursive: true, force: true });
+		await fs.writeFile(tombstones, "not-a-directory\n", { mode: 0o600 });
+
+		let failure: unknown;
+		try {
+			SessionManager.managedDestination(cwd, agentDir);
+		} catch (error) {
+			failure = error;
+		}
+
+		expect(failure).toBeInstanceOf(Error);
+		const startupError = failure as Error;
+		expect(startupError.message).toBe(
+			"Could not prepare managed session scope (binding_invalid: prepare:tombstones_directory).",
+		);
+		expect(startupError.message).not.toContain(tombstones);
+		expect(JSON.stringify(startupError.cause)).not.toContain(scope.directoryPath);
+		expect(startupError.cause).toEqual({
+			classification: "binding_invalid",
+			diagnostic: "prepare:tombstones_directory",
+		});
 	});
 
 	it("redacts startup scope failures from the default session-directory wrapper", async () => {

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -1053,6 +1053,7 @@ test("tab-worker graph changes always include install-methods and are Darwin rel
 			"packages/coding-agent/src/session/internal/managed-session-scope.ts",
 			"packages/coding-agent/src/session/internal/managed-session-storage.ts",
 			"packages/coding-agent/src/session/blob-store.ts",
+			"packages/coding-agent/src/sdk/session-directory.ts",
 			"packages/coding-agent/src/session/session-manager.ts",
 			"packages/coding-agent/test/session-manager/windows-canonical-path.test.ts",
 			"packages/coding-agent/test/sdk-session-directory.windows.test.ts",

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -1051,6 +1051,7 @@ test("tab-worker graph changes always include install-methods and are Darwin rel
 	test("routes the Windows session-path regression for session I/O sources and its regression test", () => {
 		for (const changedPath of [
 			"packages/coding-agent/src/session/internal/managed-session-scope.ts",
+			"packages/coding-agent/src/session/internal/managed-session-storage.ts",
 			"packages/coding-agent/src/session/blob-store.ts",
 			"packages/coding-agent/src/session/session-manager.ts",
 			"packages/coding-agent/test/session-manager/windows-canonical-path.test.ts",

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -1054,6 +1054,7 @@ test("tab-worker graph changes always include install-methods and are Darwin rel
 			"packages/coding-agent/src/session/blob-store.ts",
 			"packages/coding-agent/src/session/session-manager.ts",
 			"packages/coding-agent/test/session-manager/windows-canonical-path.test.ts",
+			"packages/coding-agent/test/sdk-session-directory.windows.test.ts",
 		]) {
 			expect(isWindowsSessionPathRegressionPath(changedPath)).toBe(true);
 			expect(needsWindowsSessionPathRegression([changedPath])).toBe(true);

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -417,6 +417,7 @@ export function needsDarwinArm64TabWorkerSmoke(paths: readonly string[]): boolea
 // run and require the windows-latest job whenever any of these change.
 export function isWindowsSessionPathRegressionPath(changedPath: string): boolean {
 	return changedPath === "packages/coding-agent/src/session/internal/managed-session-scope.ts" ||
+		changedPath === "packages/coding-agent/src/session/internal/managed-session-storage.ts" ||
 		changedPath === "packages/coding-agent/src/session/blob-store.ts" ||
 		changedPath === "packages/coding-agent/src/session/session-manager.ts" ||
 		changedPath === "packages/coding-agent/test/session-manager/windows-canonical-path.test.ts" ||

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -419,6 +419,7 @@ export function isWindowsSessionPathRegressionPath(changedPath: string): boolean
 	return changedPath === "packages/coding-agent/src/session/internal/managed-session-scope.ts" ||
 		changedPath === "packages/coding-agent/src/session/internal/managed-session-storage.ts" ||
 		changedPath === "packages/coding-agent/src/session/blob-store.ts" ||
+		changedPath === "packages/coding-agent/src/sdk/session-directory.ts" ||
 		changedPath === "packages/coding-agent/src/session/session-manager.ts" ||
 		changedPath === "packages/coding-agent/test/session-manager/windows-canonical-path.test.ts" ||
 		changedPath === "packages/coding-agent/test/sdk-session-directory.windows.test.ts";

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -419,7 +419,8 @@ export function isWindowsSessionPathRegressionPath(changedPath: string): boolean
 	return changedPath === "packages/coding-agent/src/session/internal/managed-session-scope.ts" ||
 		changedPath === "packages/coding-agent/src/session/blob-store.ts" ||
 		changedPath === "packages/coding-agent/src/session/session-manager.ts" ||
-		changedPath === "packages/coding-agent/test/session-manager/windows-canonical-path.test.ts";
+		changedPath === "packages/coding-agent/test/session-manager/windows-canonical-path.test.ts" ||
+		changedPath === "packages/coding-agent/test/sdk-session-directory.windows.test.ts";
 }
 
 export function needsWindowsSessionPathRegression(paths: readonly string[]): boolean {


### PR DESCRIPTION
## Summary

- retain a closed, path-free stage diagnostic across synchronous managed-session scope preparation
- surface the stable preparation classification plus bounded native durability detail in the startup error
- cover malformed binding, native durability, and tombstone-directory failures without exposing workspace/session paths or raw OS error text

## Scope boundary

This PR addresses only the diagnostic gap reported in #3383. It does **not** claim that the unknown Windows startup root cause is fixed, and it intentionally does not close #3383. The issue remains open until the new classification identifies ACL, binding, durability, or protocol-directory failure on a current Windows reproduction and a separate repair is proven.

## Verification

- `bun test packages/coding-agent/test/session-manager/session-directory.test.ts` — 57 pass, 3 skip
- managed-scope/session-path focused suites — 66 pass, 8 skip
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run build`
- Windows affected-path classifier selects the required Windows session-path gate

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*