### PR TITLE
fix(coding-agent): prefer canonical psmux aliases on Windows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Windows automatic tmux resolution now selects `psmux` then `pmux` by canonical command order without rejecting distinct lower-priority aliases; it probes `tmux` only when neither named provider is available (#3725).
 - Ordinary `ask` selectors now bound long question premises and page through every premise row without skipping rows hidden by overflow indicators (#3675).
 - First-event timeout retries now require a typed, content-free failure from the current clean attempt scope, preventing prior or stale extension activity from suppressing or admitting a later request (#3553).
 - The issue-1979 Korean prose wrap test now cleans up inherited multiplexer env vars (`TMUX`, `TMUX_PANE`, etc.) so it deterministically exercises the plain-terminal render path regardless of the CI runner's terminal session (#1979).

--- a/packages/coding-agent/src/gjc-runtime/psmux-detect.ts
+++ b/packages/coding-agent/src/gjc-runtime/psmux-detect.ts
@@ -324,25 +324,21 @@ export function resolveGjcTmuxBinary(options: ResolveGjcTmuxBinaryOptions = {}):
 		return { command: explicit, isPsmux, viaExplicitOverride: true };
 	}
 	if (platform === "win32") {
-		const candidates: Array<{ command: string; identity: string }> = [];
-		for (const candidate of PSMUX_BINARY_NAMES) {
-			const executablePath = resolveBinaryPath(candidate);
+		for (const command of ["psmux", "pmux"] as const) {
+			const executablePath = resolveBinaryPath(command);
 			if (!executablePath) continue;
-			const isPsmuxAlias = candidate !== "tmux" || detectPsmuxForCommand(candidate, runner);
-			if (!isPsmuxAlias) continue;
-			const identity = activeExecutableIdentityResolver(executablePath);
-			if (!identity)
-				throw new Error(`gjc_tmux_provider_ambiguous: Windows ${candidate} executable identity is unavailable`);
-			candidates.push({ command: candidate, identity });
+			if (!activeExecutableIdentityResolver(executablePath))
+				throw new Error(`gjc_tmux_provider_ambiguous: Windows ${command} executable identity is unavailable`);
+			return { command, isPsmux: true, viaExplicitOverride: false };
 		}
-		if (candidates.length > 0) {
-			const identities = new Set(candidates.map(candidate => candidate.identity));
-			if (identities.size !== 1)
-				throw new Error("gjc_tmux_provider_ambiguous: Windows psmux aliases resolve to different executables");
-			// The order is the canonical provider spelling, then its compatibility
-			// aliases. Identity equality above makes PATH-order alias selection safe.
-			return { command: candidates[0]!.command, isPsmux: true, viaExplicitOverride: false };
+		const tmuxPath = resolveBinaryPath("tmux");
+		if (tmuxPath) {
+			const isPsmux = outputMentionsPsmux(probeVersionOutput(tmuxPath, runner));
+			if (isPsmux && !activeExecutableIdentityResolver(tmuxPath))
+				throw new Error("gjc_tmux_provider_ambiguous: Windows tmux executable identity is unavailable");
+			return { command: "tmux", isPsmux, viaExplicitOverride: false };
 		}
+		return { command: "tmux", isPsmux: false, viaExplicitOverride: false };
 	}
 	const tmuxPath = resolveBinaryPath("tmux");
 	if (tmuxPath) {

--- a/packages/coding-agent/test/gjc-runtime/psmux-detect.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/psmux-detect.test.ts
@@ -130,15 +130,22 @@ describe("PSMUX_BINARY_NAMES", () => {
 			).toThrow("gjc_tmux_provider_ambiguous: selected psmux command requires Windows");
 		});
 
-		it("refuses Windows aliases with conflicting canonical identities", () => {
+		it("uses the canonical psmux provider despite distinct compatibility aliases", () => {
+			__setBinaryResolverForTests(candidate =>
+				candidate === "psmux" || candidate === "pmux" || candidate === "tmux"
+					? `C:\\psmux\\${candidate}.exe`
+					: null,
+			);
 			__setExecutableIdentityResolverForTests(executable => executable);
-			expect(() =>
-				resolveGjcTmuxProviderContext({
-					platform: "win32",
-					env: {},
-					runner: buildRunner(psmuxVersionOutput()),
-				}),
-			).toThrow("gjc_tmux_provider_ambiguous");
+
+			const context = resolveGjcTmuxProviderContext({
+				platform: "win32",
+				env: {},
+				runner: buildRunner(psmuxVersionOutput()),
+			});
+
+			expect(context.kind).toBe("windows-psmux");
+			expect(context.command).toBe("C:\\psmux\\psmux.exe");
 		});
 		it("persists authority and rejects invalid sidecars before mutation", () => {
 			const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-psmux-provider-"));
@@ -530,14 +537,107 @@ describe("resolveGjcTmuxBinary", () => {
 		expect(resolved.isPsmux).toBe(true);
 	});
 
-	it("treats a selected Windows psmux executable as psmux even with a generic tmux banner", () => {
+	it("prefers psmux over distinct compatibility aliases without inspecting lower aliases", () => {
+		const resolvedCandidates: string[] = [];
+		const identityCandidates: string[] = [];
+		__setBinaryResolverForTests(candidate => {
+			resolvedCandidates.push(candidate);
+			return `C:\\tools\\${candidate}.exe`;
+		});
+		__setExecutableIdentityResolverForTests(executable => {
+			identityCandidates.push(executable);
+			return "volume:42";
+		});
+
 		const resolved = resolveGjcTmuxBinary({
 			platform: "win32",
 			env: {},
 			runner: buildRunner(tmuxVersionOutput()),
 		});
-		expect(resolved.command).toBe("psmux");
-		expect(resolved.isPsmux).toBe(true);
+
+		expect(resolved).toEqual({ command: "psmux", isPsmux: true, viaExplicitOverride: false });
+		expect(resolvedCandidates).toEqual(["psmux"]);
+		expect(identityCandidates).toEqual(["C:\\tools\\psmux.exe"]);
+	});
+
+	it("does not inspect broken lower-priority aliases after selecting psmux", () => {
+		__setBinaryResolverForTests(candidate => {
+			if (candidate === "psmux") return "C:\\tools\\psmux.exe";
+			throw new Error(`unexpected compatibility alias lookup: ${candidate}`);
+		});
+
+		expect(
+			resolveGjcTmuxBinary({
+				platform: "win32",
+				env: {},
+				runner: buildRunner(tmuxVersionOutput()),
+			}),
+		).toEqual({ command: "psmux", isPsmux: true, viaExplicitOverride: false });
+	});
+
+	it("rejects psmux when its executable identity is unavailable", () => {
+		__setBinaryResolverForTests(candidate => (candidate === "psmux" ? "C:\\tools\\psmux.exe" : null));
+		__setExecutableIdentityResolverForTests(() => null);
+
+		expect(() =>
+			resolveGjcTmuxBinary({
+				platform: "win32",
+				env: {},
+				runner: buildRunner(tmuxVersionOutput()),
+			}),
+		).toThrow("gjc_tmux_provider_ambiguous: Windows psmux executable identity is unavailable");
+	});
+
+	it("falls back to pmux when psmux is unavailable", () => {
+		__setBinaryResolverForTests(candidate => {
+			if (candidate === "psmux") return null;
+			if (candidate === "pmux") return "C:\\tools\\pmux.exe";
+			throw new Error(`unexpected lower-priority alias lookup: ${candidate}`);
+		});
+
+		expect(
+			resolveGjcTmuxBinary({
+				platform: "win32",
+				env: {},
+				runner: buildRunner(tmuxVersionOutput()),
+			}),
+		).toEqual({ command: "pmux", isPsmux: true, viaExplicitOverride: false });
+	});
+
+	it("treats a tmux alias with a psmux banner as psmux when named providers are unavailable", () => {
+		__setBinaryResolverForTests(candidate => (candidate === "tmux" ? "C:\\tools\\tmux.exe" : null));
+
+		expect(
+			resolveGjcTmuxBinary({
+				platform: "win32",
+				env: {},
+				runner: buildRunner(psmuxVersionOutput()),
+			}),
+		).toEqual({ command: "tmux", isPsmux: true, viaExplicitOverride: false });
+	});
+	it("rejects a psmux-marked tmux alias when its identity is unavailable", () => {
+		__setBinaryResolverForTests(candidate => (candidate === "tmux" ? "C:\\tools\\tmux.exe" : null));
+		__setExecutableIdentityResolverForTests(() => null);
+
+		expect(() =>
+			resolveGjcTmuxBinary({
+				platform: "win32",
+				env: {},
+				runner: buildRunner(psmuxVersionOutput()),
+			}),
+		).toThrow("gjc_tmux_provider_ambiguous: Windows tmux executable identity is unavailable");
+	});
+
+	it("keeps a genuine tmux-only Windows installation on native-tmux semantics", () => {
+		__setBinaryResolverForTests(candidate => (candidate === "tmux" ? "C:\\tools\\tmux.exe" : null));
+
+		expect(
+			resolveGjcTmuxBinary({
+				platform: "win32",
+				env: {},
+				runner: buildRunner(tmuxVersionOutput()),
+			}),
+		).toEqual({ command: "tmux", isPsmux: false, viaExplicitOverride: false });
 	});
 
 	it("classifies an explicit Windows tmux.exe alias by matching the psmux executable identity", () => {


### PR DESCRIPTION
## Summary
- prefer the first usable Windows named provider in canonical `psmux` → `pmux` order
- avoid comparing identities of unselected compatibility aliases
- preserve selected executable identity checks, explicit override validation, psmux-marked `tmux`, and genuine native `tmux`

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/psmux-detect.test.ts`
- `bun test packages/coding-agent/test/gjc-runtime/team-runtime.test.ts --test-name-pattern "native Windows tmux"`
- `bun --cwd=packages/coding-agent run check`

Fixes #3725