### PR TITLE
fix(acp): own deep-interview skill lifecycle end to end

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -58,6 +58,7 @@
 - Slack Web API requests now use form encoding instead of JSON, preventing thread reconciliation through `conversations.replies` from failing with `invalid_arguments`.
 
 - Managed replacement cleanup now migrates version-one receipts from earlier releases and recovers canonical exchange placeholders left by interrupted cleanup, so a stale receipt cannot permanently block the next managed session mutation with `managed_replace_cleanup_receipt_invalid`.
+- ACP and other headless clients that advertise `elicitation.form` no longer stop receiving `elicitation/create` requests after the notifications extension activates. The interactive answer source previously registered after the protocol source and won by registration order; answer sources now use a fixed protocol-over-interactive priority instead of registration order.
 
 ## [0.12.11] - 2026-08-03
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -58,7 +58,7 @@
 - Slack Web API requests now use form encoding instead of JSON, preventing thread reconciliation through `conversations.replies` from failing with `invalid_arguments`.
 
 - Managed replacement cleanup now migrates version-one receipts from earlier releases and recovers canonical exchange placeholders left by interrupted cleanup, so a stale receipt cannot permanently block the next managed session mutation with `managed_replace_cleanup_receipt_invalid`.
-- ACP and other headless clients that advertise `elicitation.form` no longer stop receiving `elicitation/create` requests after the notifications extension activates. The interactive answer source previously registered after the protocol source and won by registration order; answer sources now use a fixed protocol-over-interactive priority instead of registration order.
+- ACP clients such as OpenCode can now map advertised `/skill:*` commands to canonical `skill.invoke` while binding the run to exact correlated prompt completion and cancellation ownership, and can answer deep-interview forms in headless lifecycle sessions. Lifecycle hosts initialize the shared theme before tools render and before the MCP readiness budget is calculated, preventing the pre-elicitation `theme.status` failure, and protocol form providers remain authoritative if a local `/notify on` registers an interactive source later.
 
 ## [0.12.11] - 2026-08-03
 

--- a/packages/coding-agent/src/commands/sdk.ts
+++ b/packages/coding-agent/src/commands/sdk.ts
@@ -7,6 +7,7 @@ import type { Args as ParsedArgs } from "../cli/args";
 import { Settings } from "../config/settings";
 import { applyStartupModelProfiles, createSessionManager } from "../main";
 import { initializeExtensions } from "../modes/runtime-init";
+import { initTheme } from "../modes/theme/theme";
 import { ACP_MCP_REQUEST_TIMEOUT_MS, ACP_MCP_STARTUP_HEADROOM_MS } from "../sdk/acp/mcp";
 import { Broker } from "../sdk/broker/broker";
 import { readBrokerDiscovery } from "../sdk/broker/discovery";
@@ -387,6 +388,12 @@ export async function runSessionHost(
 			throw await registrationFailure(error);
 		}
 
+		try {
+			await initTheme(false);
+		} catch (error) {
+			throw await registrationFailure(error);
+		}
+
 		// The longer MCP startup ceiling is scoped to ACP lifecycle launches only:
 		// it applies when this request actually carried `mcpServers`. Ordinary
 		// CLI/SDK `mcpConfigPath` consumers keep the manager's short default.
@@ -395,8 +402,8 @@ export async function runSessionHost(
 		// Inside it, the throw would be caught, reclassified as
 		// `registration`/`failed`, and written a second time, losing the
 		// `startup`/`pending` outcome the readiness cutoff is supposed to report.
-		// Session-manager open and MCP config write already consumed part of the
-		// budget, so re-read the clock here rather than reusing the earlier check.
+		// Session-manager open, MCP config write, and theme initialization already
+		// consumed part of the budget, so re-read the clock here.
 		let mcpStartupTimeoutMs: number | undefined;
 		if (mcpConfigPath !== undefined) {
 			const remaining = request.semanticReadyDeadlineAt - now() - ACP_MCP_STARTUP_HEADROOM_MS;

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -621,7 +621,7 @@ export class ExtensionRunner {
 			setModelProfile: async name => (await this.#setModelProfileFn?.(name)) ?? false,
 			cycleThinkingLevel: () => this.#cycleThinkingLevelFn?.(),
 			setQueueMode: (kind, mode) => this.#setQueueModeFn?.(kind, mode) ?? false,
-			invokeSkill: async (name, args) => await this.#invokeSkillFn?.(name, args),
+			invokeSkill: async (name, args, options) => await this.#invokeSkillFn?.(name, args, options),
 
 			setPlanMode: on => this.#setPlanModeFn?.(on),
 			operateGoal: async (op, objective) => await this.#operateGoalFn?.(op, objective),

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -412,6 +412,7 @@ export interface ExtensionContext {
 			onPreflightAccepted?: () => void;
 			onPreflightAcceptCommit?: () => void | Promise<void>;
 			onSkillPrepared?: (meta: { name: string; path: string; lineCount?: number; cleanedArgs?: string }) => void;
+			preflightSignal?: AbortSignal;
 		},
 	): Promise<unknown>;
 	setPlanMode?(on: boolean): unknown;
@@ -1511,6 +1512,7 @@ export interface ExtensionContextActions {
 			onPreflightAccepted?: () => void;
 			onPreflightAcceptCommit?: () => void | Promise<void>;
 			onSkillPrepared?: (meta: { name: string; path: string; lineCount?: number; cleanedArgs?: string }) => void;
+			preflightSignal?: AbortSignal;
 		},
 	) => Promise<unknown>;
 	setPlanMode?: (on: boolean) => unknown;

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -82,6 +82,8 @@ interface PromptWaiter {
 	terminal?: { outcome: SdkPromptTerminalOutcome; correlation: PromptCorrelation };
 	/** Frames for an already-settled correlation held until acknowledgement resolves ownership. */
 	deferredFrames: JsonObject[];
+	/** Coordinates a prompt-control rejection racing an acknowledged ACP cancellation. */
+	cancelAttempt?: Promise<boolean>;
 	resolve: (response: PromptResponse) => void;
 	reject: (error: Error) => void;
 }
@@ -646,6 +648,14 @@ export function acpSessionStateFromConfig(
 	};
 }
 
+/** Recognize an advertised ACP skill command only when it is the complete, single text prompt. */
+export function acpSkillInvocation(blocks: PromptRequest["prompt"]): { name: string; args: string } | undefined {
+	if (blocks.length !== 1 || blocks[0]?.type !== "text") return undefined;
+	const match = /^\/skill:([^\s]+)(?:\s+([\s\S]*))?$/.exec(blocks[0].text.trim());
+	if (!match?.[1]) return undefined;
+	return { name: match[1], args: match[2]?.trim() ?? "" };
+}
+
 /** Convert every ACP prompt block the agent advertises without silently discarding context. */
 export function acpPromptPayload(blocks: PromptRequest["prompt"]): {
 	text: string;
@@ -1121,6 +1131,7 @@ export class AcpAgent implements Agent {
 		if (record.activePrompt) throw new AcpSdkAdapterError("conflict", "ACP session already has an active prompt.");
 		if (record.authFailure) throw new AcpSdkAdapterError("authentication_failed", record.authFailure);
 		const payload = acpPromptPayload(params.prompt);
+		const skillInvocation = acpSkillInvocation(params.prompt);
 		let waiter!: PromptWaiter;
 		const response = new Promise<PromptResponse>((resolve, reject) => {
 			waiter = {
@@ -1136,10 +1147,12 @@ export class AcpAgent implements Agent {
 			record.activePrompt = waiter;
 		});
 		try {
-			const acknowledgement = await record.adapter.prompt({
-				text: payload.text,
-				...(payload.images.length ? { images: payload.images } : {}),
-			});
+			const acknowledgement = skillInvocation
+				? await record.adapter.control("skill.invoke", skillInvocation)
+				: await record.adapter.prompt({
+						text: payload.text,
+						...(payload.images.length ? { images: payload.images } : {}),
+					});
 			const acknowledgementCorrelation = promptAcknowledgement(acknowledgement);
 			if (!acknowledgementCorrelation)
 				throw new AcpSdkAdapterError(
@@ -1160,6 +1173,7 @@ export class AcpAgent implements Agent {
 					);
 			this.#settlePrompt(record, waiter);
 		} catch (error) {
+			if (waiter.cancelAttempt && (await waiter.cancelAttempt) && waiter.settled) return await response;
 			waiter.deferredFrames.length = 0;
 			waiter.terminal = undefined;
 			waiter.settled = true;
@@ -1172,13 +1186,35 @@ export class AcpAgent implements Agent {
 	async cancel(params: { sessionId: string }): Promise<void> {
 		const record = this.#sessions.get(params.sessionId);
 		if (!record) throw new AcpSdkAdapterError("not_found", `Unknown session, not found: ${params.sessionId}`);
-		const acknowledgement = await record.adapter.cancel();
-		const result = object(object(acknowledgement)?.result) ?? object(acknowledgement);
-		if (result?.aborted !== true)
-			throw new AcpSdkAdapterError(
-				"abort_unacknowledged",
-				"SDK did not acknowledge cancellation of the active prompt.",
-			);
+		const waiter = record.activePrompt;
+		const cancelAttempt = waiter ? Promise.withResolvers<boolean>() : undefined;
+		if (waiter && cancelAttempt) waiter.cancelAttempt = cancelAttempt.promise;
+		try {
+			const acknowledgement = await record.adapter.cancel();
+			const result = object(object(acknowledgement)?.result) ?? object(acknowledgement);
+			if (result?.aborted !== true)
+				throw new AcpSdkAdapterError(
+					"abort_unacknowledged",
+					"SDK did not acknowledge cancellation of the active prompt.",
+				);
+			if (
+				result.disposition === "preflight_cancelled" &&
+				waiter &&
+				record.activePrompt === waiter &&
+				!waiter.acknowledged &&
+				!waiter.settled
+			) {
+				record.activePrompt = undefined;
+				waiter.settled = true;
+				waiter.deferredFrames.length = 0;
+				waiter.terminal = undefined;
+				waiter.resolve({ stopReason: "cancelled" });
+			}
+			cancelAttempt?.resolve(true);
+		} catch (error) {
+			cancelAttempt?.resolve(false);
+			throw error;
+		}
 	}
 
 	async extMethod(method: string, params: JsonObject): Promise<JsonObject> {

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -98,7 +98,7 @@ import {
 	isExistingThreadBindingRequested,
 } from "./existing-thread-readiness";
 import { imageAttachmentsFromMessage, notificationActionPayload, summaryFromMessage, truncate } from "./helpers";
-import { createKindAwareReconciliation } from "./kind-aware-reconciliation";
+import { createKindAwareReconciliation, type ReconciliationKind } from "./kind-aware-reconciliation";
 import { assertNativeRuntimeCompatibility } from "./native-runtime-compatibility";
 import { proposedTelegramIdentity } from "./notification-orchestration";
 import { createPromptReconciliation, sanitizePromptFailure } from "./prompt-reconciliation";
@@ -2169,6 +2169,8 @@ function sdkControlSurface(
 		requesterConnectionId?: string,
 		clientRef?: string,
 		trackReconciliation?: boolean,
+		preflightAbort?: () => void,
+		reconciliationKind?: ReconciliationKind,
 	) => void | Promise<void> = () => {},
 	onPromptFailed: (correlation: { commandId: string; turnId: string }, error: unknown) => void = () => {},
 	onPromptAcceptFailed: (correlation: { commandId: string; turnId: string }) => void = () => {},
@@ -2619,6 +2621,7 @@ function sdkControlSurface(
 			const commandId = crypto.randomUUID();
 			const turnId = crypto.randomUUID();
 			const correlation = { commandId, turnId };
+			const requesterConnectionId = controlRequesterContext.getStore();
 			if (skillRecon) {
 				try {
 					await awaitReconciliationReady();
@@ -2629,44 +2632,101 @@ function sdkControlSurface(
 				}
 				skillRecon.admit(trimmedClientRef);
 			}
+			const cancellationError = Object.assign(new Error("Skill preflight was cancelled before execution."), {
+				code: "busy",
+			});
+			const preflightController = new AbortController();
 			const { promise: acceptedP, resolve, reject } = Promise.withResolvers<Record<string, unknown>>();
-			let phase: "pending" | "accepted" | "rejected" = "pending";
+			let phase: "pending" | "accepting" | "accepted" | "rejected" = "pending";
+			let promptOwned = false;
+			let durableSkillAccepted = false;
+			let admissionReleased = false;
+			const releaseAdmission = () => {
+				if (admissionReleased || durableSkillAccepted) return;
+				admissionReleased = true;
+				skillRecon?.release(trimmedClientRef);
+			};
 			const settleAccept = (value: Record<string, unknown>) => {
-				if (phase !== "pending") return;
+				if (phase !== "pending" && phase !== "accepting") return;
 				phase = "accepted";
 				resolve(value);
 			};
 			const settleReject = (error: unknown) => {
-				if (phase !== "pending") return;
+				if (phase === "accepted" || phase === "rejected") return;
 				phase = "rejected";
 				reject(error);
 			};
+			const cancelPreflight = () => {
+				preflightController.abort();
+				if (phase === "pending") {
+					releaseAdmission();
+					settleReject(cancellationError);
+				}
+			};
+			const key = preflightKey(requesterConnectionId, correlation);
+			pendingPreflightCancellations.set(key, {
+				connectionId: requesterConnectionId,
+				cancel: cancelPreflight,
+			});
 			let prepared: { name: string; path: string; lineCount?: number; cleanedArgs?: string } | undefined;
-			const run = Promise.resolve(
-				ctx.invokeSkill(name, args as string | undefined, {
-					onSkillPrepared: meta => {
-						prepared = meta;
-					},
-					onPreflightAcceptCommit: async () => {
-						const meta = prepared ?? { name: String(name), path: "" };
-						if (skillRecon)
-							await skillRecon.noteAccepted(correlation, trimmedClientRef, { skillName: meta.name });
-						settleAccept({
-							accepted: true,
-							commandId,
-							turnId,
-							name: meta.name,
-							path: meta.path,
-							...(meta.lineCount !== undefined ? { lineCount: meta.lineCount } : {}),
-							...(meta.cleanedArgs !== undefined ? { args: meta.cleanedArgs } : {}),
-							...(trimmedClientRef ? { clientRef: trimmedClientRef } : {}),
-						});
-					},
-				}),
-			).then(
+			let run: Promise<unknown>;
+			try {
+				run = Promise.resolve(
+					ctx.invokeSkill(name, args as string | undefined, {
+						preflightSignal: preflightController.signal,
+						onSkillPrepared: meta => {
+							prepared = meta;
+						},
+						onPreflightAcceptCommit: async () => {
+							if (preflightController.signal.aborted) throw cancellationError;
+							phase = "accepting";
+							const meta = prepared ?? { name: String(name), path: "" };
+							try {
+								await onPromptAccepted(
+									correlation,
+									requesterConnectionId,
+									undefined,
+									false,
+									() => preflightController.abort(),
+									"skill",
+								);
+								promptOwned = requesterConnectionId !== undefined;
+								if (preflightController.signal.aborted) throw cancellationError;
+								if (skillRecon) {
+									await skillRecon.noteAccepted(correlation, trimmedClientRef, { skillName: meta.name });
+									durableSkillAccepted = true;
+								}
+								if (preflightController.signal.aborted) throw cancellationError;
+								settleAccept({
+									accepted: true,
+									commandId,
+									turnId,
+									name: meta.name,
+									path: meta.path,
+									...(meta.lineCount !== undefined ? { lineCount: meta.lineCount } : {}),
+									...(meta.cleanedArgs !== undefined ? { args: meta.cleanedArgs } : {}),
+									...(trimmedClientRef ? { clientRef: trimmedClientRef } : {}),
+								});
+							} catch (error) {
+								if (promptOwned) {
+									onPromptAcceptFailed(correlation);
+									promptOwned = false;
+								}
+								releaseAdmission();
+								settleReject(error);
+								throw error;
+							}
+						},
+					}),
+				);
+			} catch (error) {
+				releaseAdmission();
+				settleReject(error);
+				run = Promise.reject(error);
+			}
+			void run.then(
 				result => {
 					if (phase === "pending") {
-						// Completed without fence (e.g. queue path) — still surface result.
 						settleAccept({
 							accepted: true,
 							commandId,
@@ -2674,23 +2734,26 @@ function sdkControlSurface(
 							...(typeof result === "object" && result ? (result as object) : {}),
 							...(trimmedClientRef ? { clientRef: trimmedClientRef } : {}),
 						});
-					} else if (skillRecon) {
+					} else if (!promptOwned && durableSkillAccepted && skillRecon) {
 						void skillRecon.noteTransition(correlation, { type: "agent_end" });
 					}
-					return result;
 				},
 				error => {
-					if (phase === "pending") {
-						if (skillRecon) skillRecon.release(trimmedClientRef);
+					if (phase === "pending" || phase === "accepting") {
+						releaseAdmission();
 						settleReject(error);
-					} else if (skillRecon) {
-						void skillRecon.noteTransition(correlation, { type: "agent_failed", error });
+					} else if (phase === "accepted" && promptOwned) {
+						onPromptFailed(correlation, error);
 					}
-					throw error;
+					if (!promptOwned && durableSkillAccepted && skillRecon)
+						void skillRecon.noteTransition(correlation, { type: "agent_failed", error });
 				},
 			);
-			void run.catch(() => {});
-			return await acceptedP;
+			try {
+				return await acceptedP;
+			} finally {
+				pendingPreflightCancellations.delete(key);
+			}
 		},
 		setPlanMode: async on => {
 			if (!bindings.has("setPlanMode") || !ctx.setPlanMode)
@@ -3763,6 +3826,9 @@ export function createNotificationsExtension(
 			outcome?: SdkPromptTerminalOutcome;
 			/** Agent-owned resource run captured at acceptance; cleanup targets only this handle. */
 			executionHandle?: string;
+			/** Cancels accepted skill preparation before an execution handle exists. */
+			preflightAbort?: () => void;
+			reconciliationKind: ReconciliationKind;
 			bufferedFrames: Array<PromptLifecycleFrame | Record<string, unknown>>;
 		};
 		const promptSubmissions = new Map<string, PromptSubmission>();
@@ -3925,6 +3991,8 @@ export function createNotificationsExtension(
 			requesterConnectionId?: string,
 			clientRef?: string,
 			trackReconciliation = false,
+			preflightAbort?: () => void,
+			reconciliationKind: ReconciliationKind = "prompt",
 		) => {
 			if (!requesterConnectionId) {
 				// No delivery owner: tracked prompts cannot be reconciled. Release
@@ -3958,6 +4026,8 @@ export function createNotificationsExtension(
 				phase: "active",
 				// Bound to the Agent run at `agent_start`; acceptance precedes execution.
 				executionHandle: undefined,
+				...(preflightAbort ? { preflightAbort } : {}),
+				reconciliationKind,
 				bufferedFrames: [],
 			};
 			promptSubmissions.set(promptSubmissionKey(correlation), submission);
@@ -4049,7 +4119,10 @@ export function createNotificationsExtension(
 			handle: string | undefined,
 		) => {
 			const submission = promptSubmissions.get(promptSubmissionKey(correlation));
-			if (submission) submission.executionHandle = handle;
+			if (submission) {
+				submission.executionHandle = handle;
+				submission.preflightAbort = undefined;
+			}
 		};
 		const terminalizePrompt = async (
 			correlation: { commandId: string; turnId: string },
@@ -4065,7 +4138,11 @@ export function createNotificationsExtension(
 			submission.phase = "outcome_claimed";
 			let winner: SdkPromptTerminalOutcome;
 			try {
-				winner = await kindReconciliation.claimPendingOutcome(correlation, requestedOutcome);
+				winner = await kindReconciliation.claimPendingOutcome(
+					correlation,
+					requestedOutcome,
+					submission.reconciliationKind,
+				);
 			} catch (error) {
 				// The claim is the durability boundary: without it nothing may be published
 				// and the endpoint must fail closed so the client rejects exactly once. The
@@ -4120,7 +4197,12 @@ export function createNotificationsExtension(
 				}
 			}
 			try {
-				await kindReconciliation.finalizePromptOutcome(correlation, winner, extra?.error);
+				await kindReconciliation.finalizePromptOutcome(
+					correlation,
+					winner,
+					extra?.error,
+					submission.reconciliationKind,
+				);
 			} catch (error) {
 				// The durable pending claim survives; publishing an unpersisted terminal
 				// would contradict it, so fail the endpoint closed instead.
@@ -4233,13 +4315,20 @@ export function createNotificationsExtension(
 					([, submission]) => submission.connectionId === connectionId && !submission.terminal,
 				);
 				if (!active) return { aborted: true, disposition: "idle" as const };
-				const [commandId, turnId] = active[0].split(":", 2);
-				if (commandId && turnId)
+				const [key, submission] = active;
+				const [commandId, turnId] = key.split(":", 2);
+				if (commandId && turnId) {
+					const hasExecutionHandle = Boolean(submission.executionHandle);
+					if (!hasExecutionHandle) {
+						submission.preflightAbort?.();
+						removePendingPromptCorrelation({ commandId, turnId });
+					}
 					await terminalizePrompt(
 						{ commandId, turnId },
 						{ kind: "stopped", reason: "cancelled", provenance: "client_cancel" },
-						{ fence: true },
+						{ fence: hasExecutionHandle },
 					);
+				}
 				return { aborted: true, disposition: "cancelled" as const };
 			},
 			{
@@ -4449,7 +4538,8 @@ export function createNotificationsExtension(
 				if (
 					(request.operation === "turn.prompt" ||
 						request.operation === "turn.follow_up" ||
-						request.operation === "turn.abort_and_prompt") &&
+						request.operation === "turn.abort_and_prompt" ||
+						request.operation === "skill.invoke") &&
 					response.ok === true &&
 					response.result &&
 					typeof response.result === "object" &&
@@ -4586,11 +4676,18 @@ export function createNotificationsExtension(
 			pendingPromptCorrelations,
 			activePromptCorrelation: undefined,
 			bindPromptExecutionHandle,
-			peekPromptPendingOutcome: correlation => kindReconciliation.peekPendingOutcome(correlation),
+			peekPromptPendingOutcome: correlation => {
+				const kind =
+					promptSubmissions.get(promptSubmissionKey(correlation))?.reconciliationKind ?? ("prompt" as const);
+				return kindReconciliation.peekPendingOutcome(correlation, kind);
+			},
 			terminalizePrompt: (correlation, outcome, extra) => terminalizePrompt(correlation, outcome, {}, extra),
 			recordPromptTerminal,
 			notePromptReconciliation: (correlation, frame) => {
-				void kindReconciliation.noteTransition("prompt", correlation, frame);
+				const kind = correlation
+					? (promptSubmissions.get(promptSubmissionKey(correlation))?.reconciliationKind ?? ("prompt" as const))
+					: "prompt";
+				void kindReconciliation.noteTransition(kind, correlation, frame);
 			},
 			emitPromptFailure,
 			emitPromptLifecycle,
@@ -4722,7 +4819,10 @@ export function createNotificationsExtension(
 				// therefore only abandons delivery; ACP rejects its own local waiter once and
 				// terminal authority stays with the eventual normalized SDK outcome.
 				for (const submission of promptSubmissions.values())
-					if (submission.connectionId === connectionId) abandonPrompt(submission);
+					if (submission.connectionId === connectionId) {
+						submission.preflightAbort?.();
+						abandonPrompt(submission);
+					}
 			});
 
 			server.onReply((err, reply) => {

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -1790,71 +1790,75 @@ function registerInteractiveAnswerSource(
 	pendingInteractive: Map<string, PendingInteractiveAsk>,
 	presentationArbiter: PresentationArbiter,
 ): () => void {
-	return registerAskAnswerSource(id, {
-		awaitAnswer(question, options, signal) {
-			const result = this.awaitAnswerRequest?.({ question, options, interaction: "selector", controls: [] }, signal);
-			if (!result) return Promise.resolve(undefined);
-			return result.then(answer => {
-				if (!answer || typeof answer === "string") return answer;
-				return answer.interaction.kind === "value" ? answer.interaction.value : undefined;
-			});
-		},
-		awaitAnswerRequest(request: AskAnswerRequest, signal?: AbortSignal): Promise<AskAnswerSourceResult> {
-			if (signal?.aborted) return Promise.resolve(undefined);
-			const presentationId = `interactive:${crypto.randomUUID()}`;
-			return new Promise<AskAnswerSourceResult>(resolve => {
-				let settled = false;
-				const settle = (result: AskAnswerSourceResult) => {
-					if (settled) return;
-					settled = true;
-					resolve(result);
-				};
-				const pending: PendingInteractiveAsk = {
-					resolve: settle,
-					options: request.options,
-					controls: request.controls,
-					retireForDirectControl: () => presentationArbiter.retireForDirectControl(presentationId),
-					reissue: () => {
-						if (!pending.actionId) return false;
-						presentationArbiter.reissueAfterFailure(pending.actionId);
-						return true;
-					},
-					complete: actionId => presentationArbiter.completeInteractive(presentationId, actionId),
-					completeDirect: () => presentationArbiter.completeDirect(presentationId),
-					fail: actionId => presentationArbiter.completeInteractive(presentationId, actionId),
-				};
-				presentationArbiter.retain({
-					gateId: presentationId,
-					sessionId: id,
-					question: request.question,
-					options: request.options,
-					controls: request.controls,
-					recommendedIndex: request.recommendedIndex,
-					// The ask tool owns the multi-select loop and re-issues one request per
-					// toggle; carrying its selection here is what makes the toggle visible
-					// on a remote transport instead of an identical repeated prompt.
-					multi: request.multi === true,
-					allowEmpty: false,
-					selectedOptions: [...(request.selectedOptions ?? [])],
-					onActivated: (actionId, lease) => {
-						if (pending.actionId && pendingInteractive.get(pending.actionId) === pending)
-							pendingInteractive.delete(pending.actionId);
-						pending.actionId = actionId;
-						pendingInteractive.set(actionId, pending);
-						void lease;
-					},
-					onClosed: () => {
-						if (pending.actionId && pendingInteractive.get(pending.actionId) === pending)
-							pendingInteractive.delete(pending.actionId);
-						settle(undefined);
-					},
+	return registerAskAnswerSource(
+		id,
+		{
+			awaitAnswer(question, options, signal) {
+				const result = this.awaitAnswerRequest?.({ question, options, interaction: "selector", controls: [] }, signal);
+				if (!result) return Promise.resolve(undefined);
+				return result.then(answer => {
+					if (!answer || typeof answer === "string") return answer;
+					return answer.interaction.kind === "value" ? answer.interaction.value : undefined;
 				});
-				signal?.addEventListener("abort", () => {
-					presentationArbiter.cancel(presentationId, "interactive_abort");
+			},
+			awaitAnswerRequest(request: AskAnswerRequest, signal?: AbortSignal): Promise<AskAnswerSourceResult> {
+				if (signal?.aborted) return Promise.resolve(undefined);
+				const presentationId = `interactive:${crypto.randomUUID()}`;
+				return new Promise<AskAnswerSourceResult>(resolve => {
+					let settled = false;
+					const settle = (result: AskAnswerSourceResult) => {
+						if (settled) return;
+						settled = true;
+						resolve(result);
+					};
+					const pending: PendingInteractiveAsk = {
+						resolve: settle,
+						options: request.options,
+						controls: request.controls,
+						retireForDirectControl: () => presentationArbiter.retireForDirectControl(presentationId),
+						reissue: () => {
+							if (!pending.actionId) return false;
+							presentationArbiter.reissueAfterFailure(pending.actionId);
+							return true;
+						},
+						complete: actionId => presentationArbiter.completeInteractive(presentationId, actionId),
+						completeDirect: () => presentationArbiter.completeDirect(presentationId),
+						fail: actionId => presentationArbiter.completeInteractive(presentationId, actionId),
+					};
+					presentationArbiter.retain({
+						gateId: presentationId,
+						sessionId: id,
+						question: request.question,
+						options: request.options,
+						controls: request.controls,
+						recommendedIndex: request.recommendedIndex,
+						// The ask tool owns the multi-select loop and re-issues one request per
+						// toggle; carrying its selection here is what makes the toggle visible
+						// on a remote transport instead of an identical repeated prompt.
+						multi: request.multi === true,
+						allowEmpty: false,
+						selectedOptions: [...(request.selectedOptions ?? [])],
+						onActivated: (actionId, lease) => {
+							if (pending.actionId && pendingInteractive.get(pending.actionId) === pending)
+								pendingInteractive.delete(pending.actionId);
+							pending.actionId = actionId;
+							pendingInteractive.set(actionId, pending);
+							void lease;
+						},
+						onClosed: () => {
+							if (pending.actionId && pendingInteractive.get(pending.actionId) === pending)
+								pendingInteractive.delete(pending.actionId);
+							settle(undefined);
+						},
+					});
+					signal?.addEventListener("abort", () => {
+						presentationArbiter.cancel(presentationId, "interactive_abort");
+					});
 				});
-			});
+			},
 		},
-	});
+		"interactive",
+	);
 }
 
 /** Extract the session id from a `<timestamp>_<uuid>.jsonl` session file path. */
@@ -3667,6 +3671,7 @@ export function createNotificationsExtension(
 					createSdkUiAskAnswerSource(
 						async (params, signal) => await host!.reverse.request("ui", "ui.elicit", params, signal),
 					),
+					"protocol",
 				);
 				return;
 			}

--- a/packages/coding-agent/src/sdk/bus/kind-aware-reconciliation.ts
+++ b/packages/coding-agent/src/sdk/bus/kind-aware-reconciliation.ts
@@ -35,13 +35,15 @@ export interface KindAwareReconciliation {
 	claimPendingOutcome(
 		correlation: PromptCorrelation,
 		outcome: SdkPromptTerminalOutcome,
+		kind?: ReconciliationKind,
 	): Promise<SdkPromptTerminalOutcome>;
 	finalizePromptOutcome(
 		correlation: PromptCorrelation,
 		outcome?: SdkPromptTerminalOutcome,
 		recordError?: { code: string; message: string },
+		kind?: ReconciliationKind,
 	): Promise<void>;
-	peekPendingOutcome(correlation: PromptCorrelation): SdkPromptTerminalOutcome | undefined;
+	peekPendingOutcome(correlation: PromptCorrelation, kind?: ReconciliationKind): SdkPromptTerminalOutcome | undefined;
 	lookup(
 		kind: ReconciliationKind,
 		selector: { commandId?: string; turnId?: string; clientRef?: string },
@@ -214,10 +216,11 @@ export function createKindAwareReconciliation(
 	const claimPendingOutcome = async (
 		correlation: PromptCorrelation,
 		outcome: SdkPromptTerminalOutcome,
+		kind: ReconciliationKind = "prompt",
 	): Promise<SdkPromptTerminalOutcome> =>
 		await queueMutation(candidate => {
-			const record = candidate.get(keyOf("prompt", correlation));
-			if (!record || record.terminalAt !== undefined || record.kind !== "prompt")
+			const record = candidate.get(keyOf(kind, correlation));
+			if (!record || record.terminalAt !== undefined || record.kind !== kind)
 				return { value: outcome, changed: false };
 			if (record.pendingOutcome !== undefined) return { value: record.pendingOutcome, changed: false };
 			record.pendingOutcome = outcome;
@@ -228,10 +231,11 @@ export function createKindAwareReconciliation(
 		correlation: PromptCorrelation,
 		outcome?: SdkPromptTerminalOutcome,
 		recordError?: { code: string; message: string },
+		kind: ReconciliationKind = "prompt",
 	) => {
 		await queueMutation(candidate => {
-			const record = candidate.get(keyOf("prompt", correlation));
-			if (!record || record.terminalAt !== undefined || record.kind !== "prompt")
+			const record = candidate.get(keyOf(kind, correlation));
+			if (!record || record.terminalAt !== undefined || record.kind !== kind)
 				return { value: undefined, changed: false };
 			const finalOutcome = outcome ?? record.pendingOutcome;
 			record.terminalAt = now();
@@ -246,8 +250,8 @@ export function createKindAwareReconciliation(
 		});
 	};
 
-	const peekPendingOutcome = (correlation: PromptCorrelation) =>
-		records.get(keyOf("prompt", correlation))?.pendingOutcome;
+	const peekPendingOutcome = (correlation: PromptCorrelation, kind: ReconciliationKind = "prompt") =>
+		records.get(keyOf(kind, correlation))?.pendingOutcome;
 
 	const lookup = (
 		kind: ReconciliationKind,

--- a/packages/coding-agent/src/sdk/bus/reconciliation-store.ts
+++ b/packages/coding-agent/src/sdk/bus/reconciliation-store.ts
@@ -6,8 +6,8 @@
  *
  * Safe session ids only: /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/
  * Atomic write: temp + fsync + rename + 0600. Corrupt → quarantine + empty.
- * Non-terminal skill records settle to failed/process_restart on bootstrap; prompt
- * records finalize their pending outcome or a prompt_failed fallback.
+ * Non-terminal records with a pending outcome finalize that exact claim on bootstrap.
+ * Outcome-less skills retain the existing failed/process_restart settlement.
  */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
@@ -91,9 +91,8 @@ function isValidRecord(value: unknown): boolean {
 	if (status !== "accepted" && status !== "in_flight" && status !== "terminal_ok" && status !== "failed") return false;
 	if (typeof acceptedAt !== "number" || !Number.isFinite(acceptedAt)) return false;
 	if (terminalAt !== undefined && (typeof terminalAt !== "number" || !Number.isFinite(terminalAt))) return false;
-	// Durable invariants: only prompts carry a pending claim, a finalized record has no
-	// pending claim left, and terminal/active status must agree with `terminalAt`.
-	if (pendingOutcome !== undefined && kind !== "prompt") return false;
+	// Durable invariants: a finalized record has no pending claim left, and
+	// terminal/active status must agree with `terminalAt`.
 	if (pendingOutcome !== undefined && terminalAt !== undefined) return false;
 	const isTerminalStatus = status === "terminal_ok" || status === "failed";
 	if (isTerminalStatus !== (terminalAt !== undefined)) return false;
@@ -142,8 +141,8 @@ function parseDocument(raw: string, expectedSessionId: string): ReconciliationSt
 
 /**
  * Settle non-terminal durable records after process death.
- * Prompt records preserve a durable pending outcome; skills retain the existing
- * reconciliation-incomplete result.
+ * Any record with a durable pending outcome preserves that exact terminal claim;
+ * outcome-less skills retain the existing reconciliation-incomplete result.
  */
 export function settleProcessRestart(
 	records: DurableReconciliationRecord[],
@@ -151,7 +150,7 @@ export function settleProcessRestart(
 ): DurableReconciliationRecord[] {
 	return records.map(record => {
 		if (record.terminalAt !== undefined) return record;
-		if (record.kind === "prompt") {
+		if (record.pendingOutcome !== undefined || record.kind === "prompt") {
 			const outcome: SdkPromptTerminalOutcome = record.pendingOutcome ?? {
 				kind: "failed",
 				code: "prompt_failed",

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -734,6 +734,8 @@ export interface PromptOptions {
 	onPreflightAcceptCommit?: () => void | Promise<void>;
 	/** Skill-only: prepared metadata before the durable fence (path/lineCount/cleanedArgs). */
 	onSkillPrepared?: (meta: { name: string; path: string; lineCount?: number; cleanedArgs?: string }) => void;
+	/** Optional invocation-scoped cancellation fence used before an accepted skill starts execution. */
+	preflightSignal?: AbortSignal;
 }
 
 function promptPreflightCancelledError(): Error {
@@ -7633,8 +7635,12 @@ export class AgentSession {
 	async invokeSkill(
 		name: string,
 		args = "",
-		options?: Pick<PromptOptions, "onPreflightAccepted" | "onPreflightAcceptCommit" | "onSkillPrepared">,
+		options?: Pick<
+			PromptOptions,
+			"onPreflightAccepted" | "onPreflightAcceptCommit" | "onSkillPrepared" | "preflightSignal"
+		>,
 	): Promise<{ name: string; path: string; args?: string; lineCount?: number }> {
+		if (options?.preflightSignal?.aborted) throw promptPreflightCancelledError();
 		const skillName = name.trim();
 		if (!skillName) throw Object.assign(new Error("skill.invoke requires a skill name."), { code: "invalid_input" });
 		if (typeof args !== "string")
@@ -7666,6 +7672,7 @@ export class AgentSession {
 			attribution: "user" as const,
 		};
 		this.#deepInterviewPreclaimedCustomInputEpochs.set(skillPromptMessage, deepInterviewUserIntentEpoch);
+		if (options?.preflightSignal?.aborted) throw promptPreflightCancelledError();
 		options?.onSkillPrepared?.({
 			name: skill.name,
 			path: skill.filePath,
@@ -8535,9 +8542,15 @@ export class AgentSession {
 		message: Pick<CustomMessage<T>, "customType" | "content" | "display" | "details" | "attribution">,
 		options?: Pick<
 			PromptOptions,
-			"streamingBehavior" | "toolChoice" | "followUpQueuePolicy" | "onPreflightAccepted" | "onPreflightAcceptCommit"
+			| "streamingBehavior"
+			| "toolChoice"
+			| "followUpQueuePolicy"
+			| "onPreflightAccepted"
+			| "onPreflightAcceptCommit"
+			| "preflightSignal"
 		>,
 	): Promise<void> {
+		if (options?.preflightSignal?.aborted) throw promptPreflightCancelledError();
 		const textContent =
 			typeof message.content === "string"
 				? message.content
@@ -8600,7 +8613,12 @@ export class AgentSession {
 		expandedText: string,
 		options?: Pick<
 			PromptOptions,
-			"toolChoice" | "images" | "skipCompactionCheck" | "onPreflightAccepted" | "onPreflightAcceptCommit"
+			| "toolChoice"
+			| "images"
+			| "skipCompactionCheck"
+			| "onPreflightAccepted"
+			| "onPreflightAcceptCommit"
+			| "preflightSignal"
 		> & {
 			prependMessages?: AgentMessage[];
 			skipPostPromptRecoveryWait?: boolean;
@@ -8612,6 +8630,7 @@ export class AgentSession {
 		},
 	): Promise<void> {
 		this.#assertNoHandoffTransition();
+		if (options?.preflightSignal?.aborted) throw promptPreflightCancelledError();
 		await this.#agentEndPublicationPromise;
 		// Re-check after the publication await: a handoff can engage during that
 		// window, and #beginInFlight below would otherwise start a turn against the
@@ -8821,7 +8840,7 @@ export class AgentSession {
 
 			// Abort can race asynchronous preflight work. The injection signatures were
 			// consumed while building context, but no prompt was accepted, so reset them.
-			if (this.#isPromptPreflightCancelled(generation, preflightSignal)) {
+			if (this.#isPromptPreflightCancelled(generation, preflightSignal) || options?.preflightSignal?.aborted) {
 				this.#resetInjectedContextSignatures();
 				// Ack-waiting callers are told the preflight never ran; direct callers
 				// (aborted after setup) resolve gracefully as before f24f46ff5.
@@ -8839,8 +8858,10 @@ export class AgentSession {
 					if (hindsightRecall) this.getHindsightSessionState()?.markRecallSnippetInjected(hindsightRecall);
 				},
 			};
+			if (options?.preflightSignal?.aborted) throw promptPreflightCancelledError();
 			if (options?.onPreflightAcceptCommit) await options.onPreflightAcceptCommit();
 			else options?.onPreflightAccepted?.();
+			if (options?.preflightSignal?.aborted) throw promptPreflightCancelledError();
 			if (options?.onFinalPreflight && !(await options.onFinalPreflight({ hasPendingNextTurnMessages }))) {
 				this.#resetInjectedContextSignatures();
 				return;

--- a/packages/coding-agent/src/tools/ask-answer-registry.ts
+++ b/packages/coding-agent/src/tools/ask-answer-registry.ts
@@ -3,27 +3,41 @@
  *
  * Decouples the `ask` tool (which reads the source via `AgentSession`) from the
  * notifications extension (which registers one), without threading a new method
- * through the extension/runner/controller wiring. A session has at most one
- * source; registering returns a disposer.
+ * through the extension/runner/controller wiring. A session may have multiple
+ * sources. A "protocol" source always takes precedence over an "interactive"
+ * source regardless of registration order; within the same kind, the most
+ * recently registered source wins. Registering returns a disposer.
  */
 
 import { logger } from "@gajae-code/utils";
 import type { WorkflowGateEmitter } from "../modes/shared/agent-wire/workflow-gate-broker";
 import type { AskAnswerSource } from "./index";
 
-const sources = new Map<string, AskAnswerSource[]>();
+export type AskAnswerSourceKind = "protocol" | "interactive";
+
+export interface RegisteredAskAnswerSource {
+	readonly source: AskAnswerSource;
+	readonly kind: AskAnswerSourceKind;
+}
+
+const sources = new Map<string, RegisteredAskAnswerSource[]>();
 const workflowGateEmitters = new Map<string, WorkflowGateEmitter>();
 const workflowGateListeners = new Map<string, Set<(emitter: WorkflowGateEmitter | undefined) => void>>();
 
 /** Register `source` for `sessionId`. Returns a disposer that restores the prior source. */
-export function registerAskAnswerSource(sessionId: string, source: AskAnswerSource): () => void {
+export function registerAskAnswerSource(
+	sessionId: string,
+	source: AskAnswerSource,
+	kind: AskAnswerSourceKind = "interactive",
+): () => void {
 	const stack = sources.get(sessionId) ?? [];
-	stack.push(source);
+	const entry: RegisteredAskAnswerSource = { source, kind };
+	stack.push(entry);
 	sources.set(sessionId, stack);
 	return () => {
 		const current = sources.get(sessionId);
 		if (!current) return;
-		const index = current.lastIndexOf(source);
+		const index = current.lastIndexOf(entry);
 		if (index >= 0) current.splice(index, 1);
 		if (current.length === 0) sources.delete(sessionId);
 	};
@@ -31,7 +45,9 @@ export function registerAskAnswerSource(sessionId: string, source: AskAnswerSour
 
 /** The highest-priority answer source for `sessionId`, if one is registered. */
 export function getAskAnswerSource(sessionId: string): AskAnswerSource | undefined {
-	return sources.get(sessionId)?.at(-1);
+	const entries = sources.get(sessionId);
+	const protocolEntry = entries?.findLast(entry => entry.kind === "protocol");
+	return protocolEntry?.source ?? entries?.at(-1)?.source;
 }
 
 /** Publish a session's current workflow-gate emitter after mode initialization. */

--- a/packages/coding-agent/test/acp-deep-interview-wire.test.ts
+++ b/packages/coding-agent/test/acp-deep-interview-wire.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	type Client,
+	ClientSideConnection,
+	type CreateElicitationRequest,
+	type CreateElicitationResponse,
+	ndJsonStream,
+	type RequestPermissionRequest,
+	type RequestPermissionResponse,
+	type SessionNotification,
+} from "@agentclientprotocol/sdk";
+import { startFixtureBrokerWithLeaseForTest } from "../src/sdk/broker/ensure";
+import {
+	cleanupFixtureRoots,
+	createFixtureRootCleanup,
+	type FixtureRootCleanup,
+	registerFixtureRuntime,
+	withFixtureBrokerEnvironment,
+} from "./helpers/fixture-broker-cleanup";
+
+type AcpProc = Bun.Subprocess<"pipe", "pipe", "pipe">;
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
+const cleanupRoots: FixtureRootCleanup[] = [];
+const servers: Array<{ stop(closeActiveConnections?: boolean): void }> = [];
+
+function input(proc: AcpProc): WritableStream<Uint8Array> {
+	return new WritableStream({
+		write(chunk) {
+			proc.stdin.write(chunk);
+			proc.stdin.flush();
+		},
+		close() {
+			proc.stdin.end();
+		},
+		abort() {
+			proc.stdin.end();
+		},
+	});
+}
+
+function childEnv(root: string): Record<string, string> {
+	const agentDir = path.join(root, "agent");
+	const env: Record<string, string> = {
+		PATH: process.env.PATH ?? "/usr/bin:/bin",
+		HOME: root,
+		TMPDIR: path.join(root, "tmp"),
+		XDG_DATA_HOME: path.join(root, ".local", "share"),
+		XDG_CONFIG_HOME: path.join(root, ".config"),
+		XDG_STATE_HOME: path.join(root, ".local", "state"),
+		XDG_CACHE_HOME: path.join(root, ".cache"),
+		XDG_RUNTIME_DIR: path.join(root, ".run"),
+		GJC_CODING_AGENT_DIR: agentDir,
+		PI_CODING_AGENT_DIR: agentDir,
+		GJC_NOTIFICATIONS: "1",
+		PI_NO_TITLE: "1",
+		NO_COLOR: "1",
+	};
+	for (const key of ["LANG", "LC_ALL", "TZ"] as const) {
+		const value = process.env[key];
+		if (value) env[key] = value;
+	}
+	return env;
+}
+
+function chatStream(chunks: Record<string, unknown>[]): Response {
+	return new Response(`${chunks.map(chunk => `data: ${JSON.stringify(chunk)}\n\n`).join("")}data: [DONE]\n\n`, {
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+function chunk(delta: Record<string, unknown>, finishReason: string | null): Record<string, unknown> {
+	return {
+		id: "chatcmpl-acp-deep-interview",
+		object: "chat.completion.chunk",
+		created: 0,
+		model: "fixture-model",
+		choices: [{ index: 0, delta, finish_reason: finishReason }],
+	};
+}
+
+async function waitFor(predicate: () => boolean, label: string, timeoutMs = 15_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await Bun.sleep(10);
+	}
+	throw new Error(`Timed out waiting for ${label}`);
+}
+
+async function bounded<T>(promise: Promise<T>, label: string, timeoutMs = 15_000): Promise<T> {
+	return await Promise.race([
+		promise,
+		Bun.sleep(timeoutMs).then(() => {
+			throw new Error(`Timed out waiting for ${label}`);
+		}),
+	]);
+}
+
+class InterviewClient implements Client {
+	readonly elicitations: CreateElicitationRequest[] = [];
+	readonly updates: SessionNotification[] = [];
+
+	async requestPermission(_params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
+		return { outcome: { outcome: "selected", optionId: "allow_once" } };
+	}
+
+	async sessionUpdate(params: SessionNotification): Promise<void> {
+		this.updates.push(params);
+	}
+
+	async unstable_createElicitation(params: CreateElicitationRequest): Promise<CreateElicitationResponse> {
+		this.elicitations.push(params);
+		return { action: "accept", content: { value: "option:0" } };
+	}
+}
+
+async function stopProcess(proc: AcpProc): Promise<void> {
+	try {
+		proc.stdin.end();
+	} catch {}
+	if (!(await Promise.race([proc.exited.then(() => true), Bun.sleep(2_000).then(() => false)]))) {
+		try {
+			proc.kill("SIGKILL");
+		} catch {}
+	}
+	if (!(await Promise.race([proc.exited.then(() => true), Bun.sleep(3_000).then(() => false)])))
+		throw new Error("ACP subprocess did not exit after SIGKILL");
+}
+
+afterEach(async () => {
+	for (const server of servers.splice(0)) server.stop(true);
+	await cleanupFixtureRoots(cleanupRoots);
+});
+
+describe("OpenCode-style ACP deep-interview wire path", () => {
+	it("routes an advertised skill command to a real form elicitation in a headless lifecycle host", async () => {
+		const requests: Array<Record<string, unknown>> = [];
+		const modelServer = Bun.serve({
+			hostname: "127.0.0.1",
+			port: 0,
+			async fetch(request) {
+				const body = (await request.json()) as Record<string, unknown>;
+				requests.push(body);
+				if (requests.length === 1)
+					return chatStream([
+						chunk({ role: "assistant", content: "Wire skill completed." }, null),
+						chunk({}, "stop"),
+					]);
+				if (requests.length === 2) {
+					const args = JSON.stringify({
+						questions: [
+							{
+								id: "acp-direction",
+								question: "Which ACP direction should the interview use?",
+								options: [{ label: "Keep protocol choices" }, { label: "Use plain text" }],
+								recommended: 0,
+							},
+						],
+					});
+					return chatStream([
+						chunk(
+							{
+								role: "assistant",
+								tool_calls: [
+									{
+										index: 0,
+										id: "call-acp-ask",
+										type: "function",
+										function: { name: "ask", arguments: args },
+									},
+								],
+							},
+							null,
+						),
+						chunk({}, "tool_calls"),
+					]);
+				}
+				await Bun.sleep(3_000);
+				return chatStream([
+					chunk({ role: "assistant", content: "Cancellation fallback should not publish." }, null),
+					chunk({}, "stop"),
+				]);
+			},
+		});
+		servers.push(modelServer);
+
+		const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "gjc-acp-deep-interview-wire-"));
+		const env = childEnv(root);
+		for (const dir of [
+			env.HOME,
+			env.TMPDIR,
+			env.XDG_DATA_HOME,
+			env.XDG_CONFIG_HOME,
+			env.XDG_STATE_HOME,
+			env.XDG_CACHE_HOME,
+			env.XDG_RUNTIME_DIR,
+			env.GJC_CODING_AGENT_DIR,
+		])
+			await fs.promises.mkdir(dir, { recursive: true });
+		const workspace = path.join(root, "workspace");
+		await fs.promises.mkdir(path.join(workspace, ".gjc", "skills", "wire-skill"), { recursive: true });
+		await fs.promises.writeFile(
+			path.join(workspace, ".gjc", "skills", "wire-skill", "SKILL.md"),
+			"---\nname: wire-skill\ndescription: Complete one deterministic ACP turn.\n---\n\nReturn one short completion message.\n",
+		);
+		await fs.promises.writeFile(
+			path.join(workspace, ".gjc", "settings.json"),
+			JSON.stringify({ skills: { enabled: true, enablePiProject: true } }),
+		);
+		const agentDir = env.GJC_CODING_AGENT_DIR;
+		await fs.promises.writeFile(
+			path.join(agentDir, "models.yml"),
+			`providers:\n  fixture:\n    baseUrl: http://127.0.0.1:${modelServer.port}/v1\n    apiKey: fixture-key\n    api: openai-completions\n    models:\n      - id: fixture-model\n        name: Fixture Model\n        contextWindow: 32768\n        maxTokens: 4096\nprofiles:\n  acp-fixture:\n    display_name: ACP Fixture\n    required_providers: [fixture]\n    model_mapping:\n      default: fixture/fixture-model\n`,
+		);
+
+		const started = await withFixtureBrokerEnvironment(() => startFixtureBrokerWithLeaseForTest({ agentDir, env }));
+		const cleanup = createFixtureRootCleanup(root, agentDir, started.lease);
+		cleanupRoots.push(cleanup);
+		const proc = Bun.spawn(["bun", "packages/coding-agent/src/cli.ts", "--mode", "acp", "--mpreset", "acp-fixture"], {
+			cwd: repoRoot,
+			stdin: "pipe",
+			stdout: "pipe",
+			stderr: "pipe",
+			env,
+		});
+		let stderr = "";
+		const stderrDrain = (async () => {
+			const reader = proc.stderr.getReader();
+			const decoder = new TextDecoder();
+			for (;;) {
+				const { value, done } = await reader.read();
+				if (done) break;
+				if (value) stderr = `${stderr}${decoder.decode(value, { stream: true })}`.slice(-64 * 1024);
+			}
+		})();
+		registerFixtureRuntime(cleanup, {
+			key: "acp-deep-interview-subprocess",
+			requiredOwner: "runtime-and-broker",
+			shutdown: () => stopProcess(proc),
+			dispose: () => stderrDrain,
+		});
+
+		const client = new InterviewClient();
+		const connection = new ClientSideConnection(() => client, ndJsonStream(input(proc), proc.stdout));
+		try {
+			await connection.initialize({ protocolVersion: 1, clientCapabilities: { elicitation: { form: {} } } });
+			const { sessionId } = await connection.newSession({ cwd: workspace, mcpServers: [] });
+			const response = await bounded(
+				connection.prompt({
+					sessionId,
+					prompt: [{ type: "text", text: "/skill:wire-skill" }],
+				}),
+				"completed ACP skill prompt",
+			);
+			expect(response.stopReason).toBe("end_turn");
+			expect(requests).toHaveLength(1);
+			expect(stderr).not.toContain("theme.status");
+			const cancelSessionId = (await connection.newSession({ cwd: workspace, mcpServers: [] })).sessionId;
+			const cancelledPrompt = connection.prompt({
+				sessionId: cancelSessionId,
+				prompt: [{ type: "text", text: "/skill:deep-interview verify ACP cancellation" }],
+			});
+			await waitFor(() => client.elicitations.length === 1 && requests.length >= 3, "ACP form before cancellation");
+			expect(client.elicitations).toHaveLength(1);
+			expect(client.elicitations[0]).toMatchObject({
+				sessionId: cancelSessionId,
+				mode: "form",
+				message: "Which ACP direction should the interview use?",
+			});
+			const choiceSchema = client.elicitations[0] as CreateElicitationRequest & {
+				requestedSchema: { properties: { value: { oneOf: Array<{ const: string }> } } };
+			};
+			expect(choiceSchema.requestedSchema.properties.value.oneOf.map(choice => choice.const)).toEqual(
+				expect.arrayContaining(["option:0", "option:1"]),
+			);
+			expect(JSON.stringify(requests[1]?.tools)).toContain('"name":"ask"');
+			expect(JSON.stringify(requests[2]?.messages)).toContain("Keep protocol choices");
+			await connection.cancel({ sessionId: cancelSessionId });
+			await expect(bounded(cancelledPrompt, "cancelled ACP skill prompt")).resolves.toEqual({
+				stopReason: "cancelled",
+			});
+		} catch (error) {
+			throw new Error(
+				`${error instanceof Error ? error.message : String(error)}\nforms=${client.elicitations.length} requests=${requests.length}\n[child stderr]\n${stderr}`,
+			);
+		}
+	}, 60_000);
+});

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -89,6 +89,28 @@ describe("ExtensionRunner", () => {
 			expect(resolver).toHaveBeenCalledWith("safe-tool");
 			expect(resolver).toHaveBeenCalledWith("unknown-tool");
 		});
+
+		it("forwards skill lifecycle hooks through the extension context", async () => {
+			const runner = new ExtensionRunner(
+				[],
+				{ flagValues: new Map(), pendingProviderRegistrations: [] } as never,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const invokeSkill = vi.fn(async () => ({ name: "fixture-skill", path: "/fixture/SKILL.md" }));
+			runner.initialize({} as never, { invokeSkill } as never);
+			const options = {
+				onPreflightAccepted: vi.fn(),
+				onPreflightAcceptCommit: vi.fn(async () => {}),
+				onSkillPrepared: vi.fn(),
+				preflightSignal: new AbortController().signal,
+			};
+
+			await runner.createContext().invokeSkill?.("fixture-skill", "argument", options);
+
+			expect(invokeSkill).toHaveBeenCalledWith("fixture-skill", "argument", options);
+		});
 	});
 
 	describe("shortcut conflicts", () => {

--- a/packages/coding-agent/test/helpers/sdk-production-host.ts
+++ b/packages/coding-agent/test/helpers/sdk-production-host.ts
@@ -17,7 +17,7 @@ import { isolatedNotificationSettings } from "./notification-settings";
 
 export async function startProductionSdkHost(
 	cwd: string,
-	options: { acceptPromptPreflightWithoutExecution?: boolean } = {},
+	options: { acceptPromptPreflightWithoutExecution?: boolean; notificationsInitiallyEnabled?: boolean } = {},
 ): Promise<{
 	endpoint: { url: string; token: string };
 	sessionId: string;
@@ -26,6 +26,7 @@ export async function startProductionSdkHost(
 		question: string,
 		options: string[],
 	) => { registered: true; result: Promise<unknown> } | { registered: false; reason: "authority_unavailable" };
+	runCommand: (text: string) => Promise<void>;
 	triggerGate: (
 		spec: Parameters<
 			NonNullable<
@@ -96,7 +97,7 @@ export async function startProductionSdkHost(
 				};
 			}
 			const priorNotifications = process.env.GJC_NOTIFICATIONS;
-			process.env.GJC_NOTIFICATIONS = "1";
+			process.env.GJC_NOTIFICATIONS = options.notificationsInitiallyEnabled === false ? "0" : "1";
 			try {
 				await initializeExtensions(session, {
 					reportSendError: () => {},
@@ -133,6 +134,7 @@ export async function startProductionSdkHost(
 				observed,
 				triggerAsk,
 				triggerGate,
+				runCommand: async text => await session.prompt(text),
 				stop: () => cleanupFixtureRoot(cleanup),
 			};
 		} catch (error) {

--- a/packages/coding-agent/test/sdk-acp-production-path.test.ts
+++ b/packages/coding-agent/test/sdk-acp-production-path.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { AgentSideConnection, SessionNotification } from "@agentclientprotocol/sdk";
-import { AcpAgent } from "../src/modes/acp/acp-agent";
+import { AcpAgent, acpSkillInvocation } from "../src/modes/acp/acp-agent";
 import { writeBrokerDiscovery } from "../src/sdk/broker/discovery";
 
 type TestServer = {
@@ -37,6 +37,19 @@ async function bounded<T>(promise: Promise<T>, label: string, timeoutMs = 2_000)
 	]);
 }
 
+test("ACP advertised skill commands require one complete canonical text block", () => {
+	expect(acpSkillInvocation([{ type: "text", text: " /skill:deep-interview clarify choices " }])).toEqual({
+		name: "deep-interview",
+		args: "clarify choices",
+	});
+	expect(acpSkillInvocation([{ type: "text", text: "/skill:" }])).toBeUndefined();
+	expect(
+		acpSkillInvocation([
+			{ type: "text", text: "/skill:deep-interview" },
+			{ type: "text", text: "extra context" },
+		]),
+	).toBeUndefined();
+});
 test("production ACP routes zero-session SDK globals through the broker adapter", async () => {
 	const directory = await mkdtemp(path.join(tmpdir(), "gjc-sdk-acp-production-"));
 	directories.push(directory);
@@ -110,10 +123,13 @@ test("production ACP preserves lifecycle, turn, replay, and connection ownership
 	const lifecycleInputs: Record<string, unknown>[] = [];
 	const brokerRequests: Record<string, unknown>[] = [];
 	const promptInputs: Record<string, unknown>[] = [];
+	const skillInputs: Record<string, unknown>[] = [];
 	const controlOperations: string[] = [];
 	const updates: SessionNotification[] = [];
 	const providerRegistrations: Array<Record<string, unknown>> = [];
 	let promptSocket: { send(message: string): void } | undefined;
+	let holdSkillPreflight = false;
+	let pendingSkillControlId: string | undefined;
 	let abortAcknowledged = true;
 	let promptDeliveredWhileBusy = false;
 	const sessionCloseLedger = new Map<string, Record<string, unknown>>();
@@ -377,6 +393,34 @@ test("production ACP preserves lifecycle, turn, replay, and connection ownership
 							);
 						}
 					}
+					if (frame.operation === "skill.invoke") {
+						skillInputs.push(frame.input as Record<string, unknown>);
+						promptSocket = socket;
+						if (holdSkillPreflight) {
+							pendingSkillControlId = String(frame.id);
+							return;
+						}
+					}
+					if (frame.operation === "turn.abort" && pendingSkillControlId) {
+						socket.send(
+							JSON.stringify({
+								type: "control_response",
+								id: pendingSkillControlId,
+								ok: false,
+								error: { code: "busy", message: "Skill preflight was cancelled before execution." },
+							}),
+						);
+						pendingSkillControlId = undefined;
+						socket.send(
+							JSON.stringify({
+								type: "control_response",
+								id: frame.id,
+								ok: true,
+								result: { aborted: true, disposition: "preflight_cancelled" },
+							}),
+						);
+						return;
+					}
 					socket.send(
 						JSON.stringify({
 							type: "control_response",
@@ -385,9 +429,11 @@ test("production ACP preserves lifecycle, turn, replay, and connection ownership
 							result:
 								frame.operation === "turn.prompt"
 									? { commandId: "prompt-command", turnId: "prompt-turn", accepted: true }
-									: frame.operation === "turn.abort"
-										? { aborted: abortAcknowledged }
-										: {},
+									: frame.operation === "skill.invoke"
+										? { commandId: "skill-command", turnId: "skill-turn", accepted: true }
+										: frame.operation === "turn.abort"
+											? { aborted: abortAcknowledged }
+											: {},
 						}),
 					);
 				}
@@ -533,6 +579,34 @@ test("production ACP preserves lifecycle, turn, replay, and connection ownership
 	expect(availableCommands.availableCommands?.map(command => command.name)).toEqual(
 		expect.arrayContaining(["skill:deep-interview", "skill:ralplan", "skill:ultragoal", "skill:team"]),
 	);
+	const skillPrompt = agent.prompt({
+		sessionId: created.sessionId,
+		prompt: [{ type: "text", text: "/skill:deep-interview clarify ACP choices" }],
+	});
+	await waitFor(() => skillInputs.length === 1 && promptSocket !== undefined, "ACP skill invocation");
+	expect(skillInputs).toEqual([{ name: "deep-interview", args: "clarify ACP choices" }]);
+	expect(promptInputs).toHaveLength(0);
+	promptSocket!.send(
+		JSON.stringify({
+			type: "agent_end",
+			sessionId: created.sessionId,
+			commandId: "skill-command",
+			turnId: "skill-turn",
+			outcome: { kind: "stopped", reason: "end_turn", provenance: "agent" },
+		}),
+	);
+	await expect(bounded(skillPrompt, "ACP skill prompt completion")).resolves.toMatchObject({ stopReason: "end_turn" });
+	holdSkillPreflight = true;
+	const preflightCancelledSkill = agent.prompt({
+		sessionId: created.sessionId,
+		prompt: [{ type: "text", text: "/skill:deep-interview cancel before start" }],
+	});
+	await waitFor(() => pendingSkillControlId !== undefined, "pending ACP skill preflight");
+	await agent.cancel({ sessionId: created.sessionId });
+	await expect(bounded(preflightCancelledSkill, "preflight-cancelled ACP skill")).resolves.toEqual({
+		stopReason: "cancelled",
+	});
+	holdSkillPreflight = false;
 	const listedOwned = await bounded(agent.listSessions({ cwd }), "list owned session");
 	expect(listedOwned.sessions).toEqual([
 		expect.objectContaining({

--- a/packages/coding-agent/test/sdk-ask-answer-source-priority.test.ts
+++ b/packages/coding-agent/test/sdk-ask-answer-source-priority.test.ts
@@ -13,8 +13,15 @@ describe("ask answer source priority", () => {
 		await initTheme(false);
 	});
 	const tempDirs: string[] = [];
+	const answerSourceDisposers: Array<() => void> = [];
+
+	function trackAnswerSource(dispose: () => void): () => void {
+		answerSourceDisposers.push(dispose);
+		return dispose;
+	}
 
 	afterEach(() => {
+		for (const dispose of answerSourceDisposers.splice(0).reverse()) dispose();
 		for (const dir of tempDirs.splice(0)) {
 			fs.rmSync(dir, { recursive: true, force: true });
 		}
@@ -34,8 +41,8 @@ describe("ask answer source priority", () => {
 		try {
 			const interactive = { awaitAnswer: async () => undefined };
 			const protocol = { awaitAnswer: async () => undefined };
-			registerAskAnswerSource(session.sessionId, interactive, "interactive");
-			registerAskAnswerSource(session.sessionId, protocol, "protocol");
+			trackAnswerSource(registerAskAnswerSource(session.sessionId, interactive, "interactive"));
+			trackAnswerSource(registerAskAnswerSource(session.sessionId, protocol, "protocol"));
 
 			expect(getAskAnswerSource(session.sessionId)).toBe(protocol);
 		} finally {
@@ -57,8 +64,8 @@ describe("ask answer source priority", () => {
 		try {
 			const protocol = { awaitAnswer: async () => undefined };
 			const interactive = { awaitAnswer: async () => undefined };
-			registerAskAnswerSource(session.sessionId, protocol, "protocol");
-			registerAskAnswerSource(session.sessionId, interactive, "interactive");
+			trackAnswerSource(registerAskAnswerSource(session.sessionId, protocol, "protocol"));
+			trackAnswerSource(registerAskAnswerSource(session.sessionId, interactive, "interactive"));
 
 			expect(getAskAnswerSource(session.sessionId)).toBe(protocol);
 		} finally {
@@ -80,8 +87,8 @@ describe("ask answer source priority", () => {
 		try {
 			const protocol = { awaitAnswer: async () => undefined };
 			const interactive = { awaitAnswer: async () => undefined };
-			const disposeProtocol = registerAskAnswerSource(session.sessionId, protocol, "protocol");
-			registerAskAnswerSource(session.sessionId, interactive, "interactive");
+			const disposeProtocol = trackAnswerSource(registerAskAnswerSource(session.sessionId, protocol, "protocol"));
+			trackAnswerSource(registerAskAnswerSource(session.sessionId, interactive, "interactive"));
 			disposeProtocol();
 
 			expect(getAskAnswerSource(session.sessionId)).toBe(interactive);
@@ -104,8 +111,10 @@ describe("ask answer source priority", () => {
 		try {
 			const protocol = { awaitAnswer: async () => undefined };
 			const legacyInteractive = { awaitAnswer: async () => undefined };
-			const disposeProtocol = registerAskAnswerSource(session.sessionId, protocol, "protocol");
-			const disposeLegacyInteractive = registerAskAnswerSource(session.sessionId, legacyInteractive);
+			const disposeProtocol = trackAnswerSource(registerAskAnswerSource(session.sessionId, protocol, "protocol"));
+			const disposeLegacyInteractive = trackAnswerSource(
+				registerAskAnswerSource(session.sessionId, legacyInteractive),
+			);
 
 			expect(getAskAnswerSource(session.sessionId)).toBe(protocol);
 			disposeProtocol();
@@ -130,8 +139,8 @@ describe("ask answer source priority", () => {
 		try {
 			const firstProtocol = { awaitAnswer: async () => undefined };
 			const secondProtocol = { awaitAnswer: async () => undefined };
-			registerAskAnswerSource(session.sessionId, firstProtocol, "protocol");
-			registerAskAnswerSource(session.sessionId, secondProtocol, "protocol");
+			trackAnswerSource(registerAskAnswerSource(session.sessionId, firstProtocol, "protocol"));
+			trackAnswerSource(registerAskAnswerSource(session.sessionId, secondProtocol, "protocol"));
 
 			expect(getAskAnswerSource(session.sessionId)).toBe(secondProtocol);
 		} finally {

--- a/packages/coding-agent/test/sdk-ask-answer-source-priority.test.ts
+++ b/packages/coding-agent/test/sdk-ask-answer-source-priority.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
+import { createAgentSession } from "@gajae-code/coding-agent/sdk";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { getAskAnswerSource, registerAskAnswerSource } from "@gajae-code/coding-agent/tools/ask-answer-registry";
+
+describe("ask answer source priority", () => {
+	beforeAll(async () => {
+		await initTheme(false);
+	});
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const dir of tempDirs.splice(0)) {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("selects the protocol source when it registers after an interactive source", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-ask-source-priority-"));
+		tempDirs.push(tempDir);
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			sessionManager: SessionManager.inMemory(tempDir),
+			settings: Settings.isolated(),
+			hasUI: true,
+		});
+
+		try {
+			const interactive = { awaitAnswer: async () => undefined };
+			const protocol = { awaitAnswer: async () => undefined };
+			registerAskAnswerSource(session.sessionId, interactive, "interactive");
+			registerAskAnswerSource(session.sessionId, protocol, "protocol");
+
+			expect(getAskAnswerSource(session.sessionId)).toBe(protocol);
+		} finally {
+			await session.dispose?.();
+		}
+	});
+
+	it("selects the protocol source when an interactive source registers later", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-ask-source-priority-"));
+		tempDirs.push(tempDir);
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			sessionManager: SessionManager.inMemory(tempDir),
+			settings: Settings.isolated(),
+			hasUI: true,
+		});
+
+		try {
+			const protocol = { awaitAnswer: async () => undefined };
+			const interactive = { awaitAnswer: async () => undefined };
+			registerAskAnswerSource(session.sessionId, protocol, "protocol");
+			registerAskAnswerSource(session.sessionId, interactive, "interactive");
+
+			expect(getAskAnswerSource(session.sessionId)).toBe(protocol);
+		} finally {
+			await session.dispose?.();
+		}
+	});
+
+	it("falls back to the interactive source after disposing the protocol source", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-ask-source-priority-"));
+		tempDirs.push(tempDir);
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			sessionManager: SessionManager.inMemory(tempDir),
+			settings: Settings.isolated(),
+			hasUI: true,
+		});
+
+		try {
+			const protocol = { awaitAnswer: async () => undefined };
+			const interactive = { awaitAnswer: async () => undefined };
+			const disposeProtocol = registerAskAnswerSource(session.sessionId, protocol, "protocol");
+			registerAskAnswerSource(session.sessionId, interactive, "interactive");
+			disposeProtocol();
+
+			expect(getAskAnswerSource(session.sessionId)).toBe(interactive);
+		} finally {
+			await session.dispose?.();
+		}
+	});
+
+	it("selects the most recently registered protocol source", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-ask-source-priority-"));
+		tempDirs.push(tempDir);
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			sessionManager: SessionManager.inMemory(tempDir),
+			settings: Settings.isolated(),
+			hasUI: true,
+		});
+
+		try {
+			const firstProtocol = { awaitAnswer: async () => undefined };
+			const secondProtocol = { awaitAnswer: async () => undefined };
+			registerAskAnswerSource(session.sessionId, firstProtocol, "protocol");
+			registerAskAnswerSource(session.sessionId, secondProtocol, "protocol");
+
+			expect(getAskAnswerSource(session.sessionId)).toBe(secondProtocol);
+		} finally {
+			await session.dispose?.();
+		}
+	});
+
+	it("returns undefined when no source is registered", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-ask-source-priority-"));
+		tempDirs.push(tempDir);
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			sessionManager: SessionManager.inMemory(tempDir),
+			settings: Settings.isolated(),
+			hasUI: true,
+		});
+
+		try {
+			expect(getAskAnswerSource(session.sessionId)).toBeUndefined();
+		} finally {
+			await session.dispose?.();
+		}
+	});
+});

--- a/packages/coding-agent/test/sdk-ask-answer-source-priority.test.ts
+++ b/packages/coding-agent/test/sdk-ask-answer-source-priority.test.ts
@@ -90,6 +90,32 @@ describe("ask answer source priority", () => {
 		}
 	});
 
+	it("keeps a protocol source ahead of a legacy two-argument interactive registration", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-ask-source-priority-"));
+		tempDirs.push(tempDir);
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			sessionManager: SessionManager.inMemory(tempDir),
+			settings: Settings.isolated(),
+			hasUI: true,
+		});
+
+		try {
+			const protocol = { awaitAnswer: async () => undefined };
+			const legacyInteractive = { awaitAnswer: async () => undefined };
+			const disposeProtocol = registerAskAnswerSource(session.sessionId, protocol, "protocol");
+			const disposeLegacyInteractive = registerAskAnswerSource(session.sessionId, legacyInteractive);
+
+			expect(getAskAnswerSource(session.sessionId)).toBe(protocol);
+			disposeProtocol();
+			expect(getAskAnswerSource(session.sessionId)).toBe(legacyInteractive);
+			disposeLegacyInteractive();
+		} finally {
+			await session.dispose?.();
+		}
+	});
+
 	it("selects the most recently registered protocol source", async () => {
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-ask-source-priority-"));
 		tempDirs.push(tempDir);

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -3011,104 +3011,123 @@ test("SDK ACP form elicitation remains preferred after /notify on and falls back
 		ui: { notify: (message: string, level: string) => messages.push({ message, level }) },
 	};
 	process.env.GJC_NOTIFICATIONS = "0";
-	start(sessionContext, undefined, () => {}, false, commands);
-	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
-	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
-	expect(getAskAnswerSource(sessionId)).toBeUndefined();
-	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
-	const frames: Record<string, unknown>[] = [];
-	const socket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
-	sockets.push(socket);
-	socket.addEventListener("message", event => frames.push(JSON.parse(String(event.data))));
-	await new Promise<void>((resolve, reject) => {
-		socket.addEventListener("open", () => resolve(), { once: true });
-		socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
-	});
-	await waitFor(() => frames.some(frame => frame.type === "hello"), "SDK hello");
-	const connectionId = String(frames.find(frame => frame.type === "hello")?.connectionId);
-	socket.send(
-		JSON.stringify({
-			type: "register_provider",
-			id: "ui",
-			connectionId,
-			capability: "ui",
-			definitions: [],
-		}),
-	);
-	await waitFor(
-		() => frames.some(frame => frame.type === "register_provider_result" && frame.id === "ui"),
-		"UI provider registration",
-	);
-	process.env.GJC_NOTIFICATIONS = "1";
-	await commands.get("notify")!.handler("on", sessionContext);
-	expect(messages).toEqual([{ message: "Notifications enabled for this session.", level: "info" }]);
+	const handlers = start(sessionContext, undefined, () => {}, false, commands);
+	try {
+		const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+		await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+		expect(getAskAnswerSource(sessionId)).toBeUndefined();
+		const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+		const frames: Record<string, unknown>[] = [];
+		const socket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+		sockets.push(socket);
+		socket.addEventListener("message", event => frames.push(JSON.parse(String(event.data))));
+		await new Promise<void>((resolve, reject) => {
+			socket.addEventListener("open", () => resolve(), { once: true });
+			socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+		});
+		await waitFor(() => frames.some(frame => frame.type === "hello"), "SDK hello");
+		const connectionId = String(frames.find(frame => frame.type === "hello")?.connectionId);
+		socket.send(
+			JSON.stringify({
+				type: "register_provider",
+				id: "ui",
+				connectionId,
+				capability: "ui",
+				definitions: [],
+			}),
+		);
+		await waitFor(
+			() => frames.some(frame => frame.type === "register_provider_result" && frame.id === "ui"),
+			"UI provider registration",
+		);
+		process.env.GJC_NOTIFICATIONS = "1";
+		await commands.get("notify")!.handler("on", sessionContext);
+		expect(messages).toEqual([{ message: "Notifications enabled for this session.", level: "info" }]);
 
-	const protocolAnswer = getAskAnswerSource(sessionId)!.awaitAnswerRequest!(
-		{ question: "Choose the protocol answer", options: ["First", "Second"], interaction: "selector", controls: [] },
-		new AbortController().signal,
-	);
-	await waitFor(() => frames.some(frame => frame.type === "reverse_request"), "protocol elicitation request");
-	const protocolRequest = frames.find(frame => frame.type === "reverse_request")!;
-	expect(protocolRequest).toMatchObject({
-		payload: {
-			method: "ui.elicit",
-			payload: { mode: "form", message: "Choose the protocol answer" },
-		},
-	});
-	socket.send(
-		JSON.stringify({
-			type: "reverse_response",
-			id: protocolRequest.id,
-			connectionId,
-			leaseId: protocolRequest.leaseId,
-			ok: true,
-			result: { action: "accept", content: { value: "option:1" } },
-		}),
-	);
-	expect(await protocolAnswer).toBe("Second");
-
-	await closeSocket(socket);
-	const fallbackFrames: Record<string, unknown>[] = [];
-	const fallbackSocket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
-	sockets.push(fallbackSocket);
-	fallbackSocket.addEventListener("message", event => fallbackFrames.push(JSON.parse(String(event.data))));
-	await new Promise<void>((resolve, reject) => {
-		fallbackSocket.addEventListener("open", () => resolve(), { once: true });
-		fallbackSocket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
-	});
-	const fallbackAnswer = getAskAnswerSource(sessionId)!.awaitAnswer("Choose the interactive fallback", [
-		"Continue",
-		"Stop",
-	]);
-	await waitFor(
-		() => fallbackFrames.some(frame => frame.type === "action_needed" && frame.kind === "ask"),
-		"interactive fallback presentation",
-	);
-	const fallbackAction = fallbackFrames.find(frame => frame.type === "action_needed" && frame.kind === "ask")!;
-	fallbackSocket.send(
-		JSON.stringify({
-			type: "control_command",
-			sessionId,
-			token: endpoint.token,
-			requestId: "interactive-fallback-answer",
-			command: {
-				type: "control_request",
-				id: "interactive-fallback-answer",
-				operation: "ask.answer",
-				input: { id: fallbackAction.id, answer: 0 },
-				idempotencyKey: "interactive-fallback-answer",
+		const protocolAnswerSource = getAskAnswerSource(sessionId);
+		expect(protocolAnswerSource).toBeDefined();
+		const protocolAnswer = protocolAnswerSource!.awaitAnswerRequest!(
+			{
+				question: "Choose the protocol answer",
+				options: ["First", "Second"],
+				interaction: "selector",
+				controls: [],
 			},
-		}),
-	);
-	await waitFor(
-		() =>
-			fallbackFrames.some(
-				frame => frame.type === "control_command_result" && frame.requestId === "interactive-fallback-answer",
-			),
-		"interactive fallback answer",
-	);
-	expect(await fallbackAnswer).toBe("Continue");
-	expect(frames.filter(frame => frame.type === "reverse_request")).toHaveLength(1);
+			new AbortController().signal,
+		);
+		await waitFor(() => frames.some(frame => frame.type === "reverse_request"), "protocol elicitation request");
+		const protocolRequest = frames.find(frame => frame.type === "reverse_request")!;
+		expect(protocolRequest).toMatchObject({
+			payload: {
+				method: "ui.elicit",
+				payload: { mode: "form", message: "Choose the protocol answer" },
+			},
+		});
+		socket.send(
+			JSON.stringify({
+				type: "reverse_response",
+				id: protocolRequest.id,
+				connectionId,
+				leaseId: protocolRequest.leaseId,
+				ok: true,
+				result: { action: "accept", content: { value: "option:1" } },
+			}),
+		);
+		expect(await protocolAnswer).toBe("Second");
+
+		await closeSocket(socket);
+		await waitFor(() => {
+			const selected = getAskAnswerSource(sessionId);
+			return selected !== undefined && selected !== protocolAnswerSource;
+		}, "interactive answer source restoration");
+		const fallbackFrames: Record<string, unknown>[] = [];
+		const fallbackSocket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+		sockets.push(fallbackSocket);
+		fallbackSocket.addEventListener("message", event => fallbackFrames.push(JSON.parse(String(event.data))));
+		await new Promise<void>((resolve, reject) => {
+			fallbackSocket.addEventListener("open", () => resolve(), { once: true });
+			fallbackSocket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+		});
+		await waitFor(() => fallbackFrames.some(frame => frame.type === "hello"), "fallback SDK hello");
+		const interactiveAnswerSource = getAskAnswerSource(sessionId);
+		expect(interactiveAnswerSource).toBeDefined();
+		expect(interactiveAnswerSource).not.toBe(protocolAnswerSource);
+		const fallbackAnswer = interactiveAnswerSource!.awaitAnswer("Choose the interactive fallback", [
+			"Continue",
+			"Stop",
+		]);
+		await waitFor(
+			() => fallbackFrames.some(frame => frame.type === "action_needed" && frame.kind === "ask"),
+			"interactive fallback presentation",
+		);
+		const fallbackAction = fallbackFrames.find(frame => frame.type === "action_needed" && frame.kind === "ask")!;
+		fallbackSocket.send(
+			JSON.stringify({
+				type: "control_command",
+				sessionId,
+				token: endpoint.token,
+				requestId: "interactive-fallback-answer",
+				command: {
+					type: "control_request",
+					id: "interactive-fallback-answer",
+					operation: "ask.answer",
+					input: { id: fallbackAction.id, answer: 0 },
+					idempotencyKey: "interactive-fallback-answer",
+				},
+			}),
+		);
+		await waitFor(
+			() =>
+				fallbackFrames.some(
+					frame => frame.type === "control_command_result" && frame.requestId === "interactive-fallback-answer",
+				),
+			"interactive fallback answer",
+		);
+		expect(await fallbackAnswer).toBe("Continue");
+		expect(frames.filter(frame => frame.type === "reverse_request")).toHaveLength(1);
+	} finally {
+		await handlers.get("session_shutdown")!({ type: "session_shutdown" }, sessionContext);
+	}
 });
 
 test("rejects malformed provider definitions without replacing a valid tools registry", async () => {

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -2246,6 +2246,89 @@ test("SDK host terminalizes a cancelled preflight and releases prompt authority"
 	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, context(cwd, sessionId));
 });
 
+test("SDK host cancels canonical skill invocation before agent start and fences late acceptance", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-skill-preflight-cancelled-"));
+	dirs.push(cwd);
+	const sessionId = `sdk-skill-preflight-cancelled-${Date.now()}`;
+	const preflightStarted = Promise.withResolvers<void>();
+	const releasePreflight = Promise.withResolvers<void>();
+	let executionStarted = false;
+	const sessionContext = context(cwd, sessionId);
+	const baseBindings = sessionContext.sdkBindings as () => string[];
+	sessionContext.sdkBindings = () => [...baseBindings(), "invokeSkill"];
+	sessionContext.invokeSkill = async (
+		name: string,
+		args: string | undefined,
+		options?: {
+			onSkillPrepared?: (meta: { name: string; path: string }) => void;
+			onPreflightAcceptCommit?: () => void | Promise<void>;
+			preflightSignal?: AbortSignal;
+		},
+	) => {
+		expect(name).toBe("fixture-skill");
+		expect(args).toBe("cancel before start");
+		preflightStarted.resolve();
+		await releasePreflight.promise;
+		options?.onSkillPrepared?.({ name, path: "/fixture/SKILL.md" });
+		await options?.onPreflightAcceptCommit?.();
+		if (options?.preflightSignal?.aborted)
+			throw Object.assign(new Error("Skill preflight was cancelled before execution."), { code: "busy" });
+		executionStarted = true;
+		return { name, path: "/fixture/SKILL.md", args };
+	};
+	const handlers = start(sessionContext);
+	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+	const frames: Record<string, unknown>[] = [];
+	const socket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	sockets.push(socket);
+	socket.addEventListener("message", event => frames.push(JSON.parse(String(event.data))));
+	await new Promise<void>((resolve, reject) => {
+		socket.addEventListener("open", () => resolve(), { once: true });
+		socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+	});
+	socket.send(
+		JSON.stringify({
+			type: "control_request",
+			id: "skill-preflight",
+			operation: "skill.invoke",
+			input: { name: "fixture-skill", args: "cancel before start" },
+		}),
+	);
+	await preflightStarted.promise;
+	socket.send(
+		JSON.stringify({
+			type: "control_request",
+			id: "abort-skill-preflight",
+			operation: "turn.abort",
+			input: {},
+		}),
+	);
+	await waitFor(
+		() =>
+			frames.some(frame => frame.type === "control_response" && frame.id === "skill-preflight") &&
+			frames.some(frame => frame.type === "control_response" && frame.id === "abort-skill-preflight"),
+		"skill preflight cancellation responses",
+	);
+	expect(frames.find(frame => frame.type === "control_response" && frame.id === "skill-preflight")).toMatchObject({
+		ok: false,
+		error: { code: "busy", message: "Skill preflight was cancelled before execution." },
+	});
+	expect(
+		frames.find(frame => frame.type === "control_response" && frame.id === "abort-skill-preflight"),
+	).toMatchObject({
+		ok: true,
+		result: { aborted: true, disposition: "preflight_cancelled" },
+	});
+	releasePreflight.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+	expect(executionStarted).toBe(false);
+	expect(frames.some(frame => frame.type === "agent_start")).toBe(false);
+	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
+});
+
 test("SDK host terminalizes a never-resolving preflight on abort and fences late acceptance", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-prompt-preflight-never-"));
 	dirs.push(cwd);
@@ -3003,20 +3086,10 @@ test("SDK host routes AskUserQuestion through a live ACP form elicitation provid
 test("SDK ACP form elicitation remains preferred after /notify on and falls back on provider disconnect", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-ui-provider-notify-priority-"));
 	dirs.push(cwd);
-	const sessionId = `sdk-ui-provider-notify-priority-${Date.now()}`;
-	const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
-	const messages: Array<{ message: string; level: string }> = [];
-	const sessionContext = {
-		...context(cwd, sessionId),
-		ui: { notify: (message: string, level: string) => messages.push({ message, level }) },
-	};
-	process.env.GJC_NOTIFICATIONS = "0";
-	const handlers = start(sessionContext, undefined, () => {}, false, commands);
+	const host = await startProductionSdkHost(cwd, { notificationsInitiallyEnabled: false });
+	const { sessionId, endpoint } = host;
 	try {
-		const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
-		await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
 		expect(getAskAnswerSource(sessionId)).toBeUndefined();
-		const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
 		const frames: Record<string, unknown>[] = [];
 		const socket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
 		sockets.push(socket);
@@ -3040,9 +3113,14 @@ test("SDK ACP form elicitation remains preferred after /notify on and falls back
 			() => frames.some(frame => frame.type === "register_provider_result" && frame.id === "ui"),
 			"UI provider registration",
 		);
+		const priorNotifications = process.env.GJC_NOTIFICATIONS;
 		process.env.GJC_NOTIFICATIONS = "1";
-		await commands.get("notify")!.handler("on", sessionContext);
-		expect(messages).toEqual([{ message: "Notifications enabled for this session.", level: "info" }]);
+		try {
+			await host.runCommand("/notify on");
+		} finally {
+			if (priorNotifications === undefined) delete process.env.GJC_NOTIFICATIONS;
+			else process.env.GJC_NOTIFICATIONS = priorNotifications;
+		}
 
 		const protocolAnswerSource = getAskAnswerSource(sessionId);
 		expect(protocolAnswerSource).toBeDefined();
@@ -3126,7 +3204,7 @@ test("SDK ACP form elicitation remains preferred after /notify on and falls back
 		expect(await fallbackAnswer).toBe("Continue");
 		expect(frames.filter(frame => frame.type === "reverse_request")).toHaveLength(1);
 	} finally {
-		await handlers.get("session_shutdown")!({ type: "session_shutdown" }, sessionContext);
+		await host.stop();
 	}
 });
 

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -3000,6 +3000,117 @@ test("SDK host routes AskUserQuestion through a live ACP form elicitation provid
 	disposePriorAnswerSource();
 });
 
+test("SDK ACP form elicitation remains preferred after /notify on and falls back on provider disconnect", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-ui-provider-notify-priority-"));
+	dirs.push(cwd);
+	const sessionId = `sdk-ui-provider-notify-priority-${Date.now()}`;
+	const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
+	const messages: Array<{ message: string; level: string }> = [];
+	const sessionContext = {
+		...context(cwd, sessionId),
+		ui: { notify: (message: string, level: string) => messages.push({ message, level }) },
+	};
+	process.env.GJC_NOTIFICATIONS = "0";
+	start(sessionContext, undefined, () => {}, false, commands);
+	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+	expect(getAskAnswerSource(sessionId)).toBeUndefined();
+	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+	const frames: Record<string, unknown>[] = [];
+	const socket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	sockets.push(socket);
+	socket.addEventListener("message", event => frames.push(JSON.parse(String(event.data))));
+	await new Promise<void>((resolve, reject) => {
+		socket.addEventListener("open", () => resolve(), { once: true });
+		socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+	});
+	await waitFor(() => frames.some(frame => frame.type === "hello"), "SDK hello");
+	const connectionId = String(frames.find(frame => frame.type === "hello")?.connectionId);
+	socket.send(
+		JSON.stringify({
+			type: "register_provider",
+			id: "ui",
+			connectionId,
+			capability: "ui",
+			definitions: [],
+		}),
+	);
+	await waitFor(
+		() => frames.some(frame => frame.type === "register_provider_result" && frame.id === "ui"),
+		"UI provider registration",
+	);
+	process.env.GJC_NOTIFICATIONS = "1";
+	await commands.get("notify")!.handler("on", sessionContext);
+	expect(messages).toEqual([{ message: "Notifications enabled for this session.", level: "info" }]);
+
+	const protocolAnswer = getAskAnswerSource(sessionId)!.awaitAnswerRequest!(
+		{ question: "Choose the protocol answer", options: ["First", "Second"], interaction: "selector", controls: [] },
+		new AbortController().signal,
+	);
+	await waitFor(() => frames.some(frame => frame.type === "reverse_request"), "protocol elicitation request");
+	const protocolRequest = frames.find(frame => frame.type === "reverse_request")!;
+	expect(protocolRequest).toMatchObject({
+		payload: {
+			method: "ui.elicit",
+			payload: { mode: "form", message: "Choose the protocol answer" },
+		},
+	});
+	socket.send(
+		JSON.stringify({
+			type: "reverse_response",
+			id: protocolRequest.id,
+			connectionId,
+			leaseId: protocolRequest.leaseId,
+			ok: true,
+			result: { action: "accept", content: { value: "option:1" } },
+		}),
+	);
+	expect(await protocolAnswer).toBe("Second");
+
+	await closeSocket(socket);
+	const fallbackFrames: Record<string, unknown>[] = [];
+	const fallbackSocket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	sockets.push(fallbackSocket);
+	fallbackSocket.addEventListener("message", event => fallbackFrames.push(JSON.parse(String(event.data))));
+	await new Promise<void>((resolve, reject) => {
+		fallbackSocket.addEventListener("open", () => resolve(), { once: true });
+		fallbackSocket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+	});
+	const fallbackAnswer = getAskAnswerSource(sessionId)!.awaitAnswer("Choose the interactive fallback", [
+		"Continue",
+		"Stop",
+	]);
+	await waitFor(
+		() => fallbackFrames.some(frame => frame.type === "action_needed" && frame.kind === "ask"),
+		"interactive fallback presentation",
+	);
+	const fallbackAction = fallbackFrames.find(frame => frame.type === "action_needed" && frame.kind === "ask")!;
+	fallbackSocket.send(
+		JSON.stringify({
+			type: "control_command",
+			sessionId,
+			token: endpoint.token,
+			requestId: "interactive-fallback-answer",
+			command: {
+				type: "control_request",
+				id: "interactive-fallback-answer",
+				operation: "ask.answer",
+				input: { id: fallbackAction.id, answer: 0 },
+				idempotencyKey: "interactive-fallback-answer",
+			},
+		}),
+	);
+	await waitFor(
+		() =>
+			fallbackFrames.some(
+				frame => frame.type === "control_command_result" && frame.requestId === "interactive-fallback-answer",
+			),
+		"interactive fallback answer",
+	);
+	expect(await fallbackAnswer).toBe("Continue");
+	expect(frames.filter(frame => frame.type === "reverse_request")).toHaveLength(1);
+});
+
 test("rejects malformed provider definitions without replacing a valid tools registry", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-provider-validation-"));
 	dirs.push(cwd);

--- a/packages/coding-agent/test/sdk-prompt-terminal-arbiter.test.ts
+++ b/packages/coding-agent/test/sdk-prompt-terminal-arbiter.test.ts
@@ -151,13 +151,51 @@ describe("SDK prompt terminal arbiter", () => {
 		);
 	});
 
-	test("settles restart records with pending prompt outcomes and preserves skill restart failures", () => {
+	test("serializes delayed skill claims before exact normal and cancellation finalization", async () => {
+		for (const outcome of [stopped("end_turn"), stopped("cancelled")]) {
+			const store = new MemoryStore();
+			const reconciliation = createKindAwareReconciliation({ store, now: () => 200 });
+			await reconciliation.noteAccepted("skill", correlation, "skill-ref", { skillName: "deep-interview" });
+			const held = Promise.withResolvers<void>();
+			const claimEntered = Promise.withResolvers<void>();
+			store.holdNext(held.promise, claimEntered.resolve);
+
+			const claim = reconciliation.claimPendingOutcome(correlation, outcome, "skill");
+			await claimEntered.promise;
+			const finalize = reconciliation.finalizePromptOutcome(correlation, undefined, undefined, "skill");
+			held.resolve();
+			await Promise.all([claim, finalize]);
+
+			expect(reconciliation.lookup("skill", correlation)).toMatchObject({
+				status: "terminal_ok",
+				outcome,
+			});
+			expect(store.snapshot()).toMatchObject([
+				{
+					kind: "skill",
+					status: "terminal_ok",
+					outcome,
+					pendingOutcome: undefined,
+				},
+			]);
+		}
+	});
+
+	test("settles restart records with pending prompt and skill outcomes while preserving outcome-less skill failures", () => {
 		const pendingOutcome: SdkPromptTerminalOutcome = stopped("max_tokens");
 		const settled = settleProcessRestart(
 			[
 				{ kind: "prompt", commandId: "pending", turnId: "1", status: "accepted", acceptedAt: 1, pendingOutcome },
 				{ kind: "prompt", commandId: "missing", turnId: "2", status: "in_flight", acceptedAt: 1 },
 				{ kind: "skill", commandId: "skill", turnId: "3", status: "accepted", acceptedAt: 1 },
+				{
+					kind: "skill",
+					commandId: "skill-pending",
+					turnId: "4",
+					status: "in_flight",
+					acceptedAt: 1,
+					pendingOutcome: stopped("cancelled"),
+				},
 			],
 			500,
 		);
@@ -170,5 +208,10 @@ describe("SDK prompt terminal arbiter", () => {
 			error: { code: "prompt_failed" },
 		});
 		expect(settled[2]).toMatchObject({ status: "failed", error: { code: "process_restart" } });
+		expect(settled[3]).toMatchObject({
+			status: "terminal_ok",
+			outcome: stopped("cancelled"),
+			pendingOutcome: undefined,
+		});
 	});
 });

--- a/packages/coding-agent/test/sdk-reconciliation-store.test.ts
+++ b/packages/coding-agent/test/sdk-reconciliation-store.test.ts
@@ -101,6 +101,58 @@ describe("reconciliation-store", () => {
 		await fs.rm(root, { recursive: true, force: true });
 	});
 
+	test("reload preserves a skill pending claim without quarantining sibling records", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "recon-skill-pending-"));
+		try {
+			const sessionFile = path.join(root, "sess.jsonl");
+			await fs.writeFile(sessionFile, "");
+			const store = createReconciliationStore({ sessionFile, sessionId: "skill-session", now: () => 5_000 });
+			await store.transact(() => [
+				{
+					kind: "skill",
+					commandId: "skill-command",
+					turnId: "skill-turn",
+					status: "in_flight",
+					acceptedAt: 1_000,
+					startedAt: 2_000,
+					skillName: "deep-interview",
+					pendingOutcome: { kind: "stopped", reason: "cancelled", provenance: "client_cancel" },
+				},
+				{
+					kind: "prompt",
+					commandId: "completed-command",
+					turnId: "completed-turn",
+					status: "terminal_ok",
+					acceptedAt: 1_000,
+					terminalAt: 3_000,
+					outcome: { kind: "stopped", reason: "end_turn", provenance: "agent" },
+				},
+			]);
+
+			const reopened = createReconciliationStore({ sessionFile, sessionId: "skill-session", now: () => 9_000 });
+			expect(await reopened.load()).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						kind: "skill",
+						status: "terminal_ok",
+						terminalAt: 9_000,
+						outcome: { kind: "stopped", reason: "cancelled", provenance: "client_cancel" },
+						pendingOutcome: undefined,
+					}),
+					expect.objectContaining({
+						kind: "prompt",
+						commandId: "completed-command",
+						status: "terminal_ok",
+					}),
+				]),
+			);
+			const entries = await fs.readdir(path.dirname(store.path!));
+			expect(entries.some(name => name.includes("corrupt"))).toBe(false);
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
+
 	test("corrupt file quarantines and returns empty", async () => {
 		const root = await fs.mkdtemp(path.join(os.tmpdir(), "recon-corrupt-"));
 		const sessionFile = path.join(root, "s.jsonl");


### PR DESCRIPTION
## What

This PR fixes the real OpenCode → GJC ACP → `deep-interview` choice flow end to end:

- protocol answer providers outrank later interactive notification providers while preserving the legacy two-argument registration API and fallback disposal behavior;
- exact single-text `/skill:*` ACP prompts route through canonical `skill.invoke`;
- requester-owned skill invocations use correlated prompt completion as their sole durable terminal authority;
- active and preflight cancellation are fenced so late acceptance cannot start unowned work;
- skill pending outcomes survive delayed store writes and process restart without quarantine or outcome loss;
- headless lifecycle hosts initialize the shared theme before calculating the remaining MCP readiness budget.

## Why

OpenCode can control GJC over ACP and invoke `deep-interview`, but the concrete path previously failed before form elicitation because the headless lifecycle host had no initialized theme. The original registry fix also depended on registration order, and canonical skill invocation lacked exact requester-owned completion/cancellation semantics. Together those defects could prevent the structured choice from reaching OpenCode or leave the ACP request with ambiguous terminal ownership.

## Production proof

`packages/coding-agent/test/acp-deep-interview-wire.test.ts` uses the official ACP SDK against a real GJC subprocess. It advertises `elicitation.form`, invokes `deep-interview`, selects `option:0`, verifies the selected choice reaches the continuation, and covers normal completion plus active cancellation.

The production-path and host tests additionally cover:

- exact canonical command parsing and malformed/multi-block fallback to normal prompts;
- correlated completion and preflight cancellation with late-release fencing;
- legitimate local `/notify on` activation after protocol-provider registration and interactive fallback after provider removal;
- delayed durable normal/cancel outcomes, restart settlement, and no corrupt quarantine;
- lifecycle option forwarding, theme startup ordering, and MCP budget accounting.

## Exact-head verification

Head: `7b9fac9012c98525fdc73cd10d0d50145294a6d4`  
Base: `dev@6c1c8a4798917be42071af02ab3c005ca71817c3`

- coding-agent TypeScript check: passed
- `bun run check:tools`: passed; Biome checked 3338 files
- reconciliation suites: 19 pass, 0 fail, 69 assertions
- ACP/provider suites: 59 pass, 0 fail, 237 assertions
- full `sdk-host-wiring.test.ts`: 80 pass, 0 fail, 434 assertions
- OpenCode 1.18.13 dogfood of the real wire + production path: 4 pass, 0 fail, 106 assertions
- independent frozen-head architect review: `CLEAR/CLEAR/CLEAR`, `APPROVE`
- independent frozen-head QA/red-team: passed, no blockers
- terminal critic: `OKAY`, no blockers

GitHub Actions for fork commits may remain `action_required` until a maintainer approves them; no workflow was manually rerun or cancelled.

## Scope note

PR #3241's separate form-elicitation `frameTail` timeout finding is unchanged and remains out of scope. This PR fixes invocation routing, answer-source authority, startup, cancellation, and durable terminal ownership without claiming to solve that independent timeout policy.
