### PR TITLE
Make IRC and todo work lanes responsive

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Added
 
 - User-created Telegram forum topics can now start a GJC session by selecting the home folder, choosing a verified recent work folder, or entering an explicit folder path. The selected topic is adopted by the new session without creating or deleting a separate Telegram topic.
+- The interactive terminal’s responsive IRC/todo work-lane contract now covers exact narrow/wide geometry, requested versus effective IRC visibility, direct-root pin ordering, todo lane bounds, remapped IRC toggles, and live composer shortcut hints.
 
 ## [Unreleased]
 ### Fixed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -873,8 +873,8 @@ export const SETTINGS_SCHEMA = {
 		default: true,
 		ui: {
 			tab: "appearance",
-			label: "Status Line Action Hints",
-			description: "Show contextual keyboard shortcuts in the status line",
+			label: "Composer Shortcut Hints",
+			description: "Show contextual keyboard shortcuts in the composer placeholder",
 		},
 	},
 

--- a/packages/coding-agent/src/modes/DESIGN.md
+++ b/packages/coding-agent/src/modes/DESIGN.md
@@ -291,6 +291,59 @@ textual state without SGR. Korean, Japanese, Chinese, and mixed CJK/Latin prose
 must wrap at semantic phrase boundaries, never through an action/status label or
 short identifier; a semantic CJK break is a visual-QA failure.
 
+### Direct-root anatomy, IRC lane, and pin boundary
+
+The production root has one ordered, direct-child anatomy. Do not wrap, reorder,
+or independently pin these regions:
+
+1. `ircSplitView` is the viewport anchor and owns the transcript (and the IRC
+   sidebar when effective);
+2. `pendingMessagesContainer`, `statusContainer`, `todoContainer`, and
+   `btwContainer` follow the anchor **before** the pin boundary;
+3. `statusLine` is the pin boundary; and
+4. `hookWidgetContainerAbove`, `editorContainer`, `petFloorContainer`, and
+   `hookWidgetContainerBelow` are the later direct composer children in that
+   order.
+
+`statusContainer` is transient operation/status content in the pre-boundary
+application flow; it is not the persistent `statusLine` telemetry rail. The
+status line begins the fixed suffix. The focused editor, its cursor, and every
+later direct composer child remain below that boundary during manual history,
+streaming, and reflow. Pending messages, todo, and BTW therefore remain
+transcript-adjacent rather than becoming accidental fixed chrome.
+
+IRC has one shared work-lane geometry. At **64 cells or narrower** the IRC lane
+is ineffective and transcript/todo use the full width. At **65 cells** it is
+exactly **32 / 3 / 30** cells (left work lane / separator / IRC lane). At wider
+sizes the same split calculation applies; todo uses the left work lane whenever
+IRC is effective, including empty, streaming, and long IRC histories. Todo
+does not create a second sidebar, a separately rounded width, or a different
+collapse rule.
+
+Todo is absent when empty. Populated todos support long text, multiple phases,
+and collapsed/expanded views without crossing the separator or overflowing
+their work lane. The active phase is retained in collapsed view; expanded view
+keeps phase/task order. IRC empty, streaming, and long states preserve the
+same root order and pin boundary.
+
+Row reservation is content-priority based: reserve the focused composer and
+status line first, then normal hooks; when height is constrained, drop the
+manual-output notice first, then the decorative pet, then low-priority hooks.
+A zero-row transcript capacity is valid. Neither reservation nor degradation
+may hide focus/cursor geometry, move an anchor into pinned chrome, or turn a
+resize into a follow/manual state change. Manual and follow paths, streaming
+updates, width growth/shrink, and height growth/shrink preserve the anchor
+semantics; resize must recompute the shared IRC/todo lane before rendering.
+
+All lane measurement, clipping, and wrapping is ANSI-aware terminal-cell
+measurement. Terminal graphics may be shown only where the effective layout
+permits them and must degrade to the textual graphics fallback without changing
+row ownership. ANSI/color output preserves visible cursor/focus state; ASCII
+and no-color output retains textual selection/status affordances. CJK and mixed
+CJK/Latin todo, IRC, status, and BTW text break at semantic phrase boundaries,
+not inside a phase/action/status label, short identifier, or grapheme cluster.
+Those defects, width overflow, overlap, hidden focus/cursor, and lost anchors
+are blocking visual-QA failures.
 ### Sticky viewport deterministic visual QA
 
 `test/fixtures/tui/sticky-viewport-showcase.ts` is a fixed-clock, no-network,

--- a/packages/coding-agent/src/modes/components/irc-sidebar.ts
+++ b/packages/coding-agent/src/modes/components/irc-sidebar.ts
@@ -82,6 +82,35 @@ export function computeIrcSplitWidths(width: number): {
 		rightWidth: sidebarWidth,
 	};
 }
+/**
+ * Resolves the single shared work-lane geometry. The left lane is used by both
+ * transcript and todo content whenever the IRC lane is effective.
+ */
+export function computeIrcWorkLaneWidths(
+	width: number,
+	sidebarVisible: boolean,
+): { leftWidth: number; separatorWidth: number; rightWidth: number } {
+	const fullWidth = Math.max(0, Math.floor(width));
+	return sidebarVisible
+		? computeIrcSplitWidths(fullWidth)
+		: { leftWidth: fullWidth, separatorWidth: 0, rightWidth: 0 };
+}
+
+export class IrcLeftLaneComponent implements Component {
+	constructor(
+		private readonly content: Component,
+		private readonly isSidebarVisible: (width: number) => boolean,
+	) {}
+
+	render(width: number): string[] {
+		const layout = computeIrcWorkLaneWidths(width, this.isSidebarVisible(width));
+		return this.content.render(layout.leftWidth);
+	}
+
+	invalidate(): void {
+		this.content.invalidate?.();
+	}
+}
 
 type SemanticLine = Readonly<{
 	kind: "header" | "body" | "elision" | "blank";
@@ -288,7 +317,7 @@ export class IrcSplitViewComponent implements ViewportAnchorProvider {
 	renderWithViewportAnchors(width: number): ViewportAnchorRender {
 		if (!this.#visible) return renderComponentWithViewportAnchors(this.leftPane, width);
 		const componentTheme = typeof this.componentTheme === "function" ? this.componentTheme() : this.componentTheme;
-		const { leftWidth, separatorWidth, rightWidth } = computeIrcSplitWidths(width);
+		const { leftWidth, separatorWidth, rightWidth } = computeIrcWorkLaneWidths(width, this.#visible);
 		if (rightWidth === 0) return renderComponentWithViewportAnchors(this.leftPane, width);
 		const separator = separatorWidth > 0 ? componentTheme.fg("dim", ` ${componentTheme.boxSharp.vertical} `) : "";
 		const leftRender = withTerminalGraphicsFallback(

--- a/packages/coding-agent/src/modes/components/tool-status-header.ts
+++ b/packages/coding-agent/src/modes/components/tool-status-header.ts
@@ -206,7 +206,6 @@ export class StatusLineComponent implements Component {
 			separator: settings.get("statusLine.separator"),
 			showHookStatus: settings.get("statusLine.showHookStatus"),
 			showSkillHud: settings.get("statusLine.showSkillHud"),
-			showActionHints: settings.get("statusLine.showActionHints"),
 			segmentOptions: settings.getGroup("statusLine").segmentOptions,
 			sessionAccent: settings.get("statusLine.sessionAccent"),
 			maxRows: settings.get("statusLine.maxRows"),

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -197,7 +197,6 @@ export function buildStatusLineSettings(settingsInstance: Settings): StatusLineS
 		rightSegments: settingsInstance.get("statusLine.rightSegments"),
 		separator: settingsInstance.get("statusLine.separator"),
 		showHookStatus: settingsInstance.get("statusLine.showHookStatus"),
-		showActionHints: settingsInstance.get("statusLine.showActionHints"),
 		sessionAccent: settingsInstance.get("statusLine.sessionAccent"),
 		maxRows: settingsInstance.get("statusLine.maxRows"),
 		segmentOptions: settingsInstance.get("statusLine.segmentOptions"),
@@ -1626,13 +1625,16 @@ export class SelectorController {
 				this.ctx.session.agent.repetitionPenalty = repetitionPenalty >= 0 ? repetitionPenalty : undefined;
 				break;
 			}
+			case "statusLine.showActionHints": {
+				this.ctx.updateEditorChrome();
+				break;
+			}
 			case "statusLinePreset":
 			case "statusLine.preset":
 			case "statusLineSeparator":
 			case "statusLine.separator":
 			case "statusLineShowHooks":
 			case "statusLine.showHookStatus":
-			case "statusLine.showActionHints":
 			case "statusLine.sessionAccent":
 			case "statusLine.maxRows":
 			case "statusLine.leftSegments":

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -13,7 +13,7 @@ import {
 	Text,
 	TUI,
 } from "@gajae-code/tui";
-import { APP_NAME, adjustHsv, getProjectDir, logger, postmortem } from "@gajae-code/utils";
+import { APP_NAME, adjustHsv, getProjectDir, logger, postmortem, sanitizeText } from "@gajae-code/utils";
 import chalk from "chalk";
 import { AsyncJobManager } from "../async";
 import {
@@ -61,7 +61,12 @@ import { GajaePetWidget, type PetMode } from "./components/gajae-pet-widget";
 import type { HookEditorComponent } from "./components/hook-editor";
 import type { HookInputComponent } from "./components/hook-input";
 import type { HookSelectorComponent } from "./components/hook-selector";
-import { computeIrcSplitWidths, getIrcSidebarSemanticToken, IrcSplitViewComponent } from "./components/irc-sidebar";
+import {
+	computeIrcSplitWidths,
+	getIrcSidebarSemanticToken,
+	IrcLeftLaneComponent,
+	IrcSplitViewComponent,
+} from "./components/irc-sidebar";
 import {
 	getPetUnavailableWarning,
 	isPetAvailable,
@@ -118,8 +123,9 @@ import { addChatChild, prepareTranscriptRebuild, UiHelpers } from "./utils/ui-he
 function buildComposerPlaceholder(
 	keybindings: Pick<KeybindingsManager, "getDisplayString">,
 	context: KeyDisplayContext,
-	options: { readonly busy: boolean; readonly busyPromptMode: "steer" | "queue" },
+	options: { readonly busy: boolean; readonly busyPromptMode: "steer" | "queue"; readonly showActionHints: boolean },
 ): string {
+	if (!options.showActionHints) return "Type your message...";
 	const parts: string[] = [];
 	const submitKey = options.busy ? keybindings.getDisplayString("tui.input.submit", context) : "";
 	if (submitKey) {
@@ -155,7 +161,11 @@ export function getDefaultComposerPlaceholder(
 		KeybindingsManager.inMemory({
 			"app.message.queue": defaultMessageQueueKeysForPlatform(context.platform),
 		});
-	return buildComposerPlaceholder(effectiveKeybindings, context, { busy: false, busyPromptMode: "steer" });
+	return buildComposerPlaceholder(effectiveKeybindings, context, {
+		busy: false,
+		busyPromptMode: "steer",
+		showActionHints: true,
+	});
 }
 
 export const DEFAULT_COMPOSER_PLACEHOLDER = getDefaultComposerPlaceholder();
@@ -163,7 +173,7 @@ export const DEFAULT_COMPOSER_PLACEHOLDER = getDefaultComposerPlaceholder();
 export function getComposerPlaceholder(
 	keybindings: Pick<KeybindingsManager, "getDisplayString">,
 	context: KeyDisplayContext,
-	options: { readonly busy: boolean; readonly busyPromptMode: "steer" | "queue" },
+	options: { readonly busy: boolean; readonly busyPromptMode: "steer" | "queue"; readonly showActionHints: boolean },
 ): string {
 	return buildComposerPlaceholder(keybindings, context, options);
 }
@@ -646,7 +656,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#todoCommandController = new TodoCommandController(this);
 		this.#selectorController = new SelectorController(this);
 		this.#inputController = new InputController(this);
-		this.statusLine.setActionRegistry(this.#inputController.actionRegistry, () => this.keybindings);
+		// Composer shortcut discovery owns contextual action hints; retain only status telemetry in the rail.
 		this.promptSuggestion = new PromptSuggestionController(this);
 		this.#observerRegistry = new SessionObserverRegistry();
 	}
@@ -1132,6 +1142,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		return getComposerPlaceholder(this.keybindings, this.#keyDisplayContext, {
 			busy: this.#isPromptDeliveryBusy(),
 			busyPromptMode: this.settings.get("busyPromptMode"),
+			showActionHints: this.settings.get("statusLine.showActionHints"),
 		});
 	}
 
@@ -1280,18 +1291,23 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.renderSessionContext(context);
 	}
 
+	#sanitizeTodoText(text: string): string {
+		return sanitizeText(text).replaceAll("\t", "    ");
+	}
+
 	#formatTodoLine(todo: TodoItem, prefix: string): string {
 		const checkbox = theme.checkbox;
 		const marker = formatHudNoteMarker(todo.notes?.length ?? 0);
+		const content = this.#sanitizeTodoText(todo.content);
 		switch (todo.status) {
 			case "completed":
-				return theme.fg("success", `${prefix}${checkbox.checked} ${chalk.strikethrough(todo.content)}`) + marker;
+				return theme.fg("success", `${prefix}${checkbox.checked} ${chalk.strikethrough(content)}`) + marker;
 			case "in_progress":
-				return theme.fg("accent", `${prefix}${checkbox.unchecked} ${todo.content}`) + marker;
+				return theme.fg("accent", `${prefix}${checkbox.unchecked} ${content}`) + marker;
 			case "abandoned":
-				return theme.fg("error", `${prefix}${checkbox.unchecked} ${chalk.strikethrough(todo.content)}`) + marker;
+				return theme.fg("error", `${prefix}${checkbox.unchecked} ${chalk.strikethrough(content)}`) + marker;
 			default:
-				return theme.fg("dim", `${prefix}${checkbox.unchecked} ${todo.content}`) + marker;
+				return theme.fg("dim", `${prefix}${checkbox.unchecked} ${content}`) + marker;
 		}
 	}
 
@@ -1301,6 +1317,13 @@ export class InteractiveMode implements InteractiveModeContext {
 			phase.tasks.some(task => task.status === "pending" || task.status === "in_progress"),
 		);
 		return active ?? nonEmpty[nonEmpty.length - 1];
+	}
+
+	#addTodoContent(lines: string[]): void {
+		const content = new Text(lines.join("\n"), 1, 0);
+		this.todoContainer.addChild(
+			new IrcLeftLaneComponent(content, width => this.#ircSplitView.effectiveSidebarVisible(width)),
+		);
 	}
 
 	#renderTodoList(): void {
@@ -1319,7 +1342,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			const activePhase = phases[activeIdx];
 			if (!activePhase) return;
 			lines.push(
-				`${indent}${theme.fg("accent", `${hook} ${formatPhaseDisplayName(activePhase.name, activeIdx + 1)}`)}`,
+				`${indent}${theme.fg("accent", `${hook} ${formatPhaseDisplayName(this.#sanitizeTodoText(activePhase.name), activeIdx + 1)}`)}`,
 			);
 			const visibleTasks = activePhase.tasks.slice(0, 5);
 			visibleTasks.forEach((todo, index) => {
@@ -1330,19 +1353,21 @@ export class InteractiveMode implements InteractiveModeContext {
 				const remaining = activePhase.tasks.length - visibleTasks.length;
 				lines.push(theme.fg("muted", `${indent}  ${hook} +${remaining} more`));
 			}
-			this.todoContainer.addChild(new Text(lines.join("\n"), 1, 0));
+			this.#addTodoContent(lines);
 			return;
 		}
 
 		phases.forEach((phase, phaseIndex) => {
-			lines.push(`${indent}${theme.fg("accent", `${hook} ${formatPhaseDisplayName(phase.name, phaseIndex + 1)}`)}`);
+			lines.push(
+				`${indent}${theme.fg("accent", `${hook} ${formatPhaseDisplayName(this.#sanitizeTodoText(phase.name), phaseIndex + 1)}`)}`,
+			);
 			phase.tasks.forEach((todo, index) => {
 				const prefix = `${indent}${index === 0 ? hook : " "} `;
 				lines.push(this.#formatTodoLine(todo, prefix));
 			});
 		});
 
-		this.todoContainer.addChild(new Text(lines.join("\n"), 1, 0));
+		this.#addTodoContent(lines);
 	}
 
 	async #loadTodoList(): Promise<void> {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -253,6 +253,7 @@ export interface InteractiveModeContext {
 	updateEditorTopBorder(): void;
 	updateEditorBorderColor(): void;
 	rebuildChatFromMessages(policy: TranscriptRebuildPolicy): void;
+	updateEditorChrome(): void;
 	setTodos(todos: TodoItem[] | TodoPhase[]): void;
 	reloadTodos(): Promise<void>;
 	toggleTodoExpansion(): void;

--- a/packages/coding-agent/test/composer-placeholder.test.ts
+++ b/packages/coding-agent/test/composer-placeholder.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { KeybindingsManager } from "../src/config/keybindings";
+import { SETTINGS_SCHEMA } from "../src/config/settings-schema";
 import { getComposerPlaceholder, getDefaultComposerPlaceholder } from "../src/modes/interactive-mode";
 
 describe("composer placeholder", () => {
@@ -29,7 +30,15 @@ describe("composer placeholder", () => {
 			"Type your message... ⌃K: Queue (busy) · ⌃T: Thinking · ⌘M: Model · ⌥H: History · ⇧↩/⌃J: New line · ⌃C: Clear",
 		);
 		expect(
-			getComposerPlaceholder(keybindings, { platform: "darwin" }, { busy: false, busyPromptMode: "steer" }),
+			getComposerPlaceholder(
+				keybindings,
+				{ platform: "darwin" },
+				{
+					busy: false,
+					busyPromptMode: "steer",
+					showActionHints: true,
+				},
+			),
 		).toBe(
 			"Type your message... ⌃K: Queue (busy) · ⌃T: Thinking · ⌘M: Model · ⌥H: History · ⇧↩/⌃J: New line · ⌃C: Clear",
 		);
@@ -43,9 +52,17 @@ describe("composer placeholder", () => {
 			"app.message.queue": [],
 		});
 
-		expect(getComposerPlaceholder(keybindings, { platform: "linux" }, { busy: false, busyPromptMode: "steer" })).toBe(
-			"Type your message... Shift+Enter/Ctrl+J: New line · Ctrl+C: Clear",
-		);
+		expect(
+			getComposerPlaceholder(
+				keybindings,
+				{ platform: "linux" },
+				{
+					busy: false,
+					busyPromptMode: "steer",
+					showActionHints: true,
+				},
+			),
+		).toBe("Type your message... Shift+Enter/Ctrl+J: New line · Ctrl+C: Clear");
 	});
 
 	it("shows distinct submit and queue actions while busy in steer mode", () => {
@@ -54,7 +71,17 @@ describe("composer placeholder", () => {
 			"tui.input.submit": "enter",
 		});
 
-		expect(getComposerPlaceholder(keybindings, { platform: "darwin" }, { busy: true, busyPromptMode: "steer" })).toBe(
+		expect(
+			getComposerPlaceholder(
+				keybindings,
+				{ platform: "darwin" },
+				{
+					busy: true,
+					busyPromptMode: "steer",
+					showActionHints: true,
+				},
+			),
+		).toBe(
 			"Type your message... ↩: Steer · ⌥Q: Queue · ⇧⇥: Thinking · ⌃L: Model · ⌃R: History · ⇧↩/⌃J: New line · ⌃C: Clear",
 		);
 	});
@@ -65,9 +92,17 @@ describe("composer placeholder", () => {
 			"tui.input.submit": "enter",
 		});
 
-		expect(getComposerPlaceholder(keybindings, { platform: "darwin" }, { busy: true, busyPromptMode: "queue" })).toBe(
-			"Type your message... ↩: Queue · ⇧⇥: Thinking · ⌃L: Model · ⌃R: History · ⇧↩/⌃J: New line · ⌃C: Clear",
-		);
+		expect(
+			getComposerPlaceholder(
+				keybindings,
+				{ platform: "darwin" },
+				{
+					busy: true,
+					busyPromptMode: "queue",
+					showActionHints: true,
+				},
+			),
+		).toBe("Type your message... ↩: Queue · ⇧⇥: Thinking · ⌃L: Model · ⌃R: History · ⇧↩/⌃J: New line · ⌃C: Clear");
 	});
 
 	it("falls back to the dedicated queue binding when busy queue submit is unbound", () => {
@@ -76,8 +111,43 @@ describe("composer placeholder", () => {
 			"tui.input.submit": [],
 		});
 
-		expect(getComposerPlaceholder(keybindings, { platform: "win32" }, { busy: true, busyPromptMode: "queue" })).toBe(
+		expect(
+			getComposerPlaceholder(
+				keybindings,
+				{ platform: "win32" },
+				{
+					busy: true,
+					busyPromptMode: "queue",
+					showActionHints: true,
+				},
+			),
+		).toBe(
 			"Type your message... Ctrl+K: Queue · Shift+Tab: Thinking · Ctrl+L: Model · Ctrl+R: History · Alt+Enter/Ctrl+J: New line · Ctrl+C: Clear",
 		);
+	});
+	it("uses the stable action-hints setting for composer shortcut visibility", () => {
+		expect(SETTINGS_SCHEMA["statusLine.showActionHints"]).toMatchObject({
+			default: true,
+			ui: {
+				label: "Composer Shortcut Hints",
+				description: "Show contextual keyboard shortcuts in the composer placeholder",
+			},
+		});
+
+		const keybindings = KeybindingsManager.inMemory({
+			"app.message.queue": "ctrl+k",
+			"app.thinking.cycle": "ctrl+t",
+		});
+		expect(
+			getComposerPlaceholder(
+				keybindings,
+				{ platform: "linux" },
+				{
+					busy: true,
+					busyPromptMode: "queue",
+					showActionHints: false,
+				},
+			),
+		).toBe("Type your message...");
 	});
 });

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -433,17 +433,22 @@ describe("InputController keybinding setup", () => {
 		expect(spies.toggleIrcSidebar).toHaveBeenCalledTimes(1);
 	});
 
-	it("registers remapped IRC sidebar shortcuts", async () => {
-		const { InputController, ctx, editor } = await createContext({ ircSidebarToggleKeys: ["ctrl+alt+i"] });
+	it("dispatches only a remapped IRC sidebar shortcut", async () => {
+		const { InputController, ctx, editor, spies } = await createContext({ ircSidebarToggleKeys: ["ctrl+alt+i"] });
 		const controller = new InputController(ctx);
 
 		controller.setupKeyHandlers();
 
-		expect(editor.setCustomKeyHandler).toHaveBeenCalledWith("ctrl+alt+i", expect.any(Function));
+		const registration = (editor.setCustomKeyHandler as ReturnType<typeof vi.fn>).mock.calls.find(
+			([key]) => key === "ctrl+alt+i",
+		);
+		expect(registration).toBeDefined();
 		expect(editor.setCustomKeyHandler).not.toHaveBeenCalledWith("alt+i", expect.any(Function));
+		expect((registration?.[1] as () => boolean)()).toBe(true);
+		expect(spies.toggleIrcSidebar).toHaveBeenCalledTimes(1);
 	});
 
-	it("does not register a sidebar handler when its binding is explicitly empty", async () => {
+	it("does not register a sidebar handler when the shortcut is explicitly unbound", async () => {
 		const { InputController, ctx, editor } = await createContext({ ircSidebarToggleKeys: [] });
 		new InputController(ctx).setupKeyHandlers();
 

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
-import * as path from "node:path";
 import { stripVTControlCharacters } from "node:util";
 import { Agent } from "@gajae-code/agent-core";
 import type { AssistantMessage } from "@gajae-code/ai";
@@ -16,7 +15,9 @@ import type {
 	ExtensionUIContext,
 } from "../src/extensibility/extensions";
 import { CustomEditor } from "../src/modes/components/custom-editor";
+import { computeIrcWorkLaneWidths, IrcSplitViewComponent } from "../src/modes/components/irc-sidebar";
 import { ExtensionUiController } from "../src/modes/controllers/extension-ui-controller";
+import { SelectorController } from "../src/modes/controllers/selector-controller";
 import { InteractiveMode } from "../src/modes/interactive-mode";
 import { AgentSession } from "../src/session/agent-session";
 import { AuthStorage } from "../src/session/auth-storage";
@@ -50,7 +51,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 		resetSettingsForTest();
 		tempDir = TempDir.createSync("@pi-editor-component-");
 		await Settings.init({ inMemory: true, cwd: tempDir.path() });
-		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage = await AuthStorage.create(":memory:");
 		const modelRegistry = new ModelRegistry(authStorage);
 		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
 		if (!model) {
@@ -87,8 +88,8 @@ describe("InteractiveMode.setEditorComponent", () => {
 		mode?.stop();
 		await session?.dispose();
 		authStorage?.close();
-		tempDir?.removeSync();
 		resetSettingsForTest();
+		await tempDir?.remove();
 	});
 
 	it("applies viewport policy inside the real destructive rebuild methods", () => {
@@ -219,19 +220,59 @@ describe("InteractiveMode.setEditorComponent", () => {
 		expect(mode.captureIrcArrivalSnapshot().resolvedToggleKey).toBe("alt+i");
 	});
 
-	it("converts requested-visible state to a closed arrival snapshot below the sidebar width floor", () => {
+	it("preserves requested IRC visibility across the exact width boundary round trip", async () => {
+		vi.spyOn(mode.ui, "start").mockImplementation(() => {});
+		await mode.init();
 		mode.settings.set("irc.enabled", true);
 		mode.settings.set("irc.sidebar.enabled", true);
 		mode.applyIrcSidebarAvailability(true);
 		mode.toggleIrcSidebar();
+		mode.addMessageToChat({ role: "user", content: "anchored transcript", timestamp: 1 });
+
+		const split = mode.ui.children.find(component => component instanceof IrcSplitViewComponent);
+		if (!(split instanceof IrcSplitViewComponent)) throw new Error("Expected IRC split in the production root");
+		for (const columns of [64, 65, 80, 120, 160, 120, 80, 65, 64]) {
+			forceTerminalSize(mode, columns, 24);
+			const arrival = mode.captureIrcArrivalSnapshot();
+			const layout = computeIrcWorkLaneWidths(columns, arrival.panelVisible);
+			const rendered = mode.ui.render(columns).map(stripRenderControls);
+			const splitLines = split.render(columns).map(stripRenderControls);
+			expect(arrival.panelRequestedVisible).toBe(true);
+			expect(arrival.panelVisible).toBe(columns >= 65);
+			expect(layout.leftWidth + layout.separatorWidth + layout.rightWidth).toBe(columns);
+			expect(layout.separatorWidth === 3).toBe(columns >= 65);
+			expect(splitLines.some(line => line.includes(theme.boxSharp.vertical))).toBe(columns >= 65);
+			expect(rendered.every(line => visibleWidth(line) <= columns)).toBe(true);
+		}
+	});
+	it("keeps todos in the transcript lane without changing the production root order", async () => {
+		await mode.init();
+		mode.settings.set("irc.enabled", true);
+		mode.settings.set("irc.sidebar.enabled", true);
+		mode.applyIrcSidebarAvailability(true);
+		mode.toggleIrcSidebar();
+		mode.setTodos([{ content: "A long todo that must not occupy IRC cells", status: "in_progress" }]);
+
+		const root = mode.ui.children;
+		const splitIndex = root.findIndex(component => component instanceof IrcSplitViewComponent);
+		expect(root.slice(splitIndex, splitIndex + 10)).toEqual([
+			root[splitIndex],
+			mode.pendingMessagesContainer,
+			mode.statusContainer,
+			mode.todoContainer,
+			mode.btwContainer,
+			mode.statusLine,
+			mode.hookWidgetContainerAbove,
+			mode.editorContainer,
+			mode.petFloorContainer,
+			mode.hookWidgetContainerBelow,
+		]);
+		expect(mode.todoContainer.render(65).every(line => visibleWidth(line) <= 32)).toBe(true);
 
 		forceTerminalSize(mode, 64, 24);
-		const narrow = mode.captureIrcArrivalSnapshot();
-		expect(narrow.panelVisible).toBe(false);
-
-		forceTerminalSize(mode, 65, 24);
-		const wideEnough = mode.captureIrcArrivalSnapshot();
-		expect(wideEnough.panelVisible).toBe(true);
+		expect(mode.todoContainer.render(64).some(line => visibleWidth(line) > 32)).toBe(true);
+		forceTerminalSize(mode, 80, 24);
+		expect(mode.todoContainer.render(80).every(line => visibleWidth(line) <= 47)).toBe(true);
 	});
 
 	it("suppresses the toggle hint when the panel is requested-open but yielded at narrow width", () => {
@@ -506,6 +547,34 @@ describe("InteractiveMode.setEditorComponent", () => {
 		expect(rendered).toContain("Type your message...");
 		expect(rendered).not.toContain(expectedSubmitShortcutHint());
 		expect(rendered).toContain(expectedQueueShortcutHint("Queue (busy)"));
+	});
+	it("applies the public shortcut-hint setting through the live composer side-effect path", () => {
+		const controller = new SelectorController(mode);
+		mode.settings.set("statusLine.showActionHints", false);
+		controller.handleSettingChange("statusLine.showActionHints", false);
+
+		let rendered = mode.editor.render(300).map(stripRenderControls).join("\n");
+		expect(rendered).toContain("Type your message...");
+		expect(rendered).not.toContain(expectedQueueShortcutHint("Queue (busy)"));
+		expect(rendered).not.toContain(expectedNewlineShortcutHint());
+
+		mode.settings.set("statusLine.showActionHints", true);
+		controller.handleSettingChange("statusLine.showActionHints", true);
+
+		rendered = mode.editor.render(300).map(stripRenderControls).join("\n");
+		expect(rendered).toContain(expectedQueueShortcutHint("Queue (busy)"));
+		expect(rendered).toContain(expectedNewlineShortcutHint());
+	});
+	it("keeps adjacent status-line settings on the live status update path", () => {
+		const updateSettings = vi.spyOn(mode.statusLine, "updateSettings");
+		const updateEditorTopBorder = vi.spyOn(mode, "updateEditorTopBorder");
+		const controller = new SelectorController(mode);
+
+		mode.settings.set("statusLine.separator", "pipe");
+		controller.handleSettingChange("statusLine.separator", "pipe");
+
+		expect(updateSettings).toHaveBeenCalledTimes(1);
+		expect(updateEditorTopBorder).toHaveBeenCalledTimes(1);
 	});
 	it("uses the effective submit binding in busy hints and omits it when unbound", () => {
 		(session.agent as unknown as { state: { isStreaming: boolean } }).state.isStreaming = true;

--- a/packages/coding-agent/test/modes/components/irc-sidebar.test.ts
+++ b/packages/coding-agent/test/modes/components/irc-sidebar.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import {
 	computeIrcSplitWidths,
+	computeIrcWorkLaneWidths,
 	getIrcSidebarSemanticToken,
 	IRC_SIDEBAR_MAX_RENDER_ROWS,
+	IrcLeftLaneComponent,
 	type IrcSidebarTheme,
 	IrcSplitViewComponent,
 } from "@gajae-code/coding-agent/modes/components/irc-sidebar";
@@ -137,6 +139,18 @@ describe("computeIrcSplitWidths", () => {
 			expect(result.rightWidth === 0).toBe(width < 65);
 			expect(result.leftWidth).toBeGreaterThanOrEqual(Math.floor(width * 0.5));
 		}
+	});
+});
+describe("shared work lane", () => {
+	it("keeps dependent pre-boundary content in the transcript lane only while IRC is effective", () => {
+		const todo = new TestPane("todo content");
+		const lane = new IrcLeftLaneComponent(todo, width => width >= 65);
+
+		expect(computeIrcWorkLaneWidths(64, true)).toEqual({ leftWidth: 64, separatorWidth: 0, rightWidth: 0 });
+		expect(computeIrcWorkLaneWidths(65, true)).toEqual({ leftWidth: 32, separatorWidth: 3, rightWidth: 30 });
+		expect(lane.render(64)).toEqual(["todo content"]);
+		expect(lane.render(80)).toEqual(["todo content"]);
+		expect(todo.widths).toEqual([64, computeIrcSplitWidths(80).leftWidth]);
 	});
 });
 

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -490,7 +490,7 @@
 				},
 				"showActionHints": {
 					"type": "boolean",
-					"description": "Show contextual keyboard shortcuts in the status line",
+					"description": "Show contextual keyboard shortcuts in the composer placeholder",
 					"default": true
 				},
 				"leftSegments": {


### PR DESCRIPTION
## What

- use one responsive geometry contract for IRC and todo work lanes
- preserve requested IRC visibility while narrow layouts yield space to the transcript
- retain direct-root order and the status-line pin boundary across resize
- sanitize todo rows and keep them inside the shared work lane
- move `statusLine.showActionHints` display ownership to the composer placeholder with live updates
- update the generated settings schema, focused tests, DESIGN contract, and changelog

## Scope

This is the second contract-focused successor to closed #3484. It is independent of the native key PR and intentionally excludes all key parsing, terminal viewport observation, capture/verifier, and sticky-evidence files.

The diff is exactly 13 files: five production mode files, settings/schema, four focused tests, DESIGN, and changelog.

## Testing

- `bun run check:schemas`
- focused composer/keybinding/editor/IRC suites: **116 passed, 0 failed, 5,017 expectations**
- `bun --cwd=packages/coding-agent run check` passed on the contract base before the latest upstream-only formatting drift
- native addon build passed
- `git diff --check`

Independent exact-head architecture review for `0602c2f2b79221d855685ce6e1d3b349719cf4c6` is in progress; the head will remain stable.

## Checklist

- [x] Rebased onto current `dev`
- [x] One responsive layout/settings contract
- [x] Exact 64/65/80 boundaries covered
- [x] Root/pin ordering and live settings covered
- [x] No viewport evidence or key parser changes
