### PR TITLE
feat(models): overhaul opencodego profile to Kimi K3 (k3-first)

### DIFF
--- a/docs/gpt-5.6-codex-preset-benchmark.md
+++ b/docs/gpt-5.6-codex-preset-benchmark.md
@@ -120,7 +120,7 @@ The selected-task data show that Luna xhigh used more reported tokens than Luna 
 | `codex-medium` | `openai-codex/gpt-5.6-sol:low` | `openai-codex/gpt-5.6-terra:low` | `openai-codex/gpt-5.6-terra:high` | `openai-codex/gpt-5.6-sol:xhigh` | `openai-codex/gpt-5.6-sol:high` |
 | `codex-pro` | `openai-codex/gpt-5.6-sol:medium` | `openai-codex/gpt-5.6-terra:medium` | `openai-codex/gpt-5.6-sol:high` | `openai-codex/gpt-5.6-sol:max` | `openai-codex/gpt-5.6-sol:xhigh` |
 | `opus-codex` | `anthropic/claude-opus-5:xhigh` | `openai-codex/gpt-5.6-terra:low` | `anthropic/claude-sonnet-5` | `openai-codex/gpt-5.6-sol:xhigh` | `openai-codex/gpt-5.6-sol:high` |
-| `codex-opencodego` | `openai-codex/gpt-5.6-sol:low` | `opencode-go/deepseek-v4-pro` | `opencode-go/kimi-k2.6` | `opencode-go/mimo-v2.5-pro` | `openai-codex/gpt-5.6-sol:high` |
+| `codex-opencodego` | `openai-codex/gpt-5.6-sol:low` | `opencode-go/deepseek-v4-pro` | `opencode-go/kimi-k3` | `opencode-go/mimo-v2.5-pro` | `openai-codex/gpt-5.6-sol:high` |
 | `fable-opus-codex` | `anthropic/claude-fable-5:high` | `openai-codex/gpt-5.6-terra:medium` | `anthropic/claude-opus-5:medium` | `anthropic/claude-opus-5:high` | `openai-codex/gpt-5.6-sol:xhigh` |
 
 ## Limitations

--- a/docs/models.md
+++ b/docs/models.md
@@ -234,7 +234,7 @@ Cancellation discards provisional output and emits exactly one cancelled `agent_
 Built-in profiles are grouped by provider mix and tier:
 
 - `codex-{eco,medium,pro}` — GPT-5.6 Sol/Terra/Luna role mixes tuned by tier and reasoning effort; `lunamaxxing` — OpenAI Codex Luna-only profile with maximum reasoning on delegated roles
-- `opencodego` — single OpenCode Go preset (Kimi default, DeepSeek executor/architect, Qwen planner, MiMo critic)
+- `opencodego` — single OpenCode Go preset (Kimi K3 default and planner, DeepSeek executor/architect, MiMo critic)
 - `claude-opus` — Anthropic OAuth preset centered on `claude-opus-5`
 - Single-provider tiers: `glm-{eco,medium,pro}`, `kimi-coding-plan-{eco,medium,pro}`, `mimo-{eco,medium,pro}`, `grok-{eco,medium,pro}`, `cursor-{eco,medium,pro}`, `minimax-{eco,medium,pro}`
 - Alibaba Token Plan: `alibaba-token-plan-balanced` preserves the established Qwen/DeepSeek V4 Pro/GLM mix; `alibaba-token-plan-pro` raises execution and independent criticism with DeepSeek V4 Flash 0731 max and GLM xhigh; `alibaba-token-plan-qwenmaxxing` stays Qwen-only; `alibaba-token-plan-qwen-deepseek` keeps Qwen 3.8 Max (`qwen3.8-max`) on the expensive default (high)/architect (xhigh)/critic (xhigh) roles and spends DeepSeek V4 Flash 0731 on the cheap planner (max) and executor (high) roles; `alibaba-token-plan-glm-deepseek` does the same with GLM 5.2 (`glm-5.2`) as the expensive model

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -2546,6 +2546,14 @@ const OPENCODE_GO_OFFICIAL_MODELS: Readonly<Record<string, OpenCodeGoOfficialMod
 		reasoning: true,
 		cost: { input: 0.95, output: 4, cacheRead: 0.19, cacheWrite: 0 },
 	},
+	"kimi-k3": {
+		name: "Kimi K3 (2x usage)",
+		contextWindow: 1_048_576,
+		maxTokens: 131_072,
+		input: ["text", "image"],
+		reasoning: true,
+		cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 },
+	},
 	"minimax-m2.5": {
 		name: "MiniMax M2.5",
 		contextWindow: 204_800,

--- a/packages/coding-agent/src/config/model-profiles.ts
+++ b/packages/coding-agent/src/config/model-profiles.ts
@@ -100,9 +100,9 @@ export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
 		architect: "openai-codex/gpt-5.6-luna:max",
 	}),
 	profile("opencodego", ["opencode-go"], {
-		default: "opencode-go/kimi-k2.6",
+		default: "opencode-go/kimi-k3",
 		executor: "opencode-go/deepseek-v4-flash",
-		planner: "opencode-go/qwen3.7-max",
+		planner: "opencode-go/kimi-k3",
 		critic: "opencode-go/mimo-v2.5-pro",
 		architect: "opencode-go/deepseek-v4-pro",
 	}),
@@ -329,7 +329,7 @@ export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
 	profile("codex-opencodego", ["openai-codex", "opencode-go"], {
 		default: "openai-codex/gpt-5.6-sol:low",
 		executor: "opencode-go/deepseek-v4-pro",
-		planner: "opencode-go/kimi-k2.6",
+		planner: "opencode-go/kimi-k3",
 		critic: "opencode-go/mimo-v2.5-pro",
 		architect: "openai-codex/gpt-5.6-sol:high",
 	}),

--- a/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
+++ b/packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts
@@ -42,7 +42,7 @@ const builtinComboModels = [
 	model("anthropic", "claude-fable-5", Effort.Low),
 	model("anthropic", "claude-sonnet-5"),
 	model("opencode-go", "deepseek-v4-pro"),
-	model("opencode-go", "kimi-k2.6"),
+	model("opencode-go", "kimi-k3"),
 	model("opencode-go", "mimo-v2.5-pro"),
 ];
 
@@ -70,7 +70,7 @@ const combo: ModelProfileDefinition = {
 const comboOpencode: ModelProfileDefinition = {
 	name: "codex-opencodego",
 	requiredProviders: ["openai-codex", "opencode-go"],
-	modelMapping: { default: "opencode-go/kimi-k2.6", executor: "openai-codex/gpt-5.5:low" },
+	modelMapping: { default: "opencode-go/kimi-k3", executor: "openai-codex/gpt-5.5:low" },
 	source: "builtin",
 };
 const minimax: ModelProfileDefinition = {
@@ -349,7 +349,7 @@ describe("preset landing adversarial QA", () => {
 		const text = await rendered(selector);
 		expect(text).toContain("DEFAULT: openai-codex/gpt-5.6-sol");
 		expect(text).toContain("EXECUTOR: opencode-go/deepseek-v4-pro");
-		expect(text).toContain("PLANNER: opencode-go/kimi-k2.6");
+		expect(text).toContain("PLANNER: opencode-go/kimi-k3");
 		expect(text).toContain("CRITIC: opencode-go/mimo-v2.5-pro");
 		expect(text).toContain("ARCHITECT: openai-codex/gpt-5.6-sol");
 	});

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -98,7 +98,7 @@ function fakeRegistry(options?: { missingProviders?: string[]; profiles?: ModelP
 			}),
 			model("anthropic", "claude-sonnet-5"),
 			model("opencode-go", "deepseek-v4-pro"),
-			model("opencode-go", "kimi-k2.6"),
+			model("opencode-go", "kimi-k3"),
 			model("opencode-go", "mimo-v2.5-pro"),
 			model("minimax-code", "MiniMax-M3"),
 			model("minimax-code-cn", "MiniMax-M3"),
@@ -591,7 +591,7 @@ describe("model profile activation", () => {
 			{
 				default: "openai-codex/gpt-5.6-sol:low",
 				executor: "opencode-go/deepseek-v4-pro",
-				planner: "opencode-go/kimi-k2.6",
+				planner: "opencode-go/kimi-k3",
 				critic: "opencode-go/mimo-v2.5-pro",
 				architect: "openai-codex/gpt-5.6-sol:high",
 			},

--- a/packages/coding-agent/test/model-profiles-catalog.test.ts
+++ b/packages/coding-agent/test/model-profiles-catalog.test.ts
@@ -67,9 +67,9 @@ const expectedProfiles: Array<{ name: string; requiredProviders: string[]; mappi
 		name: "opencodego",
 		requiredProviders: ["opencode-go"],
 		mapping: {
-			default: "opencode-go/kimi-k2.6",
+			default: "opencode-go/kimi-k3",
 			executor: "opencode-go/deepseek-v4-flash",
-			planner: "opencode-go/qwen3.7-max",
+			planner: "opencode-go/kimi-k3",
 			critic: "opencode-go/mimo-v2.5-pro",
 			architect: "opencode-go/deepseek-v4-pro",
 		},
@@ -410,7 +410,7 @@ const expectedProfiles: Array<{ name: string; requiredProviders: string[]; mappi
 		mapping: {
 			default: "openai-codex/gpt-5.6-sol:low",
 			executor: "opencode-go/deepseek-v4-pro",
-			planner: "opencode-go/kimi-k2.6",
+			planner: "opencode-go/kimi-k3",
 			critic: "opencode-go/mimo-v2.5-pro",
 			architect: "openai-codex/gpt-5.6-sol:high",
 		},
@@ -472,7 +472,7 @@ const fixedNonCodexComboMappings: Record<string, Partial<Record<Role, string>>> 
 	},
 	"codex-opencodego": {
 		executor: "opencode-go/deepseek-v4-pro",
-		planner: "opencode-go/kimi-k2.6",
+		planner: "opencode-go/kimi-k3",
 		critic: "opencode-go/mimo-v2.5-pro",
 	},
 	"fable-opus-codex": {


### PR DESCRIPTION
## What

Overhauls the builtin `opencodego` model profile (and the related `codex-opencodego` combo) for the **current** OpenCode Go catalog, k3-first, per community feedback that the profile still defaulted to Kimi K2.6 while K3 is already in the catalog.

## Role → model mapping

| Profile | Role | Before | After | Rationale |
|---|---|---|---|---|
| opencodego | default | `opencode-go/kimi-k2.6` | **`opencode-go/kimi-k3`** | Current flagship (the #3973 complaint); 1M ctx; multimodal for tool images; k3-first anchor |
| opencodego | executor | `opencode-go/deepseek-v4-flash` | `opencode-go/deepseek-v4-flash` (kept) | Cheapest model in the catalog (0.14/0.28); 1M ctx; 384k output budget; high-volume role economics |
| opencodego | planner | `opencode-go/qwen3.7-max` | **`opencode-go/kimi-k3`** | Modern long-context Kimi the issue names; 1M ctx + vision; low planner volume amortizes the premium; k3's 131k output cap is still 2× the qwen3.7-max incumbent (65k) |
| opencodego | critic | `opencode-go/mimo-v2.5-pro` | `opencode-go/mimo-v2.5-pro` (kept) | Cross-family independence (Xiaomi vs Kimi/DeepSeek); 1M ctx; proven |
| opencodego | architect | `opencode-go/deepseek-v4-pro` | `opencode-go/deepseek-v4-pro` (kept) | 1M ctx for large-repo analysis; 384k output budget for design docs; mid-tier price; family diversity |
| codex-opencodego | planner | `opencode-go/kimi-k2.6` | **`opencode-go/kimi-k3`** | Last stale k2.x in the combo; keeps the opencode-go slice coherent with the single-provider profile |

All opencode-go selectors stay bare `provider/id` (no effort suffix), matching the existing convention; `required_providers` unchanged for both profiles.

## Hardening

- Adds `kimi-k3` to `OPENCODE_GO_OFFICIAL_MODELS` (metadata mirrors `models.json` exactly), so the new default's metadata override is idempotent under live discovery/catalog regeneration (Architect finding, R4).

## Tests & docs synced

- `model-profiles-catalog.test.ts`, `model-preset-landing-redteam-qa.test.ts`, `model-profile-activation.test.ts` — expected mappings/fixtures updated
- `docs/models.md`, `docs/gpt-5.6-codex-preset-benchmark.md` — new mapping documented

## Verification

- `bun test` on all 5 touched/related test files: **101 pass, 0 fail**
- `bun --cwd=packages/coding-agent run check` and `bun --cwd=packages/ai run check`: biome + tsc clean
- `model-registry.test.ts` has 5 pre-existing environment-dependent failures (live models.dev discovery) reproduced identically on the clean tree — unrelated to this change

## Notes / open item

The bundled catalog names K3 `"Kimi K3 (2x usage)"`. If that label means metered tokens bill at 2×, effective cost is 6/30; the fallback diff (default+planner → `opencode-go/kimi-k2.7-code`) is documented in the ralplan ADR and can be applied if pricing confirmation lands that way. Shipped k3-first per the issue preference.

Closes #3973

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
