### PR TITLE
fix(tui): bind sticky-viewport oracle authority to one reviewed commit and widen provenance to Rust

### DIFF
--- a/packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts
@@ -177,19 +177,56 @@ const PROVENANCE_SOURCES = [
 	"packages/coding-agent/src/modes/components/irc-sidebar.ts",
 	"packages/tui/src/tui.ts",
 ] as const;
+// Working-tree scope for `git_diff_binary_sha256`, persisted alongside the digest
+// as `git_diff_scope` so a reviewer reads the covered surface off the bundle
+// instead of inferring it.
+//
+// This digest used to hash `git diff --binary HEAD --` over the ENTIRE worktree.
+// The verifier recomputes it live at verify time, so that coupled bundle validity
+// to every tracked file in the repo: an unrelated edit anywhere — a doc typo,
+// another package's test — retroactively made every already-captured bundle
+// "stale". Those are false positives, and they are nondeterministic, because any
+// write landing in the capture→verify window flips the digest mid-run and masks
+// whichever guard was actually under test.
+//
+// The scope below is the transitive render-dependency closure of the fixture:
+// every workspace package the capture reaches (coding-agent → agent, ai,
+// bridge-client, natives, stats, tui, utils), the fixture plus the virtual
+// terminal it paints into, both showcase scripts, and the lockfile pinning the
+// installed dependency versions. Uncommitted edits inside this closure still
+// invalidate a bundle — that is the property the staleness guard exists to
+// enforce. Edits outside it no longer can, because they cannot change the paint.
+export const PROVENANCE_DIFF_SCOPE = [
+	"bun.lock",
+	"packages/agent/src",
+	"packages/ai/src",
+	"packages/bridge-client/src",
+	"packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts",
+	"packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts",
+	"packages/coding-agent/src",
+	"packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts",
+	"packages/natives/native",
+	"packages/stats/src",
+	"packages/tui/src",
+	"packages/tui/test/virtual-terminal.ts",
+	"packages/utils/src",
+] as const;
 async function git(args: string[]): Promise<Uint8Array> {
 	const result = Bun.spawn(["git", ...args], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
 	if ((await result.exited) !== 0)
 		throw new Error(`git ${args.join(" ")} failed: ${await new Response(result.stderr).text()}`);
 	return new Uint8Array(await new Response(result.stdout).arrayBuffer());
 }
-type CaptureProvenance = {
+export type CaptureProvenance = {
 	git_head: string;
+	git_diff_scope: readonly string[];
 	git_diff_binary_sha256: string;
 	source_sha256: Record<string, string>;
 };
 
-async function captureProvenance(): Promise<CaptureProvenance> {
+// Single source of truth: the verifier imports this so capture and verify can
+// never drift into computing the field two different ways.
+export async function captureProvenance(): Promise<CaptureProvenance> {
 	const gitHead = new TextDecoder().decode(await git(["rev-parse", "HEAD"])).trim();
 	const sourceSha256 = Object.fromEntries(
 		await Promise.all(
@@ -198,7 +235,8 @@ async function captureProvenance(): Promise<CaptureProvenance> {
 	);
 	return {
 		git_head: gitHead,
-		git_diff_binary_sha256: hash(await git(["diff", "--binary", "HEAD", "--"])),
+		git_diff_scope: PROVENANCE_DIFF_SCOPE,
+		git_diff_binary_sha256: hash(await git(["diff", "--binary", "HEAD", "--", ...PROVENANCE_DIFF_SCOPE])),
 		source_sha256: sourceSha256,
 	};
 }

--- a/packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts
@@ -217,6 +217,23 @@ async function git(args: string[]): Promise<Uint8Array> {
 		throw new Error(`git ${args.join(" ")} failed: ${await new Response(result.stderr).text()}`);
 	return new Uint8Array(await new Response(result.stdout).arrayBuffer());
 }
+
+// Digest of a path's COMMITTED blob at a given commit, read straight out of the
+// object database. This is the only provenance input a bundle author cannot
+// restamp: `captureProvenance()` hashes the worktree, so mutating an oracle file
+// and re-running it yields a self-consistent stamp. The committed blob is fixed
+// by the commit id, so changing it requires a new commit -- which changes
+// `git_head` and is therefore visible to the reviewer.
+export async function committedBlobSha256(commit: string, filePath: string): Promise<string | null> {
+	const result = Bun.spawn(["git", "cat-file", "blob", `${commit}:${filePath}`], {
+		cwd: process.cwd(),
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const bytes = new Uint8Array(await new Response(result.stdout).arrayBuffer());
+	if ((await result.exited) !== 0) return null;
+	return hash(bytes);
+}
 export type CaptureProvenance = {
 	git_head: string;
 	git_diff_scope: readonly string[];

--- a/packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts
@@ -206,11 +206,7 @@ function out(args: string[]): string {
 	if (args.length !== 2 || args[0] !== "--out" || !args[1]) throw new Error(`Usage: ${COMMAND}`);
 	return args[1];
 }
-async function capture(
-	entry: StickyViewportShowcaseEntry,
-	root: string,
-	sourceProvenance: CaptureProvenance,
-) {
+async function capture(entry: StickyViewportShowcaseEntry, root: string, sourceProvenance: CaptureProvenance) {
 	const rendered = await renderStickyViewportShowcase(entry);
 	if (!rendered.state.composer_visible)
 		throw new Error(`${entry.key}: focused composer was not visible in production frame`);

--- a/packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts
@@ -183,7 +183,13 @@ async function git(args: string[]): Promise<Uint8Array> {
 		throw new Error(`git ${args.join(" ")} failed: ${await new Response(result.stderr).text()}`);
 	return new Uint8Array(await new Response(result.stdout).arrayBuffer());
 }
-async function captureProvenance() {
+type CaptureProvenance = {
+	git_head: string;
+	git_diff_binary_sha256: string;
+	source_sha256: Record<string, string>;
+};
+
+async function captureProvenance(): Promise<CaptureProvenance> {
 	const gitHead = new TextDecoder().decode(await git(["rev-parse", "HEAD"])).trim();
 	const sourceSha256 = Object.fromEntries(
 		await Promise.all(
@@ -203,7 +209,7 @@ function out(args: string[]): string {
 async function capture(
 	entry: StickyViewportShowcaseEntry,
 	root: string,
-	sourceProvenance: Awaited<ReturnType<typeof captureProvenance>>,
+	sourceProvenance: CaptureProvenance,
 ) {
 	const rendered = await renderStickyViewportShowcase(entry);
 	if (!rendered.state.composer_visible)

--- a/packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts
@@ -197,7 +197,11 @@ const PROVENANCE_SOURCES = [
 // invalidate a bundle — that is the property the staleness guard exists to
 // enforce. Edits outside it no longer can, because they cannot change the paint.
 export const PROVENANCE_DIFF_SCOPE = [
+	"Cargo.lock",
+	"Cargo.toml",
 	"bun.lock",
+	"crates",
+
 	"packages/agent/src",
 	"packages/ai/src",
 	"packages/bridge-client/src",
@@ -224,6 +228,23 @@ async function git(args: string[]): Promise<Uint8Array> {
 // and re-running it yields a self-consistent stamp. The committed blob is fixed
 // by the commit id, so changing it requires a new commit -- which changes
 // `git_head` and is therefore visible to the reviewer.
+/** sha256 of every distinct blob this path has ever had in any ref-reachable commit. */
+export async function reachableBlobSha256s(filePath: string): Promise<string[]> {
+	const out = new TextDecoder().decode(await git(["rev-list", "--all", "--objects", "--", filePath]));
+	const ids = new Set<string>();
+	for (const line of out.split("\n")) {
+		const [id, ...rest] = line.trim().split(" ");
+		if (id && id.length === 40 && rest.join(" ") === filePath) ids.add(id);
+	}
+	const digests: string[] = [];
+	for (const id of ids) {
+		try {
+			const bytes = await git(["cat-file", "blob", id]);
+			digests.push(hash(bytes));
+		} catch {}
+	}
+	return digests;
+}
 export async function committedBlobSha256(commit: string, filePath: string): Promise<string | null> {
 	const result = Bun.spawn(["git", "cat-file", "blob", `${commit}:${filePath}`], {
 		cwd: process.cwd(),

--- a/packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts
@@ -168,17 +168,51 @@ export function ansiToHtml(value: string): string {
 	return `<!doctype html><html lang="en"><meta charset="utf-8"><title>Sticky viewport showcase</title><style>body{margin:0;background:#110b0b;color:#ffe7dc}pre{white-space:pre;font-family:ui-monospace,monospace}@keyframes blink{50%{visibility:hidden}}</style><pre>${body}</pre></html>\n`;
 }
 const json = (value: unknown) => `${JSON.stringify(value, null, 2)}\n`;
-const hash = (value: string) => new Bun.CryptoHasher("sha256").update(value).digest("hex");
+const hash = (value: string | Uint8Array) => new Bun.CryptoHasher("sha256").update(value).digest("hex");
+const PROVENANCE_SOURCES = [
+	"packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts",
+	"packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts",
+	"packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts",
+	"packages/coding-agent/src/modes/interactive-mode.ts",
+	"packages/coding-agent/src/modes/components/irc-sidebar.ts",
+	"packages/tui/src/tui.ts",
+] as const;
+async function git(args: string[]): Promise<Uint8Array> {
+	const result = Bun.spawn(["git", ...args], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
+	if ((await result.exited) !== 0)
+		throw new Error(`git ${args.join(" ")} failed: ${await new Response(result.stderr).text()}`);
+	return new Uint8Array(await new Response(result.stdout).arrayBuffer());
+}
+async function captureProvenance() {
+	const gitHead = new TextDecoder().decode(await git(["rev-parse", "HEAD"])).trim();
+	const sourceSha256 = Object.fromEntries(
+		await Promise.all(
+			PROVENANCE_SOURCES.map(async source => [source, hash(new Uint8Array(await Bun.file(source).arrayBuffer()))]),
+		),
+	);
+	return {
+		git_head: gitHead,
+		git_diff_binary_sha256: hash(await git(["diff", "--binary", "HEAD", "--"])),
+		source_sha256: sourceSha256,
+	};
+}
 function out(args: string[]): string {
 	if (args.length !== 2 || args[0] !== "--out" || !args[1]) throw new Error(`Usage: ${COMMAND}`);
 	return args[1];
 }
-async function capture(entry: StickyViewportShowcaseEntry, root: string) {
+async function capture(
+	entry: StickyViewportShowcaseEntry,
+	root: string,
+	sourceProvenance: Awaited<ReturnType<typeof captureProvenance>>,
+) {
 	const rendered = await renderStickyViewportShowcase(entry);
 	if (!rendered.state.composer_visible)
 		throw new Error(`${entry.key}: focused composer was not visible in production frame`);
-	if (entry.stateId === "manual-new-output" && rendered.state.notice !== true)
-		throw new Error(`${entry.key}: manual output notice precondition failed`);
+	if (
+		(entry.stateId === "manual-new-output" && rendered.state.notice !== true) ||
+		(entry.stateId !== "manual-new-output" && rendered.state.notice !== false)
+	)
+		throw new Error(`${entry.key}: renderer-owned output notice precondition failed`);
 	if (
 		JSON.stringify(rendered.cjkPhraseBoundaries) !==
 		JSON.stringify(entry.stateId === "narrow-cjk" ? CJK_PHRASE_BOUNDARIES : [])
@@ -210,6 +244,7 @@ async function capture(entry: StickyViewportShowcaseEntry, root: string) {
 			fixed_clock: true,
 			author_identity: "capture-sticky-viewport-showcase",
 			executor_identity: "capture-sticky-viewport-showcase",
+			...sourceProvenance,
 		},
 		cjk_phrase_boundaries: rendered.cjkPhraseBoundaries,
 	});
@@ -241,8 +276,9 @@ async function capture(entry: StickyViewportShowcaseEntry, root: string) {
 async function main() {
 	const root = path.resolve(out(process.argv.slice(2)));
 	await fs.mkdir(root, { recursive: true });
+	const sourceProvenance = await captureProvenance();
 	const entries = [];
-	for (const entry of STICKY_VIEWPORT_SHOWCASE_ENTRIES) entries.push(await capture(entry, root));
+	for (const entry of STICKY_VIEWPORT_SHOWCASE_ENTRIES) entries.push(await capture(entry, root, sourceProvenance));
 	const manifest = json({
 		schema_version: 2,
 		fixture_revision: REVISION,
@@ -258,6 +294,7 @@ async function main() {
 			fixed_clock: true,
 			author_identity: "capture-sticky-viewport-showcase",
 			executor_identity: "capture-sticky-viewport-showcase",
+			...sourceProvenance,
 		},
 		review_input_file: "review-input.json",
 		entries,
@@ -281,6 +318,15 @@ async function main() {
 			acceptance_version: ACCEPTANCE_VERSION,
 			design_version: DESIGN_VERSION,
 			host_matrix: HOST_MATRIX,
+			provenance: {
+				capture_mode: "production-tui-virtual-terminal",
+				live_pty: false,
+				network: false,
+				fixed_clock: true,
+				author_identity: "capture-sticky-viewport-showcase",
+				executor_identity: "capture-sticky-viewport-showcase",
+				...sourceProvenance,
+			},
 			narrow_cjk: {
 				entry_key: "narrow-cjk/48x10/unicode-color",
 				phrase_boundaries: ["의미 있는 문장 경계", "意味のある文の境界", "保留语义短语边界"],

--- a/packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts
@@ -229,21 +229,13 @@ async function git(args: string[]): Promise<Uint8Array> {
 // by the commit id, so changing it requires a new commit -- which changes
 // `git_head` and is therefore visible to the reviewer.
 /** sha256 of every distinct blob this path has ever had in any ref-reachable commit. */
-export async function reachableBlobSha256s(filePath: string): Promise<string[]> {
-	const out = new TextDecoder().decode(await git(["rev-list", "--all", "--objects", "--", filePath]));
-	const ids = new Set<string>();
-	for (const line of out.split("\n")) {
-		const [id, ...rest] = line.trim().split(" ");
-		if (id && id.length === 40 && rest.join(" ") === filePath) ids.add(id);
+export async function gitObjectType(commitish: string): Promise<string | null> {
+	try {
+		const out = new TextDecoder().decode(await git(["cat-file", "-t", commitish])).trim();
+		return out || null;
+	} catch {
+		return null;
 	}
-	const digests: string[] = [];
-	for (const id of ids) {
-		try {
-			const bytes = await git(["cat-file", "blob", id]);
-			digests.push(hash(bytes));
-		} catch {}
-	}
-	return digests;
 }
 export async function committedBlobSha256(commit: string, filePath: string): Promise<string | null> {
 	const result = Bun.spawn(["git", "cat-file", "blob", `${commit}:${filePath}`], {
@@ -257,6 +249,7 @@ export async function committedBlobSha256(commit: string, filePath: string): Pro
 }
 export type CaptureProvenance = {
 	git_head: string;
+	oracle_commit: string;
 	git_diff_scope: readonly string[];
 	git_diff_binary_sha256: string;
 	source_sha256: Record<string, string>;
@@ -273,6 +266,7 @@ export async function captureProvenance(): Promise<CaptureProvenance> {
 	);
 	return {
 		git_head: gitHead,
+		oracle_commit: process.env.GJC_STICKY_VIEWPORT_ORACLE_COMMIT?.trim() ?? gitHead,
 		git_diff_scope: PROVENANCE_DIFF_SCOPE,
 		git_diff_binary_sha256: hash(await git(["diff", "--binary", "HEAD", "--", ...PROVENANCE_DIFF_SCOPE])),
 		source_sha256: sourceSha256,

--- a/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
@@ -10,6 +10,7 @@ import {
 	captureProvenance,
 	committedBlobSha256,
 	PROVENANCE_DIFF_SCOPE,
+	reachableBlobSha256s,
 	xterm256Color,
 } from "./capture-sticky-viewport-showcase";
 
@@ -426,13 +427,45 @@ const ORACLE_SOURCES = [
 	"packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts",
 	"packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts",
 ] as const;
+// The reviewed PR commit, supplied out-of-band by the verifying operator.
+// `provenance.git_head` is `git rev-parse HEAD`, which is NOT the reviewed commit
+// during an uncommitted synthetic merge: there HEAD is the integration base while
+// the running oracle is the staged PR version. Comparing against HEAD alone
+// therefore rejects an honest bundle before any evidence guard runs. This value is
+// environment-supplied rather than bundle-supplied, so a bundle author cannot
+// choose which commit vouches for the oracle.
+const ORACLE_COMMIT_ENV = "GJC_STICKY_VIEWPORT_ORACLE_COMMIT";
 const verifyOracleIntegrity = async (gitHead: string) => {
+	// The reviewed PR head — not the integration worktree's `HEAD`. The review
+	// protocol validates an *uncommitted* synthetic merge: the running oracle is
+	// the PR's version while `HEAD` is the current-dev base, so comparing against
+	// `HEAD` alone rejects honest bundles. Accept the running bytes when that exact
+	// content exists as this path's blob in ANY commit reachable from any ref, which
+	// is true for the reviewed PR head and false for a worktree-only mutation. An
+	// attacker who commits the mutation puts it in the reviewed diff, where it is
+	// visible rather than laundered through a restamped provenance block.
+	const declared = process.env[ORACLE_COMMIT_ENV]?.trim();
 	for (const source of ORACLE_SOURCES) {
-		const committed = await committedBlobSha256(gitHead, source);
-		// Fail closed: an unreadable blob is indistinguishable from a rewritten one.
-		if (committed === null) fail(`oracle integrity: ${source} has no committed blob at ${gitHead}`);
 		const running = hash(new Uint8Array(await fs.readFile(source)));
-		if (running !== committed) fail(`oracle integrity: ${source} differs from its committed blob at ${gitHead}`);
+		let matched = false;
+		let sawBlob = false;
+		for (const commit of declared ? [declared, gitHead] : [gitHead]) {
+			const committed = await committedBlobSha256(commit, source);
+			if (committed === null) continue;
+			sawBlob = true;
+			if (running === committed) {
+				matched = true;
+				break;
+			}
+		}
+		if (!matched) {
+			const reachable = await reachableBlobSha256s(source);
+			if (reachable.length > 0) sawBlob = true;
+			matched = reachable.includes(running);
+		}
+		// Fail closed: no readable blob anywhere is indistinguishable from a rewrite.
+		if (!sawBlob) fail(`oracle integrity: ${source} has no committed blob`);
+		if (!matched) fail(`oracle integrity: ${source} differs from every committed blob of that path`);
 	}
 };
 const SEMANTIC_ANCHOR_EXPECTATION: Readonly<

--- a/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
@@ -9,8 +9,8 @@ import {
 	ansiToHtml,
 	captureProvenance,
 	committedBlobSha256,
+	gitObjectType,
 	PROVENANCE_DIFF_SCOPE,
-	reachableBlobSha256s,
 	xterm256Color,
 } from "./capture-sticky-viewport-showcase";
 
@@ -435,37 +435,32 @@ const ORACLE_SOURCES = [
 // environment-supplied rather than bundle-supplied, so a bundle author cannot
 // choose which commit vouches for the oracle.
 const ORACLE_COMMIT_ENV = "GJC_STICKY_VIEWPORT_ORACLE_COMMIT";
-const verifyOracleIntegrity = async (gitHead: string) => {
-	// The reviewed PR head — not the integration worktree's `HEAD`. The review
-	// protocol validates an *uncommitted* synthetic merge: the running oracle is
-	// the PR's version while `HEAD` is the current-dev base, so comparing against
-	// `HEAD` alone rejects honest bundles. Accept the running bytes when that exact
-	// content exists as this path's blob in ANY commit reachable from any ref, which
-	// is true for the reviewed PR head and false for a worktree-only mutation. An
-	// attacker who commits the mutation puts it in the reviewed diff, where it is
-	// visible rather than laundered through a restamped provenance block.
+const verifyOracleIntegrity = async (gitHead: string, declaredProvenanceCommit: unknown) => {
+	// Authority is exactly one commit. Reachability is NOT authority: bytes
+	// committed on an unrelated local or remote-tracking ref are reachable via
+	// `--all` yet were never reviewed, so enumerating refs would let any pushed
+	// or fetched branch authorize the oracle. The reviewed commit is therefore
+	// either declared out-of-band by the review harness or it is `git_head`.
 	const declared = process.env[ORACLE_COMMIT_ENV]?.trim();
+	if (declared !== undefined && !/^[0-9a-f]{40}$/.test(declared))
+		fail(`oracle integrity: ${ORACLE_COMMIT_ENV} must be a full 40-hex commit id`);
+	const authority = declared ?? gitHead;
+	// Fail closed when the authority is not a readable commit object.
+	if ((await gitObjectType(authority)) !== "commit")
+		fail(`oracle integrity: authority ${authority} is not a readable commit object`);
+	// The bundle records which commit it claimed; a mismatch means the bundle was
+	// captured against a different authority than the one being verified.
+	if (declaredProvenanceCommit !== authority)
+		fail(
+			`oracle integrity: provenance oracle_commit ${String(declaredProvenanceCommit)} is not the authority ${authority}`,
+		);
+	// Both oracle files must resolve at that same commit; per-file provenance
+	// from different refs is not accepted.
 	for (const source of ORACLE_SOURCES) {
+		const committed = await committedBlobSha256(authority, source);
+		if (committed === null) fail(`oracle integrity: ${source} has no committed blob at ${authority}`);
 		const running = hash(new Uint8Array(await fs.readFile(source)));
-		let matched = false;
-		let sawBlob = false;
-		for (const commit of declared ? [declared, gitHead] : [gitHead]) {
-			const committed = await committedBlobSha256(commit, source);
-			if (committed === null) continue;
-			sawBlob = true;
-			if (running === committed) {
-				matched = true;
-				break;
-			}
-		}
-		if (!matched) {
-			const reachable = await reachableBlobSha256s(source);
-			if (reachable.length > 0) sawBlob = true;
-			matched = reachable.includes(running);
-		}
-		// Fail closed: no readable blob anywhere is indistinguishable from a rewrite.
-		if (!sawBlob) fail(`oracle integrity: ${source} has no committed blob`);
-		if (!matched) fail(`oracle integrity: ${source} differs from every committed blob of that path`);
+		if (running !== committed) fail(`oracle integrity: ${source} differs from its committed blob at ${authority}`);
 	}
 };
 const SEMANTIC_ANCHOR_EXPECTATION: Readonly<
@@ -717,7 +712,7 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 		fail("manifest capture provenance is stale");
 	// Runs before every entry check: a rewritten oracle would otherwise decide
 	// what "valid" means for all of them.
-	await verifyOracleIntegrity(provenance.git_head as string);
+	await verifyOracleIntegrity(provenance.git_head as string, provenance.oracle_commit);
 	const entries = array(manifest.entries, "manifest entries");
 	if (entries.length !== KEYS.length) fail("manifest entries must contain exactly 20 entries");
 	// Cross-entry anchor identity ledger. Uniqueness is a hard contract, not a

--- a/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
@@ -1,5 +1,10 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import {
+	SEMANTIC_ANCHOR_DOMAIN,
+	semanticAnchorDigest,
+	semanticAnchorNamespace,
+} from "../test/fixtures/tui/sticky-viewport-showcase";
 import { ansiToHtml, xterm256Color } from "./capture-sticky-viewport-showcase";
 
 const KEYS = [
@@ -64,6 +69,18 @@ const INDEPENDENT_REVIEW_KEYS = [
 const INDEPENDENT_REVIEW_RESULT_KEYS = ["key", "result", "notes", "artifact_checks"] as const;
 const INDEPENDENT_REVIEW_DEFECT_KEYS = ["description", "accepted"] as const;
 const ARTIFACT_CHECK_KEYS = ["terminal_txt", "terminal_ansi_txt", "terminal_html", "metadata_json"] as const;
+const SEMANTIC_ANCHOR_KEYS = [
+	"domain",
+	"id",
+	"namespace",
+	"grapheme_start",
+	"grapheme_end",
+	"cell_start",
+	"cell_end",
+	"frame_start_row",
+	"row_text_sha256",
+	"frame_sha256",
+] as const;
 const SEMANTIC_ROOT_IDS = [
 	"irc-split",
 	"pending-messages",
@@ -409,6 +426,77 @@ const frameGeometry = (key: string, text: string) => {
 	// the painted status row sits one lower than the transcript capacity.
 	return { capacity: statusRow - noticeRows, statusRow, noticeRows };
 };
+// Semantic anchor identity guard. The persisted `semantic_anchor.id` is the only
+// durable handle on WHICH painted row the evidence anchors, so it must be
+// unforgeable rather than merely well-formed. A geometry-only digest failed both
+// ways: distinct entries painting different content at equal offsets collapsed
+// onto one id, and an 8-hex truncation is brute-forceable. This recomputes the
+// full domain-separated digest from the persisted inputs plus the committed paint
+// and rejects arbitrary, transplanted, aliased, malformed, and truncated ids. It
+// runs BEFORE every downstream metadata check so a forged id can never ride
+// through on an earlier-passing path.
+const verifySemanticAnchor = (
+	key: string,
+	state: string,
+	value: unknown,
+	text: string,
+	ansiSha256: string,
+	seen: Map<string, string>,
+) => {
+	if (state === "capacity-zero") {
+		if (value !== null) fail(`semantic anchor guard: ${key} must not carry an anchor at zero capacity`);
+		return;
+	}
+	const anchor = object(value, `semantic anchor ${key}`);
+	exactKeys(anchor, SEMANTIC_ANCHOR_KEYS, `semantic anchor ${key}`);
+	if (anchor.domain !== SEMANTIC_ANCHOR_DOMAIN)
+		fail(`semantic anchor guard: ${key} domain separation literal mismatch`);
+	const id = anchor.id;
+	const namespace = anchor.namespace;
+	if (typeof id !== "string" || typeof namespace !== "string" || !namespace)
+		fail(`semantic anchor guard: ${key} id or namespace is not a nonempty string`);
+	const geometry = ["grapheme_start", "grapheme_end", "cell_start", "cell_end", "frame_start_row"] as const;
+	for (const field of geometry)
+		if (!Number.isInteger(anchor[field]) || (anchor[field] as number) < 0)
+			fail(`semantic anchor guard: ${key} ${field} is not a nonnegative integer`);
+	const graphemeStart = anchor.grapheme_start as number;
+	const graphemeEnd = anchor.grapheme_end as number;
+	const cellStart = anchor.cell_start as number;
+	const cellEnd = anchor.cell_end as number;
+	const frameRow = anchor.frame_start_row as number;
+	if (graphemeEnd <= graphemeStart || cellEnd <= cellStart)
+		fail(`semantic anchor guard: ${key} geometry span is empty or inverted`);
+	// The row text is read from the committed paint, never from metadata, so the id
+	// stays bound to what the artifact actually renders at the recorded row.
+	const rows = text.split("\n");
+	const rowText = rows[frameRow];
+	if (rowText === undefined) fail(`semantic anchor guard: ${key} frame_start_row is outside the committed paint`);
+	if (anchor.row_text_sha256 !== hash(rowText as string))
+		fail(`semantic anchor guard: ${key} row content digest does not match the painted anchor row`);
+	if (anchor.frame_sha256 !== ansiSha256)
+		fail(`semantic anchor guard: ${key} frame digest does not match the committed frame`);
+	if (semanticAnchorNamespace(id as string) !== namespace)
+		fail(`semantic anchor guard: ${key} id namespace does not match the persisted namespace`);
+	const expected = `${namespace}:${semanticAnchorDigest({
+		entryKey: key,
+		namespace: namespace as string,
+		rowText: rowText as string,
+		graphemeStart,
+		graphemeEnd,
+		cellStart,
+		cellEnd,
+		frameRow,
+		frameSha256: ansiSha256,
+	})}`;
+	if (id !== expected) fail(`semantic anchor guard: ${key} id is not the digest of its own persisted inputs`);
+	// No silent aliasing: distinct evidence entries are distinct anchors by
+	// construction, because the entry key is inside the preimage. A repeat here can
+	// only mean a transplanted id, so it is a hard failure rather than an
+	// equivalence to be tolerated.
+	const owner = seen.get(id as string);
+	if (owner !== undefined) fail(`semantic anchor guard: ${key} id aliases the anchor already claimed by ${owner}`);
+	seen.set(id as string, key);
+};
 export async function verifyStickyViewportShowcase(rootInput: string, requireIndependentReview = false): Promise<void> {
 	const root = path.resolve(rootInput);
 	const manifestText = await fs.readFile(path.join(root, "manifest.json"), "utf8");
@@ -445,6 +533,9 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 		fail("manifest capture provenance is stale");
 	const entries = array(manifest.entries, "manifest entries");
 	if (entries.length !== KEYS.length) fail("manifest entries must contain exactly 20 entries");
+	// Cross-entry anchor identity ledger. Uniqueness is a hard contract, not a
+	// tolerance: every distinct evidence entry must own a distinct anchor id.
+	const anchorIds = new Map<string, string>();
 	for (let index = 0; index < KEYS.length; index += 1) {
 		const key = KEYS[index]!;
 		const entry = object(entries[index], `entry ${index}`);
@@ -547,6 +638,10 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 			stateEvidence.composer_visible !== true
 		)
 			fail(`metadata schema mismatch for ${key}`);
+		// Anchor identity is validated here, before any downstream metadata check, so
+		// a forged, transplanted, or aliased id cannot ride through on an
+		// earlier-passing path.
+		verifySemanticAnchor(key, state!, stateEvidence.semantic_anchor, text, hash(ansi), anchorIds);
 		// Frame-derived geometry must AGREE with the renderer's self-report, which is
 		// strictly stronger than either alone. `transcript_capacity` and
 		// `pin_boundary.row` both come from one renderer local, so they can only be
@@ -583,21 +678,6 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 			metadata.output_revision !== stateEvidence.observed_output_revision
 		)
 			fail(`renderer-owned viewport state mismatch for ${key}`);
-		const semanticAnchor =
-			state === "capacity-zero"
-				? stateEvidence.semantic_anchor
-				: object(stateEvidence.semantic_anchor, `metadata ${key} semantic anchor`);
-		const semanticAnchorValid =
-			state === "capacity-zero"
-				? semanticAnchor === null && stateEvidence.transcript_capacity === 0
-				: typeof (semanticAnchor as Record<string, unknown>).id === "string" &&
-					((semanticAnchor as Record<string, unknown>).id as string).length > 0 &&
-					Number.isInteger((semanticAnchor as Record<string, unknown>).grapheme_start) &&
-					((semanticAnchor as Record<string, unknown>).grapheme_start as number) >= 0 &&
-					Number.isInteger((semanticAnchor as Record<string, unknown>).cell_start) &&
-					((semanticAnchor as Record<string, unknown>).cell_start as number) >= 0 &&
-					Number.isInteger((semanticAnchor as Record<string, unknown>).frame_start_row) &&
-					((semanticAnchor as Record<string, unknown>).frame_start_row as number) >= 0;
 		const visibleEmpty = object(stateEvidence.visible_empty_irc_frame, `metadata ${key} visible empty IRC frame`);
 		exactKeys(stateEvidence, STATE_KEYS, `metadata ${key} state`);
 		strings(rootOrder, SEMANTIC_ROOT_IDS, `metadata ${key} semantic root IDs`);
@@ -679,7 +759,6 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 			!Number.isInteger(cursor.col) ||
 			(cursor.col as number) < 0 ||
 			(cursor.col as number) >= columns ||
-			!semanticAnchorValid ||
 			cursor.frame_sha256 !== hash(ansi) ||
 			cursor.blink !== true
 		)

--- a/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
@@ -8,6 +8,7 @@ import {
 import {
 	ansiToHtml,
 	captureProvenance,
+	committedBlobSha256,
 	PROVENANCE_DIFF_SCOPE,
 	xterm256Color,
 } from "./capture-sticky-viewport-showcase";
@@ -414,6 +415,26 @@ const frameGeometry = (key: string, text: string) => {
 // and this file's own sha256 is inside `source_sha256`, so a bundle author cannot
 // restate it. Geometry was measured identical across indexed-color and truecolor
 // hosts, so pinning it costs no host portability.
+// Files that OWN the verification contract itself: the expectation table, the
+// anchor digest function, and every guard below. `source_sha256` cannot protect
+// these, because it is produced by `captureProvenance()` from the worktree -- an
+// author who edits an oracle and restamps provenance gets a self-consistent
+// bundle. So these two are pinned to their committed blobs at the bundle's own
+// `git_head` instead. Product-source diffs stay permitted for staged current-dev
+// integration; oracle diffs do not.
+const ORACLE_SOURCES = [
+	"packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts",
+	"packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts",
+] as const;
+const verifyOracleIntegrity = async (gitHead: string) => {
+	for (const source of ORACLE_SOURCES) {
+		const committed = await committedBlobSha256(gitHead, source);
+		// Fail closed: an unreadable blob is indistinguishable from a rewritten one.
+		if (committed === null) fail(`oracle integrity: ${source} has no committed blob at ${gitHead}`);
+		const running = hash(new Uint8Array(await fs.readFile(source)));
+		if (running !== committed) fail(`oracle integrity: ${source} differs from its committed blob at ${gitHead}`);
+	}
+};
 const SEMANTIC_ANCHOR_EXPECTATION: Readonly<
 	Record<string, { frameRow: number; graphemeStart: number; graphemeEnd: number; cellStart: number; cellEnd: number }>
 > = Object.freeze({
@@ -661,6 +682,9 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 		JSON.stringify(provenance.source_sha256) !== JSON.stringify(expectedProvenance.source_sha256)
 	)
 		fail("manifest capture provenance is stale");
+	// Runs before every entry check: a rewritten oracle would otherwise decide
+	// what "valid" means for all of them.
+	await verifyOracleIntegrity(provenance.git_head as string);
 	const entries = array(manifest.entries, "manifest entries");
 	if (entries.length !== KEYS.length) fail("manifest entries must contain exactly 20 entries");
 	// Cross-entry anchor identity ledger. Uniqueness is a hard contract, not a

--- a/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
@@ -636,6 +636,9 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 					typeof frame.ansi !== "string" ||
 					frame.text !== Bun.stripANSI(frame.ansi) ||
 					frame.sha256 !== hash(frame.ansi) ||
+					// Required ASCII metadata frames must be escape-free too, or the bundle
+					// digest stays host-dependent even when the top-level payload is canonical.
+					(mode === "ascii-no-color" && /\x1b\[/.test(frame.ansi as string)) ||
 					(!capacityConstrained && split && !frame.text.includes("│")) ||
 					(!capacityConstrained &&
 						!split &&
@@ -651,6 +654,7 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 			typeof visibleEmpty.ansi !== "string" ||
 			visibleEmpty.text !== Bun.stripANSI(visibleEmpty.ansi) ||
 			visibleEmpty.sha256 !== hash(visibleEmpty.ansi) ||
+			(mode === "ascii-no-color" && /\x1b\[/.test(visibleEmpty.ansi as string)) ||
 			JSON.stringify(rootOrder) !==
 				JSON.stringify([
 					"irc-split",

--- a/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
@@ -392,18 +392,6 @@ const hasColorSgr = (ansi: string) =>
 				code === 48,
 		);
 	});
-const hasIndexedOrBasicColorSgr = (ansi: string) =>
-	[...ansi.matchAll(/\x1b\[([0-9;]*)m/g)].some(match => {
-		const codes = (match[1] || "0").split(";").map(Number);
-		for (let index = 0; index < codes.length; index += 1) {
-			const code = codes[index]!;
-			if ((code >= 30 && code <= 37) || (code >= 40 && code <= 47) || (code >= 90 && code <= 107)) return true;
-			if (code !== 38 && code !== 48) continue;
-			if (codes[index + 1] === 5) return true;
-			if (codes[index + 1] === 2) index += 4;
-		}
-		return false;
-	});
 export async function verifyStickyViewportShowcase(rootInput: string, requireIndependentReview = false): Promise<void> {
 	const root = path.resolve(rootInput);
 	const manifestText = await fs.readFile(path.join(root, "manifest.json"), "utf8");
@@ -480,7 +468,11 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 		)
 			fail(`entry ${key} ANSI/HTML style-run mismatch`);
 		if (text.split("\n").length - 1 !== rows) fail(`entry ${key} terminal row count mismatch`);
-		if (mode === "ascii-no-color" ? hasIndexedOrBasicColorSgr(ansi) : !hasColorSgr(ansi))
+		// `ascii-no-color` artifacts must contain no escape sequence at all, which is
+		// host-independent. The color branch keeps the widened check below because the
+		// prior `3[0-9]|38;` regex missed background (40-47/100-107) and bright (90-97)
+		// color, so a frame carrying only those would have passed as "no color".
+		if (mode === "ascii-no-color" ? /\x1b\[/.test(ansi) : !hasColorSgr(ansi))
 			fail(`entry ${key} ANSI mode/color mismatch`);
 		const metadata = await readJson(path.join(root, key, "metadata.json"), `metadata ${key}`);
 		exactKeys(

--- a/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
@@ -5,7 +5,12 @@ import {
 	semanticAnchorDigest,
 	semanticAnchorNamespace,
 } from "../test/fixtures/tui/sticky-viewport-showcase";
-import { ansiToHtml, xterm256Color } from "./capture-sticky-viewport-showcase";
+import {
+	ansiToHtml,
+	captureProvenance,
+	PROVENANCE_DIFF_SCOPE,
+	xterm256Color,
+} from "./capture-sticky-viewport-showcase";
 
 const KEYS = [
 	"live-overflow/80x24/unicode-color",
@@ -125,31 +130,6 @@ type Style = {
 };
 type Run = { text: string; style: Style };
 const hash = (value: string | Uint8Array) => new Bun.CryptoHasher("sha256").update(value).digest("hex");
-const PROVENANCE_SOURCES = [
-	"packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts",
-	"packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts",
-	"packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts",
-	"packages/coding-agent/src/modes/interactive-mode.ts",
-	"packages/coding-agent/src/modes/components/irc-sidebar.ts",
-	"packages/tui/src/tui.ts",
-] as const;
-async function git(args: string[]): Promise<Uint8Array> {
-	const result = Bun.spawn(["git", ...args], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
-	if ((await result.exited) !== 0) fail(`git ${args.join(" ")} failed: ${await new Response(result.stderr).text()}`);
-	return new Uint8Array(await new Response(result.stdout).arrayBuffer());
-}
-async function currentProvenance() {
-	const sourceSha256 = Object.fromEntries(
-		await Promise.all(
-			PROVENANCE_SOURCES.map(async source => [source, hash(new Uint8Array(await Bun.file(source).arrayBuffer()))]),
-		),
-	);
-	return {
-		git_head: new TextDecoder().decode(await git(["rev-parse", "HEAD"])).trim(),
-		git_diff_binary_sha256: hash(await git(["diff", "--binary", "HEAD", "--"])),
-		source_sha256: sourceSha256,
-	};
-}
 const cellWidth = (grapheme: string) => {
 	const scalar = grapheme.codePointAt(0)!;
 	if (scalar === 0x200d || (scalar >= 0x300 && scalar <= 0x36f) || (scalar >= 0xfe00 && scalar <= 0xfe0f)) return 0;
@@ -513,7 +493,7 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 		fail("manifest schema or provenance literals mismatch");
 	strings(manifest.ordered_keys, KEYS, "manifest ordered_keys");
 	const provenance = object(manifest.provenance, "manifest provenance");
-	const expectedProvenance = await currentProvenance();
+	const expectedProvenance = await captureProvenance();
 	if (
 		provenance.capture_mode !== "production-tui-virtual-terminal" ||
 		provenance.live_pty !== false ||
@@ -525,8 +505,12 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 		!provenance.executor_identity.trim()
 	)
 		fail("manifest provenance mismatch");
+	// `git_diff_scope` is compared against the verifier's own constant, so a bundle
+	// cannot narrow the covered surface to dodge the digest: claiming a smaller
+	// scope than the verifier requires is itself a staleness rejection.
 	if (
 		provenance.git_head !== expectedProvenance.git_head ||
+		JSON.stringify(provenance.git_diff_scope) !== JSON.stringify(PROVENANCE_DIFF_SCOPE) ||
 		provenance.git_diff_binary_sha256 !== expectedProvenance.git_diff_binary_sha256 ||
 		JSON.stringify(provenance.source_sha256) !== JSON.stringify(expectedProvenance.source_sha256)
 	)
@@ -633,6 +617,7 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 			metaProvenance.author_identity !== provenance.author_identity ||
 			metaProvenance.executor_identity !== provenance.executor_identity ||
 			metaProvenance.git_head !== expectedProvenance.git_head ||
+			JSON.stringify(metaProvenance.git_diff_scope) !== JSON.stringify(PROVENANCE_DIFF_SCOPE) ||
 			metaProvenance.git_diff_binary_sha256 !== expectedProvenance.git_diff_binary_sha256 ||
 			JSON.stringify(metaProvenance.source_sha256) !== JSON.stringify(expectedProvenance.source_sha256) ||
 			stateEvidence.composer_visible !== true
@@ -810,6 +795,7 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 	const reviewProvenance = object(reviewInput.provenance, "review input provenance");
 	if (
 		reviewProvenance.git_head !== expectedProvenance.git_head ||
+		JSON.stringify(reviewProvenance.git_diff_scope) !== JSON.stringify(PROVENANCE_DIFF_SCOPE) ||
 		reviewProvenance.git_diff_binary_sha256 !== expectedProvenance.git_diff_binary_sha256 ||
 		JSON.stringify(reviewProvenance.source_sha256) !== JSON.stringify(expectedProvenance.source_sha256)
 	)

--- a/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
@@ -64,6 +64,35 @@ const INDEPENDENT_REVIEW_KEYS = [
 const INDEPENDENT_REVIEW_RESULT_KEYS = ["key", "result", "notes", "artifact_checks"] as const;
 const INDEPENDENT_REVIEW_DEFECT_KEYS = ["description", "accepted"] as const;
 const ARTIFACT_CHECK_KEYS = ["terminal_txt", "terminal_ansi_txt", "terminal_html", "metadata_json"] as const;
+const SEMANTIC_ROOT_IDS = [
+	"irc-split",
+	"pending-messages",
+	"status-container",
+	"todos",
+	"btw",
+	"status-line",
+	"hooks-above",
+	"editor-container",
+	"pet-floor",
+	"hooks-below",
+] as const;
+const STATE_KEYS = [
+	"manual",
+	"notice",
+	"observed_output_revision",
+	"transcript_capacity",
+	"composer_visible",
+	"resize_probes",
+	"visible_empty_irc_frame",
+	"root_order",
+	"pin_boundary",
+	"focused_component",
+	"cursor",
+	"selection",
+	"semantic_anchor",
+	"cjk_contiguous_semantics",
+	"coverage",
+] as const;
 type Style = {
 	foreground: string;
 	background: string;
@@ -78,7 +107,77 @@ type Style = {
 	overline: boolean;
 };
 type Run = { text: string; style: Style };
-const hash = (value: string) => new Bun.CryptoHasher("sha256").update(value).digest("hex");
+const hash = (value: string | Uint8Array) => new Bun.CryptoHasher("sha256").update(value).digest("hex");
+const PROVENANCE_SOURCES = [
+	"packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts",
+	"packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts",
+	"packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts",
+	"packages/coding-agent/src/modes/interactive-mode.ts",
+	"packages/coding-agent/src/modes/components/irc-sidebar.ts",
+	"packages/tui/src/tui.ts",
+] as const;
+async function git(args: string[]): Promise<Uint8Array> {
+	const result = Bun.spawn(["git", ...args], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
+	if ((await result.exited) !== 0) fail(`git ${args.join(" ")} failed: ${await new Response(result.stderr).text()}`);
+	return new Uint8Array(await new Response(result.stdout).arrayBuffer());
+}
+async function currentProvenance() {
+	const sourceSha256 = Object.fromEntries(
+		await Promise.all(
+			PROVENANCE_SOURCES.map(async source => [source, hash(new Uint8Array(await Bun.file(source).arrayBuffer()))]),
+		),
+	);
+	return {
+		git_head: new TextDecoder().decode(await git(["rev-parse", "HEAD"])).trim(),
+		git_diff_binary_sha256: hash(await git(["diff", "--binary", "HEAD", "--"])),
+		source_sha256: sourceSha256,
+	};
+}
+const cellWidth = (grapheme: string) => {
+	const scalar = grapheme.codePointAt(0)!;
+	if (scalar === 0x200d || (scalar >= 0x300 && scalar <= 0x36f) || (scalar >= 0xfe00 && scalar <= 0xfe0f)) return 0;
+	return (scalar >= 0x1100 && scalar <= 0x115f) ||
+		(scalar >= 0x2e80 && scalar <= 0xa4cf) ||
+		(scalar >= 0xac00 && scalar <= 0xd7a3) ||
+		(scalar >= 0xf900 && scalar <= 0xfaff) ||
+		(scalar >= 0xff01 && scalar <= 0xff60) ||
+		(scalar >= 0xffe0 && scalar <= 0xffe6)
+		? 2
+		: 1;
+};
+const terminalRows = (text: string, columns: number) =>
+	text
+		.slice(0, -1)
+		.split("\n")
+		.map(text => {
+			const cells = [...new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(text)].map(item => ({
+				grapheme: item.segment,
+				width: cellWidth(item.segment),
+			}));
+			const width = cells.reduce((total, cell) => total + cell.width, 0);
+			if (width > columns) fail(`terminal row exceeds ${columns} cells`);
+			return { text, cells, width };
+		});
+const verifyCjkCellOracle = (text: string, columns: number, pinRow: unknown, cursorRow: unknown) => {
+	if (!Number.isInteger(pinRow) || !Number.isInteger(cursorRow)) fail("narrow CJK lane geometry missing");
+	const pinnedRow = pinRow as number;
+	const editorRow = cursorRow as number;
+	const rows = terminalRows(text, columns);
+	const phrase = CJK[1];
+	const row = rows.findIndex(candidate => candidate.text.includes(phrase));
+	if (row < 0) fail("narrow CJK cell oracle missing canonical phrase");
+	const candidate = rows[row]!;
+	const phraseIndex = candidate.text.indexOf(phrase);
+	const prefix = candidate.text.slice(0, phraseIndex);
+	const phraseCells = [...new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(phrase)];
+	const phraseStart = [...new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(prefix)].reduce(
+		(total, item) => total + cellWidth(item.segment),
+		0,
+	);
+	const phraseWidth = phraseCells.reduce((total, item) => total + cellWidth(item.segment), 0);
+	if (phraseStart + phraseWidth > columns || row >= pinnedRow || row === editorRow)
+		fail("narrow CJK cell oracle lane overlap");
+};
 const fail = (message: string): never => {
 	throw new Error(`Sticky viewport evidence invalid: ${message}`);
 };
@@ -281,79 +380,30 @@ const normalized = (runs: Run[]) => {
 	return merged;
 };
 const equalRuns = (left: Run[], right: Run[]) => JSON.stringify(normalized(left)) === JSON.stringify(normalized(right));
-const transcriptCapacity = (text: string) => {
-	const row = text.split("\n").findIndex(line => line.includes("status:"));
-	return row < 0 ? fail("frame omits pinned status row") : row;
-};
-const expectedState = (state: string) => ({
-	manual: state !== "live-overflow",
-	notice: state === "manual-new-output",
-	status: state === "live-overflow" ? "status: live follow" : "status: manual history · composer pinned",
-	multiline: state === "multiline-editor-hooks-pet",
-});
-function validateOracle(
-	key: string,
-	text: string,
-	metadata: Record<string, unknown>,
-	stateEvidence: Record<string, unknown>,
-) {
-	const state = key.split("/")[0]!;
-	const expected = expectedState(state);
-	const lines = text.split("\n");
-	if (stateEvidence.manual !== expected.manual || stateEvidence.notice !== expected.notice)
-		fail(`immutable state oracle mismatch for ${key}`);
-	if (lines.filter(line => line.includes(expected.status)).length !== 1)
-		fail(`exact status oracle mismatch for ${key}`);
-	const markers = [
-		expected.status,
-		...(expected.multiline
-			? ["hook: ready", "completed: visual proof", "pet: ◕‿◕", "> ", "first composer line", "second composer line"]
-			: ["> "]),
-	];
-	let position = -1;
-	for (const marker of markers) {
-		const next = text.indexOf(marker, position + 1);
-		if (next < 0) fail(`ordered suffix oracle missing ${marker} for ${key}`);
-		position = next;
-	}
-	if (text.split("New output — type to follow").length - 1 !== (expected.notice ? 1 : 0))
-		fail(`notice cardinality oracle mismatch for ${key}`);
-	if (
-		expected.multiline !==
-		(text.includes("hook: ready") &&
-			text.includes("pet: ◕‿◕") &&
-			text.includes("first composer line") &&
-			text.includes("second composer line"))
-	)
-		fail(`multiline editor/hooks/pet oracle mismatch for ${key}`);
-	if (metadata.output_revision !== (expected.notice ? "1" : "0")) fail(`manual notice invariant mismatch for ${key}`);
-	if (state === "selection-boundary") {
-		const copied = stateEvidence.selection_copied_text;
-		if (
-			stateEvidence.selection_scope !== "transcript" ||
-			typeof copied !== "string" ||
-			!copied.trim() ||
-			copied.includes("status:") ||
-			copied.includes("> ") ||
-			!lines.some(line => line.includes(copied.trim()))
-		)
-			fail(`selection oracle mismatch for ${key}`);
-	} else if (stateEvidence.selection_scope !== "none" || stateEvidence.selection_copied_text !== "")
-		fail(`selection oracle mismatch for ${key}`);
-	const historicalRows = stateEvidence.manual_historical_rows;
-	const preOutputCapacity = stateEvidence.manual_pre_output_capacity;
-	if (expected.manual) {
-		if (
-			!Number.isInteger(preOutputCapacity) ||
-			(preOutputCapacity as number) < 0 ||
-			!Array.isArray(historicalRows) ||
-			historicalRows.length !== ((preOutputCapacity as number) > 0 ? 1 : 0) ||
-			historicalRows.some(row => typeof row !== "string" || !row.trim() || !lines.includes(row))
-		)
-			fail(`manual historical transcript evidence mismatch for ${key}`);
-	} else if (preOutputCapacity !== 0 || !Array.isArray(historicalRows) || historicalRows.length !== 0)
-		fail(`manual historical transcript evidence mismatch for ${key}`);
-}
+const hasColorSgr = (ansi: string) =>
+	[...ansi.matchAll(/\x1b\[([0-9;]*)m/g)].some(match => {
+		const codes = (match[1] || "0").split(";").map(Number);
+		return codes.some(
+			code =>
+				(code >= 30 && code <= 37) ||
+				(code >= 40 && code <= 47) ||
+				(code >= 90 && code <= 107) ||
+				code === 38 ||
+				code === 48,
+		);
+	});
+const hasIndexedOrBasicColorSgr = (ansi: string) =>
+	[...ansi.matchAll(/\x1b\[([0-9;]*)m/g)].some(match => {
+		const codes = (match[1] || "0").split(";").map(Number);
+		for (let index = 0; index < codes.length; index += 1) {
+			const code = codes[index]!;
+			if ((code >= 30 && code <= 37) || (code >= 40 && code <= 47) || (code >= 90 && code <= 107)) return true;
+			if (code !== 38 && code !== 48) continue;
+			if (codes[index + 1] === 5) return true;
+			if (codes[index + 1] === 2) index += 4;
+		}
+		return false;
+	});
 export async function verifyStickyViewportShowcase(rootInput: string, requireIndependentReview = false): Promise<void> {
 	const root = path.resolve(rootInput);
 	const manifestText = await fs.readFile(path.join(root, "manifest.json"), "utf8");
@@ -370,6 +420,7 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 		fail("manifest schema or provenance literals mismatch");
 	strings(manifest.ordered_keys, KEYS, "manifest ordered_keys");
 	const provenance = object(manifest.provenance, "manifest provenance");
+	const expectedProvenance = await currentProvenance();
 	if (
 		provenance.capture_mode !== "production-tui-virtual-terminal" ||
 		provenance.live_pty !== false ||
@@ -381,6 +432,12 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 		!provenance.executor_identity.trim()
 	)
 		fail("manifest provenance mismatch");
+	if (
+		provenance.git_head !== expectedProvenance.git_head ||
+		provenance.git_diff_binary_sha256 !== expectedProvenance.git_diff_binary_sha256 ||
+		JSON.stringify(provenance.source_sha256) !== JSON.stringify(expectedProvenance.source_sha256)
+	)
+		fail("manifest capture provenance is stale");
 	const entries = array(manifest.entries, "manifest entries");
 	if (entries.length !== KEYS.length) fail("manifest entries must contain exactly 20 entries");
 	for (let index = 0; index < KEYS.length; index += 1) {
@@ -422,21 +479,8 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 			!equalRuns(ansiStyleRuns, htmlStyleRuns)
 		)
 			fail(`entry ${key} ANSI/HTML style-run mismatch`);
-		if (state === "multiline-editor-hooks-pet" && (!ansi.includes("\x1b[9m") || !html.includes("line-through")))
-			fail(`entry ${key} strikethrough evidence missing`);
-		if (state === "selection-boundary" && !ansi.includes("\x1b[7m"))
-			fail(`entry ${key} inverse selection evidence missing`);
-		if (state === "narrow-cjk" && CJK.some(boundary => !text.includes(boundary)))
-			fail("narrow CJK visible terminal evidence missing");
-		if (
-			text
-				.split("\n")
-				.slice(0, -1)
-				.some(row => Bun.stringWidth(row) !== columns) ||
-			text.split("\n").length - 1 !== rows
-		)
-			fail(`entry ${key} terminal dimensions mismatch`);
-		if (mode === "ascii-no-color" ? /\x1b\[/.test(ansi) : !/\x1b\[[0-9;]*(?:3[0-9]|38;)/.test(ansi))
+		if (text.split("\n").length - 1 !== rows) fail(`entry ${key} terminal row count mismatch`);
+		if (mode === "ascii-no-color" ? hasIndexedOrBasicColorSgr(ansi) : !hasColorSgr(ansi))
 			fail(`entry ${key} ANSI mode/color mismatch`);
 		const metadata = await readJson(path.join(root, key, "metadata.json"), `metadata ${key}`);
 		exactKeys(
@@ -476,7 +520,7 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 			metadata.fixture_source !== FIXTURE ||
 			metadata.render_mode !== mode ||
 			metadata.ansi_mode !== (mode === "unicode-color") ||
-			metadata.source_revision !== "production-tui-virtual-terminal-v2" ||
+			metadata.source_revision !== "production-tui-virtual-terminal-v3" ||
 			terminal.id !== id ||
 			terminal.columns !== columns ||
 			terminal.rows !== rows ||
@@ -488,21 +532,160 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 			metaProvenance.fixed_clock !== true ||
 			metaProvenance.author_identity !== provenance.author_identity ||
 			metaProvenance.executor_identity !== provenance.executor_identity ||
+			metaProvenance.git_head !== expectedProvenance.git_head ||
+			metaProvenance.git_diff_binary_sha256 !== expectedProvenance.git_diff_binary_sha256 ||
+			JSON.stringify(metaProvenance.source_sha256) !== JSON.stringify(expectedProvenance.source_sha256) ||
 			stateEvidence.composer_visible !== true
 		)
 			fail(`metadata schema mismatch for ${key}`);
-		if (stateEvidence.transcript_capacity !== transcriptCapacity(text))
-			fail(`capacity metadata/frame mismatch for ${key}`);
-		validateOracle(key, text, metadata, stateEvidence);
-		if (state === "capacity-zero" && transcriptCapacity(text) !== 0)
-			fail(`zero capacity frame invariant mismatch for ${key}`);
-		if (state === "capacity-one" && transcriptCapacity(text) !== 1)
-			fail(`one capacity frame invariant mismatch for ${key}`);
-		if (state === "capacity-many" && transcriptCapacity(text) < 2)
-			fail(`many capacity frame invariant mismatch for ${key}`);
+		if (!Number.isInteger(stateEvidence.transcript_capacity)) fail(`capacity metadata/frame mismatch for ${key}`);
+		const observations = array(stateEvidence.resize_probes, `metadata ${key} resize observations`);
+		const probeWidths = [64, 65, 80, 120, 160, 120, 80, 65, 64];
+		const rootOrder = array(stateEvidence.root_order, `metadata ${key} root order`);
+		const pinBoundary = object(stateEvidence.pin_boundary, `metadata ${key} pin boundary`);
+		const cursor = object(stateEvidence.cursor, `metadata ${key} cursor`);
+		const selection = stateEvidence.selection;
+		const expectedManual = state !== "live-overflow" && state !== "capacity-zero";
+		const expectedNotice = state === "manual-new-output";
+		const expectedRevision = expectedNotice ? "1" : "0";
+		if (
+			stateEvidence.manual !== expectedManual ||
+			stateEvidence.notice !== expectedNotice ||
+			stateEvidence.observed_output_revision !== expectedRevision ||
+			metadata.output_revision !== stateEvidence.observed_output_revision
+		)
+			fail(`renderer-owned viewport state mismatch for ${key}`);
+		const semanticAnchor =
+			state === "capacity-zero"
+				? stateEvidence.semantic_anchor
+				: object(stateEvidence.semantic_anchor, `metadata ${key} semantic anchor`);
+		const semanticAnchorValid =
+			state === "capacity-zero"
+				? semanticAnchor === null && stateEvidence.transcript_capacity === 0
+				: typeof (semanticAnchor as Record<string, unknown>).id === "string" &&
+					((semanticAnchor as Record<string, unknown>).id as string).length > 0 &&
+					Number.isInteger((semanticAnchor as Record<string, unknown>).grapheme_start) &&
+					((semanticAnchor as Record<string, unknown>).grapheme_start as number) >= 0 &&
+					Number.isInteger((semanticAnchor as Record<string, unknown>).cell_start) &&
+					((semanticAnchor as Record<string, unknown>).cell_start as number) >= 0 &&
+					Number.isInteger((semanticAnchor as Record<string, unknown>).frame_start_row) &&
+					((semanticAnchor as Record<string, unknown>).frame_start_row as number) >= 0;
+		const visibleEmpty = object(stateEvidence.visible_empty_irc_frame, `metadata ${key} visible empty IRC frame`);
+		exactKeys(stateEvidence, STATE_KEYS, `metadata ${key} state`);
+		strings(rootOrder, SEMANTIC_ROOT_IDS, `metadata ${key} semantic root IDs`);
+		const coverage = object(stateEvidence.coverage, `metadata ${key} coverage`);
+		exactKeys(
+			coverage,
+			["irc", "todo", "widths", "heights", "viewport", "chrome", "evidence"],
+			`metadata ${key} coverage`,
+		);
+		strings(coverage.irc, ["empty", "streaming", "long"], `metadata ${key} IRC coverage`);
+		strings(
+			coverage.todo,
+			["empty", "populated", "long", "multi-phase", "collapsed", "expanded"],
+			`metadata ${key} todo coverage`,
+		);
+		const emptyText = visibleEmpty.text as string;
+		const capacityConstrained = state === "capacity-one" || state === "capacity-zero";
+		if (
+			JSON.stringify(coverage.widths) !== JSON.stringify(probeWidths) ||
+			emptyText.includes("worker → you") ||
+			emptyText.includes("long IRC observation") ||
+			observations.length !== probeWidths.length ||
+			observations.some((value, index) => {
+				const probe = object(value, `metadata ${key} resize observation`);
+				const frame = object(probe.frame, `metadata ${key} resize frame`);
+				const split = probeWidths[index]! >= 65;
+				return (
+					probe.columns !== probeWidths[index] ||
+					probe.effective_lane !== (split ? "split" : "transcript") ||
+					probe.separator_width !== (split ? 3 : 0) ||
+					(probe.left_width as number) + (probe.separator_width as number) + (probe.right_width as number) !==
+						probeWidths[index] ||
+					probe.irc_records !== (split ? 1 : 0) ||
+					probe.todo_rows !== (split ? 1 : 0) ||
+					probe.todo_expanded !== (probe.columns as number) >= 80 ||
+					typeof frame.ansi !== "string" ||
+					frame.text !== Bun.stripANSI(frame.ansi) ||
+					frame.sha256 !== hash(frame.ansi) ||
+					(!capacityConstrained && split && !frame.text.includes("│")) ||
+					(!capacityConstrained &&
+						!split &&
+						(frame.text.includes("worker → you") || frame.text.includes("Todos"))) ||
+					(!capacityConstrained &&
+						(probe.columns as number) >= 80 &&
+						(!frame.text.includes("long IRC observation") ||
+							!frame.text.includes("☑ verify production todo") ||
+							!frame.text.includes("☐ expanded production todo"))) ||
+					(!capacityConstrained && (probe.columns as number) >= 120 && !frame.text.includes("worker → you"))
+				);
+			}) ||
+			typeof visibleEmpty.ansi !== "string" ||
+			visibleEmpty.text !== Bun.stripANSI(visibleEmpty.ansi) ||
+			visibleEmpty.sha256 !== hash(visibleEmpty.ansi) ||
+			JSON.stringify(rootOrder) !==
+				JSON.stringify([
+					"irc-split",
+					"pending-messages",
+					"status-container",
+					"todos",
+					"btw",
+					"status-line",
+					"hooks-above",
+					"editor-container",
+					"pet-floor",
+					"hooks-below",
+				]) ||
+			pinBoundary.component !== "status-line" ||
+			pinBoundary.index !== 5 ||
+			pinBoundary.row !== stateEvidence.transcript_capacity ||
+			pinBoundary.pinned !== true ||
+			stateEvidence.focused_component !== "editor" ||
+			!Number.isInteger(cursor.row) ||
+			(cursor.row as number) < 0 ||
+			(cursor.row as number) >= rows ||
+			!Number.isInteger(cursor.col) ||
+			(cursor.col as number) < 0 ||
+			(cursor.col as number) >= columns ||
+			!semanticAnchorValid ||
+			cursor.frame_sha256 !== hash(ansi) ||
+			cursor.blink !== true
+		)
+			fail(`runtime observation mismatch for ${key}`);
+		if (
+			(state === "capacity-many" && (stateEvidence.transcript_capacity as number) <= 1) ||
+			(state === "capacity-one" && stateEvidence.transcript_capacity !== 1) ||
+			(state === "capacity-zero" && stateEvidence.transcript_capacity !== 0)
+		)
+			fail(`capacity scenario mismatch for ${key}`);
+		if (state === "selection-boundary") {
+			const selected = object(selection, `metadata ${key} selection`);
+			const start = object(selected.start, `metadata ${key} selection start`);
+			const end = object(selected.end, `metadata ${key} selection end`);
+			if (
+				!Number.isInteger(start.row) ||
+				!Number.isInteger(start.col) ||
+				!Number.isInteger(end.row) ||
+				!Number.isInteger(end.col) ||
+				(start.row as number) < 0 ||
+				(end.row as number) >= (stateEvidence.transcript_capacity as number) ||
+				((start.row as number) === (end.row as number) && (start.col as number) >= (end.col as number))
+			)
+				fail(`selection boundary evidence missing for ${key}`);
+		} else if (selection !== null) fail(`unexpected selection evidence for ${key}`);
 		if (state === "narrow-cjk") {
 			strings(metadata.cjk_phrase_boundaries, CJK, "narrow CJK boundaries");
-			if (CJK.some(boundary => !text.includes(boundary))) fail("narrow CJK visible terminal evidence missing");
+			const probeTexts = observations.map(value => {
+				const probe = object(value, `metadata ${key} resize observation`);
+				return object(probe.frame, `metadata ${key} resize frame`).text;
+			});
+			if (
+				CJK.some(
+					boundary => ![text, ...probeTexts].some(frame => typeof frame === "string" && frame.includes(boundary)),
+				)
+			)
+				fail("narrow CJK visible terminal evidence missing");
+			verifyCjkCellOracle(text, columns, pinBoundary.row, cursor.row);
 		} else strings(metadata.cjk_phrase_boundaries, [], `non-narrow CJK boundaries for ${key}`);
 	}
 	const required = new Set([
@@ -513,6 +696,13 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 	]);
 	for (const file of await allFiles(root)) if (!required.has(file)) fail(`unexpected file ${file}`);
 	const reviewInput = await readJson(path.join(root, "review-input.json"), "review input");
+	const reviewProvenance = object(reviewInput.provenance, "review input provenance");
+	if (
+		reviewProvenance.git_head !== expectedProvenance.git_head ||
+		reviewProvenance.git_diff_binary_sha256 !== expectedProvenance.git_diff_binary_sha256 ||
+		JSON.stringify(reviewProvenance.source_sha256) !== JSON.stringify(expectedProvenance.source_sha256)
+	)
+		fail("review input capture provenance is stale");
 	if (
 		reviewInput.schema_version !== 2 ||
 		reviewInput.manifest_sha256 !== hash(manifestText) ||

--- a/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
@@ -392,6 +392,23 @@ const hasColorSgr = (ansi: string) =>
 				code === 48,
 		);
 	});
+// Independent, frame-derived transcript geometry. The renderer assigns
+// `transcriptCapacity` and `pinBoundary.row` from one local (tui.ts), so
+// comparing those two to each other can never fail. These derivations read the
+// committed paint instead, so a renderer reporting stale geometry is rejected.
+const STATUS_ROW_MARKER = "⬢";
+const NOTICE_MARKER = "New output — type to follow";
+const frameGeometry = (key: string, text: string) => {
+	const rows = text.split("\n").slice(0, -1);
+	const statusRows = rows.filter(row => row.includes(STATUS_ROW_MARKER));
+	if (statusRows.length !== 1) fail(`entry ${key} status row cardinality is not exactly one`);
+	const statusRow = rows.findIndex(row => row.includes(STATUS_ROW_MARKER));
+	const noticeRows = text.split(NOTICE_MARKER).length - 1;
+	if (noticeRows > 1) fail(`entry ${key} notice row cardinality exceeds one`);
+	// The notice, when present, occupies the first row below the transcript, so
+	// the painted status row sits one lower than the transcript capacity.
+	return { capacity: statusRow - noticeRows, statusRow, noticeRows };
+};
 export async function verifyStickyViewportShowcase(rootInput: string, requireIndependentReview = false): Promise<void> {
 	const root = path.resolve(rootInput);
 	const manifestText = await fs.readFile(path.join(root, "manifest.json"), "utf8");
@@ -530,7 +547,26 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 			stateEvidence.composer_visible !== true
 		)
 			fail(`metadata schema mismatch for ${key}`);
-		if (!Number.isInteger(stateEvidence.transcript_capacity)) fail(`capacity metadata/frame mismatch for ${key}`);
+		// Frame-derived geometry must AGREE with the renderer's self-report, which is
+		// strictly stronger than either alone. `transcript_capacity` and
+		// `pin_boundary.row` both come from one renderer local, so they can only be
+		// falsified against the committed paint: a renderer reporting stale capacity
+		// or pin geometry now fails here instead of passing self-consistently.
+		const frameGeom = frameGeometry(key, text);
+		if (
+			!Number.isInteger(stateEvidence.transcript_capacity) ||
+			stateEvidence.transcript_capacity !== frameGeom.capacity ||
+			frameGeom.noticeRows !== (state === "manual-new-output" ? 1 : 0)
+		)
+			fail(`capacity metadata/frame mismatch for ${key}`);
+		// Ordered suffix markers follow the production root order: status-line (5),
+		// hooks-above (6), editor-container (7). Painted order, not reported order.
+		let markerPosition = -1;
+		for (const marker of [STATUS_ROW_MARKER, "hook: ready", "> "]) {
+			const next = text.indexOf(marker, markerPosition + 1);
+			if (next < 0) fail(`entry ${key} ordered suffix marker missing: ${marker}`);
+			markerPosition = next;
+		}
 		const observations = array(stateEvidence.resize_probes, `metadata ${key} resize observations`);
 		const probeWidths = [64, 65, 80, 120, 160, 120, 80, 65, 64];
 		const rootOrder = array(stateEvidence.root_order, `metadata ${key} root order`);
@@ -630,7 +666,7 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 				]) ||
 			pinBoundary.component !== "status-line" ||
 			pinBoundary.index !== 5 ||
-			pinBoundary.row !== stateEvidence.transcript_capacity ||
+			pinBoundary.row !== frameGeom.capacity ||
 			pinBoundary.pinned !== true ||
 			stateEvidence.focused_component !== "editor" ||
 			!Number.isInteger(cursor.row) ||

--- a/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
@@ -85,6 +85,7 @@ const SEMANTIC_ANCHOR_KEYS = [
 	"frame_start_row",
 	"row_text_sha256",
 	"frame_sha256",
+	"frame_text_sha256",
 ] as const;
 const SEMANTIC_ROOT_IDS = [
 	"irc-split",
@@ -406,6 +407,136 @@ const frameGeometry = (key: string, text: string) => {
 	// the painted status row sits one lower than the transcript capacity.
 	return { capacity: statusRow - noticeRows, statusRow, noticeRows };
 };
+// Immutable per-entry anchor expectation. A recomputed digest only proves internal
+// consistency: the producer chooses `frame_start_row` and the geometry, so it can
+// mint a cryptographically valid id for a RELOCATED or TRANSPLANTED anchor. This
+// table is the independent witness. It lives in verifier source, not in the bundle,
+// and this file's own sha256 is inside `source_sha256`, so a bundle author cannot
+// restate it. Geometry was measured identical across indexed-color and truecolor
+// hosts, so pinning it costs no host portability.
+const SEMANTIC_ANCHOR_EXPECTATION: Readonly<
+	Record<string, { frameRow: number; graphemeStart: number; graphemeEnd: number; cellStart: number; cellEnd: number }>
+> = Object.freeze({
+	"live-overflow/80x24/unicode-color": {
+		frameRow: 2,
+		graphemeStart: 0,
+		graphemeEnd: 1638400,
+		cellStart: 0,
+		cellEnd: 1638400,
+	},
+	"live-overflow/120x36/unicode-color": {
+		frameRow: 2,
+		graphemeStart: 0,
+		graphemeEnd: 3276800,
+		cellStart: 0,
+		cellEnd: 3276800,
+	},
+	"manual-history/80x24/unicode-color": {
+		frameRow: 0,
+		graphemeStart: 1638400,
+		graphemeEnd: 3276800,
+		cellStart: 1638400,
+		cellEnd: 3276800,
+	},
+	"manual-history/120x36/unicode-color": {
+		frameRow: 0,
+		graphemeStart: 0,
+		graphemeEnd: 3276800,
+		cellStart: 0,
+		cellEnd: 3276800,
+	},
+	"manual-new-output/80x24/unicode-color": {
+		frameRow: 0,
+		graphemeStart: 1638400,
+		graphemeEnd: 3276800,
+		cellStart: 1638400,
+		cellEnd: 3276800,
+	},
+	"manual-new-output/120x36/unicode-color": {
+		frameRow: 0,
+		graphemeStart: 0,
+		graphemeEnd: 3276800,
+		cellStart: 0,
+		cellEnd: 3276800,
+	},
+	"multiline-editor-hooks-pet/80x24/unicode-color": {
+		frameRow: 3,
+		graphemeStart: 0,
+		graphemeEnd: 1638400,
+		cellStart: 0,
+		cellEnd: 1638400,
+	},
+	"multiline-editor-hooks-pet/120x36/unicode-color": {
+		frameRow: 3,
+		graphemeStart: 0,
+		graphemeEnd: 3276800,
+		cellStart: 0,
+		cellEnd: 3276800,
+	},
+	"capacity-many/80x24/unicode-color": {
+		frameRow: 0,
+		graphemeStart: 1638400,
+		graphemeEnd: 3276800,
+		cellStart: 1638400,
+		cellEnd: 3276800,
+	},
+	"capacity-many/120x36/unicode-color": {
+		frameRow: 0,
+		graphemeStart: 0,
+		graphemeEnd: 3276800,
+		cellStart: 0,
+		cellEnd: 3276800,
+	},
+	"capacity-one/80x24/unicode-color": {
+		frameRow: 0,
+		graphemeStart: 0,
+		graphemeEnd: 1605632,
+		cellStart: 0,
+		cellEnd: 1605632,
+	},
+	"capacity-one/120x36/unicode-color": {
+		frameRow: 0,
+		graphemeStart: 0,
+		graphemeEnd: 3211264,
+		cellStart: 0,
+		cellEnd: 3211264,
+	},
+	"selection-boundary/80x24/unicode-color": {
+		frameRow: 0,
+		graphemeStart: 1638400,
+		graphemeEnd: 3276800,
+		cellStart: 1638400,
+		cellEnd: 3276800,
+	},
+	"selection-boundary/120x36/unicode-color": {
+		frameRow: 0,
+		graphemeStart: 0,
+		graphemeEnd: 3276800,
+		cellStart: 0,
+		cellEnd: 3276800,
+	},
+	"manual-new-output/80x24/ascii-no-color": {
+		frameRow: 0,
+		graphemeStart: 1638400,
+		graphemeEnd: 3276800,
+		cellStart: 1638400,
+		cellEnd: 3276800,
+	},
+	"multiline-editor-hooks-pet/48x10/unicode-color": {
+		frameRow: 0,
+		graphemeStart: 1638400,
+		graphemeEnd: 3276800,
+		cellStart: 1638400,
+		cellEnd: 3276800,
+	},
+	"narrow-cjk/48x10/unicode-color": {
+		frameRow: 3,
+		graphemeStart: 0,
+		graphemeEnd: 589824,
+		cellStart: 0,
+		cellEnd: 589824,
+	},
+});
 // Semantic anchor identity guard. The persisted `semantic_anchor.id` is the only
 // durable handle on WHICH painted row the evidence anchors, so it must be
 // unforgeable rather than merely well-formed. A geometry-only digest failed both
@@ -446,6 +577,18 @@ const verifySemanticAnchor = (
 	const frameRow = anchor.frame_start_row as number;
 	if (graphemeEnd <= graphemeStart || cellEnd <= cellStart)
 		fail(`semantic anchor guard: ${key} geometry span is empty or inverted`);
+	// Independent witness: reject relocation/transplant even when every digest and
+	// provenance field is internally consistent.
+	const expectation = SEMANTIC_ANCHOR_EXPECTATION[key];
+	if (!expectation) fail(`semantic anchor guard: ${key} has no immutable anchor expectation`);
+	if (
+		frameRow !== expectation!.frameRow ||
+		graphemeStart !== expectation!.graphemeStart ||
+		graphemeEnd !== expectation!.graphemeEnd ||
+		cellStart !== expectation!.cellStart ||
+		cellEnd !== expectation!.cellEnd
+	)
+		fail(`semantic anchor guard: ${key} anchor row or geometry does not match its immutable expectation`);
 	// The row text is read from the committed paint, never from metadata, so the id
 	// stays bound to what the artifact actually renders at the recorded row.
 	const rows = text.split("\n");
@@ -455,6 +598,9 @@ const verifySemanticAnchor = (
 		fail(`semantic anchor guard: ${key} row content digest does not match the painted anchor row`);
 	if (anchor.frame_sha256 !== ansiSha256)
 		fail(`semantic anchor guard: ${key} frame digest does not match the committed frame`);
+	const frameTextSha256 = hash(Bun.stripANSI(text));
+	if (anchor.frame_text_sha256 !== frameTextSha256)
+		fail(`semantic anchor guard: ${key} frame text digest does not match the committed paint`);
 	if (semanticAnchorNamespace(id as string) !== namespace)
 		fail(`semantic anchor guard: ${key} id namespace does not match the persisted namespace`);
 	const expected = `${namespace}:${semanticAnchorDigest({
@@ -466,7 +612,7 @@ const verifySemanticAnchor = (
 		cellStart,
 		cellEnd,
 		frameRow,
-		frameSha256: ansiSha256,
+		frameTextSha256,
 	})}`;
 	if (id !== expected) fail(`semantic anchor guard: ${key} id is not the digest of its own persisted inputs`);
 	// No silent aliasing: distinct evidence entries are distinct anchors by

--- a/packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts
+++ b/packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts
@@ -90,26 +90,54 @@ const semanticRootIds = (mode: InteractiveMode) =>
 		if (child === mode.hookWidgetContainerBelow) return "hooks-below";
 		throw new Error("unexpected production root child");
 	});
+// Domain-separated semantic anchor identity. A geometry-only digest is forgeable
+// and aliasing: distinct evidence entries painting different content at the same
+// row/cell offsets collapse onto one id, and an 8-hex truncation is searchable by
+// brute force. The preimage therefore binds the evidence entry key, the painted
+// anchor row text, the COMPLETE geometry (grapheme and cell start AND end plus
+// frameRow), and the committed frame digest, under a versioned domain literal so
+// the digest cannot be repurposed in another context.
+export const SEMANTIC_ANCHOR_DOMAIN = "gjc.sticky-viewport.semantic-anchor.v1";
+// Netstring framing (`<byteLength>:<value>,`). A plain `a:b:c` join is ambiguous
+// as soon as any field may itself contain `:` — which namespaces and painted row
+// text both do — so distinct field tuples could otherwise share a preimage.
+export const semanticAnchorPreimage = (fields: readonly string[]) =>
+	fields.map(field => `${Buffer.byteLength(field)}:${field},`).join("");
+export const semanticAnchorDigest = (input: {
+	entryKey: string;
+	namespace: string;
+	rowText: string;
+	graphemeStart: number;
+	graphemeEnd: number;
+	cellStart: number;
+	cellEnd: number;
+	frameRow: number;
+	frameSha256: string;
+}) =>
+	new Bun.CryptoHasher("sha256")
+		.update(
+			semanticAnchorPreimage([
+				SEMANTIC_ANCHOR_DOMAIN,
+				input.entryKey,
+				input.namespace,
+				input.rowText,
+				String(input.graphemeStart),
+				String(input.graphemeEnd),
+				String(input.cellStart),
+				String(input.cellEnd),
+				String(input.frameRow),
+				input.frameSha256,
+			]),
+		)
+		.digest("hex");
+/** Namespace of a renderer anchor id, i.e. everything before its volatile per-run suffix. */
+export const semanticAnchorNamespace = (id: string) => id.split(":").slice(0, -1).join(":");
 // Every persisted frame must be canonical for its render mode, not just the
 // top-level payload. `metadata.json` is a required manifest artifact, so raw
 // frames here would make the whole bundle host-dependent: theme.ts emits SGR
 // directly and `detectColorMode()` picks truecolor vs indexed `38;5;n` from
 // COLORTERM/TERM. Stripping at the single capture point keeps
 // `visible_empty_irc_frame` and every resize probe byte-identical across hosts.
-const canonicalAnchorId = (anchor: {
-	id: string;
-	graphemeStart: number;
-	graphemeEnd: number;
-	cellStart: number;
-	cellEnd: number;
-}) => {
-	const namespace = anchor.id.split(":").slice(0, -1).join(":");
-	const digest = new Bun.CryptoHasher("sha256")
-		.update(`${anchor.graphemeStart}:${anchor.graphemeEnd}:${anchor.cellStart}:${anchor.cellEnd}`)
-		.digest("hex")
-		.slice(0, 8);
-	return namespace ? `${namespace}:${digest}` : digest;
-};
 const captureFrame = (terminal: VirtualTerminal, renderMode: StickyViewportShowcaseEntry["renderMode"]) => {
 	const raw = terminal.getViewportAnsi();
 	const ansi = renderMode === "ascii-no-color" ? Bun.stripANSI(raw) : raw;
@@ -124,10 +152,25 @@ const captureFrame = (terminal: VirtualTerminal, renderMode: StickyViewportShowc
 async function createMode(entry: StickyViewportShowcaseEntry) {
 	resetSettingsForTest();
 	const dir = TempDir.createSync("@sticky-viewport-");
+	// The default status-line preset paints the `git` and `path` segments into every
+	// frame at >=120 columns. Both are host state, not renderer state: `path` prints
+	// the cwd basename, and `git` prints the branch plus staged/unstaged counts that
+	// `StatusLineComponent` resolves through an async `git status --porcelain` whose
+	// completion races the capture — the same worktree at the same merge state paints
+	// `detached` or `detached +8` depending on which render observes the resolved
+	// promise. `metadata.json` is a required artifact, so that race makes the bundle
+	// digest nondeterministic run-to-run and across hosts. Neither segment carries
+	// sticky-viewport evidence, so the capture pins a deterministic custom preset that
+	// excludes them instead of sampling repository state at all.
+	const statusLineOverrides = {
+		"statusLine.preset": "custom",
+		"statusLine.leftSegments": ["model"],
+		"statusLine.rightSegments": ["session_name"],
+	} as const;
 	await Settings.init({
 		inMemory: true,
 		cwd: dir.path(),
-		overrides: { "startup.quiet": true, "mouse.enabled": true },
+		overrides: { "startup.quiet": true, "mouse.enabled": true, ...statusLineOverrides },
 	});
 	const auth = await AuthStorage.create(":memory:");
 	const registry = new ModelRegistry(auth);
@@ -136,6 +179,9 @@ async function createMode(entry: StickyViewportShowcaseEntry) {
 	const settings = Settings.isolated();
 	settings.set("startup.quiet", true);
 	settings.set("mouse.enabled", true);
+	settings.set("statusLine.preset", statusLineOverrides["statusLine.preset"]);
+	settings.set("statusLine.leftSegments", [...statusLineOverrides["statusLine.leftSegments"]]);
+	settings.set("statusLine.rightSegments", [...statusLineOverrides["statusLine.rightSegments"]]);
 	const session = new AgentSession({
 		agent: new Agent({
 			initialState: { model, systemPrompt: ["Sticky viewport production capture"], tools: [], messages: [] },
@@ -351,6 +397,8 @@ export async function renderStickyViewportShowcase(
 		// persisted ANSI payload and the recorded cursor frame digest — must use this one
 		// value, or the verifier's `cursor.frame_sha256 !== hash(ansi)` check rejects it.
 		const canonicalAnsi = entry.renderMode === "ascii-no-color" ? Bun.stripANSI(retainedFrame) : retainedFrame;
+		const canonicalText = Bun.stripANSI(retainedFrame);
+		const frameSha256 = new Bun.CryptoHasher("sha256").update(canonicalAnsi).digest("hex");
 		const rootOrder = semanticRootIds(mode);
 		const focused = mode.ui.getFocusedComponent();
 		const cursor = observation.cursor;
@@ -359,7 +407,7 @@ export async function renderStickyViewportShowcase(
 		if (anchor === null && observation.transcriptCapacity > 0)
 			throw new Error("renderer produced no visible semantic anchor");
 		return {
-			terminalText: Bun.stripANSI(retainedFrame),
+			terminalText: canonicalText,
 			terminalAnsiText: canonicalAnsi,
 			sourceRevision: "production-tui-virtual-terminal-v3",
 			outputRevision:
@@ -386,7 +434,7 @@ export async function renderStickyViewportShowcase(
 				focused_component: focused === mode.editor && observation.focused ? "editor" : null,
 				cursor: {
 					...cursor,
-					frame_sha256: new Bun.CryptoHasher("sha256").update(canonicalAnsi).digest("hex"),
+					frame_sha256: frameSha256,
 					blink: mode.editor.focused,
 				},
 				selection: observation.selection
@@ -402,17 +450,42 @@ export async function renderStickyViewportShowcase(
 						}
 					: null,
 				semantic_anchor: anchor
-					? {
+					? (() => {
 							// `anchor.id` embeds a per-run session entry id, so persisting it raw
 							// makes the required metadata artifact differ between two captures on
-							// the SAME host. Keep the semantic namespace and replace only the
-							// volatile suffix with a digest of the anchor's own geometry, so the
-							// bundle is reproducible while distinct anchors stay distinguishable.
-							id: canonicalAnchorId(anchor),
-							grapheme_start: anchor.graphemeStart,
-							cell_start: anchor.cellStart,
-							frame_start_row: anchor.frameRow,
-						}
+							// the SAME host. Keep the semantic namespace and replace the volatile
+							// suffix with a domain-separated digest that binds this entry, the
+							// painted anchor row, the complete geometry, and the committed frame —
+							// so the bundle stays reproducible while distinct anchors stay
+							// distinguishable and no id is transplantable to another entry.
+							const rows = canonicalText.split("\n");
+							const rowText = rows[anchor.frameRow];
+							if (rowText === undefined) throw new Error("semantic anchor frame row is outside the paint");
+							const namespace = semanticAnchorNamespace(anchor.id);
+							if (!namespace) throw new Error("semantic anchor id carries no namespace");
+							return {
+								domain: SEMANTIC_ANCHOR_DOMAIN,
+								id: `${namespace}:${semanticAnchorDigest({
+									entryKey: entry.key,
+									namespace,
+									rowText,
+									graphemeStart: anchor.graphemeStart,
+									graphemeEnd: anchor.graphemeEnd,
+									cellStart: anchor.cellStart,
+									cellEnd: anchor.cellEnd,
+									frameRow: anchor.frameRow,
+									frameSha256,
+								})}`,
+								namespace,
+								grapheme_start: anchor.graphemeStart,
+								grapheme_end: anchor.graphemeEnd,
+								cell_start: anchor.cellStart,
+								cell_end: anchor.cellEnd,
+								frame_start_row: anchor.frameRow,
+								row_text_sha256: new Bun.CryptoHasher("sha256").update(rowText).digest("hex"),
+								frame_sha256: frameSha256,
+							};
+						})()
 					: null,
 				cjk_contiguous_semantics: CJK_BOUNDARIES,
 				coverage: STICKY_VIEWPORT_SHOWCASE_COVERAGE,

--- a/packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts
+++ b/packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts
@@ -321,6 +321,15 @@ export async function renderStickyViewportShowcase(
 		const frame = terminal.getViewportAnsi();
 		const pinIndex = mode.ui.children.indexOf(mode.statusLine);
 		const retainedFrame = frame;
+		// `ascii-no-color` must be genuinely escape-free on every host. `chalk.level = 0`
+		// cannot deliver that: theme.ts emits SGR directly (`fgAnsi`/`bgAnsi`) without
+		// consulting chalk, and its color form depends on `detectColorMode()` — truecolor
+		// when COLORTERM=truecolor, indexed `38;5;N` when TERM is dumb/empty/linux (CI).
+		// Stripping here keeps the artifact host-independent instead of encoding whichever
+		// color form the capture host happened to negotiate. Every consumer below — the
+		// persisted ANSI payload and the recorded cursor frame digest — must use this one
+		// value, or the verifier's `cursor.frame_sha256 !== hash(ansi)` check rejects it.
+		const canonicalAnsi = entry.renderMode === "ascii-no-color" ? Bun.stripANSI(retainedFrame) : retainedFrame;
 		const rootOrder = semanticRootIds(mode);
 		const focused = mode.ui.getFocusedComponent();
 		const cursor = observation.cursor;
@@ -330,7 +339,7 @@ export async function renderStickyViewportShowcase(
 			throw new Error("renderer produced no visible semantic anchor");
 		return {
 			terminalText: Bun.stripANSI(retainedFrame),
-			terminalAnsiText: retainedFrame,
+			terminalAnsiText: canonicalAnsi,
 			sourceRevision: "production-tui-virtual-terminal-v3",
 			outputRevision:
 				observation.outputRevision ??
@@ -354,7 +363,11 @@ export async function renderStickyViewportShowcase(
 					pinned: observation.pinBoundary.pinned,
 				},
 				focused_component: focused === mode.editor && observation.focused ? "editor" : null,
-				cursor: { ...cursor, frame_sha256: captureFrame(terminal).sha256, blink: mode.editor.focused },
+				cursor: {
+					...cursor,
+					frame_sha256: new Bun.CryptoHasher("sha256").update(canonicalAnsi).digest("hex"),
+					blink: mode.editor.focused,
+				},
 				selection: observation.selection
 					? {
 							start: {

--- a/packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts
+++ b/packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts
@@ -90,8 +90,29 @@ const semanticRootIds = (mode: InteractiveMode) =>
 		if (child === mode.hookWidgetContainerBelow) return "hooks-below";
 		throw new Error("unexpected production root child");
 	});
-const captureFrame = (terminal: VirtualTerminal) => {
-	const ansi = terminal.getViewportAnsi();
+// Every persisted frame must be canonical for its render mode, not just the
+// top-level payload. `metadata.json` is a required manifest artifact, so raw
+// frames here would make the whole bundle host-dependent: theme.ts emits SGR
+// directly and `detectColorMode()` picks truecolor vs indexed `38;5;n` from
+// COLORTERM/TERM. Stripping at the single capture point keeps
+// `visible_empty_irc_frame` and every resize probe byte-identical across hosts.
+const canonicalAnchorId = (anchor: {
+	id: string;
+	graphemeStart: number;
+	graphemeEnd: number;
+	cellStart: number;
+	cellEnd: number;
+}) => {
+	const namespace = anchor.id.split(":").slice(0, -1).join(":");
+	const digest = new Bun.CryptoHasher("sha256")
+		.update(`${anchor.graphemeStart}:${anchor.graphemeEnd}:${anchor.cellStart}:${anchor.cellEnd}`)
+		.digest("hex")
+		.slice(0, 8);
+	return namespace ? `${namespace}:${digest}` : digest;
+};
+const captureFrame = (terminal: VirtualTerminal, renderMode: StickyViewportShowcaseEntry["renderMode"]) => {
+	const raw = terminal.getViewportAnsi();
+	const ansi = renderMode === "ascii-no-color" ? Bun.stripANSI(raw) : raw;
 	return {
 		ansi,
 		text: Bun.stripANSI(ansi),
@@ -216,7 +237,7 @@ export async function renderStickyViewportShowcase(
 		mode.ircLedger.reset();
 		mode.ui.requestResizeRender();
 		await terminal.waitForRender();
-		const visibleEmptyIrcFrame = captureFrame(terminal);
+		const visibleEmptyIrcFrame = captureFrame(terminal, entry.renderMode);
 		for (const probe of PROBES) {
 			terminal.resize(probe.columns, probe.rows);
 			mode.ircLedger.reset();
@@ -256,7 +277,7 @@ export async function renderStickyViewportShowcase(
 				);
 			mode.ui.requestResizeRender();
 			await terminal.waitForRender();
-			const frame = captureFrame(terminal);
+			const frame = captureFrame(terminal, entry.renderMode);
 			const sidebarVisible = probe.columns >= 65;
 			const layout = computeIrcWorkLaneWidths(probe.columns, sidebarVisible);
 			resizeProbes.push({
@@ -382,7 +403,12 @@ export async function renderStickyViewportShowcase(
 					: null,
 				semantic_anchor: anchor
 					? {
-							id: anchor.id,
+							// `anchor.id` embeds a per-run session entry id, so persisting it raw
+							// makes the required metadata artifact differ between two captures on
+							// the SAME host. Keep the semantic namespace and replace only the
+							// volatile suffix with a digest of the anchor's own geometry, so the
+							// bundle is reproducible while distinct anchors stay distinguishable.
+							id: canonicalAnchorId(anchor),
 							grapheme_start: anchor.graphemeStart,
 							cell_start: anchor.cellStart,
 							frame_start_row: anchor.frameRow,

--- a/packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts
+++ b/packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts
@@ -112,7 +112,7 @@ export const semanticAnchorDigest = (input: {
 	cellStart: number;
 	cellEnd: number;
 	frameRow: number;
-	frameSha256: string;
+	frameTextSha256: string;
 }) =>
 	new Bun.CryptoHasher("sha256")
 		.update(
@@ -126,7 +126,7 @@ export const semanticAnchorDigest = (input: {
 				String(input.cellStart),
 				String(input.cellEnd),
 				String(input.frameRow),
-				input.frameSha256,
+				input.frameTextSha256,
 			]),
 		)
 		.digest("hex");
@@ -461,6 +461,13 @@ export async function renderStickyViewportShowcase(
 							const rows = canonicalText.split("\n");
 							const rowText = rows[anchor.frameRow];
 							if (rowText === undefined) throw new Error("semantic anchor frame row is outside the paint");
+							// Semantic identity must not move with the host's color encoding. The
+							// ANSI frame digest differs between indexed and truecolor hosts while the
+							// stripped paint is identical, so the preimage binds the stripped text and
+							// `frame_sha256` stays as a separate artifact-binding field.
+							const frameTextSha256 = new Bun.CryptoHasher("sha256")
+								.update(Bun.stripANSI(canonicalText))
+								.digest("hex");
 							const namespace = semanticAnchorNamespace(anchor.id);
 							if (!namespace) throw new Error("semantic anchor id carries no namespace");
 							return {
@@ -474,7 +481,7 @@ export async function renderStickyViewportShowcase(
 									cellStart: anchor.cellStart,
 									cellEnd: anchor.cellEnd,
 									frameRow: anchor.frameRow,
-									frameSha256,
+									frameTextSha256: frameTextSha256,
 								})}`,
 								namespace,
 								grapheme_start: anchor.graphemeStart,
@@ -484,6 +491,7 @@ export async function renderStickyViewportShowcase(
 								frame_start_row: anchor.frameRow,
 								row_text_sha256: new Bun.CryptoHasher("sha256").update(rowText).digest("hex"),
 								frame_sha256: frameSha256,
+								frame_text_sha256: frameTextSha256,
 							};
 						})()
 					: null,

--- a/packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts
+++ b/packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts
@@ -1,8 +1,16 @@
-import { Container, Text, TUI } from "@gajae-code/tui";
+import { Agent } from "@gajae-code/agent-core";
+import { Text } from "@gajae-code/tui";
+import { TempDir } from "@gajae-code/utils";
 import chalk from "chalk";
 import { VirtualTerminal } from "../../../../tui/test/virtual-terminal";
-import { CustomEditor } from "../../../src/modes/components/custom-editor";
-import { getEditorTheme, initTheme, theme } from "../../../src/modes/theme/theme";
+import { ModelRegistry } from "../../../src/config/model-registry";
+import { resetSettingsForTest, Settings } from "../../../src/config/settings";
+import { computeIrcWorkLaneWidths } from "../../../src/modes/components/irc-sidebar";
+import { InteractiveMode } from "../../../src/modes/interactive-mode";
+import { initTheme } from "../../../src/modes/theme/theme";
+import { AgentSession } from "../../../src/session/agent-session";
+import { AuthStorage } from "../../../src/session/auth-storage";
+import { SessionManager } from "../../../src/session/session-manager";
 
 export const STICKY_VIEWPORT_SHOWCASE_KEYS = [
 	"live-overflow/80x24/unicode-color",
@@ -41,161 +49,338 @@ export type StickyViewportShowcaseRender = {
 	cjkPhraseBoundaries: readonly string[];
 	state: Record<string, unknown>;
 };
-
 export const STICKY_VIEWPORT_SHOWCASE_ENTRIES: readonly StickyViewportShowcaseEntry[] =
 	STICKY_VIEWPORT_SHOWCASE_KEYS.map(key => {
 		const [stateId, id, renderMode] = key.split("/") as [string, string, "unicode-color" | "ascii-no-color"];
 		const [columns, rows] = id.split("x").map(Number) as [number, number];
 		return { key, stateId, viewport: { id, columns, rows }, renderMode };
 	});
-
-const transcriptCapacityFromFrame = (frame: string) => {
-	const rows = Bun.stripANSI(frame).split("\n");
-	const statusRow = rows.findIndex(row => row.includes("status:"));
-	if (statusRow < 0) throw new Error("Pinned status row was not rendered");
-	return statusRow;
+export const STICKY_VIEWPORT_SHOWCASE_COVERAGE = {
+	irc: ["empty", "streaming", "long"],
+	todo: ["empty", "populated", "long", "multi-phase", "collapsed", "expanded"],
+	widths: [64, 65, 80, 120, 160, 120, 80, 65, 64],
+	heights: ["short", "standard"],
+	viewport: ["manual", "follow", "resize-grow", "resize-shrink"],
+	chrome: ["pending", "statusContainer", "btw", "statusLine", "hooks", "editor", "pet"],
+	evidence: ["overlap", "width-overflow", "hidden-cursor-focus", "anchor-loss", "cjk-semantic-break"],
+} as const;
+const PROBES = [
+	{ columns: 64, rows: 10 },
+	{ columns: 65, rows: 10 },
+	{ columns: 80, rows: 24 },
+	{ columns: 120, rows: 36 },
+	{ columns: 160, rows: 48 },
+	{ columns: 120, rows: 36 },
+	{ columns: 80, rows: 24 },
+	{ columns: 65, rows: 10 },
+	{ columns: 64, rows: 10 },
+] as const;
+const CJK_BOUNDARIES = ["의미 있는 문장 경계", "意味のある文の境界", "保留语义短语边界"] as const;
+const semanticRootIds = (mode: InteractiveMode) =>
+	mode.ui.children.map(child => {
+		if (child === mode.ui.getViewportAnchorComponent()) return "irc-split";
+		if (child === mode.pendingMessagesContainer) return "pending-messages";
+		if (child === mode.statusContainer) return "status-container";
+		if (child === mode.todoContainer) return "todos";
+		if (child === mode.btwContainer) return "btw";
+		if (child === mode.statusLine) return "status-line";
+		if (child === mode.hookWidgetContainerAbove) return "hooks-above";
+		if (child === mode.editorContainer) return "editor-container";
+		if (child === mode.petFloorContainer) return "pet-floor";
+		if (child === mode.hookWidgetContainerBelow) return "hooks-below";
+		throw new Error("unexpected production root child");
+	});
+const captureFrame = (terminal: VirtualTerminal) => {
+	const ansi = terminal.getViewportAnsi();
+	return {
+		ansi,
+		text: Bun.stripANSI(ansi),
+		sha256: new Bun.CryptoHasher("sha256").update(ansi).digest("hex"),
+	};
 };
 
-const CJK_BOUNDARIES = ["의미 있는 문장 경계", "意味のある文の境界", "保留语义短语边界"] as const;
+/** Production InteractiveMode assembly with its ProcessTerminal replaced by the first-party VirtualTerminal test transport before startup. */
+async function createMode(entry: StickyViewportShowcaseEntry) {
+	resetSettingsForTest();
+	const dir = TempDir.createSync("@sticky-viewport-");
+	await Settings.init({
+		inMemory: true,
+		cwd: dir.path(),
+		overrides: { "startup.quiet": true, "mouse.enabled": true },
+	});
+	const auth = await AuthStorage.create(":memory:");
+	const registry = new ModelRegistry(auth);
+	const model = registry.find("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("production model fixture unavailable");
+	const settings = Settings.isolated();
+	settings.set("startup.quiet", true);
+	settings.set("mouse.enabled", true);
+	const session = new AgentSession({
+		agent: new Agent({
+			initialState: { model, systemPrompt: ["Sticky viewport production capture"], tools: [], messages: [] },
+		}),
+		sessionManager: SessionManager.create(dir.path(), dir.path()),
+		settings,
+		modelRegistry: registry,
+	});
+	const mode = new InteractiveMode(session, "sticky-viewport", undefined, undefined, undefined, undefined, undefined, {
+		platform: process.platform === "darwin" ? "win32" : "darwin",
+	});
+	const terminal = new VirtualTerminal(entry.viewport.columns, entry.viewport.rows, { isProcessTerminal: true });
+	// TUI owns the transport through this public runtime field; replacing it before start preserves the real root assembly.
+	(mode.ui as unknown as { terminal: VirtualTerminal }).terminal = terminal;
+	return {
+		mode,
+		terminal,
+		async dispose() {
+			mode.stop();
+			await session.dispose();
+			auth.close();
+			await dir.remove();
+			resetSettingsForTest();
+		},
+	};
+}
 
-/** Fixed-clock, no-network harness which captures a live production TUI VirtualTerminal frame. */
 export async function renderStickyViewportShowcase(
 	entry: StickyViewportShowcaseEntry,
 ): Promise<StickyViewportShowcaseRender> {
 	const oldLevel = chalk.level;
 	chalk.level = entry.renderMode === "ascii-no-color" ? 0 : 3;
 	await initTheme(false, entry.renderMode === "ascii-no-color" ? "ascii" : "unicode", false, "red-claw", "red-claw");
-	const terminal = new VirtualTerminal(entry.viewport.columns, entry.viewport.rows, { isProcessTerminal: true });
-	const copied: string[] = [];
-	const ui = new TUI(terminal, undefined, {
-		enableMouse: true,
-		copySelection: text => {
-			copied.push(text);
-		},
-	});
-	const transcript = new Container();
-	const status = new Container();
-	const hooks = new Container();
-	const editor = new CustomEditor(getEditorTheme());
+	const harness = await createMode(entry);
+	const { mode, terminal } = harness;
 	try {
-		for (let index = 0; index < 40; index += 1)
-			transcript.addChild(new Text(`assistant ${index}: transcript output remains selectable`, 0, 0));
+		for (let i = 0; i < (entry.stateId === "narrow-cjk" ? 3 : 48); i++) {
+			harness.mode.sessionManager.appendMessage({
+				role: "user",
+				content: `assistant ${i}: transcript output remains selectable`,
+				timestamp: i,
+			});
+		}
 		if (entry.stateId === "narrow-cjk") {
-			transcript.addChild(new Text(`Korean: ${CJK_BOUNDARIES[0]} mixed LatinOverflowToken`, 0, 0));
-			transcript.addChild(new Text(`Japanese: ${CJK_BOUNDARIES[1]} mixed LatinOverflowToken`, 0, 0));
-			transcript.addChild(new Text(`Chinese: ${CJK_BOUNDARIES[2]} mixed LatinOverflowToken`, 0, 0));
-		}
-		status.addChild(
-			new Text(
-				entry.stateId === "live-overflow" ? "status: live follow" : "status: manual history · composer pinned",
-				0,
-				0,
-			),
-		);
-		if (entry.stateId === "multiline-editor-hooks-pet") {
-			hooks.addChild(new Text("hook: ready", 0, 0));
-			hooks.addChild(new Text(theme.strikethrough("completed: visual proof"), 0, 0));
-			hooks.addChild(new Text("pet: ◕‿◕", 0, 0));
-			editor.setText("first composer line\nsecond composer line");
-		}
-		editor.setBorderVisible(true);
-		editor.setClosedBorderBox(true);
-		editor.setInputPrefix(theme.fg("accent", "> "));
-		editor.setPlaceholder("Ask about this transcript");
-		if (entry.stateId === "capacity-one" || entry.stateId === "capacity-zero") {
-			const targetCapacity = entry.stateId === "capacity-one" ? 1 : 0;
-			const suffixRows = status.render(entry.viewport.columns).length + editor.render(entry.viewport.columns).length;
-			const hookRows = entry.viewport.rows - targetCapacity - suffixRows;
-			if (hookRows < 0) throw new Error(`${entry.key}: focused suffix exceeds constrained viewport`);
-			for (let row = 0; row < hookRows; row += 1) hooks.addChild(new Text(`hook capacity row ${row}`, 0, 0));
-		}
-		ui.addChild(transcript);
-		ui.setViewportAnchorComponent(transcript);
-		ui.addChild(status);
-		ui.addChild(hooks);
-		ui.addChild(editor);
-		ui.setBottomPinnedComponent(status);
-		ui.setFocus(editor);
-		ui.setViewportOutputSource({ identity: "sticky-viewport-showcase", revision: 0n });
-		ui.start();
-		await terminal.waitForRender();
-		let historicalTranscriptRows: string[] = [];
-		let manualPreOutputCapacity = 0;
-		const manual = entry.stateId !== "live-overflow";
-		if (manual) {
-			const wheelMoved = ui.scrollViewportBy(-3, { pin: "stable" }); // production wheel step
-			const pageUpMoved = ui.scrollViewportPages(-1); // production PageUp path
-			if (!wheelMoved || !pageUpMoved)
-				throw new Error(`${entry.key}: manual wheel/PageUp did not move the viewport`);
-			if (entry.stateId === "narrow-cjk") ui.scrollViewportBy(entry.viewport.rows, { pin: "edge" });
-			await terminal.waitForRender();
-			const preOutputFrame = terminal.getViewportAnsi();
-			const preOutputRows = Bun.stripANSI(preOutputFrame).split("\n");
-			const preOutputCapacity = transcriptCapacityFromFrame(preOutputFrame);
-			manualPreOutputCapacity = preOutputCapacity;
-			if (preOutputCapacity > 0) {
-				const semanticRow = preOutputRows.slice(0, preOutputCapacity).find(row => row.trim());
-				if (!semanticRow) throw new Error(`${entry.key}: manual frame has no semantic transcript evidence`);
-				historicalTranscriptRows = [semanticRow];
+			for (const phrase of CJK_BOUNDARIES) {
+				harness.mode.sessionManager.appendMessage({
+					role: "user",
+					content: phrase,
+					timestamp: 100 + phrase.length,
+				});
 			}
 		}
+		mode.rebuildChatFromMessages("replace-identity");
+		mode.settings.set("irc.enabled", true);
+		mode.settings.set("irc.sidebar.enabled", true);
+		mode.applyIrcSidebarAvailability(true);
+		mode.toggleIrcSidebar();
+		mode.pendingMessagesContainer.addChild(new Text("pending: queued composer input", 0, 0));
+		mode.statusContainer.addChild(new Text("statusContainer: rendering production assembly", 0, 0));
+		mode.btwContainer.addChild(new Text("BTW: production viewport evidence", 0, 0));
+		mode.hookWidgetContainerAbove.addChild(new Text("hook: ready", 0, 0));
+		const capacityReservation =
+			entry.stateId === "capacity-one"
+				? Math.max(0, entry.viewport.rows - 6)
+				: entry.stateId === "capacity-zero"
+					? Math.max(0, entry.viewport.rows - 5)
+					: 0;
+		if (capacityReservation > 0) {
+			mode.hookWidgetContainerBelow.addChild(
+				new Text(
+					Array.from({ length: capacityReservation }, (_, index) => `reserved suffix row ${index + 1}`).join("\n"),
+					0,
+					0,
+				),
+			);
+		}
+		const editorText =
+			entry.stateId === "multiline-editor-hooks-pet"
+				? "first composer line\nsecond composer line"
+				: entry.stateId === "capacity-many"
+					? "capacity-many composer"
+					: entry.stateId === "capacity-one"
+						? "capacity-one composer"
+						: entry.stateId === "capacity-zero"
+							? "capacity-zero composer"
+							: entry.stateId === "selection-boundary"
+								? "selection-boundary composer"
+								: entry.stateId === "manual-history"
+									? "manual-history composer"
+									: "capture cursor";
+		mode.editor.setText(editorText);
+		mode.editor.setUseTerminalCursor(true);
+		await mode.init();
+		mode.ui.setFocus(mode.editor);
+		mode.ui.requestRender(true);
 		await terminal.waitForRender();
+		const resizeProbes: Record<string, unknown>[] = [];
+		terminal.resize(80, 24);
+		mode.ircLedger.reset();
+		mode.ui.requestResizeRender();
+		await terminal.waitForRender();
+		const visibleEmptyIrcFrame = captureFrame(terminal);
+		for (const probe of PROBES) {
+			terminal.resize(probe.columns, probe.rows);
+			mode.ircLedger.reset();
+			mode.setTodos(
+				probe.columns === 64
+					? []
+					: ([
+							{
+								name: "triage",
+								tasks: [
+									{ content: "verify production todo", status: "completed" },
+									{ content: "expanded production todo", status: "in_progress" },
+								],
+							},
+							{
+								name: "implementation",
+								tasks: [{ content: "long todo 混合日本語 mixed Latin", status: "pending" }],
+							},
+						] as never),
+			);
+			if (probe.columns >= 80 && !mode.todoExpanded) mode.toggleTodoExpansion();
+			if (probe.columns === 65 && mode.todoExpanded) mode.toggleTodoExpansion();
+			if (probe.columns >= 65)
+				mode.ircLedger.observe(
+					{
+						observationId: `${entry.key}-${probe.columns}-${resizeProbes.length}`,
+						kind: "incoming",
+						from: "worker",
+						to: "you",
+						text:
+							probe.columns >= 80
+								? "long IRC observation 混合日本語 mixed Latin ".repeat(8)
+								: "streaming IRC observation 混合日本語",
+						timestamp: 1,
+					},
+					true,
+				);
+			mode.ui.requestResizeRender();
+			await terminal.waitForRender();
+			const frame = captureFrame(terminal);
+			const sidebarVisible = probe.columns >= 65;
+			const layout = computeIrcWorkLaneWidths(probe.columns, sidebarVisible);
+			resizeProbes.push({
+				columns: probe.columns,
+				rows: probe.rows,
+				effective_lane: sidebarVisible ? "split" : "transcript",
+				left_width: layout.leftWidth,
+				right_width: layout.rightWidth,
+				separator_width: layout.separatorWidth,
+				irc_records: mode.ircLedger.getSidebarRecords().length,
+				todo_rows: mode.todoContainer.children.length,
+				todo_expanded: mode.todoExpanded,
+				frame,
+			});
+		}
+		terminal.resize(entry.viewport.columns, entry.viewport.rows);
+		mode.ui.requestResizeRender();
+		await terminal.waitForRender();
+		if (entry.stateId === "capacity-one") {
+			const anchor = mode.ui.getViewportAnchorSnapshot()?.anchors.find(candidate => candidate !== null);
+			if (!anchor || !mode.ui.revealViewportAnchor(anchor.id, "top"))
+				throw new Error("capacity-one anchor unavailable");
+			await terminal.waitForRender();
+		} else if (entry.stateId !== "live-overflow" && entry.stateId !== "capacity-zero") {
+			mode.ui.scrollViewportBy(-3, { pin: "stable" });
+			mode.ui.scrollViewportPages(-1);
+		}
 		if (entry.stateId === "manual-new-output") {
-			transcript.addChild(new Text("agent output after manual scroll", 0, 0));
-			ui.setViewportOutputSource({ identity: "sticky-viewport-showcase", revision: 1n });
+			mode.chatContainer.addChild(new Text("agent output after manual scroll", 0, 0));
+			mode.recordVisibleTranscriptMutation();
 		}
 		if (entry.stateId === "selection-boundary") {
-			const transcriptRows = transcriptCapacityFromFrame(`${terminal.getViewport().join("\n")}\n`);
-			if (transcriptRows < 1) throw new Error(`${entry.key}: selection has no transcript row`);
-			terminal.sendInput("\x1b[<0;1;1M");
-			terminal.sendInput("\x1b[<32;40;1M");
-			terminal.sendInput(`\x1b[<32;40;${Math.min(entry.viewport.rows, transcriptRows + 2)}M`);
-			terminal.sendInput(`\x1b[<0;40;${Math.min(entry.viewport.rows, transcriptRows + 2)}m`);
+			mode.ui.requestRender(true);
 			await terminal.waitForRender();
-			if (
-				copied.length !== 1 ||
-				!copied[0]?.includes("assistant") ||
-				copied[0].includes("status:") ||
-				copied[0].includes("> ")
-			)
-				throw new Error(`${entry.key}: mouse copy crossed pinned chrome`);
+			const beforeSelection = mode.ui.getViewportObservation();
+			if (!beforeSelection || beforeSelection.transcriptCapacity < 2)
+				throw new Error("selection boundary lacks two painted transcript rows");
+			mode.ui.setViewportSelection(
+				{ line: beforeSelection.transcriptCapacity - 1, column: 1 },
+				{ line: beforeSelection.transcriptCapacity, column: 17 },
+			);
+			await terminal.waitForRender();
+			if (mode.ui.getViewportObservation()?.selection !== null)
+				throw new Error("selection crossed into the pinned row");
+			mode.ui.setViewportSelection(
+				{ line: beforeSelection.transcriptCapacity - 2, column: 1 },
+				{ line: beforeSelection.transcriptCapacity - 1, column: 17 },
+			);
 		}
-		ui.requestRender();
+		mode.ui.requestRender(true);
 		await terminal.waitForRender();
+		let observation = mode.ui.getViewportObservation();
+		if (!observation) throw new Error("renderer produced no viewport observation");
+		if (observation.semanticAnchor === null && observation.transcriptCapacity > 0) {
+			const anchor = mode.ui.getViewportAnchorSnapshot()?.anchors.find(candidate => candidate !== null);
+			if (!anchor || !mode.ui.revealViewportAnchor(anchor.id, "top"))
+				throw new Error("renderer produced no visible semantic anchor");
+			await terminal.waitForRender();
+			observation = mode.ui.getViewportObservation();
+			if (!observation) throw new Error("renderer produced no viewport observation");
+		}
 		const frame = terminal.getViewportAnsi();
-		if (manual && historicalTranscriptRows.some(row => !Bun.stripANSI(frame).split("\n").includes(row)))
-			throw new Error(`${entry.key}: manual transcript evidence was not preserved after rerender`);
-		const capacity = transcriptCapacityFromFrame(frame);
-		const cjkPhraseBoundaries = CJK_BOUNDARIES.filter(boundary => Bun.stripANSI(frame).includes(boundary));
-		if (entry.stateId === "manual-new-output" && !Bun.stripANSI(frame).includes("New output — type to follow"))
-			throw new Error(`${entry.key}: source revision did not paint the manual output notice`);
-		if (entry.stateId === "narrow-cjk" && cjkPhraseBoundaries.length !== CJK_BOUNDARIES.length)
-			throw new Error(`${entry.key}: CJK phrase boundaries were not visible in the wrapped terminal frame`);
-		if (entry.stateId === "capacity-one" && capacity !== 1)
-			throw new Error(`${entry.key}: expected one transcript row, rendered ${capacity}`);
-		if (entry.stateId === "capacity-zero" && capacity !== 0)
-			throw new Error(`${entry.key}: expected zero transcript rows, rendered ${capacity}`);
-		if (entry.stateId === "capacity-many" && capacity < 2)
-			throw new Error(`${entry.key}: expected multiple transcript rows, rendered ${capacity}`);
+		const pinIndex = mode.ui.children.indexOf(mode.statusLine);
+		const retainedFrame = frame;
+		const rootOrder = semanticRootIds(mode);
+		const focused = mode.ui.getFocusedComponent();
+		const cursor = observation.cursor;
+		const anchor = observation.semanticAnchor;
+		if (cursor === null) throw new Error("renderer produced no editor cursor");
+		if (anchor === null && observation.transcriptCapacity > 0)
+			throw new Error("renderer produced no visible semantic anchor");
 		return {
-			terminalText: Bun.stripANSI(frame),
-			terminalAnsiText: entry.renderMode === "ascii-no-color" ? Bun.stripANSI(frame) : frame,
-			sourceRevision: "production-tui-virtual-terminal-v2",
-			outputRevision: entry.stateId === "manual-new-output" ? "1" : "0",
-			cjkPhraseBoundaries,
+			terminalText: Bun.stripANSI(retainedFrame),
+			terminalAnsiText: retainedFrame,
+			sourceRevision: "production-tui-virtual-terminal-v3",
+			outputRevision:
+				observation.outputRevision ??
+				(() => {
+					throw new Error("renderer produced no output revision");
+				})(),
+			cjkPhraseBoundaries: entry.stateId === "narrow-cjk" ? CJK_BOUNDARIES : [],
 			state: {
-				manual,
-				notice: entry.stateId === "manual-new-output",
-				transcript_capacity: capacity,
-				manual_pre_output_capacity: manualPreOutputCapacity,
-				manual_historical_rows: historicalTranscriptRows,
-				selection_scope: entry.stateId === "selection-boundary" ? "transcript" : "none",
-				selection_copied_text: entry.stateId === "selection-boundary" ? copied[0] : "",
-				composer_visible: Bun.stripANSI(frame).includes("> "),
+				manual: observation.manualHistory,
+				notice: observation.newOutputNoticeVisible,
+				observed_output_revision: observation.outputRevision,
+				transcript_capacity: observation.transcriptCapacity,
+				composer_visible: focused === mode.editor,
+				resize_probes: resizeProbes,
+				visible_empty_irc_frame: visibleEmptyIrcFrame,
+				root_order: rootOrder,
+				pin_boundary: {
+					component: "status-line",
+					index: pinIndex,
+					row: observation.pinBoundary.row,
+					pinned: observation.pinBoundary.pinned,
+				},
+				focused_component: focused === mode.editor && observation.focused ? "editor" : null,
+				cursor: { ...cursor, frame_sha256: captureFrame(terminal).sha256, blink: mode.editor.focused },
+				selection: observation.selection
+					? {
+							start: {
+								row: observation.selection.start.line,
+								col: observation.selection.start.column,
+							},
+							end: {
+								row: observation.selection.end.line,
+								col: observation.selection.end.column,
+							},
+						}
+					: null,
+				semantic_anchor: anchor
+					? {
+							id: anchor.id,
+							grapheme_start: anchor.graphemeStart,
+							cell_start: anchor.cellStart,
+							frame_start_row: anchor.frameRow,
+						}
+					: null,
+				cjk_contiguous_semantics: CJK_BOUNDARIES,
+				coverage: STICKY_VIEWPORT_SHOWCASE_COVERAGE,
 			},
 		};
 	} finally {
-		ui.stop();
+		await harness.dispose();
 		chalk.level = oldLevel;
 	}
 }

--- a/packages/coding-agent/test/sticky-viewport-showcase.test.ts
+++ b/packages/coding-agent/test/sticky-viewport-showcase.test.ts
@@ -290,7 +290,22 @@ describe("sticky viewport production evidence verifier", () => {
 		capacityMetadata.state.transcript_capacity = 2;
 		await Bun.write(capacityMetadataPath, `${JSON.stringify(capacityMetadata, null, 2)}\n`);
 		await rehash(capacityRoot, capacityKey, "metadata.json");
-		await expect(verifyStickyViewportShowcase(capacityRoot)).rejects.toThrow("runtime observation mismatch");
+		// The frame-derived capacity oracle rejects this before the downstream
+		// observation check, because the painted status row contradicts the claim.
+		await expect(verifyStickyViewportShowcase(capacityRoot)).rejects.toThrow("capacity metadata/frame mismatch");
+
+		// `pin_boundary.row` is assigned from the same renderer local as
+		// `transcript_capacity`, so mutating it alone is only detectable against the
+		// committed paint. This case fails if that assertion ever becomes tautological.
+		const pinRoot = await cloneBase();
+		const pinKey = "capacity-one/80x24/unicode-color";
+		const pinMetadataPath = path.join(pinRoot, pinKey, "metadata.json");
+		const pinMetadata = JSON.parse(await fs.readFile(pinMetadataPath, "utf8"));
+		pinMetadata.state.pin_boundary.row = (pinMetadata.state.pin_boundary.row as number) + 1;
+		pinMetadata.state.transcript_capacity = pinMetadata.state.pin_boundary.row;
+		await Bun.write(pinMetadataPath, `${JSON.stringify(pinMetadata, null, 2)}\n`);
+		await rehash(pinRoot, pinKey, "metadata.json");
+		await expect(verifyStickyViewportShowcase(pinRoot)).rejects.toThrow("capacity metadata/frame mismatch");
 
 		const cjkRoot = await cloneBase();
 		const cjkKey = "narrow-cjk/48x10/unicode-color";

--- a/packages/coding-agent/test/sticky-viewport-showcase.test.ts
+++ b/packages/coding-agent/test/sticky-viewport-showcase.test.ts
@@ -6,6 +6,7 @@ import { VirtualTerminal } from "../../tui/test/virtual-terminal";
 import {
 	ansiToHtml,
 	captureProvenance,
+	committedBlobSha256,
 	PROVENANCE_DIFF_SCOPE,
 	xterm256Color,
 } from "../scripts/capture-sticky-viewport-showcase";
@@ -1032,5 +1033,22 @@ describe("sticky viewport production evidence verifier", () => {
 		// proves the rejection was the oracle mutation and not incidental staleness.
 		await restampProvenance(root);
 		await verifyStickyViewportShowcase(root);
+	}, 300_000);
+	it("accepts an oracle absent from the base commit but present in a reachable commit", async () => {
+		// The review protocol verifies an UNCOMMITTED synthetic merge: `HEAD` is the
+		// current-dev base while the running oracle is the staged PR version. A gate
+		// that only compares against the base blob rejects that honest shape before any
+		// evidence guard runs. The trust boundary is therefore "these exact bytes are
+		// committed somewhere reachable", which an uncommitted mutation cannot satisfy.
+		const oracle = "packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts";
+		const running = new Bun.CryptoHasher("sha256")
+			.update(await fs.readFile(path.resolve(import.meta.dir, "../scripts/verify-sticky-viewport-showcase.ts")))
+			.digest("hex");
+		// The parent commit is a stand-in for the synthetic-merge base. This branch
+		// changed the oracle, so the parent's blob differs from the running bytes.
+		const parent = await committedBlobSha256("HEAD~1", oracle);
+		expect(parent).not.toBe(running);
+		// Acceptance therefore cannot be coming from the base blob.
+		await verifyStickyViewportShowcase(await capture());
 	}, 300_000);
 });

--- a/packages/coding-agent/test/sticky-viewport-showcase.test.ts
+++ b/packages/coding-agent/test/sticky-viewport-showcase.test.ts
@@ -1034,7 +1034,55 @@ describe("sticky viewport production evidence verifier", () => {
 		await restampProvenance(root);
 		await verifyStickyViewportShowcase(root);
 	}, 300_000);
-	it("accepts an oracle absent from the base commit but present in a reachable commit", async () => {
+	it("rejects oracle bytes authorized only by an unrelated local or remote-tracking ref", async () => {
+		// `--all` reachability proves a commit exists somewhere, not that it is the
+		// commit under review. Committing malicious oracle bytes on any side ref must
+		// not authorize them, with or without an explicit trusted authority.
+		const root = await capture();
+		const oracle = "packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts";
+		const original = await fs.readFile(oracle, "utf8");
+		const index = path.join(os.tmpdir(), `gjc-attacker-index-${Date.now()}`);
+		const refs = ["refs/heads/gjc-test-attacker-ref", "refs/remotes/origin/gjc-test-attacker-ref"];
+		const git = async (args: string[], stdin?: string) => {
+			const proc = Bun.spawn(["git", ...args], {
+				stdout: "pipe",
+				stderr: "pipe",
+				stdin: stdin === undefined ? "ignore" : new TextEncoder().encode(stdin),
+				env: { ...process.env, GIT_INDEX_FILE: index },
+			});
+			const out = await new Response(proc.stdout).text();
+			if ((await proc.exited) !== 0) throw new Error(`git ${args[0]}: ${await new Response(proc.stderr).text()}`);
+			return out.trim();
+		};
+		try {
+			const malicious = `${original}\n// attacker-authorized bytes\n`;
+			const blob = await git(["hash-object", "-w", "--stdin"], malicious);
+			await git(["read-tree", "HEAD"]);
+			await git(["update-index", "--add", "--cacheinfo", `100644,${blob},${oracle}`]);
+			const tree = await git(["write-tree"]);
+			const commit = await git(["commit-tree", tree, "-p", "HEAD", "-m", "attacker oracle"]);
+			for (const ref of refs) await git(["update-ref", ref, commit]);
+			// The malicious bytes are now reachable from two side refs and are what the
+			// verifier would actually execute.
+			await Bun.write(oracle, malicious);
+			await restampProvenance(root);
+			await expect(verifyStickyViewportShowcase(root)).rejects.toThrow("oracle integrity");
+			process.env.GJC_STICKY_VIEWPORT_ORACLE_COMMIT = await git(["rev-parse", "HEAD"]);
+			try {
+				await restampProvenance(root);
+				await expect(verifyStickyViewportShowcase(root)).rejects.toThrow("oracle integrity");
+			} finally {
+				delete process.env.GJC_STICKY_VIEWPORT_ORACLE_COMMIT;
+			}
+		} finally {
+			await Bun.write(oracle, original);
+			for (const ref of refs) {
+				Bun.spawnSync(["git", "update-ref", "-d", ref], { stdout: "ignore", stderr: "ignore" });
+			}
+			await fs.rm(index, { force: true });
+		}
+	}, 300_000);
+	it("requires the declared oracle authority to carry the running oracle bytes", async () => {
 		// The review protocol verifies an UNCOMMITTED synthetic merge: `HEAD` is the
 		// current-dev base while the running oracle is the staged PR version. A gate
 		// that only compares against the base blob rejects that honest shape before any

--- a/packages/coding-agent/test/sticky-viewport-showcase.test.ts
+++ b/packages/coding-agent/test/sticky-viewport-showcase.test.ts
@@ -1048,7 +1048,16 @@ describe("sticky viewport production evidence verifier", () => {
 				stdout: "pipe",
 				stderr: "pipe",
 				stdin: stdin === undefined ? "ignore" : new TextEncoder().encode(stdin),
-				env: { ...process.env, GIT_INDEX_FILE: index },
+				// CI runners have no git identity, and `commit-tree` requires one. Supply it
+				// through env so the test never mutates repository or global git config.
+				env: {
+					...process.env,
+					GIT_INDEX_FILE: index,
+					GIT_AUTHOR_NAME: "gjc-test",
+					GIT_AUTHOR_EMAIL: "gjc-test@example.invalid",
+					GIT_COMMITTER_NAME: "gjc-test",
+					GIT_COMMITTER_EMAIL: "gjc-test@example.invalid",
+				},
 			});
 			const out = await new Response(proc.stdout).text();
 			if ((await proc.exited) !== 0) throw new Error(`git ${args[0]}: ${await new Response(proc.stderr).text()}`);

--- a/packages/coding-agent/test/sticky-viewport-showcase.test.ts
+++ b/packages/coding-agent/test/sticky-viewport-showcase.test.ts
@@ -1005,4 +1005,32 @@ describe("sticky viewport production evidence verifier", () => {
 		await rehash(probeRoot, key, "metadata.json");
 		await expect(verifyStickyViewportShowcase(probeRoot)).rejects.toThrow("runtime observation mismatch");
 	}, 300_000);
+	it("rejects a mutated verifier oracle expectation even when every provenance field is restamped", async () => {
+		// The expectation table is immutable only if its digest comes from somewhere
+		// the bundle cannot reach. `captureProvenance()` hashes the WORKTREE file, so
+		// an author who edits the table and restamps provenance keeps the bundle
+		// internally consistent, and that was accepted. The committed blob at the
+		// recorded `git_head` is outside that reach: changing it requires a commit,
+		// which changes `git_head` itself. This must reject BEFORE semantic-anchor
+		// validation, because a mutated table would otherwise define what "valid"
+		// means for every anchor downstream.
+		const root = await capture();
+		const oraclePath = path.resolve(import.meta.dir, "../scripts/verify-sticky-viewport-showcase.ts");
+		const original = await fs.readFile(oraclePath, "utf8");
+		try {
+			const mutated = original.replace(/("manual-new-output\/80x24\/unicode-color":\s*\{\s*frameRow:\s*)0/, "$11");
+			expect(mutated).not.toBe(original);
+			await Bun.write(oraclePath, mutated);
+			// Restamp exactly as the oracle did: metadata, manifest, review input, and
+			// every provenance block recomputed against the mutated worktree.
+			await restampProvenance(root);
+			await expect(verifyStickyViewportShowcase(root)).rejects.toThrow("oracle integrity");
+		} finally {
+			await Bun.write(oraclePath, original);
+		}
+		// Restoring the committed bytes makes the same bundle valid again, which
+		// proves the rejection was the oracle mutation and not incidental staleness.
+		await restampProvenance(root);
+		await verifyStickyViewportShowcase(root);
+	}, 300_000);
 });

--- a/packages/coding-agent/test/sticky-viewport-showcase.test.ts
+++ b/packages/coding-agent/test/sticky-viewport-showcase.test.ts
@@ -22,6 +22,24 @@ async function capture(): Promise<string> {
 	if ((await result.exited) !== 0) throw new Error(await new Response(result.stderr).text());
 	return root;
 }
+async function captureWithEnv(overrides: Record<string, string>, drop: readonly string[] = []): Promise<string> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "sticky-viewport-showcase-env-"));
+	roots.push(root);
+	const env: Record<string, string> = {};
+	for (const [key, value] of Object.entries(process.env)) if (value !== undefined) env[key] = value;
+	for (const key of drop) delete env[key];
+	const result = Bun.spawn(
+		["bun", "packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts", "--out", root],
+		{
+			cwd: path.resolve(import.meta.dir, "../../.."),
+			stdout: "pipe",
+			stderr: "pipe",
+			env: { ...env, ...overrides },
+		},
+	);
+	if ((await result.exited) !== 0) throw new Error(await new Response(result.stderr).text());
+	return root;
+}
 async function rehash(root: string, key: string, name: string): Promise<void> {
 	const manifestPath = path.join(root, "manifest.json");
 	const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
@@ -534,4 +552,59 @@ describe("sticky viewport production evidence verifier", () => {
 			await expect(verifyStickyViewportShowcase(root, true)).rejects.toThrow("independent review");
 		}
 	}, 180_000);
+	it("keeps required ascii-no-color metadata escape-free and reproducible across capture hosts", async () => {
+		// `metadata.json` is a required manifest artifact, so host-negotiated color
+		// there makes the whole bundle host-dependent even when the three top-level
+		// payloads are canonical. `detectColorMode()` picks indexed `38;5;n` when
+		// TERM is dumb/empty/linux and truecolor `38;2;r;g;b` when COLORTERM says so,
+		// which is exactly the pair this asserts away.
+		const asciiKeys = ["manual-new-output/80x24/ascii-no-color", "capacity-zero/48x10/ascii-no-color"] as const;
+		const dumb = await captureWithEnv({ TERM: "dumb" }, ["COLORTERM"]);
+		const truecolor = await captureWithEnv({ TERM: "xterm-256color", COLORTERM: "truecolor" });
+		for (const key of asciiKeys) {
+			const dumbMetadata = await fs.readFile(path.join(dumb, key, "metadata.json"), "utf8");
+			const truecolorMetadata = await fs.readFile(path.join(truecolor, key, "metadata.json"), "utf8");
+			expect(dumbMetadata).not.toContain("\u001b[");
+			expect(truecolorMetadata).not.toContain("\u001b[");
+			expect(dumbMetadata).toEqual(truecolorMetadata);
+		}
+		await verifyStickyViewportShowcase(dumb);
+		await verifyStickyViewportShowcase(truecolor);
+	}, 300_000);
+
+	it("rejects escape bytes in required ascii-no-color metadata frames", async () => {
+		const base = await capture();
+		const key = "manual-new-output/80x24/ascii-no-color";
+		const cloneBase = async () => {
+			const clone = await fs.mkdtemp(path.join(os.tmpdir(), "sticky-viewport-showcase-ascii-"));
+			roots.push(clone);
+			await fs.cp(base, clone, { recursive: true });
+			return clone;
+		};
+		const forge = (value: string) => {
+			const forged = `\u001b[31m${value}`;
+			return {
+				ansi: forged,
+				text: Bun.stripANSI(forged),
+				sha256: new Bun.CryptoHasher("sha256").update(forged).digest("hex"),
+			};
+		};
+		// The pre-existing text/digest checks are satisfied on purpose, so only the
+		// no-color guard can reject these.
+		const emptyRoot = await cloneBase();
+		const emptyPath = path.join(emptyRoot, key, "metadata.json");
+		const emptyMetadata = JSON.parse(await fs.readFile(emptyPath, "utf8"));
+		emptyMetadata.state.visible_empty_irc_frame = forge(emptyMetadata.state.visible_empty_irc_frame.ansi);
+		await Bun.write(emptyPath, `${JSON.stringify(emptyMetadata, null, 2)}\n`);
+		await rehash(emptyRoot, key, "metadata.json");
+		await expect(verifyStickyViewportShowcase(emptyRoot)).rejects.toThrow("runtime observation mismatch");
+
+		const probeRoot = await cloneBase();
+		const probePath = path.join(probeRoot, key, "metadata.json");
+		const probeMetadata = JSON.parse(await fs.readFile(probePath, "utf8"));
+		probeMetadata.state.resize_probes[0].frame = forge(probeMetadata.state.resize_probes[0].frame.ansi);
+		await Bun.write(probePath, `${JSON.stringify(probeMetadata, null, 2)}\n`);
+		await rehash(probeRoot, key, "metadata.json");
+		await expect(verifyStickyViewportShowcase(probeRoot)).rejects.toThrow("runtime observation mismatch");
+	}, 300_000);
 });

--- a/packages/coding-agent/test/sticky-viewport-showcase.test.ts
+++ b/packages/coding-agent/test/sticky-viewport-showcase.test.ts
@@ -3,7 +3,12 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { VirtualTerminal } from "../../tui/test/virtual-terminal";
-import { ansiToHtml, xterm256Color } from "../scripts/capture-sticky-viewport-showcase";
+import {
+	ansiToHtml,
+	captureProvenance,
+	PROVENANCE_DIFF_SCOPE,
+	xterm256Color,
+} from "../scripts/capture-sticky-viewport-showcase";
 import { verifyStickyViewportShowcase } from "../scripts/verify-sticky-viewport-showcase";
 import {
 	SEMANTIC_ANCHOR_DOMAIN,
@@ -75,6 +80,40 @@ async function rebindReviewInput(root: string): Promise<void> {
 	await Bun.write(reviewPath, `${JSON.stringify(review, null, 2)}\n`);
 }
 
+// Re-stamp every persisted provenance block to the values the verifier computes
+// live, then rebind every digest that depends on them. `git_diff_binary_sha256`
+// is recomputed at verify time over the render-dependency closure, so a bundle
+// captured seconds earlier goes stale the moment anything in that closure is
+// written. The staleness guard then rejects BEFORE the guard a corruption case
+// targets, and the case silently proves nothing. Re-stamping models an attacker
+// who controls the entire bundle — they ran the capture themselves, so the
+// provenance stamp is theirs too — which is strictly stronger than one who
+// cannot. The staleness guard keeps its own dedicated coverage below.
+async function restampProvenance(root: string): Promise<void> {
+	const manifestPath = path.join(root, "manifest.json");
+	const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+	const current = await captureProvenance();
+	for (const key of manifest.ordered_keys as string[]) {
+		const metadataPath = path.join(root, key, "metadata.json");
+		const metadata = JSON.parse(await fs.readFile(metadataPath, "utf8"));
+		metadata.provenance = { ...metadata.provenance, ...current };
+		const content = `${JSON.stringify(metadata, null, 2)}\n`;
+		await Bun.write(metadataPath, content);
+		const file = manifest.entries
+			.find((entry: { key: string }) => entry.key === key)
+			.files.find((entry: { path: string }) => entry.path.endsWith("/metadata.json"));
+		file.sha256 = new Bun.CryptoHasher("sha256").update(content).digest("hex");
+		file.byte_length = Buffer.byteLength(content);
+	}
+	manifest.provenance = { ...manifest.provenance, ...current };
+	const manifestText = `${JSON.stringify(manifest, null, 2)}\n`;
+	await Bun.write(manifestPath, manifestText);
+	const reviewPath = path.join(root, "review-input.json");
+	const review = JSON.parse(await fs.readFile(reviewPath, "utf8"));
+	review.provenance = { ...review.provenance, ...current };
+	review.manifest_sha256 = new Bun.CryptoHasher("sha256").update(manifestText).digest("hex");
+	await Bun.write(reviewPath, `${JSON.stringify(review, null, 2)}\n`);
+}
 // The owner's exploit rehashed `metadata.json`, the manifest entry, AND the review
 // input together, so the bundle stayed internally consistent and only the anchor
 // guard could reject it. Every anchor corruption case below performs that same
@@ -82,8 +121,7 @@ async function rebindReviewInput(root: string): Promise<void> {
 // prove nothing about the guard.
 async function writeMetadataCoordinated(root: string, key: string, metadata: unknown): Promise<void> {
 	await Bun.write(path.join(root, key, "metadata.json"), `${JSON.stringify(metadata, null, 2)}\n`);
-	await rehash(root, key, "metadata.json");
-	await rebindReviewInput(root);
+	await restampProvenance(root);
 }
 // Mutable view of a persisted entry. Only the fields the corruption cases below
 // actually reach into are named; the rest stays opaque so a schema addition does
@@ -567,6 +605,72 @@ describe("sticky viewport production evidence verifier", () => {
 		await Bun.write(nonNarrowMetadataPath, `${JSON.stringify(nonNarrowMetadata, null, 2)}\n`);
 		await rehash(nonNarrowCjkRoot, key, "metadata.json");
 		await expect(verifyStickyViewportShowcase(nonNarrowCjkRoot)).rejects.toThrow("non-narrow CJK boundaries");
+	}, 180_000);
+	// The corruption cases above re-stamp provenance so they isolate the guard they
+	// target. That is only safe if the staleness guard is independently proven to
+	// still reject a genuinely stale bundle — otherwise re-stamping could mask its
+	// removal. These cases carry an internally consistent bundle whose ONLY defect
+	// is provenance, at each of the three sites the verifier checks.
+	it("fails closed for stale and scope-narrowed capture provenance", async () => {
+		const base = await capture();
+		const cloneBase = async () => {
+			const clone = await fs.mkdtemp(path.join(os.tmpdir(), "sticky-viewport-showcase-stale-"));
+			roots.push(clone);
+			await fs.cp(base, clone, { recursive: true });
+			return clone;
+		};
+		const key = "manual-new-output/80x24/unicode-color";
+		// `git_diff_binary_sha256` covers the render-dependency closure, NOT the whole
+		// worktree. Editing an out-of-scope file cannot change the paint, so it must
+		// not invalidate a bundle; this pins that the test file itself is out of scope
+		// and the renderer sources are in it.
+		expect(PROVENANCE_DIFF_SCOPE).toContain("packages/tui/src");
+		expect(PROVENANCE_DIFF_SCOPE).toContain("packages/coding-agent/src");
+		expect(PROVENANCE_DIFF_SCOPE).not.toContain("packages/coding-agent/test/sticky-viewport-showcase.test.ts");
+
+		// Re-stamping an otherwise untouched bundle must still verify. This is what
+		// makes the re-stamped corruption cases above trustworthy: a rejection there
+		// is the injected defect, never the re-stamp.
+		const restamped = await cloneBase();
+		await restampProvenance(restamped);
+		await verifyStickyViewportShowcase(restamped);
+
+		// Rebind the review input in both manifest cases, so the ONLY remaining defect
+		// is provenance and the rejection cannot be attributed to a digest mismatch.
+		const staleManifest = await cloneBase();
+		const staleManifestPath = path.join(staleManifest, "manifest.json");
+		const staleManifestJson = JSON.parse(await fs.readFile(staleManifestPath, "utf8"));
+		staleManifestJson.provenance.git_diff_binary_sha256 = "0".repeat(64);
+		await Bun.write(staleManifestPath, `${JSON.stringify(staleManifestJson, null, 2)}\n`);
+		await rebindReviewInput(staleManifest);
+		await expect(verifyStickyViewportShowcase(staleManifest)).rejects.toThrow("manifest capture provenance is stale");
+
+		// A bundle must not be able to shrink the covered surface to dodge the digest.
+		const narrowedScope = await cloneBase();
+		const narrowedPath = path.join(narrowedScope, "manifest.json");
+		const narrowed = JSON.parse(await fs.readFile(narrowedPath, "utf8"));
+		narrowed.provenance.git_diff_scope = ["packages/tui/src/tui.ts"];
+		await Bun.write(narrowedPath, `${JSON.stringify(narrowed, null, 2)}\n`);
+		await rebindReviewInput(narrowedScope);
+		await expect(verifyStickyViewportShowcase(narrowedScope)).rejects.toThrow("manifest capture provenance is stale");
+
+		const staleMetadata = await cloneBase();
+		const staleMetadataPath = path.join(staleMetadata, key, "metadata.json");
+		const staleMetadataJson = JSON.parse(await fs.readFile(staleMetadataPath, "utf8"));
+		staleMetadataJson.provenance.git_diff_binary_sha256 = "0".repeat(64);
+		await Bun.write(staleMetadataPath, `${JSON.stringify(staleMetadataJson, null, 2)}\n`);
+		await rehash(staleMetadata, key, "metadata.json");
+		await rebindReviewInput(staleMetadata);
+		await expect(verifyStickyViewportShowcase(staleMetadata)).rejects.toThrow("metadata schema mismatch");
+
+		const staleReview = await cloneBase();
+		const staleReviewPath = path.join(staleReview, "review-input.json");
+		const staleReviewJson = JSON.parse(await fs.readFile(staleReviewPath, "utf8"));
+		staleReviewJson.provenance.git_diff_binary_sha256 = "0".repeat(64);
+		await Bun.write(staleReviewPath, `${JSON.stringify(staleReviewJson, null, 2)}\n`);
+		await expect(verifyStickyViewportShowcase(staleReview)).rejects.toThrow(
+			"review input capture provenance is stale",
+		);
 	}, 180_000);
 	it("rejects table-driven manifest, metadata, and review-input corruption", async () => {
 		const base = await capture();

--- a/packages/coding-agent/test/sticky-viewport-showcase.test.ts
+++ b/packages/coding-agent/test/sticky-viewport-showcase.test.ts
@@ -5,7 +5,11 @@ import * as path from "node:path";
 import { VirtualTerminal } from "../../tui/test/virtual-terminal";
 import { ansiToHtml, xterm256Color } from "../scripts/capture-sticky-viewport-showcase";
 import { verifyStickyViewportShowcase } from "../scripts/verify-sticky-viewport-showcase";
-import { STICKY_VIEWPORT_SHOWCASE_COVERAGE } from "./fixtures/tui/sticky-viewport-showcase";
+import {
+	SEMANTIC_ANCHOR_DOMAIN,
+	STICKY_VIEWPORT_SHOWCASE_COVERAGE,
+	semanticAnchorDigest,
+} from "./fixtures/tui/sticky-viewport-showcase";
 
 const roots: string[] = [];
 async function capture(): Promise<string> {
@@ -69,6 +73,72 @@ async function rebindReviewInput(root: string): Promise<void> {
 	const review = JSON.parse(await fs.readFile(reviewPath, "utf8"));
 	review.manifest_sha256 = new Bun.CryptoHasher("sha256").update(manifest).digest("hex");
 	await Bun.write(reviewPath, `${JSON.stringify(review, null, 2)}\n`);
+}
+
+// The owner's exploit rehashed `metadata.json`, the manifest entry, AND the review
+// input together, so the bundle stayed internally consistent and only the anchor
+// guard could reject it. Every anchor corruption case below performs that same
+// coordinated rehash — otherwise it would fail on an earlier digest check and
+// prove nothing about the guard.
+async function writeMetadataCoordinated(root: string, key: string, metadata: unknown): Promise<void> {
+	await Bun.write(path.join(root, key, "metadata.json"), `${JSON.stringify(metadata, null, 2)}\n`);
+	await rehash(root, key, "metadata.json");
+	await rebindReviewInput(root);
+}
+// Mutable view of a persisted entry. Only the fields the corruption cases below
+// actually reach into are named; the rest stays opaque so a schema addition does
+// not force a change here.
+type SemanticAnchorEvidence = {
+	domain: string;
+	id: string;
+	namespace: string;
+	grapheme_start: number;
+	grapheme_end: number;
+	cell_start: number;
+	cell_end: number;
+	frame_start_row: number;
+	row_text_sha256: string;
+	frame_sha256: string;
+};
+type MetadataEvidence = {
+	state: {
+		semantic_anchor: SemanticAnchorEvidence | null;
+		cursor: { frame_sha256: string };
+		visible_empty_irc_frame: { text: string };
+		resize_probes: Array<{ frame: { text: string } }>;
+	} & Record<string, unknown>;
+} & Record<string, unknown>;
+async function readMetadata(root: string, key: string): Promise<MetadataEvidence> {
+	return JSON.parse(await fs.readFile(path.join(root, key, "metadata.json"), "utf8")) as MetadataEvidence;
+}
+// Recompute a VALID anchor for an already-mutated frame. The anchor guard runs
+// before the downstream metadata checks, so a case that mutates the painted frame
+// to exercise one of those later checks must carry an anchor that is honest about
+// the new paint — otherwise the guard rejects first and the case stops proving
+// what it was written to prove.
+async function recomputeAnchor(root: string, key: string): Promise<void> {
+	const metadata = await readMetadata(root, key);
+	const anchor = metadata.state.semantic_anchor;
+	if (anchor === null) return;
+	const ansi = await fs.readFile(path.join(root, key, "terminal-ansi.txt"), "utf8");
+	const rowText = (await fs.readFile(path.join(root, key, "terminal.txt"), "utf8")).split("\n")[
+		anchor.frame_start_row
+	]!;
+	const frameSha256 = new Bun.CryptoHasher("sha256").update(ansi).digest("hex");
+	anchor.frame_sha256 = frameSha256;
+	anchor.row_text_sha256 = new Bun.CryptoHasher("sha256").update(rowText).digest("hex");
+	anchor.id = `${anchor.namespace}:${semanticAnchorDigest({
+		entryKey: key,
+		namespace: anchor.namespace,
+		rowText,
+		graphemeStart: anchor.grapheme_start,
+		graphemeEnd: anchor.grapheme_end,
+		cellStart: anchor.cell_start,
+		cellEnd: anchor.cell_end,
+		frameRow: anchor.frame_start_row,
+		frameSha256,
+	})}`;
+	await writeMetadataCoordinated(root, key, metadata);
 }
 
 async function validIndependentReview(root: string): Promise<Record<string, unknown>> {
@@ -197,6 +267,10 @@ describe("sticky viewport production evidence verifier", () => {
 		const root = await capture();
 		const cubeKey = "manual-new-output/80x24/unicode-color";
 		await replaceAnsiColor(root, cubeKey, "\x1b[38;5;196;48;5;51m");
+		// Give the mutated frame an honest anchor, so the anchor guard has nothing to
+		// object to and `cursor.frame_sha256` remains the sole falsified digest. This
+		// keeps the case pointed at the runtime observation check it was written for.
+		await recomputeAnchor(root, cubeKey);
 		await rebindReviewInput(root);
 		await expect(verifyStickyViewportShowcase(root)).rejects.toThrow("runtime observation mismatch");
 	}, 120_000);
@@ -226,6 +300,135 @@ describe("sticky viewport production evidence verifier", () => {
 	it("captures and accepts the immutable production 20-key matrix", async () => {
 		await verifyStickyViewportShowcase(await capture());
 	}, 120_000);
+	it("binds every semantic anchor id to its own entry, content, geometry, and frame", async () => {
+		const root = await capture();
+		const keys: string[] = JSON.parse(await fs.readFile(path.join(root, "manifest.json"), "utf8")).ordered_keys;
+		const seen = new Map<string, string>();
+		let anchored = 0;
+		for (const key of keys) {
+			const metadata = await readMetadata(root, key);
+			const anchor = metadata.state.semantic_anchor;
+			if (anchor === null) continue;
+			anchored += 1;
+			expect(anchor.domain).toBe(SEMANTIC_ANCHOR_DOMAIN);
+			expect(anchor.namespace).toBe("user:entry");
+			// Full-length digest: the previous 8-hex suffix was brute-forceable, and a
+			// chosen-input search found a colliding geometry pair in ~26k attempts.
+			expect(anchor.id).toMatch(/^user:entry:[0-9a-f]{64}$/);
+			// Every digest input is persisted, so a third party can recompute the id
+			// without re-running the capture.
+			const text = await fs.readFile(path.join(root, key, "terminal.txt"), "utf8");
+			const rowText = text.split("\n")[anchor.frame_start_row]!;
+			expect(anchor.row_text_sha256).toBe(new Bun.CryptoHasher("sha256").update(rowText).digest("hex"));
+			expect(anchor.frame_sha256).toBe(
+				new Bun.CryptoHasher("sha256")
+					.update(await fs.readFile(path.join(root, key, "terminal-ansi.txt"), "utf8"))
+					.digest("hex"),
+			);
+			expect(anchor.id).toBe(
+				`user:entry:${semanticAnchorDigest({
+					entryKey: key,
+					namespace: "user:entry",
+					rowText,
+					graphemeStart: anchor.grapheme_start,
+					graphemeEnd: anchor.grapheme_end,
+					cellStart: anchor.cell_start,
+					cellEnd: anchor.cell_end,
+					frameRow: anchor.frame_start_row,
+					frameSha256: anchor.frame_sha256,
+				})}`,
+			);
+			// No silent aliasing: the geometry-only digest collapsed 17 anchors onto 6
+			// ids, one of which claimed six entries with different painted frames.
+			expect(seen.has(anchor.id)).toBe(false);
+			seen.set(anchor.id, key);
+		}
+		expect(anchored).toBe(17);
+		expect(seen.size).toBe(17);
+		await verifyStickyViewportShowcase(root);
+	}, 120_000);
+	it("rejects rehashed semantic anchor forgery, transplant, geometry, content, and truncation", async () => {
+		const base = await capture();
+		const cloneBase = async () => {
+			const clone = await fs.mkdtemp(path.join(os.tmpdir(), "sticky-viewport-showcase-anchor-"));
+			roots.push(clone);
+			await fs.cp(base, clone, { recursive: true });
+			return clone;
+		};
+		const key = "manual-new-output/80x24/unicode-color";
+		const otherKey = "manual-history/80x24/unicode-color";
+		// Every case below asserts on a non-null anchor, so narrow once here rather
+		// than repeating a non-null assertion at each mutation site.
+		const anchorOf = (metadata: MetadataEvidence): SemanticAnchorEvidence => {
+			const anchor = metadata.state.semantic_anchor;
+			if (anchor === null) throw new Error(`expected a semantic anchor for ${key}`);
+			return anchor;
+		};
+
+		// 1. Arbitrary id. This is the exact `deadbeef`-style substitution the owner
+		// pushed through the official verifier.
+		const arbitrary = await cloneBase();
+		const arbitraryMetadata = await readMetadata(arbitrary, key);
+		anchorOf(arbitraryMetadata).id = "user:entry:deadbeef";
+		await writeMetadataCoordinated(arbitrary, key, arbitraryMetadata);
+		await expect(verifyStickyViewportShowcase(arbitrary)).rejects.toThrow("semantic anchor guard");
+
+		// 2. Cross-entry transplant. Previously accepted, because ids were not bound
+		// to the entry they describe.
+		const swapped = await cloneBase();
+		const donor = await readMetadata(swapped, otherKey);
+		const swappedMetadata = await readMetadata(swapped, key);
+		expect(anchorOf(donor).id).not.toBe(anchorOf(swappedMetadata).id);
+		anchorOf(swappedMetadata).id = anchorOf(donor).id;
+		await writeMetadataCoordinated(swapped, key, swappedMetadata);
+		await expect(verifyStickyViewportShowcase(swapped)).rejects.toThrow("semantic anchor guard");
+
+		// 3. Two distinct anchor geometries under one id. `grapheme_end`/`cell_end`
+		// were not even persisted before, so neither was recomputable.
+		for (const field of ["grapheme_end", "cell_end"] as const) {
+			const geometry = await cloneBase();
+			const geometryMetadata = await readMetadata(geometry, key);
+			anchorOf(geometryMetadata)[field] = anchorOf(geometryMetadata)[field] + 1;
+			await writeMetadataCoordinated(geometry, key, geometryMetadata);
+			await expect(verifyStickyViewportShowcase(geometry)).rejects.toThrow("semantic anchor guard");
+		}
+
+		// 4. Content mutation with UNCHANGED geometry. Every other digest in the
+		// bundle is coordinately recomputed — including the row and frame digests the
+		// guard itself reads — so only the id-to-content binding can reject this.
+		const content = await cloneBase();
+		const contentMetadata = await readMetadata(content, key);
+		const frameRow = anchorOf(contentMetadata).frame_start_row;
+		const ansiPath = path.join(content, key, "terminal-ansi.txt");
+		const ansiRows = (await fs.readFile(ansiPath, "utf8")).split("\n");
+		// Same cell width, so the geometry the guard recomputes against is identical.
+		expect(ansiRows[frameRow]).toContain("selectable");
+		ansiRows[frameRow] = ansiRows[frameRow]!.replace("selectable", "selectabIe");
+		const mutatedAnsi = ansiRows.join("\n");
+		await Bun.write(ansiPath, mutatedAnsi);
+		await Bun.write(path.join(content, key, "terminal.txt"), Bun.stripANSI(mutatedAnsi));
+		await Bun.write(path.join(content, key, "terminal.html"), ansiToHtml(mutatedAnsi));
+		const mutatedFrameSha = new Bun.CryptoHasher("sha256").update(mutatedAnsi).digest("hex");
+		contentMetadata.state.cursor.frame_sha256 = mutatedFrameSha;
+		anchorOf(contentMetadata).frame_sha256 = mutatedFrameSha;
+		anchorOf(contentMetadata).row_text_sha256 = new Bun.CryptoHasher("sha256")
+			.update(Bun.stripANSI(mutatedAnsi).split("\n")[frameRow]!)
+			.digest("hex");
+		for (const name of ["terminal-ansi.txt", "terminal.txt", "terminal.html"] as const)
+			await rehash(content, key, name);
+		await writeMetadataCoordinated(content, key, contentMetadata);
+		await expect(verifyStickyViewportShowcase(content)).rejects.toThrow("semantic anchor guard");
+
+		// 5. Truncated-prefix collision. The owner found two distinct geometry tuples
+		// colliding on prefix `f2dc8fc6` in 26,084 attempts, so a truncated id must
+		// never be accepted as equivalent to its own full digest.
+		const truncated = await cloneBase();
+		const truncatedMetadata = await readMetadata(truncated, key);
+		const fullId = anchorOf(truncatedMetadata).id;
+		anchorOf(truncatedMetadata).id = `user:entry:${fullId.split(":")[2]!.slice(0, 8)}`;
+		await writeMetadataCoordinated(truncated, key, truncatedMetadata);
+		await expect(verifyStickyViewportShowcase(truncated)).rejects.toThrow("semantic anchor guard");
+	}, 300_000);
 	it("fails closed for semantic evidence and provenance corruption", async () => {
 		// `capture()` spawns a ~2.2s subprocess. Capture once and clone the
 		// deterministic output so each corruption case stays isolated without
@@ -343,6 +546,10 @@ describe("sticky viewport production evidence verifier", () => {
 			.digest("hex");
 		await Bun.write(cjkMetadataPath, `${JSON.stringify(cjkMetadata, null, 2)}\n`);
 		await rehash(cjkRoot, cjkKey, "metadata.json");
+		// The mutated CJK paint moves the anchor row, so re-derive the anchor from it.
+		// The guard then has no objection and the narrow-CJK boundary check stays the
+		// assertion under test.
+		await recomputeAnchor(cjkRoot, cjkKey);
 		await expect(verifyStickyViewportShowcase(cjkRoot)).rejects.toThrow("narrow CJK boundaries");
 
 		const evidenceRoot = await cloneBase();
@@ -552,7 +759,7 @@ describe("sticky viewport production evidence verifier", () => {
 			await expect(verifyStickyViewportShowcase(root, true)).rejects.toThrow("independent review");
 		}
 	}, 180_000);
-	it("keeps required ascii-no-color metadata escape-free and reproducible across capture hosts", async () => {
+	it("keeps required metadata escape-free, repo-independent, and reproducible within and across hosts", async () => {
 		// `metadata.json` is a required manifest artifact, so host-negotiated color
 		// there makes the whole bundle host-dependent even when the three top-level
 		// payloads are canonical. `detectColorMode()` picks indexed `38;5;n` when
@@ -561,16 +768,56 @@ describe("sticky viewport production evidence verifier", () => {
 		const asciiKeys = ["manual-new-output/80x24/ascii-no-color", "capacity-zero/48x10/ascii-no-color"] as const;
 		const dumb = await captureWithEnv({ TERM: "dumb" }, ["COLORTERM"]);
 		const truecolor = await captureWithEnv({ TERM: "xterm-256color", COLORTERM: "truecolor" });
+		// Same host, same worktree, same merge state, back-to-back. This is the axis
+		// the `detached` vs `detached +8` defect broke: the status line resolved repo
+		// state through an async `git status --porcelain` whose completion raced the
+		// capture, so one run painted the staged count and the next did not.
+		const dumbRepeat = await captureWithEnv({ TERM: "dumb" }, ["COLORTERM"]);
 		for (const key of asciiKeys) {
 			const dumbMetadata = await fs.readFile(path.join(dumb, key, "metadata.json"), "utf8");
 			const truecolorMetadata = await fs.readFile(path.join(truecolor, key, "metadata.json"), "utf8");
+			const repeatMetadata = await fs.readFile(path.join(dumbRepeat, key, "metadata.json"), "utf8");
 			expect(dumbMetadata).not.toContain("\u001b[");
 			expect(truecolorMetadata).not.toContain("\u001b[");
 			expect(dumbMetadata).toEqual(truecolorMetadata);
+			expect(dumbMetadata).toEqual(repeatMetadata);
+			expect(new Bun.CryptoHasher("sha256").update(dumbMetadata).digest("hex")).toBe(
+				new Bun.CryptoHasher("sha256").update(truecolorMetadata).digest("hex"),
+			);
+		}
+		// Repository state must not reach ANY required frame, on either color axis.
+		// The git segment paints the branch plus `*n`/`+n`/`?n` porcelain counts at
+		// >=120 columns, and the path segment paints the cwd basename — both are host
+		// state, and the capture now pins a preset that excludes them outright.
+		const keys: string[] = JSON.parse(await fs.readFile(path.join(dumb, "manifest.json"), "utf8")).ordered_keys;
+		for (const root of [dumb, truecolor, dumbRepeat]) {
+			for (const key of keys) {
+				const metadata = await readMetadata(root, key);
+				const frames = [
+					metadata.state.visible_empty_irc_frame.text as string,
+					...(metadata.state.resize_probes as Array<{ frame: { text: string } }>).map(probe => probe.frame.text),
+				];
+				for (const frame of frames) {
+					expect(frame).toContain("⬢");
+					// No branch name, no porcelain counts, no cwd basename.
+					expect(frame).not.toContain("detached");
+					expect(frame).not.toContain("⑂");
+					expect(frame).not.toContain("🗑");
+					expect(frame).not.toMatch(/[*+?]\d+\s/);
+				}
+			}
+			// Unicode entries legitimately differ in SGR form across hosts, but their
+			// semantic payload must not: stripping color has to leave identical bytes.
+			for (const key of keys) {
+				const stripped = Bun.stripANSI(await fs.readFile(path.join(root, key, "terminal.txt"), "utf8"));
+				const reference = Bun.stripANSI(await fs.readFile(path.join(dumb, key, "terminal.txt"), "utf8"));
+				expect(stripped).toEqual(reference);
+			}
 		}
 		await verifyStickyViewportShowcase(dumb);
 		await verifyStickyViewportShowcase(truecolor);
-	}, 300_000);
+		await verifyStickyViewportShowcase(dumbRepeat);
+	}, 600_000);
 
 	it("rejects escape bytes in required ascii-no-color metadata frames", async () => {
 		const base = await capture();

--- a/packages/coding-agent/test/sticky-viewport-showcase.test.ts
+++ b/packages/coding-agent/test/sticky-viewport-showcase.test.ts
@@ -137,6 +137,7 @@ type SemanticAnchorEvidence = {
 	frame_start_row: number;
 	row_text_sha256: string;
 	frame_sha256: string;
+	frame_text_sha256: string;
 };
 type MetadataEvidence = {
 	state: {
@@ -163,7 +164,9 @@ async function recomputeAnchor(root: string, key: string): Promise<void> {
 		anchor.frame_start_row
 	]!;
 	const frameSha256 = new Bun.CryptoHasher("sha256").update(ansi).digest("hex");
+	const frameTextSha256 = new Bun.CryptoHasher("sha256").update(Bun.stripANSI(ansi)).digest("hex");
 	anchor.frame_sha256 = frameSha256;
+	anchor.frame_text_sha256 = frameTextSha256;
 	anchor.row_text_sha256 = new Bun.CryptoHasher("sha256").update(rowText).digest("hex");
 	anchor.id = `${anchor.namespace}:${semanticAnchorDigest({
 		entryKey: key,
@@ -174,7 +177,7 @@ async function recomputeAnchor(root: string, key: string): Promise<void> {
 		cellStart: anchor.cell_start,
 		cellEnd: anchor.cell_end,
 		frameRow: anchor.frame_start_row,
-		frameSha256,
+		frameTextSha256,
 	})}`;
 	await writeMetadataCoordinated(root, key, metadata);
 }
@@ -373,7 +376,7 @@ describe("sticky viewport production evidence verifier", () => {
 					cellStart: anchor.cell_start,
 					cellEnd: anchor.cell_end,
 					frameRow: anchor.frame_start_row,
-					frameSha256: anchor.frame_sha256,
+					frameTextSha256: anchor.frame_text_sha256,
 				})}`,
 			);
 			// No silent aliasing: the geometry-only digest collapsed 17 anchors onto 6
@@ -466,6 +469,29 @@ describe("sticky viewport production evidence verifier", () => {
 		anchorOf(truncatedMetadata).id = `user:entry:${fullId.split(":")[2]!.slice(0, 8)}`;
 		await writeMetadataCoordinated(truncated, key, truncatedMetadata);
 		await expect(verifyStickyViewportShowcase(truncated)).rejects.toThrow("semantic anchor guard");
+
+		// 6. Fully coordinated relocation + geometry transplant. Every digest the
+		// producer controls is recomputed — row text digest, frame digests, the full
+		// 64-hex id, metadata digest, manifest, review-input binding, and scoped
+		// provenance — so the bundle is internally consistent by construction. Digest
+		// consistency therefore cannot reject it; only the source-side immutable
+		// expectation can, because the verifier's own bytes are inside
+		// `source_sha256` and a bundle producer cannot rewrite them.
+		const relocated = await cloneBase();
+		const transplantMetadata = await readMetadata(relocated, "manual-history/80x24/unicode-color");
+		const transplant = anchorOf(transplantMetadata);
+		const relocatedMetadata = await readMetadata(relocated, key);
+		const victim = anchorOf(relocatedMetadata);
+		victim.grapheme_start = transplant.grapheme_start;
+		victim.grapheme_end = transplant.grapheme_end;
+		victim.cell_start = transplant.cell_start;
+		victim.cell_end = transplant.cell_end;
+		victim.frame_start_row = victim.frame_start_row + 1;
+		await writeMetadataCoordinated(relocated, key, relocatedMetadata);
+		await recomputeAnchor(relocated, key);
+		await expect(verifyStickyViewportShowcase(relocated)).rejects.toThrow(
+			"anchor row or geometry does not match its immutable expectation",
+		);
 	}, 300_000);
 	it("fails closed for semantic evidence and provenance corruption", async () => {
 		// `capture()` spawns a ~2.2s subprocess. Capture once and clone the
@@ -921,6 +947,27 @@ describe("sticky viewport production evidence verifier", () => {
 		await verifyStickyViewportShowcase(dumb);
 		await verifyStickyViewportShowcase(truecolor);
 		await verifyStickyViewportShowcase(dumbRepeat);
+		// Semantic anchor identity must name WHAT is anchored, not how the host
+		// negotiated color. The first digest bound the ANSI frame sha256, so 16 of 17
+		// anchors changed id between an indexed-color and a truecolor host while the
+		// stripped paint was byte-identical — an evidence field that moves for a
+		// reason unrelated to its meaning. The preimage now binds the stripped-text
+		// digest, and `frame_sha256` stays persisted only as artifact binding.
+		let comparedAnchors = 0;
+		for (const key of keys) {
+			const dumbAnchor = (await readMetadata(dumb, key)).state.semantic_anchor;
+			const truecolorAnchor = (await readMetadata(truecolor, key)).state.semantic_anchor;
+			if (dumbAnchor === null || truecolorAnchor === null) {
+				expect(dumbAnchor).toBe(truecolorAnchor);
+				continue;
+			}
+			expect(dumbAnchor.id).toBe(truecolorAnchor.id);
+			expect(dumbAnchor.frame_text_sha256).toBe(truecolorAnchor.frame_text_sha256);
+			expect(dumbAnchor.row_text_sha256).toBe(truecolorAnchor.row_text_sha256);
+			expect(dumbAnchor.frame_start_row).toBe(truecolorAnchor.frame_start_row);
+			comparedAnchors += 1;
+		}
+		expect(comparedAnchors).toBe(17);
 	}, 600_000);
 
 	it("rejects escape bytes in required ascii-no-color metadata frames", async () => {

--- a/packages/coding-agent/test/sticky-viewport-showcase.test.ts
+++ b/packages/coding-agent/test/sticky-viewport-showcase.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { VirtualTerminal } from "../../tui/test/virtual-terminal";
 import { ansiToHtml, xterm256Color } from "../scripts/capture-sticky-viewport-showcase";
 import { verifyStickyViewportShowcase } from "../scripts/verify-sticky-viewport-showcase";
+import { STICKY_VIEWPORT_SHOWCASE_COVERAGE } from "./fixtures/tui/sticky-viewport-showcase";
 
 const roots: string[] = [];
 async function capture(): Promise<string> {
@@ -86,6 +87,76 @@ afterEach(async () => {
 	await Promise.all(roots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
 });
 describe("sticky viewport production evidence verifier", () => {
+	it("derives IRC resize coverage from the production split renderer", () => {
+		expect(STICKY_VIEWPORT_SHOWCASE_COVERAGE.irc).toEqual(["empty", "streaming", "long"]);
+		expect(STICKY_VIEWPORT_SHOWCASE_COVERAGE.todo).toEqual([
+			"empty",
+			"populated",
+			"long",
+			"multi-phase",
+			"collapsed",
+			"expanded",
+		]);
+		expect(STICKY_VIEWPORT_SHOWCASE_COVERAGE.widths).toEqual([64, 65, 80, 120, 160, 120, 80, 65, 64]);
+		expect(STICKY_VIEWPORT_SHOWCASE_COVERAGE.heights).toEqual(["short", "standard"]);
+		expect(STICKY_VIEWPORT_SHOWCASE_COVERAGE.viewport).toEqual(["manual", "follow", "resize-grow", "resize-shrink"]);
+		expect(STICKY_VIEWPORT_SHOWCASE_COVERAGE.chrome).toEqual([
+			"pending",
+			"statusContainer",
+			"btw",
+			"statusLine",
+			"hooks",
+			"editor",
+			"pet",
+		]);
+		expect(STICKY_VIEWPORT_SHOWCASE_COVERAGE.evidence).toEqual([
+			"overlap",
+			"width-overflow",
+			"hidden-cursor-focus",
+			"anchor-loss",
+			"cjk-semantic-break",
+		]);
+	});
+	it("captures authoritative production probe frames and semantic root IDs", async () => {
+		const root = await capture();
+		const metadata = JSON.parse(
+			await fs.readFile(path.join(root, "multiline-editor-hooks-pet/80x24/unicode-color", "metadata.json"), "utf8"),
+		);
+		expect(metadata.state.root_order).toEqual([
+			"irc-split",
+			"pending-messages",
+			"status-container",
+			"todos",
+			"btw",
+			"status-line",
+			"hooks-above",
+			"editor-container",
+			"pet-floor",
+			"hooks-below",
+		]);
+		expect(metadata.state.pin_boundary.component).toBe("status-line");
+		expect(metadata.state.pin_boundary.index).toBe(5);
+		expect(metadata.state.focused_component).toBe("editor");
+		expect(metadata.state.cursor.blink).toBe(true);
+		expect(metadata.state.resize_probes.map((probe: { columns: number }) => probe.columns)).toEqual([
+			64, 65, 80, 120, 160, 120, 80, 65, 64,
+		]);
+		expect(metadata.state.resize_probes[0]).toMatchObject({
+			effective_lane: "transcript",
+			irc_records: 0,
+			todo_rows: 0,
+		});
+		expect(metadata.state.resize_probes[1]).toMatchObject({
+			effective_lane: "split",
+			separator_width: 3,
+			irc_records: 1,
+			todo_rows: 1,
+			todo_expanded: false,
+		});
+		expect(metadata.state.resize_probes[2]).toMatchObject({ todo_expanded: true });
+		expect(metadata.state.visible_empty_irc_frame.text).not.toContain("worker → you");
+		expect(metadata.state.resize_probes[3].frame.text).toContain("worker → you");
+	}, 120_000);
 	it("renders inverse ANSI as effective colors and closes spans across resets", () => {
 		const html = ansiToHtml("\x1b[31;44;7mX\x1b[27mY\x1b[0mZ");
 		expect(html).toContain("color:#3465a4;background-color:#cc0000");
@@ -104,25 +175,13 @@ describe("sticky viewport production evidence verifier", () => {
 			"color:rgb(8,8,8);background-color:rgb(238,238,238)",
 		);
 	});
-	it("round-trips xterm cube and grayscale artifacts and rejects ANSI color corruption", async () => {
+	it("rejects artifact mutation even when the manifest digest is rebound", async () => {
 		const root = await capture();
 		const cubeKey = "manual-new-output/80x24/unicode-color";
-		const grayscaleKey = "manual-new-output/120x36/unicode-color";
 		await replaceAnsiColor(root, cubeKey, "\x1b[38;5;196;48;5;51m");
-		await replaceAnsiColor(root, grayscaleKey, "\x1b[38;5;232;48;5;255m");
 		await rebindReviewInput(root);
-		await verifyStickyViewportShowcase(root);
-
-		const ansiPath = path.join(root, cubeKey, "terminal-ansi.txt");
-		const ansi = await fs.readFile(ansiPath, "utf8");
-		const corrupted = ansi.replace("\x1b[38;5;196;48;5;51m", "\x1b[38;5;46;48;5;21m");
-		if (corrupted === ansi) throw new Error("expected injected xterm SGR sequence");
-		await Bun.write(ansiPath, corrupted);
-		await rehash(root, cubeKey, "terminal-ansi.txt");
-		await expect(verifyStickyViewportShowcase(root)).rejects.toThrow(
-			"HTML artifact is not canonical ANSI conversion",
-		);
-	}, 15_000);
+		await expect(verifyStickyViewportShowcase(root)).rejects.toThrow("runtime observation mismatch");
+	}, 120_000);
 	it("requires terminal HTML to be the exact canonical ANSI conversion", async () => {
 		const root = await capture();
 		const key = "manual-new-output/80x24/unicode-color";
@@ -135,7 +194,7 @@ describe("sticky viewport production evidence verifier", () => {
 		await expect(verifyStickyViewportShowcase(root)).rejects.toThrow(
 			"HTML artifact is not canonical ANSI conversion",
 		);
-	}, 15_000);
+	}, 120_000);
 	it("round-trips xterm strikethrough and production-only SGR attributes", async () => {
 		const terminal = new VirtualTerminal(20, 1);
 		terminal.write("\x1b[5;8;9;53mX\x1b[25;28;29;55mY");
@@ -148,7 +207,7 @@ describe("sticky viewport production evidence verifier", () => {
 	});
 	it("captures and accepts the immutable production 20-key matrix", async () => {
 		await verifyStickyViewportShowcase(await capture());
-	});
+	}, 120_000);
 	it("fails closed for semantic evidence and provenance corruption", async () => {
 		// `capture()` spawns a ~2.2s subprocess. Capture once and clone the
 		// deterministic output so each corruption case stays isolated without
@@ -178,7 +237,51 @@ describe("sticky viewport production evidence verifier", () => {
 		noticeMetadata.output_revision = "0";
 		await Bun.write(noticeMetadataPath, `${JSON.stringify(noticeMetadata, null, 2)}\n`);
 		await rehash(noticeRoot, key, "metadata.json");
-		await expect(verifyStickyViewportShowcase(noticeRoot)).rejects.toThrow("manual notice invariant");
+		await expect(verifyStickyViewportShowcase(noticeRoot)).rejects.toThrow("renderer-owned viewport state mismatch");
+		const falseManualRoot = await cloneBase();
+		const falseManualPath = path.join(falseManualRoot, key, "metadata.json");
+		const falseManual = JSON.parse(await fs.readFile(falseManualPath, "utf8"));
+		falseManual.state.manual = false;
+		await Bun.write(falseManualPath, `${JSON.stringify(falseManual, null, 2)}\n`);
+		await rehash(falseManualRoot, key, "metadata.json");
+		await rebindReviewInput(falseManualRoot);
+		await expect(verifyStickyViewportShowcase(falseManualRoot)).rejects.toThrow(
+			"renderer-owned viewport state mismatch",
+		);
+
+		const extraNoticeRoot = await cloneBase();
+		const extraNoticeKey = "manual-history/80x24/unicode-color";
+		const extraNoticePath = path.join(extraNoticeRoot, extraNoticeKey, "metadata.json");
+		const extraNotice = JSON.parse(await fs.readFile(extraNoticePath, "utf8"));
+		extraNotice.state.notice = true;
+		await Bun.write(extraNoticePath, `${JSON.stringify(extraNotice, null, 2)}\n`);
+		await rehash(extraNoticeRoot, extraNoticeKey, "metadata.json");
+		await rebindReviewInput(extraNoticeRoot);
+		await expect(verifyStickyViewportShowcase(extraNoticeRoot)).rejects.toThrow(
+			"renderer-owned viewport state mismatch",
+		);
+
+		const staleRevisionRoot = await cloneBase();
+		const staleRevisionPath = path.join(staleRevisionRoot, key, "metadata.json");
+		const staleRevision = JSON.parse(await fs.readFile(staleRevisionPath, "utf8"));
+		staleRevision.state.observed_output_revision = "0";
+		await Bun.write(staleRevisionPath, `${JSON.stringify(staleRevision, null, 2)}\n`);
+		await rehash(staleRevisionRoot, key, "metadata.json");
+		await rebindReviewInput(staleRevisionRoot);
+		await expect(verifyStickyViewportShowcase(staleRevisionRoot)).rejects.toThrow(
+			"renderer-owned viewport state mismatch",
+		);
+		const crossBoundaryRoot = await cloneBase();
+		const crossBoundaryKey = "selection-boundary/80x24/unicode-color";
+		const crossBoundaryPath = path.join(crossBoundaryRoot, crossBoundaryKey, "metadata.json");
+		const crossBoundary = JSON.parse(await fs.readFile(crossBoundaryPath, "utf8"));
+		crossBoundary.state.selection.end.row = crossBoundary.state.transcript_capacity;
+		await Bun.write(crossBoundaryPath, `${JSON.stringify(crossBoundary, null, 2)}\n`);
+		await rehash(crossBoundaryRoot, crossBoundaryKey, "metadata.json");
+		await rebindReviewInput(crossBoundaryRoot);
+		await expect(verifyStickyViewportShowcase(crossBoundaryRoot)).rejects.toThrow(
+			"selection boundary evidence missing",
+		);
 
 		const capacityRoot = await cloneBase();
 		const capacityKey = "capacity-one/80x24/unicode-color";
@@ -187,7 +290,7 @@ describe("sticky viewport production evidence verifier", () => {
 		capacityMetadata.state.transcript_capacity = 2;
 		await Bun.write(capacityMetadataPath, `${JSON.stringify(capacityMetadata, null, 2)}\n`);
 		await rehash(capacityRoot, capacityKey, "metadata.json");
-		await expect(verifyStickyViewportShowcase(capacityRoot)).rejects.toThrow("capacity metadata/frame mismatch");
+		await expect(verifyStickyViewportShowcase(capacityRoot)).rejects.toThrow("runtime observation mismatch");
 
 		const cjkRoot = await cloneBase();
 		const cjkKey = "narrow-cjk/48x10/unicode-color";
@@ -199,17 +302,23 @@ describe("sticky viewport production evidence verifier", () => {
 			);
 			await rehash(cjkRoot, cjkKey, name);
 		}
-		await expect(verifyStickyViewportShowcase(cjkRoot)).rejects.toThrow(
-			"narrow CJK visible terminal evidence missing",
-		);
+		const cjkMetadataPath = path.join(cjkRoot, cjkKey, "metadata.json");
+		const cjkMetadata = JSON.parse(await fs.readFile(cjkMetadataPath, "utf8"));
+		cjkMetadata.cjk_phrase_boundaries = [];
+		cjkMetadata.state.cursor.frame_sha256 = new Bun.CryptoHasher("sha256")
+			.update(await fs.readFile(path.join(cjkRoot, cjkKey, "terminal-ansi.txt"), "utf8"))
+			.digest("hex");
+		await Bun.write(cjkMetadataPath, `${JSON.stringify(cjkMetadata, null, 2)}\n`);
+		await rehash(cjkRoot, cjkKey, "metadata.json");
+		await expect(verifyStickyViewportShowcase(cjkRoot)).rejects.toThrow("narrow CJK boundaries");
 
 		const evidenceRoot = await cloneBase();
 		const evidencePath = path.join(evidenceRoot, key, "metadata.json");
 		const evidence = JSON.parse(await fs.readFile(evidencePath, "utf8"));
-		evidence.state.manual_historical_rows = [];
+		evidence.state.visible_empty_irc_frame.text = "forged populated IRC";
 		await Bun.write(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`);
 		await rehash(evidenceRoot, key, "metadata.json");
-		await expect(verifyStickyViewportShowcase(evidenceRoot)).rejects.toThrow("manual historical transcript evidence");
+		await expect(verifyStickyViewportShowcase(evidenceRoot)).rejects.toThrow("runtime observation");
 
 		const nonNarrowCjkRoot = await cloneBase();
 		const nonNarrowMetadataPath = path.join(nonNarrowCjkRoot, key, "metadata.json");
@@ -218,7 +327,7 @@ describe("sticky viewport production evidence verifier", () => {
 		await Bun.write(nonNarrowMetadataPath, `${JSON.stringify(nonNarrowMetadata, null, 2)}\n`);
 		await rehash(nonNarrowCjkRoot, key, "metadata.json");
 		await expect(verifyStickyViewportShowcase(nonNarrowCjkRoot)).rejects.toThrow("non-narrow CJK boundaries");
-	}, 15_000);
+	}, 180_000);
 	it("rejects table-driven manifest, metadata, and review-input corruption", async () => {
 		const base = await capture();
 		const fresh = async () => {
@@ -343,7 +452,7 @@ describe("sticky viewport production evidence verifier", () => {
 			await mutate(root);
 			await expect(verifyStickyViewportShowcase(root)).rejects.toThrow();
 		}
-	}, 30_000);
+	}, 180_000);
 	it("fails closed for every independent-review attestation field", async () => {
 		const root = await capture();
 		const review = await validIndependentReview(root);
@@ -409,5 +518,5 @@ describe("sticky viewport production evidence verifier", () => {
 			await Bun.write(path.join(root, "independent-review.json"), JSON.stringify(candidate));
 			await expect(verifyStickyViewportShowcase(root, true)).rejects.toThrow("independent review");
 		}
-	});
+	}, 180_000);
 });

--- a/packages/coding-agent/test/sticky-viewport-showcase.test.ts
+++ b/packages/coding-agent/test/sticky-viewport-showcase.test.ts
@@ -1044,10 +1044,15 @@ describe("sticky viewport production evidence verifier", () => {
 		const running = new Bun.CryptoHasher("sha256")
 			.update(await fs.readFile(path.resolve(import.meta.dir, "../scripts/verify-sticky-viewport-showcase.ts")))
 			.digest("hex");
-		// The parent commit is a stand-in for the synthetic-merge base. This branch
-		// changed the oracle, so the parent's blob differs from the running bytes.
-		const parent = await committedBlobSha256("HEAD~1", oracle);
-		expect(parent).not.toBe(running);
+		// The merge-base with dev is exactly the base the maintainer's synthetic
+		// integration checks out, and this branch changed the oracle relative to dev,
+		// so that base provably lacks the running bytes. Using it instead of `HEAD~1`
+		// keeps the assertion independent of local commit topology.
+		const base = new TextDecoder()
+			.decode(Bun.spawnSync(["git", "merge-base", "HEAD", "origin/dev"], { stdout: "pipe" }).stdout)
+			.trim();
+		expect(base).not.toBe("");
+		expect(await committedBlobSha256(base, oracle)).not.toBe(running);
 		// Acceptance therefore cannot be coming from the base blob.
 		await verifyStickyViewportShowcase(await capture());
 	}, 300_000);

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 - The renderer's reported cursor column is now clamped to the last real cell, so it always names a column that exists in the current terminal width. On the wire this is unchanged (a terminal already clamps `CHA` to the last column), but the reported value is now truthful for callers reading it through the viewport observation.
 
+## [0.12.3] - 2026-07-30
+
 ## [0.12.2] - 2026-07-30
 
 ## [0.12.1] - 2026-07-29

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -9,6 +9,13 @@
 ## [0.12.2] - 2026-07-30
 
 ## [0.12.1] - 2026-07-29
+### Added
+
+- `Tui` now exposes renderer-owned viewport observations so tests and evidence capture can assert against committed paint state instead of re-deriving geometry: `getViewportObservation()` (returns a defensive copy of the latest committed observation), `getViewportAnchorSnapshot()`, `getViewportAnchorComponent()`, `getFocusedComponent()`, and `setViewportSelection()`, plus the `TuiViewportObservation` and `MouseSelectionPoint` types.
+
+### Changed
+
+- Alternate-scroll mode (`DECSET 1007`) is now explicitly disabled at startup, on every mouse-capture toggle, at stop, and during emergency restore, so the host terminal or multiplexer owns mouse-wheel scrollback instead of receiving wheel-to-cursor-key translation. Hosts that never answer a `DECRQM ?1007$p` query (Apple Terminal among them) cannot report this mode, so it is reset unconditionally rather than conditionally on a reported state.
 
 ### Fixed
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -15,10 +15,11 @@
 
 ### Changed
 
-- Alternate-scroll mode (`DECSET 1007`) is now explicitly disabled at startup, on every mouse-capture toggle, at stop, and during emergency restore, so the host terminal or multiplexer owns mouse-wheel scrollback instead of receiving wheel-to-cursor-key translation. Hosts that never answer a `DECRQM ?1007$p` query (Apple Terminal among them) cannot report this mode, so it is reset unconditionally rather than conditionally on a reported state.
+- Alternate-scroll mode (`DECSET 1007`) is now explicitly disabled at startup, on every mouse-capture toggle, at stop, and during emergency restore, so no host translates wheel input into cursor keys. While mouse capture is off this leaves wheel scrollback to the host terminal or multiplexer; while capture is on GJC consumes SGR wheel reports itself, and the reset removes a conflicting second translation path. Hosts that never answer a `DECRQM ?1007$p` query (Apple Terminal among them) cannot report this mode, so it is reset unconditionally rather than conditionally on a reported state.
 
 ### Fixed
 
+- The renderer's reported cursor column is now clamped to the last real cell, so it always names a column that exists in the current terminal width. On the wire this is unchanged (a terminal already clamps `CHA` to the last column), but the reported value is now truthful for callers reading it through the viewport observation.
 - Kitty/Ghostty inline images no longer remain visually pinned when sticky or semantic viewport repaints move their anchors into application scrollback. The renderer now soft-deletes only the named placement from the old viewport, retains uploaded pixels for history replay, and keeps placement tracking aligned across unresolved-anchor and follow-live transitions.
 
 ## [0.12.0] - 2026-07-28

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -20,6 +20,13 @@
 ### Fixed
 
 - The renderer's reported cursor column is now clamped to the last real cell, so it always names a column that exists in the current terminal width. On the wire this is unchanged (a terminal already clamps `CHA` to the last column), but the reported value is now truthful for callers reading it through the viewport observation.
+
+## [0.12.2] - 2026-07-30
+
+## [0.12.1] - 2026-07-29
+
+### Fixed
+
 - Kitty/Ghostty inline images no longer remain visually pinned when sticky or semantic viewport repaints move their anchors into application scrollback. The renderer now soft-deletes only the named placement from the old viewport, retains uploaded pixels for history replay, and keeps placement tracking aligned across unresolved-anchor and follow-live transitions.
 
 ## [0.12.0] - 2026-07-28

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -189,7 +189,6 @@ export interface TuiViewportObservation {
 	semanticAnchor: (ViewportAnchorRow & { frameRow: number }) | null;
 }
 
-
 export interface ViewportAnchorRow {
 	id: ViewportAnchorId;
 	graphemeStart: number;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -83,7 +83,7 @@ type OverlayMouseBounds = {
 	termHeight: number;
 };
 
-type MouseSelectionPoint = {
+export type MouseSelectionPoint = {
 	line: number;
 	column: number;
 };
@@ -176,6 +176,19 @@ export { visibleWidth };
 
 /** Durable source identifier for a semantically anchored viewport row. */
 export type ViewportAnchorId = string;
+/** Immutable renderer-owned details of the most recently rendered viewport. */
+export interface TuiViewportObservation {
+	transcriptCapacity: number;
+	pinBoundary: { row: number; pinned: boolean };
+	manualHistory: boolean;
+	newOutputNoticeVisible: boolean;
+	outputRevision: string | null;
+	focused: boolean;
+	cursor: { row: number; col: number; visible: boolean } | null;
+	selection: { start: MouseSelectionPoint; end: MouseSelectionPoint } | null;
+	semanticAnchor: (ViewportAnchorRow & { frameRow: number }) | null;
+}
+
 
 export interface ViewportAnchorRow {
 	id: ViewportAnchorId;
@@ -731,6 +744,7 @@ export class TUI extends Container {
 	#manualViewportFallbackAnchors: ManualViewportAnchor[] = [];
 	#reconcileMissingViewportAnchor = false;
 	#lastCursorPosition: { row: number; col: number } | null = null;
+	#latestViewportObservation: TuiViewportObservation | null = null;
 	#sixelProbePendingDa = false;
 	#sixelProbePendingGraphics = false;
 	#sixelProbeBuffer = "";
@@ -890,6 +904,56 @@ export class TUI extends Container {
 			component.focused = true;
 		}
 	}
+	/** Returns the currently focused component without exposing mutable focus state. */
+	getFocusedComponent(): Component | null {
+		return this.#focusedComponent;
+	}
+
+	/** Returns a defensive snapshot of the latest renderer-owned viewport anchors. */
+	getViewportAnchorSnapshot(): { startRow: number; anchors: Array<ViewportAnchorRow | null> } | null {
+		if (this.#viewportAnchorFrame === null) return null;
+		return {
+			startRow: this.#viewportAnchorFrame.startRow,
+			anchors: this.#viewportAnchorFrame.anchors.map(anchor => (anchor ? { ...anchor } : null)),
+		};
+	}
+
+	/** Returns a defensive snapshot of renderer-owned viewport geometry. */
+	getViewportObservation(): TuiViewportObservation | null {
+		const observation = this.#latestViewportObservation;
+		return observation
+			? {
+					...observation,
+					pinBoundary: { ...observation.pinBoundary },
+					cursor: observation.cursor ? { ...observation.cursor } : null,
+					selection: observation.selection
+						? { start: { ...observation.selection.start }, end: { ...observation.selection.end } }
+						: null,
+					semanticAnchor: observation.semanticAnchor ? { ...observation.semanticAnchor } : null,
+				}
+			: null;
+	}
+
+	/** Selects a zero-based painted viewport cell range using the same renderer path as mouse dragging. */
+	setViewportSelection(start: MouseSelectionPoint, end: MouseSelectionPoint): void {
+		if (!this.options.copySelection) return;
+		const map = (point: MouseSelectionPoint): MouseSelectionPoint | null => {
+			const row = Math.max(0, Math.min(this.terminal.rows - 1, point.line));
+			const column = Math.max(0, Math.min(this.terminal.columns - 1, point.column));
+			return this.#mouseSelectionPoint({ x: column + 1, y: row + 1, kind: "drag" });
+		};
+		const mappedStart = map(start);
+		const mappedEnd = map(end);
+		if (mappedStart === null || mappedEnd === null) {
+			this.#clearMouseSelection();
+			this.requestRender(false, "selection");
+			return;
+		}
+		this.#mouseSelectionStart = mappedStart;
+		this.#mouseSelectionEnd = mappedEnd;
+		this.#mouseSelectionDragged = true;
+		this.requestRender(false, "selection");
+	}
 
 	override removeChild(component: Component): void {
 		this.#invalidateFocusForRemovedTree(component);
@@ -951,6 +1015,10 @@ export class TUI extends Container {
 		if (this.#viewportAnchorComponent === component) return;
 		this.#viewportAnchorComponent = component;
 		this.#viewportAnchorFrame = null;
+	}
+	/** Returns the direct component registered as the semantic viewport anchor source. */
+	getViewportAnchorComponent(): Component | null {
+		return this.#viewportAnchorComponent;
 	}
 
 	/** Clear manual viewport ownership before replacing the transcript identity namespace. */
@@ -2439,7 +2507,7 @@ export class TUI extends Container {
 			if (markerIndex !== -1) {
 				// Calculate visual column (width of text before marker)
 				const beforeMarker = line.slice(0, markerIndex);
-				const col = visibleWidth(beforeMarker);
+				const col = Math.max(0, Math.min(Math.max(0, this.terminal.columns - 1), visibleWidth(beforeMarker)));
 
 				// Strip marker from the line
 				lines[row] = line.slice(0, markerIndex) + line.slice(markerIndex + CURSOR_MARKER.length);
@@ -2909,6 +2977,8 @@ export class TUI extends Container {
 				emittedRegions,
 			);
 			onPainted?.();
+			this.#paintedManualOutputNotice = paintManual && this.#manualOutputNotice;
+			this.#recordPaintedViewportObservation(nextViewportTop, height, paintManual);
 		});
 		if (!contentWritten) return false;
 
@@ -2917,6 +2987,63 @@ export class TUI extends Container {
 			this.#appendDebugRedrawLog(msg);
 		}
 		return writeSucceeded;
+	}
+	#recordPaintedViewportObservation(viewportTop: number, height: number, paintManual: boolean): void {
+		const transcriptCapacity = this.#manualTranscriptCapacity(height);
+		const anchorFrame = this.#viewportAnchorFrame;
+		const semanticAnchor =
+			anchorFrame === null
+				? null
+				: (this.#committedTranscriptRows
+						.map((transcriptRow, screenRow) => {
+							if (transcriptRow === null) return null;
+							const anchor = anchorFrame.anchors[transcriptRow - anchorFrame.startRow];
+							return anchor ? { ...anchor, frameRow: screenRow } : null;
+						})
+						.find(anchor => anchor !== null) ?? null);
+		const cursor = this.#lastCursorPosition;
+		let cursorRow: number | null = null;
+		if (cursor !== null) {
+			if (paintManual && cursor.row >= this.#manualTranscriptLineCount) {
+				const noticeRows = this.#manualOutputNotice && height > this.#manualSuffixLineCount ? 1 : 0;
+				cursorRow = transcriptCapacity + noticeRows + (cursor.row - this.#manualTranscriptLineCount);
+			} else if (paintManual) {
+				cursorRow = this.#committedTranscriptRows.indexOf(cursor.row);
+			} else {
+				cursorRow = cursor.row - viewportTop;
+			}
+		}
+		const cursorVisible = cursorRow !== null && cursorRow >= 0 && cursorRow < height;
+		const selectedRange = this.#mouseSelectionDragged ? this.#orderedMouseSelection() : null;
+		const paintedSelection =
+			selectedRange === null
+				? null
+				: {
+						start: { line: selectedRange.start.line - viewportTop, column: selectedRange.start.column },
+						end: { line: selectedRange.end.line - viewportTop, column: selectedRange.end.column },
+					};
+		this.#latestViewportObservation = {
+			transcriptCapacity,
+			pinBoundary: { row: transcriptCapacity, pinned: this.#bottomPinnedComponent !== null },
+			manualHistory: paintManual,
+			newOutputNoticeVisible: paintManual && this.#paintedManualOutputNotice,
+			outputRevision: this.#viewportOutputSource?.revision.toString() ?? null,
+			focused: this.#focusedComponent !== null,
+			cursor: cursor
+				? { row: cursorVisible ? cursorRow! : cursor.row, col: cursor.col, visible: cursorVisible }
+				: null,
+			selection: paintedSelection,
+			semanticAnchor,
+		};
+	}
+
+	#refreshPaintedLiveViewportObservation(height: number): void {
+		this.#committedTranscriptRows = Array.from({ length: height }, (_, screenRow) => {
+			const transcriptRow = this.#viewportTopRow + screenRow;
+			return transcriptRow < this.#manualTranscriptLineCount ? transcriptRow : null;
+		});
+		this.#paintedManualOutputNotice = false;
+		this.#recordPaintedViewportObservation(this.#viewportTopRow, height, false);
 	}
 
 	#doRender(): void {
@@ -3147,6 +3274,7 @@ export class TUI extends Container {
 			}
 			const nextViewportTop = resolvedAnchorTop ?? this.#manualViewportTop;
 			if (
+				!this.#mouseSelectionDragged &&
 				this.#previousWidth === width &&
 				this.#previousHeight === height &&
 				nextViewportTop === this.#manualViewportTop &&
@@ -3248,6 +3376,7 @@ export class TUI extends Container {
 					);
 					this.#manualTranscriptLineCount = nextTranscriptLineCount;
 					this.#manualSuffixLineCount = nextSuffixLineCount;
+					this.#refreshPaintedLiveViewportObservation(height);
 				})
 			)
 				return;
@@ -3310,6 +3439,7 @@ export class TUI extends Container {
 				);
 				this.#manualTranscriptLineCount = nextTranscriptLineCount;
 				this.#manualSuffixLineCount = nextSuffixLineCount;
+				this.#refreshPaintedLiveViewportObservation(height);
 			});
 			if (!contentWritten) return false;
 
@@ -3436,8 +3566,8 @@ export class TUI extends Container {
 
 		// No changes - but still need to update hardware cursor position if it moved
 		if (firstChanged === -1) {
-			this.#writeCursorPosition(cursorPos, newLines.length);
 			this.#viewportTopRow = Math.max(0, this.#maxLinesRendered - height);
+			if (this.#writeCursorPosition(cursorPos, newLines.length)) this.#refreshPaintedLiveViewportObservation(height);
 			return;
 		}
 
@@ -3548,6 +3678,7 @@ export class TUI extends Container {
 						);
 						this.#manualTranscriptLineCount = nextTranscriptLineCount;
 						this.#manualSuffixLineCount = nextSuffixLineCount;
+						this.#refreshPaintedLiveViewportObservation(height);
 					})
 				)
 					return;
@@ -3559,6 +3690,7 @@ export class TUI extends Container {
 			this.#viewportTopRow = Math.max(0, newLines.length - height);
 			this.#manualTranscriptLineCount = nextTranscriptLineCount;
 			this.#manualSuffixLineCount = nextSuffixLineCount;
+			this.#refreshPaintedLiveViewportObservation(height);
 			return;
 		}
 
@@ -3724,6 +3856,7 @@ export class TUI extends Container {
 				);
 				this.#manualTranscriptLineCount = nextTranscriptLineCount;
 				this.#manualSuffixLineCount = nextSuffixLineCount;
+				this.#refreshPaintedLiveViewportObservation(height);
 			})
 		)
 			return;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -936,6 +936,11 @@ export class TUI extends Container {
 	/** Selects a zero-based painted viewport cell range using the same renderer path as mouse dragging. */
 	setViewportSelection(start: MouseSelectionPoint, end: MouseSelectionPoint): void {
 		if (!this.options.copySelection) return;
+		// Non-finite coordinates would survive the clamp below as NaN, latch
+		// #mouseSelectionDragged, and force a repaint every frame while reporting a
+		// NaN selection through getViewportObservation(). Reject them the same way
+		// scrollViewportBy does rather than storing an unpaintable selection.
+		if (![start.line, start.column, end.line, end.column].every(value => Number.isFinite(value))) return;
 		const map = (point: MouseSelectionPoint): MouseSelectionPoint | null => {
 			const row = Math.max(0, Math.min(this.terminal.rows - 1, point.line));
 			const column = Math.max(0, Math.min(this.terminal.columns - 1, point.column));

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -261,6 +261,12 @@ export class VirtualTerminal implements Terminal {
 		return `${rows.join("\n")}\n`;
 	}
 
+	/** Returns the hardware cursor position from the emulated terminal's active viewport. */
+	getCursorPosition(): { row: number; col: number } {
+		const buffer = this.xterm.buffer.active;
+		return { row: buffer.cursorY, col: buffer.cursorX };
+	}
+
 	/**
 	 * Get the entire scroll buffer
 	 */

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -262,11 +262,6 @@ export class VirtualTerminal implements Terminal {
 	}
 
 	/** Returns the hardware cursor position from the emulated terminal's active viewport. */
-	getCursorPosition(): { row: number; col: number } {
-		const buffer = this.xterm.buffer.active;
-		return { row: buffer.cursorY, col: buffer.cursorX };
-	}
-
 	/**
 	 * Get the entire scroll buffer
 	 */

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -261,7 +261,6 @@ export class VirtualTerminal implements Terminal {
 		return `${rows.join("\n")}\n`;
 	}
 
-	/** Returns the hardware cursor position from the emulated terminal's active viewport. */
 	/**
 	 * Get the entire scroll buffer
 	 */


### PR DESCRIPTION
## What

Sticky-viewport renderer evidence: strict single-commit oracle authority, host-independent semantic anchor identity, immutable source-side anchor expectations, Rust/Cargo provenance scope, and repo-independent required metadata.

Successor to #3580. Both P1 findings from the #3580 verdict are repaired.

## P1 — oracle authority was inferable from ref topology (repaired)

The verdict was correct and this was the serious one. The previous fallback called `reachableBlobSha256s(source)` and accepted the running oracle hash if it appeared on **any** ref. As the hostile reproduction showed, committing malicious oracle bytes on `refs/heads/unrelated-attacker-ref` was sufficient. `--all` proves reachability, not review authority, and my earlier comment claiming a committed mutation is "visible in the reviewed diff" was false for an unrelated ref.

The gate now implements the required repair exactly:

1. When `GJC_STICKY_VIEWPORT_ORACLE_COMMIT` is set, both oracle sources are validated against **that one commit only**, with no ref fallback of any kind.
2. The authority is resolved as a full commit object (`git rev-parse <c>^{commit}`) and fails closed when absent or unreadable.
3. Without the variable, only `provenance.git_head` is accepted.
4. An uncommitted synthetic merge requires the harness to set `GJC_STICKY_VIEWPORT_ORACLE_COMMIT=<exact-reviewed-pr-head>`; authority is never inferred from repository topology.
5. The chosen commit is persisted as `provenance.oracle_commit` and cross-checked against the resolved authority at verify time.
6. Both oracle files must resolve at the same authoritative commit; per-file provenance from different refs is rejected.

### Reviewer note (required)

For synthetic-merge integration please run:

```
GJC_STICKY_VIEWPORT_ORACLE_COMMIT=<exact reviewed PR head> bun test packages/coding-agent/test/sticky-viewport-showcase.test.ts
```

Without it the gate correctly refuses to authorize staged-but-uncommitted oracle bytes.

## P1 — provenance scope omitted the Rust crates (repaired)

`PROVENANCE_DIFF_SCOPE` now includes `crates`, `Cargo.toml`, and `Cargo.lock`, so a paint-affecting native source change can no longer survive a rebuild without changing declared provenance.

## Regressions added

- Malicious oracle bytes authorized only by an unrelated **local** ref and an unrelated **remote-tracking** ref, both with and without an explicit trusted authority: rejected.
- A declared authority that does not carry the running oracle bytes: rejected.
- Restamped expectation-table mutation: rejected before semantic-anchor validation.

## Verification at this exact head

- Showcase suite, `TERM=dumb` (no `COLORTERM`): **19 passed / 0 failed**
- Showcase suite, truecolor: **19 passed / 0 failed**
- `packages/tui` terminal/detach/viewport/key suites: **14 passed / 0 failed**
- `tui` and `coding-agent` checks, `check:public-sync`, `check-visible-definitions`, `verify-g002-gates`, strict rebrand: pass
- Native addon rebuilt at this head
- Rebased conflict-free onto `dev@3eff6b89`; attack regressions leave zero refs behind

Not merging. Thanks for the hostile oracles on ref topology — that fallback was a real authority hole and the reproduction made it unambiguous.
