### PR TITLE
fix(sdk/broker): bound publication ambiguity so fenced brokers cannot leak

### DIFF
--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -12,6 +12,7 @@ import {
 import {
 	BROKER_HEARTBEAT_TTL_MS,
 	type BrokerDiscovery,
+	type BrokerPublicationObservation,
 	brokerDiscoveryPath,
 	brokerProcessIncarnation,
 	heartbeatBrokerDiscoveryRetained,
@@ -396,6 +397,14 @@ type BrokerLockSnapshot = {
 
 const BROKER_PUBLICATION_CADENCE_MS = 5_000;
 const BROKER_PUBLICATION_GRACE_MS = 15_000;
+// A broker that cannot observe its own publication is not provably the root, but
+// ambiguity is also not proof of replacement, so it must not be treated as a
+// `lost-root` immediately. It must still be bounded: an indefinitely ambiguous
+// broker stops heartbeating, so peers discover it as stale and spawn replacements
+// while it keeps its port and memory forever. Ambiguity therefore accrues against
+// its own deadline, generous enough to absorb transient filesystem faults and far
+// longer than the loss grace.
+const BROKER_AMBIGUITY_GRACE_MS = 120_000;
 const BROKER_SETTLEMENT_MS = 2_000;
 type BrokerPublicationState =
 	| "healthy-owned"
@@ -406,6 +415,8 @@ type BrokerPublicationState =
 type BrokerStopMode = "owned-root" | "lost-root";
 
 const terminalPersistenceHooksForTest = new WeakMap<Broker, () => void>();
+const ambiguityGraceOverridesForTest = new WeakMap<Broker, number>();
+const publicationObservationOverridesForTest = new WeakMap<Broker, BrokerPublicationObservation>();
 
 export class Broker {
 	readonly settings: ResolvedBrokerSettings;
@@ -419,6 +430,7 @@ export class Broker {
 	#publication: RetainedBrokerDiscovery | null = null;
 	#publicationState: BrokerPublicationState = "healthy-owned";
 	#lossAt: bigint | null = null;
+	#ambiguousAt: bigint | null = null;
 	#stopping = false;
 	#transport: BrokerTransport | null = null;
 	#heartbeatTimer: NodeJS.Timeout | null = null;
@@ -565,6 +577,7 @@ export class Broker {
 		this.#stopping = false;
 		this.#publicationState = "healthy-owned";
 		this.#lossAt = null;
+		this.#ambiguousAt = null;
 		await Promise.all([this.ledger.assertSupportedStateVersions(), readBrokerDiscovery(this.settings.agentDir)]);
 		await fs.mkdir(path.dirname(this.#lock), { recursive: true, mode: 0o700 });
 		for (;;) {
@@ -648,16 +661,35 @@ export class Broker {
 	#fence(kind: "suspect-unpublished" | "observation-ambiguous" | "heartbeat-ambiguous"): void {
 		if (this.#publicationState === "stopping") return;
 		this.#publicationState = kind;
-		if (kind === "suspect-unpublished") this.#lossAt ??= process.hrtime.bigint();
-		else this.#lossAt = null;
+		if (kind === "suspect-unpublished") {
+			this.#lossAt ??= process.hrtime.bigint();
+			this.#ambiguousAt = null;
+		} else {
+			this.#lossAt = null;
+			this.#ambiguousAt ??= process.hrtime.bigint();
+		}
+	}
+	/**
+	 * Whether this broker has been unable to confirm it is the published root for
+	 * longer than the deadline for its current fence. Replacement is proven quickly
+	 * and ambiguity slowly, but neither may persist indefinitely: a permanently
+	 * fenced broker never heartbeats, so it is unreachable through discovery while
+	 * still holding its port and memory.
+	 */
+	#fencedBeyondDeadline(): boolean {
+		const now = process.hrtime.bigint();
+		if (this.#lossAt !== null && now - this.#lossAt >= BigInt(BROKER_PUBLICATION_GRACE_MS) * 1_000_000n) return true;
+		const ambiguityGraceMs = ambiguityGraceOverridesForTest.get(this) ?? BROKER_AMBIGUITY_GRACE_MS;
+		return this.#ambiguousAt !== null && now - this.#ambiguousAt >= BigInt(ambiguityGraceMs) * 1_000_000n;
 	}
 	async #watchPublication(writeHeartbeat = true): Promise<void> {
 		if (!this.#publication || this.#publicationState === "stopping") return;
 		let observation: ReturnType<RetainedBrokerDiscovery["observe"]>;
 		try {
-			observation = this.#publication.observe();
+			observation = publicationObservationOverridesForTest.get(this) ?? this.#publication.observe();
 		} catch {
 			this.#fence("observation-ambiguous");
+			if (this.#fencedBeyondDeadline()) void this.#complete("lost-root");
 			return;
 		}
 		if (observation === "owned") {
@@ -667,15 +699,12 @@ export class Broker {
 			}
 			this.#publicationState = "healthy-owned";
 			this.#lossAt = null;
+			this.#ambiguousAt = null;
 			if (writeHeartbeat) await this.#writeHeartbeat();
 			return;
 		}
 		this.#fence(observation === "ambiguous" ? "observation-ambiguous" : "suspect-unpublished");
-		if (
-			this.#lossAt !== null &&
-			process.hrtime.bigint() - this.#lossAt >= BigInt(BROKER_PUBLICATION_GRACE_MS) * 1_000_000n
-		)
-			void this.#complete("lost-root");
+		if (this.#fencedBeyondDeadline()) void this.#complete("lost-root");
 	}
 	async #writeHeartbeat(): Promise<void> {
 		if (!this.discovery || !this.#publication || this.#publicationState === "stopping") return;
@@ -691,6 +720,7 @@ export class Broker {
 		}
 		this.#publicationState = "healthy-owned";
 		this.#lossAt = null;
+		this.#ambiguousAt = null;
 		this.discovery = { ...this.discovery, heartbeatAt };
 	}
 	async heartbeat(): Promise<void> {
@@ -970,4 +1000,19 @@ export class Broker {
 export function setTerminalPersistenceHookForTest(broker: Broker, hook: (() => void) | undefined): void {
 	if (hook) terminalPersistenceHooksForTest.set(broker, hook);
 	else terminalPersistenceHooksForTest.delete(broker);
+}
+
+/** Test-only hook for shortening the bounded ambiguity deadline. */
+export function setAmbiguityGraceForTest(broker: Broker, graceMs: number | undefined): void {
+	if (graceMs === undefined) ambiguityGraceOverridesForTest.delete(broker);
+	else ambiguityGraceOverridesForTest.set(broker, graceMs);
+}
+
+/** Test-only hook for forcing the observation the publication watchdog sees. */
+export function setPublicationObservationForTest(
+	broker: Broker,
+	observation: BrokerPublicationObservation | undefined,
+): void {
+	if (observation === undefined) publicationObservationOverridesForTest.delete(broker);
+	else publicationObservationOverridesForTest.set(broker, observation);
 }

--- a/packages/coding-agent/test/sdk-broker-publication-fence.test.ts
+++ b/packages/coding-agent/test/sdk-broker-publication-fence.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Broker, setAmbiguityGraceForTest, setPublicationObservationForTest } from "../src/sdk/broker/broker";
+
+// A short TTL drives the publication watchdog at `ttl/3`, so the fence advances
+// in tens of milliseconds instead of the production five-second cadence.
+const HEARTBEAT_TTL_MS = 300;
+const WATCHDOG_CADENCE_MS = HEARTBEAT_TTL_MS / 3;
+
+const brokers: Broker[] = [];
+const roots: string[] = [];
+
+async function startBroker(): Promise<Broker> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-fence-"));
+	roots.push(root);
+	const broker = new Broker({ agentDir: path.join(root, "agent"), heartbeatTtlMs: HEARTBEAT_TTL_MS });
+	brokers.push(broker);
+	await broker.start();
+	return broker;
+}
+
+/** Resolves to true when the broker self-terminated inside the window. */
+function completedWithin(broker: Broker, ms: number): Promise<boolean> {
+	return Promise.race([
+		broker.completion.then(
+			() => true,
+			() => true,
+		),
+		Bun.sleep(ms).then(() => false),
+	]);
+}
+
+afterEach(async () => {
+	for (const broker of brokers) {
+		setPublicationObservationForTest(broker, undefined);
+		setAmbiguityGraceForTest(broker, undefined);
+		await broker.stop().catch(() => {});
+	}
+	brokers.length = 0;
+	for (const root of roots) await fs.rm(root, { recursive: true, force: true });
+	roots.length = 0;
+});
+
+test("a permanently ambiguous broker self-terminates instead of lingering forever", async () => {
+	const broker = await startBroker();
+	setAmbiguityGraceForTest(broker, WATCHDOG_CADENCE_MS);
+	// `observe()` returns "ambiguous" forever once the retained publication handle
+	// is closed. Before the ambiguity deadline existed this state cleared the loss
+	// timer on every tick, so the broker stopped heartbeating but never exited --
+	// peers then discovered it as stale and spawned unbounded replacements.
+	setPublicationObservationForTest(broker, "ambiguous");
+
+	expect(await completedWithin(broker, WATCHDOG_CADENCE_MS * 20)).toBe(true);
+});
+
+test("transient ambiguity within the deadline does not terminate the broker", async () => {
+	const broker = await startBroker();
+	setAmbiguityGraceForTest(broker, 60_000);
+	setPublicationObservationForTest(broker, "ambiguous");
+
+	expect(await completedWithin(broker, WATCHDOG_CADENCE_MS * 6)).toBe(false);
+});
+
+test("recovering to owned clears accrued ambiguity", async () => {
+	const broker = await startBroker();
+	setAmbiguityGraceForTest(broker, WATCHDOG_CADENCE_MS * 8);
+	setPublicationObservationForTest(broker, "ambiguous");
+	await Bun.sleep(WATCHDOG_CADENCE_MS * 5);
+
+	// Recovery must reset the clock, so the broker survives well past the point
+	// where the original uninterrupted ambiguity would have expired.
+	setPublicationObservationForTest(broker, "owned");
+	await Bun.sleep(WATCHDOG_CADENCE_MS * 2);
+	setPublicationObservationForTest(broker, "ambiguous");
+
+	expect(await completedWithin(broker, WATCHDOG_CADENCE_MS * 5)).toBe(false);
+});
+
+test("a replaced publication still terminates on the shorter loss grace", async () => {
+	const broker = await startBroker();
+	// Replacement is proven, not ambiguous, so it must not wait for the ambiguity
+	// deadline; the pre-existing 15s loss grace governs it.
+	setAmbiguityGraceForTest(broker, 60_000);
+	setPublicationObservationForTest(broker, "replaced");
+
+	expect(await completedWithin(broker, 25_000)).toBe(true);
+}, 30_000);


### PR DESCRIPTION
## Problem

A single machine accumulated **920 orphaned broker processes holding ~85 GB**, exhausting a 75 GB swap file over ~13 days of normal use.

`Broker.#fence()` cleared the loss timer for both ambiguous states:

```js
if (kind === "suspect-unpublished") this.#lossAt ??= process.hrtime.bigint();
else this.#lossAt = null;          // observation-ambiguous / heartbeat-ambiguous
```

Self-termination via `#complete("lost-root")` is gated on `#lossAt !== null`, so an ambiguous broker could never reach it.

That state is both reachable and **absorbing** — `discovery.ts:51` returns `"ambiguous"` permanently once the retained publication handle is closed:

```js
observe(): BrokerPublicationObservation {
    if (this.#closed) return "ambiguous";
    ...
}
```

A broker fenced this way stops writing heartbeats, so peers read its discovery record as stale and spawn a replacement, while the fenced process keeps its port and ~95 MB resident **forever**. Each replacement can meet the same fate, so the population only grows.

The `"absent"` / `"replaced"` path was always correct. Only ambiguity was immortal.

## Fix

Ambiguity now accrues against its own `#ambiguousAt` clock instead of clearing `#lossAt`:

- **Replacement** keeps the existing `BROKER_PUBLICATION_GRACE_MS` (15s) — it is proven, so it should act fast.
- **Ambiguity** gets a deliberately generous `BROKER_AMBIGUITY_GRACE_MS` (120s), so transient filesystem faults cannot terminate a healthy root.
- Recovery to `"owned"` clears both clocks.

`lost-root` is the correct termination mode here: it does **not** unlink the discovery file and does **not** release the lock, which is exactly right for a broker that cannot prove it owns the record.

## Tests

The publication fence state machine had **zero** test coverage — that is how this shipped. Adds `test/sdk-broker-publication-fence.test.ts` (4 tests):

| test | guards |
|---|---|
| permanently ambiguous broker self-terminates | the leak |
| transient ambiguity within deadline does not terminate | over-correction |
| recovering to owned clears accrued ambiguity | clock reset |
| replaced publication still terminates on the shorter loss grace | unchanged existing behavior |

Confirmed as a genuine regression test: reverting only the accrual line (`#ambiguousAt = null`) makes test 1 fail; restoring it passes. The other three pass with and without the fix, which is what makes them useful as over-correction guards.

Two test-only seams added, following the existing `set*ForTest` WeakMap convention used by `setTerminalPersistenceHookForTest` — no production signature or public config surface changed.

## Verification

- `tsc --noEmit` clean
- `biome check` clean
- `test/sdk-broker-publication-fence.test.ts` — 4/4 pass
- `test/sdk-broker-lifecycle-e2e.test.ts` — 55 pass / 5 fail, **identical 5 failures on stashed baseline** (pre-existing, unrelated to this change)

On the affected machine: swap 74.2 G → 15.5 G, free memory 48% → 92%, steady state back to the intended one broker per `agentDir`.

## Follow-ups (not in this PR)

- `sdk/bus/index.ts:5146` — broker registration failure is swallowed as a warning when `lifecycleRequired` is false, letting a session retry indefinitely. This drove the spawn *rate*; this PR bounds the resulting population regardless, but the unbounded silent retry is still worth addressing.
- No reaper exists for brokers already orphaned by older builds. Largely moot once they self-terminate, but nothing reclaims pre-existing ones.
