### PR TITLE
fix(coding-agent): validate settings array items

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Deferred `agent_end` publication again settles public session readiness before slow extension handlers finish, while retaining exact cancellation leases through queued extension delivery and draining that delivery before session shutdown.
 - Ultragoal validation-batch hydration now fails closed unless deferred and final-close evidence exactly matches a complete authoritative cumulative Git/CI inventory and durable batch tuple. Explicit malformed, partial, unknown, reordered, or stale receipt data is rejected; Git path capture is byte-safe, NUL-delimited, and includes untracked files; incomplete capture conservatively requires computer-control QA; shared settings and tool registries cannot use partial diffs to bypass that suite; validate/checkpoint replacement hydration is identical; and current/replacement receipts are byte-bound to ledger payloads (#3541).
 - Fixture quality gates that complete intermediate Ultragoal stories now write file-backed adversarial artifact proof; skill-state hooks and computer red-team fixtures match the unconditional adversarial path check so #3543 CI stays fail-closed without weakening hydration exactness (#3543).
+- Runtime settings reconciliation now validates every `web_search.fallback` entry against the declared provider enum instead of accepting unsupported or non-string array items (#3601).
 
 ### Fixed
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3744,6 +3744,11 @@ function schemaPaths(value: Record<string, unknown>, prefix = ""): string[] {
 	return paths;
 }
 
+function validArraySettingValue(value: unknown, allowedValues: readonly string[] | undefined): boolean {
+	if (!Array.isArray(value)) return false;
+	return !allowedValues || value.every(item => typeof item === "string" && allowedValues.includes(item));
+}
+
 function validSettingValue(definition: (typeof SETTINGS_SCHEMA)[SettingPath], value: unknown): boolean {
 	return (
 		(definition.type === "boolean" && typeof value === "boolean") ||
@@ -3755,7 +3760,8 @@ function validSettingValue(definition: (typeof SETTINGS_SCHEMA)[SettingPath], va
 		(definition.type === "enum" &&
 			typeof value === "string" &&
 			(definition.values as readonly string[]).includes(value)) ||
-		(definition.type === "array" && Array.isArray(value)) ||
+		(definition.type === "array" &&
+			validArraySettingValue(value, "items" in definition ? definition.items?.enum : undefined)) ||
 		(definition.type === "record" && !!value && typeof value === "object" && !Array.isArray(value))
 	);
 }
@@ -3792,8 +3798,16 @@ export function reconcileSettingsSchema(raw: Record<string, unknown>): {
 			schemaSetAtPath(settings, path, next);
 			issues.push({ path, kind: "coerced", detail: `Coerced ${typeof value} to ${definition.type}.` });
 		}
-		if (!validSettingValue(definition, next))
-			issues.push({ path, kind: "invalid", detail: `Expected ${definition.type}.` });
+		if (!validSettingValue(definition, next)) {
+			const arrayItemEnum =
+				definition.type === "array" && Array.isArray(next) && "items" in definition
+					? definition.items?.enum
+					: undefined;
+			const detail = arrayItemEnum
+				? `Expected array items to be one of: ${arrayItemEnum.join(", ")}.`
+				: `Expected ${definition.type}.`;
+			issues.push({ path, kind: "invalid", detail });
+		}
 		if (
 			definition.type === "record" &&
 			"valueSchema" in definition &&

--- a/packages/coding-agent/test/settings-array-enum-validation.test.ts
+++ b/packages/coding-agent/test/settings-array-enum-validation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { reconcileSettingsSchema, SETTINGS_SCHEMA } from "../src/config/settings-schema";
+
+describe("settings array item validation", () => {
+	const fallbackItemValues = SETTINGS_SCHEMA["web_search.fallback"].items.enum;
+	it("accepts supported web search fallback providers", () => {
+		const reconciled = reconcileSettingsSchema({ web_search: { fallback: ["exa", "brave"] } });
+
+		expect(reconciled.report.valid).toBe(true);
+		expect(reconciled.settings.web_search).toEqual({ fallback: ["exa", "brave"] });
+	});
+
+	it.each(["typo-provider", 42])("rejects unsupported web search fallback item %j", item => {
+		const reconciled = reconcileSettingsSchema({ web_search: { fallback: [item] } });
+
+		expect(reconciled.report.valid).toBe(false);
+		expect(reconciled.report.issues).toContainEqual({
+			path: "web_search.fallback",
+			kind: "invalid",
+			detail: `Expected array items to be one of: ${fallbackItemValues.join(", ")}.`,
+		});
+	});
+
+	it("reports the array container error for a non-array fallback value", () => {
+		const reconciled = reconcileSettingsSchema({ web_search: { fallback: "exa" } });
+
+		expect(reconciled.report.valid).toBe(false);
+		expect(reconciled.report.issues).toContainEqual({
+			path: "web_search.fallback",
+			kind: "invalid",
+			detail: "Expected array.",
+		});
+	});
+
+	it("preserves container-only validation for arrays without item metadata", () => {
+		const reconciled = reconcileSettingsSchema({ extensions: [42] });
+
+		expect(reconciled.report.valid).toBe(true);
+		expect(reconciled.settings.extensions).toEqual([42]);
+	});
+});


### PR DESCRIPTION
## What

- Validate every item of enum-backed settings arrays at runtime.
- Reject unsupported and non-string web-search fallback providers.
- Preserve container-only behavior for arrays without item metadata and accurate non-array diagnostics.
- Add focused reconciliation regressions and an Unreleased changelog entry.

## Why

`web_search.fallback` declared a provider enum, but runtime reconciliation checked only `Array.isArray`. Typos passed runtime diagnostics even though the published schema rejected them.

Fixes #3601

## Testing

- `bun --cwd=packages/natives run build`
- `bun test packages/coding-agent/test/settings-array-enum-validation.test.ts` (4 passed before diagnostic follow-up)
- `bun test packages/coding-agent/test/settings-array-enum-validation.test.ts packages/coding-agent/test/retry-budget-settings.test.ts packages/coding-agent/test/settings-manager.test.ts` (53 passed)
- `bunx biome check packages/coding-agent/src/config/settings-schema.ts packages/coding-agent/test/settings-array-enum-validation.test.ts packages/coding-agent/CHANGELOG.md`
- `bun run check:tools`
- `bun scripts/ci-release-publish.ts --check-types`

## GJC verdict

`gajae.pr-review-verdict.v1 merge-approved sha256:6f1a178b9 reviewer:architect evidence:bun-test-settings-array-suite`