### PR TITLE
test(coding-agent): gate the committed docs index in CI, and select that gate for docs-only changes

### DIFF
--- a/packages/coding-agent/test/docs-index-lazy.test.ts
+++ b/packages/coding-agent/test/docs-index-lazy.test.ts
@@ -30,6 +30,22 @@ async function scanDocsCorpus(): Promise<string[]> {
 	return entries.sort();
 }
 
+const REPO_ROOT = path.join(import.meta.dir, "../../..");
+const GENERATED_INDEX = "packages/coding-agent/src/internal-urls/docs-index.generated.ts";
+
+/** `git diff --quiet HEAD -- <paths>`. Exit 0 means the worktree matches the commit. */
+function matchesHead(...paths: string[]): boolean {
+	const result = Bun.spawnSync({
+		cmd: ["git", "diff", "--quiet", "HEAD", "--", ...paths],
+		cwd: REPO_ROOT,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	// 0 = no diff, 1 = diff. Anything else (no git, not a repo) is a real error.
+	expect([0, 1], result.stderr.toString() || `git diff exited ${result.exitCode}`).toContain(result.exitCode);
+	return result.exitCode === 0;
+}
+
 describe("internal-urls docs index loading", () => {
 	it("does not load the generated docs corpus when importing the barrel", () => {
 		const stdout = runBunEval(`
@@ -84,5 +100,26 @@ describe("internal-urls docs index loading", () => {
 			.map(({ fileName }) => fileName);
 
 		expect(stale, `stale embedded docs index for ${stale.join(", ") || "(none)"}; ${REGENERATE_HINT}`).toEqual([]);
+	});
+
+	/**
+	 * The two assertions above compare the worktree index to the worktree docs, and
+	 * the root `prepare` hook regenerates the index on every `bun install` — which CI
+	 * runs before any test. So a *committed* index that is stale gets silently repaired
+	 * in the worktree and both assertions pass. The invariant they cannot see is
+	 * `committed index == committed docs`.
+	 *
+	 * This closes that: if `docs/` matches HEAD but the index does not, the only thing
+	 * that could have rewritten the index is the generator, which means the commit
+	 * shipped a stale one. When `docs/` is itself dirty the developer is mid-edit and
+	 * there is nothing to conclude, so the check yields rather than false-failing.
+	 */
+	it("commits an index that matches the committed docs", () => {
+		if (!matchesHead("docs")) return;
+
+		expect(
+			matchesHead(GENERATED_INDEX),
+			`committed docs index is stale relative to committed docs/; ${REGENERATE_HINT}`,
+		).toBe(true);
 	});
 });

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -16,6 +16,8 @@ const packages: WorkspacePackage[] = [
 	},
 ];
 
+const EMBEDDED_DOCS_GATE_KEY = "test:packages/coding-agent/test/docs-index-lazy.test.ts";
+
 function planForPaths(paths: readonly string[]) {
 	return planTasks(paths, packages);
 }
@@ -1247,8 +1249,50 @@ test("tab-worker graph changes always include install-methods and are Darwin rel
 		expect(rootCheck).toMatchObject({ command: ["bun", "run", "ci:check:full"], native: true, nativeBuild: false });
 	});
 
-	test("docs/changelog-only changes plan nothing expensive", () => {
-		expect(targeted(["docs/guide.md", "CHANGELOG.md", "packages/coding-agent/README.md"])).toEqual([]);
+	test("changelog and package-readme-only changes plan nothing", () => {
+		expect(targeted(["CHANGELOG.md", "packages/coding-agent/README.md"])).toEqual([]);
+	});
+
+	// docs/ is the source the embedded docs index is generated from, so shipping a
+	// docs edit without regenerating that index is the one drift class a docs-only
+	// change can introduce. Both planners must select that gate, because dev CI runs
+	// on push as well as pull_request.
+	test("docs-only changes select the embedded-docs gate and nothing else", () => {
+		const changed = ["docs/guide.md", "docs/nested/other.md"];
+		for (const keys of [targeted(changed), planTasks(changed, packages)].map(tasks =>
+			tasks.map(task => task.key),
+		)) {
+			expect(keys).toEqual([EMBEDDED_DOCS_GATE_KEY]);
+		}
+	});
+
+	// The generated index is a real source file, so it also pulls its owning-package
+	// tasks. The gate must still be selected -- that is the half a docs-only plan
+	// cannot cover on its own.
+	test("a generated-docs-index change also selects the embedded-docs gate", () => {
+		for (const changed of [
+			["packages/coding-agent/src/internal-urls/docs-index.generated.ts"],
+			["docs/guide.md", "packages/coding-agent/src/internal-urls/docs-index.generated.ts"],
+		]) {
+			for (const tasks of [targeted(changed), planTasks(changed, packages)]) {
+				expect(tasks.map(task => task.key)).toContain(EMBEDDED_DOCS_GATE_KEY);
+			}
+		}
+	});
+
+	// Markdown outside docs/ is not embedded, so it must not drag the gate in.
+	test("the embedded-docs gate stays out of unrelated plans", () => {
+		for (const changed of [
+			["CHANGELOG.md"],
+			["packages/coding-agent/README.md"],
+			["README.md"],
+			[".gjc/skills/example/SKILL.md"],
+			["packages/example/src/index.ts"],
+		]) {
+			for (const tasks of [targeted(changed), planTasks(changed, packages)]) {
+				expect(tasks.map(task => task.key)).not.toContain(EMBEDDED_DOCS_GATE_KEY);
+			}
+		}
 	});
 
 test("Python SDK changes plan dedicated Python validation and one native build", () => {

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -699,6 +699,11 @@ function readStringMap(value: unknown): Record<string, string> | undefined {
 
 export function planTasks(paths: readonly string[], packages: readonly WorkspacePackage[]): Task[] {
 	const tasks = new Map<string, Task>();
+	// Mirror of the docs-index gate in planTargetedTasks: docs/ is the source the
+	// embedded index is generated from, so either side changing must run its gate.
+	if (paths.some(isEmbeddedDocsSourcePath)) {
+		addTestFileTask(tasks, EMBEDDED_DOCS_GATE_TEST);
+	}
 	const touchedPackages = findTouchedPackages(paths, packages);
 	const rootPackageReleaseHarnessOnly = isRootPackageReleaseHarnessOnly(paths);
 	const fullWorkspace = paths.some(isFullWorkspacePath) && !rootPackageReleaseHarnessOnly;
@@ -799,8 +804,14 @@ export function planTasks(paths: readonly string[], packages: readonly Workspace
 export function planTargetedTasks(paths: readonly string[], packages: readonly WorkspacePackage[], testFiles: readonly string[]): Task[] {
 	const tasks = new Map<string, Task>();
 	const relevant = paths.filter(changedPath => !isDocOrChangelogPath(changedPath));
+	// A docs edit is cheap, but it is not free: docs/ is the source the embedded docs
+	// index is generated from, so shipping the edit without regenerating that index is
+	// the one drift class a docs-only PR can introduce. Select just its gate.
+	if (paths.some(isEmbeddedDocsSourcePath)) {
+		addTestFileTask(tasks, EMBEDDED_DOCS_GATE_TEST);
+	}
 	if (relevant.length === 0) {
-		return [];
+		return [...tasks.values()];
 	}
 
 	const fullWorkspace = relevant.some(isFullWorkspacePath) && !isRootPackageReleaseHarnessOnly(relevant);
@@ -1007,6 +1018,14 @@ function ensureNativeBuild(tasks: Map<string, Task>): void {
 
 function isDocOrChangelogPath(changedPath: string): boolean {
 	return changedPath.endsWith(".md") || changedPath.startsWith("docs/") || changedPath.startsWith(".gjc/");
+}
+
+/** The generated index embeds every markdown file under `docs/`, so one test gates both sides. */
+const EMBEDDED_DOCS_GATE_TEST = "packages/coding-agent/test/docs-index-lazy.test.ts";
+const GENERATED_DOCS_INDEX = "packages/coding-agent/src/internal-urls/docs-index.generated.ts";
+
+function isEmbeddedDocsSourcePath(changedPath: string): boolean {
+	return (changedPath.startsWith("docs/") && changedPath.endsWith(".md")) || changedPath === GENERATED_DOCS_INDEX;
 }
 
 function isTestFilePath(changedPath: string): boolean {


### PR DESCRIPTION
## Problem

The docs-index parity gate I added in #3525 **cannot fail in CI**, so the coverage that PR claimed is not the coverage CI has.

Root `package.json:150` defines `"prepare": "bun --cwd=packages/coding-agent run generate-docs-index"`. Every CI job runs `bun install --frozen-lockfile`, which fires `prepare` and regenerates the index **before any test runs**. By the time the existing assertions compare `EMBEDDED_DOCS` to `docs/`, both sides are freshly derived from the same source. A stale *committed* index is repaired in the worktree and the gate passes.

Reproduced on dev with the exact CI command:

```
index matches doc: False              # committed index is stale
$ bun install --frozen-lockfile
Generated src/internal-urls/docs-index.generated.ts (118 docs)
git diff --name-only -> packages/coding-agent/src/internal-urls/docs-index.generated.ts
```

| when | `docs-index` violations |
| --- | --- |
| before `prepare` | **1** — `Generated docs index is stale` |
| after `prepare` (what CI sees) | **0** |

`scripts/check-public-version-sync.ts:240-254` byte-compares the same regenerated index and is masked identically, so this is a property of the `prepare` hook rather than something #3525 introduced. But #3525 advertised the gate as closing the drift class, and in CI it did not.

## Fix

Two commits, because the assertion alone was not enough — it was never being selected.

### 1. `test(coding-agent)`: assert the committed index against the committed docs

The invariant the existing assertions cannot see is **committed index == committed docs**. One `git diff --quiet HEAD` call:

- `docs/` clean vs HEAD, index dirty → the only thing that rewrites the index is the generator, so the commit shipped a stale one. **Fail.**
- `docs/` dirty → developer is mid-edit, nothing to conclude. **Yield.**

A generator `--check` mode cannot work here: `prepare` has already rewritten the file, so `--check` compares it to itself.

### 2. `ci(dev)`: select that gate for docs-only changes

This is the part I got wrong in the first push of this PR, and it mattered. `scripts/ci-dev-affected.ts:801` filters `isDocOrChangelogPath` out before task planning, so I measured what a docs-only PR actually selects:

```
CI_DEV_CHANGED_PATHS=docs/environment-variables.md  ->  []          # zero tasks
CI_DEV_CHANGED_PATHS=<the generated index>          ->  14 tasks, gate NOT among them
```

So the gate fired on *this* PR only because this PR edits the test file itself. On a real docs drift it would never have run. `planTargetedTasks` now selects exactly `test:packages/coding-agent/test/docs-index-lazy.test.ts` when a changed path is `docs/**/*.md` or the generated index, and nothing else for the docs-only case.

I narrowed the existing contract test rather than deleting it. `docs/changelog-only changes plan nothing expensive` asserted `["docs/guide.md", "CHANGELOG.md", "packages/coding-agent/README.md"] -> []`. `CHANGELOG.md` and package READMEs are `.md` *outside* `docs/`, so they still plan nothing; that half is now `changelog and package-readme-only changes plan nothing`. The `docs/` half asserts the gate and nothing else — one ~1.5s test file, which I'd argue is still "nothing expensive".

## Correcting my own earlier claim

An earlier revision of this PR body and my comment on #3525 both said **`check:public-sync` never runs on a dev PR at all**. That is false and I'm retracting it. `scripts/ci-dev-affected.ts:899` emits `root-check` → `["bun", "run", "ci:check:full"]` for an unmapped root-level `isCodeIshPath` change (also `:727`, `:749`, `:812`), and `package.json:128` includes `check:public-sync` in `ci:check:full`. So it does reach dev PRs, just not for the path classes involved here.

The narrower true claim, which is what the A→B decision actually rested on: **dev-ci.yml defines no `ci:check:full` job.** Option A was a YAML step in ci.yml's `check` job (`ci.yml:51-52`), and ci.yml triggers only on `push: branches: [main]`, `tags: v*`, and `pull_request: branches: [main]`. It could not have run on #3514, a dev-targeted PR. The substitution stands on that; the absolute I used to justify it did not.

## Verification

End-to-end, the chain this PR claims:

```
1. commit a doc edit without regenerating   -> committed index stale
2. planner for that path set                -> ["test:.../docs-index-lazy.test.ts"]   (gate selected)
3. prepare regenerates, run the gate        -> FAIL: committed docs index is stale
                                                relative to committed docs/
```

Three cases on the assertion:

| case | `docs/` | index | result |
| --- | --- | --- | --- |
| clean commit | clean | clean | **pass** |
| stale commit | clean | dirty | **fail** — names the remedy |
| local mid-edit | dirty | — | **yields** |

Selector: `bun test scripts/ci-dev-affected.test.ts` → **84 pass / 0 fail**; `scripts/dev-ci-guard-topology.test.ts` → **5 pass / 0 fail**. `tsc --noEmit` on coding-agent clean. `biome check` on `scripts/` reports "no files processed" because `scripts/` is biome-ignored by config, which is why the repo's own `check:tools` passes `--no-errors-on-unmatched`.

Non-vacuity: the generator's only write target is `docs-index.generated.ts` (`generate-docs-index.ts:71` → `outputPath` at `:28`); `generate-hotkeys-docs.ts` writes `docs/keybindings.md` only *without* `--check`, and `packages/coding-agent/package.json:33` invokes it with `--check`. So `docs/` is clean in a CI checkout and the gate evaluates rather than yielding. It is fail-open by construction — if that ever changes the gate goes quiet rather than false-failing, which is the safer direction but worth knowing.

Two pre-existing failures in `docs-index-lazy.test.ts` on my machine (`runBunEval` needs a matching native addon; worktree wants 0.12.4 and none is built). Identical on pristine dev — 2 pass / 2 fail there, 3 pass / 2 fail with this change. They pass in CI.

## Scope

3 files, +83/-3. One test assertion, one selector mapping, three selector tests. No `src/` change.
