### PR TITLE
chore(coding-agent): restore ultragoal formatting

### DIFF
--- a/packages/coding-agent/src/defaults/gjc-defaults.ts
+++ b/packages/coding-agent/src/defaults/gjc-defaults.ts
@@ -9,10 +9,10 @@ import deepInterviewSkill from "./gjc/skills/deep-interview/SKILL.md" with { typ
 import ralplanSkill from "./gjc/skills/ralplan/SKILL.md" with { type: "text" };
 import teamSkill from "./gjc/skills/team/SKILL.md" with { type: "text" };
 import aiSlopCleanerFragment from "./gjc/skills/ultragoal/ai-slop-cleaner.md" with { type: "text" };
+import ultragoalSkill from "./gjc/skills/ultragoal/SKILL.md" with { type: "text" };
 import validationBatchContractsFragment from "./gjc/skills/ultragoal/validation-batch-contracts.md" with {
 	type: "text",
 };
-import ultragoalSkill from "./gjc/skills/ultragoal/SKILL.md" with { type: "text" };
 
 export const DEFAULT_GJC_DEFINITION_NAMES = ["deep-interview", "ralplan", "team", "ultragoal"] as const;
 export type DefaultGjcDefinitionName = (typeof DEFAULT_GJC_DEFINITION_NAMES)[number];

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -2305,9 +2305,7 @@ function validateReviewCohort(gate: JsonObject, iteration: JsonObject): void {
 		throw new Error("iteration.reviewCohort.joined must be true: all lane findings must join before checkpoint");
 	const lanes = qualityGateObject(cohort.lanes);
 	if (!lanes) throw new Error("iteration.reviewCohort.lanes is required");
-	const unsupportedLanes = Object.keys(lanes).filter(
-		key => !(COHORT_LANE_KEYS as readonly string[]).includes(key),
-	);
+	const unsupportedLanes = Object.keys(lanes).filter(key => !(COHORT_LANE_KEYS as readonly string[]).includes(key));
 	if (unsupportedLanes.length > 0)
 		throw new Error(`iteration.reviewCohort.lanes contains unsupported lanes: ${unsupportedLanes.join(", ")}`);
 	for (const lane of COHORT_LANE_KEYS) {
@@ -2434,7 +2432,11 @@ async function validateCompletionQualityGate(
 	);
 	const unsupportedKeys = Object.keys(gate).filter(key => !allowedKeys.has(key));
 	if (unsupportedKeys.length > 0) {
-		found.add("qualityGate", "unsupported_keys", `qualityGate contains unsupported keys: ${unsupportedKeys.join(", ")}`);
+		found.add(
+			"qualityGate",
+			"unsupported_keys",
+			`qualityGate contains unsupported keys: ${unsupportedKeys.join(", ")}`,
+		);
 	}
 	const architectReview = qualityGateObject(gate.architectReview);
 	const executorQa = qualityGateObject(gate.executorQa);

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -415,7 +415,9 @@ Project executor override body.
 		expect(ultragoal).toContain("### Validation batches (explicit phase/module boundaries)");
 		expect(ultragoal).toContain("## Boundary completion cohort gate");
 		expect(ultragoal).toContain("gjc ultragoal quality-gate validate");
-		expect(ultragoal).toContain("reports **all** structural, evidence, surface, cohort, and declaration errors in one run");
+		expect(ultragoal).toContain(
+			"reports **all** structural, evidence, surface, cohort, and declaration errors in one run",
+		);
 		expect(ultragoal).toContain("strictly read-only");
 		expect(ultragoal).toContain("once per boundary generation");
 		expect(ultragoal).toContain("iteration.reviewCohort");
@@ -461,7 +463,9 @@ Project executor override body.
 		// C: intra-goal validation-lane parallelism.
 		expect(ultragoal).toContain("### Intra-goal validation-lane parallelism");
 		expect(ultragoal).toContain("Cohort lanes are parallel by construction");
-		expect(ultragoal).toContain("`cleaner`, `architect`, and `qa` can run concurrently against the identical immutable snapshot");
+		expect(ultragoal).toContain(
+			"`cleaner`, `architect`, and `qa` can run concurrently against the identical immutable snapshot",
+		);
 		expect(ultragoal).toContain("join before checkpoint");
 		expect(ultragoal).toContain("Fall back to **sequential** lanes");
 		expect(ultragoal).toContain("red-team lane depends on architect fixes");

--- a/packages/coding-agent/test/gjc-runtime/computer-red-team-fixtures.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/computer-red-team-fixtures.test.ts
@@ -205,8 +205,18 @@ function qualityGate(qa: Record<string, unknown>): string {
 				sourceHash: "sha256:test-frozen-source",
 				joined: true,
 				lanes: {
-					cleaner: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "cleaner clean", blockers: [] },
-					architect: { status: "CLEAR", sourceHash: "sha256:test-frozen-source", evidence: "architect clear", blockers: [] },
+					cleaner: {
+						status: "passed",
+						sourceHash: "sha256:test-frozen-source",
+						evidence: "cleaner clean",
+						blockers: [],
+					},
+					architect: {
+						status: "CLEAR",
+						sourceHash: "sha256:test-frozen-source",
+						evidence: "architect clear",
+						blockers: [],
+					},
 					qa: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "qa passed", blockers: [] },
 				},
 			},

--- a/packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/state-handoff-thrift.test.ts
@@ -97,8 +97,18 @@ function passingQualityGate(): string {
 				sourceHash: "sha256:test-frozen-source",
 				joined: true,
 				lanes: {
-					cleaner: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "cleaner clean", blockers: [] },
-					architect: { status: "CLEAR", sourceHash: "sha256:test-frozen-source", evidence: "architect clear", blockers: [] },
+					cleaner: {
+						status: "passed",
+						sourceHash: "sha256:test-frozen-source",
+						evidence: "cleaner clean",
+						blockers: [],
+					},
+					architect: {
+						status: "CLEAR",
+						sourceHash: "sha256:test-frozen-source",
+						evidence: "architect clear",
+						blockers: [],
+					},
 					qa: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "qa passed", blockers: [] },
 				},
 			},

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-critic-gate.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-critic-gate.test.ts
@@ -181,8 +181,18 @@ function passingLiveQualityGate(): Record<string, unknown> {
 				sourceHash: "sha256:test-frozen-source",
 				joined: true,
 				lanes: {
-					cleaner: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "cleaner clean", blockers: [] },
-					architect: { status: "CLEAR", sourceHash: "sha256:test-frozen-source", evidence: "architect clear", blockers: [] },
+					cleaner: {
+						status: "passed",
+						sourceHash: "sha256:test-frozen-source",
+						evidence: "cleaner clean",
+						blockers: [],
+					},
+					architect: {
+						status: "CLEAR",
+						sourceHash: "sha256:test-frozen-source",
+						evidence: "architect clear",
+						blockers: [],
+					},
 					qa: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "qa passed", blockers: [] },
 				},
 			},

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-dogfood.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-dogfood.test.ts
@@ -223,8 +223,18 @@ function qualityGate(): Record<string, unknown> {
 				sourceHash: "sha256:test-frozen-source",
 				joined: true,
 				lanes: {
-					cleaner: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "cleaner clean", blockers: [] },
-					architect: { status: "CLEAR", sourceHash: "sha256:test-frozen-source", evidence: "architect clear", blockers: [] },
+					cleaner: {
+						status: "passed",
+						sourceHash: "sha256:test-frozen-source",
+						evidence: "cleaner clean",
+						blockers: [],
+					},
+					architect: {
+						status: "CLEAR",
+						sourceHash: "sha256:test-frozen-source",
+						evidence: "architect clear",
+						blockers: [],
+					},
 					qa: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "qa passed", blockers: [] },
 				},
 			},

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-durable-completion-release.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-durable-completion-release.test.ts
@@ -130,8 +130,18 @@ function passingQualityGate(): string {
 				sourceHash: "sha256:test-frozen-source",
 				joined: true,
 				lanes: {
-					cleaner: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "cleaner clean", blockers: [] },
-					architect: { status: "CLEAR", sourceHash: "sha256:test-frozen-source", evidence: "architect clear", blockers: [] },
+					cleaner: {
+						status: "passed",
+						sourceHash: "sha256:test-frozen-source",
+						evidence: "cleaner clean",
+						blockers: [],
+					},
+					architect: {
+						status: "CLEAR",
+						sourceHash: "sha256:test-frozen-source",
+						evidence: "architect clear",
+						blockers: [],
+					},
 					qa: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "qa passed", blockers: [] },
 				},
 			},

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-review.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-review.test.ts
@@ -243,8 +243,18 @@ function passingQualityGate(): Record<string, unknown> {
 				sourceHash: "sha256:test-frozen-source",
 				joined: true,
 				lanes: {
-					cleaner: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "cleaner clean", blockers: [] },
-					architect: { status: "CLEAR", sourceHash: "sha256:test-frozen-source", evidence: "architect clear", blockers: [] },
+					cleaner: {
+						status: "passed",
+						sourceHash: "sha256:test-frozen-source",
+						evidence: "cleaner clean",
+						blockers: [],
+					},
+					architect: {
+						status: "CLEAR",
+						sourceHash: "sha256:test-frozen-source",
+						evidence: "architect clear",
+						blockers: [],
+					},
 					qa: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "qa passed", blockers: [] },
 				},
 			},
@@ -408,9 +418,24 @@ describe("ultragoal review command", () => {
 							sourceHash: "sha256:test-frozen-source",
 							joined: true,
 							lanes: {
-								cleaner: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "cleaner clean", blockers: [] },
-								architect: { status: "CLEAR", sourceHash: "sha256:test-frozen-source", evidence: "architect clear", blockers: [] },
-								qa: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "qa passed", blockers: [] },
+								cleaner: {
+									status: "passed",
+									sourceHash: "sha256:test-frozen-source",
+									evidence: "cleaner clean",
+									blockers: [],
+								},
+								architect: {
+									status: "CLEAR",
+									sourceHash: "sha256:test-frozen-source",
+									evidence: "architect clear",
+									blockers: [],
+								},
+								qa: {
+									status: "passed",
+									sourceHash: "sha256:test-frozen-source",
+									evidence: "qa passed",
+									blockers: [],
+								},
 							},
 						},
 						rerunCommands: ["bun test:e2e"],

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-runtime.test.ts
@@ -187,8 +187,18 @@ function passingQualityGate(): string {
 				sourceHash: "sha256:test-frozen-source",
 				joined: true,
 				lanes: {
-					cleaner: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "cleaner clean", blockers: [] },
-					architect: { status: "CLEAR", sourceHash: "sha256:test-frozen-source", evidence: "architect clear", blockers: [] },
+					cleaner: {
+						status: "passed",
+						sourceHash: "sha256:test-frozen-source",
+						evidence: "cleaner clean",
+						blockers: [],
+					},
+					architect: {
+						status: "CLEAR",
+						sourceHash: "sha256:test-frozen-source",
+						evidence: "architect clear",
+						blockers: [],
+					},
 					qa: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "qa passed", blockers: [] },
 				},
 			},
@@ -488,9 +498,24 @@ function deferredBatchGate(
 					sourceHash: "sha256:test-frozen-source",
 					joined: true,
 					lanes: {
-						cleaner: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "cleaner clean", blockers: [] },
-						architect: { status: "CLEAR", sourceHash: "sha256:test-frozen-source", evidence: "architect clear", blockers: [] },
-						qa: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "qa passed", blockers: [] },
+						cleaner: {
+							status: "passed",
+							sourceHash: "sha256:test-frozen-source",
+							evidence: "cleaner clean",
+							blockers: [],
+						},
+						architect: {
+							status: "CLEAR",
+							sourceHash: "sha256:test-frozen-source",
+							evidence: "architect clear",
+							blockers: [],
+						},
+						qa: {
+							status: "passed",
+							sourceHash: "sha256:test-frozen-source",
+							evidence: "qa passed",
+							blockers: [],
+						},
 					},
 				},
 				rerunCommands: ["bun test validation batch"],
@@ -1484,7 +1509,13 @@ describe("native GJC ultragoal runtime", () => {
 				redTeamCommands: [],
 				blockers: ["qa blocker"],
 			},
-			iteration: { status: "failed", fullRerun: false, rerunCommands: [], evidence: "", blockers: ["iteration blocker"] },
+			iteration: {
+				status: "failed",
+				fullRerun: false,
+				rerunCommands: [],
+				evidence: "",
+				blockers: ["iteration blocker"],
+			},
 			bogusKey: {},
 		};
 		const gatePath = path.join(root, "broken-gate.json");
@@ -3941,9 +3972,24 @@ describe("native GJC ultragoal runtime", () => {
 							sourceHash: "sha256:test-frozen-source",
 							joined: true,
 							lanes: {
-								cleaner: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "cleaner clean", blockers: [] },
-								architect: { status: "CLEAR", sourceHash: "sha256:test-frozen-source", evidence: "architect clear", blockers: [] },
-								qa: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "qa passed", blockers: [] },
+								cleaner: {
+									status: "passed",
+									sourceHash: "sha256:test-frozen-source",
+									evidence: "cleaner clean",
+									blockers: [],
+								},
+								architect: {
+									status: "CLEAR",
+									sourceHash: "sha256:test-frozen-source",
+									evidence: "architect clear",
+									blockers: [],
+								},
+								qa: {
+									status: "passed",
+									sourceHash: "sha256:test-frozen-source",
+									evidence: "qa passed",
+									blockers: [],
+								},
 							},
 						},
 						rerunCommands: ["bun test:e2e"],

--- a/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-skill-state-hooks.test.ts
@@ -197,9 +197,24 @@ describe("GJC native skill-state hooks", () => {
 					sourceHash: "sha256:test-frozen-source",
 					joined: true,
 					lanes: {
-						cleaner: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "cleaner clean", blockers: [] },
-						architect: { status: "CLEAR", sourceHash: "sha256:test-frozen-source", evidence: "architect clear", blockers: [] },
-						qa: { status: "passed", sourceHash: "sha256:test-frozen-source", evidence: "qa passed", blockers: [] },
+						cleaner: {
+							status: "passed",
+							sourceHash: "sha256:test-frozen-source",
+							evidence: "cleaner clean",
+							blockers: [],
+						},
+						architect: {
+							status: "CLEAR",
+							sourceHash: "sha256:test-frozen-source",
+							evidence: "architect clear",
+							blockers: [],
+						},
+						qa: {
+							status: "passed",
+							sourceHash: "sha256:test-frozen-source",
+							evidence: "qa passed",
+							blockers: [],
+						},
 					},
 				},
 				rerunCommands: ["bun test:e2e", "bun test:red-team"],


### PR DESCRIPTION
## Summary

Restores Biome formatting for the Ultragoal simplification merged in #3498. Current `dev` run `30462346930` is terminal red in `check:@gajae-code/coding-agent` because these 11 files are not formatter-clean; the failure is reproducible directly at `f439879aa4bd6ed446fc993e0e129deffd06eeb8`.

This is formatting-only and intentionally separate from the Bash/output-loss repair in #3483.

## Verification

- `bun --cwd=packages/coding-agent run check`: passed.
- Nine directly affected Ultragoal/default-definition suites: 269 pass / 0 fail.
- `git diff --check`: passed.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*