### PR TITLE
fix(extensions): preserve live handler context accessors

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Telegram daemon restart now revokes every persisted callback alias before polling. Reconnecting sessions must replay a pending ask to receive fresh, owner-bound aliases; old controls remain stale, and their keyboards are best-effort terminalized when the original Telegram message id is available. Shutdown now fences new session messages and drains every admitted handler before final callback persistence and ownership release, preventing a successful send racing shutdown from publishing alias state after a successor takes ownership (#3727).
+- Extension handler timeout signals now preserve lazy, live context accessors instead of eagerly snapshotting them. Model changes made through SDK controls are immediately visible to later context reads, and unused getters can no longer reject lifecycle emission before the runner's extension error boundary (#3817).
 - Direct interactive launches inside tmux now bind automatic window renames to the originating pane's immutable pane/window identities and observed window index. If that binding changes before mutation, GJC preserves every window name instead of renaming whichever window became active (#3808).
 
 ### Fixed

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -84,6 +84,7 @@ function createHandlerContext(ctx: ExtensionContext, signal: AbortSignal): Exten
 	descriptors.signal = {
 		configurable: true,
 		enumerable: true,
+		writable: true,
 		value: signal,
 	};
 	return Object.defineProperties({}, descriptors) as ExtensionContext;

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -79,6 +79,15 @@ export function testSetExtensionHandlerTimeoutMs(timeoutMs: number): void {
 const EXTENSION_HANDLER_TIMEOUT = Symbol("extensionHandlerTimeout");
 
 const MAX_PENDING_CREDENTIAL_DISABLED = 32;
+function createHandlerContext(ctx: ExtensionContext, signal: AbortSignal): ExtensionContext {
+	const descriptors = Object.getOwnPropertyDescriptors(ctx);
+	descriptors.signal = {
+		configurable: true,
+		enumerable: true,
+		value: signal,
+	};
+	return Object.defineProperties({}, descriptors) as ExtensionContext;
+}
 
 /**
  * Events handled by the generic emit() method.
@@ -690,7 +699,7 @@ export class ExtensionRunner {
 	): Promise<TResult | undefined> {
 		let timeout: NodeJS.Timeout | undefined;
 		const abortController = new AbortController();
-		const handlerContext: ExtensionContext = { ...ctx, signal: abortController.signal };
+		const handlerContext = createHandlerContext(ctx, abortController.signal);
 		try {
 			const timeoutPromise = new Promise<typeof EXTENSION_HANDLER_TIMEOUT>(resolve => {
 				timeout = setTimeout(() => resolve(EXTENSION_HANDLER_TIMEOUT), timeoutMs);

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -12,6 +12,8 @@ import {
 	ExtensionRunner,
 	testSetExtensionHandlerTimeoutMs,
 } from "@gajae-code/coding-agent/extensibility/extensions/runner";
+import type { ExtensionContext } from "@gajae-code/coding-agent/extensibility/extensions/types";
+
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
 import { getProjectAgentDir, logger, TempDir } from "@gajae-code/utils";
@@ -645,6 +647,65 @@ describe("ExtensionRunner", () => {
 	});
 
 	describe("handler timeouts", () => {
+		it("preserves live context accessors while attaching a handler abort signal", async () => {
+			let currentModel = { id: "first-model" };
+			const observedModels: string[] = [];
+			const extension = {
+				path: "live-context-extension",
+				handlers: new Map([
+					[
+						"session_start",
+						[
+							async (_event: unknown, ctx: ExtensionContext) => {
+								expect(ctx.signal).toBeInstanceOf(AbortSignal);
+								observedModels.push(ctx.model?.id ?? "missing");
+								currentModel = { id: "second-model" };
+								observedModels.push(ctx.model?.id ?? "missing");
+							},
+						],
+					],
+				]),
+			};
+			const runner = new ExtensionRunner(
+				[extension as never],
+				{ flagValues: new Map(), pendingProviderRegistrations: [] } as never,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			runner.initialize({} as never, { getModel: () => currentModel } as never);
+
+			await expect(runner.emit({ type: "session_start" })).resolves.toBeUndefined();
+			expect(observedModels).toEqual(["first-model", "second-model"]);
+		});
+
+		it("does not evaluate unused context accessors before the handler error boundary", async () => {
+			const handler = vi.fn(async (_event: unknown, ctx: ExtensionContext) => {
+				expect(ctx.signal).toBeInstanceOf(AbortSignal);
+			});
+			const extension = {
+				path: "lazy-context-extension",
+				handlers: new Map([["session_start", [handler]]]),
+			};
+			const runner = new ExtensionRunner(
+				[extension as never],
+				{ flagValues: new Map(), pendingProviderRegistrations: [] } as never,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			runner.initialize(
+				{} as never,
+				{
+					getModel: () => {
+						throw new Error("model accessor must stay lazy");
+					},
+				} as never,
+			);
+
+			await expect(runner.emit({ type: "session_start" })).resolves.toBeUndefined();
+			expect(handler).toHaveBeenCalledTimes(1);
+		});
 		it("times out session_start handlers, emits an error, and continues to sibling extensions", async () => {
 			const hangExtensionPath = path.join(tempDir.path(), "hang-session-start.ts");
 			const fastExtensionPath = path.join(tempDir.path(), "fast-session-start.ts");

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -647,7 +647,7 @@ describe("ExtensionRunner", () => {
 	});
 
 	describe("handler timeouts", () => {
-		it("preserves live context accessors while attaching a handler abort signal", async () => {
+		it("preserves live context accessors and writable signal semantics", async () => {
 			let currentModel = { id: "first-model" };
 			const observedModels: string[] = [];
 			const extension = {
@@ -658,6 +658,18 @@ describe("ExtensionRunner", () => {
 						[
 							async (_event: unknown, ctx: ExtensionContext) => {
 								expect(ctx.signal).toBeInstanceOf(AbortSignal);
+								const descriptor = Object.getOwnPropertyDescriptor(ctx, "signal");
+								expect(descriptor).toMatchObject({
+									configurable: true,
+									enumerable: true,
+									value: ctx.signal,
+									writable: true,
+								});
+								const replacementSignal = new AbortController().signal;
+								expect(() => {
+									ctx.signal = replacementSignal;
+								}).not.toThrow();
+								expect(ctx.signal).toBe(replacementSignal);
 								observedModels.push(ctx.model?.id ?? "missing");
 								currentModel = { id: "second-model" };
 								observedModels.push(ctx.model?.id ?? "missing");


### PR DESCRIPTION
## Signed status

**REPAIR READY / OWNER: @Yeachan-Heo / SOLE LANE: `fix/issue-3817-live-extension-context`**

Closes #3817.

## Failure and attribution

Merged `dev` commit `ded5926ad3c538a680449d61c1d31ac508499b2e` failed Dev CI run https://github.com/Yeachan-Heo/gajae-code/actions/runs/30890523179 in coding-agent shard 3/8:

- SDK Q10 model selection retained `initial-model` after selecting `reasoning-model`.
- Two SDK lifecycle containment tests rejected `runner.emit()` instead of resolving.
- Evidence producer and final affected-path validation failed only as cascades.

PR #3814 changed only TUI files. It exposed the regression by scheduling the dependent coding-agent shard; it did not cause it. All three failures reproduce at #3805 merge commit `0aa86a4c9537b2327145e09661de0aa85c95c16f` and pass at parent `9477947f8`.

#3805's handler timeout change attached `signal` with `{ ...ctx, signal }`. That eagerly evaluated the live `model` getter, freezing its value, and evaluated getters before the handler error boundary.

## Repair

Copy property descriptors into the per-handler context before adding its isolated abort signal. This preserves lazy/live getters and own-property enumeration without sharing timeout signals between handlers.

Added focused regression coverage for live getter updates and unused accessor laziness.

## Validation

- `bun test test/extensions-runner.test.ts test/sdk-default-model-selection-e2e.test.ts test/sdk-host-wiring.test.ts` — 112 pass, 0 fail.
- `bun --cwd=packages/coding-agent run check` — Biome and TypeScript pass.
- `bunx biome check ...` and `git diff --check` — pass.
- Exact shard 3/8 no longer reports the three Dev CI failures. A full local shard receipt remains blocked by unrelated operator-home GC discovery (`file lock discovery capped at 20000 entries`); attempts to substitute isolated HOME/config roots invalidate unrelated home/plugin-discovery fixtures, so that gap is left to PR CI rather than masking it.

No CI rerun/cancel, merge, canonical fast-forward, `main`, release, or #3805 evidence mutation was performed.

Signed-off-by: Bellman <gaebal-gajae@users.noreply.github.com>