### PR TITLE
fix: preserve shell mode during prompt submission

### DIFF
--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -771,6 +771,8 @@ export class InputController {
 
 	async submitText(text: string, composer: ComposerSubmissionOptions): Promise<void> {
 		text = text.trim();
+		const submittedBashMode = this.ctx.isBashMode;
+		const submittedBashNoContext = this.ctx.isBashNoContext;
 		if ((!isSettingsInitialized() || settings.get("emojiAutocomplete")) && text) text = expandEmoticons(text);
 		if (this.ctx.hasActiveBtw()) {
 			if (!text) return;
@@ -873,19 +875,32 @@ export class InputController {
 		}
 
 		// Handle bash command (! for normal, !! for excluded from context)
-		if (text.startsWith("!")) {
-			const isExcluded = text.startsWith("!!");
-			const command = isExcluded ? text.slice(2).trim() : text.slice(1).trim();
+		const hasExplicitShellPrefix = text.startsWith("!");
+		const hasExplicitNoContextPrefix = text.startsWith("!!");
+		const shellMode = submittedBashMode || hasExplicitShellPrefix;
+		if (shellMode) {
+			const isExcluded = hasExplicitNoContextPrefix || (!hasExplicitShellPrefix && submittedBashNoContext);
+			const command = hasExplicitNoContextPrefix
+				? text.slice(2).trim()
+				: hasExplicitShellPrefix
+					? text.slice(1).trim()
+					: text.trim();
+			const historyText = hasExplicitShellPrefix ? text : `${isExcluded ? "!!" : "!"}${text}`;
 			if (command) {
 				if (this.ctx.session.isBashRunning) {
 					this.ctx.showWarning("A bash command is already running. Press Esc to cancel it first.");
 					if (this.#canModifyComposer(composer)) {
+						const isBashMode = hasExplicitShellPrefix || submittedBashMode;
+						const isBashNoContext = hasExplicitShellPrefix ? hasExplicitNoContextPrefix : submittedBashNoContext;
 						this.ctx.editor.setText(text);
+						this.ctx.isBashMode = isBashMode;
+						this.ctx.isBashNoContext = isBashNoContext;
+						this.ctx.updateEditorBorderColor();
 					}
 					return;
 				}
 				if (this.#canModifyComposer(composer)) {
-					this.ctx.editor.addToHistory(text);
+					this.ctx.editor.addToHistory(historyText);
 				}
 				await this.ctx.handleBashCommand(command, isExcluded);
 				this.ctx.isBashMode = false;
@@ -1759,9 +1774,8 @@ export class InputController {
 		if (this.ctx.pendingImages.length === 0 || IMAGE_PLACEHOLDER_PRESENT_PATTERN.test(text)) {
 			return;
 		}
-		// Editor submit resets the composer and emits onChange("") before onSubmit(result).
-		// Defer the empty-buffer clear so the submit handler can still resolve image
-		// placeholders against pendingImages, while manual clears still drop stale images.
+		// Editor clears its internal buffer before invoking onSubmit and emits
+		// onChange("") afterward; defer the empty-buffer clear for that callback.
 		if (text.length === 0) {
 			const pendingImages = this.ctx.pendingImages;
 			const pendingImageCount = pendingImages.length;

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -1359,4 +1359,43 @@ describe("InputController shell mode cues", () => {
 		expect(ctx.isBashMode).toBe(false);
 		expect(ctx.isBashNoContext).toBe(false);
 	});
+
+	it("executes a command typed after entering shell mode", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		controller.setupEditorSubmitHandler();
+		ctx.isBashMode = true;
+		await editor.onSubmit?.("pwd");
+
+		expect(spies.handleBashCommand).toHaveBeenCalledWith("pwd", false);
+		expect(ctx.isBashMode).toBe(false);
+		expect(ctx.isBashNoContext).toBe(false);
+	});
+	it("preserves explicit single-bang parsing in no-context mode", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		controller.setupEditorSubmitHandler();
+		ctx.isBashMode = true;
+		ctx.isBashNoContext = true;
+		await editor.onSubmit?.("!pwd");
+
+		expect(spies.handleBashCommand).toHaveBeenCalledWith("pwd", false);
+	});
+
+	it("keeps prefix-less shell history replayable", async () => {
+		const { InputController, ctx, editor, spies } = await createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		controller.setupEditorSubmitHandler();
+		ctx.isBashMode = true;
+		await editor.onSubmit?.("pwd");
+
+		expect(editor.addToHistory).toHaveBeenCalledWith("!pwd");
+		expect(spies.handleBashCommand).toHaveBeenCalledWith("pwd", false);
+	});
 });

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2093,8 +2093,8 @@ export class Editor implements Component, Focusable {
 		this.#undoStack.length = 0;
 		this.#wrappedLineCache.length = 0;
 
-		if (this.onChange) this.onChange("");
 		if (this.onSubmit) this.onSubmit(result);
+		if (this.onChange) this.onChange("");
 	}
 
 	#handleBackspace(): void {

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -775,6 +775,19 @@ describe("Editor component", () => {
 				if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
 			}
 		});
+		it("preserves the submitted text for onSubmit before clearing onChange state", () => {
+			const editor = new Editor(defaultEditorTheme);
+			const events: string[] = [];
+			editor.onChange = text => events.push(`change:${text}`);
+			editor.onSubmit = text => events.push(`submit:${text}`);
+
+			editor.handleInput("!pwd");
+			events.length = 0;
+			editor.handleInput("\r");
+
+			expect(events).toEqual(["submit:!pwd", "change:"]);
+			expect(editor.getText()).toBe("");
+		});
 
 		it("deletes single-code-unit unicode characters (umlauts) with Backspace", () => {
 			const editor = new Editor(defaultEditorTheme);


### PR DESCRIPTION
## Summary
- preserve `!` shell-mode state across async prompt submission
- keep explicit `!`/`!!` parsing and history semantics consistent
- add editor callback-order and shell-mode regression coverage

## Verification
- `bun test packages/tui/test/editor.test.ts packages/coding-agent/test/input-controller-keybindings.test.ts packages/coding-agent/test/bash-executor.test.ts`
- `bun --cwd=packages/tui run check`
- `bun --cwd=packages/coding-agent run check`