### PR TITLE
fix(session): soft-handle concurrent receipt disappearance in reconcile cleanup (#3876)

### DIFF
--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -944,6 +944,13 @@ export class ManagedSessionDescendantStore {
 			quarantineName,
 		});
 		if (
+			!detached.ok &&
+			detached.code === "not_found" &&
+			detached.retainedSuccessorPath === undefined &&
+			detached.retainedUnknownPath === undefined
+		)
+			return;
+		if (
 			(!detached.ok && detached.code !== "cleanup_pending") ||
 			detached.detachedPath !== path.join(this.#baseDir, quarantineName) ||
 			detached.retainedSuccessorPath ||
@@ -956,7 +963,13 @@ export class ManagedSessionDescendantStore {
 	#reconcileLegacyReplacementCleanupReceipt(receiptPath: string, name: string): void {
 		const binding = legacyReplacementCleanupReceiptBinding(name);
 		if (!binding) throw new Error("managed_replace_cleanup_receipt_invalid");
-		const receipt = captureManagedFileNoFollow(receiptPath);
+		let receipt: ManagedFileSnapshot;
+		try {
+			receipt = captureManagedFileNoFollow(receiptPath);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+			throw error;
+		}
 		const parsed = parseLegacyReplacementCleanupReceipt(receipt.bytes);
 		const expectedPredecessor = path.join(
 			this.#baseDir,
@@ -985,7 +998,16 @@ export class ManagedSessionDescendantStore {
 		if (!exactUnlinkCompleted(retired) && retired.code !== "not_found")
 			throw new Error(`managed_replace_cleanup_pending:${retired.code ?? "unknown"}`);
 
-		const currentReceipt = captureManagedFileNoFollow(receiptPath);
+		let currentReceipt: ManagedFileSnapshot;
+		try {
+			currentReceipt = captureManagedFileNoFollow(receiptPath);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+				fsyncDirectory(this.#baseDir);
+				return;
+			}
+			throw error;
+		}
 		if (
 			!sameIdentity(currentReceipt.identity, receipt.identity) ||
 			currentReceipt.identity.sha256 !== receipt.identity.sha256

--- a/packages/coding-agent/test/session-storage.test.ts
+++ b/packages/coding-agent/test/session-storage.test.ts
@@ -1048,6 +1048,259 @@ describe.skipIf(process.platform !== "darwin")("managed replacement receipt deta
 		expect(fs.existsSync(predecessorPath)).toBe(false);
 	});
 });
+describe("replacement cleanup receipt reconcile TOCTOU resilience", () => {
+	let root: string;
+
+	type ReceiptTestSnapshot = {
+		dev: string;
+		ino: string;
+		nlink: string;
+		size: string;
+		mtimeNs: string;
+		ctimeNs: string;
+		sha256: string;
+	};
+	const snapshot = (pathname: string): ReceiptTestSnapshot => {
+		const stat = fs.lstatSync(pathname, { bigint: true });
+		return {
+			dev: stat.dev.toString(),
+			ino: stat.ino.toString(),
+			nlink: stat.nlink.toString(),
+			size: stat.size.toString(),
+			mtimeNs: stat.mtimeNs.toString(),
+			ctimeNs: stat.ctimeNs.toString(),
+			sha256: createHash("sha256").update(fs.readFileSync(pathname)).digest("hex"),
+		};
+	};
+	const canonicalReceiptPath = (predecessor: ReceiptTestSnapshot, receipt: ReceiptTestSnapshot) =>
+		path.join(
+			root,
+			`.gjc-replace-cleanup-${BigInt(predecessor.dev).toString(16)}-${BigInt(predecessor.ino).toString(16)}-receipt-${BigInt(receipt.dev).toString(16)}-${BigInt(receipt.ino).toString(16)}.json`,
+		);
+	const publishCanonicalReceipt = (predecessor: ReceiptTestSnapshot, contents: string) => {
+		const pending = path.join(root, `.gjc-replace-receipt-pending-${randomUUID()}.json`);
+		fs.writeFileSync(pending, contents);
+		const receiptIdentity = snapshot(pending);
+		const receipt = canonicalReceiptPath(predecessor, receiptIdentity);
+		fs.renameSync(pending, receipt);
+		return { receipt, receiptIdentity };
+	};
+	const receiptQuarantine = (receipt: ReceiptTestSnapshot, predecessor: ReceiptTestSnapshot) =>
+		path.join(
+			root,
+			`.gjc-receipt-remove-${BigInt(receipt.dev).toString(16)}-${BigInt(receipt.ino).toString(16)}-${BigInt(predecessor.dev).toString(16)}-${BigInt(predecessor.ino).toString(16)}`,
+		);
+	const legacyReceiptPath = (predecessor: ReceiptTestSnapshot) =>
+		path.join(
+			root,
+			`.gjc-replace-cleanup-${BigInt(predecessor.dev).toString(16)}-${BigInt(predecessor.ino).toString(16)}.json`,
+		);
+	const replay = (name: string) => {
+		const store = new ManagedSessionDescendantStore(managedDirectoryRoot(root), root);
+		store.publishNoReplaceSync(name, Buffer.from("trigger\n"));
+	};
+
+	beforeEach(() => {
+		root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-replace-toctou-"));
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+		fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	it("continues reconcile when a canonical receipt disappears between capture and unlink (native not_found)", () => {
+		const predecessorPath = path.join(root, "predecessor");
+		fs.writeFileSync(predecessorPath, "predecessor\n");
+		const predecessor = snapshot(predecessorPath);
+		const { receipt, receiptIdentity } = publishCanonicalReceipt(
+			predecessor,
+			JSON.stringify({ arbitrary: "receipt contents are advisory" }),
+		);
+		const secondPredecessorPath = path.join(root, "predecessor-2");
+		fs.writeFileSync(secondPredecessorPath, "predecessor-2\n");
+		const secondPredecessor = snapshot(secondPredecessorPath);
+		const { receipt: secondReceipt, receiptIdentity: secondReceiptIdentity } = publishCanonicalReceipt(
+			secondPredecessor,
+			JSON.stringify({ arbitrary: "second receipt contents are advisory" }),
+		);
+
+		vi.spyOn(native, "exactUnlink").mockImplementation((pathname, expected) => {
+			// First receipt: simulate concurrent disappearance — return not_found.
+			if (pathname === receipt) return { ok: false, code: "not_found" };
+			// Second receipt: normal detach.
+			const stat = fs.lstatSync(pathname, { bigint: true });
+			const sha256 = createHash("sha256").update(fs.readFileSync(pathname)).digest("hex");
+			if (
+				expected.directory ||
+				!expected.quarantineName ||
+				!stat.isFile() ||
+				stat.isSymbolicLink() ||
+				stat.dev !== expected.dev ||
+				stat.ino !== expected.ino ||
+				stat.nlink !== expected.nlink ||
+				stat.size !== expected.size ||
+				stat.mtimeNs !== expected.mtimeNs ||
+				sha256 !== expected.sha256
+			)
+				return { ok: false, code: "identity_mismatch" };
+			const detachedPath = path.join(root, expected.quarantineName);
+			fs.renameSync(pathname, detachedPath);
+			return { ok: true, detachedPath };
+		});
+
+		replay("toctou-not-found");
+
+		// First receipt soft-skipped (still on disk, not quarantined — it's just gone from the
+		// native's perspective).
+		expect(fs.existsSync(receiptQuarantine(receiptIdentity, predecessor))).toBe(false);
+		// Second receipt detached cleanly.
+		expect(fs.existsSync(secondReceipt)).toBe(false);
+		expect(fs.readFileSync(receiptQuarantine(secondReceiptIdentity, secondPredecessor), "utf8")).toContain(
+			"second receipt",
+		);
+		expect(fs.existsSync(path.join(root, "toctou-not-found"))).toBe(true);
+	});
+
+	it("continues reconcile when a legacy receipt disappears before first capture (ENOENT)", () => {
+		const predecessorSeed = path.join(root, ".predecessor");
+		const predecessorContents = "predecessor\n";
+		fs.writeFileSync(predecessorSeed, predecessorContents, { mode: 0o600 });
+		const seedIdentity = snapshot(predecessorSeed);
+		const predecessorPath = path.join(
+			root,
+			`.gjc-exact-replace-destination-${BigInt(seedIdentity.dev).toString(16)}-${BigInt(seedIdentity.ino).toString(16)}`,
+		);
+		fs.renameSync(predecessorSeed, predecessorPath);
+		const predecessor = snapshot(predecessorPath);
+		const receipt = legacyReceiptPath(predecessor);
+		fs.writeFileSync(
+			receipt,
+			JSON.stringify({
+				version: 1,
+				predecessor: predecessorPath,
+				successor: path.join(root, "session.jsonl"),
+				identity: predecessor,
+			}),
+			{ mode: 0o600 },
+		);
+
+		// Second canonical receipt that should detach cleanly.
+		const secondPredecessorPath = path.join(root, "predecessor-2");
+		fs.writeFileSync(secondPredecessorPath, "predecessor-2\n");
+		const secondPredecessor = snapshot(secondPredecessorPath);
+		const { receipt: secondReceipt, receiptIdentity: secondReceiptIdentity } = publishCanonicalReceipt(
+			secondPredecessor,
+			JSON.stringify({ arbitrary: "second receipt contents are advisory" }),
+		);
+
+		// Remove the legacy receipt before reconcile runs — simulates concurrent disappearance.
+		fs.unlinkSync(receipt);
+
+		vi.spyOn(native, "exactUnlink").mockImplementation((pathname, expected) => {
+			const stat = fs.lstatSync(pathname, { bigint: true });
+			const sha256 = createHash("sha256").update(fs.readFileSync(pathname)).digest("hex");
+			if (
+				expected.directory ||
+				!expected.quarantineName ||
+				!stat.isFile() ||
+				stat.isSymbolicLink() ||
+				stat.dev !== expected.dev ||
+				stat.ino !== expected.ino ||
+				stat.nlink !== expected.nlink ||
+				stat.size !== expected.size ||
+				stat.mtimeNs !== expected.mtimeNs ||
+				sha256 !== expected.sha256
+			)
+				return { ok: false, code: "identity_mismatch" };
+			const detachedPath = path.join(root, expected.quarantineName);
+			fs.renameSync(pathname, detachedPath);
+			return { ok: true, detachedPath };
+		});
+
+		expect(() => replay("toctou-legacy-enoent")).not.toThrow();
+
+		expect(fs.existsSync(path.join(root, "toctou-legacy-enoent"))).toBe(true);
+		expect(fs.existsSync(secondReceipt)).toBe(false);
+		expect(fs.readFileSync(receiptQuarantine(secondReceiptIdentity, secondPredecessor), "utf8")).toContain(
+			"second receipt",
+		);
+	});
+
+	it("continues reconcile when a legacy receipt disappears before re-capture after predecessor retirement", () => {
+		const predecessorSeed = path.join(root, ".predecessor");
+		const predecessorContents = "predecessor\n";
+		fs.writeFileSync(predecessorSeed, predecessorContents, { mode: 0o600 });
+		const seedIdentity = snapshot(predecessorSeed);
+		const predecessorPath = path.join(
+			root,
+			`.gjc-exact-replace-destination-${BigInt(seedIdentity.dev).toString(16)}-${BigInt(seedIdentity.ino).toString(16)}`,
+		);
+		fs.renameSync(predecessorSeed, predecessorPath);
+		const predecessor = snapshot(predecessorPath);
+		const receipt = legacyReceiptPath(predecessor);
+		fs.writeFileSync(
+			receipt,
+			JSON.stringify({
+				version: 1,
+				predecessor: predecessorPath,
+				successor: path.join(root, "session.jsonl"),
+				identity: predecessor,
+			}),
+			{ mode: 0o600 },
+		);
+
+		// Second canonical receipt that should detach cleanly.
+		const secondPredecessorPath = path.join(root, "predecessor-2");
+		fs.writeFileSync(secondPredecessorPath, "predecessor-2\n");
+		const secondPredecessor = snapshot(secondPredecessorPath);
+		const { receipt: secondReceipt, receiptIdentity: secondReceiptIdentity } = publishCanonicalReceipt(
+			secondPredecessor,
+			JSON.stringify({ arbitrary: "second receipt contents are advisory" }),
+		);
+
+		vi.spyOn(native, "exactUnlink").mockImplementation((pathname, expected) => {
+			// When retiring the legacy predecessor, simulate concurrent receipt disappearance
+			// as a side-effect — the receipt is gone by the time re-capture runs.
+			if (pathname === predecessorPath) {
+				fs.unlinkSync(receipt);
+				const detachedPath = path.join(root, expected.quarantineName!);
+				fs.renameSync(pathname, detachedPath);
+				return { ok: true, detachedPath };
+			}
+			const stat = fs.lstatSync(pathname, { bigint: true });
+			const sha256 = createHash("sha256").update(fs.readFileSync(pathname)).digest("hex");
+			if (
+				expected.directory ||
+				!expected.quarantineName ||
+				!stat.isFile() ||
+				stat.isSymbolicLink() ||
+				stat.dev !== expected.dev ||
+				stat.ino !== expected.ino ||
+				stat.nlink !== expected.nlink ||
+				stat.size !== expected.size ||
+				stat.mtimeNs !== expected.mtimeNs ||
+				sha256 !== expected.sha256
+			)
+				return { ok: false, code: "identity_mismatch" };
+			const detachedPath = path.join(root, expected.quarantineName);
+			fs.renameSync(pathname, detachedPath);
+			return { ok: true, detachedPath };
+		});
+
+		expect(() => replay("toctou-legacy-recapture")).not.toThrow();
+
+		// Legacy predecessor was retired.
+		expect(fs.existsSync(predecessorPath)).toBe(false);
+		// Legacy receipt was concurrently removed (by our mock side-effect).
+		expect(fs.existsSync(receipt)).toBe(false);
+		// Second receipt detached cleanly.
+		expect(fs.existsSync(secondReceipt)).toBe(false);
+		expect(fs.readFileSync(receiptQuarantine(secondReceiptIdentity, secondPredecessor), "utf8")).toContain(
+			"second receipt",
+		);
+		expect(fs.existsSync(path.join(root, "toctou-legacy-recapture"))).toBe(true);
+	});
+});
 describe.skipIf(process.platform !== "linux")("managed native security result validation", () => {
 	const validApply = {
 		ok: true,


### PR DESCRIPTION
## Summary

Fixes the TOCTOU race in `#reconcileReplacementCleanupReceipts()` where concurrent disappearance of a `.gjc-replace-cleanup-*` receipt between readdir and open/unlink hard-failed the entire managed session store.

**Root cause:** The reconcile path runs on every store mutation via `#beforeMutation`. Three race windows lacked ENOENT/`not_found` soft-handling, unlike four sibling `exactUnlink` call sites that already tolerate `not_found`.

**Fix:** Three surgical edits that soft-handle concurrent receipt disappearance while preserving fail-closed for identity mismatches, invalid receipt names, and non-ENOENT corruption:

1. `#detachReplacementCleanupReceipt` (line ~946): early `not_found` return before the compound `detachedPath !== quarantineName` condition (which would fire on `undefined`).
2. `#reconcileLegacyReplacementCleanupReceipt` (line ~959): ENOENT try/catch on the first bare `captureManagedFileNoFollow`.
3. `#reconcileLegacyReplacementCleanupReceipt` (line ~988): ENOENT try/catch on the re-capture after predecessor retirement, with `fsyncDirectory` before return.

## Security

Fail-closed is preserved. The identity check runs **before** unlink; native `exactUnlink` re-verifies atomically. A swap yields `identity_mismatch` (still throws), not `not_found`. Only benign disappearance is soft-skipped.

## Test evidence

```
bun test packages/coding-agent/test/session-storage.test.ts
69 pass, 15 skip (Darwin-only), 0 fail
```

Three new cross-platform regression tests prove:
- Canonical receipt: `exactUnlink` returns `not_found` → reconcile continues, second receipt detaches.
- Legacy receipt: disappears before first capture → reconcile continues.
- Legacy receipt: disappears before re-capture after predecessor retirement → reconcile continues, predecessor retired.

Existing fail-closed tests (identity mismatch, alias receipt, substituted receipt, malformed filename) remain green.

## Risk

**Low.** Three additive guard lines inside reconcile callees. No identity/binding/quarantine logic touched. Trivially revertible.

Closes #3876

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*