### PR TITLE
fix(ci): aggregate failure summaries across invocations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - Windows automatic tmux resolution now selects `psmux` then `pmux` by canonical command order without rejecting distinct lower-priority aliases; it probes `tmux` only when neither named provider is available (#3725).
+- CI failure extraction now aggregates Bun failure and suite-error summaries across every test invocation in a job log instead of silently using only the first summary.
 - Ordinary `ask` selectors now bound long question premises and page through every premise row without skipping rows hidden by overflow indicators (#3675).
 - First-event timeout retries now require a typed, content-free failure from the current clean attempt scope, preventing prior or stale extension activity from suppressing or admitting a later request (#3553).
 - The issue-1979 Korean prose wrap test now cleans up inherited multiplexer env vars (`TMUX`, `TMUX_PANE`, etc.) so it deterministically exercises the plain-terminal render path regardless of the CI runner's terminal session (#1979).

--- a/scripts/ci-failure-extract.test.ts
+++ b/scripts/ci-failure-extract.test.ts
@@ -68,6 +68,36 @@ describe("extractFailures", () => {
 		expect(result.identities).toHaveLength(1);
 	});
 
+	test("aggregates multiple summary lines across timestamped invocations", () => {
+		const log = [`${TS} 0 fail`, `${TS}(fail) one recognised`, `${TS} 2 fail`].join("\n");
+
+		const result = extractFailures(log);
+
+		expect(result.reportedFailCount).toBe(2);
+		expect(result.underCounted).toBe(true);
+		expect(result.identities).toEqual(["one recognised"]);
+	});
+
+	test("aggregates suite-level error summaries across invocations", () => {
+		const log = [`${TS} 2 fail`, `${TS} 1 error`, `${TS} 1 error`].join("\n");
+
+		const result = extractFailures(log);
+
+		expect(result.reportedErrorCount).toBe(2);
+		expect(result.underCounted).toBe(false);
+	});
+
+	test("does not treat a repeated failure identity as missing output", () => {
+		const log = [`${TS}(fail) same test`, `${TS} 1 fail`, `${TS}(fail) same test`, `${TS} 1 fail`].join("\n");
+
+		const result = extractFailures(log);
+
+		expect(result.reportedFailCount).toBe(2);
+		expect(result.failures).toHaveLength(2);
+		expect(result.identities).toEqual(["same test"]);
+		expect(result.underCounted).toBe(false);
+	});
+
 	test("does not flag under-counting when extraction agrees with the summary", () => {
 		const log = [`${TS}(fail) a`, `${TS}(fail) b`, `${TS} 2 fail`].join("\n");
 

--- a/scripts/ci-failure-extract.ts
+++ b/scripts/ci-failure-extract.ts
@@ -88,30 +88,28 @@ export function extractFailures(rawLog: string): ExtractionResult {
 			continue;
 		}
 
-		if (reportedFailCount === undefined) {
-			const summary = BUN_SUMMARY.exec(line);
-			if (summary?.[1]) {
-				reportedFailCount = Number(summary[1]);
-				continue;
-			}
+		const summary = BUN_SUMMARY.exec(line);
+		if (summary?.[1]) {
+			reportedFailCount = (reportedFailCount ?? 0) + Number(summary[1]);
 		}
 
-		if (reportedErrorCount === undefined) {
-			const errors = BUN_ERROR_SUMMARY.exec(line);
-			if (errors?.[1]) reportedErrorCount = Number(errors[1]);
+		const errors = BUN_ERROR_SUMMARY.exec(line);
+		if (errors?.[1]) {
+			reportedErrorCount = (reportedErrorCount ?? 0) + Number(errors[1]);
 		}
 	}
 
 	const identities = [...new Set(failures.map(f => f.identity))].sort();
 
-	// Compare against distinct identities: a single test failing in several
-	// shards of one log is one identity but several `(fail)` lines.
+	// Compare against extracted failure lines. Identities are deduplicated for
+	// reporting, but repeated failures across invocations still account for each
+	// invocation's summary count.
 	//
 	// Suite-level errors are counted by the runner as failures but never print a
 	// `(fail) <name>` line — there is no test to name when an import throws or an
 	// exception escapes between tests. Allowing for them keeps the guard pointed
 	// at genuine pattern gaps instead of firing on a shape it cannot ever match.
-	const unexplained = (reportedFailCount ?? 0) - identities.length - (reportedErrorCount ?? 0);
+	const unexplained = (reportedFailCount ?? 0) - failures.length - (reportedErrorCount ?? 0);
 	const underCounted = reportedFailCount !== undefined && unexplained > 0;
 
 	return { failures, identities, reportedFailCount, reportedErrorCount, underCounted };


### PR DESCRIPTION
## What

- Aggregate every Bun `fail` and suite-level `error` summary across a complete CI job log.
- Compare the aggregate count with extracted failure occurrences while keeping the public identity list deduplicated.
- Add regressions for multiple invocations, repeated identities, and suite-level errors.

## Why

CI jobs can run multiple `bun test` invocations in one log. The extractor previously kept only the first summary, so later failures could be silently omitted. This is a corrected current-`dev` successor to closed PR #3560 and also closes the repeated-identity false positive found during independent exact-head review.

## Testing

- `bun test scripts/ci-failure-extract.test.ts` — 17 passed, 31 assertions
- `bun run check:tools` — Biome and tools TypeScript check passed
- `bun run check:rs` — Rust scope check passed; no Rust-affecting changes
- `git diff --check`

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:a830f589f4daf5aac86ad8e703852f2d1cabf803 reviewer:human evidence:needs-independent-review
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
