### PR TITLE
fix(coding-agent): bound busy-reschedule loop for fire-and-forget continuations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `smithery-env-trust.test.ts` warms the Bun probe child in `beforeAll` and kills stalled spawns at a 45s budget so the first case no longer absorbs cold-start compile cost into its per-test timeout under shard contention (observed 60001ms timeout after the 60s cap on #3969 exact-head CI). Assertions unchanged.
 - `smithery-env-trust.test.ts` raises the per-test child-process timeout from 30s to 60s so CI contention cannot fail at the previous 30s cap (Dev CI run 31128319216 timed out at 30004ms).
 - `smithery-env-trust.test.ts` now sets a 30s per-test timeout on all five child-process-spawning trust-boundary tests, preventing CI flake when the Bun child-process spawn + env-file-parse chain exceeds the default 5s budget under parallel shard contention (Dev CI run 31102063678).
+- Fire-and-forget agent continuations (auto-compaction retries, queued follow-ups) racing a still-busy agent no longer spin on a fixed 100ms reschedule forever: they now back off exponentially (100ms doubling up to 5s) and give up after 50 attempts (~4 minutes) with an explicit warn, fixing a runaway loop observed as 10,742 reschedules over 21 minutes in a single session.
 
 ## [0.12.15] - 2026-08-06
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1721,6 +1721,23 @@ type SessionAdmissionLease = {
 	release(): void;
 };
 
+/**
+ * Fire-and-forget continuations (auto-compaction retries, queued follow-ups) race a
+ * still-busy agent whose current turn can legitimately hold the run for minutes.
+ * Reschedule with capped exponential backoff instead of a fixed 100ms spin, and give
+ * up after a bounded number of attempts (~4 minutes total) so a stuck busy state
+ * cannot spin forever — observed in production logs as 10,742 reschedules over
+ * 21 minutes inside a single session.
+ */
+const AGENT_CONTINUE_BUSY_RESCHEDULE_BASE_DELAY_MS = 100;
+const AGENT_CONTINUE_BUSY_RESCHEDULE_MAX_DELAY_MS = 5_000;
+const AGENT_CONTINUE_BUSY_MAX_RESCHEDULES = 50;
+
+function agentContinueBusyRescheduleDelayMs(attempt: number): number {
+	const exponential = AGENT_CONTINUE_BUSY_RESCHEDULE_BASE_DELAY_MS * 2 ** Math.max(0, attempt - 1);
+	return Math.min(exponential, AGENT_CONTINUE_BUSY_RESCHEDULE_MAX_DELAY_MS);
+}
+
 export class AgentSession {
 	readonly agent: Agent;
 	readonly sessionManager: SessionManager;
@@ -4713,6 +4730,7 @@ export class AgentSession {
 			options?.onError?.(error);
 		};
 		const scheduledGeneration = options?.generation;
+		let busyReschedules = 0;
 		const scheduleAttempt = (delayMs = options?.delayMs): Promise<void> => {
 			const leaseSettlement = Promise.withResolvers<void>();
 			const settleLease = () => leaseSettlement.resolve();
@@ -4805,12 +4823,25 @@ export class AgentSession {
 								!terminalized &&
 								canContinue()
 							) {
-								this.#retainDeferredAgentEndAfterContinuationBusy(predecessorAgentEndHold, predecessorAgentEnd);
-								logger.debug("agent.continue busy after scheduling; rescheduling", {
+								if (busyReschedules < AGENT_CONTINUE_BUSY_MAX_RESCHEDULES) {
+									busyReschedules += 1;
+									const nextDelayMs = agentContinueBusyRescheduleDelayMs(busyReschedules);
+									this.#retainDeferredAgentEndAfterContinuationBusy(
+										predecessorAgentEndHold,
+										predecessorAgentEnd,
+									);
+									logger.debug("agent.continue busy after scheduling; rescheduling", {
+										error: error.message,
+										attempt: busyReschedules,
+										delayMs: nextDelayMs,
+									});
+									void scheduleAttempt(nextDelayMs);
+									return;
+								}
+								logger.warn("agent.continue busy reschedule budget exhausted; giving up", {
+									attempts: busyReschedules,
 									error: error.message,
 								});
-								void scheduleAttempt(100);
-								return;
 							}
 							if (!predecessorAccepted)
 								this.#restoreDeferredAgentEndAfterContinuationFailure(predecessorAgentEnd);
@@ -4939,6 +4970,7 @@ export class AgentSession {
 			if (!authorized) this.emitNotice("info", "Auto-continue skipped: no unfinished work detected");
 			return authorized;
 		};
+		let busyReschedules = 0;
 		const scheduleAttempt = (delayMs = 0) => {
 			let rescheduled = false;
 			void this.#schedulePostPromptTask(
@@ -4976,14 +5008,25 @@ export class AgentSession {
 							return;
 						}
 						if (this.#isAgentBusyError(error) && this.#promptGeneration === scheduledGeneration) {
-							logger.debug("Auto-compaction continuation busy; rescheduling", {
+							if (busyReschedules < AGENT_CONTINUE_BUSY_MAX_RESCHEDULES) {
+								busyReschedules += 1;
+								const nextDelayMs = agentContinueBusyRescheduleDelayMs(busyReschedules);
+								logger.debug("Auto-compaction continuation busy; rescheduling", {
+									source: "auto_continue_prompt",
+									reason: "queue_drained",
+									error: error.message,
+									attempt: busyReschedules,
+									delayMs: nextDelayMs,
+								});
+								rescheduled = true;
+								scheduleAttempt(nextDelayMs);
+								return;
+							}
+							logger.warn("Auto-compaction continuation busy reschedule budget exhausted; giving up", {
 								source: "auto_continue_prompt",
-								reason: "queue_drained",
+								attempts: busyReschedules,
 								error: error.message,
 							});
-							rescheduled = true;
-							scheduleAttempt(100);
-							return;
 						}
 						this.#logCompactionContinuationError("auto_continue_prompt", error);
 					} finally {

--- a/packages/coding-agent/test/agent-session-auto-compaction-continue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-continue.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { scheduler } from "node:timers/promises";
 import { Agent, AgentBusyError } from "@gajae-code/agent-core";
 import type { AssistantMessage } from "@gajae-code/ai";
 import { getBundledModel } from "@gajae-code/ai/models";
@@ -655,6 +656,51 @@ describe("AgentSession auto-compaction continuation", () => {
 		expect(debugSpy.mock.calls.some(call => call[0] === "agent.continue busy after scheduling; rescheduling")).toBe(
 			true,
 		);
+	});
+
+	it("bounds a persistently busy AgentBusyError with capped exponential backoff, then gives up", async () => {
+		session.agent.followUp({
+			role: "custom",
+			customType: "test",
+			content: [{ type: "text", text: "Queued" }],
+			display: false,
+			timestamp: Date.now(),
+		});
+		const warnSpy = vi.spyOn(logger, "warn");
+		const debugSpy = vi.spyOn(logger, "debug");
+		// Instant waits: without a cap the reschedule loop never terminates, so this
+		// test hangs instead of passing against the unpatched fixed-100ms spin.
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const continueSpy = vi.spyOn(session.agent, "continue").mockRejectedValue(new AgentBusyError());
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue();
+
+		await driveCompaction();
+		await advancePostPrompt(300);
+		await session.waitForIdle();
+
+		// 1 initial attempt + 50 bounded reschedules, then the loop stops for good.
+		expect(continueSpy).toHaveBeenCalledTimes(51);
+		await advancePostPrompt(300);
+		await session.waitForIdle();
+		expect(continueSpy).toHaveBeenCalledTimes(51);
+
+		const busyDebugs = debugSpy.mock.calls.filter(
+			call => call[0] === "agent.continue busy after scheduling; rescheduling",
+		);
+		expect(busyDebugs).toHaveLength(50);
+		// Capped exponential backoff: 100ms base doubling up to a 5s ceiling.
+		const rescheduleDelays = busyDebugs.map(call => (call[1] as { delayMs: number }).delayMs);
+		expect(rescheduleDelays).toEqual([100, 200, 400, 800, 1600, 3200, ...Array(44).fill(5000)]);
+
+		const exhaustedWarns = warnSpy.mock.calls.filter(
+			call => call[0] === "agent.continue busy reschedule budget exhausted; giving up",
+		);
+		expect(exhaustedWarns).toHaveLength(1);
+		expect(exhaustedWarns[0]?.[1]).toMatchObject({ attempts: 50 });
+		// Giving up still routes through the standard failure handlers.
+		expect(warnSpy.mock.calls.some(call => call[0] === "agent.continue failed after scheduling")).toBe(true);
+		expect(warnSpy.mock.calls.some(call => call[0] === "Auto-compaction continuation failed")).toBe(true);
+		expect(promptSpy).not.toHaveBeenCalled();
 	});
 
 	it("preserves synthetic auto-continue prompt delivery across an AgentBusyError", async () => {


### PR DESCRIPTION
## What

Bound the `AgentBusyError` reschedule loops for fire-and-forget agent continuations (auto-compaction retries, queued follow-ups) with capped exponential backoff (100ms doubling up to 5s) and a 50-attempt budget (~4 minutes total), then give up with an explicit warn and route through the pre-existing failure handlers.

Two sites in `packages/coding-agent/src/session/agent-session.ts`:
- `#scheduleAgentContinue` — rescheduled `agent.continue()` on a fixed 100ms timer with **no attempt cap** whenever the agent stayed busy
- `#scheduleAutoContinuePrompt` — identical fixed-100ms unbounded pattern (practically unreachable today since `agent.prompt` busy is retried internally by `#promptAgentWithIdleRetry` under a 30s deadline; fixed defensively for consistency)

On budget exhaustion the continuation falls through to the exact pre-existing failure path (restore deferred agent-end → throw → `fail()` → `onError`), so all four `rescheduleOnBusy` call sites keep their current failure semantics and queued messages are never lost. A `canContinue()`-false race (abort / generation change) stays silent exactly as before.

## Why

Production logs from a real session (2026-08-06, gjc 0.12.15): a single process emitted `agent.continue busy after scheduling; rescheduling` **10,742 times over 21 minutes** — one continuous 100ms spin while the agent stayed busy. No bound, no backoff, no give-up.

## Testing

- Reproduction: the new regression test (instant `scheduler.wait`, persistently busy `agent.continue`) **times out against the unpatched code** (unbounded loop) and passes against the patch
- New test asserts: exactly 51 continue calls (1 initial + 50 reschedules), termination stability (no further calls after giving up), the exact backoff series `[100, 200, 400, 800, 1600, 3200, 5000×44]`, exactly one exhaustion warn with `{ attempts: 50 }`, and that the standard failure warns (`agent.continue failed after scheduling`, `Auto-compaction continuation failed`) still fire
- `bun test packages/coding-agent/test/agent-session-auto-compaction-continue.test.ts` — 20/20 pass (incl. 2 pre-existing busy-reschedule delivery tests)
- Related suites: auto-compaction-oversized/queue/x-initiator, deep-interview-continuation, resilient-retry, retry-busy-recovery, queued-prompts, startup-continue, retry-cap — 139/139 pass
- `tsc -p tsconfig.json --noEmit` (packages/coding-agent) — clean
- `biome check` on touched files — clean

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:dbf5338c1c407d7a70cf09072dc49cadb7611efd25e13be97b00ddf922c59c1f reviewer:critic evidence:bun test packages/coding-agent/test/agent-session-auto-compaction-continue.test.ts (20/20) + tsc --noEmit + two independent critic passes on exact head 04d525143 (rebase onto upstream/dev 38321884d; code diff byte-identical to critic-approved 85664355a, CHANGELOG conflict resolved keeping both entries)
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes (biome + tsc on touched package)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
