### PR TITLE
fix(coding-agent): complete single-model credential failover for extension-loaded sessions (#3491)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Kitty/Ghostty inline images no longer remain visually pinned when transcript, pinned, or overlay rows are replaced, removed, scrolled, resized, or fully repainted. The TUI now parses only bounded named placements, soft-deletes overwritten placements from the previously committed physical frame, retains transmitted pixels, and restores placements from application scrollback without retransmitting image data.
 - Reviewer `report_finding` evidence is no longer injected into caller-owned strict JTD completion data; full findings are published separately through a bounded artifact reference, and failed evidence publication now fails the task closed (#2893).
 - Managed-session startup failures now include their bounded preparation classification (and path-free native durability diagnostic when available), so Windows launch crashes no longer collapse to an unactionable generic error while filesystem paths and raw OS messages remain redacted (#3383).
+- Single-model sessions now rotate immediately to another stored provider credential after a content-free quota or rate-limit failure, without requiring a synthetic model fallback chain. Credential rotation is replay-safe for content-free failures regardless of extension lifecycle participation, and traverses the full credential pool independent of `retry.maxRetries` (#3491).
 
 ### Added
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8315,6 +8315,7 @@ export class AgentSession {
 				await this.#agentEndPublicationPromise;
 			} else {
 				await this.#agentEndHandlingPromise;
+				await this.#waitForPostPromptRecovery();
 				await this.#agentEndPublicationPromise;
 			}
 		}
@@ -14313,25 +14314,25 @@ export class AgentSession {
 		return `Model fallback chain exhausted; models tried: ${tried}; models skipped: ${skipped}`;
 	}
 
-	async #markFailedManagedCredential(trigger: {
-		class: FallbackTriggerClass;
-		retryAfterMs?: number;
-	}): Promise<boolean> {
+	async #markFailedCredential(trigger: { class: FallbackTriggerClass; retryAfterMs?: number }): Promise<boolean> {
 		if (!this.model || (trigger.class !== "auth" && trigger.class !== "quota" && trigger.class !== "rate_limit")) {
 			return false;
 		}
 		const authStorage = this.#modelRegistry.authStorage;
+		const providerAffinitySessionId = this.agent.providerSessionId ?? this.agent.sessionId ?? this.sessionId;
 		if (trigger.class === "auth") {
-			const apiKey = await this.#modelRegistry.getApiKey(this.model, this.sessionId);
+			const apiKey = await this.#modelRegistry.getApiKey(this.model, providerAffinitySessionId);
 			if (!isAuthenticated(apiKey)) return false;
-			return authStorage.invalidateCredentialMatching(this.model.provider, apiKey, { sessionId: this.sessionId });
+			return authStorage.invalidateCredentialMatching(this.model.provider, apiKey, {
+				sessionId: providerAffinitySessionId,
+			});
 		}
 		if (authStorage.hasRuntimeApiKey(this.model.provider)) return false;
-		const activeApiKey = await this.#modelRegistry.getApiKey(this.model, this.sessionId);
-		const rotated = await authStorage.markUsageLimitReached(this.model.provider, this.sessionId, {
+		const activeApiKey = await this.#modelRegistry.getApiKey(this.model, providerAffinitySessionId);
+		const rotated = await authStorage.markUsageLimitReached(this.model.provider, providerAffinitySessionId, {
 			retryAfterMs: trigger.retryAfterMs,
 		});
-		return rotated && (await this.#modelRegistry.getApiKey(this.model, this.sessionId)) !== activeApiKey;
+		return rotated && (await this.#modelRegistry.getApiKey(this.model, providerAffinitySessionId)) !== activeApiKey;
 	}
 
 	/** Handle retryable errors with exponential backoff. */
@@ -14363,8 +14364,29 @@ export class AgentSession {
 		) {
 			return false;
 		}
-		// Bare defaults admit only clean, side-effect-free canonical stream watchdog failures.
-		if (!managedFallback && !legacyRetryConfigured) {
+		const trigger = this.#fallbackTriggerFor(message, !managedFallback, transportFailure);
+		if (!trigger) {
+			return managedOutcome
+				? this.#managedFallbackExhaustionDecision(message, message.errorMessage || "Model fallback attempt failed")
+				: false;
+		}
+		// Credential rotation: a content-free quota/rate-limit failure has no
+		// observable state to corrupt, so it is replay-safe regardless of
+		// extension lifecycle participation. Mark the failed credential and
+		// retry with the next stored credential of the same provider.
+		let credentialRotated =
+			!managedFallback &&
+			!assistantMessageHasVisibleOrToolContent(message) &&
+			(trigger.class === "quota" || trigger.class === "rate_limit") &&
+			(await this.#markFailedCredential(trigger));
+		// A content-free credential rotation is inherently replay-safe: no partial
+		// output, no tool calls, no extension-observable streaming state was produced
+		// before the failure. This bypasses #hasCleanRetryReplaySafety because the
+		// content-free check is the replay-safety guarantee for credential rotation.
+		const canReplayRotatedCredential = credentialRotated;
+		// Bare defaults admit only clean, side-effect-free canonical stream watchdog failures
+		// or content-free quota/rate-limit failures that switched to another stored credential.
+		if (!managedFallback && !legacyRetryConfigured && !canReplayRotatedCredential) {
 			if (
 				(!this.#isTypedFirstEventTimeout(message) &&
 					(hasBareDefaultRetryDisqualifyingFacts(message) ||
@@ -14375,12 +14397,6 @@ export class AgentSession {
 				return false;
 			}
 		}
-		const trigger = this.#fallbackTriggerFor(message, !managedFallback, transportFailure);
-		if (!trigger) {
-			return managedOutcome
-				? this.#managedFallbackExhaustionDecision(message, message.errorMessage || "Model fallback attempt failed")
-				: false;
-		}
 		const legacyUnbounded = classification === "transient";
 		const attemptsUsed = managedFallback ? controller.attemptsUsed || 1 : this.#retryAttempt + 1;
 		const failedSelector = managedFallback ? controller.currentSelector() : undefined;
@@ -14389,12 +14405,14 @@ export class AgentSession {
 			: legacyUnbounded || attemptsUsed <= retrySettings.maxRetries
 				? "retry"
 				: "exhausted";
-		const credentialRotated =
-			managedFallback &&
-			outcome === "advance" &&
-			(trigger.class === "quota" || trigger.class === "rate_limit") &&
-			(await this.#markFailedManagedCredential(trigger));
-		if (credentialRotated && controller.restorePreviousEntryForRetry()) {
+		// Credential rotation is unbounded: a fresh credential is a different
+		// retry dimension from transient-error backoff, so it overrides maxRetries
+		// exhaustion and forces an immediate same-model retry.
+		if (managedFallback && outcome === "advance" && (trigger.class === "quota" || trigger.class === "rate_limit")) {
+			credentialRotated = await this.#markFailedCredential(trigger);
+		}
+		if (credentialRotated) {
+			if (managedFallback) controller.restorePreviousEntryForRetry();
 			outcome = "retry";
 		}
 		if (outcome === "exhausted") {
@@ -14430,7 +14448,7 @@ export class AgentSession {
 		}
 
 		const retry = async (ownership?: ManagedAttemptContinuationOwnership): Promise<void> => {
-			if (managedFallback && !credentialRotated) await this.#markFailedManagedCredential(trigger);
+			if (managedFallback && !credentialRotated) await this.#markFailedCredential(trigger);
 			let advanced = outcome !== "advance";
 			let resolutionError: unknown;
 			if (outcome === "advance") {

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -2,11 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
 import { Agent } from "@gajae-code/agent-core";
-import { type AssistantMessage, getBundledModel } from "@gajae-code/ai";
+import { type AssistantMessage, getBundledModel, type Model } from "@gajae-code/ai";
 import { createMockModel } from "@gajae-code/ai/providers/mock";
 import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { ExtensionRunner } from "@gajae-code/coding-agent/extensibility/extensions/runner";
+import type { Extension } from "@gajae-code/coding-agent/extensibility/extensions/types";
 import {
 	AgentSession,
 	type AgentSessionEvent,
@@ -42,6 +44,95 @@ function getLastAssistantMessage(session: AgentSession): AssistantMessage {
 		throw new Error("Expected final assistant message");
 	}
 	return lastMessage;
+}
+
+function typedRateLimitStream(
+	model: Model,
+	retryAfterMs: number,
+	errorMessage = "Provider returned error: rate_limit_error: organization quota reached",
+): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+	queueMicrotask(() => {
+		const message: AssistantMessage = {
+			role: "assistant",
+			content: [],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "error",
+			errorMessage,
+			errorStatus: 429,
+			transportFailure: {
+				kind: "transport",
+				status: 429,
+				headers: { "retry-after-ms": String(retryAfterMs) },
+			},
+			timestamp: Date.now(),
+		};
+		stream.push({ type: "start", partial: message });
+		stream.push({ type: "error", reason: "error", error: message });
+	});
+	return stream;
+}
+
+function typedUsageLimitStream(model: Model, retryAfterMs = 60_000): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+	queueMicrotask(() => {
+		const message: AssistantMessage = {
+			role: "assistant",
+			content: [],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "error",
+			errorMessage:
+				'429 {"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed your account\'s rate limit. Please try again later."}}',
+			errorStatus: 429,
+			transportFailure: { kind: "transport", status: 429, headers: { "retry-after-ms": String(retryAfterMs) } },
+			timestamp: Date.now(),
+		};
+		stream.push({ type: "start", partial: message });
+		stream.push({ type: "error", reason: "error", error: message });
+	});
+	return stream;
+}
+
+function makeExtensionRunner(handlers: string[], cwd: string, sm: SessionManager, mr: ModelRegistry): ExtensionRunner {
+	const handlerMap = new Map<string, Array<() => Promise<void>>>();
+	for (const h of handlers) handlerMap.set(h, [async () => {}]);
+	const extension: Extension = {
+		path: "test-extension",
+		resolvedPath: "test-extension",
+		handlers: handlerMap as Extension["handlers"],
+		tools: new Map(),
+		messageRenderers: new Map(),
+		commands: new Map(),
+		flags: new Map(),
+		shortcuts: new Map(),
+	};
+	return new ExtensionRunner(
+		handlerMap.size === 0 ? [] : [extension],
+		{ flagValues: new Map(), pendingProviderRegistrations: [] } as never,
+		cwd,
+		sm,
+		mr,
+	);
 }
 
 describe("AgentSession retry fallback", () => {
@@ -445,6 +536,172 @@ describe("AgentSession retry fallback", () => {
 		expect(retryStartEvents).toHaveLength(1);
 		expect(retryEndEvents).toHaveLength(1);
 		expect(retryEndEvents[0]).toMatchObject({ success: true, attempt: 1 });
+	});
+
+	it("rotates a single-model stored credential after a typed quota failure before prompt completion", async () => {
+		const model = getBundledModel("openai", "gpt-4o-mini");
+		if (!model) throw new Error("Expected bundled test model");
+		authStorage.removeRuntimeApiKey("openai");
+		await authStorage.set("openai", [
+			{ type: "api_key", key: "account-a-key" },
+			{ type: "api_key", key: "account-b-key" },
+		]);
+
+		const logicalSessionId = "logical-session";
+		const providerAffinitySessionId = "pool-session";
+		const requestedKeys: string[] = [];
+		let calls = 0;
+		const agent = new Agent({
+			getApiKey: async provider => {
+				const key = await modelRegistry.getApiKeyForProvider(provider, providerAffinitySessionId);
+				if (key) requestedKeys.push(key);
+				return key;
+			},
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (requestedModel, context, options) => {
+				calls++;
+				if (calls === 1) return typedRateLimitStream(requestedModel, 60_000);
+				return createMockModel({ responses: [{ content: ["Recovered with another account"] }] }).stream(
+					requestedModel,
+					context,
+					options,
+				);
+			},
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+			providerSessionId: logicalSessionId,
+			providerCacheSessionId: providerAffinitySessionId,
+		});
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents, retryEndEvents } = trackRetryEvents(session);
+
+		await session.prompt("retry with another stored credential");
+
+		expect(calls).toBe(2);
+		expect(requestedKeys).toHaveLength(2);
+		expect(new Set(requestedKeys).size).toBe(2);
+		expect(session.isRetrying).toBe(false);
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryStartEvents[0]).toMatchObject({ delayMs: 0 });
+		expect(waitSpy).toHaveBeenCalledWith(0, { signal: expect.any(AbortSignal) });
+		expect(retryEndEvents).toHaveLength(1);
+		expect(retryEndEvents[0]).toMatchObject({ success: true, attempt: 1 });
+		expect(getLastAssistantMessage(session)).toMatchObject({ stopReason: "stop" });
+	});
+
+	it("rotates a single-model credential through an extension-loaded session (#3491 claim 1)", async () => {
+		const model = getBundledModel("openai", "gpt-4o-mini");
+		if (!model) throw new Error("Expected bundled test model");
+		authStorage.removeRuntimeApiKey("openai");
+		await authStorage.set("openai", [
+			{ type: "api_key", key: "account-a-key" },
+			{ type: "api_key", key: "account-b-key" },
+		]);
+
+		const poolSessionId = "pool-session";
+		const requestedKeys: string[] = [];
+		let calls = 0;
+		const agent = new Agent({
+			getApiKey: async provider => {
+				const key = await modelRegistry.getApiKeyForProvider(provider, poolSessionId);
+				if (key) requestedKeys.push(key);
+				return key;
+			},
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (requestedModel, context, options) => {
+				calls++;
+				if (calls === 1) return typedRateLimitStream(requestedModel, 60_000);
+				return createMockModel({ responses: [{ content: ["Recovered"] }] }).stream(
+					requestedModel,
+					context,
+					options,
+				);
+			},
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		const extensionRunner = makeExtensionRunner(
+			["context"],
+			tempDir.path(),
+			SessionManager.inMemory(),
+			modelRegistry,
+		);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+			providerSessionId: "logical-session",
+			providerCacheSessionId: poolSessionId,
+			extensionRunner,
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents } = trackRetryEvents(session);
+
+		await session.prompt("retry with another stored credential under extensions");
+
+		expect(calls).toBe(2);
+		expect(new Set(requestedKeys).size).toBe(2);
+		expect(retryStartEvents).toHaveLength(1);
+		expect(getLastAssistantMessage(session)).toMatchObject({ stopReason: "stop" });
+	});
+
+	it("traverses the full credential pool independent of retry.maxRetries (#3491 claim 3)", async () => {
+		const model = getBundledModel("openai", "gpt-4o-mini");
+		if (!model) throw new Error("Expected bundled test model");
+		authStorage.removeRuntimeApiKey("openai");
+		await authStorage.set("openai", [
+			{ type: "api_key", key: "acct-1" },
+			{ type: "api_key", key: "acct-2" },
+			{ type: "api_key", key: "acct-3" },
+			{ type: "api_key", key: "acct-4" },
+			{ type: "api_key", key: "acct-5" },
+			{ type: "api_key", key: "acct-6" },
+		]);
+
+		const poolSessionId = "pool-session";
+		const requestedKeys: string[] = [];
+		let calls = 0;
+		const agent = new Agent({
+			getApiKey: async provider => {
+				const key = await modelRegistry.getApiKeyForProvider(provider, poolSessionId);
+				if (key) requestedKeys.push(key);
+				return key;
+			},
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (requestedModel, context, options) => {
+				calls++;
+				if (calls < 6) return typedUsageLimitStream(requestedModel);
+				return createMockModel({ responses: [{ content: ["Recovered on 6th credential"] }] }).stream(
+					requestedModel,
+					context,
+					options,
+				);
+			},
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "retry.maxRetries": 2 });
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+			providerSessionId: "logical-session",
+			providerCacheSessionId: poolSessionId,
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+
+		await session.prompt("exhaust the pool");
+
+		expect(calls).toBe(6);
+		expect(new Set(requestedKeys).size).toBe(6);
+		expect(getLastAssistantMessage(session)).toMatchObject({ stopReason: "stop" });
 	});
 
 	it("does not replay a Kimi Code first-event timeout through a managed fallback chain", async () => {


### PR DESCRIPTION
## Summary

Completes the pooled credential rotation work for single-model retry/fallback, closing #3491. Independently reproduced all three reported contract gaps and fixed them in one coherent change.

## Root cause

Three gaps in the credential-rotation retry gate:

1. **Extension-loaded sessions**: `#hasCleanRetryReplaySafety` is `false` when extensions register `context`/`before_provider_request`/`after_provider_response` handlers. The credential-rotation path gated on it, blocking same-turn failover even though the credential was already marked failed.

2. **`usage_limit` pool bounded by `retry.maxRetries`**: errors matching `isUsageLimitError` classify as `usage_limit` (not `transient`), so pool traversal stopped at `maxRetries+1` attempts.

3. **Intermediate 429 visibility**: downstream of gap 1.

## Fix

- **Content-free rotation bypass**: a content-free quota/rate-limit failure has no observable state to corrupt, so `canReplayRotatedCredential = credentialRotated` (the content-free check IS the replay-safety guarantee).
- **Unbounded pool traversal**: credential rotation overrides `maxRetries` exhaustion.
- **Provider affinity**: `#markFailedCredential` uses `providerAffinitySessionId`.
- **Post-prompt recovery**: `#waitForPostPromptRecovery()` inserted after agent-end handling.

## Test evidence

3 new contract tests (all passing). Zero regressions across retry-fallback (20/20), resilient-retry (42/42), message-pipeline (24/24), concurrent (21/21).

Supersedes #3478 (closed with REQUEST_CHANGES).

Signed-off-by: gaebal-gajae (clawdbot) 🦞