### PR TITLE
test(read): batch SQLite table-list fixture creation into one transaction

### DIFF
--- a/packages/coding-agent/test/tools/read-direction.test.ts
+++ b/packages/coding-agent/test/tools/read-direction.test.ts
@@ -493,10 +493,21 @@ describe("read truncation direction resolution", () => {
 		const databasePath = path.join(tempDir, "tables.sqlite");
 		const db = new Database(databasePath);
 		try {
-			for (let index = 0; index < 600; index++) {
-				const name = `table_${String(index).padStart(4, "0")}_${"x".repeat(90)}`;
-				db.run(`CREATE TABLE "${name}" (id INTEGER)`);
+			// Batch the 600 schema writes into one commit: per-statement
+			// autocommit fsyncs blow the bun test timeout under CI disk load,
+			// which then lets afterEach delete the fixture while the read is
+			// still in flight and surfaces a spurious `Path not found`.
+			db.run("BEGIN");
+			try {
+				for (let index = 0; index < 600; index++) {
+					const name = `table_${String(index).padStart(4, "0")}_${"x".repeat(90)}`;
+					db.run(`CREATE TABLE "${name}" (id INTEGER)`);
+				}
+			} catch (error) {
+				db.run("ROLLBACK");
+				throw error;
 			}
+			db.run("COMMIT");
 		} finally {
 			db.close();
 		}


### PR DESCRIPTION
## What

Dev shard-5 fails on `packages/coding-agent/test/tools/read-direction.test.ts` → `applies direction to the rendered SQLite table list`, unrelated to #3854:

```
(fail) read truncation direction resolution > applies direction to the rendered SQLite table list [~6.6s]
  ^ this test timed out after 5000ms.
... ToolError Path .../tables.sqlite not found
```

## Root cause (reproduced)

The fixture writes 600 `CREATE TABLE`s, each in its own autocommit → one fsync per statement. Under CI disk load that costs ~4.6–6.8s (idle: ~830ms), blowing bun's default 5s per-test timeout. The timeout fires mid-fixture, bun runs `afterEach` (`fs.rm(tempDir, recursive)`), and the still-pending read lifecycle then surfaces a spurious `Path .../tables.sqlite not found` ToolError.

Reproduced locally by running the focused test under concurrent fsync load: timed out at 5000ms, then the pending `#readSqlite` read failed with the not-found ToolError — matching the shard-5 log exactly.

## Fix

Wrap the 600 schema writes in a single `BEGIN`/`COMMIT` transaction (with `ROLLBACK` on failure). All 600 tables and names are byte-identical; the fsync storm collapses to one commit (~1.1s under the same load). No timeout increase, no assertion weakening, read direction / SQLite listing / path safety unchanged (test-only change).

## Verification

- Focused test 25× under concurrent fsync load — 25/25 pass (was failing).
- Full `read-direction.test.ts` 10× under load — 19/19 pass.
- Read suite (goldens, receipt, stream-collector, artifact-spill, artifact-tree-authorization, acp-fs, multi-range, summary, tool-group): 232 tests pass.
- `tools/sqlite.test.ts`: 33 tests pass.
- `bun --cwd=packages/coding-agent run check` (biome + tsc): clean.