### PR TITLE
fix(coding-agent): retain deferred shell output

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 
 - Settings now requests a repaint after asynchronous GJC bundle and plugin views rebuild, so loaded content and mutation results appear without an extra keypress (#3643).
+- Shell commands submitted while the agent is working now survive pending-message and transcript rebuilds, then remain visible in chat with their completed output (#3639).
 - Deferred `agent_end` publication again settles public session readiness before slow extension handlers finish, while retaining exact cancellation leases through queued extension delivery and draining that delivery before session shutdown.
 - Ultragoal validation-batch hydration now fails closed unless deferred and final-close evidence exactly matches a complete authoritative cumulative Git/CI inventory and durable batch tuple. Explicit malformed, partial, unknown, reordered, or stale receipt data is rejected; Git path capture is byte-safe, NUL-delimited, and includes untracked files; incomplete capture conservatively requires computer-control QA; shared settings and tool registries cannot use partial diffs to bypass that suite; validate/checkpoint replacement hydration is identical; and current/replacement receipts are byte-bound to ledger payloads (#3541).
 - Fixture quality gates that complete intermediate Ultragoal stories now write file-backed adversarial artifact proof; skill-state hooks and computer red-team fixtures match the unconditional adversarial path check so #3543 CI stays fail-closed without weakening hydration exactness (#3543).

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1177,11 +1177,8 @@ export class CommandController {
 			}
 			this.ctx.showError(`Bash command failed: ${error instanceof Error ? error.message : "Unknown error"}`);
 		}
-		const bashComponent = this.ctx.bashComponent;
-		if (isDeferred && bashComponent && this.ctx.pendingBashComponents.includes(bashComponent)) {
-			this.ctx.pendingMessagesContainer.detachChild(bashComponent);
-		}
-
+		// Deferred components stay pending until the next prompt persists their session messages
+		// and moves the same component into the chat transcript.
 		this.ctx.bashComponent = undefined;
 		this.ctx.ui.requestRender();
 	}

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -261,6 +261,19 @@ function isActiveChatChild(ctx: InteractiveModeContext, component: Component): b
 	return component === ctx.bashComponent || component === ctx.pythonComponent || component === ctx.streamingComponent;
 }
 
+function detachPendingExecutionComponents(ctx: InteractiveModeContext): Component[] {
+	const attached = new Set(ctx.pendingMessagesContainer.children);
+	const components = [...(ctx.pendingBashComponents ?? []), ...(ctx.pendingPythonComponents ?? [])].filter(component =>
+		attached.has(component),
+	);
+	for (const component of components) ctx.pendingMessagesContainer.detachChild(component);
+	return components;
+}
+
+function restorePendingExecutionComponents(ctx: InteractiveModeContext, components: Component[]): void {
+	for (const component of components) ctx.pendingMessagesContainer.addChild(component);
+}
+
 function getChatChildTime(component: Component): number {
 	return chatChildAddedAt.get(component) ?? Date.now();
 }
@@ -899,10 +912,9 @@ export class UiHelpers {
 		// This path is used to rebuild the visible chat transcript (e.g. after custom/debug UI).
 		// Clear existing rendered chat first to avoid duplicating the full session in the container.
 		const preservedChatChildren = options.preserveExistingChat ? this.ctx.chatContainer.children : undefined;
+		const pendingExecutionComponents = detachPendingExecutionComponents(this.ctx);
 		this.ctx.chatContainer.clear();
 		this.ctx.pendingMessagesContainer.clear();
-		this.ctx.pendingBashComponents = [];
-		this.ctx.pendingPythonComponents = [];
 
 		// Reuse a pre-built context when available (e.g. from navigateTree) to avoid a second O(N) walk.
 		const context = prebuiltContext ?? this.ctx.sessionManager.buildSessionContext();
@@ -910,6 +922,7 @@ export class UiHelpers {
 			updateFooter: true,
 			populateHistory: true,
 		});
+		restorePendingExecutionComponents(this.ctx, pendingExecutionComponents);
 
 		// Show compaction info if session was compacted
 		const allEntries = this.ctx.sessionManager.getEntries();
@@ -979,6 +992,7 @@ export class UiHelpers {
 	}
 
 	updatePendingMessagesDisplay(): void {
+		const pendingExecutionComponents = detachPendingExecutionComponents(this.ctx);
 		this.ctx.pendingMessagesContainer.clear();
 		const queuedMessages = this.ctx.session.getQueuedMessages() as QueuedMessages;
 
@@ -1015,6 +1029,7 @@ export class UiHelpers {
 				this.ctx.pendingMessagesContainer.addChild(new TruncatedText(hintText, 1, 0));
 			}
 		}
+		restorePendingExecutionComponents(this.ctx, pendingExecutionComponents);
 	}
 
 	queueCompactionMessage(text: string, mode: "steer" | "followUp", options?: ComposerSubmissionOptions): void {

--- a/packages/coding-agent/test/modes/controllers/bash-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/bash-command.test.ts
@@ -13,26 +13,32 @@ beforeAll(async () => {
 });
 
 describe("shell command display", () => {
-	it("removes a completed deferred command from the pending surface", async () => {
+	it("preserves a deferred command through running and completed transcript rebuilds", async () => {
 		const chatContainer = new Container();
 		const pendingMessagesContainer = new Container();
 		const pendingBashComponents: BashExecutionComponent[] = [];
+		const execution = Promise.withResolvers<{
+			exitCode: number;
+			cancelled: boolean;
+			output: string;
+			truncated: boolean;
+		}>();
 		const ui = { requestRender: () => {} } as unknown as TUI;
 		const ctx = {
 			session: {
 				isStreaming: true,
-				executeBash: async () => ({
-					exitCode: 0,
-					cancelled: false,
-					output: "clean",
-					truncated: false,
-				}),
+				executeBash: async () => execution.promise,
+				getQueuedMessages: () => ({ steering: [], followUp: [] }),
 			},
 			ui,
 			chatContainer,
 			pendingMessagesContainer,
 			pendingBashComponents,
 			pendingPythonComponents: [],
+			compactionQueuedMessages: [],
+			keybindings: { getDisplayString: () => "" },
+			sessionManager: { buildSessionContext: () => ({}), getEntries: () => [] },
+			renderSessionContext: () => {},
 			pendingTools: new Map(),
 			bashComponent: undefined,
 			pythonComponent: undefined,
@@ -40,17 +46,30 @@ describe("shell command display", () => {
 			showError: () => {},
 		} as unknown as InteractiveModeContext;
 
-		await new CommandController(ctx).handleBashCommand("printf clean");
+		const command = new CommandController(ctx).handleBashCommand("printf clean");
+		const component = ctx.bashComponent;
+		expect(component).toBeInstanceOf(BashExecutionComponent);
+		expect(pendingMessagesContainer.children).toContain(component!);
 
-		expect(pendingMessagesContainer.children).toHaveLength(0);
-		expect(ctx.pendingBashComponents).toHaveLength(1);
+		const helpers = new UiHelpers(ctx);
+		helpers.updatePendingMessagesDisplay();
+		helpers.renderInitialMessages();
+		expect(pendingMessagesContainer.children).toContain(component!);
+
+		execution.resolve({ exitCode: 0, cancelled: false, output: "clean", truncated: false });
+		await command;
+
+		helpers.renderInitialMessages();
+		expect(pendingMessagesContainer.children).toEqual([component!]);
+		expect(pendingMessagesContainer.render(120).join("\n")).toContain("clean");
+		expect(ctx.pendingBashComponents).toEqual([component!]);
 		expect(chatContainer.children).toHaveLength(0);
-		expect(ctx.bashComponent).toBeUndefined();
 
-		new UiHelpers(ctx).flushPendingBashComponents();
-
+		helpers.flushPendingBashComponents();
+		expect(pendingMessagesContainer.children).toHaveLength(0);
 		expect(ctx.pendingBashComponents).toHaveLength(0);
-		expect(chatContainer.children).toHaveLength(1);
-		expect(chatContainer.children[0]).toBeInstanceOf(BashExecutionComponent);
+		expect(chatContainer.children).toEqual([component!]);
+		expect(chatContainer.render(120).join("\n")).toContain("clean");
+		expect(ctx.bashComponent).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## What

- Detach and restore live shell/Python components around pending-message and transcript rebuilds instead of disposing them.
- Keep a completed deferred shell component in tracked pending ownership until the next prompt flushes the queued session message and moves that same component into chat.
- Add regression coverage for rebuilds while running, after completion, and during the final pending-to-chat flush.

## Why

A deferred shell command could be disposed by a UI rebuild and finish without visible output. Moving it into chat immediately on completion was also insufficient because the session message is not persisted until the next prompt, so another transcript rebuild could still erase it.

Fixes #3639
Supersedes #3652, whose code had no owner-reviewed P0/P1 but was closed after its stale base could no longer produce a clean merge. This replacement is rebased and also closes the post-completion rebuild gap found during fresh exact-head review.

## Testing

- `bun test packages/coding-agent/test/modes/controllers/bash-command.test.ts` (1 pass, 0 fail, 12 assertions)
- `bun --cwd=packages/coding-agent run check`
- `git diff --check`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:d564f7ef86392698dee4ecad182110a0e4d93878 reviewer:critic evidence:local-exact-head-review
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
