### PR TITLE
test(ai): bind cache eval to complete generated inputs

### DIFF
--- a/artifacts/issue-3670-anthropic-cache-eval.json
+++ b/artifacts/issue-3670-anthropic-cache-eval.json
@@ -8,7 +8,7 @@
 		"retrievedAt": "2026-07-18",
 		"providerSourceBlobOid": "5f9708abab7652c3ba56f214d2c92751bea1e2ed",
 		"providerSourceSha256": "fbf80b8d5c1f8ddc94197c7777053a6cd057c9db8b793dbfb201948f1f0d9334",
-		"inputFixtureSha256": "b1ca8d3183ca168140774f848ed414252178f7c5788d61243069862ae59c129b"
+		"inputFixtureSha256": "562926fba79f003eff4d45c0da2292ac66d84302e3960b2d7493441ade1f9e04"
 	},
 	"derivationCommands": [
 		"git rev-parse HEAD:packages/ai/src/providers/anthropic.ts",

--- a/packages/ai/test/anthropic-cache-eval.integration.test.ts
+++ b/packages/ai/test/anthropic-cache-eval.integration.test.ts
@@ -126,6 +126,16 @@ function contextForTurn(turn: number): Context {
 		messages,
 	};
 }
+function evaluationInput(): { model: Model<"anthropic-messages">; contexts: Context[] } {
+	return {
+		model,
+		contexts: fixture.toolResultVariants.map((_, turn) => contextForTurn(turn)),
+	};
+}
+
+function inputFixtureSha256(): Promise<string> {
+	return sha256(JSON.stringify(evaluationInput()));
+}
 
 function capturePayload(turn: number): Promise<Payload> {
 	const controller = new AbortController();
@@ -270,7 +280,7 @@ async function deriveEvidence(): Promise<{
 
 async function buildArtifact(): Promise<EvalArtifact> {
 	const identity = await currentSourceIdentity();
-	const fixtureSha256 = await sha256(JSON.stringify(fixture));
+	const fixtureSha256 = await inputFixtureSha256();
 	const evidence = await deriveEvidence();
 	const perTurn = async (placement: Placement) =>
 		Promise.all(
@@ -334,7 +344,7 @@ describe("Anthropic cache placement eval (deterministic sequential three-request
 		const artifact = (await Bun.file(artifactPath).json()) as EvalArtifact;
 		expect(artifact).toEqual(derivedArtifact);
 		const identity = await currentSourceIdentity();
-		const fixtureSha256 = await sha256(JSON.stringify(fixture));
+		const fixtureSha256 = await inputFixtureSha256();
 		validateSource(artifact, identity, fixtureSha256);
 		expect(() =>
 			validateSource(
@@ -350,6 +360,13 @@ describe("Anthropic cache placement eval (deterministic sequential three-request
 				fixtureSha256,
 			),
 		).toThrow();
+		const tamperedInput = structuredClone(evaluationInput());
+		const tamperedMessage = tamperedInput.contexts[0]?.messages[0];
+		if (tamperedMessage?.role !== "user" || typeof tamperedMessage.content !== "string") {
+			throw new Error("Evaluation input lacks the expected first user message");
+		}
+		tamperedMessage.content += "!";
+		expect(await sha256(JSON.stringify(tamperedInput))).not.toBe(fixtureSha256);
 
 		const evidence = await deriveEvidence();
 		for (const placement of ["oldPlacement", "newPlacement"] as const) {


### PR DESCRIPTION
## Summary

Follow-up to #3933's post-merge P2 review comment. Bind `inputFixtureSha256` to the complete deterministic evaluation input—model metadata plus all generated turn contexts—instead of only the variable text fixture.

The test also mutates the first user message while preserving request shape and verifies that the input identity changes.

No product behavior changes.

## Verification

- cache eval write + validation: 2 + 2 pass
- `bun --cwd=packages/ai run check`: Biome + TypeScript pass
- provider source blob equals artifact OID: `5f9708abab7652c3ba56f214d2c92751bea1e2ed`