### PR TITLE
fix(telegram): drain session handlers before release

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
-- Telegram daemon restart now revokes every persisted callback alias before polling. Reconnecting sessions must replay a pending ask to receive fresh, owner-bound aliases; old controls remain stale, and their keyboards are best-effort terminalized when the original Telegram message id is available (#3727).
+- Telegram daemon restart now revokes every persisted callback alias before polling. Reconnecting sessions must replay a pending ask to receive fresh, owner-bound aliases; old controls remain stale, and their keyboards are best-effort terminalized when the original Telegram message id is available. Shutdown now fences new session messages and drains every admitted handler before final callback persistence and ownership release, preventing a successful send racing shutdown from publishing alias state after a successor takes ownership (#3727).
 
 ## [0.12.11] - 2026-08-03
 

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts
@@ -65,8 +65,10 @@ export const NOTIFICATION_PROTOCOL_VERSION = 3;
  * 47 settles failed staged revocation and guards the complete callback authority
  * and polling dependency chain. Generation 48 uses crash-durable callback
  * receipts, a legacy-disjoint random alias namespace, and exact topic leases.
+ * Generation 49 drains every admitted session-message handler before final
+ * durable persistence and ownership release.
  */
-export const DAEMON_GENERATION = 48;
+export const DAEMON_GENERATION = 49;
 
 /**
  * Serving-compatibility boundary for daemon lifecycle requests. Epoch 1 covers

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -4443,6 +4443,7 @@ interface PendingBtwDelivery {
 
 class TelegramEffectSupervisor {
 	#stopping = false;
+	#admitting = true;
 	readonly #abort = new AbortController();
 	readonly #terminalContext = new AsyncLocalStorage<boolean>();
 	readonly #pending = new Set<Promise<unknown>>();
@@ -4464,6 +4465,16 @@ class TelegramEffectSupervisor {
 		return this.track(api.call(method, body, { ...opts, signal }));
 	}
 
+	admit<T>(effect: () => Promise<T>): Promise<T> {
+		if (!this.#admitting)
+			return Promise.reject(Object.assign(new Error("Daemon is stopping"), { name: "AbortError" }));
+		try {
+			return this.track(effect());
+		} catch (error) {
+			return Promise.reject(error);
+		}
+	}
+
 	track<T>(effect: Promise<T>): Promise<T> {
 		this.#pending.add(effect);
 		void effect.then(
@@ -4477,7 +4488,12 @@ class TelegramEffectSupervisor {
 		return this.#stopping;
 	}
 
+	closeAdmission(): void {
+		this.#admitting = false;
+	}
+
 	beginShutdown(): void {
+		this.closeAdmission();
 		this.#stopping = true;
 		this.#abort.abort("daemon_shutdown");
 	}
@@ -4680,6 +4696,7 @@ export class TelegramNotificationDaemon {
 	 */
 	requestStop(_reason?: "reload" | "stop" | "signal"): void {
 		this.stopRequested = true;
+		this.effects.closeAdmission();
 
 		const toolShutdown = this.beginToolActivityShutdown();
 		void toolShutdown
@@ -5723,11 +5740,13 @@ export class TelegramNotificationDaemon {
 			// Identity guard: a delayed frame from a superseded socket must not act
 			// through the replacement session.
 			if (this.sessions.get(sessionId) !== session) return;
-			void this.handleSessionMessage(session, JSON.parse(String(ev.data))).catch(err => {
-				// Surface frame-handling failures (e.g. a rejected ask sendMessage) to
-				// the daemon log instead of an invisible unhandled rejection.
-				logger.error("notifications daemon: handleSessionMessage failed", { error: String(err) });
-			});
+			void this.effects
+				.admit(() => this.handleSessionMessage(session, JSON.parse(String(ev.data))))
+				.catch(err => {
+					// Surface frame-handling failures (e.g. a rejected ask sendMessage) to
+					// the daemon log instead of an invisible unhandled rejection.
+					logger.error("notifications daemon: handleSessionMessage failed", { error: String(err) });
+				});
 		});
 		ws.addEventListener("close", () => {
 			this.dropSession(session, "socket_closed");
@@ -11322,37 +11341,41 @@ export class TelegramNotificationDaemon {
 				}
 				this.effects.beginShutdown();
 				this.#deliveryAbort.abort();
+				this.stopFlushTimer();
+				this.stopScanTimer();
+				this.stopTypingTimer();
+				this.stopAdoptionSweepTimer();
+				this.stopLifecycleControl();
 				let persisted = false;
-				const shutdown = this.effects.allowTerminal(async () => {
-					if (toolShutdownError) throw toolShutdownError;
-					await this.#drainBtwTurns();
-					await this.toolTerminalizationChain;
-					this.stopFlushTimer();
-					this.stopScanTimer();
-					this.stopTypingTimer();
-					this.stopAdoptionSweepTimer();
-					this.stopLifecycleControl();
-					await this.cleanupAllAttachmentDirs();
-					await this.persistAliases();
-					await this.persistTopics();
-					await this.persistSeenUpdateIds();
-					await this.opts.control?.clear?.(this.opts.ownerId);
-					persisted = true;
-				});
-				const deadline = Promise.withResolvers<boolean>();
-				const deadlineTimer = setTimeout(() => deadline.resolve(false), BTW_SHUTDOWN_JOIN_MS);
-				const completed = await Promise.race([
-					shutdown.then(
-						() => true,
-						error => {
-							logger.warn(`notifications: shutdown persistence failed: ${sanitizeDiagnostic(String(error))}`);
-							return false;
-						},
-					),
-					deadline.promise,
-				]);
-				clearTimeout(deadlineTimer);
-				const quiesced = completed && heartbeatJoined && (await this.effects.join(BTW_SHUTDOWN_JOIN_MS));
+				const sessionEffectsQuiesced = await this.effects.join(BTW_SHUTDOWN_JOIN_MS);
+				let completed = false;
+				if (sessionEffectsQuiesced) {
+					const shutdown = this.effects.allowTerminal(async () => {
+						if (toolShutdownError) throw toolShutdownError;
+						await this.#drainBtwTurns();
+						await this.toolTerminalizationChain;
+						await this.cleanupAllAttachmentDirs();
+						await this.persistAliases();
+						await this.persistTopics();
+						await this.persistSeenUpdateIds();
+						await this.opts.control?.clear?.(this.opts.ownerId);
+						persisted = true;
+					});
+					const deadline = Promise.withResolvers<boolean>();
+					const deadlineTimer = setTimeout(() => deadline.resolve(false), BTW_SHUTDOWN_JOIN_MS);
+					completed = await Promise.race([
+						shutdown.then(
+							() => true,
+							error => {
+								logger.warn(`notifications: shutdown persistence failed: ${sanitizeDiagnostic(String(error))}`);
+								return false;
+							},
+						),
+						deadline.promise,
+					]);
+					clearTimeout(deadlineTimer);
+				}
+				const quiesced = completed && heartbeatJoined && sessionEffectsQuiesced;
 				if (!quiesced || !persisted) {
 					logger.warn("notifications: shutdown was not durably quiesced; retaining daemon ownership");
 				} else {

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -2949,7 +2949,7 @@ describe("telegram daemon", () => {
 			}),
 		);
 	}
-	test("keeps wire protocol 3 through generation 48 durable callback routing", () => {
+	test("keeps wire protocol 3 through generation 49 durable callback routing", () => {
 		expect(NOTIFICATION_PROTOCOL_VERSION).toBe(3);
 		// Generations 34 and 35 add media conversion and topic adoption; generation
 		// 36 bound managed-session replacement to exact native filesystem authority,
@@ -2965,8 +2965,9 @@ describe("telegram daemon", () => {
 		// 44 adds restart-safe callback recovery; generation 45 makes accepted callback
 		// receipts durable before exact-ask routing; generation 46 stages activation;
 		// generation 47 settles failed staged revocation; generation 48 makes receipts
-		// crash-durable, aliases legacy-disjoint, and topic authority exact.
-		expect(DAEMON_GENERATION).toBe(48);
+		// crash-durable, aliases legacy-disjoint, and topic authority exact; generation
+		// 49 drains admitted session handlers before final persistence and ownership release.
+		expect(DAEMON_GENERATION).toBe(49);
 	});
 	test.each([
 		"1",
@@ -19182,6 +19183,97 @@ describe("telegram daemon /btw reservation and capability boundaries", () => {
 		expect(bot.calls.filter(call => call.method === "createForumTopic")).toHaveLength(0);
 	});
 
+	test("shutdown admission tracks callback alias persistence before the durable barrier", async () => {
+		FakeWs.instances = [];
+		const agentDir = tempAgentDir();
+		const sendStarted = Promise.withResolvers<void>();
+		const releaseSend = Promise.withResolvers<unknown>();
+		class HeldSendBotApi extends FakeBotApi {
+			override async call(
+				method: string,
+				body: unknown,
+				options?: { noRetry?: boolean; signal?: AbortSignal },
+			): Promise<unknown> {
+				if (method !== "sendMessage") return await super.call(method, body, options);
+				this.calls.push({ method, body, options });
+				sendStarted.resolve();
+				return await releaseSend.promise;
+			}
+		}
+		const bot = new HeldSendBotApi();
+		const daemon = new TelegramNotificationDaemon({
+			settings: settings(agentDir),
+			ownerId: "owner",
+			botToken: "tok",
+			chatId: "42",
+			botApi: bot,
+			rich: { enabled: false },
+			WebSocketImpl: FakeWs as any,
+		});
+		daemon.connectSession("S", "ws://session", "token");
+		const session = daemon.sessions.get("S")!;
+		const handlerPersistStarted = Promise.withResolvers<void>();
+		const releaseHandlerPersist = Promise.withResolvers<void>();
+		const persistAliases = daemon.persistAliases.bind(daemon);
+		let heldReceiptPersistence = false;
+		spyOn(daemon, "persistAliases").mockImplementation(async () => {
+			if (
+				!heldReceiptPersistence &&
+				daemon.aliasTable.entries().some(([, route]) => route.actionId === "ask" && route.messageId === 7)
+			) {
+				heldReceiptPersistence = true;
+				handlerPersistStarted.resolve();
+				await releaseHandlerPersist.promise;
+			}
+			await persistAliases();
+		});
+
+		(session.ws as unknown as FakeWs).emit({
+			type: "action_needed",
+			sessionId: "S",
+			id: "ask",
+			kind: "ask",
+			question: "Continue?",
+			options: ["Yes"],
+		});
+		await sendStarted.promise;
+		const effects = (
+			daemon as unknown as {
+				effects: { closeAdmission(): void; join(deadlineMs: number): Promise<boolean> };
+			}
+		).effects;
+		effects.closeAdmission();
+		const aliasesBeforeRejectedMessage = Array.from(daemon.aliasTable.entries()).length;
+		(session.ws as unknown as FakeWs).emit({
+			type: "action_needed",
+			sessionId: "S",
+			id: "rejected-after-shutdown",
+			kind: "ask",
+			question: "Must not admit",
+			options: ["No"],
+		});
+		expect(Array.from(daemon.aliasTable.entries())).toHaveLength(aliasesBeforeRejectedMessage);
+
+		releaseSend.resolve({ ok: true, result: { message_id: 7 } });
+		await handlerPersistStarted.promise;
+		let joined = false;
+		const joinedEffect = effects.join(100).then(value => {
+			joined = value;
+			return value;
+		});
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(joined).toBe(false);
+
+		releaseHandlerPersist.resolve();
+		await expect(joinedEffect).resolves.toBe(true);
+		const persistedAliases = JSON.parse(fs.readFileSync(daemonPaths(agentDir).aliases, "utf8")) as {
+			routes: Record<string, unknown>;
+		};
+		expect(Object.values(persistedAliases.routes)).toEqual([
+			expect.objectContaining({ actionId: "ask", messageId: 7, sessionId: "S" }),
+		]);
+	});
 	test("shutdown retains ownership and returns when control persistence never settles", async () => {
 		const agentDir = tempAgentDir();
 		const s = settings(agentDir);

--- a/scripts/telegram-daemon-generation-guard.test.ts
+++ b/scripts/telegram-daemon-generation-guard.test.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { describe, expect, test } from "bun:test";
 import manifest from "./telegram-daemon-generation-manifest.json" with { type: "json" };
-import { assertGuardAuthority, currentTreeDigests, declaration, evaluate, GUARD_CONTRACT_VERSION, isLegacyBootstrapBase, manifestForCurrentTree, protectedInventory, validateCiInputs, validateCurrentTreeManifest, validateInventory, validateManifest, validateSha, writeManifest } from "./telegram-daemon-generation-guard";
+import { assertGuardAuthority, currentTreeDigests, declaration, evaluate, GUARD_CONTRACT_VERSION, isLegacyBootstrapBase, manifestForCurrentTree, protectedInventory, TELEGRAM_SHUTDOWN_DRAIN_PROTECTED_DECLARATIONS, validateCiInputs, validateCurrentTreeManifest, validateInventory, validateManifest, validateSha, writeManifest } from "./telegram-daemon-generation-guard";
 
 const guardScript = "scripts/telegram-daemon-generation-guard.ts";
 const manifestScript = "scripts/telegram-daemon-generation-manifest.json";
@@ -763,6 +763,11 @@ test("fails closed when a protected native authority declaration is missing or m
 		const endpointDiscovery = mutableInventory();
 		delete endpointDiscovery.discord[chatRuntime];
 		expect(() => validateInventory(endpointDiscovery)).toThrow("isolated chat endpoint discovery");
+	});
+	test("protects Telegram shutdown admission and durable drain authorities", () => {
+		expect(protectedInventory.telegram[telegramDaemon]).toEqual(
+			expect.arrayContaining([...TELEGRAM_SHUTDOWN_DRAIN_PROTECTED_DECLARATIONS]),
+		);
 	});
 
 	test("protects Telegram provenance and signaling authorities", () => {

--- a/scripts/telegram-daemon-generation-guard.ts
+++ b/scripts/telegram-daemon-generation-guard.ts
@@ -8,7 +8,7 @@ import * as path from "node:path";
 
 const root = path.join(import.meta.dir, "..");
 const SHA = /^[0-9a-f]{40}$/i;
-export const GUARD_CONTRACT_VERSION = 42;
+export const GUARD_CONTRACT_VERSION = 43;
 const telegramContract = "packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts";
 const telegramDaemon = "packages/coding-agent/src/sdk/bus/telegram-daemon.ts";
 const telegramControl = "packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts";
@@ -202,6 +202,13 @@ function validateTelegramCallbackRecoveryInventory(inventory: Inventory): void {
 	}
 }
 
+/** Shutdown must fence new session work and await admitted handlers before durable release. */
+export const TELEGRAM_SHUTDOWN_DRAIN_PROTECTED_DECLARATIONS = [
+	"TelegramEffectSupervisor",
+	"handleSessionMessage",
+	"run",
+] as const;
+
 /** Chat credential, provenance, and persistence are shared takeover authority. */
 export const CHAT_OWNER_LOCK_PROTECTED_DECLARATIONS = [
 	"identityFor",
@@ -280,6 +287,12 @@ function validateTelegramLifecycleInventory(inventory: Inventory): void {
 	if (!symbols || TELEGRAM_LIFECYCLE_PROTECTED_DECLARATIONS.some(symbol => !symbols.includes(symbol)))
 		throw new Error("telegram-daemon-generation-guard: Telegram authentication and lifecycle primitives must be protected by the Telegram generation contract");
 }
+function validateTelegramShutdownDrainInventory(inventory: Inventory): void {
+	const symbols = inventory.telegram[telegramDaemon];
+	if (!symbols || TELEGRAM_SHUTDOWN_DRAIN_PROTECTED_DECLARATIONS.some(symbol => !symbols.includes(symbol)))
+		throw new Error("telegram-daemon-generation-guard: Telegram shutdown admission and durable drain primitives must be protected by the Telegram generation contract");
+}
+
 function validateTelegramCallbackReceiptInventory(inventory: Inventory): void {
 	const symbols = inventory.telegram[telegramDaemon];
 	if (!symbols || TELEGRAM_CALLBACK_RECEIPT_PROTECTED_DECLARATIONS.some(symbol => !symbols.includes(symbol)))
@@ -325,6 +338,7 @@ export function validateInventory(inventory: Inventory = protectedInventory): vo
 	validateChatEndpointDiscoveryInventory(inventory);
 	validateTelegramToolActivityInventory(inventory);
 	validateTelegramCallbackRecoveryInventory(inventory);
+	validateTelegramShutdownDrainInventory(inventory);
 }
 
 export function validateManifest(value: unknown = manifest): asserts value is GuardManifest {

--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -1,5 +1,5 @@
 {
-  "contractVersion": 42,
+  "contractVersion": 43,
   "inventory": {
     "telegram": {
       "packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts": [
@@ -531,7 +531,7 @@
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:ownerPidFromOwnerId": "46691373b2bee01f28f3817a6aa6a7efffe880c2cea337c89155582c98d952bf",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:runDaemonInternal": "8d9135cabb89a9d022cb22d0aad159d4f1fe1b7c574afc61dadaeaa66b1b7e36",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:runDaemonSmoke": "6f085a667aa5c83de46d2d8945fb845c355fcbb43c46872342a44489203a5830",
-    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:DAEMON_GENERATION": "21bc75f6f42e3cc2158bca1ba60aafb51d962a54c15e8eb36e55fe65177dfe61",
+    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:DAEMON_GENERATION": "13e924c3b28a3e8a16edc1e2adc2bec8a5bc3e1989be1d4b2b637f355d4895a3",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:NOTIFICATION_PROTOCOL_VERSION": "b99289f651fedcf020d28dbaf6f07dd37e7e4a5f6dc1f5118b872112325f1e81",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts:DaemonProcessReference": "c3d13e3670a6245a1250c4ebfcd80a36dd8fc96c67ab64d9f979182bd117bc4e",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts:TelegramDaemonController": "7381b51cd968199876bfccd341ce79f1bcd895c9fb3899149394d6c54459f07f",
@@ -554,7 +554,7 @@
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:TOOL_ACTIVITY_CAPABILITY": "547f80bd6b3bd1c615fc3d885e507aba4418e6c4c54c47d36938b8b2e5d2abd7",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:TelegramBotTransport": "a52ed3c9633e50db460c4cf020172dec284124563bd62d5bc647bf4461ec9aa0",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:TelegramDaemonOwnershipPhase": "e18b8212480f9c8c7d21c3e97b9b4813d445e5afa8f13c16916cc145d0a45339",
-    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:TelegramEffectSupervisor": "bda743ada8426b1f22471ad3410d4107f3ce8bd608794918317374a99fd55b14",
+    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:TelegramEffectSupervisor": "10188ff7bfc0eb88ccc6fd75aec7e882666cc2e4ff9817ed00815abdaa6de906",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:TelegramNotificationDaemon.#authorizeLease": "8798e128b9dd7e53788221b7a2e94332cb607e74e467457b8b885911315ff82a",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:TelegramNotificationDaemon.#leaseAllows": "c83f77e57d8f4199c8b8c39707cd719efe46bfc14f03ac0b42d40711cd9664ad",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:TelegramNotificationDaemon.#leaseTokenAllows": "611a62a9f4a8593725463387d4a28d76e426234db8d84600332203aa7c088883",
@@ -611,12 +611,12 @@
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:reissuePendingAction": "05a1f010289fc997e0b95d0e888a8f43b0253d4b719480807c2f6a1ee3a08554",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:releaseDaemonOwnership": "b4116e177d692673ac104cb4cc25c1f971e08ac00fb52c3a8bb24906491a04b6",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:renewDaemonHeartbeat": "abd555094701af127d2300dac50e0b195b6879592d504040c9908dd46fafa695",
-    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:requestStop": "09541e49e39af232b571d29d8eac79cfa71eb142ae0d8f0d2d34c731fa41b57a",
+    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:requestStop": "cbca8fba4193aad7a4348c5a1a0a71e2d831c683d49f7738ab3196018196b621",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:restoreNotificationRootRegistration": "8361cce360804d2dab321da3477e7c3c6f148b49c49afb77d519a081281f267b",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:retireProvisionalDaemonOwnership": "d5f45044ea524f0694691bda67f47f9d74eaa5506926b718f40f2613a892d82f",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:revokeCallbackAliases": "42407ae6ce220a36e06f6b74a339b59dc1ec1efd44fa0e4c80fb2cf43d4fb5ba",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:rollbackOwnershipLockRebind": "7e9bc148e69268c393051e0b87417c20ce44824e777d4be050b9e91607c410a1",
-    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:run": "402fad8c2dd1bd4eee40dc01107ec50151cf911365d06ac1ff66664081f07f19",
+    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:run": "234ec760a43e3322653eb9c1f4ea5bb13131b590134d9d7d29ad326fd69d3944",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:spawnTelegramDaemonOwner": "8c8fc501b466b3d75ed696483821e52023681b05a1c943398d9abe6306c7eef0",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:startLifecycleControl": "237cf7c7881048e0e4329650567c8a47f597abe43206fe2f29376eb912cd6d1c",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon.ts:syncTelegramDirectory": "d056e2d84b39bd98a2c0b5a6f22ab0bb13adcd909c092b2f0636382dca488468",


### PR DESCRIPTION
## Summary
- fence WebSocket session-message admission as soon as daemon shutdown is requested
- supervise the complete `handleSessionMessage` chain rather than only its nested Bot API request
- drain every admitted handler before final aliases/topics/update persistence and ownership release
- retain bounded shutdown and predecessor ownership on quiescence or persistence uncertainty
- bump Telegram generation 49 and generation-guard contract 43 with exact protected inventory

A callback send could settle after its nested Bot API promise left the effect set, then resume and persist accepted aliases after shutdown had already saved an older snapshot and released ownership. A successor could therefore be overwritten by the predecessor. This follow-up closes that post-merge #3727 race.

Follow-up to #3787.

## Verification
Exact head: `8a3ee57bcdb852868da8e33c6ea7878b63d85b6a`
Base: `971ff98fc5c33e34de0962c3e59c18f51a65c395`

- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts` — 541 passed
- `bun test scripts/telegram-daemon-generation-guard.test.ts` — 48 passed
- `bun test packages/coding-agent/test/notifications-rich-render.test.ts` — 44 passed
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/natives run build`
- `bun scripts/telegram-daemon-generation-guard.ts --validate-current-tree`
- exact-range generation guard — v43 required generation bump verified
- `git diff --check upstream/dev...HEAD`