### PR TITLE
fix(session): gate automatic retry after observable stream progress (#3791)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Automatic session retry now refuses to re-issue a request once the failed attempt carries observable assistant text, thinking, or tool-call content — including under explicit legacy `retry.*` settings. Content-free clean failures keep their existing bounded/unbounded policy; managed provisional discard, credential rotation, first-event timeout scope checks, and manual `/retry` are unchanged (#3791).
+
 - Parent sessions and their subagent trees now share one identity-authorized artifact manager across persistent and ephemeral operation. Non-persistent roots are retired on committed session transitions and terminal close, failed transitions retain predecessor ownership, and atomic numeric-ID claims prevent same-root managers from creating ambiguous artifact references (#3813).
 
 - Telegram daemon restart now revokes every persisted callback alias before polling. Reconnecting sessions must replay a pending ask to receive fresh, owner-bound aliases; old controls remain stale, and their keyboards are best-effort terminalized when the original Telegram message id is available. Shutdown now fences new session messages and drains every admitted handler before final callback persistence and ownership release, preventing a successful send racing shutdown from publishing alias state after a successor takes ownership (#3727).

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -15066,6 +15066,17 @@ export class AgentSession {
 		// before the failure. This bypasses #hasCleanRetryReplaySafety because the
 		// content-free check is the replay-safety guarantee for credential rotation.
 		const canReplayRotatedCredential = credentialRotated;
+		// Universal automatic replay-safety gate (#3791): once the failed attempt
+		// carries observable assistant text, thinking, or tool-call content,
+		// automatic session retry must not re-issue the request. This covers
+		// configured legacy retry (which previously only gated first-event
+		// timeouts) as well as bare defaults. Managed fallback keeps its
+		// provisional discard path (events never published to the session).
+		// Content-free credential rotation remains eligible above; first-event
+		// timeout keeps its additional typed/scope checks earlier in this method.
+		if (!managedFallback && assistantMessageHasVisibleOrToolContent(message)) {
+			return false;
+		}
 		// Bare defaults retain their narrow watchdog and Codex admissions. A
 		// first-event timeout adds the typed, content-free, current-clean-scope
 		// requirement above; other transient watchdogs preserve legacy behavior.

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -375,6 +375,97 @@ describe("AgentSession resilient retry", () => {
 		expect(lastAssistant(session).stopReason).toBe("stop");
 	});
 
+	it("does not auto-retry configured legacy unknown errors after partial stream progress (#3791)", async () => {
+		// Proxy-style terminal stream failure after partial output crossed the public
+		// stream boundary. Under explicit retry.* settings the unclassified failure
+		// is bounded-unknown-retry eligible, but replaying after observable content
+		// is unsafe for non-idempotent tool side effects.
+		const cases: Array<{
+			partialContent: string;
+			errorMessage: string;
+			transportFailure?: AssistantMessage["transportFailure"];
+		}> = [
+			{
+				partialContent: "already streamed",
+				errorMessage: "upstream request failed: stream interrupted before terminal response event",
+				transportFailure: { kind: "transport", providerCode: "upstream_stream_error" },
+			},
+			{
+				partialContent: "partial thinking leaked as text",
+				errorMessage: "weird unclassified glitch after progress",
+			},
+		];
+		for (const testCase of cases) {
+			const requestedModels: string[] = [];
+			session = buildStatusErrorSession({
+				errorMessage: testCase.errorMessage,
+				transportFailure: testCase.transportFailure,
+				partialContent: testCase.partialContent,
+				recoveredContent: "should-not-retry",
+				requestedModels,
+			});
+			vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+			const { retryStartEvents } = track(session);
+
+			await session.prompt("partial progress then terminal stream failure");
+			await session.waitForIdle();
+
+			expect(retryStartEvents).toHaveLength(0);
+			expect(requestedModels).toHaveLength(1);
+			const last = lastAssistant(session);
+			expect(last.stopReason).toBe("error");
+			expect(last.errorMessage).toBe(testCase.errorMessage);
+			expect(last.content).toEqual([{ type: "text", text: testCase.partialContent }]);
+			await session.dispose();
+			session = undefined;
+		}
+	});
+
+	it("does not auto-retry configured legacy transient errors after partial stream progress (#3791)", async () => {
+		const requestedModels: string[] = [];
+		session = buildStatusErrorSession({
+			errorMessage: "stream stall: connection terminated mid-response",
+			partialContent: "hello from the partial stream",
+			recoveredContent: "should-not-retry",
+			requestedModels,
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents } = track(session);
+
+		await session.prompt("partial progress then transient-class stream failure");
+		await session.waitForIdle();
+
+		expect(retryStartEvents).toHaveLength(0);
+		expect(requestedModels).toHaveLength(1);
+		const last = lastAssistant(session);
+		expect(last.stopReason).toBe("error");
+		expect(last.content).toEqual([{ type: "text", text: "hello from the partial stream" }]);
+	});
+
+	it("still retries content-free configured legacy unknown errors after the replay-safety gate (#3791)", async () => {
+		// Content-free clean failures keep the existing bounded unknown retry policy.
+		const requestedModels: string[] = [];
+		session = buildStatusErrorSession({
+			errorMessage: "upstream request failed: stream interrupted before terminal response event",
+			transportFailure: { kind: "transport", providerCode: "upstream_stream_error" },
+			recoveredContent: "recovered",
+			requestedModels,
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents, retryEndEvents } = track(session);
+
+		await session.prompt("content-free upstream_stream_error");
+		await session.waitForIdle();
+
+		expect(requestedModels).toHaveLength(2);
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryEndEvents).toEqual([expect.objectContaining({ success: true })]);
+		expect(lastAssistant(session)).toMatchObject({
+			stopReason: "stop",
+			content: [{ type: "text", text: "recovered" }],
+		});
+	});
+
 	it("surfaces terminal coded errors without retrying", async () => {
 		session = buildSession({
 			responses: [{ throw: "401 unauthorized: invalid api key" }],


### PR DESCRIPTION
## Summary

Fixes #3791.

Configured legacy `retry.*` could re-issue a turn after partial assistant text, thinking, or tool-call content had already crossed the public stream boundary (e.g. proxy `response.failed` / `upstream_stream_error`). Replay-safety checks applied to first-event timeouts and bare defaults, but unclassified failures could still enter bounded unknown retry after observable progress — unsafe for non-idempotent tool side effects.

Apply one universal automatic gate in `#handleRetryableError`: once the failed attempt carries observable assistant content, non-managed auto-retry returns `false`. Content-free clean failures keep existing bounded/unbounded policy; managed provisional discard, credential rotation, first-event scope checks, and manual `/retry` remain unchanged.

## Changes

- `agent-session.ts`: universal content gate after the credential-rotation check and before bare-default admissions.
- Regression tests: partial + `upstream_stream_error`/unknown blocked; partial + transient-class blocked; content-free `upstream_stream_error` still retries.
- CHANGELOG Unreleased note.

## Why not special-case `upstream_stream_error` only?

Same bug class under any message/code. The gate is on **observable content of the failed attempt**, not on a single provider error string.

## Why not blanket `#hasCleanRetryReplaySafety` for all legacy retries?

Prompt-epoch marks can be dirtied by earlier tool execution in the same turn, which would over-block mid-turn content-free 503s after successful tools. Content on the failed attempt matches the reported incident shape.

## Test plan

- [x] `bun test packages/coding-agent/test/agent-session-resilient-retry.test.ts` — 52 pass, 0 fail
- [x] Related retry-fallback + manual-retry suites — pass
- [x] `bun --cwd=packages/coding-agent run check` — pass
- [ ] Live Responses-proxy partial-then-failed e2e (not run)

## Out of scope

- Automatic continuation from committed text-only partials (issue §7; fail closed and preserve the partial).
- Extension-only current-attempt side effects without content (product decision).