### PR TITLE
fix: preserve first-event timeout transport facts

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Unreleased]
-- Provider streams now surface first-event watchdog expiry as a typed timeout so callers can apply bounded retry policy without parsing error prose.
+- Provider streams, including the lazy wrapper's abort signal, now surface first-event watchdog expiry as a typed timeout so callers can apply bounded retry policy without parsing error prose.
 - Codex websocket first-event timeouts now discard the timed-out connection before the outer retry/fallback layer handles the typed failure, preventing late frames from the abandoned request from being consumed by the replayed turn.
 - Codex named-tool requests now recognize provider `Tool choice '<name>' not found in 'tools' parameter` errors as runtime capability failures and retry once without forcing the choice.
 - The Kimi OAuth host (`KIMI_CODE_OAUTH_HOST` / `KIMI_OAUTH_HOST`) is now resolved from trusted environment sources only. That host receives the device-authorization request, the authorization-code exchange, and the refresh call that carries the existing refresh token, so reading it through the merged view that includes the caller's `cwd/.env` let a repository redirect the login flow and collect the user's Kimi credentials. Resolution now uses the non-project resolver; shell and user-level configuration is unchanged.

--- a/packages/ai/src/providers/register-builtins.ts
+++ b/packages/ai/src/providers/register-builtins.ts
@@ -23,7 +23,12 @@ import type {
 import { type AbortSourceTracker, createAbortSourceTracker } from "../utils/abort";
 import { AssistantMessageEventStream as EventStreamImpl } from "../utils/event-stream";
 import { transportFailureFacts } from "../utils/fallback-transport";
-import { getStreamFirstEventTimeoutMs, getStreamIdleTimeoutMs, iterateWithIdleTimeout } from "../utils/idle-iterator";
+import {
+	FirstEventTimeoutError,
+	getStreamFirstEventTimeoutMs,
+	getStreamIdleTimeoutMs,
+	iterateWithIdleTimeout,
+} from "../utils/idle-iterator";
 import type { BedrockOptions } from "./amazon-bedrock";
 import type { AnthropicOptions } from "./anthropic";
 import type { AzureOpenAIResponsesOptions } from "./azure-openai-responses";
@@ -231,7 +236,8 @@ function forwardStream<TApi extends Api>(
 				errorMessage: LAZY_STREAM_IDLE_TIMEOUT_ERROR,
 				firstItemErrorMessage: LAZY_STREAM_FIRST_EVENT_TIMEOUT_ERROR,
 				onIdle: () => abortTracker.abortLocally(new Error(LAZY_STREAM_IDLE_TIMEOUT_ERROR)),
-				onFirstItemTimeout: () => abortTracker.abortLocally(new Error(LAZY_STREAM_FIRST_EVENT_TIMEOUT_ERROR)),
+				onFirstItemTimeout: () =>
+					abortTracker.abortLocally(new FirstEventTimeoutError(LAZY_STREAM_FIRST_EVENT_TIMEOUT_ERROR)),
 				abortSignal: options.signal,
 				// The synthetic `start` event is yielded immediately by every provider before
 				// the upstream model has emitted any tokens. Treating it as the first "real"

--- a/packages/ai/test/register-builtins.test.ts
+++ b/packages/ai/test/register-builtins.test.ts
@@ -292,7 +292,13 @@ describe("outer lazy-stream first-event watchdog (fake timers)", () => {
 	it("alibaba-token-plan times out at 300s when the source never emits", async () => {
 		vi.useFakeTimers();
 		const source = createHangingSource();
-		setBedrockProviderModule({ streamBedrock: () => source });
+		let providerSignal: AbortSignal | undefined;
+		setBedrockProviderModule({
+			streamBedrock: (_model, _context, options) => {
+				providerSignal = options.signal;
+				return source;
+			},
+		});
 
 		const stream = streamBedrock(createAlibabaModel(), baseContext, {});
 		await flush();
@@ -315,6 +321,10 @@ describe("outer lazy-stream first-event watchdog (fake timers)", () => {
 		expect(result.errorMessage).toBe("Provider stream timed out while waiting for the first event");
 		expect(result.transportFailure).toMatchObject({
 			kind: "transport",
+			providerCode: "stream_first_event_timeout",
+		});
+		expect(providerSignal?.reason).toMatchObject({
+			name: "FirstEventTimeoutError",
 			providerCode: "stream_first_event_timeout",
 		});
 	});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Fixed
 
+- Detached-subagent retry status now classifies first-event timeouts from the canonical provider transport code before falling back to legacy error-message matching.
 - Team Linux worker memory-guard replacement no longer holds the team task-mutation fence across the successor startup-ack wait, so concurrent `worker-startup-ack` can publish and selector-replacement no longer hangs under CI contention.
 - Kitty/Ghostty inline images no longer remain visually pinned when transcript, pinned, or overlay rows are replaced, removed, scrolled, resized, or fully repainted. The TUI now parses only bounded named placements, soft-deletes overwritten placements from the previously committed physical frame, retains transmitted pixels, and restores placements from application scrollback without retransmitting image data.
 - Reviewer `report_finding` evidence is no longer injected into caller-owned strict JTD completion data; full findings are published separately through a bounded artifact reference, and failed evidence publication now fails the task closed (#2893).

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1893,11 +1893,15 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					for (const message of session.messages) {
 						if (message.role === "assistant") rememberAssistantMessage(message);
 					}
+					const retryProviderCode = session.messages.findLast(
+						(message): message is AssistantMessage =>
+							isProviderAssistantMessage(message) && message.errorMessage === event.errorMessage,
+					)?.transportFailure?.providerCode;
 					progress.retryState = {
 						attempt: event.attempt,
 						maxAttempts: event.maxAttempts,
 						unbounded: event.unbounded,
-						kind: classifyProviderRetry(event.errorMessage),
+						kind: classifyProviderRetry(event.errorMessage, retryProviderCode),
 						provider: providerNameFromModel(
 							activeProviderModelString ?? lastAssistantModelString ?? resolvedModelString,
 						),

--- a/packages/coding-agent/src/task/provider-retry-status.ts
+++ b/packages/coding-agent/src/task/provider-retry-status.ts
@@ -1,3 +1,4 @@
+import { STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE } from "@gajae-code/ai/utils/fallback-transport";
 import type { AgentProgress, TaskToolDetails } from "./types";
 
 export type ProviderRetryKind = NonNullable<AgentProgress["retryState"]>["kind"];
@@ -5,7 +6,8 @@ export type ProviderRetryKind = NonNullable<AgentProgress["retryState"]>["kind"]
 const FIRST_EVENT_TIMEOUT_PATTERN = /stream timed out while waiting for the first event/i;
 const IDLE_STREAM_STALL_PATTERN = /stream stalled while waiting for the next event/i;
 
-export function classifyProviderRetry(errorMessage: string): ProviderRetryKind {
+export function classifyProviderRetry(errorMessage: string, providerCode?: string): ProviderRetryKind {
+	if (providerCode?.toLowerCase() === STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE) return "first_event_timeout";
 	if (FIRST_EVENT_TIMEOUT_PATTERN.test(errorMessage)) return "first_event_timeout";
 	if (IDLE_STREAM_STALL_PATTERN.test(errorMessage)) return "idle_stream_stall";
 	return "provider_error";

--- a/packages/coding-agent/test/task/provider-retry-status.test.ts
+++ b/packages/coding-agent/test/task/provider-retry-status.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import { classifyProviderRetry } from "../../src/task/provider-retry-status";
+
+describe("classifyProviderRetry", () => {
+	it("classifies the canonical first-event timeout provider code before message wording", () => {
+		expect(classifyProviderRetry("provider wording changed", "stream_first_event_timeout")).toBe(
+			"first_event_timeout",
+		);
+	});
+
+	it("retains message matching for legacy retry events without provider facts", () => {
+		expect(classifyProviderRetry("Provider stream timed out while waiting for the first event")).toBe(
+			"first_event_timeout",
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- abort lazy provider streams with `FirstEventTimeoutError` so the abort signal retains `stream_first_event_timeout`
- classify detached-subagent retry status from the canonical provider code before legacy message matching
- cover the lazy-wrapper abort reason and fact-driven status classification with regression tests

Closes #3496

## Verification
- `bun test packages/ai/test/register-builtins.test.ts packages/coding-agent/test/task/provider-retry-status.test.ts packages/coding-agent/test/agent-session-resilient-retry.test.ts` (57 pass)
- `bunx biome check packages/ai/src/providers/register-builtins.ts packages/ai/test/register-builtins.test.ts packages/coding-agent/src/task/provider-retry-status.ts packages/coding-agent/src/task/executor.ts packages/coding-agent/test/task/provider-retry-status.test.ts`
- `git diff --check`

## Existing upstream gate failures
- `bun run check:ts` stops in `check:tools` on 11 pre-existing formatting/import-order errors outside this change.
- `packages/ai` package type checking reaches existing `PruneToolOutputsOptions` / `PruneResult` errors in coding-agent; the changed executor type error found during development was fixed.