### PR TITLE
fix(coding-agent): assert the cooperative dispose path after #3894

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- An aborted run whose tool ignores its `AbortSignal` now terminates on its own (#3894). `Promise.allSettled` waited on the unresolved call forever, so the turn only ended when the session's force-abort budget expired; the loop now emits a synthetic aborted result for the outstanding calls and `waitForIdle` settles immediately. Session dispose consequently reaches idle through the cooperative path instead of force-invalidating the run.
+
 ## [0.12.12] - 2026-08-05
 
 ### Fixed

--- a/packages/coding-agent/test/agent-session-abort-timeout.test.ts
+++ b/packages/coding-agent/test/agent-session-abort-timeout.test.ts
@@ -160,7 +160,7 @@ describe("AgentSession abort timeout", () => {
 		expect(aborted).toBe(true);
 	});
 
-	it("bounds dispose, force-invalidates an abort-ignoring run, and drops its late events", async () => {
+	it("bounds dispose, lets an abort-ignoring run settle cooperatively, and drops its late events", async () => {
 		tempDir = TempDir.createSync("@gjc-dispose-timeout-");
 		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
 		const mock = createMockModel();
@@ -248,9 +248,13 @@ describe("AgentSession abort timeout", () => {
 			disposed = true;
 			const elapsed = Date.now() - started;
 
-			expect(elapsed).toBeLessThan(6_000);
-			expect(forcedAbort).toHaveBeenCalledTimes(1);
-			expect(forceAbortResults).toEqual([true]);
+			// Since #3894 the agent loop emits a synthetic aborted result for tool
+			// calls that outlive their signal, so the turn terminates on its own and
+			// `waitForIdle` settles well inside the 2s force-abort budget. Burning
+			// that budget would mean the loop is hanging again.
+			expect(elapsed).toBeLessThan(2_000);
+			expect(forcedAbort).not.toHaveBeenCalled();
+			expect(forceAbortResults).toEqual([]);
 			expect(agent.state.isStreaming).toBe(false);
 
 			const branchIdsAfterDispose = sessionManager.getBranch().map(entry => entry.id);


### PR DESCRIPTION
Dev CI is red on `dev@4bc67a8d8` and has been since 4e33420ef (#3894): [`Affected path validation / test:@gajae-code/coding-agent:shard-3-of-8`](https://github.com/Yeachan-Heo/gajae-code/actions/runs/31068742553/job/92513966339).

```
packages/coding-agent/test/agent-session-abort-timeout.test.ts:252
expect(forcedAbort).toHaveBeenCalledTimes(1)
Expected number of calls: 1
Received number of calls: 0
```

## Cause

`#3894` made the agent loop emit a synthetic aborted result for tool calls that outlive their `AbortSignal`, so an aborted turn terminates instead of parking in `Promise.allSettled`. `AgentSession.#dispose` therefore reaches idle through `waitForIdle()` and never spends its 2s force-abort budget — the exact hang the old test was pinning.

Bisected by restoring `packages/agent/src/agent-loop.ts` at `4e33420ef^`: 4 pass. At `4e33420ef`: 1 fail.

## Change

- The test now asserts the current contract: dispose settles inside the 2s budget and calls no `forceAbort`. CI observed the whole test at ~91ms, so the bound keeps ~20x headroom while still failing loudly if the loop hangs again.
- This also un-skips the tail of the test. The old expectation threw at line 252, so the late-event assertions — branch stability and no `agent_end` after teardown once the held tool finally resolves — had stopped running. They pass.
- `#3894` shipped without a changelog entry; added to `packages/agent`.

No product code changes: `forceAbort` remains the safety net for teardown paths that genuinely stall.

## Verification

`bun test packages/coding-agent/test/agent-session-abort-timeout.test.ts packages/agent/test/agent-loop.test.ts` — 40 pass, 0 fail.
