### PR TITLE
fix(coding-agent): preserve terminal timeout providers

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -873,16 +873,17 @@ type RetryErrorClassification =
 
 const BARE_DEFAULT_WATCHDOG_ERROR =
 	/^(?:[A-Za-z][A-Za-z0-9-]*(?: [A-Za-z][A-Za-z0-9-]*){0,3} )stream (?:timed out while waiting for the first event|stalled while waiting for the next event)$/;
-const WRAPPED_PROVIDER_FIRST_EVENT_TIMEOUT_ERROR = "Error: Provider stream timed out while waiting for the first event";
+const PROVIDER_FIRST_EVENT_TIMEOUT_ERROR = "Provider stream timed out while waiting for the first event";
+const WRAPPED_PROVIDER_FIRST_EVENT_TIMEOUT_ERROR = `Error: ${PROVIDER_FIRST_EVENT_TIMEOUT_ERROR}`;
 const PROVIDER_FIRST_EVENT_TIMEOUT_WITHOUT_ARTICLE_ERROR = "Provider stream timed out while waiting for first event";
 const BARE_DEFAULT_CODEX_OVERLOAD_ERROR = /^Codex error event(?:: .*)? \(code=server_is_overloaded(?:, [^)]+)*\)$/;
 const KIMI_CODE_FIRST_EVENT_TIMEOUT_MESSAGES = {
 	"anthropic-messages": new Set([
-		"Provider stream timed out while waiting for the first event",
+		PROVIDER_FIRST_EVENT_TIMEOUT_ERROR,
 		"Anthropic stream timed out while waiting for the first event",
 	]),
 	"openai-completions": new Set([
-		"Provider stream timed out while waiting for the first event",
+		PROVIDER_FIRST_EVENT_TIMEOUT_ERROR,
 		"OpenAI completions stream timed out while waiting for the first event",
 	]),
 } as const;
@@ -890,11 +891,11 @@ const KIMI_CODE_FIRST_EVENT_TIMEOUT_MESSAGES = {
 const ALIBABA_TOKEN_PLAN_PROVIDER = "alibaba-token-plan";
 const ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MESSAGES = {
 	"openai-responses": new Set([
-		"Provider stream timed out while waiting for the first event",
+		PROVIDER_FIRST_EVENT_TIMEOUT_ERROR,
 		"OpenAI responses stream timed out while waiting for the first event",
 	]),
 	"openai-completions": new Set([
-		"Provider stream timed out while waiting for the first event",
+		PROVIDER_FIRST_EVENT_TIMEOUT_ERROR,
 		"OpenAI completions stream timed out while waiting for the first event",
 	]),
 } as const;
@@ -911,6 +912,11 @@ function hasBareDefaultRetryDisqualifyingFacts(message: AssistantMessage): boole
 		facts.openaiErrorCode !== undefined ||
 		(facts.headers !== undefined && Object.keys(facts.headers).length > 0)
 	);
+}
+function terminalProviderFirstEventTimeoutIdentity(errorMessage: string): string {
+	return errorMessage === WRAPPED_PROVIDER_FIRST_EVENT_TIMEOUT_ERROR
+		? PROVIDER_FIRST_EVENT_TIMEOUT_ERROR
+		: errorMessage;
 }
 function isMessageOnlyFirstEventTimeout(message: AssistantMessage): boolean {
 	if (hasBareDefaultRetryDisqualifyingFacts(message)) return false;
@@ -14017,7 +14023,7 @@ export class AgentSession {
 
 	#isKimiCodeFirstEventTimeout(message: AssistantMessage): boolean {
 		if (message.stopReason !== "error" || message.provider !== "kimi-code") return false;
-		const errorMessage = message.errorMessage ?? "";
+		const errorMessage = terminalProviderFirstEventTimeoutIdentity(message.errorMessage ?? "");
 		if (message.api === "anthropic-messages") {
 			return KIMI_CODE_FIRST_EVENT_TIMEOUT_MESSAGES["anthropic-messages"].has(errorMessage);
 		}
@@ -14044,7 +14050,8 @@ export class AgentSession {
 	#isAlibabaTokenPlanFirstEventTimeout(message: AssistantMessage): boolean {
 		if (message.stopReason !== "error" || message.provider !== ALIBABA_TOKEN_PLAN_PROVIDER) return false;
 		const timeoutMessages = this.#alibabaTokenPlanTimeoutMessagesForApi(message.api);
-		return timeoutMessages?.has(message.errorMessage ?? "") ?? false;
+		const errorMessage = terminalProviderFirstEventTimeoutIdentity(message.errorMessage ?? "");
+		return timeoutMessages?.has(errorMessage) ?? false;
 	}
 
 	#isAlibabaTokenPlanCompactionTimeout(candidate: Model, errorMessage: string): boolean {

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -779,6 +779,12 @@ describe("AgentSession resilient retry", () => {
 			},
 			{
 				model: responsesModel,
+				errorMessage: "Error: Provider stream timed out while waiting for the first event",
+				settingsOverrides: { "retry.maxRetries": 10 },
+				bareDefault: false,
+			},
+			{
+				model: responsesModel,
 				errorMessage: "OpenAI responses stream timed out while waiting for the first event",
 				settingsOverrides: { "retry.maxRetries": 10 },
 				bareDefault: false,
@@ -786,6 +792,12 @@ describe("AgentSession resilient retry", () => {
 			{
 				model: completionsModel,
 				errorMessage: "Provider stream timed out while waiting for the first event",
+				settingsOverrides: undefined,
+				bareDefault: true,
+			},
+			{
+				model: completionsModel,
+				errorMessage: "Error: Provider stream timed out while waiting for the first event",
 				settingsOverrides: undefined,
 				bareDefault: true,
 			},
@@ -968,25 +980,37 @@ describe("AgentSession resilient retry", () => {
 		expect(last.errorMessage).toContain("first event");
 		expect(waitSpy).toHaveBeenCalled();
 	});
-	it("surfaces a Kimi Code first-event timeout after its continuous wait without replaying the request", async () => {
+	it("surfaces raw and wrapped Kimi Code first-event timeouts without replaying", async () => {
 		const model = getBundledModel("kimi-code", "kimi-k2.5");
 		if (!model) throw new Error("Expected bundled Kimi Code test model to exist");
-		const requestedModels: string[] = [];
-		session = buildStatusErrorSession({
-			model,
-			errorMessage: "Provider stream timed out while waiting for the first event",
-			requestedModels,
-		});
-		const { retryStartEvents, retryEndEvents } = track(session);
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		for (const errorMessage of [
+			"Provider stream timed out while waiting for the first event",
+			"Error: Provider stream timed out while waiting for the first event",
+		]) {
+			const requestedModels: string[] = [];
+			session = buildStatusErrorSession({
+				model,
+				errorMessage,
+				requestedModels,
+				settingsOverrides: { "retry.maxRetries": 10 },
+			});
+			const { retryStartEvents, retryEndEvents } = track(session);
 
-		await session.prompt("slow Kimi request");
-		await session.waitForIdle();
+			await session.prompt("slow Kimi request");
+			await session.waitForIdle();
 
-		expect(retryStartEvents).toHaveLength(0);
-		expect(retryEndEvents).toHaveLength(0);
-		expect(requestedModels).toHaveLength(1);
-		expect(lastAssistant(session).stopReason).toBe("error");
-		expect(lastAssistant(session).errorMessage).toContain("first event");
+			expect(retryStartEvents).toHaveLength(0);
+			expect(retryEndEvents).toHaveLength(0);
+			expect(requestedModels).toEqual([`${model.provider}/${model.id}`]);
+			expect(waitSpy).not.toHaveBeenCalled();
+			expect(lastAssistant(session)).toMatchObject({ stopReason: "error", errorMessage });
+			expect(session.isRetrying).toBe(false);
+			expect(session.isStreaming).toBe(false);
+			await session.dispose();
+			session = undefined;
+			waitSpy.mockClear();
+		}
 	});
 
 	it("keeps first-party first-event timeout retries unbounded (#713 scope guard)", async () => {

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -988,6 +988,69 @@ describe("AgentSession retry fallback", () => {
 		});
 	});
 
+	it("keeps wrapped terminal-provider timeouts out of managed fallback", async () => {
+		const kimi = getBundledModel("kimi-code", "kimi-k2.5");
+		const alibabaResponses = getBundledModel("alibaba-token-plan", "qwen3.8-max-preview");
+		const alibabaCompletions = getBundledModel("alibaba-token-plan", "deepseek-v4-pro");
+		const fallback = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!kimi || !alibabaResponses || !alibabaCompletions || !fallback) {
+			throw new Error("Expected bundled terminal-provider and fallback models");
+		}
+		authStorage.setRuntimeApiKey("kimi-code", "kimi-test-key");
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		for (const model of [kimi, alibabaResponses, alibabaCompletions]) {
+			const requestedModels: string[] = [];
+			const agent = new Agent({
+				getApiKey: provider => `${provider}-test-key`,
+				initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+				streamFn: requestedModel => {
+					requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+					return canonicalFirstEventTimeoutStream(
+						requestedModel,
+						[],
+						requestedModel.provider === "alibaba-token-plan" ? { kind: "transport", status: 503 } : undefined,
+					);
+				},
+			});
+			const settings = Settings.isolated({
+				"compaction.enabled": false,
+				"fallback.maxAttempts": 2,
+				"retry.baseDelayMs": 1,
+			});
+			settings.setModelRole("default", `${model.provider}/${model.id}`);
+			session = new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
+			session.setConfiguredModelChain(
+				"default",
+				[`${model.provider}/${model.id}`, `${fallback.provider}/${fallback.id}`],
+				"test",
+			);
+			const { retryStartEvents, retryEndEvents } = trackRetryEvents(session);
+			const switches: Extract<AgentSessionEvent, { type: "model_fallback_switched" }>[] = [];
+			session.subscribe(event => {
+				if (event.type === "model_fallback_switched") switches.push(event);
+			});
+
+			await session.prompt("do not replay wrapped terminal-provider timeout");
+			await session.waitForIdle();
+
+			expect(requestedModels).toEqual([`${model.provider}/${model.id}`]);
+			expect(retryStartEvents).toHaveLength(0);
+			expect(retryEndEvents).toHaveLength(0);
+			expect(switches).toHaveLength(0);
+			expect(waitSpy).not.toHaveBeenCalled();
+			expect(session.model).toMatchObject({ provider: model.provider, id: model.id });
+			expect(getLastAssistantMessage(session)).toMatchObject({
+				provider: model.provider,
+				api: model.api,
+				stopReason: "error",
+				errorMessage: "Error: Provider stream timed out while waiting for the first event",
+			});
+			await session.dispose();
+			session = undefined;
+			waitSpy.mockClear();
+		}
+	});
+
 	it("does not replay a Kimi Code first-event timeout through a managed fallback chain", async () => {
 		const primary = getBundledModel("kimi-code", "kimi-k2.5");
 		const fallback = getBundledModel("anthropic", "claude-sonnet-4-5");
@@ -1270,7 +1333,7 @@ describe("AgentSession retry fallback", () => {
 							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 						},
 						stopReason: "error",
-						errorMessage: "Provider stream timed out while waiting for the first event",
+						errorMessage: "Error: Provider stream timed out while waiting for the first event",
 						timestamp: Date.now(),
 					};
 					stream.push({ type: "start", partial: failure });
@@ -1299,7 +1362,7 @@ describe("AgentSession retry fallback", () => {
 		expect(getLastAssistantMessage(session)).toMatchObject({
 			provider: fallback.provider,
 			stopReason: "error",
-			errorMessage: "Provider stream timed out while waiting for the first event",
+			errorMessage: "Error: Provider stream timed out while waiting for the first event",
 		});
 
 		await session.prompt("Keep the sticky fallback on the next turn");


### PR DESCRIPTION
## Summary

Correct the P1 found by the completed independent contrarian review after #3573 merged:

- treat only the exact admitted `Error: Provider stream timed out while waiting for the first event` wrapper as equivalent to the existing raw generic terminal tuple inside valid Kimi Code and Alibaba Token Plan direct/managed predicates
- preserve the original diagnostic text and leave no-`the`, provider-specific wrappers, punctuation, cross-API, arbitrary prefixes, compaction matching, controller accounting, and sticky fallback behavior unchanged
- cover raw/wrapped Kimi, both Alibaba APIs, managed terminal providers as primary, and wrapped Alibaba in fallback position

## Verification

- affected retry/fallback matrix: 172 passed, 0 failed, 935 assertions across 13 files
- focused terminal-provider QA: 107 passed, 0 failed, 647 assertions across 5 files
- coding-agent package check: passed
- coding-agent binary build: passed
- generation-3 architect: CLEAR/APPROVE
- generation-3 terminal critic: OKAY

Corrective continuation of #3573 for #3553.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*