### PR TITLE
fix(test): set 30s timeout on smithery-env-trust child-process tests

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added first-class `cline-pass` and `commandcode-goat` provider presets with documented API endpoints, environment-variable credentials, non-hardcoded live model discovery from models.dev and the Command Code Provider API, and prefix-based Claude routing.
 
+### Fixed
+
+- `smithery-env-trust.test.ts` now sets a 30s per-test timeout on all five child-process-spawning trust-boundary tests, preventing CI flake when the Bun child-process spawn + env-file-parse chain exceeds the default 5s budget under parallel shard contention (Dev CI run 31102063678).
+
 ## [0.12.15] - 2026-08-06
 
 ## [0.12.14] - 2026-08-06

--- a/packages/coding-agent/test/smithery-env-trust.test.ts
+++ b/packages/coding-agent/test/smithery-env-trust.test.ts
@@ -77,17 +77,17 @@ describe("Smithery env trust boundary", () => {
 		expect(resolved.url).toBe("https://smithery.ai");
 		expect(resolved.apiBaseUrl).toBe("https://api.smithery.ai");
 		expect(resolved.apiKey).toBeNull();
-	});
+	}, 30_000);
 
 	it("ignores Smithery endpoints planted by the project .env", async () => {
 		const resolved = await resolveIn(projectDir(PLANTED));
 		expect(resolved.url).toBe("https://smithery.ai");
 		expect(resolved.apiBaseUrl).toBe("https://api.smithery.ai");
-	});
+	}, 30_000);
 
 	it("ignores a Smithery API key planted by the project .env", async () => {
 		expect((await resolveIn(projectDir(PLANTED))).apiKey).toBeNull();
-	});
+	}, 30_000);
 
 	it("still honors inherited Smithery configuration", async () => {
 		const resolved = await resolveIn(projectDir(), {
@@ -98,7 +98,7 @@ describe("Smithery env trust boundary", () => {
 		expect(resolved.url).toBe("https://smithery.internal");
 		expect(resolved.apiBaseUrl).toBe("https://api.smithery.internal");
 		expect(resolved.apiKey).toBe("operator-key");
-	});
+	}, 30_000);
 
 	it("does not let the project .env override inherited configuration", async () => {
 		const resolved = await resolveIn(projectDir(PLANTED), {
@@ -107,5 +107,5 @@ describe("Smithery env trust boundary", () => {
 		});
 		expect(resolved.url).toBe("https://smithery.internal");
 		expect(resolved.apiKey).toBe("operator-key");
-	});
+	}, 30_000);
 });


### PR DESCRIPTION
Dev CI run 31102063678 (dev @473eab944) timed out in smithery-env-trust shard 7 after 5004ms. Each test spawns a child Bun process that parses 9 env/dotfiles at module load; under CI parallel load this exceeds Bun's default 5s timeout. CI flake, not deterministic regression (3x local reproduction: 5 pass / 0 fail each). Fix: add 30s per-test timeout matching the established pattern (agent-session-resilient-retry.test.ts). No production code changed.