### PR TITLE
feat(modes): report turn status to the hosting terminal

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,10 @@
 - Authority-absent Darwin `appendSync` regression coverage now exercises the replace-based race window (destination mutation during successor staging) instead of the retired in-place `O_APPEND` open path, and documents that ctime-only destination transitions are tolerated by exact replacement.
 - The legacy interactive footer now uses the session manager's cumulative usage index, so completed task and subagent tokens, premium requests, and estimated costs are included exactly once instead of reporting only the parent agent's assistant messages.
 
+### Added
+
+- Interactive turns now emit a host-terminal status marker (OSC 777 `notify;Terax;gjc;<event>`) when `TERAX_TERMINAL` is set, so a hosting terminal can follow working/attention/finished without polling. Silent in every other terminal.
+
 ## [0.12.10] - 2026-08-03
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+
+### Added
+
+- Interactive turns now announce their state as an OSC 777 sequence (`notify;Terax;gjc;working|attention|finished`), so a hosting terminal can follow the agent without polling. Terminals that do not parse it discard it like any unknown OSC, and print/RPC mode stdout is untouched.
+
 ### Fixed
 
 - Telegram daemon restart now revokes every persisted callback alias before polling. Reconnecting sessions must replay a pending ask to receive fresh, owner-bound aliases; old controls remain stale, and their keyboards are best-effort terminalized when the original Telegram message id is available. Shutdown now fences new session messages and drains every admitted handler before final callback persistence and ownership release, preventing a successful send racing shutdown from publishing alias state after a successor takes ownership (#3727).
@@ -19,10 +24,6 @@
 - `todo_write` recovery reminders now distinguish rejected payloads from runtime aborts, preserve the available cause, and require durable state reconciliation instead of incorrectly telling the agent to change a valid payload (#3743, #3760).
 - Authority-absent Darwin `appendSync` regression coverage now exercises the replace-based race window (destination mutation during successor staging) instead of the retired in-place `O_APPEND` open path, and documents that ctime-only destination transitions are tolerated by exact replacement.
 - The legacy interactive footer now uses the session manager's cumulative usage index, so completed task and subagent tokens, premium requests, and estimated costs are included exactly once instead of reporting only the parent agent's assistant messages.
-
-### Added
-
-- Interactive turns now emit a host-terminal status marker (OSC 777 `notify;Terax;gjc;<event>`) when `TERAX_TERMINAL` is set, so a hosting terminal can follow working/attention/finished without polling. Silent in every other terminal.
 
 ## [0.12.10] - 2026-08-03
 

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -32,6 +32,7 @@ import { computeIrcSplitWidths, getIrcSidebarSemanticToken } from "../components
 import type { IrcObservationRecord } from "../irc-observation-ledger";
 import { interruptHint } from "../shared";
 import { buildAbortDisplayMessage } from "../utils/abort-message";
+import { emitHostStatus } from "../utils/host-status";
 import { consumeInjectedOptimisticSignature } from "../utils/injected-user-submission";
 import { parseIrcMessage } from "../utils/irc-message";
 import { ringTerminalBell } from "../utils/terminal-bell";
@@ -298,6 +299,7 @@ export class EventController {
 	}
 
 	async #handleAgentStart(_event: Extract<AgentSessionEvent, { type: "agent_start" }>): Promise<void> {
+		emitHostStatus("working");
 		this.ctx.promptSuggestion?.onAgentStart();
 		this.#lastIntent = undefined;
 		this.#readToolCallArgs.clear();
@@ -924,6 +926,7 @@ export class EventController {
 		this.ctx.updateEditorBorderColor();
 		this.ctx.ui.requestRender();
 		this.#scheduleIdleCompaction();
+		emitHostStatus("finished");
 		this.sendCompletionNotification();
 		this.ctx.promptSuggestion?.onAgentEnd();
 	}

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -40,6 +40,7 @@ import { createReadonlySessionManager } from "../../session/session-manager";
 import { parseThinkingLevel } from "../../thinking";
 import type { TodoPhase } from "../../tools/todo-write";
 import { setSessionTerminalTitle, setTerminalTitle } from "../../utils/title-generator";
+import { emitHostStatus } from "../utils/host-status";
 import { applyInjectedUserSubmission } from "../utils/injected-user-submission";
 import { classifyHookSelectorBellEvent, ringTerminalBell } from "../utils/terminal-bell";
 import { prepareTranscriptRebuild } from "../utils/ui-helpers";
@@ -1258,6 +1259,7 @@ export class ExtensionUiController {
 			computeBudget();
 
 		ringTerminalBell(classifyHookSelectorBellEvent(title));
+		emitHostStatus("attention");
 
 		this.ctx.hookSelector = new HookSelectorComponent(
 			title,

--- a/packages/coding-agent/src/modes/utils/host-status.ts
+++ b/packages/coding-agent/src/modes/utils/host-status.ts
@@ -1,0 +1,29 @@
+/**
+ * Host-terminal agent status markers.
+ *
+ * Terax runs `gjc` inside its own PTY and shows per-tab agent status. It reads
+ * an OSC 777 marker (`notify;Terax;gjc;<event>`) from the PTY stream, so the
+ * status is reported here rather than through the extension surface, which is
+ * quarantined for filesystem-discovered modules.
+ *
+ * The marker is written only when the host advertises itself through
+ * `TERAX_TERMINAL`; every other terminal sees nothing.
+ */
+
+export type HostStatusEvent = "working" | "attention" | "finished";
+
+function marker(event: HostStatusEvent): string {
+	return `\x1b]777;notify;Terax;gjc;${event}\x07`;
+}
+
+export function emitHostStatus(
+	event: HostStatusEvent,
+	output: Pick<NodeJS.WriteStream, "write"> = process.stdout,
+): void {
+	if (!process.env.TERAX_TERMINAL) return;
+	try {
+		output.write(marker(event));
+	} catch {
+		// Best-effort host integration only.
+	}
+}

--- a/packages/coding-agent/src/modes/utils/host-status.ts
+++ b/packages/coding-agent/src/modes/utils/host-status.ts
@@ -1,13 +1,23 @@
 /**
  * Host-terminal agent status markers.
  *
- * Terax runs `gjc` inside its own PTY and shows per-tab agent status. It reads
- * an OSC 777 marker (`notify;Terax;gjc;<event>`) from the PTY stream, so the
- * status is reported here rather than through the extension surface, which is
- * quarantined for filesystem-discovered modules.
+ * Interactive turns announce their state as an OSC 777 sequence:
  *
- * The marker is written only when the host advertises itself through
- * `TERAX_TERMINAL`; every other terminal sees nothing.
+ *     ESC ] 777 ; notify;Terax;gjc;<event> BEL
+ *
+ * A terminal that understands the sequence (Terax reads it to drive its per-tab
+ * agent status and header bell) reacts; every other terminal discards the OSC
+ * as unknown, exactly like the OSC 133 prompt marks and OSC 7 cwd reports that
+ * shells emit unconditionally. So there is no host sniffing and no env gate:
+ * any host that wants agent status can parse the stream without gjc knowing it
+ * exists.
+ *
+ * `notify;Terax;` is the wire identifier of the only protocol that currently
+ * carries per-turn agent state, not a host check - the payload names gjc as the
+ * reporting agent.
+ *
+ * Interactive TUI only. Print and RPC mode stdout stays byte-for-byte parseable
+ * because they never reach these controllers.
  */
 
 export type HostStatusEvent = "working" | "attention" | "finished";
@@ -20,7 +30,6 @@ export function emitHostStatus(
 	event: HostStatusEvent,
 	output: Pick<NodeJS.WriteStream, "write"> = process.stdout,
 ): void {
-	if (!process.env.TERAX_TERMINAL) return;
 	try {
 		output.write(marker(event));
 	} catch {

--- a/packages/coding-agent/test/host-status.test.ts
+++ b/packages/coding-agent/test/host-status.test.ts
@@ -1,26 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { emitHostStatus } from "@gajae-code/coding-agent/modes/utils/host-status";
 
-const original = process.env.TERAX_TERMINAL;
-
 afterEach(() => {
-	if (original === undefined) delete process.env.TERAX_TERMINAL;
-	else process.env.TERAX_TERMINAL = original;
 	vi.restoreAllMocks();
 });
 
 describe("host status markers", () => {
-	it("stays silent outside a host terminal", () => {
-		delete process.env.TERAX_TERMINAL;
-		const output = { write: vi.fn(() => true) };
-
-		emitHostStatus("working", output);
-
-		expect(output.write).not.toHaveBeenCalled();
-	});
-
 	it("writes the agent-attributed OSC 777 marker for each event", () => {
-		process.env.TERAX_TERMINAL = "1";
 		const output = { write: vi.fn(() => true) };
 
 		emitHostStatus("working", output);
@@ -32,8 +18,31 @@ describe("host status markers", () => {
 		expect(output.write).toHaveBeenNthCalledWith(3, "\x1b]777;notify;Terax;gjc;finished\x07");
 	});
 
+	it("reports without asking the host to identify itself", () => {
+		const previous = process.env.TERAX_TERMINAL;
+		delete process.env.TERAX_TERMINAL;
+		const output = { write: vi.fn(() => true) };
+
+		emitHostStatus("finished", output);
+
+		expect(output.write).toHaveBeenCalledTimes(1);
+		if (previous !== undefined) process.env.TERAX_TERMINAL = previous;
+	});
+
+	it("emits a self-terminating OSC that carries no cursor movement", () => {
+		const output = { write: vi.fn(() => true) };
+
+		emitHostStatus("working", output);
+
+		const written = output.write.mock.calls[0][0] as string;
+		expect(written.startsWith("\x1b]")).toBe(true);
+		expect(written.endsWith("\x07")).toBe(true);
+		// A terminal that does not know the sequence discards it; nothing here
+		// may render or move the cursor if it does not.
+		expect(written.slice(2, -1)).toMatch(/^[\x20-\x7e]*$/);
+	});
+
 	it("swallows write failures so a broken stdout can't abort a turn", () => {
-		process.env.TERAX_TERMINAL = "1";
 		const output = {
 			write: vi.fn(() => {
 				throw new Error("EPIPE");

--- a/packages/coding-agent/test/host-status.test.ts
+++ b/packages/coding-agent/test/host-status.test.ts
@@ -30,7 +30,7 @@ describe("host status markers", () => {
 	});
 
 	it("emits a self-terminating OSC that carries no cursor movement", () => {
-		const output = { write: vi.fn(() => true) };
+		const output = { write: vi.fn((_value: string) => true) };
 
 		emitHostStatus("working", output);
 

--- a/packages/coding-agent/test/host-status.test.ts
+++ b/packages/coding-agent/test/host-status.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { emitHostStatus } from "@gajae-code/coding-agent/modes/utils/host-status";
+
+const original = process.env.TERAX_TERMINAL;
+
+afterEach(() => {
+	if (original === undefined) delete process.env.TERAX_TERMINAL;
+	else process.env.TERAX_TERMINAL = original;
+	vi.restoreAllMocks();
+});
+
+describe("host status markers", () => {
+	it("stays silent outside a host terminal", () => {
+		delete process.env.TERAX_TERMINAL;
+		const output = { write: vi.fn(() => true) };
+
+		emitHostStatus("working", output);
+
+		expect(output.write).not.toHaveBeenCalled();
+	});
+
+	it("writes the agent-attributed OSC 777 marker for each event", () => {
+		process.env.TERAX_TERMINAL = "1";
+		const output = { write: vi.fn(() => true) };
+
+		emitHostStatus("working", output);
+		emitHostStatus("attention", output);
+		emitHostStatus("finished", output);
+
+		expect(output.write).toHaveBeenNthCalledWith(1, "\x1b]777;notify;Terax;gjc;working\x07");
+		expect(output.write).toHaveBeenNthCalledWith(2, "\x1b]777;notify;Terax;gjc;attention\x07");
+		expect(output.write).toHaveBeenNthCalledWith(3, "\x1b]777;notify;Terax;gjc;finished\x07");
+	});
+
+	it("swallows write failures so a broken stdout can't abort a turn", () => {
+		process.env.TERAX_TERMINAL = "1";
+		const output = {
+			write: vi.fn(() => {
+				throw new Error("EPIPE");
+			}),
+		};
+
+		expect(() => emitHostStatus("finished", output)).not.toThrow();
+		expect(output.write).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
Reopened against `dev` per the review on #3790, rebased onto current `origin/dev` (`65d975bee`).

## What

Interactive turns announce their state as an OSC 777 sequence so a hosting terminal can follow the agent:

```
ESC ] 777 ; notify;Terax;gjc;working|attention|finished BEL
```

- `agent_start` -> `working`
- `agent_end` -> `finished`
- approval / ask selector -> `attention`

Emitted unconditionally, the way shells emit OSC 133 prompt marks and OSC 7 cwd reports: a terminal that parses it reacts, one that does not discards it as an unknown OSC. No host sniffing, no env gate, no setting.

## Why it lives in the controllers

[Terax](https://github.com/crynta/terax-ai) supports Pi by installing an extension file that emits the marker. GJC is a Pi fork, so that was tried first. It cannot work:

```ts
// src/sdk/session.ts
// Extension/module discovery is quarantined; retain only the private
// runtime needed for bundled product extensions ... Filesystem extension
// paths remain ignored here even when options.additionalExtensionPaths is supplied.
```

Confirmed against the released binary: an extension in `~/.gjc/agent/extensions/` and one passed with `-e` both silently fail to load, and `discoverAndLoadHooks` has no callers. The emission has to come from the TUI controllers.

## Placement notes

- `emitHostStatus("finished")` sits **before** `sendCompletionNotification()`, which returns early when `completion.notify` is `"off"`. Host status must not inherit an unrelated preference.
- The existing `ringTerminalBell` call sites were the model for placement. The bell writes a bare `\x07`, which carries no state and is not machine-readable.
- OSC sequences do not move the cursor, and writes go through the same `process.stdout` as the bell, so TUI rendering is unaffected.

## Verified, not assumed

- Only the interactive controllers report. `gjc -p "say only: ok"` emits `ok\n` and nothing else; marker count in print-mode stdout is 0, so piped output stays parseable.
- Byte-for-byte from the installed tree:

  ```
  1b5d 3737 373b 6e6f 7469 6679 3b54 6572  .]777;notify;Ter
  6178 3b67 6a63 3b66 696e 6973 6865 6407  ax;gjc;finished.
  ```

- `bun test packages/coding-agent/test/host-status.test.ts` - 4 pass: exact bytes per event, emission without host identification, OSC shape/terminator, write-failure containment
- `bunx biome check` clean on all four touched files
- `bun run check:ts` could not run here (`tsgo` / `@typescript/native-preview` is not installed in this environment); the change adds one three-member string union and no other types

## Consuming side

`notify;Terax;` is the wire identifier of the only protocol that currently carries per-turn agent state; the payload names `gjc` as the reporting agent. crynta/terax-ai#1106 generalizes the consumer to accept any agent id matching `[a-z0-9][a-z0-9-]{0,31}` instead of a compiled whitelist, so neither side needs a release when the other adds an agent or a host.