### PR TITLE
fix(coding-agent): surface the subagent fast-mode glyph

### DIFF
--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -164,6 +164,8 @@ export interface SubagentRecord {
 	effectiveModel?: string;
 	/** True when the requested model lacked credentials and the subagent fell back to the parent model. */
 	modelFellBack?: boolean;
+	/** True when the effective subagent provider is in fast mode. */
+	fastMode?: boolean;
 }
 
 /** Lightweight, manager-owned resume payload. The async layer treats `data` as opaque. */
@@ -702,16 +704,17 @@ export class AsyncJobManager {
 		this.#notifyChange();
 	}
 
-	/** Patch model metadata onto an existing subagent record (best-effort; no-op if unknown). */
+	/** Patch model/runtime metadata onto an existing subagent record (best-effort; no-op if unknown). */
 	updateSubagentModel(
 		subagentId: string,
-		model: { requestedModel?: string; effectiveModel?: string; modelFellBack?: boolean },
+		model: { requestedModel?: string; effectiveModel?: string; modelFellBack?: boolean; fastMode?: boolean },
 	): void {
 		const record = this.#subagentRecords.get(subagentId);
 		if (!record) return;
 		record.requestedModel = model.requestedModel;
 		record.effectiveModel = model.effectiveModel;
 		record.modelFellBack = model.modelFellBack;
+		record.fastMode = model.fastMode;
 	}
 
 	#recordFromResumeDescriptor(subagentId: string, filter?: AsyncJobFilter): SubagentRecord | undefined {

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -1566,6 +1566,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				// (serviceTier === undefined) would be resurrected to the startup value.
 				return agent ? agent.serviceTier : initialServiceTier;
 			},
+			isFastForSubagentProvider: provider => session?.isFastForSubagentProvider(provider) ?? false,
 			getAgentId: () => resolvedAgentId,
 			bashAllowedPrefixes: options.bashAllowedPrefixes,
 			bashRestrictionProfile: options.bashRestrictionProfile,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1533,6 +1533,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					requestedModel: modelSubstitutionWarning?.requested ?? resolvedModelString,
 					effectiveModel: resolvedModelString,
 					modelFellBack: authFallbackUsed === true,
+					fastMode: progress.fastMode,
 				});
 			}
 			if (model?.contextWindow && model.contextWindow > 0) {

--- a/packages/coding-agent/src/tools/subagent-render.ts
+++ b/packages/coding-agent/src/tools/subagent-render.ts
@@ -182,12 +182,15 @@ function renderSubagentSnapshotBody(
 		lines.push(`  ${theme.fg("dim", `Agent: ${snapshot.agent} (${snapshot.agentSource})`)}`);
 	}
 	if (snapshot.effectiveModel) {
+		// Fast mode is a property of the tier this model runs under, so the ⚡ glyph
+		// belongs on the model line rather than the id.
+		const fastSuffix = snapshot.fastMode && theme.icon.fast ? ` ${theme.icon.fast}` : "";
 		if (snapshot.modelFellBack && snapshot.requestedModel) {
 			lines.push(
-				`  ${theme.fg("warning", `Model: ${snapshot.effectiveModel} (requested ${snapshot.requestedModel}, fell back — no credentials)`)}`,
+				`  ${theme.fg("warning", `Model: ${snapshot.effectiveModel} (requested ${snapshot.requestedModel}, fell back — no credentials)`)}${fastSuffix}`,
 			);
 		} else {
-			lines.push(`  ${theme.fg("dim", `Model: ${snapshot.effectiveModel}`)}`);
+			lines.push(`  ${theme.fg("dim", `Model: ${snapshot.effectiveModel}`)}${fastSuffix}`);
 		}
 	}
 	if (snapshot.description) lines.push(`  ${theme.fg("dim", `Description: ${snapshot.description}`)}`);

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -84,6 +84,8 @@ export interface SubagentSnapshot {
 	requestedModel?: string;
 	/** True when the requested model lacked credentials and fell back to the parent model. */
 	modelFellBack?: boolean;
+	/** True when the effective subagent provider is in fast mode. */
+	fastMode?: boolean;
 }
 
 export type SubagentAwaitOutcome = "completed" | "timed_out" | "interrupted";
@@ -698,6 +700,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		if (record.effectiveModel) fields.effectiveModel = record.effectiveModel;
 		if (record.requestedModel) fields.requestedModel = record.requestedModel;
 		if (record.modelFellBack) fields.modelFellBack = true;
+		if (record.fastMode) fields.fastMode = true;
 		return fields;
 	}
 
@@ -906,6 +909,7 @@ function canonicalizeSnapshotForSignature(snapshot: SubagentSnapshot): unknown {
 		effectiveModel: snapshot.effectiveModel ?? null,
 		requestedModel: snapshot.requestedModel ?? null,
 		modelFellBack: snapshot.modelFellBack ?? false,
+		fastMode: snapshot.fastMode ?? false,
 		// durationMs intentionally excluded (time-derived; would defeat idle gating).
 		progress: snapshot.progress ? canonicalizeProgressForSignature(snapshot.progress) : null,
 	};

--- a/packages/coding-agent/test/agent-session-fast-mode.test.ts
+++ b/packages/coding-agent/test/agent-session-fast-mode.test.ts
@@ -5,10 +5,12 @@ import type { AssistantMessage } from "@gajae-code/ai";
 import { getBundledModel } from "@gajae-code/ai/models";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { createAgentSession } from "@gajae-code/coding-agent/sdk";
 import type { AgentSessionEvent } from "@gajae-code/coding-agent/session/agent-session";
 import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import type { ToolSession } from "@gajae-code/coding-agent/tools";
 import { TempDir } from "@gajae-code/utils";
 import { createAssistantMessage } from "./helpers/agent-session-setup";
 
@@ -201,5 +203,64 @@ describe("AgentSession fast-mode Q1 auto-disable (provider-scoped marker)", () =
 		expect(entries.length).toBe(before + 1);
 		expect(entries.at(-1)?.serviceTier).toBeNull();
 		expect(session.serviceTier).toBeUndefined();
+	});
+});
+
+// The Task tool reaches the session through the SDK's `ToolSession` adapter and calls
+// `isFastForSubagentProvider` optionally (`?.(provider) ?? false`). An adapter that omits
+// the member therefore degrades silently to "never fast", which is exactly how the ⚡
+// glyph went missing for every subagent. Pin the delegation to the adapter object.
+describe("ToolSession adapter fast-mode delegation", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let created: Awaited<ReturnType<typeof createAgentSession>>;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-tool-session-fast-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		created = await createAgentSession({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			sessionManager: SessionManager.inMemory(),
+			authStorage,
+			// `task.serviceTier` defaults to "inherit", so the subagent predicate resolves
+			// this scoped parent tier: priority on OpenAI providers, nothing on Anthropic.
+			settings: Settings.isolated({ serviceTier: "openai-only", "recipe.enabled": false }),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			extensions: [],
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			notificationHostModeSupported: false,
+			sdkHostModeSupported: false,
+		});
+	});
+
+	afterEach(() => {
+		created.session.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	function toolSession(): ToolSession {
+		const tool = created.session.getToolByName("subagent");
+		if (!tool) throw new Error("subagent tool is not registered");
+		return (tool as unknown as { session: ToolSession }).session;
+	}
+
+	it("exposes isFastForSubagentProvider on the adapter handed to tools", () => {
+		expect(typeof toolSession().isFastForSubagentProvider).toBe("function");
+	});
+
+	it("delegates the scoped subagent tier through the adapter", () => {
+		const adapter = toolSession();
+		expect(adapter.isFastForSubagentProvider?.("openai")).toBe(true);
+		expect(adapter.isFastForSubagentProvider?.("openai-codex")).toBe(true);
+		expect(adapter.isFastForSubagentProvider?.("anthropic")).toBe(false);
+		expect(adapter.isFastForSubagentProvider?.(undefined)).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/tools/subagent-live-progress.test.ts
+++ b/packages/coding-agent/test/tools/subagent-live-progress.test.ts
@@ -91,6 +91,79 @@ describe("subagent await live progress", () => {
 		await manager.dispose({ timeoutMs: 100 });
 	});
 
+	it("surfaces retained fast mode from the canonical subagent record", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const jobId = manager.register(
+			"task",
+			"fast subagent",
+			async () => {
+				await Bun.sleep(150);
+				return "done";
+			},
+			{
+				id: "job-fast",
+				ownerId: "0-Main",
+				metadata: { subagent: { id: "0-Fast", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+		manager.registerSubagentRecord(runningRecord("0-Fast", jobId));
+		manager.updateSubagentModel("0-Fast", { fastMode: true });
+
+		const result = await tool.execute("inspect", { action: "inspect", ids: ["0-Fast"] });
+		const snap = result.details?.subagents.find(s => s.id === "0-Fast");
+
+		expect(snap?.fastMode).toBe(true);
+
+		manager.cancelSubagent("0-Fast", { ownerId: "0-Main" });
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("retains fast mode across a live progress update", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const jobId = manager.register(
+			"task",
+			"fast subagent",
+			async () => {
+				await Bun.sleep(2000);
+				return "done";
+			},
+			{
+				id: "job-fast-live",
+				ownerId: "0-Main",
+				metadata: { subagent: { id: "0-FastLive", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+		manager.registerSubagentRecord(runningRecord("0-FastLive", jobId));
+		manager.updateSubagentModel("0-FastLive", { fastMode: true });
+
+		const updates: SubagentSnapshot[] = [];
+		const pending = tool.execute(
+			"await",
+			{ action: "await", ids: ["0-FastLive"], timeout_ms: 1500 },
+			undefined,
+			result => {
+				const snap = result.details?.subagents.find(s => s.id === "0-FastLive");
+				if (snap) updates.push(snap);
+			},
+		);
+
+		// Mutate progress only AFTER the await is live, so the panel is forced to
+		// rebuild the snapshot in flight. The record-derived fast flag must survive
+		// that rebuild, or the ⚡ glyph vanishes the moment the subagent reports.
+		await Bun.sleep(50);
+		manager.recordSubagentProgress("0-FastLive", makeProgress({ id: "0-FastLive", currentTool: "read" }));
+		await pending;
+
+		const rebuilt = updates.filter(snap => snap.progress?.currentTool === "read");
+		expect(rebuilt.length).toBeGreaterThan(0);
+		expect(rebuilt.every(snap => snap.fastMode === true)).toBe(true);
+
+		manager.cancelSubagent("0-FastLive", { ownerId: "0-Main" });
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
 	it("isolates live progress per subagent id", async () => {
 		const manager = createManager();
 		const tool = new SubagentTool(createSession());
@@ -410,6 +483,7 @@ describe("subagentAwaitRenderedStateSignature", () => {
 			s => ({ ...s, effectiveModel: "model-2" }),
 			s => ({ ...s, requestedModel: "model-1" }),
 			s => ({ ...s, modelFellBack: true }),
+			s => ({ ...s, fastMode: true }),
 			s => ({ ...s, description: "new description" }),
 			s => ({ ...s, assignment: "new assignment" }),
 			s => ({ ...s, progress: { ...baseProgress, currentTool: "bash" } }),

--- a/packages/coding-agent/test/tools/subagent-render.test.ts
+++ b/packages/coding-agent/test/tools/subagent-render.test.ts
@@ -69,6 +69,37 @@ describe("subagentToolRenderer", () => {
 		expect(out).toContain("read");
 		expect(out).toContain("scanning the repo");
 	});
+	it("renders the fast glyph on the model line only when fast mode is enabled", () => {
+		const out = render({
+			subagents: [
+				snapshot({
+					id: "0-LiveFast",
+					fastMode: true,
+					effectiveModel: "openai-codex/gpt-5.6-sol",
+					liveProgressAvailable: true,
+				}),
+				snapshot({
+					id: "0-TerminalFast",
+					status: "completed",
+					fastMode: true,
+					effectiveModel: "openai-codex/gpt-5.6-sol",
+					resultText: "done",
+				}),
+				snapshot({
+					id: "0-TerminalNormal",
+					status: "completed",
+					effectiveModel: "anthropic/claude-sonnet-4-5",
+					resultText: "done",
+				}),
+			],
+		});
+		// The glyph rides the model line, never the id.
+		expect(out).toContain(`Model: openai-codex/gpt-5.6-sol ${theme.icon.fast}`);
+		expect(out).not.toContain(`0-LiveFast ${theme.icon.fast}`);
+		expect(out).not.toContain(`0-TerminalFast ${theme.icon.fast}`);
+		expect(out).toContain("Model: anthropic/claude-sonnet-4-5");
+		expect(out).not.toContain(`Model: anthropic/claude-sonnet-4-5 ${theme.icon.fast}`);
+	});
 
 	it("expands live recent output, tool args, and the full task section when expanded=true and collapses them back (AC1/AC2)", () => {
 		const details: SubagentToolDetails = {


### PR DESCRIPTION
## Problem

The ⚡ fast-mode glyph never appeared on subagents, even with a priority-granting service tier configured. With `serviceTier: openai-only` and an `openai-codex` subagent — which resolves to `priority` — the await panel still rendered no glyph.

## Root cause

`ToolSession` in `src/sdk/session.ts` exposed `serviceTier` but not `isFastForSubagentProvider`.

The Task tool calls it defensively:

```ts
// src/task/index.ts
isFastForSubagentProvider: provider => this.session.isFastForSubagentProvider?.(provider) ?? false,
```

The missing member therefore degraded silently to "never fast", so `progress.fastMode` was always `false` and the glyph was suppressed everywhere. `AgentSession` had the method all along; only the adapter handed to tools lacked it.

`selector-controller.ts` calls the same predicate without optional chaining against the real `AgentSession`, which is why the model-selector role badge was correct while every subagent panel was wrong — the inconsistency that isolated the defect.

## Changes

- Expose `isFastForSubagentProvider` on the `ToolSession` adapter (the actual fix).
- Plumb the resolved flag through to the await panel: `SubagentRecord.fastMode`, `updateSubagentModel`, the snapshot builder, and the rendered-state signature — the last one so the cached body is keyed on it and cannot go stale.
- Render the glyph on the `Model:` line instead of next to the subagent id, since fast mode is a property of the tier the model runs under. The nested task panel keeps it on the title because it renders no model line.

## Tests

- The SDK adapter both exposes and correctly delegates the predicate, asserted against the real production adapter object rather than a stand-in.
- `fastMode` survives an in-flight snapshot rebuild driven by a live progress update.
- The glyph rides the model line and never the id.

Both regression tests were confirmed to fail when their respective fixes are reverted, yielding exactly the original symptom (`Received: undefined`).

## Verification

- `bun run check` (biome + tsc) clean
- 354 pass / 0 fail across the subagent, task, fast-status, and model-selector suites
- Verified live in a running session: the glyph now renders as `Model: openai-codex/gpt-5.6-sol ⚡`