### PR TITLE
feat(task): bind review results to source snapshot and mark stale

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,7 @@
 ### Added
 - Published bounded, redacted, hash-bound sealed perf-corpus memory evidence and an output-free replay notebook. The authenticated analysis identifies sustained heap growth on the `agent-session` and `tui` surfaces while keeping RSS/native allocation and p95 claims explicitly out of scope.
 
+- Review-capable task results (`architect`, `critic`, `planner`, and names containing `review`/`qa`) now capture a source worktree snapshot at spawn and stamp receipts with `sourceRevision` / `sourceStatus`. When the parent worktree advances before delivery, results are marked `stale` with explicit guidance so late review findings cannot silently satisfy completion gates (#3469).
 - User-created Telegram forum topics can now start a GJC session by selecting the home folder, choosing a verified recent work folder, or entering an explicit folder path. The selected topic is adopted by the new session without creating or deleting a separate Telegram topic.
 - The interactive terminal’s responsive IRC/todo work-lane contract now covers exact narrow/wide geometry, requested versus effective IRC visibility, direct-root pin ordering, todo lane bounds, remapped IRC toggles, and live composer shortcut hints.
 - Managed-session startup now preserves bounded Windows ACL and identity failure classifications in path-redacted recovery guidance without broadening permissions, elevation, or unsafe fallback.

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -1,4 +1,5 @@
 import { logger } from "@gajae-code/utils";
+import type { TaskSourceRevision } from "../task/source-revision";
 import type { AgentProgress, AgentSource } from "../task/types";
 
 const DELIVERY_RETRY_BASE_MS = 500;
@@ -62,6 +63,11 @@ export interface AsyncJobMetadata {
 		description?: string;
 		assignment?: string;
 	};
+	/**
+	 * Worktree identity captured at spawn for review-capable tasks (#3469).
+	 * Used to mark late deliveries stale when the parent worktree advances.
+	 */
+	sourceRevision?: TaskSourceRevision;
 	/** True when this bash job was started by the `monitor` tool (vs plain async bash). */
 	monitor?: boolean;
 }

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -69,6 +69,12 @@ import { assertNoRawTaskFields, buildTaskReceipt, buildTaskRoiSummary } from "./
 import { renderResult, renderCall as renderTaskCall } from "./render";
 import { reconcileSpawnRoi } from "./roi-reconciliation";
 import { getTaskSimpleModeCapabilities, type TaskSimpleMode } from "./simple-mode";
+import {
+	captureTaskSourceRevision,
+	isReviewCapableAgent,
+	resolveSourceFreshnessFields,
+	type TaskSourceRevision,
+} from "./source-revision";
 import { DEFAULT_SPAWN_THRESHOLD, evaluateSpawnGate } from "./spawn-gate";
 import {
 	applyNestedPatches,
@@ -194,6 +200,17 @@ function repositoryBindingFromTask(task: TaskItem): RepositoryBinding | undefine
 	return task.repositoryBinding ? publicRepositoryBinding(task.repositoryBinding as RepositoryBinding) : undefined;
 }
 
+/** Stamp review-capable results with spawn-time source identity and live freshness (#3469). */
+async function withSourceFreshness(
+	cwd: string,
+	result: SingleResult,
+	reviewed: TaskSourceRevision | undefined,
+): Promise<SingleResult> {
+	if (!reviewed) return result;
+	const fields = await resolveSourceFreshnessFields(cwd, reviewed);
+	return { ...result, ...fields };
+}
+
 function validateTaskIdsForScheduling(tasks: readonly TaskItem[]): string | undefined {
 	const invalid: string[] = [];
 	for (let i = 0; i < tasks.length; i++) {
@@ -225,6 +242,15 @@ export {
 	findRawTaskLeakKeys,
 	sanitizeTaskToolDetails,
 } from "./receipt";
+export type { TaskSourceRevision, TaskSourceStatus } from "./source-revision";
+export {
+	captureTaskSourceRevision,
+	classifyTaskSourceFreshness,
+	isReviewCapableAgent,
+	resolveSourceFreshnessFields,
+	STALE_SOURCE_GUIDANCE,
+	sourceRevisionsEqual,
+} from "./source-revision";
 export type {
 	AgentDefinition,
 	AgentProgress,
@@ -945,6 +971,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			});
 		};
 		const frozenForkSeeds = new Map<string, ForkContextSeed>();
+		// Bind review-capable detached jobs to the worktree identity at spawn (#3469).
+		const frozenSourceRevisions = new Map<string, TaskSourceRevision>();
 
 		for (let i = 0; i < taskItems.length; i++) {
 			const taskItem = taskItems[i];
@@ -969,6 +997,11 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				break;
 			}
 			if (frozenForkSeed) frozenForkSeeds.set(uniqueId, frozenForkSeed);
+			// Bind review-capable detached jobs to the worktree identity at spawn (#3469).
+			const spawnSourceRevision = isReviewCapableAgent(params.agent, fallbackAgentSource)
+				? await captureTaskSourceRevision(this.session.cwd)
+				: undefined;
+			if (spawnSourceRevision) frozenSourceRevisions.set(uniqueId, spawnSourceRevision);
 			const singleParams: TaskParams = { ...params, tasks: [taskItem] };
 			const label = uniqueId;
 			try {
@@ -1014,6 +1047,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 										effectiveArtifactsDir: batchArtifactsDir,
 										parentArtifactManager: asyncParentArtifactManager,
 									},
+									sourceRevisions: frozenSourceRevisions,
 								},
 							);
 							const finalText = result.content.find(part => part.type === "text")?.text ?? "(no output)";
@@ -1103,6 +1137,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								description: taskItem.description,
 								assignment: taskItem.assignment.trim(),
 							},
+							...(spawnSourceRevision ? { sourceRevision: spawnSourceRevision } : {}),
 						},
 						onProgress: (text, details) => {
 							const progressDetails =
@@ -1230,6 +1265,11 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			 * against a single child's receipts.
 			 */
 			suppressRoiReconciliation?: boolean;
+			/**
+			 * Spawn-time source snapshots for review-capable tasks (#3469).
+			 * Keyed by allocated task id; omitted entries are captured at run start.
+			 */
+			sourceRevisions?: ReadonlyMap<string, TaskSourceRevision>;
 		},
 	): Promise<AgentToolResult<TaskToolDetails>> {
 		const startTime = Date.now();
@@ -1662,6 +1702,13 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					recommendedMode: advisory.recommendedMode,
 					reasons: advisory.reasons,
 				};
+				// Capture source identity at spawn/run-start for review-capable agents (#3469).
+				const sourceRevision = isReviewCapableAgent(agentName, agent.source)
+					? (executionOverrides?.sourceRevisions?.get(task.id) ??
+						(await captureTaskSourceRevision(this.session.cwd)))
+					: undefined;
+				const finish = (result: SingleResult): Promise<SingleResult> =>
+					withSourceFreshness(this.session.cwd, result, sourceRevision);
 				const managedPersistence = parentArtifactManager?.getManagedStore()
 					? createManagedTaskPersistence(parentArtifactManager, task.id)
 					: undefined;
@@ -1727,12 +1774,12 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						parentTelemetry: this.session.getTelemetry?.(),
 						forkContextSeed,
 					});
-					return {
+					return finish({
 						...result,
 						...(forkContext ? { forkContext } : {}),
 						forkContextAdvisory,
 						repositoryBinding: publicRepositoryBinding(taskRepositoryBinding),
-					};
+					});
 				}
 
 				const taskStart = Date.now();
@@ -1828,18 +1875,18 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								commitMsg,
 							);
 							const producedChanges = Boolean(commitResult?.branchName || commitResult?.nestedPatches.length);
-							return {
+							return finish({
 								...resultWithForkContext,
 								branchName: commitResult?.branchName,
 								nestedPatches: commitResult?.nestedPatches,
 								producedChanges,
-							};
+							});
 						} catch (mergeErr) {
 							// Agent succeeded but branch commit failed — clean up stale branch
 							const branchName = `gjc/task/${task.id}`;
 							await git.branch.tryDelete(repoRoot, branchName);
 							const msg = mergeErr instanceof Error ? mergeErr.message : String(mergeErr);
-							return { ...resultWithForkContext, error: `Merge failed: ${msg}` };
+							return finish({ ...resultWithForkContext, error: `Merge failed: ${msg}` });
 						}
 					}
 					if (resultWithForkContext.exitCode === 0) {
@@ -1855,22 +1902,22 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 							await Bun.write(patchPath, delta.rootPatch);
 							isolatedPatchBytes.set(patchPath, Buffer.from(delta.rootPatch, "utf8"));
 							const producedChanges = Boolean(delta.rootPatch.trim() || delta.nestedPatches.length);
-							return {
+							return finish({
 								...resultWithForkContext,
 								patchPath,
 								nestedPatches: delta.nestedPatches,
 								producedChanges,
-							};
+							});
 						} catch (patchErr) {
 							const msg = patchErr instanceof Error ? patchErr.message : String(patchErr);
-							return { ...resultWithForkContext, error: `Patch capture failed: ${msg}` };
+							return finish({ ...resultWithForkContext, error: `Patch capture failed: ${msg}` });
 						}
 					}
-					return resultWithForkContext;
+					return finish(resultWithForkContext);
 				} catch (err) {
 					const message = err instanceof Error ? err.message : String(err);
 					const assignment = task.assignment.trim();
-					return {
+					return finish({
 						index,
 						id: task.id,
 						agent: agent.name,
@@ -1887,7 +1934,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						modelOverride,
 						forkContext,
 						error: message,
-					};
+					});
 				} finally {
 					if (isolationHandle) {
 						await cleanupIsolation(isolationHandle);

--- a/packages/coding-agent/src/task/receipt.ts
+++ b/packages/coding-agent/src/task/receipt.ts
@@ -1,3 +1,4 @@
+import type { TaskSourceRevision, TaskSourceStatus } from "./source-revision";
 import {
 	hasCompleteUsageCostBreakdown,
 	type ReviewFindingsArtifactRef,
@@ -66,6 +67,14 @@ export interface TaskResultReceipt {
 	forkContextAdvisory?: SingleResult["forkContextAdvisory"];
 	/** Resolved repository identity for this delegated lane (#2901). */
 	repositoryBinding?: SingleResult["repositoryBinding"];
+	/**
+	 * Source worktree identity captured when a review-capable task was spawned (#3469).
+	 * Omitted for ordinary executor tasks. When `sourceStatus` is `"stale"`, results
+	 * are advisory only and must not satisfy completion gates.
+	 */
+	sourceRevision?: TaskSourceRevision;
+	sourceStatus?: TaskSourceStatus;
+	sourceGuidance?: string;
 	roi?: TaskRoi;
 }
 
@@ -119,25 +128,26 @@ function normalizeReviewFindingSeverity(severity: unknown, priority: unknown): s
 
 function buildSafeSynopsis(raw: SingleResult, outputRef: TaskResultReceipt["outputRef"]): string {
 	const status = getStatus(raw);
+	const stalePrefix = raw.sourceStatus === "stale" ? "STALE source; " : "";
 	if (raw.setupFailure) {
-		return `Task ${status} during setup: ${raw.setupFailure.summary}`;
+		return `${stalePrefix}Task ${status} during setup: ${raw.setupFailure.summary}`;
 	}
 	if (raw.modelSubstitutionWarning) {
-		return `Task ${status}; requested model substituted from ${raw.modelSubstitutionWarning.requested} to ${raw.modelSubstitutionWarning.effective}.`;
+		return `${stalePrefix}Task ${status}; requested model substituted from ${raw.modelSubstitutionWarning.requested} to ${raw.modelSubstitutionWarning.effective}.`;
 	}
 	if (raw.retryFailure) {
-		return `Task ${status}; retry stopped after attempt ${raw.retryFailure.attempt}.`;
+		return `${stalePrefix}Task ${status}; retry stopped after attempt ${raw.retryFailure.attempt}.`;
 	}
 	if (raw.abortReason) {
-		return `Task ${status}; abort reason recorded.`;
+		return `${stalePrefix}Task ${status}; abort reason recorded.`;
 	}
 	if (raw.error) {
-		return `Task ${status}; error recorded.`;
+		return `${stalePrefix}Task ${status}; error recorded.`;
 	}
 	if (outputRef) {
-		return `Task ${status}; output stored in ${outputRef.uri} (${outputRef.lineCount} lines, ${outputRef.sizeBytes} bytes).`;
+		return `${stalePrefix}Task ${status}; output stored in ${outputRef.uri} (${outputRef.lineCount} lines, ${outputRef.sizeBytes} bytes).`;
 	}
-	return `Task ${status}; output artifact unavailable.`;
+	return `${stalePrefix}Task ${status}; output artifact unavailable.`;
 }
 
 function getStatus(raw: SingleResult): TaskResultReceipt["status"] {
@@ -291,6 +301,9 @@ export function buildTaskReceipt(raw: SingleResult): TaskResultReceipt {
 		forkContext: raw.forkContext,
 		forkContextAdvisory: raw.forkContextAdvisory,
 		repositoryBinding: raw.repositoryBinding,
+		sourceRevision: raw.sourceRevision,
+		sourceStatus: raw.sourceStatus,
+		sourceGuidance: raw.sourceGuidance,
 		roi: buildTaskRoi(raw),
 	};
 }

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -885,9 +885,16 @@ function renderAgentResult(result: TaskResultReceipt, isLast: boolean, expanded:
 	if (result.truncated || result.previewTruncated) {
 		statusLine += ` ${theme.fg("warning", "[truncated]")}`;
 	}
+	if (result.sourceStatus === "stale") {
+		statusLine += ` ${theme.fg("warning", "[STALE]")}`;
+	}
 	lines.push(statusLine);
 
 	lines.push(...renderTaskSection(result.assignment ?? result.task, continuePrefix, expanded, theme));
+
+	if (result.sourceStatus === "stale" && result.sourceGuidance) {
+		lines.push(`${continuePrefix}${theme.fg("warning", truncateToWidth(replaceTabs(result.sourceGuidance), 100))}`);
+	}
 
 	if (result.review) {
 		if (result.review.overallCorrectness) {

--- a/packages/coding-agent/src/task/source-revision.ts
+++ b/packages/coding-agent/src/task/source-revision.ts
@@ -1,0 +1,123 @@
+/**
+ * Source-snapshot fencing for review-capable task results (#3469).
+ *
+ * Detached review subagents must be bound to the worktree identity they
+ * inspected. When the parent advances HEAD or dirties the tree after spawn,
+ * late deliveries are marked stale so completion gates can reject them.
+ */
+import { createHash } from "node:crypto";
+import * as git from "../utils/git";
+
+/** Fixed hash used when there is no git worktree (or capture failed closed). */
+export const EMPTY_WORKTREE_DIFF_SHA256 = createHash("sha256").update("").digest("hex");
+
+export type TaskSourceRevision = {
+	/** `git rev-parse HEAD`, or null outside a git checkout. */
+	head: string | null;
+	/** Cheap fingerprint of dirty worktree content relative to HEAD. */
+	worktreeDiffSha256: string;
+	/** ISO-8601 capture timestamp. */
+	capturedAt: string;
+};
+
+export type TaskSourceStatus = "current" | "stale";
+
+export const STALE_SOURCE_GUIDANCE =
+	"Worktree changed since this review started; rerun on the current snapshot. Stale results are advisory only and must not satisfy completion gates.";
+
+/**
+ * True for agents whose results may be treated as review evidence by
+ * orchestrators. Ordinary `executor` implementation tasks omit fencing.
+ */
+export function isReviewCapableAgent(name: string, _agentSource?: string): boolean {
+	const n = name.toLowerCase().trim();
+	if (n === "architect" || n === "critic" || n === "planner") return true;
+	return n.includes("review") || n.includes("qa");
+}
+
+function sha256Hex(material: string): string {
+	return createHash("sha256").update(material).digest("hex");
+}
+
+/**
+ * Build a cheap, content-sensitive fingerprint of the worktree vs HEAD.
+ *
+ * Material:
+ * - `git diff HEAD` (staged + unstaged content vs HEAD)
+ * - `git status --porcelain=v1` (tracked dirty names + untracked names)
+ *
+ * HEAD itself is stored separately so a clean checkout still detects commits.
+ */
+async function hashWorktreeDiff(cwd: string): Promise<string> {
+	const [diffText, statusText] = await Promise.all([
+		git.diff(cwd, { base: "HEAD", allowFailure: true }),
+		git.status(cwd, { porcelainV1: true }).catch(() => ""),
+	]);
+	return sha256Hex(`diff:\n${diffText}\nstatus:\n${statusText}`);
+}
+
+/** Capture the source identity the subagent is about to inspect. */
+export async function captureTaskSourceRevision(cwd: string): Promise<TaskSourceRevision> {
+	const capturedAt = new Date().toISOString();
+	const repository = await git.repo.resolve(cwd);
+	if (!repository) {
+		return {
+			head: null,
+			worktreeDiffSha256: EMPTY_WORKTREE_DIFF_SHA256,
+			capturedAt,
+		};
+	}
+
+	const head = await git.head.sha(cwd);
+	let worktreeDiffSha256 = EMPTY_WORKTREE_DIFF_SHA256;
+	try {
+		worktreeDiffSha256 = await hashWorktreeDiff(cwd);
+	} catch {
+		// Fail closed to empty hash rather than aborting spawn; equality still works.
+		worktreeDiffSha256 = EMPTY_WORKTREE_DIFF_SHA256;
+	}
+
+	return {
+		head,
+		worktreeDiffSha256,
+		capturedAt,
+	};
+}
+
+/** Structural equality of two captured revisions (ignores capturedAt). */
+export function sourceRevisionsEqual(a: TaskSourceRevision, b: TaskSourceRevision): boolean {
+	return a.head === b.head && a.worktreeDiffSha256 === b.worktreeDiffSha256;
+}
+
+/**
+ * Recompute the live worktree fingerprint and compare against the reviewed
+ * snapshot. Returns `"stale"` when HEAD or dirty content diverged.
+ */
+export async function classifyTaskSourceFreshness(
+	cwd: string,
+	reviewed: TaskSourceRevision,
+): Promise<TaskSourceStatus> {
+	const current = await captureTaskSourceRevision(cwd);
+	return sourceRevisionsEqual(reviewed, current) ? "current" : "stale";
+}
+
+/**
+ * Attach reviewed snapshot + live freshness fields for a completed result.
+ * Returns an empty object when no reviewed revision was captured (non-review agents).
+ */
+export async function resolveSourceFreshnessFields(
+	cwd: string,
+	reviewed: TaskSourceRevision | undefined,
+): Promise<{
+	sourceRevision?: TaskSourceRevision;
+	sourceStatus?: TaskSourceStatus;
+	sourceGuidance?: string;
+}> {
+	if (!reviewed) return {};
+	const sourceStatus = await classifyTaskSourceFreshness(cwd, reviewed);
+	return {
+		sourceRevision: reviewed,
+		sourceStatus,
+		...(sourceStatus === "stale" ? { sourceGuidance: STALE_SOURCE_GUIDANCE } : {}),
+	};
+}

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -6,6 +6,7 @@ import { isValidTaskId, TASK_ID_DESCRIPTION } from "./id";
 import type { TaskResultReceipt } from "./receipt";
 import type { SpawnRoiReconciliation } from "./roi-reconciliation";
 import { getTaskSimpleModeCapabilities, type TaskSimpleMode } from "./simple-mode";
+import type { TaskSourceRevision, TaskSourceStatus } from "./source-revision";
 import type { SpawnPlanReceipt } from "./spawn-gate";
 import type { NestedRepoPatch } from "./worktree";
 
@@ -506,6 +507,18 @@ export interface SingleResult {
 		head?: string;
 		branch?: string;
 	};
+	/**
+	 * Worktree identity captured when a review-capable task was spawned (#3469).
+	 * Omitted for ordinary executor implementation tasks.
+	 */
+	sourceRevision?: TaskSourceRevision;
+	/**
+	 * Freshness of `sourceRevision` vs the parent worktree at delivery time.
+	 * `"stale"` means the tree advanced after the review started; results are advisory only.
+	 */
+	sourceStatus?: TaskSourceStatus;
+	/** Human guidance when `sourceStatus` is `"stale"`. */
+	sourceGuidance?: string;
 }
 
 /** True only for complete, factual five-bucket cost accounting. */

--- a/packages/coding-agent/test/task/source-revision.test.ts
+++ b/packages/coding-agent/test/task/source-revision.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildTaskReceipt } from "../../src/task/receipt";
+import {
+	captureTaskSourceRevision,
+	classifyTaskSourceFreshness,
+	EMPTY_WORKTREE_DIFF_SHA256,
+	isReviewCapableAgent,
+	resolveSourceFreshnessFields,
+	STALE_SOURCE_GUIDANCE,
+	sourceRevisionsEqual,
+	type TaskSourceRevision,
+} from "../../src/task/source-revision";
+import type { SingleResult } from "../../src/task/types";
+
+const tempDirs: string[] = [];
+
+async function runGit(repo: string, args: string[]): Promise<string> {
+	const proc = Bun.spawn(["git", ...args], {
+		cwd: repo,
+		stderr: "pipe",
+		stdout: "pipe",
+		windowsHide: true,
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	if ((exitCode ?? 0) !== 0) {
+		throw new Error(stderr.trim() || stdout.trim() || `git ${args.join(" ")} failed with exit code ${exitCode ?? 0}`);
+	}
+	return stdout.trim();
+}
+
+async function createGitRepo(): Promise<string> {
+	const repo = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-source-revision-"));
+	tempDirs.push(repo);
+	await runGit(repo, ["init"]);
+	await runGit(repo, ["config", "user.email", "test@example.com"]);
+	await runGit(repo, ["config", "user.name", "Test User"]);
+	await fs.writeFile(path.join(repo, "tracked.txt"), "base content\n");
+	await runGit(repo, ["add", "."]);
+	await runGit(repo, ["commit", "-m", "initial"]);
+	return repo;
+}
+
+function makeRaw(overrides: Partial<SingleResult> = {}): SingleResult {
+	return {
+		index: 0,
+		id: "0-Review",
+		agent: "architect",
+		agentSource: "bundled",
+		task: "review",
+		assignment: "review the tree",
+		description: "review",
+		exitCode: 0,
+		output: "findings",
+		stderr: "",
+		truncated: false,
+		durationMs: 10,
+		tokens: 20,
+		...overrides,
+	};
+}
+
+afterEach(async () => {
+	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("isReviewCapableAgent", () => {
+	it("includes bundled review roles and review/qa names", () => {
+		expect(isReviewCapableAgent("architect")).toBe(true);
+		expect(isReviewCapableAgent("critic")).toBe(true);
+		expect(isReviewCapableAgent("planner")).toBe(true);
+		expect(isReviewCapableAgent("code-reviewer")).toBe(true);
+		expect(isReviewCapableAgent("QA")).toBe(true);
+		expect(isReviewCapableAgent("ultragoal-qa")).toBe(true);
+	});
+
+	it("excludes ordinary executor implementation agents", () => {
+		expect(isReviewCapableAgent("executor")).toBe(false);
+		expect(isReviewCapableAgent("implementer")).toBe(false);
+	});
+});
+
+describe("captureTaskSourceRevision / classifyTaskSourceFreshness", () => {
+	it("capture → equal after no changes → current", async () => {
+		const repo = await createGitRepo();
+		const first = await captureTaskSourceRevision(repo);
+		expect(first.head).toMatch(/^[0-9a-f]{40}$/);
+		expect(first.worktreeDiffSha256).toMatch(/^[0-9a-f]{64}$/);
+		expect(first.capturedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+		const second = await captureTaskSourceRevision(repo);
+		expect(sourceRevisionsEqual(first, second)).toBe(true);
+		expect(await classifyTaskSourceFreshness(repo, first)).toBe("current");
+	});
+
+	it("capture → edit a tracked file → classify stale", async () => {
+		const repo = await createGitRepo();
+		const reviewed = await captureTaskSourceRevision(repo);
+		await fs.writeFile(path.join(repo, "tracked.txt"), "edited content\n");
+		expect(await classifyTaskSourceFreshness(repo, reviewed)).toBe("stale");
+
+		const after = await captureTaskSourceRevision(repo);
+		expect(sourceRevisionsEqual(reviewed, after)).toBe(false);
+		expect(after.worktreeDiffSha256).not.toBe(reviewed.worktreeDiffSha256);
+	});
+
+	it("detects HEAD advancement without dirty worktree as stale", async () => {
+		const repo = await createGitRepo();
+		const reviewed = await captureTaskSourceRevision(repo);
+		await fs.writeFile(path.join(repo, "tracked.txt"), "committed edit\n");
+		await runGit(repo, ["add", "."]);
+		await runGit(repo, ["commit", "-m", "advance head"]);
+		expect(await classifyTaskSourceFreshness(repo, reviewed)).toBe("stale");
+		const after = await captureTaskSourceRevision(repo);
+		expect(after.head).not.toBe(reviewed.head);
+	});
+
+	it("non-git cwd uses null head and fixed empty hash", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-source-revision-nongit-"));
+		tempDirs.push(dir);
+		const revision = await captureTaskSourceRevision(dir);
+		expect(revision.head).toBeNull();
+		expect(revision.worktreeDiffSha256).toBe(EMPTY_WORKTREE_DIFF_SHA256);
+		expect(await classifyTaskSourceFreshness(dir, revision)).toBe("current");
+	});
+});
+
+describe("review receipt source fencing", () => {
+	it("non-review agent receipts omit sourceRevision", () => {
+		const receipt = buildTaskReceipt(makeRaw({ agent: "executor" }));
+		expect(receipt.sourceRevision).toBeUndefined();
+		expect(receipt.sourceStatus).toBeUndefined();
+		expect(receipt.sourceGuidance).toBeUndefined();
+		expect(receipt.preview).not.toContain("STALE");
+	});
+
+	it("review agent receipt includes sourceRevision; late classify is stale after edit", async () => {
+		const repo = await createGitRepo();
+		const reviewed = await captureTaskSourceRevision(repo);
+		await fs.writeFile(path.join(repo, "tracked.txt"), "parent advanced\n");
+
+		const fields = await resolveSourceFreshnessFields(repo, reviewed);
+		expect(fields.sourceStatus).toBe("stale");
+		expect(fields.sourceGuidance).toBe(STALE_SOURCE_GUIDANCE);
+		expect(fields.sourceRevision).toEqual(reviewed);
+
+		const receipt = buildTaskReceipt(
+			makeRaw({
+				agent: "architect",
+				sourceRevision: fields.sourceRevision,
+				sourceStatus: fields.sourceStatus,
+				sourceGuidance: fields.sourceGuidance,
+			}),
+		);
+		expect(receipt.sourceRevision).toEqual(reviewed);
+		expect(receipt.sourceStatus).toBe("stale");
+		expect(receipt.sourceGuidance).toBe(STALE_SOURCE_GUIDANCE);
+		expect(receipt.preview.startsWith("STALE source;")).toBe(true);
+	});
+
+	it("resolveSourceFreshnessFields returns empty when no reviewed snapshot", async () => {
+		const repo = await createGitRepo();
+		expect(await resolveSourceFreshnessFields(repo, undefined)).toEqual({});
+	});
+
+	it("current review receipt keeps sourceRevision without STALE prefix", async () => {
+		const repo = await createGitRepo();
+		const reviewed: TaskSourceRevision = await captureTaskSourceRevision(repo);
+		const fields = await resolveSourceFreshnessFields(repo, reviewed);
+		expect(fields.sourceStatus).toBe("current");
+		expect(fields.sourceGuidance).toBeUndefined();
+
+		const receipt = buildTaskReceipt(
+			makeRaw({
+				sourceRevision: fields.sourceRevision,
+				sourceStatus: fields.sourceStatus,
+			}),
+		);
+		expect(receipt.sourceStatus).toBe("current");
+		expect(receipt.preview).not.toContain("STALE");
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #3469.

Detached review subagents can finish after the parent has moved past the revision they inspected, and their conclusions were still treated as current. This binds review-capable task receipts to an immutable **source revision** snapshot (HEAD + dirty-tree fingerprint) and marks later consumption as stale when the parent worktree no longer matches.

### Behavior
- Capture `sourceRevision` when a review-capable task starts
- Persist it on the task receipt
- Classify freshness on parent-side consumption (`current` vs `stale`)
- Surface stale review output with an explicit STALE signal rather than silently applying a late verdict

### Tests
- `packages/coding-agent/test/task/source-revision.test.ts` (10 pass locally)

## Test plan
- [x] Focused unit tests for capture / classify / receipt fencing
- [ ] Hosted CI green on exact head
- [ ] Manual: start review task, edit a tracked file, confirm late review is marked stale