### PR TITLE
feat(utils): treat stdout EIO/EBADF as benign closed-stream, not fatal (#3810)

### DIFF
--- a/packages/utils/src/broken-pipe.ts
+++ b/packages/utils/src/broken-pipe.ts
@@ -9,6 +9,16 @@
 import * as fs from "node:fs";
 
 const KNOWN_SINK_PEER_CLOSED_CODES = new Set(["EPIPE", "ERR_STREAM_DESTROYED"]);
+/**
+ * Errno codes that mean the process's own stdout sink has gone away because
+ * the peer (terminal emulator, pager, pipe reader, or pty) was torn down. On
+ * macOS a torn-down pty slave produces `EIO`; a closed fd produces `EBADF`;
+ * a closed pipe produces `EPIPE`. All three are the same benign condition:
+ * the terminal disconnected.
+ *
+ * Mirrors `CLOSED_STDERR_ERROR_CODES` in `safe-stderr.ts`; keep in sync.
+ */
+const PROCESS_STDOUT_PEER_CLOSED_CODES = new Set(["EIO", "EPIPE", "EBADF"]);
 
 type ErrorProperty = "code" | "fd" | "syscall";
 
@@ -70,9 +80,10 @@ export function isBrokenPipeError(error: unknown): boolean {
 }
 
 /**
- * A classifier for process-level stdout `EPIPE` errors. Its direct-write
- * evidence is private to each factory instance, so only the owner that
- * intercepted `process.stdout.write` can mark an error for this classifier.
+ * A classifier for process-level stdout peer-closed errors (`EPIPE`, `EIO`,
+ * `EBADF`). Its direct-write evidence is private to each factory instance, so
+ * only the owner that intercepted `process.stdout.write` can mark an error
+ * for this classifier.
  */
 export interface ProcessStdoutEpipeClassifier {
 	markDirectProcessStdoutWriteError(error: unknown): void;
@@ -109,7 +120,8 @@ export function createProcessStdoutEpipeClassifier(): ProcessStdoutEpipeClassifi
 			if (!isObjectLike(error)) return false;
 
 			const code = readErrorProperty(error, "code");
-			if (!code.available || code.value !== "EPIPE") return false;
+			if (!code.available || typeof code.value !== "string" || !PROCESS_STDOUT_PEER_CLOSED_CODES.has(code.value))
+				return false;
 
 			if (directProcessStdoutWriteErrors.has(error)) return true;
 

--- a/packages/utils/test/postmortem-fixture.ts
+++ b/packages/utils/test/postmortem-fixture.ts
@@ -27,6 +27,13 @@ function writeResult(result: Record<string, unknown>): void {
 function epipeError(message: string, details: EpipeDetails): Error {
 	return Object.assign(new Error(message), { code: "EPIPE", ...details });
 }
+/**
+ * Construct a peer-closed error with an arbitrary code, for EIO/EBADF
+ * regression fixtures that exercise the broader closed-stdout family.
+ */
+function closedFdError(message: string, code: string, details: EpipeDetails): Error {
+	return Object.assign(new Error(message), { code, ...details });
+}
 
 async function throwFromTimer(error: Error): Promise<void> {
 	setTimeout(() => {
@@ -135,6 +142,37 @@ async function runStdoutFdUnhandledRejection(): Promise<void> {
 	};
 	void Promise.reject(error);
 	await Bun.sleep(2_000);
+}
+
+async function runStdoutFdEioUnhandledRejection(): Promise<void> {
+	const error = closedFdError("fixture: stdout fd EIO (pty gone)", "EIO", {
+		fd: process.stdout.fd,
+		syscall: "write",
+	});
+	void Promise.reject(error);
+	await Bun.sleep(2_000);
+}
+
+async function runStdoutFdEbadfUnhandledRejection(): Promise<void> {
+	const error = closedFdError("fixture: stdout fd EBADF (fd gone)", "EBADF", {
+		fd: process.stdout.fd,
+		syscall: "write",
+	});
+	void Promise.reject(error);
+	await Bun.sleep(2_000);
+}
+
+/**
+ * EIO from a non-stdout descriptor must stay fatal. Guards against
+ * over-broadening the classifier to swallow every EIO in the process.
+ */
+async function runNonStdoutEioFatal(): Promise<void> {
+	await throwFromTimer(
+		closedFdError("fixture: non-stdout EIO stays fatal", "EIO", {
+			fd: process.stderr.fd,
+			syscall: "write",
+		}),
+	);
 }
 
 async function runStdoutFdMissingSyscallEpipe(): Promise<void> {
@@ -340,6 +378,15 @@ switch (scenario) {
 		break;
 	case "stdout-fd-unhandled-rejection":
 		await runStdoutFdUnhandledRejection();
+		break;
+	case "stdout-fd-eio-unhandled-rejection":
+		await runStdoutFdEioUnhandledRejection();
+		break;
+	case "stdout-fd-ebadf-unhandled-rejection":
+		await runStdoutFdEbadfUnhandledRejection();
+		break;
+	case "non-stdout-eio-fatal":
+		await runNonStdoutEioFatal();
 		break;
 	case "stdout-fd-missing-syscall-epipe":
 		await runStdoutFdMissingSyscallEpipe();

--- a/packages/utils/test/postmortem.test.ts
+++ b/packages/utils/test/postmortem.test.ts
@@ -287,3 +287,27 @@ describe("postmortem process stdout EPIPE policy", () => {
 		expectOrdinaryFatal(rejection, "Unhandled Rejection", "fixture: genuine rejected fatal error");
 	}, 15_000);
 });
+
+describe("postmortem process stdout closed-stream family (EIO/EBADF, issue #3810)", () => {
+	it("exits quietly with 141 for an attributed stdout EIO (pty torn down)", async () => {
+		const result = await runScenario("stdout-fd-eio-unhandled-rejection");
+
+		expect(result.exitCode).toBe(141);
+		expect(result.stderr).not.toContain("[Unhandled Rejection]");
+		expect(result.stderr).not.toContain("EIO");
+	}, 15_000);
+
+	it("exits quietly with 141 for an attributed stdout EBADF (fd gone)", async () => {
+		const result = await runScenario("stdout-fd-ebadf-unhandled-rejection");
+
+		expect(result.exitCode).toBe(141);
+		expect(result.stderr).not.toContain("[Unhandled Rejection]");
+		expect(result.stderr).not.toContain("EBADF");
+	}, 15_000);
+
+	it("keeps a non-stdout EIO fatal — only stdout's own sink is benign", async () => {
+		const result = await runScenario("non-stdout-eio-fatal");
+
+		expectOrdinaryFatal(result, "Uncaught Exception", "fixture: non-stdout EIO stays fatal");
+	}, 15_000);
+});


### PR DESCRIPTION
## Summary

Closes #3810.

When a pty slave is torn down (SSH disconnect, `screen -dmS` teardown), the next `process.stdout.write` fails synchronously with `EIO` (macOS) or `EBADF` (fd gone). The postmortem write interceptor in `postmortem.ts` **did** mark these errors via `markDirectProcessStdoutWriteError`, but `isAttributableProcessStdoutEpipe` in `broken-pipe.ts` rejected them at the first gate (`code !== "EPIPE"`). They fell through to `handleFatalError` → `uncaughtException` → process death, killing the agent mid-turn.

## Fix

The same errno family that `safe-stderr.ts` already treats as benign closed-stream (`EIO` / `EPIPE` / `EBADF`) is now accepted by the process stdout classifier. The strict fd-attribution check (fd must match process stdout's identity) is unchanged, so non-stdout `EIO`/`EPIPE`/`EBADF` stays fatal.

**Root cause:** `packages/utils/src/broken-pipe.ts:122` — single-code gate `code.value !== "EPIPE"`.

**Smallest correct fix:** replaced the single-code check with set-membership against `PROCESS_STDOUT_PEER_CLOSED_CODES = {EIO, EPIPE, EBADF}`, mirroring `CLOSED_STDERR_ERROR_CODES` in `safe-stderr.ts`.

### Files changed
- `packages/utils/src/broken-pipe.ts` — new `PROCESS_STDOUT_PEER_CLOSED_CODES` set; classifier code gate broadened from `EPIPE`-only to the full closed-stream family. Updated doc comments.
- `packages/utils/test/postmortem-fixture.ts` — 3 new fixture scenarios: `stdout-fd-eio-unhandled-rejection`, `stdout-fd-ebadf-unhandled-rejection`, `non-stdout-eio-fatal`.
- `packages/utils/test/postmortem.test.ts` — 3 regression tests covering the new closed-stream family + the guard that non-stdout EIO stays fatal.

## What is preserved

- **Real fatal errors unchanged:** non-stdout `EIO`/`EPIPE`/`EBADF` (wrong fd, stderr fd, missing/invalid fd) stays fatal with exit 1. Verified by the existing `non-stdout-eio-fatal` test and all pre-existing EPIPE policy tests.
- **EPIPE quiet-exit contract unchanged:** the existing 12 EPIPE policy tests all pass.
- **ERR_STREAM_DESTROYED stays fatal at process scope** (unchanged).
- **Socket-send EPIPE stays fatal** even when its fd is process stdout (unchanged).

## Test plan

```
bun test packages/utils/test/postmortem.test.ts --test-name-pattern "3810"
  3 pass, 0 fail

bun test packages/utils/test/postmortem.test.ts --test-name-pattern "EPIPE policy"
  12 pass, 1 fail (pre-existing on base: late-registration-async-rejection — logger transport capture, unrelated)

bun test packages/utils/test/safe-stderr.test.ts
  4 pass, 0 fail

bun test packages/utils/test/postmortem-crash-log.test.ts
  15 pass, 0 fail
```

The pre-existing `late-registration-async-rejection` failure is confirmed on the base branch (verified via `git stash`) and is unrelated to this change — it's a logger output capture flake in this environment.

*[repo owner's gaebal-gajae (clawdbot) 🦞]*