### PR TITLE
fix(tui): preserve restart admission after repaint failure

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Temporary TUI restarts now retain their native-scrollback admission frontier when the following viewport repaint fails, preventing newly appended rows from being duplicated on retry.
 
 ## [0.12.6] - 2026-07-31
 ### Fixed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -3812,6 +3812,16 @@ export class TUI extends Container {
 			if (restartAppendProven && rawLines.length > this.#restartDurableLineCount) {
 				const appendBuffer = `\x1b[?2026h${newLines.slice(this.#restartDurableLineCount).join("\r\n")}\x1b[?2026l`;
 				if (!this.#writeTerminal(appendBuffer)) return;
+				// The append already reached native scrollback. Advance both the live
+				// frontier and the retained restart baseline before the viewport write:
+				// a subsequent terminal failure must not re-admit this suffix on restart.
+				this.#durableLineCount = newLines.length;
+				this.#durableRenderedLines = newLines.slice();
+				this.#durableRawLines = rawLines.slice();
+				this.#restartDurableLineCount = newLines.length;
+				this.#restartDurableRenderedLines = newLines.slice();
+				this.#restartDurableRawLines = rawLines.slice();
+				this.#restartDurableWidth = width;
 			}
 			if (viewportRepaint("restart after temporary stop")) {
 				if (restartAppendProven) {

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -148,6 +148,10 @@ class FaultingVirtualTerminal implements Terminal {
 		return this.#available;
 	}
 
+	get isProcessTerminal(): boolean | undefined {
+		return this.terminal.isProcessTerminal;
+	}
+
 	get columns(): number {
 		return this.terminal.columns;
 	}
@@ -2935,6 +2939,43 @@ describe("TUI terminal-state regressions", () => {
 					expect(
 						scrollback.filter(line => line.trim() === row),
 						`${row} should appear exactly once`,
+					).toHaveLength(1);
+				}
+			} finally {
+				tui.stop();
+			}
+		});
+		it("does not re-admit restart rows when the viewport repaint write fails", async () => {
+			const backingTerminal = new VirtualTerminal(32, 5, { isProcessTerminal: true });
+			const terminal = new FaultingVirtualTerminal(backingTerminal);
+			const tui = new TUI(terminal);
+			const initialRows = rows("restart-", 20);
+			const stoppedRows = rows("stopped-", 8);
+			const component = new MutableLinesComponent(initialRows);
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(backingTerminal);
+
+				tui.stop();
+				component.setLines([...initialRows, ...stoppedRows]);
+				tui.start();
+				// start() has completed its synchronous terminal setup. Let the suffix
+				// append succeed, then fail the following viewport paint.
+				terminal.setWriteFailureAt(terminal.writeCount + 2);
+				await settle(backingTerminal);
+				expect(terminal.available).toBe(false);
+
+				terminal.setWriteFailureAt(undefined);
+				tui.start();
+				await settle(backingTerminal);
+
+				const scrollback = backingTerminal.getScrollBuffer();
+				for (const row of stoppedRows) {
+					expect(
+						scrollback.filter(line => line.trim() === row),
+						`${row} should be admitted once`,
 					).toHaveLength(1);
 				}
 			} finally {


### PR DESCRIPTION
Follow-up to #3684.

## Problem

A temporary TUI stop/start can append rows produced while stopped before repainting the live viewport. The append reaches native scrollback first, but the durable frontier was previously advanced only after the subsequent viewport repaint succeeded.

If that repaint write failed or the terminal detached, a later restart retained the old frontier and appended the already-admitted rows again.

## Reproduction

1. Start a process-terminal TUI with an existing transcript.
2. Stop it and append rows while stopped.
3. Restart it, allow the suffix append write to succeed, then fail the following viewport repaint write.
4. Restore the terminal and restart again.

**Expected:** each stopped row remains admitted exactly once.  
**Previous behavior:** the old durable frontier caused the second restart to emit the stopped suffix again.

## Change

Advance both the durable frontier and retained restart baseline immediately after the suffix append write succeeds. The subsequent viewport repaint remains responsible only for displaying the frame; its failure cannot re-admit bytes that already reached native scrollback.

## Verification

- Added a deterministic restart-retry regression using a faulting process-terminal wrapper: the append succeeds, the following viewport write fails, and every stopped row is asserted exactly once after recovery.
- Focused TUI suite: **184 passed**, 0 failed, 1,789 assertions.
- `bun --cwd=packages/tui run check` passed.

## Scope

Only `packages/tui/src/tui.ts` and `packages/tui/test/render-regressions.test.ts` change. This is a follow-up to review feedback after the upstream transcript-loss PR merged; it targets the fork's `dev` branch only.

**Base:** `eacf5345a1e9cf658a58f7cef0c06e79d4448e59`  
**Head:** `610c256ca386985076f2beee85e7e09b866dd59b`