### PR TITLE
fix(coding-agent): avoid double-decoding local URL authorities

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Deferred `agent_end` publication again settles public session readiness before slow extension handlers finish, while retaining exact cancellation leases through queued extension delivery and draining that delivery before session shutdown.
 - Ultragoal validation-batch hydration now fails closed unless deferred and final-close evidence exactly matches a complete authoritative cumulative Git/CI inventory and durable batch tuple. Explicit malformed, partial, unknown, reordered, or stale receipt data is rejected; Git path capture is byte-safe, NUL-delimited, and includes untracked files; incomplete capture conservatively requires computer-control QA; shared settings and tool registries cannot use partial diffs to bypass that suite; validate/checkpoint replacement hydration is identical; and current/replacement receipts are byte-bound to ledger payloads (#3541).
 - Fixture quality gates that complete intermediate Ultragoal stories now write file-backed adversarial artifact proof; skill-state hooks and computer red-team fixtures match the unconditional adversarial path check so #3543 CI stays fail-closed without weakening hydration exactness (#3543).
+- `local://` URL authorities decoded by the internal parser are no longer decoded a second time, so percent-encoded filenames resolve to their exact local files (#3594).
 
 ### Fixed
 

--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -103,25 +103,25 @@ async function buildListing(url: InternalUrl, localRoot: string): Promise<Intern
 function extractRelativePath(url: InternalUrl): string {
 	const host = url.rawHost || url.hostname;
 	const pathname = url.rawPathname ?? url.pathname;
+	const encodedHost = url.href.match(/^[a-z][a-z0-9+.-]*:\/\/([^/?#]*)/i)?.[1] ?? "";
 
-	const combined = host
-		? pathname && pathname !== "/"
-			? `${host}${pathname}`
-			: host
-		: pathname && pathname !== "/"
-			? pathname.slice(1)
-			: "";
-
-	if (!combined) {
-		return "";
-	}
-
-	let decoded: string;
+	let decodedPathname: string;
 	try {
-		decoded = decodeURIComponent(combined.replaceAll("\\", "/"));
+		decodeURIComponent(encodedHost);
+		decodedPathname = decodeURIComponent(pathname);
 	} catch {
 		throw new Error(`Invalid URL encoding in local:// path: ${url.href}`);
 	}
+
+	const combined = host
+		? decodedPathname && decodedPathname !== "/"
+			? `${host}${decodedPathname}`
+			: host
+		: decodedPathname && decodedPathname !== "/"
+			? decodedPathname.slice(1)
+			: "";
+
+	const decoded = combined.replaceAll("\\", "/");
 	try {
 		validateRelativePath(decoded);
 	} catch (error) {

--- a/packages/coding-agent/test/tools/search-internal-urls.test.ts
+++ b/packages/coding-agent/test/tools/search-internal-urls.test.ts
@@ -189,6 +189,37 @@ describe("SearchTool internal URL resolution", () => {
 		// Hashline anchor (LINE+ID|content) is kept for mutable local:// sources
 		expect(text).toMatch(/^\*?\s*\d+[a-z]{2}\|/m);
 	});
+	it("resolves percent-encoded local URL authorities without selecting decoded siblings", async () => {
+		const localRoot = path.join(artifactsDir, "local");
+		await fs.mkdir(localRoot, { recursive: true });
+		await Bun.write(path.join(localRoot, "report%3Araw.txt"), "percent-named sibling\n");
+		await Bun.write(path.join(localRoot, "report:raw.txt"), "colon-named sibling\n");
+
+		LocalProtocolHandler.setOverride({ getArtifactsDir: () => artifactsDir, getSessionId: () => "session" });
+
+		const tool = new SearchTool(createSession());
+		const result = await tool.execute("test-call", {
+			pattern: "sibling",
+			paths: ["local://report%253Araw.txt"],
+		});
+
+		const text = getResultText(result);
+		expect(text).toContain("percent-named sibling");
+		expect(text).not.toContain("colon-named sibling");
+	});
+
+	it("rejects malformed percent escapes in local URL authorities", async () => {
+		const localRoot = path.join(artifactsDir, "local");
+		await fs.mkdir(localRoot, { recursive: true });
+		await Bun.write(path.join(localRoot, "bad%ZZ.txt"), "must not be reachable\n");
+
+		LocalProtocolHandler.setOverride({ getArtifactsDir: () => artifactsDir, getSessionId: () => "session" });
+
+		const tool = new SearchTool(createSession());
+		await expect(tool.execute("test-call", { pattern: "reachable", paths: ["local://bad%ZZ.txt"] })).rejects.toThrow(
+			"Invalid URL encoding in local:// path",
+		);
+	});
 
 	it("keeps hashlines on mutable files when mixed with immutable artifact:// inputs", async () => {
 		const content = "alpha line\nbeta needle line\ngamma line\n";


### PR DESCRIPTION
## What

- Preserve the already-decoded local-scheme authority returned by the internal URL parser.
- Validate the raw encoded authority without applying its decoded value a second time.
- Decode only the raw pathname before normalization and safety validation.
- Add regressions for exact percent-named sibling selection and malformed authority escapes.
- Document the fix in the coding-agent Unreleased changelog.

## Why

The authority was decoded once by `parseInternalUrl` and again by `LocalProtocolHandler`, so an encoded authority of `report%253Araw.txt` could resolve `report:raw.txt` instead of `report%3Araw.txt`.

Fixes #3594

## Testing

- `bun --cwd=packages/natives run build`
- `bun test packages/coding-agent/test/tools/search-internal-urls.test.ts`
- `bun test packages/coding-agent/test/tools/search-internal-urls.test.ts packages/coding-agent/test/tools/split-internal-url-sel.test.ts packages/coding-agent/test/marketplace/parse-internal-url.test.ts` (51 passed)
- `bunx biome check packages/coding-agent/src/internal-urls/local-protocol.ts packages/coding-agent/test/tools/search-internal-urls.test.ts packages/coding-agent/CHANGELOG.md`
- `bun run check:tools`
- `bun scripts/ci-release-publish.ts --check-types`

## GJC verdict

`gajae.pr-review-verdict.v1 merge-approved sha256:52fe11f7e reviewer:architect evidence:bun-test-internal-url-suite`