### PR TITLE
fix(coding-agent): assert message-pipeline callback payloads instead of arity

### DIFF
--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -86,7 +86,7 @@ describe("AgentSession message pipeline", () => {
 			...(payload as Record<string, unknown>),
 			session: true,
 		}));
-		const requestOnPayload = vi.fn(async () => undefined);
+		const requestOnPayload = vi.fn(async (_payload: unknown) => undefined);
 		const session = new AgentSession({
 			agent: createAgent(),
 			sessionManager: SessionManager.inMemory(),
@@ -103,13 +103,15 @@ describe("AgentSession message pipeline", () => {
 		const prepared = session.prepareSimpleStreamOptions(options);
 		const result = await prepared.onPayload?.({ original: true });
 
-		expect(sessionOnPayload).toHaveBeenCalledWith({ original: true }, undefined);
-		expect(requestOnPayload).toHaveBeenCalledWith({ original: true, session: true }, undefined);
+		expect(sessionOnPayload.mock.calls.length).toBe(1);
+		expect(sessionOnPayload.mock.calls[0]?.[0]).toEqual({ original: true });
+		expect(requestOnPayload.mock.calls.length).toBe(1);
+		expect(requestOnPayload.mock.calls[0]?.[0]).toEqual({ original: true, session: true });
 		expect(result).toEqual({ original: true, session: true });
 	});
 
 	it("records raw SSE diagnostics into the session buffer before request hooks", async () => {
-		const requestOnSseEvent = vi.fn();
+		const requestOnSseEvent = vi.fn((_event: unknown) => {});
 		const session = new AgentSession({
 			agent: createAgent(),
 			sessionManager: SessionManager.inMemory(),
@@ -123,10 +125,12 @@ describe("AgentSession message pipeline", () => {
 		prepared.onSseEvent?.({ event: "message", data: "{}", raw: ["event: message", "data: {}"] });
 
 		expect(session.rawSseDebugBuffer.snapshot().totalEvents).toBe(1);
-		expect(requestOnSseEvent).toHaveBeenCalledWith(
-			{ event: "message", data: "{}", raw: ["event: message", "data: {}"] },
-			undefined,
-		);
+		expect(requestOnSseEvent.mock.calls.length).toBe(1);
+		expect(requestOnSseEvent.mock.calls[0]?.[0]).toEqual({
+			event: "message",
+			data: "{}",
+			raw: ["event: message", "data: {}"],
+		});
 	});
 
 	it("emits message_update to session listeners before slow extension handlers finish", async () => {
@@ -198,7 +202,19 @@ describe("AgentSession message pipeline", () => {
 	});
 
 	it("forwards stop reasons and reasoning summaries to extension handlers", async () => {
-		const extensionEmit = vi.fn(async () => {});
+		const extensionEmit = vi.fn(
+			async (
+				_event: {
+					type: string;
+					messages?: unknown[];
+					stopReason?: string;
+					contentIndex?: number;
+					content?: string;
+				},
+				_continueWhile?: () => boolean,
+				_scope?: unknown,
+			) => {},
+		);
 		const session = new AgentSession({
 			agent: createAgent(),
 			sessionManager: SessionManager.inMemory(),
@@ -225,15 +241,17 @@ describe("AgentSession message pipeline", () => {
 		await Bun.sleep(0);
 		await Bun.sleep(0);
 
-		expect(extensionEmit).toHaveBeenCalledWith({ type: "agent_end", messages: [], stopReason: "cancelled" });
-		expect(extensionEmit).toHaveBeenCalledWith(
+		const emittedEvents = extensionEmit.mock.calls.map(([event]) => event);
+		expect(emittedEvents).toContainEqual({ type: "agent_end", messages: [], stopReason: "cancelled" });
+		const reasoningCall = extensionEmit.mock.calls.find(([event]) => event?.type === "reasoning_summary_end");
+		expect(reasoningCall?.[0]).toEqual(
 			expect.objectContaining({
 				type: "reasoning_summary_end",
 				contentIndex: 0,
 				content: "safe summary",
 			}),
-			expect.any(Function),
 		);
+		expect(typeof reasoningCall?.[1]).toBe("function");
 	});
 
 	it("drains pre-terminal reasoning summaries through slow extension handlers and drops post-terminal updates", async () => {


### PR DESCRIPTION
## Summary

`packages/coding-agent/test/agent-session-message-pipeline.test.ts` has three assertions that pin the *argument count* of session callbacks with `toHaveBeenCalledWith`. The per-attempt scope facility (#3592 / #3608) threads an additional callback-scope argument through `onPayload`, `onSseEvent`, and extension `emit`, so those three assertions now fail on current `dev` even though every observable behaviour is unchanged.

This replaces the arity pins with assertions on the payload each hook actually receives.

## Reproduction on current dev

At `8937871b1` (dev tip), with freshly built natives:

```
bun test packages/coding-agent/test/agent-session-message-pipeline.test.ts
 21 pass
 3 fail
```

The three failures, each an added trailing argument:

| Test | Line | Diff |
|---|---|---|
| composes session payload hooks into direct side-request options | 106 | `Received + 1` — extra `undefined` |
| records raw SSE diagnostics into the session buffer before request hooks | 126 | `Received + 1` — extra `undefined` |
| forwards stop reasons and reasoning summaries to extension handlers | 228 | received `(event, [Function: belongsToCurrentTurn], undefined)` |

The product side is intentional — `prepareSimpleStreamOptions` composes `(payload, model, callbackScope)` at `agent-session.ts:7318`, and `onSseEvent`/`onResponse` use the same 3-argument shape.

## Change

- **composes session payload hooks** — assert the session hook receives the original payload and the request hook receives the *session-transformed* payload. This is strictly stronger than the old assertion: it now pins the session→request threading order, which the arity check never covered.
- **records raw SSE diagnostics** — assert the forwarded SSE event object.
- **forwards stop reasons and reasoning summaries** — locate the `reasoning_summary_end` call and assert both its event payload and that its `continueWhile` argument is a function. The previous `expect.any(Function)` guarantee is preserved, not dropped.

Spy parameter types are widened so no cast is required. Assertions are arity-tolerant, so a future scope-argument change will not re-break them.

## Verification

Verified in a clean worktree at dev tip `8937871b1`:

| Check | Result |
|---|---|
| `agent-session-message-pipeline.test.ts` | **24 pass / 0 fail** (was 21 pass / 3 fail) |
| `expect()` calls | **84 → 91** |
| `bun run check:types` (`packages/coding-agent`) | exit 0 |
| `biome check .` | exit 0 |
| Files changed | 1 (test only) |

### Fail-on-revert proof

Reverting only this change at the same base restores `21 pass / 3 fail`; restoring it returns `24 pass / 0 fail`.

### Product-coupling proofs

To confirm the new assertions are coupled to product behaviour rather than accommodating the fixture, two independent product breaks were introduced with the test fix in place:

1. Pass the raw `payload` instead of `sessionResolvedPayload` to the request hook (`agent-session.ts:7320`) → **caught**, `23 pass / 1 fail`.
2. Replace the session SSE hook assignment with a no-op (the branch this test exercises) → **caught**, `23 pass / 1 fail`.

Both restore to `24 pass / 0 fail`. So these assertions detect regressions the previous arity pins could not.

## Overlap disclosure

#3638 ("AttemptScope post-merge compatibility repairs") repairs the same family of arity artifacts in `agent-session.ts`, `packages/agent/src/agent.ts`, and `test/goals/goal-mode-integration.test.ts`. At its head `8a3ea37ab` I verified it does **not** touch `agent-session-message-pipeline.test.ts`, and that file still shows `21 pass / 3 fail` there — which is why this is offered separately.

I should also disclose that my #3637 edits the same line of `test/goals/goal-mode-integration.test.ts` that #3638 edits, using a different approach. #3638 is the broader change and carries the product-side repairs; please prefer it and close #3637 if that is simplest. I am happy to close this PR too if you would rather fold the message-pipeline assertions into #3638.

Also noted for completeness: `agent-session-auto-compaction-continue.test.ts` still shows `16 pass / 2 fail` at #3638's head (`resetAttemptBudgetSpy` observed 0 calls, expected 1, at lines 476 and 599). That one looks product-side in `agent-session.ts`, which #3638 owns, so I have not touched it.

No product files, no changelog surface, and no generated artifacts are modified. Thank you for reviewing.
