### PR TITLE
fix(dev): require requested link target

### DIFF
--- a/scripts/dev-link.test.ts
+++ b/scripts/dev-link.test.ts
@@ -265,6 +265,35 @@ describe.skipIf(process.platform === "win32")("dev:link Windows Bun workspace sh
 });
 
 describe("dev:link", () => {
+	test.skipIf(process.platform === "win32")("fails when --binary is shadowed by this checkout's source", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-dev-link-mode-shadow-"));
+		tempRoots.push(root);
+		const fixtureScript = path.join(root, "scripts", "dev-link.ts");
+		const source = path.join(root, "packages", "coding-agent", "src", "cli.ts");
+		const binary = path.join(root, "packages", "coding-agent", "dist", "gjc");
+		const shadowDir = path.join(root, "shadow-bin");
+		const targetDir = path.join(root, "managed-bin");
+		const smokeFixture = '#!/bin/sh\nif [ "$1" = "--smoke-test" ]; then echo "smoke-test: ok"; fi\n';
+
+		await fs.mkdir(path.dirname(fixtureScript), { recursive: true });
+		await Bun.write(fixtureScript, Bun.file(path.join(import.meta.dir, "dev-link.ts")));
+		await makeExecutable(source, smokeFixture);
+		await makeExecutable(binary, smokeFixture);
+		await fs.mkdir(shadowDir, { recursive: true });
+		await fs.symlink(source, path.join(shadowDir, "gjc"));
+
+		const result = Bun.spawnSync([process.execPath, fixtureScript, "--binary"], {
+			cwd: root,
+			env: { ...process.env, GJC_DEV_LINK_DIR: targetDir, PATH: `${shadowDir}:${targetDir}` },
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr.toString()).toContain("still resolves to a different command earlier on PATH");
+		expect(result.stderr.toString()).toContain(path.join(shadowDir, "gjc"));
+	});
+
 	test.skipIf(process.platform === "win32")("removes Bun global links that resolve to this checkout wrapper", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-dev-link-bun-shadow-"));
 		tempRoots.push(root);

--- a/scripts/dev-link.ts
+++ b/scripts/dev-link.ts
@@ -304,13 +304,13 @@ function isApprovedSource(winner: GjcHit): boolean {
 	return isApprovedWorkspaceSource(winner.file, winner.real);
 }
 
-function assertResolvedGjcIsSource(winner: GjcHit | undefined): void {
-	if (!winner || isApprovedSource(winner)) return;
+function assertResolvedGjcMatchesTarget(winner: GjcHit | undefined, expectedReal: string): void {
+	if (!winner || winner.real === expectedReal) return;
 	console.error("");
 	console.error("✗ Linked, but `gjc` still resolves to a different command earlier on PATH.");
 	console.error(`  Resolved: ${winner.file}`);
 	console.error(`       -> ${describe(winner.real)}`);
-	console.error(`  Expected source: ${cliSourceReal}`);
+	console.error(`  Expected target: ${expectedReal}`);
 	console.error(`  The managed link was created at: ${path.join(targetDir, "gjc")}`);
 	console.error("  Move the managed link directory earlier on PATH or remove the shadowing command.");
 	process.exit(1);
@@ -423,7 +423,7 @@ function link(binary: boolean): never {
 		console.warn(`    Remove it: rm "${hit.file}"`);
 	}
 	const winner = findGjcOnPath()[0];
-	assertResolvedGjcIsSource(winner);
+	assertResolvedGjcMatchesTarget(winner, linkSourceReal);
 	const smoke = smokeTest(winner?.file ?? target);
 	if (!smoke.ok) {
 		console.error("");


### PR DESCRIPTION
## What

- Validate that the `gjc` command resolved from `PATH` matches the mode requested by `dev:link`.
- Add a black-box regression test for a source command shadowing a newly linked `--binary` target.

## Why

The post-link check accepted either this checkout's source or binary. As a result, `dev:link --binary` could report success while an earlier source command on `PATH` remained active.

## Testing

- `bun test scripts/dev-link.test.ts` (12 pass)
- `bun run check:tools`
- `bun run ci:check:full`
- `bun check` on the shared current-`dev` tree completed all 576 SDK manifest receipts, then hit the existing Telegram baseline mismatch (two missing test commands unrelated to this diff).

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:bc42b2e90f34355a4818a3c22c28f16935ef1169 reviewer:human evidence:needs-independent-review
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
