### PR TITLE
fix(ci): classify tool session cleanup seam

### DIFF
--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -35,6 +35,8 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 	"slash_command:transcript": "visual/local-only transcript viewer, not a user-facing SDK control seam",
 	"slash_command:sessions": "visual/local-only sessions dashboard, not a user-facing SDK control seam",
 	"agent_session:constructor": "internal accessor/plumbing, not a user-facing control seam",
+	"agent_session:registerToolSessionCleanup":
+		"internal tool lifecycle cleanup registration, not a user-facing SDK control seam",
 	"agent_session:nextToolChoice": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:setForcedToolChoice": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:getActiveSkillState": "internal accessor/plumbing, not a user-facing control seam",

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -2532,6 +2532,17 @@
 		}
 	},
 	{
+		"sourceId": "agent_session:registerToolSessionCleanup",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "internal tool lifecycle cleanup registration, not a user-facing SDK control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
 		"sourceId": "agent_session:getAsyncJobSnapshot",
 		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
 		"sourceKind": "agent_session",


### PR DESCRIPTION
## Summary

Repairs the sole postmerge failure on dev `7bdc064f3d46debe82f7258903b862556e2f2934` from run `30482356182`, shard 4.

`AgentSession.registerToolSessionCleanup` is internal lifecycle plumbing added by merged PR #3517, not a public SDK operation. This PR records that reviewed exclusion and regenerates the committed SDK operation inventory. No runtime behavior changes.

## Verification

- `bun test packages/coding-agent/test/sdk-operation-inventory.test.ts`: `17 pass`, `0 fail`, `224 assertions`.
- Generator `--check`: pass, `pending=0`.
- `bun --cwd=packages/coding-agent run check`: pass.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*