### PR TITLE
Unify native terminal key parsing

### DIFF
--- a/crates/pi-natives/src/keys.rs
+++ b/crates/pi-natives/src/keys.rs
@@ -201,8 +201,11 @@ static LEGACY_SEQUENCES: phf::Map<&'static [u8], &'static str> = phf_map! {
 	b"\x1b[[A" => "f1", b"\x1b[[B" => "f2", b"\x1b[[C" => "f3", b"\x1b[[D" => "f4", b"\x1b[[E" => "f5",
 	b"\x1b[15~" => "f5", b"\x1b[17~" => "f6", b"\x1b[18~" => "f7", b"\x1b[19~" => "f8",
 	b"\x1b[20~" => "f9", b"\x1b[21~" => "f10", b"\x1b[23~" => "f11", b"\x1b[24~" => "f12",
-	// Alt+arrow (legacy)
-	b"\x1bb" => "alt+left", b"\x1bf" => "alt+right", b"\x1bp" => "alt+up", b"\x1bn" => "alt+down",
+	// Alt+arrow (legacy Meta navigation aliases)
+	b"\x1bb" => "alt+left", b"\x1bB" => "alt+left",
+	b"\x1bf" => "alt+right", b"\x1bF" => "alt+right",
+	b"\x1bp" => "alt+up", b"\x1bP" => "alt+up",
+	b"\x1bn" => "alt+down", b"\x1bN" => "alt+down",
 };
 
 /// Pre-allocated single ASCII printable characters (33-126)
@@ -775,7 +778,7 @@ fn matches_key_inner(bytes: &[u8], key_id: &str, kitty_protocol_active: bool) ->
 
 	if key.eq_ignore_ascii_case("up") {
 		if modifier == MOD_ALT {
-			return bytes == b"\x1bp" || kitty_matches(ARROW_UP, MOD_ALT);
+			return matches_legacy_key(bytes, "alt+up") || kitty_matches(ARROW_UP, MOD_ALT);
 		}
 		if modifier == 0 {
 			return matches_legacy_key(bytes, "up") || kitty_matches(ARROW_UP, 0);
@@ -786,7 +789,7 @@ fn matches_key_inner(bytes: &[u8], key_id: &str, kitty_protocol_active: bool) ->
 
 	if key.eq_ignore_ascii_case("down") {
 		if modifier == MOD_ALT {
-			return bytes == b"\x1bn" || kitty_matches(ARROW_DOWN, MOD_ALT);
+			return matches_legacy_key(bytes, "alt+down") || kitty_matches(ARROW_DOWN, MOD_ALT);
 		}
 		if modifier == 0 {
 			return matches_legacy_key(bytes, "down") || kitty_matches(ARROW_DOWN, 0);
@@ -798,8 +801,7 @@ fn matches_key_inner(bytes: &[u8], key_id: &str, kitty_protocol_active: bool) ->
 	if key.eq_ignore_ascii_case("left") {
 		if modifier == MOD_ALT {
 			return bytes == b"\x1b[1;3D"
-				|| (!kitty_protocol_active && bytes == b"\x1bB")
-				|| bytes == b"\x1bb"
+				|| matches_legacy_key(bytes, "alt+left")
 				|| kitty_matches(ARROW_LEFT, MOD_ALT);
 		}
 		if modifier == MOD_CTRL {
@@ -817,8 +819,7 @@ fn matches_key_inner(bytes: &[u8], key_id: &str, kitty_protocol_active: bool) ->
 	if key.eq_ignore_ascii_case("right") {
 		if modifier == MOD_ALT {
 			return bytes == b"\x1b[1;3C"
-				|| (!kitty_protocol_active && bytes == b"\x1bF")
-				|| bytes == b"\x1bf"
+				|| matches_legacy_key(bytes, "alt+right")
 				|| kitty_matches(ARROW_RIGHT, MOD_ALT);
 		}
 		if modifier == MOD_CTRL {
@@ -878,13 +879,25 @@ fn matches_key_inner(bytes: &[u8], key_id: &str, kitty_protocol_active: bool) ->
 		}
 
 		// alt+letter in legacy mode
-		if modifier == MOD_ALT && !kitty_protocol_active && is_letter {
-			return bytes.len() == 2 && bytes[0] == 0x1b && bytes[1] == ch;
+		// Legacy ALT-prefix parsing remains valid when Kitty is enabled: terminals
+		// can negotiate Kitty support yet still emit these sequences for Option.
+		if modifier == MOD_ALT && is_letter {
+			return (!is_legacy_meta_navigation_alias(bytes)
+				&& bytes.len() == 2
+				&& bytes[0] == 0x1b
+				&& bytes[1] == ch)
+				|| kitty_matches(codepoint, MOD_ALT)
+				|| mok_matches(codepoint, MOD_ALT);
 		}
 
 		// alt+shift+letter in legacy mode (ESC + UPPERCASE letter)
-		if modifier == (MOD_ALT | MOD_SHIFT) && !kitty_protocol_active && is_letter {
-			return bytes.len() == 2 && bytes[0] == 0x1b && bytes[1] == ch.to_ascii_uppercase();
+		if modifier == (MOD_ALT | MOD_SHIFT) && is_letter {
+			return (!is_legacy_meta_navigation_alias(bytes)
+				&& bytes.len() == 2
+				&& bytes[0] == 0x1b
+				&& bytes[1] == ch.to_ascii_uppercase())
+				|| kitty_matches(codepoint, MOD_ALT | MOD_SHIFT)
+				|| mok_matches(codepoint, MOD_ALT | MOD_SHIFT);
 		}
 
 		// ctrl+key
@@ -1076,21 +1089,29 @@ fn parse_esc_pair(code: u8, kitty_protocol_active: bool) -> Option<Cow<'static, 
 		_ => {},
 	}
 
-	// Legacy ALT-prefix parsing only when kitty protocol isn't expected to
-	// disambiguate.
-	if !kitty_protocol_active {
-		match code {
-			b' ' => return Some(Cow::Borrowed("alt+space")),
-			b'B' => return Some(Cow::Borrowed("alt+left")),
-			b'F' => return Some(Cow::Borrowed("alt+right")),
-			1..=26 => return Some(Cow::Borrowed(CTRL_ALT_LETTERS[(code - 1) as usize])),
-			b'a'..=b'z' => return Some(Cow::Borrowed(ALT_LETTERS[(code - b'a') as usize])),
-			b'A'..=b'Z' => return Some(Cow::Borrowed(ALT_SHIFT_LETTERS[(code - b'A') as usize])),
-			_ => {},
-		}
+	// Legacy Meta navigation aliases always retain their navigation meaning;
+	// CSI-u and modifyOtherKeys provide the disambiguated literal Alt-letter path.
+	match code {
+		b'b' | b'B' => Some(Cow::Borrowed("alt+left")),
+		b'f' | b'F' => Some(Cow::Borrowed("alt+right")),
+		b'p' | b'P' => Some(Cow::Borrowed("alt+up")),
+		b'n' | b'N' => Some(Cow::Borrowed("alt+down")),
+		b'a'..=b'z' => Some(Cow::Borrowed(ALT_LETTERS[(code - b'a') as usize])),
+		b'A'..=b'Z' => Some(Cow::Borrowed(ALT_SHIFT_LETTERS[(code - b'A') as usize])),
+		b' ' if !kitty_protocol_active => Some(Cow::Borrowed("alt+space")),
+		1..=26 if !kitty_protocol_active => {
+			Some(Cow::Borrowed(CTRL_ALT_LETTERS[(code - 1) as usize]))
+		},
+		_ => None,
 	}
+}
 
-	None
+#[inline]
+const fn is_legacy_meta_navigation_alias(bytes: &[u8]) -> bool {
+	matches!(
+		bytes,
+		b"\x1bb" | b"\x1bB" | b"\x1bf" | b"\x1bF" | b"\x1bp" | b"\x1bP" | b"\x1bn" | b"\x1bN"
+	)
 }
 
 // =============================================================================
@@ -1287,6 +1308,10 @@ fn parse_functional(bytes: &[u8]) -> Option<ParsedKittySequence> {
 	}
 
 	let codepoint = match key_num {
+		// PSMux encodes Shift+Enter and Ctrl+Shift+Enter using the F3
+		// functional-key number. Normalize those established terminal sequences
+		// before the generic function-key mapping.
+		13 if mod_value == 2 || mod_value == 6 => CP_ENTER,
 		// Common functional keys
 		2 => FUNC_INSERT,
 		3 => FUNC_DELETE,
@@ -1423,13 +1448,15 @@ fn format_key_name(codepoint: i32) -> Option<&'static str> {
 #[inline]
 fn format_with_mods(mods: u32, key_name: &str) -> String {
 	let mut result = String::with_capacity(16);
-	if mods & MOD_SHIFT != 0 {
+	if mods & MOD_ALT != 0 && mods & MOD_SHIFT != 0 {
+		result.push_str("alt+shift+");
+	} else if mods & MOD_SHIFT != 0 {
 		result.push_str("shift+");
 	}
 	if mods & MOD_CTRL != 0 {
 		result.push_str("ctrl+");
 	}
-	if mods & MOD_ALT != 0 {
+	if mods & MOD_ALT != 0 && mods & MOD_SHIFT == 0 {
 		result.push_str("alt+");
 	}
 	if mods & MOD_SUPER != 0 {
@@ -1499,6 +1526,46 @@ mod tests {
 		assert!(!matches_key_inner(b"\x1b[27;5;27~", "escape", false));
 		assert!(matches_key_inner(b"\x1b[27;5u", "ctrl+escape", true));
 		assert!(matches_key_inner(b"\x1b[27;9u", "super+escape", true));
+	}
+	#[test]
+	fn two_byte_escape_sequences_are_parse_match_symmetric() {
+		let cases = [
+			(b"\x1bi".as_slice(), "alt+i", true, true),
+			(b"\x1bI".as_slice(), "alt+shift+i", true, true),
+			(b"\x1b ".as_slice(), "alt+space", true, false),
+			(b"\x1b\x01".as_slice(), "ctrl+alt+a", true, false),
+		];
+
+		for (bytes, key_id, kitty_active, expected_match) in cases {
+			assert_eq!(
+				parse_key_inner(bytes, kitty_active)
+					.as_deref()
+					.is_some_and(|parsed| parsed == key_id),
+				expected_match,
+			);
+			assert_eq!(matches_key_inner(bytes, key_id, kitty_active), expected_match);
+		}
+	}
+	#[test]
+	fn legacy_meta_navigation_aliases_are_exclusive_under_kitty_on_and_off() {
+		let cases = [
+			(b"\x1bb".as_slice(), "alt+left", "alt+b"),
+			(b"\x1bB".as_slice(), "alt+left", "alt+shift+b"),
+			(b"\x1bf".as_slice(), "alt+right", "alt+f"),
+			(b"\x1bF".as_slice(), "alt+right", "alt+shift+f"),
+			(b"\x1bp".as_slice(), "alt+up", "alt+p"),
+			(b"\x1bP".as_slice(), "alt+up", "alt+shift+p"),
+			(b"\x1bn".as_slice(), "alt+down", "alt+n"),
+			(b"\x1bN".as_slice(), "alt+down", "alt+shift+n"),
+		];
+
+		for (bytes, navigation, literal) in cases {
+			for kitty_active in [false, true] {
+				assert_eq!(parse_key_inner(bytes, kitty_active).as_deref(), Some(navigation));
+				assert!(matches_key_inner(bytes, navigation, kitty_active));
+				assert!(!matches_key_inner(bytes, literal, kitty_active));
+			}
+		}
 	}
 
 	#[test]

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Terminal input now normalizes Option/Meta navigation and psmux modified-Enter encodings through the native key parser, keeping legacy, Kitty CSI-u, and modifyOtherKeys behavior consistent.
 
 - Team Linux worker memory-guard replacement no longer holds the team task-mutation fence across the successor startup-ack wait, so concurrent `worker-startup-ack` can publish and selector-replacement no longer hangs under CI contention.
 - Kitty/Ghostty inline images no longer remain visually pinned when the sticky live viewport repaints past their anchor. The TUI now soft-deletes its named placements from the old viewport before repainting, retains transmitted pixels, and restores the placement when application scrollback revisits the image row.

--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -423,7 +423,6 @@ const KITTY_MOD_SUPER = 8;
 const KITTY_MOD_NUM_LOCK = 128;
 const KITTY_LOCK_MASK = 64 + 128; // Caps Lock + Num Lock
 const MODIFY_OTHER_KEYS_PATTERN = /^\x1b\[27;(\d+);(\d+)~$/;
-const PSMUX_MODIFIED_ENTER_PATTERN = /^\x1b\[13;(2|6)~$/;
 const KITTY_KEYPAD_OPERATOR_TEXT: Record<number, string> = {
 	57410: "/",
 	57411: "*",
@@ -496,21 +495,6 @@ export function parseKittySequence(data: string): ParsedKittySequence | null {
 		eventType: result.eventType,
 	};
 }
-
-function parsePsmuxModifiedEnter(data: string): string | undefined {
-	const match = data.match(PSMUX_MODIFIED_ENTER_PATTERN);
-	if (!match) return undefined;
-	return match[1] === "6" ? "shift+ctrl+enter" : "shift+enter";
-}
-
-function matchesPsmuxModifiedEnter(data: string, keyId: KeyId): boolean {
-	const parsed = parsePsmuxModifiedEnter(data);
-	if (!parsed) return false;
-	const expected = String(keyId);
-	if (parsed === expected) return true;
-	return parsed === "shift+ctrl+enter" && expected === "ctrl+shift+enter";
-}
-
 function hasControlChars(data: string): boolean {
 	return [...data].some(ch => {
 		const code = ch.charCodeAt(0);
@@ -654,7 +638,7 @@ export function decodePrintableKey(data: string): string | undefined {
  * @param keyId - Key identifier (e.g., "ctrl+c", "escape", Key.ctrl("c"))
  */
 export function matchesKey(data: string, keyId: KeyId): boolean {
-	return matchesPsmuxModifiedEnter(data, keyId) || matchesKeyNative(data, keyId, kittyProtocolActive);
+	return matchesKeyNative(data, keyId, kittyProtocolActive);
 }
 
 /**
@@ -666,5 +650,5 @@ export function matchesKey(data: string, keyId: KeyId): boolean {
  * @param data - Raw input data from terminal
  */
 export function parseKey(data: string): string | undefined {
-	return parsePsmuxModifiedEnter(data) ?? parseKeyNative(data, kittyProtocolActive) ?? undefined;
+	return parseKeyNative(data, kittyProtocolActive) ?? undefined;
 }

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -97,6 +97,77 @@ describe("matchesKey", () => {
 		setKittyProtocolActive(false);
 	});
 });
+describe.each([
+	{ data: "\x1bq", kitty: false, key: "alt+q", expected: "alt+q" },
+	{ data: "\x1bC", kitty: true, key: "alt+shift+c", expected: "alt+shift+c" },
+	{ data: "\x1b[113;3u", kitty: true, key: "alt+q", expected: "alt+q" },
+	{ data: "\x1b[99;4u", kitty: true, key: "alt+shift+c", expected: "alt+shift+c" },
+	{ data: "\x1b[27;3;105~", kitty: false, key: "alt+i", expected: "alt+i" },
+] as const)("normalizes Option input $expected", ({ data, kitty, key, expected }) => {
+	it("matches and parses one canonical KeyId", () => {
+		setKittyProtocolActive(kitty);
+		expect(matchesKey(data, key)).toBe(true);
+		expect(parseKey(data)).toBe(expected);
+		setKittyProtocolActive(false);
+	});
+});
+describe("Alt+I protocol symmetry", () => {
+	it.each([
+		{ data: "\x1bi", kitty: true, expected: "alt+i" },
+		{ data: "\x1b[105;3u", kitty: true, expected: "alt+i" },
+		{ data: "\x1b[27;3;105~", kitty: true, expected: "alt+i" },
+	])("matches and parses $expected", ({ data, kitty, expected }) => {
+		setKittyProtocolActive(kitty);
+		expect(matchesKey(data, expected)).toBe(true);
+		expect(parseKey(data)).toBe(expected);
+		setKittyProtocolActive(false);
+	});
+
+	it("does not parse or match gated legacy space and control forms while Kitty is active", () => {
+		setKittyProtocolActive(true);
+		expect(matchesKey("\x1b ", "alt+space")).toBe(false);
+		expect(parseKey("\x1b ")).toBeUndefined();
+		expect(matchesKey("\x1b\x01", "ctrl+alt+a")).toBe(false);
+		expect(parseKey("\x1b\x01")).toBeUndefined();
+		setKittyProtocolActive(false);
+	});
+
+	it.each([
+		{ data: "\x1bb", navigation: "alt+left", literal: "alt+b" },
+		{ data: "\x1bB", navigation: "alt+left", literal: "alt+shift+b" },
+		{ data: "\x1bf", navigation: "alt+right", literal: "alt+f" },
+		{ data: "\x1bF", navigation: "alt+right", literal: "alt+shift+f" },
+		{ data: "\x1bp", navigation: "alt+up", literal: "alt+p" },
+		{ data: "\x1bP", navigation: "alt+up", literal: "alt+shift+p" },
+		{ data: "\x1bn", navigation: "alt+down", literal: "alt+n" },
+		{ data: "\x1bN", navigation: "alt+down", literal: "alt+shift+n" },
+	])("keeps $data as exclusive $navigation navigation under Kitty on and off", ({ data, navigation, literal }) => {
+		for (const kitty of [false, true]) {
+			setKittyProtocolActive(kitty);
+			expect(parseKey(data)).toBe(navigation);
+			expect(matchesKey(data, navigation)).toBe(true);
+			expect(matchesKey(data, literal)).toBe(false);
+			for (const otherNavigation of ["alt+left", "alt+right", "alt+up", "alt+down"] as const) {
+				expect(matchesKey(data, otherNavigation)).toBe(otherNavigation === navigation);
+			}
+		}
+		setKittyProtocolActive(false);
+	});
+
+	it.each([
+		{ data: "\x1b[98;3u", expected: "alt+b" },
+		{ data: "\x1b[98;4u", expected: "alt+shift+b" },
+		{ data: "\x1b[27;3;102~", expected: "alt+f" },
+		{ data: "\x1b[27;4;102~", expected: "alt+shift+f" },
+		{ data: "\x1b[112;3u", expected: "alt+p" },
+		{ data: "\x1b[110;4u", expected: "alt+shift+n" },
+	])("uses enhanced encoding for literal $expected", ({ data, expected }) => {
+		setKittyProtocolActive(true);
+		expect(parseKey(data)).toBe(expected);
+		expect(matchesKey(data, expected)).toBe(true);
+		setKittyProtocolActive(false);
+	});
+});
 
 describe("parseKey", () => {
 	it("should prefer codepoint for Latin letters when base layout differs", () => {

--- a/packages/tui/test/stdin-buffer.test.ts
+++ b/packages/tui/test/stdin-buffer.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { beforeEach, describe, expect, it } from "bun:test";
+import { parseKey, setKittyProtocolActive } from "@gajae-code/tui/keys";
 import { StdinBuffer } from "@gajae-code/tui/stdin-buffer";
 
 describe("StdinBuffer", () => {
@@ -207,6 +208,33 @@ describe("StdinBuffer", () => {
 			processInput("\x1b[104u\x1b[104;1:3u\x1b[105u\x1b[105;1:3u");
 			expect(emittedSequences).toEqual(["\x1b[104u", "\x1b[104;1:3u", "\x1b[105u", "\x1b[105;1:3u"]);
 		});
+	});
+	describe.each([
+		{ chunks: ["\x1bi"], expected: ["\x1bi"], parsed: ["alt+i"] },
+		{ chunks: ["\x1b", "i"], expected: ["\x1bi"], parsed: ["alt+i"] },
+		{ chunks: ["\x1b[105;3u"], expected: ["\x1b[105;3u"], parsed: ["alt+i"] },
+		{ chunks: ["\x1b[27;3;105~"], expected: ["\x1b[27;3;105~"], parsed: ["alt+i"] },
+		{ chunks: ["\x1b[105;3:3u"], expected: ["\x1b[105;3:3u"], parsed: [undefined] },
+	])("frames canonical key input", ({ chunks, expected, parsed }) => {
+		it("emits each wire sequence exactly once", () => {
+			setKittyProtocolActive(true);
+			for (const chunk of chunks) processInput(chunk);
+			expect(emittedSequences).toEqual([...expected]);
+			expect(emittedSequences.map(parseKey)).toEqual([...parsed]);
+			setKittyProtocolActive(false);
+		});
+	});
+
+	it("emits bare Escape before a character that arrives after its timeout", async () => {
+		buffer = new StdinBuffer({ timeout: 5 });
+		emittedSequences = [];
+		buffer.on("data", sequence => emittedSequences.push(sequence));
+
+		processInput("\x1b");
+		await Bun.sleep(10);
+		processInput("i");
+
+		expect(emittedSequences).toEqual(["\x1b", "i"]);
 	});
 
 	describe("Mouse Events", () => {


### PR DESCRIPTION
## What

- normalize Option/Meta navigation in the native key parser across legacy, Kitty CSI-u, and modifyOtherKeys forms
- recognize psmux modified-Enter encodings before generic key mapping
- remove the divergent TypeScript psmux parsing workaround
- add protocol-symmetry and fragmented-input regressions

## Why

Native parsing should be the single key-decoding authority. Keeping a second psmux-specific TypeScript path made parse/match behavior depend on which layer saw the bytes first.

## Scope and previous feedback

This is the first contract-focused successor to closed #3484. It contains only five files covering native key semantics, the TUI adapter/tests, and one precise changelog entry. Responsive layout and renderer-evidence work are excluded.

The previous exact-head TypeScript blockers are fixed: navigation cases are typed as `KeyId` literals and readonly table cases are compared through explicit copies. The branch is rebased onto exact event base `40b96b1c4ec28eaa00010bf5815aaf2bc112fa05`.

## Testing

- native key tests: **14 passed, 0 failed**
- TUI key/stdin tests: **126 passed, 0 failed, 364 expectations**
- `bun --cwd=packages/tui run check`
- `bun run ci:build:native`
- `git diff --check`
- independent exact-head architecture review: **CLEAR / APPROVE**

## Review receipt

`gajae.pr-review-verdict.v1 merge-approved sha256:ea9d6a7d86d1e9200a1344f9da9308ff9ff28122 reviewer:architect evidence:native-keys-14/0,tui-key-stdin-126/0/364,native-build,tui-check,diff-check`

## Checklist

- [x] Rebased onto current `dev`
- [x] Single independently reviewable contract
- [x] Exact-head focused checks pass
- [x] No responsive-layout or viewport-evidence changes
- [x] Precise changelog entry included
