### PR TITLE
fix(skills): preserve exact-name discovery matches

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Canonical wrapped first-event timeouts now continue the same clean turn through bounded retries and configured fallback rotation, while preserving replay-safety, cancellation, provider-terminal policies, exact attempt diagnostics, and task/subagent retry-status truth (#3553).
+- Runtime skill discovery now preserves a candidate when its exact skill name appears as a query token, so additional task-specific terms no longer discard an explicitly named skill.
 
 ## [0.12.4] - 2026-07-30
 

--- a/packages/coding-agent/src/extensibility/runtime-skill-discovery.ts
+++ b/packages/coding-agent/src/extensibility/runtime-skill-discovery.ts
@@ -132,15 +132,13 @@ function isAllowedByPolicy(
 	return true;
 }
 function matchesQuery(candidate: RuntimeSkillDiscoveryCandidate, query: string): boolean {
-	const normalized = query.trim().toLowerCase();
-	if (!normalized) return true;
+	const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+	if (terms.length === 0) return true;
+	if (terms.includes(candidate.name.toLowerCase())) return true;
 	const haystack = [candidate.name, candidate.description, candidate.source, ...(candidate.useWhen ?? [])]
 		.join("\n")
 		.toLowerCase();
-	return normalized
-		.split(/\s+/)
-		.filter(Boolean)
-		.every(term => haystack.includes(term));
+	return terms.every(term => haystack.includes(term));
 }
 
 async function realPathOrSelf(filePath: string): Promise<string> {

--- a/packages/coding-agent/test/tools/skill-discovery.test.ts
+++ b/packages/coding-agent/test/tools/skill-discovery.test.ts
@@ -78,6 +78,28 @@ describe("SkillDiscoveryTool", () => {
 		expect(details!.candidates[0]?.useWhen).toContain("**/*.ts");
 	});
 
+	it("preserves exact skill-name tokens without broadening unnamed partial matches", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-exact-name-skill-"));
+		await makeSkill(path.join(cwd, ".gjc", "skills"), "aws", "Cloud operations router");
+		await makeSkill(path.join(cwd, ".gjc", "skills"), "harbor", "Container registry router");
+		const tool = new SkillDiscoveryTool(createSession(cwd, { settings: runtimeSkillSettings() }));
+
+		const exact = await tool.execute("call", { query: "aws" });
+		expect(exact.details?.candidates.map(candidate => candidate.name)).toEqual(["aws"]);
+
+		const exactWithExtraTerms = await tool.execute("call", { query: "AWS ec2 cloudwatch production health" });
+		expect(exactWithExtraTerms.details?.candidates.map(candidate => candidate.name)).toEqual(["aws"]);
+
+		const existingAllTermMatch = await tool.execute("call", { query: "cloud operations" });
+		expect(existingAllTermMatch.details?.candidates.map(candidate => candidate.name)).toEqual(["aws"]);
+
+		const partialWithoutExactName = await tool.execute("call", { query: "cloud production health" });
+		expect(partialWithoutExactName.details?.candidates).toEqual([]);
+
+		const unrelated = await tool.execute("call", { query: "database latency" });
+		expect(unrelated.details?.candidates).toEqual([]);
+	});
+
 	it("discovers user runtime skills from ~/.gjc/skills", async () => {
 		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-user-skills-cwd-"));
 		const home = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-user-skills-home-"));


### PR DESCRIPTION
## Summary

- preserve a runtime skill candidate when its exact normalized name appears as a query token
- retain the existing all-term metadata predicate for queries that do not explicitly name a skill
- retain the verified exact-name and no-fuzzy-regression matrix from #3558 on current `dev`

## Successor to #3558

#3558 received code-level approval but was closed because its submitted head did not contain current `dev`.

This successor is rebuilt directly on current `dev`:

```
PR parent: ffd3260e17dde0cc77f35176221fe201845b5a1e
upstream/dev: ffd3260e17dde0cc77f35176221fe201845b5a1e
```

The production change and regression matrix are unchanged from the approved patch.

## Problem

`skill_discovery` currently requires every query term to occur in a candidate's name, description, source, or use conditions. This can discard the intended skill even after the model selects the correct discovery surface and names that skill explicitly.

A local end-to-end trace produced this query for a runtime skill named `humanizer`:

```
humanizer 자연스러운 한국어 문장 교정
```

The current all-term predicate discarded `humanizer` because the additional Korean task terms were absent from its English metadata, so the installed skill was not loaded.

## Matching boundary

Previously:

```
oldMatch = every query term occurs in candidate metadata
```

Now:

```
newMatch = exact skill-name token present || oldMatch
```

Every previous match therefore remains a match. A candidate becomes newly eligible only when its complete lower-cased name is a standalone whitespace-delimited query token. Queries without an exact name keep the existing behavior.

This does not add semantic search, cause the model to invoke `skill_discovery`, expose a startup skill catalog, or change policy gates, source precedence, deduplication, ordering, limits, MCP activation, or lazy `SKILL.md` loading.

## Verification on the successor head

- `13 pass, 0 fail, 56 expect() calls` — `skill-discovery.test.ts`
- `88 pass, 0 fail, 248 expect() calls` across:
  - `tools/skill.test.ts`
  - `sdk-skills.test.ts`
  - `tools/index.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `git diff --check upstream/dev...HEAD`
- exact parent/current-dev check: `0 0`

The change preserves the existing runtime-skill policy boundaries; it only narrows a false-negative inside candidate query matching.