### PR TITLE
fix(utils): release discarded retry response bodies

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Retryable responses discarded before another fetch attempt now begin body cancellation without blocking retry progress on transport cleanup, releasing buffered response data without consuming responses returned to callers.
+
 ## [0.12.4] - 2026-07-30
 
 ## [0.12.3] - 2026-07-30

--- a/packages/utils/src/fetch-retry.ts
+++ b/packages/utils/src/fetch-retry.ts
@@ -153,6 +153,7 @@ export async function fetchWithRetry(
 		if (hint !== undefined && hint > maxDelayMs) return response;
 
 		const delayMs = Math.min(hint ?? resolveDefaultDelay(defaultDelayMs, attempt, maxDelayMs), maxDelayMs);
+		void response.body?.cancel().catch(() => undefined);
 		await scheduler.wait(delayMs, { signal });
 	}
 }

--- a/packages/utils/test/fetch-retry.test.ts
+++ b/packages/utils/test/fetch-retry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, vi } from "bun:test";
 import { fetchWithRetry } from "../src/fetch-retry";
 
 describe("fetchWithRetry", () => {
@@ -39,5 +39,144 @@ describe("fetchWithRetry", () => {
 		expect(response.status).toBe(200);
 		expect(await response.text()).toBe("done");
 		expect(attempt).toBe(2);
+	});
+
+	it("cancels response bodies that are discarded before a retry", async () => {
+		const payload = new Uint8Array(1024 * 1024);
+		const discardedResponse = new Response(
+			new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.enqueue(payload);
+					controller.close();
+				},
+			}),
+			{ status: 503 },
+		);
+		let attempt = 0;
+
+		const response = await fetchWithRetry("https://example.invalid/discarded-body", {
+			fetch: async () => {
+				attempt += 1;
+				return attempt === 1 ? discardedResponse : new Response("done", { status: 200 });
+			},
+			defaultDelayMs: 0,
+			maxAttempts: 2,
+		});
+
+		expect(response.status).toBe(200);
+		expect(discardedResponse.bodyUsed).toBe(true);
+		await expect(discardedResponse.arrayBuffer()).rejects.toThrow();
+	});
+
+	it("continues retrying when discarded-body cancellation never settles", async () => {
+		const discardedResponse = new Response("retry", { status: 503 });
+		const cancellation = Promise.withResolvers<void>();
+		const cancelSpy = vi.spyOn(discardedResponse.body!, "cancel").mockImplementation(() => cancellation.promise);
+		let attempt = 0;
+
+		const request = fetchWithRetry("https://example.invalid/pending-cancel", {
+			fetch: async () => {
+				attempt += 1;
+				return attempt === 1 ? discardedResponse : new Response("done", { status: 200 });
+			},
+			defaultDelayMs: 0,
+			maxAttempts: 2,
+		});
+
+		const outcome = await Promise.race([
+			request.then(() => "completed" as const),
+			Bun.sleep(100).then(() => "timed-out" as const),
+		]);
+		cancellation.resolve();
+
+		expect(outcome).toBe("completed");
+		expect(cancelSpy).toHaveBeenCalledTimes(1);
+		expect(attempt).toBe(2);
+	});
+
+	it("continues retrying when discarded-body cancellation rejects", async () => {
+		const discardedResponse = new Response("retry", { status: 503 });
+		const cancelSpy = vi
+			.spyOn(discardedResponse.body!, "cancel")
+			.mockRejectedValue(new Error("transport refused cancellation"));
+		let attempt = 0;
+
+		const response = await fetchWithRetry("https://example.invalid/rejected-cancel", {
+			fetch: async () => {
+				attempt += 1;
+				return attempt === 1 ? discardedResponse : new Response("done", { status: 200 });
+			},
+			defaultDelayMs: 0,
+			maxAttempts: 2,
+		});
+
+		expect(response.status).toBe(200);
+		expect(cancelSpy).toHaveBeenCalledTimes(1);
+		expect(attempt).toBe(2);
+	});
+
+	it("observes external aborts while discarded-body cancellation remains pending", async () => {
+		const controller = new AbortController();
+		const discardedResponse = new Response("retry", { status: 503 });
+		const cancellation = Promise.withResolvers<void>();
+		const cleanupStarted = Promise.withResolvers<void>();
+		const cancelSpy = vi.spyOn(discardedResponse.body!, "cancel").mockImplementation(() => {
+			cleanupStarted.resolve();
+			return cancellation.promise;
+		});
+		let attempt = 0;
+
+		const request = fetchWithRetry("https://example.invalid/abort-during-cancel", {
+			fetch: async () => {
+				attempt += 1;
+				return discardedResponse;
+			},
+			defaultDelayMs: 0,
+			maxAttempts: 2,
+			signal: controller.signal,
+		});
+
+		await cleanupStarted.promise;
+		controller.abort();
+		const outcome = await Promise.race([
+			request.then(
+				() => ({ status: "resolved" as const }),
+				error => ({ status: "rejected" as const, error }),
+			),
+			Bun.sleep(100).then(() => ({ status: "timed-out" as const })),
+		]);
+		cancellation.resolve();
+		await request.catch(() => undefined);
+
+		expect(outcome).toMatchObject({ status: "rejected", error: { name: "AbortError" } });
+		expect(cancelSpy).toHaveBeenCalledTimes(1);
+		expect(attempt).toBe(1);
+	});
+
+	it("does not consume an exhausted retryable response body", async () => {
+		const finalResponse = new Response("retry later", { status: 503 });
+
+		const response = await fetchWithRetry("https://example.invalid/final-body", {
+			fetch: async () => finalResponse,
+			maxAttempts: 1,
+		});
+
+		expect(response).toBe(finalResponse);
+		expect(response.bodyUsed).toBe(false);
+		expect(await response.text()).toBe("retry later");
+	});
+
+	it("does not consume a retryable response returned for a hint above the delay cap", async () => {
+		const finalResponse = new Response("Please retry in 2s", { status: 429 });
+
+		const response = await fetchWithRetry("https://example.invalid/capped-hint", {
+			fetch: async () => finalResponse,
+			maxAttempts: 2,
+			maxDelayMs: 1,
+		});
+
+		expect(response).toBe(finalResponse);
+		expect(response.bodyUsed).toBe(false);
+		expect(await response.text()).toBe("Please retry in 2s");
 	});
 });


### PR DESCRIPTION
## Finding

Retry-hint inspection clones a response body. When a retryable response is then abandoned for another attempt, leaving the original body branch open can retain buffered response data for the lifetime of the retry operation.

## Root cause and enforcement boundary

The retry loop did not start cleanup for responses it had definitively decided not to return. Cleanup now begins only after the final-attempt and hint-over-cap return paths are excluded. It is deliberately not awaited because custom transports control the cancellation promise and must not be able to stall retry or abort progress.

## Scope

- begin cancellation for retryable response bodies discarded before another attempt
- keep exhausted and hint-over-cap responses untouched for their caller
- preserve retry progress when cancellation is pending or rejects
- preserve external abort progress during pending cleanup
- document the behavior under `packages/utils` Unreleased/Fixed

The production change is one line; the rest is focused observable-contract coverage and changelog text.

## Verification

- Candidate parent: `ffd3260e17dde0cc77f35176221fe201845b5a1e`
- Head SHA: `ea1b2982e42416af8a01842cc61de7f865ee82ac`
- Exact parent Dev CI: [30530686205](https://github.com/Yeachan-Heo/gajae-code/actions/runs/30530686205) — terminal success
- Red on parent: the discarded response remained unconsumed/readable after the next attempt, proving its tee branch was retained
- Focused retry suite: 8 passed, 0 failed
- Pending/rejecting cancellation stress review: 800 repeated focused runs passed
- `packages/utils` Biome/typecheck: passed
- `git diff --check`: passed
- Independent exact-head adversarial review: MERGE_READY

### Dogfood trace

- first attempt `503`, cleanup promise never settles -> second attempt still returns `200`
- cleanup rejects -> second attempt still returns `200` without an unhandled rejection
- external abort while cleanup remains pending -> request settles with `AbortError` before cleanup is released
- exhausted `503` and over-cap `429` -> exact response remains unconsumed and readable

## Overlap and integration

All 14 open PRs were checked by title and changed file; none touches `fetch-retry.ts`, its regression test, or the utils changelog. This candidate intentionally remains ordered ahead of the separate delay-normalization candidate because both touch the same retry loop/test/changelog. A temporary integration tree combining this change with the computer stop fix and the owner ACP baseline-repair head passed both candidates' focused tests and package/Rust checks.

## Rollback point

Revert commit `ea1b2982e42416af8a01842cc61de7f865ee82ac`. That stops initiating cancellation for discarded retry responses and restores prior buffering behavior. There is no persisted state, generated artifact, configuration, or migration to clean up.

## Known limits

Live network socket reuse and transport-specific cancellation behavior were not exercised; production `Response` bodies and controlled pending/rejecting cancellation promises cover the API boundary locally.
