### PR TITLE
fix(agent): finish aborted non-cooperative tool batches

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2895,7 +2895,26 @@ async function executeToolCalls(
 		}
 	}
 
-	await Promise.allSettled(tasks);
+	const allTasks = Promise.allSettled(tasks);
+	if (!signal) {
+		await allTasks;
+	} else {
+		const abortPromise = Promise.withResolvers<boolean>();
+		const onAbort = () => abortPromise.resolve(true);
+		signal.addEventListener("abort", onAbort, { once: true });
+		try {
+			const aborted = signal.aborted || (await Promise.race([allTasks.then(() => false), abortPromise.promise]));
+			if (aborted) {
+				for (const record of records) {
+					if (record.toolResultMessage) continue;
+					record.skipped = true;
+					emitToolResult(record, createAbortedToolExecutionResult(), true);
+				}
+			}
+		} finally {
+			signal.removeEventListener("abort", onAbort);
+		}
+	}
 
 	for (const record of records) {
 		if (!record.toolResultMessage) {
@@ -2967,6 +2986,12 @@ function createAbortedToolResult(
 function createSkippedToolResult(): AgentToolResult<any> {
 	return {
 		content: [{ type: "text", text: "Skipped due to queued user message." }],
+		details: {},
+	};
+}
+function createAbortedToolExecutionResult(): AgentToolResult<any> {
+	return {
+		content: [{ type: "text", text: "Tool execution was aborted." }],
 		details: {},
 	};
 }

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1244,6 +1244,49 @@ describe("agentLoop with AgentMessage", () => {
 			expect(text).not.toContain("Tool execution was aborted.:");
 		}
 	});
+	it("does not wait forever for a non-cooperative tool after abort", async () => {
+		const toolSchema = z.object({ value: z.string() });
+		const abortController = new AbortController();
+		let toolStarted = false;
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "hang",
+			label: "Hang",
+			description: "Never settles",
+			parameters: toolSchema,
+			async execute() {
+				toolStarted = true;
+				abortController.abort();
+				return new Promise(() => {});
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "hang", arguments: { value: "x" } }] },
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+		const stream = agentLoop([createUserMessage("start")], context, config, abortController.signal, mock.stream);
+
+		const completion = (async () => {
+			for await (const _event of stream) {
+				// drain
+			}
+			return stream.result();
+		})();
+		const messages = await Promise.race([
+			completion,
+			new Promise<never>((_, reject) => setTimeout(() => reject(new Error("agent loop hung")), 1000)),
+		]);
+
+		expect(toolStarted).toBe(true);
+		const toolResult = messages.find(message => message.role === "toolResult");
+		expect(toolResult?.isError).toBe(true);
+		if (toolResult?.role === "toolResult") {
+			expect(toolResult.content).toEqual([{ type: "text", text: "Tool execution was aborted." }]);
+		}
+	});
 
 	it("should skip remaining tool calls when steering is queued", async () => {
 		const toolSchema = z.object({ value: z.string() });


### PR DESCRIPTION
## Summary

When an agent run was aborted while a tool ignored its `AbortSignal`, `executeToolCalls()` could wait forever at `Promise.allSettled(tasks)`. The TUI then remained on the last visible tool state, such as `Todo Write init`.

This change:
- races the tool batch against the run abort signal;
- emits an aborted tool result for unresolved calls;
- preserves the existing wait behavior for non-aborted runs;
- adds a regression test with a deliberately unresolved tool.

Closes #3895

## Verification

- `bun test packages/agent/test/agent-loop.test.ts`
- `bun --cwd=packages/agent run check`