### PR TITLE
fix(utils): surface zero-result glob cancellation

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 
+- Glob scans now reject already-aborted and zero-result cancellations instead of returning a misleading successful empty result.
 - Retryable responses discarded before another fetch attempt now begin body cancellation without blocking retry progress on transport cleanup, releasing buffered response data without consuming responses returned to callers.
 
 ## [0.12.5] - 2026-07-30

--- a/packages/utils/src/glob.ts
+++ b/packages/utils/src/glob.ts
@@ -137,6 +137,10 @@ export async function loadGitignorePatterns(baseDir: string): Promise<string[]> 
  */
 export async function globPaths(patterns: string | string[], options: GlobPathsOptions = {}): Promise<string[]> {
 	const { cwd, exclude, signal, timeoutMs, dot, onlyFiles = true, gitignore } = options;
+	const timeoutSignal = timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined;
+	const combinedSignal =
+		signal && timeoutSignal ? AbortSignal.any([signal, timeoutSignal]) : (signal ?? timeoutSignal);
+	throwIfGlobAborted(combinedSignal);
 
 	// Build exclude list: always exclude .git, exclude node_modules unless pattern references it
 	const patternArray = Array.isArray(patterns) ? patterns : [patterns];
@@ -147,6 +151,7 @@ export async function globPaths(patterns: string | string[], options: GlobPathsO
 
 	if (gitignore) {
 		const gitignorePatterns = await loadGitignorePatterns(cwd ?? getProjectDir());
+		throwIfGlobAborted(combinedSignal);
 		effectiveExclude = [...effectiveExclude, ...gitignorePatterns];
 	}
 
@@ -158,11 +163,6 @@ export async function globPaths(patterns: string | string[], options: GlobPathsO
 	// file; dedupe so a path is returned at most once regardless of pattern overlap.
 	const seen = new Set<string>();
 
-	// Combine timeout and abort signals
-	const timeoutSignal = timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined;
-	const combinedSignal =
-		signal && timeoutSignal ? AbortSignal.any([signal, timeoutSignal]) : (signal ?? timeoutSignal);
-
 	for (const pattern of patternArray) {
 		const glob = new Glob(pattern);
 		const scanOptions = {
@@ -173,11 +173,7 @@ export async function globPaths(patterns: string | string[], options: GlobPathsO
 		};
 
 		for await (const entry of glob.scan(scanOptions)) {
-			if (combinedSignal?.aborted) {
-				const reason = combinedSignal.reason;
-				if (reason instanceof Error) throw reason;
-				throw new DOMException("Aborted", "AbortError");
-			}
+			throwIfGlobAborted(combinedSignal);
 
 			// Check exclusion patterns
 			const normalized = entry.replace(/\\/g, "/");
@@ -190,7 +186,14 @@ export async function globPaths(patterns: string | string[], options: GlobPathsO
 			seen.add(normalized);
 			allResults.push(normalized);
 		}
+		throwIfGlobAborted(combinedSignal);
 	}
 
 	return allResults;
+}
+
+function throwIfGlobAborted(signal: AbortSignal | undefined): void {
+	if (!signal?.aborted) return;
+	if (signal.reason instanceof Error) throw signal.reason;
+	throw new DOMException("Aborted", "AbortError");
 }

--- a/packages/utils/test/glob.test.ts
+++ b/packages/utils/test/glob.test.ts
@@ -19,6 +19,15 @@ afterEach(async () => {
 });
 
 describe("globPaths", () => {
+	it("rejects an already-aborted scan even when the pattern has no matches", async () => {
+		const cwd = await makeTempDir();
+		const controller = new AbortController();
+		const reason = new Error("cancelled");
+		controller.abort(reason);
+
+		await expect(globPaths("definitely-no-match-*", { cwd, signal: controller.signal })).rejects.toBe(reason);
+	});
+
 	it("applies exclude patterns without dropping included files", async () => {
 		const cwd = await makeTempDir();
 		await mkdir(join(cwd, "src"), { recursive: true });


### PR DESCRIPTION
## What

- Start glob timeout/cancellation handling before gitignore loading.
- Check cancellation before scanning and after every scan, including zero-result patterns.
- Reuse the existing abort reason mapping through one local guard.
- Add regression coverage for an already-aborted scan with no matches.

## Why

Cancellation was checked only while yielded entries were processed, so an already-aborted or timed-out scan could resolve successfully with an empty array when the pattern matched nothing.

## Testing

- `bun test packages/utils/test/glob.test.ts`
- `bun test packages/utils/test`
- `bun --cwd=packages/utils run check`
- `git diff --check`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:a9d0549b6afc0b02bda79976872c685651bc2658 reviewer:critic evidence:local-exact-head-review
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
