### PR TITLE
test(tui): pin whole-frame sticky viewport content

### DIFF
--- a/packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts
@@ -3,7 +3,6 @@ import * as path from "node:path";
 
 import {
 	renderStickyViewportShowcase,
-	STICKY_VIEWPORT_FRAME_TEXT_WITNESS,
 	STICKY_VIEWPORT_SHOWCASE_ENTRIES,
 	STICKY_VIEWPORT_SHOWCASE_KEYS,
 	type StickyViewportShowcaseEntry,
@@ -175,15 +174,6 @@ export function ansiToHtml(value: string): string {
 }
 const json = (value: unknown) => `${JSON.stringify(value, null, 2)}\n`;
 const hash = (value: string | Uint8Array) => new Bun.CryptoHasher("sha256").update(value).digest("hex");
-// Host-independent digest of a painted frame. `frame_sha256` hashes the ANSI
-// artifact, which legitimately differs between an indexed-color and a truecolor
-// host because `detectColorMode()` negotiates `38;5;n` versus `38;2;r;g;b` per
-// host. The ANSI-STRIPPED paint is byte-identical across both, so it is the only
-// frame-wide value that can be pinned to a committed witness without breaking
-// host portability. It lives here rather than in the fixture so the verifier
-// imports the derivation from a module that does not also own the expectation
-// table it is checked against.
-export const stickyViewportFrameTextDigest = (frame: string): string => hash(Bun.stripANSI(frame));
 const PROVENANCE_SOURCES = [
 	"packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts",
 	"packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts",
@@ -308,16 +298,6 @@ async function capture(entry: StickyViewportShowcaseEntry, root: string, sourceP
 		JSON.stringify(entry.stateId === "narrow-cjk" ? CJK_PHRASE_BOUNDARIES : [])
 	)
 		throw new Error(`${entry.key}: CJK phrase boundary metadata precondition failed`);
-	// Capture-time drift check. The verifier pins the whole painted frame to a
-	// committed witness, so a legitimate renderer change must update that table in
-	// the same reviewed commit. Asserting here makes the drift fail at capture with
-	// the observed digest in hand, instead of surfacing later as an opaque verify
-	// failure on an already-published bundle.
-	const frameTextDigest = stickyViewportFrameTextDigest(rendered.terminalText);
-	if (frameTextDigest !== STICKY_VIEWPORT_FRAME_TEXT_WITNESS[entry.key])
-		throw new Error(
-			`${entry.key}: painted frame digest is ${frameTextDigest} but the committed witness pins ${STICKY_VIEWPORT_FRAME_TEXT_WITNESS[entry.key]}`,
-		);
 	const directory = path.join(root, ...entry.key.split("/"));
 	await fs.mkdir(directory, { recursive: true });
 	const metadata = json({

--- a/packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 
 import {
 	renderStickyViewportShowcase,
+	STICKY_VIEWPORT_FRAME_TEXT_WITNESS,
 	STICKY_VIEWPORT_SHOWCASE_ENTRIES,
 	STICKY_VIEWPORT_SHOWCASE_KEYS,
 	type StickyViewportShowcaseEntry,
@@ -174,6 +175,15 @@ export function ansiToHtml(value: string): string {
 }
 const json = (value: unknown) => `${JSON.stringify(value, null, 2)}\n`;
 const hash = (value: string | Uint8Array) => new Bun.CryptoHasher("sha256").update(value).digest("hex");
+// Host-independent digest of a painted frame. `frame_sha256` hashes the ANSI
+// artifact, which legitimately differs between an indexed-color and a truecolor
+// host because `detectColorMode()` negotiates `38;5;n` versus `38;2;r;g;b` per
+// host. The ANSI-STRIPPED paint is byte-identical across both, so it is the only
+// frame-wide value that can be pinned to a committed witness without breaking
+// host portability. It lives here rather than in the fixture so the verifier
+// imports the derivation from a module that does not also own the expectation
+// table it is checked against.
+export const stickyViewportFrameTextDigest = (frame: string): string => hash(Bun.stripANSI(frame));
 const PROVENANCE_SOURCES = [
 	"packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts",
 	"packages/coding-agent/scripts/capture-sticky-viewport-showcase.ts",
@@ -298,6 +308,16 @@ async function capture(entry: StickyViewportShowcaseEntry, root: string, sourceP
 		JSON.stringify(entry.stateId === "narrow-cjk" ? CJK_PHRASE_BOUNDARIES : [])
 	)
 		throw new Error(`${entry.key}: CJK phrase boundary metadata precondition failed`);
+	// Capture-time drift check. The verifier pins the whole painted frame to a
+	// committed witness, so a legitimate renderer change must update that table in
+	// the same reviewed commit. Asserting here makes the drift fail at capture with
+	// the observed digest in hand, instead of surfacing later as an opaque verify
+	// failure on an already-published bundle.
+	const frameTextDigest = stickyViewportFrameTextDigest(rendered.terminalText);
+	if (frameTextDigest !== STICKY_VIEWPORT_FRAME_TEXT_WITNESS[entry.key])
+		throw new Error(
+			`${entry.key}: painted frame digest is ${frameTextDigest} but the committed witness pins ${STICKY_VIEWPORT_FRAME_TEXT_WITNESS[entry.key]}`,
+		);
 	const directory = path.join(root, ...entry.key.split("/"));
 	await fs.mkdir(directory, { recursive: true });
 	const metadata = json({

--- a/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
@@ -14,7 +14,6 @@ import {
 	gitObjectType,
 	PROVENANCE_DIFF_SCOPE,
 	resolveRepositoryPath,
-	stickyViewportFrameTextDigest,
 	xterm256Color,
 } from "./capture-sticky-viewport-showcase";
 
@@ -695,6 +694,7 @@ const verifySemanticAnchor = (
 // the artifact digest and legitimately diverges between an indexed-color and a
 // truecolor host; the stripped paint does not, so it is the only frame-wide
 // surface that a single committed value can pin on both hosts.
+export const stickyViewportFrameTextDigest = (frame: string): string => hash(Bun.stripANSI(frame));
 const verifyFrameTextWitness = (key: string, text: string) => {
 	// Fail closed: an unwitnessed key is an unpinned frame, not a pass.
 	const expected: string | undefined = STICKY_VIEWPORT_FRAME_TEXT_WITNESS[key as StickyViewportShowcaseKey];

--- a/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
+++ b/packages/coding-agent/scripts/verify-sticky-viewport-showcase.ts
@@ -2,6 +2,8 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import {
 	SEMANTIC_ANCHOR_DOMAIN,
+	STICKY_VIEWPORT_FRAME_TEXT_WITNESS,
+	type StickyViewportShowcaseKey,
 	semanticAnchorDigest,
 	semanticAnchorNamespace,
 } from "../test/fixtures/tui/sticky-viewport-showcase";
@@ -12,6 +14,7 @@ import {
 	gitObjectType,
 	PROVENANCE_DIFF_SCOPE,
 	resolveRepositoryPath,
+	stickyViewportFrameTextDigest,
 	xterm256Color,
 } from "./capture-sticky-viewport-showcase";
 
@@ -673,6 +676,35 @@ const verifySemanticAnchor = (
 	if (owner !== undefined) fail(`semantic anchor guard: ${key} id aliases the anchor already claimed by ${owner}`);
 	seen.set(id as string, key);
 };
+// Whole-frame content witness. The semantic anchor guard above pins exactly ONE
+// painted row per entry, and `anchor.frame_sha256` is recomputed from the
+// bundle's OWN artifact, so it only proves internal consistency: a producer who
+// rewrites a non-anchor row and coordinately rehashes every dependent digest --
+// artifacts, metadata, manifest entry, provenance blocks, review-input binding --
+// stayed self-consistent and was ACCEPTED. In an 80x24 frame 13 rows carry
+// content while one is anchored, so the transcript rows carrying the bundle's own
+// evidence text were rewritable at will.
+//
+// This compares the painted frame against a value committed in oracle source,
+// which no bundle can reach. It is invoked LAST in the per-entry loop, after the
+// anchor guard and after every geometry, marker, and CJK oracle, so a mutation
+// those already attribute keeps its narrower message and only the rows no other
+// oracle inspects surface here.
+//
+// The digest is over the ANSI-STRIPPED paint. `frame_sha256` stays untouched as
+// the artifact digest and legitimately diverges between an indexed-color and a
+// truecolor host; the stripped paint does not, so it is the only frame-wide
+// surface that a single committed value can pin on both hosts.
+const verifyFrameTextWitness = (key: string, text: string) => {
+	// Fail closed: an unwitnessed key is an unpinned frame, not a pass.
+	const expected: string | undefined = STICKY_VIEWPORT_FRAME_TEXT_WITNESS[key as StickyViewportShowcaseKey];
+	if (expected === undefined) fail(`frame content guard: ${key} has no committed frame text witness`);
+	const observed = stickyViewportFrameTextDigest(text);
+	if (observed !== expected)
+		fail(
+			`frame content guard: ${key} painted frame digest is ${observed} but the committed witness pins ${expected}`,
+		);
+};
 export async function verifyStickyViewportShowcase(rootInput: string, requireIndependentReview = false): Promise<void> {
 	const root = path.resolve(rootInput);
 	const manifestText = await fs.readFile(path.join(root, "manifest.json"), "utf8");
@@ -982,6 +1014,15 @@ export async function verifyStickyViewportShowcase(rootInput: string, requireInd
 				fail("narrow CJK visible terminal evidence missing");
 			verifyCjkCellOracle(text, columns, pinBoundary.row, cursor.row);
 		} else strings(metadata.cjk_phrase_boundaries, [], `non-narrow CJK boundaries for ${key}`);
+		// Whole-frame pin, LAST in the per-entry loop. It runs after the semantic
+		// anchor guard so an anchor-row mutation keeps its narrower anchor
+		// attribution, and after the geometry, marker, and CJK oracles so a case that
+		// mutates the paint to reach one of those keeps its own attribution too.
+		// Ordering costs nothing here: every check above reads the same painted frame
+		// this pins, so none of them can be subverted by a paint this guard would
+		// reject. What lands here is the residue -- rows no other oracle looks at,
+		// which is precisely the unpinned surface this guard exists to close.
+		verifyFrameTextWitness(key, text);
 	}
 	const required = new Set([
 		"manifest.json",

--- a/packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts
+++ b/packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts
@@ -132,6 +132,53 @@ export const semanticAnchorDigest = (input: {
 		.digest("hex");
 /** Namespace of a renderer anchor id, i.e. everything before its volatile per-run suffix. */
 export const semanticAnchorNamespace = (id: string) => id.split(":").slice(0, -1).join(":");
+// Immutable per-entry witness over the WHOLE painted frame, not just the anchor
+// row. The semantic anchor pins exactly one row; in an 80x24 frame only 13 rows
+// carry content, so every other painted row -- including the transcript rows that
+// carry the bundle's own evidence text -- was pinned to nothing. `frame_sha256`
+// cannot close that: the verifier recomputes it from the bundle's own artifact, so
+// a producer who rewrites a row and rehashes every dependent digest stays
+// internally consistent and was accepted.
+//
+// The digest is over the ANSI-STRIPPED paint (`stickyViewportFrameTextDigest`).
+// An ANSI-frame digest is not pinnable: `detectColorMode()` negotiates truecolor
+// `38;2;r;g;b` versus indexed `38;5;n` from COLORTERM/TERM, so one committed value
+// would reject an honest capture on the other host. The stripped paint is
+// byte-identical across both, which is why `terminal.txt` is the pinned surface
+// and `frame_sha256` stays as host-dependent artifact binding only.
+//
+// The three capacity-zero entries have a null semantic anchor, so before this
+// table their frames carried no immutable expectation at all. They are covered
+// here like every other key.
+//
+// Values are rendered output, not authored constants: regenerate by printing
+// `stickyViewportFrameTextDigest(render.terminalText)` for each key. This file is
+// in the verifier's `ORACLE_SOURCES`, so `verifyOracleIntegrity()` forces these
+// bytes to match their committed blob at the reviewed authority commit -- a
+// producer cannot restate the pin without a reviewed commit.
+export const STICKY_VIEWPORT_FRAME_TEXT_WITNESS: Readonly<Record<StickyViewportShowcaseKey, string>> = Object.freeze({
+	"live-overflow/80x24/unicode-color": "18ff7c45f2d6871a12fe0c6eb5b444b8f53c3c83f012bf551c460753c1af4bbe",
+	"live-overflow/120x36/unicode-color": "d5ed298e00b6f3f775cca5103deec287d56a6cc5efa68fa5fb3da9f2bf7bced0",
+	"manual-history/80x24/unicode-color": "f2b5cc88983601d313b32d58fe62170adbba19056d9486fa9fd595040b954332",
+	"manual-history/120x36/unicode-color": "904c7e94fc0d20a31deabc2e93f794261dcbfbc97f8bd31e8a386698235fde13",
+	"manual-new-output/80x24/unicode-color": "dce169b90e5a7f6557c1db829cda47716fc250d71698892637ba00b199c4a706",
+	"manual-new-output/120x36/unicode-color": "e7cfa1971dead39a00f98200e6172117f4535301040cb4c7f40486e2e55d2463",
+	"multiline-editor-hooks-pet/80x24/unicode-color": "b6d42786e23bd931c450ba0a63886bb633c3976c4f410aad1f2fc7775a3e48fe",
+	"multiline-editor-hooks-pet/120x36/unicode-color":
+		"3944f1563c74aba7bbac2b287d8fe17917e8aefe39d74a4d6fbd7433ffba60b2",
+	"capacity-many/80x24/unicode-color": "b55610b0ecd90502338a67a951d014f9b2311658a0c64d008d6590613fef3101",
+	"capacity-many/120x36/unicode-color": "956a4cc18b50abaf30fcbe0401cf5cf876da6f1611ad1f326d2b0a0042fda409",
+	"capacity-one/80x24/unicode-color": "58dee6e4f2df74de3324ed39cfa89680f6888850717f312d9da994f932031755",
+	"capacity-one/120x36/unicode-color": "80d87c6062a26c39f932a21446cfd453852edd694db6d005544bb46d02eb916e",
+	"capacity-zero/80x24/unicode-color": "174bbb2e5913a0361c32e74abb519e0a34ed7f46d4dc29235d8c7fb568c76a86",
+	"capacity-zero/120x36/unicode-color": "482db3cfb4f47050fbdebb450721851b3f6aefb3493825321e259810848b7339",
+	"selection-boundary/80x24/unicode-color": "8a6b28cff37576e3e11d5d8a549aa33efde56b4dd6d6704da91e506d79a0ca44",
+	"selection-boundary/120x36/unicode-color": "9e45f3a188c836870c708290e5d094842f75d142de1a072465866ef1425fa027",
+	"manual-new-output/80x24/ascii-no-color": "dce169b90e5a7f6557c1db829cda47716fc250d71698892637ba00b199c4a706",
+	"capacity-zero/48x10/ascii-no-color": "d39aeb89abc4aaaa5523668f63cfe918dae6751a8dac1025178c9dbcfb68c8f9",
+	"multiline-editor-hooks-pet/48x10/unicode-color": "c54fbe3d52e8e3625cd90e746b0c4be25f5563a0c950be615d372e7295afde59",
+	"narrow-cjk/48x10/unicode-color": "dcdc88cc87b4693ef0f1500fe304de994da6f2c6916faf5165bacda77c66c161",
+});
 // Every persisted frame must be canonical for its render mode, not just the
 // top-level payload. `metadata.json` is a required manifest artifact, so raw
 // frames here would make the whole bundle host-dependent: theme.ts emits SGR

--- a/packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts
+++ b/packages/coding-agent/test/fixtures/tui/sticky-viewport-showcase.ts
@@ -152,10 +152,10 @@ export const semanticAnchorNamespace = (id: string) => id.split(":").slice(0, -1
 // here like every other key.
 //
 // Values are rendered output, not authored constants: regenerate by printing
-// `stickyViewportFrameTextDigest(render.terminalText)` for each key. This file is
-// in the verifier's `ORACLE_SOURCES`, so `verifyOracleIntegrity()` forces these
-// bytes to match their committed blob at the reviewed authority commit -- a
-// producer cannot restate the pin without a reviewed commit.
+// `stickyViewportFrameTextDigest(render.terminalText)` for each key. Both this
+// table and the digest derivation in the verifier are in `ORACLE_SOURCES`, so
+// `verifyOracleIntegrity()` forces them to match their committed blobs at the
+// reviewed authority commit -- a producer cannot restate either side.
 export const STICKY_VIEWPORT_FRAME_TEXT_WITNESS: Readonly<Record<StickyViewportShowcaseKey, string>> = Object.freeze({
 	"live-overflow/80x24/unicode-color": "18ff7c45f2d6871a12fe0c6eb5b444b8f53c3c83f012bf551c460753c1af4bbe",
 	"live-overflow/120x36/unicode-color": "d5ed298e00b6f3f775cca5103deec287d56a6cc5efa68fa5fb3da9f2bf7bced0",

--- a/packages/coding-agent/test/sticky-viewport-showcase.test.ts
+++ b/packages/coding-agent/test/sticky-viewport-showcase.test.ts
@@ -10,11 +10,13 @@ import {
 	PROVENANCE_DIFF_SCOPE,
 	REPOSITORY_ROOT,
 	resolveRepositoryPath,
+	stickyViewportFrameTextDigest,
 	xterm256Color,
 } from "../scripts/capture-sticky-viewport-showcase";
 import { verifyStickyViewportShowcase } from "../scripts/verify-sticky-viewport-showcase";
 import {
 	SEMANTIC_ANCHOR_DOMAIN,
+	STICKY_VIEWPORT_FRAME_TEXT_WITNESS,
 	STICKY_VIEWPORT_SHOWCASE_COVERAGE,
 	semanticAnchorDigest,
 } from "./fixtures/tui/sticky-viewport-showcase";
@@ -1088,6 +1090,10 @@ describe("sticky viewport production evidence verifier", () => {
 			await Bun.write(resolveRepositoryPath(oracle), malicious);
 			await restampProvenance(root);
 			await expect(verifyStickyViewportShowcase(root)).rejects.toThrow("oracle integrity");
+			// The operator may have declared an authority for the whole run (that is how
+			// an uncommitted staged oracle is reviewed). Save and restore it rather than
+			// deleting, or this case silently unpins every later case in the file.
+			const declared = process.env.GJC_STICKY_VIEWPORT_ORACLE_COMMIT;
 			process.env.GJC_STICKY_VIEWPORT_ORACLE_COMMIT = await git(["rev-parse", "HEAD"]);
 			try {
 				await restampProvenance(root);
@@ -1166,5 +1172,119 @@ describe("sticky viewport production evidence verifier", () => {
 			restoreEnvironment("GJC_STICKY_VIEWPORT_ORACLE_COMMIT", originalOracleCommit);
 			await fs.rm(temporaryGitDirectory, { recursive: true, force: true });
 		}
+	}, 300_000);
+	// Rewrite one painted row and perform the FULL coordinated rehash the bundle
+	// producer controls: all three artifacts, their manifest digests, the cursor
+	// frame digest, the anchor (optionally reminted so it is honest about the new
+	// paint), every provenance block, and the review-input binding. The result is
+	// internally consistent by construction, so no digest-consistency check can
+	// reject it.
+	async function forgeRow(
+		root: string,
+		key: string,
+		row: number,
+		mutate: (rowText: string) => string,
+		remintAnchor: boolean,
+	): Promise<string> {
+		const ansiPath = path.join(root, key, "terminal-ansi.txt");
+		const ansiRows = (await fs.readFile(ansiPath, "utf8")).split("\n");
+		const before = ansiRows[row]!;
+		ansiRows[row] = mutate(before);
+		if (ansiRows[row] === before) throw new Error(`row ${row} of ${key} was not mutated`);
+		const mutatedAnsi = ansiRows.join("\n");
+		const mutatedText = Bun.stripANSI(mutatedAnsi);
+		await Bun.write(ansiPath, mutatedAnsi);
+		await Bun.write(path.join(root, key, "terminal.txt"), mutatedText);
+		await Bun.write(path.join(root, key, "terminal.html"), ansiToHtml(mutatedAnsi));
+		for (const name of ["terminal-ansi.txt", "terminal.txt", "terminal.html"] as const) await rehash(root, key, name);
+		const metadata = await readMetadata(root, key);
+		metadata.state.cursor.frame_sha256 = new Bun.CryptoHasher("sha256").update(mutatedAnsi).digest("hex");
+		await writeMetadataCoordinated(root, key, metadata);
+		if (remintAnchor) await recomputeAnchor(root, key);
+		await rebindReviewInput(root);
+		return mutatedText;
+	}
+	const rejectionMessage = async (root: string): Promise<string> => {
+		try {
+			await verifyStickyViewportShowcase(root);
+		} catch (error) {
+			return error instanceof Error ? error.message : String(error);
+		}
+		throw new Error("expected the verifier to reject this bundle");
+	};
+	it("rejects a coordinated non-anchor row forgery the anchor guard cannot see", async () => {
+		// Measured defect: the semantic anchor pins exactly ONE painted row, and
+		// `anchor.frame_sha256` is recomputed from the bundle's own artifact. Mutating
+		// `selectable` to `selectabIe` on a NON-anchor transcript row under a full
+		// coordinated rehash was ACCEPTED — in an 80x24 frame 13 rows carry content and
+		// only one was pinned, so ~10 rows, including the transcript rows carrying the
+		// bundle's own evidence text, took arbitrary content.
+		const root = await capture();
+		const key = "manual-new-output/80x24/unicode-color";
+		const anchorRow = (await readMetadata(root, key)).state.semantic_anchor!.frame_start_row;
+		const rows = (await fs.readFile(path.join(root, key, "terminal.txt"), "utf8")).split("\n");
+		// A row carrying the same token as the anchor row but which the anchor does
+		// not cover, so the mutation is provably outside the anchor's reach. The
+		// replacement is the same cell width, so no geometry check can notice.
+		const targetRow = rows.findIndex((text, index) => index !== anchorRow && text.includes("selectable"));
+		expect(targetRow).toBeGreaterThanOrEqual(0);
+		expect(targetRow).not.toBe(anchorRow);
+		const mutatedText = await forgeRow(root, key, targetRow, text => text.replace("selectable", "selectabIe"), true);
+		const observed = stickyViewportFrameTextDigest(mutatedText);
+		const expected = STICKY_VIEWPORT_FRAME_TEXT_WITNESS[key];
+		expect(observed).not.toBe(expected);
+		const message = await rejectionMessage(root);
+		expect(message).toBe(
+			`Sticky viewport evidence invalid: frame content guard: ${key} painted frame digest is ${observed} but the committed witness pins ${expected}`,
+		);
+		// Proves the rejection is the new whole-frame pin and not an earlier check
+		// that happened to fire: no anchor guard, no digest, no provenance staleness.
+		expect(message).not.toContain("semantic anchor guard");
+		expect(message).not.toContain("hash or byte length mismatch");
+		expect(message).not.toContain("capture provenance is stale");
+	}, 300_000);
+	it("pins the capacity-zero frames whose semantic anchor is null", async () => {
+		// The three capacity-zero entries carry `semantic_anchor: null`, so before the
+		// frame witness their paint had no immutable expectation at all: every row was
+		// rewritable under the same coordinated rehash.
+		const root = await capture();
+		for (const key of ["capacity-zero/80x24/unicode-color", "capacity-zero/48x10/ascii-no-color"] as const) {
+			const clone = await fs.mkdtemp(path.join(os.tmpdir(), "sticky-viewport-showcase-frame-zero-"));
+			roots.push(clone);
+			await fs.cp(root, clone, { recursive: true });
+			expect((await readMetadata(clone, key)).state.semantic_anchor).toBeNull();
+			const rows = (await fs.readFile(path.join(clone, key, "terminal.txt"), "utf8")).split("\n");
+			const targetRow = rows.findIndex(text => text.includes("reserved suffix row 1 "));
+			expect(targetRow).toBeGreaterThanOrEqual(0);
+			// Same width, and it touches none of the ordered suffix markers, so only the
+			// frame witness can object.
+			const mutatedText = await forgeRow(
+				clone,
+				key,
+				targetRow,
+				text => text.replace("reserved suffix row 1 ", "reserved suffix row I "),
+				true,
+			);
+			const observed = stickyViewportFrameTextDigest(mutatedText);
+			expect(await rejectionMessage(clone)).toBe(
+				`Sticky viewport evidence invalid: frame content guard: ${key} painted frame digest is ${observed} but the committed witness pins ${STICKY_VIEWPORT_FRAME_TEXT_WITNESS[key]}`,
+			);
+		}
+	}, 300_000);
+	it("keeps anchor-row mutation attributed to the semantic anchor guard", async () => {
+		// The frame witness must not steal attribution. An anchor-row mutation is
+		// still the anchor guard's case, so the new guard is positioned after it and
+		// this asserts the narrower message survives.
+		const root = await capture();
+		const key = "manual-new-output/80x24/unicode-color";
+		const anchorRow = (await readMetadata(root, key)).state.semantic_anchor!.frame_start_row;
+		const rows = (await fs.readFile(path.join(root, key, "terminal.txt"), "utf8")).split("\n");
+		expect(rows[anchorRow]).toContain("selectable");
+		// `remintAnchor: false`: every artifact and provenance digest is coordinately
+		// rehashed, but the anchor id and row digest still describe the old paint.
+		await forgeRow(root, key, anchorRow, text => text.replace("selectable", "selectabIe"), false);
+		const message = await rejectionMessage(root);
+		expect(message).toContain("semantic anchor guard");
+		expect(message).not.toContain("frame content guard");
 	}, 300_000);
 });

--- a/packages/coding-agent/test/sticky-viewport-showcase.test.ts
+++ b/packages/coding-agent/test/sticky-viewport-showcase.test.ts
@@ -10,10 +10,12 @@ import {
 	PROVENANCE_DIFF_SCOPE,
 	REPOSITORY_ROOT,
 	resolveRepositoryPath,
-	stickyViewportFrameTextDigest,
 	xterm256Color,
 } from "../scripts/capture-sticky-viewport-showcase";
-import { verifyStickyViewportShowcase } from "../scripts/verify-sticky-viewport-showcase";
+import {
+	stickyViewportFrameTextDigest,
+	verifyStickyViewportShowcase,
+} from "../scripts/verify-sticky-viewport-showcase";
 import {
 	SEMANTIC_ANCHOR_DOMAIN,
 	STICKY_VIEWPORT_FRAME_TEXT_WITNESS,
@@ -1093,7 +1095,6 @@ describe("sticky viewport production evidence verifier", () => {
 			// The operator may have declared an authority for the whole run (that is how
 			// an uncommitted staged oracle is reviewed). Save and restore it rather than
 			// deleting, or this case silently unpins every later case in the file.
-			const declared = process.env.GJC_STICKY_VIEWPORT_ORACLE_COMMIT;
 			process.env.GJC_STICKY_VIEWPORT_ORACLE_COMMIT = await git(["rev-parse", "HEAD"]);
 			try {
 				await restampProvenance(root);
@@ -1248,7 +1249,11 @@ describe("sticky viewport production evidence verifier", () => {
 		// frame witness their paint had no immutable expectation at all: every row was
 		// rewritable under the same coordinated rehash.
 		const root = await capture();
-		for (const key of ["capacity-zero/80x24/unicode-color", "capacity-zero/48x10/ascii-no-color"] as const) {
+		for (const key of [
+			"capacity-zero/80x24/unicode-color",
+			"capacity-zero/120x36/unicode-color",
+			"capacity-zero/48x10/ascii-no-color",
+		] as const) {
 			const clone = await fs.mkdtemp(path.join(os.tmpdir(), "sticky-viewport-showcase-frame-zero-"));
 			roots.push(clone);
 			await fs.cp(root, clone, { recursive: true });


### PR DESCRIPTION
## Summary
- pin SHA-256 of ANSI-stripped paint for all 20 sticky-viewport showcase entries
- protect both witness derivation and values with the reviewed oracle commit
- reject coordinated non-anchor rewrites, including all three null-anchor capacity-zero frames

## Verification
- truecolor focused suite: 22 pass, 0 fail, 3388 assertions
- dumb-host focused suite: 22 pass, 0 fail, 3388 assertions
- `bun --cwd=packages/coding-agent check`
- independent architect: CLEAR
- independent maintainability review: CLEAR
- adversarial QA: PASS, no blockers

Exact reviewed head: `ec4f3732ce3c4e6eea25669ba865d25fa2704747`