### PR TITLE
fix(ai): update GPT-5.6 pricing

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Updated GPT-5.6 Sol, Terra, and Luna to current OpenAI Standard pricing, including Responses API cache-write attribution and full-request long-context pricing above 272K input tokens.
+
 ## [0.12.7] - 2026-07-31
 
 ## [0.12.6] - 2026-07-31

--- a/packages/ai/src/model-manager.ts
+++ b/packages/ai/src/model-manager.ts
@@ -403,9 +403,12 @@ function normalizeModelList<TApi extends Api>(value: unknown): Model<TApi>[] {
 	const models: Model<TApi>[] = [];
 	for (const item of value) {
 		if (isModelLike(item) && !isRetiredModel(item)) {
-			models.push(enrichModelThinking(item as Model<TApi>));
+			const model = enrichModelThinking(item as Model<TApi>);
+			model.longContextPricing = undefined;
+			models.push(model);
 		}
 	}
+	applyGeneratedModelPolicies(models as Model<Api>[]);
 	return applyFinalCodexGpt56ContextCap(models);
 }
 

--- a/packages/ai/src/model-pricing.ts
+++ b/packages/ai/src/model-pricing.ts
@@ -1,0 +1,68 @@
+import type { Api, LongContextPricing, Model, ModelCost } from "./types";
+
+interface TieredPricing {
+	cost: ModelCost;
+	longContextPricing: LongContextPricing;
+}
+
+const LONG_CONTEXT_THRESHOLD = 272_000;
+
+const GPT_5_6_SOL_PRICING: TieredPricing = {
+	cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },
+	longContextPricing: {
+		threshold: LONG_CONTEXT_THRESHOLD,
+		cost: { input: 10, output: 45, cacheRead: 1, cacheWrite: 12.5 },
+	},
+};
+
+// OpenAI Standard pricing: https://developers.openai.com/api/docs/pricing
+const OPENAI_GPT_5_6_PRICING: ReadonlyMap<string, TieredPricing> = new Map([
+	["gpt-5.6", GPT_5_6_SOL_PRICING],
+	["gpt-5.6-sol", GPT_5_6_SOL_PRICING],
+	[
+		"gpt-5.6-terra",
+		{
+			cost: { input: 2, output: 12, cacheRead: 0.2, cacheWrite: 2.5 },
+			longContextPricing: {
+				threshold: LONG_CONTEXT_THRESHOLD,
+				cost: { input: 4, output: 18, cacheRead: 0.4, cacheWrite: 5 },
+			},
+		},
+	],
+	[
+		"gpt-5.6-luna",
+		{
+			cost: { input: 0.2, output: 1.2, cacheRead: 0.02, cacheWrite: 0.25 },
+			longContextPricing: {
+				threshold: LONG_CONTEXT_THRESHOLD,
+				cost: { input: 0.4, output: 1.8, cacheRead: 0.04, cacheWrite: 0.5 },
+			},
+		},
+	],
+]);
+
+export function getOpenAIModelCost<TApi extends Api>(model: Model<TApi>, inputTokens: number): ModelCost | undefined {
+	if (model.provider !== "openai" && model.provider !== "openai-codex") {
+		return undefined;
+	}
+	const pricing = OPENAI_GPT_5_6_PRICING.get(model.id);
+	if (!pricing) {
+		return undefined;
+	}
+	return inputTokens > pricing.longContextPricing.threshold ? pricing.longContextPricing.cost : pricing.cost;
+}
+
+export function applyOpenAIModelPricing<TApi extends Api>(model: Model<TApi>): void {
+	if (model.provider !== "openai" && model.provider !== "openai-codex") {
+		return;
+	}
+	const pricing = OPENAI_GPT_5_6_PRICING.get(model.id);
+	if (!pricing) {
+		return;
+	}
+	model.cost = { ...pricing.cost };
+	model.longContextPricing = {
+		threshold: pricing.longContextPricing.threshold,
+		cost: { ...pricing.longContextPricing.cost },
+	};
+}

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -1,4 +1,5 @@
 import { CODEX_GPT_5_6_CONTEXT_CAP, isCodexGpt56Tier, isCodexProductTransport } from "./context-cap-policy";
+import { applyOpenAIModelPricing } from "./model-pricing";
 import { resolveOpenAICompat } from "./providers/openai-completions-compat";
 import type { Api, Model as ApiModel, ThinkingConfig } from "./types";
 import { isClaudeForcedToolChoiceIncapableModelId } from "./utils/tool-choice-capability";
@@ -377,6 +378,7 @@ function anthropicModelHasRealXHighEffort<TApi extends Api>(model: ApiModel<TApi
 }
 
 function applyGeneratedModelPolicy(model: ApiModel<Api>): void {
+	applyOpenAIModelPricing(model);
 	const copilotLimits = model.provider === "github-copilot" ? COPILOT_GENERATED_LIMITS[model.id] : undefined;
 	if (copilotLimits) {
 		model.contextWindow = copilotLimits.contextWindow;

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -58436,7 +58436,16 @@
 				"minLevel": "low",
 				"maxLevel": "max"
 			},
-			"applyPatchToolType": "freeform"
+			"applyPatchToolType": "freeform",
+			"longContextPricing": {
+				"threshold": 272000,
+				"cost": {
+					"input": 10,
+					"output": 45,
+					"cacheRead": 1,
+					"cacheWrite": 12.5
+				}
+			}
 		},
 		"gpt-5.6-luna": {
 			"id": "gpt-5.6-luna",
@@ -58450,10 +58459,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
-				"output": 6,
-				"cacheRead": 0.1,
-				"cacheWrite": 1.25
+				"input": 0.2,
+				"output": 1.2,
+				"cacheRead": 0.02,
+				"cacheWrite": 0.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -58462,7 +58471,16 @@
 				"minLevel": "low",
 				"maxLevel": "max"
 			},
-			"applyPatchToolType": "freeform"
+			"applyPatchToolType": "freeform",
+			"longContextPricing": {
+				"threshold": 272000,
+				"cost": {
+					"input": 0.4,
+					"output": 1.8,
+					"cacheRead": 0.04,
+					"cacheWrite": 0.5
+				}
+			}
 		},
 		"gpt-5.6-sol": {
 			"id": "gpt-5.6-sol",
@@ -58488,7 +58506,16 @@
 				"minLevel": "low",
 				"maxLevel": "max"
 			},
-			"applyPatchToolType": "freeform"
+			"applyPatchToolType": "freeform",
+			"longContextPricing": {
+				"threshold": 272000,
+				"cost": {
+					"input": 10,
+					"output": 45,
+					"cacheRead": 1,
+					"cacheWrite": 12.5
+				}
+			}
 		},
 		"gpt-5.6-terra": {
 			"id": "gpt-5.6-terra",
@@ -58502,10 +58529,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 15,
-				"cacheRead": 0.25,
-				"cacheWrite": 3.125
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -58514,7 +58541,16 @@
 				"minLevel": "low",
 				"maxLevel": "max"
 			},
-			"applyPatchToolType": "freeform"
+			"applyPatchToolType": "freeform",
+			"longContextPricing": {
+				"threshold": 272000,
+				"cost": {
+					"input": 4,
+					"output": 18,
+					"cacheRead": 0.4,
+					"cacheWrite": 5
+				}
+			}
 		},
 		"gpt-image-2": {
 			"id": "gpt-image-2",
@@ -59224,10 +59260,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
-				"output": 6,
-				"cacheRead": 0.1,
-				"cacheWrite": 1.25
+				"input": 0.2,
+				"output": 1.2,
+				"cacheRead": 0.02,
+				"cacheWrite": 0.25
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
@@ -59238,7 +59274,16 @@
 				"minLevel": "low",
 				"maxLevel": "max"
 			},
-			"applyPatchToolType": "freeform"
+			"applyPatchToolType": "freeform",
+			"longContextPricing": {
+				"threshold": 272000,
+				"cost": {
+					"input": 0.4,
+					"output": 1.8,
+					"cacheRead": 0.04,
+					"cacheWrite": 0.5
+				}
+			}
 		},
 		"gpt-5.6-sol": {
 			"id": "gpt-5.6-sol",
@@ -59266,7 +59311,16 @@
 				"minLevel": "low",
 				"maxLevel": "max"
 			},
-			"applyPatchToolType": "freeform"
+			"applyPatchToolType": "freeform",
+			"longContextPricing": {
+				"threshold": 272000,
+				"cost": {
+					"input": 10,
+					"output": 45,
+					"cacheRead": 1,
+					"cacheWrite": 12.5
+				}
+			}
 		},
 		"gpt-5.6-terra": {
 			"id": "gpt-5.6-terra",
@@ -59280,10 +59334,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 15,
-				"cacheRead": 0.25,
-				"cacheWrite": 3.125
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
@@ -59294,7 +59348,16 @@
 				"minLevel": "low",
 				"maxLevel": "max"
 			},
-			"applyPatchToolType": "freeform"
+			"applyPatchToolType": "freeform",
+			"longContextPricing": {
+				"threshold": 272000,
+				"cost": {
+					"input": 4,
+					"output": 18,
+					"cacheRead": 0.4,
+					"cacheWrite": 5
+				}
+			}
 		},
 		"gpt-image-2": {
 			"id": "gpt-image-2",

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { getOpenAIModelCost } from "./model-pricing";
 import { isRetiredModelKey } from "./model-retirements";
 import { applyGeneratedModelPolicies, enrichModelThinking } from "./model-thinking";
 // `with { type: "file" }` is embedded by `bun build --compile` and resolves to
@@ -92,10 +93,12 @@ export function getBundledModels(provider: GeneratedProvider): Model<Api>[] {
 }
 
 export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage): Usage["cost"] {
-	usage.cost.input = (model.cost.input / 1000000) * usage.input;
-	usage.cost.output = (model.cost.output / 1000000) * usage.output;
-	usage.cost.cacheRead = (model.cost.cacheRead / 1000000) * usage.cacheRead;
-	usage.cost.cacheWrite = (model.cost.cacheWrite / 1000000) * usage.cacheWrite;
+	const inputTokens = usage.input + usage.cacheRead + usage.cacheWrite;
+	const pricing = getOpenAIModelCost(model, inputTokens) ?? model.cost;
+	usage.cost.input = (pricing.input / 1000000) * usage.input;
+	usage.cost.output = (pricing.output / 1000000) * usage.output;
+	usage.cost.cacheRead = (pricing.cacheRead / 1000000) * usage.cacheRead;
+	usage.cost.cacheWrite = (pricing.cacheWrite / 1000000) * usage.cacheWrite;
 	usage.cost.total = usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite;
 	return usage.cost;
 }

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -960,20 +960,31 @@ export function populateResponsesUsageFromResponse(
 				input_tokens?: number | null;
 				output_tokens?: number | null;
 				total_tokens?: number | null;
-				input_tokens_details?: { cached_tokens?: number | null } | null;
+				input_tokens_details?: {
+					cached_tokens?: number | null;
+					cache_write_tokens?: number | null;
+				} | null;
 				output_tokens_details?: { reasoning_tokens?: number | null } | null;
 		  }
 		| null
 		| undefined,
 ): void {
 	if (!usage) return;
+	const inputTokens = usage.input_tokens || 0;
 	const cachedTokens = usage.input_tokens_details?.cached_tokens || 0;
+	const reportedCacheWrite = usage.input_tokens_details?.cache_write_tokens || 0;
+	const cacheWriteTokens =
+		Number.isSafeInteger(reportedCacheWrite) &&
+		reportedCacheWrite >= 0 &&
+		cachedTokens + reportedCacheWrite <= inputTokens
+			? reportedCacheWrite
+			: 0;
 	const reasoningTokens = usage.output_tokens_details?.reasoning_tokens || 0;
 	output.usage = {
-		input: (usage.input_tokens || 0) - cachedTokens,
+		input: Math.max(0, inputTokens - cachedTokens - cacheWriteTokens),
 		output: usage.output_tokens || 0,
 		cacheRead: cachedTokens,
-		cacheWrite: 0,
+		cacheWrite: cacheWriteTokens,
 		totalTokens: usage.total_tokens || 0,
 		...(reasoningTokens > 0 ? { reasoningTokens } : {}),
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -989,6 +989,19 @@ export interface ModelRequestTransform {
 	extraBody?: Record<string, unknown>;
 }
 
+export interface ModelCost {
+	input: number; // $/million tokens
+	output: number; // $/million tokens
+	cacheRead: number; // $/million tokens
+	cacheWrite: number; // $/million tokens
+}
+
+export interface LongContextPricing {
+	/** Input-token count above which the long-context rates apply to the full request. */
+	threshold: number;
+	cost: ModelCost;
+}
+
 export interface Model<TApi extends Api = any> {
 	id: string;
 	name: string;
@@ -1005,12 +1018,9 @@ export interface Model<TApi extends Api = any> {
 	 * provider/id heuristics.
 	 */
 	output?: ("text" | "image")[];
-	cost: {
-		input: number; // $/million tokens
-		output: number; // $/million tokens
-		cacheRead: number; // $/million tokens
-		cacheWrite: number; // $/million tokens
-	};
+	cost: ModelCost;
+	/** Optional long-context rates selected from the request's total input-token count. */
+	longContextPricing?: LongContextPricing;
 	/** Premium Copilot requests charged per user-initiated request (defaults to 1). */
 	premiumMultiplier?: number;
 	contextWindow: number;

--- a/packages/ai/test/model-manager-context-cap.test.ts
+++ b/packages/ai/test/model-manager-context-cap.test.ts
@@ -65,4 +65,48 @@ describe("model manager Codex GPT-5.6 cap", () => {
 		);
 		expect(result.models[0]?.contextWindow).toBe(200_000);
 	});
+
+	it("applies GPT-5.6 pricing to dynamically discovered models without a static entry", async () => {
+		const result = await resolveProviderModels<Api>(
+			{
+				providerId: "openai-codex",
+				staticModels: [],
+				cacheDbPath,
+				fetchDynamicModels: async () => [codexModel(272_000)],
+			},
+			"online",
+		);
+
+		expect(result.models[0]?.cost).toEqual({
+			input: 5,
+			output: 30,
+			cacheRead: 0.5,
+			cacheWrite: 6.25,
+		});
+		expect(result.models[0]?.longContextPricing).toEqual({
+			threshold: 272_000,
+			cost: { input: 10, output: 45, cacheRead: 1, cacheWrite: 12.5 },
+		});
+	});
+
+	it("does not trust long-context rates from dynamic discovery", async () => {
+		const model = codexModel(272_000);
+		model.id = "custom-model";
+		model.longContextPricing = {
+			threshold: 1,
+			cost: { input: Infinity, output: 0, cacheRead: 0, cacheWrite: 0 },
+		};
+
+		const result = await resolveProviderModels<Api>(
+			{
+				providerId: "openai-codex",
+				staticModels: [],
+				cacheDbPath,
+				fetchDynamicModels: async () => [model],
+			},
+			"online",
+		);
+
+		expect(result.models[0]?.longContextPricing).toBeUndefined();
+	});
 });

--- a/packages/ai/test/models-cost.test.ts
+++ b/packages/ai/test/models-cost.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import { calculateCost, getBundledModel } from "../src/models";
-import type { Usage } from "../src/types";
+import modelsJson from "../src/models.json" with { type: "json" };
+import { populateResponsesUsageFromResponse } from "../src/providers/openai-responses-shared";
+import type { AssistantMessage, Model, Usage } from "../src/types";
 
 describe("calculateCost", () => {
 	it("keeps token-based calculation for GitHub Copilot models", () => {
@@ -71,6 +73,29 @@ describe("calculateCost", () => {
 		expect(usage.cost.total).toBeCloseTo(2.18, 8);
 	});
 
+	it("ignores non-canonical long-context pricing", () => {
+		const model = {
+			...getBundledModel("openai", "gpt-4o-mini"),
+			cost: { input: 1000, output: 2000, cacheRead: 500, cacheWrite: 800 },
+			longContextPricing: {
+				threshold: 1,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			},
+		};
+		const usage: Usage = {
+			input: 1000,
+			output: 500,
+			cacheRead: 200,
+			cacheWrite: 100,
+			totalTokens: 1800,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+
+		calculateCost(model, usage);
+
+		expect(usage.cost.total).toBeCloseTo(2.18, 8);
+	});
+
 	it("prices OpenAI Codex GPT models from the matching OpenAI catalog entry", () => {
 		const openAIModel = getBundledModel("openai", "gpt-5.4");
 		const codexModel = getBundledModel("openai-codex", "gpt-5.4");
@@ -88,5 +113,135 @@ describe("calculateCost", () => {
 		calculateCost(codexModel, usage);
 
 		expect(usage.cost.total).toBeCloseTo(0.01005, 8);
+	});
+
+	it("bundles the current OpenAI Standard prices for the GPT-5.6 family", () => {
+		const rawCatalog = modelsJson as Record<string, Record<string, Model>>;
+		const expectedPricing = [
+			{
+				id: "gpt-5.6",
+				short: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },
+				long: { input: 10, output: 45, cacheRead: 1, cacheWrite: 12.5 },
+			},
+			{
+				id: "gpt-5.6-sol",
+				short: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },
+				long: { input: 10, output: 45, cacheRead: 1, cacheWrite: 12.5 },
+			},
+			{
+				id: "gpt-5.6-terra",
+				short: { input: 2, output: 12, cacheRead: 0.2, cacheWrite: 2.5 },
+				long: { input: 4, output: 18, cacheRead: 0.4, cacheWrite: 5 },
+			},
+			{
+				id: "gpt-5.6-luna",
+				short: { input: 0.2, output: 1.2, cacheRead: 0.02, cacheWrite: 0.25 },
+				long: { input: 0.4, output: 1.8, cacheRead: 0.04, cacheWrite: 0.5 },
+			},
+		] as const;
+
+		for (const expected of expectedPricing) {
+			const openAIModel = getBundledModel("openai", expected.id);
+
+			expect(rawCatalog.openai?.[expected.id]?.cost).toEqual(expected.short);
+			expect(rawCatalog.openai?.[expected.id]?.longContextPricing).toEqual({
+				threshold: 272_000,
+				cost: expected.long,
+			});
+			expect(openAIModel.cost).toEqual(expected.short);
+			expect(openAIModel.longContextPricing).toEqual({
+				threshold: 272_000,
+				cost: expected.long,
+			});
+			if (expected.id !== "gpt-5.6") {
+				const codexModel = getBundledModel("openai-codex", expected.id);
+				expect(rawCatalog["openai-codex"]?.[expected.id]?.cost).toEqual(expected.short);
+				expect(rawCatalog["openai-codex"]?.[expected.id]?.longContextPricing).toEqual({
+					threshold: 272_000,
+					cost: expected.long,
+				});
+				expect(codexModel.cost).toEqual(openAIModel.cost);
+				expect(codexModel.longContextPricing).toEqual(openAIModel.longContextPricing);
+			}
+		}
+	});
+
+	it("keeps GPT-5.6 short-context pricing at exactly 272K input tokens", () => {
+		const model = getBundledModel("openai", "gpt-5.6-terra");
+		const usage: Usage = {
+			input: 200_000,
+			output: 1_000,
+			cacheRead: 72_000,
+			cacheWrite: 0,
+			totalTokens: 273_000,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+
+		calculateCost(model, usage);
+
+		expect(usage.cost.input).toBeCloseTo(0.4, 8);
+		expect(usage.cost.output).toBeCloseTo(0.012, 8);
+		expect(usage.cost.cacheRead).toBeCloseTo(0.0144, 8);
+		expect(usage.cost.total).toBeCloseTo(0.4264, 8);
+	});
+
+	it("prices the full GPT-5.6 request at long-context rates above 272K input tokens", () => {
+		const model = getBundledModel("openai", "gpt-5.6-terra");
+		const usage: Usage = {
+			input: 200_000,
+			output: 1_000,
+			cacheRead: 72_000,
+			cacheWrite: 1,
+			totalTokens: 273_001,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+
+		calculateCost(model, usage);
+
+		expect(usage.cost.input).toBeCloseTo(0.8, 8);
+		expect(usage.cost.output).toBeCloseTo(0.018, 8);
+		expect(usage.cost.cacheRead).toBeCloseTo(0.0288, 8);
+		expect(usage.cost.cacheWrite).toBeCloseTo(0.000005, 8);
+		expect(usage.cost.total).toBeCloseTo(0.846805, 8);
+	});
+
+	it("attributes OpenAI Responses cache-write tokens to their billable bucket", () => {
+		const output: AssistantMessage = {
+			role: "assistant",
+			content: [],
+			api: "openai-responses",
+			provider: "openai",
+			model: "gpt-5.6-terra",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: 0,
+		};
+
+		populateResponsesUsageFromResponse(output, {
+			input_tokens: 272_001,
+			output_tokens: 1_000,
+			total_tokens: 273_001,
+			input_tokens_details: { cached_tokens: 72_000, cache_write_tokens: 1 },
+		});
+
+		expect(output.usage.input).toBe(200_000);
+		expect(output.usage.cacheRead).toBe(72_000);
+		expect(output.usage.cacheWrite).toBe(1);
+
+		populateResponsesUsageFromResponse(output, {
+			input_tokens: 10,
+			output_tokens: 0,
+			total_tokens: 10,
+			input_tokens_details: { cache_write_tokens: -1 },
+		});
+		expect(output.usage.input).toBe(10);
+		expect(output.usage.cacheWrite).toBe(0);
 	});
 });


### PR DESCRIPTION
## Summary

- update GPT-5.6 Sol, Terra, and Luna to the current OpenAI Standard rates
- apply full-request long-context rates when input tokens exceed 272K
- keep bundled and dynamically discovered model pricing aligned
- attribute Responses API cache-write tokens to the correct cost bucket

Pricing source: https://developers.openai.com/api/docs/pricing

## Testing

- `bun test packages/ai/test/models-cost.test.ts packages/ai/test/model-manager-context-cap.test.ts`
- `bun --cwd=packages/ai run check`

The full AI suite reported 2 pre-existing environment-dependent failures (Anthropic fixture hash and local llama.cpp 404); 2,070 tests passed.