### PR TITLE
fix(utils): honor executable lookup overrides

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- macOS executable discovery now honors explicit `PATH` and `cwd` lookup overrides instead of silently searching the process environment.
+
 ## [0.12.6] - 2026-07-31
 ### Fixed
 

--- a/packages/utils/src/which.ts
+++ b/packages/utils/src/which.ts
@@ -183,9 +183,10 @@ export interface WhichOptions extends Bun.WhichOptions {
 
 // Darwin-specific "which" shim: consult Xcode/CLT toolchain directories after $PATH.
 // Uses cached directory listings instead of per-command existsSync or xcrun subprocesses.
-function darwinWhich(command: string, _options?: Bun.WhichOptions): string | null {
-	const regular = Bun.which(command);
+function darwinWhich(command: string, options?: Bun.WhichOptions): string | null {
+	const regular = Bun.which(command, options);
 	if (regular) return regular;
+	if (options?.PATH !== undefined) return null;
 	if (isXcodeBin(command)) {
 		return getMacosToolPaths().get(command) ?? null;
 	}
@@ -198,10 +199,10 @@ export const whichFresh = os.platform() === "darwin" ? darwinWhich : Bun.which;
 // Derive stable cache key from command and lookup options
 function cacheKey(command: string, options?: Bun.WhichOptions): CacheKey {
 	if (!options) return command;
-	if (!options.cwd && !options.PATH) return command;
+	if (options.cwd === undefined && options.PATH === undefined) return command;
 	let h = Bun.hash(command);
-	if (options.cwd) h = Bun.hash(options.cwd, h);
-	if (options.PATH) h = Bun.hash(options.PATH, h);
+	if (options.cwd !== undefined) h = Bun.hash(`cwd:${options.cwd}`, h);
+	if (options.PATH !== undefined) h = Bun.hash(`PATH:${options.PATH}`, h);
 	return h;
 }
 

--- a/packages/utils/test/which.test.ts
+++ b/packages/utils/test/which.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { TempDir } from "../src/temp";
+import { $which, WhichCachePolicy } from "../src/which";
+
+describe.skipIf(process.platform === "win32")("$which lookup options", () => {
+	it("honors explicit PATH and cwd overrides without cache collisions", async () => {
+		const tempDir = await TempDir.create();
+		try {
+			const command = "gjc-which-option-test";
+			const executable = tempDir.join(command);
+			await Bun.write(executable, "#!/bin/sh\nexit 0\n");
+			await fs.chmod(executable, 0o755);
+
+			expect($which(command, { PATH: tempDir.path(), cache: WhichCachePolicy.Fresh })).toBe(executable);
+			expect($which(command, { PATH: "", cwd: tempDir.path(), cache: WhichCachePolicy.Cached })).toBeNull();
+			expect(
+				$which(`.${path.sep}${command}`, {
+					PATH: "",
+					cwd: tempDir.path(),
+					cache: WhichCachePolicy.Bypass,
+				}),
+			).toBe(executable);
+			expect($which("clang", { PATH: tempDir.path(), cache: WhichCachePolicy.Bypass })).toBeNull();
+		} finally {
+			await tempDir.remove();
+		}
+	});
+});


### PR DESCRIPTION
## What

- Forward caller-provided `PATH` and `cwd` options through the Darwin executable lookup shim.
- Treat an explicit `PATH` (including an empty one) as authoritative instead of escaping into Xcode/Command Line Tools fallbacks.
- Tag and retain explicit lookup option values in cache keys so `cwd` and `PATH` cannot alias.
- Add coverage for constrained lookup, empty `PATH`, relative lookup, and the former cache-key collision.

## Why

This is the current-`dev` successor to #3656, which was closed only because `dev` advanced during sequential intake. Its exact source/test patch received an owner review with P0=0/P1=0 and is unchanged here.

On macOS, the shim called `Bun.which(command)` without the caller's options. A caller attempting to constrain discovery could therefore resolve outside its requested environment, and the prior untagged cache key could reuse a result across distinct lookup authorities.

## Testing

- `bun --cwd=packages/utils run check`
- `git diff --check`
- `bun test packages/utils/test/which.test.ts` — 1 expected platform skip on this Windows host
- Full utils suite — 242 pass / 1 expected platform skip / 9 unrelated current-dev Windows environment and postmortem-signal failures
- Source+test stable patch ID matches owner-reviewed #3656 exactly: `a229d9827653f4030aef9e7abffd6af5a5e2ea2e`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:6a7bc488555aa786bc1c3a4bcd20adb568fa6c9a reviewer:critic evidence:source-test-identical-unreleased-changelog-utils-check
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit