### PR TITLE
fix(coding-agent): validate status-line PR URLs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The GitHub status-line lookup now rejects malformed PR numbers and control-bearing or non-HTTP(S) URLs before they reach terminal rendering.
+
 ## [0.12.4] - 2026-07-30
 
 ## [0.12.3] - 2026-07-30

--- a/packages/coding-agent/src/modes/components/status-line/gh.ts
+++ b/packages/coding-agent/src/modes/components/status-line/gh.ts
@@ -2,13 +2,29 @@ import { type RunGh, runGhDefault } from "../../../utils/gh";
 
 const STATUS_LINE_GH_TIMEOUT_MS = 5_000;
 
+const C0_C1_CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]/;
+const isSafePrNumber = (value: unknown): value is number =>
+	typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+
+const hasAbsoluteHttpUrl = (value: unknown): value is string => {
+	if (typeof value !== "string") return false;
+	if (C0_C1_CONTROL_CHARACTERS.test(value)) return false;
+
+	try {
+		const parsed = new URL(value);
+		return (parsed.protocol === "http:" || parsed.protocol === "https:") && parsed.host !== "";
+	} catch {
+		return false;
+	}
+};
+
 export async function lookupCurrentPr(runGh: RunGh = runGhDefault): Promise<{ number: number; url: string } | null> {
 	try {
 		const result = await runGh(["pr", "view", "--json", "number,url"], { timeoutMs: STATUS_LINE_GH_TIMEOUT_MS });
 		if (result.exitCode !== 0 || result.timedOut) return null;
 
 		const pr = JSON.parse(result.stdout) as { number?: unknown; url?: unknown };
-		if (typeof pr.number !== "number" || typeof pr.url !== "string") return null;
+		if (!isSafePrNumber(pr.number) || !hasAbsoluteHttpUrl(pr.url)) return null;
 		return { number: pr.number, url: pr.url };
 	} catch {
 		return null;

--- a/packages/coding-agent/test/status-line-gh.test.ts
+++ b/packages/coding-agent/test/status-line-gh.test.ts
@@ -48,4 +48,49 @@ describe("status-line GitHub PR lookup", () => {
 		await expect(lookupCurrentPr(runGh)).resolves.toBeNull();
 		expect(timeoutMs).toBe(5_000);
 	});
+
+	it("accepts enterprise hosts over HTTP(S)", async () => {
+		const urls = [
+			"https://ghe.internal.example.com/teams/cli/pull/3354",
+			"http://ghe.internal.example.com/teams/cli/pull/3354",
+		];
+		for (const url of urls) {
+			const runGh: RunGh = async () => ({
+				exitCode: 0,
+				stdout: JSON.stringify({ number: 3354, url }),
+				stderr: "",
+				timedOut: false,
+			});
+
+			await expect(lookupCurrentPr(runGh)).resolves.toEqual({
+				number: 3354,
+				url,
+			});
+		}
+	});
+
+	it("rejects PR URLs containing C0/C1 control characters", async () => {
+		const runGh: RunGh = async () => ({
+			exitCode: 0,
+			stdout: '{"number":3354,"url":"https://github.com/Yeachan-Heo/gajae-code/pull/3354\\u001f"}',
+			stderr: "",
+			timedOut: false,
+		});
+
+		await expect(lookupCurrentPr(runGh)).resolves.toBeNull();
+	});
+
+	it("rejects malformed PR number and protocol boundaries", async () => {
+		const malformed = [
+			'{"number":0,"url":"https://github.com/Yeachan-Heo/gajae-code/pull/3354"}',
+			`{"number":${Number.MAX_SAFE_INTEGER + 1},"url":"https://github.com/Yeachan-Heo/gajae-code/pull/3354"}`,
+			'{"number":3354,"url":"ftp://github.com/Yeachan-Heo/gajae-code/pull/3354"}',
+		];
+
+		for (const stdout of malformed) {
+			const runGh: RunGh = async () => ({ exitCode: 0, stdout, stderr: "", timedOut: false });
+
+			await expect(lookupCurrentPr(runGh)).resolves.toBeNull();
+		}
+	});
 });


### PR DESCRIPTION
## Summary
- require positive safe-integer PR numbers from `gh` JSON
- reject control-bearing and non-HTTP(S) URLs before terminal rendering
- keep GitHub Enterprise HTTP(S) URLs supported
- document the fix in the coding-agent changelog

## Tests
- `bun test packages/coding-agent/test/status-line-gh.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check src/modes/components/status-line/gh.ts test/status-line-gh.test.ts` (from `packages/coding-agent`)