### PR TITLE
fix(tui): keep padded text within render width

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
+- Truncated text now shrinks horizontal padding when the viewport is narrower than the requested inset, keeping every rendered line within its width contract.
 - Select-list no-match rows now stay within the requested render width instead of wrapping into extra terminal lines after narrow resizes (#3600).
 
 ## [0.12.5] - 2026-07-30

--- a/packages/tui/src/components/truncated-text.ts
+++ b/packages/tui/src/components/truncated-text.ts
@@ -21,9 +21,10 @@ export class TruncatedText implements Component {
 
 	render(width: number): string[] {
 		const result: string[] = [];
+		const safeWidth = Math.max(0, Math.trunc(width));
 
 		// Empty line padded to width
-		const emptyLine = padding(width);
+		const emptyLine = padding(safeWidth);
 
 		// Add vertical padding above
 		for (let i = 0; i < this.#paddingY; i++) {
@@ -31,7 +32,11 @@ export class TruncatedText implements Component {
 		}
 
 		// Calculate available width after horizontal padding
-		const availableWidth = Math.max(1, width - this.#paddingX * 2);
+		const horizontalPadding = Math.max(
+			0,
+			Math.min(Math.trunc(this.#paddingX), Math.floor(Math.max(0, safeWidth - 1) / 2)),
+		);
+		const availableWidth = safeWidth - horizontalPadding * 2;
 
 		// Take only the first line (stop at newline)
 		let singleLineText = this.#text;
@@ -44,8 +49,8 @@ export class TruncatedText implements Component {
 		const displayText = truncateToWidth(singleLineText, availableWidth);
 
 		// Add horizontal padding
-		const leftPadding = padding(this.#paddingX);
-		const rightPadding = padding(this.#paddingX);
+		const leftPadding = padding(horizontalPadding);
+		const rightPadding = padding(horizontalPadding);
 		const lineWithPadding = leftPadding + displayText + rightPadding;
 
 		// Don't pad to full width - avoids trailing spaces when copying

--- a/packages/tui/test/truncated-text.test.ts
+++ b/packages/tui/test/truncated-text.test.ts
@@ -20,6 +20,15 @@ describe("TruncatedText component", () => {
 		expect(visibleLen).toBe(13);
 	});
 
+	it("shrinks horizontal padding to stay within narrow render widths", () => {
+		const text = new TruncatedText("Hello", 2, 0);
+
+		for (const width of [0, 1, 2, 3]) {
+			expect(visibleWidth(text.render(width)[0])).toBeLessThanOrEqual(width);
+		}
+		expect(text.render(2)[0]).toContain("…");
+	});
+
 	it("pads output with vertical padding lines to width", () => {
 		const text = new TruncatedText("Hello", 0, 2);
 		const lines = text.render(40);


### PR DESCRIPTION
## What

- Bound `TruncatedText` output to the renderer's non-negative width.
- Shrink symmetric horizontal padding for narrow viewports while retaining one content cell when possible.
- Add regression coverage for widths smaller than the configured padding.

## Why

When horizontal padding exceeded the available width, the component could render more columns than requested (for example, five columns for a width of one), which could corrupt adjacent TUI layout.

## Testing

- `bun test packages/tui/test/truncated-text.test.ts` (10 pass, 0 fail)
- `bun test packages/tui/test` (970 pass, 6 skip, 0 fail)
- `bun --cwd=packages/tui run check`
- `git diff --check`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:fa3acaa9830c7237aeb456a3d2acd6f96c285253 reviewer:critic evidence:local-exact-head-review
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
