### PR TITLE
fix(ai): preserve Codex tool-choice downgrade state

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Codex named-tool fallback now keeps its downgraded request body across later same-turn provider retries and uses an independent one-shot budget, so retries cannot reintroduce `tool_choice` or suppress a later capability downgrade (#3669).
 - Anthropic requests rejected with `A maximum of 4 blocks with cache_control may be provided. Found N.` now step their generated breakpoints down instead of dying on the first attempt (#3934, supersedes #3943). An Anthropic-compatible gateway may attach its own block-level cache markers before forwarding, and those never appear in the params we serialize, so the total is unpredictable locally and the rejection itself is the only usable signal. Because that rejection says "too many", not "none allowed", recovery gives up one breakpoint at a time: explicit mode normally emits two (a conversation-prefix anchor plus a current-turn refresh point), so the first retry keeps the prefix anchor — the higher-value marker — and only a second rejection disables generated caching entirely. The reduced budget persists for the provider session so later turns neither re-trigger the 400 nor lose more caching than the endpoint requires. Only a genuine breakpoint-overflow `invalid_request_error` is claimed — other `cache_control` complaints, unrelated 400s, non-400 statuses, and our own pre-flight validation failure still surface immediately. The classifier is exported as `isAnthropicCacheBreakpointOverflowError`.
 ## [0.12.15] - 2026-08-06
 

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -169,6 +169,12 @@ function isCodexStreamProgressEvent(event: unknown): boolean {
 	return typeof type === "string" && CODEX_PROGRESS_EVENT_TYPES.has(type);
 }
 type CodexTransport = "sse" | "websocket";
+interface CodexInitialTransport {
+	eventStream: AsyncGenerator<Record<string, unknown>>;
+	requestBodyForState: RequestBody;
+	transport: CodexTransport;
+	toolChoiceFallbackApplied?: boolean;
+}
 type CodexEventItem = ResponseReasoningItem | ResponseOutputMessage | ResponseFunctionToolCall | ResponseCustomToolCall;
 type CodexThinkingBlock = ThinkingContent & { summaryBuffer: string; rawBuffer: string; summaryStarted: boolean };
 type CodexOutputBlock = CodexThinkingBlock | TextContent | (ToolCall & { partialJson: string });
@@ -221,11 +227,11 @@ async function retryCodexInitialTransportWithoutToolChoice(
 	requestContext: CodexRequestContext,
 	stream: AssistantMessageEventStream,
 	error: unknown,
-): Promise<{
-	eventStream: AsyncGenerator<Record<string, unknown>>;
-	requestBodyForState: RequestBody;
-	transport: CodexTransport;
-}> {
+): Promise<
+	CodexInitialTransport & {
+		toolChoiceFallbackApplied: true;
+	}
+> {
 	if (!isCodexForcedToolChoiceUnsupportedError(error, requestContext.transformedBody)) {
 		throw error;
 	}
@@ -250,7 +256,7 @@ async function retryCodexInitialTransportWithoutToolChoice(
 		requestContext.websocketState,
 	);
 	requestContext.rawRequestDump = { ...requestContext.rawRequestDump, body: next.requestBodyForState };
-	return next;
+	return { ...next, toolChoiceFallbackApplied: true };
 }
 
 interface CodexRequestSetup {
@@ -270,6 +276,8 @@ interface CodexStreamRuntime {
 	nativeOutputItems: Array<Record<string, unknown>>;
 	websocketStreamRetries: number;
 	providerRetryAttempt: number;
+	toolChoiceFallbackAttempted: boolean;
+	sseRequestBodyOverride?: RequestBody;
 	sawTerminalEvent: boolean;
 	canSafelyReplayWebsocketOverSse: boolean;
 	/** Ids of tool calls that received their terminal `output_item.done`. */
@@ -751,11 +759,7 @@ async function openInitialCodexEventStream(
 	options: OpenAICodexResponsesOptions | undefined,
 	requestSetup: CodexRequestSetup,
 	requestContext: CodexRequestContext,
-): Promise<{
-	eventStream: AsyncGenerator<Record<string, unknown>>;
-	requestBodyForState: RequestBody;
-	transport: CodexTransport;
-}> {
+): Promise<CodexInitialTransport> {
 	const { transformedBody, websocketState } = requestContext;
 	if (websocketState && shouldUseCodexWebSocket(model, websocketState, options?.preferWebsockets)) {
 		const websocketRetryBudget = getCodexWebSocketRetryBudget(options);
@@ -927,6 +931,7 @@ async function reopenCodexSseRuntimeStream(
 		context.requestSetup,
 		context.options,
 		state,
+		runtime.sseRequestBodyOverride,
 	);
 	runtime.eventStream = next.eventStream;
 	runtime.requestBodyForState = next.requestBodyForState;
@@ -941,6 +946,7 @@ function createCodexStreamRuntime(initial: {
 	requestBodyForState: RequestBody;
 	transport: CodexTransport;
 	websocketState?: CodexWebSocketSessionState;
+	toolChoiceFallbackApplied?: boolean;
 }): CodexStreamRuntime {
 	return {
 		eventStream: initial.eventStream,
@@ -952,6 +958,10 @@ function createCodexStreamRuntime(initial: {
 		nativeOutputItems: [],
 		websocketStreamRetries: 0,
 		providerRetryAttempt: 0,
+		toolChoiceFallbackAttempted: initial.toolChoiceFallbackApplied === true,
+		sseRequestBodyOverride: initial.toolChoiceFallbackApplied
+			? structuredCloneJSON(initial.requestBodyForState)
+			: undefined,
 		sawTerminalEvent: false,
 		canSafelyReplayWebsocketOverSse: true,
 		finalizedToolCallIds: new Set<string>(),
@@ -1500,7 +1510,7 @@ async function tryRetryWithoutForcedToolChoice(
 ): Promise<boolean> {
 	if (
 		context.options?.fallbackManaged ||
-		runtime.providerRetryAttempt > 0 ||
+		runtime.toolChoiceFallbackAttempted ||
 		context.output.content.length > 0 ||
 		context.firstTokenTime !== undefined ||
 		context.options?.signal?.aborted ||
@@ -1523,7 +1533,7 @@ async function tryRetryWithoutForcedToolChoice(
 		registryKey: resolvedToolChoice.registryKey,
 	});
 
-	runtime.providerRetryAttempt += 1;
+	runtime.toolChoiceFallbackAttempted = true;
 	runtime.currentItem = null;
 	runtime.currentBlock = null;
 	runtime.sawTerminalEvent = false;
@@ -1545,6 +1555,7 @@ async function tryRetryWithoutForcedToolChoice(
 	);
 	runtime.eventStream = next.eventStream;
 	runtime.requestBodyForState = next.requestBodyForState;
+	runtime.sseRequestBodyOverride = next.requestBodyForState;
 	runtime.transport = next.transport;
 	if (websocketState) {
 		websocketState.lastTransport = next.transport;
@@ -1852,7 +1863,7 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 
 		try {
 			const requestContext = await buildCodexRequestContext(model, context, options, output);
-			let initialTransport: Awaited<ReturnType<typeof openInitialCodexEventStream>>;
+			let initialTransport: CodexInitialTransport;
 			try {
 				initialTransport = await openInitialCodexEventStream(model, options, requestSetup, requestContext);
 			} catch (error) {

--- a/packages/ai/test/openai-codex-responses-tool-choice.test.ts
+++ b/packages/ai/test/openai-codex-responses-tool-choice.test.ts
@@ -146,6 +146,37 @@ describe("OpenAI Codex responses tool choice capability", () => {
 		expectSingleCleanFallbackEvents(events);
 	});
 
+	it("keeps an initial HTTP downgrade across a later provider retry", async () => {
+		const bodies: Record<string, unknown>[] = [];
+		const testModel = model({ id: "runtime-codex-http-sticky-downgrade" });
+		global.fetch = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit) => {
+				bodies.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+				if (bodies.length === 1) {
+					return createErrorResponse("Tool choice 'search' not found in 'tools' parameter.");
+				}
+				if (bodies.length === 2) {
+					return createSseResponse([{ type: "error", code: "server_error", message: "retry me" }]);
+				}
+				return okResponse(testModel.id);
+			},
+			{ preconnect: originalFetch.preconnect },
+		);
+
+		const result = await streamOpenAICodexResponses(testModel, testContext, {
+			apiKey: codexToken,
+			preferWebsockets: false,
+			toolChoice: { type: "function", function: { name: "search" } },
+			streamMaxRetries: 1,
+		}).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(bodies).toHaveLength(3);
+		expect(bodies[0]?.tool_choice).toEqual({ type: "function", name: "search" });
+		expect(bodies[1]?.tool_choice).toBeUndefined();
+		expect(bodies[2]?.tool_choice).toBeUndefined();
+		expect(getToolChoiceCapabilityOverride(testModel)).toBe("auto");
+	});
 	it("retries once when a Codex SSE error rejects a named tool choice", async () => {
 		const bodies: Record<string, unknown>[] = [];
 		const testModel = model({ id: "runtime-codex-sse" });
@@ -185,6 +216,65 @@ describe("OpenAI Codex responses tool choice capability", () => {
 		expect(bodies[1]?.prompt_cache_key).toBe(bodies[0]?.prompt_cache_key);
 		expect(getToolChoiceCapabilityOverride(testModel)).toBe("auto");
 		expectSingleCleanFallbackEvents(events);
+	});
+	it("keeps the downgraded SSE body across a later provider retry", async () => {
+		const bodies: Record<string, unknown>[] = [];
+		const testModel = model({ id: "runtime-codex-sticky-downgrade" });
+		global.fetch = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit) => {
+				bodies.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+				if (bodies.length === 1) return statuslessToolChoiceError("search");
+				if (bodies.length === 2) {
+					return createSseResponse([{ type: "error", code: "server_error", message: "retry me" }]);
+				}
+				return okResponse(testModel.id);
+			},
+			{ preconnect: originalFetch.preconnect },
+		);
+
+		const result = await streamOpenAICodexResponses(testModel, testContext, {
+			apiKey: codexToken,
+			preferWebsockets: false,
+			toolChoice: { type: "function", function: { name: "search" } },
+			streamMaxRetries: 1,
+		}).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(bodies).toHaveLength(3);
+		expect(bodies[0]?.tool_choice).toEqual({ type: "function", name: "search" });
+		expect(bodies[1]?.tool_choice).toBeUndefined();
+		expect(bodies[2]?.tool_choice).toBeUndefined();
+		expect(getToolChoiceCapabilityOverride(testModel)).toBe("auto");
+	});
+
+	it("allows the tool-choice fallback after an unrelated provider retry", async () => {
+		const bodies: Record<string, unknown>[] = [];
+		const testModel = model({ id: "runtime-codex-retry-then-downgrade" });
+		global.fetch = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit) => {
+				bodies.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+				if (bodies.length === 1) {
+					return createSseResponse([{ type: "error", code: "server_error", message: "retry me" }]);
+				}
+				if (bodies.length === 2) return statuslessToolChoiceError("search");
+				return okResponse(testModel.id);
+			},
+			{ preconnect: originalFetch.preconnect },
+		);
+
+		const result = await streamOpenAICodexResponses(testModel, testContext, {
+			apiKey: codexToken,
+			preferWebsockets: false,
+			toolChoice: { type: "function", function: { name: "search" } },
+			streamMaxRetries: 1,
+		}).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(bodies).toHaveLength(3);
+		expect(bodies[0]?.tool_choice).toEqual({ type: "function", name: "search" });
+		expect(bodies[1]?.tool_choice).toEqual({ type: "function", name: "search" });
+		expect(bodies[2]?.tool_choice).toBeUndefined();
+		expect(getToolChoiceCapabilityOverride(testModel)).toBe("auto");
 	});
 
 	it("does not retry a statusless SSE error in managed mode", async () => {


### PR DESCRIPTION
## What

- Track the one-shot Codex named-tool fallback separately from generic provider retries.
- Keep the downgraded SSE request body authoritative across every later same-turn reopen.
- Preserve an initial HTTP downgrade when the stream later takes a provider retry.
- Add regressions for both retry orderings and record the correction under `[Unreleased]`.

## Why

Follow-up correction for the retrospective findings on #3699. The merged implementation could rebuild from the original request after a generic retry, reintroducing forced `tool_choice`, and shared its fallback budget with ordinary provider recovery.

This applies the independently reviewed current-dev candidate from `probepark/review/issue-3669-current-dev` onto the latest `dev`, preserving the review contributor in the commit metadata.

## Testing

- `bun test packages/ai/test/openai-codex-responses-tool-choice.test.ts packages/ai/test/tool-choice-capability.test.ts` — 50 passed / 287 assertions
- `bun --cwd=packages/ai run check`
- `git diff --check origin/dev...HEAD`

---

- [x] Target branch is `dev`
- [x] Focused tests pass
- [x] Package check passes
- [x] CHANGELOG updated under `[Unreleased]`