### PR TITLE
fix(utils): validate positive-integer environment values

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Positive-integer environment helpers now reject malformed, fractional, exponent-form, non-positive, and unsafe values instead of silently accepting their numeric prefixes (#3593).
 
 ## [0.12.4] - 2026-07-30
 

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -147,16 +147,20 @@ export function $pickCredentialEnv(...keys: string[]): string | undefined {
 	return undefined;
 }
 
+function parsePositiveInteger(raw: string | undefined): number | undefined {
+	const value = raw?.trim();
+	if (!value || !/^\d+$/.test(value)) return undefined;
+	const parsed = Number(value);
+	return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
 /**
  * Parses a positive decimal integer from `$env[name]`.
- * Empty, invalid, NaN, zero, or negative values return `defaultValue`.
+ * Empty, invalid, unsafe, zero, or negative values return `defaultValue`.
  */
 export function $envpos(name: string, defaultValue: number): number {
-	const raw = $env[name];
-	if (!raw) return defaultValue;
-	const parsed = Number.parseInt(raw, 10);
-	if (Number.isNaN(parsed) || parsed <= 0) return defaultValue;
-	return parsed;
+	const parsed = parsePositiveInteger($env[name]);
+	return parsed ?? defaultValue;
 }
 
 /** True when `BUN_ENV` or `NODE_ENV` is the string `test`. */
@@ -200,10 +204,8 @@ export function $pickflag(...keys: string[]): boolean {
 /** Resolve the first positive integer among keys, else defaultValue (GJC-first). Set-but-invalid keys are skipped. */
 export function $pickenvpos(keys: string[], defaultValue: number): number {
 	for (const key of keys) {
-		const raw = $env[key]?.trim();
-		if (!raw) continue;
-		const parsed = Number.parseInt(raw, 10);
-		if (!Number.isNaN(parsed) && parsed > 0) return parsed;
+		const parsed = parsePositiveInteger($env[key]);
+		if (parsed !== undefined) return parsed;
 	}
 	return defaultValue;
 }

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
-import { $flag, $pickenvpos, $pickflag, filterProcessEnv, parseEnvFile, parseShellEnvFile } from "../src/env";
+import { $envpos, $flag, $pickenvpos, $pickflag, filterProcessEnv, parseEnvFile, parseShellEnvFile } from "../src/env";
 
 const tempDirs: string[] = [];
 
@@ -384,6 +384,36 @@ describe("$pickflag", () => {
 	});
 });
 
+describe("$envpos", () => {
+	const NAME = "__GJC_UTILS_ENVPOS_PROBE";
+
+	afterEach(() => {
+		delete process.env[NAME];
+	});
+
+	it.each([
+		"12oops",
+		"1.5",
+		"1e3",
+		"0",
+		"-1",
+		String(Number.MAX_SAFE_INTEGER + 1),
+	])("returns the default for invalid complete-token value %j", value => {
+		process.env[NAME] = value;
+		expect($envpos(NAME, 100)).toBe(100);
+	});
+
+	it("accepts a whitespace-padded positive safe integer", () => {
+		process.env[NAME] = " 42 ";
+		expect($envpos(NAME, 100)).toBe(42);
+	});
+
+	it("accepts a zero-padded positive safe integer", () => {
+		process.env[NAME] = "00042";
+		expect($envpos(NAME, 100)).toBe(42);
+	});
+});
+
 describe("$pickenvpos", () => {
 	const GJC_NAME = "__GJC_UTILS_PICKENVPOS_PROBE";
 	const PI_NAME = "__PI_UTILS_PICKENVPOS_PROBE";
@@ -414,6 +444,12 @@ describe("$pickenvpos", () => {
 
 	it("skips a set-but-invalid GJC key and falls through to a valid PI key", () => {
 		process.env[GJC_NAME] = "-5";
+		process.env[PI_NAME] = "3";
+		expect($pickenvpos([GJC_NAME, PI_NAME], 100)).toBe(3);
+	});
+
+	it("skips a partially parsed GJC value and falls through to a valid PI key", () => {
+		process.env[GJC_NAME] = "12oops";
 		process.env[PI_NAME] = "3";
 		expect($pickenvpos([GJC_NAME, PI_NAME], 100)).toBe(3);
 	});


### PR DESCRIPTION
## What

- Parse positive-integer environment values with one shared complete-token validator.
- Reject malformed, fractional, exponent-form, non-positive, and unsafe integers while preserving whitespace and leading-zero compatibility.
- Keep GJC-first fallback behavior by skipping invalid higher-priority values.
- Add focused regressions and an Unreleased utils changelog entry.

## Why

`Number.parseInt` accepted numeric prefixes, so values such as `12oops`, `1.5`, and `1e3` silently became different valid integers. A malformed GJC variable could also block a valid PI fallback.

Fixes #3593

## Testing

- `bun test packages/utils/test/env.test.ts`
- `bun test packages/utils/test`
- `bunx biome check packages/utils/src/env.ts packages/utils/test/env.test.ts packages/utils/CHANGELOG.md`
- `bun run check:ts` (completed format, declaration, Node 20 baseline, public sync, schema, and extensive SDK closure gates before the 20-minute local timeout; no failure was reported before timeout)

## GJC verdict

`gajae.pr-review-verdict.v1 merge-approved sha256:f1b7cab2f reviewer:architect evidence:bun-test-packages-utils-test-env.test.ts`