### PR TITLE
fix(coding-agent): classify /import-session seam in SDK operation inventory

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 - First-event timeout retries now require a typed, content-free failure from the current clean attempt scope, preventing prior or stale extension activity from suppressing or admitting a later request (#3553).
 - Managed session preparation now preserves native `content_too_large` storage failures as `artifact_capacity_exceeded` instead of misreporting `binding_invalid: prepare:store`.
 - The issue-1979 Korean prose wrap test now cleans up inherited multiplexer env vars (`TMUX`, `TMUX_PANE`, etc.) so it deterministically exercises the plain-terminal render path regardless of the CI runner's terminal session (#1979).
+- The SDK operation inventory now classifies the local-only `/import-session` seam as a locked exclusion and regenerates the committed matrix, fixing the shard-5 `accepts the committed generated matrix` gate failure introduced by the Codex import command (#3714).
 ## [0.12.7] - 2026-07-31
 
 ## [0.12.6] - 2026-07-31

--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -12,6 +12,8 @@ const inventoryPath = process.env.GJC_SDK_OPERATION_INVENTORY
 /** Reviewed seams deliberately excluded from the public SDK operation surface. */
 const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 	"slash_command:settings": "visual/local-only command, not a user-facing SDK control seam",
+	"slash_command:import-session":
+		"local-only trusted command (acp: false, localHeadless: true) that imports external sessions on the operator's machine, not a user-facing SDK control seam",
 	"slash_command:theme": "visual/local-only command, not a user-facing SDK control seam",
 	"slash_command:copy": "visual/local-only command, not a user-facing SDK control seam",
 	"slash_command:changelog": "visual/local-only command, not a user-facing SDK control seam",

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -1692,6 +1692,17 @@
 		]
 	},
 	{
+		"sourceId": "slash_command:import-session",
+		"sourceFile": "packages/coding-agent/src/slash-commands/builtin-registry.ts",
+		"sourceKind": "slash_command",
+		"decision": "exclude",
+		"rationale": "local-only trusted command (acp: false, localHeadless: true) that imports external sessions on the operator's machine, not a user-facing SDK control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
 		"sourceId": "slash_command:notify",
 		"sourceFile": "packages/coding-agent/src/slash-commands/builtin-registry.ts",
 		"sourceKind": "slash_command",


### PR DESCRIPTION
## Summary
Post-merge repair for the shard-5 CI failure on dev merge commit `cba1b7df8` (#3714).

**Failure 1 — attributable to #3714 (fixed here):** `SDK operation inventory > accepts the committed generated matrix` failed with `Pending review source seam: slash_command:import-session`. The new command was never classified in the inventory gate. Since `/import-session` is deliberately ACP-blocked (`acp: false`) and trusted-local-only (`localHeadless: true`), it is added to `LOCKED_EXCLUSIONS` (matching every other local-only command) and the committed matrix is regenerated — one new `exclude` record, zero other drift.

**Failure 2 — not attributable to #3714 (documented, not fixed here):** `task fork-context cache identity > does not share mutable provider state…` failed with `Failed to release file lock: missing` from `src/config/file-lock.ts:259` via `session-state-sidecar.ts`. Attribution evidence:
- Neither `file-lock.ts`, `session-state-sidecar.ts`, nor `task-cache-key.test.ts` was touched by #3714.
- Mechanism is a pre-existing liveness race: a holder stalled past `staleMs` has its lock directory GC-removed by a concurrent acquirer; the holder's release then sees `missing` and throws (`file-lock.ts` lines 217-226, 257-259).
- Not reproducible locally: 3/3 clean runs of `task-cache-key.test.ts` on merged dev.
- Prior dev CI shows shard-level flaky failures of the same environmental character (e.g. run 30692240225 shard-7 `/btw` WebSocket flake).
Recommended as a separate flaky-test/lock-lease investigation, not bundled into this repair.

## Verification
- `sdk-operation-inventory.test.ts`: 16 pass / 1 fail → **17 pass / 0 fail**
- `sdk-mcp-adapter.test.ts` + `sdk-downgrade-unknown-version.test.ts`: 10/10 pass
- `tsc -p tsconfig.json --noEmit`: exit 0
- biome clean on the generator

No release, tag, or publish.

— GJC hostile review (gjc)