### PR TITLE
fix(memory): defer startup until model profiles settle

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1608,6 +1608,9 @@ export async function runRootCommand(
 		sessionOptions.deferMcpConfigStartup = true;
 	}
 	const hasRootStartupProfile = Boolean(settingsInstance.get("modelProfile.default") || parsedArgs.mpreset);
+	const deferMemoryBackendStartup =
+		hasRootStartupProfile && !(parsedArgs.authBootstrap === true && isInteractive) && mode !== "acp";
+	sessionOptions.deferMemoryBackendStartup = deferMemoryBackendStartup;
 
 	// Research-mode (RLM) preset: augment session options before session creation.
 	deps.rlmPreset?.applyOptions(sessionOptions, settingsInstance);
@@ -1694,6 +1697,7 @@ export async function runRootCommand(
 			lspServers,
 			mcpManager,
 			startDeferredMcpConfig,
+			startDeferredMemoryBackend,
 			eventBus,
 		} = await createSession(sessionOptions, { skipPostCreateModelRefresh: hasRootStartupProfile });
 		applyCliRuntimeApiKeyOverride(authStorage, parsedArgs.apiKey, session.model);
@@ -1733,6 +1737,7 @@ export async function runRootCommand(
 				startDeferredModelProfiles = async () => {
 					try {
 						const result = await applyDeferredStartupModelProfilesForRoot(profileArgs);
+						startDeferredMemoryBackend?.();
 						ready.resolve();
 						return result;
 					} catch (error) {
@@ -1742,6 +1747,7 @@ export async function runRootCommand(
 				};
 			} else {
 				const { recoverableErrors } = await applyStartupModelProfilesForRoot(profileArgs);
+				startDeferredMemoryBackend?.();
 				for (const recoverableError of recoverableErrors) {
 					notifs.push({ kind: "error", message: recoverableError });
 				}

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -413,6 +413,11 @@ export interface CreateAgentSessionOptions {
 	 * @internal CLI-only startup optimization; SDK callers retain synchronous loading by default.
 	 */
 	deferMcpConfigStartup?: boolean;
+	/**
+	 * Defer memory backend startup until the caller has applied startup model profiles.
+	 * @internal CLI-only ordering guard; SDK callers retain immediate startup by default.
+	 */
+	deferMemoryBackendStartup?: boolean;
 
 	/** Enable LSP integration (tool, formatting, diagnostics, warmup). Default: true */
 	enableLsp?: boolean;
@@ -505,6 +510,8 @@ export interface CreateAgentSessionResult {
 	mcpManager?: MCPManager;
 	/** Starts a deferred exact-config MCP connection. Present only when deferMcpConfigStartup was requested. */
 	startDeferredMcpConfig?: () => Promise<DeferredMcpConfigStartupResult>;
+	/** Starts a deferred memory backend. Present only when deferMemoryBackendStartup was requested. */
+	startDeferredMemoryBackend?: () => void;
 	/** Warning if session was restored with a different model than saved */
 	modelFallbackMessage?: string;
 	/** LSP servers configured for lazy startup in interactive mode */
@@ -2928,18 +2935,24 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				? discoverStartupLspServers(cwd)
 				: undefined;
 
-		logger.time("startMemoryStartupTask", () =>
-			Promise.resolve(
-				resolveMemoryBackend(settings).start({
-					session,
-					settings,
-					modelRegistry,
-					agentDir,
-					taskDepth,
-					parentHindsightSessionState: options.parentHindsightSessionState,
-				}),
-			),
-		);
+		let memoryBackendStarted = false;
+		const startMemoryBackend = () => {
+			if (memoryBackendStarted) return;
+			memoryBackendStarted = true;
+			logger.time("startMemoryStartupTask", () =>
+				Promise.resolve(
+					resolveMemoryBackend(settings).start({
+						session,
+						settings,
+						modelRegistry,
+						agentDir,
+						taskDepth,
+						parentHindsightSessionState: options.parentHindsightSessionState,
+					}),
+				),
+			);
+		};
+		if (!options.deferMemoryBackendStartup) startMemoryBackend();
 
 		// Exact-config managers do not receive reactive callbacks; their tools are
 		// registered once in the session-owned catalog.
@@ -3056,6 +3069,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			setToolUIContext,
 			mcpManager: ownsMcpManager && mcpManager?.isToolsOnly() ? undefined : mcpManager,
 			startDeferredMcpConfig,
+			startDeferredMemoryBackend: options.deferMemoryBackendStartup ? startMemoryBackend : undefined,
 			modelFallbackMessage,
 			lspServers,
 			eventBus,

--- a/packages/coding-agent/test/sdk-memory-startup.test.ts
+++ b/packages/coding-agent/test/sdk-memory-startup.test.ts
@@ -65,5 +65,5 @@ describe("createAgentSession memory startup", () => {
 		} finally {
 			await session.dispose();
 		}
-	});
+	}, 30_000);
 });

--- a/packages/coding-agent/test/sdk-memory-startup.test.ts
+++ b/packages/coding-agent/test/sdk-memory-startup.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AuthStorage, getBundledModel } from "@gajae-code/ai";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { localBackend } from "@gajae-code/coding-agent/memory-backend";
+import { createAgentSession } from "@gajae-code/coding-agent/sdk";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+
+const createdDirs = new Set<string>();
+
+describe("createAgentSession memory startup", () => {
+	let authStorage: AuthStorage;
+
+	beforeEach(async () => {
+		authStorage = await AuthStorage.create(":memory:");
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		authStorage.close();
+		for (const dir of createdDirs) {
+			await fs.promises.rm(dir, { recursive: true, force: true });
+		}
+		createdDirs.clear();
+	});
+
+	test("defers memory startup until startup model profiles have settled", async () => {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-memory-startup-"));
+		createdDirs.add(cwd);
+		const modelRegistry = new ModelRegistry(authStorage);
+		const settings = Settings.isolated({ "memory.backend": "local" });
+		const startSpy = vi.spyOn(localBackend, "start").mockImplementation(() => {});
+
+		const { session, startDeferredMemoryBackend } = await createAgentSession({
+			cwd,
+			agentDir: cwd,
+			authStorage,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableLsp: false,
+			toolNames: [],
+			deferMemoryBackendStartup: true,
+		});
+
+		try {
+			expect(startSpy).not.toHaveBeenCalled();
+			expect(startDeferredMemoryBackend).toBeFunction();
+
+			startDeferredMemoryBackend?.();
+			expect(startSpy).toHaveBeenCalledTimes(1);
+			expect(startSpy.mock.calls[0]?.[0].session).toBe(session);
+
+			startDeferredMemoryBackend?.();
+			expect(startSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			await session.dispose();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- defer memory backend startup when the root CLI has a startup model profile to apply
- start the backend only after synchronous or deferred profile activation settles
- keep direct SDK callers on the existing immediate-start behavior
- make the deferred starter idempotent and add focused regression coverage

Closes #3838.

## Root cause

`createAgentSession()` started local-memory consolidation while the session still held its bootstrap catalog fallback. Root CLI profile activation happened only after session creation, so the stage-one extractor could capture retired `claude-3-5-sonnet-20240620` before the effective profile model was installed.

## Verification

- `bun test test/sdk-memory-startup.test.ts test/memories-runtime.test.ts test/cli-args-mpreset.test.ts` — 59 pass, 0 fail
- `bun run check:types`
- `bunx biome check --write src/sdk/session.ts src/main.ts test/sdk-memory-startup.test.ts`
- `git diff --check`