### PR TITLE
fix(retry): make DeepSeek reasoning-content replay 400 retryable

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- DeepSeek-family reasoning-content replay 400s are now retryable via a bounded, strip-only circuit breaker. When a proxy strips the encrypted reasoning blob to an empty `encrypted_content`, DeepSeek rejects every follow-up turn with "The `reasoning_content` in the thinking mode must be passed back to the API." Resending the identical history re-triggers this deterministic 400, so the agent loop now strips the unusable `reasoning` items from the Responses history payload in place and resends exactly once (mirroring the `invalid_prompt` poisoned-history breaker). Non-reasoning items are preserved; fail-fast when nothing can be stripped. Budget = one repaired resend.
+
 ## [0.12.11] - 2026-08-03
 
 ## [0.12.10] - 2026-08-03

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -24,7 +24,12 @@ import {
 	COMPOSER_BASH_POLICY_RECOVERY_PROMPT,
 	isCurrentComposerBashPolicyBlockedError,
 } from "@gajae-code/ai/providers/composer-discipline";
-import { isInvalidPromptError, neutralizeReservedControlTokens } from "@gajae-code/ai/utils";
+import {
+	isInvalidPromptError,
+	isReasoningContentReplayError,
+	neutralizeReservedControlTokens,
+	stripUnusableReasoningItems,
+} from "@gajae-code/ai/utils";
 import { sanitizeText } from "@gajae-code/utils";
 import type { AttemptScope } from "./attempt-scope";
 import {
@@ -201,6 +206,31 @@ function repairInvalidPromptHistory(messages: AgentMessage[]): boolean {
 		}
 	}
 	return changed;
+}
+/**
+ * Strip Responses-API `reasoning` items whose `encrypted_content` a proxy
+ * emptied, in-place across the outgoing history's `providerPayload`. DeepSeek in
+ * thinking mode rejects replay of reasoning whose encrypted blob was stripped,
+ * so dropping those items lets the model re-reason instead of re-triggering a
+ * deterministic 400 ("reasoning_content ... must be passed back to the API").
+ * Only the opaque Responses history payload is mutated; durable message content
+ * and ordering are preserved. Returns whether any item was actually removed —
+ * the circuit breaker uses this to decide between a single repaired resend
+ * (removed) and immediate fail-fast (unchanged).
+ */
+function repairReasoningContentReplayHistory(messages: AgentMessage[]): boolean {
+	let removed = 0;
+	for (const message of messages) {
+		const payload = (message as { providerPayload?: { type?: string; items?: Array<Record<string, unknown>> } })
+			.providerPayload;
+		if (payload?.type !== "openaiResponsesHistory" || !Array.isArray(payload.items)) continue;
+		const { result, removed: count } = stripUnusableReasoningItems(payload.items);
+		if (count > 0) {
+			payload.items = result;
+			removed += count;
+		}
+	}
+	return removed > 0;
 }
 
 function managedFailureOutcome(message: AssistantMessage, scope?: AttemptScope): ManagedAttemptOutcome {
@@ -1418,6 +1448,9 @@ async function runLoopBody(
 	// Fires at most one repaired resend per run for the poisoned-history
 	// `invalid_prompt` circuit breaker below.
 	let invalidPromptRepairAttempted = false;
+	// Fires at most one repaired resend per run for the reasoning-content replay
+	// breaker below (DeepSeek "reasoning_content ... must be passed back").
+	let reasoningContentRepairAttempted = false;
 	let previousMalformedToolSignatures = new Set<string>();
 	type SyntheticRecoveryKind = "malformed-tool-call" | "composer-bash-policy" | "provider";
 	let pendingRecovery:
@@ -1676,6 +1709,40 @@ async function runLoopBody(
 					? currentContext.messages.slice(0, rejectedIndex)
 					: currentContext.messages;
 				if (repairInvalidPromptHistory(retained)) {
+					if (rejectedCommitted) currentContext.messages.splice(rejectedIndex, 1);
+					continue;
+				}
+			}
+			// Session-level reasoning-content replay circuit breaker (bounded,
+			// strip-only). DeepSeek V4 (and reasoning-capable siblings on any
+			// OpenAI-compatible proxy) reject every follow-up turn with
+			// "reasoning_content ... must be passed back to the API" once a prior
+			// assistant turn carried reasoning the proxy stripped to an empty
+			// `encrypted_content`. Resending the identical history re-triggers the
+			// deterministic 400, so naive auto-retry would loop. On the first such
+			// rejection of this run, strip the unusable `reasoning` items from the
+			// Responses history payload IN PLACE (never dropping text, tool-call, or
+			// tool-output items). If that removed anything, resend exactly once so
+			// the model re-reasons; if nothing could be stripped, fall through to
+			// terminal handling and fail fast. Budget = one repaired resend.
+			if (
+				!config.fallbackManaged &&
+				message.stopReason === "error" &&
+				!reasoningContentRepairAttempted &&
+				isReasoningContentReplayError(message)
+			) {
+				reasoningContentRepairAttempted = true;
+				// The rejected turn was already committed to the context by the
+				// streaming path. Repair (and resend) only the history that
+				// preceded it: replaying an errored assistant turn re-triggers the
+				// rejection and leaves a second assistant tail behind.
+				const rejectedIndex = currentContext.messages.length - 1;
+				const rejectedCommitted =
+					rejectedIndex >= 0 && currentContext.messages[rejectedIndex]?.role === "assistant";
+				const retained = rejectedCommitted
+					? currentContext.messages.slice(0, rejectedIndex)
+					: currentContext.messages;
+				if (repairReasoningContentReplayHistory(retained)) {
 					if (rejectedCommitted) currentContext.messages.splice(rejectedIndex, 1);
 					continue;
 				}

--- a/packages/agent/test/agent-loop-reasoning-content-replay-breaker.test.ts
+++ b/packages/agent/test/agent-loop-reasoning-content-replay-breaker.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "bun:test";
+import { agentLoop } from "@gajae-code/agent-core/agent-loop";
+import type { AgentContext, AgentLoopConfig, AgentMessage } from "@gajae-code/agent-core/types";
+import type { AssistantMessage, Message } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { createUserMessage } from "./helpers";
+
+// DeepSeek-family reasoning-content replay rejection. The proxy strips the
+// encrypted reasoning blob to `""`; replaying it 400s deterministically, so the
+// bounded circuit breaker must strip the unusable reasoning items and resend
+// exactly once. Mirrors the invalid_prompt breaker's contract.
+
+const REASONING_REPLAY_ERROR =
+	"400 Error from provider (Console): Upstream request failed: [invalid_request_error] The `reasoning_content` in the thinking mode must be passed back to the API.";
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(m => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
+}
+
+async function drain(stream: AsyncIterable<unknown> & { result(): Promise<AgentMessage[]> }): Promise<AgentMessage[]> {
+	for await (const _ of stream) {
+		/* consume */
+	}
+	return stream.result();
+}
+
+/** An assistant message carrying a Responses history payload with unusable reasoning items. */
+function assistantWithStrippedReasoning(provider = "mock"): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "prior assistant turn" }],
+		api: "openai-responses",
+		provider,
+		model: "deepseek-v4-flash",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+		providerPayload: {
+			type: "openaiResponsesHistory",
+			provider,
+			dt: true,
+			items: [
+				{
+					type: "reasoning",
+					encrypted_content: "",
+					summary: [{ type: "summary_text", text: "stripped reasoning summary" }],
+				},
+				{ type: "output_text", text: "prior assistant turn" },
+			],
+		},
+	};
+}
+
+describe("agentLoop reasoning-content replay circuit breaker", () => {
+	it("strips unusable reasoning items and resends EXACTLY once", async () => {
+		const seeded = assistantWithStrippedReasoning();
+		const prompt = createUserMessage("next turn");
+		const context: AgentContext = {
+			systemPrompt: ["sys"],
+			messages: [seeded],
+			tools: [],
+		};
+		const mock = createMockModel({
+			responses: [{ throw: REASONING_REPLAY_ERROR }, { content: ["recovered"] }],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const messages = await drain(agentLoop([prompt], context, config, undefined, mock.stream));
+
+		// Exactly 2 provider requests: initial rejected send + one repaired resend.
+		expect(mock.calls.length).toBe(2);
+		const last = messages[messages.length - 1];
+		expect(last.role).toBe("assistant");
+		if (last.role !== "assistant") throw new Error("expected assistant");
+		expect(last.stopReason).toBe("stop");
+		expect(last.content).toEqual([{ type: "text", text: "recovered" }]);
+
+		// The seeded reasoning item with empty encrypted_content must be stripped
+		// in place so a durable resume no longer carries the poison.
+		const payload = seeded.providerPayload;
+		expect(payload?.type).toBe("openaiResponsesHistory");
+		const reasoningItems = payload?.items.filter(i => i.type === "reasoning") ?? [];
+		expect(reasoningItems).toEqual([]);
+	});
+
+	it("does NOT replay the rejected assistant turn on the repaired resend", async () => {
+		const seeded = assistantWithStrippedReasoning();
+		const prompt = createUserMessage("next turn");
+		const context: AgentContext = {
+			systemPrompt: ["sys"],
+			messages: [seeded],
+			tools: [],
+		};
+		const mock = createMockModel({
+			responses: [{ throw: REASONING_REPLAY_ERROR }, { content: ["recovered"] }],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		await drain(agentLoop([prompt], context, config, undefined, mock.stream));
+
+		expect(mock.calls.length).toBe(2);
+		// The repaired resend carries the seeded assistant + new user prompt, but NOT
+		// the rejected assistant turn from the first (failed) provider call.
+		expect(mock.calls[1].context.messages.map(m => m.role)).toEqual(["assistant", "user"]);
+	});
+
+	it("fails fast with EXACTLY one request when there are no reasoning items to strip", async () => {
+		// History with only non-reasoning items — stripping cannot change anything,
+		// so the breaker must not spend a resend budget.
+		const seededWithoutReasoning: AssistantMessage = {
+			...assistantWithStrippedReasoning(),
+			providerPayload: {
+				type: "openaiResponsesHistory",
+				provider: "mock",
+				dt: true,
+				items: [{ type: "output_text", text: "prior assistant turn" }],
+			},
+		};
+		const prompt = createUserMessage("next turn");
+		const context: AgentContext = {
+			systemPrompt: ["sys"],
+			messages: [seededWithoutReasoning],
+			tools: [],
+		};
+		const mock = createMockModel({ responses: [{ throw: REASONING_REPLAY_ERROR }] });
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const messages = await drain(agentLoop([prompt], context, config, undefined, mock.stream));
+
+		expect(mock.calls.length).toBe(1);
+		const last = messages[messages.length - 1];
+		if (last.role !== "assistant") throw new Error("expected assistant");
+		expect(last.stopReason).toBe("error");
+		expect(last.errorMessage).toBe(REASONING_REPLAY_ERROR);
+		// Non-reasoning items are untouched.
+		expect(seededWithoutReasoning.providerPayload?.items.length).toBe(1);
+	});
+
+	it("spends the repair budget only once even if the error recurs (budget=1)", async () => {
+		const seeded = assistantWithStrippedReasoning();
+		const prompt = createUserMessage("next turn");
+		const context: AgentContext = {
+			systemPrompt: ["sys"],
+			messages: [seeded],
+			tools: [],
+		};
+		const mock = createMockModel({
+			responses: [
+				{ throw: REASONING_REPLAY_ERROR },
+				{ throw: REASONING_REPLAY_ERROR },
+				{ content: ["never reached"] },
+			],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const messages = await drain(agentLoop([prompt], context, config, undefined, mock.stream));
+
+		// Initial send + exactly one repaired resend, then durable fail-fast.
+		expect(mock.calls.length).toBe(2);
+		const last = messages[messages.length - 1];
+		if (last.role !== "assistant") throw new Error("expected assistant");
+		expect(last.stopReason).toBe("error");
+		expect(last.errorMessage).toBe(REASONING_REPLAY_ERROR);
+	});
+
+	it("does NOT trigger on non-reasoning-content errors (negative)", async () => {
+		const seeded = assistantWithStrippedReasoning();
+		const prompt = createUserMessage("next turn");
+		const context: AgentContext = {
+			systemPrompt: ["sys"],
+			messages: [seeded],
+			tools: [],
+		};
+		const mock = createMockModel({ responses: [{ throw: "The server had an error (code=server_error)" }] });
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const messages = await drain(agentLoop([prompt], context, config, undefined, mock.stream));
+
+		expect(mock.calls.length).toBe(1);
+		const last = messages[messages.length - 1];
+		if (last.role !== "assistant") throw new Error("expected assistant");
+		expect(last.stopReason).toBe("error");
+		// The reasoning item is untouched for non-reasoning-content faults.
+		const reasoningItems = seeded.providerPayload?.items.filter(i => i.type === "reasoning") ?? [];
+		expect(reasoningItems.length).toBe(1);
+	});
+
+	it("preserves reasoning items that DO have non-empty encrypted_content", async () => {
+		// A reasoning item with a real (non-empty) encrypted_content is NOT poison:
+		// the breaker must not strip it, and since stripping changed nothing, no
+		// resend is spent.
+		const seeded: AssistantMessage = {
+			...assistantWithStrippedReasoning(),
+			providerPayload: {
+				type: "openaiResponsesHistory",
+				provider: "mock",
+				dt: true,
+				items: [
+					{
+						type: "reasoning",
+						encrypted_content: "OpaqueBlobSignatureData==",
+						summary: [{ type: "summary_text", text: "valid reasoning summary" }],
+					},
+					{ type: "output_text", text: "prior assistant turn" },
+				],
+			},
+		};
+		const prompt = createUserMessage("next turn");
+		const context: AgentContext = {
+			systemPrompt: ["sys"],
+			messages: [seeded],
+			tools: [],
+		};
+		const mock = createMockModel({ responses: [{ throw: REASONING_REPLAY_ERROR }] });
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		await drain(agentLoop([prompt], context, config, undefined, mock.stream));
+
+		expect(mock.calls.length).toBe(1);
+		// The valid reasoning item is preserved.
+		const reasoningItems = seeded.providerPayload?.items.filter(i => i.type === "reasoning") ?? [];
+		expect(reasoningItems.length).toBe(1);
+	});
+});

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - OpenAI Codex cost estimates now treat an explicit response `service_tier` as authoritative, so a request for priority processing that the provider serves at the default tier is no longer charged the priority multiplier; the requested tier remains the fallback when the terminal response omits the field.
+- Added shared `isReasoningContentReplayError` classifier and `stripUnusableReasoningItems` repair for the DeepSeek-family reasoning-content replay rejection ("The `reasoning_content` in the thinking mode must be passed back to the API"). The classifier detects the error across message carrier shapes; the repair removes only `reasoning` items whose `encrypted_content` a proxy stripped to empty, preserving all non-reasoning history (text, tool calls, tool outputs). The agent loop consumes both for a bounded repair-and-resend circuit breaker.
 
 ## [0.12.11] - 2026-08-03
 

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -200,6 +200,62 @@ function asLowerString(value: unknown): string | undefined {
 }
 
 /**
+ * Shape-tolerant classifier for the DeepSeek-family reasoning-content replay
+ * rejection: "The `reasoning_content` in the thinking mode must be passed back
+ * to the API." DeepSeek V4 (and reasoning-capable siblings reached through any
+ * OpenAI-compatible proxy) 400 every follow-up turn once a prior assistant turn
+ * carried reasoning the proxy stripped to an empty `encrypted_content` /
+ * `reasoning_content`. Resending the identical history re-triggers it, so naive
+ * session auto-retry just burns the budget — it needs the same bounded
+ * repair-and-resend contract as the `invalid_prompt` poisoned-history breaker.
+ *
+ * Accepts a raw provider error, an assistant message, or any object carrying an
+ * `errorMessage` field (the agent-loop circuit breaker keys on this).
+ */
+export function isReasoningContentReplayError(input: unknown): boolean {
+	if (!input) return false;
+	const message =
+		typeof input === "string"
+			? input
+			: input && typeof input === "object"
+				? ((input as { errorMessage?: unknown; message?: unknown }).errorMessage ??
+					(input as { message?: unknown }).message)
+				: undefined;
+	return typeof message === "string" && REASONING_CONTENT_REPLAY_MESSAGE_RE.test(message);
+}
+
+const REASONING_CONTENT_REPLAY_MESSAGE_RE =
+	/reasoning_content[\s\S]*must be passed back to the API|reasoning content[\s\S]*must be passed back to the API/i;
+
+/**
+ * Remove Responses-API `reasoning` items whose `encrypted_content` is missing or
+ * empty from an outgoing history payload. DeepSeek rejects replay of reasoning
+ * whose encrypted blob a proxy stripped to `""`; dropping those items lets the
+ * model re-reason on the next turn instead of re-triggering a deterministic 400.
+ * Non-reasoning items (text, function_call, function_call_output, ...) are kept
+ * verbatim so tool-use pairing and message order are preserved. Returns whether
+ * any item was actually removed — the circuit breaker uses this to decide
+ * between a single repaired resend (removed) and immediate fail-fast (unchanged).
+ */
+export function stripUnusableReasoningItems(items: Array<Record<string, unknown>>): {
+	result: Array<Record<string, unknown>>;
+	removed: number;
+} {
+	let removed = 0;
+	const result: Array<Record<string, unknown>> = [];
+	for (const item of items) {
+		if (item?.type === "reasoning") {
+			const encrypted = item.encrypted_content;
+			if (encrypted === undefined || encrypted === null || encrypted === "") {
+				removed++;
+				continue;
+			}
+		}
+		result.push(item);
+	}
+	return { result, removed };
+}
+/**
  * Neutralize leaked reserved control tokens across every string in an outgoing
  * Responses `input` array. This is the request-boundary complement to the
  * replay-history sanitizer: leaked Harmony markers (`<|channel|>analysis`, ...)

--- a/packages/ai/test/reasoning-content-replay.test.ts
+++ b/packages/ai/test/reasoning-content-replay.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "bun:test";
+import { isReasoningContentReplayError, stripUnusableReasoningItems } from "../src/utils";
+
+// DeepSeek-family reasoning-content replay rejection: the encrypted reasoning
+// blob was proxy-stripped to "", so replaying it 400s deterministically with
+// "reasoning_content ... must be passed back to the API". The classifier and the
+// strip repair are the shared contract the agent-loop circuit breaker keys on.
+
+describe("isReasoningContentReplayError shared classifier", () => {
+	it("detects the exact DeepSeek-family error across message carrier shapes", () => {
+		const exact =
+			"400 Error from provider (Console): Upstream request failed: [invalid_request_error] The `reasoning_content` in the thinking mode must be passed back to the API.";
+		expect(isReasoningContentReplayError(exact)).toBe(true);
+		expect(isReasoningContentReplayError({ errorMessage: exact })).toBe(true);
+		expect(isReasoningContentReplayError({ message: exact })).toBe(true);
+	});
+
+	it("detects the message-form variants (reasoning_content vs reasoning content)", () => {
+		expect(
+			isReasoningContentReplayError("The reasoning_content in the thinking mode must be passed back to the API."),
+		).toBe(true);
+		expect(
+			isReasoningContentReplayError("The reasoning content in the thinking mode must be passed back to the API."),
+		).toBe(true);
+	});
+
+	it("matches even when the phrase spans newlines (multi-line upstream errors)", () => {
+		const multiline =
+			"Upstream request failed:\n[invalid_request_error] The `reasoning_content`\nin the thinking mode\nmust be passed back to the API.";
+		expect(isReasoningContentReplayError(multiline)).toBe(true);
+	});
+
+	it("does NOT fire on other error classes (negative)", () => {
+		expect(isReasoningContentReplayError("The server had an error (code=server_error)")).toBe(false);
+		expect(isReasoningContentReplayError("Request blocked (code=invalid_prompt)")).toBe(false);
+		expect(isReasoningContentReplayError({ errorMessage: "rate limit exceeded" })).toBe(false);
+		expect(isReasoningContentReplayError({ code: "invalid_request_error", message: "max_tokens too low" })).toBe(
+			false,
+		);
+	});
+
+	it("does NOT fire on empty / non-error inputs (negative)", () => {
+		expect(isReasoningContentReplayError(undefined)).toBe(false);
+		expect(isReasoningContentReplayError(null)).toBe(false);
+		expect(isReasoningContentReplayError("")).toBe(false);
+		expect(isReasoningContentReplayError(42)).toBe(false);
+	});
+});
+
+describe("stripUnusableReasoningItems", () => {
+	it("removes reasoning items with empty encrypted_content", () => {
+		const items = [
+			{ type: "reasoning", encrypted_content: "", summary: [{ type: "summary_text", text: "x" }] },
+			{ type: "output_text", text: "hello" },
+		];
+		const { result, removed } = stripUnusableReasoningItems(items);
+		expect(removed).toBe(1);
+		expect(result).toEqual([{ type: "output_text", text: "hello" }]);
+	});
+
+	it("removes reasoning items with missing encrypted_content", () => {
+		const items = [
+			{ type: "reasoning", summary: [{ type: "summary_text", text: "no blob" }] },
+			{ type: "function_call", name: "read", arguments: "{}" },
+		];
+		const { result, removed } = stripUnusableReasoningItems(items);
+		expect(removed).toBe(1);
+		expect(result).toEqual([{ type: "function_call", name: "read", arguments: "{}" }]);
+	});
+
+	it("removes reasoning items with null encrypted_content", () => {
+		const items = [{ type: "reasoning", encrypted_content: null }];
+		const { result, removed } = stripUnusableReasoningItems(items);
+		expect(removed).toBe(1);
+		expect(result).toEqual([]);
+	});
+
+	it("preserves reasoning items that have non-empty encrypted_content", () => {
+		const reasoning = {
+			type: "reasoning",
+			encrypted_content: "OpaqueBlobSignature==",
+			summary: [{ type: "summary_text", text: "valid" }],
+		};
+		const items = [reasoning, { type: "output_text", text: "hello" }];
+		const { result, removed } = stripUnusableReasoningItems(items);
+		expect(removed).toBe(0);
+		expect(result).toEqual(items);
+	});
+
+	it("preserves all non-reasoning items verbatim (order, identity)", () => {
+		const items = [
+			{ type: "reasoning", encrypted_content: "" },
+			{ type: "function_call", call_id: "c1", name: "read", arguments: "{}" },
+			{ type: "reasoning", encrypted_content: "" },
+			{ type: "function_call_output", call_id: "c1", output: "ok" },
+			{ type: "output_text", text: "done" },
+		];
+		const { result, removed } = stripUnusableReasoningItems(items);
+		expect(removed).toBe(2);
+		expect(result).toEqual([
+			{ type: "function_call", call_id: "c1", name: "read", arguments: "{}" },
+			{ type: "function_call_output", call_id: "c1", output: "ok" },
+			{ type: "output_text", text: "done" },
+		]);
+	});
+
+	it("returns removed=0 for an empty array", () => {
+		const { result, removed } = stripUnusableReasoningItems([]);
+		expect(removed).toBe(0);
+		expect(result).toEqual([]);
+	});
+
+	it("reports removed=0 when nothing is strip-eligible", () => {
+		const items = [{ type: "output_text", text: "only text" }];
+		const { result, removed } = stripUnusableReasoningItems(items);
+		expect(removed).toBe(0);
+		expect(result).toEqual(items);
+	});
+});


### PR DESCRIPTION
## Summary

DeepSeek V4 (and reasoning-capable siblings on any OpenAI-compatible proxy) reject every follow-up turn with:

> \`400 Error from provider (Console): Upstream request failed: [invalid_request_error] The \`reasoning_content\` in the thinking mode must be passed back to the API.\`

once a prior assistant turn carried reasoning the proxy stripped to an empty \`encrypted_content\`. Resending the identical history re-triggers this deterministic 400, so naive session auto-retry just burns the budget. Previously this was classified \`terminal\` (the message contains \`invalid_request_error\`) and surfaced immediately with no repair.

This makes it **retryable** via a bounded, strip-only circuit breaker that mirrors the existing \`invalid_prompt\` poisoned-history breaker (#2282).

## Root cause

Confirmed from the saved 400 request log: all 136 \`reasoning\` items in the history carried \`encrypted_content: \"\"\` (proxy-stripped). DeepSeek in thinking mode requires the reasoning blob to be passed back; replaying the empty blob 400s on every turn.

## Fix

On the first reasoning-content replay rejection of a run, strip the unusable \`reasoning\` items from the Responses history \`providerPayload\` **in place** (never dropping text, tool-call, or tool-output items) and resend exactly once so the model re-reasons. If nothing can be stripped, fail fast. Budget = one repaired resend.

### Shared utilities (\`@gajae-code/ai/utils\`)
- \`isReasoningContentReplayError\` — shape-tolerant classifier (string / message / errorMessage carriers), matches the DeepSeek phrasing across newlines.
- \`stripUnusableReasoningItems\` — removes only \`reasoning\` items with missing/null/empty \`encrypted_content\`; preserves all non-reasoning history verbatim.

### Agent loop (\`packages/agent\`)
- New \`repairReasoningContentReplayHistory\` repair + a \`reasoningContentRepairAttempted\` budget flag, wired as a second bounded circuit breaker alongside the existing \`invalid_prompt\` breaker.

## Test plan

- [x] \`packages/agent/test/agent-loop-reasoning-content-replay-breaker.test.ts\` — 6 cases: strips + resends once, does not replay rejected turn, fail-fast when nothing to strip, budget=1 recursion cap, negative (non-reasoning error untouched), preserves valid encrypted reasoning.
- [x] \`packages/ai/test/reasoning-content-replay.test.ts\` — 12 cases: classifier across carrier shapes + multi-line, negatives, and the strip function (empty/missing/null/non-empty preservation, order/identity).
- [x] Existing suites green: \`agent-loop-invalid-prompt-breaker\`, \`agent-loop-recovery-coverage\`, \`invalid-prompt-classification\`, \`deepseek-reasoning-content\`, \`issue-883-repro\`.
- [x] \`bun --cwd=packages/agent run check\` and \`bun --cwd=packages/ai run check\` clean.

## Changelog

- \`packages/agent/CHANGELOG.md\` (Unreleased › Fixed)
- \`packages/ai/CHANGELOG.md\` (Unreleased › Fixed)