### PR TITLE
fix(cli): register auth-broker and auth-gateway so documented verbs execute (fixes #3975)

### DIFF
--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -34,6 +34,8 @@ export const commands: CommandEntry[] = [
 	{ name: "state", load: () => import("./commands/state").then(m => m.default) },
 	{ name: "setup", load: () => import("./commands/setup").then(m => m.default) },
 	{ name: "acp", load: () => import("./commands/acp").then(m => m.default) },
+	{ name: "auth-broker", load: () => import("./commands/auth-broker").then(m => m.default) },
+	{ name: "auth-gateway", load: () => import("./commands/auth-gateway").then(m => m.default) },
 	{ name: "skills", load: () => import("./commands/skills").then(m => m.default) },
 	{ name: "session", load: () => import("./commands/session").then(m => m.default) },
 	{ name: "harness", load: () => import("./commands/harness").then(m => m.default) },

--- a/packages/coding-agent/src/cli/fast-help.ts
+++ b/packages/coding-agent/src/cli/fast-help.ts
@@ -7,6 +7,8 @@ export function getExtraHelpText(): string {
   ${APP_NAME} setup                - Install GJC defaults or optional dependencies
   ${APP_NAME} session              - List, inspect, create, remove, or attach sessions
   ${APP_NAME} state                - Inspect or manage persisted GJC state
+  ${APP_NAME} auth-broker         - Manage the auth-broker (credential vault)
+  ${APP_NAME} auth-gateway        - Run an auth-gateway forward proxy
   ${APP_NAME} harness              - Run harness control-plane commands
   ${APP_NAME} coordinator          - Manage coordinator/runtime coordination helpers
   ${APP_NAME} team                 - Run tmux-backed coordinated execution

--- a/packages/coding-agent/test/cli-command-registry.test.ts
+++ b/packages/coding-agent/test/cli-command-registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { commands } from "../src/cli";
+import { commands, routeRootArgv } from "../src/cli";
 
 describe("CLI command registry", () => {
 	it("registers the `plugin` command so `gjc plugin …` resolves instead of routing to launch", () => {
@@ -48,5 +48,46 @@ describe("CLI command registry", () => {
 		const cmd = (await entry?.load()) as { description?: string } | undefined;
 		expect(cmd).toBeDefined();
 		expect(cmd?.description ?? "").toMatch(/usage statistics/i);
+	});
+	it("registers `auth-broker` so documented verbs resolve instead of routing to launch", () => {
+		// Regression (#3975): `src/commands/auth-broker.ts` and its handlers in
+		// `src/cli/auth-broker-cli.ts` existed, but the entry was never added to
+		// the `commands` registry in cli.ts. `isSubcommand()` therefore returned
+		// false for "auth-broker", so `gjc auth-broker serve|token|login|…` was
+		// rewritten to `launch` and billed a chat turn instead of executing the
+		// credential action. docs/auth-broker-gateway.md documents the verbs.
+		const entry = commands.find(c => c.name === "auth-broker");
+		expect(entry).toBeDefined();
+		expect(routeRootArgv(["auth-broker", "serve"])).toEqual(["auth-broker", "serve"]);
+		expect(routeRootArgv(["auth-broker", "token"])).toEqual(["auth-broker", "token"]);
+		expect(routeRootArgv(["auth-broker", "login", "anthropic"])).toEqual(["auth-broker", "login", "anthropic"]);
+	});
+
+	it("lazily resolves the registered `auth-broker` entry to the AuthBroker command class", async () => {
+		const entry = commands.find(c => c.name === "auth-broker");
+		const cmd = (await entry?.load()) as { description?: string } | undefined;
+		expect(cmd).toBeDefined();
+		expect(cmd?.description ?? "").toMatch(/auth-broker/i);
+	});
+
+	it("registers `auth-gateway` so documented verbs resolve instead of routing to launch", () => {
+		// Regression (#3975): same missing-registry-entry pattern as auth-broker.
+		// `gjc auth-gateway serve|token|status|check` fell through to launch.
+		const entry = commands.find(c => c.name === "auth-gateway");
+		expect(entry).toBeDefined();
+		expect(routeRootArgv(["auth-gateway", "serve"])).toEqual(["auth-gateway", "serve"]);
+		expect(routeRootArgv(["auth-gateway", "check"])).toEqual(["auth-gateway", "check"]);
+		expect(routeRootArgv(["auth-gateway", "token", "--regenerate"])).toEqual([
+			"auth-gateway",
+			"token",
+			"--regenerate",
+		]);
+	});
+
+	it("lazily resolves the registered `auth-gateway` entry to the AuthGateway command class", async () => {
+		const entry = commands.find(c => c.name === "auth-gateway");
+		const cmd = (await entry?.load()) as { description?: string } | undefined;
+		expect(cmd).toBeDefined();
+		expect(cmd?.description ?? "").toMatch(/auth-gateway/i);
 	});
 });

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -152,6 +152,8 @@ process.exitCode = await child.exited;`;
 			"state",
 			"setup",
 			"acp",
+			"auth-broker",
+			"auth-gateway",
 			"skills",
 			"session",
 			"harness",


### PR DESCRIPTION
## Problem

Closes #3975.

The reporter's reproduction is exact: `gjc auth-broker serve`, `gjc auth-broker token`, `gjc auth-gateway serve`, `gjc auth-gateway check`, and every other documented verb in `docs/auth-broker-gateway.md` fell through to the agent chat prompt, billed a turn, and never executed the credential action.

Both `src/commands/auth-broker.ts` and `src/commands/auth-gateway.ts` (plus their handlers in `src/cli/auth-broker-cli.ts` / `src/cli/auth-gateway-cli.ts`) existed, but **neither entry was registered** in the `commands` registry in `src/cli.ts`. `isSubcommand("auth-broker")` therefore returned `false`, and `routeRootArgv` rewrote the invocation to `["launch", "auth-broker", "serve", …]` — i.e. a chat message.

Before:
```
["auth-broker","serve"] => ["launch","auth-broker","serve"]
["auth-gateway","check"] => ["launch","auth-gateway","check"]
```

## Fix (smallest correct registration/routing change)

- `src/cli.ts` — register `auth-broker` and `auth-gateway` as lazy command entries (same pattern as every other command). This makes `isSubcommand()` recognize them, so `routeRootArgv` keeps the verbs on their command.
- `src/cli/fast-help.ts` — add both families to the root `gjc --help` command list.
- `test/cli-command-registry.test.ts` — regression tests pinning `routeRootArgv` so documented verbs can never be rewritten into `launch` again (mirrors the existing `plugin`/`stats` fallthrough regressions), plus lazy class-resolution checks.
- `test/cli-command-surface.test.ts` — update the exact registry-list assertion with the two new entries.

Reachability-only: no auth semantics, credential handling, or secret emission changed.

## Verification

- Focused suites: `bun test test/cli-command-registry.test.ts test/cli-command-surface.test.ts test/cli-resume-alias.test.ts test/completion-cli.test.ts` → **44 pass / 0 fail** (211 expects).
- `bun --cwd=packages/coding-agent run check` → biome clean (one pre-existing unrelated warning in `test/smithery-env-trust.test.ts`), `tsc --noEmit` exit 0.
- E2E from source: `gjc auth-broker --help` and `gjc auth-gateway --help` now render their command help (all documented verbs) and exit 0; `gjc --help` lists both entries.
- After:
```
["auth-broker","serve"] => ["auth-broker","serve"]
["auth-gateway","check"] => ["auth-gateway","check"]
```