### PR TITLE
fix(coding-agent): continue first-event timeout turns

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Canonical wrapped first-event timeouts now continue the same clean turn through bounded retries and configured fallback rotation, while preserving replay-safety, cancellation, provider-terminal policies, exact attempt diagnostics, and task/subagent retry-status truth (#3553).
+
 ## [0.12.4] - 2026-07-30
 
 ## [0.12.3] - 2026-07-30

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -869,6 +869,8 @@ type RetryErrorClassification =
 
 const BARE_DEFAULT_WATCHDOG_ERROR =
 	/^(?:[A-Za-z][A-Za-z0-9-]*(?: [A-Za-z][A-Za-z0-9-]*){0,3} )stream (?:timed out while waiting for the first event|stalled while waiting for the next event)$/;
+const WRAPPED_PROVIDER_FIRST_EVENT_TIMEOUT_ERROR = "Error: Provider stream timed out while waiting for the first event";
+const PROVIDER_FIRST_EVENT_TIMEOUT_WITHOUT_ARTICLE_ERROR = "Provider stream timed out while waiting for first event";
 const BARE_DEFAULT_CODEX_OVERLOAD_ERROR = /^Codex error event(?:: .*)? \(code=server_is_overloaded(?:, [^)]+)*\)$/;
 const KIMI_CODE_FIRST_EVENT_TIMEOUT_MESSAGES = {
 	"anthropic-messages": new Set([
@@ -904,6 +906,20 @@ function hasBareDefaultRetryDisqualifyingFacts(message: AssistantMessage): boole
 		facts.anthropicErrorType !== undefined ||
 		facts.openaiErrorCode !== undefined ||
 		(facts.headers !== undefined && Object.keys(facts.headers).length > 0)
+	);
+}
+function isMessageOnlyFirstEventTimeout(message: AssistantMessage): boolean {
+	if (hasBareDefaultRetryDisqualifyingFacts(message)) return false;
+	return (
+		message.errorMessage === WRAPPED_PROVIDER_FIRST_EVENT_TIMEOUT_ERROR ||
+		message.errorMessage === PROVIDER_FIRST_EVENT_TIMEOUT_WITHOUT_ARTICLE_ERROR
+	);
+}
+
+function isBareDefaultWrappedFirstEventTimeout(message: AssistantMessage): boolean {
+	return (
+		message.errorMessage === WRAPPED_PROVIDER_FIRST_EVENT_TIMEOUT_ERROR &&
+		!hasBareDefaultRetryDisqualifyingFacts(message)
 	);
 }
 function isBareDefaultCodexOverload(message: AssistantMessage): boolean {
@@ -14003,6 +14019,7 @@ export class AgentSession {
 		if (this.#isTerminalProviderFirstEventTimeout(message)) {
 			return "terminal";
 		}
+		if (isMessageOnlyFirstEventTimeout(message)) return "first_event_timeout";
 		// Legacy providers that have not yet stamped the typed timeout fact retain
 		// their existing bounded ollama-cloud behavior.
 		if (this.#isFirstEventTimeoutErrorMessage(err) && this.#shouldFailClosedOnFirstEventTimeout(message)) {
@@ -14378,17 +14395,20 @@ export class AgentSession {
 		// retry.enabled=false always surfaces immediately, matching the explicit
 		// user opt-out.
 		if (!managedFallback && !retrySettings.enabled) return false;
-		const classification = managedFallback ? undefined : this.#classifyErrorForRetry(message);
-		if (classification === "first_event_timeout") {
+		const classification = this.#classifyErrorForRetry(message);
+		const firstEventTimeout = classification === "first_event_timeout";
+		if (!managedFallback && firstEventTimeout) {
 			this.#firstEventTimeoutRetryStartedAt ??= Date.now();
 		}
 		// First-event timeouts are replay-safe only before any model progress,
 		// abort, or extension/provider lifecycle participation.
-		if (
-			classification === "first_event_timeout" &&
-			(!this.#hasCleanRetryReplaySafety || assistantMessageHasVisibleOrToolContent(message))
-		) {
-			return false;
+		if (firstEventTimeout && (!this.#hasCleanRetryReplaySafety || assistantMessageHasVisibleOrToolContent(message))) {
+			return managedOutcome
+				? {
+						type: "terminal",
+						terminal: { stopReason: "error", messages: [message] },
+					}
+				: false;
 		}
 		const trigger = this.#fallbackTriggerFor(message, !managedFallback, transportFailure);
 		if (!trigger) {
@@ -14415,12 +14435,14 @@ export class AgentSession {
 		// capacity-overload event.
 		if (!managedFallback && !legacyRetryConfigured && !canReplayRotatedCredential) {
 			const bareDefaultCodexOverload = isBareDefaultCodexOverload(message);
+			const bareDefaultWrappedFirstEventTimeout = isBareDefaultWrappedFirstEventTimeout(message);
 			// Content-free Codex overload is replay-safe by the same reasoning as
 			// credential rotation: no partial output means no observable state.
 			const canReplayCodexOverload = bareDefaultCodexOverload;
 			if (
 				(!canReplayCodexOverload &&
 					!this.#isTypedFirstEventTimeout(message) &&
+					!bareDefaultWrappedFirstEventTimeout &&
 					(hasBareDefaultRetryDisqualifyingFacts(message) ||
 						(classification !== "transient" && classification !== "first_event_timeout") ||
 						!BARE_DEFAULT_WATCHDOG_ERROR.test(message.errorMessage ?? ""))) ||
@@ -14429,7 +14451,7 @@ export class AgentSession {
 				return false;
 			}
 		}
-		const legacyUnbounded = classification === "transient";
+		const legacyUnbounded = !managedFallback && classification === "transient";
 		const attemptsUsed = managedFallback ? controller.attemptsUsed || 1 : this.#retryAttempt + 1;
 		const failedSelector = managedFallback ? controller.currentSelector() : undefined;
 		let outcome = managedFallback
@@ -14522,12 +14544,11 @@ export class AgentSession {
 			await this.#emitSessionEvent({
 				type: "auto_retry_start",
 				attempt: this.#retryAttempt,
-				maxAttempts:
-					classification === "first_event_timeout"
+				maxAttempts: managedFallback
+					? controller.maxAttempts
+					: firstEventTimeout
 						? retrySettings.maxRetries + 1
-						: managedFallback
-							? controller.maxAttempts
-							: retrySettings.maxRetries,
+						: retrySettings.maxRetries,
 				delayMs,
 				errorMessage,
 				unbounded: managedFallback ? false : legacyUnbounded,

--- a/packages/coding-agent/src/task/provider-retry-status.ts
+++ b/packages/coding-agent/src/task/provider-retry-status.ts
@@ -3,6 +3,7 @@ import type { AgentProgress, TaskToolDetails } from "./types";
 export type ProviderRetryKind = NonNullable<AgentProgress["retryState"]>["kind"];
 
 const FIRST_EVENT_TIMEOUT_PATTERN = /stream timed out while waiting for the first event/i;
+const FIRST_EVENT_TIMEOUT_WITHOUT_ARTICLE_MESSAGE = "Provider stream timed out while waiting for first event";
 const IDLE_STREAM_STALL_PATTERN = /stream stalled while waiting for the next event/i;
 const STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE = "stream_first_event_timeout";
 
@@ -22,7 +23,9 @@ export function classifyProviderRetryFromTransport(facts: {
 		return "first_event_timeout";
 	}
 	const errorMessage = facts.errorMessage ?? "";
-	if (FIRST_EVENT_TIMEOUT_PATTERN.test(errorMessage)) return "first_event_timeout";
+	if (FIRST_EVENT_TIMEOUT_PATTERN.test(errorMessage) || errorMessage === FIRST_EVENT_TIMEOUT_WITHOUT_ARTICLE_MESSAGE) {
+		return "first_event_timeout";
+	}
 	if (IDLE_STREAM_STALL_PATTERN.test(errorMessage)) return "idle_stream_stall";
 	return "provider_error";
 }

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -516,15 +516,15 @@ describe("AgentSession resilient retry", () => {
 		expect(lastAssistant(session).stopReason).toBe("stop");
 	});
 
-	it("does not retry when retry.enabled is false", async () => {
+	it("does not retry the canonical wrapped timeout when retry.enabled is false", async () => {
 		session = buildSession({
-			responses: [{ throw: "503 service unavailable: overloaded_error" }],
+			responses: [{ throw: "Error: Provider stream timed out while waiting for the first event" }],
 			settingsOverrides: { "retry.enabled": false },
 		});
 		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
 		const { retryStartEvents } = track(session);
 
-		await session.prompt("trigger transient with retry disabled");
+		await session.prompt("canonical timeout with retry disabled");
 		await session.waitForIdle();
 
 		expect(retryStartEvents).toHaveLength(0);
@@ -567,12 +567,13 @@ describe("AgentSession resilient retry", () => {
 		expect(lastAssistant(session).stopReason).toBe("stop");
 	});
 
-	it("abortRetry cancels the retry and surfaces the error", async () => {
+	it("abortRetry cancels a canonical first-event retry and surfaces cancellation", async () => {
+		const errorMessage = "Error: Provider stream timed out while waiting for the first event";
 		session = buildSession({
-			responses: [{ throw: "503 service unavailable: overloaded_error" }, { content: ["should not reach"] }],
+			responses: [{ throw: errorMessage }, { content: ["should not reach"] }],
 			settingsOverrides: { "retry.baseDelayMs": 600_000, "retry.maxDelayMs": 600_000 },
 		});
-		const { retryEndEvents } = track(session);
+		const { retryStartEvents, retryEndEvents } = track(session);
 		let resolveStarted!: () => void;
 		const started = new Promise<void>(r => {
 			resolveStarted = r;
@@ -598,6 +599,7 @@ describe("AgentSession resilient retry", () => {
 		expect(retryEndEvents).toHaveLength(1);
 		expect(retryEndEvents[0]).toMatchObject({ success: false });
 		expect(retryEndEvents[0].finalError).toContain("cancelled");
+		expect(retryStartEvents).toEqual([expect.objectContaining({ errorMessage, unbounded: false, maxAttempts: 2 })]);
 		// The errored assistant message was stripped in preparation for the retry,
 		// so cancellation simply returns to idle (the error remains in session history).
 		expect(session.isRetrying).toBe(false);
@@ -1206,26 +1208,73 @@ describe("AgentSession resilient retry", () => {
 		expect(progressModels).toHaveLength(1);
 		expect(lastAssistant(session).stopReason).toBe("error");
 	});
-	it("retries a bare-default watchdog with an empty extension runner", async () => {
+	it("recovers the canonical wrapped first-event timeout in the same bare-default turn", async () => {
+		const errorMessage = "Error: Provider stream timed out while waiting for the first event";
 		const requestedModels: string[] = [];
 		session = buildBareRetrySession({
-			responses: [
-				{ throw: "Example Provider Watchdog stream timed out while waiting for the first event" },
-				{ content: ["recovered"] },
-			],
+			responses: [{ throw: errorMessage }, { content: ["recovered"] }],
 			requestedModels,
 			extensionRunner: createExtensionRunner(),
 		});
 		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
 		const { retryStartEvents, retryEndEvents } = track(session);
+		const maxAttempts = session.settings.getGroup("retry").maxRetries + 1;
 
-		await session.prompt("bare-config empty extension watchdog");
+		await session.prompt("bare-config canonical wrapped timeout");
 		await session.waitForIdle();
 
-		expect(retryStartEvents).toHaveLength(1);
 		expect(requestedModels).toHaveLength(2);
-		expect(retryEndEvents).toEqual([expect.objectContaining({ success: true })]);
-		expect(lastAssistant(session).stopReason).toBe("stop");
+		expect(retryStartEvents).toEqual([
+			expect.objectContaining({ attempt: 1, maxAttempts, errorMessage, unbounded: false }),
+		]);
+		expect(retryEndEvents).toEqual([expect.objectContaining({ success: true, attempt: 1 })]);
+		expect(lastAssistant(session)).toMatchObject({
+			stopReason: "stop",
+			content: [{ type: "text", text: "recovered" }],
+		});
+	});
+
+	it("bounds canonical wrapped first-event timeout exhaustion with exact diagnostics", async () => {
+		const errorMessage = "Error: Provider stream timed out while waiting for the first event";
+		const requestedModels: string[] = [];
+		session = buildStatusErrorSession({
+			errorMessage,
+			requestedModels,
+			settingsOverrides: { "retry.maxRetries": 2 },
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents } = track(session);
+
+		await session.prompt("exhaust canonical wrapped timeout");
+		await session.waitForIdle();
+
+		expect(requestedModels).toHaveLength(3);
+		expect(retryStartEvents).toHaveLength(2);
+		expect(retryStartEvents.every(event => event.maxAttempts === 3 && event.unbounded === false)).toBe(true);
+		expect(lastAssistant(session).errorMessage).toMatch(
+			/^First-event stream timeout exhausted after 3 attempts; waited \d+ms total: Error: Provider stream timed out while waiting for the first event$/,
+		);
+	});
+
+	it("bounds the exact no-the first-event compatibility message under explicit retry policy", async () => {
+		const errorMessage = "Provider stream timed out while waiting for first event";
+		const requestedModels: string[] = [];
+		session = buildStatusErrorSession({
+			errorMessage,
+			requestedModels,
+			settingsOverrides: { "retry.maxRetries": 1 },
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents } = track(session);
+
+		await session.prompt("exact no-the first-event timeout");
+		await session.waitForIdle();
+
+		expect(requestedModels).toHaveLength(2);
+		expect(retryStartEvents).toEqual([
+			expect.objectContaining({ attempt: 1, maxAttempts: 2, errorMessage, unbounded: false }),
+		]);
+		expect(lastAssistant(session).errorMessage).toContain("exhausted after 2 attempts");
 	});
 	it("does not replay a bare-default watchdog after a reasoning summary start hook participates", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
@@ -1240,7 +1289,7 @@ describe("AgentSession resilient retry", () => {
 						model,
 						[],
 						"error",
-						"Example Provider Watchdog stream stalled while waiting for the next event",
+						"Error: Provider stream timed out while waiting for the first event",
 					);
 					stream.push({ type: "start", partial: failure });
 					stream.push({ type: "reasoning_summary_start", contentIndex: 0, partial: failure });
@@ -1277,7 +1326,7 @@ describe("AgentSession resilient retry", () => {
 		const requestedModels: string[] = [];
 		session = buildBareRetrySession({
 			responses: [
-				{ throw: "Example Provider Watchdog stream timed out while waiting for the first event" },
+				{ throw: "Error: Provider stream timed out while waiting for the first event" },
 				{ content: ["should-not-reach"] },
 			],
 			requestedModels,
@@ -1312,7 +1361,7 @@ describe("AgentSession resilient retry", () => {
 			session = buildBareRetrySession({
 				responses: [
 					{
-						throw: "Example Provider Watchdog stream timed out while waiting for the first event",
+						throw: "Error: Provider stream timed out while waiting for the first event",
 						...(eventType === "after_provider_response" ? { responseHeaders: { "x-request-id": "test" } } : {}),
 					},
 					{ content: ["should-not-reach"] },
@@ -1351,8 +1400,8 @@ describe("AgentSession resilient retry", () => {
 		const requestedModels: string[] = [];
 		session = buildBareRetrySession({
 			responses: [
-				{ throw: "Example Provider Watchdog stream timed out while waiting for the first event" },
-				{ throw: "Example Provider Watchdog stream timed out while waiting for the first event" },
+				{ throw: "Error: Provider stream timed out while waiting for the first event" },
+				{ throw: "Error: Provider stream timed out while waiting for the first event" },
 				{ content: ["should-not-reach"] },
 			],
 			requestedModels,
@@ -1413,7 +1462,7 @@ describe("AgentSession resilient retry", () => {
 							model,
 							[],
 							"error",
-							"Example Provider Watchdog stream timed out while waiting for the first event",
+							"Error: Provider stream timed out while waiting for the first event",
 						);
 						if (!partialOutput) empty.transportFailure = { kind: "transport", status: 503 };
 						stream.push({ type: "start", partial: empty });
@@ -1422,7 +1471,7 @@ describe("AgentSession resilient retry", () => {
 								model,
 								[{ type: "text", text: "already visible" }],
 								"error",
-								"Example Provider Watchdog stream timed out while waiting for the first event",
+								"Error: Provider stream timed out while waiting for the first event",
 							);
 							stream.push({ type: "text_start", contentIndex: 0, partial: empty });
 							stream.push({ type: "text_delta", contentIndex: 0, delta: "already ", partial: visible });
@@ -1489,7 +1538,7 @@ describe("AgentSession resilient retry", () => {
 						model,
 						[],
 						"error",
-						"Example Provider Watchdog stream timed out while waiting for the first event",
+						"Error: Provider stream timed out while waiting for the first event",
 					);
 					stream.push({ type: "start", partial: failure });
 					stream.push({ type: "error", reason: "error", error: failure });
@@ -1543,7 +1592,7 @@ describe("AgentSession resilient retry", () => {
 							model,
 							[],
 							"error",
-							"Example Provider Watchdog stream timed out while waiting for the first event",
+							"Error: Provider stream timed out while waiting for the first event",
 						);
 						stream.push({ type: "start", partial: failure });
 						stream.push({ type: "error", reason: "error", error: failure });
@@ -1583,8 +1632,9 @@ describe("AgentSession resilient retry", () => {
 	it("fails closed on non-canonical watchdog prose under bare defaults", async () => {
 		const nearMisses = [
 			"stream timed out while waiting for the first event",
-			"Error: Provider stream timed out while waiting for the first event",
+			"Provider stream timed out while waiting for first event",
 			"Provider stream timed out while waiting for the first event.",
+			"TypeError: Provider stream timed out while waiting for the first event",
 			"Provider stream timeout waiting for first event",
 		];
 		for (const errorMessage of nearMisses) {

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -112,6 +112,37 @@ function typedUsageLimitStream(model: Model, retryAfterMs = 60_000): AssistantMe
 	});
 	return stream;
 }
+function canonicalFirstEventTimeoutStream(
+	model: Model,
+	content: AssistantMessage["content"] = [],
+	transportFailure?: AssistantMessage["transportFailure"],
+): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+	queueMicrotask(() => {
+		const message: AssistantMessage = {
+			role: "assistant",
+			content,
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "error",
+			errorMessage: "Error: Provider stream timed out while waiting for the first event",
+			...(transportFailure === undefined ? {} : { transportFailure }),
+			timestamp: Date.now(),
+		};
+		stream.push({ type: "start", partial: message });
+		stream.push({ type: "error", reason: "error", error: message });
+	});
+	return stream;
+}
 
 function makeExtensionRunner(handlers: string[], cwd: string, sm: SessionManager, mr: ModelRegistry): ExtensionRunner {
 	const handlerMap = new Map<string, Array<() => Promise<void>>>();
@@ -702,6 +733,259 @@ describe("AgentSession retry fallback", () => {
 		expect(calls).toBe(6);
 		expect(new Set(requestedKeys).size).toBe(6);
 		expect(getLastAssistantMessage(session)).toMatchObject({ stopReason: "stop" });
+	});
+	it("recovers a clean canonical timeout through bounded managed fallback", async () => {
+		const primary = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallback = getBundledModel("openai", "gpt-4o-mini");
+		if (!primary || !fallback) throw new Error("Expected bundled test models");
+		const requestedModels: string[] = [];
+		let primaryCalls = 0;
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model: primary, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (requestedModel, context, options) => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				if (requestedModel.provider === primary.provider) {
+					primaryCalls++;
+					return canonicalFirstEventTimeoutStream(requestedModel);
+				}
+				return createMockModel({ responses: [{ content: ["Fallback recovered"] }] }).stream(
+					requestedModel,
+					context,
+					options,
+				);
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"fallback.maxAttempts": 2,
+			"retry.maxRetries": 9,
+			"retry.baseDelayMs": 1,
+		});
+		settings.setModelRole("default", `${primary.provider}/${primary.id}`);
+		session = new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
+		session.setConfiguredModelChain(
+			"default",
+			[`${primary.provider}/${primary.id}`, `${fallback.provider}/${fallback.id}`],
+			"test",
+		);
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents, retryEndEvents } = trackRetryEvents(session);
+		const switches: Extract<AgentSessionEvent, { type: "model_fallback_switched" }>[] = [];
+		session.subscribe(event => {
+			if (event.type === "model_fallback_switched") switches.push(event);
+		});
+
+		await session.prompt("recover canonical timeout through fallback");
+		await session.waitForIdle();
+
+		expect(primaryCalls).toBe(2);
+		expect(requestedModels).toEqual([
+			`${primary.provider}/${primary.id}`,
+			`${primary.provider}/${primary.id}`,
+			`${fallback.provider}/${fallback.id}`,
+		]);
+		expect(retryStartEvents).toHaveLength(2);
+		expect(retryStartEvents.every(event => event.maxAttempts === 2 && event.unbounded === false)).toBe(true);
+		expect(retryEndEvents).toEqual([expect.objectContaining({ success: true })]);
+		expect(switches).toEqual([
+			expect.objectContaining({
+				from: `${primary.provider}/${primary.id}`,
+				to: `${fallback.provider}/${fallback.id}`,
+				reason: "server",
+				attemptsUsed: 2,
+			}),
+		]);
+		expect(getLastAssistantMessage(session)).toMatchObject({ stopReason: "stop" });
+	});
+
+	it("bounds all-provider canonical timeout exhaustion", async () => {
+		const primary = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallback = getBundledModel("openai", "gpt-4o-mini");
+		if (!primary || !fallback) throw new Error("Expected bundled test models");
+		const requestedModels: string[] = [];
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model: primary, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: requestedModel => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				return canonicalFirstEventTimeoutStream(requestedModel);
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"fallback.maxAttempts": 1,
+			"retry.maxRetries": 9,
+			"retry.baseDelayMs": 1,
+		});
+		settings.setModelRole("default", `${primary.provider}/${primary.id}`);
+		session = new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
+		session.setConfiguredModelChain(
+			"default",
+			[`${primary.provider}/${primary.id}`, `${fallback.provider}/${fallback.id}`],
+			"test",
+		);
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents, retryEndEvents } = trackRetryEvents(session);
+		const fallbackNotices: Extract<AgentSessionEvent, { type: "notice" }>[] = [];
+		session.subscribe(event => {
+			if (event.type === "notice" && event.source === "fallback") fallbackNotices.push(event);
+		});
+
+		await session.prompt("exhaust canonical timeout fallback chain");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([`${primary.provider}/${primary.id}`, `${fallback.provider}/${fallback.id}`]);
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryStartEvents[0]).toMatchObject({ maxAttempts: 1, unbounded: false });
+		expect(retryEndEvents).toEqual([expect.objectContaining({ success: false })]);
+		expect(fallbackNotices).toEqual([
+			expect.objectContaining({
+				level: "error",
+				message: expect.stringContaining("Model fallback chain exhausted"),
+			}),
+		]);
+		expect(fallbackNotices[0]?.message).toContain(`${primary.provider}/${primary.id}`);
+		expect(fallbackNotices[0]?.message).toContain(`${fallback.provider}/${fallback.id}`);
+		expect(getLastAssistantMessage(session).errorMessage).toBe(
+			"Error: Provider stream timed out while waiting for the first event",
+		);
+	});
+
+	it("does not rotate a managed canonical timeout after partial output", async () => {
+		const primary = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallback = getBundledModel("openai", "gpt-4o-mini");
+		if (!primary || !fallback) throw new Error("Expected bundled test models");
+		const requestedModels: string[] = [];
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model: primary, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: requestedModel => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				return canonicalFirstEventTimeoutStream(requestedModel, [{ type: "text", text: "already visible" }]);
+			},
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "fallback.maxAttempts": 1 });
+		settings.setModelRole("default", `${primary.provider}/${primary.id}`);
+		session = new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
+		session.setConfiguredModelChain(
+			"default",
+			[`${primary.provider}/${primary.id}`, `${fallback.provider}/${fallback.id}`],
+			"test",
+		);
+		const { retryStartEvents } = trackRetryEvents(session);
+		const switches: Extract<AgentSessionEvent, { type: "model_fallback_switched" }>[] = [];
+		session.subscribe(event => {
+			if (event.type === "model_fallback_switched") switches.push(event);
+		});
+
+		await session.prompt("do not rotate after partial timeout output");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([`${primary.provider}/${primary.id}`]);
+		expect(retryStartEvents).toHaveLength(0);
+		expect(switches).toHaveLength(0);
+		expect(getLastAssistantMessage(session)).toMatchObject({
+			stopReason: "error",
+			content: [{ type: "text", text: "already visible" }],
+			errorMessage: "Error: Provider stream timed out while waiting for the first event",
+		});
+	});
+
+	it("returns a valid managed terminal decision for a typed timeout with tool content", async () => {
+		const primary = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallback = getBundledModel("openai", "gpt-4o-mini");
+		if (!primary || !fallback) throw new Error("Expected bundled test models");
+		const requestedModels: string[] = [];
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model: primary, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: requestedModel => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				return canonicalFirstEventTimeoutStream(
+					requestedModel,
+					[{ type: "toolCall", id: "unsafe-tool", name: "unsafe", arguments: {} }],
+					{ kind: "transport", providerCode: "stream_first_event_timeout" },
+				);
+			},
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "fallback.maxAttempts": 1 });
+		settings.setModelRole("default", `${primary.provider}/${primary.id}`);
+		session = new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
+		session.setConfiguredModelChain(
+			"default",
+			[`${primary.provider}/${primary.id}`, `${fallback.provider}/${fallback.id}`],
+			"test",
+		);
+		const { retryStartEvents } = trackRetryEvents(session);
+		const switches: Extract<AgentSessionEvent, { type: "model_fallback_switched" }>[] = [];
+		session.subscribe(event => {
+			if (event.type === "model_fallback_switched") switches.push(event);
+		});
+
+		await session.prompt("do not rotate typed timeout with tool content");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([`${primary.provider}/${primary.id}`]);
+		expect(retryStartEvents).toHaveLength(0);
+		expect(switches).toHaveLength(0);
+		expect(getLastAssistantMessage(session)).toMatchObject({
+			stopReason: "error",
+			content: [{ type: "toolCall", id: "unsafe-tool", name: "unsafe", arguments: {} }],
+			errorMessage: "Error: Provider stream timed out while waiting for the first event",
+			transportFailure: { kind: "transport", providerCode: "stream_first_event_timeout" },
+		});
+	});
+
+	it("does not rotate a typed managed timeout when a provider lifecycle handler is registered", async () => {
+		const primary = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallback = getBundledModel("openai", "gpt-4o-mini");
+		if (!primary || !fallback) throw new Error("Expected bundled test models");
+		const requestedModels: string[] = [];
+		const sessionManager = SessionManager.inMemory();
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model: primary, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: requestedModel => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				return canonicalFirstEventTimeoutStream(requestedModel, [], {
+					kind: "transport",
+					providerCode: "stream_first_event_timeout",
+				});
+			},
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "fallback.maxAttempts": 1 });
+		settings.setModelRole("default", `${primary.provider}/${primary.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			extensionRunner: makeExtensionRunner(["context"], tempDir.path(), sessionManager, modelRegistry),
+		});
+		session.setConfiguredModelChain(
+			"default",
+			[`${primary.provider}/${primary.id}`, `${fallback.provider}/${fallback.id}`],
+			"test",
+		);
+		const { retryStartEvents } = trackRetryEvents(session);
+		const switches: Extract<AgentSessionEvent, { type: "model_fallback_switched" }>[] = [];
+		session.subscribe(event => {
+			if (event.type === "model_fallback_switched") switches.push(event);
+		});
+
+		await session.prompt("do not rotate typed timeout with a registered lifecycle handler");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([`${primary.provider}/${primary.id}`]);
+		expect(retryStartEvents).toHaveLength(0);
+		expect(switches).toHaveLength(0);
+		expect(getLastAssistantMessage(session)).toMatchObject({
+			stopReason: "error",
+			content: [],
+			errorMessage: "Error: Provider stream timed out while waiting for the first event",
+			transportFailure: { kind: "transport", providerCode: "stream_first_event_timeout" },
+		});
 	});
 
 	it("does not replay a Kimi Code first-event timeout through a managed fallback chain", async () => {

--- a/packages/coding-agent/test/task/provider-retry-status.test.ts
+++ b/packages/coding-agent/test/task/provider-retry-status.test.ts
@@ -2,10 +2,27 @@ import { describe, expect, it } from "bun:test";
 import { classifyProviderRetry, classifyProviderRetryFromTransport } from "../../src/task/provider-retry-status";
 
 describe("classifyProviderRetry", () => {
-	it("classifies first-event timeouts from message prose", () => {
-		expect(classifyProviderRetry("Provider stream timed out while waiting for the first event")).toBe(
+	it("classifies canonical first-event timeout prose", () => {
+		for (const message of [
+			"Provider stream timed out while waiting for the first event",
+			"Anthropic stream timed out while waiting for the first event",
+			"Error: Provider stream timed out while waiting for the first event",
+		]) {
+			expect(classifyProviderRetry(message)).toBe("first_event_timeout");
+		}
+	});
+
+	it("classifies only the exact no-the first-event compatibility message", () => {
+		expect(classifyProviderRetry("Provider stream timed out while waiting for first event")).toBe(
 			"first_event_timeout",
 		);
+		for (const message of [
+			"Error: Provider stream timed out while waiting for first event",
+			"Provider stream timed out while waiting for first event.",
+			"Provider stream timeout waiting for first event",
+		]) {
+			expect(classifyProviderRetry(message)).toBe("provider_error");
+		}
 	});
 
 	it("classifies idle stalls from message prose", () => {
@@ -37,10 +54,24 @@ describe("classifyProviderRetryFromTransport", () => {
 		).toBe("first_event_timeout");
 	});
 
-	it("falls back to message regex when providerCode is absent", () => {
+	it("keeps typed first-event authority over incompatible prose", () => {
+		expect(
+			classifyProviderRetryFromTransport({
+				providerCode: "stream_first_event_timeout",
+				errorMessage: "Provider stream timed out while waiting for first event.",
+			}),
+		).toBe("first_event_timeout");
+	});
+
+	it("falls back to message classification when providerCode is absent", () => {
 		expect(
 			classifyProviderRetryFromTransport({
 				errorMessage: "Provider stream timed out while waiting for the first event",
+			}),
+		).toBe("first_event_timeout");
+		expect(
+			classifyProviderRetryFromTransport({
+				errorMessage: "Provider stream timed out while waiting for first event",
 			}),
 		).toBe("first_event_timeout");
 		expect(
@@ -51,7 +82,7 @@ describe("classifyProviderRetryFromTransport", () => {
 		expect(classifyProviderRetryFromTransport({ errorMessage: "boom" })).toBe("provider_error");
 	});
 
-	it("falls back to message regex when providerCode is not the first-event fact", () => {
+	it("falls back to message classification when providerCode is not the first-event fact", () => {
 		expect(
 			classifyProviderRetryFromTransport({
 				providerCode: "rate_limit_error",


### PR DESCRIPTION
## Summary

- classify the exact wrapped runtime timeout as bounded `first_event_timeout` and resume the same clean turn under bare defaults
- apply first-event replay safety at direct and managed fallback boundaries without moving controller accounting or provider-terminal policy
- preserve typed transport authority and legacy canonical status matching while adding exact no-`the` status compatibility
- add deterministic recovery, exhaustion, cancellation, replay-safety, configured fallback, provider-terminal, and status regressions

## Verification

- `bun test` affected retry/fallback matrix: 171 passed, 0 failed, 889 assertions across 13 files
- `bun run check` in `packages/coding-agent`: Biome clean and TypeScript check passed
- `bun run build` in `packages/coding-agent`: binary build passed
- Ultragoal architect: CLEAR/CLEAR/CLEAR, APPROVE
- Ultragoal executor QA/red-team: 80 passed, 0 failed, 483 assertions
- terminal critic: OKAY

Closes #3553

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*