### PR TITLE
fix(ai): stamp lazy-stream first-event timeouts as transport facts (#3496)

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+
+### Fixed
+
+- Lazy-stream first-event timeouts now abort with `FirstEventTimeoutError` so `transportFailure.providerCode` is `stream_first_event_timeout` on the outer watchdog path shared by all bundled providers via `createLazyStream`. Idle stalls remain bare `Error`s (distinct class intentionally) (#3496).
+
 - Provider streams now surface first-event watchdog expiry as a typed timeout so callers can apply bounded retry policy without parsing error prose.
 - Codex websocket first-event timeouts now discard the timed-out connection before the outer retry/fallback layer handles the typed failure, preventing late frames from the abandoned request from being consumed by the replayed turn.
 - Codex named-tool requests now recognize provider `Tool choice '<name>' not found in 'tools' parameter` errors as runtime capability failures and retry once without forcing the choice.

--- a/packages/ai/src/providers/register-builtins.ts
+++ b/packages/ai/src/providers/register-builtins.ts
@@ -23,7 +23,12 @@ import type {
 import { type AbortSourceTracker, createAbortSourceTracker } from "../utils/abort";
 import { AssistantMessageEventStream as EventStreamImpl } from "../utils/event-stream";
 import { transportFailureFacts } from "../utils/fallback-transport";
-import { getStreamFirstEventTimeoutMs, getStreamIdleTimeoutMs, iterateWithIdleTimeout } from "../utils/idle-iterator";
+import {
+	FirstEventTimeoutError,
+	getStreamFirstEventTimeoutMs,
+	getStreamIdleTimeoutMs,
+	iterateWithIdleTimeout,
+} from "../utils/idle-iterator";
 import type { BedrockOptions } from "./amazon-bedrock";
 import type { AnthropicOptions } from "./anthropic";
 import type { AzureOpenAIResponsesOptions } from "./azure-openai-responses";
@@ -231,7 +236,8 @@ function forwardStream<TApi extends Api>(
 				errorMessage: LAZY_STREAM_IDLE_TIMEOUT_ERROR,
 				firstItemErrorMessage: LAZY_STREAM_FIRST_EVENT_TIMEOUT_ERROR,
 				onIdle: () => abortTracker.abortLocally(new Error(LAZY_STREAM_IDLE_TIMEOUT_ERROR)),
-				onFirstItemTimeout: () => abortTracker.abortLocally(new Error(LAZY_STREAM_FIRST_EVENT_TIMEOUT_ERROR)),
+				onFirstItemTimeout: () =>
+					abortTracker.abortLocally(new FirstEventTimeoutError(LAZY_STREAM_FIRST_EVENT_TIMEOUT_ERROR)),
 				abortSignal: options.signal,
 				// The synthetic `start` event is yielded immediately by every provider before
 				// the upstream model has emitted any tokens. Treating it as the first "real"

--- a/packages/ai/test/idle-iterator.test.ts
+++ b/packages/ai/test/idle-iterator.test.ts
@@ -50,4 +50,43 @@ describe("iterateWithIdleTimeout transport facts", () => {
 		expect(error).not.toBeInstanceOf(FirstEventTimeoutError);
 		expect(transportFailureFacts(error)).toBeUndefined();
 	});
+
+	it("stamps first-item expiry as FirstEventTimeoutError with transport facts", async () => {
+		vi.useFakeTimers();
+		const source = (async function* () {
+			await new Promise<never>(() => {});
+		})();
+		const abortReasons: Error[] = [];
+		const iterator = iterateWithIdleTimeout(source, {
+			firstItemTimeoutMs: 10,
+			idleTimeoutMs: 10,
+			errorMessage: "stream idle",
+			firstItemErrorMessage: "Provider stream timed out while waiting for the first event",
+			onFirstItemTimeout: () => {
+				abortReasons.push(
+					new FirstEventTimeoutError("Provider stream timed out while waiting for the first event"),
+				);
+			},
+		});
+
+		const pending = iterator.next();
+		await waitForTimerRegistration();
+		vi.advanceTimersByTime(10);
+		const error = await pending.catch(error => error);
+
+		expect(error).toBeInstanceOf(FirstEventTimeoutError);
+		expect(transportFailureFacts(error)).toEqual({
+			kind: "transport",
+			status: undefined,
+			providerCode: STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE,
+			anthropicErrorType: undefined,
+			openaiErrorCode: undefined,
+			headers: undefined,
+		});
+		expect(abortReasons).toHaveLength(1);
+		expect(transportFailureFacts(abortReasons[0])).toMatchObject({
+			kind: "transport",
+			providerCode: STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE,
+		});
+	});
 });

--- a/packages/ai/test/register-builtins.test.ts
+++ b/packages/ai/test/register-builtins.test.ts
@@ -333,6 +333,10 @@ describe("outer lazy-stream first-event watchdog (fake timers)", () => {
 		const result = await stream.result();
 		expect(result.stopReason).toBe("error");
 		expect(result.errorMessage).toBe("Provider stream timed out while waiting for the first event");
+		expect(result.transportFailure).toMatchObject({
+			kind: "transport",
+			providerCode: "stream_first_event_timeout",
+		});
 	});
 
 	it("explicit streamFirstEventTimeoutMs takes precedence over the Alibaba fallback", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Fixed
 
+- Provider retry classification prefers the typed `stream_first_event_timeout` transport fact when present, falling back to error-message regex for message-only callers (#3496).
 - Team Linux worker memory-guard replacement no longer holds the team task-mutation fence across the successor startup-ack wait, so concurrent `worker-startup-ack` can publish and selector-replacement no longer hangs under CI contention.
 - Kitty/Ghostty inline images no longer remain visually pinned when transcript, pinned, or overlay rows are replaced, removed, scrolled, resized, or fully repainted. The TUI now parses only bounded named placements, soft-deletes overwritten placements from the previously committed physical frame, retains transmitted pixels, and restores placements from application scrollback without retransmitting image data.
 - Reviewer `report_finding` evidence is no longer injected into caller-owned strict JTD completion data; full findings are published separately through a bounded artifact reference, and failed evidence publication now fails the task closed (#2893).

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -50,7 +50,7 @@ import type { EventBus } from "../utils/event-bus";
 import { buildNamedToolChoiceResult } from "../utils/tool-choice";
 import type { WorkspaceTree } from "../workspace-tree";
 import { validateAllocatedTaskId } from "./id";
-import { classifyProviderRetry, providerNameFromModel } from "./provider-retry-status";
+import { classifyProviderRetryFromTransport, providerNameFromModel } from "./provider-retry-status";
 import { subprocessToolRegistry } from "./subprocess-tool-registry";
 import { persistTaskTokenLog, taskTokenLogFromUsage } from "./token-log";
 import {
@@ -1893,11 +1893,15 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					for (const message of session.messages) {
 						if (message.role === "assistant") rememberAssistantMessage(message);
 					}
+					const failedAssistant = session.getLastAssistantMessage();
 					progress.retryState = {
 						attempt: event.attempt,
 						maxAttempts: event.maxAttempts,
 						unbounded: event.unbounded,
-						kind: classifyProviderRetry(event.errorMessage),
+						kind: classifyProviderRetryFromTransport({
+							providerCode: failedAssistant?.transportFailure?.providerCode,
+							errorMessage: event.errorMessage,
+						}),
 						provider: providerNameFromModel(
 							activeProviderModelString ?? lastAssistantModelString ?? resolvedModelString,
 						),

--- a/packages/coding-agent/src/task/provider-retry-status.ts
+++ b/packages/coding-agent/src/task/provider-retry-status.ts
@@ -4,8 +4,24 @@ export type ProviderRetryKind = NonNullable<AgentProgress["retryState"]>["kind"]
 
 const FIRST_EVENT_TIMEOUT_PATTERN = /stream timed out while waiting for the first event/i;
 const IDLE_STREAM_STALL_PATTERN = /stream stalled while waiting for the next event/i;
+const STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE = "stream_first_event_timeout";
 
 export function classifyProviderRetry(errorMessage: string): ProviderRetryKind {
+	return classifyProviderRetryFromTransport({ errorMessage });
+}
+
+/**
+ * Prefer typed transport facts when present; fall back to message regex for
+ * message-only callers that never received `transportFailure.providerCode`.
+ */
+export function classifyProviderRetryFromTransport(facts: {
+	providerCode?: string;
+	errorMessage?: string;
+}): ProviderRetryKind {
+	if (facts.providerCode?.toLowerCase() === STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE) {
+		return "first_event_timeout";
+	}
+	const errorMessage = facts.errorMessage ?? "";
 	if (FIRST_EVENT_TIMEOUT_PATTERN.test(errorMessage)) return "first_event_timeout";
 	if (IDLE_STREAM_STALL_PATTERN.test(errorMessage)) return "idle_stream_stall";
 	return "provider_error";

--- a/packages/coding-agent/test/task/provider-retry-status.test.ts
+++ b/packages/coding-agent/test/task/provider-retry-status.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+import { classifyProviderRetry, classifyProviderRetryFromTransport } from "../../src/task/provider-retry-status";
+
+describe("classifyProviderRetry", () => {
+	it("classifies first-event timeouts from message prose", () => {
+		expect(classifyProviderRetry("Provider stream timed out while waiting for the first event")).toBe(
+			"first_event_timeout",
+		);
+	});
+
+	it("classifies idle stalls from message prose", () => {
+		expect(classifyProviderRetry("Provider stream stalled while waiting for the next event")).toBe(
+			"idle_stream_stall",
+		);
+	});
+
+	it("defaults other messages to provider_error", () => {
+		expect(classifyProviderRetry("rate limited")).toBe("provider_error");
+	});
+});
+
+describe("classifyProviderRetryFromTransport", () => {
+	it("prefers stream_first_event_timeout providerCode over message prose", () => {
+		expect(
+			classifyProviderRetryFromTransport({
+				providerCode: "stream_first_event_timeout",
+				errorMessage: "something else entirely",
+			}),
+		).toBe("first_event_timeout");
+	});
+
+	it("is case-insensitive for providerCode", () => {
+		expect(
+			classifyProviderRetryFromTransport({
+				providerCode: "STREAM_FIRST_EVENT_TIMEOUT",
+			}),
+		).toBe("first_event_timeout");
+	});
+
+	it("falls back to message regex when providerCode is absent", () => {
+		expect(
+			classifyProviderRetryFromTransport({
+				errorMessage: "Provider stream timed out while waiting for the first event",
+			}),
+		).toBe("first_event_timeout");
+		expect(
+			classifyProviderRetryFromTransport({
+				errorMessage: "Provider stream stalled while waiting for the next event",
+			}),
+		).toBe("idle_stream_stall");
+		expect(classifyProviderRetryFromTransport({ errorMessage: "boom" })).toBe("provider_error");
+	});
+
+	it("falls back to message regex when providerCode is not the first-event fact", () => {
+		expect(
+			classifyProviderRetryFromTransport({
+				providerCode: "rate_limit_error",
+				errorMessage: "Provider stream timed out while waiting for the first event",
+			}),
+		).toBe("first_event_timeout");
+		expect(
+			classifyProviderRetryFromTransport({
+				providerCode: "rate_limit_error",
+				errorMessage: "rate limited",
+			}),
+		).toBe("provider_error");
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #3496 (follow-up to #3390).

Every bundled provider goes through the lazy-stream wrapper in `packages/ai/src/providers/register-builtins.ts`. After #3390, first-event timeouts were typed as `stream_first_event_timeout` in `idle-iterator.ts`, but the lazy-stream abort path still used a bare `new Error(...)`. That meant retry/fallback could not treat the timeout as a provider transport fact, so turns still died with a non-retryable local error.

## Problem

- `iterateWithIdleTimeout` throws `FirstEventTimeoutError` with `providerCode = stream_first_event_timeout`.
- The lazy-stream `onFirstItemTimeout` path aborted with a bare `Error` (`abortTracker.abortLocally(new Error(...))`).
- Classification and retry UI often fell back to fragile message regex matching (`provider-retry-status.ts`), while wording already differed across call sites.
- User-visible result: first-event timeout still finalizes as a hard turn failure even when `retry.streamFirstEventTimeoutMs` is configured.

## What

1. **Lazy-stream abort stamping** (`register-builtins.ts`)
   - `onFirstItemTimeout` now aborts with `new FirstEventTimeoutError(LAZY_STREAM_FIRST_EVENT_TIMEOUT_ERROR)`.
   - Idle / stall aborts remain bare `Error` on purpose (distinct from first-event expiry).
2. **Fact-first retry classification** (`provider-retry-status.ts`)
   - Adds `classifyProviderRetryFromTransport({ providerCode?, errorMessage? })`.
   - Prefers `providerCode === "stream_first_event_timeout"` over message regex.
   - Existing `classifyProviderRetry(message)` remains as a regex-compatible wrapper.
3. **Executor wiring** (`task/executor.ts`)
   - Auto-retry start path uses the last assistant message's `transportFailure.providerCode` when present.

## Why

Transport facts must authorize retry/fallback. String matching is not load-bearing: two literals already differ (`"...first event"` vs other provider wording). Typing the lazy-stream path closes the hole that every bundled provider actually hits.

## Tests

```sh
bun test \
  packages/ai/test/idle-iterator.test.ts \
  packages/ai/test/register-builtins.test.ts \
  packages/coding-agent/test/task/provider-retry-status.test.ts
```

- FirstEventTimeoutError → idempotent `transportFailureFacts`
- Idle timeout remains non-FirstEventTimeoutError
- Fact-based classification beats regex / empty messages
- 23 focused tests green locally

## Out of scope / follow-up

- Making `SLOW_FIRST_EVENT_PROVIDERS` settings-driven (mentioned on the issue; optional).
- Changing idle-stream stall into a typed transport fact (intentionally still bare `Error`).