### PR TITLE
fix(coding-agent): repair merged dev CI shard failures

### DIFF
--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -294,16 +294,6 @@ fn bridge_chunks(
 			// marks dropped output at the N-API callback boundary instead of silently
 			// losing it, so truncation is always observable to the caller.
 			while let Some(chunk) = rx.recv().await {
-				if dropped_chunks > 0 {
-					match bounded_tx.try_send(shell_loss_marker(dropped_chunks, dropped_bytes)) {
-						Ok(()) => {
-							dropped_chunks = 0;
-							dropped_bytes = 0;
-						},
-						Err(mpsc::error::TrySendError::Full(_)) => {},
-						Err(mpsc::error::TrySendError::Closed(_)) => break,
-					}
-				}
 				let chunk_len = chunk.len();
 				match bounded_tx.try_send(chunk) {
 					Ok(()) => {},

--- a/packages/coding-agent/test/telegram-baseline-manifest.test.ts
+++ b/packages/coding-agent/test/telegram-baseline-manifest.test.ts
@@ -333,7 +333,7 @@ describe("test manifest runner", () => {
 		expect(result.exitCode, output(result)).toBe(0);
 		expect(output(result)).toContain(`manifest command receipts complete: ${manifest.commands.length}`);
 		expect(output(result)).toContain(
-			"manifest row receipts complete: 570 (telegram=95, discord=95, slack=95, mcp=95, acp=95, daemonCli=95)",
+			"manifest row receipts complete: 576 (telegram=96, discord=96, slack=96, mcp=96, acp=96, daemonCli=96)",
 		);
 		const invocations = (await Bun.file(fake.log).text()).trim().split("\n");
 		expect(invocations).toHaveLength(manifest.commands.length + manifest.rows.length);


### PR DESCRIPTION
## Summary

Repairs the two confirmed post-merge dev-CI failures tracked by #3720. This is independent of merged PR #3694 and does not rewrite its history.

- Update the Telegram baseline manifest receipt assertion from 570/95-per-adapter to the generated Q29 parity total of 576/96-per-adapter.
- Defer native shell loss-marker delivery until retained chunks have drained, so callback-boundary loss markers cannot split terminal async output evidence such as `TAIL`.

## Verification

- `bun test packages/coding-agent/test/telegram-baseline-manifest.test.ts` — 17 passed, 0 failed
- `bun test packages/coding-agent/test/tools.test.ts --test-name-pattern 'should bound async and monitor output while preserving full local evidence'` — 1 passed, 0 failed\n- `bun test packages/coding-agent/test/sdk-adapter-dispositions.test.ts` — 576 passed, 0 failed\n- `bun packages/coding-agent/scripts/generate-sdk-adapter-parity-manifest.ts --check` — passed\n- `bun packages/coding-agent/scripts/generate-sdk-operation-inventory.ts --check` — passed\n- `cargo test -p pi-natives shell::tests` — 8 passed, 1 flaky existing failure; isolated rerun of `embedded_external_command_runs_in_its_own_session` passed\n- `git diff --check` — passed\n\nIssue: #3720\n\nNo release, tag, or merge performed.