### PR TITLE
fix(coding-agent): `gjc -p` hangs 30–300s after completion when a tool call ran (+ stderr drain)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 ### Fixed
 
+- Print mode (`gjc -p`) no longer idles 30–300s after the final output when the run executed tool calls: after the existing cleanup, a successful print run now requests a governed `postmortem.quit(process.exitCode)` exit, mirroring the commit-command pattern from #1041. `suppressProcessExit` callers (rlm autonomous runs) are exempt, the thrown-error path still propagates to the caller, and the exit is injectable via `deps.quit` for in-process callers and tests (#3621).
+
 - Deferred `agent_end` publication again settles public session readiness before slow extension handlers finish, while retaining exact cancellation leases through queued extension delivery and draining that delivery before session shutdown.
 - Ultragoal validation-batch hydration now fails closed unless deferred and final-close evidence exactly matches a complete authoritative cumulative Git/CI inventory and durable batch tuple. Explicit malformed, partial, unknown, reordered, or stale receipt data is rejected; Git path capture is byte-safe, NUL-delimited, and includes untracked files; incomplete capture conservatively requires computer-control QA; shared settings and tool registries cannot use partial diffs to bypass that suite; validate/checkpoint replacement hydration is identical; and current/replacement receipts are byte-bound to ledger payloads (#3541).
 - Fixture quality gates that complete intermediate Ultragoal stories now write file-backed adversarial artifact proof; skill-state hooks and computer red-team fixtures match the unconditional adversarial path check so #3543 CI stays fail-closed without weakening hydration exactness (#3543).

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1085,6 +1085,12 @@ export interface RunRootCommandDependencies {
 	getChangelogForDisplay?: typeof getChangelogForDisplay;
 	createInteractiveMode?: CreateInteractiveMode;
 	runPrintMode?: RunPrintMode;
+	/**
+	 * Governed process exit used after a successful print-mode run (defaults to
+	 * `postmortem.quit`). Injectable so in-process callers/tests can observe the
+	 * exit request instead of having the process terminated under them.
+	 */
+	quit?: (code: number) => Promise<void>;
 	isResumePickerTerminal?: ResumePickerTerminalCheck;
 	listForResumePickerReadOnly?: ListForResumePickerReadOnly;
 	listManagedForResumePickerReadOnly?: ListManagedForResumePickerReadOnly;
@@ -1686,6 +1692,17 @@ export async function runRootCommand(
 				stopThemeWatcher();
 				authStorage.close();
 				if (!deps.suppressProcessExit) await postmortem.cleanup();
+			}
+			// Cleanup has run, but a print run that executed tools can leave native
+			// handles that pin the Bun event loop for 30–300s after the final
+			// output, so `gjc -p` hangs instead of returning to the shell. Mirror
+			// the commit-command exit pattern (postmortem.quit, issue #1041): flush
+			// stdout and exit with the already-recorded exit code. Success path
+			// only — a thrown error still propagates to the caller's reporting;
+			// callers that own their finalization (rlm autonomous) pass
+			// suppressProcessExit and are exempt.
+			if (!deps.suppressProcessExit) {
+				await (deps.quit ?? postmortem.quit)(typeof process.exitCode === "number" ? process.exitCode : 0);
 			}
 		}
 	}

--- a/packages/coding-agent/test/startup-update-contract.test.ts
+++ b/packages/coding-agent/test/startup-update-contract.test.ts
@@ -276,6 +276,7 @@ describe("startup update contract", () => {
 			const originalNoTitle = Bun.env.PI_NO_TITLE;
 			let checks = 0;
 			const runners: string[] = [];
+			const quitCalls: number[] = [];
 			let pipedInputReads = 0;
 			let sessionOptions: CreateAgentSessionOptions | undefined;
 			let initialMessage: string | undefined;
@@ -311,8 +312,14 @@ describe("startup update contract", () => {
 						runners.push("print");
 						initialMessage = options.initialMessage;
 					},
+					quit: async code => {
+						quitCalls.push(code);
+					},
 				});
 				expect(checks, testCase.name).toBe(0);
+				// Callers that own their finalization suppress the governed
+				// post-print exit; runRootCommand must not request it for them.
+				expect(quitCalls, testCase.name).toEqual([]);
 				expect(runners, testCase.name).toEqual([testCase.expectedRunner]);
 				expect(pipedInputReads, testCase.name).toBe(testCase.expectedRunner === "acp" ? 0 : 1);
 				expect(initialMessage, testCase.name).toBe(testCase.expectedInitialMessage);
@@ -420,6 +427,7 @@ describe("startup update contract", () => {
 			disposeCalls += 1;
 		};
 
+		const quitCalls: number[] = [];
 		try {
 			process.exitCode = 0;
 			await runRootCommand(rootArgs({ mode: "text" }), [], {
@@ -433,11 +441,17 @@ describe("startup update contract", () => {
 					process.exitCode = 78;
 					await session.dispose();
 				},
+				quit: async code => {
+					quitCalls.push(code);
+				},
 			});
 
 			expect(disposeCalls).toBe(1);
 			expect(cleanupSpy).toHaveBeenCalledTimes(1);
 			expect(process.exitCode).toBe(78);
+			// A successful print run must request a governed exit with the recorded
+			// status so lingering native handles cannot pin the process afterwards.
+			expect(quitCalls).toEqual([78]);
 		} finally {
 			vi.restoreAllMocks();
 			process.exitCode = originalExitCode ?? 0;

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 ### Fixed
 
+- `postmortem.quit()` now waits for buffered stderr to drain (bounded, like the existing stdout drain) before exiting, so diagnostics written via `console.error` — such as `GJC_TIMING` startup timings — survive a governed exit when stderr is a redirected or backpressured pipe, and a wedged stream still cannot deadlock the exit (#3621).
+
 - Positive-integer environment helpers now reject malformed, fractional, exponent-form, non-positive, and unsafe values instead of silently accepting their numeric prefixes (#3593).
 
 ### Fixed

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -456,9 +456,25 @@ export function cleanup(): Promise<void> {
 }
 
 /**
+ * Bounded wait for a stream's buffered writes to flush so a following
+ * process.exit() cannot truncate them. The race against a fixed deadline
+ * keeps a wedged or unread pipe from deadlocking the exit path.
+ */
+async function drainStreamBeforeExit(stream: NodeJS.WriteStream): Promise<void> {
+	if (stream.writableLength === 0) return;
+	const { promise, resolve } = Promise.withResolvers<void>();
+	stream.once("drain", resolve);
+	await Promise.race([promise, Bun.sleep(5000)]);
+}
+
+/**
  * Runs all cleanup callbacks and exits.
  *
- * In main thread: waits for stdout drain, then calls process.exit().
+ * In main thread: waits for stdout and stderr to drain (each bounded), then
+ * calls process.exit(). The stderr drain matters for diagnostics written via
+ * console.error (e.g. startup timings) immediately before a governed exit:
+ * with a redirected/backpressured stderr pipe, process.exit() would otherwise
+ * truncate the final lines.
  * In workers: runs cleanup only (process.exit would kill entire process).
  */
 export async function quit(code: number = 0): Promise<void> {
@@ -473,11 +489,8 @@ export async function quit(code: number = 0): Promise<void> {
 
 	const exitAfterCleanup = async (): Promise<void> => {
 		await awaitCleanupWithDeadline(Reason.MANUAL);
-		if (process.stdout.writableLength > 0) {
-			const { promise, resolve } = Promise.withResolvers<void>();
-			process.stdout.once("drain", resolve);
-			await Promise.race([promise, Bun.sleep(5000)]);
-		}
+		await drainStreamBeforeExit(process.stdout);
+		await drainStreamBeforeExit(process.stderr);
 		process.exit(code);
 	};
 

--- a/packages/utils/test/postmortem-fixture.ts
+++ b/packages/utils/test/postmortem-fixture.ts
@@ -294,6 +294,52 @@ async function runCleanupDeadlineFatal(): Promise<void> {
 	await throwFromTimer(new Error("fixture: fatal with hung cleanup"));
 }
 
+/**
+ * Replaces process.stderr with a backpressured fake whose drain is released
+ * by the returned trigger. Writes delegate to the real stderr so the drain
+ * marker below is observable by the parent process.
+ */
+function installBackpressuredStderr(): { releaseDrain: () => void } {
+	const realStderr = process.stderr;
+	const pending: { drain?: () => void } = {};
+	let released = false;
+	const fakeStderr = Object.create(realStderr) as NodeJS.WriteStream;
+	fakeStderr.write = ((...args: unknown[]) =>
+		(realStderr.write as (...inner: unknown[]) => unknown)(...args)) as NodeJS.WriteStream["write"];
+	Object.defineProperty(fakeStderr, "writableLength", {
+		get: () => (released ? 0 : 1),
+	});
+	fakeStderr.once = ((event: string, listener: () => void) => {
+		if (event === "drain") pending.drain = listener;
+		return fakeStderr;
+	}) as NodeJS.WriteStream["once"];
+	Object.defineProperty(process, "stderr", { value: fakeStderr, configurable: true });
+	return {
+		releaseDrain: () => {
+			const drain = pending.drain;
+			released = true;
+			pending.drain = undefined;
+			realStderr.write("fixture: stderr drained before exit\n");
+			drain?.();
+		},
+	};
+}
+
+async function runQuitDrainsBackpressuredStderr(): Promise<void> {
+	const { releaseDrain } = installBackpressuredStderr();
+	// The drain marker is written only when the release timer fires; if quit()
+	// exits without waiting for the drain, the marker never reaches stderr.
+	setTimeout(releaseDrain, 50);
+	await postmortem.quit(3);
+}
+
+async function runQuitBoundsUndrainedStderr(): Promise<void> {
+	installBackpressuredStderr();
+	// The drain is never released; quit() must still exit once its bounded
+	// wait expires instead of deadlocking on the wedged stream.
+	await postmortem.quit(3);
+}
+
 const scenario = process.argv[2];
 switch (scenario) {
 	case "exit-reentry-while-running":
@@ -341,6 +387,9 @@ switch (scenario) {
 	case "quiet-cleanup-late-registration":
 		await runQuietCleanupLateRegistration(process.argv[3]);
 		break;
+	case "quit-bounds-undrained-stderr":
+		await runQuitBoundsUndrainedStderr();
+		break;
 	case "ordinary-fatal-then-broken-pipe":
 		await runOrdinaryFatalThenBrokenPipe(process.argv[3]);
 		break;
@@ -370,6 +419,9 @@ switch (scenario) {
 		break;
 	case "non-pipe-unhandled-rejection":
 		await runNonPipeUnhandledRejection();
+		break;
+	case "quit-drains-backpressured-stderr":
+		await runQuitDrainsBackpressuredStderr();
 		break;
 	default:
 		throw new Error(`unknown postmortem fixture scenario: ${scenario ?? "(missing)"}`);

--- a/packages/utils/test/postmortem.test.ts
+++ b/packages/utils/test/postmortem.test.ts
@@ -272,3 +272,23 @@ describe("postmortem process stdout EPIPE policy", () => {
 		expectOrdinaryFatal(rejection, "Unhandled Rejection", "fixture: genuine rejected fatal error");
 	}, 15_000);
 });
+
+describe("postmortem quit stream drain", () => {
+	it("waits for a backpressured stderr drain before exiting so buffered diagnostics survive", async () => {
+		const result = await runScenario("quit-drains-backpressured-stderr");
+
+		expect(result.exitCode).toBe(3);
+		// The fixture writes the marker only when its delayed drain fires; an
+		// exit that did not wait for the drain would cut the marker off.
+		expect(result.stderr).toContain("fixture: stderr drained before exit");
+	}, 15_000);
+
+	it("still exits when stderr never drains, instead of deadlocking on a wedged stream", async () => {
+		const started = Date.now();
+		const result = await runScenario("quit-bounds-undrained-stderr");
+
+		expect(result.exitCode).toBe(3);
+		// The bounded wait must expire well inside the scenario timeout.
+		expect(Date.now() - started).toBeLessThan(10_000);
+	}, 15_000);
+});


### PR DESCRIPTION
Successor to #3621 (closed unmerged at exact head `1d54ad9` with a signed P0=0/P1=1 review). This branch keeps the reviewed print-mode fix and resolves the single remaining P1.

## Problem (unchanged from #3621)

A `gjc -p` (print-mode) run that executed at least one tool call keeps the process alive for **30–300 seconds after the final output**, stranding any shell/pipeline that waits for exit. Deterministic repro (macOS, 0.12.5):

```bash
time gjc -p --no-session "Run the shell command \`echo hi\` using your bash tool, then reply with exactly: OK"
```

- No tool call → exits immediately. The trigger is tool execution, not model/provider latency.
- Root cause: native handles left behind by tool execution pin the Bun event loop; nothing calls `process.exit` in print mode. Same failure class as #1041 (commit command), which already adopted `postmortem.quit`.

## Fix (unchanged from #3621)

At the end of the print branch of `runRootCommand`, after the existing cleanup, a **successful** print run requests `postmortem.quit(process.exitCode)`. Thrown errors still propagate to the caller; `suppressProcessExit` callers (rlm autonomous) are exempt; the exit is injectable via `deps.quit`.

## P1 resolution (new commit `9ae80f1`)

Review finding: `logger.printTimings()` writes via `console.error`, but `postmortem.quit()` drained only stdout before `process.exit(code)` — a timing-enabled print run with redirected/backpressured stderr could truncate final timings/diagnostics, with no test coverage.

- `postmortem.quit()` now drains **both stdout and stderr** via a shared `drainStreamBeforeExit()` helper, each bounded by the existing 5s deadline race, so a wedged or unread pipe cannot deadlock the exit (no behavior change when nothing is buffered).
- This also hardens the pre-existing commit-command (#1041) and interactive `/quit` governed exits, which shared the same stdout-only drain.
- **Deterministic backpressure coverage** (`packages/utils/test/postmortem.test.ts` + fixture): a subprocess installs a fake backpressured `process.stderr` and asserts
  1. `quit()` waits for the drain — a marker written at drain time survives (this test **fails without the fix**: verified, exit code 3 arrives with the marker cut off), and
  2. `quit()` still exits on its deadline when the drain never fires (no deadlock; exit code preserved).
  A real-pipe calibration run confirmed Bun genuinely truncates a backpressured stderr on `process.exit` (557060 of 1048711 bytes delivered, marker lost), so the guarded path is real.

## Verification

- `bun test packages/utils/test/postmortem.test.ts` 23/23 (incl. 2 new drain scenarios; drain-wait test fails without the fix).
- `bun test packages/coding-agent/test/startup-update-contract.test.ts` 20/20 (from #3621: successful print run requests `quit(<code>)` exactly once; `suppressProcessExit` callers never get one).
- `packages/utils`: `bun check` (biome + tsc) clean.
- Live before/after on the repro above, this branch: **5m04s → 5s** (hang eliminated); `--mode json` stream ends with the complete `agent_end` line; `GJC_TIMING=1` run prints the full timing tree to stderr and exits promptly.
- Full `packages/coding-agent` suite: failure set identical to the unpatched baseline (environment-dependent tmux/ACP/XDG tests only), as reported in #3621.