### PR TITLE
fix(task): keep detached outputs durable for in-memory sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 
 - Provider retry classification prefers the typed `stream_first_event_timeout` transport fact when present, falling back to error-message regex for message-only callers (#3496).
+- Detached task receipts for in-memory parent sessions no longer advertise dead `agent://` output URIs. TaskTool allocates a session-lifetime durable artifact root under the process temp directory, persists child outputs there, authorizes parent and same-session descendants for scoped resolution, and omits the URI entirely when durable allocation fails (#3471).
 - Team Linux worker memory-guard replacement no longer holds the team task-mutation fence across the successor startup-ack wait, so concurrent `worker-startup-ack` can publish and selector-replacement no longer hangs under CI contention.
 - Kitty/Ghostty inline images no longer remain visually pinned when transcript, pinned, or overlay rows are replaced, removed, scrolled, resized, or fully repainted. The TUI now parses only bounded named placements, soft-deletes overwritten placements from the previously committed physical frame, retains transmitted pixels, and restores placements from application scrollback without retransmitting image data.
 - Reviewer `report_finding` evidence is no longer injected into caller-owned strict JTD completion data; full findings are published separately through a bounded artifact reference, and failed evidence publication now fails the task closed (#2893).

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -1623,6 +1623,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				}
 			},
 			getArtifactManager: () => sessionManager.getArtifactManager(),
+			registerSessionCleanup: cleanup => session?.registerToolSessionCleanup(cleanup) ?? (() => {}),
 			settings,
 			authStorage,
 			modelRegistry,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1884,6 +1884,7 @@ export class AgentSession {
 	#providerCacheSessionId: string | undefined;
 	#isDisposed = false;
 	#disposePromise: Promise<void> | undefined;
+	readonly #toolSessionCleanups = new Set<() => Promise<void> | void>();
 	#newSessionTransition: Promise<boolean> | undefined;
 	// Extension system
 	#extensionRunner: ExtensionRunner | undefined = undefined;
@@ -3231,6 +3232,21 @@ export class AgentSession {
 
 	getAgentId(): string | undefined {
 		return this.#agentId;
+	}
+
+	registerToolSessionCleanup(cleanup: () => Promise<void> | void): () => void {
+		if (this.#isDisposed) throw new Error("Cannot register tool cleanup after session disposal has started.");
+		this.#toolSessionCleanups.add(cleanup);
+		return () => this.#toolSessionCleanups.delete(cleanup);
+	}
+
+	async #runToolSessionCleanups(): Promise<void> {
+		const cleanups = Array.from(this.#toolSessionCleanups);
+		this.#toolSessionCleanups.clear();
+		const results = await Promise.allSettled(cleanups.map(async cleanup => await cleanup()));
+		for (const result of results) {
+			if (result.status === "rejected") logger.warn("Tool session cleanup failed", { error: String(result.reason) });
+		}
 	}
 
 	getAsyncJobSnapshot(options?: { recentLimit?: number }): AsyncJobSnapshot | null {
@@ -5565,6 +5581,7 @@ export class AgentSession {
 				AsyncJobManager.setInstance(undefined);
 			}
 		}
+		await this.#runToolSessionCleanups();
 		// Only disconnect the MCP manager THIS session owns (top-level sessions that
 		// connected plugin-bundle MCP servers). Subagents and callers that merely
 		// observe the process-global manager must never tear down a manager they do

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -53,6 +53,7 @@ import {
 	resolveTaskRepositoryBinding,
 } from "../gjc-runtime/repository-binding";
 import { initializeLocalRoot, type LocalProtocolOptions, resolveLocalUrlToPath } from "../internal-urls";
+import { ArtifactManager } from "../session/artifacts";
 import { generateCommitMessage } from "../utils/commit-message-generator";
 import * as git from "../utils/git";
 import { discoverAgents, filterVisibleAgents, getAgent } from "./discovery";
@@ -436,6 +437,14 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	readonly renderResult = renderResult;
 	readonly #discoveredAgents: AgentDefinition[];
 	readonly #blockedAgent: string | undefined;
+	/**
+	 * Session-lifetime durable artifact root for in-memory parents (no session file).
+	 * Allocated once per TaskTool, reused across task batches, never deleted on task return.
+	 */
+	#durableArtifactsDir: string | undefined;
+	#durableArtifactManager: ArtifactManager | undefined;
+	#durableArtifactsEnsurePromise: Promise<string | null> | undefined;
+	#durableArtifactsAuthorizedOnSession = false;
 
 	get parameters(): TaskToolSchemaInstance {
 		const isolationEnabled = this.session.settings.get("task.isolation.mode") !== "none";
@@ -476,6 +485,101 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 
 	#getTaskSimpleMode(): TaskSimpleMode {
 		return this.session.settings.get("task.simple");
+	}
+
+	/**
+	 * Ensure a session-lifetime artifact directory when the parent has no session file.
+	 * Returns null only when durable allocation fails (mkdir error) — callers must not
+	 * advertise agent:// URIs without a successful allocation.
+	 */
+	async #ensureSessionLifetimeArtifacts(): Promise<{ dir: string; manager: ArtifactManager } | null> {
+		if (this.#durableArtifactsDir && this.#durableArtifactManager) {
+			return { dir: this.#durableArtifactsDir, manager: this.#durableArtifactManager };
+		}
+		this.#durableArtifactsEnsurePromise ??= this.#allocateSessionLifetimeArtifacts();
+		const dir = await this.#durableArtifactsEnsurePromise;
+		if (!dir || !this.#durableArtifactManager) return null;
+		return { dir, manager: this.#durableArtifactManager };
+	}
+
+	async #allocateSessionLifetimeArtifacts(): Promise<string | null> {
+		const sessionId = this.session.getSessionId?.()?.trim() || Snowflake.next();
+		const dir = path.join(os.tmpdir(), "gjc-task-session", sessionId);
+		try {
+			await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+		} catch {
+			this.#durableArtifactsDir = undefined;
+			this.#durableArtifactManager = undefined;
+			return null;
+		}
+		this.#durableArtifactsDir = dir;
+		this.#durableArtifactManager = new ArtifactManager(dir);
+		this.#authorizeSessionLifetimeArtifacts(dir, this.#durableArtifactManager);
+		return dir;
+	}
+
+	/**
+	 * Expose the durable root on the parent ToolSession so subsequent parent-side
+	 * tools and same-session descendants can resolve agent:// without registry-wide
+	 * enumeration (#3302 scoped authorization).
+	 */
+	#authorizeSessionLifetimeArtifacts(dir: string, manager: ArtifactManager): void {
+		if (this.#durableArtifactsAuthorizedOnSession) return;
+		this.#durableArtifactsAuthorizedOnSession = true;
+
+		const originalGetArtifactsDir = this.session.getArtifactsDir;
+		const originalGetAuthorizedArtifactsDirs = this.session.getAuthorizedArtifactsDirs;
+		const originalGetArtifactManager = this.session.getArtifactManager;
+
+		this.session.getArtifactsDir = () => originalGetArtifactsDir?.() ?? dir;
+		this.session.getAuthorizedArtifactsDirs = () => {
+			const dirs: string[] = [];
+			const add = (candidate: string | null | undefined) => {
+				if (!candidate) return;
+				const normalized = path.resolve(candidate);
+				if (!dirs.includes(normalized)) dirs.push(normalized);
+			};
+			for (const authorized of originalGetAuthorizedArtifactsDirs?.() ?? []) add(authorized);
+			add(dir);
+			return dirs;
+		};
+		this.session.getArtifactManager = () => originalGetArtifactManager?.() ?? manager;
+
+		// Prefer scanning the durable root for resume uniqueness when the parent
+		// never had a file-backed agent output manager.
+		if (!this.session.agentOutputManager) {
+			this.session.agentOutputManager = new AgentOutputManager(() => this.session.getArtifactsDir?.() ?? null);
+		}
+	}
+
+	/**
+	 * Resolve the effective artifacts directory for this task batch.
+	 * File-backed sessions use the session artifacts path; in-memory parents use
+	 * the session-lifetime durable temp root when allocation succeeds.
+	 */
+	async #resolveEffectiveArtifactsDir(): Promise<{
+		sessionArtifactsDir: string | null;
+		durableArtifactsDir: string | null;
+		effectiveArtifactsDir: string | undefined;
+		parentArtifactManager: ArtifactManager | undefined;
+	}> {
+		const sessionFile = this.session.getSessionFile();
+		const sessionArtifactsDir = sessionFile ? sessionFile.slice(0, -6) : null;
+		if (sessionArtifactsDir) {
+			return {
+				sessionArtifactsDir,
+				durableArtifactsDir: null,
+				effectiveArtifactsDir: sessionArtifactsDir,
+				parentArtifactManager: this.session.getArtifactManager?.() ?? undefined,
+			};
+		}
+		const durable = await this.#ensureSessionLifetimeArtifacts();
+		return {
+			sessionArtifactsDir: null,
+			durableArtifactsDir: durable?.dir ?? null,
+			effectiveArtifactsDir: durable?.dir,
+			parentArtifactManager: this.session.getArtifactManager?.() ?? durable?.manager,
+		};
 	}
 
 	/**
@@ -587,6 +691,27 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				content: [{ type: "text", text: "Subagent background execution is unavailable in this session." }],
 				details: { projectAgentsDir: null, results: [], totalDurationMs: 0 },
 			};
+		}
+
+		// Prefer file-backed session artifacts; otherwise allocate a session-lifetime
+		// durable root so detached outputs remain readable for the parent session.
+		// Resolve before ID allocation so agentOutputManager can scan the durable root.
+		const {
+			effectiveArtifactsDir: batchArtifactsDir,
+			parentArtifactManager: asyncParentArtifactManager,
+		} = await this.#resolveEffectiveArtifactsDir();
+		let externalTaskSessionsDir: string | undefined;
+		if (!batchArtifactsDir) {
+			// Durable allocation failed: keep child session jsonl under local:// only.
+			// Do not advertise agent:// URIs without durable output backing.
+			const asyncLocalOptions: LocalProtocolOptions = {
+				getArtifactsDir: this.session.getArtifactsDir ?? (() => null),
+				isManagedDestination: this.session.isManagedSessionDestination,
+				getSessionId: this.session.getSessionId ?? (() => null),
+			};
+			await initializeLocalRoot(asyncLocalOptions);
+			externalTaskSessionsDir = resolveLocalUrlToPath("local://subagents/sessions", asyncLocalOptions);
+			await fs.mkdir(externalTaskSessionsDir, { recursive: true, mode: 0o700 });
 		}
 
 		const outputManager =
@@ -714,20 +839,6 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			});
 		};
 		const frozenForkSeeds = new Map<string, ForkContextSeed>();
-		const asyncParentArtifactManager = this.session.getArtifactManager?.() ?? undefined;
-		const parentSessionFileForBatch = this.session.getSessionFile();
-		const batchArtifactsDir = parentSessionFileForBatch ? parentSessionFileForBatch.slice(0, -6) : null;
-		let externalTaskSessionsDir: string | undefined;
-		if (!batchArtifactsDir) {
-			const asyncLocalOptions: LocalProtocolOptions = {
-				getArtifactsDir: this.session.getArtifactsDir ?? (() => null),
-				isManagedDestination: this.session.isManagedSessionDestination,
-				getSessionId: this.session.getSessionId ?? (() => null),
-			};
-			await initializeLocalRoot(asyncLocalOptions);
-			externalTaskSessionsDir = resolveLocalUrlToPath("local://subagents/sessions", asyncLocalOptions);
-			await fs.mkdir(externalTaskSessionsDir, { recursive: true, mode: 0o700 });
-		}
 
 		for (let i = 0; i < taskItems.length; i++) {
 			const taskItem = taskItems[i];
@@ -1247,11 +1358,11 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 
 		const preferredIsolationBackend = parseIsolationMode(isolationMode);
 
-		// Derive artifacts directory
-		const sessionFile = this.session.getSessionFile();
-		const artifactsDir = sessionFile ? sessionFile.slice(0, -6) : null;
-		const tempArtifactsDir = artifactsDir ? null : path.join(os.tmpdir(), `gjc-task-${Snowflake.next()}`);
-		const effectiveArtifactsDir = artifactsDir || tempArtifactsDir!;
+		// File-backed session artifacts, or a session-lifetime durable temp root for
+		// in-memory parents. Never use a per-task temp dir that is deleted on return —
+		// advertised agent:// URIs must remain readable for the parent session lifetime.
+		const { effectiveArtifactsDir, parentArtifactManager } = await this.#resolveEffectiveArtifactsDir();
+		const hasDurableOutputBacking = Boolean(effectiveArtifactsDir);
 
 		// Share the parent session's local:// root with subagents so they read/write the same scratch space
 		const localProtocolOptions: LocalProtocolOptions = {
@@ -1260,9 +1371,9 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			getSessionId: this.session.getSessionId ?? (() => null),
 		};
 
-		// Subagents adopt the parent's ArtifactManager so artifact IDs are unique
-		// across the whole tree and outputs land flat in the parent's dir.
-		const parentArtifactManager = this.session.getArtifactManager?.() ?? undefined;
+		// Subagents adopt the parent's ArtifactManager (including session-lifetime
+		// durable managers) so artifact IDs are unique and agent:// resolves under
+		// scoped authorization for the whole tree.
 
 		// Initialize progress tracking
 		const progressMap = new Map<number, AgentProgress>();
@@ -1468,7 +1579,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						thinkingLevel: thinkingLevelOverride,
 						outputSchema: effectiveOutputSchema,
 						sessionFile: taskSessionFile,
-						persistArtifacts: !!artifactsDir,
+						persistArtifacts: hasDurableOutputBacking,
 						artifactsDir: effectiveArtifactsDir,
 						managedPersistence,
 						contextFile: contextFilePath,
@@ -1542,7 +1653,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						thinkingLevel: thinkingLevelOverride,
 						outputSchema: effectiveOutputSchema,
 						sessionFile: taskSessionFile,
-						persistArtifacts: !!artifactsDir,
+						persistArtifacts: hasDurableOutputBacking,
 						artifactsDir: effectiveArtifactsDir,
 						managedPersistence,
 						contextFile: contextFilePath,
@@ -1703,7 +1814,10 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					abortReason: "Cancelled before start",
 				};
 			});
-			if (!artifactsDir) {
+			// Only advertise agent:// when outputs land on durable backing (file-backed
+			// session artifacts or the session-lifetime durable temp root). Ephemeral
+			// or failed allocation must not emit dead URIs (#3471 / #295).
+			if (!hasDurableOutputBacking) {
 				for (const result of results) {
 					delete result.outputMeta;
 					delete result.outputPath;
@@ -1913,12 +2027,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				mergeSummary,
 			});
 
-			// Cleanup temp directory if used
-			const shouldCleanupTempArtifacts =
-				tempArtifactsDir && (!isIsolated || changesApplied === true || changesApplied === null);
-			if (shouldCleanupTempArtifacts) {
-				await fs.rm(tempArtifactsDir, { recursive: true, force: true });
-			}
+			// Session-lifetime durable dirs must outlive this return so parent +
+			// same-session descendants can resolve agent://. Do not rm them here.
 
 			const details: TaskToolDetails = {
 				projectAgentsDir,

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -496,6 +496,14 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		if (this.#durableArtifactsDir && this.#durableArtifactManager) {
 			return { dir: this.#durableArtifactsDir, manager: this.#durableArtifactManager };
 		}
+		const sessionArtifactsDir = this.session.getArtifactsDir?.() ?? null;
+		if (sessionArtifactsDir) {
+			const manager = this.session.getArtifactManager?.() ?? new ArtifactManager(sessionArtifactsDir);
+			this.#durableArtifactsDir = sessionArtifactsDir;
+			this.#durableArtifactManager = manager;
+			this.#authorizeSessionLifetimeArtifacts(sessionArtifactsDir, manager);
+			return { dir: sessionArtifactsDir, manager };
+		}
 		this.#durableArtifactsEnsurePromise ??= this.#allocateSessionLifetimeArtifacts();
 		const dir = await this.#durableArtifactsEnsurePromise;
 		if (!dir || !this.#durableArtifactManager) return null;
@@ -503,10 +511,9 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	}
 
 	async #allocateSessionLifetimeArtifacts(): Promise<string | null> {
-		const sessionId = this.session.getSessionId?.()?.trim() || Snowflake.next();
-		const dir = path.join(os.tmpdir(), "gjc-task-session", sessionId);
+		let dir: string;
 		try {
-			await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+			dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-task-session-"));
 		} catch {
 			this.#durableArtifactsDir = undefined;
 			this.#durableArtifactManager = undefined;

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -12,6 +12,7 @@
  *   - Progress tracking via JSON events
  *   - Session artifacts for debugging
  */
+import { randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import path from "node:path";
@@ -89,6 +90,7 @@ interface TaskResumeDescriptor {
 	params: TaskParams;
 	task: TaskItem & { id: string };
 	sessionFile: string | null;
+	durableOutputAllowed?: boolean;
 	forkContextSeed?: ForkContextSeed;
 	agentSource: AgentDefinition["source"];
 }
@@ -425,6 +427,7 @@ interface SessionLifetimeArtifactsState {
 	dir?: string;
 	manager?: ArtifactManager;
 	ensurePromise?: Promise<string | null>;
+	outputPrefix: string;
 	authorized: boolean;
 	cleanupRegistered: boolean;
 	originalGetArtifactsDir?: ToolSession["getArtifactsDir"];
@@ -442,19 +445,14 @@ const sessionLifetimeArtifacts = new WeakMap<ToolSession, SessionLifetimeArtifac
 function sessionLifetimeArtifactsState(session: ToolSession): SessionLifetimeArtifactsState {
 	let state = sessionLifetimeArtifacts.get(session);
 	if (!state) {
-		state = { authorized: false, cleanupRegistered: false };
+		state = {
+			authorized: false,
+			cleanupRegistered: false,
+			outputPrefix: `0-Session${randomUUID().replaceAll("-", "")}`,
+		};
 		sessionLifetimeArtifacts.set(session, state);
 	}
 	return state;
-}
-
-function sessionLifetimeOutputPrefix(dir: string): string {
-	const suffix = path
-		.basename(dir)
-		.replace(/^gjc-task-session-/, "")
-		.replace(/[^A-Za-z0-9_-]/g, "")
-		.slice(0, 24);
-	return `0-Session${suffix || "Root"}`;
 }
 
 /**
@@ -525,7 +523,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	 */
 	async #ensureSessionLifetimeArtifacts(): Promise<{ dir: string; manager: ArtifactManager } | null> {
 		const state = sessionLifetimeArtifactsState(this.session);
-		if (state.dir && state.manager) return { dir: state.dir, manager: state.manager };
+		if (state.authorized && state.dir && state.manager) return { dir: state.dir, manager: state.manager };
 
 		const sessionArtifactsDir = this.session.getArtifactsDir?.() ?? null;
 		if (sessionArtifactsDir) {
@@ -595,7 +593,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		state.installedGetArtifactManager = () => manager;
 		if (owned || !this.session.agentOutputManager) {
 			state.installedAgentOutputManager = new AgentOutputManager(() => this.session.getArtifactsDir?.() ?? null, {
-				parentPrefix: owned ? sessionLifetimeOutputPrefix(dir) : undefined,
+				parentPrefix: owned ? state.outputPrefix : undefined,
 				getAuthorizedArtifactsDirs: () => this.session.getAuthorizedArtifactsDirs?.() ?? [],
 			});
 		}
@@ -620,18 +618,21 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		if (owned) {
 			const registerCleanup = this.session.registerSessionCleanup;
 			if (!registerCleanup) {
-				await fs.rm(dir, { recursive: true, force: true });
+				state.dir = undefined;
+				state.manager = undefined;
+				state.ensurePromise = undefined;
 				sessionLifetimeArtifacts.delete(this.session);
+				await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
 				return false;
 			}
 			try {
 				registerCleanup(cleanup);
 			} catch {
-				await fs.rm(dir, { recursive: true, force: true });
 				state.dir = undefined;
 				state.manager = undefined;
 				state.ensurePromise = undefined;
 				sessionLifetimeArtifacts.delete(this.session);
+				await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
 				return false;
 			}
 			if (cleanupRan) return false;
@@ -890,6 +891,14 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								resumeMessage: message,
 								sessionFiles: new Map([[descriptor.task.id, descriptor.sessionFile]]),
 								suppressRoiReconciliation: true,
+								...(descriptor.durableOutputAllowed === true
+									? {}
+									: {
+											persistence: {
+												effectiveArtifactsDir: undefined,
+												parentArtifactManager: undefined,
+											},
+										}),
 							},
 						);
 						const finalText = result.content.find(part => part.type === "text")?.text ?? "(no output)";
@@ -1114,6 +1123,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								params,
 								task: { ...taskItem, id: uniqueId },
 								sessionFile: subtaskSessionFile,
+								durableOutputAllowed: Boolean(batchArtifactsDir),
 								forkContextSeed: frozenForkSeed,
 								agentSource: fallbackAgentSource,
 							} satisfies TaskResumeDescriptor,

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -696,10 +696,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		// Prefer file-backed session artifacts; otherwise allocate a session-lifetime
 		// durable root so detached outputs remain readable for the parent session.
 		// Resolve before ID allocation so agentOutputManager can scan the durable root.
-		const {
-			effectiveArtifactsDir: batchArtifactsDir,
-			parentArtifactManager: asyncParentArtifactManager,
-		} = await this.#resolveEffectiveArtifactsDir();
+		const { effectiveArtifactsDir: batchArtifactsDir, parentArtifactManager: asyncParentArtifactManager } =
+			await this.#resolveEffectiveArtifactsDir();
 		let externalTaskSessionsDir: string | undefined;
 		if (!batchArtifactsDir) {
 			// Durable allocation failed: keep child session jsonl under local:// only.

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -421,6 +421,32 @@ export function resolveForkContextMaxTokens(configured: number, model: Model | u
 // ═══════════════════════════════════════════════════════════════════════════
 // Tool Class
 // ═══════════════════════════════════════════════════════════════════════════
+interface SessionLifetimeArtifactsState {
+	dir?: string;
+	manager?: ArtifactManager;
+	ensurePromise?: Promise<string | null>;
+	authorized: boolean;
+	cleanupRegistered: boolean;
+	originalGetArtifactsDir?: ToolSession["getArtifactsDir"];
+	originalGetAuthorizedArtifactsDirs?: ToolSession["getAuthorizedArtifactsDirs"];
+	originalGetArtifactManager?: ToolSession["getArtifactManager"];
+	originalAgentOutputManager?: AgentOutputManager;
+	installedGetArtifactsDir?: ToolSession["getArtifactsDir"];
+	installedGetAuthorizedArtifactsDirs?: ToolSession["getAuthorizedArtifactsDirs"];
+	installedGetArtifactManager?: ToolSession["getArtifactManager"];
+	installedAgentOutputManager?: AgentOutputManager;
+}
+
+const sessionLifetimeArtifacts = new WeakMap<ToolSession, SessionLifetimeArtifactsState>();
+
+function sessionLifetimeArtifactsState(session: ToolSession): SessionLifetimeArtifactsState {
+	let state = sessionLifetimeArtifacts.get(session);
+	if (!state) {
+		state = { authorized: false, cleanupRegistered: false };
+		sessionLifetimeArtifacts.set(session, state);
+	}
+	return state;
+}
 
 /**
  * Task tool - Delegate tasks to specialized agents.
@@ -438,13 +464,9 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	readonly #discoveredAgents: AgentDefinition[];
 	readonly #blockedAgent: string | undefined;
 	/**
-	 * Session-lifetime durable artifact root for in-memory parents (no session file).
-	 * Allocated once per TaskTool, reused across task batches, never deleted on task return.
+	 * Session-lifetime durable artifact state is shared atomically by every
+	 * TaskTool created for the same parent ToolSession.
 	 */
-	#durableArtifactsDir: string | undefined;
-	#durableArtifactManager: ArtifactManager | undefined;
-	#durableArtifactsEnsurePromise: Promise<string | null> | undefined;
-	#durableArtifactsAuthorizedOnSession = false;
 
 	get parameters(): TaskToolSchemaInstance {
 		const isolationEnabled = this.session.settings.get("task.isolation.mode") !== "none";
@@ -493,35 +515,41 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	 * advertise agent:// URIs without a successful allocation.
 	 */
 	async #ensureSessionLifetimeArtifacts(): Promise<{ dir: string; manager: ArtifactManager } | null> {
-		if (this.#durableArtifactsDir && this.#durableArtifactManager) {
-			return { dir: this.#durableArtifactsDir, manager: this.#durableArtifactManager };
-		}
+		const state = sessionLifetimeArtifactsState(this.session);
+		if (state.dir && state.manager) return { dir: state.dir, manager: state.manager };
+
 		const sessionArtifactsDir = this.session.getArtifactsDir?.() ?? null;
 		if (sessionArtifactsDir) {
-			const manager = this.session.getArtifactManager?.() ?? new ArtifactManager(sessionArtifactsDir);
-			this.#durableArtifactsDir = sessionArtifactsDir;
-			this.#durableArtifactManager = manager;
-			this.#authorizeSessionLifetimeArtifacts(sessionArtifactsDir, manager);
+			const existingManager = this.session.getArtifactManager?.() ?? null;
+			if (existingManager && path.resolve(existingManager.dir) !== path.resolve(sessionArtifactsDir)) return null;
+			const manager = existingManager ?? new ArtifactManager(sessionArtifactsDir);
+			state.dir = sessionArtifactsDir;
+			state.manager = manager;
+			this.#authorizeSessionLifetimeArtifacts(state, sessionArtifactsDir, manager, false);
 			return { dir: sessionArtifactsDir, manager };
 		}
-		this.#durableArtifactsEnsurePromise ??= this.#allocateSessionLifetimeArtifacts();
-		const dir = await this.#durableArtifactsEnsurePromise;
-		if (!dir || !this.#durableArtifactManager) return null;
-		return { dir, manager: this.#durableArtifactManager };
+
+		state.ensurePromise ??= this.#allocateSessionLifetimeArtifacts(state);
+		const dir = await state.ensurePromise;
+		if (!dir || !state.manager) {
+			state.ensurePromise = undefined;
+			return null;
+		}
+		return { dir, manager: state.manager };
 	}
 
-	async #allocateSessionLifetimeArtifacts(): Promise<string | null> {
+	async #allocateSessionLifetimeArtifacts(state: SessionLifetimeArtifactsState): Promise<string | null> {
 		let dir: string;
 		try {
 			dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-task-session-"));
 		} catch {
-			this.#durableArtifactsDir = undefined;
-			this.#durableArtifactManager = undefined;
+			state.dir = undefined;
+			state.manager = undefined;
 			return null;
 		}
-		this.#durableArtifactsDir = dir;
-		this.#durableArtifactManager = new ArtifactManager(dir);
-		this.#authorizeSessionLifetimeArtifacts(dir, this.#durableArtifactManager);
+		state.dir = dir;
+		state.manager = new ArtifactManager(dir);
+		this.#authorizeSessionLifetimeArtifacts(state, dir, state.manager, true);
 		return dir;
 	}
 
@@ -530,32 +558,58 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	 * tools and same-session descendants can resolve agent:// without registry-wide
 	 * enumeration (#3302 scoped authorization).
 	 */
-	#authorizeSessionLifetimeArtifacts(dir: string, manager: ArtifactManager): void {
-		if (this.#durableArtifactsAuthorizedOnSession) return;
-		this.#durableArtifactsAuthorizedOnSession = true;
+	#authorizeSessionLifetimeArtifacts(
+		state: SessionLifetimeArtifactsState,
+		dir: string,
+		manager: ArtifactManager,
+		owned: boolean,
+	): void {
+		if (state.authorized) return;
+		state.authorized = true;
+		state.originalGetArtifactsDir = this.session.getArtifactsDir;
+		state.originalGetAuthorizedArtifactsDirs = this.session.getAuthorizedArtifactsDirs;
+		state.originalGetArtifactManager = this.session.getArtifactManager;
+		state.originalAgentOutputManager = this.session.agentOutputManager;
 
-		const originalGetArtifactsDir = this.session.getArtifactsDir;
-		const originalGetAuthorizedArtifactsDirs = this.session.getAuthorizedArtifactsDirs;
-		const originalGetArtifactManager = this.session.getArtifactManager;
-
-		this.session.getArtifactsDir = () => originalGetArtifactsDir?.() ?? dir;
-		this.session.getAuthorizedArtifactsDirs = () => {
+		state.installedGetArtifactsDir = () => state.originalGetArtifactsDir?.() ?? dir;
+		state.installedGetAuthorizedArtifactsDirs = () => {
 			const dirs: string[] = [];
 			const add = (candidate: string | null | undefined) => {
 				if (!candidate) return;
 				const normalized = path.resolve(candidate);
 				if (!dirs.includes(normalized)) dirs.push(normalized);
 			};
-			for (const authorized of originalGetAuthorizedArtifactsDirs?.() ?? []) add(authorized);
+			for (const authorized of state.originalGetAuthorizedArtifactsDirs?.() ?? []) add(authorized);
 			add(dir);
 			return dirs;
 		};
-		this.session.getArtifactManager = () => originalGetArtifactManager?.() ?? manager;
+		state.installedGetArtifactManager = () => state.originalGetArtifactManager?.() ?? manager;
+		this.session.getArtifactsDir = state.installedGetArtifactsDir;
+		this.session.getAuthorizedArtifactsDirs = state.installedGetAuthorizedArtifactsDirs;
+		this.session.getArtifactManager = state.installedGetArtifactManager;
 
-		// Prefer scanning the durable root for resume uniqueness when the parent
-		// never had a file-backed agent output manager.
 		if (!this.session.agentOutputManager) {
-			this.session.agentOutputManager = new AgentOutputManager(() => this.session.getArtifactsDir?.() ?? null);
+			state.installedAgentOutputManager = new AgentOutputManager(() => this.session.getArtifactsDir?.() ?? null);
+			this.session.agentOutputManager = state.installedAgentOutputManager;
+		}
+
+		if (owned && !state.cleanupRegistered && this.session.registerSessionCleanup) {
+			state.cleanupRegistered = true;
+			this.session.registerSessionCleanup(async () => {
+				try {
+					await fs.rm(dir, { recursive: true, force: true });
+				} finally {
+					if (this.session.getArtifactsDir === state.installedGetArtifactsDir)
+						this.session.getArtifactsDir = state.originalGetArtifactsDir;
+					if (this.session.getAuthorizedArtifactsDirs === state.installedGetAuthorizedArtifactsDirs)
+						this.session.getAuthorizedArtifactsDirs = state.originalGetAuthorizedArtifactsDirs;
+					if (this.session.getArtifactManager === state.installedGetArtifactManager)
+						this.session.getArtifactManager = state.originalGetArtifactManager;
+					if (this.session.agentOutputManager === state.installedAgentOutputManager)
+						this.session.agentOutputManager = state.originalAgentOutputManager;
+					sessionLifetimeArtifacts.delete(this.session);
+				}
+			});
 		}
 	}
 

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -528,6 +528,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			this.#authorizeSessionLifetimeArtifacts(state, sessionArtifactsDir, manager, false);
 			return { dir: sessionArtifactsDir, manager };
 		}
+		if (!this.session.registerSessionCleanup) return null;
 
 		state.ensurePromise ??= this.#allocateSessionLifetimeArtifacts(state);
 		const dir = await state.ensurePromise;
@@ -583,13 +584,15 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			add(dir);
 			return dirs;
 		};
-		state.installedGetArtifactManager = () => state.originalGetArtifactManager?.() ?? manager;
+		state.installedGetArtifactManager = () => manager;
 		this.session.getArtifactsDir = state.installedGetArtifactsDir;
 		this.session.getAuthorizedArtifactsDirs = state.installedGetAuthorizedArtifactsDirs;
 		this.session.getArtifactManager = state.installedGetArtifactManager;
 
-		if (!this.session.agentOutputManager) {
-			state.installedAgentOutputManager = new AgentOutputManager(() => this.session.getArtifactsDir?.() ?? null);
+		if (owned || !this.session.agentOutputManager) {
+			state.installedAgentOutputManager = new AgentOutputManager(() => this.session.getArtifactsDir?.() ?? null, {
+				getAuthorizedArtifactsDirs: () => this.session.getAuthorizedArtifactsDirs?.() ?? [],
+			});
 			this.session.agentOutputManager = state.installedAgentOutputManager;
 		}
 
@@ -627,11 +630,16 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const sessionFile = this.session.getSessionFile();
 		const sessionArtifactsDir = sessionFile ? sessionFile.slice(0, -6) : null;
 		if (sessionArtifactsDir) {
+			const candidateManager = this.session.getArtifactManager?.() ?? undefined;
+			const parentArtifactManager =
+				candidateManager && path.resolve(candidateManager.dir) === path.resolve(sessionArtifactsDir)
+					? candidateManager
+					: undefined;
 			return {
 				sessionArtifactsDir,
 				durableArtifactsDir: null,
 				effectiveArtifactsDir: sessionArtifactsDir,
-				parentArtifactManager: this.session.getArtifactManager?.() ?? undefined,
+				parentArtifactManager,
 			};
 		}
 		const durable = await this.#ensureSessionLifetimeArtifacts();
@@ -639,7 +647,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			sessionArtifactsDir: null,
 			durableArtifactsDir: durable?.dir ?? null,
 			effectiveArtifactsDir: durable?.dir,
-			parentArtifactManager: this.session.getArtifactManager?.() ?? durable?.manager,
+			parentArtifactManager: durable?.manager,
 		};
 	}
 

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -448,6 +448,15 @@ function sessionLifetimeArtifactsState(session: ToolSession): SessionLifetimeArt
 	return state;
 }
 
+function sessionLifetimeOutputPrefix(dir: string): string {
+	const suffix = path
+		.basename(dir)
+		.replace(/^gjc-task-session-/, "")
+		.replace(/[^A-Za-z0-9_-]/g, "")
+		.slice(0, 24);
+	return `0-Session${suffix || "Root"}`;
+}
+
 /**
  * Task tool - Delegate tasks to specialized agents.
  *
@@ -525,7 +534,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			const manager = existingManager ?? new ArtifactManager(sessionArtifactsDir);
 			state.dir = sessionArtifactsDir;
 			state.manager = manager;
-			this.#authorizeSessionLifetimeArtifacts(state, sessionArtifactsDir, manager, false);
+			if (!(await this.#authorizeSessionLifetimeArtifacts(state, sessionArtifactsDir, manager, false))) return null;
 			return { dir: sessionArtifactsDir, manager };
 		}
 		if (!this.session.registerSessionCleanup) return null;
@@ -550,7 +559,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		}
 		state.dir = dir;
 		state.manager = new ArtifactManager(dir);
-		this.#authorizeSessionLifetimeArtifacts(state, dir, state.manager, true);
+		if (!(await this.#authorizeSessionLifetimeArtifacts(state, dir, state.manager, true))) return null;
 		return dir;
 	}
 
@@ -559,14 +568,13 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	 * tools and same-session descendants can resolve agent:// without registry-wide
 	 * enumeration (#3302 scoped authorization).
 	 */
-	#authorizeSessionLifetimeArtifacts(
+	async #authorizeSessionLifetimeArtifacts(
 		state: SessionLifetimeArtifactsState,
 		dir: string,
 		manager: ArtifactManager,
 		owned: boolean,
-	): void {
-		if (state.authorized) return;
-		state.authorized = true;
+	): Promise<boolean> {
+		if (state.authorized) return true;
 		state.originalGetArtifactsDir = this.session.getArtifactsDir;
 		state.originalGetAuthorizedArtifactsDirs = this.session.getAuthorizedArtifactsDirs;
 		state.originalGetArtifactManager = this.session.getArtifactManager;
@@ -585,35 +593,57 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			return dirs;
 		};
 		state.installedGetArtifactManager = () => manager;
+		if (owned || !this.session.agentOutputManager) {
+			state.installedAgentOutputManager = new AgentOutputManager(() => this.session.getArtifactsDir?.() ?? null, {
+				parentPrefix: owned ? sessionLifetimeOutputPrefix(dir) : undefined,
+				getAuthorizedArtifactsDirs: () => this.session.getAuthorizedArtifactsDirs?.() ?? [],
+			});
+		}
+
+		let cleanupRan = false;
+		const cleanup = async () => {
+			cleanupRan = true;
+			try {
+				if (owned) await fs.rm(dir, { recursive: true, force: true });
+			} finally {
+				if (this.session.getArtifactsDir === state.installedGetArtifactsDir)
+					this.session.getArtifactsDir = state.originalGetArtifactsDir;
+				if (this.session.getAuthorizedArtifactsDirs === state.installedGetAuthorizedArtifactsDirs)
+					this.session.getAuthorizedArtifactsDirs = state.originalGetAuthorizedArtifactsDirs;
+				if (this.session.getArtifactManager === state.installedGetArtifactManager)
+					this.session.getArtifactManager = state.originalGetArtifactManager;
+				if (this.session.agentOutputManager === state.installedAgentOutputManager)
+					this.session.agentOutputManager = state.originalAgentOutputManager;
+				sessionLifetimeArtifacts.delete(this.session);
+			}
+		};
+		if (owned) {
+			const registerCleanup = this.session.registerSessionCleanup;
+			if (!registerCleanup) {
+				await fs.rm(dir, { recursive: true, force: true });
+				sessionLifetimeArtifacts.delete(this.session);
+				return false;
+			}
+			try {
+				registerCleanup(cleanup);
+			} catch {
+				await fs.rm(dir, { recursive: true, force: true });
+				state.dir = undefined;
+				state.manager = undefined;
+				state.ensurePromise = undefined;
+				sessionLifetimeArtifacts.delete(this.session);
+				return false;
+			}
+			if (cleanupRan) return false;
+			state.cleanupRegistered = true;
+		}
+
+		state.authorized = true;
 		this.session.getArtifactsDir = state.installedGetArtifactsDir;
 		this.session.getAuthorizedArtifactsDirs = state.installedGetAuthorizedArtifactsDirs;
 		this.session.getArtifactManager = state.installedGetArtifactManager;
-
-		if (owned || !this.session.agentOutputManager) {
-			state.installedAgentOutputManager = new AgentOutputManager(() => this.session.getArtifactsDir?.() ?? null, {
-				getAuthorizedArtifactsDirs: () => this.session.getAuthorizedArtifactsDirs?.() ?? [],
-			});
-			this.session.agentOutputManager = state.installedAgentOutputManager;
-		}
-
-		if (owned && !state.cleanupRegistered && this.session.registerSessionCleanup) {
-			state.cleanupRegistered = true;
-			this.session.registerSessionCleanup(async () => {
-				try {
-					await fs.rm(dir, { recursive: true, force: true });
-				} finally {
-					if (this.session.getArtifactsDir === state.installedGetArtifactsDir)
-						this.session.getArtifactsDir = state.originalGetArtifactsDir;
-					if (this.session.getAuthorizedArtifactsDirs === state.installedGetAuthorizedArtifactsDirs)
-						this.session.getAuthorizedArtifactsDirs = state.originalGetAuthorizedArtifactsDirs;
-					if (this.session.getArtifactManager === state.installedGetArtifactManager)
-						this.session.getArtifactManager = state.originalGetArtifactManager;
-					if (this.session.agentOutputManager === state.installedAgentOutputManager)
-						this.session.agentOutputManager = state.originalAgentOutputManager;
-					sessionLifetimeArtifacts.delete(this.session);
-				}
-			});
-		}
+		if (state.installedAgentOutputManager) this.session.agentOutputManager = state.installedAgentOutputManager;
+		return true;
 	}
 
 	/**
@@ -971,6 +1001,10 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								{
 									sessionFiles: new Map([[uniqueId, subtaskSessionFile]]),
 									suppressRoiReconciliation: true,
+									persistence: {
+										effectiveArtifactsDir: batchArtifactsDir,
+										parentArtifactManager: asyncParentArtifactManager,
+									},
 								},
 							);
 							const finalText = result.content.find(part => part.type === "text")?.text ?? "(no output)";
@@ -1176,6 +1210,10 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			runMode?: "initial" | "resume" | "message";
 			resumeMessage?: string;
 			sessionFiles?: ReadonlyMap<string, string | null>;
+			persistence?: {
+				effectiveArtifactsDir: string | undefined;
+				parentArtifactManager: ArtifactManager | undefined;
+			};
 			/**
 			 * Set for per-child async runs: the spawnPlan is carried for gate
 			 * consistency, but batch-level ROI reconciliation must not be computed
@@ -1428,7 +1466,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		// File-backed session artifacts, or a session-lifetime durable temp root for
 		// in-memory parents. Never use a per-task temp dir that is deleted on return —
 		// advertised agent:// URIs must remain readable for the parent session lifetime.
-		const { effectiveArtifactsDir, parentArtifactManager } = await this.#resolveEffectiveArtifactsDir();
+		const { effectiveArtifactsDir, parentArtifactManager } =
+			executionOverrides?.persistence ?? (await this.#resolveEffectiveArtifactsDir());
 		const hasDurableOutputBacking = Boolean(effectiveArtifactsDir);
 
 		// Share the parent session's local:// root with subagents so they read/write the same scratch space

--- a/packages/coding-agent/src/task/output-manager.ts
+++ b/packages/coding-agent/src/task/output-manager.ts
@@ -29,10 +29,15 @@ export class AgentOutputManager {
 	#initPromise: Promise<void> | undefined;
 	readonly #getArtifactsDir: () => string | null;
 	readonly #parentPrefix: string | undefined;
+	readonly #getAuthorizedArtifactsDirs: (() => readonly string[]) | undefined;
 
-	constructor(getArtifactsDir: () => string | null, options?: { parentPrefix?: string }) {
+	constructor(
+		getArtifactsDir: () => string | null,
+		options?: { parentPrefix?: string; getAuthorizedArtifactsDirs?: () => readonly string[] },
+	) {
 		this.#getArtifactsDir = getArtifactsDir;
 		this.#parentPrefix = options?.parentPrefix;
+		this.#getAuthorizedArtifactsDirs = options?.getAuthorizedArtifactsDirs;
 	}
 
 	/**
@@ -53,24 +58,29 @@ export class AgentOutputManager {
 	 * This ensures we don't overwrite outputs when resuming a session.
 	 */
 	async #scanExistingOutputs(): Promise<void> {
-		const dir = this.#getArtifactsDir();
-		if (!dir) return;
-
-		let files: string[];
-		try {
-			files = await fs.readdir(dir);
-		} catch {
-			return; // Directory doesn't exist yet
-		}
+		const dirs: string[] = [];
+		const add = (dir: string | null | undefined) => {
+			if (!dir || dirs.includes(dir)) return;
+			dirs.push(dir);
+		};
+		add(this.#getArtifactsDir());
+		for (const dir of this.#getAuthorizedArtifactsDirs?.() ?? []) add(dir);
+		if (dirs.length === 0) return;
 
 		const pattern = this.#parentPrefix
 			? new RegExp(`^${escapeRegExp(this.#parentPrefix)}\\.(\\d+)-.*\\.${RESERVED_OUTPUT_EXTENSIONS_PATTERN}$`)
 			: new RegExp(`^(\\d+)-.*\\.${RESERVED_OUTPUT_EXTENSIONS_PATTERN}$`);
-
 		let maxId = -1;
-		for (const file of files) {
-			const match = file.match(pattern);
-			if (match) {
+		for (const dir of dirs) {
+			let files: string[];
+			try {
+				files = await fs.readdir(dir);
+			} catch {
+				continue;
+			}
+			for (const file of files) {
+				const match = file.match(pattern);
+				if (!match) continue;
 				const id = Number.parseInt(match[1], 10);
 				if (id > maxId) maxId = id;
 			}

--- a/packages/coding-agent/src/task/receipt.ts
+++ b/packages/coding-agent/src/task/receipt.ts
@@ -45,7 +45,14 @@ export interface TaskResultReceipt {
 	abortSummary?: string;
 	preview: string;
 	previewTruncated: boolean;
-	outputRef?: { uri: string; sizeBytes: number; lineCount: number; sha256?: string };
+	outputRef?: {
+		uri: string;
+		sizeBytes: number;
+		lineCount: number;
+		sha256?: string;
+		/** Output remains readable for the parent session lifetime (and same-session descendants). */
+		durability?: "session";
+	};
 	outputUnavailable?: boolean;
 	review?: {
 		overallCorrectness?: string;
@@ -224,12 +231,15 @@ export function buildTaskRoiSummary(receipts: readonly TaskResultReceipt[]): Tas
 }
 
 export function buildTaskReceipt(raw: SingleResult): TaskResultReceipt {
+	// Receipts only include outputRef when production code kept outputMeta after a
+	// durable write (file-backed session dir or session-lifetime durable root).
 	const outputRef = raw.outputMeta
 		? {
 				uri: `agent://${raw.id}`,
 				sizeBytes: raw.outputMeta.byteSize ?? Buffer.byteLength(raw.output, "utf8"),
 				lineCount: raw.outputMeta.lineCount,
 				sha256: raw.outputMeta.sha256,
+				durability: "session" as const,
 			}
 		: undefined;
 	const preview = buildSafeSynopsis(raw, outputRef);

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -296,6 +296,8 @@ export interface ToolSession {
 	getAuthorizedArtifactsDirs?: () => readonly string[];
 	/** Get the ArtifactManager backing this session (shared across parent + subagents). */
 	getArtifactManager?: () => ArtifactManager | null;
+	/** Register teardown work owned by the current logical session. */
+	registerSessionCleanup?: (cleanup: () => Promise<void> | void) => () => void;
 	/** Allocate a new artifact path and ID for session-scoped truncated output. */
 	allocateOutputArtifact?: (toolType: string) => Promise<{ id?: string; path?: string }>;
 	/** Get session spawns */

--- a/packages/coding-agent/test/task/no-session-output-refs.test.ts
+++ b/packages/coding-agent/test/task/no-session-output-refs.test.ts
@@ -167,7 +167,9 @@ describe("task no-session output refs", () => {
 
 		const artifactsDir = session.getArtifactsDir?.();
 		expect(artifactsDir).toBeTruthy();
-		expect(artifactsDir).toContain(path.join("gjc-task-session", sessionId));
+		expect(path.dirname(artifactsDir!)).toBe(path.resolve(os.tmpdir()));
+		expect(path.basename(artifactsDir!)).toStartWith("gjc-task-session-");
+		expect(artifactsDir).not.toContain(sessionId);
 
 		const outputPath = path.join(artifactsDir!, `${outputId}.md`);
 		expect(await Bun.file(outputPath).exists()).toBe(true);
@@ -203,9 +205,9 @@ describe("task no-session output refs", () => {
 		});
 
 		const session = createSession(null, sessionId);
-		const tool = await TaskTool.create(session);
+		const firstTool = await TaskTool.create(session);
 
-		const firstText = await runDetachedTask(tool, {
+		const firstText = await runDetachedTask(firstTool, {
 			id: "Architect",
 			description: "review code",
 			assignment: "Produce findings.",
@@ -213,6 +215,8 @@ describe("task no-session output refs", () => {
 		const firstUriMatch = firstText.match(/agent:\/\/(\d+-Architect)/);
 		expect(firstUriMatch).toBeTruthy();
 		const firstUri = `agent://${firstUriMatch![1]!}`;
+		const firstArtifactsDir = session.getArtifactsDir?.();
+		expect(firstArtifactsDir).toBeTruthy();
 
 		const prior = await InternalUrlRouter.instance().resolve(firstUri, {
 			cwd: session.cwd,
@@ -220,8 +224,9 @@ describe("task no-session output refs", () => {
 			getAuthorizedArtifactsDirs: () => session.getAuthorizedArtifactsDirs?.() ?? [],
 		});
 		expect(prior.content).toContain(firstOutput);
+		const secondTool = await TaskTool.create(session);
 
-		const secondText = await runDetachedTask(tool, {
+		const secondText = await runDetachedTask(secondTool, {
 			id: "Critic",
 			description: "review prior findings",
 			assignment: `Read ${firstUri} and critique.`,
@@ -232,6 +237,7 @@ describe("task no-session output refs", () => {
 		// Durable root still holds both outputs for same-session descendants
 		const artifactsDir = session.getArtifactsDir?.();
 		expect(artifactsDir).toBeTruthy();
+		expect(artifactsDir).toBe(firstArtifactsDir);
 		expect(await Bun.file(path.join(artifactsDir!, `${firstUriMatch![1]!}.md`)).text()).toContain(firstOutput);
 		expect(await Bun.file(path.join(artifactsDir!, `${secondUriMatch![1]!}.md`)).text()).toContain(secondOutput);
 
@@ -251,23 +257,16 @@ describe("task no-session output refs", () => {
 			createSessionResult(createYieldingSession("output that must not get a dead URI")),
 		);
 
-		const sessionId = `alloc-fail-${Snowflake.next()}`;
-		const blockedArtifactsPath = path.join(os.tmpdir(), "gjc-task-session", sessionId);
-		await fs.mkdir(path.dirname(blockedArtifactsPath), { recursive: true, mode: 0o700 });
-		await Bun.write(blockedArtifactsPath, "blocked");
+		vi.spyOn(fs, "mkdtemp").mockRejectedValue(new Error("EACCES: permission denied"));
 
-		try {
-			const session = createSession(null, sessionId);
-			const tool = await TaskTool.create(session);
-			const resultText = await runDetachedTask(tool);
+		const session = createSession(null, `alloc-fail-${Snowflake.next()}`);
+		const tool = await TaskTool.create(session);
+		const resultText = await runDetachedTask(tool);
 
-			expect(resultText).toContain("Task completed; output artifact unavailable.");
-			expect(resultText).not.toMatch(/agent:\/\/\d+-NoSession/);
-			expect(resultText).not.toContain('ref="agent://');
-			expect(resultText).not.toContain("output stored in agent://");
-			expect(session.getArtifactsDir?.()).toBeNull();
-		} finally {
-			await fs.rm(blockedArtifactsPath, { force: true });
-		}
+		expect(resultText).toContain("Task completed; output artifact unavailable.");
+		expect(resultText).not.toMatch(/agent:\/\/\d+-NoSession/);
+		expect(resultText).not.toContain('ref="agent://');
+		expect(resultText).not.toContain("output stored in agent://");
+		expect(session.getArtifactsDir?.()).toBeNull();
 	});
 });

--- a/packages/coding-agent/test/task/no-session-output-refs.test.ts
+++ b/packages/coding-agent/test/task/no-session-output-refs.test.ts
@@ -362,7 +362,7 @@ describe("task no-session output refs", () => {
 		expect(session.getAuthorizedArtifactsDirs?.() ?? []).toEqual([]);
 	});
 
-	it("omits dead URIs after allocation failure and retries a later batch", async () => {
+	it("keeps a failed-allocation child and its resume non-durable, then retries a later batch", async () => {
 		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({ agents: [TEST_AGENT], projectAgentsDir: null });
 		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(
 			createSessionResult(createYieldingSession("output that must remain durable")),
@@ -371,15 +371,39 @@ describe("task no-session output refs", () => {
 
 		const session = createSession(null, `alloc-fail-${Snowflake.next()}`);
 		const tool = await TaskTool.create(session);
-		const failedText = await runDetachedTask(tool);
+		const manager = new AsyncJobManager({ onJobComplete: async () => {} });
+		AsyncJobManager.setInstance(manager);
+		const execute = async () => {
+			const started = await tool.execute("tool-call", {
+				agent: "executor",
+				tasks: [{ id: "NoSession", description: "produce output", assignment: "Return a result." }],
+			} as TaskParams);
+			const jobId = started.details?.async?.jobId;
+			if (!jobId) throw new Error("Expected detached task job id");
+			await manager.waitForAll();
+			return manager.getJob(jobId)?.resultText ?? "";
+		};
+
+		const failedText = await execute();
 		expect(failedText).toContain("Task completed; output artifact unavailable.");
 		expect(matchAgentOutputId(failedText, "NoSession")).toBeNull();
 		expect(session.getArtifactsDir?.()).toBeNull();
 
-		const retriedText = await runDetachedTask(tool);
+		const record = manager.getSubagentRecords()[0];
+		expect(record?.resumable).toBe(true);
+		const resumed = manager.resumeSubagent(record!.subagentId, undefined, "continue");
+		expect(resumed.ok).toBe(true);
+		await manager.waitForAll();
+		const resumedText = manager.getJob(resumed.jobId!)?.resultText ?? "";
+		expect(resumedText).toContain("Task completed; output artifact unavailable.");
+		expect(matchAgentOutputId(resumedText, record!.subagentId)).toBeNull();
+		expect(session.getArtifactsDir?.()).toBeNull();
+
+		const retriedText = await execute();
 		expect(matchAgentOutputId(retriedText, "NoSession")).toBeTruthy();
 		const artifactsDir = session.getArtifactsDir?.();
 		expect(artifactsDir).toBeTruthy();
+		await manager.dispose({ timeoutMs: 100 });
 		await session.disposeSession();
 		expect(await Bun.file(artifactsDir!).exists()).toBe(false);
 	});

--- a/packages/coding-agent/test/task/no-session-output-refs.test.ts
+++ b/packages/coding-agent/test/task/no-session-output-refs.test.ts
@@ -149,7 +149,9 @@ describe("task no-session output refs", () => {
 		const childOutput = "child full output that must remain readable after task return";
 		const sessionId = `durable-read-${Snowflake.next()}`;
 		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({ agents: [TEST_AGENT], projectAgentsDir: null });
-		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(createYieldingSession(childOutput)));
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(
+			createSessionResult(createYieldingSession(childOutput)),
+		);
 
 		const session = createSession(null, sessionId);
 		const tool = await TaskTool.create(session);
@@ -251,7 +253,10 @@ describe("task no-session output refs", () => {
 		const realMkdir = fs.mkdir.bind(fs);
 		vi.spyOn(fs, "mkdir").mockImplementation(async (dirPath, options) => {
 			const target = String(dirPath);
-			if (target.includes(`${path.sep}gjc-task-session${path.sep}`) || target.endsWith(`${path.sep}gjc-task-session`)) {
+			if (
+				target.includes(`${path.sep}gjc-task-session${path.sep}`) ||
+				target.endsWith(`${path.sep}gjc-task-session`)
+			) {
 				throw new Error("EACCES: permission denied");
 			}
 			return realMkdir(dirPath, options as { recursive?: boolean; mode?: number });

--- a/packages/coding-agent/test/task/no-session-output-refs.test.ts
+++ b/packages/coding-agent/test/task/no-session-output-refs.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import * as path from "node:path";
 import type { Message } from "@gajae-code/ai";
 import { Snowflake } from "@gajae-code/utils";
@@ -250,26 +251,23 @@ describe("task no-session output refs", () => {
 			createSessionResult(createYieldingSession("output that must not get a dead URI")),
 		);
 
-		const realMkdir = fs.mkdir.bind(fs);
-		vi.spyOn(fs, "mkdir").mockImplementation(async (dirPath, options) => {
-			const target = String(dirPath);
-			if (
-				target.includes(`${path.sep}gjc-task-session${path.sep}`) ||
-				target.endsWith(`${path.sep}gjc-task-session`)
-			) {
-				throw new Error("EACCES: permission denied");
-			}
-			return realMkdir(dirPath, options as { recursive?: boolean; mode?: number });
-		});
+		const sessionId = `alloc-fail-${Snowflake.next()}`;
+		const blockedArtifactsPath = path.join(os.tmpdir(), "gjc-task-session", sessionId);
+		await fs.mkdir(path.dirname(blockedArtifactsPath), { recursive: true, mode: 0o700 });
+		await Bun.write(blockedArtifactsPath, "blocked");
 
-		const session = createSession(null, `alloc-fail-${Snowflake.next()}`);
-		const tool = await TaskTool.create(session);
-		const resultText = await runDetachedTask(tool);
+		try {
+			const session = createSession(null, sessionId);
+			const tool = await TaskTool.create(session);
+			const resultText = await runDetachedTask(tool);
 
-		expect(resultText).toContain("Task completed; output artifact unavailable.");
-		expect(resultText).not.toMatch(/agent:\/\/\d+-NoSession/);
-		expect(resultText).not.toContain('ref="agent://');
-		expect(resultText).not.toContain("output stored in agent://");
-		expect(session.getArtifactsDir?.()).toBeNull();
+			expect(resultText).toContain("Task completed; output artifact unavailable.");
+			expect(resultText).not.toMatch(/agent:\/\/\d+-NoSession/);
+			expect(resultText).not.toContain('ref="agent://');
+			expect(resultText).not.toContain("output stored in agent://");
+			expect(session.getArtifactsDir?.()).toBeNull();
+		} finally {
+			await fs.rm(blockedArtifactsPath, { force: true });
+		}
 	});
 });

--- a/packages/coding-agent/test/task/no-session-output-refs.test.ts
+++ b/packages/coding-agent/test/task/no-session-output-refs.test.ts
@@ -96,7 +96,10 @@ function createYieldingSession(output: string): AgentSession {
 	} as unknown as AgentSession;
 }
 
-function createSession(sessionFile: string | null, sessionId = "test-in-memory-session"): ToolSession {
+type TestToolSession = ToolSession & { disposeSession: () => Promise<void> };
+
+function createSession(sessionFile: string | null, sessionId = "test-in-memory-session"): TestToolSession {
+	const cleanups = new Set<() => Promise<void> | void>();
 	return {
 		cwd: "/tmp",
 		hasUI: false,
@@ -105,7 +108,16 @@ function createSession(sessionFile: string | null, sessionId = "test-in-memory-s
 		getSessionId: () => sessionId,
 		getArtifactsDir: () => (sessionFile ? sessionFile.slice(0, -6) : null),
 		getSessionSpawns: () => "*",
-	} as unknown as ToolSession;
+		registerSessionCleanup: (cleanup: () => Promise<void> | void) => {
+			cleanups.add(cleanup);
+			return () => cleanups.delete(cleanup);
+		},
+		disposeSession: async () => {
+			const pending = Array.from(cleanups);
+			cleanups.clear();
+			await Promise.all(pending.map(async cleanup => await cleanup()));
+		},
+	} as unknown as TestToolSession;
 }
 
 function createSessionResult(session: AgentSession): CreateAgentSessionResult {
@@ -188,25 +200,25 @@ describe("task no-session output refs", () => {
 		expect(resolved.content).toBe(onDisk);
 		expect(resolved.content).toContain(childOutput);
 
-		// Cleanup durable root allocated for this test session
-		await fs.rm(artifactsDir!, { recursive: true, force: true });
+		await session.disposeSession();
+		expect(await Bun.file(artifactsDir!).exists()).toBe(false);
+		expect(session.getArtifactsDir?.()).toBeNull();
 	});
 
-	it("lets a second detached task resolve the first task's agent:// via the same in-memory parent", async () => {
+	it("shares one root and ID space with authorized descendants but denies foreign trees", async () => {
 		const firstOutput = "architect findings for sibling review";
-		const secondOutput = "critic reviewed prior output";
+		const secondOutput = "architect second-pass output";
 		const sessionId = `sibling-read-${Snowflake.next()}`;
 		let call = 0;
 		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({ agents: [TEST_AGENT], projectAgentsDir: null });
 		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async () => {
 			call += 1;
-			const text = call === 1 ? firstOutput : secondOutput;
-			return createSessionResult(createYieldingSession(text));
+			return createSessionResult(createYieldingSession(call === 1 ? firstOutput : secondOutput));
 		});
 
 		const session = createSession(null, sessionId);
 		const firstTool = await TaskTool.create(session);
-
+		const secondTool = await TaskTool.create(session);
 		const firstText = await runDetachedTask(firstTool, {
 			id: "Architect",
 			description: "review code",
@@ -218,55 +230,64 @@ describe("task no-session output refs", () => {
 		const firstArtifactsDir = session.getArtifactsDir?.();
 		expect(firstArtifactsDir).toBeTruthy();
 
-		const prior = await InternalUrlRouter.instance().resolve(firstUri, {
+		const descendantRead = await InternalUrlRouter.instance().resolve(firstUri, {
 			cwd: session.cwd,
-			getArtifactsDir: () => session.getArtifactsDir?.() ?? null,
+			getArtifactsDir: () => null,
 			getAuthorizedArtifactsDirs: () => session.getAuthorizedArtifactsDirs?.() ?? [],
 		});
-		expect(prior.content).toContain(firstOutput);
-		const secondTool = await TaskTool.create(session);
+		expect(descendantRead.content).toContain(firstOutput);
 
 		const secondText = await runDetachedTask(secondTool, {
-			id: "Critic",
+			id: "Architect",
 			description: "review prior findings",
 			assignment: `Read ${firstUri} and critique.`,
 		});
-		const secondUriMatch = secondText.match(/agent:\/\/(\d+-Critic)/);
+		const secondUriMatch = secondText.match(/agent:\/\/(\d+-Architect)/);
 		expect(secondUriMatch).toBeTruthy();
+		expect(secondUriMatch![1]).not.toBe(firstUriMatch![1]);
+		expect(Number(secondUriMatch![1]!.split("-")[0])).toBeGreaterThan(Number(firstUriMatch![1]!.split("-")[0]));
 
-		// Durable root still holds both outputs for same-session descendants
 		const artifactsDir = session.getArtifactsDir?.();
-		expect(artifactsDir).toBeTruthy();
 		expect(artifactsDir).toBe(firstArtifactsDir);
 		expect(await Bun.file(path.join(artifactsDir!, `${firstUriMatch![1]!}.md`)).text()).toContain(firstOutput);
 		expect(await Bun.file(path.join(artifactsDir!, `${secondUriMatch![1]!}.md`)).text()).toContain(secondOutput);
 
-		const stillReadable = await InternalUrlRouter.instance().resolve(firstUri, {
-			cwd: session.cwd,
-			getArtifactsDir: () => session.getArtifactsDir?.() ?? null,
-			getAuthorizedArtifactsDirs: () => session.getAuthorizedArtifactsDirs?.() ?? [],
-		});
-		expect(stillReadable.content).toContain(firstOutput);
-
-		await fs.rm(artifactsDir!, { recursive: true, force: true });
+		const foreignRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-task-foreign-"));
+		try {
+			await expect(
+				InternalUrlRouter.instance().resolve(firstUri, {
+					cwd: session.cwd,
+					getArtifactsDir: () => foreignRoot,
+					getAuthorizedArtifactsDirs: () => [],
+				}),
+			).rejects.toThrow(`agent://${firstUriMatch![1]!} not found`);
+		} finally {
+			await fs.rm(foreignRoot, { recursive: true, force: true });
+			await session.disposeSession();
+		}
+		expect(await Bun.file(artifactsDir!).exists()).toBe(false);
 	});
 
-	it("does not advertise agent:// when durable artifact allocation fails", async () => {
+	it("omits dead URIs after allocation failure and retries a later batch", async () => {
 		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({ agents: [TEST_AGENT], projectAgentsDir: null });
 		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(
-			createSessionResult(createYieldingSession("output that must not get a dead URI")),
+			createSessionResult(createYieldingSession("output that must remain durable")),
 		);
-
-		vi.spyOn(fs, "mkdtemp").mockRejectedValue(new Error("EACCES: permission denied"));
+		const mkdtempSpy = vi.spyOn(fs, "mkdtemp").mockRejectedValue(new Error("EACCES: permission denied"));
 
 		const session = createSession(null, `alloc-fail-${Snowflake.next()}`);
 		const tool = await TaskTool.create(session);
-		const resultText = await runDetachedTask(tool);
-
-		expect(resultText).toContain("Task completed; output artifact unavailable.");
-		expect(resultText).not.toMatch(/agent:\/\/\d+-NoSession/);
-		expect(resultText).not.toContain('ref="agent://');
-		expect(resultText).not.toContain("output stored in agent://");
+		const failedText = await runDetachedTask(tool);
+		expect(failedText).toContain("Task completed; output artifact unavailable.");
+		expect(failedText).not.toMatch(/agent:\/\/\d+-NoSession/);
 		expect(session.getArtifactsDir?.()).toBeNull();
+		mkdtempSpy.mockRestore();
+
+		const retriedText = await runDetachedTask(tool);
+		expect(retriedText).toMatch(/agent:\/\/\d+-NoSession/);
+		const artifactsDir = session.getArtifactsDir?.();
+		expect(artifactsDir).toBeTruthy();
+		await session.disposeSession();
+		expect(await Bun.file(artifactsDir!).exists()).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/task/no-session-output-refs.test.ts
+++ b/packages/coding-agent/test/task/no-session-output-refs.test.ts
@@ -25,6 +25,14 @@ const TEST_AGENT: AgentDefinition = {
 	tools: ["yield"],
 };
 
+function matchAgentOutputId(text: string, taskId: string): RegExpMatchArray | null {
+	return text.match(new RegExp(`agent://((?:\\d+-[A-Za-z0-9][A-Za-z0-9_-]{0,47}\\.)*\\d+-${taskId})`));
+}
+
+function agentOutputIndex(id: string): number {
+	return Number.parseInt(id.split(".").at(-1)!.split("-")[0]!, 10);
+}
+
 function createAssistantMessage(text: string): Message {
 	return {
 		role: "assistant",
@@ -171,7 +179,7 @@ describe("task no-session output refs", () => {
 		const tool = await TaskTool.create(session);
 		const resultText = await runDetachedTask(tool);
 
-		const uriMatch = resultText.match(/agent:\/\/(\d+-NoSession)/);
+		const uriMatch = matchAgentOutputId(resultText, "NoSession");
 		expect(uriMatch).toBeTruthy();
 		const outputId = uriMatch![1]!;
 		const outputUri = `agent://${outputId}`;
@@ -228,9 +236,9 @@ describe("task no-session output refs", () => {
 			description: "review code",
 			assignment: "Produce findings.",
 		});
-		const firstUriMatch = firstText.match(/agent:\/\/(\d+-Architect)/);
+		const firstUriMatch = matchAgentOutputId(firstText, "Architect");
 		expect(firstUriMatch).toBeTruthy();
-		expect(Number(firstUriMatch![1]!.split("-")[0])).toBe(1);
+		expect(agentOutputIndex(firstUriMatch![1]!)).toBe(0);
 		const firstUri = `agent://${firstUriMatch![1]!}`;
 		const firstArtifactsDir = session.getArtifactsDir?.();
 		expect(firstArtifactsDir).toBeTruthy();
@@ -247,10 +255,10 @@ describe("task no-session output refs", () => {
 			description: "review prior findings",
 			assignment: `Read ${firstUri} and critique.`,
 		});
-		const secondUriMatch = secondText.match(/agent:\/\/(\d+-Architect)/);
+		const secondUriMatch = matchAgentOutputId(secondText, "Architect");
 		expect(secondUriMatch).toBeTruthy();
 		expect(secondUriMatch![1]).not.toBe(firstUriMatch![1]);
-		expect(Number(secondUriMatch![1]!.split("-")[0])).toBeGreaterThan(Number(firstUriMatch![1]!.split("-")[0]));
+		expect(agentOutputIndex(secondUriMatch![1]!)).toBeGreaterThan(agentOutputIndex(firstUriMatch![1]!));
 
 		const artifactsDir = session.getArtifactsDir?.();
 		expect(artifactsDir).toBe(firstArtifactsDir);
@@ -285,7 +293,7 @@ describe("task no-session output refs", () => {
 		session.getArtifactManager = () => foreignManager;
 		const tool = await TaskTool.create(session);
 		const resultText = await runDetachedTask(tool);
-		expect(resultText).toMatch(/agent:\/\/\d+-NoSession/);
+		expect(matchAgentOutputId(resultText, "NoSession")).toBeTruthy();
 		const artifactsDir = session.getArtifactsDir?.();
 		expect(artifactsDir).toBeTruthy();
 		expect(path.resolve(session.getArtifactManager?.()?.dir ?? "")).toBe(path.resolve(artifactsDir!));
@@ -309,23 +317,67 @@ describe("task no-session output refs", () => {
 		expect(session.getArtifactsDir?.()).toBeNull();
 	});
 
+	it("namespaces identical task IDs across independent authorized roots", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({ agents: [TEST_AGENT], projectAgentsDir: null });
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(
+			createSessionResult(createYieldingSession("independent root output")),
+		);
+		const firstSession = createSession(null, `root-a-${Snowflake.next()}`);
+		const secondSession = createSession(null, `root-b-${Snowflake.next()}`);
+		const firstText = await runDetachedTask(await TaskTool.create(firstSession));
+		const secondText = await runDetachedTask(await TaskTool.create(secondSession));
+		const firstId = matchAgentOutputId(firstText, "NoSession")?.[1];
+		const secondId = matchAgentOutputId(secondText, "NoSession")?.[1];
+		expect(firstId).toBeTruthy();
+		expect(secondId).toBeTruthy();
+		expect(firstId).not.toBe(secondId);
+		const roots = [firstSession.getArtifactsDir?.(), secondSession.getArtifactsDir?.()].filter(
+			(root): root is string => Boolean(root),
+		);
+		expect(roots).toHaveLength(2);
+		for (const id of [firstId!, secondId!]) {
+			const resolved = await InternalUrlRouter.instance().resolve(`agent://${id}`, {
+				cwd: "/tmp",
+				getArtifactsDir: () => null,
+				getAuthorizedArtifactsDirs: () => roots,
+			});
+			expect(resolved.content).toContain("independent root output");
+		}
+		await Promise.all([firstSession.disposeSession(), secondSession.disposeSession()]);
+	});
+
+	it("rolls back durable authorization when cleanup registration throws", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({ agents: [TEST_AGENT], projectAgentsDir: null });
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(
+			createSessionResult(createYieldingSession("must not survive cleanup registration failure")),
+		);
+		const session = createSession(null, `cleanup-throw-${Snowflake.next()}`);
+		session.registerSessionCleanup = () => {
+			throw new Error("cleanup registry unavailable");
+		};
+		const resultText = await runDetachedTask(await TaskTool.create(session));
+		expect(resultText).toContain("Task completed; output artifact unavailable.");
+		expect(matchAgentOutputId(resultText, "NoSession")).toBeNull();
+		expect(session.getArtifactsDir?.()).toBeNull();
+		expect(session.getAuthorizedArtifactsDirs?.() ?? []).toEqual([]);
+	});
+
 	it("omits dead URIs after allocation failure and retries a later batch", async () => {
 		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({ agents: [TEST_AGENT], projectAgentsDir: null });
 		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(
 			createSessionResult(createYieldingSession("output that must remain durable")),
 		);
-		const mkdtempSpy = vi.spyOn(fs, "mkdtemp").mockRejectedValue(new Error("EACCES: permission denied"));
+		vi.spyOn(fs, "mkdtemp").mockRejectedValueOnce(new Error("EACCES: permission denied"));
 
 		const session = createSession(null, `alloc-fail-${Snowflake.next()}`);
 		const tool = await TaskTool.create(session);
 		const failedText = await runDetachedTask(tool);
 		expect(failedText).toContain("Task completed; output artifact unavailable.");
-		expect(failedText).not.toMatch(/agent:\/\/\d+-NoSession/);
+		expect(matchAgentOutputId(failedText, "NoSession")).toBeNull();
 		expect(session.getArtifactsDir?.()).toBeNull();
-		mkdtempSpy.mockRestore();
 
 		const retriedText = await runDetachedTask(tool);
-		expect(retriedText).toMatch(/agent:\/\/\d+-NoSession/);
+		expect(matchAgentOutputId(retriedText, "NoSession")).toBeTruthy();
 		const artifactsDir = session.getArtifactsDir?.();
 		expect(artifactsDir).toBeTruthy();
 		await session.disposeSession();

--- a/packages/coding-agent/test/task/no-session-output-refs.test.ts
+++ b/packages/coding-agent/test/task/no-session-output-refs.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import type { Message } from "@gajae-code/ai";
+import { Snowflake } from "@gajae-code/utils";
 import { AsyncJobManager } from "../../src/async";
 import { Settings } from "../../src/config/settings";
+import { InternalUrlRouter } from "../../src/internal-urls";
 import type { CreateAgentSessionResult } from "../../src/sdk";
 import * as sdkModule from "../../src/sdk";
 import type { AgentSession, AgentSessionEvent } from "../../src/session/agent-session";
@@ -72,8 +76,9 @@ function createYieldingSession(output: string): AgentSession {
 				toolCallId: "yield-call",
 				toolName: "yield",
 				result: {
-					content: [{ type: "text", text: "Result submitted." }],
-					details: { status: "success", data: { ok: true } },
+					// Executor finalizes task output from yield details.data when present.
+					content: [{ type: "text", text: output }],
+					details: { status: "success", data: { result: output } },
 				},
 				isError: false,
 			});
@@ -90,12 +95,13 @@ function createYieldingSession(output: string): AgentSession {
 	} as unknown as AgentSession;
 }
 
-function createSession(sessionFile: string | null): ToolSession {
+function createSession(sessionFile: string | null, sessionId = "test-in-memory-session"): ToolSession {
 	return {
 		cwd: "/tmp",
 		hasUI: false,
 		settings: Settings.isolated(),
 		getSessionFile: () => sessionFile,
+		getSessionId: () => sessionId,
 		getArtifactsDir: () => (sessionFile ? sessionFile.slice(0, -6) : null),
 		getSessionSpawns: () => "*",
 	} as unknown as ToolSession;
@@ -110,12 +116,19 @@ function createSessionResult(session: AgentSession): CreateAgentSessionResult {
 	};
 }
 
-async function runDetachedTask(tool: TaskTool): Promise<string> {
+async function runDetachedTask(
+	tool: TaskTool,
+	task: { id: string; description: string; assignment: string } = {
+		id: "NoSession",
+		description: "produce output",
+		assignment: "Return a result.",
+	},
+): Promise<string> {
 	const manager = new AsyncJobManager({ onJobComplete: async () => {} });
 	AsyncJobManager.setInstance(manager);
 	const started = await tool.execute("tool-call", {
 		agent: "executor",
-		tasks: [{ id: "NoSession", description: "produce output", assignment: "Return a result." }],
+		tasks: [task],
 	} as TaskParams);
 	const jobId = started.details?.async?.jobId;
 	if (!jobId) throw new Error("Expected detached task job id");
@@ -128,21 +141,130 @@ async function runDetachedTask(tool: TaskTool): Promise<string> {
 describe("task no-session output refs", () => {
 	afterEach(() => {
 		AsyncJobManager.resetForTests();
+		InternalUrlRouter.resetForTests();
 		vi.restoreAllMocks();
 	});
 
-	it("does not advertise agent:// output refs when the parent has no session artifacts directory", async () => {
+	it("advertises durable agent:// output refs for in-memory parents and keeps them readable", async () => {
+		const childOutput = "child full output that must remain readable after task return";
+		const sessionId = `durable-read-${Snowflake.next()}`;
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({ agents: [TEST_AGENT], projectAgentsDir: null });
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(createYieldingSession(childOutput)));
+
+		const session = createSession(null, sessionId);
+		const tool = await TaskTool.create(session);
+		const resultText = await runDetachedTask(tool);
+
+		const uriMatch = resultText.match(/agent:\/\/(\d+-NoSession)/);
+		expect(uriMatch).toBeTruthy();
+		const outputId = uriMatch![1]!;
+		const outputUri = `agent://${outputId}`;
+		expect(resultText).toContain(`output stored in ${outputUri}`);
+		expect(resultText).not.toContain("Task completed; output artifact unavailable.");
+
+		const artifactsDir = session.getArtifactsDir?.();
+		expect(artifactsDir).toBeTruthy();
+		expect(artifactsDir).toContain(path.join("gjc-task-session", sessionId));
+
+		const outputPath = path.join(artifactsDir!, `${outputId}.md`);
+		expect(await Bun.file(outputPath).exists()).toBe(true);
+		const onDisk = await Bun.file(outputPath).text();
+		// Yield finalization persists JSON-serialized yield data; the distinctive payload must survive.
+		expect(onDisk).toContain(childOutput);
+
+		const authorized = session.getAuthorizedArtifactsDirs?.() ?? [];
+		expect(authorized.some(dir => path.resolve(dir) === path.resolve(artifactsDir!))).toBe(true);
+
+		const resolved = await InternalUrlRouter.instance().resolve(outputUri, {
+			cwd: session.cwd,
+			getArtifactsDir: () => session.getArtifactsDir?.() ?? null,
+			getAuthorizedArtifactsDirs: () => session.getAuthorizedArtifactsDirs?.() ?? [],
+		});
+		expect(resolved.content).toBe(onDisk);
+		expect(resolved.content).toContain(childOutput);
+
+		// Cleanup durable root allocated for this test session
+		await fs.rm(artifactsDir!, { recursive: true, force: true });
+	});
+
+	it("lets a second detached task resolve the first task's agent:// via the same in-memory parent", async () => {
+		const firstOutput = "architect findings for sibling review";
+		const secondOutput = "critic reviewed prior output";
+		const sessionId = `sibling-read-${Snowflake.next()}`;
+		let call = 0;
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({ agents: [TEST_AGENT], projectAgentsDir: null });
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async () => {
+			call += 1;
+			const text = call === 1 ? firstOutput : secondOutput;
+			return createSessionResult(createYieldingSession(text));
+		});
+
+		const session = createSession(null, sessionId);
+		const tool = await TaskTool.create(session);
+
+		const firstText = await runDetachedTask(tool, {
+			id: "Architect",
+			description: "review code",
+			assignment: "Produce findings.",
+		});
+		const firstUriMatch = firstText.match(/agent:\/\/(\d+-Architect)/);
+		expect(firstUriMatch).toBeTruthy();
+		const firstUri = `agent://${firstUriMatch![1]!}`;
+
+		const prior = await InternalUrlRouter.instance().resolve(firstUri, {
+			cwd: session.cwd,
+			getArtifactsDir: () => session.getArtifactsDir?.() ?? null,
+			getAuthorizedArtifactsDirs: () => session.getAuthorizedArtifactsDirs?.() ?? [],
+		});
+		expect(prior.content).toContain(firstOutput);
+
+		const secondText = await runDetachedTask(tool, {
+			id: "Critic",
+			description: "review prior findings",
+			assignment: `Read ${firstUri} and critique.`,
+		});
+		const secondUriMatch = secondText.match(/agent:\/\/(\d+-Critic)/);
+		expect(secondUriMatch).toBeTruthy();
+
+		// Durable root still holds both outputs for same-session descendants
+		const artifactsDir = session.getArtifactsDir?.();
+		expect(artifactsDir).toBeTruthy();
+		expect(await Bun.file(path.join(artifactsDir!, `${firstUriMatch![1]!}.md`)).text()).toContain(firstOutput);
+		expect(await Bun.file(path.join(artifactsDir!, `${secondUriMatch![1]!}.md`)).text()).toContain(secondOutput);
+
+		const stillReadable = await InternalUrlRouter.instance().resolve(firstUri, {
+			cwd: session.cwd,
+			getArtifactsDir: () => session.getArtifactsDir?.() ?? null,
+			getAuthorizedArtifactsDirs: () => session.getAuthorizedArtifactsDirs?.() ?? [],
+		});
+		expect(stillReadable.content).toContain(firstOutput);
+
+		await fs.rm(artifactsDir!, { recursive: true, force: true });
+	});
+
+	it("does not advertise agent:// when durable artifact allocation fails", async () => {
 		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({ agents: [TEST_AGENT], projectAgentsDir: null });
 		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(
-			createSessionResult(createYieldingSession("child full output that would otherwise be in an artifact")),
+			createSessionResult(createYieldingSession("output that must not get a dead URI")),
 		);
 
-		const tool = await TaskTool.create(createSession(null));
+		const realMkdir = fs.mkdir.bind(fs);
+		vi.spyOn(fs, "mkdir").mockImplementation(async (dirPath, options) => {
+			const target = String(dirPath);
+			if (target.includes(`${path.sep}gjc-task-session${path.sep}`) || target.endsWith(`${path.sep}gjc-task-session`)) {
+				throw new Error("EACCES: permission denied");
+			}
+			return realMkdir(dirPath, options as { recursive?: boolean; mode?: number });
+		});
+
+		const session = createSession(null, `alloc-fail-${Snowflake.next()}`);
+		const tool = await TaskTool.create(session);
 		const resultText = await runDetachedTask(tool);
 
 		expect(resultText).toContain("Task completed; output artifact unavailable.");
-		expect(resultText).not.toContain("agent://0-NoSession");
+		expect(resultText).not.toMatch(/agent:\/\/\d+-NoSession/);
 		expect(resultText).not.toContain('ref="agent://');
 		expect(resultText).not.toContain("output stored in agent://");
+		expect(session.getArtifactsDir?.()).toBeNull();
 	});
 });

--- a/packages/coding-agent/test/task/no-session-output-refs.test.ts
+++ b/packages/coding-agent/test/task/no-session-output-refs.test.ts
@@ -10,6 +10,7 @@ import { InternalUrlRouter } from "../../src/internal-urls";
 import type { CreateAgentSessionResult } from "../../src/sdk";
 import * as sdkModule from "../../src/sdk";
 import type { AgentSession, AgentSessionEvent } from "../../src/session/agent-session";
+import { ArtifactManager } from "../../src/session/artifacts";
 import { TaskTool } from "../../src/task";
 import * as discoveryModule from "../../src/task/discovery";
 import type { AgentDefinition, TaskParams } from "../../src/task/types";
@@ -217,6 +218,9 @@ describe("task no-session output refs", () => {
 		});
 
 		const session = createSession(null, sessionId);
+		const priorAuthorizedRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-task-prior-authorized-"));
+		await Bun.write(path.join(priorAuthorizedRoot, "0-Historical.md"), "historical output");
+		session.getAuthorizedArtifactsDirs = () => [priorAuthorizedRoot];
 		const firstTool = await TaskTool.create(session);
 		const secondTool = await TaskTool.create(session);
 		const firstText = await runDetachedTask(firstTool, {
@@ -226,6 +230,7 @@ describe("task no-session output refs", () => {
 		});
 		const firstUriMatch = firstText.match(/agent:\/\/(\d+-Architect)/);
 		expect(firstUriMatch).toBeTruthy();
+		expect(Number(firstUriMatch![1]!.split("-")[0])).toBe(1);
 		const firstUri = `agent://${firstUriMatch![1]!}`;
 		const firstArtifactsDir = session.getArtifactsDir?.();
 		expect(firstArtifactsDir).toBeTruthy();
@@ -264,8 +269,44 @@ describe("task no-session output refs", () => {
 		} finally {
 			await fs.rm(foreignRoot, { recursive: true, force: true });
 			await session.disposeSession();
+			await fs.rm(priorAuthorizedRoot, { recursive: true, force: true });
 		}
 		expect(await Bun.file(artifactsDir!).exists()).toBe(false);
+	});
+
+	it("adopts its owned manager instead of a foreign manager without a primary root", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({ agents: [TEST_AGENT], projectAgentsDir: null });
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(
+			createSessionResult(createYieldingSession("owned manager output")),
+		);
+		const foreignRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-task-foreign-manager-"));
+		const foreignManager = new ArtifactManager(foreignRoot);
+		const session = createSession(null, `foreign-manager-${Snowflake.next()}`);
+		session.getArtifactManager = () => foreignManager;
+		const tool = await TaskTool.create(session);
+		const resultText = await runDetachedTask(tool);
+		expect(resultText).toMatch(/agent:\/\/\d+-NoSession/);
+		const artifactsDir = session.getArtifactsDir?.();
+		expect(artifactsDir).toBeTruthy();
+		expect(path.resolve(session.getArtifactManager?.()?.dir ?? "")).toBe(path.resolve(artifactsDir!));
+		expect((await fs.readdir(foreignRoot)).filter(name => name.endsWith(".md"))).toHaveLength(0);
+		await session.disposeSession();
+		expect(session.getArtifactManager?.()).toBe(foreignManager);
+		await fs.rm(foreignRoot, { recursive: true, force: true });
+	});
+
+	it("does not allocate durable output when session cleanup is unavailable", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({ agents: [TEST_AGENT], projectAgentsDir: null });
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(
+			createSessionResult(createYieldingSession("must remain unavailable")),
+		);
+		const session = createSession(null, `no-cleanup-${Snowflake.next()}`);
+		session.registerSessionCleanup = undefined;
+		const tool = await TaskTool.create(session);
+		const resultText = await runDetachedTask(tool);
+		expect(resultText).toContain("Task completed; output artifact unavailable.");
+		expect(resultText).not.toContain("agent://");
+		expect(session.getArtifactsDir?.()).toBeNull();
 	});
 
 	it("omits dead URIs after allocation failure and retries a later batch", async () => {

--- a/packages/coding-agent/test/task/receipt.test.ts
+++ b/packages/coding-agent/test/task/receipt.test.ts
@@ -93,6 +93,7 @@ describe("task result receipts", () => {
 			sizeBytes: Buffer.byteLength(output),
 			lineCount: output.split("\n").length,
 			sha256,
+			durability: "session",
 		});
 		expect(receipt.outputUnavailable).toBeUndefined();
 		expect(receipt.review?.overallCorrectness).toBe("patch is correct");


### PR DESCRIPTION
## Summary

Fixes #3471.

Detached tasks under in-memory parents could advertise `agent://` output URIs that later resolve as unavailable because no session file (and therefore no durable artifact root) existed. This allocates a **session-lifetime task artifact root** when the parent has no session file, persists detached outputs there, authorizes parent/sibling `agent://` resolution without registry-wide enumeration, and omits URIs when durable allocation fails.

### Behavior
- In-memory parents get a durable artifact root for detached task outputs
- Advertised `agent://` refs remain readable to the parent and sibling detached tasks
- If durable allocation fails, do not advertise unusable URIs

### Tests
- `packages/coding-agent/test/task/no-session-output-refs.test.ts`
- `packages/coding-agent/test/task/receipt.test.ts`  
  (23 pass locally)

## Test plan
- [x] Focused unit tests for in-memory durable refs / fail-closed omission
- [ ] Hosted CI green on exact head
- [ ] Manual: spawn detached task from in-memory parent, resolve advertised agent:// from parent