### PR TITLE
fix(coding-agent): clarify missing Windows multiplexer

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - The Extension Control Center inspector no longer crashes when a narrow two-column layout leaves its preview pane fewer than two columns wide.
 - Prompt-template positional arguments now preserve literal `$@` and `$ARGUMENTS` text instead of recursively expanding it during placeholder substitution.
+- Native Windows session and GC commands now report the searched `psmux` / `pmux` / `tmux` provider set when no compatible multiplexer is available instead of leaking a literal `tmux` spawn error (#3688).
 
 ## [0.12.8] - 2026-08-02
 ### Added

--- a/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
@@ -228,7 +228,7 @@ function runTmux(
 			);
 	}
 	if (result.exitCode === 0) return result.stdout?.toString() ?? "";
-	throw new Error(result.stderr?.toString().trim() || `tmux ${args.join(" ")} failed`);
+	throw new Error(result.stderr?.toString().trim() || `${tmuxCommand} ${args.join(" ")} failed`);
 }
 function normalizeExactTmuxTarget(sessionTarget: string, env: NodeJS.ProcessEnv, kind: "session" | "option"): string {
 	if (sessionTarget.startsWith("$")) return sessionTarget;
@@ -406,6 +406,13 @@ function psmuxAuthorityEnvironments(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv[]
 			});
 			if (authorities.length > 0)
 				return authorities.map(authority => environmentForProviderAuthority(env, authority));
+		}
+		if (!ambient.viaExplicitOverride && !ambientAvailable) {
+			throw new Error(
+				"gjc_tmux_provider_unavailable — GJC searched for psmux, pmux, and tmux on PATH. " +
+					"Install psmux from https://github.com/psmux/psmux for native Windows support, use WSL with real tmux, " +
+					"or set GJC_TMUX_COMMAND (and GJC_PSMUX_COMMAND when selecting a psmux compatibility alias).",
+			);
 		}
 	}
 	if (ambient.isPsmux) throw new Error("gjc_tmux_provider_authority_unavailable");

--- a/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
@@ -172,10 +172,25 @@ describe("GJC tmux session management", () => {
 
 	it("returns an empty list when tmux has no server", () => {
 		spyOn(Bun, "spawnSync").mockReturnValue(spawnResult(1, "", "no server running on /tmp/tmux"));
-		__setBinaryResolverForTests(() => null);
+		__setBinaryResolverForTests(candidate => (candidate === "tmux" ? "C:\\tools\\tmux.exe" : null));
+		spyOn(Bun, "which").mockReturnValue("C:\\tools\\tmux.exe");
 		clearPsmuxDetectionCache();
 
 		expect(listGjcTmuxSessions()).toEqual([]);
+	});
+
+	it("reports provider-aware diagnostics before spawning when Windows has no multiplexer", async () => {
+		const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-tmux-sessions-test-"));
+		fixtureDirectories.push(stateDir);
+		__setTmuxProviderAuthorityPlatformForTests("win32");
+		__setBinaryResolverForTests(() => null);
+		spyOn(Bun, "which").mockReturnValue(null);
+		const spawnSyncSpy = spyOn(Bun, "spawnSync");
+
+		expect(() => listGjcTmuxSessions({ GJC_TMUX_OWNER_STATE_DIR: stateDir })).toThrow(
+			"gjc_tmux_provider_unavailable — GJC searched for psmux, pmux, and tmux on PATH.",
+		);
+		expect(spawnSyncSpy).not.toHaveBeenCalled();
 	});
 
 	it("guards status and remove to GJC-managed sessions", () => {

--- a/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn, vi } from "bun:test";
 import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
@@ -122,6 +122,11 @@ function installPsmuxAuthorityFixture(
 }
 
 describe("GJC tmux session management", () => {
+	beforeEach(() => {
+		__setBinaryResolverForTests(candidate => (candidate === "tmux" ? "C:\\tools\\tmux.exe" : null));
+		__setExecutableIdentityResolverForTests(executablePath => `identity:${executablePath}`);
+		spyOn(Bun, "which").mockReturnValue("C:\\tools\\tmux.exe");
+	});
 	afterEach(async () => {
 		vi.restoreAllMocks();
 		__setCreateOwnerIsolationForTests(null);
@@ -172,8 +177,6 @@ describe("GJC tmux session management", () => {
 
 	it("returns an empty list when tmux has no server", () => {
 		spyOn(Bun, "spawnSync").mockReturnValue(spawnResult(1, "", "no server running on /tmp/tmux"));
-		__setBinaryResolverForTests(candidate => (candidate === "tmux" ? "C:\\tools\\tmux.exe" : null));
-		spyOn(Bun, "which").mockReturnValue("C:\\tools\\tmux.exe");
 		clearPsmuxDetectionCache();
 
 		expect(listGjcTmuxSessions()).toEqual([]);
@@ -590,6 +593,7 @@ describe("GJC tmux session management", () => {
 		const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-tmux-sessions-test-"));
 		fixtureDirectories.push(stateDir);
 		__setBinaryResolverForTests(candidate => (candidate === "psmux" ? "/fake/psmux" : null));
+		__setExecutableIdentityResolverForTests(() => null);
 		try {
 			const calls: string[][] = [];
 			injectSafeAbsentToSafeOwnerProof();


### PR DESCRIPTION
## Summary
- stop native Windows session/GC discovery before a misleading literal `tmux` spawn when `psmux`, `pmux`, and `tmux` are all unavailable
- preserve the selected provider command in empty-stderr fallback errors
- cover the no-provider boundary without weakening persisted psmux authority discovery

Closes #3688.

## Commit structure
1. runtime provider diagnostic
2. focused regression coverage
3. changelog entry
4. platform-independent tmux test fixtures

The source, regression, release note, and fixture hardening are intentionally separate for review and selective reversion.

## Verification
- `bun --cwd=packages/coding-agent run check`
- `bun test packages/coding-agent/test/gjc-runtime/psmux-detect.test.ts` (45 pass)
- focused `tmux-sessions.test.ts` provider/no-server/identity cases (3 pass)

## Local platform note
The full tmux session suite reached 34/36 on native Windows; the remaining real-child SIGTERM assertion is platform-specific and unrelated to this patch. The changed and adjacent cases pass, and CI provides the canonical full-suite lane.