### PR TITLE
fix(natives): release staging descriptor before no-replace publish

### DIFF
--- a/crates/pi-natives/src/recovery_fs.rs
+++ b/crates/pi-natives/src/recovery_fs.rs
@@ -143,11 +143,21 @@ const fn rename_flags_unsupported(errno: Option<i32>) -> bool {
 /// preserves — never weakens — no-replace authority. The staging source link is
 /// then removed so the destination is the sole link, matching a successful
 /// rename (`st_nlink == 1`).
+///
+/// `release_source_authority` runs after the link has published the destination
+/// and before the staging name is unlinked. Callers that hold a descriptor on
+/// the staged object must release it there: NFS silly-renames a still-open name
+/// to `.nfsXXXX` instead of removing it, which leaves a second link to the
+/// published inode and defeats the `st_nlink == 1` proof this fallback exists
+/// to preserve. Releasing only after the link commits keeps descriptor
+/// authority across publication itself, so the fallback is never weaker than
+/// the `renameat2` primitive it stands in for.
 fn linkat_no_replace(
 	source_parent: &File,
 	source_name: &CString,
 	destination_parent: &File,
 	destination_name: &CString,
+	release_source_authority: impl FnOnce(),
 ) -> std::io::Result<()> {
 	// SAFETY: both parents own valid fds and both names are live NUL-terminated
 	// strings for this syscall; flags are 0, so a symlink source is linked as-is.
@@ -163,6 +173,10 @@ fn linkat_no_replace(
 	if linked != 0 {
 		return Err(std::io::Error::last_os_error());
 	}
+	// Publication has committed: the destination is an independent link to the
+	// verified inode. Only now may the staged descriptor be released, and it must
+	// be released before the unlink below (see the note above).
+	release_source_authority();
 	// SAFETY: the source parent fd and name remain valid; the destination now
 	// owns an independent hard link to the same inode.
 	let unlinked = unsafe { libc::unlinkat(source_parent.as_raw_fd(), source_name.as_ptr(), 0) };
@@ -179,17 +193,27 @@ fn linkat_no_replace(
 /// `rename_flags_unsupported`). Directory publishes must not use this helper:
 /// `linkat` cannot hard-link a directory, so tree renames keep calling
 /// `renameat2_no_replace` directly.
+///
+/// `release_source_authority` is only invoked on the `linkat` path, between the
+/// publishing link and the staging unlink; see `linkat_no_replace`. `renameat2`
+/// removes the staging name as part of the same atomic step, so there is no
+/// window in which a held descriptor could block it and nothing to release.
 fn rename_file_no_replace(
 	source_parent: &File,
 	source_name: &CString,
 	destination_parent: &File,
 	destination_name: &CString,
+	release_source_authority: impl FnOnce(),
 ) -> std::io::Result<()> {
 	match renameat2_no_replace(source_parent, source_name, destination_parent, destination_name) {
 		Ok(()) => Ok(()),
-		Err(error) if rename_flags_unsupported(error.raw_os_error()) => {
-			linkat_no_replace(source_parent, source_name, destination_parent, destination_name)
-		},
+		Err(error) if rename_flags_unsupported(error.raw_os_error()) => linkat_no_replace(
+			source_parent,
+			source_name,
+			destination_parent,
+			destination_name,
+			release_source_authority,
+		),
 		Err(error) => Err(error),
 	}
 }
@@ -1820,19 +1844,18 @@ fn rename_managed_file_no_replace_inner(
 	if !same_expected(&source_file, dev, ino, size, mtime_ns, ctime_ns, sha256)? {
 		return Err("identity_mismatch".into());
 	}
-	// The staged identity is proven; release the descriptor before publishing. An
-	// open descriptor makes the `linkat(2)` fallback's `unlinkat` silly-rename the
-	// staging name on NFS instead of removing it, leaving a second link to the
-	// published inode until this process closes the file. The terminal re-open then
-	// observes `st_nlink == 2` and fails a committed publish as unprovable. Closing
-	// first does not weaken authority: the destination is re-proven below against
-	// the same dev/ino/size/mtime/digest this descriptor just verified.
-	drop(source_file);
-
 	let (source_parent, source_name) = open_parent(root, source)?;
 	let (destination_parent, destination_name) = open_parent(root, destination)?;
-	let result =
-		rename_file_no_replace(&source_parent, &source_name, &destination_parent, &destination_name);
+	// The staged descriptor stays open across publication and is released only
+	// between the fallback's link and its staging unlink, so NFS removes the
+	// staging name instead of silly-renaming it. See `linkat_no_replace`.
+	let result = rename_file_no_replace(
+		&source_parent,
+		&source_name,
+		&destination_parent,
+		&destination_name,
+		move || drop(source_file),
+	);
 	if let Err(error) = result {
 		return Err(
 			match error.raw_os_error() {
@@ -1935,7 +1958,16 @@ fn remove_managed(
 	// The parent is retained, the names are validated, and the quarantine publish
 	// is atomic no-replace: renameat2(RENAME_NOREPLACE) where supported, else a
 	// linkat(2) fallback for filesystems (e.g. NFS) that reject rename flags.
-	if let Err(error) = rename_file_no_replace(&source_parent, &name, &recovery_parent, &quarantine)
+	//
+	// No authority is released here: `authorized` is the detach proof and is read
+	// again after the quarantine publish, so on a filesystem without rename flags
+	// the staging name is silly-renamed and the detached object stays
+	// double-linked. Resolving that means re-proving the detached object from the
+	// quarantined name instead of the retained descriptor, which is
+	// descriptor-bound cleanup work and belongs to that lane rather than this
+	// fallback fix.
+	if let Err(error) =
+		rename_file_no_replace(&source_parent, &name, &recovery_parent, &quarantine, || ())
 	{
 		return Err(match error.raw_os_error() {
 			Some(libc::ENOSYS | libc::EINVAL) => "atomic_unavailable",
@@ -2231,14 +2263,17 @@ fn install_inner(
 ) -> Result<RecoveryFsResult, RetainedPublishError> {
 	let source_file = open_existing(root, source, false)?;
 	let source_identity = regular_identity(&source_file)?;
-	// Release the staged descriptor before publishing; see the matching note in
-	// `rename_managed_file_no_replace_inner`. The installed object is re-proven
-	// against `source_identity` below, so closing early keeps the same authority.
-	drop(source_file);
 	let (source_parent, source_name) = open_parent(root, source)?;
 	let (destination_parent, destination_name) = open_parent(root, destination)?;
-	let result =
-		rename_file_no_replace(&source_parent, &source_name, &destination_parent, &destination_name);
+	// Released between the fallback's link and unlink; see the matching note in
+	// `rename_managed_file_no_replace_inner`.
+	let result = rename_file_no_replace(
+		&source_parent,
+		&source_name,
+		&destination_parent,
+		&destination_name,
+		move || drop(source_file),
+	);
 	if let Err(error) = result {
 		return Err(
 			match error.raw_os_error() {
@@ -2872,6 +2907,7 @@ mod tests {
 	}
 
 	use std::{
+		cell::Cell,
 		fs,
 		path::PathBuf,
 		time::{SystemTime, UNIX_EPOCH},
@@ -3229,14 +3265,14 @@ mod tests {
 		let destination_name = CString::new("destination").expect("destination name");
 
 		fs::write(dir.join("source"), b"payload").expect("seed source");
-		linkat_no_replace(&parent, &source_name, &parent, &destination_name)
+		linkat_no_replace(&parent, &source_name, &parent, &destination_name, || ())
 			.expect("link publish on the real filesystem");
 		assert_eq!(fs::read(dir.join("destination")).expect("published destination"), b"payload");
 		assert!(!dir.join("source").exists(), "staging source removed after publish");
 
 		fs::write(dir.join("collision"), b"other").expect("seed collision source");
 		let collision_name = CString::new("collision").expect("collision name");
-		let error = linkat_no_replace(&parent, &collision_name, &parent, &destination_name)
+		let error = linkat_no_replace(&parent, &collision_name, &parent, &destination_name, || ())
 			.expect_err("no-replace must refuse an existing destination");
 		assert_eq!(error.raw_os_error(), Some(libc::EEXIST));
 		assert!(dir.join("collision").exists(), "source is untouched on collision");
@@ -3246,6 +3282,37 @@ mod tests {
 		);
 
 		let _ = fs::remove_dir_all(&dir);
+	}
+
+	/// The staged descriptor must be released between the publishing link and
+	/// the staging unlink. Releasing earlier would publish without descriptor
+	/// authority; releasing later is exactly what leaves a silly-renamed sibling
+	/// on NFS. This pins that order deterministically on any filesystem, so the
+	/// contract is covered without depending on an external mount.
+	#[test]
+	fn linkat_fallback_releases_source_authority_between_link_and_unlink() {
+		let temporary = TempDir::new();
+		let parent = temporary.root();
+		let source_name = CString::new("source").expect("source name");
+		let destination_name = CString::new("destination").expect("destination name");
+		fs::write(temporary.0.join("source"), b"payload").expect("seed source");
+
+		let observed = Cell::new(None);
+		linkat_no_replace(&parent, &source_name, &parent, &destination_name, || {
+			observed.set(Some((
+				temporary.0.join("destination").exists(),
+				temporary.0.join("source").exists(),
+			)));
+		})
+		.expect("link publish");
+
+		assert_eq!(
+			observed.get(),
+			Some((true, true)),
+			"authority must be released after the destination is published and before the staging \
+			 name is unlinked"
+		);
+		assert!(!temporary.0.join("source").exists(), "staging name removed after release");
 	}
 
 	/// Opt-in end-to-end regression for the managed publish path on a filesystem
@@ -3280,6 +3347,26 @@ mod tests {
 		)
 		.expect("restrict real-filesystem test root");
 		let root = File::open(&dir).expect("open real-filesystem root");
+
+		// Prove this mount actually lacks renameat2 rename flags. Without it the
+		// test would also pass on a filesystem where `RENAME_NOREPLACE` works and
+		// the `linkat` fallback — the whole point of this case — is never reached.
+		fs::write(dir.join("probe-source"), b"probe").expect("seed probe source");
+		let probe_error = renameat2_no_replace(
+			&root,
+			&CString::new("probe-source").expect("probe source name"),
+			&root,
+			&CString::new("probe-destination").expect("probe destination name"),
+		)
+		.expect_err(
+			"GJC_TEST_NFS_DIR must point at a filesystem whose renameat2 rejects RENAME_NOREPLACE",
+		);
+		assert!(
+			rename_flags_unsupported(probe_error.raw_os_error()),
+			"GJC_TEST_NFS_DIR must point at a filesystem without renameat2 rename flags (errno {:?})",
+			probe_error.raw_os_error()
+		);
+		fs::remove_file(dir.join("probe-source")).expect("remove probe source");
 
 		let contents = b"binding";
 		let identity = managed_file(&root, "staged", contents);

--- a/crates/pi-natives/src/recovery_fs.rs
+++ b/crates/pi-natives/src/recovery_fs.rs
@@ -1820,6 +1820,14 @@ fn rename_managed_file_no_replace_inner(
 	if !same_expected(&source_file, dev, ino, size, mtime_ns, ctime_ns, sha256)? {
 		return Err("identity_mismatch".into());
 	}
+	// The staged identity is proven; release the descriptor before publishing. An
+	// open descriptor makes the `linkat(2)` fallback's `unlinkat` silly-rename the
+	// staging name on NFS instead of removing it, leaving a second link to the
+	// published inode until this process closes the file. The terminal re-open then
+	// observes `st_nlink == 2` and fails a committed publish as unprovable. Closing
+	// first does not weaken authority: the destination is re-proven below against
+	// the same dev/ino/size/mtime/digest this descriptor just verified.
+	drop(source_file);
 
 	let (source_parent, source_name) = open_parent(root, source)?;
 	let (destination_parent, destination_name) = open_parent(root, destination)?;
@@ -2223,6 +2231,10 @@ fn install_inner(
 ) -> Result<RecoveryFsResult, RetainedPublishError> {
 	let source_file = open_existing(root, source, false)?;
 	let source_identity = regular_identity(&source_file)?;
+	// Release the staged descriptor before publishing; see the matching note in
+	// `rename_managed_file_no_replace_inner`. The installed object is re-proven
+	// against `source_identity` below, so closing early keeps the same authority.
+	drop(source_file);
 	let (source_parent, source_name) = open_parent(root, source)?;
 	let (destination_parent, destination_name) = open_parent(root, destination)?;
 	let result =
@@ -3232,6 +3244,75 @@ mod tests {
 			fs::read(dir.join("destination")).expect("destination unchanged on collision"),
 			b"payload"
 		);
+
+		let _ = fs::remove_dir_all(&dir);
+	}
+
+	/// Opt-in end-to-end regression for the managed publish path on a filesystem
+	/// whose `renameat2` rejects `RENAME_NOREPLACE`. Point `GJC_TEST_NFS_DIR` at
+	/// a writable directory on such a mount (e.g. an `NFSv4` home directory).
+	///
+	/// Unlike `linkat_no_replace_is_atomic_on_a_real_filesystem`, which
+	/// exercises the raw helper with no descriptor open, this drives the whole
+	/// publish. That distinction is the defect: the publish path held the
+	/// staging descriptor open across the fallback, so `unlinkat` silly-renamed
+	/// the staging name to `.nfsXXXX` instead of removing it. The published
+	/// inode kept a second link, the terminal re-open rejected it as
+	/// `hard_link`, and a committed publish was reported as
+	/// `rollback_unavailable` — crashing startup on every NFS home.
+	#[test]
+	fn managed_publish_commits_on_a_filesystem_without_rename_flags() {
+		let Some(base) = std::env::var_os("GJC_TEST_NFS_DIR") else {
+			return;
+		};
+		let dir = PathBuf::from(base).join(format!(
+			"pi-recovery-fs-publish-{}-{}",
+			std::process::id(),
+			SystemTime::now()
+				.duration_since(UNIX_EPOCH)
+				.expect("clock before epoch")
+				.as_nanos(),
+		));
+		fs::create_dir(&dir).expect("create real-filesystem test root");
+		fs::set_permissions(
+			&dir,
+			<fs::Permissions as std::os::unix::fs::PermissionsExt>::from_mode(0o700),
+		)
+		.expect("restrict real-filesystem test root");
+		let root = File::open(&dir).expect("open real-filesystem root");
+
+		let contents = b"binding";
+		let identity = managed_file(&root, "staged", contents);
+		let result = rename_managed_file_no_replace(
+			&root,
+			"staged",
+			"published",
+			&identity.dev,
+			&identity.ino,
+			&identity.size,
+			&identity.mtime_ns,
+			&identity.ctime_ns,
+			&file_digest(contents),
+		);
+
+		assert!(
+			result.ok,
+			"publish must commit and prove itself (code={:?} reason={} phase={})",
+			result.code, result.reason, result.phase
+		);
+		assert_eq!(result.reason, "none");
+		assert_eq!(result.phase, "complete");
+		assert_eq!(result.mutation_state, "committed");
+		assert_eq!(result.durability_state, "proven");
+		assert_eq!(fs::read(dir.join("published")).expect("published contents"), contents);
+		let published =
+			fs::symlink_metadata(dir.join("published")).expect("published destination metadata");
+		assert_eq!(
+			std::os::unix::fs::MetadataExt::nlink(&published),
+			1,
+			"no silly-renamed staging sibling may survive the publish"
+		);
+		assert!(!dir.join("staged").exists(), "staging name removed after publish");
 
 		let _ = fs::remove_dir_all(&dir);
 	}

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Retained managed publication now releases the staging descriptor before publishing, so the `linkat(2)` no-replace fallback added in 0.12.0 actually works on the filesystems it was written for. NFS silly-renames a still-open name on `unlinkat` instead of removing it, so the staging link survived as `.nfsXXXX`, the published inode kept a second link, and the terminal re-open rejected it (`st_nlink != 1` → `hard_link`). A correctly committed publish was therefore reported as `rollback_unavailable`, and every launch with a session store on an NFS home directory crashed with `Could not prepare managed session scope (binding_invalid: prepare:binding_publish)`. The staged identity is still proven before the publish and re-proven against the destination afterwards, so no authority is weakened.
+- Retained managed publication now releases the staging descriptor between the `linkat(2)` fallback's publishing link and its staging unlink, so the fallback added in 0.12.0 actually works on the filesystems it was written for. NFS silly-renames a still-open name on `unlinkat` instead of removing it, so the staging link survived as `.nfsXXXX`, the published inode kept a second link, and the terminal re-open rejected it (`st_nlink != 1` → `hard_link`). A correctly committed publish was therefore reported as `rollback_unavailable`, and every launch with a session store on an NFS home directory crashed with `Could not prepare managed session scope (binding_invalid: prepare:binding_publish)`. Descriptor authority is still held across publication itself, so the fallback remains no weaker than the `renameat2` primitive it stands in for.
 
 ## [0.12.5] - 2026-07-30
 

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Retained managed publication now releases the staging descriptor before publishing, so the `linkat(2)` no-replace fallback added in 0.12.0 actually works on the filesystems it was written for. NFS silly-renames a still-open name on `unlinkat` instead of removing it, so the staging link survived as `.nfsXXXX`, the published inode kept a second link, and the terminal re-open rejected it (`st_nlink != 1` → `hard_link`). A correctly committed publish was therefore reported as `rollback_unavailable`, and every launch with a session store on an NFS home directory crashed with `Could not prepare managed session scope (binding_invalid: prepare:binding_publish)`. The staged identity is still proven before the publish and re-proven against the destination afterwards, so no authority is weakened.
+
 ## [0.12.5] - 2026-07-30
 
 ## [0.12.4] - 2026-07-30


### PR DESCRIPTION
## What

`linkat_no_replace` (`crates/pi-natives/src/recovery_fs.rs`) now takes a `release_source_authority` callback and invokes it **after** the publishing `linkat` has committed and **before** the staging `unlinkat`. All three callers — the two file publishes and `remove_managed` — pass their staged descriptor.

Result: the descriptor is held across publication itself, and the staging name is closed by the time it is unlinked.

**Correction to the previous revision of this PR.** It fixed only the publish paths and left `remove_managed` alone, calling that follow-up work for the descriptor-bound cleanup lane. That was wrong: without it the fix does not work. gjc starts once per scope and then fails on every subsequent launch, because the session layer calls `remove_managed` to reconcile the staged file after a publish that legitimately lost the no-replace race, and its failure replaces the benign `destination_conflict`. Both paths are required; a regression test now pins that.

## Why

The `linkat(2)` no-replace fallback added in 0.12.0 does not work on the filesystems it was written for.

Both publish paths open the staging file to prove its identity and keep that descriptor alive across the rename:

```rust
let source_file = open_existing(root, source, false)?;          // held open
...
let result = rename_file_no_replace(&source_parent, &source_name, ...);
```

`rename_file_no_replace` falls back to `linkat(2)` + `unlinkat(source)` when `renameat2` rejects `RENAME_NOREPLACE`. On NFS, **unlinking a name that is still open silly-renames it** to `.nfsXXXX` in the same directory instead of removing it. So the staging link survives, the published inode keeps a second link, and the immediately following terminal re-open trips `open_existing`'s guard:

```rust
if named.st_nlink != 1 { return Err("hard_link"); }
```

which `rename_managed_file_no_replace_inner` maps through `.map_err(|_| "rollback_unavailable")`. A publish that committed correctly is reported as failed-and-unprovable.

The 0.12.0 changelog states the intended invariant exactly — *"the staging link is unlinked so the published file stays single-linked"*. That is precisely what does not hold on NFS.

Net effect: since 0.12.0, every launch with a session store on an NFS home directory still crashes at startup, only with a different message than before:

```
[Uncaught Exception] Error: Could not prepare managed session scope
(binding_invalid: prepare:binding_publish).
```

NFS home directories are the default on HPC/cluster login nodes, so this breaks gjc out of the box in those environments — the same class of environment as the ACL-less managed session fix (#2724).

### Why the existing coverage missed it

`linkat_no_replace_is_atomic_on_a_real_filesystem` is already an opt-in `GJC_TEST_NFS_DIR` test, and it passes on a real NFSv4 mount. It exercises the raw helper with **no descriptor open**, so it never triggers silly-rename. The defect only appears when the whole publish path runs, which is what the new test does.

### How

```rust
let linked = unsafe { libc::linkat(...) };
if linked != 0 { return Err(...); }
// Publication has committed. Only now may the staged descriptor be released,
// and it must be released before the unlink below.
release_source_authority();
let unlinked = unsafe { libc::unlinkat(source_parent.as_raw_fd(), source_name.as_ptr(), 0) };
```

`renameat2` unlinks the staging name in the same atomic step, so there is no window in which a held descriptor could block it and nothing is released on that path.

Authority properties, stated precisely:

- The staged descriptor is held from the identity proof through publication, so the fallback keeps exactly the authority `renameat2` provides. It is not weaker than the primitive it stands in for.
- It is **not stronger** either: `linkat` still resolves the source by name, so a substitution of the staging name between the proof and the link would publish the wrong inode — the same residual race the `renameat2` path has. Closing that would mean publishing descriptor-relative (`linkat(AT_FDCWD, "/proc/self/fd/N", …, AT_SYMLINK_FOLLOW)`), which trades the race for a `/proc` dependency and a new failure mode. Happy to do it if you want the fallback strictly stronger than `renameat2`; this revision deliberately targets parity.

## Testing

Rebased onto current `dev` (`71e9c95d9`), single commit `bd4e1652a`. Verified on a real NFSv4 home directory whose `renameat2(RENAME_NOREPLACE)` returns `EINVAL` (Linux 5.15), on an isolated compute node:

```
cargo fmt --check -p pi-natives            exit 0
cargo clippy -p pi-natives --all-targets   exit 0 (no new warnings)
GJC_TEST_NFS_DIR=... cargo test -p pi-natives recovery_fs
  test result: ok. 13 passed; 0 failed; 163 filtered out
```

Two negative controls, each run on the same node and mount:

**1. Publish authority released after the `unlinkat`** (the shipped 0.12.x behaviour):

```
test ...linkat_fallback_releases_source_authority_between_link_and_unlink ... FAILED
test ...managed_publish_commits_on_a_filesystem_without_rename_flags ... FAILED
test ...managed_remove_detaches_on_a_filesystem_without_rename_flags ... FAILED
test result: FAILED. 10 passed; 3 failed
```

**2. `remove_managed` release reverted to the no-op of the previous revision** — everything else identical, i.e. exactly the "publish-only" fix that looked complete:

```
test ...managed_remove_detaches_on_a_filesystem_without_rename_flags ... FAILED
test result: FAILED. 0 passed; 1 failed
```

Control 2 is the one that matters for review: it is the evidence that the earlier scoping decision was wrong.

`linkat_fallback_releases_source_authority_between_link_and_unlink` is the deterministic gate and needs no external mount — it observes that at release time the destination is already published *and* the staging name still exists, so the release cannot be moved to either side. The two `GJC_TEST_NFS_DIR` tests probe the mount first and fail loudly rather than passing silently on a filesystem where `RENAME_NOREPLACE` works (verified by pointing them at ext4).

**Qualification, unchanged from the previous revision.** The opt-in NFS tests are confirmation on a real mount, not reliable negative controls: whether a terminal re-open observes the silly-renamed sibling depends on client attribute-cache timing, and across repeated runs of control 1 the publish test failed in some runs and passed in others. The deterministic test is the gate.

End-to-end on the real mount, with the built binary and its session store on NFS: stock 0.12.5 crashes on the first launch in a scope; this build starts, and starts again — three consecutive launches in one scope, zero crashes, no `.gjc-managed-remove-*` residue. The previous revision passed the first launch and failed the second, which is how the `remove_managed` half was found.

`bun check` was **not** run: Rust-only change in `crates/pi-natives`, no installed workspace for the worktree here. TypeScript suites left to CI.

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:aec65dd622942bade9585580f0824e11d1e88162dad7865f032aee8e37be652b reviewer:human evidence:GJC_TEST_NFS_DIR=$HOME/.cache/gjc-nfs-test cargo test -p pi-natives recovery_fs
```

To be explicit rather than lean on the enum: **no independent review has happened.** Only the author has looked at this change, so per the template that is `needs-human`, not an approval. The `sha256` is of `git diff origin/dev...HEAD` at the exact PR head `bd4e1652a`, based on `dev` `71e9c95d9`.

---

- [x] Target branch is `dev`
- [ ] `bun check` passes — not run; Rust-only change, see Testing
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing) — `packages/natives/CHANGELOG.md`, Unreleased → Fixed
- [x] Verdict above matches the exact PR head, not an earlier commit

## Known remaining limitation: directory/tree publish

This PR does **not** make an NFS home directory fully usable, and I want that on the record rather than discovered later.

Tree no-replace (`rename_managed_tree_no_replace_inner`) calls `renameat2_no_replace` directly and has no fallback, because `linkat` cannot hard-link a directory. On a mount without rename flags it returns `EINVAL` → `invalid_request`, and session migration — resuming a session that predates the managed layout — dies with:

```
[Unhandled Rejection] Error: Could not open managed session: invalid_request
    at prepareManagedCandidateForWrite
```

0.12.0's changelog already states this ("Directory/tree no-replace still requires kernel `renameat2` flag support"), so it is a known limitation rather than a regression. I am not attempting it here: the plausible approaches — `mkdirat`'s exclusive create plus a per-entry move, avoiding tree publishes on such mounts, or an explicit degraded non-managed fallback — all change what "atomically published" means for a tree and need a new partial-state contract. That is a design decision for the owner of this subsystem, not something to smuggle into a fallback-ordering fix.

So with this PR an NFS home directory starts and keeps starting; migrating older sessions still fails. Happy to take the tree case on as a follow-up if you decide which of those directions you want.