### PR TITLE
fix(notifications): stop a failed reconciliation pass from exiting the Telegram daemon

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Made Telegram reference-client capability diagnostics safe for TUI embedding.
+- A Telegram notification daemon whose reconciliation pass fails no longer exits. The pass persists through the shared topic authority, and a momentarily unavailable authority (lock contention or a rejected compare-and-set) rejected out of both the scan timer and the run loop into the process-level fatal handler, killing the owner. Every session topic was then left behind as an unarchived shell that answers nothing — including for sessions that were still live and lost their notifications. The pass now reports the failure and the next scan interval retries it; the queue-flush timer is guarded the same way.
 - MiniMax M3 preset and profile ids canonicalized to `MiniMax-M3` (issue #3896): the `minimax` / `minimax-cn` onboarding presets and the `minimax-eco` / `minimax-medium` / `minimax-pro` builtin model profiles no longer reference the removed lowercase `minimax-m3` / `minimax-v3` first-class catalog ids.
 
 ## [0.12.12] - 2026-08-05

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon.ts
@@ -9556,7 +9556,11 @@ export class TelegramNotificationDaemon {
 	private startFlushTimer(): void {
 		this.runtime.startInterval("telegram-flush", RATE_LIMIT_FLUSH_INTERVAL_MS, () => {
 			if (!this.running || this.pool.pending === 0) return;
-			void this.flushPool();
+			// `flushPool` only swallows failures for the shared chain; the promise it
+			// returns still rejects, and an unhandled rejection here exits the daemon.
+			void this.flushPool().catch(error => {
+				logger.warn(`notifications: queue flush failed: ${sanitizeDiagnostic(String(error), this.opts.botToken)}`);
+			});
 		});
 	}
 
@@ -9596,11 +9600,27 @@ export class TelegramNotificationDaemon {
 		this.runtime.stopInterval("telegram-owner-heartbeat");
 	}
 
-	/** Run a root scan, guarding against overlapping scans from the timer + loop. */
+	/**
+	 * Run a root scan, guarding against overlapping scans from the timer + loop.
+	 *
+	 * A reconciliation pass is retried every scan interval, so a failed one must
+	 * never tear the owner down. Both callers are fatal boundaries: the timer
+	 * fires and forgets, and the run loop awaits without a handler. A rejection
+	 * escaping either one (a shared topic authority whose lock or compare-and-set
+	 * is momentarily unavailable is the observed case) reaches the process-level
+	 * handler, which exits the daemon: every session topic is then left as an
+	 * unarchived shell that answers nothing, and the sessions that were still
+	 * live lose notifications too. Report the failure and let the next scan
+	 * retry instead.
+	 */
 	private async runScan(): Promise<void> {
-		await this.runtime.runExclusive("telegram-scan", async () => {
-			await this.scanRoots();
-		});
+		try {
+			await this.runtime.runExclusive("telegram-scan", async () => {
+				await this.scanRoots();
+			});
+		} catch (error) {
+			logger.warn(`notifications: session scan failed: ${sanitizeDiagnostic(String(error), this.opts.botToken)}`);
+		}
 	}
 
 	private startScanTimer(): void {

--- a/packages/coding-agent/test/notifications-telegram-daemon.test.ts
+++ b/packages/coding-agent/test/notifications-telegram-daemon.test.ts
@@ -22418,3 +22418,93 @@ test("CAS winner advance after accepted create publishes the exact archive fence
 		[2],
 	);
 });
+
+test("a failed root scan is retried on the next tick instead of exiting the daemon owner", async () => {
+	// A dead session's topic is archived by the scan pass, and that pass persists
+	// through the shared topic authority. When the authority is momentarily
+	// unavailable the rejection used to escape the scan timer and the run loop,
+	// reach the process-level fatal handler, and exit the owner: every topic was
+	// then left behind as an unarchived shell that answers nothing.
+	const warn = spyOn(logger, "warn").mockImplementation(() => {});
+	const escaped: unknown[] = [];
+	const onEscape = (reason: any): void => void escaped.push(reason?.stack ?? String(reason));
+	process.on("unhandledRejection", onEscape);
+	const ticks: Array<() => void> = [];
+	let compareAndSetCalls = 0;
+	let armed = false;
+	let state = {
+		version: 2 as const,
+		registryGeneration: 1,
+		topics: {
+			S: {
+				topicId: "700",
+				topicOrigin: "daemon_created" as const,
+				sessionUuid: "dead-session",
+				identitySent: true,
+				createdAt: 1,
+				authorityEpoch: 0,
+				authorityState: "active" as const,
+				chatId: "42",
+				endpointKey: "ws://dead-endpoint|dead-token",
+				endpointDigest: "dead-digest",
+				endpointGeneration: 1,
+			},
+		},
+	};
+	const authority = {
+		read: async () => state,
+		compareAndSet: async (_expectedGeneration: number, next: any) => {
+			if (!armed) {
+				state = next;
+				return true;
+			}
+			compareAndSetCalls++;
+			throw new Error("shared topic authority unavailable");
+		},
+	};
+	const daemon = new TelegramNotificationDaemon({
+		settings: settings(tempAgentDir()),
+		ownerId: "owner",
+		botToken: "token",
+		chatId: "42",
+		botApi: new FakeBotApi(),
+		installationHostId: "local-host",
+		topicRegistryAuthority: authority as never,
+		setIntervalImpl: ((tick: () => void) => {
+			ticks.push(tick);
+			return 0;
+		}) as never,
+		clearIntervalImpl: (() => {}) as never,
+	});
+	try {
+		await daemon.loadTopics();
+		expect((daemon as any).topics.get("S")?.topicId).toBe("700");
+		armed = true;
+		(daemon as any).running = true;
+		(daemon as any).startScanTimer();
+		expect(ticks).toHaveLength(1);
+
+		const settle = async (): Promise<void> => {
+			for (let i = 0; i < 50; i++) await new Promise(resolve => setTimeout(resolve, 1));
+		};
+
+		const scan = spyOn(daemon, "scanRoots");
+		ticks[0]!();
+		await settle();
+		// The pass reached the shared authority, failed, and reported the failure
+		// instead of letting the rejection reach the process-level fatal handler.
+		expect(compareAndSetCalls).toBeGreaterThanOrEqual(1);
+		expect(warn.mock.calls.some(call => String(call[0]).includes("session scan failed"))).toBe(true);
+		expect(escaped).toEqual([]);
+		// The owner is still running, so the next interval retries the same pass.
+		expect((daemon as any).running).toBe(true);
+		ticks[0]!();
+		await settle();
+		expect(scan.mock.calls).toHaveLength(2);
+		expect(escaped).toEqual([]);
+		scan.mockRestore();
+	} finally {
+		process.off("unhandledRejection", onEscape);
+		warn.mockRestore();
+	}
+});


### PR DESCRIPTION
## What

A Telegram notification daemon whose reconciliation pass fails no longer exits the owner process. `runScan()` now reports the failure and lets the next scan interval retry it, and the queue-flush timer's fire-and-forget promise is handled the same way.

## Why

The scan pass archives topics whose session is gone, and that archive persists through the shared topic authority. A momentarily unavailable authority (lock contention, or a compare-and-set that cannot complete) rejected out of **both** unguarded callers:

- `startScanTimer`: `void this.runScan()` — fire-and-forget, no handler.
- `run`: `await this.runScan()` — awaited inside the loop with no `try`.

Either one reaches `process.on("unhandledRejection" | "uncaughtException")` in `packages/utils/src/postmortem.ts`, which calls `process.exit(1)`. The ownership-heartbeat and adoption-sweep timers already `.catch()`; these two did not.

Observed on a live installation, not inferred. After a session host was killed (a closed tmux window), `notifications/daemon.log` recorded two consecutive daemon generations dying seconds apart:

```text
2026-08-05T23:14:23.672Z pid=732571 [Unhandled Rejection] Error: shared topic authority unavailable
    at .../sdk/bus/telegram-daemon.ts:8379:16
2026-08-05T23:16:17.656Z pid=735076 [Uncaught Exception] Error: shared topic authority unavailable
    at .../sdk/bus/telegram-daemon.ts:8379:16
```

`telegram-daemon.heartbeat.json` stops at the second timestamp, that pid is gone, and `telegram-topics.json` still held two topics stuck in `disconnect_grace` 20+ minutes later — `ORPHAN_TOPIC_GRACE_MS` is 60s, and `orphanedAt` for one of them is the crash instant. With no owner, those topics are exactly the reported symptom: an empty-shell thread that is never archived and answers nothing. Sessions that were still live lost their notifications at the same moment, because the whole owner went down.

This is deliberately scoped to the fatal boundary. The underlying authority contention (a 5s `withFileLock` budget: 50 retries x 100ms) is a separate question; a daemon that survives it retries every scan interval and converges, whereas a daemon that exits cannot.

`run` is a protected declaration in `scripts/telegram-daemon-generation-manifest.json`, so the guard is inside `runScan` and `run` is byte-identical to `dev`. No `DAEMON_GENERATION` bump is owed (`v43 no protected changes`), which also keeps this off the 52/53 generation queue held by #3844 and #3899.

## Testing

- New regression test, `notifications-telegram-daemon.test.ts`: a loaded topic whose session has no endpoint, plus a shared authority whose `compareAndSet` rejects. Firing the scan-timer tick reaches the authority, logs `session scan failed`, records **no** `unhandledRejection`, leaves `running === true`, and the next tick runs the pass again. Verified failing on `dev` (the rejection escapes and bun reports `shared topic authority unavailable`) and passing with the fix.
- `bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts packages/coding-agent/test/notifications-topic-registry.test.ts` → 607 pass, 0 fail.
- `bun test packages/coding-agent/test/notifications-telegram-daemon-2960-redteam.test.ts packages/coding-agent/test/sdk-host-wiring.test.ts` → 84 pass, 0 fail.
- `bun scripts/telegram-daemon-generation-guard.ts` (base `11e48d5bc`, head `edd15f917`) → `v43 no protected changes`.
- `tsc --noEmit -p packages/coding-agent/tsconfig.json` clean; `biome check` clean on both touched files.

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:edd15f9172e4229ed437ff78eefbbf6c62ddc2b9 reviewer:human evidence:local bun test packages/coding-agent/test/notifications-telegram-daemon.test.ts (607 pass) + notifications/daemon.log crash evidence quoted above
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (full `bun check` not run locally; focused suites, typecheck, biome, and the daemon generation guard are green — CI covers the rest)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
