### PR TITLE
fix(coding-agent): use resolvable read spill fixtures

### DIFF
--- a/packages/coding-agent/test/tools/read-artifact-spill.test.ts
+++ b/packages/coding-agent/test/tools/read-artifact-spill.test.ts
@@ -29,9 +29,9 @@ function createSession(cwd: string): ToolSession {
 	} as unknown as ToolSession;
 }
 
-function createContext(settings: Settings): AgentToolContext {
+function createContext(settings: Settings, cwd: string): AgentToolContext {
 	return {
-		sessionManager: SessionManager.inMemory(),
+		sessionManager: SessionManager.create(cwd, path.join(cwd, "sessions")),
 		settings,
 		toolNames: ["read"],
 		isIdle: () => true,
@@ -97,6 +97,7 @@ describe("read-tool artifact spill (Finding 4)", () => {
 				"tools.artifactHeadBytes": 2,
 				"tools.artifactTailBytes": 2,
 			}),
+			testDir,
 		);
 
 		const result = await tool.execute("r1", { path: `${bigFile}:1-900` }, undefined, undefined, ctx);
@@ -117,6 +118,7 @@ describe("read-tool artifact spill (Finding 4)", () => {
 				"tools.artifactHeadBytes": 2,
 				"tools.artifactTailBytes": 2,
 			}),
+			testDir,
 		);
 
 		// Two ranges that together exceed the 5KB combined cap.
@@ -136,6 +138,7 @@ describe("read-tool artifact spill (Finding 4)", () => {
 				"tools.readArtifactSpillThreshold": 256,
 				"tools.maxInlineResultBytes": 0,
 			}),
+			testDir,
 		);
 
 		const result = await tool.execute("r3", { path: bigFile }, undefined, undefined, ctx);

--- a/packages/coding-agent/test/tools/read-receipt.test.ts
+++ b/packages/coding-agent/test/tools/read-receipt.test.ts
@@ -57,9 +57,9 @@ function createSession(cwd: string, settings: Settings = Settings.isolated()): T
 	} as unknown as ToolSession;
 }
 
-function createContext(settings: Settings): AgentToolContext {
+function createContext(settings: Settings, cwd: string): AgentToolContext {
 	return {
-		sessionManager: SessionManager.inMemory(),
+		sessionManager: SessionManager.create(cwd, path.join(cwd, "sessions")),
 		settings,
 		toolNames: ["read"],
 		isIdle: () => true,
@@ -103,7 +103,13 @@ describe("read receipt by default", () => {
 
 	async function read(filePath: string, settings = receiptSettings(), params: Record<string, unknown> = {}) {
 		const tool = wrapToolWithMetaNotice(new ReadTool(createSession(testDir, settings)));
-		return tool.execute("read-receipt", { path: filePath, ...params }, undefined, undefined, createContext(settings));
+		return tool.execute(
+			"read-receipt",
+			{ path: filePath, ...params },
+			undefined,
+			undefined,
+			createContext(settings, testDir),
+		);
 	}
 
 	it("returns a bounded, non-spillable receipt for a large prose file", async () => {
@@ -264,7 +270,7 @@ describe("read receipt by default", () => {
 		const sessionManager = SessionManager.create(testDir, path.join(testDir, "sessions"));
 		const tool = wrapToolWithMetaNotice(new ReadTool(createSession(testDir)));
 		const result = await tool.execute("read-receipt", { path: `${file}:raw` }, undefined, undefined, {
-			...createContext(settings),
+			...createContext(settings, testDir),
 			sessionManager,
 		});
 		const artifactId = result.details?.meta?.truncation?.artifactId;


### PR DESCRIPTION
## Summary

- use file-backed session managers in read spill fixtures
- keep artifact IDs protocol-resolvable after the output ownership hardening in #3483
- preserve the production ownership checks; this is a test-fixture correction only

## Why

The affected fixtures expected an `artifact://` receipt while supplying `SessionManager.inMemory()`, whose artifact capability cannot resolve a saved artifact path. Since #3483 validates that every saved artifact is protocol-resolvable, those assertions fail before exercising the intended read spill behavior. A persistent session manager is already the established fixture for the converted-raw spill assertion in the same suite.

## Verification

- `bun test packages/coding-agent/test/tools/read-receipt.test.ts packages/coding-agent/test/tools/read-artifact-spill.test.ts` — 21 pass, 0 fail
- `bunx biome check packages/coding-agent/test/tools/read-receipt.test.ts packages/coding-agent/test/tools/read-artifact-spill.test.ts`
- `bun --cwd=packages/coding-agent run check:types`

Thank you for reviewing.