### PR TITLE
fix(session): resecure managed legacy-local mode_mismatch on resume

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
-- Managed legacy-local resume no longer aborts `switchSession` with bare `mode_mismatch` when `artifacts/<id>/local` was written with group/other-readable modes: capture re-secures owner-only permissions once (same recovery class as managed-scope prepare) before failing closed.
+- Managed scope prepare and legacy-local resume no longer report success while group/other-readable descendants remain on disk (e.g. mode `0o036`/`0o644`): after the root-identity construct path stopped walking the tree, prepare now re-snapshots for `mode_mismatch`, re-secures owner-only modes with apply+verify (no silent best-effort), and retries once; legacy-local capture uses the same resecure helper.
 - ACP `session/request_permission` responses are now normalized from the spec-shaped `RequestPermissionResponse` (`{ outcome: { outcome, optionId } }`) into the SDK's flat permission-decision contract before reaching the permission provider. Standards-compliant ACP clients such as Paseo can now authorize permission-gated shell/eval and destructive file operations (`bash`, `monitor`, `eval`, `delete`, `move`, and `edit` only for delete/move operations) without an invalid-response failure; `write` and ordinary edits remain ungated. Nested and flat selected/cancelled responses are accepted by reconstructing the canonical SDK decision fields, while malformed or unknown decisions fail closed.
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
-- Managed scope prepare and legacy-local resume no longer report success while group/other-readable descendants remain on disk (e.g. mode `0o036`/`0o644`): after the root-identity construct path stopped walking the tree, prepare now re-snapshots for `mode_mismatch`, re-secures owner-only modes with apply+verify (no silent best-effort), and retries once; legacy-local capture uses the same resecure helper.
+- Managed scope prepare and legacy-local resume no longer report success while group/other-readable descendants remain on disk (e.g. mode `0o036`/`0o644`): prepare uses a mode-only walk (not `snapshotManagedTree("")`, which races concurrent writers and broke `/move`) to detect drift, re-secures with apply+verify, and retries once; legacy-local capture uses the same resecure helper.
 - ACP `session/request_permission` responses are now normalized from the spec-shaped `RequestPermissionResponse` (`{ outcome: { outcome, optionId } }`) into the SDK's flat permission-decision contract before reaching the permission provider. Standards-compliant ACP clients such as Paseo can now authorize permission-gated shell/eval and destructive file operations (`bash`, `monitor`, `eval`, `delete`, `move`, and `edit` only for delete/move operations) without an invalid-response failure; `write` and ordinary edits remain ungated. Nested and flat selected/cancelled responses are accepted by reconstructing the canonical SDK decision fields, while malformed or unknown decisions fail closed.
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
+- Managed legacy-local resume no longer aborts `switchSession` with bare `mode_mismatch` when `artifacts/<id>/local` was written with group/other-readable modes: capture re-secures owner-only permissions once (same recovery class as managed-scope prepare) before failing closed.
 - ACP `session/request_permission` responses are now normalized from the spec-shaped `RequestPermissionResponse` (`{ outcome: { outcome, optionId } }`) into the SDK's flat permission-decision contract before reaching the permission provider. Standards-compliant ACP clients such as Paseo can now authorize permission-gated shell/eval and destructive file operations (`bash`, `monitor`, `eval`, `delete`, `move`, and `edit` only for delete/move operations) without an invalid-response failure; `write` and ordinary edits remain ungated. Nested and flat selected/cancelled responses are accepted by reconstructing the canonical SDK decision fields, while malformed or unknown decisions fail closed.
 
 ### Added

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -910,6 +910,11 @@ export async function ensureManagedScope(
  * uncaught exception. Re-securing the tree in place lets a drifted scope
  * recover on the next launch instead of trapping the user behind a fatal error.
  */
+/** Re-secure owner-only modes under a managed directory (exported for legacy-local migration). */
+export function resecureOwnerOnlyManagedTree(directory: string): void {
+	reapplyOwnerOnlyManagedTree(directory);
+}
+
 function reapplyOwnerOnlyManagedTree(directory: string): void {
 	let entries: fs.Dirent[];
 	try {
@@ -953,7 +958,7 @@ function reapplyOwnerOnlyManagedTree(directory: string): void {
  * (group/other permission bits) rather than an ownership or identity change.
  * Only mode drift can be self-healed by re-applying owner-only permissions.
  */
-function isRecoverableOwnerOnlyModeDrift(error: unknown): boolean {
+export function isRecoverableOwnerOnlyModeDrift(error: unknown): boolean {
 	const message = error instanceof Error ? error.message : "";
 	return message === "mode_mismatch" || message.endsWith(": mode_mismatch");
 }

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -933,23 +933,31 @@ function reapplyOwnerOnlyManagedTree(directory: string): void {
 		if (stat.isSymbolicLink()) continue;
 		if (stat.isDirectory()) {
 			reapplyOwnerOnlyManagedTree(child);
-			try {
-				native.applyOwnerOnlyPathSecurity(child, "directory");
-			} catch {
-				// Best-effort: the managed-tree snapshot re-verifies and reports genuine failures.
-			}
+			assertOwnerOnlyApplied(child, "directory");
 		} else if (stat.isFile()) {
-			try {
-				native.applyOwnerOnlyPathSecurity(child, "file");
-			} catch {
-				// Best-effort, as above.
-			}
+			assertOwnerOnlyApplied(child, "file");
 		}
 	}
-	try {
-		native.applyOwnerOnlyPathSecurity(directory, "directory");
-	} catch {
-		// Best-effort, as above.
+	assertOwnerOnlyApplied(directory, "directory");
+}
+
+/** Apply and verify owner-only mode/ACL; throw mode_mismatch (or native code) on failure. */
+function assertOwnerOnlyApplied(pathname: string, kind: "directory" | "file"): void {
+	const applied = native.applyOwnerOnlyPathSecurity(pathname, kind);
+	if (!applied || typeof applied !== "object" || (applied as { ok?: unknown }).ok !== true) {
+		const code =
+			applied && typeof applied === "object" && typeof (applied as { code?: unknown }).code === "string"
+				? (applied as { code: string }).code
+				: "mode_mismatch";
+		throw new Error(code);
+	}
+	const verified = verifyOwnerOnlyPathSecurity(pathname, kind);
+	if (!verified || typeof verified !== "object" || (verified as { ok?: unknown }).ok !== true) {
+		const code =
+			verified && typeof verified === "object" && typeof (verified as { code?: unknown }).code === "string"
+				? (verified as { code: string }).code
+				: "mode_mismatch";
+		throw new Error(code);
 	}
 }
 
@@ -1019,8 +1027,20 @@ export function prepareManagedSessionScopeForWriteSync(
 			);
 		stage = "store";
 		let store: ManagedSessionDescendantStore;
+		const openManagedStore = (): ManagedSessionDescendantStore => {
+			const next = buildStore();
+			// #3951 root-store identity binding no longer walks the full managed tree
+			// on construct. Explicitly snapshot so group/other-readable descendants
+			// still surface mode_mismatch and trigger self-heal instead of reporting
+			// resolved while modes like 0o036 remain on disk.
+			if (retainedAuthority) {
+				const tree = retainedAuthority.snapshotManagedTree("");
+				if (!tree.ok) throw new Error(tree.code ?? "unsafe_artifacts");
+			}
+			return next;
+		};
 		try {
-			store = buildStore();
+			store = openManagedStore();
 		} catch (error) {
 			if (process.platform === "win32" && policy === "windows-existing-verify-first") throw error;
 			if (!isRecoverableOwnerOnlyModeDrift(error)) throw error;
@@ -1028,7 +1048,7 @@ export function prepareManagedSessionScopeForWriteSync(
 			// (e.g. resident-cache blobs written on the explicit session path).
 			// Re-secure the tree in place and retry once before failing closed.
 			reapplyOwnerOnlyManagedTree(scope.directoryPath);
-			store = buildStore();
+			store = openManagedStore();
 		}
 		const binding = new TextEncoder().encode(`${JSON.stringify(bindingFor(scope))}\n`);
 		stage = "binding_publish";

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -962,6 +962,32 @@ function assertOwnerOnlyApplied(pathname: string, kind: "directory" | "file"): v
 }
 
 /**
+ * Mode-only walk for managed-scope prepare self-heal.
+ * Throws `mode_mismatch` when any non-symlink descendant has group/other bits.
+ * Avoids snapshotManagedTree("") which races concurrent session writers (#3906).
+ */
+function assertOwnerOnlyModesRecursive(directory: string): void {
+	let stat: fs.Stats;
+	try {
+		stat = fs.lstatSync(directory);
+	} catch {
+		return;
+	}
+	if (stat.isSymbolicLink()) return;
+	if ((stat.mode & 0o077) !== 0) throw new Error("mode_mismatch");
+	if (!stat.isDirectory()) return;
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(directory, { withFileTypes: true });
+	} catch {
+		return;
+	}
+	for (const entry of entries) {
+		assertOwnerOnlyModesRecursive(path.join(directory, entry.name));
+	}
+}
+
+/**
  * True when a managed setup error reflects a fixable owner-only *mode* drift
  * (group/other permission bits) rather than an ownership or identity change.
  * Only mode drift can be self-healed by re-applying owner-only permissions.
@@ -1029,13 +1055,13 @@ export function prepareManagedSessionScopeForWriteSync(
 		let store: ManagedSessionDescendantStore;
 		const openManagedStore = (): ManagedSessionDescendantStore => {
 			const next = buildStore();
-			// #3951 root-store identity binding no longer walks the full managed tree
-			// on construct. Explicitly snapshot so group/other-readable descendants
-			// still surface mode_mismatch and trigger self-heal instead of reporting
-			// resolved while modes like 0o036 remain on disk.
+			// #3951 root-store identity binding no longer walks the managed tree on
+			// construct, so mode drift no longer surfaces as mode_mismatch there.
+			// Detect group/other-readable descendants with a mode-only walk — do NOT
+			// call snapshotManagedTree("") here: that reintroduces concurrent-writer
+			// identity_mismatch races (#3906) that break SessionManager.moveTo /move.
 			if (retainedAuthority) {
-				const tree = retainedAuthority.snapshotManagedTree("");
-				if (!tree.ok) throw new Error(tree.code ?? "unsafe_artifacts");
+				assertOwnerOnlyModesRecursive(scope.directoryPath);
 			}
 			return next;
 		};

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -60,19 +60,19 @@ import {
 import {
 	canonicalizeTrustedPath,
 	deleteManagedSessionCandidate,
+	isRecoverableOwnerOnlyModeDrift,
 	listManagedCandidates,
 	type ManagedCandidateWriteAuthority,
 	type ManagedMigrationPolicy,
 	type ManagedOpenCandidateResult,
 	type ManagedScope,
-	isRecoverableOwnerOnlyModeDrift,
 	managedDirectoryAuthorityForScope,
 	managedRootForScope,
 	openManagedCandidateForWrite,
 	prepareManagedSessionScopeForWriteSync,
+	resecureOwnerOnlyManagedTree,
 	resolveManagedScope,
 	resolveManagedScopeForWrite,
-	resecureOwnerOnlyManagedTree,
 } from "./internal/managed-session-scope";
 import {
 	assertManagedDirectoryRoot,

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -65,12 +65,14 @@ import {
 	type ManagedMigrationPolicy,
 	type ManagedOpenCandidateResult,
 	type ManagedScope,
+	isRecoverableOwnerOnlyModeDrift,
 	managedDirectoryAuthorityForScope,
 	managedRootForScope,
 	openManagedCandidateForWrite,
 	prepareManagedSessionScopeForWriteSync,
 	resolveManagedScope,
 	resolveManagedScopeForWrite,
+	resecureOwnerOnlyManagedTree,
 } from "./internal/managed-session-scope";
 import {
 	assertManagedDirectoryRoot,
@@ -8025,18 +8027,33 @@ export class SessionManager {
 		return {
 			capture: async () => {
 				let snapshot: native.NativeDirectoryTreeSnapshot;
+				const captureLegacyLocal = (): native.NativeDirectoryTreeSnapshot => store.captureTree(legacyLocalRoot);
 				try {
-					snapshot = store.captureTree(legacyLocalRoot);
+					snapshot = captureLegacyLocal();
 				} catch (error) {
 					if (error instanceof Error && error.message === "not_found") return null;
-					if (error instanceof Error && error.message === "reparse_point") {
+					// Prior writers (and some fixtures) can leave group/other-readable
+					// descendants under artifacts/<id>/local. Managed captureTree fails
+					// closed on mode_mismatch; re-secure owner-only modes once — same
+					// class of recovery as prepareManagedSessionScopeForWriteSync.
+					if (isRecoverableOwnerOnlyModeDrift(error)) {
+						resecureOwnerOnlyManagedTree(path.join(sessionFile.slice(0, -6), "local"));
+						try {
+							snapshot = captureLegacyLocal();
+						} catch (retryError) {
+							if (retryError instanceof Error && retryError.message === "not_found") return null;
+							throw retryError;
+						}
+					} else if (error instanceof Error && error.message === "reparse_point") {
 						try {
 							store.captureTree(legacyArtifactsRoot);
 						} catch (artifactsError) {
 							if (artifactsError instanceof Error && artifactsError.message === "not_found") return null;
 						}
+						throw error;
+					} else {
+						throw error;
 					}
-					throw error;
 				}
 				let totalBytes = 0;
 				for (const entry of snapshot.entries) if (entry.kind === "file") totalBytes += Number(entry.size);

--- a/packages/coding-agent/test/task/no-session-output-refs.test.ts
+++ b/packages/coding-agent/test/task/no-session-output-refs.test.ts
@@ -657,9 +657,14 @@ describe("task no-session output refs", () => {
 				getSessionId: () => targetSessionId,
 			});
 			await target.close();
+			// Plant a managed legacy-local tree with *non*-owner-only modes (default
+			// umask). Production must resecure mode drift once during captureTree
+			// rather than aborting switchSession with bare mode_mismatch.
 			const legacyLocalDir = path.join(targetFile.slice(0, -6), "local");
-			await fs.mkdir(legacyLocalDir, { recursive: true });
-			await Bun.write(path.join(legacyLocalDir, "legacy.txt"), "managed legacy payload");
+			await fs.mkdir(legacyLocalDir, { recursive: true, mode: 0o755 });
+			await fs.writeFile(path.join(legacyLocalDir, "legacy.txt"), "managed legacy payload", {
+				mode: 0o644,
+			});
 
 			const owner = SessionManager.create(cwd, SessionManager.managedDestination(cwd, agentDir));
 			const currentFile = owner.getSessionFile();


### PR DESCRIPTION
## Problem

#3950 exact-head CI fails:

```
(fail) task no-session output refs > stages task fallback authority for managed legacy-local resume and restores it on rollback
error: mode_mismatch
  at switchSession → managed legacy-local captureTree
```

## Attribution

- **Not ACP.** #3950 only touches `agent-session` for `suppressPredecessorAgentEnd` on todo-write continue; the failure is managed legacy-local migration.
- **Baseline / session authority.** Managed `captureTree` fails closed on group/other-readable descendants. `prepareManagedSessionScopeForWriteSync` already self-heals that class of drift; `#managedLegacyLocalMigrationSourceFor` did not.
- The task fixture planted `artifacts/<id>/local` with default umask modes (0o755/0o644-class), which is realistic for pre-managed writers — not a reason to relax assertions.

## Fix

1. Export `resecureOwnerOnlyManagedTree` / `isRecoverableOwnerOnlyModeDrift`.
2. On `mode_mismatch` during legacy-local capture: resecure the absolute `…/local` path once, retry `captureTree`, then fail closed.
3. Regression: same task fallback test plants **explicit** non-owner-only modes so the self-heal path stays covered.

## Ownership

- Separate session-owner PR (this). **#3950 ACP branch ownership retained** — after this merges, #3950 rebases for a green exact head.

## Verification

- Exact-head Dev CI on this branch (dispatched)
- No blind test skip / no assertion removal