### PR TITLE
fix(alibaba): match Qwen Code Token Plan request headers (#3557)

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Alibaba Token Plan requests now carry Qwen Code's canonical DashScope request fingerprint on both transports. The built-in `alibaba-token-plan` provider (openai-responses `qwen3.8-max-preview` and openai-completions `glm-5.2`/`deepseek-v4-pro`) now emits the four upstream identity/cache/auth headers (`User-Agent`, `X-DashScope-CacheControl: enable`, `X-DashScope-UserAgent`, `X-DashScope-AuthType: openai`) matching `QwenLM/qwen-code` v0.21.1 (commit `f4cd6e1`) exactly, via a shared helper. DashScope is compatibility-sensitive to this client fingerprint, so a non-identical set can cause request instability and affect first-event latency. Caller headers still win per key (upstream `{...default, ...customHeaders}` precedence); non-Alibaba providers are byte-unchanged (#3557).
+
+### Added
+
+- Reproducible Alibaba Token Plan header-parity A/B latency benchmark (`packages/ai/scripts/alibaba-token-plan-latency-ab.ts`): a fixed-seed interleaved A/B comparison of legacy vs Qwen-identical headers against a deterministic local HTTP server, reporting n/success/error/timeout and TTFT/total latency median/p90/p95/mean/stddev. No live credentials are required; a public-safe blocked-live-data receipt is included (`packages/ai/test/fixtures/alibaba-token-plan-latency-blocked-receipt.md`) (#3557).
+
 
 ## [0.12.4] - 2026-07-30
 

--- a/packages/ai/scripts/alibaba-token-plan-latency-ab.ts
+++ b/packages/ai/scripts/alibaba-token-plan-latency-ab.ts
@@ -1,0 +1,352 @@
+#!/usr/bin/env bun
+/**
+ * Alibaba Token Plan header-parity latency A/B benchmark (issue #3557).
+ *
+ * Compares TWO header fingerprints against a deterministic local HTTP server:
+ *   A — legacy/current mismatched headers (no DashScope identity headers)
+ *   B — Qwen Code-identical headers (canonical DashScope Token Plan set)
+ *
+ * Everything else is held constant: same endpoint, model, prompt/body, process,
+ * runtime, connection policy. A/B requests are INTERLEAVED with a fixed PRNG
+ * seed to reduce temporal bias. Warm-up requests are excluded from the sample.
+ *
+ * This harness is validated against a LOCAL deterministic server only — it does
+ * NOT call a real Alibaba endpoint. No live credentials are required or used.
+ * The server emits a fixed-size SSE stream so TTFT/total latency reflects only
+ * transport/header overhead, not model compute.
+ *
+ * Usage:
+ *   bun --cwd=packages/ai scripts/alibaba-token-plan-latency-ab.ts [options]
+ *
+ * Options:
+ *   --n <count>        Sample requests per arm (default 30)
+ *   --warmup <count>   Warm-up requests per arm, excluded from stats (default 5)
+ *   --port <port>      Local server port (default 0 = ephemeral)
+ *   --seed <int>       PRNG seed for A/B interleaving order (default 42)
+ *
+ * Output: JSON stats (n, success/error/timeout, TTFT + total latency
+ * median/p90/p95/mean/stddev) to stdout, plus a human summary on stderr.
+ *
+ * SECURITY: No tokens, prompts, or private response bodies are printed. The
+ * harness uses a dummy API key ("benchmark-key") that never leaves the local
+ * server. Authorization is present only by scheme on the wire.
+ */
+import { createServer, type Server } from "node:http";
+import {
+	dashscopeTokenPlanDefaultHeaders,
+	QWEN_CODE_UPSTREAM_COMMIT,
+	QWEN_CODE_UPSTREAM_VERSION,
+} from "../src/providers/dashscope-token-plan-headers";
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+
+function parseArgs(argv: string[]): { n: number; warmup: number; port: number; seed: number } {
+	const opts = { n: 30, warmup: 5, port: 0, seed: 42 };
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		const next = argv[i + 1];
+		if (arg === "--n" && next !== undefined) opts.n = Number(next);
+		else if (arg === "--warmup" && next !== undefined) opts.warmup = Number(next);
+		else if (arg === "--port" && next !== undefined) opts.port = Number(next);
+		else if (arg === "--seed" && next !== undefined) opts.seed = Number(next);
+	}
+	if (!(opts.n > 0) || !(opts.warmup >= 0) || !(opts.seed >= 0)) {
+		throw new Error("Invalid CLI options");
+	}
+	return opts;
+}
+
+// ── Deterministic PRNG (mulberry32) for fixed-seed interleaving ─────────────
+
+function mulberry32(seed: number): () => number {
+	let a = seed >>> 0;
+	return () => {
+		a |= 0;
+		a = (a + 0x6d2b79f5) | 0;
+		let t = Math.imul(a ^ (a >>> 15), 1 | a);
+		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+// ── Statistics ───────────────────────────────────────────────────────────────
+
+interface Stats {
+	n: number;
+	median: number;
+	p90: number;
+	p95: number;
+	mean: number;
+	stddev: number;
+}
+
+function percentile(sorted: number[], p: number): number {
+	if (sorted.length === 0) return 0;
+	const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+	return sorted[Math.max(0, idx)];
+}
+
+function computeStats(values: number[]): Stats {
+	const sorted = [...values].sort((a, b) => a - b);
+	const n = sorted.length;
+	if (n === 0) return { n: 0, median: 0, p90: 0, p95: 0, mean: 0, stddev: 0 };
+	const mean = sorted.reduce((sum, v) => sum + v, 0) / n;
+	const variance = sorted.reduce((sum, v) => sum + (v - mean) ** 2, 0) / n;
+	return {
+		n,
+		median: sorted[Math.floor(n / 2)],
+		p90: percentile(sorted, 90),
+		p95: percentile(sorted, 95),
+		mean,
+		stddev: Math.sqrt(variance),
+	};
+}
+
+// ── Deterministic local HTTP server ──────────────────────────────────────────
+// Emits a fixed-size SSE stream so latency reflects only transport/header
+// overhead. Captures the incoming request headers (redacted) for verification.
+
+interface ServerCapture {
+	status: number;
+	headers: Record<string, string>;
+	bodyBytes: number;
+}
+
+function createDeterministicServer(): { server: Server; captures: ServerCapture[] } {
+	const captures: ServerCapture[] = [];
+	const server = createServer((req, res) => {
+		// Capture request headers (lowercased) WITHOUT the Authorization value.
+		const incomingHeaders: Record<string, string> = {};
+		for (const [key, value] of Object.entries(req.headers)) {
+			if (key.toLowerCase() === "authorization") {
+				incomingHeaders[key.toLowerCase()] =
+					typeof value === "string" && value.startsWith("Bearer ") ? "Bearer <redacted>" : "<redacted>";
+			} else if (typeof value === "string") {
+				incomingHeaders[key.toLowerCase()] = value;
+			}
+		}
+		let bodyBytes = 0;
+		req.on("data", chunk => {
+			bodyBytes += chunk.length;
+		});
+		req.on("end", () => {
+			captures.push({ status: 200, headers: incomingHeaders, bodyBytes });
+			// Fixed-size SSE response: 5 chunks of identical content + DONE.
+			const chunk = `data: ${JSON.stringify({ id: "ab", choices: [{ delta: { content: "x".repeat(64) }, finish_reason: null }] })}\n\n`;
+			const frames = [
+				chunk,
+				chunk,
+				chunk,
+				chunk,
+				chunk,
+				`data: ${JSON.stringify({ id: "ab", choices: [{ delta: {}, finish_reason: "stop" }] })}\n\ndata: [DONE]\n\n`,
+			];
+			res.writeHead(200, { "content-type": "text/event-stream" });
+			let i = 0;
+			const send = () => {
+				if (i < frames.length) {
+					res.write(frames[i]);
+					i++;
+					// Deterministic inter-frame delay so TTFT is measurable but stable.
+					setTimeout(send, 2);
+				} else {
+					res.end();
+				}
+			};
+			send();
+		});
+	});
+	return { server, captures };
+}
+
+// ── Single request (capture TTFT + total) ────────────────────────────────────
+
+interface RequestResult {
+	ttftMs: number | null;
+	totalMs: number;
+	ok: boolean;
+	timedOut: boolean;
+	error: string | null;
+}
+
+async function singleRequest(
+	baseUrl: string,
+	headers: Record<string, string>,
+	arm: "A" | "B",
+	timeoutMs: number,
+): Promise<RequestResult> {
+	const start = performance.now();
+	let firstByteMs: number | null = null;
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
+	try {
+		const response = await fetch(`${baseUrl}/v1/chat/completions`, {
+			method: "POST",
+			headers: {
+				...headers,
+				"content-type": "application/json",
+				authorization: "Bearer benchmark-key",
+				"x-benchmark-arm": arm,
+			},
+			body: JSON.stringify({
+				model: "deepseek-v4-pro",
+				messages: [{ role: "user", content: "bench" }],
+				stream: true,
+			}),
+			signal: controller.signal,
+		});
+		if (!response.ok || !response.body) {
+			clearTimeout(timer);
+			return {
+				ttftMs: null,
+				totalMs: performance.now() - start,
+				ok: false,
+				timedOut: false,
+				error: `HTTP ${response.status}`,
+			};
+		}
+		const reader = response.body.getReader();
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (firstByteMs === null && value && value.length > 0) firstByteMs = performance.now();
+			if (done) break;
+		}
+		clearTimeout(timer);
+		return {
+			ttftMs: firstByteMs !== null ? firstByteMs - start : null,
+			totalMs: performance.now() - start,
+			ok: true,
+			timedOut: false,
+			error: null,
+		};
+	} catch (err) {
+		clearTimeout(timer);
+		const timedOut = err instanceof DOMException && err.name === "AbortError";
+		return {
+			ttftMs: firstByteMs !== null ? firstByteMs - start : null,
+			totalMs: performance.now() - start,
+			ok: false,
+			timedOut,
+			error: timedOut ? "timeout" : (err as Error).message,
+		};
+	}
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+	const { n, warmup, port, seed } = parseArgs(process.argv.slice(2));
+	const { server, captures } = createDeterministicServer();
+	await new Promise<void>(resolve => server.listen(port, resolve));
+	const address = server.address();
+	const actualPort = typeof address === "object" && address ? address.port : 0;
+	const baseUrl = `http://127.0.0.1:${actualPort}`;
+
+	// Arm A: legacy/missing DashScope identity headers.
+	const legacyHeaders = { "User-Agent": "legacy-benchmark/1.0" };
+	// Arm B: Qwen Code-identical canonical set.
+	const qwenHeaders = { ...dashscopeTokenPlanDefaultHeaders() };
+
+	// Fixed-seed interleaved order over (warmup + n) requests per arm.
+	const rng = mulberry32(seed);
+	const totalPerArm = warmup + n;
+	const order: ("A" | "B")[] = [];
+	for (let i = 0; i < totalPerArm; i++) {
+		order.push("A");
+		order.push("B");
+	}
+	// Fisher-Yates shuffle with the seeded RNG.
+	for (let i = order.length - 1; i > 0; i--) {
+		const j = Math.floor(rng() * (i + 1));
+		[order[i], order[j]] = [order[j], order[i]];
+	}
+
+	const armResults: Record<"A" | "B", RequestResult[]> = { A: [], B: [] };
+	const timeoutMs = 10_000;
+	let aIndex = 0;
+	let bIndex = 0;
+
+	for (const arm of order) {
+		const result = await singleRequest(baseUrl, arm === "A" ? legacyHeaders : qwenHeaders, arm, timeoutMs);
+		// Drop warmups from the stats sample.
+		if (arm === "A") {
+			if (aIndex >= warmup) armResults.A.push(result);
+			aIndex++;
+		} else {
+			if (bIndex >= warmup) armResults.B.push(result);
+			bIndex++;
+		}
+	}
+
+	server.close();
+
+	// ── Stats ─────────────────────────────────────────────────────────────────
+	function summarize(arm: "A" | "B", label: string) {
+		const results = armResults[arm];
+		const success = results.filter(r => r.ok).length;
+		const error = results.filter(r => !r.ok && !r.timedOut).length;
+		const timedOut = results.filter(r => r.timedOut).length;
+		const ttftValues = results.filter(r => r.ttftMs !== null).map(r => r.ttftMs!);
+		const totalValues = results.map(r => r.totalMs);
+		return {
+			arm,
+			label,
+			n: results.length,
+			success,
+			error,
+			timeout: timedOut,
+			ttft: computeStats(ttftValues),
+			total: computeStats(totalValues),
+		};
+	}
+
+	const statsA = summarize("A", "legacy/current mismatched headers");
+	const statsB = summarize("B", "Qwen Code-identical headers");
+
+	// ── Wire verification (redacted, partitioned by arm marker) ───────────────
+	const armACaptures = captures.filter(c => c.headers["x-benchmark-arm"] === "A");
+	const armBCaptures = captures.filter(c => c.headers["x-benchmark-arm"] === "B");
+	const canonicalPresent = armBCaptures.some(c => c.headers["x-dashscope-authtype"] === "openai");
+	const armAHasDashscope = armACaptures.some(c =>
+		Boolean(c.headers["x-dashscope-cachecontrol"] || c.headers["x-dashscope-useragent"]),
+	);
+
+	const report = {
+		upstream: {
+			repo: "QwenLM/qwen-code",
+			commit: QWEN_CODE_UPSTREAM_COMMIT,
+			version: QWEN_CODE_UPSTREAM_VERSION,
+		},
+		config: { n, warmup, seed, port: actualPort, timeoutMs, server: "local-deterministic" },
+		arms: { A: statsA, B: statsB },
+		wire: {
+			armB_canonical_headers_present: canonicalPresent,
+			armA_dashscope_headers_absent: !armAHasDashscope,
+			note: "Authorization captured as 'Bearer <redacted>'; no tokens/prompts/bodies printed",
+		},
+	};
+
+	process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+
+	const fmt = (s: Stats): string =>
+		`median=${s.median.toFixed(1)}ms p90=${s.p90.toFixed(1)}ms p95=${s.p95.toFixed(1)}ms mean=${s.mean.toFixed(1)}ms stddev=${s.stddev.toFixed(1)}ms`;
+	process.stderr.write(
+		[
+			`\n# Alibaba Token Plan header-parity A/B (local deterministic server)`,
+			`Upstream: QwenLM/qwen-code @${QWEN_CODE_UPSTREAM_COMMIT} v${QWEN_CODE_UPSTREAM_VERSION}`,
+			``,
+			`A (legacy/mismatched): n=${statsA.n} success=${statsA.success} err=${statsA.error} to=${statsA.timeout}`,
+			`  TTFT  ${fmt(statsA.ttft)}`,
+			`  total ${fmt(statsA.total)}`,
+			`B (Qwen-identical):   n=${statsB.n} success=${statsB.success} err=${statsB.error} to=${statsB.timeout}`,
+			`  TTFT  ${fmt(statsB.ttft)}`,
+			`  total ${fmt(statsB.total)}`,
+			``,
+			`Wire: arm-B canonical headers ${canonicalPresent ? "PRESENT ✓" : "MISSING ✗"} | arm-A DashScope headers ${!armAHasDashscope ? "absent ✓" : "LEAKED ✗"}`,
+			`Note: local server only; no live Alibaba credentials used. Authorization redacted.`,
+			``,
+		].join("\n"),
+	);
+}
+
+await main();

--- a/packages/ai/src/providers/dashscope-token-plan-headers.ts
+++ b/packages/ai/src/providers/dashscope-token-plan-headers.ts
@@ -1,0 +1,84 @@
+/**
+ * DashScope Token Plan canonical request headers.
+ *
+ * Reproduces QwenLM/qwen-code's DashScopeOpenAICompatibleProvider.buildHeaders()
+ * defaultHeaders so the built-in `alibaba-token-plan` provider emits the same
+ * client identity / cache / auth-type fingerprint upstream sends. DashScope is
+ * compatibility-sensitive to this fingerprint; a non-identical set can cause
+ * request instability and affect first-event latency (gajae-code #3557).
+ *
+ * Upstream pin (reproduce EXACTLY here):
+ *   Repository:    QwenLM/qwen-code
+ *   Commit:        f4cd6e1d8bbb1c24e7e5d1a40187d8e28aa7c4fb
+ *   Version:       0.21.1
+ *   Source:        packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+ *   buildHeaders():
+ *     const userAgent = `QwenCode/${version} (${process.platform}; ${process.arch})`;
+ *     const defaultHeaders = {
+ *       'User-Agent': userAgent,
+ *       'X-DashScope-CacheControl': 'enable',
+ *       'X-DashScope-UserAgent': userAgent,
+ *       'X-DashScope-AuthType': authType,
+ *     };
+ *     return customHeaders ? { ...defaultHeaders, ...customHeaders } : defaultHeaders;
+ *
+ * The Token Plan preset authenticates with AuthType.USE_OPENAI ('openai'), so
+ * X-DashScope-AuthType is the constant 'openai'. Pin the version so an upstream
+ * bump is an explicit parity update rather than silent drift.
+ */
+export const QWEN_CODE_UPSTREAM_REPO = "QwenLM/qwen-code";
+export const QWEN_CODE_UPSTREAM_COMMIT = "f4cd6e1d8bbb1c24e7e5d1a40187d8e28aa7c4fb";
+export const QWEN_CODE_UPSTREAM_VERSION = "0.21.1";
+
+// Upstream Token Plan preset uses AuthType.USE_OPENAI = 'openai'.
+const QWEN_CODE_TOKEN_PLAN_AUTH_TYPE = "openai";
+
+/**
+ * The Qwen Code CLI version string used in identity headers. Pinned to the
+ * upstream version at {@link QWEN_CODE_UPSTREAM_COMMIT}; change both together
+ * as an explicit parity update.
+ */
+export function qwenCodeUserAgent(version: string = QWEN_CODE_UPSTREAM_VERSION): string {
+	// process.platform / process.arch are read verbatim, matching upstream
+	// (e.g. "linux", "darwin", "win32"; "x64", "arm64"). No normalization.
+	return `QwenCode/${version} (${process.platform}; ${process.arch})`;
+}
+
+/**
+ * Canonical DashScope Token Plan headers (upstream defaultHeaders, no caller
+ * overrides applied). Exposed for tests/fixtures so the pinned wire set lives
+ * in exactly one place.
+ */
+export function dashscopeTokenPlanDefaultHeaders(
+	version: string = QWEN_CODE_UPSTREAM_VERSION,
+): Readonly<Record<string, string>> {
+	const userAgent = qwenCodeUserAgent(version);
+	return Object.freeze({
+		"User-Agent": userAgent,
+		"X-DashScope-CacheControl": "enable",
+		"X-DashScope-UserAgent": userAgent,
+		"X-DashScope-AuthType": QWEN_CODE_TOKEN_PLAN_AUTH_TYPE,
+	});
+}
+
+/**
+ * Merge canonical DashScope Token Plan identity headers onto a caller's header
+ * map, reproducing upstream buildHeaders() precedence EXACTLY:
+ *   `{ ...defaultHeaders, ...customHeaders }` — caller wins per header.
+ *
+ * This mirrors GJC's existing kimi-code injection order
+ * (`headers = { ...getKimiCommonHeaders(), ...headers }`): canonical identity as
+ * the base, caller-supplied headers overriding individual keys. A caller that
+ * pins `User-Agent` takes that key; the other canonicals still apply.
+ *
+ * A null/undefined `callerHeaders` returns the canonical set alone (upstream
+ * `customHeaders ? {...} : defaultHeaders` shortcut).
+ */
+export function mergeDashScopeTokenPlanHeaders(
+	callerHeaders: Record<string, string> | undefined,
+	version: string = QWEN_CODE_UPSTREAM_VERSION,
+): Record<string, string> {
+	const defaults = dashscopeTokenPlanDefaultHeaders(version);
+	if (!callerHeaders) return { ...defaults };
+	return { ...defaults, ...callerHeaders };
+}

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -68,6 +68,7 @@ import {
 	resolveToolChoice,
 } from "../utils/tool-choice-capability";
 import { COMPOSER_EDIT_DISCIPLINE_PROMPT, isComposerHarnessModel } from "./composer-discipline";
+import { mergeDashScopeTokenPlanHeaders } from "./dashscope-token-plan-headers";
 import {
 	buildCopilotDynamicHeaders,
 	hasCopilotVisionInput,
@@ -1070,6 +1071,14 @@ async function createClient(
 	}
 	if (model.provider === "kimi-code") {
 		headers = { ...getKimiCommonHeaders(), ...headers };
+	}
+	if (model.provider === "alibaba-token-plan") {
+		// Emit Qwen Code's canonical DashScope request fingerprint (User-Agent /
+		// X-DashScope-CacheControl / X-DashScope-UserAgent / X-DashScope-AuthType)
+		// so DashScope treats the caller identically to upstream QwenLM/qwen-code.
+		// Canonical identity is the base; caller headers win per key (upstream
+		// `{...default, ...customHeaders}`). #3557.
+		headers = mergeDashScopeTokenPlanHeaders(headers);
 	}
 	headers = applyOpenAIRequestTransformHeaders(headers, model.requestTransform, `Gajae-Code/${packageJson.version}`);
 	let copilotPremiumRequests: number | undefined;

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -60,6 +60,7 @@ import {
 	resolveToolChoice,
 } from "../utils/tool-choice-capability";
 import { COMPOSER_EDIT_DISCIPLINE_PROMPT, isComposerHarnessModel } from "./composer-discipline";
+import { mergeDashScopeTokenPlanHeaders } from "./dashscope-token-plan-headers";
 import {
 	buildCopilotDynamicHeaders,
 	hasCopilotVisionInput,
@@ -446,8 +447,17 @@ function createClient(
 	}
 	const rawApiKey = apiKey;
 
+	const baseHeaders =
+		model.provider === "alibaba-token-plan"
+			? // Emit Qwen Code's canonical DashScope request fingerprint (User-Agent /
+				// X-DashScope-CacheControl / X-DashScope-UserAgent / X-DashScope-AuthType)
+				// so DashScope treats the caller identically to upstream QwenLM/qwen-code.
+				// Canonical identity is the base; caller headers win per key (upstream
+				// `{...default, ...customHeaders}`). #3557.
+				mergeDashScopeTokenPlanHeaders({ ...(model.headers ?? {}), ...(extraHeaders ?? {}) })
+			: { ...(model.headers ?? {}), ...(extraHeaders ?? {}) };
 	const headers = applyOpenAIRequestTransformHeaders(
-		{ ...(model.headers ?? {}), ...(extraHeaders ?? {}) },
+		baseHeaders,
 		model.requestTransform,
 		`Gajae-Code/${packageJson.version}`,
 	);

--- a/packages/ai/test/alibaba-token-plan-headers.test.ts
+++ b/packages/ai/test/alibaba-token-plan-headers.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { getBundledModel } from "../src/models";
+import {
+	dashscopeTokenPlanDefaultHeaders,
+	mergeDashScopeTokenPlanHeaders,
+	QWEN_CODE_UPSTREAM_COMMIT,
+	QWEN_CODE_UPSTREAM_VERSION,
+	qwenCodeUserAgent,
+} from "../src/providers/dashscope-token-plan-headers";
+import { streamOpenAICompletions } from "../src/providers/openai-completions";
+import { streamOpenAIResponses } from "../src/providers/openai-responses";
+import type { Context, Model } from "../src/types";
+
+// ── Upstream parity pin ─────────────────────────────────────────────────────
+// If QwenLM/qwen-code bumps its version/commit, this test forces an explicit
+// parity update rather than silent drift. The canonical header set is defined
+// in exactly one place (dashscope-token-plan-headers.ts); these constants pin
+// the upstream source of truth the set must match.
+
+describe("DashScope Token Plan header contract (upstream pin)", () => {
+	it("pins the upstream QwenLM/qwen-code commit/version", () => {
+		expect(QWEN_CODE_UPSTREAM_COMMIT).toBe("f4cd6e1d8bbb1c24e7e5d1a40187d8e28aa7c4fb");
+		expect(QWEN_CODE_UPSTREAM_VERSION).toBe("0.21.1");
+	});
+
+	it("builds the exact upstream User-Agent string", () => {
+		// Mirrors upstream: `QwenCode/${version} (${process.platform}; ${process.arch})`
+		const ua = qwenCodeUserAgent();
+		expect(ua).toBe(`QwenCode/${QWEN_CODE_UPSTREAM_VERSION} (${process.platform}; ${process.arch})`);
+	});
+
+	it("emits exactly the four upstream default headers with correct values", () => {
+		const headers = dashscopeTokenPlanDefaultHeaders();
+		// Upstream buildHeaders() defaultHeaders, verbatim. The Token Plan preset
+		// authenticates with AuthType.USE_OPENAI ('openai').
+		expect(headers).toEqual({
+			"User-Agent": qwenCodeUserAgent(),
+			"X-DashScope-CacheControl": "enable",
+			"X-DashScope-UserAgent": qwenCodeUserAgent(),
+			"X-DashScope-AuthType": "openai",
+		});
+		// Exactly four identity headers — no more, no less.
+		expect(Object.keys(headers)).toHaveLength(4);
+	});
+});
+
+// ── Merge / override precedence (exact upstream) ────────────────────────────
+// Upstream buildHeaders(): customHeaders ? { ...default, ...customHeaders } : default.
+// Caller wins per header; an override of one identity key does NOT suppress the others.
+
+describe("mergeDashScopeTokenPlanHeaders precedence", () => {
+	it("returns the canonical set alone when no caller headers are supplied", () => {
+		expect(mergeDashScopeTokenPlanHeaders(undefined)).toEqual(dashscopeTokenPlanDefaultHeaders());
+	});
+
+	it("lets a caller override a single identity header while keeping the rest canonical", () => {
+		const merged = mergeDashScopeTokenPlanHeaders({ "User-Agent": "custom/1.0" });
+		expect(merged["User-Agent"]).toBe("custom/1.0");
+		expect(merged["X-DashScope-CacheControl"]).toBe("enable");
+		expect(merged["X-DashScope-UserAgent"]).toBe(qwenCodeUserAgent());
+		expect(merged["X-DashScope-AuthType"]).toBe("openai");
+	});
+
+	it("lets a caller override ALL identity headers (per-key precedence, no suppression)", () => {
+		const merged = mergeDashScopeTokenPlanHeaders({
+			"User-Agent": "a",
+			"X-DashScope-CacheControl": "off",
+			"X-DashScope-UserAgent": "b",
+			"X-DashScope-AuthType": "oauth",
+		});
+		expect(merged).toEqual({
+			"User-Agent": "a",
+			"X-DashScope-CacheControl": "off",
+			"X-DashScope-UserAgent": "b",
+			"X-DashScope-AuthType": "oauth",
+		});
+	});
+
+	it("preserves non-identity caller headers alongside the canonical set", () => {
+		const merged = mergeDashScopeTokenPlanHeaders({ "X-Custom": "val" });
+		expect(merged["X-Custom"]).toBe("val");
+		expect(merged["X-DashScope-AuthType"]).toBe("openai");
+	});
+
+	it("overrides case-insensitively in wire capture (Headers lowercases keys)", () => {
+		// The OpenAI SDK merges headers into a Headers instance, so a caller using a
+		// different case (e.g. "user-agent") still wins because object-spread here is
+		// case-sensitive — verify the merge record keeps the caller key as-given.
+		const merged = mergeDashScopeTokenPlanHeaders({ "user-agent": "lowercase/1.0" });
+		// Caller key wins verbatim (case-sensitive spread); canonical "User-Agent" stays.
+		expect(merged["user-agent"]).toBe("lowercase/1.0");
+		expect(merged["User-Agent"]).toBe(qwenCodeUserAgent());
+	});
+});
+
+// ── Wire-capture infrastructure ──────────────────────────────────────────────
+// createClient() sets the OpenAI SDK client's defaultHeaders; the SDK merges
+// those into the real fetch init.headers. Capturing outgoing headers proves the
+// canonical set is actually transmitted on the wire, not just stored on an object.
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+	global.fetch = originalFetch;
+});
+
+interface CapturedRequest {
+	url: string;
+	headers: Record<string, string>;
+}
+
+function createCapturingFetchCompletions(captured: CapturedRequest[]): typeof fetch {
+	async function capturingFetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
+		const headers: Record<string, string> = {};
+		const merge = (h: ConstructorParameters<typeof Headers>[0] | undefined): void => {
+			if (!h) return;
+			new Headers(h).forEach((value, key) => {
+				headers[key.toLowerCase()] = value;
+			});
+		};
+		if (input instanceof Request) merge(input.headers);
+		merge(init?.headers);
+		captured.push({ url: input instanceof Request ? input.url : String(input), headers });
+		const payload = `data: ${JSON.stringify({
+			id: "chatcmpl-test",
+			object: "chat.completion.chunk",
+			created: 0,
+			model: "test",
+			choices: [{ index: 0, delta: { content: "ok" }, finish_reason: "stop" }],
+		})}\n\ndata: [DONE]\n\n`;
+		return new Response(payload, { status: 200, headers: { "content-type": "text/event-stream" } });
+	}
+	return Object.assign(capturingFetch, { preconnect: originalFetch.preconnect });
+}
+
+function createCapturingFetchResponses(captured: CapturedRequest[]): typeof fetch {
+	async function capturingFetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
+		const headers: Record<string, string> = {};
+		const merge = (h: ConstructorParameters<typeof Headers>[0] | undefined): void => {
+			if (!h) return;
+			new Headers(h).forEach((value, key) => {
+				headers[key.toLowerCase()] = value;
+			});
+		};
+		if (input instanceof Request) merge(input.headers);
+		merge(init?.headers);
+		captured.push({ url: input instanceof Request ? input.url : String(input), headers });
+		const payload = `data: ${JSON.stringify({
+			type: "response.completed",
+			response: { id: "resp-test", status: "completed", output: [], usage: {} },
+		})}\n\ndata: [DONE]\n\n`;
+		return new Response(payload, { status: 200, headers: { "content-type": "text/event-stream" } });
+	}
+	return Object.assign(capturingFetch, { preconnect: originalFetch.preconnect });
+}
+
+function baseContext(): Context {
+	return { messages: [{ role: "user", content: "hello", timestamp: Date.now() }] };
+}
+
+function alibabaCompletionsModel(): Model<"openai-completions"> {
+	return getBundledModel("alibaba-token-plan", "deepseek-v4-pro");
+}
+
+function alibabaResponsesModel(): Model<"openai-responses"> {
+	return getBundledModel("alibaba-token-plan", "qwen3.8-max-preview");
+}
+
+// The four canonical DashScope identity headers, lowercased for wire comparison.
+const CANONICAL = {
+	"user-agent": qwenCodeUserAgent(),
+	"x-dashscope-cachecontrol": "enable",
+	"x-dashscope-useragent": qwenCodeUserAgent(),
+	"x-dashscope-authtype": "openai",
+} as const;
+
+// ── openai-completions transport (glm-5.2 / deepseek-v4-pro) ─────────────────
+
+describe("alibaba-token-plan wire headers (openai-completions)", () => {
+	it("transmits the full canonical DashScope header set on the wire", async () => {
+		const captured: CapturedRequest[] = [];
+		await streamOpenAICompletions(alibabaCompletionsModel(), baseContext(), {
+			apiKey: "test-key",
+			fetch: createCapturingFetchCompletions(captured),
+		}).result();
+
+		expect(captured).toHaveLength(1);
+		const h = captured[0].headers;
+		expect(h["user-agent"]).toBe(CANONICAL["user-agent"]);
+		expect(h["x-dashscope-cachecontrol"]).toBe(CANONICAL["x-dashscope-cachecontrol"]);
+		expect(h["x-dashscope-useragent"]).toBe(CANONICAL["x-dashscope-useragent"]);
+		expect(h["x-dashscope-authtype"]).toBe(CANONICAL["x-dashscope-authtype"]);
+	});
+
+	it("does NOT inject canonical headers when a caller overrides an identity header (per-key precedence)", async () => {
+		// Upstream { ...default, ...customHeaders }: caller User-Agent wins per key,
+		// the other canonicals still apply. No partial fingerprint is *suppressed* —
+		// the canonical set is the base and the override only takes its own key.
+		const captured: CapturedRequest[] = [];
+		await streamOpenAICompletions(alibabaCompletionsModel(), baseContext(), {
+			apiKey: "test-key",
+			headers: { "User-Agent": "my-cli/2.0" },
+			fetch: createCapturingFetchCompletions(captured),
+		}).result();
+
+		expect(captured).toHaveLength(1);
+		const h = captured[0].headers;
+		expect(h["user-agent"]).toBe("my-cli/2.0");
+		// The other canonical identity headers remain canonical.
+		expect(h["x-dashscope-cachecontrol"]).toBe("enable");
+		expect(h["x-dashscope-useragent"]).toBe(CANONICAL["x-dashscope-useragent"]);
+		expect(h["x-dashscope-authtype"]).toBe("openai");
+	});
+
+	it("sends Authorization as Bearer scheme and keeps identity headers independent of auth", async () => {
+		// Auth is the SDK's responsibility (Authorization: Bearer <key>); the canonical
+		// DashScope identity headers are separate and must coexist with auth on the wire.
+		// We compare Authorization by scheme/presence only — the token value itself is
+		// never logged or persisted by the parity path (redaction is about output, not
+		// about mutating the live wire header).
+		const captured: CapturedRequest[] = [];
+		await streamOpenAICompletions(alibabaCompletionsModel(), baseContext(), {
+			apiKey: "sk-test-key",
+			fetch: createCapturingFetchCompletions(captured),
+		}).result();
+
+		expect(captured).toHaveLength(1);
+		const h = captured[0].headers;
+		expect(h.authorization).toMatch(/^Bearer /);
+		// Canonical identity headers are present alongside auth.
+		expect(h["user-agent"]).toBe(CANONICAL["user-agent"]);
+		expect(h["x-dashscope-authtype"]).toBe("openai");
+	});
+});
+
+// ── openai-responses transport (qwen3.8-max-preview) ─────────────────────────
+
+describe("alibaba-token-plan wire headers (openai-responses)", () => {
+	it("transmits the full canonical DashScope header set on the wire", async () => {
+		const captured: CapturedRequest[] = [];
+		await streamOpenAIResponses(alibabaResponsesModel(), baseContext(), {
+			apiKey: "test-key",
+			fetch: createCapturingFetchResponses(captured),
+		}).result();
+
+		expect(captured).toHaveLength(1);
+		const h = captured[0].headers;
+		expect(h["user-agent"]).toBe(CANONICAL["user-agent"]);
+		expect(h["x-dashscope-cachecontrol"]).toBe(CANONICAL["x-dashscope-cachecontrol"]);
+		expect(h["x-dashscope-useragent"]).toBe(CANONICAL["x-dashscope-useragent"]);
+		expect(h["x-dashscope-authtype"]).toBe(CANONICAL["x-dashscope-authtype"]);
+	});
+
+	it("honors a caller identity override per-key while keeping the rest canonical", async () => {
+		const captured: CapturedRequest[] = [];
+		await streamOpenAIResponses(alibabaResponsesModel(), baseContext(), {
+			apiKey: "test-key",
+			headers: { "X-DashScope-AuthType": "oauth" },
+			fetch: createCapturingFetchResponses(captured),
+		}).result();
+
+		expect(captured).toHaveLength(1);
+		const h = captured[0].headers;
+		expect(h["x-dashscope-authtype"]).toBe("oauth");
+		expect(h["user-agent"]).toBe(CANONICAL["user-agent"]);
+		expect(h["x-dashscope-cachecontrol"]).toBe("enable");
+		expect(h["x-dashscope-useragent"]).toBe(CANONICAL["x-dashscope-useragent"]);
+	});
+});
+
+// ── Non-Alibaba providers must be unaffected ─────────────────────────────────
+
+describe("non-Alibaba providers are unaffected by the canonical header injection", () => {
+	it("openai-completions: a non-Alibaba provider sends NO DashScope headers", async () => {
+		const captured: CapturedRequest[] = [];
+		const model = getBundledModel<"openai-completions">("openai", "gpt-4o-mini");
+		await streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			fetch: createCapturingFetchCompletions(captured),
+		}).result();
+
+		expect(captured).toHaveLength(1);
+		const h = captured[0].headers;
+		expect(h["x-dashscope-cachecontrol"]).toBeUndefined();
+		expect(h["x-dashscope-useragent"]).toBeUndefined();
+		expect(h["x-dashscope-authtype"]).toBeUndefined();
+		// First-party OpenAI UA is the SDK default, not QwenCode.
+		expect(h["user-agent"]).not.toContain("QwenCode");
+	});
+});

--- a/packages/ai/test/fixtures/alibaba-token-plan-latency-blocked-receipt.md
+++ b/packages/ai/test/fixtures/alibaba-token-plan-latency-blocked-receipt.md
@@ -1,0 +1,68 @@
+# Alibaba Token Plan Header-Parity A/B — Blocked Live-Data Receipt
+
+**Issue:** gajae-code #3557
+**Harness:** `packages/ai/scripts/alibaba-token-plan-latency-ab.ts`
+**Date:** 2026-07-30
+
+## Status: BLOCKED (no live credentials)
+
+A live Alibaba Token Plan A/B benchmark could not be run during this lane
+because **no `ALIBABA_TOKEN_PLAN_API_KEY` is present** in this host's process
+or login environment, and there is no Alibaba entry in `~/.gjc/agent/models.yml`.
+
+Per the issue's latency-analysis requirements, live results were **not
+fabricated**. The harness is landed and validated against a deterministic local
+server so it is reproducible the moment credentials become available.
+
+## What was validated (local deterministic server)
+
+The harness was validated end-to-end against an in-process local HTTP server
+that emits a fixed-size SSE stream. This proves the measurement machinery
+correctly captures TTFT, total latency, success/error/timeout counts, and
+partitions the wire captures per A/B arm. Local-server numbers reflect only
+transport/header overhead — they are **not** representative of real Alibaba
+endpoint latency and are included solely as a smoke test of the harness.
+
+Representative local run (`--n 15 --warmup 3 --seed 42`):
+
+```
+A (legacy/mismatched): n=15 success=15 err=0 to=0
+  TTFT  median≈0.7ms  total median≈14.2ms
+B (Qwen-identical):   n=15 success=15 err=0 to=0
+  TTFT  median≈0.6ms  total median≈13.5ms
+Wire: arm-B canonical headers PRESENT ✓ | arm-A DashScope headers absent ✓
+```
+
+These local numbers are intentionally **not** reported as the issue's latency
+results. They only demonstrate the harness runs, interleaves with a fixed seed,
+excludes warmups, and verifies the per-arm wire fingerprint.
+
+## Reproducing the harness
+
+```sh
+bun --cwd=packages/ai scripts/alibaba-token-plan-latency-ab.ts --n 30 --warmup 5 --seed 42
+```
+
+Options: `--n` (samples/arm), `--warmup` (excluded warmups/arm), `--seed`
+(interleave RNG seed), `--port` (local server port, 0 = ephemeral).
+
+The harness prints a JSON stats object to stdout and a human summary to stderr.
+No tokens, prompts, or private response bodies are printed; `Authorization` is
+captured only as `Bearer <redacted>`.
+
+## Running a bounded live A/B when credentials are available
+
+When a valid `ALIBABA_TOKEN_PLAN_API_KEY` is provisioned through the normal GJC
+auth store, run the same harness pointed at the real endpoint. The harness must
+be extended to target `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1`
+with the live key; keep endpoint/model/prompt/body/process/connection policy
+identical across arms and interleave with the fixed seed. **Never print the
+token, the prompt, or private response bodies.** Compare `Authorization` by
+presence/scheme only.
+
+## Why local-only for now
+
+- No credential in env or GJC auth store → any live number would be fabricated.
+- The local server proves the harness is deterministic and correct.
+- The canonical header set itself is proven by the wire-capture unit tests
+  (`packages/ai/test/alibaba-token-plan-headers.test.ts`), not by latency.


### PR DESCRIPTION
## Summary

Makes the built-in `alibaba-token-plan` provider emit **QwenLM/qwen-code's canonical DashScope Token Plan request fingerprint** on both transports, reproducing upstream exactly so DashScope treats the caller identically to Qwen Code.

**Closes #3557.**

### Canonical header set (pinned to upstream)

Reproduced exactly from `QwenLM/qwen-code` **v0.21.1** (commit `f4cd6e1d8bbb1c24e7e5d1a40187d8e28aa7c4fb`), `DashScopeOpenAICompatibleProvider.buildHeaders()`:

| Header | Value |
|---|---|
| `User-Agent` | `QwenCode/0.21.1 (<platform>; <arch>)` |
| `X-DashScope-CacheControl` | `enable` |
| `X-DashScope-UserAgent` | `QwenCode/0.21.1 (<platform>; <arch>)` |
| `X-DashScope-AuthType` | `openai` |

The canonical set lives in **one shared helper** (`dashscope-token-plan-headers.ts`) with the upstream commit/version pinned, so a future upstream bump is an explicit parity update rather than silent drift.

### Why

DashScope is compatibility-sensitive to the client request-header fingerprint. GJC routed the provider through generic OpenAI transports without the DashScope-specific canonical header set, which can cause request instability and affect first-event latency.

### What changed

- **Both transports** (`openai-responses` `qwen3.8-max-preview` and `openai-completions` `glm-5.2`/`deepseek-v4-pro`) now inject the four canonical headers via the shared helper.
- **Caller precedence reproduces upstream exactly** (`{...default, ...customHeaders}`): canonical identity is the base; a caller override wins per key. Mirrors the existing `kimi-code` injection order.
- **Non-Alibaba providers are byte-unchanged** — the injection is gated on `model.provider === "alibaba-token-plan"`.
- **Auth is preserved** — `Authorization` is the SDK's responsibility and coexists with the identity headers on the wire; the parity path never logs or persists credential values (compared by presence/scheme only).

### Tests

- **`packages/ai/test/alibaba-token-plan-headers.test.ts`** (14 tests): deterministic wire-capture for both transports proving the full canonical set is transmitted; pinned upstream commit/version contract; per-key override precedence; auth-coexistence; and a non-Alibaba-unaffected guard.
- **A/B latency harness**: `packages/ai/scripts/alibaba-token-plan-latency-ab.ts` — fixed-seed interleaved A/B (legacy vs Qwen-identical) against a deterministic local HTTP server, reporting n/success/error/timeout and TTFT/total latency median/p90/p95/mean/stddev. No live credentials required.
- **Blocked-live-data receipt**: `packages/ai/test/fixtures/alibaba-token-plan-latency-blocked-receipt.md` — no `ALIBABA_TOKEN_PLAN_API_KEY` was available in the lane, so live numbers were not fabricated; the harness is validated locally and reproducible once credentials exist.

## Verification

| Check | Result |
|---|---|
| `packages/ai` typecheck (`tsc -p tsconfig.json --noEmit`) | ✅ clean |
| New header-parity tests (`alibaba-token-plan-headers.test.ts`) | ✅ 14/14 pass |
| Existing session-header tests | ✅ green |
| `register-builtins` + `stream-timeout-defaults` | ✅ green |
| Full `packages/ai` suite | ✅ 0 new failures (8 pre-existing host env contamination confirmed on clean baseline) |
| A/B harness local run | ✅ deterministic, per-arm wire verification passes |

> Note: 8 pre-existing failures in `anthropic-oauth` / endpoint-trust-boundary tests are caused by `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` being set in this host environment; confirmed identical on the clean baseline (git stash) and unrelated to this change.

## Reproducing the benchmark

\`\`\`sh
bun --cwd=packages/ai scripts/alibaba-token-plan-latency-ab.ts --n 30 --warmup 5 --seed 42
\`\`\`

## Checklist

- [x] Canonical Qwen Code Token Plan headers applied to `alibaba-token-plan` on both transports
- [x] Auth and user customization preserved; caller precedence matches upstream exactly
- [x] Shared helper / pinned upstream commit in tests
- [x] Non-Alibaba providers unchanged
- [x] Deterministic wire-capture tests for both transports + edge cases
- [x] Reproducible A/B benchmark (local deterministic server)
- [x] Public-safe blocked-live-data receipt (no fabricated numbers)
- [x] Typecheck + focused tests green