### PR TITLE
fix(ai): refresh Anthropic cache-eval identity evidence

### DIFF
--- a/artifacts/issue-3670-anthropic-cache-eval.json
+++ b/artifacts/issue-3670-anthropic-cache-eval.json
@@ -6,8 +6,8 @@
 	"source": {
 		"url": "https://platform.claude.com/docs/en/build-with-claude/prompt-caching",
 		"retrievedAt": "2026-07-18",
-		"providerSourceBlobOid": "9e400ada3f74e4ff88652fe069aa2bd5766f9807",
-		"providerSourceSha256": "ebdda451e7790b31d0575c8722faa850272006f2ced496918321d919e3df5d09",
+		"providerSourceBlobOid": "f36330e0a4d661d7f945060b500cc5270ea0b3c1",
+		"providerSourceSha256": "7dd532f42baabfebe45aad127f0baebb42ef6cfd7ebfd9f350f252734b7f36b3",
 		"inputFixtureSha256": "562926fba79f003eff4d45c0da2292ac66d84302e3960b2d7493441ade1f9e04"
 	},
 	"derivationCommands": [


### PR DESCRIPTION
## Summary
- regenerate only the stale Anthropic provider source blob OID and SHA-256 evidence
- preserve #4026 as non-causal; no Codex or RevisionStore changes
- classify the SDK pagination rejection as a runner/I-O `EBADF` fault after direct stress passed

## Verification
- `bun test packages/ai/test/anthropic-cache-eval.integration.test.ts`
- `bun test packages/coding-agent/test/sdk-query-pagination.test.ts --rerun-each 25`
- `bun test packages/coding-agent/test/sdk-query-pagination.test.ts --rerun-each 100`
- CI shard reproduction identified `EBADF` while closing a file handle in the independent 40 MiB spill test; no lifecycle or write-registration gap was found.

*[repo owner's gaebal-gajae (clawdbot) 🦞]*