### PR TITLE
fix(tui): support image paste shortcuts across layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ cd ../my-task-worktree && gjc --tmux
 GJC accepts images in two ways:
 
 - **CLI startup**: prefix a local image path with `@`, for example `gjc @screenshot.png "What should I change?"`.
-- **Interactive TUI**: copy an image to the system clipboard and use the configured **Paste image from clipboard** key (Ctrl+V on Linux/macOS, Alt+V on Windows), or type `#paste-image` and choose the prompt action. When the clipboard is unavailable, paste or pass the image file path with `@path/to/image.png` instead.
+- **Interactive TUI**: copy an image to the system clipboard and use the configured **Paste image from clipboard** key (Command+V or Ctrl+V on macOS, Ctrl+V on Linux, Ctrl+V or Alt+V on Windows), or type `#paste-image` and choose the prompt action. Korean Dubeolsik input is normalized to the corresponding shortcut when a terminal reports modified keys through the Kitty keyboard protocol, even if it omits base-layout metadata. When the clipboard is unavailable, paste or pass the image file path with `@path/to/image.png` instead.
 
 Type `#` in the interactive editor to open prompt actions. In a tmux-backed session, choose **Scroll to previous user input** (for example via `#prev`) to enter tmux copy-mode at the previous rendered user message.
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -156,7 +156,7 @@ Authoritative inventory of the keybinding registry, one row per action. Generate
 | `app.message.followUp` | _(none)_ | composer |
 | `app.message.queue` | alt+q (darwin/win32) / alt+enter (linux) | composer |
 | `app.message.dequeue` | alt+up, alt+down | composer |
-| `app.clipboard.pasteImage` | ctrl+v (darwin/linux) / alt+v (win32) | composer |
+| `app.clipboard.pasteImage` | super+v, ctrl+v (darwin) / ctrl+v, alt+v (win32) / ctrl+v (linux) | composer |
 | `app.clipboard.copyLine` | alt+shift+l | composer |
 | `app.clipboard.copyPrompt` | alt+shift+c | composer |
 | `app.session.new` | ctrl+n | composer |

--- a/packages/coding-agent/scripts/generate-hotkeys-docs.ts
+++ b/packages/coding-agent/scripts/generate-hotkeys-docs.ts
@@ -19,16 +19,18 @@ function defaultKeys(
 	bindingId: keyof typeof KEYBINDINGS,
 ): string {
 	const defaultsByPlatform = DOCUMENTATION_PLATFORMS.map(platform => {
+		let keys: string | readonly string[];
 		switch (bindingId) {
 			case "app.message.queue":
-				return defaultMessageQueueKeysForPlatform(platform);
+				keys = defaultMessageQueueKeysForPlatform(platform);
+				break;
 			case "app.clipboard.pasteImage":
-				return defaultClipboardPasteImageKeysForPlatform(platform);
-			default: {
-				const keys = value.defaultKeys;
-				return (Array.isArray(keys) ? keys : [keys]).join(", ") || "_(none)_";
-			}
+				keys = defaultClipboardPasteImageKeysForPlatform(platform);
+				break;
+			default:
+				keys = value.defaultKeys;
 		}
+		return (typeof keys === "string" ? keys : keys.join(", ")) || "_(none)_";
 	});
 	const groups = new Map<string, string[]>();
 	for (const [index, keys] of defaultsByPlatform.entries()) {

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -74,8 +74,10 @@ export function defaultMessageQueueKeysForPlatform(platform: NodeJS.Platform = p
 	return platform === "win32" || platform === "darwin" ? "alt+q" : "alt+enter";
 }
 
-export function defaultClipboardPasteImageKeysForPlatform(platform: NodeJS.Platform = process.platform): KeyId {
-	return platform === "win32" ? "alt+v" : "ctrl+v";
+export function defaultClipboardPasteImageKeysForPlatform(platform: NodeJS.Platform = process.platform): KeyId[] {
+	if (platform === "darwin") return ["super+v", "ctrl+v"];
+	if (platform === "win32") return ["ctrl+v", "alt+v"];
+	return ["ctrl+v"];
 }
 
 /**

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import { type AutocompleteProvider, parseKey } from "@gajae-code/tui";
+import { type AutocompleteProvider, parseKey, setKittyProtocolActive } from "@gajae-code/tui";
 import { defaultEditorTheme } from "../../tui/test/test-themes";
-import { defaultMessageQueueKeysForPlatform, KEYBINDINGS } from "../src/config/keybindings";
+import {
+	defaultClipboardPasteImageKeysForPlatform,
+	defaultMessageQueueKeysForPlatform,
+	KEYBINDINGS,
+} from "../src/config/keybindings";
 import { CustomEditor } from "../src/modes/components/custom-editor";
 
 function ctrl(key: string): string {
@@ -25,6 +29,7 @@ function createEditor() {
 
 afterEach(() => {
 	vi.useRealTimers();
+	setKittyProtocolActive(false);
 });
 
 describe("CustomEditor command palette keybinding", () => {
@@ -295,19 +300,41 @@ describe("CustomEditor viewport paging", () => {
 	});
 });
 
-describe("CustomEditor pasteImage default sourced from KEYBINDINGS", () => {
-	it("intercepts the registry's platform-aware pasteImage default (single source of truth)", () => {
+describe("CustomEditor pasteImage platform defaults", () => {
+	it.each([
+		["darwin", "super+v", "\x1b[118;9u"],
+		["darwin", "ctrl+v", ctrl("v")],
+		["win32", "ctrl+v", ctrl("v")],
+		["win32", "alt+v", "\x1bv"],
+	] as const)("intercepts %s %s as image paste", (platform, _key, data) => {
 		const editor = createEditor();
 		const onPasteImage = vi.fn();
 		editor.onPasteImage = onPasteImage;
-
-		const def = KEYBINDINGS["app.clipboard.pasteImage"].defaultKeys;
-		const key = Array.isArray(def) ? def[0]! : def;
-		// ctrl+v on most platforms, alt+v on win32 — both come from the registry now.
-		const data = key === "alt+v" ? "\x1bv" : ctrl("v");
+		editor.setActionKeys("app.clipboard.pasteImage", defaultClipboardPasteImageKeysForPlatform(platform));
+		setKittyProtocolActive(data.startsWith("\x1b["));
 
 		editor.handleInput(data);
+
 		expect(onPasteImage).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).toBe("");
+	});
+
+	it.each([
+		["darwin", "super+v", "\x1b[12621;9u"],
+		["darwin", "ctrl+v", "\x1b[12621;5u"],
+		["win32", "ctrl+v", "\x1b[12621;5u"],
+		["win32", "alt+v", "\x1b[12621;3u"],
+	] as const)("maps the Korean Dubeolsik V key for %s %s", (platform, _key, data) => {
+		const editor = createEditor();
+		const onPasteImage = vi.fn();
+		editor.onPasteImage = onPasteImage;
+		editor.setActionKeys("app.clipboard.pasteImage", defaultClipboardPasteImageKeysForPlatform(platform));
+		setKittyProtocolActive(true);
+
+		editor.handleInput(data);
+
+		expect(onPasteImage).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).toBe("");
 	});
 });
 

--- a/packages/coding-agent/test/keybindings-audit.test.ts
+++ b/packages/coding-agent/test/keybindings-audit.test.ts
@@ -63,18 +63,20 @@ describe("Windows-to-Darwin declared default parity", () => {
 		});
 		expect(WINDOWS_RUNTIME_SHORTCUTS.find(({ id }) => id === "app.clipboard.pasteImage")).toEqual({
 			id: "app.clipboard.pasteImage",
-			windows: ["alt+v"],
-			darwin: ["ctrl+v"],
+			windows: ["ctrl+v", "alt+v"],
+			darwin: ["super+v", "ctrl+v"],
 		});
 		expect(formatKeyHint("alt+q", { platform: "darwin" })).toBe("⌥Q");
 		expect(formatAccessibleKeyHint("alt+q", { platform: "darwin" })).toBe("⌥Q (Option+Q)");
+		expect(formatKeyHint("super+v", { platform: "darwin" })).toBe("⌘V");
+		expect(formatAccessibleKeyHint("super+v", { platform: "darwin" })).toBe("⌘V (Command+V)");
 		expect(formatKeyHint("ctrl+v", { platform: "darwin" })).toBe("⌃V");
 		expect(formatAccessibleKeyHint("ctrl+v", { platform: "darwin" })).toBe("⌃V (Control+V)");
 		expect(WINDOWS_RUNTIME_SHORTCUTS.filter(({ windows, darwin }) => windows.join() !== darwin.join())).toEqual([
 			{
 				id: "app.clipboard.pasteImage",
-				windows: ["alt+v"],
-				darwin: ["ctrl+v"],
+				windows: ["ctrl+v", "alt+v"],
+				darwin: ["super+v", "ctrl+v"],
 			},
 		]);
 	});

--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -422,6 +422,73 @@ const KITTY_MOD_CTRL = 4;
 const KITTY_MOD_SUPER = 8;
 const KITTY_MOD_NUM_LOCK = 128;
 const KITTY_LOCK_MASK = 64 + 128; // Caps Lock + Num Lock
+const KOREAN_DUBEOLSIK_BASE_KEYS = new Map<number, BaseKey>(
+	[
+		["ㄱ", "r"],
+		["ㄲ", "r"],
+		["ㄴ", "s"],
+		["ㄷ", "e"],
+		["ㄸ", "e"],
+		["ㄹ", "f"],
+		["ㅁ", "a"],
+		["ㅂ", "q"],
+		["ㅃ", "q"],
+		["ㅅ", "t"],
+		["ㅆ", "t"],
+		["ㅇ", "d"],
+		["ㅈ", "w"],
+		["ㅉ", "w"],
+		["ㅊ", "c"],
+		["ㅋ", "z"],
+		["ㅌ", "x"],
+		["ㅍ", "v"],
+		["ㅎ", "g"],
+		["ㅏ", "k"],
+		["ㅐ", "o"],
+		["ㅑ", "i"],
+		["ㅒ", "o"],
+		["ㅓ", "j"],
+		["ㅔ", "p"],
+		["ㅕ", "u"],
+		["ㅖ", "p"],
+		["ㅗ", "h"],
+		["ㅛ", "y"],
+		["ㅜ", "n"],
+		["ㅠ", "b"],
+		["ㅡ", "m"],
+		["ㅣ", "l"],
+	].map(([character, key]) => [character.codePointAt(0)!, key as BaseKey]),
+);
+
+function matchesKoreanDubeolsikKittySequence(data: string, keyId: KeyId): boolean {
+	const event = parseKittySequence(data);
+	if (!event || event.eventType === 3 || event.baseLayoutKey !== undefined) return false;
+
+	const baseKey = KOREAN_DUBEOLSIK_BASE_KEYS.get(event.codepoint);
+	if (!baseKey) return false;
+
+	const expected = parseKeyId(keyId);
+	if (!expected || expected.modifiers.length === 0 || expected.baseKey !== baseKey) return false;
+
+	let expectedModifier = 0;
+	for (const modifier of expected.modifiers) {
+		switch (modifier) {
+			case "shift":
+				expectedModifier |= KITTY_MOD_SHIFT;
+				break;
+			case "alt":
+				expectedModifier |= KITTY_MOD_ALT;
+				break;
+			case "ctrl":
+				expectedModifier |= KITTY_MOD_CTRL;
+				break;
+			case "super":
+				expectedModifier |= KITTY_MOD_SUPER;
+				break;
+		}
+	}
+	return (event.modifier & ~KITTY_LOCK_MASK) === expectedModifier;
+}
 const MODIFY_OTHER_KEYS_PATTERN = /^\x1b\[27;(\d+);(\d+)~$/;
 const KITTY_KEYPAD_OPERATOR_TEXT: Record<number, string> = {
 	57410: "/",
@@ -638,7 +705,10 @@ export function decodePrintableKey(data: string): string | undefined {
  * @param keyId - Key identifier (e.g., "ctrl+c", "escape", Key.ctrl("c"))
  */
 export function matchesKey(data: string, keyId: KeyId): boolean {
-	return matchesKeyNative(data, keyId, kittyProtocolActive);
+	return (
+		matchesKeyNative(data, keyId, kittyProtocolActive) ||
+		(kittyProtocolActive && matchesKoreanDubeolsikKittySequence(data, keyId))
+	);
 }
 
 /**

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -39,6 +39,16 @@ describe("matchesKey", () => {
 		expect(matchesKey(dvorakCtrlK, "ctrl+v")).toBe(false);
 		setKittyProtocolActive(false);
 	});
+	it("matches modified Korean Dubeolsik keys when Kitty omits the base-layout key", () => {
+		setKittyProtocolActive(true);
+		expect(matchesKey("\x1b[12621;5u", "ctrl+v")).toBe(true);
+		expect(matchesKey("\x1b[12621;9u", "super+v")).toBe(true);
+		expect(matchesKey("\x1b[12621;3u", "alt+v")).toBe(true);
+		expect(matchesKey("\x1b[12621u", "v")).toBe(false);
+		expect(matchesKey("\x1b[12621;5u", "ctrl+b")).toBe(false);
+		expect(matchesKey("\x1b[12621;5:3u", "ctrl+v")).toBe(false);
+		setKittyProtocolActive(false);
+	});
 
 	it("should prefer codepoint for symbol keys even when base layout differs", () => {
 		setKittyProtocolActive(true);


### PR DESCRIPTION
## Summary
- bind image paste to Command+V and Ctrl+V on macOS
- bind image paste to Ctrl+V and Alt+V on Windows while keeping Ctrl+V on Linux
- normalize modified Korean Dubeolsik Kitty key events when terminals omit base-layout metadata
- update generated shortcut docs and interactive image guidance

## Verification
- `bun test test/keys.test.ts` in `packages/tui` (54 passed)
- `bun run check:types` in `packages/tui`
- `bun test test/keybindings-audit.test.ts test/custom-editor-keybindings.test.ts test/prompt-action-autocomplete.test.ts` in `packages/coding-agent` (57 passed)
- `bun run check:types` in `packages/coding-agent`
- `bun run generate-hotkeys-docs --check`
- Biome checks for all changed TypeScript files

## Notes
Command+V can be handled directly when the terminal forwards Super-modified Kitty events; terminal-native bracketed paste behavior remains intact when the terminal owns Command+V.