### PR TITLE
fix(coding-agent): restore import order in managed cleanup fixture

### DIFF
--- a/packages/coding-agent/test/session-manager/move-to.test.ts
+++ b/packages/coding-agent/test/session-manager/move-to.test.ts
@@ -10,8 +10,8 @@ import {
 	syncSessionMoveDirectory,
 } from "@gajae-code/coding-agent/session/session-manager";
 import { stripOuterDoubleQuotes } from "@gajae-code/coding-agent/tools/path-utils";
-import { getConfigRootDir, getSessionsDir, setAgentDir } from "@gajae-code/utils";
 import * as native from "@gajae-code/natives";
+import { getConfigRootDir, getSessionsDir, setAgentDir } from "@gajae-code/utils";
 import { resolveManagedScope } from "../../src/session/internal/managed-session-scope";
 import { makeAssistantMessage } from "./helpers";
 


### PR DESCRIPTION
## Summary

Current `dev` (`4512ddfaa`) fails its own `check:@gajae-code/coding-agent` task. The managed cleanup fixture added by that commit places the `@gajae-code/natives` namespace import after `@gajae-code/utils` in `packages/coding-agent/test/session-manager/move-to.test.ts`, which biome's `assist/source/organizeImports` rule rejects.

Because that task is `biome check . && bun run check:types`, the failure is inherited by every PR rebased onto current `dev`, not just by `dev` itself.

This change reorders the two import statements so the module specifiers sort correctly. It is a one-line swap with no runtime or test behaviour change.

```diff
 import { stripOuterDoubleQuotes } from "@gajae-code/coding-agent/tools/path-utils";
-import { getConfigRootDir, getSessionsDir, setAgentDir } from "@gajae-code/utils";
 import * as native from "@gajae-code/natives";
+import { getConfigRootDir, getSessionsDir, setAgentDir } from "@gajae-code/utils";
```

The edit was produced by `biome check --write` rather than by hand, so it byte-matches what the CI task expects.

## Verification

Run from `packages/coding-agent` at this head:

| Check | Command | Result |
| --- | --- | --- |
| biome (the failing CI gate) | `bun x @biomejs/biome check .` | exit `0`, 2494 files checked |
| types | `bun x tsc -p tsconfig.json --noEmit` | exit `0` |
| the fixture itself | `bun test test/session-manager/move-to.test.ts` | 21 pass / 0 fail, 67 `expect()` calls |

Fail-on-revert proof, to confirm the change is load-bearing rather than cosmetic:

- Revert only this one line → `biome check .` exits `1` with exactly one `assist/source/organizeImports` diagnostic, naming `test/session-manager/move-to.test.ts:1:1`.
- Restore the line → `biome check .` exits `0`.

## Scope

- Exactly one file, one line changed.
- Test-only fixture; no product source, no generated artifact, no `DAEMON_GENERATION` interaction.
- Not on a shard-1 coverage path, so this PR does not pull in the current `sdk-machine-lifecycle-topology.test.ts` failures.
- No changelog entry, matching the precedent of the recent standalone CI-unblocker PRs (#3630, #3632).

I kept this deliberately minimal and separate so it can be evaluated on its own. Happy to adjust the commit message, split it differently, or fold it into another branch if you would prefer that. Thank you for taking a look.
