### PR TITLE
test(cli): pin --clipboard-transport/--clipboard-ssh-host in completion-cli regression suite

### DIFF
--- a/packages/coding-agent/test/completion-cli.test.ts
+++ b/packages/coding-agent/test/completion-cli.test.ts
@@ -128,6 +128,17 @@ describe("GJC inshellisense completion spec", () => {
 			"max",
 		]);
 		expect(findOption(spec.options, "--tmux")).toBeDefined();
+		// Regression guard for a canary-found gap: --clipboard-transport/--clipboard-ssh-host
+		// were registered in commands/launch.ts's parsing Command but missed in RootHelpCommand,
+		// the fast-help/completion mirror this spec builds from, so `gjc --help` and shell
+		// completion silently omitted both flags even though parsing worked correctly.
+		expect(findOption(spec.options, "--clipboard-transport")?.args?.suggestions).toEqual([
+			"auto",
+			"native",
+			"osc52",
+			"ssh",
+		]);
+		expect(findOption(spec.options, "--clipboard-ssh-host")).toBeDefined();
 		expect(findOption(spec.options, "--model")?.args).toEqual({ name: "value" });
 		expect(findOption(spec.options, "--resume")?.args).toEqual({ name: "value" });
 		expect(findOption(spec.options, "-p")?.description).toContain("Non-interactive");


### PR DESCRIPTION
## What

Small follow-up to #4008 (merged). Adds a regression assertion pinning `--clipboard-transport`/`--clipboard-ssh-host` in the shell-completion/root-help surface test, per an Architect review finding on the post-canary fix commit.

## Why

#4008's canary pass found and fixed a gap in `b119984d3`: the two clipboard flags were correctly registered in `commands/launch.ts`'s parsing `Command` but missing from `cli.ts`'s separate `RootHelpCommand` (the fast-`--help`/fig-completion mirror). That fix landed, but nothing pinned the specific defect it resolved — `test/cli-help-load-order.test.ts` covers help-text *sourcing* (that `cli.ts` reads from `fast-help.ts`, not `args.ts`), not the actual flag table, so a future accidental removal from `RootHelpCommand` would silently regress `--help`/completion coverage again with no test catching it.

## Verification

Proved this guard actually catches the regression it names, not just that it passes today:
1. Reverted `cli.ts` locally to `b119984d3~1` (the pre-fix state).
2. Ran the updated test — it failed exactly as expected (`clipboard-transport` suggestions: `undefined`).
3. Restored the fix, re-ran — green.

```
bun test packages/coding-agent/test/completion-cli.test.ts   # 7/7 pass
bun run check                                                  # biome + tsc --noEmit, clean
```

## Scope

One file, +11 lines, test-only. No product behavior change.
