### PR TITLE
fix(coding-agent): validate todo completion targets

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 
+- `todo_write` now rejects unsupported operation keys and treats a bare `done` or `drop` as an error instead of completing or abandoning every task (#3640).
 - Deferred `agent_end` publication again settles public session readiness before slow extension handlers finish, while retaining exact cancellation leases through queued extension delivery and draining that delivery before session shutdown.
 - Ultragoal validation-batch hydration now fails closed unless deferred and final-close evidence exactly matches a complete authoritative cumulative Git/CI inventory and durable batch tuple. Explicit malformed, partial, unknown, reordered, or stale receipt data is rejected; Git path capture is byte-safe, NUL-delimited, and includes untracked files; incomplete capture conservatively requires computer-control QA; shared settings and tool registries cannot use partial diffs to bypass that suite; validate/checkpoint replacement hydration is identical; and current/replacement receipts are byte-bound to ledger payloads (#3541).
 - Fixture quality gates that complete intermediate Ultragoal stories now write file-backed adversarial artifact proof; skill-state hooks and computer red-team fixtures match the unconditional adversarial path check so #3543 CI stays fail-closed without weakening hydration exactness (#3543).

--- a/packages/coding-agent/src/tools/todo-write.ts
+++ b/packages/coding-agent/src/tools/todo-write.ts
@@ -1,4 +1,5 @@
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@gajae-code/agent-core";
+import type { RawArgumentValidationResult } from "@gajae-code/ai/types";
 import type { Component } from "@gajae-code/tui";
 import { Text } from "@gajae-code/tui";
 import { prompt } from "@gajae-code/utils";
@@ -61,6 +62,39 @@ const TodoOpEntry = z.object({
 	items: z.array(z.string().describe("task content")).min(1).optional().describe("tasks to append"),
 	text: z.string().optional().describe("note text"),
 });
+
+const TODO_WRITE_KEYS = new Set(["ops"]);
+const TODO_OP_KEYS = new Set(["op", "list", "task", "phase", "items", "text"]);
+const TODO_INIT_ENTRY_KEYS = new Set(["phase", "items"]);
+
+function hasUnknownKeys(value: object, allowed: Set<string>): boolean {
+	return Object.keys(value).some(key => !allowed.has(key));
+}
+
+function validateRawTodoArguments(arguments_: Record<string, unknown>): RawArgumentValidationResult {
+	if (hasUnknownKeys(arguments_, TODO_WRITE_KEYS)) return { outcome: "reject" };
+	if (!Array.isArray(arguments_.ops)) return { outcome: "passthrough" };
+	for (const entry of arguments_.ops) {
+		if (typeof entry !== "object" || entry === null || Array.isArray(entry)) continue;
+		if (hasUnknownKeys(entry, TODO_OP_KEYS)) return { outcome: "reject" };
+		const record = entry as Record<string, unknown>;
+		if ((record.op === "done" || record.op === "drop") && !record.task && !record.phase) {
+			return { outcome: "reject" };
+		}
+		const list = record.list;
+		if (!Array.isArray(list)) continue;
+		for (const item of list) {
+			if (
+				typeof item === "object" &&
+				item !== null &&
+				!Array.isArray(item) &&
+				hasUnknownKeys(item, TODO_INIT_ENTRY_KEYS)
+			)
+				return { outcome: "reject" };
+		}
+	}
+	return { outcome: "passthrough" };
+}
 
 const todoWriteSchema = z
 	.object({
@@ -497,6 +531,7 @@ export class TodoWriteTool implements AgentTool<typeof todoWriteSchema, TodoWrit
 	readonly summary = "Write a structured todo list to track progress within a session";
 	readonly description: string;
 	readonly parameters = todoWriteSchema;
+	readonly rawArgumentValidation = validateRawTodoArguments;
 	readonly concurrency = "exclusive";
 	readonly strict = true;
 	readonly loadMode = "discoverable";
@@ -512,6 +547,18 @@ export class TodoWriteTool implements AgentTool<typeof todoWriteSchema, TodoWrit
 		_context?: AgentToolContext,
 	): Promise<AgentToolResult<TodoWriteToolDetails>> {
 		const previousPhases = clonePhases(this.session.getTodoPhases?.() ?? []);
+		const missingTarget = params.ops.find(
+			entry => (entry.op === "done" || entry.op === "drop") && !entry.task && !entry.phase,
+		);
+		if (missingTarget) {
+			const storage = this.session.getSessionFile() ? "session" : "memory";
+			const errors = [`Missing task or phase for ${missingTarget.op} operation`];
+			return {
+				content: [{ type: "text", text: formatSummary(previousPhases, errors) }],
+				details: { phases: previousPhases, storage },
+				isError: true,
+			};
+		}
 		const { phases: updated, errors } = applyParams(previousPhases, params);
 		this.session.setTodoPhases?.(updated);
 		const storage = this.session.getSessionFile() ? "session" : "memory";

--- a/packages/coding-agent/test/tools/todo-write.test.ts
+++ b/packages/coding-agent/test/tools/todo-write.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "bun:test";
+import { validateToolArguments } from "@gajae-code/ai";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
-import { type TodoPhase, TodoWriteTool } from "@gajae-code/coding-agent/tools";
+import { applyOpsToPhases, type TodoPhase, TodoWriteTool } from "@gajae-code/coding-agent/tools";
 
 function createSession(initialPhases: TodoPhase[] = []): ToolSession {
 	let phases = initialPhases;
@@ -166,6 +167,40 @@ describe("TodoWriteTool ops operations", () => {
 		const result = await tool.execute("call-2", { ops: [{ op: "done", phase: "Work" }] });
 		const allTasks = result.details?.phases.flatMap(phase => phase.tasks) ?? [];
 		expect(allTasks.map(task => task.status)).toEqual(["completed", "completed", "in_progress"]);
+	});
+
+	it("rejects unsupported keys and does not treat a bare done as complete-all", async () => {
+		const tool = new TodoWriteTool(createSession());
+		expect(() =>
+			validateToolArguments(tool, {
+				type: "toolCall",
+				id: "call-invalid",
+				name: tool.name,
+				arguments: { ops: [{ op: "done", id: "Second" }] },
+			}),
+		).toThrow('Validation failed for tool "todo_write"');
+		expect(() =>
+			validateToolArguments(tool, {
+				type: "toolCall",
+				id: "call-bare",
+				name: tool.name,
+				arguments: { ops: [{ op: "done" }] },
+			}),
+		).toThrow('Validation failed for tool "todo_write"');
+
+		await tool.execute("call-1", {
+			ops: [{ op: "init", list: [{ phase: "Work", items: ["First", "Second"] }] }],
+		});
+		const result = await tool.execute("call-2", { ops: [{ op: "done" }] });
+
+		expect(result.isError).toBe(true);
+		expect(result.details?.phases[0]?.tasks.map(task => task.status)).toEqual(["in_progress", "pending"]);
+		const summary = result.content.find(part => part.type === "text");
+		if (summary?.type !== "text") throw new Error("Expected text summary");
+		expect(summary.text).toContain("Missing task or phase for done operation");
+
+		const slashResult = applyOpsToPhases(result.details?.phases ?? [], [{ op: "done" }]);
+		expect(slashResult.phases[0]?.tasks.map(task => task.status)).toEqual(["completed", "completed"]);
 	});
 
 	it("removes all tasks when rm omits task and phase", async () => {


### PR DESCRIPTION
## What

- Reject unsupported `todo_write` keys before schema normalization can discard them.
- Require `task` or `phase` for tool-level `done` and `drop` operations while preserving the documented slash-command complete-all behavior.
- Add regression coverage for the destructive typo and bare-operation paths.

## Why

An unsupported field such as `id` was silently stripped, turning an intended single-task completion into a bare `done` that completed every task.

Fixes #3640

## Testing

- `bun test packages/coding-agent/test/tools/todo-write.test.ts packages/coding-agent/test/tools/provider-schema-compatibility.test.ts packages/coding-agent/test/eager-todo-prompt.test.ts` (13 pass, 0 fail)
- `bun --cwd=packages/coding-agent run check`
- `git diff --check`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:3db50f542e077e7e85ae2ba7a1116f1ed38ab8c8 reviewer:critic evidence:local-exact-head-review
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
