### PR TITLE
fix(prompt): require literal UTF-8 in tool inputs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Prompt-template positional arguments now preserve literal `$@` and `$ARGUMENTS` text instead of recursively expanding it during placeholder substitution.
 - Native Windows session and GC commands now report the searched `psmux` / `pmux` / `tmux` provider set when no compatible multiplexer is available instead of leaking a literal `tmux` spawn error (#3688).
 - Managed-session recovery now preserves committed mutation state and the actual Linux fallback primitive in native publish receipts, preventing unsafe retry classification after a post-link staging unlink failure (#3746).
+- The system prompt now requires non-ASCII tool-input text to be written as literal UTF-8 rather than hand-spelled `\uXXXX` escapes, including JSON serialized into a string field, while leaving escapes that are intended source syntax alone. Models that hand-spell hex codepoints for CJK mis-type them, and each mis-typed escape decodes to a valid-but-wrong syllable, so Korean text in tool parameters silently arrives corrupted (anthropics/claude-code#83033).
 
 ## [0.12.8] - 2026-08-02
 ### Added
@@ -29,6 +30,7 @@
 - The issue-1979 Korean prose wrap test now cleans up inherited multiplexer env vars (`TMUX`, `TMUX_PANE`, etc.) so it deterministically exercises the plain-terminal render path regardless of the CI runner's terminal session (#1979).
 - The model selector's assignment menu now shows the model each role currently resolves to (`Set as EXECUTOR (Executor) — now: anthropic/claude-haiku-4-5`), distinguishing an unset default, a role that inherits the default, and a configured-but-unresolvable selector. Previously the role rows were unlabeled, so the only way to learn a role's model was to scan the whole 800+ entry model list for role badges.
 - Standalone `AGENTS.md` ancestor discovery now bounds directory traversal, per-file reads, and aggregate instruction bytes while surfacing content-free omission warnings (#3722).
+
 ## [0.12.7] - 2026-07-31
 
 ## [0.12.6] - 2026-07-31

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -97,6 +97,7 @@ Do not claim a web search, browser action, integration, or subagent ran without 
 <inputs>
 - Keep tool inputs concise where possible.
 - For `path` or path-like fields, prefer relative paths.
+- Write non-ASCII text in tool inputs as literal UTF-8, NEVER as hand-spelled `\uXXXX` escapes, including JSON serialized into a string field (no `ensure_ascii`-style output there). Escapes that are the intended source syntax of the file you are writing — character-class ranges, codepoint bounds — are unaffected.
 {{#if intentTracing}}
 - Most tools have a `{{intentField}}` parameter. Fill it with a concise intent in present participle form, 2-6 words, no period, capitalized.
 {{/if}}


### PR DESCRIPTION
## What

Adds one line to the `<inputs>` block of the system prompt:

> Write non-ASCII text in tool inputs as literal UTF-8, NEVER as hand-spelled `\uXXXX` escapes, including JSON serialized into a string field (no `ensure_ascii`-style output there). Escapes that are the intended source syntax of the file you are writing — character-class ranges, codepoint bounds — are unaffected.

## Why

Models sometimes write non-ASCII tool-parameter strings as hand-spelled `\uXXXX` escapes and mis-type the hex. Every mis-typed escape decodes to a valid-but-wrong Hangul syllable, so the corruption is invisible downstream — session storage keeps `tool_use.input` already parsed, so the escapes are decoded away before they are written. Upstream root-cause report with a controlled A/B experiment: anthropics/claude-code#83033.

Measured on this machine over 13,582 GJC session transcripts. Counting only strings the model itself wrote inside tool-call inputs, deduplicated by content, with rarity defined as "outside KS X 1001" (the 2,350-syllable set covering ordinary Korean):

| | count | on non-KS-X-1001 syllables |
|---|---|---|
| Hangul written as `\uXXXX` in tool inputs | 5,674 | 0.423% |
| Hangul written literally in tool inputs | 1,471,167 | 0.0069% |

61x. The escapes cluster in parameters that carry serialized JSON as a string (`task` `tasks`, `todo_write` `ops`) rather than in plain string parameters — writing JSON-inside-a-string appears to trigger `ensure_ascii`-style output. That is why the rule names the nested case explicitly; the upstream one-line workaround leaves that path open.

Confirmed mis-spellings, read out of the stored raw parameter text:

| raw | decodes to | intended |
|---|---|---|
| `\uc226\uc740` | 숦은 | 숨은 (`U+C228` → `U+C226`) |
| `\ub2a8\uc740` | 늨은 | 남은 (`U+B0A8` → `U+B2A8`) |
| `\uace0\uce6c\ub2e4` | 고칬다 | 고친다 (`U+CE5C` → `U+CE6C`) |

Each of these also appears later in the corpus as literal text; sorting every occurrence by timestamp, the earliest instance of all three is the escaped form, with the literal ones downstream re-quoting the already-decoded value. The causal direction is escape-first.

Subagents inherit the base system prompt (`task/executor.ts` keeps `defaultPrompt` and appends), so this single edit covers agent sessions too.

## Scope carve-out

133 escapes in the same corpus are legitimate — source the model was authoring, e.g. `"\uac00" <= char <= "\ud7a3"` boundary checks and a `(?!\uAC00)` regex lookahead. An unqualified "never write `\uXXXX`" would push those toward literal Hangul inside character classes and codepoint bounds, which is worse code and wrong for files that must stay ASCII. The final sentence of the rule exempts them.

## What this does not fix

A separate, rarer class of corruption arrives as clean literal UTF-8 with zero escapes. It is present here too: 41 non-KS-X-1001 syllable instances across 32 distinct model-written tool-input strings after filtering deliberate probe data and regex bounds — including 갱슱 (갱신), 최족 (최근), 상햤 (상태) all inside one string, plus 깨뜼리는, 정귘윽, 캨리브레이션, 븠짐없이. No prompt instruction can suppress that class, and this PR does not claim to. It removes the escape-driven class only, which is the larger and more concentrated one.

## Verification

```
bun test packages/coding-agent/test/system-prompt-templates.test.ts \
         packages/coding-agent/test/system-prompt-dedup.test.ts \
         packages/coding-agent/test/qa-prompts-redteam.test.ts        # 33 pass
bun test packages/coding-agent/test/prompt-templates.test.ts          # 50 pass
```

Changelog entry added under `Unreleased` → `Fixed`.
