### PR TITLE
fix(session): tolerate concurrent cleanup receipt retirement

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Concurrent managed-session writers no longer abort an append with `ENOENT` or `managed_replace_receipt_cleanup_pending:not_found` when another writer retires the same replacement cleanup receipt between reconciliation discovery, capture, and identity-verified unlink.
 - Telegram daemon restart now revokes every persisted callback alias before polling. Reconnecting sessions must replay a pending ask to receive fresh, owner-bound aliases; old controls remain stale, and their keyboards are best-effort terminalized when the original Telegram message id is available. Shutdown now fences new session messages and drains every admitted handler before final callback persistence and ownership release, preventing a successful send racing shutdown from publishing alias state after a successor takes ownership (#3727).
 - Direct interactive launches inside tmux now bind automatic window renames to the originating pane's immutable pane/window identities and observed window index. If that binding changes before mutation, GJC preserves every window name instead of renaming whichever window became active (#3808).
 

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -788,23 +788,38 @@ export class ManagedSessionDescendantStore {
 	#detachReplacementCleanupReceipt(receiptPath: string): void {
 		const binding = replacementCleanupReceiptBinding(path.basename(receiptPath));
 		if (!binding) throw new Error("managed_replace_cleanup_receipt_invalid");
-		const receipt = captureManagedFileNoFollow(receiptPath);
+		// Another process sharing this session directory may retire a receipt after
+		// reconciliation discovers it. A missing receipt means cleanup completed.
+		let receipt: ManagedFileSnapshot;
+		try {
+			receipt = captureManagedFileNoFollow(receiptPath);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+			throw error;
+		}
 		if (receipt.identity.dev !== binding.receipt.dev || receipt.identity.ino !== binding.receipt.ino)
 			throw new Error("managed_replace_cleanup_receipt_invalid");
 		const predecessor = binding.predecessor;
 		const quarantineName = `.gjc-receipt-remove-${receipt.identity.dev.toString(16)}-${receipt.identity.ino.toString(16)}-${predecessor.dev.toString(16)}-${predecessor.ino.toString(16)}`;
-		const detached = exactUnlink(receiptPath, {
-			dev: receipt.identity.dev,
-			ino: receipt.identity.ino,
-			nlink: receipt.identity.nlink,
-			parentDev: this.#subtreeRoot.dev,
-			parentIno: this.#subtreeRoot.ino,
-			size: BigInt(receipt.identity.size),
-			mtimeNs: receipt.identity.mtimeNs,
-			sha256: receipt.identity.sha256,
-			detachOnly: true,
-			quarantineName,
-		});
+		let detached: NativeExactUnlinkResult;
+		try {
+			detached = exactUnlink(receiptPath, {
+				dev: receipt.identity.dev,
+				ino: receipt.identity.ino,
+				nlink: receipt.identity.nlink,
+				parentDev: this.#subtreeRoot.dev,
+				parentIno: this.#subtreeRoot.ino,
+				size: BigInt(receipt.identity.size),
+				mtimeNs: receipt.identity.mtimeNs,
+				sha256: receipt.identity.sha256,
+				detachOnly: true,
+				quarantineName,
+			});
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+			throw error;
+		}
+		if (detached.code === "not_found") return;
 		if (
 			(!detached.ok && detached.code !== "cleanup_pending") ||
 			detached.detachedPath !== path.join(this.#baseDir, quarantineName) ||

--- a/packages/coding-agent/test/session-storage.test.ts
+++ b/packages/coding-agent/test/session-storage.test.ts
@@ -913,6 +913,43 @@ describe.skipIf(process.platform !== "darwin")("managed replacement receipt deta
 		expect(fs.readFileSync(predecessorPath, "utf8")).toBe("retained predecessor\n");
 		expect(fs.readFileSync(path.join(root, "receipt-detached"), "utf8")).toBe("trigger\n");
 	});
+	it("treats a receipt retired by a concurrent owner as already reconciled", () => {
+		const predecessorPath = path.join(root, "predecessor");
+		fs.writeFileSync(predecessorPath, "predecessor\n");
+		const predecessor = snapshot(predecessorPath);
+		const { receipt } = publishReceipt(predecessor, JSON.stringify({ arbitrary: "receipt contents are advisory" }));
+		vi.spyOn(native, "exactUnlink").mockImplementationOnce(pathname => {
+			expect(pathname).toBe(receipt);
+			fs.unlinkSync(pathname);
+			return { ok: false, code: "not_found" };
+		});
+
+		replay("concurrent-retirement");
+
+		expect(fs.existsSync(receipt)).toBe(false);
+		expect(fs.readFileSync(path.join(root, "concurrent-retirement"), "utf8")).toBe("trigger\n");
+		expect(fs.readFileSync(predecessorPath, "utf8")).toBe("predecessor\n");
+	});
+	it("treats a receipt removed after reconciliation discovery as already reconciled", () => {
+		const predecessorPath = path.join(root, "predecessor");
+		fs.writeFileSync(predecessorPath, "predecessor\n");
+		const predecessor = snapshot(predecessorPath);
+		const { receipt } = publishReceipt(predecessor, JSON.stringify({ arbitrary: "receipt contents are advisory" }));
+		const openSync = fs.openSync;
+		vi.spyOn(fs, "openSync").mockImplementation((pathname, flags, mode) => {
+			if (pathname !== receipt) return openSync(pathname, flags, mode);
+			fs.unlinkSync(receipt);
+			const missing = new Error(`ENOENT: no such file or directory, open '${receipt}'`) as NodeJS.ErrnoException;
+			missing.code = "ENOENT";
+			throw missing;
+		});
+
+		replay("concurrent-discovery-retirement");
+
+		expect(fs.existsSync(receipt)).toBe(false);
+		expect(fs.readFileSync(path.join(root, "concurrent-discovery-retirement"), "utf8")).toBe("trigger\n");
+		expect(fs.readFileSync(predecessorPath, "utf8")).toBe("predecessor\n");
+	});
 
 	it("recovers a regular-file cleanup placeholder without deleting either quarantined receipt", () => {
 		const predecessorPath = path.join(root, "predecessor");


### PR DESCRIPTION
## What

Treat an already-retired managed replacement cleanup receipt as a completed reconciliation outcome.

- return cleanly when receipt capture loses the race with another process and raises `ENOENT`
- return cleanly when identity-verified `exactUnlink` throws `ENOENT` or returns native `not_found`
- preserve canonical filename, inode, and content identity checks for receipts that still exist
- add deterministic regressions for both the stale-readdir/open race and the post-capture native-unlink race
- document the user-visible fix in the coding-agent changelog

## Why

Multiple `gjc` processes for the same workspace share one managed session directory. Each mutation scans `.gjc-replace-cleanup-*` receipts. A peer can retire a receipt after one process snapshots the directory but before that process captures or detaches the path.

That successful peer cleanup currently escapes as either:

```text
ENOENT: no such file or directory, open|lstat '<session-dir>/.gjc-replace-cleanup-...json'
```

or:

```text
managed_replace_receipt_cleanup_pending:not_found
```

The exception aborts the unrelated session append that triggered reconciliation. The replacement publisher already treats an absent receipt as benign during its own cleanup; this change gives the reconciler the same idempotent semantics without weakening validation for present receipts.

The reproduction test failed before the fix with:

```text
managed_replace_receipt_cleanup_pending:not_found
```

and passes after the fix.

## Testing

Passed:

- `bun --cwd=packages/coding-agent run check`
- `bun test packages/coding-agent/test/session-storage.test.ts --test-name-pattern "managed replacement receipt detachment"`
  - 7 passed, 0 failed, 4 skipped
- independent exact-head architect review: approved, no blocking/high findings

Broader baseline notes (unrelated to this diff):

- full `session-storage.test.ts`: 72 passed, 4 pre-existing `FileSessionStorageWriter path security` failures; the same four failures reproduce on untouched `upstream/dev`
- root `bun run check`: TS/Rust orchestration is blocked by two pre-existing `sdk-host-wiring.test.ts` failures that reproduce on untouched `upstream/dev`, plus existing Rust formatting drift in vendored/source crates

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:fef5de7b90cabe651b495334156d381d66d73e33 reviewer:architect evidence:live-pr-3820-static-review
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (blocked by reproducible upstream baseline failures documented above)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
