### PR TITLE
test(coding-agent): lock /notify on|off always-pass-through contract

### DIFF
--- a/packages/coding-agent/src/slash-commands/notify-command.test.ts
+++ b/packages/coding-agent/src/slash-commands/notify-command.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { lookupBuiltinSlashCommand } from "./builtin-registry";
+
+/**
+ * Contract: /notify on|off is session-local and extension-owned.
+ * The builtin must always pass the raw command text through as a prompt so it
+ * cannot shadow the live per-session `api.registerCommand("notify")` control —
+ * whether or not a lazy/native command is currently installed in the fixture.
+ * See builtin-registry.ts notify handler comments.
+ */
+function runtimeWithExtension(commandInstalled: boolean) {
+	const output: string[] = [];
+	return {
+		runtime: {
+			session: commandInstalled
+				? { extensionRunner: { getCommand: () => ({ name: "notify" }) } }
+				: { extensionRunner: { getCommand: () => undefined } },
+			settings: {},
+			cwd: "/tmp",
+			output: async (message: string) => {
+				output.push(message);
+			},
+		} as never,
+		output,
+	};
+}
+
+describe("/notify SDK-only routing", () => {
+	test("always pass-through on/off when no lazy command is installed", async () => {
+		const command = lookupBuiltinSlashCommand("notify");
+		if (!command?.handle) throw new Error("notify builtin handler missing");
+		const { runtime, output } = runtimeWithExtension(false);
+		expect(await command.handle({ name: "notify", args: "on", text: "/notify on" }, runtime)).toEqual({
+			prompt: "/notify on",
+		});
+		expect(output).toEqual([]);
+		expect(await command.handle({ name: "notify", args: "off", text: "/notify off" }, runtime)).toEqual({
+			prompt: "/notify off",
+		});
+		expect(output).toEqual([]);
+	});
+
+	test("always pass-through on/off when a registered native/session command is present", async () => {
+		const command = lookupBuiltinSlashCommand("notify");
+		if (!command?.handle) throw new Error("notify builtin handler missing");
+		const { runtime, output } = runtimeWithExtension(true);
+		expect(await command.handle({ name: "notify", args: "on", text: "/notify on" }, runtime)).toEqual({
+			prompt: "/notify on",
+		});
+		expect(output).toEqual([]);
+		expect(await command.handle({ name: "notify", args: "off", text: "/notify off" }, runtime)).toEqual({
+			prompt: "/notify off",
+		});
+		expect(output).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary
- Locks the intended `/notify on|off` contract: the builtin **always** returns `{prompt: command.text}` so it cannot shadow extension-owned per-session notification controls.
- Replaces the stale assumption that a missing lazy/native command should return `{consumed:true}` + "unavailable" (that fixture is what failed #3846 exact-head shard-5).
- Minimal baseline-only change on `dev`; does **not** touch the performance PR diff.

## Evidence
Production contract (dev and #3846):
```ts
// Session-local notification controls are extension-owned. Always pass them
// through so this builtin cannot shadow the live per-session command.
if (action === "on" || action === "off") return { prompt: command.text };
```

Reproduced failure from #3846 fixture:
```
expect(received).toEqual(expected)
-   "consumed": true,
+   "prompt": "/notify on",
```

## Test plan
- [x] `bun test packages/coding-agent/src/slash-commands/notify-command.test.ts` (2 pass)
- [ ] CI green on this PR
- [ ] After merge: rebase #3846 onto dev and resolve its stale notify fixture to this contract (do not absorb midrun/provider baselines into the perf PR)

Blocks: #3846 CI green gate