### PR TITLE
fix(workflows): remove literal deep-interview argument placeholder

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Fixed
 
+- Fixed deep-interview prompts exposing the literal argument placeholder.
+
 - Automatic session retry now refuses to re-issue a request once the failed attempt carries observable assistant text, thinking, or tool-call content — including under explicit legacy `retry.*` settings. Content-free clean failures keep their existing bounded/unbounded policy; managed provisional discard, credential rotation, first-event timeout scope checks, and manual `/retry` are unchanged (#3791).
 
 - Parent sessions and their subagent trees now share one identity-authorized artifact manager across persistent and ephemeral operation. Non-persistent roots are retired on committed session transitions and terminal close, failed transitions retain predecessor ownership, and atomic numeric-ID claims prevent same-root managers from creating ambiguous artifact references (#3813).

--- a/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/deep-interview/SKILL.md
@@ -122,7 +122,7 @@ Deep Interview threshold: <resolvedThresholdPercent> (source: <resolvedThreshold
    - Substitute `<resolvedThreshold>`, `<resolvedThresholdPercent>`, and `<resolvedThresholdSource>` throughout the remaining instructions before continuing.
    - Include `threshold_source` in the first `gjc deep-interview write` payload and preserve it on later state updates; do not edit `.gjc/_session-{sessionid}/state` files directly unless an explicit force override is active.
    - Include both threshold and source in the final spec metadata.
-- Read any `language` object from active deep-interview state and carry `language.instruction` forward mechanically. If absent, default to English unless `{{ARGUMENTS}}` makes another user/session language obvious or the user explicitly requests another language. Do not add language-specific special cases.
+- Read any `language` object from active deep-interview state and carry `language.instruction` forward mechanically. If absent, default to English unless the appended `User:` request makes another user/session language obvious or the user explicitly requests another language. Do not add language-specific special cases.
 
 ## Phase 0.5: Suitability Gate
 

--- a/packages/coding-agent/test/deep-interview-skill-contract.test.ts
+++ b/packages/coding-agent/test/deep-interview-skill-contract.test.ts
@@ -188,3 +188,10 @@ describe("deep-interview ouroboros ooo-interview parity port", () => {
 		expect(skill).toMatch(/character-count/i);
 	});
 });
+
+describe("deep-interview invocation arguments contract", () => {
+	it("refers to the loader-appended user request without an unresolved placeholder", () => {
+		expect(skill).toContain("the appended `User:` request");
+		expect(skill).not.toContain("{{ARGUMENTS}}");
+	});
+});

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -13,7 +13,12 @@ import {
 	getEmbeddedDefaultGjcSkills,
 	installDefaultGjcDefinitions,
 } from "@gajae-code/coding-agent/defaults/gjc-defaults";
-import { loadSkills, resetActiveSkillsForTests, setActiveSkills } from "@gajae-code/coding-agent/extensibility/skills";
+import {
+	buildSkillPromptMessage,
+	loadSkills,
+	resetActiveSkillsForTests,
+	setActiveSkills,
+} from "@gajae-code/coding-agent/extensibility/skills";
 import { parseInternalUrl } from "@gajae-code/coding-agent/internal-urls/parse";
 import { SkillProtocolHandler } from "@gajae-code/coding-agent/internal-urls/skill-protocol";
 import { getBundledAgent } from "@gajae-code/coding-agent/task/agents";
@@ -592,7 +597,7 @@ Project executor override body.
 		expect(content).toContain("default `0.05`");
 		expect(content).toContain("language.instruction");
 		expect(content).toContain(
-			"default to English unless `{{ARGUMENTS}}` makes another user/session language obvious",
+			"default to English unless the appended `User:` request makes another user/session language obvious",
 		);
 		expect(content).toContain('"language": "<existing language object from active state, if present>"');
 		expect(content).toContain("progress reports, and spec prose");
@@ -613,6 +618,20 @@ Project executor override body.
 		]) {
 			expect(content).not.toContain(forbidden);
 		}
+	});
+
+	it("renders deep-interview arguments once through the loader-owned User field", async () => {
+		const skill = getEmbeddedDefaultGjcSkills().find(skill => skill.name === "deep-interview");
+		if (!skill) throw new Error("missing bundled deep-interview skill");
+		const request = "한국어로 인터뷰해 주세요";
+		const rendered = await buildSkillPromptMessage(skill, request);
+		const empty = await buildSkillPromptMessage(skill, "");
+
+		expect(rendered.message).not.toContain("{{ARGUMENTS}}");
+		expect(rendered.message.split(request)).toHaveLength(2);
+		expect(rendered.message).toEndWith(`Skill: ${skill.filePath}\nUser: ${request}`);
+		expect(empty.message).not.toContain("{{ARGUMENTS}}");
+		expect(empty.message).toEndWith(`Skill: ${skill.filePath}`);
 	});
 
 	it("keeps bundled ralplan stage artifacts on CLI write path", () => {
@@ -643,11 +662,14 @@ Project executor override body.
 		const initial = await installDefaultGjcDefinitions({ targetRoot });
 		const deepInterviewSkillPath = path.join(targetRoot, "skills", "deep-interview", "SKILL.md");
 		const installedDeepInterview = await Bun.file(deepInterviewSkillPath).text();
+		const bundledDeepInterview = getEmbeddedDefaultGjcSkills().find(skill => skill.name === "deep-interview");
+		if (!bundledDeepInterview) throw new Error("missing bundled deep-interview skill");
 
 		expect(initial.written).toBe(9);
 		expect(initial.total).toBe(9);
 		expect(initial.skipped).toBe(0);
 		expect(initial.files.filter(file => file.kind === "skill-fragment")).toHaveLength(5);
+		expect(installedDeepInterview).toBe(bundledDeepInterview.content);
 
 		const installedResearchFragment = await Bun.file(
 			path.join(targetRoot, "skill-fragments", "deep-interview", "auto-research-greenfield.md"),


### PR DESCRIPTION
## Evidence

`deep-interview/SKILL.md` referred to `{{ARGUMENTS}}`, while `buildSkillPromptMessage()` strips frontmatter and appends non-empty invocation arguments as `User: <arguments>` without interpolating the body.

## Root cause

The skill prose assumed a template-expansion phase that the loader does not have. The placeholder therefore remained literal in every bundled and rendered deep-interview prompt.

## Impact and necessity

A visible unresolved token weakens the workflow's language-selection instruction and gives the model a nonexistent value to inspect. Non-English invocations are especially affected because this sentence decides the default interview language.

## Contract and choice

The skill now refers to the loader-appended `User:` request. The loader remains the sole owner of argument placement. This preserves current behavior for non-empty and empty arguments and avoids introducing a second template engine.

## Observed verification

- `bun test packages/coding-agent/test/deep-interview-skill-contract.test.ts packages/coding-agent/test/default-gjc-definitions.test.ts` — 48 pass, 0 fail, 479 expectations.
- `bun scripts/check-visible-definitions.ts` — pass.
- `bun scripts/verify-g002-gates.ts` — pass.
- `bun scripts/rebrand-inventory.ts --strict` — pass.
- `bun scripts/verify-gjc-skill-docs.ts --fail` — pass, 0 command drift issues and 0 direct `.gjc` shell mutation examples.
- `bun --cwd=packages/coding-agent run check` — Biome checked 2529 files; TypeScript passed.
- Direct loader probe: Korean request occurs exactly once; placeholder count changes from 1 before to 0 after.

## Changelog

Adds the Unreleased fixed entry: “Fixed deep-interview prompts exposing the literal argument placeholder.”

## Risk and rollback

Risk is narrow and prose-only; loader semantics and public APIs are unchanged. Rollback is a single commit revert.

## Rejected alternative

Adding body interpolation was rejected because it duplicates argument ownership, expands loader semantics, and creates escaping/substitution behavior unnecessary for this defect.

## Independent merge rationale

This PR owns one prompt-rendering contract in exactly four files and has no dependency on the other planned improvements. It can be reviewed, merged, or reverted independently.