### PR TITLE
feat(ai): add read-only OpenCodex provider

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added read-only OpenCodex provider discovery with runtime-port resolution, identity-checked health probing, cached `/api/models` catalogs, raw wire model ids, and `/login opencodex` status reprobes without credential persistence.
+
 
 ### Fixed
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -11,6 +11,7 @@ import { Database, type Statement } from "bun:sqlite";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getAgentDbPath, logger } from "@gajae-code/utils";
+import { checkOpenCodexStatus } from "./providers/openai-opencodex-responses";
 import { getEnvApiKey } from "./stream";
 import type { Provider } from "./types";
 import type {
@@ -1726,7 +1727,12 @@ export class AuthStorage {
 			await this.set(provider, newCredential);
 		};
 		const manualCodeInput = () => ctrl.onPrompt({ message: "Paste the authorization code (or full redirect URL):" });
+
 		switch (provider) {
+			case "opencodex": {
+				await checkOpenCodexStatus(ctrl.onProgress);
+				return;
+			}
 			case "anthropic": {
 				const { loginAnthropic } = await import("./utils/oauth/anthropic");
 				credentials = await loginAnthropic({

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -24,6 +24,7 @@ export * from "./providers/mock";
 export * from "./providers/ollama";
 export * from "./providers/openai-codex-responses";
 export * from "./providers/openai-completions";
+export * from "./providers/openai-opencodex-responses";
 export * from "./providers/openai-responses";
 export * from "./providers/synthetic";
 export * from "./rate-limit-utils";

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -48,7 +48,12 @@ import {
 	xiaomiModelManagerOptions,
 	zenmuxModelManagerOptions,
 } from "./openai-compat";
-import { cursorModelManagerOptions, glmZcodeModelManagerOptions, zaiModelManagerOptions } from "./special";
+import {
+	cursorModelManagerOptions,
+	glmZcodeModelManagerOptions,
+	openCodexModelManagerOptions,
+	zaiModelManagerOptions,
+} from "./special";
 
 /** Catalog discovery configuration for providers that support endpoint-based model listing. */
 export interface CatalogDiscoveryConfig {
@@ -139,6 +144,7 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 		catalog("Alibaba Token Plan", ["ALIBABA_TOKEN_PLAN_API_KEY"], { oauthProvider: "alibaba-token-plan" }),
 	),
 	descriptor("openai", "gpt-5.4", config => openaiModelManagerOptions(config)),
+	descriptor("opencodex", "gpt-5.4", () => openCodexModelManagerOptions(), { allowUnauthenticated: true }),
 	descriptor("groq", "openai/gpt-oss-120b", config => groqModelManagerOptions(config)),
 	catalogDescriptor(
 		"huggingface",

--- a/packages/ai/src/provider-models/special.ts
+++ b/packages/ai/src/provider-models/special.ts
@@ -1,6 +1,14 @@
 import { once } from "@gajae-code/utils";
 import type { ModelManagerOptions } from "../model-manager";
+import { fetchOpenCodexModels, OPENCODEX_MODEL_CACHE_TTL_MS } from "../providers/openai-opencodex-responses";
 import { fetchCodexModels } from "../utils/discovery/codex";
+export function openCodexModelManagerOptions(): ModelManagerOptions<"openai-responses"> {
+	return {
+		providerId: "opencodex",
+		cacheTtlMs: OPENCODEX_MODEL_CACHE_TTL_MS,
+		fetchDynamicModels: fetchOpenCodexModels,
+	};
+}
 
 // ---------------------------------------------------------------------------
 // OpenAI code provider

--- a/packages/ai/src/providers/openai-opencodex-responses.ts
+++ b/packages/ai/src/providers/openai-opencodex-responses.ts
@@ -1,6 +1,8 @@
 import * as fs from "node:fs/promises";
+import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
+
 import type { Model } from "../types";
 
 export const OPENCODEX_DEFAULT_PORT = 10100;
@@ -43,9 +45,24 @@ function timeoutSignal(signal?: AbortSignal): AbortSignal {
 
 function normalizeEndpoint(hostname: string, port: number): string | undefined {
 	if (!Number.isInteger(port) || port < 1 || port > 65535) return undefined;
-	const host = hostname.trim();
-	if (!host || host.includes("/") || host.includes("://")) return undefined;
-	return `http://${host}:${port}`;
+	const host = normalizeLoopbackHost(hostname);
+	if (!host) return undefined;
+	return `http://${formatEndpointHost(host)}:${port}`;
+}
+
+function normalizeLoopbackHost(hostname: string): string | undefined {
+	const host = hostname.trim().toLowerCase();
+	if (net.isIP(host) === 4 && host.startsWith("127.")) return host;
+	if (host === "::1") return host;
+	return undefined;
+}
+
+function formatEndpointHost(host: string): string {
+	return host.includes(":") ? `[${host}]` : host;
+}
+
+function healthPort(endpoint: string): number {
+	return Number(new URL(endpoint).port);
 }
 
 async function readRuntimeEndpoint(): Promise<string | undefined> {
@@ -77,15 +94,10 @@ async function fetchJson(url: string, signal?: AbortSignal): Promise<unknown> {
 	return response.json();
 }
 
-function isOpenCodexHealth(payload: unknown): boolean {
+function isOpenCodexHealth(payload: unknown, expectedPort: number): boolean {
 	if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
 	const health = payload as HealthPayload;
-	if (health.ok !== true) return false;
-	return (
-		typeof health.version === "string" ||
-		(typeof health.pid === "number" && Number.isFinite(health.pid)) ||
-		(typeof health.port === "number" && Number.isFinite(health.port))
-	);
+	return health.ok === true && health.version === "opencodex" && health.port === expectedPort;
 }
 
 export async function resolveOpenCodexEndpoint(signal?: AbortSignal): Promise<OpenCodexEndpoint | undefined> {
@@ -93,7 +105,7 @@ export async function resolveOpenCodexEndpoint(signal?: AbortSignal): Promise<Op
 	for (const candidate of candidateEndpoints(runtimeEndpoint)) {
 		try {
 			const health = await fetchJson(`${candidate}/healthz`, signal);
-			if (isOpenCodexHealth(health)) return { baseUrl: candidate };
+			if (isOpenCodexHealth(health, healthPort(candidate))) return { baseUrl: candidate };
 		} catch {
 			// An unavailable or foreign listener is a normal provider absence.
 		}

--- a/packages/ai/src/providers/openai-opencodex-responses.ts
+++ b/packages/ai/src/providers/openai-opencodex-responses.ts
@@ -1,0 +1,160 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Model } from "../types";
+
+export const OPENCODEX_DEFAULT_PORT = 10100;
+export const OPENCODEX_PROBE_TIMEOUT_MS = 750;
+export const OPENCODEX_MODEL_CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface RuntimePortFile {
+	hostname?: unknown;
+	host?: unknown;
+	port?: unknown;
+}
+
+interface HealthPayload {
+	ok?: unknown;
+	pid?: unknown;
+	port?: unknown;
+	version?: unknown;
+}
+
+interface CatalogRow {
+	id?: unknown;
+	model?: unknown;
+	name?: unknown;
+	displayName?: unknown;
+	contextWindow?: unknown;
+	maxTokens?: unknown;
+	reasoning?: unknown;
+	input?: unknown;
+}
+
+export interface OpenCodexEndpoint {
+	baseUrl: string;
+}
+
+function timeoutSignal(signal?: AbortSignal): AbortSignal {
+	return signal
+		? AbortSignal.any([signal, AbortSignal.timeout(OPENCODEX_PROBE_TIMEOUT_MS)])
+		: AbortSignal.timeout(OPENCODEX_PROBE_TIMEOUT_MS);
+}
+
+function normalizeEndpoint(hostname: string, port: number): string | undefined {
+	if (!Number.isInteger(port) || port < 1 || port > 65535) return undefined;
+	const host = hostname.trim();
+	if (!host || host.includes("/") || host.includes("://")) return undefined;
+	return `http://${host}:${port}`;
+}
+
+async function readRuntimeEndpoint(): Promise<string | undefined> {
+	const home = process.env.OPENCODEX_HOME?.trim() || path.join(os.homedir(), ".opencodex");
+	try {
+		const raw = JSON.parse(await fs.readFile(path.join(home, "runtime-port.json"), "utf8")) as RuntimePortFile;
+		const hostname =
+			typeof raw.hostname === "string" ? raw.hostname : typeof raw.host === "string" ? raw.host : "127.0.0.1";
+		const port = typeof raw.port === "number" ? raw.port : typeof raw.port === "string" ? Number(raw.port) : NaN;
+		return normalizeEndpoint(hostname, port);
+	} catch {
+		return undefined;
+	}
+}
+
+function candidateEndpoints(runtimeEndpoint: string | undefined): string[] {
+	const candidates = runtimeEndpoint ? [runtimeEndpoint] : [];
+	const fallback = normalizeEndpoint("127.0.0.1", OPENCODEX_DEFAULT_PORT);
+	if (fallback && !candidates.includes(fallback)) candidates.push(fallback);
+	return candidates;
+}
+
+async function fetchJson(url: string, signal?: AbortSignal): Promise<unknown> {
+	const response = await fetch(url, {
+		headers: { Accept: "application/json" },
+		signal: timeoutSignal(signal),
+	});
+	if (!response.ok) return undefined;
+	return response.json();
+}
+
+function isOpenCodexHealth(payload: unknown): boolean {
+	if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
+	const health = payload as HealthPayload;
+	if (health.ok !== true) return false;
+	return (
+		typeof health.version === "string" ||
+		(typeof health.pid === "number" && Number.isFinite(health.pid)) ||
+		(typeof health.port === "number" && Number.isFinite(health.port))
+	);
+}
+
+export async function resolveOpenCodexEndpoint(signal?: AbortSignal): Promise<OpenCodexEndpoint | undefined> {
+	const runtimeEndpoint = await readRuntimeEndpoint();
+	for (const candidate of candidateEndpoints(runtimeEndpoint)) {
+		try {
+			const health = await fetchJson(`${candidate}/healthz`, signal);
+			if (isOpenCodexHealth(health)) return { baseUrl: candidate };
+		} catch {
+			// An unavailable or foreign listener is a normal provider absence.
+		}
+	}
+	return undefined;
+}
+
+function asPositiveNumber(value: unknown, fallback: number): number {
+	return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function normalizeCatalogPayload(payload: unknown): CatalogRow[] {
+	if (Array.isArray(payload)) return payload as CatalogRow[];
+	if (payload && typeof payload === "object" && Array.isArray((payload as { models?: unknown }).models)) {
+		return (payload as { models: CatalogRow[] }).models;
+	}
+	return [];
+}
+
+function normalizeModel(row: CatalogRow, endpoint: OpenCodexEndpoint): Model<"openai-responses"> | undefined {
+	const rawId = typeof row.id === "string" ? row.id.trim() : typeof row.model === "string" ? row.model.trim() : "";
+	if (!rawId || rawId.includes("\n")) return undefined;
+	const publicId = `opencodex/${rawId}`;
+	const input =
+		Array.isArray(row.input) && row.input.every(value => value === "text" || value === "image")
+			? row.input
+			: ["text"];
+	return {
+		id: publicId,
+		wireModelId: rawId,
+		name: typeof row.displayName === "string" ? row.displayName : typeof row.name === "string" ? row.name : rawId,
+		api: "openai-responses",
+		provider: "opencodex",
+		baseUrl: `${endpoint.baseUrl}/v1`,
+		reasoning: row.reasoning !== false,
+		input,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: asPositiveNumber(row.contextWindow, 128_000),
+		maxTokens: asPositiveNumber(row.maxTokens, 16_384),
+	};
+}
+
+export async function fetchOpenCodexModels(): Promise<readonly Model<"openai-responses">[] | null> {
+	const endpoint = await resolveOpenCodexEndpoint();
+	if (!endpoint) return null;
+	try {
+		const rows = normalizeCatalogPayload(await fetchJson(`${endpoint.baseUrl}/api/models`));
+		const models = rows
+			.map(row => normalizeModel(row, endpoint))
+			.filter((model): model is Model<"openai-responses"> => model !== undefined);
+		return models.length > 0 ? models : null;
+	} catch {
+		return null;
+	}
+}
+
+export async function checkOpenCodexStatus(onProgress?: (message: string) => void): Promise<void> {
+	const endpoint = await resolveOpenCodexEndpoint();
+	if (endpoint) {
+		onProgress?.(`OpenCodex is available at ${endpoint.baseUrl}`);
+		return;
+	}
+	onProgress?.("OpenCodex is unavailable; no identity-checked local proxy was found.");
+}

--- a/packages/ai/src/providers/openai-opencodex-responses.ts
+++ b/packages/ai/src/providers/openai-opencodex-responses.ts
@@ -88,6 +88,7 @@ function candidateEndpoints(runtimeEndpoint: string | undefined): string[] {
 async function fetchJson(url: string, signal?: AbortSignal): Promise<unknown> {
 	const response = await fetch(url, {
 		headers: { Accept: "application/json" },
+		redirect: "error",
 		signal: timeoutSignal(signal),
 	});
 	if (!response.ok) return undefined;

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -326,7 +326,7 @@ export function stream<TApi extends Api>(
 		return streamBedrock(model as Model<"bedrock-converse-stream">, context, (options || {}) as BedrockOptions);
 	}
 
-	const apiKey = options?.apiKey || getEnvApiKey(model.provider);
+	const apiKey = options?.apiKey || (model.provider === "opencodex" ? "local" : getEnvApiKey(model.provider));
 	if (!apiKey) {
 		throw new Error(formatMissingApiKeyError(model.provider));
 	}

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -124,6 +124,7 @@ export type KnownProvider =
 	| "google-vertex"
 	| "openai"
 	| "openai-codex"
+	| "opencodex"
 	| "kimi-code"
 	| "minimax-code"
 	| "minimax-code-cn"

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -26,6 +26,11 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 		available: true,
 	},
 	{
+		id: "opencodex",
+		name: "OpenCodex (local proxy status)",
+		available: true,
+	},
+	{
 		id: "openai-codex-device",
 		name: "ChatGPT Plus/Pro (Codex, headless/device)",
 		available: true,

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -60,6 +60,7 @@ export type OAuthProvider =
 	| "xiaomi-token-plan-ams"
 	| "xiaomi-token-plan-cn"
 	| "zenmux"
+	| "opencodex"
 	| "zai";
 
 export type OAuthProviderId = OAuthProvider | (string & {});

--- a/packages/ai/test/openai-opencodex-responses.test.ts
+++ b/packages/ai/test/openai-opencodex-responses.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	checkOpenCodexStatus,
+	fetchOpenCodexModels,
+	resolveOpenCodexEndpoint,
+} from "@gajae-code/ai/providers/openai-opencodex-responses";
+
+const originalFetch = globalThis.fetch;
+const originalHome = process.env.OPENCODEX_HOME;
+let tempHome: string;
+
+beforeEach(async () => {
+	tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-opencodex-"));
+	process.env.OPENCODEX_HOME = tempHome;
+});
+
+afterEach(async () => {
+	globalThis.fetch = originalFetch;
+	if (originalHome === undefined) delete process.env.OPENCODEX_HOME;
+	else process.env.OPENCODEX_HOME = originalHome;
+	await fs.rm(tempHome, { recursive: true, force: true });
+});
+
+describe("OpenCodex discovery", () => {
+	test("prefers runtime metadata before the default port and preserves raw model ids", async () => {
+		await Bun.write(path.join(tempHome, "runtime-port.json"), JSON.stringify({ hostname: "127.0.0.1", port: 10201 }));
+		const calls: string[] = [];
+		globalThis.fetch = spyOn(globalThis, "fetch").mockImplementation(async input => {
+			const url = String(input);
+			calls.push(url);
+			if (url.endsWith("/healthz"))
+				return new Response(JSON.stringify({ ok: true, version: "opencodex" }), { status: 200 });
+			return new Response(JSON.stringify([{ id: "provider/model", name: "Provider Model" }]), { status: 200 });
+		});
+
+		const models = await fetchOpenCodexModels();
+		expect(calls).toEqual(["http://127.0.0.1:10201/healthz", "http://127.0.0.1:10201/api/models"]);
+		expect(models?.[0]).toMatchObject({
+			id: "opencodex/provider/model",
+			wireModelId: "provider/model",
+			baseUrl: "http://127.0.0.1:10201/v1",
+			provider: "opencodex",
+		});
+	});
+
+	test("falls back to port 10100 when runtime metadata is absent", async () => {
+		globalThis.fetch = spyOn(globalThis, "fetch").mockImplementation(async input => {
+			expect(String(input)).toBe("http://127.0.0.1:10100/healthz");
+			return new Response(JSON.stringify({ ok: true, pid: 42, port: 10100 }), { status: 200 });
+		});
+		expect(await resolveOpenCodexEndpoint()).toEqual({ baseUrl: "http://127.0.0.1:10100" });
+	});
+
+	test("rejects foreign or malformed health responses", async () => {
+		globalThis.fetch = spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify({ ok: true }), { status: 200 }),
+		);
+		expect(await resolveOpenCodexEndpoint()).toBeUndefined();
+	});
+
+	test("omits a provider when catalog retrieval fails", async () => {
+		globalThis.fetch = spyOn(globalThis, "fetch").mockImplementation(async input => {
+			if (String(input).endsWith("/healthz"))
+				return new Response(JSON.stringify({ ok: true, version: "opencodex" }));
+			return new Response("unavailable", { status: 503 });
+		});
+		expect(await fetchOpenCodexModels()).toBeNull();
+	});
+
+	test("status is read-only and reports absence without throwing", async () => {
+		globalThis.fetch = spyOn(globalThis, "fetch").mockRejectedValue(new Error("connection refused"));
+		const messages: string[] = [];
+		await checkOpenCodexStatus(message => messages.push(message));
+		expect(messages[0]).toContain("unavailable");
+	});
+});

--- a/packages/ai/test/openai-opencodex-responses.test.ts
+++ b/packages/ai/test/openai-opencodex-responses.test.ts
@@ -34,7 +34,7 @@ describe("OpenCodex discovery", () => {
 					const url = String(input);
 					calls.push(url);
 					if (url.endsWith("/healthz"))
-						return new Response(JSON.stringify({ ok: true, version: "opencodex" }), { status: 200 });
+						return new Response(JSON.stringify({ ok: true, version: "opencodex", port: 10201 }), { status: 200 });
 					return new Response(JSON.stringify([{ id: "provider/model", name: "Provider Model" }]), { status: 200 });
 				},
 				{ preconnect: originalFetch.preconnect },
@@ -50,13 +50,74 @@ describe("OpenCodex discovery", () => {
 			provider: "opencodex",
 		});
 	});
+	test("ignores runtime endpoints on foreign hosts", async () => {
+		await Bun.write(
+			path.join(tempHome, "runtime-port.json"),
+			JSON.stringify({ hostname: "192.0.2.10", port: 10201 }),
+		);
+		const calls: string[] = [];
+		spyOn(globalThis, "fetch").mockImplementation(
+			Object.assign(
+				async (input: string | Request | URL) => {
+					calls.push(String(input));
+					return new Response(JSON.stringify({ ok: false }), { status: 200 });
+				},
+				{ preconnect: originalFetch.preconnect },
+			),
+		);
+
+		expect(await resolveOpenCodexEndpoint()).toBeUndefined();
+		expect(calls).toEqual(["http://127.0.0.1:10100/healthz"]);
+	});
+
+	test("rejects a mismatched health identity", async () => {
+		await Bun.write(path.join(tempHome, "runtime-port.json"), JSON.stringify({ hostname: "127.0.0.1", port: 10201 }));
+		const calls: string[] = [];
+		spyOn(globalThis, "fetch").mockImplementation(
+			Object.assign(
+				async (input: string | Request | URL) => {
+					const url = String(input);
+					calls.push(url);
+					if (url.includes(":10201/"))
+						return new Response(JSON.stringify({ ok: true, version: "other", port: 10201 }));
+					return new Response(JSON.stringify({ ok: false }), { status: 200 });
+				},
+				{ preconnect: originalFetch.preconnect },
+			),
+		);
+
+		expect(await resolveOpenCodexEndpoint()).toBeUndefined();
+		expect(calls).toEqual(["http://127.0.0.1:10201/healthz", "http://127.0.0.1:10100/healthz"]);
+	});
+
+	test("rejects a mismatched health port binding", async () => {
+		await Bun.write(path.join(tempHome, "runtime-port.json"), JSON.stringify({ hostname: "127.0.0.1", port: 10201 }));
+		const calls: string[] = [];
+		spyOn(globalThis, "fetch").mockImplementation(
+			Object.assign(
+				async (input: string | Request | URL) => {
+					const url = String(input);
+					calls.push(url);
+					if (url.includes(":10201/"))
+						return new Response(JSON.stringify({ ok: true, version: "opencodex", port: 10100 }));
+					return new Response(JSON.stringify({ ok: false }), { status: 200 });
+				},
+				{ preconnect: originalFetch.preconnect },
+			),
+		);
+
+		expect(await resolveOpenCodexEndpoint()).toBeUndefined();
+		expect(calls).toEqual(["http://127.0.0.1:10201/healthz", "http://127.0.0.1:10100/healthz"]);
+	});
 
 	test("falls back to port 10100 when runtime metadata is absent", async () => {
 		spyOn(globalThis, "fetch").mockImplementation(
 			Object.assign(
 				async (input: string | Request | URL) => {
 					expect(String(input)).toBe("http://127.0.0.1:10100/healthz");
-					return new Response(JSON.stringify({ ok: true, pid: 42, port: 10100 }), { status: 200 });
+					return new Response(JSON.stringify({ ok: true, version: "opencodex", pid: 42, port: 10100 }), {
+						status: 200,
+					});
 				},
 				{ preconnect: originalFetch.preconnect },
 			),
@@ -74,7 +135,7 @@ describe("OpenCodex discovery", () => {
 			Object.assign(
 				async (input: string | Request | URL) => {
 					if (String(input).endsWith("/healthz"))
-						return new Response(JSON.stringify({ ok: true, version: "opencodex" }));
+						return new Response(JSON.stringify({ ok: true, version: "opencodex", port: 10201 }));
 					return new Response("unavailable", { status: 503 });
 				},
 				{ preconnect: originalFetch.preconnect },

--- a/packages/ai/test/openai-opencodex-responses.test.ts
+++ b/packages/ai/test/openai-opencodex-responses.test.ts
@@ -109,6 +109,52 @@ describe("OpenCodex discovery", () => {
 		expect(await resolveOpenCodexEndpoint()).toBeUndefined();
 		expect(calls).toEqual(["http://127.0.0.1:10201/healthz", "http://127.0.0.1:10100/healthz"]);
 	});
+	test("does not follow foreign redirects during health probing", async () => {
+		await Bun.write(path.join(tempHome, "runtime-port.json"), JSON.stringify({ hostname: "127.0.0.1", port: 10201 }));
+		const redirects: RequestInit["redirect"][] = [];
+		spyOn(globalThis, "fetch").mockImplementation(
+			Object.assign(
+				async (_input: string | Request | URL, init?: RequestInit) => {
+					redirects.push(init?.redirect ?? "follow");
+					return new Response(null, {
+						status: 302,
+						headers: { location: "http://192.0.2.10:10201/healthz" },
+					});
+				},
+				{ preconnect: originalFetch.preconnect },
+			),
+		);
+
+		expect(await resolveOpenCodexEndpoint()).toBeUndefined();
+		expect(redirects).toEqual(["error", "error"]);
+	});
+
+	test("does not follow foreign redirects during catalog fetch", async () => {
+		await Bun.write(path.join(tempHome, "runtime-port.json"), JSON.stringify({ hostname: "127.0.0.1", port: 10201 }));
+		const calls: string[] = [];
+		const redirects: RequestInit["redirect"][] = [];
+		spyOn(globalThis, "fetch").mockImplementation(
+			Object.assign(
+				async (input: string | Request | URL, init?: RequestInit) => {
+					const url = String(input);
+					calls.push(url);
+					redirects.push(init?.redirect ?? "follow");
+					if (url.endsWith("/healthz")) {
+						return new Response(JSON.stringify({ ok: true, version: "opencodex", port: 10201 }), { status: 200 });
+					}
+					return new Response(null, {
+						status: 302,
+						headers: { location: "http://192.0.2.10:10201/api/models" },
+					});
+				},
+				{ preconnect: originalFetch.preconnect },
+			),
+		);
+
+		expect(await fetchOpenCodexModels()).toBeNull();
+		expect(calls).toEqual(["http://127.0.0.1:10201/healthz", "http://127.0.0.1:10201/api/models"]);
+		expect(redirects).toEqual(["error", "error"]);
+	});
 
 	test("falls back to port 10100 when runtime metadata is absent", async () => {
 		spyOn(globalThis, "fetch").mockImplementation(

--- a/packages/ai/test/openai-opencodex-responses.test.ts
+++ b/packages/ai/test/openai-opencodex-responses.test.ts
@@ -28,13 +28,18 @@ describe("OpenCodex discovery", () => {
 	test("prefers runtime metadata before the default port and preserves raw model ids", async () => {
 		await Bun.write(path.join(tempHome, "runtime-port.json"), JSON.stringify({ hostname: "127.0.0.1", port: 10201 }));
 		const calls: string[] = [];
-		globalThis.fetch = spyOn(globalThis, "fetch").mockImplementation(async input => {
-			const url = String(input);
-			calls.push(url);
-			if (url.endsWith("/healthz"))
-				return new Response(JSON.stringify({ ok: true, version: "opencodex" }), { status: 200 });
-			return new Response(JSON.stringify([{ id: "provider/model", name: "Provider Model" }]), { status: 200 });
-		});
+		spyOn(globalThis, "fetch").mockImplementation(
+			Object.assign(
+				async (input: string | Request | URL) => {
+					const url = String(input);
+					calls.push(url);
+					if (url.endsWith("/healthz"))
+						return new Response(JSON.stringify({ ok: true, version: "opencodex" }), { status: 200 });
+					return new Response(JSON.stringify([{ id: "provider/model", name: "Provider Model" }]), { status: 200 });
+				},
+				{ preconnect: originalFetch.preconnect },
+			),
+		);
 
 		const models = await fetchOpenCodexModels();
 		expect(calls).toEqual(["http://127.0.0.1:10201/healthz", "http://127.0.0.1:10201/api/models"]);
@@ -47,31 +52,39 @@ describe("OpenCodex discovery", () => {
 	});
 
 	test("falls back to port 10100 when runtime metadata is absent", async () => {
-		globalThis.fetch = spyOn(globalThis, "fetch").mockImplementation(async input => {
-			expect(String(input)).toBe("http://127.0.0.1:10100/healthz");
-			return new Response(JSON.stringify({ ok: true, pid: 42, port: 10100 }), { status: 200 });
-		});
+		spyOn(globalThis, "fetch").mockImplementation(
+			Object.assign(
+				async (input: string | Request | URL) => {
+					expect(String(input)).toBe("http://127.0.0.1:10100/healthz");
+					return new Response(JSON.stringify({ ok: true, pid: 42, port: 10100 }), { status: 200 });
+				},
+				{ preconnect: originalFetch.preconnect },
+			),
+		);
 		expect(await resolveOpenCodexEndpoint()).toEqual({ baseUrl: "http://127.0.0.1:10100" });
 	});
 
 	test("rejects foreign or malformed health responses", async () => {
-		globalThis.fetch = spyOn(globalThis, "fetch").mockResolvedValue(
-			new Response(JSON.stringify({ ok: true }), { status: 200 }),
-		);
+		spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 		expect(await resolveOpenCodexEndpoint()).toBeUndefined();
 	});
 
 	test("omits a provider when catalog retrieval fails", async () => {
-		globalThis.fetch = spyOn(globalThis, "fetch").mockImplementation(async input => {
-			if (String(input).endsWith("/healthz"))
-				return new Response(JSON.stringify({ ok: true, version: "opencodex" }));
-			return new Response("unavailable", { status: 503 });
-		});
+		spyOn(globalThis, "fetch").mockImplementation(
+			Object.assign(
+				async (input: string | Request | URL) => {
+					if (String(input).endsWith("/healthz"))
+						return new Response(JSON.stringify({ ok: true, version: "opencodex" }));
+					return new Response("unavailable", { status: 503 });
+				},
+				{ preconnect: originalFetch.preconnect },
+			),
+		);
 		expect(await fetchOpenCodexModels()).toBeNull();
 	});
 
 	test("status is read-only and reports absence without throwing", async () => {
-		globalThis.fetch = spyOn(globalThis, "fetch").mockRejectedValue(new Error("connection refused"));
+		spyOn(globalThis, "fetch").mockRejectedValue(new Error("connection refused"));
 		const messages: string[] = [];
 		await checkOpenCodexStatus(message => messages.push(message));
 		expect(messages[0]).toContain("unavailable");

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -2949,6 +2949,9 @@ export class SelectorController {
 		this.ctx.showStatus(`Logging in to ${providerId}…`);
 		const manualInput = this.ctx.oauthManualInput;
 		const useManualInput = CALLBACK_SERVER_PROVIDERS.has(providerId as OAuthProvider);
+		if (providerId === "opencodex") {
+			this.ctx.showStatus("Checking the local OpenCodex proxy…");
+		}
 		try {
 			await this.ctx.session.modelRegistry.authStorage.login(providerId as OAuthProvider, {
 				onAuth: (info: { url: string; instructions?: string }) => {
@@ -2997,11 +3000,17 @@ export class SelectorController {
 			});
 			await this.ctx.session.modelRegistry.refresh();
 			this.ctx.chatContainer.addChild(new Spacer(1));
-			this.ctx.chatContainer.addChild(
-				new Text(theme.fg("success", `${theme.status.success} Successfully logged in to ${providerId}`), 1, 0),
-			);
-			this.ctx.chatContainer.addChild(new Text(theme.fg("dim", `Credentials saved to ${getAgentDbPath()}`), 1, 0));
-			await this.#handlePostLoginModelProfileRecommendation(providerId);
+			const successMessage =
+				providerId === "opencodex"
+					? `${theme.status.success} OpenCodex proxy status checked`
+					: `${theme.status.success} Successfully logged in to ${providerId}`;
+			this.ctx.chatContainer.addChild(new Text(theme.fg("success", successMessage), 1, 0));
+			if (providerId !== "opencodex") {
+				this.ctx.chatContainer.addChild(
+					new Text(theme.fg("dim", `Credentials saved to ${getAgentDbPath()}`), 1, 0),
+				);
+				await this.#handlePostLoginModelProfileRecommendation(providerId);
+			}
 			this.ctx.ui.requestRender();
 		} catch (error: unknown) {
 			this.ctx.showError(`Login failed: ${error instanceof Error ? error.message : String(error)}`);


### PR DESCRIPTION
## Summary
- discover identity-checked local OpenCodex endpoints from runtime metadata or port 10100
- expose cached `/api/models` models with `opencodex/<id>` selectors and raw wire IDs
- add keyless Responses streaming and read-only `/login opencodex` status reprobes

## Verification
- `bun test packages/ai/test/openai-opencodex-responses.test.ts packages/ai/test/register-builtins.test.ts packages/ai/test/models-lazy.test.ts packages/ai/test/auth-storage-check-credentials.test.ts packages/coding-agent/test/models-config-tool-choice-support.test.ts` (29 passed)
- Biome checks passed on changed files
- Full workspace typecheck remains affected by existing sibling-worktree package links