### PR TITLE
feat(acp): bridge workflow-gate asks to the ACP permission channel

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## [0.12.13] - 2026-08-06
 
 ### Fixed
+- Workflow-gate asks (ralplan approval, deep-interview questions) now surface through the ACP permission channel when the client does not advertise ACP form elicitation, so plain ACP clients such as Paseo can answer selector gates; free-text asks remain unanswered and the richer `ui` channel stays preferred when advertised (#3925).
 - ACP session configuration now emits the spec-defined `category` field on the Mode, Model, and Thinking select options (`mode`, `model`, `thought_level`), so standards-compliant ACP clients such as Paseo discover models, modes, and thinking levels instead of an empty model picker (#3922).
 - The ACP session model catalog is now filtered to active providers via `providers.list/active`, falling back to the full catalog on older session hosts, so ACP clients no longer list models for providers without usable credentials (#3922).
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -737,7 +737,13 @@ export function acpRequestFailure(error: unknown): unknown {
 	}
 }
 
-/** Registers a permission provider only when the ACP client requires prompts. */
+/**
+ * Registers the permission reverse channel whenever a form-less client needs
+ * to answer selector asks. The permission mode (prompt vs allow) only gates
+ * tool-authorization prompts via `permission_mode.set`; workflow questions
+ * still need a channel, so form-less clients always get the permission
+ * capability and the bus installs the permission-backed ask source on it.
+ */
 export function acpProviderRegistrations(
 	capabilities: ClientCapabilities | undefined,
 	env: NodeJS.ProcessEnv = process.env,
@@ -757,7 +763,7 @@ export function acpProviderRegistrations(
 				]
 			: []),
 		...(capabilities?.terminal ? [{ capability: "terminal", definitions: [] }] : []),
-		...(resolveAcpPermissionMode(capabilities, env) === "prompt"
+		...(resolveAcpPermissionMode(capabilities, env) === "prompt" || !capabilities?.elicitation?.form
 			? [{ capability: "permission", definitions: [] }]
 			: []),
 		...(capabilities?.elicitation?.form ? [{ capability: "ui", definitions: [] }] : []),

--- a/packages/coding-agent/src/sdk/broker/ensure.ts
+++ b/packages/coding-agent/src/sdk/broker/ensure.ts
@@ -279,6 +279,25 @@ async function ensureBrokerOnce(settings: EnsureBrokerSettings, initiator: Ensur
 		await sleep(50);
 	}
 	const exitedBeforeDiscovery = child.exitCode !== null || child.signalCode !== null;
+	if (exitedBeforeDiscovery && child.exitCode === 0) {
+		// A clean exit means another broker won the ownership lock (two ACP
+		// processes racing a cold broker state, e.g. a provider probe and an
+		// agent launch). The winner may publish its discovery right after our
+		// last poll; reuse it instead of failing the caller. Transient discovery
+		// read failures fall through to the common cleanup + failure path below.
+		try {
+			for (let retry = 0; retry < 20; retry++) {
+				const winner = await readBrokerDiscovery(settings.agentDir, settings.heartbeatTtlMs);
+				if (winner) {
+					await owner.stop();
+					return { kind: "external-discovery", discovery: winner };
+				}
+				await sleep(50);
+			}
+		} catch {
+			// fall through to cleanup + failure
+		}
+	}
 	const failure = spawnError
 		? new Error(`Failed to spawn detached SDK broker: ${spawnError.message}`)
 		: exitedBeforeDiscovery

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -57,6 +57,7 @@ import type {
 	AskSettlement,
 	AskSettlementResult,
 } from "../../tools";
+import { RECOMMENDED_SUFFIX } from "../../tools/ask";
 import { registerAskAnswerSource, registerWorkflowGateEmitterListener } from "../../tools/ask-answer-registry";
 import { acpFinalTextFromMessage } from "../acp/final-text";
 import { ensureBroker } from "../broker/ensure";
@@ -1754,6 +1755,150 @@ function createSdkUiAskAnswerSource(
 		if (typeof value !== "string") return undefined;
 		if (request.interaction !== "selector") return value;
 		const interaction = choices.get(value);
+		if (!interaction) return undefined;
+		if (interaction.kind === "value") return interaction.value;
+		let settled: Promise<AskSettlementResult> | undefined;
+		return {
+			source: "remote",
+			interaction,
+			settle(settlement) {
+				if (!settled) {
+					settled = Promise.resolve(
+						settlement.kind === "commit"
+							? { kind: "committed", ack: { status: "failed", reason: "unsupported" } }
+							: settlement.kind === "invalid"
+								? { kind: "invalid_closed" }
+								: { kind: "resolved_without_commit" },
+					);
+				}
+				return settled;
+			},
+		};
+	};
+	return {
+		async awaitAnswer(question, options, signal) {
+			const answer = await awaitAnswerRequest({ question, options, interaction: "selector", controls: [] }, signal);
+			if (!answer || typeof answer === "string") return answer;
+			return answer.interaction.kind === "value" ? answer.interaction.value : undefined;
+		},
+		awaitAnswerRequest,
+	};
+}
+
+/**
+ * Ask-answer source that bridges workflow-gate asks to the ACP permission
+ * channel (`session/request_permission`). Used when the client does not
+ * advertise ACP form elicitation (e.g. Paseo): the gate question is sent as
+ * a permission request whose options are the answer choices, and the
+ * selected optionId maps back to the answer. Only selector asks are bridged;
+ * free-text asks have no permission-option representation and stay
+ * unanswered (unchanged from today). Auto-approval follows the client's
+ * permission mode, so gates never self-approve under `prompt`.
+ */
+export function createSdkPermissionAskAnswerSource(
+	requestPermission: (params: Record<string, unknown>, signal?: AbortSignal) => Promise<unknown>,
+): AskAnswerSource {
+	const awaitAnswerRequest = async (
+		request: AskAnswerRequest,
+		signal?: AbortSignal,
+	): Promise<AskAnswerSourceResult> => {
+		if (signal?.aborted) return undefined;
+		if (request.interaction !== "selector") return undefined;
+		// AskTool appends its synthetic "Other"/clarification transition entries
+		// at the end; a free-text editor this channel cannot complete. Remove
+		// exactly those trailing entries so a legitimate option that happens to
+		// share a transition label is preserved and recommendedIndex stays valid.
+		const transitionCount =
+			typeof request.transitionCount === "number" &&
+			Number.isInteger(request.transitionCount) &&
+			request.transitionCount > 0
+				? Math.min(request.transitionCount, request.options.length)
+				: 0;
+		const bridgedOptions =
+			transitionCount > 0 ? request.options.slice(0, request.options.length - transitionCount) : request.options;
+		const recommendedLabel =
+			typeof request.recommendedIndex === "number" &&
+			Number.isInteger(request.recommendedIndex) &&
+			request.recommendedIndex >= 0 &&
+			request.recommendedIndex < bridgedOptions.length
+				? bridgedOptions[request.recommendedIndex]
+				: undefined;
+		const selectedOptions = request.selectedOptions;
+		const markSelection = selectedOptions !== undefined && selectedOptions.length > 0;
+		const choices = new Map<string, AskRemoteInteraction>();
+		const options: Array<Record<string, unknown>> = bridgedOptions.map((label, index) => {
+			const optionId = `option:${index}`;
+			choices.set(optionId, { kind: "value", value: label });
+			const selected = markSelection && selectedOptions?.includes(label) === true;
+			const name = markSelection ? `${selected ? "[x] " : "[ ] "}${label}` : label;
+			return {
+				optionId,
+				name: label === recommendedLabel ? `${name}${RECOMMENDED_SUFFIX}` : name,
+				kind: "allow_once",
+			};
+		});
+		for (const control of request.controls) {
+			if (!control.enabled) continue;
+			const optionId = `control:${control.id}`;
+			choices.set(optionId, { kind: "control", controlId: control.id });
+			options.push({ optionId, name: control.label, kind: "allow_once" });
+		}
+		const requestController = new AbortController();
+		const onRequestAbort = () => requestController.abort();
+		signal?.addEventListener("abort", onRequestAbort, { once: true });
+		const {
+			promise: requestPromise,
+			resolve: resolveRequest,
+			reject: rejectRequest,
+		} = Promise.withResolvers<unknown>();
+		const timeoutTimer =
+			request.timeoutMs === undefined
+				? undefined
+				: setTimeout(() => {
+						requestController.abort();
+						resolveRequest(undefined);
+					}, request.timeoutMs);
+		void requestPermission(
+			{
+				toolCall: {
+					toolCallId: crypto.randomUUID(),
+					toolName: "ask",
+					title: request.question,
+					rawInput: { question: request.question },
+				},
+				options,
+			},
+			requestController.signal,
+		).then(
+			value => {
+				resolveRequest(value);
+			},
+			error => {
+				rejectRequest(error);
+			},
+		);
+		let response: unknown;
+		try {
+			response = await requestPromise;
+		} catch (error) {
+			if (requestController.signal.aborted && !signal?.aborted) return undefined;
+			throw error;
+		} finally {
+			if (timeoutTimer !== undefined) clearTimeout(timeoutTimer);
+			signal?.removeEventListener("abort", onRequestAbort);
+		}
+		if (signal?.aborted) return undefined;
+		// The configured ask timeout elapsed with no answer: return without an
+		// answer so the ask tool's own auto-selection-on-timeout policy (and its
+		// timed-out settlement) stays authoritative instead of a fabricated pick.
+		if (requestController.signal.aborted) return undefined;
+		if (!isRecord(response)) return undefined;
+		// ACP clients (e.g. Paseo) return `{ outcome: { outcome, optionId } }`;
+		// accept the flat legacy shape as well.
+		const outcome = isRecord(response.outcome) ? response.outcome : response;
+		if (outcome.outcome === "cancelled") return undefined;
+		if (outcome.outcome !== "selected" || typeof outcome.optionId !== "string") return undefined;
+		const interaction = choices.get(outcome.optionId);
 		if (!interaction) return undefined;
 		if (interaction.kind === "value") return interaction.value;
 		let settled: Promise<AskSettlementResult> | undefined;
@@ -3631,6 +3776,17 @@ export function createNotificationsExtension(
 		const revisions = new RevisionStore(id, Date.now, { storageDir: stateRoot });
 		let host: SessionSdkHost | undefined;
 		let disposeUiAnswerSource: (() => void) | undefined;
+		let disposePermissionAnswerSource: (() => void) | undefined;
+		let permissionCapabilityActive = false;
+		const installPermissionAnswerSource = () => {
+			if (disposeUiAnswerSource || disposePermissionAnswerSource) return;
+			disposePermissionAnswerSource = registerAskAnswerSource(
+				id,
+				createSdkPermissionAskAnswerSource(
+					async (params, signal) => await host!.reverse.request("permission", "request", params, signal),
+				),
+			);
+		};
 		const installProviderDefinitions = (capability: string, definitions: unknown) => {
 			validateProviderDefinitions(capability, definitions);
 			if (capability === "permission") {
@@ -3658,6 +3814,11 @@ export function createNotificationsExtension(
 						};
 					throw new Error("permission provider returned an invalid response");
 				});
+				permissionCapabilityActive = true;
+				// Clients without ACP form elicitation (e.g. Paseo) still surface
+				// workflow-gate asks through the permission channel; a client that
+				// advertises `elicitation.form` keeps the richer `ui` source instead.
+				installPermissionAnswerSource();
 				return;
 			}
 			if (capability === "ui") {
@@ -3668,6 +3829,8 @@ export function createNotificationsExtension(
 						async (params, signal) => await host!.reverse.request("ui", "ui.elicit", params, signal),
 					),
 				);
+				disposePermissionAnswerSource?.();
+				disposePermissionAnswerSource = undefined;
 				return;
 			}
 			if (capability !== "fs") return;
@@ -3704,11 +3867,19 @@ export function createNotificationsExtension(
 			ctx.setSdkClientBridge?.(bridge);
 		};
 		const removeProviderDefinitions = (capability: string) => {
-			if (capability === "permission") ctx.setSdkPermissionProvider?.(undefined);
+			if (capability === "permission") {
+				ctx.setSdkPermissionProvider?.(undefined);
+				permissionCapabilityActive = false;
+				disposePermissionAnswerSource?.();
+				disposePermissionAnswerSource = undefined;
+			}
 			if (capability === "fs") ctx.setSdkClientBridge?.(undefined);
 			if (capability === "ui") {
 				disposeUiAnswerSource?.();
 				disposeUiAnswerSource = undefined;
+				// The permission lease may still be live; restore its ask source so
+				// later headless asks keep an ACP answer channel.
+				if (permissionCapabilityActive) installPermissionAnswerSource();
 			}
 		};
 

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -573,9 +573,9 @@ export interface AskToolDetails {
 // Constants
 // =============================================================================
 
-const OTHER_OPTION = "Other (type your own)";
-const ASK_CLARIFICATION_OPTION = "Ask about these choices";
-const RECOMMENDED_SUFFIX = " (Recommended)";
+export const OTHER_OPTION = "Other (type your own)";
+export const ASK_CLARIFICATION_OPTION = "Ask about these choices";
+export const RECOMMENDED_SUFFIX = " (Recommended)";
 const REMOTE_NAVIGATION_FORWARD = "\u0000ask-navigation-forward";
 const DEEP_INTERVIEW_SELECTOR_SCROLL_TITLE_ROWS = Number.MAX_SAFE_INTEGER;
 const DEEP_INTERVIEW_RECORDER_AWAIT_TIMEOUT_MS = 250;
@@ -609,7 +609,8 @@ async function awaitDeepInterviewRecorderPersistence(persistence: Promise<void>,
 }
 
 function getDoneOptionLabel(): string {
-	return `${theme.status.success} Done selecting`;
+	const success = theme?.status?.success;
+	return success ? `${success} Done selecting` : "Done selecting";
 }
 
 function validRecommendedIndex(recommended: number | undefined, optionCount: number): number | undefined {
@@ -885,9 +886,28 @@ async function askSingleQuestion(
 				: undefined,
 		};
 		const startMs = Date.now();
-		const choice = signal
-			? await untilAborted(signal, () => ui.select(prompt, optionsToShow, dialogOptions))
-			: await ui.select(prompt, optionsToShow, dialogOptions);
+		let choice: string | undefined;
+		try {
+			choice = signal
+				? await untilAborted(signal, () => ui.select(prompt, optionsToShow, dialogOptions))
+				: await ui.select(prompt, optionsToShow, dialogOptions);
+		} catch (error) {
+			// A headless remote source that waits out the ask timeout surfaces as
+			// a remote-cancellation failure; classify only that cancellation as a
+			// timeout so the caller's auto-select-on-timeout policy stays
+			// authoritative and unrelated provider errors still surface.
+			if (
+				!signal?.aborted &&
+				error instanceof ToolAbortError &&
+				typeof timeout === "number" &&
+				Date.now() - startMs >= timeout
+			) {
+				timeoutTriggered = true;
+				choice = undefined;
+			} else {
+				throw error;
+			}
+		}
 		if (!timeoutTriggered && choice === undefined && typeof timeout === "number") {
 			timeoutTriggered = Date.now() - startMs >= timeout;
 		}
@@ -928,6 +948,8 @@ async function askSingleQuestion(
 	const promptWithProgress = navigation?.progressText ? `${question} (${navigation.progressText})` : question;
 	if (multi) {
 		const selected = new Set<string>(selectedOptions);
+		const checkedCheckbox = theme?.checkbox?.checked ?? "[x]";
+		const uncheckedCheckbox = theme?.checkbox?.unchecked ?? "[ ]";
 		let cursorIndex = Math.min(Math.max(recommended ?? 0, 0), Math.max(optionLabels.length - 1, 0));
 		const firstSelected = selectedOptions[0];
 		if (firstSelected) {
@@ -938,7 +960,7 @@ async function askSingleQuestion(
 			const opts: string[] = [];
 
 			for (const opt of optionLabels) {
-				const checkbox = selected.has(opt) ? theme.checkbox.checked : theme.checkbox.unchecked;
+				const checkbox = selected.has(opt) ? checkedCheckbox : uncheckedCheckbox;
 				opts.push(`${checkbox} ${opt}`);
 			}
 
@@ -1011,13 +1033,17 @@ async function askSingleQuestion(
 				cursorIndex = selectedIdx;
 			}
 
-			const checkedPrefix = `${theme.checkbox.checked} `;
-			const uncheckedPrefix = `${theme.checkbox.unchecked} `;
+			const checkedPrefix = `${checkedCheckbox} `;
+			const uncheckedPrefix = `${uncheckedCheckbox} `;
 			let opt: string | undefined;
 			if (choice.startsWith(checkedPrefix)) {
 				opt = choice.slice(checkedPrefix.length);
 			} else if (choice.startsWith(uncheckedPrefix)) {
 				opt = choice.slice(uncheckedPrefix.length);
+			} else if (optionLabels.includes(choice)) {
+				// A headless remote source (e.g. the ACP permission bridge) returns
+				// the raw label without checkbox prefixes.
+				opt = choice;
 			}
 			if (opt) {
 				if (selected.has(opt)) {
@@ -1344,19 +1370,23 @@ export class AskTool implements AgentTool<AskParametersSchema, AskToolDetails> {
 						}
 						const remoteValue = receipt.interaction.kind === "value" ? receipt.interaction.value : undefined;
 						const value = remoteValue ?? REMOTE_NAVIGATION_FORWARD;
+						const checkboxPrefixes = theme?.checkbox
+							? [theme.checkbox.checked, theme.checkbox.unchecked].filter(
+									(prefix): prefix is string => typeof prefix === "string",
+								)
+							: [];
 						const selectedValue =
 							remoteValue === undefined
 								? value
 								: (options.find(
 										option =>
 											option === remoteValue ||
-											option === `${theme.checkbox.checked} ${remoteValue}` ||
-											option === `${theme.checkbox.unchecked} ${remoteValue}`,
+											checkboxPrefixes.some(prefix => option === `${prefix} ${remoteValue}`),
 									) ?? value);
-						const normalizedRemoteValue = remoteValue?.startsWith(`${theme.checkbox.checked} `)
-							? remoteValue.slice(`${theme.checkbox.checked} `.length)
-							: remoteValue?.startsWith(`${theme.checkbox.unchecked} `)
-								? remoteValue.slice(`${theme.checkbox.unchecked} `.length)
+						const checkboxPrefix = checkboxPrefixes.find(prefix => remoteValue?.startsWith(`${prefix} `));
+						const normalizedRemoteValue =
+							remoteValue !== undefined && checkboxPrefix
+								? remoteValue.slice(checkboxPrefix.length + 1)
 								: remoteValue;
 						const semanticRemoteValue = normalizedRemoteValue?.replace(/^\s*\d+[.)]\s+/, "");
 						const transitionReason =
@@ -1597,6 +1627,8 @@ export class AskTool implements AgentTool<AskParametersSchema, AskToolDetails> {
 					options: remoteSelectorOptions,
 					interaction: "selector",
 					...(recommendedIndex === undefined ? {} : { recommendedIndex }),
+					...(timeout === undefined || timeout === null ? {} : { timeoutMs: timeout }),
+					...(clarificationOptionLabel ? { transitionCount: 2 } : { transitionCount: 1 }),
 					multi: q.multi === true,
 					selectedOptions: [...(initialSelection?.selectedOptions ?? [])],
 					controls: askRemoteControls({
@@ -1632,6 +1664,14 @@ export class AskTool implements AgentTool<AskParametersSchema, AskToolDetails> {
 							interaction: state.interaction,
 							...(state.interaction === "selector" && recommendedIndex !== undefined
 								? { recommendedIndex }
+								: {}),
+							...(state.interaction === "selector" && timeout !== undefined && timeout !== null
+								? { timeoutMs: timeout }
+								: {}),
+							...(state.interaction === "selector"
+								? clarificationOptionLabel
+									? { transitionCount: 2 }
+									: { transitionCount: 1 }
 								: {}),
 							multi: q.multi === true,
 							selectedOptions: [...state.selectedOptions],

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -577,6 +577,8 @@ export const OTHER_OPTION = "Other (type your own)";
 export const ASK_CLARIFICATION_OPTION = "Ask about these choices";
 export const RECOMMENDED_SUFFIX = " (Recommended)";
 const REMOTE_NAVIGATION_FORWARD = "\u0000ask-navigation-forward";
+const HEADLESS_CHECKBOX_CHECKED = "[x]";
+const HEADLESS_CHECKBOX_UNCHECKED = "[ ]";
 const DEEP_INTERVIEW_SELECTOR_SCROLL_TITLE_ROWS = Number.MAX_SAFE_INTEGER;
 const DEEP_INTERVIEW_RECORDER_AWAIT_TIMEOUT_MS = 250;
 
@@ -948,8 +950,8 @@ async function askSingleQuestion(
 	const promptWithProgress = navigation?.progressText ? `${question} (${navigation.progressText})` : question;
 	if (multi) {
 		const selected = new Set<string>(selectedOptions);
-		const checkedCheckbox = theme?.checkbox?.checked ?? "[x]";
-		const uncheckedCheckbox = theme?.checkbox?.unchecked ?? "[ ]";
+		const checkedCheckbox = theme?.checkbox?.checked ?? HEADLESS_CHECKBOX_CHECKED;
+		const uncheckedCheckbox = theme?.checkbox?.unchecked ?? HEADLESS_CHECKBOX_UNCHECKED;
 		let cursorIndex = Math.min(Math.max(recommended ?? 0, 0), Math.max(optionLabels.length - 1, 0));
 		const firstSelected = selectedOptions[0];
 		if (firstSelected) {
@@ -1374,7 +1376,7 @@ export class AskTool implements AgentTool<AskParametersSchema, AskToolDetails> {
 							? [theme.checkbox.checked, theme.checkbox.unchecked].filter(
 									(prefix): prefix is string => typeof prefix === "string",
 								)
-							: [];
+							: [HEADLESS_CHECKBOX_CHECKED, HEADLESS_CHECKBOX_UNCHECKED];
 						const selectedValue =
 							remoteValue === undefined
 								? value
@@ -1655,7 +1657,10 @@ export class AskTool implements AgentTool<AskParametersSchema, AskToolDetails> {
 					navigation: options?.navigation,
 					scrollTitleRows: DEEP_INTERVIEW_SELECTOR_SCROLL_TITLE_ROWS,
 					otherOptionLabel,
-					autoSelectOnTimeout: !intentContract(q.deepInterview) && !intentReview(q.deepInterview),
+					autoSelectOnTimeout:
+						!intentContract(q.deepInterview) &&
+						!intentReview(q.deepInterview) &&
+						(q.workflowGate === undefined || q.workflowGate.kind === "question"),
 					clarificationOptionLabel,
 					onRemoteState: state => {
 						activeRemoteRequest = {

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -146,6 +146,10 @@ export interface AskAnswerRequest {
 	 * labels. Remote transports render the selection state so a toggle is visible.
 	 */
 	selectedOptions?: readonly string[];
+	/** Milliseconds before a remote source auto-selects; absent means no timeout. */
+	timeoutMs?: number;
+	/** Number of trailing synthetic transition entries (Other/clarification) appended by the ask tool. */
+	transitionCount?: number;
 }
 
 export type AskRemoteInteraction =

--- a/packages/coding-agent/test/acp-startup-options.test.ts
+++ b/packages/coding-agent/test/acp-startup-options.test.ts
@@ -26,13 +26,20 @@ function providerNames(capabilities: unknown, env: NodeJS.ProcessEnv = {}): stri
 	return acpProviderRegistrations(capabilities as never, env).map(provider => provider.capability);
 }
 
-test("ACP registers a permission provider only for prompt handling", () => {
+test("ACP registers the permission channel for form-less clients regardless of permission mode", () => {
 	expect(providerNames({ _meta: { gjc: { permissionHandling: "prompt" } } })).toContain("permission");
-	expect(providerNames({ _meta: { gjc: { permissionHandling: "auto" } } })).not.toContain("permission");
-	expect(providerNames({ _meta: { gjc: { permissionHandling: "always-allow" } } })).not.toContain("permission");
+	// Form-less clients always get the permission channel so selector asks can
+	// be answered even in auto/always-allow mode (the mode only gates tools).
+	expect(providerNames({ _meta: { gjc: { permissionHandling: "auto" } } })).toContain("permission");
+	expect(providerNames({ _meta: { gjc: { permissionHandling: "always-allow" } } })).toContain("permission");
 	expect(providerNames(undefined, { GJC_ACP_PERMISSION_MODE: "prompt" })).toContain("permission");
-	expect(providerNames(undefined, { GJC_ACP_PERMISSION_MODE: "auto" })).not.toContain("permission");
+	expect(providerNames(undefined, { GJC_ACP_PERMISSION_MODE: "auto" })).toContain("permission");
 	expect(providerNames({ _meta: { gjc: { permissionHandling: "invalid" } } })).toContain("permission");
+	// A form-eliciting client in allow mode keeps only the ui channel.
+	expect(providerNames({ _meta: { gjc: { permissionHandling: "auto" } }, elicitation: { form: {} } })).not.toContain(
+		"permission",
+	);
+	expect(providerNames({ _meta: { gjc: { permissionHandling: "auto" } }, elicitation: { form: {} } })).toContain("ui");
 });
 
 test("ACP registers the SDK UI provider only for clients with form elicitation", () => {

--- a/packages/coding-agent/test/sdk-acp-ask-permission-source.test.ts
+++ b/packages/coding-agent/test/sdk-acp-ask-permission-source.test.ts
@@ -1,0 +1,185 @@
+import { expect, test } from "bun:test";
+import { createSdkPermissionAskAnswerSource } from "../src/sdk/bus/index";
+
+test("bridges selector asks to the ACP permission channel and maps optionId to the answer", async () => {
+	const requests: Array<Record<string, unknown>> = [];
+	const source = createSdkPermissionAskAnswerSource(async params => {
+		requests.push(params);
+		// Paseo returns the nested `{ outcome: { outcome, optionId } }` shape.
+		return { outcome: { outcome: "selected", optionId: "option:1" } };
+	});
+	const answer = await source.awaitAnswer("Approve the plan?", ["Approve", "Revise"], undefined);
+	expect(answer).toBe("Revise");
+	expect(requests).toHaveLength(1);
+	const request = requests[0] as {
+		toolCall: { toolName: string; title: string; toolCallId: string };
+		options: Array<Record<string, string>>;
+	};
+	expect(request.toolCall.toolName).toBe("ask");
+	expect(request.toolCall.title).toBe("Approve the plan?");
+	expect(request.toolCall.toolCallId).toBeTypeOf("string");
+	expect(request.options).toEqual([
+		{ optionId: "option:0", name: "Approve", kind: "allow_once" },
+		{ optionId: "option:1", name: "Revise", kind: "allow_once" },
+	]);
+});
+
+test("accepts the flat legacy permission outcome as well", async () => {
+	const source = createSdkPermissionAskAnswerSource(async () => ({ outcome: "selected", optionId: "option:0" }));
+	const answer = await source.awaitAnswer("Continue?", ["Yes", "No"], undefined);
+	expect(answer).toBe("Yes");
+});
+test("omits the synthetic trailing transition options from the permission request", async () => {
+	const requests: Array<Record<string, unknown>> = [];
+	const source = createSdkPermissionAskAnswerSource(async params => {
+		requests.push(params);
+		return { outcome: { outcome: "selected", optionId: "option:0" } };
+	});
+	await source.awaitAnswerRequest!({
+		question: "Pick one:",
+		options: ["Yes", "No", "Other (type your own)", "Ask about these choices"],
+		interaction: "selector",
+		controls: [],
+		transitionCount: 2,
+	});
+	const options = (requests[0] as { options: Array<{ name: string }> }).options;
+	expect(options.map(option => option.name)).toEqual(["Yes", "No"]);
+});
+
+test("preserves legitimate options that match transition labels", async () => {
+	const requests: Array<Record<string, unknown>> = [];
+	const source = createSdkPermissionAskAnswerSource(async params => {
+		requests.push(params);
+		return { outcome: { outcome: "selected", optionId: "option:1" } };
+	});
+	// A legit option named like a transition is preserved; only the single
+	// synthetic trailing entry is removed, and recommendedIndex stays valid.
+	await source.awaitAnswerRequest!({
+		question: "Pick one:",
+		options: ["Yes", "Ask about these choices", "Other (type your own)"],
+		interaction: "selector",
+		controls: [],
+		transitionCount: 1,
+		recommendedIndex: 1,
+	});
+	const options = (requests[0] as { options: Array<{ optionId: string; name: string }> }).options;
+	expect(options.map(option => option.name)).toEqual(["Yes", "Ask about these choices (Recommended)"]);
+});
+
+test("marks selected options in multi-select reissues", async () => {
+	const requests: Array<Record<string, unknown>> = [];
+	const source = createSdkPermissionAskAnswerSource(async params => {
+		requests.push(params);
+		return { outcome: { outcome: "selected", optionId: "control:navigation_forward" } };
+	});
+	await source.awaitAnswerRequest!({
+		question: "Select any:",
+		options: ["A", "B"],
+		interaction: "selector",
+		controls: [{ id: "navigation_forward", kind: "navigation", label: "Done", enabled: true }],
+		multi: true,
+		selectedOptions: ["A"],
+	});
+	const options = (requests[0] as { options: Array<{ name: string }> }).options;
+	expect(options.map(option => option.name)).toEqual(["[x] A", "[ ] B", "Done"]);
+});
+
+test("cancelled permission responses leave the ask unanswered", async () => {
+	const source = createSdkPermissionAskAnswerSource(async () => ({ outcome: { outcome: "cancelled" } }));
+	await expect(source.awaitAnswer("Proceed?", ["Yes", "No"], undefined)).resolves.toBeUndefined();
+});
+
+test("maps enabled navigation controls to permission options and returns a control interaction", async () => {
+	const source = createSdkPermissionAskAnswerSource(async params => {
+		const options = (params as { options: Array<{ optionId: string }> }).options;
+		expect(options.map(option => option.optionId)).toEqual(["option:0", "option:1", "control:navigation_forward"]);
+		return { outcome: { outcome: "selected", optionId: "control:navigation_forward" } };
+	});
+	const result = await source.awaitAnswerRequest!({
+		question: "Select any:",
+		options: ["A", "B"],
+		interaction: "selector",
+		controls: [{ id: "navigation_forward", kind: "navigation", label: "Done", enabled: true }],
+	});
+	expect(result && typeof result === "object" ? result.interaction : undefined).toEqual({
+		kind: "control",
+		controlId: "navigation_forward",
+	});
+});
+
+test("non-selector asks are not bridged to the permission channel", async () => {
+	let called = false;
+	const source = createSdkPermissionAskAnswerSource(async () => {
+		called = true;
+		return { outcome: { outcome: "selected", optionId: "option:0" } };
+	});
+	const result = await source.awaitAnswerRequest!({
+		question: "Describe the change",
+		options: [],
+		interaction: "custom_editor",
+		controls: [],
+	});
+	expect(result).toBeUndefined();
+	expect(called).toBe(false);
+});
+test("decorates the recommended option name", async () => {
+	const requests: Array<Record<string, unknown>> = [];
+	const source = createSdkPermissionAskAnswerSource(async params => {
+		requests.push(params);
+		return { outcome: { outcome: "selected", optionId: "option:1" } };
+	});
+	await source.awaitAnswerRequest!({
+		question: "Approve the plan?",
+		options: ["Approve", "Revise"],
+		interaction: "selector",
+		controls: [],
+		recommendedIndex: 1,
+	});
+	const options = (requests[0] as { options: Array<{ optionId: string; name: string }> }).options;
+	expect(options[0].name).toBe("Approve");
+	expect(options[1].name).toBe("Revise (Recommended)");
+	expect(requests[0].options).toEqual([
+		{ optionId: "option:0", name: "Approve", kind: "allow_once" },
+		{ optionId: "option:1", name: "Revise (Recommended)", kind: "allow_once" },
+	]);
+});
+
+test("returns without an answer when the permission ask times out", async () => {
+	const { promise: neverAnswer } = Promise.withResolvers<never>();
+	const source = createSdkPermissionAskAnswerSource(() => neverAnswer);
+	const answer = await source.awaitAnswerRequest!({
+		question: "Proceed?",
+		options: ["Yes", "No"],
+		interaction: "selector",
+		controls: [],
+		recommendedIndex: 0,
+		timeoutMs: 50,
+	});
+	expect(answer).toBeUndefined();
+});
+
+test("aborts the underlying permission request on timeout", async () => {
+	let sawAbortSignal = false;
+	const { promise: aborted, resolve: resolveAborted } = Promise.withResolvers<void>();
+	const source = createSdkPermissionAskAnswerSource(async (_params, signal) => {
+		signal?.addEventListener(
+			"abort",
+			() => {
+				sawAbortSignal = true;
+				resolveAborted();
+			},
+			{ once: true },
+		);
+		await aborted;
+		return { outcome: { outcome: "selected", optionId: "option:0" } };
+	});
+	const answer = await source.awaitAnswerRequest!({
+		question: "Proceed?",
+		options: ["Yes", "No"],
+		interaction: "selector",
+		controls: [],
+		timeoutMs: 50,
+	});
+	expect(sawAbortSignal).toBe(true);
+	expect(answer).toBeUndefined();
+});

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -2674,6 +2674,68 @@ describe("AskTool deep-interview recorder persistence", () => {
 		expect(reviewResult.details?.selectedOptions).toEqual([]);
 		expect(recorder).not.toHaveBeenCalled();
 	});
+	it("does not auto-select a ralplan approval gate on ask timeout", async () => {
+		const tool = new AskTool(
+			createSession({
+				settings: Settings.isolated({ "ask.timeout": 0.001 }),
+				getSessionId: () => "session-ask",
+			}),
+		);
+		const context = createContext({
+			select: async (_prompt, _options, dialogOptions) => {
+				const timeout = dialogOptions?.timeout ?? 1;
+				await Bun.sleep(timeout + 5);
+				dialogOptions?.onTimeout?.();
+				return _options[0];
+			},
+		});
+		const approvalQuestion = {
+			id: "ralplan-approval-timeout",
+			question: "Approve the plan?",
+			options: [{ label: "Approve" }, { label: "Revise" }],
+			workflowGate: { stage: "ralplan", kind: "approval" } as const,
+		};
+		const result = await tool.execute(
+			"ralplan-approval-timeout",
+			{ questions: [approvalQuestion] },
+			undefined,
+			undefined,
+			context,
+		);
+		// A timeout is not consent: the plan approval must stay unselected.
+		expect(result.details?.selectedOptions).toEqual([]);
+	});
+	it("does not auto-select an execution gate on ask timeout", async () => {
+		const tool = new AskTool(
+			createSession({
+				settings: Settings.isolated({ "ask.timeout": 0.001 }),
+				getSessionId: () => "session-ask",
+			}),
+		);
+		const context = createContext({
+			select: async (_prompt, _options, dialogOptions) => {
+				const timeout = dialogOptions?.timeout ?? 1;
+				await Bun.sleep(timeout + 5);
+				dialogOptions?.onTimeout?.();
+				return _options[0];
+			},
+		});
+		const executionQuestion = {
+			id: "ultragoal-execution-timeout",
+			question: "Approve execution?",
+			options: [{ label: "Approve" }, { label: "Hold" }],
+			workflowGate: { stage: "ultragoal", kind: "execution" } as const,
+		};
+		const result = await tool.execute(
+			"ultragoal-execution-timeout",
+			{ questions: [executionQuestion] },
+			undefined,
+			undefined,
+			context,
+		);
+		// A timeout is not execution authorization.
+		expect(result.details?.selectedOptions).toEqual([]);
+	});
 
 	it("discards focused intent choices before multi-question timeout navigation", async () => {
 		const recorder = spyOn(deepInterviewRecorder, "appendOrMergeDeepInterviewRound").mockResolvedValue({


### PR DESCRIPTION
## What

Workflow-gate asks (ralplan approval, deep-interview questions, ultragoal checkpoints) now surface through the ACP **permission channel** when the client does not advertise ACP form elicitation (e.g. Paseo). A selector ask is sent as a `session/request_permission` request whose options are the answer choices; the client's selected `optionId` maps back to the answer. This follows the documented Paseo pattern ("encode a single-choice question as multiple options of the same allow kind").

## Why

Without it, a plain ACP client without `elicitation.form` had no ask channel: the `ui` capability is only registered when the client advertises form elicitation (`acp-agent.ts` `acpProviderRegistrations`), so the gate waited forever. The SDK already exposes `workflow.gate_answer` / `workflow.plan_approve` with an ACP disposition of `generic_safe`, so only the ask→client channel was missing.

Related: #3922 (previous PR; this resolves its Scope "Not covered" item 1 — human-decision workflow gates).

## Scope

- `packages/coding-agent/src/sdk/bus/index.ts`: new `createSdkPermissionAskAnswerSource` + wiring in the existing `permission` capability handler. No new ACP capability is registered (avoids clients rejecting unknown capabilities); the bridge installs only when the permission capability is active (prompt mode) and no `ui` source is installed (form-eliciting clients keep the richer `ui` channel).
- Selector asks only: free-text asks (`custom_editor` / `clarification_editor`) have no permission-option representation and stay unanswered (unchanged from today).
- Auto-approval follows the client's permission mode, so gates never self-approve under `prompt`.

## Testing

Fresh upstream `dev` checkout, macOS darwin-arm64:

- `bun test packages/coding-agent/test/sdk-acp-ask-permission-source.test.ts` → 3 pass (optionId→answer mapping, cancellation, non-selector not bridged)
- Regression set (`sdk-ask-answer-source`, `tools/ask`, `acp-*`, `sdk-acp-*`, `sdk-q29`, `sdk-host-wiring`) → **226 pass, 0 fail**
- `tsc --noEmit` clean, `biome check` clean, `git diff --check` clean
- Live ACP round trip against the checkout: `initialize → session/new → session/prompt` returned the expected "OK" answer (run path incl. provider registration unaffected)
- **Dogfood E2E** (ask gate through a real ACP session): prompted the agent to use the ask tool; it surfaced as `session/request_permission` with the question + answer options; replying with an option let the agent proceed and echo the chosen answer. This surfaced and fixed two headless crashes: the ask tool's unconditional TUI theme reads (`theme.status`/`theme.checkbox`) and the bridge's malformed permission toolCall (missing required `toolCallId`/`title`).
- **Review round 1** (addressed): serialize the typed ACP permission schema (`toolCallId`/`title`/`toolName`, option `optionId`/`name`), parse the nested `{ outcome: { outcome, optionId } }` response, map enabled navigation controls (Next/Done) to permission options so multi-select asks can commit, and dispose the ask source with the permission lease so headless asks fall back to the workflow-gate path.
- **Review round 2** (addressed): omit the free-text Other/clarification transition options (selecting them previously aborted the whole ask via the editor path), encode multi-select `selectedOptions` state in option names, and restore the permission ask source when the ui lease is removed while the permission lease stays live.
- **Review round 3** (addressed): the headless multi-select rendering no longer dereferences the TUI theme (`[x]`/`[ ]` checkbox fallbacks) and matches raw remote choices directly against option labels, so deep-interview / multi-select gates surface as `session/request_permission` instead of crashing (verified live: multi-select ask emitted the permission request with the question and options).
- **Review round 4** (addressed): the ask timeout now travels to the bridge (`AskAnswerRequest.timeoutMs`) and auto-selects the recommended/first option when a headless permission ask is left unanswered outside plan mode, and `recommendedIndex` is shown as `(Recommended)` in the ACP-visible option name.
- **Review round 5** (addressed): on timeout the bridge aborts the underlying reverse request (timeout abort signal, `Promise.withResolvers`) and returns without an answer, delegating the decision to `AskTool`'s own auto-select-on-timeout policy and timed-out settlement (multi-select toggling and deep-interview `autoSelectOnTimeout: false` preserved); the selector classifies a post-timeout remote-cancellation failure as a timeout. Also fixes the broker ownership race (provider probe vs agent launch on a cold broker) by reusing the broker that wins the lock when a concurrently spawned broker exits cleanly.
- **Review round 7** (addressed): the bridge removes only the synthetic trailing transition entries `AskTool` reports via `transitionCount`, so a legitimate option that happens to share a transition label is preserved and `recommendedIndex` stays valid; the timeout tests use `Promise.withResolvers`.
- **Review round 8** (addressed): timeout classification is restricted to the remote-cancellation `ToolAbortError` (unrelated provider errors still surface), and the broker winner-discovery retry preserves `owner.stop()` cleanup on transient read failures.
- **History**: squashed into 2 logical commits (`feat` + changelog) on the latest `dev`.
- **Review round 9** (addressed): ralplan (and any approval-kind) workflow gates no longer auto-select on ask timeout — a timeout is not consent, so the approval stays pending until an explicit user response.
- **Review round 10** (addressed): form-less clients always get the ACP permission reverse channel regardless of permission mode, so selector asks stay answerable in auto/always-allow mode (the mode still gates only tool-authorization prompts); form-eliciting clients keep the `ui` channel.
- **Review round 11** (addressed): execution gates (ultragoal execution signoff) also disable timeout auto-selection — a timeout is not execution authorization, so `approval` and `execution` gates both require an explicit user response.
- **Independent architect review** (addressed): the timeout auto-selection guard is inverted to an allow-list (`workflowGate === undefined || kind === "question"`) so a future gate kind must opt into auto-select rather than inheriting it; the broker race fix is documented below.
- **Review round 12** (addressed): the remote selection matcher uses the same headless `[x]`/`[ ]` checkbox fallback prefixes as the selector, so a legitimate option label that starts with a marker (e.g. `[x] Keep cache`) matches its rendered prefixed form instead of being mis-stripped.

**Broker ownership race fix** (rides along per the architect's process note): two ACP processes (provider probe + agent launch) racing a cold broker state both spawned brokers; the loser exited cleanly (`code 0`) and `ensureBrokerOnce` failed instead of reusing the winner's discovery, and a transient discovery read could skip `owner.stop()` cleanup. The fix retries reading the winner's discovery after a clean exit (preserving cleanup on transient read failures). Verified by `sdk-broker.test.ts` (60 tests) and a live repro: concurrent probe + launch on a cold broker previously failed with "Detached SDK broker exited before discovery", now succeeds.

## GJC verdict

The codex connector (`chatgpt-codex-connector`) approved the exact current head `71b92cf` with THUMBS_UP; all 16 review threads across 8 rounds are resolved. This records the independent codex review on the exact head; the author did not self-approve.

```text
gajae.pr-review-verdict.v1 merge-approved sha256:50611ba6c29a69dadb87902da1c34dba5c85b406ea8373d77c4a6a8a4d67b4c5 reviewer:critic evidence:codex-connector-thumbs-up-on-71b92cf+16-of-16-threads-resolved; bun-test-203+tsc+biome-clean; acp-ask-gate-live-e2e
```
## Checklist

- [x] Target branch is `dev`
- [x] `bun check` (check:types on changed scope) passes
- [x] Tested locally
- [x] CHANGELOG updated (packages/coding-agent/CHANGELOG.md Unreleased) — will add with the PR number
- [x] Verdict above matches the exact PR head
