### PR TITLE
test(coding-agent): align onboarding red-team with discovery error contract

### DIFF
--- a/packages/coding-agent/test/provider-onboarding-wizard-redteam.test.ts
+++ b/packages/coding-agent/test/provider-onboarding-wizard-redteam.test.ts
@@ -157,7 +157,7 @@ describe("provider onboarding wizard red-team", () => {
 				apiKeyEnv: "EMPTY_MODELS_KEY",
 				models: ["", "  ", ","],
 			}),
-		).rejects.toThrow("At least one model id is required");
+		).rejects.toThrow("At least one model id or model discovery is required");
 	});
 
 	it("requires force for an existing provider and overwrites when force is confirmed", async () => {


### PR DESCRIPTION
## Problem

Dev CI at `4f6e860` fails only on `provider-onboarding-wizard-redteam` with a stale expected string after #3927:

- **Expected (stale):** `At least one model id is required`
- **Actual / intended public contract:** `At least one model id or model discovery is required.`

Production (`provider-onboarding.ts:249`) correctly allows empty model lists when discovery is configured.

## Fix

One-line test update in `packages/coding-agent/test/provider-onboarding-wizard-redteam.test.ts` to match the exact intended public error substring.

## Non-goals

- No runtime behavior change
- No unrelated ACP/session work

## Verification

```
bun test packages/coding-agent/test/provider-onboarding-wizard-redteam.test.ts
# 7 pass / 0 fail
```