### PR TITLE
fix(cli): route bare gjc models to --list-models

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- `gjc models` is no longer treated as a free-form agent prompt. The mistaken subcommand spelling now routes to the existing `--list-models` listing path so a nested bash-tool invocation cannot recursively spawn unbounded GJC agents (#3857).
 - Made Telegram reference-client capability diagnostics safe for TUI embedding.
 
 ## [0.12.12] - 2026-08-05

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -389,11 +389,34 @@ function routeLegacyRootArgv(argv: readonly string[]): string[] | undefined {
 	return ["team", size, ...remaining];
 }
 
+/**
+ * Map the common mistaken `models` subcommand spelling to non-agent listing.
+ *
+ * Agents frequently run `gjc models` from the bash tool expecting a catalog.
+ * Without this route, `models` was a positional launch prompt and nested agents
+ * re-invoked `gjc models`, spawning an unbounded process chain (#3857).
+ * Always rewrite to `launch --list-models` so the invocation exits after a
+ * bounded listing and never starts an interactive agent session.
+ */
+export function routeModelsAlias(argv: readonly string[]): string[] | undefined {
+	if (argv[0] !== "models") return undefined;
+	const rest = argv.slice(1);
+	if (rest.length === 0) return ["launch", "--list-models"];
+	// Pure search tokens become a single fuzzy pattern (matches --list-models).
+	if (rest.every(token => !token.startsWith("-") && !token.startsWith("@"))) {
+		return ["launch", "--list-models", rest.join(" ")];
+	}
+	// Mixed flags still go through list-models first so "models" is never a prompt.
+	return ["launch", "--list-models", ...rest];
+}
+
 /** Apply the same default-launch routing used by runCli after root fast paths. */
 export function routeRootArgv(argv: readonly string[]): string[] {
 	const normalizedArgv = normalizeResumeAlias(argv);
 	const legacyArgv = routeLegacyRootArgv(normalizedArgv);
 	if (legacyArgv) return legacyArgv;
+	const modelsArgv = routeModelsAlias(normalizedArgv);
+	if (modelsArgv) return modelsArgv;
 	const first = normalizedArgv[0];
 	return first === "--help" || first === "-h" || first === "--version" || first === "-v" || first === "help"
 		? normalizedArgv

--- a/packages/coding-agent/src/cli/fast-help.ts
+++ b/packages/coding-agent/src/cli/fast-help.ts
@@ -106,5 +106,6 @@ Available Tools (default-enabled unless noted):
 
 Useful Commands:
   ${APP_NAME} --list-models        - List configured provider models
+  ${APP_NAME} models               - Alias for --list-models (never starts an agent)
   ${APP_NAME} --help               - Show this help`;
 }

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -37,11 +37,7 @@ describe("GJC public CLI command surface", () => {
 	it("routes bare models to --list-models instead of a launch prompt (#3857)", () => {
 		expect(routeModelsAlias(["models"])).toEqual(["launch", "--list-models"]);
 		expect(routeModelsAlias(["models", "deepseek"])).toEqual(["launch", "--list-models", "deepseek"]);
-		expect(routeModelsAlias(["models", "claude", "sonnet"])).toEqual([
-			"launch",
-			"--list-models",
-			"claude sonnet",
-		]);
+		expect(routeModelsAlias(["models", "claude", "sonnet"])).toEqual(["launch", "--list-models", "claude sonnet"]);
 		expect(routeModelsAlias(["models", "--json"])).toEqual(["launch", "--list-models", "--json"]);
 		expect(routeModelsAlias(["stats"])).toBeUndefined();
 		expect(routeRootArgv(["models"])).toEqual(["launch", "--list-models"]);

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { lifecyclePaths } from "@gajae-code/coding-agent/gjc-runtime/tmux-owner-isolation";
 import packageJson from "../package.json";
-import { interactiveBootstrapText, routeRootArgv } from "../src/cli";
+import { interactiveBootstrapText, routeModelsAlias, routeRootArgv } from "../src/cli";
 import { parseArgs } from "../src/cli/args";
 
 const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
@@ -32,6 +32,22 @@ describe("GJC public CLI command surface", () => {
 			"0",
 			"invalid legacy --team-size",
 		]);
+	});
+
+	it("routes bare models to --list-models instead of a launch prompt (#3857)", () => {
+		expect(routeModelsAlias(["models"])).toEqual(["launch", "--list-models"]);
+		expect(routeModelsAlias(["models", "deepseek"])).toEqual(["launch", "--list-models", "deepseek"]);
+		expect(routeModelsAlias(["models", "claude", "sonnet"])).toEqual([
+			"launch",
+			"--list-models",
+			"claude sonnet",
+		]);
+		expect(routeModelsAlias(["models", "--json"])).toEqual(["launch", "--list-models", "--json"]);
+		expect(routeModelsAlias(["stats"])).toBeUndefined();
+		expect(routeRootArgv(["models"])).toEqual(["launch", "--list-models"]);
+		expect(routeRootArgv(["models", "opus"])).toEqual(["launch", "--list-models", "opus"]);
+		// Ordinary free-form prompts still launch; only the bare `models` token is remapped.
+		expect(routeRootArgv(["list available models"])).toEqual(["launch", "list available models"]);
 	});
 
 	it("renders an immediate keyboard-ready bootstrap only for interactive launch routes", () => {

--- a/packages/coding-agent/test/issue-3857-nested-models-chain.test.ts
+++ b/packages/coding-agent/test/issue-3857-nested-models-chain.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
+const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
+
+/**
+ * Regression for #3857: `gjc models` from a nested GJC tool environment must not
+ * start an interactive agent (and therefore must not re-spawn `gjc models`).
+ */
+describe("issue #3857 nested gjc models chain", () => {
+	it("exits after listing when invoked as `models` under a simulated GJC session env", async () => {
+		const home = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-issue-3857-"));
+		const agentDir = path.join(home, ".gjc", "agent");
+		try {
+			const result = Bun.spawnSync(["bun", cliEntry, "models"], {
+				cwd: repoRoot,
+				env: {
+					...process.env,
+					HOME: home,
+					GJC_CODING_AGENT_DIR: agentDir,
+					// Simulate a bash-tool child inheriting the parent agent session id.
+					GJC_SESSION_ID: "session-issue-3857-nested-models",
+					// Keep listing offline/local so the test does not hang on network discovery.
+					GJC_NO_PTY: "1",
+					GJC_NO_TITLE: "1",
+				},
+				stdout: "pipe",
+				stderr: "pipe",
+				// Fail closed if the process ever tries to open an interactive TUI session.
+				timeout: 60_000,
+			});
+			const stdout = result.stdout.toString();
+			const stderr = result.stderr.toString();
+			const combined = `${stdout}\n${stderr}`;
+
+			// Bun reports undefined (not null) for signalCode on a normal exit.
+			expect(result.signalCode ?? null, combined).toBeNull();
+			expect(result.exitCode, combined).toBe(0);
+			// Interactive launch bootstrap must never appear for this route.
+			expect(combined).not.toContain("warming workspace");
+			// Listing path is non-agent: either a catalog header/row or the empty-catalog message.
+			expect(
+				/No models available|canonical|provider|model/i.test(combined),
+				`expected model listing output, got:\n${combined}`,
+			).toBe(true);
+		} finally {
+			await fs.rm(home, { recursive: true, force: true });
+		}
+	}, 90_000);
+
+	it("does not leave a grandchild gjc process after models exits", async () => {
+		const home = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-issue-3857-child-"));
+		const agentDir = path.join(home, ".gjc", "agent");
+		const marker = `issue-3857-models-${process.pid}-${Date.now()}`;
+		try {
+			const result = Bun.spawnSync(["bun", cliEntry, "models", marker], {
+				cwd: repoRoot,
+				env: {
+					...process.env,
+					HOME: home,
+					GJC_CODING_AGENT_DIR: agentDir,
+					GJC_SESSION_ID: "session-issue-3857-grandchild-guard",
+					GJC_NO_PTY: "1",
+					GJC_NO_TITLE: "1",
+				},
+				stdout: "pipe",
+				stderr: "pipe",
+				timeout: 60_000,
+			});
+			const combined = `${result.stdout.toString()}\n${result.stderr.toString()}`;
+			expect(result.exitCode, combined).toBe(0);
+
+			// After a clean exit there must be no still-running process whose argv contains
+			// both the CLI entry and the unique search marker (would indicate a nested agent).
+			const ps = Bun.spawnSync(["ps", "-ax", "-o", "pid=,command="], {
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const processes = ps.stdout
+				.toString()
+				.split("\n")
+				.filter(line => line.includes(cliEntry) && line.includes(marker));
+			expect(processes, processes.join("\n")).toEqual([]);
+		} finally {
+			await fs.rm(home, { recursive: true, force: true });
+		}
+	}, 90_000);
+});


### PR DESCRIPTION
## Summary

Fixes #3857.

Running `gjc models` from a nested GJC bash tool was treated as a free-form launch prompt (`launch models`), so nested agents re-invoked the same command and spawned an unbounded process chain.

Bare `models` (with optional search tokens) is now rewritten to the existing non-agent `launch --list-models` path, so the invocation exits after a bounded catalog listing and never starts an interactive agent session.

## Changes

- `routeModelsAlias` / `routeRootArgv`: map `gjc models [search…]` → `launch --list-models [search…]`
- Help surface documents the alias
- Changelog entry under Unreleased
- Focused regression tests (routing + nested `GJC_SESSION_ID` spawn + no leftover grandchild process)

## Test plan

- [x] `bun test packages/coding-agent/test/cli-command-surface.test.ts packages/coding-agent/test/issue-3857-nested-models-chain.test.ts`
- [x] Nested env with `GJC_SESSION_ID` set: `gjc models` exits 0 with listing output, no `warming workspace`
- [x] No leftover process whose argv still contains the unique models search marker

## Risks

- **Low / narrow**: only remaps the exact first-token spelling `models`. Ordinary free-form prompts (`gjc "list available models"`) still launch.
- Agents that intentionally wanted to chat with the single-token prompt `models` now get a model list instead — that was the accidental recursion trigger, not a supported workflow.
- Managed child/session launch paths (tasks, team workers, SDK lifecycle) are unchanged; they never depended on bare `models` as a prompt.

## Not changed

- No general nested-session hard refuse (would break intentional one-shot `gjc -p` from tool env)
- No new top-level registered command; reuses `--list-models` semantics