### PR TITLE
fix(ci): repair three deterministic Dev CI failures at 14ae92ad3

### DIFF
--- a/artifacts/dev-14ae92-ci-repair-receipt.json
+++ b/artifacts/dev-14ae92-ci-repair-receipt.json
@@ -1,0 +1,73 @@
+{
+  "run": "dev CI run 31205224428 @ 14ae92ad3d8cd4dc9f2212543096c2cf6525cb09",
+  "branch": "fix/dev-14ae92-ci-repair",
+  "target_head": "14ae92ad3d8cd4dc9f2212543096c2cf6525cb09",
+  "failures": [
+    {
+      "shard": "test:@gajae-code/coding-agent:shard-8-of-8",
+      "test_file": "packages/coding-agent/test/modes/controllers/copy-command.test.ts",
+      "failing_tests": [
+        "/copy command > copies the latest assistant text",
+        "/copy command > falls back to the fresh handoff context when no assistant message exists"
+      ],
+      "ci_evidence": "Expected: [ \"Copied last agent message to clipboard\" ] But it was not called. (copy-command.test.ts:36:22) — showStatus was never invoked at assertion time",
+      "reproduced_locally": "deterministic, 2 pass / 2 fail on every one of 5 runs",
+      "base_run_14ae92ad3~4_6ee45028": "PASS (all 4 copy tests) — CI log and local worktree run",
+      "causal_commit": "39b1d051a (#4008) feat(coding-agent): add SSH clipboard transport",
+      "mechanism": "#4008 rewrote CommandController.#doCopy from a synchronous try/catch (copyToClipboard(content); showStatus(label)) to a promise chain (copyToClipboard(content).then(() => showStatus(label))). The tests assert synchronously, so showStatus (now scheduled on a microtask through an async copyToClipboard that awaits copyToClipboardNative) had not fired yet at assertion time. Verified empirically: 1 microtask flush is insufficient, 2 flushes suffice (Promise.resolve() x2).",
+      "repair": "test-only: make the two tests async and flush the microtask queue with await Promise.resolve() x2, matching the existing btw-controller.test.ts convention",
+      "verification": "4/4 pass locally; microtask depth empirically confirmed with a temporary instrumented test"
+    },
+    {
+      "shard": "test:@gajae-code/coding-agent:shard-2-of-8",
+      "test_file": "packages/coding-agent/test/sdk-acp-provider-reconnect.test.ts",
+      "failing_tests": [
+        "ACP reconnect exhaustion is observable as a typed rejection"
+      ],
+      "ci_evidence": "test timed out after 5000ms (test body ran 41812ms until the reconnect budget exhausted)",
+      "reproduced_locally": "deterministic — times out at 5s; adapter.start() rejects with reconnect_exhausted only after ~40s",
+      "base_run_6ee45028": "PASS in ~187ms (CI log) and ~200ms (local worktree run)",
+      "causal_commit": "14ae92ad3 (#4012) fix(acp): outlive the host heartbeat TTL when reconnecting",
+      "mechanism": "#4012 replaced the SdkClient's default reconnect budget (3 attempts, 25ms base ≈ 175ms) with ACP_SESSION_RECONNECT (23 attempts, backoff to 2s cap ≈ 40s) so the client outlives the 20s host heartbeat TTL. The exhaustion test still relied on the ~175ms default and its implicit 5s bun test timeout; the 40s budget can never exhaust within 5s.",
+      "repair": "test-only: inject a bounded client (reconnectAttempts: 1, backoff 1ms) so the adapter's typed-rejection propagation through start() is asserted fast; the full budget is already covered under a fake clock by acp-session-reconnect.test.ts (added in #4012)",
+      "verification": "2/2 pass locally in 170ms"
+    },
+    {
+      "shard": "test:@gajae-code/coding-agent:shard-5-of-8",
+      "test_file": "packages/coding-agent/test/agent-session-openai-responses-replay.test.ts",
+      "failing_tests": [
+        "AgentSession OpenAI Responses replay boundaries > preserves a forked child seeded prefix across compaction and prune rewrites"
+      ],
+      "ci_evidence": "error: StablePrefix.importSnapshot() fingerprint mismatch: expected 61razw, received 1lejnr2 (append-only-context.ts:75 via createAgentSession at sdk/session.ts:2796)",
+      "reproduced_locally": "deterministic at head (expected 1nxru87, received vejvyx in a minimal repro)",
+      "base_run_6ee45028": "PASS (CI logs: 301ms / 282ms / 317ms across three dev runs; local worktree run 24/24)",
+      "causal_commit": "3a0ec7941 (#4004) fix(sdk): key intent tracing on sub-sessions, not on having a UI",
+      "mechanism": "#4004 changed resolveIntentTracingEnabled from `(setting||flag) && hasUI` to `(setting||flag) && !subSession`. The test harness (no UI) previously ran with intentTracing OFF, so the parent's StablePrefix was exported without `_i` injection and the child re-imported it identically. With intentTracing ON by default, takeSnapshot now injects `_i` into every non-omit tool. normalizeImportedTools then re-normalizes the cloned JSON: cloneJson drops function-valued `intent` fields (deferred intent policies on tools such as the session's `resolve` tool), so those tools flip from intentMode \"omit\" to \"optional\" and get `_i` injected on import — changing `parameters` and diverging the recomputed fingerprint from the stored one. Reproduced in isolation: only the `resolve` tool's parameters changed on re-normalization (lived zod instance exported raw; cloned `{def,type}` object gets `_i` added on import).",
+      "repair": "production fix in packages/agent/src/append-only-context.ts: StablePrefix.importSnapshot now verifies the fingerprint against the stored, already-normalized tools (deep-cloned as-is) instead of re-normalizing them; the non-idempotent normalizeImportedTools helper was removed. The exported snapshot is authoritative (takeSnapshot normalized it), and the deep clone still keeps toContext() isolated.",
+      "verification": "append-only-context.test.ts 66/66, heap-eviction-retainers.test.ts 6/6, append-only-mode.test.ts 8/8, agent-session-openai-responses-replay.test.ts 24/24; intentTracing-off and PI_NO_INTENT=1 cross-checks both pass 24/24, confirming the fingerprint round-trip now matches base behavior",
+      "note": "On this local machine the two harness sessions each race a 5s workspace-tree startup deadline, so the test body hovers at bun's 5s default timeout (the same test flakes 2/3 locally at the untouched base commit 6ee45028). Added an explicit 30s test timeout so environment-speed cannot false-fail it; CI ran the same test in ~300ms pre-regression."
+    }
+  ],
+  "flaky_non_causal": {
+    "shard": "test:@gajae-code/coding-agent:shard-2-of-8",
+    "test_file": "packages/coding-agent/test/sdk-query-pagination.test.ts",
+    "failing_test": "SDK query pagination > rotates pins so sequential completed walks do not exhaust one connection",
+    "ci_evidence": "Expected: true, Received: false (sdk-query-pagination.test.ts:358:36) — continuation page came back incomplete once",
+    "reproduced_locally": "0/240 failures (24 tests x 10 reruns) at head",
+    "base_run_6ee45028": "PASS (CI log, 513ms)",
+    "causal_commit": "none — the query/pagination host code is untouched by the 4-commit batch 6ee45028..14ae92ad3",
+    "classification": "rare environment/timing-dependent flake, not reproducible locally, not caused by the batch; left unmodified (no proven repair exists; stress-verified 10x at head)"
+  },
+  "verification_matrix": {
+    "copy-command.test.ts": "4/4 pass",
+    "sdk-acp-provider-reconnect.test.ts": "2/2 pass in 170ms (was 5s timeout / 40s exhaustion)",
+    "agent-session-openai-responses-replay.test.ts": "24/24 pass",
+    "append-only-context.test.ts": "66/66 pass",
+    "append-only-mode.test.ts": "8/8 pass",
+    "heap-eviction-retainers.test.ts": "6/6 pass",
+    "sdk-query-pagination.test.ts": "24/24 pass (10x rerun stress clean)",
+    "typecheck": "bun --cwd=packages/agent run check:types clean; bun --cwd=packages/coding-agent run check:types clean",
+    "biome": "clean on all four changed files"
+  },
+  "base_comparison_note": "All three regressions were verified absent at the pre-batch commit 6ee45028b in a detached worktree (copy 4/4, ACP ~200ms pass, replay 24/24) and present at head, establishing the batch as causal. The pagination flake passed at base and head locally and is attributed to no commit."
+}

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Forked-session restore no longer crashes when the seeded append-only prefix includes a tool whose `intent` policy is a deferred function (e.g. `eval`, `bisect`, `checkpoint`, `rewind`). `StablePrefix.importSnapshot` re-normalized the cloned tool JSON, which loses function-valued `intent` fields, so those tools flipped from `omit` to `optional` intent injection and the recomputed fingerprint diverged from the stored one (`StablePrefix.importSnapshot() fingerprint mismatch`). Import now verifies against the stored, already-normalized tools instead of re-normalizing.
+
 ## [0.12.15] - 2026-08-06
 
 ## [0.12.14] - 2026-08-06

--- a/packages/agent/src/append-only-context.ts
+++ b/packages/agent/src/append-only-context.ts
@@ -65,8 +65,17 @@ export class StablePrefix {
 	}
 
 	importSnapshot(snapshot: StablePrefixSnapshot, options: BuildOptions): void {
+		// The snapshot tools were already normalized by `takeSnapshot()` at export
+		// time. Re-normalizing the cloned JSON would apply `normalizeTools` a
+		// second time, which is not idempotent: a tool whose `intent` policy is a
+		// function resolves as "omit" at export (no `_i` injected), but the
+		// function value is dropped by `cloneJson`, so a second pass resolves the
+		// missing field as "optional" and injects `_i` — changing `parameters` and
+		// diverging the recomputed fingerprint from the stored one. Verify against
+		// the stored tools as-is; the deep clone still keeps `toContext()` results
+		// isolated from later mutation.
 		const systemPrompt = cloneJson(snapshot.systemPrompt);
-		const tools = normalizeImportedTools(snapshot.tools, options);
+		const tools = cloneJson(snapshot.tools);
 		const fingerprint = computeFingerprint(systemPrompt, tools, options);
 		this.#sourceSystemPrompt = null;
 		this.#sourceTools = null;
@@ -426,12 +435,6 @@ function takeSnapshot(context: AgentContext, options: BuildOptions): StablePrefi
 		tools,
 		fingerprint: computeFingerprint(systemPrompt, tools, options),
 	};
-}
-
-function normalizeImportedTools(tools: readonly Tool[], options: BuildOptions): Tool[] {
-	const clonedTools = cloneJson(tools);
-	const normalizedTools = normalizeTools(clonedTools as AgentContext["tools"], options.intentTracing) ?? [];
-	return cloneJson(normalizedTools);
 }
 
 export function cloneJson<T>(value: T): T {

--- a/packages/coding-agent/test/agent-session-openai-responses-replay.test.ts
+++ b/packages/coding-agent/test/agent-session-openai-responses-replay.test.ts
@@ -791,7 +791,12 @@ describe("AgentSession OpenAI Responses replay boundaries", () => {
 		expect(outcome).toBe("pruned");
 		expect(appendOnly.log.toMessages().slice(0, seededPrefix.length)).toEqual(seededPrefix);
 		expect(appendOnly.log.toMessages()).not.toContainEqual(pruneLocal);
-	});
+		// Each session created by this test races the workspace-tree scan's 5s
+		// startup deadline, so on slower runners the two harness sessions plus the
+		// maintenance can exceed bun's 5s default. The CI failure this guards was
+		// the StablePrefix fingerprint crash (fast); the generous bound only
+		// prevents environment-speed false timeouts.
+	}, 30_000);
 
 	it("spawns bundled executor and architect via TaskTool with inheritContext: bounded through the production path", async () => {
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-fc-task-${Snowflake.next()}-`));

--- a/packages/coding-agent/test/modes/controllers/copy-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/copy-command.test.ts
@@ -24,26 +24,29 @@ describe("/copy command", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("copies the latest assistant text", () => {
+	it("copies the latest assistant text", async () => {
 		const copySpy = vi.spyOn(native, "copyToClipboard").mockImplementation(() => undefined);
 		const { controller, showStatus, showError } = createController({
 			assistantText: "latest **markdown** response",
 		});
 
 		controller.handleCopyCommand();
+		await Promise.resolve();
+		await Promise.resolve();
 
 		expect(copySpy).toHaveBeenCalledWith("latest **markdown** response");
 		expect(showStatus).toHaveBeenCalledWith("Copied last agent message to clipboard");
 		expect(showError).not.toHaveBeenCalled();
 	});
-
-	it("falls back to the fresh handoff context when no assistant message exists", () => {
+	it("falls back to the fresh handoff context when no assistant message exists", async () => {
 		const copySpy = vi.spyOn(native, "copyToClipboard").mockImplementation(() => undefined);
 		const { controller, showStatus, showError } = createController({
 			handoffText: "<handoff-context>\n## Goal\nContinue\n</handoff-context>",
 		});
 
 		controller.handleCopyCommand();
+		await Promise.resolve();
+		await Promise.resolve();
 
 		expect(copySpy).toHaveBeenCalledWith("<handoff-context>\n## Goal\nContinue\n</handoff-context>");
 		expect(showStatus).toHaveBeenCalledWith("Copied handoff context to clipboard");

--- a/packages/coding-agent/test/sdk-acp-provider-reconnect.test.ts
+++ b/packages/coding-agent/test/sdk-acp-provider-reconnect.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { AcpSdkAdapter } from "../src/sdk/acp";
+import { SdkClient } from "../src/sdk/client";
 
 const waitFor = async <T>(read: () => T | undefined, label: string): Promise<T> => {
 	const deadline = Date.now() + 2_000;
@@ -72,10 +73,21 @@ test("ACP provider reconnects after a server-side heartbeat disconnect, awaits h
 });
 
 test("ACP reconnect exhaustion is observable as a typed rejection", async () => {
+	// The ACP session reconnect budget (ACP_SESSION_RECONNECT) deliberately
+	// outlives the host heartbeat TTL — 23 attempts with backoff up to 2s, ~40s
+	// total. That budget is exercised under a fake clock in
+	// acp-session-reconnect.test.ts; here, inject a bounded client so the
+	// adapter's typed-rejection propagation is still asserted without a 40s
+	// real-time wait in CI.
 	const adapter = new AcpSdkAdapter({
 		url: "ws://127.0.0.1:1",
 		token: "token",
 		providers: [{ capability: "ui", definitions: [] }],
+		client: new SdkClient("ws://127.0.0.1:1", "token", {
+			reconnectAttempts: 1,
+			reconnectBackoffMs: 1,
+			reconnectMaxBackoffMs: 1,
+		}),
 	});
 	await expect(adapter.start()).rejects.toMatchObject({ code: "reconnect_exhausted" });
 });


### PR DESCRIPTION
## Summary

Dev CI run [31205224428](https://github.com/Yeachan-Heo/gajae-code/actions/runs/31205224428) at `14ae92ad3` went red on three coding-agent shards. This PR repairs all three — each is a **deterministic regression introduced by the 4-commit batch `6ee45028..14ae92ad3`**, verified by base-vs-head reproduction in a detached worktree (copy 4/4, ACP ~200ms pass, replay 24/24 at base; all failing at head). The fourth red shard-2 test (`SDK query pagination > rotates pins...`) is a **rare, non-reproducible flake** (0/240 failures locally; code untouched by the batch) and is deliberately left unmodified.

Full attribution matrix and local verification: `artifacts/dev-14ae92-ci-repair-receipt.json`.

## Failures → causes → repairs

| Failure (shard) | Causal commit | Mechanism | Repair |
|---|---|---|---|
| `/copy command` ×2 (shard-8) | #4008 (SSH clipboard transport) | `#doCopy` became `copyToClipboard(content).then(...)`; tests assert `showStatus` synchronously, before the microtask fires | Test-only: make the two tests async + flush microtasks (`await Promise.resolve()` ×2, matching `btw-controller.test.ts`) |
| `ACP reconnect exhaustion` (shard-2) | #4012 (reconnect budget) | budget grew 175ms → ~40s (23 attempts, to outlive the 20s host heartbeat TTL); bun's 5s test timeout can never see exhaustion | Test-only: inject a bounded client (1 attempt, 1ms backoff) so the adapter's typed rejection is asserted fast; the full budget is already fake-clock-tested in `acp-session-reconnect.test.ts` |
| `StablePrefix.importSnapshot() fingerprint mismatch` (shard-5) | #4004 (intent tracing on sub-sessions) | intent tracing flipped from `&& hasUI` to `&& !subSession`, turning it ON for harness sessions; `importSnapshot` re-normalized cloned tool JSON, which drops function-valued `intent` policies, flipping those tools from `omit` to `optional` `_i` injection → recomputed fingerprint diverges | Production fix in `packages/agent/src/append-only-context.ts`: verify the fingerprint against the stored, already-normalized tools (deep-cloned as-is); remove the non-idempotent `normalizeImportedTools`. The forked-child test also gets an explicit 30s bound (it hovers at bun's 5s default on slow runners — same flake reproduces at untouched base) |

## Verification

- `copy-command.test.ts` — 4/4 pass
- `sdk-acp-provider-reconnect.test.ts` — 2/2 pass in 170ms (was 5s timeout / ~40s exhaustion)
- `agent-session-openai-responses-replay.test.ts` — 24/24 pass
- `append-only-context.test.ts` 66/66, `append-only-mode.test.ts` 8/8, `heap-eviction-retainers.test.ts` 6/6
- `sdk-query-pagination.test.ts` — 24/24 (10× rerun stress clean)
- `bun --cwd=packages/agent run check:types` and `bun --cwd=packages/coding-agent run check:types` clean; biome clean on all changed files