### PR TITLE
fix(coding-agent): keep agent_end publication non-blocking

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
+- Deferred `agent_end` publication again settles public session readiness before slow extension handlers finish, while retaining exact cancellation leases through queued extension delivery and draining that delivery before session shutdown.
 - Ultragoal validation-batch hydration now fails closed unless deferred and final-close evidence exactly matches a complete authoritative cumulative Git/CI inventory and durable batch tuple. Explicit malformed, partial, unknown, reordered, or stale receipt data is rejected; Git path capture is byte-safe, NUL-delimited, and includes untracked files; incomplete capture conservatively requires computer-control QA; shared settings and tool registries cannot use partial diffs to bypass that suite; validate/checkpoint replacement hydration is identical; and current/replacement receipts are byte-bound to ledger payloads (#3541).
 - Fixture quality gates that complete intermediate Ultragoal stories now write file-backed adversarial artifact proof; skill-state hooks and computer red-team fixtures match the unconditional adversarial path check so #3543 CI stays fail-closed without weakening hydration exactness (#3543).
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2493,6 +2493,14 @@ export class AgentSession {
 		pending: AgentSessionEvent,
 		lease: RunResourceProducerLease | undefined,
 	): Promise<void> {
+		let extensionDelivery: Promise<void> | undefined;
+		const releaseLease = () => {
+			if (!lease) return;
+			if (this.#postPromptLeases.get(lease.resourceRunId) === lease) {
+				this.#postPromptLeases.delete(lease.resourceRunId);
+			}
+			lease.closeDiscovery();
+		};
 		const publish = async () => {
 			// Worker integration is first-party lifecycle persistence, not an extension
 			// hook. Make it durable before publishing the terminal boundary while user
@@ -2501,18 +2509,16 @@ export class AgentSession {
 			// Persist before notifying synchronous subscribers: a subscriber may start a
 			// successor prompt from agent_end, whose running state must serialize after
 			// this terminal boundary rather than be overwritten by it.
-			await this.#persistRuntimeStateInBackground(pending);
+			void this.#persistRuntimeStateInBackground(pending);
 			this.#emit(pending);
-			await this.#queueExtensionEvent(pending, undefined, true);
+			extensionDelivery = this.#queueExtensionEvent(pending, undefined, true);
 		};
 		try {
 			if (lease) await this.#runResourceLeaseContext.run(lease, publish);
 			else await publish();
 		} finally {
-			if (lease && this.#postPromptLeases.get(lease.resourceRunId) === lease) {
-				this.#postPromptLeases.delete(lease.resourceRunId);
-			}
-			lease?.closeDiscovery();
+			if (extensionDelivery) void extensionDelivery.then(releaseLease, releaseLease);
+			else releaseLease();
 			this.#agentEndPublicationInFlight = Math.max(0, this.#agentEndPublicationInFlight - 1);
 			this.#resolveSessionSettlement();
 		}


### PR DESCRIPTION
## Summary

- settle deferred public `agent_end` without waiting for user extension latency;
- retain the exact cancellation producer lease until the queued extension delivery settles;
- keep `dispose()` draining the authoritative extension queue before `session_shutdown`.

## Root cause

The exact terminal-ownership merge in #3565 made deferred `agent_end` publication await both background runtime-state persistence and the user extension queue. A slow extension handler therefore kept public session settlement busy and made teardown wait on the publication path itself. It also delayed the established terminal event timing enough to break the extension forwarding contract.

This repair restores the established non-blocking publication order. It does not return to the old immediate lease close: the exact producer lease now closes only when queued extension delivery fulfills or rejects, preserving the cancellation-domain lifetime added by #3565.

## Dogfood trace

- Last exact green before the regression: dev `ffd3260e17dde0cc77f35176221fe201845b5a1e`, Dev CI `30530686205`; the message-pipeline contracts passed.
- First exact red head: `4fbf5d1ba57ea66311dfdce62b010ae797d24905`, Dev CI `30532274182`; one `agent_end` forwarding assertion and two extension-delivery teardown tests failed.
- Second exact red head: `3047452af4cf43a809f3c20126b721429a1dcf8c`, Dev CI `30533508366`; the same three failures reproduced.
- Current base: `3eff6b89e2a59aa73f248ff9208d6d51c6b3b5d2`, Dev CI `30535807651` terminal success. Its affected-path plan did not rerun the regressed coding-agent shard, so it does not supersede the two exact reproductions.
- Repair head: 181/181 focused coding-agent and agent tests passed with 852 assertions. The three regressed contracts, abort/lease ownership, maintenance, retry, ACP/SDK terminal handling, and resource-ledger settlement are covered.
- Independent exact-head adversarial review: `MERGE_READY`, no P0/P1/P2 findings.

## Verification

- `bun test` across the nine focused coding-agent/agent files: 181 passed, 0 failed, 852 assertions;
- coding-agent Biome: 2,488 files checked;
- coding-agent TypeScript no-emit check;
- `git diff --check`;
- merge-tree equals the exact head tree.

## Scope and immutable refs

- Base: `3eff6b89e2a59aa73f248ff9208d6d51c6b3b5d2`
- Head: `df9cd69d382abf2c9e751e08c068d42bb09234c3`
- Tree: `212246608f0156b464578ebc1bced40bb7ebc0db`
- Stable patch-id: `373d4960c20d37c8621d12f15b82488a513c8829`
- Diff: 2 files, +13/-6

No schema, resume/checkpoint, tool-routing, reviewer-policy, termination decision, or default workflow change is included.

## Rollback

Revert the single commit `df9cd69d382abf2c9e751e08c068d42bb09234c3`. The change is isolated and has no migration or persisted-state dependency.
