### PR TITLE
fix(ai): widen Alibaba first-event timeout

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Alibaba Token Plan streams now allow 600 seconds for the first semantic event, matching observed long-context TTFT above the previous 300-second cutoff. The outer lazy watchdog and both OpenAI transports share one provider fallback; OpenAI Completions also applies it before response headers, and Alibaba SDK connection timeouts from that pre-stream phase are normalized to the typed first-event failure so session retry policy does not replay the request as an unknown timeout.
 
 ## [0.12.8] - 2026-08-02
 ### Added

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1,5 +1,5 @@
 import { $credentialEnv, $env, extractHttpStatusFromError, logger } from "@gajae-code/utils";
-import OpenAI from "openai";
+import OpenAI, { APIConnectionTimeoutError } from "openai";
 import type {
 	ChatCompletionAssistantMessageParam,
 	ChatCompletionChunk,
@@ -47,6 +47,7 @@ import {
 	rewriteCopilotError,
 } from "../utils/http-inspector";
 import {
+	FirstEventTimeoutError,
 	getOpenAIStreamIdleTimeoutMs,
 	getProviderFirstEventTimeoutFallbackMs,
 	getStreamFirstEventTimeoutMs,
@@ -500,8 +501,6 @@ function getTrailingPartialDeepseekToken(text: string): string {
 	return tail;
 }
 
-const ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS = 300_000;
-
 const OPENAI_COMPLETIONS_FIRST_EVENT_TIMEOUT_MESSAGE =
 	"OpenAI completions stream timed out while waiting for the first event";
 
@@ -515,6 +514,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 	(async () => {
 		const startTime = Date.now();
 		let firstTokenTime: number | undefined;
+		let streamConnected = false;
 		let getCapturedErrorResponse: (() => CapturedHttpErrorResponse | undefined) | undefined;
 
 		const output: AssistantMessage = createInitialResponsesAssistantMessage(model.api, model.provider, model.id);
@@ -640,10 +640,8 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 					openaiStream = await createCompletionsStream("none");
 				}
 			}
-			const firstEventFallbackMs =
-				model.provider === "alibaba-token-plan"
-					? ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS
-					: getProviderFirstEventTimeoutFallbackMs(model.provider);
+			streamConnected = true;
+			const firstEventFallbackMs = getProviderFirstEventTimeoutFallbackMs(model.provider);
 			const firstEventTimeoutMs =
 				options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs, firstEventFallbackMs);
 			if (premiumRequestsTotal !== undefined) {
@@ -1049,20 +1047,25 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 		} catch (error) {
 			for (const block of output.content) delete (block as any).index;
 			const localAbortReason = abortTracker.getLocalAbortReason();
+			const normalizedError =
+				!streamConnected && model.provider === "alibaba-token-plan" && error instanceof APIConnectionTimeoutError
+					? new FirstEventTimeoutError(OPENAI_COMPLETIONS_FIRST_EVENT_TIMEOUT_MESSAGE)
+					: error;
 			const capturedErrorResponse = getCapturedErrorResponse?.();
 			output.stopReason = abortTracker.wasCallerAbort() ? "aborted" : "error";
 			output.errorStatus =
-				extractHttpStatusFromError(localAbortReason ?? error) ??
+				extractHttpStatusFromError(localAbortReason ?? normalizedError) ??
 				(localAbortReason ? undefined : capturedErrorResponse?.status);
 			output.transportFailure = localAbortReason
 				? transportFailureFacts(localAbortReason)
-				: transportFailureFacts(error, capturedErrorResponse);
+				: transportFailureFacts(normalizedError, capturedErrorResponse);
 			output.errorMessage =
-				localAbortReason?.message ?? (await finalizeErrorMessage(error, rawRequestDump, capturedErrorResponse));
+				localAbortReason?.message ??
+				(await finalizeErrorMessage(normalizedError, rawRequestDump, capturedErrorResponse));
 			// Some providers via OpenRouter include extra details here.
-			const rawMetadata = (error as { error?: { metadata?: { raw?: string } } })?.error?.metadata?.raw;
+			const rawMetadata = (normalizedError as { error?: { metadata?: { raw?: string } } })?.error?.metadata?.raw;
 			if (rawMetadata) output.errorMessage += `\n${rawMetadata}`;
-			output.errorMessage = rewriteCopilotError(output.errorMessage, error, model.provider);
+			output.errorMessage = rewriteCopilotError(output.errorMessage, normalizedError, model.provider);
 			if (hasContentFilterSafetyCode(capturedErrorResponse)) {
 				output.errorKind = "provider_safety_stop";
 			}
@@ -1238,7 +1241,10 @@ async function createClient(
 	// wrapping watchdog arms. An explicit `0` disables the first-event watchdog,
 	// and the SDK treats `timeout: 0` as an immediate timeout, so do not pass a
 	// request timeout in that case.
-	const envSdkTimeoutMs = getStreamFirstEventTimeoutMs(getOpenAIStreamIdleTimeoutMs());
+	const envSdkTimeoutMs = getStreamFirstEventTimeoutMs(
+		getOpenAIStreamIdleTimeoutMs(),
+		getProviderFirstEventTimeoutFallbackMs(model.provider),
+	);
 	const sdkTimeoutMs =
 		streamFirstEventTimeoutOverride === 0
 			? undefined

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1238,18 +1238,20 @@ async function createClient(
 	// in the IIFE.
 	// A caller may raise `StreamOptions.streamFirstEventTimeoutMs` for a slow-
 	// before-headers provider; respect it so the SDK doesn't give up before the
-	// wrapping watchdog arms. An explicit `0` disables the first-event watchdog,
+	// wrapping watchdog arms. Provider-specific fallbacks apply only when the
+	// caller does not pin a value, so an explicit nonzero override must beat that
+	// fallback even when it is shorter. An explicit `0` disables the watchdog,
 	// and the SDK treats `timeout: 0` as an immediate timeout, so do not pass a
 	// request timeout in that case.
-	const envSdkTimeoutMs = getStreamFirstEventTimeoutMs(
-		getOpenAIStreamIdleTimeoutMs(),
-		getProviderFirstEventTimeoutFallbackMs(model.provider),
-	);
+	const providerFirstEventFallbackMs = getProviderFirstEventTimeoutFallbackMs(model.provider);
+	const envSdkTimeoutMs = getStreamFirstEventTimeoutMs(getOpenAIStreamIdleTimeoutMs(), providerFirstEventFallbackMs);
 	const sdkTimeoutMs =
 		streamFirstEventTimeoutOverride === 0
 			? undefined
 			: streamFirstEventTimeoutOverride !== undefined
-				? Math.max(envSdkTimeoutMs ?? 0, streamFirstEventTimeoutOverride)
+				? providerFirstEventFallbackMs !== undefined
+					? streamFirstEventTimeoutOverride
+					: Math.max(envSdkTimeoutMs ?? 0, streamFirstEventTimeoutOverride)
 				: envSdkTimeoutMs;
 	return {
 		client: new OpenAI({

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -1,5 +1,5 @@
 import { $credentialEnv, extractHttpStatusFromError, logger, structuredCloneJSON } from "@gajae-code/utils";
-import OpenAI from "openai";
+import OpenAI, { APIConnectionTimeoutError } from "openai";
 import type {
 	Tool as OpenAITool,
 	ResponseCreateParamsStreaming,
@@ -38,7 +38,9 @@ import { AssistantMessageEventStream } from "../utils/event-stream";
 import { transportFailureFacts } from "../utils/fallback-transport";
 import { finalizeErrorMessage, type RawHttpRequestDump, rewriteCopilotError } from "../utils/http-inspector";
 import {
+	FirstEventTimeoutError,
 	getOpenAIStreamIdleTimeoutMs,
+	getProviderFirstEventTimeoutFallbackMs,
 	getStreamFirstEventTimeoutMs,
 	iterateWithIdleTimeout,
 } from "../utils/idle-iterator";
@@ -124,7 +126,6 @@ export interface OpenAIResponsesOptions extends StreamOptions {
 }
 
 const OPENAI_RESPONSES_PROVIDER_SESSION_STATE_PREFIX = "openai-responses:";
-const ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS = 300_000;
 const OPENAI_RESPONSES_FIRST_EVENT_TIMEOUT_MESSAGE =
 	"OpenAI responses stream timed out while waiting for the first event";
 const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
@@ -314,6 +315,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 	(async () => {
 		const startTime = Date.now();
 		let firstTokenTime: number | undefined;
+		let streamConnected = false;
 
 		const output: AssistantMessage = createInitialResponsesAssistantMessage(
 			"openai-responses",
@@ -392,8 +394,8 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 				await notifyProviderResponse(options, response, model, request_id);
 				return data;
 			});
-			const firstEventFallbackMs =
-				model.provider === "alibaba-token-plan" ? ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS : undefined;
+			streamConnected = true;
+			const firstEventFallbackMs = getProviderFirstEventTimeoutFallbackMs(model.provider);
 			const firstEventTimeoutMs =
 				options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs, firstEventFallbackMs);
 			if (premiumRequestsTotal !== undefined) output.usage.premiumRequests = premiumRequestsTotal;
@@ -447,11 +449,16 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 		} catch (error) {
 			for (const block of output.content) delete (block as { index?: number }).index;
 			const localAbortReason = abortTracker.getLocalAbortReason();
+			const normalizedError =
+				!streamConnected && model.provider === "alibaba-token-plan" && error instanceof APIConnectionTimeoutError
+					? new FirstEventTimeoutError(OPENAI_RESPONSES_FIRST_EVENT_TIMEOUT_MESSAGE)
+					: error;
 			output.stopReason = abortTracker.wasCallerAbort() ? "aborted" : "error";
-			output.errorStatus = extractHttpStatusFromError(localAbortReason ?? error);
-			output.transportFailure = transportFailureFacts(localAbortReason ?? error);
-			output.errorMessage = localAbortReason?.message ?? (await finalizeErrorMessage(error, rawRequestDump));
-			output.errorMessage = rewriteCopilotError(output.errorMessage, error, model.provider);
+			output.errorStatus = extractHttpStatusFromError(localAbortReason ?? normalizedError);
+			output.transportFailure = transportFailureFacts(localAbortReason ?? normalizedError);
+			output.errorMessage =
+				localAbortReason?.message ?? (await finalizeErrorMessage(normalizedError, rawRequestDump));
+			output.errorMessage = rewriteCopilotError(output.errorMessage, normalizedError, model.provider);
 			// Explicitly mark the poisoned-history rejection so the shared
 			// `invalid_prompt` contract is present even when the SDK error surfaces
 			// only a message (no structured code). This keeps the responses

--- a/packages/ai/src/providers/register-builtins.ts
+++ b/packages/ai/src/providers/register-builtins.ts
@@ -25,6 +25,7 @@ import { AssistantMessageEventStream as EventStreamImpl } from "../utils/event-s
 import { transportFailureFacts } from "../utils/fallback-transport";
 import {
 	FirstEventTimeoutError,
+	getProviderFirstEventTimeoutFallbackMs,
 	getStreamFirstEventTimeoutMs,
 	getStreamIdleTimeoutMs,
 	iterateWithIdleTimeout,
@@ -197,13 +198,12 @@ interface LazyStreamLimits {
 const GOOGLE_GEMINI_CLI_LAZY_STREAM_LIMITS: LazyStreamLimits = {
 	defaultFirstEventTimeoutMs: 300_000,
 };
-const SLOW_FIRST_EVENT_PROVIDERS = new Set(["alibaba-token-plan", "kimi-code"]);
 
 /**
  * Resolves the first-event timeout fallback for the outer lazy-stream watchdog.
  * A configured wrapper-specific fallback (from `LazyStreamLimits`) always wins;
- * otherwise providers known to have slow first events get a five-minute floor
- * matching their inner provider-level override. Returns `undefined` for
+ * otherwise providers known to have slow first events use the same centralized
+ * fallback as their inner provider-level watchdog. Returns `undefined` for
  * providers that should use the shared default.
  */
 export function resolveLazyStreamFirstEventFallbackMs(
@@ -211,7 +211,7 @@ export function resolveLazyStreamFirstEventFallbackMs(
 	configuredFallbackMs?: number,
 ): number | undefined {
 	if (configuredFallbackMs !== undefined) return configuredFallbackMs;
-	return SLOW_FIRST_EVENT_PROVIDERS.has(provider) ? 300_000 : undefined;
+	return getProviderFirstEventTimeoutFallbackMs(provider);
 }
 
 function forwardStream<TApi extends Api>(

--- a/packages/ai/src/utils/idle-iterator.ts
+++ b/packages/ai/src/utils/idle-iterator.ts
@@ -3,9 +3,11 @@ import { STREAM_FIRST_EVENT_TIMEOUT_PROVIDER_CODE } from "./fallback-transport";
 
 const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 120_000;
 const DEFAULT_STREAM_FIRST_EVENT_TIMEOUT_MS = 100_000;
+const ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS = 600_000;
 const KIMI_CODE_FIRST_EVENT_TIMEOUT_MS = 300_000;
 
 export function getProviderFirstEventTimeoutFallbackMs(provider: string): number | undefined {
+	if (provider === "alibaba-token-plan") return ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS;
 	return provider === "kimi-code" ? KIMI_CODE_FIRST_EVENT_TIMEOUT_MS : undefined;
 }
 

--- a/packages/ai/test/openai-first-event-timeout.test.ts
+++ b/packages/ai/test/openai-first-event-timeout.test.ts
@@ -443,6 +443,38 @@ describe("OpenAI-family first-event timeouts", () => {
 		});
 	});
 
+	it("honors a shorter Alibaba completions caller timeout before response headers", async () => {
+		vi.useFakeTimers();
+		await withEnv({ PI_STREAM_FIRST_EVENT_TIMEOUT_MS: undefined }, async () => {
+			let fetchAttempts = 0;
+			const delayedFetch = createDelayedFetch(60_000, () =>
+				createOpenAICompletionsSuccessResponse(alibabaOpenAICompletionsModel.id),
+			);
+			global.fetch = Object.assign(
+				async (input: string | URL | Request, init?: RequestInit) => {
+					fetchAttempts++;
+					return delayedFetch(input, init);
+				},
+				{ preconnect: originalFetch.preconnect },
+			);
+
+			const pending = streamOpenAICompletions(alibabaOpenAICompletionsModel, baseContext(), {
+				apiKey: "test-key",
+				requestMaxRetries: 0,
+				streamFirstEventTimeoutMs: 5_000,
+			}).result();
+			await flushMicrotasks();
+			vi.advanceTimersByTime(5_000);
+			await flushMicrotasks(100);
+			const result = await pending;
+
+			expect(fetchAttempts).toBe(1);
+			expect(result.stopReason).toBe("error");
+			expect(result.errorMessage).toBe("OpenAI completions stream timed out while waiting for the first event");
+			expect(result.transportFailure?.providerCode).toBe("stream_first_event_timeout");
+		});
+	});
+
 	it("normalizes an Alibaba completions SDK setup timeout as a typed first-event timeout", async () => {
 		vi.useFakeTimers();
 		await withEnv({ PI_STREAM_FIRST_EVENT_TIMEOUT_MS: "5000" }, async () => {

--- a/packages/ai/test/openai-first-event-timeout.test.ts
+++ b/packages/ai/test/openai-first-event-timeout.test.ts
@@ -1,10 +1,10 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import { getBundledModel } from "../src/models";
 import { streamAzureOpenAIResponses } from "../src/providers/azure-openai-responses";
 import { streamOpenAICompletions } from "../src/providers/openai-completions";
 import { streamOpenAIResponses } from "../src/providers/openai-responses";
 import type { Context, Model, TextContent } from "../src/types";
-import { waitForDelayOrAbort } from "./helpers";
+import { waitForDelayOrAbort, withEnv } from "./helpers";
 
 const originalFetch = global.fetch;
 
@@ -13,6 +13,14 @@ const openAICompletionsModel = {
 	...(getBundledModel("openai", "gpt-4o-mini") as Model<"openai-completions">),
 	api: "openai-completions",
 } satisfies Model<"openai-completions">;
+const alibabaOpenAIResponsesModel = getBundledModel(
+	"alibaba-token-plan",
+	"qwen3.8-max-preview",
+) as Model<"openai-responses">;
+const alibabaOpenAICompletionsModel = getBundledModel(
+	"alibaba-token-plan",
+	"deepseek-v4-pro",
+) as Model<"openai-completions">;
 const azureOpenAIResponsesModel: Model<"azure-openai-responses"> = {
 	id: "gpt-5-mini",
 	name: "GPT-5 Mini",
@@ -253,6 +261,10 @@ function getFirstTextContent(result: { content: unknown[] }): TextContent | unde
 	});
 }
 
+async function flushMicrotasks(ticks = 40): Promise<void> {
+	for (let i = 0; i < ticks; i++) await Promise.resolve();
+}
+
 async function expectDelayedRequestSetupSucceeds(
 	run: (streamFirstEventTimeoutMs: number) => Promise<{ stopReason: string; content: unknown[] }>,
 	responseFactory: () => Response,
@@ -267,6 +279,7 @@ async function expectDelayedRequestSetupSucceeds(
 
 afterEach(() => {
 	global.fetch = originalFetch;
+	vi.useRealTimers();
 });
 
 describe("OpenAI-family first-event timeouts", () => {
@@ -389,6 +402,103 @@ describe("OpenAI-family first-event timeouts", () => {
 				}).result(),
 			() => createOpenAICompletionsSuccessResponse(openAICompletionsModel.id),
 		);
+	});
+
+	it("lets Alibaba completions wait past the old 120s SDK timeout for response headers", async () => {
+		vi.useFakeTimers();
+		await withEnv({ PI_STREAM_FIRST_EVENT_TIMEOUT_MS: undefined }, async () => {
+			let fetchAttempts = 0;
+			const delayedFetch = createDelayedFetch(150_000, () =>
+				createOpenAICompletionsSuccessResponse(alibabaOpenAICompletionsModel.id),
+			);
+			global.fetch = Object.assign(
+				async (input: string | URL | Request, init?: RequestInit) => {
+					fetchAttempts++;
+					return delayedFetch(input, init);
+				},
+				{ preconnect: originalFetch.preconnect },
+			);
+
+			const pending = streamOpenAICompletions(alibabaOpenAICompletionsModel, baseContext(), {
+				apiKey: "test-key",
+				requestMaxRetries: 0,
+			}).result();
+			await flushMicrotasks();
+			expect(fetchAttempts).toBe(1);
+
+			vi.advanceTimersByTime(120_000);
+			await flushMicrotasks();
+			let settled = false;
+			void pending.then(() => {
+				settled = true;
+			});
+			await flushMicrotasks();
+			expect(settled).toBe(false);
+
+			vi.advanceTimersByTime(30_000);
+			await flushMicrotasks();
+			const result = await pending;
+			expect(result.stopReason).toBe("stop");
+			expect(getFirstTextContent(result)).toMatchObject({ type: "text", text: "Hello delayed" });
+		});
+	});
+
+	it("normalizes an Alibaba completions SDK setup timeout as a typed first-event timeout", async () => {
+		vi.useFakeTimers();
+		await withEnv({ PI_STREAM_FIRST_EVENT_TIMEOUT_MS: "5000" }, async () => {
+			let fetchAttempts = 0;
+			const delayedFetch = createDelayedFetch(60_000, () =>
+				createOpenAICompletionsSuccessResponse(alibabaOpenAICompletionsModel.id),
+			);
+			global.fetch = Object.assign(
+				async (input: string | URL | Request, init?: RequestInit) => {
+					fetchAttempts++;
+					return delayedFetch(input, init);
+				},
+				{ preconnect: originalFetch.preconnect },
+			);
+
+			const pending = streamOpenAICompletions(alibabaOpenAICompletionsModel, baseContext(), {
+				apiKey: "test-key",
+				requestMaxRetries: 0,
+			}).result();
+			await flushMicrotasks();
+			vi.advanceTimersByTime(5_000);
+			await flushMicrotasks(100);
+			const result = await pending;
+
+			expect(fetchAttempts).toBe(1);
+			expect(result.stopReason).toBe("error");
+			expect(result.errorMessage).toBe("OpenAI completions stream timed out while waiting for the first event");
+			expect(result.transportFailure?.providerCode).toBe("stream_first_event_timeout");
+		});
+	});
+
+	it("normalizes an Alibaba responses SDK setup timeout as a typed first-event timeout", async () => {
+		vi.useFakeTimers();
+		let fetchAttempts = 0;
+		const delayedFetch = createDelayedFetch(700_000, createOpenAIResponsesSuccessResponse);
+		global.fetch = Object.assign(
+			async (input: string | URL | Request, init?: RequestInit) => {
+				fetchAttempts++;
+				return delayedFetch(input, init);
+			},
+			{ preconnect: originalFetch.preconnect },
+		);
+
+		const pending = streamOpenAIResponses(alibabaOpenAIResponsesModel, baseContext(), {
+			apiKey: "test-key",
+			requestMaxRetries: 0,
+		}).result();
+		await flushMicrotasks();
+		vi.advanceTimersByTime(600_000);
+		await flushMicrotasks(100);
+		const result = await pending;
+
+		expect(fetchAttempts).toBe(1);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("OpenAI responses stream timed out while waiting for the first event");
+		expect(result.transportFailure?.providerCode).toBe("stream_first_event_timeout");
 	});
 
 	it("does not arm the first-event watchdog before Azure OpenAI responses setup finishes", async () => {

--- a/packages/ai/test/register-builtins.test.ts
+++ b/packages/ai/test/register-builtins.test.ts
@@ -185,8 +185,8 @@ describe("register-builtins lazy streams", () => {
 });
 
 describe("resolveLazyStreamFirstEventFallbackMs", () => {
-	it("returns 300s for slow-first-event providers without a configured fallback", () => {
-		expect(resolveLazyStreamFirstEventFallbackMs("alibaba-token-plan")).toBe(300_000);
+	it("returns each slow provider's centralized first-event fallback", () => {
+		expect(resolveLazyStreamFirstEventFallbackMs("alibaba-token-plan")).toBe(600_000);
 		expect(resolveLazyStreamFirstEventFallbackMs("kimi-code")).toBe(300_000);
 	});
 	it("returns undefined for unrelated providers", () => {
@@ -261,18 +261,18 @@ describe("outer lazy-stream first-event watchdog (fake timers)", () => {
 		);
 	}
 
-	it("alibaba-token-plan survives past the 120s shared default outer watchdog", async () => {
+	it("alibaba-token-plan survives past the previous 300s outer watchdog", async () => {
 		vi.useFakeTimers();
-		// Source emits its first real token at 150s — past the 120s default but
-		// well within Alibaba's 300s outer fallback.
-		const source = createDelayedSource(150_000);
+		// Source emits its first real token at 310s — past the previous Alibaba
+		// floor but well within the widened 600s fallback.
+		const source = createDelayedSource(310_000);
 		setBedrockProviderModule({ streamBedrock: () => source });
 
 		const stream = streamBedrock(createAlibabaModel(), baseContext, {});
 		await flush();
 
-		// Advance past the shared 120s default — must NOT timeout.
-		vi.advanceTimersByTime(120_000);
+		// Advance past the previous 300s Alibaba floor — must NOT timeout.
+		vi.advanceTimersByTime(300_000);
 		await flush();
 		let settled = false;
 		void stream.result().then(() => {
@@ -281,15 +281,15 @@ describe("outer lazy-stream first-event watchdog (fake timers)", () => {
 		await flush();
 		expect(settled).toBe(false);
 
-		// Advance to 150s — the source emits text_delta and completes.
-		vi.advanceTimersByTime(30_000);
+		// Advance to 310s — the source emits text_delta and completes.
+		vi.advanceTimersByTime(10_000);
 		await flush();
 		const result = await stream.result();
 		expect(result.stopReason).toBe("stop");
 		expect(result.errorMessage).toBeUndefined();
 	});
 
-	it("alibaba-token-plan times out at 300s when the source never emits", async () => {
+	it("alibaba-token-plan times out at 600s when the source never emits", async () => {
 		vi.useFakeTimers();
 		const source = createHangingSource();
 		setBedrockProviderModule({ streamBedrock: () => source });
@@ -297,8 +297,8 @@ describe("outer lazy-stream first-event watchdog (fake timers)", () => {
 		const stream = streamBedrock(createAlibabaModel(), baseContext, {});
 		await flush();
 
-		// 299s — still alive.
-		vi.advanceTimersByTime(299_000);
+		// 599s — still alive.
+		vi.advanceTimersByTime(599_000);
 		await flush();
 		let settled = false;
 		void stream.result().then(() => {
@@ -307,7 +307,7 @@ describe("outer lazy-stream first-event watchdog (fake timers)", () => {
 		await flush();
 		expect(settled).toBe(false);
 
-		// 300s — watchdog fires.
+		// 600s — watchdog fires.
 		vi.advanceTimersByTime(1_000);
 		await flush();
 		const result = await stream.result();
@@ -359,18 +359,18 @@ describe("outer lazy-stream first-event watchdog (fake timers)", () => {
 		await flush();
 		expect(settled).toBe(false);
 
-		// 60s — explicit override fires well before the 300s Alibaba fallback.
+		// 60s — explicit override fires well before the 600s Alibaba fallback.
 		vi.advanceTimersByTime(1_000);
 		await flush();
 		const result = await stream.result();
 		expect(result.stopReason).toBe("error");
 		expect(result.errorMessage).toBe("Provider stream timed out while waiting for the first event");
 	});
-	it("keeps the exported OpenAI Completions lazy path alive past 120s for Alibaba", async () => {
+	it("keeps the exported OpenAI Completions lazy path alive past 300s for Alibaba", async () => {
 		vi.useFakeTimers();
 		const model = getBundledModel("alibaba-token-plan", "glm-5.2") as Model<"openai-completions">;
 		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async () =>
-			createDelayedSseResponse(150_000, [
+			createDelayedSseResponse(310_000, [
 				{
 					id: "chatcmpl-delayed",
 					object: "chat.completion.chunk",
@@ -398,7 +398,7 @@ describe("outer lazy-stream first-event watchdog (fake timers)", () => {
 		await flush();
 		expect(fetchSpy).toHaveBeenCalledTimes(1);
 
-		vi.advanceTimersByTime(120_000);
+		vi.advanceTimersByTime(300_000);
 		await flush();
 		let settled = false;
 		void lazyStream.result().then(() => {
@@ -407,18 +407,18 @@ describe("outer lazy-stream first-event watchdog (fake timers)", () => {
 		await flush();
 		expect(settled).toBe(false);
 
-		vi.advanceTimersByTime(30_000);
+		vi.advanceTimersByTime(10_000);
 		await flush();
 		const result = await lazyStream.result();
 		expect(result.stopReason).toBe("stop");
 		expect(result.content).toContainEqual({ type: "text", text: "Hello delayed" });
 	});
 
-	it("keeps the exported OpenAI Responses lazy path alive past 120s for Alibaba", async () => {
+	it("keeps the exported OpenAI Responses lazy path alive past 300s for Alibaba", async () => {
 		vi.useFakeTimers();
 		const model = getBundledModel("alibaba-token-plan", "qwen3.8-max-preview") as Model<"openai-responses">;
 		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async () =>
-			createDelayedSseResponse(150_000, [
+			createDelayedSseResponse(310_000, [
 				{ type: "response.created", response: { id: "resp-delayed" } },
 				{
 					type: "response.output_item.added",
@@ -455,7 +455,7 @@ describe("outer lazy-stream first-event watchdog (fake timers)", () => {
 		await flush();
 		expect(fetchSpy).toHaveBeenCalledTimes(1);
 
-		vi.advanceTimersByTime(120_000);
+		vi.advanceTimersByTime(300_000);
 		await flush();
 		let settled = false;
 		void lazyStream.result().then(() => {
@@ -464,7 +464,7 @@ describe("outer lazy-stream first-event watchdog (fake timers)", () => {
 		await flush();
 		expect(settled).toBe(false);
 
-		vi.advanceTimersByTime(30_000);
+		vi.advanceTimersByTime(10_000);
 		await flush();
 		const result = await lazyStream.result();
 		expect(result.stopReason).toBe("stop");

--- a/packages/ai/test/stream-timeout-defaults.test.ts
+++ b/packages/ai/test/stream-timeout-defaults.test.ts
@@ -43,6 +43,10 @@ afterEach(() => {
 });
 
 describe("getProviderFirstEventTimeoutFallbackMs(provider)", () => {
+	it("gives Alibaba Token Plan one continuous 600-second first-event window", () => {
+		expect(getProviderFirstEventTimeoutFallbackMs("alibaba-token-plan")).toBe(600_000);
+	});
+
 	it("gives Kimi Code one continuous 300-second first-event window", () => {
 		expect(getProviderFirstEventTimeoutFallbackMs("kimi-code")).toBe(300_000);
 	});


### PR DESCRIPTION
﻿## Problem

Alibaba Token Plan long-context requests have produced successful first semantic events at 264?311 seconds. The existing 300-second Alibaba watchdog therefore sits inside the normal observed TTFT range and can abort a legitimate response at the boundary.

There was also a shorter path on OpenAI Completions: the SDK request timeout is armed before response headers, while the iterator watchdog only starts after `create()` returns. That SDK timeout inherited the generic 120-second stream window instead of Alibaba's provider budget. When it fired, the OpenAI SDK surfaced `APIConnectionTimeoutError: Request timed out.` without the canonical `stream_first_event_timeout` transport fact, so the session layer could treat the failure as unknown/retryable and replay the request.

## Change

- Centralize provider first-event fallbacks: Alibaba Token Plan uses 600 seconds, Kimi remains at 300 seconds, and other providers retain their existing defaults.
- Apply that shared fallback to the outer lazy wrapper and both OpenAI Responses/Completions semantic-event watchdogs.
- Apply the Alibaba fallback to the OpenAI Completions SDK timeout before response headers, while preserving caller and environment override precedence (`0` still disables the first-event watchdog).
- Normalize pre-stream Alibaba `APIConnectionTimeoutError`s on both OpenAI transports to `FirstEventTimeoutError`, preserving the typed no-replay transport contract.

## Why 600 seconds

600 seconds leaves useful headroom above the observed 264?311-second range without widening the global default or delaying failures for unrelated providers. Explicit caller/environment timeout settings still win.

## Verification

- `bun test packages/ai/test/openai-first-event-timeout.test.ts packages/ai/test/register-builtins.test.ts packages/ai/test/stream-timeout-defaults.test.ts` ? 44 pass
- `bun --cwd=packages/ai run check` ? pass (Biome 446 files + package TypeScript check)
- Existing Alibaba resilient-session no-replay regression ? pass
- Existing Alibaba fallback no-replay assertion ? pass; the isolated Windows run then hit `EBUSY` while deleting its temp directory
- Full `packages/ai` run reached 1,929 pass / 337 skip; 172 failures were a Windows SQLite/temp-directory `EBUSY` cleanup cascade also reproduced by an unrelated auth-only test
- `git diff --check origin/dev...HEAD` ? pass

## Related

This is complementary to #3708. That PR addresses ownership races between the outer lazy watchdog and provider-owned raw-event watchdogs. It does not change Alibaba's provider budget, the Completions pre-header SDK timeout, or typed normalization of SDK connection timeouts; those remain necessary if #3708 lands.

