### PR TITLE
fix(ci): exclude legacy native producer from shard matrix

### DIFF
--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -675,6 +675,48 @@ describe("--matrix-json and --task CLI fan-out", () => {
 		// Native build tasks never appear as shards.
 		expect(matrix.include.every((shard: { key: string }) => shard.key !== "native-linux-x64")).toBe(true);
 	});
+
+	test("--matrix-json excludes the legacy native producer from docs-only shards", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-affected-docs-matrix-"));
+		tempDirs.push(tempDir);
+		const outputFile = path.join(tempDir, "github-output.txt");
+
+		const { stdout, exitCode } = await runScript(["--matrix-json"], "docs/acp-local-development.md", {
+			GITHUB_EVENT_NAME: "pull_request",
+			CI_DEV_PLAN_MODE: "pr",
+			GITHUB_OUTPUT: outputFile,
+		});
+		expect(exitCode).toBe(0);
+		expect((JSON.parse(stdout.trim()) as Array<{ key: string }>).map(entry => entry.key)).toEqual([
+			"test:packages/coding-agent/test/docs-index-lazy.test.ts",
+			"native-linux-x64",
+		]);
+
+		const output = await Bun.file(outputFile).text();
+		expect(output).toContain("has_tasks=true");
+		expect(output).toContain("has_native=true");
+		const planDigest = output.split("\n").find(line => line.startsWith("plan_digest="))?.slice("plan_digest=".length);
+		const planSourceSha = output.split("\n").find(line => line.startsWith("plan_source_sha="))?.slice("plan_source_sha=".length);
+		expect(planDigest).toBeDefined();
+		expect(planSourceSha).toBe(sourceSha);
+		const matrix = JSON.parse((output.split("\n").find(line => line.startsWith("matrix=")) ?? "matrix={}").slice("matrix=".length)) as {
+			include: Array<{ key: string; identity: string }>;
+		};
+		expect(matrix.include.map(entry => entry.key)).toEqual(["test:packages/coding-agent/test/docs-index-lazy.test.ts"]);
+
+		const receiptDir = path.join(tempDir, "receipts");
+		await fs.mkdir(receiptDir);
+		for (const [index, entry] of matrix.include.entries()) {
+			await Bun.write(path.join(receiptDir, `${index}.json`), JSON.stringify({ key: entry.key, identity: entry.identity }));
+		}
+		const validation = await runScript(["--validate-shard-receipts"], "", {
+			CI_DEV_AFFECTED_PLAN: path.join(repoRoot, ".ci-dev-affected-plan.json"),
+			CI_DEV_SHARD_RECEIPTS: receiptDir,
+			CI_DEV_PLAN_DIGEST: planDigest,
+			CI_DEV_PLAN_SOURCE_SHA: planSourceSha,
+		});
+		expect(validation.exitCode).toBe(0);
+	});
 	test("CI_FORCE_FULL emits Python work outside the shard matrix", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ci-dev-affected-python-full-"));
 		tempDirs.push(tempDir);

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -332,6 +332,10 @@ function isNativeBuildKey(key: string): boolean {
 	return NATIVE_BUILD_KEYS.has(key);
 }
 
+function isNativeProducerTask(task: Task): boolean {
+	return task.capabilities?.nativeProducer ?? isNativeBuildKey(task.key);
+}
+
 // Tasks that load the @gajae-code/natives addon at runtime and therefore need a
 // prebuilt `.node` present in `packages/natives/native/`. By construction (see
 // planTasks) every such task only appears in a plan that also includes a native
@@ -375,7 +379,7 @@ export function describeTasks(tasks: readonly Task[]): TaskMatrixEntry[] {
 		native: task.capabilities?.nativeConsumer ?? taskNeedsNative(task.key),
 		rust: task.capabilities?.rust ?? taskNeedsRust(task.key),
 		nextest: task.capabilities?.nextest ?? isRustTestKey(task.key),
-		nativeBuild: task.capabilities?.nativeProducer ?? isNativeBuildKey(task.key),
+		nativeBuild: isNativeProducerTask(task),
 	}));
 }
 
@@ -443,7 +447,7 @@ async function emitFullMatrix(): Promise<void> {
 	const githubOutput = process.env.GITHUB_OUTPUT;
 	if (!githubOutput) return;
 	const shards = tasks
-		.filter(task => task.capabilities?.nativeProducer !== true && task.phase !== "python")
+		.filter(task => !isNativeProducerTask(task) && task.phase !== "python")
 		.map(task => {
 			const entry = describeTasks([task])[0]!;
 			return { key: entry.key, identity: entry.identity, description: entry.description, native: entry.native, rust: entry.rust, nextest: entry.nextest };
@@ -477,7 +481,7 @@ async function emitMatrix(): Promise<void> {
 	const githubOutput = process.env.GITHUB_OUTPUT;
 	if (!githubOutput) return;
 	const shards = tasks
-		.filter(task => task.capabilities?.nativeProducer !== true && task.phase !== "python")
+		.filter(task => !isNativeProducerTask(task) && task.phase !== "python")
 		.map(task => {
 			const entry = describeTasks([task])[0]!;
 			return { key: entry.key, identity: entry.identity, description: entry.description, native: entry.native, rust: entry.rust, nextest: entry.nextest };


### PR DESCRIPTION
## Problem

PR #3977 reproduced a repository-global Dev CI evidence failure on an otherwise docs-only plan. The canonical plan contained the docs-index test plus the dedicated `native-linux-x64` producer. The GitHub shard matrix included both tasks because the legacy producer has no in-memory capabilities, while canonical evidence validation correctly excluded native producers. This created an impossible extra shard receipt and failed with `shard receipt set does not match canonical plan`.

Exact failing run: https://github.com/Yeachan-Heo/gajae-code/actions/runs/31142359014

## Fix

Use one native-producer predicate for descriptor and matrix emission, preserving the legacy key fallback when explicit capabilities are absent. Add a docs-only regression that builds the planner output, materializes receipts from the emitted shard matrix, and validates that receipt set against the canonical plan.

## Verification

- `bun test scripts/ci-dev-affected.test.ts scripts/dev-ci-guard-topology.test.ts` — 91 pass
- `git diff --check`
- `bun run check:ts` reached and passed declaration/type gates, then stopped on the pre-existing stale `packages/coding-agent/src/internal-urls/docs-index.generated.ts` public-sync check on current dev.

PR #3977 remains held until this repository-global baseline repair lands and its docs blockers are corrected.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*