### PR TITLE
fix(tui): compact oversized Bash commands

### DIFF
--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@gajae-code/agent-core";
 import type { Component } from "@gajae-code/tui";
-import { ImageProtocol, TERMINAL, Text } from "@gajae-code/tui";
+import { getKeybindings, ImageProtocol, TERMINAL, Text, visibleWidth } from "@gajae-code/tui";
 import { getProjectDir, isEnoent, logger, prompt } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import { AsyncJobManager } from "../async";
@@ -32,7 +32,8 @@ import {
 } from "../session/streaming-output";
 
 import { renderStatusLine } from "../tui";
-import { CachedOutputBlock } from "../tui/output-block";
+import { CachedOutputBlock, getOutputBlockContentWidth } from "../tui/output-block";
+import { truncateToWidth } from "../tui/utils";
 import { getSixelLineMask } from "../utils/sixel";
 import type { ToolSession } from ".";
 import { checkBashAllowedPrefixes, normalizeReadOnlyBashCommand } from "./bash-allowed-prefixes";
@@ -1635,6 +1636,7 @@ export interface ShellRendererConfig<TArgs> {
 	resolveCommand?: (args: TArgs | undefined) => string | undefined;
 	resolveCwd?: (args: TArgs | undefined) => string | undefined;
 	resolveEnv?: (args: TArgs | undefined) => Record<string, string> | undefined;
+	compactCommand?: boolean;
 }
 
 function getPartialJson<TArgs>(args: TArgs | undefined): string | undefined {
@@ -1682,6 +1684,85 @@ export function formatBashCommandLines(args: BashRenderArgs, uiTheme: Theme): st
 	return highlightedLines.map((line, i) => (i === 0 ? `${prefix}${line}` : line));
 }
 
+const BASH_COLLAPSED_COMMAND_MAX_VISUAL_ROWS = 5;
+const BASH_COMMAND_SENTINEL_MAX_VISUAL_ROWS = 3;
+
+interface BashCommandProjection {
+	lines: string[];
+}
+
+function resolveBashExpandKeyLabel(): string | undefined {
+	return getKeybindings().getKeys("app.tools.expand")[0];
+}
+
+function formatBashExpandActionHint(maxWidth?: number): string {
+	const keyLabel = resolveBashExpandKeyLabel();
+	const actionHint = keyLabel ? `${keyLabel} to expand` : "expand tools";
+	return maxWidth !== undefined && visibleWidth(actionHint) > Math.max(1, maxWidth) ? "expand tools" : actionHint;
+}
+
+function renderBashCommandProjection(
+	commandLines: string[],
+	width: number,
+	expanded: boolean,
+	actionHint: string,
+	uiTheme: Theme,
+): BashCommandProjection {
+	const renderWidth = Math.max(1, width);
+	const visualLines = new Text(commandLines.join("\n"), 0, 0).render(renderWidth);
+	if (expanded || visualLines.length <= BASH_COLLAPSED_COMMAND_MAX_VISUAL_ROWS) {
+		return { lines: visualLines };
+	}
+
+	const retained = visualLines.slice(0, BASH_COLLAPSED_COMMAND_MAX_VISUAL_ROWS);
+	const omittedVisualRows = visualLines.length - retained.length;
+	let sentinel = new Text(
+		uiTheme.fg("dim", `… ${omittedVisualRows} command rows omitted\n${actionHint}`),
+		0,
+		0,
+	).render(renderWidth);
+
+	if (sentinel.length > BASH_COMMAND_SENTINEL_MAX_VISUAL_ROWS) {
+		sentinel = new Text(uiTheme.fg("dim", `… ${omittedVisualRows} rows omitted\nexpand tools`), 0, 0).render(
+			renderWidth,
+		);
+	}
+	if (sentinel.length > BASH_COMMAND_SENTINEL_MAX_VISUAL_ROWS) {
+		sentinel = [
+			uiTheme.fg("dim", truncateToWidth(`… +${omittedVisualRows}`, renderWidth)),
+			uiTheme.fg("dim", truncateToWidth("expand tools", renderWidth)),
+		];
+	}
+
+	return { lines: [...retained, ...sentinel] };
+}
+
+function createBashCommandProjector(commandLines: string[], uiTheme: Theme) {
+	let cached:
+		| {
+				width: number;
+				expanded: boolean;
+				actionHint: string;
+				projection: BashCommandProjection;
+		  }
+		| undefined;
+
+	return {
+		render(width: number, expanded: boolean): BashCommandProjection {
+			const actionHint = formatBashExpandActionHint(width);
+			if (cached?.width === width && cached.expanded === expanded && cached.actionHint === actionHint) {
+				return cached.projection;
+			}
+			const projection = renderBashCommandProjection(commandLines, width, expanded, actionHint, uiTheme);
+			cached = { width, expanded, actionHint, projection };
+			return projection;
+		},
+		invalidate(): void {
+			cached = undefined;
+		},
+	};
+}
+
 function toBashRenderArgs<TArgs>(args: TArgs | undefined, config: ShellRendererConfig<TArgs>): BashRenderArgs {
 	return {
 		command: config.resolveCommand?.(args),
@@ -1695,10 +1776,23 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 	return {
 		renderCall(args: TArgs, options: RenderResultOptions, uiTheme: Theme): Component {
 			const renderArgs = toBashRenderArgs(args, config);
-			const cmdText = formatBashCommand(renderArgs);
 			const title = config.resolveTitle(args, options);
-			const text = renderStatusLine({ icon: "pending", title, description: cmdText }, uiTheme);
-			return new Text(text, 0, 0);
+			if (!config.compactCommand) {
+				const cmdText = formatBashCommand(renderArgs);
+				const text = renderStatusLine({ icon: "pending", title, description: cmdText }, uiTheme);
+				return new Text(text, 0, 0);
+			}
+
+			const header = renderStatusLine({ icon: "pending", title }, uiTheme);
+			const projectCommand = createBashCommandProjector(formatBashCommandLines(renderArgs, uiTheme), uiTheme);
+			const renderOptions = options as RenderResultOptions & { renderContext?: BashRenderContext };
+			return {
+				render: (width: number): string[] => {
+					const expanded = renderOptions.renderContext?.expanded ?? renderOptions.expanded;
+					return [header, ...projectCommand.render(width, expanded).lines];
+				},
+				invalidate: () => projectCommand.invalidate(),
+			};
 		},
 
 		renderResult(
@@ -1713,6 +1807,8 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 		): Component {
 			const renderArgs = toBashRenderArgs(args, config);
 			const cmdLines = args ? formatBashCommandLines(renderArgs, uiTheme) : undefined;
+			const projectCommand =
+				config.compactCommand && cmdLines ? createBashCommandProjector(cmdLines, uiTheme) : undefined;
 			const isError = result.isError === true;
 			const icon = options.isPartial ? "pending" : isError ? "error" : "success";
 			const title = config.resolveTitle(args, options);
@@ -1726,6 +1822,10 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 					const { renderContext } = options;
 					const expanded = renderContext?.expanded ?? options.expanded;
 					const previewLines = renderContext?.previewLines ?? BASH_DEFAULT_PREVIEW_LINES;
+					const commandLines =
+						cmdLines && projectCommand
+							? projectCommand.render(getOutputBlockContentWidth(width, uiTheme), expanded).lines
+							: (cmdLines ?? []);
 
 					// Get output from context (preferred) or fall back to result content.
 					// Strip the LLM-facing notice appended by wrappedExecute so we don't
@@ -1778,7 +1878,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 								outputLines.push(
 									uiTheme.fg(
 										"dim",
-										`… (${result.skippedCount} earlier lines, showing ${result.visualLines.length} of ${result.skippedCount + result.visualLines.length}) (ctrl+o to expand)`,
+										`… (${result.skippedCount} earlier lines, showing ${result.visualLines.length} of ${result.skippedCount + result.visualLines.length}) (${formatBashExpandActionHint(getOutputBlockContentWidth(width, uiTheme))})`,
 									),
 								);
 							}
@@ -1793,7 +1893,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 							header,
 							state: options.isPartial ? "pending" : isError ? "error" : "success",
 							sections: [
-								{ lines: cmdLines ?? [] },
+								{ lines: commandLines },
 								{ label: uiTheme.fg("toolTitle", "Output"), lines: outputLines },
 							],
 							width,
@@ -1803,6 +1903,7 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 				},
 				invalidate: () => {
 					outputBlock.invalidate();
+					projectCommand?.invalidate();
 				},
 			};
 		},
@@ -1816,4 +1917,5 @@ export const bashToolRenderer = createShellRenderer<BashRenderArgs>({
 	resolveCommand: args => args?.command,
 	resolveCwd: args => args?.cwd,
 	resolveEnv: args => args?.env,
+	compactCommand: true,
 });

--- a/packages/coding-agent/src/tui/output-block.ts
+++ b/packages/coding-agent/src/tui/output-block.ts
@@ -23,6 +23,16 @@ export interface OutputBlockOptions {
 	width: number;
 	applyBg?: boolean;
 }
+/**
+ * Return the width available to section content after the output block's
+ * visible left and right borders. Keep callers on the same layout contract as
+ * renderOutputBlock so width-aware projections are not wrapped a second time.
+ */
+export function getOutputBlockContentWidth(width: number, theme: Theme): number {
+	const lineWidth = Math.max(0, width);
+	const borderWidth = visibleWidth(`${theme.boxSharp.vertical} `) + visibleWidth(theme.boxSharp.vertical);
+	return Math.max(0, lineWidth - borderWidth);
+}
 
 export function renderOutputBlock(options: OutputBlockOptions, theme: Theme): string[] {
 	const { header, headerMeta, state, sections = [], width, applyBg = true } = options;
@@ -70,7 +80,7 @@ export function renderOutputBlock(options: OutputBlockOptions, theme: Theme): st
 
 	const contentPrefix = border(`${v} `);
 	const contentSuffix = border(v);
-	const contentWidth = Math.max(0, lineWidth - visibleWidth(contentPrefix) - visibleWidth(contentSuffix));
+	const contentWidth = getOutputBlockContentWidth(lineWidth, theme);
 	const lines: string[] = [];
 
 	lines.push(

--- a/packages/coding-agent/test/tools/bash-sixel-render.test.ts
+++ b/packages/coding-agent/test/tools/bash-sixel-render.test.ts
@@ -1,12 +1,14 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { RenderResultOptions } from "@gajae-code/agent-core";
+import { KeybindingsManager } from "@gajae-code/coding-agent/config/keybindings";
 import { type IrcSidebarTheme, IrcSplitViewComponent } from "@gajae-code/coding-agent/modes/components/irc-sidebar";
 import { IrcObservationLedger } from "@gajae-code/coding-agent/modes/irc-observation-ledger";
 import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
 import { bashToolRenderer } from "@gajae-code/coding-agent/tools/bash";
-import { ImageProtocol, TERMINAL } from "@gajae-code/tui";
+import { getOutputBlockContentWidth } from "@gajae-code/coding-agent/tui/output-block";
+import { getKeybindings, ImageProtocol, setKeybindings, TERMINAL, visibleWidth } from "@gajae-code/tui";
 import { sanitizeText } from "@gajae-code/utils";
 
 type MutableTerminalInfo = {
@@ -23,9 +25,16 @@ const sidebarTheme = {
 
 describe("bashToolRenderer", () => {
 	const originalProtocol = TERMINAL.imageProtocol;
+	let originalKeybindings: ReturnType<typeof getKeybindings>;
+
+	beforeEach(() => {
+		originalKeybindings = getKeybindings();
+		setKeybindings(KeybindingsManager.inMemory());
+	});
 
 	afterEach(() => {
 		terminal.imageProtocol = originalProtocol;
+		setKeybindings(originalKeybindings);
 	});
 
 	it("shows rendered env assignments in the command preview", async () => {
@@ -75,6 +84,120 @@ describe("bashToolRenderer", () => {
 		expect(rendered).toContain("~/projects/demo");
 		expect(rendered).not.toContain(os.homedir());
 		expect(rendered).not.toContain("\t");
+	});
+
+	it("bounds pending commands to five visual rows and expands inline", async () => {
+		const uiTheme = await getThemeByName("red-claw");
+		expect(uiTheme).toBeDefined();
+		const options = {
+			expanded: false,
+			isPartial: true,
+			renderContext: { expanded: false },
+		};
+		const command = Array.from({ length: 12 }, (_, index) => `echo line-${index}`).join("\n");
+		const component = bashToolRenderer.renderCall({ command }, options, uiTheme!);
+
+		const collapsed = component.render(40).map(line => sanitizeText(line));
+		expect(collapsed).toContainEqual(expect.stringContaining("line-0"));
+		expect(collapsed).toContainEqual(expect.stringContaining("line-4"));
+		expect(collapsed).not.toContainEqual(expect.stringContaining("line-5"));
+		expect(collapsed).toContainEqual(expect.stringContaining("7 command rows omitted"));
+		expect(collapsed).toContainEqual(expect.stringContaining("ctrl+o to expand"));
+		expect(collapsed.length).toBeLessThanOrEqual(1 + 5 + 3);
+		for (const line of component.render(40)) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(40);
+		}
+
+		options.renderContext.expanded = true;
+		const expanded = component.render(40).map(line => sanitizeText(line));
+		expect(expanded).toContainEqual(expect.stringContaining("line-11"));
+		expect(expanded).not.toContainEqual(expect.stringContaining("command rows omitted"));
+	});
+
+	it("bounds completed commands at the output block content width", async () => {
+		const uiTheme = await getThemeByName("red-claw");
+		expect(uiTheme).toBeDefined();
+		const command = Array.from({ length: 12 }, (_, index) => `echo line-${index}`).join("\n");
+		const component = bashToolRenderer.renderResult(
+			{
+				content: [
+					{
+						type: "text",
+						text: Array.from({ length: 12 }, (_, index) => `output-${index}`).join("\n"),
+					},
+				],
+				details: {},
+				isError: false,
+			},
+			{ expanded: false, isPartial: false },
+			uiTheme!,
+			{ command },
+		);
+
+		const rendered = component.render(20);
+		const sanitized = rendered.map(line => sanitizeText(line));
+		expect(sanitized).toContainEqual(expect.stringContaining("line-0"));
+		expect(sanitized).not.toContainEqual(expect.stringContaining("line-5"));
+		expect(sanitized).toContainEqual(expect.stringContaining("command rows"));
+		expect(sanitized).toContainEqual(expect.stringContaining("omitted"));
+		expect(sanitized).toContainEqual(expect.stringContaining("ctrl+o to expand"));
+		for (const line of rendered) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(20);
+		}
+
+		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": "ctrl+x" }));
+		const remapped = component
+			.render(80)
+			.map(line => sanitizeText(line))
+			.join("\n");
+		expect(remapped).not.toContain("ctrl+o to expand");
+		expect(remapped.match(/ctrl\+x to expand/g)).toHaveLength(2);
+
+		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": "ctrl+shift+alt+x" }));
+		const fallback = component.render(20).map(line => sanitizeText(line));
+		expect(fallback).toContainEqual(expect.stringContaining("expand tools"));
+		expect(fallback).not.toContainEqual(expect.stringContaining("ctrl+shift+alt+x"));
+	});
+
+	it("updates the collapsed hint when the expand binding changes", async () => {
+		const uiTheme = await getThemeByName("red-claw");
+		expect(uiTheme).toBeDefined();
+		const command = Array.from({ length: 8 }, (_, index) => `echo line-${index}`).join("\n");
+		const component = bashToolRenderer.renderCall({ command }, { expanded: false, isPartial: true }, uiTheme!);
+
+		expect(sanitizeText(component.render(40).join("\n"))).toContain("ctrl+o to expand");
+		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": "ctrl+x" }));
+		const remapped = sanitizeText(component.render(40).join("\n"));
+		expect(remapped).toContain("ctrl+x to expand");
+		expect(remapped).not.toContain("ctrl+o to expand");
+
+		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": [] }));
+		const unbound = sanitizeText(component.render(40).join("\n"));
+		expect(unbound).toContain("expand tools");
+		expect(unbound).not.toContain("ctrl+x to expand");
+	});
+
+	it("keeps the omission sentinel bounded at narrow widths", async () => {
+		const uiTheme = await getThemeByName("red-claw");
+		expect(uiTheme).toBeDefined();
+		setKeybindings(KeybindingsManager.inMemory({ "app.tools.expand": "ctrl+shift+alt+x" }));
+		const command = Array.from({ length: 12 }, (_, index) => `echo line-${index}`).join("\n");
+		const component = bashToolRenderer.renderCall({ command }, { expanded: false, isPartial: true }, uiTheme!);
+
+		for (const width of [1, 16]) {
+			const commandAndSentinel = component.render(width).slice(1);
+			expect(commandAndSentinel.length).toBeLessThanOrEqual(5 + 3);
+			for (const line of commandAndSentinel) {
+				expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+			}
+		}
+	});
+
+	it("exposes the output block's actual section width", async () => {
+		const uiTheme = await getThemeByName("red-claw");
+		expect(uiTheme).toBeDefined();
+		expect(getOutputBlockContentWidth(0, uiTheme!)).toBe(0);
+		expect(getOutputBlockContentWidth(20, uiTheme!)).toBe(17);
 	});
 
 	it("shows the effective timeout from result details when it differs from call args", async () => {


### PR DESCRIPTION
## Summary

- cap collapsed Bash command previews at five visual rows in both pending and completed states
- show an exact omitted-row sentinel with the effective `app.tools.expand` binding, including remapped/unbound/overlong fallbacks
- preserve full inline expansion, canonical command data, Bash output behavior, and Recipe rendering
- share the output block's real content-width calculation so wrapping is counted at the final layout boundary

## UX precedent

- Claude Code keeps detailed tool usage in a transcript view toggled with Ctrl+O: https://code.claude.com/docs/en/interactive-mode
- Codex limits tool-call previews and preserves full transcript lines separately: https://github.com/openai/codex/blob/main/codex-rs/tui/src/exec_cell/render.rs

## Verification

- `bun test packages/coding-agent/test/tools/bash-sixel-render.test.ts packages/coding-agent/test/visual-truncate.test.ts` — 15 passed, 113 assertions
- `bun test packages/coding-agent/test/modes/components` — 193 passed, 6022 assertions
- `bun --cwd=packages/coding-agent run check:types`
- `bun --cwd=packages/coding-agent run check:runtime`
- `bunx biome check packages/coding-agent/src/tools/bash.ts packages/coding-agent/src/tui/output-block.ts packages/coding-agent/test/tools/bash-sixel-render.test.ts`
- `git diff --check`

A PTY render check also confirmed five retained command rows, the exact omission count, remapped `ctrl+x` hints for both command and output truncation, and normal output coexistence.