### PR TITLE
fix(tui): prevent absolute-path autocomplete OOM

### DIFF
--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -414,11 +414,16 @@ export class CustomEditor extends Editor {
 		// Default behavior keeps autocomplete dismissal, but parent can prioritize global interrupt handling.
 		if (this.#matchesAction(data, "app.interrupt")) {
 			if (!this.isShowingAutocomplete() || this.shouldBypassAutocompleteOnEscape?.()) {
+				const cancelledHiddenPendingAutocomplete =
+					!this.isShowingAutocomplete() && this.cancelPendingAutocompleteWork();
 				// A priority interrupt consumer (e.g. an open btw panel) must win over any
 				// transient onEscape handler other controllers install (auto-compaction,
 				// auto-retry, manual compaction, etc.) so dismissal stays wired regardless
 				// of which handler currently owns onEscape.
 				if (this.onInterruptPriority?.()) {
+					return;
+				}
+				if (cancelledHiddenPendingAutocomplete) {
 					return;
 				}
 				if (this.onEscape) {

--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -207,6 +207,7 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 		lines: string[],
 		cursorLine: number,
 		cursorCol: number,
+		signal?: AbortSignal,
 	): Promise<{ items: AutocompleteItem[]; prefix: string } | null> {
 		const currentLine = lines[cursorLine] || "";
 		const textBeforeCursor = currentLine.slice(0, cursorCol);
@@ -239,7 +240,7 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 		const slashPrefix = getSlashTokenPrefix(textBeforeCursor);
 		if (slashPrefix) {
 			const baseSuggestions = withoutSkillCommandSuggestions(
-				await this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol),
+				await this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol, signal),
 			);
 			if (isRootPathSuggestionResult(baseSuggestions)) return baseSuggestions;
 			const skillCommandSuggestions = this.#getSkillCommandSuggestions(textBeforeCursor, {
@@ -256,14 +257,15 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 			if (emojiSuggestions) return emojiSuggestions;
 		}
 
-		return this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol);
+		return this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol, signal);
 	}
 	getForceFileSuggestions(
 		lines: string[],
 		cursorLine: number,
 		cursorCol: number,
+		signal?: AbortSignal,
 	): Promise<{ items: AutocompleteItem[]; prefix: string } | null> {
-		return this.#baseProvider.getForceFileSuggestions(lines, cursorLine, cursorCol);
+		return this.#baseProvider.getForceFileSuggestions(lines, cursorLine, cursorCol, signal);
 	}
 
 	applyCompletion(

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -312,6 +312,91 @@ describe("CustomEditor pasteImage default sourced from KEYBINDINGS", () => {
 });
 
 describe("CustomEditor bracketed paste interception", () => {
+	it("cancels a hidden pending autocomplete request before dispatching interrupt escape handlers", async () => {
+		const editor = createEditor();
+		const onEscape = vi.fn();
+		const requestStarted = Promise.withResolvers<AbortSignal>();
+		editor.onEscape = onEscape;
+		editor.setAutocompleteProvider({
+			async getSuggestions(_lines, _cursorLine, _cursorCol, signal) {
+				if (!signal) throw new Error("expected autocomplete cancellation signal");
+				requestStarted.resolve(signal);
+				const pending = Promise.withResolvers<never>();
+				signal.addEventListener("abort", () => pending.reject(signal.reason), { once: true });
+				return pending.promise;
+			},
+			applyCompletion(lines, cursorLine, cursorCol) {
+				return { lines, cursorLine, cursorCol };
+			},
+		} satisfies AutocompleteProvider);
+
+		editor.handleInput("@");
+		const signal = await requestStarted.promise;
+
+		try {
+			expect(editor.isShowingAutocomplete()).toBe(false);
+
+			editor.handleInput("\x1b");
+
+			expect(signal.aborted).toBe(true);
+			expect(onEscape).not.toHaveBeenCalled();
+			expect(editor.isShowingAutocomplete()).toBe(false);
+		} finally {
+			editor.handleInput("\x1b");
+			await Bun.sleep(0);
+		}
+	});
+
+	it("aborts hidden pending autocomplete before a priority interrupt consumer and ignores late results", async () => {
+		const editor = createEditor();
+		const onEscape = vi.fn();
+		const onInterruptPriority = vi.fn(() => true);
+		const requestStarted = Promise.withResolvers<AbortSignal>();
+		const pending = Promise.withResolvers<{
+			items: Array<{ label: string; value: string }>;
+			prefix: string;
+		} | null>();
+		const onAutocompleteUpdate = vi.fn();
+		editor.onEscape = onEscape;
+		editor.onInterruptPriority = onInterruptPriority;
+		editor.onAutocompleteUpdate = onAutocompleteUpdate;
+		editor.setAutocompleteProvider({
+			async getSuggestions(_lines, _cursorLine, _cursorCol, signal) {
+				if (!signal) throw new Error("expected autocomplete cancellation signal");
+				requestStarted.resolve(signal);
+				return pending.promise;
+			},
+			applyCompletion(lines, cursorLine, cursorCol) {
+				return { lines, cursorLine, cursorCol };
+			},
+		} satisfies AutocompleteProvider);
+
+		editor.handleInput("@");
+		const signal = await requestStarted.promise;
+
+		try {
+			expect(editor.isShowingAutocomplete()).toBe(false);
+
+			editor.handleInput("\x1b");
+
+			expect(signal.aborted).toBe(true);
+			expect(onInterruptPriority).toHaveBeenCalledTimes(1);
+			expect(onEscape).not.toHaveBeenCalled();
+			expect(editor.isShowingAutocomplete()).toBe(false);
+			expect(editor.isAutocompleteOpen()).toBe(false);
+
+			pending.resolve({ items: [{ label: "src/", value: "src/" }], prefix: "@" });
+			await Bun.sleep(0);
+
+			expect(onAutocompleteUpdate).not.toHaveBeenCalled();
+			expect(editor.isShowingAutocomplete()).toBe(false);
+			expect(editor.isAutocompleteOpen()).toBe(false);
+		} finally {
+			editor.handleInput("\x1b");
+			await Bun.sleep(0);
+		}
+	});
+
 	it("does not retain a standalone Escape as a possible paste prefix", () => {
 		const editor = createEditor();
 		const onEscape = vi.fn();

--- a/packages/coding-agent/test/prompt-action-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-autocomplete.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import type { SlashCommand } from "@gajae-code/tui";
 import { Editor } from "@gajae-code/tui/components/editor";
 import { defaultEditorTheme } from "../../tui/test/test-themes";
@@ -6,10 +9,10 @@ import { KeybindingsManager as AppKeybindingsManager } from "../src/config/keybi
 import { createPromptActionAutocompleteProvider } from "../src/modes/prompt-action-autocomplete";
 
 describe("prompt action autocomplete", () => {
-	function createNoopProvider(commands: SlashCommand[] = []) {
+	function createNoopProvider(commands: SlashCommand[] = [], basePath = "/tmp") {
 		return createPromptActionAutocompleteProvider({
 			commands,
-			basePath: "/tmp",
+			basePath,
 			keybindings: AppKeybindingsManager.inMemory(),
 			copyCurrentLine: () => {},
 			copyPrompt: () => {},
@@ -205,6 +208,26 @@ describe("prompt action autocomplete", () => {
 		expect(suggestions?.prefix).toBe("/");
 		expect(suggestions?.items.some(item => item.value.startsWith("/"))).toBe(true);
 		expect(suggestions?.items.map(item => item.value)).not.toContain("model");
+	});
+
+	it("forwards cancellation to the underlying file discovery provider", async () => {
+		const basePath = fs.mkdtempSync(path.join(os.tmpdir(), "prompt-action-autocomplete-cancel-"));
+		try {
+			fs.mkdirSync(path.join(basePath, "nested"), { recursive: true });
+			fs.writeFileSync(path.join(basePath, "nested", "signal-target.txt"), "nested\n");
+			fs.writeFileSync(path.join(basePath, "signaltarget-local.txt"), "fallback\n");
+			const provider = createNoopProvider([], basePath);
+			const line = "@signaltarget";
+
+			const activeResult = await provider.getSuggestions([line], 0, line.length);
+			expect(activeResult?.items.some(item => item.value.includes("signal-target.txt"))).toBe(true);
+
+			const controller = new AbortController();
+			controller.abort();
+			expect(await provider.getSuggestions([line], 0, line.length, controller.signal)).toBeNull();
+		} finally {
+			fs.rmSync(basePath, { recursive: true, force: true });
+		}
 	});
 
 	it("opens the composer autocomplete list from an adjacent inline slash", async () => {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- File mention autocomplete now cancels superseded searches and completes absolute or home-relative paths one directory segment at a time, preventing broad recursive scans from exhausting memory while typing `@` paths.
+- File mention autocomplete now cancels superseded searches, keeps absolute/home `@` lookups and ancestor-escaping relative mentions on a bounded one-directory-segment path, and preserves literal absolute/home `Tab` paths while leaving forced `Tab` completion as the exhaustive immediate-directory escape hatch. Natural bounded lookup now inspects at most 100 immediate entries and exposes at most 20 suggestions, while explicit `Tab` remains exhaustive. This prevents broad recursive scans for those mention forms from exhausting memory without truncating explicit `Tab` completion.
 
 ## [0.12.0] - 2026-07-28
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- File mention autocomplete now cancels superseded searches and completes absolute or home-relative paths one directory segment at a time, preventing broad recursive scans from exhausting memory while typing `@` paths.
+
 ## [0.12.0] - 2026-07-28
 
 ### Changed

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fuzzyFind } from "@gajae-code/natives";
-import { getProjectDir } from "@gajae-code/utils";
+import { getProjectDir, untilAborted } from "@gajae-code/utils";
 
 const PATH_DELIMITERS = new Set([" ", "\t", '"', "'", "="]);
 
@@ -267,6 +267,7 @@ export interface AutocompleteProvider {
 		lines: string[],
 		cursorLine: number,
 		cursorCol: number,
+		signal?: AbortSignal,
 	): Promise<{
 		items: AutocompleteItem[];
 		prefix: string; // What we're matching against (e.g., "/" or "src/")
@@ -288,6 +289,12 @@ export interface AutocompleteProvider {
 
 	/** Get inline hint text to show as dim ghost text after the cursor */
 	getInlineHint?(lines: string[], cursorLine: number, cursorCol: number): string | null;
+	getForceFileSuggestions?(
+		lines: string[],
+		cursorLine: number,
+		cursorCol: number,
+		signal?: AbortSignal,
+	): Promise<{ items: AutocompleteItem[]; prefix: string } | null>;
 	/** Synchronously try to complete a slash command at the start of a line (no async I/O). */
 	/** Returns matched items and the full prefix, or null if not applicable. */
 	trySyncSlashCompletion?(textBeforeCursor: string): { items: AutocompleteItem[]; prefix: string } | null;
@@ -306,15 +313,21 @@ export interface AutocompleteProvider {
 export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	#commands: (SlashCommand | AutocompleteItem)[];
 	#basePath: string;
+	#homePath: string;
 	// Intentionally separate from pi-natives cache: this cache is a local,
 	// per-directory readdir fast-path for prefix completions. Global fuzzy
 	// discovery continues to use native fuzzyFind + shared scan cache.
 	#dirCache: Map<string, { entries: fs.Dirent[]; timestamp: number }> = new Map();
 	readonly #DIR_CACHE_TTL = 2000; // 2 seconds
 
-	constructor(commands: (SlashCommand | AutocompleteItem)[] = [], basePath: string = getProjectDir()) {
+	constructor(
+		commands: (SlashCommand | AutocompleteItem)[] = [],
+		basePath: string = getProjectDir(),
+		homePath: string = os.homedir(),
+	) {
 		this.#commands = commands;
 		this.#basePath = basePath;
+		this.#homePath = homePath;
 	}
 
 	#getCommandName(cmd: SlashCommand | AutocompleteItem): string {
@@ -381,6 +394,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		lines: string[],
 		cursorLine: number,
 		cursorCol: number,
+		signal?: AbortSignal,
 	): Promise<{ items: AutocompleteItem[]; prefix: string } | null> {
 		const currentLine = lines[cursorLine] || "";
 		const textBeforeCursor = currentLine.slice(0, cursorCol);
@@ -388,13 +402,16 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		// Check for @ file reference (fuzzy search) - must be after a delimiter or at start
 		const atPrefix = this.#extractAtPrefix(textBeforeCursor);
 		if (atPrefix) {
+			if (signal?.aborted) return null;
 			const { rawPrefix, isQuotedPrefix } = parsePathPrefix(atPrefix);
+			const usesBoundedPathCompletion = this.#isAbsoluteOrHomePrefix(rawPrefix);
 			const suggestions =
-				rawPrefix.length > 0
-					? await this.#getFuzzyFileSuggestions(rawPrefix, { isQuotedPrefix })
-					: await this.#getFileSuggestions("@");
-			if (suggestions.length === 0 && rawPrefix.length > 0) {
-				const fallback = await this.#getFileSuggestions(atPrefix);
+				rawPrefix.length > 0 && !usesBoundedPathCompletion
+					? await this.#getFuzzyFileSuggestions(rawPrefix, { isQuotedPrefix }, signal)
+					: await this.#getFileSuggestions(atPrefix, signal, { fuzzy: usesBoundedPathCompletion });
+			if (signal?.aborted) return null;
+			if (suggestions.length === 0 && rawPrefix.length > 0 && !usesBoundedPathCompletion) {
+				const fallback = await this.#getFileSuggestions(atPrefix, signal);
 				if (fallback.length === 0) return null;
 				return { items: fallback, prefix: atPrefix };
 			}
@@ -448,7 +465,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const slashPrefix = this.#extractSlashCommandPrefix(textBeforeCursor);
 		if (slashPrefix) {
 			if (pathMatch === slashPrefix && slashPrefix.startsWith("/")) {
-				pathSuggestions = await this.#getFileSuggestions(pathMatch);
+				pathSuggestions = await this.#getFileSuggestions(pathMatch, signal);
 				if (pathSuggestions.length > 0) {
 					return {
 						items: pathSuggestions,
@@ -468,7 +485,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 
 		// Check for file paths - triggered by Tab or if we detect a path pattern
 		if (pathMatch !== null) {
-			const suggestions = pathSuggestions ?? (await this.#getFileSuggestions(pathMatch));
+			const suggestions = pathSuggestions ?? (await this.#getFileSuggestions(pathMatch, signal));
 			if (suggestions.length === 0) return null;
 
 			// Check if we have an exact match that is a directory
@@ -525,14 +542,15 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		// Check if we're completing a file attachment (prefix starts with "@")
 		if (prefix.startsWith("@")) {
 			// This is a file attachment completion
-			const newLine = `${beforePrefix + item.value} ${afterCursor}`;
+			const suffix = item.value.endsWith("/") ? "" : " ";
+			const newLine = beforePrefix + item.value + suffix + afterCursor;
 			const newLines = [...lines];
 			newLines[cursorLine] = newLine;
 
 			return {
 				lines: newLines,
 				cursorLine,
-				cursorCol: beforePrefix.length + item.value.length + 1, // +1 for space
+				cursorCol: beforePrefix.length + item.value.length + suffix.length,
 			};
 		}
 
@@ -612,21 +630,27 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		return null;
 	}
 
+	#isAbsoluteOrHomePrefix(prefix: string): boolean {
+		return path.isAbsolute(prefix) || prefix === "~" || prefix.startsWith("~/");
+	}
+
 	// Expand home directory (~/) to actual home path
 	#expandHomePath(filePath: string): string {
 		if (filePath.startsWith("~/")) {
-			const expandedPath = path.join(os.homedir(), filePath.slice(2));
+			const expandedPath = path.join(this.#homePath, filePath.slice(2));
 			// Preserve trailing slash if original path had one
 			return filePath.endsWith("/") && !expandedPath.endsWith("/") ? `${expandedPath}/` : expandedPath;
 		} else if (filePath === "~") {
-			return os.homedir();
+			return this.#homePath;
 		}
 		return filePath;
 	}
 
 	async #resolveScopedFuzzyQuery(
 		rawQuery: string,
+		signal?: AbortSignal,
 	): Promise<{ baseDir: string; query: string; displayBase: string } | null> {
+		signal?.throwIfAborted();
 		const slashIndex = rawQuery.lastIndexOf("/");
 		if (slashIndex === -1) {
 			return null;
@@ -645,10 +669,11 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		}
 
 		try {
-			if (!(await fs.promises.stat(baseDir)).isDirectory()) {
+			if (!(await untilAborted(signal, fs.promises.stat(baseDir))).isDirectory()) {
 				return null;
 			}
 		} catch {
+			signal?.throwIfAborted();
 			return null;
 		}
 
@@ -662,7 +687,8 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		return `${displayBase}${relativePath}`;
 	}
 
-	async #getCachedDirEntries(searchDir: string): Promise<fs.Dirent[]> {
+	async #getCachedDirEntries(searchDir: string, signal?: AbortSignal): Promise<fs.Dirent[]> {
+		signal?.throwIfAborted();
 		const now = Date.now();
 		const cached = this.#dirCache.get(searchDir);
 
@@ -670,7 +696,8 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			return cached.entries;
 		}
 
-		const entries = await fs.promises.readdir(searchDir, { withFileTypes: true });
+		const entries = await untilAborted(signal, fs.promises.readdir(searchDir, { withFileTypes: true }));
+		signal?.throwIfAborted();
 		this.#dirCache.set(searchDir, { entries, timestamp: now });
 
 		if (this.#dirCache.size > 100) {
@@ -695,8 +722,13 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	}
 
 	// Get file/directory suggestions for a given path prefix
-	async #getFileSuggestions(prefix: string): Promise<AutocompleteItem[]> {
+	async #getFileSuggestions(
+		prefix: string,
+		signal?: AbortSignal,
+		options?: { fuzzy?: boolean },
+	): Promise<AutocompleteItem[]> {
 		try {
+			signal?.throwIfAborted();
 			let searchDir: string;
 			let searchPrefix: string;
 			const { rawPrefix, isAtPrefix, isQuotedPrefix } = parsePathPrefix(prefix);
@@ -706,6 +738,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			if (expandedPrefix.startsWith("~")) {
 				expandedPrefix = this.#expandHomePath(expandedPrefix);
 			}
+			const isExpandedAbsolute = path.isAbsolute(expandedPrefix);
 
 			const isRootPrefix =
 				rawPrefix === "" ||
@@ -718,15 +751,15 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 
 			if (isRootPrefix) {
 				// Complete from specified position
-				if (rawPrefix.startsWith("~") || expandedPrefix.startsWith("/")) {
+				if (rawPrefix.startsWith("~") || isExpandedAbsolute) {
 					searchDir = expandedPrefix;
 				} else {
 					searchDir = path.join(this.#basePath, expandedPrefix);
 				}
 				searchPrefix = "";
-			} else if (rawPrefix.endsWith("/")) {
+			} else if (/[\\/]$/.test(rawPrefix)) {
 				// If prefix ends with /, show contents of that directory
-				if (rawPrefix.startsWith("~") || expandedPrefix.startsWith("/")) {
+				if (rawPrefix.startsWith("~") || isExpandedAbsolute) {
 					searchDir = expandedPrefix;
 				} else {
 					searchDir = path.join(this.#basePath, expandedPrefix);
@@ -736,7 +769,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				// Split into directory and file prefix
 				const dir = path.dirname(expandedPrefix);
 				const file = path.basename(expandedPrefix);
-				if (rawPrefix.startsWith("~") || expandedPrefix.startsWith("/")) {
+				if (rawPrefix.startsWith("~") || isExpandedAbsolute) {
 					searchDir = dir;
 				} else {
 					searchDir = path.join(this.#basePath, dir);
@@ -744,11 +777,19 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				searchPrefix = file;
 			}
 
-			const entries = await this.#getCachedDirEntries(searchDir);
-			const suggestions: AutocompleteItem[] = [];
+			const entries = await this.#getCachedDirEntries(searchDir, signal);
+			const suggestions: Array<AutocompleteItem & { matchScore: number }> = [];
+			const normalizedSearchPrefix = searchPrefix.toLowerCase();
 
 			for (const entry of entries) {
-				if (!entry.name.toLowerCase().startsWith(searchPrefix.toLowerCase())) {
+				signal?.throwIfAborted();
+				const normalizedName = entry.name.toLowerCase();
+				const matchScore = options?.fuzzy
+					? fuzzyScore(normalizedSearchPrefix, normalizedName)
+					: normalizedName.startsWith(normalizedSearchPrefix)
+						? 1
+						: 0;
+				if (matchScore === 0) {
 					continue;
 				}
 				// Skip .git directory
@@ -761,8 +802,9 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				if (!isDirectory && entry.isSymbolicLink()) {
 					try {
 						const fullPath = path.join(searchDir, entry.name);
-						isDirectory = (await fs.promises.stat(fullPath)).isDirectory();
+						isDirectory = (await untilAborted(signal, fs.promises.stat(fullPath))).isDirectory();
 					} catch {
+						signal?.throwIfAborted();
 						// Broken symlink, file deleted between readdir and stat, or permission error
 						continue;
 					}
@@ -772,23 +814,18 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				const name = entry.name;
 				const displayPrefix = rawPrefix;
 
-				if (displayPrefix.endsWith("/")) {
+				if (/[\\/]$/.test(displayPrefix)) {
 					// If prefix ends with /, append entry to the prefix
 					relativePath = displayPrefix + name;
-				} else if (displayPrefix.includes("/")) {
+				} else if (/[\\/]/.test(displayPrefix)) {
 					// Preserve ~/ format for home directory paths
 					if (displayPrefix.startsWith("~/")) {
 						const homeRelativeDir = displayPrefix.slice(2); // Remove ~/
 						const dir = path.dirname(homeRelativeDir);
 						relativePath = `~/${dir === "." ? name : path.join(dir, name)}`;
-					} else if (displayPrefix.startsWith("/")) {
+					} else if (path.isAbsolute(displayPrefix)) {
 						// Absolute path - construct properly
-						const dir = path.dirname(displayPrefix);
-						if (dir === "/") {
-							relativePath = `/${name}`;
-						} else {
-							relativePath = `${dir}/${name}`;
-						}
+						relativePath = path.join(path.dirname(displayPrefix), name);
 					} else {
 						relativePath = path.join(path.dirname(displayPrefix), name);
 						if (displayPrefix.startsWith("./") && !relativePath.startsWith("./")) {
@@ -814,6 +851,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				suggestions.push({
 					value,
 					label: name + (isDirectory ? "/" : ""),
+					matchScore,
 				});
 			}
 
@@ -823,22 +861,33 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				const bIsDir = b.value.endsWith("/");
 				if (aIsDir && !bIsDir) return -1;
 				if (!aIsDir && bIsDir) return 1;
+				if (options?.fuzzy && a.matchScore !== b.matchScore) {
+					return b.matchScore - a.matchScore;
+				}
 				return a.label.localeCompare(b.label);
 			});
 
-			return suggestions;
+			return suggestions.map(({ matchScore: _matchScore, ...item }) => item);
 		} catch {
 			// Directory doesn't exist or not accessible
 			return [];
 		}
 	}
 
-	async #getFuzzyFileSuggestions(query: string, options: { isQuotedPrefix: boolean }): Promise<AutocompleteItem[]> {
+	async #getFuzzyFileSuggestions(
+		query: string,
+		options: { isQuotedPrefix: boolean },
+		signal?: AbortSignal,
+	): Promise<AutocompleteItem[]> {
 		try {
-			const scopedQuery = await this.#resolveScopedFuzzyQuery(query);
+			const scopedQuery = await this.#resolveScopedFuzzyQuery(query, signal);
+			signal?.throwIfAborted();
 			const searchPath = scopedQuery?.baseDir ?? this.#basePath;
 			const fuzzyQuery = scopedQuery?.query ?? query;
-			const result = await fuzzyFind(buildAutocompleteFuzzyDiscoveryProfile(fuzzyQuery, searchPath));
+			const result = await fuzzyFind({
+				...buildAutocompleteFuzzyDiscoveryProfile(fuzzyQuery, searchPath),
+				signal,
+			});
 			const lowerQuery = fuzzyQuery.toLowerCase();
 			const filteredMatches = result.matches.filter(entry => {
 				const p = entry.path.endsWith("/") ? entry.path.slice(0, -1) : entry.path;
@@ -879,7 +928,9 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		lines: string[],
 		cursorLine: number,
 		cursorCol: number,
+		signal?: AbortSignal,
 	): Promise<{ items: AutocompleteItem[]; prefix: string } | null> {
+		if (signal?.aborted) return null;
 		const currentLine = lines[cursorLine] || "";
 		const textBeforeCursor = currentLine.slice(0, cursorCol);
 
@@ -891,7 +942,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		// Force extract path prefix - this will always return something
 		const pathMatch = this.#extractPathPrefix(textBeforeCursor, true);
 		if (pathMatch !== null) {
-			const suggestions = await this.#getFileSuggestions(pathMatch);
+			const suggestions = await this.#getFileSuggestions(pathMatch, signal);
 			if (suggestions.length === 0) return null;
 
 			return {

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -76,6 +76,18 @@ function extractQuotedPrefix(text: string): string | null {
 	return text.slice(quoteStart);
 }
 
+export function extractAtFileMentionPrefix(text: string): string | null {
+	const quotedPrefix = extractQuotedPrefix(text);
+	if (quotedPrefix?.startsWith('@"')) {
+		return quotedPrefix;
+	}
+
+	const lastDelimiterIndex = findLastDelimiter(text);
+	const tokenStart = lastDelimiterIndex === -1 ? 0 : lastDelimiterIndex + 1;
+
+	return text[tokenStart] === "@" ? text.slice(tokenStart) : null;
+}
+
 function parsePathPrefix(prefix: string): { rawPrefix: string; isAtPrefix: boolean; isQuotedPrefix: boolean } {
 	if (prefix.startsWith('@"')) {
 		return { rawPrefix: prefix.slice(2), isAtPrefix: true, isQuotedPrefix: true };
@@ -103,6 +115,23 @@ function buildCompletionValue(
 	const openQuote = `${prefix}"`;
 	const closeQuote = options.isDirectory ? "" : '"';
 	return `${openQuote}${path}${closeQuote}`;
+}
+
+interface CachedDirEntry {
+	name: string;
+	isDirectory: boolean;
+	isSymbolicLink: boolean;
+}
+
+interface ScopedFuzzyQuery {
+	baseDir: string;
+	query: string;
+	displayBase: string;
+	useBoundedEnumeration: boolean;
+}
+
+function isCachedDirEntry(entry: CachedDirEntry | fs.Dirent): entry is CachedDirEntry {
+	return typeof entry.isDirectory === "boolean";
 }
 
 /**
@@ -318,7 +347,13 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	// per-directory readdir fast-path for prefix completions. Global fuzzy
 	// discovery continues to use native fuzzyFind + shared scan cache.
 	#dirCache: Map<string, { entries: fs.Dirent[]; timestamp: number }> = new Map();
+	#boundedDirCache: Map<string, { entries: CachedDirEntry[]; timestamp: number }> = new Map();
 	readonly #DIR_CACHE_TTL = 2000; // 2 seconds
+	// Natural @ path discovery inspects at most 100 immediate directory entries
+	// and exposes at most 20 suggestions before materializing broader results;
+	// explicit Tab remains the exhaustive immediate-directory escape hatch.
+	readonly #MAX_BOUNDED_DIRECTORY_SCAN = 100;
+	readonly #MAX_FILE_SUGGESTIONS = 20;
 
 	constructor(
 		commands: (SlashCommand | AutocompleteItem)[] = [],
@@ -400,15 +435,27 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const textBeforeCursor = currentLine.slice(0, cursorCol);
 
 		// Check for @ file reference (fuzzy search) - must be after a delimiter or at start
-		const atPrefix = this.#extractAtPrefix(textBeforeCursor);
+		const atPrefix = extractAtFileMentionPrefix(textBeforeCursor);
 		if (atPrefix) {
 			if (signal?.aborted) return null;
 			const { rawPrefix, isQuotedPrefix } = parsePathPrefix(atPrefix);
-			const usesBoundedPathCompletion = this.#isAbsoluteOrHomePrefix(rawPrefix);
+			let scopedQuery: ScopedFuzzyQuery | null = null;
+			if (rawPrefix.length > 0 && !this.#isAbsoluteOrHomePrefix(rawPrefix)) {
+				try {
+					scopedQuery = await this.#resolveScopedFuzzyQuery(rawPrefix, signal);
+				} catch {
+					if (signal?.aborted) return null;
+				}
+			}
+			const usesBoundedPathCompletion =
+				this.#isAbsoluteOrHomePrefix(rawPrefix) || scopedQuery?.useBoundedEnumeration === true;
 			const suggestions =
 				rawPrefix.length > 0 && !usesBoundedPathCompletion
-					? await this.#getFuzzyFileSuggestions(rawPrefix, { isQuotedPrefix }, signal)
-					: await this.#getFileSuggestions(atPrefix, signal, { fuzzy: usesBoundedPathCompletion });
+					? await this.#getFuzzyFileSuggestions(rawPrefix, { isQuotedPrefix }, signal, scopedQuery)
+					: await this.#getFileSuggestions(atPrefix, signal, {
+							bounded: usesBoundedPathCompletion,
+							fuzzy: usesBoundedPathCompletion,
+						});
 			if (signal?.aborted) return null;
 			if (suggestions.length === 0 && rawPrefix.length > 0 && !usesBoundedPathCompletion) {
 				const fallback = await this.#getFileSuggestions(atPrefix, signal);
@@ -581,23 +628,6 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		};
 	}
 
-	// Extract @ prefix for fuzzy file suggestions
-	#extractAtPrefix(text: string): string | null {
-		const quotedPrefix = extractQuotedPrefix(text);
-		if (quotedPrefix?.startsWith('@"')) {
-			return quotedPrefix;
-		}
-
-		const lastDelimiterIndex = findLastDelimiter(text);
-		const tokenStart = lastDelimiterIndex === -1 ? 0 : lastDelimiterIndex + 1;
-
-		if (text[tokenStart] === "@") {
-			return text.slice(tokenStart);
-		}
-
-		return null;
-	}
-
 	// Extract a path-like prefix from the text before cursor
 	#extractPathPrefix(text: string, forceExtract: boolean = false): string | null {
 		const quotedPrefix = extractQuotedPrefix(text);
@@ -637,7 +667,8 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	// Expand home directory (~/) to actual home path
 	#expandHomePath(filePath: string): string {
 		if (filePath.startsWith("~/")) {
-			const expandedPath = path.join(this.#homePath, filePath.slice(2));
+			const homePrefix = this.#homePath.endsWith(path.sep) ? this.#homePath.slice(0, -1) : this.#homePath;
+			const expandedPath = `${homePrefix}${path.sep}${filePath.slice(2)}`;
 			// Preserve trailing slash if original path had one
 			return filePath.endsWith("/") && !expandedPath.endsWith("/") ? `${expandedPath}/` : expandedPath;
 		} else if (filePath === "~") {
@@ -646,12 +677,9 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		return filePath;
 	}
 
-	async #resolveScopedFuzzyQuery(
-		rawQuery: string,
-		signal?: AbortSignal,
-	): Promise<{ baseDir: string; query: string; displayBase: string } | null> {
+	async #resolveScopedFuzzyQuery(rawQuery: string, signal?: AbortSignal): Promise<ScopedFuzzyQuery | null> {
 		signal?.throwIfAborted();
-		const slashIndex = rawQuery.lastIndexOf("/");
+		const slashIndex = Math.max(rawQuery.lastIndexOf("/"), rawQuery.lastIndexOf("\\"));
 		if (slashIndex === -1) {
 			return null;
 		}
@@ -660,12 +688,16 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const query = rawQuery.slice(slashIndex + 1);
 
 		let baseDir: string;
+		let literalRelativeBaseDir: string | null = null;
 		if (displayBase.startsWith("~/")) {
 			baseDir = this.#expandHomePath(displayBase);
 		} else if (displayBase.startsWith("/")) {
 			baseDir = displayBase;
 		} else {
-			baseDir = path.join(this.#basePath, displayBase);
+			literalRelativeBaseDir = this.#joinRelativePathLiterally(this.#basePath, displayBase);
+			baseDir = this.#hasParentPathSegment(displayBase)
+				? await this.#resolveEnumerationDir(literalRelativeBaseDir, signal)
+				: path.join(this.#basePath, displayBase);
 		}
 
 		try {
@@ -677,7 +709,24 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			return null;
 		}
 
-		return { baseDir, query, displayBase };
+		const isLexicalAncestorEscape =
+			literalRelativeBaseDir !== null && this.#isStrictAncestorPath(literalRelativeBaseDir, this.#basePath);
+		let isSymlinkEscape = false;
+		if (literalRelativeBaseDir !== null && !isLexicalAncestorEscape) {
+			try {
+				isSymlinkEscape = await this.#isScopedSymlinkEscape(displayBase, literalRelativeBaseDir, signal);
+			} catch {
+				signal?.throwIfAborted();
+				return null;
+			}
+		}
+
+		return {
+			baseDir,
+			query,
+			displayBase,
+			useBoundedEnumeration: isLexicalAncestorEscape || isSymlinkEscape,
+		};
 	}
 
 	#scopedPathForDisplay(displayBase: string, relativePath: string): string {
@@ -685,6 +734,130 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			return `/${relativePath}`;
 		}
 		return `${displayBase}${relativePath}`;
+	}
+
+	#pruneDirCache<T>(cache: Map<string, { entries: T[]; timestamp: number }>): void {
+		if (cache.size <= 100) {
+			return;
+		}
+
+		const sortedKeys = [...cache.entries()]
+			.sort((a, b) => a[1].timestamp - b[1].timestamp)
+			.slice(0, 50)
+			.map(([key]) => key);
+		for (const key of sortedKeys) {
+			cache.delete(key);
+		}
+	}
+
+	#displayDirPrefix(displayPrefix: string): string {
+		if (/[\\/]$/.test(displayPrefix)) {
+			return displayPrefix;
+		}
+		const lastSlashIndex = Math.max(displayPrefix.lastIndexOf("/"), displayPrefix.lastIndexOf("\\"));
+		return lastSlashIndex === -1 ? "" : displayPrefix.slice(0, lastSlashIndex + 1);
+	}
+
+	#isStrictAncestorPath(candidatePath: string, descendantPath: string): boolean {
+		const normalizedCandidate = path.resolve(candidatePath);
+		const normalizedDescendant = path.resolve(descendantPath);
+		if (normalizedCandidate === normalizedDescendant) {
+			return false;
+		}
+
+		return this.#isPathWithin(normalizedCandidate, normalizedDescendant);
+	}
+
+	#joinRelativePathLiterally(basePath: string, relativePath: string): string {
+		return /[\\/]$/.test(basePath) ? `${basePath}${relativePath}` : `${basePath}${path.sep}${relativePath}`;
+	}
+
+	#hasParentPathSegment(filePath: string): boolean {
+		return filePath.split(/[\\/]+/).some(segment => segment === "..");
+	}
+
+	#isPathWithin(rootPath: string, candidatePath: string): boolean {
+		const relative = path.relative(path.resolve(rootPath), path.resolve(candidatePath));
+		return (
+			relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+		);
+	}
+
+	async #hasRelativeScopedSymlink(displayBase: string, signal?: AbortSignal): Promise<boolean> {
+		let currentPath = this.#basePath;
+		for (const segment of displayBase.split(/[\\/]+/).filter(Boolean)) {
+			signal?.throwIfAborted();
+			if (segment === ".") {
+				continue;
+			}
+			if (segment === "..") {
+				currentPath = path.dirname(currentPath);
+				continue;
+			}
+			currentPath = path.join(currentPath, segment);
+			if ((await untilAborted(signal, fs.promises.lstat(currentPath))).isSymbolicLink()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	async #isScopedSymlinkEscape(displayBase: string, literalScopedDir: string, signal?: AbortSignal): Promise<boolean> {
+		if (!(await this.#hasRelativeScopedSymlink(displayBase, signal))) {
+			return false;
+		}
+
+		const resolvedBasePath = await this.#resolveEnumerationDir(this.#basePath, signal);
+		const resolvedScopedDir = await this.#resolveEnumerationDir(literalScopedDir, signal);
+		return !this.#isPathWithin(resolvedBasePath, resolvedScopedDir);
+	}
+
+	async #resolveEnumerationDir(searchDir: string, signal?: AbortSignal): Promise<string> {
+		if (!path.isAbsolute(searchDir)) {
+			return searchDir;
+		}
+
+		const { root } = path.parse(searchDir);
+		let resolvedPath = root;
+		let hasUnresolvedSegment = false;
+		let canResolveChildren = true;
+		const segments = searchDir
+			.slice(root.length)
+			.split(/[\\/]+/)
+			.filter(Boolean);
+
+		for (const segment of segments) {
+			signal?.throwIfAborted();
+			if (hasUnresolvedSegment || !canResolveChildren) {
+				resolvedPath = resolvedPath.endsWith(path.sep)
+					? `${resolvedPath}${segment}`
+					: `${resolvedPath}${path.sep}${segment}`;
+				hasUnresolvedSegment = true;
+				canResolveChildren = false;
+				continue;
+			}
+			if (segment === ".") {
+				continue;
+			}
+			if (segment === "..") {
+				resolvedPath = path.dirname(resolvedPath);
+				continue;
+			}
+
+			const candidatePath = path.join(resolvedPath, segment);
+			try {
+				resolvedPath = await untilAborted(signal, fs.promises.realpath(candidatePath));
+				canResolveChildren = (await untilAborted(signal, fs.promises.stat(resolvedPath))).isDirectory();
+			} catch {
+				signal?.throwIfAborted();
+				resolvedPath = candidatePath;
+				hasUnresolvedSegment = true;
+				canResolveChildren = false;
+			}
+		}
+
+		return resolvedPath;
 	}
 
 	async #getCachedDirEntries(searchDir: string, signal?: AbortSignal): Promise<fs.Dirent[]> {
@@ -699,16 +872,56 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const entries = await untilAborted(signal, fs.promises.readdir(searchDir, { withFileTypes: true }));
 		signal?.throwIfAborted();
 		this.#dirCache.set(searchDir, { entries, timestamp: now });
+		this.#pruneDirCache(this.#dirCache);
 
-		if (this.#dirCache.size > 100) {
-			const sortedKeys = [...this.#dirCache.entries()]
-				.sort((a, b) => a[1].timestamp - b[1].timestamp)
-				.slice(0, 50)
-				.map(([key]) => key);
-			for (const key of sortedKeys) {
-				this.#dirCache.delete(key);
-			}
+		return entries;
+	}
+
+	async #getCachedBoundedDirEntries(searchDir: string, signal?: AbortSignal): Promise<CachedDirEntry[]> {
+		signal?.throwIfAborted();
+		const now = Date.now();
+		const cached = this.#boundedDirCache.get(searchDir);
+
+		if (cached && now - cached.timestamp < this.#DIR_CACHE_TTL) {
+			return cached.entries;
 		}
+
+		const openingDir = fs.promises.opendir(searchDir);
+		const dir = await untilAborted(signal, openingDir).catch(error => {
+			void openingDir.then(
+				async lateDir => {
+					try {
+						await lateDir.close();
+					} catch {}
+				},
+				() => {},
+			);
+			throw error;
+		});
+		const entries: CachedDirEntry[] = [];
+
+		try {
+			while (entries.length < this.#MAX_BOUNDED_DIRECTORY_SCAN) {
+				signal?.throwIfAborted();
+				const entry = await untilAborted(signal, dir.read());
+				if (!entry) {
+					break;
+				}
+				entries.push({
+					name: entry.name,
+					isDirectory: entry.isDirectory(),
+					isSymbolicLink: entry.isSymbolicLink(),
+				});
+			}
+		} finally {
+			try {
+				await dir.close();
+			} catch {}
+		}
+
+		signal?.throwIfAborted();
+		this.#boundedDirCache.set(searchDir, { entries, timestamp: now });
+		this.#pruneDirCache(this.#boundedDirCache);
 
 		return entries;
 	}
@@ -716,16 +929,49 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	invalidateDirCache(dir?: string): void {
 		if (dir) {
 			this.#dirCache.delete(dir);
+			this.#boundedDirCache.delete(dir);
 		} else {
 			this.#dirCache.clear();
+			this.#boundedDirCache.clear();
 		}
+	}
+
+	#buildRelativePath(displayPrefix: string, name: string, options?: { preserveLiteralDir?: boolean }): string {
+		if (/[\\/]$/.test(displayPrefix)) {
+			return displayPrefix + name;
+		}
+
+		if (/[\\/]/.test(displayPrefix)) {
+			if (options?.preserveLiteralDir) {
+				return `${this.#displayDirPrefix(displayPrefix)}${name}`;
+			}
+			if (displayPrefix.startsWith("~/")) {
+				const homeRelativeDir = displayPrefix.slice(2);
+				const dir = path.dirname(homeRelativeDir);
+				return `~/${dir === "." ? name : path.join(dir, name)}`;
+			}
+			if (path.isAbsolute(displayPrefix)) {
+				return path.join(path.dirname(displayPrefix), name);
+			}
+			let relativePath = path.join(path.dirname(displayPrefix), name);
+			if (displayPrefix.startsWith("./") && !relativePath.startsWith("./")) {
+				relativePath = `./${relativePath}`;
+			}
+			return relativePath;
+		}
+
+		if (displayPrefix.startsWith("~")) {
+			return `~/${name}`;
+		}
+
+		return name;
 	}
 
 	// Get file/directory suggestions for a given path prefix
 	async #getFileSuggestions(
 		prefix: string,
 		signal?: AbortSignal,
-		options?: { fuzzy?: boolean },
+		options?: { bounded?: boolean; fuzzy?: boolean; preserveLiteralDir?: boolean; resolveEnumerationDir?: boolean },
 	): Promise<AutocompleteItem[]> {
 		try {
 			signal?.throwIfAborted();
@@ -739,6 +985,14 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				expandedPrefix = this.#expandHomePath(expandedPrefix);
 			}
 			const isExpandedAbsolute = path.isAbsolute(expandedPrefix);
+			const hasLiteralRelativeParent =
+				!rawPrefix.startsWith("~") && !isExpandedAbsolute && this.#hasParentPathSegment(rawPrefix);
+			const shouldResolveEnumerationDir =
+				options?.resolveEnumerationDir === true || options?.bounded === true || hasLiteralRelativeParent;
+			const relativeSearchDirFor = (relativePath: string): string =>
+				shouldResolveEnumerationDir
+					? this.#joinRelativePathLiterally(this.#basePath, relativePath)
+					: path.join(this.#basePath, relativePath);
 
 			const isRootPrefix =
 				rawPrefix === "" ||
@@ -754,7 +1008,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				if (rawPrefix.startsWith("~") || isExpandedAbsolute) {
 					searchDir = expandedPrefix;
 				} else {
-					searchDir = path.join(this.#basePath, expandedPrefix);
+					searchDir = relativeSearchDirFor(expandedPrefix);
 				}
 				searchPrefix = "";
 			} else if (/[\\/]$/.test(rawPrefix)) {
@@ -762,7 +1016,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				if (rawPrefix.startsWith("~") || isExpandedAbsolute) {
 					searchDir = expandedPrefix;
 				} else {
-					searchDir = path.join(this.#basePath, expandedPrefix);
+					searchDir = relativeSearchDirFor(expandedPrefix);
 				}
 				searchPrefix = "";
 			} else {
@@ -772,12 +1026,17 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				if (rawPrefix.startsWith("~") || isExpandedAbsolute) {
 					searchDir = dir;
 				} else {
-					searchDir = path.join(this.#basePath, dir);
+					searchDir = relativeSearchDirFor(dir);
 				}
 				searchPrefix = file;
 			}
 
-			const entries = await this.#getCachedDirEntries(searchDir, signal);
+			const resolvedSearchDir = shouldResolveEnumerationDir
+				? await this.#resolveEnumerationDir(searchDir, signal)
+				: searchDir;
+			const entries = options?.bounded
+				? await this.#getCachedBoundedDirEntries(resolvedSearchDir, signal)
+				: await this.#getCachedDirEntries(resolvedSearchDir, signal);
 			const suggestions: Array<AutocompleteItem & { matchScore: number }> = [];
 			const normalizedSearchPrefix = searchPrefix.toLowerCase();
 
@@ -798,10 +1057,11 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				}
 
 				// Check if entry is a directory (or a symlink pointing to a directory)
-				let isDirectory = entry.isDirectory();
-				if (!isDirectory && entry.isSymbolicLink()) {
+				let isDirectory = isCachedDirEntry(entry) ? entry.isDirectory : entry.isDirectory();
+				const isSymbolicLink = isCachedDirEntry(entry) ? entry.isSymbolicLink : entry.isSymbolicLink();
+				if (!isDirectory && isSymbolicLink) {
 					try {
-						const fullPath = path.join(searchDir, entry.name);
+						const fullPath = path.join(resolvedSearchDir, entry.name);
 						isDirectory = (await untilAborted(signal, fs.promises.stat(fullPath))).isDirectory();
 					} catch {
 						signal?.throwIfAborted();
@@ -810,36 +1070,12 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 					}
 				}
 
-				let relativePath: string;
 				const name = entry.name;
 				const displayPrefix = rawPrefix;
-
-				if (/[\\/]$/.test(displayPrefix)) {
-					// If prefix ends with /, append entry to the prefix
-					relativePath = displayPrefix + name;
-				} else if (/[\\/]/.test(displayPrefix)) {
-					// Preserve ~/ format for home directory paths
-					if (displayPrefix.startsWith("~/")) {
-						const homeRelativeDir = displayPrefix.slice(2); // Remove ~/
-						const dir = path.dirname(homeRelativeDir);
-						relativePath = `~/${dir === "." ? name : path.join(dir, name)}`;
-					} else if (path.isAbsolute(displayPrefix)) {
-						// Absolute path - construct properly
-						relativePath = path.join(path.dirname(displayPrefix), name);
-					} else {
-						relativePath = path.join(path.dirname(displayPrefix), name);
-						if (displayPrefix.startsWith("./") && !relativePath.startsWith("./")) {
-							relativePath = `./${relativePath}`;
-						}
-					}
-				} else {
-					// For standalone entries, preserve ~/ if original prefix was ~/
-					if (displayPrefix.startsWith("~")) {
-						relativePath = `~/${name}`;
-					} else {
-						relativePath = name;
-					}
-				}
+				const relativePath = this.#buildRelativePath(displayPrefix, name, {
+					preserveLiteralDir:
+						options?.preserveLiteralDir ?? (options?.bounded === true || hasLiteralRelativeParent),
+				});
 
 				const pathValue = isDirectory ? `${relativePath}/` : relativePath;
 				const value = buildCompletionValue(pathValue, {
@@ -867,7 +1103,8 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				return a.label.localeCompare(b.label);
 			});
 
-			return suggestions.map(({ matchScore: _matchScore, ...item }) => item);
+			const limitedSuggestions = options?.bounded ? suggestions.slice(0, this.#MAX_FILE_SUGGESTIONS) : suggestions;
+			return limitedSuggestions.map(({ matchScore: _matchScore, ...item }) => item);
 		} catch {
 			// Directory doesn't exist or not accessible
 			return [];
@@ -878,12 +1115,20 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		query: string,
 		options: { isQuotedPrefix: boolean },
 		signal?: AbortSignal,
+		scopedQuery?: ScopedFuzzyQuery | null,
 	): Promise<AutocompleteItem[]> {
 		try {
-			const scopedQuery = await this.#resolveScopedFuzzyQuery(query, signal);
+			const resolvedScopedQuery =
+				scopedQuery === undefined ? await this.#resolveScopedFuzzyQuery(query, signal) : scopedQuery;
+			if (resolvedScopedQuery?.useBoundedEnumeration) {
+				return this.#getFileSuggestions(`${options.isQuotedPrefix ? '@"' : "@"}${query}`, signal, {
+					bounded: true,
+					fuzzy: true,
+				});
+			}
 			signal?.throwIfAborted();
-			const searchPath = scopedQuery?.baseDir ?? this.#basePath;
-			const fuzzyQuery = scopedQuery?.query ?? query;
+			const searchPath = resolvedScopedQuery?.baseDir ?? this.#basePath;
+			const fuzzyQuery = resolvedScopedQuery?.query ?? query;
 			const result = await fuzzyFind({
 				...buildAutocompleteFuzzyDiscoveryProfile(fuzzyQuery, searchPath),
 				signal,
@@ -901,8 +1146,8 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			const suggestions: AutocompleteItem[] = [];
 			for (const { path: entryPath, isDirectory } of topEntries) {
 				const pathWithoutSlash = isDirectory ? entryPath.slice(0, -1) : entryPath;
-				const displayPath = scopedQuery
-					? this.#scopedPathForDisplay(scopedQuery.displayBase, pathWithoutSlash)
+				const displayPath = resolvedScopedQuery
+					? this.#scopedPathForDisplay(resolvedScopedQuery.displayBase, pathWithoutSlash)
 					: pathWithoutSlash;
 				const entryName = path.basename(pathWithoutSlash);
 				const completionPath = isDirectory ? `${displayPath}/` : displayPath;
@@ -942,7 +1187,13 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		// Force extract path prefix - this will always return something
 		const pathMatch = this.#extractPathPrefix(textBeforeCursor, true);
 		if (pathMatch !== null) {
-			const suggestions = await this.#getFileSuggestions(pathMatch, signal);
+			const { rawPrefix } = parsePathPrefix(pathMatch);
+			const usesLiteralPathSemantics =
+				this.#isAbsoluteOrHomePrefix(rawPrefix) || this.#hasParentPathSegment(rawPrefix);
+			const suggestions = await this.#getFileSuggestions(pathMatch, signal, {
+				preserveLiteralDir: usesLiteralPathSemantics,
+				resolveEnumerationDir: usesLiteralPathSemantics,
+			});
 			if (suggestions.length === 0) return null;
 
 			return {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1,5 +1,6 @@
 import { getProjectDir, logger, onDefaultTabWidthChange } from "@gajae-code/utils";
 import {
+	type AutocompleteItem,
 	type AutocompleteProvider,
 	type CombinedAutocompleteProvider,
 	extractSlashCommandTokenPrefix,
@@ -460,6 +461,7 @@ export class Editor implements Component, Focusable {
 	#autocompleteState: "regular" | "force" | null = null;
 	#autocompletePrefix: string = "";
 	#autocompleteRequestId: number = 0;
+	#autocompleteRequestController?: AbortController;
 	#autocompleteOrigin?: { docVersion: number; cursorLine: number; cursorCol: number };
 	#autocompleteMaxVisible: number = 5;
 	onAutocompleteUpdate?: () => void;
@@ -520,6 +522,8 @@ export class Editor implements Component, Focusable {
 	dispose(): void {
 		this.#disposeTabWidthListener?.();
 		this.#disposeTabWidthListener = undefined;
+		this.#abortAutocompleteRequest();
+		this.#clearAutocompleteTimeout();
 	}
 
 	setAutocompleteProvider(provider: AutocompleteProvider): void {
@@ -691,6 +695,7 @@ export class Editor implements Component, Focusable {
 	}
 	/** Internal setText that doesn't reset history state - used by navigateHistory */
 	#setTextInternal(text: string, cursorAnchor: HistoryCursorAnchor = "end"): void {
+		this.#cancelAutocomplete();
 		this.#undoStack.length = 0;
 		const lines = sanitizeLoadedText(text).split("\n");
 		this.#state.lines = lines.length === 0 ? [""] : lines;
@@ -1154,6 +1159,10 @@ export class Editor implements Component, Focusable {
 					this.handleInput(paste.remaining);
 				}
 			}
+			return;
+		}
+		if (!this.#autocompleteState && this.#autocompleteRequestController && kb.matches(data, "tui.select.cancel")) {
+			this.#cancelAutocomplete();
 			return;
 		}
 
@@ -1837,6 +1846,7 @@ export class Editor implements Component, Focusable {
 
 	// All the editor methods from before...
 	#insertCharacter(char: string): void {
+		this.#abortAutocompleteRequest();
 		this.#exitHistoryForEditing();
 		this.#resetKillSequence();
 		this.#recordUndoState();
@@ -1901,6 +1911,14 @@ export class Editor implements Component, Focusable {
 			// Auto-trigger for "#" prompt actions anywhere in the current token
 			else if (char === "#") {
 				this.#tryTriggerAutocomplete();
+			}
+			// Continue a home-relative @ mention after the standalone "~" marker.
+			else if (char === "~") {
+				const currentLine = this.#state.lines[this.#state.cursorLine] || "";
+				const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
+				if (textBeforeCursor.match(/(?:^|[\s])@[^\s]*$/)) {
+					this.#tryTriggerAutocomplete();
+				}
 			}
 			// Also auto-trigger when typing letters/path chars in a completable context
 			else if (/[a-zA-Z0-9.\-_/]/.test(char)) {
@@ -2037,6 +2055,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	#submitValue(): void {
+		this.#cancelAutocomplete();
 		this.#resetKillSequence();
 
 		const result = this.#expandPasteMarkers(this.#state.lines.join("\n")).trim();
@@ -2055,6 +2074,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	#handleBackspace(): void {
+		this.#abortAutocompleteRequest();
 		this.#historyIndex = -1; // Exit history browsing mode
 		this.#resetKillSequence();
 		this.#recordUndoState();
@@ -2088,6 +2108,11 @@ export class Editor implements Component, Focusable {
 
 		if (this.onChange) {
 			this.onChange(this.getText());
+		}
+
+		if (this.#isEditorEmpty()) {
+			this.#cancelAutocomplete();
+			return;
 		}
 
 		// Update or re-trigger autocomplete after backspace
@@ -2193,28 +2218,54 @@ export class Editor implements Component, Focusable {
 		return result;
 	}
 
+	#cancelAutocompleteAfterCursorMove(previousLine: number, previousCol: number): void {
+		if (previousLine === this.#state.cursorLine && previousCol === this.#state.cursorCol) {
+			return;
+		}
+
+		const hadPendingRequest =
+			this.#autocompleteRequestController !== undefined || this.#autocompleteTimeout !== undefined;
+		if (!hadPendingRequest) {
+			return;
+		}
+
+		const hadAutocomplete = this.#autocompleteState !== null;
+		this.#cancelAutocomplete();
+		if (hadAutocomplete) {
+			this.onAutocompleteUpdate?.();
+		}
+	}
+
 	#moveToLineStart(): void {
+		const { cursorLine, cursorCol } = this.#state;
 		this.#resetKillSequence();
 		this.#setCursorCol(0);
+		this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 	}
 
 	#moveToLineEnd(): void {
+		const { cursorLine, cursorCol } = this.#state;
 		this.#resetKillSequence();
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 		this.#setCursorCol(currentLine.length);
+		this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 	}
 
 	#moveToMessageStart(): void {
+		const { cursorLine, cursorCol } = this.#state;
 		this.#resetKillSequence();
 		this.#state.cursorLine = 0;
 		this.#setCursorCol(0);
+		this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 	}
 
 	#moveToMessageEnd(): void {
+		const { cursorLine, cursorCol } = this.#state;
 		this.#resetKillSequence();
 		this.#state.cursorLine = this.#state.lines.length - 1;
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 		this.#setCursorCol(currentLine.length);
+		this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 	}
 
 	#resetKillSequence(): void {
@@ -2535,6 +2586,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	#handleForwardDelete(): void {
+		this.#abortAutocompleteRequest();
 		this.#historyIndex = -1; // Exit history browsing mode
 		this.#resetKillSequence();
 		this.#recordUndoState();
@@ -2642,6 +2694,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	#moveCursor(deltaLine: number, deltaCol: number): void {
+		const { cursorLine, cursorCol } = this.#state;
 		this.#resetKillSequence();
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 		const needsVisualLines = deltaLine !== 0 || (deltaCol > 0 && this.#state.cursorCol >= currentLine.length);
@@ -2700,9 +2753,12 @@ export class Editor implements Component, Focusable {
 				}
 			}
 		}
+
+		this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 	}
 
 	#pageScroll(direction: -1 | 1): void {
+		const { cursorLine, cursorCol } = this.#state;
 		this.#resetKillSequence();
 		const visualLines = this.#buildVisualLineMap(this.#lastLayoutWidth);
 		const currentVisualLine = this.#findCurrentVisualLine(visualLines);
@@ -2710,9 +2766,11 @@ export class Editor implements Component, Focusable {
 		const targetVisualLine = Math.max(0, Math.min(visualLines.length - 1, currentVisualLine + direction * step));
 		if (targetVisualLine === currentVisualLine) return;
 		this.#moveToVisualLine(visualLines, currentVisualLine, targetVisualLine);
+		this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 	}
 
 	#moveWordBackwards(): void {
+		const { cursorLine, cursorCol } = this.#state;
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 
 		// If at start of line, move to end of previous line
@@ -2722,10 +2780,12 @@ export class Editor implements Component, Focusable {
 				const prevLine = this.#state.lines[this.#state.cursorLine] || "";
 				this.#setCursorCol(prevLine.length);
 			}
+			this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 			return;
 		}
 
 		this.#setCursorCol(moveWordLeft(currentLine, this.#state.cursorCol));
+		this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 	}
 
 	/**
@@ -2733,6 +2793,7 @@ export class Editor implements Component, Focusable {
 	 * Multi-line search. Case-sensitive. Skips the current cursor position.
 	 */
 	#jumpToChar(char: string, direction: "forward" | "backward"): void {
+		const { cursorLine, cursorCol } = this.#state;
 		this.#resetKillSequence();
 		const isForward = direction === "forward";
 		const lines = this.#state.lines;
@@ -2762,6 +2823,7 @@ export class Editor implements Component, Focusable {
 			if (idx !== -1) {
 				this.#state.cursorLine = lineIdx;
 				this.#setCursorCol(idx);
+				this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 				return;
 			}
 		}
@@ -2769,6 +2831,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	#moveWordForwards(): void {
+		const { cursorLine, cursorCol } = this.#state;
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 
 		// If at end of line, move to start of next line
@@ -2777,10 +2840,12 @@ export class Editor implements Component, Focusable {
 				this.#state.cursorLine++;
 				this.#setCursorCol(0);
 			}
+			this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 			return;
 		}
 
 		this.#setCursorCol(moveWordRight(currentLine, this.#state.cursorCol));
+		this.#cancelAutocompleteAfterCursorMove(cursorLine, cursorCol);
 	}
 
 	#hasOnlyWhitespaceBeforeCursorLine(): boolean {
@@ -2875,11 +2940,21 @@ export class Editor implements Component, Focusable {
 		const origin = this.#captureAutocompleteOrigin();
 		const requestId = ++this.#autocompleteRequestId;
 
-		const suggestions = await this.#autocompleteProvider.getSuggestions(
-			this.#state.lines,
-			this.#state.cursorLine,
-			this.#state.cursorCol,
-		);
+		const signal = this.#newAutocompleteRequestController().signal;
+		let suggestions: { items: AutocompleteItem[]; prefix: string } | null;
+		try {
+			suggestions = await this.#autocompleteProvider.getSuggestions(
+				this.#state.lines,
+				this.#state.cursorLine,
+				this.#state.cursorCol,
+				signal,
+			);
+		} catch (error) {
+			if (signal.aborted) return;
+			throw error;
+		} finally {
+			this.#finishAutocompleteRequest(signal);
+		}
 		if (requestId !== this.#autocompleteRequestId || !this.#isAutocompleteOriginCurrent(origin)) return;
 
 		if (suggestions && Array.isArray(suggestions.items) && suggestions.items.length > 0) {
@@ -2948,11 +3023,21 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 
 		const origin = this.#captureAutocompleteOrigin();
 		const requestId = ++this.#autocompleteRequestId;
-		const suggestions = await provider.getForceFileSuggestions(
-			this.#state.lines,
-			this.#state.cursorLine,
-			this.#state.cursorCol,
-		);
+		const signal = this.#newAutocompleteRequestController().signal;
+		let suggestions: { items: AutocompleteItem[]; prefix: string } | null;
+		try {
+			suggestions = await provider.getForceFileSuggestions(
+				this.#state.lines,
+				this.#state.cursorLine,
+				this.#state.cursorCol,
+				signal,
+			);
+		} catch (error) {
+			if (signal.aborted) return;
+			throw error;
+		} finally {
+			this.#finishAutocompleteRequest(signal);
+		}
 		if (requestId !== this.#autocompleteRequestId || !this.#isAutocompleteOriginCurrent(origin)) return;
 
 		if (suggestions && Array.isArray(suggestions.items) && suggestions.items.length > 0) {
@@ -2992,6 +3077,7 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 
 	#cancelAutocomplete(notifyCancel: boolean = false): void {
 		const wasAutocompleting = this.#autocompleteState !== null;
+		this.#abortAutocompleteRequest();
 		this.#clearAutocompleteTimeout();
 		this.#autocompleteRequestId += 1;
 		this.#autocompleteState = null;
@@ -3019,11 +3105,21 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 		const origin = this.#captureAutocompleteOrigin();
 		const requestId = ++this.#autocompleteRequestId;
 
-		const suggestions = await this.#autocompleteProvider.getSuggestions(
-			this.#state.lines,
-			this.#state.cursorLine,
-			this.#state.cursorCol,
-		);
+		const signal = this.#newAutocompleteRequestController().signal;
+		let suggestions: { items: AutocompleteItem[]; prefix: string } | null;
+		try {
+			suggestions = await this.#autocompleteProvider.getSuggestions(
+				this.#state.lines,
+				this.#state.cursorLine,
+				this.#state.cursorCol,
+				signal,
+			);
+		} catch (error) {
+			if (signal.aborted) return;
+			throw error;
+		} finally {
+			this.#finishAutocompleteRequest(signal);
+		}
 		if (requestId !== this.#autocompleteRequestId || !this.#isAutocompleteOriginCurrent(origin)) return;
 
 		if (suggestions && Array.isArray(suggestions.items) && suggestions.items.length > 0) {
@@ -3053,6 +3149,24 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 			clearTimeout(this.#autocompleteTimeout);
 			this.#autocompleteTimeout = undefined;
 		}
+	}
+
+	#abortAutocompleteRequest(): void {
+		this.#autocompleteRequestController?.abort();
+		this.#autocompleteRequestController = undefined;
+	}
+
+	#finishAutocompleteRequest(signal: AbortSignal): void {
+		if (this.#autocompleteRequestController?.signal === signal) {
+			this.#autocompleteRequestController = undefined;
+		}
+	}
+
+	#newAutocompleteRequestController(): AbortController {
+		this.#abortAutocompleteRequest();
+		const controller = new AbortController();
+		this.#autocompleteRequestController = controller;
+		return controller;
 	}
 
 	/**

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -3,6 +3,7 @@ import {
 	type AutocompleteItem,
 	type AutocompleteProvider,
 	type CombinedAutocompleteProvider,
+	extractAtFileMentionPrefix,
 	extractSlashCommandTokenPrefix,
 	isInsideInlineCodeSpan,
 } from "../autocomplete";
@@ -522,8 +523,7 @@ export class Editor implements Component, Focusable {
 	dispose(): void {
 		this.#disposeTabWidthListener?.();
 		this.#disposeTabWidthListener = undefined;
-		this.#abortAutocompleteRequest();
-		this.#clearAutocompleteTimeout();
+		this.#cancelAutocomplete();
 	}
 
 	setAutocompleteProvider(provider: AutocompleteProvider): void {
@@ -719,6 +719,8 @@ export class Editor implements Component, Focusable {
 	}
 
 	#bumpDocumentVersion(): void {
+		this.#abortAutocompleteRequest();
+		this.#clearAutocompleteTimeout();
 		this.#docVersion += 1;
 		this.#layoutCache = undefined;
 	}
@@ -1161,8 +1163,7 @@ export class Editor implements Component, Focusable {
 			}
 			return;
 		}
-		if (!this.#autocompleteState && this.#autocompleteRequestController && kb.matches(data, "tui.select.cancel")) {
-			this.#cancelAutocomplete();
+		if (!this.#autocompleteState && kb.matches(data, "tui.select.cancel") && this.cancelPendingAutocompleteWork()) {
 			return;
 		}
 
@@ -1916,7 +1917,7 @@ export class Editor implements Component, Focusable {
 			else if (char === "~") {
 				const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 				const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
-				if (textBeforeCursor.match(/(?:^|[\s])@[^\s]*$/)) {
+				if (extractAtFileMentionPrefix(textBeforeCursor) !== null) {
 					this.#tryTriggerAutocomplete();
 				}
 			}
@@ -1929,7 +1930,7 @@ export class Editor implements Component, Focusable {
 					this.#tryTriggerAutocomplete();
 				}
 				// Check if we're in an @ file reference context
-				else if (textBeforeCursor.match(/(?:^|[\s])@[^\s]*$/)) {
+				else if (extractAtFileMentionPrefix(textBeforeCursor) !== null) {
 					this.#tryTriggerAutocomplete();
 				}
 				// Check if we're in a # prompt action context
@@ -2127,7 +2128,7 @@ export class Editor implements Component, Focusable {
 				this.#tryTriggerAutocomplete();
 			}
 			// @ file reference context
-			else if (textBeforeCursor.match(/(?:^|[\s])@[^\s]*$/)) {
+			else if (extractAtFileMentionPrefix(textBeforeCursor) !== null) {
 				this.#tryTriggerAutocomplete();
 			}
 			// # prompt action context
@@ -2309,7 +2310,7 @@ export class Editor implements Component, Focusable {
 			const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
 			if (this.#isInSubmittedSlashCommandContext() || this.#isInSlashTokenContext()) {
 				this.#tryTriggerAutocomplete();
-			} else if (textBeforeCursor.match(/(?:^|[\s])@[^\s]*$/)) {
+			} else if (extractAtFileMentionPrefix(textBeforeCursor) !== null) {
 				this.#tryTriggerAutocomplete();
 			} else if (textBeforeCursor.match(/#[^\s#]*$/)) {
 				this.#tryTriggerAutocomplete();
@@ -2627,7 +2628,7 @@ export class Editor implements Component, Focusable {
 				this.#tryTriggerAutocomplete();
 			}
 			// @ file reference context
-			else if (textBeforeCursor.match(/(?:^|[\s])@[^\s]*$/)) {
+			else if (extractAtFileMentionPrefix(textBeforeCursor) !== null) {
 				this.#tryTriggerAutocomplete();
 			}
 			// # prompt action context
@@ -3077,9 +3078,10 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 
 	#cancelAutocomplete(notifyCancel: boolean = false): void {
 		const wasAutocompleting = this.#autocompleteState !== null;
-		this.#abortAutocompleteRequest();
-		this.#clearAutocompleteTimeout();
-		this.#autocompleteRequestId += 1;
+		const invalidatedPendingWork = this.cancelPendingAutocompleteWork();
+		if (!invalidatedPendingWork) {
+			this.#autocompleteRequestId += 1;
+		}
 		this.#autocompleteState = null;
 		this.#autocompleteList = undefined;
 		this.#autocompleteOrigin = undefined;
@@ -3149,6 +3151,18 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 			clearTimeout(this.#autocompleteTimeout);
 			this.#autocompleteTimeout = undefined;
 		}
+	}
+
+	protected cancelPendingAutocompleteWork(): boolean {
+		const hadPendingWork =
+			this.#autocompleteRequestController !== undefined || this.#autocompleteTimeout !== undefined;
+		if (!hadPendingWork) {
+			return false;
+		}
+		this.#abortAutocompleteRequest();
+		this.#clearAutocompleteTimeout();
+		this.#autocompleteRequestId += 1;
+		return true;
 	}
 
 	#abortAutocompleteRequest(): void {

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -135,6 +135,242 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(values.some(value => value.includes("alpha-local.ts"))).toBe(false);
 		});
 
+		it.each([
+			[
+				"project-child",
+				(_root: string, project: string): string => path.join(project, "linked-outside"),
+				"@linked-outside/anchor-a",
+				"@linked-outside/anchor-alpha.txt",
+				"@linked-outside/nested/anchor-alpha-deep.txt",
+			],
+			[
+				"sibling",
+				(root: string, _project: string): string => path.join(root, "sibling-link"),
+				"@../sibling-link/anchor-a",
+				"@../sibling-link/anchor-alpha.txt",
+				"@../sibling-link/nested/anchor-alpha-deep.txt",
+			],
+		] as const)("bounds %s relative symlink scopes that resolve outside the project", async (_name, linkPathFor, line, expectedValue, unexpectedNestedValue) => {
+			if (process.platform === "win32") {
+				return;
+			}
+
+			const externalTree = path.join(rootDir, "external-tree");
+			fs.mkdirSync(path.join(externalTree, "nested"), { recursive: true });
+			fs.writeFileSync(path.join(externalTree, "anchor-alpha.txt"), "anchor\n");
+			fs.writeFileSync(path.join(externalTree, "nested", "anchor-alpha-deep.txt"), "deep\n");
+			fs.symlinkSync(externalTree, linkPathFor(rootDir, baseDir), "dir");
+
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const result = await provider.getSuggestions([line], 0, line.length);
+			const values = result?.items.map(item => item.value) ?? [];
+
+			expect(values).toContain(expectedValue);
+			expect(values).not.toContain(unexpectedNestedValue);
+		});
+
+		it("keeps recursive fuzzy discovery for relative symlinks that resolve inside the project", async () => {
+			if (process.platform === "win32") {
+				return;
+			}
+
+			const internalTree = path.join(baseDir, "internal-tree");
+			fs.mkdirSync(path.join(internalTree, "nested"), { recursive: true });
+			fs.writeFileSync(path.join(internalTree, "nested", "anchor-alpha-deep.txt"), "deep\n");
+			fs.symlinkSync(internalTree, path.join(baseDir, "linked-inside"), "dir");
+
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = "@linked-inside/anchor-a";
+			const result = await provider.getSuggestions([line], 0, line.length);
+			const values = result?.items.map(item => item.value) ?? [];
+
+			expect(values).toContain("@linked-inside/nested/anchor-alpha-deep.txt");
+		});
+
+		it.each([
+			[
+				"unquoted ancestor escape",
+				(basePath: string): string => path.join(path.dirname(basePath), "project", "cwd"),
+				(basePath: string): string => path.dirname(basePath),
+				(_basePath: string): string => "@../ancestor-a",
+				"@../ancestor-alpha.txt",
+				"@../ancestor-nested/ancestor-alpha-deep.txt",
+			],
+			[
+				"quoted ancestor escape with spaces",
+				(basePath: string): string => path.join(path.dirname(basePath), "project"),
+				(_basePath: string): string => rootDir,
+				(_basePath: string): string => '@"sub dir/../../ancestor-a',
+				'@"sub dir/../../ancestor-alpha.txt"',
+				'@"sub dir/../../ancestor-nested/ancestor-alpha-deep.txt"',
+			],
+		] as const)("switches %s mentions to bounded immediate-directory lookup", async (_name, basePathFor, ancestorDirFor, lineFor, expectedValue, unexpectedNestedValue) => {
+			const projectBaseDir = basePathFor(baseDir);
+			const escapedRootDir = ancestorDirFor(projectBaseDir);
+			const escapedAncestor = path.join(escapedRootDir, "ancestor-alpha.txt");
+			const escapedNestedDir = path.join(escapedRootDir, "ancestor-nested");
+
+			fs.mkdirSync(projectBaseDir, { recursive: true });
+			fs.mkdirSync(path.join(projectBaseDir, "sub dir"), { recursive: true });
+			fs.mkdirSync(escapedNestedDir, { recursive: true });
+			fs.writeFileSync(escapedAncestor, "ancestor\n");
+			fs.writeFileSync(path.join(escapedNestedDir, "ancestor-alpha-deep.txt"), "deep\n");
+
+			const provider = new CombinedAutocompleteProvider([], projectBaseDir);
+			const line = lineFor(projectBaseDir);
+			const result = await provider.getSuggestions([line], 0, line.length);
+			const values = result?.items.map(item => item.value) ?? [];
+
+			expect(values).toContain(expectedValue);
+			expect(values).not.toContain(unexpectedNestedValue);
+			expect(values.some(value => value.includes("project"))).toBe(false);
+		});
+
+		it.each([
+			[
+				"unquoted ancestor escape",
+				(basePath: string): string => path.join(path.dirname(basePath), "project", "cwd"),
+				(basePath: string): string => path.dirname(basePath),
+				(_basePath: string): string => "@../ancestor-a",
+				(_basePath: string): string[] =>
+					Array.from({ length: 25 }, (_, index) => `@../ancestor-alpha-${index.toString().padStart(3, "0")}.txt`),
+				(_basePath: string): string => "@../ancestor-alpha-late.txt",
+				"@../ancestor-nested/ancestor-alpha-deep.txt",
+			],
+			[
+				"quoted ancestor escape with spaces",
+				(basePath: string): string => path.join(path.dirname(basePath), "project"),
+				(_basePath: string): string => rootDir,
+				(_basePath: string): string => '@"sub dir/../../ancestor-a',
+				(_basePath: string): string[] =>
+					Array.from(
+						{ length: 25 },
+						(_, index) => `@"sub dir/../../ancestor-alpha-${index.toString().padStart(3, "0")}.txt"`,
+					),
+				(_basePath: string): string => '@"sub dir/../../ancestor-alpha-late.txt"',
+				'@"sub dir/../../ancestor-nested/ancestor-alpha-deep.txt"',
+			],
+		] as const)("uses bounded opendir semantics for natural %s mentions", async (_name, basePathFor, ancestorDirFor, lineFor, expectedEarlyValuesFor, expectedLateValueFor, unexpectedNestedValue) => {
+			if (process.platform === "win32") {
+				return;
+			}
+
+			const projectBaseDir = basePathFor(baseDir);
+			const escapedRootDir = ancestorDirFor(projectBaseDir);
+			const escapedNestedDir = path.join(escapedRootDir, "ancestor-nested");
+			const entries: fs.Dirent[] = Array.from({ length: 150 }, (_, index) => {
+				const name =
+					index < 25
+						? `ancestor-alpha-${index.toString().padStart(3, "0")}.txt`
+						: index === 120
+							? "ancestor-alpha-late.txt"
+							: `filler-${index.toString().padStart(3, "0")}.txt`;
+				return {
+					name,
+					isDirectory: () => false,
+					isSymbolicLink: () => false,
+				} as fs.Dirent;
+			});
+			let iterated = 0;
+			let closed = false;
+			const readdirSpy = spyOn(fs.promises, "readdir").mockRejectedValue(
+				new Error("ancestor-bounded completion must not call readdir"),
+			);
+			const opendirSpy = spyOn(fs.promises, "opendir").mockResolvedValue({
+				async read() {
+					const entry = entries[iterated] ?? null;
+					iterated += entry ? 1 : 0;
+					return entry;
+				},
+				async close() {
+					closed = true;
+				},
+			} as fs.Dir);
+
+			try {
+				fs.mkdirSync(projectBaseDir, { recursive: true });
+				fs.mkdirSync(path.join(projectBaseDir, "sub dir"), { recursive: true });
+				fs.mkdirSync(escapedNestedDir, { recursive: true });
+				fs.writeFileSync(path.join(escapedNestedDir, "ancestor-alpha-deep.txt"), "deep\n");
+
+				const provider = new CombinedAutocompleteProvider([], projectBaseDir);
+				const line = lineFor(projectBaseDir);
+				const result = await provider.getSuggestions([line], 0, line.length);
+				const values = result?.items.map(item => item.value) ?? [];
+
+				expect(opendirSpy).toHaveBeenCalledTimes(1);
+				expect(readdirSpy).not.toHaveBeenCalled();
+				expect(iterated).toBeLessThanOrEqual(100);
+				expect(closed).toBe(true);
+				expect(values).toHaveLength(20);
+				for (const expectedEarlyValue of expectedEarlyValuesFor(projectBaseDir).slice(0, 20)) {
+					expect(values).toContain(expectedEarlyValue);
+				}
+				expect(values).not.toContain(expectedLateValueFor(projectBaseDir));
+				expect(values).not.toContain(unexpectedNestedValue);
+			} finally {
+				opendirSpy.mockRestore();
+				readdirSpy.mockRestore();
+			}
+		});
+
+		it.each([
+			[
+				"windows unquoted ancestor escape",
+				(basePath: string): string => path.join(path.dirname(basePath), "project", "cwd"),
+				(basePath: string): string => path.dirname(basePath),
+				(_basePath: string): string => "@..\\ancestor-a",
+				"@..\\ancestor-alpha.txt",
+				"@..\\ancestor-nested\\ancestor-alpha-deep.txt",
+			],
+			[
+				"windows quoted ancestor escape with spaces",
+				(basePath: string): string => path.join(path.dirname(basePath), "project"),
+				(_basePath: string): string => rootDir,
+				(_basePath: string): string => '@"sub dir\\..\\..\\ancestor-a',
+				'@"sub dir\\..\\..\\ancestor-alpha.txt"',
+				'@"sub dir\\..\\..\\ancestor-nested\\ancestor-alpha-deep.txt"',
+			],
+		] as const)("switches %s mentions to bounded immediate-directory lookup with backslash separators", async (_name, basePathFor, ancestorDirFor, lineFor, expectedValue, unexpectedNestedValue) => {
+			if (process.platform !== "win32") {
+				return;
+			}
+
+			const projectBaseDir = basePathFor(baseDir);
+			const escapedRootDir = ancestorDirFor(projectBaseDir);
+			const escapedAncestor = path.join(escapedRootDir, "ancestor-alpha.txt");
+			const escapedNestedDir = path.join(escapedRootDir, "ancestor-nested");
+
+			fs.mkdirSync(projectBaseDir, { recursive: true });
+			fs.mkdirSync(path.join(projectBaseDir, "sub dir"), { recursive: true });
+			fs.mkdirSync(escapedNestedDir, { recursive: true });
+			fs.writeFileSync(escapedAncestor, "ancestor\n");
+			fs.writeFileSync(path.join(escapedNestedDir, "ancestor-alpha-deep.txt"), "deep\n");
+
+			const provider = new CombinedAutocompleteProvider([], projectBaseDir);
+			const line = lineFor(projectBaseDir);
+			const result = await provider.getSuggestions([line], 0, line.length);
+			const values = result?.items.map(item => item.value) ?? [];
+
+			expect(values).toContain(expectedValue);
+			expect(values).not.toContain(unexpectedNestedValue);
+		});
+
+		it("treats ..-prefixed sibling names as descendants instead of ancestor escapes", async () => {
+			const dotDotSiblingDir = path.join(path.dirname(baseDir), "..fixtures");
+			fs.mkdirSync(dotDotSiblingDir, { recursive: true });
+			fs.writeFileSync(path.join(dotDotSiblingDir, "alpha-local.txt"), "alpha\n");
+			fs.writeFileSync(path.join(dotDotSiblingDir, "zeta.txt"), "zeta\n");
+
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = "@../..fixtures/alp";
+			const result = await provider.getSuggestions([line], 0, line.length);
+			const values = result?.items.map(item => item.value) ?? [];
+
+			expect(values).toContain("@../..fixtures/alpha-local.txt");
+			expect(values).not.toContain("@../..fixtures/zeta.txt");
+		});
+
 		it("cancels while resolving a scoped fuzzy-search directory", async () => {
 			const directoryStats = await fs.promises.stat(outsideDir);
 			const statStarted = Promise.withResolvers<void>();
@@ -178,7 +414,9 @@ describe("CombinedAutocompleteProvider", () => {
 				fs.rmSync(mentionRoot, { recursive: true, force: true });
 			});
 
-			it.each([
+			const boundedEnumerationCases: Array<
+				[name: string, inputFor: (root: string) => string, expectedFor: (root: string) => string]
+			> = [
 				[
 					"absolute",
 					(root: string) => `@${path.join(root, "im")}`,
@@ -192,7 +430,11 @@ describe("CombinedAutocompleteProvider", () => {
 				["home root", (_root: string) => "@~", (_root: string) => "@~/immediate-target.txt"],
 				["home child", (_root: string) => "@~/im", (_root: string) => "@~/immediate-target.txt"],
 				["quoted home child", (_root: string) => '@"~/im', (_root: string) => '@"~/immediate-target.txt"'],
-			])("enumerates only one directory segment for %s mentions", async (_name, inputFor, expectedFor) => {
+			];
+
+			it.each(
+				boundedEnumerationCases,
+			)("enumerates only one directory segment for %s mentions", async (_name, inputFor, expectedFor) => {
 				const line = inputFor(mentionRoot);
 				const provider = new CombinedAutocompleteProvider([], baseDir, mentionRoot);
 				const result = await provider.getSuggestions([line], 0, line.length);
@@ -209,6 +451,157 @@ describe("CombinedAutocompleteProvider", () => {
 				const result = await provider.getSuggestions([line], 0, line.length);
 
 				expect(result?.items.map(item => item.value)).toContain("@~/Downloads/");
+			});
+
+			const boundedScanCases: Array<
+				[
+					name: string,
+					inputFor: (root: string) => string,
+					expectedEarlyValues: (root: string) => string[],
+					expectedLate: (root: string) => string,
+				]
+			> = [
+				[
+					"absolute",
+					(root: string) => `@${path.join(root, "mat")}`,
+					(root: string) =>
+						Array.from(
+							{ length: 25 },
+							(_, index) => `@${path.join(root, `match-${index.toString().padStart(3, "0")}.txt`)}`,
+						),
+					(root: string) => `@${path.join(root, "match-late.txt")}`,
+				],
+				[
+					"home",
+					(_root: string) => "@~/mat",
+					(_root: string) =>
+						Array.from({ length: 25 }, (_, index) => `@~/match-${index.toString().padStart(3, "0")}.txt`),
+					(_root: string) => "@~/match-late.txt",
+				],
+			];
+
+			it.each(
+				boundedScanCases,
+			)("avoids full readdir materialization and caps bounded %s scans", async (_name, inputFor, expectedEarlyValues, expectedLate) => {
+				const entries: fs.Dirent[] = Array.from({ length: 150 }, (_, index) => {
+					const name =
+						index < 25
+							? `match-${index.toString().padStart(3, "0")}.txt`
+							: index === 120
+								? "match-late.txt"
+								: `filler-${index.toString().padStart(3, "0")}.txt`;
+					return {
+						name,
+						isDirectory: () => false,
+						isSymbolicLink: () => false,
+					} as fs.Dirent;
+				});
+				let iterated = 0;
+				let closed = false;
+				const readdirSpy = spyOn(fs.promises, "readdir").mockRejectedValue(
+					new Error("bounded completion must not call readdir"),
+				);
+				const opendirSpy = spyOn(fs.promises, "opendir").mockResolvedValue({
+					async read() {
+						const entry = entries[iterated] ?? null;
+						iterated += entry ? 1 : 0;
+						return entry;
+					},
+					async close() {
+						closed = true;
+					},
+				} as fs.Dir);
+
+				try {
+					const provider = new CombinedAutocompleteProvider([], baseDir, mentionRoot);
+					const line = inputFor(mentionRoot);
+					const result = await provider.getSuggestions([line], 0, line.length);
+					const values = result?.items.map(item => item.value) ?? [];
+
+					expect(opendirSpy).toHaveBeenCalledTimes(1);
+					expect(readdirSpy).not.toHaveBeenCalled();
+					expect(iterated).toBeLessThanOrEqual(100);
+					expect(closed).toBe(true);
+					expect(values).toHaveLength(20);
+					for (const expectedEarly of expectedEarlyValues(mentionRoot).slice(0, 20)) {
+						expect(values).toContain(expectedEarly);
+					}
+					expect(values).not.toContain(expectedLate(mentionRoot));
+				} finally {
+					opendirSpy.mockRestore();
+					readdirSpy.mockRestore();
+				}
+			});
+
+			it.each([
+				[
+					"natural relative path",
+					"relative/lat",
+					(provider: CombinedAutocompleteProvider, line: string) =>
+						provider.getSuggestions([line], 0, line.length),
+					"relative/late-target.txt",
+				],
+				[
+					"forced generic path",
+					"./lat",
+					(provider: CombinedAutocompleteProvider, line: string) =>
+						provider.getForceFileSuggestions([line], 0, line.length),
+					"./late-target.txt",
+				],
+			] as const)("preserves full %s scans beyond 100 entries", async (_name, line, requestSuggestions, expectedValue) => {
+				const entries: fs.Dirent[] = Array.from({ length: 150 }, (_, index) => {
+					const name = index === 120 ? "late-target.txt" : `filler-${index.toString().padStart(3, "0")}.txt`;
+					return {
+						name,
+						isDirectory: () => false,
+						isSymbolicLink: () => false,
+					} as fs.Dirent;
+				});
+				const readdirSpy = spyOn(fs.promises, "readdir").mockResolvedValue(
+					entries as unknown as Awaited<ReturnType<typeof fs.promises.readdir>>,
+				);
+				const opendirSpy = spyOn(fs.promises, "opendir").mockRejectedValue(
+					new Error("generic relative completion should not use bounded opendir"),
+				);
+
+				try {
+					const provider = new CombinedAutocompleteProvider([], baseDir, mentionRoot);
+					const result = await requestSuggestions(provider, line);
+					const values = result?.items.map(item => item.value) ?? [];
+
+					expect(readdirSpy).toHaveBeenCalledTimes(1);
+					expect(opendirSpy).not.toHaveBeenCalled();
+					expect(values).toContain(expectedValue);
+				} finally {
+					readdirSpy.mockRestore();
+					opendirSpy.mockRestore();
+				}
+			});
+
+			it("keeps forced absolute Tab completion exhaustive beyond the 100-entry natural scan cap", async () => {
+				const entries: fs.Dirent[] = Array.from({ length: 150 }, (_, index) => {
+					const name = index === 120 ? "late-target.txt" : `filler-${index.toString().padStart(3, "0")}.txt`;
+					return {
+						name,
+						isDirectory: () => false,
+						isSymbolicLink: () => false,
+					} as fs.Dirent;
+				});
+				const readdirSpy = spyOn(fs.promises, "readdir").mockResolvedValue(
+					entries as unknown as Awaited<ReturnType<typeof fs.promises.readdir>>,
+				);
+
+				try {
+					const provider = new CombinedAutocompleteProvider([], baseDir, mentionRoot);
+					const line = `mention ${path.join(mentionRoot, "lat")}`;
+					const result = await provider.getForceFileSuggestions([line], 0, line.length);
+					const values = result?.items.map(item => item.value) ?? [];
+
+					expect(readdirSpy).toHaveBeenCalledTimes(1);
+					expect(values).toContain(`${path.join(mentionRoot, "late-target.txt")}`);
+				} finally {
+					readdirSpy.mockRestore();
+				}
 			});
 
 			it("keeps bounded directory completions inside the mention token", async () => {
@@ -261,10 +654,85 @@ describe("CombinedAutocompleteProvider", () => {
 				expect(await provider.getSuggestions([line], 0, line.length, controller.signal)).toBeNull();
 			});
 
-			it.each([
-				"regular",
-				"forced",
-			] as const)("cancels %s bounded path completion while directory enumeration is pending", async mode => {
+			it("cancels natural bounded path completion while opendir enumeration is pending", async () => {
+				const readStarted = Promise.withResolvers<void>();
+				const releaseRead = Promise.withResolvers<void>();
+				const opendirSpy = spyOn(fs.promises, "opendir").mockResolvedValue({
+					async read() {
+						readStarted.resolve();
+						await releaseRead.promise;
+						return null;
+					},
+					async close() {},
+				} as fs.Dir);
+				const readdirSpy = spyOn(fs.promises, "readdir").mockRejectedValue(
+					new Error("bounded completion should not use readdir"),
+				);
+				const provider = new CombinedAutocompleteProvider([], mentionRoot, mentionRoot);
+				const line = `@${path.join(mentionRoot, "im")}`;
+				const controller = new AbortController();
+				const pending = provider.getSuggestions([line], 0, line.length, controller.signal);
+
+				try {
+					await readStarted.promise;
+					controller.abort();
+					const timeout = Symbol("timeout");
+					const outcome = await Promise.race([pending, Bun.sleep(100).then(() => timeout)]);
+
+					expect(opendirSpy).toHaveBeenCalledTimes(1);
+					expect(readdirSpy).not.toHaveBeenCalled();
+					expect(outcome).not.toBe(timeout);
+					expect(outcome).toBeNull();
+				} finally {
+					releaseRead.resolve();
+					opendirSpy.mockRestore();
+					readdirSpy.mockRestore();
+					await pending.catch(() => null);
+				}
+			});
+
+			it("closes a bounded directory handle that opens after cancellation", async () => {
+				const openStarted = Promise.withResolvers<void>();
+				const opened = Promise.withResolvers<fs.Dir>();
+				let closeCalls = 0;
+				const lateDir = {
+					async read() {
+						return null;
+					},
+					async close() {
+						closeCalls += 1;
+					},
+				} as fs.Dir;
+				const opendirSpy = spyOn(fs.promises, "opendir").mockImplementation(() => {
+					openStarted.resolve();
+					return opened.promise;
+				});
+				const provider = new CombinedAutocompleteProvider([], mentionRoot, mentionRoot);
+				const line = `@${path.join(mentionRoot, "im")}`;
+				const controller = new AbortController();
+				const pending = provider.getSuggestions([line], 0, line.length, controller.signal);
+
+				try {
+					await openStarted.promise;
+					controller.abort();
+					const timeout = Symbol("timeout");
+					const outcome = await Promise.race([pending, Bun.sleep(100).then(() => timeout)]);
+
+					expect(outcome).not.toBe(timeout);
+					expect(outcome).toBeNull();
+
+					opened.resolve(lateDir);
+					await Bun.sleep(0);
+
+					expect(closeCalls).toBe(1);
+				} finally {
+					opened.resolve(lateDir);
+					opendirSpy.mockRestore();
+					await pending.catch(() => null);
+				}
+			});
+
+			it("cancels forced generic path completion while full readdir is pending", async () => {
 				const readdirStarted = Promise.withResolvers<void>();
 				const releaseReaddir = Promise.withResolvers<void>();
 				const readdirSpy = spyOn(fs.promises, "readdir").mockImplementation(async () => {
@@ -272,14 +740,13 @@ describe("CombinedAutocompleteProvider", () => {
 					await releaseReaddir.promise;
 					return [];
 				});
+				const opendirSpy = spyOn(fs.promises, "opendir").mockRejectedValue(
+					new Error("forced generic completion should not use bounded opendir"),
+				);
 				const provider = new CombinedAutocompleteProvider([], mentionRoot, mentionRoot);
-				const line =
-					mode === "regular" ? `@${path.join(mentionRoot, "im")}` : `mention ${path.join(mentionRoot, "im")}`;
+				const line = `mention ${path.join(mentionRoot, "im")}`;
 				const controller = new AbortController();
-				const pending =
-					mode === "regular"
-						? provider.getSuggestions([line], 0, line.length, controller.signal)
-						: provider.getForceFileSuggestions([line], 0, line.length, controller.signal);
+				const pending = provider.getForceFileSuggestions([line], 0, line.length, controller.signal);
 
 				try {
 					await readdirStarted.promise;
@@ -287,12 +754,234 @@ describe("CombinedAutocompleteProvider", () => {
 					const timeout = Symbol("timeout");
 					const outcome = await Promise.race([pending, Bun.sleep(100).then(() => timeout)]);
 
+					expect(readdirSpy).toHaveBeenCalledTimes(1);
+					expect(opendirSpy).not.toHaveBeenCalled();
 					expect(outcome).not.toBe(timeout);
 					expect(outcome).toBeNull();
 				} finally {
 					releaseReaddir.resolve();
 					readdirSpy.mockRestore();
+					opendirSpy.mockRestore();
 					await pending.catch(() => null);
+				}
+			});
+
+			const literalSymlinkCases: Array<
+				[
+					name: string,
+					typedDirFor: (root: string) => string,
+					expectedFor: (root: string, typedDir: string) => string,
+				]
+			> = [
+				[
+					"absolute",
+					(root: string) => `${path.join(root, "link")}/../`,
+					(_root: string, typedDir: string) => `@${typedDir}candidate.txt`,
+				],
+				["home", (_root: string) => "~/link/../", (_root: string, typedDir: string) => `@${typedDir}candidate.txt`],
+			];
+
+			it.each(
+				literalSymlinkCases,
+			)("preserves literal %s symlink-plus-dotdot display paths", async (_name, typedDirFor, expectedFor) => {
+				if (process.platform === "win32") {
+					return;
+				}
+
+				fs.mkdirSync(path.join(mentionRoot, "real-parent", "child"), { recursive: true });
+				fs.writeFileSync(path.join(mentionRoot, "real-parent", "candidate.txt"), "candidate\n");
+				fs.symlinkSync(path.join(mentionRoot, "real-parent", "child"), path.join(mentionRoot, "link"), "dir");
+
+				const provider = new CombinedAutocompleteProvider([], baseDir, mentionRoot);
+				const typedDir = typedDirFor(mentionRoot);
+				const line = `@${typedDir}ca`;
+				const result = await provider.getSuggestions([line], 0, line.length);
+				const values = result?.items.map(item => item.value) ?? [];
+
+				expect(values).toContain(expectedFor(mentionRoot, typedDir));
+			});
+
+			it.each(
+				literalSymlinkCases,
+			)("preserves literal %s symlink-plus-dotdot display paths for forced completion", async (_name, typedDirFor, expectedFor) => {
+				if (process.platform === "win32") {
+					return;
+				}
+
+				fs.mkdirSync(path.join(mentionRoot, "real-parent", "child"), { recursive: true });
+				fs.writeFileSync(path.join(mentionRoot, "real-parent", "candidate.txt"), "candidate\n");
+				fs.symlinkSync(path.join(mentionRoot, "real-parent", "child"), path.join(mentionRoot, "link"), "dir");
+
+				const provider = new CombinedAutocompleteProvider([], baseDir, mentionRoot);
+				const typedDir = typedDirFor(mentionRoot);
+				const line = `mention ${typedDir}ca`;
+				const result = await provider.getForceFileSuggestions([line], 0, line.length);
+				const values = result?.items.map(item => item.value) ?? [];
+
+				expect(values).toContain(expectedFor(mentionRoot, typedDir).slice(1));
+			});
+
+			const missingSegmentSymlinkCases: Array<[name: string, typedDirFor: (root: string) => string]> = [
+				["absolute", (root: string) => `${path.join(root, "link")}/missing/../`],
+				["home", (_root: string) => "~/link/missing/../"],
+			];
+
+			it.each(
+				missingSegmentSymlinkCases,
+			)("does not collapse missing segments after a resolved %s symlink in natural mentions", async (_name, typedDirFor) => {
+				if (process.platform === "win32") {
+					return;
+				}
+
+				fs.mkdirSync(path.join(mentionRoot, "real-parent", "child"), { recursive: true });
+				fs.writeFileSync(path.join(mentionRoot, "real-parent", "child", "candidate.txt"), "candidate\n");
+				fs.symlinkSync(path.join(mentionRoot, "real-parent", "child"), path.join(mentionRoot, "link"), "dir");
+
+				const provider = new CombinedAutocompleteProvider([], baseDir, mentionRoot);
+				const line = `@${typedDirFor(mentionRoot)}ca`;
+				const result = await provider.getSuggestions([line], 0, line.length);
+
+				expect(result).toBeNull();
+			});
+
+			it.each(
+				missingSegmentSymlinkCases,
+			)("does not collapse missing segments after a resolved %s symlink in forced completion", async (_name, typedDirFor) => {
+				if (process.platform === "win32") {
+					return;
+				}
+
+				fs.mkdirSync(path.join(mentionRoot, "real-parent", "child"), { recursive: true });
+				fs.writeFileSync(path.join(mentionRoot, "real-parent", "child", "candidate.txt"), "candidate\n");
+				fs.symlinkSync(path.join(mentionRoot, "real-parent", "child"), path.join(mentionRoot, "link"), "dir");
+
+				const provider = new CombinedAutocompleteProvider([], baseDir, mentionRoot);
+				const line = `mention ${typedDirFor(mentionRoot)}ca`;
+				const result = await provider.getForceFileSuggestions([line], 0, line.length);
+
+				expect(result).toBeNull();
+			});
+
+			const nonDirectoryDotDotCases: Array<
+				[name: string, setup: (root: string) => void, typedDirFor: (root: string) => string]
+			> = [
+				[
+					"absolute regular file",
+					(root: string) => {
+						fs.writeFileSync(path.join(root, "plain.txt"), "plain\n");
+					},
+					(root: string) => `${path.join(root, "plain.txt")}/../`,
+				],
+				[
+					"home regular file",
+					(root: string) => {
+						fs.writeFileSync(path.join(root, "plain.txt"), "plain\n");
+					},
+					(_root: string) => "~/plain.txt/../",
+				],
+				[
+					"absolute symlink to file",
+					(root: string) => {
+						fs.writeFileSync(path.join(root, "plain.txt"), "plain\n");
+						fs.symlinkSync(path.join(root, "plain.txt"), path.join(root, "file-link"), "file");
+					},
+					(root: string) => `${path.join(root, "file-link")}/../`,
+				],
+				[
+					"home symlink to file",
+					(root: string) => {
+						fs.writeFileSync(path.join(root, "plain.txt"), "plain\n");
+						fs.symlinkSync(path.join(root, "plain.txt"), path.join(root, "file-link"), "file");
+					},
+					(_root: string) => "~/file-link/../",
+				],
+			];
+
+			it.each(
+				nonDirectoryDotDotCases,
+			)("treats %s as non-traversable in natural mentions", async (_name, setup, typedDirFor) => {
+				if (process.platform === "win32") {
+					return;
+				}
+
+				setup(mentionRoot);
+				const provider = new CombinedAutocompleteProvider([], baseDir, mentionRoot);
+				const line = `@${typedDirFor(mentionRoot)}ca`;
+				const result = await provider.getSuggestions([line], 0, line.length);
+
+				expect(result).toBeNull();
+			});
+
+			it.each(
+				nonDirectoryDotDotCases,
+			)("treats %s as non-traversable in forced completion", async (_name, setup, typedDirFor) => {
+				if (process.platform === "win32") {
+					return;
+				}
+
+				setup(mentionRoot);
+				const provider = new CombinedAutocompleteProvider([], baseDir, mentionRoot);
+				const line = `mention ${typedDirFor(mentionRoot)}ca`;
+				const result = await provider.getForceFileSuggestions([line], 0, line.length);
+
+				expect(result).toBeNull();
+			});
+
+			const relativeDotDotRequestCases = [
+				[
+					"natural mentions",
+					(provider: CombinedAutocompleteProvider, line: string) =>
+						provider.getSuggestions([line], 0, line.length),
+					(pathPrefix: string) => `@${pathPrefix}`,
+					(pathPrefix: string) => `@${pathPrefix}`,
+				],
+				[
+					"forced completion",
+					(provider: CombinedAutocompleteProvider, line: string) =>
+						provider.getForceFileSuggestions([line], 0, line.length),
+					(pathPrefix: string) => `mention ${pathPrefix}`,
+					(pathPrefix: string) => pathPrefix,
+				],
+			] as const;
+
+			it.each(
+				relativeDotDotRequestCases,
+			)("preserves relative directory-symlink-plus-dotdot semantics for %s", async (_name, request, lineFor, valueFor) => {
+				if (process.platform === "win32") {
+					return;
+				}
+
+				fs.mkdirSync(path.join(baseDir, "relative-parent", "child"), { recursive: true });
+				fs.writeFileSync(path.join(baseDir, "relative-parent", "candidate.txt"), "candidate\n");
+				fs.symlinkSync(path.join(baseDir, "relative-parent", "child"), path.join(baseDir, "relative-link"), "dir");
+
+				const provider = new CombinedAutocompleteProvider([], baseDir, mentionRoot);
+				const typedPrefix = "relative-link/../ca";
+				const result = await request(provider, lineFor(typedPrefix));
+				const values = result?.items.map(item => item.value) ?? [];
+
+				expect(values).toContain(valueFor("relative-link/../candidate.txt"));
+			});
+
+			it.each(
+				relativeDotDotRequestCases,
+			)("preserves relative ENOENT and ENOTDIR boundaries for %s", async (_name, request, lineFor, _valueFor) => {
+				if (process.platform === "win32") {
+					return;
+				}
+
+				fs.mkdirSync(path.join(baseDir, "relative-parent", "child"), { recursive: true });
+				fs.writeFileSync(path.join(baseDir, "relative-parent", "child", "candidate.txt"), "candidate\n");
+				fs.symlinkSync(path.join(baseDir, "relative-parent", "child"), path.join(baseDir, "relative-link"), "dir");
+				fs.writeFileSync(path.join(baseDir, "candidate.txt"), "candidate\n");
+				fs.writeFileSync(path.join(baseDir, "plain.txt"), "plain\n");
+				fs.symlinkSync(path.join(baseDir, "plain.txt"), path.join(baseDir, "file-link"), "file");
+
+				for (const typedPrefix of ["relative-link/missing/../ca", "plain.txt/../ca", "file-link/../ca"]) {
+					const provider = new CombinedAutocompleteProvider([], baseDir, mentionRoot);
+					const result = await request(provider, lineFor(typedPrefix));
+
+					expect(result).toBeNull();
 				}
 			});
 		});

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -133,6 +133,168 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(values).toContain("@../outside/nested/deeper/also-alpha.ts");
 			expect(values).not.toContain("@../outside/nested/deeper/zzz.ts");
 			expect(values.some(value => value.includes("alpha-local.ts"))).toBe(false);
+		});
+
+		it("cancels while resolving a scoped fuzzy-search directory", async () => {
+			const directoryStats = await fs.promises.stat(outsideDir);
+			const statStarted = Promise.withResolvers<void>();
+			const releaseStat = Promise.withResolvers<void>();
+			const statSpy = spyOn(fs.promises, "stat").mockImplementation((async () => {
+				statStarted.resolve();
+				await releaseStat.promise;
+				return directoryStats;
+			}) as unknown as typeof fs.promises.stat);
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = "@../outside/a";
+			const controller = new AbortController();
+			const pending = provider.getSuggestions([line], 0, line.length, controller.signal);
+
+			try {
+				await statStarted.promise;
+				controller.abort();
+				const timeout = Symbol("timeout");
+				const outcome = await Promise.race([pending, Bun.sleep(100).then(() => timeout)]);
+
+				expect(outcome).not.toBe(timeout);
+				expect(outcome).toBeNull();
+			} finally {
+				releaseStat.resolve();
+				statSpy.mockRestore();
+				await pending.catch(() => null);
+			}
+		});
+
+		describe("bounded absolute and home path completion", () => {
+			let mentionRoot: string;
+
+			beforeEach(() => {
+				mentionRoot = fs.mkdtempSync(path.join(os.tmpdir(), "autocomplete-absolute-test-"));
+				fs.mkdirSync(path.join(mentionRoot, "immediate-dir", "nested"), { recursive: true });
+				fs.writeFileSync(path.join(mentionRoot, "immediate-target.txt"), "immediate\n");
+				fs.writeFileSync(path.join(mentionRoot, "immediate-dir", "nested", "immediate-target.txt"), "nested\n");
+			});
+
+			afterEach(() => {
+				fs.rmSync(mentionRoot, { recursive: true, force: true });
+			});
+
+			it.each([
+				[
+					"absolute",
+					(root: string) => `@${path.join(root, "im")}`,
+					(root: string) => `@${path.join(root, "immediate-target.txt")}`,
+				],
+				[
+					"quoted absolute",
+					(root: string) => `@"${path.join(root, "im")}`,
+					(root: string) => `@"${path.join(root, "immediate-target.txt")}"`,
+				],
+				["home root", (_root: string) => "@~", (_root: string) => "@~/immediate-target.txt"],
+				["home child", (_root: string) => "@~/im", (_root: string) => "@~/immediate-target.txt"],
+				["quoted home child", (_root: string) => '@"~/im', (_root: string) => '@"~/immediate-target.txt"'],
+			])("enumerates only one directory segment for %s mentions", async (_name, inputFor, expectedFor) => {
+				const line = inputFor(mentionRoot);
+				const provider = new CombinedAutocompleteProvider([], baseDir, mentionRoot);
+				const result = await provider.getSuggestions([line], 0, line.length);
+				const values = result?.items.map(item => item.value) ?? [];
+
+				expect(values).toContain(expectedFor(mentionRoot));
+				expect(values.some(value => value.replaceAll("\\", "/").includes("/nested/"))).toBe(false);
+			});
+
+			it("preserves fuzzy matching within a bounded path segment", async () => {
+				fs.mkdirSync(path.join(mentionRoot, "Downloads"));
+				const provider = new CombinedAutocompleteProvider([], baseDir, mentionRoot);
+				const line = "@~/dwn";
+				const result = await provider.getSuggestions([line], 0, line.length);
+
+				expect(result?.items.map(item => item.value)).toContain("@~/Downloads/");
+			});
+
+			it("keeps bounded directory completions inside the mention token", async () => {
+				const provider = new CombinedAutocompleteProvider([], baseDir, mentionRoot);
+				const line = `@${path.join(mentionRoot, "immediate-d")}`;
+				const result = await provider.getSuggestions([line], 0, line.length);
+				const directory = result?.items.find(item => item.label === "immediate-dir/");
+
+				expect(directory).toBeDefined();
+				if (!result || !directory) throw new Error("expected immediate directory completion");
+
+				const applied = provider.applyCompletion([line], 0, line.length, directory, result.prefix);
+				const completedLine = `@${path.join(mentionRoot, "immediate-dir")}/`;
+
+				expect(applied.lines).toEqual([completedLine]);
+				expect(applied.cursorCol).toBe(completedLine.length);
+
+				const childResult = await provider.getSuggestions(applied.lines, applied.cursorLine, applied.cursorCol);
+				expect(childResult?.items.map(item => item.value)).toContain(`${completedLine}nested/`);
+			});
+
+			it("still terminates bounded file mentions with a space", async () => {
+				const provider = new CombinedAutocompleteProvider([], baseDir, mentionRoot);
+				const line = `@${path.join(mentionRoot, "immediate-t")}`;
+				const result = await provider.getSuggestions([line], 0, line.length);
+				const file = result?.items.find(item => item.label === "immediate-target.txt");
+
+				expect(file).toBeDefined();
+				if (!result || !file) throw new Error("expected immediate file completion");
+
+				const applied = provider.applyCompletion([line], 0, line.length, file, result.prefix);
+				const completedLine = `@${path.join(mentionRoot, "immediate-target.txt")} `;
+
+				expect(applied.lines).toEqual([completedLine]);
+				expect(applied.cursorCol).toBe(completedLine.length);
+			});
+
+			it("does not fall back to directory enumeration after native fuzzy cancellation", async () => {
+				fs.mkdirSync(path.join(mentionRoot, "nested"), { recursive: true });
+				fs.writeFileSync(path.join(mentionRoot, "nested", "signal-target.txt"), "signal\n");
+				fs.writeFileSync(path.join(mentionRoot, "signaltarget-local.txt"), "fallback\n");
+				const provider = new CombinedAutocompleteProvider([], mentionRoot, mentionRoot);
+				const line = "@signaltarget";
+
+				const activeResult = await provider.getSuggestions([line], 0, line.length);
+				expect(activeResult?.items.some(item => item.value.includes("signal-target.txt"))).toBe(true);
+
+				const controller = new AbortController();
+				controller.abort();
+				expect(await provider.getSuggestions([line], 0, line.length, controller.signal)).toBeNull();
+			});
+
+			it.each([
+				"regular",
+				"forced",
+			] as const)("cancels %s bounded path completion while directory enumeration is pending", async mode => {
+				const readdirStarted = Promise.withResolvers<void>();
+				const releaseReaddir = Promise.withResolvers<void>();
+				const readdirSpy = spyOn(fs.promises, "readdir").mockImplementation(async () => {
+					readdirStarted.resolve();
+					await releaseReaddir.promise;
+					return [];
+				});
+				const provider = new CombinedAutocompleteProvider([], mentionRoot, mentionRoot);
+				const line =
+					mode === "regular" ? `@${path.join(mentionRoot, "im")}` : `mention ${path.join(mentionRoot, "im")}`;
+				const controller = new AbortController();
+				const pending =
+					mode === "regular"
+						? provider.getSuggestions([line], 0, line.length, controller.signal)
+						: provider.getForceFileSuggestions([line], 0, line.length, controller.signal);
+
+				try {
+					await readdirStarted.promise;
+					controller.abort();
+					const timeout = Symbol("timeout");
+					const outcome = await Promise.race([pending, Bun.sleep(100).then(() => timeout)]);
+
+					expect(outcome).not.toBe(timeout);
+					expect(outcome).toBeNull();
+				} finally {
+					releaseReaddir.resolve();
+					readdirSpy.mockRestore();
+					await pending.catch(() => null);
+				}
+			});
 		});
 	});
 	describe("dot-slash path completion", () => {

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -6,6 +6,7 @@ import { __editorPerfCounters, Editor } from "@gajae-code/tui/components/editor"
 import { visibleWidth } from "@gajae-code/tui/utils";
 import { getDefaultTabWidth, setDefaultTabWidth } from "@gajae-code/utils";
 import { KeybindingsManager, setKeybindings, TUI_KEYBINDINGS } from "../src/keybindings";
+import { StdinBuffer } from "../src/stdin-buffer";
 import { defaultEditorTheme } from "./test-themes";
 
 describe("Editor component", () => {
@@ -317,6 +318,135 @@ describe("Editor component", () => {
 			editor.handleInput("@");
 
 			await expect(promise).resolves.toBe("@");
+		});
+
+		it("re-triggers file-reference autocomplete for @~ in one stdin chunk", async () => {
+			const editor = new Editor(defaultEditorTheme);
+			const stdin = new StdinBuffer();
+			const calls: string[] = [];
+
+			editor.setAutocompleteProvider({
+				async getSuggestions(lines, cursorLine, cursorCol) {
+					calls.push((lines[cursorLine] ?? "").slice(0, cursorCol));
+					return null;
+				},
+				applyCompletion(lines, cursorLine, cursorCol) {
+					return { lines, cursorLine, cursorCol };
+				},
+			});
+
+			stdin.on("data", sequence => editor.handleInput(sequence));
+			stdin.process(Buffer.from("@~"));
+			await Bun.sleep(0);
+
+			expect(calls).toEqual(["@", "@~"]);
+		});
+
+		it("aborts superseded autocomplete requests from a single stdin chunk and on dismissal", async () => {
+			const editor = new Editor(defaultEditorTheme);
+			const stdin = new StdinBuffer();
+			let calls = 0;
+			let active = 0;
+			let peakActive = 0;
+			let latestText = "";
+
+			editor.setAutocompleteProvider({
+				async getSuggestions(lines, cursorLine, cursorCol, signal) {
+					calls += 1;
+					latestText = (lines[cursorLine] ?? "").slice(0, cursorCol);
+					active += 1;
+					peakActive = Math.max(peakActive, active);
+					return new Promise((_resolve, reject) => {
+						signal?.addEventListener(
+							"abort",
+							() => {
+								active -= 1;
+								reject(signal.reason);
+							},
+							{ once: true },
+						);
+					});
+				},
+				applyCompletion(lines, cursorLine, cursorCol) {
+					return { lines, cursorLine, cursorCol };
+				},
+			});
+
+			stdin.on("data", sequence => editor.handleInput(sequence));
+			stdin.process(Buffer.from("@/isolated/path"));
+
+			expect(calls).toBeGreaterThan(1);
+			expect(latestText).toBe("@/isolated/path");
+			expect(peakActive).toBe(1);
+			expect(active).toBe(1);
+
+			editor.handleInput("\x1b");
+			expect(active).toBe(0);
+		});
+
+		it.each([
+			["left-arrow", (editor: Editor) => editor.handleInput("\x1b[D")],
+			["line-start", (editor: Editor) => editor.moveToLineStart()],
+			["word-left", (editor: Editor) => editor.handleInput("\x1bb")],
+		])("aborts an in-flight autocomplete request after %s navigation moves the cursor", async (_name, navigate) => {
+			const editor = new Editor(defaultEditorTheme);
+			const requestStarted = Promise.withResolvers<AbortSignal>();
+
+			editor.setAutocompleteProvider({
+				async getSuggestions(_lines, _cursorLine, _cursorCol, signal) {
+					if (!signal) throw new Error("expected autocomplete cancellation signal");
+					requestStarted.resolve(signal);
+					return new Promise((_resolve, reject) => {
+						signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+					});
+				},
+				applyCompletion(lines, cursorLine, cursorCol) {
+					return { lines, cursorLine, cursorCol };
+				},
+			});
+
+			editor.handleInput("@");
+			const signal = await requestStarted.promise;
+
+			try {
+				navigate(editor);
+				expect(editor.getCursor()).toEqual({ line: 0, col: 0 });
+				expect(signal.aborted).toBe(true);
+				expect(editor.isShowingAutocomplete()).toBe(false);
+			} finally {
+				editor.handleInput("\x1b");
+				await Bun.sleep(0);
+			}
+		});
+
+		it("keeps an in-flight autocomplete request when navigation is a no-op", async () => {
+			const editor = new Editor(defaultEditorTheme);
+			const requestStarted = Promise.withResolvers<AbortSignal>();
+
+			editor.setAutocompleteProvider({
+				async getSuggestions(_lines, _cursorLine, _cursorCol, signal) {
+					if (!signal) throw new Error("expected autocomplete cancellation signal");
+					requestStarted.resolve(signal);
+					return new Promise((_resolve, reject) => {
+						signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+					});
+				},
+				applyCompletion(lines, cursorLine, cursorCol) {
+					return { lines, cursorLine, cursorCol };
+				},
+			});
+
+			editor.handleInput("@");
+			const signal = await requestStarted.promise;
+
+			try {
+				editor.handleInput("\x1b[C");
+				expect(editor.getCursor()).toEqual({ line: 0, col: 1 });
+				expect(signal.aborted).toBe(false);
+			} finally {
+				editor.handleInput("\x1b");
+				await Bun.sleep(0);
+			}
 		});
 
 		it("triggers prompt-action autocomplete when typing hash", async () => {

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -9,6 +9,12 @@ import { KeybindingsManager, setKeybindings, TUI_KEYBINDINGS } from "../src/keyb
 import { StdinBuffer } from "../src/stdin-buffer";
 import { defaultEditorTheme } from "./test-themes";
 
+function createAbortOnlyPromise(signal: AbortSignal): Promise<never> {
+	const pending = Promise.withResolvers<never>();
+	signal.addEventListener("abort", () => pending.reject(signal.reason), { once: true });
+	return pending.promise;
+}
+
 describe("Editor component", () => {
 	const originalTabWidth = getDefaultTabWidth();
 
@@ -356,16 +362,17 @@ describe("Editor component", () => {
 					latestText = (lines[cursorLine] ?? "").slice(0, cursorCol);
 					active += 1;
 					peakActive = Math.max(peakActive, active);
-					return new Promise((_resolve, reject) => {
-						signal?.addEventListener(
-							"abort",
-							() => {
-								active -= 1;
-								reject(signal.reason);
-							},
-							{ once: true },
-						);
-					});
+					if (!signal) throw new Error("expected autocomplete cancellation signal");
+					const pending = Promise.withResolvers<never>();
+					signal.addEventListener(
+						"abort",
+						() => {
+							active -= 1;
+							pending.reject(signal.reason);
+						},
+						{ once: true },
+					);
+					return pending.promise;
 				},
 				applyCompletion(lines, cursorLine, cursorCol) {
 					return { lines, cursorLine, cursorCol };
@@ -396,9 +403,7 @@ describe("Editor component", () => {
 				async getSuggestions(_lines, _cursorLine, _cursorCol, signal) {
 					if (!signal) throw new Error("expected autocomplete cancellation signal");
 					requestStarted.resolve(signal);
-					return new Promise((_resolve, reject) => {
-						signal.addEventListener("abort", () => reject(signal.reason), { once: true });
-					});
+					return createAbortOnlyPromise(signal);
 				},
 				applyCompletion(lines, cursorLine, cursorCol) {
 					return { lines, cursorLine, cursorCol };
@@ -427,9 +432,7 @@ describe("Editor component", () => {
 				async getSuggestions(_lines, _cursorLine, _cursorCol, signal) {
 					if (!signal) throw new Error("expected autocomplete cancellation signal");
 					requestStarted.resolve(signal);
-					return new Promise((_resolve, reject) => {
-						signal.addEventListener("abort", () => reject(signal.reason), { once: true });
-					});
+					return createAbortOnlyPromise(signal);
 				},
 				applyCompletion(lines, cursorLine, cursorCol) {
 					return { lines, cursorLine, cursorCol };
@@ -447,6 +450,191 @@ describe("Editor component", () => {
 				editor.handleInput("\x1b");
 				await Bun.sleep(0);
 			}
+		});
+
+		it("does not reopen autocomplete when a disposed request resolves after ignoring abort", async () => {
+			const editor = new Editor(defaultEditorTheme);
+			const pending = Promise.withResolvers<{
+				items: Array<{ label: string; value: string }>;
+				prefix: string;
+			} | null>();
+			let updates = 0;
+			editor.onAutocompleteUpdate = () => {
+				updates += 1;
+			};
+
+			editor.setAutocompleteProvider({
+				async getSuggestions() {
+					return pending.promise;
+				},
+				applyCompletion(lines, cursorLine, cursorCol) {
+					return { lines, cursorLine, cursorCol };
+				},
+			});
+
+			editor.handleInput("@");
+			await Bun.sleep(0);
+			editor.dispose();
+
+			pending.resolve({ items: [{ label: "src/", value: "src/" }], prefix: "@" });
+			await Bun.sleep(0);
+
+			expect(updates).toBe(0);
+			expect(editor.isShowingAutocomplete()).toBe(false);
+			expect(editor.isAutocompleteOpen()).toBe(false);
+		});
+
+		it("closes a settled autocomplete popup on escape and reports cancellation", async () => {
+			const editor = new Editor(defaultEditorTheme);
+			const cancellations: number[] = [];
+			editor.onAutocompleteCancel = () => {
+				cancellations.push(1);
+			};
+
+			editor.setAutocompleteProvider({
+				async getSuggestions() {
+					return { items: [{ label: "src/", value: "src/" }], prefix: "@" };
+				},
+				applyCompletion(lines, cursorLine, cursorCol) {
+					return { lines, cursorLine, cursorCol };
+				},
+			});
+
+			editor.handleInput("@");
+			await Bun.sleep(0);
+			expect(editor.isShowingAutocomplete()).toBe(true);
+			expect(editor.isAutocompleteOpen()).toBe(true);
+
+			editor.handleInput("\x1b");
+
+			expect(cancellations).toHaveLength(1);
+			expect(editor.isShowingAutocomplete()).toBe(false);
+			expect(editor.isAutocompleteOpen()).toBe(false);
+		});
+
+		it.each([
+			[
+				"ctrl+u",
+				(editor: Editor) => {
+					editor.setText("@seed");
+				},
+				(editor: Editor) => editor.handleInput("\x15"),
+			],
+			[
+				"ctrl+k",
+				(editor: Editor) => {
+					editor.setText("@seed");
+					editor.moveToLineStart();
+					editor.handleInput("\x1b[C");
+				},
+				(editor: Editor) => editor.handleInput("\x0b"),
+			],
+			[
+				"newline",
+				(editor: Editor) => {
+					editor.setText("@seed");
+				},
+				(editor: Editor) => editor.handleInput("\n"),
+			],
+			[
+				"yank",
+				(editor: Editor) => {
+					editor.setText("seed");
+					editor.handleInput("\x15");
+					editor.setText("@");
+				},
+				(editor: Editor) => editor.handleInput("\x19"),
+			],
+			[
+				"yank-pop",
+				(editor: Editor) => {
+					editor.setText("first");
+					editor.handleInput("\x15");
+					editor.setText("second");
+					editor.handleInput("\x15");
+					editor.setText("@");
+					editor.handleInput("\x19");
+				},
+				(editor: Editor) => editor.handleInput("\x1by"),
+			],
+			[
+				"undo",
+				(editor: Editor) => {
+					editor.setText("@");
+					editor.handleInput("x");
+				},
+				(editor: Editor) => editor.handleInput("\x1b[45;5u"),
+			],
+		])("aborts an in-flight autocomplete request after %s edits the document", async (_name, setup, edit) => {
+			const editor = new Editor(defaultEditorTheme);
+			const requestStarted = Promise.withResolvers<AbortSignal>();
+			const provider = {
+				async getSuggestions() {
+					return null;
+				},
+				applyCompletion(lines: string[], cursorLine: number, cursorCol: number) {
+					return { lines, cursorLine, cursorCol };
+				},
+				async getForceFileSuggestions(
+					_lines: string[],
+					_cursorLine: number,
+					_cursorCol: number,
+					signal?: AbortSignal,
+				) {
+					if (!signal) throw new Error("expected autocomplete cancellation signal");
+					requestStarted.resolve(signal);
+					return createAbortOnlyPromise(signal);
+				},
+			} satisfies AutocompleteProvider & {
+				getForceFileSuggestions(
+					lines: string[],
+					cursorLine: number,
+					cursorCol: number,
+					signal?: AbortSignal,
+				): Promise<never>;
+			};
+			editor.setAutocompleteProvider(provider);
+
+			setup(editor);
+			editor.handleInput("\t");
+			const signal = await requestStarted.promise;
+
+			try {
+				edit(editor);
+				expect(signal.aborted).toBe(true);
+				expect(editor.isShowingAutocomplete()).toBe(false);
+			} finally {
+				editor.handleInput("\x1b");
+				await Bun.sleep(0);
+			}
+		});
+
+		it("re-triggers file autocomplete inside an open quoted @ mention with spaces", async () => {
+			const editor = new Editor(defaultEditorTheme);
+			const calls = Promise.withResolvers<string[]>();
+			const seen: string[] = [];
+
+			editor.setAutocompleteProvider({
+				async getSuggestions(lines, cursorLine, cursorCol) {
+					seen.push((lines[cursorLine] ?? "").slice(0, cursorCol));
+					if (seen.length === 2) {
+						calls.resolve([...seen]);
+					}
+					return {
+						items: [{ label: "nested/", value: '@"dir with spaces/nested/' }],
+						prefix: '@"dir with spaces/n',
+					};
+				},
+				applyCompletion(lines, cursorLine, cursorCol) {
+					return { lines, cursorLine, cursorCol };
+				},
+			});
+
+			editor.handleInput("@");
+			editor.setText('@"dir with spaces/');
+			editor.handleInput("n");
+
+			await expect(calls.promise).resolves.toEqual(["@", '@"dir with spaces/n']);
 		});
 
 		it("triggers prompt-action autocomplete when typing hash", async () => {


### PR DESCRIPTION
## What

- Cancel superseded, dismissed, cursor-invalidated, and disposed autocomplete requests through the editor, coding-agent wrapper, scoped filesystem work, and native fuzzy discovery.
- Bound natural absolute (`@/...`), home (`@~`, `@~/...`), strict-ancestor, and off-project-symlink mentions before directory contents are fully materialized or cached.
- Close directory handles that arrive after cancellation wins an in-flight bounded `opendir()`, without delaying cancellation.
- Keep explicit Tab completion exhaustive and preserve the established recursive behavior for ordinary relative paths, direct siblings, and project-internal symlinks.
- Resolve typed paths one component at a time so valid directory-symlink-plus-`..` paths remain usable, while missing segments, regular files, and symlinks to files retain kernel-shaped `ENOENT` or `ENOTDIR` behavior.
- Prevent late results from signal-ignoring providers from reopening stale autocomplete state after edits, navigation, Escape/interrupt handling, or editor disposal.

## Why

The TUI emits a pasted or terminal-sent chunk one code point at a time. A single absolute `@` path could therefore start many concurrent recursive fuzzy scans rooted at `/`; request IDs rejected stale results only after the underlying scans completed.

On the affected macOS host, one input produced 57 overlapping requests and the process exhausted roughly 83 GiB before it was killed. The fix stops stale work and bounds only the natural path scopes that can escape the project, without truncating explicit or established project-relative completion behavior.

This supersedes #3460 and addresses all five exact-head blockers from its owner review: streamed/capped flat-directory enumeration, literal symlink-plus-`..` display paths, full disposal invalidation, centralized invalidation for real document edits, and `Promise.withResolvers()` in the cancellation tests.

## Testing

- Fail-before/pass-after regressions cover:
  - same-chunk request fan-out, supersession, dismissal, navigation, edits, Escape/priority interrupts, disposal, and signal-ignoring late results;
  - bounded absolute, quoted-absolute, home, ancestor-escape, and off-project-symlink lookup;
  - exhaustive forced Tab, direct-sibling recursion, ordinary relative paths, and project-internal symlink recursion;
  - absolute, home, and relative directory-symlink-plus-`..` display semantics;
  - missing-segment-plus-`..`, regular-file-plus-`..`, and file-symlink-plus-`..` `ENOENT`/`ENOTDIR` boundaries;
  - cancellation while scoped `stat`, `readdir`, `opendir`, `realpath`, and symlink work is pending.
- Focused four-file suite:
  - `300 passed`, `0 failed`.
- `packages/tui/test/autocomplete.test.ts`:
  - `92 passed`, `0 failed`.
- Full `packages/tui` suite:
  - `982 passed`, `6` opt-in PTY tests skipped, `0 failed`.
- `bun --cwd=packages/tui run check`
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run build`
- `git diff --check origin/dev..HEAD`
- Three independent local review lanes and an exact-head GJC critic review approved the final range.
- The known-dangerous pre-fix live replay against `/` was not repeated. An isolated fixed-build tmux replay on the affected host remained responsive, produced suggestions, showed bounded RSS growth, and had no exit `137`.

The root `bun check` reaches an SDK rename guard that also fails on exact `origin/dev` because the tracked issue document `issues/21-session-resume-model-behavior-not-configurable.md` still contains the historical string `src/sdk.ts`. This PR does not modify that file or introduce the failure. The affected package checks and downstream build pass.

Windows drive-letter, UNC, and junction completion were not exercised locally. The implementation remains fail-soft and abort-aware for filesystem races.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:7702cee14c200ce0b8426b3865cc6880686b0669 reviewer:critic evidence:gjc-codex-auto-review
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (pre-existing exact-`origin/dev` SDK rename guard failure documented above)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
