### PR TITLE
feat(coding-agent): configure user-global AGENTS precedence

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- User-global AGENTS.md context precedence is now configurable with `context.userGlobalAgentsPrecedence: fallback | override`, and `~/AGENTS.md` can be loaded only through the user-owned `context.homeRootAgents` opt-in. Project settings cannot force either control, and home-root `AGENTS.md` discovered by ancestor walking is filtered unless the opt-in is enabled.
+
 ## [0.12.11] - 2026-08-03
 
 ### Fixed

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -11,6 +11,12 @@ Package-specific references:
 - [DEVELOPMENT](./DEVELOPMENT.md)
 - [RenderMermaid guide](../../docs/render-mermaid.md)
 
+## User-global AGENTS.md context
+
+GJC loads `~/.gjc/agent/AGENTS.md` as user-global context. By default it is fallback guidance: project `AGENTS.md` files render later and win conflicts. Set `context.userGlobalAgentsPrecedence: override` to make user-global AGENTS.md win context-file conflicts while still staying below system/developer instructions.
+
+`~/AGENTS.md` is not loaded by default. Set `context.homeRootAgents: true` to opt in to that home-root file as user-global context.
+
 ## External lifecycle notifications
 
 GJC already exposes public lifecycle events through the extension/hook event contract. External notification integrations for Discord, Hermes, clawhip, or similar channels should be opt-in and subscribe to these events instead of scraping transcripts or logs:

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1550,6 +1550,41 @@ export const SETTINGS_SCHEMA = {
 	// ────────────────────────────────────────────────────────────────────────
 	// Context
 	// ────────────────────────────────────────────────────────────────────────
+	// Context files
+	"context.userGlobalAgentsPrecedence": {
+		type: "enum",
+		values: ["fallback", "override"] as const,
+		default: "fallback",
+		ui: {
+			tab: "context",
+			label: "User Global AGENTS.md Precedence",
+			description:
+				"Controls whether user-global AGENTS.md files are fallback guidance or override project context files. System/developer instructions always remain higher authority.",
+			options: [
+				{
+					value: "fallback",
+					label: "Fallback",
+					description: "Render user-global AGENTS.md before project context so project files win conflicts",
+				},
+				{
+					value: "override",
+					label: "Override",
+					description: "Render user-global AGENTS.md after project context so user-global files win conflicts",
+				},
+			],
+		},
+	},
+
+	"context.homeRootAgents": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "context",
+			label: "Home Root AGENTS.md",
+			description:
+				"Opt in to loading ~/AGENTS.md as a user-global context file. Foreign provider home files remain excluded.",
+		},
+	},
 
 	// Context promotion
 	"contextPromotion.enabled": {

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -150,10 +150,28 @@ const LOCAL_NOTIFICATION_SETTING_PATHS = new Set(
 	[...LOCAL_NOTIFICATION_SETTING_KEYS].map(key => `notifications.${key}`),
 );
 
+const USER_GLOBAL_CONTEXT_SETTING_KEYS = new Set(["userGlobalAgentsPrecedence", "homeRootAgents"]);
+
 function isNotificationSettingsPath(path: string): boolean {
 	return (
 		(path === "notifications" || path.startsWith("notifications.")) && !LOCAL_NOTIFICATION_SETTING_PATHS.has(path)
 	);
+}
+
+function stripProjectUserGlobalContextSettings(value: unknown): { value: unknown; rejected: boolean } {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return { value, rejected: false };
+
+	let rejected = false;
+	const localContext: Record<string, unknown> = {};
+	for (const [contextKey, contextValue] of Object.entries(value)) {
+		if (USER_GLOBAL_CONTEXT_SETTING_KEYS.has(contextKey)) {
+			rejected = true;
+		} else {
+			localContext[contextKey] = contextValue;
+		}
+	}
+
+	return { value: Object.keys(localContext).length > 0 ? localContext : undefined, rejected };
 }
 
 function isAtomicSettingsPath(path: string): boolean {
@@ -1245,11 +1263,14 @@ export class Settings implements NotificationSettingsReader {
 			let merged: RawSettings = {};
 			for (const item of result.items as SettingsCapabilityItem[]) {
 				if (item.level !== "project") continue;
-				const { settings, rejectedNotifications } = this.#stripProjectNotificationSettings(
+				const { settings, rejectedNotifications, rejectedUserGlobalContext } = this.#stripProjectLocalOnlySettings(
 					item.data as RawSettings,
 				);
 				if (rejectedNotifications) {
 					logger.warn("Settings: ignoring project notification settings", { path: item.path });
+				}
+				if (rejectedUserGlobalContext) {
+					logger.warn("Settings: ignoring project user-global AGENTS.md settings", { path: item.path });
 				}
 				merged = this.#deepMerge(merged, settings);
 			}
@@ -1997,11 +2018,13 @@ export class Settings implements NotificationSettingsReader {
 		}
 	}
 
-	#stripProjectNotificationSettings(settings: RawSettings): {
+	#stripProjectLocalOnlySettings(settings: RawSettings): {
 		settings: RawSettings;
 		rejectedNotifications: boolean;
+		rejectedUserGlobalContext: boolean;
 	} {
 		let rejectedNotifications = false;
+		let rejectedUserGlobalContext = false;
 		const sanitized: RawSettings = {};
 		for (const [key, value] of Object.entries(settings)) {
 			if (key === "notifications" && value && typeof value === "object" && !Array.isArray(value)) {
@@ -2020,9 +2043,19 @@ export class Settings implements NotificationSettingsReader {
 				rejectedNotifications = true;
 				continue;
 			}
+			if (key === "context") {
+				const stripped = stripProjectUserGlobalContextSettings(value);
+				if (stripped.rejected) rejectedUserGlobalContext = true;
+				if (stripped.value !== undefined) sanitized[key] = stripped.value;
+				continue;
+			}
+			if (key === "context.userGlobalAgentsPrecedence" || key === "context.homeRootAgents") {
+				rejectedUserGlobalContext = true;
+				continue;
+			}
 			sanitized[key] = value;
 		}
-		return { settings: sanitized, rejectedNotifications };
+		return { settings: sanitized, rejectedNotifications, rejectedUserGlobalContext };
 	}
 
 	#deepMerge(base: RawSettings, overrides: RawSettings): RawSettings {

--- a/packages/coding-agent/src/prompts/system/custom-system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/custom-system-prompt.md
@@ -9,6 +9,10 @@
 <project>
 ## Context
 <instructions>
+Follow the context files below for all tasks. Later files have higher precedence when context files conflict.
+{{#if userGlobalAgentsOverride}}
+User-global AGENTS.md is configured as an override and has the highest context-file precedence.
+{{/if}}
 {{#list contextFiles join="\n"}}
 <file path="{{path}}">
 {{content}}

--- a/packages/coding-agent/src/prompts/system/project-prompt.md
+++ b/packages/coding-agent/src/prompts/system/project-prompt.md
@@ -5,7 +5,10 @@
 
 {{#if contextFiles.length}}
 <context>
-Follow the context files below for all tasks:
+Follow the context files below for all tasks. Later files have higher precedence when context files conflict.
+{{#if userGlobalAgentsOverride}}
+User-global AGENTS.md is configured as an override and has the highest context-file precedence.
+{{/if}}
 {{#each contextFiles}}
 <file path="{{path}}">
 {{content}}
@@ -16,7 +19,7 @@ Follow the context files below for all tasks:
 
 {{#if agentsMdSearch.files.length}}
 <dir-context>
-Some directories may have their own rules. Deeper rules override higher ones.
+Some directories may have their own rules. Deeper rules override higher ones{{#if userGlobalAgentsOverride}}, except user-global AGENTS.md remains the configured context-file override{{/if}}.
 MUST read before making changes within:
 {{#list agentsMdSearch.files join="\n"}}- {{this}}{{/list}}
 </dir-context>

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -640,14 +640,20 @@ export async function discoverSkills(
 
 /**
  * Discover context files (AGENTS.md) walking up from cwd.
- * Returns files sorted by depth (farther from cwd first, so closer files appear last/more prominent).
+ * Returns files sorted by prompt precedence, with later files winning context-file conflicts.
  */
 export async function discoverContextFiles(
 	cwd?: string,
 	_agentDir?: string,
+	options: {
+		userGlobalAgentsPrecedence?: "fallback" | "override";
+		includeHomeRootAgents?: boolean;
+	} = {},
 ): Promise<Array<{ path: string; content: string; depth?: number }>> {
 	return await loadContextFilesInternal({
 		cwd: cwd ?? getProjectDir(),
+		userGlobalAgentsPrecedence: options.userGlobalAgentsPrecedence,
+		includeHomeRootAgents: options.includeHomeRootAgents,
 	});
 }
 
@@ -686,6 +692,8 @@ export interface BuildSystemPromptOptions {
 	cwd?: string;
 	appendPrompt?: string;
 	repeatToolDescriptions?: boolean;
+	userGlobalAgentsPrecedence?: "fallback" | "override";
+	includeHomeRootAgents?: boolean;
 }
 
 /**
@@ -701,6 +709,8 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		contextFiles: options.contextFiles,
 		appendSystemPrompt: options.appendPrompt,
 		repeatToolDescriptions: options.repeatToolDescriptions,
+		userGlobalAgentsPrecedence: options.userGlobalAgentsPrecedence,
+		includeHomeRootAgents: options.includeHomeRootAgents,
 	});
 }
 
@@ -1169,7 +1179,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// session-context build, tool creation, MCP discovery, and extension discovery.
 		const contextFilesResultPromise = options.contextFiles
 			? Promise.resolve({ contextFiles: options.contextFiles, warnings: [] })
-			: logger.time("discoverContextFiles", loadContextFilesResultInternal, { cwd });
+			: logger.time("discoverContextFiles", loadContextFilesResultInternal, {
+					cwd,
+					userGlobalAgentsPrecedence: settings.getGlobal("context.userGlobalAgentsPrecedence") ?? "fallback",
+					includeHomeRootAgents: settings.getGlobal("context.homeRootAgents") ?? false,
+				});
 		contextFilesResultPromise.catch(() => {});
 		const promptTemplatesPromise = options.promptTemplates
 			? Promise.resolve(options.promptTemplates)
@@ -2311,6 +2325,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				appendSystemPrompt: appendPrompt,
 				pluginAppendices: pluginSystemAppendices,
 				repeatToolDescriptions,
+				userGlobalAgentsPrecedence: settings.getGlobal("context.userGlobalAgentsPrecedence") ?? "fallback",
+				includeHomeRootAgents: settings.getGlobal("context.homeRootAgents") ?? false,
 				intentField,
 				toolDiscoveryActive: effectiveDiscoveryMode === "all" || mcpDiscoveryEnabled,
 				eagerTasks,

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -3,6 +3,7 @@
  */
 
 import * as os from "node:os";
+import * as path from "node:path";
 import type { AgentTool } from "@gajae-code/agent-core";
 import { $env, getGpuCachePath, getProjectDir, hasFsCode, isEnoent, logger, prompt } from "@gajae-code/utils";
 import { $ } from "bun";
@@ -232,17 +233,24 @@ export async function resolvePromptInput(input: string | undefined, description:
 	}
 }
 
+export type UserGlobalAgentsPrecedence = "fallback" | "override";
+
 export interface LoadContextFilesOptions {
 	/** Working directory to start walking up from. Default: getProjectDir() */
 	cwd?: string;
+	/** Whether user-global AGENTS.md renders as fallback or as the strongest context file. */
+	userGlobalAgentsPrecedence?: UserGlobalAgentsPrecedence;
+	/** Include ~/AGENTS.md as an explicit opt-in user-global context file. */
+	includeHomeRootAgents?: boolean;
 }
 
-function dedupeExactContextFiles(
-	contextFiles: Array<{ path: string; content: string; depth?: number }>,
-): Array<{ path: string; content: string; depth?: number }> {
+type ContextFilePromptEntry = { path: string; content: string; depth?: number };
+
+function dedupeExactContextFiles(contextFiles: ContextFilePromptEntry[]): ContextFilePromptEntry[] {
 	const lastIndexByContent = new Map<string, number>();
 	for (const [index, file] of contextFiles.entries()) {
-		// Keep the closest matching context entry when content is byte-for-byte identical.
+		// Later entries have higher prompt precedence, so keep the strongest matching
+		// context entry when content is byte-for-byte identical.
 		lastIndexByContent.set(file.content, index);
 	}
 	return contextFiles.filter((file, index) => lastIndexByContent.get(file.content) === index);
@@ -253,30 +261,57 @@ export interface ProjectContextFilesResult {
 	warnings: string[];
 }
 
+async function loadHomeRootAgentsFile(home: string, include: boolean): Promise<ContextFilePromptEntry | null> {
+	if (!include) return null;
+
+	const homeRootAgentsPath = path.join(home, "AGENTS.md");
+	try {
+		const content = await Bun.file(homeRootAgentsPath).text();
+		if (!content.trim()) return null;
+		return { path: homeRootAgentsPath, content };
+	} catch (error) {
+		if (!isEnoent(error) && !hasFsCode(error, "ENOTDIR")) {
+			logger.warn("Could not read home-root AGENTS.md", { path: homeRootAgentsPath, error: String(error) });
+		}
+		return null;
+	}
+}
+
 /**
  * Load all context files using the capability API.
  * Returns {path, content, depth} entries for all discovered context files.
- * Native user-global files (`~/.gjc/agent/AGENTS.md`) come first, then project
- * files sorted by depth (descending) so files closer to cwd appear last/more
- * prominent. User-home files from foreign providers (`~/.claude/CLAUDE.md`,
- * `~/.codex/AGENTS.md`, …) stay excluded — only gjc's own user config applies.
+ * GJC-native user-global files (`~/.gjc/agent/AGENTS.md`) are included; the
+ * opt-in home-root file (`~/AGENTS.md`) is included only when requested. Foreign
+ * provider user-home files (`~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, …)
+ * stay excluded. By default user-global files render first as fallback; with
+ * `userGlobalAgentsPrecedence: "override"` they render last and override project
+ * context while remaining below platform/system/developer instructions.
  */
 export async function loadProjectContextFilesResult(
 	options: LoadContextFilesOptions = {},
 ): Promise<ProjectContextFilesResult> {
 	const resolvedCwd = options.cwd ?? getProjectDir();
-	const result = await loadCapability(contextFileCapability.id, { cwd: resolvedCwd });
+	const includeHomeRootAgents = options.includeHomeRootAgents === true;
+	const homeRootAgentsPath = path.resolve(os.homedir(), "AGENTS.md");
+	const userGlobalAgentsPrecedence = options.userGlobalAgentsPrecedence ?? "fallback";
+
+	const [result, homeRootAgents] = await Promise.all([
+		loadCapability(contextFileCapability.id, { cwd: resolvedCwd }),
+		loadHomeRootAgentsFile(os.homedir(), includeHomeRootAgents),
+	]);
 	const items = result.items as ContextFile[];
 
-	// Native user-global context applies everywhere and is least specific, so it
-	// renders first — project files rendered later take precedence over it.
-	const userFiles = items
+	const nativeUserFiles = items
 		.filter(item => item.level === "user" && item._source.provider === "native")
 		.map(item => ({ path: item.path, content: item.content }));
+	const userFiles = [homeRootAgents, ...nativeUserFiles].filter(
+		(file): file is ContextFilePromptEntry => file !== null,
+	);
 
-	// Convert project-level ContextFile items and preserve depth info
 	const projectFiles = items
-		.filter(item => item.level === "project")
+		.filter(
+			item => item.level === "project" && (includeHomeRootAgents || path.resolve(item.path) !== homeRootAgentsPath),
+		)
 		.map(item => ({
 			path: item.path,
 			content: item.content,
@@ -284,15 +319,18 @@ export async function loadProjectContextFilesResult(
 		}));
 
 	// Sort by depth (descending): higher depth (farther from cwd) comes first,
-	// so files closer to cwd appear later and are more prominent
+	// so files closer to cwd appear later and are more prominent.
 	projectFiles.sort((a, b) => {
 		const depthA = a.depth ?? -1;
 		const depthB = b.depth ?? -1;
 		return depthB - depthA;
 	});
 
+	const orderedFiles =
+		userGlobalAgentsPrecedence === "override" ? [...projectFiles, ...userFiles] : [...userFiles, ...projectFiles];
+
 	return {
-		contextFiles: dedupeExactContextFiles([...userFiles, ...projectFiles]),
+		contextFiles: dedupeExactContextFiles(orderedFiles),
 		warnings: result.warnings,
 	};
 }
@@ -374,6 +412,10 @@ export interface BuildSystemPromptOptions {
 	cwd?: string;
 	/** Pre-loaded context files (skips discovery if provided). */
 	contextFiles?: Array<{ path: string; content: string; depth?: number }>;
+	/** Whether user-global AGENTS.md renders before or after project context. */
+	userGlobalAgentsPrecedence?: UserGlobalAgentsPrecedence;
+	/** Include ~/AGENTS.md as an explicit opt-in user-global context file. */
+	includeHomeRootAgents?: boolean;
 	/** Skills provided directly to system prompt construction. */
 	skills?: Skill[];
 	/** Pre-loaded rulebook rules (descriptions, excluding TTSR and always-apply). */
@@ -448,6 +490,8 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		cwd,
 		contextFiles: providedContextFiles,
 		rules,
+		userGlobalAgentsPrecedence = "fallback",
+		includeHomeRootAgents = false,
 		alwaysApplyRules,
 		intentField,
 		toolDiscoveryActive = false,
@@ -505,7 +549,11 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 	});
 	const contextFilesPromise = providedContextFiles
 		? Promise.resolve({ contextFiles: providedContextFiles, warnings: [] })
-		: logger.time("loadProjectContextFiles", loadProjectContextFilesResult, { cwd: resolvedCwd });
+		: logger.time("loadProjectContextFiles", loadProjectContextFilesResult, {
+				cwd: resolvedCwd,
+				userGlobalAgentsPrecedence,
+				includeHomeRootAgents,
+			});
 	const workspaceTreePromise =
 		providedWorkspaceTree !== undefined
 			? Promise.resolve(providedWorkspaceTree)
@@ -614,6 +662,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		toolRefs,
 		environment,
 		contextFiles: sanitizedContextFiles,
+		userGlobalAgentsOverride: userGlobalAgentsPrecedence === "override",
 		agentsMdSearch: { files: agentsMdFiles.map(file => escapePromptMetadata(file)) },
 		workspaceTree,
 		rules: rules ?? [],

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -299,6 +299,17 @@ export {
 function hasAvailableIrcTool(session: ToolSession): boolean {
 	return session.settings.get("irc.enabled") === true && session.getToolByName?.("irc") !== undefined;
 }
+function isUserGlobalAgentsOverrideFile(session: ToolSession, filePath: string): boolean {
+	if ((session.settings.getGlobal("context.userGlobalAgentsPrecedence") ?? "fallback") !== "override") return false;
+
+	const resolvedPath = path.resolve(filePath);
+	const candidates = [path.join(session.settings.getAgentDir(), "AGENTS.md")];
+	if ((session.settings.getGlobal("context.homeRootAgents") ?? false) === true) {
+		candidates.push(path.join(os.homedir(), "AGENTS.md"));
+	}
+
+	return candidates.some(candidate => path.resolve(candidate) === resolvedPath);
+}
 
 function renderDescription(
 	agents: AgentDefinition[],
@@ -1834,7 +1845,9 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 							.filter((s): s is NonNullable<typeof s> => s !== undefined)
 					: [];
 			const contextFiles = this.session.contextFiles?.filter(
-				file => path.basename(file.path).toLowerCase() !== "agents.md",
+				file =>
+					path.basename(file.path).toLowerCase() !== "agents.md" ||
+					isUserGlobalAgentsOverrideFile(this.session, file.path),
 			);
 			const promptTemplates = this.session.promptTemplates;
 

--- a/packages/coding-agent/test/system-prompt-dedup.test.ts
+++ b/packages/coding-agent/test/system-prompt-dedup.test.ts
@@ -107,6 +107,104 @@ describe("SYSTEM.md prompt assembly", () => {
 		expect(paths).toContain(path.join(projectDir, "AGENTS.md"));
 	});
 
+	it("loads user-global AGENTS.md after project context when override precedence is configured", async () => {
+		const projectDir = path.join(tempDir, "project");
+		fs.mkdirSync(projectDir, { recursive: true });
+		fs.writeFileSync(path.join(projectDir, "AGENTS.md"), "Project instructions");
+		const userAgentsPath = path.join(tempHomeDir, ".gjc", "agent", "AGENTS.md");
+		fs.mkdirSync(path.dirname(userAgentsPath), { recursive: true });
+		fs.writeFileSync(userAgentsPath, "User-global instructions");
+
+		const files = await loadProjectContextFiles({
+			cwd: projectDir,
+			userGlobalAgentsPrecedence: "override",
+		});
+
+		expect(files.map(file => file.path)).toEqual([path.join(projectDir, "AGENTS.md"), userAgentsPath]);
+	});
+
+	it("loads home-root AGENTS.md only when explicitly enabled and lets it override project context", async () => {
+		const projectDir = path.join(tempDir, "project");
+		fs.mkdirSync(projectDir, { recursive: true });
+		fs.writeFileSync(path.join(projectDir, "AGENTS.md"), "Project instructions");
+		const homeRootAgentsPath = path.join(tempHomeDir, "AGENTS.md");
+		fs.writeFileSync(homeRootAgentsPath, "Home-root instructions");
+
+		await expect(loadProjectContextFiles({ cwd: projectDir })).resolves.toEqual([
+			{
+				path: path.join(projectDir, "AGENTS.md"),
+				content: "Project instructions",
+				depth: 0,
+			},
+		]);
+
+		const files = await loadProjectContextFiles({
+			cwd: projectDir,
+			includeHomeRootAgents: true,
+			userGlobalAgentsPrecedence: "override",
+		});
+
+		expect(files.map(file => file.path)).toEqual([path.join(projectDir, "AGENTS.md"), homeRootAgentsPath]);
+	});
+
+	it("excludes home-root AGENTS.md discovered by ancestor walking unless explicitly enabled", async () => {
+		const workDir = path.join(tempHomeDir, "scratch", "nested");
+		fs.mkdirSync(workDir, { recursive: true });
+		const homeRootAgentsPath = path.join(tempHomeDir, "AGENTS.md");
+		fs.writeFileSync(homeRootAgentsPath, "Home-root instructions");
+
+		await expect(loadProjectContextFiles({ cwd: workDir })).resolves.toEqual([]);
+
+		const files = await loadProjectContextFiles({
+			cwd: workDir,
+			includeHomeRootAgents: true,
+		});
+
+		expect(files.map(file => file.path)).toEqual([homeRootAgentsPath]);
+	});
+
+	it("ignores project-scoped user-global AGENTS.md settings", async () => {
+		const projectDir = path.join(tempDir, "project");
+		const agentDir = path.join(tempDir, "agent");
+		fs.mkdirSync(path.join(projectDir, ".gjc"), { recursive: true });
+		fs.mkdirSync(agentDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(projectDir, ".gjc", "config.yml"),
+			["context:", "  homeRootAgents: true", "  userGlobalAgentsPrecedence: override", ""].join("\n"),
+		);
+
+		const settings = await Settings.loadForScope({ cwd: projectDir, agentDir });
+		try {
+			expect(settings.get("context.homeRootAgents")).toBe(false);
+			expect(settings.get("context.userGlobalAgentsPrecedence")).toBe("fallback");
+			expect(settings.getGlobal("context.homeRootAgents")).toBeUndefined();
+			expect(settings.getGlobal("context.userGlobalAgentsPrecedence")).toBeUndefined();
+		} finally {
+			settings.getStorage()?.close();
+		}
+	});
+
+	it("renders an explicit override precedence notice in project context", async () => {
+		const projectDir = path.join(tempDir, "project");
+		fs.mkdirSync(projectDir, { recursive: true });
+		const { systemPrompt } = await buildSystemPrompt({
+			cwd: projectDir,
+			contextFiles: [
+				{ path: path.join(projectDir, "AGENTS.md"), content: "Project instructions", depth: 0 },
+				{ path: path.join(tempHomeDir, "AGENTS.md"), content: "Home-root instructions" },
+			],
+			userGlobalAgentsPrecedence: "override",
+			skills: [],
+			rules: [],
+			toolNames: [],
+		});
+
+		const promptText = systemPrompt.join("\n\n");
+
+		expect(promptText).toContain("Later files have higher precedence");
+		expect(promptText).toContain("User-global AGENTS.md is configured as an override");
+	});
+
 	it("includes the native user-global file while still excluding foreign user-home files", async () => {
 		const projectDir = path.join(tempDir, "project");
 		fs.mkdirSync(projectDir, { recursive: true });

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -1176,6 +1176,26 @@
 			},
 			"additionalProperties": false
 		},
+		"context": {
+			"type": "object",
+			"properties": {
+				"userGlobalAgentsPrecedence": {
+					"type": "string",
+					"enum": [
+						"fallback",
+						"override"
+					],
+					"description": "Controls whether user-global AGENTS.md files are fallback guidance or override project context files. System/developer instructions always remain higher authority.",
+					"default": "fallback"
+				},
+				"homeRootAgents": {
+					"type": "boolean",
+					"description": "Opt in to loading ~/AGENTS.md as a user-global context file. Foreign provider home files remain excluded.",
+					"default": false
+				}
+			},
+			"additionalProperties": false
+		},
 		"contextPromotion": {
 			"type": "object",
 			"properties": {


### PR DESCRIPTION
## Summary
- add `context.userGlobalAgentsPrecedence` (`fallback`/`override`) for user-global AGENTS.md ordering
- add user-owned `context.homeRootAgents` support for `~/AGENTS.md`
- keep foreign provider home context excluded and document the new behavior
- reject project-scoped attempts to set user-global AGENTS controls
- filter `~/AGENTS.md` discovered by ancestor walking unless the user-owned opt-in is enabled

## Exact blocker-resolution map
- P1 global-only controls can be overridden by project settings → resolved by reading runtime controls with `settings.getGlobal(...) ?? schema default` and stripping `context.userGlobalAgentsPrecedence` / `context.homeRootAgents` from project config during settings load.
- P2 home-root opt-in bypass for non-Git paths under HOME → resolved by filtering the exact home-root `AGENTS.md` path from discovered project context unless `includeHomeRootAgents` is true; direct `~/AGENTS.md` loading remains gated by the same opt-in.
- Changelog entry outside Unreleased → resolved by adding this feature note under `packages/coding-agent/CHANGELOG.md` `## [Unreleased]`; released sections are untouched.
- Missing blocker-resolution map → this section maps each recorded blocker to the exact fix.
- current-dev/current-main base → branch is a single commit on current `upstream/main`.

## Focused regression coverage
- `system-prompt-dedup.test.ts` covers default fallback ordering, override ordering, home-root opt-in behavior, non-Git `$HOME` ancestor-walk filtering, and project-scoped control rejection.

## Verification
- `bun scripts/generate-json-schemas.ts --check`
- `bun run check:tools`
- `git diff --check`

## Local blocked checks
- `bun test packages/coding-agent/test/system-prompt-dedup.test.ts` is blocked before test execution by missing local native addon `pi_natives.darwin-arm64.node`.
- `bun --cwd=packages/coding-agent run check` is still blocked locally by upstream ACP SDK type drift around `DeleteSessionRequest` / `deleteSession`.

Supersedes closed PR #3815.

Made with [Orca](https://github.com/stablyai/orca) 🐋
