### PR TITLE
fix(composer): recover from bash policy blocks

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Composer repository-file shell policy rejections now receive one bounded, tool-enabled recovery turn without persisting the synthetic instruction. Generic loops retain their repository tools with `toolChoice: auto`; Cursor remote turns continue only when native tools did not already recover, queued user follow-ups take priority, and a second policy block terminates instead of looping. Existing malformed-tool recovery remains tool-free and does not consume dynamic tool-choice state.
+
 ## [0.12.8] - 2026-08-02
 
 ## [0.12.7] - 2026-07-31

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -20,6 +20,10 @@ import {
 	validateToolArguments,
 	zodToWireSchema,
 } from "@gajae-code/ai";
+import {
+	COMPOSER_BASH_POLICY_RECOVERY_PROMPT,
+	isComposerBashPolicyBlockedError,
+} from "@gajae-code/ai/providers/composer-discipline";
 import { isInvalidPromptError, neutralizeReservedControlTokens } from "@gajae-code/ai/utils";
 import { sanitizeText } from "@gajae-code/utils";
 import type { AttemptScope } from "./attempt-scope";
@@ -123,6 +127,15 @@ const standaloneOwnershipStates = new WeakMap<StandaloneRunOwnership, Standalone
  * bounded too.
  */
 const MAX_CONSECUTIVE_MALFORMED_TURNS = 5;
+
+function isComposerBashPolicyBlockedToolResult(result: ToolResultMessage): boolean {
+	return (
+		result.isError &&
+		result.toolName === "bash" &&
+		result.content.some(content => content.type === "text" && isComposerBashPolicyBlockedError(content.text))
+	);
+}
+
 function managedContextOverflow(message: AssistantMessage, config: AgentLoopConfig): boolean {
 	const transportFailure = managedTransportFailure(message);
 	// Managed empty-stop responses may be repaired by the managed shell below; only
@@ -1407,12 +1420,16 @@ async function runLoopBody(
 	// `invalid_prompt` circuit breaker below.
 	let invalidPromptRepairAttempted = false;
 	let previousMalformedToolSignatures = new Set<string>();
-	const recoveryState: {
-		pending: boolean;
-		inserted: boolean;
-		syntheticMessage?: UserMessage;
-	} = { pending: false, inserted: false };
+	type SyntheticRecoveryKind = "malformed-tool-call" | "composer-bash-policy" | "provider";
+	let pendingRecovery:
+		| {
+				kind: SyntheticRecoveryKind;
+				inserted: boolean;
+				syntheticMessage?: UserMessage;
+		  }
+		| undefined;
 	let malformedToolRecoveryAttempted = false;
+	let composerBashPolicyRecoveryAttempted = false;
 	// Deterministic terminal circuit breaker for argument-validation loops.
 	//
 	// Counts CONSECUTIVE turns whose tool calls were all malformed, regardless of
@@ -1507,6 +1524,8 @@ async function runLoopBody(
 			let recovered: HarmonyRecoveredToolCall | undefined;
 			let message: AssistantMessage;
 			const attemptTransaction = transaction;
+			const recoveryAttempt = pendingRecovery;
+			const wasMalformedToolRecoveryAttempt = recoveryAttempt?.kind === "malformed-tool-call";
 			try {
 				const attemptConfig = attemptTransaction
 					? {
@@ -1515,14 +1534,22 @@ async function runLoopBody(
 								attemptTransaction.stageAssistantMessageEvent(partial, event),
 						}
 					: config;
-				if (recoveryState.pending && !recoveryState.inserted) {
-					recoveryState.syntheticMessage = {
-						role: "user",
-						content: repeatedToolFailureRecoveryPrompt,
-						synthetic: true,
-						timestamp: Date.now(),
-					};
-					recoveryState.inserted = true;
+				if (recoveryAttempt && !recoveryAttempt.inserted) {
+					const recoveryContent =
+						recoveryAttempt.kind === "composer-bash-policy"
+							? COMPOSER_BASH_POLICY_RECOVERY_PROMPT
+							: recoveryAttempt.kind === "malformed-tool-call"
+								? repeatedToolFailureRecoveryPrompt
+								: undefined;
+					if (recoveryContent) {
+						recoveryAttempt.syntheticMessage = {
+							role: "user",
+							content: recoveryContent,
+							synthetic: true,
+							timestamp: Date.now(),
+						};
+					}
+					recoveryAttempt.inserted = true;
 				}
 				message = await streamAssistantResponse(
 					currentContext,
@@ -1535,8 +1562,12 @@ async function runLoopBody(
 					attemptScope,
 					streamFn,
 					harmonyRetryAttempt,
-					recoveryState.pending && recoveryState.syntheticMessage
-						? { syntheticMessage: recoveryState.syntheticMessage }
+					recoveryAttempt?.syntheticMessage
+						? {
+								syntheticMessage: recoveryAttempt.syntheticMessage,
+								disableTools: wasMalformedToolRecoveryAttempt,
+								forceAutoToolChoice: !wasMalformedToolRecoveryAttempt,
+							}
 						: undefined,
 				);
 				const detection = detectHarmonyLeakInAssistantMessage(message);
@@ -1708,8 +1739,6 @@ async function runLoopBody(
 			if (config.fallbackManaged && message.stopReason !== "error" && message.stopReason !== "aborted") {
 				await config.onManagedAttemptAccepted?.();
 			}
-			const wasRecoveryAttempt = recoveryState.pending;
-
 			if (message.stopReason === "error" || message.stopReason === "aborted") {
 				// Create placeholder tool results for any tool calls in the aborted message
 				// This maintains the tool_use/tool_result pairing that the API requires
@@ -1749,8 +1778,9 @@ async function runLoopBody(
 
 			const toolResults: ToolResultMessage[] = [];
 			let repeatedMalformedToolCall = false;
+			let sawComposerBashPolicyBlock = false;
 			if (hasMoreToolCalls) {
-				if (wasRecoveryAttempt) {
+				if (wasMalformedToolRecoveryAttempt) {
 					for (const toolCall of toolCalls) {
 						const result = createAbortedToolResult(
 							toolCall,
@@ -1781,6 +1811,7 @@ async function runLoopBody(
 
 					toolResults.push(...executionResult.toolResults);
 					steeringMessagesFromExecution = executionResult.steeringMessages;
+					sawComposerBashPolicyBlock = executionResult.toolResults.some(isComposerBashPolicyBlockedToolResult);
 
 					const malformedSignatures = executionResult.malformedToolCallSignatures;
 					const allToolCallsMalformed =
@@ -1804,10 +1835,8 @@ async function runLoopBody(
 				}
 			}
 
-			if (wasRecoveryAttempt) {
-				recoveryState.pending = false;
-				recoveryState.inserted = false;
-				recoveryState.syntheticMessage = undefined;
+			if (recoveryAttempt) {
+				pendingRecovery = undefined;
 			}
 
 			stream.push({ type: "turn_end", message, toolResults, scope: attemptScope });
@@ -1828,10 +1857,26 @@ async function runLoopBody(
 				stream.end(newMessages);
 				return;
 			}
-			if (repeatedMalformedToolCall && !malformedToolRecoveryAttempted) {
-				recoveryState.pending = true;
-				recoveryState.inserted = false;
-				recoveryState.syntheticMessage = undefined;
+			if (sawComposerBashPolicyBlock && !composerBashPolicyRecoveryAttempted) {
+				pendingRecovery = { kind: "composer-bash-policy", inserted: false };
+				composerBashPolicyRecoveryAttempted = true;
+			} else if (sawComposerBashPolicyBlock) {
+				message.stopReason = "error";
+				const recoveryLimitMessage =
+					"Composer bash policy blocked repository file I/O again after its one automatic recovery turn. Continue with dedicated repository tools.";
+				message.errorMessage = message.errorMessage
+					? `${message.errorMessage} | ${recoveryLimitMessage}`
+					: recoveryLimitMessage;
+				publishAgentEnd(
+					stream,
+					config,
+					buildAgentEndEvent(newMessages, telemetry, stepCounter.count, "completed", attemptScope),
+					attemptScope,
+				);
+				stream.end(newMessages);
+				return;
+			} else if (repeatedMalformedToolCall && !malformedToolRecoveryAttempted) {
+				pendingRecovery = { kind: "malformed-tool-call", inserted: false };
 				malformedToolRecoveryAttempted = true;
 			} else if (consecutiveMalformedTurns >= MAX_CONSECUTIVE_MALFORMED_TURNS) {
 				// Deterministic terminal circuit breaker. The one-shot recovery turn
@@ -1868,10 +1913,21 @@ async function runLoopBody(
 			stream.end(newMessages);
 			return;
 		}
+		// Poll the consume-on-read recovery candidate before follow-ups so a real
+		// user message can supersede it without letting the stale recovery resurface
+		// after that follow-up turn.
+		const syntheticRecoveryMessage = await config.getSyntheticRecoveryMessage?.();
 		const followUpMessages = (await config.getFollowUpMessages?.()) || [];
 		if (followUpMessages.length > 0) {
 			// Set as pending so inner loop processes them
 			pendingMessages = followUpMessages;
+			continue;
+		}
+		if (syntheticRecoveryMessage) {
+			// Provider-side tool protocols (such as Cursor) can finish their remote
+			// turn after a local policy rejection. Continue once without committing
+			// the recovery instruction to durable history.
+			pendingRecovery = { kind: "provider", inserted: true, syntheticMessage: syntheticRecoveryMessage };
 			continue;
 		}
 
@@ -1920,7 +1976,11 @@ async function streamAssistantResponse(
 	scope?: AttemptScope,
 	streamFn?: StreamFn,
 	harmonyRetryAttempt = 0,
-	recoveryMode?: { syntheticMessage: UserMessage },
+	recoveryMode?: {
+		syntheticMessage: UserMessage;
+		disableTools?: boolean;
+		forceAutoToolChoice?: boolean;
+	},
 ): Promise<AssistantMessage> {
 	// Apply context transform if configured (AgentMessage[] → AgentMessage[])
 	let messages = context.messages;
@@ -1951,7 +2011,11 @@ async function streamAssistantResponse(
 				await config.convertToLlm([recoveryMode.syntheticMessage]),
 				config.model,
 			);
-			llmContext = { ...llmContext, messages: [...llmContext.messages, ...syntheticMessages], tools: [] };
+			llmContext = {
+				...llmContext,
+				messages: [...llmContext.messages, ...syntheticMessages],
+				tools: recoveryMode.disableTools ? [] : llmContext.tools,
+			};
 		} else {
 			llmContext = {
 				...llmContext,
@@ -1959,7 +2023,7 @@ async function streamAssistantResponse(
 					await config.convertToLlm([...messages, recoveryMode.syntheticMessage]),
 					config.model,
 				),
-				tools: [],
+				tools: recoveryMode.disableTools ? [] : llmContext.tools,
 			};
 		}
 	}
@@ -1977,6 +2041,8 @@ async function streamAssistantResponse(
 
 	const resolvedMetadata = config.metadataResolver ? config.metadataResolver(config.model.provider) : config.metadata;
 
+	// Synthetic recovery requests choose their tool mode explicitly below and
+	// must never consume a queued dynamic choice intended for an ordinary turn.
 	const dynamicToolChoice = recoveryMode ? undefined : config.getToolChoice?.();
 	const dynamicReasoning = config.getReasoning?.();
 	const harmonyMitigationEnabled = isHarmonyLeakMitigationTarget(config.model);
@@ -1994,7 +2060,11 @@ async function streamAssistantResponse(
 				: AbortSignal.any(requestSignals);
 	const effectiveTemperature =
 		harmonyRetryAttempt > 0 && config.temperature !== undefined ? config.temperature + 0.05 : config.temperature;
-	const effectiveToolChoice = recoveryMode ? "none" : (dynamicToolChoice ?? config.toolChoice);
+	const effectiveToolChoice = recoveryMode?.disableTools
+		? "none"
+		: recoveryMode?.forceAutoToolChoice
+			? "auto"
+			: (dynamicToolChoice ?? config.toolChoice);
 	const effectiveReasoning = dynamicReasoning ?? config.reasoning;
 
 	const chatStepNumber = stepCounter.count;

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -22,7 +22,7 @@ import {
 } from "@gajae-code/ai";
 import {
 	COMPOSER_BASH_POLICY_RECOVERY_PROMPT,
-	isComposerBashPolicyBlockedError,
+	isCurrentComposerBashPolicyBlockedError,
 } from "@gajae-code/ai/providers/composer-discipline";
 import { isInvalidPromptError, neutralizeReservedControlTokens } from "@gajae-code/ai/utils";
 import { sanitizeText } from "@gajae-code/utils";
@@ -132,7 +132,7 @@ function isComposerBashPolicyBlockedToolResult(result: ToolResultMessage): boole
 	return (
 		result.isError &&
 		result.toolName === "bash" &&
-		result.content.some(content => content.type === "text" && isComposerBashPolicyBlockedError(content.text))
+		result.content.some(content => content.type === "text" && isCurrentComposerBashPolicyBlockedError(content.text))
 	);
 }
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -22,7 +22,7 @@ import {
 } from "@gajae-code/ai";
 import {
 	CURSOR_COMPOSER_BASH_POLICY_RECOVERY_PROMPT,
-	isComposerBashPolicyBlockedError,
+	isCurrentComposerBashPolicyBlockedError,
 } from "@gajae-code/ai/providers/composer-discipline";
 import { extractHttpStatusFromError } from "@gajae-code/utils";
 import { agentLoop, agentLoopContinue } from "./agent-loop";
@@ -77,7 +77,7 @@ function isCursorComposerBashPolicyBlockedResult(message: ToolResultMessage): bo
 	return (
 		message.isError &&
 		message.toolName === "bash" &&
-		message.content.some(content => content.type === "text" && isComposerBashPolicyBlockedError(content.text))
+		message.content.some(content => content.type === "text" && isCurrentComposerBashPolicyBlockedError(content.text))
 	);
 }
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -20,6 +20,10 @@ import {
 	type ToolChoice,
 	type ToolResultMessage,
 } from "@gajae-code/ai";
+import {
+	CURSOR_COMPOSER_BASH_POLICY_RECOVERY_PROMPT,
+	isComposerBashPolicyBlockedError,
+} from "@gajae-code/ai/providers/composer-discipline";
 import { extractHttpStatusFromError } from "@gajae-code/utils";
 import { agentLoop, agentLoopContinue } from "./agent-loop";
 import type { AppendOnlyContextManager } from "./append-only-context";
@@ -65,6 +69,20 @@ function assertUserImagePlaceholdersHavePayload(messages: readonly AgentMessage[
 			.join("\n");
 		assertImagePlaceholdersHavePayload(text, content);
 	}
+}
+
+const CURSOR_NATIVE_REPOSITORY_RECOVERY_TOOL_NAMES = new Set(["read", "grep", "search", "find", "write", "delete"]);
+
+function isCursorComposerBashPolicyBlockedResult(message: ToolResultMessage): boolean {
+	return (
+		message.isError &&
+		message.toolName === "bash" &&
+		message.content.some(content => content.type === "text" && isComposerBashPolicyBlockedError(content.text))
+	);
+}
+
+function isSuccessfulCursorNativeRepositoryToolResult(message: ToolResultMessage): boolean {
+	return message.isError !== true && CURSOR_NATIVE_REPOSITORY_RECOVERY_TOOL_NAMES.has(message.toolName);
 }
 
 /**
@@ -1488,6 +1506,11 @@ export class Agent {
 			messages: this.#state.messages.slice(),
 			tools: this.#state.tools,
 		};
+		// Cursor can execute native tools inside one remote turn, then return
+		// `turnEnded` without another model request. Remember a Composer policy
+		// rejection until the loop reaches that safe continuation boundary.
+		let cursorComposerBashRecoveryPending = false;
+		let cursorComposerBashRecoveryAttempted = false;
 
 		const cursorOnToolResult =
 			!fallbackManaged && (this.#cursorExecHandlers || this.#cursorOnToolResult)
@@ -1506,6 +1529,16 @@ export class Agent {
 									finalMessage = updated;
 								}
 							} catch {}
+						}
+						if (isCursorComposerBashPolicyBlockedResult(finalMessage)) {
+							cursorComposerBashRecoveryPending = true;
+						} else if (
+							cursorComposerBashRecoveryPending &&
+							isSuccessfulCursorNativeRepositoryToolResult(finalMessage)
+						) {
+							// The same remote turn already replanned through a native tool,
+							// so do not create a redundant local continuation afterward.
+							cursorComposerBashRecoveryPending = false;
 						}
 						// Cursor executes tools server-side during streaming, so the assistant message
 						// already incorporates results. We buffer here and emit in correct order
@@ -1651,6 +1684,23 @@ export class Agent {
 					return [];
 				}
 				return queued;
+			},
+			getSyntheticRecoveryMessage: async () => {
+				if (
+					this.#activeRunId !== runId ||
+					!cursorComposerBashRecoveryPending ||
+					cursorComposerBashRecoveryAttempted
+				) {
+					return undefined;
+				}
+				cursorComposerBashRecoveryPending = false;
+				cursorComposerBashRecoveryAttempted = true;
+				return {
+					role: "user",
+					content: CURSOR_COMPOSER_BASH_POLICY_RECOVERY_PROMPT,
+					synthetic: true,
+					timestamp: Date.now(),
+				};
 			},
 			onBeforeYield: async () => {
 				if (this.#activeRunId !== runId) return;

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -15,6 +15,7 @@ import type {
 	ToolResultMessage,
 	TransportFailureFacts,
 	TSchema,
+	UserMessage,
 } from "@gajae-code/ai";
 import type { AppendOnlyContextManager } from "./append-only-context";
 import type { AttemptMinter, AttemptRunHandle, AttemptScope } from "./attempt-scope";
@@ -319,6 +320,12 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 * continues with another turn.
 	 */
 	getFollowUpMessages?: () => Promise<AgentMessage[]>;
+	/**
+	 * Supplies one bounded synthetic recovery instruction before the loop would
+	 * otherwise yield. Unlike a follow-up, it is sent only to the provider and
+	 * is not committed to durable agent message history.
+	 */
+	getSyntheticRecoveryMessage?: () => Promise<UserMessage | undefined>;
 	/**
 	 * Cooperative pause checkpoint evaluated at safe loop boundaries.
 	 *

--- a/packages/agent/test/composer-bash-recovery.test.ts
+++ b/packages/agent/test/composer-bash-recovery.test.ts
@@ -60,6 +60,18 @@ function composerPolicyBlockedBashTool(): AgentTool<typeof bashSchema> {
 	};
 }
 
+function failingBashToolWithOutput(text: string): AgentTool<typeof bashSchema> {
+	return {
+		name: "bash",
+		label: "Bash",
+		description: "Runs terminal commands.",
+		parameters: bashSchema,
+		async execute() {
+			return { content: [{ type: "text", text }], isError: true };
+		},
+	};
+}
+
 function readTool(onExecute?: () => void): AgentTool<typeof readSchema> {
 	return {
 		name: "read",
@@ -213,6 +225,38 @@ describe("Composer bash policy recovery", () => {
 			expect(lastAssistant.stopReason).toBe("error");
 			expect(lastAssistant.errorMessage).toContain("one automatic recovery turn");
 		}
+	});
+
+	it("does not recover when ordinary Bash failure output merely quotes the policy error", async () => {
+		const quotedPolicyError = `Test failure output:\n${formatComposerBashPolicyError("generic")}\nCommand exited with code 1`;
+		const context: AgentContext = {
+			systemPrompt: ["Test"],
+			messages: [createUserMessage("Run the test and report its failure.")],
+			tools: [failingBashToolWithOutput(quotedPolicyError)],
+		};
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "bash-1", name: "bash", arguments: { command: "bun test" } }] },
+				{ content: ["The test failed."] },
+			],
+		});
+		const requests: CapturedRequest[] = [];
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			toolChoice: "required",
+		};
+
+		await drain(
+			agentLoopContinue(context, config, undefined, (model, requestContext, options) => {
+				requests.push({ context: requestContext, options });
+				return mock.stream(model, requestContext, options);
+			}),
+		);
+
+		expect(requests).toHaveLength(2);
+		expect(hasText(requests[1]!.context.messages, COMPOSER_BASH_POLICY_RECOVERY_PROMPT)).toBe(false);
+		expect(requests[1]!.options?.toolChoice).toBe("required");
 	});
 
 	it("continues a Cursor Composer turn once after a provider-side policy block", async () => {

--- a/packages/agent/test/composer-bash-recovery.test.ts
+++ b/packages/agent/test/composer-bash-recovery.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it } from "bun:test";
+import {
+	Agent,
+	type AgentContext,
+	type AgentLoopConfig,
+	type AgentMessage,
+	type AgentTool,
+} from "@gajae-code/agent-core";
+import { agentLoopContinue } from "@gajae-code/agent-core/agent-loop";
+import { AppendOnlyContextManager } from "@gajae-code/agent-core/append-only-context";
+import type { Context, Message, Model, SimpleStreamOptions, ToolResultMessage } from "@gajae-code/ai";
+import {
+	COMPOSER_BASH_POLICY_RECOVERY_PROMPT,
+	CURSOR_COMPOSER_BASH_POLICY_RECOVERY_PROMPT,
+	formatComposerBashPolicyError,
+} from "@gajae-code/ai/providers/composer-discipline";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import * as z from "zod/v4";
+import { createUserMessage } from "./helpers";
+
+const bashSchema = z.object({ command: z.string() });
+const readSchema = z.object({ path: z.string() });
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(
+		message => message.role === "user" || message.role === "assistant" || message.role === "toolResult",
+	) as Message[];
+}
+
+function hasText(messages: readonly (AgentMessage | Message)[], text: string): boolean {
+	return messages.some(message => {
+		if (!("content" in message)) return false;
+		if (typeof message.content === "string") return message.content.includes(text);
+		return (
+			Array.isArray(message.content) &&
+			message.content.some(block => block.type === "text" && block.text.includes(text))
+		);
+	});
+}
+
+async function drain(stream: AsyncIterable<unknown> & { result(): Promise<unknown> }): Promise<void> {
+	for await (const _event of stream) {
+		// consume
+	}
+	await stream.result();
+}
+
+function composerPolicyBlockedBashTool(): AgentTool<typeof bashSchema> {
+	return {
+		name: "bash",
+		label: "Bash",
+		description: "Runs terminal commands.",
+		parameters: bashSchema,
+		async execute() {
+			return {
+				content: [{ type: "text", text: formatComposerBashPolicyError("generic") }],
+				isError: true,
+			};
+		},
+	};
+}
+
+function readTool(onExecute?: () => void): AgentTool<typeof readSchema> {
+	return {
+		name: "read",
+		label: "Read",
+		description: "Reads a repository file.",
+		parameters: readSchema,
+		async execute(_toolCallId, args) {
+			onExecute?.();
+			return { content: [{ type: "text", text: `read ${args.path}` }] };
+		},
+	};
+}
+
+function cursorComposerModel(model: Model): Model {
+	return {
+		...model,
+		id: "composer-2.5",
+		name: "composer-2.5",
+		api: "cursor-agent",
+		provider: "cursor",
+	} as Model;
+}
+
+function cursorToolResult(toolName: string, text: string, isError: boolean, toolCallId: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName,
+		content: [{ type: "text", text }],
+		isError,
+		timestamp: Date.now(),
+	};
+}
+
+type CapturedRequest = { context: Context; options?: SimpleStreamOptions };
+
+describe("Composer bash policy recovery", () => {
+	it("keeps generic Composer tools enabled for one policy-recovery turn", async () => {
+		let reads = 0;
+		let toolChoiceGetterCalls = 0;
+		const context: AgentContext = {
+			systemPrompt: ["Test"],
+			messages: [createUserMessage("Inspect the file and continue.")],
+			tools: [composerPolicyBlockedBashTool(), readTool(() => (reads += 1))],
+		};
+		const mock = createMockModel({
+			id: "grok-composer-2.5-fast",
+			provider: "grok-build",
+			responses: [
+				{ content: [{ type: "toolCall", id: "bash-1", name: "bash", arguments: { command: "cat src/a.ts" } }] },
+				{ content: [{ type: "toolCall", id: "read-1", name: "read", arguments: { path: "src/a.ts" } }] },
+				{ content: ["Completed with the dedicated tool."] },
+			],
+		});
+		const requests: CapturedRequest[] = [];
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			getToolChoice: () => {
+				toolChoiceGetterCalls += 1;
+				return "required";
+			},
+		};
+
+		await drain(
+			agentLoopContinue(context, config, undefined, (model, requestContext, options) => {
+				requests.push({ context: requestContext, options });
+				return mock.stream(model, requestContext, options);
+			}),
+		);
+
+		expect(requests).toHaveLength(3);
+		expect(hasText(requests[1]!.context.messages, COMPOSER_BASH_POLICY_RECOVERY_PROMPT)).toBe(true);
+		expect(requests[1]!.context.tools?.map(tool => tool.name)).toEqual(["bash", "read"]);
+		expect(requests[1]!.options?.toolChoice).toBe("auto");
+		expect(requests.map(request => request.options?.toolChoice)).toEqual(["required", "auto", "required"]);
+		expect(toolChoiceGetterCalls).toBe(2);
+		expect(reads).toBe(1);
+		expect(hasText(context.messages, COMPOSER_BASH_POLICY_RECOVERY_PROMPT)).toBe(false);
+	});
+
+	it("keeps the generic recovery prompt out of append-only history and later requests", async () => {
+		const appendOnlyContext = new AppendOnlyContextManager();
+		const context: AgentContext = {
+			systemPrompt: ["Test"],
+			messages: [createUserMessage("Inspect the file and continue.")],
+			tools: [composerPolicyBlockedBashTool(), readTool()],
+		};
+		const mock = createMockModel({
+			id: "grok-composer-2.5-fast",
+			provider: "grok-build",
+			responses: [
+				{ content: [{ type: "toolCall", id: "bash-1", name: "bash", arguments: { command: "cat src/a.ts" } }] },
+				{ content: [{ type: "toolCall", id: "read-1", name: "read", arguments: { path: "src/a.ts" } }] },
+				{ content: ["Recovered."] },
+				{ content: ["Later request completed."] },
+			],
+		});
+		const requests: CapturedRequest[] = [];
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			appendOnlyContext,
+		};
+		const capture = (model: Model, requestContext: Context, options?: SimpleStreamOptions) => {
+			requests.push({ context: requestContext, options });
+			return mock.stream(model, requestContext, options);
+		};
+
+		await drain(agentLoopContinue(context, config, undefined, capture));
+		context.messages.push(createUserMessage("Handle a later request."));
+		await drain(agentLoopContinue(context, config, undefined, capture));
+
+		expect(requests).toHaveLength(4);
+		expect(hasText(requests[1]!.context.messages, COMPOSER_BASH_POLICY_RECOVERY_PROMPT)).toBe(true);
+		expect(hasText(requests[3]!.context.messages, COMPOSER_BASH_POLICY_RECOVERY_PROMPT)).toBe(false);
+		expect(hasText(appendOnlyContext.log.entries(), COMPOSER_BASH_POLICY_RECOVERY_PROMPT)).toBe(false);
+		expect(requests[3]!.context.tools?.map(tool => tool.name)).toEqual(["bash", "read"]);
+	});
+
+	it("stops after a second generic policy block instead of looping", async () => {
+		const context: AgentContext = {
+			systemPrompt: ["Test"],
+			messages: [createUserMessage("Inspect the file and continue.")],
+			tools: [composerPolicyBlockedBashTool()],
+		};
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "bash-1", name: "bash", arguments: { command: "cat src/a.ts" } }] },
+				{ content: [{ type: "toolCall", id: "bash-2", name: "bash", arguments: { command: "cat src/b.ts" } }] },
+			],
+		});
+		const requests: CapturedRequest[] = [];
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		await drain(
+			agentLoopContinue(context, config, undefined, (model, requestContext, options) => {
+				requests.push({ context: requestContext, options });
+				return mock.stream(model, requestContext, options);
+			}),
+		);
+
+		expect(requests).toHaveLength(2);
+		expect(hasText(requests[1]!.context.messages, COMPOSER_BASH_POLICY_RECOVERY_PROMPT)).toBe(true);
+		expect(
+			requests.filter(request => hasText(request.context.messages, COMPOSER_BASH_POLICY_RECOVERY_PROMPT)),
+		).toHaveLength(1);
+		const lastAssistant = context.messages.findLast(message => message.role === "assistant");
+		expect(lastAssistant?.role).toBe("assistant");
+		if (lastAssistant?.role === "assistant") {
+			expect(lastAssistant.stopReason).toBe("error");
+			expect(lastAssistant.errorMessage).toContain("one automatic recovery turn");
+		}
+	});
+
+	it("continues a Cursor Composer turn once after a provider-side policy block", async () => {
+		const mock = createMockModel({
+			responses: [{ content: ["first remote turn"] }, { content: ["recovered remote turn"] }],
+		});
+		const requests: CapturedRequest[] = [];
+		const agent = new Agent({
+			initialState: {
+				model: cursorComposerModel(mock.model),
+				systemPrompt: ["Test"],
+				tools: [readTool()],
+				messages: [],
+			},
+			convertToLlm: identityConverter,
+			cursorOnToolResult: async result => result,
+			streamFn: async (model, requestContext, options) => {
+				requests.push({ context: requestContext, options });
+				if (requests.length === 1) {
+					await options?.cursorOnToolResult?.(
+						cursorToolResult("bash", formatComposerBashPolicyError("cursor"), true, "bash-1"),
+					);
+				}
+				return mock.stream(model, requestContext, options);
+			},
+		});
+
+		await agent.prompt("Inspect the file and continue.");
+
+		expect(requests).toHaveLength(2);
+		expect(hasText(requests[1]!.context.messages, CURSOR_COMPOSER_BASH_POLICY_RECOVERY_PROMPT)).toBe(true);
+		expect(requests[1]!.context.tools?.map(tool => tool.name)).toEqual(["read"]);
+		expect(requests[1]!.options?.toolChoice).toBe("auto");
+		expect(hasText(agent.state.messages, CURSOR_COMPOSER_BASH_POLICY_RECOVERY_PROMPT)).toBe(false);
+	});
+
+	it("lets a queued user follow-up supersede Cursor's automatic recovery", async () => {
+		const mock = createMockModel({
+			responses: [{ content: ["first remote turn"] }, { content: ["follow-up handled"] }],
+		});
+		const requests: CapturedRequest[] = [];
+		let agent!: Agent;
+		agent = new Agent({
+			initialState: { model: cursorComposerModel(mock.model), systemPrompt: ["Test"], tools: [], messages: [] },
+			convertToLlm: identityConverter,
+			cursorOnToolResult: async result => result,
+			streamFn: async (model, requestContext, options) => {
+				requests.push({ context: requestContext, options });
+				if (requests.length === 1) {
+					await options?.cursorOnToolResult?.(
+						cursorToolResult("bash", formatComposerBashPolicyError("cursor"), true, "bash-1"),
+					);
+					agent.followUp(createUserMessage("Handle this user follow-up now."));
+				}
+				return mock.stream(model, requestContext, options);
+			},
+		});
+
+		await agent.prompt("Inspect the file and continue.");
+
+		expect(requests).toHaveLength(2);
+		expect(hasText(requests[1]!.context.messages, "Handle this user follow-up now.")).toBe(true);
+		expect(hasText(requests[1]!.context.messages, CURSOR_COMPOSER_BASH_POLICY_RECOVERY_PROMPT)).toBe(false);
+		expect(hasText(agent.state.messages, CURSOR_COMPOSER_BASH_POLICY_RECOVERY_PROMPT)).toBe(false);
+	});
+
+	it.each([
+		"read",
+		"search",
+		"find",
+		"write",
+		"delete",
+	])("does not add a Cursor continuation when the same remote turn recovers through %s", async toolName => {
+		const mock = createMockModel({ responses: [{ content: ["recovered in the remote turn"] }] });
+		const requests: CapturedRequest[] = [];
+		const agent = new Agent({
+			initialState: { model: cursorComposerModel(mock.model), systemPrompt: ["Test"], tools: [], messages: [] },
+			convertToLlm: identityConverter,
+			cursorOnToolResult: async result => result,
+			streamFn: async (model, requestContext, options) => {
+				requests.push({ context: requestContext, options });
+				await options?.cursorOnToolResult?.(
+					cursorToolResult("bash", formatComposerBashPolicyError("cursor"), true, "bash-1"),
+				);
+				await options?.cursorOnToolResult?.(cursorToolResult(toolName, "ok", false, `${toolName}-1`));
+				return mock.stream(model, requestContext, options);
+			},
+		});
+
+		await agent.prompt("Inspect the file and continue.");
+
+		expect(requests).toHaveLength(1);
+		expect(hasText(agent.state.messages, CURSOR_COMPOSER_BASH_POLICY_RECOVERY_PROMPT)).toBe(false);
+	});
+
+	it("does not retry a second Cursor Composer policy block", async () => {
+		const mock = createMockModel({
+			responses: [{ content: ["first remote turn"] }, { content: ["second remote turn"] }],
+		});
+		const requests: CapturedRequest[] = [];
+		const agent = new Agent({
+			initialState: { model: cursorComposerModel(mock.model), systemPrompt: ["Test"], tools: [], messages: [] },
+			convertToLlm: identityConverter,
+			cursorOnToolResult: async result => result,
+			streamFn: async (model, requestContext, options) => {
+				requests.push({ context: requestContext, options });
+				await options?.cursorOnToolResult?.(
+					cursorToolResult("bash", formatComposerBashPolicyError("cursor"), true, `bash-${requests.length}`),
+				);
+				return mock.stream(model, requestContext, options);
+			},
+		});
+
+		await agent.prompt("Inspect the file and continue.");
+
+		expect(requests).toHaveLength(2);
+		expect(hasText(requests[1]!.context.messages, CURSOR_COMPOSER_BASH_POLICY_RECOVERY_PROMPT)).toBe(true);
+		expect(
+			requests.filter(request => hasText(request.context.messages, CURSOR_COMPOSER_BASH_POLICY_RECOVERY_PROMPT)),
+		).toHaveLength(1);
+	});
+});

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
+- Composer shell-policy failures now expose a stable structured marker plus provider-specific recovery guidance, while retaining recognition of prefix-only errors from older sessions. Cursor Composer requests use a native `read`/`grep`/`write`/`delete` discipline prompt rather than the generic hashline-tool vocabulary.
 - Alibaba Token Plan streams now allow 600 seconds for the first semantic event, matching observed long-context TTFT above the previous 300-second cutoff. The outer lazy watchdog and both OpenAI transports share one provider fallback; OpenAI Completions also applies it before response headers, and Alibaba SDK connection timeouts from that pre-stream phase are normalized to the typed first-event failure so session retry policy does not replay the request as an unknown timeout.
 
 ## [0.12.8] - 2026-08-02

--- a/packages/ai/src/prompts/composer-bash-policy-recovery.md
+++ b/packages/ai/src/prompts/composer-bash-policy-recovery.md
@@ -1,0 +1,1 @@
+A Composer bash policy block interrupted a shell attempt. This is not a terminal condition: continue the same task now. Do not retry repository file I/O in bash. Use the dedicated find, search, read, and edit tools for repository work, then continue with the next safe step.

--- a/packages/ai/src/prompts/cursor-composer-bash-policy-recovery.md
+++ b/packages/ai/src/prompts/cursor-composer-bash-policy-recovery.md
@@ -1,0 +1,1 @@
+A Composer bash policy block interrupted a shell attempt. This is not a terminal condition: continue the same task now. Do not retry repository file I/O in shell. Use Cursor-native read for files or directories, grep for search or globs, write for changes, and delete only when deletion is required; then continue with the next safe step.

--- a/packages/ai/src/prompts/cursor-composer-edit-discipline.md
+++ b/packages/ai/src/prompts/cursor-composer-edit-discipline.md
@@ -1,0 +1,7 @@
+File-editing discipline for this Cursor Composer harness (this OVERRIDES contrary habits from your training):
+
+- Inspect repository files ONLY with Cursor-native read and grep: use read for file bodies or directories, and grep for content search or glob discovery. NEVER inspect repository files through shell commands (ls, find, fd, cat, sed, awk, grep, rg, head, tail, less, more) or scripts.
+- Modify files ONLY with Cursor-native write, or delete only when deletion is required. NEVER mutate files through shell redirection, tee, sed -i, perl -pi, inline python/node/bun scripts, or other out-of-band writes.
+- Re-read a file after any write before relying on its contents again. Do not fabricate line anchors, paths, tool names, or tool-call arguments.
+- Tool-call arguments must be the exact schema object requested by the native tool. Do not include Markdown, commentary, analysis text, or invented fields inside tool arguments.
+- Use shell only for terminal operations such as tests, builds, package scripts, and git commands. A shell command string must contain only the command itself; NEVER interleave reasoning or commentary into command strings or heredocs.

--- a/packages/ai/src/providers/composer-discipline.ts
+++ b/packages/ai/src/providers/composer-discipline.ts
@@ -62,6 +62,15 @@ export function isComposerBashPolicyBlockedError(text: string): boolean {
 	return text.includes(COMPOSER_BASH_POLICY_ERROR_PREFIX);
 }
 
+/**
+ * Matches only errors emitted directly by the current policy implementation.
+ * Live recovery must use this strict form so failed shell output that merely
+ * quotes a policy error cannot masquerade as the policy gate itself.
+ */
+export function isCurrentComposerBashPolicyBlockedError(text: string): boolean {
+	return text === formatComposerBashPolicyError("generic") || text === formatComposerBashPolicyError("cursor");
+}
+
 /** One bounded, tool-enabled retry instruction for generic Composer agent loops. */
 export const COMPOSER_BASH_POLICY_RECOVERY_PROMPT = composerBashPolicyRecoveryPrompt;
 

--- a/packages/ai/src/providers/composer-discipline.ts
+++ b/packages/ai/src/providers/composer-discipline.ts
@@ -1,3 +1,9 @@
+import composerBashPolicyRecoveryPrompt from "../prompts/composer-bash-policy-recovery.md" with { type: "text" };
+import cursorComposerBashPolicyRecoveryPrompt from "../prompts/cursor-composer-bash-policy-recovery.md" with {
+	type: "text",
+};
+import cursorComposerEditDisciplinePrompt from "../prompts/cursor-composer-edit-discipline.md" with { type: "text" };
+
 /**
  * Anchor/edit discipline for composer-harness models (xai grok-composer-*,
  * cursor composer-*).
@@ -30,6 +36,38 @@ export function isComposerHarnessModel(modelId: string): boolean {
 	return COMPOSER_MODEL_ID_PATTERN.test(modelId);
 }
 
+/** Stable text contract for a local shell rejection caused by Composer file-I/O discipline. */
+export const COMPOSER_BASH_POLICY_ERROR_PREFIX = "Composer bash policy blocked repository file I/O.";
+export const COMPOSER_BASH_POLICY_ERROR_CODE = "composer-bash-policy:repository-file-io";
+
+export type ComposerBashPolicyToolSurface = "generic" | "cursor";
+
+/**
+ * Format the model-visible policy rejection with a stable marker and the tool
+ * vocabulary the model actually receives on this provider surface.
+ */
+export function formatComposerBashPolicyError(surface: ComposerBashPolicyToolSurface = "generic"): string {
+	const recovery =
+		surface === "cursor"
+			? "Continue the same task with Cursor-native read, grep, write, or delete tools; do not retry repository file I/O through shell."
+			: "Continue the same task with find, search, read, and edit tools; do not retry repository file I/O through bash.";
+	return `${COMPOSER_BASH_POLICY_ERROR_PREFIX} [${COMPOSER_BASH_POLICY_ERROR_CODE}] Recovery required: ${recovery}`;
+}
+
+/**
+ * Matches both the structured current error and the original prefix so a
+ * resumed session can recover after an upgrade without string-version skew.
+ */
+export function isComposerBashPolicyBlockedError(text: string): boolean {
+	return text.includes(COMPOSER_BASH_POLICY_ERROR_PREFIX);
+}
+
+/** One bounded, tool-enabled retry instruction for generic Composer agent loops. */
+export const COMPOSER_BASH_POLICY_RECOVERY_PROMPT = composerBashPolicyRecoveryPrompt;
+
+/** One bounded, tool-enabled retry instruction for Cursor's native remote tool surface. */
+export const CURSOR_COMPOSER_BASH_POLICY_RECOVERY_PROMPT = cursorComposerBashPolicyRecoveryPrompt;
+
 export const COMPOSER_EDIT_DISCIPLINE_PROMPT = `File-editing discipline for this Composer harness (this OVERRIDES contrary habits from your training):
 
 - Discover file names ONLY with the find tool; search file contents ONLY with the search tool; read file bodies or line ranges ONLY with the read tool. NEVER inspect repository files through shell commands (ls, find, fd, cat, sed, awk, grep, rg, head, tail, less, more) or scripts — that output carries no hashline anchors and bypasses the agent's safety limits.
@@ -39,3 +77,10 @@ export const COMPOSER_EDIT_DISCIPLINE_PROMPT = `File-editing discipline for this
 - If an edit is rejected with "anchors do not match", the rejection message prints the current lines WITH fresh anchors. Retry using exactly those printed anchors.
 - Tool-call arguments must be the exact JSON/schema object requested by the tool. Do not include Markdown, commentary, analysis text, or invented fields inside tool arguments.
 - Use bash only for terminal operations such as tests, builds, package scripts, and git commands. A shell command string must contain only the command itself; NEVER interleave reasoning or commentary into command strings or heredocs.`;
+
+/**
+ * Cursor executes a different native tool vocabulary from the generic agent
+ * loop. Keep this prompt separate so Composer is never told to call `edit`,
+ * `find`, or `search` when those names are unavailable remotely.
+ */
+export const CURSOR_COMPOSER_EDIT_DISCIPLINE_PROMPT = cursorComposerEditDisciplinePrompt;

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -30,7 +30,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream";
 import { parseStreamingJson } from "../utils/json-parse";
 import { formatErrorMessageWithRetryAfter } from "../utils/retry-after";
 import { flattenToolRootCombinators, toolWireSchema } from "../utils/schema";
-import { COMPOSER_EDIT_DISCIPLINE_PROMPT, isComposerHarnessModel } from "./composer-discipline";
+import { CURSOR_COMPOSER_EDIT_DISCIPLINE_PROMPT, isComposerHarnessModel } from "./composer-discipline";
 import { CURSOR_CLIENT_VERSION } from "./cursor/client-version";
 import type { McpToolDefinition } from "./cursor/gen/agent_pb";
 import {
@@ -2329,7 +2329,7 @@ export function buildCursorSystemPromptJsons(systemPrompt: readonly string[] | u
 	// Composer-harness models need anchor/edit discipline pinned ahead of any
 	// host/default prompt (see composer-discipline.ts for the observed failure modes).
 	if (modelId !== undefined && isComposerHarnessModel(modelId)) {
-		jsons.unshift(JSON.stringify({ role: "system", content: COMPOSER_EDIT_DISCIPLINE_PROMPT }));
+		jsons.unshift(JSON.stringify({ role: "system", content: CURSOR_COMPOSER_EDIT_DISCIPLINE_PROMPT }));
 	}
 	return jsons;
 }

--- a/packages/ai/test/composer-discipline.test.ts
+++ b/packages/ai/test/composer-discipline.test.ts
@@ -13,6 +13,7 @@ import {
 	formatComposerBashPolicyError,
 	isComposerBashPolicyBlockedError,
 	isComposerHarnessModel,
+	isCurrentComposerBashPolicyBlockedError,
 } from "@gajae-code/ai/providers/composer-discipline";
 import { buildCursorSystemPromptJsons } from "@gajae-code/ai/providers/cursor";
 import { convertMessages } from "@gajae-code/ai/providers/openai-completions";
@@ -122,16 +123,24 @@ describe("isComposerBashPolicyBlockedError", () => {
 		const error = formatComposerBashPolicyError("generic");
 		expect(error).toContain(COMPOSER_BASH_POLICY_ERROR_CODE);
 		expect(isComposerBashPolicyBlockedError(error)).toBe(true);
+		expect(isCurrentComposerBashPolicyBlockedError(error)).toBe(true);
 	});
 
 	it("recognizes prefix-only errors from sessions created before the structured marker", () => {
 		const legacyError = `${COMPOSER_BASH_POLICY_ERROR_PREFIX} Use find, search, read, and edit tools.`;
 		expect(legacyError).not.toContain(COMPOSER_BASH_POLICY_ERROR_CODE);
 		expect(isComposerBashPolicyBlockedError(legacyError)).toBe(true);
+		expect(isCurrentComposerBashPolicyBlockedError(legacyError)).toBe(false);
 	});
 
 	it("rejects unrelated shell errors", () => {
 		expect(isComposerBashPolicyBlockedError("Command failed with exit code 1")).toBe(false);
+	});
+
+	it("does not treat failed command output that quotes a structured policy error as the policy gate", () => {
+		const quotedError = `Test failure output:\n${formatComposerBashPolicyError("generic")}\nCommand exited with code 1`;
+		expect(isComposerBashPolicyBlockedError(quotedError)).toBe(true);
+		expect(isCurrentComposerBashPolicyBlockedError(quotedError)).toBe(false);
 	});
 });
 

--- a/packages/ai/test/composer-discipline.test.ts
+++ b/packages/ai/test/composer-discipline.test.ts
@@ -5,7 +5,15 @@
  * Non-composer models must stay byte-identical to previous behavior.
  */
 import { describe, expect, it } from "bun:test";
-import { COMPOSER_EDIT_DISCIPLINE_PROMPT, isComposerHarnessModel } from "@gajae-code/ai/providers/composer-discipline";
+import {
+	COMPOSER_BASH_POLICY_ERROR_CODE,
+	COMPOSER_BASH_POLICY_ERROR_PREFIX,
+	COMPOSER_EDIT_DISCIPLINE_PROMPT,
+	CURSOR_COMPOSER_EDIT_DISCIPLINE_PROMPT,
+	formatComposerBashPolicyError,
+	isComposerBashPolicyBlockedError,
+	isComposerHarnessModel,
+} from "@gajae-code/ai/providers/composer-discipline";
 import { buildCursorSystemPromptJsons } from "@gajae-code/ai/providers/cursor";
 import { convertMessages } from "@gajae-code/ai/providers/openai-completions";
 import { streamOpenAIResponses } from "@gajae-code/ai/providers/openai-responses";
@@ -109,6 +117,24 @@ describe("isComposerHarnessModel", () => {
 	});
 });
 
+describe("isComposerBashPolicyBlockedError", () => {
+	it("recognizes current structured policy errors", () => {
+		const error = formatComposerBashPolicyError("generic");
+		expect(error).toContain(COMPOSER_BASH_POLICY_ERROR_CODE);
+		expect(isComposerBashPolicyBlockedError(error)).toBe(true);
+	});
+
+	it("recognizes prefix-only errors from sessions created before the structured marker", () => {
+		const legacyError = `${COMPOSER_BASH_POLICY_ERROR_PREFIX} Use find, search, read, and edit tools.`;
+		expect(legacyError).not.toContain(COMPOSER_BASH_POLICY_ERROR_CODE);
+		expect(isComposerBashPolicyBlockedError(legacyError)).toBe(true);
+	});
+
+	it("rejects unrelated shell errors", () => {
+		expect(isComposerBashPolicyBlockedError("Command failed with exit code 1")).toBe(false);
+	});
+});
+
 describe("COMPOSER_EDIT_DISCIPLINE_PROMPT", () => {
 	it("covers the observed adversarial tool-calling failure classes", () => {
 		expect(COMPOSER_EDIT_DISCIPLINE_PROMPT).toContain("find tool");
@@ -121,6 +147,17 @@ describe("COMPOSER_EDIT_DISCIPLINE_PROMPT", () => {
 		expect(COMPOSER_EDIT_DISCIPLINE_PROMPT).toContain("NEVER mutate files through shell redirection");
 		expect(COMPOSER_EDIT_DISCIPLINE_PROMPT).toContain("Tool-call arguments must be the exact JSON/schema object");
 		expect(COMPOSER_EDIT_DISCIPLINE_PROMPT).toContain("A shell command string must contain only the command itself");
+	});
+});
+
+describe("CURSOR_COMPOSER_EDIT_DISCIPLINE_PROMPT", () => {
+	it("uses only Cursor's native repository-tool vocabulary", () => {
+		expect(CURSOR_COMPOSER_EDIT_DISCIPLINE_PROMPT).toContain("Cursor-native read and grep");
+		expect(CURSOR_COMPOSER_EDIT_DISCIPLINE_PROMPT).toContain("write");
+		expect(CURSOR_COMPOSER_EDIT_DISCIPLINE_PROMPT).toContain("delete");
+		expect(CURSOR_COMPOSER_EDIT_DISCIPLINE_PROMPT).not.toContain("find tool");
+		expect(CURSOR_COMPOSER_EDIT_DISCIPLINE_PROMPT).not.toContain("search tool");
+		expect(CURSOR_COMPOSER_EDIT_DISCIPLINE_PROMPT).not.toContain("edit tool");
 	});
 });
 
@@ -192,7 +229,7 @@ describe("cursor composer discipline injection", () => {
 	it("pins the discipline block ahead of the host prompt for composer model ids", () => {
 		const jsons = buildCursorSystemPromptJsons(["Host system prompt."], "composer-1");
 		const contents = jsons.map(json => (JSON.parse(json) as { content: string }).content);
-		expect(contents[0]).toBe(COMPOSER_EDIT_DISCIPLINE_PROMPT);
+		expect(contents[0]).toBe(CURSOR_COMPOSER_EDIT_DISCIPLINE_PROMPT);
 		expect(contents[1]).toBe("Host system prompt.");
 	});
 
@@ -211,6 +248,6 @@ describe("cursor composer discipline injection", () => {
 	it("pins discipline ahead of the default prompt when no host system prompt exists", () => {
 		const jsons = buildCursorSystemPromptJsons(undefined, "composer-1");
 		const contents = jsons.map(json => (JSON.parse(json) as { content: string }).content);
-		expect(contents).toEqual([COMPOSER_EDIT_DISCIPLINE_PROMPT, "You are a helpful assistant."]);
+		expect(contents).toEqual([CURSOR_COMPOSER_EDIT_DISCIPLINE_PROMPT, "You are a helpful assistant."]);
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Composer Bash policy rejections now identify the active provider surface and direct Cursor Composer models to their native repository tools, enabling the agent runtime's bounded automatic recovery instead of leaving a blocked shell attempt as a terminal turn.
 - The Extension Control Center inspector no longer crashes when a narrow two-column layout leaves its preview pane fewer than two columns wide.
 - Prompt-template positional arguments now preserve literal `$@` and `$ARGUMENTS` text instead of recursively expanding it during placeholder substitution.
 - Native Windows session and GC commands now report the searched `psmux` / `pmux` / `tmux` provider set when no compatible multiplexer is available instead of leaking a literal `tmux` spawn error (#3688).

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -982,8 +982,10 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			}
 		}
 
+		const activeModel = this.session.model;
 		const composerPolicy = checkComposerBashPolicy({
-			modelId: this.session.getActiveModelString?.() ?? this.session.getModelString?.() ?? this.session.model?.id,
+			modelId: this.session.getActiveModelString?.() ?? this.session.getModelString?.() ?? activeModel?.id,
+			provider: activeModel?.provider,
 			commands: rawCommand === command ? [command] : [rawCommand, command],
 		});
 		if (!composerPolicy.allowed) {

--- a/packages/coding-agent/src/tools/composer-bash-policy.ts
+++ b/packages/coding-agent/src/tools/composer-bash-policy.ts
@@ -1,7 +1,11 @@
-import { isComposerHarnessModel } from "@gajae-code/ai/providers/composer-discipline";
+import {
+	type ComposerBashPolicyToolSurface,
+	formatComposerBashPolicyError,
+	isComposerHarnessModel,
+} from "@gajae-code/ai/providers/composer-discipline";
 
-export const COMPOSER_BASH_POLICY_ERROR =
-	"Composer bash policy blocked repository file I/O. Use find, search, read, and edit tools for file discovery, file inspection, and file mutation.";
+export const COMPOSER_BASH_POLICY_ERROR = formatComposerBashPolicyError("generic");
+export const CURSOR_COMPOSER_BASH_POLICY_ERROR = formatComposerBashPolicyError("cursor");
 
 type ComposerBashPolicyResult =
 	| { allowed: true }
@@ -9,6 +13,7 @@ type ComposerBashPolicyResult =
 			allowed: false;
 			reason: string;
 			message: string;
+			surface: ComposerBashPolicyToolSurface;
 	  };
 
 const BLOCK_PATTERNS: Array<{ id: string; pattern: RegExp }> = [
@@ -77,19 +82,30 @@ export function isComposerBashPolicyModel(modelId: string | undefined): boolean 
 	return Boolean(modelId && isComposerHarnessModel(modelId));
 }
 
+export function resolveComposerBashPolicyToolSurface(input: {
+	modelId?: string;
+	provider?: string;
+}): ComposerBashPolicyToolSurface {
+	if (input.provider?.toLowerCase() === "cursor") return "cursor";
+	return /(?:^|[/:._-])cursor(?:[/:._-]|$)/i.test(input.modelId ?? "") ? "cursor" : "generic";
+}
+
 export function checkComposerBashPolicy(input: {
 	modelId?: string;
+	provider?: string;
 	commands: readonly string[];
 }): ComposerBashPolicyResult {
 	if (!isComposerBashPolicyModel(input.modelId)) return { allowed: true };
+	const surface = resolveComposerBashPolicyToolSurface(input);
+	const message = formatComposerBashPolicyError(surface);
 	for (const command of input.commands) {
 		for (const block of BLOCK_PATTERNS) {
 			if (block.pattern.test(command)) {
-				return { allowed: false, reason: block.id, message: COMPOSER_BASH_POLICY_ERROR };
+				return { allowed: false, reason: block.id, message, surface };
 			}
 		}
 		if (!isAllowedComposerTerminalCommand(command)) {
-			return { allowed: false, reason: "not-allowlisted", message: COMPOSER_BASH_POLICY_ERROR };
+			return { allowed: false, reason: "not-allowlisted", message, surface };
 		}
 	}
 	return { allowed: true };

--- a/packages/coding-agent/test/tools/composer-bash-policy.test.ts
+++ b/packages/coding-agent/test/tools/composer-bash-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
 	COMPOSER_BASH_POLICY_ERROR,
+	CURSOR_COMPOSER_BASH_POLICY_ERROR,
 	checkComposerBashPolicy,
 	isComposerBashPolicyModel,
 } from "../../src/tools/composer-bash-policy";
@@ -93,6 +94,29 @@ describe("composer bash policy", () => {
 			commands: ["cd repo && cat src/secret.ts", "cat src/secret.ts"],
 		});
 		expect(result.allowed).toBe(false);
+	});
+
+	it("uses Cursor-native recovery guidance on the Cursor tool surface", () => {
+		const result = checkComposerBashPolicy({
+			modelId: "composer-2.5",
+			provider: "cursor",
+			commands: ["cat src/secret.ts"],
+		});
+		expect(result.allowed).toBe(false);
+		if (!result.allowed) {
+			expect(result.message).toBe(CURSOR_COMPOSER_BASH_POLICY_ERROR);
+			expect(result.message).toContain("Cursor-native read, grep, write, or delete");
+			expect(result.message).not.toContain("find, search, read, and edit tools");
+		}
+	});
+
+	it("recognizes Cursor's provider marker when no provider value is available", () => {
+		const result = checkComposerBashPolicy({
+			modelId: "cursor/composer-2.5",
+			commands: ["cat src/secret.ts"],
+		});
+		expect(result.allowed).toBe(false);
+		if (!result.allowed) expect(result.message).toBe(CURSOR_COMPOSER_BASH_POLICY_ERROR);
 	});
 
 	it("preserves non-composer behavior", () => {


### PR DESCRIPTION
## Summary

- recover once when Composer's repository file-I/O Bash policy blocks a generic or Cursor-backed turn
- keep the recovery instruction request-only, preserve repository tools with `toolChoice: auto`, and stop after a second block
- use Cursor-native tool vocabulary, avoid duplicate continuations after same-turn native recovery, and let queued user follow-ups win
- preserve the existing malformed-tool recovery contract: tools disabled, `toolChoice: none`, and no dynamic choice consumed

## Verification

- `bun --cwd=packages/agent run check`
- `bun --cwd=packages/ai run check`
- `bun --cwd=packages/coding-agent run check`
- 159 focused tests across the affected agent-loop, Composer discipline, stability, and Bash-policy suites
- live source-CLI probe with `cursor/composer-2.5`: forced `cat package.json`, observed the policy rejection, native `read/search` recovery, and no redundant second provider turn

## Not tested

- full monorepo test suite