### PR TITLE
fix(telegram): bound reference diagnostics

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Made Telegram reference-client capability diagnostics safe for TUI embedding.
+
 ## [0.12.12] - 2026-08-05
 
 ### Added

--- a/packages/coding-agent/src/sdk/bus/telegram-reference.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-reference.ts
@@ -16,6 +16,7 @@
 
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
+import { logger } from "@gajae-code/utils";
 import {
 	bold,
 	buildCompactChoiceGrid,
@@ -33,6 +34,44 @@ const REFERENCE_CLIENT_HELLO = {
 	protocolVersion: 3,
 	capabilities: ["ask_controls_v1"],
 } as const;
+
+const MAX_DIAGNOSTIC_CAPABILITIES = 4;
+const MAX_DIAGNOSTIC_CAPABILITY_CODE_POINTS = 64;
+const MAX_DIAGNOSTIC_ERROR_NAME_CODE_POINTS = 64;
+const MAX_DIAGNOSTIC_ERROR_MESSAGE_CODE_POINTS = 128;
+
+function boundedDiagnosticText(value: string, maxCodePoints: number): string {
+	let result = "";
+	let codePoints = 0;
+	for (const character of value) {
+		const codePoint = character.codePointAt(0)!;
+		if (codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f)) continue;
+		result += character;
+		codePoints++;
+		if (codePoints === maxCodePoints) break;
+	}
+	return result;
+}
+
+function boundedDiagnosticCallbackError(error: unknown): Readonly<{ errorName: string; errorMessage: string }> {
+	let errorName = "UnknownError";
+	let errorMessage = "Diagnostic callback threw";
+	try {
+		if (error instanceof Error) {
+			errorName = boundedDiagnosticText(error.name, MAX_DIAGNOSTIC_ERROR_NAME_CODE_POINTS) || "Error";
+			errorMessage =
+				boundedDiagnosticText(error.message, MAX_DIAGNOSTIC_ERROR_MESSAGE_CODE_POINTS) ||
+				"Diagnostic callback threw";
+		} else {
+			errorMessage =
+				boundedDiagnosticText(String(error), MAX_DIAGNOSTIC_ERROR_MESSAGE_CODE_POINTS) ||
+				"Diagnostic callback threw";
+		}
+	} catch {
+		// Hostile thrown values must not escape the diagnostic failure boundary.
+	}
+	return Object.freeze({ errorName, errorMessage });
+}
 
 /** One inline-keyboard button. */
 export interface InlineButton {
@@ -406,6 +445,12 @@ export function readEndpoint(path: string): { url: string; token: string; pid?: 
 	};
 }
 
+/** A bounded, diagnostic-only notification mirrored to reference-client embedders. */
+export type TelegramReferenceDiagnostic = Readonly<{
+	code: "action_unavailable";
+	requiredCapabilities: readonly string[];
+}>;
+
 /** Options for {@link runTelegramReferenceClient}. */
 export interface TelegramReferenceOptions {
 	botToken: string;
@@ -414,6 +459,11 @@ export interface TelegramReferenceOptions {
 	apiBase?: string;
 	fetchImpl?: typeof fetch;
 	sound?: TelegramNotificationSound;
+	/**
+	 * Additive mirror of bounded logger diagnostics. It never receives tokens,
+	 * identifiers, raw frames, Telegram content, or WebSocket replies.
+	 */
+	onDiagnostic?: (diagnostic: TelegramReferenceDiagnostic) => void;
 }
 
 /**
@@ -470,15 +520,27 @@ export async function runTelegramReferenceClient(opts: TelegramReferenceOptions)
 				msg.kind ?? "ask",
 			);
 		} else if (msg.type === "action_unavailable") {
-			const requiredCapabilities = Array.isArray(msg.requiredCapabilities)
-				? msg.requiredCapabilities
-						.filter((capability): capability is string => typeof capability === "string")
-						.slice(0, 4)
-						.map(capability => capability.slice(0, 64))
-				: [];
-			console.warn(
-				`Telegram reference client: server withheld a controlled ask because this client lacks requiredCapabilities=[${requiredCapabilities.join(", ") || "unspecified"}].`,
+			const requiredCapabilities = Object.freeze(
+				Array.isArray(msg.requiredCapabilities)
+					? msg.requiredCapabilities
+							.filter((capability): capability is string => typeof capability === "string")
+							.slice(0, MAX_DIAGNOSTIC_CAPABILITIES)
+							.map(capability => boundedDiagnosticText(capability, MAX_DIAGNOSTIC_CAPABILITY_CODE_POINTS))
+					: [],
 			);
+			const diagnostic: TelegramReferenceDiagnostic = Object.freeze({
+				code: "action_unavailable",
+				requiredCapabilities,
+			});
+			logger.warn("Telegram reference client action unavailable", diagnostic);
+			try {
+				opts.onDiagnostic?.(diagnostic);
+			} catch (error) {
+				logger.warn("Telegram reference client diagnostic callback failed", {
+					code: "diagnostic_callback_failed",
+					...boundedDiagnosticCallbackError(error),
+				});
+			}
 			// Diagnostic only: never turn it into a Telegram prompt or option buttons.
 			return;
 		} else if (msg.type === "action_resolved" && msg.id === latestPendingAskId) {

--- a/packages/coding-agent/test/notifications-e2e.test.ts
+++ b/packages/coding-agent/test/notifications-e2e.test.ts
@@ -38,6 +38,7 @@ test("e2e: ask -> Telegram -> button tap -> reply -> resolved", async () => {
 	const sent: Array<Record<string, unknown>> = [];
 	const pendingUpdates: Array<Record<string, unknown>> = [];
 	let askDelivered = false;
+	const diagnostics: string[] = [];
 	let updateId = 1000;
 
 	const fakeFetch = (async (url: string | URL | Request, init?: RequestInit) => {
@@ -88,6 +89,7 @@ test("e2e: ask -> Telegram -> button tap -> reply -> resolved", async () => {
 		chatId: "1",
 		endpointFile,
 		fetchImpl: fakeFetch,
+		onDiagnostic: diagnostic => diagnostics.push(diagnostic.code),
 	}).catch(error => {
 		clientError = error;
 	});
@@ -143,6 +145,7 @@ test("e2e: ask -> Telegram -> button tap -> reply -> resolved", async () => {
 	observer.close();
 	await clientDone;
 	expect(clientError).toBeUndefined();
+	expect(diagnostics).toEqual([]);
 }, 30000);
 
 test("interactive ask answered remotely via SDK answer source", async () => {

--- a/packages/coding-agent/test/notifications-telegram-reference.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-reference.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { logger } from "@gajae-code/utils";
 import { parseArgs } from "../src/sdk/bus/telegram-cli";
 import {
 	buildActionMarkdown,
@@ -395,24 +396,16 @@ describe("telegram reference client negotiation", () => {
 		}
 	});
 
-	test("treats action_unavailable as a diagnostic without Telegram sends or WebSocket replies", async () => {
+	test("logs action_unavailable without Telegram sends, WebSocket replies, or a callback", async () => {
 		const originalWebSocket = globalThis.WebSocket;
-		const originalWarn = console.warn;
 		const fixture = createReferenceClientFixture();
-		const diagnostics: string[] = [];
-		let resolveDiagnostic: (() => void) | undefined;
-		const diagnostic = new Promise<void>(resolve => {
-			resolveDiagnostic = resolve;
-		});
+		const warning = Promise.withResolvers<void>();
+		const warnSpy = spyOn(logger, "warn").mockImplementation(() => warning.resolve());
 		let client: Promise<void> | undefined;
 
 		try {
 			FakeReferenceWebSocket.instances = [];
 			globalThis.WebSocket = FakeReferenceWebSocket as unknown as typeof WebSocket;
-			console.warn = (...args: unknown[]) => {
-				diagnostics.push(args.map(String).join(" "));
-				resolveDiagnostic?.();
-			};
 			client = runTelegramReferenceClient({
 				botToken: "bot-token",
 				chatId: "chat-id",
@@ -427,21 +420,144 @@ describe("telegram reference client negotiation", () => {
 
 			socket.emitMessage({
 				type: "action_unavailable",
-				id: "a1",
-				sessionId: "s1",
+				id: "must-not-be-logged",
+				sessionId: "must-not-be-logged",
 				reason: "missing_capability",
 				requiredCapabilities: ["ask_controls_v1"],
 			});
-			await diagnostic;
+			await warning.promise;
 
-			expect(diagnostics).toHaveLength(1);
-			expect(diagnostics[0]).toContain("ask_controls_v1");
+			expect(warnSpy).toHaveBeenCalledTimes(1);
+			expect(warnSpy).toHaveBeenCalledWith("Telegram reference client action unavailable", {
+				code: "action_unavailable",
+				requiredCapabilities: ["ask_controls_v1"],
+			});
+			expect(JSON.stringify(warnSpy.mock.calls)).not.toContain("must-not-be-logged");
 			expect(fixture.calls.map(call => call.url)).toEqual(["https://telegram.test/botbot-token/getUpdates"]);
 			expect(fixture.calls.filter(call => /\/(?:sendMessage|sendPhoto)$/.test(call.url))).toEqual([]);
 			expect(socket.sent).toHaveLength(1);
 		} finally {
 			await stopReferenceClient(client, fixture);
-			console.warn = originalWarn;
+			warnSpy.mockRestore();
+			globalThis.WebSocket = originalWebSocket;
+			fixture.cleanup();
+		}
+	});
+
+	test("mirrors a bounded immutable action_unavailable diagnostic", async () => {
+		const originalWebSocket = globalThis.WebSocket;
+		const fixture = createReferenceClientFixture();
+		const warning = Promise.withResolvers<void>();
+		const mirrored = Promise.withResolvers<void>();
+		const events: string[] = [];
+		const warnSpy = spyOn(logger, "warn").mockImplementation(() => {
+			events.push("logger");
+			warning.resolve();
+		});
+		const diagnostics: unknown[] = [];
+		let client: Promise<void> | undefined;
+
+		try {
+			FakeReferenceWebSocket.instances = [];
+			globalThis.WebSocket = FakeReferenceWebSocket as unknown as typeof WebSocket;
+			client = runTelegramReferenceClient({
+				botToken: "bot-token",
+				chatId: "chat-id",
+				endpointFile: fixture.endpointFile,
+				apiBase: "https://telegram.test",
+				fetchImpl: fixture.fetchImpl,
+				onDiagnostic: diagnostic => {
+					diagnostics.push(diagnostic);
+					events.push("callback");
+					mirrored.resolve();
+				},
+			});
+
+			const socket = FakeReferenceWebSocket.instances[0]!;
+			socket.emitOpen();
+			socket.emitMessage({
+				type: "action_unavailable",
+				requiredCapabilities: [`\u0000ask\ncontrols_v1`, "😀".repeat(80), "third", "fourth", "ignored-fifth"],
+			});
+			await Promise.all([warning.promise, mirrored.promise]);
+
+			expect(diagnostics).toHaveLength(1);
+			const diagnostic = diagnostics[0] as {
+				code: string;
+				requiredCapabilities: readonly string[];
+			};
+			expect(diagnostic).toEqual({
+				code: "action_unavailable",
+				requiredCapabilities: ["askcontrols_v1", "😀".repeat(64), "third", "fourth"],
+			});
+			expect(Object.isFrozen(diagnostic)).toBe(true);
+			expect(Object.isFrozen(diagnostic.requiredCapabilities)).toBe(true);
+			expect(() => (diagnostic.requiredCapabilities as string[]).push("mutation")).toThrow();
+			expect([...diagnostic.requiredCapabilities[1]!]).toHaveLength(64);
+			expect(events).toEqual(["logger", "callback"]);
+		} finally {
+			await stopReferenceClient(client, fixture);
+			warnSpy.mockRestore();
+			globalThis.WebSocket = originalWebSocket;
+			fixture.cleanup();
+		}
+	});
+
+	test("contains a throwing diagnostic callback and keeps handling messages", async () => {
+		const originalWebSocket = globalThis.WebSocket;
+		const fixture = createReferenceClientFixture();
+		const warnings = Promise.withResolvers<void>();
+		const warningCalls: Array<[string, unknown]> = [];
+		const warnSpy = spyOn(logger, "warn").mockImplementation((message, metadata) => {
+			warningCalls.push([message, metadata]);
+			if (warningCalls.length === 4) warnings.resolve();
+		});
+		let callbackCalls = 0;
+		let client: Promise<void> | undefined;
+
+		try {
+			FakeReferenceWebSocket.instances = [];
+			globalThis.WebSocket = FakeReferenceWebSocket as unknown as typeof WebSocket;
+			client = runTelegramReferenceClient({
+				botToken: "bot-token",
+				chatId: "chat-id",
+				endpointFile: fixture.endpointFile,
+				apiBase: "https://telegram.test",
+				fetchImpl: fixture.fetchImpl,
+				onDiagnostic: () => {
+					callbackCalls++;
+					throw new Error(`Bad\u0000Name:${"m".repeat(160)}`);
+				},
+			});
+
+			const socket = FakeReferenceWebSocket.instances[0]!;
+			socket.emitOpen();
+			socket.emitMessage({ type: "action_unavailable", requiredCapabilities: ["first"] });
+			socket.emitMessage({ type: "action_unavailable", requiredCapabilities: ["second"] });
+			await warnings.promise;
+
+			expect(callbackCalls).toBe(2);
+			expect(warningCalls.map(([message]) => message)).toEqual([
+				"Telegram reference client action unavailable",
+				"Telegram reference client diagnostic callback failed",
+				"Telegram reference client action unavailable",
+				"Telegram reference client diagnostic callback failed",
+			]);
+			const failures = warningCalls
+				.filter(([message]) => message.endsWith("callback failed"))
+				.map(([, metadata]) => metadata as { code: string; errorName: string; errorMessage: string });
+			expect(failures).toHaveLength(2);
+			for (const failure of failures) {
+				expect(failure.code).toBe("diagnostic_callback_failed");
+				expect([...failure.errorName]).toHaveLength(5);
+				expect([...failure.errorMessage]).toHaveLength(128);
+				expect(failure.errorMessage).not.toContain("\u0000");
+			}
+			expect(fixture.calls.filter(call => /\/(?:sendMessage|sendPhoto)$/.test(call.url))).toEqual([]);
+			expect(socket.sent).toHaveLength(1);
+		} finally {
+			await stopReferenceClient(client, fixture);
+			warnSpy.mockRestore();
 			globalThis.WebSocket = originalWebSocket;
 			fixture.cleanup();
 		}


### PR DESCRIPTION
## Summary
- replace the Telegram reference client's direct `console.warn` with the centralized logger
- expose an additive typed `onDiagnostic` mirror with frozen, bounded payloads
- contain callback failures with a second bounded logger record while preserving message handling

## Evidence and root cause
`action_unavailable` was handled as diagnostic-only, but the reference client emitted it through `console.warn`. That bypassed GJC's centralized logging policy, could corrupt TUI embedding, and forced tests to monkey-patch global console state.

## Impact and necessity
Capability negotiation failures remain observable without writing directly to terminal streams. Existing callers are source-compatible because `onDiagnostic` is optional, while embedders gain a typed mirror that cannot mutate the logged payload.

## Contract and choice
The client sanitizes at most four capability strings to at most 64 Unicode code points and removes C0/C1 controls. It freezes both the copied array and diagnostic object, logs first, and invokes the callback second. A callback throw is contained and produces only `diagnostic_callback_failed` with a control-sanitized error name/message capped at 64/128 code points. Bot tokens, chat/session/action IDs, raw frames, stacks, Telegram messages, and WebSocket replies are never included or sent from this path.

## Observed verification
- `bun test packages/coding-agent/test/notifications-telegram-reference.test.ts packages/coding-agent/test/notifications-e2e.test.ts` — 44 pass, 0 fail
- `bun --cwd=packages/coding-agent run check` — Biome and TypeScript passed
- `git diff --check` — passed

## Changelog
Added the required Unreleased fixed entry: “Made Telegram reference-client capability diagnostics safe for TUI embedding.”

## Risk and rollback
Risk is narrow and limited to the diagnostic-only `action_unavailable` branch. Rollback is a clean revert of commit `420787eeb`; the optional callback has no existing required callsites.

## Rejected alternative
An injectable replacement logger sink was rejected because it duplicates the centralized logging policy and lets embedders accidentally suppress the default record. The optional mirror keeps logging authoritative and additive.

## Independent merge rationale
This changes only the reference client, its two owned test suites, and the coding-agent changelog. It has no schema, generated artifact, docs, daemon, or other planned PR dependency and can merge directly into `dev` if every sibling change is abandoned.