### PR TITLE
fix(agent,ci): unblock the acp_conformance gate on main

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - The `invalid_prompt` circuit breaker no longer replays the rejected turn on its repaired resend. The streaming path commits the failed assistant message to the context before the breaker runs, so the one repaired resend re-sent that errored turn as if the model had spoken it — re-triggering `Request blocked (code=invalid_prompt)` and leaving a second assistant tail that no continuation can resume from. The breaker now repairs and resends only the history that preceded the rejection.
 - Compaction pruning now protects the newest two user/`bashExecution` turns, uses conservative read supersession, preserves bounded error-first diagnostics, and exposes reversible artifact-backed originals with exact savings accounting.
+- Cancelling a prompt no longer fails its terminal closed. `agent_end` is published before the run resource ledger is sealed, so the event's own handlers register post-prompt work against an already-sealed run; that late registration was treated as an escaped resource and quarantined the run, making `waitForSettlement` report `unfenced` forever. Cancel therefore never obtained settlement proof and the SDK refused to publish a terminal, surfacing over ACP as `-32603 "Prompt resources did not settle before the terminalization grace expired."` Sealing now only freezes admission of genuinely new work; post-seal registration joins ordinary settlement accounting so the run stays unsettled until it actually completes.
 
 ## [0.12.0] - 2026-07-28
 

--- a/packages/agent/src/run-resource-ledger.ts
+++ b/packages/agent/src/run-resource-ledger.ts
@@ -137,11 +137,15 @@ export function createRunResourceLedger(): RunResourceLedger {
 			}
 
 			if (state.lifecycle === "sealed") {
-				// A sealed run cannot be reopened. Late registration is fenced as
-				// quarantine rather than creating a false settled run.
-				quarantineState(state);
-				appendTombstone(state, entry);
-				observeSettlement(settled, () => {});
+				// Sealing only freezes admission of *new* work; it does not mean the run's
+				// resources have all been registered yet. `agent_end` is published before
+				// seal(), and its handlers register their own post-prompt work while the
+				// event is still draining, so this late registration is the normal
+				// lifecycle rather than an escaped resource. Admit it into ordinary
+				// settlement accounting so the run stays unsettled until it completes;
+				// quarantining here would make every cancel unfenced forever.
+				state.resources.set(id, { entry });
+				observeSettlement(settled, () => settleTracked(state!, id));
 				return;
 			}
 

--- a/packages/agent/test/run-resource-ledger.test.ts
+++ b/packages/agent/test/run-resource-ledger.test.ts
@@ -65,6 +65,23 @@ describe("run resource ledger", () => {
 		});
 	});
 
+	test("post-prompt work registered after seal still settles the run", async () => {
+		// `agent_end` is published before seal(), so its handlers register their own
+		// post-prompt work while the terminal event is still draining. Treating that
+		// as an escaped resource made every cancel permanently unfenced.
+		const ledger = createRunResourceLedger();
+		const late = Promise.withResolvers<void>();
+		ledger.open("run");
+		ledger.seal("run");
+		ledger.track("run", "post_prompt", "agent-session-event", late.promise);
+
+		const settlement = ledger.waitForSettlement("run", { graceMs: 5_000 });
+		expect(ledger.pending("run")).toMatchObject([{ kind: "post_prompt", label: "agent-session-event" }]);
+		late.resolve();
+		expect(await settlement).toEqual({ status: "settled" });
+		expect(ledger.pending("run")).toEqual([]);
+	});
+
 	test("quarantine resolves existing and future waiters as unfenced", async () => {
 		const ledger = createRunResourceLedger();
 		const resource = Promise.withResolvers<void>();

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Managed-session startup failures now include their bounded preparation classification (and path-free native durability diagnostic when available), so Windows launch crashes no longer collapse to an unactionable generic error while filesystem paths and raw OS messages remain redacted (#3383).
 - Single-model sessions now rotate immediately to another stored provider credential after a content-free quota or rate-limit failure, without requiring a synthetic model fallback chain. Credential rotation is replay-safe for content-free failures regardless of extension lifecycle participation, and traverses the full credential pool independent of `retry.maxRetries` (#3491).
 - External credential discovery now follows `CLAUDE_CONFIG_DIR` and `CODEX_HOME` instead of always reading `~/.claude` and `~/.codex`, so importing from an account switcher (or any relocated Claude Code / Codex CLI config root) picks up the account the launching shell selected. Both variables resolve through the credential env trust boundary and must be absolute; redacted summaries name the variable, never the resolved path.
+- The `acp_conformance` CI job runs again. The pinned upstream `acpx` checkout resolves its own imports (`@agentclientprotocol/sdk`, `zod`) from its own tree, but its dependencies were never installed, so the corpus runner aborted with `Cannot find module 'zod/v4'` before executing a single case. The checkout is now installed after provenance verification, and the reused warm cache still skips the reinstall.
 
 ### Added
 

--- a/packages/coding-agent/scripts/run-acp-conformance.ts
+++ b/packages/coding-agent/scripts/run-acp-conformance.ts
@@ -225,6 +225,11 @@ async function checkoutAcpxSource(): Promise<AcpxCheckout> {
 	await commandOutput(["git", "clean", "-fdx", "--exclude=node_modules"], root);
 	const status = await commandOutput(["git", "status", "--porcelain"], root);
 	if (status.length > 0) throw new Error(`acpx source checkout is not clean at ${ACPX_GIT_HEAD}.`);
+	// The upstream runner resolves its own imports (`@agentclientprotocol/sdk`, `zod`)
+	// from this checkout, not from the gjc workspace, so the pin has to be installed
+	// before it can run. `git clean` deliberately preserves node_modules so a warm
+	// cache skips the reinstall.
+	await commandOutput(["bun", "install", "--no-save", "--ignore-scripts"], root);
 	return { root, head: await commandOutput(["git", "rev-parse", "HEAD"], root) };
 }
 


### PR DESCRIPTION
`main` CI has been red since v0.12.1 (run 30473200206): the `acp_conformance` job fails and the `test` gate fails closed on it. Two independent defects.

**1. The pinned acpx checkout was never installed.** `checkoutAcpxSource` clones/pins `acpx@0.13.0` at `47dc1c56b`, but the upstream runner resolves `@agentclientprotocol/sdk` and `zod` from *that* tree, not the gjc workspace. The runner died with `Cannot find module 'zod/v4'` before executing a single case. Now installed after provenance verification; `git clean --exclude=node_modules` already preserves a warm cache.

**2. Cancel could never obtain settlement proof.** With deps installed, 19/21 passed and both `acp.v1.session.cancel.in_flight` and `acp.v1.session.cancel.followup_prompt` failed with `-32603 "Prompt resources did not settle before the terminalization grace expired."` Root cause is a regression from 09f3b466d: `agent_end` is published *before* `seal()` (`agent-loop.ts` `publishAgentEnd`), and its handlers register their own post-prompt work (`agent-session.ts:3367`, `post_prompt/agent-session-event`) while the terminal event is still draining. `track()` treated that post-seal registration as an escaped resource and quarantined the whole run, so `waitForSettlement` returned `unfenced` in ~2ms — far under the 10s grace — and the SDK fenced the terminal closed forever. Sealing now only freezes admission of genuinely *new* work; post-seal registration joins ordinary settlement accounting so the run stays unsettled until it truly completes.

Instrumented proof of the mechanism (probe log): `SEAL run=1` -> `LATE-TRACK-AFTER-SEAL run=1 kind=post_prompt label=agent-session-event` -> `proof={"status":"unfenced"} ms=2`.

**Gate gap closed.** `acp_conformance` only runs on `main` pushes (`ci.yml`, gated `!startsWith(github.ref, 'refs/tags/v')`), so dev never exercised it and the regression reached main invisibly. Added a `packages/agent` regression test that reproduces exactly this ordering, so the dev shards now catch it without waiting for the main-only job. Verified it fails (`unfenced` vs `settled`) with the ledger fix reverted and passes with it.

Verification:
- `bun run conformance:run` against the pinned corpus: **21/21, exit 0**, matching `artifacts/acp-core-v1-conformance-baseline.json`. Reverting only the ledger change drops it to 19/21, proving causality.
- `packages/agent` suite: 640 pass. The 3 remaining failures (`compaction-endpoint-trust`, `remote-compaction`) are pre-existing and reproduce identically on stock `dev` — they come from a user-level `OPENAI_BASE_URL`, not this diff.
- ACP/SDK suites (`sdk-acp-prompt-terminal`, `sdk-acp-production-path`, `acp-startup-options`, `acp-fs-provider-capabilities`, `acp-fallback-cancel-completion`, `sdk-prompt-terminal-arbiter`, `sdk-reconciliation-recovery`, `run-acp-conformance`, `sdk-host-wiring`): 137 pass, 0 fail.
- `bun run check` clean in packages/coding-agent; biome clean across packages/agent.