### PR TITLE
fix(coding-agent): repaint async settings views

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 
+- Settings now requests a repaint after asynchronous GJC bundle and plugin views rebuild, so loaded content and mutation results appear without an extra keypress (#3643).
 - Deferred `agent_end` publication again settles public session readiness before slow extension handlers finish, while retaining exact cancellation leases through queued extension delivery and draining that delivery before session shutdown.
 - Ultragoal validation-batch hydration now fails closed unless deferred and final-close evidence exactly matches a complete authoritative cumulative Git/CI inventory and durable batch tuple. Explicit malformed, partial, unknown, reordered, or stale receipt data is rejected; Git path capture is byte-safe, NUL-delimited, and includes untracked files; incomplete capture conservatively requires computer-control QA; shared settings and tool registries cannot use partial diffs to bypass that suite; validate/checkpoint replacement hydration is identical; and current/replacement receipts are byte-bound to ledger payloads (#3541).
 - Fixture quality gates that complete intermediate Ultragoal stories now write file-backed adversarial artifact proof; skill-state hooks and computer red-team fixtures match the unconditional adversarial path check so #3543 CI stays fail-closed without weakening hydration exactness (#3543).

--- a/packages/coding-agent/src/modes/components/gjc-bundle-settings.ts
+++ b/packages/coding-agent/src/modes/components/gjc-bundle-settings.ts
@@ -56,6 +56,7 @@ export interface GjcBundleSettingsDependencies {
 export interface GjcBundleSettingsCallbacks {
 	onClose: () => void;
 	onBundlesChanged?: () => void;
+	onRenderRequested?: () => void;
 }
 
 export type GjcBundleSettingsState =
@@ -187,6 +188,7 @@ export class GjcBundleSettingsComponent extends Container {
 			),
 		);
 		this.addChild(new DynamicBorder());
+		this.callbacks.onRenderRequested?.();
 	}
 
 	#renderList(): void {

--- a/packages/coding-agent/src/modes/components/plugin-settings.ts
+++ b/packages/coding-agent/src/modes/components/plugin-settings.ts
@@ -127,6 +127,7 @@ export interface PluginDetailCallbacks {
 	onFeatureChange: (feature: string, enabled: boolean) => void;
 	onConfigChange: (key: string, value: unknown) => void;
 	onBack: () => void;
+	onRenderRequested?: () => void;
 }
 
 /**
@@ -288,6 +289,7 @@ export class PluginDetailComponent extends Container {
 		this.addChild(new Spacer(1));
 		this.addChild(new Text(theme.fg("dim", "  Enter to edit · Esc to go back"), 0, 0));
 		this.addChild(new DynamicBorder());
+		this.callbacks.onRenderRequested?.();
 	}
 
 	handleInput(data: string): void {
@@ -409,6 +411,7 @@ class ConfigInputSubmenu extends Container {
 export interface PluginSettingsCallbacks {
 	onClose: () => void;
 	onPluginChanged: () => void;
+	onRenderRequested?: () => void;
 }
 
 /** Component with handleInput method */
@@ -450,6 +453,7 @@ export class PluginSettingsComponent extends Container {
 		});
 
 		this.addChild(this.#viewComponent);
+		this.callbacks.onRenderRequested?.();
 	}
 
 	#showPluginDetail(plugin: InstalledPlugin): void {
@@ -477,6 +481,7 @@ export class PluginSettingsComponent extends Container {
 				this.callbacks.onPluginChanged();
 			},
 			onBack: () => this.#showPluginList(),
+			onRenderRequested: () => this.callbacks.onRenderRequested?.(),
 		});
 
 		this.addChild(this.#viewComponent);

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -719,6 +719,8 @@ export interface SettingsCallbacks {
 	getStatusLinePreview?: (width?: number) => string;
 	/** Called when plugins change */
 	onPluginsChanged?: () => void;
+	/** Called when asynchronously rebuilt settings content needs a repaint. */
+	onRenderRequested?: () => void;
 	/** Called when an interactive setting cannot be committed. */
 	onError?: (message: string) => void;
 	/** Called when settings panel is closed */
@@ -1287,6 +1289,7 @@ export class SettingsSelectorComponent extends Container {
 		this.#pluginComponent = new PluginSettingsComponent(this.context.cwd, {
 			onClose: () => this.callbacks.onCancel(),
 			onPluginChanged: () => this.callbacks.onPluginsChanged?.(),
+			onRenderRequested: () => this.callbacks.onRenderRequested?.(),
 		});
 		this.addChild(this.#pluginComponent);
 	}
@@ -1296,6 +1299,7 @@ export class SettingsSelectorComponent extends Container {
 			{
 				onClose: () => this.callbacks.onCancel(),
 				onBundlesChanged: () => this.callbacks.onPluginsChanged?.(),
+				onRenderRequested: () => this.callbacks.onRenderRequested?.(),
 			},
 			{
 				runtimeSnapshotProvider: this.context.gjcRuntimeSnapshot,

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1334,6 +1334,7 @@ export class SelectorController {
 						onPluginsChanged: () => {
 							this.ctx.ui.requestRender();
 						},
+						onRenderRequested: () => this.ctx.ui.requestRender(),
 						onCancel: () => {
 							done();
 							// Restore status line to saved settings

--- a/packages/coding-agent/test/gjc-bundle-settings-component.test.ts
+++ b/packages/coding-agent/test/gjc-bundle-settings-component.test.ts
@@ -15,6 +15,7 @@ import type {
 	GjcUpdatePreview,
 } from "../src/extensibility/gjc-plugins/types";
 import { type GjcBundleLifecyclePort, GjcBundleSettingsComponent } from "../src/modes/components/gjc-bundle-settings";
+import { PluginSettingsComponent } from "../src/modes/components/plugin-settings";
 import { setTheme } from "../src/modes/theme/theme";
 import {
 	GJC_BUNDLE_SETTINGS_ENTRIES,
@@ -57,6 +58,7 @@ class InMemoryLifecyclePort implements GjcBundleLifecyclePort {
 	readonly surfaceToggleCalls: Array<{ identity: GjcBundleIdentity; surfaceId: string; enabled: boolean }> = [];
 	readonly previewCalls: GjcBundleIdentity[] = [];
 	bundleToggleGate: Deferred<GjcLifecycleResult<GjcToggleResult>> | null = null;
+	listGate: Deferred<GjcBundleSummary[]> | null = null;
 	previewGate: Deferred<GjcLifecycleResult<GjcUpdatePreview>> | null = null;
 
 	constructor(
@@ -65,6 +67,7 @@ class InMemoryLifecyclePort implements GjcBundleLifecyclePort {
 	) {}
 
 	async listGjcBundles(_ctx: GjcLifecycleContext): Promise<GjcBundleSummary[]> {
+		if (this.listGate) return this.listGate.promise;
 		return this.bundles.map(cloneSummary);
 	}
 
@@ -132,11 +135,16 @@ class InMemoryLifecyclePort implements GjcBundleLifecyclePort {
 
 function componentFor(
 	fixture: GjcBundleSettingsFixture,
-	options: { lifecycle?: InMemoryLifecyclePort; runtime?: GjcRuntimeSnapshotProvider; onClose?: () => void } = {},
+	options: {
+		lifecycle?: InMemoryLifecyclePort;
+		runtime?: GjcRuntimeSnapshotProvider;
+		onClose?: () => void;
+		onRenderRequested?: () => void;
+	} = {},
 ): GjcBundleSettingsComponent {
 	return new GjcBundleSettingsComponent(
 		"/safe/project",
-		{ onClose: options.onClose ?? (() => {}) },
+		{ onClose: options.onClose ?? (() => {}), onRenderRequested: options.onRenderRequested },
 		{
 			lifecycle:
 				options.lifecycle ?? new InMemoryLifecyclePort(fixture.bundles.map(cloneSummary), fixture.updatePreview),
@@ -161,6 +169,29 @@ function select(component: GjcBundleSettingsComponent, down = 0): void {
 }
 
 describe("GJC bundle Settings component", () => {
+	test("requests repaint after async bundle and plugin list loads", async () => {
+		const fixture = GJC_BUNDLE_SETTINGS_STATES.find(state => state.id === "list")!.fixture;
+		const lifecycle = new InMemoryLifecyclePort(fixture.bundles.map(cloneSummary));
+		lifecycle.listGate = deferred<GjcBundleSummary[]>();
+		let bundleRenders = 0;
+		const bundle = componentFor(fixture, { lifecycle, onRenderRequested: () => bundleRenders++ });
+		const loadingRenders = bundleRenders;
+		lifecycle.listGate.resolve(fixture.bundles.map(cloneSummary));
+		await ready(bundle);
+		expect(bundleRenders).toBeGreaterThan(loadingRenders);
+		bundle.dispose();
+
+		let pluginRenders = 0;
+		const plugin = new PluginSettingsComponent("/tmp/does-not-need-to-exist", {
+			onClose: () => {},
+			onPluginChanged: () => {},
+			onRenderRequested: () => pluginRenders++,
+		});
+		for (let attempt = 0; attempt < 100 && pluginRenders === 0; attempt++) await Bun.sleep(5);
+		expect(pluginRenders).toBeGreaterThan(0);
+		plugin.dispose();
+	});
+
 	test("renders every catalog state through the live component and never exposes unsafe locator content", async () => {
 		const captured: string[] = [];
 		for (const state of GJC_BUNDLE_SETTINGS_STATES) {


### PR DESCRIPTION
## What

- Request a TUI repaint after asynchronous GJC bundle and plugin settings data finishes loading.
- Forward the existing UI render callback through the settings selector.
- Add regression coverage for bundle and plugin loading transitions.

## Why

The settings components rebuilt their internal trees after asynchronous loads, but did not ask the TUI to render again. The screen therefore remained on `Loading...` until unrelated input triggered a repaint.

Fixes #3643

## Testing

- Focused settings selector/component suite (46 pass, 0 fail)
- `bun --cwd=packages/coding-agent run check`
- `bun run check:tools`
- `git diff --check`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:71edf3db82051af1f5b3058bf3730ae2dd32fced reviewer:critic evidence:local-exact-head-review
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
