### PR TITLE
style(natives): collapse fs_cache iterator chains per pinned rustfmt

### DIFF
--- a/crates/pi-natives/src/fs_cache.rs
+++ b/crates/pi-natives/src/fs_cache.rs
@@ -9,7 +9,8 @@
 //! - `FS_SCAN_CACHE_TTL_MS`       – default `1000`
 //! - `FS_SCAN_EMPTY_RECHECK_MS`   – default `200`
 //! - `FS_SCAN_CACHE_MAX_ENTRIES`   – default `16`
-//! - `FS_SCAN_CACHE_MAX_BYTES`     – default `134217728` (128 MiB); `0` disables caching
+//! - `FS_SCAN_CACHE_MAX_BYTES`     – default `134217728` (128 MiB); `0`
+//!   disables caching
 
 use std::{
 	borrow::Cow,
@@ -146,10 +147,7 @@ fn approx_entries_bytes(entries: &[GlobMatch]) -> usize {
 type ScanCache = DashMap<CacheKey, CacheEntry>;
 
 fn cached_bytes_total(cache: &ScanCache) -> usize {
-	cache
-		.iter()
-		.map(|entry| entry.value().approx_bytes)
-		.sum()
+	cache.iter().map(|entry| entry.value().approx_bytes).sum()
 }
 
 /// Evict oldest entries until both the entry-count and byte budgets hold.


### PR DESCRIPTION
Follow-up to #3774, which was merged before the pinned-rustfmt fix landed on the branch: the `Affected path validation / rust-check` lane failed on `cargo fmt --check` for the new `cached_bytes_total` helper in `crates/pi-natives/src/fs_cache.rs`.

This applies the `fmt:rs` output for the pinned `nightly-2026-04-29` toolchain (3 insertions, 5 deletions, formatting only). Verified locally: `check:rs` clean, `cargo test -p pi-natives fs_cache` 11/11.