### PR TITLE
fix(coding-agent): scope first-event timeout retries per attempt

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -344,7 +344,7 @@ export class Agent {
 	#listeners = new Set<(e: AgentEvent) => void>();
 	#abortController?: AbortController;
 	#convertToLlm: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
-	#transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
+	#transformContext?: (messages: AgentMessage[], signal?: AbortSignal, scope?: AttemptScope) => Promise<AgentMessage[]>;
 	#steeringQueue: AgentMessage[] = [];
 	#followUpQueue: AgentMessage[] = [];
 	#followUpForceOneAtATime = new WeakSet<AgentMessage>();
@@ -395,6 +395,7 @@ export class Agent {
 	#maintainContext?: AgentLoopConfig["maintainContext"];
 	#telemetry?: AgentLoopConfig["telemetry"];
 	#appendOnlyContext?: AppendOnlyContextManager;
+	#mainAttemptScopeObserver?: (scope: AttemptScope) => void;
 
 	get intentTracing(): boolean {
 		return this.#intentTracing;
@@ -418,6 +419,17 @@ export class Agent {
 	/** Return the Agent-owned attempt scope authority for session record injection. */
 	getAttemptScopeAuthority() {
 		return this.#attemptAuthority;
+	}
+	/**
+	 * Observe each main-attempt scope synchronously, before any provider or
+	 * extension-capable lifecycle work can begin.
+	 */
+	setMainAttemptScopeObserver(observer: ((scope: AttemptScope) => void) | undefined): void {
+		this.#mainAttemptScopeObserver = observer;
+	}
+
+	#observeMainAttemptScope(scope: AttemptScope): void {
+		this.#mainAttemptScopeObserver?.(scope);
 	}
 
 	streamFn: StreamFn;
@@ -1439,6 +1451,7 @@ export class Agent {
 		}
 		const logicalRunId = managedLogicalRunOwner ?? runId;
 		const scope = this.#attemptAuthority.mintMain();
+		this.#observeMainAttemptScope(scope);
 		const handle: AttemptRunHandle = { logicalRunId, scope };
 		this.#runHandles.set(logicalRunId, handle);
 		options?.onRunAccepted?.(handle);
@@ -1547,7 +1560,13 @@ export class Agent {
 			preferWebsockets: this.#preferWebsockets,
 			convertToLlm: this.#convertToLlm,
 			transformContext: this.#transformContext,
-			attemptMinter: { mint: () => this.#attemptAuthority.mintMain() },
+			attemptMinter: {
+				mint: () => {
+					const scope = this.#attemptAuthority.mintMain();
+					this.#observeMainAttemptScope(scope);
+					return scope;
+				},
+			},
 			initialScope: scope,
 			onPayload: this.#onPayload,
 			onResponse: this.#onResponse,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Ordinary `ask` selectors now bound long question premises and page through every premise row without skipping rows hidden by overflow indicators (#3675).
+- First-event timeout retries now require a typed, content-free failure from the current clean attempt scope, preventing prior or stale extension activity from suppressing or admitting a later request (#3553).
 - The issue-1979 Korean prose wrap test now cleans up inherited multiplexer env vars (`TMUX`, `TMUX_PANE`, etc.) so it deterministically exercises the plain-terminal render path regardless of the CI runner's terminal session (#1979).
 ## [0.12.7] - 2026-07-31
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1869,13 +1869,6 @@ export class AgentSession {
 		this.#retryReplayEpoch++;
 		this.#retryReplayUnsafeEpoch = undefined;
 		this.#firstEventTimeoutRetryStartedAt = Date.now();
-		if (
-			this.#extensionRunner?.hasHandlers("context") ||
-			this.#extensionRunner?.hasHandlers("before_provider_request") ||
-			this.#extensionRunner?.hasHandlers("after_provider_response")
-		) {
-			this.#markRetryReplayUnsafe();
-		}
 	}
 
 	#markRetryReplayUnsafe(): void {
@@ -1884,6 +1877,14 @@ export class AgentSession {
 
 	get #hasCleanRetryReplaySafety(): boolean {
 		return this.#retryReplayEpoch > 0 && this.#retryReplayUnsafeEpoch !== this.#retryReplayEpoch;
+	}
+	#bindAttemptScope(scope: AttemptScope | undefined): void {
+		if (!scope) return;
+		this.#attemptRecordStore.register(scope);
+		this.#attemptRecordStore.establishClean(scope);
+	}
+	#isRetryScopeClean(scope: AttemptScope | undefined): boolean {
+		return scope !== undefined && this.#attemptRecordStore.isClean(scope);
 	}
 	#prePromptContextCheckPromise: Promise<void> | undefined = undefined;
 	/** Display-only context snapshot; pre-prompt compaction estimates deliberately remain uncached. */
@@ -1898,6 +1899,8 @@ export class AgentSession {
 	// Handoff state
 	#handoffAbortController: AbortController | undefined = undefined;
 	#skipPostTurnMaintenanceAssistantTimestamp: number | undefined = undefined;
+	/** Scope cleanliness captured after message_end extension delivery and before terminal agent_end retirement. */
+	#assistantAttemptScopes = new WeakMap<AssistantMessage, { scope?: AttemptScope; wasClean: boolean }>();
 
 	// Retry state
 	#retryAbortController: AbortController | undefined = undefined;
@@ -2606,6 +2609,7 @@ export class AgentSession {
 		if (this.#extensionRunner && typeof this.#extensionRunner.setAttemptRecordStore === "function") {
 			this.#extensionRunner.setAttemptRecordStore(this.#attemptRecordStore);
 		}
+		this.agent.setMainAttemptScopeObserver(scope => this.#bindAttemptScope(scope));
 		this.#skills = config.skills ?? [];
 		this.#skillWarnings = config.skillWarnings ?? [];
 		this.#customCommands = config.customCommands ?? [];
@@ -3739,11 +3743,7 @@ export class AgentSession {
 	/** Internal handler for agent events - shared by subscribe and reconnect */
 	#handleAgentEvent = async (event: AgentEvent, activePromptHandle?: string): Promise<void> => {
 		const attemptScope = (event as AgentEvent & { scope?: AttemptScope }).scope;
-		if ((event.type === "agent_start" || event.type === "turn_start") && attemptScope) {
-			this.#attemptRecordStore.register(attemptScope);
-			this.#attemptRecordStore.establishClean(attemptScope);
-		}
-		if (this.#extensionRunner?.hasHandlers(event.type)) this.#markRetryReplayUnsafe();
+
 		if (
 			event.type === "tool_execution_start" ||
 			event.type === "tool_execution_update" ||
@@ -3947,6 +3947,12 @@ export class AgentSession {
 		}
 
 		await this.#emitSessionEvent(displayEvent);
+		if (event.type === "message_end" && event.message.role === "assistant") {
+			this.#assistantAttemptScopes.set(event.message, {
+				scope: attemptScope,
+				wasClean: this.#isRetryScopeClean(attemptScope),
+			});
+		}
 		if (
 			displayEvent !== event &&
 			displayEvent.type === "message_end" &&
@@ -4321,7 +4327,14 @@ export class AgentSession {
 			if (this.#isRetryableError(msg)) {
 				const transportFailure = (msg as AssistantMessage & { transportFailure?: TransportFailureFacts })
 					.transportFailure;
-				const didRetry = await this.#handleRetryableError(msg, false, transportFailure);
+				const messageScope = this.#assistantAttemptScopes.get(msg);
+				const didRetry = await this.#handleRetryableError(
+					msg,
+					false,
+					transportFailure,
+					messageScope?.scope ?? event.scope,
+					messageScope?.wasClean ?? false,
+				);
 				if (didRetry) return; // Retry was initiated, don't proceed to compaction
 			}
 			if (this.#retryAttempt > 0) {
@@ -5838,6 +5851,7 @@ export class AgentSession {
 		this.#abortActiveMidRunBarriers();
 		this.abortCompaction();
 		this.agent.abort();
+		this.agent.setMainAttemptScopeObserver(undefined);
 		// Disconnect the Agent event bridge NOW — before the maintenance join and the
 		// bounded idle / forceAbort below — so no agent_end emitted during teardown
 		// (including the one forceAbort emits) can re-enter #handleAgentEvent and start
@@ -14573,6 +14587,8 @@ export class AgentSession {
 			outcome.failure.message,
 			true,
 			outcome.failure.transportFailure,
+			outcome.scope,
+			this.#isRetryScopeClean(outcome.scope),
 		) as Promise<ManagedAttemptDecision>;
 	}
 
@@ -14733,6 +14749,8 @@ export class AgentSession {
 		message: AssistantMessage,
 		managedOutcome = false,
 		transportFailure?: TransportFailureFacts,
+		scope?: AttemptScope,
+		scopeWasClean = this.#isRetryScopeClean(scope),
 	): Promise<boolean | ManagedAttemptDecision> {
 		const controller = this.#defaultFallbackChain();
 		const managedFallback = controller.chain.entries.length > 1;
@@ -14747,12 +14765,16 @@ export class AgentSession {
 		if (!managedFallback && !retrySettings.enabled) return false;
 		const classification = this.#classifyErrorForRetry(message);
 		const firstEventTimeout = classification === "first_event_timeout";
-		if (!managedFallback && firstEventTimeout) {
-			this.#firstEventTimeoutRetryStartedAt ??= Date.now();
+		if (!managedFallback && firstEventTimeout && this.#retryAttempt === 0) {
+			this.#firstEventTimeoutRetryStartedAt = Date.now();
 		}
-		// First-event timeouts are replay-safe only before any model progress,
-		// abort, or extension/provider lifecycle participation.
-		if (firstEventTimeout && (!this.#hasCleanRetryReplaySafety || assistantMessageHasVisibleOrToolContent(message))) {
+		const requiresScopedFirstEventTimeout = managedFallback || !legacyRetryConfigured;
+		if (
+			firstEventTimeout &&
+			(assistantMessageHasVisibleOrToolContent(message) ||
+				(this.#retryAttempt > 0 && !this.#hasCleanRetryReplaySafety) ||
+				(requiresScopedFirstEventTimeout && (!this.#isTypedFirstEventTimeout(message) || !scope || !scopeWasClean)))
+		) {
 			return managedOutcome
 				? {
 						type: "terminal",
@@ -14780,14 +14802,12 @@ export class AgentSession {
 		// before the failure. This bypasses #hasCleanRetryReplaySafety because the
 		// content-free check is the replay-safety guarantee for credential rotation.
 		const canReplayRotatedCredential = credentialRotated;
-		// Bare defaults admit only clean, side-effect-free canonical stream watchdog failures,
-		// content-free quota/rate-limit credential rotations, and the explicit Codex
-		// capacity-overload event.
+		// Bare defaults retain their narrow watchdog and Codex admissions. A
+		// first-event timeout adds the typed, content-free, current-clean-scope
+		// requirement above; other transient watchdogs preserve legacy behavior.
 		if (!managedFallback && !legacyRetryConfigured && !canReplayRotatedCredential) {
 			const bareDefaultCodexOverload = isBareDefaultCodexOverload(message);
 			const bareDefaultWrappedFirstEventTimeout = isBareDefaultWrappedFirstEventTimeout(message);
-			// Content-free Codex overload is replay-safe by the same reasoning as
-			// credential rotation: no partial output means no observable state.
 			const canReplayCodexOverload = bareDefaultCodexOverload;
 			if (
 				(!canReplayCodexOverload &&
@@ -14796,7 +14816,7 @@ export class AgentSession {
 					(hasBareDefaultRetryDisqualifyingFacts(message) ||
 						(classification !== "transient" && classification !== "first_event_timeout") ||
 						!BARE_DEFAULT_WATCHDOG_ERROR.test(message.errorMessage ?? ""))) ||
-				(!canReplayCodexOverload && !this.#hasCleanRetryReplaySafety)
+				(!canReplayCodexOverload && !firstEventTimeout && !this.#hasCleanRetryReplaySafety)
 			) {
 				return false;
 			}

--- a/packages/coding-agent/test/agent-session-fallback-attempt-transaction.test.ts
+++ b/packages/coding-agent/test/agent-session-fallback-attempt-transaction.test.ts
@@ -1,18 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
-import { Agent, type AgentOptions } from "@gajae-code/agent-core";
+import { Agent, type AgentOptions, type AgentTool } from "@gajae-code/agent-core";
 import * as compactionModule from "@gajae-code/agent-core/compaction";
-import { type AssistantMessage, getBundledModel, type Model } from "@gajae-code/ai";
+import { type AssistantMessage, getBundledModel, type Model, type ToolCall } from "@gajae-code/ai";
 import { createMockModel } from "@gajae-code/ai/providers/mock";
 import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { ExtensionRunner } from "@gajae-code/coding-agent/extensibility/extensions/runner";
+import type { Extension } from "@gajae-code/coding-agent/extensibility/extensions/types";
 import { AgentSession, type AgentSessionEvent } from "@gajae-code/coding-agent/session/agent-session";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
 
 import { TempDir } from "@gajae-code/utils";
+import { z } from "zod";
 
 function assistantLifecycleEvents(events: AgentSessionEvent[]): AgentSessionEvent[] {
 	return events.filter(
@@ -62,6 +65,84 @@ function failedStream(model: Model): AssistantMessageEventStream {
 		stream.push({ type: "error", reason: "error", error: message });
 	});
 	return stream;
+}
+function typedFirstEventTimeoutStream(model: Model): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+	queueMicrotask(() => {
+		const message: AssistantMessage = {
+			role: "assistant",
+			content: [],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "error",
+			errorMessage: "Error: Provider stream timed out while waiting for the first event",
+			transportFailure: { kind: "transport", providerCode: "stream_first_event_timeout" },
+			timestamp: Date.now(),
+		};
+		stream.push({ type: "start", partial: message });
+		stream.push({ type: "error", reason: "error", error: message });
+	});
+	return stream;
+}
+function toolUseStream(model: Model, toolCall: ToolCall): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+	queueMicrotask(() => {
+		const message: AssistantMessage = {
+			role: "assistant",
+			content: [toolCall],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+		stream.push({ type: "start", partial: message });
+		stream.push({ type: "done", reason: "toolUse", message });
+	});
+	return stream;
+}
+
+function extensionRunnerForHandler(
+	cwd: string,
+	sessionManager: SessionManager,
+	modelRegistry: ModelRegistry,
+	eventType: "context" | "message_end",
+	onHandler?: () => void,
+): ExtensionRunner {
+	const extension: Extension = {
+		path: "test-extension",
+		resolvedPath: "test-extension",
+		handlers: new Map([[eventType, [async () => onHandler?.()]]]) as Extension["handlers"],
+		tools: new Map(),
+		messageRenderers: new Map(),
+		commands: new Map(),
+		flags: new Map(),
+		shortcuts: new Map(),
+	};
+	return new ExtensionRunner(
+		[extension],
+		{ flagValues: new Map(), pendingProviderRegistrations: [] } as never,
+		cwd,
+		sessionManager,
+		modelRegistry,
+	);
 }
 
 function otherTransportFailureStream(model: Model, errorMessage: string): AssistantMessageEventStream {
@@ -146,13 +227,23 @@ describe("AgentSession managed fallback attempt transaction", () => {
 	function createSession(
 		streamFn: AgentOptions["streamFn"],
 		maxAttempts = 3,
+		options: { tools?: AgentTool[]; handler?: "context" | "message_end"; onHandler?: () => void } = {},
 	): { agent: Agent; primary: Model; fallback: Model } {
 		const primary = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const fallback = getBundledModel("openai", "gpt-4o-mini");
 		if (!primary || !fallback) throw new Error("Expected bundled test models");
+		const sessionManager = SessionManager.inMemory();
+		const modelRegistry = new ModelRegistry(authStorage);
+		const extensionRunner = options.handler
+			? extensionRunnerForHandler(tempDir.path(), sessionManager, modelRegistry, options.handler, options.onHandler)
+			: undefined;
 		const agent = new Agent({
 			getApiKey: provider => `${provider}-key`,
-			initialState: { model: primary, systemPrompt: ["test"], tools: [], messages: [] },
+			initialState: { model: primary, systemPrompt: ["test"], tools: options.tools ?? [], messages: [] },
+			transformContext:
+				options.handler === "context"
+					? (messages, _signal, scope) => extensionRunner!.emitContext(messages, scope)
+					: undefined,
 			streamFn,
 		});
 		const settings = Settings.isolated({
@@ -163,9 +254,10 @@ describe("AgentSession managed fallback attempt transaction", () => {
 		settings.setModelRole("default", selector(primary));
 		session = new AgentSession({
 			agent,
-			sessionManager: SessionManager.inMemory(),
+			sessionManager,
 			settings,
-			modelRegistry: new ModelRegistry(authStorage),
+			modelRegistry,
+			extensionRunner,
 		});
 		session.setConfiguredModelChain("default", [selector(primary), selector(fallback)], "test");
 		return { agent, primary, fallback };
@@ -399,6 +491,151 @@ describe("AgentSession managed fallback attempt transaction", () => {
 			],
 		});
 		expect(agentEnds).not.toContainEqual(expect.objectContaining({ stopReason: "cancelled" }));
+	});
+	it("admits a clean managed timeout successor after a committed tool attempt", async () => {
+		const toolCall: ToolCall = { type: "toolCall", id: "counted-tool", name: "counted", arguments: {} };
+		const tool: AgentTool = {
+			name: "counted",
+			label: "Counted",
+			description: "Records a committed tool attempt",
+			parameters: z.object({}),
+			execute: async () => ({ content: [{ type: "text", text: "counted" }] }),
+		};
+		const calls: string[] = [];
+		let streamCalls = 0;
+		const { agent, primary, fallback } = createSession(
+			(model, context, options) => {
+				calls.push(selector(model));
+				streamCalls++;
+				if (streamCalls === 1) {
+					const stream = new AssistantMessageEventStream();
+					queueMicrotask(() => {
+						const message: AssistantMessage = {
+							role: "assistant",
+							content: [toolCall],
+							api: model.api,
+							provider: model.provider,
+							model: model.id,
+							usage: {
+								input: 0,
+								output: 0,
+								cacheRead: 0,
+								cacheWrite: 0,
+								totalTokens: 0,
+								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+							},
+							stopReason: "toolUse",
+							timestamp: Date.now(),
+						};
+						stream.push({ type: "start", partial: message });
+						stream.push({ type: "done", reason: "toolUse", message });
+					});
+					return stream;
+				}
+				if (streamCalls === 2) return typedFirstEventTimeoutStream(model);
+				return createMockModel({ responses: [{ content: ["fallback accepted"] }] }).stream(model, context, options);
+			},
+			1,
+			{ tools: [tool] },
+		);
+		const continueSpy = vi.spyOn(agent, "continue");
+		const scopes: Array<{ attemptId: string; generation: number }> = [];
+		agent.subscribe(event => {
+			const scope = (event as { scope?: { attemptId: string; generation: number } }).scope;
+			if (scope) scopes.push(scope);
+		});
+		const events: AgentSessionEvent[] = [];
+		session!.subscribe(event => events.push(event));
+
+		await session!.prompt("commit tool then admit clean managed timeout successor");
+		await session!.waitForIdle();
+
+		expect(calls).toEqual([selector(primary), selector(primary), selector(fallback)]);
+		const scopeGenerations = [
+			...new Map(scopes.map(scope => [`${scope.attemptId}:${scope.generation}`, scope])).values(),
+		];
+		expect(scopeGenerations).toHaveLength(2);
+		expect(scopeGenerations[1]!.generation).toBeGreaterThan(scopeGenerations[0]!.generation);
+		expect(continueSpy).toHaveBeenCalledTimes(1);
+		expect(events.filter(event => event.type === "agent_end")).toHaveLength(1);
+		expect(session!.messages.filter(message => message.role === "assistant")).toHaveLength(2);
+		expect(session!.messages.filter(message => message.role === "toolResult")).toHaveLength(1);
+		expect(session!.messages.at(-1)).toMatchObject({
+			role: "assistant",
+			stopReason: "stop",
+			content: [{ type: "text", text: "fallback accepted" }],
+		});
+	});
+
+	it("rejects a context-handler execution in a managed timeout successor without publishing duplicate content", async () => {
+		const toolCall: ToolCall = { type: "toolCall", id: "prior-tool", name: "counted", arguments: {} };
+		const tool: AgentTool = {
+			name: "counted",
+			label: "Counted",
+			description: "Commits a predecessor attempt",
+			parameters: z.object({}),
+			execute: async () => ({ content: [{ type: "text", text: "counted" }] }),
+		};
+		const calls: string[] = [];
+		let streamCalls = 0;
+		const { primary } = createSession(
+			model => {
+				calls.push(selector(model));
+				return ++streamCalls === 1 ? toolUseStream(model, toolCall) : typedFirstEventTimeoutStream(model);
+			},
+			1,
+			{ tools: [tool], handler: "context" },
+		);
+		const events: AgentSessionEvent[] = [];
+		session!.subscribe(event => events.push(event));
+
+		await session!.prompt("reject extension-executed managed timeout successor");
+		await session!.waitForIdle();
+
+		expect(calls).toEqual([selector(primary), selector(primary)]);
+		expect(events.filter(event => event.type === "agent_end")).toHaveLength(1);
+		expect(session!.messages.filter(message => message.role === "assistant")).toHaveLength(2);
+		expect(session!.messages.filter(message => message.role === "toolResult")).toHaveLength(1);
+		expect(session!.messages.at(-1)).toMatchObject({ role: "assistant", stopReason: "error" });
+	});
+	it("rejects a same-scope message_end handler before direct retry admission", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled test model");
+		const sessionManager = SessionManager.inMemory();
+		const modelRegistry = new ModelRegistry(authStorage);
+		let messageEndHandlers = 0;
+		const extensionRunner = extensionRunnerForHandler(
+			tempDir.path(),
+			sessionManager,
+			modelRegistry,
+			"message_end",
+			() => {
+				messageEndHandlers++;
+			},
+		);
+		let calls = 0;
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-key`,
+			initialState: { model, systemPrompt: ["test"], tools: [], messages: [] },
+			streamFn: requestedModel => {
+				calls++;
+				return typedFirstEventTimeoutStream(requestedModel);
+			},
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		settings.setModelRole("default", selector(model));
+		session = new AgentSession({ agent, sessionManager, settings, modelRegistry, extensionRunner });
+		const events: AgentSessionEvent[] = [];
+		session.subscribe(event => events.push(event));
+
+		await session.prompt("message_end vetoes its own typed timeout");
+		await session.waitForIdle();
+
+		expect(calls).toBe(1);
+		expect(messageEndHandlers).toBeGreaterThan(0);
+		expect(events.filter(event => event.type === "agent_end")).toHaveLength(1);
+		expect(session.messages).toHaveLength(2);
+		expect(session.messages.at(-1)).toMatchObject({ role: "assistant", stopReason: "error" });
 	});
 	it("settles a rejected managed continuation without duplicate terminal events", async () => {
 		const { agent } = createSession(model => failedStream(model));

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -126,6 +126,7 @@ describe("AgentSession resilient retry", () => {
 		messageModel?: string;
 		requestedModels?: string[];
 		settingsOverrides?: Record<string, unknown>;
+		onStreamStart?: () => void;
 	}): AgentSession {
 		const model = options.model ?? getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!model) throw new Error("Expected bundled test model to exist");
@@ -137,6 +138,7 @@ describe("AgentSession resilient retry", () => {
 			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
 			streamFn: (requestedModel, context, opts) => {
 				calls++;
+				options.onStreamStart?.();
 				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
 				if (calls > 1 && options.recoveredContent) {
 					return createMockModel({ responses: [{ content: [options.recoveredContent] }] }).stream(
@@ -246,8 +248,12 @@ describe("AgentSession resilient retry", () => {
 		const agent = new Agent({
 			getApiKey: provider => `${provider}-test-key`,
 			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
-			transformContext: extensionRunner ? messages => extensionRunner.emitContext(messages) : undefined,
-			onPayload: extensionRunner ? payload => extensionRunner.emitBeforeProviderRequest(payload) : undefined,
+			transformContext: extensionRunner
+				? (messages, _signal, scope) => extensionRunner.emitContext(messages, scope)
+				: undefined,
+			onPayload: extensionRunner
+				? (payload, _model, scope) => extensionRunner.emitBeforeProviderRequest(payload, scope)
+				: undefined,
 			streamFn: (requestedModel, context, opts) => {
 				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
 				options.onStreamStart?.(agent);
@@ -265,8 +271,8 @@ describe("AgentSession resilient retry", () => {
 			modelRegistry,
 			extensionRunner,
 			onResponse: extensionRunner
-				? async (response, model) => {
-						await extensionRunner.emitAfterProviderResponse(response, model);
+				? async (response, model, scope) => {
+						await extensionRunner.emitAfterProviderResponse(response, model, scope);
 					}
 				: undefined,
 		});
@@ -281,6 +287,9 @@ describe("AgentSession resilient retry", () => {
 		const agent = new Agent({
 			getApiKey: provider => `${provider}-test-key`,
 			initialState: { model, systemPrompt: ["Test"], tools: options.tools ?? [], messages: [] },
+			transformContext: options.extensionRunner
+				? (messages, _signal, scope) => options.extensionRunner!.emitContext(messages, scope)
+				: undefined,
 			streamFn: options.streamFn,
 		});
 		const settings = Settings.isolated({ "compaction.enabled": false });
@@ -1232,13 +1241,32 @@ describe("AgentSession resilient retry", () => {
 		expect(progressModels).toHaveLength(1);
 		expect(lastAssistant(session).stopReason).toBe("error");
 	});
-	it("recovers the canonical wrapped first-event timeout in the same bare-default turn", async () => {
+	it("retries a typed clean first-event timeout without manual attempt-scope seeding", async () => {
+		const requestedModels: string[] = [];
+		session = buildStatusErrorSession({
+			bareDefault: true,
+			errorMessage: "Error: Provider stream timed out while waiting for the first event",
+			transportFailure: { kind: "transport", providerCode: "stream_first_event_timeout" },
+			recoveredContent: "recovered",
+			requestedModels,
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+
+		await session.prompt("typed clean timeout");
+		await session.waitForIdle();
+
+		expect(requestedModels).toHaveLength(2);
+		expect(lastAssistant(session).content).toEqual([{ type: "text", text: "recovered" }]);
+	});
+	it("recovers a typed first-event timeout in the same bare-default turn", async () => {
 		const errorMessage = "Error: Provider stream timed out while waiting for the first event";
 		const requestedModels: string[] = [];
-		session = buildBareRetrySession({
-			responses: [{ throw: errorMessage }, { content: ["recovered"] }],
+		session = buildStatusErrorSession({
+			bareDefault: true,
+			errorMessage,
+			transportFailure: { kind: "transport", providerCode: "stream_first_event_timeout" },
+			recoveredContent: "recovered",
 			requestedModels,
-			extensionRunner: createExtensionRunner(),
 		});
 		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
 		const { retryStartEvents, retryEndEvents } = track(session);
@@ -1263,6 +1291,7 @@ describe("AgentSession resilient retry", () => {
 		const requestedModels: string[] = [];
 		session = buildStatusErrorSession({
 			errorMessage,
+			transportFailure: { kind: "transport", providerCode: "stream_first_event_timeout" },
 			requestedModels,
 			settingsOverrides: { "retry.maxRetries": 2 },
 		});
@@ -1285,6 +1314,7 @@ describe("AgentSession resilient retry", () => {
 		const requestedModels: string[] = [];
 		session = buildStatusErrorSession({
 			errorMessage,
+			transportFailure: { kind: "transport", providerCode: "stream_first_event_timeout" },
 			requestedModels,
 			settingsOverrides: { "retry.maxRetries": 1 },
 		});
@@ -1299,6 +1329,25 @@ describe("AgentSession resilient retry", () => {
 			expect.objectContaining({ attempt: 1, maxAttempts: 2, errorMessage, unbounded: false }),
 		]);
 		expect(lastAssistant(session).errorMessage).toContain("exhausted after 2 attempts");
+	});
+	it("reseeds first-event timeout accounting at the first retryable failure", async () => {
+		let now = 10;
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+		let calls = 0;
+		session = buildStatusErrorSession({
+			errorMessage: "Error: Provider stream timed out while waiting for the first event",
+			transportFailure: { kind: "transport", providerCode: "stream_first_event_timeout" },
+			settingsOverrides: { "retry.maxRetries": 1 },
+			onStreamStart: () => {
+				now = ++calls === 1 ? 100 : 160;
+			},
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+
+		await session.prompt("deterministic first-event timeout accounting");
+		await session.waitForIdle();
+
+		expect(lastAssistant(session).errorMessage).toContain("waited 60ms total");
 	});
 	it("does not replay a bare-default watchdog after a reasoning summary start hook participates", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
@@ -1419,16 +1468,72 @@ describe("AgentSession resilient retry", () => {
 			session = undefined;
 		}
 	});
+	it("rejects a typed watchdog when a handler executes in its current scope", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		let hookCalls = 0;
+		let streamCalls = 0;
+		session = buildBareStreamingSession({
+			streamFn: () => {
+				streamCalls++;
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const failure = assistantMessage(
+						model,
+						[],
+						"error",
+						"Error: Provider stream timed out while waiting for the first event",
+					);
+					failure.transportFailure = { kind: "transport", providerCode: "stream_first_event_timeout" };
+					stream.push({ type: "start", partial: failure });
+					stream.push({ type: "error", reason: "error", error: failure });
+				});
+				return stream;
+			},
+			extensionRunner: createExtensionRunner(
+				new Map([
+					[
+						"context",
+						[
+							async () => {
+								hookCalls++;
+							},
+						],
+					],
+				]),
+			),
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents } = track(session);
+
+		await session.prompt("current scope extension watchdog");
+		await session.waitForIdle();
+
+		expect(hookCalls).toBe(1);
+		expect(streamCalls).toBe(1);
+		expect(retryStartEvents).toHaveLength(0);
+		expect(lastAssistant(session).stopReason).toBe("error");
+	});
 	it("does not replay a second bare-default watchdog after auto_retry_start handlers participate", async () => {
 		let hookCalls = 0;
-		const requestedModels: string[] = [];
-		session = buildBareRetrySession({
-			responses: [
-				{ throw: "Error: Provider stream timed out while waiting for the first event" },
-				{ throw: "Error: Provider stream timed out while waiting for the first event" },
-				{ content: ["should-not-reach"] },
-			],
-			requestedModels,
+		let streamCalls = 0;
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		session = buildBareStreamingSession({
+			streamFn: () => {
+				streamCalls++;
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const failure = assistantMessage(
+						model,
+						[],
+						"error",
+						"Error: Provider stream timed out while waiting for the first event",
+					);
+					failure.transportFailure = { kind: "transport", providerCode: "stream_first_event_timeout" };
+					stream.push({ type: "start", partial: failure });
+					stream.push({ type: "error", reason: "error", error: failure });
+				});
+				return stream;
+			},
 			extensionRunner: createExtensionRunner(
 				new Map([
 					[
@@ -1450,7 +1555,7 @@ describe("AgentSession resilient retry", () => {
 
 		expect(hookCalls).toBe(1);
 		expect(retryStartEvents).toHaveLength(1);
-		expect(requestedModels).toHaveLength(2);
+		expect(streamCalls).toBe(2);
 		expect(lastAssistant(session).stopReason).toBe("error");
 	});
 
@@ -1531,7 +1636,7 @@ describe("AgentSession resilient retry", () => {
 			session = undefined;
 		}
 	});
-	it("does not replay a bare-default watchdog after a registered tool completes and continues", async () => {
+	it("retries a typed clean watchdog after an earlier tool execution in the same run", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
 		const toolCall: ToolCall = { type: "toolCall", id: "counted-tool-call", name: "counted", arguments: {} };
 		let toolRuns = 0;
@@ -1558,31 +1663,42 @@ describe("AgentSession resilient retry", () => {
 						stream.push({ type: "done", reason: "toolUse", message: response });
 						return;
 					}
-					const failure = assistantMessage(
-						model,
-						[],
-						"error",
-						"Error: Provider stream timed out while waiting for the first event",
-					);
-					stream.push({ type: "start", partial: failure });
-					stream.push({ type: "error", reason: "error", error: failure });
+					if (streamCalls === 2) {
+						const failure = assistantMessage(
+							model,
+							[],
+							"error",
+							"Error: Provider stream timed out while waiting for the first event",
+						);
+						failure.transportFailure = { kind: "transport", providerCode: "stream_first_event_timeout" };
+						stream.push({ type: "start", partial: failure });
+						stream.push({ type: "error", reason: "error", error: failure });
+						return;
+					}
+					const recovered = assistantMessage(model, [{ type: "text", text: "recovered" }], "stop");
+					stream.push({ type: "start", partial: recovered });
+					stream.push({ type: "done", reason: "stop", message: recovered });
 				});
 				return stream;
 			},
+			extensionRunner: createExtensionRunner(),
 		});
 		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
 		const { retryStartEvents } = track(session);
 
-		await session.prompt("real counted tool watchdog");
+		await session.prompt("prior tool history, clean watchdog scope");
 		await session.waitForIdle();
 
 		expect(toolRuns).toBe(1);
 		expect(session.agent.state.messages).toContainEqual(
 			expect.objectContaining({ role: "toolResult", toolCallId: toolCall.id, toolName: "counted" }),
 		);
-		expect(streamCalls).toBe(2);
-		expect(retryStartEvents).toHaveLength(0);
-		expect(lastAssistant(session).stopReason).toBe("error");
+		expect(streamCalls).toBe(3);
+		expect(retryStartEvents).toHaveLength(1);
+		expect(lastAssistant(session)).toMatchObject({
+			stopReason: "stop",
+			content: [{ type: "text", text: "recovered" }],
+		});
 	});
 	it("gives an active cancel-and-submit replacement a clean retry epoch", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
@@ -1618,6 +1734,7 @@ describe("AgentSession resilient retry", () => {
 							"error",
 							"Error: Provider stream timed out while waiting for the first event",
 						);
+						failure.transportFailure = { kind: "transport", providerCode: "stream_first_event_timeout" };
 						stream.push({ type: "start", partial: failure });
 						stream.push({ type: "error", reason: "error", error: failure });
 						return;

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
-import { Agent } from "@gajae-code/agent-core";
-import { type AssistantMessage, getBundledModel, type Model } from "@gajae-code/ai";
+import { Agent, type AgentTool } from "@gajae-code/agent-core";
+import { type AssistantMessage, getBundledModel, type Model, type ToolCall } from "@gajae-code/ai";
 import { createMockModel } from "@gajae-code/ai/providers/mock";
 import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
@@ -17,6 +17,7 @@ import {
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
 import { TempDir } from "@gajae-code/utils";
+import { z } from "zod";
 
 type AutoRetryStartEvent = Extract<AgentSessionEvent, { type: "auto_retry_start" }>;
 type AutoRetryEndEvent = Extract<AgentSessionEvent, { type: "auto_retry_end" }>;
@@ -136,6 +137,33 @@ function canonicalFirstEventTimeoutStream(
 			stopReason: "error",
 			errorMessage: "Error: Provider stream timed out while waiting for the first event",
 			...(transportFailure === undefined ? {} : { transportFailure }),
+			timestamp: Date.now(),
+		};
+		stream.push({ type: "start", partial: message });
+		stream.push({ type: "error", reason: "error", error: message });
+	});
+	return stream;
+}
+function typedServerErrorStream(model: Model): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+	queueMicrotask(() => {
+		const message: AssistantMessage = {
+			role: "assistant",
+			content: [],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "error",
+			errorMessage: "Provider server error",
+			transportFailure: { kind: "transport", status: 503 },
 			timestamp: Date.now(),
 		};
 		stream.push({ type: "start", partial: message });
@@ -747,7 +775,10 @@ describe("AgentSession retry fallback", () => {
 				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
 				if (requestedModel.provider === primary.provider) {
 					primaryCalls++;
-					return canonicalFirstEventTimeoutStream(requestedModel);
+					return canonicalFirstEventTimeoutStream(requestedModel, [], {
+						kind: "transport",
+						providerCode: "stream_first_event_timeout",
+					});
 				}
 				return createMockModel({ responses: [{ content: ["Fallback recovered"] }] }).stream(
 					requestedModel,
@@ -809,7 +840,10 @@ describe("AgentSession retry fallback", () => {
 			initialState: { model: primary, systemPrompt: ["Test"], tools: [], messages: [] },
 			streamFn: requestedModel => {
 				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
-				return canonicalFirstEventTimeoutStream(requestedModel);
+				return canonicalFirstEventTimeoutStream(requestedModel, [], {
+					kind: "transport",
+					providerCode: "stream_first_event_timeout",
+				});
 			},
 		});
 		const settings = Settings.isolated({
@@ -847,9 +881,7 @@ describe("AgentSession retry fallback", () => {
 		]);
 		expect(fallbackNotices[0]?.message).toContain(`${primary.provider}/${primary.id}`);
 		expect(fallbackNotices[0]?.message).toContain(`${fallback.provider}/${fallback.id}`);
-		expect(getLastAssistantMessage(session).errorMessage).toBe(
-			"Error: Provider stream timed out while waiting for the first event",
-		);
+		expect(getLastAssistantMessage(session).errorMessage).toContain("Model fallback chain exhausted");
 	});
 
 	it("does not rotate a managed canonical timeout after partial output", async () => {
@@ -889,6 +921,92 @@ describe("AgentSession retry fallback", () => {
 			stopReason: "error",
 			content: [{ type: "text", text: "already visible" }],
 			errorMessage: "Error: Provider stream timed out while waiting for the first event",
+		});
+	});
+	it("advances managed fallback after an earlier tool execution and a later clean typed timeout", async () => {
+		const primary = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallback = getBundledModel("openai", "gpt-4o-mini");
+		if (!primary || !fallback) throw new Error("Expected bundled test models");
+		const toolCall: ToolCall = { type: "toolCall", id: "prior-tool", name: "counted", arguments: {} };
+		let toolRuns = 0;
+		let streamCalls = 0;
+		const countedTool: AgentTool = {
+			name: "counted",
+			label: "Counted",
+			description: "Records a real prior tool execution",
+			parameters: z.object({}),
+			execute: async () => {
+				toolRuns++;
+				return { content: [{ type: "text", text: "counted" }] };
+			},
+		};
+		const requestedModels: string[] = [];
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: { model: primary, systemPrompt: ["Test"], tools: [countedTool], messages: [] },
+			streamFn: (requestedModel, context, options) => {
+				streamCalls++;
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				if (streamCalls === 1) {
+					const stream = new AssistantMessageEventStream();
+					queueMicrotask(() => {
+						const message: AssistantMessage = {
+							role: "assistant",
+							content: [toolCall],
+							api: requestedModel.api,
+							provider: requestedModel.provider,
+							model: requestedModel.id,
+							usage: {
+								input: 0,
+								output: 0,
+								cacheRead: 0,
+								cacheWrite: 0,
+								totalTokens: 0,
+								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+							},
+							stopReason: "toolUse",
+							timestamp: Date.now(),
+						};
+						stream.push({ type: "start", partial: message });
+						stream.push({ type: "done", reason: "toolUse", message });
+					});
+					return stream;
+				}
+				if (streamCalls === 2) {
+					return canonicalFirstEventTimeoutStream(requestedModel, [], {
+						kind: "transport",
+						providerCode: "stream_first_event_timeout",
+					});
+				}
+				return createMockModel({ responses: [{ content: ["fallback recovered"] }] }).stream(
+					requestedModel,
+					context,
+					options,
+				);
+			},
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false, "fallback.maxAttempts": 1 });
+		settings.setModelRole("default", `${primary.provider}/${primary.id}`);
+		session = new AgentSession({ agent, sessionManager: SessionManager.inMemory(), settings, modelRegistry });
+		session.setConfiguredModelChain(
+			"default",
+			[`${primary.provider}/${primary.id}`, `${fallback.provider}/${fallback.id}`],
+			"test",
+		);
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+
+		await session.prompt("prior tool history, current clean managed timeout");
+		await session.waitForIdle();
+
+		expect(toolRuns).toBe(1);
+		expect(requestedModels).toEqual([
+			`${primary.provider}/${primary.id}`,
+			`${primary.provider}/${primary.id}`,
+			`${fallback.provider}/${fallback.id}`,
+		]);
+		expect(getLastAssistantMessage(session)).toMatchObject({
+			stopReason: "stop",
+			content: [{ type: "text", text: "fallback recovered" }],
 		});
 	});
 
@@ -943,9 +1061,11 @@ describe("AgentSession retry fallback", () => {
 		if (!primary || !fallback) throw new Error("Expected bundled test models");
 		const requestedModels: string[] = [];
 		const sessionManager = SessionManager.inMemory();
+		const extensionRunner = makeExtensionRunner(["context"], tempDir.path(), sessionManager, modelRegistry);
 		const agent = new Agent({
 			getApiKey: provider => `${provider}-test-key`,
 			initialState: { model: primary, systemPrompt: ["Test"], tools: [], messages: [] },
+			transformContext: (messages, _signal, scope) => extensionRunner.emitContext(messages, scope),
 			streamFn: requestedModel => {
 				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
 				return canonicalFirstEventTimeoutStream(requestedModel, [], {
@@ -961,7 +1081,7 @@ describe("AgentSession retry fallback", () => {
 			sessionManager,
 			settings,
 			modelRegistry,
-			extensionRunner: makeExtensionRunner(["context"], tempDir.path(), sessionManager, modelRegistry),
+			extensionRunner,
 		});
 		session.setConfiguredModelChain(
 			"default",
@@ -1116,18 +1236,17 @@ describe("AgentSession retry fallback", () => {
 
 		const requestedModels: string[] = [];
 		const mock = createMockModel({
-			responses: [
-				{ throw: "Provider server error" },
-				{ content: ["Fallback recovered"] },
-				{ content: ["Fallback remained active"] },
-			],
+			responses: [{ content: ["Fallback recovered"] }, { content: ["Fallback remained active"] }],
 		});
+		let streamCalls = 0;
 		const agent = new Agent({
 			getApiKey: provider => `${provider}-test-key`,
 			initialState: { model: primary, systemPrompt: ["Test"], tools: [], messages: [] },
 			streamFn: (requestedModel, context, options) => {
 				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
-				return mock.stream(requestedModel, context, options);
+				return streamCalls++ === 0
+					? typedServerErrorStream(requestedModel)
+					: mock.stream(requestedModel, context, options);
 			},
 		});
 		const settings = Settings.isolated({ "compaction.enabled": false, "fallback.maxAttempts": 1 });
@@ -1161,18 +1280,17 @@ describe("AgentSession retry fallback", () => {
 
 		const requestedModels: string[] = [];
 		const mock = createMockModel({
-			responses: [
-				{ throw: "Provider server error" },
-				{ content: ["Fallback recovered"] },
-				{ content: ["Fallback remained active"] },
-			],
+			responses: [{ content: ["Fallback recovered"] }, { content: ["Fallback remained active"] }],
 		});
+		let streamCalls = 0;
 		const agent = new Agent({
 			getApiKey: provider => `${provider}-test-key`,
 			initialState: { model: primary, systemPrompt: ["Test"], tools: [], messages: [] },
 			streamFn: (requestedModel, context, options) => {
 				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
-				return mock.stream(requestedModel, context, options);
+				return streamCalls++ === 0
+					? typedServerErrorStream(requestedModel)
+					: mock.stream(requestedModel, context, options);
 			},
 		});
 		const settings = Settings.isolated({ "compaction.enabled": false, "fallback.maxAttempts": 1 });
@@ -1302,11 +1420,7 @@ describe("AgentSession retry fallback", () => {
 			streamFn: (requestedModel, context, options) => {
 				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
 				if (requestedModel.provider === primary.provider) {
-					return createMockModel({ responses: [{ throw: "Provider server error" }] }).stream(
-						requestedModel,
-						context,
-						options,
-					);
+					return typedServerErrorStream(requestedModel);
 				}
 				fallbackCalls++;
 				if (fallbackCalls > 1) {


### PR DESCRIPTION
## Problem

#3553 remains reproducible after the earlier bounded retry work because retry replay safety is turn-scoped. Any committed tool execution marks the entire turn unsafe, so a later typed, content-free first-event timeout is rejected before retry accounting even when the current provider attempt performed no observable work.

## Change

- synchronously observe both main `AttemptScope` mint sites before provider or extension-capable lifecycle work
- idempotently register and establish each concrete scope in `AgentSession`
- admit first-event timeout recovery only for a typed, content-free failure whose exact current scope was clean before terminal delivery
- preserve current-attempt extension execution as a fail-closed veto while ignoring prior-request tool history
- propagate exact scope evidence through direct and managed fallback outcomes
- reseed first-event timeout elapsed accounting on the first retryable failure
- add direct, managed, current-extension-veto, terminal-provider, overflow, and accounting regressions

Fixes #3553

## Verification

- `bun test packages/coding-agent/test/agent-session-resilient-retry.test.ts packages/coding-agent/test/agent-session-retry-fallback.test.ts packages/coding-agent/test/attempt-scope-regressions.test.ts` — 89 pass, 0 fail, 560 assertions
- `bun test packages/coding-agent/test/agent-session-fallback-upstream-count.e2e.test.ts packages/coding-agent/test/agent-session-auto-compaction-oversized.test.ts` — 26 pass, 0 fail, 118 assertions
- `bun --cwd=packages/agent run check:types` — passed
- `bun --cwd=packages/coding-agent run check:types` — passed
- `git diff --check` — passed

## Preserved behavior

- `retry.enabled=false` remains terminal
- Kimi Code and Alibaba Token Plan first-event terminal policy remains unchanged
- untyped/legacy wording is not newly admitted
- visible/tool content, stale/absent scopes, and current-attempt extension execution remain fail-closed
- Codex overload and credential-rotation admissions remain separate