### PR TITLE
fix(ci): aggregate failure summaries across invocations

### DIFF
--- a/scripts/ci-failure-extract.test.ts
+++ b/scripts/ci-failure-extract.test.ts
@@ -67,6 +67,24 @@ describe("extractFailures", () => {
 		expect(result.reportedFailCount).toBe(6);
 		expect(result.identities).toHaveLength(1);
 	});
+	test("aggregates multiple summary lines across timestamped invocations", () => {
+		const log = [`${TS} 0 fail`, `${TS}(fail) one recognised`, `${TS} 2 fail`].join("\n");
+
+		const result = extractFailures(log);
+
+		expect(result.reportedFailCount).toBe(2);
+		expect(result.underCounted).toBe(true);
+		expect(result.identities).toEqual(["one recognised"]);
+	});
+
+	test("aggregates suite-level error summaries across invocations", () => {
+		const log = [`${TS} 2 fail`, `${TS} 1 error`, `${TS} 1 error`].join("\n");
+
+		const result = extractFailures(log);
+
+		expect(result.reportedErrorCount).toBe(2);
+		expect(result.underCounted).toBe(false);
+	});
 
 	test("does not flag under-counting when extraction agrees with the summary", () => {
 		const log = [`${TS}(fail) a`, `${TS}(fail) b`, `${TS} 2 fail`].join("\n");

--- a/scripts/ci-failure-extract.ts
+++ b/scripts/ci-failure-extract.ts
@@ -88,17 +88,14 @@ export function extractFailures(rawLog: string): ExtractionResult {
 			continue;
 		}
 
-		if (reportedFailCount === undefined) {
-			const summary = BUN_SUMMARY.exec(line);
-			if (summary?.[1]) {
-				reportedFailCount = Number(summary[1]);
-				continue;
-			}
+		const summary = BUN_SUMMARY.exec(line);
+		if (summary?.[1]) {
+			reportedFailCount = (reportedFailCount ?? 0) + Number(summary[1]);
 		}
 
-		if (reportedErrorCount === undefined) {
-			const errors = BUN_ERROR_SUMMARY.exec(line);
-			if (errors?.[1]) reportedErrorCount = Number(errors[1]);
+		const errors = BUN_ERROR_SUMMARY.exec(line);
+		if (errors?.[1]) {
+			reportedErrorCount = (reportedErrorCount ?? 0) + Number(errors[1]);
 		}
 	}
 


### PR DESCRIPTION
## Summary
- aggregate every Bun fail summary across a whole CI job log
- aggregate suite-level error summaries across repeated test invocations
- preserve undefined counts when no matching summary exists

## Tests
- `bun test scripts/ci-failure-extract.test.ts`
- `bunx tsc -p tsconfig.tools.json --noEmit`