### PR TITLE
feat(subagent): until_terminal await with deadline and join (#3472)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ### Added
 
+- `subagent await` supports `mode: "until_terminal"` with optional `deadline_ms` (default 10 min), sparse `heartbeat_ms` progress, and `join: "any_terminal" | "all_terminal"`, so long-running reviewers can be waited on in one tool call instead of repeated 30s bounded polls (#3472).
+
+### Fixed
+
 - `gjc ultragoal quality-gate init` scaffolds a multi-surface quality-gate template (`--surface` repeatable, `--out` required) so agents can fill evidence once and use read-only `quality-gate validate` multi-error diagnostics instead of discovering missing fields one checkpoint at a time (#3474).
 
 ### Added

--- a/packages/coding-agent/src/prompts/tools/subagent.md
+++ b/packages/coding-agent/src/prompts/tools/subagent.md
@@ -14,8 +14,14 @@ Inspect selected subagents by `ids`; omit `ids` to inspect current running subag
 
 ## `action: "await"`
 Wait for selected subagents by `ids`; omit `ids` to wait for current running subagents.
-- Always set `timeout_ms` when the result is not immediately required forever.
-- Await timeout only bounds this tool call's wait; it does not stop the subagent and is not a failure reason.
+- `mode` (optional): `"bounded"` (default) or `"until_terminal"`.
+  - **bounded**: uses `timeout_ms` (default 30000). Good for short checks and independent work loops.
+  - **until_terminal**: waits in a single tool call until the join condition is met or `deadline_ms` (default 600000 / 10 min) expires. Prefer this for long reviewers and other multi-minute children so you do not re-poll every 30s.
+- `deadline_ms` (optional): hard wait cap for `until_terminal` only. On expiry, `awaitOutcome` is `timed_out` and the child keeps running.
+- `heartbeat_ms` (optional): sparse `onUpdate` progress interval for `until_terminal` (default 120000; `0` disables heartbeats). Does not cause artificial timeouts.
+- `join` (optional): `"all_terminal"` (default, wait for every watched job) or `"any_terminal"` (resolve when any watched job reaches a terminal status; final snapshots still cover all requested ids).
+- Always set `timeout_ms` (bounded) or `deadline_ms` (until_terminal) when the result is not required for the full default window.
+- Await timeout/deadline only bounds this tool call's wait; it does not stop the subagent and is not a failure reason.
 - On timeout, inspect progress and keep doing independent work. Never cancel just because an await timed out; cancel only if the subagent has actually failed, gone off-track, or become unrecoverably wrong.
 - Completed results are receipt-first by default: bounded preview plus `agent://<id>` output ref when available, not full retained output.
 

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -55,7 +55,9 @@ const subagentSchema = z.object({
 		.min(0)
 		.max(MAX_AWAIT_TIMEOUT_MS)
 		.optional()
-		.describe("until_terminal hard deadline in milliseconds (default 600000); child keeps running if deadline expires"),
+		.describe(
+			"until_terminal hard deadline in milliseconds (default 600000); child keeps running if deadline expires",
+		),
 	heartbeat_ms: z
 		.number()
 		.min(0)
@@ -416,10 +418,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 						MAX_AWAIT_TIMEOUT_MS,
 						Math.max(0, Math.floor(params.deadline_ms ?? DEFAULT_UNTIL_TERMINAL_DEADLINE_MS)),
 					)
-				: Math.min(
-						MAX_AWAIT_TIMEOUT_MS,
-						Math.max(0, Math.floor(params.timeout_ms ?? DEFAULT_AWAIT_TIMEOUT_MS)),
-					);
+				: Math.min(MAX_AWAIT_TIMEOUT_MS, Math.max(0, Math.floor(params.timeout_ms ?? DEFAULT_AWAIT_TIMEOUT_MS)));
 		// Heartbeats only apply to until_terminal; bounded keeps the 500ms change-gated poll.
 		const heartbeatMs =
 			awaitMode === "until_terminal"
@@ -461,9 +460,9 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		const { promise: timeoutPromise, resolve: resolveTimeout } = Promise.withResolvers<SubagentAwaitOutcome>();
 		const timeoutTimer = setTimeout(() => resolveTimeout("timed_out"), waitMs);
 		const jobPromises = runningJobs.map(job => job.promise);
-		const completionPromise = (
-			join === "any_terminal" ? Promise.race(jobPromises) : Promise.all(jobPromises)
-		).then(() => "completed" as const);
+		const completionPromise = (join === "any_terminal" ? Promise.race(jobPromises) : Promise.all(jobPromises)).then(
+			() => "completed" as const,
+		);
 		let onAbort: (() => void) | undefined;
 		try {
 			if (signal) {

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -12,6 +12,12 @@ import { ToolError } from "./tool-errors";
 
 const DEFAULT_AWAIT_TIMEOUT_MS = 30_000;
 const MAX_AWAIT_TIMEOUT_MS = 60 * 60 * 1000;
+/** Default hard deadline for `mode: "until_terminal"` awaits (10 minutes). */
+const DEFAULT_UNTIL_TERMINAL_DEADLINE_MS = 600_000;
+/** Default onUpdate heartbeat interval for `until_terminal` (sparse progress). */
+const DEFAULT_UNTIL_TERMINAL_HEARTBEAT_MS = 120_000;
+/** Floor for progress-timer intervals when heartbeats are enabled. */
+const MIN_PROGRESS_INTERVAL_MS = 500;
 const DEFAULT_LIST_LIMIT = 10;
 const MAX_LIST_LIMIT = 50;
 const RECEIPT_PREVIEW_WIDTH = 280;
@@ -32,7 +38,38 @@ const subagentSchema = z.object({
 	id: z.string().optional().describe("single subagent id or backing job id for resume/steer"),
 	message: z.string().optional().describe("message to deliver when resuming or steering a subagent"),
 	pause: z.boolean().optional().describe("pause after steering a currently running subagent"),
-	timeout_ms: z.number().min(0).max(MAX_AWAIT_TIMEOUT_MS).optional().describe("await timeout in milliseconds"),
+	timeout_ms: z
+		.number()
+		.min(0)
+		.max(MAX_AWAIT_TIMEOUT_MS)
+		.optional()
+		.describe("bounded await timeout in milliseconds (default 30000; ignored when mode is until_terminal)"),
+	mode: z
+		.enum(["bounded", "until_terminal"])
+		.optional()
+		.describe(
+			'await wait mode: "bounded" (default, uses timeout_ms) or "until_terminal" (wait until join condition or deadline_ms)',
+		),
+	deadline_ms: z
+		.number()
+		.min(0)
+		.max(MAX_AWAIT_TIMEOUT_MS)
+		.optional()
+		.describe("until_terminal hard deadline in milliseconds (default 600000); child keeps running if deadline expires"),
+	heartbeat_ms: z
+		.number()
+		.min(0)
+		.max(MAX_AWAIT_TIMEOUT_MS)
+		.optional()
+		.describe(
+			"until_terminal onUpdate progress heartbeat interval in milliseconds (default 120000; 0 disables heartbeats)",
+		),
+	join: z
+		.enum(["all_terminal", "any_terminal"])
+		.optional()
+		.describe(
+			'await join policy: "all_terminal" (default, wait for every watched job) or "any_terminal" (resolve when any watched job terminals)',
+		),
 	limit: z.number().min(1).max(MAX_LIST_LIMIT).optional().describe("maximum subagents to return"),
 	verbosity: z
 		.enum(["receipt", "preview", "full"])
@@ -87,6 +124,8 @@ export interface SubagentSnapshot {
 }
 
 export type SubagentAwaitOutcome = "completed" | "timed_out" | "interrupted";
+export type SubagentAwaitMode = "bounded" | "until_terminal";
+export type SubagentAwaitJoin = "all_terminal" | "any_terminal";
 
 const AWAIT_INTERRUPTED_GUIDANCE =
 	"Await interrupted; this subagent continues. Inspect its current state or cancel it only when necessary.";
@@ -97,6 +136,10 @@ export interface SubagentToolDetails {
 	awaitOutcome?: SubagentAwaitOutcome;
 	/** True only when the parent await was interrupted; the child was not cancelled. */
 	interrupted?: true;
+	/** Wait mode used for this await; omitted when no wait was started. */
+	awaitMode?: SubagentAwaitMode;
+	/** Join policy used for this await; omitted when no wait was started. */
+	join?: SubagentAwaitJoin;
 }
 
 export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentToolDetails> {
@@ -365,10 +408,32 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			});
 		}
 
-		const timeoutMs = Math.min(
-			MAX_AWAIT_TIMEOUT_MS,
-			Math.max(0, Math.floor(params.timeout_ms ?? DEFAULT_AWAIT_TIMEOUT_MS)),
-		);
+		const awaitMode: SubagentAwaitMode = params.mode ?? "bounded";
+		const join: SubagentAwaitJoin = params.join ?? "all_terminal";
+		const waitMs =
+			awaitMode === "until_terminal"
+				? Math.min(
+						MAX_AWAIT_TIMEOUT_MS,
+						Math.max(0, Math.floor(params.deadline_ms ?? DEFAULT_UNTIL_TERMINAL_DEADLINE_MS)),
+					)
+				: Math.min(
+						MAX_AWAIT_TIMEOUT_MS,
+						Math.max(0, Math.floor(params.timeout_ms ?? DEFAULT_AWAIT_TIMEOUT_MS)),
+					);
+		// Heartbeats only apply to until_terminal; bounded keeps the 500ms change-gated poll.
+		const heartbeatMs =
+			awaitMode === "until_terminal"
+				? Math.min(
+						MAX_AWAIT_TIMEOUT_MS,
+						Math.max(0, Math.floor(params.heartbeat_ms ?? DEFAULT_UNTIL_TERMINAL_HEARTBEAT_MS)),
+					)
+				: MIN_PROGRESS_INTERVAL_MS;
+		const progressIntervalMs =
+			awaitMode === "until_terminal"
+				? heartbeatMs === 0
+					? 0
+					: Math.max(MIN_PROGRESS_INTERVAL_MS, heartbeatMs)
+				: MIN_PROGRESS_INTERVAL_MS;
 		const watchedJobIds = runningJobs.map(job => job.id);
 		manager.watchJobs(watchedJobIds);
 		let lastEmittedSignature: string | undefined;
@@ -380,7 +445,12 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			lastEmittedSignature = signature;
 			onUpdate(result);
 		};
-		const progressTimer = onUpdate ? setInterval(() => emitIfChanged(false), 500) : undefined;
+		// until_terminal forces sparse heartbeats even when the signature is idle so the
+		// parent sees the tool is still waiting; bounded keeps change-gated 500ms polls.
+		const progressTimer =
+			onUpdate && progressIntervalMs > 0
+				? setInterval(() => emitIfChanged(awaitMode === "until_terminal"), progressIntervalMs)
+				: undefined;
 		// Initial emission so the panel appears immediately; later idle ticks are
 		// gated on a value-based rendered-state signature so unchanged progress no
 		// longer rebuilds the renderer component or mutates transcript lines above
@@ -389,8 +459,11 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 
 		let awaitOutcome: SubagentAwaitOutcome;
 		const { promise: timeoutPromise, resolve: resolveTimeout } = Promise.withResolvers<SubagentAwaitOutcome>();
-		const timeoutTimer = setTimeout(() => resolveTimeout("timed_out"), timeoutMs);
-		const completionPromise = Promise.all(runningJobs.map(job => job.promise)).then(() => "completed" as const);
+		const timeoutTimer = setTimeout(() => resolveTimeout("timed_out"), waitMs);
+		const jobPromises = runningJobs.map(job => job.promise);
+		const completionPromise = (
+			join === "any_terminal" ? Promise.race(jobPromises) : Promise.all(jobPromises)
+		).then(() => "completed" as const);
 		let onAbort: (() => void) | undefined;
 		try {
 			if (signal) {
@@ -431,6 +504,8 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			verbosity: params.verbosity ?? "receipt",
 			attachLiveProgress: true,
 			awaitOutcome,
+			awaitMode,
+			join,
 		});
 	}
 
@@ -549,6 +624,8 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			verbosity?: SubagentParams["verbosity"];
 			attachLiveProgress?: boolean;
 			awaitOutcome?: SubagentAwaitOutcome;
+			awaitMode?: SubagentAwaitMode;
+			join?: SubagentAwaitJoin;
 		},
 	): Promise<AgentToolResult<SubagentToolDetails>> {
 		const verifiedOutputIds = await this.#verifiedOutputIds(records);
@@ -583,14 +660,23 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 				}
 			}
 		}
-		return this.#buildSnapshotResult(snapshots, options.title, options.awaitOutcome);
+		return this.#buildSnapshotResult(snapshots, options.title, {
+			awaitOutcome: options.awaitOutcome,
+			awaitMode: options.awaitMode,
+			join: options.join,
+		});
 	}
 
 	#buildSnapshotResult(
 		snapshots: SubagentSnapshot[],
 		title: string,
-		awaitOutcome?: SubagentAwaitOutcome,
+		receipt?: {
+			awaitOutcome?: SubagentAwaitOutcome;
+			awaitMode?: SubagentAwaitMode;
+			join?: SubagentAwaitJoin;
+		},
 	): AgentToolResult<SubagentToolDetails> {
+		const awaitOutcome = receipt?.awaitOutcome;
 		const lines = [`## ${title} (${snapshots.length})`, ""];
 		for (const snapshot of snapshots) {
 			lines.push(`### ${snapshot.id} — ${snapshot.status}`);
@@ -625,6 +711,8 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 				subagents: snapshots,
 				...(awaitOutcome ? { awaitOutcome } : {}),
 				...(awaitOutcome === "interrupted" ? { interrupted: true } : {}),
+				...(receipt?.awaitMode ? { awaitMode: receipt.awaitMode } : {}),
+				...(receipt?.join ? { join: receipt.join } : {}),
 			},
 		};
 	}
@@ -711,7 +799,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		const subagent = job.metadata?.subagent;
 		const runningTimeoutGuidance =
 			timedOut && job.status === "running"
-				? "Still running after the await timeout; timeout only bounded this wait and is not a failure. Inspect progress, continue independent work, and never cancel just because an await timed out; cancel only if the subagent has actually failed, gone off-track, or become unrecoverably wrong."
+				? "Still running after the await timeout; timeout only bounded this wait and is not a failure. Inspect progress, continue independent work, and never cancel just because an await timed out; cancel only if the subagent has actually failed, gone off-track, or become unrecoverably wrong. For long-running reviewers, prefer mode=until_terminal with a suitable deadline_ms instead of repeated short bounded awaits."
 				: undefined;
 		const output = previewJobOutput(job, verbosity);
 		const outputRef = record && verifiedOutputIds.has(record.subagentId) ? `agent://${record.subagentId}` : undefined;

--- a/packages/coding-agent/test/tools/subagent.test.ts
+++ b/packages/coding-agent/test/tools/subagent.test.ts
@@ -641,10 +641,13 @@ describe("SubagentTool", () => {
 		expect(result.details?.subagents[0]?.status).toBe("running");
 		expect(result.details?.awaitOutcome).toBe("timed_out");
 		expect(result.details?.interrupted).toBeUndefined();
+		expect(result.details?.awaitMode).toBe("bounded");
+		expect(result.details?.join).toBe("all_terminal");
 		expect(guidance).toContain("Still running");
 		expect(guidance).toContain("not a failure");
 		expect(guidance).toContain("never cancel just because an await timed out");
 		expect(guidance).toContain("cancel only if the subagent has actually failed");
+		expect(guidance).toContain("until_terminal");
 		expect(guidance).not.toContain("steer");
 		expect(guidance).not.toContain("shutdown");
 
@@ -658,6 +661,134 @@ describe("SubagentTool", () => {
 		expect(completed.details?.subagents[0]?.status).toBe("completed");
 		expect(completed.details?.subagents[0]?.resultText).toContain("slow result");
 		expect(manager.getJob("job-slow")?.status).toBe("completed");
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("until_terminal waits past the bounded default for a job that finishes within deadline", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const gate = Promise.withResolvers<string>();
+		manager.register("task", "until-terminal success", async () => gate.promise, {
+			id: "job-until-success",
+			ownerId: "0-Main",
+			metadata: {
+				subagent: {
+					id: "0-UntilSuccess",
+					agent: "executor",
+					agentSource: "bundled",
+					description: "until terminal success",
+					assignment: "Finish within deadline.",
+				},
+			},
+		});
+		setTimeout(() => gate.resolve("finished within deadline"), 80);
+
+		const started = Date.now();
+		const result = await tool.execute("subagent-await-until-success", {
+			action: "await",
+			ids: ["0-UntilSuccess"],
+			mode: "until_terminal",
+			deadline_ms: 5_000,
+			heartbeat_ms: 0,
+		});
+		const elapsed = Date.now() - started;
+
+		expect(result.details?.awaitOutcome).toBe("completed");
+		expect(result.details?.awaitMode).toBe("until_terminal");
+		expect(result.details?.join).toBe("all_terminal");
+		expect(result.details?.subagents[0]?.status).toBe("completed");
+		expect(result.details?.subagents[0]?.resultText).toContain("finished within deadline");
+		expect(elapsed).toBeGreaterThanOrEqual(60);
+		expect(elapsed).toBeLessThan(4_000);
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("until_terminal times out at a short deadline while the job is still running", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const gate = Promise.withResolvers<string>();
+		const jobId = manager.register("task", "until-terminal timeout", async () => gate.promise, {
+			id: "job-until-timeout",
+			ownerId: "0-Main",
+			metadata: {
+				subagent: {
+					id: "0-UntilTimeout",
+					agent: "executor",
+					agentSource: "bundled",
+					description: "until terminal timeout",
+					assignment: "Stay running past deadline.",
+				},
+			},
+		});
+
+		const result = await tool.execute("subagent-await-until-timeout", {
+			action: "await",
+			ids: ["0-UntilTimeout"],
+			mode: "until_terminal",
+			deadline_ms: 30,
+			heartbeat_ms: 0,
+		});
+
+		expect(result.details?.awaitOutcome).toBe("timed_out");
+		expect(result.details?.awaitMode).toBe("until_terminal");
+		expect(result.details?.subagents[0]?.status).toBe("running");
+		expect(manager.getJob(jobId)?.status).toBe("running");
+
+		gate.resolve("late finish");
+		await manager.getJob(jobId)?.promise;
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("join any_terminal completes when the first of two jobs finishes", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const first = Promise.withResolvers<string>();
+		const second = Promise.withResolvers<string>();
+		const firstJobId = manager.register("task", "any-terminal first", async () => first.promise, {
+			id: "job-any-first",
+			ownerId: "0-Main",
+			metadata: {
+				subagent: {
+					id: "0-AnyFirst",
+					agent: "executor",
+					agentSource: "bundled",
+					description: "finishes first",
+				},
+			},
+		});
+		const secondJobId = manager.register("task", "any-terminal second", async () => second.promise, {
+			id: "job-any-second",
+			ownerId: "0-Main",
+			metadata: {
+				subagent: {
+					id: "0-AnySecond",
+					agent: "executor",
+					agentSource: "bundled",
+					description: "stays running",
+				},
+			},
+		});
+		setTimeout(() => first.resolve("first done"), 20);
+
+		const result = await tool.execute("subagent-await-any-terminal", {
+			action: "await",
+			ids: ["0-AnyFirst", "0-AnySecond"],
+			mode: "until_terminal",
+			deadline_ms: 5_000,
+			heartbeat_ms: 0,
+			join: "any_terminal",
+		});
+
+		expect(result.details?.awaitOutcome).toBe("completed");
+		expect(result.details?.awaitMode).toBe("until_terminal");
+		expect(result.details?.join).toBe("any_terminal");
+		expect(result.details?.subagents.find(s => s.id === "0-AnyFirst")?.status).toBe("completed");
+		expect(result.details?.subagents.find(s => s.id === "0-AnySecond")?.status).toBe("running");
+		expect(manager.getJob(firstJobId)?.status).toBe("completed");
+		expect(manager.getJob(secondJobId)?.status).toBe("running");
+
+		second.resolve("second done later");
+		await manager.getJob(secondJobId)?.promise;
 		await manager.dispose({ timeoutMs: 100 });
 	});
 


### PR DESCRIPTION
## Summary

Fixes #3472.

`subagent await` defaulted to a 30s wait timeout. Long reviewers (4–11 minutes in Ultragoal runs) forced parents to reissue await every 30 seconds, creating many no-op tool turns and encouraging duplicate fallback reviewers.

## Problem

In `packages/coding-agent/src/tools/subagent.ts`:

```ts
const DEFAULT_AWAIT_TIMEOUT_MS = 30_000;
// race completion vs timeout; timeout leaves the child running
```

- Timeout is only a wait bound (correct), but the only practical long-wait interface was repeated polling.
- Unchanged receipts still cost model-visible tool turns.
- Impatient parents sometimes launched a second critic while the first was still running.

## What

Additive optional schema fields (all optional; default behavior unchanged):

| Field | Default | Behavior |
| --- | --- | --- |
| `mode` | `"bounded"` | Existing `timeout_ms` path (default 30s) |
| `mode: "until_terminal"` | — | Wait until join condition or `deadline_ms` |
| `deadline_ms` | `600_000` (10m) when until_terminal | Hard wait ceiling; timeout is still non-terminal for the child |
| `heartbeat_ms` | `120_000` when until_terminal | Sparse `onUpdate` progress (0 disables) |
| `join` | `"all_terminal"` | `any_terminal` resolves when the first watched job terminals |

Details now also surface `awaitMode` / `join` for receipts. Prompt docs (`subagent.md`) describe when to use until_terminal for long reviewers. Timeout guidance still says: never cancel just because await timed out.

## Why

A 6-minute child should not require ~12 model-visible poll turns. One tool call can wait with sparse heartbeats, while bounded 30s remains available for callers that want short observation windows.

## Tests

```sh
bun test packages/coding-agent/test/tools/subagent.test.ts
# also: subagent-live-progress + subagent-render
```

- until_terminal waits through short child completion without timed_out
- short deadline still times out while child runs
- join `any_terminal` completes when the first of two jobs finishes
- bounded default / existing interrupt / timeout contracts preserved
- 41 + related suite green locally

## Out of scope / follow-up

- Separate `action: "join"` tool action
- Duplicate same-role reviewer supersede warnings
- Auto-delivery of terminal completion after a prior timed-out parent await (session push path)
- Exponential backoff policy on the *caller* side (this PR makes long single awaits possible instead)