### PR TITLE
docs(acp): document the local ACP development loop

### DIFF
--- a/docs/acp-local-development.md
+++ b/docs/acp-local-development.md
@@ -4,12 +4,16 @@ How to run a source change through a real ACP client on your machine. The
 protocol contract lives in [External control readiness](./external-control-readiness.md);
 this page is only the build/run/verify loop.
 
+The commands below assume macOS or Linux with a POSIX shell. The Paseo examples
+were verified with Paseo 0.2.5; confirm command and status names when using a
+newer release.
+
 ## The loop
 
 ```sh
 bun run build:native        # only when crates/ changed
 bun run install:dev:bin     # compile dist/gjc and point `gjc` on PATH at it
-bun run restart:sdk-broker  # REQUIRED — see below
+bun run restart:sdk-broker -- --close-session-hosts  # REQUIRED — see below
 ```
 
 Then drive it from a client, or from a bare stdio handshake:
@@ -42,27 +46,35 @@ the elapsed time predates your build:
 19466  08:25:00  /Users/you/git/gajae-code/packages/coding-agent/dist/gjc sdk broker-internal --agent-dir /Users/you/.gjc/agent
 ```
 
-After `bun run restart:sdk-broker` from your checkout it is replaced by one
-running that checkout's source:
+After `bun run restart:sdk-broker -- --close-session-hosts` from your checkout,
+the broker is replaced by one running that checkout's source:
 
 ```
 79955  00:09  bun --config=.../src/sdk/broker/internal-source.bunfig.toml .../src/cli.ts sdk broker-internal --agent-dir /Users/you/.gjc/agent
 ```
 
 The restart asks the published broker to shut down over its authenticated
-loopback channel and starts a replacement. By default it leaves live session
-hosts alone, so an interactive `gjc` session running in another terminal keeps
-working; pass `--close-session-hosts` to close broker-spawned hosts too.
+loopback channel and starts a replacement. `--close-session-hosts` first closes
+every broker-spawned host in that agent directory, so it can interrupt active
+ACP work; it never closes interactive `gjc` TUI sessions. Without the flag,
+live hosts keep their old entrypoint. A broker-only restart is safe only when
+you will create a fresh ACP session instead of loading or reusing an existing
+one.
 
 Working against a scratch agent directory instead:
 
 ```sh
-bun run restart:sdk-broker -- --agent-dir /tmp/gjc-acp-agent
+bun run restart:sdk-broker -- --agent-dir /tmp/gjc-acp-agent --close-session-hosts
+GJC_CODING_AGENT_DIR=/tmp/gjc-acp-agent gjc acp
 ```
 
-and point the client at it with `GJC_CODING_AGENT_DIR=/tmp/gjc-acp-agent`. A
-fresh agent directory carries no credentials — copy `config.yml`, `models.yml`
-and `models.db` from `~/.gjc/agent` first.
+A fresh agent directory carries no credentials. Stored local credentials live
+in `agent.db`, not `models.db`; do not copy a live SQLite database. Authenticate
+inside the scratch agent directory, use provider environment variables or an
+auth broker, or copy `agent.db` only while no process is using either database.
+For Paseo, put `GJC_CODING_AGENT_DIR` in the provider's `env` entry and restart
+the Paseo daemon, or pass it with `paseo run --env` so the provider process
+receives the override.
 
 ## Confirming what is actually live
 
@@ -87,14 +99,17 @@ paseo daemon restart              # after editing config.json
 paseo provider ls                 # gjc must read `available`, not `error`
 paseo run --provider gjc --cwd /tmp/gjc-acp-test --wait-timeout 3m "your prompt"
 paseo logs <agent-id>             # rendered transcript
-paseo ls                          # status: running / idle / completed / timeout
+paseo ls                          # lifecycle: running / idle / error
 paseo stop <agent-id>             # exercises session/cancel
 paseo delete <agent-id>
 ```
 
 Paseo runs its daemon as a separate long-lived process, so it needs its own
 restart after a config change — but not after a GJC rebuild, since it spawns
-`gjc` per session.
+`gjc` per session. `--wait-timeout 3m` stops the CLI from waiting; it does not
+cancel the agent, which may remain `running`. That timeout is separate from
+GJC's `sdk.promptDeadlineMs`, which defaults to 30 minutes and settles as
+`prompt_deadline_exceeded`.
 
 Errors surface in the daemon log with the JSON-RPC payload intact, which is
 where to look when the CLI prints something opaque like
@@ -106,13 +121,14 @@ grep -i 'failed to create agent' ~/.paseo/daemon.log | tail -1
 
 ## What to smoke-test
 
-Unit tests do not cover the transitions that break in practice. At minimum:
+Unit tests cover the individual terminal and cancellation contracts, but not
+the complete client/daemon/process lifecycle. At minimum:
 
-- **A prompt that makes the agent use a tool and then continue.** Continuations
-  (todo reminders, TTSR resume, auto-continue) re-enter the agent loop and emit
-  a second `agent_start` within one `session/prompt`. Regressions here strand the
-  client until `sdk.promptDeadlineMs` (30 minutes) rather than failing fast, so
-  a run that never leaves `running` is the signal — not an error.
+- **A configured continuation path.** Exercise a deterministic todo reminder,
+  TTSR resume, or auto-continue setup and verify that the same `session/prompt`
+  eventually settles instead of remaining `running`. Different continuation
+  mechanisms may start another agent run or continue within a managed loop, so
+  do not use a fixed `agent_start` count as the invariant.
 - **A follow-up turn on the same session**, including a tool call that touches
   the filesystem.
 - **Cancel mid-turn.** The pending prompt must settle as `cancelled`, and the

--- a/docs/acp-local-development.md
+++ b/docs/acp-local-development.md
@@ -1,0 +1,129 @@
+# ACP local development
+
+How to run a source change through a real ACP client on your machine. The
+protocol contract lives in [External control readiness](./external-control-readiness.md);
+this page is only the build/run/verify loop.
+
+## The loop
+
+```sh
+bun run build:native        # only when crates/ changed
+bun run install:dev:bin     # compile dist/gjc and point `gjc` on PATH at it
+bun run restart:sdk-broker  # REQUIRED — see below
+```
+
+Then drive it from a client, or from a bare stdio handshake:
+
+```sh
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{"fs":{"readTextFile":true,"writeTextFile":true},"terminal":true}}}' | gjc acp
+```
+
+## Why the broker restart is not optional
+
+`gjc acp` is a thin stdio front end. It does not run the agent loop — it attaches
+to the SDK broker published for the agent directory, and the broker spawns a
+`sdk session-host-internal` child per session. That broker is long-lived and
+holds the entrypoint it was started from, so **rebuilding the binary changes
+nothing for ACP until the broker is replaced**: the new `gjc acp` process talks
+to an old broker, which spawns session hosts from the old build, and your change
+appears to have no effect.
+
+The symptom is indistinguishable from a broken fix. Check the broker's
+entrypoint before concluding anything about a change:
+
+```sh
+ps -eo pid,etime,command | grep '[b]roker-internal'
+```
+
+A stale broker is obvious once you look — the path is a different checkout, or
+the elapsed time predates your build:
+
+```
+19466  08:25:00  /Users/you/git/gajae-code/packages/coding-agent/dist/gjc sdk broker-internal --agent-dir /Users/you/.gjc/agent
+```
+
+After `bun run restart:sdk-broker` from your checkout it is replaced by one
+running that checkout's source:
+
+```
+79955  00:09  bun --config=.../src/sdk/broker/internal-source.bunfig.toml .../src/cli.ts sdk broker-internal --agent-dir /Users/you/.gjc/agent
+```
+
+The restart asks the published broker to shut down over its authenticated
+loopback channel and starts a replacement. By default it leaves live session
+hosts alone, so an interactive `gjc` session running in another terminal keeps
+working; pass `--close-session-hosts` to close broker-spawned hosts too.
+
+Working against a scratch agent directory instead:
+
+```sh
+bun run restart:sdk-broker -- --agent-dir /tmp/gjc-acp-agent
+```
+
+and point the client at it with `GJC_CODING_AGENT_DIR=/tmp/gjc-acp-agent`. A
+fresh agent directory carries no credentials — copy `config.yml`, `models.yml`
+and `models.db` from `~/.gjc/agent` first.
+
+## Confirming what is actually live
+
+| Question | Command |
+|---|---|
+| Which binary is `gjc`? | `readlink $(which gjc)` |
+| When was it built? | `ls -l packages/coding-agent/dist/gjc` |
+| Which broker is serving? | `ps -eo pid,etime,command \| grep '[b]roker-internal'` |
+| Which hosts are running? | `ps -eo pid,etime,command \| grep 'session-host-internal'` |
+
+`bun run install:dev:bin` prints the symlink it wrote and runs a smoke test, so
+its output already answers the first question.
+
+## Driving it from Paseo
+
+Register GJC as a custom ACP provider in `~/.paseo/config.json` (full example in
+[External control readiness](./external-control-readiness.md#paseo-custom-agent)),
+then:
+
+```sh
+paseo daemon restart              # after editing config.json
+paseo provider ls                 # gjc must read `available`, not `error`
+paseo run --provider gjc --cwd /tmp/gjc-acp-test --wait-timeout 3m "your prompt"
+paseo logs <agent-id>             # rendered transcript
+paseo ls                          # status: running / idle / completed / timeout
+paseo stop <agent-id>             # exercises session/cancel
+paseo delete <agent-id>
+```
+
+Paseo runs its daemon as a separate long-lived process, so it needs its own
+restart after a config change — but not after a GJC rebuild, since it spawns
+`gjc` per session.
+
+Errors surface in the daemon log with the JSON-RPC payload intact, which is
+where to look when the CLI prints something opaque like
+`Failed to create agent: [object Object]`:
+
+```sh
+grep -i 'failed to create agent' ~/.paseo/daemon.log | tail -1
+```
+
+## What to smoke-test
+
+Unit tests do not cover the transitions that break in practice. At minimum:
+
+- **A prompt that makes the agent use a tool and then continue.** Continuations
+  (todo reminders, TTSR resume, auto-continue) re-enter the agent loop and emit
+  a second `agent_start` within one `session/prompt`. Regressions here strand the
+  client until `sdk.promptDeadlineMs` (30 minutes) rather than failing fast, so
+  a run that never leaves `running` is the signal — not an error.
+- **A follow-up turn on the same session**, including a tool call that touches
+  the filesystem.
+- **Cancel mid-turn.** The pending prompt must settle as `cancelled`, and the
+  agent must land on `idle` rather than surfacing a transport error.
+- **A non-default mode**, if the client offers one.
+- **`initialize`** against the bare stdio handshake above, to eyeball the
+  advertised capabilities.
+
+## Verification references
+
+- `packages/coding-agent/test/acp-*.test.ts`
+- `packages/coding-agent/test/acp/`
+- `packages/coding-agent/test/sdk-acp-*.test.ts`
+- `bun run conformance:run` — pinned `acp-core-v1` corpus

--- a/docs/external-control-readiness.md
+++ b/docs/external-control-readiness.md
@@ -20,6 +20,8 @@ The SDK endpoint is loopback-only and is created with the session. It provides t
 
 ACP remains a stdio editor protocol. Its session control uses the SDK adapter internally; it is not a replacement external bot-control protocol.
 
+For the build/run/verify loop when changing ACP code locally, see [ACP local development](./acp-local-development.md).
+
 #### Evidence promotion policy
 
 Ordinary CI runs publish an **ephemeral** report under `$RUNNER_TEMP` and upload it as a


### PR DESCRIPTION
## Why

Rebuilding the binary does nothing for ACP until the SDK broker is restarted, and there is currently no documentation that says so.

`gjc acp` is a thin stdio front end — it attaches to the long-lived broker published for the agent directory, and that broker spawns a `sdk session-host-internal` child per session from the entrypoint *it* was started with. So after `bun run install:dev:bin` you get a new `gjc` on PATH talking to an eight-hour-old broker that keeps running the old code. The change appears to have no effect, which is indistinguishable from the fix being wrong.

I lost real time to exactly this while smoke-testing #3950 against Paseo:

```
19466  08:25:00  /Users/probe/git/probepark/gajae-code/packages/coding-agent/dist/gjc sdk broker-internal
```

`bun run restart:sdk-broker` was documented only as one sentence inside the JetBrains Air subsection of `external-control-readiness.md`, phrased as a description of what the script does — not as a step you must run. Nothing connects it to "your ACP change is not live".

## What

New `docs/acp-local-development.md` covering:

- the build → install → restart loop, and why the restart is not optional
- how to tell which build is actually serving (`ps` on `broker-internal`, before/after)
- `--agent-dir` / `--close-session-hosts` for scratch or full restarts
- driving GJC from Paseo: provider registration, `run`/`logs`/`ls`/`stop`, and reading the JSON-RPC payload out of `~/.paseo/daemon.log` when the CLI prints `Failed to create agent: [object Object]`
- the bare stdio `initialize` handshake
- which ACP transitions to smoke-test, because unit tests don't cover them — notably that a prompt whose agent continues mid-turn strands the client for 30 minutes rather than erroring, so "still `running`" is the signal, not a failure message

`external-control-readiness.md` gets a link to it from the ACP readiness section. That doc keeps its role as the protocol/support contract; this one is the dev loop.

## Verification

Every command in the doc was run against a live Paseo 0.2.5 daemon on macOS, including a real broker restart and a `--agent-dir` restart verified not to disturb the main broker. `docs-index.generated.ts` is gitignored, so there is nothing to regenerate in-tree.