### PR TITLE
fix(coding-agent): `gjc -p` hangs 30–300s after completion when a tool call ran

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1085,6 +1085,12 @@ export interface RunRootCommandDependencies {
 	getChangelogForDisplay?: typeof getChangelogForDisplay;
 	createInteractiveMode?: CreateInteractiveMode;
 	runPrintMode?: RunPrintMode;
+	/**
+	 * Governed process exit used after a successful print-mode run (defaults to
+	 * `postmortem.quit`). Injectable so in-process callers/tests can observe the
+	 * exit request instead of having the process terminated under them.
+	 */
+	quit?: (code: number) => Promise<void>;
 	isResumePickerTerminal?: ResumePickerTerminalCheck;
 	listForResumePickerReadOnly?: ListForResumePickerReadOnly;
 	listManagedForResumePickerReadOnly?: ListManagedForResumePickerReadOnly;
@@ -1686,6 +1692,17 @@ export async function runRootCommand(
 				stopThemeWatcher();
 				authStorage.close();
 				if (!deps.suppressProcessExit) await postmortem.cleanup();
+			}
+			// Cleanup has run, but a print run that executed tools can leave native
+			// handles that pin the Bun event loop for 30–300s after the final
+			// output, so `gjc -p` hangs instead of returning to the shell. Mirror
+			// the commit-command exit pattern (postmortem.quit, issue #1041): flush
+			// stdout and exit with the already-recorded exit code. Success path
+			// only — a thrown error still propagates to the caller's reporting;
+			// callers that own their finalization (rlm autonomous) pass
+			// suppressProcessExit and are exempt.
+			if (!deps.suppressProcessExit) {
+				await (deps.quit ?? postmortem.quit)(typeof process.exitCode === "number" ? process.exitCode : 0);
 			}
 		}
 	}

--- a/packages/coding-agent/test/startup-update-contract.test.ts
+++ b/packages/coding-agent/test/startup-update-contract.test.ts
@@ -276,6 +276,7 @@ describe("startup update contract", () => {
 			const originalNoTitle = Bun.env.PI_NO_TITLE;
 			let checks = 0;
 			const runners: string[] = [];
+			const quitCalls: number[] = [];
 			let pipedInputReads = 0;
 			let sessionOptions: CreateAgentSessionOptions | undefined;
 			let initialMessage: string | undefined;
@@ -311,8 +312,14 @@ describe("startup update contract", () => {
 						runners.push("print");
 						initialMessage = options.initialMessage;
 					},
+					quit: async code => {
+						quitCalls.push(code);
+					},
 				});
 				expect(checks, testCase.name).toBe(0);
+				// Callers that own their finalization suppress the governed
+				// post-print exit; runRootCommand must not request it for them.
+				expect(quitCalls, testCase.name).toEqual([]);
 				expect(runners, testCase.name).toEqual([testCase.expectedRunner]);
 				expect(pipedInputReads, testCase.name).toBe(testCase.expectedRunner === "acp" ? 0 : 1);
 				expect(initialMessage, testCase.name).toBe(testCase.expectedInitialMessage);
@@ -420,6 +427,7 @@ describe("startup update contract", () => {
 			disposeCalls += 1;
 		};
 
+		const quitCalls: number[] = [];
 		try {
 			process.exitCode = 0;
 			await runRootCommand(rootArgs({ mode: "text" }), [], {
@@ -433,11 +441,17 @@ describe("startup update contract", () => {
 					process.exitCode = 78;
 					await session.dispose();
 				},
+				quit: async code => {
+					quitCalls.push(code);
+				},
 			});
 
 			expect(disposeCalls).toBe(1);
 			expect(cleanupSpy).toHaveBeenCalledTimes(1);
 			expect(process.exitCode).toBe(78);
+			// A successful print run must request a governed exit with the recorded
+			// status so lingering native handles cannot pin the process afterwards.
+			expect(quitCalls).toEqual([78]);
 		} finally {
 			vi.restoreAllMocks();
 			process.exitCode = originalExitCode ?? 0;


### PR DESCRIPTION
## Problem

A `gjc -p` (print-mode) run that executed at least one tool call keeps the process alive for **30–300 seconds after the final output**, stranding any shell/pipeline that spawned it and waits for exit.

Deterministic repro (macOS, 0.12.5):

```bash
time gjc -p --no-session "Run the shell command \`echo hi\` using your bash tool, then reply with exactly: OK"
# output complete in ~7s, process exits at ~36s (+29s hang)
```

- No tool call → exits immediately after output.
- `--mode json` vs text makes no difference; the trigger is tool execution.
- The hang length varies by what ran (observed ~25s and ~280s classes across repeated benchmark runs on two days); it is not caused by model/provider latency — the last event is written, then the process just idles.

## Root cause

Print mode relies on the Bun event loop draining naturally: `runPrintMode` flushes and disposes the session, `runRootCommand` runs `postmortem.cleanup()`, and then nothing calls `process.exit`. Instrumentation shows cleanup completes in ~1ms with the shell-session registry already empty — but native handles left behind by tool execution still pin the event loop until their own timeouts/finalizers fire.

This is the same failure class as the commit command fixed in #1041 ("`session.dispose()` releases what it can … a few timers stay armed long enough to pin the event loop"), which already adopted the `postmortem.quit` exit pattern.

## Fix

At the end of the print branch of `runRootCommand`, after the existing cleanup, request a governed exit with the already-recorded status:

- `postmortem.quit(process.exitCode)` — runs/awaits cleanup with its deadline, drains stdout (bounded), then exits, so JSON event streams and telemetry lines are never truncated (verified live: final `agent_end` + telemetry line intact).
- **Success path only** — a thrown error still propagates to the caller's reporting unchanged.
- Callers that own their finalization (rlm autonomous runs) already pass `suppressProcessExit` and are exempt.
- The exit is injectable (`deps.quit`, defaulting to `postmortem.quit`) so in-process callers and tests observe the exit request instead of having the process terminated under them — same dependency-injection style as the rest of `RunRootCommandDependencies`.

## Verification

- Live before/after on the repro above: total wall **36s → 5s** (hang eliminated); no-tool runs unchanged (2s).
- `--mode json` + tool run: stream ends with the complete `agent_end`/telemetry line, exit immediately after.
- Print-mode exit status preserved (`process.exitCode` 78/1 paths still reported; contract test asserts `quit(78)`).
- `packages/coding-agent`: `tsc --noEmit` clean, `biome check` clean.
- `bun test test/startup-update-contract.test.ts` 20/20 — extended the existing contract test with the new expectations (successful print run requests `quit(<code>)` exactly once; `suppressProcessExit` callers never get one).
- Full `packages/coding-agent` suite: failure set identical to the unpatched baseline on the same machine (environment-dependent tmux/ACP/XDG tests only; counts in PR discussion if useful).
