### PR TITLE
fix(alibaba): strengthen A/B harness wire checks and relabel as synthetic (#3557)

### DIFF
--- a/packages/ai/scripts/alibaba-token-plan-latency-ab.ts
+++ b/packages/ai/scripts/alibaba-token-plan-latency-ab.ts
@@ -304,12 +304,25 @@ async function main(): Promise<void> {
 	const statsB = summarize("B", "Qwen Code-identical headers");
 
 	// ── Wire verification (redacted, partitioned by arm marker) ───────────────
+	// Exact per-capture: every B capture must carry ALL FOUR canonical values;
+	// every A capture must lack ALL THREE DashScope-specific headers. A partial
+	// fingerprint (e.g. only AuthType present in B, or AuthType alone leaked in
+	// A) must NOT pass. This validates the complete arm fingerprint, not just
+	// one marker header.
+	const dashscopeKeys = ["x-dashscope-cachecontrol", "x-dashscope-useragent", "x-dashscope-authtype"] as const;
 	const armACaptures = captures.filter(c => c.headers["x-benchmark-arm"] === "A");
 	const armBCaptures = captures.filter(c => c.headers["x-benchmark-arm"] === "B");
-	const canonicalPresent = armBCaptures.some(c => c.headers["x-dashscope-authtype"] === "openai");
-	const armAHasDashscope = armACaptures.some(c =>
-		Boolean(c.headers["x-dashscope-cachecontrol"] || c.headers["x-dashscope-useragent"]),
-	);
+	const expectedUa = `QwenCode/${QWEN_CODE_UPSTREAM_VERSION} (${process.platform}; ${process.arch})`;
+	const everyBHasFullCanonical =
+		armBCaptures.length > 0 &&
+		armBCaptures.every(
+			c =>
+				c.headers["user-agent"] === expectedUa &&
+				c.headers["x-dashscope-cachecontrol"] === "enable" &&
+				c.headers["x-dashscope-useragent"] === expectedUa &&
+				c.headers["x-dashscope-authtype"] === "openai",
+		);
+	const armAHasAnyDashscope = armACaptures.some(c => dashscopeKeys.some(key => c.headers[key] !== undefined));
 
 	const report = {
 		upstream: {
@@ -320,9 +333,11 @@ async function main(): Promise<void> {
 		config: { n, warmup, seed, port: actualPort, timeoutMs, server: "local-deterministic" },
 		arms: { A: statsA, B: statsB },
 		wire: {
-			armB_canonical_headers_present: canonicalPresent,
-			armA_dashscope_headers_absent: !armAHasDashscope,
-			note: "Authorization captured as 'Bearer <redacted>'; no tokens/prompts/bodies printed",
+			armB_every_capture_full_canonical: everyBHasFullCanonical,
+			armB_captures: armBCaptures.length,
+			armA_every_capture_no_dashscope: !armAHasAnyDashscope,
+			armA_captures: armACaptures.length,
+			note: "Synthetic loopback smoke test (raw fetch, NOT production SDK shape). Exact per-capture: every B capture carries all four canonical values; every A capture lacks all three DashScope-specific headers. Authorization captured as 'Bearer <redacted>'; no tokens/prompts/bodies printed.",
 		},
 	};
 
@@ -332,7 +347,7 @@ async function main(): Promise<void> {
 		`median=${s.median.toFixed(1)}ms p90=${s.p90.toFixed(1)}ms p95=${s.p95.toFixed(1)}ms mean=${s.mean.toFixed(1)}ms stddev=${s.stddev.toFixed(1)}ms`;
 	process.stderr.write(
 		[
-			`\n# Alibaba Token Plan header-parity A/B (local deterministic server)`,
+			`\n# Alibaba Token Plan header-parity A/B (SYNTHETIC loopback smoke test)`,
 			`Upstream: QwenLM/qwen-code @${QWEN_CODE_UPSTREAM_COMMIT} v${QWEN_CODE_UPSTREAM_VERSION}`,
 			``,
 			`A (legacy/mismatched): n=${statsA.n} success=${statsA.success} err=${statsA.error} to=${statsA.timeout}`,
@@ -342,8 +357,8 @@ async function main(): Promise<void> {
 			`  TTFT  ${fmt(statsB.ttft)}`,
 			`  total ${fmt(statsB.total)}`,
 			``,
-			`Wire: arm-B canonical headers ${canonicalPresent ? "PRESENT ✓" : "MISSING ✗"} | arm-A DashScope headers ${!armAHasDashscope ? "absent ✓" : "LEAKED ✗"}`,
-			`Note: local server only; no live Alibaba credentials used. Authorization redacted.`,
+			`Wire (exact per-capture): arm-B every capture full canonical ${everyBHasFullCanonical ? "PASS ✓" : "FAIL ✗"} (${armBCaptures.length} captures) | arm-A no DashScope headers ${!armAHasAnyDashscope ? "PASS ✓" : "LEAKED ✗"} (${armACaptures.length} captures)`,
+			`Note: SYNTHETIC loopback smoke test (raw fetch, not production SDK shape). Local server only; no live Alibaba credentials used. Authorization redacted.`,
 			``,
 		].join("\n"),
 	);

--- a/packages/ai/test/fixtures/alibaba-token-plan-latency-blocked-receipt.md
+++ b/packages/ai/test/fixtures/alibaba-token-plan-latency-blocked-receipt.md
@@ -14,28 +14,25 @@ Per the issue's latency-analysis requirements, live results were **not
 fabricated**. The harness is landed and validated against a deterministic local
 server so it is reproducible the moment credentials become available.
 
-## What was validated (local deterministic server)
+## What was validated (synthetic loopback smoke test)
 
-The harness was validated end-to-end against an in-process local HTTP server
-that emits a fixed-size SSE stream. This proves the measurement machinery
-correctly captures TTFT, total latency, success/error/timeout counts, and
-partitions the wire captures per A/B arm. Local-server numbers reflect only
-transport/header overhead — they are **not** representative of real Alibaba
-endpoint latency and are included solely as a smoke test of the harness.
+This harness is a **synthetic loopback smoke test**, not a production-fidelity
+benchmark. It constructs raw `fetch` requests against an in-process local HTTP
+server (not the production OpenAI SDK request shape), so it validates the
+measurement machinery and the per-arm header-transport logic — it does **not**
+measure the real Gajae-Code vs Alibaba request fingerprint or establish
+production latency impact. Production fingerprint parity is proven separately by
+the wire-capture unit tests
+(`packages/ai/test/alibaba-token-plan-headers.test.ts`), which exercise the
+real SDK fetch path.
 
-Representative local run (`--n 15 --warmup 3 --seed 42`):
+The harness proves: it captures TTFT, total latency, success/error/timeout
+counts; it interleaves with a fixed seed; it excludes warmups; and it
+partitions captures per A/B arm with an **exact per-capture** wire check (every
+B capture carries all four canonical values; every A capture lacks all three
+DashScope-specific headers). Local-server numbers reflect only raw-transport
+overhead and are **not** representative of real Alibaba endpoint latency.
 
-```
-A (legacy/mismatched): n=15 success=15 err=0 to=0
-  TTFT  median≈0.7ms  total median≈14.2ms
-B (Qwen-identical):   n=15 success=15 err=0 to=0
-  TTFT  median≈0.6ms  total median≈13.5ms
-Wire: arm-B canonical headers PRESENT ✓ | arm-A DashScope headers absent ✓
-```
-
-These local numbers are intentionally **not** reported as the issue's latency
-results. They only demonstrate the harness runs, interleaves with a fixed seed,
-excludes warmups, and verifies the per-arm wire fingerprint.
 
 ## Reproducing the harness
 


### PR DESCRIPTION
Follow-up to #3566 addressing the two MEDIUM architect-review findings on the latency harness. **Harness/docs only — no production request-path change** (the production header-parity code merged in #3566 is untouched and the architect explicitly approved it: *"Retain the helper and gates unchanged; no production request-path change is recommended."*).

## Findings addressed

### 1. Wire verification now exact per-capture

The previous `some(...)` predicates checked only one marker header per arm, so a partial fingerprint could pass. Now every arm-B capture must carry **all four** canonical values (`User-Agent`, `X-DashScope-CacheControl`, `X-DashScope-UserAgent`, `X-DashScope-AuthType`) and every arm-A capture must lack **all three** DashScope-specific headers. A partial fingerprint (e.g. only `AuthType` present in B, or `AuthType` alone leaked in A) no longer passes.

### 2. Explicitly relabeled as a synthetic loopback smoke test

The harness and blocked-live-data receipt no longer claim production-fingerprint validation. They are explicitly a **synthetic loopback smoke test** (raw `fetch`, not the production OpenAI SDK request shape). Production fingerprint parity is correctly attributed to the wire-capture unit tests (`packages/ai/test/alibaba-token-plan-headers.test.ts`) which exercise the real SDK fetch path.

## Verification

- `packages/ai` typecheck: clean
- `packages/ai` biome + tsc (`bun run check`): clean
- Harness run: `Wire (exact per-capture): arm-B every capture full canonical PASS ✓ | arm-A no DashScope headers PASS ✓`
- Header-parity unit tests: 14/14 pass (unchanged)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*