### PR TITLE
fix(tui): apply slash autocomplete layout

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
+- Applied the compact 12–32-column primary layout to slash-command autocomplete while leaving file and other completion lists on their existing layout.
 - Restored 60 fps time-dependent loader gradients on direct local terminals while retaining the 80 ms cadence and congestion dropping on SSH and multiplexed terminals.
 - Bounded loader animation scheduling to 80 ms, stopped OSC 11 polling after DA1 proves the query unsupported while preserving Mode 2031 recovery, and added the default-on `GJC_TUI_SYNCHRONIZED_OUTPUT=0` compatibility opt-out for terminal parsers that mishandle synchronized-output framing. Real iOS-client validation remains pending for #3798.
 - Decorative animation ticks now pause while stdout has more than 64 KiB buffered, preventing slow SSH terminals and multiplexers from accumulating stale spinner frames.

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -242,6 +242,13 @@ export interface AutocompleteItem {
 	/** Dim hint text shown inline after cursor when this item is selected */
 	hint?: string;
 }
+export type AutocompleteSuggestionKind = "slash-command" | "default";
+
+export interface AutocompleteSuggestions {
+	items: AutocompleteItem[];
+	prefix: string;
+	kind?: AutocompleteSuggestionKind;
+}
 
 type Awaitable<T> = T | Promise<T>;
 
@@ -263,14 +270,7 @@ export interface SlashCommand {
 
 export interface AutocompleteProvider {
 	/** Get autocomplete suggestions for current text/cursor position */
-	getSuggestions(
-		lines: string[],
-		cursorLine: number,
-		cursorCol: number,
-	): Promise<{
-		items: AutocompleteItem[];
-		prefix: string; // What we're matching against (e.g., "/" or "src/")
-	} | null>;
+	getSuggestions(lines: string[], cursorLine: number, cursorCol: number): Promise<AutocompleteSuggestions | null>;
 
 	/** Apply the selected item and return new text + cursor position */
 	applyCompletion(
@@ -381,7 +381,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		lines: string[],
 		cursorLine: number,
 		cursorCol: number,
-	): Promise<{ items: AutocompleteItem[]; prefix: string } | null> {
+	): Promise<AutocompleteSuggestions | null> {
 		const currentLine = lines[cursorLine] || "";
 		const textBeforeCursor = currentLine.slice(0, cursorCol);
 
@@ -403,6 +403,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			return {
 				items: suggestions,
 				prefix: atPrefix,
+				kind: "default",
 			};
 		}
 
@@ -419,6 +420,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 
 				return {
 					items: matches,
+					kind: "slash-command",
 					prefix: textBeforeCursor,
 				};
 			}
@@ -439,6 +441,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 
 			return {
 				items: argumentSuggestions,
+				kind: "default",
 				prefix: argumentText,
 			};
 		}
@@ -452,6 +455,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				if (pathSuggestions.length > 0) {
 					return {
 						items: pathSuggestions,
+						kind: "default",
 						prefix: pathMatch,
 					};
 				}
@@ -461,6 +465,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			if (matches.length > 0) {
 				return {
 					items: matches,
+					kind: "slash-command",
 					prefix: slashPrefix,
 				};
 			}
@@ -479,12 +484,14 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				// We still return it so user can select it and add /
 				return {
 					items: suggestions,
+					kind: "default",
 					prefix: pathMatch,
 				};
 			}
 
 			return {
 				items: suggestions,
+				kind: "default",
 				prefix: pathMatch,
 			};
 		}

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2904,11 +2904,8 @@ export class Editor implements Component, Focusable {
 		prefix: string,
 		items: Array<{ value: string; label: string; description?: string }>,
 	): SelectList {
-		// Layout options prepared for future SelectList enhancements (e.g., for slash commands)
 		const layout = prefix.startsWith("/") ? SLASH_COMMAND_SELECT_LIST_LAYOUT : undefined;
-		// TODO: Pass layout to SelectList when constructor is updated to support it
-		void layout; // Use layout variable to avoid lint warnings
-		return new SelectList(items, this.#autocompleteMaxVisible, this.#theme.selectList);
+		return new SelectList(items, this.#autocompleteMaxVisible, this.#theme.selectList, layout);
 	}
 
 	#handleTabCompletion(): void {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1,6 +1,7 @@
 import { getProjectDir, logger, onDefaultTabWidthChange } from "@gajae-code/utils";
 import {
 	type AutocompleteProvider,
+	type AutocompleteSuggestionKind,
 	type CombinedAutocompleteProvider,
 	extractSlashCommandTokenPrefix,
 	isInsideInlineCodeSpan,
@@ -2894,10 +2895,7 @@ export class Editor implements Component, Focusable {
 
 		if (suggestions && Array.isArray(suggestions.items) && suggestions.items.length > 0) {
 			this.#autocompletePrefix = suggestions.prefix;
-			this.#autocompleteList = this.#createAutocompleteList(
-				suggestions.items,
-				this.#isSlashCommandNameAutocompleteContext() ? "slash-command" : "default",
-			);
+			this.#autocompleteList = this.#createAutocompleteList(suggestions.items, suggestions.kind ?? "default");
 			this.#autocompleteState = "regular";
 			this.#autocompleteOrigin = origin;
 			this.onAutocompleteUpdate?.();
@@ -2909,7 +2907,7 @@ export class Editor implements Component, Focusable {
 	}
 	#createAutocompleteList(
 		items: Array<{ value: string; label: string; description?: string }>,
-		kind: "slash-command" | "default",
+		kind: AutocompleteSuggestionKind,
 	): SelectList {
 		const layout = kind === "slash-command" ? SLASH_COMMAND_SELECT_LIST_LAYOUT : undefined;
 		return new SelectList(items, this.#autocompleteMaxVisible, this.#theme.selectList, layout);
@@ -3039,10 +3037,7 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 		if (suggestions && Array.isArray(suggestions.items) && suggestions.items.length > 0) {
 			this.#autocompletePrefix = suggestions.prefix;
 			// Always create new SelectList to ensure update
-			this.#autocompleteList = this.#createAutocompleteList(
-				suggestions.items,
-				this.#isSlashCommandNameAutocompleteContext() ? "slash-command" : "default",
-			);
+			this.#autocompleteList = this.#createAutocompleteList(suggestions.items, suggestions.kind ?? "default");
 			this.#autocompleteOrigin = origin;
 			this.onAutocompleteUpdate?.();
 		} else {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2838,16 +2838,20 @@ export class Editor implements Component, Focusable {
 		);
 	}
 
-	#isSlashCommandNameAutocompleteSelection(): boolean {
-		if (this.#autocompleteState !== "regular") {
-			return false;
-		}
-
+	#isSlashCommandNameAutocompleteContext(): boolean {
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 		const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol).trimStart();
 		return (
 			this.#isInSubmittedSlashCommandContext() && textBeforeCursor.startsWith("/") && !textBeforeCursor.includes(" ")
 		);
+	}
+
+	#isSlashCommandNameAutocompleteSelection(): boolean {
+		if (this.#autocompleteState !== "regular") {
+			return false;
+		}
+
+		return this.#isSlashCommandNameAutocompleteContext();
 	}
 
 	#isCompletedSlashCommandAtCursor(): boolean {
@@ -2890,7 +2894,10 @@ export class Editor implements Component, Focusable {
 
 		if (suggestions && Array.isArray(suggestions.items) && suggestions.items.length > 0) {
 			this.#autocompletePrefix = suggestions.prefix;
-			this.#autocompleteList = this.#createAutocompleteList(suggestions.prefix, suggestions.items);
+			this.#autocompleteList = this.#createAutocompleteList(
+				suggestions.items,
+				this.#isSlashCommandNameAutocompleteContext() ? "slash-command" : "default",
+			);
 			this.#autocompleteState = "regular";
 			this.#autocompleteOrigin = origin;
 			this.onAutocompleteUpdate?.();
@@ -2901,10 +2908,10 @@ export class Editor implements Component, Focusable {
 		}
 	}
 	#createAutocompleteList(
-		prefix: string,
 		items: Array<{ value: string; label: string; description?: string }>,
+		kind: "slash-command" | "default",
 	): SelectList {
-		const layout = prefix.startsWith("/") ? SLASH_COMMAND_SELECT_LIST_LAYOUT : undefined;
+		const layout = kind === "slash-command" ? SLASH_COMMAND_SELECT_LIST_LAYOUT : undefined;
 		return new SelectList(items, this.#autocompleteMaxVisible, this.#theme.selectList, layout);
 	}
 
@@ -2982,7 +2989,7 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 			}
 
 			this.#autocompletePrefix = suggestions.prefix;
-			this.#autocompleteList = this.#createAutocompleteList(suggestions.prefix, suggestions.items);
+			this.#autocompleteList = this.#createAutocompleteList(suggestions.items, "default");
 			this.#autocompleteState = "force";
 			this.#autocompleteOrigin = origin;
 			this.onAutocompleteUpdate?.();
@@ -3032,7 +3039,10 @@ https://github.com/EsotericSoftware/spine-runtimes/actions/runs/19536643416/job/
 		if (suggestions && Array.isArray(suggestions.items) && suggestions.items.length > 0) {
 			this.#autocompletePrefix = suggestions.prefix;
 			// Always create new SelectList to ensure update
-			this.#autocompleteList = this.#createAutocompleteList(suggestions.prefix, suggestions.items);
+			this.#autocompleteList = this.#createAutocompleteList(
+				suggestions.items,
+				this.#isSlashCommandNameAutocompleteContext() ? "slash-command" : "default",
+			);
 			this.#autocompleteOrigin = origin;
 			this.onAutocompleteUpdate?.();
 		} else {

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -2,7 +2,15 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { CombinedAutocompleteProvider, extractSlashCommandTokenPrefix } from "@gajae-code/tui/autocomplete";
+import {
+	type AutocompleteItem,
+	type AutocompleteProvider,
+	CombinedAutocompleteProvider,
+	extractSlashCommandTokenPrefix,
+} from "@gajae-code/tui/autocomplete";
+import { Editor } from "@gajae-code/tui/components/editor";
+import { visibleWidth } from "@gajae-code/tui/utils";
+import { defaultEditorTheme } from "./test-themes";
 
 describe("CombinedAutocompleteProvider", () => {
 	describe("extractPathPrefix", () => {
@@ -470,5 +478,89 @@ describe("trySyncSlashCompletion", () => {
 		const colon = provider.trySyncSlashCompletion("/skill:te");
 		expect(dashed?.items[0]?.value).toBe("skill:team");
 		expect(colon?.items[0]?.value).toBe("skill:team");
+	});
+});
+
+class StaticAutocompleteProvider implements AutocompleteProvider {
+	#result: { items: AutocompleteItem[]; prefix: string };
+
+	constructor(result: { items: AutocompleteItem[]; prefix: string }) {
+		this.#result = result;
+	}
+
+	async getSuggestions(): Promise<{ items: AutocompleteItem[]; prefix: string }> {
+		return this.#result;
+	}
+
+	applyCompletion(
+		lines: string[],
+		cursorLine: number,
+		cursorCol: number,
+	): { lines: string[]; cursorLine: number; cursorCol: number } {
+		return { lines, cursorLine, cursorCol };
+	}
+}
+
+async function renderEditorAutocomplete(prefix: string, items: AutocompleteItem[], width: number): Promise<string[]> {
+	const editor = new Editor(defaultEditorTheme);
+	editor.setBorderVisible(false);
+	editor.setAutocompleteProvider(new StaticAutocompleteProvider({ prefix, items }));
+	for (const character of prefix) editor.handleInput(character);
+	await Bun.sleep(0);
+	return editor
+		.render(width)
+		.slice(1)
+		.map(line => Bun.stripANSI(line));
+}
+
+describe("Editor autocomplete layout", () => {
+	const slashItems: AutocompleteItem[] = [
+		{ value: "go", label: "go", description: "Run immediately" },
+		{ value: "한글명령", label: "한글명령", description: "Unicode workflow description" },
+	];
+
+	it("keeps slash-command rows width-safe at narrow, medium, and wide terminal widths", async () => {
+		const snapshots = await Promise.all(
+			[20, 40, 120].map(async width => {
+				const lines = await renderEditorAutocomplete("/g", slashItems, width);
+				expect(lines.every(line => visibleWidth(line) <= width)).toBeTrue();
+				return lines;
+			}),
+		);
+
+		expect(snapshots).toEqual([
+			["> go", "  한글명령"],
+			["> go", "  한글명령"],
+			["> go          Run immediately", "  한글명령    Unicode workflow description"],
+		]);
+	});
+
+	it("clamps slash primary columns between 12 and 32 cells with Unicode labels", async () => {
+		const shortLines = await renderEditorAutocomplete("/g", slashItems, 120);
+		const longLines = await renderEditorAutocomplete(
+			"/g",
+			[
+				{
+					value: "skill:한글-워크플로-이름이-아주-긴-명령",
+					label: "skill:한글-워크플로-이름이-아주-긴-명령",
+					description: "Long description",
+				},
+			],
+			120,
+		);
+		const shortDescriptionColumn = visibleWidth(shortLines[0]!.slice(0, shortLines[0]!.indexOf("Run immediately")));
+		const longDescriptionColumn = visibleWidth(longLines[0]!.slice(0, longLines[0]!.indexOf("Long description")));
+
+		expect(shortDescriptionColumn).toBe(14);
+		expect(longDescriptionColumn).toBe(34);
+	});
+
+	it("keeps non-slash autocomplete on the default 32-column layout", async () => {
+		const lines = await renderEditorAutocomplete("@f", slashItems, 120);
+
+		expect(lines).toEqual([
+			"> go                              Run immediately",
+			"  한글명령                        Unicode workflow description",
+		]);
 	});
 });

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import {
 	type AutocompleteItem,
 	type AutocompleteProvider,
+	type AutocompleteSuggestionKind,
 	CombinedAutocompleteProvider,
 	extractSlashCommandTokenPrefix,
 } from "@gajae-code/tui/autocomplete";
@@ -244,6 +245,16 @@ describe("inline backtick slash classification", () => {
 });
 
 describe("inline slash command suggestions", () => {
+	it("marks start-of-input command-name suggestions as slash commands", async () => {
+		const provider = new CombinedAutocompleteProvider(
+			[{ name: "model", description: "Switch AI model", value: "model" }],
+			"/tmp",
+		);
+		const result = await provider.getSuggestions(["/mo"], 0, 3);
+
+		expect(result?.kind).toBe("slash-command");
+	});
+
 	it("suggests command names for slash tokens after existing prompt text", async () => {
 		const provider = new CombinedAutocompleteProvider(
 			[{ name: "model", description: "Switch AI model", value: "model" }],
@@ -254,6 +265,7 @@ describe("inline slash command suggestions", () => {
 
 		expect(result).not.toBeNull();
 		expect(result!.prefix).toBe("/mo");
+		expect(result!.kind).toBe("slash-command");
 		expect(result!.items.map(item => item.value)).toEqual(["model"]);
 	});
 
@@ -281,6 +293,7 @@ describe("inline slash command suggestions", () => {
 		const result = await provider.getSuggestions([line], 0, line.length);
 
 		expect(result).toEqual(pathOnlyResult);
+		expect(result?.kind).toBe("default");
 		expect(result?.items.map(item => item.value) ?? []).not.toContain("template");
 	});
 
@@ -294,6 +307,7 @@ describe("inline slash command suggestions", () => {
 
 		expect(result).not.toBeNull();
 		expect(result!.prefix).toBe("/");
+		expect(result!.kind).toBe("default");
 		expect(result!.items.some(item => item.value.startsWith("/"))).toBe(true);
 		expect(result!.items.map(item => item.value)).not.toContain("model");
 	});
@@ -482,13 +496,13 @@ describe("trySyncSlashCompletion", () => {
 });
 
 class StaticAutocompleteProvider implements AutocompleteProvider {
-	#result: { items: AutocompleteItem[]; prefix: string };
+	#result: { items: AutocompleteItem[]; prefix: string; kind?: AutocompleteSuggestionKind };
 
-	constructor(result: { items: AutocompleteItem[]; prefix: string }) {
+	constructor(result: { items: AutocompleteItem[]; prefix: string; kind?: AutocompleteSuggestionKind }) {
 		this.#result = result;
 	}
 
-	async getSuggestions(): Promise<{ items: AutocompleteItem[]; prefix: string }> {
+	async getSuggestions(): Promise<{ items: AutocompleteItem[]; prefix: string; kind?: AutocompleteSuggestionKind }> {
 		return this.#result;
 	}
 
@@ -501,10 +515,17 @@ class StaticAutocompleteProvider implements AutocompleteProvider {
 	}
 }
 
-async function renderEditorAutocomplete(prefix: string, items: AutocompleteItem[], width: number): Promise<string[]> {
+async function renderEditorAutocomplete(
+	prefix: string,
+	items: AutocompleteItem[],
+	width: number,
+	kind: AutocompleteSuggestionKind = "default",
+	leadingText: string = "",
+): Promise<string[]> {
 	const editor = new Editor(defaultEditorTheme);
 	editor.setBorderVisible(false);
-	editor.setAutocompleteProvider(new StaticAutocompleteProvider({ prefix, items }));
+	editor.setAutocompleteProvider(new StaticAutocompleteProvider({ prefix, items, kind }));
+	editor.setText(leadingText);
 	for (const character of prefix) editor.handleInput(character);
 	await Bun.sleep(0);
 	return editor
@@ -520,7 +541,7 @@ async function renderEditorAbsolutePathAutocomplete(
 ): Promise<string[]> {
 	const editor = new Editor(defaultEditorTheme);
 	editor.setBorderVisible(false);
-	editor.setAutocompleteProvider(new StaticAutocompleteProvider({ prefix, items }));
+	editor.setAutocompleteProvider(new StaticAutocompleteProvider({ prefix, items, kind: "default" }));
 	editor.setText(`read ${prefix}`);
 	editor.handleInput("\t");
 	await Bun.sleep(0);
@@ -539,7 +560,7 @@ describe("Editor autocomplete layout", () => {
 	it("keeps slash-command rows width-safe at narrow, medium, and wide terminal widths", async () => {
 		const snapshots = await Promise.all(
 			[20, 40, 120].map(async width => {
-				const lines = await renderEditorAutocomplete("/g", slashItems, width);
+				const lines = await renderEditorAutocomplete("/g", slashItems, width, "slash-command");
 				expect(lines.every(line => visibleWidth(line) <= width)).toBeTrue();
 				return lines;
 			}),
@@ -553,7 +574,7 @@ describe("Editor autocomplete layout", () => {
 	});
 
 	it("clamps slash primary columns between 12 and 32 cells with Unicode labels", async () => {
-		const shortLines = await renderEditorAutocomplete("/g", slashItems, 120);
+		const shortLines = await renderEditorAutocomplete("/g", slashItems, 120, "slash-command");
 		const longLines = await renderEditorAutocomplete(
 			"/g",
 			[
@@ -564,6 +585,7 @@ describe("Editor autocomplete layout", () => {
 				},
 			],
 			120,
+			"slash-command",
 		);
 		const shortDescriptionColumn = visibleWidth(shortLines[0]!.slice(0, shortLines[0]!.indexOf("Run immediately")));
 		const longDescriptionColumn = visibleWidth(longLines[0]!.slice(0, longLines[0]!.indexOf("Long description")));
@@ -579,6 +601,11 @@ describe("Editor autocomplete layout", () => {
 			"> go                              Run immediately",
 			"  한글명령                        Unicode workflow description",
 		]);
+	});
+	it("uses the compact slash-command layout for inline command-name suggestions", async () => {
+		const lines = await renderEditorAutocomplete("/g", slashItems, 120, "slash-command", "explain this ");
+
+		expect(lines).toEqual(["> go          Run immediately", "  한글명령    Unicode workflow description"]);
 	});
 
 	it("keeps absolute-path file autocomplete byte-identical to the default layout", async () => {

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -513,6 +513,23 @@ async function renderEditorAutocomplete(prefix: string, items: AutocompleteItem[
 		.map(line => Bun.stripANSI(line));
 }
 
+async function renderEditorAbsolutePathAutocomplete(
+	prefix: string,
+	items: AutocompleteItem[],
+	width: number,
+): Promise<string[]> {
+	const editor = new Editor(defaultEditorTheme);
+	editor.setBorderVisible(false);
+	editor.setAutocompleteProvider(new StaticAutocompleteProvider({ prefix, items }));
+	editor.setText(`read ${prefix}`);
+	editor.handleInput("\t");
+	await Bun.sleep(0);
+	return editor
+		.render(width)
+		.slice(1)
+		.map(line => Bun.stripANSI(line));
+}
+
 describe("Editor autocomplete layout", () => {
 	const slashItems: AutocompleteItem[] = [
 		{ value: "go", label: "go", description: "Run immediately" },
@@ -562,5 +579,12 @@ describe("Editor autocomplete layout", () => {
 			"> go                              Run immediately",
 			"  한글명령                        Unicode workflow description",
 		]);
+	});
+
+	it("keeps absolute-path file autocomplete byte-identical to the default layout", async () => {
+		const defaultLines = await renderEditorAutocomplete("@f", slashItems, 120);
+		const absolutePathLines = await renderEditorAbsolutePathAutocomplete("/tmp/f", slashItems, 120);
+
+		expect(absolutePathLines).toEqual(defaultLines);
 	});
 });


### PR DESCRIPTION
## Summary
- pass the existing compact layout to slash-command `SelectList` instances
- preserve the default layout for file and other non-slash completions
- cover 20/40/120-column rendering, Unicode widths, min/max clamping, and exact non-slash output

## Verification
- `bun test packages/tui/test/autocomplete.test.ts packages/tui/test/select-list.test.ts packages/tui/test/editor-autocomplete-actions.test.ts`
- `bun --cwd=packages/tui run check`

## Changelog
- added an Unreleased TUI fix entry