### PR TITLE
fix(ci): give the docs-only plan the native producer its gate needs

### DIFF
--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -950,8 +950,10 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		expect(stderr).toContain("not in the current plan");
 	});
 
+	// CHANGELOG.md, not a docs/ path: docs/**/*.md selects the embedded-docs gate,
+	// which is a native consumer and therefore now carries a native producer.
 	test("--native-build is a no-op when the plan has no native build task", async () => {
-		const { stdout, exitCode } = await runScript(["--native-build"], "docs/readme.md");
+		const { stdout, exitCode } = await runScript(["--native-build"], "CHANGELOG.md");
 		expect(exitCode).toBe(0);
 		expect(stdout).toContain("no native build tasks in plan");
 	});
@@ -1256,13 +1258,28 @@ test("tab-worker graph changes always include install-methods and are Darwin rel
 	// docs/ is the source the embedded docs index is generated from, so shipping a
 	// docs edit without regenerating that index is the one drift class a docs-only
 	// change can introduce. Both planners must select that gate, because dev CI runs
-	// on push as well as pull_request.
-	test("docs-only changes select the embedded-docs gate and nothing else", () => {
+	// on push as well as pull_request. The gate reads the generated corpus through the
+	// package barrel, so it is a native consumer: it has to bring its own producer, or
+	// the shard's `if: matrix.native` download step asks for an artifact that the
+	// skipped `affected-native` job never uploaded.
+	test("docs-only changes select the embedded-docs gate and its native producer", () => {
 		const changed = ["docs/guide.md", "docs/nested/other.md"];
 		for (const keys of [targeted(changed), planTasks(changed, packages)].map(tasks =>
 			tasks.map(task => task.key),
 		)) {
-			expect(keys).toEqual([EMBEDDED_DOCS_GATE_KEY]);
+			expect(keys).toEqual([EMBEDDED_DOCS_GATE_KEY, "native-linux-x64"]);
+		}
+	});
+
+	// The producer invariant stated as the matrix sees it: any plan with a native
+	// consumer must also carry a native producer, or has_native gates it off.
+	test("a docs-only plan never ships a native consumer without a producer", () => {
+		for (const changed of [["docs/guide.md"], ["docs/tools/read.md", "docs/guide.md"]]) {
+			for (const tasks of [targeted(changed), planTasks(changed, packages)]) {
+				const entries = describeTasks(tasks);
+				expect(entries.some(entry => entry.native)).toBe(true);
+				expect(entries.some(entry => entry.nativeBuild)).toBe(true);
+			}
 		}
 	});
 

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -701,8 +701,11 @@ export function planTasks(paths: readonly string[], packages: readonly Workspace
 	const tasks = new Map<string, Task>();
 	// Mirror of the docs-index gate in planTargetedTasks: docs/ is the source the
 	// embedded index is generated from, so either side changing must run its gate.
+	// The gate loads the generated corpus through the package barrel, so it is a
+	// native consumer and must bring its own producer.
 	if (paths.some(isEmbeddedDocsSourcePath)) {
 		addTestFileTask(tasks, EMBEDDED_DOCS_GATE_TEST);
+		addNativeBuild(tasks);
 	}
 	const touchedPackages = findTouchedPackages(paths, packages);
 	const rootPackageReleaseHarnessOnly = isRootPackageReleaseHarnessOnly(paths);
@@ -811,6 +814,9 @@ export function planTargetedTasks(paths: readonly string[], packages: readonly W
 		addTestFileTask(tasks, EMBEDDED_DOCS_GATE_TEST);
 	}
 	if (relevant.length === 0) {
+		// The shared ensureNativeBuild escalation is past this return, and the gate is
+		// a native consumer, so apply it here or the shard ships with no producer.
+		ensureNativeBuild(tasks);
 		return [...tasks.values()];
 	}
 


### PR DESCRIPTION
## Follow-up to #3559: its docs-only plan ships a native consumer with no producer

Reporting and fixing a defect in my own merged PR. #3559 is correct in what it gates; the bug is in the CI plan it produces for the one change class it was written for.

### The defect

#3559 made a docs-only dev PR select exactly one shard:

```
$ CI_DEV_CHANGED_PATHS=docs/guide.md bun scripts/ci-dev-affected.ts --matrix-json
[{"key":"test:packages/coding-agent/test/docs-index-lazy.test.ts","native":true,"nativeBuild":false,...}]
```

`native: true` because `taskNeedsNative` ends with `key.startsWith("test:")` (`scripts/ci-dev-affected.ts:351`). `nativeBuild: false` because nothing added a producer. That combination is the bug:

| step | wiring | result on a docs-only plan |
| --- | --- | --- |
| `emitMatrix` | `has_native = entries.some(e => e.nativeBuild)` (`:484`) | `false` |
| `affected-native` | `if: needs.affected-plan.outputs.has_native == 'true'` (`dev-ci.yml:358`) | **skipped** → `dev-affected-native-${run_id}` never uploaded |
| shard "Download native addon(s)" | `if: ${{ matrix.native }}` (`dev-ci.yml:610`) | **fires**, against an artifact that does not exist |

So the shard either fails on the download or runs the gate with no addon. `docs-index-lazy.test.ts` genuinely needs it — two of its four tests spawn `bun` and import the package barrel, which loads the native addon. Those are exactly the two failures I disclosed in #3559's body as local-only.

### Why the escalation didn't catch it

The repo already has the invariant — `ensureNativeBuild` adds `native-linux-x64` when any planned task reports as a native consumer. It just isn't reachable on this path:

- `planTargetedTasks` calls it at `:928`, **after** the docs-only early return at `:816`.
- `planTasks` has no such tail at all.

#3559 introduced the first PR-mode plan that returns before that escalation.

### Why #3559's own CI was green

It edits `packages/coding-agent/test/docs-index-lazy.test.ts` and `scripts/`, so its plan was never docs-only. 22 success / 6 skipped / 0 failure was real — it just never exercised the path it added. That is the same blind spot as the `prepare`-masking finding: the gate's own CI run does not exercise the class it gates.

### The fix

Six lines, at both seams:

```ts
// planTasks
if (paths.some(isEmbeddedDocsSourcePath)) {
    addTestFileTask(tasks, EMBEDDED_DOCS_GATE_TEST);
    addNativeBuild(tasks);
}

// planTargetedTasks
if (relevant.length === 0) {
    ensureNativeBuild(tasks);   // shared escalation is past this return
    return [...tasks.values()];
}
```

Measured before/after on the same input:

| | `has_native` for `docs/guide.md` |
| --- | --- |
| dev (`4fbf5d1ba`) | `false` |
| this branch | `true` |

Consumer/producer pairing across both planners:

| changed paths | PR mode | push mode |
| --- | --- | --- |
| `docs/guide.md` | consumer+producer | consumer+producer |
| `docs/a/b/deep.md` | consumer+producer | consumer+producer |
| `docs-index.generated.ts` | consumer+producer | consumer+producer |
| both | consumer+producer | consumer+producer |
| `CHANGELOG.md` | neither | neither |

### Tests

The merged assertion was pinning the defect:

```ts
expect(keys).toEqual([EMBEDDED_DOCS_GATE_KEY]);           // before — no producer
expect(keys).toEqual([EMBEDDED_DOCS_GATE_KEY, "native-linux-x64"]);   // after
```

Plus a new contract test stating the invariant the way the matrix consumes it, so a future early return cannot silently reintroduce this:

```ts
test("a docs-only plan never ships a native consumer without a producer", () => {
    const entries = describeTasks(tasks);
    expect(entries.some(e => e.native)).toBe(true);
    expect(entries.some(e => e.nativeBuild)).toBe(true);
});
```

The `--native-build is a no-op when the plan has no native build task` fixture moves off `docs/readme.md` — which now legitimately has a producer — onto `CHANGELOG.md`, which has none. The assertion is unchanged.

### Verification

| check | result |
| --- | --- |
| `bun test scripts/ci-dev-affected.test.ts` | 85 pass / 0 fail |
| `bun test scripts/dev-ci-guard-topology.test.ts` | 5 pass / 0 fail |
| `bun test packages/coding-agent/test/docs-index-lazy.test.ts -t "commits an index"` | 1 pass / 0 fail |
| `tsc -p tsconfig.tools.json --noEmit` | clean |
| `biome check` (repo's own `check:tools` form) | clean |
| measured `has_native` flip | `false` → `true` |

Base is `4fbf5d1ba`, 0 behind dev. 2 files, +27/-4, no `src/` change.

### Cost

One extra `native-linux-x64` job on docs-only PRs. That job restores from cache when no native source changed, so it is a cache hit rather than a rebuild. Without it the shard has no addon, which is worse than the job's cost.
