### PR TITLE
fix(ai): advance explicit Anthropic cache through tool loops

### DIFF
--- a/artifacts/issue-3670-anthropic-cache-eval.json
+++ b/artifacts/issue-3670-anthropic-cache-eval.json
@@ -6,8 +6,8 @@
 	"source": {
 		"url": "https://platform.claude.com/docs/en/build-with-claude/prompt-caching",
 		"retrievedAt": "2026-07-18",
-		"providerSourceBlobOid": "bc15958b9b80add7af990abd0e82d0450640a931",
-		"providerSourceSha256": "3d926409bf0a7b4ec1d7222a4c402f18b3ee5c01a5f01c6d84d8894bda16e963",
+		"providerSourceBlobOid": "a8f9134b09ceb66d273fd3e9190a3789cbdc15fd",
+		"providerSourceSha256": "e40dde0fe4fc7acdc98437a89c7d4232f10871207f1876fb837453bc59be98fe",
 		"inputFixtureSha256": "b1ca8d3183ca168140774f848ed414252178f7c5788d61243069862ae59c129b"
 	},
 	"derivationCommands": [

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Anthropic thinking-replay repair now also recovers when a proxy masks the rejection entirely (issue #3900). Live CLIProxyAPI captures replace the upstream 400 body with a generic `{"type":"api_error","message":"An error occurred while processing the request."}` SSE event on an HTTP 200 response, which names no cause and matches no transient phrase, so the turn died on the first attempt. Such a masked rejection now takes the same one-shot latest-then-full-history repair, but only before the first token and only while the request actually replays signed `thinking`/`redacted_thinking` blocks; masked failures on requests without replayed thinking still surface immediately. The classifier is exported as `isAnthropicMaskedProxyRejection`.
 
 - Anthropic cache-control resolution now falls back to `model.cacheRetention` at the provider boundary, preserving configured retention and request-over-model precedence through special dispatch wrappers such as GitLab Duo. A configured `cacheRetention: "none"` can no longer be dropped and replaced by the new automatic Claude-family cache marker.
+- Anthropic explicit prompt caching now advances its conversation breakpoint during tool-use loops by marking the latest completed assistant tool-use turn while leaving the newest tool result uncached. Previously it kept refreshing only the original human message until another human turn arrived, pinning proxy cache reads to the static tools/system prefix throughout long agentic runs.
 ## [0.12.12] - 2026-08-05
 
 ### Fixed

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2332,10 +2332,11 @@ function applyExplicitPromptCaching(params: AnthropicCacheParams, cacheControl: 
 	const currentUser = params.messages[currentUserIndex];
 	if (!currentUser) return;
 
-	// A tool result is encoded as role "user" on the wire, but belongs to the
-	// preceding assistant turn. Anchor that assistant turn, not the tool result,
-	// so changing tool output does not invalidate the reusable conversation prefix.
-	for (let index = currentUserIndex - 1; index >= 0; index--) {
+	// Tool results are encoded as role "user" on the wire but belong to the
+	// assistant tool-use turn immediately before them. Anchor the latest completed
+	// assistant turn so the reusable prefix advances during an agent tool loop,
+	// while keeping the newest tool output outside the cache boundary.
+	for (let index = params.messages.length - 1; index >= 0; index--) {
 		const message = params.messages[index];
 		if (message?.role !== "assistant" || !Array.isArray(message.content)) continue;
 		if (

--- a/packages/ai/test/anthropic-cache.test.ts
+++ b/packages/ai/test/anthropic-cache.test.ts
@@ -449,7 +449,7 @@ describe("Anthropic prompt caching", () => {
 		});
 	});
 
-	it("does not treat a tool-result-only wire user turn as the explicit human refresh", async () => {
+	it("advances explicit caching to the latest assistant tool-use turn without caching its result", async () => {
 		const payload = await capturePayload(
 			explicitCompatibleModel,
 			context([
@@ -479,12 +479,41 @@ describe("Anthropic prompt caching", () => {
 					isError: false,
 					timestamp: 3,
 				},
+				{
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call_2", name: "lookup", arguments: {} }],
+					api: "anthropic-messages",
+					provider: "anthropic",
+					model: canonicalModel.id,
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "toolUse",
+					timestamp: 4,
+				},
+				{
+					role: "toolResult",
+					toolCallId: "call_2",
+					toolName: "lookup",
+					content: [{ type: "text", text: "Second answer" }],
+					isError: false,
+					timestamp: 5,
+				},
 			]),
 		);
+		const firstAssistantContent = payload.messages[1]?.content as Array<{ cache_control?: CacheControl }>;
+		const latestAssistantContent = payload.messages[3]?.content as Array<{ cache_control?: CacheControl }>;
 		const firstUserContent = payload.messages[0]?.content as Array<{ cache_control?: CacheControl }>;
 		const toolResultContent = payload.messages.at(-1)?.content as Array<{ cache_control?: CacheControl }>;
 
 		expect(firstUserContent.at(-1)?.cache_control).toEqual({ type: "ephemeral" });
+		expect(firstAssistantContent.some(block => block.cache_control)).toBe(false);
+		expect(latestAssistantContent.at(-1)?.cache_control).toEqual({ type: "ephemeral" });
 		expect(toolResultContent.some(block => block.cache_control)).toBe(false);
 	});
 


### PR DESCRIPTION
## Summary

- advance explicit Anthropic cache placement to the latest completed assistant turn during tool-use loops
- keep the newest tool result outside the breakpoint, so changing live tool output does not invalidate the reusable prefix
- preserve the existing current-human refresh marker and ordinary follow-up behavior
- refresh the deterministic Anthropic cache-eval source identity

## Root cause

Explicit mode found the last human user message and searched only before it for an assistant breakpoint. Agentic tool loops add assistant tool-use and tool-result turns without another human message, so every request kept marking the original human turn. Real CLIProxyAPI usage stayed pinned at 52,350 cache-read tokens while the uncached tail grew from roughly 2K to 26K tokens.

## Verification

- `bun test packages/ai/test/anthropic-cache.test.ts packages/ai/test/anthropic-stream-envelope.test.ts packages/ai/test/anthropic-alignment.test.ts packages/ai/test/issue-814-repro.test.ts packages/ai/test/anthropic-cache-eval.integration.test.ts` — 88 pass, 0 fail
- `bun --cwd=packages/ai run check` — Biome and TypeScript pass
- cache-eval write + validation — 2 + 2 pass
- provider source blob matches eval artifact: `a8f9134b09ceb66d273fd3e9190a3789cbdc15fd`
- live three-request Sonnet 5 tool-loop probe through CLIProxyAPI with 13 tools and two system prompts:
  - turn 1: cacheRead 0, cacheWrite 65,915
  - turn 2: cacheRead 65,915, cacheWrite 78
  - turn 3: cacheRead 65,993, cacheWrite 82

The live probe demonstrates the breakpoint now advances through successive assistant tool-use turns instead of remaining pinned to the static tools/system prefix.