### PR TITLE
test(tui): pin terminal transport context in G010 scheduler red-team and loader tests

### DIFF
--- a/packages/tui/test/animation-scheduler-redteam.test.ts
+++ b/packages/tui/test/animation-scheduler-redteam.test.ts
@@ -8,15 +8,54 @@ function makeUi() {
 	return { requestRender: vi.fn() } as unknown as TUI & { requestRender: ReturnType<typeof vi.fn> };
 }
 
+const TERMINAL_TRANSPORT_ENV_KEYS = [
+	"SSH_CONNECTION",
+	"SSH_CLIENT",
+	"SSH_TTY",
+	"TMUX",
+	"TMUX_PANE",
+	"STY",
+	"ZELLIJ",
+	"GJC_TMUX_LAUNCHED",
+	// TERM feeds the multiplexer predicate: tmux-*/screen-* values count as
+	// multiplexed and would route animated loaders back to the 80ms bucket.
+	"TERM",
+] as const;
+
+const pinnedTerminalTransportEnv: Record<string, string | undefined> = {};
+
+// resolveAnimationCadence routes timeDependentColor loaders to the 16ms bucket
+// on direct local terminals and the shared 80ms bucket on remote or multiplexed
+// ones, so scheduler-count assertions must pin the terminal transport context.
+function pinTerminalTransportEnv(overrides: Record<string, string>): void {
+	for (const key of TERMINAL_TRANSPORT_ENV_KEYS) {
+		if (!(key in pinnedTerminalTransportEnv)) pinnedTerminalTransportEnv[key] = process.env[key];
+		delete process.env[key];
+	}
+	for (const [key, value] of Object.entries(overrides)) process.env[key] = value;
+}
+
+function restoreTerminalTransportEnv(): void {
+	for (const key of TERMINAL_TRANSPORT_ENV_KEYS) {
+		if (!(key in pinnedTerminalTransportEnv)) continue;
+		const value = pinnedTerminalTransportEnv[key];
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+		delete pinnedTerminalTransportEnv[key];
+	}
+}
+
 describe("G010 shared animation scheduler red-team", () => {
 	afterEach(() => {
 		__animationSchedulerTestHooks.reset();
+		restoreTerminalTransportEnv();
 		vi.restoreAllMocks();
 		vi.useRealTimers();
 	});
 
 	it("SINGLE-TIMER: uses one active timer per cadence bucket and stops each empty bucket", () => {
 		vi.useFakeTimers();
+		pinTerminalTransportEnv({ SSH_CONNECTION: "test" });
 		const ui = makeUi();
 		const defaults = Array.from(
 			{ length: 20 },
@@ -101,6 +140,7 @@ describe("G010 shared animation scheduler red-team", () => {
 
 	it("CADENCE: default and time-dependent loaders repaint and advance frames only every 80ms", () => {
 		vi.useFakeTimers();
+		pinTerminalTransportEnv({ SSH_CONNECTION: "test" });
 		const defaultUi = makeUi();
 		const animatedUi = makeUi();
 		const defaultFrames: string[] = [];
@@ -207,6 +247,7 @@ describe("G010 shared animation scheduler red-team", () => {
 
 	it("UNREF: started timers are unref'd", () => {
 		vi.useFakeTimers();
+		pinTerminalTransportEnv({ SSH_CONNECTION: "test" });
 		const fakeSetInterval = globalThis.setInterval;
 		const handles: Array<{ unref?: ReturnType<typeof vi.fn> }> = [];
 		vi.spyOn(globalThis, "setInterval").mockImplementation(((...args: Parameters<typeof setInterval>) => {
@@ -243,6 +284,59 @@ describe("G010 shared animation scheduler red-team", () => {
 
 		defaultLoader.dispose();
 		animatedLoader.dispose();
+		expect(__animationSchedulerTestHooks.getActiveTimerCount()).toBe(0);
+	});
+
+	it("DIRECT-LOCAL: time-dependent loaders use the 16ms bucket on direct local terminals while spinner cadence stays 80ms", () => {
+		vi.useFakeTimers();
+		pinTerminalTransportEnv({ TERM: "xterm-256color" });
+		const defaultUi = makeUi();
+		const animatedUi = makeUi();
+		const defaultFrames: string[] = [];
+		const animatedFrames: string[] = [];
+		const defaultLoader = new Loader(
+			defaultUi,
+			frame => {
+				defaultFrames.push(frame);
+				return frame;
+			},
+			text => text,
+			"default",
+			["A", "B", "C"],
+		);
+		const animatedLoader = new Loader(
+			animatedUi,
+			frame => {
+				animatedFrames.push(frame);
+				return frame;
+			},
+			text => `${text}-${performance.now()}`,
+			"animated",
+			["A", "B", "C"],
+			{ timeDependentColor: true },
+		);
+
+		expect(__animationSchedulerTestHooks.getRegistrantCount(80)).toBe(1);
+		expect(__animationSchedulerTestHooks.getRegistrantCount(16)).toBe(1);
+		expect(__animationSchedulerTestHooks.getActiveTimerCount()).toBe(2);
+
+		const initialDefaultRequests = defaultUi.requestRender.mock.calls.length;
+		const initialAnimatedRequests = animatedUi.requestRender.mock.calls.length;
+
+		vi.advanceTimersByTime(16);
+		expect(defaultUi.requestRender.mock.calls.length).toBe(initialDefaultRequests);
+		expect(animatedUi.requestRender.mock.calls.length).toBe(initialAnimatedRequests + 1);
+		expect(defaultFrames.at(-1)).toBe("A");
+		expect(animatedFrames.at(-1)).toBe("A");
+
+		vi.advanceTimersByTime(64);
+		expect(defaultUi.requestRender.mock.calls.length).toBe(initialDefaultRequests + 1);
+		expect(animatedUi.requestRender.mock.calls.length).toBe(initialAnimatedRequests + 5);
+		expect(defaultFrames.at(-1)).toBe("B");
+		expect(animatedFrames.at(-1)).toBe("B");
+
+		defaultLoader.stop();
+		animatedLoader.stop();
 		expect(__animationSchedulerTestHooks.getActiveTimerCount()).toBe(0);
 	});
 });

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -14,6 +14,9 @@ const TERMINAL_TRANSPORT_ENV_KEYS = [
 	"STY",
 	"ZELLIJ",
 	"GJC_TMUX_LAUNCHED",
+	// TERM feeds the multiplexer predicate: tmux-*/screen-* values count as
+	// multiplexed and would route animated loaders back to the 80ms bucket.
+	"TERM",
 ] as const;
 
 function clearTerminalTransportEnv(): () => void {
@@ -151,6 +154,7 @@ describe("Loader component", () => {
 	it("restores the 60fps color cadence for direct local terminals", () => {
 		vi.useFakeTimers();
 		const restoreEnv = clearTerminalTransportEnv();
+		process.env.TERM = "xterm-256color";
 		const term = new VirtualTerminal(40, 4);
 		const tui = new TUI(term);
 		let colorTick = 0;


### PR DESCRIPTION
## Why

The 0.12.12 main-push CI shard `test:@gajae-code/tui` failed 3 tests in `packages/tui/test/animation-scheduler-redteam.test.ts` (SINGLE-TIMER, CADENCE, UNREF) with `Expected: 1, Received: 2` timer/handle counts.

Root cause: the tests assume `timeDependentColor` loaders always share the 80ms cadence bucket, but #3845 (`resolveAnimationCadence`) routes them to a **16ms bucket on direct local terminals** — the intended 60fps gradient behavior called out in the 0.12.12 changelog. The test file predates #3845 (added in c6c4c474a), and no dev CI lane runs the tui suite (affected-path builds only), so the stale expectations first surfaced on the 0.12.12 main push. Reproduced locally 3 fail / 4 pass on pinned bun 1.3.14.

Review then found the same latent host-dependence class in `loader.test.ts`: its `clearTerminalTransportEnv` helper omits `TERM`, but `isUnderTerminalMultiplexer` treats `TERM=tmux-*/screen-*` as multiplexed — the direct-local 60fps cadence test fails 1/8 under `TERM=tmux-256color` (i.e., for anyone running the suite inside tmux).

## What

**animation-scheduler-redteam.test.ts**
- Add a `pinTerminalTransportEnv` helper (save/clear/restore of `SSH_CONNECTION`, `SSH_CLIENT`, `SSH_TTY`, `TMUX`, `TMUX_PANE`, `STY`, `ZELLIJ`, `GJC_TMUX_LAUNCHED`, `TERM`), restored from the existing `afterEach`, following the conventions in `loader.test.ts` and `animation-scheduler.test.ts`.
- Pin `SSH_CONNECTION=test` (remote context → 80ms bucket) in SINGLE-TIMER, CADENCE, and UNREF.
- Add a DIRECT-LOCAL test pinning `TERM=xterm-256color` with all transport keys cleared, asserting the #3845 behavior: animated loader lands in the 16ms bucket while defaults stay at 80ms (2 timers), color re-evaluation renders every 16ms tick, and spinner frame advance stays on the 80ms cadence.

**loader.test.ts**
- Add `TERM` to `TERMINAL_TRANSPORT_ENV_KEYS` (with the multiplexer-predicate comment) and pin `TERM=xterm-256color` in the direct-local cadence test.

No product code changes.

## Verification

- `bun test packages/tui`: 1068 pass / 0 fail across 76 files (shard-equivalent scope; previously 3 fail)
- Adversarial host envs over the red-team file: `SSH_CONNECTION=1`, `TMUX=/tmp/fake,1,0`, all transport keys cleared, `TERM=tmux-256color`, `TERM=screen-256color` — 8/8 each
- `loader.test.ts` under `TERM=tmux-256color`, `TERM=screen-256color`, default env — 8/8 each (previously 7/8 under tmux TERM)
- Combined redteam + scheduler + loader invocation: 18/18 (no cross-file env leakage)
- `biome check` clean, `tsc --noEmit` clean