### PR TITLE
fix(tui): stop queuing decorative animation frames

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 
 - Bounded loader animation scheduling to 80 ms, stopped OSC 11 polling after DA1 proves the query unsupported while preserving Mode 2031 recovery, and added the default-on `GJC_TUI_SYNCHRONIZED_OUTPUT=0` compatibility opt-out for terminal parsers that mishandle synchronized-output framing. Real iOS-client validation remains pending for #3798.
+- Decorative animation ticks now pause while stdout has more than 64 KiB buffered, preventing slow SSH terminals and multiplexers from accumulating stale spinner frames.
 
 ## [0.12.11] - 2026-08-03
 

--- a/packages/tui/src/animation-scheduler.ts
+++ b/packages/tui/src/animation-scheduler.ts
@@ -9,6 +9,28 @@ interface CadenceBucket {
 	startedTimers: number;
 }
 
+// Animation ticks are decorative. When the output sink cannot keep up — a
+// remote terminal over SSH, a multiplexer, a slow pipe — those frames are not
+// merely wasted, they queue. Bun buffers whatever `write()` could not hand to
+// the OS, so the renderer runs ahead of the wire and the user watches a backlog
+// drain instead of the current frame.
+//
+// Dropping a decorative tick loses nothing: the next one redraws from live state.
+// Skipping is therefore always safe here, and must never be extended to renders
+// that carry content, which the diff renderer must still emit in order.
+const DEFAULT_CONGESTION_THRESHOLD_BYTES = 64 * 1024;
+
+let bufferedOutputBytesProbe: (() => number | undefined) | undefined;
+let skippedTicks = 0;
+
+function outputIsCongested(): boolean {
+	const stdout = globalThis.process?.stdout as { writableLength?: number } | undefined;
+	const buffered = bufferedOutputBytesProbe ? bufferedOutputBytesProbe() : stdout?.writableLength;
+	// A healthy TTY drains synchronously and reports 0 here, so this is a no-op
+	// locally and only engages once bytes are genuinely stuck.
+	return typeof buffered === "number" && buffered > DEFAULT_CONGESTION_THRESHOLD_BYTES;
+}
+
 const buckets = new Map<AnimationCadence, CadenceBucket>();
 
 function getBucket(cadence: AnimationCadence): CadenceBucket {
@@ -23,6 +45,12 @@ function getBucket(cadence: AnimationCadence): CadenceBucket {
 function startBucket(cadence: AnimationCadence, bucket: CadenceBucket): void {
 	if (bucket.timer) return;
 	bucket.timer = setInterval(() => {
+		// Skip the whole tick, not each callback: the decision is about the shared
+		// output sink, so sampling it once keeps every registrant on the same frame.
+		if (outputIsCongested()) {
+			skippedTicks += 1;
+			return;
+		}
 		const now = performance.now();
 		// Snapshot so re-entrant register/unregister during a tick is safe, and
 		// isolate each callback so one throwing registrant cannot starve siblings
@@ -89,11 +117,22 @@ export const __animationSchedulerTestHooks = {
 		for (const bucket of buckets.values()) count += bucket.startedTimers;
 		return count;
 	},
+	getSkippedTickCount(): number {
+		return skippedTicks;
+	},
+	getCongestionThresholdBytes(): number {
+		return DEFAULT_CONGESTION_THRESHOLD_BYTES;
+	},
+	setBufferedOutputBytesProbe(probe: (() => number | undefined) | undefined): void {
+		bufferedOutputBytesProbe = probe;
+	},
 	reset(): void {
 		for (const bucket of buckets.values()) {
 			stopBucket(bucket);
 			bucket.callbacks.clear();
 			bucket.startedTimers = 0;
 		}
+		skippedTicks = 0;
+		bufferedOutputBytesProbe = undefined;
 	},
 };

--- a/packages/tui/test/animation-congestion.test.ts
+++ b/packages/tui/test/animation-congestion.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+// Imported from the module rather than the package barrel: the barrel pulls in
+// the native addon, which this suite does not need and which is not built in
+// every checkout.
+import { __animationSchedulerTestHooks, registerAnimationCallback } from "@gajae-code/tui/animation-scheduler";
+
+/**
+ * Animation ticks are decorative and droppable. When the output sink is backed
+ * up — a remote terminal over SSH, a multiplexer, any slow pipe — emitting them
+ * anyway does not make the screen more current; it queues frames the terminal
+ * has not drained yet, so the user watches a backlog replay.
+ *
+ * These tests pin the two halves of that contract: skip while congested, resume
+ * the moment it clears, and never skip on a healthy terminal.
+ */
+describe("animation scheduler backpressure", () => {
+	afterEach(() => {
+		__animationSchedulerTestHooks.reset();
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
+	it("does not run callbacks while the output sink is congested", () => {
+		vi.useFakeTimers();
+		__animationSchedulerTestHooks.setBufferedOutputBytesProbe(
+			() => __animationSchedulerTestHooks.getCongestionThresholdBytes() + 1,
+		);
+		const tick = vi.fn();
+		registerAnimationCallback(tick, 80);
+
+		vi.advanceTimersByTime(80 * 10);
+
+		expect(tick).not.toHaveBeenCalled();
+		expect(__animationSchedulerTestHooks.getSkippedTickCount()).toBe(10);
+	});
+
+	it("resumes on the next tick once the sink drains", () => {
+		vi.useFakeTimers();
+		let buffered = __animationSchedulerTestHooks.getCongestionThresholdBytes() + 1;
+		__animationSchedulerTestHooks.setBufferedOutputBytesProbe(() => buffered);
+		const tick = vi.fn();
+		registerAnimationCallback(tick, 80);
+
+		vi.advanceTimersByTime(80 * 5);
+		expect(tick).not.toHaveBeenCalled();
+
+		buffered = 0;
+		vi.advanceTimersByTime(80 * 5);
+
+		// Skipped frames are dropped, not replayed: the backlog is the thing being
+		// avoided, so only the ticks that fell in the healthy window may run.
+		expect(tick).toHaveBeenCalledTimes(5);
+	});
+
+	it("does not skip at the congestion threshold", () => {
+		vi.useFakeTimers();
+		__animationSchedulerTestHooks.setBufferedOutputBytesProbe(() =>
+			__animationSchedulerTestHooks.getCongestionThresholdBytes(),
+		);
+		const tick = vi.fn();
+		registerAnimationCallback(tick, 80);
+
+		vi.advanceTimersByTime(80 * 10);
+
+		expect(tick).toHaveBeenCalledTimes(10);
+		expect(__animationSchedulerTestHooks.getSkippedTickCount()).toBe(0);
+	});
+
+	it("suppresses every registrant on a congested tick, not just one", () => {
+		vi.useFakeTimers();
+		let buffered = 0;
+		__animationSchedulerTestHooks.setBufferedOutputBytesProbe(() => buffered);
+		const fast = vi.fn();
+		const slow = vi.fn();
+		registerAnimationCallback(fast, 80);
+		registerAnimationCallback(slow, 80);
+
+		vi.advanceTimersByTime(80);
+		expect(fast).toHaveBeenCalledTimes(1);
+		expect(slow).toHaveBeenCalledTimes(1);
+
+		buffered = __animationSchedulerTestHooks.getCongestionThresholdBytes() + 1;
+		vi.advanceTimersByTime(80 * 4);
+
+		// One sink, one decision: a partially-updated frame would be worse than a
+		// dropped one, so registrants sharing a bucket move together.
+		expect(fast).toHaveBeenCalledTimes(1);
+		expect(slow).toHaveBeenCalledTimes(1);
+	});
+
+	it("treats an unmeasurable sink as healthy rather than stalling animation", () => {
+		vi.useFakeTimers();
+		// No probe override: falls back to reading process.stdout.writableLength,
+		// which is 0 or undefined in this harness. A missing measurement must not
+		// be read as congestion, or animation would stop wherever the runtime does
+		// not expose the counter.
+		const tick = vi.fn();
+		registerAnimationCallback(tick, 80);
+
+		vi.advanceTimersByTime(80 * 3);
+
+		expect(tick).toHaveBeenCalledTimes(3);
+	});
+});


### PR DESCRIPTION
## Summary

- pause shared decorative animation ticks while stdout has more than 64 KiB buffered
- resume from current state on the first healthy cadence without replaying skipped frames
- keep direct content-bearing renders outside the throttle and preserve shared-bucket frame consistency
- adapt the closed #3811 change to current `dev` after #3806 reduced real animation scheduling to 80 ms

## Why this is a new PR

PR #3811 was closed solely because its stale head did not contain the recorded base, so the affected-path plan never ran. The signed review found no code blocker and explicitly requested a fresh `dev`-based head. This branch is cut directly from current `upstream/dev` and contains the same scheduler-level mechanism with current-dev comments, 80 ms tests, threshold-boundary coverage, and a TUI changelog entry.

## Verification

- `bun test packages/tui/test/animation-congestion.test.ts packages/tui/test/animation-scheduler.test.ts packages/tui/test/loader.test.ts` — 13 pass, 0 fail
- `bun --cwd=packages/tui run check` — passed
- full `packages/tui/test/` — 1064 pass, 6 skip, 1 known baseline failure in `render-helper-counts.test.ts` (`differentialGuardVisibleWidthCalls`, also documented as reproducing on the exact #3806 base)
- `git diff --check upstream/dev...HEAD` — passed
- exact head contains current `upstream/dev`

Supersedes #3811.