### PR TITLE
test(slack): synchronize reconnect redelivery acceptance

### DIFF
--- a/packages/coding-agent/test/sdk-slack-daemon.test.ts
+++ b/packages/coding-agent/test/sdk-slack-daemon.test.ts
@@ -1073,12 +1073,14 @@ describe("SlackNotificationDaemon fake-provider acceptance", () => {
 			const root = await daemon.postRoot("session", "root");
 			await daemon.notify("session", "question", "event-1");
 			await daemon.start();
-			fake.handler?.(messageEnvelope("first", "event-1", root.rootTs!));
-			for (let attempt = 0; attempt < 100 && injected.length === 0; attempt++) await Bun.sleep(1);
+			const firstHandler = fake.handler;
+			expect(firstHandler).toBeDefined();
+			await firstHandler!(messageEnvelope("first", "event-1", root.rootTs!));
 			await daemon.stop();
 			await daemon.start();
-			fake.handler?.(messageEnvelope("redelivery", "event-1", root.rootTs!));
-			for (let attempt = 0; attempt < 100 && !fake.acks.includes("redelivery"); attempt++) await Bun.sleep(1);
+			const redeliveryHandler = fake.handler;
+			expect(redeliveryHandler).toBeDefined();
+			await redeliveryHandler!(messageEnvelope("redelivery", "event-1", root.rootTs!));
 			expect(fake.acks).toEqual(["first", "redelivery"]);
 			expect(injected).toHaveLength(1);
 			expect(fake.stops).toBe(1);


### PR DESCRIPTION
## Summary

- Fixes the post-merge Dev CI blocker surfaced by #3789 / run 30861920383.
- Replaces timing-sensitive 100ms polling with explicit fake-handler readiness checks and awaited handler completion.
- Keeps the production Slack lifecycle unchanged.

## Evidence

- Current-dev focused test: pass.
- Current-dev focused test repeated 100 consecutive times: pass.
- Full `sdk-slack-daemon.test.ts`: 49 pass.
- Targeted coding-agent typecheck: pass.

The original failure is a fixture timing race: the first inbound dispatch could still be pending after the 100ms polling window under CI load, leaving `injected` at 0. The current-dev production lifecycle passed the focused test 100/100 before this test-only synchronization.