### PR TITLE
fix(utils): honour deletion of an inherited credential env var

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - The crash-log credential scrubber recognizes GitHub fine-grained PATs (`github_pat_`) and complete AWS STS credentials. It already had rules for both vendors, but matched only the classic `gh[opsur]_` and long-term `AKIA` shapes. It now also covers the temporary `ASIA` key id and, critically, the `SecretAccessKey` / `SessionToken` values that ship alongside it — the id alone is not the credential, and neither canonical field name matched the existing labeled-value rule. All of these previously survived into a file the module keeps indefinitely.
+- `$inheritedEnv` (and therefore `$credentialEnv` / `$pickCredentialEnv`) honours the removal of an inherited variable. The inherited snapshot is taken once, at module load, and was consulted first and unconditionally, so a provider credential exported by the launching shell could never be suppressed afterwards: deleting it from the live environment left every credential lookup still returning the snapshot value. Tests that clear provider env vars before exercising credential resolution therefore ran against the developer's real credential — and printed it when the assertion failed. Deletion is now honoured while the snapshot value stays pinned, so a later in-process write still cannot swap the credential a request authenticates with.
 
 ## [0.12.0] - 2026-07-28
 

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -52,7 +52,17 @@ const projectEnv = parseEnvFile(path.join(process.cwd(), ".env"));
 const inheritedEnv = filterCredentialInheritedEnv(Bun.env);
 
 export function $inheritedEnv(name: string): string | undefined {
-	return resolveFileEnvValue(inheritedEnv, name);
+	const snapshotValue = resolveFileEnvValue(inheritedEnv, name);
+	if (snapshotValue === undefined) return undefined;
+	// The snapshot records provenance — this key was inherited from the launching
+	// shell rather than the caller's cwd/.env — and pins the value so a later
+	// in-process write cannot swap the credential we authenticate with. It is not
+	// a cache that outlives the variable: once the key is removed from the live
+	// environment it is no longer inherited, so deletion is honoured. Without
+	// this, a credential present at import time can never be suppressed (tests
+	// that clear provider env vars silently keep resolving the real credential).
+	if (Bun.env[name] === undefined) return undefined;
+	return snapshotValue;
 }
 
 function resolveLiveCredentialEnvValue(name: string): string | undefined {

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -120,6 +120,9 @@ assertEqual($env.GJC_ENV_TEST_INHERITED_ONLY, "overlay-after-import", "live $env
 Bun.env.GJC_ENV_TEST_FALLBACK_ONLY = "fallback-after-import";
 assertEqual($inheritedEnv("GJC_ENV_TEST_FALLBACK_ONLY"), undefined, "absent inherited value");
 assertEqual($env.GJC_ENV_TEST_FALLBACK_ONLY, "fallback-after-import", "fallback remains available through $env");
+delete Bun.env.GJC_ENV_TEST_INHERITED_ONLY;
+assertEqual($inheritedEnv("GJC_ENV_TEST_INHERITED_ONLY"), undefined, "deleted key is no longer inherited");
+assertEqual($env.GJC_ENV_TEST_INHERITED_ONLY, undefined, "deleted key is gone from merged env");
 `,
 			{ GJC_ENV_TEST_INHERITED_ONLY: "shell-from-parent" },
 			dir,


### PR DESCRIPTION
## What

`inheritedEnv` is a snapshot of `Bun.env` taken once at module load (`packages/utils/src/env.ts:52`), and `$inheritedEnv` returned from it unconditionally. It is the first source `$credentialEnv` consults, so a provider credential exported by the launching shell could never be suppressed afterwards: removing it from the live environment left every credential lookup still returning the snapshot value.

## Why it matters

The suppression seam is untestable, and the failure mode leaks credentials.

Any test that clears a provider variable before exercising credential resolution keeps resolving the developer's real credential. On a machine that exports `ANTHROPIC_OAUTH_TOKEN`, 2 of the 8 cases in `packages/ai/test/auth-storage-oauth-refresh-race.test.ts` fail — and because the assertion is `expect(apiKey).toBeUndefined()`, the diff prints the live OAuth token:

```
error: expect(received).toBeUndefined()
Received: "sk-ant-oat01-…"
```

`withEnv({ ANTHROPIC_OAUTH_TOKEN: undefined }, …)` deletes the key from `Bun.env` exactly as intended; the frozen snapshot silently overrode it. CI does not export the variable, so this only bites contributors who authenticate that way locally.

## Change

`$inheritedEnv` keeps returning the pinned snapshot *value* — a later in-process write still cannot swap the credential a request authenticates with — but treats the key as no longer inherited once it is absent from the live environment.

The project-`.env` trust boundary is untouched: `filterCredentialInheritedEnv` still decides what counts as inherited, and `resolveLiveCredentialEnvValue` still applies the ambiguous-project-match rule.

## Tests

```
bun test packages/utils/test/env.test.ts   # 24 pass
```

The existing `$inheritedEnv` isolation script gains a deletion assertion; it fails without the source change (`deleted key is no longer inherited: expected undefined, got shell-from-parent`).

Downstream check — with `ANTHROPIC_OAUTH_TOKEN` exported:

```
ANTHROPIC_OAUTH_TOKEN=fake bun test packages/ai/test/auth-storage-oauth-refresh-race.test.ts packages/ai/test/auth-storage-credential-disabled-event.test.ts   # 21 pass (2 failed before)
```

Also run: `bun test` in `packages/utils` (235 pass), `bun run check:types` (clean), `bunx biome check` on the touched files (clean).
