### PR TITLE
fix(coding-agent): bound extension inspector separators

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The Extension Control Center inspector no longer crashes when a narrow two-column layout leaves its preview pane fewer than two columns wide.
+
 ## [0.12.8] - 2026-08-02
 ### Added
 

--- a/packages/coding-agent/src/modes/components/extensions/inspector-panel.ts
+++ b/packages/coding-agent/src/modes/components/extensions/inspector-panel.ts
@@ -9,6 +9,10 @@ import { theme } from "../../../modes/theme/theme";
 import { shortenPath } from "../../../tools/render-utils";
 import type { Extension, ExtensionState } from "./types";
 
+function renderSeparator(width: number): string {
+	return theme.fg("dim", theme.boxSharp.horizontal.repeat(Math.max(0, Math.min(width - 2, 40))));
+}
+
 export class InspectorPanel implements Component {
 	#extension: Extension | null = null;
 
@@ -106,7 +110,7 @@ export class InspectorPanel implements Component {
 	#renderFilePreview(raw: unknown, width: number): string[] {
 		const lines: string[] = [];
 		lines.push(theme.fg("muted", "Preview:"));
-		lines.push(theme.fg("dim", theme.boxSharp.horizontal.repeat(Math.min(width - 2, 40))));
+		lines.push(renderSeparator(width));
 
 		const content = this.#getContextFileContent(raw);
 		if (!content) {
@@ -164,7 +168,7 @@ export class InspectorPanel implements Component {
 	#renderToolArgs(raw: unknown, width: number): string[] {
 		const lines: string[] = [];
 		lines.push(theme.fg("muted", "Arguments:"));
-		lines.push(theme.fg("dim", theme.boxSharp.horizontal.repeat(Math.min(width - 2, 40))));
+		lines.push(renderSeparator(width));
 
 		try {
 			const tool = raw as any;
@@ -203,7 +207,7 @@ export class InspectorPanel implements Component {
 	#renderSkillContent(raw: unknown, width: number): string[] {
 		const lines: string[] = [];
 		lines.push(theme.fg("muted", "Instruction:"));
-		lines.push(theme.fg("dim", theme.boxSharp.horizontal.repeat(Math.min(width - 2, 40))));
+		lines.push(renderSeparator(width));
 
 		try {
 			const skill = raw as any;
@@ -232,7 +236,7 @@ export class InspectorPanel implements Component {
 	#renderMcpDetails(raw: unknown, width: number): string[] {
 		const lines: string[] = [];
 		lines.push(theme.fg("muted", "Connection:"));
-		lines.push(theme.fg("dim", theme.boxSharp.horizontal.repeat(Math.min(width - 2, 40))));
+		lines.push(renderSeparator(width));
 
 		try {
 			const mcp = raw as any;
@@ -271,7 +275,7 @@ export class InspectorPanel implements Component {
 		// Show trigger pattern if present
 		if (ext.trigger) {
 			lines.push(theme.fg("muted", "Trigger:"));
-			lines.push(theme.fg("dim", theme.boxSharp.horizontal.repeat(Math.min(width - 2, 40))));
+			lines.push(renderSeparator(width));
 			lines.push(`  ${theme.fg("accent", ext.trigger)}`);
 			lines.push("");
 		}

--- a/packages/coding-agent/test/modes/components/extension-inspector-width.test.ts
+++ b/packages/coding-agent/test/modes/components/extension-inspector-width.test.ts
@@ -1,0 +1,48 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { InspectorPanel } from "../../../src/modes/components/extensions/inspector-panel";
+import type { Extension } from "../../../src/modes/components/extensions/types";
+import * as themeModule from "../../../src/modes/theme/theme";
+
+const previews: ReadonlyArray<{
+	kind: Extension["kind"];
+	heading: string;
+	raw: unknown;
+	trigger?: string;
+}> = [
+	{ kind: "context-file", heading: "Preview:", raw: { content: "context" } },
+	{ kind: "tool", heading: "Arguments:", raw: { parameters: { properties: {} } } },
+	{ kind: "skill", heading: "Instruction:", raw: { prompt: "instruction" } },
+	{ kind: "mcp", heading: "Connection:", raw: { transport: "stdio" } },
+	{ kind: "slash-command", heading: "Trigger:", raw: null, trigger: "/test" },
+];
+
+describe("InspectorPanel narrow widths", () => {
+	beforeAll(async () => {
+		await themeModule.initTheme(false, undefined, undefined, "red-claw", "blue-crab");
+	});
+
+	it("renders every preview separator when the right pane is narrower than its padding", () => {
+		for (const preview of previews) {
+			const extension: Extension = {
+				id: `${preview.kind}:test`,
+				kind: preview.kind,
+				name: "test",
+				displayName: "Test",
+				path: "/tmp/test",
+				source: { provider: "native", providerName: "Native", level: "native" },
+				state: "active",
+				raw: preview.raw,
+				...(preview.trigger ? { trigger: preview.trigger } : {}),
+			};
+			const panel = new InspectorPanel();
+			panel.setExtension(extension);
+
+			for (const width of [0, 1]) {
+				const lines = panel.render(width).map(line => Bun.stripANSI(line));
+				const headingIndex = lines.indexOf(preview.heading);
+				expect(headingIndex).toBeGreaterThanOrEqual(0);
+				expect(lines[headingIndex + 1]).toBe("");
+			}
+		}
+	});
+});


### PR DESCRIPTION
## What

- Clamp Extension Control Center preview separators to a non-negative width before rendering.
- Route context-file, tool, skill, MCP, and trigger previews through the same bounded separator.
- Add a regression covering right-pane widths of zero and one for every preview path.

## Why

`TwoColumnBody` can assign the inspector a zero- or one-column right pane when the terminal becomes extremely narrow. The inspector previously passed `width - 2` directly through `Math.min(...)` to `String.repeat()`, producing a negative repeat count and crashing the Extension Control Center with a `RangeError`.

A current open-PR file census found no overlap with the changed source or test paths.

## Testing

- `bun test packages/coding-agent/test/modes/components/extension-inspector-width.test.ts` — 1 pass, 20 assertions
- `bun --cwd=packages/coding-agent run check`
- `bun run ci:check:full`
- `git diff --check upstream/dev...HEAD`
- `bun check` completed all 576 SDK baseline row receipts with zero test failures, then stopped at the unchanged current-`dev` Telegram baseline manifest drift: the generated baseline includes `notifications-telegram-daemon-staging-temp-leak.test.ts` and `notifications-topic-settle-fence-epoch.test.ts`, while the committed baseline omits them. This branch does not touch either test or the manifest; current `dev` hosted Dev CI is green: https://github.com/Yeachan-Heo/gajae-code/actions/runs/30748682583

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:cea0d13dd55dea2731fc7d2c9c473c1d57bf6972 reviewer:human evidence:needs-independent-review
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (blocked by the unchanged current-`dev` manifest drift described above)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
