### PR TITLE
fix(ai): recover Codex SSE tool-choice rejections

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Codex named-tool rejections delivered as HTTP 200 SSE `invalid_request_error` events now trigger the same clean one-shot fallback as HTTP 400 responses, retrying without the forced `tool_choice` before any output is emitted (#3669).
+
 ## [0.12.6] - 2026-07-31
 
 ## [0.12.5] - 2026-07-30

--- a/packages/ai/src/utils/tool-choice-capability.ts
+++ b/packages/ai/src/utils/tool-choice-capability.ts
@@ -165,7 +165,13 @@ export function resolveToolChoice(
 
 /** Detects provider errors indicating forced tool_choice is unsupported. */
 export function isForcedToolChoiceUnsupportedError(error: unknown, sentForcedToolChoice: boolean): boolean {
-	if (!sentForcedToolChoice || extractHttpStatusFromError(error) !== 400) return false;
+	const status = extractHttpStatusFromError(error);
+	if (
+		!sentForcedToolChoice ||
+		(status !== 400 && (status !== undefined || extractProviderErrorCode(error) !== "invalid_request_error"))
+	) {
+		return false;
+	}
 	const message = errorMessage(error);
 	return (
 		// `by <something>` continuations ("not supported by billing") describe a
@@ -178,6 +184,12 @@ export function isForcedToolChoiceUnsupportedError(error: unknown, sentForcedToo
 		/does\s+not\s+support\s+forced\s+tool[_\s-]?choices?/is.test(message) ||
 		/tool[_\s-]?choices?\s+['"`][^'"`\r\n]+['"`]\s+not\s+found\s+in\s+['"`]tools['"`]\s+parameter\b/is.test(message)
 	);
+}
+
+function extractProviderErrorCode(error: unknown): string | undefined {
+	if (!error || typeof error !== "object") return undefined;
+	const code = (error as { code?: unknown }).code;
+	return typeof code === "string" ? code : undefined;
 }
 
 export type { ToolChoiceCompat, ToolChoiceSupport, ToolChoiceSupportSource } from "../types";

--- a/packages/ai/test/openai-codex-responses-tool-choice.test.ts
+++ b/packages/ai/test/openai-codex-responses-tool-choice.test.ts
@@ -140,6 +140,46 @@ describe("OpenAI Codex responses tool choice capability", () => {
 		expectSingleCleanFallbackEvents(events);
 	});
 
+	it("retries once when a Codex SSE error rejects a named tool choice", async () => {
+		const bodies: Record<string, unknown>[] = [];
+		const testModel = model({ id: "runtime-codex-sse" });
+		const todoContext = {
+			...testContext,
+			tools: [{ ...testContext.tools![0]!, name: "todo_write" }],
+		};
+		global.fetch = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit) => {
+				bodies.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+				return bodies.length === 1
+					? createSseResponse([
+							{
+								type: "error",
+								code: "invalid_request_error",
+								message: "Tool choice 'todo_write' not found in 'tools' parameter.",
+							},
+						])
+					: okResponse(testModel.id);
+			},
+			{ preconnect: originalFetch.preconnect },
+		);
+		const stream = streamOpenAICodexResponses(testModel, todoContext, {
+			apiKey: codexToken,
+			preferWebsockets: false,
+			toolChoice: { type: "function", function: { name: "todo_write" } },
+			sessionId: "session-sse",
+		});
+		const events = await collectEvents(stream);
+		const result = await stream.result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(bodies).toHaveLength(2);
+		expect(bodies[0]?.tool_choice).toEqual({ type: "function", name: "todo_write" });
+		expect(bodies[1]?.tool_choice).toBeUndefined();
+		expect(bodies[1]?.prompt_cache_key).toBe(bodies[0]?.prompt_cache_key);
+		expect(getToolChoiceCapabilityOverride(testModel)).toBe("auto");
+		expectSingleCleanFallbackEvents(events);
+	});
+
 	it("does not retry forced tool choice in managed mode", async () => {
 		let calls = 0;
 		const testModel = model({ id: "managed-runtime-codex" });

--- a/packages/ai/test/tool-choice-capability.test.ts
+++ b/packages/ai/test/tool-choice-capability.test.ts
@@ -178,6 +178,22 @@ describe("isForcedToolChoiceUnsupportedError", () => {
 		).toBe(true);
 	});
 
+	it("matches statusless semantic invalid-request errors without accepting other codes or statuses", () => {
+		const message = "Tool choice 'todo_write' not found in 'tools' parameter.";
+		expect(
+			isForcedToolChoiceUnsupportedError(Object.assign(new Error(message), { code: "invalid_request_error" }), true),
+		).toBe(true);
+		expect(
+			isForcedToolChoiceUnsupportedError(Object.assign(new Error(message), { code: "server_error" }), true),
+		).toBe(false);
+		expect(
+			isForcedToolChoiceUnsupportedError(
+				Object.assign(new Error(message), { code: "invalid_request_error", status: 500 }),
+				true,
+			),
+		).toBe(false);
+	});
+
 	it("rejects non-400 errors", () => {
 		expect(
 			isForcedToolChoiceUnsupportedError(


### PR DESCRIPTION
## What

- Accept statusless provider `invalid_request_error` events at the existing forced-tool-choice capability boundary.
- Keep the fallback constrained to the exact named-tool-not-in-tools message and reject other semantic codes or explicit non-400 statuses.
- Cover the HTTP 200 SSE transport path where the first request fails and the clean replay succeeds without `tool_choice`.

## Why

Fixes #3669.

Codex can reject a named tool choice inside an HTTP 200 SSE stream. The existing fallback only admitted HTTP 400 errors, so this semantically identical rejection terminated the turn before the one-shot capability downgrade could run.

## Testing

- `bun test packages/ai/test/openai-codex-responses-tool-choice.test.ts packages/ai/test/tool-choice-capability.test.ts packages/ai/test/tool-choice-capability.redteam.test.ts` — 86 pass, 0 fail, 414 assertions
- `bun --cwd=packages/ai run check`
- `git diff --check`
- Broader non-authoritative package run: 1,903 pass / 337 skip / 164 unrelated current-dev auth/cache shared-state failures; no failure in the changed or focused paths

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:f798ca3c2d6e2d023458d7c25e331cc961453554 reviewer:critic evidence:identical-tree-lore-fixed-focused86-ai-check
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit