### PR TITLE
fix(notify): report a failed Telegram setup by durable state, not code path

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- A failed `notify setup` no longer reports "Unable to persist and activate Telegram notification settings" when the new bot token and chat id are already on disk. The wording now follows the durable configuration, so it can no longer contradict a follow-up `notify status`; an operator who reads the failure as "nothing was saved" would otherwise leave Telegram armed for a token another poller may own (#3761).
+
 ## [0.12.11] - 2026-08-03
 
 ### Fixed
@@ -31,7 +35,6 @@
 - Dead-owner notification recovery now preserves a machine-readable transition block, marker-age diagnostics, and safe force-recovery guidance without weakening ownership proofs (#3762).
 - Detached SDK session hosts no longer outlive the broker that spawned them. A host whose broker died without teardown (crash, `SIGKILL`, restart without `--close-session-hosts`) previously stayed resident forever, holding its session's memory — hundreds of MB per orphan. Each host now polls the broker discovery publication and, after a bounded grace period with no live broker, disposes itself through the same graceful teardown a `SIGTERM` takes. A replacement broker resets the window, so hosts still survive ordinary broker restarts, and a transient discovery read failure is treated as ambiguity rather than proof of orphanhood.
 - Syntax highlighting now recognizes special filenames such as `CMakeLists.txt`, `Dockerfile.*`, `Makefile`, and `.env.*` before generic filename extensions.
-- A failed `notify setup` no longer reports "Unable to persist and activate Telegram notification settings" when the new bot token and chat id are already on disk. The wording now follows the durable configuration, so it can no longer contradict a follow-up `notify status`; an operator who reads the failure as "nothing was saved" would otherwise leave Telegram armed for a token another poller may own (#3761).
 
 ## [0.12.8] - 2026-08-02
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Dead-owner notification recovery now preserves a machine-readable transition block, marker-age diagnostics, and safe force-recovery guidance without weakening ownership proofs (#3762).
 - Detached SDK session hosts no longer outlive the broker that spawned them. A host whose broker died without teardown (crash, `SIGKILL`, restart without `--close-session-hosts`) previously stayed resident forever, holding its session's memory — hundreds of MB per orphan. Each host now polls the broker discovery publication and, after a bounded grace period with no live broker, disposes itself through the same graceful teardown a `SIGTERM` takes. A replacement broker resets the window, so hosts still survive ordinary broker restarts, and a transient discovery read failure is treated as ambiguity rather than proof of orphanhood.
 - Syntax highlighting now recognizes special filenames such as `CMakeLists.txt`, `Dockerfile.*`, `Makefile`, and `.env.*` before generic filename extensions.
+- A failed `notify setup` no longer reports "Unable to persist and activate Telegram notification settings" when the new bot token and chat id are already on disk. The wording now follows the durable configuration, so it can no longer contradict a follow-up `notify status`; an operator who reads the failure as "nothing was saved" would otherwise leave Telegram armed for a token another poller may own (#3761).
 
 ## [0.12.8] - 2026-08-02
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- A failed `notify setup` no longer reports "Unable to persist and activate Telegram notification settings" when the new bot token and chat id are already on disk. The wording now follows the durable configuration, so it can no longer contradict a follow-up `notify status`; an operator who reads the failure as "nothing was saved" would otherwise leave Telegram armed for a token another poller may own (#3761).
+- A failed `notify setup` no longer reports "Unable to persist and activate Telegram notification settings" when the durable configuration already carries the attempted bot token, chat id, and enabled state. The wording now follows the stored configuration, so it can no longer contradict a follow-up `notify status`; an operator who reads the failure as "nothing was saved" would otherwise leave Telegram armed for a token another poller may own. A commit that was entered and then failed while the stored configuration is also unreadable is reported as undecided, pointing at `notify status`, instead of guessing either outcome (#3761).
 
 ## [0.12.11] - 2026-08-03
 

--- a/packages/coding-agent/src/cli/notify-cli.ts
+++ b/packages/coding-agent/src/cli/notify-cli.ts
@@ -534,8 +534,13 @@ async function runTelegramSetup(cmd: NotifyCommandArgs, deps: NotifyCommandDeps)
 		receipt.discard();
 	} catch (error) {
 		const detail = sanitizeDiagnostic(error instanceof Error ? error.message : "unknown persistence failure", token);
+		// The wording must describe what a follow-up `notify status` will show. A failure
+		// raised after the durable write landed — including one raised from inside the
+		// commit itself — must not claim the settings were not persisted, or the operator
+		// walks away believing Telegram is off while the daemon is armed for that token.
+		const persisted = settingsCommitted || telegramIdentityIsPersisted(settings, token.trim(), result.chatId);
 		throw new Error(
-			settingsCommitted
+			persisted
 				? `Telegram notification settings were saved, but activation or recovery failed: ${detail}`
 				: `Unable to persist and activate Telegram notification settings: ${detail}`,
 		);
@@ -543,6 +548,20 @@ async function runTelegramSetup(cmd: NotifyCommandArgs, deps: NotifyCommandDeps)
 	process.stdout.write(
 		`Notifications enabled. botToken=${maskToken(token)} chatId=${result.chatId} threaded=${result.threadedLabel}\n`,
 	);
+}
+
+/**
+ * Whether the durable settings already carry the Telegram identity this setup run
+ * attempted to write. Used to describe a setup failure by observed state instead of by
+ * how far the code path got, so the reported wording can never contradict `notify status`.
+ */
+function telegramIdentityIsPersisted(settings: Settings, botToken: string, chatId: string): boolean {
+	try {
+		const cfg = getNotificationConfig(settings);
+		return cfg.botToken === botToken && cfg.chatId === chatId;
+	} catch {
+		return false;
+	}
 }
 
 function proposedIdentityFromSetupPreflight(

--- a/packages/coding-agent/src/cli/notify-cli.ts
+++ b/packages/coding-agent/src/cli/notify-cli.ts
@@ -563,7 +563,9 @@ async function runTelegramSetup(cmd: NotifyCommandArgs, deps: NotifyCommandDeps)
 function telegramIntentIsPersisted(settings: Settings, botToken: string, chatId: string): boolean | undefined {
 	try {
 		const cfg = getNotificationConfig(settings);
-		return cfg.enabled === true && cfg.botToken === botToken && cfg.chatId === chatId;
+		return (
+			cfg.enabled === true && cfg.telegram?.enabled === true && cfg.botToken === botToken && cfg.chatId === chatId
+		);
 	} catch {
 		return undefined;
 	}

--- a/packages/coding-agent/src/cli/notify-cli.ts
+++ b/packages/coding-agent/src/cli/notify-cli.ts
@@ -538,7 +538,8 @@ async function runTelegramSetup(cmd: NotifyCommandArgs, deps: NotifyCommandDeps)
 		// raised after the durable write landed — including one raised from inside the
 		// commit itself — must not claim the settings were not persisted, or the operator
 		// walks away believing Telegram is off while the daemon is armed for that token.
-		const persisted = settingsCommitted || telegramIdentityIsPersisted(settings, token.trim(), result.chatId);
+		// Observed state wins; the code-path flag is only the fallback for an unreadable read.
+		const persisted = telegramIntentIsPersisted(settings, token.trim(), result.chatId) ?? settingsCommitted;
 		throw new Error(
 			persisted
 				? `Telegram notification settings were saved, but activation or recovery failed: ${detail}`
@@ -551,16 +552,20 @@ async function runTelegramSetup(cmd: NotifyCommandArgs, deps: NotifyCommandDeps)
 }
 
 /**
- * Whether the durable settings already carry the Telegram identity this setup run
- * attempted to write. Used to describe a setup failure by observed state instead of by
- * how far the code path got, so the reported wording can never contradict `notify status`.
+ * Whether the durable settings already carry the Telegram intent this setup run attempted to
+ * write: the same identity *and* the enabled state it would have produced. Matching the token
+ * and chat id alone is not enough — a previously disabled configuration can already hold both,
+ * and a commit that fails before enabling Telegram has persisted nothing new.
+ *
+ * Returns `undefined` when the durable state cannot be observed, so the caller can fall back
+ * instead of reporting a state nobody read.
  */
-function telegramIdentityIsPersisted(settings: Settings, botToken: string, chatId: string): boolean {
+function telegramIntentIsPersisted(settings: Settings, botToken: string, chatId: string): boolean | undefined {
 	try {
 		const cfg = getNotificationConfig(settings);
-		return cfg.botToken === botToken && cfg.chatId === chatId;
+		return cfg.enabled === true && cfg.botToken === botToken && cfg.chatId === chatId;
 	} catch {
-		return false;
+		return undefined;
 	}
 }
 

--- a/packages/coding-agent/src/cli/notify-cli.ts
+++ b/packages/coding-agent/src/cli/notify-cli.ts
@@ -457,6 +457,7 @@ async function runTelegramSetup(cmd: NotifyCommandArgs, deps: NotifyCommandDeps)
 		process.stdout.write(`Using provided chat id ${result.chatId} (non-interactive).\n`);
 	}
 	let settingsCommitted = false;
+	let commitAttempted = false;
 	try {
 		const proposedIdentity = deps.setupPreflight
 			? proposedIdentityFromSetupPreflight(deps.setupPreflight, token.trim(), result.chatId)
@@ -480,6 +481,7 @@ async function runTelegramSetup(cmd: NotifyCommandArgs, deps: NotifyCommandDeps)
 			{ path: "notifications.telegram.enabled", op: "set", value: true },
 		];
 		if (deps.setupRedact ?? cmd.redact) patches.push({ path: "notifications.redact", op: "set", value: true });
+		commitAttempted = true;
 		const receipt = await settings.commitAtomicBatch(patches);
 		settingsCommitted = true;
 		const activationMarker = createTelegramActivationMarker({
@@ -539,7 +541,17 @@ async function runTelegramSetup(cmd: NotifyCommandArgs, deps: NotifyCommandDeps)
 		// commit itself — must not claim the settings were not persisted, or the operator
 		// walks away believing Telegram is off while the daemon is armed for that token.
 		// Observed state wins; the code-path flag is only the fallback for an unreadable read.
-		const persisted = telegramIntentIsPersisted(settings, token.trim(), result.chatId) ?? settingsCommitted;
+		const observed = telegramIntentIsPersisted(settings, token.trim(), result.chatId);
+		const persisted = observed ?? settingsCommitted;
+		// A commit that was entered and then failed, whose durable state is also unreadable,
+		// is genuinely undecided: `commitAtomicBatch` can persist and still throw. Claiming
+		// either outcome would be a guess, so say so and point at the authoritative check.
+		if (!persisted && observed === undefined && commitAttempted) {
+			throw new Error(
+				"Telegram notification settings may or may not have been saved, and the stored configuration could not be read; " +
+					`run \`gjc notify status\` before retrying: ${detail}`,
+			);
+		}
 		throw new Error(
 			persisted
 				? `Telegram notification settings were saved, but activation or recovery failed: ${detail}`

--- a/packages/coding-agent/test/notify-setup.test.ts
+++ b/packages/coding-agent/test/notify-setup.test.ts
@@ -1601,6 +1601,46 @@ test("CLI setup reports a save when the durable identity landed before the failu
 	expect(getNotificationConfig(settings)).toMatchObject({ enabled: true, botToken: token, chatId: "999" });
 });
 
+test("CLI setup reports a persistence failure when the identity was already present but disabled", async () => {
+	// The same token and chat id can already sit in a disabled configuration. A commit that fails
+	// before enabling Telegram has persisted nothing new, so identity alone must not read as saved.
+	const settings = setupSettings({
+		"notifications.enabled": false,
+		"notifications.telegram.botToken": token,
+		"notifications.telegram.chatId": "999",
+	});
+	Object.defineProperty(settings, "commitAtomicBatch", {
+		configurable: true,
+		writable: true,
+		value: async (): Promise<CasReceipt> => {
+			throw new Error("could not persist");
+		},
+	});
+	const { fetchImpl } = makeFetch({ getMe: [{ ok: true, result: userOn }] });
+	let exitCode: number | undefined;
+	const { stdout, stderr } = await captureOutput(() =>
+		runNotifyCliCommand(
+			{ action: "setup", rawArgs: [] },
+			{
+				settings,
+				fetchImpl,
+				setupToken: token,
+				setupChatId: "999",
+				setupInteractive: false,
+				setupPreflight: {},
+				setExitCode: code => {
+					exitCode = code;
+				},
+			},
+		),
+	);
+	expect(exitCode).toBe(1);
+	expect(stderr).toContain("Unable to persist and activate Telegram notification settings");
+	expect(stderr).not.toContain("settings were saved");
+	expect(`${stdout}\n${stderr}`).not.toContain(token);
+	expect(getNotificationConfig(settings)).toMatchObject({ enabled: false });
+});
+
 describe("notify daemon-internal lightweight startup", () => {
 	function tempAgentDir(): string {
 		return fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notify-daemon-agent-"));

--- a/packages/coding-agent/test/notify-setup.test.ts
+++ b/packages/coding-agent/test/notify-setup.test.ts
@@ -1554,6 +1554,53 @@ test("CLI setup reports atomic persistence failure without an enabled success me
 	});
 });
 
+test("CLI setup reports a save when the durable identity landed before the failure", async () => {
+	// Regression for the field failure in #3761: the commit applies the new identity and then
+	// throws, so the code path never reaches its `settingsCommitted` flag while `notify status`
+	// already reports the new bot. The wording must follow the durable state, not the flag.
+	const settings = setupSettings({
+		"notifications.enabled": true,
+		"notifications.telegram.botToken": "prior-token",
+		"notifications.telegram.chatId": "prior-chat",
+	});
+	Object.defineProperty(settings, "commitAtomicBatch", {
+		configurable: true,
+		writable: true,
+		value: async (patches: readonly SettingsAtomicPatch[]): Promise<CasReceipt> => {
+			for (const patch of patches) {
+				if (patch.op === "set") settings.set(patch.path, patch.value as never);
+				else settings.unset(patch.path);
+			}
+			throw new Error("Telegram daemon provisional ownership could not be retired safely");
+		},
+	});
+	const { fetchImpl } = makeFetch({ getMe: [{ ok: true, result: userOn }] });
+	let exitCode: number | undefined;
+	const { stdout, stderr } = await captureOutput(() =>
+		runNotifyCliCommand(
+			{ action: "setup", rawArgs: [] },
+			{
+				settings,
+				fetchImpl,
+				setupToken: token,
+				setupChatId: "999",
+				setupInteractive: false,
+				setupPreflight: {},
+				setExitCode: code => {
+					exitCode = code;
+				},
+			},
+		),
+	);
+	expect(exitCode).toBe(1);
+	expect(stderr).toContain("settings were saved, but activation or recovery failed");
+	expect(stderr).not.toContain("Unable to persist");
+	expect(`${stdout}\n${stderr}`).not.toContain(token);
+	expect(stdout).not.toContain("Notifications enabled.");
+	// The reported wording matches what a follow-up `notify status` would show.
+	expect(getNotificationConfig(settings)).toMatchObject({ enabled: true, botToken: token, chatId: "999" });
+});
+
 describe("notify daemon-internal lightweight startup", () => {
 	function tempAgentDir(): string {
 		return fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notify-daemon-agent-"));

--- a/packages/coding-agent/test/notify-setup.test.ts
+++ b/packages/coding-agent/test/notify-setup.test.ts
@@ -1738,6 +1738,58 @@ test("CLI setup falls back to the code path when the durable state cannot be rea
 	expect(blockedReads).toBeGreaterThan(0);
 });
 
+test("CLI setup reports an undecided outcome when a failed commit leaves the state unreadable", async () => {
+	// `commitAtomicBatch` can persist and still throw, so a throw from inside the commit plus an
+	// unreadable durable state is genuinely undecided. Asserting either wording would be a guess.
+	const settings = setupSettings({
+		"notifications.enabled": false,
+		"notifications.telegram.botToken": "prior-token",
+		"notifications.telegram.chatId": "prior-chat",
+	});
+	let committed = false;
+	const readSnapshot = settings.getNotificationSettingsSnapshot.bind(settings);
+	Object.defineProperty(settings, "getNotificationSettingsSnapshot", {
+		configurable: true,
+		writable: true,
+		value: () => {
+			if (committed) throw new Error("settings snapshot unavailable");
+			return readSnapshot();
+		},
+	});
+	Object.defineProperty(settings, "commitAtomicBatch", {
+		configurable: true,
+		writable: true,
+		value: async (): Promise<CasReceipt> => {
+			committed = true;
+			throw new Error("commit failed after writing");
+		},
+	});
+	const { fetchImpl } = makeFetch({ getMe: [{ ok: true, result: userOn }] });
+	let exitCode: number | undefined;
+	const { stdout, stderr } = await captureOutput(() =>
+		runNotifyCliCommand(
+			{ action: "setup", rawArgs: [] },
+			{
+				settings,
+				fetchImpl,
+				setupToken: token,
+				setupChatId: "999",
+				setupInteractive: false,
+				setupPreflight: {},
+				setExitCode: code => {
+					exitCode = code;
+				},
+			},
+		),
+	);
+	expect(committed).toBe(true);
+	expect(exitCode).toBe(1);
+	expect(stderr).toContain("may or may not have been saved");
+	expect(stderr).toContain("notify status");
+	expect(stderr).not.toContain("Unable to persist and activate");
+	expect(`${stdout}\n${stderr}`).not.toContain(token);
+});
+
 describe("notify daemon-internal lightweight startup", () => {
 	function tempAgentDir(): string {
 		return fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notify-daemon-agent-"));

--- a/packages/coding-agent/test/notify-setup.test.ts
+++ b/packages/coding-agent/test/notify-setup.test.ts
@@ -1641,6 +1641,103 @@ test("CLI setup reports a persistence failure when the identity was already pres
 	expect(getNotificationConfig(settings)).toMatchObject({ enabled: false });
 });
 
+test("CLI setup reports a persistence failure when only the Telegram provider flag is missing", async () => {
+	// Global notifications can already be on with the same identity while the Telegram provider
+	// itself is disabled. `notify setup` writes both flags, so a commit that fails before the
+	// provider flag lands has persisted nothing new — status would still show Telegram off.
+	const settings = setupSettings({
+		"notifications.enabled": true,
+		"notifications.telegram.enabled": false,
+		"notifications.telegram.botToken": token,
+		"notifications.telegram.chatId": "999",
+	});
+	Object.defineProperty(settings, "commitAtomicBatch", {
+		configurable: true,
+		writable: true,
+		value: async (): Promise<CasReceipt> => {
+			throw new Error("could not persist");
+		},
+	});
+	const { fetchImpl } = makeFetch({ getMe: [{ ok: true, result: userOn }] });
+	let exitCode: number | undefined;
+	const { stdout, stderr } = await captureOutput(() =>
+		runNotifyCliCommand(
+			{ action: "setup", rawArgs: [] },
+			{
+				settings,
+				fetchImpl,
+				setupToken: token,
+				setupChatId: "999",
+				setupInteractive: false,
+				setupPreflight: {},
+				setExitCode: code => {
+					exitCode = code;
+				},
+			},
+		),
+	);
+	expect(exitCode).toBe(1);
+	expect(stderr).toContain("Unable to persist and activate Telegram notification settings");
+	expect(stderr).not.toContain("settings were saved");
+	expect(`${stdout}\n${stderr}`).not.toContain(token);
+	expect(getNotificationConfig(settings).telegram?.enabled).not.toBe(true);
+});
+
+test("CLI setup falls back to the code path when the durable state cannot be read", async () => {
+	// An unreadable durable state must not silently read as "not persisted": the commit landed,
+	// so the code-path flag is the only remaining evidence and it says the settings were saved.
+	const settings = setupSettings({
+		"notifications.enabled": false,
+		"notifications.telegram.botToken": "prior-token",
+		"notifications.telegram.chatId": "prior-chat",
+	});
+	let committed = false;
+	let blockedReads = 0;
+	const readSnapshot = settings.getNotificationSettingsSnapshot.bind(settings);
+	Object.defineProperty(settings, "getNotificationSettingsSnapshot", {
+		configurable: true,
+		writable: true,
+		value: () => {
+			if (committed) {
+				blockedReads += 1;
+				throw new Error("settings snapshot unavailable");
+			}
+			return readSnapshot();
+		},
+	});
+	const commit = settings.commitAtomicBatch.bind(settings);
+	Object.defineProperty(settings, "commitAtomicBatch", {
+		configurable: true,
+		writable: true,
+		value: async (patches: readonly SettingsAtomicPatch[]): Promise<CasReceipt> => {
+			const receipt = await commit(patches);
+			committed = true;
+			return receipt;
+		},
+	});
+	const { fetchImpl } = makeFetch({ getMe: [{ ok: true, result: userOn }] });
+	await expect(
+		captureOutput(() =>
+			runNotifyCommand(
+				{ action: "setup", rawArgs: [] },
+				{
+					settings,
+					fetchImpl,
+					setupToken: token,
+					setupChatId: "999",
+					setupInteractive: false,
+					setupPreflight: NO_DAEMON_PREFLIGHT,
+					ensureTelegramDaemon: async () => {
+						throw new Error("daemon readiness failed");
+					},
+				},
+			),
+		),
+	).rejects.toThrow("settings were saved, but activation or recovery failed");
+	// Proves the wording came from the code-path fallback, not from a readable durable state.
+	expect(blockedReads).toBeGreaterThan(0);
+});
+
 describe("notify daemon-internal lightweight startup", () => {
 	function tempAgentDir(): string {
 		return fs.mkdtempSync(path.join(os.tmpdir(), "gjc-notify-daemon-agent-"));


### PR DESCRIPTION
## What

`notify setup` chooses its failure wording from the durable Telegram configuration instead of from a flag set after `commitAtomicBatch` returns.

- `telegramIntentIsPersisted()` requires the attempted bot token, chat id **and** the enabled state the run intended; it returns `undefined` when the durable state cannot be read, and only then does the code-path flag act as fallback.
- A failure raised once the durable write has landed — including one raised from inside the commit — now reports "settings were saved, but activation or recovery failed".
- A genuinely unpersisted failure keeps "Unable to persist and activate …", including the case where the same token/chat id already sit in a **disabled** configuration — globally, or with only `notifications.telegram.enabled` off.
- A commit that was entered and then failed while the durable state is *also* unreadable is reported as undecided ("may or may not have been saved … run `gjc notify status`") instead of guessing an outcome in either direction.

Deliberately **not** in scope: rolling back the committed patches, and the daemon activation failure itself (#3761 slice 2, root cause not identified — see the investigation comment on the issue).

## Why

Fixes the reporting half of #3761.

`gjc notify setup --token … --chat-id …` fails with

```
Error: Unable to persist and activate Telegram notification settings:
       Telegram daemon provisional ownership could not be retired safely
```

while `gjc notify status` immediately afterwards reports `enabled: true`, `telegram.configured: yes`, and `gjc notify test` delivers. Reproduced on a brand-new bot with no competing poller, so it is not the 409 case. The operator reads "Unable to persist", assumes nothing happened, and leaves Telegram armed for that token — if the token belongs to a bot another product already polls, the next session's daemon competes for `getUpdates` on it, which is the #3587 failure mode reached silently through setup.

The wording came from `settingsCommitted`, set after the commit call returns, so it described how far the code path got rather than what is on disk.

## Testing

- `bun test packages/coding-agent/test/notify-setup.test.ts` → **56 pass, 0 fail**.
- Four new cases, all mutation-checked:
  - *durable identity landed before the failure* — the fake `commitAtomicBatch` applies the patches then throws; reverting the predicate to the flag alone fails it.
  - *identity already present but globally disabled* — dropping the `cfg.enabled === true` condition fails it.
  - *only the Telegram provider flag missing* — dropping the `cfg.telegram?.enabled === true` condition fails it.
  - *unreadable durable state* — one case asserts the code-path fallback still reports the saved wording after a successful commit plus a failed activation (and asserts the read was actually blocked), the other asserts the undecided wording when the commit itself threw.
- `bun --cwd=packages/coding-agent run check` (biome + tsc) → clean, re-run after each rebase.
- Full `bun run check` does not complete on this host for two pre-existing environment reasons, both reproduced on `origin/dev` without this diff: `sdk-daemon-cli-e2e.test.ts` "preserves unreadable endpoint discovery errors" expects exit 1 but the suite runs as root where `chmod 000` does not deny access; and an earlier run aborted inside a `bun x tsc` child with a Go runtime crash (`fatal error: non in-use span in unswept list`).

## Rebase history

Rebased onto `38e026c78` (current `dev`, through the 0.12.11 bump). The rebase carried the CHANGELOG entry into the already-released `0.12.10` section; it is now back under `[Unreleased]`. #3768 touches the same file and test file on the `recovery` path; the architect pass below covers that interaction and the CHANGELOG release-boundary check.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:68e0a288b0e01a718ca58a662ffb2626a565411f reviewer:architect evidence:local architect pass (packages/coding-agent/src/prompts/agents/architect.md, model codex-2/gpt-5.6-terra) on exact head 68e0a288b0e01a718ca58a662ffb2626a565411f — APPROVE, findings 0, five-item table all pass (predicate/fallback, truthfulness, Unreleased CHANGELOG ownership, tests, status-daemon-recovery interaction); two earlier findings on prior heads (missing notifications.telegram.enabled in the predicate; unreadable-state-after-failed-commit reported as not persisted) are fixed and covered; plus bun test packages/coding-agent/test/notify-setup.test.ts 56 pass 0 fail and biome + tsc -p tsconfig.tools.json --noEmit clean
```

Earlier architect passes on prior heads raised three findings, each fixed by the following commit and re-reviewed: identity-only match could misreport a pre-existing disabled configuration as saved; the predicate ignored `notifications.telegram.enabled`; and a commit that threw after persisting with an unreadable durable state reported "Unable to persist". The current head is the first to come back with 0 findings.

---

- [x] Target branch is `dev`
- [ ] `bun check` passes — targeted `bun --cwd=packages/coding-agent run check` is clean; the full aggregate aborts on pre-existing host failures documented above (both reproduce on `origin/dev`)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit

