### PR TITLE
fix(test): raise smithery-env-trust child-process timeout to 60s

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- `smithery-env-trust.test.ts` raises the per-test child-process timeout from 30s to 60s so CI contention cannot fail at the previous 30s cap (Dev CI run 31128319216 timed out at 30004ms).
 - `smithery-env-trust.test.ts` now sets a 30s per-test timeout on all five child-process-spawning trust-boundary tests, preventing CI flake when the Bun child-process spawn + env-file-parse chain exceeds the default 5s budget under parallel shard contention (Dev CI run 31102063678).
 
 ## [0.12.15] - 2026-08-06

--- a/packages/coding-agent/test/smithery-env-trust.test.ts
+++ b/packages/coding-agent/test/smithery-env-trust.test.ts
@@ -77,17 +77,17 @@ describe("Smithery env trust boundary", () => {
 		expect(resolved.url).toBe("https://smithery.ai");
 		expect(resolved.apiBaseUrl).toBe("https://api.smithery.ai");
 		expect(resolved.apiKey).toBeNull();
-	}, 30_000);
+	}, 60_000);
 
 	it("ignores Smithery endpoints planted by the project .env", async () => {
 		const resolved = await resolveIn(projectDir(PLANTED));
 		expect(resolved.url).toBe("https://smithery.ai");
 		expect(resolved.apiBaseUrl).toBe("https://api.smithery.ai");
-	}, 30_000);
+	}, 60_000);
 
 	it("ignores a Smithery API key planted by the project .env", async () => {
 		expect((await resolveIn(projectDir(PLANTED))).apiKey).toBeNull();
-	}, 30_000);
+	}, 60_000);
 
 	it("still honors inherited Smithery configuration", async () => {
 		const resolved = await resolveIn(projectDir(), {
@@ -98,7 +98,7 @@ describe("Smithery env trust boundary", () => {
 		expect(resolved.url).toBe("https://smithery.internal");
 		expect(resolved.apiBaseUrl).toBe("https://api.smithery.internal");
 		expect(resolved.apiKey).toBe("operator-key");
-	}, 30_000);
+	}, 60_000);
 
 	it("does not let the project .env override inherited configuration", async () => {
 		const resolved = await resolveIn(projectDir(PLANTED), {
@@ -107,5 +107,5 @@ describe("Smithery env trust boundary", () => {
 		});
 		expect(resolved.url).toBe("https://smithery.internal");
 		expect(resolved.apiKey).toBe("operator-key");
-	}, 30_000);
+	}, 60_000);
 });


### PR DESCRIPTION
## Problem

#3855 exact-head Dev CI run [31128319216](https://github.com/Yeachan-Heo/gajae-code/actions/runs/31128319216) is functionally clean except:

`Smithery env trust boundary > uses the built-in endpoints and no key by default` timed out at **30004ms** — exactly the **30s** per-test cap from merged #3948.

This is CI contention on the child Bun probe spawn, not #3855 behavior. #3855 must not absorb this baseline fix.

## Fix

Raise each of the five child-process `it()` timeouts from `30_000` → `60_000` (established pattern: `acp-session-delete-wire` uses 60s).

- No assertion changes
- No provider / runtime changes

## Verification

| Evidence | Result |
|----------|--------|
| Sequential 3× | 5 pass / 0 fail (~3.9s each) |
| 6-way parallel contention | 6× 5 pass / 0 fail (~4.2s wall) |

## Non-goals

- Do not weaken trust-boundary assertions
- Do not change Smithery provider behavior
- Separate from #3855