### PR TITLE
fix(acp): normalize session/request_permission responses into the SDK decision contract

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- ACP `session/request_permission` responses are now normalized from the spec-shaped `RequestPermissionResponse` (`{ outcome: { outcome, optionId } }`) into the SDK's flat permission-decision contract before reaching the permission provider. Standards-compliant ACP clients such as Paseo answer with the nested shape, which previously made every permission-gated tool call (bash, edit, write) fail with "permission provider returned an invalid response"; the flat legacy shape keeps passing through unchanged.
 
 ### Added
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
-- ACP `session/request_permission` responses are now normalized from the spec-shaped `RequestPermissionResponse` (`{ outcome: { outcome, optionId } }`) into the SDK's flat permission-decision contract before reaching the permission provider. Standards-compliant ACP clients such as Paseo answer with the nested shape, which previously made every permission-gated tool call (bash, edit, write) fail with "permission provider returned an invalid response"; the flat legacy shape keeps passing through unchanged.
+- ACP `session/request_permission` responses are now normalized from the spec-shaped `RequestPermissionResponse` (`{ outcome: { outcome, optionId } }`) into the SDK's flat permission-decision contract before reaching the permission provider. Standards-compliant ACP clients such as Paseo can now authorize permission-gated shell/eval and destructive file operations (`bash`, `monitor`, `eval`, `delete`, `move`, and `edit` only for delete/move operations) without an invalid-response failure; `write` and ordinary edits remain ungated. Nested and flat selected/cancelled responses are accepted by reconstructing the canonical SDK decision fields, while malformed or unknown decisions fail closed.
 
 ### Added
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -785,13 +785,26 @@ export function createAcpReverseConnection(connection: AgentSideConnection, sess
 			const rawRequest = (connection as unknown as Record<string, unknown>).request;
 			if (typeof rawRequest !== "function")
 				throw new AcpSdkAdapterError("acp_reverse_unavailable", "ACP reverse request surface is unavailable.");
-			return await (
+			const result = await (
 				rawRequest as (
 					method: string,
 					input: JsonObject,
 					options?: { cancellationSignal?: AbortSignal },
 				) => Promise<unknown>
 			).call(connection, name, { ...params, sessionId }, options);
+			// ACP clients answer `session/request_permission` with the spec-shaped
+			// `RequestPermissionResponse` `{ outcome: { outcome, optionId } }`, while the
+			// SDK permission-provider contract is the flat decision `{ outcome, optionId }`.
+			// Normalize the outer wrapper (accepting the flat legacy shape as well) so
+			// permission-gated tool calls resolve instead of failing as an invalid response.
+			const response = object(result);
+			if (name === "session/request_permission" && response) {
+				const decision = object(response.outcome) ?? response;
+				if (decision.outcome === "cancelled") return { outcome: "cancelled" };
+				if (decision.outcome === "selected" && typeof decision.optionId === "string")
+					return { outcome: "selected", optionId: decision.optionId };
+			}
+			return result;
 		},
 	};
 }

--- a/packages/coding-agent/test/acp-client-bridge.test.ts
+++ b/packages/coding-agent/test/acp-client-bridge.test.ts
@@ -22,7 +22,7 @@ describe("ACP client bridge permission requests", () => {
 			_meta: { gjc: { permissionHandling: "prompt" } },
 		});
 
-		await bridge.requestPermission!(
+		const outcome = await bridge.requestPermission!(
 			{
 				toolCallId: "call-1",
 				toolName: "bash",
@@ -43,6 +43,25 @@ describe("ACP client bridge permission requests", () => {
 			rawInput: { command: "echo hi" },
 			content: [{ type: "content", content: { type: "text", text: "$ echo hi" } }],
 		});
+		expect(outcome).toEqual({ outcome: "selected", optionId: "allow_once", kind: "allow_once" });
+	});
+
+	it("returns cancelled ACP permission outcomes through the typed client bridge contract", async () => {
+		const connection = {
+			async requestPermission() {
+				return { outcome: { outcome: "cancelled" as const } };
+			},
+		} as unknown as AgentSideConnection;
+		const bridge = createAcpClientBridge(connection, "session-1", {
+			_meta: { gjc: { permissionHandling: "prompt" } },
+		});
+
+		expect(
+			await bridge.requestPermission!(
+				{ toolCallId: "call-2", toolName: "bash", title: "cancel", status: "pending" },
+				[{ optionId: "reject_once", name: "Reject once", kind: "reject_once" }],
+			),
+		).toEqual({ outcome: "cancelled" });
 	});
 
 	it("only enables ACP permission requests in prompt mode", () => {

--- a/packages/coding-agent/test/acp-startup-options.test.ts
+++ b/packages/coding-agent/test/acp-startup-options.test.ts
@@ -69,6 +69,7 @@ test("ACP reverse requests use canonical names, session scope, and cancellation"
 	const reverse = createAcpReverseConnection(connection, "session-1");
 	const requests = [
 		["request", { toolCallId: "call-1", sessionId: "spoofed-session" }],
+		["permission.request", { toolCallId: "call-2", sessionId: "spoofed-session" }],
 		["fs.readTextFile", { path: "/workspace/README.md" }],
 		["fs.writeTextFile", { path: "/workspace/README.md", content: "updated" }],
 		["terminal.create", { command: "printf", args: ["ok"] }],
@@ -78,6 +79,7 @@ test("ACP reverse requests use canonical names, session scope, and cancellation"
 
 	expect(calls).toEqual([
 		["session/request_permission", { toolCallId: "call-1", sessionId: "session-1" }, { cancellationSignal: signal }],
+		["session/request_permission", { toolCallId: "call-2", sessionId: "session-1" }, { cancellationSignal: signal }],
 		["fs/read_text_file", { path: "/workspace/README.md", sessionId: "session-1" }, { cancellationSignal: signal }],
 		[
 			"fs/write_text_file",
@@ -93,32 +95,27 @@ test("ACP reverse requests use canonical names, session scope, and cancellation"
 	]);
 	expect(typedCalls).toEqual([]);
 });
-test("ACP reverse permission responses normalize the spec-shaped outcome into the SDK decision contract", async () => {
-	const selectedConnection = {
-		request: async () => ({ outcome: { outcome: "selected", optionId: "allow_once" } }),
-	} as unknown as AgentSideConnection;
-	const selectedReverse = createAcpReverseConnection(selectedConnection, "session-1");
-	expect(await selectedReverse.request?.("request", { toolCallId: "call-1" })).toEqual({
-		outcome: "selected",
-		optionId: "allow_once",
-	});
-
-	const cancelledConnection = {
-		request: async () => ({ outcome: { outcome: "cancelled" } }),
-	} as unknown as AgentSideConnection;
-	const cancelledReverse = createAcpReverseConnection(cancelledConnection, "session-1");
-	expect(await cancelledReverse.request?.("request", { toolCallId: "call-2" })).toEqual({
-		outcome: "cancelled",
-	});
-
-	const flatConnection = {
-		request: async () => ({ outcome: "selected", optionId: "allow_always" }),
-	} as unknown as AgentSideConnection;
-	const flatReverse = createAcpReverseConnection(flatConnection, "session-1");
-	expect(await flatReverse.request?.("request", { toolCallId: "call-3" })).toEqual({
-		outcome: "selected",
-		optionId: "allow_always",
-	});
+test("ACP reverse permission aliases normalize nested and flat outcomes into the SDK decision contract", async () => {
+	for (const method of ["request", "permission.request"] as const) {
+		for (const [response, expected] of [
+			[
+				{ outcome: { outcome: "selected", optionId: "allow_once" } },
+				{ outcome: "selected", optionId: "allow_once" },
+			],
+			[{ outcome: { outcome: "cancelled" } }, { outcome: "cancelled" }],
+			[
+				{ outcome: "selected", optionId: "allow_always" },
+				{ outcome: "selected", optionId: "allow_always" },
+			],
+			[{ outcome: "cancelled" }, { outcome: "cancelled" }],
+		] as const) {
+			const connection = {
+				request: async () => response,
+			} as unknown as AgentSideConnection;
+			const reverse = createAcpReverseConnection(connection, "session-1");
+			expect(await reverse.request?.(method, { toolCallId: "call-1" })).toEqual(expected);
+		}
+	}
 });
 
 test("ACP maps non-prompt permission handling to the SDK allow policy", async () => {

--- a/packages/coding-agent/test/acp-startup-options.test.ts
+++ b/packages/coding-agent/test/acp-startup-options.test.ts
@@ -93,6 +93,33 @@ test("ACP reverse requests use canonical names, session scope, and cancellation"
 	]);
 	expect(typedCalls).toEqual([]);
 });
+test("ACP reverse permission responses normalize the spec-shaped outcome into the SDK decision contract", async () => {
+	const selectedConnection = {
+		request: async () => ({ outcome: { outcome: "selected", optionId: "allow_once" } }),
+	} as unknown as AgentSideConnection;
+	const selectedReverse = createAcpReverseConnection(selectedConnection, "session-1");
+	expect(await selectedReverse.request?.("request", { toolCallId: "call-1" })).toEqual({
+		outcome: "selected",
+		optionId: "allow_once",
+	});
+
+	const cancelledConnection = {
+		request: async () => ({ outcome: { outcome: "cancelled" } }),
+	} as unknown as AgentSideConnection;
+	const cancelledReverse = createAcpReverseConnection(cancelledConnection, "session-1");
+	expect(await cancelledReverse.request?.("request", { toolCallId: "call-2" })).toEqual({
+		outcome: "cancelled",
+	});
+
+	const flatConnection = {
+		request: async () => ({ outcome: "selected", optionId: "allow_always" }),
+	} as unknown as AgentSideConnection;
+	const flatReverse = createAcpReverseConnection(flatConnection, "session-1");
+	expect(await flatReverse.request?.("request", { toolCallId: "call-3" })).toEqual({
+		outcome: "selected",
+		optionId: "allow_always",
+	});
+});
 
 test("ACP maps non-prompt permission handling to the SDK allow policy", async () => {
 	const modes: string[] = [];

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -2,11 +2,13 @@ import { afterEach, expect, spyOn, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { Agent } from "@gajae-code/agent-core";
+import type { AgentSideConnection } from "@agentclientprotocol/sdk";
+import { Agent, type AgentTool } from "@gajae-code/agent-core";
 import { closeModelCache, getBundledModel } from "@gajae-code/ai";
 import { createMockModel } from "@gajae-code/ai/providers/mock";
 import { NotificationServer } from "@gajae-code/natives";
 import { logger } from "@gajae-code/utils";
+import * as z from "zod/v4";
 import { ModelRegistry } from "../src/config/model-registry";
 import { Settings } from "../src/config/settings";
 import { ExtensionRunner } from "../src/extensibility/extensions/runner";
@@ -24,6 +26,7 @@ async function firePreflightAccept(options?: {
 	else options?.onPreflightAccepted?.();
 }
 
+import { createAcpReverseConnection } from "../src/modes/acp/acp-agent";
 import { ExtensionUiController } from "../src/modes/controllers/extension-ui-controller";
 import { buildAskGateAnswerSchema as buildDeepInterviewAskGateAnswerSchema } from "../src/modes/shared/agent-wire/deep-interview-gate";
 import {
@@ -38,6 +41,7 @@ import {
 	validateAskGateStageState,
 } from "../src/modes/shared/agent-wire/workflow-gate-types";
 import type { InteractiveModeContext } from "../src/modes/types";
+import { AcpSdkAdapter } from "../src/sdk/acp/adapter";
 import { brokerOwnerForTest } from "../src/sdk/broker/ensure";
 import { SessionIndex } from "../src/sdk/broker/session-index";
 import { createNotificationsExtension, formatPromptSettlementDiagnostic, PresentationArbiter } from "../src/sdk/bus";
@@ -2817,6 +2821,144 @@ test("SDK host routes pure ACP permission prompts through a live reverse provide
 	});
 	socket.close();
 	await waitFor(() => permissionProvider === undefined, "permission provider removal after disconnect");
+});
+
+test("ACP permission attachment normalizes decisions through the registered provider path", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-acp-permission-path-"));
+	dirs.push(cwd);
+	const sessionId = `sdk-acp-permission-path-${Date.now()}`;
+	const acpSessionId = "acp-session-authority";
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Expected bundled test model");
+	const bashTool = {
+		name: "bash",
+		label: "bash",
+		description: "Guarded fixture tool",
+		parameters: z.object({ command: z.string() }),
+		executeCalls: 0,
+		async execute() {
+			bashTool.executeCalls++;
+			return { content: [{ type: "text" as const, text: "executed" }] };
+		},
+	} satisfies AgentTool & { executeCalls: number };
+	const sessionManager = SessionManager.inMemory(cwd);
+	const agentSession = new AgentSession({
+		agent: new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [bashTool], messages: [] },
+			streamFn: createMockModel({ responses: [] }).stream,
+		}),
+		sessionManager,
+		settings: Settings.isolated({ "compaction.enabled": false }),
+		modelRegistry: {} as never,
+		toolRegistry: new Map([[bashTool.name, bashTool]]),
+	});
+	agentSession.setSdkPermissionMode("prompt");
+	let permissionProvider: SdkPermissionProvider;
+	const ctx = {
+		...context(cwd, sessionId),
+		setSdkPermissionProvider: (provider: SdkPermissionProvider | undefined) => {
+			permissionProvider = provider!;
+			agentSession.setSdkPermissionProvider(provider);
+		},
+	};
+	process.env.GJC_NOTIFICATIONS = "1";
+	start(ctx);
+	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+
+	let nextResponse: unknown;
+	let waitForReverseAbort = false;
+	let reverseAbortObserved = false;
+	const reverseCalls: Array<{
+		method: string;
+		input: Record<string, unknown>;
+		signal: AbortSignal | undefined;
+	}> = [];
+	const connection = {
+		async request(
+			method: string,
+			input: Record<string, unknown>,
+			options?: { cancellationSignal?: AbortSignal },
+		): Promise<unknown> {
+			const signal = options?.cancellationSignal;
+			reverseCalls.push({ method, input, signal });
+			if (!waitForReverseAbort) return nextResponse;
+			const { promise, resolve } = Promise.withResolvers<unknown>();
+			const observeAbort = () => {
+				reverseAbortObserved = true;
+				resolve({ outcome: { outcome: "cancelled" } });
+			};
+			if (signal?.aborted) observeAbort();
+			else signal?.addEventListener("abort", observeAbort, { once: true });
+			return await promise;
+		},
+	} as unknown as AgentSideConnection;
+	const adapter = await AcpSdkAdapter.connect({
+		url: endpoint.url,
+		token: endpoint.token,
+		connection: createAcpReverseConnection(connection, acpSessionId),
+		providers: [{ capability: "permission", definitions: [] }],
+		heartbeatMs: 60_000,
+	});
+
+	try {
+		await waitFor(() => permissionProvider !== undefined, "ACP permission provider installation");
+		await agentSession.setActiveToolsByName(["bash"]);
+		const guardedBash = agentSession.agent.state.tools.find(tool => tool.name === "bash");
+		if (!guardedBash) throw new Error("Expected guarded bash tool");
+		let callNumber = 0;
+		const execute = async (response: unknown, signal?: AbortSignal) => {
+			nextResponse = response;
+			return await guardedBash.execute(
+				`call-${++callNumber}`,
+				{ command: "printf guarded" },
+				signal,
+				undefined as never,
+				undefined as never,
+			);
+		};
+
+		for (const response of [
+			{ outcome: { outcome: "selected", optionId: "reject_once" } },
+			{ outcome: { outcome: "cancelled" } },
+			{ outcome: "cancelled" },
+			null,
+			1,
+			[],
+			{},
+			{ outcome: "unknown" },
+			{ outcome: "selected" },
+			{ outcome: "selected", optionId: 1 },
+			{ outcome: "selected", optionId: "" },
+			{ outcome: "selected", optionId: "unknown_option" },
+		]) {
+			await expect(execute(response)).rejects.toThrow();
+			expect(bashTool.executeCalls).toBe(0);
+		}
+
+		waitForReverseAbort = true;
+		const cancellation = new AbortController();
+		const cancelledExecution = execute(undefined, cancellation.signal);
+		await waitFor(() => reverseCalls.length === 13, "reverse permission cancellation request");
+		cancellation.abort();
+		await expect(cancelledExecution).rejects.toThrow("Permission request cancelled");
+		await waitFor(() => reverseAbortObserved, "ACP reverse cancellation signal");
+		expect(bashTool.executeCalls).toBe(0);
+		waitForReverseAbort = false;
+
+		await expect(execute({ outcome: { outcome: "selected", optionId: "allow_once" } })).resolves.toBeDefined();
+		await expect(execute({ outcome: "selected", optionId: "allow_once" })).resolves.toBeDefined();
+		expect(bashTool.executeCalls).toBe(2);
+		expect(reverseCalls).toHaveLength(15);
+		expect(reverseCalls.every(call => call.method === "session/request_permission")).toBe(true);
+		expect(reverseCalls.every(call => call.input.sessionId === acpSessionId)).toBe(true);
+		expect(reverseCalls.every(call => call.signal instanceof AbortSignal)).toBe(true);
+	} finally {
+		await adapter.close();
+		await agentSession.dispose();
+	}
 });
 
 test("SDK host routes AskUserQuestion through a live ACP form elicitation provider", async () => {


### PR DESCRIPTION
## Problem

Permission-gated tool calls (`bash`, `edit`, `write`) fail with **"permission provider returned an invalid response"** whenever GJC runs as an ACP agent under a standards-compliant ACP client. Reproduced with Paseo 0.3.0-beta.2 (the app's daemon launches `cli.ts acp` as the provider), affecting every bash/edit/write call once the client answers a permission prompt.

### Affected environment

- GJC ACP agent mode: `gjc ... acp` (any ACP client).
- Repro: client sends `session/new`, prompts the agent to use `bash`, then answers the incoming `session/request_permission` with the spec-shaped response. The tool call fails with `permission provider returned an invalid response`; expected behavior is that the tool executes.

## Root cause

The ACP spec (`@agentclientprotocol/sdk`, pinned `1.3.0`) defines the response to `session/request_permission` as `RequestPermissionResponse`:

```ts
{ outcome: { outcome: "selected", optionId } }   // nested decision object
{ outcome: { outcome: "cancelled" } }
```

Paseo (and the official SDK's own fixtures) send exactly this nested shape. GJC's SDK permission provider (`sdk/bus/index.ts`) validates the **flat** decision `{ outcome: "selected", optionId }`, so `response.outcome` is an object instead of the expected string and the validation rejects it. The ACP reverse bridge (`modes/acp/acp-agent.ts` `createAcpReverseConnection`) returned the raw wire payload without the unwrap that the sibling `acp-client-bridge.ts` path already performs.

## Change

Normalize `session/request_permission` responses at the ACP adapter boundary (`createAcpReverseConnection`):

- Spec-shaped `{ outcome: { outcome, optionId } }` → SDK contract `{ outcome, optionId }` (selected / cancelled).
- The flat legacy shape passes through unchanged.
- Malformed responses stay fail-closed (existing "invalid response" error preserved).

Scope is one function plus a regression test and a changelog entry. No public API or behavior change beyond permission prompts resolving correctly.

## Validation

- **Unit tests** (`test/acp-startup-options.test.ts`): nested selected, nested cancelled, and flat passthrough — all pass.
- **Related ACP suites** (55 tests): `acp-startup-options`, `acp-client-bridge`, `agent-session-acp-permission`, `sdk-acp-production-path` — all pass.
- **Type/lint**: `bun --cwd=packages/coding-agent run check` (biome + tsc) passes on the final head.
- **End-to-end (real daemon)**: Paseo app 0.3.0-beta.2 → daemon → GJC provider; prompt to run `echo daemon-permission-ok`, answered the permission request with the nested spec shape. Transcript shows `toolResult "daemon-permission-ok\n"` and a completed turn; `permission provider returned an invalid response` appears **0 times**.
- **Before/after wire probe**: identical nested response — before the fix the turn failed with the invalid-response error; after the fix bash executes.

## Related work

- The identical change is also open on the fork as **snowykr/gajae-code#23**; this PR targets upstream `dev` and supersedes the fork PR for upstream review.
- Related existing work: **#3925** "feat(acp): bridge workflow-gate asks to the ACP permission channel" routes workflow-gate asks through the same `session/request_permission` channel and would hit the same shape bug; this change is complementary (fixes the permission response contract) and not a duplicate.
- No existing issue/PR addresses the "permission provider returned an invalid response" shape mismatch.

## Checklist

- [x] Problem and motivation clearly described
- [x] Related issues/PRs linked and non-duplicate rationale
- [x] Scope focused (one function + test + changelog)
- [x] Failure handling preserved (fail-closed on malformed)
- [x] Single coherent commit, conventional message with trailers
- [x] Tests added and executed (55 pass)
- [x] End-to-end validation through the real ACP client/daemon environment
- [x] Branch rebased onto upstream `dev` (upstream `dev` is an ancestor; branch is 1 commit ahead)
- [x] CI runs on the final head commit
