### PR TITLE
feat(modes): report turn status to the hosting terminal

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Interactive turns now emit a host-terminal status marker (OSC 777 `notify;Terax;gjc;<event>`) when `TERAX_TERMINAL` is set, so a hosting terminal can follow working/attention/finished without polling. Silent in every other terminal.
+- Interactive turns now announce their state as an OSC 777 sequence (`notify;Terax;gjc;working|attention|finished`), so a hosting terminal can follow the agent without polling. Terminals that do not parse it discard it like any unknown OSC, and print/RPC mode stdout is untouched.
 
 ## [0.12.10] - 2026-08-03
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Interactive turns now emit a host-terminal status marker (OSC 777 `notify;Terax;gjc;<event>`) when `TERAX_TERMINAL` is set, so a hosting terminal can follow working/attention/finished without polling. Silent in every other terminal.
+
 ## [0.12.10] - 2026-08-03
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -32,6 +32,7 @@ import { computeIrcSplitWidths, getIrcSidebarSemanticToken } from "../components
 import type { IrcObservationRecord } from "../irc-observation-ledger";
 import { interruptHint } from "../shared";
 import { buildAbortDisplayMessage } from "../utils/abort-message";
+import { emitHostStatus } from "../utils/host-status";
 import { consumeInjectedOptimisticSignature } from "../utils/injected-user-submission";
 import { parseIrcMessage } from "../utils/irc-message";
 import { ringTerminalBell } from "../utils/terminal-bell";
@@ -298,6 +299,7 @@ export class EventController {
 	}
 
 	async #handleAgentStart(_event: Extract<AgentSessionEvent, { type: "agent_start" }>): Promise<void> {
+		emitHostStatus("working");
 		this.ctx.promptSuggestion?.onAgentStart();
 		this.#lastIntent = undefined;
 		this.#readToolCallArgs.clear();
@@ -924,6 +926,7 @@ export class EventController {
 		this.ctx.updateEditorBorderColor();
 		this.ctx.ui.requestRender();
 		this.#scheduleIdleCompaction();
+		emitHostStatus("finished");
 		this.sendCompletionNotification();
 		this.ctx.promptSuggestion?.onAgentEnd();
 	}

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -40,6 +40,7 @@ import { createReadonlySessionManager } from "../../session/session-manager";
 import { parseThinkingLevel } from "../../thinking";
 import type { TodoPhase } from "../../tools/todo-write";
 import { setSessionTerminalTitle, setTerminalTitle } from "../../utils/title-generator";
+import { emitHostStatus } from "../utils/host-status";
 import { applyInjectedUserSubmission } from "../utils/injected-user-submission";
 import { classifyHookSelectorBellEvent, ringTerminalBell } from "../utils/terminal-bell";
 import { prepareTranscriptRebuild } from "../utils/ui-helpers";
@@ -1258,6 +1259,7 @@ export class ExtensionUiController {
 			computeBudget();
 
 		ringTerminalBell(classifyHookSelectorBellEvent(title));
+		emitHostStatus("attention");
 
 		this.ctx.hookSelector = new HookSelectorComponent(
 			title,

--- a/packages/coding-agent/src/modes/utils/host-status.ts
+++ b/packages/coding-agent/src/modes/utils/host-status.ts
@@ -1,0 +1,29 @@
+/**
+ * Host-terminal agent status markers.
+ *
+ * Terax runs `gjc` inside its own PTY and shows per-tab agent status. It reads
+ * an OSC 777 marker (`notify;Terax;gjc;<event>`) from the PTY stream, so the
+ * status is reported here rather than through the extension surface, which is
+ * quarantined for filesystem-discovered modules.
+ *
+ * The marker is written only when the host advertises itself through
+ * `TERAX_TERMINAL`; every other terminal sees nothing.
+ */
+
+export type HostStatusEvent = "working" | "attention" | "finished";
+
+function marker(event: HostStatusEvent): string {
+	return `\x1b]777;notify;Terax;gjc;${event}\x07`;
+}
+
+export function emitHostStatus(
+	event: HostStatusEvent,
+	output: Pick<NodeJS.WriteStream, "write"> = process.stdout,
+): void {
+	if (!process.env.TERAX_TERMINAL) return;
+	try {
+		output.write(marker(event));
+	} catch {
+		// Best-effort host integration only.
+	}
+}

--- a/packages/coding-agent/src/modes/utils/host-status.ts
+++ b/packages/coding-agent/src/modes/utils/host-status.ts
@@ -1,13 +1,23 @@
 /**
  * Host-terminal agent status markers.
  *
- * Terax runs `gjc` inside its own PTY and shows per-tab agent status. It reads
- * an OSC 777 marker (`notify;Terax;gjc;<event>`) from the PTY stream, so the
- * status is reported here rather than through the extension surface, which is
- * quarantined for filesystem-discovered modules.
+ * Interactive turns announce their state as an OSC 777 sequence:
  *
- * The marker is written only when the host advertises itself through
- * `TERAX_TERMINAL`; every other terminal sees nothing.
+ *     ESC ] 777 ; notify;Terax;gjc;<event> BEL
+ *
+ * A terminal that understands the sequence (Terax reads it to drive its per-tab
+ * agent status and header bell) reacts; every other terminal discards the OSC
+ * as unknown, exactly like the OSC 133 prompt marks and OSC 7 cwd reports that
+ * shells emit unconditionally. So there is no host sniffing and no env gate:
+ * any host that wants agent status can parse the stream without gjc knowing it
+ * exists.
+ *
+ * `notify;Terax;` is the wire identifier of the only protocol that currently
+ * carries per-turn agent state, not a host check - the payload names gjc as the
+ * reporting agent.
+ *
+ * Interactive TUI only. Print and RPC mode stdout stays byte-for-byte parseable
+ * because they never reach these controllers.
  */
 
 export type HostStatusEvent = "working" | "attention" | "finished";
@@ -20,7 +30,6 @@ export function emitHostStatus(
 	event: HostStatusEvent,
 	output: Pick<NodeJS.WriteStream, "write"> = process.stdout,
 ): void {
-	if (!process.env.TERAX_TERMINAL) return;
 	try {
 		output.write(marker(event));
 	} catch {

--- a/packages/coding-agent/test/host-status.test.ts
+++ b/packages/coding-agent/test/host-status.test.ts
@@ -1,26 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { emitHostStatus } from "@gajae-code/coding-agent/modes/utils/host-status";
 
-const original = process.env.TERAX_TERMINAL;
-
 afterEach(() => {
-	if (original === undefined) delete process.env.TERAX_TERMINAL;
-	else process.env.TERAX_TERMINAL = original;
 	vi.restoreAllMocks();
 });
 
 describe("host status markers", () => {
-	it("stays silent outside a host terminal", () => {
-		delete process.env.TERAX_TERMINAL;
-		const output = { write: vi.fn(() => true) };
-
-		emitHostStatus("working", output);
-
-		expect(output.write).not.toHaveBeenCalled();
-	});
-
 	it("writes the agent-attributed OSC 777 marker for each event", () => {
-		process.env.TERAX_TERMINAL = "1";
 		const output = { write: vi.fn(() => true) };
 
 		emitHostStatus("working", output);
@@ -32,8 +18,31 @@ describe("host status markers", () => {
 		expect(output.write).toHaveBeenNthCalledWith(3, "\x1b]777;notify;Terax;gjc;finished\x07");
 	});
 
+	it("reports without asking the host to identify itself", () => {
+		const previous = process.env.TERAX_TERMINAL;
+		delete process.env.TERAX_TERMINAL;
+		const output = { write: vi.fn(() => true) };
+
+		emitHostStatus("finished", output);
+
+		expect(output.write).toHaveBeenCalledTimes(1);
+		if (previous !== undefined) process.env.TERAX_TERMINAL = previous;
+	});
+
+	it("emits a self-terminating OSC that carries no cursor movement", () => {
+		const output = { write: vi.fn(() => true) };
+
+		emitHostStatus("working", output);
+
+		const written = output.write.mock.calls[0][0] as string;
+		expect(written.startsWith("\x1b]")).toBe(true);
+		expect(written.endsWith("\x07")).toBe(true);
+		// A terminal that does not know the sequence discards it; nothing here
+		// may render or move the cursor if it does not.
+		expect(written.slice(2, -1)).toMatch(/^[\x20-\x7e]*$/);
+	});
+
 	it("swallows write failures so a broken stdout can't abort a turn", () => {
-		process.env.TERAX_TERMINAL = "1";
 		const output = {
 			write: vi.fn(() => {
 				throw new Error("EPIPE");

--- a/packages/coding-agent/test/host-status.test.ts
+++ b/packages/coding-agent/test/host-status.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { emitHostStatus } from "@gajae-code/coding-agent/modes/utils/host-status";
+
+const original = process.env.TERAX_TERMINAL;
+
+afterEach(() => {
+	if (original === undefined) delete process.env.TERAX_TERMINAL;
+	else process.env.TERAX_TERMINAL = original;
+	vi.restoreAllMocks();
+});
+
+describe("host status markers", () => {
+	it("stays silent outside a host terminal", () => {
+		delete process.env.TERAX_TERMINAL;
+		const output = { write: vi.fn(() => true) };
+
+		emitHostStatus("working", output);
+
+		expect(output.write).not.toHaveBeenCalled();
+	});
+
+	it("writes the agent-attributed OSC 777 marker for each event", () => {
+		process.env.TERAX_TERMINAL = "1";
+		const output = { write: vi.fn(() => true) };
+
+		emitHostStatus("working", output);
+		emitHostStatus("attention", output);
+		emitHostStatus("finished", output);
+
+		expect(output.write).toHaveBeenNthCalledWith(1, "\x1b]777;notify;Terax;gjc;working\x07");
+		expect(output.write).toHaveBeenNthCalledWith(2, "\x1b]777;notify;Terax;gjc;attention\x07");
+		expect(output.write).toHaveBeenNthCalledWith(3, "\x1b]777;notify;Terax;gjc;finished\x07");
+	});
+
+	it("swallows write failures so a broken stdout can't abort a turn", () => {
+		process.env.TERAX_TERMINAL = "1";
+		const output = {
+			write: vi.fn(() => {
+				throw new Error("EPIPE");
+			}),
+		};
+
+		expect(() => emitHostStatus("finished", output)).not.toThrow();
+		expect(output.write).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## What

Interactive turns emit an OSC 777 marker so a hosting terminal can follow the agent's state:

```
\x1b]777;notify;Terax;gjc;working|attention|finished\x07
```

- `agent_start` -> `working`
- `agent_end` -> `finished`
- approval / ask selector -> `attention`

Gated on `TERAX_TERMINAL`. Unset (every normal terminal, CI, pipes) means nothing is written at all.

## Why not an extension

[Terax](https://github.com/crynta/terax-ai) supports Pi by installing `terax-notifications.ts` into the user's extension dir and letting the extension emit the marker. GJC is a Pi fork, so that was the first thing tried. It cannot work here:

```ts
// src/sdk/session.ts
// Extension/module discovery is quarantined; retain only the private
// runtime needed for bundled product extensions ... Filesystem extension
// paths remain ignored here even when options.additionalExtensionPaths is supplied.
```

Confirmed against the released 0.12.10 binary: an extension in `~/.gjc/agent/extensions/` and one passed with `-e` both silently fail to load. `discoverAndLoadHooks` has no callers, so the hook route is dead too. The emission has to live in the controllers.

## Placement notes

- `emitHostStatus("finished")` sits **before** `sendCompletionNotification()`. That method returns early when `completion.notify` is `"off"`, and host status must not inherit an unrelated user preference.
- The existing `ringTerminalBell` call sites were the model for placement; the bell writes a bare `\x07`, which carries no state and is not machine-readable.
- Writes go through the same `process.stdout` as the bell, and OSC sequences do not move the cursor, so TUI rendering is unaffected.

## Verification

- `bun test packages/coding-agent/test/host-status.test.ts` - 3 pass: silence without `TERAX_TERMINAL`, exact bytes for all three events, write failures swallowed
- `bunx biome check` clean on all four touched files
- `bun run check:ts` could not run in this environment (`tsgo` is not installed - `@typescript/native-preview` missing); the change adds no new types beyond a three-member union

The Terax-side counterpart is crynta/terax-ai#1106; that PR is inert without this one, and this one is silent without a host that reads the marker.