### PR TITLE
fix(telegram): reconcile reverted guard ownership

### DIFF
--- a/packages/coding-agent/src/sdk/bus/chat-daemon-control.ts
+++ b/packages/coding-agent/src/sdk/bus/chat-daemon-control.ts
@@ -41,10 +41,12 @@ export type ChatDaemonAction = "stop" | "reload";
  * through shared notification parsing. Generation 17 bound managed-session
  * replacement to exact native filesystem authority; generation 18 retired that
  * binding, and generation 19 binds exact cleanup to parent/link-count authority.
+ * Generation 20 fences reverted process-group ownership, and generation 21
+ * defers live-process probes until durable owner identity matches.
  */
 export const CHAT_DAEMON_GENERATIONS: Readonly<Record<ChatDaemonKind, number>> = {
-	discord: 20,
-	slack: 20,
+	discord: 21,
+	slack: 21,
 };
 
 export function chatDaemonGeneration(kind: ChatDaemonKind): number {
@@ -1124,18 +1126,17 @@ export async function releaseChatDaemonOwnership(input: {
 	const pidIncarnation = input.pidIncarnation ?? defaultPidIncarnation;
 	await withStateWriteLock(paths.state, async () => {
 		const state = await readJson<unknown>(paths.state);
-		const currentIncarnation = pidIncarnation(input.pid);
 		if (
 			!hasSafeChatDaemonStateShape(state) ||
 			!hasProcessIncarnationAuthority(input.incarnation) ||
 			state.ownerId !== input.ownerId ||
 			state.pid !== input.pid ||
-			state.incarnation !== input.incarnation ||
-			!pidAlive(input.pid) ||
-			!hasProcessIncarnationAuthority(currentIncarnation) ||
-			currentIncarnation !== input.incarnation
+			state.incarnation !== input.incarnation
 		)
 			return;
+		if (!pidAlive(input.pid)) return;
+		const currentIncarnation = pidIncarnation(input.pid);
+		if (!hasProcessIncarnationAuthority(currentIncarnation) || currentIncarnation !== input.incarnation) return;
 		await writeJson(paths.state, { ...state, stoppedAt: Date.now(), transportHealthy: false });
 		const lock = await captureChatDaemonOwnerLockLease(paths.lock);
 		let owner: unknown;

--- a/packages/coding-agent/test/daemon-control.test.ts
+++ b/packages/coding-agent/test/daemon-control.test.ts
@@ -1511,6 +1511,9 @@ describe("ChatDaemonController ownership safety", () => {
 				...input,
 			} as any);
 
+		const forbiddenProbe = () => {
+			throw new Error("process probes must not run before durable owner identity matches");
+		};
 		for (const input of [
 			{ ownerId: "wrong-owner" },
 			{ pid: undefined },
@@ -1518,6 +1521,12 @@ describe("ChatDaemonController ownership safety", () => {
 			{ incarnation: undefined },
 			{ incarnation: "wrong" },
 			{ incarnation: "stale" },
+		]) {
+			restore();
+			await release({ ...input, pidAlive: forbiddenProbe, pidIncarnation: forbiddenProbe });
+			unchanged();
+		}
+		for (const input of [
 			{ pidIncarnation: () => "linux:12346" },
 			{ pidIncarnation: () => undefined },
 			{ pidAlive: () => false, pidIncarnation: () => "linux:12345" },

--- a/scripts/telegram-daemon-generation-guard.ts
+++ b/scripts/telegram-daemon-generation-guard.ts
@@ -8,7 +8,7 @@ import * as path from "node:path";
 
 const root = path.join(import.meta.dir, "..");
 const SHA = /^[0-9a-f]{40}$/i;
-export const GUARD_CONTRACT_VERSION = 33;
+export const GUARD_CONTRACT_VERSION = 34;
 const telegramContract = "packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts";
 const telegramDaemon = "packages/coding-agent/src/sdk/bus/telegram-daemon.ts";
 const telegramControl = "packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts";
@@ -36,10 +36,9 @@ const nativeAuthorityDeclarations = {
 		"exact_remove_directory_tree",
 	],
 	"crates/pi-natives/src/ps.rs": ["napi impl Process"],
-	"crates/pi-shell/src/process.rs": ["impl Process", "kill_process_group", "process_group_members", "current_descendant_pids", "add_new_descendants"],
-	"crates/pi-shell/src/shell.rs": ["const MAX_OWNED_COMMAND_PROCESSES", "const MAX_PENDING_SHELL_RUNS", "impl Shell", "impl CommandProcessGroups", "impl ExternalCommandProcessObserver for CommandProcessGroups", "run_shell_session", "run_shell_oneshot", "run_shell_oneshot_streams", "run_shell_command", "run_shell_command_streams", "terminate_owned_process_groups", "impl builtins::Command for TimeoutCommand"],
-	"crates/brush-core-vendored/src/interp.rs": ["trait ExternalCommandProcessObserver", "set_process_group_observer", "notify_external_command_spawned"],
-	"crates/brush-core-vendored/src/commands.rs": ["observed_process_group_id", "execute_external_command"],
+	"crates/pi-shell/src/process.rs": ["impl Process", "kill_process_group", "current_descendant_pids", "add_new_descendants"],
+	"crates/pi-shell/src/shell.rs": ["impl Shell", "run_shell_session", "run_shell_oneshot", "run_shell_oneshot_streams", "run_shell_command", "run_shell_command_streams", "impl builtins::Command for TimeoutCommand"],
+	"crates/brush-core-vendored/src/commands.rs": ["execute_external_command"],
 	"packages/natives/native/index.d.ts": ["Process"],
 	"packages/coding-agent/src/sdk/broker/process-incarnation.ts": ["isProcessIncarnation", "processIncarnation"],
 } as const;

--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -1,5 +1,5 @@
 {
-  "contractVersion": 33,
+  "contractVersion": 34,
   "inventory": {
     "telegram": {
       "packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts": [
@@ -346,7 +346,7 @@
     "discord:packages/coding-agent/src/sdk/bus/chat-daemon-control.ts:readChatDaemonState": "2bad479b3fa8110fdbfcbddeefb1ace0e340867f33ae0451ecd827e1ab83b704",
     "discord:packages/coding-agent/src/sdk/bus/chat-daemon-control.ts:readJson": "512f0b26ebf43ddceb94fc5cc7a2e5c60256f9705cf4d1f01cf591c0c40707e0",
     "discord:packages/coding-agent/src/sdk/bus/chat-daemon-control.ts:reclaimChatDaemonOwnerLock": "4d46271925a44748c3b249f02e9d0688d4ec9bac9775f7c533bc71728680eac8",
-    "discord:packages/coding-agent/src/sdk/bus/chat-daemon-control.ts:releaseChatDaemonOwnership": "18096f000b4f3b6d5428cc18b2e3000858bc76752e2cc9f11868d890f0e4d9db",
+    "discord:packages/coding-agent/src/sdk/bus/chat-daemon-control.ts:releaseChatDaemonOwnership": "9e5f089a036a137351417e0db66a54770f34aafd86553213b8c02387873d60b7",
     "discord:packages/coding-agent/src/sdk/bus/chat-daemon-control.ts:reload": "cf04d1211abe5e33f66bf185780463cfa720dc9291101552b96945fc63f2d7ee",
     "discord:packages/coding-agent/src/sdk/bus/chat-daemon-control.ts:renewChatDaemonHeartbeat": "fbf6c4af5e1c5b655f7fba8c9f8c55c937d9b82c6262e98c477ea43d7610d368",
     "discord:packages/coding-agent/src/sdk/bus/chat-daemon-control.ts:result": "8a32fac3d91a4b8c22d5a7d0af5ed72b515665e6e6ac72dd22fe260fdf2f2ae7",
@@ -424,7 +424,7 @@
     "slack:packages/coding-agent/src/sdk/bus/chat-daemon-control.ts:readChatDaemonState": "2bad479b3fa8110fdbfcbddeefb1ace0e340867f33ae0451ecd827e1ab83b704",
     "slack:packages/coding-agent/src/sdk/bus/chat-daemon-control.ts:readJson": "512f0b26ebf43ddceb94fc5cc7a2e5c60256f9705cf4d1f01cf591c0c40707e0",
     "slack:packages/coding-agent/src/sdk/bus/chat-daemon-control.ts:reclaimChatDaemonOwnerLock": "4d46271925a44748c3b249f02e9d0688d4ec9bac9775f7c533bc71728680eac8",
-    "slack:packages/coding-agent/src/sdk/bus/chat-daemon-control.ts:releaseChatDaemonOwnership": "18096f000b4f3b6d5428cc18b2e3000858bc76752e2cc9f11868d890f0e4d9db",
+    "slack:packages/coding-agent/src/sdk/bus/chat-daemon-control.ts:releaseChatDaemonOwnership": "9e5f089a036a137351417e0db66a54770f34aafd86553213b8c02387873d60b7",
     "slack:packages/coding-agent/src/sdk/bus/chat-daemon-control.ts:reload": "cf04d1211abe5e33f66bf185780463cfa720dc9291101552b96945fc63f2d7ee",
     "slack:packages/coding-agent/src/sdk/bus/chat-daemon-control.ts:renewChatDaemonHeartbeat": "fbf6c4af5e1c5b655f7fba8c9f8c55c937d9b82c6262e98c477ea43d7610d368",
     "slack:packages/coding-agent/src/sdk/bus/chat-daemon-control.ts:result": "8a32fac3d91a4b8c22d5a7d0af5ed72b515665e6e6ac72dd22fe260fdf2f2ae7",
@@ -474,7 +474,7 @@
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:ownerPidFromOwnerId": "46691373b2bee01f28f3817a6aa6a7efffe880c2cea337c89155582c98d952bf",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:runDaemonInternal": "7689b6c98f5d0a658b3aa921e384c549355aba7eb672c2ebf4014171da01ba5c",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:runDaemonSmoke": "6f085a667aa5c83de46d2d8945fb845c355fcbb43c46872342a44489203a5830",
-    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:DAEMON_GENERATION": "adc41640c635b42476409aa17f70439e7cad825ed050007d67c92ed3117fa792",
+    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:DAEMON_GENERATION": "02634937df51a7dd1d5542d1210c937da8b21bab3d764d53eab3b6264717cf47",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:NOTIFICATION_PROTOCOL_VERSION": "b99289f651fedcf020d28dbaf6f07dd37e7e4a5f6dc1f5118b872112325f1e81",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts:DaemonProcessReference": "c3d13e3670a6245a1250c4ebfcd80a36dd8fc96c67ab64d9f979182bd117bc4e",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts:TelegramDaemonController": "d92bf5e0aea850d62c415092a8d9024d3d3571e0f2b8855d7e3fb418ec59a59c",
@@ -555,10 +555,9 @@
   "nativeAuthoritySha256": {
     "crates/pi-natives/src/path_identity.rs": "90a5ac813f53dee0f9a81002f5971594c07f8a9bdf8d5f262737be1d8203aae1",
     "crates/pi-natives/src/ps.rs": "7696078e123b9beecc7252371c71eab2cec590413be6e6ddf4692ff6fe8c41e1",
-    "crates/pi-shell/src/process.rs": "e0f04bbec2c64e679dee630325c0c3d054ca3be9c7355880f83873cbf4b75c95",
-    "crates/pi-shell/src/shell.rs": "8d92db6549bc7d43a7a14c970dc98121e5b8fe32b051cf2ae78aae7195c89cca",
-    "crates/brush-core-vendored/src/interp.rs": "7cddfa17c6ab12d151d5588a6659d97c427cd19d67335a127b7a4d0f5a552ac6",
-    "crates/brush-core-vendored/src/commands.rs": "5245715727bd1339b78274e4e8194336f89a26eed98b2e9d990022443395a9e1",
+    "crates/pi-shell/src/process.rs": "0b4473e5ca231d01c8180a3e2ade04d3ef5cc9800ea25fa66fe8e22050fe5c41",
+    "crates/pi-shell/src/shell.rs": "b0d83d5152d2083ca5d1972ee8dcd8bdf0ef2e6bf914ca76cae019704c03bd16",
+    "crates/brush-core-vendored/src/commands.rs": "55e9dceffad7d829051547e91592ca8e392a9073e2d4ee2f7546e3b6c1b75a9d",
     "packages/natives/native/index.d.ts": "c61e02fd4712c822d30fb4b1496f064097a38718c9443bef526711f828165c50",
     "packages/coding-agent/src/sdk/broker/process-incarnation.ts": "cedd073107475b238757c6167129484ccec27fe49a2fb52b72f71592d78a7814"
   }


### PR DESCRIPTION
## Summary

- remove generation-guard native authority selectors whose implementations were reverted from current `dev`
- bump the guard contract to v34 and regenerate the exact manifest
- make chat ownership release reject durable identity mismatches before performing live PID/incarnation probes
- add regression coverage proving mismatched durable authority performs no process probe

This supersedes closed PR #3668. Its exact Windows run exposed a deterministic 5-second timeout in the ownership-release regression: every negative case eagerly performed process-incarnation discovery before rejecting an already-mismatched durable owner. The successor fixes that source ordering rather than increasing the timeout.

## Verification

- `bun test packages/coding-agent/test/daemon-control.test.ts` (157 pass, 0 fail)
- focused ownership regression (1 pass, 30 assertions, ~248 ms locally)
- `bun scripts/telegram-daemon-generation-guard.ts --write-manifest`
- `bun scripts/telegram-daemon-generation-guard.ts --validate-current-tree`
- `bun test scripts/telegram-daemon-generation-guard.test.ts` (42 pass, 0 fail)
- Biome check on the changed source and regression test

Thank you for reviewing.