### PR TITLE
fix(ai): preserve relay session affinity headers

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- OpenAI Responses-compatible relay providers now receive `session_id` and `x-client-request-id` when prompt caching is enabled and a session ID is present, preserving session affinity instead of falling back to body-only cache routing (#3689).
+
 ## [0.12.7] - 2026-07-31
 
 ## [0.12.6] - 2026-07-31

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -271,6 +271,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 		try {
 			// Keep request headers and prompt-cache routing on the same session-derived value.
 			const cacheSessionId = getOpenAIResponsesCacheSessionId(options);
+			const cacheRetention = resolveCacheRetention(options?.cacheRetention ?? model.cacheRetention);
 			const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
 			const { client, copilotPremiumRequests, baseUrl } = createClient(
 				model,
@@ -279,6 +280,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 				options?.headers,
 				options?.initiatorOverride,
 				cacheSessionId,
+				cacheRetention,
 				options?.onSseEvent,
 				options?.fetch,
 				options?.authCredentialType,
@@ -429,6 +431,7 @@ function createClient(
 	extraHeaders?: Record<string, string>,
 	initiatorOverride?: MessageAttribution,
 	sessionId?: string,
+	cacheRetention?: CacheRetention,
 	onSseEvent?: OpenAIResponsesOptions["onSseEvent"],
 	fetchOverride?: FetchImpl,
 	authCredentialType?: OpenAIResponsesOptions["authCredentialType"],
@@ -485,7 +488,7 @@ function createClient(
 		copilotPremiumRequests = copilot.premiumRequests;
 		baseUrl = resolveGitHubCopilotBaseUrl(model.baseUrl, rawApiKey) ?? model.baseUrl;
 	}
-	if (sessionId && model.provider === "openai" && (!model.baseUrl || (baseUrl && isDefaultOpenAIBaseUrl(baseUrl)))) {
+	if (sessionId && cacheRetention !== "none") {
 		headers.session_id ??= sessionId;
 		headers["x-client-request-id"] ??= sessionId;
 	}

--- a/packages/ai/test/openai-responses-cache-affinity.test.ts
+++ b/packages/ai/test/openai-responses-cache-affinity.test.ts
@@ -105,13 +105,24 @@ describe("openai-responses cache affinity", () => {
 		expect(captured.body?.prompt_cache_key).toBe("session-123");
 	});
 
-	it("keeps prompt_cache_key when cache retention is disabled", async () => {
+	it("omits session routing headers when cache retention is disabled", async () => {
 		const captured = await captureOpenAIResponseHeaders({ cacheRetention: "none", sessionId: "session-123" });
+
+		expect(captured.sessionId).toBeNull();
+		expect(captured.clientRequestId).toBeNull();
+		expect(captured.body?.prompt_cache_key).toBe("session-123");
+		expect(captured.body?.prompt_cache_retention).toBeUndefined();
+	});
+
+	it("sets session routing headers for custom OpenAI Responses base URLs", async () => {
+		const captured = await captureOpenAIResponseHeaders(
+			{ sessionId: "session-123" },
+			{ ...model, baseUrl: "https://codex-pooler.example/v1" },
+		);
 
 		expect(captured.sessionId).toBe("session-123");
 		expect(captured.clientRequestId).toBe("session-123");
 		expect(captured.body?.prompt_cache_key).toBe("session-123");
-		expect(captured.body?.prompt_cache_retention).toBeUndefined();
 	});
 
 	it("uses model cacheRetention for OpenAI Responses retention when request omits cacheRetention", async () => {


### PR DESCRIPTION
## Problem
OpenAI Responses-compatible relays received `prompt_cache_key` but not `session_id` or `x-client-request-id`, yielding a measured 100% session-affinity miss and 54-57% HTTP-fallback cache hits compared with 94-97% for header-affinity sessions on the same pooler.

## Mechanism
Send `session_id` and `x-client-request-id` for every OpenAI Responses request with a normalized session ID while cache retention is enabled. Explicit caller headers still override defaults; `cacheRetention: "none"` omits the affinity headers. Prompt-cache-key derivation, retention behavior, and cache-write accounting are unchanged.

## Pi lineage
Matches upstream earendil-works/pi `packages/ai/src/api/openai-responses.ts` session-affinity behavior (L131-138, L232-241): cache-enabled session requests carry affinity headers for compatible providers rather than only the official OpenAI endpoint.

## Red proof
Before the implementation, `bun test packages/ai/test/openai-responses-cache-affinity.test.ts` failed: the disabled-retention assertion received `"session-123"` instead of `null`, and the custom relay assertion received `null` instead of `"session-123"`.

## Verification
- `bun test packages/ai/test/openai-responses-cache-affinity.test.ts` — 7 pass, 0 fail
- `bun --cwd=packages/ai run check` — Biome clean and `tsc -p tsconfig.json --noEmit` passed

Fixes #3689