### PR TITLE
fix(subagent): restore steer for running subagents without a session file

### DIFF
--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -1387,7 +1387,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						currentJobGeneration: manager.getJob(jobId)?.generation,
 						historicalJobIds: [],
 						status: manager.getJob(jobId)?.status ?? "running",
-						sessionFile: null,
+						sessionFile: subtaskSessionFile,
 						resumable: true,
 						duplicateIdentity: duplicateIdentityKey(admission.identity),
 						duplicateDisposition: admission.disposition?.action,

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -284,7 +284,6 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			if (!record) {
 				missing.push(this.#missingSnapshot(id, "not_found", "No visible detached subagent matches this id."));
 			} else {
-				if (!record.sessionFile) throw new ToolError(`Subagent ${record.subagentId} has no session file.`);
 				if (record.status === "running") {
 					const handle = manager.getLiveHandle(record.subagentId);
 					if (!handle) throw new ToolError(`Subagent ${record.subagentId} has no live handle.`);

--- a/packages/coding-agent/test/tools/subagent.test.ts
+++ b/packages/coding-agent/test/tools/subagent.test.ts
@@ -919,6 +919,40 @@ describe("SubagentTool", () => {
 		expect(steerText).not.toContain("acted on");
 		await manager.dispose({ timeoutMs: 100 });
 	});
+	it("steer running injects through the live handle even when the record has no session file (regression)", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		let injected: string | undefined;
+		// The task tool registers SubagentRecords with sessionFile: null
+		// (subtask session files are carried by the resume descriptor), so the
+		// steer path must not demand record.sessionFile for a running subagent.
+		manager.registerSubagentRecord({
+			subagentId: "0-SteerNoSession",
+			ownerId: "0-Main",
+			currentJobId: null,
+			historicalJobIds: [],
+			status: "running",
+			sessionFile: null,
+			resumable: true,
+		});
+		manager.registerLiveHandle("0-SteerNoSession", {
+			requestPause() {},
+			async injectMessage(content) {
+				injected = content;
+			},
+		});
+
+		const result = await tool.execute("subagent-steer-no-session", {
+			action: "steer",
+			id: "0-SteerNoSession",
+			message: "course correction",
+		});
+
+		expect(injected).toBe("course correction");
+		expect(result.details?.subagents[0]?.steerMessage).toBe("course correction");
+		expect(result.details?.subagents[0]?.steerState).toBe("queued");
+		await manager.dispose({ timeoutMs: 100 });
+	});
 
 	it("steer attributes the caller (nested parent) id, not main or the child id", async () => {
 		const manager = createManager();


### PR DESCRIPTION
## What
Fixes the subagent steer regression where `subagent` tool `steer` threw `Subagent <id> has no session file` for every task-tool-spawned subagent — even running ones — making it impossible to correct a live agent mid-flight.

## Root cause
Two interacting defects:
1. `task/index.ts` registered the `SubagentRecord` with `sessionFile: null` even though the real subtask session file (`subtaskSessionFile`) was known — the pre-rewrite code carried it.
2. `tools/subagent.ts` steer action demanded `record.sessionFile` unconditionally, *before* checking whether the subagent was running.

## Fix
- `task/index.ts`: register the record with `sessionFile: subtaskSessionFile` (the real subtask session file).
- `tools/subagent.ts`: drop the unconditional session-file requirement. A running subagent is steered through its live handle (`injectMessage`), which needs no session file; the non-running resume path already validates retained context itself (`resumeSubagent` → `context_unavailable` when neither a resume descriptor nor a session file exists).
- `test/tools/subagent.test.ts`: regression test — a running record with `sessionFile: null` + live handle accepts a steer and reports `queued`.

## Verification
- subagent tool suite: 42 pass (incl. new regression test)
- job-manager resume queue: 19 pass
- executor pause/managed-resume + live-progress + render: 52 pass
- steer observation + tool discovery: 7 pass
- `bun --cwd=packages/coding-agent run check`: biome + tsc clean
- Boundary cohort (cleaner / architect / executor QA red-team) joined clean on the frozen change set; terminal critic OKAY