### PR TITLE
fix(session): observe resume picker rejections without process kill (#3804)

### DIFF
--- a/packages/coding-agent/src/modes/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/components/session-selector.ts
@@ -197,7 +197,7 @@ export class SessionSelectorComponent extends Container {
 
 	constructor(
 		sessions: SessionInfo[],
-		private readonly onSelect: (sessionPath: string) => void,
+		private readonly onSelect: (sessionPath: string) => void | Promise<void>,
 		private readonly onCancel: () => void,
 		private readonly onExit: () => void,
 		private readonly onDelete?: (session: SessionInfo) => Promise<boolean>,
@@ -214,7 +214,7 @@ export class SessionSelectorComponent extends Container {
 		this.#sessionList = new SessionList(sessions);
 		this.#sessionList.onSelect = session => {
 			if (this.inspector) void this.#inspect(session);
-			else this.onSelect(session.path);
+			else this.#dispatchSelect(session.path);
 		};
 		this.#sessionList.onCancel = () => this.#cancel();
 		this.#sessionList.onExit = () => this.#exit();
@@ -241,6 +241,29 @@ export class SessionSelectorComponent extends Container {
 		this.#onRequestRender?.();
 	}
 
+	/**
+	 * Observe async `onSelect` handlers. Callers (e.g. resume) may return a
+	 * Promise; leaving it unobserved turns preparation/switch failures into
+	 * process-killing unhandled rejections. Inline recovery keeps the picker
+	 * usable when the host has not already closed it.
+	 */
+	#dispatchSelect(sessionPath: string): void {
+		void Promise.resolve(this.onSelect(sessionPath)).catch((error: unknown) => {
+			if (this.#state.kind === "settled") {
+				// Host already closed the picker (interactive resume path). Surface the
+				// message only if we still have a render surface; controller catch is
+				// the primary recovery path after `done()`.
+				this.#showError(error instanceof Error ? error.message : String(error));
+				this.#requestRender();
+				return;
+			}
+			this.#state = { kind: "browsing" };
+			this.#sessionList.setInputFrozen(false);
+			this.#showError(error instanceof Error ? error.message : String(error));
+			this.#requestRender();
+		});
+	}
+
 	#settle(selection: SessionSelectionResult): void {
 		if (this.#state.kind === "settled") return;
 		this.#state = { kind: "settled" };
@@ -249,7 +272,7 @@ export class SessionSelectorComponent extends Container {
 		this.#confirmationDialog = null;
 		if (dialog) this.removeChild(dialog);
 		if (this.onSelection) this.onSelection(selection);
-		else if (selection.kind === "selected") this.onSelect(selection.path);
+		else if (selection.kind === "selected") this.#dispatchSelect(selection.path);
 		else this.onCancel();
 	}
 	#cancel(): void {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -2638,9 +2638,15 @@ export class SelectorController {
 		this.showSelector(done => {
 			const selector = new SessionSelectorComponent(
 				sessions,
-				async sessionPath => {
+				sessionPath => {
+					// `onSelect` is a void dispatch boundary: close the picker first, then
+					// observe resume failures so a managed-candidate race (or any other
+					// preparation/switch rejection) surfaces as UI error instead of an
+					// unhandled rejection that can kill the process. Do not auto-retry.
 					done();
-					await this.handleResumeSession(sessionPath);
+					void this.handleResumeSession(sessionPath).catch(error => {
+						this.ctx.showError(error instanceof Error ? error.message : String(error));
+					});
 				},
 				() => {
 					done();

--- a/packages/coding-agent/test/modes/components/session-selector-resume-confirm.test.ts
+++ b/packages/coding-agent/test/modes/components/session-selector-resume-confirm.test.ts
@@ -154,4 +154,34 @@ describe("SessionSelectorComponent resume consent", () => {
 		expect(text(component)).toContain("Error: unreadable");
 		expect(results).toEqual([]);
 	});
+
+	it("observes async onSelect rejections without unhandled rejection (#3804)", async () => {
+		const unhandled = vi.fn();
+		process.on("unhandledRejection", unhandled);
+		try {
+			const selected = vi.fn(async () => {
+				throw new Error("Managed session changed before migration authority was adopted.");
+			});
+			const component = new SessionSelectorComponent(
+				[session("one")],
+				selected,
+				() => {},
+				() => {},
+				undefined,
+			);
+			component.handleInput("\n");
+			await Bun.sleep(0);
+			await new Promise<void>(resolve => setImmediate(resolve));
+
+			expect(selected).toHaveBeenCalledWith("/tmp/one.jsonl");
+			expect(text(component)).toContain(
+				"Error: Managed session changed before migration authority was adopted.",
+			);
+			// Picker stays usable for another attempt (no auto-retry of the same candidate).
+			expect(text(component)).toContain("one");
+			expect(unhandled).not.toHaveBeenCalled();
+		} finally {
+			process.off("unhandledRejection", unhandled);
+		}
+	});
 });

--- a/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts
@@ -320,6 +320,70 @@ describe("SelectorController session deletion", () => {
 		expect(switchSession).not.toHaveBeenCalled();
 	});
 
+	it("surfaces managed-candidate race from the picker without unhandled rejection (#3804)", async () => {
+		const selected = makeSessionInfo("/tmp/project/legacy/race.jsonl");
+		const identity = {
+			canonicalPath: selected.path,
+			sessionId: "race",
+			dev: 1n,
+			ino: 1n,
+			size: 1,
+			mtimeMs: 1,
+			mtimeNs: 1n,
+			sha256: "before-replacement",
+		};
+		const {
+			ctx,
+			switchSession,
+			prepareManagedCandidateForStrictAdoption,
+			setManagedDestination,
+			listForResumePickerReadOnly,
+		} = createContext("/tmp/project/sessions/a.jsonl");
+		setManagedDestination(true);
+		listForResumePickerReadOnly.mockResolvedValue([selected]);
+		vi.spyOn(SessionManager, "inspectSessionTailReadOnly").mockResolvedValue({ kind: "resumable", identity });
+		prepareManagedCandidateForStrictAdoption.mockRejectedValue(
+			new Error("Managed session changed before migration authority was adopted."),
+		);
+		const errorShown = Promise.withResolvers<void>();
+		const showError = vi.fn(() => errorShown.resolve());
+		ctx.showError = showError;
+		const controller = new SelectorController(ctx);
+		const unhandled = vi.fn();
+		process.on("unhandledRejection", unhandled);
+
+		try {
+			await controller.showSessionSelector();
+			const selector = ctx.editorContainer.children[0];
+			if (!(selector instanceof SessionSelectorComponent)) {
+				throw new Error("Expected session selector component");
+			}
+
+			// Legacy five-argument path: Enter selects immediately via void onSelect.
+			selector.handleInput("\n");
+			await errorShown.promise;
+			// Give the event loop a tick so an unobserved rejection would fire.
+			await new Promise<void>(resolve => setImmediate(resolve));
+
+			expect(showError).toHaveBeenCalledWith(
+				"Managed session changed before migration authority was adopted.",
+			);
+			expect(unhandled).not.toHaveBeenCalled();
+			// Strict fence: one preparation attempt, no switch, no auto-retry.
+			expect(prepareManagedCandidateForStrictAdoption).toHaveBeenCalledTimes(1);
+			expect(prepareManagedCandidateForStrictAdoption).toHaveBeenCalledWith(
+				selected.path,
+				"copy-retain",
+				identity,
+			);
+			expect(switchSession).not.toHaveBeenCalled();
+			// Current session remains the active one after recovery.
+			expect(ctx.sessionManager.getSessionFile()).toBe("/tmp/project/sessions/a.jsonl");
+		} finally {
+			process.off("unhandledRejection", unhandled);
+		}
+	});
+
 	it("lists sessions through the active manager's captured destination authority", async () => {
 		const { ctx, listForResumePickerReadOnly } = createContext("/tmp/project/sessions/a.jsonl");
 		const controller = new SelectorController(ctx);

--- a/packages/coding-agent/test/modes/controllers/session-selector-delete.test.ts
+++ b/packages/coding-agent/test/modes/controllers/session-selector-delete.test.ts
@@ -28,7 +28,7 @@ function createSession(id: string, title: string): SessionInfo {
 
 function createSelector(
 	onDelete: (session: SessionInfo) => Promise<boolean>,
-	onSelect: (sessionPath: string) => void = () => {},
+	onSelect: (sessionPath: string) => void | Promise<void> = () => {},
 ): SessionSelectorComponent {
 	return new SessionSelectorComponent(
 		[createSession("session-a", "Alpha"), createSession("session-b", "Beta")],


### PR DESCRIPTION
## Summary

Fixes #3804.

Managed-candidate preparation can reject with `Managed session changed before migration authority was adopted.` before the inner `switchSession()` catch in `handleResumeSession`. The session picker typed and invoked `onSelect` as a void callback while the host passed an async resume path, so that rejection escaped as an **unhandled promise rejection** and could kill the process (observed on Windows upgrade resume).

This PR observes the async rejection at the UI dispatch boundary, surfaces it via `showError`, and keeps the current session usable. The strict identity fence is preserved: no auto-retry of a changed candidate, and direct `handleResumeSession` callers still propagate the rejection.

## Changes

- `SelectorController.showSessionSelector`: close the picker, then `void handleResumeSession(...).catch(...)` → `ctx.showError` (same pattern as the command palette).
- `SessionSelectorComponent`: `onSelect` is `void | Promise<void>`; `#dispatchSelect` observes rejections when the host has not already closed the picker.
- Regression tests: picker race → `showError` + no `unhandledRejection` + single prepare attempt; component async `onSelect` recovery.

## Test plan

- [x] `bun test packages/coding-agent/test/modes/controllers/selector-controller-session-delete.test.ts packages/coding-agent/test/modes/components/session-selector-resume-confirm.test.ts packages/coding-agent/test/modes/controllers/session-selector-delete.test.ts packages/coding-agent/test/resume-session-reentrancy.test.ts packages/coding-agent/test/resume-session-reentrancy.redteam.test.ts packages/coding-agent/test/modes/controllers/selector-controller-command-palette.test.ts packages/coding-agent/test/resume-progress-lease.test.ts` — 60 pass, 0 fail
- [ ] Live interactive TUI resume against a real filesystem race (not run)

## Constraints

- Preserve strict identity fence — do not weaken validation or auto-retry the changed candidate.
- Keep the active session usable after resume preparation failure.