### PR TITLE
fix(tui): bound a bracketed paste with no end marker

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- A bracketed paste whose end marker never arrives no longer freezes terminal input for the rest of the session. `StdinBuffer` latched `#pasteMode` on `ESC[200~` and cleared it only on the matching `ESC[201~`, with no timeout and no size bound, unlike the SGR quarantine (100ms / 256 bytes) and the probe-fragment hold (500ms / 256 bytes) in the same file. Every byte after a dropped, mangled, or spurious marker was appended to the paste buffer and never emitted, so the application stopped receiving input entirely - and because `Tui` dispatches input only to the focused component and raw mode delivers Ctrl+C as byte 0x03 rather than SIGINT, neither Escape nor Ctrl+C could recover the session. A 500ms idle watchdog now releases the latch once paste bytes stop arriving, and a 10s absolute cap releases it even while input keeps re-arming that timer; both emit what accumulated as a normal paste event, so pasted text is preserved rather than replayed as keystrokes. A paste that is still streaming re-arms the idle timer on every chunk and is never truncated.
 
 ## [0.12.12] - 2026-08-05
 ### Fixed

--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -33,6 +33,14 @@ const PROBE_FRAGMENT_MAX_BYTES = 256;
 const PROBE_ESCAPE_HOLD_MAX_MS = 150;
 const PROBE_REPLY_WINDOW_MS = 2500;
 
+// Bounds for a bracketed-paste
+// START whose END terminator never arrives. Without these the paste latch swallows
+// all input forever, including ESC and Ctrl+C. A real paste streams continuously so
+// the idle bound never trips on it; the absolute bound covers a user typing fast
+// enough to keep re-arming the idle timer.
+const PASTE_IDLE_MAX_MS = 500;
+const PASTE_HOLD_MAX_MS = 10000;
+
 /**
  * True when the buffer is an escape sequence that only a terminal reply can
  * complete: an OSC without its BEL/ST terminator (OSC 11 background color) or a
@@ -375,6 +383,9 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 	readonly #timeoutMs: number;
 	#pasteMode: boolean = false;
 	#pasteBuffer: string = "";
+	// Bracketed-paste latch watchdog state.
+	#pasteIdleTimer?: NodeJS.Timeout;
+	#pasteStartedAt = 0;
 	#pendingKittyPrintableCodepoint: number | undefined;
 	// Persistent UTF-8 decoder. Holds an incomplete trailing multi-byte
 	// sequence between chunks so split reads (e.g. a 3-byte Korean syllable
@@ -484,8 +495,10 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 				const pastedContent = this.#pasteBuffer.slice(0, endIndex);
 				const remaining = this.#pasteBuffer.slice(endIndex + BRACKETED_PASTE_END.length);
 
+				this.#clearPasteIdleWatchdog();
 				this.#pasteMode = false;
 				this.#pasteBuffer = "";
+				this.#pasteStartedAt = 0;
 				this.#pendingKittyPrintableCodepoint = undefined;
 
 				this.emit("paste", pastedContent);
@@ -493,7 +506,18 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 				if (remaining.length > 0) {
 					this.process(remaining);
 				}
+				return;
 			}
+			// The END terminator has
+			// not arrived. Bound the wait so a dropped/mangled terminator cannot swallow
+			// every following keystroke (ESC and Ctrl+C included) for the rest of the
+			// session. The absolute cap is checked here because a user typing during the
+			// stall keeps re-arming the idle timer.
+			if (this.#pasteStartedAt !== 0 && Date.now() - this.#pasteStartedAt >= PASTE_HOLD_MAX_MS) {
+				this.#releaseStrandedPaste();
+				return;
+			}
+			this.#armPasteIdleWatchdog();
 			return;
 		}
 
@@ -513,6 +537,7 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 			this.#pendingKittyPrintableCodepoint = undefined;
 			this.#buffer = this.#buffer.slice(startIndex + BRACKETED_PASTE_START.length);
 			this.#pasteMode = true;
+			this.#pasteStartedAt = Date.now();
 			this.#pasteBuffer = this.#buffer;
 			this.#buffer = "";
 
@@ -521,8 +546,10 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 				const pastedContent = this.#pasteBuffer.slice(0, endIndex);
 				const remaining = this.#pasteBuffer.slice(endIndex + BRACKETED_PASTE_END.length);
 
+				this.#clearPasteIdleWatchdog();
 				this.#pasteMode = false;
 				this.#pasteBuffer = "";
+				this.#pasteStartedAt = 0;
 				this.#pendingKittyPrintableCodepoint = undefined;
 
 				this.emit("paste", pastedContent);
@@ -530,7 +557,10 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 				if (remaining.length > 0) {
 					this.process(remaining);
 				}
+				return;
 			}
+			// No terminator yet: bound the wait. See the in-paste-mode branch above.
+			this.#armPasteIdleWatchdog();
 			return;
 		}
 
@@ -626,6 +656,40 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 		this.#decoderHasPendingUtf8 = false;
 		return legacyMetaSequence(byte);
 	}
+	// Bracketed-paste latch watchdog.
+	// Uses its own timer rather than the shared #timeout, which the SGR-quarantine and
+	// pending-lead-byte paths own and which process() clears on every chunk.
+	#armPasteIdleWatchdog(): void {
+		this.#clearPasteIdleWatchdog();
+		this.#pasteIdleTimer = setTimeout(() => {
+			this.#pasteIdleTimer = undefined;
+			this.#releaseStrandedPaste();
+		}, PASTE_IDLE_MAX_MS);
+		this.#pasteIdleTimer.unref?.();
+	}
+
+	#clearPasteIdleWatchdog(): void {
+		if (this.#pasteIdleTimer) {
+			clearTimeout(this.#pasteIdleTimer);
+			this.#pasteIdleTimer = undefined;
+		}
+	}
+
+	// Leave the latch and hand back whatever accumulated. Emitting it as a paste keeps
+	// the user's pasted text intact and routes it through the editor's paste path;
+	// re-processing it as input would read newlines inside pasted text as Enter and
+	// submit the message.
+	#releaseStrandedPaste(): void {
+		this.#clearPasteIdleWatchdog();
+		if (!this.#pasteMode) return;
+		const stranded = this.#pasteBuffer;
+		this.#pasteMode = false;
+		this.#pasteBuffer = "";
+		this.#pasteStartedAt = 0;
+		this.#pendingKittyPrintableCodepoint = undefined;
+		if (stranded.length > 0) this.emit("paste", stranded);
+	}
+
 	#emitDataSequence(sequence: string): void {
 		const rawCodepoint = singleCodePoint(sequence);
 		if (rawCodepoint !== undefined && rawCodepoint === this.#pendingKittyPrintableCodepoint) {
@@ -717,8 +781,10 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 			this.#timeout = undefined;
 		}
 		this.#buffer = "";
+		this.#clearPasteIdleWatchdog();
 		this.#pasteMode = false;
 		this.#pasteBuffer = "";
+		this.#pasteStartedAt = 0;
 		this.#pendingKittyPrintableCodepoint = undefined;
 		this.#sgrQuarantine = false;
 		this.#sgrQuarantineBytes = 0;

--- a/packages/tui/test/stdin-buffer.test.ts
+++ b/packages/tui/test/stdin-buffer.test.ts
@@ -5,7 +5,7 @@
  * MIT License - Copyright (c) 2025 opentui
  */
 
-import { beforeEach, describe, expect, it } from "bun:test";
+import { beforeEach, describe, expect, it, setSystemTime } from "bun:test";
 import { parseKey, setKittyProtocolActive } from "@gajae-code/tui/keys";
 import { StdinBuffer } from "@gajae-code/tui/stdin-buffer";
 
@@ -657,6 +657,97 @@ describe("StdinBuffer", () => {
 		it("keeps an OSC string terminator attached to its sequence", () => {
 			processInput("\x1b]11;rgb:0000/0000/0000\x1b\\");
 			expect(emittedSequences).toEqual(["\x1b]11;rgb:0000/0000/0000\x1b\\"]);
+		});
+	});
+	describe("Stranded Bracketed Paste", () => {
+		const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+		let emittedPaste: string[];
+
+		beforeEach(() => {
+			buffer = new StdinBuffer({ timeout: 10 });
+			emittedSequences = [];
+			buffer.on("data", (sequence: string) => {
+				emittedSequences.push(sequence);
+			});
+			emittedPaste = [];
+			buffer.on("paste", (data: string) => {
+				emittedPaste.push(data);
+			});
+		});
+
+		it("releases the latch when the end marker never arrives", async () => {
+			processInput("\x1b[200~hello");
+			expect(emittedPaste).toEqual([]);
+
+			await sleep(700);
+
+			expect(emittedPaste).toEqual(["hello"]);
+		});
+
+		it("delivers keys again after a stranded paste, including Escape and Ctrl+C", async () => {
+			processInput("\x1b[200~hello");
+			processInput("a");
+			expect(emittedSequences).toEqual([]); // latched: every byte is swallowed
+
+			await sleep(700);
+			emittedSequences = [];
+
+			processInput("b");
+			processInput("\x03");
+			await sleep(20);
+
+			expect(emittedSequences).toContain("b");
+			expect(emittedSequences).toContain("\x03");
+		});
+
+		it("keeps a slow paste intact while it is still streaming", async () => {
+			processInput("\x1b[200~part-one ");
+			await sleep(200);
+			processInput("part-two ");
+			await sleep(200);
+			processInput("part-three\x1b[201~");
+
+			expect(emittedPaste).toEqual(["part-one part-two part-three"]);
+			expect(emittedSequences).toEqual([]);
+		});
+
+		it("releases the latch at the absolute cap when input keeps re-arming the idle timer", () => {
+			processInput("\x1b[200~");
+			processInput("k");
+			expect(emittedPaste).toEqual([]);
+
+			// A user typing during the stall refreshes the idle timer forever; only the
+			// absolute cap can end it.
+			setSystemTime(new Date(Date.now() + 11_000));
+			try {
+				processInput("k");
+				expect(emittedPaste).toEqual(["kk"]);
+			} finally {
+				setSystemTime();
+			}
+
+			processInput("\x03");
+			expect(emittedSequences).toEqual(["\x03"]);
+		});
+
+		it("cancels the pending watchdog on clear()", async () => {
+			processInput("\x1b[200~orphan");
+			buffer.clear();
+			processInput("z");
+
+			await sleep(700);
+
+			expect(emittedPaste).toEqual([]);
+			expect(emittedSequences).toEqual(["z"]);
+		});
+
+		it("arms no watchdog for a paste that completed normally", async () => {
+			processInput("\x1b[200~done\x1b[201~");
+			expect(emittedPaste).toEqual(["done"]);
+
+			await sleep(700);
+
+			expect(emittedPaste).toEqual(["done"]);
 		});
 	});
 });


### PR DESCRIPTION
## Problem

A session stops accepting input entirely: the composer takes no keys, and neither `Escape` nor `Ctrl+C` does anything. The frame stays painted, the process keeps running, and the only way out is `kill` from another terminal. It survives into a resumed session and reproduces intermittently rather than on demand.

Minimal reproduction against `dev` - a bracketed-paste start with no matching end, then ordinary keys:

```ts
const buf = new StdinBuffer();
buf.on("data", s => seen.push(s));

buf.process(Buffer.from("\x1b[200~hello")); // START, END never arrives
buf.process(Buffer.from("a"));
buf.process(Buffer.from("\x1b"));           // Escape
buf.process(Buffer.from("\x03"));           // Ctrl+C
// seen === []   - and it stays empty forever
```

## Root cause

`StdinBuffer.process()` latches `#pasteMode` on `ESC[200~` and clears it only when `ESC[201~` shows up (`packages/tui/src/stdin-buffer.ts`). While latched, every byte is appended to `#pasteBuffer` and the method returns without emitting. There is no timeout and no size bound.

That is the odd one out in this file. Every other hold is bounded:

| hold | time bound | size bound |
| --- | --- | --- |
| SGR quarantine | `SGR_QUARANTINE_TIMEOUT_MS` 100ms | `SGR_QUARANTINE_MAX_BYTES` 256 |
| probe fragment | `PROBE_FRAGMENT_HOLD_MAX_MS` 500ms | `PROBE_FRAGMENT_MAX_BYTES` 256 |
| bare ESC in a probe window | `PROBE_ESCAPE_HOLD_MAX_MS` 150ms | - |
| **bracketed paste** | **none** | **none** |

Two other properties turn "input is held" into "the session is unrecoverable":

- `Tui.#handleInput` dispatches to `#focusedComponent` and nothing else, so no other layer can observe the keys.
- The terminal is in raw mode, so `ISIG` is off and `Ctrl+C` is byte `0x03` travelling that same dead path, not `SIGINT`.

A fresh session is fine because the latch starts clear; it only rots after a paste whose terminator is dropped, split across a mode change, or mangled by a multiplexer or a slow link.

## Fix

`packages/tui/src/stdin-buffer.ts`

- **Idle watchdog, `PASTE_IDLE_MAX_MS` = 500ms.** Re-armed on every chunk while in paste mode. A real paste streams continuously and keeps refreshing it, so it cannot truncate live paste traffic; a stranded latch goes idle and is released.
- **Absolute cap, `PASTE_HOLD_MAX_MS` = 10s**, measured from paste start and checked on each appended chunk. This covers the case the idle bound alone cannot: a user typing during the stall keeps re-arming the idle timer indefinitely.
- Both paths go through `#releaseStrandedPaste()`, which leaves paste mode and emits what accumulated as a normal `paste` event. Emitting rather than re-processing is deliberate - re-parsing would read newlines inside pasted text as `Enter` and submit the message.
- The watchdog uses its own timer, not the shared `#timeout` that the SGR-quarantine and pending-lead-byte paths own and that `process()` clears on every chunk.
- `clear()` cancels the watchdog and resets the start stamp, so `destroy()` cannot leave a late `paste` event pending.

No new configuration and no behavior change for a paste that completes normally.

## Tests

`packages/tui/test/stdin-buffer.test.ts`, new `Stranded Bracketed Paste` block (6 cases):

- releases the latch when the end marker never arrives
- delivers keys again afterwards, including `Escape` and `Ctrl+C`
- keeps a slow paste intact while it is still streaming (200ms gaps, under the idle bound)
- releases at the absolute cap when input keeps re-arming the idle timer (`setSystemTime` to cross the 10s boundary deterministically)
- cancels the pending watchdog on `clear()`
- arms no watchdog for a paste that completed normally

**3 of the 6 fail on unmodified `dev`** - the three that describe the bug. The other 3 are regression guards for the fix itself and pass either way.

Verification run on this branch:

- `bun test packages/tui/test/stdin-buffer.test.ts` - 79 pass, 0 fail
- `bun test packages/tui/test/` - 1080 pass, 6 skip, 0 fail (1086 across 77 files)
- `bunx tsc --noEmit -p packages/tui/tsconfig.json` - exit 0
- `bunx biome check packages/tui/src/stdin-buffer.ts packages/tui/test/stdin-buffer.test.ts` - OK

Changelog entry added under `packages/tui/CHANGELOG.md` `[Unreleased]`.
