### PR TITLE
fix(tui): bound select-list no-match rows

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Select-list no-match rows now stay within the requested render width instead of wrapping into extra terminal lines after narrow resizes (#3600).
 
 ## [0.12.4] - 2026-07-30
 

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -118,7 +118,7 @@ export class SelectList implements Component {
 
 		// If no items match filter, show message
 		if (this.#filteredItems.length === 0) {
-			lines.push(this.theme.noMatch("  No matching commands"));
+			lines.push(truncateToWidth(this.theme.noMatch("  No matching commands"), Math.max(0, width), Ellipsis.Omit));
 			return lines;
 		}
 

--- a/packages/tui/test/select-list.test.ts
+++ b/packages/tui/test/select-list.test.ts
@@ -203,6 +203,30 @@ describe("SelectList", () => {
 		expect(cancelled).toBe(true);
 	});
 
+	it.each([10, 0])("bounds the no-match row to render width %d", width => {
+		const list = new SelectList([{ value: "run", label: "run" }], 5, testTheme);
+		list.setFilter("missing");
+
+		const rendered = list.render(width);
+
+		expect(rendered).toHaveLength(1);
+		expect(visibleWidth(rendered[0])).toBeLessThanOrEqual(width);
+	});
+
+	it("preserves ANSI styling while bounding the no-match row", () => {
+		const list = new SelectList([{ value: "run", label: "run" }], 5, {
+			...testTheme,
+			noMatch: text => `\x1b[31m${text}\x1b[0m`,
+		});
+		list.setFilter("missing");
+
+		const [row] = list.render(10);
+
+		expect(visibleWidth(row)).toBeLessThanOrEqual(10);
+		expect(row).toContain("\x1b[31m");
+		expect(row).toContain("\x1b[0m");
+	});
+
 	it("preserves enabled-only callbacks when arrow navigation wraps to the same item", () => {
 		const changed: string[] = [];
 		const list = new SelectList([{ value: "only", label: "only" }], 5, testTheme);


### PR DESCRIPTION
## What

- Truncate the themed SelectList no-match row to the requested non-negative render width.
- Preserve one logical row and ANSI styling/reset behavior at narrow widths.
- Add zero-width, narrow-width, and ANSI regression coverage.
- Document the fix in the TUI Unreleased changelog.

## Why

The fixed `  No matching commands` row ignored `render(width)`. Narrow terminals could wrap it into extra physical lines and break redraw line accounting after a resize.

Fixes #3600

## Testing

- `bun --cwd=packages/natives run build`
- `bun test packages/tui/test/select-list.test.ts` (22 passed)
- `bun test packages/tui/test` (968 passed, 6 skipped)
- `bunx biome check packages/tui/src/components/select-list.ts packages/tui/test/select-list.test.ts packages/tui/CHANGELOG.md`
- `bun scripts/ci-release-publish.ts --check-types`

## GJC verdict

`gajae.pr-review-verdict.v1 merge-approved sha256:42d3511d4 reviewer:architect evidence:bun-test-packages-tui-test-select-list.test.ts`