### PR TITLE
fix(ultragoal): preserve explicit state clear on status

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ### Fixed
 
+- Prevent `gjc ultragoal status` from reactivating a session that was explicitly cleared with `gjc state clear --force --mode ultragoal`; execution commands can still resume its durable ledger.
+
 - Team Linux worker memory-guard replacement no longer holds the team task-mutation fence across the successor startup-ack wait, so concurrent `worker-startup-ack` can publish and selector-replacement no longer hangs under CI contention.
 
 ### Added

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -53,7 +53,7 @@ import {
 	writeSessionActivityMarker,
 } from "./session-resolution";
 import { renderUltragoalStatusMarkdown } from "./state-renderer";
-import { reconcileWorkflowSkillState } from "./state-runtime";
+import { readWorkflowStateJson, reconcileWorkflowSkillState } from "./state-runtime";
 import {
 	appendJsonl,
 	persistedStateRevision,
@@ -4878,8 +4878,9 @@ const RECONCILE_COMMANDS = new Set([
  * follows `gjc state` (`GJC_SESSION_ID`). This is a derived repair: it never changes
  * the triggering command's status/stdout, but a failure is surfaced (stderr + a
  * `reconcile_failed` ledger audit event) rather than silently swallowed. `status` is
- * therefore a read PLUS a derived repair; it never mutates goals.json/ledger.jsonl
- * beyond that reconcile-failure audit event.
+ * therefore a read PLUS a derived repair unless the operator explicitly cleared the
+ * workflow state; it never mutates goals.json/ledger.jsonl beyond that
+ * reconcile-failure audit event.
  */
 async function reconcileUltragoalState(cwd: string): Promise<void> {
 	const sessionId = currentUltragoalSessionId(cwd);
@@ -4958,11 +4959,26 @@ async function reconcileUltragoalState(cwd: string): Promise<void> {
 	}
 }
 
+async function isExplicitlyClearedUltragoalState(cwd: string): Promise<boolean> {
+	const sessionId = currentUltragoalSessionId(cwd);
+	const state = await readWorkflowStateJson(cwd, "ultragoal", sessionId);
+	const receipt = qualityGateObject(state.receipt);
+	return (
+		state.active === false &&
+		state.current_phase === "complete" &&
+		receipt?.skill === "ultragoal" &&
+		receipt.owner === "gjc-state-cli" &&
+		receipt.command === "gjc state ultragoal clear"
+	);
+}
+
 export async function runNativeUltragoalCommand(args: string[], cwd = process.cwd()): Promise<UltragoalCommandResult> {
 	const command = commandName(args);
 	const result = await dispatchUltragoalCommand(args, cwd);
 	const isHelp = args.some(isHelpArg) || args[0] === "help";
-	if (!isHelp && result.status === 0 && RECONCILE_COMMANDS.has(command)) {
+	const explicitClearBlocksStatusRepair =
+		!isHelp && command === "status" && result.status === 0 && (await isExplicitlyClearedUltragoalState(cwd));
+	if (!isHelp && result.status === 0 && RECONCILE_COMMANDS.has(command) && !explicitClearBlocksStatusRepair) {
 		await reconcileUltragoalState(cwd);
 	}
 	return result;

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -10,7 +10,7 @@ import {
 	sessionStateDir,
 	sessionUltragoalDir,
 } from "@gajae-code/coding-agent/gjc-runtime/session-layout";
-import { reconcileWorkflowSkillState } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
+import { reconcileWorkflowSkillState, runNativeStateCommand } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
 import {
 	validateCompletionReceipt,
 	verifyUltragoalDurableCompletionState,
@@ -5169,6 +5169,56 @@ describe("ultragoal mode-state + HUD reconciliation (#342)", () => {
 			expect(await Bun.file(path.join(sessionUltragoalDir(root, TEST_SESSION_ID), "ledger.jsonl")).text()).toBe(
 				beforeLedger,
 			);
+		});
+	});
+
+	it("does not let status resurrect an explicitly cleared failed run", async () => {
+		const root = await tempDir();
+		await withSessionId(TEST_SESSION_ID, async () => {
+			await runNativeUltragoalCommand(["create-goals", "--brief", "Recover a stuck run"], root);
+			await runNativeUltragoalCommand(["complete-goals"], root);
+			await runNativeUltragoalCommand(
+				[
+					"checkpoint",
+					"--goal-id",
+					"G001",
+					"--status",
+					"failed",
+					"--evidence",
+					"goal tool rejected malformed model arguments",
+				],
+				root,
+			);
+
+			const clear = await runNativeStateCommand(
+				["clear", "--mode", "ultragoal", "--session-id", TEST_SESSION_ID, "--force", "--json"],
+				root,
+			);
+			expect(clear.status).toBe(0);
+			const justClearedMode = await readModeState(root);
+			expect(justClearedMode).toMatchObject({ active: false, current_phase: "complete" });
+			expect(justClearedMode.receipt).toMatchObject({
+				owner: "gjc-state-cli",
+				command: "gjc state ultragoal clear",
+			});
+
+			const status = await runNativeUltragoalCommand(["status"], root);
+			expect(status.status).toBe(0);
+			expect(status.stdout).toContain("status: failed");
+			const clearedMode = await readModeState(root);
+			expect(clearedMode).toMatchObject({ active: false, current_phase: "complete" });
+			expect(clearedMode.receipt).toMatchObject({
+				owner: "gjc-state-cli",
+				command: "gjc state ultragoal clear",
+			});
+			const clearedActive = await readVisibleSkillActiveState(root, TEST_SESSION_ID);
+			expect(clearedActive?.active_skills?.some(entry => entry.skill === "ultragoal")).not.toBe(true);
+
+			const retry = await runNativeUltragoalCommand(["complete-goals", "--retry-failed"], root);
+			expect(retry.status).toBe(0);
+			const resumedMode = await readModeState(root);
+			expect(resumedMode).toMatchObject({ active: true, current_phase: "active" });
+			expect(resumedMode.receipt).toMatchObject({ owner: "gjc-runtime", verb: "reconcile" });
 		});
 	});
 


### PR DESCRIPTION
## Summary

- preserve an explicit `gjc state clear --force --mode ultragoal` across read-only `gjc ultragoal status`
- retain status-based repair for missing or stale derived state
- allow execution commands such as `complete-goals --retry-failed` to reactivate the durable ledger

## Root cause

`status` is intentionally included in `RECONCILE_COMMANDS`, but reconciliation did not distinguish derived stale state from an explicit operator clear. A successful status call therefore rebuilt active mode and HUD state from a failed durable plan immediately after clear, restoring the planning mutation guard.

The incident initially appeared to be GoalTool argument loss because validation printed `Received arguments: {}`. Raw session history instead showed the model emitted only the `_i` intent field and omitted required `op`; `_i` is stripped before Zod validation. This PR does not add unsafe operation inference and is scoped to the reproducible clear/status resurrection bug.

## Verification

- focused explicit-clear regression: 1 passed
- GoalTool suite: 21 passed
- ultragoal runtime suite: 141 passed; 4 unrelated Windows 5-second timeout/file-lock failures
- workflow mutation guard: 29 passed; 1 unrelated Windows symlink `EPERM`
- Biome check and `git diff --check` passed