### PR TITLE
fix(coding-agent): rotate pooled credentials for single models

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 
 - Team Linux worker memory-guard replacement no longer holds the team task-mutation fence across the successor startup-ack wait, so concurrent `worker-startup-ack` can publish and selector-replacement no longer hangs under CI contention.
+- Single-model sessions now rotate immediately to another stored provider credential after a replay-safe quota or rate-limit failure, without requiring a synthetic model fallback chain.
 - Reviewer `report_finding` evidence is no longer injected into caller-owned strict JTD completion data; full findings are published separately through a bounded artifact reference, and failed evidence publication now fails the task closed (#2893).
 
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8270,6 +8270,7 @@ export class AgentSession {
 				await this.#agentEndPublicationPromise;
 			} else {
 				await this.#agentEndHandlingPromise;
+				await this.#waitForPostPromptRecovery();
 				await this.#agentEndPublicationPromise;
 			}
 		}
@@ -14268,25 +14269,25 @@ export class AgentSession {
 		return `Model fallback chain exhausted; models tried: ${tried}; models skipped: ${skipped}`;
 	}
 
-	async #markFailedManagedCredential(trigger: {
-		class: FallbackTriggerClass;
-		retryAfterMs?: number;
-	}): Promise<boolean> {
+	async #markFailedCredential(trigger: { class: FallbackTriggerClass; retryAfterMs?: number }): Promise<boolean> {
 		if (!this.model || (trigger.class !== "auth" && trigger.class !== "quota" && trigger.class !== "rate_limit")) {
 			return false;
 		}
 		const authStorage = this.#modelRegistry.authStorage;
+		const providerAffinitySessionId = this.agent.providerSessionId ?? this.agent.sessionId ?? this.sessionId;
 		if (trigger.class === "auth") {
-			const apiKey = await this.#modelRegistry.getApiKey(this.model, this.sessionId);
+			const apiKey = await this.#modelRegistry.getApiKey(this.model, providerAffinitySessionId);
 			if (!isAuthenticated(apiKey)) return false;
-			return authStorage.invalidateCredentialMatching(this.model.provider, apiKey, { sessionId: this.sessionId });
+			return authStorage.invalidateCredentialMatching(this.model.provider, apiKey, {
+				sessionId: providerAffinitySessionId,
+			});
 		}
 		if (authStorage.hasRuntimeApiKey(this.model.provider)) return false;
-		const activeApiKey = await this.#modelRegistry.getApiKey(this.model, this.sessionId);
-		const rotated = await authStorage.markUsageLimitReached(this.model.provider, this.sessionId, {
+		const activeApiKey = await this.#modelRegistry.getApiKey(this.model, providerAffinitySessionId);
+		const rotated = await authStorage.markUsageLimitReached(this.model.provider, providerAffinitySessionId, {
 			retryAfterMs: trigger.retryAfterMs,
 		});
-		return rotated && (await this.#modelRegistry.getApiKey(this.model, this.sessionId)) !== activeApiKey;
+		return rotated && (await this.#modelRegistry.getApiKey(this.model, providerAffinitySessionId)) !== activeApiKey;
 	}
 
 	/** Handle retryable errors with exponential backoff. */
@@ -14318,8 +14319,21 @@ export class AgentSession {
 		) {
 			return false;
 		}
-		// Bare defaults admit only clean, side-effect-free canonical stream watchdog failures.
-		if (!managedFallback && !legacyRetryConfigured) {
+		const trigger = this.#fallbackTriggerFor(message, !managedFallback, transportFailure);
+		if (!trigger) {
+			return managedOutcome
+				? this.#managedFallbackExhaustionDecision(message, message.errorMessage || "Model fallback attempt failed")
+				: false;
+		}
+		let credentialRotated =
+			!managedFallback &&
+			!assistantMessageHasVisibleOrToolContent(message) &&
+			(trigger.class === "quota" || trigger.class === "rate_limit") &&
+			(await this.#markFailedCredential(trigger));
+		const canReplayRotatedCredential = credentialRotated && this.#hasCleanRetryReplaySafety;
+		// Bare defaults admit only clean, side-effect-free canonical stream watchdog failures
+		// or quota/rate-limit failures that can immediately switch to another stored credential.
+		if (!managedFallback && !legacyRetryConfigured && !canReplayRotatedCredential) {
 			if (
 				(!this.#isTypedFirstEventTimeout(message) &&
 					(hasBareDefaultRetryDisqualifyingFacts(message) ||
@@ -14330,12 +14344,6 @@ export class AgentSession {
 				return false;
 			}
 		}
-		const trigger = this.#fallbackTriggerFor(message, !managedFallback, transportFailure);
-		if (!trigger) {
-			return managedOutcome
-				? this.#managedFallbackExhaustionDecision(message, message.errorMessage || "Model fallback attempt failed")
-				: false;
-		}
 		const legacyUnbounded = classification === "transient";
 		const attemptsUsed = managedFallback ? controller.attemptsUsed || 1 : this.#retryAttempt + 1;
 		const failedSelector = managedFallback ? controller.currentSelector() : undefined;
@@ -14344,12 +14352,10 @@ export class AgentSession {
 			: legacyUnbounded || attemptsUsed <= retrySettings.maxRetries
 				? "retry"
 				: "exhausted";
-		const credentialRotated =
-			managedFallback &&
-			outcome === "advance" &&
-			(trigger.class === "quota" || trigger.class === "rate_limit") &&
-			(await this.#markFailedManagedCredential(trigger));
-		if (credentialRotated && controller.restorePreviousEntryForRetry()) {
+		if (managedFallback && outcome === "advance" && (trigger.class === "quota" || trigger.class === "rate_limit")) {
+			credentialRotated = await this.#markFailedCredential(trigger);
+		}
+		if (managedFallback && credentialRotated && controller.restorePreviousEntryForRetry()) {
 			outcome = "retry";
 		}
 		if (outcome === "exhausted") {
@@ -14385,7 +14391,7 @@ export class AgentSession {
 		}
 
 		const retry = async (ownership?: ManagedAttemptContinuationOwnership): Promise<void> => {
-			if (managedFallback && !credentialRotated) await this.#markFailedManagedCredential(trigger);
+			if (managedFallback && !credentialRotated) await this.#markFailedCredential(trigger);
 			let advanced = outcome !== "advance";
 			let resolutionError: unknown;
 			if (outcome === "advance") {

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
 import { Agent } from "@gajae-code/agent-core";
-import { type AssistantMessage, getBundledModel } from "@gajae-code/ai";
+import { type AssistantMessage, getBundledModel, type Model } from "@gajae-code/ai";
 import { createMockModel } from "@gajae-code/ai/providers/mock";
 import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
@@ -42,6 +42,43 @@ function getLastAssistantMessage(session: AgentSession): AssistantMessage {
 		throw new Error("Expected final assistant message");
 	}
 	return lastMessage;
+}
+
+function typedRateLimitStream(
+	model: Model,
+	retryAfterMs: number,
+	errorMessage = "Provider returned error: rate_limit_error: organization quota reached",
+): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+	queueMicrotask(() => {
+		const message: AssistantMessage = {
+			role: "assistant",
+			content: [],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "error",
+			errorMessage,
+			errorStatus: 429,
+			transportFailure: {
+				kind: "transport",
+				status: 429,
+				headers: { "retry-after-ms": String(retryAfterMs) },
+			},
+			timestamp: Date.now(),
+		};
+		stream.push({ type: "start", partial: message });
+		stream.push({ type: "error", reason: "error", error: message });
+	});
+	return stream;
 }
 
 describe("AgentSession retry fallback", () => {
@@ -445,6 +482,63 @@ describe("AgentSession retry fallback", () => {
 		expect(retryStartEvents).toHaveLength(1);
 		expect(retryEndEvents).toHaveLength(1);
 		expect(retryEndEvents[0]).toMatchObject({ success: true, attempt: 1 });
+	});
+
+	it("rotates a single-model stored credential after a typed quota failure before prompt completion", async () => {
+		const model = getBundledModel("openai", "gpt-4o-mini");
+		if (!model) throw new Error("Expected bundled test model");
+		authStorage.removeRuntimeApiKey("openai");
+		await authStorage.set("openai", [
+			{ type: "api_key", key: "account-a-key" },
+			{ type: "api_key", key: "account-b-key" },
+		]);
+
+		const logicalSessionId = "logical-session";
+		const providerAffinitySessionId = "pool-session";
+		const requestedKeys: string[] = [];
+		let calls = 0;
+		const agent = new Agent({
+			getApiKey: async provider => {
+				const key = await modelRegistry.getApiKeyForProvider(provider, providerAffinitySessionId);
+				if (key) requestedKeys.push(key);
+				return key;
+			},
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (requestedModel, context, options) => {
+				calls++;
+				if (calls === 1) return typedRateLimitStream(requestedModel, 60_000);
+				return createMockModel({ responses: [{ content: ["Recovered with another account"] }] }).stream(
+					requestedModel,
+					context,
+					options,
+				);
+			},
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+			providerSessionId: logicalSessionId,
+			providerCacheSessionId: providerAffinitySessionId,
+		});
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents, retryEndEvents } = trackRetryEvents(session);
+
+		await session.prompt("retry with another stored credential");
+
+		expect(calls).toBe(2);
+		expect(requestedKeys).toHaveLength(2);
+		expect(new Set(requestedKeys).size).toBe(2);
+		expect(session.isRetrying).toBe(false);
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryStartEvents[0]).toMatchObject({ delayMs: 0 });
+		expect(waitSpy).toHaveBeenCalledWith(0, { signal: expect.any(AbortSignal) });
+		expect(retryEndEvents).toHaveLength(1);
+		expect(retryEndEvents[0]).toMatchObject({ success: true, attempt: 1 });
+		expect(getLastAssistantMessage(session)).toMatchObject({ stopReason: "stop" });
 	});
 
 	it("does not replay a Kimi Code first-event timeout through a managed fallback chain", async () => {


### PR DESCRIPTION
## What

- Rotate a single-model session to another stored provider credential after a replay-safe quota or rate-limit failure.
- Key rotation to the provider-affinity session identity so the credential that actually failed is blocked.
- Recheck post-prompt recovery after asynchronous `agent_end` handling so print/no-session callers wait for the rotated retry to settle.
- Keep single-model requests on the existing unmanaged provider path, preserving provider-internal repairs and Cursor execution behavior.

## Why

Stored multi-account pools only rotated through managed model fallback, so a one-entry model selection could repeatedly reuse a quota-exhausted account unless users added a synthetic second model. The fix uses the existing legacy retry path and `AuthStorage.markUsageLimitReached()` instead of broadening managed fallback semantics.

## Testing

- `bun test packages/coding-agent/test/auth-storage-rotation.test.ts packages/coding-agent/test/agent-session-retry-fallback.test.ts packages/coding-agent/test/agent-session-fallback-attempt-accounting.test.ts packages/coding-agent/test/agent-session-fallback-attempt-transaction.test.ts packages/coding-agent/test/routing-adversarial.test.ts` — 53 passed
- `bun --cwd=packages/coding-agent run check` — passed
- Live source checkout, `anthropic/claude-fable-5`, two stored OAuth accounts, single-model `--no-session` invocation: account A returned 429 `org_spend_cap_reached`; `auto_retry_start` reported `delayMs: 0`; account B returned `OK`; `auto_retry_end` reported success.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:a515e8d14a92a23731736ca10c4a7ea01c733d58 reviewer:critic evidence:git-show-head-vs-origin-dev
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit