### PR TITLE
fix(tui): stop the win32 fallback from overriding a reported process-terminal capability

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Restored the `isProcessTerminal`/`shouldUseViewportRepaintForHost` gate on the width-change viewport-repaint intercept so plain terminals (non-multiplexer, non-process-terminal) use `fullRender` for width changes instead of an unconditional viewport repaint. The #3684 chain removed this gate, causing lossless Korean/CJK prose wrapping to break at narrow widths because the viewport repaint only painted the visible rows without committing the full transcript to scrollback (#1979).
 - Restored the `fullRender` fallback for the `firstChanged < viewportTop` branch on non-viewport-repaint hosts, so above-viewport mutations replay the full frame instead of silently viewport-repainting.
 - Propagated IME cursor write failure from `#writeRenderBufferAndReanchorImeCursor` so callers detect terminal detach when the deferred cursor write fails after the shared frame commits.
+- The win32 viewport-repaint fallback no longer outranks a terminal that reports `isProcessTerminal: false`. Platform identity exists to recognize Windows console hosts that cannot report the capability, so a terminal that has answered now decides; previously every non-process terminal on Windows (embedders, pipes, the render regression suite) inherited viewport-repaint semantics, suppressed durable history replay, and left contracted rows behind as duplicates.
 
 ## [0.12.7] - 2026-07-31
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -431,6 +431,28 @@ export function shouldUseViewportRepaintForHost(
 }
 
 /**
+ * Viewport-repaint host gate resolved against a terminal's reported capability.
+ *
+ * `includeNativeWindows` exists so a Windows console host that cannot report
+ * `isProcessTerminal` is still recognized from platform identity. It is a
+ * fallback, so it must not outrank a terminal that has answered: a terminal
+ * reporting `false` is not a native console host, and letting win32 override it
+ * gives every non-process terminal on Windows — embedders, pipes, and the
+ * render regression suite — viewport-repaint semantics. Those hosts then never
+ * replay durable history, so contracted rows survive as duplicates.
+ */
+export function shouldUseViewportRepaintForTerminal(
+	isProcessTerminal: boolean | undefined,
+	env: Record<string, string | undefined> = Bun.env,
+	platform: NodeJS.Platform = process.platform,
+): boolean {
+	return shouldUseViewportRepaintForHost(env, platform, {
+		includeNativeWindows: isProcessTerminal !== false,
+		includeProcessTerminal: isProcessTerminal === true,
+	});
+}
+
+/**
  * Options for overlay positioning and sizing.
  * Values can be absolute numbers or percentage strings (e.g., "50%").
  */
@@ -1939,6 +1961,11 @@ export class TUI extends Container {
 		this.#forcedRenderQueued = false;
 	}
 
+	/** Host gate for viewport-repaint decisions, resolved against this terminal. */
+	#viewportRepaintHost(): boolean {
+		return shouldUseViewportRepaintForTerminal(this.terminal.isProcessTerminal);
+	}
+
 	/**
 	 * Viewport-repaint-aware resize render request.
 	 *
@@ -1962,13 +1989,7 @@ export class TUI extends Container {
 		this.#lastObservedWidth = observedWidth;
 		const heightChanged = this.#previousHeight !== this.terminal.rows;
 		if (widthChanged) this.#scheduleWidthSettleRedraw();
-		this.requestRender(
-			heightChanged &&
-				!shouldUseViewportRepaintForHost(Bun.env, process.platform, {
-					includeProcessTerminal: this.terminal.isProcessTerminal === true,
-				}),
-			"resize",
-		);
+		this.requestRender(heightChanged && !this.#viewportRepaintHost(), "resize");
 	}
 
 	/**
@@ -3564,10 +3585,7 @@ export class TUI extends Container {
 			return;
 		}
 		// Helper to clear scrollback and viewport and render all new lines
-		const shouldPreserveScrollbackOnFullClear =
-			shouldUseViewportRepaintForHost(Bun.env, process.platform, {
-				includeProcessTerminal: this.terminal.isProcessTerminal === true,
-			}) || this.#legacyMultiplexerFullRender;
+		const shouldPreserveScrollbackOnFullClear = this.#viewportRepaintHost() || this.#legacyMultiplexerFullRender;
 		let viewportRepaint: (
 			reason: string,
 			targetViewportTopOrAllowPastLiveBottom?: number | boolean,
@@ -3763,9 +3781,7 @@ export class TUI extends Container {
 			fullRender(true, "width settled", true);
 			return;
 		}
-		const useViewportRepaintPath = shouldUseViewportRepaintForHost(Bun.env, process.platform, {
-			includeProcessTerminal: this.terminal.isProcessTerminal === true,
-		});
+		const useViewportRepaintPath = this.#viewportRepaintHost();
 		const widthReflowRequired =
 			this.#previousWidth > 0 &&
 			rawLines.some(

--- a/packages/tui/test/viewport-scroll.test.ts
+++ b/packages/tui/test/viewport-scroll.test.ts
@@ -17,6 +17,7 @@ import {
 	setKittyTransmitWriter,
 	setTerminalImageProtocol,
 	shouldUseViewportRepaintForHost,
+	shouldUseViewportRepaintForTerminal,
 	TERMINAL,
 	Text,
 	TUI,
@@ -1909,5 +1910,29 @@ describe("registered viewport anchor", () => {
 		} finally {
 			tui.stop();
 		}
+	});
+
+	// A terminal that reports `isProcessTerminal: false` has answered the
+	// capability question. Platform identity is only a fallback for hosts that
+	// cannot answer, so win32 must not promote such a terminal onto the
+	// viewport-repaint path — doing so suppresses durable history replay and
+	// leaves contracted rows behind as duplicates.
+	it.each([
+		{ label: "explicit process terminal", isProcessTerminal: true, expected: true },
+		{ label: "explicit non-process terminal", isProcessTerminal: false, expected: false },
+		{ label: "unreported capability", isProcessTerminal: undefined, expected: true },
+	])("resolves the win32 viewport-repaint gate for an $label", ({ isProcessTerminal, expected }) => {
+		expect(shouldUseViewportRepaintForTerminal(isProcessTerminal, {}, "win32")).toBe(expected);
+	});
+
+	it("keeps non-win32 hosts off the viewport-repaint path regardless of capability", () => {
+		for (const isProcessTerminal of [false, undefined] as const) {
+			expect(shouldUseViewportRepaintForTerminal(isProcessTerminal, {}, "linux")).toBe(false);
+		}
+		expect(shouldUseViewportRepaintForTerminal(true, {}, "linux")).toBe(true);
+	});
+
+	it("still honors explicit Windows Terminal markers for a non-process terminal", () => {
+		expect(shouldUseViewportRepaintForTerminal(false, { WT_SESSION: "1" }, "win32")).toBe(true);
 	});
 });


### PR DESCRIPTION
## What

`shouldUseViewportRepaintForHost` recognizes native Windows console hosts from platform identity, because such hosts cannot report `isProcessTerminal`. Its own doc comment scopes that clause as a fallback:

> Native Windows console hosts are also recognized from platform identity **when that process-terminal capability is unavailable**.

The three renderer call sites passed `includeProcessTerminal: this.terminal.isProcessTerminal === true` but left `includeNativeWindows` at its default `true`. On win32 the platform clause then fired even when the terminal had explicitly answered `false`, so the fallback outranked the answer.

Consequences on Windows, for any terminal reporting `isProcessTerminal: false` (embedders, pipes, and the render regression suite's `VirtualTerminal`):

- `shouldPreserveScrollbackOnFullClear` is unconditionally true, so `fullRender(clear)` downgrades to `viewportRepaint` whenever `#scrollbackResumeViewportTop` is set
- the width-change intercept always takes the viewport-repaint branch
- `requestResizeRender` never forces a clearing render on height change

Durable history is therefore never replayed, and rows retired by a contraction survive in native scrollback as duplicates.

## Evidence

Two `packages/tui/test/render-regressions.test.ts` cases under **scrollback integrity** fail on win32 on current `dev` and pass with this change. Both are host-neutral by construction (`new VirtualTerminal(...)` with no `isProcessTerminal` option, i.e. explicitly `false`).

`appending lines during aggressive resize does not duplicate history rows` — appends 140 rows while flipping width 79↔80 and height 17↔18:

```
- Expected  - 1
+ Received  + 86
  expect(duplicated).toEqual([])
  duplicated = [4, 5, 6, 8, 9, 14, 15, 16, 17, 20, ... 124]
```

`rebases the durable frontier after a successful contraction replay before regrowth` — contraction replay followed by regrowth:

```
expect(writes).toContain("\r\n")
Received: "\u001B[?2026h\u001B[Hhistory-2\u001B[0m …\r\u001B[1Bhistory-3…"
```

A viewport repaint where a durable append was required — the observable shape of the same defect.

## Changes

- New exported pure helper `shouldUseViewportRepaintForTerminal(isProcessTerminal, env, platform)`. It consults platform identity only when the capability is unreported (`undefined`); an explicit `false` decides.
- `TUI` resolves the gate through a single private `#viewportRepaintHost()` that delegates to it, replacing the three ad-hoc `shouldUseViewportRepaintForHost(Bun.env, process.platform, { … })` call sites (`requestResizeRender`, `shouldPreserveScrollbackOnFullClear`, the width-change intercept).
- Multiplexer handling, `PI_TUI_LEGACY_MULTIPLEXER_FULL_RENDER`, explicit Windows Terminal markers, and real process terminals are unchanged — `isProcessTerminal === true` still yields `true` on every host.

## Tests

Added to `packages/tui/test/viewport-scroll.test.ts`, alongside the existing `shouldUseViewportRepaintForHost` host-matrix assertions. These pin the rule with an explicit `platform` argument, so they hold the invariant on Linux/macOS CI rather than only on a Windows host:

- win32 × `true` → `true`, win32 × `false` → `false`, win32 × `undefined` → `true`
- linux × `false`/`undefined` → `false`, linux × `true` → `true`
- win32 × `false` with `WT_SESSION` set → `true` (explicit markers still win)

Commands run (Windows 11, bun 1.3.14, natives built locally):

- `bun test --timeout 30000 packages/tui/test/render-regressions.test.ts` — **89 pass, 0 fail** (2 fail on `dev` without this change)
- `bun test --timeout 30000 packages/tui/test/viewport-scroll.test.ts packages/tui/test/render-regressions.test.ts packages/tui/test/resize-replay-storm.test.ts` — 155 pass, 0 fail
- `bun test --timeout 30000 packages/tui/test` — 1017 pass, 2 fail
- `bun run --cwd packages/tui check` (biome + tsc) — clean

The 2 remaining failures are pre-existing and unrelated (`Editor Enter handler sync slash completion > does not submit a forced absolute-path popup on the first Enter` and `> rejects a forced absolute-path popup after cursor relocation`). Both reproduce identically on this branch's base with the changes stashed — same two tests, same counts.

Note on the default timeout: `streaming content under aggressive resize keeps a single consistent viewport` exceeds the 5s default on this host and passes at 30s. That is host slowness, not a behavior change; it is unaffected by this diff.

## Relation to existing work

This is adjacent to the `#3684` → `#3686` → `#3691` chain and to the host gate `#3691` restored for the width-change intercept. That fix reinstated the `isProcessTerminal` check at one call site; this one closes the remaining path by which the win32 platform fallback re-enters after the capability has already answered.

## Compatibility

No behavior change for real process terminals, which is every interactive session. Only terminals that explicitly report `isProcessTerminal: false` on win32 change, and they move onto the same path they already take on every other platform.

## ELI5

On Windows the renderer assumed "this is a Windows console" even when the terminal had already said it is not one, so it skipped redrawing history and left duplicate rows behind. Now the terminal's own answer wins.
