### PR TITLE
fix(utils): normalize retry delay scheduling

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 - Retryable responses discarded before another fetch attempt now begin body cancellation without blocking retry progress on transport cleanup, releasing buffered response data without consuming responses returned to callers.
 
+### Fixed
+
+- `fetchWithRetry` now normalizes the final response and network-error delay immediately before scheduling, so a scheduled value that remains negative or non-finite after capping becomes an immediate retry instead of reaching the timer runtime; valid delays and the existing hint-over-cap fail-fast path retain their behavior.
+
 ## [0.12.4] - 2026-07-30
 
 ## [0.12.3] - 2026-07-30

--- a/packages/utils/src/fetch-retry.ts
+++ b/packages/utils/src/fetch-retry.ts
@@ -87,7 +87,8 @@ export interface FetchWithRetryOptions extends RequestInit {
 	/**
 	 * Fallback delay schedule when no server hint is present. Number, array
 	 * (indexed by attempt, clamped to last), or function. Default exponential
-	 * `500ms * 2 ** attempt` capped at `maxDelayMs`.
+	 * `500ms * 2 ** attempt` capped at `maxDelayMs`. Values that remain negative
+	 * or non-finite after capping retry immediately.
 	 */
 	defaultDelayMs?: number | readonly number[] | ((attempt: number) => number);
 	/**
@@ -142,7 +143,8 @@ export async function fetchWithRetry(
 			if (signal?.aborted) throw new Error("Request was aborted");
 			const wrapped = wrapNetworkError(error);
 			if (attempt + 1 >= maxAttempts) throw wrapped;
-			await scheduler.wait(resolveDefaultDelay(defaultDelayMs, attempt, maxDelayMs), { signal });
+			const delayMs = normalizeRetryDelay(resolveDefaultDelay(defaultDelayMs, attempt), maxDelayMs);
+			await scheduler.wait(delayMs, { signal });
 			continue;
 		}
 
@@ -152,7 +154,7 @@ export async function fetchWithRetry(
 		const hint = extractRetryHint(response, await response.clone().text());
 		if (hint !== undefined && hint > maxDelayMs) return response;
 
-		const delayMs = Math.min(hint ?? resolveDefaultDelay(defaultDelayMs, attempt, maxDelayMs), maxDelayMs);
+		const delayMs = normalizeRetryDelay(hint ?? resolveDefaultDelay(defaultDelayMs, attempt), maxDelayMs);
 		void response.body?.cancel().catch(() => undefined);
 		await scheduler.wait(delayMs, { signal });
 	}
@@ -184,15 +186,16 @@ function wrapNetworkError(error: unknown): Error {
 	return new Error(String(error));
 }
 
-function resolveDefaultDelay(
-	option: FetchWithRetryOptions["defaultDelayMs"],
-	attempt: number,
-	maxDelayMs: number,
-): number {
-	if (option === undefined) return Math.min(500 * 2 ** attempt, maxDelayMs);
-	if (typeof option === "number") return Math.min(option, maxDelayMs);
-	if (typeof option === "function") return Math.min(option(attempt), maxDelayMs);
-	return Math.min(option[Math.min(attempt, option.length - 1)] ?? 0, maxDelayMs);
+function resolveDefaultDelay(option: FetchWithRetryOptions["defaultDelayMs"], attempt: number): number {
+	if (option === undefined) return 500 * 2 ** attempt;
+	if (typeof option === "number") return option;
+	if (typeof option === "function") return option(attempt);
+	return option[Math.min(attempt, option.length - 1)] ?? 0;
+}
+
+function normalizeRetryDelay(delayMs: number, maxDelayMs: number): number {
+	const cappedDelayMs = Math.min(delayMs, maxDelayMs);
+	return Number.isFinite(cappedDelayMs) && cappedDelayMs >= 0 ? cappedDelayMs : 0;
 }
 
 /**

--- a/packages/utils/test/fetch-retry.test.ts
+++ b/packages/utils/test/fetch-retry.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it, vi } from "bun:test";
-import { fetchWithRetry } from "../src/fetch-retry";
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { scheduler } from "node:timers/promises";
+import { type FetchWithRetryOptions, fetchWithRetry } from "../src/fetch-retry";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
 
 describe("fetchWithRetry", () => {
 	it("routes requests through the `fetch` override when provided", async () => {
@@ -178,5 +183,107 @@ describe("fetchWithRetry", () => {
 		expect(response).toBe(finalResponse);
 		expect(response.bodyUsed).toBe(false);
 		expect(await response.text()).toBe("Please retry in 2s");
+	});
+
+	it.each([
+		["negative numeric", -1, 0],
+		["NaN numeric", Number.NaN, 0],
+		["negative-infinite numeric", Number.NEGATIVE_INFINITY, 0],
+		["negative function result", () => -1, 0],
+		["NaN function result", () => Number.NaN, 0],
+		["negative-infinite function result", () => Number.NEGATIVE_INFINITY, 0],
+		["negative array entry", [-1], 0],
+		["NaN array entry", [Number.NaN], 0],
+		["negative-infinite array entry", [Number.NEGATIVE_INFINITY], 0],
+		["positive-infinite numeric capped to the maximum", Number.POSITIVE_INFINITY, 60_000],
+		["positive-infinite function result capped to the maximum", () => Number.POSITIVE_INFINITY, 60_000],
+		["positive-infinite array entry capped to the maximum", [Number.POSITIVE_INFINITY], 60_000],
+		["finite numeric", 7, 7],
+		["finite function result", () => 11, 11],
+		["finite array entry", [13], 13],
+	] satisfies Array<
+		[string, NonNullable<FetchWithRetryOptions["defaultDelayMs"]>, number]
+	>)("resolves %s before reaching the scheduler", async (_label, defaultDelayMs, expectedDelayMs) => {
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		let attempt = 0;
+
+		const response = await fetchWithRetry("https://example.invalid/delay", {
+			fetch: async () => {
+				attempt += 1;
+				return new Response("", { status: attempt === 1 ? 503 : 200 });
+			},
+			defaultDelayMs,
+			maxAttempts: 2,
+		});
+
+		expect(response.status).toBe(200);
+		expect(waitSpy).toHaveBeenCalledTimes(1);
+		expect(waitSpy).toHaveBeenCalledWith(expectedDelayMs, { signal: undefined });
+	});
+
+	it.each([
+		["negative", -1, 0],
+		["NaN", Number.NaN, 0],
+		["negative-infinite", Number.NEGATIVE_INFINITY, 0],
+		["positive-infinite", Number.POSITIVE_INFINITY, 7],
+	] as const)("normalizes a %s response-path maximum at the scheduler boundary", async (_label, maxDelayMs, expected) => {
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		let attempt = 0;
+
+		const response = await fetchWithRetry("https://example.invalid/response-cap", {
+			fetch: async () => {
+				attempt += 1;
+				return new Response("", { status: attempt === 1 ? 503 : 200 });
+			},
+			defaultDelayMs: 7,
+			maxAttempts: 2,
+			maxDelayMs,
+		});
+
+		expect(response.status).toBe(200);
+		expect(waitSpy).toHaveBeenCalledWith(expected, { signal: undefined });
+	});
+
+	it("normalizes a hinted response delay after applying an invalid maximum", async () => {
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		let attempt = 0;
+
+		const response = await fetchWithRetry("https://example.invalid/hint-cap", {
+			fetch: async () => {
+				attempt += 1;
+				return attempt === 1
+					? new Response("", { status: 429, headers: { "retry-after": "1" } })
+					: new Response("done", { status: 200 });
+			},
+			maxAttempts: 2,
+			maxDelayMs: Number.NaN,
+		});
+
+		expect(response.status).toBe(200);
+		expect(waitSpy).toHaveBeenCalledWith(0, { signal: undefined });
+	});
+
+	it.each([
+		["negative", -1, 0],
+		["NaN", Number.NaN, 0],
+		["negative-infinite", Number.NEGATIVE_INFINITY, 0],
+		["positive-infinite", Number.POSITIVE_INFINITY, 7],
+	] as const)("normalizes a %s network-error maximum at the scheduler boundary", async (_label, maxDelayMs, expected) => {
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		let attempt = 0;
+
+		const response = await fetchWithRetry("https://example.invalid/network-cap", {
+			fetch: async () => {
+				attempt += 1;
+				if (attempt === 1) throw new Error("temporary network failure");
+				return new Response("done", { status: 200 });
+			},
+			defaultDelayMs: 7,
+			maxAttempts: 2,
+			maxDelayMs,
+		});
+
+		expect(response.status).toBe(200);
+		expect(waitSpy).toHaveBeenCalledWith(expected, { signal: undefined });
 	});
 });


### PR DESCRIPTION
## Finding / reproduction

`fetchWithRetry` accepts caller-provided fallback schedules and delay caps, but current `dev` does not normalize the final value at every scheduler boundary. Negative or non-finite values can therefore reach the timer runtime and be warned about or coerced inconsistently.

This remains reproducible on exact base `29ddfe08f51039b1bf4e8e373ba06c68d7005d44`: the network-error path passes `resolveDefaultDelay(...)` directly to `scheduler.wait(...)`.

The affected boundary is retry-delay resolution immediately before scheduling. Public request, response, retry-count, hint-cap, and cancellation contracts remain in scope and preserved.

## Root cause

Delay values are capped while resolving some schedules, but there is no shared final normalization after all caller-controlled schedule and cap combinations have been applied. The response and network-error branches can therefore disagree or hand invalid post-cap values to `scheduler.wait`.

## Change

- Normalize the final delay immediately adjacent to both scheduler calls.
- Keep finite non-negative delays unchanged.
- Clamp positive infinity through the existing cap and turn remaining negative, `NaN`, or negative-infinite results into an immediate `0 ms` retry.
- Preserve the non-blocking cancellation of discarded retry responses introduced by #3577.
- Add boundary regressions for numeric, function, array, hint, response, and network-error paths.

## Scope

- Changed files: 3
- Production: `packages/utils/src/fetch-retry.ts` (`+15/-12`)
- Tests: `packages/utils/test/fetch-retry.test.ts` (`+109/-2`)
- Changelog: `packages/utils/CHANGELOG.md` (`+4/-0`)
- Generated/docs: none

This PR addresses one root cause at one runtime boundary: final retry-delay normalization before scheduling. It adds no dependency, abstraction, unrelated cleanup, or public API.

## Contract

Preserved:

- retry attempt counts and retryable-status behavior;
- server-hint fail-fast behavior above `maxDelayMs`;
- finite schedule values and ordinary caps;
- external abort behavior;
- final-response ownership;
- non-blocking discarded-body cancellation from #3577.

Intentional behavior change: invalid post-cap delay values schedule an immediate retry instead of relying on timer-runtime warning/coercion behavior.

No owner product decision or public-contract migration is required.

## Workflow / orchestration gate

- Transition boundary: none; this is a utils runtime helper.
- Adjacent workflow boundaries changed: none.
- Default path impact: none.
- Shadow/opt-in flag: not applicable.
- Deep-interview impact: none.
- Contributor review tier: T1 / Normal.
- Human approval: normal maintainer review/merge only; no product-owner gate.
- Rollback point: `29ddfe08f51039b1bf4e8e373ba06c68d7005d44`. Revert this single commit (or its eventual squash merge) to restore the exact prior scheduler behavior. No persisted state, generated artifact, schema, or migration remains after rollback.

## Verification

- Base SHA: `29ddfe08f51039b1bf4e8e373ba06c68d7005d44`
- Head SHA: `22488d7a9ac9a895ee6eb867147667468dee28f2`
- Red-on-base: current `dev` sends the network-error result of `resolveDefaultDelay(...)` directly to `scheduler.wait(...)`; a `-1` schedule is not finally normalized.
- Focused tests: `32 passed`, `0 failed`, `89 assertions`.
- Affected package suite: `274 passed`, `0 failed`, `603 assertions` across 22 files.
- Type/lint/check: utils Biome checked 59 files with no fixes; TypeScript check passed.
- Build/binary/Rust: not applicable to this TypeScript-only utils patch.
- Generated/public gates: not applicable.
- `git diff --check`: passed.
- Exact-current-dev CI: run `30585207616` completed terminal success on base `29ddfe08f5`, including all eight coding-agent shards, evidence producer, and aggregate.
- Hosted exact-head CI: pending at PR creation; this head is not considered merge-authorized until its own hosted run is terminal green.

Focused/package commands:

```sh
mise exec bun@1.3.14 -- bun test packages/utils/test/fetch-retry.test.ts
mise exec bun@1.3.14 -- bun test packages/utils/test
(cd packages/utils && mise exec bun@1.3.14 -- bun run check)
```

Dogfood command:

```sh
mise exec bun@1.3.14 -- bun -e 'import { fetchWithRetry } from "./packages/utils/src/fetch-retry.ts";
let attempts = 0;
let cancelled = 0;
const started = performance.now();
const response = await fetchWithRetry("https://dogfood.invalid", {
  maxAttempts: 2,
  defaultDelayMs: -1,
  fetch: async () => {
    attempts += 1;
    if (attempts === 2) return new Response("ok", { status: 200 });
    return {
      status: 503,
      headers: new Headers(),
      clone: () => new Response("retry", { status: 503 }),
      body: { cancel: async () => { cancelled += 1; } },
    };
  },
});
await Bun.sleep(0);
console.log(JSON.stringify({ attempts, status: response.status, cancelled, elapsedMs: Math.round(performance.now() - started) }));'
```

Observed trace: `{"attempts":2,"status":200,"cancelled":1,"elapsedMs":2}`. The invalid `-1` delay retried immediately, the second attempt returned 200, and the discarded retryable response was cancelled.

Exact-head adversarial review: `MERGE_READY`, reviewed SHA `22488d7a9ac9a895ee6eb867147667468dee28f2`, with `P0=0 / P1=0 / P2=0`. The review independently verified the scheduling boundary, #3577 cancellation preservation, Lore trailers, changelog placement, merge-tree identity, clean worktree, and open-PR overlap.

## Overlap and integration

- Scanned all 8 open upstream PRs immediately before publication.
- File overlap with the three changed utils paths: zero.
- Topic/root-cause overlap: zero.
- Remote head was verified to equal exact local head `22488d7a9` before PR creation.
- `git merge-tree --write-tree upstream/dev HEAD` succeeded.
- Merge-tree and candidate tree are identical: `3d225281131a053ca0781ad6d7f35a1d50f7a462`.
- Combined integration worktree was not needed because there is no open file or semantic overlap and the candidate is a direct child of exact current `dev`.

## Known limits / non-goals

- Full monorepo tests were not run locally; the full exact-current-dev workflow is green and exact-head hosted CI is intentionally tracked after publication.
- No live upstream service was called; runtime dogfood used an instrumented fetch boundary to observe attempts, status, scheduling behavior, and body cancellation without external network variability.
- This PR does not validate configuration at construction time or change retry policy; it only normalizes the final scheduler input.
