### PR TITLE
fix(ai): honor MiniMax M3 official 1M routes

### DIFF
--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -456,11 +456,17 @@ function applyGeneratedModelPolicy(model: ApiModel<Api>): void {
 			requiresReasoningContentForToolCalls: true,
 		};
 	}
-	// MiniMax-M3: MiniMax exposes a 1M context tier, but usage beyond 512K is
-	// billed separately. Keep bundled/default metadata at the billing-safe 512K
-	// unless an explicit paid-tier contract is added.
-	if (model.provider !== "opencode-go" && model.id === "minimax-m3") {
-		model.contextWindow = 512_000;
+	// MiniMax-M3's official Token Plan routes expose a 1M context window.
+	// Scope the correction to the four first-class regional MiniMax routes;
+	// unrelated catalog aliases and providers keep their own contracts.
+	if (
+		model.id === "minimax-m3" &&
+		(model.provider === "minimax" ||
+			model.provider === "minimax-cn" ||
+			model.provider === "minimax-code" ||
+			model.provider === "minimax-code-cn")
+	) {
+		model.contextWindow = 1_000_000;
 	}
 }
 

--- a/packages/ai/test/issue-385-minimax-m3.test.ts
+++ b/packages/ai/test/issue-385-minimax-m3.test.ts
@@ -11,7 +11,7 @@ describe("MiniMax M3 support (issue #385)", () => {
 
 			expect(model.id).toBe("minimax-m3");
 			expect(model.provider).toBe(provider);
-			expect(model.contextWindow).toBe(512_000);
+			expect(model.contextWindow).toBe(1_000_000);
 			expect(model.maxTokens).toBe(128_000);
 			expect(model.input).toContain("text");
 			expect(model.input).toContain("image");
@@ -29,5 +29,9 @@ describe("MiniMax M3 support (issue #385)", () => {
 			const model = getBundledModel(provider, "minimax-m3");
 			expect(model.name).toBe("MiniMax-M3");
 		}
+	});
+
+	test("does not widen unrelated MiniMax catalog aliases", () => {
+		expect(getBundledModel("minimax-code", "minimax-v3").contextWindow).toBe(512_000);
 	});
 });

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -229,6 +229,24 @@ describe("generated model policies", () => {
 		});
 	});
 
+	it("maps only first-class MiniMax M3 routes to the official 1M context", () => {
+		const models = [
+			createModel({ id: "minimax-m3", api: "anthropic-messages", provider: "minimax" }),
+			createModel({ id: "minimax-m3", api: "anthropic-messages", provider: "minimax-cn" }),
+			createModel({ id: "minimax-m3", api: "openai-completions", provider: "minimax-code" }),
+			createModel({ id: "minimax-m3", api: "openai-completions", provider: "minimax-code-cn" }),
+			createModel({ id: "minimax-m3", api: "openai-completions", provider: "openai-codex" }),
+			createModel({ id: "minimax-m3", api: "openai-completions", provider: "opencode" }),
+		];
+
+		applyGeneratedModelPolicies(models);
+
+		expect(models.slice(0, 4).map(model => model.contextWindow)).toEqual([
+			1_000_000, 1_000_000, 1_000_000, 1_000_000,
+		]);
+		expect(models.slice(4).map(model => model.contextWindow)).toEqual([200_000, 200_000]);
+	});
+
 	it("refreshes thinking metadata and applies parsed catalog corrections", () => {
 		const models: Model<Api>[] = [
 			{


### PR DESCRIPTION
## Summary
- scope MiniMax M3's 1,000,000-token context correction to the four first-class regional MiniMax routes
- preserve unrelated catalog aliases and providers, including `openai-codex`
- add route-specific policy, boundary, and alias-preservation regressions

## Evidence
Official MiniMax Token Plan sources:
- Claude Code: https://platform.minimax.io/docs/token-plan/claude-code.md (`MiniMax-M3[1m]`, auto-compact window `1000000`)
- Codex: https://platform.minimax.io/docs/token-plan/codex.md (`model_provider = "minimax"`, `wire_api = "responses"`, `model_context_window = 1000000`)

## Verification
- `bun test packages/ai/test/issue-385-minimax-m3.test.ts packages/ai/test/model-thinking.test.ts`
- `bun test packages/ai/test/issue-385-minimax-m3.test.ts packages/ai/test/generate-models.test.ts packages/ai/test/startup-imports.test.ts packages/ai/test/openai-codex-default.test.ts`
- `bun --cwd=packages/ai run check`
- `bun run ci:test:smoke`
- `bun run build`
- `git diff --check`

Full repository `bun run check` was started and is still being observed in the lane; focused/package/build/smoke commands completed successfully.

Closes #3770

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*