### PR TITLE
fix(coding-agent): retain deferred shell output

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 
+- Shell commands submitted while the agent is working now survive pending-message and transcript rebuilds, then remain visible in chat with their completed output (#3639).
 - Deferred `agent_end` publication again settles public session readiness before slow extension handlers finish, while retaining exact cancellation leases through queued extension delivery and draining that delivery before session shutdown.
 - Ultragoal validation-batch hydration now fails closed unless deferred and final-close evidence exactly matches a complete authoritative cumulative Git/CI inventory and durable batch tuple. Explicit malformed, partial, unknown, reordered, or stale receipt data is rejected; Git path capture is byte-safe, NUL-delimited, and includes untracked files; incomplete capture conservatively requires computer-control QA; shared settings and tool registries cannot use partial diffs to bypass that suite; validate/checkpoint replacement hydration is identical; and current/replacement receipts are byte-bound to ledger payloads (#3541).
 - Fixture quality gates that complete intermediate Ultragoal stories now write file-backed adversarial artifact proof; skill-state hooks and computer red-team fixtures match the unconditional adversarial path check so #3543 CI stays fail-closed without weakening hydration exactness (#3543).

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -54,7 +54,7 @@ import { getDisplayChangelogEntries } from "../../utils/changelog";
 import { copyToClipboard } from "../../utils/clipboard";
 import { openPath } from "../../utils/open";
 import { setSessionTerminalTitle } from "../../utils/title-generator";
-import { prepareTranscriptRebuild } from "../utils/ui-helpers";
+import { addChatChild, prepareTranscriptRebuild } from "../utils/ui-helpers";
 
 function showMarkdownPanel(ctx: InteractiveModeContext, title: string, markdown: string): void {
 	ctx.chatContainer.addChild(new Spacer(1));
@@ -1180,6 +1180,10 @@ export class CommandController {
 		const bashComponent = this.ctx.bashComponent;
 		if (isDeferred && bashComponent && this.ctx.pendingBashComponents.includes(bashComponent)) {
 			this.ctx.pendingMessagesContainer.detachChild(bashComponent);
+			addChatChild(this.ctx, bashComponent);
+			this.ctx.pendingBashComponents = this.ctx.pendingBashComponents.filter(
+				component => component !== bashComponent,
+			);
 		}
 
 		this.ctx.bashComponent = undefined;

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -261,6 +261,19 @@ function isActiveChatChild(ctx: InteractiveModeContext, component: Component): b
 	return component === ctx.bashComponent || component === ctx.pythonComponent || component === ctx.streamingComponent;
 }
 
+function detachPendingExecutionComponents(ctx: InteractiveModeContext): Component[] {
+	const attached = new Set(ctx.pendingMessagesContainer.children);
+	const components = [...(ctx.pendingBashComponents ?? []), ...(ctx.pendingPythonComponents ?? [])].filter(component =>
+		attached.has(component),
+	);
+	for (const component of components) ctx.pendingMessagesContainer.detachChild(component);
+	return components;
+}
+
+function restorePendingExecutionComponents(ctx: InteractiveModeContext, components: Component[]): void {
+	for (const component of components) ctx.pendingMessagesContainer.addChild(component);
+}
+
 function getChatChildTime(component: Component): number {
 	return chatChildAddedAt.get(component) ?? Date.now();
 }
@@ -899,10 +912,9 @@ export class UiHelpers {
 		// This path is used to rebuild the visible chat transcript (e.g. after custom/debug UI).
 		// Clear existing rendered chat first to avoid duplicating the full session in the container.
 		const preservedChatChildren = options.preserveExistingChat ? this.ctx.chatContainer.children : undefined;
+		const pendingExecutionComponents = detachPendingExecutionComponents(this.ctx);
 		this.ctx.chatContainer.clear();
 		this.ctx.pendingMessagesContainer.clear();
-		this.ctx.pendingBashComponents = [];
-		this.ctx.pendingPythonComponents = [];
 
 		// Reuse a pre-built context when available (e.g. from navigateTree) to avoid a second O(N) walk.
 		const context = prebuiltContext ?? this.ctx.sessionManager.buildSessionContext();
@@ -910,6 +922,7 @@ export class UiHelpers {
 			updateFooter: true,
 			populateHistory: true,
 		});
+		restorePendingExecutionComponents(this.ctx, pendingExecutionComponents);
 
 		// Show compaction info if session was compacted
 		const allEntries = this.ctx.sessionManager.getEntries();
@@ -979,6 +992,7 @@ export class UiHelpers {
 	}
 
 	updatePendingMessagesDisplay(): void {
+		const pendingExecutionComponents = detachPendingExecutionComponents(this.ctx);
 		this.ctx.pendingMessagesContainer.clear();
 		const queuedMessages = this.ctx.session.getQueuedMessages() as QueuedMessages;
 
@@ -1015,6 +1029,7 @@ export class UiHelpers {
 				this.ctx.pendingMessagesContainer.addChild(new TruncatedText(hintText, 1, 0));
 			}
 		}
+		restorePendingExecutionComponents(this.ctx, pendingExecutionComponents);
 	}
 
 	queueCompactionMessage(text: string, mode: "steer" | "followUp", options?: ComposerSubmissionOptions): void {

--- a/packages/coding-agent/test/modes/controllers/bash-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/bash-command.test.ts
@@ -13,26 +13,32 @@ beforeAll(async () => {
 });
 
 describe("shell command display", () => {
-	it("removes a completed deferred command from the pending surface", async () => {
+	it("preserves a running deferred command and moves its result into chat", async () => {
 		const chatContainer = new Container();
 		const pendingMessagesContainer = new Container();
 		const pendingBashComponents: BashExecutionComponent[] = [];
+		const execution = Promise.withResolvers<{
+			exitCode: number;
+			cancelled: boolean;
+			output: string;
+			truncated: boolean;
+		}>();
 		const ui = { requestRender: () => {} } as unknown as TUI;
 		const ctx = {
 			session: {
 				isStreaming: true,
-				executeBash: async () => ({
-					exitCode: 0,
-					cancelled: false,
-					output: "clean",
-					truncated: false,
-				}),
+				executeBash: async () => execution.promise,
+				getQueuedMessages: () => ({ steering: [], followUp: [] }),
 			},
 			ui,
 			chatContainer,
 			pendingMessagesContainer,
 			pendingBashComponents,
 			pendingPythonComponents: [],
+			compactionQueuedMessages: [],
+			keybindings: { getDisplayString: () => "" },
+			sessionManager: { buildSessionContext: () => ({}), getEntries: () => [] },
+			renderSessionContext: () => {},
 			pendingTools: new Map(),
 			bashComponent: undefined,
 			pythonComponent: undefined,
@@ -40,17 +46,24 @@ describe("shell command display", () => {
 			showError: () => {},
 		} as unknown as InteractiveModeContext;
 
-		await new CommandController(ctx).handleBashCommand("printf clean");
+		const command = new CommandController(ctx).handleBashCommand("printf clean");
+		const component = ctx.bashComponent;
+		expect(component).toBeInstanceOf(BashExecutionComponent);
+		expect(pendingMessagesContainer.children).toContain(component!);
+
+		const helpers = new UiHelpers(ctx);
+		helpers.updatePendingMessagesDisplay();
+		helpers.renderInitialMessages();
+		expect(pendingMessagesContainer.children).toContain(component!);
+
+		execution.resolve({ exitCode: 0, cancelled: false, output: "clean", truncated: false });
+		await command;
 
 		expect(pendingMessagesContainer.children).toHaveLength(0);
-		expect(ctx.pendingBashComponents).toHaveLength(1);
-		expect(chatContainer.children).toHaveLength(0);
-		expect(ctx.bashComponent).toBeUndefined();
-
-		new UiHelpers(ctx).flushPendingBashComponents();
-
 		expect(ctx.pendingBashComponents).toHaveLength(0);
 		expect(chatContainer.children).toHaveLength(1);
-		expect(chatContainer.children[0]).toBeInstanceOf(BashExecutionComponent);
+		expect(chatContainer.children[0]).toBe(component!);
+		expect(chatContainer.render(120).join("\n")).toContain("clean");
+		expect(ctx.bashComponent).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## What

- Preserve running shell/Python execution components while pending UI containers are rebuilt.
- Move completed deferred shell commands into chat history instead of disposing them with the pending container.
- Add regression coverage across pending refresh, transcript rebuild, and command completion.

## Why

Clearing the pending container disposed its running child components. Deferred shell commands could then finish without their output ever becoming visible in the transcript.

Fixes #3639

## Testing

- Focused command/pending-render suite (31 pass, 0 fail)
- `bun --cwd=packages/coding-agent run check`
- `bun run check:tools`
- `git diff --check`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:2bbb01605708e4237c160375804b44dfca26dcc7 reviewer:critic evidence:local-exact-head-review
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
