### PR TITLE
fix(session): remove Darwin replacement predecessors

### DIFF
--- a/crates/pi-natives/src/path_identity.rs
+++ b/crates/pi-natives/src/path_identity.rs
@@ -987,7 +987,7 @@ pub fn open_darwin_replacement_auth(
 	{
 		let handle = platform::open_darwin_replacement_auth(Path::new(&parent_path), &lock_name)
 			.map_err(napi::Error::from_reason)?;
-		return Ok(DarwinReplacementAuth { inner: Mutex::new(Some(handle)) });
+		Ok(DarwinReplacementAuth { inner: Mutex::new(Some(handle)) })
 	}
 	#[cfg(not(target_os = "macos"))]
 	{
@@ -1042,7 +1042,7 @@ pub fn exchange_darwin_managed_file(
 				operation_id,
 			};
 		};
-		return platform::exchange_darwin_managed_file(
+		platform::exchange_darwin_managed_file(
 			handle,
 			Path::new(&parent_path),
 			parent_dev,
@@ -1052,7 +1052,7 @@ pub fn exchange_darwin_managed_file(
 			&expected_source,
 			&expected_destination,
 			&operation_id,
-		);
+		)
 	}
 	#[cfg(not(target_os = "macos"))]
 	{
@@ -4997,7 +4997,7 @@ pub(crate) mod platform {
 		}
 		NativeDarwinReplacementIdentity {
 			dev: BigInt::from(stat.st_dev as u64),
-			ino: BigInt::from(stat.st_ino as u64),
+			ino: BigInt::from(stat.st_ino),
 			nlink: BigInt::from(stat.st_nlink as u64),
 			size: BigInt::from(stat.st_size as u64),
 			mtime_ns: BigInt::from(stat_mtime_ns(stat) as i64),
@@ -5045,21 +5045,24 @@ pub(crate) mod platform {
 		if parent.st_dev as u64 != handle.parent_dev || parent.st_ino as u64 != handle.parent_ino {
 			return Err("identity_mismatch");
 		}
+		// SAFETY: zero is valid initialized storage for the `fstatat` output.
 		let mut lock: libc::stat = unsafe { std::mem::zeroed() };
-		// SAFETY: parent_fd, lock name, and output storage are valid.
 		let lock_name =
 			CString::new("darwin-replacement-admission.lock").map_err(|_| "invalid_request")?;
+		// SAFETY: parent_fd, lock name, and output storage are valid.
 		if unsafe {
 			libc::fstatat(handle.parent_fd, lock_name.as_ptr(), &mut lock, libc::AT_SYMLINK_NOFOLLOW)
 		} != 0
 		{
 			return Err("migration_busy");
 		}
+		// SAFETY: querying the effective user ID has no preconditions.
+		let effective_uid = unsafe { libc::geteuid() };
 		if lock.st_dev as u64 != handle.lock_dev
 			|| lock.st_ino as u64 != handle.lock_ino
 			|| lock.st_mode & libc::S_IFMT != libc::S_IFREG
 			|| lock.st_nlink != 1
-			|| lock.st_uid != unsafe { libc::geteuid() }
+			|| lock.st_uid != effective_uid
 			|| lock.st_mode & 0o077 != 0
 		{
 			return Err("migration_busy");
@@ -5082,7 +5085,9 @@ pub(crate) mod platform {
 		}
 		let requested_name = darwin_component(lock_name)?;
 		let (parent_fd, parent) = darwin_parent_fd(parent_path)?;
+		// SAFETY: zero is valid initialized storage for the `fstatat` output.
 		let mut lock_before: libc::stat = unsafe { std::mem::zeroed() };
+		// SAFETY: parent_fd, requested name, and output storage are valid.
 		let existed = unsafe {
 			libc::fstatat(
 				parent_fd,
@@ -5091,6 +5096,7 @@ pub(crate) mod platform {
 				libc::AT_SYMLINK_NOFOLLOW,
 			)
 		} == 0;
+		// SAFETY: parent_fd is live and the component name remains valid for the call.
 		let lock_fd = unsafe {
 			libc::openat(
 				parent_fd,
@@ -5100,16 +5106,21 @@ pub(crate) mod platform {
 			)
 		};
 		if lock_fd < 0 {
+			// SAFETY: this branch owns the live parent descriptor exactly once.
 			unsafe { libc::close(parent_fd) };
 			return Err(security_code(&std::io::Error::last_os_error()));
 		}
-		let mut lock = unsafe { std::mem::zeroed() };
+		// SAFETY: zero is valid initialized storage for the `fstat` output.
+		let mut lock: libc::stat = unsafe { std::mem::zeroed() };
+		// SAFETY: lock_fd and output storage are valid.
 		let valid = unsafe { libc::fstat(lock_fd, &mut lock) } == 0
 			&& lock.st_mode & libc::S_IFMT == libc::S_IFREG
-			&& lock.st_nlink == 1
-			&& lock.st_uid == unsafe { libc::geteuid() }
-			&& lock.st_mode & 0o077 == 0;
+			&& lock.st_nlink == 1;
+		// SAFETY: querying the effective user ID has no preconditions.
+		let effective_uid = unsafe { libc::geteuid() };
+		let valid = valid && lock.st_uid == effective_uid && lock.st_mode & 0o077 == 0;
 		if !valid {
+			// SAFETY: this branch owns both live descriptors exactly once.
 			unsafe {
 				libc::close(lock_fd);
 				libc::close(parent_fd);
@@ -5120,17 +5131,20 @@ pub(crate) mod platform {
 		// lock.
 		if unsafe { flock(lock_fd, libc::LOCK_EX | libc::LOCK_NB) } != 0 {
 			let code = std::io::Error::last_os_error().raw_os_error();
+			// SAFETY: this branch owns both live descriptors exactly once.
 			unsafe {
 				libc::close(lock_fd);
 				libc::close(parent_fd);
 			}
 			return Err(match code {
 				Some(libc::EAGAIN) => "migration_busy",
-				Some(libc::EACCES) | Some(libc::EPERM) => "permission_denied",
+				Some(libc::EACCES | libc::EPERM) => "permission_denied",
 				_ => "io_error",
 			});
 		}
+		// SAFETY: the live parent descriptor binds the newly created lock entry.
 		if !existed && unsafe { libc::fsync(parent_fd) } != 0 {
+			// SAFETY: this branch owns both live descriptors exactly once.
 			unsafe {
 				libc::close(lock_fd);
 				libc::close(parent_fd);
@@ -5141,7 +5155,7 @@ pub(crate) mod platform {
 			lock_fd,
 			parent_fd,
 			parent_dev: parent.st_dev as u64,
-			parent_ino: parent.st_ino as u64,
+			parent_ino: parent.st_ino,
 			lock_dev: lock.st_dev as u64,
 			lock_ino: lock.st_ino as u64,
 		};
@@ -5156,15 +5170,19 @@ pub(crate) mod platform {
 		expected: &DarwinExpectedIdentity,
 		verify_timestamps: bool,
 	) -> Result<(libc::stat, [u8; 32]), &'static str> {
+		// SAFETY: zero is valid initialized storage for the `fstatat` output.
 		let mut stat: libc::stat = unsafe { std::mem::zeroed() };
+		// SAFETY: parent_fd, component name, and output storage are valid.
 		if unsafe { libc::fstatat(parent_fd, name.as_ptr(), &mut stat, libc::AT_SYMLINK_NOFOLLOW) }
 			!= 0
 		{
 			return Err(security_code(&std::io::Error::last_os_error()));
 		}
+		// SAFETY: querying the effective user ID has no preconditions.
+		let effective_uid = unsafe { libc::geteuid() };
 		if stat.st_mode & libc::S_IFMT != libc::S_IFREG
 			|| stat.st_nlink != 1
-			|| stat.st_uid != unsafe { libc::geteuid() }
+			|| stat.st_uid != effective_uid
 			|| stat.st_mode & 0o077 != 0
 			|| stat.st_dev as u64 != expected.dev
 			|| stat.st_ino as u64 != expected.ino
@@ -5184,7 +5202,7 @@ pub(crate) mod platform {
 	}
 
 	#[cfg(target_os = "macos")]
-	fn darwin_exchange_error(error: i32) -> &'static str {
+	const fn darwin_exchange_error(error: i32) -> &'static str {
 		match error {
 			libc::ENOSYS | libc::EINVAL | libc::ENOTSUP | libc::EOPNOTSUPP => "atomic_unavailable",
 			libc::EACCES | libc::EPERM => "permission_denied",
@@ -5306,7 +5324,8 @@ pub(crate) mod platform {
 				);
 			},
 		};
-		if parent.st_dev as u64 != parent_dev || parent.st_ino as u64 != parent_ino {
+		if parent.st_dev as u64 != parent_dev || parent.st_ino != parent_ino {
+			// SAFETY: this branch owns the live parent descriptor exactly once.
 			unsafe { libc::close(parent_fd) };
 			return darwin_result(
 				false,
@@ -5323,6 +5342,7 @@ pub(crate) mod platform {
 		let before_source = match darwin_named_identity(parent_fd, &source_name, &source, true) {
 			Ok(value) => value,
 			Err(code) => {
+				// SAFETY: this error branch owns the live parent descriptor exactly once.
 				unsafe { libc::close(parent_fd) };
 				return darwin_result(
 					false,
@@ -5341,6 +5361,7 @@ pub(crate) mod platform {
 			match darwin_named_identity(parent_fd, &destination_name, &destination, true) {
 				Ok(value) => value,
 				Err(code) => {
+					// SAFETY: this error branch owns the live parent descriptor exactly once.
 					unsafe { libc::close(parent_fd) };
 					return darwin_result(
 						false,
@@ -5356,6 +5377,7 @@ pub(crate) mod platform {
 				},
 			};
 		if source.dev == destination.dev && source.ino == destination.ino {
+			// SAFETY: this branch owns the live parent descriptor exactly once.
 			unsafe { libc::close(parent_fd) };
 			return darwin_result(
 				false,
@@ -5398,6 +5420,7 @@ pub(crate) mod platform {
 				} else {
 					"committed_unproven"
 				};
+			// SAFETY: this error branch owns the live parent descriptor exactly once.
 			unsafe { libc::close(parent_fd) };
 			return darwin_result(
 				false,
@@ -5413,22 +5436,20 @@ pub(crate) mod platform {
 		}
 		let after_destination = darwin_named_identity(parent_fd, &destination_name, &source, false);
 		let after_source = darwin_named_identity(parent_fd, &source_name, &destination, false);
-		let (after_source, after_destination) = match (after_source, after_destination) {
-			(Ok(source), Ok(destination)) => (source, destination),
-			_ => {
-				unsafe { libc::close(parent_fd) };
-				return darwin_result(
-					false,
-					"committed_unproven",
-					Some("identity_mismatch"),
-					"post_exchange",
-					"identity_proof_failed",
-					false,
-					None,
-					None,
-					operation_id,
-				);
-			},
+		let (Ok(after_source), Ok(after_destination)) = (after_source, after_destination) else {
+			// SAFETY: this error branch owns the live parent descriptor exactly once.
+			unsafe { libc::close(parent_fd) };
+			return darwin_result(
+				false,
+				"committed_unproven",
+				Some("identity_mismatch"),
+				"post_exchange",
+				"identity_proof_failed",
+				false,
+				None,
+				None,
+				operation_id,
+			);
 		};
 		// SAFETY: the verified parent descriptor and component-bound predecessor name
 		// remain live under the held Darwin replacement admission.

--- a/crates/pi-natives/src/path_identity.rs
+++ b/crates/pi-natives/src/path_identity.rs
@@ -197,19 +197,19 @@ pub struct NativeDarwinReplacementIdentity {
 /// Closed result returned by the Darwin descriptor-bound replacement exchange.
 #[napi(object)]
 pub struct NativeDarwinReplacementResult {
-	pub ok:             bool,
-	pub state:          String,
-	pub code:           Option<String>,
-	pub phase:          String,
-	pub reason:         String,
-	pub parent_fsync:   bool,
-	pub source:         Option<NativeDarwinReplacementIdentity>,
-	pub destination:    Option<NativeDarwinReplacementIdentity>,
-	pub operation_id:   String,
+	pub ok:           bool,
+	pub state:        String,
+	pub code:         Option<String>,
+	pub phase:        String,
+	pub reason:       String,
+	pub parent_fsync: bool,
+	pub source:       Option<NativeDarwinReplacementIdentity>,
+	pub destination:  Option<NativeDarwinReplacementIdentity>,
+	pub operation_id: String,
 }
 
-/// Darwin-only persistent kernel replacement admission. The descriptor is opaque
-/// to JavaScript and remains held until `close` or process teardown.
+/// Darwin-only persistent kernel replacement admission. The descriptor is
+/// opaque to JavaScript and remains held until `close` or process teardown.
 #[napi]
 pub struct DarwinReplacementAuth {
 	#[cfg(target_os = "macos")]
@@ -1014,7 +1014,8 @@ pub fn exchange_darwin_managed_file(
 	{
 		let (parent_dev_negative, parent_dev, parent_dev_lossless) = parent_dev.get_u64();
 		let (parent_ino_negative, parent_ino, parent_ino_lossless) = parent_ino.get_u64();
-		if parent_dev_negative || parent_ino_negative || !parent_dev_lossless || !parent_ino_lossless {
+		if parent_dev_negative || parent_ino_negative || !parent_dev_lossless || !parent_ino_lossless
+		{
 			return NativeDarwinReplacementResult {
 				ok: false,
 				state: "not_committed".to_owned(),
@@ -1401,7 +1402,6 @@ pub(crate) mod platform {
 	use std::os::unix::fs::MetadataExt;
 	#[cfg(test)]
 	use std::sync::{Mutex, OnceLock, mpsc};
-	use napi::bindgen_prelude::BigInt;
 	use std::{
 		borrow::Cow,
 		ffi::CString,
@@ -1413,6 +1413,8 @@ pub(crate) mod platform {
 		},
 		path::{Component, Path},
 	};
+
+	use napi::bindgen_prelude::BigInt;
 
 	use super::{
 		ExactFileIdentity, NativeCanonicalDirectoryIdentity, NativeDarwinReplacementIdentity,
@@ -4875,12 +4877,12 @@ pub(crate) mod platform {
 	}
 	#[cfg(target_os = "macos")]
 	pub(super) struct DarwinReplacementAuthHandle {
-		lock_fd: libc::c_int,
-		parent_fd: libc::c_int,
+		lock_fd:    libc::c_int,
+		parent_fd:  libc::c_int,
 		parent_dev: u64,
 		parent_ino: u64,
-		lock_dev: u64,
-		lock_ino: u64,
+		lock_dev:   u64,
+		lock_ino:   u64,
 	}
 
 	#[cfg(target_os = "macos")]
@@ -4901,7 +4903,12 @@ pub(crate) mod platform {
 
 	#[cfg(target_os = "macos")]
 	fn darwin_component(value: &str) -> Result<CString, &'static str> {
-		if value.is_empty() || value == "." || value == ".." || value.contains('/') || value.contains('\\') {
+		if value.is_empty()
+			|| value == "."
+			|| value == ".."
+			|| value.contains('/')
+			|| value.contains('\\')
+		{
 			return Err("invalid_request");
 		}
 		CString::new(value.as_bytes()).map_err(|_| "invalid_request")
@@ -4909,14 +4916,15 @@ pub(crate) mod platform {
 
 	#[cfg(target_os = "macos")]
 	fn darwin_parent_fd(path: &Path) -> Result<(libc::c_int, libc::stat), &'static str> {
-		let authority = checked_file(path, "directory").map_err(|result| match result.code.as_deref() {
-			Some("reparse_point") => "reparse_point",
-			Some("not_directory") => "not_directory",
-			Some("owner_mismatch") => "owner_mismatch",
-			Some("mode_mismatch") => "mode_mismatch",
-			Some("acl_verify_failed") => "acl_verify_failed",
-			_ => "io_error",
-		})?;
+		let authority =
+			checked_file(path, "directory").map_err(|result| match result.code.as_deref() {
+				Some("reparse_point") => "reparse_point",
+				Some("not_directory") => "not_directory",
+				Some("owner_mismatch") => "owner_mismatch",
+				Some("mode_mismatch") => "mode_mismatch",
+				Some("acl_verify_failed") => "acl_verify_failed",
+				_ => "io_error",
+			})?;
 		let security = verify_authority(&authority, "directory");
 		if !security.ok {
 			return Err(match security.code.as_deref() {
@@ -4969,17 +4977,20 @@ pub(crate) mod platform {
 	#[cfg(target_os = "macos")]
 	#[derive(Clone, Copy)]
 	struct DarwinExpectedIdentity {
-		dev: u64,
-		ino: u64,
-		nlink: u64,
-		size: u64,
+		dev:      u64,
+		ino:      u64,
+		nlink:    u64,
+		size:     u64,
 		mtime_ns: i64,
 		ctime_ns: i64,
-		digest: [u8; 32],
+		digest:   [u8; 32],
 	}
 
 	#[cfg(target_os = "macos")]
-	fn darwin_identity_value(stat: &libc::stat, digest: [u8; 32]) -> NativeDarwinReplacementIdentity {
+	fn darwin_identity_value(
+		stat: &libc::stat,
+		digest: [u8; 32],
+	) -> NativeDarwinReplacementIdentity {
 		let mut sha256 = String::with_capacity(64);
 		for byte in digest {
 			let _ = write!(sha256, "{byte:02x}");
@@ -5036,8 +5047,12 @@ pub(crate) mod platform {
 		}
 		let mut lock: libc::stat = unsafe { std::mem::zeroed() };
 		// SAFETY: parent_fd, lock name, and output storage are valid.
-		let lock_name = CString::new("darwin-replacement-admission.lock").map_err(|_| "invalid_request")?;
-		if unsafe { libc::fstatat(handle.parent_fd, lock_name.as_ptr(), &mut lock, libc::AT_SYMLINK_NOFOLLOW) } != 0 {
+		let lock_name =
+			CString::new("darwin-replacement-admission.lock").map_err(|_| "invalid_request")?;
+		if unsafe {
+			libc::fstatat(handle.parent_fd, lock_name.as_ptr(), &mut lock, libc::AT_SYMLINK_NOFOLLOW)
+		} != 0
+		{
 			return Err("migration_busy");
 		}
 		if lock.st_dev as u64 != handle.lock_dev
@@ -5049,8 +5064,8 @@ pub(crate) mod platform {
 		{
 			return Err("migration_busy");
 		}
-		// SAFETY: flock only inspects/reacquires the live descriptor and does not mutate
-		// the namespace.
+		// SAFETY: flock only inspects/reacquires the live descriptor and does not
+		// mutate the namespace.
 		if unsafe { flock(handle.lock_fd, libc::LOCK_EX | libc::LOCK_NB) } != 0 {
 			return Err("migration_busy");
 		}
@@ -5069,7 +5084,12 @@ pub(crate) mod platform {
 		let (parent_fd, parent) = darwin_parent_fd(parent_path)?;
 		let mut lock_before: libc::stat = unsafe { std::mem::zeroed() };
 		let existed = unsafe {
-			libc::fstatat(parent_fd, requested_name.as_ptr(), &mut lock_before, libc::AT_SYMLINK_NOFOLLOW)
+			libc::fstatat(
+				parent_fd,
+				requested_name.as_ptr(),
+				&mut lock_before,
+				libc::AT_SYMLINK_NOFOLLOW,
+			)
 		} == 0;
 		let lock_fd = unsafe {
 			libc::openat(
@@ -5096,7 +5116,8 @@ pub(crate) mod platform {
 			}
 			return Err("identity_mismatch");
 		}
-		// SAFETY: flock is called on the owned descriptor with a nonblocking exclusive lock.
+		// SAFETY: flock is called on the owned descriptor with a nonblocking exclusive
+		// lock.
 		if unsafe { flock(lock_fd, libc::LOCK_EX | libc::LOCK_NB) } != 0 {
 			let code = std::io::Error::last_os_error().raw_os_error();
 			unsafe {
@@ -5136,7 +5157,9 @@ pub(crate) mod platform {
 		verify_timestamps: bool,
 	) -> Result<(libc::stat, [u8; 32]), &'static str> {
 		let mut stat: libc::stat = unsafe { std::mem::zeroed() };
-		if unsafe { libc::fstatat(parent_fd, name.as_ptr(), &mut stat, libc::AT_SYMLINK_NOFOLLOW) } != 0 {
+		if unsafe { libc::fstatat(parent_fd, name.as_ptr(), &mut stat, libc::AT_SYMLINK_NOFOLLOW) }
+			!= 0
+		{
 			return Err(security_code(&std::io::Error::last_os_error()));
 		}
 		if stat.st_mode & libc::S_IFMT != libc::S_IFREG
@@ -5184,50 +5207,167 @@ pub(crate) mod platform {
 		operation_id: &str,
 	) -> NativeDarwinReplacementResult {
 		let Some(source) = darwin_identity_parts(expected_source) else {
-			return darwin_result(false, "not_committed", Some("identity_mismatch"), "preflight", "invalid_source_identity", false, None, None, operation_id);
+			return darwin_result(
+				false,
+				"not_committed",
+				Some("identity_mismatch"),
+				"preflight",
+				"invalid_source_identity",
+				false,
+				None,
+				None,
+				operation_id,
+			);
 		};
 		let Some(destination) = darwin_identity_parts(expected_destination) else {
-			return darwin_result(false, "not_committed", Some("identity_mismatch"), "preflight", "invalid_destination_identity", false, None, None, operation_id);
+			return darwin_result(
+				false,
+				"not_committed",
+				Some("identity_mismatch"),
+				"preflight",
+				"invalid_destination_identity",
+				false,
+				None,
+				None,
+				operation_id,
+			);
 		};
 		if source_name == destination_name {
-			return darwin_result(false, "not_committed", Some("invalid_request"), "preflight", "names_equal", false, None, None, operation_id);
+			return darwin_result(
+				false,
+				"not_committed",
+				Some("invalid_request"),
+				"preflight",
+				"names_equal",
+				false,
+				None,
+				None,
+				operation_id,
+			);
 		}
 		let source_name = match darwin_component(source_name) {
 			Ok(name) => name,
-			Err(code) => return darwin_result(false, "not_committed", Some(code), "preflight", "invalid_source_name", false, None, None, operation_id),
+			Err(code) => {
+				return darwin_result(
+					false,
+					"not_committed",
+					Some(code),
+					"preflight",
+					"invalid_source_name",
+					false,
+					None,
+					None,
+					operation_id,
+				);
+			},
 		};
 		let destination_name = match darwin_component(destination_name) {
 			Ok(name) => name,
-			Err(code) => return darwin_result(false, "not_committed", Some(code), "preflight", "invalid_destination_name", false, None, None, operation_id),
+			Err(code) => {
+				return darwin_result(
+					false,
+					"not_committed",
+					Some(code),
+					"preflight",
+					"invalid_destination_name",
+					false,
+					None,
+					None,
+					operation_id,
+				);
+			},
 		};
 		if let Err(code) = darwin_revalidate_auth(handle) {
-			return darwin_result(false, "not_committed", Some(code), "preflight", "authorization_unavailable", false, None, None, operation_id);
+			return darwin_result(
+				false,
+				"not_committed",
+				Some(code),
+				"preflight",
+				"authorization_unavailable",
+				false,
+				None,
+				None,
+				operation_id,
+			);
 		}
 		let (parent_fd, parent) = match darwin_parent_fd(parent_path) {
 			Ok(value) => value,
-			Err(code) => return darwin_result(false, "not_committed", Some(code), "preflight", "parent_unavailable", false, None, None, operation_id),
+			Err(code) => {
+				return darwin_result(
+					false,
+					"not_committed",
+					Some(code),
+					"preflight",
+					"parent_unavailable",
+					false,
+					None,
+					None,
+					operation_id,
+				);
+			},
 		};
 		if parent.st_dev as u64 != parent_dev || parent.st_ino as u64 != parent_ino {
 			unsafe { libc::close(parent_fd) };
-			return darwin_result(false, "not_committed", Some("parent_mismatch"), "preflight", "parent_identity", false, None, None, operation_id);
+			return darwin_result(
+				false,
+				"not_committed",
+				Some("parent_mismatch"),
+				"preflight",
+				"parent_identity",
+				false,
+				None,
+				None,
+				operation_id,
+			);
 		}
 		let before_source = match darwin_named_identity(parent_fd, &source_name, &source, true) {
 			Ok(value) => value,
 			Err(code) => {
 				unsafe { libc::close(parent_fd) };
-				return darwin_result(false, "not_committed", Some(code), "preflight", "source_identity", false, None, None, operation_id);
+				return darwin_result(
+					false,
+					"not_committed",
+					Some(code),
+					"preflight",
+					"source_identity",
+					false,
+					None,
+					None,
+					operation_id,
+				);
 			},
 		};
-		let before_destination = match darwin_named_identity(parent_fd, &destination_name, &destination, true) {
-			Ok(value) => value,
-			Err(code) => {
-				unsafe { libc::close(parent_fd) };
-				return darwin_result(false, "not_committed", Some(code), "preflight", "destination_identity", true, Some((&before_source.0, before_source.1)), None, operation_id);
-			},
-		};
+		let before_destination =
+			match darwin_named_identity(parent_fd, &destination_name, &destination, true) {
+				Ok(value) => value,
+				Err(code) => {
+					unsafe { libc::close(parent_fd) };
+					return darwin_result(
+						false,
+						"not_committed",
+						Some(code),
+						"preflight",
+						"destination_identity",
+						true,
+						Some((&before_source.0, before_source.1)),
+						None,
+						operation_id,
+					);
+				},
+			};
 		if source.dev == destination.dev && source.ino == destination.ino {
 			unsafe { libc::close(parent_fd) };
-			return darwin_result(false, "not_committed", Some("identity_mismatch"), "preflight", "same_object", true, Some((&before_source.0, before_source.1)), Some((&before_destination.0, before_destination.1)), operation_id);
+			return darwin_result(
+				false,
+				"not_committed",
+				Some("identity_mismatch"),
+				"preflight",
+				"same_object",
+				true,
+				Some((&before_source.0, before_source.1)),
+				Some((&before_destination.0, before_destination.1)),
+				operation_id,
+			);
 		}
 		const RENAME_SWAP: u32 = 0x0000_0002;
 		const RENAME_NOFOLLOW_ANY: u32 = 0x0000_0010;
@@ -5243,13 +5383,33 @@ pub(crate) mod platform {
 		};
 		if swapped != 0 {
 			let code = std::io::Error::last_os_error().raw_os_error();
-			let state = if matches!(code, Some(libc::ENOSYS | libc::EINVAL | libc::ENOTSUP | libc::EOPNOTSUPP | libc::EACCES | libc::EPERM | libc::EXDEV)) {
-				"not_committed"
-			} else {
-				"committed_unproven"
-			};
+			let state =
+				if matches!(
+					code,
+					Some(
+						libc::ENOSYS
+							| libc::EINVAL | libc::ENOTSUP
+							| libc::EOPNOTSUPP
+							| libc::EACCES | libc::EPERM
+							| libc::EXDEV
+					)
+				) {
+					"not_committed"
+				} else {
+					"committed_unproven"
+				};
 			unsafe { libc::close(parent_fd) };
-			return darwin_result(false, state, Some(darwin_exchange_error(code.unwrap_or(libc::EIO)),), "exchange", "renameatx_np_failed", false, Some((&before_source.0, before_source.1)), Some((&before_destination.0, before_destination.1)), operation_id);
+			return darwin_result(
+				false,
+				state,
+				Some(darwin_exchange_error(code.unwrap_or(libc::EIO))),
+				"exchange",
+				"renameatx_np_failed",
+				false,
+				Some((&before_source.0, before_source.1)),
+				Some((&before_destination.0, before_destination.1)),
+				operation_id,
+			);
 		}
 		let after_destination = darwin_named_identity(parent_fd, &destination_name, &source, false);
 		let after_source = darwin_named_identity(parent_fd, &source_name, &destination, false);
@@ -5257,15 +5417,45 @@ pub(crate) mod platform {
 			(Ok(source), Ok(destination)) => (source, destination),
 			_ => {
 				unsafe { libc::close(parent_fd) };
-				return darwin_result(false, "committed_unproven", Some("identity_mismatch"), "post_exchange", "identity_proof_failed", false, None, None, operation_id);
+				return darwin_result(
+					false,
+					"committed_unproven",
+					Some("identity_mismatch"),
+					"post_exchange",
+					"identity_proof_failed",
+					false,
+					None,
+					None,
+					operation_id,
+				);
 			},
 		};
 		let synced = unsafe { libc::fsync(parent_fd) } == 0;
 		unsafe { libc::close(parent_fd) };
 		if !synced {
-			return darwin_result(false, "committed_unproven", Some("durability_failed"), "parent_fsync", "parent_fsync_failed", false, Some((&after_source.0, after_source.1)), Some((&after_destination.0, after_destination.1)), operation_id);
+			return darwin_result(
+				false,
+				"committed_unproven",
+				Some("durability_failed"),
+				"parent_fsync",
+				"parent_fsync_failed",
+				false,
+				Some((&after_source.0, after_source.1)),
+				Some((&after_destination.0, after_destination.1)),
+				operation_id,
+			);
 		}
-		darwin_result(true, "committed_durable", None, "complete", "none", true, Some((&after_source.0, after_source.1)), Some((&after_destination.0, after_destination.1)), operation_id)
+		darwin_result(
+			true,
+			"committed_durable",
+			None,
+			"complete",
+			"none",
+			true,
+			Some((&after_source.0, after_source.1)),
+			Some((&after_destination.0, after_destination.1)),
+			operation_id,
+		)
 	}
 }
 

--- a/crates/pi-natives/src/path_identity.rs
+++ b/crates/pi-natives/src/path_identity.rs
@@ -182,6 +182,72 @@ pub struct NativeExactUnlinkResult {
 	/// neither a stale detached object nor a publisher successor.
 	pub retained_unknown_path: Option<String>,
 }
+/// Full regular-file identity used by the Darwin managed replacement exchange.
+#[napi(object)]
+pub struct NativeDarwinReplacementIdentity {
+	pub dev:      BigInt,
+	pub ino:      BigInt,
+	pub nlink:    BigInt,
+	pub size:     BigInt,
+	pub mtime_ns: BigInt,
+	pub ctime_ns: BigInt,
+	pub sha256:   String,
+}
+
+/// Closed result returned by the Darwin descriptor-bound replacement exchange.
+#[napi(object)]
+pub struct NativeDarwinReplacementResult {
+	pub ok:             bool,
+	pub state:          String,
+	pub code:           Option<String>,
+	pub phase:          String,
+	pub reason:         String,
+	pub parent_fsync:   bool,
+	pub source:         Option<NativeDarwinReplacementIdentity>,
+	pub destination:    Option<NativeDarwinReplacementIdentity>,
+	pub operation_id:   String,
+}
+
+/// Darwin-only persistent kernel replacement admission. The descriptor is opaque
+/// to JavaScript and remains held until `close` or process teardown.
+#[napi]
+pub struct DarwinReplacementAuth {
+	#[cfg(target_os = "macos")]
+	inner: Mutex<Option<platform::DarwinReplacementAuthHandle>>,
+	#[cfg(not(target_os = "macos"))]
+	inner: Mutex<Option<()>>,
+}
+#[napi]
+impl DarwinReplacementAuth {
+	#[napi]
+	pub fn close(&self) {
+		#[cfg(target_os = "macos")]
+		{
+			self.inner.lock().take();
+		}
+		#[cfg(not(target_os = "macos"))]
+		{
+			self.inner.lock().take();
+		}
+	}
+
+	#[napi]
+	pub fn is_held(&self) -> bool {
+		#[cfg(target_os = "macos")]
+		{
+			self.inner.lock().is_some()
+		}
+		#[cfg(not(target_os = "macos"))]
+		{
+			false
+		}
+	}
+}
+impl Drop for DarwinReplacementAuth {
+	fn drop(&mut self) {
+		self.close();
+	}
+}
 
 /// Bounded, path-free evidence for one publish operation.
 #[napi(object)]
@@ -910,6 +976,108 @@ pub fn exact_replace_path(
 		NativeExactUnlinkResult::failure("unsupported_platform")
 	}
 }
+/// Open the fixed owner-only Darwin replacement lock and retain its kernel
+/// authorization until the returned opaque object is closed or dropped.
+#[napi]
+pub fn open_darwin_replacement_auth(
+	parent_path: String,
+	lock_name: String,
+) -> napi::Result<DarwinReplacementAuth> {
+	#[cfg(target_os = "macos")]
+	{
+		let handle = platform::open_darwin_replacement_auth(Path::new(&parent_path), &lock_name)
+			.map_err(napi::Error::from_reason)?;
+		return Ok(DarwinReplacementAuth { inner: Mutex::new(Some(handle)) });
+	}
+	#[cfg(not(target_os = "macos"))]
+	{
+		let _ = (parent_path, lock_name);
+		Err(napi::Error::from_reason("unsupported_platform"))
+	}
+}
+
+/// Execute one authenticated Darwin exact exchange. The native side owns the
+/// final admission check and invokes `renameatx_np` exactly once.
+#[napi]
+pub fn exchange_darwin_managed_file(
+	auth: &DarwinReplacementAuth,
+	parent_path: String,
+	parent_dev: BigInt,
+	parent_ino: BigInt,
+	source_name: String,
+	destination_name: String,
+	expected_source: NativeDarwinReplacementIdentity,
+	expected_destination: NativeDarwinReplacementIdentity,
+	operation_id: String,
+) -> NativeDarwinReplacementResult {
+	#[cfg(target_os = "macos")]
+	{
+		let (parent_dev_negative, parent_dev, parent_dev_lossless) = parent_dev.get_u64();
+		let (parent_ino_negative, parent_ino, parent_ino_lossless) = parent_ino.get_u64();
+		if parent_dev_negative || parent_ino_negative || !parent_dev_lossless || !parent_ino_lossless {
+			return NativeDarwinReplacementResult {
+				ok: false,
+				state: "not_committed".to_owned(),
+				code: Some("parent_mismatch".to_owned()),
+				phase: "preflight".to_owned(),
+				reason: "invalid_parent_identity".to_owned(),
+				parent_fsync: false,
+				source: None,
+				destination: None,
+				operation_id,
+			};
+		}
+		let guard = auth.inner.lock();
+		let Some(handle) = guard.as_ref() else {
+			return NativeDarwinReplacementResult {
+				ok: false,
+				state: "not_committed".to_owned(),
+				code: Some("migration_busy".to_owned()),
+				phase: "preflight".to_owned(),
+				reason: "authorization_closed".to_owned(),
+				parent_fsync: false,
+				source: None,
+				destination: None,
+				operation_id,
+			};
+		};
+		return platform::exchange_darwin_managed_file(
+			handle,
+			Path::new(&parent_path),
+			parent_dev,
+			parent_ino,
+			&source_name,
+			&destination_name,
+			&expected_source,
+			&expected_destination,
+			&operation_id,
+		);
+	}
+	#[cfg(not(target_os = "macos"))]
+	{
+		let _ = (
+			auth,
+			parent_path,
+			parent_dev,
+			parent_ino,
+			source_name,
+			destination_name,
+			expected_source,
+			expected_destination,
+		);
+		NativeDarwinReplacementResult {
+			ok: false,
+			state: "not_committed".to_owned(),
+			code: Some("unsupported_platform".to_owned()),
+			phase: "preflight".to_owned(),
+			reason: "unsupported_platform".to_owned(),
+			parent_fsync: false,
+			source: None,
+			destination: None,
+			operation_id,
+		}
+	}
+}
 
 /// Restore only the detached object that still has the supplied platform
 #[cfg_attr(clippy, doc = "")]
@@ -1233,6 +1401,7 @@ pub(crate) mod platform {
 	use std::os::unix::fs::MetadataExt;
 	#[cfg(test)]
 	use std::sync::{Mutex, OnceLock, mpsc};
+	use napi::bindgen_prelude::BigInt;
 	use std::{
 		borrow::Cow,
 		ffi::CString,
@@ -1246,9 +1415,10 @@ pub(crate) mod platform {
 	};
 
 	use super::{
-		ExactFileIdentity, NativeCanonicalDirectoryIdentity, NativeDirectoryTreeEntry,
-		NativeDirectoryTreeResult, NativeDirectoryTreeSnapshot, NativeExactUnlinkResult,
-		NativeOwnerOnlySecurityResult, digest_reader, io_code, security_io_code, sha256,
+		ExactFileIdentity, NativeCanonicalDirectoryIdentity, NativeDarwinReplacementIdentity,
+		NativeDarwinReplacementResult, NativeDirectoryTreeEntry, NativeDirectoryTreeResult,
+		NativeDirectoryTreeSnapshot, NativeExactUnlinkResult, NativeOwnerOnlySecurityResult,
+		digest_reader, io_code, security_io_code, sha256,
 	};
 
 	/// Bound on EINTR restarts for the no-replace rename primitive. A signal
@@ -4702,6 +4872,400 @@ pub(crate) mod platform {
 			"cleanup_pending",
 			detached_retained_path,
 		)
+	}
+	#[cfg(target_os = "macos")]
+	pub(super) struct DarwinReplacementAuthHandle {
+		lock_fd: libc::c_int,
+		parent_fd: libc::c_int,
+		parent_dev: u64,
+		parent_ino: u64,
+		lock_dev: u64,
+		lock_ino: u64,
+	}
+
+	#[cfg(target_os = "macos")]
+	impl Drop for DarwinReplacementAuthHandle {
+		fn drop(&mut self) {
+			// SAFETY: both descriptors are owned by this handle and are closed once.
+			unsafe {
+				libc::close(self.lock_fd);
+				libc::close(self.parent_fd);
+			}
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	unsafe extern "C" {
+		fn flock(fd: libc::c_int, operation: libc::c_int) -> libc::c_int;
+	}
+
+	#[cfg(target_os = "macos")]
+	fn darwin_component(value: &str) -> Result<CString, &'static str> {
+		if value.is_empty() || value == "." || value == ".." || value.contains('/') || value.contains('\\') {
+			return Err("invalid_request");
+		}
+		CString::new(value.as_bytes()).map_err(|_| "invalid_request")
+	}
+
+	#[cfg(target_os = "macos")]
+	fn darwin_parent_fd(path: &Path) -> Result<(libc::c_int, libc::stat), &'static str> {
+		let authority = checked_file(path, "directory").map_err(|result| match result.code.as_deref() {
+			Some("reparse_point") => "reparse_point",
+			Some("not_directory") => "not_directory",
+			Some("owner_mismatch") => "owner_mismatch",
+			Some("mode_mismatch") => "mode_mismatch",
+			Some("acl_verify_failed") => "acl_verify_failed",
+			_ => "io_error",
+		})?;
+		let security = verify_authority(&authority, "directory");
+		if !security.ok {
+			return Err(match security.code.as_deref() {
+				Some("reparse_point") => "reparse_point",
+				Some("owner_mismatch") => "owner_mismatch",
+				Some("mode_mismatch") => "mode_mismatch",
+				Some("acl_verify_failed") => "acl_verify_failed",
+				_ => "acl_verify_failed",
+			});
+		}
+		let stat = revalidate_authority(&authority).map_err(|_| "identity_mismatch")?;
+		use std::os::fd::IntoRawFd;
+		let fd = authority.file.into_raw_fd();
+		Ok((fd, stat))
+	}
+
+	#[cfg(target_os = "macos")]
+	fn darwin_identity_parts(
+		input: &NativeDarwinReplacementIdentity,
+	) -> Option<DarwinExpectedIdentity> {
+		let (dev_negative, dev, dev_lossless) = input.dev.get_u64();
+		let (ino_negative, ino, ino_lossless) = input.ino.get_u64();
+		let (nlink_negative, nlink, nlink_lossless) = input.nlink.get_u64();
+		let (size_negative, size, size_lossless) = input.size.get_u64();
+		let (mtime_ns, mtime_lossless) = input.mtime_ns.get_i64();
+		let (ctime_ns, ctime_lossless) = input.ctime_ns.get_i64();
+		if dev_negative
+			|| ino_negative
+			|| nlink_negative
+			|| size_negative
+			|| !dev_lossless
+			|| !ino_lossless
+			|| !nlink_lossless
+			|| !size_lossless
+			|| !mtime_lossless
+			|| !ctime_lossless
+			|| nlink != 1
+			|| input.sha256.len() != 64
+			|| !input.sha256.bytes().all(|byte| byte.is_ascii_hexdigit())
+		{
+			return None;
+		}
+		let mut digest = [0u8; 32];
+		for (index, pair) in input.sha256.as_bytes().chunks_exact(2).enumerate() {
+			digest[index] = u8::from_str_radix(std::str::from_utf8(pair).ok()?, 16).ok()?;
+		}
+		Some(DarwinExpectedIdentity { dev, ino, nlink, size, mtime_ns, ctime_ns, digest })
+	}
+
+	#[cfg(target_os = "macos")]
+	#[derive(Clone, Copy)]
+	struct DarwinExpectedIdentity {
+		dev: u64,
+		ino: u64,
+		nlink: u64,
+		size: u64,
+		mtime_ns: i64,
+		ctime_ns: i64,
+		digest: [u8; 32],
+	}
+
+	#[cfg(target_os = "macos")]
+	fn darwin_identity_value(stat: &libc::stat, digest: [u8; 32]) -> NativeDarwinReplacementIdentity {
+		let mut sha256 = String::with_capacity(64);
+		for byte in digest {
+			let _ = write!(sha256, "{byte:02x}");
+		}
+		NativeDarwinReplacementIdentity {
+			dev: BigInt::from(stat.st_dev as u64),
+			ino: BigInt::from(stat.st_ino as u64),
+			nlink: BigInt::from(stat.st_nlink as u64),
+			size: BigInt::from(stat.st_size as u64),
+			mtime_ns: BigInt::from(stat_mtime_ns(stat) as i64),
+			ctime_ns: BigInt::from(stat_ctime_ns(stat) as i64),
+			sha256,
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	fn darwin_result(
+		ok: bool,
+		state: &str,
+		code: Option<&str>,
+		phase: &str,
+		reason: &str,
+		parent_fsync: bool,
+		source: Option<(&libc::stat, [u8; 32])>,
+		destination: Option<(&libc::stat, [u8; 32])>,
+		operation_id: &str,
+	) -> NativeDarwinReplacementResult {
+		NativeDarwinReplacementResult {
+			ok,
+			state: state.to_owned(),
+			code: code.map(str::to_owned),
+			phase: phase.to_owned(),
+			reason: reason.to_owned(),
+			parent_fsync,
+			source: source.map(|(stat, digest)| darwin_identity_value(stat, digest)),
+			destination: destination.map(|(stat, digest)| darwin_identity_value(stat, digest)),
+			operation_id: operation_id.to_owned(),
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	fn darwin_revalidate_auth(handle: &DarwinReplacementAuthHandle) -> Result<(), &'static str> {
+		let parent = {
+			// SAFETY: parent_fd is owned by the live authorization handle.
+			let mut stat: libc::stat = unsafe { std::mem::zeroed() };
+			// SAFETY: parent_fd and stat are valid.
+			if unsafe { libc::fstat(handle.parent_fd, &mut stat) } != 0 {
+				return Err("identity_mismatch");
+			}
+			stat
+		};
+		if parent.st_dev as u64 != handle.parent_dev || parent.st_ino as u64 != handle.parent_ino {
+			return Err("identity_mismatch");
+		}
+		let mut lock: libc::stat = unsafe { std::mem::zeroed() };
+		// SAFETY: parent_fd, lock name, and output storage are valid.
+		let lock_name = CString::new("darwin-replacement-admission.lock").map_err(|_| "invalid_request")?;
+		if unsafe { libc::fstatat(handle.parent_fd, lock_name.as_ptr(), &mut lock, libc::AT_SYMLINK_NOFOLLOW) } != 0 {
+			return Err("migration_busy");
+		}
+		if lock.st_dev as u64 != handle.lock_dev
+			|| lock.st_ino as u64 != handle.lock_ino
+			|| lock.st_mode & libc::S_IFMT != libc::S_IFREG
+			|| lock.st_nlink != 1
+			|| lock.st_uid != unsafe { libc::geteuid() }
+			|| lock.st_mode & 0o077 != 0
+		{
+			return Err("migration_busy");
+		}
+		// SAFETY: flock only inspects/reacquires the live descriptor and does not mutate
+		// the namespace.
+		if unsafe { flock(handle.lock_fd, libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+			return Err("migration_busy");
+		}
+		Ok(())
+	}
+
+	#[cfg(target_os = "macos")]
+	pub(super) fn open_darwin_replacement_auth(
+		parent_path: &Path,
+		lock_name: &str,
+	) -> Result<DarwinReplacementAuthHandle, &'static str> {
+		if lock_name != "darwin-replacement-admission.lock" {
+			return Err("invalid_request");
+		}
+		let requested_name = darwin_component(lock_name)?;
+		let (parent_fd, parent) = darwin_parent_fd(parent_path)?;
+		let mut lock_before: libc::stat = unsafe { std::mem::zeroed() };
+		let existed = unsafe {
+			libc::fstatat(parent_fd, requested_name.as_ptr(), &mut lock_before, libc::AT_SYMLINK_NOFOLLOW)
+		} == 0;
+		let lock_fd = unsafe {
+			libc::openat(
+				parent_fd,
+				requested_name.as_ptr(),
+				libc::O_CREAT | libc::O_RDWR | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+				0o600,
+			)
+		};
+		if lock_fd < 0 {
+			unsafe { libc::close(parent_fd) };
+			return Err(security_code(&std::io::Error::last_os_error()));
+		}
+		let mut lock = unsafe { std::mem::zeroed() };
+		let valid = unsafe { libc::fstat(lock_fd, &mut lock) } == 0
+			&& lock.st_mode & libc::S_IFMT == libc::S_IFREG
+			&& lock.st_nlink == 1
+			&& lock.st_uid == unsafe { libc::geteuid() }
+			&& lock.st_mode & 0o077 == 0;
+		if !valid {
+			unsafe {
+				libc::close(lock_fd);
+				libc::close(parent_fd);
+			}
+			return Err("identity_mismatch");
+		}
+		// SAFETY: flock is called on the owned descriptor with a nonblocking exclusive lock.
+		if unsafe { flock(lock_fd, libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+			let code = std::io::Error::last_os_error().raw_os_error();
+			unsafe {
+				libc::close(lock_fd);
+				libc::close(parent_fd);
+			}
+			return Err(match code {
+				Some(libc::EAGAIN) => "migration_busy",
+				Some(libc::EACCES) | Some(libc::EPERM) => "permission_denied",
+				_ => "io_error",
+			});
+		}
+		if !existed && unsafe { libc::fsync(parent_fd) } != 0 {
+			unsafe {
+				libc::close(lock_fd);
+				libc::close(parent_fd);
+			}
+			return Err("durability_failed");
+		}
+		let handle = DarwinReplacementAuthHandle {
+			lock_fd,
+			parent_fd,
+			parent_dev: parent.st_dev as u64,
+			parent_ino: parent.st_ino as u64,
+			lock_dev: lock.st_dev as u64,
+			lock_ino: lock.st_ino as u64,
+		};
+		darwin_revalidate_auth(&handle)?;
+		Ok(handle)
+	}
+
+	#[cfg(target_os = "macos")]
+	fn darwin_named_identity(
+		parent_fd: libc::c_int,
+		name: &CString,
+		expected: &DarwinExpectedIdentity,
+		verify_timestamps: bool,
+	) -> Result<(libc::stat, [u8; 32]), &'static str> {
+		let mut stat: libc::stat = unsafe { std::mem::zeroed() };
+		if unsafe { libc::fstatat(parent_fd, name.as_ptr(), &mut stat, libc::AT_SYMLINK_NOFOLLOW) } != 0 {
+			return Err(security_code(&std::io::Error::last_os_error()));
+		}
+		if stat.st_mode & libc::S_IFMT != libc::S_IFREG
+			|| stat.st_nlink != 1
+			|| stat.st_uid != unsafe { libc::geteuid() }
+			|| stat.st_mode & 0o077 != 0
+			|| stat.st_dev as u64 != expected.dev
+			|| stat.st_ino as u64 != expected.ino
+			|| stat.st_nlink as u64 != expected.nlink
+			|| stat.st_size as u64 != expected.size
+			|| (verify_timestamps
+				&& (stat_mtime_ns(&stat) as i64 != expected.mtime_ns
+					|| stat_ctime_ns(&stat) as i64 != expected.ctime_ns))
+		{
+			return Err("identity_mismatch");
+		}
+		let digest = digest_openat(parent_fd, name)?;
+		if digest != expected.digest {
+			return Err("identity_mismatch");
+		}
+		Ok((stat, digest))
+	}
+
+	#[cfg(target_os = "macos")]
+	fn darwin_exchange_error(error: i32) -> &'static str {
+		match error {
+			libc::ENOSYS | libc::EINVAL | libc::ENOTSUP | libc::EOPNOTSUPP => "atomic_unavailable",
+			libc::EACCES | libc::EPERM => "permission_denied",
+			libc::EXDEV => "cross_device",
+			libc::EINTR => "interrupted",
+			_ => "io_error",
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	pub(super) fn exchange_darwin_managed_file(
+		handle: &DarwinReplacementAuthHandle,
+		parent_path: &Path,
+		parent_dev: u64,
+		parent_ino: u64,
+		source_name: &str,
+		destination_name: &str,
+		expected_source: &NativeDarwinReplacementIdentity,
+		expected_destination: &NativeDarwinReplacementIdentity,
+		operation_id: &str,
+	) -> NativeDarwinReplacementResult {
+		let Some(source) = darwin_identity_parts(expected_source) else {
+			return darwin_result(false, "not_committed", Some("identity_mismatch"), "preflight", "invalid_source_identity", false, None, None, operation_id);
+		};
+		let Some(destination) = darwin_identity_parts(expected_destination) else {
+			return darwin_result(false, "not_committed", Some("identity_mismatch"), "preflight", "invalid_destination_identity", false, None, None, operation_id);
+		};
+		if source_name == destination_name {
+			return darwin_result(false, "not_committed", Some("invalid_request"), "preflight", "names_equal", false, None, None, operation_id);
+		}
+		let source_name = match darwin_component(source_name) {
+			Ok(name) => name,
+			Err(code) => return darwin_result(false, "not_committed", Some(code), "preflight", "invalid_source_name", false, None, None, operation_id),
+		};
+		let destination_name = match darwin_component(destination_name) {
+			Ok(name) => name,
+			Err(code) => return darwin_result(false, "not_committed", Some(code), "preflight", "invalid_destination_name", false, None, None, operation_id),
+		};
+		if let Err(code) = darwin_revalidate_auth(handle) {
+			return darwin_result(false, "not_committed", Some(code), "preflight", "authorization_unavailable", false, None, None, operation_id);
+		}
+		let (parent_fd, parent) = match darwin_parent_fd(parent_path) {
+			Ok(value) => value,
+			Err(code) => return darwin_result(false, "not_committed", Some(code), "preflight", "parent_unavailable", false, None, None, operation_id),
+		};
+		if parent.st_dev as u64 != parent_dev || parent.st_ino as u64 != parent_ino {
+			unsafe { libc::close(parent_fd) };
+			return darwin_result(false, "not_committed", Some("parent_mismatch"), "preflight", "parent_identity", false, None, None, operation_id);
+		}
+		let before_source = match darwin_named_identity(parent_fd, &source_name, &source, true) {
+			Ok(value) => value,
+			Err(code) => {
+				unsafe { libc::close(parent_fd) };
+				return darwin_result(false, "not_committed", Some(code), "preflight", "source_identity", false, None, None, operation_id);
+			},
+		};
+		let before_destination = match darwin_named_identity(parent_fd, &destination_name, &destination, true) {
+			Ok(value) => value,
+			Err(code) => {
+				unsafe { libc::close(parent_fd) };
+				return darwin_result(false, "not_committed", Some(code), "preflight", "destination_identity", true, Some((&before_source.0, before_source.1)), None, operation_id);
+			},
+		};
+		if source.dev == destination.dev && source.ino == destination.ino {
+			unsafe { libc::close(parent_fd) };
+			return darwin_result(false, "not_committed", Some("identity_mismatch"), "preflight", "same_object", true, Some((&before_source.0, before_source.1)), Some((&before_destination.0, before_destination.1)), operation_id);
+		}
+		const RENAME_SWAP: u32 = 0x0000_0002;
+		const RENAME_NOFOLLOW_ANY: u32 = 0x0000_0010;
+		// SAFETY: descriptors and NUL-terminated names remain live for this one call.
+		let swapped = unsafe {
+			renameatx_np(
+				parent_fd,
+				source_name.as_ptr(),
+				parent_fd,
+				destination_name.as_ptr(),
+				RENAME_SWAP | RENAME_NOFOLLOW_ANY,
+			)
+		};
+		if swapped != 0 {
+			let code = std::io::Error::last_os_error().raw_os_error();
+			let state = if matches!(code, Some(libc::ENOSYS | libc::EINVAL | libc::ENOTSUP | libc::EOPNOTSUPP | libc::EACCES | libc::EPERM | libc::EXDEV)) {
+				"not_committed"
+			} else {
+				"committed_unproven"
+			};
+			unsafe { libc::close(parent_fd) };
+			return darwin_result(false, state, Some(darwin_exchange_error(code.unwrap_or(libc::EIO)),), "exchange", "renameatx_np_failed", false, Some((&before_source.0, before_source.1)), Some((&before_destination.0, before_destination.1)), operation_id);
+		}
+		let after_destination = darwin_named_identity(parent_fd, &destination_name, &source, false);
+		let after_source = darwin_named_identity(parent_fd, &source_name, &destination, false);
+		let (after_source, after_destination) = match (after_source, after_destination) {
+			(Ok(source), Ok(destination)) => (source, destination),
+			_ => {
+				unsafe { libc::close(parent_fd) };
+				return darwin_result(false, "committed_unproven", Some("identity_mismatch"), "post_exchange", "identity_proof_failed", false, None, None, operation_id);
+			},
+		};
+		let synced = unsafe { libc::fsync(parent_fd) } == 0;
+		unsafe { libc::close(parent_fd) };
+		if !synced {
+			return darwin_result(false, "committed_unproven", Some("durability_failed"), "parent_fsync", "parent_fsync_failed", false, Some((&after_source.0, after_source.1)), Some((&after_destination.0, after_destination.1)), operation_id);
+		}
+		darwin_result(true, "committed_durable", None, "complete", "none", true, Some((&after_source.0, after_source.1)), Some((&after_destination.0, after_destination.1)), operation_id)
 	}
 }
 

--- a/crates/pi-natives/src/path_identity.rs
+++ b/crates/pi-natives/src/path_identity.rs
@@ -5430,7 +5430,28 @@ pub(crate) mod platform {
 				);
 			},
 		};
+		// SAFETY: the verified parent descriptor and component-bound predecessor name
+		// remain live under the held Darwin replacement admission.
+		if unsafe { libc::unlinkat(parent_fd, source_name.as_ptr(), 0) } != 0 {
+			let code = security_code(&std::io::Error::last_os_error());
+			// SAFETY: this error branch owns the live parent descriptor exactly once.
+			unsafe { libc::close(parent_fd) };
+			return darwin_result(
+				false,
+				"committed_unproven",
+				Some(code),
+				"predecessor_cleanup",
+				"unlink_failed",
+				false,
+				Some((&after_source.0, after_source.1)),
+				Some((&after_destination.0, after_destination.1)),
+				operation_id,
+			);
+		}
+		// SAFETY: the live parent descriptor binds both the exchange and predecessor
+		// unlink.
 		let synced = unsafe { libc::fsync(parent_fd) } == 0;
+		// SAFETY: this path owns the live parent descriptor exactly once.
 		unsafe { libc::close(parent_fd) };
 		if !synced {
 			return darwin_result(

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -41,6 +41,8 @@
 - The model selector's assignment menu now shows the model each role currently resolves to (`Set as EXECUTOR (Executor) — now: anthropic/claude-haiku-4-5`), distinguishing an unset default, a role that inherits the default, and a configured-but-unresolvable selector. Previously the role rows were unlabeled, so the only way to learn a role's model was to scan the whole 800+ entry model list for role badges.
 - Standalone `AGENTS.md` ancestor discovery now bounds directory traversal, per-file reads, and aggregate instruction bytes while surfacing content-free omission warnings (#3722).
 
+- The SDK operation inventory now classifies the local-only `/import-session` seam as a locked exclusion and regenerates the committed matrix, fixing the shard-5 `accepts the committed generated matrix` gate failure introduced by the Codex import command (#3714).
+- Managed transcript rewrites on macOS now use the Darwin native exact-replacement path instead of failing with `managed_replace_exact_unavailable`; successful exchanges retain the predecessor for recovery evidence.
 ## [0.12.7] - 2026-07-31
 
 ## [0.12.6] - 2026-07-31

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -5,17 +5,18 @@ import * as path from "node:path";
 import {
 	applyOwnerOnlyFdSecurity,
 	applyOwnerOnlyPathSecurity,
+	type DarwinReplacementAuth,
 	exactRemoveDirectoryTree,
 	exactReplacePath,
 	exactRestore,
 	exactUnlink,
-	linkNoReplacePath,
 	exchangeDarwinManagedFile,
+	linkNoReplacePath,
 	type NativeDarwinReplacementIdentity,
 	type NativeDarwinReplacementResult,
-	openDarwinReplacementAuth,
 	type NativeDirectoryTreeSnapshot,
 	type NativeOwnerOnlySecurityResult,
+	openDarwinReplacementAuth,
 	openRecoveryFsRoot,
 	type RecoveryFsRoot,
 	renameNoReplacePath,
@@ -57,6 +58,16 @@ export class ManagedPublishError extends Error {
 		this.name = "ManagedPublishError";
 		this.classification = classification;
 		this.diagnostic = formatNativePublishDiagnostic(outcome);
+	}
+}
+export class ManagedDarwinReplacementError extends Error {
+	readonly code = "managed_replace_failed";
+	readonly nativeResult: NativeDarwinReplacementResult;
+
+	constructor(nativeResult: NativeDarwinReplacementResult) {
+		super(`managed_replace_${nativeResult.state}:${nativeResult.code ?? nativeResult.reason}`);
+		this.name = "ManagedDarwinReplacementError";
+		this.nativeResult = nativeResult;
 	}
 }
 
@@ -148,7 +159,6 @@ export type ManagedStorageFailure =
 	| "atomic_unavailable"
 	| "durability_not_provable"
 	| "migration_retired"
-	| "retention_bound_exceeded"
 	| "managed_storage_unsupported";
 
 export interface ManagedStorageLock {
@@ -336,67 +346,6 @@ export interface ManagedDirectoryRoot {
 	readonly dev: bigint;
 	readonly ino: bigint;
 }
-/**
- * Trusted Darwin replacement metadata. It contains no descriptor or pathname
- * authority; every operation revalidates the bound directory before admission.
- */
-export interface ManagedDarwinReplacementContext {
-	readonly rootPath: string;
-	readonly rootDev: bigint;
-	readonly rootIno: bigint;
-	readonly directoryPath: string;
-	readonly directoryDev: bigint;
-	readonly directoryIno: bigint;
-	readonly replacementDirectory: string;
-	readonly lockName: "darwin-replacement-admission.lock";
-}
-
-export function createManagedDarwinReplacementContext(
-	root: ManagedDirectoryRoot,
-	directory: string,
-): ManagedDarwinReplacementContext | undefined {
-	if (process.platform !== "darwin") return undefined;
-	assertManagedDirectoryRoot(root);
-	managedRelativePath(root, directory);
-	const resolved = path.resolve(directory);
-	const stat = fs.lstatSync(resolved, { bigint: true });
-	if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error("Managed replacement directory is unsafe");
-	return Object.freeze({
-		rootPath: root.canonicalPath,
-		rootDev: root.dev,
-		rootIno: root.ino,
-		directoryPath: resolved,
-		directoryDev: stat.dev,
-		directoryIno: stat.ino,
-		replacementDirectory: path.join(resolved, ".gjc-managed-session-internal", "replacements"),
-		lockName: "darwin-replacement-admission.lock" as const,
-	});
-}
-
-function deriveManagedDarwinReplacementContext(
-	context: ManagedDarwinReplacementContext | undefined,
-	root: ManagedDirectoryRoot,
-	directory: string,
-): ManagedDarwinReplacementContext | undefined {
-	if (!context || process.platform !== "darwin") return undefined;
-	if (
-		context.rootPath !== root.canonicalPath ||
-		context.rootDev !== root.dev ||
-		context.rootIno !== root.ino
-	)
-		throw new Error("Managed Darwin replacement root binding changed");
-	const resolved = path.resolve(directory);
-	managedRelativePath(root, resolved);
-	const stat = fs.lstatSync(resolved, { bigint: true });
-	if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error("Managed Darwin replacement directory is unsafe");
-	return Object.freeze({
-		...context,
-		directoryPath: resolved,
-		directoryDev: stat.dev,
-		directoryIno: stat.ino,
-		replacementDirectory: path.join(resolved, ".gjc-managed-session-internal", "replacements"),
-	});
-}
 
 /**
  * Establish the first managed directory beneath a potentially shared ancestor.
@@ -499,6 +448,18 @@ function managedRelativePath(root: ManagedDirectoryRoot, pathname: string): read
 	if (path.isAbsolute(relative) || relative.split(path.sep).includes(".."))
 		throw new Error(`Managed path escapes configured root: ${pathname}`);
 	return relative.split(path.sep);
+}
+function openManagedDarwinReplacementAuth(
+	root: ManagedDirectoryRoot,
+	directory: string,
+): DarwinReplacementAuth | undefined {
+	if (process.platform !== "darwin") return undefined;
+	assertManagedDirectoryRoot(root);
+	managedRelativePath(root, directory);
+	const resolved = path.resolve(directory);
+	const stat = fs.lstatSync(resolved, { bigint: true });
+	if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error("Managed replacement directory is unsafe");
+	return openDarwinReplacementAuth(resolved, "darwin-replacement-admission.lock");
 }
 
 const PROCESS_START_ID = randomUUID();
@@ -605,7 +566,6 @@ export class ManagedSessionDescendantStore {
 	/** Logical profile root inherited by nested managed session destinations. */
 	readonly #profileAgentDir: string;
 	readonly #subtreeRoot: ManagedDirectoryRoot;
-	readonly #darwinContext: ManagedDarwinReplacementContext | undefined;
 
 	constructor(
 		root: ManagedDirectoryRoot,
@@ -613,7 +573,6 @@ export class ManagedSessionDescendantStore {
 		retained?: { authority: RecoveryFsRoot; authorityBaseDir: string },
 		policy?: ManagedSessionSecurityPolicy,
 		profileAgentDir?: string,
-		darwinContext?: ManagedDarwinReplacementContext,
 	) {
 		managedRelativePath(root, baseDir);
 
@@ -633,8 +592,6 @@ export class ManagedSessionDescendantStore {
 				ino: BigInt(captured.snapshot.rootIno),
 			});
 			this.#authority = retained.authority;
-			this.#darwinContext = deriveManagedDarwinReplacementContext(darwinContext, root, this.#baseDir);
-			if (darwinContext && !this.#darwinContext) throw new Error("Managed Darwin replacement authority unavailable");
 			this.#assertBound();
 
 			return;
@@ -643,8 +600,6 @@ export class ManagedSessionDescendantStore {
 		ensureManagedDirectory(this.#baseDir, root, this.#policy);
 		const subtreeStat = fs.lstatSync(this.#baseDir, { bigint: true });
 		this.#subtreeRoot = Object.freeze({ canonicalPath: this.#baseDir, dev: subtreeStat.dev, ino: subtreeStat.ino });
-		this.#darwinContext = deriveManagedDarwinReplacementContext(darwinContext, root, this.#baseDir);
-		if (darwinContext && !this.#darwinContext) throw new Error("Managed Darwin replacement authority unavailable");
 		if (process.platform === "linux") {
 			const before = fs.lstatSync(this.#baseDir, { bigint: true });
 			const authority = openRecoveryFsRoot(this.#baseDir);
@@ -682,38 +637,12 @@ export class ManagedSessionDescendantStore {
 	get profileAgentDir(): string {
 		return this.#profileAgentDir;
 	}
-	get darwinReplacementContext(): ManagedDarwinReplacementContext | undefined {
-		return this.#darwinContext;
-	}
-
-	/**
-	 * Derive a fresh context for a trusted child directory. The child identity is
-	 * captured here, never inferred from a caller pathname.
-	 */
-	deriveDarwinReplacementContext(directory: string): ManagedDarwinReplacementContext | undefined {
-		this.#assertBound();
-		const resolved = path.resolve(directory);
-		if (resolved !== this.#baseDir && !resolved.startsWith(`${this.#baseDir}${path.sep}`)) {
-			throw new Error("Managed Darwin replacement child escaped retained store");
-		}
-		const relative = path.relative(this.#baseDir, resolved);
-		const child = this.ensureDirectory(relative);
-		if (!this.#darwinContext) return undefined;
-		return deriveManagedDarwinReplacementContext(this.#darwinContext, this.#root, child.canonicalPath);
-	}
 
 	deriveSubtree(relativePath: string): ManagedSessionDescendantStore {
 		const child = this.ensureDirectory(relativePath);
 		const resolved = this.#resolve(relativePath);
 		if (!this.#authority)
-			return new ManagedSessionDescendantStore(
-				this.#root,
-				resolved,
-				undefined,
-				this.#policy,
-				this.#profileAgentDir,
-				deriveManagedDarwinReplacementContext(this.#darwinContext, this.#root, resolved),
-			);
+			return new ManagedSessionDescendantStore(this.#root, resolved, undefined, this.#policy, this.#profileAgentDir);
 		const retainedChild = this.#authority.retainManagedDirectory(
 			this.#relative(resolved),
 			child.dev.toString(),
@@ -728,7 +657,6 @@ export class ManagedSessionDescendantStore {
 			},
 			this.#policy,
 			this.#profileAgentDir,
-			deriveManagedDarwinReplacementContext(this.#darwinContext, this.#root, resolved),
 		);
 	}
 
@@ -1085,8 +1013,7 @@ export class ManagedSessionDescendantStore {
 	}
 
 	#openDarwinReplacementAuth(directory: string): { close(): void } | undefined {
-		const context = createManagedDarwinReplacementContext(this.#root, directory);
-		return context ? openDarwinReplacementAuth(directory, context.lockName) : undefined;
+		return openManagedDarwinReplacementAuth(this.#root, directory);
 	}
 	#relative(resolved: string): string {
 		return path.relative(this.#authorityBaseDir, resolved).split(path.sep).join("/");
@@ -1847,45 +1774,6 @@ export function publishManagedFileNoReplaceSync(
 	if (failure !== undefined) throw failure;
 }
 
-type DarwinReplacementReceiptState =
-	| "reserved"
-	| "prepared"
-	| "swap_intent"
-	| "retained_predecessor"
-	| "committed_durable"
-	| "committed_unproven"
-	| "abandoned";
-
-type DarwinReplacementReceipt = {
-	version: 1;
-	sequence: number;
-	operationId: string;
-	state: DarwinReplacementReceiptState;
-	parentDev: string;
-	parentIno: string;
-	sourceName: string;
-	destinationName: string;
-	source: NativeDarwinReplacementIdentity | null;
-	destination: NativeDarwinReplacementIdentity | null;
-	result: {
-		state: string;
-		code: string | null;
-		phase: string;
-		reason: string;
-		parentFsync: boolean;
-	};
-};
-
-const DARWIN_RECEIPT_STATES = new Set<DarwinReplacementReceiptState>([
-	"reserved",
-	"prepared",
-	"swap_intent",
-	"retained_predecessor",
-	"committed_durable",
-	"committed_unproven",
-	"abandoned",
-]);
-
 function isDarwinIdentity(value: unknown): value is NativeDarwinReplacementIdentity {
 	if (!value || typeof value !== "object") return false;
 	const record = value as Record<string, unknown>;
@@ -1902,10 +1790,7 @@ function isDarwinIdentity(value: unknown): value is NativeDarwinReplacementIdent
 	);
 }
 
-function validateDarwinReplacementResult(
-	value: unknown,
-	operationId: string,
-): NativeDarwinReplacementResult {
+function validateDarwinReplacementResult(value: unknown, operationId: string): NativeDarwinReplacementResult {
 	const malformed = (): NativeDarwinReplacementResult => ({
 		ok: false,
 		state: "committed_unproven",
@@ -1920,21 +1805,13 @@ function validateDarwinReplacementResult(
 	if (
 		Object.keys(record).some(
 			key =>
-				![
-					"ok",
-					"state",
-					"code",
-					"phase",
-					"reason",
-					"parentFsync",
-					"source",
-					"destination",
-					"operationId",
-				].includes(key),
+				!["ok", "state", "code", "phase", "reason", "parentFsync", "source", "destination", "operationId"].includes(
+					key,
+				),
 		) ||
 		typeof record.ok !== "boolean" ||
-		(typeof record.state !== "string" ||
-			!["not_committed", "committed_durable", "committed_unproven"].includes(record.state)) ||
+		typeof record.state !== "string" ||
+		!["not_committed", "committed_durable", "committed_unproven"].includes(record.state) ||
 		(record.code !== undefined && record.code !== null && typeof record.code !== "string") ||
 		typeof record.phase !== "string" ||
 		typeof record.reason !== "string" ||
@@ -1946,107 +1823,14 @@ function validateDarwinReplacementResult(
 		return malformed();
 	}
 	const result = value as NativeDarwinReplacementResult;
-	if (result.state === "committed_durable" && (!result.ok || result.parentFsync !== true || !result.source || !result.destination)) {
+	if (
+		result.state === "committed_durable" &&
+		(!result.ok || result.parentFsync !== true || !result.source || !result.destination)
+	) {
 		return malformed();
 	}
 	if (result.ok && result.state !== "committed_durable") return malformed();
 	return result;
-}
-
-
-function darwinReceiptPath(context: ManagedDarwinReplacementContext, operationId: string, sequence: number): string {
-	return path.join(context.replacementDirectory, `.gjc-darwin-replacement-${operationId}-${sequence}.json`);
-}
-
-function parseDarwinReceipt(pathname: string): DarwinReplacementReceipt {
-	const parsed: unknown = JSON.parse(fs.readFileSync(pathname, "utf8"));
-	if (!parsed || typeof parsed !== "object") throw new Error("managed_replace_receipt_invalid");
-	const record = parsed as Record<string, unknown>;
-	if (
-		Object.keys(record).length !== 11 ||
-		record.version !== 1 ||
-		typeof record.sequence !== "number" ||
-		!Number.isSafeInteger(record.sequence) ||
-		typeof record.operationId !== "string" ||
-		!DARWIN_RECEIPT_STATES.has(record.state as DarwinReplacementReceiptState) ||
-		typeof record.parentDev !== "string" ||
-		typeof record.parentIno !== "string" ||
-		typeof record.sourceName !== "string" ||
-		typeof record.destinationName !== "string" ||
-		(record.source !== null && !isDarwinReceiptIdentity(record.source)) ||
-		(record.destination !== null && !isDarwinReceiptIdentity(record.destination)) ||
-		!record.result ||
-		typeof record.result !== "object"
-	)
-		throw new Error("managed_replace_receipt_invalid");
-	const result = record.result as Record<string, unknown>;
-	if (
-		Object.keys(result).length !== 5 ||
-		typeof result.state !== "string" ||
-		(result.code !== null && typeof result.code !== "string") ||
-		typeof result.phase !== "string" ||
-		typeof result.reason !== "string" ||
-		typeof result.parentFsync !== "boolean"
-	)
-		throw new Error("managed_replace_receipt_invalid");
-	return record as unknown as DarwinReplacementReceipt;
-}
-
-function isDarwinReceiptIdentity(value: unknown): boolean {
-	if (!value || typeof value !== "object") return false;
-	const record = value as Record<string, unknown>;
-	return (
-		Object.keys(record).length === 7 &&
-		typeof record.dev === "string" &&
-		/^(0|[1-9][0-9]*)$/.test(record.dev) &&
-		typeof record.ino === "string" &&
-		/^(0|[1-9][0-9]*)$/.test(record.ino) &&
-		typeof record.nlink === "string" &&
-		/^(0|[1-9][0-9]*)$/.test(record.nlink) &&
-		typeof record.size === "string" &&
-		/^(0|[1-9][0-9]*)$/.test(record.size) &&
-		typeof record.mtimeNs === "string" &&
-		/^(0|[1-9][0-9]*)$/.test(record.mtimeNs) &&
-		typeof record.ctimeNs === "string" &&
-		/^(0|[1-9][0-9]*)$/.test(record.ctimeNs) &&
-		typeof record.sha256 === "string" &&
-		/^[0-9a-f]{64}$/.test(record.sha256)
-	);
-}
-
-function validateDarwinReplacementReceipts(context: ManagedDarwinReplacementContext): string[] {
-	if (!fs.existsSync(context.replacementDirectory)) return [];
-	const paths = fs
-		.readdirSync(context.replacementDirectory)
-		.filter(name => name.startsWith(".gjc-darwin-replacement-") && name.endsWith(".json"))
-		.map(name => path.join(context.replacementDirectory, name));
-	for (const receiptPath of paths) parseDarwinReceipt(receiptPath);
-	return paths;
-}
-
-function appendDarwinReplacementReceipt(
-	context: ManagedDarwinReplacementContext,
-	root: ManagedDirectoryRoot,
-	policy: ManagedSessionSecurityPolicy,
-	receipt: Omit<DarwinReplacementReceipt, "version" | "sequence">,
-): void {
-	ensureManagedDirectory(context.replacementDirectory, root, policy);
-	const existing = validateDarwinReplacementReceipts(context);
-	const record: DarwinReplacementReceipt = {
-		version: 1,
-		sequence: existing.length + 1,
-		...receipt,
-	};
-	const receiptPath = darwinReceiptPath(context, receipt.operationId, record.sequence);
-	publishManagedFileNoReplaceSync(
-		receiptPath,
-		Buffer.from(
-			`${JSON.stringify(record, (_key, value: unknown) => (typeof value === "bigint" ? value.toString() : value))}\n`,
-		),
-		root,
-		policy,
-	);
-	fsyncDirectory(context.replacementDirectory);
 }
 
 /** Replace one managed regular file while retaining the secured staging fd through publication. */
@@ -2088,8 +1872,9 @@ export function replaceManagedFileSync(
 			throw new Error("managed_replace_exact_unavailable");
 		}
 		if (process.platform === "darwin" && expectedDestination) {
-			const context = createManagedDarwinReplacementContext(root, parent);
-			if (!context) throw new Error("managed_replace_exact_unavailable");
+			preserveStaging = true;
+			const auth = openManagedDarwinReplacementAuth(root, parent);
+			if (!auth) throw new Error("managed_replace_exact_unavailable");
 			const operationId = randomUUID();
 			const parentIdentity = fs.lstatSync(parent, { bigint: true });
 			const sourceName = path.basename(staging);
@@ -2112,46 +1897,8 @@ export function replaceManagedFileSync(
 				ctimeNs: expectedDestination.ctimeNs,
 				sha256: expectedDestination.sha256,
 			};
-			const appendReceipt = (
-				state: DarwinReplacementReceiptState,
-				result: DarwinReplacementReceipt["result"],
-			): void =>
-				appendDarwinReplacementReceipt(context, root, policy, {
-					operationId,
-					state,
-					parentDev: parentIdentity.dev.toString(),
-					parentIno: parentIdentity.ino.toString(),
-					sourceName,
-					destinationName,
-					source,
-					destination: target,
-					result,
-				});
-			appendReceipt("reserved", {
-				state: "not_committed",
-				code: null,
-				phase: "reservation",
-				reason: "none",
-				parentFsync: false,
-			});
-			appendReceipt("prepared", {
-				state: "not_committed",
-				code: null,
-				phase: "staging",
-				reason: "none",
-				parentFsync: false,
-			});
-			appendReceipt("swap_intent", {
-				state: "committed_unproven",
-				code: null,
-				phase: "exchange",
-				reason: "pending",
-				parentFsync: false,
-			});
-			const auth = openDarwinReplacementAuth(parent, context.lockName);
-			let result: NativeDarwinReplacementResult;
 			try {
-				result = validateDarwinReplacementResult(
+				const result = validateDarwinReplacementResult(
 					exchangeDarwinManagedFile(
 						auth,
 						parent,
@@ -2165,28 +1912,12 @@ export function replaceManagedFileSync(
 					),
 					operationId,
 				);
+				if (result.state !== "committed_durable") {
+					throw new ManagedDarwinReplacementError(result);
+				}
 			} finally {
 				auth.close();
 			}
-			appendReceipt(result.state === "committed_durable" ? "committed_durable" : "committed_unproven", {
-				state: result.state,
-				code: result.code ?? null,
-				phase: result.phase,
-				reason: result.reason,
-				parentFsync: result.parentFsync,
-			});
-			if (result.state !== "committed_durable") {
-				preserveStaging = true;
-				throw new Error(`managed_replace_${result.state}:${result.code ?? result.reason}`);
-			}
-			appendReceipt("retained_predecessor", {
-				state: result.state,
-				code: null,
-				phase: "retained_predecessor",
-				reason: "none",
-				parentFsync: result.parentFsync,
-			});
-			preserveStaging = true;
 		} else if (process.platform === "win32" && expectedDestination) {
 			const parentIdentity = fs.lstatSync(parent, { bigint: true });
 			const replaced = exactReplacePath(
@@ -2294,9 +2025,8 @@ export function replaceManagedFileSync(
 				}
 			}
 		} else if (process.platform === "darwin") {
-			const context = createManagedDarwinReplacementContext(root, parent);
-			if (!context) throw new Error("managed_replace_exact_unavailable");
-			darwinNoExpectedAuth = openDarwinReplacementAuth(parent, context.lockName);
+			darwinNoExpectedAuth = openManagedDarwinReplacementAuth(root, parent);
+			if (!darwinNoExpectedAuth) throw new Error("managed_replace_exact_unavailable");
 			fs.renameSync(staging, destination);
 		} else fs.renameSync(staging, destination);
 		if (process.platform !== "darwin" || !expectedDestination) assertFence?.();

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -1013,70 +1013,76 @@ export class ManagedSessionDescendantStore {
 		this.#beforeMutation();
 		this.#assertBound();
 		const resolved = this.#resolve(relativePath);
-		let existing = this.readExpected(relativePath);
-		if (!existing) throw new Error("managed_append_missing");
-		if (this.#authority) {
-			const appended = this.#authority.appendManaged(
-				this.#relative(resolved),
-				bytes,
-				existing.identity.dev.toString(),
-				existing.identity.ino.toString(),
-				existing.identity.size.toString(),
-				existing.identity.mtimeNs.toString(),
-				existing.identity.ctimeNs.toString(),
-				existing.identity.sha256,
-			);
-			if (!appended.ok) throw new Error(appended.code ?? "managed_append_failed");
-			this.#assertBound();
-			return;
-		}
-		// On Darwin, the first write-append open can change only ctime (e.g. com.apple.provenance)
-		// while leaving dev/ino/size/mtime/content intact. Allow one bounded refresh+retry for that
-		// transition only; any other identity change or a second ctime transition stays fail-closed.
-		// See https://github.com/Yeachan-Heo/gajae-code/issues/2944
-		let fd: number | undefined;
-		let darwinCtimeRefreshConsumed = false;
+		const context = createManagedDarwinReplacementContext(this.#root, path.dirname(resolved));
+		const auth = context ? openDarwinReplacementAuth(path.dirname(resolved), context.lockName) : undefined;
 		try {
-			for (;;) {
-				fd = fs.openSync(resolved, fs.constants.O_WRONLY | fs.constants.O_APPEND | fs.constants.O_NOFOLLOW);
-				const before = identity(fs.fstatSync(fd, { bigint: true }));
-				if (!sameIdentity(before, existing.identity)) {
-					const allowDarwinCtimeRefresh =
-						process.platform === "darwin" &&
-						!darwinCtimeRefreshConsumed &&
-						isCtimeOnlyIdentityMismatch(before, existing.identity);
-					if (!allowDarwinCtimeRefresh) throw new Error("identity_mismatch");
-					fs.closeSync(fd);
-					fd = undefined;
-					darwinCtimeRefreshConsumed = true;
-					const original = existing;
-					const refreshed = this.readExpected(relativePath);
-					if (
-						!refreshed ||
-						!sameStableIdentityIgnoringCtime(refreshed.identity, original.identity) ||
-						refreshed.identity.sha256 !== original.identity.sha256 ||
-						!refreshed.bytes.equals(original.bytes)
-					) {
-						throw new Error("identity_mismatch");
-					}
-					existing = refreshed;
-					continue;
-				}
-				secureFileDescriptor(resolved, fd, "verify");
-				let offset = 0;
-				while (offset < bytes.byteLength) offset += fs.writeSync(fd, bytes, offset, bytes.byteLength - offset);
-				fs.fsyncSync(fd);
-				secureFileDescriptor(resolved, fd, "verify");
-				const after = identity(fs.fstatSync(fd, { bigint: true }));
-				const named = identity(fs.lstatSync(resolved, { bigint: true }));
-				if (!sameIdentity(after, named) || after.dev !== before.dev || after.ino !== before.ino)
-					throw new Error("identity_mismatch");
-				break;
+			let existing = this.readExpected(relativePath);
+			if (!existing) throw new Error("managed_append_missing");
+			if (this.#authority) {
+				const appended = this.#authority.appendManaged(
+					this.#relative(resolved),
+					bytes,
+					existing.identity.dev.toString(),
+					existing.identity.ino.toString(),
+					existing.identity.size.toString(),
+					existing.identity.mtimeNs.toString(),
+					existing.identity.ctimeNs.toString(),
+					existing.identity.sha256,
+				);
+				if (!appended.ok) throw new Error(appended.code ?? "managed_append_failed");
+				this.#assertBound();
+				return;
 			}
+			// On Darwin, the first write-append open can change only ctime (e.g. com.apple.provenance)
+			// while leaving dev/ino/size/mtime/content intact. Allow one bounded refresh+retry for that
+			// transition only; any other identity change or a second ctime transition stays fail-closed.
+			// See https://github.com/Yeachan-Heo/gajae-code/issues/2944
+			let fd: number | undefined;
+			let darwinCtimeRefreshConsumed = false;
+			try {
+				for (;;) {
+					fd = fs.openSync(resolved, fs.constants.O_WRONLY | fs.constants.O_APPEND | fs.constants.O_NOFOLLOW);
+					const before = identity(fs.fstatSync(fd, { bigint: true }));
+					if (!sameIdentity(before, existing.identity)) {
+						const allowDarwinCtimeRefresh =
+							process.platform === "darwin" &&
+							!darwinCtimeRefreshConsumed &&
+							isCtimeOnlyIdentityMismatch(before, existing.identity);
+						if (!allowDarwinCtimeRefresh) throw new Error("identity_mismatch");
+						fs.closeSync(fd);
+						fd = undefined;
+						darwinCtimeRefreshConsumed = true;
+						const original = existing;
+						const refreshed = this.readExpected(relativePath);
+						if (
+							!refreshed ||
+							!sameStableIdentityIgnoringCtime(refreshed.identity, original.identity) ||
+							refreshed.identity.sha256 !== original.identity.sha256 ||
+							!refreshed.bytes.equals(original.bytes)
+						) {
+							throw new Error("identity_mismatch");
+						}
+						existing = refreshed;
+						continue;
+					}
+					secureFileDescriptor(resolved, fd, "verify");
+					let offset = 0;
+					while (offset < bytes.byteLength) offset += fs.writeSync(fd, bytes, offset, bytes.byteLength - offset);
+					fs.fsyncSync(fd);
+					secureFileDescriptor(resolved, fd, "verify");
+					const after = identity(fs.fstatSync(fd, { bigint: true }));
+					const named = identity(fs.lstatSync(resolved, { bigint: true }));
+					if (!sameIdentity(after, named) || after.dev !== before.dev || after.ino !== before.ino)
+						throw new Error("identity_mismatch");
+					break;
+				}
+			} finally {
+				if (fd !== undefined) fs.closeSync(fd);
+			}
+			this.#assertBound();
 		} finally {
-			if (fd !== undefined) fs.closeSync(fd);
+			auth?.close();
 		}
-		this.#assertBound();
 	}
 
 	#relative(resolved: string): string {
@@ -1933,18 +1939,6 @@ function validateDarwinReplacementResult(
 	return result;
 }
 
-function darwinIdentityPayload(identity: NativeDarwinReplacementIdentity | null): unknown {
-	if (!identity) return null;
-	return {
-		dev: identity.dev.toString(),
-		ino: identity.ino.toString(),
-		nlink: identity.nlink.toString(),
-		size: identity.size.toString(),
-		mtimeNs: identity.mtimeNs.toString(),
-		ctimeNs: identity.ctimeNs.toString(),
-		sha256: identity.sha256,
-	};
-}
 
 function darwinReceiptPath(context: ManagedDarwinReplacementContext, operationId: string, sequence: number): string {
 	return path.join(context.replacementDirectory, `.gjc-darwin-replacement-${operationId}-${sequence}.json`);
@@ -2041,17 +2035,6 @@ function appendDarwinReplacementReceipt(
 	fsyncDirectory(context.replacementDirectory);
 }
 
-function darwinExpectedIdentity(snapshot: ManagedFileSnapshot): NativeDarwinReplacementIdentity {
-	return {
-		dev: snapshot.identity.dev,
-		ino: snapshot.identity.ino,
-		nlink: snapshot.identity.nlink,
-		size: BigInt(snapshot.identity.size),
-		mtimeNs: snapshot.identity.mtimeNs,
-		ctimeNs: snapshot.identity.ctimeNs,
-		sha256: snapshot.identity.sha256,
-	};
-}
 /** Replace one managed regular file while retaining the secured staging fd through publication. */
 export function replaceManagedFileSync(
 	destination: string,
@@ -2067,6 +2050,7 @@ export function replaceManagedFileSync(
 	let fd: number | undefined;
 	let stagedIdentity: { dev: bigint; ino: bigint } | undefined;
 	let preserveStaging = false;
+	let darwinNoExpectedAuth: { close(): void } | undefined;
 	try {
 		fd = fs.openSync(
 			staging,
@@ -2295,8 +2279,13 @@ export function replaceManagedFileSync(
 					);
 				}
 			}
+		} else if (process.platform === "darwin") {
+			const context = createManagedDarwinReplacementContext(root, parent);
+			if (!context) throw new Error("managed_replace_exact_unavailable");
+			darwinNoExpectedAuth = openDarwinReplacementAuth(parent, context.lockName);
+			fs.renameSync(staging, destination);
 		} else fs.renameSync(staging, destination);
-		assertFence?.();
+		if (process.platform !== "darwin" || !expectedDestination) assertFence?.();
 		assertManagedDirectoryRoot(root);
 		const named = fs.lstatSync(destination, { bigint: true });
 		if (!named.isFile() || named.isSymbolicLink() || named.dev !== staged.dev || named.ino !== staged.ino) {
@@ -2310,6 +2299,7 @@ export function replaceManagedFileSync(
 		fsyncDirectory(parent);
 	} finally {
 		if (fd !== undefined) fs.closeSync(fd);
+		darwinNoExpectedAuth?.close();
 		if (stagedIdentity && !preserveStaging) {
 			try {
 				const named = fs.lstatSync(staging, { bigint: true });

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -1013,8 +1013,7 @@ export class ManagedSessionDescendantStore {
 		this.#beforeMutation();
 		this.#assertBound();
 		const resolved = this.#resolve(relativePath);
-		const context = createManagedDarwinReplacementContext(this.#root, path.dirname(resolved));
-		const auth = context ? openDarwinReplacementAuth(path.dirname(resolved), context.lockName) : undefined;
+		const auth = this.#openDarwinReplacementAuth(path.dirname(resolved));
 		try {
 			let existing = this.readExpected(relativePath);
 			if (!existing) throw new Error("managed_append_missing");
@@ -1085,6 +1084,10 @@ export class ManagedSessionDescendantStore {
 		}
 	}
 
+	#openDarwinReplacementAuth(directory: string): { close(): void } | undefined {
+		const context = createManagedDarwinReplacementContext(this.#root, directory);
+		return context ? openDarwinReplacementAuth(directory, context.lockName) : undefined;
+	}
 	#relative(resolved: string): string {
 		return path.relative(this.#authorityBaseDir, resolved).split(path.sep).join("/");
 	}
@@ -1228,27 +1231,33 @@ export class ManagedSessionDescendantStore {
 		this.#beforeMutation();
 		this.#assertBound();
 		if (!this.#authority) {
-			const removed = exactUnlink(this.#resolve(relativePath), {
-				dev: expected.identity.dev,
-				ino: expected.identity.ino,
-				size: BigInt(expected.identity.size),
-				mtimeNs: expected.identity.mtimeNs,
-				sha256: expected.identity.sha256,
-				quarantineName: `.gjc-remove-${process.pid}-${randomUUID()}`,
-			});
-			if (
-				!removed.ok &&
-				!(
-					removed.code === "cleanup_pending" &&
-					(removed.detachedPath ??
-						removed.retainedSuccessorPath ??
-						removed.retainedPlaceholderPath ??
-						removed.retainedUnknownPath) !== undefined
+			const resolved = this.#resolve(relativePath);
+			const auth = this.#openDarwinReplacementAuth(path.dirname(resolved));
+			try {
+				const removed = exactUnlink(resolved, {
+					dev: expected.identity.dev,
+					ino: expected.identity.ino,
+					size: BigInt(expected.identity.size),
+					mtimeNs: expected.identity.mtimeNs,
+					sha256: expected.identity.sha256,
+					quarantineName: `.gjc-remove-${process.pid}-${randomUUID()}`,
+				});
+				if (
+					!removed.ok &&
+					!(
+						removed.code === "cleanup_pending" &&
+						(removed.detachedPath ??
+							removed.retainedSuccessorPath ??
+							removed.retainedPlaceholderPath ??
+							removed.retainedUnknownPath) !== undefined
+					)
 				)
-			)
-				throw new Error(removed.code ?? "managed_remove_failed");
-			this.#assertBound();
-			return;
+					throw new Error(removed.code ?? "managed_remove_failed");
+				this.#assertBound();
+				return;
+			} finally {
+				auth?.close();
+			}
 		}
 		const removed = (this.#authority as RecoveryFsRoot & RetainedManagedReplacer).removeManaged(
 			this.#relative(this.#resolve(relativePath)),
@@ -1290,16 +1299,21 @@ export class ManagedSessionDescendantStore {
 			this.#assertBound();
 			return existing.data;
 		}
-		let snapshot: ManagedFileSnapshot;
+		const auth = this.#openDarwinReplacementAuth(path.dirname(resolved));
 		try {
-			snapshot = captureManagedFileNoFollow(resolved);
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
-			throw error;
+			let snapshot: ManagedFileSnapshot;
+			try {
+				snapshot = captureManagedFileNoFollow(resolved);
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+				throw error;
+			}
+			await unlinkManagedFileVerified(resolved, snapshot.identity);
+			this.#assertBound();
+			return snapshot.bytes;
+		} finally {
+			auth?.close();
 		}
-		await unlinkManagedFileVerified(resolved, snapshot.identity);
-		this.#assertBound();
-		return snapshot.bytes;
 	}
 
 	/** Remove one managed descendant through retained authority when it exists. */

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -10,6 +10,10 @@ import {
 	exactRestore,
 	exactUnlink,
 	linkNoReplacePath,
+	exchangeDarwinManagedFile,
+	type NativeDarwinReplacementIdentity,
+	type NativeDarwinReplacementResult,
+	openDarwinReplacementAuth,
 	type NativeDirectoryTreeSnapshot,
 	type NativeOwnerOnlySecurityResult,
 	openRecoveryFsRoot,
@@ -144,6 +148,7 @@ export type ManagedStorageFailure =
 	| "atomic_unavailable"
 	| "durability_not_provable"
 	| "migration_retired"
+	| "retention_bound_exceeded"
 	| "managed_storage_unsupported";
 
 export interface ManagedStorageLock {
@@ -330,6 +335,67 @@ export interface ManagedDirectoryRoot {
 	readonly canonicalPath: string;
 	readonly dev: bigint;
 	readonly ino: bigint;
+}
+/**
+ * Trusted Darwin replacement metadata. It contains no descriptor or pathname
+ * authority; every operation revalidates the bound directory before admission.
+ */
+export interface ManagedDarwinReplacementContext {
+	readonly rootPath: string;
+	readonly rootDev: bigint;
+	readonly rootIno: bigint;
+	readonly directoryPath: string;
+	readonly directoryDev: bigint;
+	readonly directoryIno: bigint;
+	readonly replacementDirectory: string;
+	readonly lockName: "darwin-replacement-admission.lock";
+}
+
+export function createManagedDarwinReplacementContext(
+	root: ManagedDirectoryRoot,
+	directory: string,
+): ManagedDarwinReplacementContext | undefined {
+	if (process.platform !== "darwin") return undefined;
+	assertManagedDirectoryRoot(root);
+	managedRelativePath(root, directory);
+	const resolved = path.resolve(directory);
+	const stat = fs.lstatSync(resolved, { bigint: true });
+	if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error("Managed replacement directory is unsafe");
+	return Object.freeze({
+		rootPath: root.canonicalPath,
+		rootDev: root.dev,
+		rootIno: root.ino,
+		directoryPath: resolved,
+		directoryDev: stat.dev,
+		directoryIno: stat.ino,
+		replacementDirectory: path.join(resolved, ".gjc-managed-session-internal", "replacements"),
+		lockName: "darwin-replacement-admission.lock" as const,
+	});
+}
+
+function deriveManagedDarwinReplacementContext(
+	context: ManagedDarwinReplacementContext | undefined,
+	root: ManagedDirectoryRoot,
+	directory: string,
+): ManagedDarwinReplacementContext | undefined {
+	if (!context || process.platform !== "darwin") return undefined;
+	if (
+		context.rootPath !== root.canonicalPath ||
+		context.rootDev !== root.dev ||
+		context.rootIno !== root.ino
+	)
+		throw new Error("Managed Darwin replacement root binding changed");
+	const resolved = path.resolve(directory);
+	managedRelativePath(root, resolved);
+	const stat = fs.lstatSync(resolved, { bigint: true });
+	if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error("Managed Darwin replacement directory is unsafe");
+	return Object.freeze({
+		...context,
+		directoryPath: resolved,
+		directoryDev: stat.dev,
+		directoryIno: stat.ino,
+		replacementDirectory: path.join(resolved, ".gjc-managed-session-internal", "replacements"),
+	});
 }
 
 /**
@@ -539,6 +605,7 @@ export class ManagedSessionDescendantStore {
 	/** Logical profile root inherited by nested managed session destinations. */
 	readonly #profileAgentDir: string;
 	readonly #subtreeRoot: ManagedDirectoryRoot;
+	readonly #darwinContext: ManagedDarwinReplacementContext | undefined;
 
 	constructor(
 		root: ManagedDirectoryRoot,
@@ -546,6 +613,7 @@ export class ManagedSessionDescendantStore {
 		retained?: { authority: RecoveryFsRoot; authorityBaseDir: string },
 		policy?: ManagedSessionSecurityPolicy,
 		profileAgentDir?: string,
+		darwinContext?: ManagedDarwinReplacementContext,
 	) {
 		managedRelativePath(root, baseDir);
 
@@ -565,6 +633,8 @@ export class ManagedSessionDescendantStore {
 				ino: BigInt(captured.snapshot.rootIno),
 			});
 			this.#authority = retained.authority;
+			this.#darwinContext = deriveManagedDarwinReplacementContext(darwinContext, root, this.#baseDir);
+			if (darwinContext && !this.#darwinContext) throw new Error("Managed Darwin replacement authority unavailable");
 			this.#assertBound();
 
 			return;
@@ -573,6 +643,8 @@ export class ManagedSessionDescendantStore {
 		ensureManagedDirectory(this.#baseDir, root, this.#policy);
 		const subtreeStat = fs.lstatSync(this.#baseDir, { bigint: true });
 		this.#subtreeRoot = Object.freeze({ canonicalPath: this.#baseDir, dev: subtreeStat.dev, ino: subtreeStat.ino });
+		this.#darwinContext = deriveManagedDarwinReplacementContext(darwinContext, root, this.#baseDir);
+		if (darwinContext && !this.#darwinContext) throw new Error("Managed Darwin replacement authority unavailable");
 		if (process.platform === "linux") {
 			const before = fs.lstatSync(this.#baseDir, { bigint: true });
 			const authority = openRecoveryFsRoot(this.#baseDir);
@@ -610,12 +682,38 @@ export class ManagedSessionDescendantStore {
 	get profileAgentDir(): string {
 		return this.#profileAgentDir;
 	}
+	get darwinReplacementContext(): ManagedDarwinReplacementContext | undefined {
+		return this.#darwinContext;
+	}
+
+	/**
+	 * Derive a fresh context for a trusted child directory. The child identity is
+	 * captured here, never inferred from a caller pathname.
+	 */
+	deriveDarwinReplacementContext(directory: string): ManagedDarwinReplacementContext | undefined {
+		this.#assertBound();
+		const resolved = path.resolve(directory);
+		if (resolved !== this.#baseDir && !resolved.startsWith(`${this.#baseDir}${path.sep}`)) {
+			throw new Error("Managed Darwin replacement child escaped retained store");
+		}
+		const relative = path.relative(this.#baseDir, resolved);
+		const child = this.ensureDirectory(relative);
+		if (!this.#darwinContext) return undefined;
+		return deriveManagedDarwinReplacementContext(this.#darwinContext, this.#root, child.canonicalPath);
+	}
 
 	deriveSubtree(relativePath: string): ManagedSessionDescendantStore {
 		const child = this.ensureDirectory(relativePath);
 		const resolved = this.#resolve(relativePath);
 		if (!this.#authority)
-			return new ManagedSessionDescendantStore(this.#root, resolved, undefined, this.#policy, this.#profileAgentDir);
+			return new ManagedSessionDescendantStore(
+				this.#root,
+				resolved,
+				undefined,
+				this.#policy,
+				this.#profileAgentDir,
+				deriveManagedDarwinReplacementContext(this.#darwinContext, this.#root, resolved),
+			);
 		const retainedChild = this.#authority.retainManagedDirectory(
 			this.#relative(resolved),
 			child.dev.toString(),
@@ -630,6 +728,7 @@ export class ManagedSessionDescendantStore {
 			},
 			this.#policy,
 			this.#profileAgentDir,
+			deriveManagedDarwinReplacementContext(this.#darwinContext, this.#root, resolved),
 		);
 	}
 
@@ -1728,6 +1827,231 @@ export function publishManagedFileNoReplaceSync(
 	if (failure !== undefined) throw failure;
 }
 
+type DarwinReplacementReceiptState =
+	| "reserved"
+	| "prepared"
+	| "swap_intent"
+	| "retained_predecessor"
+	| "committed_durable"
+	| "committed_unproven"
+	| "abandoned";
+
+type DarwinReplacementReceipt = {
+	version: 1;
+	sequence: number;
+	operationId: string;
+	state: DarwinReplacementReceiptState;
+	parentDev: string;
+	parentIno: string;
+	sourceName: string;
+	destinationName: string;
+	source: NativeDarwinReplacementIdentity | null;
+	destination: NativeDarwinReplacementIdentity | null;
+	result: {
+		state: string;
+		code: string | null;
+		phase: string;
+		reason: string;
+		parentFsync: boolean;
+	};
+};
+
+const DARWIN_RECEIPT_STATES = new Set<DarwinReplacementReceiptState>([
+	"reserved",
+	"prepared",
+	"swap_intent",
+	"retained_predecessor",
+	"committed_durable",
+	"committed_unproven",
+	"abandoned",
+]);
+
+function isDarwinIdentity(value: unknown): value is NativeDarwinReplacementIdentity {
+	if (!value || typeof value !== "object") return false;
+	const record = value as Record<string, unknown>;
+	return (
+		Object.keys(record).length === 7 &&
+		typeof record.dev === "bigint" &&
+		typeof record.ino === "bigint" &&
+		typeof record.nlink === "bigint" &&
+		typeof record.size === "bigint" &&
+		typeof record.mtimeNs === "bigint" &&
+		typeof record.ctimeNs === "bigint" &&
+		typeof record.sha256 === "string" &&
+		/^[0-9a-f]{64}$/.test(record.sha256)
+	);
+}
+
+function validateDarwinReplacementResult(
+	value: unknown,
+	operationId: string,
+): NativeDarwinReplacementResult {
+	const malformed = (): NativeDarwinReplacementResult => ({
+		ok: false,
+		state: "committed_unproven",
+		code: "malformed_native_result",
+		phase: "validation",
+		reason: "native_result_contract_unknown",
+		parentFsync: false,
+		operationId,
+	});
+	if (!value || typeof value !== "object") return malformed();
+	const record = value as Record<string, unknown>;
+	if (
+		Object.keys(record).some(
+			key =>
+				![
+					"ok",
+					"state",
+					"code",
+					"phase",
+					"reason",
+					"parentFsync",
+					"source",
+					"destination",
+					"operationId",
+				].includes(key),
+		) ||
+		typeof record.ok !== "boolean" ||
+		(typeof record.state !== "string" ||
+			!["not_committed", "committed_durable", "committed_unproven"].includes(record.state)) ||
+		(record.code !== undefined && record.code !== null && typeof record.code !== "string") ||
+		typeof record.phase !== "string" ||
+		typeof record.reason !== "string" ||
+		typeof record.parentFsync !== "boolean" ||
+		(record.source !== undefined && record.source !== null && !isDarwinIdentity(record.source)) ||
+		(record.destination !== undefined && record.destination !== null && !isDarwinIdentity(record.destination)) ||
+		record.operationId !== operationId
+	) {
+		return malformed();
+	}
+	const result = value as NativeDarwinReplacementResult;
+	if (result.state === "committed_durable" && (!result.ok || result.parentFsync !== true || !result.source || !result.destination)) {
+		return malformed();
+	}
+	if (result.ok && result.state !== "committed_durable") return malformed();
+	return result;
+}
+
+function darwinIdentityPayload(identity: NativeDarwinReplacementIdentity | null): unknown {
+	if (!identity) return null;
+	return {
+		dev: identity.dev.toString(),
+		ino: identity.ino.toString(),
+		nlink: identity.nlink.toString(),
+		size: identity.size.toString(),
+		mtimeNs: identity.mtimeNs.toString(),
+		ctimeNs: identity.ctimeNs.toString(),
+		sha256: identity.sha256,
+	};
+}
+
+function darwinReceiptPath(context: ManagedDarwinReplacementContext, operationId: string, sequence: number): string {
+	return path.join(context.replacementDirectory, `.gjc-darwin-replacement-${operationId}-${sequence}.json`);
+}
+
+function parseDarwinReceipt(pathname: string): DarwinReplacementReceipt {
+	const parsed: unknown = JSON.parse(fs.readFileSync(pathname, "utf8"));
+	if (!parsed || typeof parsed !== "object") throw new Error("managed_replace_receipt_invalid");
+	const record = parsed as Record<string, unknown>;
+	if (
+		Object.keys(record).length !== 11 ||
+		record.version !== 1 ||
+		typeof record.sequence !== "number" ||
+		!Number.isSafeInteger(record.sequence) ||
+		typeof record.operationId !== "string" ||
+		!DARWIN_RECEIPT_STATES.has(record.state as DarwinReplacementReceiptState) ||
+		typeof record.parentDev !== "string" ||
+		typeof record.parentIno !== "string" ||
+		typeof record.sourceName !== "string" ||
+		typeof record.destinationName !== "string" ||
+		(record.source !== null && !isDarwinReceiptIdentity(record.source)) ||
+		(record.destination !== null && !isDarwinReceiptIdentity(record.destination)) ||
+		!record.result ||
+		typeof record.result !== "object"
+	)
+		throw new Error("managed_replace_receipt_invalid");
+	const result = record.result as Record<string, unknown>;
+	if (
+		Object.keys(result).length !== 5 ||
+		typeof result.state !== "string" ||
+		(result.code !== null && typeof result.code !== "string") ||
+		typeof result.phase !== "string" ||
+		typeof result.reason !== "string" ||
+		typeof result.parentFsync !== "boolean"
+	)
+		throw new Error("managed_replace_receipt_invalid");
+	return record as unknown as DarwinReplacementReceipt;
+}
+
+function isDarwinReceiptIdentity(value: unknown): boolean {
+	if (!value || typeof value !== "object") return false;
+	const record = value as Record<string, unknown>;
+	return (
+		Object.keys(record).length === 7 &&
+		typeof record.dev === "string" &&
+		/^(0|[1-9][0-9]*)$/.test(record.dev) &&
+		typeof record.ino === "string" &&
+		/^(0|[1-9][0-9]*)$/.test(record.ino) &&
+		typeof record.nlink === "string" &&
+		/^(0|[1-9][0-9]*)$/.test(record.nlink) &&
+		typeof record.size === "string" &&
+		/^(0|[1-9][0-9]*)$/.test(record.size) &&
+		typeof record.mtimeNs === "string" &&
+		/^(0|[1-9][0-9]*)$/.test(record.mtimeNs) &&
+		typeof record.ctimeNs === "string" &&
+		/^(0|[1-9][0-9]*)$/.test(record.ctimeNs) &&
+		typeof record.sha256 === "string" &&
+		/^[0-9a-f]{64}$/.test(record.sha256)
+	);
+}
+
+function validateDarwinReplacementReceipts(context: ManagedDarwinReplacementContext): string[] {
+	if (!fs.existsSync(context.replacementDirectory)) return [];
+	const paths = fs
+		.readdirSync(context.replacementDirectory)
+		.filter(name => name.startsWith(".gjc-darwin-replacement-") && name.endsWith(".json"))
+		.map(name => path.join(context.replacementDirectory, name));
+	for (const receiptPath of paths) parseDarwinReceipt(receiptPath);
+	return paths;
+}
+
+function appendDarwinReplacementReceipt(
+	context: ManagedDarwinReplacementContext,
+	root: ManagedDirectoryRoot,
+	policy: ManagedSessionSecurityPolicy,
+	receipt: Omit<DarwinReplacementReceipt, "version" | "sequence">,
+): void {
+	ensureManagedDirectory(context.replacementDirectory, root, policy);
+	const existing = validateDarwinReplacementReceipts(context);
+	const record: DarwinReplacementReceipt = {
+		version: 1,
+		sequence: existing.length + 1,
+		...receipt,
+	};
+	const receiptPath = darwinReceiptPath(context, receipt.operationId, record.sequence);
+	publishManagedFileNoReplaceSync(
+		receiptPath,
+		Buffer.from(
+			`${JSON.stringify(record, (_key, value: unknown) => (typeof value === "bigint" ? value.toString() : value))}\n`,
+		),
+		root,
+		policy,
+	);
+	fsyncDirectory(context.replacementDirectory);
+}
+
+function darwinExpectedIdentity(snapshot: ManagedFileSnapshot): NativeDarwinReplacementIdentity {
+	return {
+		dev: snapshot.identity.dev,
+		ino: snapshot.identity.ino,
+		nlink: snapshot.identity.nlink,
+		size: BigInt(snapshot.identity.size),
+		mtimeNs: snapshot.identity.mtimeNs,
+		ctimeNs: snapshot.identity.ctimeNs,
+		sha256: snapshot.identity.sha256,
+	};
+}
 /** Replace one managed regular file while retaining the secured staging fd through publication. */
 export function replaceManagedFileSync(
 	destination: string,
@@ -1756,16 +2080,116 @@ export function replaceManagedFileSync(
 		secureFileDescriptor(staging, fd, "verify");
 		const staged = fs.fstatSync(fd, { bigint: true });
 		stagedIdentity = { dev: staged.dev, ino: staged.ino };
-		if (process.platform === "win32" && expectedDestination) {
+		if ((process.platform === "win32" || process.platform === "darwin") && expectedDestination) {
 			fs.closeSync(fd);
 			fd = undefined;
 		}
 		assertManagedDirectoryRoot(root);
 		assertFence?.();
-		if (process.platform !== "win32" && expectedDestination) {
+		if (process.platform !== "win32" && process.platform !== "darwin" && expectedDestination) {
 			throw new Error("managed_replace_exact_unavailable");
 		}
-		if (process.platform === "win32" && expectedDestination) {
+		if (process.platform === "darwin" && expectedDestination) {
+			const context = createManagedDarwinReplacementContext(root, parent);
+			if (!context) throw new Error("managed_replace_exact_unavailable");
+			const operationId = randomUUID();
+			const parentIdentity = fs.lstatSync(parent, { bigint: true });
+			const sourceName = path.basename(staging);
+			const destinationName = path.basename(destination);
+			const source: NativeDarwinReplacementIdentity = {
+				dev: staged.dev,
+				ino: staged.ino,
+				nlink: staged.nlink,
+				size: staged.size,
+				mtimeNs: staged.mtimeNs,
+				ctimeNs: staged.ctimeNs,
+				sha256: createHash("sha256").update(bytes).digest("hex"),
+			};
+			const target: NativeDarwinReplacementIdentity = {
+				dev: expectedDestination.dev,
+				ino: expectedDestination.ino,
+				nlink: expectedDestination.nlink,
+				size: BigInt(expectedDestination.size),
+				mtimeNs: expectedDestination.mtimeNs,
+				ctimeNs: expectedDestination.ctimeNs,
+				sha256: expectedDestination.sha256,
+			};
+			const appendReceipt = (
+				state: DarwinReplacementReceiptState,
+				result: DarwinReplacementReceipt["result"],
+			): void =>
+				appendDarwinReplacementReceipt(context, root, policy, {
+					operationId,
+					state,
+					parentDev: parentIdentity.dev.toString(),
+					parentIno: parentIdentity.ino.toString(),
+					sourceName,
+					destinationName,
+					source,
+					destination: target,
+					result,
+				});
+			appendReceipt("reserved", {
+				state: "not_committed",
+				code: null,
+				phase: "reservation",
+				reason: "none",
+				parentFsync: false,
+			});
+			appendReceipt("prepared", {
+				state: "not_committed",
+				code: null,
+				phase: "staging",
+				reason: "none",
+				parentFsync: false,
+			});
+			appendReceipt("swap_intent", {
+				state: "committed_unproven",
+				code: null,
+				phase: "exchange",
+				reason: "pending",
+				parentFsync: false,
+			});
+			const auth = openDarwinReplacementAuth(parent, context.lockName);
+			let result: NativeDarwinReplacementResult;
+			try {
+				result = validateDarwinReplacementResult(
+					exchangeDarwinManagedFile(
+						auth,
+						parent,
+						parentIdentity.dev,
+						parentIdentity.ino,
+						sourceName,
+						destinationName,
+						source,
+						target,
+						operationId,
+					),
+					operationId,
+				);
+			} finally {
+				auth.close();
+			}
+			appendReceipt(result.state === "committed_durable" ? "committed_durable" : "committed_unproven", {
+				state: result.state,
+				code: result.code ?? null,
+				phase: result.phase,
+				reason: result.reason,
+				parentFsync: result.parentFsync,
+			});
+			if (result.state !== "committed_durable") {
+				preserveStaging = true;
+				throw new Error(`managed_replace_${result.state}:${result.code ?? result.reason}`);
+			}
+			appendReceipt("retained_predecessor", {
+				state: result.state,
+				code: null,
+				phase: "retained_predecessor",
+				reason: "none",
+				parentFsync: result.parentFsync,
+			});
+			preserveStaging = true;
+		} else if (process.platform === "win32" && expectedDestination) {
 			const parentIdentity = fs.lstatSync(parent, { bigint: true });
 			const replaced = exactReplacePath(
 				staging,

--- a/packages/coding-agent/test/darwin-managed-replace.test.ts
+++ b/packages/coding-agent/test/darwin-managed-replace.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { openDarwinReplacementAuth } from "@gajae-code/natives";
 import {
 	ManagedSessionDescendantStore,
 	prepareManagedDirectoryRoot,
@@ -33,5 +34,22 @@ describe("Darwin managed replacement", () => {
 			.filter(entry => entry.startsWith(".session.jsonl.") && entry.endsWith(".replacement"));
 		expect(predecessors).toHaveLength(1);
 		expect(fs.readFileSync(path.join(root.canonicalPath, predecessors[0]), "utf8")).toBe("before\n");
+	});
+	it("rejects append while the Darwin replacement admission is held", () => {
+		if (process.platform !== "darwin") return;
+		const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-darwin-managed-append-"));
+		tempDirectories.push(temporaryDirectory);
+		const root = prepareManagedDirectoryRoot(temporaryDirectory);
+		const store = new ManagedSessionDescendantStore(root, root.canonicalPath);
+		const transcript = path.join(root.canonicalPath, "session.jsonl");
+		store.publishNoReplaceSync("session.jsonl", Buffer.from("before\n"));
+
+		const auth = openDarwinReplacementAuth(root.canonicalPath, "darwin-replacement-admission.lock");
+		try {
+			expect(() => store.appendSync("session.jsonl", Buffer.from("append\n"))).toThrow("migration_busy");
+			expect(fs.readFileSync(transcript, "utf8")).toBe("before\n");
+		} finally {
+			auth.close();
+		}
 	});
 });

--- a/packages/coding-agent/test/darwin-managed-replace.test.ts
+++ b/packages/coding-agent/test/darwin-managed-replace.test.ts
@@ -3,9 +3,8 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
-	captureManagedFileNoFollow,
+	ManagedSessionDescendantStore,
 	prepareManagedDirectoryRoot,
-	replaceManagedFileSync,
 } from "../src/session/internal/managed-session-storage";
 
 const tempDirectories: string[] = [];
@@ -20,17 +19,13 @@ describe("Darwin managed replacement", () => {
 		const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-darwin-managed-replace-"));
 		tempDirectories.push(temporaryDirectory);
 		const root = prepareManagedDirectoryRoot(temporaryDirectory);
+		const store = new ManagedSessionDescendantStore(root, root.canonicalPath);
 		const transcript = path.join(root.canonicalPath, "session.jsonl");
-		fs.writeFileSync(transcript, "before\n", { mode: 0o600 });
+		store.publishNoReplaceSync("session.jsonl", Buffer.from("before\n"));
+		const expected = store.readExpected("session.jsonl");
+		if (!expected) throw new Error("managed transcript was not published");
 
-		replaceManagedFileSync(
-			transcript,
-			Buffer.from("after\n"),
-			root,
-			"default",
-			undefined,
-			captureManagedFileNoFollow(transcript).identity,
-		);
+		store.replaceExpected("session.jsonl", Buffer.from("after\n"), expected);
 
 		expect(fs.readFileSync(transcript, "utf8")).toBe("after\n");
 		const predecessors = fs

--- a/packages/coding-agent/test/darwin-managed-replace.test.ts
+++ b/packages/coding-agent/test/darwin-managed-replace.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	captureManagedFileNoFollow,
+	prepareManagedDirectoryRoot,
+	replaceManagedFileSync,
+} from "../src/session/internal/managed-session-storage";
+
+const tempDirectories: string[] = [];
+
+afterEach(() => {
+	for (const directory of tempDirectories.splice(0)) fs.rmSync(directory, { recursive: true, force: true });
+});
+
+describe("Darwin managed replacement", () => {
+	it("atomically replaces an existing managed transcript while retaining its predecessor", () => {
+		if (process.platform !== "darwin") return;
+		const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-darwin-managed-replace-"));
+		tempDirectories.push(temporaryDirectory);
+		const root = prepareManagedDirectoryRoot(temporaryDirectory);
+		const transcript = path.join(root.canonicalPath, "session.jsonl");
+		fs.writeFileSync(transcript, "before\n", { mode: 0o600 });
+
+		replaceManagedFileSync(
+			transcript,
+			Buffer.from("after\n"),
+			root,
+			"default",
+			undefined,
+			captureManagedFileNoFollow(transcript).identity,
+		);
+
+		expect(fs.readFileSync(transcript, "utf8")).toBe("after\n");
+		expect(
+			fs.readdirSync(root.canonicalPath).some(entry => entry.includes(".replacement")),
+		).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/darwin-managed-replace.test.ts
+++ b/packages/coding-agent/test/darwin-managed-replace.test.ts
@@ -33,8 +33,10 @@ describe("Darwin managed replacement", () => {
 		);
 
 		expect(fs.readFileSync(transcript, "utf8")).toBe("after\n");
-		expect(
-			fs.readdirSync(root.canonicalPath).some(entry => entry.includes(".replacement")),
-		).toBe(true);
+		const predecessors = fs
+			.readdirSync(root.canonicalPath)
+			.filter(entry => entry.startsWith(".session.jsonl.") && entry.endsWith(".replacement"));
+		expect(predecessors).toHaveLength(1);
+		expect(fs.readFileSync(path.join(root.canonicalPath, predecessors[0]), "utf8")).toBe("before\n");
 	});
 });

--- a/packages/coding-agent/test/darwin-managed-replace.test.ts
+++ b/packages/coding-agent/test/darwin-managed-replace.test.ts
@@ -52,4 +52,23 @@ describe("Darwin managed replacement", () => {
 			auth.close();
 		}
 	});
+	it("rejects removal while the Darwin replacement admission is held", () => {
+		if (process.platform !== "darwin") return;
+		const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-darwin-managed-remove-"));
+		tempDirectories.push(temporaryDirectory);
+		const root = prepareManagedDirectoryRoot(temporaryDirectory);
+		const store = new ManagedSessionDescendantStore(root, root.canonicalPath);
+		const transcript = path.join(root.canonicalPath, "session.jsonl");
+		store.publishNoReplaceSync("session.jsonl", Buffer.from("before\n"));
+		const expected = store.readExpected("session.jsonl");
+		if (!expected) throw new Error("managed transcript was not published");
+
+		const auth = openDarwinReplacementAuth(root.canonicalPath, "darwin-replacement-admission.lock");
+		try {
+			expect(() => store.removeExpected("session.jsonl", expected)).toThrow("migration_busy");
+			expect(fs.readFileSync(transcript, "utf8")).toBe("before\n");
+		} finally {
+			auth.close();
+		}
+	});
 });

--- a/packages/coding-agent/test/darwin-managed-replace.test.ts
+++ b/packages/coding-agent/test/darwin-managed-replace.test.ts
@@ -15,7 +15,7 @@ afterEach(() => {
 });
 
 describe("Darwin managed replacement", () => {
-	it("atomically replaces an existing managed transcript while retaining its predecessor", () => {
+	it("atomically replaces an existing managed transcript without retaining predecessor artifacts", () => {
 		if (process.platform !== "darwin") return;
 		const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-darwin-managed-replace-"));
 		tempDirectories.push(temporaryDirectory);
@@ -29,11 +29,16 @@ describe("Darwin managed replacement", () => {
 		store.replaceExpected("session.jsonl", Buffer.from("after\n"), expected);
 
 		expect(fs.readFileSync(transcript, "utf8")).toBe("after\n");
-		const predecessors = fs
-			.readdirSync(root.canonicalPath)
-			.filter(entry => entry.startsWith(".session.jsonl.") && entry.endsWith(".replacement"));
-		expect(predecessors).toHaveLength(1);
-		expect(fs.readFileSync(path.join(root.canonicalPath, predecessors[0]), "utf8")).toBe("before\n");
+		expect(
+			fs
+				.readdirSync(root.canonicalPath)
+				.some(
+					entry =>
+						entry.includes(".replacement") ||
+						entry.startsWith(".gjc-darwin-replacement-") ||
+						entry === ".gjc-managed-session-internal",
+				),
+		).toBe(false);
 	});
 	it("rejects append while the Darwin replacement admission is held", () => {
 		if (process.platform !== "darwin") return;

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added Darwin native replacement admission and exact-exchange APIs for descriptor-bound managed-session transcript rewrites.
+
+### Changed
 
 ### Fixed
 

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -21,6 +21,15 @@ export declare class ComputerController {
 }
 
 /**
+ * Darwin-only persistent kernel replacement admission. The descriptor is opaque
+ * to JavaScript and remains held until `close` or process teardown.
+ */
+export declare class DarwinReplacementAuth {
+  close(): void
+  isHeld(): boolean
+}
+
+/**
  * Long-lived macOS appearance observer.
  *
  * Subscribes to `AppleInterfaceThemeChangedNotification` via
@@ -870,6 +879,12 @@ export declare function exactRestore(detachedPath: string, originalPath: string,
 export declare function exactUnlink(path: string, identity: NativeExactFileIdentity): NativeExactUnlinkResult
 
 /**
+ * Execute one authenticated Darwin exact exchange. The native side owns the
+ * final admission check and invokes `renameatx_np` exactly once.
+ */
+export declare function exchangeDarwinManagedFile(auth: DarwinReplacementAuth, parentPath: string, parentDev: bigint, parentIno: bigint, sourceName: string, destinationName: string, expectedSource: NativeDarwinReplacementIdentity, expectedDestination: NativeDarwinReplacementIdentity, operationId: string): NativeDarwinReplacementResult
+
+/**
  * Execute a brush shell command.
  *
  * Creates a fresh session for each call. The `on_chunk` callback receives
@@ -1685,6 +1700,30 @@ export type NativeCanonicalDirectoryIdentity =
 			code: "not_found" | "not_directory" | "not_utf8" | "network_unsupported" | "identity_unavailable" | "io_error";
 	  }
 
+/** Full regular-file identity used by the Darwin managed replacement exchange. */
+export interface NativeDarwinReplacementIdentity {
+  dev: bigint
+  ino: bigint
+  nlink: bigint
+  size: bigint
+  mtimeNs: bigint
+  ctimeNs: bigint
+  sha256: string
+}
+
+/** Closed result returned by the Darwin descriptor-bound replacement exchange. */
+export interface NativeDarwinReplacementResult {
+  ok: boolean
+  state: string
+  code?: string
+  phase: string
+  reason: string
+  parentFsync: boolean
+  source?: NativeDarwinReplacementIdentity
+  destination?: NativeDarwinReplacementIdentity
+  operationId: string
+}
+
 export interface NativeDirectoryParentIdentity {
   dev: bigint
   ino: bigint
@@ -1895,6 +1934,12 @@ export interface NotificationEndpoint {
   /** The session id this endpoint serves. */
   sessionId: string
 }
+
+/**
+ * Open the fixed owner-only Darwin replacement lock and retain its kernel
+ * authorization until the returned opaque object is closed or dropped.
+ */
+export declare function openDarwinReplacementAuth(parentPath: string, lockName: string): DarwinReplacementAuth
 
 /**
  * Acquire an immutable trusted-root descriptor. Linux is required; every

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -21,8 +21,8 @@ export declare class ComputerController {
 }
 
 /**
- * Darwin-only persistent kernel replacement admission. The descriptor is opaque
- * to JavaScript and remains held until `close` or process teardown.
+ * Darwin-only persistent kernel replacement admission. The descriptor is
+ * opaque to JavaScript and remains held until `close` or process teardown.
  */
 export declare class DarwinReplacementAuth {
   close(): void

--- a/packages/natives/native/index.js
+++ b/packages/natives/native/index.js
@@ -18,6 +18,7 @@ nativeBindings.initNativeCrashDiagnostics?.();
 // --- generated native exports (do not edit) ---
 // classes
 export const ComputerController = nativeBindings.ComputerController;
+export const DarwinReplacementAuth = nativeBindings.DarwinReplacementAuth;
 export const MacAppearanceObserver = nativeBindings.MacAppearanceObserver;
 export const MacOSPowerAssertion = nativeBindings.MacOSPowerAssertion;
 export const NativeRetainedBrokerPublication = nativeBindings.NativeRetainedBrokerPublication;
@@ -46,6 +47,7 @@ export const exactRemoveDirectoryTree = nativeBindings.exactRemoveDirectoryTree;
 export const exactReplacePath = nativeBindings.exactReplacePath;
 export const exactRestore = nativeBindings.exactRestore;
 export const exactUnlink = nativeBindings.exactUnlink;
+export const exchangeDarwinManagedFile = nativeBindings.exchangeDarwinManagedFile;
 export const executeShell = nativeBindings.executeShell;
 export const extractSegments = nativeBindings.extractSegments;
 export const fuzzyFind = nativeBindings.fuzzyFind;
@@ -74,6 +76,7 @@ export const matchesKey = nativeBindings.matchesKey;
 export const matchesKittySequence = nativeBindings.matchesKittySequence;
 export const matchesLegacySequence = nativeBindings.matchesLegacySequence;
 export const nativeBuildInfo = nativeBindings.nativeBuildInfo;
+export const openDarwinReplacementAuth = nativeBindings.openDarwinReplacementAuth;
 export const openRecoveryFsRoot = nativeBindings.openRecoveryFsRoot;
 export const parseKey = nativeBindings.parseKey;
 export const parseKittySequence = nativeBindings.parseKittySequence;

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -418,6 +418,18 @@ export function validateLoadedBindings(ctx, bindings, candidate) {
 	if (typeof bindings.renameNoReplacePath !== "function") {
 		throw new Error(`Loaded ${candidate} but it lacks required atomic publish capability \`renameNoReplacePath\`.`);
 	}
+	if (ctx.platformTag.startsWith("darwin-")) {
+		const darwinCapabilities = [
+			["DarwinReplacementAuth", bindings.DarwinReplacementAuth],
+			["openDarwinReplacementAuth", bindings.openDarwinReplacementAuth],
+			["exchangeDarwinManagedFile", bindings.exchangeDarwinManagedFile],
+		];
+		for (const [name, capability] of darwinCapabilities) {
+			if (typeof capability !== "function") {
+				throw new Error(`Loaded ${candidate} but it lacks required Darwin replacement capability \`${name}\`.`);
+			}
+		}
+	}
 	if (typeof bindings.probeWindowsJobMemory !== "function") {
 		throw new Error(`Loaded ${candidate} but it lacks required memory probe capability \`probeWindowsJobMemory\`.`);
 	}

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -418,7 +418,7 @@ export function validateLoadedBindings(ctx, bindings, candidate) {
 	if (typeof bindings.renameNoReplacePath !== "function") {
 		throw new Error(`Loaded ${candidate} but it lacks required atomic publish capability \`renameNoReplacePath\`.`);
 	}
-	if (ctx.platformTag.startsWith("darwin-")) {
+	if (ctx.platformTag?.startsWith("darwin-")) {
 		const darwinCapabilities = [
 			["DarwinReplacementAuth", bindings.DarwinReplacementAuth],
 			["openDarwinReplacementAuth", bindings.openDarwinReplacementAuth],


### PR DESCRIPTION
## Summary
- remove persisted Darwin replacement receipts and predecessor retention
- unlink the authenticated, verified predecessor before parent durability sync
- complete macOS-only native lint requirements
- cover artifact-free Darwin transcript replacement

## Verification
- Rust scope check passed:
- crates/pi-natives: N-API addon boundary for native, CPU-bound, blocking I/O, and OS integration primitives.
- crates/pi-shell: Embedded shell, PTY, and process-management runtime used behind native bindings.
- crates/pi-ast: Tree-sitter parsing and summarization hot paths shared by native code.
- crates/pi-iso: Native filesystem isolation backends such as clone, reflink, overlay, and ProjFS.
- crates/gjc-sdk: Gajae-Code SDK Rust core for loopback WebSocket transport, endpoint discovery, and planned N-API integration.
- crates/brush-core-vendored: Vendored Rust shell runtime dependency for the native shell boundary.
- crates/brush-builtins-vendored: Vendored Rust shell builtin dependency for the native shell boundary.
- 1 non-crate Rust fixture(s) allowed for tests only.
- Building pi-natives for darwin-arm64 (ci)…
Normalizing native addon filename: pi_natives.darwin-arm64.node → pi_natives.darwin-arm64.node
Generated 89 explicit ESM exports in index.js, fixed 9 const enums in index.d.ts
Build complete.
- Checked 2509 files in 1961ms. No fixes applied.
- bun test v1.3.14 (0d9b296a)
- bun test v1.3.14 (0d9b296a)