### PR TITLE
fix(ai): add explicit Responses relay session affinity

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -774,6 +774,7 @@ Request shaping:
 - `supportsStore` — emit `store: false` on requests. Default: auto (off for non-standard endpoints).
 - `supportsDeveloperRole` — use the `developer` system role for reasoning models instead of `system`. Default: auto.
 - `sendSessionHeaders` — forward the agent session id as `session_id` and `x-session-id` request headers so OpenAI-compatible relays/proxies can do session-affinity routing and reuse a server-side prompt cache. Default: `false`. Caller-set `headers`/`requestTransform` values are never overwritten.
+- `supportsResponsesSessionAffinity` — for `openai-responses`, opt in to forwarding `session_id` and `x-client-request-id` affinity headers to a custom OpenAI-compatible relay. Canonical OpenAI routing remains automatic; known non-OpenAI provider IDs are rejected. Default: `false`.
 - `supportsUsageInStreaming` — send `stream_options: { include_usage: true }` to receive token usage on streaming responses. Default: `true`.
 - `maxTokensField` — `"max_completion_tokens"` or `"max_tokens"`. Default: auto.
 - `supportsToolChoice` — emit the `tool_choice` parameter when the caller forces a specific tool. Default: `true`. Set `false` for endpoints that 400 on `tool_choice` (e.g. DeepSeek when reasoning is on).

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added opt-in `compat.supportsResponsesSessionAffinity` for OpenAI Responses custom relays. When enabled, supported `openai-responses` models may send `session_id` and `x-client-request-id` affinity headers to a custom endpoint; canonical OpenAI routing remains automatic and known non-OpenAI provider IDs remain excluded.
 
 ### Fixed
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -782,6 +782,7 @@ interface OpenAICompat {
 	supportsStore?: boolean; // Whether provider supports the `store` field (default: true)
 	supportsDeveloperRole?: boolean; // Whether provider supports `developer` role vs `system` (default: true)
 	sendSessionHeaders?: boolean; // Forward the session id as `session_id`/`x-session-id` headers for relay session-affinity & prompt-cache reuse (default: false)
+	supportsResponsesSessionAffinity?: boolean; // Opt in to session-affinity headers for custom openai-responses relays; canonical OpenAI routing is automatic (default: false)
 	supportsReasoningEffort?: boolean; // Whether provider supports `reasoning_effort` (default: true)
 	maxTokensField?: "max_completion_tokens" | "max_tokens"; // Which field name to use (default: max_completion_tokens)
 	extraBody?: Record<string, unknown>; // Extra request-body fields for custom proxy routing or provider-specific options

--- a/packages/ai/src/providers/openai-completions-compat.ts
+++ b/packages/ai/src/providers/openai-completions-compat.ts
@@ -6,13 +6,19 @@ type ResolvedToolStrictMode = NonNullable<OpenAICompat["toolStrictMode"]> | "mix
 export type ResolvedOpenAICompat = Required<
 	Omit<
 		OpenAICompat,
-		"openRouterRouting" | "vercelGatewayRouting" | "extraBody" | "toolStrictMode" | "toolChoiceSupport"
+		| "openRouterRouting"
+		| "vercelGatewayRouting"
+		| "extraBody"
+		| "toolStrictMode"
+		| "toolChoiceSupport"
+		| "supportsResponsesSessionAffinity"
 	>
 > & {
 	openRouterRouting?: OpenAICompat["openRouterRouting"];
 	vercelGatewayRouting?: OpenAICompat["vercelGatewayRouting"];
 	extraBody?: OpenAICompat["extraBody"];
 	toolStrictMode: ResolvedToolStrictMode;
+	supportsResponsesSessionAffinity?: OpenAICompat["supportsResponsesSessionAffinity"];
 	/** Optional explicit capability override; resolved via deriveToolChoiceSupport. */
 	toolChoiceSupport?: OpenAICompat["toolChoiceSupport"];
 };
@@ -204,6 +210,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 		supportsStore: !isNonStandard,
 		supportsDeveloperRole: !isNonStandard,
 		sendSessionHeaders: false,
+		supportsResponsesSessionAffinity: false,
 		supportsMultipleSystemMessages: supportsMultipleSystemMessagesDefault,
 		supportsReasoningEffort: !isGrok && !isZai,
 		reasoningEffortMap,
@@ -270,6 +277,10 @@ export function resolveOpenAICompat(
 		supportsStore: model.compat.supportsStore ?? detected.supportsStore,
 		supportsDeveloperRole: model.compat.supportsDeveloperRole ?? detected.supportsDeveloperRole,
 		sendSessionHeaders: model.compat.sendSessionHeaders ?? detected.sendSessionHeaders,
+		supportsResponsesSessionAffinity:
+			("supportsResponsesSessionAffinity" in model.compat
+				? model.compat.supportsResponsesSessionAffinity
+				: undefined) ?? detected.supportsResponsesSessionAffinity,
 		supportsMultipleSystemMessages:
 			model.compat.supportsMultipleSystemMessages ?? detected.supportsMultipleSystemMessages,
 		supportsReasoningEffort: model.compat.supportsReasoningEffort ?? detected.supportsReasoningEffort,

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -178,7 +178,11 @@ function shouldSendOpenAIResponsesSessionHeaders(
 	if (cacheRetention === "none" || isKnownProvider(model.provider)) {
 		return false;
 	}
-	return model.compat?.supportsResponsesSessionAffinity === true && !isCanonicalOpenAIAffinityOrigin(baseUrl);
+	return (
+		Boolean(baseUrl?.trim()) &&
+		model.compat?.supportsResponsesSessionAffinity === true &&
+		!isCanonicalOpenAIAffinityOrigin(baseUrl)
+	);
 }
 
 function isOpenAIHostBaseUrl(baseUrl: string): boolean {

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -137,7 +137,10 @@ const OPENAI_DEFAULT_BASE_URL_HOST = "api.openai.com";
 function isDefaultOpenAIBaseUrl(baseUrl: string): boolean {
 	try {
 		const url = new URL(baseUrl);
-		return url.hostname === OPENAI_DEFAULT_BASE_URL_HOST && (url.pathname === "" || url.pathname === "/v1");
+		return (
+			url.hostname === OPENAI_DEFAULT_BASE_URL_HOST &&
+			(url.pathname === "" || url.pathname === "/" || url.pathname === "/v1")
+		);
 	} catch {
 		return baseUrl === OPENAI_DEFAULT_BASE_URL;
 	}
@@ -151,7 +154,7 @@ function isCanonicalOpenAIAffinityOrigin(baseUrl: string | undefined): boolean {
 			url.origin === "https://api.openai.com" &&
 			url.username === "" &&
 			url.password === "" &&
-			(url.pathname === "" || url.pathname === "/v1") &&
+			(url.pathname === "" || url.pathname === "/" || url.pathname === "/v1") &&
 			url.search === "" &&
 			url.hash === ""
 		);
@@ -178,7 +181,7 @@ function shouldSendOpenAIResponsesSessionHeaders(
 	if (cacheRetention === "none" || isKnownProvider(model.provider)) {
 		return false;
 	}
-	return model.compat?.supportsResponsesSessionAffinity === true;
+	return model.compat?.supportsResponsesSessionAffinity === true && !isCanonicalOpenAIAffinityOrigin(baseUrl);
 }
 
 function isOpenAIHostBaseUrl(baseUrl: string): boolean {

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -12,6 +12,7 @@ import {
 	type CacheRetention,
 	type Context,
 	type FetchImpl,
+	isKnownProvider,
 	type MessageAttribution,
 	type Model,
 	type OpenAICompat,
@@ -21,7 +22,6 @@ import {
 	type StreamOptions,
 	type Tool,
 	type ToolChoice,
-	isKnownProvider,
 } from "../types";
 import {
 	createOpenAIResponsesHistoryPayload,
@@ -570,11 +570,7 @@ function createClient(
 		headers.session_id ??= sessionId;
 		headers["x-client-request-id"] ??= sessionId;
 	}
-	headers = applyOpenAIRequestTransformHeaders(
-		headers,
-		model.requestTransform,
-		`Gajae-Code/${packageJson.version}`,
-	);
+	headers = applyOpenAIRequestTransformHeaders(headers, model.requestTransform, `Gajae-Code/${packageJson.version}`);
 	const { baseUrl: clientBaseUrl, query: endpointQuery } = splitBaseUrlQuery(baseUrl);
 	const baseFetch = fetchOverride ?? fetch;
 	const queryFetch = Object.assign(

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -7,20 +7,21 @@ import type {
 } from "openai/resources/responses/responses";
 import packageJson from "../../package.json" with { type: "json" };
 import { getEnvApiKey } from "../stream";
-import type {
-	AssistantMessage,
-	CacheRetention,
-	Context,
-	FetchImpl,
-	MessageAttribution,
-	Model,
-	OpenAICompat,
-	ProviderSessionState,
-	ServiceTier,
-	StreamFunction,
-	StreamOptions,
-	Tool,
-	ToolChoice,
+import {
+	type AssistantMessage,
+	type CacheRetention,
+	type Context,
+	type FetchImpl,
+	type MessageAttribution,
+	type Model,
+	type OpenAICompat,
+	type ProviderSessionState,
+	type ServiceTier,
+	type StreamFunction,
+	type StreamOptions,
+	type Tool,
+	type ToolChoice,
+	isKnownProvider,
 } from "../types";
 import {
 	createOpenAIResponsesHistoryPayload,
@@ -140,6 +141,44 @@ function isDefaultOpenAIBaseUrl(baseUrl: string): boolean {
 	} catch {
 		return baseUrl === OPENAI_DEFAULT_BASE_URL;
 	}
+}
+
+function isCanonicalOpenAIAffinityOrigin(baseUrl: string | undefined): boolean {
+	if (!baseUrl) return false;
+	try {
+		const url = new URL(baseUrl);
+		return (
+			url.origin === "https://api.openai.com" &&
+			url.username === "" &&
+			url.password === "" &&
+			(url.pathname === "" || url.pathname === "/v1") &&
+			url.search === "" &&
+			url.hash === ""
+		);
+	} catch {
+		return false;
+	}
+}
+/**
+ * Official OpenAI keeps its existing session-routing behavior even when prompt
+ * caching is disabled. Relay affinity is opt-in, cache-enabled, and limited to
+ * explicitly supported openai or unknown provider ids so known non-target
+ * transports cannot inherit the headers.
+ */
+
+function shouldSendOpenAIResponsesSessionHeaders(
+	model: Model<"openai-responses">,
+	baseUrl: string | undefined,
+	cacheRetention: CacheRetention,
+): boolean {
+	if (model.provider === "openai") {
+		if (isCanonicalOpenAIAffinityOrigin(baseUrl)) return true;
+		return cacheRetention !== "none" && model.compat?.supportsResponsesSessionAffinity === true;
+	}
+	if (cacheRetention === "none" || isKnownProvider(model.provider)) {
+		return false;
+	}
+	return model.compat?.supportsResponsesSessionAffinity === true;
 }
 
 function isOpenAIHostBaseUrl(baseUrl: string): boolean {
@@ -305,6 +344,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 		try {
 			// Keep request headers and prompt-cache routing on the same session-derived value.
 			const cacheSessionId = getOpenAIResponsesCacheSessionId(options);
+			const cacheRetention = resolveCacheRetention(options?.cacheRetention ?? model.cacheRetention);
 			const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
 			const { client, copilotPremiumRequests, baseUrl, requestBaseUrl, requestQuery } = createClient(
 				model,
@@ -313,6 +353,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 				options?.headers,
 				options?.initiatorOverride,
 				cacheSessionId,
+				cacheRetention,
 				options?.onSseEvent,
 				options?.fetch,
 				options?.authCredentialType,
@@ -323,7 +364,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 			);
 			const premiumRequestsTotal = copilotPremiumRequests;
 			const providerSessionState = getOpenAIResponsesProviderSessionState(model, options?.providerSessionState);
-			const { params } = buildParams(model, context, options, providerSessionState, baseUrl);
+			const { params } = buildParams(model, context, options, providerSessionState, cacheRetention, baseUrl);
 			const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getOpenAIStreamIdleTimeoutMs();
 			options?.onPayload?.(params, undefined, options?.attemptScope);
 			rawRequestDump = {
@@ -469,6 +510,7 @@ function createClient(
 	extraHeaders?: Record<string, string>,
 	initiatorOverride?: MessageAttribution,
 	sessionId?: string,
+	cacheRetention?: CacheRetention,
 	onSseEvent?: OpenAIResponsesOptions["onSseEvent"],
 	fetchOverride?: FetchImpl,
 	authCredentialType?: OpenAIResponsesOptions["authCredentialType"],
@@ -502,11 +544,6 @@ function createClient(
 				// `{...default, ...customHeaders}`). #3557.
 				mergeDashScopeTokenPlanHeaders({ ...(model.headers ?? {}), ...(extraHeaders ?? {}) })
 			: { ...(model.headers ?? {}), ...(extraHeaders ?? {}) };
-	const headers = applyOpenAIRequestTransformHeaders(
-		baseHeaders,
-		model.requestTransform,
-		`Gajae-Code/${packageJson.version}`,
-	);
 	let copilotPremiumRequests: number | undefined;
 
 	let baseUrl =
@@ -514,6 +551,7 @@ function createClient(
 	if (model.provider === "openai" && !baseUrl) {
 		baseUrl = OPENAI_DEFAULT_BASE_URL;
 	}
+	let headers = baseHeaders;
 	if (model.provider === "github-copilot") {
 		apiKey = parseGitHubCopilotApiKey(rawApiKey).accessToken;
 		const hasImages = hasCopilotVisionInput(context.messages);
@@ -528,10 +566,15 @@ function createClient(
 		copilotPremiumRequests = copilot.premiumRequests;
 		baseUrl = resolveGitHubCopilotBaseUrl(model.baseUrl, rawApiKey) ?? model.baseUrl;
 	}
-	if (sessionId && model.provider === "openai" && (!model.baseUrl || (baseUrl && isDefaultOpenAIBaseUrl(baseUrl)))) {
+	if (sessionId && shouldSendOpenAIResponsesSessionHeaders(model, baseUrl, cacheRetention ?? "short")) {
 		headers.session_id ??= sessionId;
 		headers["x-client-request-id"] ??= sessionId;
 	}
+	headers = applyOpenAIRequestTransformHeaders(
+		headers,
+		model.requestTransform,
+		`Gajae-Code/${packageJson.version}`,
+	);
 	const { baseUrl: clientBaseUrl, query: endpointQuery } = splitBaseUrlQuery(baseUrl);
 	const baseFetch = fetchOverride ?? fetch;
 	const queryFetch = Object.assign(
@@ -579,6 +622,7 @@ function buildParams(
 	context: Context,
 	options: OpenAIResponsesOptions | undefined,
 	providerSessionState: OpenAIResponsesProviderSessionState | undefined,
+	cacheRetention: CacheRetention,
 	resolvedBaseUrl?: string,
 ): { conversationMessages: ResponseInput; params: OpenAIResponsesSamplingParams } {
 	const strictResponsesPairing =
@@ -621,7 +665,6 @@ function buildParams(
 		}
 	}
 
-	const cacheRetention = resolveCacheRetention(options?.cacheRetention ?? model.cacheRetention);
 	const promptCacheKey = getOpenAIResponsesCacheSessionId(options);
 	const params: OpenAIResponsesSamplingParams = {
 		model: model.wireModelId ?? model.id,

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -137,10 +137,7 @@ const OPENAI_DEFAULT_BASE_URL_HOST = "api.openai.com";
 function isDefaultOpenAIBaseUrl(baseUrl: string): boolean {
 	try {
 		const url = new URL(baseUrl);
-		return (
-			url.hostname === OPENAI_DEFAULT_BASE_URL_HOST &&
-			(url.pathname === "" || url.pathname === "/" || url.pathname === "/v1")
-		);
+		return url.hostname === OPENAI_DEFAULT_BASE_URL_HOST && (url.pathname === "" || url.pathname === "/v1");
 	} catch {
 		return baseUrl === OPENAI_DEFAULT_BASE_URL;
 	}

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -113,64 +113,73 @@ export interface ThinkingConfig {
 	mode: ThinkingControlMode;
 }
 
-export type KnownProvider =
-	| "alibaba-token-plan"
-	| "amazon-bedrock"
-	| "azure-openai"
-	| "anthropic"
-	| "google"
-	| "google-gemini-cli"
-	| "google-antigravity"
-	| "google-vertex"
-	| "openai"
-	| "openai-codex"
-	| "opencodex"
-	| "kimi-code"
-	| "minimax-code"
-	| "minimax-code-cn"
-	| "github-copilot"
-	| "fireworks"
-	| "firepass"
-	| "fugu"
-	| "gitlab-duo"
-	| "cursor"
-	| "deepseek"
-	| "deepinfra"
-	| "xai"
-	| "groq"
-	| "cerebras"
-	| "openrouter"
-	| "kilo"
-	| "vercel-ai-gateway"
-	| "zai"
-	| "glm-zcode"
-	| "mistral"
-	| "minimax"
-	| "opencode-go"
-	| "opencode-zen"
-	| "opengateway"
-	| "bizrouter"
-	| "mara"
-	| "synthetic"
-	| "cloudflare-ai-gateway"
-	| "huggingface"
-	| "litellm"
-	| "moonshot"
-	| "nvidia"
-	| "nanogpt"
-	| "ollama"
-	| "ollama-cloud"
-	| "qianfan"
-	| "qwen-portal"
-	| "together"
-	| "venice"
-	| "vllm"
-	| "xiaomi"
-	| "xiaomi-token-plan-sgp"
-	| "xiaomi-token-plan-ams"
-	| "xiaomi-token-plan-cn"
-	| "zenmux"
-	| "lm-studio";
+export const KNOWN_PROVIDERS = [
+	"alibaba-token-plan",
+	"amazon-bedrock",
+	"azure-openai",
+	"anthropic",
+	"google",
+	"google-gemini-cli",
+	"google-antigravity",
+	"google-vertex",
+	"openai",
+	"openai-codex",
+	"opencodex",
+	"kimi-code",
+	"minimax-code",
+	"minimax-code-cn",
+	"github-copilot",
+	"fireworks",
+	"firepass",
+	"fugu",
+	"gitlab-duo",
+	"cursor",
+	"deepseek",
+	"deepinfra",
+	"xai",
+	"groq",
+	"cerebras",
+	"openrouter",
+	"kilo",
+	"vercel-ai-gateway",
+	"zai",
+	"glm-zcode",
+	"mistral",
+	"minimax",
+	"opencode-go",
+	"opencode-zen",
+	"opengateway",
+	"bizrouter",
+	"mara",
+	"synthetic",
+	"cloudflare-ai-gateway",
+	"huggingface",
+	"litellm",
+	"moonshot",
+	"nvidia",
+	"nanogpt",
+	"ollama",
+	"ollama-cloud",
+	"qianfan",
+	"qwen-portal",
+	"together",
+	"venice",
+	"vllm",
+	"xiaomi",
+	"xiaomi-token-plan-sgp",
+	"xiaomi-token-plan-ams",
+	"xiaomi-token-plan-cn",
+	"zenmux",
+	"lm-studio",
+] as const;
+
+export type KnownProvider = (typeof KNOWN_PROVIDERS)[number];
+
+const KNOWN_PROVIDER_SET = new Set<string>(KNOWN_PROVIDERS);
+
+export function isKnownProvider(provider: string): provider is KnownProvider {
+	return KNOWN_PROVIDER_SET.has(provider);
+}
 export type Provider = KnownProvider | string;
 
 import type { Effort } from "./model-thinking";
@@ -852,6 +861,13 @@ export interface OpenAICompat extends ToolChoiceCompat {
 	 * caller already set via `headers`/`requestTransform`.
 	 */
 	sendSessionHeaders?: boolean;
+	/**
+	 * Whether an OpenAI Responses transport may forward the agent session id
+	 * as `session_id` and `x-client-request-id` affinity headers for an
+	 * explicitly configured custom relay. First-party OpenAI uses its canonical
+	 * HTTPS origin automatically; known non-OpenAI providers remain excluded.
+	 */
+	supportsResponsesSessionAffinity?: boolean;
 	/**
 	 * Whether the provider's chat-completions endpoint accepts multiple
 	 * leading `system`/`developer` messages. When false, ordered system

--- a/packages/ai/test/composer-discipline.test.ts
+++ b/packages/ai/test/composer-discipline.test.ts
@@ -24,6 +24,7 @@ const compat: Required<OpenAICompat> = {
 	supportsStore: true,
 	supportsDeveloperRole: false,
 	sendSessionHeaders: false,
+	supportsResponsesSessionAffinity: false,
 	supportsMultipleSystemMessages: true,
 	supportsReasoningEffort: false,
 	reasoningEffortMap: {},

--- a/packages/ai/test/issue-967-vision-guard.test.ts
+++ b/packages/ai/test/issue-967-vision-guard.test.ts
@@ -23,6 +23,7 @@ const compat: Required<OpenAICompat> = {
 	supportsStore: true,
 	supportsDeveloperRole: true,
 	sendSessionHeaders: false,
+	supportsResponsesSessionAffinity: false,
 	supportsMultipleSystemMessages: true,
 	supportsReasoningEffort: true,
 	reasoningEffortMap: {},

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -72,6 +72,7 @@ describe("openai-completions compatibility", () => {
 			supportsStore: true,
 			supportsDeveloperRole: true,
 			sendSessionHeaders: false,
+			supportsResponsesSessionAffinity: false,
 			supportsMultipleSystemMessages: true,
 			supportsReasoningEffort: true,
 			reasoningEffortMap: {},

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -16,6 +16,7 @@ const compat: Required<OpenAICompat> = {
 	supportsStore: true,
 	supportsDeveloperRole: true,
 	sendSessionHeaders: false,
+	supportsResponsesSessionAffinity: false,
 	supportsMultipleSystemMessages: true,
 	supportsReasoningEffort: true,
 	reasoningEffortMap: {},

--- a/packages/ai/test/openai-responses-cache-affinity.test.ts
+++ b/packages/ai/test/openai-responses-cache-affinity.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { getBundledModel } from "../src/models";
 import { type OpenAIResponsesOptions, streamOpenAIResponses } from "../src/providers/openai-responses";
-import type { Context, Model } from "../src/types";
+import type { AssistantMessage, Context, Model, ProviderSessionState } from "../src/types";
+import { createOpenAIResponsesHistoryPayload } from "../src/utils";
 
 const originalFetch = global.fetch;
 const model = getBundledModel("openai", "gpt-5-mini") as Model<"openai-responses">;
@@ -21,11 +22,18 @@ function getHeader(headers: RequestInit["headers"], name: string): string | null
 async function captureOpenAIResponseHeaders(
 	options: OpenAIResponsesOptions,
 	modelOverride: Model<"openai-responses"> = model,
-): Promise<{ sessionId: string | null; clientRequestId: string | null; body: Record<string, unknown> | null }> {
+	contextOverride?: Context,
+): Promise<{
+	sessionId: string | null;
+	clientRequestId: string | null;
+	body: Record<string, unknown> | null;
+	message: AssistantMessage | null;
+}> {
 	const captured = {
 		sessionId: null as string | null,
 		clientRequestId: null as string | null,
 		body: null as Record<string, unknown> | null,
+		message: null as AssistantMessage | null,
 	};
 	const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
 		captured.sessionId = getHeader(init?.headers, "session_id");
@@ -64,14 +72,18 @@ async function captureOpenAIResponseHeaders(
 	});
 	global.fetch = Object.assign(fetchMock, { preconnect: originalFetch.preconnect }) as typeof fetch;
 
-	const context: Context = {
+	const context: Context = contextOverride ?? {
 		systemPrompt: ["stable system", "stable durable context"],
 		messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
 	};
 	const stream = streamOpenAIResponses(modelOverride, context, { apiKey: "test-key", ...options });
 
 	for await (const event of stream) {
-		if (event.type === "done" || event.type === "error") break;
+		if (event.type === "done") {
+			captured.message = event.message;
+			break;
+		}
+		if (event.type === "error") break;
 	}
 
 	return captured;
@@ -83,29 +95,170 @@ afterEach(() => {
 });
 
 describe("openai-responses cache affinity", () => {
-	it("sets session routing headers for official OpenAI Responses requests with a sessionId", async () => {
+	it("sets session routing headers for the canonical official OpenAI Responses origin", async () => {
 		const captured = await captureOpenAIResponseHeaders({ sessionId: "session-123" });
 
 		expect(captured.sessionId).toBe("session-123");
 		expect(captured.clientRequestId).toBe("session-123");
 		expect(captured.body?.prompt_cache_key).toBe("session-123");
+		expect(captured.body?.prompt_cache_retention).toBeUndefined();
 	});
 
-	it("lets explicit headers override the default OpenAI session routing headers", async () => {
-		const captured = await captureOpenAIResponseHeaders({
-			sessionId: "session-123",
-			headers: {
-				session_id: "override-session",
-				"x-client-request-id": "override-request",
+	it("sets affinity headers for an explicitly opted-in openai-relay provider", async () => {
+		const captured = await captureOpenAIResponseHeaders(
+			{ sessionId: "session-123" },
+			{
+				...model,
+				provider: "openai-relay",
+				baseUrl: "https://relay.example.com/v1",
+				compat: { ...model.compat, supportsResponsesSessionAffinity: true },
 			},
-		});
+		);
 
-		expect(captured.sessionId).toBe("override-session");
-		expect(captured.clientRequestId).toBe("override-request");
+		expect(captured.sessionId).toBe("session-123");
+		expect(captured.clientRequestId).toBe("session-123");
+		expect(captured.body?.prompt_cache_key).toBe("session-123");
+		expect(captured.body?.prompt_cache_retention).toBeUndefined();
+	});
+	it("allows an explicit opt-in on the known openai provider when it uses a custom relay", async () => {
+		const captured = await captureOpenAIResponseHeaders(
+			{ sessionId: "session-123" },
+			{
+				...model,
+				baseUrl: "https://relay.example.com/v1",
+				compat: { ...model.compat, supportsResponsesSessionAffinity: true },
+			},
+		);
+
+		expect(captured.sessionId).toBe("session-123");
+		expect(captured.clientRequestId).toBe("session-123");
+	});
+
+	it("keeps an arbitrary relay default-off", async () => {
+		const captured = await captureOpenAIResponseHeaders(
+			{ sessionId: "session-123" },
+			{ ...model, provider: "openai-relay", baseUrl: "https://relay.example.com/v1" },
+		);
+
+		expect(captured.sessionId).toBeNull();
+		expect(captured.clientRequestId).toBeNull();
 		expect(captured.body?.prompt_cache_key).toBe("session-123");
 	});
 
-	it("keeps prompt_cache_key when cache retention is disabled", async () => {
+	it("excludes known non-target providers even when affinity is explicitly enabled", async () => {
+		const captured = await captureOpenAIResponseHeaders(
+			{ sessionId: "session-123" },
+			{
+				...model,
+				provider: "github-copilot",
+				baseUrl: "https://relay.example.com/v1",
+				compat: { ...model.compat, supportsResponsesSessionAffinity: true },
+			},
+		);
+
+		expect(captured.sessionId).toBeNull();
+		expect(captured.clientRequestId).toBeNull();
+	});
+
+	it.each([
+		"http://api.openai.com/v1",
+		"https://api.openai.com:8443/v1",
+		"https://api.openai.com/v2",
+		"https://user:password@api.openai.com/v1",
+		"https://api.openai.com/v1?tenant=relay",
+	])("does not set automatic affinity headers for non-canonical origin %s", async baseUrl => {
+		const captured = await captureOpenAIResponseHeaders({ sessionId: "session-123" }, { ...model, baseUrl });
+
+		expect(captured.sessionId).toBeNull();
+		expect(captured.clientRequestId).toBeNull();
+	});
+
+	it("preserves model and request header precedence over affinity defaults", async () => {
+		const modelHeaders = await captureOpenAIResponseHeaders(
+			{ sessionId: "session-123" },
+			{
+				...model,
+				headers: {
+					session_id: "model-session",
+					"x-client-request-id": "model-request",
+				},
+			},
+		);
+		expect(modelHeaders.sessionId).toBe("model-session");
+		expect(modelHeaders.clientRequestId).toBe("model-request");
+
+		const requestHeaders = await captureOpenAIResponseHeaders(
+			{
+				sessionId: "session-123",
+				headers: {
+					session_id: "request-session",
+					"x-client-request-id": "request-request",
+				},
+			},
+			{
+				...model,
+				headers: {
+					session_id: "model-session",
+					"x-client-request-id": "model-request",
+				},
+			},
+		);
+		expect(requestHeaders.sessionId).toBe("request-session");
+		expect(requestHeaders.clientRequestId).toBe("request-request");
+		expect(requestHeaders.body?.prompt_cache_key).toBe("session-123");
+	});
+
+	it("preserves requestTransform strip, set, and null semantics", async () => {
+		const stripped = await captureOpenAIResponseHeaders(
+			{ sessionId: "session-123" },
+			{
+				...model,
+				baseUrl: "https://relay.example.com/v1",
+				compat: { ...model.compat, supportsResponsesSessionAffinity: true },
+				requestTransform: {
+					stripHeaders: ["session_id", "x-client-request-id"],
+				},
+			},
+		);
+		expect(stripped.sessionId).toBeNull();
+		expect(stripped.clientRequestId).toBeNull();
+
+		const set = await captureOpenAIResponseHeaders(
+			{ sessionId: "session-123" },
+			{
+				...model,
+				baseUrl: "https://relay.example.com/v1",
+				compat: { ...model.compat, supportsResponsesSessionAffinity: true },
+				requestTransform: {
+					setHeaders: {
+						session_id: "transform-session",
+						"x-client-request-id": "transform-request",
+					},
+				},
+			},
+		);
+		expect(set.sessionId).toBe("transform-session");
+		expect(set.clientRequestId).toBe("transform-request");
+
+		const nulled = await captureOpenAIResponseHeaders(
+			{ sessionId: "session-123" },
+			{
+				...model,
+				baseUrl: "https://relay.example.com/v1",
+				compat: { ...model.compat, supportsResponsesSessionAffinity: true },
+				requestTransform: {
+					setHeaders: {
+						session_id: null,
+						"x-client-request-id": null,
+					},
+				},
+			},
+		);
+		expect(nulled.sessionId).toBeNull();
+		expect(nulled.clientRequestId).toBeNull();
+	});
+
+	it("keeps official affinity headers when retention is none but omits body retention", async () => {
 		const captured = await captureOpenAIResponseHeaders({ cacheRetention: "none", sessionId: "session-123" });
 
 		expect(captured.sessionId).toBe("session-123");
@@ -114,43 +267,155 @@ describe("openai-responses cache affinity", () => {
 		expect(captured.body?.prompt_cache_retention).toBeUndefined();
 	});
 
-	it("uses model cacheRetention for OpenAI Responses retention when request omits cacheRetention", async () => {
-		const captured = await captureOpenAIResponseHeaders(
-			{ authCredentialType: "oauth", sessionId: "session-123" },
-			{ ...model, baseUrl: "https://api.openai.com/v1", cacheRetention: "long" },
-		);
-
-		expect(captured.body?.prompt_cache_key).toBe("session-123");
-		expect(captured.body?.prompt_cache_retention).toBe("24h");
-	});
-
-	it("lets explicit request cacheRetention win over model cacheRetention", async () => {
+	it("gates opted-in relay affinity headers on effective retention", async () => {
 		const captured = await captureOpenAIResponseHeaders(
 			{ cacheRetention: "none", sessionId: "session-123" },
-			{ ...model, cacheRetention: "long" },
+			{
+				...model,
+				provider: "openai-relay",
+				baseUrl: "https://relay.example.com/v1",
+				compat: { ...model.compat, supportsResponsesSessionAffinity: true },
+			},
 		);
 
+		expect(captured.sessionId).toBeNull();
+		expect(captured.clientRequestId).toBeNull();
 		expect(captured.body?.prompt_cache_key).toBe("session-123");
 		expect(captured.body?.prompt_cache_retention).toBeUndefined();
 	});
 
-	it("uses GJC_CACHE_RETENTION when request and model omit cacheRetention", async () => {
-		const previous = Bun.env.GJC_CACHE_RETENTION;
+	it.each(["short", "long"] as const)("uses the effective %s retention for relay affinity", async cacheRetention => {
+		const captured = await captureOpenAIResponseHeaders(
+			{ cacheRetention, sessionId: "session-123" },
+			{
+				...model,
+				provider: "openai-relay",
+				baseUrl: "https://relay.example.com/v1",
+				compat: { ...model.compat, supportsResponsesSessionAffinity: true },
+			},
+		);
+
+		expect(captured.sessionId).toBe("session-123");
+		expect(captured.clientRequestId).toBe("session-123");
+		expect(captured.body?.prompt_cache_key).toBe("session-123");
+		expect(captured.body?.prompt_cache_retention).toBeUndefined();
+	});
+
+	it("preserves protected body fields while allowing safe transform extras", async () => {
+		const captured = await captureOpenAIResponseHeaders(
+			{ sessionId: "session-123" },
+			{
+				...model,
+				requestTransform: {
+					extraBody: {
+						prompt_cache_key: "wrong-key",
+						prompt_cache_retention: "wrong-retention",
+						store: true,
+						relay_marker: "present",
+					},
+				},
+			},
+		);
+
+		expect(captured.body?.prompt_cache_key).toBe("session-123");
+		expect(captured.body?.prompt_cache_retention).toBeUndefined();
+		expect(captured.body?.store).toBe(false);
+		expect(captured.body?.relay_marker).toBe("present");
+	});
+
+	it("keeps the same session identity when replaying provider-session-state history", async () => {
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const options: OpenAIResponsesOptions = {
+			sessionId: "session-continuity",
+			providerSessionState,
+		};
+		const firstContext: Context = {
+			messages: [{ role: "user", content: "first turn", timestamp: Date.now() }],
+		};
+		const first = await captureOpenAIResponseHeaders(options, model, firstContext);
+		expect(first.message).not.toBeNull();
+		(first.message as AssistantMessage).providerPayload = createOpenAIResponsesHistoryPayload("openai", [
+			{
+				type: "message",
+				role: "assistant",
+				content: [{ type: "output_text", text: "native replay marker" }],
+				status: "completed",
+			},
+		]);
+		const replayed = await captureOpenAIResponseHeaders(options, model, {
+			messages: [
+				...firstContext.messages,
+				first.message as AssistantMessage,
+				{ role: "user", content: "follow-up turn", timestamp: Date.now() },
+			],
+		});
+
+		expect([first.sessionId, replayed.sessionId]).toEqual(["session-continuity", "session-continuity"]);
+		expect([first.clientRequestId, replayed.clientRequestId]).toEqual(["session-continuity", "session-continuity"]);
+		expect([first.body?.prompt_cache_key, replayed.body?.prompt_cache_key]).toEqual([
+			"session-continuity",
+			"session-continuity",
+		]);
+		const replayedInput = replayed.body?.input as Array<Record<string, unknown>>;
+		expect(replayedInput).toContainEqual({
+			type: "message",
+			role: "assistant",
+			content: [{ type: "output_text", text: "native replay marker" }],
+			status: "completed",
+		});
+		expect(providerSessionState.size).toBe(1);
+	});
+
+	it("uses model retention when the request omits it and request retention takes precedence", async () => {
+		const modelRetention = await captureOpenAIResponseHeaders(
+			{ authCredentialType: "oauth", sessionId: "session-123" },
+			{ ...model, baseUrl: "https://api.openai.com/v1", cacheRetention: "long" },
+		);
+		expect(modelRetention.body?.prompt_cache_key).toBe("session-123");
+		expect(modelRetention.body?.prompt_cache_retention).toBe("24h");
+
+		const requestRetention = await captureOpenAIResponseHeaders(
+			{ authCredentialType: "oauth", cacheRetention: "none", sessionId: "session-123" },
+			{ ...model, cacheRetention: "long" },
+		);
+		expect(requestRetention.body?.prompt_cache_key).toBe("session-123");
+		expect(requestRetention.body?.prompt_cache_retention).toBeUndefined();
+	});
+
+	it("isolates environment retention overrides", async () => {
+		const previousGjc = Bun.env.GJC_CACHE_RETENTION;
+		const previousPi = Bun.env.PI_CACHE_RETENTION;
 		Bun.env.GJC_CACHE_RETENTION = "long";
+		delete Bun.env.PI_CACHE_RETENTION;
 		try {
 			const captured = await captureOpenAIResponseHeaders(
 				{ authCredentialType: "oauth", sessionId: "session-123" },
 				{ ...model, baseUrl: "https://api.openai.com/v1" },
 			);
-
-			expect(captured.body?.prompt_cache_key).toBe("session-123");
 			expect(captured.body?.prompt_cache_retention).toBe("24h");
 		} finally {
-			if (previous === undefined) {
-				delete Bun.env.GJC_CACHE_RETENTION;
-			} else {
-				Bun.env.GJC_CACHE_RETENTION = previous;
-			}
+			if (previousGjc === undefined) delete Bun.env.GJC_CACHE_RETENTION;
+			else Bun.env.GJC_CACHE_RETENTION = previousGjc;
+			if (previousPi === undefined) delete Bun.env.PI_CACHE_RETENTION;
+			else Bun.env.PI_CACHE_RETENTION = previousPi;
+		}
+	});
+
+	it("respects custom and HTTP OPENAI_BASE_URL without treating them as canonical affinity origins", async () => {
+		const previous = Bun.env.OPENAI_BASE_URL;
+		try {
+			Bun.env.OPENAI_BASE_URL = "https://relay.example.com/v1";
+			const custom = await captureOpenAIResponseHeaders({ sessionId: "session-123" });
+			expect(custom.sessionId).toBeNull();
+			expect(custom.clientRequestId).toBeNull();
+
+			Bun.env.OPENAI_BASE_URL = "http://api.openai.com/v1";
+			const http = await captureOpenAIResponseHeaders({ sessionId: "session-123" });
+			expect(http.sessionId).toBeNull();
+			expect(http.clientRequestId).toBeNull();
+		} finally {
+			if (previous === undefined) delete Bun.env.OPENAI_BASE_URL;
+			else Bun.env.OPENAI_BASE_URL = previous;
 		}
 	});
 });

--- a/packages/ai/test/openai-responses-cache-affinity.test.ts
+++ b/packages/ai/test/openai-responses-cache-affinity.test.ts
@@ -150,6 +150,20 @@ describe("openai-responses cache affinity", () => {
 		expect(captured.sessionId).toBeNull();
 		expect(captured.clientRequestId).toBeNull();
 	});
+	it("does not set affinity headers for an unknown provider without an explicit base URL", async () => {
+		const captured = await captureOpenAIResponseHeaders(
+			{ sessionId: "session-123" },
+			{
+				...model,
+				provider: "openai-relay",
+				baseUrl: "",
+				compat: { ...model.compat, supportsResponsesSessionAffinity: true },
+			},
+		);
+
+		expect(captured.sessionId).toBeNull();
+		expect(captured.clientRequestId).toBeNull();
+	});
 
 	it("allows an explicit opt-in on the known openai provider when it uses a custom relay", async () => {
 		const captured = await captureOpenAIResponseHeaders(

--- a/packages/ai/test/openai-responses-cache-affinity.test.ts
+++ b/packages/ai/test/openai-responses-cache-affinity.test.ts
@@ -104,6 +104,17 @@ describe("openai-responses cache affinity", () => {
 		expect(captured.body?.prompt_cache_retention).toBeUndefined();
 	});
 
+	it.each([
+		"https://api.openai.com",
+		"https://api.openai.com/",
+	])("sets affinity headers for the canonical official OpenAI Responses root origin %s", async baseUrl => {
+		const captured = await captureOpenAIResponseHeaders({ sessionId: "session-123" }, { ...model, baseUrl });
+
+		expect(captured.sessionId).toBe("session-123");
+		expect(captured.clientRequestId).toBe("session-123");
+		expect(captured.body?.prompt_cache_key).toBe("session-123");
+	});
+
 	it("sets affinity headers for an explicitly opted-in openai-relay provider", async () => {
 		const captured = await captureOpenAIResponseHeaders(
 			{ sessionId: "session-123" },
@@ -120,6 +131,26 @@ describe("openai-responses cache affinity", () => {
 		expect(captured.body?.prompt_cache_key).toBe("session-123");
 		expect(captured.body?.prompt_cache_retention).toBeUndefined();
 	});
+
+	it.each([
+		"https://api.openai.com",
+		"https://api.openai.com/v1",
+		"https://api.openai.com/",
+	])("does not set affinity headers for an unknown provider on a canonical OpenAI origin %s", async baseUrl => {
+		const captured = await captureOpenAIResponseHeaders(
+			{ sessionId: "session-123" },
+			{
+				...model,
+				provider: "openai-relay",
+				baseUrl,
+				compat: { ...model.compat, supportsResponsesSessionAffinity: true },
+			},
+		);
+
+		expect(captured.sessionId).toBeNull();
+		expect(captured.clientRequestId).toBeNull();
+	});
+
 	it("allows an explicit opt-in on the known openai provider when it uses a custom relay", async () => {
 		const captured = await captureOpenAIResponseHeaders(
 			{ sessionId: "session-123" },

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -288,7 +288,7 @@ function assertResponsesSessionAffinitySupported(
 	if (api !== "openai-responses") {
 		throw new Error(`Provider ${providerName}: ${source} is only supported with the openai-responses API.`);
 	}
-	if (!isKnownProvider(providerName) && isCanonicalOpenAIAffinityBaseUrl(baseUrl)) {
+	if (!isKnownProvider(providerName) && (!baseUrl?.trim() || isCanonicalOpenAIAffinityBaseUrl(baseUrl))) {
 		throw new Error(
 			`Provider ${providerName}: ${source} requires a genuinely custom base URL for unknown provider IDs.`,
 		);

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -257,11 +257,7 @@ function getKnownProviderModelApi(providerName: string, modelId: string): Api | 
 		?.api as Api | undefined;
 }
 
-function assertResponsesSessionAffinitySupported(
-	providerName: string,
-	api: Api | undefined,
-	source: string,
-): void {
+function assertResponsesSessionAffinitySupported(providerName: string, api: Api | undefined, source: string): void {
 	if (isKnownProvider(providerName) && providerName !== "openai") {
 		throw new Error(
 			`Provider ${providerName}: ${source} is only supported for the openai provider or unknown user-defined provider IDs.`,
@@ -360,7 +356,11 @@ function validateProviderConfiguration(
 		throw new Error(`Provider ${providerName}: "api" is required when discovery is enabled at provider level.`);
 	}
 	const configCompat = config.compat;
-	if (configCompat && "supportsResponsesSessionAffinity" in configCompat && configCompat.supportsResponsesSessionAffinity !== undefined) {
+	if (
+		configCompat &&
+		"supportsResponsesSessionAffinity" in configCompat &&
+		configCompat.supportsResponsesSessionAffinity !== undefined
+	) {
 		const source = '"compat.supportsResponsesSessionAffinity"';
 		if (models.length > 0) {
 			for (const model of models) {
@@ -3021,7 +3021,14 @@ export class ModelRegistry {
 		entry: T,
 		override: Pick<
 			ProviderOverride,
-			"baseUrl" | "headers" | "authHeader" | "apiKey" | "compat" | "transport" | "requestTransform" | "cacheRetention"
+			| "baseUrl"
+			| "headers"
+			| "authHeader"
+			| "apiKey"
+			| "compat"
+			| "transport"
+			| "requestTransform"
+			| "cacheRetention"
 		>,
 	): T {
 		const headers = mergeAuthHeader(

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -257,7 +257,29 @@ function getKnownProviderModelApi(providerName: string, modelId: string): Api | 
 		?.api as Api | undefined;
 }
 
-function assertResponsesSessionAffinitySupported(providerName: string, api: Api | undefined, source: string): void {
+function isCanonicalOpenAIAffinityBaseUrl(baseUrl: string | undefined): boolean {
+	if (!baseUrl) return false;
+	try {
+		const url = new URL(baseUrl);
+		return (
+			url.origin === "https://api.openai.com" &&
+			url.username === "" &&
+			url.password === "" &&
+			(url.pathname === "/" || url.pathname === "/v1") &&
+			url.search === "" &&
+			url.hash === ""
+		);
+	} catch {
+		return false;
+	}
+}
+
+function assertResponsesSessionAffinitySupported(
+	providerName: string,
+	api: Api | undefined,
+	baseUrl: string | undefined,
+	source: string,
+): void {
 	if (isKnownProvider(providerName) && providerName !== "openai") {
 		throw new Error(
 			`Provider ${providerName}: ${source} is only supported for the openai provider or unknown user-defined provider IDs.`,
@@ -266,10 +288,16 @@ function assertResponsesSessionAffinitySupported(providerName: string, api: Api 
 	if (api !== "openai-responses") {
 		throw new Error(`Provider ${providerName}: ${source} is only supported with the openai-responses API.`);
 	}
+	if (!isKnownProvider(providerName) && isCanonicalOpenAIAffinityBaseUrl(baseUrl)) {
+		throw new Error(
+			`Provider ${providerName}: ${source} requires a genuinely custom base URL for unknown provider IDs.`,
+		);
+	}
 }
 
 interface ProviderValidationModel {
 	id: string;
+	baseUrl?: string;
 	api?: Api;
 	contextWindow?: number;
 	maxTokens?: number;
@@ -367,18 +395,19 @@ function validateProviderConfiguration(
 				assertResponsesSessionAffinitySupported(
 					providerName,
 					model.api ?? config.api ?? getKnownProviderModelApi(providerName, model.id),
+					model.baseUrl ?? config.baseUrl,
 					source,
 				);
 			}
 		} else if (config.api) {
-			assertResponsesSessionAffinitySupported(providerName, config.api, source);
+			assertResponsesSessionAffinitySupported(providerName, config.api, config.baseUrl, source);
 		} else {
 			const knownApis = getKnownProviderApis(providerName);
 			if (knownApis.size === 0) {
-				assertResponsesSessionAffinitySupported(providerName, undefined, source);
+				assertResponsesSessionAffinitySupported(providerName, undefined, config.baseUrl, source);
 			}
 			for (const api of knownApis) {
-				assertResponsesSessionAffinitySupported(providerName, api, source);
+				assertResponsesSessionAffinitySupported(providerName, api, config.baseUrl, source);
 			}
 		}
 	}
@@ -392,6 +421,7 @@ function validateProviderConfiguration(
 			assertResponsesSessionAffinitySupported(
 				providerName,
 				effectiveApi,
+				config.baseUrl,
 				`modelOverrides ${modelId} "compat.supportsResponsesSessionAffinity"`,
 			);
 		}
@@ -435,6 +465,7 @@ function validateProviderConfiguration(
 			assertResponsesSessionAffinitySupported(
 				providerName,
 				effectiveApi,
+				modelDef.baseUrl ?? config.baseUrl,
 				`model ${modelDef.id} "compat.supportsResponsesSessionAffinity"`,
 			);
 		}

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -13,6 +13,7 @@ import {
 	getBundledProviders,
 	googleAntigravityModelManagerOptions,
 	googleGeminiCliModelManagerOptions,
+	isKnownProvider,
 	type Model,
 	type ModelManagerOptions,
 	type ModelRefreshStrategy,
@@ -256,11 +257,27 @@ function getKnownProviderModelApi(providerName: string, modelId: string): Api | 
 		?.api as Api | undefined;
 }
 
+function assertResponsesSessionAffinitySupported(
+	providerName: string,
+	api: Api | undefined,
+	source: string,
+): void {
+	if (isKnownProvider(providerName) && providerName !== "openai") {
+		throw new Error(
+			`Provider ${providerName}: ${source} is only supported for the openai provider or unknown user-defined provider IDs.`,
+		);
+	}
+	if (api !== "openai-responses") {
+		throw new Error(`Provider ${providerName}: ${source} is only supported with the openai-responses API.`);
+	}
+}
+
 interface ProviderValidationModel {
 	id: string;
 	api?: Api;
 	contextWindow?: number;
 	maxTokens?: number;
+	compat?: Model<Api>["compat"];
 	requestTransform?: ModelRequestTransform;
 }
 
@@ -342,13 +359,43 @@ function validateProviderConfiguration(
 	if (mode === "models-config" && config.discovery && !config.api) {
 		throw new Error(`Provider ${providerName}: "api" is required when discovery is enabled at provider level.`);
 	}
+	const configCompat = config.compat;
+	if (configCompat && "supportsResponsesSessionAffinity" in configCompat && configCompat.supportsResponsesSessionAffinity !== undefined) {
+		const source = '"compat.supportsResponsesSessionAffinity"';
+		if (models.length > 0) {
+			for (const model of models) {
+				assertResponsesSessionAffinitySupported(
+					providerName,
+					model.api ?? config.api ?? getKnownProviderModelApi(providerName, model.id),
+					source,
+				);
+			}
+		} else if (config.api) {
+			assertResponsesSessionAffinitySupported(providerName, config.api, source);
+		} else {
+			const knownApis = getKnownProviderApis(providerName);
+			if (knownApis.size === 0) {
+				assertResponsesSessionAffinitySupported(providerName, undefined, source);
+			}
+			for (const api of knownApis) {
+				assertResponsesSessionAffinitySupported(providerName, api, source);
+			}
+		}
+	}
 	for (const [modelId, rawOverride] of Object.entries(config.modelOverrides ?? {})) {
 		const override = rawOverride as ModelOverride;
-		if (!override.requestTransform) continue;
 		const effectiveApi =
 			models.find(model => model.id === modelId)?.api ??
 			config.api ??
 			getKnownProviderModelApi(providerName, modelId);
+		if (override.compat?.supportsResponsesSessionAffinity !== undefined) {
+			assertResponsesSessionAffinitySupported(
+				providerName,
+				effectiveApi,
+				`modelOverrides ${modelId} "compat.supportsResponsesSessionAffinity"`,
+			);
+		}
+		if (!override.requestTransform) continue;
 		if (effectiveApi) {
 			assertRequestTransformSupportedForModelApi(
 				providerName,
@@ -383,6 +430,14 @@ function validateProviderConfiguration(
 			throw new Error(`Provider ${providerName}: model missing "id"`);
 		}
 		const effectiveApi = modelDef.api ?? config.api;
+		const modelCompat = modelDef.compat;
+		if (modelCompat && "supportsResponsesSessionAffinity" in modelCompat) {
+			assertResponsesSessionAffinitySupported(
+				providerName,
+				effectiveApi,
+				`model ${modelDef.id} "compat.supportsResponsesSessionAffinity"`,
+			);
+		}
 		if (config.requestTransform && effectiveApi) {
 			assertRequestTransformSupportedForModelApi(
 				providerName,
@@ -717,6 +772,26 @@ function mergeCompat<TBase extends object, TOverride extends object>(
 			isRecord(baseValue) && isRecord(overrideValue) ? mergeCompat(baseValue, overrideValue) : overrideValue;
 	}
 	return merged as TBase & TOverride;
+}
+
+function mergeProviderCompat(
+	baseCompat: Model<Api>["compat"],
+	overrideCompat: Model<Api>["compat"],
+): Model<Api>["compat"] {
+	const merged = mergeCompat(baseCompat, overrideCompat);
+	// An explicit model-level opt-out must win over a provider-level opt-in.
+	const baseAffinity =
+		baseCompat && "supportsResponsesSessionAffinity" in baseCompat
+			? baseCompat.supportsResponsesSessionAffinity
+			: undefined;
+	const overrideAffinity =
+		overrideCompat && "supportsResponsesSessionAffinity" in overrideCompat
+			? overrideCompat.supportsResponsesSessionAffinity
+			: undefined;
+	if (baseAffinity === false && overrideAffinity !== undefined) {
+		return { ...merged, supportsResponsesSessionAffinity: false };
+	}
+	return merged;
 }
 
 function mergeRequestTransform(
@@ -1362,7 +1437,6 @@ export class ModelRegistry {
 				const withTransportOverride = this.#applyProviderTransportOverride(m, providerOverride);
 				return {
 					...withTransportOverride,
-					compat: mergeCompat(m.compat, providerOverride.compat),
 					cacheRetention: m.cacheRetention ?? providerOverride.cacheRetention,
 				};
 			});
@@ -1462,10 +1536,7 @@ export class ModelRegistry {
 			const withTransport = providerOverride
 				? models.map(model => this.#applyProviderTransportOverride(model, providerOverride))
 				: models;
-			const withCompat = providerOverride?.compat
-				? withTransport.map(model => ({ ...model, compat: mergeCompat(model.compat, providerOverride.compat) }))
-				: withTransport;
-			cachedModels.push(...this.#applyProviderModelOverrides(descriptor.providerId, withCompat));
+			cachedModels.push(...this.#applyProviderModelOverrides(descriptor.providerId, withTransport));
 		}
 		return cachedModels;
 	}
@@ -2940,12 +3011,17 @@ export class ModelRegistry {
 		};
 	}
 	#applyProviderTransportOverride<
-		T extends { baseUrl?: string; headers?: Record<string, string>; cacheRetention?: CacheRetention },
+		T extends {
+			baseUrl?: string;
+			headers?: Record<string, string>;
+			compat?: Model<Api>["compat"];
+			cacheRetention?: CacheRetention;
+		},
 	>(
 		entry: T,
 		override: Pick<
 			ProviderOverride,
-			"baseUrl" | "headers" | "authHeader" | "apiKey" | "transport" | "requestTransform" | "cacheRetention"
+			"baseUrl" | "headers" | "authHeader" | "apiKey" | "compat" | "transport" | "requestTransform" | "cacheRetention"
 		>,
 	): T {
 		const headers = mergeAuthHeader(
@@ -2955,6 +3031,7 @@ export class ModelRegistry {
 		);
 		return {
 			...entry,
+			compat: mergeProviderCompat(entry.compat, override.compat),
 			baseUrl: override.baseUrl ?? entry.baseUrl,
 			headers,
 			// Preserve the model's existing transport when the override omits one;
@@ -2967,12 +3044,19 @@ export class ModelRegistry {
 			cacheRetention: entry.cacheRetention ?? override.cacheRetention,
 		};
 	}
+	#applyRuntimeProviderOverride(model: Model<Api>, override: ProviderOverride): Model<Api> {
+		const withTransportOverride = this.#applyProviderTransportOverride(model, override);
+		const modelCompat = this.#modelOverrides.get(model.provider)?.get(model.id)?.compat;
+		return modelCompat
+			? { ...withTransportOverride, compat: mergeCompat(withTransportOverride.compat, modelCompat) }
+			: withTransportOverride;
+	}
 	#applyRuntimeProviderOverrides(models: Model<Api>[]): Model<Api>[] {
 		if (this.#runtimeProviderOverrides.size === 0) return models;
 		return models.map(model => {
 			const override = this.#runtimeProviderOverrides.get(model.provider);
 			if (!override) return model;
-			return this.#applyProviderTransportOverride(model, override);
+			return this.#applyRuntimeProviderOverride(model, override);
 		});
 	}
 	#applyModelOverrides(models: Model<Api>[], overrides: Map<string, Map<string, ModelOverride>>): Model<Api>[] {
@@ -3558,6 +3642,7 @@ export class ModelRegistry {
 				apiKey: config.apiKey,
 				api: config.api,
 				oauthConfigured: Boolean(config.oauth),
+				compat: config.compat,
 				requestTransform: config.requestTransform,
 				models: (config.models ?? []) as ProviderValidationModel[],
 			},
@@ -3648,7 +3733,7 @@ export class ModelRegistry {
 			const withRuntimeTransportOverride = runtimeTransportOverride
 				? nextModels.map(model => {
 						if (model.provider !== providerName) return model;
-						return this.#applyProviderTransportOverride(model, runtimeTransportOverride);
+						return this.#applyRuntimeProviderOverride(model, runtimeTransportOverride);
 					})
 				: nextModels;
 
@@ -3675,6 +3760,7 @@ export class ModelRegistry {
 			config.headers ||
 			config.apiKey ||
 			config.authHeader !== undefined ||
+			config.compat !== undefined ||
 			config.requestTransform !== undefined ||
 			config.transport !== undefined
 		) {
@@ -3683,6 +3769,7 @@ export class ModelRegistry {
 				headers: config.headers,
 				apiKey: config.apiKey,
 				authHeader: config.authHeader,
+				compat: config.compat,
 				requestTransform: config.requestTransform,
 				transport: config.transport,
 			};
@@ -3693,7 +3780,7 @@ export class ModelRegistry {
 			this.#runtimeProviderOverrides.set(providerName, nextRuntimeOverride);
 			this.#models = this.#models.map(m => {
 				if (m.provider !== providerName) return m;
-				return this.#applyProviderTransportOverride(m, transportOverride);
+				return this.#applyRuntimeProviderOverride(m, transportOverride);
 			});
 			this.#rebuildCanonicalIndex();
 			this.#rebuildProviderActivity();

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -24,6 +24,7 @@ export const ModelCompatSchema = z.object({
 	supportsStore: z.boolean().optional(),
 	supportsDeveloperRole: z.boolean().optional(),
 	sendSessionHeaders: z.boolean().optional(),
+	supportsResponsesSessionAffinity: z.boolean().optional(),
 	supportsMultipleSystemMessages: z.boolean().optional(),
 	supportsReasoningEffort: z.boolean().optional(),
 	reasoningEffortMap: ReasoningEffortMapSchema.optional(),

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -234,6 +234,9 @@ describe("ModelRegistry runtime provider registration", () => {
 		registry.registerProvider(
 			"relay",
 			{
+				// Unknown provider IDs still require a genuinely custom base URL when
+				// enabling affinity, even on a transport-only re-registration.
+				baseUrl: "https://relay.example.com/v1",
 				api: "openai-responses",
 				compat: { supportsResponsesSessionAffinity: true },
 			},

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -200,6 +200,53 @@ describe("ModelRegistry runtime provider registration", () => {
 		registry.clearSourceRegistrations("ext://runtime");
 		expectProviderHeader(registry, providerName, "Authorization", undefined);
 	});
+	test("registerProvider applies provider-only responses affinity compat across refresh", async () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		registry.registerProvider(
+			"openai",
+			{
+				baseUrl: "https://openai-relay.example.com/v1",
+				api: "openai-responses",
+				compat: { supportsResponsesSessionAffinity: true },
+			},
+			"ext://runtime",
+		);
+
+		const readAffinity = () =>
+			(registry.find("openai", "gpt-4o-mini")?.compat as { supportsResponsesSessionAffinity?: boolean } | undefined)
+				?.supportsResponsesSessionAffinity;
+		expect(readAffinity()).toBe(true);
+		await registry.refresh("offline");
+		expect(readAffinity()).toBe(true);
+	});
+	test("model-level false survives a later runtime provider compat override", async () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		registry.registerProvider(
+			"relay",
+			{
+				baseUrl: "https://relay.example.com/v1",
+				api: "openai-responses",
+				apiKey: "RUNTIME_KEY",
+				models: [{ ...baseModel, compat: { supportsResponsesSessionAffinity: false } }],
+			},
+			"ext://runtime",
+		);
+		registry.registerProvider(
+			"relay",
+			{
+				api: "openai-responses",
+				compat: { supportsResponsesSessionAffinity: true },
+			},
+			"ext://runtime",
+		);
+
+		const readAffinity = () =>
+			(registry.find("relay", "runtime-model")?.compat as { supportsResponsesSessionAffinity?: boolean } | undefined)
+				?.supportsResponsesSessionAffinity;
+		expect(readAffinity()).toBe(false);
+		await registry.refresh("offline");
+		expect(readAffinity()).toBe(false);
+	});
 
 	test("registerProvider preserves explicit thinking on runtime models", () => {
 		const registry = new ModelRegistry(authStorage, modelsJsonPath);

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -4540,6 +4540,19 @@ describe("ModelRegistry", () => {
 		const registry = new ModelRegistry(authStorage, modelsJsonPath);
 		expect(String(registry.getError()?.message)).toContain("requires a genuinely custom base URL");
 	});
+	test("rejects unknown-provider responses affinity without a base URL", () => {
+		writeRawModelsConfig({
+			providers: {
+				relay: {
+					api: "openai-responses",
+					compat: { supportsResponsesSessionAffinity: true },
+				},
+			},
+		});
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		expect(String(registry.getError()?.message)).toContain("requires a genuinely custom base URL");
+	});
 	test("rejects responses affinity on non-Responses APIs", () => {
 		writeRawModelsConfig({
 			providers: {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1400,6 +1400,21 @@ describe("ModelRegistry", () => {
 				expect(getOpenAICompat(model)?.allowsSyntheticReasoningContentForToolCalls).toBe(false);
 			}
 		});
+		test("provider-level responses affinity applies to bundled OpenAI models", async () => {
+			writeRawModelsJson({
+				openai: {
+					baseUrl: "https://openai-relay.example.com/v1",
+					api: "openai-responses",
+					apiKey: "TEST_KEY",
+					compat: { supportsResponsesSessionAffinity: true },
+				},
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			expect(getOpenAICompat(registry.find("openai", "gpt-4o-mini"))?.supportsResponsesSessionAffinity).toBe(true);
+			await registry.refresh("offline");
+			expect(getOpenAICompat(registry.find("openai", "gpt-4o-mini"))?.supportsResponsesSessionAffinity).toBe(true);
+		});
 
 		test("provider-level compat applies to custom models", () => {
 			writeRawModelsJson({
@@ -1463,6 +1478,32 @@ describe("ModelRegistry", () => {
 			const compat = getOpenAICompat(model);
 			expect(compat?.supportsUsageInStreaming).toBe(true);
 			expect(compat?.maxTokensField).toBe("max_completion_tokens");
+		});
+		test("model-level false overrides provider-level responses affinity", async () => {
+			writeRawModelsJson({
+				relay: {
+					baseUrl: "https://relay.example.com/v1",
+					apiKey: "TEST_KEY",
+					api: "openai-responses",
+					compat: { supportsResponsesSessionAffinity: true },
+					models: [
+						{
+							id: "relay-model",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 128000,
+							maxTokens: 8192,
+							compat: { supportsResponsesSessionAffinity: false },
+						},
+					],
+				},
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			expect(getOpenAICompat(registry.find("relay", "relay-model"))?.supportsResponsesSessionAffinity).toBe(false);
+			await registry.refresh("offline");
+			expect(getOpenAICompat(registry.find("relay", "relay-model"))?.supportsResponsesSessionAffinity).toBe(false);
 		});
 	});
 
@@ -4465,6 +4506,53 @@ describe("ModelRegistry", () => {
 
 		expect(model?.wireModelId).toBe("proxy-gpt-4o-mini");
 		expect(model?.requestTransform).toEqual({ extraBody: { routed: true } });
+	});
+	test("rejects responses affinity on known non-target providers", () => {
+		writeRawModelsConfig({
+			providers: {
+				anthropic: {
+					baseUrl: "https://relay.example.com/v1",
+					api: "openai-responses",
+					compat: { supportsResponsesSessionAffinity: true },
+				},
+			},
+		});
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		expect(String(registry.getError()?.message)).toContain("only supported for the openai provider");
+	});
+
+	test("rejects responses affinity on non-Responses APIs", () => {
+		writeRawModelsConfig({
+			providers: {
+				relay: {
+					baseUrl: "https://relay.example.com/v1",
+					apiKey: "TEST_KEY",
+					api: "openai-completions",
+					compat: { supportsResponsesSessionAffinity: true },
+				},
+			},
+		});
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		expect(String(registry.getError()?.message)).toContain("only supported with the openai-responses API");
+	});
+
+	test("rejects provider affinity inherited by a non-Responses model API", () => {
+		writeRawModelsConfig({
+			providers: {
+				relay: {
+					baseUrl: "https://relay.example.com/v1",
+					api: "openai-responses",
+					apiKey: "TEST_KEY",
+					compat: { supportsResponsesSessionAffinity: true },
+					models: [{ id: "chat-model", api: "openai-completions" }],
+				},
+			},
+		});
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		expect(String(registry.getError()?.message)).toContain("only supported with the openai-responses API");
 	});
 	describe("generic local OpenAI-compatible provider config", () => {
 		test("does not add a generic local provider by default", () => {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -4522,6 +4522,24 @@ describe("ModelRegistry", () => {
 		expect(String(registry.getError()?.message)).toContain("only supported for the openai provider");
 	});
 
+	test.each([
+		"https://api.openai.com",
+		"https://api.openai.com/v1",
+		"https://api.openai.com/",
+	])("rejects unknown-provider responses affinity on a canonical OpenAI base URL %s", baseUrl => {
+		writeRawModelsConfig({
+			providers: {
+				relay: {
+					baseUrl,
+					api: "openai-responses",
+					compat: { supportsResponsesSessionAffinity: true },
+				},
+			},
+		});
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		expect(String(registry.getError()?.message)).toContain("requires a genuinely custom base URL");
+	});
 	test("rejects responses affinity on non-Responses APIs", () => {
 		writeRawModelsConfig({
 			providers: {

--- a/packages/coding-agent/test/models-config-send-session-headers.test.ts
+++ b/packages/coding-agent/test/models-config-send-session-headers.test.ts
@@ -23,6 +23,39 @@ describe("models config sendSessionHeaders", () => {
 		});
 		expect(result.success).toBe(true);
 	});
+	test("accepts supportsResponsesSessionAffinity in provider and model compat", () => {
+		const result = ModelsConfigSchema.safeParse({
+			providers: {
+				relay: {
+					baseUrl: "https://relay.example.com/v1",
+					api: "openai-responses",
+					compat: { supportsResponsesSessionAffinity: true },
+					models: [
+						{
+							id: "relay-model",
+							name: "Relay",
+							contextWindow: 128000,
+							maxTokens: 8192,
+							compat: { supportsResponsesSessionAffinity: false },
+						},
+					],
+				},
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+	test("rejects a non-boolean supportsResponsesSessionAffinity value", () => {
+		const result = ModelsConfigSchema.safeParse({
+			providers: {
+				relay: {
+					baseUrl: "https://relay.example.com/v1",
+					api: "openai-responses",
+					compat: { supportsResponsesSessionAffinity: "yes" },
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+	});
 
 	test("rejects a non-boolean sendSessionHeaders value", () => {
 		const result = ModelsConfigSchema.safeParse({

--- a/schemas/models.schema.json
+++ b/schemas/models.schema.json
@@ -62,6 +62,9 @@
 							"sendSessionHeaders": {
 								"type": "boolean"
 							},
+							"supportsResponsesSessionAffinity": {
+								"type": "boolean"
+							},
 							"supportsMultipleSystemMessages": {
 								"type": "boolean"
 							},
@@ -505,6 +508,9 @@
 										"sendSessionHeaders": {
 											"type": "boolean"
 										},
+										"supportsResponsesSessionAffinity": {
+											"type": "boolean"
+										},
 										"supportsMultipleSystemMessages": {
 											"type": "boolean"
 										},
@@ -886,6 +892,9 @@
 											"type": "boolean"
 										},
 										"sendSessionHeaders": {
+											"type": "boolean"
+										},
+										"supportsResponsesSessionAffinity": {
 											"type": "boolean"
 										},
 										"supportsMultipleSystemMessages": {


### PR DESCRIPTION
## Summary
- add an explicit Responses-only session-affinity capability for custom OpenAI relays
- preserve canonical first-party safeguards and existing body/tool/transform behavior
- propagate the capability through model configuration and runtime provider overrides
- add focused transport, config, registry, retention, precedence, and replay regressions

## Verification
- `bun test packages/ai/test/openai-responses-cache-affinity.test.ts`
- `bun test packages/coding-agent/test/models-config-send-session-headers.test.ts packages/coding-agent/test/model-registry-runtime-provider.test.ts`
- `bun test packages/coding-agent/test/model-registry.test.ts --test-name-pattern 'Responses|affinity|provider override|supportsResponses'`
- `bun --cwd=packages/ai run check:types`
- `bun --cwd=packages/coding-agent run check:types`
- `bun run check:schemas`
- `git diff --check`

Fixes #3689