### PR TITLE
fix(tui): restore smooth local loader gradients

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
+- Restored 60 fps time-dependent loader gradients on direct local terminals while retaining the 80 ms cadence and congestion dropping on SSH and multiplexed terminals.
 - Bounded loader animation scheduling to 80 ms, stopped OSC 11 polling after DA1 proves the query unsupported while preserving Mode 2031 recovery, and added the default-on `GJC_TUI_SYNCHRONIZED_OUTPUT=0` compatibility opt-out for terminal parsers that mishandle synchronized-output framing. Real iOS-client validation remains pending for #3798.
 - Decorative animation ticks now pause while stdout has more than 64 KiB buffered, preventing slow SSH terminals and multiplexers from accumulating stale spinner frames.
 

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -1,4 +1,5 @@
 import { type AnimationRegistration, registerAnimationCallback } from "../animation-scheduler";
+import { isRemoteTerminalSession, isUnderTerminalMultiplexer } from "../terminal-capabilities";
 import type { TUI } from "../tui";
 import { sliceByColumn, visibleWidth } from "../utils";
 import { Text } from "./text";
@@ -8,13 +9,21 @@ const SPINNER_ADVANCE_MS = 80;
 /**
  * Compatibility options for existing loader call sites.
  *
- * @deprecated `timeDependentColor` no longer selects a faster scheduler. Every
- * colorizer is reevaluated on the shared 80 ms cadence, so both option values
- * now have identical behavior. The field remains accepted to avoid a source
- * break for downstream callers while they remove it.
+ * @deprecated `timeDependentColor` preserves the historical smooth-animation
+ * contract: direct local terminals reevaluate colorizers at 60 fps, while
+ * remote or multiplexed terminals stay on the shared 80 ms cadence to avoid
+ * output churn. The field remains accepted for downstream callers while they
+ * migrate to an explicit animation policy.
  */
 export interface LoaderOptions {
 	timeDependentColor?: boolean;
+}
+
+const SMOOTH_ANIMATION_MS = 16;
+
+function resolveAnimationCadence(options: LoaderOptions): 16 | 80 {
+	if (options.timeDependentColor !== true) return SPINNER_ADVANCE_MS;
+	return isRemoteTerminalSession() || isUnderTerminalMultiplexer() ? SPINNER_ADVANCE_MS : SMOOTH_ANIMATION_MS;
 }
 
 /** Test-only performance counters for advisory baseline tests. */
@@ -45,7 +54,7 @@ export class Loader extends Text {
 		private messageColorFn: (str: string) => string,
 		private message: string = "Loading...",
 		spinnerFrames?: string[],
-		_options: LoaderOptions = {},
+		private options: LoaderOptions = {},
 	) {
 		super("", 1, 0);
 		this.#ui = ui;
@@ -79,7 +88,7 @@ export class Loader extends Text {
 				this.#lastSpinnerTick = now;
 			}
 			this.#updateDisplay();
-		}, SPINNER_ADVANCE_MS);
+		}, resolveAnimationCadence(this.options));
 	}
 
 	stop() {

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -60,6 +60,11 @@ function multiplexerEnvEnabled(value: string | undefined): boolean {
 	return normalized !== undefined && normalized.length > 0 && !MULTIPLEXER_DISABLED_ENV_VALUES.has(normalized);
 }
 
+/** Returns whether stdout crosses an SSH transport, where animation bytes can outpace the link. */
+export function isRemoteTerminalSession(env: NodeJS.ProcessEnv = Bun.env): boolean {
+	return Boolean(env.SSH_CONNECTION || env.SSH_CLIENT || env.SSH_TTY);
+}
+
 /**
  * Returns whether the process runs under a terminal multiplexer (tmux, GNU
  * screen, or zellij). Recognizes the same host markers as the renderer's

--- a/packages/tui/test/animation-scheduler.test.ts
+++ b/packages/tui/test/animation-scheduler.test.ts
@@ -42,8 +42,10 @@ describe("shared animation scheduler", () => {
 		expect(__animationSchedulerTestHooks.getActiveTimerCount(80)).toBe(0);
 	});
 
-	it("recomputes all loaders at 80ms while preserving time-dependent colors", () => {
+	it("recomputes time-dependent colors at 80ms on constrained terminals", () => {
 		vi.useFakeTimers();
+		const previousSshConnection = process.env.SSH_CONNECTION;
+		process.env.SSH_CONNECTION = "test";
 		let tick = 0;
 		const defaultRequests = vi.fn();
 		const animatedRequests = vi.fn();
@@ -77,6 +79,8 @@ describe("shared animation scheduler", () => {
 		} finally {
 			defaultLoader.stop();
 			animatedLoader.stop();
+			if (previousSshConnection === undefined) delete process.env.SSH_CONNECTION;
+			else process.env.SSH_CONNECTION = previousSshConnection;
 		}
 	});
 });

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -5,6 +5,28 @@ import { visibleWidth } from "@gajae-code/tui/utils";
 import { __animationSchedulerTestHooks } from "../src/animation-scheduler";
 import { VirtualTerminal } from "./virtual-terminal";
 
+const TERMINAL_TRANSPORT_ENV_KEYS = [
+	"SSH_CONNECTION",
+	"SSH_CLIENT",
+	"SSH_TTY",
+	"TMUX",
+	"TMUX_PANE",
+	"STY",
+	"ZELLIJ",
+	"GJC_TMUX_LAUNCHED",
+] as const;
+
+function clearTerminalTransportEnv(): () => void {
+	const saved = TERMINAL_TRANSPORT_ENV_KEYS.map(key => [key, process.env[key]] as const);
+	for (const key of TERMINAL_TRANSPORT_ENV_KEYS) delete process.env[key];
+	return () => {
+		for (const [key, value] of saved) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	};
+}
+
 afterEach(() => {
 	vi.useRealTimers();
 	__animationSchedulerTestHooks.reset();
@@ -126,8 +148,9 @@ describe("Loader component", () => {
 		tui.stop();
 	});
 
-	it("bounds time-dependent animation callbacks and render requests to the 80ms cadence", () => {
+	it("restores the 60fps color cadence for direct local terminals", () => {
 		vi.useFakeTimers();
+		const restoreEnv = clearTerminalTransportEnv();
 		const term = new VirtualTerminal(40, 4);
 		const tui = new TUI(term);
 		let colorTick = 0;
@@ -142,24 +165,83 @@ describe("Loader component", () => {
 			},
 		);
 
-		expect(__loaderPerfCounters.renderRequests).toBe(1);
-		vi.advanceTimersByTime(1000);
+		try {
+			expect(__animationSchedulerTestHooks.getActiveTimerCount(16)).toBe(1);
+			expect(__animationSchedulerTestHooks.getActiveTimerCount(80)).toBe(0);
+			expect(__loaderPerfCounters.renderRequests).toBe(1);
+			vi.advanceTimersByTime(1000);
 
-		expect(__loaderPerfCounters.callbackInvocations).toBeLessThanOrEqual(13);
-		expect(__loaderPerfCounters.renderRequests).toBeLessThanOrEqual(14);
+			expect(__loaderPerfCounters.callbackInvocations).toBe(62);
+			expect(__loaderPerfCounters.renderRequests).toBe(63);
 
-		const beforeMessage = __loaderPerfCounters.renderRequests;
-		loader.setMessage("Immediate");
-		expect(__loaderPerfCounters.renderRequests).toBe(beforeMessage + 1);
+			const beforeMessage = __loaderPerfCounters.renderRequests;
+			loader.setMessage("Immediate");
+			expect(__loaderPerfCounters.renderRequests).toBe(beforeMessage + 1);
 
-		loader.dispose();
-		const callbacksAfterDispose = __loaderPerfCounters.callbackInvocations;
-		const requestsAfterDispose = __loaderPerfCounters.renderRequests;
-		vi.advanceTimersByTime(1000);
-		expect(__loaderPerfCounters.callbackInvocations).toBe(callbacksAfterDispose);
-		expect(__loaderPerfCounters.renderRequests).toBe(requestsAfterDispose);
-		expect(__loaderPerfCounters.liveIntervals).toBe(0);
-		tui.stop();
+			loader.dispose();
+			const callbacksAfterDispose = __loaderPerfCounters.callbackInvocations;
+			const requestsAfterDispose = __loaderPerfCounters.renderRequests;
+			vi.advanceTimersByTime(1000);
+			expect(__loaderPerfCounters.callbackInvocations).toBe(callbacksAfterDispose);
+			expect(__loaderPerfCounters.renderRequests).toBe(requestsAfterDispose);
+			expect(__loaderPerfCounters.liveIntervals).toBe(0);
+		} finally {
+			loader.dispose();
+			tui.stop();
+			restoreEnv();
+		}
+	});
+
+	it("keeps time-dependent loaders at 80ms over SSH", () => {
+		vi.useFakeTimers();
+		const restoreEnv = clearTerminalTransportEnv();
+		process.env.SSH_CONNECTION = "test";
+		const tui = new TUI(new VirtualTerminal(40, 4));
+		const loader = new Loader(
+			tui,
+			text => text,
+			text => text,
+			"Working",
+			["|"],
+			{
+				timeDependentColor: true,
+			},
+		);
+
+		try {
+			expect(__animationSchedulerTestHooks.getActiveTimerCount(16)).toBe(0);
+			expect(__animationSchedulerTestHooks.getActiveTimerCount(80)).toBe(1);
+		} finally {
+			loader.dispose();
+			tui.stop();
+			restoreEnv();
+		}
+	});
+
+	it("keeps time-dependent loaders at 80ms under a multiplexer", () => {
+		vi.useFakeTimers();
+		const restoreEnv = clearTerminalTransportEnv();
+		process.env.TMUX = "test";
+		const tui = new TUI(new VirtualTerminal(40, 4));
+		const loader = new Loader(
+			tui,
+			text => text,
+			text => text,
+			"Working",
+			["|"],
+			{
+				timeDependentColor: true,
+			},
+		);
+
+		try {
+			expect(__animationSchedulerTestHooks.getActiveTimerCount(16)).toBe(0);
+			expect(__animationSchedulerTestHooks.getActiveTimerCount(80)).toBe(1);
+		} finally {
+			loader.dispose();
+			tui.stop();
+			restoreEnv();
+		}
 	});
 	it("deduplicates unchanged output while callbacks remain bounded", () => {
 		vi.useFakeTimers();


### PR DESCRIPTION
## Summary
- restore 60 fps time-dependent loader gradients on direct local terminals
- keep SSH and multiplexed terminals on the bounded 80 ms cadence
- retain congestion-based decorative frame dropping from #3814

## Verification
- bun test packages/tui/test/loader.test.ts packages/tui/test/animation-scheduler.test.ts packages/tui/test/animation-congestion.test.ts
- bun --cwd=packages/tui run check
- bun --cwd=packages/coding-agent run check