### PR TITLE
fix(utils): handle rejecting postmortem callbacks registered after cleanup

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - macOS executable discovery now honors explicit `PATH` and `cwd` lookup overrides instead of silently searching the process environment.
+- Postmortem callbacks registered after a completed plain cleanup now run through the handled `Promise.try(...).catch(log)` path instead of a bare synchronous call that dropped the returned promise, so rejecting async late registrations are logged instead of surfacing as unhandled rejections that fail unrelated in-flight work.
 
 ## [0.12.7] - 2026-07-31
 

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -433,12 +433,12 @@ export function register(id: string, callback: (reason: Reason) => void | Promis
 		}
 		// If cleanup is already running/completed, warn and run on microtask.
 		logger.warn("Cleanup invoked recursively", { id });
-		try {
-			callback(Reason.MANUAL);
-		} catch (error) {
-			const err = error instanceof Error ? error : new Error(String(error));
-			logger.error("Cleanup callback failed", { err, id, stack: err.stack });
-		}
+		queueMicrotask(() => {
+			void Promise.try(() => exec(Reason.MANUAL)).catch(error => {
+				const err = error instanceof Error ? error : new Error(String(error));
+				logger.error("Cleanup callback failed", { err, id, stack: err.stack });
+			});
+		});
 		return () => {};
 	}
 

--- a/packages/utils/test/postmortem-fixture.ts
+++ b/packages/utils/test/postmortem-fixture.ts
@@ -189,6 +189,18 @@ async function runQuietCleanupLateRegistration(resultPath: string | undefined): 
 	await runBrokenPipeStdoutWrite();
 }
 
+async function runLateRegistrationAsyncRejection(resultPath: string | undefined): Promise<void> {
+	if (!resultPath) throw new Error("late registration fixture requires a result path");
+	postmortem.register("fixture-late-registration-early", () => {});
+	await postmortem.cleanup();
+	postmortem.register("fixture-late-registration-async-rejection", async () => {
+		await Bun.sleep(20);
+		throw new Error("fixture: late registration async rejection");
+	});
+	await Bun.sleep(200);
+	await Bun.write(resultPath, JSON.stringify({ count: 1 }));
+}
+
 async function runOrdinaryFatalThenBrokenPipe(resultPath: string | undefined): Promise<void> {
 	if (!resultPath) throw new Error("ordinary fatal fixture requires a result path");
 
@@ -340,6 +352,9 @@ switch (scenario) {
 		break;
 	case "quiet-cleanup-late-registration":
 		await runQuietCleanupLateRegistration(process.argv[3]);
+		break;
+	case "late-registration-async-rejection":
+		await runLateRegistrationAsyncRejection(process.argv[3]);
 		break;
 	case "ordinary-fatal-then-broken-pipe":
 		await runOrdinaryFatalThenBrokenPipe(process.argv[3]);

--- a/packages/utils/test/postmortem.test.ts
+++ b/packages/utils/test/postmortem.test.ts
@@ -33,8 +33,8 @@ async function captureProcess(command: string[], cwd: string): Promise<ScenarioR
 	return { stdout, stderr, exitCode };
 }
 
-async function runScenario(scenario: string): Promise<ScenarioResult> {
-	return captureProcess([process.execPath, fixturePath, scenario], utilsDirectory);
+async function runScenario(scenario: string, extraArgs: readonly string[] = []): Promise<ScenarioResult> {
+	return captureProcess([process.execPath, fixturePath, scenario, ...extraArgs], utilsDirectory);
 }
 
 async function runPipelineCommand(command: readonly string[]): Promise<ScenarioResult> {
@@ -200,6 +200,21 @@ describe("postmortem process stdout EPIPE policy", () => {
 			expect(JSON.parse(await fs.readFile(resultPath, "utf8"))).toEqual({ count: 2 });
 			expect(result.stderr).not.toContain("Cleanup callback failed");
 			expect(result.stderr).not.toContain("Cleanup invoked recursively");
+		} finally {
+			await fs.rm(temporaryDirectory, { recursive: true, force: true });
+		}
+	}, 15_000);
+
+	it("handles a rejecting async callback registered after plain cleanup without an unhandled rejection", async () => {
+		const temporaryDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "postmortem-late-registration-"));
+		const resultPath = path.join(temporaryDirectory, "result.json");
+		try {
+			const result = await runScenario("late-registration-async-rejection", [resultPath]);
+
+			expect(result.exitCode).toBe(0);
+			expect(JSON.parse(await fs.readFile(resultPath, "utf8"))).toEqual({ count: 1 });
+			expect(combinedOutput(result)).toContain("Cleanup callback failed");
+			expect(combinedOutput(result)).not.toContain("[Unhandled Rejection]");
 		} finally {
 			await fs.rm(temporaryDirectory, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Summary
Independent post-merge repair for the recurring dev-CI shard-5 failure `task fork-context cache identity > does not share mutable provider state unless explicitly supplied` (failed on merge commits `cba1b7df8` and `c36376844`). Unrelated to #3717, whose history is untouched.

## Root mechanism (deterministically reproduced)
`packages/utils/src/postmortem.ts` `register()`: the late-registration branch (cleanup already completed, non-quiet) invoked `callback(Reason.MANUAL)` synchronously and **dropped the returned promise**. Every other invocation path routes through `Promise.try` + `allSettled`/`.catch`; this was the sole escape. A rejecting async late registration therefore surfaced as an unhandled rejection attributed by Bun to whatever test was in flight.

Chain in CI: an earlier shard-5 test completes a global `postmortem.cleanup()` → `AgentSession` registers its coordinator runtime-state finalizer (agent-session.ts:2591) **after** cleanup → the detached persist writes `runtime-state.json` under the session temp dir while `afterEach` `rm -rf`s it → `ENOENT` on lock mkdir + `Failed to release file lock: missing` on release → unhandled rejection → test marked failed.

## Attribution
Pre-existing latent defect in `@gajae-code/utils` — none of `postmortem.ts`, `file-lock.ts`, `session-state-sidecar.ts`, `agent-session.ts`, or the failing test were touched by #3714/#3717. First sighting coincided with the #3714 merge because dev-CI shards are content-hash packed and the new test files repacked shard 5, arming the latent path. Environmental aggravation, not a code regression.

## Fix
Route the branch through the same `Promise.try(...).catch(log)` shape as the quiet-shutdown path, on a microtask as its own comment already stated. Armed-callback and quiet-shutdown paths are unchanged.

## Verification
- New fixture scenario + test: exit 0, result persisted, `Cleanup callback failed` logged, no `[Unhandled Rejection]`. **Negative control:** fails with exit 1 on the unfixed source.
- `packages/utils`: postmortem suite 22/22, full suite 253/253, `tsc --noEmit` exit 0, biome clean.
- coding-agent affected tests (task-cache-key, executor-managed-resume, fork-context-advisory, session-manager-close-race, session-resident-lifecycle): 37/37.
- Scoped to exactly 4 files: `src/postmortem.ts`, `test/postmortem-fixture.ts`, `test/postmortem.test.ts`, `CHANGELOG.md`.

No release, tag, or publish.

— GJC hostile review (gjc)