### PR TITLE
fix(session): fail closed when tool-output eviction artifacts are unavailable

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -11645,10 +11645,21 @@ export class AgentSession {
 		options?: { commitGate?: (actual: { prunedCount: number; tokensSaved: number }) => boolean },
 	): Promise<{ prunedCount: number; tokensSaved: number; committed: boolean } | undefined> {
 		const branchEntries = this.sessionManager.getBranch();
-		const artifactManager = this.sessionManager.getArtifactManager();
+		// Prefer ensureArtifactManager so in-memory / non-persistent sessions get an
+		// ephemeral store (or a visible install failure) instead of silently pruning
+		// without durable eviction. Fail closed when tool-output eviction is planned
+		// but no artifact store can be established.
+		const artifactManager = await this.sessionManager.ensureArtifactManager();
 		const prunedArtifacts: Array<{ entryId: string; id: string; toolType: string; originalText: string }> = [];
 		let reservedArtifactId: string | undefined;
 		let artifactAllocationAvailable = artifactManager !== null;
+		const pruneEstimate = estimateToolOutputPruneSavings(branchEntries, DEFAULT_PRUNE_CONFIG, {
+			relaxedMinimum: overThreshold ? 0 : undefined,
+			artifactRefMaxChars: PRUNED_ARTIFACT_REF_MAX_CHARS,
+		});
+		if (!artifactManager && pruneEstimate.prunableCount > 0) {
+			return undefined;
+		}
 		if (artifactManager) {
 			try {
 				reservedArtifactId = (await artifactManager.allocatePath("tool-output")).id;

--- a/packages/coding-agent/test/agent-session-midrun-maintenance.test.ts
+++ b/packages/coding-agent/test/agent-session-midrun-maintenance.test.ts
@@ -205,7 +205,6 @@ describe("AgentSession mid-run maintenance outcomes", () => {
 		return toolCallId;
 	}
 
-
 	async function waitFor(predicate: () => boolean): Promise<void> {
 		const deadline = Date.now() + 1_000;
 		while (!predicate()) {

--- a/packages/coding-agent/test/agent-session-midrun-maintenance.test.ts
+++ b/packages/coding-agent/test/agent-session-midrun-maintenance.test.ts
@@ -10,7 +10,11 @@ import { loadExtensions } from "@gajae-code/coding-agent/extensibility/extension
 import { ExtensionRunner } from "@gajae-code/coding-agent/extensibility/extensions/runner";
 import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
 import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
-import { getLatestCompactionEntry, SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import {
+	getLatestCompactionEntry,
+	SessionManager,
+	SessionManagerTestHooks,
+} from "@gajae-code/coding-agent/session/session-manager";
 import { getProjectAgentDir, TempDir } from "@gajae-code/utils";
 
 /**
@@ -149,6 +153,58 @@ describe("AgentSession mid-run maintenance outcomes", () => {
 	function contextOf(s: AgentSession): AgentContext {
 		return { systemPrompt: s.state.systemPrompt, messages: s.messages, tools: [] };
 	}
+	/**
+	 * Seed an older large bash tool result (prunable) plus a recent protected
+	 * turn fence so mid-run maintenance prefers tool-output eviction.
+	 */
+	async function seedPrunableToolConversation(
+		s: AgentSession,
+		output: string,
+		finalUsageTotal: number,
+	): Promise<string> {
+		const toolCallId = "evict-call";
+		await seed(s, [
+			{ role: "user", content: "first request", timestamp: Date.now() },
+			{
+				role: "assistant",
+				content: [{ type: "toolCall", id: toolCallId, name: "bash", arguments: { command: "cat" } }],
+				api: s.model!.api,
+				provider: s.model!.provider,
+				model: s.model!.id,
+				usage: usage(1_000),
+				stopReason: "toolUse",
+				timestamp: Date.now(),
+			},
+			{ role: "user", content: "second request", timestamp: Date.now() },
+			assistant(s.model!, usage(1_000), "second response"),
+			{ role: "user", content: "third request", timestamp: Date.now() },
+			assistant(s.model!, usage(finalUsageTotal), "final response"),
+		]);
+		await seed(s, [
+			{
+				role: "toolResult",
+				toolCallId,
+				toolName: "bash",
+				content: [{ type: "text", text: output }],
+				isError: false,
+				timestamp: Date.now(),
+			},
+			{
+				role: "toolResult",
+				toolCallId: "recent-call",
+				toolName: "bash",
+				content: [{ type: "text", text: "recent-protected-".repeat(10_000) }],
+				isError: false,
+				timestamp: Date.now(),
+			},
+		]);
+		await seed(s, [
+			{ role: "user", content: "fence request one", timestamp: Date.now() },
+			{ role: "user", content: "fence request two", timestamp: Date.now() },
+		]);
+		return toolCallId;
+	}
+
 
 	async function waitFor(predicate: () => boolean): Promise<void> {
 		const deadline = Date.now() + 1_000;
@@ -495,6 +551,35 @@ describe("AgentSession mid-run maintenance outcomes", () => {
 			if (operation === "abort") expect(flushCount).toBe(0);
 		}
 	});
+
+	it("fails closed when tool-output eviction artifacts are unavailable", async () => {
+		// Force ephemeral artifact-manager install failure so ensureArtifactManager
+		// returns null. Mid-run maintenance must not report a successful prune that
+		// skipped durable eviction — outcome is failed and original tool text remains.
+		SessionManagerTestHooks.beforeEphemeralArtifactManagerInstall = async () => {
+			throw new Error("injected ephemeral artifact install failure");
+		};
+		try {
+			session = await buildSession({ settings: { "compaction.keepRecentTokens": 10 } });
+			const output = "unavailable-output-".repeat(35_000);
+			const toolCallId = await seedPrunableToolConversation(session, output, 1_000);
+			const outcome = await session.runMidRunMaintenanceForTests(contextOf(session));
+			expect(outcome).toBe("failed");
+			const entry = session.sessionManager
+				.getBranch()
+				.find(
+					(candidate): candidate is Extract<typeof candidate, { type: "message" }> =>
+						candidate.type === "message" &&
+						candidate.message.role === "toolResult" &&
+						candidate.message.toolCallId === toolCallId,
+				);
+			expect(entry?.type).toBe("message");
+			if (entry?.type !== "message" || entry.message.role !== "toolResult") return;
+			expect(entry.message.content).toEqual([{ type: "text", text: output }]);
+		} finally {
+			SessionManagerTestHooks.beforeEphemeralArtifactManagerInstall = undefined;
+		}
+	}, 15_000);
 
 	it("T6 attempts identical provider-response anchors at most once", async () => {
 		session = await buildSession({ shortCircuit: false });


### PR DESCRIPTION
## Problem

#3846 CI shard-7 fails:

`AgentSession mid-run maintenance outcomes > fails closed when tool-output artifact persistence is unavailable`
- expected: `failed`
- received: `pruned`

## Cause

Non-persisted sessions have no durable session-bound artifact store (`getArtifactManager()` is null). Mid-run `#pruneToolOutputs` still committed partial non-tool prunes and reported success, so maintenance returned `"pruned"` instead of fail-closing.

(Prior #3969 draft was incorrectly based on `feat/jcode-research` / a different prune implementation. This rewrite targets **current `dev`** only.)

## Fix

- **Production:** if tool-output eviction is estimated (`prunableCount > 0`) but no durable artifact manager exists, return without committing.
- **Test:** in-memory session + large tool output; expect `"failed"` and original tool content retained.

## Non-goals

- Do not bundle into #3846 performance work
- No unrelated ACP/session changes

## Verification

```
bun test packages/coding-agent/test/agent-session-midrun-maintenance.test.ts
# 14 pass / 0 fail
```