### PR TITLE
fix(agent): reject malformed proxy tool-call endings

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Proxy streams now fail closed when a `toolcall_end` event references missing or non-tool-call content instead of silently dropping the protocol violation and accepting a later terminal event.
+
 ## [0.12.4] - 2026-07-30
 
 ## [0.12.3] - 2026-07-30

--- a/packages/agent/src/proxy.ts
+++ b/packages/agent/src/proxy.ts
@@ -387,7 +387,7 @@ function processProxyEvent(
 					partial,
 				};
 			}
-			return undefined;
+			throw new Error("Received toolcall_end for non-toolCall content");
 		}
 
 		case "done":

--- a/packages/agent/test/proxy-toolcall-event-contract.test.ts
+++ b/packages/agent/test/proxy-toolcall-event-contract.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { AssistantMessageEvent, Model } from "@gajae-code/ai";
+import { streamProxy } from "../src/proxy";
+
+type EventType = AssistantMessageEvent["type"];
+
+const model: Model = {
+	id: "test",
+	name: "test",
+	api: "openai-responses",
+	provider: "test",
+	baseUrl: "https://example.test",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 1,
+	maxTokens: 1,
+};
+
+const usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+function installProxyEvents(events: Array<Record<string, unknown>>): void {
+	(
+		globalThis as {
+			fetch: (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => Promise<Response>;
+		}
+	).fetch = async () =>
+		new Response(events.map(event => `data: ${JSON.stringify(event)}\n\n`).join(""), {
+			headers: { "Content-Type": "text/event-stream" },
+		});
+}
+
+async function collectEvents(): Promise<AssistantMessageEvent[]> {
+	return Array.fromAsync(
+		streamProxy(model, { messages: [] }, { authToken: "test", proxyUrl: "https://proxy.example.test" }),
+	);
+}
+
+describe("streamProxy tool-call event contract", () => {
+	test.each([
+		[
+			"missing content",
+			[{ type: "start" }, { type: "toolcall_end", contentIndex: 0 }, { type: "done", reason: "stop", usage }],
+			["start", "error"],
+		],
+		[
+			"non-toolCall content",
+			[
+				{ type: "start" },
+				{ type: "text_start", contentIndex: 0 },
+				{ type: "toolcall_end", contentIndex: 0 },
+				{ type: "done", reason: "stop", usage },
+			],
+			["start", "text_start", "error"],
+		],
+	] satisfies Array<
+		[string, Array<Record<string, unknown>>, EventType[]]
+	>)("fails closed when toolcall_end references %s", async (_label, proxyEvents, expectedTypes) => {
+		installProxyEvents(proxyEvents);
+
+		const events = await collectEvents();
+
+		expect(events.map(event => event.type)).toEqual(expectedTypes);
+		const terminal = events.at(-1);
+		expect(terminal?.type).toBe("error");
+		if (terminal?.type !== "error") throw new Error("expected an error terminal");
+		expect(terminal.error.errorMessage).toBe("Received toolcall_end for non-toolCall content");
+	});
+
+	test("preserves a valid tool-call sequence", async () => {
+		installProxyEvents([
+			{ type: "start" },
+			{ type: "toolcall_start", contentIndex: 0, id: "call-1", toolName: "lookup" },
+			{ type: "toolcall_delta", contentIndex: 0, delta: '{"query":"status"}' },
+			{ type: "toolcall_end", contentIndex: 0 },
+			{ type: "done", reason: "stop", usage },
+		]);
+
+		const events = await collectEvents();
+
+		expect(events.map(event => event.type)).toEqual([
+			"start",
+			"toolcall_start",
+			"toolcall_delta",
+			"toolcall_end",
+			"done",
+		]);
+		const ended = events.find(event => event.type === "toolcall_end");
+		expect(ended?.type).toBe("toolcall_end");
+		if (ended?.type !== "toolcall_end") throw new Error("expected a toolcall_end event");
+		expect(ended.toolCall).toMatchObject({
+			id: "call-1",
+			name: "lookup",
+			arguments: { query: "status" },
+		});
+		expect("partialJson" in ended.toolCall).toBe(false);
+	});
+});


### PR DESCRIPTION
## Finding

`convertProxyEvents` rejected content-type mismatches for delta/end events except `toolcall_end`. A malformed end event could therefore be accepted as a successful terminal message even when its `contentIndex` did not identify an active tool call.

## Root cause and enforcement boundary

The `toolcall_end` conversion branch dereferenced the indexed content without enforcing the same `toolCall` type invariant used by the other proxy event branches. The fix is limited to that event-conversion boundary and preserves valid tool-call finalization.

## Scope

- fail closed when `toolcall_end` targets missing or non-tool-call content
- preserve valid tool-call output and removal of `partialJson`
- add focused observable-contract coverage
- record the fix under `packages/agent` Unreleased/Fixed

No protocol redesign, transport change, or unrelated refactor is included.

## Verification

- Base SHA: `949e5bbb2d23c1cad5dfd4f1db722736ad2fce95`
- Head SHA: `1121258b93ccc06e249c7af42b10d410b6782172`
- Red on base: a mismatched `toolcall_end` sequence completed with `done` instead of producing an error
- Focused contract tests: 3 passed
- Full `packages/agent` suite: 646 passed, 0 failed, 2,593 assertions
- `packages/agent` Biome/typecheck: passed
- `git diff --check`: passed
- Candidate tree and merge-tree: `dbfda0f4a361309dda0a09fe30f5aae0d90e7dae`
- Current exact-base Dev CI: [30526241036](https://github.com/Yeachan-Heo/gajae-code/actions/runs/30526241036), terminal success
- Independent exact-head adversarial review: MERGE_READY

### Dogfood trace

- malformed start/end sequence -> terminal `error`; no later `done`
- valid start/delta/end sequence -> retained output, cleared `partialJson`, terminal `done`

## Overlap and integration

Open-PR file and symbol searches found no other PR touching the conversion branch or this regression contract. `git merge-tree` against current `dev` exactly reproduces the candidate tree.

## Rollback point

Revert commit `1121258b93ccc06e249c7af42b10d410b6782172` to restore the previous lenient malformed-event behavior. The change creates no persisted state, generated artifacts, migrations, or configuration that require cleanup.

## Known limits

Live remote proxy transport was not exercised; the event conversion and terminal-message behavior are covered locally through the production converter.
