### PR TITLE
fix(tui): repair reentrant SDK callbacks and pipeline ownership

### DIFF
--- a/crates/pi-natives/src/sdk.rs
+++ b/crates/pi-natives/src/sdk.rs
@@ -324,8 +324,8 @@ impl NotificationServer {
 			let mut rx = handle
 				.take_reply_receiver()
 				.ok_or_else(|| Error::from_reason("notification reply receiver unavailable"))?;
-			let task = napi::tokio::spawn(async move {
-				while let Some(reply) = rx.recv().await {
+			let task = napi::tokio::task::spawn_blocking(move || {
+				while let Some(reply) = rx.blocking_recv() {
 					let event = ReplyEvent {
 						id:               reply.reply.id,
 						answer_json:      serde_json::to_string(&reply.reply.answer)
@@ -333,7 +333,9 @@ impl NotificationServer {
 						idempotency_key:  reply.reply.idempotency_key,
 						reply_receipt_id: reply.reply_receipt_id,
 					};
-					tsfn.call(Ok(event), ThreadsafeFunctionCallMode::NonBlocking);
+					if tsfn.call(Ok(event), ThreadsafeFunctionCallMode::Blocking) != napi::Status::Ok {
+						break;
+					}
 				}
 			});
 			self.pump_tasks.lock().push(task);
@@ -343,9 +345,9 @@ impl NotificationServer {
 		let inbound_tsfn = self.on_inbound.lock().take();
 		let inbound_rx = handle.take_inbound_receiver();
 		if let (Some(tsfn), Some(mut rx)) = (inbound_tsfn, inbound_rx) {
-			let task = napi::tokio::spawn(async move {
+			let task = napi::tokio::task::spawn_blocking(move || {
 				while let Some(gjc_sdk::server::InboundMessage { connection_id, message: msg }) =
-					rx.recv().await
+					rx.blocking_recv()
 				{
 					let event = match msg {
 						ClientMessage::UserMessage(u) => InboundEvent {
@@ -413,7 +415,9 @@ impl NotificationServer {
 						},
 						_ => continue,
 					};
-					tsfn.call(Ok(event), ThreadsafeFunctionCallMode::NonBlocking);
+					if tsfn.call(Ok(event), ThreadsafeFunctionCallMode::Blocking) != napi::Status::Ok {
+						break;
+					}
 				}
 			});
 			self.pump_tasks.lock().push(task);

--- a/packages/coding-agent/test/issue-3761-symlinked-notifications-activation.test.ts
+++ b/packages/coding-agent/test/issue-3761-symlinked-notifications-activation.test.ts
@@ -187,6 +187,13 @@ describe("issue #3761 symlinked notifications activation", () => {
 			chatId: CHAT_ID,
 			tokenFingerprint: tokenFingerprint(BOT_TOKEN),
 		});
+		// Readiness can publish while the parent still holds the transition
+		// steal lock; #3761 requires that the steal marker is released, not
+		// that the two events are same-tick. Bound the drain so CI load does
+		// not fail the contract while still catching a stuck steal.
+		for (let i = 0; i < 50 && fs.existsSync(paths.steal); i++) {
+			await Bun.sleep(20);
+		}
 		expect(fs.existsSync(paths.steal)).toBe(false);
 		expect(fs.existsSync(paths.lock)).toBe(true);
 	});


### PR DESCRIPTION
## Summary
- preserve bounded NotificationServer inbound/reply delivery during synchronous host reentry
- refresh valid live pipeline process-group anchors before failing closed
- keep Bash head/tail stripping enabled and disabled behavior unchanged

## Verification
- NotificationServer focused reentrancy: 5/5 passes
- BashTool head/tail stripping: 5/5 passes
- cargo test -p pi-shell shell --lib: 51 passed
- bun --cwd=packages/natives run check:types: passed
- native build: passed

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*