### PR TITLE
feat(update): add opt-in pre-release channel via `gjc update --pre`

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `gjc update --pre` opts into the pre-release channel (npm dist-tag `next`) while plain `gjc update` / `--check` stay on stable `latest`. Version comparison uses semver pre-release ordering so a user on `X.Y.Z-rc.N` who runs plain `gjc update` after `X.Y.Z` GA installs the stable build instead of being told "Already up to date", and binary installs surface an actionable message when a pre-release exists on npm without matching GitHub release assets (#3850).
+
 ### Fixed
 - ACP session configuration now emits the spec-defined `category` field on the Mode, Model, and Thinking select options (`mode`, `model`, `thought_level`), so standards-compliant ACP clients such as Paseo discover models, modes, and thinking levels instead of an empty model picker (#3922).
 - The ACP session model catalog is now filtered to active providers via `providers.list/active`, falling back to the full catalog on older session hosts, so ACP clients no longer list models for providers without usable credentials (#3922).

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -24,6 +24,20 @@ const PACKAGE = "@gajae-code/coding-agent";
 const NPM_WRAPPER_PACKAGE = "gajae-code";
 const NPM_MANAGED_PACKAGES = [NPM_WRAPPER_PACKAGE, PACKAGE] as const;
 
+/** Stable channel (default). Resolves the npm `latest` dist-tag. */
+export const UPDATE_STABLE_CHANNEL = "latest";
+/** Opt-in pre-release channel for `gjc update --pre`. Resolves npm dist-tag `next`. */
+export const UPDATE_PRE_CHANNEL = "next";
+
+export type UpdateChannel = typeof UPDATE_STABLE_CHANNEL | typeof UPDATE_PRE_CHANNEL;
+
+export interface UpdateCommandOptions {
+	force: boolean;
+	check: boolean;
+	/** When true, resolve the pre-release (`next`) dist-tag instead of `latest`. */
+	pre?: boolean;
+}
+
 interface ReleaseInfo {
 	tag: string;
 	version: string;
@@ -31,6 +45,8 @@ interface ReleaseInfo {
 	registry: string;
 	/** Config problems that did not stop the lookup but changed its outcome. */
 	warnings: string[];
+	/** npm dist-tag that answered the lookup (`latest` or `next`). */
+	channel: string;
 }
 
 /** Result from running the installed binary and parsing its reported version. */
@@ -71,7 +87,7 @@ export interface BinaryReplacementOptions {
  * Parse update subcommand arguments.
  * Returns undefined if not an update command.
  */
-export function parseUpdateArgs(args: string[]): { force: boolean; check: boolean } | undefined {
+export function parseUpdateArgs(args: string[]): UpdateCommandOptions | undefined {
 	if (args.length === 0 || args[0] !== "update") {
 		return undefined;
 	}
@@ -79,7 +95,13 @@ export function parseUpdateArgs(args: string[]): { force: boolean; check: boolea
 	return {
 		force: args.includes("--force") || args.includes("-f"),
 		check: args.includes("--check") || args.includes("-c"),
+		pre: args.includes("--pre"),
 	};
+}
+
+/** Resolve the npm dist-tag channel for an update invocation. */
+export function resolveUpdateChannel(opts: Pick<UpdateCommandOptions, "pre">): UpdateChannel {
+	return opts.pre ? UPDATE_PRE_CHANNEL : UPDATE_STABLE_CHANNEL;
 }
 
 async function getBunGlobalBinDir(): Promise<string | undefined> {
@@ -219,13 +241,18 @@ async function resolveUpdateTarget(): Promise<UpdateTarget> {
  * The registry comes from npm config (`npm_config_registry`, `.npmrc`,
  * `BUN_CONFIG_REGISTRY`) so the check reaches the same place the install does.
  * Hardcoding the public registry broke every mirrored or firewalled network.
+ *
+ * Pass `channel: "next"` (via `gjc update --pre`) to opt into the pre-release
+ * dist-tag. The default channel is `latest` and never resolves pre-releases.
  */
 async function getLatestRelease(options?: Installer | NpmRegistryLookupOptions): Promise<ReleaseInfo> {
 	const overrides: NpmRegistryLookupOptions = typeof options === "string" ? { installer: options } : (options ?? {});
+	const channel = overrides.channel ?? UPDATE_STABLE_CHANNEL;
 	// The user is deliberately waiting on this command, unlike the startup check.
 	const { version, registry, warnings } = await fetchLatestPackageVersion(PACKAGE, {
 		timeoutMs: 20_000,
 		...overrides,
+		channel,
 	});
 
 	return {
@@ -233,6 +260,7 @@ async function getLatestRelease(options?: Installer | NpmRegistryLookupOptions):
 		version,
 		registry,
 		warnings,
+		channel,
 	};
 }
 
@@ -241,21 +269,21 @@ export function getLatestReleaseForTest(options: NpmRegistryLookupOptions): Prom
 }
 
 /**
- * Compare semver versions. Returns:
+ * Compare semver versions, including pre-release ordering.
+ * Returns:
  * - negative if a < b
  * - 0 if a == b
  * - positive if a > b
+ *
+ * Must be pre-release-aware: a plain split-on-`.` comparator ranks
+ * `0.13.0-rc.1` above `0.13.0`, which would strand users on an rc after GA.
  */
 function compareVersions(a: string, b: string): number {
-	const pa = a.split(".").map(Number);
-	const pb = b.split(".").map(Number);
+	return Bun.semver.order(a, b);
+}
 
-	for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-		const na = pa[i] || 0;
-		const nb = pb[i] || 0;
-		if (na !== nb) return na - nb;
-	}
-	return 0;
+export function compareVersionsForTest(a: string, b: string): number {
+	return compareVersions(a, b);
 }
 
 /**
@@ -303,6 +331,18 @@ function resolveGjcPath(): string | undefined {
 }
 
 /**
+ * Parse `gjc --version` output (`gjc/X.Y.Z` or `gjc/X.Y.Z-rc.N`).
+ * Pre-release suffixes must be preserved so update verification can confirm an rc install.
+ */
+export function parseReportedVersion(output: string): string | undefined {
+	const trimmed = output.trim();
+	const slash = trimmed.lastIndexOf("/");
+	if (slash < 0) return undefined;
+	const version = trimmed.slice(slash + 1).trim();
+	return version.length > 0 ? version : undefined;
+}
+
+/**
  * Run the resolved gjc binary and check if it reports the expected version.
  */
 async function verifyInstalledVersion(expectedVersion: string): Promise<InstalledVersionVerification> {
@@ -312,9 +352,8 @@ async function verifyInstalledVersion(expectedVersion: string): Promise<Installe
 		const result = await $`${ompPath} --version`.quiet().nothrow();
 		if (result.exitCode !== 0) return { ok: false, path: ompPath };
 		const output = result.text().trim();
-		// Output format: "gjc/X.Y.Z"
-		const match = output.match(/\/(\d+\.\d+\.\d+)/);
-		const actual = match?.[1];
+		// Output format: "gjc/X.Y.Z" or "gjc/X.Y.Z-rc.N"
+		const actual = parseReportedVersion(output);
 		return { ok: actual === expectedVersion, actual, path: ompPath };
 	} catch {
 		return { ok: false, path: ompPath };
@@ -686,12 +725,34 @@ function formatRegistryProvenance(version: string, registry: string | undefined)
 }
 
 /**
+ * Extra guidance when a pre-release version resolved from npm has no GitHub asset.
+ * Binary installs download `releases/download/v{version}/…`, so a published npm
+ * `next` tag without a matching GitHub pre-release leaves the binary path stuck.
+ */
+function formatPreReleaseAssetNote(version: string): string | undefined {
+	// Semver pre-release identifiers are separated by `-` (e.g. 0.13.0-rc.1).
+	if (!version.includes("-")) return undefined;
+	return `Pre-release ${version} was resolved from the npm registry, but the matching GitHub release asset under tag v${version} is missing. Publish the GitHub pre-release with the same gjc-* assets as stable, or update via bun/npm instead of the binary path.`;
+}
+
+function formatBinaryDownloadNotes(version: string, registry?: string): string | undefined {
+	const notes = [formatRegistryProvenance(version, registry), formatPreReleaseAssetNote(version)].filter(
+		(note): note is string => Boolean(note),
+	);
+	return notes.length > 0 ? notes.join("\n") : undefined;
+}
+
+export function formatBinaryDownloadNotesForTest(version: string, registry?: string): string | undefined {
+	return formatBinaryDownloadNotes(version, registry);
+}
+
+/**
  * Download a release binary to a target path, replacing an existing file.
  */
 async function updateViaBinaryAt(targetPath: string, expectedVersion: string, registry?: string): Promise<void> {
 	const binaryName = getBinaryName();
 	const url = buildReleaseBinaryUrl(expectedVersion);
-	const registryNote = formatRegistryProvenance(expectedVersion, registry);
+	const registryNote = formatBinaryDownloadNotes(expectedVersion, registry);
 	console.log(chalk.dim(`Downloading ${binaryName}…`));
 
 	const verification = await runBinaryUpdateFlow(targetPath, url, expectedVersion, {
@@ -712,7 +773,7 @@ async function updateViaBinaryAt(targetPath: string, expectedVersion: string, re
  * Run the update command.
  */
 export interface UpdateCommandDependencies {
-	getLatestRelease?: (installer?: Installer) => Promise<ReleaseInfo>;
+	getLatestRelease?: (options?: Installer | NpmRegistryLookupOptions) => Promise<ReleaseInfo>;
 	resolveUpdateTarget?: () => Promise<UpdateTarget>;
 	performUpdate?: (target: UpdateTarget, expectedVersion: string, registry?: string) => Promise<void>;
 	refreshInstalledDefaultSkills?: () => Promise<void>;
@@ -730,7 +791,7 @@ async function performUpdate(target: UpdateTarget, expectedVersion: string, regi
 }
 
 export async function runUpdateCommand(
-	opts: { force: boolean; check: boolean },
+	opts: UpdateCommandOptions,
 	deps: UpdateCommandDependencies = {},
 ): Promise<void> {
 	const lookupRelease = deps.getLatestRelease ?? getLatestRelease;
@@ -738,8 +799,10 @@ export async function runUpdateCommand(
 	const update = deps.performUpdate ?? performUpdate;
 	const refreshDefaults = deps.refreshInstalledDefaultSkills ?? refreshInstalledDefaultSkills;
 	const exit = deps.exit ?? process.exit;
+	const channel = resolveUpdateChannel(opts);
 
 	console.log(chalk.dim(`Current version: ${VERSION}`));
+	console.log(chalk.dim(`Channel: ${channel}`));
 
 	// Resolve the install target first so the registry lookup can match the
 	// manager that will actually run: the npm-managed path ignores
@@ -757,7 +820,7 @@ export async function runUpdateCommand(
 
 	let release: ReleaseInfo;
 	try {
-		release = await lookupRelease(installer);
+		release = await lookupRelease({ installer, channel });
 	} catch (err) {
 		console.error(chalk.red(`Failed to check for updates: ${err}`));
 		return exit(1);
@@ -769,6 +832,8 @@ export async function runUpdateCommand(
 	// consumer can satisfy without the field.
 	for (const warning of release.warnings ?? []) console.warn(chalk.yellow(`Warning: ${warning}`));
 
+	// Bun.semver.order ranks stable above its own pre-release, so a user on
+	// X.Y.Z-rc.N who runs plain `gjc update` after X.Y.Z GA installs the GA.
 	const comparison = compareVersions(release.version, VERSION);
 
 	if (comparison <= 0 && !opts.force) {
@@ -777,9 +842,9 @@ export async function runUpdateCommand(
 	}
 
 	if (comparison > 0) {
-		console.log(chalk.cyan(`New version available: ${release.version}`));
+		console.log(chalk.cyan(`New version available: ${release.version} (${release.channel ?? channel})`));
 	} else {
-		console.log(chalk.yellow(`Forcing reinstall of ${release.version}`));
+		console.log(chalk.yellow(`Forcing reinstall of ${release.version} (${release.channel ?? channel})`));
 	}
 
 	if (opts.check) return;
@@ -828,10 +893,13 @@ ${chalk.bold("Usage:")}
 ${chalk.bold("Options:")}
   -c, --check   Check for updates without installing
   -f, --force   Force reinstall even if up to date
+      --pre     Opt into the pre-release channel (npm dist-tag "${UPDATE_PRE_CHANNEL}")
 
 ${chalk.bold("Examples:")}
-  ${APP_NAME} update           Update to latest version
-  ${APP_NAME} update --check   Check if updates are available
-  ${APP_NAME} update --force   Force reinstall
+  ${APP_NAME} update           Update to the latest stable version
+  ${APP_NAME} update --check   Check if a stable update is available
+  ${APP_NAME} update --pre     Install the newest pre-release when published
+  ${APP_NAME} update --pre --check   Check the pre-release channel only
+  ${APP_NAME} update --force   Force reinstall of the resolved channel
 `);
 }

--- a/packages/coding-agent/src/commands/update.ts
+++ b/packages/coding-agent/src/commands/update.ts
@@ -11,11 +11,15 @@ export default class Update extends Command {
 	static flags = {
 		force: Flags.boolean({ char: "f", description: "Force update", default: false }),
 		check: Flags.boolean({ char: "c", description: "Check for updates without installing", default: false }),
+		pre: Flags.boolean({
+			description: 'Opt into the pre-release channel (npm dist-tag "next")',
+			default: false,
+		}),
 	};
 
 	async run(): Promise<void> {
 		const { flags } = await this.parse(Update);
 		await initTheme();
-		await runUpdateCommand({ force: flags.force, check: flags.check });
+		await runUpdateCommand({ force: flags.force, check: flags.check, pre: flags.pre });
 	}
 }

--- a/packages/coding-agent/src/utils/npm-registry.ts
+++ b/packages/coding-agent/src/utils/npm-registry.ts
@@ -86,9 +86,17 @@ export type FetchLike = (
 	init?: { headers?: Record<string, string>; signal?: AbortSignal },
 ) => Promise<FetchResponseLike>;
 
+/** npm dist-tag used when resolving a package version. Defaults to `latest`. */
+export type PackageVersionChannel = "latest" | "next";
+
 export interface NpmRegistryLookupOptions extends NpmRegistryEnvironment {
 	fetchImpl?: FetchLike;
 	timeoutMs?: number;
+	/**
+	 * Dist-tag to resolve. Stable updates use `latest`; `gjc update --pre` uses
+	 * `next`. Arbitrary tags are accepted so tests can exercise packument fallback.
+	 */
+	channel?: string;
 }
 
 /** Thrown when a registry is configured but unusable, so it is never silently ignored. */
@@ -585,7 +593,7 @@ function withWarnings(message: string, warnings: string[]): string {
 
 interface VersionResponse {
 	version?: string;
-	"dist-tags"?: { latest?: string };
+	"dist-tags"?: Record<string, string | undefined>;
 }
 
 async function requestJson(
@@ -626,11 +634,11 @@ async function requestJson(
 	}
 }
 
-function readVersion(data: VersionResponse | undefined): string | undefined {
-	return data?.version ?? data?.["dist-tags"]?.latest;
+function readVersion(data: VersionResponse | undefined, channel: string): string | undefined {
+	return data?.version ?? data?.["dist-tags"]?.[channel];
 }
 
-/** Fetch the latest published version of `packageName` from the configured registry. */
+/** Fetch the published version of `packageName` for the requested dist-tag channel. */
 export async function fetchLatestPackageVersion(
 	packageName: string,
 	options: NpmRegistryLookupOptions = {},
@@ -638,23 +646,26 @@ export async function fetchLatestPackageVersion(
 	const resolved = await resolveNpmRegistry(packageName, options);
 	// One deadline for the whole lookup, so the packument retry cannot double it.
 	const signal = AbortSignal.timeout(options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+	const channel = options.channel ?? "latest";
 
-	const latestUrl = buildRegistryPackageUrl(resolved.registry, packageName, "latest");
-	const latest = await requestJson(latestUrl, resolved, options, signal);
-	const version = readVersion(latest.data);
+	const channelUrl = buildRegistryPackageUrl(resolved.registry, packageName, channel);
+	const channelResponse = await requestJson(channelUrl, resolved, options, signal);
+	const version = readVersion(channelResponse.data, channel);
 	if (version) return { version, registry: resolved.registry, warnings: resolved.warnings };
 
-	// `/{pkg}/latest` is a registry-API convenience route; a mirror that only
+	// `/{pkg}/{dist-tag}` is a registry-API convenience route; a mirror that only
 	// serves packuments — which is all the installer itself needs — 404s it.
-	if (latest.status === 404 || (!latest.failure && !version)) {
+	if (channelResponse.status === 404 || (!channelResponse.failure && !version)) {
 		const packumentUrl = buildRegistryPackageUrl(resolved.registry, packageName);
 		const packument = await requestJson(packumentUrl, resolved, options, signal);
-		const fallback = readVersion(packument.data);
+		const fallback = readVersion(packument.data, channel);
 		if (fallback) return { version: fallback, registry: resolved.registry, warnings: resolved.warnings };
-		throw new Error(
-			withWarnings(packument.failure ?? latest.failure ?? `${packumentUrl} returned no version`, resolved.warnings),
-		);
+		const missingTag =
+			packument.status === 200 || packument.data
+				? `${packumentUrl} has no dist-tag "${channel}"`
+				: (packument.failure ?? channelResponse.failure ?? `${packumentUrl} returned no version`);
+		throw new Error(withWarnings(missingTag, resolved.warnings));
 	}
 
-	throw new Error(withWarnings(latest.failure ?? `${latestUrl} returned no version`, resolved.warnings));
+	throw new Error(withWarnings(channelResponse.failure ?? `${channelUrl} returned no version`, resolved.warnings));
 }

--- a/packages/coding-agent/test/npm-registry.test.ts
+++ b/packages/coding-agent/test/npm-registry.test.ts
@@ -815,6 +815,39 @@ describe("fetchLatestPackageVersion", () => {
 		]);
 	});
 
+	it("resolves a non-latest dist-tag and falls back to packument dist-tags.next", async () => {
+		const seen: string[] = [];
+		const result = await fetchLatestPackageVersion(PACKAGE, {
+			...environment({ env: { npm_config_registry: "https://nexus.example.com/npm" } }),
+			channel: "next",
+			fetchImpl: async url => {
+				seen.push(url);
+				return url.endsWith("/next")
+					? respond(null, { ok: false, status: 404, statusText: "Not Found" })
+					: respond({ "dist-tags": { latest: "1.2.3", next: "1.3.0-rc.1" } });
+			},
+		});
+
+		expect(result.version).toBe("1.3.0-rc.1");
+		expect(seen).toEqual([
+			"https://nexus.example.com/npm/@gajae-code/coding-agent/next",
+			"https://nexus.example.com/npm/@gajae-code/coding-agent",
+		]);
+	});
+
+	it("names a missing dist-tag instead of falling back to latest", async () => {
+		const failing = fetchLatestPackageVersion(PACKAGE, {
+			...environment({ env: { npm_config_registry: "https://nexus.example.com/npm" } }),
+			channel: "next",
+			fetchImpl: async url =>
+				url.endsWith("/next")
+					? respond(null, { ok: false, status: 404, statusText: "Not Found" })
+					: respond({ "dist-tags": { latest: "1.2.3" } }),
+		});
+
+		await expect(failing).rejects.toThrow('has no dist-tag "next"');
+	});
+
 	it("reports the original failure when the packument fallback also fails", async () => {
 		const failing = lookup({ env: { npm_config_registry: "https://nexus.example.com" } }, async () =>
 			respond(null, { ok: false, status: 404, statusText: "Not Found" }),
@@ -883,7 +916,7 @@ describe("fetchLatestPackageVersion", () => {
 	it("rejects a response without any version field", async () => {
 		const failing = lookup({}, async () => respond({ name: PACKAGE }));
 
-		await expect(failing).rejects.toThrow("returned no version");
+		await expect(failing).rejects.toThrow('has no dist-tag "latest"');
 	});
 });
 

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -6,17 +6,24 @@ import * as path from "node:path";
 import type { BinaryUpdateFlow } from "../src/cli/update-cli";
 import {
 	buildReleaseBinaryUrlForTest,
+	compareVersionsForTest,
 	formatBinaryDownloadFailureMessageForTest,
+	formatBinaryDownloadNotesForTest,
 	formatManualUpdateInstructionsForTest,
 	formatVerificationFailureForTest,
 	fsyncFileForTest,
 	getLatestReleaseForTest,
+	parseReportedVersion,
+	parseUpdateArgs,
 	replaceBinaryForUpdate,
 	resolveNpmManagedTargetForTest,
+	resolveUpdateChannel,
 	resolveUpdateMethodForTest,
 	runBinaryUpdateFlow,
 	runPackageManagerUpdateForTest,
 	runUpdateCommand,
+	UPDATE_PRE_CHANNEL,
+	UPDATE_STABLE_CHANNEL,
 } from "../src/cli/update-cli";
 import { initTheme } from "../src/modes/theme/theme";
 import { DEFAULT_NPM_REGISTRY } from "../src/utils/npm-registry";
@@ -60,7 +67,60 @@ describe("update-cli release lookup", () => {
 			version: "9.9.9",
 			registry: "https://nexus.example.com/repository/npm-all",
 			warnings: [],
+			channel: UPDATE_STABLE_CHANNEL,
 		});
+	});
+
+	it("resolves the pre-release dist-tag when channel is next", async () => {
+		const requested: string[] = [];
+
+		const release = await getLatestReleaseForTest({
+			...isolated,
+			channel: UPDATE_PRE_CHANNEL,
+			lookupEnv: () => undefined,
+			fetchImpl: async url => {
+				requested.push(url);
+				return { ok: true, status: 200, statusText: "OK", json: async () => ({ version: "0.13.0-rc.1" }) };
+			},
+		});
+
+		expect(requested).toEqual(["https://registry.npmjs.org/@gajae-code/coding-agent/next"]);
+		expect(release).toEqual({
+			tag: "v0.13.0-rc.1",
+			version: "0.13.0-rc.1",
+			registry: DEFAULT_NPM_REGISTRY,
+			warnings: [],
+			channel: UPDATE_PRE_CHANNEL,
+		});
+	});
+
+	it("falls back to packument dist-tags.next when the /next route is missing", async () => {
+		const requested: string[] = [];
+
+		const release = await getLatestReleaseForTest({
+			...isolated,
+			channel: UPDATE_PRE_CHANNEL,
+			lookupEnv: () => undefined,
+			fetchImpl: async url => {
+				requested.push(url);
+				if (url.endsWith("/next")) {
+					return { ok: false, status: 404, statusText: "Not Found", json: async () => ({}) };
+				}
+				return {
+					ok: true,
+					status: 200,
+					statusText: "OK",
+					json: async () => ({ "dist-tags": { latest: "0.12.11", next: "0.13.0-rc.2" } }),
+				};
+			},
+		});
+
+		expect(requested).toEqual([
+			"https://registry.npmjs.org/@gajae-code/coding-agent/next",
+			"https://registry.npmjs.org/@gajae-code/coding-agent",
+		]);
+		expect(release.version).toBe("0.13.0-rc.2");
+		expect(release.channel).toBe(UPDATE_PRE_CHANNEL);
 	});
 
 	it("surfaces the failing url and status so blocked registries are diagnosable", async () => {
@@ -76,6 +136,139 @@ describe("update-cli release lookup", () => {
 		});
 
 		await expect(failing).rejects.toThrow("https://registry.npmjs.org/@gajae-code/coding-agent/latest responded 503");
+	});
+});
+
+describe("update-cli channel and version ordering", () => {
+	it("parses --pre alongside existing flags", () => {
+		expect(parseUpdateArgs(["update"])).toEqual({ force: false, check: false, pre: false });
+		expect(parseUpdateArgs(["update", "--pre", "--check"])).toEqual({ force: false, check: true, pre: true });
+		expect(parseUpdateArgs(["update", "-f", "--pre"])).toEqual({ force: true, check: false, pre: true });
+		expect(parseUpdateArgs(["status"])).toBeUndefined();
+	});
+
+	it("maps --pre to the next dist-tag and default to latest", () => {
+		expect(resolveUpdateChannel({})).toBe(UPDATE_STABLE_CHANNEL);
+		expect(resolveUpdateChannel({ pre: false })).toBe(UPDATE_STABLE_CHANNEL);
+		expect(resolveUpdateChannel({ pre: true })).toBe(UPDATE_PRE_CHANNEL);
+	});
+
+	it("orders stable above its own pre-release so GA can leave an rc behind", () => {
+		// The previous split-on-`.` comparator ranked rc above stable and stranded
+		// users who ran plain `gjc update` after GA.
+		expect(compareVersionsForTest("0.13.0-rc.1", "0.13.0")).toBeLessThan(0);
+		expect(compareVersionsForTest("0.13.0", "0.13.0-rc.1")).toBeGreaterThan(0);
+		expect(compareVersionsForTest("0.13.0-rc.2", "0.13.0-rc.1")).toBeGreaterThan(0);
+		expect(compareVersionsForTest("0.12.11", "0.13.0-rc.1")).toBeLessThan(0);
+		expect(compareVersionsForTest("0.13.0", "0.13.0")).toBe(0);
+	});
+
+	it("parses pre-release versions from gjc --version output", () => {
+		expect(parseReportedVersion("gjc/0.13.0-rc.1")).toBe("0.13.0-rc.1");
+		expect(parseReportedVersion("gjc/0.12.11")).toBe("0.12.11");
+		expect(parseReportedVersion("  gjc/1.0.0-beta.2\n")).toBe("1.0.0-beta.2");
+		expect(parseReportedVersion("not-a-version")).toBeUndefined();
+	});
+
+	it("prints the channel and installs a newer stable over an installed pre-release", async () => {
+		const output: string[] = [];
+		const logSpy = vi.spyOn(console, "log").mockImplementation(message => {
+			output.push(String(message));
+		});
+		const updates: Array<{ version: string; registry?: string }> = [];
+		try {
+			await runUpdateCommand(
+				{ force: false, check: false, pre: false },
+				{
+					getLatestRelease: async options => {
+						const channel =
+							typeof options === "string" ? UPDATE_STABLE_CHANNEL : (options?.channel ?? UPDATE_STABLE_CHANNEL);
+						expect(channel).toBe(UPDATE_STABLE_CHANNEL);
+						return {
+							tag: "v0.13.0",
+							version: "0.13.0",
+							registry: DEFAULT_NPM_REGISTRY,
+							warnings: [],
+							channel: UPDATE_STABLE_CHANNEL,
+						};
+					},
+					resolveUpdateTarget: async () => ({ method: "bun" }),
+					performUpdate: async (_target, expectedVersion, registry) => {
+						updates.push({ version: expectedVersion, registry });
+					},
+					refreshInstalledDefaultSkills: async () => {},
+				},
+			);
+			// VERSION is whatever the workspace package reports; we only assert channel
+			// surfacing and that a mocked newer stable is offered when comparison allows.
+			expect(output.some(line => line.includes(`Channel: ${UPDATE_STABLE_CHANNEL}`))).toBe(true);
+			// When the mocked release is newer than VERSION, an install is attempted.
+			// When the workspace is already at or above 0.13.0, the command reports up to date.
+			if (updates.length > 0) {
+				expect(updates).toEqual([{ version: "0.13.0", registry: DEFAULT_NPM_REGISTRY }]);
+				expect(output.some(line => line.includes("New version available: 0.13.0"))).toBe(true);
+			} else {
+				expect(output.some(line => line.includes("Already up to date"))).toBe(true);
+			}
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+
+	it("requests the pre-release channel and surfaces it when --pre is set", async () => {
+		const output: string[] = [];
+		const logSpy = vi.spyOn(console, "log").mockImplementation(message => {
+			output.push(String(message));
+		});
+		let seenChannel: string | undefined;
+		try {
+			await runUpdateCommand(
+				{ force: false, check: true, pre: true },
+				{
+					getLatestRelease: async options => {
+						seenChannel =
+							typeof options === "string" ? UPDATE_STABLE_CHANNEL : (options?.channel ?? UPDATE_STABLE_CHANNEL);
+						return {
+							tag: "v0.13.0-rc.1",
+							version: "0.13.0-rc.1",
+							registry: DEFAULT_NPM_REGISTRY,
+							warnings: [],
+							channel: UPDATE_PRE_CHANNEL,
+						};
+					},
+					resolveUpdateTarget: async () => ({ method: "bun" }),
+					performUpdate: async () => {
+						throw new Error("check mode must not install");
+					},
+					refreshInstalledDefaultSkills: async () => {},
+				},
+			);
+			expect(seenChannel).toBe(UPDATE_PRE_CHANNEL);
+			expect(output.some(line => line.includes(`Channel: ${UPDATE_PRE_CHANNEL}`))).toBe(true);
+			expect(output.some(line => line.includes("0.13.0-rc.1") && line.includes(UPDATE_PRE_CHANNEL))).toBe(true);
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+
+	it("includes pre-release asset guidance when a GitHub binary is missing for an rc", () => {
+		const notes = formatBinaryDownloadNotesForTest("0.13.0-rc.1");
+		expect(notes).toContain("Pre-release 0.13.0-rc.1 was resolved from the npm registry");
+		expect(notes).toContain("matching GitHub release asset under tag v0.13.0-rc.1 is missing");
+		expect(formatBinaryDownloadNotesForTest("0.13.0")).toBeUndefined();
+
+		const message = formatBinaryDownloadFailureMessageForTest(
+			"gjc-linux-x64",
+			"https://github.com/Yeachan-Heo/gajae-code/releases/download/v0.13.0-rc.1/gjc-linux-x64",
+			"Not Found",
+			"linux",
+			notes,
+		);
+
+		expect(message).toContain("Download failed for gjc-linux-x64");
+		expect(message).toContain("Pre-release 0.13.0-rc.1 was resolved from the npm registry");
+		expect(message).toContain("matching GitHub release asset under tag v0.13.0-rc.1 is missing");
+		expect(message).toContain("bun install -g @gajae-code/coding-agent@latest");
 	});
 });
 
@@ -379,6 +572,7 @@ describe("update-cli command verification failures", () => {
 							version: "999.0.0",
 							registry: DEFAULT_NPM_REGISTRY,
 							warnings: [],
+							channel: UPDATE_STABLE_CHANNEL,
 						}),
 						resolveUpdateTarget: async () => ({ method: "bun" }),
 						performUpdate: async (_target, expectedVersion) => {
@@ -440,6 +634,7 @@ describe("update-cli command verification failures", () => {
 							version: "999.0.0",
 							registry: DEFAULT_NPM_REGISTRY,
 							warnings: [],
+							channel: UPDATE_STABLE_CHANNEL,
 						}),
 						resolveUpdateTarget: async () => ({ method: "bun" }),
 						performUpdate: async (_target, expectedVersion) => {


### PR DESCRIPTION
## Summary
- Add `gjc update --pre` to resolve npm dist-tag `next` while plain `gjc update` / `--check` stay on stable `latest`.
- Replace naive `compareVersions` with `Bun.semver.order` so stable ranks above its own pre-release (prevents stranding users on an rc after GA).
- Surface the selected channel in CLI output; keep pre-release suffixes in post-install `--version` verification; give actionable guidance when a pre-release exists on npm without matching GitHub binary assets.

## Test plan
- [x] `bun test packages/coding-agent/test/update-cli.test.ts packages/coding-agent/test/npm-registry.test.ts` (116 pass)
- [x] `bun --cwd=packages/coding-agent run check` (biome + tsc)
- [ ] Live install from a published `next` dist-tag once maintainers publish the channel
- [ ] Binary path against a GitHub pre-release tag with and without assets

Fixes #3850