### PR TITLE
fix(session): recover interrupted managed cleanup receipts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,8 @@
 - A failed `notify setup` no longer reports "Unable to persist and activate Telegram notification settings" when the durable configuration already carries the attempted bot token, chat id, and enabled state. The wording now follows the stored configuration, so it can no longer contradict a follow-up `notify status`; an operator who reads the failure as "nothing was saved" would otherwise leave Telegram armed for a token another poller may own. A commit that was entered and then failed while the stored configuration is also unreadable is reported as undecided, pointing at `notify status`, instead of guessing either outcome (#3761).
 - Continuing a large managed session on Darwin now batches stale OpenAI Responses replay-metadata patches into one transcript append instead of performing one identity-verified whole-file replacement per patch. Interactive startup also renders before exact MCP connection and explicit `--mpreset` activation, gates every provider turn until both are ready, and refreshes models online only after the UI is usable, preventing `gjc -c` from remaining at `GJC warming workspace` with sustained CPU, multi-gigabyte RSS growth, or avoidable network waits (#3793).
 
+- Managed replacement cleanup now migrates version-one receipts from earlier releases and recovers canonical exchange placeholders left by interrupted cleanup, so a stale receipt cannot permanently block the next managed session mutation with `managed_replace_cleanup_receipt_invalid`.
+
 ## [0.12.11] - 2026-08-03
 
 ### Fixed

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -217,7 +217,83 @@ type ReplacementCleanupReceipt = {
 	predecessor: SerializedReplacementIdentity;
 };
 
+type LegacyReplacementCleanupIdentity = {
+	dev: bigint;
+	ino: bigint;
+	nlink: bigint;
+	size: bigint;
+	mtimeNs: bigint;
+	ctimeNs: bigint;
+	sha256: string;
+};
+
 const U64_MAX = 18_446_744_073_709_551_615n;
+
+function parseCanonicalU64(value: unknown): bigint | undefined {
+	if (typeof value !== "string" || !/^(0|[1-9][0-9]*)$/.test(value) || value.length > 20) return undefined;
+	const parsed = BigInt(value);
+	return parsed <= U64_MAX ? parsed : undefined;
+}
+
+function parseLegacyHexU64(value: string): bigint | undefined {
+	if (!/^[0-9a-f]+$/.test(value) || value.length > 16) return undefined;
+	const parsed = BigInt(`0x${value}`);
+	return parsed <= U64_MAX ? parsed : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return value !== null && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+function legacyReplacementCleanupReceiptBinding(name: string): { dev: bigint; ino: bigint } | undefined {
+	const match = /^\.gjc-replace-cleanup-([0-9a-f]+)-([0-9a-f]+)\.json$/.exec(name);
+	if (!match?.[1] || !match[2]) return undefined;
+	const dev = parseLegacyHexU64(match[1]);
+	const ino = parseLegacyHexU64(match[2]);
+	return dev !== undefined && ino !== undefined ? { dev, ino } : undefined;
+}
+
+function parseLegacyReplacementCleanupIdentity(value: unknown): LegacyReplacementCleanupIdentity | undefined {
+	const identity = asRecord(value);
+	if (!identity) return undefined;
+	const dev = parseCanonicalU64(identity.dev);
+	const ino = parseCanonicalU64(identity.ino);
+	const nlink = parseCanonicalU64(identity.nlink);
+	const size = parseCanonicalU64(identity.size);
+	const mtimeNs = parseCanonicalU64(identity.mtimeNs);
+	const ctimeNs = parseCanonicalU64(identity.ctimeNs);
+	const sha256 = identity.sha256;
+	if (
+		dev === undefined ||
+		ino === undefined ||
+		nlink === undefined ||
+		size === undefined ||
+		mtimeNs === undefined ||
+		ctimeNs === undefined ||
+		typeof sha256 !== "string" ||
+		!/^[0-9a-f]{64}$/.test(sha256)
+	)
+		return undefined;
+	return { dev, ino, nlink, size, mtimeNs, ctimeNs, sha256 };
+}
+
+function parseLegacyReplacementCleanupReceipt(
+	bytes: Uint8Array,
+): { predecessor: string; successor: string; identity: LegacyReplacementCleanupIdentity } | undefined {
+	let value: unknown;
+	try {
+		value = JSON.parse(Buffer.from(bytes).toString("utf8")) as unknown;
+	} catch {
+		return undefined;
+	}
+	const receipt = asRecord(value);
+	if (receipt?.version !== 1 || typeof receipt.predecessor !== "string" || typeof receipt.successor !== "string")
+		return undefined;
+	const identity = parseLegacyReplacementCleanupIdentity(receipt.identity);
+	return identity ? { predecessor: receipt.predecessor, successor: receipt.successor, identity } : undefined;
+}
 
 function replacementCleanupReceiptBinding(
 	name: string,
@@ -258,10 +334,18 @@ function replacementReceiptPath(
 }
 
 function replacementReceiptRetirementName(
-	receipt: ManagedFileSnapshot["identity"],
-	predecessor: ManagedFileSnapshot["identity"],
+	receipt: { dev: bigint; ino: bigint },
+	predecessor: { dev: bigint; ino: bigint },
 ): string {
 	return `.gjc-receipt-remove-${receipt.dev.toString(16)}-${receipt.ino.toString(16)}-${predecessor.dev.toString(16)}-${predecessor.ino.toString(16)}`;
+}
+
+function replacementReceiptPlaceholderRetirementName(
+	placeholder: { dev: bigint; ino: bigint },
+	predecessor: { dev: bigint; ino: bigint },
+	receipt: { dev: bigint; ino: bigint },
+): string {
+	return `.gjc-receipt-placeholder-remove-${placeholder.dev.toString(16)}-${placeholder.ino.toString(16)}-${predecessor.dev.toString(16)}-${predecessor.ino.toString(16)}-${receipt.dev.toString(16)}-${receipt.ino.toString(16)}`;
 }
 
 const ACL_FAILURE_CODES = new Set(["acl_denied", "acl_io_error", "acl_present", "acl_malformed", "acl_unknown"]);
@@ -785,14 +869,68 @@ export class ManagedSessionDescendantStore {
 		}
 	}
 
+	#recoverReplacementCleanupPlaceholder(
+		receiptPath: string,
+		binding: { predecessor: { dev: bigint; ino: bigint }; receipt: { dev: bigint; ino: bigint } },
+		placeholder: ManagedFileSnapshot,
+	): boolean {
+		if (placeholder.bytes.byteLength !== 0) return false;
+		const detachedReceiptPath = path.join(
+			this.#baseDir,
+			replacementReceiptRetirementName(binding.receipt, binding.predecessor),
+		);
+		let detachedReceipt: ManagedFileSnapshot;
+		try {
+			detachedReceipt = captureManagedFileNoFollow(detachedReceiptPath);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+			throw error;
+		}
+		if (detachedReceipt.identity.dev !== binding.receipt.dev || detachedReceipt.identity.ino !== binding.receipt.ino)
+			return false;
+
+		const quarantineName = replacementReceiptPlaceholderRetirementName(
+			placeholder.identity,
+			binding.predecessor,
+			binding.receipt,
+		);
+		const removed = exactUnlink(receiptPath, {
+			dev: placeholder.identity.dev,
+			ino: placeholder.identity.ino,
+			nlink: placeholder.identity.nlink,
+			parentDev: this.#subtreeRoot.dev,
+			parentIno: this.#subtreeRoot.ino,
+			size: BigInt(placeholder.identity.size),
+			mtimeNs: placeholder.identity.mtimeNs,
+			sha256: placeholder.identity.sha256,
+			quarantineName,
+		});
+		if (
+			(!exactUnlinkCompleted(removed) && removed.code !== "not_found") ||
+			removed.retainedSuccessorPath !== undefined ||
+			removed.retainedUnknownPath !== undefined
+		)
+			throw new Error(`managed_replace_receipt_cleanup_pending:${removed.code ?? "unknown"}`);
+		fsyncDirectory(this.#baseDir);
+		return true;
+	}
+
 	#detachReplacementCleanupReceipt(receiptPath: string): void {
 		const binding = replacementCleanupReceiptBinding(path.basename(receiptPath));
 		if (!binding) throw new Error("managed_replace_cleanup_receipt_invalid");
-		const receipt = captureManagedFileNoFollow(receiptPath);
-		if (receipt.identity.dev !== binding.receipt.dev || receipt.identity.ino !== binding.receipt.ino)
+		let receipt: ManagedFileSnapshot;
+		try {
+			receipt = captureManagedFileNoFollow(receiptPath);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+			throw error;
+		}
+		if (receipt.identity.dev !== binding.receipt.dev || receipt.identity.ino !== binding.receipt.ino) {
+			if (this.#recoverReplacementCleanupPlaceholder(receiptPath, binding, receipt)) return;
 			throw new Error("managed_replace_cleanup_receipt_invalid");
+		}
 		const predecessor = binding.predecessor;
-		const quarantineName = `.gjc-receipt-remove-${receipt.identity.dev.toString(16)}-${receipt.identity.ino.toString(16)}-${predecessor.dev.toString(16)}-${predecessor.ino.toString(16)}`;
+		const quarantineName = replacementReceiptRetirementName(receipt.identity, predecessor);
 		const detached = exactUnlink(receiptPath, {
 			dev: receipt.identity.dev,
 			ino: receipt.identity.ino,
@@ -815,14 +953,75 @@ export class ManagedSessionDescendantStore {
 		fsyncDirectory(this.#baseDir);
 	}
 
+	#reconcileLegacyReplacementCleanupReceipt(receiptPath: string, name: string): void {
+		const binding = legacyReplacementCleanupReceiptBinding(name);
+		if (!binding) throw new Error("managed_replace_cleanup_receipt_invalid");
+		const receipt = captureManagedFileNoFollow(receiptPath);
+		const parsed = parseLegacyReplacementCleanupReceipt(receipt.bytes);
+		const expectedPredecessor = path.join(
+			this.#baseDir,
+			`.gjc-exact-replace-destination-${binding.dev.toString(16)}-${binding.ino.toString(16)}`,
+		);
+		if (
+			!parsed ||
+			parsed.identity.dev !== binding.dev ||
+			parsed.identity.ino !== binding.ino ||
+			path.resolve(parsed.predecessor) !== expectedPredecessor ||
+			path.dirname(path.resolve(parsed.successor)) !== this.#baseDir
+		)
+			throw new Error("managed_replace_cleanup_receipt_invalid");
+
+		const retired = exactUnlink(expectedPredecessor, {
+			dev: parsed.identity.dev,
+			ino: parsed.identity.ino,
+			nlink: parsed.identity.nlink,
+			parentDev: this.#subtreeRoot.dev,
+			parentIno: this.#subtreeRoot.ino,
+			size: parsed.identity.size,
+			mtimeNs: parsed.identity.mtimeNs,
+			sha256: parsed.identity.sha256,
+			quarantineName: `.gjc-replace-retry-${parsed.identity.dev.toString(16)}-${parsed.identity.ino.toString(16)}`,
+		});
+		if (!exactUnlinkCompleted(retired) && retired.code !== "not_found")
+			throw new Error(`managed_replace_cleanup_pending:${retired.code ?? "unknown"}`);
+
+		const currentReceipt = captureManagedFileNoFollow(receiptPath);
+		if (
+			!sameIdentity(currentReceipt.identity, receipt.identity) ||
+			currentReceipt.identity.sha256 !== receipt.identity.sha256
+		)
+			throw new Error("managed_replace_cleanup_receipt_invalid");
+		const removed = exactUnlink(receiptPath, {
+			dev: currentReceipt.identity.dev,
+			ino: currentReceipt.identity.ino,
+			nlink: currentReceipt.identity.nlink,
+			parentDev: this.#subtreeRoot.dev,
+			parentIno: this.#subtreeRoot.ino,
+			size: BigInt(currentReceipt.identity.size),
+			mtimeNs: currentReceipt.identity.mtimeNs,
+			sha256: currentReceipt.identity.sha256,
+			quarantineName: `.gjc-receipt-remove-${currentReceipt.identity.dev.toString(16)}-${currentReceipt.identity.ino.toString(16)}`,
+		});
+		if (!exactUnlinkCompleted(removed) && removed.code !== "not_found")
+			throw new Error(`managed_replace_receipt_cleanup_pending:${removed.code ?? "unknown"}`);
+		fsyncDirectory(this.#baseDir);
+	}
+
 	#reconcileReplacementCleanupReceipts(): void {
 		if (this.#reconcilingReplacementCleanup) return;
 		this.#reconcilingReplacementCleanup = true;
 		try {
 			for (const name of fs.readdirSync(this.#baseDir)) {
 				if (!name.startsWith(".gjc-replace-cleanup-")) continue;
-				if (!replacementCleanupReceiptBinding(name)) throw new Error("managed_replace_cleanup_receipt_invalid");
-				this.#detachReplacementCleanupReceipt(path.join(this.#baseDir, name));
+				if (replacementCleanupReceiptBinding(name)) {
+					this.#detachReplacementCleanupReceipt(path.join(this.#baseDir, name));
+					continue;
+				}
+				if (legacyReplacementCleanupReceiptBinding(name)) {
+					this.#reconcileLegacyReplacementCleanupReceipt(path.join(this.#baseDir, name), name);
+					continue;
+				}
+				throw new Error("managed_replace_cleanup_receipt_invalid");
 			}
 		} finally {
 			this.#reconcilingReplacementCleanup = false;

--- a/packages/coding-agent/test/session-storage.test.ts
+++ b/packages/coding-agent/test/session-storage.test.ts
@@ -815,7 +815,16 @@ describe.skipIf(process.platform !== "darwin")("managed replacement receipt deta
 	let root: string;
 	let leaveReceiptPlaceholder = false;
 
-	const snapshot = (pathname: string) => {
+	type ReceiptTestSnapshot = {
+		dev: string;
+		ino: string;
+		nlink: string;
+		size: string;
+		mtimeNs: string;
+		ctimeNs: string;
+		sha256: string;
+	};
+	const snapshot = (pathname: string): ReceiptTestSnapshot => {
 		const stat = fs.lstatSync(pathname, { bigint: true });
 		return {
 			dev: stat.dev.toString(),
@@ -827,12 +836,12 @@ describe.skipIf(process.platform !== "darwin")("managed replacement receipt deta
 			sha256: createHash("sha256").update(fs.readFileSync(pathname)).digest("hex"),
 		};
 	};
-	const receiptPath = (predecessor: ReturnType<typeof snapshot>, receipt: ReturnType<typeof snapshot>) =>
+	const receiptPath = (predecessor: ReceiptTestSnapshot, receipt: ReceiptTestSnapshot) =>
 		path.join(
 			root,
 			`.gjc-replace-cleanup-${BigInt(predecessor.dev).toString(16)}-${BigInt(predecessor.ino).toString(16)}-receipt-${BigInt(receipt.dev).toString(16)}-${BigInt(receipt.ino).toString(16)}.json`,
 		);
-	const publishReceipt = (predecessor: ReturnType<typeof snapshot>, contents: string) => {
+	const publishReceipt = (predecessor: ReceiptTestSnapshot, contents: string) => {
 		const pending = path.join(root, `.gjc-replace-receipt-pending-${randomUUID()}.json`);
 		fs.writeFileSync(pending, contents);
 		const receiptIdentity = snapshot(pending);
@@ -840,7 +849,7 @@ describe.skipIf(process.platform !== "darwin")("managed replacement receipt deta
 		fs.renameSync(pending, receipt);
 		return { receipt, receiptIdentity };
 	};
-	const receiptQuarantine = (receipt: ReturnType<typeof snapshot>, predecessor: ReturnType<typeof snapshot>) =>
+	const receiptQuarantine = (receipt: ReceiptTestSnapshot, predecessor: ReceiptTestSnapshot) =>
 		path.join(
 			root,
 			`.gjc-receipt-remove-${BigInt(receipt.dev).toString(16)}-${BigInt(receipt.ino).toString(16)}-${BigInt(predecessor.dev).toString(16)}-${BigInt(predecessor.ino).toString(16)}`,
@@ -857,7 +866,6 @@ describe.skipIf(process.platform !== "darwin")("managed replacement receipt deta
 			const stat = fs.lstatSync(pathname, { bigint: true });
 			const sha256 = createHash("sha256").update(fs.readFileSync(pathname)).digest("hex");
 			if (
-				!expected.detachOnly ||
 				expected.directory ||
 				!expected.quarantineName ||
 				!stat.isFile() ||
@@ -872,7 +880,7 @@ describe.skipIf(process.platform !== "darwin")("managed replacement receipt deta
 				return { ok: false, code: "identity_mismatch" };
 			const detachedPath = path.join(root, expected.quarantineName);
 			fs.renameSync(pathname, detachedPath);
-			if (leaveReceiptPlaceholder) {
+			if (expected.detachOnly && leaveReceiptPlaceholder) {
 				leaveReceiptPlaceholder = false;
 				fs.writeFileSync(pathname, "");
 				return { ok: false, code: "cleanup_pending", detachedPath, retainedPlaceholderPath: pathname };
@@ -914,6 +922,25 @@ describe.skipIf(process.platform !== "darwin")("managed replacement receipt deta
 		expect(fs.readFileSync(path.join(root, "receipt-detached"), "utf8")).toBe("trigger\n");
 	});
 
+	it("reconciles an exchange placeholder left by an interrupted receipt cleanup", () => {
+		vi.restoreAllMocks();
+		const predecessorPath = path.join(root, "predecessor-real-native");
+		fs.writeFileSync(predecessorPath, "predecessor\n");
+		const predecessor = snapshot(predecessorPath);
+		const { receipt, receiptIdentity } = publishReceipt(
+			predecessor,
+			JSON.stringify({ arbitrary: "receipt contents are advisory" }),
+		);
+		const firstQuarantine = receiptQuarantine(receiptIdentity, predecessor);
+		fs.renameSync(receipt, firstQuarantine);
+		fs.writeFileSync(receipt, "");
+
+		replay("placeholder-real-native");
+
+		expect(fs.existsSync(receipt)).toBe(false);
+		expect(fs.readFileSync(firstQuarantine, "utf8")).toContain("advisory");
+		expect(fs.existsSync(path.join(root, "placeholder-real-native"))).toBe(true);
+	});
 	it("recovers a regular-file cleanup placeholder without deleting either quarantined receipt", () => {
 		const predecessorPath = path.join(root, "predecessor");
 		fs.writeFileSync(predecessorPath, "predecessor\n");
@@ -931,13 +958,12 @@ describe.skipIf(process.platform !== "darwin")("managed replacement receipt deta
 		expect(fs.readFileSync(receipt, "utf8")).toBe("");
 		expect(fs.existsSync(firstQuarantine)).toBe(true);
 
-		expect(() => replay("placeholder-second")).toThrow("managed_replace_cleanup_receipt_invalid");
+		replay("placeholder-second");
 
-		expect(fs.lstatSync(receipt).isFile()).toBe(true);
-		expect(fs.readFileSync(receipt, "utf8")).toBe("");
+		expect(fs.existsSync(receipt)).toBe(false);
 		expect(fs.readFileSync(firstQuarantine, "utf8")).toContain("advisory");
 		expect(fs.readFileSync(predecessorPath, "utf8")).toBe("predecessor\n");
-		expect(fs.existsSync(path.join(root, "placeholder-second"))).toBe(false);
+		expect(fs.existsSync(path.join(root, "placeholder-second"))).toBe(true);
 	});
 
 	it("does not let an alias receipt delete the live transcript", () => {
@@ -987,6 +1013,39 @@ describe.skipIf(process.platform !== "darwin")("managed replacement receipt deta
 
 		expect(() => replay("malformed-receipt")).toThrow("managed_replace_cleanup_receipt_invalid");
 		expect(fs.readFileSync(malformed, "utf8")).toBe("receipt");
+	});
+	it("reconciles a legacy version-one cleanup receipt from an earlier release", () => {
+		vi.restoreAllMocks();
+		const predecessorSeed = path.join(root, ".predecessor");
+		const predecessorContents = "predecessor\n";
+		fs.writeFileSync(predecessorSeed, predecessorContents, { mode: 0o600 });
+		const seedIdentity = snapshot(predecessorSeed);
+		const predecessorPath = path.join(
+			root,
+			`.gjc-exact-replace-destination-${BigInt(seedIdentity.dev).toString(16)}-${BigInt(seedIdentity.ino).toString(16)}`,
+		);
+		fs.renameSync(predecessorSeed, predecessorPath);
+		const predecessor = snapshot(predecessorPath);
+		const receipt = path.join(
+			root,
+			`.gjc-replace-cleanup-${BigInt(predecessor.dev).toString(16)}-${BigInt(predecessor.ino).toString(16)}.json`,
+		);
+		fs.writeFileSync(
+			receipt,
+			JSON.stringify({
+				version: 1,
+				predecessor: predecessorPath,
+				successor: path.join(root, "session.jsonl"),
+				identity: predecessor,
+			}),
+			{ mode: 0o600 },
+		);
+
+		replay("legacy-receipt");
+
+		expect(fs.existsSync(receipt)).toBe(false);
+		expect(fs.existsSync(path.join(root, "legacy-receipt"))).toBe(true);
+		expect(fs.existsSync(predecessorPath)).toBe(false);
 	});
 });
 describe.skipIf(process.platform !== "linux")("managed native security result validation", () => {


### PR DESCRIPTION
## Summary

- Recover an empty canonical replacement-receipt placeholder left by an interrupted exact-unlink exchange, but only when the detached receipt path proves the encoded receipt identity.
- Continue failing closed for non-empty/substituted receipt entries.
- Reconcile version-one cleanup receipts left by an interrupted upgrade.
- Add Darwin native-backed and regression coverage plus an Unreleased changelog entry.

The reported `managed_replace_cleanup_receipt_invalid` was a real persistence failure: the installed stack reached receipt identity validation during `appendSync`, and the affected process had previously crashed with `identity-mismatch`. The `FS_SCAN_LIMIT` message is a separate intentional 250,000-entry guard triggered by scanning `/Users`; it recommends narrowing the search rather than indicating repository corruption.

## Verification

- `bun test packages/coding-agent/test/session-storage.test.ts -t 'managed replacement receipt detachment'` — 7 pass
- `bun test packages/coding-agent/test/session-storage.test.ts -t 'authority-absent managed replacement'` — 8 pass
- `bun --cwd=packages/coding-agent run check:types` — pass
- `bunx biome check ...` — pass
- Full `session-storage.test.ts`: 72 pass, 5 skipped, 4 unrelated pre-existing `FileSessionStorageWriter path security` failures on this Darwin/native setup.

Fixes #3843
