### PR TITLE
fix(onboarding): load pasted custom-provider credentials

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -317,10 +317,11 @@ Use provider-level `headers` for proxy-required headers. Keep the provider `api`
 | Intent | Required keys |
 | --- | --- |
 | Authenticated proxy (recommended) | `auth: apiKey` (default) + `apiKeyEnv: MY_TOKEN` |
+| Authenticated proxy, key stored by GJC | `auth: apiKey` (default) + `apiKeyStored: true`; configure it through `/provider` so the credential exists in GJC's credential database |
 | Authenticated proxy, key inline | `auth: apiKey` (default) + `apiKey: sk-…` (less safe; stored in plaintext) |
 | Genuinely unauthenticated endpoint | `auth: none`, no key |
 
-Omitting both `apiKey` and `apiKeyEnv` while leaving `auth` at its `apiKey` default fails with `Provider <name>: custom models need a credential source, but none is configured.` — the fix is to add one of the rows above, not to change `api` or `baseUrl`.
+Omitting all three credential sources (`apiKey`, `apiKeyEnv`, and `apiKeyStored`) while leaving `auth` at its `apiKey` default fails with `Provider <name>: custom models need a credential source, but none is configured.` Add one of the authenticated rows above, or use `auth: none` only when the endpoint is genuinely unauthenticated.
 
 `input` is the model modality list GJC uses to decide whether image content is forwarded. When a custom model omits `input`, GJC defaults to `[text]` (unless a bundled model with the same id contributes a reference). Vision-capable upstream models therefore need an explicit `input: [text, image]`; otherwise `read`/tool images are stripped before the request and replaced with `[image omitted: model does not support vision]`, even if the remote model can see images.
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -246,7 +246,7 @@ gjc --mpreset codex-medium
 gjc --mpreset opencodego --default
 ```
 
-The `/model` command opens to a preset landing view: presets are grouped by provider with live auth marks (✓/✗), highlighting a group expands its tiers, and selecting a tier shows the full role→model preview before applying for the session or as default. Typing jumps straight to model search, and `Browse all models` opens the classic tabbed model selector. In `/login`, `Add custom provider` is the first option for configuring credentials needed by custom or profile-required providers; after a successful provider login, the matching preset is recommended automatically.
+The `/model` command opens to a preset landing view: presets are grouped by provider with live auth marks (✓/✗), highlighting a group expands its tiers, and selecting a tier shows the full role→model preview before applying for the session or as default. Typing jumps straight to model search, and `Browse all models` opens the classic tabbed model selector. In `/login`, `Add custom provider` is the first option for configuring credentials needed by custom or profile-required providers; after a successful provider login, the matching preset is recommended automatically. When that wizard receives a pasted API key, it stores the secret in GJC's credential database and writes only `apiKeyStored: true` to `models.yml`.
 
 MiniMax's OpenAI-compatible endpoint rejects multiple system messages and emits thinking in `reasoning_content`, so pin the public-safe compatibility fields when hand-authoring a custom provider:
 
@@ -282,6 +282,7 @@ providers:
 ### Allowed auth/discovery values
 
 - `auth`: `apiKey` (default), `none`, or `oauth`; for `models.yml` custom models, `oauth` is accepted by schema but does not waive the `apiKey` requirement
+- `apiKeyStored: true`: resolve the provider key from GJC's credential database without writing the secret to `models.yml`; `/provider` adds this marker for pasted keys
 - `models.yml` is strict: unknown provider/model keys fail validation before provider dispatch, so stale keys such as `requestTransform` or `wireModelId` only work where this document lists them.
 - `discovery.type`: `ollama`, `llama.cpp`, `lm-studio`, or `openai-models-list`
 - `cacheRetention`: `none`, `short`, or `long`; request-time options win over model/modelOverride values, then provider values, then `GJC_CACHE_RETENTION`, then the runtime default. The runtime default is `short` for most providers, but the Anthropic provider defaults to `long` because the ~5m cache is fragile for long-running subagent workflows. Canonical Anthropic models use top-level automatic caching and emit `ttl: "1h"` when long retention is supported. Claude-family models on non-canonical Anthropic-compatible endpoints default to explicit block markers because compatible proxies commonly inject, rewrite, or reject top-level cache controls; they omit `ttl` unless `compat.supportsLongCacheRetention: true` opts the endpoint into 1-hour retention. For OpenAI Responses, this controls `prompt_cache_retention` only; it does not disable `prompt_cache_key` when a stable session id exists.
@@ -391,7 +392,7 @@ modelBindings:
 Required:
 
 - `baseUrl`
-- A credential source: `apiKeyEnv` or `apiKey`. `auth` selects the scheme, not the credential, so `auth: apiKey` (the default) still needs one of them. Exempt: `auth: none`, and `api: bedrock-converse-stream`, which resolves AWS credentials from its own chain.
+- A credential source: `apiKeyEnv`, `apiKey`, or `apiKeyStored: true`. `auth` selects the scheme, not the credential, so `auth: apiKey` (the default) still needs a source. Provider setup writes `apiKeyStored: true` when it saves the credential in auth storage. Exempt: `auth: none`, and `api: bedrock-converse-stream`, which resolves AWS credentials from its own chain.
 - `api` at provider level or each model
 
 ### Override-only provider (`models` missing or empty)

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -92,6 +92,9 @@
 ### Changed
 
 - Updated the Cursor Eco, Medium, and Pro profiles from Composer 1.5 to distinct Composer 2.5 tiers: standard throughout for Eco, Fast on execution/review/design roles for Medium, and Fast throughout for Pro. Removed inert generic effort suffixes that the Cursor RPC could not transport.
+### Fixed
+
+- Pasted API keys from the custom-provider wizard now leave an explicit stored-credential marker in `models.yml`, so the generated provider survives immediate registry refresh and later restarts without exposing the secret (#3738).
 
 ## [0.12.8] - 2026-08-02
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -58,6 +58,7 @@
 - Slack Web API requests now use form encoding instead of JSON, preventing thread reconciliation through `conversations.replies` from failing with `invalid_arguments`.
 
 - Managed replacement cleanup now migrates version-one receipts from earlier releases and recovers canonical exchange placeholders left by interrupted cleanup, so a stale receipt cannot permanently block the next managed session mutation with `managed_replace_cleanup_receipt_invalid`.
+- Pasted API keys from the custom-provider wizard now leave an explicit stored-credential marker in `models.yml`, so the generated provider survives immediate registry refresh and later restarts without exposing the secret (#3738).
 
 ## [0.12.11] - 2026-08-03
 
@@ -93,8 +94,6 @@
 
 - Updated the Cursor Eco, Medium, and Pro profiles from Composer 1.5 to distinct Composer 2.5 tiers: standard throughout for Eco, Fast on execution/review/design roles for Medium, and Fast throughout for Pro. Removed inert generic effort suffixes that the Cursor RPC could not transport.
 ### Fixed
-
-- Pasted API keys from the custom-provider wizard now leave an explicit stored-credential marker in `models.yml`, so the generated provider survives immediate registry refresh and later restarts without exposing the secret (#3738).
 
 ## [0.12.8] - 2026-08-02
 ### Added

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -269,6 +269,7 @@ interface ProviderValidationConfig {
 	headers?: Record<string, string>;
 	apiKey?: string;
 	apiKeyEnv?: string;
+	apiKeyStored?: true;
 	api?: Api;
 	auth?: ProviderAuthMode;
 	oauthConfigured?: boolean;
@@ -326,6 +327,7 @@ function validateProviderConfiguration(
 				: !usesProviderCredentialChain &&
 					!config.apiKey &&
 					!config.apiKeyEnv &&
+					!config.apiKeyStored &&
 					(config.auth ?? "apiKey") !== "none";
 		if (requiresAuth) {
 			throw new Error(
@@ -333,8 +335,9 @@ function validateProviderConfiguration(
 					? `Provider ${providerName}: "apiKey" or "oauth" is required when defining models.`
 					: `Provider ${providerName}: custom models need a credential source, but none is configured. ` +
 							`"auth" only selects the scheme ("auth: apiKey" does not supply a key). ` +
+							`One of "apiKey", "apiKeyEnv", or "apiKeyStored" is required unless auth is "none". ` +
 							`Fix by adding "apiKeyEnv: <ENV_VAR>" (recommended) or "apiKey: <literal-key>", ` +
-							`or set "auth: none" if the endpoint is genuinely unauthenticated.`,
+							`using a credential stored by provider setup, or setting "auth: none" for an unauthenticated endpoint.`,
 			);
 		}
 	}
@@ -421,6 +424,7 @@ export const ModelsConfigFile = new ConfigFile<ModelsConfig>("models", ModelsCon
 					headers: providerConfig.headers,
 					apiKey: providerConfig.apiKey,
 					apiKeyEnv: providerConfig.apiKeyEnv,
+					apiKeyStored: providerConfig.apiKeyStored,
 					api: providerConfig.api as Api | undefined,
 					auth: (providerConfig.auth ?? "apiKey") as ProviderAuthMode,
 					discovery: providerConfig.discovery as ProviderDiscovery | undefined,

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -210,6 +210,7 @@ const ProviderConfigSchema = z
 		baseUrl: z.string().min(1).optional(),
 		apiKey: z.string().min(1).optional(),
 		apiKeyEnv: z.string().min(1).optional(),
+		apiKeyStored: z.literal(true).optional(),
 		api: z
 			.enum([
 				"openai-completions",

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1614,19 +1614,39 @@ export class SelectorController {
 		this.showSelector(done => {
 			let wizard: CustomProviderWizardComponent;
 			const submit = async (input: CustomProviderWizardSubmit): Promise<void> => {
+				let result: Awaited<ReturnType<typeof addApiCompatibleProvider>>;
 				try {
-					const result = await addApiCompatibleProvider(input);
-					if (result.credentialSource === "literal") await this.ctx.session.modelRegistry.authStorage.reload();
-					await this.ctx.session.modelRegistry.refresh("offline");
-					await this.ctx.notifyConfigChanged?.();
-					this.ctx.showStatus(formatProviderSetupResult(result));
-					wizard.complete();
-					done();
-					this.ctx.ui.requestRender();
+					result = await addApiCompatibleProvider(input);
 				} catch (err) {
 					const message = err instanceof Error ? err.message : String(err);
 					wizard.setSubmitError(`Provider setup failed: ${message}`);
+					return;
 				}
+				try {
+					await this.ctx.session.modelRegistry.authStorage.reload();
+					await this.ctx.session.modelRegistry.refresh("offline");
+				} catch {
+					wizard.setSubmitError(
+						"Provider was configured, but the live provider list could not be reloaded. Retry setup and confirm replacement, or restart GJC.",
+					);
+					return;
+				}
+				try {
+					await this.ctx.notifyConfigChanged?.();
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					this.ctx.showStatus(
+						`Provider '${result.providerId}' was configured and reloaded, but configuration notification failed: ${message}`,
+					);
+					wizard.complete();
+					done();
+					this.ctx.ui.requestRender();
+					return;
+				}
+				this.ctx.showStatus(formatProviderSetupResult(result));
+				wizard.complete();
+				done();
+				this.ctx.ui.requestRender();
 			};
 			wizard = new CustomProviderWizardComponent(
 				input => {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1616,6 +1616,7 @@ export class SelectorController {
 			const submit = async (input: CustomProviderWizardSubmit): Promise<void> => {
 				try {
 					const result = await addApiCompatibleProvider(input);
+					if (result.credentialSource === "literal") await this.ctx.session.modelRegistry.authStorage.reload();
 					await this.ctx.session.modelRegistry.refresh("offline");
 					await this.ctx.notifyConfigChanged?.();
 					this.ctx.showStatus(formatProviderSetupResult(result));

--- a/packages/coding-agent/src/setup/provider-onboarding.ts
+++ b/packages/coding-agent/src/setup/provider-onboarding.ts
@@ -331,6 +331,7 @@ export async function addApiCompatibleProvider(input: ProviderSetupInput): Promi
 		} finally {
 			authStorage.close();
 		}
+		provider.apiKeyStored = true;
 	}
 	const next: ModelsConfig = {
 		...existing,

--- a/packages/coding-agent/src/setup/provider-onboarding.ts
+++ b/packages/coding-agent/src/setup/provider-onboarding.ts
@@ -1,8 +1,11 @@
 import { randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { resolveOAuthStorageProvider } from "@gajae-code/ai";
 import { getAgentDbPath, getAgentDir } from "@gajae-code/utils";
 import { YAML } from "bun";
+import { enqueueAtomicYamlOperation } from "../config/atomic-yaml-patch";
+import { withFileLock } from "../config/file-lock";
 import { type ModelsConfig, ModelsConfigSchema } from "../config/models-config-schema";
 import { compareRankedProviders, famousProviderIndex } from "../config/provider-ranking";
 import { AuthStorage } from "../session/auth-storage";
@@ -308,52 +311,83 @@ async function writeModelsConfig(modelsPath: string, config: ModelsConfig): Prom
 export async function addApiCompatibleProvider(input: ProviderSetupInput): Promise<ProviderSetupResult> {
 	const validated = validateSetupInput(input);
 	const modelsPath = input.modelsPath ?? getDefaultModelsPath();
-	const existing = await readModelsConfig(modelsPath);
-	if (existing.providers?.[validated.providerId] && !input.force) {
-		throw new Error(`Provider '${validated.providerId}' already exists. Use --force to replace it.`);
-	}
-	const provider: ProviderConfig = {
-		baseUrl: validated.baseUrl,
-		api: validated.api,
-		auth: "apiKey",
-		models: validated.models.map(id => {
-			const api = validated.modelApi?.[id];
-			return api ? { id, api } : { id };
-		}),
-	};
-	if (validated.compat) provider.compat = validated.compat;
-	const authStorage = await AuthStorage.create(getAgentDbPath());
-	try {
-		if (validated.credentialSource === "env") {
-			await authStorage.remove(validated.providerId);
-			provider.apiKeyEnv = validated.apiKey;
-		} else {
-			await authStorage.set(validated.providerId, { type: "api_key", key: validated.apiKey });
-			provider.apiKeyStored = true;
-		}
-	} finally {
-		authStorage.close();
-	}
-	const next: ModelsConfig = {
-		...existing,
-		providers: {
-			...(existing.providers ?? {}),
-			[validated.providerId]: provider,
-		},
-	};
-	await writeModelsConfig(modelsPath, next);
-	return {
-		providerId: validated.providerId,
-		compatibility: validated.compatibility,
-		api: validated.api,
-		baseUrl: validated.baseUrl,
-		modelIds: validated.models,
-		modelsPath,
-		redactedApiKey: redactSecret(validated.apiKey),
-		credentialSource: validated.credentialSource,
-		preset: validated.preset?.id,
-		presetName: validated.preset?.name,
-	};
+
+	return await enqueueAtomicYamlOperation(getAgentDbPath(), async () =>
+		enqueueAtomicYamlOperation(modelsPath, async () =>
+			withFileLock(modelsPath, async () => {
+				const existing = await readModelsConfig(modelsPath);
+				if (existing.providers?.[validated.providerId] && !input.force) {
+					throw new Error(`Provider '${validated.providerId}' already exists. Use --force to replace it.`);
+				}
+
+				const provider: ProviderConfig = {
+					baseUrl: validated.baseUrl,
+					api: validated.api,
+					auth: "apiKey",
+					models: validated.models.map(id => {
+						const api = validated.modelApi?.[id];
+						return api ? { id, api } : { id };
+					}),
+				};
+				if (validated.compat) provider.compat = validated.compat;
+
+				const storageProvider = resolveOAuthStorageProvider(validated.providerId);
+				const authStorage = await AuthStorage.create(getAgentDbPath());
+				const previousCredentials = authStorage.getAll()[storageProvider];
+				let credentialMutationCompleted = false;
+				try {
+					if (validated.credentialSource === "env") {
+						await authStorage.remove(storageProvider);
+						provider.apiKeyEnv = validated.apiKey;
+					} else {
+						await authStorage.set(storageProvider, { type: "api_key", key: validated.apiKey });
+						provider.apiKeyStored = true;
+					}
+					credentialMutationCompleted = true;
+
+					const next: ModelsConfig = {
+						...existing,
+						providers: {
+							...(existing.providers ?? {}),
+							[validated.providerId]: provider,
+						},
+					};
+					await writeModelsConfig(modelsPath, next);
+				} catch (error) {
+					if (!credentialMutationCompleted) throw error;
+					try {
+						if (previousCredentials) {
+							await authStorage.set(storageProvider, previousCredentials);
+						} else {
+							await authStorage.remove(storageProvider);
+						}
+					} catch {
+						throw new Error(
+							"Provider setup could not save models configuration and could not restore the previous credential.",
+						);
+					}
+					throw new Error(
+						"Provider setup could not save models configuration; credential changes were rolled back.",
+					);
+				} finally {
+					authStorage.close();
+				}
+
+				return {
+					providerId: validated.providerId,
+					compatibility: validated.compatibility,
+					api: validated.api,
+					baseUrl: validated.baseUrl,
+					modelIds: validated.models,
+					modelsPath,
+					redactedApiKey: redactSecret(validated.apiKey),
+					credentialSource: validated.credentialSource,
+					preset: validated.preset?.id,
+					presetName: validated.preset?.name,
+				};
+			}),
+		),
+	);
 }
 
 function isLocalHttpHost(hostname: string): boolean {

--- a/packages/coding-agent/src/setup/provider-onboarding.ts
+++ b/packages/coding-agent/src/setup/provider-onboarding.ts
@@ -322,16 +322,17 @@ export async function addApiCompatibleProvider(input: ProviderSetupInput): Promi
 		}),
 	};
 	if (validated.compat) provider.compat = validated.compat;
-	if (validated.credentialSource === "env") {
-		provider.apiKeyEnv = validated.apiKey;
-	} else {
-		const authStorage = await AuthStorage.create(getAgentDbPath());
-		try {
+	const authStorage = await AuthStorage.create(getAgentDbPath());
+	try {
+		if (validated.credentialSource === "env") {
+			await authStorage.remove(validated.providerId);
+			provider.apiKeyEnv = validated.apiKey;
+		} else {
 			await authStorage.set(validated.providerId, { type: "api_key", key: validated.apiKey });
-		} finally {
-			authStorage.close();
+			provider.apiKeyStored = true;
 		}
-		provider.apiKeyStored = true;
+	} finally {
+		authStorage.close();
 	}
 	const next: ModelsConfig = {
 		...existing,

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -4291,6 +4291,40 @@ describe("ModelRegistry", () => {
 		expect(message).toContain("unsupportedModelKey");
 	});
 
+	test("loads custom models that declare a stored API key", async () => {
+		await authStorage.set("stored-provider", { type: "api_key", key: "stored-secret" });
+		writeRawModelsJson({
+			"stored-provider": {
+				baseUrl: "https://api.example.com/v1",
+				apiKeyStored: true,
+				api: "openai-completions",
+				auth: "apiKey",
+				models: [{ id: "stored-model" }],
+			},
+		});
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+
+		expect(registry.getError()).toBeUndefined();
+		expect(registry.find("stored-provider", "stored-model")).toBeDefined();
+		expect(await registry.getApiKeyForProvider("stored-provider")).toBe("stored-secret");
+	});
+
+	test("still rejects custom models without a declared credential source", () => {
+		writeRawModelsJson({
+			"missing-credential": {
+				baseUrl: "https://api.example.com/v1",
+				api: "openai-completions",
+				auth: "apiKey",
+				models: [{ id: "missing-model" }],
+			},
+		});
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+
+		expect(String(registry.getError()?.message)).toContain('"apiKey", "apiKeyEnv", or "apiKeyStored" is required');
+	});
+
 	test("rejects model-level request shaping on non-OpenAI-compatible APIs", () => {
 		writeRawModelsConfig({
 			providers: {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -4321,8 +4321,13 @@ describe("ModelRegistry", () => {
 		});
 
 		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const message = String(registry.getError()?.message);
 
-		expect(String(registry.getError()?.message)).toContain('"apiKey", "apiKeyEnv", or "apiKeyStored" is required');
+		expect(message).toContain("Provider missing-credential: custom models need a credential source");
+		expect(message).toContain('"auth" only selects the scheme');
+		expect(message).toContain('"apiKey", "apiKeyEnv", or "apiKeyStored" is required');
+		expect(message).toContain('"apiKeyEnv: <ENV_VAR>"');
+		expect(message).toContain('"auth: none"');
 	});
 
 	test("rejects model-level request shaping on non-OpenAI-compatible APIs", () => {

--- a/packages/coding-agent/test/provider-onboarding-wizard-redteam.test.ts
+++ b/packages/coding-agent/test/provider-onboarding-wizard-redteam.test.ts
@@ -116,7 +116,7 @@ describe("provider onboarding wizard red-team", () => {
 		expect(rendered).toContain("Base URL must use https unless it targets localhost or a loopback address");
 	});
 
-	it("does not report success when config notification rejects and renders the wizard error", async () => {
+	it("reports a committed provider separately when config notification rejects", async () => {
 		await withRegistry(async registry => {
 			let notificationAttempts = 0;
 			const ctx = createControllerContext(registry, async () => {
@@ -133,8 +133,10 @@ describe("provider onboarding wizard red-team", () => {
 			await errorRendered.promise;
 
 			expect(notificationAttempts).toBe(1);
-			expect(ctx.statuses).toEqual([]);
-			expect(visibleText(wizard)).toContain("Provider setup failed: notification unavailable");
+			expect(ctx.statuses).toEqual([
+				"Provider 'notify-failure' was configured and reloaded, but configuration notification failed: notification unavailable",
+			]);
+			expect(visibleText(wizard)).not.toContain("Provider setup failed");
 		});
 	});
 

--- a/packages/coding-agent/test/provider-onboarding-wizard.test.ts
+++ b/packages/coding-agent/test/provider-onboarding-wizard.test.ts
@@ -220,6 +220,45 @@ describe("provider onboarding wizard", () => {
 		}
 	});
 
+	it("reloads pasted credentials and makes the provider available without restart", async () => {
+		tempAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-provider-wizard-"));
+		setAgentDir(tempAgentDir);
+		const store = await SqliteAuthCredentialStore.open(path.join(tempAgentDir, "agent.db"));
+		try {
+			const authStorage = new AuthStorage(store);
+			const registry = new ModelRegistry(authStorage, path.join(tempAgentDir, "models.yml"));
+			const ctx = createControllerContext(registry);
+			const completion = Promise.withResolvers<void>();
+			ctx.showStatus = message => {
+				ctx.statuses.push(message);
+				completion.resolve();
+			};
+			const controller = new SelectorController(ctx);
+
+			controller.showCustomProviderWizard();
+			const wizard = ctx.ui.focused as CustomProviderWizardComponent;
+			wizard.handleInput("\n");
+			typeText(wizard, "literal-provider");
+			wizard.handleInput("\n");
+			typeText(wizard, "https://api.example.com/v1");
+			wizard.handleInput("\n");
+			wizard.handleInput("\x1b[B");
+			wizard.handleInput("\n");
+			typeText(wizard, "literal-secret");
+			wizard.handleInput("\n");
+			typeText(wizard, "literal-model");
+			wizard.handleInput("\n");
+			wizard.handleInput("\n");
+			await completion.promise;
+
+			expect(registry.getError()).toBeUndefined();
+			expect(registry.getAvailable().some(model => model.provider === "literal-provider")).toBe(true);
+			expect(await registry.getApiKeyForProvider("literal-provider")).toBe("literal-secret");
+		} finally {
+			store.close();
+		}
+	});
+
 	it("keeps OAuth and API guide onboarding actions routed", () => {
 		const ctx = createControllerContext({ refresh: async () => undefined } as unknown as ModelRegistry);
 		const controller = new SelectorController(ctx);

--- a/packages/coding-agent/test/provider-onboarding-wizard.test.ts
+++ b/packages/coding-agent/test/provider-onboarding-wizard.test.ts
@@ -175,9 +175,12 @@ describe("provider onboarding wizard", () => {
 	it("refreshes offline after success and exposes the provider in model selector data without restart", async () => {
 		tempAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-provider-wizard-"));
 		setAgentDir(tempAgentDir);
+		const previousEnv = Bun.env.CUSTOM_PROVIDER_KEY;
+		Bun.env.CUSTOM_PROVIDER_KEY = "environment-secret";
 		const store = await SqliteAuthCredentialStore.open(path.join(tempAgentDir, "agent.db"));
 		try {
 			const authStorage = new AuthStorage(store);
+			await authStorage.set("live-provider", { type: "api_key", key: "stale-stored-secret" });
 			const registry = new ModelRegistry(authStorage, path.join(tempAgentDir, "models.yml"));
 			const refreshModes: (string | undefined)[] = [];
 			const originalRefresh = registry.refresh.bind(registry);
@@ -214,7 +217,44 @@ describe("provider onboarding wizard", () => {
 			expect(refreshModes).toEqual(["offline"]);
 			expect(configChanged).toBe(true);
 			expect(registry.find("live-provider", "live-model")).toBeDefined();
+			expect(await registry.getApiKeyForProvider("live-provider")).toBe("environment-secret");
 			expect(ctx.statuses).toEqual([successStatus]);
+		} finally {
+			store.close();
+			if (previousEnv === undefined) delete Bun.env.CUSTOM_PROVIDER_KEY;
+			else Bun.env.CUSTOM_PROVIDER_KEY = previousEnv;
+		}
+	});
+	it("keeps the wizard retryable when offline refresh fails after provider setup commits", async () => {
+		tempAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-provider-wizard-"));
+		setAgentDir(tempAgentDir);
+		const store = await SqliteAuthCredentialStore.open(path.join(tempAgentDir, "agent.db"));
+		try {
+			const authStorage = new AuthStorage(store);
+			const registry = new ModelRegistry(authStorage, path.join(tempAgentDir, "models.yml"));
+			const refreshStarted = Promise.withResolvers<void>();
+			registry.refresh = async mode => {
+				expect(mode).toBe("offline");
+				refreshStarted.resolve();
+				throw new Error("reload failed for literal-secret");
+			};
+			const ctx = createControllerContext(registry);
+			const reloadFailureRendered = Promise.withResolvers<void>();
+			const controller = new SelectorController(ctx);
+			controller.showCustomProviderWizard();
+			const wizard = ctx.ui.focused as CustomProviderWizardComponent;
+			driveEnvWizard(wizard, { providerId: "reload-failure-provider", model: "reload-failure-model" });
+			ctx.ui.requestRender = () => reloadFailureRendered.resolve();
+			wizard.handleInput("\n");
+			await refreshStarted.promise;
+			await reloadFailureRendered.promise;
+
+			const rendered = visibleText(wizard);
+			expect(rendered).toContain("Provider was configured, but the live provider list could not be reloaded.");
+			expect(rendered).toContain("Retry setup and confirm replacement, or restart GJC.");
+			expect(rendered).not.toContain("literal-secret");
+			expect(ctx.statuses).toEqual([]);
+			expect(await Bun.file(path.join(tempAgentDir, "models.yml")).exists()).toBe(true);
 		} finally {
 			store.close();
 		}

--- a/packages/coding-agent/test/provider-onboarding.test.ts
+++ b/packages/coding-agent/test/provider-onboarding.test.ts
@@ -351,6 +351,7 @@ describe("provider onboarding setup core", () => {
 
 	it("stores literal keys in AuthStorage instead of models.yml", async () => {
 		const modelsPath = await tempModelsPath();
+		setAgentDir(tempRoot!);
 		await addApiCompatibleProvider({
 			compatibility: "openai",
 			providerId: "literal-key-provider",
@@ -361,14 +362,20 @@ describe("provider onboarding setup core", () => {
 		});
 		const text = await Bun.file(modelsPath).text();
 		expect(text).not.toContain("literal-secret");
-		const store = await SqliteAuthCredentialStore.open(getAgentDbPath());
+		const parsed = YAML.parse(text) as { providers: Record<string, { apiKeyStored?: true }> };
+		expect(parsed.providers["literal-key-provider"]?.apiKeyStored).toBe(true);
+		const authStorage = await AuthStorage.create(getAgentDbPath());
 		try {
-			expect(store.listAuthCredentials("literal-key-provider")[0]?.credential).toEqual({
+			expect(authStorage.get("literal-key-provider")).toEqual({
 				type: "api_key",
 				key: "literal-secret",
 			});
+			const registry = new ModelRegistry(authStorage, modelsPath);
+			expect(registry.getError()).toBeUndefined();
+			expect(registry.find("literal-key-provider", "example-model")).toBeDefined();
+			expect(await registry.getApiKeyForProvider("literal-key-provider")).toBe("literal-secret");
 		} finally {
-			store.close();
+			authStorage.close();
 		}
 	});
 

--- a/packages/coding-agent/test/provider-onboarding.test.ts
+++ b/packages/coding-agent/test/provider-onboarding.test.ts
@@ -352,7 +352,7 @@ describe("provider onboarding setup core", () => {
 	it("stores literal keys in AuthStorage instead of models.yml", async () => {
 		const modelsPath = await tempModelsPath();
 		setAgentDir(tempRoot!);
-		await addApiCompatibleProvider({
+		const result = await addApiCompatibleProvider({
 			compatibility: "openai",
 			providerId: "literal-key-provider",
 			baseUrl: "https://api.example.com/v1",
@@ -362,6 +362,10 @@ describe("provider onboarding setup core", () => {
 		});
 		const text = await Bun.file(modelsPath).text();
 		expect(text).not.toContain("literal-secret");
+		const output = formatProviderSetupResult(result);
+		expect(output).not.toContain("literal-secret");
+		expect(output).not.toContain("literal-sec");
+		expect(output).toContain("API key:");
 		const parsed = YAML.parse(text) as { providers: Record<string, { apiKeyStored?: true }> };
 		expect(parsed.providers["literal-key-provider"]?.apiKeyStored).toBe(true);
 		const authStorage = await AuthStorage.create(getAgentDbPath());
@@ -440,6 +444,99 @@ describe("provider onboarding setup core", () => {
 		} finally {
 			if (previousEnv === undefined) delete Bun.env[envName];
 			else Bun.env[envName] = previousEnv;
+		}
+	});
+	it("restores a stored credential and models config when env replacement cannot be committed", async () => {
+		const modelsPath = await tempModelsPath();
+		setAgentDir(tempRoot!);
+		await addApiCompatibleProvider({
+			compatibility: "openai",
+			providerId: "atomic-env-provider",
+			baseUrl: "https://api.example.com/v1",
+			apiKey: "old-stored-secret",
+			models: ["old-model"],
+			modelsPath,
+		});
+		const oldModelsConfig = await Bun.file(modelsPath).text();
+		const renameSpy = vi.spyOn(fs, "rename").mockRejectedValueOnce(new Error("write failed for new-env-secret"));
+		let failure: Error;
+		try {
+			failure = await addApiCompatibleProvider({
+				compatibility: "openai",
+				providerId: "atomic-env-provider",
+				baseUrl: "https://api.example.com/v2",
+				apiKeyEnv: "NEW_ENV_SECRET",
+				models: ["new-model"],
+				modelsPath,
+				force: true,
+			}).then(
+				() => {
+					throw new Error("Expected models config write to fail.");
+				},
+				error => (error instanceof Error ? error : new Error(String(error))),
+			);
+		} finally {
+			renameSpy.mockRestore();
+		}
+
+		expect(failure.message).toContain("credential changes were rolled back");
+		expect(failure.message).not.toContain("old-stored-secret");
+		expect(failure.message).not.toContain("new-env-secret");
+		expect(await Bun.file(modelsPath).text()).toBe(oldModelsConfig);
+		const authStorage = await AuthStorage.create(getAgentDbPath());
+		try {
+			expect(authStorage.get("atomic-env-provider")).toEqual({ type: "api_key", key: "old-stored-secret" });
+			const registry = new ModelRegistry(authStorage, modelsPath);
+			expect(await registry.getApiKeyForProvider("atomic-env-provider")).toBe("old-stored-secret");
+		} finally {
+			authStorage.close();
+		}
+	});
+
+	it("restores a stored credential and models config when literal replacement cannot be committed", async () => {
+		const modelsPath = await tempModelsPath();
+		setAgentDir(tempRoot!);
+		await addApiCompatibleProvider({
+			compatibility: "openai",
+			providerId: "atomic-literal-provider",
+			baseUrl: "https://api.example.com/v1",
+			apiKey: "old-literal-secret",
+			models: ["old-model"],
+			modelsPath,
+		});
+		const oldModelsConfig = await Bun.file(modelsPath).text();
+		const renameSpy = vi.spyOn(fs, "rename").mockRejectedValueOnce(new Error("write failed for new-literal-secret"));
+		let failure: Error;
+		try {
+			failure = await addApiCompatibleProvider({
+				compatibility: "openai",
+				providerId: "atomic-literal-provider",
+				baseUrl: "https://api.example.com/v2",
+				apiKey: "new-literal-secret",
+				models: ["new-model"],
+				modelsPath,
+				force: true,
+			}).then(
+				() => {
+					throw new Error("Expected models config write to fail.");
+				},
+				error => (error instanceof Error ? error : new Error(String(error))),
+			);
+		} finally {
+			renameSpy.mockRestore();
+		}
+
+		expect(failure.message).toContain("credential changes were rolled back");
+		expect(failure.message).not.toContain("old-literal-secret");
+		expect(failure.message).not.toContain("new-literal-secret");
+		expect(await Bun.file(modelsPath).text()).toBe(oldModelsConfig);
+		const authStorage = await AuthStorage.create(getAgentDbPath());
+		try {
+			expect(authStorage.get("atomic-literal-provider")).toEqual({ type: "api_key", key: "old-literal-secret" });
+			const registry = new ModelRegistry(authStorage, modelsPath);
+			expect(await registry.getApiKeyForProvider("atomic-literal-provider")).toBe("old-literal-secret");
+		} finally {
+			authStorage.close();
 		}
 	});
 

--- a/packages/coding-agent/test/provider-onboarding.test.ts
+++ b/packages/coding-agent/test/provider-onboarding.test.ts
@@ -404,6 +404,45 @@ describe("provider onboarding setup core", () => {
 		expect(await Bun.file(path.join(path.dirname(modelsPath), "agent.db")).exists()).toBe(false);
 	});
 
+	it("removes a stored key when force-replacing a provider with env auth", async () => {
+		const modelsPath = await tempModelsPath();
+		setAgentDir(tempRoot!);
+		const envName = "GJC_TEST_REPLACED_PROVIDER_KEY";
+		const previousEnv = Bun.env[envName];
+		Bun.env[envName] = "environment-secret";
+		try {
+			await addApiCompatibleProvider({
+				compatibility: "openai",
+				providerId: "replaced-provider",
+				baseUrl: "https://api.example.com/v1",
+				apiKey: "stale-stored-secret",
+				models: ["example-model"],
+				modelsPath,
+			});
+			await addApiCompatibleProvider({
+				compatibility: "openai",
+				providerId: "replaced-provider",
+				baseUrl: "https://api.example.com/v1",
+				apiKeyEnv: envName,
+				models: ["example-model"],
+				modelsPath,
+				force: true,
+			});
+
+			const authStorage = await AuthStorage.create(getAgentDbPath());
+			try {
+				expect(authStorage.get("replaced-provider")).toBeUndefined();
+				const registry = new ModelRegistry(authStorage, modelsPath);
+				expect(await registry.getApiKeyForProvider("replaced-provider")).toBe("environment-secret");
+			} finally {
+				authStorage.close();
+			}
+		} finally {
+			if (previousEnv === undefined) delete Bun.env[envName];
+			else Bun.env[envName] = previousEnv;
+		}
+	});
+
 	it("rejects remote plaintext HTTP and existing providers unless forced", async () => {
 		const modelsPath = await tempModelsPath();
 		await expect(

--- a/schemas/models.schema.json
+++ b/schemas/models.schema.json
@@ -25,6 +25,10 @@
 						"type": "string",
 						"minLength": 1
 					},
+					"apiKeyStored": {
+						"type": "boolean",
+						"const": true
+					},
 					"api": {
 						"type": "string",
 						"enum": [


### PR DESCRIPTION
## What

- Add an explicit `apiKeyStored: true` credential-source marker for custom models whose key lives in GJC credential storage.
- Make env-backed provider replacement remove stale stored credentials, then reload the active credential cache for both env and literal setup.
- Cover strict validation, secure persistence, literal-to-env replacement, immediate availability, restart loading, docs, changelog, and the generated docs index.

## Why

Fixes #3738.

The wizard already stored pasted API keys outside `models.yml`, but the generated provider entry did not declare that credential source. Static config validation therefore rejected the wizard output.

A force replacement from a pasted key to `apiKeyEnv` also left the stored key active. Because stored credentials outrank environment values, the old secret continued to win. Env setup now removes that stored credential, and the running session reloads the canonical store before refreshing models.

Hand-authored custom models with no `apiKey`, `apiKeyEnv`, or stored-key marker remain invalid.

## Testing

- `bun test packages/coding-agent/test/provider-onboarding.test.ts packages/coding-agent/test/provider-onboarding-wizard.test.ts` (255 focused tests passed / 2841 assertions)
- `bun test packages/coding-agent/test/provider-onboarding.test.ts packages/coding-agent/test/provider-onboarding-wizard.test.ts packages/coding-agent/test/model-registry.test.ts --test-name-pattern "stored API key|declared credential source|provider onboarding"` (32 passed)
- `bun test packages/coding-agent/test/docs-index-lazy.test.ts` (5 passed)
- `bun --cwd=packages/coding-agent run check`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:0df28bb15c6d6329e1b8511e0e49a95100e33458 reviewer:architect evidence:local-source-diff-review+local-test-docs-review
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit