### PR TITLE
fix(tui): limit slash autocomplete to prompt start

### DIFF
--- a/packages/coding-agent/test/prompt-action-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-autocomplete.test.ts
@@ -187,35 +187,17 @@ describe("prompt action autocomplete", () => {
 		);
 	});
 
-	it("offers slash command names from inline prompt text", async () => {
+	it.each([
+		"please /he",
+		"please/hel",
+		"open /",
+	])("does not offer slash or path suggestions after prompt text: %s", async line => {
 		const provider = createNoopProvider([{ name: "help", description: "Learn commands and beginner workflows" }]);
-		const line = "please /he";
-		const suggestions = await provider.getSuggestions([line], 0, line.length);
 
-		expect(suggestions?.prefix).toBe("/he");
-		expect(suggestions?.items.map(item => item.value)).toContain("help");
+		expect(await provider.getSuggestions([line], 0, line.length)).toBeNull();
 	});
 
-	it("offers slash command names from adjacent inline prompt text", async () => {
-		const provider = createNoopProvider([{ name: "help", description: "Learn commands and beginner workflows" }]);
-		const line = "please/hel";
-		const suggestions = await provider.getSuggestions([line], 0, line.length);
-
-		expect(suggestions?.prefix).toBe("/hel");
-		expect(suggestions?.items.map(item => item.value)).toContain("help");
-	});
-
-	it("preserves root path suggestions for bare absolute inline slash", async () => {
-		const provider = createNoopProvider([{ name: "model", description: "Switch model" }]);
-		const line = "open /";
-		const suggestions = await provider.getSuggestions([line], 0, line.length);
-
-		expect(suggestions?.prefix).toBe("/");
-		expect(suggestions?.items.some(item => item.value.startsWith("/"))).toBe(true);
-		expect(suggestions?.items.map(item => item.value)).not.toContain("model");
-	});
-
-	it("opens the composer autocomplete list from an adjacent inline slash", async () => {
+	it("keeps the composer autocomplete closed for an inline slash", async () => {
 		const editor = new Editor(defaultEditorTheme);
 		editor.setAutocompleteProvider(
 			createNoopProvider([{ name: "help", description: "Learn commands and beginner workflows" }]),
@@ -224,22 +206,7 @@ describe("prompt action autocomplete", () => {
 		editor.handleInput("please/");
 		await Bun.sleep(0);
 
-		expect(editor.isShowingAutocomplete()).toBe(true);
-	});
-
-	it("applies adjacent inline slash command completion without replacing prompt text", async () => {
-		const provider = createNoopProvider([{ name: "help", description: "Learn commands and beginner workflows" }]);
-		const line = "please/hel";
-		const suggestions = await provider.getSuggestions([line], 0, line.length);
-		const item = suggestions?.items.find(entry => entry.value === "help");
-		expect(item).toBeDefined();
-		if (!item || !suggestions) {
-			throw new Error("expected help suggestion");
-		}
-
-		const applied = provider.applyCompletion([line], 0, line.length, item, suggestions.prefix);
-		expect(applied.lines[0]).toBe("please/help ");
-		expect(applied.cursorCol).toBe("please/help ".length);
+		expect(editor.isShowingAutocomplete()).toBe(false);
 	});
 
 	it("passes the typed trigger to undo and leaves text removal to the editor", async () => {

--- a/packages/coding-agent/test/prompt-action-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-autocomplete.test.ts
@@ -190,8 +190,7 @@ describe("prompt action autocomplete", () => {
 	it.each([
 		"please /he",
 		"please/hel",
-		"open /",
-	])("does not offer slash or path suggestions after prompt text: %s", async line => {
+	])("does not offer slash-command suggestions after prompt text: %s", async line => {
 		const provider = createNoopProvider([{ name: "help", description: "Learn commands and beginner workflows" }]);
 
 		expect(await provider.getSuggestions([line], 0, line.length)).toBeNull();

--- a/packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts
@@ -43,24 +43,13 @@ describe("prompt action skill autocomplete", () => {
 		expect(applied.lines[0]).toBe("/skill:deep-interview ");
 	});
 
-	it("normalizes inline direct skill-name typing to the canonical skill command", async () => {
+	it.each([
+		"please use /ra",
+		"/skill:deep-interview first /skill-deep",
+	])("does not offer skill completions after existing prompt text: %s", async line => {
 		const provider = createProvider();
-		const line = "please use /ra";
-		const suggestions = await provider.getSuggestions([line], 0, line.length);
-		expect(suggestions?.prefix).toBe("/ra");
-		expect(suggestions?.items[0]?.value).toBe("skill:ralplan");
-		const applied = provider.applyCompletion([line], 0, line.length, suggestions!.items[0]!, suggestions!.prefix);
-		expect(applied.lines[0]).toBe("please use /skill:ralplan ");
-	});
 
-	it("normalizes slash-skill-name typing at intermediate positions", async () => {
-		const provider = createProvider();
-		const line = "/skill:deep-interview first /skill-deep";
-		const suggestions = await provider.getSuggestions([line], 0, line.length);
-		expect(suggestions?.prefix).toBe("/skill-deep");
-		expect(suggestions?.items[0]?.value).toBe("skill:deep-interview");
-		const applied = provider.applyCompletion([line], 0, line.length, suggestions!.items[0]!, suggestions!.prefix);
-		expect(applied.lines[0]).toBe("/skill:deep-interview first /skill:deep-interview ");
+		expect(await provider.getSuggestions([line], 0, line.length)).toBeNull();
 	});
 
 	it("does not offer skill completions from a bare top-level slash token", async () => {
@@ -72,23 +61,13 @@ describe("prompt action skill autocomplete", () => {
 		expect(values.some(value => value.startsWith("skill:"))).toBe(false);
 	});
 
-	it("does not offer skill completions from an adjacent bare slash token after prompt text", async () => {
+	it.each([
+		"please use/",
+		"please use /skill",
+	])("keeps skill autocomplete closed for inline slash tokens: %s", async line => {
 		const provider = createProvider();
-		const line = "please use/";
-		const suggestions = await provider.getSuggestions([line], 0, line.length);
-		const values = suggestions?.items.map(item => item.value) ?? [];
-		expect(suggestions?.prefix).toBe("/");
-		expect(values).toEqual(expect.arrayContaining(["model"]));
-		expect(values.some(value => value.startsWith("skill:"))).toBe(false);
-	});
 
-	it("offers skill completions from an inline /skill token after prompt text", async () => {
-		const provider = createProvider();
-		const line = "please use /skill";
-		const suggestions = await provider.getSuggestions([line], 0, line.length);
-		expect(suggestions?.prefix).toBe("/skill");
-		expect(suggestions?.items.map(item => item.value)).toContain("skill:team");
-		expect(suggestions?.items.map(item => item.value)).not.toContain("model");
+		expect(await provider.getSuggestions([line], 0, line.length)).toBeNull();
 	});
 
 	it("does not rewrite a nested filesystem path as a skill command", async () => {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Native fuzzy matching and image encoding bindings now load only when their TUI feature is used instead of at module startup.
 
+### Fixed
+
+- Slash-command autocomplete now uses the same prompt-start rule for suggestions and Enter-time completion, preserves inline file-path suggestions, and never rewrites slash-like text on later prompt lines.
+
 ## [0.12.15] - 2026-08-06
 
 ## [0.12.14] - 2026-08-06

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -201,7 +201,6 @@ function normalizeSlashCommandText(value: string): string {
 		.trim()
 		.replace(/\s+/g, " ");
 }
-const NON_COMMAND_SLASH_PREFIX_PRECEDERS = new Set(["/", "\\", ":", ".", "~"]);
 function findOpenInlineCodeSpanStart(text: string): number | null {
 	let openDelimiter: number | null = null;
 
@@ -231,21 +230,8 @@ export function isInsideInlineCodeSpan(text: string): boolean {
 }
 
 export function extractSlashCommandTokenPrefix(text: string): string | null {
-	const slashIndex = text.lastIndexOf("/");
-	if (slashIndex === -1) return null;
-	if (isInsideInlineCodeSpan(text.slice(0, slashIndex + 1))) return null;
-
-	const token = text.slice(slashIndex);
-	if (/[\s]/.test(token)) return null;
-
-	const charBeforeSlash = text[slashIndex - 1];
-	if (charBeforeSlash && NON_COMMAND_SLASH_PREFIX_PRECEDERS.has(charBeforeSlash)) return null;
-
-	let tokenStart = slashIndex;
-	while (tokenStart > 0 && !/\s/.test(text[tokenStart - 1] ?? "")) tokenStart -= 1;
-	if (text.slice(tokenStart, slashIndex).includes("/")) return null;
-
-	return token;
+	if (!text.startsWith("/") || /[\s]/.test(text) || text.slice(1).includes("/")) return null;
+	return text;
 }
 export interface AutocompleteItem {
 	value: string;
@@ -369,26 +355,6 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			.map(({ score: _score, priority: _priority, matchRank: _matchRank, index: _index, ...rest }) => rest);
 	}
 
-	#getInlineSlashCommandNameSuggestions(prefix: string): AutocompleteItem[] {
-		if (prefix.length === 0) return this.#getSlashCommandNameSuggestions(prefix);
-
-		const normalizedPrefix = normalizeSlashCommandText(prefix);
-		return this.#getSlashCommandNameSuggestions(prefix).filter(item => {
-			const lowerValue = item.value.toLowerCase();
-			if (lowerValue.startsWith(prefix.toLowerCase())) return true;
-			if (!normalizedPrefix) return true;
-			return normalizeSlashCommandText(item.value).startsWith(normalizedPrefix);
-		});
-	}
-
-	#extractSlashCommandPrefix(text: string): string | null {
-		return extractSlashCommandTokenPrefix(text);
-	}
-
-	#isKnownCommandItem(item: AutocompleteItem): boolean {
-		return this.#commands.some(cmd => this.#getCommandName(cmd) === item.value);
-	}
-
 	async getSuggestions(
 		lines: string[],
 		cursorLine: number,
@@ -420,7 +386,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		}
 
 		// Check for slash commands at the submitted-message start
-		if (textBeforeCursor.startsWith("/")) {
+		if (cursorLine === 0 && textBeforeCursor.startsWith("/")) {
 			const spaceIndex = textBeforeCursor.indexOf(" ");
 
 			if (spaceIndex === -1) {
@@ -459,33 +425,10 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		}
 
 		const pathMatch = this.#extractPathPrefix(textBeforeCursor, false);
-		let pathSuggestions: AutocompleteItem[] | null = null;
-		const slashPrefix = this.#extractSlashCommandPrefix(textBeforeCursor);
-		if (slashPrefix) {
-			if (pathMatch === slashPrefix && slashPrefix.startsWith("/")) {
-				pathSuggestions = await this.#getFileSuggestions(pathMatch);
-				if (pathSuggestions.length > 0) {
-					return {
-						items: pathSuggestions,
-						kind: "default",
-						prefix: pathMatch,
-					};
-				}
-			}
-
-			const matches = this.#getInlineSlashCommandNameSuggestions(slashPrefix.slice(1));
-			if (matches.length > 0) {
-				return {
-					items: matches,
-					kind: "slash-command",
-					prefix: slashPrefix,
-				};
-			}
-		}
 
 		// Check for file paths - triggered by Tab or if we detect a path pattern
-		if (pathMatch !== null) {
-			const suggestions = pathSuggestions ?? (await this.#getFileSuggestions(pathMatch));
+		if (cursorLine === 0 && pathMatch !== null && pathMatch === textBeforeCursor) {
+			const suggestions = await this.#getFileSuggestions(pathMatch);
 			if (suggestions.length === 0) return null;
 
 			// Check if we have an exact match that is a directory
@@ -522,12 +465,8 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const beforePrefix = currentLine.slice(0, cursorCol - prefix.length);
 		const afterCursor = currentLine.slice(cursorCol);
 
-		// Check if we're completing a slash command name. Start-of-line commands
-		// execute on submit; inline slash tokens are completed as ordinary text.
-		const isSlashCommand =
-			prefix.startsWith("/") &&
-			!prefix.slice(1).includes("/") &&
-			(beforePrefix.trim() === "" || this.#isKnownCommandItem(item));
+		// Slash commands are completed only at the start of the prompt.
+		const isSlashCommand = prefix.startsWith("/") && !prefix.slice(1).includes("/") && beforePrefix.trim() === "";
 		if (isSlashCommand) {
 			// This is a command name completion
 			const newLine = `${beforePrefix}/${item.value} ${afterCursor}`;

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -233,6 +233,9 @@ export function extractSlashCommandTokenPrefix(text: string): string | null {
 	if (!text.startsWith("/") || /[\s]/.test(text) || text.slice(1).includes("/")) return null;
 	return text;
 }
+export function isSlashCommandPromptStart(lines: string[], cursorLine: number, textBeforeCursor: string): boolean {
+	return lines.slice(0, cursorLine).every(line => line.trim() === "") && textBeforeCursor.trimStart().startsWith("/");
+}
 export interface AutocompleteItem {
 	value: string;
 	label: string;
@@ -386,12 +389,13 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		}
 
 		// Check for slash commands at the submitted-message start
-		if (cursorLine === 0 && textBeforeCursor.startsWith("/")) {
-			const spaceIndex = textBeforeCursor.indexOf(" ");
+		if (isSlashCommandPromptStart(lines, cursorLine, textBeforeCursor)) {
+			const commandText = textBeforeCursor.trimStart();
+			const spaceIndex = commandText.indexOf(" ");
 
 			if (spaceIndex === -1) {
 				// No space yet - complete command names
-				const prefix = textBeforeCursor.slice(1); // Remove the "/"
+				const prefix = commandText.slice(1); // Remove the "/"
 				const matches = this.#getSlashCommandNameSuggestions(prefix);
 
 				if (matches.length === 0) return null;
@@ -399,13 +403,13 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				return {
 					items: matches,
 					kind: "slash-command",
-					prefix: textBeforeCursor,
+					prefix: commandText,
 				};
 			}
 
 			// Space found - complete command arguments
-			const commandName = textBeforeCursor.slice(1, spaceIndex); // Command without "/"
-			const argumentText = textBeforeCursor.slice(spaceIndex + 1); // Text after space
+			const commandName = commandText.slice(1, spaceIndex); // Command without "/"
+			const argumentText = commandText.slice(spaceIndex + 1); // Text after space
 
 			const command = this.#commands.find(cmd => this.#getCommandName(cmd) === commandName);
 			if (!command || !("getArgumentCompletions" in command) || !command.getArgumentCompletions) {
@@ -427,7 +431,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const pathMatch = this.#extractPathPrefix(textBeforeCursor, false);
 
 		// Check for file paths - triggered by Tab or if we detect a path pattern
-		if (cursorLine === 0 && pathMatch !== null && pathMatch === textBeforeCursor) {
+		if (pathMatch !== null) {
 			const suggestions = await this.#getFileSuggestions(pathMatch);
 			if (suggestions.length === 0) return null;
 
@@ -899,13 +903,14 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		return command.getInlineHint(argumentText);
 	}
 	trySyncSlashCompletion(textBeforeCursor: string): { items: AutocompleteItem[]; prefix: string } | null {
-		if (!textBeforeCursor.startsWith("/")) return null;
-		if (textBeforeCursor.length <= 1) return null; // Bare "/" alone, don't auto-complete
-		if (textBeforeCursor.includes(" ")) return null; // Only complete command name, not args
+		const commandText = textBeforeCursor.trimStart();
+		if (!commandText.startsWith("/")) return null;
+		if (commandText.length <= 1) return null; // Bare "/" alone, don't auto-complete
+		if (commandText.includes(" ")) return null; // Only complete command name, not args
 
-		const matches = this.#getSlashCommandNameSuggestions(textBeforeCursor.slice(1));
+		const matches = this.#getSlashCommandNameSuggestions(commandText.slice(1));
 
 		if (matches.length === 0) return null;
-		return { items: matches, prefix: textBeforeCursor };
+		return { items: matches, prefix: commandText };
 	}
 }

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -5,6 +5,7 @@ import {
 	type CombinedAutocompleteProvider,
 	extractSlashCommandTokenPrefix,
 	isInsideInlineCodeSpan,
+	isSlashCommandPromptStart,
 } from "../autocomplete";
 import { BracketedPasteHandler } from "../bracketed-paste";
 import { getKeybindings, type KeybindingsManager } from "../keybindings";
@@ -2838,13 +2839,14 @@ export class Editor implements Component, Focusable {
 	#isInSubmittedSlashCommandContext(): boolean {
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 		const beforeCursor = currentLine.slice(0, this.#state.cursorCol);
-		return this.#hasOnlyWhitespaceBeforeCursorLine() && beforeCursor.trimStart().startsWith("/");
+		return isSlashCommandPromptStart(this.#state.lines, this.#state.cursorLine, beforeCursor);
 	}
 
 	#getSlashTokenBeforeCursor(): string | null {
+		if (!this.#hasOnlyWhitespaceBeforeCursorLine()) return null;
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 		const beforeCursor = currentLine.slice(0, this.#state.cursorCol);
-		return extractSlashCommandTokenPrefix(beforeCursor);
+		return extractSlashCommandTokenPrefix(beforeCursor.trimStart());
 	}
 
 	#isInSlashTokenContext(): boolean {
@@ -2856,7 +2858,7 @@ export class Editor implements Component, Focusable {
 		const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
 		if (!textBeforeCursor.endsWith(this.#autocompletePrefix)) return false;
 		if (this.#autocompleteState !== "regular" || !this.#autocompletePrefix.startsWith("/")) return true;
-		return extractSlashCommandTokenPrefix(textBeforeCursor) === this.#autocompletePrefix;
+		return this.#getSlashTokenBeforeCursor() === this.#autocompletePrefix;
 	}
 	#captureAutocompleteOrigin(): { docVersion: number; cursorLine: number; cursorCol: number } {
 		return {

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -225,9 +225,7 @@ describe("slash command suggestion position", () => {
 	it.each([
 		"explain this /mo",
 		"explain this/hel",
-		"open /",
-		"open /tmp",
-	])("does not open automatic slash or path suggestions after prompt text: %s", async line => {
+	])("does not open automatic slash-command suggestions after prompt text: %s", async line => {
 		const provider = new CombinedAutocompleteProvider(
 			[
 				{ name: "model", description: "Switch AI model", value: "model" },
@@ -237,6 +235,37 @@ describe("slash command suggestion position", () => {
 		);
 
 		expect(await provider.getSuggestions([line], 0, line.length)).toBeNull();
+	});
+
+	it("preserves inline file-path suggestions after prompt text", async () => {
+		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "autocomplete-inline-path-test-"));
+		try {
+			fs.mkdirSync(path.join(baseDir, "src", "foo"), { recursive: true });
+			fs.writeFileSync(path.join(baseDir, "src", "foo", "bar.ts"), "export {};\n");
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = "read src/foo/";
+			const result = await provider.getSuggestions([line], 0, line.length);
+
+			expect(result?.prefix).toBe("src/foo/");
+			expect(result?.items.map(item => item.value)).toContain("src/foo/bar.ts");
+		} finally {
+			fs.rmSync(baseDir, { recursive: true, force: true });
+		}
+	});
+
+	it.each([
+		[["", "/mo"], 1, 3],
+		[["  /mo"], 0, 5],
+	])("offers command suggestions after only leading whitespace", async (lines, cursorLine, cursorCol) => {
+		const provider = new CombinedAutocompleteProvider(
+			[{ name: "model", description: "Switch AI model", value: "model" }],
+			"/tmp",
+		);
+		const result = await provider.getSuggestions(lines, cursorLine, cursorCol);
+
+		expect(result?.kind).toBe("slash-command");
+		expect(result?.prefix).toBe("/mo");
+		expect(result?.items.map(item => item.value)).toContain("model");
 	});
 
 	it("does not offer slash commands at the start of a later prompt line", async () => {

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -178,53 +178,19 @@ describe("CombinedAutocompleteProvider", () => {
 	});
 });
 
-describe("inline backtick slash classification", () => {
-	it.each([
-		["open span", "please use `/mo", null],
-		["closed span", "please use `/mo` then /he", "/he"],
-		["multiple spans", "`/mo` and `/he", null],
-		["odd escaped delimiter", "please use \\`/mo", "/mo"],
-		["even escaped delimiter", "please use \\\\`/mo", null],
-		["double-backtick run", "please use ``/mo", "/mo"],
-		["triple-backtick run", "please use ```/mo", "/mo"],
-	])("handles %s", (_name, text, expected) => {
-		expect(extractSlashCommandTokenPrefix(text)).toBe(expected);
-	});
-
-	it("resets literal state at line boundaries", () => {
-		expect(extractSlashCommandTokenPrefix("/mo")).toBe("/mo");
-	});
-
+describe("slash command token classification", () => {
 	it.each([
 		["top-level command", "/he", "/he"],
-		["inline command token", "please use /he", "/he"],
+		["inline command token", "please use /he", null],
+		["adjacent inline token", "please/hel", null],
 		["nested absolute path", "/chromium/src", null],
 		["multi-segment relative path", "chromium/lib/src", null],
 		["URL path", "https://example.com/he", null],
-	])("classifies %s with nested slash boundaries", (_name, text, expected) => {
+	])("classifies %s", (_name, text, expected) => {
 		expect(extractSlashCommandTokenPrefix(text)).toBe(expected);
 	});
 
-	it("preserves path suggestions inside an open inline-code span", async () => {
-		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "autocomplete-backtick-test-"));
-		try {
-			fs.mkdirSync(path.join(baseDir, "src", "foo"), { recursive: true });
-			fs.writeFileSync(path.join(baseDir, "src", "foo", "bar.ts"), "export {};\n");
-			const provider = new CombinedAutocompleteProvider(
-				[{ name: "model", description: "Switch AI model", value: "model" }],
-				baseDir,
-			);
-			const line = "please read `src/foo/";
-			const result = await provider.getSuggestions([line], 0, line.length);
-
-			expect(result?.prefix).toBe("src/foo/");
-			expect(result?.items.map(item => item.value)).toContain("src/foo/bar.ts");
-			expect(result?.items.map(item => item.value)).not.toContain("model");
-		} finally {
-			fs.rmSync(baseDir, { recursive: true, force: true });
-		}
-	});
-	it("preserves submitted command argument completion inside backticks", async () => {
+	it("preserves submitted command argument completion", async () => {
 		const provider = new CombinedAutocompleteProvider(
 			[
 				{
@@ -236,15 +202,15 @@ describe("inline backtick slash classification", () => {
 			],
 			"/tmp",
 		);
-		const line = "/read `src/foo/";
+		const line = "/read src/foo/";
 		const result = await provider.getSuggestions([line], 0, line.length);
 
-		expect(result?.prefix).toBe("`src/foo/");
-		expect(result?.items).toEqual([{ value: "`src/foo/", label: "existing argument completion" }]);
+		expect(result?.prefix).toBe("src/foo/");
+		expect(result?.items).toEqual([{ value: "src/foo/", label: "existing argument completion" }]);
 	});
 });
 
-describe("inline slash command suggestions", () => {
+describe("slash command suggestion position", () => {
 	it("marks start-of-input command-name suggestions as slash commands", async () => {
 		const provider = new CombinedAutocompleteProvider(
 			[{ name: "model", description: "Switch AI model", value: "model" }],
@@ -253,100 +219,33 @@ describe("inline slash command suggestions", () => {
 		const result = await provider.getSuggestions(["/mo"], 0, 3);
 
 		expect(result?.kind).toBe("slash-command");
+		expect(result?.items.map(item => item.value)).toContain("model");
 	});
 
-	it("suggests command names for slash tokens after existing prompt text", async () => {
+	it.each([
+		"explain this /mo",
+		"explain this/hel",
+		"open /",
+		"open /tmp",
+	])("does not open automatic slash or path suggestions after prompt text: %s", async line => {
+		const provider = new CombinedAutocompleteProvider(
+			[
+				{ name: "model", description: "Switch AI model", value: "model" },
+				{ name: "help", description: "Learn commands", value: "help" },
+			],
+			"/tmp",
+		);
+
+		expect(await provider.getSuggestions([line], 0, line.length)).toBeNull();
+	});
+
+	it("does not offer slash commands at the start of a later prompt line", async () => {
 		const provider = new CombinedAutocompleteProvider(
 			[{ name: "model", description: "Switch AI model", value: "model" }],
 			"/tmp",
 		);
-		const line = "explain this /mo";
-		const result = await provider.getSuggestions([line], 0, line.length);
 
-		expect(result).not.toBeNull();
-		expect(result!.prefix).toBe("/mo");
-		expect(result!.kind).toBe("slash-command");
-		expect(result!.items.map(item => item.value)).toEqual(["model"]);
-	});
-
-	it("suggests command names for slash tokens adjacent to prompt text", async () => {
-		const provider = new CombinedAutocompleteProvider(
-			[{ name: "help", description: "Learn commands", value: "help" }],
-			"/tmp",
-		);
-		const line = "explain this/hel";
-		const result = await provider.getSuggestions([line], 0, line.length);
-
-		expect(result).not.toBeNull();
-		expect(result!.prefix).toBe("/hel");
-		expect(result!.items.map(item => item.value)).toEqual(["help"]);
-	});
-
-	it("lets absolute paths use file suggestions when the inline slash token is not a command prefix", async () => {
-		const line = "open /tmp";
-		const pathOnlyProvider = new CombinedAutocompleteProvider([], "/tmp");
-		const pathOnlyResult = await pathOnlyProvider.getSuggestions([line], 0, line.length);
-		const provider = new CombinedAutocompleteProvider(
-			[{ name: "template", description: "Temporary prompt template", value: "template" }],
-			"/tmp",
-		);
-		const result = await provider.getSuggestions([line], 0, line.length);
-
-		expect(result).toEqual(pathOnlyResult);
-		expect(result?.kind).toBe("default");
-		expect(result?.items.map(item => item.value) ?? []).not.toContain("template");
-	});
-
-	it("lets bare absolute root paths use file suggestions before slash commands", async () => {
-		const line = "open /";
-		const provider = new CombinedAutocompleteProvider(
-			[{ name: "model", description: "Switch model", value: "model" }],
-			"/tmp",
-		);
-		const result = await provider.getSuggestions([line], 0, line.length);
-
-		expect(result).not.toBeNull();
-		expect(result!.prefix).toBe("/");
-		expect(result!.kind).toBe("default");
-		expect(result!.items.some(item => item.value.startsWith("/"))).toBe(true);
-		expect(result!.items.map(item => item.value)).not.toContain("model");
-	});
-
-	it("matches normalized inline slash command prefixes", async () => {
-		const provider = new CombinedAutocompleteProvider(
-			[{ name: "skill:team", description: "Run team workflow", value: "skill:team" }],
-			"/tmp",
-		);
-		const line = "explain this /skill-te";
-		const result = await provider.getSuggestions([line], 0, line.length);
-
-		expect(result).not.toBeNull();
-		expect(result!.prefix).toBe("/skill-te");
-		expect(result!.items.map(item => item.value)).toEqual(["skill:team"]);
-	});
-
-	it("applies inline slash command completion without replacing prior text", () => {
-		const provider = new CombinedAutocompleteProvider(
-			[{ name: "model", description: "Switch AI model", value: "model" }],
-			"/tmp",
-		);
-		const line = "explain this /mo";
-		const result = provider.applyCompletion([line], 0, line.length, { value: "model", label: "model" }, "/mo");
-
-		expect(result.lines[0]).toBe("explain this /model ");
-		expect(result.cursorCol).toBe("explain this /model ".length);
-	});
-
-	it("applies adjacent inline slash command completion without replacing prior text", () => {
-		const provider = new CombinedAutocompleteProvider(
-			[{ name: "help", description: "Learn commands", value: "help" }],
-			"/tmp",
-		);
-		const line = "explain this/hel";
-		const result = provider.applyCompletion([line], 0, line.length, { value: "help", label: "help" }, "/hel");
-
-		expect(result.lines[0]).toBe("explain this/help ");
-		expect(result.cursorCol).toBe("explain this/help ".length);
+		expect(await provider.getSuggestions(["explain this", "/mo"], 1, 3)).toBeNull();
 	});
 });
 describe("trySyncSlashCompletion", () => {
@@ -602,10 +501,10 @@ describe("Editor autocomplete layout", () => {
 			"  한글명령                        Unicode workflow description",
 		]);
 	});
-	it("uses the compact slash-command layout for inline command-name suggestions", async () => {
+	it("does not render slash-command suggestions after existing prompt text", async () => {
 		const lines = await renderEditorAutocomplete("/g", slashItems, 120, "slash-command", "explain this ");
 
-		expect(lines).toEqual(["> go          Run immediately", "  한글명령    Unicode workflow description"]);
+		expect(lines).toEqual([]);
 	});
 
 	it("keeps absolute-path file autocomplete byte-identical to the default layout", async () => {

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -217,7 +217,7 @@ class InlineSkillProvider implements AutocompleteProvider {
 	syncCallCount = 0;
 }
 describe("Editor Enter handler sync slash completion", () => {
-	it("auto-triggers slash command autocomplete from an inline slash after prompt text", async () => {
+	it("does not auto-trigger slash command autocomplete after prompt text", async () => {
 		const editor = new Editor(defaultEditorTheme);
 		editor.setAutocompleteProvider(
 			new CombinedAutocompleteProvider([{ name: "model", description: "Switch model", value: "model" }], "/tmp"),
@@ -226,10 +226,10 @@ describe("Editor Enter handler sync slash completion", () => {
 		editor.handleInput("explain this/");
 		await Bun.sleep(0);
 
-		expect(editor.isShowingAutocomplete()).toBe(true);
+		expect(editor.isShowingAutocomplete()).toBe(false);
 	});
 
-	it("auto-triggers slash command autocomplete from an adjacent slash after prompt text", async () => {
+	it("does not auto-trigger slash command autocomplete from an adjacent slash", async () => {
 		const editor = new Editor(defaultEditorTheme);
 		editor.setAutocompleteProvider(
 			new CombinedAutocompleteProvider([{ name: "help", description: "Learn commands", value: "help" }], "/tmp"),
@@ -238,7 +238,7 @@ describe("Editor Enter handler sync slash completion", () => {
 		editor.handleInput("explain this/");
 		await Bun.sleep(0);
 
-		expect(editor.isShowingAutocomplete()).toBe(true);
+		expect(editor.isShowingAutocomplete()).toBe(false);
 	});
 	it("opens path-only autocomplete inside inline code", async () => {
 		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "editor-backtick-path-"));
@@ -349,7 +349,7 @@ describe("Editor Enter handler sync slash completion", () => {
 		expect(editor.getText()).toBe("please read `src/");
 	});
 
-	it("restores command autocomplete after a closed inline-code span", async () => {
+	it("keeps command autocomplete closed after a closed inline-code span", async () => {
 		const editor = new Editor(defaultEditorTheme);
 		editor.setAutocompleteProvider(
 			new CombinedAutocompleteProvider([{ name: "model", description: "Switch model", value: "model" }], "/tmp"),
@@ -359,10 +359,10 @@ describe("Editor Enter handler sync slash completion", () => {
 		editor.handleInput("o");
 		await Bun.sleep(20);
 
-		expect(editor.isShowingAutocomplete()).toBe(true);
+		expect(editor.isShowingAutocomplete()).toBe(false);
 	});
 
-	it("auto-triggers inline slash skill autocomplete after prompt text", async () => {
+	it("does not auto-trigger inline slash skill autocomplete after prompt text", async () => {
 		const provider = new InlineSkillProvider();
 		const editor = new Editor(defaultEditorTheme);
 		editor.setAutocompleteProvider(provider);
@@ -370,11 +370,11 @@ describe("Editor Enter handler sync slash completion", () => {
 		editor.handleInput("explain with /skill-te");
 		await Bun.sleep(0);
 
-		expect(provider.suggestionCalls).toBeGreaterThan(0);
-		expect(editor.isShowingAutocomplete()).toBe(true);
+		expect(provider.suggestionCalls).toBe(0);
+		expect(editor.isShowingAutocomplete()).toBe(false);
 	});
 
-	it("applies inline slash skill completion before submitting", async () => {
+	it("submits inline slash skill text without completion", async () => {
 		const provider = new InlineSkillProvider();
 		const editor = new Editor(defaultEditorTheme);
 		editor.setAutocompleteProvider(provider);
@@ -387,7 +387,7 @@ describe("Editor Enter handler sync slash completion", () => {
 		await Bun.sleep(0);
 		editor.handleInput("\r");
 
-		expect(submitted).toBe("explain with /skill:team");
+		expect(submitted).toBe("explain with /skill-te");
 	});
 	it("submits an inline-code skill token without synchronous Enter completion", () => {
 		const provider = new InlineSkillProvider();

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -389,6 +389,33 @@ describe("Editor Enter handler sync slash completion", () => {
 
 		expect(submitted).toBe("explain with /skill-te");
 	});
+	it("does not synchronously rewrite a slash skill token on a later prompt line", () => {
+		const provider = new InlineSkillProvider();
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(provider);
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		editor.setText("explain this\n/skill-te");
+		editor.handleInput("\r");
+
+		expect(submitted).toBe("explain this\n/skill-te");
+		expect(provider.syncCallCount).toBe(0);
+	});
+	it.each(["\n/m", "  /m"])("shows command completion for prompt-start whitespace: %s", async initialText => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(
+			new CombinedAutocompleteProvider([{ name: "model", description: "Switch model", value: "model" }], "/tmp"),
+		);
+		editor.setText(initialText);
+
+		editor.handleInput("o");
+		await Bun.sleep(20);
+
+		expect(editor.isShowingAutocomplete()).toBe(true);
+	});
 	it("submits an inline-code skill token without synchronous Enter completion", () => {
 		const provider = new InlineSkillProvider();
 		const editor = new Editor(defaultEditorTheme);


### PR DESCRIPTION
## Summary
- use one prompt-start rule across provider, editor, and Enter-time slash completion
- preserve visible command completion after leading blank lines or spaces
- prevent hidden rewrites of `/skill-*` text on later prompt lines
- restore automatic inline file-path suggestions
- replay the scoped intent from closed #4000 onto current `dev`

## Review mapping
- blank first line and leading-space commands: fixed with shared `isSlashCommandPromptStart`
- later-line Enter rewrite: fixed by gating token extraction on prompt-start whitespace
- inline file-path regression: fixed independently of slash-command classification
- TUI changelog: added under `## [Unreleased]`
- base branch: fresh PR targets `dev`

## Verification
- `bun test packages/tui/test/autocomplete.test.ts packages/tui/test/editor-autocomplete-actions.test.ts packages/coding-agent/test/prompt-action-autocomplete.test.ts packages/coding-agent/test/prompt-action-skill-autocomplete.test.ts` — 91 pass, 0 fail, 190 assertions
- `bun --cwd=packages/tui run check` — clean
- `bun --cwd=packages/coding-agent run check` — typecheck clean; one pre-existing unrelated smithery `KEYS` warning
- `git diff --check origin/dev...HEAD` — clean

Historical PR: #4000