### PR TITLE
fix(coding-agent): assert goal_updated payload instead of emit arity

### DIFF
--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -383,9 +383,11 @@ describe("InteractiveMode goal mode integration", () => {
 		const extensionError = new TypeError(
 			'The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received undefined',
 		);
-		const emit = vi.fn(async (event: { type: string }) => {
-			if (event.type === "goal_updated") throw extensionError;
-		});
+		const emit = vi.fn(
+			async (event: { type: string; goal?: { status?: string } | null; state?: { mode?: string } }) => {
+				if (event.type === "goal_updated") throw extensionError;
+			},
+		);
 		harness = await createGoalHarness({
 			extensionRunner: { emit, getRegisteredCommands: () => [] } as unknown as ExtensionRunner,
 		});
@@ -398,7 +400,11 @@ describe("InteractiveMode goal mode integration", () => {
 		expect(result.details?.goal?.status).toBe("complete");
 		expect(harness.session.getGoalModeState()?.goal.status).toBe("complete");
 		expect(harness.session.getGoalModeState()?.mode).toBe("exiting");
-		expect(emit).toHaveBeenCalledWith(expect.objectContaining({ type: "goal_updated" }));
+		const goalUpdates = emit.mock.calls.map(([event]) => event).filter(event => event.type === "goal_updated");
+		expect(goalUpdates.length).toBeGreaterThan(0);
+		const terminalUpdate = goalUpdates[goalUpdates.length - 1];
+		expect(terminalUpdate?.goal?.status).toBe("complete");
+		expect(terminalUpdate?.state?.mode).toBe("exiting");
 	});
 
 	it("does not loop AgentBusyError when a busy/orphaned session triggers goal continuation", async () => {


### PR DESCRIPTION
## Summary

`packages/coding-agent/test/goals/goal-mode-integration.test.ts` fails on current `dev` (`b6198e748`) with a stale call-arity assertion. This is a test-only repair; no product file changes.

The immutable per-attempt scope facility (#3608) routes every session extension event through the three-argument shape:

```ts
await this.#extensionRunner.emit(
    { type: "goal_updated", goal: event.goal, state: event.state },
    undefined,
    deliveryScope,
);
```

The test still asserted the single-argument shape:

```ts
expect(emit).toHaveBeenCalledWith(expect.objectContaining({ type: "goal_updated" }));
```

`toHaveBeenCalledWith` matches the full argument list, so the extra `undefined, undefined` makes it fail with `Number of calls: 2`.

I checked whether `deliveryScope === undefined` is itself the defect, and I do not believe it is. `goal_updated` is emitted from `#emitSessionEvent` (`agent-session.ts:2768`) with no attempt scope attached, and `deliveryScope` resolves as `scope ?? event.scope`. Goal state is session-level rather than attempt-level, so no scope is the correct value here. The product looks right and the assertion is the stale part.

## Change

Assert the delivered payload instead of the call arity. The test now locates the terminal `goal_updated` event the throwing hook actually received and proves it carries the completion state:

```ts
const goalUpdates = emit.mock.calls.map(([event]) => event).filter(event => event.type === "goal_updated");
expect(goalUpdates.length).toBeGreaterThan(0);
const terminalUpdate = goalUpdates[goalUpdates.length - 1];
expect(terminalUpdate?.goal?.status).toBe("complete");
expect(terminalUpdate?.state?.mode).toBe("exiting");
```

This is what the test's name already claims, and it is stronger than what it replaced: the old line only proved *some* `goal_updated` fired, while this proves the throwing hook received the terminal completion payload. `expect()` calls in the file go from 80 to 82. The spy's parameter type is widened structurally, so there is no cast and no private access.

## Verification

On `b6198e748`, darwin-arm64:

- `bun test packages/coding-agent/test/goals/goal-mode-integration.test.ts` — **17 pass / 0 fail**, 82 `expect()` calls (was 16 pass / 1 fail, 80 calls)
- `bun run check:types` (`tsc -p packages/coding-agent/tsconfig.json --noEmit`) — exit 0
- `bun x @biomejs/biome check packages/coding-agent/test/goals/goal-mode-integration.test.ts` — exit 0
- Exactly one changed file

Two-sided proof, since a fixture-side change deserves the scrutiny:

1. **Fail-on-revert.** Reverting only this diff on the same tree returns 16 pass / 1 fail; restoring returns 17 pass / 0 fail.
2. **Product-coupled.** With the fix in place, dropping `state: event.state` from the `goal_updated` emit in `agent-session.ts` makes the new assertion fail (16 pass / 1 fail); restoring the product returns 17 pass / 0 fail.

The second proof is the one I care about. I did not want to hand you an assertion that merely accommodates whatever the code currently does — it is bound to product behaviour and fails when that behaviour regresses.

## Notes

I found this while checking why `test:@gajae-code/coding-agent:shard-1-of-8` is red. It was the only remaining failing test in that shard on my open PRs (#3618, #3620) after the earlier topology failures cleared. The file is not in `CODING_AGENT_SHARD_ONE_COVERAGE_PATHS` and, as far as I can tell from the open PR list, is not claimed by any open PR — if it overlaps work you already have in flight, please close this and I will drop it without argument.

Happy to adjust the assertion shape if you would prefer a different convention here; there was no existing precedent in the repo for asserting the three-argument `emit` shape, so I picked one.
