### PR TITLE
test(bash): complete Settings fixtures after default-tail merge

### DIFF
--- a/packages/coding-agent/test/tools/bash-interceptor.test.ts
+++ b/packages/coding-agent/test/tools/bash-interceptor.test.ts
@@ -19,6 +19,9 @@ afterEach(async () => {
 function createBashTool(rules: BashInterceptorRule[]): BashTool {
 	const session = {
 		settings: {
+			has(key: string) {
+				return this.get(key) !== undefined;
+			},
 			get(key: string) {
 				if (key === "bashInterceptor.enabled") return true;
 				if (key === "async.enabled") return false;
@@ -92,6 +95,9 @@ describe("BashTool head/tail stripping", () => {
 			getSessionFile: () => null,
 			getSessionId: () => undefined,
 			settings: {
+				has(key: string) {
+					return this.get(key) !== undefined;
+				},
 				get(key: string) {
 					if (key === "bashInterceptor.enabled") return false;
 					if (key === "async.enabled") return false;
@@ -144,6 +150,9 @@ describe("BashTool restricted role-agent allowlist", () => {
 			bashAllowedPrefixes,
 			bashRestrictionProfile,
 			settings: {
+				has(key: string) {
+					return this.get(key) !== undefined;
+				},
 				get(key: string) {
 					if (key === "bashInterceptor.enabled") return false;
 					if (key === "async.enabled") return false;


### PR DESCRIPTION
## Summary

- add the `Settings.has()` contract to the three BashTool session fixtures in `bash-interceptor.test.ts`
- derive `has()` from each fixture's existing `get()` behavior so false-valued explicit settings remain present while `tools.artifactTailBytes` stays absent

## Evidence

Merged #3476 made `resolveBashOutputSinkTailBytes()` correctly distinguish explicit shared tail configuration through `Settings.has()`, but these duck-typed test sessions implemented only `get()`. Current-dev full shards fail six BashTool tests before exercising their actual assertions with `TypeError: s.has is not a function`.

Verification:
- `bun test packages/coding-agent/test/tools/bash-interceptor.test.ts` — 14 pass
- bash tail regression cluster (`bash-executor`, `bash-interactive-tail`, `output-meta-truncation`, `bash-interceptor`) — 56 pass
- coding-agent `bun run check` — green

No production behavior changes.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*