### PR TITLE
fix(tui): stop queuing decorative animation frames a slow terminal cannot drain

### DIFF
--- a/packages/tui/src/animation-scheduler.ts
+++ b/packages/tui/src/animation-scheduler.ts
@@ -9,6 +9,35 @@ interface CadenceBucket {
 	startedTimers: number;
 }
 
+// Animation ticks are decorative: the spinner glyph advances on its own 80ms
+// clock, and the extra 16ms ticks exist only to move a colour gradient. When the
+// output sink cannot keep up — a remote terminal over SSH, a multiplexer, a slow
+// pipe — those frames are not merely wasted, they queue. Node buffers whatever
+// `write()` could not hand to the OS, so the renderer runs ahead of the wire and
+// the user watches a backlog drain instead of the current frame.
+//
+// Dropping a decorative tick loses nothing: the next one redraws from live state.
+// Skipping is therefore always safe here, and must never be extended to renders
+// that carry content, which the diff renderer must still emit in order.
+const DEFAULT_CONGESTION_THRESHOLD_BYTES = 64 * 1024;
+
+let congestionProbe: (() => boolean) | undefined;
+let skippedTicks = 0;
+
+function outputIsCongested(): boolean {
+	if (congestionProbe) return congestionProbe();
+	const stdout = globalThis.process?.stdout as { writableLength?: number } | undefined;
+	const buffered = stdout?.writableLength;
+	// A healthy TTY drains synchronously and reports 0 here, so this is a no-op
+	// locally and only engages once bytes are genuinely stuck.
+	return typeof buffered === "number" && buffered > DEFAULT_CONGESTION_THRESHOLD_BYTES;
+}
+
+/** Test seam: override how congestion is sampled. Pass undefined to restore. */
+export function __setAnimationCongestionProbe(probe: (() => boolean) | undefined): void {
+	congestionProbe = probe;
+}
+
 const buckets = new Map<AnimationCadence, CadenceBucket>();
 
 function getBucket(cadence: AnimationCadence): CadenceBucket {
@@ -23,6 +52,12 @@ function getBucket(cadence: AnimationCadence): CadenceBucket {
 function startBucket(cadence: AnimationCadence, bucket: CadenceBucket): void {
 	if (bucket.timer) return;
 	bucket.timer = setInterval(() => {
+		// Skip the whole tick, not each callback: the decision is about the shared
+		// output sink, so sampling it once keeps every registrant on the same frame.
+		if (outputIsCongested()) {
+			skippedTicks += 1;
+			return;
+		}
 		const now = performance.now();
 		// Snapshot so re-entrant register/unregister during a tick is safe, and
 		// isolate each callback so one throwing registrant cannot starve siblings
@@ -89,11 +124,16 @@ export const __animationSchedulerTestHooks = {
 		for (const bucket of buckets.values()) count += bucket.startedTimers;
 		return count;
 	},
+	getSkippedTickCount(): number {
+		return skippedTicks;
+	},
 	reset(): void {
 		for (const bucket of buckets.values()) {
 			stopBucket(bucket);
 			bucket.callbacks.clear();
 			bucket.startedTimers = 0;
 		}
+		skippedTicks = 0;
+		congestionProbe = undefined;
 	},
 };

--- a/packages/tui/test/animation-congestion.test.ts
+++ b/packages/tui/test/animation-congestion.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+// Imported from the module rather than the package barrel: the barrel pulls in
+// the native addon, which this suite does not need and which is not built in
+// every checkout.
+import {
+	__animationSchedulerTestHooks,
+	__setAnimationCongestionProbe,
+	registerAnimationCallback,
+} from "@gajae-code/tui/animation-scheduler";
+
+/**
+ * Animation ticks are decorative and droppable. When the output sink is backed
+ * up — a remote terminal over SSH, a multiplexer, any slow pipe — emitting them
+ * anyway does not make the screen more current; it queues frames the terminal
+ * has not drained yet, so the user watches a backlog replay.
+ *
+ * These tests pin the two halves of that contract: skip while congested, resume
+ * the moment it clears, and never skip on a healthy terminal.
+ */
+describe("animation scheduler backpressure", () => {
+	afterEach(() => {
+		__animationSchedulerTestHooks.reset();
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
+	it("does not run callbacks while the output sink is congested", () => {
+		vi.useFakeTimers();
+		__setAnimationCongestionProbe(() => true);
+		const tick = vi.fn();
+		registerAnimationCallback(tick, 16);
+
+		vi.advanceTimersByTime(16 * 10);
+
+		expect(tick).not.toHaveBeenCalled();
+		expect(__animationSchedulerTestHooks.getSkippedTickCount()).toBe(10);
+	});
+
+	it("resumes on the next tick once the sink drains", () => {
+		vi.useFakeTimers();
+		let congested = true;
+		__setAnimationCongestionProbe(() => congested);
+		const tick = vi.fn();
+		registerAnimationCallback(tick, 16);
+
+		vi.advanceTimersByTime(16 * 5);
+		expect(tick).not.toHaveBeenCalled();
+
+		congested = false;
+		vi.advanceTimersByTime(16 * 5);
+
+		// Skipped frames are dropped, not replayed: the backlog is the thing being
+		// avoided, so only the ticks that fell in the healthy window may run.
+		expect(tick).toHaveBeenCalledTimes(5);
+	});
+
+	it("never skips on a healthy terminal", () => {
+		vi.useFakeTimers();
+		__setAnimationCongestionProbe(() => false);
+		const tick = vi.fn();
+		registerAnimationCallback(tick, 16);
+
+		vi.advanceTimersByTime(16 * 10);
+
+		expect(tick).toHaveBeenCalledTimes(10);
+		expect(__animationSchedulerTestHooks.getSkippedTickCount()).toBe(0);
+	});
+
+	it("suppresses every registrant on a congested tick, not just one", () => {
+		vi.useFakeTimers();
+		let congested = false;
+		__setAnimationCongestionProbe(() => congested);
+		const fast = vi.fn();
+		const slow = vi.fn();
+		registerAnimationCallback(fast, 16);
+		registerAnimationCallback(slow, 16);
+
+		vi.advanceTimersByTime(16);
+		expect(fast).toHaveBeenCalledTimes(1);
+		expect(slow).toHaveBeenCalledTimes(1);
+
+		congested = true;
+		vi.advanceTimersByTime(16 * 4);
+
+		// One sink, one decision: a partially-updated frame would be worse than a
+		// dropped one, so registrants sharing a bucket move together.
+		expect(fast).toHaveBeenCalledTimes(1);
+		expect(slow).toHaveBeenCalledTimes(1);
+	});
+
+	it("treats an unmeasurable sink as healthy rather than stalling animation", () => {
+		vi.useFakeTimers();
+		// No probe override: falls back to reading process.stdout.writableLength,
+		// which is 0 or undefined in this harness. A missing measurement must not
+		// be read as congestion, or animation would stop wherever the runtime does
+		// not expose the counter.
+		const tick = vi.fn();
+		registerAnimationCallback(tick, 16);
+
+		vi.advanceTimersByTime(16 * 3);
+
+		expect(tick).toHaveBeenCalledTimes(3);
+	});
+});


### PR DESCRIPTION
Follows the investigation in #3810, but is a separate defect: that issue is about a crash, this one is about throughput.

## What I measured

A session reached over SSH on a Tailscale tailnet felt laggy. The link was not the problem:

| | |
|---|---|
| path | **direct** (no DERP relay) |
| RTT | 13 ms |
| packet loss | 0% |
| system CPU | gjc family 228% of 1600% |
| memory | 89% free, swap 0 |

What was happening instead: the host was pushing a **sustained 290 KB/s of terminal escape sequences**, 5.5 GB cumulative. At ~60fps that is several KB per frame, continuously, into a terminal multiplexer that must parse every byte of it.

## Why

Two things compound.

**1. Most animation ticks are decorative.** `Loader` advances the spinner glyph on its own 80 ms clock but registers on the 16 ms cadence whenever `timeDependentColor` is set:

```ts
// packages/tui/src/components/loader.ts:65-74
this.#animation = registerAnimationCallback(
    now => {
        if (now - this.#lastSpinnerTick >= SPINNER_ADVANCE_MS) {  // 80ms
            this.#currentFrame = (this.#currentFrame + 1) % this.#frames.length;
            this.#lastSpinnerTick = now;
        }
        this.#updateDisplay();     // ← every tick, i.e. ~62/s
    },
    this.#timeDependentColor ? 16 : 80,
);
```

Roughly five of every six ticks exist only to move a colour gradient, and each still marks the tree dirty, drives a render and writes.

**2. Nothing reacts to backpressure.**

```ts
// packages/tui/src/terminal.ts:918
process.stdout.write(data);   // return value discarded
```

On a local TTY this is harmless — the write drains synchronously. On a remote terminal Node buffers whatever it could not hand to the OS, the renderer keeps producing at 62fps, and the queue grows. The user ends up watching a backlog drain instead of the current frame. That is lag no amount of bandwidth removes.

## The change

Skip an animation tick while the output sink is congested.

```ts
if (outputIsCongested()) {
    skippedTicks += 1;
    return;
}
```

Three properties make this safe:

- **Animation frames are droppable by construction.** The next tick redraws from live state, so skipped frames are dropped rather than replayed — dropping the backlog is the entire point.
- **The check is per tick, not per callback.** Registrants sharing a bucket stay on the same frame, so no half-updated frame can be emitted.
- **An unmeasurable sink counts as healthy.** A runtime that does not expose `writableLength` keeps animating rather than silently freezing.

It deliberately does **not** touch renders that carry content. Those must still be emitted in order for the diff renderer's invariants to hold; only the decorative layer is droppable. Threshold is 64 KiB of buffered output, and a healthy TTY sits at 0, so this is a no-op locally.

## Tests

`packages/tui/test/animation-congestion.test.ts` — 5 tests covering: skipping while congested, resuming on drain without replaying, never skipping when healthy, suppressing every registrant on a congested tick, and treating an unmeasurable sink as healthy.

Proven non-vacuous: removing the four-line skip makes 3 of the 5 fail.

```
bun test packages/tui/test/            → 1039 pass, 6 skip, 1 fail
bunx tsc --noEmit -p packages/tui      → clean
```

The single failure is `render-helper-counts.test.ts > reuses normalized line widths in the differential truncation guard`, which **fails identically on a clean checkout** (`expect(differentialGuardVisibleWidthCalls).toBe(0)` receives 4). Pre-existing, unrelated to this change — verified by stashing.

## Note on scope

I looked for a naive full-repaint bug first and did not find one: the renderer already does line-diffing, gates repaint storms at zero, coalesces cadences into shared buckets, and has a virtual viewport. The waste is not in *how* a frame is drawn but in drawing frames the terminal has not asked for yet.

A follow-up worth considering separately: `timeDependentColor` driving a 16 ms cadence is expensive for what it buys, and could reasonably fall back to 80 ms when the output is not a local terminal.
