### PR TITLE
fix(tui): harden Kitty placement lifecycle

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Fixed
 
 - Team Linux worker memory-guard replacement no longer holds the team task-mutation fence across the successor startup-ack wait, so concurrent `worker-startup-ack` can publish and selector-replacement no longer hangs under CI contention.
-- Kitty/Ghostty inline images no longer remain visually pinned when the sticky live viewport repaints past their anchor. The TUI now soft-deletes its named placements from the old viewport before repainting, retains transmitted pixels, and restores the placement when application scrollback revisits the image row.
+- Kitty/Ghostty inline images no longer remain visually pinned when transcript, pinned, or overlay rows are replaced, removed, scrolled, resized, or fully repainted. The TUI now parses only bounded named placements, soft-deletes overwritten placements from the previously committed physical frame, retains transmitted pixels, and restores placements from application scrollback without retransmitting image data.
 - Reviewer `report_finding` evidence is no longer injected into caller-owned strict JTD completion data; full findings are published separately through a bounded artifact reference, and failed evidence publication now fails the task closed (#2893).
 - Managed-session startup failures now include their bounded preparation classification (and path-free native durability diagnostic when available), so Windows launch crashes no longer collapse to an unactionable generic error while filesystem paths and raw OS messages remain redacted (#3383).
 

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -520,35 +520,53 @@ export interface KittyPlacementReference {
 	rows: number;
 }
 
-/** Extract named kitty placements from a rendered line. */
+const MAX_KITTY_CONTROL_CHARS = 4096;
+const MAX_KITTY_PLACEMENTS_PER_LINE = 1024;
+const MAX_KITTY_PLACEMENT_SCAN_CHARS = 256 * 1024;
+const MAX_KITTY_PLACEMENT_SCAN_BYTES = 256 * 1024;
+const MAX_KITTY_UINT32 = 0xffff_ffff;
+const MAX_KITTY_CONTROL_FIELDS = 64;
+
+function parseKittyUint32(raw: string | undefined): number | null {
+	if (raw === undefined || raw.length === 0 || raw.length > 10 || !/^\d+$/u.test(raw)) return null;
+	const value = Number(raw);
+	return Number.isInteger(value) && value > 0 && value <= MAX_KITTY_UINT32 ? value : null;
+}
+
+/** Extract bounded, named kitty placements from a rendered line. */
 export function extractKittyPlacementReferences(line: string): KittyPlacementReference[] {
-	if (!line.includes(ImageProtocol.Kitty)) return [];
+	if (line.length > MAX_KITTY_PLACEMENT_SCAN_CHARS) return [];
+	if (!line.includes(ImageProtocol.Kitty) || Buffer.byteLength(line) > MAX_KITTY_PLACEMENT_SCAN_BYTES) return [];
 	const placements: KittyPlacementReference[] = [];
-	for (const match of line.matchAll(/\x1b_G([^;\x1b]*)(?:;[^\x1b]*)?\x1b\\/gu)) {
+	for (const match of line.matchAll(/\x1b_G([^;\x1b]*)(?:;([^\x1b]*))?\x1b\\/gu)) {
+		const control = match[1] ?? "";
+		if (control.length === 0 || control.length > MAX_KITTY_CONTROL_CHARS || match[2] !== undefined) continue;
+		const parts = control.split(",");
+		if (parts.length > MAX_KITTY_CONTROL_FIELDS) continue;
+
 		const params = new Map<string, string>();
-		for (const part of (match[1] ?? "").split(",")) {
+		let valid = true;
+		for (const part of parts) {
 			const separator = part.indexOf("=");
-			if (separator > 0) params.set(part.slice(0, separator), part.slice(separator + 1));
+			if (separator !== 1 || part.length === 2) {
+				valid = false;
+				break;
+			}
+			const key = part[0];
+			if (!/[A-Za-z]/u.test(key) || params.has(key)) {
+				valid = false;
+				break;
+			}
+			params.set(key, part.slice(2));
 		}
-		if (params.get("a") !== "p") continue;
-		const imageIdRaw = params.get("i") ?? "";
-		const placementIdRaw = params.get("p") ?? "";
-		const rowsRaw = params.get("r") ?? "1";
-		if (!/^\d+$/u.test(imageIdRaw) || !/^\d+$/u.test(placementIdRaw) || !/^\d+$/u.test(rowsRaw)) continue;
-		const imageId = Number(imageIdRaw);
-		const placementId = Number(placementIdRaw);
-		const rows = Number(rowsRaw);
-		if (
-			!Number.isSafeInteger(imageId) ||
-			imageId <= 0 ||
-			!Number.isSafeInteger(placementId) ||
-			placementId <= 0 ||
-			!Number.isSafeInteger(rows) ||
-			rows <= 0
-		) {
-			continue;
-		}
+		if (!valid || params.get("a") !== "p" || params.get("C") !== "1" || params.has("m")) continue;
+
+		const imageId = parseKittyUint32(params.get("i"));
+		const placementId = parseKittyUint32(params.get("p"));
+		const rows = parseKittyUint32(params.get("r"));
+		if (imageId === null || placementId === null || rows === null) continue;
 		placements.push({ imageId, placementId, rows });
+		if (placements.length > MAX_KITTY_PLACEMENTS_PER_LINE) return [];
 	}
 	return placements;
 }
@@ -799,8 +817,8 @@ export function renderImage(
 		// and ALL of its placements (breaking sibling components showing the
 		// same content) and would re-send multi-MB payloads on every repaint.
 		if (!transmittedKittyImageIds.has(imageId)) {
-			transmittedKittyImageIds.add(imageId);
 			(options.onTransmit ?? kittyTransmitWriter)(encodeKittyTransmit(base64Data, imageId));
+			transmittedKittyImageIds.add(imageId);
 		}
 		const sequence = encodeKittyPlacement({ imageId, placementId, columns: fit.columns, rows: fit.rows });
 		return { sequence, rows: fit.rows, cursorNeutral: true };

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -641,8 +641,21 @@ type RenderCommitWaiter = {
 	timer: NodeJS.Timeout;
 };
 
+type KittyPlacementOwner = "transcript" | "suffix" | "overlay";
+
 type KittyPlacementSpan = KittyPlacementReference & {
 	row: number;
+	owner: KittyPlacementOwner;
+};
+
+type KittyPlacementRegion = {
+	top: number;
+	bottom: number;
+};
+
+type KittyPlacementDeletePlan = {
+	deletedKeys: Set<string>;
+	output: string;
 };
 
 /**
@@ -652,6 +665,9 @@ export class TUI extends Container {
 	terminal: Terminal;
 	#previousLines: string[] = [];
 	#latestRenderedLines: string[] = [];
+	#latestRenderedTranscriptLineCount = 0;
+	#latestRenderedSuffixLineCount = 0;
+	#latestRenderedPlacementOwners = new Map<string, KittyPlacementOwner>();
 	/**
 	 * Raw (pre-normalization) lines from the previous frame, kept only when the
 	 * virtual-viewport flag is on. Used to detect whether the off-screen prefix is
@@ -660,7 +676,6 @@ export class TUI extends Container {
 	 */
 	#previousRaw: string[] = [];
 	#kittyPlacementSpans: KittyPlacementSpan[] = [];
-	#latestKittyPlacementSpans: KittyPlacementSpan[] = [];
 	#lineNormalizationCache = new Map<string, LineNormalizationCacheEntry>();
 	#lineEmitWidthCache = new Map<string, number>();
 	#lineTruncationCache = new Map<string, string>();
@@ -1038,6 +1053,10 @@ export class TUI extends Container {
 		if (!Number.isFinite(deltaRows)) return false;
 		const delta = Math.trunc(deltaRows);
 		if (delta === 0) return false;
+		const previousManualViewportTop = this.#manualViewportTop;
+		const previousManualViewportAnchor = this.#manualViewportAnchor;
+		const previousManualViewportFallbackAnchors = this.#manualViewportFallbackAnchors;
+		const previousReconcileMissingViewportAnchor = this.#reconcileMissingViewportAnchor;
 
 		const direction: -1 | 1 = delta < 0 ? -1 : 1;
 		const pin = options?.pin ?? "stable";
@@ -1128,7 +1147,8 @@ export class TUI extends Container {
 			}
 		}
 		this.#manualViewportTop = targetViewportTop;
-		return this.#repaintViewportFromLines(
+		let contentPainted = false;
+		const painted = this.#repaintViewportFromLines(
 			this.#previousLines,
 			width,
 			height,
@@ -1136,7 +1156,26 @@ export class TUI extends Container {
 			null,
 			"manual viewport scroll",
 			this.#manualViewportAnchor !== null,
+			() => {
+				contentPainted = true;
+				this.#manualTranscriptLineCount = this.#latestRenderedTranscriptLineCount;
+				this.#manualSuffixLineCount = this.#latestRenderedSuffixLineCount;
+			},
+			false,
+			this.#kittyPlacementSpans,
+			this.#kittyPlacementSpansForLines(this.#previousLines, this.#latestRenderedPlacementOwners),
+			{
+				transcriptLineCount: this.#latestRenderedTranscriptLineCount,
+				suffixLineCount: this.#latestRenderedSuffixLineCount,
+			},
 		);
+		if (!contentPainted) {
+			this.#manualViewportTop = previousManualViewportTop;
+			this.#manualViewportAnchor = previousManualViewportAnchor;
+			this.#manualViewportFallbackAnchors = previousManualViewportFallbackAnchors;
+			this.#reconcileMissingViewportAnchor = previousReconcileMissingViewportAnchor;
+		}
+		return painted;
 	}
 
 	scrollViewportPages(direction: -1 | 1): boolean {
@@ -1153,9 +1192,12 @@ export class TUI extends Container {
 		const paddedLiveLines = this.#padBeforeBottomPinnedComponent(
 			this.#latestRenderedLines,
 			height,
-			this.#manualSuffixLineCount,
+			this.#latestRenderedSuffixLineCount,
 		);
 		const liveLines = paddedLiveLines.lines;
+		const liveTranscriptLineCount = this.#latestRenderedTranscriptLineCount;
+		const liveSuffixLineCount = this.#latestRenderedSuffixLineCount + paddedLiveLines.insertedBlankRows;
+		const liveKittyPlacementSpans = this.#kittyPlacementSpansForLines(liveLines, this.#latestRenderedPlacementOwners);
 		let liveCursorPosition = this.#lastCursorPosition;
 		if (liveCursorPosition !== null && liveCursorPosition.row >= paddedLiveLines.insertionRow) {
 			liveCursorPosition = {
@@ -1182,7 +1224,8 @@ export class TUI extends Container {
 				this.#paintedManualOutputNotice = false;
 				this.#lastCursorPosition = liveCursorPosition;
 				this.#previousLines = liveLines;
-				this.#kittyPlacementSpans = this.#latestKittyPlacementSpans;
+				this.#manualTranscriptLineCount = liveTranscriptLineCount;
+				this.#manualSuffixLineCount = liveSuffixLineCount;
 				if (this.#scrollbackResumeViewportTop === undefined) {
 					this.#nativeScrollbackViewportTop = liveViewportTop;
 				}
@@ -1196,6 +1239,9 @@ export class TUI extends Container {
 				}
 			},
 			true,
+			this.#kittyPlacementSpans,
+			liveKittyPlacementSpans,
+			{ transcriptLineCount: liveTranscriptLineCount, suffixLineCount: liveSuffixLineCount },
 		);
 	}
 
@@ -1574,6 +1620,8 @@ export class TUI extends Container {
 
 	stop(): void {
 		this.flushTerminalCleanup();
+		const placementCleanup = this.#kittyPlacementDeletePlan(this.#kittyPlacementSpans, [], [], true).output;
+		if (placementCleanup.length > 0 && this.#writeTerminal(placementCleanup)) this.#kittyPlacementSpans = [];
 		this.#clearSixelProbeState();
 		this.#stopped = true;
 		this.#settleRenderCommitWaiters(false);
@@ -1626,7 +1674,6 @@ export class TUI extends Container {
 		this.#latestRenderedLines = [];
 		this.#previousRaw = [];
 		this.#kittyPlacementSpans = [];
-		this.#latestKittyPlacementSpans = [];
 		this.#lineNormalizationCache.clear();
 		this.#lineTruncationCache.clear();
 		this.#lineEmitWidthCache.clear();
@@ -1730,8 +1777,6 @@ export class TUI extends Container {
 		}
 		if (renderMetrics.enabled) renderMetrics.recordRequest(source);
 		if (force) {
-			const preserveViewportCursor =
-				useViewportRepaintPath(this.terminal) || shouldPreserveScrollbackOnFullClear(this.terminal);
 			// A forced full redraw supersedes any queued input-priority render.
 			this.#inputRenderPending = false;
 			this.#previousLines = [];
@@ -1744,12 +1789,6 @@ export class TUI extends Container {
 			this.#previousHeight = -1; // -1 triggers heightChanged, forcing a full clear
 			this.#lineNormalizationCacheLimit = 0;
 			this.#lineTruncationCacheLimit = 0;
-			if (!preserveViewportCursor) {
-				this.#cursorRow = 0;
-				this.#hardwareCursorRow = 0;
-				this.#viewportTopRow = 0;
-				this.#maxLinesRendered = 0;
-			}
 			if (this.#renderTimer) {
 				clearTimeout(this.#renderTimer);
 				this.#renderTimer = undefined;
@@ -2241,7 +2280,12 @@ export class TUI extends Container {
 	}
 
 	/** Composite all overlays into content lines (in stack order, later = on top). */
-	#compositeOverlays(lines: string[], termWidth: number, termHeight: number): string[] {
+	#compositeOverlays(
+		lines: string[],
+		termWidth: number,
+		termHeight: number,
+		placementOwners?: Map<string, KittyPlacementOwner>,
+	): string[] {
 		if (this.overlayStack.length === 0) return lines;
 		const result = [...lines];
 		for (const entry of this.overlayStack) entry.mouseBounds = undefined;
@@ -2302,6 +2346,11 @@ export class TUI extends Container {
 					// (components should already respect width, but this ensures it)
 					const truncatedOverlayLine =
 						visibleWidth(overlayLines[i]) > w ? sliceByColumn(overlayLines[i], 0, w, true) : overlayLines[i];
+					if (placementOwners !== undefined) {
+						for (const placement of extractKittyPlacementReferences(truncatedOverlayLine)) {
+							placementOwners.set(this.#kittyPlacementKey(placement), "overlay");
+						}
+					}
 					result[idx] = this.#compositeLineAt(result[idx], truncatedOverlayLine, col, w, termWidth);
 					modifiedLines.add(idx);
 				}
@@ -2519,19 +2568,90 @@ export class TUI extends Container {
 		return lines;
 	}
 
-	#kittyViewportCleanup(placements: KittyPlacementSpan[], viewportTop: number, height: number): string {
-		if (TERMINAL.imageProtocol !== ImageProtocol.Kitty || height <= 0) return "";
-		const viewportBottom = viewportTop + height;
-		const deleted = new Set<string>();
+	#kittyPlacementKey(reference: KittyPlacementReference): string {
+		return `${reference.imageId}:${reference.placementId}`;
+	}
+
+	#kittyPlacementSpansForLines(
+		lines: string[],
+		owners: ReadonlyMap<string, KittyPlacementOwner>,
+	): KittyPlacementSpan[] {
+		const placements: KittyPlacementSpan[] = [];
+		for (let row = 0; row < lines.length; row++) {
+			for (const placement of extractKittyPlacementReferences(lines[row])) {
+				placements.push({
+					...placement,
+					row,
+					owner: owners.get(this.#kittyPlacementKey(placement)) ?? "transcript",
+				});
+			}
+		}
+		return placements;
+	}
+
+	#kittyPlacementIntersectsRegion(placement: KittyPlacementSpan, region: KittyPlacementRegion): boolean {
+		return placement.row < region.bottom && placement.row + placement.rows > region.top;
+	}
+
+	#kittyPlacementDeletePlan(
+		previous: KittyPlacementSpan[],
+		next: KittyPlacementSpan[],
+		overwrittenRegions: KittyPlacementRegion[],
+		deleteAll = false,
+		overwrittenOwners: KittyPlacementOwner[] = [],
+	): KittyPlacementDeletePlan {
+		const deletedKeys = new Set<string>();
+		if (TERMINAL.imageProtocol !== ImageProtocol.Kitty) return { deletedKeys, output: "" };
+		const nextByKey = new Map(next.map(placement => [this.#kittyPlacementKey(placement), placement]));
 		let output = "";
-		for (const placement of placements) {
-			if (placement.row >= viewportBottom || placement.row + placement.rows <= viewportTop) continue;
-			const key = `${placement.imageId}:${placement.placementId}`;
-			if (deleted.has(key)) continue;
-			deleted.add(key);
+		for (const placement of previous) {
+			const key = this.#kittyPlacementKey(placement);
+			if (deletedKeys.has(key)) continue;
+			const candidate = nextByKey.get(key);
+			const changed =
+				candidate === undefined || candidate.row !== placement.row || candidate.rows !== placement.rows;
+			const overwritten =
+				deleteAll ||
+				overwrittenOwners.includes(placement.owner) ||
+				overwrittenRegions.some(region => this.#kittyPlacementIntersectsRegion(placement, region));
+			if (!changed && !overwritten) continue;
+			deletedKeys.add(key);
 			output += encodeKittyPlacementDelete(placement);
 		}
-		return output;
+		return { deletedKeys, output };
+	}
+
+	#kittyCommittedPlacementsAfterPaint(
+		previous: KittyPlacementSpan[],
+		next: KittyPlacementSpan[],
+		deletePlan: KittyPlacementDeletePlan,
+		emittedRegions: KittyPlacementRegion[],
+	): KittyPlacementSpan[] {
+		const committed = new Map<string, KittyPlacementSpan>();
+		for (const placement of previous) {
+			const key = this.#kittyPlacementKey(placement);
+			if (!deletePlan.deletedKeys.has(key)) committed.set(key, placement);
+		}
+		for (const placement of next) {
+			if (!emittedRegions.some(region => placement.row >= region.top && placement.row < region.bottom)) continue;
+			committed.set(this.#kittyPlacementKey(placement), placement);
+		}
+		return [...committed.values()];
+	}
+
+	#kittyViewportTopIncludingPlacementAnchors(viewportTop: number, placements: KittyPlacementSpan[]): number {
+		let resolvedTop = viewportTop;
+		let changed: boolean;
+		do {
+			const priorTop = resolvedTop;
+			for (const placement of placements) {
+				if (placement.row < resolvedTop && placement.row + placement.rows > resolvedTop) {
+					resolvedTop = placement.row;
+				}
+			}
+			changed = resolvedTop !== priorTop;
+		} while (changed);
+		return resolvedTop;
 	}
 
 	#pinnedChildLines(component: Component, renderedChildren: Map<Component, string[]>): string[] {
@@ -2633,9 +2753,9 @@ export class TUI extends Container {
 		padded.splice(insertionRow, 0, ...Array.from({ length: insertedBlankRows }, () => ""));
 		return { lines: padded, insertionRow, insertedBlankRows };
 	}
-	#manualTranscriptCapacity(height: number): number {
-		const noticeRows = this.#manualOutputNotice && height > this.#manualSuffixLineCount ? 1 : 0;
-		return Math.max(0, height - this.#manualSuffixLineCount - noticeRows);
+	#manualTranscriptCapacity(height: number, suffixLineCount = this.#manualSuffixLineCount): number {
+		const noticeRows = this.#manualOutputNotice && height > suffixLineCount ? 1 : 0;
+		return Math.max(0, height - suffixLineCount - noticeRows);
 	}
 	#resolveManualAnchor(frame: ViewportAnchorFrame): number | null {
 		const anchor = this.#manualViewportAnchor;
@@ -2697,8 +2817,12 @@ export class TUI extends Container {
 		onPainted?: () => void,
 		paintLive = false,
 		placementsToClear: KittyPlacementSpan[] = this.#kittyPlacementSpans,
+		placementsToPaint: KittyPlacementSpan[] = placementsToClear,
+		geometry?: { transcriptLineCount: number; suffixLineCount: number },
 	): boolean {
 		const paintManual = this.#manualViewportTop !== undefined && !paintLive;
+		const transcriptLineCount = geometry?.transcriptLineCount ?? this.#manualTranscriptLineCount;
+		const suffixLineCount = geometry?.suffixLineCount ?? this.#manualSuffixLineCount;
 		if (height <= 0 || width <= 0) return false;
 		const maxViewportTop = Math.max(
 			0,
@@ -2706,19 +2830,32 @@ export class TUI extends Container {
 				? lines.length - (allowPastLiveBottom ? 1 : height)
 				: allowPastLiveBottom
 					? lines.length - 1
-					: this.#manualTranscriptLineCount - this.#manualTranscriptCapacity(height),
+					: transcriptLineCount - this.#manualTranscriptCapacity(height, suffixLineCount),
 		);
-		const nextViewportTop = Math.max(0, Math.min(maxViewportTop, viewportTop));
+		let nextViewportTop = Math.max(0, Math.min(maxViewportTop, viewportTop));
+		if (paintManual)
+			nextViewportTop = this.#kittyViewportTopIncludingPlacementAnchors(nextViewportTop, placementsToPaint);
 		const currentScreenRow = Math.max(0, Math.min(height - 1, this.#hardwareCursorRow - this.#viewportTopRow));
-		let buffer = "\x1b[?2026h";
-		buffer += this.#kittyViewportCleanup(placementsToClear, this.#viewportTopRow, height);
+		const transcriptCapacity = paintManual ? this.#manualTranscriptCapacity(height, suffixLineCount) : height;
+		const noticeRows = paintManual && this.#manualOutputNotice && height > suffixLineCount ? 1 : 0;
+		const deletePlan = this.#kittyPlacementDeletePlan(
+			placementsToClear,
+			placementsToPaint,
+			[{ top: this.#viewportTopRow, bottom: this.#viewportTopRow + height }],
+			false,
+			paintManual ? ["suffix", "overlay"] : [],
+		);
+		const emittedRegions: KittyPlacementRegion[] = paintManual
+			? [
+					{ top: nextViewportTop, bottom: nextViewportTop + transcriptCapacity },
+					{ top: transcriptLineCount, bottom: transcriptLineCount + suffixLineCount },
+				]
+			: [{ top: nextViewportTop, bottom: nextViewportTop + height }];
+		let buffer = `\x1b[?2026h${deletePlan.output}`;
 		if (currentScreenRow > 0) {
 			buffer += `\x1b[${currentScreenRow}A`;
 		}
 		buffer += "\r";
-
-		const transcriptCapacity = paintManual ? this.#manualTranscriptCapacity(height) : height;
-		const noticeRows = paintManual && this.#manualOutputNotice && height > this.#manualSuffixLineCount ? 1 : 0;
 		const committedTranscriptRows: Array<number | null> = [];
 		for (let screenRow = 0; screenRow < height; screenRow++) {
 			if (screenRow > 0) buffer += "\r\n";
@@ -2729,12 +2866,12 @@ export class TUI extends Container {
 				paintManual && screenRow === transcriptCapacity && noticeRows > 0
 					? "New output — type to follow"
 					: paintManual && suffixRow >= 0
-						? (lines[this.#manualTranscriptLineCount + suffixRow] ?? "")
-						: paintManual && lineIndex >= this.#manualTranscriptLineCount
+						? (lines[transcriptLineCount + suffixRow] ?? "")
+						: paintManual && lineIndex >= transcriptLineCount
 							? ""
 							: (lines[lineIndex] ?? "");
 			committedTranscriptRows.push(
-				screenRow < transcriptCapacity && lineIndex < this.#manualTranscriptLineCount ? lineIndex : null,
+				screenRow < transcriptCapacity && lineIndex < transcriptLineCount ? lineIndex : null,
 			);
 			const isImage = TERMINAL.isImageLine(line);
 			if (!isImage && this.#visibleWidthForDifferentialGuard(line) > width) {
@@ -2756,23 +2893,30 @@ export class TUI extends Container {
 		}
 		buffer += cursorSeq;
 		buffer += "\x1b[?2026l";
-		if (
-			!this.#writeRenderBufferAndReanchorImeCursor(buffer, cursorPos, lines.length, () => {
-				this.#hardwareCursorRow = cursorToRow;
-				this.#committedTranscriptRows = committedTranscriptRows;
-				this.#cursorRow = Math.max(0, lines.length - 1);
-				this.#maxLinesRendered = lines.length;
-				this.#viewportTopRow = nextViewportTop;
-				onPainted?.();
-			})
-		)
-			return false;
+		let contentWritten = false;
+		const writeSucceeded = this.#writeRenderBufferAndReanchorImeCursor(buffer, cursorPos, lines.length, () => {
+			contentWritten = true;
+			this.#hardwareCursorRow = cursorToRow;
+			this.#committedTranscriptRows = committedTranscriptRows;
+			this.#cursorRow = Math.max(0, lines.length - 1);
+			this.#maxLinesRendered = lines.length;
+			this.#viewportTopRow = nextViewportTop;
+			if (paintManual) this.#manualViewportTop = nextViewportTop;
+			this.#kittyPlacementSpans = this.#kittyCommittedPlacementsAfterPaint(
+				placementsToClear,
+				placementsToPaint,
+				deletePlan,
+				emittedRegions,
+			);
+			onPainted?.();
+		});
+		if (!contentWritten) return false;
 
 		if (this.#debugRedraw) {
 			const msg = `[${new Date().toISOString()}] viewportRepaint: ${reason} (lines=${lines.length}, height=${height}, viewportTop=${nextViewportTop})\n`;
 			this.#appendDebugRedrawLog(msg);
 		}
-		return true;
+		return writeSucceeded;
 	}
 
 	#doRender(): void {
@@ -2793,8 +2937,8 @@ export class TUI extends Container {
 		const renderedLines: string[] = [];
 		const renderedChildren = new Map<Component, string[]>();
 		let anchorFrame: ViewportAnchorFrame | null = null;
-		const previousKittyPlacementSpans = this.#kittyPlacementSpans;
-		const nextKittyPlacementSpans: KittyPlacementSpan[] = [];
+		let previousKittyPlacementSpans = this.#kittyPlacementSpans;
+		const placementOwners = new Map<string, KittyPlacementOwner>();
 		const pinnedChildIndex =
 			this.#bottomPinnedComponent === null ? -1 : this.children.indexOf(this.#bottomPinnedComponent);
 		const hasStickySuffix = pinnedChildIndex >= 0;
@@ -2806,13 +2950,10 @@ export class TUI extends Container {
 			if (child === this.#viewportAnchorComponent && rendered.anchors.some(anchor => anchor !== null)) {
 				anchorFrame = { startRow: renderedLines.length, anchors: rendered.anchors };
 			}
-			const trackPlacements = !hasStickySuffix || childIndex < pinnedChildIndex;
+			const owner: KittyPlacementOwner = hasStickySuffix && childIndex >= pinnedChildIndex ? "suffix" : "transcript";
 			for (const line of rendered.lines) {
-				if (trackPlacements && line.includes(ImageProtocol.Kitty)) {
-					const row = renderedLines.length;
-					for (const placement of extractKittyPlacementReferences(line)) {
-						nextKittyPlacementSpans.push({ ...placement, row });
-					}
+				for (const placement of extractKittyPlacementReferences(line)) {
+					placementOwners.set(this.#kittyPlacementKey(placement), owner);
 				}
 				renderedLines.push(line);
 			}
@@ -2834,10 +2975,12 @@ export class TUI extends Container {
 				newLines.length - sourceTranscriptLineCount,
 			).lines;
 		}
+		const nextTranscriptLineCount = sourceTranscriptLineCount;
+		const nextSuffixLineCount = hasStickySuffix ? Math.max(0, newLines.length - nextTranscriptLineCount) : 0;
 
 		// Composite overlays into the rendered lines (before differential compare)
 		if (this.overlayStack.length > 0) {
-			newLines = this.#compositeOverlays(newLines, width, height);
+			newLines = this.#compositeOverlays(newLines, width, height, placementOwners);
 		}
 
 		// Extract cursor position (marker must be found before diff comparison)
@@ -2905,11 +3048,11 @@ export class TUI extends Container {
 			renderMetrics.recordLineCount("measured", total - diffStart);
 			if (usedWindowNormalize) renderMetrics.recordLineCount("offscreenScan", diffStart);
 		}
+		const nextKittyPlacementSpans = this.#kittyPlacementSpansForLines(newLines, placementOwners);
 		this.#latestRenderedLines = newLines;
-		this.#latestKittyPlacementSpans = nextKittyPlacementSpans;
-		this.#kittyPlacementSpans = nextKittyPlacementSpans;
-		this.#manualTranscriptLineCount = sourceTranscriptLineCount;
-		this.#manualSuffixLineCount = Math.max(0, newLines.length - sourceTranscriptLineCount);
+		this.#latestRenderedTranscriptLineCount = nextTranscriptLineCount;
+		this.#latestRenderedSuffixLineCount = nextSuffixLineCount;
+		this.#latestRenderedPlacementOwners = placementOwners;
 		const naturalViewportTop = Math.max(0, newLines.length - height);
 		const priorLogicalLineCount = Math.max(this.#previousLines.length, this.#maxLinesRendered);
 		if (this.#transcriptIdentityResetPending) {
@@ -2925,6 +3068,17 @@ export class TUI extends Container {
 		}
 
 		if (this.#manualViewportTop !== undefined) {
+			const committedManualViewportTop = this.#manualViewportTop;
+			const committedManualViewportAnchor = this.#manualViewportAnchor;
+			const committedManualViewportFallbackAnchors = this.#manualViewportFallbackAnchors;
+			const committedReconcileMissingViewportAnchor = this.#reconcileMissingViewportAnchor;
+			const restoreManualIntent = (): void => {
+				this.#manualViewportTop = committedManualViewportTop;
+				this.#manualViewportAnchor = committedManualViewportAnchor;
+				this.#manualViewportFallbackAnchors = committedManualViewportFallbackAnchors;
+				this.#reconcileMissingViewportAnchor = committedReconcileMissingViewportAnchor;
+			};
+			let contentPainted = false;
 			let resolvedAnchorTop = anchorFrame === null ? null : this.#resolveManualAnchor(anchorFrame);
 			if (
 				this.#manualViewportAnchor !== null &&
@@ -2942,6 +3096,7 @@ export class TUI extends Container {
 				if (anchorRenderFailed) {
 					// Keep semantic intent armed for recovery, but render the diagnostic frame
 					// instead of masking a provider failure behind stale transcript content.
+					contentPainted = false;
 					this.#repaintViewportFromLines(
 						newLines,
 						width,
@@ -2950,37 +3105,44 @@ export class TUI extends Container {
 						null,
 						"failed semantic viewport render",
 						true,
-						undefined,
+						() => {
+							contentPainted = true;
+							this.#previousLines = newLines;
+							this.#previousWidth = width;
+							this.#previousHeight = height;
+							this.#manualTranscriptLineCount = nextTranscriptLineCount;
+							this.#manualSuffixLineCount = nextSuffixLineCount;
+						},
 						false,
 						previousKittyPlacementSpans,
+						nextKittyPlacementSpans,
+						{ transcriptLineCount: nextTranscriptLineCount, suffixLineCount: nextSuffixLineCount },
 					);
-					this.#previousLines = newLines;
-					this.#previousWidth = width;
-					this.#previousHeight = height;
+					if (!contentPainted) restoreManualIntent();
 					return;
 				}
 				// A formerly valid semantic target is temporarily absent (provider removal,
 				// replacement, eviction, or object deletion). Keep the last resolved frame
 				// instead of silently reinterpreting manual intent as a numeric viewport.
 				const retainedLines = this.#previousLines.length > 0 ? this.#previousLines : newLines;
-				if (
-					this.#repaintViewportFromLines(
-						retainedLines,
-						width,
-						height,
-						this.#manualViewportTop,
-						null,
-						"unresolved semantic viewport render",
-						true,
-						undefined,
-						false,
-						previousKittyPlacementSpans,
-					)
-				) {
-					this.#kittyPlacementSpans = previousKittyPlacementSpans;
-				}
-				this.#previousWidth = width;
-				this.#previousHeight = height;
+				contentPainted = false;
+				this.#repaintViewportFromLines(
+					retainedLines,
+					width,
+					height,
+					this.#manualViewportTop,
+					null,
+					"unresolved semantic viewport render",
+					true,
+					() => {
+						contentPainted = true;
+						this.#previousWidth = width;
+						this.#previousHeight = height;
+					},
+					false,
+					previousKittyPlacementSpans,
+				);
+				if (!contentPainted) restoreManualIntent();
 				return;
 			}
 			const nextViewportTop = resolvedAnchorTop ?? this.#manualViewportTop;
@@ -2996,29 +3158,34 @@ export class TUI extends Container {
 			}
 			this.#manualViewportTop = nextViewportTop;
 			this.#reconcileMissingViewportAnchor = false;
-			if (
-				this.#repaintViewportFromLines(
-					newLines,
-					width,
-					height,
-					nextViewportTop,
-					null,
-					"manual viewport render",
-					this.#manualViewportAnchor !== null,
-					undefined,
-					false,
-					previousKittyPlacementSpans,
-				)
-			) {
-				this.#previousLines = newLines;
-				this.#previousWidth = width;
-				this.#previousHeight = height;
-				this.#paintedManualOutputNotice = this.#manualOutputNotice;
-			}
+			contentPainted = false;
+			this.#repaintViewportFromLines(
+				newLines,
+				width,
+				height,
+				nextViewportTop,
+				null,
+				"manual viewport render",
+				this.#manualViewportAnchor !== null,
+				() => {
+					contentPainted = true;
+					this.#previousLines = newLines;
+					this.#previousWidth = width;
+					this.#previousHeight = height;
+					this.#paintedManualOutputNotice = this.#manualOutputNotice;
+					this.#manualTranscriptLineCount = nextTranscriptLineCount;
+					this.#manualSuffixLineCount = nextSuffixLineCount;
+				},
+				false,
+				previousKittyPlacementSpans,
+				nextKittyPlacementSpans,
+				{ transcriptLineCount: nextTranscriptLineCount, suffixLineCount: nextSuffixLineCount },
+			);
+			if (!contentPainted) restoreManualIntent();
 			return;
 		}
 		// Helper to clear scrollback and viewport and render all new lines
-		let viewportRepaint: (reason: string, targetViewportTop?: number) => void;
+		let viewportRepaint: (reason: string, targetViewportTop?: number) => boolean;
 		const fullRender = (clear: boolean, reason = "full render", forceScrollbackClear = false): void => {
 			if (
 				clear &&
@@ -3031,8 +3198,13 @@ export class TUI extends Container {
 			}
 			this.#fullRedrawCount += 1;
 			if (renderMetrics.enabled) renderMetrics.recordFullRedraw(reason);
-			let buffer = "\x1b[?2026h"; // Begin synchronized output
-			if (clear) buffer += this.#kittyViewportCleanup(previousKittyPlacementSpans, prevViewportTop, height);
+			const deletePlan = this.#kittyPlacementDeletePlan(
+				previousKittyPlacementSpans,
+				nextKittyPlacementSpans,
+				[],
+				clear,
+			);
+			let buffer = `\x1b[?2026h${deletePlan.output}`; // Begin synchronized output
 			// Skip clearing scrollback (3J) in hosts where clear/replay can snap the
 			// native viewport away from the live prompt (tmux/screen, Windows ConPTY) —
 			// unless the caller explicitly needs history erased (the settled width
@@ -3068,18 +3240,28 @@ export class TUI extends Container {
 					this.#previousLines = newLines;
 					this.#previousWidth = width;
 					this.#previousHeight = height;
+					this.#kittyPlacementSpans = this.#kittyCommittedPlacementsAfterPaint(
+						previousKittyPlacementSpans,
+						nextKittyPlacementSpans,
+						deletePlan,
+						[{ top: Number.NEGATIVE_INFINITY, bottom: Number.POSITIVE_INFINITY }],
+					);
+					this.#manualTranscriptLineCount = nextTranscriptLineCount;
+					this.#manualSuffixLineCount = nextSuffixLineCount;
 				})
 			)
 				return;
 		};
 
-		viewportRepaint = (reason: string, targetViewportTop = Math.max(0, newLines.length - height)): void => {
+		viewportRepaint = (reason: string, targetViewportTop = Math.max(0, newLines.length - height)): boolean => {
 			this.#fullRedrawCount += 1;
 			if (renderMetrics.enabled) renderMetrics.recordFullRedraw(reason);
 			const nextViewportTop = targetViewportTop;
 			const currentScreenRow = Math.max(0, Math.min(height - 1, hardwareCursorRow - prevViewportTop));
-			let buffer = "\x1b[?2026h";
-			buffer += this.#kittyViewportCleanup(previousKittyPlacementSpans, prevViewportTop, height);
+			const deletePlan = this.#kittyPlacementDeletePlan(previousKittyPlacementSpans, nextKittyPlacementSpans, [
+				{ top: prevViewportTop, bottom: prevViewportTop + height },
+			]);
+			let buffer = `\x1b[?2026h${deletePlan.output}`;
 			if (currentScreenRow > 0) {
 				buffer += `\x1b[${currentScreenRow}A`;
 			}
@@ -3110,23 +3292,32 @@ export class TUI extends Container {
 			}
 			buffer += cursorSeq;
 			buffer += "\x1b[?2026l";
-			if (
-				!this.#writeRenderBufferAndReanchorImeCursor(buffer, cursorPos, newLines.length, () => {
-					this.#hardwareCursorRow = cursorToRow;
-					this.#cursorRow = Math.max(0, newLines.length - 1);
-					this.#maxLinesRendered = newLines.length;
-					this.#viewportTopRow = nextViewportTop;
-					this.#previousLines = newLines;
-					this.#previousWidth = width;
-					this.#previousHeight = height;
-				})
-			)
-				return;
+			let contentWritten = false;
+			this.#writeRenderBufferAndReanchorImeCursor(buffer, cursorPos, newLines.length, () => {
+				contentWritten = true;
+				this.#hardwareCursorRow = cursorToRow;
+				this.#cursorRow = Math.max(0, newLines.length - 1);
+				this.#maxLinesRendered = newLines.length;
+				this.#viewportTopRow = nextViewportTop;
+				this.#previousLines = newLines;
+				this.#previousWidth = width;
+				this.#previousHeight = height;
+				this.#kittyPlacementSpans = this.#kittyCommittedPlacementsAfterPaint(
+					previousKittyPlacementSpans,
+					nextKittyPlacementSpans,
+					deletePlan,
+					[{ top: nextViewportTop, bottom: nextViewportTop + height }],
+				);
+				this.#manualTranscriptLineCount = nextTranscriptLineCount;
+				this.#manualSuffixLineCount = nextSuffixLineCount;
+			});
+			if (!contentWritten) return false;
 
 			if (this.#debugRedraw) {
 				const msg = `[${new Date().toISOString()}] viewportRepaint: ${reason} (prev=${this.#previousLines.length}, new=${newLines.length}, height=${height}, viewportTop=${nextViewportTop})\n`;
 				this.#appendDebugRedrawLog(msg);
 			}
+			return true;
 		};
 
 		const debugRedraw = this.#debugRedraw;
@@ -3226,6 +3417,22 @@ export class TUI extends Container {
 			lastChanged = newLines.length - 1;
 		}
 		let appendStart = appendedLines && firstChanged === this.#previousLines.length && firstChanged > 0;
+		if (firstChanged >= 0) {
+			const changedTop = firstChanged;
+			let expanded: boolean;
+			do {
+				const priorTop = firstChanged;
+				const priorBottom = lastChanged + 1;
+				for (const placement of previousKittyPlacementSpans) {
+					const placementBottom = placement.row + placement.rows;
+					if (placement.row >= priorBottom || placementBottom <= priorTop) continue;
+					firstChanged = Math.min(firstChanged, placement.row);
+					lastChanged = Math.max(lastChanged, placementBottom - 1);
+				}
+				expanded = firstChanged !== priorTop || lastChanged + 1 !== priorBottom;
+			} while (expanded);
+			if (firstChanged !== changedTop) appendStart = false;
+		}
 
 		// No changes - but still need to update hardware cursor position if it moved
 		if (firstChanged === -1) {
@@ -3237,6 +3444,21 @@ export class TUI extends Container {
 		const nextLiveViewportTop = Math.max(0, newLines.length - height);
 		if (newLines.length < this.#previousLines.length && nextLiveViewportTop !== prevViewportTop) {
 			viewportRepaint(`content contraction changed viewport top (${prevViewportTop} -> ${nextLiveViewportTop})`);
+			return;
+		}
+		if (
+			appendedLines &&
+			nextLiveViewportTop > prevViewportTop &&
+			previousKittyPlacementSpans.some(placement =>
+				this.#kittyPlacementIntersectsRegion(placement, {
+					top: prevViewportTop,
+					bottom: prevViewportTop + height,
+				}),
+			)
+		) {
+			viewportRepaint(
+				`content append moved a Kitty placement viewport (${prevViewportTop} -> ${nextLiveViewportTop})`,
+			);
 			return;
 		}
 		if (appendedLines && this.#scrollbackResumeViewportTop !== undefined && nextLiveViewportTop > prevViewportTop) {
@@ -3251,10 +3473,15 @@ export class TUI extends Container {
 			const previousLines = this.#previousLines;
 			const previousWidth = this.#previousWidth;
 			const previousHeight = this.#previousHeight;
-			viewportRepaint(
-				`staging committed scrollback frontier before resumed admission (${prevViewportTop} -> ${resumeViewportTop} -> ${nextLiveViewportTop})`,
-				resumeViewportTop,
-			);
+			if (
+				!viewportRepaint(
+					`staging committed scrollback frontier before resumed admission (${prevViewportTop} -> ${resumeViewportTop} -> ${nextLiveViewportTop})`,
+					resumeViewportTop,
+				)
+			) {
+				return;
+			}
+			previousKittyPlacementSpans = this.#kittyPlacementSpans;
 			this.#previousLines = previousLines;
 			this.#previousWidth = previousWidth;
 			this.#previousHeight = previousHeight;
@@ -3268,7 +3495,10 @@ export class TUI extends Container {
 		// All changes are in deleted lines (nothing to render, just clear)
 		if (firstChanged >= newLines.length) {
 			if (this.#previousLines.length > newLines.length) {
-				let buffer = "\x1b[?2026h";
+				const deletePlan = this.#kittyPlacementDeletePlan(previousKittyPlacementSpans, nextKittyPlacementSpans, [
+					{ top: firstChanged, bottom: lastChanged + 1 },
+				]);
+				let buffer = `\x1b[?2026h${deletePlan.output}`;
 				// Move to end of new content (clamp to 0 for empty content)
 				const targetRow = Math.max(0, newLines.length - 1);
 				const lineDiff = computeLineDiff(targetRow);
@@ -3310,6 +3540,14 @@ export class TUI extends Container {
 						this.#previousHeight = height;
 						this.#maxLinesRendered = newLines.length;
 						this.#viewportTopRow = Math.max(0, newLines.length - height);
+						this.#kittyPlacementSpans = this.#kittyCommittedPlacementsAfterPaint(
+							previousKittyPlacementSpans,
+							nextKittyPlacementSpans,
+							deletePlan,
+							[],
+						);
+						this.#manualTranscriptLineCount = nextTranscriptLineCount;
+						this.#manualSuffixLineCount = nextSuffixLineCount;
 					})
 				)
 					return;
@@ -3319,6 +3557,8 @@ export class TUI extends Container {
 			this.#previousHeight = height;
 			this.#maxLinesRendered = newLines.length;
 			this.#viewportTopRow = Math.max(0, newLines.length - height);
+			this.#manualTranscriptLineCount = nextTranscriptLineCount;
+			this.#manualSuffixLineCount = nextSuffixLineCount;
 			return;
 		}
 
@@ -3345,7 +3585,10 @@ export class TUI extends Container {
 
 		// Render from first changed line to end
 		// Build buffer with all updates wrapped in synchronized output
-		let buffer = "\x1b[?2026h"; // Begin synchronized output
+		const deletePlan = this.#kittyPlacementDeletePlan(previousKittyPlacementSpans, nextKittyPlacementSpans, [
+			{ top: firstChanged, bottom: lastChanged + 1 },
+		]);
+		let buffer = `\x1b[?2026h${deletePlan.output}`; // Begin synchronized output
 		const prevViewportBottom = prevViewportTop + height - 1;
 		const moveTargetRow = appendStart ? firstChanged - 1 : firstChanged;
 		if (moveTargetRow > prevViewportBottom) {
@@ -3473,6 +3716,14 @@ export class TUI extends Container {
 				this.#previousLines = newLines;
 				this.#previousWidth = width;
 				this.#previousHeight = height;
+				this.#kittyPlacementSpans = this.#kittyCommittedPlacementsAfterPaint(
+					previousKittyPlacementSpans,
+					nextKittyPlacementSpans,
+					deletePlan,
+					[{ top: firstChanged, bottom: renderEnd + 1 }],
+				);
+				this.#manualTranscriptLineCount = nextTranscriptLineCount;
+				this.#manualSuffixLineCount = nextSuffixLineCount;
 			})
 		)
 			return;

--- a/packages/tui/test/image-render.test.ts
+++ b/packages/tui/test/image-render.test.ts
@@ -369,6 +369,32 @@ describe("kitty transmit/placement split (dedup on repaint)", () => {
 		expect(chunks.at(-1)).toContain("m=0");
 	});
 
+	it("retries Kitty pixel transmission after the writer rejects the first attempt", () => {
+		let attempts = 0;
+		setKittyTransmitWriter(() => {
+			attempts += 1;
+			if (attempts === 1) throw new Error("transmit rejected");
+		});
+
+		expect(() =>
+			renderImage(BASE64_DUMMY, SQUARE_DIMENSIONS, {
+				imageId: 42,
+				placementId: 43,
+				maxWidthCells: 2,
+				maxHeightCells: 2,
+			}),
+		).toThrow("transmit rejected");
+		const replay = renderImage(BASE64_DUMMY, SQUARE_DIMENSIONS, {
+			imageId: 42,
+			placementId: 43,
+			maxWidthCells: 2,
+			maxHeightCells: 2,
+		});
+
+		expect(attempts).toBe(2);
+		expect(replay?.sequence).toContain("a=p,i=42,p=43");
+	});
+
 	it("repainting one component does not delete a sibling placement with identical content", () => {
 		const makeImage = () =>
 			new Image(
@@ -431,11 +457,52 @@ describe("kitty transmit/placement split (dedup on repaint)", () => {
 
 		expect(model.images.size).toBe(1);
 		expect(new Set(model.placements.keys())).toEqual(new Set([`${placementB!.imageId}:${placementB!.placementId}`]));
+		model.apply(linesA);
+		expect(model.images.size).toBe(1);
+		expect(model.placements.size).toBe(2);
+		expect(transmitted).toHaveLength(1);
 	});
 
-	it("ignores malformed Kitty placement identifiers", () => {
-		expect(extractKittyPlacementReferences("\x1b_Ga=p,i=123junk,p=7,r=2,C=1,q=2\x1b\\")).toEqual([]);
-		expect(extractKittyPlacementReferences("\x1b_Ga=p,i=123,p=7,r=2junk,C=1,q=2\x1b\\")).toEqual([]);
+	it("extracts multiple bounded placement commands from one line", () => {
+		const first = "\x1b_Ga=p,i=1,p=2,r=3,C=1,q=2\x1b\\";
+		const second = "\x1b_Ga=p,i=4294967295,p=4294967295,r=4294967295,C=1,q=2\x1b\\";
+
+		expect(extractKittyPlacementReferences(`${first}text${second}`)).toEqual([
+			{ imageId: 1, placementId: 2, rows: 3 },
+			{ imageId: 4294967295, placementId: 4294967295, rows: 4294967295 },
+		]);
+	});
+
+	it("rejects malformed, ambiguous, payload-bearing, and unbounded placement commands", () => {
+		const invalid = [
+			"\x1b_Ga=p,i=123junk,p=7,r=2,C=1,q=2\x1b\\",
+			"\x1b_Ga=p,i=123,p=7,r=2junk,C=1,q=2\x1b\\",
+			"\x1b_Ga=p,i=4294967296,p=7,r=2,C=1,q=2\x1b\\",
+			"\x1b_Ga=p,i=7,p=4294967296,r=2,C=1,q=2\x1b\\",
+			"\x1b_Ga=p,i=7,p=8,r=4294967296,C=1,q=2\x1b\\",
+			"\x1b_Ga=p,i=0,p=8,r=2,C=1,q=2\x1b\\",
+			"\x1b_Ga=p,i=7,p=0,r=2,C=1,q=2\x1b\\",
+			"\x1b_Ga=p,i=7,p=8,r=0,C=1,q=2\x1b\\",
+			"\x1b_Ga=p,i=-7,p=8,r=2,C=1,q=2\x1b\\",
+			"\x1b_Ga=p,i=+7,p=8,r=2,C=1,q=2\x1b\\",
+			"\x1b_Ga=p,i=7.0,p=8,r=2,C=1,q=2\x1b\\",
+			"\x1b_Ga=p,i=7e0,p=8,r=2,C=1,q=2\x1b\\",
+			"\x1b_Ga=p,i= 7,p=8,r=2,C=1,q=2\x1b\\",
+			"\x1b_Ga=p,i=7,p=8,r=2,C=0,q=2\x1b\\",
+			"\x1b_Ga=p,i=7,p=8,r=2,q=2\x1b\\",
+			"\x1b_Ga=p,i=7,p=8,C=1,q=2\x1b\\",
+			"\x1b_Ga=p,i=7,p=8,r=2;AAAA\x1b\\",
+			"\x1b_Ga=t,a=p,i=7,p=8,r=2\x1b\\",
+			"\x1b_Ga=p,i=7,p=8,p=9,r=2\x1b\\",
+			"\x1b_Ga=p,i=7,p=8,r=2,m=1\x1b\\",
+			"\x1b_Ga=t,i=7,p=8,r=2\x1b\\",
+			"\x1b_Ga=T,i=7,p=8,r=2;AAAA\x1b\\",
+			"\x1b_Ga=d,d=i,i=7,p=8\x1b\\",
+			"\x1b_Ga=p,i=7,p=8,r=2",
+		];
+		for (const sequence of invalid) expect(extractKittyPlacementReferences(sequence)).toEqual([]);
+		expect(extractKittyPlacementReferences(`\x1b_Ga=p,i=7,p=8,r=2\x1b\\${"x".repeat(256 * 1024)}`)).toEqual([]);
+		expect(extractKittyPlacementReferences("x".repeat(256 * 1024 + 1))).toEqual([]);
 	});
 
 	it("legacy a=T emission stacks placements in the terminal model (regression contrast)", () => {

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -13,6 +13,7 @@ import {
 	TERMINAL,
 	TUI,
 } from "@gajae-code/tui";
+import type { Terminal, TerminalAppearance } from "@gajae-code/tui/terminal";
 import { visibleWidth } from "@gajae-code/tui/utils";
 import { VirtualTerminal } from "./virtual-terminal";
 
@@ -31,6 +32,118 @@ class MutableLinesComponent implements Component {
 
 	render(width: number): string[] {
 		return this.#lines.map(line => line.slice(0, width));
+	}
+}
+
+class RawMutableLinesComponent implements Component {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		this.#lines = [...lines];
+	}
+
+	setLines(lines: string[]): void {
+		this.#lines = [...lines];
+	}
+
+	invalidate(): void {}
+
+	render(): string[] {
+		return this.#lines;
+	}
+}
+
+class FaultingVirtualTerminal implements Terminal {
+	#available = true;
+	#writeFailureAt: number | undefined;
+	#writes = 0;
+
+	constructor(readonly terminal: VirtualTerminal) {}
+
+	setWriteFailureAt(writeFailureAt: number | undefined): void {
+		this.#writeFailureAt = writeFailureAt;
+		if (writeFailureAt === undefined) this.#available = true;
+	}
+
+	get writeCount(): number {
+		return this.#writes;
+	}
+
+	start(onInput: (data: string) => void, onResize: () => void): void {
+		this.terminal.start(onInput, onResize);
+	}
+
+	stop(): void {
+		this.terminal.stop();
+	}
+
+	drainInput(maxMs?: number, idleMs?: number): Promise<void> {
+		return this.terminal.drainInput(maxMs, idleMs);
+	}
+
+	write(data: string): void {
+		if (!this.#available || (this.#writeFailureAt !== undefined && this.#writes + 1 >= this.#writeFailureAt)) {
+			this.#available = false;
+			throw Object.assign(new Error("deterministic image repaint failure"), { code: "EIO" });
+		}
+		this.#writes += 1;
+		this.terminal.write(data);
+	}
+
+	get available(): boolean {
+		return this.#available;
+	}
+
+	get columns(): number {
+		return this.terminal.columns;
+	}
+
+	get rows(): number {
+		return this.terminal.rows;
+	}
+
+	get kittyProtocolActive(): boolean {
+		return this.terminal.kittyProtocolActive;
+	}
+
+	get appearance(): TerminalAppearance | undefined {
+		return this.terminal.appearance;
+	}
+
+	onAppearanceChange(callback: (appearance: TerminalAppearance) => void): void {
+		this.terminal.onAppearanceChange(callback);
+	}
+
+	moveBy(lines: number): void {
+		this.write(lines > 0 ? `\x1b[${lines}B` : `\x1b[${-lines}A`);
+	}
+
+	hideCursor(): void {
+		this.write("\x1b[?25l");
+	}
+
+	showCursor(): void {
+		this.write("\x1b[?25h");
+	}
+
+	clearLine(): void {
+		this.write("\x1b[K");
+	}
+
+	clearFromCursor(): void {
+		this.write("\x1b[J");
+	}
+
+	clearScreen(): void {
+		this.write("\x1b[H\x1b[0J");
+	}
+
+	setTitle(title: string): void {
+		this.write(`\x1b]0;${title}\x07`);
+	}
+
+	setProgress(active: boolean): void {
+		this.write(active ? "\x1b]9;4;3\x07" : "\x1b]9;4;0;\x07");
 	}
 }
 
@@ -282,6 +395,499 @@ describe("TUI terminal-state regressions", () => {
 				const followedOutput = term.getWriteLog().join("");
 				expect(followedOutput).toContain(encodeKittyPlacementDelete(placement!));
 				expect(extractKittyPlacementReferences(followedOutput)).toEqual([]);
+			} finally {
+				tui.stop();
+				setCellDimensions(originalCellDimensions);
+				setTerminalImageProtocol(originalProtocol);
+				resetKittyTransmissions();
+				setKittyTransmitWriter(sequence => process.stdout.write(sequence));
+			}
+		});
+
+		it("soft-deletes a same-row Kitty placement before differential replacement and replays without retransmit", async () => {
+			const originalProtocol = TERMINAL.imageProtocol;
+			const originalCellDimensions = getCellDimensions();
+			const transmissions: string[] = [];
+			setCellDimensions({ widthPx: 10, heightPx: 10 });
+			setTerminalImageProtocol(ImageProtocol.Kitty);
+			resetKittyTransmissions();
+			setKittyTransmitWriter(sequence => transmissions.push(sequence));
+
+			const image = new Image(
+				"AA==",
+				"image/png",
+				{ fallbackColor: value => value },
+				{ maxWidthCells: 4, maxHeightCells: 2 },
+				{ widthPx: 20, heightPx: 20 },
+			);
+			const imageLines = image.render(40);
+			const component = new RawMutableLinesComponent(["header", ...imageLines, "footer"]);
+			const term = new VirtualTerminal(40, 8);
+			const tui = new TUI(term);
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+				const [placement] = extractKittyPlacementReferences(term.getWriteLog().join(""));
+				expect(placement).toBeDefined();
+				expect(transmissions).toHaveLength(1);
+
+				term.clearWriteLog();
+				component.setLines(["header", "replacement", "", "footer"]);
+				tui.requestRender();
+				await settle(term);
+				const replacedOutput = term.getWriteLog().join("");
+				const deleteSequence = encodeKittyPlacementDelete(placement!);
+				expect(replacedOutput).toContain(deleteSequence);
+				expect(replacedOutput.indexOf(deleteSequence)).toBeLessThan(replacedOutput.indexOf("\x1b[2K"));
+				expect(extractKittyPlacementReferences(replacedOutput)).toEqual([]);
+
+				term.clearWriteLog();
+				component.setLines(["header", ...imageLines, "footer"]);
+				tui.requestRender();
+				await settle(term);
+				expect(extractKittyPlacementReferences(term.getWriteLog().join(""))).toEqual([placement]);
+				expect(transmissions).toHaveLength(1);
+			} finally {
+				tui.stop();
+				setCellDimensions(originalCellDimensions);
+				setTerminalImageProtocol(originalProtocol);
+				resetKittyTransmissions();
+				setKittyTransmitWriter(sequence => process.stdout.write(sequence));
+			}
+		});
+
+		it("preserves the committed Kitty placement ledger when a differential paint fails", async () => {
+			const originalProtocol = TERMINAL.imageProtocol;
+			const originalCellDimensions = getCellDimensions();
+			setCellDimensions({ widthPx: 10, heightPx: 10 });
+			setTerminalImageProtocol(ImageProtocol.Kitty);
+			resetKittyTransmissions();
+			setKittyTransmitWriter(() => {});
+
+			const image = new Image(
+				"AA==",
+				"image/png",
+				{ fallbackColor: value => value },
+				{ maxWidthCells: 4, maxHeightCells: 2 },
+				{ widthPx: 20, heightPx: 20 },
+			);
+			const imageLines = image.render(40);
+			const component = new RawMutableLinesComponent(["header", ...imageLines, "footer"]);
+			const baseTerminal = new VirtualTerminal(40, 8);
+			const terminal = new FaultingVirtualTerminal(baseTerminal);
+			const tui = new TUI(terminal);
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(baseTerminal);
+				const [placement] = extractKittyPlacementReferences(baseTerminal.getWriteLog().join(""));
+				expect(placement).toBeDefined();
+
+				baseTerminal.clearWriteLog();
+				terminal.setWriteFailureAt(terminal.writeCount + 1);
+				component.setLines(["header", "replacement", "", "footer"]);
+				tui.requestRender();
+				await settle(baseTerminal);
+				expect(baseTerminal.getWriteLog()).toEqual([]);
+
+				terminal.setWriteFailureAt(undefined);
+				baseTerminal.clearWriteLog();
+				tui.start();
+				await settle(baseTerminal);
+				expect(baseTerminal.getWriteLog().join("")).toContain(encodeKittyPlacementDelete(placement!));
+			} finally {
+				tui.stop();
+				setCellDimensions(originalCellDimensions);
+				setTerminalImageProtocol(originalProtocol);
+				resetKittyTransmissions();
+				setKittyTransmitWriter(sequence => process.stdout.write(sequence));
+			}
+		});
+
+		it("rolls back manual viewport ownership when the scroll repaint fails", async () => {
+			const baseTerminal = new VirtualTerminal(30, 6);
+			const terminal = new FaultingVirtualTerminal(baseTerminal);
+			const tui = new TUI(terminal);
+			tui.addChild(new MutableLinesComponent(rows("history-", 20)));
+
+			try {
+				tui.start();
+				await settle(baseTerminal);
+				terminal.setWriteFailureAt(terminal.writeCount + 1);
+				expect(tui.scrollViewportPages(-1)).toBe(false);
+
+				terminal.setWriteFailureAt(undefined);
+				baseTerminal.clearWriteLog();
+				tui.start();
+				await settle(baseTerminal);
+				expect(visible(baseTerminal)).toEqual(rows("history-", 20).slice(-6));
+			} finally {
+				tui.stop();
+			}
+		});
+
+		it("soft-deletes and replays a Kitty placement across terminal resize", async () => {
+			const originalProtocol = TERMINAL.imageProtocol;
+			const originalCellDimensions = getCellDimensions();
+			const transmissions: string[] = [];
+			setCellDimensions({ widthPx: 10, heightPx: 10 });
+			setTerminalImageProtocol(ImageProtocol.Kitty);
+			resetKittyTransmissions();
+			setKittyTransmitWriter(sequence => transmissions.push(sequence));
+
+			const term = new VirtualTerminal(40, 8);
+			const tui = new TUI(term, undefined, { widthSettleMs: 0 });
+			tui.addChild(
+				new Image(
+					"AA==",
+					"image/png",
+					{ fallbackColor: value => value },
+					{ maxWidthCells: 4, maxHeightCells: 2, refetch: () => "AA==" },
+					{ widthPx: 20, heightPx: 20 },
+				),
+			);
+
+			try {
+				tui.start();
+				await settle(term);
+				const [placement] = extractKittyPlacementReferences(term.getWriteLog().join(""));
+				expect(placement).toBeDefined();
+
+				term.clearWriteLog();
+				term.resize(30, 8);
+				await settle(term);
+				const resizedOutput = term.getWriteLog().join("");
+				expect(resizedOutput).toContain(encodeKittyPlacementDelete(placement!));
+				expect(extractKittyPlacementReferences(resizedOutput)).toEqual([placement]);
+				expect(transmissions).toHaveLength(1);
+			} finally {
+				tui.stop();
+				setCellDimensions(originalCellDimensions);
+				setTerminalImageProtocol(originalProtocol);
+				resetKittyTransmissions();
+				setKittyTransmitWriter(sequence => process.stdout.write(sequence));
+			}
+		});
+
+		it("cleans a partial Kitty span and replays it when manual navigation revisits the anchor", async () => {
+			const originalProtocol = TERMINAL.imageProtocol;
+			setTerminalImageProtocol(ImageProtocol.Kitty);
+			const placement = "\x1b_Ga=p,i=301,p=302,c=2,r=3,C=1,q=2\x1b\\";
+			const term = new VirtualTerminal(40, 5, { isProcessTerminal: true });
+			const tui = new TUI(term, undefined, { widthSettleMs: 0 });
+			tui.addChild(new RawMutableLinesComponent([placement, "", "", "tail-0", "tail-1"]));
+
+			try {
+				tui.start();
+				await settle(term);
+				term.clearWriteLog();
+				term.resize(40, 4);
+				await settle(term);
+				const output = term.getWriteLog().join("");
+				expect(output).toContain(encodeKittyPlacementDelete({ imageId: 301, placementId: 302, rows: 3 }));
+				expect(extractKittyPlacementReferences(output)).toEqual([]);
+
+				term.clearWriteLog();
+				expect(tui.scrollViewportBy(-1)).toBe(true);
+				await term.flush();
+				expect(extractKittyPlacementReferences(term.getWriteLog().join(""))).toEqual([
+					{ imageId: 301, placementId: 302, rows: 3 },
+				]);
+			} finally {
+				tui.stop();
+				setTerminalImageProtocol(originalProtocol);
+			}
+		});
+
+		it("keeps an unchanged Kitty placement when unpin coalesces with an unrelated edit", async () => {
+			const originalProtocol = TERMINAL.imageProtocol;
+			const originalCellDimensions = getCellDimensions();
+			setCellDimensions({ widthPx: 10, heightPx: 10 });
+			setTerminalImageProtocol(ImageProtocol.Kitty);
+			resetKittyTransmissions();
+			setKittyTransmitWriter(() => {});
+
+			const term = new VirtualTerminal(40, 3);
+			const tui = new TUI(term);
+			const transcript = new MutableLinesComponent(["body"]);
+			const image = new Image(
+				"AA==",
+				"image/png",
+				{ fallbackColor: value => value },
+				{ maxWidthCells: 4, maxHeightCells: 2 },
+				{ widthPx: 20, heightPx: 20 },
+			);
+			tui.addChild(transcript);
+			tui.addChild(image);
+			tui.setBottomPinnedComponent(image);
+
+			try {
+				tui.start();
+				await settle(term);
+				const [placement] = extractKittyPlacementReferences(term.getWriteLog().join(""));
+				expect(placement).toBeDefined();
+
+				term.clearWriteLog();
+				tui.setBottomPinnedComponent(null);
+				transcript.setLines(["changed"]);
+				tui.requestRender();
+				await settle(term);
+				expect(term.getWriteLog().join("")).not.toContain(encodeKittyPlacementDelete(placement!));
+			} finally {
+				tui.stop();
+				setCellDimensions(originalCellDimensions);
+				setTerminalImageProtocol(originalProtocol);
+				resetKittyTransmissions();
+				setKittyTransmitWriter(sequence => process.stdout.write(sequence));
+			}
+		});
+
+		it("cleans a formerly pinned placement when manual repaint adopts transcript geometry", async () => {
+			const originalProtocol = TERMINAL.imageProtocol;
+			const originalCellDimensions = getCellDimensions();
+			setCellDimensions({ widthPx: 10, heightPx: 10 });
+			setTerminalImageProtocol(ImageProtocol.Kitty);
+			resetKittyTransmissions();
+			setKittyTransmitWriter(() => {});
+
+			const term = new VirtualTerminal(40, 6);
+			const tui = new TUI(term);
+			const transcript = new MutableLinesComponent(rows("history-", 10));
+			const image = new Image(
+				"AA==",
+				"image/png",
+				{ fallbackColor: value => value },
+				{ maxWidthCells: 4, maxHeightCells: 2 },
+				{ widthPx: 20, heightPx: 20 },
+			);
+			tui.addChild(transcript);
+			tui.addChild(image);
+			tui.setBottomPinnedComponent(image);
+
+			try {
+				tui.start();
+				await settle(term);
+				const [placement] = extractKittyPlacementReferences(term.getWriteLog().join(""));
+				expect(placement).toBeDefined();
+				expect(tui.scrollViewportPages(-1)).toBe(true);
+				await term.flush();
+
+				term.clearWriteLog();
+				tui.setBottomPinnedComponent(null);
+				await settle(term);
+				expect(term.getWriteLog().join("")).not.toContain(encodeKittyPlacementDelete(placement!));
+
+				term.clearWriteLog();
+				expect(tui.scrollViewportBy(-1)).toBe(true);
+				await term.flush();
+				const output = term.getWriteLog().join("");
+				expect(output).toContain(encodeKittyPlacementDelete(placement!));
+				expect(extractKittyPlacementReferences(output)).toEqual([]);
+			} finally {
+				tui.stop();
+				setCellDimensions(originalCellDimensions);
+				setTerminalImageProtocol(originalProtocol);
+				resetKittyTransmissions();
+				setKittyTransmitWriter(sequence => process.stdout.write(sequence));
+			}
+		});
+
+		it("replays every overlapping Kitty span after fixed-point differential expansion", async () => {
+			const originalProtocol = TERMINAL.imageProtocol;
+			setTerminalImageProtocol(ImageProtocol.Kitty);
+			const placementA = "\x1b_Ga=p,i=101,p=102,c=2,r=2,C=1,q=2\x1b\\";
+			const placementB = "\x1b_Ga=p,i=201,p=202,c=2,r=2,C=1,q=2\x1b\\";
+			const component = new RawMutableLinesComponent([placementA, placementB, "old", "tail"]);
+			const term = new VirtualTerminal(40, 6);
+			const tui = new TUI(term);
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+				term.clearWriteLog();
+				component.setLines([placementA, placementB, "new", "tail"]);
+				tui.requestRender();
+				await settle(term);
+				const output = term.getWriteLog().join("");
+				expect(output).toContain(encodeKittyPlacementDelete({ imageId: 101, placementId: 102, rows: 2 }));
+				expect(output).toContain(encodeKittyPlacementDelete({ imageId: 201, placementId: 202, rows: 2 }));
+				expect(extractKittyPlacementReferences(output)).toEqual([
+					{ imageId: 101, placementId: 102, rows: 2 },
+					{ imageId: 201, placementId: 202, rows: 2 },
+				]);
+			} finally {
+				tui.stop();
+				setTerminalImageProtocol(originalProtocol);
+			}
+		});
+
+		it("soft-deletes a high logical-row placement before forced full replay", async () => {
+			const originalProtocol = TERMINAL.imageProtocol;
+			const originalCellDimensions = getCellDimensions();
+			setCellDimensions({ widthPx: 10, heightPx: 10 });
+			setTerminalImageProtocol(ImageProtocol.Kitty);
+			resetKittyTransmissions();
+			setKittyTransmitWriter(() => {});
+
+			const image = new Image(
+				"AA==",
+				"image/png",
+				{ fallbackColor: value => value },
+				{ maxWidthCells: 4, maxHeightCells: 2 },
+				{ widthPx: 20, heightPx: 20 },
+			);
+			const initialLines = [...rows("history-", 18), ...image.render(40), "tail"];
+			const component = new RawMutableLinesComponent(initialLines);
+			const term = new VirtualTerminal(40, 6);
+			const tui = new TUI(term);
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+				const [placement] = extractKittyPlacementReferences(term.getWriteLog().join(""));
+				expect(placement).toBeDefined();
+
+				term.clearWriteLog();
+				component.setLines([...rows("history-", 18), "replacement", "", "tail"]);
+				tui.requestRender(true, "test.forced-image-removal");
+				await settle(term);
+				expect(term.getWriteLog().join("")).toContain(encodeKittyPlacementDelete(placement!));
+			} finally {
+				tui.stop();
+				setCellDimensions(originalCellDimensions);
+				setTerminalImageProtocol(originalProtocol);
+				resetKittyTransmissions();
+				setKittyTransmitWriter(sequence => process.stdout.write(sequence));
+			}
+		});
+
+		it("soft-deletes Kitty placements on stop and restores them without retransmit on restart", async () => {
+			const originalProtocol = TERMINAL.imageProtocol;
+			const originalCellDimensions = getCellDimensions();
+			const transmissions: string[] = [];
+			setCellDimensions({ widthPx: 10, heightPx: 10 });
+			setTerminalImageProtocol(ImageProtocol.Kitty);
+			resetKittyTransmissions();
+			setKittyTransmitWriter(sequence => transmissions.push(sequence));
+
+			const term = new VirtualTerminal(40, 6);
+			const tui = new TUI(term);
+			tui.addChild(
+				new Image(
+					"AA==",
+					"image/png",
+					{ fallbackColor: value => value },
+					{ maxWidthCells: 4, maxHeightCells: 2, refetch: () => "AA==" },
+					{ widthPx: 20, heightPx: 20 },
+				),
+			);
+
+			try {
+				tui.start();
+				await settle(term);
+				const [placement] = extractKittyPlacementReferences(term.getWriteLog().join(""));
+				expect(placement).toBeDefined();
+
+				term.clearWriteLog();
+				tui.stop();
+				expect(term.getWriteLog().join("")).toContain(encodeKittyPlacementDelete(placement!));
+
+				term.clearWriteLog();
+				tui.start();
+				await settle(term);
+				expect(extractKittyPlacementReferences(term.getWriteLog().join(""))).toEqual([placement]);
+				expect(transmissions).toHaveLength(1);
+			} finally {
+				tui.stop();
+				setCellDimensions(originalCellDimensions);
+				setTerminalImageProtocol(originalProtocol);
+				resetKittyTransmissions();
+				setKittyTransmitWriter(sequence => process.stdout.write(sequence));
+			}
+		});
+
+		it("tracks and cleans a removed bottom-pinned Kitty placement", async () => {
+			const originalProtocol = TERMINAL.imageProtocol;
+			const originalCellDimensions = getCellDimensions();
+			setCellDimensions({ widthPx: 10, heightPx: 10 });
+			setTerminalImageProtocol(ImageProtocol.Kitty);
+			resetKittyTransmissions();
+			setKittyTransmitWriter(() => {});
+
+			const term = new VirtualTerminal(40, 6);
+			const tui = new TUI(term);
+			const transcript = new MutableLinesComponent(["body"]);
+			const pinnedImage = new Image(
+				"AA==",
+				"image/png",
+				{ fallbackColor: value => value },
+				{ maxWidthCells: 4, maxHeightCells: 2 },
+				{ widthPx: 20, heightPx: 20 },
+			);
+			tui.addChild(transcript);
+			tui.addChild(pinnedImage);
+			tui.setBottomPinnedComponent(pinnedImage);
+
+			try {
+				tui.start();
+				await settle(term);
+				const [placement] = extractKittyPlacementReferences(term.getWriteLog().join(""));
+				expect(placement).toBeDefined();
+
+				term.clearWriteLog();
+				tui.setBottomPinnedComponent(null);
+				tui.detachChild(pinnedImage);
+				tui.requestRender();
+				await settle(term);
+				expect(term.getWriteLog().join("")).toContain(encodeKittyPlacementDelete(placement!));
+			} finally {
+				tui.stop();
+				setCellDimensions(originalCellDimensions);
+				setTerminalImageProtocol(originalProtocol);
+				resetKittyTransmissions();
+				setKittyTransmitWriter(sequence => process.stdout.write(sequence));
+			}
+		});
+
+		it("tracks and cleans a hidden Kitty image overlay", async () => {
+			const originalProtocol = TERMINAL.imageProtocol;
+			const originalCellDimensions = getCellDimensions();
+			setCellDimensions({ widthPx: 10, heightPx: 10 });
+			setTerminalImageProtocol(ImageProtocol.Kitty);
+			resetKittyTransmissions();
+			setKittyTransmitWriter(() => {});
+
+			const term = new VirtualTerminal(40, 8);
+			const tui = new TUI(term);
+			tui.addChild(new MutableLinesComponent(["base-0", "base-1", "base-2", "base-3"]));
+
+			try {
+				tui.start();
+				await settle(term);
+				term.clearWriteLog();
+				const overlay = tui.showOverlay(
+					new Image(
+						"AA==",
+						"image/png",
+						{ fallbackColor: value => value },
+						{ maxWidthCells: 4, maxHeightCells: 2 },
+						{ widthPx: 20, heightPx: 20 },
+					),
+					{ anchor: "center", width: 10 },
+				);
+				await settle(term);
+				const [placement] = extractKittyPlacementReferences(term.getWriteLog().join(""));
+				expect(placement).toBeDefined();
+
+				term.clearWriteLog();
+				overlay.hide();
+				await settle(term);
+				expect(term.getWriteLog().join("")).toContain(encodeKittyPlacementDelete(placement!));
 			} finally {
 				tui.stop();
 				setCellDimensions(originalCellDimensions);


### PR DESCRIPTION
## What

Corrective follow-up to merged PR #3475. That PR merged old head `9e794ce4b81a1787e181edff90b3158bc894dc70` as `40b96b1c4ec28eaa00010bf5815aaf2bc112fa05` before its reviewed lifecycle repair became the PR head. This PR carries only the stranded repair, rebased directly onto that merge commit.

- Parse only bounded, unambiguous Kitty named-placement commands.
- Publish transmitted-image cache state only after the writer accepts the payload.
- Track transcript, pinned-suffix, and overlay placements as committed physical state.
- Soft-delete overwritten named placements before erase/repaint while retaining pixel data for replay without retransmission.
- Cover differential/full/viewport/manual/resize/overlay/pinned/stop-restart transitions, fixed-point overlaps, failed-write rollback, staged-frontier failure, coalesced owner transitions, and cursor-write failure semantics.

## Exact head

- Base: `40b96b1c4ec28eaa00010bf5815aaf2bc112fa05`
- Head: `cfb171d7bfa9da0c2770d929420e952970ef2401`
- One commit, five files; source/test blobs are byte-identical to the independently cleared stranded repair.

## Verification

- Focused terminal-detach/image/render/viewport suite: `135 pass`, `0 fail`, `1010 assertions`.
- Full TUI suite: `937 pass`, `6 skip`, `0 fail`, `7128 assertions`.
- `bun --cwd=packages/tui run check`: pass.
- `bun --cwd=packages/coding-agent run build`: pass.
- ANSI-preserving PTY replay: PASS; one pixel transmit, two placements, two soft deletes; delete offset `250` precedes erase `288` and replay `349`; raw SHA-256 `316628a9a19557f312089387bee769ff13c67a88e32a4e8bf0b25dcdd51559ce`.
- Exact-head independent verdicts: Architect `CLEAR` (0.99), red-team `MERGE_READY` (0.99), terminal Critic `MERGE_READY` (0.99).

No external contributor branch is rewritten by this corrective PR.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*