### PR TITLE
fix(computer): stop latched key sequences

### DIFF
--- a/crates/pi-natives/src/computer/executor.rs
+++ b/crates/pi-natives/src/computer/executor.rs
@@ -15,7 +15,7 @@
 
 use super::{
 	coords::{CoordError, NormalizedDisplay},
-	input::{EventSink, InputController, InputError, MouseButton},
+	input::{EventSink, InputController, InputError, KeypressOutcome, MouseButton},
 	supervisor::Supervisor,
 };
 
@@ -202,16 +202,27 @@ where
 {
 	gate(action, supervisor, perms, display_ctx, expected_epoch)?;
 	if cancelled() {
-		return Err(ExecError::Cancelled);
+		return Err(if supervisor.is_suspended() {
+			ExecError::Suspended
+		} else {
+			ExecError::Cancelled
+		});
 	}
 
-	let result = dispatch(action, display, controller, cancelled);
+	let action_cancelled = || cancelled() || supervisor.is_suspended();
+	let result = dispatch(action, display, controller, &action_cancelled);
+	let suspended = supervisor.is_suspended();
 
 	// release_all on any failure, or if the kill-switch latched mid-action.
-	if result.is_err() || supervisor.is_suspended() {
+	if result.is_err() || suspended {
 		controller.release_all();
 	}
-	result
+
+	match result {
+		Ok(()) if suspended => Err(ExecError::Suspended),
+		Err(ExecError::Cancelled) if suspended => Err(ExecError::Suspended),
+		other => other,
+	}
 }
 
 fn dispatch<S: EventSink>(
@@ -238,7 +249,10 @@ fn dispatch<S: EventSink>(
 			controller.type_text(text);
 			Ok(())
 		},
-		InputAction::Keypress { keys } => controller.keypress(keys).map_err(Into::into),
+		InputAction::Keypress { keys } => match controller.keypress_abortable(keys, cancelled)? {
+			KeypressOutcome::Completed => Ok(()),
+			KeypressOutcome::Cancelled => Err(ExecError::Cancelled),
+		},
 		InputAction::Wait { ms } => wait_abortable(*ms, cancelled),
 	}
 }
@@ -258,6 +272,8 @@ fn wait_abortable(ms: u64, cancelled: &dyn Fn() -> bool) -> Result<(), ExecError
 
 #[cfg(test)]
 mod tests {
+	use std::cell::Cell;
+
 	use super::{DisplayContext, ExecError, InputAction, PermissionGate, execute_input};
 	use crate::computer::{
 		coords::{LogicalPoint, NormalizedDisplay},
@@ -306,6 +322,36 @@ mod tests {
 
 		fn key(&mut self, code: u16, down: bool) {
 			self.ops.push(SinkOp::Key { code, down });
+		}
+	}
+
+	struct LatchingSink<'a> {
+		latch: &'a dyn Fn(),
+		ops:   Vec<SinkOp>,
+	}
+
+	impl EventSink for LatchingSink<'_> {
+		fn move_cursor(&mut self, to: LogicalPoint) {
+			self.ops.push(SinkOp::Move(to));
+		}
+
+		fn mouse_button(&mut self, at: LogicalPoint, button: MouseButton, down: bool) {
+			self.ops.push(SinkOp::Button { at, button, down });
+		}
+
+		fn scroll(&mut self, dx: f64, dy: f64) {
+			self.ops.push(SinkOp::Scroll { dx, dy });
+		}
+
+		fn type_unicode(&mut self, text: &str) {
+			self.ops.push(SinkOp::TypeUnicode(text.to_string()));
+		}
+
+		fn key(&mut self, code: u16, down: bool) {
+			self.ops.push(SinkOp::Key { code, down });
+			if down {
+				(self.latch)();
+			}
 		}
 	}
 
@@ -439,10 +485,89 @@ mod tests {
 		assert!(res.is_ok());
 		assert_eq!(ops, vec![SinkOp::TypeUnicode("hi".to_string())]);
 
-		let (res2, ops2) =
-			run(&InputAction::Keypress { keys: vec!["enter".to_string()] }, &sup, true, None, 0);
+		let (res2, ops2) = run(
+			&InputAction::Keypress { keys: vec!["enter".to_string(), "tab".to_string()] },
+			&sup,
+			true,
+			None,
+			0,
+		);
 		assert!(res2.is_ok());
-		assert_eq!(ops2.len(), 2); // key down + up
+		assert_eq!(ops2, vec![
+			SinkOp::Key { code: 36, down: true },
+			SinkOp::Key { code: 36, down: false },
+			SinkOp::Key { code: 48, down: true },
+			SinkOp::Key { code: 48, down: false },
+		]);
+	}
+
+	#[test]
+	fn suspension_during_keypress_releases_current_key_and_stops_before_next() {
+		let sup = live_supervisor();
+		let latch = || sup.trigger_stop();
+		let mut controller = InputController::new(LatchingSink { latch: &latch, ops: Vec::new() });
+		let result = execute_input(
+			&InputAction::Keypress { keys: vec!["enter".to_string(), "tab".to_string()] },
+			&sup,
+			&FakePerms { granted: true },
+			&FakeDisplay { epoch: 0 },
+			None,
+			&display(),
+			&mut controller,
+			&never_cancel(),
+		);
+
+		assert_eq!(result, Err(ExecError::Suspended));
+		assert_eq!(controller.into_sink().ops, vec![
+			SinkOp::Key { code: 36, down: true },
+			SinkOp::Key { code: 36, down: false },
+		]);
+	}
+
+	#[test]
+	fn suspension_during_initial_cancellation_probe_takes_precedence() {
+		let sup = live_supervisor();
+		let mut controller = InputController::new(RecordingSink::default());
+		let result = execute_input(
+			&InputAction::Keypress { keys: vec!["enter".to_string(), "tab".to_string()] },
+			&sup,
+			&FakePerms { granted: true },
+			&FakeDisplay { epoch: 0 },
+			None,
+			&display(),
+			&mut controller,
+			&|| {
+				sup.trigger_stop();
+				true
+			},
+		);
+
+		assert_eq!(result, Err(ExecError::Suspended));
+		assert!(controller.into_sink().ops.is_empty());
+	}
+
+	#[test]
+	fn cancellation_during_keypress_releases_current_key_and_stops_before_next() {
+		let sup = live_supervisor();
+		let cancelled = Cell::new(false);
+		let latch = || cancelled.set(true);
+		let mut controller = InputController::new(LatchingSink { latch: &latch, ops: Vec::new() });
+		let result = execute_input(
+			&InputAction::Keypress { keys: vec!["enter".to_string(), "tab".to_string()] },
+			&sup,
+			&FakePerms { granted: true },
+			&FakeDisplay { epoch: 0 },
+			None,
+			&display(),
+			&mut controller,
+			&|| cancelled.get(),
+		);
+
+		assert_eq!(result, Err(ExecError::Cancelled));
+		assert_eq!(controller.into_sink().ops, vec![
+			SinkOp::Key { code: 36, down: true },
+			SinkOp::Key { code: 36, down: false },
+		]);
 	}
 
 	#[test]

--- a/crates/pi-natives/src/computer/input.rs
+++ b/crates/pi-natives/src/computer/input.rs
@@ -67,6 +67,11 @@ pub enum InputError {
 	UnknownKey(String),
 }
 
+pub(super) enum KeypressOutcome {
+	Completed,
+	Cancelled,
+}
+
 impl From<CoordError> for InputError {
 	fn from(value: CoordError) -> Self {
 		Self::Coord(value)
@@ -261,12 +266,33 @@ impl<S: EventSink> InputController<S> {
 	/// Returns [`InputError::UnknownKey`] when a name is unrecognized; keys
 	/// before the failure have already been sent.
 	pub fn keypress(&mut self, keys: &[String]) -> Result<(), InputError> {
+		self.keypress_abortable(keys, &|| false).map(|_| ())
+	}
+
+	/// Press and release each named key in order, polling `cancelled` before
+	/// every key-down and after its matching key-up. A cancellation observed
+	/// after key-down still allows the matching key-up, then stops the action.
+	///
+	/// # Errors
+	/// Returns [`InputError::UnknownKey`] when a name is unrecognized. Keys
+	/// before the failure have already been sent.
+	pub(super) fn keypress_abortable(
+		&mut self,
+		keys: &[String],
+		cancelled: &dyn Fn() -> bool,
+	) -> Result<KeypressOutcome, InputError> {
 		for name in keys {
+			if cancelled() {
+				return Ok(KeypressOutcome::Cancelled);
+			}
 			let code = key_code_for(name).ok_or_else(|| InputError::UnknownKey(name.clone()))?;
 			self.sink.key(code, true);
 			self.sink.key(code, false);
+			if cancelled() {
+				return Ok(KeypressOutcome::Cancelled);
+			}
 		}
-		Ok(())
+		Ok(KeypressOutcome::Completed)
 	}
 
 	/// Release every held mouse button (idempotent). Run on abort/error paths

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Native computer keypress sequences now stop before the next key when suspension or cancellation latches, while still releasing any key already admitted; suspension keeps precedence across the pre-dispatch race.
+
 ## [0.12.4] - 2026-07-30
 
 ## [0.12.3] - 2026-07-30


### PR DESCRIPTION
## Finding

A multi-key computer action observed cancellation only around the whole dispatch. If suspension or cancellation latched after one key was admitted, later keys in the same action could still be emitted before the executor noticed the stop state.

## Root cause and enforcement boundary

The low-level keypress loop had no abort-aware result boundary. The fix polls the existing stop predicate between keys while keeping each admitted key-down paired with its matching key-up. The executor preserves suspension precedence, including the race between the initial gate and dispatch.

## Scope

- add abort-aware keypress sequencing without changing the public `keypress` API
- release an admitted key before stopping the remaining sequence
- distinguish cancellation from supervisor suspension at the executor boundary
- preserve normal key ordering and unknown-key errors
- document the native behavior fix under Unreleased/Fixed

No new dependency, platform-specific policy, workflow change, or unrelated native refactor is included.

## Verification

- Candidate parent: `ffd3260e17dde0cc77f35176221fe201845b5a1e`
- Head SHA: `b5ec670d0091ff641aca62b2aefa8d0eff1fa1fc`
- Exact parent Dev CI: [30530686205](https://github.com/Yeachan-Heo/gajae-code/actions/runs/30530686205) — terminal success
- Red on parent: mid-sequence stop regressions emitted later keys; the pre-dispatch race returned cancellation instead of suspension
- Full pre-rebase `pi-natives` suite: 149 passed, 5 environment-dependent live tests ignored
- Fresh focused computer suite on the current base: 44 passed, 5 live tests ignored
- `cargo fmt --check`: passed
- `cargo check -p pi-natives`: passed
- Library clippy with warnings denied: passed
- `git diff --check`: passed
- Independent exact-head adversarial review: MERGE_READY

### Dogfood trace

- `enter, tab` with suspension latched on first key-down -> `enter down`, `enter up`, terminal `COMPUTER_SUSPENDED`
- same sequence with ordinary cancellation -> `enter down`, `enter up`, terminal `COMPUTER_CANCELLED`
- no stop -> ordered `enter` pair followed by ordered `tab` pair

## Overlap and integration

All 14 open PRs were checked. None touches the computer executor/input boundary; #3483 shares only the native changelog for an unrelated shell note on different lines. A temporary integration tree combining this change with the retry-body fix and the owner ACP baseline-repair head passed both candidates' focused tests and package/Rust checks. Two unrelated process tests flaked only in the parallel full Rust run and each passed immediately when rerun alone.

## Rollback point

Revert commit `b5ec670d0091ff641aca62b2aefa8d0eff1fa1fc`. This restores whole-action polling; no persisted state, generated data, migration, setting, or runtime flag remains after the revert.

## Known limits

Live macOS `CGEvent` injection was not exercised because it moves real input and requires Accessibility grants. The same production sequencing boundary was exercised through the platform-neutral recording sink.
