### PR TITLE
fix(coding-agent): surface the subagent fast-mode glyph (v2)

### DIFF
--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -704,17 +704,22 @@ export class AsyncJobManager {
 		this.#notifyChange();
 	}
 
-	/** Patch model/runtime metadata onto an existing subagent record (best-effort; no-op if unknown). */
+	/**
+	 * Patch model/runtime metadata onto an existing subagent record (best-effort; no-op if
+	 * unknown). Every field is optional and omitting one preserves its current value, so a
+	 * narrow patch like `{ fastMode: true }` cannot erase model identity recorded earlier.
+	 * A field therefore cannot be cleared back to `undefined` through this method.
+	 */
 	updateSubagentModel(
 		subagentId: string,
 		model: { requestedModel?: string; effectiveModel?: string; modelFellBack?: boolean; fastMode?: boolean },
 	): void {
 		const record = this.#subagentRecords.get(subagentId);
 		if (!record) return;
-		record.requestedModel = model.requestedModel;
-		record.effectiveModel = model.effectiveModel;
-		record.modelFellBack = model.modelFellBack;
-		record.fastMode = model.fastMode;
+		record.requestedModel = model.requestedModel ?? record.requestedModel;
+		record.effectiveModel = model.effectiveModel ?? record.effectiveModel;
+		record.modelFellBack = model.modelFellBack ?? record.modelFellBack;
+		record.fastMode = model.fastMode ?? record.fastMode;
 	}
 
 	#recordFromResumeDescriptor(subagentId: string, filter?: AsyncJobFilter): SubagentRecord | undefined {

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -164,6 +164,8 @@ export interface SubagentRecord {
 	effectiveModel?: string;
 	/** True when the requested model lacked credentials and the subagent fell back to the parent model. */
 	modelFellBack?: boolean;
+	/** True when the effective subagent provider is in fast mode. */
+	fastMode?: boolean;
 }
 
 /** Lightweight, manager-owned resume payload. The async layer treats `data` as opaque. */
@@ -702,16 +704,17 @@ export class AsyncJobManager {
 		this.#notifyChange();
 	}
 
-	/** Patch model metadata onto an existing subagent record (best-effort; no-op if unknown). */
+	/** Patch model/runtime metadata onto an existing subagent record (best-effort; no-op if unknown). */
 	updateSubagentModel(
 		subagentId: string,
-		model: { requestedModel?: string; effectiveModel?: string; modelFellBack?: boolean },
+		model: { requestedModel?: string; effectiveModel?: string; modelFellBack?: boolean; fastMode?: boolean },
 	): void {
 		const record = this.#subagentRecords.get(subagentId);
 		if (!record) return;
 		record.requestedModel = model.requestedModel;
 		record.effectiveModel = model.effectiveModel;
 		record.modelFellBack = model.modelFellBack;
+		record.fastMode = model.fastMode;
 	}
 
 	#recordFromResumeDescriptor(subagentId: string, filter?: AsyncJobFilter): SubagentRecord | undefined {

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -1566,6 +1566,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				// (serviceTier === undefined) would be resurrected to the startup value.
 				return agent ? agent.serviceTier : initialServiceTier;
 			},
+			isFastForSubagentProvider: provider => session?.isFastForSubagentProvider(provider) ?? false,
 			getAgentId: () => resolvedAgentId,
 			bashAllowedPrefixes: options.bashAllowedPrefixes,
 			bashRestrictionProfile: options.bashRestrictionProfile,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1533,6 +1533,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					requestedModel: modelSubstitutionWarning?.requested ?? resolvedModelString,
 					effectiveModel: resolvedModelString,
 					modelFellBack: authFallbackUsed === true,
+					fastMode: progress.fastMode,
 				});
 			}
 			if (model?.contextWindow && model.contextWindow > 0) {

--- a/packages/coding-agent/src/tools/subagent-render.ts
+++ b/packages/coding-agent/src/tools/subagent-render.ts
@@ -182,12 +182,15 @@ function renderSubagentSnapshotBody(
 		lines.push(`  ${theme.fg("dim", `Agent: ${snapshot.agent} (${snapshot.agentSource})`)}`);
 	}
 	if (snapshot.effectiveModel) {
+		// Fast mode is a property of the tier this model runs under, so the ⚡ glyph
+		// belongs on the model line rather than the id.
+		const fastSuffix = snapshot.fastMode && theme.icon.fast ? ` ${theme.icon.fast}` : "";
 		if (snapshot.modelFellBack && snapshot.requestedModel) {
 			lines.push(
-				`  ${theme.fg("warning", `Model: ${snapshot.effectiveModel} (requested ${snapshot.requestedModel}, fell back — no credentials)`)}`,
+				`  ${theme.fg("warning", `Model: ${snapshot.effectiveModel} (requested ${snapshot.requestedModel}, fell back — no credentials)`)}${fastSuffix}`,
 			);
 		} else {
-			lines.push(`  ${theme.fg("dim", `Model: ${snapshot.effectiveModel}`)}`);
+			lines.push(`  ${theme.fg("dim", `Model: ${snapshot.effectiveModel}`)}${fastSuffix}`);
 		}
 	}
 	if (snapshot.description) lines.push(`  ${theme.fg("dim", `Description: ${snapshot.description}`)}`);

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -937,6 +937,10 @@ function canonicalizeProgressForSignature(progress: AgentProgress): unknown {
 		cost: progress.cost,
 		modelOverride: progress.modelOverride ?? null,
 		modelSubstitutionWarning: progress.modelSubstitutionWarning ?? null,
+		// The nested task panel renders this, so it must reach the signature or a
+		// fast-mode-only change would render differently while comparing byte-identical,
+		// suppressing the very update that introduces the glyph.
+		fastMode: progress.fastMode ?? false,
 		// durationMs intentionally excluded (time-derived).
 		extractedToolData: progress.extractedToolData
 			? canonicalizeExtractedToolDataForSignature(progress.extractedToolData)

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -84,6 +84,8 @@ export interface SubagentSnapshot {
 	requestedModel?: string;
 	/** True when the requested model lacked credentials and fell back to the parent model. */
 	modelFellBack?: boolean;
+	/** True when the effective subagent provider is in fast mode. */
+	fastMode?: boolean;
 }
 
 export type SubagentAwaitOutcome = "completed" | "timed_out" | "interrupted";
@@ -698,6 +700,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		if (record.effectiveModel) fields.effectiveModel = record.effectiveModel;
 		if (record.requestedModel) fields.requestedModel = record.requestedModel;
 		if (record.modelFellBack) fields.modelFellBack = true;
+		if (record.fastMode) fields.fastMode = true;
 		return fields;
 	}
 
@@ -906,6 +909,7 @@ function canonicalizeSnapshotForSignature(snapshot: SubagentSnapshot): unknown {
 		effectiveModel: snapshot.effectiveModel ?? null,
 		requestedModel: snapshot.requestedModel ?? null,
 		modelFellBack: snapshot.modelFellBack ?? false,
+		fastMode: snapshot.fastMode ?? false,
 		// durationMs intentionally excluded (time-derived; would defeat idle gating).
 		progress: snapshot.progress ? canonicalizeProgressForSignature(snapshot.progress) : null,
 	};

--- a/packages/coding-agent/test/agent-session-fast-mode.test.ts
+++ b/packages/coding-agent/test/agent-session-fast-mode.test.ts
@@ -5,10 +5,12 @@ import type { AssistantMessage } from "@gajae-code/ai";
 import { getBundledModel } from "@gajae-code/ai/models";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { createAgentSession } from "@gajae-code/coding-agent/sdk";
 import type { AgentSessionEvent } from "@gajae-code/coding-agent/session/agent-session";
 import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import type { ToolSession } from "@gajae-code/coding-agent/tools";
 import { TempDir } from "@gajae-code/utils";
 import { createAssistantMessage } from "./helpers/agent-session-setup";
 
@@ -201,5 +203,64 @@ describe("AgentSession fast-mode Q1 auto-disable (provider-scoped marker)", () =
 		expect(entries.length).toBe(before + 1);
 		expect(entries.at(-1)?.serviceTier).toBeNull();
 		expect(session.serviceTier).toBeUndefined();
+	});
+});
+
+// The Task tool reaches the session through the SDK's `ToolSession` adapter and calls
+// `isFastForSubagentProvider` optionally (`?.(provider) ?? false`). An adapter that omits
+// the member therefore degrades silently to "never fast", which is exactly how the ⚡
+// glyph went missing for every subagent. Pin the delegation to the adapter object.
+describe("ToolSession adapter fast-mode delegation", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let created: Awaited<ReturnType<typeof createAgentSession>>;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-tool-session-fast-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		created = await createAgentSession({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			sessionManager: SessionManager.inMemory(),
+			authStorage,
+			// `task.serviceTier` defaults to "inherit", so the subagent predicate resolves
+			// this scoped parent tier: priority on OpenAI providers, nothing on Anthropic.
+			settings: Settings.isolated({ serviceTier: "openai-only", "recipe.enabled": false }),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			extensions: [],
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			notificationHostModeSupported: false,
+			sdkHostModeSupported: false,
+		});
+	});
+
+	afterEach(() => {
+		created.session.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	function toolSession(): ToolSession {
+		const tool = created.session.getToolByName("subagent");
+		if (!tool) throw new Error("subagent tool is not registered");
+		return (tool as unknown as { session: ToolSession }).session;
+	}
+
+	it("exposes isFastForSubagentProvider on the adapter handed to tools", () => {
+		expect(typeof toolSession().isFastForSubagentProvider).toBe("function");
+	});
+
+	it("delegates the scoped subagent tier through the adapter", () => {
+		const adapter = toolSession();
+		expect(adapter.isFastForSubagentProvider?.("openai")).toBe(true);
+		expect(adapter.isFastForSubagentProvider?.("openai-codex")).toBe(true);
+		expect(adapter.isFastForSubagentProvider?.("anthropic")).toBe(false);
+		expect(adapter.isFastForSubagentProvider?.(undefined)).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/async-job-manager.test.ts
+++ b/packages/coding-agent/test/async-job-manager.test.ts
@@ -384,6 +384,44 @@ describe("AsyncJobManager", () => {
 		await manager.waitForAll();
 		expect(manager.getJob(parentJobId)?.status).toBe("cancelled");
 	});
+	test("updateSubagentModel preserves fields omitted from a partial patch", () => {
+		const manager = new AsyncJobManager({ onJobComplete: async () => {} });
+		const jobId = manager.register("task", "fast subagent", async () => "done", { ownerId: "0-Main" });
+		manager.registerSubagentRecord({
+			subagentId: "0-Fast",
+			ownerId: "0-Main",
+			currentJobId: jobId,
+			historicalJobIds: [],
+			status: "running",
+			sessionFile: null,
+			resumable: false,
+		});
+
+		manager.updateSubagentModel("0-Fast", {
+			requestedModel: "anthropic/claude-opus-4-5",
+			effectiveModel: "anthropic/claude-sonnet-4-5",
+			modelFellBack: true,
+			fastMode: true,
+		});
+		expect(manager.getSubagentRecord("0-Fast")).toMatchObject({
+			requestedModel: "anthropic/claude-opus-4-5",
+			effectiveModel: "anthropic/claude-sonnet-4-5",
+			modelFellBack: true,
+			fastMode: true,
+		});
+
+		// A narrow fast-mode patch must not erase the model identity recorded above;
+		// unconditional assignment used to blank all three of the omitted fields.
+		manager.updateSubagentModel("0-Fast", { fastMode: false });
+		expect(manager.getSubagentRecord("0-Fast")).toMatchObject({
+			requestedModel: "anthropic/claude-opus-4-5",
+			effectiveModel: "anthropic/claude-sonnet-4-5",
+			modelFellBack: true,
+			fastMode: false,
+		});
+
+		manager.cancelAll();
+	});
 	test("retention-zero eviction runs onEvict and records a monitor tombstone", async () => {
 		let evictCount = 0;
 		const manager = new AsyncJobManager({ retentionMs: 0, onJobComplete: async () => {} });

--- a/packages/coding-agent/test/tools/subagent-live-progress.test.ts
+++ b/packages/coding-agent/test/tools/subagent-live-progress.test.ts
@@ -3,7 +3,11 @@ import { AsyncJobManager, type SubagentRecord } from "../../src/async";
 import { Settings } from "../../src/config/settings";
 import type { AgentProgress } from "../../src/task/types";
 import { SubagentTool, type ToolSession } from "../../src/tools";
-import { type SubagentSnapshot, subagentAwaitRenderedStateSignature } from "../../src/tools/subagent";
+import {
+	type SubagentSnapshot,
+	type SubagentToolDetails,
+	subagentAwaitRenderedStateSignature,
+} from "../../src/tools/subagent";
 
 function createSession(agentId = "0-Main"): ToolSession {
 	return {
@@ -572,6 +576,49 @@ describe("subagentAwaitRenderedStateSignature", () => {
 			subagentAwaitRenderedStateSignature([early]),
 		);
 	});
+
+	it("changes when only fastMode flips, at every rendered progress route", () => {
+		// The nested task panel renders `AgentProgress.fastMode`, and the producer's
+		// await gating plus the body cache both key off this signature. If the shared
+		// progress canonicalizer omits fastMode, the one update that introduces the
+		// glyph compares byte-identical and is suppressed, leaving a stale body.
+		const nestedTask = (fastMode: boolean) =>
+			[{ id: "n1", progress: [makeProgress({ id: "n1", fastMode })] }] as unknown as NonNullable<
+				AgentProgress["extractedToolData"]
+			>["task"];
+		const inflight = (fastMode: boolean) =>
+			({ id: "t1", progress: [makeProgress({ id: "t1", fastMode })] }) as unknown as NonNullable<
+				AgentProgress["inflightTaskDetails"]
+			>;
+
+		const routes: Array<[string, (fastMode: boolean) => SubagentSnapshot]> = [
+			["root progress", fastMode => makeSnapshot({ id: "0-A", progress: makeProgress({ id: "0-A", fastMode }) })],
+			[
+				"inflightTaskDetails.progress",
+				fastMode =>
+					makeSnapshot({
+						id: "0-A",
+						progress: makeProgress({ id: "0-A", inflightTaskDetails: inflight(fastMode) }),
+					}),
+			],
+			[
+				"extractedToolData.task[].progress",
+				fastMode =>
+					makeSnapshot({
+						id: "0-A",
+						progress: makeProgress({ id: "0-A", extractedToolData: { task: nestedTask(fastMode) } }),
+					}),
+			],
+		];
+
+		for (const [route, build] of routes) {
+			const slow = subagentAwaitRenderedStateSignature([build(false)]);
+			const fast = subagentAwaitRenderedStateSignature([build(true)]);
+			expect(fast, `fastMode must reach the signature via ${route}`).not.toBe(slow);
+			// Same value twice stays stable, so the difference is fastMode and not churn.
+			expect(subagentAwaitRenderedStateSignature([build(true)])).toBe(fast);
+		}
+	});
 });
 
 describe("subagent await emit gating", () => {
@@ -628,6 +675,71 @@ describe("subagent await emit gating", () => {
 		ac.abort();
 		for (const control of controls) control.resolve();
 		await Promise.all(execs);
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("emits exactly once when only a nested task's fastMode flips, and not for an unchanged poll", async () => {
+		vi.useFakeTimers();
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const control = Promise.withResolvers<void>();
+		const jobId = manager.register(
+			"task",
+			"0-Nested",
+			async () => {
+				await control.promise;
+				return "done";
+			},
+			{
+				id: "job-0-Nested",
+				ownerId: "0-Main",
+				metadata: { subagent: { id: "0-Nested", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+		manager.registerSubagentRecord(runningRecord("0-Nested", jobId));
+
+		const nested = (fastMode: boolean) =>
+			makeProgress({
+				id: "0-Nested",
+				currentTool: "task",
+				inflightTaskDetails: {
+					id: "t1",
+					progress: [makeProgress({ id: "n1", fastMode })],
+				} as unknown as NonNullable<AgentProgress["inflightTaskDetails"]>,
+			});
+
+		manager.recordSubagentProgress("0-Nested", nested(false));
+		const ac = new AbortController();
+		const spy = vi.fn();
+		const exec = tool.execute(
+			"await-0-Nested",
+			{ action: "await", ids: ["0-Nested"], timeout_ms: 3_600_000 },
+			ac.signal,
+			spy,
+		);
+		await Promise.resolve();
+		expect(spy).toHaveBeenCalledTimes(1);
+
+		// Re-recording the identical nested progress is not a rendered-state change.
+		manager.recordSubagentProgress("0-Nested", nested(false));
+		vi.advanceTimersByTime(500);
+		expect(spy).toHaveBeenCalledTimes(1);
+
+		// Flipping only the nested fastMode changes what renders, so it must emit once.
+		manager.recordSubagentProgress("0-Nested", nested(true));
+		vi.advanceTimersByTime(500);
+		expect(spy).toHaveBeenCalledTimes(2);
+		const emitted = spy.mock.calls.at(-1)?.[0] as { details?: SubagentToolDetails } | undefined;
+		expect(emitted?.details?.subagents?.[0]?.progress?.inflightTaskDetails?.progress?.[0]?.fastMode).toBe(true);
+
+		// And the new value is then stable: another identical poll stays quiet.
+		manager.recordSubagentProgress("0-Nested", nested(true));
+		vi.advanceTimersByTime(500);
+		expect(spy).toHaveBeenCalledTimes(2);
+
+		ac.abort();
+		control.resolve();
+		await exec;
 		await manager.dispose({ timeoutMs: 100 });
 	});
 });

--- a/packages/coding-agent/test/tools/subagent-live-progress.test.ts
+++ b/packages/coding-agent/test/tools/subagent-live-progress.test.ts
@@ -91,6 +91,79 @@ describe("subagent await live progress", () => {
 		await manager.dispose({ timeoutMs: 100 });
 	});
 
+	it("surfaces retained fast mode from the canonical subagent record", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const jobId = manager.register(
+			"task",
+			"fast subagent",
+			async () => {
+				await Bun.sleep(150);
+				return "done";
+			},
+			{
+				id: "job-fast",
+				ownerId: "0-Main",
+				metadata: { subagent: { id: "0-Fast", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+		manager.registerSubagentRecord(runningRecord("0-Fast", jobId));
+		manager.updateSubagentModel("0-Fast", { fastMode: true });
+
+		const result = await tool.execute("inspect", { action: "inspect", ids: ["0-Fast"] });
+		const snap = result.details?.subagents.find(s => s.id === "0-Fast");
+
+		expect(snap?.fastMode).toBe(true);
+
+		manager.cancelSubagent("0-Fast", { ownerId: "0-Main" });
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	it("retains fast mode across a live progress update", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const jobId = manager.register(
+			"task",
+			"fast subagent",
+			async () => {
+				await Bun.sleep(2000);
+				return "done";
+			},
+			{
+				id: "job-fast-live",
+				ownerId: "0-Main",
+				metadata: { subagent: { id: "0-FastLive", agent: "executor", agentSource: "bundled" } },
+			},
+		);
+		manager.registerSubagentRecord(runningRecord("0-FastLive", jobId));
+		manager.updateSubagentModel("0-FastLive", { fastMode: true });
+
+		const updates: SubagentSnapshot[] = [];
+		const pending = tool.execute(
+			"await",
+			{ action: "await", ids: ["0-FastLive"], timeout_ms: 1500 },
+			undefined,
+			result => {
+				const snap = result.details?.subagents.find(s => s.id === "0-FastLive");
+				if (snap) updates.push(snap);
+			},
+		);
+
+		// Mutate progress only AFTER the await is live, so the panel is forced to
+		// rebuild the snapshot in flight. The record-derived fast flag must survive
+		// that rebuild, or the ⚡ glyph vanishes the moment the subagent reports.
+		await Bun.sleep(50);
+		manager.recordSubagentProgress("0-FastLive", makeProgress({ id: "0-FastLive", currentTool: "read" }));
+		await pending;
+
+		const rebuilt = updates.filter(snap => snap.progress?.currentTool === "read");
+		expect(rebuilt.length).toBeGreaterThan(0);
+		expect(rebuilt.every(snap => snap.fastMode === true)).toBe(true);
+
+		manager.cancelSubagent("0-FastLive", { ownerId: "0-Main" });
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
 	it("isolates live progress per subagent id", async () => {
 		const manager = createManager();
 		const tool = new SubagentTool(createSession());
@@ -410,6 +483,7 @@ describe("subagentAwaitRenderedStateSignature", () => {
 			s => ({ ...s, effectiveModel: "model-2" }),
 			s => ({ ...s, requestedModel: "model-1" }),
 			s => ({ ...s, modelFellBack: true }),
+			s => ({ ...s, fastMode: true }),
 			s => ({ ...s, description: "new description" }),
 			s => ({ ...s, assignment: "new assignment" }),
 			s => ({ ...s, progress: { ...baseProgress, currentTool: "bash" } }),

--- a/packages/coding-agent/test/tools/subagent-render.test.ts
+++ b/packages/coding-agent/test/tools/subagent-render.test.ts
@@ -655,4 +655,39 @@ describe("subagent await renderer body cache (PR2)", () => {
 		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(140);
 		expect(subagentBodyCacheTestHooks.size).toBeLessThanOrEqual(128);
 	});
+
+	it("invalidates the cached body when only a nested task's fastMode flips", () => {
+		// The body cache is keyed by subagentAwaitRenderedStateSignature, so a nested
+		// fastMode change that the signature ignored would serve a stale body and the
+		// glyph would never appear.
+		const nested = (fastMode: boolean): SubagentToolDetails => ({
+			subagents: [
+				snapshot({
+					id: "0-Nested",
+					liveProgressAvailable: true,
+					progress: progress({
+						id: "0-Nested",
+						currentTool: "task",
+						inflightTaskDetails: {
+							id: "t1",
+							progress: [progress({ id: "n1", currentTool: "read", fastMode })],
+						} as unknown as NonNullable<AgentProgress["inflightTaskDetails"]>,
+					}),
+				}),
+			],
+		});
+
+		const slow = renderWith(nested(false));
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+		// Same value again is a genuine cache hit.
+		renderWith(nested(false));
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(1);
+
+		const fast = renderWith(nested(true));
+		expect(subagentBodyCacheTestHooks.bodyRenders).toBe(2);
+		expect(fast).not.toEqual(slow);
+		expect(theme.icon.fast).toBeTruthy();
+		expect(fast.join("\n")).toContain(theme.icon.fast);
+		expect(slow.join("\n")).not.toContain(theme.icon.fast);
+	});
 });

--- a/packages/coding-agent/test/tools/subagent-render.test.ts
+++ b/packages/coding-agent/test/tools/subagent-render.test.ts
@@ -69,6 +69,37 @@ describe("subagentToolRenderer", () => {
 		expect(out).toContain("read");
 		expect(out).toContain("scanning the repo");
 	});
+	it("renders the fast glyph on the model line only when fast mode is enabled", () => {
+		const out = render({
+			subagents: [
+				snapshot({
+					id: "0-LiveFast",
+					fastMode: true,
+					effectiveModel: "openai-codex/gpt-5.6-sol",
+					liveProgressAvailable: true,
+				}),
+				snapshot({
+					id: "0-TerminalFast",
+					status: "completed",
+					fastMode: true,
+					effectiveModel: "openai-codex/gpt-5.6-sol",
+					resultText: "done",
+				}),
+				snapshot({
+					id: "0-TerminalNormal",
+					status: "completed",
+					effectiveModel: "anthropic/claude-sonnet-4-5",
+					resultText: "done",
+				}),
+			],
+		});
+		// The glyph rides the model line, never the id.
+		expect(out).toContain(`Model: openai-codex/gpt-5.6-sol ${theme.icon.fast}`);
+		expect(out).not.toContain(`0-LiveFast ${theme.icon.fast}`);
+		expect(out).not.toContain(`0-TerminalFast ${theme.icon.fast}`);
+		expect(out).toContain("Model: anthropic/claude-sonnet-4-5");
+		expect(out).not.toContain(`Model: anthropic/claude-sonnet-4-5 ${theme.icon.fast}`);
+	});
 
 	it("expands live recent output, tool args, and the full task section when expanded=true and collapses them back (AC1/AC2)", () => {
 		const details: SubagentToolDetails = {


### PR DESCRIPTION
Supersedes #3540 (closed unmerged at head `4822d2f61`, disposition `REQUEST_CHANGES`, P0=0 / P1=1 / P2=1). Reopen was not possible, so this is a fresh branch cut from current `dev` with `4822d2f61` cherry-picked and the two open findings repaired on top.

**Head SHA: `6cf7e0ff6e6f9a9dda3d96e1525bdb8658e97fd8`** · **Dev CI: [run 30515536975](https://github.com/Yeachan-Heo/gajae-code/actions/runs/30515536975) — success** (19 pass, 6 skipped, 0 fail, first attempt), `head_sha` verified equal to this PR head.

## Finding → fix → test → SHA → CI mapping

All rows verified on `6cf7e0ff6e6f9a9dda3d96e1525bdb8658e97fd8`.

| Finding | Fix | Test proving it | CI job |
|---|---|---|---|
| **P1** — `canonicalizeProgressForSignature()` omitted `fastMode`, so a nested task's fast-mode change rendered differently but produced a byte-identical signature, letting `emitIfChanged` suppress the update and leaving the body cache stale | `packages/coding-agent/src/tools/subagent.ts` — add `fastMode: progress.fastMode ?? false` | `changes when only fastMode flips, at every rendered progress route` (root, `inflightTaskDetails.progress`, `extractedToolData.task[].progress`) | [subagent-live-progress](https://github.com/Yeachan-Heo/gajae-code/actions/runs/30515536975/job/90785439357) |
| **P1** (producer emission) | same | `emits exactly once when only a nested task's fastMode flips, and not for an unchanged poll` | [subagent-live-progress](https://github.com/Yeachan-Heo/gajae-code/actions/runs/30515536975/job/90785439357) |
| **P1** (cache invalidation) | same — body cache is keyed by the same signature, so no second cache key was added | `invalidates the cached body when only a nested task's fastMode flips` (`bodyRenders` 1→2, output gains `theme.icon.fast`) | [subagent-render](https://github.com/Yeachan-Heo/gajae-code/actions/runs/30515536975/job/90785439340) |
| **P2** — `updateSubagentModel` documented as a patch but assigned all four fields unconditionally, so `{ fastMode: false }` erased `requestedModel`, `effectiveModel`, `modelFellBack` | `packages/coding-agent/src/async/job-manager.ts` — preserve-on-omit (`model.X ?? record.X`), parameter properties left optional | `updateSubagentModel preserves fields omitted from a partial patch` | [async-job-manager](https://github.com/Yeachan-Heo/gajae-code/actions/runs/30515536975/job/90785439317) |
| Required repair 4 — re-run the reviewer-named suites | — | `agent-session-fast-mode.test.ts` | [agent-session-fast-mode](https://github.com/Yeachan-Heo/gajae-code/actions/runs/30515536975/job/90785439333) |
| Typecheck + lint gate | — | `biome check` + `tsc --noEmit` | [check:@gajae-code/coding-agent](https://github.com/Yeachan-Heo/gajae-code/actions/runs/30515536975/job/90785439413) |

## Unchanged from the predecessor

The review found the top-level fix sound, so nothing there was re-litigated. Carried over verbatim: the production `ToolSession` adapter delegating to the provider-aware subagent tier predicate; use of the effective provider after auth fallback; `SubagentRecord.fastMode` surviving ordinary live-progress snapshot rebuilds; the top-level snapshot signature including `fastMode` via `canonicalizeSnapshotForSignature()`; and the glyph rendering on the model line.

## P1 detail

The nested task panel renders `AgentProgress.fastMode`, but the producer's await gating and the body cache both key off `subagentAwaitRenderedStateSignature()`, which canonicalizes nested `AgentProgress` through `canonicalizeProgressForSignature()`. That function carried `modelOverride` and `modelSubstitutionWarning` but omitted `fastMode`.

One insertion covers all three rendered routes, because `canonicalizeTaskDetailsForSignature()` maps `details.progress` back through the same function and `canonicalizeProgressForSignature()` recurses into `inflightTaskDetails`.

## P2 detail — why preserve-on-omit rather than complete replacement

The review offered either option. Preserve-on-omit was chosen because two **pre-existing** partial callers already exist — `test/tools/subagent-live-progress.test.ts` calls `updateSubagentModel(id, { fastMode: true })` in two places. Requiring complete objects would have forced both to supply unrelated model values, destroying the strongest available proof that a fast-mode-only patch preserves model identity. `SubagentRecord`'s four fields are optional, so dropping the `?` markers would also have produced real compile failures rather than a cosmetic tightening.

Documented tradeoff: a field can no longer be cleared back to `undefined` through this method. No caller needs that. `??`-preservation is safe for the sole production caller because `packages/coding-agent/src/task/executor.ts:1514` assigns `progress.fastMode = model ? (options.isFastForSubagentProvider?.(model.provider) ?? false) : false` immediately before the call, so all four arguments are concrete non-nullish values.

## Non-vacuous test verification

Each new test was confirmed to fail without its production change: reverting the `subagent.ts` insertion produces 3 failures (three-route signature, emit-gating, body-cache); reverting the `job-manager.ts` change produces 1 (preserve-on-omit).

## Local evidence

All on the exact pushed head, worktree clean at commit time. Bounded explicit file batches only — a whole-directory `bun test packages/coding-agent/test/` OOMs at exit 137 on this tree.

```
bun test <subagent-live-progress, subagent-render, agent-session-fast-mode, async-job-manager>
→ 78 pass, 0 fail

bun --cwd packages/coding-agent run check:types  → clean
biome check                                      → clean
```

Because this PR's affected-path set is narrow, CI scheduled per-file jobs rather than `shard-1-of-8`. The broader consumer surface of the two changed modules was therefore verified locally as well — 17 consumer test files importing `tools/subagent` or `async/job-manager`, **249 tests, 0 failures**: `tools.test.ts`, `task-fork-context`, `interactive-mode-background-activity` (135); `tools/subagent.test.ts`, `tools/task-simple-mode`, `task/subagent-lsp`, `jobs-observer` (64); `tools/bash-resource-lifecycle` + `.redteam`, `monitor-cron-tools`, `sdk-embedding-tools` (34); six `task/executor-*` plus `task/id` (16).

## Relationship to the other successor PR

Companion to the #3539 successor (#3550). The two touch disjoint production files and are independently reviewable; this one is the smaller of the pair.
