### PR TITLE
fix(coding-agent): suppress expected interactive cancellation

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1839,6 +1839,9 @@ export async function runRootCommand(
 				} catch {
 					logger.warn("Failed to dispose session after interactive error");
 				}
+				if (error !== null && typeof error === "object" && "code" in error && error.code === "cancelled") {
+					return;
+				}
 				throw error;
 			}
 


### PR DESCRIPTION
Closes #3877

Interactive shutdown rejects pending input with the expected `cancelled` lifecycle error. The root command previously rethrew it, causing `Interactive mode stopped` to be recorded as an uncaught exception and crash report.

This change treats only the existing `cancelled` error code as a normal interactive exit while preserving propagation of unexpected errors.

Verification:
- `bun test test/main-interactive-input.test.ts test/interactive-mode-background-activity.test.ts`
- `bun --cwd=packages/coding-agent run check`