### PR TITLE
fix(sdk): lock registerToolSessionTransitionCleanup out of public inventory

### DIFF
--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -37,6 +37,8 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 	"agent_session:constructor": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:registerToolSessionCleanup":
 		"internal tool lifecycle cleanup registration, not a user-facing SDK control seam",
+	"agent_session:registerToolSessionTransitionCleanup":
+		"internal tool transition cleanup registration for shared artifact-manager ownership, not a user-facing SDK control seam",
 	"agent_session:nextToolChoice": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:setForcedToolChoice": "internal accessor/plumbing, not a user-facing control seam",
 	"agent_session:getActiveSkillState": "internal accessor/plumbing, not a user-facing control seam",

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -2572,6 +2572,17 @@
 		}
 	},
 	{
+		"sourceId": "agent_session:registerToolSessionTransitionCleanup",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "internal tool transition cleanup registration for shared artifact-manager ownership, not a user-facing SDK control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
 		"sourceId": "agent_session:getAsyncJobSnapshot",
 		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
 		"sourceKind": "agent_session",


### PR DESCRIPTION
## Summary

Follow-up to #3813. Current `dev` fails `SDK operation inventory > accepts the committed generated matrix` with:

```text
Pending review source seam: agent_session:registerToolSessionTransitionCleanup
```

`AgentSession.registerToolSessionTransitionCleanup` is an internal tool/session lifecycle registration seam used for shared artifact-manager ownership across transitions. It is not a user-facing SDK control (same class as `registerToolSessionCleanup`, already locked out).

## Changes

- Add `agent_session:registerToolSessionTransitionCleanup` to `LOCKED_EXCLUSIONS` in `generate-sdk-operation-inventory.ts`.
- Regenerate `operation-inventory.generated.json`.

## Why this matters

Any exact-head PR based on current `dev` that runs coding-agent shard inventory checks inherits this red, including notification PR #3834 (whose own generation guard and package check are green). Owner review of #3834 classified this as a pre-existing base regression that still must be green on the exact head before merge.

## Test plan

- [x] `bun test packages/coding-agent/test/sdk-operation-inventory.test.ts` — 17 pass
- [x] `bun packages/coding-agent/scripts/generate-sdk-operation-inventory.ts --check`
- [ ] Full Dev CI coding-agent shards (expected green after this lands)

## Scope

- `Refs #3813` only — inventory classification, not a behavior change.