### PR TITLE
fix(sdk): classify startup turn barrier inventory

### DIFF
--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -66,6 +66,8 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 	"agent_session:closeWriterStrict": "internal ACP lifecycle teardown plumbing, not a user-facing control seam",
 	"agent_session:disposeChildSubprocesses": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:waitForIdle": "internal accessor/plumbing, not a user-facing control seam",
+	"agent_session:extendStartupTurnBarrier":
+		"internal CLI startup-readiness fence composition, not a user-facing SDK control seam",
 	"agent_session:awaitPendingContextTransformations":
 		"internal context-transformation lifecycle barrier, not a user-facing SDK control seam",
 	"agent_session:drainAsyncJobDeliveriesForAcp": "internal accessor/plumbing, not a user-facing control seam",

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -2330,6 +2330,17 @@
 		}
 	},
 	{
+		"sourceId": "agent_session:extendStartupTurnBarrier",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "internal CLI startup-readiness fence composition, not a user-facing SDK control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
 		"sourceId": "agent_session:constructor",
 		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
 		"sourceKind": "agent_session",


### PR DESCRIPTION
## Summary
- classify `agent_session:extendStartupTurnBarrier` as an internal CLI startup-readiness fence
- regenerate the committed SDK operation inventory with pending review count restored to zero
- repair post-merge Dev CI run 30850158219 from #3794 without changing startup, MCP, profile, or session behavior

## Root cause
PR #3794 added `AgentSession.extendStartupTurnBarrier()` for CLI-hosted deferred model-profile readiness. The fail-closed SDK inventory scanner correctly discovered the new public class method, but the generator classification table and committed matrix were not updated. The seam is not a public SDK protocol operation; its sole production caller composes CLI startup barriers in `main.ts`.

## Verification
- `bun test packages/coding-agent/test/sdk-operation-inventory.test.ts packages/coding-agent/test/sdk-operation-matrix.test.ts` — 21 pass
- `bun packages/coding-agent/scripts/generate-sdk-operation-inventory.ts --check`
- Biome on the generator and generated inventory
- `git diff --check`

`check:sdk-closure` was also attempted and reached an unrelated pre-existing Telegram daemon semantic-manifest drift gate on the exact dev base; this PR does not alter those files.

Signed: **GJC — Dev CI 30850158219 SDK inventory repair owner, 2026-08-03**