### PR TITLE
fix(coding-agent): preserve literal prompt placeholders

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - The Extension Control Center inspector no longer crashes when a narrow two-column layout leaves its preview pane fewer than two columns wide.
+- Prompt-template positional arguments now preserve literal `$@` and `$ARGUMENTS` text instead of recursively expanding it during placeholder substitution.
 
 ## [0.12.8] - 2026-08-02
 ### Added

--- a/packages/coding-agent/src/utils/command-args.ts
+++ b/packages/coding-agent/src/utils/command-args.ts
@@ -39,38 +39,27 @@ export function parseCommandArgs(argsString: string): string[] {
  * containing patterns like $1, $@, or $ARGUMENTS are NOT recursively substituted.
  */
 export function substituteArgs(content: string, args: string[]): string {
-	let result = content;
-
-	// Replace $1, $2, etc. with positional args FIRST (before wildcards)
-	// This prevents wildcard replacement values containing $<digit> patterns from being re-substituted
-	result = result.replace(/\$(\d+)/g, (_, num) => {
-		const index = parseInt(num, 10) - 1;
-		return args[index] ?? "";
-	});
-
-	result = result.replace(/\$@\[(\d+)(?::(\d*)?)?\]/g, (_, startRaw: string, lengthRaw?: string) => {
-		const start = Number.parseInt(startRaw, 10);
-		if (!Number.isFinite(start) || start < 1) return "";
-		const startIndex = start - 1;
-		if (startIndex >= args.length) return "";
-
-		if (lengthRaw === undefined || lengthRaw === "") {
-			return args.slice(startIndex).join(" ");
-		}
-
-		const length = Number.parseInt(lengthRaw, 10);
-		if (!Number.isFinite(length) || length <= 0) return "";
-		return args.slice(startIndex, startIndex + length).join(" ");
-	});
-
-	// Pre-compute all args joined (optimization)
 	const allArgs = args.join(" ");
+	return content.replace(
+		/\$@\[(\d+)(?::(\d*)?)?\]|\$ARGUMENTS|\$@|\$(\d+)/g,
+		(_, startRaw: string | undefined, lengthRaw: string | undefined, positionRaw: string | undefined) => {
+			if (positionRaw !== undefined) {
+				return args[Number.parseInt(positionRaw, 10) - 1] ?? "";
+			}
+			if (startRaw === undefined) return allArgs;
 
-	// Replace $ARGUMENTS with all args joined (new syntax, aligns with Anthropic model, OpenAI code backend, OpenCode)
-	result = result.replaceAll("$ARGUMENTS", allArgs);
+			const start = Number.parseInt(startRaw, 10);
+			if (!Number.isFinite(start) || start < 1) return "";
+			const startIndex = start - 1;
+			if (startIndex >= args.length) return "";
 
-	// Replace $@ with all args joined (existing syntax)
-	result = result.replaceAll("$@", allArgs);
+			if (lengthRaw === undefined || lengthRaw === "") {
+				return args.slice(startIndex).join(" ");
+			}
 
-	return result;
+			const length = Number.parseInt(lengthRaw, 10);
+			if (!Number.isFinite(length) || length <= 0) return "";
+			return args.slice(startIndex, startIndex + length).join(" ");
+		},
+	);
 }

--- a/packages/coding-agent/test/prompt-templates.test.ts
+++ b/packages/coding-agent/test/prompt-templates.test.ts
@@ -20,6 +20,11 @@ import hashlineDescription from "../src/prompts/tools/hashline.md" with { type: 
 // ============================================================================
 
 describe("substituteArgs", () => {
+	test("does not recursively expand placeholders from positional argument values", () => {
+		expect(substituteArgs("$1", ["$ARGUMENTS", "tail"])).toBe("$ARGUMENTS");
+		expect(substituteArgs("$1", ["$@", "tail"])).toBe("$@");
+	});
+
 	test("should support $@ slicing with start offset", () => {
 		expect(substituteArgs("Test: $@[2]", ["a", "b", "c"])).toBe("Test: b c");
 	});


### PR DESCRIPTION
## What

- Substitute supported prompt placeholders in one pass.
- Preserve placeholder-like text supplied as a positional argument.
- Add regression coverage for literal `$ARGUMENTS` and `$@` values.

## Why

The previous sequential replacements could reprocess text inserted by `$1`. An argument value such as `$ARGUMENTS` was therefore changed into unrelated trailing arguments even though argument values are documented as non-recursive.

## Testing

- `bun test packages/coding-agent/test/prompt-templates.test.ts` (65 pass)
- `bun --cwd=packages/coding-agent run check`
- `bun run ci:check:full`
- `bun check` completed all 576 SDK manifest receipts, then hit the current `dev` Telegram baseline mismatch (two missing test commands unrelated to this diff).

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:dc22c940cbbd022d30720eb4e17e5af419f3e203 reviewer:human evidence:needs-independent-review
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
