### PR TITLE
feat(gc): add --disk natives version retention

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `gjc gc --disk` starts an opt-in disk-retention pass alongside the existing PID-liveness reaper. The first surface reclaims excess `~/.gjc/natives/<version>/` caches: keep the running natives version plus N older predecessors (`--natives-keep-versions`, default 2), report reclaimable bytes in dry-run, and delete only with `--prune`. Non-semver entries, newer-than-current caches, and the current version stay fail-closed. Session transcripts, blobs, backups, and worktrees are intentionally out of scope for this slice (#3853).
+
 ### Fixed
 - ACP session configuration now emits the spec-defined `category` field on the Mode, Model, and Thinking select options (`mode`, `model`, `thought_level`), so standards-compliant ACP clients such as Paseo discover models, modes, and thinking levels instead of an empty model picker (#3922).
 - The ACP session model catalog is now filtered to active providers via `providers.list/active`, falling back to the full catalog on older session hosts, so ACP clients no longer list models for providers without usable credentials (#3922).

--- a/packages/coding-agent/src/commands/gc.ts
+++ b/packages/coding-agent/src/commands/gc.ts
@@ -2,13 +2,21 @@ import { Command, Flags } from "@gajae-code/utils/cli";
 import { runGjcGcCommand } from "../gjc-runtime/gc-runtime";
 
 export default class Gc extends Command {
-	static description = "Garbage-collect stale GJC session/PID records (dry-run by default)";
+	static description = "Garbage-collect stale GJC session/PID records and optional disk caches (dry-run by default)";
 	static strict = false;
 	static flags = {
 		json: Flags.boolean({ char: "j", description: "Emit machine-readable JSON", default: false }),
 		prune: Flags.boolean({ description: "Remove stale records (default: report only)", default: false }),
 		force: Flags.boolean({ description: "Alias for --prune (eligible records only)", default: false }),
 		"dry-run": Flags.boolean({ description: "Force report-only mode", default: false }),
+		disk: Flags.boolean({
+			description:
+				"Opt-in disk-retention pass (natives version caches; dry-run unless --prune). Sessions/blobs/backups are follow-ups.",
+			default: false,
+		}),
+		"natives-keep-versions": Flags.integer({
+			description: "With --disk: keep the running natives version plus this many older predecessors (default: 2)",
+		}),
 		"repair-session-index": Flags.boolean({
 			description: "Quarantine a corrupt session-index suffix and retain its valid prefix",
 			default: false,
@@ -20,6 +28,10 @@ export default class Gc extends Command {
 		"gjc gc --json",
 		"gjc gc --prune",
 		"gjc gc --prune --json",
+		"gjc gc --disk",
+		"gjc gc --disk --json",
+		"gjc gc --disk --prune",
+		"gjc gc --disk --natives-keep-versions 1 --prune --json",
 		"gjc gc --repair-session-index --json",
 	];
 

--- a/packages/coding-agent/src/gjc-runtime/gc-disk.ts
+++ b/packages/coding-agent/src/gjc-runtime/gc-disk.ts
@@ -1,0 +1,546 @@
+/**
+ * Disk-retention pass for `gjc gc --disk`.
+ *
+ * Orthogonal to the PID-liveness reaper: this axis reclaims aged/unreferenced
+ * on-disk cache directories. First surface: versioned natives addons under
+ * `~/.gjc/natives/<version>/` (see packages/natives/native/loader-state.js).
+ *
+ * Contract (mirrors liveness GC):
+ * - Opt-in via `--disk`; without it this module is never invoked.
+ * - Dry-run by default; only `--prune` deletes.
+ * - Fail-closed: current version, newer-than-current caches, non-semver names,
+ *   and unreadable entries are kept with an explicit reason.
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { getNativesDir, isEnoent } from "@gajae-code/utils";
+
+import type { GcAction } from "./gc-runtime";
+
+/** Surfaces this slice can reclaim. Expand in follow-ups (sessions, blobs, backups). */
+export type GcDiskSurface = "natives_versions";
+
+export const GC_DISK_SURFACES: readonly GcDiskSurface[] = ["natives_versions"] as const;
+
+/** Default: keep the running natives version plus this many older predecessors. */
+export const DEFAULT_NATIVES_KEEP_VERSIONS = 2;
+
+/** Bound directory size walks so a pathological tree cannot stall `gjc gc`. */
+const MAX_SIZE_ENTRIES = 50_000;
+
+export interface GcDiskCandidate {
+	surface: GcDiskSurface;
+	/** Stable identifier (e.g. natives package version). */
+	id: string;
+	path: string;
+	bytes: number;
+	/** True when size walk hit the entry budget (bytes may be a lower bound). */
+	bytes_truncated?: boolean;
+	status: string;
+	removable: boolean;
+	action: GcAction;
+	reason: string;
+	detail?: string;
+	error?: string;
+	removed?: boolean;
+}
+
+export interface GcDiskCounts {
+	discovered: number;
+	kept: number;
+	would_remove: number;
+	removed: number;
+	failed: number;
+	reclaimable_bytes: number;
+	reclaimed_bytes: number;
+	by_surface: Record<
+		GcDiskSurface,
+		{
+			discovered: number;
+			kept: number;
+			would_remove: number;
+			removed: number;
+			failed: number;
+			reclaimable_bytes: number;
+			reclaimed_bytes: number;
+		}
+	>;
+}
+
+export interface GcDiskPolicy {
+	natives_keep_versions: number;
+	natives_current_version: string;
+	natives_dir: string;
+}
+
+export interface GcDiskReport {
+	dry_run: boolean;
+	policy: GcDiskPolicy;
+	surfaces: Record<GcDiskSurface, GcDiskCandidate[]>;
+	counts: GcDiskCounts;
+	errors: Array<{ surface: GcDiskSurface; scope: string; message: string }>;
+}
+
+export interface GcDiskCollectOptions {
+	nativesDir: string;
+	currentNativesVersion: string;
+	/** Number of strictly older predecessors to keep (in addition to current). */
+	keepVersions: number;
+}
+
+export interface GcDiskDeps {
+	nativesDir?: string;
+	currentNativesVersion?: string;
+	keepVersions?: number;
+}
+
+function emptyBySurface(): GcDiskCounts["by_surface"] {
+	const by = {} as GcDiskCounts["by_surface"];
+	for (const surface of GC_DISK_SURFACES) {
+		by[surface] = {
+			discovered: 0,
+			kept: 0,
+			would_remove: 0,
+			removed: 0,
+			failed: 0,
+			reclaimable_bytes: 0,
+			reclaimed_bytes: 0,
+		};
+	}
+	return by;
+}
+
+function emptySurfaces(): Record<GcDiskSurface, GcDiskCandidate[]> {
+	const surfaces = {} as Record<GcDiskSurface, GcDiskCandidate[]>;
+	for (const surface of GC_DISK_SURFACES) surfaces[surface] = [];
+	return surfaces;
+}
+
+function computeDiskCounts(surfaces: Record<GcDiskSurface, GcDiskCandidate[]>): GcDiskCounts {
+	const counts: GcDiskCounts = {
+		discovered: 0,
+		kept: 0,
+		would_remove: 0,
+		removed: 0,
+		failed: 0,
+		reclaimable_bytes: 0,
+		reclaimed_bytes: 0,
+		by_surface: emptyBySurface(),
+	};
+	for (const surface of GC_DISK_SURFACES) {
+		for (const candidate of surfaces[surface]) {
+			counts.discovered++;
+			counts.by_surface[surface].discovered++;
+			if (candidate.action === "would_remove") {
+				counts.would_remove++;
+				counts.by_surface[surface].would_remove++;
+				counts.reclaimable_bytes += candidate.bytes;
+				counts.by_surface[surface].reclaimable_bytes += candidate.bytes;
+			} else if (candidate.action === "removed") {
+				counts.removed++;
+				counts.by_surface[surface].removed++;
+				counts.reclaimed_bytes += candidate.bytes;
+				counts.by_surface[surface].reclaimed_bytes += candidate.bytes;
+			} else if (candidate.action === "remove_failed") {
+				counts.failed++;
+				counts.by_surface[surface].failed++;
+			} else {
+				counts.kept++;
+				counts.by_surface[surface].kept++;
+			}
+		}
+	}
+	return counts;
+}
+
+/** True when `version` is a parseable semver Bun can order. */
+export function isOrderableSemver(version: string): boolean {
+	try {
+		// order against itself: invalid versions throw or return NaN-ish behavior.
+		return Bun.semver.order(version, version) === 0;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Compare two orderable semver strings. Returns negative if a < b, 0 if equal,
+ * positive if a > b. Callers must gate with {@link isOrderableSemver}.
+ */
+export function compareSemver(a: string, b: string): number {
+	return Bun.semver.order(a, b);
+}
+
+/**
+ * Resolve the installed `@gajae-code/natives` package version (the key used for
+ * `~/.gjc/natives/<version>/` by the loader). Fail-closed callers should treat
+ * an unresolved version as "keep everything".
+ */
+export async function resolveCurrentNativesVersion(): Promise<string> {
+	const mainUrl = import.meta.resolve("@gajae-code/natives");
+	const mainPath = fileURLToPath(mainUrl);
+	// main is packages/natives/native/index.js → package root is parent of native/
+	const packageJsonPath = path.join(path.dirname(mainPath), "..", "package.json");
+	const raw = await Bun.file(packageJsonPath).text();
+	const parsed = JSON.parse(raw) as { version?: unknown };
+	if (typeof parsed.version !== "string" || parsed.version.trim().length === 0) {
+		throw new Error(`natives_package_missing_version:${packageJsonPath}`);
+	}
+	return parsed.version.trim();
+}
+
+export async function directoryByteSize(
+	root: string,
+	maxEntries: number = MAX_SIZE_ENTRIES,
+): Promise<{ bytes: number; truncated: boolean }> {
+	let bytes = 0;
+	let entries = 0;
+	let truncated = false;
+	const stack: string[] = [root];
+
+	while (stack.length > 0) {
+		const current = stack.pop();
+		if (!current) break;
+		if (entries >= maxEntries) {
+			truncated = true;
+			break;
+		}
+		entries++;
+
+		let stat: Awaited<ReturnType<typeof fs.lstat>>;
+		try {
+			stat = await fs.lstat(current);
+		} catch (error) {
+			if (isEnoent(error)) continue;
+			// Permission or other errors: count what we have so far; caller may still keep.
+			truncated = true;
+			continue;
+		}
+
+		if (stat.isSymbolicLink()) {
+			// Do not follow symlinks; count the link node only (size often 0 on some FS).
+			bytes += stat.size;
+			continue;
+		}
+		if (stat.isFile()) {
+			bytes += stat.size;
+			continue;
+		}
+		if (!stat.isDirectory()) {
+			bytes += stat.size;
+			continue;
+		}
+
+		let children: string[];
+		try {
+			children = await fs.readdir(current);
+		} catch {
+			truncated = true;
+			continue;
+		}
+		for (const name of children) stack.push(path.join(current, name));
+	}
+
+	return { bytes, truncated };
+}
+
+/**
+ * Classify version directories under nativesDir.
+ *
+ * Keep set = { current } ∪ top `keepVersions` versions strictly older than current.
+ * Also keep: non-semver names, versions newer than current, unreadable entries.
+ */
+export async function collectNativesVersionCandidates(
+	options: GcDiskCollectOptions,
+): Promise<{ candidates: GcDiskCandidate[]; errors: GcDiskReport["errors"] }> {
+	const candidates: GcDiskCandidate[] = [];
+	const errors: GcDiskReport["errors"] = [];
+	const { nativesDir, currentNativesVersion, keepVersions } = options;
+
+	if (!Number.isInteger(keepVersions) || keepVersions < 0) {
+		errors.push({
+			surface: "natives_versions",
+			scope: "policy",
+			message: `invalid_keep_versions:${keepVersions}`,
+		});
+		return { candidates, errors };
+	}
+
+	if (!isOrderableSemver(currentNativesVersion)) {
+		errors.push({
+			surface: "natives_versions",
+			scope: "policy",
+			message: `invalid_current_natives_version:${currentNativesVersion}`,
+		});
+		return { candidates, errors };
+	}
+
+	let dirents: string[];
+	try {
+		dirents = await fs.readdir(nativesDir);
+	} catch (error) {
+		if (isEnoent(error)) return { candidates, errors };
+		errors.push({
+			surface: "natives_versions",
+			scope: nativesDir,
+			message: error instanceof Error ? error.message : String(error),
+		});
+		return { candidates, errors };
+	}
+
+	const versionDirs: Array<{ version: string; path: string }> = [];
+	for (const name of dirents) {
+		const full = path.join(nativesDir, name);
+		let stat: Awaited<ReturnType<typeof fs.lstat>>;
+		try {
+			stat = await fs.lstat(full);
+		} catch (error) {
+			if (isEnoent(error)) continue;
+			candidates.push({
+				surface: "natives_versions",
+				id: name,
+				path: full,
+				bytes: 0,
+				status: "unreadable",
+				removable: false,
+				action: "none",
+				reason: "natives_version_unreadable",
+				detail: error instanceof Error ? error.message : String(error),
+			});
+			continue;
+		}
+
+		if (!stat.isDirectory() || stat.isSymbolicLink()) {
+			// Only plain version directories are reclaimable; leave files/symlinks alone.
+			candidates.push({
+				surface: "natives_versions",
+				id: name,
+				path: full,
+				bytes: 0,
+				status: "non_directory",
+				removable: false,
+				action: "none",
+				reason: "natives_entry_not_a_version_directory",
+			});
+			continue;
+		}
+
+		if (!isOrderableSemver(name)) {
+			candidates.push({
+				surface: "natives_versions",
+				id: name,
+				path: full,
+				bytes: 0,
+				status: "non_semver",
+				removable: false,
+				action: "none",
+				reason: "natives_version_not_orderable_semver",
+			});
+			continue;
+		}
+
+		versionDirs.push({ version: name, path: full });
+	}
+
+	const older = versionDirs
+		.filter(v => compareSemver(v.version, currentNativesVersion) < 0)
+		.sort((a, b) => compareSemver(b.version, a.version));
+	const keptOlder = new Set(older.slice(0, keepVersions).map(v => v.version));
+
+	for (const entry of versionDirs) {
+		const size = await directoryByteSize(entry.path);
+		const sizeDetail = size.truncated ? "size_walk_truncated" : undefined;
+
+		if (entry.version === currentNativesVersion) {
+			candidates.push({
+				surface: "natives_versions",
+				id: entry.version,
+				path: entry.path,
+				bytes: size.bytes,
+				bytes_truncated: size.truncated || undefined,
+				status: "current",
+				removable: false,
+				action: "none",
+				reason: "natives_current_version",
+				detail: sizeDetail,
+			});
+			continue;
+		}
+
+		if (compareSemver(entry.version, currentNativesVersion) > 0) {
+			candidates.push({
+				surface: "natives_versions",
+				id: entry.version,
+				path: entry.path,
+				bytes: size.bytes,
+				bytes_truncated: size.truncated || undefined,
+				status: "newer_than_current",
+				removable: false,
+				action: "none",
+				reason: "natives_version_newer_than_running",
+				detail: sizeDetail,
+			});
+			continue;
+		}
+
+		if (keptOlder.has(entry.version)) {
+			const rank = older.findIndex(v => v.version === entry.version) + 1;
+			candidates.push({
+				surface: "natives_versions",
+				id: entry.version,
+				path: entry.path,
+				bytes: size.bytes,
+				bytes_truncated: size.truncated || undefined,
+				status: "retained_predecessor",
+				removable: false,
+				action: "none",
+				reason: "natives_predecessor_within_keep_versions",
+				detail: [sizeDetail, `predecessor_rank=${rank}`, `keep_versions=${keepVersions}`].filter(Boolean).join(" "),
+			});
+			continue;
+		}
+
+		candidates.push({
+			surface: "natives_versions",
+			id: entry.version,
+			path: entry.path,
+			bytes: size.bytes,
+			bytes_truncated: size.truncated || undefined,
+			status: "excess_predecessor",
+			removable: true,
+			action: "would_remove",
+			reason: "natives_version_beyond_keep_versions",
+			detail: [sizeDetail, `keep_versions=${keepVersions}`, `current=${currentNativesVersion}`]
+				.filter(Boolean)
+				.join(" "),
+		});
+	}
+
+	// Stable report order: newest first among orderable, then others by id.
+	candidates.sort((a, b) => {
+		const aOrder = isOrderableSemver(a.id);
+		const bOrder = isOrderableSemver(b.id);
+		if (aOrder && bOrder) return compareSemver(b.id, a.id);
+		if (aOrder !== bOrder) return aOrder ? -1 : 1;
+		return a.id.localeCompare(b.id);
+	});
+
+	return { candidates, errors };
+}
+
+/**
+ * Remove a single natives version directory. Re-validates path containment and
+ * that the entry is still a directory before deleting (TOCTOU fail-closed).
+ */
+export async function pruneNativesVersionCandidate(
+	candidate: GcDiskCandidate,
+	options: Pick<GcDiskCollectOptions, "nativesDir" | "currentNativesVersion">,
+): Promise<{ removed: boolean; error?: string; skipped?: string }> {
+	if (candidate.surface !== "natives_versions") {
+		return { removed: false, skipped: "wrong_surface" };
+	}
+	if (!candidate.removable) {
+		return { removed: false, skipped: "not_removable" };
+	}
+	if (candidate.id === options.currentNativesVersion) {
+		return { removed: false, skipped: "natives_current_version" };
+	}
+
+	const resolvedRoot = path.resolve(options.nativesDir);
+	const resolvedTarget = path.resolve(candidate.path);
+	const relative = path.relative(resolvedRoot, resolvedTarget);
+	if (
+		relative === "" ||
+		relative.startsWith("..") ||
+		path.isAbsolute(relative) ||
+		relative.includes(path.sep) ||
+		relative !== candidate.id
+	) {
+		return { removed: false, skipped: "path_escape_or_mismatch" };
+	}
+
+	try {
+		const stat = await fs.lstat(resolvedTarget);
+		if (!stat.isDirectory() || stat.isSymbolicLink()) {
+			return { removed: false, skipped: "no_longer_a_directory" };
+		}
+	} catch (error) {
+		if (isEnoent(error)) return { removed: false, skipped: "already_absent" };
+		return { removed: false, error: error instanceof Error ? error.message : String(error) };
+	}
+
+	try {
+		await fs.rm(resolvedTarget, { recursive: true, force: false });
+		return { removed: true };
+	} catch (error) {
+		return { removed: false, error: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+export async function resolveGcDiskCollectOptions(
+	deps: GcDiskDeps = {},
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<GcDiskCollectOptions> {
+	const nativesDir = deps.nativesDir?.trim() || env.GJC_NATIVES_DIR?.trim() || getNativesDir();
+	const currentNativesVersion = deps.currentNativesVersion?.trim() || (await resolveCurrentNativesVersion());
+	const keepVersions = deps.keepVersions !== undefined ? deps.keepVersions : DEFAULT_NATIVES_KEEP_VERSIONS;
+	return { nativesDir, currentNativesVersion, keepVersions };
+}
+
+/**
+ * Collect + optionally prune all disk surfaces for this slice.
+ */
+export async function collectGcDiskReport(options: GcDiskCollectOptions, prune: boolean): Promise<GcDiskReport> {
+	const surfaces = emptySurfaces();
+	const errors: GcDiskReport["errors"] = [];
+
+	const natives = await collectNativesVersionCandidates(options);
+	surfaces.natives_versions.push(...natives.candidates);
+	errors.push(...natives.errors);
+
+	if (prune) {
+		for (const candidate of surfaces.natives_versions) {
+			if (!candidate.removable) continue;
+			const outcome = await pruneNativesVersionCandidate(candidate, options);
+			if (outcome.removed) {
+				candidate.action = "removed";
+				candidate.removed = true;
+			} else if (outcome.skipped) {
+				candidate.action = "skipped";
+				candidate.reason = outcome.skipped;
+				candidate.removed = false;
+			} else {
+				candidate.action = "remove_failed";
+				candidate.removed = false;
+				candidate.error = outcome.error ?? "remove_failed";
+			}
+		}
+	}
+
+	return {
+		dry_run: !prune,
+		policy: {
+			natives_keep_versions: options.keepVersions,
+			natives_current_version: options.currentNativesVersion,
+			natives_dir: options.nativesDir,
+		},
+		surfaces,
+		counts: computeDiskCounts(surfaces),
+		errors,
+	};
+}
+
+export function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	const units = ["KiB", "MiB", "GiB", "TiB"] as const;
+	let value = bytes / 1024;
+	let unitIndex = 0;
+	while (value >= 1024 && unitIndex < units.length - 1) {
+		value /= 1024;
+		unitIndex++;
+	}
+	const rounded = value >= 10 || unitIndex === 0 ? value.toFixed(0) : value.toFixed(1);
+	return `${rounded} ${units[unitIndex]}`;
+}

--- a/packages/coding-agent/src/gjc-runtime/gc-render.ts
+++ b/packages/coding-agent/src/gjc-runtime/gc-render.ts
@@ -3,6 +3,7 @@
  * `gc-runtime.ts`; this module owns the human-readable grouped report.
  */
 
+import { formatBytes, GC_DISK_SURFACES, type GcDiskCandidate } from "./gc-disk";
 import type { GcRecord, GcReport, GcStore } from "./gc-runtime";
 import { GC_STORES } from "./gc-runtime";
 
@@ -15,7 +16,11 @@ const STORE_HEADINGS: Record<GcStore, string> = {
 	local_roots: "Session local roots",
 };
 
-function actionLabel(record: GcRecord): string {
+const DISK_SURFACE_HEADINGS: Record<(typeof GC_DISK_SURFACES)[number], string> = {
+	natives_versions: "Natives version caches",
+};
+
+function actionLabel(record: { action: GcRecord["action"]; error?: string; reason: string }): string {
 	switch (record.action) {
 		case "would_remove":
 			return "would remove";
@@ -36,6 +41,13 @@ function renderRecord(record: GcRecord): string {
 	const pidStatus = record.pid_status ? ` (${record.pid_status})` : "";
 	const note = record.detail ? ` — ${record.detail}` : "";
 	return `  [${actionLabel(record)}] ${target}${pid}${pidStatus} :: ${record.status} — ${record.reason}${note}`;
+}
+
+function renderDiskCandidate(candidate: GcDiskCandidate): string {
+	const size = formatBytes(candidate.bytes);
+	const trunc = candidate.bytes_truncated ? "~" : "";
+	const note = candidate.detail ? ` — ${candidate.detail}` : "";
+	return `  [${actionLabel(candidate)}] ${candidate.path} (${trunc}${size}) :: ${candidate.status} — ${candidate.reason}${note}`;
 }
 
 export function buildGcReportText(report: GcReport): string {
@@ -69,6 +81,33 @@ export function buildGcReportText(report: GcReport): string {
 			lines.push("  Upgrade GJC before attempting a repair; no index data was changed.");
 		if (index.status === "repaired")
 			lines.push("  Restart or re-register hosts whose only registration was in the quarantined suffix.");
+		lines.push("");
+	}
+
+	if (report.disk) {
+		const disk = report.disk;
+		lines.push(
+			`Disk retention (${disk.dry_run ? "dry run" : "prune"}): current natives=${disk.policy.natives_current_version} keep_predecessors=${disk.policy.natives_keep_versions}`,
+		);
+		lines.push(`  natives dir: ${disk.policy.natives_dir}`);
+		for (const surface of GC_DISK_SURFACES) {
+			const candidates = disk.surfaces[surface];
+			lines.push(`  ${DISK_SURFACE_HEADINGS[surface]} (${candidates.length})`);
+			if (candidates.length === 0) {
+				lines.push("    (none)");
+			} else {
+				for (const candidate of candidates) lines.push(`  ${renderDiskCandidate(candidate)}`);
+			}
+		}
+		if (disk.errors.length > 0) {
+			lines.push(`  Disk errors (${disk.errors.length})`);
+			for (const err of disk.errors) lines.push(`    [${err.surface}/${err.scope}] ${err.message}`);
+		}
+		const d = disk.counts;
+		lines.push(
+			`  Disk summary: discovered=${d.discovered} kept=${d.kept} ` +
+				`${disk.dry_run ? `would_remove=${d.would_remove} reclaimable=${formatBytes(d.reclaimable_bytes)}` : `removed=${d.removed} reclaimed=${formatBytes(d.reclaimed_bytes)} failed=${d.failed}`}`,
+		);
 		lines.push("");
 	}
 

--- a/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
@@ -17,6 +17,13 @@ import { getAgentDir } from "@gajae-code/utils";
 import { SessionIndex } from "../sdk/broker/session-index";
 import { UnsupportedStateVersionError } from "../sdk/broker/state-version";
 
+import {
+	collectGcDiskReport,
+	DEFAULT_NATIVES_KEEP_VERSIONS,
+	type GcDiskDeps,
+	type GcDiskReport,
+	resolveGcDiskCollectOptions,
+} from "./gc-disk";
 import { buildGcReportText } from "./gc-render";
 
 export type GcStore =
@@ -152,6 +159,11 @@ export interface GcReport {
 	/** Partial-result notices that do not fail the run (e.g. walk caps). */
 	warnings: GcWarning[];
 	session_index?: GcSessionIndexHealth;
+	/**
+	 * Present only when `--disk` was requested. Disk retention is a separate
+	 * opt-in axis from PID liveness and never runs implicitly.
+	 */
+	disk?: GcDiskReport;
 }
 
 export interface GcRunResult {
@@ -258,19 +270,32 @@ interface ParsedGcArgs {
 	json: boolean;
 	prune: boolean;
 	repairSessionIndex: boolean;
+	disk: boolean;
+	nativesKeepVersions: number | undefined;
 	help: boolean;
 }
 
 class GcUsageError extends Error {}
 
+function parsePositiveIntFlag(flag: string, raw: string | undefined): number {
+	if (raw === undefined || raw.trim() === "") throw new GcUsageError(`${flag}_requires_non_negative_integer`);
+	if (!/^\d+$/.test(raw.trim())) throw new GcUsageError(`${flag}_requires_non_negative_integer`);
+	const value = Number(raw.trim());
+	if (!Number.isInteger(value) || value < 0) throw new GcUsageError(`${flag}_requires_non_negative_integer`);
+	return value;
+}
+
 function parseGcArgs(argv: string[]): ParsedGcArgs {
 	let json = false;
 	let prune = false;
 	let repairSessionIndex = false;
+	let disk = false;
+	let nativesKeepVersions: number | undefined;
 
 	let dryRun = false;
 	let help = false;
-	for (const arg of argv) {
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i]!;
 		switch (arg) {
 			case "--json":
 			case "-j":
@@ -283,7 +308,15 @@ function parseGcArgs(argv: string[]): ParsedGcArgs {
 			case "--repair-session-index":
 				repairSessionIndex = true;
 				break;
-
+			case "--disk":
+				disk = true;
+				break;
+			case "--natives-keep-versions": {
+				const next = argv[i + 1];
+				nativesKeepVersions = parsePositiveIntFlag("--natives-keep-versions", next);
+				i++;
+				break;
+			}
 			case "--dry-run":
 				dryRun = true;
 				break;
@@ -292,14 +325,25 @@ function parseGcArgs(argv: string[]): ParsedGcArgs {
 				help = true;
 				break;
 			default:
+				if (arg.startsWith("--natives-keep-versions=")) {
+					nativesKeepVersions = parsePositiveIntFlag(
+						"--natives-keep-versions",
+						arg.slice("--natives-keep-versions=".length),
+					);
+					break;
+				}
 				throw new GcUsageError(`unknown_flag:${arg}`);
 		}
 	}
 	if (repairSessionIndex && prune) throw new GcUsageError("repair_session_index_cannot_combine_with_prune");
 	if (repairSessionIndex && dryRun) throw new GcUsageError("repair_session_index_cannot_combine_with_dry_run");
+	if (repairSessionIndex && disk) throw new GcUsageError("repair_session_index_cannot_combine_with_disk");
+	if (nativesKeepVersions !== undefined && !disk) {
+		throw new GcUsageError("natives_keep_versions_requires_disk");
+	}
 	// Explicit --dry-run always wins over --prune/--force.
 	if (dryRun) prune = false;
-	return { json, prune, repairSessionIndex, help };
+	return { json, prune, repairSessionIndex, disk, nativesKeepVersions, help };
 }
 
 /**
@@ -372,11 +416,17 @@ export async function collectGcReport(adapters: GcStoreAdapter[], ctx: GcContext
  * - hard discovery errors => 1 (both modes)
  * - prune mode with a failed intended removal => 1
  * - warnings alone never fail the run
+ * - disk pass discovery errors => 1
+ * - disk prune mode with a failed intended removal => 1
  * - otherwise => 0
  */
 export function computeExitCode(report: GcReport): number {
 	if (report.errors.length > 0) return 1;
 	if (!report.dry_run && report.counts.failed > 0) return 1;
+	if (report.disk) {
+		if (report.disk.errors.length > 0) return 1;
+		if (!report.disk.dry_run && report.disk.counts.failed > 0) return 1;
+	}
 	return 0;
 }
 
@@ -419,6 +469,7 @@ export async function runGjcGcCommand(
 	cwd: string = process.cwd(),
 	env: NodeJS.ProcessEnv = process.env,
 	adapters?: GcStoreAdapter[],
+	diskDeps?: GcDiskDeps,
 ): Promise<GcRunResult> {
 	let parsed: ParsedGcArgs;
 	try {
@@ -437,6 +488,59 @@ export async function runGjcGcCommand(
 	const report = await collectGcReport(resolvedAdapters, ctx, parsed.prune);
 	report.operation = parsed.repairSessionIndex ? "repair_session_index" : parsed.prune ? "prune" : "dry_run";
 	report.session_index = await collectSessionIndexHealth(parsed.repairSessionIndex, resolveGcAgentDir(env));
+
+	if (parsed.disk) {
+		try {
+			const options = await resolveGcDiskCollectOptions(
+				{
+					...diskDeps,
+					...(parsed.nativesKeepVersions !== undefined ? { keepVersions: parsed.nativesKeepVersions } : {}),
+				},
+				env,
+			);
+			report.disk = await collectGcDiskReport(options, parsed.prune);
+		} catch (error) {
+			// Fail closed: surface resolution failures without mutating disk state.
+			report.disk = {
+				dry_run: !parsed.prune,
+				policy: {
+					natives_keep_versions:
+						parsed.nativesKeepVersions ?? diskDeps?.keepVersions ?? DEFAULT_NATIVES_KEEP_VERSIONS,
+					natives_current_version: diskDeps?.currentNativesVersion ?? "unknown",
+					natives_dir: diskDeps?.nativesDir ?? env.GJC_NATIVES_DIR ?? "",
+				},
+				surfaces: { natives_versions: [] },
+				counts: {
+					discovered: 0,
+					kept: 0,
+					would_remove: 0,
+					removed: 0,
+					failed: 0,
+					reclaimable_bytes: 0,
+					reclaimed_bytes: 0,
+					by_surface: {
+						natives_versions: {
+							discovered: 0,
+							kept: 0,
+							would_remove: 0,
+							removed: 0,
+							failed: 0,
+							reclaimable_bytes: 0,
+							reclaimed_bytes: 0,
+						},
+					},
+				},
+				errors: [
+					{
+						surface: "natives_versions",
+						scope: "resolve",
+						message: error instanceof Error ? error.message : String(error),
+					},
+				],
+			};
+		}
+	}
+
 	const sessionIndexFailed =
 		report.session_index?.status === "corrupt" ||
 		report.session_index?.status === "unsupported" ||
@@ -448,20 +552,24 @@ export async function runGjcGcCommand(
 
 export function gcHelpText(): string {
 	return [
-		"gjc gc - garbage-collect stale GJC session/PID records",
+		"gjc gc - garbage-collect stale GJC session/PID records and optional disk caches",
 		"",
 		"USAGE",
-		"  $ gjc gc [--prune|--force] [--repair-session-index] [--json]",
-
+		"  $ gjc gc [--prune|--force] [--disk] [--natives-keep-versions <n>] [--repair-session-index] [--json]",
 		"",
 		"FLAGS",
-		"  --prune, --force  Actually remove stale records (default: dry-run report only)",
+		"  --prune, --force  Actually remove eligible records (default: dry-run report only)",
 		"  --dry-run         Force report-only mode (overrides --prune/--force)",
+		"  --disk            Opt-in disk-retention pass (natives version caches; dry-run unless --prune)",
+		"  --natives-keep-versions <n>  With --disk: keep current natives version plus <n> older predecessors (default: 2)",
 		"  -j, --json        Emit machine-readable JSON",
 		"  --repair-session-index  Explicitly quarantine a corrupt session-index suffix and retain its valid prefix",
 		"",
-		"Liveness-only: a record is removed only when its owning process is dead",
+		"Liveness: a PID-backed record is removed only when its owning process is dead",
 		"(ESRCH). Live / permission-denied / unknown processes are always kept.",
+		"",
+		"Disk (--disk): reclaims aged on-disk cache directories. First surface is",
+		"~/.gjc/natives/<version>/; sessions, blobs, backups, and worktrees are follow-ups.",
 		"",
 	].join("\n");
 }

--- a/packages/coding-agent/test/gc-disk.test.ts
+++ b/packages/coding-agent/test/gc-disk.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	collectGcDiskReport,
+	collectNativesVersionCandidates,
+	compareSemver,
+	formatBytes,
+	isOrderableSemver,
+	pruneNativesVersionCandidate,
+} from "@gajae-code/coding-agent/gjc-runtime/gc-disk";
+import { runGjcGcCommand } from "@gajae-code/coding-agent/gjc-runtime/gc-runtime";
+import { getAgentDir, setAgentDir } from "@gajae-code/utils";
+import { SessionIndex } from "../src/sdk/broker/session-index";
+
+const originalAgentDir = getAgentDir();
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	setAgentDir(originalAgentDir);
+	for (const dir of tempDirs.splice(0)) {
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+});
+
+async function makeTemp(prefix: string): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+async function seedVersionDir(nativesDir: string, version: string, payload = "x"): Promise<string> {
+	const dir = path.join(nativesDir, version);
+	await fs.mkdir(dir, { recursive: true });
+	await fs.writeFile(path.join(dir, "addon.node"), payload.repeat(100));
+	return dir;
+}
+
+async function seedHealthySessionIndex(): Promise<string> {
+	const agentDir = await makeTemp("gc-disk-session-index-");
+	setAgentDir(agentDir);
+	const index = await new SessionIndex(agentDir).open();
+	await index.append({
+		type: "host_registered",
+		sessionId: "gc-disk-session",
+		locator: { repo: "/tmp/repo", stateRoot: "/tmp/state" },
+		endpointGeneration: 1,
+		pid: process.pid,
+		endpointMtimeMs: Date.now(),
+	});
+	return agentDir;
+}
+
+describe("semver helpers", () => {
+	test("isOrderableSemver accepts release versions", () => {
+		expect(isOrderableSemver("0.12.12")).toBe(true);
+		expect(isOrderableSemver("1.0.0")).toBe(true);
+		expect(isOrderableSemver("not-a-version")).toBe(false);
+		expect(isOrderableSemver("")).toBe(false);
+	});
+
+	test("compareSemver orders ascending", () => {
+		expect(compareSemver("0.11.7", "0.11.8")).toBeLessThan(0);
+		expect(compareSemver("0.12.12", "0.11.8")).toBeGreaterThan(0);
+		expect(compareSemver("0.12.12", "0.12.12")).toBe(0);
+	});
+
+	test("formatBytes uses binary units", () => {
+		expect(formatBytes(512)).toBe("512 B");
+		expect(formatBytes(2048)).toBe("2 KiB");
+	});
+});
+
+describe("collectNativesVersionCandidates", () => {
+	test("keeps current and N older predecessors; excess is reclaimable", async () => {
+		const nativesDir = await makeTemp("gc-disk-natives-");
+		await seedVersionDir(nativesDir, "0.12.12", "current");
+		await seedVersionDir(nativesDir, "0.11.8", "keep1");
+		await seedVersionDir(nativesDir, "0.11.7", "keep2");
+		await seedVersionDir(nativesDir, "0.5.1", "drop");
+		await seedVersionDir(nativesDir, "0.4.0", "drop2");
+
+		const { candidates, errors } = await collectNativesVersionCandidates({
+			nativesDir,
+			currentNativesVersion: "0.12.12",
+			keepVersions: 2,
+		});
+		expect(errors).toEqual([]);
+
+		const byId = Object.fromEntries(candidates.map(c => [c.id, c]));
+		expect(byId["0.12.12"]?.removable).toBe(false);
+		expect(byId["0.12.12"]?.status).toBe("current");
+		expect(byId["0.11.8"]?.removable).toBe(false);
+		expect(byId["0.11.8"]?.status).toBe("retained_predecessor");
+		expect(byId["0.11.7"]?.removable).toBe(false);
+		expect(byId["0.5.1"]?.removable).toBe(true);
+		expect(byId["0.5.1"]?.action).toBe("would_remove");
+		expect(byId["0.4.0"]?.removable).toBe(true);
+		expect(byId["0.5.1"]?.bytes).toBeGreaterThan(0);
+	});
+
+	test("keepVersions=0 retains only the current version", async () => {
+		const nativesDir = await makeTemp("gc-disk-natives-keep0-");
+		await seedVersionDir(nativesDir, "0.12.12");
+		await seedVersionDir(nativesDir, "0.11.8");
+
+		const { candidates } = await collectNativesVersionCandidates({
+			nativesDir,
+			currentNativesVersion: "0.12.12",
+			keepVersions: 0,
+		});
+		const byId = Object.fromEntries(candidates.map(c => [c.id, c]));
+		expect(byId["0.12.12"]?.removable).toBe(false);
+		expect(byId["0.11.8"]?.removable).toBe(true);
+	});
+
+	test("keeps versions newer than current (fail-closed)", async () => {
+		const nativesDir = await makeTemp("gc-disk-natives-newer-");
+		await seedVersionDir(nativesDir, "0.12.12");
+		await seedVersionDir(nativesDir, "0.13.0");
+
+		const { candidates } = await collectNativesVersionCandidates({
+			nativesDir,
+			currentNativesVersion: "0.12.12",
+			keepVersions: 2,
+		});
+		const newer = candidates.find(c => c.id === "0.13.0");
+		expect(newer?.removable).toBe(false);
+		expect(newer?.status).toBe("newer_than_current");
+	});
+
+	test("keeps non-semver and non-directory entries", async () => {
+		const nativesDir = await makeTemp("gc-disk-natives-junk-");
+		await seedVersionDir(nativesDir, "0.12.12");
+		await fs.writeFile(path.join(nativesDir, "README"), "nope");
+		await fs.mkdir(path.join(nativesDir, "staging-tmp"), { recursive: true });
+
+		const { candidates } = await collectNativesVersionCandidates({
+			nativesDir,
+			currentNativesVersion: "0.12.12",
+			keepVersions: 2,
+		});
+		const readme = candidates.find(c => c.id === "README");
+		const staging = candidates.find(c => c.id === "staging-tmp");
+		expect(readme?.removable).toBe(false);
+		expect(staging?.removable).toBe(false);
+		expect(staging?.status).toBe("non_semver");
+	});
+
+	test("missing natives dir is empty, not an error", async () => {
+		const nativesDir = path.join(await makeTemp("gc-disk-missing-parent-"), "nope");
+		const { candidates, errors } = await collectNativesVersionCandidates({
+			nativesDir,
+			currentNativesVersion: "0.12.12",
+			keepVersions: 2,
+		});
+		expect(candidates).toEqual([]);
+		expect(errors).toEqual([]);
+	});
+});
+
+describe("pruneNativesVersionCandidate", () => {
+	test("removes excess predecessor and leaves current intact", async () => {
+		const nativesDir = await makeTemp("gc-disk-prune-");
+		const current = await seedVersionDir(nativesDir, "0.12.12");
+		// With keepVersions=2 these two newest predecessors are retained…
+		await seedVersionDir(nativesDir, "0.11.8");
+		await seedVersionDir(nativesDir, "0.11.7");
+		// …and anything older is excess.
+		const excess = await seedVersionDir(nativesDir, "0.5.1");
+
+		const { candidates } = await collectNativesVersionCandidates({
+			nativesDir,
+			currentNativesVersion: "0.12.12",
+			keepVersions: 2,
+		});
+		const target = candidates.find(c => c.id === "0.5.1");
+		expect(target?.removable).toBe(true);
+
+		const outcome = await pruneNativesVersionCandidate(target!, {
+			nativesDir,
+			currentNativesVersion: "0.12.12",
+		});
+		expect(outcome.removed).toBe(true);
+		expect(await fs.exists(excess)).toBe(false);
+		expect(await fs.exists(current)).toBe(true);
+	});
+
+	test("refuses path escape / current version", async () => {
+		const nativesDir = await makeTemp("gc-disk-prune-guard-");
+		await seedVersionDir(nativesDir, "0.12.12");
+		const outcome = await pruneNativesVersionCandidate(
+			{
+				surface: "natives_versions",
+				id: "0.12.12",
+				path: path.join(nativesDir, "0.12.12"),
+				bytes: 1,
+				status: "current",
+				removable: true,
+				action: "would_remove",
+				reason: "forced",
+			},
+			{ nativesDir, currentNativesVersion: "0.12.12" },
+		);
+		expect(outcome.removed).toBe(false);
+		expect(outcome.skipped).toBe("natives_current_version");
+	});
+});
+
+describe("collectGcDiskReport", () => {
+	test("dry-run marks would_remove without deleting", async () => {
+		const nativesDir = await makeTemp("gc-disk-report-");
+		const excess = await seedVersionDir(nativesDir, "0.1.0");
+		await seedVersionDir(nativesDir, "0.12.12");
+
+		const report = await collectGcDiskReport(
+			{ nativesDir, currentNativesVersion: "0.12.12", keepVersions: 0 },
+			false,
+		);
+		expect(report.dry_run).toBe(true);
+		expect(report.counts.would_remove).toBe(1);
+		expect(report.counts.reclaimable_bytes).toBeGreaterThan(0);
+		expect(await fs.exists(excess)).toBe(true);
+	});
+
+	test("prune removes excess and reports reclaimed bytes", async () => {
+		const nativesDir = await makeTemp("gc-disk-report-prune-");
+		const excess = await seedVersionDir(nativesDir, "0.1.0");
+		await seedVersionDir(nativesDir, "0.12.12");
+
+		const report = await collectGcDiskReport({ nativesDir, currentNativesVersion: "0.12.12", keepVersions: 0 }, true);
+		expect(report.dry_run).toBe(false);
+		expect(report.counts.removed).toBe(1);
+		expect(report.counts.reclaimed_bytes).toBeGreaterThan(0);
+		expect(await fs.exists(excess)).toBe(false);
+	});
+});
+
+describe("runGjcGcCommand --disk", () => {
+	test("without --disk, disk section is absent and natives stay untouched", async () => {
+		await seedHealthySessionIndex();
+		const nativesDir = await makeTemp("gc-disk-cli-absent-");
+		const excess = await seedVersionDir(nativesDir, "0.1.0");
+		await seedVersionDir(nativesDir, "0.12.12");
+
+		const result = await runGjcGcCommand(["--json", "--prune"], "/tmp", process.env, [], {
+			nativesDir,
+			currentNativesVersion: "0.12.12",
+			keepVersions: 0,
+		});
+		const report = JSON.parse(result.stdout);
+		expect(report.disk).toBeUndefined();
+		expect(await fs.exists(excess)).toBe(true);
+		expect(result.status).toBe(0);
+	});
+
+	test("--disk dry-run reports reclaimable natives without deleting", async () => {
+		await seedHealthySessionIndex();
+		const nativesDir = await makeTemp("gc-disk-cli-dry-");
+		const excess = await seedVersionDir(nativesDir, "0.1.0");
+		await seedVersionDir(nativesDir, "0.12.12");
+
+		const result = await runGjcGcCommand(["--disk", "--json"], "/tmp", process.env, [], {
+			nativesDir,
+			currentNativesVersion: "0.12.12",
+			keepVersions: 0,
+		});
+		expect(result.status).toBe(0);
+		const report = JSON.parse(result.stdout);
+		expect(report.disk?.dry_run).toBe(true);
+		expect(report.disk?.counts.would_remove).toBe(1);
+		expect(report.disk?.policy.natives_current_version).toBe("0.12.12");
+		expect(await fs.exists(excess)).toBe(true);
+	});
+
+	test("--disk --prune removes excess natives versions", async () => {
+		await seedHealthySessionIndex();
+		const nativesDir = await makeTemp("gc-disk-cli-prune-");
+		const excess = await seedVersionDir(nativesDir, "0.1.0");
+		const current = await seedVersionDir(nativesDir, "0.12.12");
+
+		const result = await runGjcGcCommand(["--disk", "--prune", "--json"], "/tmp", process.env, [], {
+			nativesDir,
+			currentNativesVersion: "0.12.12",
+			keepVersions: 0,
+		});
+		expect(result.status).toBe(0);
+		const report = JSON.parse(result.stdout);
+		expect(report.disk?.dry_run).toBe(false);
+		expect(report.disk?.counts.removed).toBe(1);
+		expect(await fs.exists(excess)).toBe(false);
+		expect(await fs.exists(current)).toBe(true);
+	});
+
+	test("--natives-keep-versions requires --disk", async () => {
+		const result = await runGjcGcCommand(["--natives-keep-versions", "1", "--json"], "/tmp", {}, []);
+		expect(result.status).toBe(2);
+		expect(result.stderr).toContain("natives_keep_versions_requires_disk");
+	});
+
+	test("text mode mentions disk retention when --disk is set", async () => {
+		await seedHealthySessionIndex();
+		const nativesDir = await makeTemp("gc-disk-cli-text-");
+		await seedVersionDir(nativesDir, "0.12.12");
+
+		const result = await runGjcGcCommand(["--disk"], "/tmp", process.env, [], {
+			nativesDir,
+			currentNativesVersion: "0.12.12",
+			keepVersions: 2,
+		});
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("Disk retention");
+		expect(result.stdout).toContain("Natives version caches");
+	});
+});


### PR DESCRIPTION
## Summary

Bounded first slice for #3853: add an **opt-in disk-retention axis** to `gjc gc` without redesigning the PID-liveness reaper.

- `gjc gc --disk` (dry-run by default) reports reclaimable bytes for the first surface: **`~/.gjc/natives/<version>/`**
- `gjc gc --disk --prune` deletes only excess older version dirs
- Policy: keep the **running** natives package version plus **N older predecessors** (`--natives-keep-versions`, default `2`)
- Fail-closed: current version, newer-than-current caches, non-semver names, unreadable entries are **kept**
- Without `--disk`, JSON/text/exit behavior of the liveness reaper is unchanged (no `disk` field)

### Intentionally out of scope (follow-ups)

| Surface | Why deferred |
| --- | --- |
| `agent/sessions` age/size | Needs live/reference oracle (leases, team workers, recent resume) |
| `agent/blobs` mark-and-sweep | Depends on safe session retirement |
| `~/.gjc/backups` / `*.bak` | Separate update-restore evidence path |
| `~/.gjc/wt` worktrees | Worktree CLI was deliberately removed; must stay evidence-based |

**Refs #3853** (partial; full multi-surface retention remains open).

## Usage

```sh
gjc gc --disk                 # report reclaimable natives versions
gjc gc --disk --json          # machine-readable report.disk
gjc gc --disk --prune         # delete excess versions
gjc gc --disk --natives-keep-versions 1 --prune --json
```

## Test plan

- [x] `bun test packages/coding-agent/test/gc-disk.test.ts` (17 tests)
- [x] `bun test packages/coding-agent/test/gc-runtime.test.ts` (liveness contract unchanged)
- [x] `bun test packages/coding-agent/test/gc-e2e.test.ts`
- [x] `bun test packages/coding-agent/test/gc-stores.test.ts`
- [x] `bun test packages/coding-agent/test/gc-redteam.test.ts`
- [ ] Manual: `gjc gc --disk --json` on a machine with multiple `~/.gjc/natives/*` versions; confirm current kept and reclaimable bytes match `du`

## Risks

- **Windows open-handle**: deleting a version still loaded by another process may fail; we report `remove_failed` and exit 1 in prune mode (fail-visible, not silent).
- **Version resolution**: current version is read from the installed `@gajae-code/natives` package.json (same key the loader uses for the versioned cache dir).
- **No settings schema yet**: only CLI `--natives-keep-versions`; settings keys from the issue remain a follow-up.