### PR TITLE
fix(session): stop migration lock self-fence and surface capacity errors (#3508)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
+- Managed session open/resume no longer self-fences a live migration lock solely because a JS timer heartbeat was starved past 60s, and `artifact_capacity_exceeded` / `migration_busy` are surfaced as operator-facing startup errors with recovery guidance instead of uncaught process crashes (#3508).
 - Deferred `agent_end` publication again settles public session readiness before slow extension handlers finish, while retaining exact cancellation leases through queued extension delivery and draining that delivery before session shutdown.
 - Ultragoal validation-batch hydration now fails closed unless deferred and final-close evidence exactly matches a complete authoritative cumulative Git/CI inventory and durable batch tuple. Explicit malformed, partial, unknown, reordered, or stale receipt data is rejected; Git path capture is byte-safe, NUL-delimited, and includes untracked files; incomplete capture conservatively requires computer-control QA; shared settings and tool registries cannot use partial diffs to bypass that suite; validate/checkpoint replacement hydration is identical; and current/replacement receipts are byte-bound to ledger payloads (#3541).
 - Fixture quality gates that complete intermediate Ultragoal stories now write file-backed adversarial artifact proof; skill-state hooks and computer red-team fixtures match the unconditional adversarial path check so #3543 CI stays fail-closed without weakening hydration exactness (#3543).

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -59,12 +59,16 @@ import {
 import type { AgentSession } from "./session/agent-session";
 
 import {
+	formatOperatorFacingSessionOpenError,
+	isOperatorFacingSessionOpenError,
 	type ResumeSessionIdentity,
 	resolveResumableSession,
+	SessionArtifactCapacityError,
 	type SessionDestination,
 	type SessionDirectoryMigrationPolicy,
 	type SessionInfo,
 	SessionManager,
+	SessionMigrationBusyError,
 	type StrictSessionOpenResult,
 } from "./session/session-manager";
 import { runStartupCredentialAutoImportIfNeeded } from "./setup/credential-auto-import";
@@ -1208,13 +1212,31 @@ export async function runRootCommand(
 				undefined,
 				resumeMigrationPolicy,
 			);
-		} catch {
-			process.stderr.write(`${BARE_RESUME_OPEN_ERROR}\n`);
+		} catch (error) {
+			if (isOperatorFacingSessionOpenError(error)) {
+				process.stderr.write(`${formatOperatorFacingSessionOpenError(error)}\n`);
+			} else {
+				process.stderr.write(`${BARE_RESUME_OPEN_ERROR}\n`);
+			}
 			if (!deps.suppressProcessExit) process.exitCode = 1;
 			return;
 		}
 		if (opened.kind === "error") {
-			process.stderr.write(`${BARE_RESUME_OPEN_ERROR}\n`);
+			if (opened.reason === "artifact_capacity_exceeded") {
+				process.stderr.write(
+					`${formatOperatorFacingSessionOpenError(
+						new SessionArtifactCapacityError(
+							opened.message ?? "Session artifacts exceed the migration capacity.",
+						),
+					)}\n`,
+				);
+			} else if (opened.reason === "migration_busy") {
+				process.stderr.write(
+					`${formatOperatorFacingSessionOpenError(new SessionMigrationBusyError(opened.message))}\n`,
+				);
+			} else {
+				process.stderr.write(`${BARE_RESUME_OPEN_ERROR}\n`);
+			}
 			if (!deps.suppressProcessExit) process.exitCode = 1;
 			return;
 		}
@@ -1381,9 +1403,29 @@ export async function runRootCommand(
 
 	// Create session manager based on CLI flags. A bare resume was strictly opened
 	// before startup discovery, so it never reaches create-or-open behavior here.
-	const sessionManager =
-		bareResumeSessionManager ??
-		(await logger.time("createSessionManager", createSessionManager, parsedArgs, cwd, settingsInstance));
+	let sessionManager: SessionManager | undefined = bareResumeSessionManager;
+	if (!sessionManager) {
+		try {
+			sessionManager = await logger.time(
+				"createSessionManager",
+				createSessionManager,
+				parsedArgs,
+				cwd,
+				settingsInstance,
+			);
+		} catch (error) {
+			// Capacity / migration fencing failures must not become uncaught crashes (#3508).
+			if (isOperatorFacingSessionOpenError(error)) {
+				process.stderr.write(`${formatOperatorFacingSessionOpenError(error)}\n`);
+				if (!deps.suppressProcessExit) process.exitCode = 1;
+				authStorage.close();
+				stopThemeWatcher();
+				await postmortem.cleanup();
+				return;
+			}
+			throw error;
+		}
+	}
 
 	// Restore the resumed session's working directory so the HUD branch, the
 	// project path, and the agent's tools all match where the session was

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -1618,21 +1618,31 @@ export async function acquireManagedLock(
 				} catch {
 					throw new Error("migration_busy");
 				}
+				// Live holders prove ownership via the open fd + attemptId/inode identity.
+				// Do not self-fence solely because a JS timer heartbeat was starved by long
+				// synchronous lock-held work (Windows legacy migration can exceed 60s) (#3508).
 				if (
 					released ||
 					descriptorClosed ||
 					!current ||
 					!sameFileIdentity(lockIdentity, named) ||
-					current.attemptId !== attemptId ||
-					current.leaseExpiresAt < Date.now()
+					current.attemptId !== attemptId
 				)
 					throw new Error("migration_busy");
+				const now = Date.now();
+				// Keep the on-disk lease fresh so waiters still observe a live owner even when
+				// setInterval heartbeats cannot run during long event-loop blocks.
+				if (current.leaseExpiresAt < now + LOCK_HEARTBEAT_MS) {
+					writeLockDescriptor(fd, {
+						...record,
+						heartbeatAt: now,
+						leaseExpiresAt: now + LOCK_LEASE_MS,
+					});
+				}
 			};
 			const heartbeat = setInterval(() => {
 				try {
 					assertOwned();
-					const now = Date.now();
-					writeLockDescriptor(fd, { ...record, heartbeatAt: now, leaseExpiresAt: now + LOCK_LEASE_MS });
 				} catch {
 					/* fencing rejects later publication */
 				}

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -939,10 +939,50 @@ export class SessionMigrationPolicyError extends Error {
 }
 
 export class SessionArtifactCapacityError extends Error {
+	readonly code = "artifact_capacity_exceeded";
+
 	constructor(message: string) {
 		super(message);
 		this.name = "SessionArtifactCapacityError";
 	}
+}
+
+/** Managed migration/open lost lock fencing or could not finish under a live lease (#3508). */
+export class SessionMigrationBusyError extends Error {
+	readonly code = "migration_busy";
+
+	constructor(
+		message = "Could not open managed session: migration_busy. Another migration may hold the lease, or a previous attempt expired mid-flight. Retry shortly; if this persists after capacity cleanup, delete the session's managed lock under the agent sessions root only after confirming no other GJC process is running.",
+	) {
+		super(message);
+		this.name = "SessionMigrationBusyError";
+	}
+}
+
+/** Operator-facing recovery text for legacy artifact capacity refusal (#3508). */
+export function formatSessionArtifactCapacityRecovery(message?: string): string {
+	const capacity =
+		message?.trim() || "Legacy session artifacts exceed the migration capacity (50,000 files or 512 MiB).";
+	return (
+		`${capacity}\n` +
+		"Recovery: non-destructively move generated artifacts out of the session artifact root " +
+		"(the directory next to the `.jsonl` transcript, typically named like the session file without the extension) " +
+		"until the tree is under the capacity limits, then re-run `gjc --resume <session-id>`. " +
+		"`gjc gc --prune` does not manage these legacy session artifacts."
+	);
+}
+
+export function isOperatorFacingSessionOpenError(
+	error: unknown,
+): error is SessionArtifactCapacityError | SessionMigrationBusyError {
+	return error instanceof SessionArtifactCapacityError || error instanceof SessionMigrationBusyError;
+}
+
+export function formatOperatorFacingSessionOpenError(
+	error: SessionArtifactCapacityError | SessionMigrationBusyError,
+): string {
+	if (error instanceof SessionArtifactCapacityError) return formatSessionArtifactCapacityRecovery(error.message);
+	return error.message;
 }
 
 export type ResumeTailInspection = ResumeTailResumable | ResumeTailTerminal | ResumeTailError;
@@ -953,7 +993,12 @@ export interface StrictSessionOpenSuccess {
 
 export interface StrictSessionOpenFailure {
 	kind: "error";
-	reason: ResumeTailError["reason"] | "identity-mismatch" | "migration-required" | "artifact_capacity_exceeded";
+	reason:
+		| ResumeTailError["reason"]
+		| "identity-mismatch"
+		| "migration-required"
+		| "artifact_capacity_exceeded"
+		| "migration_busy";
 	message?: string;
 }
 
@@ -9604,6 +9649,7 @@ export class SessionManager {
 			managedDestinationStore.assertBound();
 			if (opened.code === "legacy_migration_disabled") throw new SessionMigrationPolicyError();
 			if (opened.code === "artifact_capacity_exceeded") throw new SessionArtifactCapacityError(opened.message);
+			if (opened.code === "migration_busy") throw new SessionMigrationBusyError();
 			throw new Error(`Could not open managed session: ${opened.message}`);
 		}
 		assertManagedDestinationBound();
@@ -9699,7 +9745,15 @@ export class SessionManager {
 			throw new Error(`Could not open session: ${inspected.reason}`);
 		}
 		const opened = await SessionManager.openExistingStrict(inspected.identity, destination, storage, migrationPolicy);
-		if (opened.kind === "error") throw new Error(`Could not open session: ${opened.reason}`);
+		if (opened.kind === "error") {
+			if (opened.reason === "legacy_migration_disabled") throw new SessionMigrationPolicyError();
+			if (opened.reason === "artifact_capacity_exceeded")
+				throw new SessionArtifactCapacityError(
+					opened.message ?? "Session artifacts exceed the migration capacity.",
+				);
+			if (opened.reason === "migration_busy") throw new SessionMigrationBusyError(opened.message);
+			throw new Error(`Could not open session: ${opened.reason}`);
+		}
 		return opened.manager;
 	}
 
@@ -10382,11 +10436,17 @@ export class SessionManager {
 					return { kind: "error", reason: "legacy_migration_disabled" };
 				if (error instanceof SessionArtifactCapacityError)
 					return { kind: "error", reason: "artifact_capacity_exceeded", message: error.message };
+				if (error instanceof SessionMigrationBusyError)
+					return { kind: "error", reason: "migration_busy", message: error.message };
+				if (error instanceof Error && error.message === "migration_busy")
+					return { kind: "error", reason: "migration_busy", message: new SessionMigrationBusyError().message };
 				if (
 					error instanceof Error &&
 					(error.message.includes("source_changed") || error.message.includes("changed before migration"))
 				)
 					return { kind: "error", reason: "identity-mismatch" };
+				if (error instanceof Error && error.message.startsWith("Could not open managed session: migration_busy"))
+					return { kind: "error", reason: "migration_busy", message: new SessionMigrationBusyError().message };
 				throw error;
 			}
 		}
@@ -10444,6 +10504,7 @@ export class SessionManager {
 					throw new SessionArtifactCapacityError(
 						opened.message ?? "Session artifacts exceed the migration capacity.",
 					);
+				if (opened.reason === "migration_busy") throw new SessionMigrationBusyError(opened.message);
 				return undefined;
 			}
 			return opened.manager;

--- a/packages/coding-agent/test/session-manager/session-directory.test.ts
+++ b/packages/coding-agent/test/session-manager/session-directory.test.ts
@@ -20,7 +20,12 @@ import {
 	validateNativeSecurityResult,
 } from "../../src/session/internal/managed-session-storage";
 import { classifyNativePublishOutcome } from "../../src/session/internal/native-publish-outcome";
-import { SessionArtifactCapacityError, SessionManager } from "../../src/session/session-manager";
+import {
+	formatSessionArtifactCapacityRecovery,
+	SessionArtifactCapacityError,
+	SessionManager,
+	SessionMigrationBusyError,
+} from "../../src/session/session-manager";
 import { FileSessionStorage } from "../../src/session/session-storage";
 
 const temporaryDirectories: string[] = [];
@@ -538,6 +543,10 @@ describe("managed session write protocol", () => {
 		await expect(
 			SessionManager.continueRecent(cwd, SessionManager.managedDestination(cwd, path.dirname(sessionsRoot))),
 		).rejects.toThrow(SessionArtifactCapacityError);
+		const capacityMessage = `Legacy session artifacts exceed the migration capacity (${MANAGED_ARTIFACT_MAX_FILES.toLocaleString()} files or 512 MiB).`;
+		expect(formatSessionArtifactCapacityRecovery(capacityMessage)).toContain("gjc --resume");
+		expect(formatSessionArtifactCapacityRecovery(capacityMessage)).toContain("gjc gc --prune");
+		expect(new SessionMigrationBusyError().code).toBe("migration_busy");
 	}, 120_000);
 
 	it("distinguishes artifact capacity from unsafe topology violations", async () => {

--- a/packages/coding-agent/test/session/managed-lock-lease.test.ts
+++ b/packages/coding-agent/test/session/managed-lock-lease.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Managed storage lock lease ownership (#3508).
+ *
+ * Long synchronous migration work can starve `setInterval` heartbeats past
+ * `LOCK_LEASE_MS`. The live holder must not self-fence solely because the
+ * on-disk lease timestamp elapsed while the open fd + attemptId still prove ownership.
+ */
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { acquireManagedLock } from "../../src/session/internal/managed-session-storage";
+
+function readLock(pathname: string): {
+	attemptId: string;
+	leaseExpiresAt: number;
+	heartbeatAt: number;
+} {
+	return JSON.parse(fs.readFileSync(pathname, "utf8")) as {
+		attemptId: string;
+		leaseExpiresAt: number;
+		heartbeatAt: number;
+	};
+}
+
+describe("managed storage lock lease (#3508)", () => {
+	it("does not self-fence when the live holder renews after a starved lease window", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-managed-lock-lease-"));
+		const locks = path.join(root, "locks");
+		fs.mkdirSync(locks, { recursive: true });
+		const lock = await acquireManagedLock(locks, "migration-lease");
+		try {
+			const before = readLock(lock.path);
+			// Simulate a JS-timer starvation window: lease fully expired, heartbeat frozen.
+			const expired = {
+				...before,
+				heartbeatAt: before.heartbeatAt,
+				leaseExpiresAt: Date.now() - 5_000,
+			};
+			fs.writeFileSync(lock.path, `${JSON.stringify(expired)}\n`);
+			// Busy-block longer than a typical heartbeat tick would cover if we relied on setInterval alone.
+			const start = Date.now();
+			while (Date.now() - start < 50) {
+				/* spin */
+			}
+			expect(() => lock.assertOwned()).not.toThrow();
+			const after = readLock(lock.path);
+			expect(after.attemptId).toBe(before.attemptId);
+			expect(after.leaseExpiresAt).toBeGreaterThan(Date.now());
+		} finally {
+			await lock.release();
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("still fences when the attempt id no longer matches", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-managed-lock-fence-"));
+		const locks = path.join(root, "locks");
+		fs.mkdirSync(locks, { recursive: true });
+		const lock = await acquireManagedLock(locks, "migration-fence");
+		try {
+			const current = readLock(lock.path);
+			fs.writeFileSync(
+				lock.path,
+				`${JSON.stringify({
+					...current,
+					attemptId: "not-the-holder",
+					leaseExpiresAt: Date.now() + 60_000,
+				})}\n`,
+			);
+			expect(() => lock.assertOwned()).toThrow("migration_busy");
+		} finally {
+			try {
+				await lock.release();
+			} catch {
+				/* holder already fenced */
+			}
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #3508.

On Windows, resuming a large **legacy** session by ID can enter a two-step failure loop:

1. **Uncaught capacity crash** — an oversized legacy artifact root aborts with `SessionArtifactCapacityError` / `artifact_capacity_exceeded` as an unhandled rejection / uncaught exception (`gjc-crash.log`), with no supported recovery path (`gjc gc --prune` does not manage these artifacts).
2. **Self-fenced migration** — after the operator non-destructively shrinks the artifact tree under the documented cap, re-resume can still fail with `Could not open managed session: migration_busy` because migration holds the managed lock across long **synchronous** capture/hash/copy/verify work. Heartbeat renewal is a `setInterval` timer; when the event loop is blocked past `LOCK_LEASE_MS` (60s), `lock.assertOwned()` rejects the **same holder's** expired lease.

Reporter evidence (from the issue):

- Artifact root before cleanup: ~68k files / ~1.4 GiB (over 50k / 512 MiB caps).
- After cleanup to 33 files / 2.5 MiB: resume still failed in ~70s.
- Lock record: `heartbeatAt === createdAt`, `leaseExpiresAt === createdAt + 60_000` (no heartbeat renewal).
- Local experiment: raising `LOCK_LEASE_MS` to 300s allowed migration to complete — confirms lease starvation, not permanent corruption.

Owner reconciliation after #3489 explicitly left these three requirements open for a separate PR (comment on #3508).

## Requirements mapping (owner comment)

| # | Requirement | This PR |
| --- | --- | --- |
| a | Catch `SessionArtifactCapacityError` at the CLI/open boundary with a recovery path | Typed error + CLI stderr recovery text; no uncaught crash on resume/open/continue |
| b | Lock renewal independent of starved JS timer / no self-fence on long sync work | Live holder proves ownership via open fd + attemptId + inode; renews lease on `assertOwned` near expiry |
| c | Surface `migration_busy` and capacity as operator-facing startup errors | `SessionMigrationBusyError` + mapped through open paths and CLI catch |

## Root cause (code)

### Capacity path

`openManagedCandidateForWrite` / tree validation throw `artifact_capacity_exceeded`. That becomes `SessionArtifactCapacityError` in places, but other open paths rethrow generic `Error` or leave the exception uncaught at CLI startup (`createSessionManager` / resume-by-id), producing process crashes instead of a clean operator message.

### Lock path

`acquireManagedLock` used:

- `LOCK_LEASE_MS = 60_000`
- heartbeat via `setInterval(LOCK_HEARTBEAT_MS)`
- `assertOwned()` failed when `current.leaseExpiresAt < Date.now()` **even for the live fd holder**

So a single >60s synchronous span that never yields to the event loop both (1) prevents the timer from firing and (2) makes the next `assertOwned()` self-fence as `migration_busy`.

## Design (what we changed and why)

### 1. Live-holder lock ownership (`managed-session-storage.ts`)

`assertOwned()` now fails only when ownership is actually lost:

- lock released / fd closed
- lock path gone or inode mismatch
- `attemptId` mismatch (another owner / reclaim)

It does **not** fail solely because `leaseExpiresAt` elapsed while the live holder still has the open, identity-bound descriptor.

When the lease is near expiry, the live holder **synchronously renews** the on-disk lease during `assertOwned()` so waiters still observe a live owner even if `setInterval` heartbeats were starved.

**Why not only raise `LOCK_LEASE_MS`?**  
That is a timeout race with unbounded migration size (and the issue already showed 70s > 60s). Ownership should be tied to the live holder's proof, not a single wall-clock constant.

**Security / fencing invariants preserved:**

- Waiters still reclaim only after lease expiry **and** owner-gone / stale recheck logic (unchanged acquire path).
- A different process or attempt cannot satisfy `assertOwned` without matching attemptId + inode.
- We do **not** unlink locks by pathname on release (existing exact-identity retirement remains).

### 2. Typed open failures + CLI surfaces (`session-manager.ts`, `main.ts`)

- `SessionArtifactCapacityError` keeps a stable `code`.
- New `SessionMigrationBusyError` with recovery-oriented default message.
- `formatSessionArtifactCapacityRecovery()` / `formatOperatorFacingSessionOpenError()` for consistent stderr text (mentions safe manual archive of the artifact root next to the `.jsonl`, and that `gjc gc --prune` does not cover legacy session artifacts).
- `openExistingStrict` maps both capacity and `migration_busy` into `{ kind: "error", reason }` instead of rethrowing as uncaught exceptions where possible.
- `open` / `continueRecent` / `prepareManagedCandidateForWrite` throw the typed errors with recovery messages.
- CLI: bare-resume picker path and `createSessionManager` path catch operator-facing errors, print recovery text, set `exitCode = 1`, clean up, and return — **no process crash**.

## Files

| File | Role |
| --- | --- |
| `packages/coding-agent/src/session/internal/managed-session-storage.ts` | Live-holder assertOwned + synchronous lease renew |
| `packages/coding-agent/src/session/session-manager.ts` | Typed errors, open/continue/prepare mapping, recovery formatters |
| `packages/coding-agent/src/main.ts` | CLI catch on resume picker + createSessionManager |
| `packages/coding-agent/test/session/managed-lock-lease.test.ts` | Regression: expired lease still owned; foreign attemptId still fences |
| `packages/coding-agent/test/session-manager/session-directory.test.ts` | Capacity recovery message assertions |
| `packages/coding-agent/CHANGELOG.md` | Unreleased note |

## Out of scope (intentionally)

- Full `gjc gc` support for bulk-archiving legacy session artifacts (issue suggests either GC **or** precise recovery text; this PR does the latter).
- Chunking/hashing every migration I/O path to yield the event loop (not required once live holders do not self-fence; can be a follow-up for fairness under extreme load).
- Re-introducing or depending on #3489 Windows replacement-authority work (later reverted on `dev`); this PR targets #3508's three requirements only.

## Test plan

- [x] `bun --cwd=packages/coding-agent run check` (biome + tsc)
- [x] `bun test packages/coding-agent/test/session/managed-lock-lease.test.ts`
  - live holder renews after forced lease expiry
  - foreign `attemptId` still throws `migration_busy`
- [x] Capacity open path still returns `reason: "artifact_capacity_exceeded"` with recovery text helpers
- [ ] Hosted exact-head Dev CI green on this PR
- [ ] Optional Windows dogfood: oversized legacy resume shows recovery message (no crash); after shrinking artifacts, long migration completes without `migration_busy`

## Risk notes for reviewers

- Lock change is intentionally narrow: only the **live fd holder** is exempt from pure lease-timestamp self-fence; reclaim semantics for dead owners remain lease-based.
- Please verify no path relies on “self-fence after 60s of stuck holder” as a deliberate liveness mechanism (we treat that as the bug described in #3508).

