### PR TITLE
fix(coding-agent): tolerate run acceptance without a minted handle

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2068,7 +2068,10 @@ export class AgentSession {
 	#attemptAuthority!: AttemptScopeAuthority;
 	#attemptRecordStore!: AttemptRecordStore;
 	#activeLogicalRunId: AttemptRunHandle["logicalRunId"] | undefined;
-	#acceptRunHandle(handle: AttemptRunHandle): void {
+	#acceptRunHandle(handle: AttemptRunHandle | undefined): void {
+		// Integration doubles can accept a run without minting a handle; keep the
+		// previously recorded run id rather than throwing inside the callback.
+		if (!handle) return;
 		this.#activeLogicalRunId = handle.logicalRunId;
 	}
 


### PR DESCRIPTION
Hello, and thank you for the rapid sequence of AttemptScope repairs today — #3638 cleared the abort-timeout family cleanly.

One family is still red on current dev after #3638, and I believe this is the remaining cause. I would be glad to defer if you already have a repair in flight.

## Symptom on current dev (`e25590979`)

```
packages/coding-agent/test/agent-session-auto-compaction-continue.test.ts
  16 pass  2 fail

(fail) threshold queued-followup continuation suppresses predecessor terminal readiness
(fail) reschedules an AgentBusyError racing the queued-followup continue until delivery

expect(resetAttemptBudgetSpy).toHaveBeenCalledTimes(1)
Expected number of calls: 1
Received number of calls: 0
```

## Root cause

#3638 added the queued-successor accounting reset inside the continuation's `onRunAccepted` callback (`agent-session.ts:4746`):

```ts
onRunAccepted: (handle: AttemptRunHandle) => {
	this.#acceptRunHandle(handle);   // <-- first statement
	settleLease();
	releasePredecessor();
	if (startsQueuedSuccessor) {
		this.#defaultFallbackChain().resetAttemptBudget();
		this.#overflowMaintenanceAttempts = 0;
	}
},
```

`#acceptRunHandle` dereferences the handle unconditionally:

```ts
#acceptRunHandle(handle: AttemptRunHandle): void {
	this.#activeLogicalRunId = handle.logicalRunId;
}
```

The test's `continue` double accepts the run without minting a handle:

```ts
const continueSpy = vi.spyOn(session.agent, "continue").mockImplementation(async options => {
	options?.onRunAccepted?.();
});
```

So the callback throws on `handle.logicalRunId` before reaching the `startsQueuedSuccessor` branch, and `resetAttemptBudget` is never called. The spy is on the real public `FallbackChainController.prototype.resetAttemptBudget`, so the assertion itself is sound — the reset genuinely does not happen.

## The change

Return early when no handle is supplied, keeping the previously recorded run id:

```ts
#acceptRunHandle(handle: AttemptRunHandle | undefined): void {
	// Integration doubles can accept a run without minting a handle; keep the
	// previously recorded run id rather than throwing inside the callback.
	if (!handle) return;
	this.#activeLogicalRunId = handle.logicalRunId;
}
```

This follows the doctrine you established in `42b6786ad` ("tolerate legacy extension runner doubles"). Real callers in `#runLoop` (`agent.ts:1443-1444`) always mint a handle before invoking the callback, so live behaviour is unchanged.

I deliberately did **not** change the test. The assertion targets a real product method and the reset genuinely was not happening; encoding the throw into the fixture would have masked it, which is the mistake you correctly rejected in #3628.

## Verification on `e25590979`

Fail-on-revert proof — reverting only this change:

```
16 pass  2 fail        <- reverted
18 pass  0 fail        <- restored
```

Broad regression sweep across every `agent-session*` test file (68 files), since this is hot product code:

```
714 pass  18 skip  0 fail   3280 expect() calls
```

Also green: `check:types` = 0, `biome check .` = 0.

## Scope

One file, +4/-1, product-only. No test files touched. No public API change — `#acceptRunHandle` is a private method and its only callers are the four in-file `onRunAccepted` callbacks.

Please close this without hesitation if you would rather fold it into your own sequence; my only aim is to get dev green. Thank you for your time reviewing this.
