### PR TITLE
fix(utils): clamp retry delays at the timer boundary

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `fetchWithRetry` now normalizes every response and network-error delay immediately before scheduling, including clamping values above the platform timer ceiling so large backoffs cannot collapse into an immediate retry.
+
 ## [0.12.6] - 2026-07-31
 ### Fixed
 

--- a/packages/utils/src/fetch-retry.ts
+++ b/packages/utils/src/fetch-retry.ts
@@ -81,13 +81,16 @@ export interface FetchWithRetryOptions extends RequestInit {
 	/**
 	 * Per-delay cap. Server-provided `Retry-After` hints exceeding this return
 	 * the current response immediately — caller deals with the `!response.ok`.
-	 * Default `60_000`.
+	 * Scheduled values are also capped at the platform timer ceiling. Default
+	 * `60_000`.
 	 */
 	maxDelayMs?: number;
 	/**
 	 * Fallback delay schedule when no server hint is present. Number, array
 	 * (indexed by attempt, clamped to last), or function. Default exponential
-	 * `500ms * 2 ** attempt` capped at `maxDelayMs`.
+	 * `500ms * 2 ** attempt` capped at `maxDelayMs` and the platform timer
+	 * ceiling. Values that remain negative or non-finite after capping retry
+	 * immediately.
 	 */
 	defaultDelayMs?: number | readonly number[] | ((attempt: number) => number);
 	/**
@@ -106,6 +109,9 @@ export interface FetchWithRetryOptions extends RequestInit {
 
 const DEFAULT_MAX_DELAY_MS = 60_000;
 const DEFAULT_MAX_ATTEMPTS = 5;
+// Node-compatible timers coerce larger delays to 1 ms. Bun follows the same
+// signed 32-bit boundary, so every scheduler input must stay at or below it.
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 /**
  * Fetch with bounded retries and sensible defaults. Retries on any
@@ -142,7 +148,8 @@ export async function fetchWithRetry(
 			if (signal?.aborted) throw new Error("Request was aborted");
 			const wrapped = wrapNetworkError(error);
 			if (attempt + 1 >= maxAttempts) throw wrapped;
-			await scheduler.wait(resolveDefaultDelay(defaultDelayMs, attempt, maxDelayMs), { signal });
+			const delayMs = normalizeRetryDelay(resolveDefaultDelay(defaultDelayMs, attempt), maxDelayMs);
+			await scheduler.wait(delayMs, { signal });
 			continue;
 		}
 
@@ -152,7 +159,7 @@ export async function fetchWithRetry(
 		const hint = extractRetryHint(response, await response.clone().text());
 		if (hint !== undefined && hint > maxDelayMs) return response;
 
-		const delayMs = Math.min(hint ?? resolveDefaultDelay(defaultDelayMs, attempt, maxDelayMs), maxDelayMs);
+		const delayMs = normalizeRetryDelay(hint ?? resolveDefaultDelay(defaultDelayMs, attempt), maxDelayMs);
 		void response.body?.cancel().catch(() => undefined);
 		await scheduler.wait(delayMs, { signal });
 	}
@@ -184,15 +191,16 @@ function wrapNetworkError(error: unknown): Error {
 	return new Error(String(error));
 }
 
-function resolveDefaultDelay(
-	option: FetchWithRetryOptions["defaultDelayMs"],
-	attempt: number,
-	maxDelayMs: number,
-): number {
-	if (option === undefined) return Math.min(500 * 2 ** attempt, maxDelayMs);
-	if (typeof option === "number") return Math.min(option, maxDelayMs);
-	if (typeof option === "function") return Math.min(option(attempt), maxDelayMs);
-	return Math.min(option[Math.min(attempt, option.length - 1)] ?? 0, maxDelayMs);
+function resolveDefaultDelay(option: FetchWithRetryOptions["defaultDelayMs"], attempt: number): number {
+	if (option === undefined) return 500 * 2 ** attempt;
+	if (typeof option === "number") return option;
+	if (typeof option === "function") return option(attempt);
+	return option[Math.min(attempt, option.length - 1)] ?? 0;
+}
+
+function normalizeRetryDelay(delayMs: number, maxDelayMs: number): number {
+	const cappedDelayMs = Math.min(delayMs, maxDelayMs, MAX_TIMER_DELAY_MS);
+	return Number.isFinite(cappedDelayMs) && cappedDelayMs >= 0 ? cappedDelayMs : 0;
 }
 
 /**

--- a/packages/utils/test/fetch-retry.test.ts
+++ b/packages/utils/test/fetch-retry.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it, vi } from "bun:test";
-import { fetchWithRetry } from "../src/fetch-retry";
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { scheduler } from "node:timers/promises";
+import { type FetchWithRetryOptions, fetchWithRetry } from "../src/fetch-retry";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
 
 describe("fetchWithRetry", () => {
+	const maxTimerDelayMs = 2_147_483_647;
+
 	it("routes requests through the `fetch` override when provided", async () => {
 		const calls: Array<{ input: string | URL | Request; init: RequestInit | undefined }> = [];
 		const customFetch = async (input: string | URL | Request, init?: RequestInit) => {
@@ -178,5 +185,157 @@ describe("fetchWithRetry", () => {
 		expect(response).toBe(finalResponse);
 		expect(response.bodyUsed).toBe(false);
 		expect(await response.text()).toBe("Please retry in 2s");
+	});
+
+	it.each([
+		["negative numeric", -1, 0],
+		["NaN numeric", Number.NaN, 0],
+		["negative-infinite numeric", Number.NEGATIVE_INFINITY, 0],
+		["negative function result", () => -1, 0],
+		["NaN function result", () => Number.NaN, 0],
+		["negative-infinite function result", () => Number.NEGATIVE_INFINITY, 0],
+		["negative array entry", [-1], 0],
+		["NaN array entry", [Number.NaN], 0],
+		["negative-infinite array entry", [Number.NEGATIVE_INFINITY], 0],
+		["positive-infinite numeric capped to the maximum", Number.POSITIVE_INFINITY, 60_000],
+		["positive-infinite function result capped to the maximum", () => Number.POSITIVE_INFINITY, 60_000],
+		["positive-infinite array entry capped to the maximum", [Number.POSITIVE_INFINITY], 60_000],
+		["finite numeric", 7, 7],
+		["finite function result", () => 11, 11],
+		["finite array entry", [13], 13],
+	] satisfies Array<
+		[string, NonNullable<FetchWithRetryOptions["defaultDelayMs"]>, number]
+	>)("resolves %s before reaching the scheduler", async (_label, defaultDelayMs, expectedDelayMs) => {
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		let attempt = 0;
+
+		const response = await fetchWithRetry("https://example.invalid/delay", {
+			fetch: async () => {
+				attempt += 1;
+				return new Response("", { status: attempt === 1 ? 503 : 200 });
+			},
+			defaultDelayMs,
+			maxAttempts: 2,
+		});
+
+		expect(response.status).toBe(200);
+		expect(waitSpy).toHaveBeenCalledTimes(1);
+		expect(waitSpy).toHaveBeenCalledWith(expectedDelayMs, { signal: undefined });
+	});
+
+	it.each([
+		["negative", -1, 0],
+		["NaN", Number.NaN, 0],
+		["negative-infinite", Number.NEGATIVE_INFINITY, 0],
+		["positive-infinite", Number.POSITIVE_INFINITY, 7],
+	] as const)("normalizes a %s response-path maximum at the scheduler boundary", async (_label, maxDelayMs, expected) => {
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		let attempt = 0;
+
+		const response = await fetchWithRetry("https://example.invalid/response-cap", {
+			fetch: async () => {
+				attempt += 1;
+				return new Response("", { status: attempt === 1 ? 503 : 200 });
+			},
+			defaultDelayMs: 7,
+			maxAttempts: 2,
+			maxDelayMs,
+		});
+
+		expect(response.status).toBe(200);
+		expect(waitSpy).toHaveBeenCalledWith(expected, { signal: undefined });
+	});
+
+	it("normalizes a hinted response delay after applying an invalid maximum", async () => {
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		let attempt = 0;
+
+		const response = await fetchWithRetry("https://example.invalid/hint-cap", {
+			fetch: async () => {
+				attempt += 1;
+				return attempt === 1
+					? new Response("", { status: 429, headers: { "retry-after": "1" } })
+					: new Response("done", { status: 200 });
+			},
+			maxAttempts: 2,
+			maxDelayMs: Number.NaN,
+		});
+
+		expect(response.status).toBe(200);
+		expect(waitSpy).toHaveBeenCalledWith(0, { signal: undefined });
+	});
+
+	it.each([
+		["negative", -1, 0],
+		["NaN", Number.NaN, 0],
+		["negative-infinite", Number.NEGATIVE_INFINITY, 0],
+		["positive-infinite", Number.POSITIVE_INFINITY, 7],
+	] as const)("normalizes a %s network-error maximum at the scheduler boundary", async (_label, maxDelayMs, expected) => {
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		let attempt = 0;
+
+		const response = await fetchWithRetry("https://example.invalid/network-cap", {
+			fetch: async () => {
+				attempt += 1;
+				if (attempt === 1) throw new Error("temporary network failure");
+				return new Response("done", { status: 200 });
+			},
+			defaultDelayMs: 7,
+			maxAttempts: 2,
+			maxDelayMs,
+		});
+
+		expect(response.status).toBe(200);
+		expect(waitSpy).toHaveBeenCalledWith(expected, { signal: undefined });
+	});
+
+	it.each([
+		["response", maxTimerDelayMs, maxTimerDelayMs],
+		["response", maxTimerDelayMs + 1, maxTimerDelayMs],
+		["response", 3_000_000_000, maxTimerDelayMs],
+		["network", maxTimerDelayMs, maxTimerDelayMs],
+		["network", maxTimerDelayMs + 1, maxTimerDelayMs],
+		["network", 3_000_000_000, maxTimerDelayMs],
+	] as const)("keeps the %s retry delay within the timer ceiling for %d ms", async (path, configuredDelayMs, expectedDelayMs) => {
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		let attempt = 0;
+
+		const response = await fetchWithRetry("https://example.invalid/timer-ceiling", {
+			fetch: async () => {
+				attempt += 1;
+				if (attempt === 1) {
+					if (path === "network") throw new Error("temporary network failure");
+					return new Response("", { status: 503 });
+				}
+				return new Response("done", { status: 200 });
+			},
+			defaultDelayMs: configuredDelayMs,
+			maxAttempts: 2,
+			maxDelayMs: configuredDelayMs,
+		});
+
+		expect(response.status).toBe(200);
+		expect(waitSpy).toHaveBeenCalledTimes(1);
+		expect(waitSpy).toHaveBeenCalledWith(expectedDelayMs, { signal: undefined });
+	});
+
+	it("clamps a server retry hint at the timer ceiling", async () => {
+		const waitSpy = vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		let attempt = 0;
+
+		const response = await fetchWithRetry("https://example.invalid/hint-timer-ceiling", {
+			fetch: async () => {
+				attempt += 1;
+				return attempt === 1
+					? new Response("", { status: 429, headers: { "retry-after": "3000000" } })
+					: new Response("done", { status: 200 });
+			},
+			maxAttempts: 2,
+			maxDelayMs: 3_000_000_000,
+		});
+
+		expect(response.status).toBe(200);
+		expect(waitSpy).toHaveBeenCalledTimes(1);
+		expect(waitSpy).toHaveBeenCalledWith(maxTimerDelayMs, { signal: undefined });
 	});
 });


### PR DESCRIPTION
## What

- Normalize every caller-provided retry delay immediately before the response and network-error scheduler boundaries.
- Clamp scheduled delays to the signed 32-bit timer ceiling (`2_147_483_647` ms), including server hints that are otherwise allowed by `maxDelayMs`.
- Add deterministic boundary, overflow, invalid-input, and server-hint regression coverage.

## Why

This is the corrected successor to #3612. Node-compatible timers, including Bun's scheduler, coerce delays above `2_147_483_647` ms to roughly 1 ms, so a large finite backoff could become an immediate retry. The original contributor's authorship is preserved; this successor adds the maintainer-requested scheduler-boundary clamp and upper-bound coverage.

## Testing

- `bun test packages/utils/test/fetch-retry.test.ts` — 39 passed, 0 failed (110 assertions)
- `bun --cwd=packages/utils run check` — passed
- `git diff --check origin/dev...HEAD` — passed
- Live Bun probe confirmed `scheduler.wait(2_147_483_648)` overflows to an approximately 1 ms timer without this clamp.
- `bun check` reached and passed repository Biome/type/declaration/Rust-scope checks, then stopped at the pre-existing `telegram-daemon-generation-guard` native-authority digest mismatch. This branch changes only `packages/utils/{src,test,CHANGELOG.md}`.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:6b3a1df47e6ffc175d4769a066b2644513e8378d reviewer:critic evidence:focused-fetch-retry-39-pass-utils-check
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (blocked by the unchanged `dev` Telegram generation-guard digest mismatch described above)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
