### PR TITLE
test(coding-agent): gate the whole embedded docs corpus for staleness

### DIFF
--- a/packages/coding-agent/test/docs-index-lazy.test.ts
+++ b/packages/coding-agent/test/docs-index-lazy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import * as path from "node:path";
-import { EMBEDDED_DOCS } from "../src/internal-urls/docs-index.generated";
+import { EMBEDDED_DOC_FILENAMES, EMBEDDED_DOCS } from "../src/internal-urls/docs-index.generated";
 
 function runBunEval(script: string) {
 	const result = Bun.spawnSync({
@@ -15,7 +15,20 @@ function runBunEval(script: string) {
 	return stdout;
 }
 
-const DOCS_WITH_SOURCE_PARITY = ["gpt-5.6-codex-preset-benchmark.md", "models.md"] as const;
+const DOCS_DIR = path.join(import.meta.dir, "../../../docs");
+const REGENERATE_HINT = "run: bun --cwd=packages/coding-agent run generate-docs-index";
+
+// Mirrors how scripts/generate-docs-index.ts derives the corpus: a recursive .md
+// scan of docs/, POSIX-separated and sorted. Deriving it here rather than pinning
+// a list is what makes the parity assertions below a drift gate instead of a
+// reminder to update two hand-maintained filenames.
+async function scanDocsCorpus(): Promise<string[]> {
+	const entries: string[] = [];
+	for await (const relativePath of new Bun.Glob("**/*.md").scan(DOCS_DIR)) {
+		entries.push(relativePath.split(path.sep).join("/"));
+	}
+	return entries.sort();
+}
 
 describe("internal-urls docs index loading", () => {
 	it("does not load the generated docs corpus when importing the barrel", () => {
@@ -45,9 +58,31 @@ describe("internal-urls docs index loading", () => {
 		expect(result.contentLength).toBeGreaterThan(0);
 	});
 
-	it.each([...DOCS_WITH_SOURCE_PARITY])("matches the source %s document", async fileName => {
-		const source = await Bun.file(path.join(import.meta.dir, "../../../docs", fileName)).text();
+	it("embeds exactly the docs corpus that exists on disk", async () => {
+		const onDisk = await scanDocsCorpus();
 
-		expect(EMBEDDED_DOCS[fileName]).toBe(source);
+		expect(
+			[...EMBEDDED_DOC_FILENAMES],
+			`docs corpus changed without regenerating the index; ${REGENERATE_HINT}`,
+		).toEqual(onDisk);
+		expect(
+			Object.keys(EMBEDDED_DOCS).sort(),
+			`embedded doc keys drifted from the corpus; ${REGENERATE_HINT}`,
+		).toEqual(onDisk);
+	});
+
+	it("keeps every embedded doc byte-identical to its source", async () => {
+		const onDisk = await scanDocsCorpus();
+		const sources = await Promise.all(
+			onDisk.map(async fileName => ({
+				fileName,
+				source: await Bun.file(path.join(DOCS_DIR, fileName)).text(),
+			})),
+		);
+		const stale = sources
+			.filter(({ fileName, source }) => EMBEDDED_DOCS[fileName] !== source)
+			.map(({ fileName }) => fileName);
+
+		expect(stale, `stale embedded docs index for ${stale.join(", ") || "(none)"}; ${REGENERATE_HINT}`).toEqual([]);
 	});
 });


### PR DESCRIPTION
## What

`docs-index.generated.ts` embeds every `docs/**/*.md` file, but its only staleness gate byte-compared **two** hand-listed docs:

```ts
const DOCS_WITH_SOURCE_PARITY = ["gpt-5.6-codex-preset-benchmark.md", "models.md"] as const;
```

The other 116 docs had no gate. Editing any of them without running `generate-docs-index` ships `gjc://<doc>` stale with a green test suite.

This replaces the allowlist with the corpus the generator actually walks, and asserts the filename set **and** per-doc bytes.

## Why

The drift is not hypothetical — the index has needed standalone repair commits:

| commit | note |
| --- | --- |
| `2ddd030a` (#3519) | `chore: regenerate docs index after #3513` — 1 line, index-only |
| `2bd7c4b8` | `chore: regenerate docs index for compaction doc updates` |
| `968ecbe3` | `chore: regenerate docs index after sdk.md reconciliation docs` |
| `186562c2` | `chore: regenerate docs index after rebase` |

Neither of the two allowlisted docs was involved in #3519 — `environment-variables.md` was, and it was not gated.

There is also no `--check` mode on `generate-docs-index.ts` and no CI step that runs it (`rg 'docs-index|generate-docs' .github/workflows` → no matches). `prepare`/`prepack` regenerate at install and publish time, so staleness self-heals at release but is invisible between commits. Until a generator `--check` exists, this test is the only signal — so it should cover the whole corpus.

## How

The test now derives the corpus exactly as `scripts/generate-docs-index.ts` does — sorted recursive `**/*.md` scan, POSIX-separated — instead of pinning filenames. That derivation is what makes it a drift gate rather than a reminder to update two strings.

Two assertions, matching the generator's two exports:

- `EMBEDDED_DOC_FILENAMES` and `Object.keys(EMBEDDED_DOCS)` equal the on-disk corpus → catches **added** and **deleted** docs.
- every embedded value is byte-identical to its source → catches **edited** docs.

Failures name the offending docs and carry the fix:

```
stale embedded docs index for codebase-overview.md; run: bun --cwd=packages/coding-agent run generate-docs-index
```

Byte-equality is a genuine generator invariant, not an over-tight assertion: `generate-docs-index.ts` writes `JSON.stringify(content)` verbatim per doc with no normalization, so this cannot false-fail on formatting.

## Verification

Ran in a clean worktree at `upstream/dev` (`68027638`).

Baseline — `bun test test/docs-index-lazy.test.ts`:

```
4 pass, 0 fail, 8 expect() calls
```

Mutation proof, one drift class at a time (each restored after):

| mutation | old allowlist | this gate |
| --- | --- | --- |
| edit `codebase-overview.md`, no regenerate | passes | **fails** — `stale embedded docs index for codebase-overview.md` |
| add a new doc, no regenerate | passes | **fails** — `docs corpus changed without regenerating the index` |
| delete a doc, no regenerate | passes | **fails** — `docs corpus changed without regenerating the index` |

`codebase-overview.md` is deliberately outside the old allowlist. The previous gate caught **none** of the three.

Also confirmed dev is already in parity, so this lands green rather than importing a pre-existing failure: `bun install` runs `prepare` → `generate-docs-index`, and the tree stayed clean afterwards (118 docs).

Gates: `tsc --noEmit` exit 0 · `biome check` clean (formatter-applied, not hand-formatted) · restored tree green at 4 pass.

## Cost and scope

118 docs / ~1.35 MB per run, reads issued through one `Promise.all` — the file went from ~370 ms to ~1.1 s on first run. Test-only change; no `src/` or `docs/` edits, and no CHANGELOG entry per the convention for test-only commits (e.g. `589971b2`).

The alternative shape is `--check` on `generate-docs-index.ts` wired into CI, which puts the check at the generator seam and would let this test shrink again. That needs a new script surface plus a workflow edit, so I kept this PR to the test. Happy to do the `--check` version instead if you'd prefer the gate there.
