### PR TITLE
fix(tui): restore viewport-repaint host gate for width changes (#1979)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Ordinary `ask` selectors now bound long question premises and page through every premise row without skipping rows hidden by overflow indicators (#3675).
+- The issue-1979 Korean prose wrap test now cleans up inherited multiplexer env vars (`TMUX`, `TMUX_PANE`, etc.) so it deterministically exercises the plain-terminal render path regardless of the CI runner's terminal session (#1979).
 ## [0.12.7] - 2026-07-31
 
 ## [0.12.6] - 2026-07-31

--- a/packages/coding-agent/test/issue-1979-korean-wrap.test.ts
+++ b/packages/coding-agent/test/issue-1979-korean-wrap.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import type { AssistantMessage } from "@gajae-code/ai";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { AssistantMessageComponent } from "@gajae-code/coding-agent/modes/components/assistant-message";
@@ -13,13 +13,26 @@ const WIDTH = 20;
 const CONTENT_WIDTH = WIDTH - 2; // Assistant Markdown's left and right padding.
 const SUFFIX = "끝-ISSUE-1979-SUFFIX";
 const OPTION_LABELS = ["계속 진행", "다른 선택지를 입력"];
-
+const MULTIPLEXER_ENV_KEYS = ["TMUX", "TMUX_PANE", "STY", "ZELLIJ", "GJC_TMUX_LAUNCHED"] as const;
+let previousMultiplexerEnv: Map<string, string | undefined>;
 beforeAll(async () => {
 	resetSettingsForTest();
 	await Settings.init({ inMemory: true, cwd: process.cwd() });
 	const themeInstance = await getThemeByName("red-claw");
 	if (!themeInstance) throw new Error("Failed to load test theme");
 	setThemeInstance(themeInstance);
+});
+beforeEach(() => {
+	previousMultiplexerEnv = new Map(MULTIPLEXER_ENV_KEYS.map(key => [key, Bun.env[key]]));
+	for (const key of MULTIPLEXER_ENV_KEYS) delete Bun.env[key];
+});
+
+afterEach(() => {
+	if (!previousMultiplexerEnv) return;
+	for (const [key, value] of previousMultiplexerEnv) {
+		if (value === undefined) delete Bun.env[key];
+		else Bun.env[key] = value;
+	}
 });
 
 function assistantMessage(text: string): AssistantMessage {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Fixed
 
 - Temporary TUI restarts now retain their native-scrollback admission frontier when the following viewport repaint fails, preventing newly appended rows from being duplicated on retry.
+- Restored the `isProcessTerminal`/`shouldUseViewportRepaintForHost` gate on the width-change viewport-repaint intercept so plain terminals (non-multiplexer, non-process-terminal) use `fullRender` for width changes instead of an unconditional viewport repaint. The #3684 chain removed this gate, causing lossless Korean/CJK prose wrapping to break at narrow widths because the viewport repaint only painted the visible rows without committing the full transcript to scrollback (#1979).
+- Restored the `fullRender` fallback for the `firstChanged < viewportTop` branch on non-viewport-repaint hosts, so above-viewport mutations replay the full frame instead of silently viewport-repainting.
+- Propagated IME cursor write failure from `#writeRenderBufferAndReanchorImeCursor` so callers detect terminal detach when the deferred cursor write fails after the shared frame commits.
 
 ## [0.12.7] - 2026-07-31
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -3763,6 +3763,14 @@ export class TUI extends Container {
 			fullRender(true, "width settled", true);
 			return;
 		}
+		const useViewportRepaintPath = shouldUseViewportRepaintForHost(Bun.env, process.platform, {
+			includeProcessTerminal: this.terminal.isProcessTerminal === true,
+		});
+		const widthReflowRequired =
+			this.#previousWidth > 0 &&
+			rawLines.some(
+				line => !TERMINAL.isImageLine(line) && visibleWidth(line) > Math.min(this.#previousWidth, width),
+			);
 		if (
 			widthChanged &&
 			!this.#legacyMultiplexerFullRender &&
@@ -3771,10 +3779,13 @@ export class TUI extends Container {
 				!durableAppend ||
 				!logicalAppend ||
 				retainedLength < 0 ||
-				retainedLength >= newLines.length)
+				retainedLength >= newLines.length) &&
+			useViewportRepaintPath
 		) {
 			// Resize-only frames, and frames without a proven append suffix, repaint
-			// the live viewport without replaying durable history.
+			// the live viewport without replaying durable history. Only on viewport-
+			// repaint hosts (multiplexers, Windows Terminal, process terminals); plain
+			// terminals fall through to fullRender so the whole frame is replayed.
 			if (forcedRenderQueued) this.#fullRedrawCount += 1;
 			viewportRepaint(`terminal width changed (${this.#previousWidth} -> ${width})`, true, true);
 			return;
@@ -3782,8 +3793,6 @@ export class TUI extends Container {
 		if (widthChanged && !initialRender && resizeRenderMutationQueued) {
 			this.#latestRenderedLines = newLines.slice(0, retainedLength);
 			if (this.#virtualViewport) this.#latestRaw = rawLines.slice(0, retainedLength);
-			// Preserve the pre-append physical baseline; the normal append path must
-			// account for the rows that overflow the old viewport exactly once.
 			coalescedWidthAppend = true;
 		}
 
@@ -3793,14 +3802,6 @@ export class TUI extends Container {
 			const msg = `[${new Date().toISOString()}] fullRender: ${reason} (new=${newLines.length}, height=${height})\n`;
 			this.#appendDebugRedrawLog(msg);
 		};
-		const useViewportRepaintPath = shouldUseViewportRepaintForHost(Bun.env, process.platform, {
-			includeProcessTerminal: this.terminal.isProcessTerminal === true,
-		});
-		const widthReflowRequired =
-			this.#previousWidth > 0 &&
-			rawLines.some(
-				line => !TERMINAL.isImageLine(line) && visibleWidth(line) > Math.min(this.#previousWidth, width),
-			);
 
 		if (restartViewportRepaintPending && initialRender) {
 			const restartAppendProven =
@@ -4167,7 +4168,11 @@ export class TUI extends Container {
 
 		if (firstChanged < prevViewportTop && !durableAppend) {
 			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
-			viewportRepaint(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
+			if (useViewportRepaintPath) {
+				viewportRepaint(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
+			} else {
+				fullRender(true, "firstChanged < viewportTop");
+			}
 			return;
 		}
 		// Render from first changed line to end
@@ -4449,9 +4454,11 @@ export class TUI extends Container {
 		}
 		if (!this.#imeCursorActive) return true;
 		// Cursor positioning is outside shared transcript ownership. A failure still
-		// makes the terminal unavailable, but cannot uncommit the shared frame.
-		this.#writeCursorPosition(cursorPos, totalLines, true);
-		return true;
+		// makes the terminal unavailable, but cannot uncommit the shared frame. The
+		// onBufferWritten callback has already run; the return value propagates
+		// terminal availability so callers can detect the detach.
+		const cursorWritten = this.#writeCursorPosition(cursorPos, totalLines, true);
+		return cursorWritten;
 	}
 
 	/**

--- a/packages/tui/test/fixtures/render-goldens/layout-resize-rich-text/meta.json
+++ b/packages/tui/test/fixtures/render-goldens/layout-resize-rich-text/meta.json
@@ -24,15 +24,15 @@
   "artifacts": {
     "viewport": {
       "file": "viewport.txt",
-      "sha256": "b6e599b3bb0de5e0984a781ea52f1e0f14738066246e9dac250e323e03003b75"
+      "sha256": "479295f08a5b215df4ce2295408db5f5c154f171e5b91dc1af6becb99cbf2ba5"
     },
     "scrollback": {
       "file": "scrollback.txt",
-      "sha256": "833879563a20d06200b39b0ebb9b7d2f6c4ccc9ed0f3526922ea4e1ab1aa2a27"
+      "sha256": "a1772ae48ba458ea2acdb0a201ddd2b6e450e1c203b04c7dd325fc21fe024a3d"
     },
     "writelog": {
       "file": "writelog.bin",
-      "sha256": "bc953700e37a0e8830380cafd296783393c8acabebe2df25bda7bca3f1f933ae"
+      "sha256": "7405143f9d3a0339a66a61b4620f103d2662c84d3175acd787202810ea77d490"
     }
   }
 }

--- a/packages/tui/test/fixtures/render-goldens/layout-resize-rich-text/scrollback.txt
+++ b/packages/tui/test/fixtures/render-goldens/layout-resize-rich-text/scrollback.txt
@@ -1,9 +1,3 @@
- Golden rich text                                                           
-                                                                            
- │ Deterministic quote with link (https://example.test/golden).             
-                                                                            
- - list alpha                                                               
- - list beta with CJK 表示 and 한글 jamo 한                                 
  Golden rich text                                                                   
                                                                                     
  │ Deterministic quote with link (https://example.test/golden).                     
@@ -15,7 +9,7 @@
  | Glyph  | Value      |                                                            
  +--------+------------+                                                            
  | family | 👨‍👩‍👧‍👦         |                                                          
-                                  ``ts                                              
+  
  +--------+------------+                                                            
  | wide   | コンニチハ |                                                            
  +--------+------------+                                                            
@@ -23,4 +17,5 @@
  ```ts                                                                              
    const width = 'stable';                                                          
    console.log(width);                                                              
+ ```                                                                                
  OSC8 link end                                                                      

--- a/packages/tui/test/fixtures/render-goldens/layout-resize-rich-text/viewport.txt
+++ b/packages/tui/test/fixtures/render-goldens/layout-resize-rich-text/viewport.txt
@@ -1,4 +1,3 @@
- Golden rich text                                                                   
                                                                                     
  │ Deterministic quote with link (https://example.test/golden).                     
                                                                                     
@@ -9,7 +8,7 @@
  | Glyph  | Value      |                                                            
  +--------+------------+                                                            
  | family | 👨‍👩‍👧‍👦         |                                                          
-                                  ``ts                                              
+  
  +--------+------------+                                                            
  | wide   | コンニチハ |                                                            
  +--------+------------+                                                            
@@ -17,4 +16,5 @@
  ```ts                                                                              
    const width = 'stable';                                                          
    console.log(width);                                                              
+ ```                                                                                
  OSC8 link end                                                                      

--- a/packages/tui/test/fixtures/render-goldens/layout-resize-rich-text/writelog.bin
+++ b/packages/tui/test/fixtures/render-goldens/layout-resize-rich-text/writelog.bin
@@ -17,4 +17,43 @@
    [32mconst width = 'stable';[39m                                                  [0m
    [32mconsole.log(width);[39m                                                      [0m
  [2m```[22m                                                                        [0m
- ]8;;https://example.test/osc8OSC8 link]8;; end                                                              [0m]8;;[?25l[?2026l[?2026h[H                                                          [0m[1B +--------+------------+                                  [0m[1B | [1mGlyph [22m | [1mValue     [22m |                                  [0m[1B +--------+------------+                                  [0m[1B | family | 👨‍👩‍👧‍👦         |                                  [0m[1B +--------+------------+                                  [0m[1B | wide   | コンニチハ |                                  [0m[1B +--------+------------+                                  [0m[1B                                                          [0m[1B [2m```ts[22m                                                    [0m[1B   [32mconst width = 'stable';[39m                                [0m[1B   [32mconsole.log(width);[39m                                    [0m[1B [2m```[22m                                                      [0m[1B ]8;;https://example.test/osc8OSC8 link]8;; end                                            [0m]8;;[?25l[?2026l[?2026h[H [1m[36m[1m[4mGolden rich text[24m[22m[1m[39m[22m                                                                   [0m[1B                                                                                    [0m[1B [2m│ [22m[3m[3mDeterministic quote with ]8;;https://example.test/golden[34m[4mlink[24m[39m]8;;]8;;https://example.test/golden[2m (https://example.test/golden)[22m]8;;.[23m[3m[23m                     [0m]8;;[1B                                                                                    [0m[1B [36m- [39mlist alpha                                                                       [0m[1B [36m- [39mlist beta with CJK 表示 and 한글 jamo 한                                         [0m[1B                                                                                    [0m[1B +--------+------------+                                                            [0m[1B | [1mGlyph [22m | [1mValue     [22m |                                                            [0m[1B +--------+------------+                                                            [0m[1B | family | 👨‍👩‍👧‍👦         |                                                            [0m[1B +--------+------------+                                                            [0m[1B | wide   | コンニチハ |                                                            [0m[1B +--------+------------+                                                            [0m[1B                                                                                    [0m[1B [2m```ts[22m                                                                              [0m[1B   [32mconst width = 'stable';[39m                                                          [0m[1B   [32mconsole.log(width);[39m                                                              [0m[1B [2m```[22m                                                                                [0m[1B ]8;;https://example.test/osc8OSC8 link]8;; end                                                                      [0m]8;;[?25l[?2026l
+ ]8;;https://example.test/osc8OSC8 link]8;; end                                                              [0m]8;;[?25l[?2026l[?2026h[2J[H[3J [1m[36m[1m[4mGolden rich text[24m[22m[1m[39m[22m                                         [0m
+                                                          [0m
+ [2m│ [22m[3m[3mDeterministic quote with ]8;;https://example.test/golden[34m[4mlink[24m[39m]8;;]8;;https://example.test/golden[2m                          [0m]8;;
+ [2m│ [22m[2;3m(https://example.test/golden)[22m]8;;.[23m[3m[23m                         [0m]8;;
+                                                          [0m
+ [36m- [39mlist alpha                                             [0m
+ [36m- [39mlist beta with CJK 表示 and 한글 jamo 한               [0m
+                                                          [0m
+ +--------+------------+                                  [0m
+ | [1mGlyph [22m | [1mValue     [22m |                                  [0m
+ +--------+------------+                                  [0m
+ | family | 👨‍👩‍👧‍👦         |                                  [0m
+ +--------+------------+                                  [0m
+ | wide   | コンニチハ |                                  [0m
+ +--------+------------+                                  [0m
+                                                          [0m
+ [2m```ts[22m                                                    [0m
+   [32mconst width = 'stable';[39m                                [0m
+   [32mconsole.log(width);[39m                                    [0m
+ [2m```[22m                                                      [0m
+ ]8;;https://example.test/osc8OSC8 link]8;; end                                            [0m]8;;[?25l[?2026l[?2026h[2J[H[3J [1m[36m[1m[4mGolden rich text[24m[22m[1m[39m[22m                                                                   [0m
+                                                                                    [0m
+ [2m│ [22m[3m[3mDeterministic quote with ]8;;https://example.test/golden[34m[4mlink[24m[39m]8;;]8;;https://example.test/golden[2m (https://example.test/golden)[22m]8;;.[23m[3m[23m                     [0m]8;;
+                                                                                    [0m
+ [36m- [39mlist alpha                                                                       [0m
+ [36m- [39mlist beta with CJK 表示 and 한글 jamo 한                                         [0m
+                                                                                    [0m
+ +--------+------------+                                                            [0m
+ | [1mGlyph [22m | [1mValue     [22m |                                                            [0m
+ +--------+------------+                                                            [0m
+ | family | 👨‍👩‍👧‍👦         |                                                            [0m
+ +--------+------------+                                                            [0m
+ | wide   | コンニチハ |                                                            [0m
+ +--------+------------+                                                            [0m
+                                                                                    [0m
+ [2m```ts[22m                                                                              [0m
+   [32mconst width = 'stable';[39m                                                          [0m
+   [32mconsole.log(width);[39m                                                              [0m
+ [2m```[22m                                                                                [0m
+ ]8;;https://example.test/osc8OSC8 link]8;; end                                                                      [0m]8;;[?25l[?2026l

--- a/packages/tui/test/fixtures/render-goldens/transcript-shrink-clear/meta.json
+++ b/packages/tui/test/fixtures/render-goldens/transcript-shrink-clear/meta.json
@@ -24,7 +24,7 @@
     },
     "writelog": {
       "file": "writelog.bin",
-      "sha256": "4a29813db4c5afe3a01603169092ca4557f8784c80b96073b17b121c684f4efc"
+      "sha256": "b4b16c762cb174f8a184d57589dbe42b7e46efd7b09702217051eaf9ed487d22"
     }
   }
 }

--- a/packages/tui/test/fixtures/render-goldens/transcript-shrink-clear/writelog.bin
+++ b/packages/tui/test/fixtures/render-goldens/transcript-shrink-clear/writelog.bin
@@ -23,4 +23,29 @@ transcript-21 :: stable append[0m
 transcript-22 :: stable append[0m
 transcript-23 :: stable append[0m
 transcript-24 :: stable append[0m
-transcript-25 :: stable append[0m[?25l[?2026l[?2026h[Htranscript-18 :: stable append[0m                      [1Btranscript-19 :: stable append[0m                      [1Btranscript-20 :: stable append[0m                      [1Btranscript-21 :: stable append[0m                      [1Btranscript-22 :: stable append[0m                      [1Btranscript-23 :: stable append[0m                      [1Btranscript-24 :: stable append[0m                      [1Btranscript-25 :: stable append[0m                      [?25l[?2026l[?2026h[Hshort-0[0m                                             [1Bshort-1[0m                                             [1Bshort-2[0m                                             [1B                                                    [1B                                                    [1B                                                    [1B                                                    [1B                                                    [?25l[?2026l
+transcript-25 :: stable append[0m[?25l[?2026l[?2026h[2J[H[3Jtranscript-00 :: stable append[0m
+transcript-01 :: stable append[0m
+transcript-02 :: stable append[0m
+transcript-03 :: stable append[0m
+transcript-04 :: stable append[0m
+transcript-05 :: stable append[0m
+transcript-06 :: stable append[0m
+transcript-07 :: stable append[0m
+transcript-08 :: stable append[0m
+transcript-09 :: stable append[0m
+transcript-10 :: stable append[0m
+transcript-11 :: stable append[0m
+transcript-12 :: stable append[0m
+transcript-13 :: stable append[0m
+transcript-14 :: stable append[0m
+transcript-15 :: stable append[0m
+transcript-16 :: stable append[0m
+transcript-17 :: stable append[0m
+transcript-18 :: stable append[0m
+transcript-19 :: stable append[0m
+transcript-20 :: stable append[0m
+transcript-21 :: stable append[0m
+transcript-22 :: stable append[0m
+transcript-23 :: stable append[0m
+transcript-24 :: stable append[0m
+transcript-25 :: stable append[0m[?25l[?2026l[?2026h[Hshort-0[0m                                             [1Bshort-1[0m                                             [1Bshort-2[0m                                             [1B                                                    [1B                                                    [1B                                                    [1B                                                    [1B                                                    [?25l[?2026l

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -416,6 +416,7 @@ describe("TUI terminal-state regressions", () => {
 		"ZELLIJ",
 		"GJC_TMUX_LAUNCHED",
 		"TERMUX_VERSION",
+		"PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER",
 		"PI_TUI_VIRTUAL_VIEWPORT",
 	] as const;
 	let previousHostEnv = new Map<string, string | undefined>();
@@ -1393,7 +1394,7 @@ describe("TUI terminal-state regressions", () => {
 
 	describe("resize + viewport behavior", () => {
 		it("preserves preexisting shell rows without startup clear", async () => {
-			const term = new VirtualTerminal(50, 5);
+			const term = new VirtualTerminal(50, 5, { isProcessTerminal: true });
 			term.write("shell-0\r\nshell-1\r\nshell-2\r\nshell-3\r\nshell-4\r\n");
 			await settle(term);
 			term.clearWriteLog();
@@ -1666,7 +1667,7 @@ describe("TUI terminal-state regressions", () => {
 			}
 		});
 		it("repaints width reflow without appending existing rows to scrollback", async () => {
-			const term = new VirtualTerminal(24, 5);
+			const term = new VirtualTerminal(24, 5, { isProcessTerminal: true });
 			const tui = new TUI(term);
 			const component = new MutableLinesComponent(rows("existing-", 8));
 			tui.addChild(component);
@@ -1688,7 +1689,7 @@ describe("TUI terminal-state regressions", () => {
 			}
 		});
 		it("repaints width reflow that increases row count without re-emitting historic rows", async () => {
-			const term = new VirtualTerminal(24, 5);
+			const term = new VirtualTerminal(24, 5, { isProcessTerminal: true });
 			const tui = new TUI(term);
 			tui.addChild(new WidthSensitiveComponent());
 
@@ -1712,7 +1713,7 @@ describe("TUI terminal-state regressions", () => {
 			}
 		});
 		it("repaints an offscreen same-length mutation after width reflow growth without replaying history", async () => {
-			const term = new VirtualTerminal(24, 5);
+			const term = new VirtualTerminal(24, 5, { isProcessTerminal: true });
 			const tui = new TUI(term);
 			const component = new ReflowableHeaderComponent();
 			tui.addChild(component);
@@ -1804,7 +1805,7 @@ describe("TUI terminal-state regressions", () => {
 			}
 		});
 		it("repaints newly exposed rows after transient width reflow before a height-only resize", async () => {
-			const term = new VirtualTerminal(24, 10);
+			const term = new VirtualTerminal(24, 10, { isProcessTerminal: true });
 			const tui = new TUI(term);
 			const component = new WidthSensitiveComponent();
 			tui.addChild(component);
@@ -2053,7 +2054,7 @@ describe("TUI terminal-state regressions", () => {
 			}
 		});
 		it("repaints an ambiguous final-row mutation instead of committing its reflow continuation", async () => {
-			const term = new VirtualTerminal(24, 4);
+			const term = new VirtualTerminal(24, 4, { isProcessTerminal: true });
 			const tui = new TUI(term);
 			const component = new FinalWrappingStatusComponent();
 			tui.addChild(component);
@@ -2077,7 +2078,7 @@ describe("TUI terminal-state regressions", () => {
 			}
 		});
 		it("repaints a prefix-extending final-row mutation instead of committing its reflow continuation", async () => {
-			const term = new VirtualTerminal(24, 4);
+			const term = new VirtualTerminal(24, 4, { isProcessTerminal: true });
 			const tui = new TUI(term);
 			const component = new FinalWrappingStatusComponent();
 			tui.addChild(component);
@@ -2667,6 +2668,7 @@ describe("TUI terminal-state regressions", () => {
 
 	describe("scrollback integrity", () => {
 		it("repaints only the visible viewport for offscreen changes in tmux", async () => {
+			const previousTmux = Bun.env.TMUX;
 			Bun.env.TMUX = "1";
 
 			const term = new VirtualTerminal(32, 5, { isProcessTerminal: true });
@@ -2695,6 +2697,8 @@ describe("TUI terminal-state regressions", () => {
 				expect(writes).toContain("line-79");
 			} finally {
 				tui.stop();
+				if (previousTmux === undefined) delete Bun.env.TMUX;
+				else Bun.env.TMUX = previousTmux;
 			}
 		});
 

--- a/packages/tui/test/resize-replay-storm.test.ts
+++ b/packages/tui/test/resize-replay-storm.test.ts
@@ -325,6 +325,7 @@ describe("multiplexer resize replay storm regression", () => {
 	describe("in Termux", () => {
 		let origTermuxVersion: string | undefined;
 		let origTmux: string | undefined;
+		let origTmuxPane: string | undefined;
 		let origSty: string | undefined;
 		let origZellij: string | undefined;
 		let origLaunched: string | undefined;
@@ -332,11 +333,13 @@ describe("multiplexer resize replay storm regression", () => {
 		beforeEach(() => {
 			origTermuxVersion = process.env.TERMUX_VERSION;
 			origTmux = process.env.TMUX;
+			origTmuxPane = process.env.TMUX_PANE;
 			origSty = process.env.STY;
 			origZellij = process.env.ZELLIJ;
 			origLaunched = process.env.GJC_TMUX_LAUNCHED;
 			process.env.TERMUX_VERSION = "1";
 			delete process.env.TMUX;
+			delete process.env.TMUX_PANE;
 			delete process.env.STY;
 			delete process.env.ZELLIJ;
 			delete process.env.GJC_TMUX_LAUNCHED;
@@ -347,6 +350,8 @@ describe("multiplexer resize replay storm regression", () => {
 			else process.env.TERMUX_VERSION = origTermuxVersion;
 			if (origTmux === undefined) delete process.env.TMUX;
 			else process.env.TMUX = origTmux;
+			if (origTmuxPane === undefined) delete process.env.TMUX_PANE;
+			else process.env.TMUX_PANE = origTmuxPane;
 			if (origSty === undefined) delete process.env.STY;
 			else process.env.STY = origSty;
 			if (origZellij === undefined) delete process.env.ZELLIJ;
@@ -374,7 +379,7 @@ describe("multiplexer resize replay storm regression", () => {
 			tui.stop();
 		});
 		it("uses a bounded viewport repaint for headless height resizes", async () => {
-			const term = new VirtualTerminal(COLS, 30);
+			const term = new VirtualTerminal(COLS, 30, { isProcessTerminal: true });
 			const tui = new TUI(term);
 			tui.start();
 			await term.waitForRender();
@@ -452,9 +457,11 @@ describe("multiplexer resize replay storm regression", () => {
 			await term.waitForRender();
 
 			const out = term.getWriteLog().join("");
-			expect(distinctReplayedLineMarkers(out)).toBeLessThanOrEqual(term.rows + 2);
-			expect(out).not.toContain("\x1b[3J");
-			expect(out).not.toContain("\x1b[2J");
+			// Plain terminals use fullRender on forced redraws, which clears
+			// scrollback and replays the full transcript.
+			expect(distinctReplayedLineMarkers(out)).toBe(60);
+			expect(out).toContain("\x1b[3J");
+			expect(out).toContain("\x1b[2J");
 
 			tui.stop();
 		});


### PR DESCRIPTION
## Summary

The #3684 chain (`eacf5345a` → `4c6e81706` → `eef2afbd8`) removed the `shouldUseViewportRepaintForHost` gate from the width-change viewport-repaint intercept in `packages/tui/src/tui.ts`. This made **all** terminals unconditionally redirect width-changed renders to a live viewport repaint, bypassing `fullRender` on plain terminals (non-multiplexer, non-process-terminal).

### Root cause

Korean/CJK prose wrapping broke at narrow widths (#1979) because the viewport repaint only painted the visible `height` rows without committing the full transcript frame. The suffix `끝-ISSUE-1979-SUFFIX` was split across viewport boundaries with selector content interleaved between its halves.

### Fix (3 changes in `tui.ts`)

1. **Width-change intercept** — moved `useViewportRepaintPath` computation before the intercept and added it as a condition. Non-viewport-repaint hosts now fall through to the existing `fullRender` path.
2. **`firstChanged < viewportTop` branch** — restored `fullRender` fallback for non-viewport-repaint hosts.
3. **`#writeRenderBufferAndReanchorImeCursor`** — propagated IME cursor write failure so callers detect terminal detach when the deferred cursor write fails after the shared frame commits.

### Test updates

- `issue-1979-korean-wrap.test.ts` — added multiplexer env cleanup so the test deterministically exercises the plain-terminal render path.
- `render-regressions.test.ts` — added `isProcessTerminal: true` to VirtualTerminals in 7 tests that exercise viewport-repaint-specific behavior.
- `resize-replay-storm.test.ts` — added `TMUX_PANE` cleanup to Termux beforeEach, `isProcessTerminal: true` to the headless height test, and corrected the plain-terminal forced-redraw expectation.
- Regenerated 2 render golden fixtures.

### Verification

- `bun test packages/coding-agent/test/issue-1979-korean-wrap.test.ts` — **1 pass**
- `bun test packages/tui/test/` — **1014 pass, 6 skip, 1 fail** (pre-existing test isolation issue: `repaints only the visible viewport for offscreen changes in tmux` fails when run after Kitty tests due to module-level state leakage; passes individually and within its describe block)

Issue: #1979
Confidence: high
Scope-risk: narrow
Reversibility: revert-commit
Tested: full TUI suite + issue-1979 Korean wrap test
Not-tested: real multiplexer session (CI covers via env injection)