### PR TITLE
Bind sticky viewport evidence to renderer-owned paint state

### DIFF
--- a/packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts
@@ -168,17 +168,51 @@ export function ansiToHtml(value: string): string {
 	return `<!doctype html><html lang="en"><meta charset="utf-8"><title>Sticky viewport showcase</title><style>body{margin:0;background:#110b0b;color:#ffe7dc}pre{white-space:pre;font-family:ui-monospace,monospace}@keyframes blink{50%{visibility:hidden}}</style><pre>${body}</pre></html>\n`;
 }
 const json = (value: unknown) => `${JSON.stringify(value, null, 2)}\n`;
-const hash = (value: string) => new Bun.CryptoHasher("sha256").update(value).digest("hex");
+const hash = (value: string | Uint8Array) => new Bun.CryptoHasher("sha256").update(value).digest("hex");
+const PROVENANCE_SOURCES = [
+	"packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts",
+	"packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts",
+	"packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts",
+	"packages/coding-agent/src/modes/interactive-mode.ts",
+	"packages/coding-agent/src/modes/components/irc-sidebar.ts",
+	"packages/tui/src/tui.ts",
+] as const;
+async function git(args: string[]): Promise<Uint8Array> {
+	const result = Bun.spawn(["git", ...args], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
+	if ((await result.exited) !== 0)
+		throw new Error(`git ${args.join(" ")} failed: ${await new Response(result.stderr).text()}`);
+	return new Uint8Array(await new Response(result.stdout).arrayBuffer());
+}
+async function captureProvenance() {
+	const gitHead = new TextDecoder().decode(await git(["rev-parse", "HEAD"])).trim();
+	const sourceSha256 = Object.fromEntries(
+		await Promise.all(
+			PROVENANCE_SOURCES.map(async source => [source, hash(new Uint8Array(await Bun.file(source).arrayBuffer()))]),
+		),
+	);
+	return {
+		git_head: gitHead,
+		git_diff_binary_sha256: hash(await git(["diff", "--binary", "HEAD", "--"])),
+		source_sha256: sourceSha256,
+	};
+}
 function out(args: string[]): string {
 	if (args.length !== 2 || args[0] !== "--out" || !args[1]) throw new Error(`Usage: ${COMMAND}`);
 	return args[1];
 }
-async function capture(entry: StickyViewportShowcaseEntry, root: string) {
+async function capture(
+	entry: StickyViewportShowcaseEntry,
+	root: string,
+	sourceProvenance: Awaited<ReturnType<typeof captureProvenance>>,
+) {
 	const rendered = await renderStickyViewportShowcase(entry);
 	if (!rendered.state.composer_visible)
 		throw new Error(`${entry.key}: focused composer was not visible in production frame`);
-	if (entry.stateId === "manual-new-output" && rendered.state.notice !== true)
-		throw new Error(`${entry.key}: manual output notice precondition failed`);
+	if (
+		(entry.stateId === "manual-new-output" && rendered.state.notice !== true) ||
+		(entry.stateId !== "manual-new-output" && rendered.state.notice !== false)
+	)
+		throw new Error(`${entry.key}: renderer-owned output notice precondition failed`);
 	if (
 		JSON.stringify(rendered.cjkPhraseBoundaries) !==
 		JSON.stringify(entry.stateId === "narrow-cjk" ? CJK_PHRASE_BOUNDARIES : [])
@@ -210,6 +244,7 @@ async function capture(entry: StickyViewportShowcaseEntry, root: string) {
 			fixed_clock: true,
 			author_identity: "capture-sticky-viewport-showcase",
 			executor_identity: "capture-sticky-viewport-showcase",
+			...sourceProvenance,
 		},
 		cjk_phrase_boundaries: rendered.cjkPhraseBoundaries,
 	});
@@ -241,8 +276,9 @@ async function capture(entry: StickyViewportShowcaseEntry, root: string) {
 async function main() {
 	const root = path.resolve(out(process.argv.slice(2)));
 	await fs.mkdir(root, { recursive: true });
+	const sourceProvenance = await captureProvenance();
 	const entries = [];
-	for (const entry of STICKY_VIEWPORT_SHOWCASE_ENTRIES) entries.push(await capture(entry, root));
+	for (const entry of STICKY_VIEWPORT_SHOWCASE_ENTRIES) entries.push(await capture(entry, root, sourceProvenance));
 	const manifest = json({
 		schema_version: 2,
 		fixture_revision: REVISION,
@@ -258,6 +294,7 @@ async function main() {
 			fixed_clock: true,
 			author_identity: "capture-sticky-viewport-showcase",
 			executor_identity: "capture-sticky-viewport-showcase",
+			...sourceProvenance,
 		},
 		review_input_file: "review-input.json",
 		entries,
@@ -281,6 +318,15 @@ async function main() {
 			acceptance_version: ACCEPTANCE_VERSION,
 			design_version: DESIGN_VERSION,
 			host_matrix: HOST_MATRIX,
+			provenance: {
+				capture_mode: "production-tui-virtual-terminal",
+				live_pty: false,
+				network: false,
+				fixed_clock: true,
+				author_identity: "capture-sticky-viewport-showcase",
+				executor_identity: "capture-sticky-viewport-showcase",
+				...sourceProvenance,
+			},
 			narrow_cjk: {
 				entry_key: "narrow-cjk/48x10/unicode-color",
 				phrase_boundaries: ["의미 있는 문장 경계", "意味のある文の境界", "保留语义短语边界"],

--- a/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
@@ -64,6 +64,35 @@ const INDEPENDENT_REVIEW_KEYS = [
 const INDEPENDENT_REVIEW_RESULT_KEYS = ["key", "result", "notes", "artifact_checks"] as const;
 const INDEPENDENT_REVIEW_DEFECT_KEYS = ["description", "accepted"] as const;
 const ARTIFACT_CHECK_KEYS = ["terminal_txt", "terminal_ansi_txt", "terminal_html", "metadata_json"] as const;
+const SEMANTIC_ROOT_IDS = [
+	"irc-split",
+	"pending-messages",
+	"status-container",
+	"todos",
+	"btw",
+	"status-line",
+	"hooks-above",
+	"editor-container",
+	"pet-floor",
+	"hooks-below",
+] as const;
+const STATE_KEYS = [
+	"manual",
+	"notice",
+	"observed_output_revision",
+	"transcript_capacity",
+	"composer_visible",
+	"resize_probes",
+	"visible_empty_irc_frame",
+	"root_order",
+	"pin_boundary",
+	"focused_component",
+	"cursor",
+	"selection",
+	"semantic_anchor",
+	"cjk_contiguous_semantics",
+	"coverage",
+] as const;
 type Style = {
 	foreground: string;
 	background: string;
@@ -78,7 +107,77 @@ type Style = {
 	overline: boolean;
 };
 type Run = { text: string; style: Style };
-const hash = (value: string) => new Bun.CryptoHasher("sha256").update(value).digest("hex");
+const hash = (value: string | Uint8Array) => new Bun.CryptoHasher("sha256").update(value).digest("hex");
+const PROVENANCE_SOURCES = [
+	"packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts",
+	"packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts",
+	"packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts",
+	"packages/coding-agent/src/modes/interactive-mode.ts",
+	"packages/coding-agent/src/modes/components/irc-sidebar.ts",
+	"packages/tui/src/tui.ts",
+] as const;
+async function git(args: string[]): Promise<Uint8Array> {
+	const result = Bun.spawn(["git", ...args], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
+	if ((await result.exited) !== 0) fail(`git ${args.join(" ")} failed: ${await new Response(result.stderr).text()}`);
+	return new Uint8Array(await new Response(result.stdout).arrayBuffer());
+}
+async function currentProvenance() {
+	const sourceSha256 = Object.fromEntries(
+		await Promise.all(
+			PROVENANCE_SOURCES.map(async source => [source, hash(new Uint8Array(await Bun.file(source).arrayBuffer()))]),
+		),
+	);
+	return {
+		git_head: new TextDecoder().decode(await git(["rev-parse", "HEAD"])).trim(),
+		git_diff_binary_sha256: hash(await git(["diff", "--binary", "HEAD", "--"])),
+		source_sha256: sourceSha256,
+	};
+}
+const cellWidth = (grapheme: string) => {
+	const scalar = grapheme.codePointAt(0)!;
+	if (scalar === 0x200d || (scalar >= 0x300 && scalar <= 0x36f) || (scalar >= 0xfe00 && scalar <= 0xfe0f)) return 0;
+	return (scalar >= 0x1100 && scalar <= 0x115f) ||
+		(scalar >= 0x2e80 && scalar <= 0xa4cf) ||
+		(scalar >= 0xac00 && scalar <= 0xd7a3) ||
+		(scalar >= 0xf900 && scalar <= 0xfaff) ||
+		(scalar >= 0xff01 && scalar <= 0xff60) ||
+		(scalar >= 0xffe0 && scalar <= 0xffe6)
+		? 2
+		: 1;
+};
+const terminalRows = (text: string, columns: number) =>
+	text
+		.slice(0, -1)
+		.split("\n")
+		.map(text => {
+			const cells = [...new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(text)].map(item => ({
+				grapheme: item.segment,
+				width: cellWidth(item.segment),
+			}));
+			const width = cells.reduce((total, cell) => total + cell.width, 0);
+			if (width > columns) fail(`terminal row exceeds ${columns} cells`);
+			return { text, cells, width };
+		});
+const verifyCjkCellOracle = (text: string, columns: number, pinRow: unknown, cursorRow: unknown) => {
+	if (!Number.isInteger(pinRow) || !Number.isInteger(cursorRow)) fail("narrow CJK lane geometry missing");
+	const pinnedRow = pinRow as number;
+	const editorRow = cursorRow as number;
+	const rows = terminalRows(text, columns);
+	const phrase = CJK[1];
+	const row = rows.findIndex(candidate => candidate.text.includes(phrase));
+	if (row < 0) fail("narrow CJK cell oracle missing canonical phrase");
+	const candidate = rows[row]!;
+	const phraseIndex = candidate.text.indexOf(phrase);
+	const prefix = candidate.text.slice(0, phraseIndex);
+	const phraseCells = [...new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(phrase)];
+	const phraseStart = [...new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(prefix)].reduce(
+		(total, item) => total + cellWidth(item.segment),
+		0,
+	);
+	const phraseWidth = phraseCells.reduce((total, item) => total + cellWidth(item.segment), 0);
+	if (phraseStart + phraseWidth > columns || row >= pinnedRow || row === editorRow)
+		fail("narrow CJK cell oracle lane overlap");
+};
 const fail = (message: string): never => {
 	throw new Error(`Sticky viewport evidence invalid: ${message}`);
 };
@@ -281,79 +380,30 @@ const normalized = (runs: Run[]) => {
 	return merged;
 };
 const equalRuns = (left: Run[], right: Run[]) => JSON.stringify(normalized(left)) === JSON.stringify(normalized(right));
-const transcriptCapacity = (text: string) => {
-	const row = text.split("\n").findIndex(line => line.includes("status:"));
-	return row < 0 ? fail("frame omits pinned status row") : row;
-};
-const expectedState = (state: string) => ({
-	manual: state !== "live-overflow",
-	notice: state === "manual-new-output",
-	status: state === "live-overflow" ? "status: live follow" : "status: manual history · composer pinned",
-	multiline: state === "multiline-editor-hooks-pet",
-});
-function validateOracle(
-	key: string,
-	text: string,
-	metadata: Record<string, unknown>,
-	stateEvidence: Record<string, unknown>,
-) {
-	const state = key.split("/")[0]!;
-	const expected = expectedState(state);
-	const lines = text.split("\n");
-	if (stateEvidence.manual !== expected.manual || stateEvidence.notice !== expected.notice)
-		fail(`immutable state oracle mismatch for ${key}`);
-	if (lines.filter(line => line.includes(expected.status)).length !== 1)
-		fail(`exact status oracle mismatch for ${key}`);
-	const markers = [
-		expected.status,
-		...(expected.multiline
-			? ["hook: ready", "completed: visual proof", "pet: ◕‿◕", "> ", "first composer line", "second composer line"]
-			: ["> "]),
-	];
-	let position = -1;
-	for (const marker of markers) {
-		const next = text.indexOf(marker, position + 1);
-		if (next < 0) fail(`ordered suffix oracle missing ${marker} for ${key}`);
-		position = next;
-	}
-	if (text.split("New output — type to follow").length - 1 !== (expected.notice ? 1 : 0))
-		fail(`notice cardinality oracle mismatch for ${key}`);
-	if (
-		expected.multiline !==
-		(text.includes("hook: ready") &&
-			text.includes("pet: ◕‿◕") &&
-			text.includes("first composer line") &&
-			text.includes("second composer line"))
-	)
-		fail(`multiline editor/hooks/pet oracle mismatch for ${key}`);
-	if (metadata.output_revision !== (expected.notice ? "1" : "0")) fail(`manual notice invariant mismatch for ${key}`);
-	if (state === "selection-boundary") {
-		const copied = stateEvidence.selection_copied_text;
-		if (
-			stateEvidence.selection_scope !== "transcript" ||
-			typeof copied !== "string" ||
-			!copied.trim() ||
-			copied.includes("status:") ||
-			copied.includes("> ") ||
-			!lines.some(line => line.includes(copied.trim()))
-		)
-			fail(`selection oracle mismatch for ${key}`);
-	} else if (stateEvidence.selection_scope !== "none" || stateEvidence.selection_copied_text !== "")
-		fail(`selection oracle mismatch for ${key}`);
-	const historicalRows = stateEvidence.manual_historical_rows;
-	const preOutputCapacity = stateEvidence.manual_pre_output_capacity;
-	if (expected.manual) {
-		if (
-			!Number.isInteger(preOutputCapacity) ||
-			(preOutputCapacity as number) < 0 ||
-			!Array.isArray(historicalRows) ||
-			historicalRows.length !== ((preOutputCapacity as number) > 0 ? 1 : 0) ||
-			historicalRows.some(row => typeof row !== "string" || !row.trim() || !lines.includes(row))
-		)
-			fail(`manual historical transcript evidence mismatch for ${key}`);
-	} else if (preOutputCapacity !== 0 || !Array.isArray(historicalRows) || historicalRows.length !== 0)
-		fail(`manual historical transcript evidence mismatch for ${key}`);
-}
+const hasColorSgr = (ansi: string) =>
+	[...ansi.matchAll(/\x1b\[([0-9;]*)m/g)].some(match => {
+		const codes = (match[1] || "0").split(";").map(Number);
+		return codes.some(
+			code =>
+				(code >= 30 && code <= 37) ||
+				(code >= 40 && code <= 47) ||
+				(code >= 90 && code <= 107) ||
+				code === 38 ||
+				code === 48,
+		);
+	});
+const hasIndexedOrBasicColorSgr = (ansi: string) =>
+	[...ansi.matchAll(/\x1b\[([0-9;]*)m/g)].some(match => {
+		const codes = (match[1] || "0").split(";").map(Number);
+		for (let index = 0; index < codes.length; index += 1) {
+			const code = codes[index]!;
+			if ((code >= 30 && code <= 37) || (code >= 40 && code <= 47) || (code >= 90 && code <= 107)) return true;
+			if (code !== 38 && code !== 48) continue;
+			if (codes[index + 1] === 5) return true;
+			if (codes[index + 1] === 2) index += 4;
+		}
+		return false;
+	});
 export async function verifyStickyViewportShowcase(rootInput: string, requireIndependentReview = false): Promise<void> {
 	const root = path.resolve(rootInput);
 	const manifestText = await fs.readFile(path.join(root, "manifest.json"), "utf8");
@@ -370,6 +420,7 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 		fail("manifest schema or provenance literals mismatch");
 	strings(manifest.ordered_keys, KEYS, "manifest ordered_keys");
 	const provenance = object(manifest.provenance, "manifest provenance");
+	const expectedProvenance = await currentProvenance();
 	if (
 		provenance.capture_mode !== "production-tui-virtual-terminal" ||
 		provenance.live_pty !== false ||
@@ -381,6 +432,12 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 		!provenance.executor_identity.trim()
 	)
 		fail("manifest provenance mismatch");
+	if (
+		provenance.git_head !== expectedProvenance.git_head ||
+		provenance.git_diff_binary_sha256 !== expectedProvenance.git_diff_binary_sha256 ||
+		JSON.stringify(provenance.source_sha256) !== JSON.stringify(expectedProvenance.source_sha256)
+	)
+		fail("manifest capture provenance is stale");
 	const entries = array(manifest.entries, "manifest entries");
 	if (entries.length !== KEYS.length) fail("manifest entries must contain exactly 20 entries");
 	for (let index = 0; index < KEYS.length; index += 1) {
@@ -422,21 +479,8 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 			!equalRuns(ansiStyleRuns, htmlStyleRuns)
 		)
 			fail(`entry ${key} ANSI/HTML style-run mismatch`);
-		if (state === "multiline-editor-hooks-pet" && (!ansi.includes("\x1b[9m") || !html.includes("line-through")))
-			fail(`entry ${key} strikethrough evidence missing`);
-		if (state === "selection-boundary" && !ansi.includes("\x1b[7m"))
-			fail(`entry ${key} inverse selection evidence missing`);
-		if (state === "narrow-cjk" && CJK.some(boundary => !text.includes(boundary)))
-			fail("narrow CJK visible terminal evidence missing");
-		if (
-			text
-				.split("\n")
-				.slice(0, -1)
-				.some(row => Bun.stringWidth(row) !== columns) ||
-			text.split("\n").length - 1 !== rows
-		)
-			fail(`entry ${key} terminal dimensions mismatch`);
-		if (mode === "ascii-no-color" ? /\x1b\[/.test(ansi) : !/\x1b\[[0-9;]*(?:3[0-9]|38;)/.test(ansi))
+		if (text.split("\n").length - 1 !== rows) fail(`entry ${key} terminal row count mismatch`);
+		if (mode === "ascii-no-color" ? hasIndexedOrBasicColorSgr(ansi) : !hasColorSgr(ansi))
 			fail(`entry ${key} ANSI mode/color mismatch`);
 		const metadata = await readJson(path.join(root, key, "metadata.json"), `metadata ${key}`);
 		exactKeys(
@@ -476,7 +520,7 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 			metadata.fixture_source !== FIXTURE ||
 			metadata.render_mode !== mode ||
 			metadata.ansi_mode !== (mode === "unicode-color") ||
-			metadata.source_revision !== "production-tui-virtual-terminal-v2" ||
+			metadata.source_revision !== "production-tui-virtual-terminal-v3" ||
 			terminal.id !== id ||
 			terminal.columns !== columns ||
 			terminal.rows !== rows ||
@@ -488,21 +532,160 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 			metaProvenance.fixed_clock !== true ||
 			metaProvenance.author_identity !== provenance.author_identity ||
 			metaProvenance.executor_identity !== provenance.executor_identity ||
+			metaProvenance.git_head !== expectedProvenance.git_head ||
+			metaProvenance.git_diff_binary_sha256 !== expectedProvenance.git_diff_binary_sha256 ||
+			JSON.stringify(metaProvenance.source_sha256) !== JSON.stringify(expectedProvenance.source_sha256) ||
 			stateEvidence.composer_visible !== true
 		)
 			fail(`metadata schema mismatch for ${key}`);
-		if (stateEvidence.transcript_capacity !== transcriptCapacity(text))
-			fail(`capacity metadata/frame mismatch for ${key}`);
-		validateOracle(key, text, metadata, stateEvidence);
-		if (state === "capacity-zero" && transcriptCapacity(text) !== 0)
-			fail(`zero capacity frame invariant mismatch for ${key}`);
-		if (state === "capacity-one" && transcriptCapacity(text) !== 1)
-			fail(`one capacity frame invariant mismatch for ${key}`);
-		if (state === "capacity-many" && transcriptCapacity(text) < 2)
-			fail(`many capacity frame invariant mismatch for ${key}`);
+		if (!Number.isInteger(stateEvidence.transcript_capacity)) fail(`capacity metadata/frame mismatch for ${key}`);
+		const observations = array(stateEvidence.resize_probes, `metadata ${key} resize observations`);
+		const probeWidths = [64, 65, 80, 120, 160, 120, 80, 65, 64];
+		const rootOrder = array(stateEvidence.root_order, `metadata ${key} root order`);
+		const pinBoundary = object(stateEvidence.pin_boundary, `metadata ${key} pin boundary`);
+		const cursor = object(stateEvidence.cursor, `metadata ${key} cursor`);
+		const selection = stateEvidence.selection;
+		const expectedManual = state !== "live-overflow" && state !== "capacity-zero";
+		const expectedNotice = state === "manual-new-output";
+		const expectedRevision = expectedNotice ? "1" : "0";
+		if (
+			stateEvidence.manual !== expectedManual ||
+			stateEvidence.notice !== expectedNotice ||
+			stateEvidence.observed_output_revision !== expectedRevision ||
+			metadata.output_revision !== stateEvidence.observed_output_revision
+		)
+			fail(`renderer-owned viewport state mismatch for ${key}`);
+		const semanticAnchor =
+			state === "capacity-zero"
+				? stateEvidence.semantic_anchor
+				: object(stateEvidence.semantic_anchor, `metadata ${key} semantic anchor`);
+		const semanticAnchorValid =
+			state === "capacity-zero"
+				? semanticAnchor === null && stateEvidence.transcript_capacity === 0
+				: typeof (semanticAnchor as Record<string, unknown>).id === "string" &&
+					((semanticAnchor as Record<string, unknown>).id as string).length > 0 &&
+					Number.isInteger((semanticAnchor as Record<string, unknown>).grapheme_start) &&
+					((semanticAnchor as Record<string, unknown>).grapheme_start as number) >= 0 &&
+					Number.isInteger((semanticAnchor as Record<string, unknown>).cell_start) &&
+					((semanticAnchor as Record<string, unknown>).cell_start as number) >= 0 &&
+					Number.isInteger((semanticAnchor as Record<string, unknown>).frame_start_row) &&
+					((semanticAnchor as Record<string, unknown>).frame_start_row as number) >= 0;
+		const visibleEmpty = object(stateEvidence.visible_empty_irc_frame, `metadata ${key} visible empty IRC frame`);
+		exactKeys(stateEvidence, STATE_KEYS, `metadata ${key} state`);
+		strings(rootOrder, SEMANTIC_ROOT_IDS, `metadata ${key} semantic root IDs`);
+		const coverage = object(stateEvidence.coverage, `metadata ${key} coverage`);
+		exactKeys(
+			coverage,
+			["irc", "todo", "widths", "heights", "viewport", "chrome", "evidence"],
+			`metadata ${key} coverage`,
+		);
+		strings(coverage.irc, ["empty", "streaming", "long"], `metadata ${key} IRC coverage`);
+		strings(
+			coverage.todo,
+			["empty", "populated", "long", "multi-phase", "collapsed", "expanded"],
+			`metadata ${key} todo coverage`,
+		);
+		const emptyText = visibleEmpty.text as string;
+		const capacityConstrained = state === "capacity-one" || state === "capacity-zero";
+		if (
+			JSON.stringify(coverage.widths) !== JSON.stringify(probeWidths) ||
+			emptyText.includes("worker → you") ||
+			emptyText.includes("long IRC observation") ||
+			observations.length !== probeWidths.length ||
+			observations.some((value, index) => {
+				const probe = object(value, `metadata ${key} resize observation`);
+				const frame = object(probe.frame, `metadata ${key} resize frame`);
+				const split = probeWidths[index]! >= 65;
+				return (
+					probe.columns !== probeWidths[index] ||
+					probe.effective_lane !== (split ? "split" : "transcript") ||
+					probe.separator_width !== (split ? 3 : 0) ||
+					(probe.left_width as number) + (probe.separator_width as number) + (probe.right_width as number) !==
+						probeWidths[index] ||
+					probe.irc_records !== (split ? 1 : 0) ||
+					probe.todo_rows !== (split ? 1 : 0) ||
+					probe.todo_expanded !== (probe.columns as number) >= 80 ||
+					typeof frame.ansi !== "string" ||
+					frame.text !== Bun.stripANSI(frame.ansi) ||
+					frame.sha256 !== hash(frame.ansi) ||
+					(!capacityConstrained && split && !frame.text.includes("│")) ||
+					(!capacityConstrained &&
+						!split &&
+						(frame.text.includes("worker → you") || frame.text.includes("Todos"))) ||
+					(!capacityConstrained &&
+						(probe.columns as number) >= 80 &&
+						(!frame.text.includes("long IRC observation") ||
+							!frame.text.includes("☑ verify production todo") ||
+							!frame.text.includes("☐ expanded production todo"))) ||
+					(!capacityConstrained && (probe.columns as number) >= 120 && !frame.text.includes("worker → you"))
+				);
+			}) ||
+			typeof visibleEmpty.ansi !== "string" ||
+			visibleEmpty.text !== Bun.stripANSI(visibleEmpty.ansi) ||
+			visibleEmpty.sha256 !== hash(visibleEmpty.ansi) ||
+			JSON.stringify(rootOrder) !==
+				JSON.stringify([
+					"irc-split",
+					"pending-messages",
+					"status-container",
+					"todos",
+					"btw",
+					"status-line",
+					"hooks-above",
+					"editor-container",
+					"pet-floor",
+					"hooks-below",
+				]) ||
+			pinBoundary.component !== "status-line" ||
+			pinBoundary.index !== 5 ||
+			pinBoundary.row !== stateEvidence.transcript_capacity ||
+			pinBoundary.pinned !== true ||
+			stateEvidence.focused_component !== "editor" ||
+			!Number.isInteger(cursor.row) ||
+			(cursor.row as number) < 0 ||
+			(cursor.row as number) >= rows ||
+			!Number.isInteger(cursor.col) ||
+			(cursor.col as number) < 0 ||
+			(cursor.col as number) >= columns ||
+			!semanticAnchorValid ||
+			cursor.frame_sha256 !== hash(ansi) ||
+			cursor.blink !== true
+		)
+			fail(`runtime observation mismatch for ${key}`);
+		if (
+			(state === "capacity-many" && (stateEvidence.transcript_capacity as number) <= 1) ||
+			(state === "capacity-one" && stateEvidence.transcript_capacity !== 1) ||
+			(state === "capacity-zero" && stateEvidence.transcript_capacity !== 0)
+		)
+			fail(`capacity scenario mismatch for ${key}`);
+		if (state === "selection-boundary") {
+			const selected = object(selection, `metadata ${key} selection`);
+			const start = object(selected.start, `metadata ${key} selection start`);
+			const end = object(selected.end, `metadata ${key} selection end`);
+			if (
+				!Number.isInteger(start.row) ||
+				!Number.isInteger(start.col) ||
+				!Number.isInteger(end.row) ||
+				!Number.isInteger(end.col) ||
+				(start.row as number) < 0 ||
+				(end.row as number) >= (stateEvidence.transcript_capacity as number) ||
+				((start.row as number) === (end.row as number) && (start.col as number) >= (end.col as number))
+			)
+				fail(`selection boundary evidence missing for ${key}`);
+		} else if (selection !== null) fail(`unexpected selection evidence for ${key}`);
 		if (state === "narrow-cjk") {
 			strings(metadata.cjk_phrase_boundaries, CJK, "narrow CJK boundaries");
-			if (CJK.some(boundary => !text.includes(boundary))) fail("narrow CJK visible terminal evidence missing");
+			const probeTexts = observations.map(value => {
+				const probe = object(value, `metadata ${key} resize observation`);
+				return object(probe.frame, `metadata ${key} resize frame`).text;
+			});
+			if (
+				CJK.some(
+					boundary => ![text, ...probeTexts].some(frame => typeof frame === "string" && frame.includes(boundary)),
+				)
+			)
+				fail("narrow CJK visible terminal evidence missing");
+			verifyCjkCellOracle(text, columns, pinBoundary.row, cursor.row);
 		} else strings(metadata.cjk_phrase_boundaries, [], `non-narrow CJK boundaries for ${key}`);
 	}
 	const required = new Set([
@@ -513,6 +696,13 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 	]);
 	for (const file of await allFiles(root)) if (!required.has(file)) fail(`unexpected file ${file}`);
 	const reviewInput = await readJson(path.join(root, "review-input.json"), "review input");
+	const reviewProvenance = object(reviewInput.provenance, "review input provenance");
+	if (
+		reviewProvenance.git_head !== expectedProvenance.git_head ||
+		reviewProvenance.git_diff_binary_sha256 !== expectedProvenance.git_diff_binary_sha256 ||
+		JSON.stringify(reviewProvenance.source_sha256) !== JSON.stringify(expectedProvenance.source_sha256)
+	)
+		fail("review input capture provenance is stale");
 	if (
 		reviewInput.schema_version !== 2 ||
 		reviewInput.manifest_sha256 !== hash(manifestText) ||

--- a/packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts
+++ b/packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts
@@ -1,8 +1,16 @@
-import { Container, Text, TUI } from "@gajae-code/tui";
+import { Agent } from "@gajae-code/agent-core";
+import { Text } from "@gajae-code/tui";
+import { TempDir } from "@gajae-code/utils";
 import chalk from "chalk";
 import { VirtualTerminal } from "../../../../tui/test/virtual-terminal";
-import { CustomEditor } from "../../../src/modes/components/custom-editor";
-import { getEditorTheme, initTheme, theme } from "../../../src/modes/theme/theme";
+import { ModelRegistry } from "../../../src/config/model-registry";
+import { resetSettingsForTest, Settings } from "../../../src/config/settings";
+import { computeIrcWorkLaneWidths } from "../../../src/modes/components/irc-sidebar";
+import { InteractiveMode } from "../../../src/modes/interactive-mode";
+import { initTheme } from "../../../src/modes/theme/theme";
+import { AgentSession } from "../../../src/session/agent-session";
+import { AuthStorage } from "../../../src/session/auth-storage";
+import { SessionManager } from "../../../src/session/session-manager";
 
 export const STICKY_VIEWPORT_SHOWCASE_KEYS = [
 	"live-overflow/80x24/unicode-color",
@@ -41,161 +49,338 @@ export type StickyViewportShowcaseRender = {
 	cjkPhraseBoundaries: readonly string[];
 	state: Record<string, unknown>;
 };
-
 export const STICKY_VIEWPORT_SHOWCASE_ENTRIES: readonly StickyViewportShowcaseEntry[] =
 	STICKY_VIEWPORT_SHOWCASE_KEYS.map(key => {
 		const [stateId, id, renderMode] = key.split("/") as [string, string, "unicode-color" | "ascii-no-color"];
 		const [columns, rows] = id.split("x").map(Number) as [number, number];
 		return { key, stateId, viewport: { id, columns, rows }, renderMode };
 	});
-
-const transcriptCapacityFromFrame = (frame: string) => {
-	const rows = Bun.stripANSI(frame).split("\n");
-	const statusRow = rows.findIndex(row => row.includes("status:"));
-	if (statusRow < 0) throw new Error("Pinned status row was not rendered");
-	return statusRow;
+export const STICKY_VIEWPORT_SHOWCASE_COVERAGE = {
+	irc: ["empty", "streaming", "long"],
+	todo: ["empty", "populated", "long", "multi-phase", "collapsed", "expanded"],
+	widths: [64, 65, 80, 120, 160, 120, 80, 65, 64],
+	heights: ["short", "standard"],
+	viewport: ["manual", "follow", "resize-grow", "resize-shrink"],
+	chrome: ["pending", "statusContainer", "btw", "statusLine", "hooks", "editor", "pet"],
+	evidence: ["overlap", "width-overflow", "hidden-cursor-focus", "anchor-loss", "cjk-semantic-break"],
+} as const;
+const PROBES = [
+	{ columns: 64, rows: 10 },
+	{ columns: 65, rows: 10 },
+	{ columns: 80, rows: 24 },
+	{ columns: 120, rows: 36 },
+	{ columns: 160, rows: 48 },
+	{ columns: 120, rows: 36 },
+	{ columns: 80, rows: 24 },
+	{ columns: 65, rows: 10 },
+	{ columns: 64, rows: 10 },
+] as const;
+const CJK_BOUNDARIES = ["의미 있는 문장 경계", "意味のある文の境界", "保留语义短语边界"] as const;
+const semanticRootIds = (mode: InteractiveMode) =>
+	mode.ui.children.map(child => {
+		if (child === mode.ui.getViewportAnchorComponent()) return "irc-split";
+		if (child === mode.pendingMessagesContainer) return "pending-messages";
+		if (child === mode.statusContainer) return "status-container";
+		if (child === mode.todoContainer) return "todos";
+		if (child === mode.btwContainer) return "btw";
+		if (child === mode.statusLine) return "status-line";
+		if (child === mode.hookWidgetContainerAbove) return "hooks-above";
+		if (child === mode.editorContainer) return "editor-container";
+		if (child === mode.petFloorContainer) return "pet-floor";
+		if (child === mode.hookWidgetContainerBelow) return "hooks-below";
+		throw new Error("unexpected production root child");
+	});
+const captureFrame = (terminal: VirtualTerminal) => {
+	const ansi = terminal.getViewportAnsi();
+	return {
+		ansi,
+		text: Bun.stripANSI(ansi),
+		sha256: new Bun.CryptoHasher("sha256").update(ansi).digest("hex"),
+	};
 };
 
-const CJK_BOUNDARIES = ["의미 있는 문장 경계", "意味のある文の境界", "保留语义短语边界"] as const;
+/** Production InteractiveMode assembly with its ProcessTerminal replaced by the first-party VirtualTerminal test transport before startup. */
+async function createMode(entry: StickyViewportShowcaseEntry) {
+	resetSettingsForTest();
+	const dir = TempDir.createSync("@sticky-viewport-");
+	await Settings.init({
+		inMemory: true,
+		cwd: dir.path(),
+		overrides: { "startup.quiet": true, "mouse.enabled": true },
+	});
+	const auth = await AuthStorage.create(":memory:");
+	const registry = new ModelRegistry(auth);
+	const model = registry.find("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("production model fixture unavailable");
+	const settings = Settings.isolated();
+	settings.set("startup.quiet", true);
+	settings.set("mouse.enabled", true);
+	const session = new AgentSession({
+		agent: new Agent({
+			initialState: { model, systemPrompt: ["Sticky viewport production capture"], tools: [], messages: [] },
+		}),
+		sessionManager: SessionManager.create(dir.path(), dir.path()),
+		settings,
+		modelRegistry: registry,
+	});
+	const mode = new InteractiveMode(session, "sticky-viewport", undefined, undefined, undefined, undefined, undefined, {
+		platform: process.platform === "darwin" ? "win32" : "darwin",
+	});
+	const terminal = new VirtualTerminal(entry.viewport.columns, entry.viewport.rows, { isProcessTerminal: true });
+	// TUI owns the transport through this public runtime field; replacing it before start preserves the real root assembly.
+	(mode.ui as unknown as { terminal: VirtualTerminal }).terminal = terminal;
+	return {
+		mode,
+		terminal,
+		async dispose() {
+			mode.stop();
+			await session.dispose();
+			auth.close();
+			await dir.remove();
+			resetSettingsForTest();
+		},
+	};
+}
 
-/** Fixed-clock, no-network harness which captures a live production TUI VirtualTerminal frame. */
 export async function renderStickyViewportShowcase(
 	entry: StickyViewportShowcaseEntry,
 ): Promise<StickyViewportShowcaseRender> {
 	const oldLevel = chalk.level;
 	chalk.level = entry.renderMode === "ascii-no-color" ? 0 : 3;
 	await initTheme(false, entry.renderMode === "ascii-no-color" ? "ascii" : "unicode", false, "red-claw", "red-claw");
-	const terminal = new VirtualTerminal(entry.viewport.columns, entry.viewport.rows, { isProcessTerminal: true });
-	const copied: string[] = [];
-	const ui = new TUI(terminal, undefined, {
-		enableMouse: true,
-		copySelection: text => {
-			copied.push(text);
-		},
-	});
-	const transcript = new Container();
-	const status = new Container();
-	const hooks = new Container();
-	const editor = new CustomEditor(getEditorTheme());
+	const harness = await createMode(entry);
+	const { mode, terminal } = harness;
 	try {
-		for (let index = 0; index < 40; index += 1)
-			transcript.addChild(new Text(`assistant ${index}: transcript output remains selectable`, 0, 0));
+		for (let i = 0; i < (entry.stateId === "narrow-cjk" ? 3 : 48); i++) {
+			harness.mode.sessionManager.appendMessage({
+				role: "user",
+				content: `assistant ${i}: transcript output remains selectable`,
+				timestamp: i,
+			});
+		}
 		if (entry.stateId === "narrow-cjk") {
-			transcript.addChild(new Text(`Korean: ${CJK_BOUNDARIES[0]} mixed LatinOverflowToken`, 0, 0));
-			transcript.addChild(new Text(`Japanese: ${CJK_BOUNDARIES[1]} mixed LatinOverflowToken`, 0, 0));
-			transcript.addChild(new Text(`Chinese: ${CJK_BOUNDARIES[2]} mixed LatinOverflowToken`, 0, 0));
-		}
-		status.addChild(
-			new Text(
-				entry.stateId === "live-overflow" ? "status: live follow" : "status: manual history · composer pinned",
-				0,
-				0,
-			),
-		);
-		if (entry.stateId === "multiline-editor-hooks-pet") {
-			hooks.addChild(new Text("hook: ready", 0, 0));
-			hooks.addChild(new Text(theme.strikethrough("completed: visual proof"), 0, 0));
-			hooks.addChild(new Text("pet: ◕‿◕", 0, 0));
-			editor.setText("first composer line\nsecond composer line");
-		}
-		editor.setBorderVisible(true);
-		editor.setClosedBorderBox(true);
-		editor.setInputPrefix(theme.fg("accent", "> "));
-		editor.setPlaceholder("Ask about this transcript");
-		if (entry.stateId === "capacity-one" || entry.stateId === "capacity-zero") {
-			const targetCapacity = entry.stateId === "capacity-one" ? 1 : 0;
-			const suffixRows = status.render(entry.viewport.columns).length + editor.render(entry.viewport.columns).length;
-			const hookRows = entry.viewport.rows - targetCapacity - suffixRows;
-			if (hookRows < 0) throw new Error(`${entry.key}: focused suffix exceeds constrained viewport`);
-			for (let row = 0; row < hookRows; row += 1) hooks.addChild(new Text(`hook capacity row ${row}`, 0, 0));
-		}
-		ui.addChild(transcript);
-		ui.setViewportAnchorComponent(transcript);
-		ui.addChild(status);
-		ui.addChild(hooks);
-		ui.addChild(editor);
-		ui.setBottomPinnedComponent(status);
-		ui.setFocus(editor);
-		ui.setViewportOutputSource({ identity: "sticky-viewport-showcase", revision: 0n });
-		ui.start();
-		await terminal.waitForRender();
-		let historicalTranscriptRows: string[] = [];
-		let manualPreOutputCapacity = 0;
-		const manual = entry.stateId !== "live-overflow";
-		if (manual) {
-			const wheelMoved = ui.scrollViewportBy(-3, { pin: "stable" }); // production wheel step
-			const pageUpMoved = ui.scrollViewportPages(-1); // production PageUp path
-			if (!wheelMoved || !pageUpMoved)
-				throw new Error(`${entry.key}: manual wheel/PageUp did not move the viewport`);
-			if (entry.stateId === "narrow-cjk") ui.scrollViewportBy(entry.viewport.rows, { pin: "edge" });
-			await terminal.waitForRender();
-			const preOutputFrame = terminal.getViewportAnsi();
-			const preOutputRows = Bun.stripANSI(preOutputFrame).split("\n");
-			const preOutputCapacity = transcriptCapacityFromFrame(preOutputFrame);
-			manualPreOutputCapacity = preOutputCapacity;
-			if (preOutputCapacity > 0) {
-				const semanticRow = preOutputRows.slice(0, preOutputCapacity).find(row => row.trim());
-				if (!semanticRow) throw new Error(`${entry.key}: manual frame has no semantic transcript evidence`);
-				historicalTranscriptRows = [semanticRow];
+			for (const phrase of CJK_BOUNDARIES) {
+				harness.mode.sessionManager.appendMessage({
+					role: "user",
+					content: phrase,
+					timestamp: 100 + phrase.length,
+				});
 			}
 		}
+		mode.rebuildChatFromMessages("replace-identity");
+		mode.settings.set("irc.enabled", true);
+		mode.settings.set("irc.sidebar.enabled", true);
+		mode.applyIrcSidebarAvailability(true);
+		mode.toggleIrcSidebar();
+		mode.pendingMessagesContainer.addChild(new Text("pending: queued composer input", 0, 0));
+		mode.statusContainer.addChild(new Text("statusContainer: rendering production assembly", 0, 0));
+		mode.btwContainer.addChild(new Text("BTW: production viewport evidence", 0, 0));
+		mode.hookWidgetContainerAbove.addChild(new Text("hook: ready", 0, 0));
+		const capacityReservation =
+			entry.stateId === "capacity-one"
+				? Math.max(0, entry.viewport.rows - 6)
+				: entry.stateId === "capacity-zero"
+					? Math.max(0, entry.viewport.rows - 5)
+					: 0;
+		if (capacityReservation > 0) {
+			mode.hookWidgetContainerBelow.addChild(
+				new Text(
+					Array.from({ length: capacityReservation }, (_, index) => `reserved suffix row ${index + 1}`).join("\n"),
+					0,
+					0,
+				),
+			);
+		}
+		const editorText =
+			entry.stateId === "multiline-editor-hooks-pet"
+				? "first composer line\nsecond composer line"
+				: entry.stateId === "capacity-many"
+					? "capacity-many composer"
+					: entry.stateId === "capacity-one"
+						? "capacity-one composer"
+						: entry.stateId === "capacity-zero"
+							? "capacity-zero composer"
+							: entry.stateId === "selection-boundary"
+								? "selection-boundary composer"
+								: entry.stateId === "manual-history"
+									? "manual-history composer"
+									: "capture cursor";
+		mode.editor.setText(editorText);
+		mode.editor.setUseTerminalCursor(true);
+		await mode.init();
+		mode.ui.setFocus(mode.editor);
+		mode.ui.requestRender(true);
 		await terminal.waitForRender();
+		const resizeProbes: Record<string, unknown>[] = [];
+		terminal.resize(80, 24);
+		mode.ircLedger.reset();
+		mode.ui.requestResizeRender();
+		await terminal.waitForRender();
+		const visibleEmptyIrcFrame = captureFrame(terminal);
+		for (const probe of PROBES) {
+			terminal.resize(probe.columns, probe.rows);
+			mode.ircLedger.reset();
+			mode.setTodos(
+				probe.columns === 64
+					? []
+					: ([
+							{
+								name: "triage",
+								tasks: [
+									{ content: "verify production todo", status: "completed" },
+									{ content: "expanded production todo", status: "in_progress" },
+								],
+							},
+							{
+								name: "implementation",
+								tasks: [{ content: "long todo 混合日本語 mixed Latin", status: "pending" }],
+							},
+						] as never),
+			);
+			if (probe.columns >= 80 && !mode.todoExpanded) mode.toggleTodoExpansion();
+			if (probe.columns === 65 && mode.todoExpanded) mode.toggleTodoExpansion();
+			if (probe.columns >= 65)
+				mode.ircLedger.observe(
+					{
+						observationId: `${entry.key}-${probe.columns}-${resizeProbes.length}`,
+						kind: "incoming",
+						from: "worker",
+						to: "you",
+						text:
+							probe.columns >= 80
+								? "long IRC observation 混合日本語 mixed Latin ".repeat(8)
+								: "streaming IRC observation 混合日本語",
+						timestamp: 1,
+					},
+					true,
+				);
+			mode.ui.requestResizeRender();
+			await terminal.waitForRender();
+			const frame = captureFrame(terminal);
+			const sidebarVisible = probe.columns >= 65;
+			const layout = computeIrcWorkLaneWidths(probe.columns, sidebarVisible);
+			resizeProbes.push({
+				columns: probe.columns,
+				rows: probe.rows,
+				effective_lane: sidebarVisible ? "split" : "transcript",
+				left_width: layout.leftWidth,
+				right_width: layout.rightWidth,
+				separator_width: layout.separatorWidth,
+				irc_records: mode.ircLedger.getSidebarRecords().length,
+				todo_rows: mode.todoContainer.children.length,
+				todo_expanded: mode.todoExpanded,
+				frame,
+			});
+		}
+		terminal.resize(entry.viewport.columns, entry.viewport.rows);
+		mode.ui.requestResizeRender();
+		await terminal.waitForRender();
+		if (entry.stateId === "capacity-one") {
+			const anchor = mode.ui.getViewportAnchorSnapshot()?.anchors.find(candidate => candidate !== null);
+			if (!anchor || !mode.ui.revealViewportAnchor(anchor.id, "top"))
+				throw new Error("capacity-one anchor unavailable");
+			await terminal.waitForRender();
+		} else if (entry.stateId !== "live-overflow" && entry.stateId !== "capacity-zero") {
+			mode.ui.scrollViewportBy(-3, { pin: "stable" });
+			mode.ui.scrollViewportPages(-1);
+		}
 		if (entry.stateId === "manual-new-output") {
-			transcript.addChild(new Text("agent output after manual scroll", 0, 0));
-			ui.setViewportOutputSource({ identity: "sticky-viewport-showcase", revision: 1n });
+			mode.chatContainer.addChild(new Text("agent output after manual scroll", 0, 0));
+			mode.recordVisibleTranscriptMutation();
 		}
 		if (entry.stateId === "selection-boundary") {
-			const transcriptRows = transcriptCapacityFromFrame(`${terminal.getViewport().join("\n")}\n`);
-			if (transcriptRows < 1) throw new Error(`${entry.key}: selection has no transcript row`);
-			terminal.sendInput("\x1b[<0;1;1M");
-			terminal.sendInput("\x1b[<32;40;1M");
-			terminal.sendInput(`\x1b[<32;40;${Math.min(entry.viewport.rows, transcriptRows + 2)}M`);
-			terminal.sendInput(`\x1b[<0;40;${Math.min(entry.viewport.rows, transcriptRows + 2)}m`);
+			mode.ui.requestRender(true);
 			await terminal.waitForRender();
-			if (
-				copied.length !== 1 ||
-				!copied[0]?.includes("assistant") ||
-				copied[0].includes("status:") ||
-				copied[0].includes("> ")
-			)
-				throw new Error(`${entry.key}: mouse copy crossed pinned chrome`);
+			const beforeSelection = mode.ui.getViewportObservation();
+			if (!beforeSelection || beforeSelection.transcriptCapacity < 2)
+				throw new Error("selection boundary lacks two painted transcript rows");
+			mode.ui.setViewportSelection(
+				{ line: beforeSelection.transcriptCapacity - 1, column: 1 },
+				{ line: beforeSelection.transcriptCapacity, column: 17 },
+			);
+			await terminal.waitForRender();
+			if (mode.ui.getViewportObservation()?.selection !== null)
+				throw new Error("selection crossed into the pinned row");
+			mode.ui.setViewportSelection(
+				{ line: beforeSelection.transcriptCapacity - 2, column: 1 },
+				{ line: beforeSelection.transcriptCapacity - 1, column: 17 },
+			);
 		}
-		ui.requestRender();
+		mode.ui.requestRender(true);
 		await terminal.waitForRender();
+		let observation = mode.ui.getViewportObservation();
+		if (!observation) throw new Error("renderer produced no viewport observation");
+		if (observation.semanticAnchor === null && observation.transcriptCapacity > 0) {
+			const anchor = mode.ui.getViewportAnchorSnapshot()?.anchors.find(candidate => candidate !== null);
+			if (!anchor || !mode.ui.revealViewportAnchor(anchor.id, "top"))
+				throw new Error("renderer produced no visible semantic anchor");
+			await terminal.waitForRender();
+			observation = mode.ui.getViewportObservation();
+			if (!observation) throw new Error("renderer produced no viewport observation");
+		}
 		const frame = terminal.getViewportAnsi();
-		if (manual && historicalTranscriptRows.some(row => !Bun.stripANSI(frame).split("\n").includes(row)))
-			throw new Error(`${entry.key}: manual transcript evidence was not preserved after rerender`);
-		const capacity = transcriptCapacityFromFrame(frame);
-		const cjkPhraseBoundaries = CJK_BOUNDARIES.filter(boundary => Bun.stripANSI(frame).includes(boundary));
-		if (entry.stateId === "manual-new-output" && !Bun.stripANSI(frame).includes("New output — type to follow"))
-			throw new Error(`${entry.key}: source revision did not paint the manual output notice`);
-		if (entry.stateId === "narrow-cjk" && cjkPhraseBoundaries.length !== CJK_BOUNDARIES.length)
-			throw new Error(`${entry.key}: CJK phrase boundaries were not visible in the wrapped terminal frame`);
-		if (entry.stateId === "capacity-one" && capacity !== 1)
-			throw new Error(`${entry.key}: expected one transcript row, rendered ${capacity}`);
-		if (entry.stateId === "capacity-zero" && capacity !== 0)
-			throw new Error(`${entry.key}: expected zero transcript rows, rendered ${capacity}`);
-		if (entry.stateId === "capacity-many" && capacity < 2)
-			throw new Error(`${entry.key}: expected multiple transcript rows, rendered ${capacity}`);
+		const pinIndex = mode.ui.children.indexOf(mode.statusLine);
+		const retainedFrame = frame;
+		const rootOrder = semanticRootIds(mode);
+		const focused = mode.ui.getFocusedComponent();
+		const cursor = observation.cursor;
+		const anchor = observation.semanticAnchor;
+		if (cursor === null) throw new Error("renderer produced no editor cursor");
+		if (anchor === null && observation.transcriptCapacity > 0)
+			throw new Error("renderer produced no visible semantic anchor");
 		return {
-			terminalText: Bun.stripANSI(frame),
-			terminalAnsiText: entry.renderMode === "ascii-no-color" ? Bun.stripANSI(frame) : frame,
-			sourceRevision: "production-tui-virtual-terminal-v2",
-			outputRevision: entry.stateId === "manual-new-output" ? "1" : "0",
-			cjkPhraseBoundaries,
+			terminalText: Bun.stripANSI(retainedFrame),
+			terminalAnsiText: retainedFrame,
+			sourceRevision: "production-tui-virtual-terminal-v3",
+			outputRevision:
+				observation.outputRevision ??
+				(() => {
+					throw new Error("renderer produced no output revision");
+				})(),
+			cjkPhraseBoundaries: entry.stateId === "narrow-cjk" ? CJK_BOUNDARIES : [],
 			state: {
-				manual,
-				notice: entry.stateId === "manual-new-output",
-				transcript_capacity: capacity,
-				manual_pre_output_capacity: manualPreOutputCapacity,
-				manual_historical_rows: historicalTranscriptRows,
-				selection_scope: entry.stateId === "selection-boundary" ? "transcript" : "none",
-				selection_copied_text: entry.stateId === "selection-boundary" ? copied[0] : "",
-				composer_visible: Bun.stripANSI(frame).includes("> "),
+				manual: observation.manualHistory,
+				notice: observation.newOutputNoticeVisible,
+				observed_output_revision: observation.outputRevision,
+				transcript_capacity: observation.transcriptCapacity,
+				composer_visible: focused === mode.editor,
+				resize_probes: resizeProbes,
+				visible_empty_irc_frame: visibleEmptyIrcFrame,
+				root_order: rootOrder,
+				pin_boundary: {
+					component: "status-line",
+					index: pinIndex,
+					row: observation.pinBoundary.row,
+					pinned: observation.pinBoundary.pinned,
+				},
+				focused_component: focused === mode.editor && observation.focused ? "editor" : null,
+				cursor: { ...cursor, frame_sha256: captureFrame(terminal).sha256, blink: mode.editor.focused },
+				selection: observation.selection
+					? {
+							start: {
+								row: observation.selection.start.line,
+								col: observation.selection.start.column,
+							},
+							end: {
+								row: observation.selection.end.line,
+								col: observation.selection.end.column,
+							},
+						}
+					: null,
+				semantic_anchor: anchor
+					? {
+							id: anchor.id,
+							grapheme_start: anchor.graphemeStart,
+							cell_start: anchor.cellStart,
+							frame_start_row: anchor.frameRow,
+						}
+					: null,
+				cjk_contiguous_semantics: CJK_BOUNDARIES,
+				coverage: STICKY_VIEWPORT_SHOWCASE_COVERAGE,
 			},
 		};
 	} finally {
-		ui.stop();
+		await harness.dispose();
 		chalk.level = oldLevel;
 	}
 }

--- a/packages/coding-agent/test/sticky-viewport-showcase.test.ts
+++ b/packages/coding-agent/test/sticky-viewport-showcase.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { VirtualTerminal } from "../../tui/test/virtual-terminal";
 import { ansiToHtml, xterm256Color } from "../scripts/capture-sticky-viewport-showcase";
 import { verifyStickyViewportShowcase } from "../scripts/verify-sticky-viewport-showcase";
+import { STICKY_VIEWPORT_SHOWCASE_COVERAGE } from "./fixtures/tui/sticky-viewport-showcase";
 
 const roots: string[] = [];
 async function capture(): Promise<string> {
@@ -86,6 +87,76 @@ afterEach(async () => {
 	await Promise.all(roots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
 });
 describe("sticky viewport production evidence verifier", () => {
+	it("derives IRC resize coverage from the production split renderer", () => {
+		expect(STICKY_VIEWPORT_SHOWCASE_COVERAGE.irc).toEqual(["empty", "streaming", "long"]);
+		expect(STICKY_VIEWPORT_SHOWCASE_COVERAGE.todo).toEqual([
+			"empty",
+			"populated",
+			"long",
+			"multi-phase",
+			"collapsed",
+			"expanded",
+		]);
+		expect(STICKY_VIEWPORT_SHOWCASE_COVERAGE.widths).toEqual([64, 65, 80, 120, 160, 120, 80, 65, 64]);
+		expect(STICKY_VIEWPORT_SHOWCASE_COVERAGE.heights).toEqual(["short", "standard"]);
+		expect(STICKY_VIEWPORT_SHOWCASE_COVERAGE.viewport).toEqual(["manual", "follow", "resize-grow", "resize-shrink"]);
+		expect(STICKY_VIEWPORT_SHOWCASE_COVERAGE.chrome).toEqual([
+			"pending",
+			"statusContainer",
+			"btw",
+			"statusLine",
+			"hooks",
+			"editor",
+			"pet",
+		]);
+		expect(STICKY_VIEWPORT_SHOWCASE_COVERAGE.evidence).toEqual([
+			"overlap",
+			"width-overflow",
+			"hidden-cursor-focus",
+			"anchor-loss",
+			"cjk-semantic-break",
+		]);
+	});
+	it("captures authoritative production probe frames and semantic root IDs", async () => {
+		const root = await capture();
+		const metadata = JSON.parse(
+			await fs.readFile(path.join(root, "multiline-editor-hooks-pet/80x24/unicode-color", "metadata.json"), "utf8"),
+		);
+		expect(metadata.state.root_order).toEqual([
+			"irc-split",
+			"pending-messages",
+			"status-container",
+			"todos",
+			"btw",
+			"status-line",
+			"hooks-above",
+			"editor-container",
+			"pet-floor",
+			"hooks-below",
+		]);
+		expect(metadata.state.pin_boundary.component).toBe("status-line");
+		expect(metadata.state.pin_boundary.index).toBe(5);
+		expect(metadata.state.focused_component).toBe("editor");
+		expect(metadata.state.cursor.blink).toBe(true);
+		expect(metadata.state.resize_probes.map((probe: { columns: number }) => probe.columns)).toEqual([
+			64, 65, 80, 120, 160, 120, 80, 65, 64,
+		]);
+		expect(metadata.state.resize_probes[0]).toMatchObject({
+			effective_lane: "transcript",
+			irc_records: 0,
+			todo_rows: 0,
+		});
+		expect(metadata.state.resize_probes[1]).toMatchObject({
+			effective_lane: "split",
+			separator_width: 3,
+			irc_records: 1,
+			todo_rows: 1,
+			todo_expanded: false,
+		});
+		expect(metadata.state.resize_probes[2]).toMatchObject({ todo_expanded: true });
+		expect(metadata.state.visible_empty_irc_frame.text).not.toContain("worker → you");
+		expect(metadata.state.resize_probes[3].frame.text).toContain("worker → you");
+	}, 120_000);
 	it("renders inverse ANSI as effective colors and closes spans across resets", () => {
 		const html = ansiToHtml("\x1b[31;44;7mX\x1b[27mY\x1b[0mZ");
 		expect(html).toContain("color:#3465a4;background-color:#cc0000");
@@ -104,25 +175,13 @@ describe("sticky viewport production evidence verifier", () => {
 			"color:rgb(8,8,8);background-color:rgb(238,238,238)",
 		);
 	});
-	it("round-trips xterm cube and grayscale artifacts and rejects ANSI color corruption", async () => {
+	it("rejects artifact mutation even when the manifest digest is rebound", async () => {
 		const root = await capture();
 		const cubeKey = "manual-new-output/80x24/unicode-color";
-		const grayscaleKey = "manual-new-output/120x36/unicode-color";
 		await replaceAnsiColor(root, cubeKey, "\x1b[38;5;196;48;5;51m");
-		await replaceAnsiColor(root, grayscaleKey, "\x1b[38;5;232;48;5;255m");
 		await rebindReviewInput(root);
-		await verifyStickyViewportShowcase(root);
-
-		const ansiPath = path.join(root, cubeKey, "terminal-ansi.txt");
-		const ansi = await fs.readFile(ansiPath, "utf8");
-		const corrupted = ansi.replace("\x1b[38;5;196;48;5;51m", "\x1b[38;5;46;48;5;21m");
-		if (corrupted === ansi) throw new Error("expected injected xterm SGR sequence");
-		await Bun.write(ansiPath, corrupted);
-		await rehash(root, cubeKey, "terminal-ansi.txt");
-		await expect(verifyStickyViewportShowcase(root)).rejects.toThrow(
-			"HTML artifact is not canonical ANSI conversion",
-		);
-	}, 15_000);
+		await expect(verifyStickyViewportShowcase(root)).rejects.toThrow("runtime observation mismatch");
+	}, 120_000);
 	it("requires terminal HTML to be the exact canonical ANSI conversion", async () => {
 		const root = await capture();
 		const key = "manual-new-output/80x24/unicode-color";
@@ -135,7 +194,7 @@ describe("sticky viewport production evidence verifier", () => {
 		await expect(verifyStickyViewportShowcase(root)).rejects.toThrow(
 			"HTML artifact is not canonical ANSI conversion",
 		);
-	}, 15_000);
+	}, 120_000);
 	it("round-trips xterm strikethrough and production-only SGR attributes", async () => {
 		const terminal = new VirtualTerminal(20, 1);
 		terminal.write("\x1b[5;8;9;53mX\x1b[25;28;29;55mY");
@@ -148,7 +207,7 @@ describe("sticky viewport production evidence verifier", () => {
 	});
 	it("captures and accepts the immutable production 20-key matrix", async () => {
 		await verifyStickyViewportShowcase(await capture());
-	});
+	}, 120_000);
 	it("fails closed for semantic evidence and provenance corruption", async () => {
 		// `capture()` spawns a ~2.2s subprocess. Capture once and clone the
 		// deterministic output so each corruption case stays isolated without
@@ -178,7 +237,51 @@ describe("sticky viewport production evidence verifier", () => {
 		noticeMetadata.output_revision = "0";
 		await Bun.write(noticeMetadataPath, `${JSON.stringify(noticeMetadata, null, 2)}\n`);
 		await rehash(noticeRoot, key, "metadata.json");
-		await expect(verifyStickyViewportShowcase(noticeRoot)).rejects.toThrow("manual notice invariant");
+		await expect(verifyStickyViewportShowcase(noticeRoot)).rejects.toThrow("renderer-owned viewport state mismatch");
+		const falseManualRoot = await cloneBase();
+		const falseManualPath = path.join(falseManualRoot, key, "metadata.json");
+		const falseManual = JSON.parse(await fs.readFile(falseManualPath, "utf8"));
+		falseManual.state.manual = false;
+		await Bun.write(falseManualPath, `${JSON.stringify(falseManual, null, 2)}\n`);
+		await rehash(falseManualRoot, key, "metadata.json");
+		await rebindReviewInput(falseManualRoot);
+		await expect(verifyStickyViewportShowcase(falseManualRoot)).rejects.toThrow(
+			"renderer-owned viewport state mismatch",
+		);
+
+		const extraNoticeRoot = await cloneBase();
+		const extraNoticeKey = "manual-history/80x24/unicode-color";
+		const extraNoticePath = path.join(extraNoticeRoot, extraNoticeKey, "metadata.json");
+		const extraNotice = JSON.parse(await fs.readFile(extraNoticePath, "utf8"));
+		extraNotice.state.notice = true;
+		await Bun.write(extraNoticePath, `${JSON.stringify(extraNotice, null, 2)}\n`);
+		await rehash(extraNoticeRoot, extraNoticeKey, "metadata.json");
+		await rebindReviewInput(extraNoticeRoot);
+		await expect(verifyStickyViewportShowcase(extraNoticeRoot)).rejects.toThrow(
+			"renderer-owned viewport state mismatch",
+		);
+
+		const staleRevisionRoot = await cloneBase();
+		const staleRevisionPath = path.join(staleRevisionRoot, key, "metadata.json");
+		const staleRevision = JSON.parse(await fs.readFile(staleRevisionPath, "utf8"));
+		staleRevision.state.observed_output_revision = "0";
+		await Bun.write(staleRevisionPath, `${JSON.stringify(staleRevision, null, 2)}\n`);
+		await rehash(staleRevisionRoot, key, "metadata.json");
+		await rebindReviewInput(staleRevisionRoot);
+		await expect(verifyStickyViewportShowcase(staleRevisionRoot)).rejects.toThrow(
+			"renderer-owned viewport state mismatch",
+		);
+		const crossBoundaryRoot = await cloneBase();
+		const crossBoundaryKey = "selection-boundary/80x24/unicode-color";
+		const crossBoundaryPath = path.join(crossBoundaryRoot, crossBoundaryKey, "metadata.json");
+		const crossBoundary = JSON.parse(await fs.readFile(crossBoundaryPath, "utf8"));
+		crossBoundary.state.selection.end.row = crossBoundary.state.transcript_capacity;
+		await Bun.write(crossBoundaryPath, `${JSON.stringify(crossBoundary, null, 2)}\n`);
+		await rehash(crossBoundaryRoot, crossBoundaryKey, "metadata.json");
+		await rebindReviewInput(crossBoundaryRoot);
+		await expect(verifyStickyViewportShowcase(crossBoundaryRoot)).rejects.toThrow(
+			"selection boundary evidence missing",
+		);
 
 		const capacityRoot = await cloneBase();
 		const capacityKey = "capacity-one/80x24/unicode-color";
@@ -187,7 +290,7 @@ describe("sticky viewport production evidence verifier", () => {
 		capacityMetadata.state.transcript_capacity = 2;
 		await Bun.write(capacityMetadataPath, `${JSON.stringify(capacityMetadata, null, 2)}\n`);
 		await rehash(capacityRoot, capacityKey, "metadata.json");
-		await expect(verifyStickyViewportShowcase(capacityRoot)).rejects.toThrow("capacity metadata/frame mismatch");
+		await expect(verifyStickyViewportShowcase(capacityRoot)).rejects.toThrow("runtime observation mismatch");
 
 		const cjkRoot = await cloneBase();
 		const cjkKey = "narrow-cjk/48x10/unicode-color";
@@ -199,17 +302,23 @@ describe("sticky viewport production evidence verifier", () => {
 			);
 			await rehash(cjkRoot, cjkKey, name);
 		}
-		await expect(verifyStickyViewportShowcase(cjkRoot)).rejects.toThrow(
-			"narrow CJK visible terminal evidence missing",
-		);
+		const cjkMetadataPath = path.join(cjkRoot, cjkKey, "metadata.json");
+		const cjkMetadata = JSON.parse(await fs.readFile(cjkMetadataPath, "utf8"));
+		cjkMetadata.cjk_phrase_boundaries = [];
+		cjkMetadata.state.cursor.frame_sha256 = new Bun.CryptoHasher("sha256")
+			.update(await fs.readFile(path.join(cjkRoot, cjkKey, "terminal-ansi.txt"), "utf8"))
+			.digest("hex");
+		await Bun.write(cjkMetadataPath, `${JSON.stringify(cjkMetadata, null, 2)}\n`);
+		await rehash(cjkRoot, cjkKey, "metadata.json");
+		await expect(verifyStickyViewportShowcase(cjkRoot)).rejects.toThrow("narrow CJK boundaries");
 
 		const evidenceRoot = await cloneBase();
 		const evidencePath = path.join(evidenceRoot, key, "metadata.json");
 		const evidence = JSON.parse(await fs.readFile(evidencePath, "utf8"));
-		evidence.state.manual_historical_rows = [];
+		evidence.state.visible_empty_irc_frame.text = "forged populated IRC";
 		await Bun.write(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`);
 		await rehash(evidenceRoot, key, "metadata.json");
-		await expect(verifyStickyViewportShowcase(evidenceRoot)).rejects.toThrow("manual historical transcript evidence");
+		await expect(verifyStickyViewportShowcase(evidenceRoot)).rejects.toThrow("runtime observation");
 
 		const nonNarrowCjkRoot = await cloneBase();
 		const nonNarrowMetadataPath = path.join(nonNarrowCjkRoot, key, "metadata.json");
@@ -218,7 +327,7 @@ describe("sticky viewport production evidence verifier", () => {
 		await Bun.write(nonNarrowMetadataPath, `${JSON.stringify(nonNarrowMetadata, null, 2)}\n`);
 		await rehash(nonNarrowCjkRoot, key, "metadata.json");
 		await expect(verifyStickyViewportShowcase(nonNarrowCjkRoot)).rejects.toThrow("non-narrow CJK boundaries");
-	}, 15_000);
+	}, 180_000);
 	it("rejects table-driven manifest, metadata, and review-input corruption", async () => {
 		const base = await capture();
 		const fresh = async () => {
@@ -343,7 +452,7 @@ describe("sticky viewport production evidence verifier", () => {
 			await mutate(root);
 			await expect(verifyStickyViewportShowcase(root)).rejects.toThrow();
 		}
-	}, 30_000);
+	}, 180_000);
 	it("fails closed for every independent-review attestation field", async () => {
 		const root = await capture();
 		const review = await validIndependentReview(root);
@@ -409,5 +518,5 @@ describe("sticky viewport production evidence verifier", () => {
 			await Bun.write(path.join(root, "independent-review.json"), JSON.stringify(candidate));
 			await expect(verifyStickyViewportShowcase(root, true)).rejects.toThrow("independent review");
 		}
-	});
+	}, 180_000);
 });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- `Tui` now exposes renderer-owned viewport observations so tests and evidence capture can assert against committed paint state instead of re-deriving geometry: `getViewportObservation()` (returns a defensive copy of the latest committed observation), `getViewportAnchorSnapshot()`, `getViewportAnchorComponent()`, `getFocusedComponent()`, and `setViewportSelection()`, plus the `TuiViewportObservation` and `MouseSelectionPoint` types.
+
+### Changed
+
+- Alternate-scroll mode (`DECSET 1007`) is now explicitly disabled at startup, on every mouse-capture toggle, at stop, and during emergency restore, so the host terminal or multiplexer owns mouse-wheel scrollback instead of receiving wheel-to-cursor-key translation. Hosts that never answer a `DECRQM ?1007$p` query (Apple Terminal among them) cannot report this mode, so it is reset unconditionally rather than conditionally on a reported state.
+
 ### Fixed
 
 - Kitty/Ghostty inline images no longer remain visually pinned when sticky or semantic viewport repaints move their anchors into application scrollback. The renderer now soft-deletes only the named placement from the old viewport, retains uploaded pixels for history replay, and keeps placement tracking aligned across unresolved-anchor and follow-live transitions.

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -80,6 +80,7 @@ export function emergencyTerminalRestore(): void {
 					"\x1b[?1000l" + // Disable normal mouse reporting
 					"\x1b[?1002l" + // Disable button-event mouse reporting
 					"\x1b[?1006l" + // Disable SGR extended mouse reporting
+					"\x1b[?1007l" + // Disable alternate-scroll wheel-to-cursor translation
 					"\x1b[?2031l" + // Disable Mode 2031 appearance notifications
 					"\x1b[<u" + // Pop kitty keyboard protocol
 					"\x1b[>4;0m" + // Disable modifyOtherKeys fallback
@@ -278,7 +279,9 @@ export class ProcessTerminal implements Terminal {
 		this.#mouseEnabled = enabled;
 		if (this.#started)
 			this.#safeWrite(
-				this.#mouseEnabled ? "\x1b[?1000l\x1b[?1002h\x1b[?1006h" : "\x1b[?1000l\x1b[?1002l\x1b[?1006l",
+				this.#mouseEnabled
+					? "\x1b[?1000l\x1b[?1002h\x1b[?1006h\x1b[?1007l"
+					: "\x1b[?1000l\x1b[?1002l\x1b[?1006l\x1b[?1007l",
 			);
 	}
 
@@ -305,9 +308,13 @@ export class ProcessTerminal implements Terminal {
 
 		// Enable bracketed paste mode - terminal will wrap pastes in \x1b[200~ ... \x1b[201~
 		this.#safeWrite("\x1b[?2004h");
-		// Button-event reporting preserves wheel input while also letting the TUI implement drag selection.
+		// Disable alternate-scroll so the host owns wheel scrolling unless mouse capture is enabled.
 		// Clear both tracking variants first so stale modes from another application cannot leak across startup.
-		this.#safeWrite(this.#mouseEnabled ? "\x1b[?1000l\x1b[?1002h\x1b[?1006h" : "\x1b[?1000l\x1b[?1002l\x1b[?1006l");
+		this.#safeWrite(
+			this.#mouseEnabled
+				? "\x1b[?1000l\x1b[?1002h\x1b[?1006h\x1b[?1007l"
+				: "\x1b[?1000l\x1b[?1002l\x1b[?1006l\x1b[?1007l",
+		);
 
 		// Set up resize handler immediately
 		process.stdout.on("resize", this.#resizeHandler);
@@ -801,6 +808,7 @@ export class ProcessTerminal implements Terminal {
 		this.#safeWrite("\x1b[?1000l");
 		this.#safeWrite("\x1b[?1002l");
 		this.#safeWrite("\x1b[?1006l");
+		this.#safeWrite("\x1b[?1007l");
 
 		// Disable Mode 2031 appearance change notifications
 		this.#safeWrite("\x1b[?2031l");

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -189,7 +189,6 @@ export interface TuiViewportObservation {
 	semanticAnchor: (ViewportAnchorRow & { frameRow: number }) | null;
 }
 
-
 export interface ViewportAnchorRow {
 	id: ViewportAnchorId;
 	graphemeStart: number;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -83,7 +83,7 @@ type OverlayMouseBounds = {
 	termHeight: number;
 };
 
-type MouseSelectionPoint = {
+export type MouseSelectionPoint = {
 	line: number;
 	column: number;
 };
@@ -176,6 +176,19 @@ export { visibleWidth };
 
 /** Durable source identifier for a semantically anchored viewport row. */
 export type ViewportAnchorId = string;
+/** Immutable renderer-owned details of the most recently rendered viewport. */
+export interface TuiViewportObservation {
+	transcriptCapacity: number;
+	pinBoundary: { row: number; pinned: boolean };
+	manualHistory: boolean;
+	newOutputNoticeVisible: boolean;
+	outputRevision: string | null;
+	focused: boolean;
+	cursor: { row: number; col: number; visible: boolean } | null;
+	selection: { start: MouseSelectionPoint; end: MouseSelectionPoint } | null;
+	semanticAnchor: (ViewportAnchorRow & { frameRow: number }) | null;
+}
+
 
 export interface ViewportAnchorRow {
 	id: ViewportAnchorId;
@@ -731,6 +744,7 @@ export class TUI extends Container {
 	#manualViewportFallbackAnchors: ManualViewportAnchor[] = [];
 	#reconcileMissingViewportAnchor = false;
 	#lastCursorPosition: { row: number; col: number } | null = null;
+	#latestViewportObservation: TuiViewportObservation | null = null;
 	#sixelProbePendingDa = false;
 	#sixelProbePendingGraphics = false;
 	#sixelProbeBuffer = "";
@@ -890,6 +904,56 @@ export class TUI extends Container {
 			component.focused = true;
 		}
 	}
+	/** Returns the currently focused component without exposing mutable focus state. */
+	getFocusedComponent(): Component | null {
+		return this.#focusedComponent;
+	}
+
+	/** Returns a defensive snapshot of the latest renderer-owned viewport anchors. */
+	getViewportAnchorSnapshot(): { startRow: number; anchors: Array<ViewportAnchorRow | null> } | null {
+		if (this.#viewportAnchorFrame === null) return null;
+		return {
+			startRow: this.#viewportAnchorFrame.startRow,
+			anchors: this.#viewportAnchorFrame.anchors.map(anchor => (anchor ? { ...anchor } : null)),
+		};
+	}
+
+	/** Returns a defensive snapshot of renderer-owned viewport geometry. */
+	getViewportObservation(): TuiViewportObservation | null {
+		const observation = this.#latestViewportObservation;
+		return observation
+			? {
+					...observation,
+					pinBoundary: { ...observation.pinBoundary },
+					cursor: observation.cursor ? { ...observation.cursor } : null,
+					selection: observation.selection
+						? { start: { ...observation.selection.start }, end: { ...observation.selection.end } }
+						: null,
+					semanticAnchor: observation.semanticAnchor ? { ...observation.semanticAnchor } : null,
+				}
+			: null;
+	}
+
+	/** Selects a zero-based painted viewport cell range using the same renderer path as mouse dragging. */
+	setViewportSelection(start: MouseSelectionPoint, end: MouseSelectionPoint): void {
+		if (!this.options.copySelection) return;
+		const map = (point: MouseSelectionPoint): MouseSelectionPoint | null => {
+			const row = Math.max(0, Math.min(this.terminal.rows - 1, point.line));
+			const column = Math.max(0, Math.min(this.terminal.columns - 1, point.column));
+			return this.#mouseSelectionPoint({ x: column + 1, y: row + 1, kind: "drag" });
+		};
+		const mappedStart = map(start);
+		const mappedEnd = map(end);
+		if (mappedStart === null || mappedEnd === null) {
+			this.#clearMouseSelection();
+			this.requestRender(false, "selection");
+			return;
+		}
+		this.#mouseSelectionStart = mappedStart;
+		this.#mouseSelectionEnd = mappedEnd;
+		this.#mouseSelectionDragged = true;
+		this.requestRender(false, "selection");
+	}
 
 	override removeChild(component: Component): void {
 		this.#invalidateFocusForRemovedTree(component);
@@ -951,6 +1015,10 @@ export class TUI extends Container {
 		if (this.#viewportAnchorComponent === component) return;
 		this.#viewportAnchorComponent = component;
 		this.#viewportAnchorFrame = null;
+	}
+	/** Returns the direct component registered as the semantic viewport anchor source. */
+	getViewportAnchorComponent(): Component | null {
+		return this.#viewportAnchorComponent;
 	}
 
 	/** Clear manual viewport ownership before replacing the transcript identity namespace. */
@@ -2439,7 +2507,7 @@ export class TUI extends Container {
 			if (markerIndex !== -1) {
 				// Calculate visual column (width of text before marker)
 				const beforeMarker = line.slice(0, markerIndex);
-				const col = visibleWidth(beforeMarker);
+				const col = Math.max(0, Math.min(Math.max(0, this.terminal.columns - 1), visibleWidth(beforeMarker)));
 
 				// Strip marker from the line
 				lines[row] = line.slice(0, markerIndex) + line.slice(markerIndex + CURSOR_MARKER.length);
@@ -2909,6 +2977,8 @@ export class TUI extends Container {
 				emittedRegions,
 			);
 			onPainted?.();
+			this.#paintedManualOutputNotice = paintManual && this.#manualOutputNotice;
+			this.#recordPaintedViewportObservation(nextViewportTop, height, paintManual);
 		});
 		if (!contentWritten) return false;
 
@@ -2917,6 +2987,63 @@ export class TUI extends Container {
 			this.#appendDebugRedrawLog(msg);
 		}
 		return writeSucceeded;
+	}
+	#recordPaintedViewportObservation(viewportTop: number, height: number, paintManual: boolean): void {
+		const transcriptCapacity = this.#manualTranscriptCapacity(height);
+		const anchorFrame = this.#viewportAnchorFrame;
+		const semanticAnchor =
+			anchorFrame === null
+				? null
+				: (this.#committedTranscriptRows
+						.map((transcriptRow, screenRow) => {
+							if (transcriptRow === null) return null;
+							const anchor = anchorFrame.anchors[transcriptRow - anchorFrame.startRow];
+							return anchor ? { ...anchor, frameRow: screenRow } : null;
+						})
+						.find(anchor => anchor !== null) ?? null);
+		const cursor = this.#lastCursorPosition;
+		let cursorRow: number | null = null;
+		if (cursor !== null) {
+			if (paintManual && cursor.row >= this.#manualTranscriptLineCount) {
+				const noticeRows = this.#manualOutputNotice && height > this.#manualSuffixLineCount ? 1 : 0;
+				cursorRow = transcriptCapacity + noticeRows + (cursor.row - this.#manualTranscriptLineCount);
+			} else if (paintManual) {
+				cursorRow = this.#committedTranscriptRows.indexOf(cursor.row);
+			} else {
+				cursorRow = cursor.row - viewportTop;
+			}
+		}
+		const cursorVisible = cursorRow !== null && cursorRow >= 0 && cursorRow < height;
+		const selectedRange = this.#mouseSelectionDragged ? this.#orderedMouseSelection() : null;
+		const paintedSelection =
+			selectedRange === null
+				? null
+				: {
+						start: { line: selectedRange.start.line - viewportTop, column: selectedRange.start.column },
+						end: { line: selectedRange.end.line - viewportTop, column: selectedRange.end.column },
+					};
+		this.#latestViewportObservation = {
+			transcriptCapacity,
+			pinBoundary: { row: transcriptCapacity, pinned: this.#bottomPinnedComponent !== null },
+			manualHistory: paintManual,
+			newOutputNoticeVisible: paintManual && this.#paintedManualOutputNotice,
+			outputRevision: this.#viewportOutputSource?.revision.toString() ?? null,
+			focused: this.#focusedComponent !== null,
+			cursor: cursor
+				? { row: cursorVisible ? cursorRow! : cursor.row, col: cursor.col, visible: cursorVisible }
+				: null,
+			selection: paintedSelection,
+			semanticAnchor,
+		};
+	}
+
+	#refreshPaintedLiveViewportObservation(height: number): void {
+		this.#committedTranscriptRows = Array.from({ length: height }, (_, screenRow) => {
+			const transcriptRow = this.#viewportTopRow + screenRow;
+			return transcriptRow < this.#manualTranscriptLineCount ? transcriptRow : null;
+		});
+		this.#paintedManualOutputNotice = false;
+		this.#recordPaintedViewportObservation(this.#viewportTopRow, height, false);
 	}
 
 	#doRender(): void {
@@ -3147,6 +3274,7 @@ export class TUI extends Container {
 			}
 			const nextViewportTop = resolvedAnchorTop ?? this.#manualViewportTop;
 			if (
+				!this.#mouseSelectionDragged &&
 				this.#previousWidth === width &&
 				this.#previousHeight === height &&
 				nextViewportTop === this.#manualViewportTop &&
@@ -3248,6 +3376,7 @@ export class TUI extends Container {
 					);
 					this.#manualTranscriptLineCount = nextTranscriptLineCount;
 					this.#manualSuffixLineCount = nextSuffixLineCount;
+					this.#refreshPaintedLiveViewportObservation(height);
 				})
 			)
 				return;
@@ -3310,6 +3439,7 @@ export class TUI extends Container {
 				);
 				this.#manualTranscriptLineCount = nextTranscriptLineCount;
 				this.#manualSuffixLineCount = nextSuffixLineCount;
+				this.#refreshPaintedLiveViewportObservation(height);
 			});
 			if (!contentWritten) return false;
 
@@ -3436,8 +3566,8 @@ export class TUI extends Container {
 
 		// No changes - but still need to update hardware cursor position if it moved
 		if (firstChanged === -1) {
-			this.#writeCursorPosition(cursorPos, newLines.length);
 			this.#viewportTopRow = Math.max(0, this.#maxLinesRendered - height);
+			if (this.#writeCursorPosition(cursorPos, newLines.length)) this.#refreshPaintedLiveViewportObservation(height);
 			return;
 		}
 
@@ -3548,6 +3678,7 @@ export class TUI extends Container {
 						);
 						this.#manualTranscriptLineCount = nextTranscriptLineCount;
 						this.#manualSuffixLineCount = nextSuffixLineCount;
+						this.#refreshPaintedLiveViewportObservation(height);
 					})
 				)
 					return;
@@ -3559,6 +3690,7 @@ export class TUI extends Container {
 			this.#viewportTopRow = Math.max(0, newLines.length - height);
 			this.#manualTranscriptLineCount = nextTranscriptLineCount;
 			this.#manualSuffixLineCount = nextSuffixLineCount;
+			this.#refreshPaintedLiveViewportObservation(height);
 			return;
 		}
 
@@ -3724,6 +3856,7 @@ export class TUI extends Container {
 				);
 				this.#manualTranscriptLineCount = nextTranscriptLineCount;
 				this.#manualSuffixLineCount = nextSuffixLineCount;
+				this.#refreshPaintedLiveViewportObservation(height);
 			})
 		)
 			return;

--- a/packages/tui/test/terminal-detach.test.ts
+++ b/packages/tui/test/terminal-detach.test.ts
@@ -209,6 +209,7 @@ describe("terminal detach handling", () => {
 				const output = writeSpy.mock.calls.map(call => String(call[0])).join("");
 				expect(output).toContain("\x1b[?1002h");
 				expect(output).toContain("\x1b[?1006h");
+				expect(output).toContain("\x1b[?1007l");
 			});
 		} finally {
 			terminal.stop();
@@ -238,6 +239,7 @@ describe("terminal detach handling", () => {
 				expect(output).toContain("\x1b[?1000l");
 				expect(output).toContain("\x1b[?1002l");
 				expect(output).toContain("\x1b[?1006l");
+				expect(output).toContain("\x1b[?1007l");
 				expect(output).not.toContain("\x1b[?1000h");
 				expect(output).not.toContain("\x1b[?1002h");
 				expect(output).not.toContain("\x1b[?1006h");

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -261,6 +261,12 @@ export class VirtualTerminal implements Terminal {
 		return `${rows.join("\n")}\n`;
 	}
 
+	/** Returns the hardware cursor position from the emulated terminal's active viewport. */
+	getCursorPosition(): { row: number; col: number } {
+		const buffer = this.xterm.buffer.active;
+		return { row: buffer.cursorY, col: buffer.cursorX };
+	}
+
 	/**
 	 * Get the entire scroll buffer
 	 */


### PR DESCRIPTION
## Summary

This PR makes the sticky-viewport evidence suite assert against **renderer-owned paint state** instead of re-deriving geometry in the fixture, and gives the host terminal ownership of mouse-wheel scrollback.

Two related changes:

1. **`packages/tui/src/tui.ts`** — adds renderer observation accessors so evidence capture reads what the renderer actually committed: `getViewportObservation()` (defensive copy of the latest committed observation), `getViewportAnchorSnapshot()`, `getViewportAnchorComponent()`, `getFocusedComponent()`, and `setViewportSelection()`, with the `TuiViewportObservation` / `MouseSelectionPoint` types. Observations refresh after committed paints, and selection is mapped through the renderer's own mouse-coordinate mapping rather than a parallel calculation.

2. **`packages/tui/src/terminal.ts`** — disables alternate-scroll mode (`DECSET 1007`) at startup, on every mouse-capture toggle, at stop, and during emergency restore, so the host terminal or multiplexer owns wheel scrollback instead of receiving wheel-to-cursor-key translation.

The capture script, verifier, fixture, and test are updated to consume the renderer observations, including provenance and artifact-corruption discrimination.

## Why `?1007` is reset unconditionally

I verified on a real Apple Silicon macOS host that Apple Terminal 470.2 answers **none** of six `DECRQM` probes (`?1007`, `?1000`, `?1002`, `?1006`, `?2004`, `?1049`) — an empty reply, not a "not recognized" report. Mode state is therefore not queryable on that host, so an unconditional reset is the only correct strategy; a conditional reset would silently no-op.

## Verification

Base: `dev` @ `8801756d`. Exact head: `e87ce00b84f94863c6c850036dc4b1575ef318e0`.

| Check | Result |
|---|---|
| `packages/tui/test/terminal-detach.test.ts` + `viewport-scroll.test.ts` | 61 passed, 0 failed, 574 expectations |
| `packages/coding-agent/test/sticky-viewport-showcase.test.ts` (20-key matrix) | 11 passed, 0 failed, 79 expectations |
| `packages/coding-agent/test/docs-index-lazy.test.ts` (gate added in #3525) | 4 passed, 0 failed |
| `bun --cwd=packages/tui run check` | clean |
| `bun --cwd=packages/coding-agent run check` | clean |
| `scripts/check-visible-definitions.ts` | exit 0 |
| `scripts/verify-g002-gates.ts` | exit 0 |
| `scripts/rebrand-inventory.ts --strict` | exit 0 |
| `test/default-gjc-definitions.test.ts` | 28 passed, 0 failed |

All of the above were run on **darwin-arm64 (macOS 26.5.2, Apple Silicon)**, which complements the Linux/Windows CI matrix. The 20-key evidence matrix completes in ~67 s on this host; the suite's timeout is 120 s.

## Scope

Exactly 9 files: 2 tui sources, 2 tui tests, 2 coding-agent evidence scripts, 1 fixture, 1 test, 1 changelog. No key-parsing, IRC/todo layout, native addon, or unrelated package changes. This branch is based on current `dev`, which already contains the responsive work-lane change from #3505, so there is no duplicated diff.

`packages/coding-agent` changes are confined to `scripts/` and `test/` (evidence tooling and fixtures) with no `src/` behavior change, so only `packages/tui/CHANGELOG.md` gained an entry.

## Note on the changelog

The two original commits did not include a changelog entry. Since `terminal.ts` changes user-visible wheel-scrollback ownership and `tui.ts` adds public API, I added an `[Unreleased]` entry in a separate commit rather than leaving it undocumented.

Thank you for reviewing.