### PR TITLE
fix(coordinator): reconcile terminal SDK prompt outcomes

### DIFF
--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -18,6 +18,7 @@ import { type EnsureBrokerSettings, ensureBroker } from "../sdk/broker/ensure";
 import { UnsupportedStateVersionError } from "../sdk/broker/state-version";
 import { SdkClient, SdkClientError } from "../sdk/client/client";
 import { readSdkBrokerDiscovery } from "../sdk/client/discovery";
+import type { SdkPromptTerminalOutcome, TurnPromptReconciliation } from "../sdk/prompt-status";
 import {
 	type ActivatedPreparedSession,
 	requestPreparedSessionActivation,
@@ -1600,6 +1601,79 @@ async function markTurnFailedForUnavailableSession(turn: TurnRecord, reason: str
 	return failed;
 }
 
+const SDK_PROMPT_STOP_REASONS = new Set(["end_turn", "max_tokens", "max_turn_requests", "refusal", "cancelled"]);
+const SDK_PROMPT_FAILURE_CODES = new Set(["prompt_failed", "prompt_deadline_exceeded"]);
+
+function sdkPromptTerminalOutcome(value: unknown): SdkPromptTerminalOutcome | null {
+	const outcome = asRecord(value);
+	if (!outcome) return null;
+	if (
+		outcome.kind === "stopped" &&
+		typeof outcome.reason === "string" &&
+		SDK_PROMPT_STOP_REASONS.has(outcome.reason) &&
+		(outcome.provenance === "agent" || outcome.provenance === "client_cancel")
+	)
+		return outcome as SdkPromptTerminalOutcome;
+	if (
+		outcome.kind === "failed" &&
+		typeof outcome.code === "string" &&
+		SDK_PROMPT_FAILURE_CODES.has(outcome.code) &&
+		typeof outcome.message === "string" &&
+		(outcome.provenance === "agent_failed" || outcome.provenance === "deadline")
+	)
+		return outcome as SdkPromptTerminalOutcome;
+	return null;
+}
+
+function markTurnTerminalFromPromptStatus(turn: TurnRecord, promptStatus: TurnPromptReconciliation): TurnRecord | null {
+	if (promptStatus.status !== "terminal_ok" && promptStatus.status !== "failed") return null;
+	const rawOutcome = promptStatus.outcome;
+	const outcome = sdkPromptTerminalOutcome(rawOutcome);
+	if (rawOutcome !== undefined && !outcome) return null;
+	const failed = promptStatus.status === "failed" || outcome?.kind === "failed";
+	const cancelled = outcome?.kind === "stopped" && outcome.reason === "cancelled";
+	const status: TurnStatus = failed ? "failed" : cancelled ? "cancelled" : "completed";
+	const statusError = promptStatus.status === "failed" ? promptStatus.error : null;
+	const errorMessage =
+		outcome?.kind === "failed"
+			? outcome.message
+			: statusError && typeof statusError.message === "string"
+				? statusError.message
+				: "SDK prompt failed.";
+	const errorCode =
+		outcome?.kind === "failed"
+			? outcome.code
+			: statusError && typeof statusError.code === "string"
+				? statusError.code
+				: "prompt_failed";
+	const terminalDate = new Date(promptStatus.terminalAt);
+	const timestamp = Number.isNaN(terminalDate.getTime()) ? new Date().toISOString() : terminalDate.toISOString();
+	return {
+		...turn,
+		status,
+		delivery: { ...turn.delivery, prompt_acknowledged: true, state: "acknowledged" },
+		final_response: reportableFinalResponse(turn.final_response)
+			? turn.final_response
+			: {
+					text: failed ? errorMessage : cancelled ? "SDK prompt was cancelled." : null,
+					format: "markdown",
+					source: "sdk_prompt_status",
+					artifact_path: null,
+					truncated: false,
+				},
+		error: failed
+			? {
+					code: errorCode,
+					message: errorMessage,
+					recoverable: errorCode === "prompt_deadline_exceeded",
+				}
+			: null,
+		liveness: { checked_at: timestamp, live: true, reason: "sdk_prompt_terminal" },
+		updated_at: timestamp,
+		completed_at: timestamp,
+	};
+}
+
 async function markTurnTerminalFromSessionState(
 	turn: TurnRecord,
 	sessionState: CoordinatorSessionState,
@@ -2568,6 +2642,68 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 		};
 	}
 
+	async function queryPromptStatus(
+		session: Record<string, unknown>,
+		turn: TurnRecord,
+	): Promise<TurnPromptReconciliation | null> {
+		const commandId = turn.delivery.runtime_command_id;
+		const runtimeTurnId = turn.delivery.runtime_turn_id;
+		if (!commandId || !runtimeTurnId) return null;
+		const item = asRecord(
+			sdkQueryPageItem(
+				await querySession(session, "turn.prompt_status", { commandId, turnId: runtimeTurnId }),
+				"turn.prompt_status",
+			),
+		);
+		if (!item || typeof item.status !== "string") return null;
+		if (item.status === "unknown") return item as unknown as TurnPromptReconciliation;
+		if (item.commandId !== commandId || item.turnId !== runtimeTurnId) return null;
+		if (item.status === "accepted" || item.status === "in_flight") return item as unknown as TurnPromptReconciliation;
+		if (
+			(item.status === "terminal_ok" || item.status === "failed") &&
+			typeof item.terminalAt === "number" &&
+			Number.isFinite(item.terminalAt) &&
+			item.terminalAt > 0
+		) {
+			if (item.status === "failed") {
+				const error = asRecord(item.error);
+				if (!error || typeof error.code !== "string" || typeof error.message !== "string") return null;
+			}
+			return item as unknown as TurnPromptReconciliation;
+		}
+		return null;
+	}
+	async function brokerSessionTerminalReason(
+		session: Record<string, unknown>,
+		sessionId: string,
+	): Promise<string | null> {
+		const cwd = optionalString(session.cwd);
+		const persistedWorkspace = optionalString(session.broker_workspace);
+		const persistedGeneration =
+			typeof session.endpoint_generation === "number" &&
+			Number.isSafeInteger(session.endpoint_generation) &&
+			session.endpoint_generation > 0
+				? session.endpoint_generation
+				: null;
+		const persistedIncarnation = optionalString(session.endpoint_incarnation);
+		if (!cwd || !persistedWorkspace || persistedGeneration === null || !persistedIncarnation)
+			throw new SdkClientError("not_found", "Coordinator session has no incarnation-bound broker identity.");
+		const workspace = await canonicalBrokerWorkspace(cwd);
+		if (!sameCanonicalPath(workspace, persistedWorkspace, platform))
+			throw new SdkClientError("endpoint_stale", "Coordinator session workspace binding is stale.");
+		const matches = (await listSessions(workspace)).filter(candidate => brokerSessionId(candidate) === sessionId);
+		if (matches.length === 0) return "broker_session_not_indexed";
+		if (matches.length !== 1)
+			throw new SdkClientError("endpoint_stale", "Broker session identity is not unique in its bound workspace.");
+		const brokerRecord = matches[0]!;
+		const generation = brokerEndpointGeneration(brokerRecord);
+		const incarnation = brokerEndpointIncarnation(brokerRecord, sessionId);
+		if (generation === null || incarnation === null)
+			throw new SdkClientError("endpoint_stale", "Broker session has no usable endpoint incarnation.");
+		if (generation !== persistedGeneration || incarnation !== persistedIncarnation) return "broker_session_replaced";
+		return brokerRecord.live === false ? "broker_session_not_live" : null;
+	}
+
 	function requirePromptAcknowledgement(result: unknown): RuntimePromptAcknowledgement {
 		return normalizeRuntimePromptAcknowledgement(result);
 	}
@@ -3191,6 +3327,42 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 					live: null,
 					reason: error instanceof SdkClientError ? error.code : "unavailable",
 				};
+				if (ACTIVE_TURN_STATUSES.has(resolvedTurn.status)) {
+					let brokerReason: string | null = null;
+					try {
+						brokerReason = await brokerSessionTerminalReason(session, resolvedTurn.session_id);
+					} catch {
+						// A broker lookup failure is not terminal proof. Preserve the SDK
+						// advisory and let a later read reconcile against fresh authority.
+					}
+					if (brokerReason) {
+						advisoryStatus = { authority: "sdk_broker", live: false, reason: brokerReason };
+						const unavailable = await markTurnFailedForUnavailableSession(resolvedTurn, brokerReason);
+						resolvedTurn = await projectTerminalTransition(unavailable, {
+							desiredState: "stale",
+							reason: "session_unavailable",
+							live: false,
+						});
+						sessionState = await readSessionState(namespaceDir, resolvedTurn.session_id);
+					}
+				}
+			}
+			if (ACTIVE_TURN_STATUSES.has(resolvedTurn.status)) {
+				let promptStatus: TurnPromptReconciliation | null = null;
+				try {
+					promptStatus = await queryPromptStatus(session, resolvedTurn);
+				} catch {
+					// Q26 unavailability is uncertainty, not terminal proof.
+				}
+				const terminal = promptStatus ? markTurnTerminalFromPromptStatus(resolvedTurn, promptStatus) : null;
+				if (terminal) {
+					resolvedTurn = await projectTerminalTransition(terminal, {
+						desiredState: terminal.status === "failed" ? "errored" : "completed",
+						reason: terminal.status === "failed" ? "reported_failure" : null,
+						live: true,
+					});
+					sessionState = await readSessionState(namespaceDir, resolvedTurn.session_id);
+				}
 			}
 		} else {
 			advisoryStatus = { authority: "sdk", live: null, reason: "session_record_missing" };
@@ -3224,7 +3396,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 			(sessionState.state === "completed" || sessionState.state === "errored")
 		) {
 			resolvedTurn = await markTurnTerminalFromSessionState(resolvedTurn, sessionState);
-			await projectTerminalTransition(resolvedTurn, {
+			resolvedTurn = await projectTerminalTransition(resolvedTurn, {
 				desiredState: sessionState.state,
 				reason: sessionState.reason ? "terminal_uncertain" : null,
 				live: sessionState.live,
@@ -3232,7 +3404,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 			sessionState = await readSessionState(namespaceDir, resolvedTurn.session_id);
 		} else if (!session && ACTIVE_TURN_STATUSES.has(resolvedTurn.status)) {
 			resolvedTurn = await markTurnFailedForUnavailableSession(resolvedTurn, "session_record_missing");
-			await projectTerminalTransition(resolvedTurn, {
+			resolvedTurn = await projectTerminalTransition(resolvedTurn, {
 				desiredState: "stale",
 				reason: "session_unavailable",
 				live: false,
@@ -3247,7 +3419,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 				promptAckTimeoutMs,
 			);
 			if (!ACTIVE_TURN_STATUSES.has(resolvedTurn.status)) {
-				await projectTerminalTransition(resolvedTurn, {
+				resolvedTurn = await projectTerminalTransition(resolvedTurn, {
 					desiredState: "stale",
 					reason: "terminal_uncertain",
 					live: resolvedTurn.liveness.live,
@@ -3339,6 +3511,36 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 		});
 		return keyDigest;
 	}
+	function attachCanonicalReport(
+		transaction: CoordinatorSessionTransactionV1,
+		report: CanonicalReportSnapshotV1,
+		revision: number,
+	): void {
+		if (transaction.canonical.reports[report.report_id]) return;
+		transaction.canonical.reports[report.report_id] = report;
+		const reportEventId = deterministicOutboxId(
+			report.session_id,
+			revision,
+			"report.written",
+			"report",
+			report.report_id,
+		);
+		transaction.outbox[reportEventId] = {
+			id: reportEventId,
+			transaction_revision: revision,
+			kind: "report.written",
+			entity: "report",
+			entity_id: report.report_id,
+			payload: {
+				session_id: report.session_id,
+				turn_id: report.turn_id,
+				report_id: report.report_id,
+				status: report.status,
+				created_at: report.created_at,
+			},
+			emitted: false,
+		};
+	}
 
 	/** Commits terminal fencing, question revocation, report, and promotion together before legacy projection. */
 	async function commitTerminalTransition(
@@ -3349,9 +3551,25 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 			report?: CanonicalReportSnapshotV1;
 			promoteQueuedTurn?: boolean;
 		},
-	): Promise<{ promotedTurnId: string | null; desiredState: CoordinatorSessionStateValue }> {
+	): Promise<{
+		promotedTurnId: string | null;
+		desiredState: CoordinatorSessionStateValue;
+		committedTurn: TurnRecord;
+	}> {
 		await ensureQuestionTransaction(turn.session_id);
 		return await withAdmittedSessionTransaction(questionPaths, turn.session_id, async transaction => {
+			const existing = transaction.canonical.turns[turn.turn_id];
+			if (existing && TERMINAL_TURN_STATUSES.has(existing.status as TurnStatus)) {
+				if (input.report) attachCanonicalReport(transaction, input.report, transaction.revision + 1);
+				return {
+					promotedTurnId:
+						transaction.canonical.queue.selected_promotion?.from_turn_id === turn.turn_id
+							? transaction.canonical.queue.selected_promotion.to_turn_id
+							: null,
+					desiredState: transaction.canonical.desired_session_state,
+					committedTurn: turnFromCanonical(existing),
+				};
+			}
 			const terminalEpoch = transaction.revision + 1;
 			transaction.canonical.turns[turn.turn_id] = {
 				schema_version: 1,
@@ -3390,7 +3608,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 					reason: input.reason ?? "terminal_uncertain",
 				});
 			}
-			if (input.report) transaction.canonical.reports[input.report.report_id] = input.report;
+			if (input.report) attachCanonicalReport(transaction, input.report, terminalEpoch);
 			const next =
 				input.promoteQueuedTurn === false
 					? null
@@ -3427,31 +3645,11 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 				},
 				emitted: false,
 			};
-			if (input.report) {
-				const reportEventId = deterministicOutboxId(
-					turn.session_id,
-					terminalEpoch,
-					"report.written",
-					"report",
-					input.report.report_id,
-				);
-				transaction.outbox[reportEventId] ??= {
-					id: reportEventId,
-					transaction_revision: terminalEpoch,
-					kind: "report.written",
-					entity: "report",
-					entity_id: input.report.report_id,
-					payload: {
-						session_id: turn.session_id,
-						turn_id: turn.turn_id,
-						report_id: input.report.report_id,
-						status: input.report.status,
-						created_at: input.report.created_at,
-					},
-					emitted: false,
-				};
-			}
-			return { promotedTurnId: next?.turn_id ?? null, desiredState: next ? "running" : input.desiredState };
+			return {
+				promotedTurnId: next?.turn_id ?? null,
+				desiredState: next ? "running" : input.desiredState,
+				committedTurn: turnFromCanonical(transaction.canonical.turns[turn.turn_id]!),
+			};
 		});
 	}
 
@@ -3523,9 +3721,10 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 		turn: TurnRecord,
 
 		input: Parameters<typeof commitTerminalTransition>[1] & { live?: boolean | null },
-	): Promise<void> {
-		await commitTerminalTransition(turn, input);
+	): Promise<TurnRecord> {
+		const committed = await commitTerminalTransition(turn, input);
 		await repairCanonicalProjections(turn.session_id);
+		return committed.committedTurn;
 	}
 
 	async function commitCanonicalTurn(
@@ -3674,6 +3873,39 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 					live: false,
 				});
 				continue;
+			}
+			let promptStatus: TurnPromptReconciliation | null = null;
+			let promptStatusUnavailable = false;
+			try {
+				promptStatus = await queryPromptStatus(session, resolvedTurn);
+			} catch {
+				promptStatusUnavailable = true;
+			}
+			const terminal = promptStatus ? markTurnTerminalFromPromptStatus(resolvedTurn, promptStatus) : null;
+			if (terminal) {
+				await projectTerminalTransition(terminal, {
+					desiredState: terminal.status === "failed" ? "errored" : "completed",
+					reason: terminal.status === "failed" ? "reported_failure" : null,
+					live: true,
+				});
+				continue;
+			}
+			if (promptStatusUnavailable) {
+				let brokerReason: string | null = null;
+				try {
+					brokerReason = await brokerSessionTerminalReason(session, resolvedTurn.session_id);
+				} catch {
+					// Neither SDK nor broker authority produced terminal proof.
+				}
+				if (brokerReason) {
+					const unavailable = await markTurnFailedForUnavailableSession(resolvedTurn, brokerReason);
+					await projectTerminalTransition(unavailable, {
+						desiredState: "stale",
+						reason: "session_unavailable",
+						live: false,
+					});
+					continue;
+				}
 			}
 			resolvedTurn = await reconcileRuntimeAcknowledgement(
 				namespaceDir,
@@ -5033,7 +5265,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 									evidence_paths: evidence.map(item => item.path),
 									created_at: report.created_at,
 								};
-								await projectTerminalTransition(turn, {
+								turn = await projectTerminalTransition(turn, {
 									desiredState: terminalStatus === "failed" ? "errored" : "completed",
 									reason: terminalStatus === "failed" ? "reported_failure" : null,
 									report: canonicalReport,

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -65,6 +65,7 @@ import {
 	initializeCoordinatorNamespace,
 	recordDeletionIntent,
 	repairProjections,
+	transactionPath,
 	withAdmittedSessionTransaction,
 	withNamespaceRegistry,
 	withSessionTransaction,
@@ -3304,11 +3305,13 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 	}
 
 	async function readTurnPayload(turnId: unknown, sessionId: unknown): Promise<Record<string, unknown>> {
-		const turn = await readTurnRecord(namespaceDir, turnId);
+		let turn = await readTurnRecord(namespaceDir, turnId);
 		if (!turn) return { ok: false, reason: "unknown_turn" };
 		if (sessionId != null && turn.session_id !== safeExternalId("session", sessionId)) {
 			return { ok: false, reason: "turn_session_mismatch" };
 		}
+		if (await repairPendingCanonicalProjections(turn.session_id))
+			turn = (await readTurnRecord(namespaceDir, turn.turn_id)) ?? turn;
 		await reconcileQuestions(turn.session_id);
 		const session = asRecord(await readJsonFile(sessionFile(turn.session_id)));
 		let resolvedTurn = turn;
@@ -3725,6 +3728,28 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 		const committed = await commitTerminalTransition(turn, input);
 		await repairCanonicalProjections(turn.session_id);
 		return committed.committedTurn;
+	}
+	async function repairPendingCanonicalProjections(sessionId: string): Promise<boolean> {
+		const transaction = (await readJsonFile(
+			transactionPath(questionPaths, sessionId),
+		)) as CoordinatorSessionTransactionV1 | null;
+		if (!transaction) return false;
+		const projection = transaction.projection;
+		const appliedRevisions = [
+			projection.applied_turns_revision,
+			projection.applied_reports_revision,
+			projection.applied_session_revision,
+			projection.applied_active_revision,
+		];
+		if (
+			!Number.isSafeInteger(transaction.revision) ||
+			!appliedRevisions.every(revision => Number.isSafeInteger(revision) && revision >= 0)
+		)
+			throw new Error("state_corrupt");
+		const pending = appliedRevisions.some(revision => revision < transaction.revision - 1);
+		if (!pending) return false;
+		await repairCanonicalProjections(sessionId);
+		return true;
 	}
 
 	async function commitCanonicalTurn(

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -986,14 +986,45 @@ describe("Coordinator MCP canonical SDK controls", () => {
 
 		await fs.rm(sessionStatesPath);
 		await fs.rename(sessionStatesBackup, sessionStatesPath);
-		await expect(server.callTool("gjc_coordinator_read_turn", { turn_id: sent.turn_id })).resolves.toMatchObject({
+		const repaired = await server.callTool("gjc_coordinator_read_turn", { turn_id: sent.turn_id });
+		expect(repaired).toMatchObject({
 			ok: true,
 			turn: { status: "completed", completed_at: "2026-08-06T09:04:29.000Z" },
+			session_state: { state: "completed", current_turn_id: null },
 		});
 		await expect(server.callTool("gjc_coordinator_read_coordination_status")).resolves.toMatchObject({
 			ok: true,
 			summary: { active_turns: 0 },
 		});
+		const namespaceIds = await fs.readdir(path.join(root, ".gjc", "coordinator-state", "v1"));
+		expect(namespaceIds).toHaveLength(1);
+		const transaction = JSON.parse(
+			await fs.readFile(
+				path.join(
+					root,
+					".gjc",
+					"coordinator-state",
+					"v1",
+					namespaceIds[0]!,
+					"sessions",
+					"visible-session",
+					"transaction.v1.json",
+				),
+				"utf8",
+			),
+		) as {
+			revision: number;
+			projection: {
+				applied_turns_revision: number;
+				applied_reports_revision: number;
+				applied_session_revision: number;
+				applied_active_revision: number;
+			};
+		};
+		expect(transaction.projection.applied_turns_revision).toBe(transaction.revision - 1);
+		expect(transaction.projection.applied_reports_revision).toBe(transaction.revision - 1);
+		expect(transaction.projection.applied_session_revision).toBe(transaction.revision - 1);
+		expect(transaction.projection.applied_active_revision).toBe(transaction.revision - 1);
 	});
 	it("fences concurrent terminal reconciliation to one queued-turn promotion", async () => {
 		const root = await tempRoot();

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -172,7 +172,7 @@ async function createSdkControlServer(
 	root: string,
 	controls: SdkControl[],
 	queries: string[] = [],
-	queryResult: (query: string, cursor?: string) => unknown = query =>
+	queryResult: (query: string, input?: Record<string, unknown>, cursor?: string) => unknown = query =>
 		query === "context.get"
 			? {
 					type: "query_response",
@@ -305,9 +305,9 @@ async function createSdkControlServer(
 						}
 						return { ok: true, result: { sessionId: String(input.sessionId ?? "visible-session") } };
 					},
-					query: async (query: string, _input: Record<string, unknown>, cursor?: string) => {
+					query: async (query: string, input: Record<string, unknown>, cursor?: string) => {
 						queries.push(query);
-						return queryResult(query, cursor);
+						return queryResult(query, input, cursor);
 					},
 					request: async (frame: Record<string, unknown>) => {
 						serverOptions.sessionFrames?.push(frame);
@@ -756,7 +756,484 @@ describe("Coordinator MCP canonical SDK controls", () => {
 			ok: true,
 			advisory_status: { authority: "sdk", live: true, is_streaming: true },
 		});
-		expect(queries).toEqual(["Q12", "context.get"]);
+		expect(queries).toEqual(["Q12", "context.get", "turn.prompt_status"]);
+	});
+	it("reconciles authoritative SDK prompt outcomes into terminal Coordinator turns", async () => {
+		for (const testCase of [
+			{
+				name: "deadline failure",
+				promptStatus: {
+					status: "failed",
+					error: { code: "prompt_deadline_exceeded", message: "Prompt deadline exceeded." },
+					outcome: {
+						kind: "failed",
+						code: "prompt_deadline_exceeded",
+						message: "Prompt deadline exceeded.",
+						provenance: "deadline",
+					},
+				},
+				expectedStatus: "failed",
+				expectedError: { code: "prompt_deadline_exceeded", recoverable: true },
+			},
+			{
+				name: "client cancellation",
+				promptStatus: {
+					status: "terminal_ok",
+					outcome: { kind: "stopped", reason: "cancelled", provenance: "client_cancel" },
+				},
+				expectedStatus: "cancelled",
+				expectedError: null,
+			},
+			{
+				name: "normal completion",
+				promptStatus: {
+					status: "terminal_ok",
+					outcome: { kind: "stopped", reason: "end_turn", provenance: "agent" },
+				},
+				expectedStatus: "completed",
+				expectedError: null,
+			},
+			{
+				name: "completion without outcome detail",
+				promptStatus: {
+					status: "terminal_ok",
+				},
+				expectedStatus: "completed",
+				expectedError: null,
+			},
+		] as const) {
+			const root = await tempRoot();
+			const controls: SdkControl[] = [];
+			const promptStatusSelectors: Record<string, unknown>[] = [];
+			const terminalAt = Date.parse("2026-08-06T09:04:29.000Z");
+			const server = await createSdkControlServer(root, controls, [], (query, input = {}) => {
+				if (query === "Q12")
+					return { ok: true, page: { items: [], complete: true, revision: `q12-${testCase.name}` } };
+				if (query === "context.get")
+					return {
+						type: "query_response",
+						id: "query-context",
+						ok: true,
+						page: { items: [{ isStreaming: false }], complete: true, revision: "context" },
+					};
+				if (query === "turn.prompt_status") {
+					promptStatusSelectors.push(input);
+					return {
+						type: "query_response",
+						id: "query-prompt-status",
+						ok: true,
+						page: {
+							items: [
+								{
+									...testCase.promptStatus,
+									commandId: input.commandId,
+									turnId: input.turnId,
+									acceptedAt: terminalAt - 2_000,
+									startedAt: terminalAt - 1_000,
+									terminalAt,
+								},
+							],
+							complete: true,
+							revision: "prompt-status",
+						},
+					};
+				}
+				throw new Error(`unexpected query: ${query}`);
+			});
+			await registerSdkSession(server, root);
+			const sent = await server.callTool("gjc_coordinator_send_prompt", {
+				session_id: "visible-session",
+				prompt: testCase.name,
+				idempotency_key: `prompt-terminal-${testCase.name}`,
+				allow_mutation: true,
+			});
+			if (testCase.name === "deadline failure")
+				await expect(server.callTool("gjc_coordinator_read_coordination_status")).resolves.toMatchObject({
+					ok: true,
+					summary: { active_turns: 0 },
+				});
+
+			const result = await server.callTool("gjc_coordinator_read_turn", { turn_id: sent.turn_id });
+			expect(result).toMatchObject({
+				ok: true,
+				turn: {
+					status: testCase.expectedStatus,
+					error: testCase.expectedError,
+					liveness: { live: true, reason: "sdk_prompt_terminal" },
+					completed_at: "2026-08-06T09:04:29.000Z",
+				},
+			});
+			expect(promptStatusSelectors).toEqual([
+				{
+					commandId: (sent.turn as { delivery: { runtime_command_id: string } }).delivery.runtime_command_id,
+					turnId: (sent.turn as { delivery: { runtime_turn_id: string } }).delivery.runtime_turn_id,
+				},
+			]);
+			await expect(server.callTool("gjc_coordinator_read_coordination_status")).resolves.toMatchObject({
+				ok: true,
+				summary: { active_turns: 0 },
+			});
+		}
+	});
+	it("does not terminalize from nonterminal, unknown, or identity-mismatched Q26 records", async () => {
+		for (const q26Record of [
+			{ status: "unknown" },
+			{ status: "accepted" },
+			{ status: "in_flight", startedAt: Date.now() },
+			{
+				status: "terminal_ok",
+				commandId: "different-command",
+				turnId: "different-turn",
+				terminalAt: Date.now(),
+				outcome: { kind: "stopped", reason: "end_turn", provenance: "agent" },
+			},
+		]) {
+			const root = await tempRoot();
+			const controls: SdkControl[] = [];
+			const server = await createSdkControlServer(root, controls, [], (query, input = {}) => {
+				if (query === "Q12") return { ok: true, page: { items: [], complete: true, revision: "q12" } };
+				if (query === "context.get")
+					return {
+						type: "query_response",
+						id: "query-context",
+						ok: true,
+						page: { items: [{ isStreaming: false }], complete: true, revision: "context" },
+					};
+				if (query === "turn.prompt_status")
+					return {
+						type: "query_response",
+						id: "query-prompt-status",
+						ok: true,
+						page: {
+							items: [
+								{
+									commandId: input.commandId,
+									turnId: input.turnId,
+									acceptedAt: Date.now() - 1_000,
+									...q26Record,
+								},
+							],
+							complete: true,
+							revision: "prompt-status",
+						},
+					};
+				throw new Error(`unexpected query: ${query}`);
+			});
+			await registerSdkSession(server, root);
+			const sent = await server.callTool("gjc_coordinator_send_prompt", {
+				session_id: "visible-session",
+				prompt: `q26-${q26Record.status}`,
+				idempotency_key: `q26-${q26Record.status}-${String(q26Record.commandId ?? "bound")}`,
+				allow_mutation: true,
+			});
+
+			await expect(server.callTool("gjc_coordinator_read_turn", { turn_id: sent.turn_id })).resolves.toMatchObject({
+				ok: true,
+				turn: { status: "active" },
+			});
+		}
+	});
+
+	it("surfaces projection failure and repairs the already-fenced terminal turn on retry", async () => {
+		const root = await tempRoot();
+		const controls: SdkControl[] = [];
+		const terminalAt = Date.parse("2026-08-06T09:04:29.000Z");
+		const server = await createSdkControlServer(root, controls, [], (query, input = {}) => {
+			if (query === "Q12") return { ok: true, page: { items: [], complete: true, revision: "q12" } };
+			if (query === "context.get")
+				return {
+					type: "query_response",
+					id: "query-context",
+					ok: true,
+					page: { items: [{ isStreaming: false }], complete: true, revision: "context" },
+				};
+			if (query === "turn.prompt_status")
+				return {
+					type: "query_response",
+					id: "query-prompt-status",
+					ok: true,
+					page: {
+						items: [
+							{
+								status: "terminal_ok",
+								commandId: input.commandId,
+								turnId: input.turnId,
+								acceptedAt: terminalAt - 1_000,
+								terminalAt,
+							},
+						],
+						complete: true,
+						revision: "prompt-status",
+					},
+				};
+			throw new Error(`unexpected query: ${query}`);
+		});
+		await registerSdkSession(server, root);
+		const sent = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "projection failure",
+			idempotency_key: "projection-failure",
+			allow_mutation: true,
+		});
+		const sessionStatesPath = path.join(root, ".gjc", "coordinator-state", "local", "repo", "session-states");
+		const sessionStatesBackup = `${sessionStatesPath}.backup`;
+		await fs.rename(sessionStatesPath, sessionStatesBackup);
+		await fs.writeFile(sessionStatesPath, "blocks projection");
+
+		const projectionFailure = await server.callTool("gjc_coordinator_read_turn", { turn_id: sent.turn_id });
+		expect(projectionFailure).toMatchObject({ ok: false });
+		expect(String(projectionFailure.reason)).toContain("EEXIST");
+
+		await fs.rm(sessionStatesPath);
+		await fs.rename(sessionStatesBackup, sessionStatesPath);
+		await expect(server.callTool("gjc_coordinator_read_turn", { turn_id: sent.turn_id })).resolves.toMatchObject({
+			ok: true,
+			turn: { status: "completed", completed_at: "2026-08-06T09:04:29.000Z" },
+		});
+		await expect(server.callTool("gjc_coordinator_read_coordination_status")).resolves.toMatchObject({
+			ok: true,
+			summary: { active_turns: 0 },
+		});
+	});
+	it("fences concurrent terminal reconciliation to one queued-turn promotion", async () => {
+		const root = await tempRoot();
+		const controls: SdkControl[] = [];
+		const terminalAt = Date.parse("2026-08-06T09:04:29.000Z");
+		const server = await createSdkControlServer(root, controls, [], (query, input = {}) => {
+			if (query === "Q12") return { ok: true, page: { items: [], complete: true, revision: "q12" } };
+			if (query === "context.get")
+				return {
+					type: "query_response",
+					id: "query-context",
+					ok: true,
+					page: { items: [{ isStreaming: false }], complete: true, revision: "context" },
+				};
+			if (query === "turn.prompt_status")
+				return {
+					type: "query_response",
+					id: "query-prompt-status",
+					ok: true,
+					page: {
+						items: [
+							{
+								status: "terminal_ok",
+								commandId: input.commandId,
+								turnId: input.turnId,
+								acceptedAt: terminalAt - 1_000,
+								terminalAt,
+							},
+						],
+						complete: true,
+						revision: "prompt-status",
+					},
+				};
+			throw new Error(`unexpected query: ${query}`);
+		});
+		await registerSdkSession(server, root);
+		const active = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "active",
+			idempotency_key: "concurrent-active",
+			allow_mutation: true,
+		});
+		const firstQueued = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "first queued",
+			queue: true,
+			idempotency_key: "concurrent-queued-1",
+			allow_mutation: true,
+		});
+		const secondQueued = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "second queued",
+			queue: true,
+			idempotency_key: "concurrent-queued-2",
+			allow_mutation: true,
+		});
+
+		const reads = await Promise.all(
+			Array.from({ length: 8 }, () => server.callTool("gjc_coordinator_read_turn", { turn_id: active.turn_id })),
+		);
+		for (const result of reads) expect(result).toMatchObject({ ok: true, turn: { status: "completed" } });
+		const stateRoot = path.join(root, ".gjc", "coordinator-state", "local", "repo");
+		const activePointer = JSON.parse(
+			await fs.readFile(path.join(stateRoot, "active-turns", "visible-session.json"), "utf8"),
+		) as { turn_id: string };
+		expect(activePointer.turn_id).toBe(String(firstQueued.turn_id));
+		await expect(
+			fs.readFile(path.join(stateRoot, "turns", `${String(firstQueued.turn_id)}.json`), "utf8").then(JSON.parse),
+		).resolves.toMatchObject({ status: "active" });
+		await expect(
+			fs.readFile(path.join(stateRoot, "turns", `${String(secondQueued.turn_id)}.json`), "utf8").then(JSON.parse),
+		).resolves.toMatchObject({ status: "queued" });
+	});
+	it("attaches a later report without replacing the authoritative Q26 terminal winner", async () => {
+		const root = await tempRoot();
+		const controls: SdkControl[] = [];
+		const terminalAt = Date.parse("2026-08-06T09:04:29.000Z");
+		const server = await createSdkControlServer(root, controls, [], (query, input = {}) => {
+			if (query === "Q12") return { ok: true, page: { items: [], complete: true, revision: "q12" } };
+			if (query === "context.get")
+				return {
+					type: "query_response",
+					id: "query-context",
+					ok: true,
+					page: { items: [{ isStreaming: false }], complete: true, revision: "context" },
+				};
+			if (query === "turn.prompt_status")
+				return {
+					type: "query_response",
+					id: "query-prompt-status",
+					ok: true,
+					page: {
+						items: [
+							{
+								status: "terminal_ok",
+								commandId: input.commandId,
+								turnId: input.turnId,
+								acceptedAt: terminalAt - 1_000,
+								terminalAt,
+								outcome: { kind: "stopped", reason: "cancelled", provenance: "client_cancel" },
+							},
+						],
+						complete: true,
+						revision: "prompt-status",
+					},
+				};
+			throw new Error(`unexpected query: ${query}`);
+		});
+		await registerSdkSession(server, root);
+		const sent = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "cancel then report",
+			idempotency_key: "cancel-then-report",
+			allow_mutation: true,
+		});
+		await expect(server.callTool("gjc_coordinator_read_turn", { turn_id: sent.turn_id })).resolves.toMatchObject({
+			ok: true,
+			turn: { status: "cancelled" },
+		});
+
+		const reported = await server.callTool("gjc_coordinator_report_status", {
+			session_id: "visible-session",
+			turn_id: sent.turn_id,
+			status: "completed",
+			summary: "late report",
+			idempotency_key: "late-terminal-report",
+			allow_mutation: true,
+		});
+		expect(reported).toMatchObject({
+			ok: true,
+			report: { status: "completed", summary: "late report" },
+			turn: { status: "cancelled" },
+		});
+		await expect(server.callTool("gjc_coordinator_read_coordination_status")).resolves.toMatchObject({
+			ok: true,
+			summary: { active_turns: 0, reports: 1 },
+		});
+	});
+	it("keeps an active turn nonterminal when the SDK is unavailable but the broker still reports it live", async () => {
+		const root = await tempRoot();
+		const controls: SdkControl[] = [];
+		const queries: string[] = [];
+		const brokerSessions = [
+			{
+				sessionId: "visible-session",
+				locator: { repo: root },
+				live: true,
+				endpointGeneration: 1,
+				pid: 101,
+				endpointMtimeMs: 1,
+			},
+		];
+		const server = await createSdkControlServer(
+			root,
+			controls,
+			queries,
+			() => ({
+				type: "query_response",
+				id: "query-1",
+				ok: false,
+				error: { code: "unavailable", message: "session endpoint unavailable" },
+			}),
+			brokerSessions,
+		);
+		await registerSdkSession(server, root);
+		const sent = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "work",
+			idempotency_key: "prompt-live-broker",
+			allow_mutation: true,
+		});
+
+		await expect(server.callTool("gjc_coordinator_read_turn", { turn_id: sent.turn_id })).resolves.toMatchObject({
+			ok: true,
+			turn: { status: "active" },
+			advisory_status: { authority: "sdk", live: null, reason: "unavailable" },
+		});
+		expect(controls).toContainEqual({
+			operation: "session.list",
+			input: { cwd: root },
+			idempotencyKey: undefined,
+		});
+	});
+
+	it("terminalizes an active turn when the SDK is unavailable and broker authority says the session is gone", async () => {
+		for (const [brokerState, expectedReason] of [
+			["not-indexed", "broker_session_not_indexed"],
+			["not-live", "broker_session_not_live"],
+			["replaced", "broker_session_replaced"],
+		] as const) {
+			const root = await tempRoot();
+			const controls: SdkControl[] = [];
+			const queries: string[] = [];
+			const brokerSessions = [
+				{
+					sessionId: "visible-session",
+					locator: { repo: root },
+					live: true,
+					endpointGeneration: 1,
+					pid: 101,
+					endpointMtimeMs: 1,
+				},
+			];
+			const server = await createSdkControlServer(
+				root,
+				controls,
+				queries,
+				() => ({
+					type: "query_response",
+					id: "query-1",
+					ok: false,
+					error: { code: "unavailable", message: "session endpoint unavailable" },
+				}),
+				brokerSessions,
+			);
+			await registerSdkSession(server, root);
+			const sent = await server.callTool("gjc_coordinator_send_prompt", {
+				session_id: "visible-session",
+				prompt: "work",
+				idempotency_key: `prompt-${brokerState}`,
+				allow_mutation: true,
+			});
+			if (brokerState === "not-indexed") brokerSessions.splice(0);
+			else if (brokerState === "not-live") brokerSessions[0]!.live = false;
+			else brokerSessions[0]!.endpointGeneration = 2;
+
+			await expect(server.callTool("gjc_coordinator_read_turn", { turn_id: sent.turn_id })).resolves.toMatchObject({
+				ok: true,
+				turn: {
+					status: "failed",
+					error: { code: "session_unavailable", message: expectedReason, recoverable: true },
+					liveness: { live: false, reason: expectedReason },
+				},
+				advisory_status: { authority: "sdk_broker", live: false, reason: expectedReason },
+			});
+			await expect(server.callTool("gjc_coordinator_read_coordination_status")).resolves.toMatchObject({
+				ok: true,
+				summary: { active_turns: 0 },
+			});
+		}
 	});
 	it("uses the generation-bound broker endpoint when a stale local endpoint file is absent", async () => {
 		const root = await tempRoot();
@@ -776,7 +1253,7 @@ describe("Coordinator MCP canonical SDK controls", () => {
 			ok: true,
 			advisory_status: { authority: "sdk", live: true, is_streaming: true },
 		});
-		expect(queries).toEqual(["Q12", "context.get"]);
+		expect(queries).toEqual(["Q12", "context.get", "turn.prompt_status"]);
 	});
 
 	it("passes a resolved mpreset into the SDK lifecycle create request and persists it with the session", async () => {
@@ -1374,7 +1851,7 @@ describe("Coordinator MCP canonical SDK controls", () => {
 			root,
 			controls,
 			[],
-			(query, cursor) => {
+			(query, _input, cursor) => {
 				if (query !== "Q12") return { ok: true, page: { items: [], complete: true, revision: "context" } };
 				q12Calls.push(cursor);
 				return cursor


### PR DESCRIPTION
## Summary

Reconcile Coordinator-managed turns with the SDK's authoritative prompt terminal state and the bound broker incarnation, so a cancelled, failed, or otherwise terminated delegated session cannot leave the durable Coordinator turn permanently `active`.

## Why this is an upstream GJC issue

A Coordinator turn is a second durable projection of an SDK prompt. Once `turn.prompt` is acknowledged, the Coordinator intentionally stops applying its pre-ack timeout. Before this change, however, it never joined that acknowledged turn back to either:

- Q26 (`turn.prompt_status`) when the SDK recorded a terminal outcome, or
- definitive loss/replacement of the exact broker endpoint incarnation.

That creates a state-machine authority gap: the SDK can be terminal while the Coordinator's durable turn and active pointer remain active forever. `await_turn` then only repeats bounded client-side timeouts. Any downstream integration that serializes work per session/thread can appear hung even though the gateway and heartbeat are healthy. This is not specific to one Hermes profile or workspace configuration.

The production incident that exposed the gap also contained an older headless Ask failure (`undefined is not an object (evaluating 'Q.status')`). The exact captured Ask payload converts and opens a workflow gate on current `dev`, so this PR does **not** claim to fix that historical Ask crash. It fixes the independent GJC-owned lifecycle defect that allowed the failed/cancelled delegated prompt to remain durably active afterward.

## What changed

- Query Q26 with the exact acknowledged SDK `commandId` + `turnId`.
- Strictly validate terminal DTO identity and outcome shape.
- Map authoritative outcomes to Coordinator terminal states:
  - client cancellation → `cancelled`
  - SDK/deadline failure → `failed`
  - normal SDK stop → `completed`
- Preserve `unknown`, `accepted`, `in_flight`, malformed data, query failure, and live bound broker state as nonterminal uncertainty.
- When SDK observation is unavailable, compare broker workspace, endpoint generation, and derived endpoint incarnation against the persisted binding; only missing, non-live, or replaced bound authority is terminal proof.
- Commit terminal state through the existing canonical transition and projection machinery.
- Fence the transition atomically so concurrent readers produce one terminal epoch/event and promote at most one queued successor.
- Keep observation failures separate from durable commit/projection failures; projection errors now surface and can be repaired from the canonical fence on retry.
- Return the committed canonical winner from every read-facing terminal path.
- Retain a later canonical report without allowing it to overwrite an already-fenced terminal outcome.

## Safety properties

This deliberately does not add an arbitrary elapsed-time timeout. A transient SDK/broker error remains nonterminal. Terminalization requires either identity-bound Q26 terminal authority or proven loss/replacement of the persisted broker incarnation.

The canonical transaction is the exactly-once boundary. Legacy projections are repaired only after that commit, and a projection failure does not masquerade as a successful terminal response.

## Regression coverage

The focused suite covers:

- deadline failure, explicit client cancellation, normal completion, and terminal completion without optional outcome detail;
- Q26 `unknown`, `accepted`, `in_flight`, malformed/identity-mismatched terminal rows remaining active;
- SDK uncertainty with a live bound broker;
- missing, non-live, and replaced broker incarnations;
- projection failure followed by canonical repair;
- eight concurrent terminal readers with two queued successors, proving only the first successor is promoted;
- a conflicting late report after Q26 cancellation, proving the cancelled winner remains authoritative and the report remains canonical.

## Verification

- `bun test packages/coding-agent/test/coordinator-mcp-server.test.ts packages/coding-agent/test/coordinator-mcp/send-prompt-concurrency.test.ts packages/coding-agent/test/coordinator-mcp-actual-runtime-readiness.test.ts packages/coding-agent/test/coordinator-mcp/stop-session.test.ts`
  - 83 passed, 0 failed, 401 assertions
- `bun --cwd=packages/coding-agent run check`
  - Biome clean across 2,536 files
  - TypeScript `--noEmit` clean
- `git diff --check`
  - clean

## Scope boundary

Hermes's one-hour `clarify` wait, downstream cancel propagation into that wait, relay-scope shutdown cleanup, and long-session compaction latency are downstream concerns and are intentionally not modified here. The unrelated Coordinator evidence-path allowed-root rejection observed during the incident was also not causal and is not part of this change.
