### PR TITLE
fix(coding-agent): separate review findings evidence

### DIFF
--- a/artifacts/issue-2893-ai-slop-cleaner.txt
+++ b/artifacts/issue-2893-ai-slop-cleaner.txt
@@ -1,0 +1,27 @@
+AI SLOP CLEANUP REPORT
+======================
+
+Scope: packages/coding-agent/CHANGELOG.md; src/task/executor.ts; src/task/receipt.ts; src/task/types.ts; src/tools/review.ts; test/task/executor-review-findings.test.ts; test/task/executor-warnings.test.ts; test/task/receipt.test.ts; test/tools/review.test.ts
+Mode: read-only detector/report; no edits performed
+Blocking Findings: none
+Advisory Findings: none
+Fallback Findings: `withArtifactManagerFinalizationTurn` intentionally catches only a failed prior queue tail so later finalizations can proceed; the failing operation still rejects, task failure evidence is preserved, and the failure-then-success regression covers this grounded fail-safe behavior. Advisory/no action.
+UI/Design Findings: N/A; no UI files changed
+Missing Test Findings: none; strict explicit-yield and real subprocess fallback separation, full artifact resolution, receipt bounds/leaks, fixed publication failure, aborted-yield failure dominance, exact byte ceiling, same-manager uniqueness/recovery, persistence-owned locking, mixed managed selector/output finalization, and different-manager independence are covered
+Recursion Guard: confirmed no nested ralplan/team/deep-interview/ultragoal spawned; broad findings handed to leader
+Changed Files Reviewed:
+- packages/coding-agent/CHANGELOG.md - reviewed
+- packages/coding-agent/src/task/executor.ts - reviewed
+- packages/coding-agent/src/task/receipt.ts - reviewed
+- packages/coding-agent/src/task/types.ts - reviewed
+- packages/coding-agent/src/tools/review.ts - reviewed
+- packages/coding-agent/test/task/executor-review-findings.test.ts - reviewed
+- packages/coding-agent/test/task/executor-warnings.test.ts - reviewed
+- packages/coding-agent/test/task/receipt.test.ts - reviewed
+- packages/coding-agent/test/tools/review.test.ts - reviewed
+
+Gate Result: PASS
+Leader Action:
+- PASS: continue to verification, architect review, and executor red-team QA.
+Remaining Risks:
+- none

--- a/artifacts/issue-2893-api-package-test-report.json
+++ b/artifacts/issue-2893-api-package-test-report.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": 1,
+  "kind": "api-package-test-report",
+  "issue": 2893,
+  "branch": "fix/issue-2893-review-findings-contract",
+  "implementationBase": "dfe8285c0563e51a2745c67dbc37b2ebd93582f4",
+  "verification": [
+    {
+      "command": "bun test packages/coding-agent/test/task/executor-review-findings.test.ts packages/coding-agent/test/task/executor-warnings.test.ts packages/coding-agent/test/task/receipt.test.ts packages/coding-agent/test/tools/review.test.ts",
+      "result": "52 pass, 0 fail, 223 expect calls"
+    },
+    {
+      "command": "bun test packages/coding-agent/test/task packages/coding-agent/test/tools/review.test.ts",
+      "result": "306 pass, 0 fail, 958 expect calls"
+    },
+    {
+      "command": "bun --cwd=packages/coding-agent run check",
+      "result": "Biome checked 2477 files with no fixes; TypeScript noEmit passed"
+    },
+    {
+      "command": "bun --cwd=packages/coding-agent run build",
+      "result": "compiled packages/coding-agent/dist/gjc successfully",
+      "binarySha256": "152fe9d249a58f430d0eba7f65fb665c794a01122804b69b2c4d22b5cb772202"
+    }
+  ],
+  "compiledDogfood": {
+    "mode": "json",
+    "sessionId": "019face3-1558-7000-bc5f-9a50350bc99c",
+    "taskId": "0-ReviewFixture",
+    "model": "layofflabs/gpt-5.6-luna",
+    "taskTranscript": "/tmp/gjc-2893-dogfood-019fac2e/run8.jsonl",
+    "taskTranscriptSha256": "a9b56b4a41bb7b15338b68db6ef933af716195dd9ce6f309a9ffa025ae1a65fc",
+    "resolverTranscript": "/tmp/gjc-2893-dogfood-019fac2e/run9.jsonl",
+    "resolverTranscriptSha256": "4240b9681705b2a9549b3554e568345ecfd94d665f3ef320f8656ec4336bbf16",
+    "callerOutput": {
+      "uri": "agent://0-ReviewFixture",
+      "sizeBytes": 162,
+      "sha256": "08ebe1acab26dd689141f0ad42e77aff204c1ade8b5c43e4452d2c5e262b3d41",
+      "contract": "exact strict three-field completion; no findings field"
+    },
+    "reviewEvidence": {
+      "uri": "artifact://0",
+      "sizeBytes": 461,
+      "sha256": "77fdeb2d8cb28f8d92591d6f8fdf1d34cca387507accd78194f3b242b7f68c71",
+      "contract": "version 1 review-findings payload; taskId 0-ReviewFixture; findingCount 1; full finding retained"
+    },
+    "resolverResult": "compiled read resolved both internal URIs from the resumed session"
+  },
+  "boundedSuiteAttribution": {
+    "fullCodingAgentSuite": "not used as a green gate because unrelated replay/midrun/sdk-host tests timed out at fixed 5 second limits under full-suite contention",
+    "q17Branch": "1 pass, 74 filtered, 0 fail in 2.33s",
+    "q17CurrentDev": "1 pass, 74 filtered, 0 fail in 3.03s at origin/dev 27e26c2e9ccbb464f2fade636692efbff4de594f",
+    "conclusion": "Q17 timeout is baseline/contention, not caused by issue #2893"
+  }
+}

--- a/artifacts/issue-2893-quality-gate.json
+++ b/artifacts/issue-2893-quality-gate.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": 1,
+  "goalId": "G001",
+  "goalTitle": "Resolve issue #2893 review-wrapper findings contract",
+  "verdict": "MERGE_READY",
+  "summary": "Strict caller-owned JTD completion data remains untouched; wrapper-owned review findings are published as exact bounded artifact evidence with leak-safe receipt references, serialized shared-manager finalization, and fail-closed publication semantics. Current tests, check, build, compiled workflow dogfood, cleanup, architecture review, red-team QA, and terminal critic are green.",
+  "subchecks": [
+    {
+      "name": "focused-contract-tests",
+      "verdict": "PASS",
+      "evidence": "52 pass, 0 fail, 223 expect calls"
+    },
+    {
+      "name": "task-subsystem-tests",
+      "verdict": "PASS",
+      "evidence": "306 pass, 0 fail, 958 expect calls"
+    },
+    {
+      "name": "package-check",
+      "verdict": "PASS",
+      "evidence": "Biome 2477 files; TypeScript noEmit passed"
+    },
+    {
+      "name": "compiled-workflow-dogfood",
+      "verdict": "PASS",
+      "evidence": "dist/gjc sha256 152fe9d249a58f430d0eba7f65fb665c794a01122804b69b2c4d22b5cb772202; session 019face3-1558-7000-bc5f-9a50350bc99c resolved strict agent:// and separate artifact:// payloads"
+    },
+    {
+      "name": "cleanup-review",
+      "verdict": "PASS",
+      "evidence": "artifacts/issue-2893-ai-slop-cleaner.txt"
+    },
+    {
+      "name": "architecture-review",
+      "verdict": "CLEAR",
+      "evidence": "Exact product snapshot; confidence 0.97"
+    },
+    {
+      "name": "red-team-qa",
+      "verdict": "CLEAR",
+      "evidence": "Exact final test snapshot; confidence 0.99"
+    },
+    {
+      "name": "terminal-critic",
+      "verdict": "MERGE_READY",
+      "evidence": "Exact final snapshot; confidence 0.99"
+    },
+    {
+      "name": "current-dev-overlap",
+      "verdict": "PASS",
+      "evidence": "origin/dev 27e26c2e9ccbb464f2fade636692efbff4de594f changed only packages/utils since frozen base"
+    }
+  ],
+  "remediation": []
+}

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 
 - Team Linux worker memory-guard replacement no longer holds the team task-mutation fence across the successor startup-ack wait, so concurrent `worker-startup-ack` can publish and selector-replacement no longer hangs under CI contention.
+- Reviewer `report_finding` evidence is no longer injected into caller-owned strict JTD completion data; full findings are published separately through a bounded artifact reference, and failed evidence publication now fails the task closed (#2893).
 
 ### Added
 

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -44,7 +44,7 @@ import { SessionManager } from "../session/session-manager";
 import { truncateTail } from "../session/streaming-output";
 import type { ContextFileEntry } from "../tools";
 import { jtdToJsonSchema, normalizeSchema } from "../tools/jtd-to-json-schema";
-import { type ReportFindingDetails, toReviewFinding } from "../tools/review";
+import type { ReportFindingDetails } from "../tools/review";
 import { ToolAbortError } from "../tools/tool-errors";
 import type { EventBus } from "../utils/event-bus";
 import { buildNamedToolChoiceResult } from "../utils/tool-choice";
@@ -61,7 +61,7 @@ import {
 	MAX_OUTPUT_BYTES,
 	MAX_OUTPUT_LINES,
 	type ModelSubstitutionWarning,
-	type ReviewFinding,
+	type ReviewFindingsArtifactRef,
 	type SetupFailureSummary,
 	type SingleResult,
 	TASK_SUBAGENT_EVENT_CHANNEL,
@@ -295,17 +295,72 @@ export class ManagedTaskPersistence {
 	}
 
 	async publishOutput(rawOutput: string, metadata: Uint8Array): Promise<void> {
-		await this.#artifacts.publishManagedOutputGeneration(
-			`${this.#taskId}.md.selector.json`,
-			`${this.#taskId}.md`,
-			Buffer.from(rawOutput, "utf8"),
-			metadata,
+		await withArtifactManagerFinalizationTurn(this.#artifacts, () =>
+			this.#artifacts.publishManagedOutputGeneration(
+				`${this.#taskId}.md.selector.json`,
+				`${this.#taskId}.md`,
+				Buffer.from(rawOutput, "utf8"),
+				metadata,
+			),
 		);
 	}
 }
 
 export function createManagedTaskPersistence(artifacts: ArtifactManager, taskId: string): ManagedTaskPersistence {
 	return new ManagedTaskPersistence(artifacts, taskId);
+}
+
+const MAX_REVIEW_FINDINGS_ARTIFACT_BYTES = 16 * 1024 * 1024;
+const REVIEW_FINDINGS_ARTIFACT_FAILURE = "Review findings artifact publication failed.";
+const artifactManagerFinalizationTails = new WeakMap<ArtifactManager, Promise<void>>();
+
+interface ReviewFindingsArtifactPayload {
+	version: 1;
+	kind: "review-findings";
+	taskId: string;
+	findingCount: number;
+	findings: ReportFindingDetails[];
+}
+
+async function withArtifactManagerFinalizationTurn<T>(
+	manager: ArtifactManager,
+	operation: () => Promise<T>,
+): Promise<T> {
+	const priorTail = artifactManagerFinalizationTails.get(manager);
+	const turn = Promise.withResolvers<void>();
+	artifactManagerFinalizationTails.set(manager, turn.promise);
+
+	try {
+		await priorTail?.catch(() => undefined);
+		return await operation();
+	} finally {
+		turn.resolve();
+		if (artifactManagerFinalizationTails.get(manager) === turn.promise) {
+			artifactManagerFinalizationTails.delete(manager);
+		}
+	}
+}
+
+async function publishReviewFindingsArtifact(
+	manager: ArtifactManager,
+	taskId: string,
+	findings: ReportFindingDetails[],
+): Promise<ReviewFindingsArtifactRef> {
+	const payload: ReviewFindingsArtifactPayload = {
+		version: 1,
+		kind: "review-findings",
+		taskId,
+		findingCount: findings.length,
+		findings,
+	};
+	const serialized = JSON.stringify(payload, null, 2);
+	const sizeBytes = Buffer.byteLength(serialized, "utf8");
+	if (sizeBytes > MAX_REVIEW_FINDINGS_ARTIFACT_BYTES) throw new Error("review findings artifact exceeds limit");
+	const sha256 = createHash("sha256").update(serialized).digest("hex");
+	const artifactId = await withArtifactManagerFinalizationTurn(manager, () =>
+		manager.save(serialized, "review-findings", { maxBytes: sizeBytes }),
+	);
+	return { uri: `artifact://${artifactId}`, sizeBytes, sha256, findingCount: findings.length };
 }
 
 export function renderSubagentUserPrompt(assignment: string, independentMode: boolean): string {
@@ -443,21 +498,8 @@ function extractCompletionData(parsed: unknown): unknown {
 	return parsed;
 }
 
-function normalizeCompleteData(data: unknown, reportFindings?: ReviewFinding[]): unknown {
-	let normalized = parseStringifiedJson(data ?? null);
-	if (
-		Array.isArray(reportFindings) &&
-		reportFindings.length > 0 &&
-		normalized &&
-		typeof normalized === "object" &&
-		!Array.isArray(normalized)
-	) {
-		const record = normalized as Record<string, unknown>;
-		if (!("findings" in record)) {
-			normalized = { ...record, findings: reportFindings };
-		}
-	}
-	return normalized;
+function normalizeCompleteData(data: unknown): unknown {
+	return parseStringifiedJson(data ?? null);
 }
 
 function resolveFallbackCompletion(rawOutput: string, outputSchema: unknown): { data: unknown } | null {
@@ -484,7 +526,6 @@ interface FinalizeSubprocessOutputArgs {
 	doneAborted: boolean;
 	signalAborted: boolean;
 	yieldItems?: YieldItem[];
-	reportFindings?: ReviewFinding[];
 	outputSchema: unknown;
 }
 
@@ -545,7 +586,7 @@ function buildPlaceholderYieldOutcome(
 
 export function finalizeSubprocessOutput(args: FinalizeSubprocessOutputArgs): FinalizeSubprocessOutputResult {
 	let { rawOutput, exitCode, stderr } = args;
-	const { yieldItems, reportFindings, doneAborted, signalAborted, outputSchema } = args;
+	const { yieldItems, doneAborted, signalAborted, outputSchema } = args;
 	let abortedViaYield = false;
 	const hasYield = Array.isArray(yieldItems) && yieldItems.length > 0;
 
@@ -565,7 +606,7 @@ export function finalizeSubprocessOutput(args: FinalizeSubprocessOutputArgs): Fi
 			if (submitData === null || submitData === undefined) {
 				rawOutput = rawOutput ? `${SUBAGENT_WARNING_NULL_YIELD}\n\n${rawOutput}` : SUBAGENT_WARNING_NULL_YIELD;
 			} else {
-				const completeData = normalizeCompleteData(submitData, reportFindings);
+				const completeData = normalizeCompleteData(submitData);
 				const { validator, error: schemaError } = buildOutputValidator(outputSchema);
 				if (schemaError) {
 					const outcome = buildSchemaViolationOutcome(
@@ -612,7 +653,7 @@ export function finalizeSubprocessOutput(args: FinalizeSubprocessOutputArgs): Fi
 		const hasOutputSchema = normalizedSchema !== undefined && !schemaError;
 		const fallback = allowFallback ? resolveFallbackCompletion(rawOutput, outputSchema) : null;
 		if (fallback) {
-			const completeData = normalizeCompleteData(fallback.data, reportFindings);
+			const completeData = normalizeCompleteData(fallback.data);
 			const { validator } = buildOutputValidator(outputSchema);
 			const placeholderPath = findPlaceholderYieldPath(completeData);
 			if (placeholderPath) {
@@ -2072,7 +2113,6 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 	let rawOutput = finalOutputChunks.length > 0 ? finalOutputChunks.join("") : outputChunks.join("");
 	const yieldItems = progress.extractedToolData?.yield as YieldItem[] | undefined;
 	const reportFindingDetails = progress.extractedToolData?.report_finding as ReportFindingDetails[] | undefined;
-	const reportFindings: ReviewFinding[] | undefined = reportFindingDetails?.map(toReviewFinding);
 	const finalized = finalizeSubprocessOutput({
 		rawOutput,
 		exitCode,
@@ -2080,12 +2120,25 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		doneAborted: Boolean(done.aborted),
 		signalAborted: Boolean(signal?.aborted),
 		yieldItems,
-		reportFindings,
 		outputSchema,
 	});
 	rawOutput = finalized.rawOutput;
 	exitCode = finalized.exitCode;
 	stderr = finalized.stderr;
+	let reviewFindingsRef: ReviewFindingsArtifactRef | undefined;
+	let reviewFindingsPublicationFailed = false;
+	if (reportFindingDetails && reportFindingDetails.length > 0) {
+		try {
+			const manager = options.parentArtifactManager;
+			if (!manager) throw new Error("review findings artifact authority unavailable");
+			reviewFindingsRef = await publishReviewFindingsArtifact(manager, id, reportFindingDetails);
+		} catch {
+			reviewFindingsPublicationFailed = true;
+			exitCode = 1;
+			stderr = REVIEW_FINDINGS_ARTIFACT_FAILURE;
+			paused = false;
+		}
+	}
 	const lastYield = yieldItems?.[yieldItems.length - 1];
 	const yieldAbortReason = lastYield?.status === "aborted" ? lastYield.error || "Subagent aborted task" : undefined;
 	const { abortedViaYield, hasYield } = finalized;
@@ -2142,7 +2195,9 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		exitCode = 1;
 	}
 	const wasAborted =
-		runtimeLimitExceeded || abortedViaYield || (!hasYield && (done.aborted || signal?.aborted || false));
+		runtimeLimitExceeded ||
+		(!reviewFindingsPublicationFailed &&
+			(abortedViaYield || (!hasYield && (done.aborted || signal?.aborted || false))));
 	const finalAbortReason = wasAborted
 		? runtimeLimitExceeded
 			? resolveAbortReasonText()
@@ -2198,5 +2253,6 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		extractedToolData: progress.extractedToolData,
 		retryFailure: progress.retryFailure,
 		outputMeta,
+		reviewFindingsRef,
 	};
 }

--- a/packages/coding-agent/src/task/receipt.ts
+++ b/packages/coding-agent/src/task/receipt.ts
@@ -1,4 +1,9 @@
-import { hasCompleteUsageCostBreakdown, type SingleResult, type TaskToolDetails } from "./types";
+import {
+	hasCompleteUsageCostBreakdown,
+	type ReviewFindingsArtifactRef,
+	type SingleResult,
+	type TaskToolDetails,
+} from "./types";
 export interface TaskRoi {
 	tokens: number;
 	contextTokens?: number;
@@ -46,6 +51,8 @@ export interface TaskResultReceipt {
 		overallCorrectness?: string;
 		findingCount: number;
 		findings?: Array<{ severity?: string; summary: string }>;
+		/** Canonical full-fidelity findings; inline summaries are display-only. */
+		findingsRef?: ReviewFindingsArtifactRef;
 	};
 	extractedToolCounts?: Record<string, number>;
 	forkContext?: SingleResult["forkContext"];
@@ -136,32 +143,34 @@ function getStatus(raw: SingleResult): TaskResultReceipt["status"] {
 
 function buildReview(raw: SingleResult): TaskResultReceipt["review"] | undefined {
 	const data = raw.extractedToolData;
-	if (!data) return undefined;
-	const yields = Array.isArray(data.yield) ? data.yield : [];
+	const findingsRef = raw.reviewFindingsRef;
+	const yields = Array.isArray(data?.yield) ? data.yield : [];
 	const reviewYield = yields
 		.map(item => (item && typeof item === "object" ? (item as { data?: unknown }).data : undefined))
 		.findLast(item => item && typeof item === "object" && "overall_correctness" in item) as
 		| { overall_correctness?: unknown }
 		| undefined;
-	const rawFindings = Array.isArray(data.report_finding) ? data.report_finding : [];
+	const rawFindings = Array.isArray(data?.report_finding) ? data.report_finding : [];
 	const findings = rawFindings.slice(0, 20).map(item => {
 		const value = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
 		const severity = normalizeReviewFindingSeverity(value.severity, value.priority);
 		const summaryValue = value.summary ?? value.title ?? value.message ?? value.body ?? "finding";
 		return { severity, summary: truncateText(String(summaryValue), 200) ?? "finding" };
 	});
-	if (!reviewYield && findings.length === 0) return undefined;
+	if (!reviewYield && findings.length === 0 && !findingsRef) return undefined;
 	return {
 		overallCorrectness: truncateText(
 			typeof reviewYield?.overall_correctness === "string" ? reviewYield.overall_correctness : undefined,
 			200,
 		),
-		findingCount: rawFindings.length,
+		findingCount: findingsRef?.findingCount ?? rawFindings.length,
 		findings: findings.length > 0 ? findings : undefined,
+		findingsRef,
 	};
 }
 
 function hasReviewFindings(raw: SingleResult): boolean {
+	if (raw.reviewFindingsRef) return true;
 	const findings = raw.extractedToolData?.report_finding;
 	return Array.isArray(findings) && findings.length > 0;
 }

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -212,6 +212,14 @@ export interface ReviewFinding {
 	line_end: number;
 }
 
+/** Durable full-fidelity review findings artifact associated with a task result. */
+export interface ReviewFindingsArtifactRef {
+	uri: `artifact://${string}`;
+	sizeBytes: number;
+	sha256: string;
+	findingCount: number;
+}
+
 /** Review summary submitted by the reviewer agent */
 export interface ReviewSummary {
 	overall_correctness: "correct" | "incorrect";
@@ -464,6 +472,8 @@ export interface SingleResult {
 	producedChanges?: boolean;
 	/** Data extracted by registered subprocess tool handlers (keyed by tool name) */
 	extractedToolData?: Record<string, unknown[]>;
+	/** Full wrapper-owned review evidence, kept separate from caller completion data. */
+	reviewFindingsRef?: ReviewFindingsArtifactRef;
 	/**
 	 * Terminal retry failure, when the subagent exited because the auto-retry
 	 * loop gave up (retry-after exceeded the cap, or all attempts exhausted).

--- a/packages/coding-agent/src/tools/review.ts
+++ b/packages/coding-agent/src/tools/review.ts
@@ -188,15 +188,13 @@ export interface SubmitReviewDetails {
 // Re-export types for external use
 export type { ReportFindingDetails };
 /**
- * Coerce a tool-side `ReportFindingDetails` into the cross-boundary
- * `ReviewFinding` shape consumed by the reviewer agent's JTD output schema.
+ * Convert tool-side `ReportFindingDetails` into the numeric-priority
+ * `ReviewFinding` shape used by caller-owned reviewer payloads.
  *
  * The `report_finding` tool exposes `priority` as a string enum (`"P0".."P3"`)
- * for ergonomics, but the bundled reviewer schema (and every custom review
- * agent that mirrors it) declares `priority: number`. Without this coercion
- * the auto-populated `findings[]` fails JTD validation and every review run
- * that surfaces a finding is rejected with `findings.0.priority: expected
- * number, received string`.
+ * for ergonomics, while reviewer schemas may explicitly declare numeric
+ * priorities. This pure conversion does not add findings to completion data;
+ * callers that include `findings` own both that field and its output schema.
  */
 export function toReviewFinding(details: ReportFindingDetails): ReviewFinding {
 	return {

--- a/packages/coding-agent/test/task/executor-review-findings.test.ts
+++ b/packages/coding-agent/test/task/executor-review-findings.test.ts
@@ -1,0 +1,648 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { createHash } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentEvent } from "@gajae-code/agent-core";
+import type { AssistantMessage } from "@gajae-code/ai";
+import { AsyncJobManager } from "../../src/async/job-manager";
+import { kNoAuth } from "../../src/config/model-registry";
+import { Settings } from "../../src/config/settings";
+import type { LoadExtensionsResult } from "../../src/extensibility/extensions/types";
+import { ArtifactProtocolHandler } from "../../src/internal-urls/artifact-protocol";
+import type { CreateAgentSessionResult } from "../../src/sdk";
+import * as sdkModule from "../../src/sdk";
+import type { AgentSession, AgentSessionEvent } from "../../src/session/agent-session";
+import { ArtifactManager } from "../../src/session/artifacts";
+import {
+	ManagedSessionDescendantStore,
+	managedDirectoryRoot,
+} from "../../src/session/internal/managed-session-storage";
+import { createManagedTaskPersistence, type ExecutorOptions, runSubprocess } from "../../src/task/executor";
+import { buildTaskReceipt, findRawTaskLeakKeys } from "../../src/task/receipt";
+import type { AgentDefinition, SingleResult } from "../../src/task/types";
+import { EventBus } from "../../src/utils/event-bus";
+
+const MAX_REVIEW_FINDINGS_BYTES = 16 * 1024 * 1024;
+const REVIEW_FINDINGS_FAILURE = "Review findings artifact publication failed.";
+const roots: string[] = [];
+
+const agent: AgentDefinition = {
+	name: "architect",
+	description: "test reviewer",
+	systemPrompt: "test",
+	tools: ["report_finding", "yield"],
+	source: "bundled",
+};
+
+const modelRegistry = {
+	refresh: async () => {},
+	getAvailable: () => [],
+	getApiKey: async () => kNoAuth,
+} as unknown as import("../../src/config/model-registry").ModelRegistry;
+
+interface Finding {
+	title: string;
+	body: string;
+	priority: "P0" | "P1" | "P2" | "P3";
+	confidence: number;
+	file_path: string;
+	line_start: number;
+	line_end: number;
+}
+
+interface CanonicalReviewPayload {
+	version: 1;
+	kind: "review-findings";
+	taskId: string;
+	findingCount: number;
+	findings: Finding[];
+}
+
+function finding(index: number, body = `details ${index}`): Finding {
+	return {
+		title: `[P1] finding ${index}`,
+		body,
+		priority: "P1",
+		confidence: 0.9,
+		file_path: `/repo/src/example-${index}.ts`,
+		line_start: index + 1,
+		line_end: index + 2,
+	};
+}
+
+function completion() {
+	return {
+		overall_correctness: "incorrect" as const,
+		explanation: "Found review defects",
+		confidence: 0.95,
+	};
+}
+
+function outputSchema() {
+	return {
+		properties: {
+			overall_correctness: { enum: ["correct", "incorrect"] },
+			explanation: { type: "string" },
+			confidence: { type: "float64" },
+		},
+	};
+}
+
+function createMessage(text = "review completed"): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "openai-responses",
+		provider: "openai",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+interface ReviewSessionOptions {
+	includeYield?: boolean;
+	yieldStatus?: "success" | "aborted";
+	messageText?: string;
+	onDispose?: () => void;
+	disposeRelease?: Promise<void>;
+	onlyFirstPrompt?: boolean;
+}
+
+function createReviewSession(
+	findings: Finding[],
+	data = completion(),
+	options: ReviewSessionOptions = {},
+): AgentSession {
+	const listeners: Array<(event: AgentSessionEvent) => void> = [];
+	const message = createMessage(options.messageText);
+	let promptCalls = 0;
+	const emit = (event: AgentEvent) => {
+		for (const listener of listeners) listener(event);
+	};
+	return {
+		state: { messages: [] },
+		agent: { state: { systemPrompt: ["test"] } },
+		model: undefined,
+		extensionRunner: undefined,
+		sessionManager: { appendSessionInit: () => {} },
+		getActiveToolNames: () => ["report_finding", "yield"],
+		setActiveToolsByName: async () => {},
+		setConfiguredModelChain: () => {},
+		getConfiguredModelChain: () => undefined,
+		seedDefaultFallbackResolution: () => {},
+		subscribe: (listener: (event: AgentSessionEvent) => void) => {
+			listeners.push(listener);
+			return () => {
+				const index = listeners.indexOf(listener);
+				if (index >= 0) listeners.splice(index, 1);
+			};
+		},
+		prompt: async () => {
+			promptCalls += 1;
+			if (options.onlyFirstPrompt && promptCalls > 1) return;
+			emit({ type: "message_end", message });
+			for (const [index, details] of findings.entries()) {
+				emit({
+					type: "tool_execution_end",
+					toolCallId: `finding-${index}`,
+					toolName: "report_finding",
+					result: { content: [{ type: "text", text: "Finding recorded" }], details },
+					isError: false,
+				});
+			}
+			if (options.includeYield !== false) {
+				const details =
+					options.yieldStatus === "aborted"
+						? { status: "aborted" as const, error: "review aborted" }
+						: { status: "success" as const, data };
+				emit({
+					type: "tool_execution_end",
+					toolCallId: "yield-call",
+					toolName: "yield",
+					result: { content: [{ type: "text", text: "Result submitted" }], details },
+					isError: false,
+				});
+			}
+			emit({ type: "agent_end", messages: [message], stopReason: "completed" });
+		},
+		waitForIdle: async () => {},
+		getLastAssistantMessage: () => message,
+		abort: async () => {},
+		dispose: async () => {
+			options.onDispose?.();
+			if (options.disposeRelease) await options.disposeRelease;
+		},
+	} as unknown as AgentSession;
+}
+
+async function drainMicrotasks(): Promise<void> {
+	for (let index = 0; index < 20; index++) await Promise.resolve();
+}
+
+function createSessionResult(session: AgentSession): CreateAgentSessionResult {
+	return {
+		session,
+		extensionsResult: {} as LoadExtensionsResult,
+		setToolUIContext: () => {},
+		eventBus: new EventBus(),
+	};
+}
+
+async function tempRoot(): Promise<string> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-review-findings-"));
+	roots.push(root);
+	return root;
+}
+
+function baseOptions(id: string, root: string): ExecutorOptions {
+	return {
+		cwd: root,
+		agent,
+		task: "review fixture",
+		index: 0,
+		id,
+		subagentId: id,
+		artifactsDir: path.join(root, "artifacts"),
+		settings: Settings.isolated(),
+		modelRegistry,
+		enableLsp: false,
+		outputSchema: outputSchema(),
+	};
+}
+
+function artifactId(result: SingleResult): string {
+	const uri = result.reviewFindingsRef?.uri;
+	if (!uri) throw new Error("Expected review findings reference");
+	return uri.slice("artifact://".length);
+}
+
+async function readArtifact(manager: ArtifactManager, result: SingleResult): Promise<string> {
+	const id = artifactId(result);
+	const artifactPath = await manager.getPath(id);
+	if (!artifactPath) throw new Error(`Missing artifact ${id}`);
+	return fs.readFile(artifactPath, "utf8");
+}
+
+async function readManagedSelected(
+	artifactsDir: string,
+	taskId: string,
+): Promise<{
+	output: string;
+	metadata: { id: string; kind: string; sizeBytes: number; lineCount: number; sha256: string; createdAt: string };
+}> {
+	const selector = JSON.parse(await fs.readFile(path.join(artifactsDir, `${taskId}.md.selector.json`), "utf8")) as {
+		outputFilename: string;
+		metadataFilename: string;
+	};
+	return {
+		output: await fs.readFile(path.join(artifactsDir, selector.outputFilename), "utf8"),
+		metadata: JSON.parse(await fs.readFile(path.join(artifactsDir, selector.metadataFilename), "utf8")) as {
+			id: string;
+			kind: string;
+			sizeBytes: number;
+			sha256: string;
+			lineCount: number;
+			createdAt: string;
+		},
+	};
+}
+
+function canonicalPayload(taskId: string, findings: Finding[]): CanonicalReviewPayload {
+	return { version: 1, kind: "review-findings", taskId, findingCount: findings.length, findings };
+}
+
+function resolveContext(dir: string) {
+	return { getArtifactsDir: () => dir, getAuthorizedArtifactsDirs: () => [dir] };
+}
+
+beforeEach(() => {
+	AsyncJobManager.setInstance(new AsyncJobManager({ onJobComplete: async () => {} }));
+});
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	const manager = AsyncJobManager.instance();
+	if (manager) await manager.dispose({ timeoutMs: 100 });
+	AsyncJobManager.setInstance(undefined);
+	await Promise.all(roots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe("review findings evidence separation", () => {
+	it("keeps strict caller output separate from full canonical findings", async () => {
+		const root = await tempRoot();
+		const artifactsDir = path.join(root, "artifacts");
+		const manager = new ArtifactManager(artifactsDir);
+		const findings = Array.from({ length: 21 }, (_, index) =>
+			finding(index, index === 20 ? "Unicode tail 한국어 😀 FULL-FINDING-TAIL-SENTINEL" : `details ${index}`),
+		);
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(createReviewSession(findings)));
+
+		const result = await runSubprocess({ ...baseOptions("0-Review", root), parentArtifactManager: manager });
+		const receipt = buildTaskReceipt(result);
+		const artifact = await readArtifact(manager, result);
+		const ref = result.reviewFindingsRef!;
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toBe("");
+		expect(JSON.parse(result.output)).toEqual(completion());
+		expect(result.output).not.toContain("findings");
+		expect(JSON.parse(artifact)).toEqual(canonicalPayload("0-Review", findings));
+		expect(Buffer.byteLength(artifact)).toBe(ref.sizeBytes);
+		expect(createHash("sha256").update(artifact).digest("hex")).toBe(ref.sha256);
+		expect(ref.findingCount).toBe(21);
+		expect(receipt.review?.findings).toHaveLength(20);
+		expect(receipt.review?.findingsRef).toEqual(ref);
+		expect(JSON.stringify(receipt)).not.toContain("FULL-FINDING-TAIL-SENTINEL");
+		expect(JSON.stringify(receipt)).not.toContain("/repo/src/example-20.ts");
+		expect(findRawTaskLeakKeys(receipt)).toEqual([]);
+
+		const resolved = await new ArtifactProtocolHandler().resolve(
+			new URL(ref.uri) as never,
+			resolveContext(artifactsDir),
+		);
+		expect(resolved.content).toBe(artifact);
+	});
+
+	it("recovers fallback caller data while publishing findings separately", async () => {
+		const root = await tempRoot();
+		const manager = new ArtifactManager(path.join(root, "artifacts"));
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(
+			createSessionResult(
+				createReviewSession([finding(0)], completion(), {
+					includeYield: false,
+					messageText: JSON.stringify({ data: completion() }),
+					onlyFirstPrompt: true,
+				}),
+			),
+		);
+
+		const result = await runSubprocess({ ...baseOptions("0-Fallback", root), parentArtifactManager: manager });
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toBe("");
+		expect(JSON.parse(result.output)).toEqual(completion());
+		expect(result.output).not.toContain("findings");
+		expect(JSON.parse(await readArtifact(manager, result))).toEqual(canonicalPayload("0-Fallback", [finding(0)]));
+	});
+
+	it("fails closed without artifact authority while preserving caller output", async () => {
+		const root = await tempRoot();
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(
+			createSessionResult(createReviewSession([finding(0)])),
+		);
+
+		const result = await runSubprocess(baseOptions("0-NoAuthority", root));
+		const receipt = buildTaskReceipt(result);
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toBe(REVIEW_FINDINGS_FAILURE);
+		expect(result.reviewFindingsRef).toBeUndefined();
+		expect(JSON.parse(result.output)).toEqual(completion());
+		expect(receipt.status).toBe("failed");
+		expect(receipt.errorSummary).toBe("Error recorded.");
+	});
+
+	it("reports failed rather than aborted when evidence publication fails", async () => {
+		const root = await tempRoot();
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(
+			createSessionResult(createReviewSession([finding(0)], completion(), { yieldStatus: "aborted" })),
+		);
+
+		const result = await runSubprocess(baseOptions("0-AbortedPublicationFailure", root));
+		const receipt = buildTaskReceipt(result);
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toBe(REVIEW_FINDINGS_FAILURE);
+		expect(result.aborted).toBe(false);
+		expect(result.abortReason).toBeUndefined();
+		expect(result.reviewFindingsRef).toBeUndefined();
+		expect(receipt.status).toBe("failed");
+	});
+
+	it("serializes concurrent same-manager review publications and recovers after failure", async () => {
+		const root = await tempRoot();
+		const manager = new ArtifactManager(path.join(root, "artifacts"));
+		const saveEntered = Promise.withResolvers<void>();
+		const releaseFirst = Promise.withResolvers<void>();
+		const secondDisposeEntered = Promise.withResolvers<void>();
+		const releaseSecondDispose = Promise.withResolvers<void>();
+		const realSave = manager.save.bind(manager);
+		let saveCalls = 0;
+		const saveSpy = vi.spyOn(manager, "save").mockImplementation(async (...args) => {
+			saveCalls += 1;
+			if (saveCalls === 1) {
+				saveEntered.resolve();
+				await releaseFirst.promise;
+				throw new Error("injected save failure");
+			}
+			return realSave(...args);
+		});
+		vi.spyOn(sdkModule, "createAgentSession")
+			.mockResolvedValueOnce(createSessionResult(createReviewSession([finding(0)])))
+			.mockResolvedValueOnce(
+				createSessionResult(
+					createReviewSession([finding(1)], completion(), {
+						onDispose: secondDisposeEntered.resolve,
+						disposeRelease: releaseSecondDispose.promise,
+					}),
+				),
+			);
+
+		const first = runSubprocess({ ...baseOptions("0-First", root), parentArtifactManager: manager });
+		await saveEntered.promise;
+		const second = runSubprocess({ ...baseOptions("1-Second", root), parentArtifactManager: manager, index: 1 });
+		await secondDisposeEntered.promise;
+		releaseSecondDispose.resolve();
+		await drainMicrotasks();
+		expect(saveCalls).toBe(1);
+		releaseFirst.resolve();
+		const [firstResult, secondResult] = await Promise.all([first, second]);
+
+		expect(firstResult.exitCode).toBe(1);
+		expect(firstResult.stderr).toBe(REVIEW_FINDINGS_FAILURE);
+		expect(secondResult.exitCode).toBe(0);
+		expect(JSON.parse(await readArtifact(manager, secondResult))).toEqual(canonicalPayload("1-Second", [finding(1)]));
+		expect(saveSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps different artifact managers independent", async () => {
+		const root = await tempRoot();
+		const firstManager = new ArtifactManager(path.join(root, "first-artifacts"));
+		const secondManager = new ArtifactManager(path.join(root, "second-artifacts"));
+		const firstSaveEntered = Promise.withResolvers<void>();
+		const releaseFirstSave = Promise.withResolvers<void>();
+		const realFirstSave = firstManager.save.bind(firstManager);
+		vi.spyOn(firstManager, "save").mockImplementation(async (...args) => {
+			firstSaveEntered.resolve();
+			await releaseFirstSave.promise;
+			return realFirstSave(...args);
+		});
+		vi.spyOn(sdkModule, "createAgentSession")
+			.mockResolvedValueOnce(createSessionResult(createReviewSession([finding(0)])))
+			.mockResolvedValueOnce(createSessionResult(createReviewSession([finding(1)])));
+
+		const first = runSubprocess({
+			...baseOptions("0-FirstManager", root),
+			artifactsDir: path.join(root, "first-artifacts"),
+			parentArtifactManager: firstManager,
+		});
+		await firstSaveEntered.promise;
+		const secondResult = await runSubprocess({
+			...baseOptions("1-SecondManager", root),
+			index: 1,
+			artifactsDir: path.join(root, "second-artifacts"),
+			parentArtifactManager: secondManager,
+		});
+
+		releaseFirstSave.resolve();
+		const firstResult = await first;
+		expect(secondResult.exitCode).toBe(0);
+		expect(JSON.parse(await readArtifact(secondManager, secondResult))).toEqual(
+			canonicalPayload("1-SecondManager", [finding(1)]),
+		);
+		expect(firstResult.exitCode).toBe(0);
+	});
+
+	it("publishes at the reader limit and fails before save above it", async () => {
+		const root = await tempRoot();
+		const manager = new ArtifactManager(path.join(root, "artifacts"));
+		const taskId = "0-AtLimit";
+		const emptyFinding = finding(0, "");
+		const baseSize = Buffer.byteLength(JSON.stringify(canonicalPayload(taskId, [emptyFinding]), null, 2));
+		const atLimitFinding = finding(0, "x".repeat(MAX_REVIEW_FINDINGS_BYTES - baseSize));
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValueOnce(
+			createSessionResult(createReviewSession([atLimitFinding])),
+		);
+
+		const atLimit = await runSubprocess({ ...baseOptions(taskId, root), parentArtifactManager: manager });
+		const atLimitArtifact = await readArtifact(manager, atLimit);
+		expect(atLimit.exitCode).toBe(0);
+		expect(Buffer.byteLength(atLimitArtifact)).toBe(MAX_REVIEW_FINDINGS_BYTES);
+
+		const overflowManager = new ArtifactManager(path.join(root, "overflow-artifacts"));
+		const overflowTaskId = "1-OverLimit";
+		const overflowBase = Buffer.byteLength(JSON.stringify(canonicalPayload(overflowTaskId, [emptyFinding]), null, 2));
+		const overflowFinding = finding(0, "x".repeat(MAX_REVIEW_FINDINGS_BYTES - overflowBase + 1));
+		const overflowSave = vi.spyOn(overflowManager, "save");
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValueOnce(
+			createSessionResult(createReviewSession([overflowFinding])),
+		);
+
+		const overflow = await runSubprocess({
+			...baseOptions(overflowTaskId, root),
+			index: 1,
+			artifactsDir: path.join(root, "overflow-artifacts"),
+			parentArtifactManager: overflowManager,
+		});
+		const overflowReceipt = buildTaskReceipt(overflow);
+		expect(overflow.exitCode).toBe(1);
+		expect(overflow.stderr).toBe(REVIEW_FINDINGS_FAILURE);
+		expect(overflow.reviewFindingsRef).toBeUndefined();
+		expect(overflowSave).not.toHaveBeenCalled();
+		expect(JSON.parse(overflow.output)).toEqual(completion());
+		expect(overflow.output).not.toContain("findings");
+		expect(overflowReceipt.status).toBe("failed");
+		expect(overflowReceipt.errorSummary).toBe("Error recorded.");
+	});
+});
+
+describe.skipIf(process.platform !== "linux")("managed review findings finalization", () => {
+	it("serializes managed outputs by the persistence-owned manager", async () => {
+		const root = await tempRoot();
+		const artifactsDir = path.join(root, "artifacts");
+		const manager = new ArtifactManager(new ManagedSessionDescendantStore(managedDirectoryRoot(root), artifactsDir));
+		const firstPublishEntered = Promise.withResolvers<void>();
+		const releaseFirstPublish = Promise.withResolvers<void>();
+		const secondDisposeEntered = Promise.withResolvers<void>();
+		const releaseSecondDispose = Promise.withResolvers<void>();
+		const realPublish = manager.publishManagedOutputGeneration.bind(manager);
+		let publishCalls = 0;
+		vi.spyOn(manager, "publishManagedOutputGeneration").mockImplementation(async (...args) => {
+			publishCalls += 1;
+			if (publishCalls === 1) {
+				firstPublishEntered.resolve();
+				await releaseFirstPublish.promise;
+			}
+			return realPublish(...args);
+		});
+		vi.spyOn(sdkModule, "createAgentSession")
+			.mockResolvedValueOnce(createSessionResult(createReviewSession([])))
+			.mockResolvedValueOnce(
+				createSessionResult(
+					createReviewSession([], completion(), {
+						onDispose: secondDisposeEntered.resolve,
+						disposeRelease: releaseSecondDispose.promise,
+					}),
+				),
+			);
+
+		const first = runSubprocess({
+			...baseOptions("0-FirstOutput", root),
+			artifactsDir,
+			managedPersistence: createManagedTaskPersistence(manager, "0-FirstOutput"),
+		});
+		await firstPublishEntered.promise;
+		const second = runSubprocess({
+			...baseOptions("1-SecondOutput", root),
+			index: 1,
+			artifactsDir,
+			managedPersistence: createManagedTaskPersistence(manager, "1-SecondOutput"),
+		});
+		await secondDisposeEntered.promise;
+		releaseSecondDispose.resolve();
+		await drainMicrotasks();
+		const serializedBeforeRelease = publishCalls === 1;
+		releaseFirstPublish.resolve();
+		const [firstResult, secondResult] = await Promise.all([first, second]);
+
+		expect(serializedBeforeRelease).toBe(true);
+		expect([firstResult.exitCode, secondResult.exitCode]).toEqual([0, 0]);
+		expect(publishCalls).toBe(2);
+	});
+	it("orders review saves with managed output generation on one shared manager", async () => {
+		const root = await tempRoot();
+		const artifactsDir = path.join(root, "artifacts");
+		const manager = new ArtifactManager(new ManagedSessionDescendantStore(managedDirectoryRoot(root), artifactsDir));
+		const firstSaveEntered = Promise.withResolvers<void>();
+		const releaseFirstSave = Promise.withResolvers<void>();
+		const bDisposeEntered = Promise.withResolvers<void>();
+		const cDisposeEntered = Promise.withResolvers<void>();
+		const releaseBDispose = Promise.withResolvers<void>();
+		const releaseCDispose = Promise.withResolvers<void>();
+		const realSave = manager.save.bind(manager);
+		let saveCalls = 0;
+		vi.spyOn(manager, "save").mockImplementation(async (...args) => {
+			saveCalls += 1;
+			if (saveCalls === 1) {
+				firstSaveEntered.resolve();
+				await releaseFirstSave.promise;
+			}
+			return realSave(...args);
+		});
+		const outputSpy = vi.spyOn(manager, "publishManagedOutputGeneration");
+		vi.spyOn(sdkModule, "createAgentSession")
+			.mockResolvedValueOnce(createSessionResult(createReviewSession([finding(0)])))
+			.mockResolvedValueOnce(
+				createSessionResult(
+					createReviewSession([finding(0)], completion(), {
+						onDispose: bDisposeEntered.resolve,
+						disposeRelease: releaseBDispose.promise,
+					}),
+				),
+			)
+			.mockResolvedValueOnce(
+				createSessionResult(
+					createReviewSession([finding(0)], completion(), {
+						onDispose: cDisposeEntered.resolve,
+						disposeRelease: releaseCDispose.promise,
+					}),
+				),
+			);
+
+		const a = runSubprocess({
+			...baseOptions("0-A", root),
+			artifactsDir,
+			parentArtifactManager: manager,
+			managedPersistence: createManagedTaskPersistence(manager, "0-A"),
+		});
+		await firstSaveEntered.promise;
+		const b = runSubprocess({
+			...baseOptions("1-B", root),
+			index: 1,
+			artifactsDir,
+			parentArtifactManager: manager,
+			managedPersistence: createManagedTaskPersistence(manager, "1-B"),
+		});
+		const c = runSubprocess({
+			...baseOptions("2-C", root),
+			index: 2,
+			artifactsDir,
+			parentArtifactManager: manager,
+			managedPersistence: createManagedTaskPersistence(manager, "2-C"),
+		});
+		await Promise.all([bDisposeEntered.promise, cDisposeEntered.promise]);
+		releaseBDispose.resolve();
+		releaseCDispose.resolve();
+		await drainMicrotasks();
+		expect(outputSpy).not.toHaveBeenCalled();
+		expect(saveCalls).toBe(1);
+		releaseFirstSave.resolve();
+		const [aResult, bResult, cResult] = await Promise.all([a, b, c]);
+
+		expect([aResult.exitCode, bResult.exitCode, cResult.exitCode]).toEqual([0, 0, 0]);
+		expect(new Set([artifactId(aResult), artifactId(bResult), artifactId(cResult)]).size).toBe(3);
+		expect(JSON.parse(await readArtifact(manager, aResult))).toEqual(canonicalPayload("0-A", [finding(0)]));
+		expect(JSON.parse(await readArtifact(manager, bResult))).toEqual(canonicalPayload("1-B", [finding(0)]));
+		expect(JSON.parse(await readArtifact(manager, cResult))).toEqual(canonicalPayload("2-C", [finding(0)]));
+		const managedResults: Array<[string, SingleResult]> = [
+			["0-A", aResult],
+			["1-B", bResult],
+			["2-C", cResult],
+		];
+		for (const [taskId, result] of managedResults) {
+			const selected = await readManagedSelected(artifactsDir, taskId);
+			expect(selected.output).toBe(result.output);
+			const sha256 = result.outputMeta?.sha256;
+			if (!sha256) throw new Error(`Missing output hash for ${taskId}`);
+			expect(selected.metadata).toEqual({
+				id: taskId,
+				kind: "agent-output",
+				sizeBytes: Buffer.byteLength(result.output),
+				lineCount: result.output.split("\n").length,
+				sha256,
+				createdAt: expect.any(String),
+			});
+		}
+		expect(outputSpy).toHaveBeenCalledTimes(3);
+	});
+});

--- a/packages/coding-agent/test/task/executor-warnings.test.ts
+++ b/packages/coding-agent/test/task/executor-warnings.test.ts
@@ -55,6 +55,22 @@ describe("subagent warning injection", () => {
 		expect(result.rawOutput.includes("SYSTEM WARNING")).toBe(false);
 	});
 
+	it("recovers strict JTD fallback data without synthesizing findings", () => {
+		const result = finalizeSubprocessOutput({
+			rawOutput: '{"data":{"accepted":true}}',
+			exitCode: 0,
+			stderr: "",
+			doneAborted: false,
+			signalAborted: false,
+			yieldItems: undefined,
+			outputSchema: { properties: { accepted: { type: "boolean" } } },
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toBe("");
+		expect(JSON.parse(result.rawOutput)).toEqual({ accepted: true });
+	});
+
 	it("prefixes missing-submit warning on stop outputs", () => {
 		const result = finalizeSubprocessOutput({
 			rawOutput: "agent stopped after writing analysis",
@@ -118,6 +134,41 @@ describe("subagent warning injection", () => {
 		expect(result.exitCode).toBe(0);
 		expect(result.stderr).toBe("");
 		expect(result.rawOutput.includes("SYSTEM WARNING")).toBe(false);
+	});
+
+	it("validates strict reviewer output without synthesizing findings", () => {
+		const result = finalizeSubprocessOutput({
+			rawOutput: "ignored",
+			exitCode: 0,
+			stderr: "",
+			doneAborted: false,
+			signalAborted: false,
+			yieldItems: [
+				{
+					status: "success",
+					data: {
+						overall_correctness: "incorrect",
+						explanation: "Found one bug",
+						confidence: 0.9,
+					},
+				},
+			],
+			outputSchema: {
+				properties: {
+					overall_correctness: { enum: ["correct", "incorrect"] },
+					explanation: { type: "string" },
+					confidence: { type: "float64" },
+				},
+			},
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toBe("");
+		expect(JSON.parse(result.rawOutput)).toEqual({
+			overall_correctness: "incorrect",
+			explanation: "Found one bug",
+			confidence: 0.9,
+		});
 	});
 
 	it("rejects placeholder yield data that points at omitted message body", () => {
@@ -206,7 +257,7 @@ describe("subagent warning injection", () => {
 	});
 
 	describe("rejected payload persistence", () => {
-		function rejectedEnvelope(result: ReturnType<typeof finalizeSubprocessOutput>) {
+		function rejectedEnvelope(result: { rawOutput: string }) {
 			return JSON.parse(result.rawOutput) as { error: string; data: unknown };
 		}
 
@@ -250,7 +301,7 @@ describe("subagent warning injection", () => {
 			expect(result.rawOutput).toContain("REJECTED-PAYLOAD-TAIL-SENTINEL");
 		});
 
-		it("preserves long findings in explicit yields, fallback completions, and placeholder rejections", () => {
+		it("keeps rejected caller data complete without injecting wrapper findings into fallback output", () => {
 			const data = {
 				findings: Array.from({ length: 20 }, (_, index) => ({
 					title: `finding ${index}`,
@@ -284,7 +335,6 @@ describe("subagent warning injection", () => {
 				doneAborted: false,
 				signalAborted: false,
 				yieldItems: undefined,
-				reportFindings: data.findings,
 				outputSchema: { ...invalidSchema, additionalProperties: false },
 			});
 			const placeholder = finalizeSubprocessOutput({
@@ -297,13 +347,15 @@ describe("subagent warning injection", () => {
 				outputSchema: undefined,
 			});
 
-			for (const result of [explicit, fallback, placeholder]) {
+			for (const result of [explicit, placeholder]) {
 				expect(result.exitCode).toBe(1);
 				expect(result.rawOutput).toContain("LONG-FINDINGS-TAIL-SENTINEL");
 			}
 			expect(rejectedEnvelope(explicit).data).toEqual(data);
-			expect(rejectedEnvelope(fallback).data).toEqual({ accepted: true, findings: data.findings });
 			expect(rejectedEnvelope(placeholder).data).toEqual({ ...data, plan_markdown: placeholderPlanText });
+			expect(fallback.exitCode).toBe(0);
+			expect(JSON.parse(fallback.rawOutput)).toEqual({ accepted: true });
+			expect(fallback.rawOutput).not.toContain("LONG-FINDINGS-TAIL-SENTINEL");
 		});
 
 		it("preserves rejected data when the output schema itself is invalid", () => {

--- a/packages/coding-agent/test/task/receipt.test.ts
+++ b/packages/coding-agent/test/task/receipt.test.ts
@@ -150,6 +150,65 @@ describe("task result receipts", () => {
 		expect(findRawTaskLeakKeys(receipt)).toEqual([]);
 	});
 
+	it("exposes a canonical findings reference without leaking full findings", () => {
+		const receipt = buildTaskReceipt(
+			makeRaw({
+				reviewFindingsRef: {
+					uri: "artifact://7",
+					sizeBytes: 4096,
+					sha256: "a".repeat(64),
+					findingCount: 21,
+				},
+				extractedToolData: {
+					report_finding: Array.from({ length: 21 }, (_, index) => ({
+						priority: "P1",
+						title: `finding ${index}`,
+						body: `${"detail ".repeat(40)}${index === 20 ? "FULL-FINDING-TAIL-SENTINEL" : ""}`,
+						file_path: "/tmp/private/example.ts",
+					})),
+				},
+			}),
+		);
+
+		expect(receipt.review?.findingCount).toBe(21);
+		expect(receipt.review?.findings).toHaveLength(20);
+		expect(receipt.review?.findingsRef).toEqual({
+			uri: "artifact://7",
+			sizeBytes: 4096,
+			sha256: "a".repeat(64),
+			findingCount: 21,
+		});
+		expect(JSON.stringify(receipt)).not.toContain("FULL-FINDING-TAIL-SENTINEL");
+		expect(JSON.stringify(receipt)).not.toContain("/tmp/private");
+		expect(findRawTaskLeakKeys(receipt)).toEqual([]);
+	});
+
+	it("keeps review metadata visible when only the canonical reference remains", () => {
+		const receipt = buildTaskReceipt(
+			makeRaw({
+				reviewFindingsRef: {
+					uri: "artifact://8",
+					sizeBytes: 128,
+					sha256: "b".repeat(64),
+					findingCount: 2,
+				},
+			}),
+		);
+
+		expect(receipt.review).toEqual({
+			overallCorrectness: undefined,
+			findingCount: 2,
+			findings: undefined,
+			findingsRef: {
+				uri: "artifact://8",
+				sizeBytes: 128,
+				sha256: "b".repeat(64),
+				findingCount: 2,
+			},
+		});
+		expect(receipt.roi?.materialContribution).toBe(true);
+	});
+
 	it("buildTaskReceipt marks output unavailable when no artifact metadata is present", () => {
 		const receipt = buildTaskReceipt(makeRaw());
 		expect(receipt.outputRef).toBeUndefined();

--- a/packages/coding-agent/test/tools/review.test.ts
+++ b/packages/coding-agent/test/tools/review.test.ts
@@ -77,10 +77,7 @@ describe("toReviewFinding", () => {
 		expect(toReviewFinding({ ...base, priority: "P3" }).priority).toBe(3);
 	});
 
-	it("passes JTD validation against the reviewer agent's numeric priority schema (#1350)", () => {
-		// Mirrors the bundled reviewer agent's output schema. Before the fix the
-		// string priority from `report_finding` short-circuited every successful
-		// review run with `findings.0.priority: expected number, received string`.
+	it("supports explicitly caller-owned numeric findings in a declared reviewer schema", () => {
 		const reviewerSchema = {
 			properties: {
 				overall_correctness: { enum: ["correct", "incorrect"] },
@@ -117,10 +114,10 @@ describe("toReviewFinding", () => {
 						overall_correctness: "incorrect",
 						explanation: "Found one bug",
 						confidence: 0.9,
+						findings: [toReviewFinding({ ...base, priority: "P2" })],
 					},
 				},
 			],
-			reportFindings: [toReviewFinding({ ...base, priority: "P2" })],
 			outputSchema: reviewerSchema,
 		});
 


### PR DESCRIPTION
## Summary
- keep caller-owned strict JTD completion data unchanged by wrapper `report_finding` events
- publish full deduplicated review findings as bounded canonical internal artifact evidence and expose a leak-safe receipt reference
- fail closed on evidence publication errors and serialize review/output finalization per owning artifact manager
- add explicit-yield, fallback, failure, exact-byte-boundary, receipt, protocol-resolution, and concurrency regressions

## Verification
- `bun test packages/coding-agent/test/task/executor-review-findings.test.ts packages/coding-agent/test/task/executor-warnings.test.ts packages/coding-agent/test/task/receipt.test.ts packages/coding-agent/test/tools/review.test.ts` — 52 pass, 0 fail, 223 assertions
- `bun test packages/coding-agent/test/task packages/coding-agent/test/tools/review.test.ts` — 306 pass, 0 fail, 958 assertions
- `bun --cwd=packages/coding-agent run check` — pass
- `bun --cwd=packages/coding-agent run build` — pass; binary SHA-256 `152fe9d249a58f430d0eba7f65fb665c794a01122804b69b2c4d22b5cb772202`
- compiled JSON-mode TaskTool dogfood session `019face3-1558-7000-bc5f-9a50350bc99c` resolved strict caller output and separate canonical findings evidence
- Architect: CLEAR; red-team QA: CLEAR; terminal Critic: MERGE_READY

Closes #2893

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*