### PR TITLE
fix(local): encode listing href components

### DIFF
--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -80,10 +80,32 @@ async function listFilesRecursively(rootPath: string): Promise<string[]> {
 
 	return files.sort((a, b) => a.localeCompare(b));
 }
+function localListingLabel(file: string): string {
+	return file.replace(/[\\[\]\r\n]/g, character => {
+		switch (character) {
+			case "\r":
+				return "\\r";
+			case "\n":
+				return "\\n";
+			default:
+				return `\\${character}`;
+		}
+	});
+}
+
+function localListingHref(file: string): string {
+	return file
+		.split("/")
+		.map(component => encodeURIComponent(component).replaceAll("(", "%28").replaceAll(")", "%29"))
+		.join("/");
+}
 
 async function buildListing(url: InternalUrl, localRoot: string): Promise<InternalResource> {
 	const files = await listFilesRecursively(localRoot);
-	const listing = files.length === 0 ? "(empty)" : files.map(file => `- [${file}](local://${file})`).join("\n");
+	const listing =
+		files.length === 0
+			? "(empty)"
+			: files.map(file => `- [${localListingLabel(file)}](local://${localListingHref(file)})`).join("\n");
 	const content =
 		`# Local\n\n` +
 		`Session-scoped scratch space for large intermediate data, subagent handoffs, and reusable planning artifacts.\n\n` +
@@ -103,31 +125,30 @@ async function buildListing(url: InternalUrl, localRoot: string): Promise<Intern
 function extractRelativePath(url: InternalUrl): string {
 	const host = url.rawHost || url.hostname;
 	const pathname = url.rawPathname ?? url.pathname;
-
-	const combined = host
-		? pathname && pathname !== "/"
-			? `${host}${pathname}`
-			: host
-		: pathname && pathname !== "/"
-			? pathname.slice(1)
-			: "";
-
-	if (!combined) {
-		return "";
-	}
-
-	let decoded: string;
+	const encodedAuthority = /^local:\/\/([^/?#]*)/i.exec(url.href)?.[1] ?? "";
+	const validatedHost = host;
+	let decodedPathname = pathname;
 	try {
-		decoded = decodeURIComponent(combined.replaceAll("\\", "/"));
+		const decodedAuthority = decodeURIComponent(encodedAuthority);
+		if (host && decodedAuthority !== host) throw new Error("authority_mismatch");
+		decodedPathname = decodeURIComponent(pathname.replaceAll("\\", "/"));
 	} catch {
 		throw new Error(`Invalid URL encoding in local:// path: ${url.href}`);
 	}
+	const combined = validatedHost
+		? decodedPathname && decodedPathname !== "/"
+			? `${validatedHost}${decodedPathname}`
+			: validatedHost
+		: decodedPathname && decodedPathname !== "/"
+			? decodedPathname.slice(1)
+			: "";
+	if (!combined) return "";
 	try {
-		validateRelativePath(decoded);
+		validateRelativePath(combined);
 	} catch (error) {
 		throw toLocalValidationError(error);
 	}
-	return decoded;
+	return combined;
 }
 
 function safeSessionId(options: LocalProtocolOptions): string {

--- a/packages/coding-agent/test/internal-urls/local-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/local-protocol.test.ts
@@ -421,6 +421,68 @@ describe("LocalProtocolHandler", () => {
 		});
 	});
 
+	it("component-encodes listing hrefs and follows delimiter and literal-percent siblings", async () => {
+		await withTempDir(async tempDir => {
+			const sessionId = `encoded-listing-${path.basename(tempDir)}`;
+			await withLocalRoot(sessionId, async localRoot => {
+				await Bun.write(path.join(localRoot, "report%3Araw.txt"), "literal-percent");
+				await Bun.write(path.join(localRoot, "report:raw.txt"), "colon-sibling");
+				await Bun.write(path.join(localRoot, "report).txt"), "root-delimiter");
+				await fs.mkdir(path.join(localRoot, "batch(1)"));
+				await Bun.write(path.join(localRoot, "batch(1)", "report).txt"), "nested-delimiter");
+				await Bun.write(path.join(localRoot, "report](other.txt"), "root-label-delimiter");
+				await fs.mkdir(path.join(localRoot, "batch[1]"));
+				await Bun.write(path.join(localRoot, "batch[1]", "report](other.txt"), "nested-label-delimiter");
+				LocalProtocolHandler.setOverride(localOptions(sessionId, path.join(tempDir, "artifacts")));
+				const router = InternalUrlRouter.instance();
+				const listing = await router.resolve("local://");
+				expect(listing.content).toContain("[report%3Araw.txt](local://report%253Araw.txt)");
+				expect(listing.content).toContain("[report:raw.txt](local://report%3Araw.txt)");
+				expect(listing.content).toContain("[report).txt](local://report%29.txt)");
+				expect(listing.content).toContain("[batch(1)/report).txt](local://batch%281%29/report%29.txt)");
+				expect(listing.content).toContain("[report\\](other.txt](local://report%5D%28other.txt)");
+				expect(listing.content).toContain(
+					"[batch\\[1\\]/report\\](other.txt](local://batch%5B1%5D/report%5D%28other.txt)",
+				);
+				expect((await router.resolve("local://report%253Araw.txt")).content).toBe("literal-percent");
+				expect((await router.resolve("local://report%3Araw.txt")).content).toBe("colon-sibling");
+				expect((await router.resolve("local://report%29.txt")).content).toBe("root-delimiter");
+				expect((await router.resolve("local://batch%281%29/report%29.txt")).content).toBe("nested-delimiter");
+				expect((await router.resolve("local://report%5D%28other.txt")).content).toBe("root-label-delimiter");
+				expect((await router.resolve("local://batch%5B1%5D/report%5D%28other.txt")).content).toBe(
+					"nested-label-delimiter",
+				);
+				expect((await router.resolve("LOCAL://report%5D%28other.txt")).content).toBe("root-label-delimiter");
+				await expect(router.resolve("local://report%2Graw.txt")).rejects.toThrow(
+					"Invalid URL encoding in local:// path",
+				);
+			});
+		});
+	});
+
+	it.skipIf(process.platform === "win32")(
+		"keeps CR and LF filenames on one listing bullet and follows exact hrefs",
+		async () => {
+			await withTempDir(async tempDir => {
+				const sessionId = `multiline-listing-${path.basename(tempDir)}`;
+				await withLocalRoot(sessionId, async localRoot => {
+					await Bun.write(path.join(localRoot, "line\nbreak.txt"), "line-feed");
+					await fs.mkdir(path.join(localRoot, "batch\rname"));
+					await Bun.write(path.join(localRoot, "batch\rname", "report\nraw.txt"), "nested-controls");
+					LocalProtocolHandler.setOverride(localOptions(sessionId, path.join(tempDir, "artifacts")));
+					const router = InternalUrlRouter.instance();
+					const listing = await router.resolve("local://");
+					const bullets = listing.content.split("\n").filter(line => line.startsWith("- ["));
+					expect(bullets).toHaveLength(2);
+					expect(bullets).toContain("- [line\\nbreak.txt](local://line%0Abreak.txt)");
+					expect(bullets).toContain("- [batch\\rname/report\\nraw.txt](local://batch%0Dname/report%0Araw.txt)");
+					expect((await router.resolve("local://line%0Abreak.txt")).content).toBe("line-feed");
+					expect((await router.resolve("local://batch%0Dname/report%0Araw.txt")).content).toBe("nested-controls");
+				});
+			});
+		},
+	);
+
 	it("blocks path traversal attempts", async () => {
 		await withTempDir(async tempDir => {
 			const sessionId = `session-c-${path.basename(tempDir)}`;


### PR DESCRIPTION
## Summary
- component-encode each generated `'/tmp/gjc-local/019fb007-ec0e-7000-844a-8b5934678539'` listing href segment
- validate the original encoded authority while preserving the parser-decoded host
- decode only the raw pathname, preventing literal-percent sibling substitution
- cover both siblings and malformed authority encoding

Closes #3594.

## Verification
- `bun test packages/coding-agent/test/internal-urls/local-protocol.test.ts packages/coding-agent/test/tools/search-internal-urls.test.ts` (31 passed)
- `bun --cwd=packages/coding-agent run check:types`
- Biome and `git diff --check`