### PR TITLE
fix(async): harden terminal wait generations

### DIFF
--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -245,7 +245,6 @@ interface AsyncJobDelivery {
 	promise?: Promise<void>;
 }
 
-
 interface DeadLetteredDelivery {
 	jobId: string;
 	generation: string;
@@ -345,7 +344,6 @@ interface TerminalWaitState {
 	acknowledged: boolean;
 	terminalGenerations: Set<string>;
 }
-
 
 function sliceTextFromUtf8ByteOffset(text: string, offsetBytes: number): string {
 	if (offsetBytes <= 0) return text;
@@ -492,7 +490,7 @@ export class AsyncJobManager {
 	 */
 	readonly #changeListeners = new Set<() => void>();
 
-#pruneTerminalEvents(): void {
+	#pruneTerminalEvents(): void {
 		const cutoff = Date.now() - Math.max(this.#retentionMs, 300_000);
 		for (const [generation, event] of this.#terminalEvents) {
 			if (event.createdAt >= cutoff) continue;
@@ -502,7 +500,7 @@ export class AsyncJobManager {
 		}
 	}
 
-#eventForTarget(target: AsyncJobWaitTarget): TerminalEvent | undefined {
+	#eventForTarget(target: AsyncJobWaitTarget): TerminalEvent | undefined {
 		this.#pruneTerminalEvents();
 		const aliasedGeneration = this.#waitGenerationAliases.get(target.generation);
 		if (aliasedGeneration) return this.#terminalEvents.get(aliasedGeneration);
@@ -510,7 +508,14 @@ export class AsyncJobManager {
 		if (job) {
 			if (job.generation !== target.generation) return undefined;
 			if (job.status === "completed" || job.status === "failed" || job.status === "cancelled") {
-				return { generation: job.generation, jobId: job.id, subagentId: target.subagentId, ownerId: job.ownerId, status: job.status, createdAt: job.endTime ?? Date.now() };
+				return {
+					generation: job.generation,
+					jobId: job.id,
+					subagentId: target.subagentId,
+					ownerId: job.ownerId,
+					status: job.status,
+					createdAt: job.endTime ?? Date.now(),
+				};
 			}
 			return undefined;
 		}
@@ -546,9 +551,22 @@ export class AsyncJobManager {
 			record.status = status;
 			record.queued = undefined;
 		}
-		this.#terminalEvents.set(generation, { generation, jobId: null, subagentId, ownerId: record?.ownerId, status, createdAt: Date.now() });
+		this.#terminalEvents.set(generation, {
+			generation,
+			jobId: null,
+			subagentId,
+			ownerId: record?.ownerId,
+			status,
+			createdAt: Date.now(),
+		});
 		for (const state of this.#terminalWaits.values()) {
-			if (state.targets.some(target => target.generation === generation || this.#waitGenerationAliases.get(target.generation) === generation)) this.#maybeResolveWait(state);
+			if (
+				state.targets.some(
+					target =>
+						target.generation === generation || this.#waitGenerationAliases.get(target.generation) === generation,
+				)
+			)
+				this.#maybeResolveWait(state);
 		}
 	}
 
@@ -556,11 +574,28 @@ export class AsyncJobManager {
 		if (job.status !== "completed" && job.status !== "failed" && job.status !== "cancelled") return;
 		if (this.#publishedTerminalGenerations.has(job.generation)) return;
 		this.#publishedTerminalGenerations.add(job.generation);
-		const record = Array.from(this.#subagentRecords.values()).find(item => item.currentJobId === job.id && item.currentJobGeneration === job.generation);
+		const record = Array.from(this.#subagentRecords.values()).find(
+			item => item.currentJobId === job.id && item.currentJobGeneration === job.generation,
+		);
 		if (record) record.terminalGeneration = job.generation;
-		this.#terminalEvents.set(job.generation, { generation: job.generation, jobId: job.id, subagentId: record?.subagentId, ownerId: job.ownerId, status: job.status, createdAt: Date.now() });
+		this.#terminalEvents.set(job.generation, {
+			generation: job.generation,
+			jobId: job.id,
+			subagentId: record?.subagentId,
+			ownerId: job.ownerId,
+			status: job.status,
+			createdAt: Date.now(),
+		});
 		for (const state of this.#terminalWaits.values()) {
-			if (state.targets.some(target => target.generation === job.generation || target.jobId === job.id || this.#waitGenerationAliases.get(target.generation) === job.generation)) this.#maybeResolveWait(state);
+			if (
+				state.targets.some(
+					target =>
+						target.generation === job.generation ||
+						target.jobId === job.id ||
+						this.#waitGenerationAliases.get(target.generation) === job.generation,
+				)
+			)
+				this.#maybeResolveWait(state);
 		}
 	}
 
@@ -572,37 +607,96 @@ export class AsyncJobManager {
 		if (record) {
 			if (filter?.ownerId && record.ownerId !== filter.ownerId) return undefined;
 			if (record.status === "queued" && record.queued?.seq !== undefined) {
-				return { targetId, jobId: null, subagentId: record.subagentId, generation: `queued:${record.subagentId}:${record.queued.seq}`, ownerId: record.ownerId, initialStatus: "queued" };
+				return {
+					targetId,
+					jobId: null,
+					subagentId: record.subagentId,
+					generation: `queued:${record.subagentId}:${record.queued.seq}`,
+					ownerId: record.ownerId,
+					initialStatus: "queued",
+				};
 			}
 			if (record.terminalGeneration && this.#terminalEvents.has(record.terminalGeneration)) {
 				const generation = record.terminalGeneration;
 				const event = this.#terminalEvents.get(generation);
 				const current = record.currentJobId ? this.#jobs.get(record.currentJobId) : undefined;
 				if (!current || current.generation !== record.currentJobGeneration || current.generation !== generation) {
-					return { targetId, jobId: event?.jobId ?? null, subagentId: record.subagentId, generation, ownerId: record.ownerId, initialStatus: record.status };
+					return {
+						targetId,
+						jobId: event?.jobId ?? null,
+						subagentId: record.subagentId,
+						generation,
+						ownerId: record.ownerId,
+						initialStatus: record.status,
+					};
 				}
 			}
 			if (record.currentJobId) {
 				const job = this.#jobs.get(record.currentJobId);
-				if (job && record.currentJobGeneration === job.generation) return { targetId, jobId: record.currentJobId, subagentId: record.subagentId, generation: job.generation, ownerId: record.ownerId, initialStatus: job.status };
+				if (job && record.currentJobGeneration === job.generation)
+					return {
+						targetId,
+						jobId: record.currentJobId,
+						subagentId: record.subagentId,
+						generation: job.generation,
+						ownerId: record.ownerId,
+						initialStatus: job.status,
+					};
 			}
 			if (record.terminalGeneration && this.#terminalEvents.has(record.terminalGeneration)) {
 				const generation = record.terminalGeneration;
-				return { targetId, jobId: generation.startsWith("queued:") ? null : generation, subagentId: record.subagentId, generation, ownerId: record.ownerId, initialStatus: record.status };
+				return {
+					targetId,
+					jobId: generation.startsWith("queued:") ? null : generation,
+					subagentId: record.subagentId,
+					generation,
+					ownerId: record.ownerId,
+					initialStatus: record.status,
+				};
 			}
 			return undefined;
 		}
 		const job = this.#jobs.get(targetId);
-		if (job && (!filter?.ownerId || job.ownerId === filter.ownerId)) return { targetId, jobId: job.id, subagentId: job.metadata?.subagent?.id, generation: job.generation, ownerId: job.ownerId, initialStatus: job.status };
-		const metadataJobs = Array.from(this.#jobs.values()).filter(candidate => candidate.metadata?.subagent?.id === targetId && (!filter?.ownerId || candidate.ownerId === filter.ownerId));
+		if (job && (!filter?.ownerId || job.ownerId === filter.ownerId))
+			return {
+				targetId,
+				jobId: job.id,
+				subagentId: job.metadata?.subagent?.id,
+				generation: job.generation,
+				ownerId: job.ownerId,
+				initialStatus: job.status,
+			};
+		const metadataJobs = Array.from(this.#jobs.values()).filter(
+			candidate =>
+				candidate.metadata?.subagent?.id === targetId && (!filter?.ownerId || candidate.ownerId === filter.ownerId),
+		);
 		const metadataJob = metadataJobs.sort((a, b) => b.startTime - a.startTime)[0];
-		if (metadataJob) return { targetId, jobId: metadataJob.id, subagentId: metadataJob.metadata?.subagent?.id, generation: metadataJob.generation, ownerId: metadataJob.ownerId, initialStatus: metadataJob.status };
+		if (metadataJob)
+			return {
+				targetId,
+				jobId: metadataJob.id,
+				subagentId: metadataJob.metadata?.subagent?.id,
+				generation: metadataJob.generation,
+				ownerId: metadataJob.ownerId,
+				initialStatus: metadataJob.status,
+			};
 		const event = this.#terminalEvents.get(targetId);
-		if (event && (!filter?.ownerId || event.ownerId === filter.ownerId)) return { targetId, jobId: event.jobId, subagentId: event.subagentId, generation: event.generation, ownerId: event.ownerId, initialStatus: event.status };
+		if (event && (!filter?.ownerId || event.ownerId === filter.ownerId))
+			return {
+				targetId,
+				jobId: event.jobId,
+				subagentId: event.subagentId,
+				generation: event.generation,
+				ownerId: event.ownerId,
+				initialStatus: event.status,
+			};
 		return undefined;
 	}
 
-	subscribeTerminalWait(targets: readonly AsyncJobWaitTarget[], condition: AsyncJobWaitCondition = "all_terminal"): AsyncJobWaitHandle {
+	subscribeTerminalWait(
+		targets: readonly AsyncJobWaitTarget[],
+		condition: AsyncJobWaitCondition = "all_terminal",
+	): AsyncJobWaitHandle {
 		const deduped: AsyncJobWaitTarget[] = [];
 		const seen = new Set<string>();
 		for (const target of targets) {
@@ -611,8 +705,18 @@ export class AsyncJobManager {
 			deduped.push(target);
 		}
 		let resolve!: (result: AsyncJobWaitResult) => void;
-		const result = new Promise<AsyncJobWaitResult>(resolver => { resolve = resolver; });
-		const state: TerminalWaitState = { token: `wait_${++this.#waitSeq}`, targets: deduped, condition, resolve, settled: false, acknowledged: false, terminalGenerations: new Set() };
+		const result = new Promise<AsyncJobWaitResult>(resolver => {
+			resolve = resolver;
+		});
+		const state: TerminalWaitState = {
+			token: `wait_${++this.#waitSeq}`,
+			targets: deduped,
+			condition,
+			resolve,
+			settled: false,
+			acknowledged: false,
+			terminalGenerations: new Set(),
+		};
 		const handle: AsyncJobWaitHandle = {
 			token: state.token,
 			result,
@@ -631,7 +735,13 @@ export class AsyncJobManager {
 					this.#deliveryAckOwners.set(event.generation, state.token);
 					this.#suppressedDeliveries.add(event.generation);
 				}
-				this.#deliveries.splice(0, this.#deliveries.length, ...this.#deliveries.filter(delivery => !this.#isDeliveryAcknowledged(delivery.jobId, delivery.generation)));
+				this.#deliveries.splice(
+					0,
+					this.#deliveries.length,
+					...this.#deliveries.filter(
+						delivery => !this.#isDeliveryAcknowledged(delivery.jobId, delivery.generation),
+					),
+				);
 				return { acknowledged: ids.length > 0, jobIds: ids };
 			},
 			close: () => {
@@ -1407,7 +1517,8 @@ export class AsyncJobManager {
 		rec.currentJobGeneration = this.#jobs.get(newJobId)?.generation;
 		rec.status = this.#jobs.get(newJobId)?.status ?? "running";
 		rec.queued = undefined;
-		if (queuedGeneration) this.#waitGenerationAliases.set(queuedGeneration, this.#jobs.get(newJobId)?.generation ?? newJobId);
+		if (queuedGeneration)
+			this.#waitGenerationAliases.set(queuedGeneration, this.#jobs.get(newJobId)?.generation ?? newJobId);
 		this.#notifyChange();
 		return { ok: true, status: rec.status, jobId: newJobId };
 	}
@@ -1436,7 +1547,8 @@ export class AsyncJobManager {
 						continue;
 					}
 					const queuedSeq = rec.queued?.seq;
-					if (queuedSeq !== undefined) this.#publishQueuedTerminal(rec.subagentId, `queued:${rec.subagentId}:${queuedSeq}`, "failed");
+					if (queuedSeq !== undefined)
+						this.#publishQueuedTerminal(rec.subagentId, `queued:${rec.subagentId}:${queuedSeq}`, "failed");
 				}
 				this.#resumeQueue.splice(index, 1);
 			} catch (error) {
@@ -1445,7 +1557,8 @@ export class AsyncJobManager {
 					continue;
 				}
 				const queuedSeq = rec.queued?.seq;
-				if (queuedSeq !== undefined) this.#publishQueuedTerminal(rec.subagentId, `queued:${rec.subagentId}:${queuedSeq}`, "failed");
+				if (queuedSeq !== undefined)
+					this.#publishQueuedTerminal(rec.subagentId, `queued:${rec.subagentId}:${queuedSeq}`, "failed");
 				this.#resumeQueue.splice(index, 1);
 			}
 		}
@@ -1475,7 +1588,8 @@ export class AsyncJobManager {
 			const queuedSeq = rec.queued?.seq;
 			if (idx !== -1) this.#resumeQueue.splice(idx, 1);
 			rec.status = "cancelled";
-			if (queuedSeq !== undefined) this.#publishQueuedTerminal(rec.subagentId, `queued:${rec.subagentId}:${queuedSeq}`, "cancelled");
+			if (queuedSeq !== undefined)
+				this.#publishQueuedTerminal(rec.subagentId, `queued:${rec.subagentId}:${queuedSeq}`, "cancelled");
 			rec.queued = undefined;
 			this.#subagentProgress.delete(rec.subagentId);
 			this.#notifyChange();
@@ -1716,7 +1830,11 @@ export class AsyncJobManager {
 			}
 		}
 		const before = this.#deliveries.length;
-		this.#deliveries.splice(0, this.#deliveries.length, ...this.#deliveries.filter(delivery => !this.#isDeliveryAcknowledged(delivery.jobId, delivery.generation)));
+		this.#deliveries.splice(
+			0,
+			this.#deliveries.length,
+			...this.#deliveries.filter(delivery => !this.#isDeliveryAcknowledged(delivery.jobId, delivery.generation)),
+		);
 		return before - this.#deliveries.length;
 	}
 
@@ -1939,7 +2057,7 @@ export class AsyncJobManager {
 		this.#evictionTimers.set(jobId, timer);
 	}
 
-#evictJob(jobId: string): void {
+	#evictJob(jobId: string): void {
 		this.#expireMonitorTombstones();
 		this.#recordMonitorTombstone(jobId);
 		this.#runLifecycle(jobId, "evict");
@@ -1965,17 +2083,21 @@ export class AsyncJobManager {
 
 	#filterDeliveries(filter?: AsyncJobFilter): AsyncJobDelivery[] {
 		const ownerId = filter?.ownerId;
-		if (!ownerId) return this.#deliveries.filter(delivery => !this.isDeliverySuppressed(delivery.jobId, delivery.generation));
+		if (!ownerId)
+			return this.#deliveries.filter(delivery => !this.isDeliverySuppressed(delivery.jobId, delivery.generation));
 		return this.#deliveries.filter(
-		delivery => delivery.ownerId === ownerId && !this.isDeliverySuppressed(delivery.jobId, delivery.generation),
+			delivery => delivery.ownerId === ownerId && !this.isDeliverySuppressed(delivery.jobId, delivery.generation),
 		);
 	}
 
 	#filterInFlightDeliveries(filter?: AsyncJobFilter): AsyncJobDelivery[] {
 		const ownerId = filter?.ownerId;
-		if (!ownerId) return this.#inFlightDeliveries.filter(delivery => !this.isDeliverySuppressed(delivery.jobId, delivery.generation));
+		if (!ownerId)
+			return this.#inFlightDeliveries.filter(
+				delivery => !this.isDeliverySuppressed(delivery.jobId, delivery.generation),
+			);
 		return this.#inFlightDeliveries.filter(
-		delivery => delivery.ownerId === ownerId && !this.isDeliverySuppressed(delivery.jobId, delivery.generation),
+			delivery => delivery.ownerId === ownerId && !this.isDeliverySuppressed(delivery.jobId, delivery.generation),
 		);
 	}
 
@@ -1985,7 +2107,8 @@ export class AsyncJobManager {
 
 	#hasDeliverable(): boolean {
 		return this.#deliveries.some(
-		delivery => !this.isDeliverySuppressed(delivery.jobId, delivery.generation) && !this.#isDeliveryFenced(delivery),
+			delivery =>
+				!this.isDeliverySuppressed(delivery.jobId, delivery.generation) && !this.#isDeliveryFenced(delivery),
 		);
 	}
 
@@ -1994,7 +2117,8 @@ export class AsyncJobManager {
 			let selected: AsyncJobDelivery | undefined;
 			for (const delivery of this.#deliveries) {
 				if (delivery.ownerId !== filter.ownerId) continue;
-				if (this.isDeliverySuppressed(delivery.jobId, delivery.generation) || this.#isDeliveryFenced(delivery)) continue;
+				if (this.isDeliverySuppressed(delivery.jobId, delivery.generation) || this.#isDeliveryFenced(delivery))
+					continue;
 				if (!selected || delivery.nextAttemptAt < selected.nextAttemptAt) {
 					selected = delivery;
 				}
@@ -2022,8 +2146,11 @@ export class AsyncJobManager {
 		}
 	}
 
-#isDeliveryAcknowledged(jobId: string, generation?: string): boolean {
-		return (generation !== undefined && this.#suppressedDeliveries.has(generation)) || this.#suppressedDeliveries.has(jobId);
+	#isDeliveryAcknowledged(jobId: string, generation?: string): boolean {
+		return (
+			(generation !== undefined && this.#suppressedDeliveries.has(generation)) ||
+			this.#suppressedDeliveries.has(jobId)
+		);
 	}
 
 	isDeliverySuppressed(jobId: string, generation?: string): boolean {
@@ -2059,7 +2186,7 @@ export class AsyncJobManager {
 		}
 	}
 
-#enqueueDelivery(jobId: string, text: string): void {
+	#enqueueDelivery(jobId: string, text: string): void {
 		const job = this.#jobs.get(jobId);
 		if (!job || this.#isDeliveryAcknowledged(jobId, job.generation)) return;
 		const deliveryText = this.#boundedDeliveryText(text);
@@ -2115,7 +2242,8 @@ export class AsyncJobManager {
 	async #runDeliveryLoop(): Promise<void> {
 		while (this.#deliveries.length > 0) {
 			const delivery = this.#deliveries.find(
-				candidate => !this.isDeliverySuppressed(candidate.jobId, candidate.generation) && !this.#isDeliveryFenced(candidate),
+				candidate =>
+					!this.isDeliverySuppressed(candidate.jobId, candidate.generation) && !this.#isDeliveryFenced(candidate),
 			);
 			if (!delivery) return;
 			const waitMs = delivery.nextAttemptAt - Date.now();
@@ -2124,7 +2252,8 @@ export class AsyncJobManager {
 			}
 			const index = this.#deliveries.indexOf(delivery);
 			if (index === -1) continue;
-			if (this.isDeliverySuppressed(delivery.jobId, delivery.generation) || this.#isDeliveryFenced(delivery)) continue;
+			if (this.isDeliverySuppressed(delivery.jobId, delivery.generation) || this.#isDeliveryFenced(delivery))
+				continue;
 
 			this.#deliveries.splice(index, 1);
 			await this.#deliverDelivery(delivery);
@@ -2152,7 +2281,10 @@ export class AsyncJobManager {
 				} else {
 					delivery.nextAttemptAt = Date.now() + this.#getRetryDelay(delivery.attempt);
 					const currentJob = this.#jobs.get(delivery.jobId);
-					if (currentJob?.generation === delivery.generation && !this.#isDeliveryAcknowledged(delivery.jobId, delivery.generation)) {
+					if (
+						currentJob?.generation === delivery.generation &&
+						!this.#isDeliveryAcknowledged(delivery.jobId, delivery.generation)
+					) {
 						this.#deliveries.push(delivery);
 					}
 					logger.warn("Async job completion delivery failed", {

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -16,6 +16,7 @@ const MAX_DEAD_LETTERED_DELIVERIES = 50;
 
 export interface AsyncJob {
 	id: string;
+	readonly generation: string;
 	type: "bash" | "task";
 	status: "running" | "completed" | "failed" | "cancelled" | "paused";
 	startTime: number;
@@ -61,6 +62,8 @@ export interface AsyncJobMetadata {
 		agentSource: AgentSource;
 		description?: string;
 		assignment?: string;
+		duplicateIdentity?: string;
+		duplicateDisposition?: "warned" | "superseded";
 	};
 	/** True when this bash job was started by the `monitor` tool (vs plain async bash). */
 	monitor?: boolean;
@@ -166,6 +169,11 @@ export interface SubagentRecord {
 	modelFellBack?: boolean;
 	/** True when the effective subagent provider is in fast mode. */
 	fastMode?: boolean;
+	duplicateIdentity?: string;
+	duplicateDisposition?: "warned" | "superseded";
+	terminalGeneration?: string;
+	/** Generation of currentJobId, preventing stale ID reuse from mutating this record. */
+	currentJobGeneration?: string;
 }
 
 /** Lightweight, manager-owned resume payload. The async layer treats `data` as opaque. */
@@ -225,6 +233,8 @@ export interface AsyncJobDisposeDiagnostics {
 
 interface AsyncJobDelivery {
 	jobId: string;
+	generation: string;
+	job: AsyncJob;
 	text: string;
 	originalBytes?: number;
 	truncated?: boolean;
@@ -235,8 +245,10 @@ interface AsyncJobDelivery {
 	promise?: Promise<void>;
 }
 
+
 interface DeadLetteredDelivery {
 	jobId: string;
+	generation: string;
 	attempt: number;
 	lastError?: string;
 }
@@ -288,6 +300,52 @@ export interface AsyncJobRegisterOptions {
 export interface AsyncJobFilter {
 	ownerId?: string;
 }
+
+export type AsyncJobWaitCondition = "all_terminal" | "any_terminal";
+export type AsyncJobWaitOutcome = "completed" | "timed_out_wait" | "interrupted";
+
+export interface AsyncJobWaitTarget {
+	targetId: string;
+	jobId: string | null;
+	subagentId?: string;
+	generation: string;
+	ownerId?: string;
+	initialStatus: AsyncJob["status"] | "queued" | "not_found";
+}
+
+export interface AsyncJobWaitResult {
+	outcome: AsyncJobWaitOutcome;
+	condition: AsyncJobWaitCondition;
+	terminalJobIds: string[];
+	pendingJobIds: string[];
+}
+
+export interface AsyncJobWaitHandle {
+	readonly token: string;
+	readonly result: Promise<AsyncJobWaitResult>;
+	acknowledge(targetIds?: readonly string[]): { acknowledged: boolean; jobIds: string[] };
+	close(): void;
+}
+
+interface TerminalEvent {
+	generation: string;
+	jobId: string | null;
+	subagentId?: string;
+	ownerId?: string;
+	status: "completed" | "failed" | "cancelled";
+	createdAt: number;
+}
+
+interface TerminalWaitState {
+	token: string;
+	targets: AsyncJobWaitTarget[];
+	condition: AsyncJobWaitCondition;
+	resolve: (result: AsyncJobWaitResult) => void;
+	settled: boolean;
+	acknowledged: boolean;
+	terminalGenerations: Set<string>;
+}
+
 
 function sliceTextFromUtf8ByteOffset(text: string, offsetBytes: number): string {
 	if (offsetBytes <= 0) return text;
@@ -387,6 +445,7 @@ export class AsyncJobManager {
 	readonly #deliveries: AsyncJobDelivery[] = [];
 	readonly #inFlightDeliveries: AsyncJobDelivery[] = [];
 	readonly #suppressedDeliveries = new Set<string>();
+	readonly #deliveryAckOwners = new Map<string, string>();
 	readonly #watchedJobs = new Set<string>();
 	readonly #evictionTimers = new Map<string, NodeJS.Timeout>();
 	readonly #outputState = new Map<string, AsyncJobOutputState>();
@@ -401,6 +460,12 @@ export class AsyncJobManager {
 	#deliveryLoop: Promise<void> | undefined;
 	#disposed = false;
 	readonly #subagentRecords = new Map<string, SubagentRecord>();
+	readonly #terminalEvents = new Map<string, TerminalEvent>();
+	readonly #waitGenerationAliases = new Map<string, string>();
+	readonly #terminalWaits = new Map<string, TerminalWaitState>();
+	#waitSeq = 0;
+	readonly #publishedTerminalGenerations = new Set<string>();
+	#jobGenerationSeq = 0;
 	readonly #liveHandles = new Map<string, SubagentLiveHandle>();
 	readonly #subagentProgress = new Map<string, AgentProgress>();
 	readonly #resumeQueue: ResumeQueueEntry[] = [];
@@ -426,6 +491,160 @@ export class AsyncJobManager {
 	 * jobs widget / overlay to refresh event-driven without polling.
 	 */
 	readonly #changeListeners = new Set<() => void>();
+
+#pruneTerminalEvents(): void {
+		const cutoff = Date.now() - Math.max(this.#retentionMs, 300_000);
+		for (const [generation, event] of this.#terminalEvents) {
+			if (event.createdAt >= cutoff) continue;
+			this.#terminalEvents.delete(generation);
+			this.#publishedTerminalGenerations.delete(generation);
+			this.#deliveryAckOwners.delete(generation);
+		}
+	}
+
+#eventForTarget(target: AsyncJobWaitTarget): TerminalEvent | undefined {
+		this.#pruneTerminalEvents();
+		const aliasedGeneration = this.#waitGenerationAliases.get(target.generation);
+		if (aliasedGeneration) return this.#terminalEvents.get(aliasedGeneration);
+		const job = target.jobId ? this.#jobs.get(target.jobId) : undefined;
+		if (job) {
+			if (job.generation !== target.generation) return undefined;
+			if (job.status === "completed" || job.status === "failed" || job.status === "cancelled") {
+				return { generation: job.generation, jobId: job.id, subagentId: target.subagentId, ownerId: job.ownerId, status: job.status, createdAt: job.endTime ?? Date.now() };
+			}
+			return undefined;
+		}
+		return this.#terminalEvents.get(target.generation);
+	}
+
+	#resultForWait(state: TerminalWaitState, outcome: AsyncJobWaitOutcome): AsyncJobWaitResult {
+		const terminalJobIds: string[] = [];
+		const pendingJobIds: string[] = [];
+		for (const target of state.targets) {
+			if (this.#eventForTarget(target)) terminalJobIds.push(target.targetId);
+			else pendingJobIds.push(target.targetId);
+		}
+		return { outcome, condition: state.condition, terminalJobIds, pendingJobIds };
+	}
+
+	#maybeResolveWait(state: TerminalWaitState): void {
+		if (state.settled) return;
+		const terminalCount = state.targets.filter(target => this.#eventForTarget(target)).length;
+		if (state.condition === "all_terminal" ? terminalCount !== state.targets.length : terminalCount === 0) return;
+		state.settled = true;
+		this.#terminalWaits.delete(state.token);
+		state.resolve(this.#resultForWait(state, "completed"));
+	}
+
+	#publishQueuedTerminal(subagentId: string, generation: string, status: "completed" | "failed" | "cancelled"): void {
+		if (this.#publishedTerminalGenerations.has(generation)) return;
+		this.#publishedTerminalGenerations.add(generation);
+		const record = this.#subagentRecords.get(subagentId);
+		if (record) {
+			record.currentJobId = null;
+			record.terminalGeneration = generation;
+			record.status = status;
+			record.queued = undefined;
+		}
+		this.#terminalEvents.set(generation, { generation, jobId: null, subagentId, ownerId: record?.ownerId, status, createdAt: Date.now() });
+		for (const state of this.#terminalWaits.values()) {
+			if (state.targets.some(target => target.generation === generation || this.#waitGenerationAliases.get(target.generation) === generation)) this.#maybeResolveWait(state);
+		}
+	}
+
+	#publishTerminal(job: AsyncJob): void {
+		if (job.status !== "completed" && job.status !== "failed" && job.status !== "cancelled") return;
+		if (this.#publishedTerminalGenerations.has(job.generation)) return;
+		this.#publishedTerminalGenerations.add(job.generation);
+		const record = Array.from(this.#subagentRecords.values()).find(item => item.currentJobId === job.id && item.currentJobGeneration === job.generation);
+		if (record) record.terminalGeneration = job.generation;
+		this.#terminalEvents.set(job.generation, { generation: job.generation, jobId: job.id, subagentId: record?.subagentId, ownerId: job.ownerId, status: job.status, createdAt: Date.now() });
+		for (const state of this.#terminalWaits.values()) {
+			if (state.targets.some(target => target.generation === job.generation || target.jobId === job.id || this.#waitGenerationAliases.get(target.generation) === job.generation)) this.#maybeResolveWait(state);
+		}
+	}
+
+	resolveSubagentWaitTarget(id: string, filter?: AsyncJobFilter): AsyncJobWaitTarget | undefined {
+		const targetId = id.trim();
+		if (!targetId) return undefined;
+		this.#pruneTerminalEvents();
+		const record = this.getSubagentRecord(targetId, filter);
+		if (record) {
+			if (filter?.ownerId && record.ownerId !== filter.ownerId) return undefined;
+			if (record.status === "queued" && record.queued?.seq !== undefined) {
+				return { targetId, jobId: null, subagentId: record.subagentId, generation: `queued:${record.subagentId}:${record.queued.seq}`, ownerId: record.ownerId, initialStatus: "queued" };
+			}
+			if (record.terminalGeneration && this.#terminalEvents.has(record.terminalGeneration)) {
+				const generation = record.terminalGeneration;
+				const event = this.#terminalEvents.get(generation);
+				const current = record.currentJobId ? this.#jobs.get(record.currentJobId) : undefined;
+				if (!current || current.generation !== record.currentJobGeneration || current.generation !== generation) {
+					return { targetId, jobId: event?.jobId ?? null, subagentId: record.subagentId, generation, ownerId: record.ownerId, initialStatus: record.status };
+				}
+			}
+			if (record.currentJobId) {
+				const job = this.#jobs.get(record.currentJobId);
+				if (job && record.currentJobGeneration === job.generation) return { targetId, jobId: record.currentJobId, subagentId: record.subagentId, generation: job.generation, ownerId: record.ownerId, initialStatus: job.status };
+			}
+			if (record.terminalGeneration && this.#terminalEvents.has(record.terminalGeneration)) {
+				const generation = record.terminalGeneration;
+				return { targetId, jobId: generation.startsWith("queued:") ? null : generation, subagentId: record.subagentId, generation, ownerId: record.ownerId, initialStatus: record.status };
+			}
+			return undefined;
+		}
+		const job = this.#jobs.get(targetId);
+		if (job && (!filter?.ownerId || job.ownerId === filter.ownerId)) return { targetId, jobId: job.id, subagentId: job.metadata?.subagent?.id, generation: job.generation, ownerId: job.ownerId, initialStatus: job.status };
+		const metadataJobs = Array.from(this.#jobs.values()).filter(candidate => candidate.metadata?.subagent?.id === targetId && (!filter?.ownerId || candidate.ownerId === filter.ownerId));
+		const metadataJob = metadataJobs.sort((a, b) => b.startTime - a.startTime)[0];
+		if (metadataJob) return { targetId, jobId: metadataJob.id, subagentId: metadataJob.metadata?.subagent?.id, generation: metadataJob.generation, ownerId: metadataJob.ownerId, initialStatus: metadataJob.status };
+		const event = this.#terminalEvents.get(targetId);
+		if (event && (!filter?.ownerId || event.ownerId === filter.ownerId)) return { targetId, jobId: event.jobId, subagentId: event.subagentId, generation: event.generation, ownerId: event.ownerId, initialStatus: event.status };
+		return undefined;
+	}
+
+	subscribeTerminalWait(targets: readonly AsyncJobWaitTarget[], condition: AsyncJobWaitCondition = "all_terminal"): AsyncJobWaitHandle {
+		const deduped: AsyncJobWaitTarget[] = [];
+		const seen = new Set<string>();
+		for (const target of targets) {
+			if (seen.has(target.generation)) continue;
+			seen.add(target.generation);
+			deduped.push(target);
+		}
+		let resolve!: (result: AsyncJobWaitResult) => void;
+		const result = new Promise<AsyncJobWaitResult>(resolver => { resolve = resolver; });
+		const state: TerminalWaitState = { token: `wait_${++this.#waitSeq}`, targets: deduped, condition, resolve, settled: false, acknowledged: false, terminalGenerations: new Set() };
+		const handle: AsyncJobWaitHandle = {
+			token: state.token,
+			result,
+			acknowledge: (targetIds?: readonly string[]) => {
+				if (state.acknowledged) return { acknowledged: false, jobIds: [] };
+				state.acknowledged = true;
+				const allowed = targetIds ? new Set(targetIds) : undefined;
+				const ids: string[] = [];
+				for (const target of deduped) {
+					if (allowed && !allowed.has(target.targetId)) continue;
+					const event = this.#eventForTarget(target);
+					if (!event) continue;
+					ids.push(event.jobId ?? event.generation);
+					const owner = this.#deliveryAckOwners.get(event.generation);
+					if (owner && owner !== state.token) continue;
+					this.#deliveryAckOwners.set(event.generation, state.token);
+					this.#suppressedDeliveries.add(event.generation);
+				}
+				this.#deliveries.splice(0, this.#deliveries.length, ...this.#deliveries.filter(delivery => !this.#isDeliveryAcknowledged(delivery.jobId, delivery.generation)));
+				return { acknowledged: ids.length > 0, jobIds: ids };
+			},
+			close: () => {
+				if (state.settled) return;
+				state.settled = true;
+				this.#terminalWaits.delete(state.token);
+				resolve(this.#resultForWait(state, "interrupted"));
+			},
+		};
+		this.#terminalWaits.set(state.token, state);
+		this.#maybeResolveWait(state);
+		return handle;
+	}
 
 	#filterJobs(jobs: Iterable<AsyncJob>, filter?: AsyncJobFilter): AsyncJob[] {
 		const ownerId = filter?.ownerId;
@@ -491,12 +710,12 @@ export class AsyncJobManager {
 
 		this.#expireMonitorTombstones();
 		const id = this.#resolveJobId(options?.id);
-		this.#suppressedDeliveries.delete(id);
 		const abortController = new AbortController();
 		const startTime = Date.now();
 
 		const job: AsyncJob = {
 			id,
+			generation: `job:${++this.#jobGenerationSeq}`,
 			type,
 			status: "running",
 			startTime,
@@ -527,7 +746,8 @@ export class AsyncJobManager {
 
 				if (job.status === "cancelled") {
 					job.resultText = outcome.kind === "paused" ? outcome.note : outcome.text;
-					this.#markRecordTerminal(id, "cancelled");
+					this.#markRecordTerminal(id, "cancelled", job.generation);
+					this.#publishTerminal(job);
 					this.#runLifecycle(id, "terminal", job);
 					this.#scheduleEviction(id);
 					this.#drainResumeQueue();
@@ -540,7 +760,7 @@ export class AsyncJobManager {
 					job.status = "paused";
 					this.#freezeEndTime(job);
 					if (outcome.note) job.resultText = outcome.note;
-					this.#markRecordPaused(id);
+					this.#markRecordPaused(id, job.generation);
 					this.#notifyChange();
 					this.#drainResumeQueue();
 					return;
@@ -550,7 +770,8 @@ export class AsyncJobManager {
 					job.setupFailureSummary = outcome.setupFailureSummary;
 					this.#freezeEndTime(job);
 					job.errorText = outcome.text;
-					this.#markRecordTerminal(id, "failed");
+					this.#markRecordTerminal(id, "failed", job.generation);
+					this.#publishTerminal(job);
 					this.#enqueueDelivery(id, outcome.text);
 					this.#runLifecycle(id, "terminal", job);
 					this.#scheduleEviction(id);
@@ -561,7 +782,8 @@ export class AsyncJobManager {
 				job.status = "completed";
 				this.#freezeEndTime(job);
 				job.resultText = outcome.text;
-				this.#markRecordTerminal(id, "completed");
+				this.#markRecordTerminal(id, "completed", job.generation);
+				this.#publishTerminal(job);
 				this.#enqueueDelivery(id, outcome.text);
 				this.#runLifecycle(id, "terminal", job);
 				this.#scheduleEviction(id);
@@ -569,7 +791,8 @@ export class AsyncJobManager {
 			} catch (error) {
 				if (job.status === "cancelled") {
 					job.errorText = error instanceof Error ? error.message : String(error);
-					this.#markRecordTerminal(id, "cancelled");
+					this.#markRecordTerminal(id, "cancelled", job.generation);
+					this.#publishTerminal(job);
 					this.#runLifecycle(id, "terminal", job);
 					this.#scheduleEviction(id);
 					this.#drainResumeQueue();
@@ -579,7 +802,8 @@ export class AsyncJobManager {
 				job.status = "failed";
 				this.#freezeEndTime(job);
 				job.errorText = errorText;
-				this.#markRecordTerminal(id, "failed");
+				this.#markRecordTerminal(id, "failed", job.generation);
+				this.#publishTerminal(job);
 				this.#enqueueDelivery(id, errorText);
 				this.#runLifecycle(id, "terminal", job);
 				this.#scheduleEviction(id);
@@ -605,7 +829,9 @@ export class AsyncJobManager {
 			// Paused jobs have no running promise to abort; transition directly.
 			// The session file is kept, so the record stays resumable by id.
 			job.status = "cancelled";
-			this.#markRecordTerminal(id, "cancelled");
+			this.#markRecordTerminal(id, "cancelled", job.generation);
+			this.#freezeEndTime(job);
+			this.#publishTerminal(job);
 			this.#runLifecycle(id, "cancel");
 			this.#scheduleEviction(id);
 			this.#drainResumeQueue();
@@ -614,7 +840,8 @@ export class AsyncJobManager {
 		if (job.status !== "running") return false;
 		job.status = "cancelled";
 		this.#freezeEndTime(job);
-		this.#markRecordTerminal(id, "cancelled");
+		this.#markRecordTerminal(id, "cancelled", job.generation);
+		this.#publishTerminal(job);
 		this.#runLifecycle(id, "cancel");
 		job.abortController.abort();
 		this.#notifyChange();
@@ -700,6 +927,8 @@ export class AsyncJobManager {
 
 	/** Register or replace the canonical record for a subagent. */
 	registerSubagentRecord(record: SubagentRecord): void {
+		const currentJob = record.currentJobId ? this.#jobs.get(record.currentJobId) : undefined;
+		if (currentJob && record.currentJobGeneration === undefined) record.currentJobGeneration = currentJob.generation;
 		this.#subagentRecords.set(record.subagentId, record);
 		this.#notifyChange();
 	}
@@ -1061,15 +1290,17 @@ export class AsyncJobManager {
 		if (outcome === "release") this.#ensureDeliveryLoop();
 	}
 
-	#recordByJobId(jobId: string): SubagentRecord | undefined {
+	#recordByJobId(jobId: string, expectedGeneration?: string): SubagentRecord | undefined {
 		for (const rec of this.#subagentRecords.values()) {
-			if (rec.currentJobId === jobId) return rec;
+			if (rec.currentJobId !== jobId) continue;
+			if (expectedGeneration !== undefined && rec.currentJobGeneration !== expectedGeneration) continue;
+			return rec;
 		}
 		return undefined;
 	}
 
-	#markRecordPaused(jobId: string): void {
-		const rec = this.#recordByJobId(jobId);
+	#markRecordPaused(jobId: string, generation?: string): void {
+		const rec = this.#recordByJobId(jobId, generation);
 		if (rec) {
 			rec.status = "paused";
 			this.#liveHandles.delete(rec.subagentId);
@@ -1077,16 +1308,16 @@ export class AsyncJobManager {
 		}
 	}
 
-	#purgeTerminalSubagentStateForJob(jobId: string): void {
-		const rec = this.#recordByJobId(jobId);
+	#purgeTerminalSubagentStateForJob(jobId: string, generation?: string): void {
+		const rec = this.#recordByJobId(jobId, generation);
 		if (!rec) return;
 		if (rec.status === "paused" || rec.status === "queued") return;
 		this.#liveHandles.delete(rec.subagentId);
 		this.#subagentProgress.delete(rec.subagentId);
 	}
 
-	#markRecordTerminal(jobId: string, status: "completed" | "failed" | "cancelled"): void {
-		const rec = this.#recordByJobId(jobId);
+	#markRecordTerminal(jobId: string, status: "completed" | "failed" | "cancelled", generation?: string): void {
+		const rec = this.#recordByJobId(jobId, generation);
 		if (!rec) return;
 		rec.status = status;
 		this.#liveHandles.delete(rec.subagentId);
@@ -1163,6 +1394,7 @@ export class AsyncJobManager {
 			return { ok: false, status: rec.status, reason: "owner_shutdown_in_progress" };
 		}
 		const prevJobId = rec.currentJobId;
+		const queuedGeneration = rec.queued?.seq !== undefined ? `queued:${rec.subagentId}:${rec.queued.seq}` : undefined;
 		// Clear any retained progress from the previous run so a resumed subagent
 		// never renders the prior run's tool/output as live before it emits again.
 		this.#subagentProgress.delete(rec.subagentId);
@@ -1170,9 +1402,12 @@ export class AsyncJobManager {
 		const newJobId = runner?.(rec.subagentId, message, descriptor);
 		if (!newJobId) return { ok: false, reason: "resume_failed" };
 		if (prevJobId && prevJobId !== newJobId) rec.historicalJobIds.push(prevJobId);
+		rec.terminalGeneration = undefined;
 		rec.currentJobId = newJobId;
+		rec.currentJobGeneration = this.#jobs.get(newJobId)?.generation;
 		rec.status = this.#jobs.get(newJobId)?.status ?? "running";
 		rec.queued = undefined;
+		if (queuedGeneration) this.#waitGenerationAliases.set(queuedGeneration, this.#jobs.get(newJobId)?.generation ?? newJobId);
 		this.#notifyChange();
 		return { ok: true, status: rec.status, jobId: newJobId };
 	}
@@ -1195,9 +1430,13 @@ export class AsyncJobManager {
 			}
 			try {
 				const result = this.#startResume(rec, entry.message, this.#descriptorForRecord(rec));
-				if (result.reason === "owner_shutdown_in_progress") {
-					index += 1;
-					continue;
+				if (!result.ok) {
+					if (result.reason === "owner_shutdown_in_progress") {
+						index += 1;
+						continue;
+					}
+					const queuedSeq = rec.queued?.seq;
+					if (queuedSeq !== undefined) this.#publishQueuedTerminal(rec.subagentId, `queued:${rec.subagentId}:${queuedSeq}`, "failed");
 				}
 				this.#resumeQueue.splice(index, 1);
 			} catch (error) {
@@ -1205,7 +1444,9 @@ export class AsyncJobManager {
 					index += 1;
 					continue;
 				}
-				throw error;
+				const queuedSeq = rec.queued?.seq;
+				if (queuedSeq !== undefined) this.#publishQueuedTerminal(rec.subagentId, `queued:${rec.subagentId}:${queuedSeq}`, "failed");
+				this.#resumeQueue.splice(index, 1);
 			}
 		}
 	}
@@ -1220,6 +1461,7 @@ export class AsyncJobManager {
 			const job = currentJobId ? this.#jobs.get(currentJobId) : undefined;
 			const shouldScheduleEviction = job?.status === "paused";
 			if (shouldScheduleEviction) job.status = "cancelled";
+			if (shouldScheduleEviction && job) this.#publishTerminal(job);
 			rec.status = "cancelled";
 			this.#liveHandles.delete(rec.subagentId);
 			this.#subagentProgress.delete(rec.subagentId);
@@ -1230,8 +1472,10 @@ export class AsyncJobManager {
 		}
 		if (rec.status === "queued") {
 			const idx = this.#resumeQueue.findIndex(e => e.subagentId === rec.subagentId);
+			const queuedSeq = rec.queued?.seq;
 			if (idx !== -1) this.#resumeQueue.splice(idx, 1);
 			rec.status = "cancelled";
+			if (queuedSeq !== undefined) this.#publishQueuedTerminal(rec.subagentId, `queued:${rec.subagentId}:${queuedSeq}`, "cancelled");
 			rec.queued = undefined;
 			this.#subagentProgress.delete(rec.subagentId);
 			this.#notifyChange();
@@ -1464,17 +1708,15 @@ export class AsyncJobManager {
 	acknowledgeDeliveries(jobIds: string[]): number {
 		const uniqueJobIds = Array.from(new Set(jobIds.map(id => id.trim()).filter(id => id.length > 0)));
 		if (uniqueJobIds.length === 0) return 0;
-
 		for (const jobId of uniqueJobIds) {
-			this.#suppressedDeliveries.add(jobId);
+			const currentJob = this.#jobs.get(jobId);
+			if (currentJob) this.#suppressedDeliveries.add(currentJob.generation);
+			for (const delivery of [...this.#deliveries, ...this.#inFlightDeliveries]) {
+				if (delivery.jobId === jobId) this.#suppressedDeliveries.add(delivery.generation);
+			}
 		}
-
 		const before = this.#deliveries.length;
-		this.#deliveries.splice(
-			0,
-			this.#deliveries.length,
-			...this.#deliveries.filter(delivery => !this.#isDeliveryAcknowledged(delivery.jobId)),
-		);
+		this.#deliveries.splice(0, this.#deliveries.length, ...this.#deliveries.filter(delivery => !this.#isDeliveryAcknowledged(delivery.jobId, delivery.generation)));
 		return before - this.#deliveries.length;
 	}
 
@@ -1635,6 +1877,8 @@ export class AsyncJobManager {
 		this.#deadLetteredDeliveries.clear();
 		this.#deadLetteredDeliveryOwners.clear();
 		this.#suppressedDeliveries.clear();
+		this.#deliveryAckOwners.clear();
+		this.#waitGenerationAliases.clear();
 		this.#watchedJobs.clear();
 		this.#outputState.clear();
 		this.#ownerCleanups.clear();
@@ -1695,17 +1939,19 @@ export class AsyncJobManager {
 		this.#evictionTimers.set(jobId, timer);
 	}
 
-	#evictJob(jobId: string): void {
+#evictJob(jobId: string): void {
 		this.#expireMonitorTombstones();
 		this.#recordMonitorTombstone(jobId);
 		this.#runLifecycle(jobId, "evict");
 		this.#purgeTerminalSubagentStateForJob(jobId);
+		const job = this.#jobs.get(jobId);
 		this.#jobs.delete(jobId);
 		this.#lifecycles.delete(jobId);
 		this.#lifecyclePhases.delete(jobId);
 		this.#deadLetteredDeliveries.delete(jobId);
 		this.#deadLetteredDeliveryOwners.delete(jobId);
 		this.#suppressedDeliveries.delete(jobId);
+		if (job) this.#publishedTerminalGenerations.delete(job.generation);
 		this.#watchedJobs.delete(jobId);
 		this.#outputState.delete(jobId);
 	}
@@ -1719,17 +1965,17 @@ export class AsyncJobManager {
 
 	#filterDeliveries(filter?: AsyncJobFilter): AsyncJobDelivery[] {
 		const ownerId = filter?.ownerId;
-		if (!ownerId) return this.#deliveries.filter(delivery => !this.isDeliverySuppressed(delivery.jobId));
+		if (!ownerId) return this.#deliveries.filter(delivery => !this.isDeliverySuppressed(delivery.jobId, delivery.generation));
 		return this.#deliveries.filter(
-			delivery => delivery.ownerId === ownerId && !this.isDeliverySuppressed(delivery.jobId),
+		delivery => delivery.ownerId === ownerId && !this.isDeliverySuppressed(delivery.jobId, delivery.generation),
 		);
 	}
 
 	#filterInFlightDeliveries(filter?: AsyncJobFilter): AsyncJobDelivery[] {
 		const ownerId = filter?.ownerId;
-		if (!ownerId) return this.#inFlightDeliveries.filter(delivery => !this.isDeliverySuppressed(delivery.jobId));
+		if (!ownerId) return this.#inFlightDeliveries.filter(delivery => !this.isDeliverySuppressed(delivery.jobId, delivery.generation));
 		return this.#inFlightDeliveries.filter(
-			delivery => delivery.ownerId === ownerId && !this.isDeliverySuppressed(delivery.jobId),
+		delivery => delivery.ownerId === ownerId && !this.isDeliverySuppressed(delivery.jobId, delivery.generation),
 		);
 	}
 
@@ -1739,7 +1985,7 @@ export class AsyncJobManager {
 
 	#hasDeliverable(): boolean {
 		return this.#deliveries.some(
-			delivery => !this.isDeliverySuppressed(delivery.jobId) && !this.#isDeliveryFenced(delivery),
+		delivery => !this.isDeliverySuppressed(delivery.jobId, delivery.generation) && !this.#isDeliveryFenced(delivery),
 		);
 	}
 
@@ -1748,7 +1994,7 @@ export class AsyncJobManager {
 			let selected: AsyncJobDelivery | undefined;
 			for (const delivery of this.#deliveries) {
 				if (delivery.ownerId !== filter.ownerId) continue;
-				if (this.isDeliverySuppressed(delivery.jobId) || this.#isDeliveryFenced(delivery)) continue;
+				if (this.isDeliverySuppressed(delivery.jobId, delivery.generation) || this.#isDeliveryFenced(delivery)) continue;
 				if (!selected || delivery.nextAttemptAt < selected.nextAttemptAt) {
 					selected = delivery;
 				}
@@ -1770,18 +2016,18 @@ export class AsyncJobManager {
 			const index = this.#deliveries.indexOf(selected);
 			if (index === -1) continue;
 			this.#deliveries.splice(index, 1);
-			if (this.isDeliverySuppressed(selected.jobId)) continue;
+			if (this.isDeliverySuppressed(selected.jobId, selected.generation)) continue;
 
 			return this.#waitForDeliveryPromise(this.#deliverDelivery(selected), deadline);
 		}
 	}
 
-	#isDeliveryAcknowledged(jobId: string): boolean {
-		return this.#suppressedDeliveries.has(jobId);
+#isDeliveryAcknowledged(jobId: string, generation?: string): boolean {
+		return (generation !== undefined && this.#suppressedDeliveries.has(generation)) || this.#suppressedDeliveries.has(jobId);
 	}
 
-	isDeliverySuppressed(jobId: string): boolean {
-		return this.#isDeliveryAcknowledged(jobId) || this.#watchedJobs.has(jobId);
+	isDeliverySuppressed(jobId: string, generation?: string): boolean {
+		return this.#isDeliveryAcknowledged(jobId, generation) || this.#watchedJobs.has(jobId);
 	}
 
 	#pruneEvictedDeadLetters(): void {
@@ -1794,11 +2040,13 @@ export class AsyncJobManager {
 
 	#recordDeadLetter(delivery: AsyncJobDelivery): void {
 		this.#pruneEvictedDeadLetters();
-		if (!this.#jobs.has(delivery.jobId)) return;
+		const currentJob = this.#jobs.get(delivery.jobId);
+		if (!currentJob || currentJob.generation !== delivery.generation) return;
 		this.#deadLetteredDeliveries.delete(delivery.jobId);
 		this.#deadLetteredDeliveryOwners.delete(delivery.jobId);
 		this.#deadLetteredDeliveries.set(delivery.jobId, {
 			jobId: delivery.jobId,
+			generation: delivery.generation,
 			attempt: delivery.attempt,
 			lastError: delivery.lastError,
 		});
@@ -1811,20 +2059,20 @@ export class AsyncJobManager {
 		}
 	}
 
-	#enqueueDelivery(jobId: string, text: string): void {
-		// Skip delivery if already acknowledged
-		if (this.#isDeliveryAcknowledged(jobId)) {
-			return;
-		}
+#enqueueDelivery(jobId: string, text: string): void {
+		const job = this.#jobs.get(jobId);
+		if (!job || this.#isDeliveryAcknowledged(jobId, job.generation)) return;
 		const deliveryText = this.#boundedDeliveryText(text);
 		this.#deliveries.push({
 			jobId,
+			generation: job.generation,
+			job,
 			text: deliveryText.text,
 			originalBytes: deliveryText.originalBytes,
 			truncated: deliveryText.truncated,
 			attempt: 0,
 			nextAttemptAt: Date.now(),
-			ownerId: this.#jobs.get(jobId)?.ownerId,
+			ownerId: job.ownerId,
 		});
 		while (this.#deliveries.length > DEFAULT_MAX_DELIVERY_QUEUE) {
 			const dropped = this.#deliveries.shift();
@@ -1867,7 +2115,7 @@ export class AsyncJobManager {
 	async #runDeliveryLoop(): Promise<void> {
 		while (this.#deliveries.length > 0) {
 			const delivery = this.#deliveries.find(
-				candidate => !this.isDeliverySuppressed(candidate.jobId) && !this.#isDeliveryFenced(candidate),
+				candidate => !this.isDeliverySuppressed(candidate.jobId, candidate.generation) && !this.#isDeliveryFenced(candidate),
 			);
 			if (!delivery) return;
 			const waitMs = delivery.nextAttemptAt - Date.now();
@@ -1876,7 +2124,7 @@ export class AsyncJobManager {
 			}
 			const index = this.#deliveries.indexOf(delivery);
 			if (index === -1) continue;
-			if (this.isDeliverySuppressed(delivery.jobId) || this.#isDeliveryFenced(delivery)) continue;
+			if (this.isDeliverySuppressed(delivery.jobId, delivery.generation) || this.#isDeliveryFenced(delivery)) continue;
 
 			this.#deliveries.splice(index, 1);
 			await this.#deliverDelivery(delivery);
@@ -1887,7 +2135,10 @@ export class AsyncJobManager {
 		const promise = (async () => {
 			this.#inFlightDeliveries.push(delivery);
 			try {
-				await this.#onJobComplete(delivery.jobId, delivery.text, this.#jobs.get(delivery.jobId));
+				const currentJob = this.#jobs.get(delivery.jobId);
+				if (currentJob && currentJob.generation !== delivery.generation) return;
+				if (this.#isDeliveryAcknowledged(delivery.jobId, delivery.generation)) return;
+				await this.#onJobComplete(delivery.jobId, delivery.text, delivery.job);
 			} catch (error) {
 				delivery.attempt += 1;
 				delivery.lastError = error instanceof Error ? error.message : String(error);
@@ -1900,7 +2151,8 @@ export class AsyncJobManager {
 					});
 				} else {
 					delivery.nextAttemptAt = Date.now() + this.#getRetryDelay(delivery.attempt);
-					if (!this.#isDeliveryAcknowledged(delivery.jobId)) {
+					const currentJob = this.#jobs.get(delivery.jobId);
+					if (currentJob?.generation === delivery.generation && !this.#isDeliveryAcknowledged(delivery.jobId, delivery.generation)) {
 						this.#deliveries.push(delivery);
 					}
 					logger.warn("Async job completion delivery failed", {

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -209,20 +209,40 @@ async function resolveTaskItemsWithRepositoryBindings(
 			resolved.push({ ...task, repositoryBinding: binding });
 		} catch (error) {
 			const id = task.id?.trim() ? task.id : "(missing-id)";
-			if (error instanceof RepositoryBindingError) return { tasks: [], error: `Task "${id}" repository binding rejected: ${error.message}` };
-			return { tasks: [], error: `Task "${id}" repository binding rejected: ${error instanceof Error ? error.message : String(error)}` };
+			if (error instanceof RepositoryBindingError)
+				return { tasks: [], error: `Task "${id}" repository binding rejected: ${error.message}` };
+			return {
+				tasks: [],
+				error: `Task "${id}" repository binding rejected: ${error instanceof Error ? error.message : String(error)}`,
+			};
 		}
 	}
 	return { tasks: resolved };
 }
 
-function duplicateIdentityForTask(task: TaskItem, role: string, ownerId: string | undefined, parentSession: string | null): DuplicateIdentity {
+function duplicateIdentityForTask(
+	task: TaskItem,
+	role: string,
+	ownerId: string | undefined,
+	parentSession: string | null,
+): DuplicateIdentity {
 	const binding = task.repositoryBinding as RepositoryBinding;
-	return { role: role.trim(), ownerId, parentSession, repository: { root: binding.commonDir ?? binding.worktreeRoot, relativeSubdir: binding.relativeSubdir ?? null } };
+	return {
+		role: role.trim(),
+		ownerId,
+		parentSession,
+		repository: { root: binding.commonDir ?? binding.worktreeRoot, relativeSubdir: binding.relativeSubdir ?? null },
+	};
 }
 
 function duplicateIdentityKey(identity: DuplicateIdentity): string {
-	return JSON.stringify([identity.role, identity.ownerId ?? null, identity.parentSession, identity.repository.root, identity.repository.relativeSubdir]);
+	return JSON.stringify([
+		identity.role,
+		identity.ownerId ?? null,
+		identity.parentSession,
+		identity.repository.root,
+		identity.repository.relativeSubdir,
+	]);
 }
 
 function repositoryBindingFromTask(task: TaskItem): RepositoryBinding | undefined {
@@ -875,7 +895,13 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		}
 
 		const startedJobs: Array<{ jobId: string; taskId: string }> = [];
-		const failedSchedules: Array<{ task: TaskItem & { id: string }; taskIndex: number; message: string; signalSkip: boolean; duplicateDisposition?: DuplicateDisposition }> = [];
+		const failedSchedules: Array<{
+			task: TaskItem & { id: string };
+			taskIndex: number;
+			message: string;
+			signalSkip: boolean;
+			duplicateDisposition?: DuplicateDisposition;
+		}> = [];
 		let completedJobs = 0;
 		let failedJobs = 0;
 
@@ -904,18 +930,43 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const maxConcurrency = this.session.settings.get("task.maxConcurrency");
 		const ownerId = this.session.getAgentId?.() ?? undefined;
 		const parentSession = this.session.getSessionFile();
-		const admitDuplicateLaunch = (subagentId: string, task: TaskItem, policy: "warn" | "supersede", selfSubagentId?: string): { ok: boolean; disposition?: DuplicateDisposition; error?: string; identity: DuplicateIdentity } => {
+		const admitDuplicateLaunch = (
+			subagentId: string,
+			task: TaskItem,
+			policy: "warn" | "supersede",
+			selfSubagentId?: string,
+		): { ok: boolean; disposition?: DuplicateDisposition; error?: string; identity: DuplicateIdentity } => {
 			const identity = duplicateIdentityForTask(task, params.agent, ownerId, parentSession);
 			const key = duplicateIdentityKey(identity);
-			const predecessors = manager.getSubagentRecords({ ownerId }).filter(record => {
-				if (record.subagentId === selfSubagentId || record.subagentId === subagentId) return false;
-				if (record.status !== "running" && record.status !== "paused" && record.status !== "queued") return false;
-				return record.duplicateIdentity === key;
-			}).sort((a, b) => (b.currentJobId ? manager.getJob(b.currentJobId)?.startTime ?? 0 : 0) - (a.currentJobId ? manager.getJob(a.currentJobId)?.startTime ?? 0 : 0) || a.subagentId.localeCompare(b.subagentId));
+			const predecessors = manager
+				.getSubagentRecords({ ownerId })
+				.filter(record => {
+					if (record.subagentId === selfSubagentId || record.subagentId === subagentId) return false;
+					if (record.status !== "running" && record.status !== "paused" && record.status !== "queued")
+						return false;
+					return record.duplicateIdentity === key;
+				})
+				.sort(
+					(a, b) =>
+						(b.currentJobId ? (manager.getJob(b.currentJobId)?.startTime ?? 0) : 0) -
+							(a.currentJobId ? (manager.getJob(a.currentJobId)?.startTime ?? 0) : 0) ||
+						a.subagentId.localeCompare(b.subagentId),
+				);
 			if (predecessors.length === 0) return { ok: true, identity };
-			if (policy === "warn") return { ok: true, identity, disposition: { action: "warned", predecessorIds: predecessors.map(record => record.subagentId) } };
-			for (const predecessor of predecessors) if (!manager.cancelSubagent(predecessor.subagentId, { ownerId })) return { ok: false, identity, error: "duplicate_supersede_failed" };
-			return { ok: true, identity, disposition: { action: "superseded", predecessorIds: predecessors.map(record => record.subagentId) } };
+			if (policy === "warn")
+				return {
+					ok: true,
+					identity,
+					disposition: { action: "warned", predecessorIds: predecessors.map(record => record.subagentId) },
+				};
+			for (const predecessor of predecessors)
+				if (!manager.cancelSubagent(predecessor.subagentId, { ownerId }))
+					return { ok: false, identity, error: "duplicate_supersede_failed" };
+			return {
+				ok: true,
+				identity,
+				disposition: { action: "superseded", predecessorIds: predecessors.map(record => record.subagentId) },
+			};
 		};
 		let resumeRunner: ResumeRunner | undefined;
 		if (typeof manager.setResumeRunner === "function") {
@@ -925,14 +976,37 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				const admission = (() => {
 					const identity = descriptor.duplicateIdentity;
 					const key = duplicateIdentityKey(identity);
-					const predecessors = manager.getSubagentRecords({ ownerId }).filter(record => {
-					if (record.subagentId === descriptor.task.id || !["running", "paused", "queued"].includes(record.status)) return false;
-					return record.duplicateIdentity === key;
-					}).sort((a, b) => (b.currentJobId ? manager.getJob(b.currentJobId)?.startTime ?? 0 : 0) - (a.currentJobId ? manager.getJob(a.currentJobId)?.startTime ?? 0 : 0) || a.subagentId.localeCompare(b.subagentId));
+					const predecessors = manager
+						.getSubagentRecords({ ownerId })
+						.filter(record => {
+							if (
+								record.subagentId === descriptor.task.id ||
+								!["running", "paused", "queued"].includes(record.status)
+							)
+								return false;
+							return record.duplicateIdentity === key;
+						})
+						.sort(
+							(a, b) =>
+								(b.currentJobId ? (manager.getJob(b.currentJobId)?.startTime ?? 0) : 0) -
+									(a.currentJobId ? (manager.getJob(a.currentJobId)?.startTime ?? 0) : 0) ||
+								a.subagentId.localeCompare(b.subagentId),
+						);
 					if (predecessors.length === 0) return { ok: true, identity };
-					if (descriptor.duplicatePolicy === "warn") return { ok: true, identity, disposition: { action: "warned", predecessorIds: predecessors.map(record => record.subagentId) } };
-					for (const predecessor of predecessors) if (!manager.cancelSubagent(predecessor.subagentId, { ownerId })) return { ok: false, identity, error: "duplicate_supersede_failed" };
-					return { ok: true, identity, disposition: { action: "superseded", predecessorIds: predecessors.map(record => record.subagentId) } };
+					if (descriptor.duplicatePolicy === "warn")
+						return {
+							ok: true,
+							identity,
+							disposition: { action: "warned", predecessorIds: predecessors.map(record => record.subagentId) },
+						};
+					for (const predecessor of predecessors)
+						if (!manager.cancelSubagent(predecessor.subagentId, { ownerId }))
+							return { ok: false, identity, error: "duplicate_supersede_failed" };
+					return {
+						ok: true,
+						identity,
+						disposition: { action: "superseded", predecessorIds: predecessors.map(record => record.subagentId) },
+					};
 				})();
 				if (!admission.ok) {
 					descriptor.lastAdmissionFailure = admission.error;
@@ -942,7 +1016,11 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				const forkSeeds = descriptor.forkContextSeed
 					? new Map([[descriptor.task.id, descriptor.forkContextSeed]])
 					: undefined;
-				const resumedTask = { ...descriptor.task, repositoryBinding: descriptor.repositoryBinding, duplicate_policy: descriptor.duplicatePolicy };
+				const resumedTask = {
+					...descriptor.task,
+					repositoryBinding: descriptor.repositoryBinding,
+					duplicate_policy: descriptor.duplicatePolicy,
+				};
 				return manager.register(
 					"task",
 					descriptor.task.id,
@@ -972,16 +1050,19 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						const finalText = result.content.find(part => part.type === "text")?.text ?? "(no output)";
 						const rawSingleResult = result.details?.results[0];
 						const singleResult = rawSingleResult
-			? {
-					...rawSingleResult,
-						duplicateDisposition: (() => {
-							const initial = descriptor.initialDisposition;
-							const current = admission.disposition;
-							if (!initial) return current;
-							if (!current) return initial;
-							return { action: current.action, predecessorIds: [...new Set([...initial.predecessorIds, ...current.predecessorIds])] };
-						})(),
-			}
+							? {
+									...rawSingleResult,
+									duplicateDisposition: (() => {
+										const initial = descriptor.initialDisposition;
+										const current = admission.disposition;
+										if (!initial) return current;
+										if (!current) return initial;
+										return {
+											action: current.action,
+											predecessorIds: [...new Set([...initial.predecessorIds, ...current.predecessorIds])],
+										};
+									})(),
+								}
 							: rawSingleResult;
 						return subagentRunOutcomeFromSingleResult(finalText, singleResult);
 					},
@@ -994,7 +1075,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								agent: descriptor.params.agent,
 								agentSource: descriptor.agentSource,
 								duplicateIdentity: duplicateIdentityKey(descriptor.duplicateIdentity),
-								duplicateDisposition: (admission.disposition?.action ?? descriptor.initialDisposition?.action) as DuplicateDisposition["action"] | undefined,
+								duplicateDisposition: (admission.disposition?.action ??
+									descriptor.initialDisposition?.action) as DuplicateDisposition["action"] | undefined,
 								description: descriptor.task.description,
 								assignment: descriptor.task.assignment.trim(),
 							},
@@ -1031,7 +1113,12 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		for (let i = 0; i < taskItems.length; i++) {
 			const taskItem = taskItems[i];
 			if (signal?.aborted) {
-				failedSchedules.push({ task: taskItem as TaskItem & { id: string }, taskIndex: i, message: "cancelled before scheduling", signalSkip: true });
+				failedSchedules.push({
+					task: taskItem as TaskItem & { id: string },
+					taskIndex: i,
+					message: "cancelled before scheduling",
+					signalSkip: true,
+				});
 				const progress = progressByTaskId.get(taskItem.id);
 				if (progress) {
 					progress.status = "aborted";
@@ -1044,7 +1131,12 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			if (signal?.aborted) {
 				for (let skippedIndex = i; skippedIndex < taskItems.length; skippedIndex++) {
 					const skippedTask = taskItems[skippedIndex]!;
-					failedSchedules.push({ task: skippedTask as TaskItem & { id: string }, taskIndex: skippedIndex, message: "cancelled before scheduling", signalSkip: true });
+					failedSchedules.push({
+						task: skippedTask as TaskItem & { id: string },
+						taskIndex: skippedIndex,
+						message: "cancelled before scheduling",
+						signalSkip: true,
+					});
 					const skippedProgress = progressByTaskId.get(skippedTask.id);
 					if (skippedProgress) skippedProgress.status = "aborted";
 				}
@@ -1062,7 +1154,13 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					: path.join(batchArtifactsDir ?? externalTaskSessionsDir!, `${uniqueId}.jsonl`);
 				const admission = admitDuplicateLaunch(uniqueId, taskItem, taskItem.duplicate_policy ?? "warn");
 				if (!admission.ok) {
-					failedSchedules.push({ task: taskItem as TaskItem & { id: string }, taskIndex: i, message: admission.error ?? "duplicate_supersede_failed", signalSkip: false, duplicateDisposition: admission.disposition });
+					failedSchedules.push({
+						task: taskItem as TaskItem & { id: string },
+						taskIndex: i,
+						message: admission.error ?? "duplicate_supersede_failed",
+						signalSkip: false,
+						duplicateDisposition: admission.disposition,
+					});
 					continue;
 				}
 				const jobId = manager.register(
@@ -1106,7 +1204,10 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 							const finalText = result.content.find(part => part.type === "text")?.text ?? "(no output)";
 							const rawSingleResult = result.details?.results[0];
 							const singleResult = rawSingleResult
-								? { ...rawSingleResult, duplicateDisposition: rawSingleResult.duplicateDisposition ?? admission.disposition }
+								? {
+										...rawSingleResult,
+										duplicateDisposition: rawSingleResult.duplicateDisposition ?? admission.disposition,
+									}
 								: rawSingleResult;
 							if (progress) {
 								progress.status = singleResult?.paused
@@ -1248,7 +1349,12 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						: error instanceof Error
 							? error.message
 							: String(error);
-				failedSchedules.push({ task: taskItem as TaskItem & { id: string }, taskIndex: i, message, signalSkip: false });
+				failedSchedules.push({
+					task: taskItem as TaskItem & { id: string },
+					taskIndex: i,
+					message,
+					signalSkip: false,
+				});
 				const progress = progressByTaskId.get(taskItem.id);
 				if (progress) {
 					progress.status = "failed";
@@ -1264,29 +1370,34 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const scheduleFailureReceipts = failedSchedules
 			.slice()
 			.sort((a, b) => a.taskIndex - b.taskIndex)
-			.map((entry, index) => buildTaskReceipt({
-				index,
-				id: entry.task.id,
-				agent: params.agent,
-				agentSource: fallbackAgentSource,
-				task: renderTaskAssignment(entry.task.assignment, simpleMode),
-				assignment: entry.task.assignment,
-				description: entry.task.description,
-				status: "failed",
-				exitCode: 1,
-				aborted: entry.signalSkip ? true : undefined,
-				abortReason: entry.signalSkip ? "Cancelled before start" : undefined,
-				truncated: false,
-				durationMs: 0,
-				tokens: 0,
-				output: "",
-				stderr: entry.message,
-				error: entry.message,
-				duplicateDisposition: entry.duplicateDisposition,
-			} as SingleResult));
+			.map((entry, index) =>
+				buildTaskReceipt({
+					index,
+					id: entry.task.id,
+					agent: params.agent,
+					agentSource: fallbackAgentSource,
+					task: renderTaskAssignment(entry.task.assignment, simpleMode),
+					assignment: entry.task.assignment,
+					description: entry.task.description,
+					status: "failed",
+					exitCode: 1,
+					aborted: entry.signalSkip ? true : undefined,
+					abortReason: entry.signalSkip ? "Cancelled before start" : undefined,
+					truncated: false,
+					durationMs: 0,
+					tokens: 0,
+					output: "",
+					stderr: entry.message,
+					error: entry.message,
+					duplicateDisposition: entry.duplicateDisposition,
+				} as SingleResult),
+			);
 		if (startedJobs.length === 0) {
 			const failureText = `Failed to start background task jobs: ${failedSchedules.map(entry => `${entry.task.id}: ${entry.message}`).join("; ")}`;
-			return { content: [{ type: "text", text: failureText }], details: { projectAgentsDir: null, results: scheduleFailureReceipts, totalDurationMs: 0 } };
+			return {
+				content: [{ type: "text", text: failureText }],
+				details: { projectAgentsDir: null, results: scheduleFailureReceipts, totalDurationMs: 0 },
+			};
 		}
 
 		const asyncState = completedJobs === taskItems.length ? (failedJobs > 0 ? "failed" : "completed") : "running";

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -91,6 +91,18 @@ import {
 	type WorktreeBaseline,
 } from "./worktree";
 
+interface DuplicateIdentity {
+	role: string;
+	ownerId?: string;
+	parentSession: string | null;
+	repository: { root: string; relativeSubdir: string | null };
+}
+
+interface DuplicateDisposition {
+	action: "warned" | "superseded";
+	predecessorIds: string[];
+}
+
 interface TaskResumeDescriptor {
 	toolCallId: string;
 	params: TaskParams;
@@ -99,6 +111,11 @@ interface TaskResumeDescriptor {
 	durableOutputAllowed?: boolean;
 	forkContextSeed?: ForkContextSeed;
 	agentSource: AgentDefinition["source"];
+	repositoryBinding: RepositoryBinding;
+	duplicateIdentity: DuplicateIdentity;
+	duplicatePolicy: "warn" | "supersede";
+	initialDisposition?: DuplicateDisposition;
+	lastAdmissionFailure?: string;
 }
 
 function isTaskResumeDescriptor(value: unknown): value is TaskResumeDescriptor {
@@ -188,25 +205,24 @@ async function resolveTaskItemsWithRepositoryBindings(
 	for (const task of tasks) {
 		try {
 			const binding = await resolveTaskRepositoryBinding(cwd, task.repositoryBinding);
-			if (binding.relativeSubdir) {
-				assertPathUnderRepositoryBinding(binding, ".");
-			}
-			resolved.push({
-				...task,
-				repositoryBinding: binding,
-			});
+			if (binding.relativeSubdir) assertPathUnderRepositoryBinding(binding, ".");
+			resolved.push({ ...task, repositoryBinding: binding });
 		} catch (error) {
 			const id = task.id?.trim() ? task.id : "(missing-id)";
-			if (error instanceof RepositoryBindingError) {
-				return { tasks: [], error: `Task "${id}" repository binding rejected: ${error.message}` };
-			}
-			return {
-				tasks: [],
-				error: `Task "${id}" repository binding rejected: ${error instanceof Error ? error.message : String(error)}`,
-			};
+			if (error instanceof RepositoryBindingError) return { tasks: [], error: `Task "${id}" repository binding rejected: ${error.message}` };
+			return { tasks: [], error: `Task "${id}" repository binding rejected: ${error instanceof Error ? error.message : String(error)}` };
 		}
 	}
 	return { tasks: resolved };
+}
+
+function duplicateIdentityForTask(task: TaskItem, role: string, ownerId: string | undefined, parentSession: string | null): DuplicateIdentity {
+	const binding = task.repositoryBinding as RepositoryBinding;
+	return { role: role.trim(), ownerId, parentSession, repository: { root: binding.commonDir ?? binding.worktreeRoot, relativeSubdir: binding.relativeSubdir ?? null } };
+}
+
+function duplicateIdentityKey(identity: DuplicateIdentity): string {
+	return JSON.stringify([identity.role, identity.ownerId ?? null, identity.parentSession, identity.repository.root, identity.repository.relativeSubdir]);
 }
 
 function repositoryBindingFromTask(task: TaskItem): RepositoryBinding | undefined {
@@ -859,7 +875,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		}
 
 		const startedJobs: Array<{ jobId: string; taskId: string }> = [];
-		const failedSchedules: string[] = [];
+		const failedSchedules: Array<{ task: TaskItem & { id: string }; taskIndex: number; message: string; signalSkip: boolean; duplicateDisposition?: DuplicateDisposition }> = [];
 		let completedJobs = 0;
 		let failedJobs = 0;
 
@@ -886,21 +902,54 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		};
 
 		const maxConcurrency = this.session.settings.get("task.maxConcurrency");
+		const ownerId = this.session.getAgentId?.() ?? undefined;
+		const parentSession = this.session.getSessionFile();
+		const admitDuplicateLaunch = (subagentId: string, task: TaskItem, policy: "warn" | "supersede", selfSubagentId?: string): { ok: boolean; disposition?: DuplicateDisposition; error?: string; identity: DuplicateIdentity } => {
+			const identity = duplicateIdentityForTask(task, params.agent, ownerId, parentSession);
+			const key = duplicateIdentityKey(identity);
+			const predecessors = manager.getSubagentRecords({ ownerId }).filter(record => {
+				if (record.subagentId === selfSubagentId || record.subagentId === subagentId) return false;
+				if (record.status !== "running" && record.status !== "paused" && record.status !== "queued") return false;
+				return record.duplicateIdentity === key;
+			}).sort((a, b) => (b.currentJobId ? manager.getJob(b.currentJobId)?.startTime ?? 0 : 0) - (a.currentJobId ? manager.getJob(a.currentJobId)?.startTime ?? 0 : 0) || a.subagentId.localeCompare(b.subagentId));
+			if (predecessors.length === 0) return { ok: true, identity };
+			if (policy === "warn") return { ok: true, identity, disposition: { action: "warned", predecessorIds: predecessors.map(record => record.subagentId) } };
+			for (const predecessor of predecessors) if (!manager.cancelSubagent(predecessor.subagentId, { ownerId })) return { ok: false, identity, error: "duplicate_supersede_failed" };
+			return { ok: true, identity, disposition: { action: "superseded", predecessorIds: predecessors.map(record => record.subagentId) } };
+		};
 		let resumeRunner: ResumeRunner | undefined;
 		if (typeof manager.setResumeRunner === "function") {
 			resumeRunner = (_subagentId, message, resumeDescriptor) => {
 				const descriptor = isTaskResumeDescriptor(resumeDescriptor?.data) ? resumeDescriptor.data : undefined;
 				if (!descriptor) return undefined;
+				const admission = (() => {
+					const identity = descriptor.duplicateIdentity;
+					const key = duplicateIdentityKey(identity);
+					const predecessors = manager.getSubagentRecords({ ownerId }).filter(record => {
+					if (record.subagentId === descriptor.task.id || !["running", "paused", "queued"].includes(record.status)) return false;
+					return record.duplicateIdentity === key;
+					}).sort((a, b) => (b.currentJobId ? manager.getJob(b.currentJobId)?.startTime ?? 0 : 0) - (a.currentJobId ? manager.getJob(a.currentJobId)?.startTime ?? 0 : 0) || a.subagentId.localeCompare(b.subagentId));
+					if (predecessors.length === 0) return { ok: true, identity };
+					if (descriptor.duplicatePolicy === "warn") return { ok: true, identity, disposition: { action: "warned", predecessorIds: predecessors.map(record => record.subagentId) } };
+					for (const predecessor of predecessors) if (!manager.cancelSubagent(predecessor.subagentId, { ownerId })) return { ok: false, identity, error: "duplicate_supersede_failed" };
+					return { ok: true, identity, disposition: { action: "superseded", predecessorIds: predecessors.map(record => record.subagentId) } };
+				})();
+				if (!admission.ok) {
+					descriptor.lastAdmissionFailure = admission.error;
+					return undefined;
+				}
+				if (!descriptor) return undefined;
 				const forkSeeds = descriptor.forkContextSeed
 					? new Map([[descriptor.task.id, descriptor.forkContextSeed]])
 					: undefined;
+				const resumedTask = { ...descriptor.task, repositoryBinding: descriptor.repositoryBinding, duplicate_policy: descriptor.duplicatePolicy };
 				return manager.register(
 					"task",
 					descriptor.task.id,
 					async ({ signal: runSignal }) => {
 						const result = await this.#executeSync(
 							descriptor.toolCallId,
-							{ ...descriptor.params, tasks: [descriptor.task] },
+							{ ...descriptor.params, tasks: [resumedTask] },
 							runSignal,
 							undefined,
 							[descriptor.task.id],
@@ -921,7 +970,19 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 							},
 						);
 						const finalText = result.content.find(part => part.type === "text")?.text ?? "(no output)";
-						const singleResult = result.details?.results[0];
+						const rawSingleResult = result.details?.results[0];
+						const singleResult = rawSingleResult
+			? {
+					...rawSingleResult,
+						duplicateDisposition: (() => {
+							const initial = descriptor.initialDisposition;
+							const current = admission.disposition;
+							if (!initial) return current;
+							if (!current) return initial;
+							return { action: current.action, predecessorIds: [...new Set([...initial.predecessorIds, ...current.predecessorIds])] };
+						})(),
+			}
+							: rawSingleResult;
 						return subagentRunOutcomeFromSingleResult(finalText, singleResult);
 					},
 					{
@@ -932,6 +993,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								id: descriptor.task.id,
 								agent: descriptor.params.agent,
 								agentSource: descriptor.agentSource,
+								duplicateIdentity: duplicateIdentityKey(descriptor.duplicateIdentity),
+								duplicateDisposition: (admission.disposition?.action ?? descriptor.initialDisposition?.action) as DuplicateDisposition["action"] | undefined,
 								description: descriptor.task.description,
 								assignment: descriptor.task.assignment.trim(),
 							},
@@ -968,7 +1031,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		for (let i = 0; i < taskItems.length; i++) {
 			const taskItem = taskItems[i];
 			if (signal?.aborted) {
-				failedSchedules.push(`${taskItem.id}: cancelled before scheduling`);
+				failedSchedules.push({ task: taskItem as TaskItem & { id: string }, taskIndex: i, message: "cancelled before scheduling", signalSkip: true });
 				const progress = progressByTaskId.get(taskItem.id);
 				if (progress) {
 					progress.status = "aborted";
@@ -981,7 +1044,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			if (signal?.aborted) {
 				for (let skippedIndex = i; skippedIndex < taskItems.length; skippedIndex++) {
 					const skippedTask = taskItems[skippedIndex]!;
-					failedSchedules.push(`${skippedTask.id}: cancelled before scheduling`);
+					failedSchedules.push({ task: skippedTask as TaskItem & { id: string }, taskIndex: skippedIndex, message: "cancelled before scheduling", signalSkip: true });
 					const skippedProgress = progressByTaskId.get(skippedTask.id);
 					if (skippedProgress) skippedProgress.status = "aborted";
 				}
@@ -997,6 +1060,11 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				const subtaskSessionFile = managedPersistence
 					? null
 					: path.join(batchArtifactsDir ?? externalTaskSessionsDir!, `${uniqueId}.jsonl`);
+				const admission = admitDuplicateLaunch(uniqueId, taskItem, taskItem.duplicate_policy ?? "warn");
+				if (!admission.ok) {
+					failedSchedules.push({ task: taskItem as TaskItem & { id: string }, taskIndex: i, message: admission.error ?? "duplicate_supersede_failed", signalSkip: false, duplicateDisposition: admission.disposition });
+					continue;
+				}
 				const jobId = manager.register(
 					"task",
 					label,
@@ -1036,7 +1104,10 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								},
 							);
 							const finalText = result.content.find(part => part.type === "text")?.text ?? "(no output)";
-							const singleResult = result.details?.results[0];
+							const rawSingleResult = result.details?.results[0];
+							const singleResult = rawSingleResult
+								? { ...rawSingleResult, duplicateDisposition: rawSingleResult.duplicateDisposition ?? admission.disposition }
+								: rawSingleResult;
 							if (progress) {
 								progress.status = singleResult?.paused
 									? "paused"
@@ -1119,6 +1190,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								id: uniqueId,
 								agent: params.agent,
 								agentSource: fallbackAgentSource,
+								duplicateIdentity: duplicateIdentityKey(admission.identity),
+								duplicateDisposition: admission.disposition?.action,
 								description: taskItem.description,
 								assignment: taskItem.assignment.trim(),
 							},
@@ -1145,6 +1218,10 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 								durableOutputAllowed: Boolean(batchArtifactsDir),
 								forkContextSeed: frozenForkSeed,
 								agentSource: fallbackAgentSource,
+								repositoryBinding: taskItem.repositoryBinding as RepositoryBinding,
+								duplicateIdentity: admission.identity,
+								duplicatePolicy: taskItem.duplicate_policy ?? "warn",
+								initialDisposition: admission.disposition,
 							} satisfies TaskResumeDescriptor,
 						},
 						resumeRunner,
@@ -1155,10 +1232,13 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						subagentId: uniqueId,
 						ownerId: this.session.getAgentId?.() ?? undefined,
 						currentJobId: jobId,
+						currentJobGeneration: manager.getJob(jobId)?.generation,
 						historicalJobIds: [],
 						status: manager.getJob(jobId)?.status ?? "running",
 						sessionFile: null,
 						resumable: true,
+						duplicateIdentity: duplicateIdentityKey(admission.identity),
+						duplicateDisposition: admission.disposition?.action,
 					});
 				}
 			} catch (error) {
@@ -1168,7 +1248,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						: error instanceof Error
 							? error.message
 							: String(error);
-				failedSchedules.push(`${taskItem.id}: ${message}`);
+				failedSchedules.push({ task: taskItem as TaskItem & { id: string }, taskIndex: i, message, signalSkip: false });
 				const progress = progressByTaskId.get(taskItem.id);
 				if (progress) {
 					progress.status = "failed";
@@ -1181,12 +1261,32 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			failedJobs += failedSchedules.length;
 		}
 
+		const scheduleFailureReceipts = failedSchedules
+			.slice()
+			.sort((a, b) => a.taskIndex - b.taskIndex)
+			.map((entry, index) => buildTaskReceipt({
+				index,
+				id: entry.task.id,
+				agent: params.agent,
+				agentSource: fallbackAgentSource,
+				task: renderTaskAssignment(entry.task.assignment, simpleMode),
+				assignment: entry.task.assignment,
+				description: entry.task.description,
+				status: "failed",
+				exitCode: 1,
+				aborted: entry.signalSkip ? true : undefined,
+				abortReason: entry.signalSkip ? "Cancelled before start" : undefined,
+				truncated: false,
+				durationMs: 0,
+				tokens: 0,
+				output: "",
+				stderr: entry.message,
+				error: entry.message,
+				duplicateDisposition: entry.duplicateDisposition,
+			} as SingleResult));
 		if (startedJobs.length === 0) {
-			const failureText = `Failed to start background task jobs: ${failedSchedules.join("; ")}`;
-			return {
-				content: [{ type: "text", text: failureText }],
-				details: { projectAgentsDir: null, results: [], totalDurationMs: 0 },
-			};
+			const failureText = `Failed to start background task jobs: ${failedSchedules.map(entry => `${entry.task.id}: ${entry.message}`).join("; ")}`;
+			return { content: [{ type: "text", text: failureText }], details: { projectAgentsDir: null, results: scheduleFailureReceipts, totalDurationMs: 0 } };
 		}
 
 		const asyncState = completedJobs === taskItems.length ? (failedJobs > 0 ? "failed" : "completed") : "running";
@@ -1233,7 +1333,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			],
 			details: {
 				projectAgentsDir: null,
-				results: [],
+				results: scheduleFailureReceipts,
 				totalDurationMs: 0,
 				progress: getProgressSnapshot(),
 				async: { state: asyncState, jobId: startedJobs[0].jobId, type: "task" },

--- a/packages/coding-agent/src/task/receipt.ts
+++ b/packages/coding-agent/src/task/receipt.ts
@@ -43,6 +43,7 @@ export interface TaskResultReceipt {
 	retryFailure?: { attempt: number; errorSummary: string };
 	setupFailure?: { summary: string };
 	errorSummary?: string;
+	duplicateDisposition?: SingleResult["duplicateDisposition"];
 	abortSummary?: string;
 	preview: string;
 	previewTruncated: boolean;
@@ -296,6 +297,7 @@ export function buildTaskReceipt(raw: SingleResult): TaskResultReceipt {
 		retryFailure: raw.retryFailure
 			? { attempt: raw.retryFailure.attempt, errorSummary: "Retry failure recorded." }
 			: undefined,
+		duplicateDisposition: raw.duplicateDisposition,
 		errorSummary:
 			raw.setupFailure?.summary ??
 			(raw.error

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -116,6 +116,7 @@ const createTaskItemSchema = (_contextEnabled: boolean) =>
 				"authoritative repository identity; omitted items are stamped from session cwd before discovery/spawn and still fail closed on sibling drift",
 			),
 		reviewSource: reviewSourceSchema.optional(),
+		duplicate_policy: z.enum(["warn", "supersede"]).optional().describe("duplicate launch policy; defaults to warn"),
 	});
 
 const reviewSourceSchema = z
@@ -218,6 +219,7 @@ export interface TaskParams {
 	spawnPlan?: SpawnPlanReceipt;
 	tasks: TaskItem[];
 	isolated?: boolean;
+	duplicate_policy?: "warn" | "supersede";
 }
 
 /** A code review finding reported by the reviewer agent */
@@ -452,6 +454,12 @@ export interface TaskRecoveryArtifactRef {
 	durability: "session";
 }
 
+/** Bounded duplicate-launch disposition carried into task receipts. */
+export interface DuplicateDisposition {
+	action: "warned" | "superseded";
+	predecessorIds: string[];
+}
+
 export interface TaskPersistenceResult {
 	outcome: "applied" | "no_changes" | "recovery_available";
 	ownerWorktreeApplied: boolean;
@@ -488,6 +496,8 @@ export interface SingleResult {
 	setupFailure?: SetupFailureSummary;
 	aborted?: boolean;
 	abortReason?: string;
+
+	duplicateDisposition?: DuplicateDisposition;
 	paused?: boolean;
 	/** Aggregated usage from the subprocess, accumulated incrementally from message_end events. */
 	usage?: Usage;

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -32,6 +32,8 @@ const subagentSchema = z.object({
 	id: z.string().optional().describe("single subagent id or backing job id for resume/steer"),
 	message: z.string().optional().describe("message to deliver when resuming or steering a subagent"),
 	pause: z.boolean().optional().describe("pause after steering a currently running subagent"),
+	condition: z.enum(["all_terminal", "any_terminal"]).optional().describe("terminal wait condition; defaults to all_terminal"),
+	heartbeat_ms: z.number().refine(value => value === 0 || (Number.isInteger(value) && value >= 100 && value <= 5000)).optional().describe("heartbeat interval; 0 disables"),
 	timeout_ms: z.number().min(0).max(MAX_AWAIT_TIMEOUT_MS).optional().describe("await timeout in milliseconds"),
 	limit: z.number().min(1).max(MAX_LIST_LIMIT).optional().describe("maximum subagents to return"),
 	verbosity: z
@@ -97,6 +99,11 @@ export interface SubagentToolDetails {
 	subagents: SubagentSnapshot[];
 	/** Await outcome for a live await receipt; omitted when no wait was started. */
 	awaitOutcome?: SubagentAwaitOutcome;
+	waitOutcome?: "completed" | "timed_out_wait" | "interrupted";
+	condition?: "all_terminal" | "any_terminal";
+	heartbeatMs?: number;
+	terminalIds?: string[];
+	acknowledgedTerminalIds?: string[];
 	/** True only when the parent await was interrupted; the child was not cancelled. */
 	interrupted?: true;
 }
@@ -344,35 +351,26 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		signal: AbortSignal | undefined,
 		onUpdate: AgentToolUpdateCallback<SubagentToolDetails> | undefined,
 	): Promise<AgentToolResult<SubagentToolDetails>> {
-		const records = params.ids?.length
-			? this.#visibleRecordsByIds(manager, params.ids, ownerFilter)
-			: this.#runningRecords(manager, ownerFilter);
-		const notFoundIds = this.#notFoundRecordIds(manager, params.ids ?? [], ownerFilter);
-		if (records.length === 0) {
-			const missing = notFoundIds.map(id =>
-				this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."),
-			);
-			return this.#buildSnapshotResult(missing, "Subagent await");
+		const ids = params.ids?.map(id => id.trim()).filter(Boolean).filter((id, index, all) => all.indexOf(id) === index);
+		const records = ids?.length ? this.#visibleRecordsByIds(manager, ids, ownerFilter) : this.#runningRecords(manager, ownerFilter);
+		const notFoundIds = (ids ?? []).filter(id => !this.#findVisibleRecord(manager, id, ownerFilter));
+		if (records.length === 0) return this.#buildSnapshotResult(notFoundIds.map(id => this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id.")), "Subagent await");
+		const targets = records.map(record => manager.resolveSubagentWaitTarget(record.subagentId, ownerFilter)).filter((target): target is NonNullable<typeof target> => target !== undefined);
+		if (targets.length === 0) return this.#buildSnapshotResult([], "Subagent await");
+		const condition = params.condition ?? "all_terminal";
+		const handle = manager.subscribeTerminalWait(targets, condition);
+		const timeoutMs = Math.min(MAX_AWAIT_TIMEOUT_MS, Math.max(0, Math.floor(params.timeout_ms ?? DEFAULT_AWAIT_TIMEOUT_MS)));
+		const targetsAlreadyTerminal = targets.every(target => target.initialStatus === "completed" || target.initialStatus === "failed" || target.initialStatus === "cancelled");
+		if (targetsAlreadyTerminal) {
+			const waitResult = await handle.result;
+			handle.acknowledge(waitResult.terminalJobIds);
+			handle.close();
+			const terminalJobIds = waitResult.terminalJobIds;
+			return await this.#buildRecordResult(manager, records, { title: "Subagent await", verbosity: params.verbosity ?? "receipt", waitOutcome: "completed", condition, terminalIds: terminalJobIds });
 		}
-
-		const runningJobs = records
-			.filter(record => record.status === "running" && record.currentJobId)
-			.map(record => manager.getJob(record.currentJobId!))
-			.filter((job): job is AsyncJob => job !== undefined);
-		if (runningJobs.length === 0) {
-			return await this.#buildRecordResult(manager, records, {
-				title: "Subagent await",
-				notFoundIds,
-				verbosity: params.verbosity ?? "receipt",
-			});
-		}
-
-		const timeoutMs = Math.min(
-			MAX_AWAIT_TIMEOUT_MS,
-			Math.max(0, Math.floor(params.timeout_ms ?? DEFAULT_AWAIT_TIMEOUT_MS)),
-		);
-		const watchedJobIds = runningJobs.map(job => job.id);
+		const watchedJobIds = targets.map(target => target.jobId).filter((jobId): jobId is string => jobId !== null);
 		manager.watchJobs(watchedJobIds);
+		const heartbeatMs = params.heartbeat_ms === undefined ? 500 : params.heartbeat_ms;
 		let lastEmittedSignature: string | undefined;
 		const emitIfChanged = (force: boolean): void => {
 			if (!onUpdate) return;
@@ -382,57 +380,43 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			lastEmittedSignature = signature;
 			onUpdate(result);
 		};
-		const progressTimer = onUpdate ? setInterval(() => emitIfChanged(false), 500) : undefined;
-		// Initial emission so the panel appears immediately; later idle ticks are
-		// gated on a value-based rendered-state signature so unchanged progress no
-		// longer rebuilds the renderer component or mutates transcript lines above
-		// the viewport (the source of the await-panel repaint storms).
+		const progressTimer = onUpdate && heartbeatMs > 0 ? setInterval(() => emitIfChanged(false), heartbeatMs) : undefined;
 		emitIfChanged(true);
-
-		let awaitOutcome: SubagentAwaitOutcome;
-		const { promise: timeoutPromise, resolve: resolveTimeout } = Promise.withResolvers<SubagentAwaitOutcome>();
-		const timeoutTimer = setTimeout(() => resolveTimeout("timed_out"), timeoutMs);
-		const completionPromise = Promise.all(runningJobs.map(job => job.promise)).then(() => "completed" as const);
+		let waitOutcome: "completed" | "timed_out_wait" | "interrupted";
 		let onAbort: (() => void) | undefined;
 		try {
-			if (signal) {
-				const { promise: abortPromise, resolve: resolveAbort } = Promise.withResolvers<SubagentAwaitOutcome>();
-				onAbort = () => resolveAbort("interrupted");
-				if (signal.aborted) onAbort();
-				else signal.addEventListener("abort", onAbort, { once: true });
-				awaitOutcome = await Promise.race([completionPromise, timeoutPromise, abortPromise]);
-			} else {
-				awaitOutcome = await Promise.race([completionPromise, timeoutPromise]);
-			}
+			const abortPromise = new Promise<"interrupted">(resolve => {
+				onAbort = () => resolve("interrupted");
+				if (signal?.aborted) onAbort();
+				else signal?.addEventListener("abort", onAbort, { once: true });
+			});
+			waitOutcome = targetsAlreadyTerminal && !signal?.aborted
+				? "completed"
+				: await Promise.race([
+						handle.result.then(() => "completed" as const),
+						Bun.sleep(timeoutMs).then(() => "timed_out_wait" as const),
+						abortPromise,
+				  ]);
 		} finally {
-			clearTimeout(timeoutTimer);
 			if (signal && onAbort) signal.removeEventListener("abort", onAbort);
 			if (progressTimer) clearInterval(progressTimer);
 		}
-		if (awaitOutcome !== "interrupted") {
-			const terminalWatchedJobIds = watchedJobIds.filter(jobId => {
-				const status = manager.getJob(jobId)?.status;
-				return status === "completed" || status === "failed" || status === "cancelled";
-			});
-			manager.acknowledgeDeliveries(terminalWatchedJobIds);
-		}
+		const waitResult = waitOutcome === "completed" ? await handle.result : undefined;
+		if (waitOutcome === "completed") handle.acknowledge(waitResult?.terminalJobIds);
 		manager.unwatchJobs(watchedJobIds);
-
-		const finalRecords = this.#visibleRecordsByIds(
-			manager,
-			records.map(record => record.subagentId),
-			ownerFilter,
-		);
-		const finalNotFoundIds = [...new Set([...notFoundIds, ...records.map(record => record.subagentId)])].filter(
-			id => !finalRecords.some(record => record.subagentId === id),
-		);
+		handle.close();
+		const awaitOutcome: SubagentAwaitOutcome = waitOutcome === "completed" ? "completed" : waitOutcome === "timed_out_wait" ? "timed_out" : "interrupted";
+		const finalRecords = this.#visibleRecordsByIds(manager, records.map(record => record.subagentId), ownerFilter);
 		return await this.#buildRecordResult(manager, finalRecords, {
-			title: awaitOutcome === "interrupted" ? "Subagent await interrupted" : "Subagent await",
-			notFoundIds: finalNotFoundIds,
-			timedOut: awaitOutcome === "timed_out",
+			title: waitOutcome === "interrupted" ? "Subagent await interrupted" : "Subagent await",
+			notFoundIds,
+			timedOut: waitOutcome === "timed_out_wait",
 			verbosity: params.verbosity ?? "receipt",
 			attachLiveProgress: true,
 			awaitOutcome,
+			waitOutcome,
+			condition,
+			terminalIds: waitResult?.terminalJobIds,
 		});
 	}
 
@@ -490,7 +474,8 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		if (direct && isSubagentJob(direct) && (!ownerId || direct.ownerId === ownerId)) return direct;
 		return manager
 			.getAllJobs(ownerId ? { ownerId } : undefined)
-			.find(job => isSubagentJob(job) && job.metadata?.subagent?.id === id);
+			.filter(job => isSubagentJob(job) && job.metadata?.subagent?.id === id)
+			.sort((a, b) => b.startTime - a.startTime)[0];
 	}
 
 	#visibleRecordsByIds(
@@ -551,6 +536,9 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			verbosity?: SubagentParams["verbosity"];
 			attachLiveProgress?: boolean;
 			awaitOutcome?: SubagentAwaitOutcome;
+			waitOutcome?: "completed" | "timed_out_wait" | "interrupted";
+			condition?: "all_terminal" | "any_terminal";
+			terminalIds?: string[];
 		},
 	): Promise<AgentToolResult<SubagentToolDetails>> {
 		const verifiedOutputIds = await this.#verifiedOutputIds(records);
@@ -565,33 +553,27 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		for (const id of options.notFoundIds ?? []) {
 			snapshots.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
 		}
-		if (options.awaitOutcome !== "interrupted") {
-			manager.acknowledgeDeliveries(
-				snapshots
-					.filter(
-						s =>
-							s.status !== "running" &&
-							s.status !== "paused" &&
-							s.status !== "queued" &&
-							s.status !== "not_found",
-					)
-					.map(s => s.jobId),
-			);
-		}
 		if (options.awaitOutcome === "interrupted") {
 			for (const snapshot of snapshots) {
-				if (snapshot.status === "running" || snapshot.status === "paused" || snapshot.status === "queued") {
-					snapshot.guidance = AWAIT_INTERRUPTED_GUIDANCE;
-				}
+				if (snapshot.status === "running" || snapshot.status === "paused" || snapshot.status === "queued") snapshot.guidance = AWAIT_INTERRUPTED_GUIDANCE;
 			}
 		}
-		return this.#buildSnapshotResult(snapshots, options.title, options.awaitOutcome);
+		const details: SubagentToolDetails = {
+			subagents: snapshots,
+			...(options.awaitOutcome !== undefined ? { awaitOutcome: options.awaitOutcome } : {}),
+			...(options.waitOutcome !== undefined ? { waitOutcome: options.waitOutcome } : {}),
+			...(options.condition !== undefined ? { condition: options.condition } : {}),
+			...(options.terminalIds !== undefined ? { terminalIds: options.terminalIds } : {}),
+		};
+		if (options.awaitOutcome === "interrupted") details.interrupted = true;
+		return this.#buildSnapshotResult(snapshots, options.title, options.awaitOutcome, details);
 	}
 
 	#buildSnapshotResult(
 		snapshots: SubagentSnapshot[],
 		title: string,
 		awaitOutcome?: SubagentAwaitOutcome,
+		extraDetails?: SubagentToolDetails,
 	): AgentToolResult<SubagentToolDetails> {
 		const lines = [`## ${title} (${snapshots.length})`, ""];
 		for (const snapshot of snapshots) {
@@ -623,7 +605,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		}
 		return {
 			content: [{ type: "text", text: lines.join("\n").trimEnd() }],
-			details: {
+			details: extraDetails ?? {
 				subagents: snapshots,
 				...(awaitOutcome ? { awaitOutcome } : {}),
 				...(awaitOutcome === "interrupted" ? { interrupted: true } : {}),
@@ -651,8 +633,6 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 	): Pick<SubagentSnapshot, "progress" | "liveProgressAvailable"> {
 		if (!attachLiveProgress) return {};
 		const liveProgressAvailable = manager.hasLiveSubagent(record.subagentId);
-		// Only surface progress when a live producer exists; stale/retained progress
-		// for a record with no live producer must degrade to a static snapshot (AC5).
 		if (!liveProgressAvailable) return { liveProgressAvailable: false };
 		const progress = manager.getSubagentProgress(record.subagentId);
 		return {

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -32,8 +32,15 @@ const subagentSchema = z.object({
 	id: z.string().optional().describe("single subagent id or backing job id for resume/steer"),
 	message: z.string().optional().describe("message to deliver when resuming or steering a subagent"),
 	pause: z.boolean().optional().describe("pause after steering a currently running subagent"),
-	condition: z.enum(["all_terminal", "any_terminal"]).optional().describe("terminal wait condition; defaults to all_terminal"),
-	heartbeat_ms: z.number().refine(value => value === 0 || (Number.isInteger(value) && value >= 100 && value <= 5000)).optional().describe("heartbeat interval; 0 disables"),
+	condition: z
+		.enum(["all_terminal", "any_terminal"])
+		.optional()
+		.describe("terminal wait condition; defaults to all_terminal"),
+	heartbeat_ms: z
+		.number()
+		.refine(value => value === 0 || (Number.isInteger(value) && value >= 100 && value <= 5000))
+		.optional()
+		.describe("heartbeat interval; 0 disables"),
 	timeout_ms: z.number().min(0).max(MAX_AWAIT_TIMEOUT_MS).optional().describe("await timeout in milliseconds"),
 	limit: z.number().min(1).max(MAX_LIST_LIMIT).optional().describe("maximum subagents to return"),
 	verbosity: z
@@ -351,22 +358,49 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		signal: AbortSignal | undefined,
 		onUpdate: AgentToolUpdateCallback<SubagentToolDetails> | undefined,
 	): Promise<AgentToolResult<SubagentToolDetails>> {
-		const ids = params.ids?.map(id => id.trim()).filter(Boolean).filter((id, index, all) => all.indexOf(id) === index);
-		const records = ids?.length ? this.#visibleRecordsByIds(manager, ids, ownerFilter) : this.#runningRecords(manager, ownerFilter);
+		const ids = params.ids
+			?.map(id => id.trim())
+			.filter(Boolean)
+			.filter((id, index, all) => all.indexOf(id) === index);
+		const records = ids?.length
+			? this.#visibleRecordsByIds(manager, ids, ownerFilter)
+			: this.#runningRecords(manager, ownerFilter);
 		const notFoundIds = (ids ?? []).filter(id => !this.#findVisibleRecord(manager, id, ownerFilter));
-		if (records.length === 0) return this.#buildSnapshotResult(notFoundIds.map(id => this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id.")), "Subagent await");
-		const targets = records.map(record => manager.resolveSubagentWaitTarget(record.subagentId, ownerFilter)).filter((target): target is NonNullable<typeof target> => target !== undefined);
+		if (records.length === 0)
+			return this.#buildSnapshotResult(
+				notFoundIds.map(id =>
+					this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."),
+				),
+				"Subagent await",
+			);
+		const targets = records
+			.map(record => manager.resolveSubagentWaitTarget(record.subagentId, ownerFilter))
+			.filter((target): target is NonNullable<typeof target> => target !== undefined);
 		if (targets.length === 0) return this.#buildSnapshotResult([], "Subagent await");
 		const condition = params.condition ?? "all_terminal";
 		const handle = manager.subscribeTerminalWait(targets, condition);
-		const timeoutMs = Math.min(MAX_AWAIT_TIMEOUT_MS, Math.max(0, Math.floor(params.timeout_ms ?? DEFAULT_AWAIT_TIMEOUT_MS)));
-		const targetsAlreadyTerminal = targets.every(target => target.initialStatus === "completed" || target.initialStatus === "failed" || target.initialStatus === "cancelled");
+		const timeoutMs = Math.min(
+			MAX_AWAIT_TIMEOUT_MS,
+			Math.max(0, Math.floor(params.timeout_ms ?? DEFAULT_AWAIT_TIMEOUT_MS)),
+		);
+		const targetsAlreadyTerminal = targets.every(
+			target =>
+				target.initialStatus === "completed" ||
+				target.initialStatus === "failed" ||
+				target.initialStatus === "cancelled",
+		);
 		if (targetsAlreadyTerminal) {
 			const waitResult = await handle.result;
 			handle.acknowledge(waitResult.terminalJobIds);
 			handle.close();
 			const terminalJobIds = waitResult.terminalJobIds;
-			return await this.#buildRecordResult(manager, records, { title: "Subagent await", verbosity: params.verbosity ?? "receipt", waitOutcome: "completed", condition, terminalIds: terminalJobIds });
+			return await this.#buildRecordResult(manager, records, {
+				title: "Subagent await",
+				verbosity: params.verbosity ?? "receipt",
+				waitOutcome: "completed",
+				condition,
+				terminalIds: terminalJobIds,
+			});
 		}
 		const watchedJobIds = targets.map(target => target.jobId).filter((jobId): jobId is string => jobId !== null);
 		manager.watchJobs(watchedJobIds);
@@ -380,7 +414,8 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			lastEmittedSignature = signature;
 			onUpdate(result);
 		};
-		const progressTimer = onUpdate && heartbeatMs > 0 ? setInterval(() => emitIfChanged(false), heartbeatMs) : undefined;
+		const progressTimer =
+			onUpdate && heartbeatMs > 0 ? setInterval(() => emitIfChanged(false), heartbeatMs) : undefined;
 		emitIfChanged(true);
 		let waitOutcome: "completed" | "timed_out_wait" | "interrupted";
 		let onAbort: (() => void) | undefined;
@@ -390,13 +425,14 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 				if (signal?.aborted) onAbort();
 				else signal?.addEventListener("abort", onAbort, { once: true });
 			});
-			waitOutcome = targetsAlreadyTerminal && !signal?.aborted
-				? "completed"
-				: await Promise.race([
-						handle.result.then(() => "completed" as const),
-						Bun.sleep(timeoutMs).then(() => "timed_out_wait" as const),
-						abortPromise,
-				  ]);
+			waitOutcome =
+				targetsAlreadyTerminal && !signal?.aborted
+					? "completed"
+					: await Promise.race([
+							handle.result.then(() => "completed" as const),
+							Bun.sleep(timeoutMs).then(() => "timed_out_wait" as const),
+							abortPromise,
+						]);
 		} finally {
 			if (signal && onAbort) signal.removeEventListener("abort", onAbort);
 			if (progressTimer) clearInterval(progressTimer);
@@ -405,8 +441,13 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		if (waitOutcome === "completed") handle.acknowledge(waitResult?.terminalJobIds);
 		manager.unwatchJobs(watchedJobIds);
 		handle.close();
-		const awaitOutcome: SubagentAwaitOutcome = waitOutcome === "completed" ? "completed" : waitOutcome === "timed_out_wait" ? "timed_out" : "interrupted";
-		const finalRecords = this.#visibleRecordsByIds(manager, records.map(record => record.subagentId), ownerFilter);
+		const awaitOutcome: SubagentAwaitOutcome =
+			waitOutcome === "completed" ? "completed" : waitOutcome === "timed_out_wait" ? "timed_out" : "interrupted";
+		const finalRecords = this.#visibleRecordsByIds(
+			manager,
+			records.map(record => record.subagentId),
+			ownerFilter,
+		);
 		return await this.#buildRecordResult(manager, finalRecords, {
 			title: waitOutcome === "interrupted" ? "Subagent await interrupted" : "Subagent await",
 			notFoundIds,
@@ -555,7 +596,8 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		}
 		if (options.awaitOutcome === "interrupted") {
 			for (const snapshot of snapshots) {
-				if (snapshot.status === "running" || snapshot.status === "paused" || snapshot.status === "queued") snapshot.guidance = AWAIT_INTERRUPTED_GUIDANCE;
+				if (snapshot.status === "running" || snapshot.status === "paused" || snapshot.status === "queued")
+					snapshot.guidance = AWAIT_INTERRUPTED_GUIDANCE;
 			}
 		}
 		const details: SubagentToolDetails = {

--- a/packages/coding-agent/test/async-job-manager.test.ts
+++ b/packages/coding-agent/test/async-job-manager.test.ts
@@ -554,13 +554,22 @@ describe("AsyncJobManager", () => {
 		const targets = [manager.resolveSubagentWaitTarget(first)!, manager.resolveSubagentWaitTarget(second)!];
 		const all = manager.subscribeTerminalWait(targets, "all_terminal");
 		const any = manager.subscribeTerminalWait(targets, "any_terminal");
-		expect(await any.result).toMatchObject({ outcome: "completed", condition: "any_terminal", terminalJobIds: [first] });
+		expect(await any.result).toMatchObject({
+			outcome: "completed",
+			condition: "any_terminal",
+			terminalJobIds: [first],
+		});
 		expect(any.acknowledge()).toEqual({ acknowledged: true, jobIds: [first] });
 		expect(any.acknowledge()).toEqual({ acknowledged: false, jobIds: [] });
 
 		secondGate.resolve("two");
 		await manager.getJob(second)?.promise;
-		expect(await all.result).toMatchObject({ outcome: "completed", condition: "all_terminal", terminalJobIds: [first, second], pendingJobIds: [] });
+		expect(await all.result).toMatchObject({
+			outcome: "completed",
+			condition: "all_terminal",
+			terminalJobIds: [first, second],
+			pendingJobIds: [],
+		});
 		expect(all.acknowledge()).toEqual({ acknowledged: true, jobIds: [first, second] });
 		await manager.dispose({ timeoutMs: 100 });
 	});
@@ -580,21 +589,56 @@ describe("AsyncJobManager", () => {
 
 	test("paused and queued cancellation publish terminal wait evidence", async () => {
 		const pausedManager = new AsyncJobManager({ onJobComplete: async () => {} });
-		const pausedJobId = pausedManager.register("task", "pause", async () => ({ kind: "paused", note: "safe boundary" }), { id: "paused-job" });
-		pausedManager.registerSubagentRecord({ subagentId: "paused-subagent", ownerId: "0-Main", currentJobId: pausedJobId, historicalJobIds: [], status: "running", sessionFile: "/tmp/paused.jsonl", resumable: true });
+		const pausedJobId = pausedManager.register(
+			"task",
+			"pause",
+			async () => ({ kind: "paused", note: "safe boundary" }),
+			{ id: "paused-job" },
+		);
+		pausedManager.registerSubagentRecord({
+			subagentId: "paused-subagent",
+			ownerId: "0-Main",
+			currentJobId: pausedJobId,
+			historicalJobIds: [],
+			status: "running",
+			sessionFile: "/tmp/paused.jsonl",
+			resumable: true,
+		});
 		await pausedManager.getJob(pausedJobId)?.promise;
-		const pausedWait = pausedManager.subscribeTerminalWait([pausedManager.resolveSubagentWaitTarget("paused-subagent")!]);
+		const pausedWait = pausedManager.subscribeTerminalWait([
+			pausedManager.resolveSubagentWaitTarget("paused-subagent")!,
+		]);
 		expect(pausedManager.cancelSubagent("paused-subagent", { ownerId: "0-Main" })).toBe(true);
 		expect(await pausedWait.result).toMatchObject({ outcome: "completed", terminalJobIds: ["paused-subagent"] });
 		await pausedManager.dispose({ timeoutMs: 100 });
 
 		const queuedManager = new AsyncJobManager({ maxRunningJobs: 1, onJobComplete: async () => {} });
 		const blockerGate = Promise.withResolvers<void>();
-		const blocker = queuedManager.register("task", "blocker", async () => { await blockerGate.promise; return "released"; }, { id: "queue-blocker", ownerId: "0-Main" });
-		queuedManager.registerSubagentRecord({ subagentId: "queued-subagent", ownerId: "0-Main", currentJobId: null, historicalJobIds: [], status: "completed", sessionFile: "/tmp/queued.jsonl", resumable: true });
-		queuedManager.setResumeRunner(() => queuedManager.register("task", "queued resume", async () => "resumed", { ownerId: "0-Main" }));
+		const blocker = queuedManager.register(
+			"task",
+			"blocker",
+			async () => {
+				await blockerGate.promise;
+				return "released";
+			},
+			{ id: "queue-blocker", ownerId: "0-Main" },
+		);
+		queuedManager.registerSubagentRecord({
+			subagentId: "queued-subagent",
+			ownerId: "0-Main",
+			currentJobId: null,
+			historicalJobIds: [],
+			status: "completed",
+			sessionFile: "/tmp/queued.jsonl",
+			resumable: true,
+		});
+		queuedManager.setResumeRunner(() =>
+			queuedManager.register("task", "queued resume", async () => "resumed", { ownerId: "0-Main" }),
+		);
 		expect(queuedManager.resumeSubagent("queued-subagent", { ownerId: "0-Main" }).queued).toBe(true);
-		const queuedWait = queuedManager.subscribeTerminalWait([queuedManager.resolveSubagentWaitTarget("queued-subagent")!]);
+		const queuedWait = queuedManager.subscribeTerminalWait([
+			queuedManager.resolveSubagentWaitTarget("queued-subagent")!,
+		]);
 		expect(queuedManager.cancelSubagent("queued-subagent", { ownerId: "0-Main" })).toBe(true);
 		expect(await queuedWait.result).toMatchObject({ outcome: "completed", terminalJobIds: ["queued-subagent"] });
 		blockerGate.resolve();

--- a/packages/coding-agent/test/async-job-manager.test.ts
+++ b/packages/coding-agent/test/async-job-manager.test.ts
@@ -543,4 +543,62 @@ describe("AsyncJobManager", () => {
 		expect(phases.filter(p => p === "terminal")).toHaveLength(1);
 		expect(phases.filter(p => p === "evict")).toHaveLength(2);
 	});
+
+	test("terminal waits support all/any predicates and idempotent acknowledgement", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: async () => {} });
+		const first = manager.register("task", "first", async () => "one", { id: "wait-first" });
+		const secondGate = Promise.withResolvers<string>();
+		const second = manager.register("task", "second", async () => secondGate.promise, { id: "wait-second" });
+		await manager.getJob(first)?.promise;
+
+		const targets = [manager.resolveSubagentWaitTarget(first)!, manager.resolveSubagentWaitTarget(second)!];
+		const all = manager.subscribeTerminalWait(targets, "all_terminal");
+		const any = manager.subscribeTerminalWait(targets, "any_terminal");
+		expect(await any.result).toMatchObject({ outcome: "completed", condition: "any_terminal", terminalJobIds: [first] });
+		expect(any.acknowledge()).toEqual({ acknowledged: true, jobIds: [first] });
+		expect(any.acknowledge()).toEqual({ acknowledged: false, jobIds: [] });
+
+		secondGate.resolve("two");
+		await manager.getJob(second)?.promise;
+		expect(await all.result).toMatchObject({ outcome: "completed", condition: "all_terminal", terminalJobIds: [first, second], pendingJobIds: [] });
+		expect(all.acknowledge()).toEqual({ acknowledged: true, jobIds: [first, second] });
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	test("closing a terminal wait interrupts observation without mutating child status", async () => {
+		const manager = new AsyncJobManager({ onJobComplete: async () => {} });
+		const gate = Promise.withResolvers<string>();
+		const jobId = manager.register("task", "held", async () => gate.promise, { id: "wait-held" });
+		const handle = manager.subscribeTerminalWait([manager.resolveSubagentWaitTarget(jobId)!]);
+		handle.close();
+		expect(await handle.result).toMatchObject({ outcome: "interrupted", pendingJobIds: [jobId] });
+		expect(manager.getJob(jobId)?.status).toBe("running");
+		gate.resolve("finished");
+		await manager.getJob(jobId)?.promise;
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
+	test("paused and queued cancellation publish terminal wait evidence", async () => {
+		const pausedManager = new AsyncJobManager({ onJobComplete: async () => {} });
+		const pausedJobId = pausedManager.register("task", "pause", async () => ({ kind: "paused", note: "safe boundary" }), { id: "paused-job" });
+		pausedManager.registerSubagentRecord({ subagentId: "paused-subagent", ownerId: "0-Main", currentJobId: pausedJobId, historicalJobIds: [], status: "running", sessionFile: "/tmp/paused.jsonl", resumable: true });
+		await pausedManager.getJob(pausedJobId)?.promise;
+		const pausedWait = pausedManager.subscribeTerminalWait([pausedManager.resolveSubagentWaitTarget("paused-subagent")!]);
+		expect(pausedManager.cancelSubagent("paused-subagent", { ownerId: "0-Main" })).toBe(true);
+		expect(await pausedWait.result).toMatchObject({ outcome: "completed", terminalJobIds: ["paused-subagent"] });
+		await pausedManager.dispose({ timeoutMs: 100 });
+
+		const queuedManager = new AsyncJobManager({ maxRunningJobs: 1, onJobComplete: async () => {} });
+		const blockerGate = Promise.withResolvers<void>();
+		const blocker = queuedManager.register("task", "blocker", async () => { await blockerGate.promise; return "released"; }, { id: "queue-blocker", ownerId: "0-Main" });
+		queuedManager.registerSubagentRecord({ subagentId: "queued-subagent", ownerId: "0-Main", currentJobId: null, historicalJobIds: [], status: "completed", sessionFile: "/tmp/queued.jsonl", resumable: true });
+		queuedManager.setResumeRunner(() => queuedManager.register("task", "queued resume", async () => "resumed", { ownerId: "0-Main" }));
+		expect(queuedManager.resumeSubagent("queued-subagent", { ownerId: "0-Main" }).queued).toBe(true);
+		const queuedWait = queuedManager.subscribeTerminalWait([queuedManager.resolveSubagentWaitTarget("queued-subagent")!]);
+		expect(queuedManager.cancelSubagent("queued-subagent", { ownerId: "0-Main" })).toBe(true);
+		expect(await queuedWait.result).toMatchObject({ outcome: "completed", terminalJobIds: ["queued-subagent"] });
+		blockerGate.resolve();
+		await queuedManager.getJob(blocker)?.promise;
+		await queuedManager.dispose({ timeoutMs: 100 });
+	});
 });

--- a/packages/coding-agent/test/task/receipt.test.ts
+++ b/packages/coding-agent/test/task/receipt.test.ts
@@ -533,6 +533,27 @@ describe("task result receipts", () => {
 		expect(rendered).not.toContain("raw ");
 		expect(rendered).not.toContain("stderr");
 	});
+	it("preserves duplicate disposition in a receipt and converts failed scheduling to failure", () => {
+		const warned = buildTaskReceipt(
+			makeRaw({ id: "DuplicateWarned", duplicateDisposition: { action: "warned", predecessorIds: ["Earlier"] } }),
+		);
+		expect(warned.status).toBe("completed");
+		expect(warned.duplicateDisposition).toEqual({ action: "warned", predecessorIds: ["Earlier"] });
+
+		const failedSchedule = buildTaskReceipt(
+			makeRaw({
+				id: "DuplicateSupersedeFailed",
+				exitCode: 1,
+				output: "",
+				stderr: "duplicate_supersede_failed",
+				error: "duplicate_supersede_failed",
+				duplicateDisposition: { action: "superseded", predecessorIds: ["Earlier"] },
+			}),
+		);
+		expect(failedSchedule.status).toBe("failed");
+		expect(failedSchedule.errorSummary).toBe("Error recorded.");
+		expect(failedSchedule.duplicateDisposition).toEqual({ action: "superseded", predecessorIds: ["Earlier"] });
+	});
 });
 
 describe("agent protocol metadata verification", () => {

--- a/packages/coding-agent/test/tools/subagent.test.ts
+++ b/packages/coding-agent/test/tools/subagent.test.ts
@@ -623,6 +623,31 @@ describe("SubagentTool", () => {
 		await manager.dispose({ timeoutMs: 100 });
 	});
 
+	it("accepts terminal wait conditions and heartbeat bounds while retaining child status on timeout", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const gate = Promise.withResolvers<string>();
+		const jobId = manager.register("task", "heartbeat child", async () => gate.promise, {
+			id: "job-heartbeat-bounds",
+			ownerId: "0-Main",
+			metadata: { subagent: { id: "0-HeartbeatBounds", agent: "executor", agentSource: "bundled" } },
+		});
+		const updates: unknown[] = [];
+		const timedOut = await tool.execute(
+			"await-heartbeat-bounds",
+			{ action: "await", ids: ["0-HeartbeatBounds"], condition: "any_terminal", heartbeat_ms: 0, timeout_ms: 1 },
+			undefined,
+			update => updates.push(update),
+		);
+		expect(timedOut.details?.condition).toBe("any_terminal");
+		expect(timedOut.details?.awaitOutcome).toBe("timed_out");
+		expect(manager.getJob(jobId)?.status).toBe("running");
+		expect(updates).toHaveLength(1);
+		gate.resolve("done");
+		await manager.getJob(jobId)?.promise;
+		await manager.dispose({ timeoutMs: 100 });
+	});
+
 	it("await timeout is non-terminal and guides continued observation instead of shutdown", async () => {
 		const manager = createManager();
 		const tool = new SubagentTool(createSession());


### PR DESCRIPTION
## Summary

Closes #3472. Hardens async/subagent terminal waits across queued resume, eviction, preferred-ID reuse, and delivery acknowledgement.

## Changes

- Adds immutable generation identity for job and queued-resume attempts.
- Preserves and resolves queued terminal evidence through successful resume, cancellation, and resume failure.
- Scopes terminal acknowledgement and delivery suppression by generation and wait ownership.
- Prevents stale deliveries from being attributed to reused job IDs.
- Preserves duplicate-admission disposition across resume receipts and metadata.

## Verification

- `bun --cwd=packages/coding-agent run check:types`
- `bun test packages/coding-agent/test/async-job-manager.test.ts` — 21 passed
- `bun test packages/coding-agent/test/tools/subagent.test.ts` — 41 passed
- `bun test packages/coding-agent/test/tools/subagent-live-progress.test.ts` — 19 passed
- `bun test packages/coding-agent/test/task/receipt.test.ts` — 25 passed
- `git diff --check`

## Review receipt

Architect: CLEAR / APPROVE. Executor QA: passed.

Commit: a253cca85