### PR TITLE
fix(coding-agent): preserve complete bash streaming output

### DIFF
--- a/packages/coding-agent/src/modes/components/bash-execution.ts
+++ b/packages/coding-agent/src/modes/components/bash-execution.ts
@@ -33,7 +33,7 @@ import {
 
 // Preview line limit when not expanded (matches tool execution behavior)
 const PREVIEW_LINES = 20;
-const STREAMING_LINE_CAP = PREVIEW_LINES * 5;
+const STREAMING_PREVIEW_LINE_CAP = PREVIEW_LINES * 5;
 const MAX_DISPLAY_LINE_CHARS = 4000;
 // Minimum interval between processing incoming chunks for display (ms).
 // Chunks arriving faster than this are accumulated and processed in one batch.
@@ -41,6 +41,11 @@ const CHUNK_THROTTLE_MS = 50;
 
 export class BashExecutionComponent extends Container {
 	#outputLines: string[] = [];
+	#fullOutputChunks: string[] = [];
+	#fullOutputText?: string;
+	#fullOutputLines?: string[];
+	#pendingOutputChunks: string[] = [];
+	#flushTimer?: NodeJS.Timeout;
 	#status: ExecutionStatus = "running";
 	#exitCode: number | undefined = undefined;
 	#loader: Loader;
@@ -48,9 +53,9 @@ export class BashExecutionComponent extends Container {
 	#expanded = false;
 	#displayDirty = false;
 	#displayBuiltWithGraphicsFallback: boolean | undefined;
-	#chunkGate = false;
 	#contentContainer: Container;
 	#headerText: Text;
+	#ui: TUI;
 
 	constructor(
 		private readonly command: string,
@@ -58,6 +63,7 @@ export class BashExecutionComponent extends Container {
 		excludeFromContext = false,
 	) {
 		super();
+		this.#ui = ui;
 
 		// Use dim border for excluded-from-context commands (!! prefix)
 		const colorKey = excludeFromContext ? "dim" : "bashMode";
@@ -94,15 +100,27 @@ export class BashExecutionComponent extends Container {
 	}
 
 	appendOutput(chunk: string): void {
-		// During high-throughput output (e.g. seq 1 500M), processing every
-		// chunk would saturate the event loop. Instead, accept one chunk per
-		// throttle window and drop the rest — the OutputSink captures everything
-		// for the artifact, and setComplete() replaces with the final output.
-		if (this.#chunkGate) return;
-		this.#chunkGate = true;
-		setTimeout(() => {
-			this.#chunkGate = false;
+		const clean = sanitizeWithOptionalSixelPassthrough(chunk, sanitizeText);
+		if (clean.length === 0) return;
+
+		// Keep every chunk for expanded output. Only the preview update is
+		// throttled; dropping chunks here makes live output lose arbitrary middle
+		// sections even when the executor captured them successfully.
+		this.#fullOutputChunks.push(clean);
+		this.#fullOutputText = undefined;
+		this.#fullOutputLines = undefined;
+		this.#pendingOutputChunks.push(clean);
+		if (this.#flushTimer) return;
+		this.#flushTimer = setTimeout(() => {
+			this.#flushTimer = undefined;
+			this.#flushPendingOutput();
 		}, CHUNK_THROTTLE_MS);
+	}
+
+	#flushPendingOutput(): void {
+		if (this.#pendingOutputChunks.length === 0) return;
+		const chunk = this.#pendingOutputChunks.join("");
+		this.#pendingOutputChunks = [];
 
 		const incomingLines = chunk.split("\n");
 		if (this.#outputLines.length > 0 && incomingLines.length > 0) {
@@ -115,12 +133,14 @@ export class BashExecutionComponent extends Container {
 			this.#outputLines.push(...this.#clampLinesPreservingSixel(incomingLines));
 		}
 
-		// Cap stored lines during streaming to avoid unbounded memory growth
-		if (this.#outputLines.length > STREAMING_LINE_CAP) {
-			this.#outputLines = this.#outputLines.slice(-STREAMING_LINE_CAP);
+		// Keep the collapsed preview bounded. The complete stream remains in
+		// #fullOutputChunks for expanded rendering and getOutput().
+		if (this.#outputLines.length > STREAMING_PREVIEW_LINE_CAP) {
+			this.#outputLines = this.#outputLines.slice(-STREAMING_PREVIEW_LINE_CAP);
 		}
 
 		this.#displayDirty = true;
+		this.#ui.requestRender();
 	}
 
 	setComplete(
@@ -128,10 +148,15 @@ export class BashExecutionComponent extends Container {
 		cancelled: boolean,
 		options?: { output?: string; truncation?: TruncationMeta },
 	): void {
+		if (this.#flushTimer) {
+			clearTimeout(this.#flushTimer);
+			this.#flushTimer = undefined;
+		}
+		this.#flushPendingOutput();
 		this.#exitCode = exitCode;
 		this.#status = resolveExecutionStatus(exitCode, cancelled);
 		this.#truncation = options?.truncation;
-		if (options?.output !== undefined) {
+		if (options?.output !== undefined && this.#fullOutputChunks.length === 0) {
 			this.#setOutput(options.output);
 		}
 
@@ -150,9 +175,18 @@ export class BashExecutionComponent extends Container {
 		return super.render(width);
 	}
 
+	override dispose(): void {
+		if (this.#flushTimer) {
+			clearTimeout(this.#flushTimer);
+			this.#flushTimer = undefined;
+		}
+		this.#pendingOutputChunks = [];
+		super.dispose();
+	}
+
 	#updateDisplay(): void {
 		const fallbackActive = isTerminalGraphicsFallbackActive();
-		const availableLines = this.#outputLines;
+		const availableLines = this.#expanded ? this.#getFullOutputLines() : this.#outputLines;
 		const sixelLineMask =
 			fallbackActive || (TERMINAL.imageProtocol === ImageProtocol.Sixel && isSixelPassthroughEnabled())
 				? getSixelLineMask(availableLines)
@@ -243,14 +277,32 @@ export class BashExecutionComponent extends Container {
 
 	#setOutput(output: string): void {
 		const clean = sanitizeWithOptionalSixelPassthrough(output, sanitizeText);
-		this.#outputLines = clean ? this.#clampLinesPreservingSixel(clean.split("\n")) : [];
+		this.#fullOutputChunks = clean ? [clean] : [];
+		this.#fullOutputText = clean;
+		this.#fullOutputLines = clean ? this.#clampLinesPreservingSixel(clean.split("\n")) : [];
+		this.#outputLines = this.#fullOutputLines.slice(-STREAMING_PREVIEW_LINE_CAP);
+	}
+
+	#getFullOutput(): string {
+		if (this.#fullOutputText === undefined) {
+			this.#fullOutputText = this.#fullOutputChunks.join("");
+		}
+		return this.#fullOutputText;
+	}
+
+	#getFullOutputLines(): string[] {
+		if (this.#fullOutputLines === undefined) {
+			const fullOutput = this.#getFullOutput();
+			this.#fullOutputLines = fullOutput ? this.#clampLinesPreservingSixel(fullOutput.split("\n")) : [];
+		}
+		return this.#fullOutputLines;
 	}
 
 	/**
 	 * Get the raw output for creating BashExecutionMessage.
 	 */
 	getOutput(): string {
-		return this.#outputLines.join("\n");
+		return this.#getFullOutputLines().join("\n");
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -19,6 +19,7 @@ import { getProjectDir, logger, sanitizeText } from "@gajae-code/utils";
 import { EDIT_MODE_STRATEGIES, type EditMode, type PerFileDiffPreview } from "../../edit";
 import type { Theme } from "../../modes/theme/theme";
 import { theme } from "../../modes/theme/theme";
+import type { StreamingOutputDelta } from "../../session/streaming-output";
 import { BASH_DEFAULT_PREVIEW_LINES } from "../../tools/bash";
 import { EVAL_DEFAULT_PREVIEW_LINES } from "../../tools/eval";
 import {
@@ -84,6 +85,15 @@ function argsCanBeSharedWithRenderer(toolName: string, tool: AgentTool | undefin
 function partialJsonLength(args: unknown): number {
 	const value = args && typeof args === "object" ? (args as { __partialJson?: unknown }).__partialJson : undefined;
 	return typeof value === "string" ? value.length : -1;
+}
+
+function readStreamingOutputDelta(details: unknown): StreamingOutputDelta | undefined {
+	if (typeof details !== "object" || details === null) return undefined;
+	const candidate = (details as { streamingOutput?: unknown }).streamingOutput;
+	if (typeof candidate !== "object" || candidate === null) return undefined;
+	const delta = candidate as { kind?: unknown; text?: unknown };
+	if (delta.kind !== "append" || typeof delta.text !== "string" || delta.text.length === 0) return undefined;
+	return { kind: "append", text: delta.text };
 }
 
 /**
@@ -211,6 +221,7 @@ export class ToolExecutionComponent extends Container {
 	#editAllowFuzzy: boolean | undefined;
 	#hashlineAutoDropPureInsertDuplicates: boolean | undefined;
 	#isPartial = true;
+	#streamingOutput = "";
 	#tool?: AgentTool;
 	#ui: TUI;
 	#cwd: string;
@@ -402,6 +413,12 @@ export class ToolExecutionComponent extends Container {
 	): void {
 		if (this.#isPartial === isPartial && Bun.deepEquals(this.#result, result)) return;
 		this.#textOutputCache = undefined;
+		if (this.#toolName === "bash" && isPartial) {
+			const delta = readStreamingOutputDelta(result.details);
+			if (delta?.kind === "append") {
+				this.#streamingOutput += sanitizeWithOptionalSixelPassthrough(delta.text, sanitizeText);
+			}
+		}
 		this.#result = result;
 		this.#invalidateStaleKittyConversions();
 		this.#isPartial = isPartial;
@@ -885,8 +902,16 @@ export class ToolExecutionComponent extends Container {
 			// plus this context to keep the inline command preview visible while tool-call JSON is still streaming.
 			if (this.#result) {
 				// Pass raw output and expanded state - renderer handles width-aware truncation
-				const output = this.#getTextOutput().trimEnd();
+				const streamedOutput =
+					this.#streamingOutput.length > 0
+						? isTerminalGraphicsFallbackActive()
+							? replaceSixelOutputForGraphicsFallback(this.#streamingOutput)
+							: this.#streamingOutput
+						: undefined;
+				const useStreamedOutput = this.#expanded && streamedOutput !== undefined;
+				const output = (useStreamedOutput ? streamedOutput : this.#getTextOutput()).trimEnd();
 				context.output = output;
+				if (useStreamedOutput) context.isFullOutput = true;
 			}
 			context.expanded = this.#expanded;
 			context.previewLines = BASH_DEFAULT_PREVIEW_LINES;

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1154,15 +1154,14 @@ export class CommandController {
 		this.ctx.ui.requestRender();
 
 		try {
-			const result = await this.ctx.session.executeBash(
-				command,
-				chunk => {
+			const result = await this.ctx.session.executeBash(command, undefined, {
+				excludeFromContext,
+				onRawChunk: chunk => {
 					if (this.ctx.bashComponent) {
 						this.ctx.bashComponent.appendOutput(chunk);
 					}
 				},
-				{ excludeFromContext },
-			);
+			});
 
 			if (this.ctx.bashComponent) {
 				const meta = outputMeta().truncationFromSummary(result, { direction: "tail" }).get();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -15168,7 +15168,10 @@ export class AgentSession {
 	async executeBash(
 		command: string,
 		onChunk?: (chunk: string) => void,
-		options?: { excludeFromContext?: boolean },
+		options?: {
+			excludeFromContext?: boolean;
+			onRawChunk?: (chunk: string) => void;
+		},
 	): Promise<BashResult> {
 		const excludeFromContext = options?.excludeFromContext === true;
 		this.#markRetryReplayUnsafe();
@@ -15197,6 +15200,7 @@ export class AgentSession {
 		try {
 			const result = await executeBashCommand(command, {
 				onChunk,
+				onRawChunk: options?.onRawChunk,
 				signal: abortController.signal,
 				sessionKey: this.sessionId,
 				cwd,

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -76,6 +76,18 @@ export interface OutputSummary {
 	artifactFailureDiagnostic?: string;
 }
 
+/**
+ * Incremental output carried only for the interactive renderer.
+ *
+ * The tool result itself is intentionally allowed to remain bounded. The
+ * renderer consumes these append-only deltas so a user can expand the live
+ * output without inheriting the LLM-facing tail truncation policy.
+ */
+export interface StreamingOutputDelta {
+	kind: "append";
+	text: string;
+}
+
 export interface OutputSinkOptions {
 	/**
 	 * Deprecated managed artifact pathname. Bare paths are deliberately ignored:
@@ -1585,6 +1597,68 @@ export class OutputSink {
 			artifactId,
 		};
 	}
+}
+
+// =============================================================================
+// User-facing live output updates
+// =============================================================================
+
+export interface StreamOutputUpdateCallbacks {
+	onChunk: (chunk: string) => void;
+	onRawChunk: (chunk: string) => void;
+	flush: () => void;
+}
+
+/**
+ * Build callbacks that keep the bounded tail snapshot for tool consumers while
+ * forwarding every sanitized process chunk to the interactive renderer as an
+ * append-only delta. `OutputSink` throttles `onChunk`, so raw chunks are queued
+ * there and flushed at the existing UI cadence; `flush()` closes the final
+ * throttle window after the process exits.
+ */
+export function createStreamOutputUpdates<TDetails, TInput = unknown>(
+	tailBuffer: TailBuffer,
+	onUpdate: AgentToolUpdateCallback<TDetails, TInput> | undefined,
+	createDetails: (delta: string) => TDetails,
+): StreamOutputUpdateCallbacks {
+	if (!onUpdate) {
+		return {
+			onChunk: () => {},
+			onRawChunk: () => {},
+			flush: () => {},
+		};
+	}
+
+	let pending: string[] = [];
+
+	const flush = (): void => {
+		if (pending.length === 0) return;
+		const delta = pending.join("");
+		pending = [];
+		onUpdate({
+			content: [{ type: "text", text: tailBuffer.text() }],
+			details: createDetails(delta),
+		});
+	};
+
+	return {
+		onRawChunk: chunk => {
+			if (chunk.length === 0) return;
+			tailBuffer.append(chunk);
+			pending.push(chunk);
+		},
+		onChunk: chunk => {
+			// Keep compatibility with callers/tests that provide only onChunk. In
+			// the normal executor path onRawChunk runs first, so this branch does
+			// not duplicate data.
+			if (pending.length === 0 && chunk.length > 0) {
+				tailBuffer.append(chunk);
+				pending.push(chunk);
+			}
+			flush();
+		},
+		flush,
+	};
 }
 
 // =============================================================================

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -20,17 +20,17 @@ import bashDescription from "../prompts/tools/bash.md" with { type: "text" };
 import type { ArtifactManager } from "../session/artifacts";
 import type { ClientBridgeTerminalExitStatus, ClientBridgeTerminalOutput } from "../session/client-bridge";
 import {
+	createStreamOutputUpdates,
 	DEFAULT_ARTIFACT_MAX_BYTES,
 	OutputSink,
 	type OutputSummary,
-	streamTailUpdates,
+	type StreamingOutputDelta,
 	TailBuffer,
 	type TerminalArtifactPublisher,
 	type TerminalArtifactPublishResult,
 	truncateHeadBytes,
 	truncateTailBytes,
 } from "../session/streaming-output";
-
 import { renderStatusLine } from "../tui";
 import { CachedOutputBlock } from "../tui/output-block";
 import { getSixelLineMask } from "../utils/sixel";
@@ -395,6 +395,8 @@ export interface BashToolDetails {
 	timeoutSeconds?: number;
 	requestedTimeoutSeconds?: number;
 	terminalId?: string;
+	/** Append-only user-facing output delta; never used as the LLM result body. */
+	streamingOutput?: StreamingOutputDelta;
 	async?: {
 		state: "running" | "completed" | "failed";
 		jobId: string;
@@ -1536,8 +1538,12 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		const spillThreshold = resolveBashOutputSinkTailBytes(this.session.settings);
 		const headBytes = resolveBashOutputSinkHeadBytes(this.session.settings);
 
-		// Track output for streaming updates (tail only)
+		// Keep the bounded tail for tool consumers, and forward append-only
+		// deltas separately so expanded UI output preserves the entire stream.
 		const tailBuffer = new TailBuffer(spillThreshold);
+		const streamUpdates = createStreamOutputUpdates(tailBuffer, onUpdate, text => ({
+			streamingOutput: { kind: "append" as const, text },
+		}));
 
 		// Allocate artifact for truncated output storage
 		const { path: artifactPath, id: artifactId } = (await this.session.allocateOutputArtifact?.("bash")) ?? {};
@@ -1549,36 +1555,42 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 				: canUseInteractiveBashPty(pty, ctx)
 					? ctx?.ui
 					: undefined;
-		const result: BashResult | BashInteractiveResult = interactiveUi
-			? await runInteractiveBashPty(interactiveUi, {
-					command,
-					cwd: commandCwd,
-					timeoutMs,
-					signal,
-					env: resolvedEnv,
-					artifactPath,
-					artifactId,
-					artifactPublisher,
-					spillThreshold,
-					headBytes,
-				})
-			: await executeBash(command, {
-					cwd: commandCwd,
-					sessionKey: this.session.getSessionId?.() ?? undefined,
-					oneShot: this.session.bashRestrictionProfile === "read-only",
-					timeout: timeoutMs,
-					signal,
-					env: resolvedEnv,
-					artifactPath,
-					artifactId,
-					artifactPublisher,
-					spillThreshold,
-					headBytes,
-					onChunk: streamTailUpdates(tailBuffer, onUpdate),
-					onMinimizedSave: async originalText => saveBashOriginalArtifact(this.session, originalText),
-					ignoreShellPrefix: this.session.bashRestrictionProfile === "read-only",
-					disableShellSnapshot: this.session.bashRestrictionProfile === "read-only",
-				});
+		let result: BashResult | BashInteractiveResult;
+		try {
+			result = interactiveUi
+				? await runInteractiveBashPty(interactiveUi, {
+						command,
+						cwd: commandCwd,
+						timeoutMs,
+						signal,
+						env: resolvedEnv,
+						artifactPath,
+						artifactId,
+						artifactPublisher,
+						spillThreshold,
+						headBytes,
+					})
+				: await executeBash(command, {
+						cwd: commandCwd,
+						sessionKey: this.session.getSessionId?.() ?? undefined,
+						oneShot: this.session.bashRestrictionProfile === "read-only",
+						timeout: timeoutMs,
+						signal,
+						env: resolvedEnv,
+						artifactPath,
+						artifactId,
+						artifactPublisher,
+						spillThreshold,
+						headBytes,
+						onChunk: streamUpdates.onChunk,
+						onRawChunk: streamUpdates.onRawChunk,
+						onMinimizedSave: async originalText => saveBashOriginalArtifact(this.session, originalText),
+						ignoreShellPrefix: this.session.bashRestrictionProfile === "read-only",
+						disableShellSnapshot: this.session.bashRestrictionProfile === "read-only",
+					});
+		} finally {
+			streamUpdates.flush();
+		}
 		if (result.cancelled) {
 			const failureText = formatBashFailureMessage(
 				result,

--- a/packages/coding-agent/test/bash-execution-sixel.test.ts
+++ b/packages/coding-agent/test/bash-execution-sixel.test.ts
@@ -213,43 +213,37 @@ describe("BashExecutionComponent streaming throttle", () => {
 		setThemeInstance(theme!);
 	});
 
-	it("caps stored lines during streaming", () => {
+	it("keeps the complete stream while the collapsed preview stays bounded", () => {
 		const component = new BashExecutionComponent("test", ui, false);
 
-		// Flood with 500 lines in one chunk (exceeds STREAMING_LINE_CAP of 100)
+		// Flood with more lines than the collapsed preview retains.
 		const lines = Array.from({ length: 500 }, (_, i) => `line${i}`).join("\n");
 		component.appendOutput(lines);
+		component.setComplete(0, false);
 
-		// Internal lines should be capped (we can't read #outputLines directly,
-		// but getOutput() returns the joined lines — it should have at most ~100 lines)
 		const output = component.getOutput();
 		const outputLineCount = output.split("\n").length;
-		expect(outputLineCount).toBeLessThanOrEqual(101); // 100 cap + possible partial
-		// Should retain the tail, not the head
+		expect(outputLineCount).toBe(500);
+		// The complete stream is available for expansion.
+		expect(output).toContain("line0\n");
 		expect(output).toContain("line499");
-		expect(output).not.toContain("line0\n");
 	});
 
-	it("gate drops rapid chunks", async () => {
+	it("retains rapid chunks while throttling preview updates", async () => {
 		const component = new BashExecutionComponent("test", ui, false);
 
-		// Send 100 chunks rapidly (all in same tick, before setTimeout fires)
+		// Send 100 chunks rapidly (all in the same tick).
 		for (let i = 0; i < 100; i++) {
 			component.appendOutput(`chunk${i}\n`);
 		}
 
-		// Only the first chunk should have been processed (gate blocks the rest)
+		await Bun.sleep(60); // CHUNK_THROTTLE_MS is 50
 		const output = component.getOutput();
 		expect(output).toContain("chunk0");
-		expect(output).not.toContain("chunk99");
-
-		// After the gate timer expires, the next chunk is accepted
-		await Bun.sleep(60); // CHUNK_THROTTLE_MS is 50
-		component.appendOutput("after_gate\n");
-		expect(component.getOutput()).toContain("after_gate");
+		expect(output).toContain("chunk99");
 	});
 
-	it("setComplete replaces streaming output with final output", () => {
+	it("keeps streamed output when the final result is tail-bounded", () => {
 		const component = new BashExecutionComponent("test", ui, false);
 
 		// Stream some partial output
@@ -259,9 +253,8 @@ describe("BashExecutionComponent streaming throttle", () => {
 		component.setComplete(0, false, { output: "final_line_1\nfinal_line_2" });
 
 		const output = component.getOutput();
-		expect(output).toContain("final_line_1");
-		expect(output).toContain("final_line_2");
-		// Streaming output is replaced, not appended
-		expect(output).not.toContain("streaming_line");
+		expect(output).toContain("streaming_line");
+		// The bounded final snapshot must not replace the complete live stream.
+		expect(output).not.toContain("final_line_1");
 	});
 });

--- a/packages/coding-agent/test/modes/components/tool-execution-spacing.test.ts
+++ b/packages/coding-agent/test/modes/components/tool-execution-spacing.test.ts
@@ -85,6 +85,31 @@ it("lets untouched components follow automatic expansion", () => {
 	expect(Bun.stripANSI(component.render(80).join("\n"))).toContain("Args");
 });
 
+it("keeps the complete streamed bash output available after the final result is tail-truncated", () => {
+	const component = new ToolExecutionComponent("bash", { command: "emit output" }, {}, undefined, uiStub);
+	const fullOutput = Array.from({ length: 30 }, (_, index) => `stream-line-${index + 1}`).join("\n");
+
+	component.updateResult(
+		{
+			content: [{ type: "text", text: "stream-line-30" }],
+			details: { streamingOutput: { kind: "append", text: fullOutput } },
+		},
+		true,
+	);
+	component.updateResult(
+		{
+			content: [{ type: "text", text: "stream-line-30" }],
+			isError: false,
+		},
+		false,
+	);
+	component.setExpanded(true);
+
+	const rendered = Bun.stripANSI(component.render(120).join("\n"));
+	expect(rendered).toContain("stream-line-1");
+	expect(rendered).toContain("stream-line-30");
+});
+
 it("replaces generic SIXEL output while the IRC sidebar is visible and restores passthrough when hidden", () => {
 	terminal.imageProtocol = ImageProtocol.Sixel;
 	Bun.env.PI_FORCE_IMAGE_PROTOCOL = "sixel";

--- a/packages/coding-agent/test/streaming-output.test.ts
+++ b/packages/coding-agent/test/streaming-output.test.ts
@@ -3,10 +3,12 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
+	createStreamOutputUpdates,
 	formatHeadTruncationNotice,
 	formatMiddleElisionMarker,
 	formatTailTruncationNotice,
 	OutputSink,
+	type StreamingOutputDelta,
 	TailBuffer,
 	truncateContent,
 	truncateHead,
@@ -181,6 +183,31 @@ describe("TailBuffer", () => {
 		tail.append("x");
 		expect(tail.text()).toBe("x");
 		expect(tail.bytes()).toBe(1);
+	});
+
+	test("keeps every raw chunk in renderer deltas while the result snapshot stays bounded", () => {
+		const updates: Array<{ snapshot: string; delta?: StreamingOutputDelta }> = [];
+		const callbacks = createStreamOutputUpdates<{ streamingOutput: StreamingOutputDelta }>(
+			new TailBuffer(5),
+			update => {
+				const first = update.content[0];
+				updates.push({
+					snapshot: first?.type === "text" ? first.text : "",
+					delta: update.details?.streamingOutput,
+				});
+			},
+			text => ({ streamingOutput: { kind: "append", text } }),
+		);
+
+		callbacks.onRawChunk("head\n");
+		callbacks.onChunk("head\n");
+		callbacks.onRawChunk("middle\n");
+		callbacks.onRawChunk("tail\n");
+		callbacks.flush();
+
+		expect(updates).toHaveLength(2);
+		expect(updates.map(update => update.delta?.text).join("")).toBe("head\nmiddle\ntail\n");
+		expect(updates[1]?.snapshot).toBe("tail\n");
 	});
 });
 


### PR DESCRIPTION
## Summary

- Preserve the full live Bash stream for expanded TUI output.
- Keep bounded tail snapshots for tool and model context.
- Retain rapid direct-shell chunks instead of dropping them.

## Validation

- bun --cwd=packages/coding-agent run check
- bun test packages/coding-agent/test/bash-execution-sixel.test.ts packages/coding-agent/test/modes/components/tool-execution-spacing.test.ts packages/coding-agent/test/streaming-output.test.ts (86 pass, 0 fail)