### PR TITLE
style(agent): reformat #transformContext signature for biome (#3553 post-merge repair)

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -344,7 +344,11 @@ export class Agent {
 	#listeners = new Set<(e: AgentEvent) => void>();
 	#abortController?: AbortController;
 	#convertToLlm: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
-	#transformContext?: (messages: AgentMessage[], signal?: AbortSignal, scope?: AttemptScope) => Promise<AgentMessage[]>;
+	#transformContext?: (
+		messages: AgentMessage[],
+		signal?: AbortSignal,
+		scope?: AttemptScope,
+	) => Promise<AgentMessage[]>;
 	#steeringQueue: AgentMessage[] = [];
 	#followUpQueue: AgentMessage[] = [];
 	#followUpForceOneAtATime = new WeakSet<AgentMessage>();


### PR DESCRIPTION
## Summary
Post-merge CI repair for merge commit f85218eb (PR #3711, issue #3553). The changed `#transformContext` field declaration in `packages/agent/src/agent.ts` was left on a single line exceeding biome 2.5.2's line width, failing the required dev format gate. Formatter output applied verbatim — no semantics changed.

## Verification
- `biome check .` on packages/agent: clean (80 files)
- `tsc -p packages/agent/tsconfig.json --noEmit`: clean
- `biome check --changed` at repo root: clean (558 files)
- 87 pass / 0 fail across `agent-session-fallback-attempt-transaction`, `agent-session-resilient-retry`, `agent-session-retry-fallback` tests

Refs #3553