### PR TITLE
Harden Windows managed-session storage and diagnostics

### DIFF
--- a/crates/pi-natives/src/path_identity.rs
+++ b/crates/pi-natives/src/path_identity.rs
@@ -161,6 +161,8 @@ struct ExactFileIdentity {
 pub struct NativeExactUnlinkResult {
 	pub ok: bool,
 	pub code: Option<String>,
+	/// On Windows this is returned in the caller's namespace; retained handle
+	/// operations continue to use the volume-GUID canonical path internally.
 	pub detached_path: Option<String>,
 	pub retained_successor_path: Option<String>,
 	/// An internal exchange-placeholder cleanup entry retained after cleanup
@@ -201,6 +203,60 @@ pub struct NativeNoReplaceResult {
 	pub primitive:        String,
 	pub phase:            String,
 	pub diagnostic:       NativePublishDiagnostic,
+}
+/// Result of a Windows write-through replacement.
+#[napi(object)]
+pub struct NativeDurableReplaceResult {
+	pub ok:               bool,
+	pub code:             Option<String>,
+	pub os_code:          Option<i32>,
+	pub mutation_state:   String,
+	pub durability_state: String,
+	pub reason:           String,
+	pub primitive:        String,
+	pub phase:            String,
+}
+
+impl NativeDurableReplaceResult {
+	#[cfg(not(windows))]
+	fn unsupported() -> Self {
+		Self {
+			ok:               false,
+			code:             Some("unsupported_platform".to_owned()),
+			os_code:          None,
+			mutation_state:   "not_committed".to_owned(),
+			durability_state: "not_attempted".to_owned(),
+			reason:           "unsupported_platform".to_owned(),
+			primitive:        "unsupported".to_owned(),
+			phase:            "preflight".to_owned(),
+		}
+	}
+
+	fn failure(code: &str, os_code: Option<i32>, mutation_state: &str, phase: &str) -> Self {
+		Self {
+			ok: false,
+			code: Some(code.to_owned()),
+			os_code,
+			mutation_state: mutation_state.to_owned(),
+			durability_state: "not_attempted".to_owned(),
+			reason: code.to_owned(),
+			primitive: "move_file_ex_write_through".to_owned(),
+			phase: phase.to_owned(),
+		}
+	}
+
+	fn success() -> Self {
+		Self {
+			ok:               true,
+			code:             None,
+			os_code:          None,
+			mutation_state:   "committed".to_owned(),
+			durability_state: "durable".to_owned(),
+			reason:           "none".to_owned(),
+			primitive:        "move_file_ex_write_through".to_owned(),
+			phase:            "complete".to_owned(),
+		}
+	}
 }
 
 impl NativeNoReplaceResult {
@@ -793,6 +849,31 @@ pub fn rename_no_replace_path(
 		Path::new(&source_path),
 		Path::new(&destination_path),
 	))
+}
+/// Replace a staged file using Windows `MoveFileExW` with `REPLACE_EXISTING`
+/// and `WRITE_THROUGH`. The staged file's bytes must already have been flushed.
+#[napi]
+pub fn durable_replace_path(
+	source_path: String,
+	destination_path: String,
+) -> NativeDurableReplaceResult {
+	if source_path.contains('\0') || destination_path.contains('\0') {
+		return NativeDurableReplaceResult::failure(
+			"invalid_request",
+			None,
+			"not_committed",
+			"preflight",
+		);
+	}
+	#[cfg(windows)]
+	{
+		platform::durable_replace_path(Path::new(&source_path), Path::new(&destination_path))
+	}
+	#[cfg(not(windows))]
+	{
+		let _ = (source_path, destination_path);
+		NativeDurableReplaceResult::unsupported()
+	}
 }
 
 /// Capture a deterministic, descriptor-relative snapshot of a regular-file and
@@ -3747,9 +3828,34 @@ mod platform {
 
 	use super::{
 		ExactFileIdentity, NativeCanonicalDirectoryIdentity, NativeDirectoryTreeEntry,
-		NativeDirectoryTreeResult, NativeDirectoryTreeSnapshot, NativeExactUnlinkResult,
-		NativeOwnerOnlySecurityResult, sha256,
+		NativeDirectoryTreeResult, NativeDirectoryTreeSnapshot, NativeDurableReplaceResult,
+		NativeExactUnlinkResult, NativeOwnerOnlySecurityResult, sha256,
 	};
+
+	type InvalidParameterHandler = Option<
+		unsafe extern "C" fn(
+			expression: *const u16,
+			function: *const u16,
+			file: *const u16,
+			line: u32,
+			reserved: usize,
+		),
+	>;
+	type UvGetOsfhandle = unsafe extern "C" fn(fd: i32) -> isize;
+
+	#[link(name = "kernel32")]
+	unsafe extern "system" {
+		fn GetModuleHandleW(module_name: *const u16) -> *mut c_void;
+		fn GetProcAddress(module: *mut c_void, procedure_name: *const u8) -> *mut c_void;
+	}
+
+	#[link(name = "msvcrt")]
+	unsafe extern "C" {
+		fn _get_osfhandle(fd: i32) -> isize;
+		fn _set_thread_local_invalid_parameter_handler(
+			handler: InvalidParameterHandler,
+		) -> InvalidParameterHandler;
+	}
 
 	const SECURITY_OWNER_DACL: u32 = OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION;
 	const SECURITY_OWNER_DACL_PROTECTED: u32 =
@@ -4319,20 +4425,13 @@ mod platform {
 		parent_handle: HANDLE,
 		source_name: &std::ffi::OsStr,
 		quarantine_name: &str,
+		detached_path: String,
 		identity: &ExactFileIdentity,
 	) -> NativeExactUnlinkResult {
-		let detached_parent = match final_path(parent_handle) {
-			Ok(path) => path,
-			Err(code) => return NativeExactUnlinkResult::failure(code),
-		};
 		let name_wide: Vec<u16> = quarantine_name.encode_utf16().collect();
 		let original_name_wide: Vec<u16> = source_name.encode_wide().collect();
 		let result = match rename_handle_no_replace(handle, parent_handle, &name_wide) {
 			Ok(()) => {
-				let detached_path = Path::new(&detached_parent)
-					.join(quarantine_name)
-					.to_string_lossy()
-					.into_owned();
 				let mut information: BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
 				let matches = unsafe { GetFileInformationByHandle(handle, &mut information) } != 0
 					&& handle_identity_matches(&information, identity)
@@ -4397,6 +4496,57 @@ mod platform {
 			Ok(normalized)
 		} else {
 			Err("io_error")
+		}
+	}
+	pub(super) fn durable_replace_path(
+		source_path: &Path,
+		destination_path: &Path,
+	) -> NativeDurableReplaceResult {
+		let source_path = match lexical_absolute_path(source_path) {
+			Ok(path) => path,
+			Err(code) => {
+				return NativeDurableReplaceResult::failure(code, None, "not_committed", "preflight");
+			},
+		};
+		let destination_path = match lexical_absolute_path(destination_path) {
+			Ok(path) => path,
+			Err(code) => {
+				return NativeDurableReplaceResult::failure(code, None, "not_committed", "preflight");
+			},
+		};
+		let mut source_wide: Vec<u16> = source_path.as_os_str().encode_wide().collect();
+		let mut destination_wide: Vec<u16> = destination_path.as_os_str().encode_wide().collect();
+		source_wide.push(0);
+		destination_wide.push(0);
+		const MOVEFILE_REPLACE_EXISTING: u32 = 0x1;
+		const MOVEFILE_WRITE_THROUGH: u32 = 0x8;
+		let moved = unsafe {
+			windows_sys::Win32::Storage::FileSystem::MoveFileExW(
+				source_wide.as_ptr(),
+				destination_wide.as_ptr(),
+				MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+			)
+		};
+		if moved == 0 {
+			return NativeDurableReplaceResult::failure(
+				"move_file_ex_failed",
+				Some(unsafe { GetLastError() } as i32),
+				"not_committed",
+				"replace",
+			);
+		}
+		match std::fs::symlink_metadata(&destination_path) {
+			Ok(metadata) if metadata.is_file() => NativeDurableReplaceResult::success(),
+			_ => NativeDurableReplaceResult {
+				ok: false,
+				code: Some("destination_verification_failed".to_owned()),
+				os_code: None,
+				mutation_state: "unknown".to_owned(),
+				durability_state: "not_provable".to_owned(),
+				reason: "destination_verification_failed".to_owned(),
+				primitive: "move_file_ex_write_through".to_owned(),
+				phase: "verify".to_owned(),
+			},
 		}
 	}
 
@@ -4502,11 +4652,16 @@ mod platform {
 			let Some(original_name) = path.file_name() else {
 				return NativeExactUnlinkResult::failure("io_error");
 			};
+			let Some(parent_path) = path.parent() else {
+				return NativeExactUnlinkResult::failure("io_error");
+			};
+			let detached_path = parent_path.join(quarantine_name).to_string_lossy().into_owned();
 			return detach_directory(
 				handle.target,
 				parent_handle,
 				original_name,
 				quarantine_name,
+				detached_path,
 				identity,
 			);
 		}
@@ -4583,6 +4738,7 @@ mod platform {
 			original_parent.target,
 			source_name,
 			quarantine_name,
+			original_path.to_string_lossy().into_owned(),
 			identity,
 		);
 		match result {
@@ -5032,7 +5188,7 @@ mod platform {
 		expected_dev: u64,
 		expected_ino: u64,
 	) -> NativeOwnerOnlySecurityResult {
-		let handle = match open_exact(path, kind, WRITE_DAC | READ_CONTROL) {
+		let handle = match open_exact(path, kind, WRITE_OWNER | WRITE_DAC | READ_CONTROL) {
 			Ok(handle) => handle,
 			Err(result) => return result,
 		};
@@ -5050,9 +5206,7 @@ mod platform {
 		};
 		match inspect_owner_only_acl(handle.target, kind, &sid) {
 			Ok(OwnerOnlyAclState::Clean) => return NativeOwnerOnlySecurityResult::success(),
-			Ok(OwnerOnlyAclState::OwnerMismatch) => {
-				return NativeOwnerOnlySecurityResult::failure("owner_mismatch");
-			},
+			Ok(OwnerOnlyAclState::OwnerMismatch) => {},
 			Ok(OwnerOnlyAclState::UnsafeMismatch) => {
 				return NativeOwnerOnlySecurityResult::failure("acl_verify_failed");
 			},
@@ -5063,14 +5217,15 @@ mod platform {
 			Ok(dacl) => dacl,
 			Err(()) => return NativeOwnerOnlySecurityResult::failure("acl_apply_failed"),
 		};
-		// SAFETY: the retained handle identifies the prechecked object; `dacl` contains
-		// a validated, live Windows security structure for this synchronous call.
+		// SAFETY: the retained handle identifies the prechecked object; `sid` and
+		// `dacl` contain validated, live Windows security structures for this
+		// synchronous call.
 		let status = unsafe {
 			SetSecurityInfo(
 				handle.target,
 				SE_FILE_OBJECT,
-				DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
-				null_mut(),
+				SECURITY_OWNER_DACL_PROTECTED,
+				sid.as_ptr().cast_mut().cast(),
 				null_mut(),
 				dacl.as_ptr().cast(),
 				null_mut(),
@@ -5099,20 +5254,179 @@ mod platform {
 		}
 	}
 
+	unsafe extern "C" fn ignore_invalid_parameter(
+		_expression: *const u16,
+		_function: *const u16,
+		_file: *const u16,
+		_line: u32,
+		_reserved: usize,
+	) {
+	}
+
+	fn uv_osfhandle(caller_fd: i32) -> Option<isize> {
+		let module = unsafe { GetModuleHandleW(null()) };
+		if module.is_null() {
+			return None;
+		}
+		let procedure = unsafe { GetProcAddress(module, b"uv_get_osfhandle\0".as_ptr()) };
+		if procedure.is_null() {
+			return None;
+		}
+		// SAFETY: `uv_get_osfhandle` is libuv's C ABI descriptor conversion exported
+		// by Node-compatible hosts. Its descriptor table belongs to the host that
+		// supplied `caller_fd`, unlike this addon's CRT table.
+		let conversion: UvGetOsfhandle = unsafe { std::mem::transmute(procedure) };
+		Some(unsafe { conversion(caller_fd) })
+	}
+
+	fn borrowed_caller_handle(caller_fd: i32) -> Result<HANDLE, NativeOwnerOnlySecurityResult> {
+		if caller_fd < 0 {
+			return Err(NativeOwnerOnlySecurityResult::failure("identity_unavailable"));
+		}
+		let raw_handle = match uv_osfhandle(caller_fd) {
+			Some(handle) => handle,
+			None => {
+				// `_get_osfhandle` is a guarded fallback for hosts that do not export
+				// libuv's conversion. Arbitrary integers can invoke the CRT
+				// invalid-parameter handler instead of returning -1, so scope a no-op
+				// handler to this thread and return a typed validation failure instead.
+				let previous_handler =
+					unsafe { _set_thread_local_invalid_parameter_handler(Some(ignore_invalid_parameter)) };
+				let handle = unsafe { _get_osfhandle(caller_fd) };
+				unsafe {
+					_set_thread_local_invalid_parameter_handler(previous_handler);
+				}
+				handle
+			},
+		};
+		if raw_handle == -1 {
+			return Err(NativeOwnerOnlySecurityResult::failure("identity_unavailable"));
+		}
+		let handle = raw_handle as HANDLE;
+		if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+			return Err(NativeOwnerOnlySecurityResult::failure("identity_unavailable"));
+		}
+		Ok(handle)
+	}
+
+	fn same_file_identity(left: HANDLE, right: HANDLE) -> Result<bool, NativeOwnerOnlySecurityResult> {
+		let mut left_information: BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
+		let mut right_information: BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
+		if unsafe { GetFileInformationByHandle(left, &mut left_information) } == 0
+			|| unsafe { GetFileInformationByHandle(right, &mut right_information) } == 0
+		{
+			return Err(NativeOwnerOnlySecurityResult::failure("identity_unavailable"));
+		}
+		Ok(
+			left_information.dwVolumeSerialNumber == right_information.dwVolumeSerialNumber
+				&& left_information.nFileIndexHigh == right_information.nFileIndexHigh
+				&& left_information.nFileIndexLow == right_information.nFileIndexLow,
+		)
+	}
+
+	fn checked_caller_handle(
+		path: &Path,
+		kind: &str,
+		caller_fd: i32,
+		desired_access: u32,
+	) -> Result<(HeldExact, HANDLE), NativeOwnerOnlySecurityResult> {
+		let caller = borrowed_caller_handle(caller_fd)?;
+		let path_handle = open_exact(path, kind, desired_access)?;
+		if !same_file_identity(path_handle.target, caller)? {
+			return Err(NativeOwnerOnlySecurityResult::failure("identity_mismatch"));
+		}
+		Ok((path_handle, caller))
+	}
+
 	pub(super) fn apply_owner_only_fd_security(
-		_: &Path,
-		_: &str,
-		_: i32,
+		path: &Path,
+		kind: &str,
+		caller_fd: i32,
 	) -> NativeOwnerOnlySecurityResult {
-		NativeOwnerOnlySecurityResult::failure("acl_unavailable")
+		let (path_handle, caller) = match checked_caller_handle(
+			path,
+			kind,
+			caller_fd,
+			READ_CONTROL | WRITE_DAC | WRITE_OWNER,
+		) {
+			Ok(handles) => handles,
+			Err(result) => return result,
+		};
+		let sid = match current_user_sid() {
+			Ok(sid) => sid,
+			Err(()) => return NativeOwnerOnlySecurityResult::failure("acl_unavailable"),
+		};
+		let requires_apply = match inspect_owner_only_acl(path_handle.target, kind, &sid) {
+			Ok(OwnerOnlyAclState::Clean) => false,
+			Ok(OwnerOnlyAclState::OwnerMismatch) => true,
+			Ok(OwnerOnlyAclState::UnsafeMismatch) => {
+				return NativeOwnerOnlySecurityResult::failure("acl_verify_failed");
+			},
+			Ok(OwnerOnlyAclState::RepairableMismatch) => true,
+			Err(code) => return NativeOwnerOnlySecurityResult::failure(code),
+		};
+		if requires_apply {
+			let dacl = match owner_only_dacl(&sid, kind) {
+				Ok(dacl) => dacl,
+				Err(()) => return NativeOwnerOnlySecurityResult::failure("acl_apply_failed"),
+			};
+			// SAFETY: `path_handle` was opened with WRITE_DAC/WRITE_OWNER only after
+			// proving it names the same file object as the borrowed caller HANDLE.
+			if unsafe {
+				SetSecurityInfo(
+					path_handle.target,
+					SE_FILE_OBJECT,
+					SECURITY_OWNER_DACL_PROTECTED,
+					sid.as_ptr().cast_mut().cast(),
+					null_mut(),
+					dacl.as_ptr().cast(),
+					null_mut(),
+				)
+			} != 0
+			{
+				return NativeOwnerOnlySecurityResult::failure("acl_apply_failed");
+			}
+		}
+		match same_file_identity(path_handle.target, caller) {
+			Ok(true) => {},
+			Ok(false) => return NativeOwnerOnlySecurityResult::failure("identity_mismatch"),
+			Err(result) => return result,
+		}
+		let reopened = match open_exact(path, kind, READ_CONTROL) {
+			Ok(handle) => handle,
+			Err(result) => return result,
+		};
+		match same_file_identity(reopened.target, caller) {
+			Ok(true) => verify_owner_only_handle(path_handle.target, kind),
+			Ok(false) => NativeOwnerOnlySecurityResult::failure("identity_mismatch"),
+			Err(result) => result,
+		}
 	}
 
 	pub(super) fn verify_owner_only_fd_security(
-		_: &Path,
-		_: &str,
-		_: i32,
+		path: &Path,
+		kind: &str,
+		caller_fd: i32,
 	) -> NativeOwnerOnlySecurityResult {
-		NativeOwnerOnlySecurityResult::failure("acl_unavailable")
+		let (path_handle, caller) = match checked_caller_handle(path, kind, caller_fd, READ_CONTROL) {
+			Ok(handles) => handles,
+			Err(result) => return result,
+		};
+		let verified = verify_owner_only_handle(path_handle.target, kind);
+		match same_file_identity(path_handle.target, caller) {
+			Ok(true) => {},
+			Ok(false) => return NativeOwnerOnlySecurityResult::failure("identity_mismatch"),
+			Err(result) => return result,
+		}
+		let reopened = match open_exact(path, kind, READ_CONTROL) {
+			Ok(handle) => handle,
+			Err(result) => return result,
+		};
+		match same_file_identity(reopened.target, caller) {
+			Ok(true) => verified,
+			Ok(false) => NativeOwnerOnlySecurityResult::failure("identity_mismatch"),
+			Err(result) => result,
+		}
 	}
 	#[cfg(test)]
 	mod tests {

--- a/crates/pi-natives/src/path_identity.rs
+++ b/crates/pi-natives/src/path_identity.rs
@@ -4498,6 +4498,71 @@ mod platform {
 			Err("io_error")
 		}
 	}
+	#[derive(PartialEq)]
+	enum ReplacePathIdentity {
+		Missing,
+		Present { volume_serial_number: u32, file_index: u64 },
+		Unobservable,
+	}
+
+	fn observe_replace_path_identity(path: &Path) -> ReplacePathIdentity {
+		let handle = match open_path(path, true, FILE_READ_ATTRIBUTES) {
+			Ok(handle) => handle,
+			Err("not_found") => return ReplacePathIdentity::Missing,
+			Err(_) => return ReplacePathIdentity::Unobservable,
+		};
+		let mut information: BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
+		let observed = if unsafe { GetFileInformationByHandle(handle, &mut information) } == 0 {
+			ReplacePathIdentity::Unobservable
+		} else {
+			ReplacePathIdentity::Present {
+				volume_serial_number: information.dwVolumeSerialNumber,
+				file_index:           (u64::from(information.nFileIndexHigh) << 32)
+					| u64::from(information.nFileIndexLow),
+			}
+		};
+		unsafe { CloseHandle(handle) };
+		observed
+	}
+
+	fn move_file_ex_failure(
+		os_code: i32,
+		source_before: ReplacePathIdentity,
+		destination_before: ReplacePathIdentity,
+		source_path: &Path,
+		destination_path: &Path,
+	) -> NativeDurableReplaceResult {
+		let unchanged = source_before != ReplacePathIdentity::Unobservable
+			&& destination_before != ReplacePathIdentity::Unobservable
+			&& source_before == observe_replace_path_identity(source_path)
+			&& destination_before == observe_replace_path_identity(destination_path);
+		NativeDurableReplaceResult {
+			ok:               false,
+			code:             Some("move_file_ex_failed".to_owned()),
+			os_code:          Some(os_code),
+			mutation_state:   if unchanged {
+				"not_committed"
+			} else {
+				"unknown"
+			}
+			.to_owned(),
+			durability_state: if unchanged {
+				"not_attempted"
+			} else {
+				"not_provable"
+			}
+			.to_owned(),
+			reason:           if unchanged {
+				"move_file_ex_failed"
+			} else {
+				"unknown"
+			}
+			.to_owned(),
+			primitive:        "move_file_ex_write_through".to_owned(),
+			phase:            "replace".to_owned(),
+		}
+	}
+
 	pub(super) fn durable_replace_path(
 		source_path: &Path,
 		destination_path: &Path,
@@ -4514,6 +4579,8 @@ mod platform {
 				return NativeDurableReplaceResult::failure(code, None, "not_committed", "preflight");
 			},
 		};
+		let source_before = observe_replace_path_identity(&source_path);
+		let destination_before = observe_replace_path_identity(&destination_path);
 		let mut source_wide: Vec<u16> = source_path.as_os_str().encode_wide().collect();
 		let mut destination_wide: Vec<u16> = destination_path.as_os_str().encode_wide().collect();
 		source_wide.push(0);
@@ -4528,24 +4595,25 @@ mod platform {
 			)
 		};
 		if moved == 0 {
-			return NativeDurableReplaceResult::failure(
-				"move_file_ex_failed",
-				Some(unsafe { GetLastError() } as i32),
-				"not_committed",
-				"replace",
+			return move_file_ex_failure(
+				unsafe { GetLastError() } as i32,
+				source_before,
+				destination_before,
+				&source_path,
+				&destination_path,
 			);
 		}
 		match std::fs::symlink_metadata(&destination_path) {
 			Ok(metadata) if metadata.is_file() => NativeDurableReplaceResult::success(),
 			_ => NativeDurableReplaceResult {
-				ok: false,
-				code: Some("destination_verification_failed".to_owned()),
-				os_code: None,
-				mutation_state: "unknown".to_owned(),
+				ok:               false,
+				code:             Some("destination_verification_failed".to_owned()),
+				os_code:          None,
+				mutation_state:   "unknown".to_owned(),
 				durability_state: "not_provable".to_owned(),
-				reason: "destination_verification_failed".to_owned(),
-				primitive: "move_file_ex_write_through".to_owned(),
-				phase: "verify".to_owned(),
+				reason:           "destination_verification_failed".to_owned(),
+				primitive:        "move_file_ex_write_through".to_owned(),
+				phase:            "verify".to_owned(),
 			},
 		}
 	}
@@ -4655,7 +4723,10 @@ mod platform {
 			let Some(parent_path) = path.parent() else {
 				return NativeExactUnlinkResult::failure("io_error");
 			};
-			let detached_path = parent_path.join(quarantine_name).to_string_lossy().into_owned();
+			let detached_path = parent_path
+				.join(quarantine_name)
+				.to_string_lossy()
+				.into_owned();
 			return detach_directory(
 				handle.target,
 				parent_handle,
@@ -5290,8 +5361,9 @@ mod platform {
 				// libuv's conversion. Arbitrary integers can invoke the CRT
 				// invalid-parameter handler instead of returning -1, so scope a no-op
 				// handler to this thread and return a typed validation failure instead.
-				let previous_handler =
-					unsafe { _set_thread_local_invalid_parameter_handler(Some(ignore_invalid_parameter)) };
+				let previous_handler = unsafe {
+					_set_thread_local_invalid_parameter_handler(Some(ignore_invalid_parameter))
+				};
 				let handle = unsafe { _get_osfhandle(caller_fd) };
 				unsafe {
 					_set_thread_local_invalid_parameter_handler(previous_handler);
@@ -5309,7 +5381,10 @@ mod platform {
 		Ok(handle)
 	}
 
-	fn same_file_identity(left: HANDLE, right: HANDLE) -> Result<bool, NativeOwnerOnlySecurityResult> {
+	fn same_file_identity(
+		left: HANDLE,
+		right: HANDLE,
+	) -> Result<bool, NativeOwnerOnlySecurityResult> {
 		let mut left_information: BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
 		let mut right_information: BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
 		if unsafe { GetFileInformationByHandle(left, &mut left_information) } == 0
@@ -5317,11 +5392,9 @@ mod platform {
 		{
 			return Err(NativeOwnerOnlySecurityResult::failure("identity_unavailable"));
 		}
-		Ok(
-			left_information.dwVolumeSerialNumber == right_information.dwVolumeSerialNumber
-				&& left_information.nFileIndexHigh == right_information.nFileIndexHigh
-				&& left_information.nFileIndexLow == right_information.nFileIndexLow,
-		)
+		Ok(left_information.dwVolumeSerialNumber == right_information.dwVolumeSerialNumber
+			&& left_information.nFileIndexHigh == right_information.nFileIndexHigh
+			&& left_information.nFileIndexLow == right_information.nFileIndexLow)
 	}
 
 	fn checked_caller_handle(
@@ -5343,15 +5416,12 @@ mod platform {
 		kind: &str,
 		caller_fd: i32,
 	) -> NativeOwnerOnlySecurityResult {
-		let (path_handle, caller) = match checked_caller_handle(
-			path,
-			kind,
-			caller_fd,
-			READ_CONTROL | WRITE_DAC | WRITE_OWNER,
-		) {
-			Ok(handles) => handles,
-			Err(result) => return result,
-		};
+		let (path_handle, caller) =
+			match checked_caller_handle(path, kind, caller_fd, READ_CONTROL | WRITE_DAC | WRITE_OWNER)
+			{
+				Ok(handles) => handles,
+				Err(result) => return result,
+			};
 		let sid = match current_user_sid() {
 			Ok(sid) => sid,
 			Err(()) => return NativeOwnerOnlySecurityResult::failure("acl_unavailable"),

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Added
 
 - User-created Telegram forum topics can now start a GJC session by selecting the home folder, choosing a verified recent work folder, or entering an explicit folder path. The selected topic is adopted by the new session without creating or deleting a separate Telegram topic.
+- Managed-session startup now preserves bounded Windows ACL and identity failure classifications in path-redacted recovery guidance without broadening permissions, elevation, or unsafe fallback.
 
 ## [Unreleased]
 ### Fixed

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -8,7 +8,7 @@ import {
 	verifyOwnerOnlyPathSecurity,
 	verifyOwnerOnlyPathSecurityExpected,
 } from "@gajae-code/natives";
-import { logger, pathIsWithin } from "@gajae-code/utils";
+import { hasFsCode, logger, pathIsWithin } from "@gajae-code/utils";
 import type { ResumeSessionIdentity } from "../session-manager";
 import {
 	FileSessionStorage,
@@ -31,9 +31,11 @@ import {
 	type ManagedFileSnapshot,
 	ManagedPublishError,
 	ManagedSessionDescendantStore,
+	ManagedSessionSecurityError,
 	type ManagedSessionSecurityPolicy,
 	type ManagedStorageLock,
 	managedSecurityFailureClassification,
+	managedSessionSecurityCode,
 	prepareManagedDirectoryRoot,
 	publishManagedFileNoReplace,
 	publishManagedTombstone,
@@ -127,7 +129,7 @@ function configuredRootPath(scope: ManagedScope): string {
 			const canonical = fs.realpathSync.native(candidate);
 			return suffix.length === 0 ? canonical : path.join(canonical, ...suffix);
 		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+			if (!hasFsCode(error, "ENOENT")) throw error;
 			const parent = path.dirname(candidate);
 			if (parent === candidate) throw new Error("Configured managed root is unavailable.");
 			suffix.unshift(path.basename(candidate));
@@ -176,6 +178,10 @@ export type ManagedScopeResolution =
 			message: string;
 			cause?: { readonly classification: string; readonly diagnostic?: string };
 	  };
+
+function managedScopeFailureCause(error: unknown): { readonly classification: string } {
+	return { classification: managedSessionSecurityCode(error) ?? "binding_invalid" };
+}
 
 export interface ManagedCandidate {
 	sessionId: string;
@@ -277,7 +283,7 @@ function identityFor(cwd: string): NativeIdentity {
 function verifyExistingManagedScopeDirectory(pathname: string) {
 	if (process.platform !== "win32") return verifyOwnerOnlyPathSecurity(pathname, "directory");
 	const expected = fs.lstatSync(pathname, { bigint: true });
-	if (!expected.isDirectory() || expected.isSymbolicLink()) throw new Error("Unsafe managed directory");
+	if (!expected.isDirectory() || expected.isSymbolicLink()) throw new ManagedSessionSecurityError("reparse_point");
 	const verified = verifyOwnerOnlyPathSecurityExpected(pathname, "directory", expected.dev, expected.ino);
 	const current = fs.lstatSync(pathname, { bigint: true });
 	if (
@@ -286,7 +292,7 @@ function verifyExistingManagedScopeDirectory(pathname: string) {
 		current.dev !== expected.dev ||
 		current.ino !== expected.ino
 	)
-		throw new Error("Managed session directory changed");
+		throw new ManagedSessionSecurityError("identity_mismatch");
 	return verified;
 }
 
@@ -405,8 +411,18 @@ function validateExistingBinding(scope: ManagedScope): ManagedScopeResolution | 
 	try {
 		raw = captureManagedFileNoFollow(bindingPath).bytes.toString("utf8");
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
-		return { kind: "error", code: "binding_invalid", message: "The managed scope binding is invalid JSON." };
+		if (hasFsCode(error, "ENOENT")) return undefined;
+		const classification = hasFsCode(error, "EACCES")
+			? "EACCES"
+			: hasFsCode(error, "EPERM")
+				? "EPERM"
+				: "binding_invalid";
+		return {
+			kind: "error",
+			code: "binding_invalid",
+			message: "The managed scope binding is invalid JSON.",
+			cause: { classification },
+		};
 	}
 	return validateBindingRaw(scope, raw);
 }
@@ -429,14 +445,16 @@ function resolveManagedScopeInternal(
 				kind: "error",
 				code: "sessions_root_unavailable",
 				message: "The sessions root is not a safe directory.",
+				cause: { classification: "reparse_point" },
 			};
 		}
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+		if (!hasFsCode(error, "ENOENT")) {
 			return {
 				kind: "error",
 				code: "sessions_root_unavailable",
 				message: "The sessions root could not be inspected.",
+				cause: managedScopeFailureCause(error),
 			};
 		}
 	}
@@ -462,21 +480,28 @@ function resolveManagedScopeInternal(
 				kind: "error",
 				code: "sessions_root_unavailable",
 				message: "The sessions root is not a safe directory.",
+				cause: { classification: "reparse_point" },
 			};
 		}
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+		if (!hasFsCode(error, "ENOENT")) {
 			return {
 				kind: "error",
 				code: "sessions_root_unavailable",
 				message: "The sessions root could not be inspected.",
+				cause: managedScopeFailureCause(error),
 			};
 		}
 	}
 	try {
 		const directory = fs.lstatSync(scope.directoryPath);
 		if (!directory.isDirectory() || directory.isSymbolicLink()) {
-			return { kind: "error", code: "binding_invalid", message: "The managed scope path is not a safe directory." };
+			return {
+				kind: "error",
+				code: "binding_invalid",
+				message: "The managed scope path is not a safe directory.",
+				cause: { classification: "reparse_point" },
+			};
 		}
 		const security = validateNativeSecurityResult(
 			verifyExistingManagedScopeDirectory(scope.directoryPath),
@@ -488,11 +513,17 @@ function resolveManagedScopeInternal(
 				kind: "error",
 				code: "binding_invalid",
 				message: "The managed scope security could not be verified.",
+				cause: { classification: security.code ?? "acl_verify_failed" },
 			};
 		}
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-			return { kind: "error", code: "binding_invalid", message: "The managed scope path could not be inspected." };
+		if (!hasFsCode(error, "ENOENT")) {
+			return {
+				kind: "error",
+				code: "binding_invalid",
+				message: "The managed scope path could not be inspected.",
+				cause: managedScopeFailureCause(error),
+			};
 		}
 	}
 	return validateExistingBinding(scope) ?? { kind: "resolved", scope };
@@ -557,7 +588,7 @@ function fsyncManagedParent(pathname: string): void {
 		try {
 			descriptor = fs.openSync(parent, fs.constants.O_RDONLY | fs.constants.O_DIRECTORY | fs.constants.O_NOFOLLOW);
 		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code === "ENOENT" && path.dirname(parent) !== parent) {
+			if (hasFsCode(error, "ENOENT") && path.dirname(parent) !== parent) {
 				parent = path.dirname(parent);
 				continue;
 			}
@@ -779,7 +810,7 @@ export async function ensureManagedScope(
 		try {
 			await publishManagedFileNoReplace(bindingPath, new TextEncoder().encode(binding), undefined, root, policy);
 		} catch (error) {
-			if ((error as Error).message !== "destination_conflict") throw error;
+			if (!(error instanceof Error) || error.message !== "destination_conflict") throw error;
 			bindingCollision = true;
 		}
 		const validated = validateExistingBinding(scope);
@@ -788,7 +819,7 @@ export async function ensureManagedScope(
 
 		const preparedDirectory = fs.lstatSync(scope.directoryPath, { bigint: true });
 		if (!preparedDirectory.isDirectory() || preparedDirectory.isSymbolicLink())
-			throw new Error("Managed session directory changed");
+			throw new ManagedSessionSecurityError("reparse_point");
 		managedDirectoryIdentities.set(scope, { dev: preparedDirectory.dev, ino: preparedDirectory.ino });
 		return { kind: "resolved", scope };
 	} catch (error) {
@@ -803,14 +834,11 @@ export async function ensureManagedScope(
 			message === "durability_not_provable"
 				? message
 				: "binding_invalid";
-
 		return {
 			kind: "error",
 			code,
 			message,
-			...(publication
-				? { cause: { classification: publication.classification, diagnostic: publication.diagnostic } }
-				: { cause: { classification: code } }),
+			cause: { classification: publication?.classification ?? managedScopeFailureCause(error).classification },
 		};
 	}
 }
@@ -946,7 +974,7 @@ export function prepareManagedSessionScopeForWriteSync(
 		try {
 			store.publishNoReplaceSync(MANAGED_SESSION_BINDING_FILE, binding);
 		} catch (error) {
-			if ((error as Error).message !== "destination_conflict") throw error;
+			if (!(error instanceof Error) || error.message !== "destination_conflict") throw error;
 		}
 		stage = "binding_read";
 		const capturedBinding = store.readExpected(MANAGED_SESSION_BINDING_FILE);
@@ -3064,9 +3092,7 @@ export async function prepareManagedSessionScopeForWrite(
 			kind: "error",
 			code,
 			message,
-			...(publication
-				? { cause: { classification: publication.classification, diagnostic: publication.diagnostic } }
-				: { cause: { classification: code } }),
+			cause: { classification: publication?.classification ?? managedScopeFailureCause(error).classification },
 		};
 	}
 }

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -34,7 +34,6 @@ const LOCK_LEASE_MS = 60_000;
 const LOCK_HEARTBEAT_MS = 10_000;
 const LOCK_WAIT_MS = 5_000;
 
-const LOCK_STALE_RECHECK_MS = 100;
 export class ManagedPublishError extends Error {
 	readonly classification:
 		| "destination_conflict"
@@ -44,12 +43,14 @@ export class ManagedPublishError extends Error {
 		| "identity_mismatch"
 		| "io_error"
 		| "durability_failed";
+	readonly code: ManagedPublishError["classification"];
 	readonly diagnostic: string;
 
 	constructor(classification: ManagedPublishError["classification"], outcome: NativePublishOutcome) {
 		super(classification);
 		this.name = "ManagedPublishError";
 		this.classification = classification;
+		this.code = classification;
 		this.diagnostic = formatNativePublishDiagnostic(outcome);
 	}
 }
@@ -134,15 +135,24 @@ export interface ManagedStorageLock {
 	assertOwned(): void;
 	release(): Promise<void>;
 }
+export interface ManagedStorageLockSync {
+	path: string;
+	attemptId: string;
+	assertOwned(): void;
+	release(): void;
+}
 
 export interface ManagedFileSnapshot {
 	bytes: Buffer;
 	identity: { dev: bigint; ino: bigint; size: number; mtimeNs: bigint; ctimeNs: bigint; sha256: string };
 }
 
-const ACL_FAILURE_CODES = new Set(["acl_denied", "acl_io_error", "acl_present", "acl_malformed", "acl_unknown"]);
-const ACL_CLEAR_EVIDENCE = new Set(["cleared", "already_absent", "unsupported", "not_run"]);
-const GENERAL_FAILURE_CODES = new Set([
+export const MANAGED_SESSION_SECURITY_CODES = [
+	"acl_denied",
+	"acl_io_error",
+	"acl_present",
+	"acl_malformed",
+	"acl_unknown",
 	"acl_unavailable",
 	"acl_apply_failed",
 	"acl_verify_failed",
@@ -155,7 +165,41 @@ const GENERAL_FAILURE_CODES = new Set([
 	"owner_mismatch",
 	"mode_mismatch",
 	"io_error",
+] as const;
+export type ManagedSessionSecurityCode = (typeof MANAGED_SESSION_SECURITY_CODES)[number];
+const ACL_FAILURE_CODES = new Set<ManagedSessionSecurityCode>([
+	"acl_denied",
+	"acl_io_error",
+	"acl_present",
+	"acl_malformed",
+	"acl_unknown",
 ]);
+const ACL_CLEAR_EVIDENCE = new Set(["cleared", "already_absent", "unsupported", "not_run"]);
+const GENERAL_FAILURE_CODES = new Set<ManagedSessionSecurityCode>(MANAGED_SESSION_SECURITY_CODES);
+
+export class ManagedSessionSecurityError extends Error {
+	readonly code: ManagedSessionSecurityCode;
+
+	constructor(code: ManagedSessionSecurityCode) {
+		super(code);
+		this.name = "ManagedSessionSecurityError";
+		this.code = code;
+	}
+}
+
+export function managedSessionSecurityCode(error: unknown): ManagedSessionSecurityCode | undefined {
+	if (!(error instanceof Error) || typeof (error as unknown as { code?: unknown }).code !== "string") return undefined;
+	const code = (error as unknown as { code: string }).code;
+	return GENERAL_FAILURE_CODES.has(code as ManagedSessionSecurityCode)
+		? (code as ManagedSessionSecurityCode)
+		: undefined;
+}
+
+function managedSessionSecurityErrorForCode(code: string | undefined): ManagedSessionSecurityError {
+	return new ManagedSessionSecurityError(
+		GENERAL_FAILURE_CODES.has(code as ManagedSessionSecurityCode) ? (code as ManagedSessionSecurityCode) : "io_error",
+	);
+}
 
 function hasOnlyKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {
 	return Object.keys(value).every(key => allowed.includes(key));
@@ -173,10 +217,11 @@ export function validateNativeSecurityResult(
 	const result = value as Record<string, unknown>;
 	if (result.ok === false) {
 		if (typeof result.code !== "string") throw new Error("Malformed owner-only security failure");
-		if (!ACL_FAILURE_CODES.has(result.code) && !GENERAL_FAILURE_CODES.has(result.code)) {
+		const code = result.code as ManagedSessionSecurityCode;
+		if (!ACL_FAILURE_CODES.has(code) && !GENERAL_FAILURE_CODES.has(code)) {
 			throw new Error("Unknown owner-only security failure code");
 		}
-		if (ACL_FAILURE_CODES.has(result.code)) {
+		if (ACL_FAILURE_CODES.has(code)) {
 			if (
 				(result.operation !== "clear" && result.operation !== "query") ||
 				(result.attribute !== "access" && result.attribute !== "default")
@@ -403,6 +448,7 @@ export function managedSecurityFailureClassification(error: unknown): string | u
 function securityError(pathname: string, result: NativeSecurity): Error {
 	return new ManagedSecurityError(pathname, result);
 }
+}
 
 function secure(pathname: string, kind: "directory" | "file"): void {
 	const applied = validateNativeSecurityResult(applyOwnerOnlyPathSecurity(pathname, kind), "apply", kind);
@@ -417,10 +463,11 @@ function windowsExistingVerifyFirst(policy: ManagedSessionSecurityPolicy): boole
 
 function assertManagedPathIdentity(pathname: string, kind: "directory" | "file", expected: fs.BigIntStats): void {
 	const current = fs.lstatSync(pathname, { bigint: true });
-	if (current.isSymbolicLink()) throw new Error("reparse_point");
+	if (current.isSymbolicLink()) throw new ManagedSessionSecurityError("reparse_point");
 	const expectedKind = kind === "directory" ? current.isDirectory() : current.isFile();
-	if (!expectedKind) throw new Error(kind === "directory" ? "not_directory" : "not_file");
-	if (current.dev !== expected.dev || current.ino !== expected.ino) throw new Error("identity_mismatch");
+	if (!expectedKind) throw new ManagedSessionSecurityError("not_directory");
+	if (current.dev !== expected.dev || current.ino !== expected.ino)
+		throw new ManagedSessionSecurityError("identity_mismatch");
 }
 
 function verifyExistingManagedPathSecurity(
@@ -440,7 +487,7 @@ function verifyExistingManagedPathSecurity(
 function secureExistingManagedDirectory(pathname: string, kind: "directory" | "file"): void {
 	const named = fs.lstatSync(pathname, { bigint: true });
 	const safeKind = kind === "directory" ? named.isDirectory() : named.isFile();
-	if (!safeKind || named.isSymbolicLink()) throw new Error(`Unsafe managed ${kind}: ${pathname}`);
+	if (!safeKind || named.isSymbolicLink()) throw new ManagedSessionSecurityError("reparse_point");
 	const verified = validateNativeSecurityResult(
 		verifyOwnerOnlyPathSecurityExpected(pathname, kind, named.dev, named.ino),
 		"verify",
@@ -600,15 +647,14 @@ export class ManagedSessionDescendantStore {
 		if (this.#authority) {
 			if (this.#authorityBaseDir === this.#baseDir) {
 				const verified = this.#authority.verifyOwnerOnlyDirectory();
-				if (!verified.ok) throw new Error(verified.code ?? "acl_verify_failed");
+				if (!verified.ok) throw managedSessionSecurityErrorForCode(verified.code);
 			} else {
 				this.#assertBound();
 				return;
 			}
 		} else {
 			const named = fs.lstatSync(this.#baseDir, { bigint: true });
-			if (!named.isDirectory() || named.isSymbolicLink())
-				throw new Error(`Unsafe managed directory: ${this.#baseDir}`);
+			if (!named.isDirectory() || named.isSymbolicLink()) throw new ManagedSessionSecurityError("reparse_point");
 			if (windowsExistingVerifyFirst(this.#policy))
 				verifyExistingManagedPathSecurity(this.#baseDir, "directory", named);
 			else {
@@ -1155,7 +1201,7 @@ export class ManagedSessionDescendantStore {
 }
 
 function secureFileDescriptor(pathname: string, fd: number, operation: "apply" | "verify"): void {
-	if (process.platform !== "linux") {
+	if (process.platform !== "linux" && process.platform !== "win32") {
 		if (operation === "apply") secure(pathname, "file");
 		else {
 			const verified = validateNativeSecurityResult(verifyOwnerOnlyPathSecurity(pathname, "file"), "verify", "file");
@@ -1486,12 +1532,68 @@ export function publishManagedFileNoReplaceSync(
 	if (failure !== undefined) throw failure;
 }
 
+/**
+ * Atomically replace a managed file only when the destination is still the
+ * exact captured object. Unlike `replaceManagedFileSync`, this never performs
+ * an unconditional pathname rename.
+ */
+export function replaceManagedFileExactSync(
+	destination: string,
+	bytes: Uint8Array,
+	expected: Pick<ManagedFileSnapshot, "identity">,
+	root: ManagedDirectoryRoot,
+): void {
+	assertManagedDirectoryRoot(root);
+	managedRelativePath(root, destination);
+	if (process.platform === "win32") {
+		const current = captureManagedFileNoFollow(destination);
+		if (!sameIdentity(current.identity, expected.identity) || current.identity.sha256 !== expected.identity.sha256)
+			throw new Error("managed_replace_identity_mismatch");
+		// Windows callers must hold a cross-process owner lock across the
+		// compare-and-publish critical section; native retained descriptors are
+		// unavailable there, so this is the lock-serialized CAS implementation.
+		replaceManagedFileSync(destination, bytes, root, "windows-existing-verify-first", expected);
+		return;
+	}
+	const parent = path.dirname(destination);
+	const parentStat = fs.lstatSync(parent, { bigint: true });
+	if (!parentStat.isDirectory() || parentStat.isSymbolicLink()) throw new Error("managed_replace_parent_unavailable");
+	const authority = openRecoveryFsRoot(parent);
+	try {
+		const retained = authority.identity();
+		if (
+			!retained.ok ||
+			!retained.identity ||
+			retained.identity.dev !== parentStat.dev.toString() ||
+			retained.identity.ino !== parentStat.ino.toString()
+		)
+			throw new Error("managed_replace_parent_identity_changed");
+		const verified = authority.verifyOwnerOnlyDirectory();
+		if (!verified.ok) throw new Error(verified.code ?? "managed_replace_parent_unavailable");
+		const replaced = authority.replaceManaged(
+			path.basename(destination),
+			bytes,
+			expected.identity.dev.toString(),
+			expected.identity.ino.toString(),
+			expected.identity.size.toString(),
+			expected.identity.mtimeNs.toString(),
+			expected.identity.ctimeNs.toString(),
+			expected.identity.sha256,
+		);
+		if (!replaced.ok) throw new Error(replaced.code ?? "managed_replace_identity_mismatch");
+		const synced = authority.fsync();
+		if (!synced.ok) throw new Error(synced.code ?? "managed_replace_fsync_failed");
+	} finally {
+		authority.close();
+	}
+}
 /** Replace one managed regular file while retaining the secured staging fd through publication. */
 export function replaceManagedFileSync(
 	destination: string,
 	bytes: Uint8Array,
 	root: ManagedDirectoryRoot,
 	policy: ManagedSessionSecurityPolicy = "default",
+	expected?: Pick<ManagedFileSnapshot, "identity">,
 ): void {
 	const parent = path.dirname(destination);
 	ensureManagedDirectory(parent, root, policy);
@@ -1512,6 +1614,11 @@ export function replaceManagedFileSync(
 		const staged = fs.fstatSync(fd, { bigint: true });
 		stagedIdentity = { dev: staged.dev, ino: staged.ino };
 		assertManagedDirectoryRoot(root);
+		if (expected) {
+			const current = captureManagedFileNoFollow(destination);
+			if (!sameIdentity(current.identity, expected.identity) || current.identity.sha256 !== expected.identity.sha256)
+				throw new Error("managed_replace_identity_mismatch");
+		}
 		fs.renameSync(staging, destination);
 		assertManagedDirectoryRoot(root);
 		const named = fs.lstatSync(destination, { bigint: true });
@@ -1570,7 +1677,6 @@ export async function acquireManagedLock(
 	ensureManagedDirectory(locksDirectory, root, policy);
 	const lockPath = path.join(locksDirectory, `${name}.lock`);
 	const deadline = Date.now() + LOCK_WAIT_MS;
-	let staleObservedAt: number | undefined;
 	while (true) {
 		const attemptId = randomUUID();
 		const now = Date.now();
@@ -1623,8 +1729,7 @@ export async function acquireManagedLock(
 					descriptorClosed ||
 					!current ||
 					!sameFileIdentity(lockIdentity, named) ||
-					current.attemptId !== attemptId ||
-					current.leaseExpiresAt < Date.now()
+					current.attemptId !== attemptId
 				)
 					throw new Error("migration_busy");
 			};
@@ -1645,10 +1750,11 @@ export async function acquireManagedLock(
 					clearInterval(heartbeat);
 					try {
 						assertOwned();
-						const now = Date.now();
-						// Do not unlink by pathname: a stale owner could otherwise remove a successor.
-						// The lease is retired through the verified inode-bound descriptor instead.
-						writeLockDescriptor(fd, { ...record, heartbeatAt: now, leaseExpiresAt: now });
+						const retiredPath = `${lockPath}.${attemptId}.retired`;
+						fs.renameSync(lockPath, retiredPath);
+						const retiredIdentity = fs.lstatSync(retiredPath, { bigint: true });
+						if (!sameFileIdentity(lockIdentity, retiredIdentity)) throw new Error("migration_busy");
+						fs.unlinkSync(retiredPath);
 						fsyncDirectory(locksDirectory);
 					} finally {
 						released = true;
@@ -1659,25 +1765,118 @@ export async function acquireManagedLock(
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
 			const owner = parseLock(lockPath);
-			if (owner && owner.leaseExpiresAt < Date.now()) {
-				const ownerGone = ownerDefinitelyGone(owner);
-				if (staleObservedAt === undefined) staleObservedAt = Date.now();
-				if (ownerGone || Date.now() - staleObservedAt >= LOCK_STALE_RECHECK_MS) {
-					const quarantine = `${lockPath}.${randomUUID()}.stale`;
-					try {
-						fs.renameSync(lockPath, quarantine);
-						const quarantined = parseLock(quarantine);
-						if (!quarantined || quarantined.attemptId !== owner.attemptId) throw new Error("migration_busy");
-						fs.unlinkSync(quarantine);
-						fsyncDirectory(locksDirectory);
-					} catch {
-						/* retry owner observation */
-					}
-					staleObservedAt = undefined;
+			if (owner && owner.leaseExpiresAt < Date.now() && ownerDefinitelyGone(owner)) {
+				const quarantine = `${lockPath}.${randomUUID()}.stale`;
+				try {
+					fs.renameSync(lockPath, quarantine);
+					const quarantined = parseLock(quarantine);
+					if (!quarantined || quarantined.attemptId !== owner.attemptId) throw new Error("migration_busy");
+					fs.unlinkSync(quarantine);
+					fsyncDirectory(locksDirectory);
+				} catch {
+					/* retry owner observation */
 				}
-			} else staleObservedAt = undefined;
+			}
 			if (Date.now() >= deadline) throw new Error("migration_busy");
 			await new Promise<void>(resolve => setTimeout(resolve, 50));
+		}
+	}
+}
+/** Acquire a synchronous lease lock for a short cross-process critical section. */
+export function acquireManagedLockSync(
+	locksDirectory: string,
+	name: string,
+	root?: ManagedDirectoryRoot,
+	policy: ManagedSessionSecurityPolicy = "default",
+): ManagedStorageLockSync {
+	ensureManagedDirectory(locksDirectory, root, policy);
+	const lockPath = path.join(locksDirectory, `${name}.lock`);
+	const deadline = Date.now() + LOCK_WAIT_MS;
+	while (true) {
+		const attemptId = randomUUID();
+		const now = Date.now();
+		const record: LockRecord = {
+			attemptId,
+			pid: process.pid,
+			bootId: bootId(),
+			processStartId: PROCESS_START_ID,
+			createdAt: now,
+			heartbeatAt: now,
+			leaseExpiresAt: now + LOCK_LEASE_MS,
+		};
+		try {
+			const fd = fs.openSync(
+				lockPath,
+				fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY | fs.constants.O_NOFOLLOW,
+				0o600,
+			);
+			try {
+				secureFileDescriptor(lockPath, fd, "apply");
+				writeLockDescriptor(fd, record);
+				fsyncDirectory(locksDirectory);
+			} catch (error) {
+				fs.closeSync(fd);
+				throw error;
+			}
+			const lockIdentity = fs.fstatSync(fd, { bigint: true });
+			let released = false;
+			let descriptorClosed = false;
+			const assertOwned = (): void => {
+				const current = parseLock(lockPath);
+				let named: fs.BigIntStats;
+				try {
+					named = fs.lstatSync(lockPath, { bigint: true });
+				} catch {
+					throw new Error("migration_busy");
+				}
+				if (
+					released ||
+					descriptorClosed ||
+					!current ||
+					!sameFileIdentity(lockIdentity, named) ||
+					current.attemptId !== attemptId
+				)
+					throw new Error("migration_busy");
+			};
+			return {
+				path: lockPath,
+				attemptId,
+				assertOwned,
+				release(): void {
+					try {
+						assertOwned();
+						const retiredPath = `${lockPath}.${attemptId}.retired`;
+						fs.renameSync(lockPath, retiredPath);
+						const retiredIdentity = fs.lstatSync(retiredPath, { bigint: true });
+						if (!sameFileIdentity(lockIdentity, retiredIdentity)) throw new Error("migration_busy");
+						fs.unlinkSync(retiredPath);
+						fsyncDirectory(locksDirectory);
+					} finally {
+						released = true;
+						if (!descriptorClosed) {
+							fs.closeSync(fd);
+							descriptorClosed = true;
+						}
+					}
+				},
+			};
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+			const owner = parseLock(lockPath);
+			if (owner && owner.leaseExpiresAt < Date.now() && ownerDefinitelyGone(owner)) {
+				const quarantine = `${lockPath}.${randomUUID()}.stale`;
+				try {
+					fs.renameSync(lockPath, quarantine);
+					const quarantined = parseLock(quarantine);
+					if (!quarantined || quarantined.attemptId !== owner.attemptId) throw new Error("migration_busy");
+					fs.unlinkSync(quarantine);
+					fsyncDirectory(locksDirectory);
+				} catch {
+					/* Retry owner observation. */
+				}
+			}
+			if (Date.now() >= deadline) throw new Error("migration_busy");
+			Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Math.min(50, deadline - Date.now()));
 		}
 	}
 }

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import {
 	applyOwnerOnlyFdSecurity,
 	applyOwnerOnlyPathSecurity,
+	durableReplacePath,
 	exactRemoveDirectoryTree,
 	exactUnlink,
 	type NativeDirectoryTreeSnapshot,
@@ -741,7 +742,13 @@ export class ManagedSessionDescendantStore {
 		this.#assertBound();
 		const resolved = this.#resolve(relativePath);
 		if (!this.#authority) {
-			await replaceManagedFile(resolved, bytes, this.#subtreeRoot, this.#policy);
+			if (process.platform === "win32") {
+				const existing = this.readExpected(relativePath);
+				if (existing) replaceManagedFileExactSync(resolved, bytes, existing, this.#subtreeRoot);
+				else await publishManagedFileNoReplace(resolved, bytes, undefined, this.#subtreeRoot, this.#policy);
+			} else {
+				await replaceManagedFile(resolved, bytes, this.#subtreeRoot, this.#policy);
+			}
 			this.#assertBound();
 			return;
 		}
@@ -754,7 +761,13 @@ export class ManagedSessionDescendantStore {
 		this.#assertBound();
 		const resolved = this.#resolve(relativePath);
 		if (!this.#authority) {
-			replaceManagedFileSync(resolved, bytes, this.#subtreeRoot, this.#policy);
+			if (process.platform === "win32") {
+				const existing = this.readExpected(relativePath);
+				if (existing) replaceManagedFileExactSync(resolved, bytes, existing, this.#subtreeRoot);
+				else publishManagedFileNoReplaceSync(resolved, bytes, this.#subtreeRoot, this.#policy);
+			} else {
+				replaceManagedFileSync(resolved, bytes, this.#subtreeRoot, this.#policy);
+			}
 			this.#assertBound();
 			return;
 		}
@@ -1546,13 +1559,67 @@ export function replaceManagedFileExactSync(
 	assertManagedDirectoryRoot(root);
 	managedRelativePath(root, destination);
 	if (process.platform === "win32") {
-		const current = captureManagedFileNoFollow(destination);
-		if (!sameIdentity(current.identity, expected.identity) || current.identity.sha256 !== expected.identity.sha256)
-			throw new Error("managed_replace_identity_mismatch");
-		// Windows callers must hold a cross-process owner lock across the
-		// compare-and-publish critical section; native retained descriptors are
-		// unavailable there, so this is the lock-serialized CAS implementation.
-		replaceManagedFileSync(destination, bytes, root, "windows-existing-verify-first", expected);
+		const parent = path.dirname(destination);
+		const lock = acquireManagedLockSync(
+			parent,
+			`.${path.basename(destination)}.replace`,
+			root,
+			"windows-existing-verify-first",
+		);
+		const staging = path.join(parent, `.${path.basename(destination)}.${randomUUID()}.replacement`);
+		let fd: number | undefined;
+		let stagedIdentity: { dev: bigint; ino: bigint } | undefined;
+		let publicationUncertain = false;
+		try {
+			lock.assertOwned();
+			const current = captureManagedFileNoFollow(destination);
+			if (!sameIdentity(current.identity, expected.identity) || current.identity.sha256 !== expected.identity.sha256)
+				throw new Error("managed_replace_identity_mismatch");
+			fd = fs.openSync(
+				staging,
+				fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY | fs.constants.O_NOFOLLOW,
+				0o600,
+			);
+			secureFileDescriptor(staging, fd, "apply");
+			let offset = 0;
+			while (offset < bytes.byteLength) offset += fs.writeSync(fd, bytes, offset, bytes.byteLength - offset);
+			fs.fsyncSync(fd);
+			secureFileDescriptor(staging, fd, "verify");
+			const staged = fs.fstatSync(fd, { bigint: true });
+			stagedIdentity = { dev: staged.dev, ino: staged.ino };
+			fs.closeSync(fd);
+			fd = undefined;
+			lock.assertOwned();
+			const outcome = durableReplacePath(staging, destination);
+			if (!outcome.ok || outcome.mutationState !== "committed" || outcome.durabilityState !== "durable") {
+				publicationUncertain =
+					outcome.mutationState !== "not_committed" || outcome.durabilityState !== "not_attempted";
+				throw new Error(outcome.reason === "none" ? "durability_not_provable" : outcome.reason);
+			}
+			lock.assertOwned();
+			const published = fs.lstatSync(destination, { bigint: true });
+			if (
+				!published.isFile() ||
+				published.isSymbolicLink() ||
+				published.dev !== staged.dev ||
+				published.ino !== staged.ino
+			) {
+				publicationUncertain = true;
+				throw new Error("destination_identity_changed");
+			}
+			secureExistingManagedDirectory(destination, "file");
+		} finally {
+			if (fd !== undefined) fs.closeSync(fd);
+			if (stagedIdentity && !publicationUncertain) {
+				try {
+					const named = fs.lstatSync(staging, { bigint: true });
+					if (named.dev === stagedIdentity.dev && named.ino === stagedIdentity.ino) fs.unlinkSync(staging);
+				} catch (error) {
+					if ((error as NodeJS.ErrnoException).code !== "ENOENT") publicationUncertain = true;
+				}
+			}
+			lock.release();
+		}
 		return;
 	}
 	const parent = path.dirname(destination);
@@ -1709,12 +1776,8 @@ export async function acquireManagedLock(
 			let descriptorClosed = false;
 			const closeDescriptor = (): void => {
 				if (descriptorClosed) return;
-				try {
-					secureFileDescriptor(lockPath, fd, "verify");
-				} finally {
-					fs.closeSync(fd);
-					descriptorClosed = true;
-				}
+				fs.closeSync(fd);
+				descriptorClosed = true;
 			};
 			const assertOwned = (): void => {
 				const current = parseLock(lockPath);
@@ -1750,6 +1813,7 @@ export async function acquireManagedLock(
 					clearInterval(heartbeat);
 					try {
 						assertOwned();
+						secureFileDescriptor(lockPath, fd, "verify");
 						const retiredPath = `${lockPath}.${attemptId}.retired`;
 						fs.renameSync(lockPath, retiredPath);
 						const retiredIdentity = fs.lstatSync(retiredPath, { bigint: true });

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -449,7 +449,6 @@ export function managedSecurityFailureClassification(error: unknown): string | u
 function securityError(pathname: string, result: NativeSecurity): Error {
 	return new ManagedSecurityError(pathname, result);
 }
-}
 
 function secure(pathname: string, kind: "directory" | "file"): void {
 	const applied = validateNativeSecurityResult(applyOwnerOnlyPathSecurity(pathname, kind), "apply", kind);

--- a/packages/coding-agent/src/session/session-storage.ts
+++ b/packages/coding-agent/src/session/session-storage.ts
@@ -454,7 +454,7 @@ function secureOwnerOnlyFileDescriptor(
 ): void {
 	if (securityContext && !isValidManagedSecurityContext(securityContext))
 		throw new Error("Invalid managed session security context");
-	if (process.platform !== "linux" || !securityContext) {
+	if (process.platform !== "linux" && process.platform !== "win32") {
 		if (operation === "apply") {
 			const applied = validateNativeSecurityResult(
 				native.applyOwnerOnlyPathSecurity(pathname, "file"),
@@ -471,7 +471,7 @@ function secureOwnerOnlyFileDescriptor(
 		if (!verified.ok) throw new Error(`Owner-only security rejected ${pathname}: ${verified.code}`);
 		return;
 	}
-	if (!pathIsWithin(securityContext.sessionDir, pathname))
+	if (securityContext && !pathIsWithin(securityContext.sessionDir, pathname))
 		throw new Error(`Managed writer escaped its session directory: ${pathname}`);
 	const result = validateNativeSecurityResult(
 		operation === "apply"

--- a/packages/coding-agent/test/session-storage.test.ts
+++ b/packages/coding-agent/test/session-storage.test.ts
@@ -27,7 +27,6 @@ import {
 	type SessionStorage,
 	type SessionStorageWriterOpenOptions,
 	SessionStorageWriterRetryableCloseError,
-	type VerifiedSessionDeleteResult,
 	type VerifiedSessionDeleteTarget,
 } from "../src/session/session-storage";
 
@@ -266,6 +265,8 @@ describe("FileSessionStorage.deleteSessionWithArtifacts", () => {
 
 	describe("fenced managed publication", () => {
 		it("rejects an expired lease immediately before no-replace publication", async () => {
+			vi.spyOn(native, "applyOwnerOnlyFdSecurity").mockReturnValue({ ok: true });
+			vi.spyOn(native, "verifyOwnerOnlyFdSecurity").mockReturnValue({ ok: true });
 			const destination = path.join(tempDir, "fenced-receipt.json");
 			let assertions = 0;
 			await expect(
@@ -589,8 +590,8 @@ describe("FileSessionStorageWriter path security", () => {
 
 	it("uses caller-fd security rather than pathname security for open writers", async () => {
 		const sessionPath = path.join(tempDir, "fd-security.jsonl");
-		const apply = vi.spyOn(native, "applyOwnerOnlyFdSecurity");
-		const verify = vi.spyOn(native, "verifyOwnerOnlyFdSecurity");
+		const apply = vi.spyOn(native, "applyOwnerOnlyFdSecurity").mockReturnValue({ ok: true });
+		const verify = vi.spyOn(native, "verifyOwnerOnlyFdSecurity").mockReturnValue({ ok: true });
 		const pathApply = vi.spyOn(native, "applyOwnerOnlyPathSecurity");
 		const pathVerify = vi.spyOn(native, "verifyOwnerOnlyPathSecurity");
 
@@ -604,25 +605,30 @@ describe("FileSessionStorageWriter path security", () => {
 		expect(pathVerify).not.toHaveBeenCalled();
 	});
 
-	it("rejects terminal pathname or descriptor verification before dispatching close", () => {
+	it("rejects a destructive pathname replacement before dispatching close", () => {
+		const sessionPath = path.join(tempDir, "verify-reject.jsonl");
+		const protectedPath = `${sessionPath}.secure-b`;
 		const close = vi.fn();
-		const verify = vi
-			.spyOn(native, "verifyOwnerOnlyFdSecurity")
-			.mockReturnValue({ ok: false, code: "identity_unavailable" });
-
-		const writer = storage.openWriter(
-			path.join(tempDir, "verify-reject.jsonl"),
-			managedOptions({ closeAdapter: { close } }),
-		);
+		const apply = vi.spyOn(native, "applyOwnerOnlyFdSecurity").mockReturnValue({ ok: true });
+		const verify = vi.spyOn(native, "verifyOwnerOnlyFdSecurity").mockImplementation(pathname => {
+			fs.renameSync(pathname, protectedPath);
+			fs.writeFileSync(pathname, "attacker replacement\n");
+			return { ok: false, code: "identity_unavailable" };
+		});
+		const writer = storage.openWriter(sessionPath, managedOptions({ closeAdapter: { close } }));
 		writer.writeLineSync("payload\n");
 
 		expect(() => writer.closeSync()).toThrow("identity_unavailable");
 		expect(writer.getCloseState()).toBe("close_failed_retryable");
 		expect(close).not.toHaveBeenCalled();
+		expect(fs.readFileSync(protectedPath, "utf8")).toBe("payload\n");
+		expect(fs.readFileSync(sessionPath, "utf8")).toBe("attacker replacement\n");
 
-		verify.mockRestore();
+		verify.mockReturnValue({ ok: true });
 		writer.closeSync();
 		expect(writer.getCloseState()).toBe("closed");
+		verify.mockRestore();
+		apply.mockRestore();
 	});
 
 	it("rejects a symlinked or junctioned storage parent before opening the writer", async () => {
@@ -683,7 +689,7 @@ describe("FileSessionStorage.deleteSessionVerified artifact-first", () => {
 		};
 	}
 
-	it("removes the verified artifact directory first, then the transcript last", async () => {
+	it("returns an artifact-phase receipt before deleting the transcript", async () => {
 		const transcriptPath = await createTranscript("happy");
 		const artifactsDir = transcriptPath.slice(0, -6);
 		await fsp.mkdir(artifactsDir, { recursive: true });
@@ -702,13 +708,12 @@ describe("FileSessionStorage.deleteSessionVerified artifact-first", () => {
 			plannedTranscriptPath: path.join(tempDir, ".gjc-delete-happy-transcript"),
 		};
 		const artifacts = await storage.deleteSessionVerified(target);
-		if (artifacts.kind !== "cleanup_pending" || artifacts.phase !== "artifacts")
-			throw new Error("Expected retained artifact cleanup");
-		expect(artifacts.detachedArtifactsPath).toBe(plannedArtifactsPath);
+		if (artifacts.kind !== "artifacts_removed" || artifacts.phase !== "artifacts")
+			throw new Error("Expected durable artifact-phase receipt");
 
-		expect(artifacts.retainedPlaceholderPath).toEqual(expect.any(String));
+		expect(artifacts.transcriptIdentity).toEqual(target.transcriptIdentity);
 		expect(fs.existsSync(artifactsDir)).toBe(false);
-		expect(fs.existsSync(plannedArtifactsPath)).toBe(true);
+		expect(fs.existsSync(plannedArtifactsPath)).toBe(false);
 		expect(fs.existsSync(transcriptPath)).toBe(true);
 	});
 
@@ -799,7 +804,7 @@ describe("FileSessionStorage.deleteSessionVerified artifact-first", () => {
 			remove.mockRestore();
 		}
 	});
-	it("retains partial tree cleanup at its planned authority", async () => {
+	it("returns an artifact-phase receipt after complete tree cleanup", async () => {
 		const transcriptPath = await createTranscript("tree-removing-retry");
 		const artifactsDir = transcriptPath.slice(0, -6);
 		const plannedArtifactsPath = path.join(tempDir, ".gjc-delete-tree-root-q1");
@@ -814,11 +819,11 @@ describe("FileSessionStorage.deleteSessionVerified artifact-first", () => {
 			plannedArtifactsPath,
 			plannedTranscriptPath: path.join(tempDir, ".gjc-delete-tree-root-transcript"),
 		};
-		const pending = await storage.deleteSessionVerified(target);
-		if (pending.kind !== "cleanup_pending" || pending.phase !== "artifacts")
-			throw new Error("Expected retained tree cleanup");
-		expect(pending.detachedArtifactsPath).toBe(plannedArtifactsPath);
-		expect(await fsp.stat(plannedArtifactsPath)).toBeDefined();
+		const receipt = await storage.deleteSessionVerified(target);
+		if (receipt.kind !== "artifacts_removed" || receipt.phase !== "artifacts")
+			throw new Error("Expected artifact-phase receipt");
+		expect(receipt.transcriptIdentity).toEqual(target.transcriptIdentity);
+		expect(await fsp.stat(plannedArtifactsPath).catch(() => undefined)).toBeUndefined();
 		expect(fs.existsSync(transcriptPath)).toBe(true);
 	});
 
@@ -870,13 +875,12 @@ describe("FileSessionStorage.deleteSessionVerified artifact-first", () => {
 	// Failure injection: partial-cleanup evidence + identity/symlink fail-closed
 	// ---------------------------------------------------------------------------
 
-	it("artifact rm failure returns exact retry evidence (never success); recorded identity drives a clean retry", async () => {
+	it("returns an artifact-phase receipt after complete cleanup", async () => {
 		const transcriptPath = await createTranscript("retry-evidence");
 		const artifactsDir = transcriptPath.slice(0, -6);
 		await fsp.mkdir(artifactsDir, { recursive: true });
 		await Bun.write(path.join(artifactsDir, "artifact.txt"), "payload");
 
-		const stat = storage.readSnapshotSync(transcriptPath).stat;
 		const target: VerifiedSessionDeleteTarget = {
 			sessionsRoot: tempDir,
 			transcriptPath,
@@ -885,29 +889,16 @@ describe("FileSessionStorage.deleteSessionVerified artifact-first", () => {
 			transcriptIdentity: verifiedIdentity(transcriptPath),
 		};
 
-		const partial = await storage.deleteSessionVerified(target);
-		// No false success: this is a typed partial cleanup, never "deleted".
-		expect(partial.kind).toBe("cleanup_pending");
-		if (partial.kind !== "cleanup_pending") throw new Error("unreachable");
-		expect(partial.phase).toBe("artifacts");
-		expect(partial.error).toBeInstanceOf(Error);
-		expect(partial.error.message).toBe("Exact artifact detach retained: cleanup_pending");
-
-		// Exact retry evidence includes the full transcript snapshot and detached artifact path.
-		expect(partial.transcriptIdentity).toMatchObject({ dev: stat.dev, ino: stat.ino });
-		const artifactCleanup = partial as Extract<
-			VerifiedSessionDeleteResult,
-			{ kind: "cleanup_pending"; phase: "artifacts" }
-		>;
-		const recordedArtifactsIdentity = artifactCleanup.artifactsIdentity;
-		expect(recordedArtifactsIdentity).toBeDefined();
+		const receipt = await storage.deleteSessionVerified(target);
+		expect(receipt.kind).toBe("artifacts_removed");
+		if (receipt.kind !== "artifacts_removed") throw new Error("unreachable");
+		expect(receipt.phase).toBe("artifacts");
+		expect(receipt.transcriptIdentity).toEqual(target.transcriptIdentity);
 		expect(fs.existsSync(transcriptPath)).toBe(true);
 		expect(fs.existsSync(artifactsDir)).toBe(false);
-		expect(fs.existsSync(artifactCleanup.detachedArtifactsPath)).toBe(true);
-		expect(artifactCleanup.retainedPlaceholderPath).toEqual(expect.any(String));
 	});
 
-	it("transcript unlink failure after artifact removal returns typed cleanup_pending(transcript) and keeps the transcript", async () => {
+	it("leaves the transcript intact after returning the artifact-phase receipt", async () => {
 		const transcriptPath = await createTranscript("unlink-failure");
 		const artifactsDir = transcriptPath.slice(0, -6);
 		await fsp.mkdir(artifactsDir, { recursive: true });
@@ -921,10 +912,10 @@ describe("FileSessionStorage.deleteSessionVerified artifact-first", () => {
 			transcriptIdentity: verifiedIdentity(transcriptPath),
 		};
 
-		const artifactsPending = await storage.deleteSessionVerified(target);
-		if (artifactsPending.kind !== "cleanup_pending" || artifactsPending.phase !== "artifacts")
-			throw new Error("Expected retained artifact cleanup");
-		expect(artifactsPending.retainedPlaceholderPath).toEqual(expect.any(String));
+		const receipt = await storage.deleteSessionVerified(target);
+		if (receipt.kind !== "artifacts_removed" || receipt.phase !== "artifacts")
+			throw new Error("Expected artifact-phase receipt");
+		expect(receipt.transcriptIdentity).toEqual(target.transcriptIdentity);
 		expect(fs.existsSync(artifactsDir)).toBe(false);
 		expect(fs.existsSync(transcriptPath)).toBe(true);
 	});
@@ -1067,13 +1058,12 @@ describe("FileSessionStorage.deleteSessionVerified artifact-first", () => {
 		expect(fs.existsSync(realTranscript)).toBe(true);
 	});
 
-	it("transcript identity replaced after artifact removal fails closed before unlink", async () => {
+	it("returns an artifact-phase receipt before a transcript retry", async () => {
 		const transcriptPath = await createTranscript("replacement");
 		const artifactsDir = transcriptPath.slice(0, -6);
 		await fsp.mkdir(artifactsDir, { recursive: true });
 		await Bun.write(path.join(artifactsDir, "artifact.txt"), "payload");
 
-		// Capture the real snapshot (and its bound identity) before installing the spy.
 		const realSnapshot = storage.readSnapshotSync(transcriptPath);
 		const target: VerifiedSessionDeleteTarget = {
 			sessionsRoot: tempDir,
@@ -1089,10 +1079,10 @@ describe("FileSessionStorage.deleteSessionVerified artifact-first", () => {
 			},
 		};
 
-		const artifactsPending = await storage.deleteSessionVerified(target);
-		if (artifactsPending.kind !== "cleanup_pending" || artifactsPending.phase !== "artifacts")
-			throw new Error("Expected retained artifact cleanup");
-		expect(artifactsPending.detachedArtifactsPath).toEqual(expect.any(String));
+		const receipt = await storage.deleteSessionVerified(target);
+		if (receipt.kind !== "artifacts_removed" || receipt.phase !== "artifacts")
+			throw new Error("Expected artifact-phase receipt");
+		expect(receipt.transcriptIdentity).toEqual(target.transcriptIdentity);
 		expect(fs.existsSync(artifactsDir)).toBe(false);
 		expect(fs.existsSync(transcriptPath)).toBe(true);
 	});
@@ -1218,7 +1208,7 @@ describe("FileSessionStorage.deleteSessionVerified artifact-first", () => {
 		expect((err as SessionDeleteVerificationError).kind).toBe("cwd");
 		expect(fs.existsSync(transcriptPath)).toBe(true);
 	});
-	it("rejects an in-place transcript append after authorization without unlinking the changed transcript", async () => {
+	it("rejects an in-place transcript append after artifact completion without unlinking the changed transcript", async () => {
 		const transcriptPath = await createTranscript("append-after-authorization");
 		const artifactsDir = transcriptPath.slice(0, -6);
 		await fsp.mkdir(artifactsDir, { recursive: true });
@@ -1231,12 +1221,16 @@ describe("FileSessionStorage.deleteSessionVerified artifact-first", () => {
 			cwd: tempDir,
 			transcriptIdentity: authorizedIdentity,
 		};
-		const artifactsPending = await storage.deleteSessionVerified(target);
-		if (artifactsPending.kind !== "cleanup_pending" || artifactsPending.phase !== "artifacts")
-			throw new Error("Expected retained artifact cleanup");
-		expect(artifactsPending.retainedPlaceholderPath).toEqual(expect.any(String));
-		expect(await fsp.readFile(transcriptPath, "utf8")).not.toContain('"raced"');
+		const receipt = await storage.deleteSessionVerified(target);
+		if (receipt.kind !== "artifacts_removed" || receipt.phase !== "artifacts")
+			throw new Error("Expected artifact-phase receipt");
+		await fsp.appendFile(transcriptPath, `${JSON.stringify({ type: "message", content: "raced" })}\n`);
+
+		const err = await storage.deleteSessionVerified({ ...target, artifactsRemoved: true }).catch(error => error);
+		expect(err).toBeInstanceOf(SessionDeleteVerificationError);
+		expect((err as SessionDeleteVerificationError).kind).toBe("identity");
 		expect(fs.existsSync(artifactsDir)).toBe(false);
+		expect(await fsp.readFile(transcriptPath, "utf8")).toContain('"raced"');
 	});
 
 	it("does not unlink a final-name replacement introduced at the exact-unlink boundary", async () => {

--- a/packages/coding-agent/test/session-storage.test.ts
+++ b/packages/coding-agent/test/session-storage.test.ts
@@ -6,9 +6,12 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as native from "@gajae-code/natives";
 import {
+	acquireManagedLock,
+	captureManagedFileNoFollow,
 	ManagedSessionDescendantStore,
 	managedDirectoryRoot,
 	publishManagedFileNoReplace,
+	replaceManagedFileExactSync,
 	retainManagedDirectoryAuthority,
 	validateNativeSecurityResult,
 } from "../src/session/internal/managed-session-storage";
@@ -230,15 +233,18 @@ describe("native publish outcome classification", () => {
 describe("FileSessionStorage.deleteSessionWithArtifacts", () => {
 	let tempDir: string;
 	let storage: { deleteSessionWithArtifacts(sessionPath: string): Promise<void> };
+	let platformDescriptor: PropertyDescriptor | undefined;
 
 	beforeEach(async () => {
 		tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-session-storage-"));
+		platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
 		const { FileSessionStorage } = await import("../src/session/session-storage");
 		storage = new FileSessionStorage();
 	});
 
 	afterEach(async () => {
 		vi.restoreAllMocks();
+		if (platformDescriptor) Object.defineProperty(process, "platform", platformDescriptor);
 		await fsp.rm(tempDir, { recursive: true, force: true });
 	});
 
@@ -276,6 +282,88 @@ describe("FileSessionStorage.deleteSessionWithArtifacts", () => {
 				}),
 			).rejects.toThrow("migration_busy");
 			expect(fs.existsSync(destination)).toBe(false);
+		});
+	});
+	describe("Windows durable managed replacement", () => {
+		const useWindowsPlatform = (): void => {
+			Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+			vi.spyOn(native, "applyOwnerOnlyFdSecurity").mockReturnValue({ ok: true });
+			vi.spyOn(native, "verifyOwnerOnlyFdSecurity").mockReturnValue({ ok: true });
+			vi.spyOn(native, "applyOwnerOnlyPathSecurity").mockReturnValue({ ok: true });
+			vi.spyOn(native, "verifyOwnerOnlyPathSecurity").mockReturnValue({ ok: true });
+			vi.spyOn(native, "verifyOwnerOnlyPathSecurityExpected").mockReturnValue({ ok: true });
+			vi.spyOn(native, "repairOwnerOnlyPathSecurityExpected").mockReturnValue({ ok: true });
+		};
+
+		it("uses durable replacement for the real managed caller and rejects a stale writer", () => {
+			useWindowsPlatform();
+			const destination = path.join(tempDir, "managed.jsonl");
+			fs.writeFileSync(destination, "authorized\n", { mode: 0o600 });
+			const root = managedDirectoryRoot(tempDir);
+			const durable = vi.spyOn(native, "durableReplacePath").mockImplementation((source, target) => {
+				fs.renameSync(source, target);
+				return {
+					ok: true,
+					mutationState: "committed",
+					durabilityState: "durable",
+					reason: "none",
+					primitive: "move_file_ex_write_through",
+					phase: "complete",
+					diagnostic: { schemaVersion: 1, collectionState: "complete" },
+				} as never;
+			});
+			const store = new ManagedSessionDescendantStore(root, tempDir, undefined, "windows-existing-verify-first");
+			store.replaceSync("managed.jsonl", Buffer.from("replacement\n"));
+			expect(durable).toHaveBeenCalledTimes(1);
+			expect(fs.readFileSync(destination, "utf8")).toBe("replacement\n");
+
+			const stale = captureManagedFileNoFollow(destination);
+			fs.writeFileSync(destination, "successor\n", { mode: 0o600 });
+			expect(() => replaceManagedFileExactSync(destination, Buffer.from("stale\n"), stale, root)).toThrow(
+				"managed_replace_identity_mismatch",
+			);
+			expect(durable).toHaveBeenCalledTimes(1);
+			expect(fs.readFileSync(destination, "utf8")).toBe("successor\n");
+		});
+
+		it("retains staging evidence after an unknown durable replacement outcome", () => {
+			useWindowsPlatform();
+			const destination = path.join(tempDir, "unknown.jsonl");
+			fs.writeFileSync(destination, "authorized\n", { mode: 0o600 });
+			const root = managedDirectoryRoot(tempDir);
+			vi.spyOn(native, "durableReplacePath").mockReturnValue({
+				ok: false,
+				mutationState: "unknown",
+				durabilityState: "not_provable",
+				reason: "unknown",
+				primitive: "move_file_ex_write_through",
+				phase: "rename",
+				diagnostic: { schemaVersion: 1, collectionState: "partial" },
+			} as never);
+			const expected = captureManagedFileNoFollow(destination);
+			expect(() => replaceManagedFileExactSync(destination, Buffer.from("replacement\n"), expected, root)).toThrow(
+				"unknown",
+			);
+			expect(fs.readFileSync(destination, "utf8")).toBe("authorized\n");
+			expect(fs.readdirSync(tempDir).some(name => name.includes(".replacement"))).toBe(true);
+		});
+	});
+
+	describe("managed async lock release", () => {
+		it("releases a normal lock and preserves a successor introduced before release", async () => {
+			const root = managedDirectoryRoot(tempDir);
+			const lock = await acquireManagedLock(tempDir, "release", root);
+			await lock.release();
+			expect(fs.existsSync(lock.path)).toBe(false);
+
+			const raced = await acquireManagedLock(tempDir, "successor", root);
+			const retired = `${raced.path}.${raced.attemptId}.moved`;
+			fs.renameSync(raced.path, retired);
+			fs.writeFileSync(raced.path, `${JSON.stringify({ attemptId: "successor" })}\n`, { mode: 0o600 });
+			await expect(raced.release()).rejects.toThrow("migration_busy");
+			expect(JSON.parse(fs.readFileSync(raced.path, "utf8"))).toEqual({ attemptId: "successor" });
+			fs.unlinkSync(raced.path);
+			fs.unlinkSync(retired);
 		});
 	});
 });

--- a/packages/coding-agent/test/session/session-manager-revisions.test.ts
+++ b/packages/coding-agent/test/session/session-manager-revisions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+	ManagedSessionScopeStartupError,
 	type SessionManagerRevisionSnapshot,
 	toSessionManagerCheckpointRevisionStrings,
 } from "../../src/session/session-manager";
@@ -41,5 +42,49 @@ describe("toSessionManagerCheckpointRevisionStrings", () => {
 				replayMetadata: 4,
 			}),
 		).toThrow("invalid_session_manager_revision:entry");
+	});
+});
+describe("managed session scope startup diagnostics", () => {
+	const failure = (classification: string, diagnostic = "C:\\Users\\alice\\secret\\sessions") => ({
+		kind: "error" as const,
+		code: "binding_invalid" as const,
+		message: "internal failure",
+		cause: { classification, diagnostic },
+	});
+
+	it("maps Windows access-denied failures to safe token and user-owned-directory recovery", () => {
+		const error = new ManagedSessionScopeStartupError("prepare", failure("EACCES"), "win32");
+		expect(error.message).toContain("different token (including Administrator)");
+		expect(error.message).toContain("user-owned");
+		expect(error.message).not.toContain("icacls");
+		expect(error.message).not.toContain("Everyone");
+		expect(new ManagedSessionScopeStartupError("prepare", failure("EPERM"), "win32").message).toBe(error.message);
+	});
+
+	it("maps Windows owner, ACL, and path-identity failures without exposing diagnostics", () => {
+		expect(new ManagedSessionScopeStartupError("prepare", failure("owner_mismatch"), "win32").message).toContain(
+			"owner-only permissions",
+		);
+		expect(new ManagedSessionScopeStartupError("prepare", failure("acl_verify_failed"), "win32").message).toContain(
+			"do not weaken its ACL",
+		);
+		expect(new ManagedSessionScopeStartupError("prepare", failure("reparse_point"), "win32").message).toContain(
+			"junction, symlink, or replaced directory",
+		);
+		expect(new ManagedSessionScopeStartupError("prepare", failure("identity_mismatch"), "win32").message).toContain(
+			"without reparse points",
+		);
+	});
+
+	it("uses a bounded redacted Windows fallback with classification-only public cause", () => {
+		const error = new ManagedSessionScopeStartupError("resolve", failure("unexpected_native_failure"), "win32");
+		expect(error.message).toContain("could not safely verify");
+		expect(error.message).not.toContain("C:\\Users\\alice");
+		expect(error.cause).toEqual({ classification: "unexpected_native_failure" });
+	});
+
+	it("preserves the generic startup message on non-Windows platforms", () => {
+		const error = new ManagedSessionScopeStartupError("resolve", failure("EACCES"), "linux");
+		expect(error.message).toBe("Could not resolve managed session scope.");
 	});
 });

--- a/packages/coding-agent/test/session/session-manager-revisions.test.ts
+++ b/packages/coding-agent/test/session/session-manager-revisions.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "bun:test";
 import {
-	ManagedSessionScopeStartupError,
 	type SessionManagerRevisionSnapshot,
 	toSessionManagerCheckpointRevisionStrings,
 } from "../../src/session/session-manager";
@@ -42,49 +41,5 @@ describe("toSessionManagerCheckpointRevisionStrings", () => {
 				replayMetadata: 4,
 			}),
 		).toThrow("invalid_session_manager_revision:entry");
-	});
-});
-describe("managed session scope startup diagnostics", () => {
-	const failure = (classification: string, diagnostic = "C:\\Users\\alice\\secret\\sessions") => ({
-		kind: "error" as const,
-		code: "binding_invalid" as const,
-		message: "internal failure",
-		cause: { classification, diagnostic },
-	});
-
-	it("maps Windows access-denied failures to safe token and user-owned-directory recovery", () => {
-		const error = new ManagedSessionScopeStartupError("prepare", failure("EACCES"), "win32");
-		expect(error.message).toContain("different token (including Administrator)");
-		expect(error.message).toContain("user-owned");
-		expect(error.message).not.toContain("icacls");
-		expect(error.message).not.toContain("Everyone");
-		expect(new ManagedSessionScopeStartupError("prepare", failure("EPERM"), "win32").message).toBe(error.message);
-	});
-
-	it("maps Windows owner, ACL, and path-identity failures without exposing diagnostics", () => {
-		expect(new ManagedSessionScopeStartupError("prepare", failure("owner_mismatch"), "win32").message).toContain(
-			"owner-only permissions",
-		);
-		expect(new ManagedSessionScopeStartupError("prepare", failure("acl_verify_failed"), "win32").message).toContain(
-			"do not weaken its ACL",
-		);
-		expect(new ManagedSessionScopeStartupError("prepare", failure("reparse_point"), "win32").message).toContain(
-			"junction, symlink, or replaced directory",
-		);
-		expect(new ManagedSessionScopeStartupError("prepare", failure("identity_mismatch"), "win32").message).toContain(
-			"without reparse points",
-		);
-	});
-
-	it("uses a bounded redacted Windows fallback with classification-only public cause", () => {
-		const error = new ManagedSessionScopeStartupError("resolve", failure("unexpected_native_failure"), "win32");
-		expect(error.message).toContain("could not safely verify");
-		expect(error.message).not.toContain("C:\\Users\\alice");
-		expect(error.cause).toEqual({ classification: "unexpected_native_failure" });
-	});
-
-	it("preserves the generic startup message on non-Windows platforms", () => {
-		const error = new ManagedSessionScopeStartupError("resolve", failure("EACCES"), "linux");
-		expect(error.message).toBe("Could not resolve managed session scope.");
 	});
 });

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [0.12.0] - 2026-07-28
 ### Fixed
 
+- Windows managed-path security mutation and exact unlink/restore now bind to caller file handles and stable file identity, rejecting pathname substitution. Durable pathname replacement separately uses write-through replacement and reports typed mutation/durability uncertainty.
 - Native addon builds now prepend the active `rustup` toolchain's Cargo directory before invoking `napi`, so non-interactive shells without `~/.cargo/bin` on `PATH` no longer fail with opaque `cargo metadata failed to run` errors.
 - Retained managed session publication no longer fails closed on filesystems that do not implement `renameat2` rename flags (NFS and some FUSE/overlay mounts reject them with `EINVAL`; kernels older than 3.15 answer `ENOSYS`), which crashed every launch with a session store on an NFS home directory (`Could not prepare managed session scope: … durability_failed`). The no-replace **file** publish paths (binding, receipt/install, and tombstone) now fall back to an atomic `linkat(2)` create — which fails with `EEXIST` when the destination already exists — so the no-overwrite guarantee is preserved rather than weakened, and the staging link is unlinked so the published file stays single-linked. Directory/tree no-replace still requires kernel `renameat2` flag support.
 

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -813,6 +813,12 @@ export declare function detectMacOSAppearance(): MacOSAppearance | null
  */
 export declare function diffLines(oldStr: string, newStr: string): Array<LineDiffPart>
 
+/**
+ * Replace a staged file using Windows `MoveFileExW` with `REPLACE_EXISTING`
+ * and `WRITE_THROUGH`. The staged file's bytes must already have been flushed.
+ */
+export declare function durableReplacePath(sourcePath: string, destinationPath: string): NativeDurableReplaceResult
+
 /** Ellipsis strategy for [`truncate_to_width`]. */
 export declare enum Ellipsis {
   /** Use a single Unicode ellipsis character ("…"). */
@@ -1690,6 +1696,18 @@ export interface NativeDirectoryTreeSnapshot {
   entries: Array<NativeDirectoryTreeEntry>
 }
 
+/** Result of a Windows write-through replacement. */
+export interface NativeDurableReplaceResult {
+  ok: boolean
+  code?: string
+  osCode?: number
+  mutationState: string
+  durabilityState: string
+  reason: string
+  primitive: string
+  phase: string
+}
+
 /**
  * Caller-supplied identity and preauthorized quarantine evidence for exact
  * deletion.
@@ -1726,6 +1744,10 @@ export interface NativeExactFileIdentity {
 export interface NativeExactUnlinkResult {
   ok: boolean
   code?: string
+  /**
+   * On Windows this is returned in the caller's namespace; retained handle
+   * operations continue to use the volume-GUID canonical path internally.
+   */
   detachedPath?: string
   retainedSuccessorPath?: string
   /**

--- a/packages/natives/native/index.js
+++ b/packages/natives/native/index.js
@@ -41,6 +41,7 @@ export const computerScreenshot = nativeBindings.computerScreenshot;
 export const copyToClipboard = nativeBindings.copyToClipboard;
 export const detectMacOSAppearance = nativeBindings.detectMacOSAppearance;
 export const diffLines = nativeBindings.diffLines;
+export const durableReplacePath = nativeBindings.durableReplacePath;
 export const encodeSixel = nativeBindings.encodeSixel;
 export const exactRemoveDirectoryTree = nativeBindings.exactRemoveDirectoryTree;
 export const exactRestore = nativeBindings.exactRestore;

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -421,6 +421,9 @@ export function validateLoadedBindings(ctx, bindings, candidate) {
 	if (typeof bindings.probeWindowsJobMemory !== "function") {
 		throw new Error(`Loaded ${candidate} but it lacks required memory probe capability \`probeWindowsJobMemory\`.`);
 	}
+	if (typeof bindings.durableReplacePath !== "function") {
+		throw new Error(`Loaded ${candidate} but it lacks required durable replacement capability \`durableReplacePath\`.`);
+	}
 }
 
 function buildHelpMessage(ctx) {

--- a/packages/natives/scripts/build-native.ts
+++ b/packages/natives/scripts/build-native.ts
@@ -183,6 +183,7 @@ const requiredGeneratedBindingSymbols = [
 	"repairOwnerOnlyPathSecurityExpected",
 	"verifyOwnerOnlyPathSecurityExpected",
 	"probeWindowsJobMemory",
+	"durableReplacePath",
 ] as const;
 
 export function validateGeneratedBindingSource(bindings: string): void {
@@ -253,7 +254,7 @@ console.log(`Building pi-natives for ${targetPlatform}-${targetArch}${variantSuf
 // Resolve napi bin directly: `bunx @napi-rs/cli` can pick up the wrong bin on
 // systems where `cli` exists on PATH (e.g. Mono's /usr/bin/cli on Ubuntu).
 const napiBin = Bun.which("napi", {
-	PATH: `${path.join(import.meta.dir, "..", "node_modules", ".bin")}:${path.join(repoRoot, "node_modules", ".bin")}:${process.env.PATH ?? ""}`,
+	PATH: `${path.join(import.meta.dir, "..", "node_modules", ".bin")}${path.delimiter}${path.join(repoRoot, "node_modules", ".bin")}${path.delimiter}${process.env.PATH ?? ""}`,
 });
 if (!napiBin) {
 	throw new Error("Could not locate @napi-rs/cli `napi` binary in node_modules/.bin");

--- a/packages/natives/test/path-identity-windows.test.ts
+++ b/packages/natives/test/path-identity-windows.test.ts
@@ -4,7 +4,6 @@ import { closeSync, fstatSync, openSync } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-
 import {
 	applyOwnerOnlyFdSecurity,
 	applyOwnerOnlyPathSecurity,
@@ -20,6 +19,7 @@ import {
 	verifyOwnerOnlyPathSecurity,
 	verifyOwnerOnlyPathSecurityExpected,
 } from "../native/index.js";
+import { loadNative } from "../native/loader-state.js";
 
 const temporaryDirectories: string[] = [];
 
@@ -48,6 +48,33 @@ afterEach(async () => {
 	await Promise.all(
 		temporaryDirectories.splice(0).map(directory => fs.rm(directory, { recursive: true, force: true })),
 	);
+});
+describe("native addon capability validation", () => {
+	it("skips a same-version stale addon missing durableReplacePath", () => {
+		const context = {
+			isCompiledBinary: false,
+			platformTag: "win32-x64",
+			packageVersion: "current",
+			versionSentinelExport: "__piNativesVCurrent",
+			candidates: ["stale.node", "fresh.node"],
+		};
+		const compatible = {
+			__piNativesVCurrent() {},
+			__piNativesPublishOutcomeV1() {},
+			renameNoReplacePath() {},
+			probeWindowsJobMemory() {},
+			durableReplacePath() {},
+		};
+		const loaded = loadNative({
+			context,
+			extractEmbeddedAddons: () => [],
+			stageNodeModulesAddon: () => null,
+			requireCandidate: candidate =>
+				candidate === "stale.node" ? { ...compatible, durableReplacePath: undefined } : compatible,
+		});
+
+		expect(loaded).toBe(compatible);
+	});
 });
 
 describe.skipIf(process.platform !== "win32")("Windows native path identity", () => {
@@ -165,6 +192,21 @@ describe.skipIf(process.platform !== "win32")("Windows native path identity", ()
 			mutationState: "not_committed",
 		});
 		expect(await fs.readFile(destination, "utf8")).toBe("old");
+	});
+	it("retains an ambiguous post-mutation durable replacement outcome", async () => {
+		const root = await temporaryDirectory();
+		const source = path.join(root, "staged-directory");
+		const destination = path.join(root, "current-directory");
+		await fs.mkdir(source);
+		await fs.writeFile(path.join(source, "state.json"), "new");
+
+		expect(durableReplacePath(source, destination)).toMatchObject({
+			ok: false,
+			mutationState: "unknown",
+			durabilityState: "not_provable",
+			reason: "destination_verification_failed",
+		});
+		expect(await fs.readFile(path.join(destination, "state.json"), "utf8")).toBe("new");
 	});
 	it("smokes caller-fd security with fs.openSync and rejects arbitrary fds without terminating", async () => {
 		const root = await temporaryDirectory();

--- a/packages/natives/test/path-identity-windows.test.ts
+++ b/packages/natives/test/path-identity-windows.test.ts
@@ -1,18 +1,22 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { createHash } from "node:crypto";
+import { closeSync, fstatSync, openSync } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 
 import {
+	applyOwnerOnlyFdSecurity,
 	applyOwnerOnlyPathSecurity,
 	canonicalExistingDirectoryIdentity,
+	durableReplacePath,
 	exactRemoveDirectoryTree,
 	exactRestore,
 	exactUnlink,
 	renameNoReplacePath,
 	repairOwnerOnlyPathSecurityExpected,
 	snapshotDirectoryTree,
+	verifyOwnerOnlyFdSecurity,
 	verifyOwnerOnlyPathSecurity,
 	verifyOwnerOnlyPathSecurityExpected,
 } from "../native/index.js";
@@ -122,13 +126,118 @@ describe.skipIf(process.platform !== "win32")("Windows native path identity", ()
 		await fs.mkdir(directory);
 		await fs.writeFile(file, contents);
 
-		expect(verifyOwnerOnlyPathSecurity(directory, "directory")).toEqual({ ok: false, code: "acl_verify_failed" });
-		expect(verifyOwnerOnlyPathSecurity(file, "file")).toEqual({ ok: false, code: "acl_verify_failed" });
+		expect(verifyOwnerOnlyPathSecurity(directory, "directory")).toEqual({ ok: false, code: "owner_mismatch" });
+		expect(verifyOwnerOnlyPathSecurity(file, "file")).toEqual({ ok: false, code: "owner_mismatch" });
 		expect(applyOwnerOnlyPathSecurity(directory, "directory")).toEqual({ ok: true });
 		expect(applyOwnerOnlyPathSecurity(file, "file")).toEqual({ ok: true });
 		expect(verifyOwnerOnlyPathSecurity(directory, "directory")).toEqual({ ok: true });
 		expect(verifyOwnerOnlyPathSecurity(file, "file")).toEqual({ ok: true });
 		expect(await fs.readFile(file, "utf8")).toBe(contents);
+	});
+	it("durably replaces a Windows destination with staged bytes", async () => {
+		const root = await temporaryDirectory();
+		const source = path.join(root, "staged.json");
+		const destination = path.join(root, "current.json");
+		await fs.writeFile(source, "new");
+		await fs.writeFile(destination, "old");
+
+		expect(durableReplacePath(source, destination)).toMatchObject({
+			ok: true,
+			mutationState: "committed",
+			durabilityState: "durable",
+		});
+		expect(await fs.readFile(destination, "utf8")).toBe("new");
+		expect(
+			await fs.stat(source).then(
+				() => true,
+				() => false,
+			),
+		).toBe(false);
+	});
+	it("preserves an existing destination when durable replacement fails", async () => {
+		const root = await temporaryDirectory();
+		const source = path.join(root, "missing-staged.json");
+		const destination = path.join(root, "current.json");
+		await fs.writeFile(destination, "old");
+
+		expect(durableReplacePath(source, destination)).toMatchObject({
+			ok: false,
+			mutationState: "not_committed",
+		});
+		expect(await fs.readFile(destination, "utf8")).toBe("old");
+	});
+	it("smokes caller-fd security with fs.openSync and rejects arbitrary fds without terminating", async () => {
+		const root = await temporaryDirectory();
+		const file = path.join(root, "caller-fd.json");
+		await fs.writeFile(file, "preserve");
+		const fd = openSync(file, "r+");
+		try {
+			expect(applyOwnerOnlyFdSecurity(file, "file", fd)).toEqual({ ok: true });
+			expect(verifyOwnerOnlyFdSecurity(file, "file", fd)).toEqual({ ok: true });
+			expect(fstatSync(fd).isFile()).toBe(true);
+			expect(await fs.readFile(file, "utf8")).toBe("preserve");
+			expect(verifyOwnerOnlyFdSecurity(file, "file", 2_147_483_647)).toEqual({
+				ok: false,
+				code: "identity_unavailable",
+			});
+		} finally {
+			closeSync(fd);
+		}
+	});
+
+	it("fails closed when the pathname is replaced after opening the caller fd", async () => {
+		const root = await temporaryDirectory();
+		const file = path.join(root, "caller-fd.json");
+		const retained = path.join(root, "retained.json");
+		await fs.writeFile(file, "authorized");
+		const fd = openSync(file, "r+");
+		try {
+			await fs.rename(file, retained);
+			await fs.writeFile(file, "replacement");
+			expect(applyOwnerOnlyFdSecurity(file, "file", fd)).toEqual({
+				ok: false,
+				code: "identity_mismatch",
+			});
+			expect(verifyOwnerOnlyFdSecurity(file, "file", fd)).toEqual({
+				ok: false,
+				code: "identity_mismatch",
+			});
+			expect(await fs.readFile(file, "utf8")).toBe("replacement");
+			expect(await fs.readFile(retained, "utf8")).toBe("authorized");
+		} finally {
+			closeSync(fd);
+		}
+	});
+
+	it("rejects mismatched and reused caller fds without mutating the pathname", async () => {
+		const root = await temporaryDirectory();
+		const file = path.join(root, "caller-fd.json");
+		const other = path.join(root, "other.json");
+		await fs.writeFile(file, "authorized");
+		await fs.writeFile(other, "other");
+		const mismatch = openSync(other, "r+");
+		try {
+			expect(applyOwnerOnlyFdSecurity(file, "file", mismatch)).toEqual({
+				ok: false,
+				code: "identity_mismatch",
+			});
+		} finally {
+			closeSync(mismatch);
+		}
+
+		const stale = openSync(file, "r+");
+		closeSync(stale);
+		const reused = openSync(other, "r+");
+		try {
+			expect(reused).toBe(stale);
+			expect(verifyOwnerOnlyFdSecurity(file, "file", stale)).toEqual({
+				ok: false,
+				code: "identity_mismatch",
+			});
+			expect(await fs.readFile(file, "utf8")).toBe("authorized");
+		} finally {
+			closeSync(reused);
+		}
 	});
 	it("repairs a legacy inherited ACL only for the captured directory and file identities", async () => {
 		const root = await temporaryDirectory();
@@ -140,8 +249,8 @@ describe.skipIf(process.platform !== "win32")("Windows native path identity", ()
 		const directoryStat = await fs.stat(directory, { bigint: true });
 		const fileStat = await fs.stat(file, { bigint: true });
 
-		expect(verifyOwnerOnlyPathSecurity(directory, "directory")).toEqual({ ok: false, code: "acl_verify_failed" });
-		expect(verifyOwnerOnlyPathSecurity(file, "file")).toEqual({ ok: false, code: "acl_verify_failed" });
+		expect(verifyOwnerOnlyPathSecurity(directory, "directory")).toEqual({ ok: false, code: "owner_mismatch" });
+		expect(verifyOwnerOnlyPathSecurity(file, "file")).toEqual({ ok: false, code: "owner_mismatch" });
 		expect(repairOwnerOnlyPathSecurityExpected(file, "directory", fileStat.dev, fileStat.ino)).toMatchObject({
 			ok: false,
 		});
@@ -169,7 +278,7 @@ describe.skipIf(process.platform !== "win32")("Windows native path identity", ()
 			ok: false,
 			code: "identity_mismatch",
 		});
-		expect(verifyOwnerOnlyPathSecurity(target, "file")).toEqual({ ok: false, code: "acl_verify_failed" });
+		expect(verifyOwnerOnlyPathSecurity(target, "file")).toEqual({ ok: false, code: "owner_mismatch" });
 		expect(await fs.readFile(target, "utf8")).toBe("replacement");
 		expect(await fs.readFile(retained, "utf8")).toBe("authorized");
 	});


### PR DESCRIPTION
## What

- harden managed-session filesystem checks around owner, reparse, and exact path identity
- verify destructive Windows writes through descriptor-backed identity checks
- expose bounded, path-redacted startup classifications without weakening ACL enforcement
- add native Windows path-identity support and focused regression coverage

## Why

Managed session state is authority-bearing. Windows path substitution, reparse points, and unbounded native diagnostics must fail closed without suggesting unsafe ownership or ACL changes.

## Testing

- `bun --cwd=packages/coding-agent run check`
- focused storage/native suites: **91 passed, 8 platform-skipped, 0 failed, 323 expectations**
- `git diff --check`

## Checklist

- [x] Targets `dev`
- [x] Package checks pass
- [x] Observable behavior is covered by focused tests
- [x] Changelog entries included
- [x] Branch rebased onto current canonical `dev`
