### PR TITLE
fix(windows): stop console windows flashing on every spawn

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-tmux.ts
@@ -689,6 +689,7 @@ function readCurrentBranch(cwd: string): string | null {
 			cwd,
 			stdout: "pipe",
 			stderr: "ignore",
+			windowsHide: true,
 		});
 		if (result.exitCode !== 0) return null;
 		const branch = result.stdout.toString().trim();

--- a/packages/coding-agent/src/gjc-runtime/launch-worktree.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-worktree.ts
@@ -39,14 +39,14 @@ interface GitWorktreeEntry {
 const BRANCH_IN_USE_PATTERN = /already checked out|already used by worktree|is already checked out/i;
 
 function runGit(cwd: string, args: string[]): string {
-	const result = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+	const result = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe", windowsHide: true });
 	if (result.exitCode === 0) return result.stdout.toString().trim();
 	const stderr = result.stderr.toString().trim();
 	throw new Error(stderr || `git ${args.join(" ")} failed`);
 }
 
 function tryRunGit(cwd: string, args: string[]): string | null {
-	const result = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+	const result = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe", windowsHide: true });
 	return result.exitCode === 0 ? result.stdout.toString().trim() : null;
 }
 
@@ -72,6 +72,7 @@ function branchExists(repoRoot: string, branchName: string): boolean {
 		cwd: repoRoot,
 		stdout: "ignore",
 		stderr: "ignore",
+		windowsHide: true,
 	});
 	return result.exitCode === 0;
 }
@@ -81,6 +82,7 @@ function validateBranchName(repoRoot: string, branchName: string): void {
 		cwd: repoRoot,
 		stdout: "pipe",
 		stderr: "pipe",
+		windowsHide: true,
 	});
 	if (result.exitCode === 0) return;
 	const stderr = result.stderr.toString().trim();
@@ -376,7 +378,7 @@ export function ensureLaunchWorktree(
 	else if (branchAlreadyExisted) args.push(plan.worktreePath, plan.branchName ?? "");
 	else args.push("-b", plan.branchName ?? "", plan.worktreePath, plan.baseRef);
 
-	const result = Bun.spawnSync(["git", ...args], { cwd: plan.repoRoot, stdout: "pipe", stderr: "pipe" });
+	const result = Bun.spawnSync(["git", ...args], { cwd: plan.repoRoot, stdout: "pipe", stderr: "pipe", windowsHide: true });
 	if (result.exitCode !== 0) {
 		const stderr = result.stderr.toString().trim();
 		if (plan.branchName && BRANCH_IN_USE_PATTERN.test(stderr)) throw new Error(`branch_in_use:${plan.branchName}`);

--- a/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
@@ -619,7 +619,7 @@ function worktreeBaselineDirtyFromEnvOrMarker(): boolean | null {
 function observedRecoverableWorktreeChanges(cwd: string): boolean {
 	if (!cwd.trim()) return false;
 	try {
-		const proc = Bun.spawnSync(["git", "status", "--porcelain"], { cwd, stdout: "pipe", stderr: "pipe" });
+		const proc = Bun.spawnSync(["git", "status", "--porcelain"], { cwd, stdout: "pipe", stderr: "pipe", windowsHide: true });
 		return proc.exitCode === 0 && proc.stdout.byteLength > 0;
 	} catch {
 		return false;

--- a/packages/coding-agent/src/gjc-runtime/team-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/team-runtime.ts
@@ -2335,6 +2335,7 @@ function runGitResult(cwd: string, args: string[]): GitResult {
 		cwd,
 		stdout: "pipe",
 		stderr: "pipe",
+		windowsHide: true,
 	});
 	return {
 		ok: result.exitCode === 0,
@@ -2343,7 +2344,7 @@ function runGitResult(cwd: string, args: string[]): GitResult {
 	};
 }
 async function runGitResultAsync(cwd: string, args: string[], signal?: AbortSignal): Promise<GitResult> {
-	const result = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+	const result = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe", windowsHide: true });
 	const kill = () => {
 		try {
 			result.kill("SIGKILL");
@@ -2422,6 +2423,7 @@ function branchExists(repoRoot: string, branchName: string): boolean {
 			cwd: repoRoot,
 			stdout: "ignore",
 			stderr: "ignore",
+			windowsHide: true,
 		}).exitCode === 0
 	);
 }
@@ -3184,6 +3186,7 @@ async function rollbackCreatedWorktrees(workers: GjcTeamWorker[]): Promise<void>
 				cwd: worker.worktree_repo_root,
 				stdout: "ignore",
 				stderr: "ignore",
+				windowsHide: true,
 			});
 }
 async function removeCleanCreatedWorktrees(workers: GjcTeamWorker[]): Promise<void> {
@@ -3193,6 +3196,7 @@ async function removeCleanCreatedWorktrees(workers: GjcTeamWorker[]): Promise<vo
 				cwd: worker.worktree_repo_root,
 				stdout: "ignore",
 				stderr: "ignore",
+				windowsHide: true,
 			});
 }
 

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -240,6 +240,7 @@ export class CommandController {
 				stdin: "ignore",
 				stdout: "ignore",
 				stderr: "ignore",
+				windowsHide: true,
 			});
 			if ((await authProcess.exited) !== 0) {
 				this.ctx.showError("GitHub CLI is not logged in. Run 'gh auth login' first.");
@@ -271,6 +272,7 @@ export class CommandController {
 				stdout: "pipe",
 				stderr: "pipe",
 				signal: loader.signal,
+				windowsHide: true,
 			});
 			loader.onAbort = () => {
 				cancellationRequested = gistProcess.exitCode === null;

--- a/packages/coding-agent/src/sdk/broker/process-incarnation.ts
+++ b/packages/coding-agent/src/sdk/broker/process-incarnation.ts
@@ -40,7 +40,18 @@ export interface ProcessIncarnationOptions {
 
 function runProcessIncarnationCommand(command: string, args: readonly string[]): ProcessIncarnationCommandResult {
 	try {
-		const result = Bun.spawnSync([command, ...args], { stdin: "ignore", stdout: "pipe", stderr: "ignore" });
+		// windowsHide: Windows 에서 이 경로는 PowerShell(콘솔 애플리케이션)을 스폰한다.
+		// 이 옵션이 없으면 CREATE_NO_WINDOW 가 빠져서 호출마다 콘솔 창이 실제로 뜬다.
+		// notification-service / telegram-daemon / lifecycle-control-runtime 이 PID 생사를
+		// 주기적으로 확인하므로, 세션이 여러 개면 몇 초에 한 번씩 화면에 창이 튄다
+		// (2026-08-02 실측: 세션 8개 · 30초에 콘솔 46개). Bun 의 windowsHide 는 손자에게
+		// 전파되지 않으므로 스폰 지점마다 개별로 걸어야 한다.
+		const result = Bun.spawnSync([command, ...args], {
+			stdin: "ignore",
+			stdout: "pipe",
+			stderr: "ignore",
+			windowsHide: true,
+		});
 		return { exitCode: result.exitCode, stdout: Buffer.from(result.stdout).toString("utf8") };
 	} catch {
 		return undefined;

--- a/packages/coding-agent/src/stt/recorder.ts
+++ b/packages/coding-agent/src/stt/recorder.ts
@@ -221,6 +221,7 @@ async function startPowerShellRecording(outputPath: string): Promise<RecordingHa
 		stdin: "pipe",
 		stdout: "pipe",
 		stderr: "ignore",
+		windowsHide: true,
 	});
 
 	proc.exited.then(() => {

--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -99,6 +99,7 @@ async function readImageViaPowerShell(): Promise<ClipboardImage | null> {
 			stdout: "pipe",
 			stderr: "ignore",
 			stdin: "ignore",
+			windowsHide: true,
 		});
 		const timer = setTimeout(() => proc.kill(), POWERSHELL_TIMEOUT_MS);
 		let stdout = "";

--- a/packages/coding-agent/test/windows-console-hide.test.ts
+++ b/packages/coding-agent/test/windows-console-hide.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Windows 콘솔 창 누출 회귀 방지.
+ *
+ * Windows 에서 powershell/cmd/git/gh 같은 콘솔 애플리케이션을 스폰할 때
+ * `windowsHide: true` 가 빠지면 CREATE_NO_WINDOW 가 걸리지 않아 호출마다
+ * 실제 콘솔 창이 뜬다. 부모가 콘솔 없는 데몬(브로커·알림·telegram)일 때 특히 그렇다.
+ *
+ * Bun 의 windowsHide 는 손자 프로세스로 전파되지 않으므로 스폰 지점마다
+ * 개별로 걸어야 한다. 그래서 한 번 고쳐도 새 코드에서 쉽게 재발한다.
+ *
+ * 2026-08-02 실측(Windows 11, GJC 세션 8개): 30초에 conhost 46개 + WindowsTerminal 6개가
+ * 생성됐고, 관측된 커맨드라인은 sdk/broker/process-incarnation.ts 가 만드는
+ * `powershell.exe -NoLogo -NoProfile -NonInteractive -Command ...` 였다.
+ */
+
+const SRC_ROOT = join(import.meta.dir, "..", "src");
+
+/** 실행 파일 이름이 리터럴로 확정되는 콘솔 애플리케이션. */
+const CONSOLE_EXECUTABLE =
+	/"(powershell(?:\.exe)?|pwsh|cmd(?:\.exe)?|git|gh|tmux|wmic|tasklist|taskkill|schtasks)"/;
+
+const SPAWN_CALL = /\b(?:Bun\.spawn(?:Sync)?|spawnSync|execFile)\s*\(/g;
+
+function collectSourceFiles(dir: string, out: string[] = []): string[] {
+	for (const entry of readdirSync(dir)) {
+		const full = join(dir, entry);
+		if (statSync(full).isDirectory()) {
+			collectSourceFiles(full, out);
+			continue;
+		}
+		if (!entry.endsWith(".ts") && !entry.endsWith(".tsx")) continue;
+		if (entry.includes(".test.") || entry.includes(".spec.")) continue;
+		if (entry.endsWith(".generated.ts")) continue;
+		out.push(full);
+	}
+	return out;
+}
+
+/** 스폰 호출의 괄호 범위를 반환한다. 닫히지 않으면 undefined. */
+function callRange(source: string, openParenIndex: number): { start: number; end: number } | undefined {
+	let depth = 0;
+	for (let i = openParenIndex; i < source.length; i++) {
+		const ch = source[i];
+		if (ch === "(") depth++;
+		else if (ch === ")") {
+			depth--;
+			if (depth === 0) return { start: openParenIndex, end: i };
+		}
+	}
+	return undefined;
+}
+
+describe("windows console hide", () => {
+	it("콘솔 애플리케이션을 스폰하는 런타임 코드는 windowsHide 를 지정한다", () => {
+		const offenders: string[] = [];
+
+		for (const file of collectSourceFiles(SRC_ROOT)) {
+			const source = readFileSync(file, "utf8");
+			SPAWN_CALL.lastIndex = 0;
+			let match: RegExpExecArray | null;
+			while ((match = SPAWN_CALL.exec(source)) !== null) {
+				const range = callRange(source, match.index + match[0].length - 1);
+				if (!range) continue;
+				const block = source.slice(range.start, range.end + 1);
+				if (!CONSOLE_EXECUTABLE.test(block)) continue;
+				if (block.includes("windowsHide")) continue;
+				const line = source.slice(0, match.index).split("\n").length;
+				offenders.push(`${file.slice(SRC_ROOT.length + 1)}:${line}`);
+			}
+		}
+
+		expect(offenders).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Problem

On Windows, spawning a console application (`powershell` / `cmd` / `git` / `gh`) without `windowsHide: true` omits `CREATE_NO_WINDOW`, so Windows allocates a real console window for every call.

This is invisible when the parent already owns a console. It is very visible when the parent is a daemon-like process with no console — the broker, notification service and telegram daemon are exactly that. Every poll pops a window onto the user's screen.

Bun's `windowsHide` **does not propagate to grandchildren**, so it has to be set at each spawn site individually. `utils/git.ts` already did this; the rest of the runtime did not.

## Measurement

Windows 11, 8 concurrent GJC sessions, 30 second sample:

| | count |
|---|---|
| `git.exe` spawned | 53 |
| `powershell.exe` spawned | 20 |
| `conhost.exe` created | 46 |
| `WindowsTerminal.exe` created | 6 |

A window appeared roughly every 3 seconds. The observed command line

```
powershell.exe -NoLogo -NoProfile -NonInteractive -Command ...
```

traces to `sdk/broker/process-incarnation.ts`, which `notification-service`, `telegram-daemon` and `lifecycle-control-runtime` call periodically to decide whether a PID is still the same incarnation. That is the hot path.

Reducing session count only changes the frequency, not the cause — a single session still flashes.

## Change

Adds `windowsHide: true` to the 16 runtime spawn sites whose executable is a **string literal** for a known console application:

- `sdk/broker/process-incarnation.ts` — powershell, the polling hot path
- `gjc-runtime/launch-tmux.ts`, `launch-worktree.ts`, `session-state-sidecar.ts`, `team-runtime.ts` — git
- `modes/controllers/command-controller.ts` — gh
- `stt/recorder.ts`, `utils/clipboard.ts` — powershell

Spawn sites whose command comes from a variable are deliberately left alone. Guessing wrong there is worse than the flash.

## Regression guard

`test/windows-console-hide.test.ts` statically scans `src/` and fails when a spawn of a literal console executable lacks `windowsHide`. Because the option must be repeated at every call site, this class of bug reappears easily with new code, so a static check is more useful here than a mock-based one.

Verified the guard actually catches a deliberately reintroduced regression:

```
+   "utils\clipboard.ts:98",
(fail) windows console hide > 콘솔 애플리케이션을 스폰하는 런타임 코드는 windowsHide 를 지정한다
```

## Verification

- `bunx tsc --noEmit -p packages/coding-agent/tsconfig.json` → **0 errors**
- `bun test packages/coding-agent/test/windows-console-hide.test.ts` → **1 pass**
- Behaviour is unchanged on non-Windows platforms; `windowsHide` is a no-op there.

### Not verified

I could not isolate the visual effect on this machine. Spawning from a console-owning parent hides the difference entirely, and spawning from a console-less parent was drowned out by the 8 pre-existing sessions still creating windows during the probe. The fix rests on the traced command line plus the documented `CREATE_NO_WINDOW` semantics, not on a before/after screen recording.
