### PR TITLE
feat(tui): add incremental search to settings menus

### DIFF
--- a/packages/coding-agent/src/modes/DESIGN.md
+++ b/packages/coding-agent/src/modes/DESIGN.md
@@ -63,9 +63,11 @@ visible-width-aligned column capped at 30 cells, two spaces, then a truncated
 value. The selected row uses the themed cursor; unselected rows reserve two
 spaces. It centers the selected item inside its `maxVisible` window, reports
 scroll position as `(current/total)`, places a blank row before the selected
-item description, and ends with the dim
-`Enter/Space to change · Esc to cancel` hint. Hosts that need stable height
-reserve fixed description rows; the status-line custom editor reserves two.
+item description, and ends with a dim keyboard hint. Printable text starts a
+case-insensitive label search shown above the list; Backspace removes one
+grapheme, and Escape clears a non-empty search before a later Escape cancels
+the list. Hosts that need stable height reserve fixed description rows; the
+status-line custom editor reserves two.
 
 Submenus are a content replacement, not a modal overlay: a bold accent title,
 optional muted description, optional preview, a spacer, a select/list control,
@@ -82,8 +84,9 @@ empty space and list density for an operational setup flow.
 ### Focus, cursor, keyboard, and input behavior
 
 - Up/Down wrap within selector lists. Enter and Space activate the current
-  action. Escape follows the current component's cancel path before the parent
-  is allowed to close.
+  action. Printable text filters settings by label. Escape first clears an
+  active filter, then follows the current component's cancel path before the
+  parent is allowed to close.
 - The parent routes Tab/Left/Right to the tab bar except while a text input is
   active. Text entry owns arrow keys and Tab in that state.
 - `Input` has a visible `> ` prompt, a zero-width hardware cursor marker only

--- a/packages/tui/src/components/settings-list.ts
+++ b/packages/tui/src/components/settings-list.ts
@@ -207,7 +207,7 @@ export class SettingsList implements Component {
 		// Add hint
 		lines.push("");
 		const hint = this.#searchQuery
-			? "  Type to search · Backspace to edit · Esc to clear"
+			? "  Type to search · Enter to change · Backspace to edit · Esc to clear"
 			: "  Type to search · Enter/Space to change · Esc to cancel";
 		lines.push(truncateToWidth(this.#theme.hint(hint), width));
 

--- a/packages/tui/src/components/settings-list.ts
+++ b/packages/tui/src/components/settings-list.ts
@@ -1,6 +1,7 @@
 import { getKeybindings } from "../keybindings";
+import { extractPrintableText, matchesKey } from "../keys";
 import type { Component } from "../tui";
-import { Ellipsis, padding, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "../utils";
+import { Ellipsis, getSegmenter, padding, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "../utils";
 
 export interface SettingItem {
 	/** Unique identifier for this setting */
@@ -26,7 +27,9 @@ export interface SettingsListTheme {
 }
 
 export class SettingsList implements Component {
+	#allItems: SettingItem[];
 	#items: SettingItem[];
+	#searchQuery = "";
 	#theme: SettingsListTheme;
 	#selectedIndex = 0;
 	#maxVisible: number;
@@ -48,6 +51,7 @@ export class SettingsList implements Component {
 		onSelectionChange?: (item: SettingItem | undefined) => void,
 		descriptionRows = 0,
 	) {
+		this.#allItems = items;
 		this.#items = items;
 		this.#maxVisible = maxVisible;
 		this.#theme = theme;
@@ -68,7 +72,7 @@ export class SettingsList implements Component {
 
 	/** Update an item's currentValue */
 	updateValue(id: string, newValue: string): void {
-		const item = this.#items.find(i => i.id === id);
+		const item = this.#allItems.find(i => i.id === id);
 		if (item) {
 			item.currentValue = newValue;
 		}
@@ -82,8 +86,21 @@ export class SettingsList implements Component {
 	 * restored index against the new list on the way out.
 	 */
 	setItems(items: SettingItem[]): void {
-		this.#items = items;
+		this.#allItems = items;
+		this.#items = this.#filterItems();
 		this.#clampSelectedIndex();
+		this.#notifySelectionChange();
+	}
+
+	#filterItems(): SettingItem[] {
+		const query = this.#searchQuery.toLocaleLowerCase();
+		return query ? this.#allItems.filter(item => item.label.toLocaleLowerCase().includes(query)) : this.#allItems;
+	}
+
+	#setSearchQuery(query: string): void {
+		this.#searchQuery = query.normalize("NFC");
+		this.#items = this.#filterItems();
+		this.#selectedIndex = 0;
 		this.#notifySelectionChange();
 	}
 
@@ -106,9 +123,17 @@ export class SettingsList implements Component {
 
 	#renderMainList(width: number): string[] {
 		const lines: string[] = [];
+		if (this.#searchQuery) {
+			lines.push(this.#theme.hint(truncateToWidth(`  Search: ${this.#searchQuery}`, width)));
+			lines.push("");
+		}
 
 		if (this.#items.length === 0) {
-			lines.push(this.#theme.hint("  No settings available"));
+			lines.push(this.#theme.hint(this.#searchQuery ? "  No matching settings" : "  No settings available"));
+			if (this.#searchQuery) {
+				lines.push("");
+				lines.push(this.#theme.hint(truncateToWidth("  Type to search · Backspace to edit · Esc to clear", width)));
+			}
 			return lines;
 		}
 
@@ -181,7 +206,10 @@ export class SettingsList implements Component {
 
 		// Add hint
 		lines.push("");
-		lines.push(truncateToWidth(this.#theme.hint("  Enter/Space to change · Esc to cancel"), width));
+		const hint = this.#searchQuery
+			? "  Type to search · Backspace to edit · Esc to clear"
+			: "  Type to search · Enter/Space to change · Esc to cancel";
+		lines.push(truncateToWidth(this.#theme.hint(hint), width));
 
 		return lines;
 	}
@@ -196,24 +224,44 @@ export class SettingsList implements Component {
 
 		// Main list input handling
 		const kb = getKeybindings();
-		if (this.#items.length === 0) {
-			if (kb.matches(data, "tui.select.cancel")) {
+		if (this.#items.length > 0 && kb.matches(data, "tui.select.up")) {
+			this.#selectedIndex = this.#selectedIndex === 0 ? this.#items.length - 1 : this.#selectedIndex - 1;
+			this.#notifySelectionChange();
+			return;
+		}
+		if (this.#items.length > 0 && kb.matches(data, "tui.select.down")) {
+			this.#selectedIndex = this.#selectedIndex === this.#items.length - 1 ? 0 : this.#selectedIndex + 1;
+			this.#notifySelectionChange();
+			return;
+		}
+		if (
+			this.#items.length > 0 &&
+			(kb.matches(data, "tui.select.confirm") || data === "\n" || (data === " " && !this.#searchQuery))
+		) {
+			this.#activateItem();
+			return;
+		}
+		if (kb.matches(data, "tui.select.cancel")) {
+			if (this.#searchQuery) {
+				this.#setSearchQuery("");
+			} else {
 				this.#onCancel();
 			}
 			return;
 		}
-
-		if (kb.matches(data, "tui.select.up")) {
-			this.#selectedIndex = this.#selectedIndex === 0 ? this.#items.length - 1 : this.#selectedIndex - 1;
-			this.#notifySelectionChange();
-		} else if (kb.matches(data, "tui.select.down")) {
-			this.#selectedIndex = this.#selectedIndex === this.#items.length - 1 ? 0 : this.#selectedIndex + 1;
-			this.#notifySelectionChange();
-		} else if (kb.matches(data, "tui.select.confirm") || data === " " || data === "\n") {
-			this.#activateItem();
-		} else if (kb.matches(data, "tui.select.cancel")) {
-			this.#onCancel();
+		if (this.#searchQuery && matchesKey(data, "backspace")) {
+			const graphemes = [...getSegmenter().segment(this.#searchQuery)];
+			this.#setSearchQuery(
+				graphemes
+					.slice(0, -1)
+					.map(part => part.segment)
+					.join(""),
+			);
+			return;
 		}
+
+		const printableText = extractPrintableText(data);
+		if (printableText) this.#setSearchQuery(this.#searchQuery + printableText);
 	}
 
 	#activateItem(): void {

--- a/packages/tui/test/settings-list.test.ts
+++ b/packages/tui/test/settings-list.test.ts
@@ -153,6 +153,34 @@ describe("SettingsList", () => {
 		expect(rendered).toContain("Memory Backend");
 		expect(rendered).not.toContain("Theme");
 	});
+	it("activates the filtered item at its filtered index, not its original index", () => {
+		const changes: Array<[string, string]> = [];
+		const list = new SettingsList(
+			[
+				{ id: "memory", label: "Memory Backend", currentValue: "local", values: ["local", "off"] },
+				{ id: "theme", label: "Theme", currentValue: "dark", values: ["dark", "light"] },
+			],
+			5,
+			testTheme,
+			(id, newValue) => {
+				changes.push([id, newValue]);
+			},
+			() => {
+				throw new Error("cancel should not be called");
+			},
+		);
+
+		// "theme" is index 1 in the unfiltered list but index 0 once filtered.
+		for (const character of "theme") list.handleInput(character);
+		const filtered = Bun.stripANSI(list.render(80).join("\n"));
+		expect(filtered).toContain("Theme");
+		expect(filtered).not.toContain("Memory Backend");
+		expect(filtered).toContain("Enter to change");
+
+		list.handleInput("\n");
+
+		expect(changes).toEqual([["theme", "light"]]);
+	});
 
 	it("clears search before cancelling the settings list", () => {
 		let cancelCount = 0;

--- a/packages/tui/test/settings-list.test.ts
+++ b/packages/tui/test/settings-list.test.ts
@@ -127,6 +127,65 @@ describe("SettingsList", () => {
 		expect(cancelled).toBe(true);
 	});
 
+	it("filters settings as printable text is entered", () => {
+		let changed = false;
+		const list = new SettingsList(
+			[
+				{ id: "memory", label: "Memory Backend", currentValue: "local", values: ["local", "off"] },
+				{ id: "theme", label: "Theme", currentValue: "dark" },
+			],
+			5,
+			testTheme,
+			() => {
+				changed = true;
+			},
+			() => {
+				throw new Error("cancel should not be called");
+			},
+		);
+
+		for (const character of "Memory") list.handleInput(character);
+		list.handleInput(" ");
+		const rendered = Bun.stripANSI(list.render(80).join("\n"));
+
+		expect(changed).toBe(false);
+		expect(rendered).toContain("Search: Memory ");
+		expect(rendered).toContain("Memory Backend");
+		expect(rendered).not.toContain("Theme");
+	});
+
+	it("clears search before cancelling the settings list", () => {
+		let cancelCount = 0;
+		const list = new SettingsList(
+			[
+				{ id: "memory", label: "Memory Backend", currentValue: "local" },
+				{ id: "theme", label: "Theme", currentValue: "dark" },
+			],
+			5,
+			testTheme,
+			() => {},
+			() => {
+				cancelCount += 1;
+			},
+		);
+
+		list.handleInput("m");
+		list.handleInput("e");
+		list.handleInput("x");
+		list.handleInput("\x7f");
+		expect(Bun.stripANSI(list.render(80).join("\n"))).toContain("Search: me");
+
+		list.handleInput("\x1b");
+		const restored = Bun.stripANSI(list.render(80).join("\n"));
+		expect(cancelCount).toBe(0);
+		expect(restored).not.toContain("Search:");
+		expect(restored).toContain("Memory Backend");
+		expect(restored).toContain("Theme");
+
+		list.handleInput("\x1b");
+		expect(cancelCount).toBe(1);
+	});
+
 	it("clamps selection when a submenu closes after the list shrinks", () => {
 		const list = new SettingsList(
 			[


### PR DESCRIPTION
## Summary

- filter settings by label as printable text is entered
- show the active query and search-specific keyboard hints
- clear the active search on Escape before closing the settings menu
- support grapheme-aware Backspace and multi-word queries

## Behavior

Typing in a settings list now performs a case-insensitive substring search. When a query is active, Space is appended to the query; with no active query, the existing Space-to-activate behavior is preserved. Submenu input ownership and confirm precedence remain unchanged.

## Testing

- `bun test packages/tui/test/settings-list.test.ts`
- `bun --cwd=packages/tui run check`
- real PTY and xterm.js verification for filtering and Escape restoration at 120x44
- independent integrity and visual fidelity reviews passed