### PR TITLE
fix(coding-agent): tolerate minimal Bash settings adapters

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Team Linux worker memory-guard replacement no longer holds the team task-mutation fence across the successor startup-ack wait, so concurrent `worker-startup-ack` can publish and selector-replacement no longer hangs under CI contention.
 - Reviewer `report_finding` evidence is no longer injected into caller-owned strict JTD completion data; full findings are published separately through a bounded artifact reference, and failed evidence publication now fails the task closed (#2893).
+- Bash output-tail initialization now tolerates constrained `ToolSession` settings adapters that expose `get()` without `has()`, preserving the 1 KiB default and explicit head/tail overrides instead of crashing restricted and interceptor Bash execution.
 
 ### Added
 

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -818,7 +818,12 @@ export const BASH_DEFAULT_OUTPUT_TAIL_BYTES = 1024;
  * budget still wins.
  */
 export function resolveBashOutputSinkTailBytes(s: Settings): number {
-	return s.has("tools.artifactTailBytes") ? s.get("tools.artifactTailBytes") * 1024 : BASH_DEFAULT_OUTPUT_TAIL_BYTES;
+	const configuredTailBytes = s.get("tools.artifactTailBytes");
+	const hasExplicitTailBytes =
+		typeof s.has === "function" ? s.has("tools.artifactTailBytes") : configuredTailBytes !== undefined;
+	return hasExplicitTailBytes && configuredTailBytes !== undefined
+		? configuredTailBytes * 1024
+		: BASH_DEFAULT_OUTPUT_TAIL_BYTES;
 }
 /**
  * Bash keeps only the tail unless the user explicitly opts into the shared
@@ -826,7 +831,10 @@ export function resolveBashOutputSinkTailBytes(s: Settings): number {
  * tools without silently turning Bash back into middle-elision mode.
  */
 export function resolveBashOutputSinkHeadBytes(s: Settings): number {
-	return s.has("tools.artifactHeadBytes") ? resolveOutputSinkHeadBytes(s) : 0;
+	const configuredHeadBytes = s.get("tools.artifactHeadBytes");
+	const hasExplicitHeadBytes =
+		typeof s.has === "function" ? s.has("tools.artifactHeadBytes") : configuredHeadBytes !== undefined;
+	return hasExplicitHeadBytes && configuredHeadBytes !== undefined ? configuredHeadBytes * 1024 : 0;
 }
 
 /**


### PR DESCRIPTION
## Disposition

Repairs the exact six BashTool failures blocking current `dev` after #3476.

Root cause: `resolveBashOutputSinkTailBytes()` and `resolveBashOutputSinkHeadBytes()` assumed every `ToolSession.settings` adapter implements `Settings.has()`. Interceptor and restricted-role sessions intentionally use minimal adapters with `get()` only, so Bash setup threw before command execution.

The resolver now preserves production `Settings.has()` semantics while falling back to the adapter's `get()` result when `has()` is unavailable. The 1 KiB default, explicit tail override, and explicit head opt-in remain unchanged.

## Exact evidence

- Dev run `30442101902`, merge `3be1bc86d3b5adc6dc98b8712a230c57250a20df`, shard 3 job `90547348071`: 1624 pass / 30 skip / 6 fail, all `TypeError: s.has is not a function`.
- Current dev `2ce4678abec0a8aec629ed0bf71fbcaf127a66a0`, shard 3 job `90551005723`: same six failures and same root cause.
- `bun test packages/coding-agent/test/tools/bash-interceptor.test.ts`: 14 pass / 0 fail.
- `bun test packages/coding-agent/test/tools.test.ts`: 105 pass / 0 fail.
- Affected dry-run job `90551005759` is separately attributable to a Node 24 node-pty header download timeout, not this product path.

Commit `41d1fc4ca` is the independent rollback boundary for this red-dev repair. The broader pi-shell callback-loss investigation is preserved on a separate follow-up branch and is not included here.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*