### PR TITLE
fix(sdk): hide console windows for GUI-embedded session hosts on Windows

### DIFF
--- a/packages/coding-agent/src/sdk/broker/ensure.ts
+++ b/packages/coding-agent/src/sdk/broker/ensure.ts
@@ -1,4 +1,5 @@
 import { type ChildProcess, spawn } from "node:child_process";
+import { spawnDetachedChild } from "../../utils/detached-spawn";
 import { type BrokerDiscovery, brokerProcessIncarnation, readBrokerDiscovery } from "./discovery";
 import { resolveSdkInternalSpawnCommand, type SdkInternalSpawnCommand } from "./runtime";
 export interface EnsureBrokerSettings {
@@ -245,9 +246,10 @@ async function ensureBrokerOnce(settings: EnsureBrokerSettings, initiator: Ensur
 	}
 
 	const command = resolveSdkInternalSpawnCommand("broker-internal");
-	const child = spawn(command.file, [...command.args, "--agent-dir", settings.agentDir], {
-		detached: true,
-		stdio: "ignore",
+	// spawnDetachedChild keeps the detached broker console-less on Windows; Bun's
+	// node:child_process ignores windowsHide for detached children and would
+	// otherwise flash a new console window on every broker spawn.
+	const child = spawnDetachedChild(command.file, [...command.args, "--agent-dir", settings.agentDir], {
 		env: brokerSpawnEnvironment(command, settings.env),
 		...(command.kind === "bun-source" ? { cwd: command.cwd } : {}),
 	});

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -1,4 +1,5 @@
-import { type ChildProcess, spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+import { spawnDetachedChild } from "../../utils/detached-spawn";
 import { createHash, randomUUID } from "node:crypto";
 import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
@@ -3134,10 +3135,15 @@ async function executeLifecycleResponse(
 		let spawnedAuthority: EffectMarker | undefined;
 		try {
 			const cmd = command(broker);
-			const spawned = spawn(cmd.file, cmd.args, {
+			// hiddenConsole (not detached) is what actually suppresses the console
+			// windows: the session host runs shell tool calls in-process through the
+			// compiled @gajae-code/natives executor, and those children inherit the
+			// host's console. A detached host has none, so each one allocates a fresh
+			// visible console. The host's parent is this long-lived broker, so
+			// dropping detached does not shorten its life across a client quit.
+			const spawned = spawnDetachedChild(cmd.file, cmd.args, {
 				cwd: launch.cwd,
-				detached: true,
-				stdio: "ignore",
+				hiddenConsole: true,
 				env: {
 					...("kind" in cmd ? cmd.env : process.env),
 					GJC_AGENT_DIR: broker.settings.agentDir,

--- a/packages/coding-agent/src/utils/detached-spawn.ts
+++ b/packages/coding-agent/src/utils/detached-spawn.ts
@@ -1,0 +1,97 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+
+export interface DetachedSpawnOptions {
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
+	/**
+	 * win32-only. Spawn the child so it owns a *hidden* console instead of no
+	 * console at all, and drop `detached` to get it.
+	 *
+	 * Win32 `CreateProcess` treats `DETACHED_PROCESS` and `CREATE_NO_WINDOW` as
+	 * mutually exclusive and `DETACHED_PROCESS` wins, so a detached child has no
+	 * console whatsoever -- and every console-subsystem grandchild it later
+	 * spawns must allocate a fresh **visible** one. That is the real source of
+	 * the console windows: not the spawn itself (a console-less process shows
+	 * nothing), but the shell children the session host runs afterwards through
+	 * `@gajae-code/natives`, which is compiled and cannot pass its own flags.
+	 *
+	 * Setting this omits `detached` so `windowsHide` can take effect as
+	 * `CREATE_NO_WINDOW`: the child gets a hidden console that its own console
+	 * children inherit, and nothing is ever displayed. Verified empirically --
+	 * a host spawned `detached + windowsHide` has no conhost and its children
+	 * allocate visible consoles; spawned `windowsHide` alone it has a hidden
+	 * conhost and its children inherit it.
+	 *
+	 * Only for children whose parent outlives them (the broker's session hosts).
+	 * Do NOT set it for the broker itself, which must survive the CLI/Electron
+	 * process that spawns it.
+	 */
+	hiddenConsole?: boolean;
+}
+
+/**
+ * Spawns a child that never displays a console window.
+ *
+ * On Windows under Bun, `node:child_process` ignores `windowsHide: true` for
+ * `detached: true` children, so these spawns route through `Bun.spawn` behind a
+ * minimal ChildProcess-shaped facade exposing exactly the surface the callers
+ * use: `pid`, `exitCode`, `signalCode`, `kill`, `unref`, and the
+ * `error`/`exit`/`close` events.
+ *
+ * Note that `Bun.spawn` does not rescue `windowsHide` for a *detached* child
+ * either -- `DETACHED_PROCESS` still wins. Suppressing the windows that shell
+ * tool calls open requires `hiddenConsole`, which trades `detached` away for an
+ * inheritable hidden console. See `DetachedSpawnOptions.hiddenConsole`.
+ *
+ * Spawn failures (e.g. a missing executable) throw synchronously, matching
+ * Bun's `node:child_process` behavior that existing callers rely on.
+ *
+ * On other platforms (and non-Bun runtimes) this defers to
+ * `node:child_process.spawn` with `detached: true` and `windowsHide: true`,
+ * preserving prior behavior: there is no console to inherit off Windows, so
+ * `hiddenConsole` is ignored there and process-group semantics stay unchanged.
+ */
+export function spawnDetachedChild(file: string, args: string[], options: DetachedSpawnOptions = {}): ChildProcess {
+	if (process.platform !== "win32" || typeof Bun === "undefined") {
+		return spawn(file, args, {
+			detached: true,
+			stdio: ["ignore", "ignore", "ignore"],
+			// A detached console-subsystem child would otherwise flash a cmd window on Windows under Node.
+			windowsHide: true,
+			env: options.env,
+			...(options.cwd ? { cwd: options.cwd } : {}),
+		});
+	}
+	const proc = Bun.spawn([file, ...args], {
+		stdio: ["ignore", "ignore", "ignore"] as never,
+		// Mutually exclusive on Win32: detached wins and costs the hidden console.
+		...(options.hiddenConsole ? {} : { detached: true }),
+		windowsHide: true,
+		env: options.env as Record<string, string | undefined> | undefined,
+		...(options.cwd ? { cwd: options.cwd } : {}),
+	});
+	const emitter = new EventEmitter();
+	const emitExit = (): void => {
+		emitter.emit("exit", proc.exitCode, proc.signalCode);
+		emitter.emit("close", proc.exitCode, proc.signalCode);
+	};
+	proc.exited.then(emitExit, emitExit);
+	Object.defineProperties(emitter, {
+		pid: { get: () => proc.pid },
+		exitCode: { get: () => proc.exitCode },
+		signalCode: { get: () => proc.signalCode },
+	});
+	const facade = emitter as unknown as ChildProcess & {
+		kill: (signal?: NodeJS.Signals | number) => boolean;
+		unref: () => void;
+	};
+	facade.kill = (signal?: NodeJS.Signals | number): boolean => {
+		proc.kill(signal as never);
+		return true;
+	};
+	facade.unref = (): void => {
+		proc.unref();
+	};
+	return facade;
+}


### PR DESCRIPTION
## Hide the console windows GUI-embedded sessions flash on Windows (`hiddenConsole` for session hosts)

### Symptom

Under a GUI parent (Electron), every `bash` tool call from a GJC session flashes a
visible `cmd`/conhost window on Windows. A terminal (TUI) install of the same
build shows none. Tracked in #2537.

### Mechanism (this is the part #2561 got wrong)

`DETACHED_PROCESS` and `CREATE_NO_WINDOW` are **mutually exclusive** in Win32
`CreateProcess`, and `DETACHED_PROCESS` wins. This holds **regardless of the
runtime issuing the spawn** — `node:child_process` and `Bun.spawn` behave
identically (the Node half is nodejs/node#21825).

The consequence:

- A **detached** child gets **no console at all**, so it displays nothing itself
  — `windowsHide` on a detached spawn has nothing to hide.
- But every **console-subsystem grandchild** that console-less process later
  spawns must allocate a **fresh, visible** console.
- Each `bash` tool call is such a grandchild: it is spawned from inside the
  session host by `@gajae-code/natives`, a **compiled in-process** shell
  executor that cannot be handed creation flags.

So the host's own console is the only available lever. Measured against real
processes (a process with a console — even a hidden one — has a `conhost.exe`):

| Session host spawned with           | Host's console        | Its console children              |
| ----------------------------------- | --------------------- | --------------------------------- |
| `detached: true` + `windowsHide`    | **none** (no conhost) | allocate their own — **visible**  |
| `windowsHide`, **no** `detached`    | **hidden** console    | **inherit it** — nothing shown    |

### Why #2561's facade alone would not have fixed this

[#2561](https://github.com/Yeachan-Heo/gajae-code/pull/2561) added a
`spawnDetachedChild` facade but kept `detached: true`, producing the same
console-less host — so the popups would have remained. The facade is necessary
scaffolding; the missing half is spawning the **session host** with
`windowsHide` and **without** `detached`. This PR is deliberately narrow (the
facade + its two call sites, nothing else) so it can be judged on that mechanism.

### The change

`src/utils/detached-spawn.ts` — a minimal `ChildProcess`-shaped facade over
`Bun.spawn` (Bun ignores `windowsHide` for detached children under
`node:child_process`), with a `hiddenConsole` option that omits `detached` so
`windowsHide` lands as `CREATE_NO_WINDOW`.

- **Session host** (`lifecycle.ts`) → `hiddenConsole: true`. Gets a hidden
  console its shell children inherit.
- **Broker** (`ensure.ts`) → keeps `detached` (it must outlive the CLI/Electron
  process that spawned it). A detached broker is console-less and already shows
  nothing.

### Lifetime trade (arguably a fix in its own right)

Dropping `detached` on the session host means it stops being its own process
group and now **dies with the broker** instead of orphaning. Because the host's
parent *is* the long-lived broker, it still survives a client disconnect. This
removes a real defect: orphaned `sdk session-host-internal` processes surviving
client quit and holding working-tree handles (observed downstream).

Off Windows and on non-Bun runtimes the facade defers to
`node:child_process.spawn` with `detached: true` + `windowsHide: true`,
preserving prior behavior; `hiddenConsole` is ignored there.
