### PR TITLE
fix(tui): quarantine throwing animation callbacks

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Throwing animation callbacks are now removed before one bounded centralized diagnostic is recorded, so a failed decorative registrant runs only once, healthy siblings continue, the final shared timer stops, and scheduler failures never write directly to terminal stdout or stderr.
+
 ## [0.12.12] - 2026-08-05
 ### Fixed
 

--- a/packages/tui/src/animation-scheduler.ts
+++ b/packages/tui/src/animation-scheduler.ts
@@ -1,3 +1,5 @@
+import { logger, sanitizeText } from "@gajae-code/utils";
+
 export type AnimationCadence = 16 | 80;
 
 type TimerHandle = ReturnType<typeof setInterval>;
@@ -22,6 +24,35 @@ const DEFAULT_CONGESTION_THRESHOLD_BYTES = 64 * 1024;
 
 let bufferedOutputBytesProbe: (() => number | undefined) | undefined;
 let skippedTicks = 0;
+let failedCallbackCount = 0;
+
+const MAX_ERROR_NAME_CODE_POINTS = 64;
+const MAX_ERROR_MESSAGE_CODE_POINTS = 256;
+
+function boundedDiagnosticText(value: string, limit: number, fallback: string): string {
+	const sanitized = sanitizeText(value).replace(/\s+/g, " ").trim();
+	return Array.from(sanitized || fallback)
+		.slice(0, limit)
+		.join("");
+}
+
+function errorDiagnostic(error: unknown): { errorName: string; message: string } {
+	if (!(error instanceof Error)) {
+		return { errorName: "UnknownError", message: "Animation callback threw a non-Error value" };
+	}
+	let name = "Error";
+	let message = "Animation callback threw";
+	try {
+		if (typeof error.name === "string") name = error.name;
+		if (typeof error.message === "string") message = error.message;
+	} catch {
+		// Hostile accessors must not turn diagnostic extraction into another tick failure.
+	}
+	return {
+		errorName: boundedDiagnosticText(name, MAX_ERROR_NAME_CODE_POINTS, "Error"),
+		message: boundedDiagnosticText(message, MAX_ERROR_MESSAGE_CODE_POINTS, "Animation callback threw"),
+	};
+}
 
 function outputIsCongested(): boolean {
 	const stdout = globalThis.process?.stdout as { writableLength?: number } | undefined;
@@ -52,14 +83,22 @@ function startBucket(cadence: AnimationCadence, bucket: CadenceBucket): void {
 			return;
 		}
 		const now = performance.now();
-		// Snapshot so re-entrant register/unregister during a tick is safe, and
-		// isolate each callback so one throwing registrant cannot starve siblings
-		// or surface as an uncaught exception that kills the shared timer.
+		// Snapshot so re-entrant register/unregister during a tick is safe.
 		for (const callback of [...bucket.callbacks]) {
 			try {
 				callback(now);
-			} catch (err) {
-				console.error("[animation-scheduler] callback threw:", err);
+			} catch (error) {
+				// A failed decorative registration is disposable: quarantine it before
+				// reporting so neither logger latency nor failure can make it run again.
+				bucket.callbacks.delete(callback);
+				failedCallbackCount += 1;
+				if (bucket.callbacks.size === 0) stopBucket(bucket);
+				const diagnostic = errorDiagnostic(error);
+				logger.warn("Animation callback quarantined after throwing", {
+					cadence,
+					errorName: diagnostic.errorName,
+					message: diagnostic.message,
+				});
 			}
 		}
 	}, cadence);
@@ -120,6 +159,9 @@ export const __animationSchedulerTestHooks = {
 	getSkippedTickCount(): number {
 		return skippedTicks;
 	},
+	getFailedCallbackCount(): number {
+		return failedCallbackCount;
+	},
 	getCongestionThresholdBytes(): number {
 		return DEFAULT_CONGESTION_THRESHOLD_BYTES;
 	},
@@ -133,6 +175,7 @@ export const __animationSchedulerTestHooks = {
 			bucket.startedTimers = 0;
 		}
 		skippedTicks = 0;
+		failedCallbackCount = 0;
 		bufferedOutputBytesProbe = undefined;
 	},
 };

--- a/packages/tui/src/animation-scheduler.ts
+++ b/packages/tui/src/animation-scheduler.ts
@@ -30,24 +30,44 @@ const MAX_ERROR_NAME_CODE_POINTS = 64;
 const MAX_ERROR_MESSAGE_CODE_POINTS = 256;
 
 function boundedDiagnosticText(value: string, limit: number, fallback: string): string {
-	const sanitized = sanitizeText(value).replace(/\s+/g, " ").trim();
-	return Array.from(sanitized || fallback)
-		.slice(0, limit)
-		.join("");
+	try {
+		let bounded = "";
+		let codePoints = 0;
+		for (const codePoint of value) {
+			if (codePoints >= limit) break;
+			bounded += codePoint;
+			codePoints += 1;
+		}
+		const sanitized = sanitizeText(bounded).replace(/\s+/g, " ").trim();
+		return sanitized || fallback;
+	} catch {
+		return fallback;
+	}
+}
+
+function isErrorValue(value: unknown): value is Error {
+	try {
+		return value instanceof Error;
+	} catch {
+		return false;
+	}
+}
+
+function readErrorString(error: Error, property: "name" | "message"): string | undefined {
+	try {
+		const value = Reflect.get(error, property);
+		return typeof value === "string" ? value : undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 function errorDiagnostic(error: unknown): { errorName: string; message: string } {
-	if (!(error instanceof Error)) {
+	if (!isErrorValue(error)) {
 		return { errorName: "UnknownError", message: "Animation callback threw a non-Error value" };
 	}
-	let name = "Error";
-	let message = "Animation callback threw";
-	try {
-		if (typeof error.name === "string") name = error.name;
-		if (typeof error.message === "string") message = error.message;
-	} catch {
-		// Hostile accessors must not turn diagnostic extraction into another tick failure.
-	}
+	const name = readErrorString(error, "name") ?? "Error";
+	const message = readErrorString(error, "message") ?? "Animation callback threw";
 	return {
 		errorName: boundedDiagnosticText(name, MAX_ERROR_NAME_CODE_POINTS, "Error"),
 		message: boundedDiagnosticText(message, MAX_ERROR_MESSAGE_CODE_POINTS, "Animation callback threw"),

--- a/packages/tui/test/animation-scheduler-redteam.test.ts
+++ b/packages/tui/test/animation-scheduler-redteam.test.ts
@@ -3,6 +3,7 @@ import { __animationSchedulerTestHooks } from "@gajae-code/tui";
 import { registerAnimationCallback } from "@gajae-code/tui/animation-scheduler";
 import { Loader } from "@gajae-code/tui/components/loader";
 import type { TUI } from "@gajae-code/tui/tui";
+import { logger } from "@gajae-code/utils";
 
 function makeUi() {
 	return { requestRender: vi.fn() } as unknown as TUI & { requestRender: ReturnType<typeof vi.fn> };
@@ -193,6 +194,7 @@ describe("G010 shared animation scheduler red-team", () => {
 
 	it("THROW-ISOLATION: one throwing callback does not stop the bucket or block other registrants", () => {
 		vi.useFakeTimers();
+		const warning = vi.spyOn(logger, "warn").mockImplementation(() => {});
 		let healthyCalls = 0;
 		const throwing = registerAnimationCallback(() => {
 			throw new Error("red-team scheduler throw");
@@ -204,14 +206,45 @@ describe("G010 shared animation scheduler red-team", () => {
 		expect(() => vi.advanceTimersByTime(80)).not.toThrow();
 		expect(healthyCalls).toBe(1);
 		expect(__animationSchedulerTestHooks.getActiveTimerCount(80)).toBe(1);
+		expect(__animationSchedulerTestHooks.getRegistrantCount(80)).toBe(1);
+		expect(__animationSchedulerTestHooks.getFailedCallbackCount()).toBe(1);
+		expect(warning).toHaveBeenCalledTimes(1);
 
 		throwing.unregister();
 		vi.advanceTimersByTime(80);
 		expect(healthyCalls).toBe(2);
 		expect(__animationSchedulerTestHooks.getActiveTimerCount(80)).toBe(1);
+		expect(warning).toHaveBeenCalledTimes(1);
 
 		healthy.unregister();
 		expect(__animationSchedulerTestHooks.getActiveTimerCount()).toBe(0);
+	});
+
+	it("keeps scheduler failures out of terminal bytes", () => {
+		const result = Bun.spawnSync({
+			cmd: [
+				process.execPath,
+				"--eval",
+				`
+					import { __animationSchedulerTestHooks, registerAnimationCallback } from "./packages/tui/src/animation-scheduler.ts";
+					registerAnimationCallback(() => { throw new Error("terminal-byte-sentinel"); }, 16);
+					await Bun.sleep(40);
+					process.exitCode =
+						__animationSchedulerTestHooks.getFailedCallbackCount() === 1 &&
+						__animationSchedulerTestHooks.getActiveTimerCount() === 0
+							? 0
+							: 1;
+				`,
+			],
+			cwd: process.cwd(),
+			env: process.env,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.byteLength).toBe(0);
+		expect(result.stderr.byteLength).toBe(0);
 	});
 
 	it("REENTRANT: callback registration and unregistration during a tick do not corrupt invocation counts", () => {

--- a/packages/tui/test/animation-scheduler-redteam.test.ts
+++ b/packages/tui/test/animation-scheduler-redteam.test.ts
@@ -220,17 +220,36 @@ describe("G010 shared animation scheduler red-team", () => {
 		expect(__animationSchedulerTestHooks.getActiveTimerCount()).toBe(0);
 	});
 
-	it("keeps scheduler failures out of terminal bytes", () => {
+	it("quarantines hostile thrown Proxies without blocking siblings or emitting terminal bytes", () => {
 		const result = Bun.spawnSync({
 			cmd: [
 				process.execPath,
 				"--eval",
 				`
 					import { __animationSchedulerTestHooks, registerAnimationCallback } from "./packages/tui/src/animation-scheduler.ts";
-					registerAnimationCallback(() => { throw new Error("terminal-byte-sentinel"); }, 16);
-					await Bun.sleep(40);
+					const hostilePrototype = new Proxy(new Error("hidden"), {
+						getPrototypeOf() {
+							throw new Error("\\x1b[31mterminal-byte-sentinel");
+						},
+					});
+					const hostileProperties = new Proxy(new Error("hidden"), {
+						get() {
+							throw new Error("\\x1b[31mterminal-byte-sentinel");
+						},
+					});
+					let healthyCalls = 0;
+					registerAnimationCallback(() => { throw hostilePrototype; }, 16);
+					registerAnimationCallback(() => { throw hostileProperties; }, 16);
+					const healthy = registerAnimationCallback(() => { healthyCalls += 1; }, 16);
+					await Bun.sleep(55);
+					const quarantined =
+						__animationSchedulerTestHooks.getFailedCallbackCount() === 2 &&
+						__animationSchedulerTestHooks.getRegistrantCount(16) === 1 &&
+						__animationSchedulerTestHooks.getActiveTimerCount(16) === 1;
+					healthy.unregister();
 					process.exitCode =
-						__animationSchedulerTestHooks.getFailedCallbackCount() === 1 &&
+						quarantined &&
+						healthyCalls >= 2 &&
 						__animationSchedulerTestHooks.getActiveTimerCount() === 0
 							? 0
 							: 1;

--- a/packages/tui/test/animation-scheduler.test.ts
+++ b/packages/tui/test/animation-scheduler.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import { __animationSchedulerTestHooks } from "@gajae-code/tui";
+import { __animationSchedulerTestHooks, registerAnimationCallback } from "@gajae-code/tui";
 import { Loader } from "@gajae-code/tui/components/loader";
 import type { TUI } from "@gajae-code/tui/tui";
+import { logger } from "@gajae-code/utils";
 
 describe("shared animation scheduler", () => {
 	afterEach(() => {
 		__animationSchedulerTestHooks.reset();
+		vi.restoreAllMocks();
 		vi.useRealTimers();
 	});
 
@@ -82,5 +84,65 @@ describe("shared animation scheduler", () => {
 			if (previousSshConnection === undefined) delete process.env.SSH_CONNECTION;
 			else process.env.SSH_CONNECTION = previousSshConnection;
 		}
+	});
+
+	it("quarantines a throwing callback once while preserving its sibling", () => {
+		vi.useFakeTimers();
+		const warning = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		let throwingCalls = 0;
+		let healthyCalls = 0;
+		const error = new Error(`unsafe\x1b[31m\n${"😀".repeat(300)}`);
+		error.name = "NamedFailure".repeat(10);
+		const throwing = registerAnimationCallback(() => {
+			throwingCalls += 1;
+			throw error;
+		});
+		const healthy = registerAnimationCallback(() => {
+			healthyCalls += 1;
+		});
+
+		vi.advanceTimersByTime(160);
+
+		expect(throwingCalls).toBe(1);
+		expect(healthyCalls).toBe(2);
+		expect(__animationSchedulerTestHooks.getRegistrantCount(80)).toBe(1);
+		expect(__animationSchedulerTestHooks.getFailedCallbackCount()).toBe(1);
+		expect(warning).toHaveBeenCalledTimes(1);
+		const [warningMessage, diagnostic] = warning.mock.calls[0]!;
+		expect(warningMessage).toBe("Animation callback quarantined after throwing");
+		expect(diagnostic).toEqual({
+			cadence: 80,
+			errorName: expect.any(String),
+			message: expect.any(String),
+		});
+		expect(Array.from(String(diagnostic?.errorName))).toHaveLength(64);
+		expect(Array.from(String(diagnostic?.message))).toHaveLength(256);
+		expect(String(diagnostic?.message)).not.toContain("\x1b");
+		expect(String(diagnostic?.message)).not.toContain("\n");
+		expect(diagnostic).not.toHaveProperty("stack");
+		expect(diagnostic).not.toHaveProperty("source");
+		expect(diagnostic).not.toHaveProperty("path");
+
+		throwing.unregister();
+		expect(__animationSchedulerTestHooks.getRegistrantCount(80)).toBe(1);
+		healthy.unregister();
+		expect(__animationSchedulerTestHooks.getActiveTimerCount()).toBe(0);
+
+		__animationSchedulerTestHooks.reset();
+		expect(__animationSchedulerTestHooks.getFailedCallbackCount()).toBe(0);
+	});
+
+	it("stops the bucket when its final callback throws", () => {
+		vi.useFakeTimers();
+		vi.spyOn(logger, "warn").mockImplementation(() => {});
+		registerAnimationCallback(() => {
+			throw new Error("final failure");
+		}, 16);
+
+		vi.advanceTimersByTime(16);
+
+		expect(__animationSchedulerTestHooks.getRegistrantCount(16)).toBe(0);
+		expect(__animationSchedulerTestHooks.getActiveTimerCount(16)).toBe(0);
+		expect(__animationSchedulerTestHooks.getFailedCallbackCount()).toBe(1);
 	});
 });

--- a/packages/tui/test/animation-scheduler.test.ts
+++ b/packages/tui/test/animation-scheduler.test.ts
@@ -116,7 +116,7 @@ describe("shared animation scheduler", () => {
 			message: expect.any(String),
 		});
 		expect(Array.from(String(diagnostic?.errorName))).toHaveLength(64);
-		expect(Array.from(String(diagnostic?.message))).toHaveLength(256);
+		expect(Array.from(String(diagnostic?.message)).length).toBeLessThanOrEqual(256);
 		expect(String(diagnostic?.message)).not.toContain("\x1b");
 		expect(String(diagnostic?.message)).not.toContain("\n");
 		expect(diagnostic).not.toHaveProperty("stack");


### PR DESCRIPTION
## Problem

The shared animation scheduler caught callback failures but left the throwing callback registered and called `console.error` on every tick. A single broken decorative registrant therefore produced repeated terminal writes for the lifetime of its cadence bucket.

## Impact and necessity

Animation callbacks share one timer. Repeatedly invoking a known-bad callback wastes tick capacity, continuously contaminates stdout/stderr used by the TUI, and prevents the final bucket timer from stopping when the thrower is the only registrant. The scheduler boundary must isolate failures without starving healthy sibling animations.

## Solution

- Delete a throwing callback from its bucket before diagnostic work.
- Increment the existing scheduler test-hook failure counter and stop an empty bucket immediately.
- Emit one centralized `logger.warn` record containing only cadence, a sanitized error name capped at 64 Unicode code points, and a sanitized message capped at 256 code points.
- Preserve snapshot iteration so healthy siblings still execute in the same tick.
- Add regression and red-team coverage, including a subprocess assertion that stdout and stderr remain byte-empty.

## Verification

- `bun test packages/tui/test/animation-scheduler.test.ts packages/tui/test/animation-scheduler-redteam.test.ts packages/tui/test/animation-congestion.test.ts` — 17 pass, 0 fail, 291 assertions.
- `bun --cwd=packages/tui run check` — Biome checked 120 files; TypeScript completed with no errors.
- Base: `origin/dev` at `0e9e9447d0888f9255408490ccfc07b14ff6bace`.
- Commit: `250622305`.