### PR TITLE
fix(ci): require exact PR base ancestry for exact-head gates

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -65,6 +65,16 @@ jobs:
         run: |
           head="$(git rev-parse HEAD)"
           test "$head" = "$CI_DEV_SOURCE_SHA" || { echo "Checked-out SHA $head does not match $CI_DEV_SOURCE_SHA"; exit 1; }
+      - name: Verify PR head contains exact base
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "${GITHUB_BASE_SHA}"
+          git merge-base --is-ancestor "${GITHUB_BASE_SHA}" HEAD || {
+            echo "::error::Exact-head CI requires this PR head to contain base ${GITHUB_BASE_SHA}; rebase onto current ${GITHUB_BASE_REF}."
+            exit 1
+          }
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: "1.3.14"

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -70,11 +70,21 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git fetch --no-tags origin "${GITHUB_BASE_SHA}"
-          git merge-base --is-ancestor "${GITHUB_BASE_SHA}" HEAD || {
-            echo "::error::Exact-head CI requires this PR head to contain base ${GITHUB_BASE_SHA}; rebase onto current ${GITHUB_BASE_REF}."
+          if ! git fetch --no-tags origin "${GITHUB_BASE_SHA}"; then
+            echo "::error::Could not fetch immutable event base ${GITHUB_BASE_SHA} from ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}; rerun the PR event or rebase onto current ${GITHUB_BASE_REF}."
             exit 1
-          }
+          fi
+          if git merge-base --is-ancestor "${GITHUB_BASE_SHA}" HEAD; then
+            :
+          else
+            status=$?
+            if [ "$status" -eq 1 ]; then
+              echo "::error::Exact-head CI requires this PR head to contain base ${GITHUB_BASE_SHA}; rebase onto current ${GITHUB_BASE_REF}."
+            else
+              echo "::error::Could not compare exact PR head ${CI_DEV_SOURCE_SHA} with immutable event base ${GITHUB_BASE_SHA} (merge-base exit ${status})."
+            fi
+            exit 1
+          fi
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: "1.3.14"

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -64,8 +64,10 @@ describe("dev-ci canonical-plan workflow contract", () => {
 		const guard = workflow.slice(guardStart, guardEnd);
 		expect(guardStart).toBeGreaterThan(0);
 		expect(guard).toContain("if: ${{ github.event_name == 'pull_request' }}");
-		expect(guard).toContain('git fetch --no-tags origin "${GITHUB_BASE_SHA}"');
-		expect(guard).toContain('git merge-base --is-ancestor "${GITHUB_BASE_SHA}" HEAD');
+		expect(guard).toContain('if ! git fetch --no-tags origin "${GITHUB_BASE_SHA}"; then');
+		expect(guard).toContain("Could not fetch immutable event base ${GITHUB_BASE_SHA}");
+		expect(guard).toContain('if git merge-base --is-ancestor "${GITHUB_BASE_SHA}" HEAD; then');
+		expect(guard).toContain("merge-base exit ${status}");
 		expect(guard).toContain("rebase onto current ${GITHUB_BASE_REF}");
 	});
 
@@ -1062,7 +1064,6 @@ test("tab-worker graph changes always include install-methods and are Darwin rel
 
 	test("routes the Windows session-path regression for session I/O sources and its regression test", () => {
 		for (const changedPath of [
-			".github/workflows/dev-ci.yml",
 			"packages/coding-agent/src/session/internal/managed-session-scope.ts",
 			"packages/coding-agent/src/session/internal/managed-session-storage.ts",
 			"packages/coding-agent/src/session/blob-store.ts",

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -57,6 +57,18 @@ describe("dev-ci canonical-plan workflow contract", () => {
 		expect(hash(noShardReceipt)).toBe("7f3cb1ebf7ca106b8030dd79353dabbc57ed22137ac41e169cc5700d29493091");
 		expect(hash(multiShardReceipt)).toBe("2c298faf1d92681cef1499a7526d1df0e8aee947694804d50aa47e015b222e26");
 	});
+	test("requires a pull request exact head to contain the event base before planning", async () => {
+		const workflow = await Bun.file(path.join(import.meta.dir, "..", ".github", "workflows", "dev-ci.yml")).text();
+		const guardStart = workflow.indexOf("      - name: Verify PR head contains exact base");
+		const guardEnd = workflow.indexOf("\n      - ", guardStart + 1);
+		const guard = workflow.slice(guardStart, guardEnd);
+		expect(guardStart).toBeGreaterThan(0);
+		expect(guard).toContain("if: ${{ github.event_name == 'pull_request' }}");
+		expect(guard).toContain('git fetch --no-tags origin "${GITHUB_BASE_SHA}"');
+		expect(guard).toContain('git merge-base --is-ancestor "${GITHUB_BASE_SHA}" HEAD');
+		expect(guard).toContain("rebase onto current ${GITHUB_BASE_REF}");
+	});
+
 	test("uses a detached finalized evidence producer and artifact-ID consumer", async () => {
 		const workflow = await Bun.file(path.join(import.meta.dir, "..", ".github", "workflows", "dev-ci.yml")).text();
 		expect(workflow).toContain("affected-evidence-producer:");
@@ -1050,6 +1062,7 @@ test("tab-worker graph changes always include install-methods and are Darwin rel
 
 	test("routes the Windows session-path regression for session I/O sources and its regression test", () => {
 		for (const changedPath of [
+			".github/workflows/dev-ci.yml",
 			"packages/coding-agent/src/session/internal/managed-session-scope.ts",
 			"packages/coding-agent/src/session/internal/managed-session-storage.ts",
 			"packages/coding-agent/src/session/blob-store.ts",

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -416,8 +416,7 @@ export function needsDarwinArm64TabWorkerSmoke(paths: readonly string[]): boolea
 // Linux shard cannot verify the ENOENT fix; dev-ci consumes this emitted flag to
 // run and require the windows-latest job whenever any of these change.
 export function isWindowsSessionPathRegressionPath(changedPath: string): boolean {
-	return changedPath === ".github/workflows/dev-ci.yml" ||
-		changedPath === "packages/coding-agent/src/session/internal/managed-session-scope.ts" ||
+	return changedPath === "packages/coding-agent/src/session/internal/managed-session-scope.ts" ||
 		changedPath === "packages/coding-agent/src/session/internal/managed-session-storage.ts" ||
 		changedPath === "packages/coding-agent/src/session/blob-store.ts" ||
 		changedPath === "packages/coding-agent/src/sdk/session-directory.ts" ||

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -416,7 +416,8 @@ export function needsDarwinArm64TabWorkerSmoke(paths: readonly string[]): boolea
 // Linux shard cannot verify the ENOENT fix; dev-ci consumes this emitted flag to
 // run and require the windows-latest job whenever any of these change.
 export function isWindowsSessionPathRegressionPath(changedPath: string): boolean {
-	return changedPath === "packages/coding-agent/src/session/internal/managed-session-scope.ts" ||
+	return changedPath === ".github/workflows/dev-ci.yml" ||
+		changedPath === "packages/coding-agent/src/session/internal/managed-session-scope.ts" ||
 		changedPath === "packages/coding-agent/src/session/internal/managed-session-storage.ts" ||
 		changedPath === "packages/coding-agent/src/session/blob-store.ts" ||
 		changedPath === "packages/coding-agent/src/sdk/session-directory.ts" ||


### PR DESCRIPTION
## Summary

- fail the affected-plan job before matrix planning when a pull-request source head does not contain the immutable event base commit
- distinguish unavailable event-base fetches, stale ancestry, and merge-base operational failures with actionable annotations
- leave push/workflow-dispatch behavior and unrelated Windows session-path routing unchanged

## Evidence

PRs #3464/#3466/#3468 target current `dev` but their exact source heads do not contain merged #3462. Dev CI intentionally checks out the source head, so their Windows jobs executed the superseded issue-3383 test contract even though the synthetic merge would contain the repaired test. Locally, `git merge-base --is-ancestor 2ce4678a <#3464 head>` rejects the stale head while this branch passes.

Focused verification:
- `bun test scripts/ci-dev-affected.test.ts -t 'requires a pull request exact head|routes the Windows session-path regression'`
- `bun test scripts/dev-ci-guard-topology.test.ts scripts/check-workflow-permissions.test.ts`
- `bun scripts/check-workflow-yaml.ts .github/workflows/dev-ci.yml`
- `bun run check:tools`

This is an issue-3383 CI follow-up. It does not change managed-session product behavior. After merge, the stacked contributor PRs still require sequential rebases onto current `dev` before exact-head review/CI.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*