### PR TITLE
fix(slack): form encode Slack Web API requests

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Slack Web API calls are now form encoded instead of JSON encoded. `conversations.replies` rejects `application/json` with `invalid_arguments`, so the reconciliation lookup that follows an uncertain root post threw an uncaught `SlackProviderError` and killed the notification daemon before it published ownership. Sessions then reported `slack runtime is not ready or attached` and never received a Slack thread, even with valid credentials, scopes, and configuration.
+
 - Telegram daemon restart now revokes every persisted callback alias before polling. Reconnecting sessions must replay a pending ask to receive fresh, owner-bound aliases; old controls remain stale, and their keyboards are best-effort terminalized when the original Telegram message id is available. Shutdown now fences new session messages and drains every admitted handler before final callback persistence and ownership release, preventing a successful send racing shutdown from publishing alias state after a successor takes ownership (#3727).
 - Extension handler timeout signals now preserve lazy, live context accessors instead of eagerly snapshotting them. Model changes made through SDK controls are immediately visible to later context reads, and unused getters can no longer reject lifecycle emission before the runner's extension error boundary (#3817).
 - Direct interactive launches inside tmux now bind automatic window renames to the originating pane's immutable pane/window identities and observed window index. If that binding changes before mutation, GJC preserves every window name instead of renaming whichever window became active (#3808).

--- a/packages/coding-agent/src/sdk/bus/slack-live-provider.ts
+++ b/packages/coding-agent/src/sdk/bus/slack-live-provider.ts
@@ -86,6 +86,20 @@ function messages(value: unknown): SlackApiMessage[] {
 		: [];
 }
 
+/**
+ * Slack Web API request bodies must be form encoded. Several read methods —
+ * `conversations.replies` among them — reject `application/json` with
+ * `invalid_arguments`, so JSON encoding breaks root-post reconciliation and
+ * takes the notification daemon down with an uncaught provider error.
+ */
+function formBody(body: Record<string, string | undefined>): string {
+	const parameters = new URLSearchParams();
+	for (const [key, value] of Object.entries(body)) {
+		if (value !== undefined) parameters.set(key, value);
+	}
+	return parameters.toString();
+}
+
 function retryAfterMilliseconds(response: Response, body: SlackApiResponse, maximum: number): number {
 	const header = Number(response.headers.get("retry-after"));
 	const bodyValue = typeof body.retry_after === "number" ? body.retry_after : Number(body.retry_after);
@@ -385,8 +399,11 @@ export class SlackLiveProvider implements SlackProviderClient, SlackDiagnosticPr
 			try {
 				response = await this.#fetch(`${SLACK_API}/${operation}`, {
 					method: "POST",
-					headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json; charset=utf-8" },
-					body: JSON.stringify(body),
+					headers: {
+						Authorization: `Bearer ${token}`,
+						"Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+					},
+					body: formBody(body),
 					signal,
 				});
 			} catch {

--- a/packages/coding-agent/test/sdk-slack-live-provider.test.ts
+++ b/packages/coding-agent/test/sdk-slack-live-provider.test.ts
@@ -167,6 +167,34 @@ describe("SlackLiveProvider fake Socket Mode protocol", () => {
 		expect(fixture.requests[0]?.init?.body).toContain("client_msg_id");
 	});
 
+	it("form encodes every Web API request so conversations.replies is not rejected", async () => {
+		const fixture = setup([
+			response({ ok: true, channel: "C1", ts: "1.0", client_msg_id: "client-1" }),
+			response({ ok: true, messages: [] }),
+			response({ ok: true, messages: [{ ts: "2.0", client_msg_id: "client-1" }] }),
+		]);
+		await fixture.provider.postMessage({ channel: "C1", text: "hi there", clientMsgId: "client-1" });
+		await fixture.provider.findMessageByClientMsgId({ channel: "C1", threadTs: "0.0", clientMsgId: "client-1" });
+
+		expect(fixture.requests).toHaveLength(3);
+		for (const request of fixture.requests) {
+			const headers = request.init?.headers as Record<string, string> | undefined;
+			expect(headers?.["Content-Type"]).toBe("application/x-www-form-urlencoded; charset=utf-8");
+			expect(typeof request.init?.body).toBe("string");
+		}
+
+		const post = new URLSearchParams(String(fixture.requests[0]?.init?.body));
+		expect(post.get("channel")).toBe("C1");
+		expect(post.get("text")).toBe("hi there");
+		expect(post.get("client_msg_id")).toBe("client-1");
+		// Absent optional fields must not reach Slack as the literal "undefined".
+		expect(post.has("thread_ts")).toBe(false);
+
+		const replies = new URLSearchParams(String(fixture.requests[2]?.init?.body));
+		expect(replies.get("channel")).toBe("C1");
+		expect(replies.get("ts")).toBe("0.0");
+	});
+
 	it("bounds rate-limit retry and exposes no credential in typed errors", async () => {
 		const fixture = setup([
 			response({ ok: false }, 429, { "retry-after": "120" }),


### PR DESCRIPTION
## What changed

`SlackLiveProvider#request` now sends Slack Web API calls as
`application/x-www-form-urlencoded` instead of `application/json`.

## Why

`conversations.replies` is form-encoded only. It answers `invalid_arguments`
for a JSON body:

```
POST conversations.replies  Content-Type: application/json
  -> ok=false  error=invalid_arguments
POST conversations.replies  Content-Type: application/x-www-form-urlencoded
  -> ok=true
```

`findMessageByClientMsgId` calls it for the reconciliation lookup that follows
an uncertain root post. `#api` turns the `ok=false` into a thrown
`SlackProviderError`, which is uncaught in the daemon's post path, so the
notification daemon dies before publishing ownership:

```
[Uncaught Exception] SlackProviderError: conversations.replies failed (web_api)
    at #api (slack-live-provider.ts:372)
    at async findMessageByClientMsgId (slack-live-provider.ts:269)
    at async findMessageByClientMsgId (slack-provider.ts:98)
    at async <anonymous> (slack-daemon.ts:1815)
    at async #postDurable (slack-daemon.ts:1814)
    at async notify (slack-daemon.ts:515)
```

Observed symptoms with valid credentials, scopes (`chat:write`,
`channels:history`), and a complete `gjc notify setup slack`:

- `gjc daemon restart slack` -> `slack daemon did not publish ownership after spawning`
- `gjc notify test --provider slack` -> `slack runtime is not ready or attached`
- `ensureSlackDaemon` -> `Unable to attach or spawn slack daemon owner`
- no session ever receives a Slack thread

`gjc notify health --provider slack --probe` reports OK throughout, because
`auth.test` and `apps.connections.open` both accept JSON. Only the read
methods reject it, which makes this hard to attribute to encoding.

Note `conversations.history` accepts JSON, so the failure only appears on the
thread-reply branch after the history lookup misses.

## Why form encoding for all calls

Form encoding is Slack's canonical request format and is lossless here: every
`#request` body is a flat `Record<string, string | undefined>`. `formBody`
drops undefined entries so an absent optional field cannot reach Slack as the
literal string `"undefined"` — `JSON.stringify` dropped them too, so this
preserves existing behavior.

## Tests

The existing reconciliation test asserted only that the request body contained
`client_msg_id`, which held under both encodings — that is why this slipped
through. The added test asserts the wire encoding directly:

```
bun test packages/coding-agent/test/sdk-slack-live-provider.test.ts
  11 pass, 0 fail
```

Reverting the source change makes the new test fail with
`Expected: application/x-www-form-urlencoded; charset=utf-8` /
`Received: application/json; charset=utf-8`.

Also run: `biome check` and `tsc --noEmit` clean on the changed files.

`sdk-slack-daemon.test.ts` and `sdk-slack-thread-state.test.ts` fail in a fresh
worktree because `pi_natives.darwin-arm64.node` is not built; they fail
identically on an unmodified checkout.

## Verified against a live workspace

After patching a local `0.12.11` install, the daemon attached and posted real
session roots:

```
gjc daemon status slack  -> running
gjc notify test --provider slack -> OK - Slack notification test delivered
```
