### PR TITLE
feat(ai): force Codex GPT-5.6 family context window to 372K

### DIFF
--- a/docs/multi-vendor-profiles.md
+++ b/docs/multi-vendor-profiles.md
@@ -60,7 +60,7 @@ profiles:
       architect: google-antigravity/gemini-3.1-pro-low
       critic:    google-antigravity/gemini-3.5-flash
 
-  monorepo:              # huge codebases (openai-codex excluded: 272k context cap)
+  monorepo:              # huge codebases (openai-codex excluded: 372k context cap)
     required_providers: [anthropic, google-antigravity, opencode-go]
     model_mapping:
       default:   anthropic/claude-opus-5:medium

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Changed
 
-- Raised the enforced OpenAI code (Codex) GPT-5.6 family prompt budget from 272K to 372K input tokens: `CODEX_GPT_5_6_CONTEXT_CAP` fallback/ceiling is now 372K, live `openai-codex` discovery metadata above 372K is capped to it, and the bundled `openai-codex` GPT-5.6 Sol/Terra/Luna catalog entries now advertise 372K context. Smaller observed live limits remain authoritative, first-party OpenAI and non-5.6 codex variants (e.g. `gpt-5.4-codex`, `gpt-5.6-codex`) are untouched, and the 272K long-context pricing threshold is unchanged.
+- Forced the OpenAI code (Codex) GPT-5.6 family prompt budget to 372K input tokens: `CODEX_GPT_5_6_CONTEXT_CAP.enforced` is 372K and is applied as a hard override at discovery (`resolveCodexGpt56DiscoveryContext`), generated-catalog policy (`applyGpt56ContextWindow`), and final model-manager cap (`applyFinalCodexGpt56ContextCap`). The live backend metadata still reports the old 272K budget for the tier, so smaller observations are overridden rather than preserved. The bundled `openai-codex` GPT-5.6 Sol/Terra/Luna catalog entries now advertise 372K context (matching `bun run generate-models` output). Non-5.6 codex variants (`gpt-5.5`, `gpt-5.4-codex`, `gpt-5.6-codex`, GPT-5.4 mini/nano) keep the generic 272K budget via the shared `CODEX_GENERIC_CONTEXT_WINDOW`, first-party OpenAI is untouched, and the 272K long-context pricing threshold is unchanged.
 
 ### Fixed
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 - Added opt-in `compat.supportsResponsesSessionAffinity` for OpenAI Responses custom relays. When enabled, supported `openai-responses` models may send `session_id` and `x-client-request-id` affinity headers to a custom endpoint; canonical OpenAI routing remains automatic and known non-OpenAI provider IDs remain excluded.
 
+### Changed
+
+- Raised the enforced OpenAI code (Codex) GPT-5.6 family prompt budget from 272K to 372K input tokens: `CODEX_GPT_5_6_CONTEXT_CAP` fallback/ceiling is now 372K, live `openai-codex` discovery metadata above 372K is capped to it, and the bundled `openai-codex` GPT-5.6 Sol/Terra/Luna catalog entries now advertise 372K context. Smaller observed live limits remain authoritative, first-party OpenAI and non-5.6 codex variants (e.g. `gpt-5.4-codex`, `gpt-5.6-codex`) are untouched, and the 272K long-context pricing threshold is unchanged.
+
 ### Fixed
 
 - Anthropic requests rejected with `A maximum of 4 blocks with cache_control may be provided. Found N.` now step their generated breakpoints down instead of dying on the first attempt (#3934, supersedes #3943). An Anthropic-compatible gateway may attach its own block-level cache markers before forwarding, and those never appear in the params we serialize, so the total is unpredictable locally and the rejection itself is the only usable signal. Because that rejection says "too many", not "none allowed", recovery gives up one breakpoint at a time: explicit mode normally emits two (a conversation-prefix anchor plus a current-turn refresh point), so the first retry keeps the prefix anchor — the higher-value marker — and only a second rejection disables generated caching entirely. The reduced budget persists for the provider session so later turns neither re-trigger the 400 nor lose more caching than the endpoint requires. Only a genuine breakpoint-overflow `invalid_request_error` is claimed — other `cache_control` complaints, unrelated 400s, non-400 statuses, and our own pre-flight validation failure still surface immediately. The classifier is exported as `isAnthropicCacheBreakpointOverflowError`.

--- a/packages/ai/src/context-cap-policy.ts
+++ b/packages/ai/src/context-cap-policy.ts
@@ -1,24 +1,25 @@
 import type { Api, Model } from "./types";
 
 export interface CodexGpt56ContextCapPolicy {
-	fallback: number;
-	ceiling: number;
+	/**
+	 * Usable prompt budget forced for the GPT-5.6 tier on the Codex product
+	 * transport. The live OpenAI code backend metadata still reports the old
+	 * 272K budget (or the total-window figure), so this is an explicit product
+	 * override: the tier is forced to the enforced window regardless of what
+	 * discovery reports.
+	 */
+	enforced: number;
 }
 
 export const CODEX_GPT_5_6_CONTEXT_CAP: CodexGpt56ContextCapPolicy = {
-	// 372K is the currently enforced usable prompt budget for the OpenAI code
-	// backend, but only for the GPT-5.6 tier (raised from 272K); discovery
-	// metadata above it is a total-window figure that includes the output budget
-	// and must not be trusted as input.
-	fallback: 372_000,
-	ceiling: 372_000,
+	enforced: 372_000,
 };
 
 /**
  * Generic usable prompt budget for OpenAI code backend models outside the
  * GPT-5.6 tier (e.g. gpt-5.5, gpt-5.4-codex, gpt-5.6-codex). Kept separate from
- * {@link CODEX_GPT_5_6_CONTEXT_CAP} so a future authority raise for the 5.6
- * tier never leaks a larger fallback into unrelated Codex discovery rows.
+ * {@link CODEX_GPT_5_6_CONTEXT_CAP} so the forced 5.6-tier window never leaks
+ * into unrelated Codex discovery rows.
  */
 export const CODEX_GENERIC_CONTEXT_WINDOW = 272_000;
 
@@ -48,8 +49,9 @@ export function resolveCodexGpt56DiscoveryContext(
 		// gpt-5.6-codex is applied later by the generated-catalog policy).
 		return isPositiveFiniteNumber(rawContextWindow) ? rawContextWindow : CODEX_GENERIC_CONTEXT_WINDOW;
 	}
-	const observed = isPositiveFiniteNumber(rawContextWindow) ? rawContextWindow : policy.fallback;
-	return Math.min(observed, policy.ceiling);
+	// Force the enforced window: the backend's current metadata under-reports
+	// the GPT-5.6 tier budget, and stale smaller observations must not win.
+	return policy.enforced;
 }
 
 export function applyFinalCodexGpt56ContextCap<TApi extends Api>(
@@ -57,15 +59,10 @@ export function applyFinalCodexGpt56ContextCap<TApi extends Api>(
 	policy: CodexGpt56ContextCapPolicy = CODEX_GPT_5_6_CONTEXT_CAP,
 ): Model<TApi>[] {
 	return models.map(model => {
-		if (
-			!isCodexGpt56Tier(model as Model<Api>) ||
-			!isCodexProductTransport(model as Model<Api>) ||
-			!isPositiveFiniteNumber(model.contextWindow) ||
-			model.contextWindow <= policy.ceiling
-		) {
+		if (!isCodexGpt56Tier(model as Model<Api>) || !isCodexProductTransport(model as Model<Api>)) {
 			return model;
 		}
-		return { ...model, contextWindow: policy.ceiling };
+		return { ...model, contextWindow: policy.enforced };
 	});
 }
 

--- a/packages/ai/src/context-cap-policy.ts
+++ b/packages/ai/src/context-cap-policy.ts
@@ -6,8 +6,11 @@ export interface CodexGpt56ContextCapPolicy {
 }
 
 export const CODEX_GPT_5_6_CONTEXT_CAP: CodexGpt56ContextCapPolicy = {
-	fallback: 272_000,
-	ceiling: 272_000,
+	// 372K is the currently enforced usable prompt budget for the OpenAI code
+	// backend (raised from 272K); discovery metadata above it is a total-window
+	// figure that includes the output budget and must not be trusted as input.
+	fallback: 372_000,
+	ceiling: 372_000,
 };
 
 const CODEX_GPT_5_6_MODEL_IDS: ReadonlySet<string> = new Set([

--- a/packages/ai/src/context-cap-policy.ts
+++ b/packages/ai/src/context-cap-policy.ts
@@ -7,11 +7,20 @@ export interface CodexGpt56ContextCapPolicy {
 
 export const CODEX_GPT_5_6_CONTEXT_CAP: CodexGpt56ContextCapPolicy = {
 	// 372K is the currently enforced usable prompt budget for the OpenAI code
-	// backend (raised from 272K); discovery metadata above it is a total-window
-	// figure that includes the output budget and must not be trusted as input.
+	// backend, but only for the GPT-5.6 tier (raised from 272K); discovery
+	// metadata above it is a total-window figure that includes the output budget
+	// and must not be trusted as input.
 	fallback: 372_000,
 	ceiling: 372_000,
 };
+
+/**
+ * Generic usable prompt budget for OpenAI code backend models outside the
+ * GPT-5.6 tier (e.g. gpt-5.5, gpt-5.4-codex, gpt-5.6-codex). Kept separate from
+ * {@link CODEX_GPT_5_6_CONTEXT_CAP} so a future authority raise for the 5.6
+ * tier never leaks a larger fallback into unrelated Codex discovery rows.
+ */
+export const CODEX_GENERIC_CONTEXT_WINDOW = 272_000;
 
 const CODEX_GPT_5_6_MODEL_IDS: ReadonlySet<string> = new Set([
 	"gpt-5.6",
@@ -33,10 +42,13 @@ export function resolveCodexGpt56DiscoveryContext(
 	rawContextWindow: unknown,
 	policy: CodexGpt56ContextCapPolicy = CODEX_GPT_5_6_CONTEXT_CAP,
 ): number {
-	const observed = isPositiveFiniteNumber(rawContextWindow) ? rawContextWindow : policy.fallback;
 	if (!isCodexGpt56Tier(model) || !isCodexProductTransport(model)) {
-		return observed;
+		// Non-5.6 rows keep the generic Codex prompt budget as their fallback;
+		// live observations still pass through (the 272K pin for gpt-5.5 and
+		// gpt-5.6-codex is applied later by the generated-catalog policy).
+		return isPositiveFiniteNumber(rawContextWindow) ? rawContextWindow : CODEX_GENERIC_CONTEXT_WINDOW;
 	}
+	const observed = isPositiveFiniteNumber(rawContextWindow) ? rawContextWindow : policy.fallback;
 	return Math.min(observed, policy.ceiling);
 }
 

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -1,4 +1,9 @@
-import { CODEX_GPT_5_6_CONTEXT_CAP, isCodexGpt56Tier, isCodexProductTransport } from "./context-cap-policy";
+import {
+	CODEX_GENERIC_CONTEXT_WINDOW,
+	CODEX_GPT_5_6_CONTEXT_CAP,
+	isCodexGpt56Tier,
+	isCodexProductTransport,
+} from "./context-cap-policy";
 import { applyOpenAIModelPricing } from "./model-pricing";
 import { resolveOpenAICompat } from "./openai-completions-compat";
 import type { Api, Model as ApiModel, ThinkingConfig } from "./types";
@@ -529,7 +534,9 @@ function applyGpt55ContextWindow(model: ApiModel<Api>, parsedModel: OpenAIModel)
 		// marketing total window; using 1M here delays compaction and makes the UI
 		// promise space that `/responses/compact`/agent turns cannot actually use.
 		model.contextWindow =
-			model.provider === "openai-codex" || model.api === "openai-codex-responses" ? 272_000 : 1_000_000;
+			model.provider === "openai-codex" || model.api === "openai-codex-responses"
+				? CODEX_GENERIC_CONTEXT_WINDOW
+				: 1_000_000;
 		return true;
 	}
 	return false;
@@ -553,7 +560,7 @@ function applyOpenAICatalogPolicy(model: ApiModel<Api>, parsedModel: OpenAIModel
 	}
 	// OpenAI code backend models: 400K figure includes output budget; input window is 272K.
 	if (parsedModel.variant.startsWith("codex") && parsedModel.variant !== "codex-spark") {
-		model.contextWindow = 272000;
+		model.contextWindow = CODEX_GENERIC_CONTEXT_WINDOW;
 		return;
 	}
 	// GPT-5.4 mini/nano use plain OpenAI IDs on the OpenAI code backend transport, but OpenAI code backend still
@@ -566,7 +573,7 @@ function applyOpenAICatalogPolicy(model: ApiModel<Api>, parsedModel: OpenAIModel
 			model.priority = normalizedPriority;
 		}
 		if (parsedModel.variant === "mini" || parsedModel.variant === "nano") {
-			model.contextWindow = 272000;
+			model.contextWindow = CODEX_GENERIC_CONTEXT_WINDOW;
 		}
 	}
 }

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -545,9 +545,10 @@ function applyGpt56ContextWindow(model: ApiModel<Api>): boolean {
 	if (!isCodexGpt56Tier(model) || !isCodexProductTransport(model)) {
 		return false;
 	}
-	// Codex product metadata is bounded by the currently enforced prompt cap.
-	// Smaller observed limits remain authoritative; first-party OpenAI is untouched.
-	model.contextWindow = Math.min(model.contextWindow, CODEX_GPT_5_6_CONTEXT_CAP.ceiling);
+	// Force the enforced 372K window: the OpenAI code backend metadata still
+	// under-reports the GPT-5.6 tier budget, and smaller observed values would
+	// otherwise keep the tier at the old 272K cap. First-party OpenAI is untouched.
+	model.contextWindow = CODEX_GPT_5_6_CONTEXT_CAP.enforced;
 	return true;
 }
 

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -59234,7 +59234,7 @@
 				"cacheRead": 0.02,
 				"cacheWrite": 0.25
 			},
-			"contextWindow": 272000,
+			"contextWindow": 372000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"priority": 3,
@@ -59271,7 +59271,7 @@
 				"cacheRead": 0.5,
 				"cacheWrite": 6.25
 			},
-			"contextWindow": 272000,
+			"contextWindow": 372000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"priority": 1,
@@ -59308,7 +59308,7 @@
 				"cacheRead": 0.2,
 				"cacheWrite": 2.5
 			},
-			"contextWindow": 272000,
+			"contextWindow": 372000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"priority": 2,

--- a/packages/ai/test/codex-discovery-context-cap.test.ts
+++ b/packages/ai/test/codex-discovery-context-cap.test.ts
@@ -41,6 +41,10 @@ describe("Codex GPT-5.6 discovery context cap", () => {
 			expect(await discover(id, 1_050_000)).toBe(372_000);
 			// Even smaller live metadata is overridden — the tier is forced to 372K.
 			expect(await discover(id, 200_000)).toBe(372_000);
+			// Invalid metadata shapes (JSON-safe: null/zero/string) are forced too.
+			expect(await discover(id, null)).toBe(372_000);
+			expect(await discover(id, 0)).toBe(372_000);
+			expect(await discover(id, "373000")).toBe(372_000);
 		}
 	});
 

--- a/packages/ai/test/codex-discovery-context-cap.test.ts
+++ b/packages/ai/test/codex-discovery-context-cap.test.ts
@@ -28,12 +28,12 @@ describe("Codex GPT-5.6 discovery context cap", () => {
 			clientVersion: "0.99.0",
 			fetchFn: fetchResponse(undefined),
 		});
-		expect(result?.models[0]?.contextWindow).toBe(272_000);
+		expect(result?.models[0]?.contextWindow).toBe(372_000);
 	});
 
 	it("caps larger live metadata but preserves a smaller live cap", async () => {
 		for (const [observed, expected] of [
-			[373_000, 272_000],
+			[373_000, 372_000],
 			[200_000, 200_000],
 		] as const) {
 			const result = await fetchCodexModels({

--- a/packages/ai/test/codex-discovery-context-cap.test.ts
+++ b/packages/ai/test/codex-discovery-context-cap.test.ts
@@ -34,19 +34,20 @@ const GPT_5_6_TIER_IDS = ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-lu
 const NON_TIER_CODEX_IDS = ["gpt-5.5", "gpt-5.6-codex"] as const;
 
 describe("Codex GPT-5.6 discovery context cap", () => {
-	it("applies the 372K fallback and ceiling to every GPT-5.6 tier id", async () => {
+	it("forces the 372K window for every GPT-5.6 tier id", async () => {
 		for (const id of GPT_5_6_TIER_IDS) {
 			expect(await discover(id, undefined)).toBe(372_000);
 			expect(await discover(id, 373_000)).toBe(372_000);
 			expect(await discover(id, 1_050_000)).toBe(372_000);
-			expect(await discover(id, 200_000)).toBe(200_000);
+			// Even smaller live metadata is overridden — the tier is forced to 372K.
+			expect(await discover(id, 200_000)).toBe(372_000);
 		}
 	});
 
 	it("keeps the generic 272K fallback for non-5.6 Codex rows and passes live values through", async () => {
 		for (const id of NON_TIER_CODEX_IDS) {
 			// The 272K pin for these ids is applied by the generated-catalog policy
-			// (model-thinking), so raw discovery must not advertise the 372K authority.
+			// (model-thinking), so raw discovery must not advertise the 372K window.
 			expect(await discover(id, undefined)).toBe(272_000);
 			expect(await discover(id, 373_000)).toBe(373_000);
 		}

--- a/packages/ai/test/codex-discovery-context-cap.test.ts
+++ b/packages/ai/test/codex-discovery-context-cap.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import { fetchCodexModels } from "../src/utils/discovery/codex";
 
-function response(contextWindow: unknown): Response {
+function response(slug: string, contextWindow: unknown): Response {
 	return new Response(
 		JSON.stringify({
 			models: [
 				{
-					slug: "gpt-5.6-sol",
-					display_name: "GPT-5.6 Sol",
+					slug,
+					display_name: slug,
 					context_window: contextWindow,
 					supported_in_api: true,
 				},
@@ -17,31 +17,38 @@ function response(contextWindow: unknown): Response {
 	);
 }
 
-function fetchResponse(contextWindow: unknown): typeof fetch {
-	return (() => Promise.resolve(response(contextWindow))) as unknown as typeof fetch;
+function fetchResponse(slug: string, contextWindow: unknown): typeof fetch {
+	return (() => Promise.resolve(response(slug, contextWindow))) as unknown as typeof fetch;
 }
 
+async function discover(slug: string, contextWindow: unknown): Promise<number | undefined> {
+	const result = await fetchCodexModels({
+		accessToken: "test-token",
+		clientVersion: "0.99.0",
+		fetchFn: fetchResponse(slug, contextWindow),
+	});
+	return result?.models[0]?.contextWindow;
+}
+
+const GPT_5_6_TIER_IDS = ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] as const;
+const NON_TIER_CODEX_IDS = ["gpt-5.5", "gpt-5.6-codex"] as const;
+
 describe("Codex GPT-5.6 discovery context cap", () => {
-	it("uses the conservative fallback for absent metadata", async () => {
-		const result = await fetchCodexModels({
-			accessToken: "test-token",
-			clientVersion: "0.99.0",
-			fetchFn: fetchResponse(undefined),
-		});
-		expect(result?.models[0]?.contextWindow).toBe(372_000);
+	it("applies the 372K fallback and ceiling to every GPT-5.6 tier id", async () => {
+		for (const id of GPT_5_6_TIER_IDS) {
+			expect(await discover(id, undefined)).toBe(372_000);
+			expect(await discover(id, 373_000)).toBe(372_000);
+			expect(await discover(id, 1_050_000)).toBe(372_000);
+			expect(await discover(id, 200_000)).toBe(200_000);
+		}
 	});
 
-	it("caps larger live metadata but preserves a smaller live cap", async () => {
-		for (const [observed, expected] of [
-			[373_000, 372_000],
-			[200_000, 200_000],
-		] as const) {
-			const result = await fetchCodexModels({
-				accessToken: "test-token",
-				clientVersion: "0.99.0",
-				fetchFn: fetchResponse(observed),
-			});
-			expect(result?.models[0]?.contextWindow).toBe(expected);
+	it("keeps the generic 272K fallback for non-5.6 Codex rows and passes live values through", async () => {
+		for (const id of NON_TIER_CODEX_IDS) {
+			// The 272K pin for these ids is applied by the generated-catalog policy
+			// (model-thinking), so raw discovery must not advertise the 372K authority.
+			expect(await discover(id, undefined)).toBe(272_000);
+			expect(await discover(id, 373_000)).toBe(373_000);
 		}
 	});
 });

--- a/packages/ai/test/context-cap-policy.test.ts
+++ b/packages/ai/test/context-cap-policy.test.ts
@@ -23,10 +23,10 @@ function model(overrides: Partial<Model<Api>> = {}): Model<Api> {
 }
 
 describe("Codex GPT-5.6 context cap policy", () => {
-	it("uses the conservative fallback and preserves smaller live limits", () => {
+	it("uses the 372K fallback and preserves smaller live limits", () => {
 		const identity = model();
-		expect(resolveCodexGpt56DiscoveryContext(identity, undefined)).toBe(272_000);
-		expect(resolveCodexGpt56DiscoveryContext(identity, 373_000)).toBe(272_000);
+		expect(resolveCodexGpt56DiscoveryContext(identity, undefined)).toBe(372_000);
+		expect(resolveCodexGpt56DiscoveryContext(identity, 373_000)).toBe(372_000);
 		expect(resolveCodexGpt56DiscoveryContext(identity, 200_000)).toBe(200_000);
 	});
 
@@ -41,20 +41,20 @@ describe("Codex GPT-5.6 context cap policy", () => {
 			model({ id: "gpt-5.6-codex" }),
 		]);
 		expect(capped.map(entry => entry.contextWindow)).toEqual([
-			272_000, 272_000, 272_000, 272_000, 373_000, 373_000, 373_000,
+			372_000, 372_000, 372_000, 372_000, 373_000, 373_000, 373_000,
 		]);
 	});
 
-	it("supports a future authority increase without promoting stale smaller observations", () => {
-		const futurePolicy = { ...CODEX_GPT_5_6_CONTEXT_CAP, fallback: 372_000, ceiling: 372_000 };
+	it("does not promote stale smaller observations when authority rises", () => {
+		const futurePolicy = { ...CODEX_GPT_5_6_CONTEXT_CAP, fallback: 400_000, ceiling: 400_000 };
 		const identity = model();
-		expect(resolveCodexGpt56DiscoveryContext(identity, undefined, futurePolicy)).toBe(372_000);
-		expect(resolveCodexGpt56DiscoveryContext(identity, 372_000, futurePolicy)).toBe(372_000);
+		expect(resolveCodexGpt56DiscoveryContext(identity, undefined, futurePolicy)).toBe(400_000);
+		expect(resolveCodexGpt56DiscoveryContext(identity, 400_000, futurePolicy)).toBe(400_000);
 		expect(applyFinalCodexGpt56ContextCap([model({ contextWindow: 272_000 })], futurePolicy)[0]?.contextWindow).toBe(
 			272_000,
 		);
-		expect(applyFinalCodexGpt56ContextCap([model({ contextWindow: 373_000 })], futurePolicy)[0]?.contextWindow).toBe(
-			372_000,
+		expect(applyFinalCodexGpt56ContextCap([model({ contextWindow: 500_000 })], futurePolicy)[0]?.contextWindow).toBe(
+			400_000,
 		);
 	});
 });

--- a/packages/ai/test/context-cap-policy.test.ts
+++ b/packages/ai/test/context-cap-policy.test.ts
@@ -23,19 +23,22 @@ function model(overrides: Partial<Model<Api>> = {}): Model<Api> {
 }
 
 describe("Codex GPT-5.6 context cap policy", () => {
-	it("uses the 372K fallback and preserves smaller live limits", () => {
+	it("forces the 372K window for the tier regardless of observations", () => {
 		const identity = model();
 		expect(resolveCodexGpt56DiscoveryContext(identity, undefined)).toBe(372_000);
 		expect(resolveCodexGpt56DiscoveryContext(identity, 373_000)).toBe(372_000);
-		expect(resolveCodexGpt56DiscoveryContext(identity, 200_000)).toBe(200_000);
-		// Non-5.6 Codex rows keep the generic 272K fallback — the 372K authority
-		// never leaks into unrelated discovery rows with absent metadata.
+		expect(resolveCodexGpt56DiscoveryContext(identity, 1_050_000)).toBe(372_000);
+		// Smaller observations are overridden too — the tier is forced to 372K
+		// because the live backend metadata under-reports the GPT-5.6 budget.
+		expect(resolveCodexGpt56DiscoveryContext(identity, 200_000)).toBe(372_000);
+		// Non-5.6 Codex rows keep the generic 272K fallback — the forced 372K
+		// window never leaks into unrelated discovery rows with absent metadata.
 		expect(resolveCodexGpt56DiscoveryContext(model({ id: "gpt-5.5" }), undefined)).toBe(272_000);
 		expect(resolveCodexGpt56DiscoveryContext(model({ id: "gpt-5.6-codex" }), undefined)).toBe(272_000);
 		expect(resolveCodexGpt56DiscoveryContext(model({ id: "gpt-5.5" }), 373_000)).toBe(373_000);
 	});
 
-	it("scopes the ceiling to exact tiers and Codex product transports", () => {
+	it("scopes the forced window to exact tiers and Codex product transports", () => {
 		const capped = applyFinalCodexGpt56ContextCap([
 			model({ id: "gpt-5.6" }),
 			model({ id: "gpt-5.6-sol" }),
@@ -50,16 +53,19 @@ describe("Codex GPT-5.6 context cap policy", () => {
 		]);
 	});
 
-	it("does not promote stale smaller observations when authority rises", () => {
-		const futurePolicy = { ...CODEX_GPT_5_6_CONTEXT_CAP, fallback: 400_000, ceiling: 400_000 };
+	it("applies a custom enforced window only to the exact tier", () => {
+		const customPolicy = { ...CODEX_GPT_5_6_CONTEXT_CAP, enforced: 400_000 };
 		const identity = model();
-		expect(resolveCodexGpt56DiscoveryContext(identity, undefined, futurePolicy)).toBe(400_000);
-		expect(resolveCodexGpt56DiscoveryContext(identity, 400_000, futurePolicy)).toBe(400_000);
-		expect(applyFinalCodexGpt56ContextCap([model({ contextWindow: 272_000 })], futurePolicy)[0]?.contextWindow).toBe(
-			272_000,
-		);
-		expect(applyFinalCodexGpt56ContextCap([model({ contextWindow: 500_000 })], futurePolicy)[0]?.contextWindow).toBe(
+		expect(resolveCodexGpt56DiscoveryContext(identity, undefined, customPolicy)).toBe(400_000);
+		expect(resolveCodexGpt56DiscoveryContext(identity, 400_000, customPolicy)).toBe(400_000);
+		expect(resolveCodexGpt56DiscoveryContext(identity, 272_000, customPolicy)).toBe(400_000);
+		expect(applyFinalCodexGpt56ContextCap([model({ contextWindow: 272_000 })], customPolicy)[0]?.contextWindow).toBe(
 			400_000,
 		);
+		expect(applyFinalCodexGpt56ContextCap([model({ contextWindow: 500_000 })], customPolicy)[0]?.contextWindow).toBe(
+			400_000,
+		);
+		// Non-tier rows are untouched by the policy entirely.
+		expect(resolveCodexGpt56DiscoveryContext(model({ id: "gpt-5.5" }), undefined, customPolicy)).toBe(272_000);
 	});
 });

--- a/packages/ai/test/context-cap-policy.test.ts
+++ b/packages/ai/test/context-cap-policy.test.ts
@@ -38,6 +38,19 @@ describe("Codex GPT-5.6 context cap policy", () => {
 		expect(resolveCodexGpt56DiscoveryContext(model({ id: "gpt-5.5" }), 373_000)).toBe(373_000);
 	});
 
+	it("forces 372K for invalid observations on the tier", () => {
+		// The tier branch ignores the observation entirely, so every invalid shape
+		// must resolve to the enforced window without crashing or falling through.
+		for (const raw of [null, "373000", 0, -100, Number.NaN, Number.POSITIVE_INFINITY] as const) {
+			expect(resolveCodexGpt56DiscoveryContext(model(), raw)).toBe(372_000);
+		}
+		for (const bad of [Number.NaN, 0, -1, undefined as unknown as number]) {
+			expect(applyFinalCodexGpt56ContextCap([model({ contextWindow: bad })])[0]?.contextWindow).toBe(372_000);
+		}
+		// The generic fallback still applies to non-tier rows with invalid metadata.
+		expect(resolveCodexGpt56DiscoveryContext(model({ id: "gpt-5.5" }), null)).toBe(272_000);
+	});
+
 	it("scopes the forced window to exact tiers and Codex product transports", () => {
 		const capped = applyFinalCodexGpt56ContextCap([
 			model({ id: "gpt-5.6" }),

--- a/packages/ai/test/context-cap-policy.test.ts
+++ b/packages/ai/test/context-cap-policy.test.ts
@@ -28,6 +28,11 @@ describe("Codex GPT-5.6 context cap policy", () => {
 		expect(resolveCodexGpt56DiscoveryContext(identity, undefined)).toBe(372_000);
 		expect(resolveCodexGpt56DiscoveryContext(identity, 373_000)).toBe(372_000);
 		expect(resolveCodexGpt56DiscoveryContext(identity, 200_000)).toBe(200_000);
+		// Non-5.6 Codex rows keep the generic 272K fallback — the 372K authority
+		// never leaks into unrelated discovery rows with absent metadata.
+		expect(resolveCodexGpt56DiscoveryContext(model({ id: "gpt-5.5" }), undefined)).toBe(272_000);
+		expect(resolveCodexGpt56DiscoveryContext(model({ id: "gpt-5.6-codex" }), undefined)).toBe(272_000);
+		expect(resolveCodexGpt56DiscoveryContext(model({ id: "gpt-5.5" }), 373_000)).toBe(373_000);
 	});
 
 	it("scopes the ceiling to exact tiers and Codex product transports", () => {

--- a/packages/ai/test/model-manager-context-cap.test.ts
+++ b/packages/ai/test/model-manager-context-cap.test.ts
@@ -47,7 +47,7 @@ describe("model manager Codex GPT-5.6 cap", () => {
 			},
 			"online",
 		);
-		expect(result.models[0]?.contextWindow).toBe(272_000);
+		expect(result.models[0]?.contextWindow).toBe(372_000);
 	});
 
 	it("prefers a newly observed smaller live cap over stale larger cache metadata", async () => {

--- a/packages/ai/test/model-manager-context-cap.test.ts
+++ b/packages/ai/test/model-manager-context-cap.test.ts
@@ -50,7 +50,7 @@ describe("model manager Codex GPT-5.6 cap", () => {
 		expect(result.models[0]?.contextWindow).toBe(372_000);
 	});
 
-	it("prefers a newly observed smaller live cap over stale larger cache metadata", async () => {
+	it("forces the 372K window over stale larger cache metadata and smaller live observations", async () => {
 		const now = () => 1_800_000_000_000;
 		writeModelCache("openai-codex", now(), [codexModel(373_000)], true, "empty", cacheDbPath);
 		const result = await resolveProviderModels<Api>(
@@ -63,7 +63,7 @@ describe("model manager Codex GPT-5.6 cap", () => {
 			},
 			"online",
 		);
-		expect(result.models[0]?.contextWindow).toBe(200_000);
+		expect(result.models[0]?.contextWindow).toBe(372_000);
 	});
 
 	it("applies GPT-5.6 pricing to dynamically discovered models without a static entry", async () => {

--- a/packages/ai/test/model-manager-context-cap.test.ts
+++ b/packages/ai/test/model-manager-context-cap.test.ts
@@ -20,6 +20,13 @@ function codexModel(contextWindow: number): Model<Api> {
 		maxTokens: 128_000,
 	};
 }
+function codexTierModel(id: string, contextWindow: number): Model<Api> {
+	return {
+		...codexModel(contextWindow),
+		id,
+		name: id,
+	};
+}
 
 describe("model manager Codex GPT-5.6 cap", () => {
 	let cacheDir: string;
@@ -64,6 +71,20 @@ describe("model manager Codex GPT-5.6 cap", () => {
 			"online",
 		);
 		expect(result.models[0]?.contextWindow).toBe(372_000);
+	});
+	it("forces the 372K window for every tier id through the manager pipeline", async () => {
+		for (const id of ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] as const) {
+			const result = await resolveProviderModels<Api>(
+				{
+					providerId: "openai-codex",
+					staticModels: [],
+					cacheDbPath,
+					fetchDynamicModels: async () => [codexTierModel(id, 272_000)],
+				},
+				"online",
+			);
+			expect(result.models[0]?.contextWindow).toBe(372_000);
+		}
 	});
 
 	it("applies GPT-5.6 pricing to dynamically discovered models without a static entry", async () => {

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -562,6 +562,23 @@ describe("generated model policies", () => {
 		expect(models[0]?.applyPatchToolType).toBe("freeform");
 		expect(models[1]?.applyPatchToolType).toBe("freeform");
 	});
+
+	it("forces every GPT-5.6 tier id to 372K through generated policies regardless of observation", () => {
+		const models: Model<Api>[] = [];
+		for (const id of ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] as const) {
+			for (const contextWindow of [200_000, 272_000, 373_000, 1_050_000]) {
+				models.push({
+					...createModel({ id, api: "openai-codex-responses", provider: "openai-codex" }),
+					contextWindow,
+					maxTokens: 128000,
+				});
+			}
+		}
+		applyGeneratedModelPolicies(models);
+		for (const model of models) {
+			expect(model.contextWindow).toBe(372_000);
+		}
+	});
 });
 
 describe("model thinking runtime helpers", () => {

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -532,7 +532,7 @@ describe("generated model policies", () => {
 		}
 	});
 
-	it("caps only Codex product GPT-5.6 tiers at the 272K prompt budget", () => {
+	it("caps only Codex product GPT-5.6 tiers at the 372K prompt budget", () => {
 		const models: Model<Api>[] = [
 			{
 				...createModel({ id: "gpt-5.6-sol", api: "openai-codex-responses", provider: "openai-codex" }),
@@ -558,7 +558,7 @@ describe("generated model policies", () => {
 
 		applyGeneratedModelPolicies(models);
 
-		expect(models.map(model => model.contextWindow)).toEqual([272_000, 1_050_000, 200_000, 272_000]);
+		expect(models.map(model => model.contextWindow)).toEqual([372_000, 1_050_000, 200_000, 272_000]);
 		expect(models[0]?.applyPatchToolType).toBe("freeform");
 		expect(models[1]?.applyPatchToolType).toBe("freeform");
 	});

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -532,7 +532,7 @@ describe("generated model policies", () => {
 		}
 	});
 
-	it("caps only Codex product GPT-5.6 tiers at the 372K prompt budget", () => {
+	it("forces only Codex product GPT-5.6 tiers to the 372K prompt budget", () => {
 		const models: Model<Api>[] = [
 			{
 				...createModel({ id: "gpt-5.6-sol", api: "openai-codex-responses", provider: "openai-codex" }),
@@ -558,7 +558,7 @@ describe("generated model policies", () => {
 
 		applyGeneratedModelPolicies(models);
 
-		expect(models.map(model => model.contextWindow)).toEqual([372_000, 1_050_000, 200_000, 272_000]);
+		expect(models.map(model => model.contextWindow)).toEqual([372_000, 1_050_000, 372_000, 272_000]);
 		expect(models[0]?.applyPatchToolType).toBe("freeform");
 		expect(models[1]?.applyPatchToolType).toBe("freeform");
 	});

--- a/packages/ai/test/openai-codex-default.test.ts
+++ b/packages/ai/test/openai-codex-default.test.ts
@@ -21,4 +21,12 @@ describe("OpenAI Codex defaults", () => {
 		// safe request cap instead of promising a window that overflows upstream.
 		expect(model.contextWindow).toBe(272_000);
 	});
+
+	it("advertises the 372K prompt budget for bundled GPT-5.6 tiers", () => {
+		for (const id of ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
+			const model = getBundledModel("openai-codex", id);
+			expect(model.contextWindow).toBe(372_000);
+			expect(model.maxTokens).toBe(128_000);
+		}
+	});
 });

--- a/packages/ai/test/openai-codex-default.test.ts
+++ b/packages/ai/test/openai-codex-default.test.ts
@@ -27,6 +27,7 @@ describe("OpenAI Codex defaults", () => {
 			const model = getBundledModel("openai-codex", id);
 			expect(model.contextWindow).toBe(372_000);
 			expect(model.maxTokens).toBe(128_000);
+			expect(model.longContextPricing?.threshold).toBe(272_000);
 		}
 	});
 });


### PR DESCRIPTION
## Summary

Force-overrides the OpenAI Codex GPT-5.6 family context window (`gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) to **372K** tokens on the Codex product transport (provider `openai-codex` OR api `openai-codex-responses`), replacing the previously enforced 272K budget.

## Why "force" (not just a raised cap)

Verified with real OAuth credentials, live OpenAI code discovery still reports `context_window: 272000` for the GPT-5.6 tier. A raised cap with "smaller observations authoritative" semantics would therefore have been a functional no-op — the tier would stay at 272K everywhere. The brief asks for a force-override to 372K, so `CODEX_GPT_5_6_CONTEXT_CAP` is now a single enforced window (`{ enforced: 372_000 }`) applied as a **hard override** at all three layers:

- discovery: `resolveCodexGpt56DiscoveryContext`
- generated-catalog policy: `applyGpt56ContextWindow`
- final model-manager cap: `applyFinalCodexGpt56ContextCap`

Every observation (absent, 200K, 272K, 373K, 1.05M, invalid) resolves to 372K for the exact tier on the Codex transport.

## Scope isolation (unchanged for everything else)

- Non-5.6 Codex rows (`gpt-5.5`, `gpt-5.4-codex`, `gpt-5.6-codex`, GPT-5.4 mini/nano) keep the generic **272K** budget via the shared `CODEX_GENERIC_CONTEXT_WINDOW` (absent/invalid metadata falls back to 272K; live values pass through at discovery; generated policies pin them to 272K).
- First-party OpenAI (`openai`/`openai-responses`) is untouched (1.05M window preserved).
- The **272K long-context pricing threshold** and **128K maxTokens** are unchanged.
- The provider-or-API Codex transport predicate is the pre-existing deliberate contract; API-only custom transports are explicitly locked by tests.

## Bundled catalog and regeneration

The bundled `openai-codex` GPT-5.6 Sol/Terra/Luna entries advertise `contextWindow: 372000`. Canonical `bun run generate-models` was executed against the final source and reproduces exactly those entries (evidence: `.gjc/_session-019fdb09-f82f-7000-a6b6-e24b9a74ec7d/ultragoal/artifacts/regen-evidence.txt`). The remaining generator-vs-HEAD diff is pre-existing live-catalog drift (models.dev/provider catalogs moved since the last committed snapshot) and is intentionally not part of this PR.

## Files

- `packages/ai/src/context-cap-policy.ts` — `CODEX_GPT_5_6_CONTEXT_CAP.enforced = 372_000`; `CODEX_GENERIC_CONTEXT_WINDOW = 272_000`; hard override at discovery + final cap.
- `packages/ai/src/model-thinking.ts` — `applyGpt56ContextWindow` forces the enforced window; three literal 272K codex pins now use the shared constant.
- `packages/ai/src/models.json` — bundled openai-codex GPT-5.6 Sol/Terra/Luna `contextWindow: 372000` (matches canonical generator output).
- Tests: `context-cap-policy`, `codex-discovery-context-cap`, `model-manager-context-cap`, `model-thinking`, `openai-codex-default` — force matrix (all four tier ids x {absent, 200K, 272K, 373K, 1.05M, invalid}), tier/transport scoping, non-5.6 generic fallback, bundled 372K/128K/272K-threshold lock.
- `docs/multi-vendor-profiles.md`, `packages/ai/CHANGELOG.md` — 372K cap documented.

## Verification

- Targeted suites: **59 pass / 0 fail** (332 expectations) across the 7 affected files.
- Red-team boundary probe: **261/261 PASS** (tier matching incl. case-insensitivity, transport isolation, invalid metadata, non-5.6 isolation, first-party isolation, stale-cache forcing, custom-policy scoping) — artifacts: `suite.log`, `boundary-report.json`, `probe.log` in the ultragoal artifacts dir.
- Runtime probe: bundled `openai-codex/gpt-5.6-sol` → 372000; discovery absent/272K/373K → 372000; final cap 272K/200K → 372000; non-tier absent → 272000; first-party `openai/gpt-5.6-terra` → 1050000.
- `biome check` clean on changed files.
- Full `packages/ai` suite: 2225 pass, 5 pre-existing env-dependent failures (OPENAI_BASE_URL leaking from the local shell env; confirmed identical with this change stashed).