### PR TITLE
fix(sdk): bound broker shutdown by graceful timeout

### DIFF
--- a/scripts/restart-sdk-broker-core.ts
+++ b/scripts/restart-sdk-broker-core.ts
@@ -50,6 +50,12 @@ async function stopPreviousBroker(discovery: BrokerDiscoveryLike, deps: RestartS
 	}
 }
 
+function createAuthenticatedShutdownTimeoutError(previousPid: number, gracefulTimeoutMs: number): Error {
+	return new Error(
+		`SDK broker pid ${previousPid} did not complete its authenticated shutdown within ${gracefulTimeoutMs}ms.`,
+	);
+}
+
 /**
  * Session hosts outlive the broker that spawned them, so a broker-only restart keeps
  * serving whatever source those processes started with. Closing them through the live
@@ -74,16 +80,25 @@ export async function restartSdkBroker(
 	let closedSessionIds: string[] | undefined;
 	if (previous) {
 		if (options.closeSessionHosts) closedSessionIds = await closeSessionHosts(previous, deps);
-		await stopPreviousBroker(previous, deps);
 		const deadline = Date.now() + gracefulTimeoutMs;
+		const timeout = Promise.withResolvers<void>();
+		const timeoutId = setTimeout(() => {
+			timeout.reject(createAuthenticatedShutdownTimeoutError(previous.pid, gracefulTimeoutMs));
+		}, Math.max(0, deadline - Date.now()));
+		try {
+			await Promise.race([stopPreviousBroker(previous, deps), timeout.promise]);
+		} finally {
+			clearTimeout(timeoutId);
+		}
+
 		while (Date.now() < deadline) {
 			const current = await deps.readDiscovery(options.agentDir, Number.POSITIVE_INFINITY);
 			if (!current || current.pid !== previous.pid || current.incarnation !== previous.incarnation) break;
-			await deps.sleep(SHUTDOWN_POLL_INTERVAL_MS);
+			await deps.sleep(Math.min(SHUTDOWN_POLL_INTERVAL_MS, Math.max(0, deadline - Date.now())));
 		}
 		const current = await deps.readDiscovery(options.agentDir, Number.POSITIVE_INFINITY);
 		if (current?.pid === previous.pid && current.incarnation === previous.incarnation) {
-			throw new Error(`SDK broker pid ${previous.pid} did not complete its authenticated shutdown.`);
+			throw createAuthenticatedShutdownTimeoutError(previous.pid, gracefulTimeoutMs);
 		}
 	}
 

--- a/scripts/restart-sdk-broker.test.ts
+++ b/scripts/restart-sdk-broker.test.ts
@@ -96,6 +96,31 @@ test("does not start a replacement when authenticated shutdown fails", async () 
 	expect(ensured).toBe(false);
 });
 
+test("rejects when authenticated shutdown exceeds the graceful timeout", async () => {
+	const previous = discovery(1, "darwin:1:0");
+	const neverSettlingShutdown = Promise.withResolvers<void>();
+	let ensureCalled = false;
+	await expect(
+		Promise.race([
+			restartSdkBroker(
+				{ agentDir: "/agent", gracefulTimeoutMs: 20 },
+				deps({
+					readDiscovery: async () => previous,
+					shutdown: () => neverSettlingShutdown.promise,
+					ensure: async () => {
+						ensureCalled = true;
+						return discovery(2, "darwin:2:0");
+					},
+				}),
+			),
+			Bun.sleep(200).then(() => {
+				throw new Error("watchdog timeout");
+			}),
+		]),
+	).rejects.toThrow("did not complete its authenticated shutdown within 20ms");
+	expect(ensureCalled).toBe(false);
+});
+
 test("falls back to an identity-fenced signal when the broker lacks broker.shutdown", async () => {
 	const previous = discovery(1, "darwin:1:0");
 	const replacement = discovery(2, "darwin:2:0");


### PR DESCRIPTION
## Summary
- apply the graceful timeout to the authenticated broker shutdown request itself
- reuse one deadline for shutdown and discovery polling
- keep replacement startup fenced after a stalled shutdown

## Tests
- `bun test scripts/restart-sdk-broker.test.ts`
- `bunx tsc -p tsconfig.tools.json --noEmit`