### PR TITLE
fix(coding-agent): use stored credential in auth-invalidation test

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Composer Bash policy rejections now identify the active provider surface and direct Cursor Composer models to their native repository tools, enabling the agent runtime's bounded automatic recovery instead of leaving a blocked shell attempt as a terminal turn.
+- The `AgentSession retry fallback > invalidates an auth-failed managed credential` test now uses a stored credential instead of a runtime-key override, matching the pin-guard behavior added in #3724 where `--api-key`/`--credential` pinned keys are never invalidated; the shared test fixture installed runtime keys as plumbing, which silently tripped the new guard and blocked the auth invalidation path.
 - The Extension Control Center inspector no longer crashes when a narrow two-column layout leaves its preview pane fewer than two columns wide.
 - Prompt-template positional arguments now preserve literal `$@` and `$ARGUMENTS` text instead of recursively expanding it during placeholder substitution.
 - Native Windows session and GC commands now report the searched `psmux` / `pmux` / `tmux` provider set when no compatible multiplexer is available instead of leaking a literal `tmux` spawn error (#3688).

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -1527,6 +1527,13 @@ describe("AgentSession retry fallback", () => {
 	});
 
 	it("invalidates an auth-failed managed credential before its next outer attempt", async () => {
+	// #3724 added a pin guard that refuses to rotate credentials set via
+	// setRuntimeApiKey (—api-key/—credential). The shared beforeEach installs
+	// runtime keys for every provider as test plumbing, which silently tripped
+	// that guard and blocked invalidation on the auth path. Use a stored
+	// credential instead, matching the other rotation tests in this suite.
+	authStorage.removeRuntimeApiKey("anthropic");
+	await authStorage.set("anthropic", [{ type: "api_key", key: "anthropic-test-key" }]);
 		const primary = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const fallback = getBundledModel("openai", "gpt-4o-mini");
 		if (!primary || !fallback) throw new Error("Expected bundled test models");


### PR DESCRIPTION
## What

- Switch the "invalidates an auth-failed managed credential" test from a `setRuntimeApiKey` override to a stored credential (`removeRuntimeApiKey` + `set`), matching the pin-guard behavior added in #3724.

## Why

#3724 added a pin guard to `#markFailedCredential` that refuses to invalidate credentials set via `setRuntimeApiKey` (`--api-key`/`--credential`). The shared `beforeEach` in `agent-session-retry-fallback.test.ts` installs runtime keys for every provider as test plumbing, which silently tripped the new guard and blocked the auth invalidation path. The test received 6 retry calls instead of the expected 2 (primary fails → fallback succeeds).

CI run [30771702761](https://github.com/Yeachan-Heo/gajae-code/actions/runs/30771702761) shard-8-of-8 failed with:
```
(fail) AgentSession retry fallback > invalidates an auth-failed managed credential
Expected: 2
Received: 6
```

## Root cause

**Merge attribution: #3724** (`ffe2ca4fe`). The commit moved `hasRuntimeApiKey` from after `invalidateCredentialMatching` (old: auth-path-only) to before it (new: shared pin guard for all trigger classes). This is the intended behavior change: a pinned key should never be rotated. The test simply needed updating to match.

## Verification

- `bun test packages/coding-agent/test/agent-session-retry-fallback.test.ts` — 27 pass, 0 fail (was 26 pass, 1 fail)
- `bun test packages/coding-agent/test/fallback-controller-credential-rotation.test.ts` — 5 pass (#3724 tests still pass)
- `bun test packages/coding-agent/test/credential-rotation-session.e2e.test.ts` — 2 pass (#3724 tests still pass)
- `bun test packages/ai/test/stream-auth-forbidden.test.ts` — 6 pass
- `bun test packages/ai/test/fallback-transport-auth-kind.test.ts` — 9 pass
- `biome lint` — clean
- `tsc --noEmit` — no errors

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-ready sha256:831fff2ac reviewer:Yeachan-Heo evidence:terminal-exact-head-red-team
```

- [x] Target branch is `dev`
- [x] `bun check` passes (focused)
- [x] Tested locally