### PR TITLE
fix(session): root-store identity (#3906) + coordinator broker terminalization (#2549)

### DIFF
--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -4037,6 +4037,9 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 												cwd: canonicalCwd,
 												target: coordinatorLifecycleTarget(config.sessionCommand, canonicalCwd),
 												...(mpresetResolution.mpreset ? { modelPreset: mpresetResolution.mpreset } : {}),
+												// Thread the coordinator state dir so the broker-spawned runtime
+												// writes terminal state to the coordinator-shared file (#2549).
+												coordinatorStateDir: namespaceDir,
 											},
 											idempotencyKey,
 										),
@@ -4249,6 +4252,9 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 										target: coordinatorLifecycleTarget(config.sessionCommand, cwd),
 										...(mpresetResolution.mpreset ? { modelPreset: mpresetResolution.mpreset } : {}),
 										...(preparesExistingThread ? { readiness: "deferred" } : {}),
+										// Thread the coordinator state dir so the broker-spawned runtime
+										// writes terminal state to the coordinator-shared file (#2549).
+										coordinatorStateDir: namespaceDir,
 									},
 									idempotencyKey,
 								),

--- a/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
@@ -406,13 +406,18 @@ function validPreviousRuntimeStatePayload(value: unknown): value is Record<strin
 			payload.state !== "unknown")
 	)
 		return false;
-	if (typeof payload.cwd !== "string" || payload.cwd.trim().length === 0) return false;
-	if (typeof payload.workdir !== "string" || payload.workdir.trim().length === 0) return false;
-	if (
-		!Object.hasOwn(payload, "session_file") ||
-		(payload.session_file !== null && typeof payload.session_file !== "string")
-	)
-		return false;
+	// Coordinator-seeded payloads (#2549) carry session_id and state but not the
+	// runtime identity fields cwd/workdir/session_file. Accept their absence; when
+	// present, validate them as before.
+	if (typeof payload.cwd !== "undefined") {
+		if (typeof payload.cwd !== "string" || payload.cwd.trim().length === 0) return false;
+	}
+	if (typeof payload.workdir !== "undefined") {
+		if (typeof payload.workdir !== "string" || payload.workdir.trim().length === 0) return false;
+	}
+	if (Object.hasOwn(payload, "session_file")) {
+		if (payload.session_file !== null && typeof payload.session_file !== "string") return false;
+	}
 	if (payload.ready_for_input !== undefined && typeof payload.ready_for_input !== "boolean") return false;
 	if (payload.live !== undefined && payload.live !== null && typeof payload.live !== "boolean") return false;
 	if (payload.reason !== undefined && payload.reason !== null && typeof payload.reason !== "string") return false;
@@ -519,20 +524,26 @@ function shouldPreserveTerminalPayload(previous: RuntimeStateSidecarPayload, inp
 
 function assertPreviousRuntimeStateIdentity(previous: Record<string, unknown>, input: RuntimeStateIdentity): void {
 	if (Object.keys(previous).length === 0) return;
-	if (
-		previous.session_id !== input.sessionId ||
-		typeof previous.cwd !== "string" ||
-		typeof previous.workdir !== "string" ||
-		!sameResolvedPath(previous.cwd, input.cwd, input.platform) ||
-		!sameResolvedPath(previous.workdir, input.cwd, input.platform) ||
-		(previous.session_file !== input.sessionFile &&
-			!(
-				typeof previous.session_file === "string" &&
-				typeof input.sessionFile === "string" &&
-				sameResolvedPath(previous.session_file, input.sessionFile, input.platform)
-			))
-	)
-		throw new PreviousRuntimeStateReadError();
+	// A coordinator-seeded payload (#2549) carries session_id and current_turn_id
+	// but not cwd/workdir/session_file (those are runtime identity fields). When
+	// the runtime writes to the coordinator-shared file, the seed is from the
+	// same session — the session_id match plus the broker-scoped file path is
+	// sufficient identity. Only refuse a genuinely foreign session_id.
+	if (previous.session_id !== input.sessionId) throw new PreviousRuntimeStateReadError();
+	// If the previous payload has runtime identity fields, verify them fully.
+	if (typeof previous.cwd === "string" && typeof previous.workdir === "string") {
+		if (
+			!sameResolvedPath(previous.cwd, input.cwd, input.platform) ||
+			!sameResolvedPath(previous.workdir, input.cwd, input.platform) ||
+			(previous.session_file !== input.sessionFile &&
+				!(
+					typeof previous.session_file === "string" &&
+					typeof input.sessionFile === "string" &&
+					sameResolvedPath(previous.session_file, input.sessionFile, input.platform)
+				))
+		)
+			throw new PreviousRuntimeStateReadError();
+	}
 }
 
 function runtimeStateFileForContext(context: RuntimeStateContext): string | null {

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -20,6 +20,11 @@ import {
 	type GjcLaunchWorktreePlan,
 	planLaunchWorktree,
 } from "../../gjc-runtime/launch-worktree";
+import {
+	GJC_COORDINATOR_SESSION_BRANCH_ENV,
+	GJC_COORDINATOR_SESSION_ID_ENV,
+	GJC_COORDINATOR_SESSION_STATE_FILE_ENV,
+} from "../../gjc-runtime/session-state-sidecar";
 import { validateManagedArtifactTree } from "../../session/internal/managed-session-storage";
 import {
 	FileSessionStorage,
@@ -236,6 +241,10 @@ export interface SessionLifecycleLaunchRequest {
 	semanticReadyDeadlineAt: number;
 	terminationStartDeadlineAt: number;
 	lifecycleCleanupDeadlineAt: number;
+	/** Coordinator namespace dir; broker computes the state file path from launch.id (#2549). */
+	coordinatorStateDir?: string;
+	coordinatorSessionId?: string;
+	coordinatorSessionBranch?: string;
 }
 
 function isSessionLifecycleTranscriptIdentity(value: unknown): value is SessionLifecycleTranscriptIdentity {
@@ -382,7 +391,14 @@ export function readSessionLifecycleLaunchRequest(
 			!hasValidTranscriptAuthority(request.sessionPath, request.sessionIdentity)) ||
 		(request.operation === "session.fork" &&
 			(!hasValidTranscriptAuthority(request.sourceSessionPath, request.sourceSessionIdentity) ||
-				request.sourceSessionId === undefined))
+				request.sourceSessionId === undefined)) ||
+		(request.coordinatorStateDir !== undefined &&
+			(typeof request.coordinatorStateDir !== "string" || request.coordinatorStateDir.length > 4096)) ||
+		(request.coordinatorSessionId !== undefined &&
+			(typeof request.coordinatorSessionId !== "string" ||
+				!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(request.coordinatorSessionId))) ||
+		(request.coordinatorSessionBranch !== undefined &&
+			(typeof request.coordinatorSessionBranch !== "string" || request.coordinatorSessionBranch.length > 512))
 	)
 		throw new Error("GJC_SDK_LIFECYCLE_REQUEST is invalid.");
 	return request as SessionLifecycleLaunchRequest;
@@ -400,6 +416,10 @@ type SessionLaunch = {
 	sessionIdentity?: SessionLifecycleTranscriptIdentity;
 	modelPreset?: string;
 	mcpServers?: SessionLifecycleMcpServer[];
+	/** Coordinator namespace dir; broker computes the state file path from launch.id (#2549). */
+	coordinatorStateDir?: string;
+	coordinatorSessionId?: string;
+	coordinatorSessionBranch?: string;
 	worktree?: SessionLifecycleWorktreeTarget;
 	readiness?: SessionLifecycleReadiness;
 	worktreePlan?: GjcLaunchWorktreePlan;
@@ -2484,6 +2504,14 @@ async function launchInput(
 	if (readiness === "deferred" && operation !== "session.create")
 		return fail("invalid_input", "readiness deferred is only supported for session.create.");
 
+	// Coordinator-correlation env scoped to this designated launch only (#2549).
+	// The coordinator passes these so the broker-spawned runtime writes terminal
+	// state to the coordinator-shared file instead of an unread session-local
+	// fallback. They are threaded into the child env, not exported broadly.
+	const coordinatorStateDir = text(input.coordinatorStateDir);
+	const coordinatorSessionId = text(input.coordinatorSessionId);
+	const coordinatorSessionBranch = text(input.coordinatorSessionBranch);
+
 	if (operation === "session.create")
 		return {
 			id: randomUUID(),
@@ -2494,6 +2522,9 @@ async function launchInput(
 			worktree,
 			worktreePlan,
 			...(readiness ? { readiness } : {}),
+			...(coordinatorStateDir ? { coordinatorStateDir } : {}),
+			...(coordinatorSessionId ? { coordinatorSessionId } : {}),
+			...(coordinatorSessionBranch ? { coordinatorSessionBranch } : {}),
 		};
 	if (operation === "session.resume") {
 		if (!requested) return fail("invalid_input", "sessionId is required to resume a saved session.");
@@ -2511,6 +2542,9 @@ async function launchInput(
 			mcpServers,
 			worktree,
 			worktreePlan,
+			...(coordinatorStateDir ? { coordinatorStateDir } : {}),
+			...(coordinatorSessionId ? { coordinatorSessionId } : {}),
+			...(coordinatorSessionBranch ? { coordinatorSessionBranch } : {}),
 		};
 	}
 	const sourceSessionId = text(input.sourceSessionId) ?? text(input.sourceId);
@@ -2533,6 +2567,9 @@ async function launchInput(
 		mcpServers,
 		worktree,
 		worktreePlan,
+		...(coordinatorStateDir ? { coordinatorStateDir } : {}),
+		...(coordinatorSessionId ? { coordinatorSessionId } : {}),
+		...(coordinatorSessionBranch ? { coordinatorSessionBranch } : {}),
 	};
 }
 
@@ -3155,6 +3192,9 @@ async function executeLifecycleResponse(
 			...(launch.mcpServers ? { mcpServers: launch.mcpServers } : {}),
 			...(launch.worktree ? { worktree: launch.worktree } : {}),
 			...(launch.readiness ? { readiness: launch.readiness } : {}),
+			...(launch.coordinatorStateDir ? { coordinatorStateDir: launch.coordinatorStateDir } : {}),
+			...(launch.coordinatorSessionId ? { coordinatorSessionId: launch.coordinatorSessionId } : {}),
+			...(launch.coordinatorSessionBranch ? { coordinatorSessionBranch: launch.coordinatorSessionBranch } : {}),
 		};
 		let child: ChildProcess | undefined;
 		let spawnedAuthority: EffectMarker | undefined;
@@ -3172,6 +3212,26 @@ async function executeLifecycleResponse(
 					GJC_STATE_ROOT: launch.root,
 					GJC_LIFECYCLE_REQUEST_ID: effectMarker,
 					GJC_SDK_LIFECYCLE_REQUEST: JSON.stringify(request),
+					// Coordinator-correlation env scoped to this designated launch only (#2549).
+					// The runtime sidecar reads these to write terminal state to the
+					// coordinator-shared file instead of an unread session-local fallback.
+					// The broker computes the file path from coordinatorStateDir + launch.id
+					// because the session ID is generated at spawn time.
+					...(launch.coordinatorStateDir
+						? {
+								[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]: path.join(
+									launch.coordinatorStateDir,
+									"session-states",
+									`${launch.id}.json`,
+								),
+							}
+						: {}),
+					...(launch.coordinatorSessionId
+						? { [GJC_COORDINATOR_SESSION_ID_ENV]: launch.coordinatorSessionId }
+						: {}),
+					...(launch.coordinatorSessionBranch
+						? { [GJC_COORDINATOR_SESSION_BRANCH_ENV]: launch.coordinatorSessionBranch }
+						: {}),
 				},
 			});
 			child = spawned;

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -715,14 +715,33 @@ export class ManagedSessionDescendantStore {
 		this.#authorityBaseDir = retained?.authorityBaseDir ?? this.#baseDir;
 		if (retained) {
 			const relative = path.relative(retained.authorityBaseDir, this.#baseDir).split(path.sep).join("/");
-			const captured = retained.authority.snapshotManagedTree(relative);
-			if (!captured.ok || !captured.snapshot)
-				throw new Error(captured.code ?? "Managed subtree identity unavailable");
-			this.#subtreeRoot = Object.freeze({
-				canonicalPath: this.#baseDir,
-				dev: BigInt(captured.snapshot.rootDev),
-				ino: BigInt(captured.snapshot.rootIno),
-			});
+			// For the root case (authorityBaseDir === baseDir, relative === ""), the
+			// stable identity() result carries the exact root dev/inode without
+			// snapshotting the entire live session tree. snapshotManagedTree("")
+			// walks every mutable descendant, so concurrent writers (other GJC
+			// processes appending jsonl/resident-cache/recovery data) make the
+			// snapshot return identity_mismatch (#3906). Mirrors #assertBound(),
+			// which already uses identity() for this same case. Nested descendants
+			// (relative !== "") still snapshot their subtree as before.
+			if (relative === "") {
+				const rootIdentity = retained.authority.identity();
+				if (!rootIdentity.ok || !rootIdentity.identity)
+					throw new Error(rootIdentity.code ?? "Managed subtree identity unavailable");
+				this.#subtreeRoot = Object.freeze({
+					canonicalPath: this.#baseDir,
+					dev: BigInt(rootIdentity.identity.dev),
+					ino: BigInt(rootIdentity.identity.ino),
+				});
+			} else {
+				const captured = retained.authority.snapshotManagedTree(relative);
+				if (!captured.ok || !captured.snapshot)
+					throw new Error(captured.code ?? "Managed subtree identity unavailable");
+				this.#subtreeRoot = Object.freeze({
+					canonicalPath: this.#baseDir,
+					dev: BigInt(captured.snapshot.rootDev),
+					ino: BigInt(captured.snapshot.rootIno),
+				});
+			}
 			this.#authority = retained.authority;
 			this.#assertBound();
 

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -793,7 +793,12 @@ describe("Coordinator MCP canonical SDK controls", () => {
 		expect(lifecycleControls(controls)).toEqual([
 			{
 				operation: "session.create",
-				input: { cwd: root, target: { path: root }, modelPreset: "codex-eco" },
+				input: {
+					cwd: root,
+					target: { path: root },
+					modelPreset: "codex-eco",
+					coordinatorStateDir: path.join(root, ".gjc", "coordinator-state", "local", "repo"),
+				},
 				idempotencyKey: "preset-start",
 			},
 		]);
@@ -858,6 +863,7 @@ describe("Coordinator MCP canonical SDK controls", () => {
 			input: {
 				cwd: root,
 				target: { path: root, worktree: { enabled: true, name: "hermes" } },
+				coordinatorStateDir: path.join(root, ".gjc", "coordinator-state", "local", "repo"),
 			},
 			idempotencyKey: "worktree-start",
 		});
@@ -1563,7 +1569,15 @@ describe("Coordinator MCP canonical SDK controls", () => {
 		}
 		expect(lifecycleControls(controls)).toEqual(
 			expect.arrayContaining([
-				{ operation: "session.create", input: { cwd: root, target: { path: root } }, idempotencyKey: "plan" },
+				{
+					operation: "session.create",
+					input: {
+						cwd: root,
+						target: { path: root },
+						coordinatorStateDir: path.join(root, ".gjc", "coordinator-state", "local", "repo"),
+					},
+					idempotencyKey: "plan",
+				},
 				{
 					operation: "turn.prompt",
 					input: { text: expect.stringContaining("/skill:ralplan") },

--- a/packages/coding-agent/test/session-state-sidecar.test.ts
+++ b/packages/coding-agent/test/session-state-sidecar.test.ts
@@ -2067,4 +2067,77 @@ describe("coordinator runtime state sidecar", () => {
 		expect(await readJson(readinessFile)).toEqual(marker);
 		expect((await readJson(stateFile)).state).toBe("running");
 	});
+	it("accepts a coordinator-seeded payload and preserves current_turn_id (#2549)", async () => {
+		// The coordinator seeds its state file with current_turn_id but without
+		// cwd/workdir/session_file (runtime identity fields). When the runtime writes
+		// to the same coordinator-shared file, assertPreviousRuntimeStateIdentity
+		// must accept the seed (same session_id) and basePayload must preserve the
+		// coordinator's current_turn_id. This is the fencing-compatibility fix that
+		// lets the exact-match terminal predicate work without heuristic inference.
+		const root = await tempRoot();
+		const stateFile = path.join(root, "coordinator-state.json");
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		const sessionId = "broker-session-2549";
+		const coordinatorTurnId = "turn-correlated-2549";
+
+		// Seed the file as the coordinator would: session_id + current_turn_id, no cwd/workdir.
+		await Bun.write(
+			stateFile,
+			`${JSON.stringify({
+				schema_version: 1,
+				session_id: sessionId,
+				state: "running",
+				ready_for_input: false,
+				current_turn_id: coordinatorTurnId,
+				last_turn_id: null,
+				updated_at: new Date().toISOString(),
+				source: "coordinator",
+				live: null,
+				reason: null,
+			})}\n`,
+		);
+
+		// Runtime writes agent_end to the same file. It must not throw fencing error.
+		await persistCoordinatorRuntimeStateFromEvent(assistantEnd("FINAL-2549"), {
+			sessionId,
+			cwd: root,
+			sessionFile: path.join(root, "session.jsonl"),
+		});
+
+		const payload = await readPayload(stateFile);
+		// The runtime completed with the coordinator's turn ID preserved.
+		expect(payload.state).toBe("completed");
+		expect(payload.source).toBe("agent_session_event");
+		expect(payload.current_turn_id).toBe(coordinatorTurnId);
+		expect((payload.final_response as Record<string, unknown> | undefined)?.text).toBe("FINAL-2549");
+	});
+
+	it("rejects a foreign session_id in the coordinator-shared file (#2549)", async () => {
+		// A genuinely foreign session_id must still be rejected by identity fencing,
+		// even when the previous payload lacks cwd/workdir/session_file.
+		const root = await tempRoot();
+		const stateFile = path.join(root, "coordinator-state-foreign.json");
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		const foreignSessionId = "different-session";
+		const runtimeSessionId = "runtime-session-2549";
+
+		await Bun.write(
+			stateFile,
+			`${JSON.stringify({
+				schema_version: 1,
+				session_id: foreignSessionId,
+				state: "running",
+				current_turn_id: "turn-foreign",
+			})}\n`,
+		);
+
+		// The runtime has a different session_id; fencing must throw.
+		await expect(
+			persistCoordinatorRuntimeStateFromEvent(assistantEnd("should-not-persist"), {
+				sessionId: runtimeSessionId,
+				cwd: root,
+				sessionFile: path.join(root, "session.jsonl"),
+			}),
+		).rejects.toThrow();
+	});
 });

--- a/packages/coding-agent/test/session-storage.test.ts
+++ b/packages/coding-agent/test/session-storage.test.ts
@@ -1420,6 +1420,104 @@ describe.skipIf(process.platform !== "linux")("managed descendant retained bindi
 			fs.rmSync(root, { recursive: true, force: true });
 		}
 	});
+
+	it("root retained-authority store does not snapshot mutable descendants (#3906)", () => {
+		// On Linux, retained-authority store construction must use identity() for the
+		// root case (authorityBaseDir === baseDir) rather than snapshotManagedTree(""),
+		// which walks every mutable descendant and returns identity_mismatch under
+		// concurrent writers. #assertBound() already uses identity() for this case;
+		// the constructor must mirror it. Nested descendants still snapshot.
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-managed-root-snapshot-3906-"));
+		try {
+			const rootAuthority = managedDirectoryRoot(root);
+			// Publish a file so the tree is non-empty (a mutable descendant exists).
+			const warmup = new ManagedSessionDescendantStore(rootAuthority, root);
+			warmup.publishNoReplaceSync("session.jsonl", Buffer.from('{"id":"warm"}\n'));
+			warmup.close();
+
+			const retainedAuthority = retainManagedDirectoryAuthority(rootAuthority, root);
+			if (!retainedAuthority) {
+				// Non-Linux: no retained native root authority. Verify construction still
+				// succeeds without a retained authority and skip the snapshot assertion.
+				const fallback = new ManagedSessionDescendantStore(rootAuthority, root);
+				fallback.close();
+				return;
+			}
+
+			// Spy on snapshotManagedTree: it must NOT be called for root construction.
+			const snapshotSpy = vi.spyOn(native.RecoveryFsRoot.prototype, "snapshotManagedTree");
+
+			const store = new ManagedSessionDescendantStore(rootAuthority, root, {
+				authority: retainedAuthority,
+				authorityBaseDir: root,
+			});
+
+			// Root construction must not have snapshotted the tree at all.
+			expect(snapshotSpy).not.toHaveBeenCalled();
+			store.close();
+
+			snapshotSpy.mockRestore();
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("root retained-authority store survives concurrent descendant writes (#3906)", () => {
+		// Simulate a concurrent writer appending to a descendant file while the
+		// root store is constructed. Before the fix, snapshotManagedTree("") would
+		// observe the mutable descendant mid-write and return identity_mismatch.
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-managed-concurrent-3906-"));
+		try {
+			const rootAuthority = managedDirectoryRoot(root);
+			// Warm up: create a descendant file that will be concurrently written.
+			const warmup = new ManagedSessionDescendantStore(rootAuthority, root);
+			warmup.publishNoReplaceSync("session.jsonl", Buffer.from('{"id":"base"}\n'));
+			warmup.close();
+
+			const retainedAuthority = retainManagedDirectoryAuthority(rootAuthority, root);
+			if (!retainedAuthority) return; // Non-Linux: no retained authority path.
+
+			// Concurrently append to the descendant while constructing the root store.
+			// This would make snapshotManagedTree("") see a changing tree. The fix
+			// uses identity() which only reads the stable root inode/dev.
+			const append = Buffer.from('{"id":"concurrent"}\n');
+			const writer = new ManagedSessionDescendantStore(rootAuthority, root);
+			const interval = setInterval(() => {
+				try {
+					writer.replaceSync("session.jsonl", Buffer.concat([Buffer.from('{"id":"base"}\n'), append]));
+				} catch {
+					// ignore transient races; the point is to create concurrent mutation
+				}
+			}, 1);
+
+			let constructions = 0;
+			let failures = 0;
+			try {
+				for (let i = 0; i < 20; i++) {
+					try {
+						const store = new ManagedSessionDescendantStore(rootAuthority, root, {
+							authority: retainManagedDirectoryAuthority(rootAuthority, root)!,
+							authorityBaseDir: root,
+						});
+						store.assertBound();
+						store.close();
+						constructions++;
+					} catch {
+						failures++;
+					}
+				}
+			} finally {
+				clearInterval(interval);
+				writer.close();
+			}
+
+			// Every root construction must succeed despite concurrent descendant writes.
+			expect(failures).toBe(0);
+			expect(constructions).toBe(20);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
 });
 
 describe("FileSessionStorageWriter path security", () => {


### PR DESCRIPTION
## Summary

Fixes two independently reproduced defects in the managed session and coordinator lifecycle.

### #3906 — concurrent root-store binding_invalid

The `ManagedSessionDescendantStore` constructor always called `snapshotManagedTree("")` for the root retained-authority case (`relative === ""`), walking every mutable descendant. Concurrent GJC startups in one actively-written workspace caused the snapshot to return `identity_mismatch`, aborting managed-session initialization with `binding_invalid: prepare:store`.

**Fix:** the constructor now mirrors `#assertBound()`: uses `identity()` for `relative === ""` (stable root dev/inode), keeps `snapshotManagedTree(relative)` for genuinely nested descendants.

### #2549 — coordinator broker terminalization via correlation contract

Broker-spawned coordinator sessions never terminalized because the runtime sidecar wrote terminal state to a session-local file the coordinator never read, and `current_turn_id` was always null for broker sessions.

**Deeper fix (preserves `unsafe_identity_predicate_hold`):**
- **Coordinator** (`server.ts`): passes `coordinatorStateDir` into `session.create` broker input.
- **Broker** (`lifecycle.ts`): threads `coordinatorStateDir` through `SessionLifecycleLaunchRequest` + `SessionLaunch` + `launchInput()`, computes the state file path from `coordinatorStateDir + launch.id`, sets `GJC_COORDINATOR_SESSION_STATE_FILE` env scoped to the designated spawn only.
- **Runtime sidecar** (`session-state-sidecar.ts`): fencing (`validPreviousRuntimeStatePayload` + `assertPreviousRuntimeStateIdentity`) accepts coordinator-seeded payloads (same `session_id` without `cwd`/`workdir`/`session_file`), `basePayload` preserves `current_turn_id` from the coordinator seed.

The exact-match terminal predicate (`current_turn_id === turn.turn_id`) is **preserved** — the missing identity is made *available* via the correlation contract, not *inferred*. The issue's proposed `completed` + null-`current_turn_id` symmetry is explicitly rejected per the owner's `unsafe_identity_predicate_hold`.

Also fixes the env-leak concern from @suho-han: `GJC_COORDINATOR_SESSION_*` is scoped to the broker spawn env (the designated runtime launch only), not exported into the general process environment.

## Test plan

- `session-storage.test.ts`: 71 pass / 0 fail (includes 2 new #3906 regression tests)
- `session-state-sidecar.test.ts`: 55 pass / 0 fail (includes 2 new #2549 regression tests)
- `coordinator-mcp-server.test.ts`: 66 pass / 0 fail
- `sdk-broker.test.ts`: 60 pass / 0 fail
- `tsc` + `biome check`: clean

## Constraints

- PR targets `dev`.
- Preserves `unsafe_identity_predicate_hold` on #2549.
- No unrelated work.
- Nested retained authorities preserve existing fail-closed identity validation.

Closes #3906
Closes #2549