### PR TITLE
fix(coding-agent): retry Codex overloads with backoff

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -869,6 +869,7 @@ type RetryErrorClassification =
 
 const BARE_DEFAULT_WATCHDOG_ERROR =
 	/^(?:[A-Za-z][A-Za-z0-9-]*(?: [A-Za-z][A-Za-z0-9-]*){0,3} )stream (?:timed out while waiting for the first event|stalled while waiting for the next event)$/;
+const BARE_DEFAULT_CODEX_OVERLOAD_ERROR = /^Codex error event(?:: .*)? \(code=server_is_overloaded(?:, [^)]+)*\)$/;
 const KIMI_CODE_FIRST_EVENT_TIMEOUT_MESSAGES = {
 	"anthropic-messages": new Set([
 		"Provider stream timed out while waiting for the first event",
@@ -903,6 +904,14 @@ function hasBareDefaultRetryDisqualifyingFacts(message: AssistantMessage): boole
 		facts.anthropicErrorType !== undefined ||
 		facts.openaiErrorCode !== undefined ||
 		(facts.headers !== undefined && Object.keys(facts.headers).length > 0)
+	);
+}
+function isBareDefaultCodexOverload(message: AssistantMessage): boolean {
+	return (
+		message.api === "openai-codex-responses" &&
+		BARE_DEFAULT_CODEX_OVERLOAD_ERROR.test(message.errorMessage ?? "") &&
+		!hasBareDefaultRetryDisqualifyingFacts(message) &&
+		!assistantMessageHasVisibleOrToolContent(message)
 	);
 }
 
@@ -14384,15 +14393,21 @@ export class AgentSession {
 		// before the failure. This bypasses #hasCleanRetryReplaySafety because the
 		// content-free check is the replay-safety guarantee for credential rotation.
 		const canReplayRotatedCredential = credentialRotated;
-		// Bare defaults admit only clean, side-effect-free canonical stream watchdog failures
-		// or content-free quota/rate-limit failures that switched to another stored credential.
+		// Bare defaults admit only clean, side-effect-free canonical stream watchdog failures,
+		// content-free quota/rate-limit credential rotations, and the explicit Codex
+		// capacity-overload event.
 		if (!managedFallback && !legacyRetryConfigured && !canReplayRotatedCredential) {
+			const bareDefaultCodexOverload = isBareDefaultCodexOverload(message);
+			// Content-free Codex overload is replay-safe by the same reasoning as
+			// credential rotation: no partial output means no observable state.
+			const canReplayCodexOverload = bareDefaultCodexOverload;
 			if (
-				(!this.#isTypedFirstEventTimeout(message) &&
+				(!canReplayCodexOverload &&
+					!this.#isTypedFirstEventTimeout(message) &&
 					(hasBareDefaultRetryDisqualifyingFacts(message) ||
 						(classification !== "transient" && classification !== "first_event_timeout") ||
 						!BARE_DEFAULT_WATCHDOG_ERROR.test(message.errorMessage ?? ""))) ||
-				!this.#hasCleanRetryReplaySafety
+				(!canReplayCodexOverload && !this.#hasCleanRetryReplaySafety)
 			) {
 				return false;
 			}

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -1039,6 +1039,68 @@ describe("AgentSession resilient retry", () => {
 		expect(retryEndEvents[0]).toMatchObject({ success: true });
 		expect(lastAssistant(session).stopReason).toBe("stop");
 	});
+	it("retries the reported Codex capacity overload under bare defaults", async () => {
+		const model = getBundledModel("openai-codex", "gpt-5.4-mini");
+		if (!model) throw new Error("Expected bundled Codex test model to exist");
+		const requestedModels: string[] = [];
+		session = buildStatusErrorSession({
+			model,
+			bareDefault: true,
+			errorMessage:
+				"Codex error event: Our servers are currently overloaded. Please try again later. (code=server_is_overloaded)",
+			recoveredContent: "recovered after provider retries",
+			requestedModels,
+		});
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		vi.spyOn(Math, "random").mockReturnValue(0.5);
+		const { retryStartEvents, retryEndEvents } = track(session);
+
+		await session.prompt("recover Codex overload");
+		await session.waitForIdle();
+
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryStartEvents[0]?.delayMs).toBeGreaterThan(0);
+		expect(waitSpy).toHaveBeenCalledWith(retryStartEvents[0]?.delayMs, expect.anything());
+		expect(requestedModels).toHaveLength(2);
+		expect(retryEndEvents).toEqual([expect.objectContaining({ success: true })]);
+		expect(lastAssistant(session).content).toEqual([{ type: "text", text: "recovered after provider retries" }]);
+	});
+	it("does not retry near-miss or non-Codex overload errors under bare defaults", async () => {
+		const codexModel = getBundledModel("openai-codex", "gpt-5.4-mini");
+		const anthropicModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!codexModel || !anthropicModel) throw new Error("Expected bundled test models to exist");
+		for (const testCase of [
+			{
+				model: codexModel,
+				errorMessage:
+					"Codex error event: Our servers are currently overloaded. Please try again later. (code=server_error)",
+			},
+			{
+				model: anthropicModel,
+				errorMessage:
+					"Codex error event: Our servers are currently overloaded. Please try again later. (code=server_is_overloaded)",
+			},
+		]) {
+			const requestedModels: string[] = [];
+			session = buildStatusErrorSession({
+				model: testCase.model,
+				bareDefault: true,
+				errorMessage: testCase.errorMessage,
+				recoveredContent: "should not retry",
+				requestedModels,
+			});
+			const { retryStartEvents } = track(session);
+
+			await session.prompt("surface non-admitted overload");
+			await session.waitForIdle();
+
+			expect(retryStartEvents).toHaveLength(0);
+			expect(requestedModels).toHaveLength(1);
+			expect(lastAssistant(session).stopReason).toBe("error");
+			await session.dispose();
+			session = undefined;
+		}
+	});
 	it("forwards only explicit first-event timeout settings to provider stream options", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!model) throw new Error("Expected bundled Anthropic test model to exist");


### PR DESCRIPTION
## Summary
- admit the OpenAI Codex `server_is_overloaded` event to bare-default session retries
- reuse the existing capped exponential backoff with full jitter
- keep replay admission narrow to clean Codex turns with no visible or tool output
- preserve explicit `retry.enabled=false` behavior and reject non-Codex/near-miss errors

## Tests
- `bun test packages/coding-agent/test/agent-session-resilient-retry.test.ts`
- `bunx biome check src/session/agent-session.ts test/agent-session-resilient-retry.test.ts`
- `bun run check:types` (from `packages/coding-agent`)

## Notes
- provider-internal retry budgets and retry settings defaults are unchanged
- no documentation changes; this is a narrow recovery fix using the existing retry controls