### PR TITLE
fix(coding-agent): bound ancestor AGENTS discovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 - First-event timeout retries now require a typed, content-free failure from the current clean attempt scope, preventing prior or stale extension activity from suppressing or admitting a later request (#3553).
 - The issue-1979 Korean prose wrap test now cleans up inherited multiplexer env vars (`TMUX`, `TMUX_PANE`, etc.) so it deterministically exercises the plain-terminal render path regardless of the CI runner's terminal session (#1979).
 - The model selector's assignment menu now shows the model each role currently resolves to (`Set as EXECUTOR (Executor) — now: anthropic/claude-haiku-4-5`), distinguishing an unset default, a role that inherits the default, and a configured-but-unresolvable selector. Previously the role rows were unlabeled, so the only way to learn a role's model was to scan the whole 800+ entry model list for role badges.
+- Standalone `AGENTS.md` ancestor discovery now bounds directory traversal, per-file reads, and aggregate instruction bytes while surfacing content-free omission warnings (#3722).
 ## [0.12.7] - 2026-07-31
 
 ## [0.12.6] - 2026-07-31

--- a/packages/coding-agent/src/discovery/agents-md.ts
+++ b/packages/coding-agent/src/discovery/agents-md.ts
@@ -34,6 +34,8 @@ async function readBoundedAgentsMdFile(
 	try {
 		const file = await fs.open(filePath, "r");
 		try {
+			const stats = await file.stat();
+			if (!stats.isFile()) return { content: null, byteLength: 0, tooLarge: false };
 			const bytes = Buffer.alloc(maxBytes + 1);
 			const { bytesRead } = await file.read(bytes, 0, bytes.length, 0);
 			if (bytesRead > maxBytes) return { content: null, byteLength: bytesRead, tooLarge: true };
@@ -73,25 +75,21 @@ export async function loadAgentsMd(
 
 		if (!baseName.startsWith(".")) {
 			const remainingAggregateBytes = MAX_AGGREGATE_BYTES - aggregateBytes;
-			if (remainingAggregateBytes === 0) {
-				omittedAggregateFile = true;
-			} else {
-				const allowedBytes = Math.min(MAX_FILE_BYTES, remainingAggregateBytes);
-				const result = await readCandidate(candidate, allowedBytes);
-				if (result.tooLarge) {
-					if (allowedBytes < MAX_FILE_BYTES) omittedAggregateFile = true;
-					else omittedOversizedFile = true;
-				} else if (result.content !== null) {
-					const fileDir = path.dirname(candidate);
-					items.push({
-						path: candidate,
-						content: result.content,
-						level: "project",
-						depth: calculateDepth(ctx.cwd, fileDir, path.sep),
-						_source: createSourceMeta(PROVIDER_ID, candidate, "project"),
-					});
-					aggregateBytes += result.byteLength;
-				}
+			const allowedBytes = Math.min(MAX_FILE_BYTES, remainingAggregateBytes);
+			const result = await readCandidate(candidate, allowedBytes);
+			if (result.tooLarge) {
+				if (allowedBytes < MAX_FILE_BYTES) omittedAggregateFile = true;
+				else omittedOversizedFile = true;
+			} else if (result.content !== null) {
+				const fileDir = path.dirname(candidate);
+				items.push({
+					path: candidate,
+					content: result.content,
+					level: "project",
+					depth: calculateDepth(ctx.cwd, fileDir, path.sep),
+					_source: createSourceMeta(PROVIDER_ID, candidate, "project"),
+				});
+				aggregateBytes += result.byteLength;
 			}
 		}
 

--- a/packages/coding-agent/src/discovery/agents-md.ts
+++ b/packages/coding-agent/src/discovery/agents-md.ts
@@ -5,56 +5,110 @@
  * This handles AGENTS.md files that live in project root (not in config directories
  * like .OpenAI code backend/ or .gemini/, which are handled by their respective providers).
  */
+import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { registerProvider } from "../capability";
 import { type ContextFile, contextFileCapability } from "../capability/context-file";
-import { readFile } from "../capability/fs";
 import type { LoadContext, LoadResult } from "../capability/types";
 import { calculateDepth, createSourceMeta } from "./helpers";
 
 const PROVIDER_ID = "agents-md";
 const DISPLAY_NAME = "AGENTS.md";
+// Bound hostile ancestor walks and instruction payloads before they reach prompt assembly.
+const MAX_ANCESTOR_DIRECTORIES = 32;
+const MAX_FILE_BYTES = 64 * 1024;
+const MAX_AGGREGATE_BYTES = 256 * 1024;
+const DIRECTORY_LIMIT_WARNING = "AGENTS.md discovery stopped after scanning 32 ancestor directories.";
+const FILE_LIMIT_WARNING = "Skipped one or more AGENTS.md files that exceed the 64 KiB limit.";
+const AGGREGATE_LIMIT_WARNING = "Skipped one or more AGENTS.md files that exceed the 256 KiB aggregate limit.";
+
+export type AgentsMdReader = (
+	filePath: string,
+	maxBytes: number,
+) => Promise<{ content: string | null; byteLength: number; tooLarge: boolean }>;
+
+async function readBoundedAgentsMdFile(
+	filePath: string,
+	maxBytes: number,
+): Promise<{ content: string | null; byteLength: number; tooLarge: boolean }> {
+	try {
+		const file = await fs.open(filePath, "r");
+		try {
+			const bytes = Buffer.alloc(maxBytes + 1);
+			const { bytesRead } = await file.read(bytes, 0, bytes.length, 0);
+			if (bytesRead > maxBytes) return { content: null, byteLength: bytesRead, tooLarge: true };
+			return {
+				content: new TextDecoder().decode(bytes.subarray(0, bytesRead)),
+				byteLength: bytesRead,
+				tooLarge: false,
+			};
+		} finally {
+			await file.close();
+		}
+	} catch {
+		return { content: null, byteLength: 0, tooLarge: false };
+	}
+}
 
 /**
  * Load standalone AGENTS.md files.
  */
-async function loadAgentsMd(ctx: LoadContext): Promise<LoadResult<ContextFile>> {
+export async function loadAgentsMd(
+	ctx: LoadContext,
+	readCandidate: AgentsMdReader = readBoundedAgentsMdFile,
+): Promise<LoadResult<ContextFile>> {
 	const items: ContextFile[] = [];
 	const warnings: string[] = [];
-
-	// Walk up from cwd looking for AGENTS.md files
 	let current = ctx.cwd;
+	let scannedDirectories = 0;
+	let aggregateBytes = 0;
+	let omittedOversizedFile = false;
+	let omittedAggregateFile = false;
 
 	while (true) {
+		scannedDirectories += 1;
 		const candidate = path.join(current, "AGENTS.md");
-		const content = await readFile(candidate);
+		const parent = path.dirname(candidate);
+		const baseName = parent.split(path.sep).pop() ?? "";
 
-		if (content !== null) {
-			const parent = path.dirname(candidate);
-			const baseName = parent.split(path.sep).pop() ?? "";
-
-			if (!baseName.startsWith(".")) {
-				const fileDir = path.dirname(candidate);
-				const calculatedDepth = calculateDepth(ctx.cwd, fileDir, path.sep);
-
-				items.push({
-					path: candidate,
-					content,
-					level: "project",
-					depth: calculatedDepth,
-					_source: createSourceMeta(PROVIDER_ID, candidate, "project"),
-				});
+		if (!baseName.startsWith(".")) {
+			const remainingAggregateBytes = MAX_AGGREGATE_BYTES - aggregateBytes;
+			if (remainingAggregateBytes === 0) {
+				omittedAggregateFile = true;
+			} else {
+				const allowedBytes = Math.min(MAX_FILE_BYTES, remainingAggregateBytes);
+				const result = await readCandidate(candidate, allowedBytes);
+				if (result.tooLarge) {
+					if (allowedBytes < MAX_FILE_BYTES) omittedAggregateFile = true;
+					else omittedOversizedFile = true;
+				} else if (result.content !== null) {
+					const fileDir = path.dirname(candidate);
+					items.push({
+						path: candidate,
+						content: result.content,
+						level: "project",
+						depth: calculateDepth(ctx.cwd, fileDir, path.sep),
+						_source: createSourceMeta(PROVIDER_ID, candidate, "project"),
+					});
+					aggregateBytes += result.byteLength;
+				}
 			}
 		}
 
-		if (current === (ctx.repoRoot ?? ctx.home)) break; // scanned repo root or home, stop
+		const stopDirectory = ctx.repoRoot ?? ctx.home;
+		if (current === stopDirectory) break;
+		if (scannedDirectories === MAX_ANCESTOR_DIRECTORIES) {
+			warnings.push(DIRECTORY_LIMIT_WARNING);
+			break;
+		}
 
-		// Move to parent directory
-		const parent = path.dirname(current);
-		if (parent === current) break; // Reached filesystem root
-		current = parent;
+		const parentDirectory = path.dirname(current);
+		if (parentDirectory === current) break;
+		current = parentDirectory;
 	}
 
+	if (omittedOversizedFile) warnings.push(FILE_LIMIT_WARNING);
+	if (omittedAggregateFile) warnings.push(AGGREGATE_LIMIT_WARNING);
 	return { items, warnings };
 }
 

--- a/packages/coding-agent/src/discovery/agents-md.ts
+++ b/packages/coding-agent/src/discovery/agents-md.ts
@@ -32,12 +32,17 @@ async function readBoundedAgentsMdFile(
 	maxBytes: number,
 ): Promise<{ content: string | null; byteLength: number; tooLarge: boolean }> {
 	try {
-		const file = await fs.open(filePath, "r");
+		const file = await fs.open(filePath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
 		try {
 			const stats = await file.stat();
 			if (!stats.isFile()) return { content: null, byteLength: 0, tooLarge: false };
 			const bytes = Buffer.alloc(maxBytes + 1);
-			const { bytesRead } = await file.read(bytes, 0, bytes.length, 0);
+			let bytesRead = 0;
+			while (bytesRead < bytes.length) {
+				const result = await file.read(bytes, bytesRead, bytes.length - bytesRead, bytesRead);
+				if (result.bytesRead === 0) break;
+				bytesRead += result.bytesRead;
+			}
 			if (bytesRead > maxBytes) return { content: null, byteLength: bytesRead, tooLarge: true };
 			return {
 				content: new TextDecoder().decode(bytes.subarray(0, bytesRead)),

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -198,6 +198,9 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 	let unsubscribe: (() => void) | undefined;
 
 	try {
+		for (const warning of new Set(session.configWarnings)) {
+			await writeStderrAndQuiesce(`Warning: ${warning}\n`);
+		}
 		// Emit session header for JSON mode.
 		if (mode === "json") {
 			const header = session.sessionManager.getHeader();

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -136,6 +136,7 @@ import {
 	buildSystemPrompt as buildSystemPromptInternal,
 	buildSystemPromptToolMetadata,
 	loadProjectContextFiles as loadContextFilesInternal,
+	loadProjectContextFilesResult as loadContextFilesResultInternal,
 } from "../system-prompt";
 import { AgentOutputManager } from "../task/output-manager";
 import { parseThinkingLevel, resolveThinkingLevelForModel, toReasoningEffort } from "../thinking";
@@ -1166,10 +1167,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// Independent discoveries that depend only on cwd/agentDir — kicked off in parallel and awaited
 		// at their respective consumer sites. Their work can overlap with model resolution, secret loading,
 		// session-context build, tool creation, MCP discovery, and extension discovery.
-		const contextFilesPromise = options.contextFiles
-			? Promise.resolve(options.contextFiles)
-			: logger.time("discoverContextFiles", discoverContextFiles, cwd, agentDir);
-		contextFilesPromise.catch(() => {});
+		const contextFilesResultPromise = options.contextFiles
+			? Promise.resolve({ contextFiles: options.contextFiles, warnings: [] })
+			: logger.time("discoverContextFiles", loadContextFilesResultInternal, { cwd });
+		contextFilesResultPromise.catch(() => {});
 		const promptTemplatesPromise = options.promptTemplates
 			? Promise.resolve(options.promptTemplates)
 			: logger.time("discoverPromptTemplates", discoverPromptTemplates, cwd, agentDir);
@@ -1465,10 +1466,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			}
 			return result;
 		};
-		const [contextFiles, resolvedWorkspaceTree] = await Promise.all([
-			contextFilesPromise,
+		const [contextFilesResult, resolvedWorkspaceTree] = await Promise.all([
+			contextFilesResultPromise,
 			raceWithDeadline("buildWorkspaceTree", workspaceTreePromise),
 		]);
+		const contextFiles = contextFilesResult.contextFiles;
+		const discoveredContextFileWarnings = contextFilesResult.warnings;
 
 		const backgroundJobsEnabled = isBackgroundJobSupportEnabled(settings);
 		const asyncMaxJobs = Math.min(100, Math.max(1, settings.get("async.maxJobs") ?? 100));
@@ -2233,7 +2236,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			settings.get("tools.intentTracing"),
 			options.hasUI ?? false,
 		);
-		const emittedContextFileWarnings = new Set<string>();
+		const emittedContextFileWarnings = new Set(discoveredContextFileWarnings);
+		const contextFileWarnings = [...discoveredContextFileWarnings];
+		for (const warning of discoveredContextFileWarnings) {
+			logger.warn("Context file discovery warning", { warning });
+		}
 		const intentField = intentTracingEnabled ? INTENT_FIELD : undefined;
 		const rebuildSystemPrompt = async (
 			toolNames: string[],
@@ -2315,6 +2322,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			for (const warning of defaultPrompt.warnings) {
 				if (emittedContextFileWarnings.has(warning)) continue;
 				emittedContextFileWarnings.add(warning);
+				contextFileWarnings.push(warning);
+				if (hasSession) session.configWarnings.push(warning);
 				logger.warn("Context file discovery warning", { warning });
 			}
 			if (options.systemPrompt === undefined) {
@@ -2804,6 +2813,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			forkContextSeed: options.forkContextSeed,
 			providerSessionState: options.providerSessionState,
 		});
+		session.configWarnings.push(...contextFileWarnings);
 		hasSession = true;
 		if (asyncJobManager) {
 			session.yieldQueue.register<AsyncResultEntry>("async-result", {

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -2233,6 +2233,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			settings.get("tools.intentTracing"),
 			options.hasUI ?? false,
 		);
+		const emittedContextFileWarnings = new Set<string>();
 		const intentField = intentTracingEnabled ? INTENT_FIELD : undefined;
 		const rebuildSystemPrompt = async (
 			toolNames: string[],
@@ -2311,14 +2312,20 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				subagent: options.parentTaskPrefix !== undefined,
 			});
 
+			for (const warning of defaultPrompt.warnings) {
+				if (emittedContextFileWarnings.has(warning)) continue;
+				emittedContextFileWarnings.add(warning);
+				logger.warn("Context file discovery warning", { warning });
+			}
 			if (options.systemPrompt === undefined) {
 				return defaultPrompt;
 			}
 			if (Array.isArray(options.systemPrompt)) {
-				return { systemPrompt: options.systemPrompt };
+				return { systemPrompt: options.systemPrompt, warnings: defaultPrompt.warnings };
 			}
 			return {
 				systemPrompt: options.systemPrompt(defaultPrompt.systemPrompt),
+				warnings: defaultPrompt.warnings,
 			};
 		};
 

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -245,8 +245,12 @@ function dedupeExactContextFiles(
 		// Keep the closest matching context entry when content is byte-for-byte identical.
 		lastIndexByContent.set(file.content, index);
 	}
-
 	return contextFiles.filter((file, index) => lastIndexByContent.get(file.content) === index);
+}
+
+export interface ProjectContextFilesResult {
+	contextFiles: Array<{ path: string; content: string; depth?: number }>;
+	warnings: string[];
 }
 
 /**
@@ -257,11 +261,10 @@ function dedupeExactContextFiles(
  * prominent. User-home files from foreign providers (`~/.claude/CLAUDE.md`,
  * `~/.codex/AGENTS.md`, …) stay excluded — only gjc's own user config applies.
  */
-export async function loadProjectContextFiles(
+export async function loadProjectContextFilesResult(
 	options: LoadContextFilesOptions = {},
-): Promise<Array<{ path: string; content: string; depth?: number }>> {
+): Promise<ProjectContextFilesResult> {
 	const resolvedCwd = options.cwd ?? getProjectDir();
-
 	const result = await loadCapability(contextFileCapability.id, { cwd: resolvedCwd });
 	const items = result.items as ContextFile[];
 
@@ -288,7 +291,17 @@ export async function loadProjectContextFiles(
 		return depthB - depthA;
 	});
 
-	return dedupeExactContextFiles([...userFiles, ...projectFiles]);
+	return {
+		contextFiles: dedupeExactContextFiles([...userFiles, ...projectFiles]),
+		warnings: result.warnings,
+	};
+}
+
+/** Load project context files without exposing discovery diagnostics. */
+export async function loadProjectContextFiles(
+	options: LoadContextFilesOptions = {},
+): Promise<Array<{ path: string; content: string; depth?: number }>> {
+	return (await loadProjectContextFilesResult(options)).contextFiles;
 }
 
 /**
@@ -386,10 +399,11 @@ export interface BuildSystemPromptOptions {
 	subagent?: boolean;
 }
 
-/** Result of building provider-facing system prompt messages. */
 export interface BuildSystemPromptResult {
 	/** Ordered system prompt blocks. Providers should preserve entries as distinct messages/blocks. */
 	systemPrompt: string[];
+	/** Context-file discovery warnings visible to SDK and session callers. */
+	warnings: string[];
 }
 export interface BuildVolatileProjectContextOptions {
 	cwd?: string;
@@ -421,7 +435,7 @@ export function buildVolatileProjectContext(options: BuildVolatileProjectContext
 /** Build the system prompt with tools, guidelines, and context */
 export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}): Promise<BuildSystemPromptResult> {
 	if ($env.NULL_PROMPT === "true") {
-		return { systemPrompt: [] };
+		return { systemPrompt: [], warnings: [] };
 	}
 
 	const {
@@ -448,7 +462,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		resolvedCustomPrompt: undefined as string | undefined,
 		resolvedAppendPrompt: undefined as string | undefined,
 		systemPromptCustomization: null as string | null,
-		contextFiles: dedupeExactContextFiles(providedContextFiles ?? []),
+		contextFiles: { contextFiles: [] as Array<{ path: string; content: string; depth?: number }>, warnings: [] },
 		workspaceTree: {
 			rootPath: resolvedCwd,
 			rendered: "",
@@ -490,8 +504,8 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		cwd: resolvedCwd,
 	});
 	const contextFilesPromise = providedContextFiles
-		? Promise.resolve(providedContextFiles)
-		: logger.time("loadProjectContextFiles", loadProjectContextFiles, { cwd: resolvedCwd });
+		? Promise.resolve({ contextFiles: providedContextFiles, warnings: [] })
+		: logger.time("loadProjectContextFiles", loadProjectContextFilesResult, { cwd: resolvedCwd });
 	const workspaceTreePromise =
 		providedWorkspaceTree !== undefined
 			? Promise.resolve(providedWorkspaceTree)
@@ -499,7 +513,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 					buildWorkspaceTree(resolvedCwd, { timeoutMs: SYSTEM_PROMPT_PREP_TIMEOUT_MS }),
 				);
 
-	const [resolvedCustomPrompt, resolvedAppendPrompt, systemPromptCustomization, contextFiles, workspaceTree] =
+	const [resolvedCustomPrompt, resolvedAppendPrompt, systemPromptCustomization, contextFileResult, workspaceTree] =
 		await Promise.all([
 			withDeadline(
 				"customPrompt",
@@ -516,11 +530,10 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 				systemPromptCustomizationPromise,
 				prepDefaults.systemPromptCustomization,
 			),
-			withDeadline("loadProjectContextFiles", contextFilesPromise, prepDefaults.contextFiles).then(
-				dedupeExactContextFiles,
-			),
+			withDeadline("loadProjectContextFiles", contextFilesPromise, prepDefaults.contextFiles),
 			withDeadline("buildWorkspaceTree", workspaceTreePromise, prepDefaults.workspaceTree),
 		]);
+	const contextFiles = dedupeExactContextFiles(contextFileResult.contextFiles);
 	const agentsMdFiles = Array.from(new Set(workspaceTree.agentsMdFiles)).sort().slice(0, AGENTS_MD_LIMIT);
 
 	if (timedOut.length > 0) {
@@ -628,5 +641,5 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		systemPrompt.push(pluginAppendices.trim());
 	}
 
-	return { systemPrompt };
+	return { systemPrompt, warnings: contextFileResult.warnings };
 }

--- a/packages/coding-agent/test/discovery/agents-md.test.ts
+++ b/packages/coding-agent/test/discovery/agents-md.test.ts
@@ -136,4 +136,30 @@ describe("AGENTS.md discovery bounds", () => {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		}
 	});
+	test.skipIf(process.platform === "win32")("rejects a FIFO candidate without blocking discovery", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-agents-md-"));
+		const agentPath = path.join(tempDir, "AGENTS.md");
+		const created = Bun.spawnSync(["mkfifo", agentPath]);
+		expect(created.exitCode).toBe(0);
+		const loadPromise = loadAgentsMd(context(tempDir, tempDir));
+		try {
+			await expect(
+				Promise.race([
+					loadPromise,
+					Bun.sleep(500).then(() => {
+						throw new Error("FIFO discovery blocked");
+					}),
+				]),
+			).resolves.toEqual({ items: [], warnings: [] });
+		} finally {
+			try {
+				const writer = fs.openSync(agentPath, fs.constants.O_WRONLY | fs.constants.O_NONBLOCK);
+				fs.closeSync(writer);
+			} catch {
+				// No pending reader remains after the non-blocking descriptor check.
+			}
+			await loadPromise.catch(() => {});
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/coding-agent/test/discovery/agents-md.test.ts
+++ b/packages/coding-agent/test/discovery/agents-md.test.ts
@@ -28,12 +28,13 @@ describe("AGENTS.md discovery bounds", () => {
 		expect(result.warnings).toEqual(["AGENTS.md discovery stopped after scanning 32 ancestor directories."]);
 	});
 
-	test("uses raw byte counts to retain nearest whole files without reading past a full aggregate budget", async () => {
+	test("uses raw byte counts without warning for nonexistent ancestors beyond a full aggregate budget", async () => {
 		const root = path.join(path.sep, "repo");
 		const cwd = path.join(root, "one", "two", "three", "four");
 		const requestedBytes: number[] = [];
 		const reader: AgentsMdReader = async (filePath, maxBytes) => {
 			requestedBytes.push(maxBytes);
+			if (path.dirname(filePath) === root) return { content: null, byteLength: 0, tooLarge: false };
 			return {
 				content: path.basename(path.dirname(filePath)),
 				byteLength: MAX_FILE_BYTES,
@@ -44,7 +45,28 @@ describe("AGENTS.md discovery bounds", () => {
 		const result = await loadAgentsMd(context(cwd, root), reader);
 
 		expect(result.items.map(item => item.content)).toEqual(["four", "three", "two", "one"]);
-		expect(requestedBytes).toEqual([MAX_FILE_BYTES, MAX_FILE_BYTES, MAX_FILE_BYTES, MAX_FILE_BYTES]);
+		expect(requestedBytes).toEqual([MAX_FILE_BYTES, MAX_FILE_BYTES, MAX_FILE_BYTES, MAX_FILE_BYTES, 0]);
+		expect(result.warnings).toEqual([]);
+	});
+
+	test("warns when an existing ancestor is omitted after the aggregate budget is full", async () => {
+		const root = path.join(path.sep, "repo");
+		const cwd = path.join(root, "one", "two", "three", "four");
+		const requestedBytes: number[] = [];
+		const reader: AgentsMdReader = async (filePath, maxBytes) => {
+			requestedBytes.push(maxBytes);
+			if (maxBytes === 0) return { content: null, byteLength: 1, tooLarge: true };
+			return {
+				content: path.basename(path.dirname(filePath)),
+				byteLength: MAX_FILE_BYTES,
+				tooLarge: false,
+			};
+		};
+
+		const result = await loadAgentsMd(context(cwd, root), reader);
+
+		expect(result.items.map(item => item.content)).toEqual(["four", "three", "two", "one"]);
+		expect(requestedBytes).toEqual([MAX_FILE_BYTES, MAX_FILE_BYTES, MAX_FILE_BYTES, MAX_FILE_BYTES, 0]);
 		expect(result.warnings).toEqual(["Skipped one or more AGENTS.md files that exceed the 256 KiB aggregate limit."]);
 	});
 
@@ -96,6 +118,19 @@ describe("AGENTS.md discovery bounds", () => {
 			await expect(loadAgentsMd(context(tempDir, tempDir))).resolves.toEqual({
 				items: [],
 				warnings: ["Skipped one or more AGENTS.md files that exceed the 64 KiB limit."],
+			});
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+	test("ignores non-regular AGENTS.md candidates", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-agents-md-"));
+		const agentPath = path.join(tempDir, "AGENTS.md");
+		try {
+			fs.mkdirSync(agentPath);
+			await expect(loadAgentsMd(context(tempDir, tempDir))).resolves.toEqual({
+				items: [],
+				warnings: [],
 			});
 		} finally {
 			fs.rmSync(tempDir, { recursive: true, force: true });

--- a/packages/coding-agent/test/discovery/agents-md.test.ts
+++ b/packages/coding-agent/test/discovery/agents-md.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { LoadContext } from "@gajae-code/coding-agent/capability/types";
+import { type AgentsMdReader, loadAgentsMd } from "@gajae-code/coding-agent/discovery/agents-md";
+
+const MAX_FILE_BYTES = 64 * 1024;
+
+function context(cwd: string, repoRoot: string): LoadContext {
+	return { cwd, home: path.dirname(repoRoot), repoRoot };
+}
+
+describe("AGENTS.md discovery bounds", () => {
+	test("limits ancestor candidates to 32 directories and passes the per-file byte limit to its reader", async () => {
+		const root = path.join(path.sep, "repo");
+		const cwd = path.join(root, ...Array.from({ length: 32 }, (_value, index) => `level-${index}`));
+		const calls: string[] = [];
+		const reader: AgentsMdReader = async (filePath, maxBytes) => {
+			calls.push(filePath);
+			expect(maxBytes).toBe(MAX_FILE_BYTES);
+			return { content: null, byteLength: 0, tooLarge: false };
+		};
+
+		const result = await loadAgentsMd(context(cwd, root), reader);
+
+		expect(calls).toHaveLength(32);
+		expect(result.warnings).toEqual(["AGENTS.md discovery stopped after scanning 32 ancestor directories."]);
+	});
+
+	test("uses raw byte counts to retain nearest whole files without reading past a full aggregate budget", async () => {
+		const root = path.join(path.sep, "repo");
+		const cwd = path.join(root, "one", "two", "three", "four");
+		const requestedBytes: number[] = [];
+		const reader: AgentsMdReader = async (filePath, maxBytes) => {
+			requestedBytes.push(maxBytes);
+			return {
+				content: path.basename(path.dirname(filePath)),
+				byteLength: MAX_FILE_BYTES,
+				tooLarge: false,
+			};
+		};
+
+		const result = await loadAgentsMd(context(cwd, root), reader);
+
+		expect(result.items.map(item => item.content)).toEqual(["four", "three", "two", "one"]);
+		expect(requestedBytes).toEqual([MAX_FILE_BYTES, MAX_FILE_BYTES, MAX_FILE_BYTES, MAX_FILE_BYTES]);
+		expect(result.warnings).toEqual(["Skipped one or more AGENTS.md files that exceed the 256 KiB aggregate limit."]);
+	});
+
+	test("caps the final candidate read at the remaining aggregate bytes plus its sentinel", async () => {
+		const root = path.join(path.sep, "repo");
+		const cwd = path.join(root, "one", "two", "three", "four");
+		const requestedBytes: number[] = [];
+		const acceptedBytes = [MAX_FILE_BYTES, MAX_FILE_BYTES, MAX_FILE_BYTES, 60 * 1024];
+		const reader: AgentsMdReader = async (_filePath, maxBytes) => {
+			requestedBytes.push(maxBytes);
+			const byteLength = acceptedBytes.shift();
+			if (byteLength !== undefined) return { content: "accepted", byteLength, tooLarge: false };
+			return { content: null, byteLength: maxBytes + 1, tooLarge: true };
+		};
+
+		const result = await loadAgentsMd(context(cwd, root), reader);
+
+		expect(requestedBytes).toEqual([MAX_FILE_BYTES, MAX_FILE_BYTES, MAX_FILE_BYTES, MAX_FILE_BYTES, 4 * 1024]);
+		expect(result.items).toHaveLength(4);
+		expect(result.warnings).toEqual(["Skipped one or more AGENTS.md files that exceed the 256 KiB aggregate limit."]);
+	});
+
+	test("omits an oversized candidate without including partial content", async () => {
+		const root = path.join(path.sep, "repo");
+		const cwd = path.join(root, "child");
+		const reader: AgentsMdReader = async filePath =>
+			filePath.startsWith(cwd)
+				? { content: null, byteLength: MAX_FILE_BYTES + 1, tooLarge: true }
+				: { content: "parent", byteLength: 6, tooLarge: false };
+
+		const result = await loadAgentsMd(context(cwd, root), reader);
+
+		expect(result.items.map(item => item.content)).toEqual(["parent"]);
+		expect(result.warnings).toEqual(["Skipped one or more AGENTS.md files that exceed the 64 KiB limit."]);
+	});
+	test("reads only through the sentinel and still follows a regular-file symlink", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-agents-md-"));
+		const target = path.join(tempDir, "target.md");
+		const agentPath = path.join(tempDir, "AGENTS.md");
+		try {
+			fs.writeFileSync(target, "linked instructions");
+			fs.symlinkSync(target, agentPath);
+			await expect(loadAgentsMd(context(tempDir, tempDir))).resolves.toMatchObject({
+				items: [{ content: "linked instructions" }],
+				warnings: [],
+			});
+
+			fs.writeFileSync(agentPath, Buffer.alloc(MAX_FILE_BYTES + 1));
+			await expect(loadAgentsMd(context(tempDir, tempDir))).resolves.toEqual({
+				items: [],
+				warnings: ["Skipped one or more AGENTS.md files that exceed the 64 KiB limit."],
+			});
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/silent-abort-print-mode.test.ts
+++ b/packages/coding-agent/test/silent-abort-print-mode.test.ts
@@ -61,9 +61,10 @@ function installImmediateStdoutMock(output: string[] = []): void {
 /** Minimal mock of the AgentSession text-output path. */
 function createMockSession(
 	messages: Message[],
-	opts?: { contextWindow?: number; autoCompactionEnabled?: boolean },
+	opts?: { contextWindow?: number; autoCompactionEnabled?: boolean; configWarnings?: string[] },
 ): AgentSession {
 	return {
+		configWarnings: opts?.configWarnings ?? [],
 		state: { messages },
 		model: opts?.contextWindow !== undefined ? { contextWindow: opts.contextWindow } : undefined,
 		autoCompactionEnabled: opts?.autoCompactionEnabled ?? false,
@@ -113,6 +114,7 @@ function createPrintModeTrackingSession(
 		lifecycle.push("prompt:end");
 	});
 	const session = {
+		configWarnings: [],
 		state: { messages },
 		sessionManager: { getHeader: () => header },
 		extensionRunner: undefined,
@@ -155,6 +157,17 @@ describe("Print mode", () => {
 		process.exitCode = previousExitCode ?? 0;
 	});
 
+	it("prints each session configuration warning to stderr once", async () => {
+		const { runPrintMode } = await import("../src/modes/print-mode");
+		const stderrOutput: string[] = [];
+		installImmediateStderrMock(stderrOutput);
+		installImmediateStdoutMock();
+		const warning = "[AGENTS.md] Skipped one or more oversized files.";
+
+		await runPrintMode(createMockSession([], { configWarnings: [warning, warning] }), { mode: "text" });
+
+		expect(stderrOutput).toEqual([`Warning: ${warning}\n`]);
+	});
 	it("does not render a silent-abort marker or overwrite a caller status", async () => {
 		const { runPrintMode } = await import("../src/modes/print-mode");
 		const stderrOutput: string[] = [];

--- a/packages/coding-agent/test/system-prompt-dedup.test.ts
+++ b/packages/coding-agent/test/system-prompt-dedup.test.ts
@@ -209,4 +209,30 @@ describe("SYSTEM.md prompt assembly", () => {
 
 		expect(built.warnings).toContain("[AGENTS.md] Skipped one or more AGENTS.md files that exceed the 64 KiB limit.");
 	});
+	it("exposes AGENTS.md discovery warnings on the created session once", async () => {
+		const projectDir = path.join(tempDir, "project");
+		fs.mkdirSync(projectDir, { recursive: true });
+		fs.writeFileSync(path.join(projectDir, "AGENTS.md"), "x".repeat(64 * 1024 + 1));
+
+		const { session } = await createAgentSession({
+			cwd: projectDir,
+			agentDir: projectDir,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		try {
+			expect(session.configWarnings).toEqual([
+				"[AGENTS.md] Skipped one or more AGENTS.md files that exceed the 64 KiB limit.",
+			]);
+		} finally {
+			await session.dispose();
+		}
+	}, 15_000);
 });

--- a/packages/coding-agent/test/system-prompt-dedup.test.ts
+++ b/packages/coding-agent/test/system-prompt-dedup.test.ts
@@ -195,4 +195,18 @@ describe("SYSTEM.md prompt assembly", () => {
 		expect(promptText).toContain("Root context instructions");
 		expect(promptText).toContain("Near context instructions");
 	});
+	it("exposes bounded AGENTS.md discovery warnings on the production prompt result", async () => {
+		const projectDir = path.join(tempDir, "project");
+		fs.mkdirSync(projectDir, { recursive: true });
+		fs.writeFileSync(path.join(projectDir, "AGENTS.md"), "x".repeat(64 * 1024 + 1));
+
+		const built = await buildSystemPrompt({
+			cwd: projectDir,
+			skills: [],
+			rules: [],
+			toolNames: [],
+		});
+
+		expect(built.warnings).toContain("[AGENTS.md] Skipped one or more AGENTS.md files that exceed the 64 KiB limit.");
+	});
 });


### PR DESCRIPTION
## Summary
- bound ancestor `AGENTS.md` discovery to 32 directories, 64 KiB per file, and 256 KiB aggregate raw bytes
- read only the applicable limit plus one sentinel byte and omit whole oversized files
- preserve nearest-first budget allocation, final prompt ordering, and regular-file symlinks
- expose deterministic omission warnings through prompt results and session logging

## Verification
- `bun test packages/coding-agent/test/discovery/agents-md.test.ts packages/coding-agent/test/system-prompt-dedup.test.ts packages/coding-agent/test/system-prompt-volatile-context.test.ts packages/coding-agent/test/system-prompt-templates.test.ts`
- `bun --cwd=packages/coding-agent run check`

Fixes #3722