### PR TITLE
fix(slack): form-encode Web API requests

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 - A failed `notify setup` no longer reports "Unable to persist and activate Telegram notification settings" when the durable configuration already carries the attempted bot token, chat id, and enabled state. The wording now follows the stored configuration, so it can no longer contradict a follow-up `notify status`; an operator who reads the failure as "nothing was saved" would otherwise leave Telegram armed for a token another poller may own. A commit that was entered and then failed while the stored configuration is also unreadable is reported as undecided, pointing at `notify status`, instead of guessing either outcome (#3761).
 - Continuing a large managed session on Darwin now batches stale OpenAI Responses replay-metadata patches into one transcript append instead of performing one identity-verified whole-file replacement per patch. Interactive startup also renders before exact MCP connection and explicit `--mpreset` activation, gates every provider turn until both are ready, and refreshes models online only after the UI is usable, preventing `gjc -c` from remaining at `GJC warming workspace` with sustained CPU, multi-gigabyte RSS growth, or avoidable network waits (#3793).
+- Slack Web API requests now use form encoding instead of JSON, preventing thread reconciliation through `conversations.replies` from failing with `invalid_arguments`.
 
 ## [0.12.11] - 2026-08-03
 

--- a/packages/coding-agent/src/sdk/bus/slack-live-provider.ts
+++ b/packages/coding-agent/src/sdk/bus/slack-live-provider.ts
@@ -98,6 +98,17 @@ function socketFromGlobal(url: string): SlackWebSocket {
 }
 
 /**
+ * Slack's Web API rejects JSON bodies for read methods such as conversations.replies
+ * with `invalid_arguments`, so every call is encoded as a form body with undefined
+ * parameters omitted rather than serialized.
+ */
+function formBody(body: Record<string, string | undefined>): string {
+	const parameters = new URLSearchParams();
+	for (const [key, value] of Object.entries(body)) if (value !== undefined) parameters.set(key, value);
+	return parameters.toString();
+}
+
+/**
  * Production Socket Mode and Web API client. It keeps all connection state in
  * memory and deliberately never maintains a Slack cursor.
  */
@@ -385,8 +396,11 @@ export class SlackLiveProvider implements SlackProviderClient, SlackDiagnosticPr
 			try {
 				response = await this.#fetch(`${SLACK_API}/${operation}`, {
 					method: "POST",
-					headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json; charset=utf-8" },
-					body: JSON.stringify(body),
+					headers: {
+						Authorization: `Bearer ${token}`,
+						"Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+					},
+					body: formBody(body),
 					signal,
 				});
 			} catch {

--- a/packages/coding-agent/test/sdk-slack-live-provider.test.ts
+++ b/packages/coding-agent/test/sdk-slack-live-provider.test.ts
@@ -167,6 +167,33 @@ describe("SlackLiveProvider fake Socket Mode protocol", () => {
 		expect(fixture.requests[0]?.init?.body).toContain("client_msg_id");
 	});
 
+	it("sends Web API calls as Slack-compatible form encoding and omits undefined values", async () => {
+		const fixture = setup([
+			response({ ok: true, messages: [] }),
+			response({ ok: true, messages: [{ ts: "2.0", client_msg_id: "client-1" }] }),
+		]);
+		await expect(
+			fixture.provider.findMessageByClientMsgId({ channel: "C1", threadTs: "0.0", clientMsgId: "client-1" }),
+		).resolves.toEqual({ channel: "C1", ts: "2.0", client_msg_id: "client-1" });
+		const replies = fixture.requests[1];
+		expect(replies?.url).toBe("https://slack.com/api/conversations.replies");
+		expect(new Headers(replies?.init?.headers).get("content-type")).toBe(
+			"application/x-www-form-urlencoded; charset=utf-8",
+		);
+		expect([...new URLSearchParams(String(replies?.init?.body))]).toEqual([
+			["channel", "C1"],
+			["ts", "0.0"],
+		]);
+
+		const posted = setup([response({ ok: true, channel: "C1", ts: "1.0", client_msg_id: "client-1" })]);
+		await posted.provider.postMessage({ channel: "C1", text: "hello world", clientMsgId: "client-1" });
+		expect([...new URLSearchParams(String(posted.requests[0]?.init?.body))]).toEqual([
+			["channel", "C1"],
+			["text", "hello world"],
+			["client_msg_id", "client-1"],
+		]);
+	});
+
 	it("bounds rate-limit retry and exposes no credential in typed errors", async () => {
 		const fixture = setup([
 			response({ ok: false }, 429, { "retry-after": "120" }),


### PR DESCRIPTION
## What

- Serialize Slack Web API POST parameters with `URLSearchParams` form encoding and omit `undefined` values.
- Add regression coverage for `conversations.replies`, `chat.postMessage`, and optional `thread_ts` omission.
- Document the user-facing fix under `packages/coding-agent/CHANGELOG.md` → `Unreleased / Fixed`.

## Why

Slack's `conversations.replies` endpoint returns `invalid_arguments` for the JSON request body used by the live provider, while the equivalent form-encoded request succeeds. This prevents thread reconciliation during Slack notification startup.

## Testing

- [x] `bun test packages/coding-agent/test/sdk-slack-live-provider.test.ts packages/coding-agent/test/sdk-slack-daemon.test.ts` — 60 pass, 221 assertions
- [x] `bun --cwd=packages/coding-agent run check`
- [x] `bun run ci:test:smoke`
- [ ] `bun run check` — all adapter receipts completed, then the Telegram baseline manifest reported two missing commands; reproduced unchanged on pristine `upstream/dev` and still present after rebasing to `caeeecbc` with `bun scripts/generate-telegram-baseline-manifest.ts --check`:
  - `notifications-telegram-daemon-staging-temp-leak.test.ts`
  - `notifications-topic-settle-fence-epoch.test.ts`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:93ce077c585a91bf61c378f16fdffc00d74aad0bd5024409037c292973284bc7 reviewer:critic evidence:local-focused-checks
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
