### PR TITLE
style(coding-agent): fix Biome indentation in auth-invalidation test

### DIFF
--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -1527,13 +1527,13 @@ describe("AgentSession retry fallback", () => {
 	});
 
 	it("invalidates an auth-failed managed credential before its next outer attempt", async () => {
-	// #3724 added a pin guard that refuses to rotate credentials set via
-	// setRuntimeApiKey (—api-key/—credential). The shared beforeEach installs
-	// runtime keys for every provider as test plumbing, which silently tripped
-	// that guard and blocked invalidation on the auth path. Use a stored
-	// credential instead, matching the other rotation tests in this suite.
-	authStorage.removeRuntimeApiKey("anthropic");
-	await authStorage.set("anthropic", [{ type: "api_key", key: "anthropic-test-key" }]);
+		// #3724 added a pin guard that refuses to rotate credentials set via
+		// setRuntimeApiKey (—api-key/—credential). The shared beforeEach installs
+		// runtime keys for every provider as test plumbing, which silently tripped
+		// that guard and blocked invalidation on the auth path. Use a stored
+		// credential instead, matching the other rotation tests in this suite.
+		authStorage.removeRuntimeApiKey("anthropic");
+		await authStorage.set("anthropic", [{ type: "api_key", key: "anthropic-test-key" }]);
 		const primary = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const fallback = getBundledModel("openai", "gpt-4o-mini");
 		if (!primary || !fallback) throw new Error("Expected bundled test models");


### PR DESCRIPTION
## What

- Fix single-tab → double-tab indentation on the 7 lines added by #3766 inside the `it()` body in `agent-session-retry-fallback.test.ts`.

## Why

#3766 added lines with single-tab indentation, but Biome requires double-tab (the lines are inside `describe()` → `it()`, so two levels of nesting). The formatter violation failed `biome check .` in the CI `check:@gajae-code/coding-agent` job.

CI run [30773462117](https://github.com/Yeachan-Heo/gajae-code/actions/runs/30773462117) failed:
```
test/agent-session-retry-fallback.test.ts format
× Formatter would have printed the following content:
  1530 │ - → // #3724 added...
  1530 │ + → → // #3724 added...
```

## Root cause

My prior PR #3766 commit was not formatted with `biome check --write` before pushing. The test passed but the formatter gate caught the indentation mismatch. This is a follow-up to my own merged change.

## Verification

- `biome check packages/coding-agent/test/agent-session-retry-fallback.test.ts` — clean
- `bun test packages/coding-agent/test/agent-session-retry-fallback.test.ts -t "invalidates..."` — 1 pass, 3 assertions
- Diff is indentation-only (1-tab → 2-tab on 7 lines), zero logic change

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-ready sha256:5c8d6b1de reviewer:Yeachan-Heo evidence:terminal-exact-head-red-team
```

- [x] Target branch is `dev`
- [x] `biome check` passes
- [x] Tested locally