### PR TITLE
fix(tui): handle enhanced Ctrl+J as newline

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `Ctrl+J` now inserts a newline when multiplexers such as Herdr forward it through Kitty CSI-u or xterm `modifyOtherKeys`, matching the existing legacy line-feed behavior and displayed shortcut.
+
 ## [0.12.8] - 2026-08-02
 ### Fixed
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1366,6 +1366,7 @@ export class Editor implements Component, Focusable {
 		}
 		// New line
 		else if (
+			matchesKey(data, "ctrl+j") || // Ctrl+J (Kitty/modifyOtherKeys)
 			(data.charCodeAt(0) === 10 && data.length > 1) || // Ctrl+Enter with modifiers
 			matchesKey(data, "ctrl+enter") || // Ctrl+Enter (Kitty/modifyOtherKeys, including lock bits/keypad Enter)
 			matchesKey(data, "ctrl+shift+enter") || // Ctrl+Shift+Enter (Kitty/modifyOtherKeys combined modifier)

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -707,6 +707,20 @@ describe("Editor component", () => {
 			}
 		});
 
+		it("inserts a newline for Ctrl+J enhanced keyboard protocol variants", () => {
+			const variants = ["\x1b[106;5u", "\x1b[106;5:1u", "\x1b[106;5:2u", "\x1b[27;5;106~"];
+
+			for (const variant of variants) {
+				const editor = new Editor(defaultEditorTheme);
+
+				editor.handleInput("a");
+				editor.handleInput(variant);
+				editor.handleInput("b");
+
+				expect(editor.getText()).toBe("a\nb");
+			}
+		});
+
 		it("inserts a newline for Ctrl+Shift+Enter terminal protocol variants", () => {
 			const variants = ["\x1b[13;6u", "\x1b[27;6;13~", "\x1b[13;6~", "\x1b[13;2~", "\x1b[13;2u"];
 


### PR DESCRIPTION
## Summary

- recognize `Ctrl+J` as a newline when terminals or multiplexers encode it with Kitty CSI-u
- support xterm `modifyOtherKeys` encoding through the same existing key matcher
- add regression coverage for Kitty press/repeat events and `modifyOtherKeys`
- document the fix in the TUI changelog

## Root cause

GJC advertises `Ctrl+J` as a fixed newline shortcut and already handles its legacy LF byte. After GJC negotiates the Kitty keyboard protocol, multiplexers such as Herdr preserve the key identity and forward `Ctrl+J` as an enhanced sequence such as `CSI 106;5:1u`. The key parser could recognize that sequence, but the editor's newline branch never asked it to match `ctrl+j`, so the input was ignored.

This change routes enhanced `Ctrl+J` encodings through the same newline path while retaining the existing legacy LF behavior.

## Testing

- `bun test packages/tui/test/editor.test.ts` — 146 passed
- `bun --cwd=packages/tui run check`
- manually verified multiline entry with `Ctrl+J` while running GJC inside Herdr