### PR TITLE
fix(ai): harden AWS event stream framing

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 
 - Alibaba Token Plan requests now carry Qwen Code's canonical DashScope request fingerprint on both transports. The built-in `alibaba-token-plan` provider (openai-responses `qwen3.8-max-preview` and openai-completions `glm-5.2`/`deepseek-v4-pro`) now emits the four upstream identity/cache/auth headers (`User-Agent`, `X-DashScope-CacheControl: enable`, `X-DashScope-UserAgent`, `X-DashScope-AuthType: openai`) matching `QwenLM/qwen-code` v0.21.1 (commit `f4cd6e1`) exactly, via a shared helper. DashScope is compatibility-sensitive to this client fingerprint, so a non-identical set can cause request instability and affect first-event latency. Caller headers still win per key (upstream `{...default, ...customHeaders}` precedence); non-Alibaba providers are byte-unchanged (#3557).
+- AWS EventStream decoding now bounds standard payload and header sizes, validates preludes before waiting for frame bodies, rejects malformed or duplicate typed headers, and cancels invalid streams.
 
 ### Added
 

--- a/packages/ai/src/providers/aws-eventstream.ts
+++ b/packages/ai/src/providers/aws-eventstream.ts
@@ -22,6 +22,27 @@ const PRELUDE_CRC_LEN = 4;
 const MESSAGE_CRC_LEN = 4;
 const HEADER_BLOCK_OFFSET = PRELUDE_LEN + PRELUDE_CRC_LEN;
 const MIN_MESSAGE_LEN = HEADER_BLOCK_OFFSET + MESSAGE_CRC_LEN;
+// AWS EventStream permits 24 MiB payloads and 128 KiB headers. These
+// protocol-compatible bounds prevent an unfinished hostile frame from retaining
+// unbounded memory, while rejecting only nonstandard larger messages.
+const MAX_PAYLOAD_LEN = 24 * 1024 * 1024;
+const MAX_HEADERS_LEN = 128 * 1024;
+const MAX_MESSAGE_LEN = MAX_PAYLOAD_LEN + MAX_HEADERS_LEN + MIN_MESSAGE_LEN;
+const MAX_VARIABLE_HEADER_VALUE_LEN = 32_767;
+
+function validateFrameLengths(total: number, headersLen?: number): void {
+	if (total < MIN_MESSAGE_LEN) throw new Error(`eventstream: total length ${total} below minimum`);
+	if (total > MAX_MESSAGE_LEN)
+		throw new Error(`eventstream: total length ${total} exceeds maximum ${MAX_MESSAGE_LEN}`);
+	if (headersLen === undefined) return;
+	if (headersLen > MAX_HEADERS_LEN)
+		throw new Error(`eventstream: header length ${headersLen} exceeds maximum ${MAX_HEADERS_LEN}`);
+	const payloadLen = total - headersLen - MIN_MESSAGE_LEN;
+	if (payloadLen < 0)
+		throw new Error(`eventstream: header length ${headersLen} exceeds frame body ${total - MIN_MESSAGE_LEN}`);
+	if (payloadLen > MAX_PAYLOAD_LEN)
+		throw new Error(`eventstream: payload length ${payloadLen} exceeds maximum ${MAX_PAYLOAD_LEN}`);
+}
 
 export interface EventStreamMessage {
 	/** Lower-cased copy is *not* applied — Bedrock uses casing like `:event-type` verbatim. */
@@ -56,8 +77,9 @@ export function decodeMessage(frame: Uint8Array): EventStreamMessage {
 	if (frame.length < MIN_MESSAGE_LEN) throw new Error("eventstream: frame too short");
 	const view = new DataView(frame.buffer, frame.byteOffset, frame.byteLength);
 	const total = view.getUint32(0, false);
-	if (total !== frame.length) throw new Error(`eventstream: framed length ${total} != buffer ${frame.length}`);
 	const headersLen = view.getUint32(4, false);
+	validateFrameLengths(total, headersLen);
+	if (total !== frame.length) throw new Error(`eventstream: framed length ${total} != buffer ${frame.length}`);
 	const preludeCrc = view.getUint32(8, false);
 	const computedPreludeCrc = crc32(frame.subarray(0, PRELUDE_LEN));
 	if (computedPreludeCrc !== preludeCrc) throw new Error("eventstream: prelude CRC mismatch");
@@ -73,66 +95,88 @@ export function decodeMessage(frame: Uint8Array): EventStreamMessage {
 function parseHeaders(buf: Uint8Array): Record<string, string> {
 	const out: Record<string, string> = {};
 	const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
-	const decoder = new TextDecoder();
+	const decoder = new TextDecoder("utf-8", { fatal: true });
 	let p = 0;
+
+	const take = (length: number, description: string): Uint8Array => {
+		if (length > buf.length - p) throw new Error(`eventstream: truncated ${description}`);
+		const value = buf.subarray(p, p + length);
+		p += length;
+		return value;
+	};
+	const readInteger = (length: number, description: string): DataView => {
+		const bytes = take(length, description);
+		return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+	};
+	const decodeUtf8 = (bytes: Uint8Array, description: string): string => {
+		try {
+			return decoder.decode(bytes);
+		} catch {
+			throw new Error(`eventstream: invalid UTF-8 ${description}`);
+		}
+	};
+	const readVariableLength = (description: string): number => {
+		const length = readInteger(2, `${description} length`).getUint16(0, false);
+		if (length < 1 || length > MAX_VARIABLE_HEADER_VALUE_LEN)
+			throw new Error(`eventstream: ${description} length ${length} outside 1..${MAX_VARIABLE_HEADER_VALUE_LEN}`);
+		return length;
+	};
+	const setHeader = (name: string, value: string): void => {
+		Object.defineProperty(out, name, { value, enumerable: true, writable: true, configurable: true });
+	};
+
 	while (p < buf.length) {
 		const nameLen = view.getUint8(p);
 		p += 1;
-		const name = decoder.decode(buf.subarray(p, p + nameLen));
-		p += nameLen;
+		if (nameLen === 0) throw new Error("eventstream: empty header name");
+		const name = decodeUtf8(take(nameLen, "header name"), "header name");
+		if (Object.hasOwn(out, name)) throw new Error(`eventstream: duplicate header "${name}"`);
+		if (p >= buf.length) throw new Error("eventstream: truncated header value type");
 		const type = view.getUint8(p);
 		p += 1;
 		switch (type) {
 			case 0: // bool true
-				out[name] = "true";
+				setHeader(name, "true");
 				break;
 			case 1: // bool false
-				out[name] = "false";
+				setHeader(name, "false");
 				break;
 			case 2: // byte
-				out[name] = String(view.getInt8(p));
-				p += 1;
+				setHeader(name, String(readInteger(1, "byte header value").getInt8(0)));
 				break;
 			case 3: // short
-				out[name] = String(view.getInt16(p, false));
-				p += 2;
+				setHeader(name, String(readInteger(2, "short header value").getInt16(0, false)));
 				break;
 			case 4: // integer
-				out[name] = String(view.getInt32(p, false));
-				p += 4;
+				setHeader(name, String(readInteger(4, "integer header value").getInt32(0, false)));
 				break;
 			case 5: // long — surface as decimal string to avoid precision loss
-				out[name] = bigIntFromBytes(buf.subarray(p, p + 8)).toString();
-				p += 8;
+				setHeader(name, bigIntFromBytes(take(8, "long header value")).toString());
 				break;
 			case 6: {
 				// byte array — base64 for safe transport
-				const len = view.getUint16(p, false);
-				p += 2;
-				out[name] = Buffer.from(buf.buffer, buf.byteOffset + p, len).toString("base64");
-				p += len;
+				const len = readVariableLength("byte array header value");
+				setHeader(name, Buffer.from(take(len, "byte array header value")).toString("base64"));
 				break;
 			}
 			case 7: {
 				// string
-				const len = view.getUint16(p, false);
-				p += 2;
-				out[name] = decoder.decode(buf.subarray(p, p + len));
-				p += len;
+				const len = readVariableLength("string header value");
+				setHeader(name, decodeUtf8(take(len, "string header value"), "string header value"));
 				break;
 			}
 			case 8: // timestamp (ms since epoch as i64)
-				out[name] = new Date(Number(bigIntFromBytes(buf.subarray(p, p + 8)))).toISOString();
-				p += 8;
+				setHeader(name, new Date(Number(bigIntFromBytes(take(8, "timestamp header value")))).toISOString());
 				break;
 			case 9: {
 				// uuid
-				const u = buf.subarray(p, p + 16);
+				const u = take(16, "uuid header value");
 				const hex: string[] = [];
 				for (let i = 0; i < 16; i++) hex.push(u[i].toString(16).padStart(2, "0"));
-				out[name] =
-					`${hex.slice(0, 4).join("")}-${hex.slice(4, 6).join("")}-${hex.slice(6, 8).join("")}-${hex.slice(8, 10).join("")}-${hex.slice(10, 16).join("")}`;
-				p += 16;
+				setHeader(
+					name,
+					`${hex.slice(0, 4).join("")}-${hex.slice(4, 6).join("")}-${hex.slice(6, 8).join("")}-${hex.slice(8, 10).join("")}-${hex.slice(10, 16).join("")}`,
+				);
 				break;
 			}
 			default:
@@ -158,27 +202,96 @@ function bigIntFromBytes(b: Uint8Array): bigint {
  */
 export async function* decodeEventStream(source: ReadableStream<Uint8Array>): AsyncGenerator<EventStreamMessage> {
 	const reader = source.getReader();
-	// Single growable buffer; we slide a read cursor along it and compact when a
-	// complete prefix has been consumed. Avoids per-message Uint8Array copies.
-	let buf: Uint8Array<ArrayBufferLike> = new Uint8Array(0);
+	// Keep source chunks until a whole frame is available. This avoids repeated
+	// whole-buffer copies under one-byte fragmentation; only split frames copy once.
+	const chunks: Uint8Array[] = [];
+	let chunkStart = 0;
+	let bufferedLength = 0;
+
+	const byteAt = (offset: number): number => {
+		for (let i = chunkStart; i < chunks.length; i++) {
+			const chunk = chunks[i];
+			if (offset < chunk.length) return chunk[offset];
+			offset -= chunk.length;
+		}
+		throw new Error("eventstream: internal buffer underflow");
+	};
+	const readUint32 = (offset: number): number =>
+		(byteAt(offset) * 0x1000000 + (byteAt(offset + 1) << 16) + (byteAt(offset + 2) << 8) + byteAt(offset + 3)) >>> 0;
+	const prefix = (length: number): Uint8Array => {
+		const first = chunks[chunkStart];
+		if (first.length >= length) return first.subarray(0, length);
+		const result = new Uint8Array(length);
+		let offset = 0;
+		for (let i = chunkStart; i < chunks.length; i++) {
+			const chunk = chunks[i];
+			const copied = Math.min(chunk.length, length - offset);
+			result.set(chunk.subarray(0, copied), offset);
+			offset += copied;
+			if (offset === length) return result;
+		}
+		throw new Error("eventstream: internal buffer underflow");
+	};
+	const consume = (length: number): void => {
+		bufferedLength -= length;
+		while (length > 0) {
+			const chunk = chunks[chunkStart];
+			if (length < chunk.length) {
+				chunks[chunkStart] = chunk.subarray(length);
+				if (chunkStart > 1024 && chunkStart * 2 > chunks.length) {
+					chunks.splice(0, chunkStart);
+					chunkStart = 0;
+				}
+				return;
+			}
+			length -= chunk.length;
+			chunkStart += 1;
+		}
+		if (chunkStart > 1024 && chunkStart * 2 > chunks.length) {
+			chunks.splice(0, chunkStart);
+			chunkStart = 0;
+		}
+	};
+
 	try {
 		while (true) {
 			const { value, done } = await reader.read();
-			if (value && value.length > 0) buf = buf.length === 0 ? value : Buffer.concat([buf, value]);
-			let offset = 0;
-			while (buf.length - offset >= 4) {
-				const dv = new DataView(buf.buffer, buf.byteOffset + offset, buf.length - offset);
-				const total = dv.getUint32(0, false);
-				if (total < MIN_MESSAGE_LEN) throw new Error(`eventstream: total length ${total} below minimum`);
-				if (buf.length - offset < total) break;
-				const frame = buf.subarray(offset, offset + total);
-				yield decodeMessage(frame);
-				offset += total;
+			if (value && value.length > 0) {
+				chunks.push(value);
+				bufferedLength += value.length;
 			}
-			if (offset > 0) buf = buf.slice(offset);
+
+			while (bufferedLength >= 4) {
+				const total = readUint32(0);
+				validateFrameLengths(total);
+				if (bufferedLength < HEADER_BLOCK_OFFSET) break;
+
+				const headersLen = readUint32(4);
+				validateFrameLengths(total, headersLen);
+				const prelude = prefix(HEADER_BLOCK_OFFSET);
+				const preludeCrc = new DataView(prelude.buffer, prelude.byteOffset, prelude.byteLength).getUint32(
+					PRELUDE_LEN,
+					false,
+				);
+				if (crc32(prelude.subarray(0, PRELUDE_LEN)) !== preludeCrc)
+					throw new Error("eventstream: prelude CRC mismatch");
+
+				if (bufferedLength < total) break;
+				const frame = prefix(total);
+				const message = decodeMessage(frame);
+				consume(total);
+				yield message;
+			}
 			if (done) break;
 		}
-		if (buf.length > 0) throw new Error("eventstream: truncated message at end of stream");
+		if (bufferedLength > 0) throw new Error("eventstream: truncated message at end of stream");
+	} catch (error) {
+		try {
+			await reader.cancel(error);
+		} catch {
+			// Preserve the framing error if cancellation itself fails.
+		}
+		throw error;
 	} finally {
 		reader.releaseLock();
 	}

--- a/packages/ai/test/aws-eventstream.test.ts
+++ b/packages/ai/test/aws-eventstream.test.ts
@@ -1,13 +1,20 @@
 import { describe, expect, test } from "bun:test";
 import { crc32, decodeEventStream, decodeMessage } from "../src/providers/aws-eventstream";
 
+const MAX_PAYLOAD_LEN = 24 * 1024 * 1024;
+const MAX_HEADERS_LEN = 128 * 1024;
+const MAX_MESSAGE_LEN = MAX_PAYLOAD_LEN + MAX_HEADERS_LEN + 16;
+
 // ---- Frame builder (mirrors @smithy/eventstream-codec but in-process so the
 // test owns the bytes). The decoder is the production code; we encode here for
 // fixture generation only.
 
 function encodeStringHeader(name: string, value: string): Uint8Array {
+	return encodeStringHeaderBytes(name, new TextEncoder().encode(value));
+}
+
+function encodeStringHeaderBytes(name: string, valueBytes: Uint8Array): Uint8Array {
 	const nameBytes = new TextEncoder().encode(name);
-	const valueBytes = new TextEncoder().encode(value);
 	if (nameBytes.length > 255) throw new Error("name too long");
 	const buf = new Uint8Array(1 + nameBytes.length + 1 + 2 + valueBytes.length);
 	const view = new DataView(buf.buffer);
@@ -27,25 +34,46 @@ function encodeStringHeader(name: string, value: string): Uint8Array {
 function encodeFrame(headers: Record<string, string>, payload: Uint8Array): Uint8Array {
 	const headerChunks: Uint8Array[] = [];
 	for (const name in headers) headerChunks.push(encodeStringHeader(name, headers[name]));
-	const headerLen = headerChunks.reduce((s, c) => s + c.length, 0);
-	const headerBytes = new Uint8Array(headerLen);
-	let off = 0;
-	for (const c of headerChunks) {
-		headerBytes.set(c, off);
-		off += c.length;
-	}
-	const total = 4 + 4 + 4 + headerLen + payload.length + 4;
+	return encodeFrameBytes(joinBytes(headerChunks), payload);
+}
+
+function encodeFrameBytes(headerBytes: Uint8Array, payload: Uint8Array): Uint8Array {
+	const total = 4 + 4 + 4 + headerBytes.length + payload.length + 4;
 	const out = new Uint8Array(total);
 	const view = new DataView(out.buffer);
 	view.setUint32(0, total, false);
-	view.setUint32(4, headerLen, false);
-	const preludeCrc = crc32(out.subarray(0, 8));
-	view.setUint32(8, preludeCrc, false);
+	view.setUint32(4, headerBytes.length, false);
+	view.setUint32(8, crc32(out.subarray(0, 8)), false);
 	out.set(headerBytes, 12);
-	out.set(payload, 12 + headerLen);
-	const msgCrc = crc32(out.subarray(0, total - 4));
-	view.setUint32(total - 4, msgCrc, false);
+	out.set(payload, 12 + headerBytes.length);
+	updateFrameCrcs(out);
 	return out;
+}
+
+function joinBytes(chunks: Uint8Array[]): Uint8Array {
+	const length = chunks.reduce((total, chunk) => total + chunk.length, 0);
+	const out = new Uint8Array(length);
+	let offset = 0;
+	for (const chunk of chunks) {
+		out.set(chunk, offset);
+		offset += chunk.length;
+	}
+	return out;
+}
+
+function updateFrameCrcs(frame: Uint8Array): void {
+	const view = new DataView(frame.buffer, frame.byteOffset, frame.byteLength);
+	view.setUint32(8, crc32(frame.subarray(0, 8)), false);
+	view.setUint32(frame.length - 4, crc32(frame.subarray(0, frame.length - 4)), false);
+}
+
+function encodePrelude(total: number, headersLen: number): Uint8Array {
+	const prelude = new Uint8Array(12);
+	const view = new DataView(prelude.buffer);
+	view.setUint32(0, total, false);
+	view.setUint32(4, headersLen, false);
+	view.setUint32(8, crc32(prelude.subarray(0, 8)), false);
+	return prelude;
 }
 
 function streamFrom(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
@@ -155,5 +183,161 @@ describe("aws-eventstream", () => {
 		const frame = encodeFrame({ ":event-type": "x" }, new TextEncoder().encode("{}"));
 		frame[frame.length - 1] ^= 0xff;
 		expect(() => decodeMessage(frame)).toThrow(/message CRC/);
+	});
+	test("stitches one-byte fragmented frames", async () => {
+		const frame = encodeFrame({ ":event-type": "contentBlockDelta" }, new TextEncoder().encode('{"text":"hi"}'));
+		const collected = await collect(streamFrom(Array.from(frame, byte => Uint8Array.of(byte))));
+		expect(collected).toHaveLength(1);
+		expect(collected[0].headers[":event-type"]).toBe("contentBlockDelta");
+		expect(collected[0].text).toBe('{"text":"hi"}');
+	});
+
+	test("rejects an oversized declared message length from the prelude", async () => {
+		const prelude = encodePrelude(MAX_MESSAGE_LEN + 1, 0);
+		await expect(collect(streamFrom([prelude]))).rejects.toThrow(
+			`eventstream: total length ${MAX_MESSAGE_LEN + 1} exceeds maximum ${MAX_MESSAGE_LEN}`,
+		);
+	});
+	test("rejects a frame whose declared payload exceeds the payload limit", async () => {
+		const prelude = encodePrelude(MAX_MESSAGE_LEN, 0);
+		await expect(collect(streamFrom([prelude]))).rejects.toThrow(
+			`eventstream: payload length ${MAX_MESSAGE_LEN - 16} exceeds maximum ${MAX_PAYLOAD_LEN}`,
+		);
+	});
+	test("accepts exact AWS EventStream payload and header limits", () => {
+		const headers = joinBytes([
+			encodeStringHeaderBytes("a", new Uint8Array(32_767)),
+			encodeStringHeaderBytes("b", new Uint8Array(32_767)),
+			encodeStringHeaderBytes("c", new Uint8Array(32_767)),
+			encodeStringHeaderBytes("d", new Uint8Array(32_751)),
+		]);
+		expect(headers).toHaveLength(MAX_HEADERS_LEN);
+
+		const decoded = decodeMessage(encodeFrameBytes(headers, new Uint8Array(MAX_PAYLOAD_LEN)));
+		expect(decoded.headers.a).toHaveLength(32_767);
+		expect(decoded.payload).toHaveLength(MAX_PAYLOAD_LEN);
+	});
+
+	test("rejects a malformed prelude before waiting for its declared frame body", async () => {
+		const prelude = new Uint8Array(12);
+		const view = new DataView(prelude.buffer);
+		view.setUint32(0, 16, false);
+		view.setUint32(4, 0, false);
+		view.setUint32(8, crc32(prelude.subarray(0, 8)) ^ 0xffffffff, false);
+
+		let cancelled = false;
+		const source = new ReadableStream<Uint8Array>(
+			{
+				start(controller) {
+					controller.enqueue(prelude);
+				},
+				pull() {
+					return new Promise<void>(() => {});
+				},
+				cancel() {
+					cancelled = true;
+				},
+			},
+			{ highWaterMark: 0 },
+		);
+
+		await expect(collect(source)).rejects.toThrow("eventstream: prelude CRC mismatch");
+		expect(cancelled).toBe(true);
+	});
+
+	test("rejects an oversized declared header length from the prelude", async () => {
+		const prelude = encodePrelude(MAX_MESSAGE_LEN, MAX_HEADERS_LEN + 1);
+		await expect(collect(streamFrom([prelude]))).rejects.toThrow(
+			"eventstream: header length 131073 exceeds maximum 131072",
+		);
+	});
+	test("preserves prototype-sensitive header names as own data properties", () => {
+		const headers = joinBytes([encodeStringHeader("__proto__", "safe"), encodeStringHeader("constructor", "plain")]);
+		const decoded = decodeMessage(encodeFrameBytes(headers, new Uint8Array(0)));
+
+		expect(Object.getPrototypeOf(decoded.headers)).toBe(Object.prototype);
+		expect(Object.getOwnPropertyDescriptor(decoded.headers, "__proto__")?.value).toBe("safe");
+		expect(Object.getOwnPropertyDescriptor(decoded.headers, "constructor")?.value).toBe("plain");
+	});
+
+	test("rejects a header block that extends outside the frame", () => {
+		const frame = encodeFrame({}, new Uint8Array(0));
+		new DataView(frame.buffer).setUint32(4, 1, false);
+		updateFrameCrcs(frame);
+		expect(() => decodeMessage(frame)).toThrow("eventstream: header length 1 exceeds frame body 0");
+	});
+
+	test("rejects duplicate header names", () => {
+		const headers = joinBytes([
+			encodeStringHeader(":event-type", "first"),
+			encodeStringHeader(":event-type", "second"),
+		]);
+		expect(() => decodeMessage(encodeFrameBytes(headers, new Uint8Array(0)))).toThrow(
+			'eventstream: duplicate header ":event-type"',
+		);
+	});
+
+	test("rejects truncated typed header values", () => {
+		const truncatedStringHeader = Uint8Array.from([1, 120, 7, 0, 4, 120]);
+		expect(() => decodeMessage(encodeFrameBytes(truncatedStringHeader, new Uint8Array(0)))).toThrow(
+			"eventstream: truncated string header value",
+		);
+	});
+	test("rejects out-of-range string and byte-array header lengths", () => {
+		const emptyString = Uint8Array.from([1, 120, 7, 0, 0]);
+		expect(() => decodeMessage(encodeFrameBytes(emptyString, new Uint8Array(0)))).toThrow(
+			"eventstream: string header value length 0 outside 1..32767",
+		);
+
+		const oversizedString = encodeStringHeaderBytes("x", new Uint8Array(32_768));
+		expect(() => decodeMessage(encodeFrameBytes(oversizedString, new Uint8Array(0)))).toThrow(
+			"eventstream: string header value length 32768 outside 1..32767",
+		);
+
+		const emptyByteArray = Uint8Array.from([1, 120, 6, 0, 0]);
+		expect(() => decodeMessage(encodeFrameBytes(emptyByteArray, new Uint8Array(0)))).toThrow(
+			"eventstream: byte array header value length 0 outside 1..32767",
+		);
+	});
+
+	test("rejects malformed UTF-8 header names and string values", () => {
+		const invalidName = Uint8Array.from([1, 0x80, 0]);
+		expect(() => decodeMessage(encodeFrameBytes(invalidName, new Uint8Array(0)))).toThrow(
+			"eventstream: invalid UTF-8 header name",
+		);
+
+		const invalidString = Uint8Array.from([1, 120, 7, 0, 1, 0x80]);
+		expect(() => decodeMessage(encodeFrameBytes(invalidString, new Uint8Array(0)))).toThrow(
+			"eventstream: invalid UTF-8 string header value",
+		);
+	});
+
+	test("rejects EOF in the middle of a frame", async () => {
+		const frame = encodeFrame({ ":event-type": "x" }, new TextEncoder().encode("payload"));
+		await expect(collect(streamFrom([frame.subarray(0, frame.length - 1)]))).rejects.toThrow(
+			"eventstream: truncated message at end of stream",
+		);
+	});
+
+	test("cancels the underlying source before releasing its reader lock on decoder error", async () => {
+		const expectedMessage = `eventstream: total length ${MAX_MESSAGE_LEN + 1} exceeds maximum ${MAX_MESSAGE_LEN}`;
+		let cancelReason: unknown;
+		let lockedDuringCancellation = false;
+		let source: ReadableStream<Uint8Array>;
+		source = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encodePrelude(MAX_MESSAGE_LEN + 1, 0));
+			},
+			cancel(reason) {
+				cancelReason = reason;
+				lockedDuringCancellation = source.locked;
+			},
+		});
+
+		await expect(collect(source)).rejects.toThrow(expectedMessage);
+		expect(cancelReason).toBeInstanceOf(Error);
+		expect((cancelReason as Error).message).toBe(expectedMessage);
+		expect(lockedDuringCancellation).toBe(true);
+		expect(source.locked).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary

- enforce AWS EventStream's standard 24 MiB payload and 128 KiB header bounds, including declared payload arithmetic
- validate the prelude CRC as soon as 12 bytes arrive and buffer hostile fragmentation without repeated whole-buffer copies
- reject malformed UTF-8, out-of-range typed values, empty/duplicate/prototype-sensitive header hazards, and truncated frames with deterministic errors
- cancel malformed sources before releasing the reader lock while preserving valid arbitrary chunk boundaries and packed frames

## Scope and provenance

PR #3581's owner review identified generic hostile-frame coverage gaps. This PR extracts only that provider-neutral decoder hardening; it does **not** add or salvage a Kiro provider and does not change Kiro auth, transport, catalog, or onboarding behavior. That work remains governed by #3575's owner-lane hold.

Implementation was derived from the existing Gajae Code decoder and public AWS EventStream encoding documentation. No `jwadow/kiro-gateway` AGPL source, fixtures, translations, paraphrases, or ports were inspected or used.

Public framing references:
- https://smithy.io/2.0/aws/amazon-eventstream.html
- https://docs.aws.amazon.com/lexv2/latest/dg/event-stream-encoding.html
- https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/EventStream/Encoder.html

## Verification

- `bun --cwd=packages/ai run check`
- `bun test packages/ai/test/aws-eventstream.test.ts` — 21 passed
- `bun test packages/ai/test/aws-eventstream.test.ts packages/ai/test/bedrock-tool-choice.test.ts packages/ai/test/issue-1934-bedrock-auth.test.ts` — 43 passed
- `unset FORCE_COLOR NO_COLOR; bun --cwd=packages/ai test` — 2,079 passed, 337 skipped, 0 failed, 9,953 assertions

## Review relationship

- Incorporates the generic EventStream integrity, resource-bound, early-CRC, fragmentation, and lifecycle lessons from #3581's changes-requested review.
- A first independent review found compatibility and false-assurance gaps in this PR's initial 16 MiB implementation; those findings were addressed with canonical bounds, early prelude validation, amortized buffering, strict typed-header validation, and expanded adversarial coverage before the branch update.
- Intentionally leaves Kiro-specific blockers untouched because #3575 explicitly reserves that implementation to the owner lane pending first-party authority.
