### PR TITLE
fix(acp): make an ACP turn settle when it finishes and survive while it runs

### DIFF
--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -50,11 +50,7 @@ import { ensureBroker } from "../../sdk/broker/ensure";
 import { readSdkBrokerDiscovery, SdkClient, SdkClientError } from "../../sdk/client";
 import { SYNTHETIC_PROVIDER_ID } from "../../sdk/model-profile-model";
 import type { SdkPromptTerminalOutcome } from "../../sdk/prompt-status";
-import {
-	ACP_PROMPT_INACTIVITY_TIMEOUT_MS,
-	type PromptWatchdogClock,
-	systemPromptWatchdogClock,
-} from "../../sdk/prompt-watchdog";
+import { PromptToolActivity, type PromptWatchdogClock, systemPromptWatchdogClock } from "../../sdk/prompt-watchdog";
 import {
 	buildToolCallStartUpdate,
 	mapAgentSessionEventToAcpSessionUpdates,
@@ -115,6 +111,8 @@ interface PromptWaiter {
 	lastFrameType: string;
 	/** Cancels the armed inactivity watchdog; re-armed by every inbound frame for this prompt. */
 	cancelWatchdog?: () => void;
+	/** Tool calls the host started but has not ended; widens the bound while one is running. */
+	toolActivity: PromptToolActivity;
 	resolve: (response: PromptResponse) => void;
 	reject: (error: Error) => void;
 }
@@ -1263,6 +1261,7 @@ export class AcpAgent implements Agent {
 				deferredFrames: [],
 				lastFrameAt: this.#promptWatchdogClock.now(),
 				lastFrameType: "prompt_dispatch",
+				toolActivity: new PromptToolActivity(),
 				resolve,
 				reject,
 			};
@@ -1863,7 +1862,7 @@ export class AcpAgent implements Agent {
 		waiter.cancelWatchdog?.();
 		// No frame can still arrive once the transport is known to be gone, so waiting out
 		// the full bound would only add dead time to an outcome that is already decided.
-		const delayMs = this.#promptTransportGone(id, record) ? 0 : ACP_PROMPT_INACTIVITY_TIMEOUT_MS;
+		const delayMs = this.#promptTransportGone(id, record) ? 0 : waiter.toolActivity.inactivityBoundMs;
 		waiter.cancelWatchdog = this.#promptWatchdogClock.schedule(() => {
 			void this.#expirePromptWatchdog(id, record, waiter);
 		}, delayMs);
@@ -1877,6 +1876,12 @@ export class AcpAgent implements Agent {
 		waiter.lastFrameAt = this.#promptWatchdogClock.now();
 		waiter.lastFrameType =
 			typeof event?.type === "string" ? event.type : typeof frame.type === "string" ? frame.type : "unknown";
+		// Tool lifecycle frames also decide which bound the next gap gets: silence while a
+		// tool is observably executing is expected, silence with nothing running is not.
+		waiter.toolActivity.observe(
+			typeof event?.type === "string" ? event.type : undefined,
+			typeof event?.toolCallId === "string" ? event.toolCallId : undefined,
+		);
 		this.#armPromptWatchdog(id, record, waiter);
 	}
 
@@ -1900,7 +1905,8 @@ export class AcpAgent implements Agent {
 			cause,
 			silenceMs,
 			lastFrameType: waiter.lastFrameType,
-			inactivityBoundMs: ACP_PROMPT_INACTIVITY_TIMEOUT_MS,
+			inactivityBoundMs: waiter.toolActivity.inactivityBoundMs,
+			toolRunning: waiter.toolActivity.running,
 			...(waiter.correlation.commandId ? { commandId: waiter.correlation.commandId } : {}),
 			...(waiter.correlation.turnId ? { turnId: waiter.correlation.turnId } : {}),
 		});

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -51,6 +51,11 @@ import { readSdkBrokerDiscovery, SdkClient, SdkClientError } from "../../sdk/cli
 import { SYNTHETIC_PROVIDER_ID } from "../../sdk/model-profile-model";
 import type { SdkPromptTerminalOutcome } from "../../sdk/prompt-status";
 import {
+	ACP_PROMPT_INACTIVITY_TIMEOUT_MS,
+	type PromptWatchdogClock,
+	systemPromptWatchdogClock,
+} from "../../sdk/prompt-watchdog";
+import {
 	buildToolCallStartUpdate,
 	mapAgentSessionEventToAcpSessionUpdates,
 	mapAgentWireEventPayloadToAcpSessionUpdates,
@@ -104,6 +109,12 @@ interface PromptWaiter {
 	terminal?: { outcome: SdkPromptTerminalOutcome; correlation: PromptCorrelation };
 	/** Frames for an already-settled correlation held until acknowledgement resolves ownership. */
 	deferredFrames: JsonObject[];
+	/** Clock reading of the last inbound frame for this prompt; baseline of the inactivity watchdog. */
+	lastFrameAt: number;
+	/** Frame (or wire event) type of that last frame, reported when the watchdog expires. */
+	lastFrameType: string;
+	/** Cancels the armed inactivity watchdog; re-armed by every inbound frame for this prompt. */
+	cancelWatchdog?: () => void;
 	resolve: (response: PromptResponse) => void;
 	reject: (error: Error) => void;
 }
@@ -160,6 +171,14 @@ function parseAcpStartupOptions(value: unknown): AcpStartupOptions | undefined {
 				...(modelPreset ? { modelPreset } : {}),
 				...(thinkingLevel ? { thinkingLevel } : {}),
 			}
+		: undefined;
+}
+
+/** Tests inject a virtual clock so watchdog coverage never sleeps in real time. */
+function parsePromptWatchdogClock(value: unknown): PromptWatchdogClock | undefined {
+	const candidate = object(value);
+	return typeof candidate?.now === "function" && typeof candidate.schedule === "function"
+		? (candidate as unknown as PromptWatchdogClock)
 		: undefined;
 }
 
@@ -298,6 +317,15 @@ function hasCompleteCorrelation(correlation: PromptCorrelation): correlation is 
 		typeof correlation.turnId === "string" &&
 		correlation.turnId.trim().length > 0
 	);
+}
+
+function clearPromptWatchdog(waiter: PromptWaiter): void {
+	waiter.cancelWatchdog?.();
+	waiter.cancelWatchdog = undefined;
+}
+
+function describeCorrelation(correlation: PromptCorrelation): string {
+	return `commandId=${correlation.commandId ?? "none"} turnId=${correlation.turnId ?? "none"}`;
 }
 
 function correlationsExactlyMatch(expected: PromptCorrelation, actual: PromptCorrelation): boolean {
@@ -889,12 +917,20 @@ export class AcpAgent implements Agent {
 	#broker: Promise<BrokerConnection> | undefined;
 	readonly #startupOptions: AcpStartupOptions | undefined;
 	readonly #cancelSettlementGraceMs: number;
+	readonly #promptWatchdogClock: PromptWatchdogClock;
 	#disposed = false;
 	#disposePromise: Promise<void> | undefined;
 
 	constructor(
 		connection: AgentSideConnection,
-		options?: { agentDir?: string; startupOptions?: AcpStartupOptions; cancelSettlementGraceMs?: number } | unknown,
+		options?:
+			| {
+					agentDir?: string;
+					startupOptions?: AcpStartupOptions;
+					cancelSettlementGraceMs?: number;
+					promptWatchdogClock?: PromptWatchdogClock;
+			  }
+			| unknown,
 	) {
 		this.#connection = connection;
 		const candidate = object(options);
@@ -905,6 +941,7 @@ export class AcpAgent implements Agent {
 			Number.isSafeInteger(candidate.cancelSettlementGraceMs)
 				? candidate.cancelSettlementGraceMs
 				: CANCEL_SETTLEMENT_GRACE_MS;
+		this.#promptWatchdogClock = parsePromptWatchdogClock(candidate?.promptWatchdogClock) ?? systemPromptWatchdogClock;
 		queueMicrotask(() => {
 			if (connection.signal.aborted) {
 				this.#beginDispose();
@@ -1224,11 +1261,16 @@ export class AcpAgent implements Agent {
 				emittedAssistantText: "",
 				settled: false,
 				deferredFrames: [],
+				lastFrameAt: this.#promptWatchdogClock.now(),
+				lastFrameType: "prompt_dispatch",
 				resolve,
 				reject,
 			};
 			record.activePrompt = waiter;
 		});
+		// Silence has to be bounded from the moment the prompt owns the session: a host that
+		// dies before it ever answers is exactly the failure that leaves the client running.
+		this.#armPromptWatchdog(params.sessionId, record, waiter);
 		// Echo the user's own message back as `user_message_chunk`. Clients render their
 		// transcript from session/update, so without this a prompt's text and any attached
 		// image never appear in the client UI — only the agent's reply does. Replay
@@ -1272,6 +1314,7 @@ export class AcpAgent implements Agent {
 			this.#settlePrompt(record, waiter);
 		} catch (error) {
 			waiter.deferredFrames.length = 0;
+			clearPromptWatchdog(waiter);
 			waiter.terminal = undefined;
 			waiter.settled = true;
 			if (record.activePrompt === waiter) record.activePrompt = undefined;
@@ -1326,6 +1369,7 @@ export class AcpAgent implements Agent {
 		// when nothing settled the prompt the client already asked to cancel.
 		if (this.#sessions.get(id) !== record || record.activePrompt !== waiter || waiter.settled) return;
 		record.activePrompt = undefined;
+		clearPromptWatchdog(waiter);
 		record.cancelRequested = false;
 		waiter.settled = true;
 		waiter.deferredFrames.length = 0;
@@ -1674,6 +1718,7 @@ export class AcpAgent implements Agent {
 				// MUST catch these errors and return the semantically meaningful `cancelled`
 				// stop reason." Involuntary teardown (transport loss) still rejects.
 				if (waiter && !waiter.settled) {
+					clearPromptWatchdog(waiter);
 					if (reason === "closed" || reason === "discarded") {
 						waiter.settled = true;
 						waiter.resolve({ stopReason: "cancelled" });
@@ -1721,6 +1766,7 @@ export class AcpAgent implements Agent {
 		record.reconnectUnsubscribe();
 		const waiter = record.activePrompt;
 		record.activePrompt = undefined;
+		if (waiter) clearPromptWatchdog(waiter);
 		waiter?.reject(error);
 		try {
 			await adapter.close();
@@ -1806,11 +1852,79 @@ export class AcpAgent implements Agent {
 		return new AcpSdkAdapterError("frame_processing_failed", `ACP session frame processing failed: ${detail}`);
 	}
 
+	/**
+	 * Bounds how long one prompt may stay silent. A session host that stops producing
+	 * never publishes a terminal frame, and an ACP prompt only settles on a terminal, so
+	 * without this bound `session/prompt` never returns and the client reports the turn as
+	 * running forever behind a dead session.
+	 */
+	#armPromptWatchdog(id: string, record: SessionRecord, waiter: PromptWaiter): void {
+		if (waiter.settled) return;
+		waiter.cancelWatchdog?.();
+		// No frame can still arrive once the transport is known to be gone, so waiting out
+		// the full bound would only add dead time to an outcome that is already decided.
+		const delayMs = this.#promptTransportGone(id, record) ? 0 : ACP_PROMPT_INACTIVITY_TIMEOUT_MS;
+		waiter.cancelWatchdog = this.#promptWatchdogClock.schedule(() => {
+			void this.#expirePromptWatchdog(id, record, waiter);
+		}, delayMs);
+	}
+
+	/** Any frame proves the producer is alive, so every one of them restarts the bound. */
+	#refreshPromptWatchdog(id: string, record: SessionRecord, frame: JsonObject): void {
+		const waiter = record.activePrompt;
+		if (!waiter || waiter.settled) return;
+		const event = receivedSdkEvent(frame)?.event;
+		waiter.lastFrameAt = this.#promptWatchdogClock.now();
+		waiter.lastFrameType =
+			typeof event?.type === "string" ? event.type : typeof frame.type === "string" ? frame.type : "unknown";
+		this.#armPromptWatchdog(id, record, waiter);
+	}
+
+	/** Names why the prompt can be settled at once instead of waiting out the inactivity bound. */
+	#promptTransportGone(id: string, record: SessionRecord): string | undefined {
+		if (this.#disposed || this.#connection.signal.aborted) return "the ACP client connection is closed";
+		if (this.#sessions.get(id) !== record) return "the SDK session host record was already discarded";
+		return undefined;
+	}
+
+	/**
+	 * Settles the ACP prompt only. The agent's own work is left alone: this reports that the
+	 * turn can no longer be observed, it does not cancel or tear down the session.
+	 */
+	async #expirePromptWatchdog(id: string, record: SessionRecord, waiter: PromptWaiter): Promise<void> {
+		if (record.activePrompt !== waiter || waiter.settled) return;
+		const silenceMs = Math.max(0, this.#promptWatchdogClock.now() - waiter.lastFrameAt);
+		const cause = this.#promptTransportGone(id, record) ?? "the SDK session host stopped producing frames";
+		logger.error("acp_prompt_watchdog_expired", {
+			sessionId: id,
+			cause,
+			silenceMs,
+			lastFrameType: waiter.lastFrameType,
+			inactivityBoundMs: ACP_PROMPT_INACTIVITY_TIMEOUT_MS,
+			...(waiter.correlation.commandId ? { commandId: waiter.correlation.commandId } : {}),
+			...(waiter.correlation.turnId ? { turnId: waiter.correlation.turnId } : {}),
+		});
+		await this.#rejectPrompt(
+			record,
+			id,
+			waiter,
+			new AcpSdkAdapterError(
+				"prompt_abandoned",
+				`ACP prompt was abandoned after ${Math.round(silenceMs / 1_000)}s of silence: ${cause}. Last frame was ` +
+					`"${waiter.lastFrameType}" (${describeCorrelation(waiter.correlation)}). The turn was settled so the ` +
+					`client stops waiting; the session still accepts the next prompt.`,
+			),
+		);
+	}
+
 	#enqueueSdkFrame(id: string, adapter: AcpSdkAdapter, frame: JsonObject): void {
 		const record = this.#sessions.get(id);
 		if (!record || record.adapter !== adapter) return;
 		// Ingress ordering is recorded before queued work begins.
 		this.#observeSessionActivity(record, frame);
+		// Any frame at all proves the producer is still alive, so it refreshes the
+		// inactivity watchdog before the queued work that may take a long time to run.
+		this.#refreshPromptWatchdog(id, record, frame);
 		++record.inboundSequence;
 		const task = record.frameTail.then(async () => await this.#handleSdkFrame(id, adapter, frame));
 		record.frameTail = task.catch(
@@ -1828,6 +1942,7 @@ export class AcpAgent implements Agent {
 				const waiter = record.activePrompt;
 				if (waiter && !waiter.settled && !waiter.terminal) {
 					record.activePrompt = undefined;
+					clearPromptWatchdog(waiter);
 					waiter.settled = true;
 					if (hasCorrelation(waiter.correlation)) {
 						record.settledPromptCorrelations.push(waiter.correlation);
@@ -1978,6 +2093,7 @@ export class AcpAgent implements Agent {
 	): Promise<void> {
 		if (record.activePrompt !== waiter || waiter.settled) return;
 		record.activePrompt = undefined;
+		clearPromptWatchdog(waiter);
 		waiter.settled = true;
 		waiter.deferredFrames.length = 0;
 		waiter.terminal = undefined;
@@ -2024,6 +2140,7 @@ export class AcpAgent implements Agent {
 			return;
 		}
 		record.activePrompt = undefined;
+		clearPromptWatchdog(waiter);
 		waiter.settled = true;
 		if (hasCorrelation(waiter.correlation)) {
 			record.settledPromptCorrelations.push(waiter.correlation);

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1878,7 +1878,12 @@ export class AcpAgent implements Agent {
 		}, delayMs);
 	}
 
-	/** Any frame proves the producer is alive, so every one of them restarts the bound. */
+	/**
+	 * Any frame proves the producer is alive, so every one of them restarts the bound: liveness
+	 * is a property of the session host process, not of one turn, and a host still flushing an
+	 * abandoned turn's backlog is exactly a producer that has not stopped producing. Which bound
+	 * is restarted is a different question, and that one is correlation-owned; see below.
+	 */
 	#refreshPromptWatchdog(id: string, record: SessionRecord, frame: JsonObject): void {
 		const waiter = record.activePrompt;
 		if (!waiter || waiter.settled) return;
@@ -1886,14 +1891,21 @@ export class AcpAgent implements Agent {
 		waiter.lastFrameAt = this.#promptWatchdogClock.now();
 		waiter.lastFrameType =
 			typeof event?.type === "string" ? event.type : typeof frame.type === "string" ? frame.type : "unknown";
-		// Lifecycle frames also decide which bound the next gap gets: silence while a tool is
-		// observably executing, or while a dispatched model call has not answered yet, is
-		// expected; silence with nothing running and nobody thinking is not.
-		waiter.activity.observe(
-			typeof event?.type === "string" ? event.type : undefined,
-			typeof event?.toolCallId === "string" ? event.toolCallId : undefined,
-			frameMessageRole(event),
-		);
+		// Which bound applies is per-turn state, so it is fenced by the same identity that gates
+		// settlement: only a frame carrying exactly the acknowledged prompt's command/turn may
+		// start, clear, or extend a bound. Without this fence an already-settled turn's flushed
+		// frames mutate the live turn — a stale `message_update` clears `awaitingModel` and
+		// narrows it off the inference bound, a stale `tool_execution_start` pins it to the tool
+		// bound with no tool running. Frames with no correlation at all (heartbeats,
+		// session-scoped events) are refresh-only for the same reason: they prove the producer
+		// lives but say nothing about what this turn is doing, so they leave the bound as is.
+		// Before acknowledgement the prompt has no identity, so nothing is provably its own yet.
+		if (correlationsExactlyMatch(waiter.correlation, correlationFrom(frame, event)))
+			waiter.activity.observe(
+				typeof event?.type === "string" ? event.type : undefined,
+				typeof event?.toolCallId === "string" ? event.toolCallId : undefined,
+				frameMessageRole(event),
+			);
 		this.#armPromptWatchdog(id, record, waiter);
 	}
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -50,7 +50,7 @@ import { ensureBroker } from "../../sdk/broker/ensure";
 import { readSdkBrokerDiscovery, SdkClient, SdkClientError } from "../../sdk/client";
 import { SYNTHETIC_PROVIDER_ID } from "../../sdk/model-profile-model";
 import type { SdkPromptTerminalOutcome } from "../../sdk/prompt-status";
-import { PromptToolActivity, type PromptWatchdogClock, systemPromptWatchdogClock } from "../../sdk/prompt-watchdog";
+import { PromptActivity, type PromptWatchdogClock, systemPromptWatchdogClock } from "../../sdk/prompt-watchdog";
 import {
 	buildToolCallStartUpdate,
 	mapAgentSessionEventToAcpSessionUpdates,
@@ -111,8 +111,8 @@ interface PromptWaiter {
 	lastFrameType: string;
 	/** Cancels the armed inactivity watchdog; re-armed by every inbound frame for this prompt. */
 	cancelWatchdog?: () => void;
-	/** Tool calls the host started but has not ended; widens the bound while one is running. */
-	toolActivity: PromptToolActivity;
+	/** What the host is observably doing — a tool running, a model call unanswered — and the bound that follows from it. */
+	activity: PromptActivity;
 	resolve: (response: PromptResponse) => void;
 	reject: (error: Error) => void;
 }
@@ -450,6 +450,16 @@ function receivedSdkEvent(frame: JsonObject): ReceivedSdkEvent | undefined {
 		event,
 		...(object(payload.event) ? { wirePayload: payload } : {}),
 	};
+}
+
+/**
+ * Author of the message a `message_start`/`message_end` frame carries. The host echoes the
+ * user prompt and every tool result back through the same events, so only `"assistant"`
+ * proves a model call answered.
+ */
+function frameMessageRole(event: JsonObject | undefined): string | undefined {
+	const role = object(event?.message)?.role;
+	return typeof role === "string" ? role : undefined;
 }
 
 const ACP_CONFIG_OPTIONS = [
@@ -1261,7 +1271,7 @@ export class AcpAgent implements Agent {
 				deferredFrames: [],
 				lastFrameAt: this.#promptWatchdogClock.now(),
 				lastFrameType: "prompt_dispatch",
-				toolActivity: new PromptToolActivity(),
+				activity: new PromptActivity(),
 				resolve,
 				reject,
 			};
@@ -1862,7 +1872,7 @@ export class AcpAgent implements Agent {
 		waiter.cancelWatchdog?.();
 		// No frame can still arrive once the transport is known to be gone, so waiting out
 		// the full bound would only add dead time to an outcome that is already decided.
-		const delayMs = this.#promptTransportGone(id, record) ? 0 : waiter.toolActivity.inactivityBoundMs;
+		const delayMs = this.#promptTransportGone(id, record) ? 0 : waiter.activity.inactivityBoundMs;
 		waiter.cancelWatchdog = this.#promptWatchdogClock.schedule(() => {
 			void this.#expirePromptWatchdog(id, record, waiter);
 		}, delayMs);
@@ -1876,11 +1886,13 @@ export class AcpAgent implements Agent {
 		waiter.lastFrameAt = this.#promptWatchdogClock.now();
 		waiter.lastFrameType =
 			typeof event?.type === "string" ? event.type : typeof frame.type === "string" ? frame.type : "unknown";
-		// Tool lifecycle frames also decide which bound the next gap gets: silence while a
-		// tool is observably executing is expected, silence with nothing running is not.
-		waiter.toolActivity.observe(
+		// Lifecycle frames also decide which bound the next gap gets: silence while a tool is
+		// observably executing, or while a dispatched model call has not answered yet, is
+		// expected; silence with nothing running and nobody thinking is not.
+		waiter.activity.observe(
 			typeof event?.type === "string" ? event.type : undefined,
 			typeof event?.toolCallId === "string" ? event.toolCallId : undefined,
+			frameMessageRole(event),
 		);
 		this.#armPromptWatchdog(id, record, waiter);
 	}
@@ -1905,8 +1917,9 @@ export class AcpAgent implements Agent {
 			cause,
 			silenceMs,
 			lastFrameType: waiter.lastFrameType,
-			inactivityBoundMs: waiter.toolActivity.inactivityBoundMs,
-			toolRunning: waiter.toolActivity.running,
+			inactivityBoundMs: waiter.activity.inactivityBoundMs,
+			toolRunning: waiter.activity.running,
+			awaitingModel: waiter.activity.awaitingModel,
 			...(waiter.correlation.commandId ? { commandId: waiter.correlation.commandId } : {}),
 			...(waiter.correlation.turnId ? { turnId: waiter.correlation.turnId } : {}),
 		});

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -105,6 +105,8 @@ interface PromptWaiter {
 	terminal?: { outcome: SdkPromptTerminalOutcome; correlation: PromptCorrelation };
 	/** Frames for an already-settled correlation held until acknowledgement resolves ownership. */
 	deferredFrames: JsonObject[];
+	/** Activity frames held until acknowledgement establishes exact prompt ownership. */
+	deferredActivityFrames: JsonObject[];
 	/** Clock reading of the last inbound frame for this prompt; baseline of the inactivity watchdog. */
 	lastFrameAt: number;
 	/** Frame (or wire event) type of that last frame, reported when the watchdog expires. */
@@ -1269,6 +1271,7 @@ export class AcpAgent implements Agent {
 				emittedAssistantText: "",
 				settled: false,
 				deferredFrames: [],
+				deferredActivityFrames: [],
 				lastFrameAt: this.#promptWatchdogClock.now(),
 				lastFrameType: "prompt_dispatch",
 				activity: new PromptActivity(),
@@ -1314,6 +1317,13 @@ export class AcpAgent implements Agent {
 			waiter.acknowledged = true;
 			// Frames held while ownership was unknown belong to this prompt only when the
 			// acknowledgement proves their complete correlation matches exactly.
+			const deferredActivityFrames = waiter.deferredActivityFrames.splice(0);
+			for (const deferredFrame of deferredActivityFrames) {
+				const deferredEvent = receivedSdkEvent(deferredFrame)?.event;
+				if (correlationsExactlyMatch(waiter.correlation, correlationFrom(deferredFrame, deferredEvent)))
+					this.#observePromptActivity(waiter, deferredFrame);
+			}
+			if (deferredActivityFrames.length > 0) this.#armPromptWatchdog(params.sessionId, record, waiter);
 			const deferred = waiter.deferredFrames.splice(0);
 			for (const deferredFrame of deferred)
 				if (correlationsExactlyMatch(waiter.correlation, correlationFrom(deferredFrame)))
@@ -1323,6 +1333,7 @@ export class AcpAgent implements Agent {
 			this.#settlePrompt(record, waiter);
 		} catch (error) {
 			waiter.deferredFrames.length = 0;
+			waiter.deferredActivityFrames.length = 0;
 			clearPromptWatchdog(waiter);
 			waiter.terminal = undefined;
 			waiter.settled = true;
@@ -1382,6 +1393,7 @@ export class AcpAgent implements Agent {
 		record.cancelRequested = false;
 		waiter.settled = true;
 		waiter.deferredFrames.length = 0;
+		waiter.deferredActivityFrames.length = 0;
 		waiter.terminal = undefined;
 		// A late terminal for this turn must stay closed rather than publish over a
 		// prompt the client has already been told is cancelled.
@@ -1899,14 +1911,23 @@ export class AcpAgent implements Agent {
 		// bound with no tool running. Frames with no correlation at all (heartbeats,
 		// session-scoped events) are refresh-only for the same reason: they prove the producer
 		// lives but say nothing about what this turn is doing, so they leave the bound as is.
-		// Before acknowledgement the prompt has no identity, so nothing is provably its own yet.
-		if (correlationsExactlyMatch(waiter.correlation, correlationFrom(frame, event)))
-			waiter.activity.observe(
-				typeof event?.type === "string" ? event.type : undefined,
-				typeof event?.toolCallId === "string" ? event.toolCallId : undefined,
-				frameMessageRole(event),
-			);
+		// Before acknowledgement the prompt has no identity, so correlated activity is retained
+		// and folded in only after the acknowledgement proves exact ownership.
+		if (!waiter.acknowledged) {
+			if (hasCorrelation(correlationFrom(frame, event))) waiter.deferredActivityFrames.push(frame);
+		} else if (correlationsExactlyMatch(waiter.correlation, correlationFrom(frame, event))) {
+			this.#observePromptActivity(waiter, frame);
+		}
 		this.#armPromptWatchdog(id, record, waiter);
+	}
+
+	#observePromptActivity(waiter: PromptWaiter, frame: JsonObject): void {
+		const event = receivedSdkEvent(frame)?.event;
+		waiter.activity.observe(
+			typeof event?.type === "string" ? event.type : undefined,
+			typeof event?.toolCallId === "string" ? event.toolCallId : undefined,
+			frameMessageRole(event),
+		);
 	}
 
 	/** Names why the prompt can be settled at once instead of waiting out the inactivity bound. */
@@ -2131,6 +2152,7 @@ export class AcpAgent implements Agent {
 		clearPromptWatchdog(waiter);
 		waiter.settled = true;
 		waiter.deferredFrames.length = 0;
+		waiter.deferredActivityFrames.length = 0;
 		waiter.terminal = undefined;
 		if (hasCompleteCorrelation(waiter.correlation)) {
 			record.settledPromptCorrelations.push(waiter.correlation);

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -2084,11 +2084,15 @@ export class AcpAgent implements Agent {
 					});
 				}
 			}
-			await this.#emitEndOfTurnUpdates(id, adapter);
-		} else if (event.type === "agent_failed") {
-			await this.#emitEndOfTurnUpdates(id, adapter);
 		}
+		// The terminal frame is the turn's end, so it settles the prompt before anything
+		// else is asked of the session host. `#emitEndOfTurnUpdates` queries `context.get`
+		// and `session.metadata`, and a host that stops producing the moment it publishes
+		// its terminal answers neither: sequencing settlement behind those advisory
+		// queries is what left a finished turn reported as running until the inactivity
+		// watchdog rescued it.
 		if (activePrompt) this.#settlePrompt(record, activePrompt);
+		if (event.type === "agent_end" || event.type === "agent_failed") await this.#emitEndOfTurnUpdates(id, adapter);
 	}
 
 	async #rejectPrompt(
@@ -2180,6 +2184,9 @@ export class AcpAgent implements Agent {
 		} catch {
 			// Session naming is advisory; prompt completion remains authoritative.
 		}
+		// The prompt settled before these queries were asked, so a host that answers late
+		// must not report the session idle after the next turn has already started.
+		if (this.#sessions.get(id)?.activePrompt) return;
 		if (typeof usage?.tokens === "number" && typeof usage.contextWindow === "number") {
 			await this.#publishSessionUpdate(
 				id,

--- a/packages/coding-agent/src/sdk/prompt-watchdog.ts
+++ b/packages/coding-agent/src/sdk/prompt-watchdog.ts
@@ -59,18 +59,73 @@ export const ACP_PROMPT_INACTIVITY_TIMEOUT_MS = DEFAULT_TOOL_RUNTIME_MS + SDK_RE
 export const ACP_PROMPT_TOOL_ACTIVITY_TIMEOUT_MS = MAX_TOOL_RUNTIME_MS + SDK_RECONNECT_BUDGET_MS;
 
 /**
- * Per-prompt view of which tool calls the session host has started but not finished.
- * Inbound frames are the only evidence the ACP side has, so "a tool is running" means
- * exactly "a start was observed and its end was not".
+ * Widest frame-free window a single provider call may legitimately occupy before the
+ * agent's own stream watchdog aborts it. Mirrors `ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS`
+ * in `packages/ai/src/utils/idle-iterator.ts` (600s), the largest per-provider first-event
+ * fallback of any built-in provider — `DEFAULT_STREAM_FIRST_EVENT_TIMEOUT_MS` is 100s and
+ * `kimi-code` gets 300s. That constant is module-private there, so it is mirrored here and
+ * pinned against `getProviderFirstEventTimeoutFallbackMs` in the watchdog test: a change on
+ * either side fails loudly instead of silently inflating this bound.
  */
-export class PromptToolActivity {
-	readonly #running = new Set<string>();
+const MAX_PROVIDER_FIRST_EVENT_TIMEOUT_MS = 600_000;
 
-	/** Folds one inbound frame's tool lifecycle event into the in-flight set. */
-	observe(eventType: string | undefined, toolCallId: string | undefined): void {
+/**
+ * Inactivity bound that applies while a prompt is awaiting the model: a provider call is in
+ * flight and has not produced the first frame of its response yet.
+ *
+ * Tool execution had evidence and model inference did not, so a turn thinking after
+ * `agent_start` looked exactly like a dead producer and was killed at
+ * {@link ACP_PROMPT_INACTIVITY_TIMEOUT_MS}. Inference gets the same evidence-based
+ * tolerance: the wide bound stands only as long as a model call is observably unanswered.
+ *
+ * It still terminates. A provider stream that yields nothing within
+ * {@link MAX_PROVIDER_FIRST_EVENT_TIMEOUT_MS} is aborted by the agent's own stream watchdog,
+ * which republishes as an error/retry frame, so a host that dies mid-inference is still
+ * reported one reconnect budget later.
+ */
+export const ACP_PROMPT_INFERENCE_TIMEOUT_MS = MAX_PROVIDER_FIRST_EVENT_TIMEOUT_MS + SDK_RECONNECT_BUDGET_MS;
+
+/**
+ * Per-prompt view of what the session host is observably doing: which tool calls it has
+ * started but not finished, and whether it is waiting on a model call. Inbound frames are
+ * the only evidence the ACP side has, so "a tool is running" means exactly "a start was
+ * observed and its end was not", and "awaiting the model" means exactly "a model call was
+ * dispatched and nothing from its response has been observed".
+ */
+export class PromptActivity {
+	readonly #running = new Set<string>();
+	#awaitingModel = false;
+
+	/** Folds one inbound frame's lifecycle event into the in-flight tool and model state. */
+	observe(eventType: string | undefined, toolCallId: string | undefined, messageRole: string | undefined): void {
+		this.#observeInference(eventType, messageRole);
 		if (toolCallId === undefined) return;
 		if (eventType === "tool_execution_start" || eventType === "tool_execution_update") this.#running.add(toolCallId);
 		else if (eventType === "tool_execution_end") this.#running.delete(toolCallId);
+	}
+
+	/**
+	 * A turn is awaiting the model from every point where the host dispatches a provider
+	 * call — `agent_start` for the turn's first call, `tool_execution_end` for the
+	 * re-invocation that carries a tool result back — until the first frame of that
+	 * response proves the model answered.
+	 */
+	#observeInference(eventType: string | undefined, messageRole: string | undefined): void {
+		if (eventType === "agent_start" || eventType === "tool_execution_end") {
+			this.#awaitingModel = true;
+			return;
+		}
+		// Streamed content/thinking/tool-call deltas, and the tool call the model asked for,
+		// are only ever produced by an answering model.
+		if (eventType === "message_update" || eventType === "tool_execution_start") {
+			this.#awaitingModel = false;
+			return;
+		}
+		// Providers that do not stream emit no `message_update`, so the assistant message
+		// itself is the first proof. `message_start`/`message_end` also carry the user and
+		// tool-result messages the host echoes back, which prove nothing about the model.
+		if ((eventType === "message_start" || eventType === "message_end") && messageRole === "assistant")
+			this.#awaitingModel = false;
 	}
 
 	/** True while at least one started tool call has not reported an end. */
@@ -78,9 +133,15 @@ export class PromptToolActivity {
 		return this.#running.size > 0;
 	}
 
+	/** True while a dispatched model call has not produced the first frame of its response. */
+	get awaitingModel(): boolean {
+		return this.#awaitingModel;
+	}
+
 	/** Bound that applies to the next frame-free gap, given what is observably executing. */
 	get inactivityBoundMs(): number {
-		return this.running ? ACP_PROMPT_TOOL_ACTIVITY_TIMEOUT_MS : ACP_PROMPT_INACTIVITY_TIMEOUT_MS;
+		if (this.running) return ACP_PROMPT_TOOL_ACTIVITY_TIMEOUT_MS;
+		return this.#awaitingModel ? ACP_PROMPT_INFERENCE_TIMEOUT_MS : ACP_PROMPT_INACTIVITY_TIMEOUT_MS;
 	}
 }
 

--- a/packages/coding-agent/src/sdk/prompt-watchdog.ts
+++ b/packages/coding-agent/src/sdk/prompt-watchdog.ts
@@ -1,0 +1,38 @@
+import { TOOL_TIMEOUTS } from "../tools/tool-timeouts";
+import { HEARTBEAT_TTL_MS } from "./bus/daemon-paths";
+
+/** Ceiling of a single blocking tool call, the longest frame-free step of a healthy turn. */
+const MAX_TOOL_RUNTIME_MS = Math.max(...Object.values(TOOL_TIMEOUTS).map(config => config.max)) * 1_000;
+
+/**
+ * Inactivity bound for one prompt: the silence after which a session host is
+ * treated as having stopped producing, so the prompt is settled instead of
+ * hanging the client forever.
+ *
+ * The bound cannot fire during healthy work. Every step of a live turn emits a
+ * frame (agent_start, message and tool events, agent_end), so the longest
+ * legitimate silence within a turn is one blocking tool call, and
+ * `TOOL_TIMEOUTS` caps the slowest tools (`bash`, `ssh`) at
+ * {@link MAX_TOOL_RUNTIME_MS}. Ten owner-heartbeat windows
+ * ({@link HEARTBEAT_TTL_MS}) are added on top of that ceiling, which also
+ * covers the SDK reconnect budget (2 x HEARTBEAT_TTL_MS) plus the model call
+ * that follows a tool result. Only a producer that stopped for good stays
+ * silent this long.
+ */
+export const ACP_PROMPT_INACTIVITY_TIMEOUT_MS = MAX_TOOL_RUNTIME_MS + 10 * HEARTBEAT_TTL_MS;
+
+/** Timer surface behind the prompt watchdog; tests substitute a virtual clock. */
+export interface PromptWatchdogClock {
+	now(): number;
+	/** Runs `handler` after `delayMs`; the returned callback cancels the pending run. */
+	schedule(handler: () => void, delayMs: number): () => void;
+}
+
+export const systemPromptWatchdogClock: PromptWatchdogClock = {
+	now: () => Date.now(),
+	schedule(handler: () => void, delayMs: number): () => void {
+		const timer = setTimeout(handler, delayMs);
+		timer.unref?.();
+		return () => clearTimeout(timer);
+	},
+};

--- a/packages/coding-agent/src/sdk/prompt-watchdog.ts
+++ b/packages/coding-agent/src/sdk/prompt-watchdog.ts
@@ -1,25 +1,88 @@
 import { TOOL_TIMEOUTS } from "../tools/tool-timeouts";
 import { HEARTBEAT_TTL_MS } from "./bus/daemon-paths";
 
-/** Ceiling of a single blocking tool call, the longest frame-free step of a healthy turn. */
+/** Ceiling a caller may *request* for one tool call; `bash`/`ssh` cap out at 3600s. */
 const MAX_TOOL_RUNTIME_MS = Math.max(...Object.values(TOOL_TIMEOUTS).map(config => config.max)) * 1_000;
 
+/** Budget one tool call gets when nobody asks to extend it; `bash` defaults to 300s. */
+const DEFAULT_TOOL_RUNTIME_MS = Math.max(...Object.values(TOOL_TIMEOUTS).map(config => config.default)) * 1_000;
+
 /**
- * Inactivity bound for one prompt: the silence after which a session host is
- * treated as having stopped producing, so the prompt is settled instead of
- * hanging the client forever.
- *
- * The bound cannot fire during healthy work. Every step of a live turn emits a
- * frame (agent_start, message and tool events, agent_end), so the longest
- * legitimate silence within a turn is one blocking tool call, and
- * `TOOL_TIMEOUTS` caps the slowest tools (`bash`, `ssh`) at
- * {@link MAX_TOOL_RUNTIME_MS}. Ten owner-heartbeat windows
- * ({@link HEARTBEAT_TTL_MS}) are added on top of that ceiling, which also
- * covers the SDK reconnect budget (2 x HEARTBEAT_TTL_MS) plus the model call
- * that follows a tool result. Only a producer that stopped for good stays
- * silent this long.
+ * Frame-free cost of one transport round trip while the producer is still healthy:
+ * the owner heartbeat has to lapse ({@link HEARTBEAT_TTL_MS}) before a reconnect is
+ * even attempted, and the reconnect itself gets a second window.
  */
-export const ACP_PROMPT_INACTIVITY_TIMEOUT_MS = MAX_TOOL_RUNTIME_MS + 10 * HEARTBEAT_TTL_MS;
+const SDK_RECONNECT_BUDGET_MS = 2 * HEARTBEAT_TTL_MS;
+
+/**
+ * Inactivity bound for a prompt whose session host has no tool call in flight: after
+ * this much silence the host is treated as having stopped producing, so the prompt is
+ * settled instead of hanging the client forever.
+ *
+ * Every step of a live turn emits a frame (`agent_start`, message events, tool events,
+ * `agent_end`), so this bound only has to exceed the longest frame-free gap a healthy
+ * turn can produce *with nothing executing*: one model round trip, from the request
+ * leaving the host to the first streamed event coming back, possibly straddling a
+ * transport reconnect.
+ *
+ * `TOOL_TIMEOUTS` is this runtime's own statement of how long a single unattended step
+ * may block before it is declared stuck, and its slowest **default**
+ * ({@link DEFAULT_TOOL_RUNTIME_MS}) is the longest such wait nobody explicitly opted
+ * into. That is well above the agent's own model-stream watchdog (120s idle / 100s
+ * first event in `packages/ai/src/utils/idle-iterator.ts`), which aborts a stalled
+ * provider stream and republishes it as an error frame — itself a frame — long before
+ * this bound. {@link SDK_RECONNECT_BUDGET_MS} is added on top so a reconnect landing
+ * inside that gap cannot trip it either. Two providers widen their first-event
+ * fallback past this bound (alibaba-token-plan 600s, kimi-code 300s); a turn that
+ * emits nothing at all for this long on those is reported as abandoned rather than
+ * left `running`, and the session still accepts the next prompt.
+ *
+ * {@link MAX_TOOL_RUNTIME_MS} is deliberately *not* used here. `max` is what a caller
+ * may request, not what tools take, so sizing every gap for it produced a 63min bound
+ * that could never act as a safety net. Turns that legitimately reach that ceiling are
+ * covered by {@link ACP_PROMPT_TOOL_ACTIVITY_TIMEOUT_MS} instead, which is gated on
+ * evidence that a tool is actually executing.
+ */
+export const ACP_PROMPT_INACTIVITY_TIMEOUT_MS = DEFAULT_TOOL_RUNTIME_MS + SDK_RECONNECT_BUDGET_MS;
+
+/**
+ * Inactivity bound that applies only while the session host has an unfinished tool
+ * call — a `tool_execution_start`/`tool_execution_update` with no matching
+ * `tool_execution_end`.
+ *
+ * A long `bash` is protected by the evidence that it is running, not by a constant
+ * sized for the worst case, so this wide bound stands only for as long as that
+ * evidence does. It still terminates: no tool call may outlive
+ * {@link MAX_TOOL_RUNTIME_MS}, after which the host must publish `tool_execution_end`,
+ * so a host that dies mid-tool is still reported (one reconnect budget later).
+ */
+export const ACP_PROMPT_TOOL_ACTIVITY_TIMEOUT_MS = MAX_TOOL_RUNTIME_MS + SDK_RECONNECT_BUDGET_MS;
+
+/**
+ * Per-prompt view of which tool calls the session host has started but not finished.
+ * Inbound frames are the only evidence the ACP side has, so "a tool is running" means
+ * exactly "a start was observed and its end was not".
+ */
+export class PromptToolActivity {
+	readonly #running = new Set<string>();
+
+	/** Folds one inbound frame's tool lifecycle event into the in-flight set. */
+	observe(eventType: string | undefined, toolCallId: string | undefined): void {
+		if (toolCallId === undefined) return;
+		if (eventType === "tool_execution_start" || eventType === "tool_execution_update") this.#running.add(toolCallId);
+		else if (eventType === "tool_execution_end") this.#running.delete(toolCallId);
+	}
+
+	/** True while at least one started tool call has not reported an end. */
+	get running(): boolean {
+		return this.#running.size > 0;
+	}
+
+	/** Bound that applies to the next frame-free gap, given what is observably executing. */
+	get inactivityBoundMs(): number {
+		return this.running ? ACP_PROMPT_TOOL_ACTIVITY_TIMEOUT_MS : ACP_PROMPT_INACTIVITY_TIMEOUT_MS;
+	}
+}
 
 /** Timer surface behind the prompt watchdog; tests substitute a virtual clock. */
 export interface PromptWatchdogClock {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -13777,11 +13777,6 @@ export class AgentSession {
 			`(Reminder ${this.#todoReminderCount}/${remindersMax})\n` +
 			`</system-reminder>`;
 
-		logger.debug("Todo completion: sending reminder", {
-			incomplete: incomplete.length,
-			attempt: this.#todoReminderCount,
-		});
-
 		// Emit event for UI to render notification
 		await this.#emitSessionEvent({
 			type: "todo_reminder",
@@ -13790,7 +13785,27 @@ export class AgentSession {
 			maxAttempts: remindersMax,
 		});
 
-		// Inject reminder and continue the conversation
+		// Consumers that cannot represent a server-initiated turn (ACP v1 clients, SDK
+		// hosts) keep reporting the prompt as running until the terminal `agent_end` is
+		// published. Injecting here would park that terminal behind a continuation hold
+		// (`#scheduleAgentContinue` -> `#reserveDeferredAgentEndForContinuation`), so a
+		// turn that already delivered its final answer would never settle — and there is
+		// no interactive consumer to act on the nudge. Those hosts get the advisory
+		// event above and nothing else.
+		if (this.#clientBridge?.deferAgentInitiatedTurns && !this.#allowAcpAgentInitiatedTurns) {
+			logger.debug("Todo completion: advisory reminder only", {
+				incomplete: incomplete.length,
+				attempt: this.#todoReminderCount,
+			});
+			return;
+		}
+
+		logger.debug("Todo completion: sending reminder", {
+			incomplete: incomplete.length,
+			attempt: this.#todoReminderCount,
+		});
+
+		// Inject reminder and continue conversation
 		this.agent.appendMessage({
 			role: "developer",
 			content: [{ type: "text", text: reminder }],

--- a/packages/coding-agent/test/acp-prompt-settle-on-completion.test.ts
+++ b/packages/coding-agent/test/acp-prompt-settle-on-completion.test.ts
@@ -4,7 +4,7 @@ import type { AgentSideConnection, PromptRequest, SessionNotification } from "@a
 import { TempDir } from "@gajae-code/utils";
 import { AcpAgent } from "../src/modes/acp/acp-agent";
 import { writeBrokerDiscovery } from "../src/sdk/broker/discovery";
-import { ACP_PROMPT_INACTIVITY_TIMEOUT_MS } from "../src/sdk/prompt-watchdog";
+import { ACP_PROMPT_INFERENCE_TIMEOUT_MS } from "../src/sdk/prompt-watchdog";
 
 type TestSocket = { send(message: string): void };
 type StoppedReason = "end_turn" | "max_tokens" | "max_turn_requests" | "refusal" | "cancelled";
@@ -310,7 +310,9 @@ test("a producer that never publishes a terminal is still settled by the inactiv
 	const fixture = await createFixture();
 	try {
 		const { settled } = await startTurn(fixture, "dead producer");
-		fixture.clock.advance(ACP_PROMPT_INACTIVITY_TIMEOUT_MS);
+		// The turn died right after `agent_start`, i.e. while awaiting the model, so the
+		// inference bound is the one that has to catch it.
+		fixture.clock.advance(ACP_PROMPT_INFERENCE_TIMEOUT_MS);
 		expect(await bounded(settled, "watchdog settlement")).toMatchObject({
 			rejected: { code: "prompt_abandoned" },
 		});

--- a/packages/coding-agent/test/acp-prompt-settle-on-completion.test.ts
+++ b/packages/coding-agent/test/acp-prompt-settle-on-completion.test.ts
@@ -1,0 +1,320 @@
+import { expect, test } from "bun:test";
+import * as path from "node:path";
+import type { AgentSideConnection, PromptRequest, SessionNotification } from "@agentclientprotocol/sdk";
+import { TempDir } from "@gajae-code/utils";
+import { AcpAgent } from "../src/modes/acp/acp-agent";
+import { writeBrokerDiscovery } from "../src/sdk/broker/discovery";
+import { ACP_PROMPT_INACTIVITY_TIMEOUT_MS } from "../src/sdk/prompt-watchdog";
+
+type TestSocket = { send(message: string): void };
+type StoppedReason = "end_turn" | "max_tokens" | "max_turn_requests" | "refusal" | "cancelled";
+
+/**
+ * Virtual timer source for the prompt watchdog. A normally completed turn must settle
+ * with this clock frozen at zero: a settlement that needs the clock moved is the
+ * watchdog rescuing a dead producer, not the terminal frame ending the turn.
+ */
+class VirtualClock {
+	#now = 0;
+	#nextId = 1;
+	readonly #timers = new Map<number, { at: number; handler: () => void }>();
+
+	now(): number {
+		return this.#now;
+	}
+
+	schedule(handler: () => void, delayMs: number): () => void {
+		const id = this.#nextId++;
+		this.#timers.set(id, { at: this.#now + delayMs, handler });
+		return () => {
+			this.#timers.delete(id);
+		};
+	}
+
+	get pending(): number {
+		return this.#timers.size;
+	}
+
+	advance(ms: number): void {
+		const target = this.#now + ms;
+		for (;;) {
+			let dueId: number | undefined;
+			let dueAt = Number.POSITIVE_INFINITY;
+			for (const [id, timer] of this.#timers) {
+				if (timer.at <= target && timer.at < dueAt) {
+					dueId = id;
+					dueAt = timer.at;
+				}
+			}
+			if (dueId === undefined) break;
+			const timer = this.#timers.get(dueId);
+			this.#timers.delete(dueId);
+			this.#now = dueAt;
+			timer?.handler();
+		}
+		this.#now = target;
+	}
+}
+
+type Fixture = {
+	agent: AcpAgent;
+	sessionId: string;
+	updates: SessionNotification[];
+	clock: VirtualClock;
+	queryCalls: string[];
+	sendStopped(reason: StoppedReason): void;
+	dispose(): void;
+};
+
+async function bounded<T>(promise: Promise<T>, label: string): Promise<T> {
+	return await Promise.race([
+		promise,
+		Bun.sleep(2_000).then(() => {
+			throw new Error(`Timed out waiting for ${label}`);
+		}),
+	]);
+}
+
+async function waitFor(predicate: () => boolean, label: string): Promise<void> {
+	const deadline = Date.now() + 2_000;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await Bun.sleep(5);
+	}
+	throw new Error(`Timed out waiting for ${label}`);
+}
+
+function phaseUpdates(updates: SessionNotification[], phase: string): number {
+	return updates.filter(
+		update =>
+			update.update.sessionUpdate === "session_info_update" &&
+			(update.update as { _meta?: { gjcPhase?: string } })._meta?.gjcPhase === phase,
+	).length;
+}
+
+/**
+ * @param options.silentQueries Query ids the session host accepts and never answers,
+ * reproducing a host that stops producing the moment it publishes its terminal frame.
+ */
+async function createFixture(options: { silentQueries?: string[] } = {}): Promise<Fixture> {
+	const silent = new Set(options.silentQueries ?? []);
+	const tempDir = TempDir.createSync("@acp-prompt-settle-");
+	const agentDir = path.join(tempDir.path(), "agent");
+	const cwd = path.join(tempDir.path(), "workspace");
+	const token = "acp-prompt-settle-token";
+	const sessionId = "prompt-settle-session";
+	const commandId = "prompt-settle-command";
+	const turnId = "prompt-settle-turn";
+	const updates: SessionNotification[] = [];
+	const queryCalls: string[] = [];
+	const clock = new VirtualClock();
+	const abort = new AbortController();
+	let promptSocket: TestSocket | undefined;
+	let server!: ReturnType<typeof Bun.serve>;
+
+	const send = (frame: Record<string, unknown>): void => {
+		if (!promptSocket) throw new Error("Expected a prompt socket");
+		promptSocket.send(JSON.stringify(frame));
+	};
+	const sendStopped = (reason: StoppedReason): void => {
+		send({
+			type: "agent_end",
+			sessionId,
+			commandId,
+			turnId,
+			finalText: "the complete final report",
+			outcome: { kind: "stopped", reason, provenance: reason === "cancelled" ? "client_cancel" : "agent" },
+		});
+	};
+
+	server = Bun.serve({
+		hostname: "127.0.0.1",
+		port: 0,
+		fetch(request, server) {
+			if (new URL(request.url).searchParams.get("token") !== token)
+				return new Response("Unauthorized", { status: 401 });
+			if (!server.upgrade(request, { data: undefined })) return new Response("Upgrade failed", { status: 400 });
+		},
+		websocket: {
+			open(socket) {
+				socket.send(JSON.stringify({ type: "hello", connectionId: "acp-prompt-settle" }));
+			},
+			message(socket, raw) {
+				const frame = JSON.parse(String(raw)) as Record<string, unknown>;
+				if (frame.type === "register_provider") {
+					socket.send(
+						JSON.stringify({ type: "register_provider_result", id: frame.id, ok: true, leaseId: "lease" }),
+					);
+					return;
+				}
+				if (frame.type === "broker_request") {
+					const result =
+						frame.operation === "session.create"
+							? { sessionId, endpoint: { url: `ws://127.0.0.1:${server.port}`, token } }
+							: {};
+					socket.send(JSON.stringify({ type: "broker_response", id: frame.id, ok: true, result }));
+					return;
+				}
+				if (frame.type === "query_request") {
+					queryCalls.push(String(frame.query));
+					if (silent.has(String(frame.query))) return;
+					const items =
+						frame.query === "config.list/get"
+							? [{ mode: "default", model: "openai/gpt", thinking: "medium" }]
+							: frame.query === "models.list/current"
+								? [{ provider: "openai", id: "gpt", name: "GPT" }]
+								: frame.query === "providers.list/active"
+									? [{ providerId: "openai", connectionKind: "credential" }]
+									: [];
+					const result =
+						frame.query === "runtime.capabilities"
+							? { promptTerminalOutcomeVersion: 1 }
+							: frame.query === "context.get"
+								? { usage: { tokens: 0, contextWindow: 200_000, percent: 0, source: "test" } }
+								: { page: { items, complete: true } };
+					socket.send(JSON.stringify({ type: "query_response", id: frame.id, ok: true, result }));
+					return;
+				}
+				if (frame.type !== "control_request") return;
+				if (frame.operation === "turn.prompt") promptSocket = socket;
+				socket.send(
+					JSON.stringify({
+						type: "control_response",
+						id: frame.id,
+						ok: true,
+						result:
+							frame.operation === "turn.prompt"
+								? { commandId, turnId, accepted: true }
+								: frame.operation === "turn.abort"
+									? { aborted: true }
+									: {},
+					}),
+				);
+				// Frames are FIFO on the socket, so the client records the acknowledged
+				// correlation before this start frame reaches the session record.
+				if (frame.operation === "turn.prompt")
+					socket.send(JSON.stringify({ type: "agent_start", sessionId, commandId, turnId }));
+			},
+		},
+	});
+	const port = server.port;
+	if (port === undefined) throw new Error("Expected an ACP fixture server port");
+	await writeBrokerDiscovery(agentDir, {
+		version: 1,
+		protocolVersion: 3,
+		packageGeneration: "test",
+		ownerId: "test-owner",
+		pid: process.pid,
+		host: "127.0.0.1",
+		port,
+		url: `ws://127.0.0.1:${port}`,
+		token,
+		startedAt: Date.now(),
+		heartbeatAt: Date.now(),
+	});
+	const agent = new AcpAgent(
+		{
+			sessionUpdate: async (update: SessionNotification) => updates.push(update),
+			signal: abort.signal,
+			closed: Promise.withResolvers<void>().promise,
+		} as unknown as AgentSideConnection,
+		{ agentDir, promptWatchdogClock: clock },
+	);
+	const created = await bounded(agent.newSession({ cwd, mcpServers: [] }), "new session");
+	await waitFor(() => phaseUpdates(updates, "idle") > 0, "bootstrap update");
+
+	return {
+		agent,
+		sessionId: created.sessionId,
+		updates,
+		clock,
+		queryCalls,
+		sendStopped,
+		dispose: () => {
+			abort.abort();
+			server.stop(true);
+			tempDir.removeSync();
+		},
+	};
+}
+
+/**
+ * Runs a turn up to its acknowledged, started state. The pending prompt is returned
+ * wrapped so its settlement is observed without leaving an unhandled rejection while
+ * the test drives the host.
+ */
+async function startTurn(
+	fixture: Fixture,
+	text: string,
+): Promise<{ settled: Promise<{ resolved?: { stopReason: StoppedReason }; rejected?: { code?: string } }> }> {
+	const started = phaseUpdates(fixture.updates, "working");
+	const pending = fixture.agent.prompt({
+		sessionId: fixture.sessionId,
+		messageId: "00000000-0000-4000-8000-000000000001",
+		prompt: [{ type: "text", text }],
+	} as PromptRequest) as Promise<{ stopReason: StoppedReason }>;
+	const settled = pending.then(
+		resolved => ({ resolved }),
+		(error: unknown) => ({ rejected: error as { code?: string } }),
+	);
+	await waitFor(() => phaseUpdates(fixture.updates, "working") > started, "turn start");
+	return { settled };
+}
+
+test("a completed turn settles on its terminal frame even when end-of-turn metadata never answers", async () => {
+	// `context.get` and `session.metadata` are advisory decoration. A host that stops
+	// producing right after publishing its terminal must not hold the ACP turn open.
+	const fixture = await createFixture({ silentQueries: ["context.get", "session.metadata"] });
+	try {
+		const { settled } = await startTurn(fixture, "long running turn");
+		fixture.sendStopped("end_turn");
+		expect(await bounded(settled, "prompt completion")).toEqual({ resolved: { stopReason: "end_turn" } });
+		// Settlement came from the terminal frame, not the inactivity watchdog: the
+		// virtual clock never moved, so nothing near the bound could have fired.
+		expect(fixture.clock.now()).toBe(0);
+		expect(fixture.clock.pending).toBe(0);
+		// The terminal was processed in full, not dropped: its final report reached the
+		// client as an assistant chunk in the same pass that settled the turn.
+		expect(
+			fixture.updates
+				.filter(update => update.update.sessionUpdate === "agent_message_chunk")
+				.map(update => (update.update as { content: { text: string } }).content.text),
+		).toEqual(["the complete final report"]);
+	} finally {
+		fixture.dispose();
+	}
+});
+
+test("a completed turn settles exactly once for duplicate and late terminal frames", async () => {
+	const fixture = await createFixture();
+	try {
+		const idleBefore = phaseUpdates(fixture.updates, "idle");
+		const { settled } = await startTurn(fixture, "duplicated terminal");
+		fixture.sendStopped("end_turn");
+		fixture.sendStopped("end_turn");
+		expect(await bounded(settled, "prompt completion")).toEqual({ resolved: { stopReason: "end_turn" } });
+		await waitFor(() => fixture.queryCalls.includes("session.metadata"), "end-of-turn metadata query");
+		// A late duplicate arriving after settlement must not re-run the end-of-turn work.
+		fixture.sendStopped("end_turn");
+		await Bun.sleep(50);
+		expect(phaseUpdates(fixture.updates, "idle")).toBe(idleBefore + 1);
+		expect(fixture.queryCalls.filter(query => query === "context.get")).toHaveLength(1);
+		expect(fixture.queryCalls.filter(query => query === "session.metadata")).toHaveLength(1);
+		expect(fixture.updates.filter(update => update.update.sessionUpdate === "agent_message_chunk")).toHaveLength(1);
+	} finally {
+		fixture.dispose();
+	}
+});
+
+test("a producer that never publishes a terminal is still settled by the inactivity watchdog", async () => {
+	const fixture = await createFixture();
+	try {
+		const { settled } = await startTurn(fixture, "dead producer");
+		fixture.clock.advance(ACP_PROMPT_INACTIVITY_TIMEOUT_MS);
+		expect(await bounded(settled, "watchdog settlement")).toMatchObject({
+			rejected: { code: "prompt_abandoned" },
+		});
+	} finally {
+		fixture.dispose();
+	}
+});

--- a/packages/coding-agent/test/acp-prompt-watchdog.test.ts
+++ b/packages/coding-agent/test/acp-prompt-watchdog.test.ts
@@ -1,10 +1,15 @@
 import { expect, test } from "bun:test";
 import * as path from "node:path";
 import type { AgentSideConnection, PromptRequest, SessionNotification } from "@agentclientprotocol/sdk";
+import { getProviderFirstEventTimeoutFallbackMs } from "@gajae-code/ai/utils/idle-iterator";
 import { TempDir } from "@gajae-code/utils";
 import { AcpAgent } from "../src/modes/acp/acp-agent";
 import { writeBrokerDiscovery } from "../src/sdk/broker/discovery";
-import { ACP_PROMPT_INACTIVITY_TIMEOUT_MS, ACP_PROMPT_TOOL_ACTIVITY_TIMEOUT_MS } from "../src/sdk/prompt-watchdog";
+import {
+	ACP_PROMPT_INACTIVITY_TIMEOUT_MS,
+	ACP_PROMPT_INFERENCE_TIMEOUT_MS,
+	ACP_PROMPT_TOOL_ACTIVITY_TIMEOUT_MS,
+} from "../src/sdk/prompt-watchdog";
 
 type TestSocket = { send(message: string): void };
 type StoppedReason = "end_turn" | "max_tokens" | "max_turn_requests" | "refusal" | "cancelled";
@@ -325,14 +330,14 @@ async function startTurn(fixture: Fixture): Promise<{ pending: Promise<{ stopRea
 	return { pending };
 }
 
-test("a prompt that goes silent past the inactivity bound is rejected instead of hanging", async () => {
+test("a prompt awaiting the model past the inference bound is rejected instead of hanging", async () => {
 	const fixture = await createFixture();
 	try {
 		const { pending } = await startTurn(fixture);
 		const { commandId, turnId } = fixture.correlation();
 		const idleBefore = idleUpdates(fixture.updates);
 
-		fixture.clock.advance(ACP_PROMPT_INACTIVITY_TIMEOUT_MS + 1);
+		fixture.clock.advance(ACP_PROMPT_INFERENCE_TIMEOUT_MS + 1);
 
 		const error = await bounded(
 			pending.then(
@@ -344,7 +349,7 @@ test("a prompt that goes silent past the inactivity bound is rejected instead of
 		expect(error).toBeInstanceOf(Error);
 		const message = (error as Error).message;
 		expect(message).toContain("ACP prompt was abandoned");
-		expect(message).toContain(`${Math.round(ACP_PROMPT_INACTIVITY_TIMEOUT_MS / 1_000)}s of silence`);
+		expect(message).toContain(`${Math.round(ACP_PROMPT_INFERENCE_TIMEOUT_MS / 1_000)}s of silence`);
 		expect(message).toContain("the SDK session host stopped producing frames");
 		expect(message).toContain('"agent_start"');
 		expect(message).toContain(`commandId=${commandId}`);
@@ -394,7 +399,7 @@ test("a session accepts a new prompt after a watchdog rejection", async () => {
 	try {
 		const { pending: abandoned } = await startTurn(fixture);
 		const firstCommandId = fixture.correlation().commandId;
-		fixture.clock.advance(ACP_PROMPT_INACTIVITY_TIMEOUT_MS + 1);
+		fixture.clock.advance(ACP_PROMPT_INFERENCE_TIMEOUT_MS + 1);
 		await bounded(
 			abandoned.then(
 				() => undefined,
@@ -444,12 +449,22 @@ test("a normal agent_end settles the prompt once and disarms the watchdog", asyn
 test("the watchdog bounds stay pinned to their derivation", () => {
 	// Slowest tool default (`bash`, 300s) + one SDK reconnect budget (2 x 20s heartbeat).
 	expect(ACP_PROMPT_INACTIVITY_TIMEOUT_MS).toBe(340_000);
+	// Widest per-provider first-event window (`alibaba-token-plan`, 600s) + the same budget.
+	expect(ACP_PROMPT_INFERENCE_TIMEOUT_MS).toBe(640_000);
 	// Slowest per-tool ceiling (`bash`/`ssh`, 3600s) + the same reconnect budget.
 	expect(ACP_PROMPT_TOOL_ACTIVITY_TIMEOUT_MS).toBe(3_640_000);
 	// A frame-free gap with nothing running must stay operationally useful; the wide
 	// bound is only ever reachable while a tool call is observably in flight.
 	expect(ACP_PROMPT_INACTIVITY_TIMEOUT_MS).toBeLessThan(10 * 60_000);
 	expect(ACP_PROMPT_TOOL_ACTIVITY_TIMEOUT_MS).toBeGreaterThan(3_600_000);
+	// Each bound is strictly wider than the evidence-free one it replaces, and the
+	// inference bound stays far below the tool ceiling: thinking is not executing.
+	expect(ACP_PROMPT_INFERENCE_TIMEOUT_MS).toBeGreaterThan(ACP_PROMPT_INACTIVITY_TIMEOUT_MS);
+	expect(ACP_PROMPT_INFERENCE_TIMEOUT_MS).toBeLessThan(ACP_PROMPT_TOOL_ACTIVITY_TIMEOUT_MS);
+	// The inference bound mirrors a constant that lives in another package. If that
+	// widens or narrows, this fails instead of silently drifting.
+	expect(getProviderFirstEventTimeoutFallbackMs("alibaba-token-plan")).toBe(600_000);
+	expect(getProviderFirstEventTimeoutFallbackMs("kimi-code")).toBe(300_000);
 });
 
 test("a tool call running past the idle bound is protected while it runs, not after it ends", async () => {
@@ -480,8 +495,9 @@ test("a tool call running past the idle bound is protected while it runs, not af
 		fixture.sendToolEnd("watchdog-tool-1");
 		await waitFor(() => toolCallUpdates(fixture.updates) > ended, "tool call end");
 
-		// Evidence is gone: the next frame-free gap is bounded by the idle bound again.
-		fixture.clock.advance(ACP_PROMPT_INACTIVITY_TIMEOUT_MS + 1);
+		// Tool evidence is gone, but returning a tool result re-invokes the model, so the
+		// gap that follows is an inference gap — the idle bound no longer governs it.
+		fixture.clock.advance(ACP_PROMPT_INFERENCE_TIMEOUT_MS + 1);
 		const error = await bounded(
 			pending.then(
 				() => undefined,
@@ -528,6 +544,115 @@ test("a tool call still in flight keeps the wide bound armed across silent gaps"
 
 		fixture.sendStopped("end_turn");
 		expect(await bounded(pending, "prompt completion")).toEqual({ stopReason: "end_turn" });
+	} finally {
+		fixture.dispose();
+	}
+});
+
+test("a turn silent after agent_start is not killed while the model is still answering", async () => {
+	const fixture = await createFixture();
+	try {
+		const { pending } = await startTurn(fixture);
+		let settled = false;
+		void pending.then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			},
+		);
+
+		// 49 of the 65 production expiries looked exactly like this: the host went quiet
+		// right after `agent_start` because the provider was still reasoning. Nothing is
+		// executing, but a dispatched model call has not answered, so the evidence-free
+		// bound is the wrong one to apply.
+		fixture.clock.advance(ACP_PROMPT_INACTIVITY_TIMEOUT_MS + 1);
+		await Bun.sleep(10);
+		expect(settled).toBe(false);
+
+		// Still one tick short of the inference bound after the whole gap.
+		fixture.clock.advance(ACP_PROMPT_INFERENCE_TIMEOUT_MS - ACP_PROMPT_INACTIVITY_TIMEOUT_MS - 2);
+		await Bun.sleep(10);
+		expect(settled).toBe(false);
+
+		const chunks = textChunks(fixture.updates);
+		fixture.sendAssistantText("done thinking");
+		await waitFor(() => textChunks(fixture.updates) > chunks, "assistant chunk");
+		fixture.sendStopped("end_turn");
+		expect(await bounded(pending, "prompt completion")).toEqual({ stopReason: "end_turn" });
+	} finally {
+		fixture.dispose();
+	}
+});
+
+test("a turn silent after tool_execution_end is not killed while the model is re-invoked", async () => {
+	const fixture = await createFixture();
+	try {
+		const { pending } = await startTurn(fixture);
+		let settled = false;
+		void pending.then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			},
+		);
+
+		const started = toolCalls(fixture.updates);
+		fixture.sendToolStart("watchdog-inference-tool");
+		await waitFor(() => toolCalls(fixture.updates) > started, "tool call start");
+		const ended = toolCallUpdates(fixture.updates);
+		fixture.sendToolEnd("watchdog-inference-tool");
+		await waitFor(() => toolCallUpdates(fixture.updates) > ended, "tool call end");
+
+		// The other 15 expiries: the tool result went back to the model and the next
+		// provider call had not answered yet. No tool is running, so the wide tool bound is
+		// correctly retired — but the turn is still legitimately silent.
+		fixture.clock.advance(ACP_PROMPT_INACTIVITY_TIMEOUT_MS + 1);
+		await Bun.sleep(10);
+		expect(settled).toBe(false);
+
+		fixture.clock.advance(ACP_PROMPT_INFERENCE_TIMEOUT_MS - ACP_PROMPT_INACTIVITY_TIMEOUT_MS - 2);
+		await Bun.sleep(10);
+		expect(settled).toBe(false);
+
+		const chunks = textChunks(fixture.updates);
+		fixture.sendAssistantText("after the tool");
+		await waitFor(() => textChunks(fixture.updates) > chunks, "assistant chunk");
+		fixture.sendStopped("end_turn");
+		expect(await bounded(pending, "prompt completion")).toEqual({ stopReason: "end_turn" });
+	} finally {
+		fixture.dispose();
+	}
+});
+
+test("a turn with no tool running and no model call pending is still held to the narrow bound", async () => {
+	const fixture = await createFixture();
+	try {
+		const { pending } = await startTurn(fixture);
+		// The model answered, so no inference is pending; no tool ever started, so nothing
+		// is executing. Nobody is working — this is the state the narrow bound exists for,
+		// and widening it for inference must not have blinded it here.
+		const chunks = textChunks(fixture.updates);
+		fixture.sendAssistantText("answered, then died");
+		await waitFor(() => textChunks(fixture.updates) > chunks, "assistant chunk");
+
+		fixture.clock.advance(ACP_PROMPT_INACTIVITY_TIMEOUT_MS + 1);
+		const error = await bounded(
+			pending.then(
+				() => undefined,
+				(reason: unknown) => reason,
+			),
+			"watchdog rejection",
+		);
+		expect(error).toBeInstanceOf(Error);
+		const message = (error as Error).message;
+		expect(message).toContain("ACP prompt was abandoned");
+		expect(message).toContain(`${Math.round(ACP_PROMPT_INACTIVITY_TIMEOUT_MS / 1_000)}s of silence`);
+		expect(message).toContain("the SDK session host stopped producing frames");
+		expect(message).toContain('"message_end"');
 	} finally {
 		fixture.dispose();
 	}

--- a/packages/coding-agent/test/acp-prompt-watchdog.test.ts
+++ b/packages/coding-agent/test/acp-prompt-watchdog.test.ts
@@ -418,9 +418,13 @@ test("a normal agent_end settles the prompt once and disarms the watchdog", asyn
 		const { pending } = await startTurn(fixture);
 		// The turn is being watched, so the disarm assertion below cannot pass vacuously.
 		expect(fixture.clock.pending).toBe(1);
+		const idleBeforeTerminal = idleUpdates(fixture.updates);
 		fixture.sendStopped("end_turn");
 		expect(await bounded(pending, "prompt completion")).toEqual({ stopReason: "end_turn" });
 
+		// The prompt settles on its terminal frame, ahead of the advisory end-of-turn
+		// queries, so the phase publication is snapshotted once those have flushed.
+		await waitFor(() => idleUpdates(fixture.updates) > idleBeforeTerminal, "end-of-turn idle update");
 		const updatesAfterSettle = fixture.updates.length;
 		const idleAfterSettle = idleUpdates(fixture.updates);
 		expect(fixture.clock.pending).toBe(0);

--- a/packages/coding-agent/test/acp-prompt-watchdog.test.ts
+++ b/packages/coding-agent/test/acp-prompt-watchdog.test.ts
@@ -129,7 +129,11 @@ function toolCallUpdates(updates: SessionNotification[]): number {
 	return updates.filter(update => update.update.sessionUpdate === "tool_call_update").length;
 }
 
-async function createFixture(): Promise<Fixture> {
+type FixtureOptions = {
+	agentStartBeforeAcknowledgement?: boolean;
+};
+
+async function createFixture(options: FixtureOptions = {}): Promise<Fixture> {
 	const tempDir = TempDir.createSync("@acp-prompt-watchdog-");
 	const agentDir = path.join(tempDir.path(), "agent");
 	const cwd = path.join(tempDir.path(), "workspace");
@@ -255,6 +259,8 @@ async function createFixture(): Promise<Fixture> {
 					commandId = `watchdog-command-${turnCount}`;
 					turnId = `watchdog-turn-${turnCount}`;
 				}
+				if (frame.operation === "turn.prompt" && options.agentStartBeforeAcknowledgement)
+					socket.send(JSON.stringify({ type: "agent_start", sessionId, commandId, turnId }));
 				socket.send(
 					JSON.stringify({
 						type: "control_response",
@@ -268,10 +274,11 @@ async function createFixture(): Promise<Fixture> {
 									: {},
 					}),
 				);
-				// Frames are FIFO on the socket, so the client records the acknowledged
-				// correlation before this start frame reaches the session record.
-				if (frame.operation === "turn.prompt")
+				if (frame.operation === "turn.prompt" && !options.agentStartBeforeAcknowledgement) {
+					// Frames are FIFO on the socket, so the client records the acknowledged
+					// correlation before this start frame reaches the session record.
 					socket.send(JSON.stringify({ type: "agent_start", sessionId, commandId, turnId }));
+				}
 			},
 		},
 	});
@@ -824,6 +831,38 @@ test("a correlationless frame refreshes liveness without moving the turn's bound
 		const message = (error as Error).message;
 		expect(message).toContain(`${Math.round(ACP_PROMPT_INFERENCE_TIMEOUT_MS / 1_000)}s of silence`);
 		expect(message).toContain('"message_end"');
+	} finally {
+		fixture.dispose();
+	}
+});
+test("a pre-ack agent_start keeps the live prompt on the inference bound", async () => {
+	const fixture = await createFixture({ agentStartBeforeAcknowledgement: true });
+	try {
+		const { pending } = await startTurn(fixture);
+		let settled = false;
+		void pending.then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			},
+		);
+
+		fixture.clock.advance(ACP_PROMPT_INACTIVITY_TIMEOUT_MS + 1);
+		await Bun.sleep(10);
+		expect(settled).toBe(false);
+
+		fixture.clock.advance(ACP_PROMPT_INFERENCE_TIMEOUT_MS - ACP_PROMPT_INACTIVITY_TIMEOUT_MS);
+		const error = await bounded(
+			pending.then(
+				() => undefined,
+				(reason: unknown) => reason,
+			),
+			"watchdog rejection",
+		);
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toContain(`${Math.round(ACP_PROMPT_INFERENCE_TIMEOUT_MS / 1_000)}s of silence`);
 	} finally {
 		fixture.dispose();
 	}

--- a/packages/coding-agent/test/acp-prompt-watchdog.test.ts
+++ b/packages/coding-agent/test/acp-prompt-watchdog.test.ts
@@ -39,6 +39,12 @@ class VirtualClock {
 		return this.#timers.size;
 	}
 
+	/** The single armed watchdog timer; every re-arm replaces it, so the id changes with it. */
+	get armed(): { id: number; at: number } | undefined {
+		for (const [id, timer] of this.#timers) return { id, at: timer.at };
+		return undefined;
+	}
+
 	advance(ms: number): void {
 		const target = this.#now + ms;
 		for (;;) {
@@ -66,6 +72,8 @@ type Fixture = {
 	clock: VirtualClock;
 	/** Correlation the fixture host acknowledged for the turn currently in flight. */
 	correlation(): { commandId: string; turnId: string };
+	/** Sends one raw frame down the session socket, correlation included or omitted verbatim. */
+	send(frame: Record<string, unknown>): void;
 	sendAssistantText(text: string): void;
 	sendStopped(reason: StoppedReason): void;
 	sendToolStart(toolCallId: string): void;
@@ -299,6 +307,7 @@ async function createFixture(): Promise<Fixture> {
 		updates,
 		clock,
 		correlation: () => ({ commandId, turnId }),
+		send,
 		sendAssistantText,
 		sendStopped,
 		sendToolStart,
@@ -652,6 +661,168 @@ test("a turn with no tool running and no model call pending is still held to the
 		expect(message).toContain("ACP prompt was abandoned");
 		expect(message).toContain(`${Math.round(ACP_PROMPT_INACTIVITY_TIMEOUT_MS / 1_000)}s of silence`);
 		expect(message).toContain("the SDK session host stopped producing frames");
+		expect(message).toContain('"message_end"');
+	} finally {
+		fixture.dispose();
+	}
+});
+
+/**
+ * Abandons one turn and starts a second one, then hands back the settled turn's correlation.
+ * This is the supported recovery flow: the watchdog rejects a turn, the client re-prompts, and
+ * the slow-but-alive host then flushes the abandoned turn's frames onto the live turn's socket.
+ */
+async function abandonTurnThenStartAnother(
+	fixture: Fixture,
+): Promise<{ stale: { commandId: string; turnId: string }; pending: Promise<{ stopReason: StoppedReason }> }> {
+	const { pending: abandoned } = await startTurn(fixture);
+	const stale = fixture.correlation();
+	fixture.clock.advance(ACP_PROMPT_INFERENCE_TIMEOUT_MS + 1);
+	await bounded(
+		abandoned.then(
+			() => undefined,
+			() => undefined,
+		),
+		"watchdog rejection",
+	);
+	const { pending } = await startTurn(fixture);
+	expect(fixture.correlation().turnId).not.toBe(stale.turnId);
+	return { stale, pending };
+}
+
+function staleEventFrame(
+	stale: { commandId: string; turnId: string },
+	eventType: string,
+	event: Record<string, unknown>,
+): Record<string, unknown> {
+	return {
+		type: "event",
+		commandId: stale.commandId,
+		turnId: stale.turnId,
+		payload: { event_type: eventType, event },
+	};
+}
+
+test("a settled turn's stale message frame does not narrow the live turn off the inference bound", async () => {
+	const fixture = await createFixture();
+	try {
+		const { stale, pending } = await abandonTurnThenStartAnother(fixture);
+		let settled = false;
+		void pending.then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			},
+		);
+
+		const armedBefore = fixture.clock.armed;
+		fixture.send(
+			staleEventFrame(stale, "message_update", {
+				type: "message_update",
+				message: { role: "assistant", content: [{ type: "text", text: "flushed from the abandoned turn" }] },
+			}),
+		);
+		await waitFor(() => fixture.clock.armed?.id !== armedBefore?.id, "stale frame ingress");
+
+		// The live turn has emitted only `agent_start`: its own model call is still unanswered, so
+		// the inference bound owns it. A frame belonging to a settled turn cannot clear that.
+		expect(fixture.clock.armed?.at).toBe(fixture.clock.now() + ACP_PROMPT_INFERENCE_TIMEOUT_MS);
+		fixture.clock.advance(ACP_PROMPT_INACTIVITY_TIMEOUT_MS + 1);
+		await Bun.sleep(10);
+		expect(settled).toBe(false);
+
+		fixture.sendStopped("end_turn");
+		expect(await bounded(pending, "prompt completion")).toEqual({ stopReason: "end_turn" });
+	} finally {
+		fixture.dispose();
+	}
+});
+
+test("a settled turn's stale tool start does not pin the live turn to the tool bound", async () => {
+	const fixture = await createFixture();
+	try {
+		const { stale, pending } = await abandonTurnThenStartAnother(fixture);
+
+		const armedBefore = fixture.clock.armed;
+		fixture.send(
+			staleEventFrame(stale, "tool_execution_start", {
+				type: "tool_execution_start",
+				toolCallId: "stale-turn-tool",
+				toolName: "bash",
+				args: { command: "sleep 100000" },
+			}),
+		);
+		await waitFor(() => fixture.clock.armed?.id !== armedBefore?.id, "stale frame ingress");
+
+		// Nothing is executing on the live turn, so the hour-wide tool bound must stay retired:
+		// borrowing it from a settled turn would blind the safety net to a dead producer.
+		expect(fixture.clock.armed?.at).toBe(fixture.clock.now() + ACP_PROMPT_INFERENCE_TIMEOUT_MS);
+		fixture.clock.advance(ACP_PROMPT_INFERENCE_TIMEOUT_MS + 1);
+		const error = await bounded(
+			pending.then(
+				() => undefined,
+				(reason: unknown) => reason,
+			),
+			"watchdog rejection",
+		);
+		expect(error).toBeInstanceOf(Error);
+		const message = (error as Error).message;
+		expect(message).toContain("ACP prompt was abandoned");
+		expect(message).toContain(`${Math.round(ACP_PROMPT_INFERENCE_TIMEOUT_MS / 1_000)}s of silence`);
+	} finally {
+		fixture.dispose();
+	}
+});
+
+test("a correlationless frame refreshes liveness without moving the turn's bound", async () => {
+	const fixture = await createFixture();
+	try {
+		const { pending } = await startTurn(fixture);
+		let settled = false;
+		void pending.then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			},
+		);
+
+		// Heartbeats and session-scoped events carry no command/turn identity. They prove the
+		// producer lives, so they refresh the baseline, but they own no activity transition —
+		// an assistant message that belongs to nobody must not retire this turn's inference bound.
+		const chunks = textChunks(fixture.updates);
+		fixture.send({
+			type: "event",
+			payload: {
+				event_type: "message_end",
+				event: {
+					type: "message_end",
+					message: { role: "assistant", content: [{ type: "text", text: "unowned" }] },
+				},
+			},
+		});
+		await waitFor(() => textChunks(fixture.updates) > chunks, "correlationless frame ingress");
+
+		expect(fixture.clock.armed?.at).toBe(fixture.clock.now() + ACP_PROMPT_INFERENCE_TIMEOUT_MS);
+		fixture.clock.advance(ACP_PROMPT_INACTIVITY_TIMEOUT_MS + 1);
+		await Bun.sleep(10);
+		expect(settled).toBe(false);
+
+		// The baseline did move with that frame: the expiry is measured from it, and reports it.
+		fixture.clock.advance(ACP_PROMPT_INFERENCE_TIMEOUT_MS - ACP_PROMPT_INACTIVITY_TIMEOUT_MS);
+		const error = await bounded(
+			pending.then(
+				() => undefined,
+				(reason: unknown) => reason,
+			),
+			"watchdog rejection",
+		);
+		expect(error).toBeInstanceOf(Error);
+		const message = (error as Error).message;
+		expect(message).toContain(`${Math.round(ACP_PROMPT_INFERENCE_TIMEOUT_MS / 1_000)}s of silence`);
 		expect(message).toContain('"message_end"');
 	} finally {
 		fixture.dispose();

--- a/packages/coding-agent/test/acp-prompt-watchdog.test.ts
+++ b/packages/coding-agent/test/acp-prompt-watchdog.test.ts
@@ -4,14 +4,14 @@ import type { AgentSideConnection, PromptRequest, SessionNotification } from "@a
 import { TempDir } from "@gajae-code/utils";
 import { AcpAgent } from "../src/modes/acp/acp-agent";
 import { writeBrokerDiscovery } from "../src/sdk/broker/discovery";
-import { ACP_PROMPT_INACTIVITY_TIMEOUT_MS } from "../src/sdk/prompt-watchdog";
+import { ACP_PROMPT_INACTIVITY_TIMEOUT_MS, ACP_PROMPT_TOOL_ACTIVITY_TIMEOUT_MS } from "../src/sdk/prompt-watchdog";
 
 type TestSocket = { send(message: string): void };
 type StoppedReason = "end_turn" | "max_tokens" | "max_turn_requests" | "refusal" | "cancelled";
 
 /**
  * Virtual timer source for the prompt watchdog. Every watchdog assertion moves this
- * clock instead of sleeping, so a 3800s inactivity bound costs no wall time.
+ * clock instead of sleeping, so a 60min tool-activity bound costs no wall time.
  */
 class VirtualClock {
 	#now = 0;
@@ -63,6 +63,8 @@ type Fixture = {
 	correlation(): { commandId: string; turnId: string };
 	sendAssistantText(text: string): void;
 	sendStopped(reason: StoppedReason): void;
+	sendToolStart(toolCallId: string): void;
+	sendToolEnd(toolCallId: string): void;
 	dispose(): void;
 };
 
@@ -104,6 +106,16 @@ function textChunks(updates: SessionNotification[]): number {
 	return updates.filter(update => update.update.sessionUpdate === "agent_message_chunk").length;
 }
 
+/** ACP `tool_call` updates, i.e. tool executions the host reported as started. */
+function toolCalls(updates: SessionNotification[]): number {
+	return updates.filter(update => update.update.sessionUpdate === "tool_call").length;
+}
+
+/** ACP `tool_call_update` updates, i.e. tool executions the host reported as finished. */
+function toolCallUpdates(updates: SessionNotification[]): number {
+	return updates.filter(update => update.update.sessionUpdate === "tool_call_update").length;
+}
+
 async function createFixture(): Promise<Fixture> {
 	const tempDir = TempDir.createSync("@acp-prompt-watchdog-");
 	const agentDir = path.join(tempDir.path(), "agent");
@@ -141,6 +153,39 @@ async function createFixture(): Promise<Fixture> {
 			commandId,
 			turnId,
 			outcome: { kind: "stopped", reason, provenance: reason === "cancelled" ? "client_cancel" : "agent" },
+		});
+	};
+	const sendToolStart = (toolCallId: string): void => {
+		send({
+			type: "event",
+			commandId,
+			turnId,
+			payload: {
+				event_type: "tool_execution_start",
+				event: {
+					type: "tool_execution_start",
+					toolCallId,
+					toolName: "bash",
+					args: { command: "sleep 100000" },
+				},
+			},
+		});
+	};
+	const sendToolEnd = (toolCallId: string): void => {
+		send({
+			type: "event",
+			commandId,
+			turnId,
+			payload: {
+				event_type: "tool_execution_end",
+				event: {
+					type: "tool_execution_end",
+					toolCallId,
+					toolName: "bash",
+					isError: false,
+					result: { content: [{ type: "text", text: "done" }] },
+				},
+			},
 		});
 	};
 
@@ -251,6 +296,8 @@ async function createFixture(): Promise<Fixture> {
 		correlation: () => ({ commandId, turnId }),
 		sendAssistantText,
 		sendStopped,
+		sendToolStart,
+		sendToolEnd,
 		dispose: () => {
 			abort.abort();
 			server.stop(true);
@@ -385,6 +432,98 @@ test("a normal agent_end settles the prompt once and disarms the watchdog", asyn
 		expect(fixture.updates.length).toBe(updatesAfterSettle);
 		expect(idleUpdates(fixture.updates)).toBe(idleAfterSettle);
 		expect(await bounded(pending, "settled prompt")).toEqual({ stopReason: "end_turn" });
+	} finally {
+		fixture.dispose();
+	}
+});
+
+test("the watchdog bounds stay pinned to their derivation", () => {
+	// Slowest tool default (`bash`, 300s) + one SDK reconnect budget (2 x 20s heartbeat).
+	expect(ACP_PROMPT_INACTIVITY_TIMEOUT_MS).toBe(340_000);
+	// Slowest per-tool ceiling (`bash`/`ssh`, 3600s) + the same reconnect budget.
+	expect(ACP_PROMPT_TOOL_ACTIVITY_TIMEOUT_MS).toBe(3_640_000);
+	// A frame-free gap with nothing running must stay operationally useful; the wide
+	// bound is only ever reachable while a tool call is observably in flight.
+	expect(ACP_PROMPT_INACTIVITY_TIMEOUT_MS).toBeLessThan(10 * 60_000);
+	expect(ACP_PROMPT_TOOL_ACTIVITY_TIMEOUT_MS).toBeGreaterThan(3_600_000);
+});
+
+test("a tool call running past the idle bound is protected while it runs, not after it ends", async () => {
+	const fixture = await createFixture();
+	try {
+		const { pending } = await startTurn(fixture);
+		let settled = false;
+		void pending.then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			},
+		);
+
+		const started = toolCalls(fixture.updates);
+		fixture.sendToolStart("watchdog-tool-1");
+		await waitFor(() => toolCalls(fixture.updates) > started, "tool call start");
+
+		// A `bash` that blocks far past the idle bound is evidenced as running, so the
+		// silence it produces is legitimate and must not be rejected.
+		fixture.clock.advance(ACP_PROMPT_TOOL_ACTIVITY_TIMEOUT_MS - 1);
+		await Bun.sleep(10);
+		expect(settled).toBe(false);
+
+		const ended = toolCallUpdates(fixture.updates);
+		fixture.sendToolEnd("watchdog-tool-1");
+		await waitFor(() => toolCallUpdates(fixture.updates) > ended, "tool call end");
+
+		// Evidence is gone: the next frame-free gap is bounded by the idle bound again.
+		fixture.clock.advance(ACP_PROMPT_INACTIVITY_TIMEOUT_MS + 1);
+		const error = await bounded(
+			pending.then(
+				() => undefined,
+				(reason: unknown) => reason,
+			),
+			"watchdog rejection",
+		);
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toContain("ACP prompt was abandoned");
+		expect((error as Error).message).toContain('"tool_execution_end"');
+	} finally {
+		fixture.dispose();
+	}
+});
+
+test("a tool call still in flight keeps the wide bound armed across silent gaps", async () => {
+	const fixture = await createFixture();
+	try {
+		const { pending } = await startTurn(fixture);
+		let settled = false;
+		void pending.then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			},
+		);
+
+		const started = toolCalls(fixture.updates);
+		fixture.sendToolStart("watchdog-tool-a");
+		await waitFor(() => toolCalls(fixture.updates) > started, "first tool call start");
+
+		// A second tool starting and finishing must not retire the evidence held by the
+		// first one, which is still running.
+		const ended = toolCallUpdates(fixture.updates);
+		fixture.sendToolStart("watchdog-tool-b");
+		fixture.sendToolEnd("watchdog-tool-b");
+		await waitFor(() => toolCallUpdates(fixture.updates) > ended, "second tool call end");
+
+		fixture.clock.advance(ACP_PROMPT_INACTIVITY_TIMEOUT_MS * 3);
+		await Bun.sleep(10);
+		expect(settled).toBe(false);
+
+		fixture.sendStopped("end_turn");
+		expect(await bounded(pending, "prompt completion")).toEqual({ stopReason: "end_turn" });
 	} finally {
 		fixture.dispose();
 	}

--- a/packages/coding-agent/test/acp-prompt-watchdog.test.ts
+++ b/packages/coding-agent/test/acp-prompt-watchdog.test.ts
@@ -1,0 +1,391 @@
+import { expect, test } from "bun:test";
+import * as path from "node:path";
+import type { AgentSideConnection, PromptRequest, SessionNotification } from "@agentclientprotocol/sdk";
+import { TempDir } from "@gajae-code/utils";
+import { AcpAgent } from "../src/modes/acp/acp-agent";
+import { writeBrokerDiscovery } from "../src/sdk/broker/discovery";
+import { ACP_PROMPT_INACTIVITY_TIMEOUT_MS } from "../src/sdk/prompt-watchdog";
+
+type TestSocket = { send(message: string): void };
+type StoppedReason = "end_turn" | "max_tokens" | "max_turn_requests" | "refusal" | "cancelled";
+
+/**
+ * Virtual timer source for the prompt watchdog. Every watchdog assertion moves this
+ * clock instead of sleeping, so a 3800s inactivity bound costs no wall time.
+ */
+class VirtualClock {
+	#now = 0;
+	#nextId = 1;
+	readonly #timers = new Map<number, { at: number; handler: () => void }>();
+
+	now(): number {
+		return this.#now;
+	}
+
+	schedule(handler: () => void, delayMs: number): () => void {
+		const id = this.#nextId++;
+		this.#timers.set(id, { at: this.#now + delayMs, handler });
+		return () => {
+			this.#timers.delete(id);
+		};
+	}
+
+	get pending(): number {
+		return this.#timers.size;
+	}
+
+	advance(ms: number): void {
+		const target = this.#now + ms;
+		for (;;) {
+			let dueId: number | undefined;
+			let dueAt = Number.POSITIVE_INFINITY;
+			for (const [id, timer] of this.#timers)
+				if (timer.at <= target && timer.at < dueAt) {
+					dueId = id;
+					dueAt = timer.at;
+				}
+			if (dueId === undefined) break;
+			const due = this.#timers.get(dueId);
+			this.#timers.delete(dueId);
+			this.#now = dueAt;
+			due?.handler();
+		}
+		this.#now = target;
+	}
+}
+
+type Fixture = {
+	agent: AcpAgent;
+	sessionId: string;
+	updates: SessionNotification[];
+	clock: VirtualClock;
+	/** Correlation the fixture host acknowledged for the turn currently in flight. */
+	correlation(): { commandId: string; turnId: string };
+	sendAssistantText(text: string): void;
+	sendStopped(reason: StoppedReason): void;
+	dispose(): void;
+};
+
+async function bounded<T>(promise: Promise<T>, label: string): Promise<T> {
+	return await Promise.race([
+		promise,
+		Bun.sleep(2_000).then(() => {
+			throw new Error(`Timed out waiting for ${label}`);
+		}),
+	]);
+}
+
+async function waitFor(predicate: () => boolean, label: string): Promise<void> {
+	const deadline = Date.now() + 2_000;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await Bun.sleep(5);
+	}
+	throw new Error(`Timed out waiting for ${label}`);
+}
+
+function workingUpdates(updates: SessionNotification[]): number {
+	return updates.filter(
+		update =>
+			update.update.sessionUpdate === "session_info_update" &&
+			(update.update as { _meta?: { gjcPhase?: string } })._meta?.gjcPhase === "working",
+	).length;
+}
+
+function idleUpdates(updates: SessionNotification[]): number {
+	return updates.filter(
+		update =>
+			update.update.sessionUpdate === "session_info_update" &&
+			(update.update as { _meta?: { gjcPhase?: string } })._meta?.gjcPhase === "idle",
+	).length;
+}
+
+function textChunks(updates: SessionNotification[]): number {
+	return updates.filter(update => update.update.sessionUpdate === "agent_message_chunk").length;
+}
+
+async function createFixture(): Promise<Fixture> {
+	const tempDir = TempDir.createSync("@acp-prompt-watchdog-");
+	const agentDir = path.join(tempDir.path(), "agent");
+	const cwd = path.join(tempDir.path(), "workspace");
+	const token = "acp-prompt-watchdog-token";
+	const sessionId = "prompt-watchdog-session";
+	const updates: SessionNotification[] = [];
+	const clock = new VirtualClock();
+	const abort = new AbortController();
+	let turnCount = 0;
+	let commandId = "";
+	let turnId = "";
+	let promptSocket: TestSocket | undefined;
+	let server!: ReturnType<typeof Bun.serve>;
+
+	const send = (frame: Record<string, unknown>): void => {
+		if (!promptSocket) throw new Error("Expected a prompt socket");
+		promptSocket.send(JSON.stringify(frame));
+	};
+	const sendAssistantText = (text: string): void => {
+		send({
+			type: "event",
+			commandId,
+			turnId,
+			payload: {
+				event_type: "message_end",
+				event: { type: "message_end", message: { role: "assistant", content: [{ type: "text", text }] } },
+			},
+		});
+	};
+	const sendStopped = (reason: StoppedReason): void => {
+		send({
+			type: "agent_end",
+			sessionId,
+			commandId,
+			turnId,
+			outcome: { kind: "stopped", reason, provenance: reason === "cancelled" ? "client_cancel" : "agent" },
+		});
+	};
+
+	server = Bun.serve({
+		hostname: "127.0.0.1",
+		port: 0,
+		fetch(request, server) {
+			if (new URL(request.url).searchParams.get("token") !== token)
+				return new Response("Unauthorized", { status: 401 });
+			if (!server.upgrade(request, { data: undefined })) return new Response("Upgrade failed", { status: 400 });
+		},
+		websocket: {
+			open(socket) {
+				socket.send(JSON.stringify({ type: "hello", connectionId: "acp-prompt-watchdog" }));
+			},
+			message(socket, raw) {
+				const frame = JSON.parse(String(raw)) as Record<string, unknown>;
+				if (frame.type === "register_provider") {
+					socket.send(
+						JSON.stringify({ type: "register_provider_result", id: frame.id, ok: true, leaseId: "lease" }),
+					);
+					return;
+				}
+				if (frame.type === "broker_request") {
+					const result =
+						frame.operation === "session.create"
+							? { sessionId, endpoint: { url: `ws://127.0.0.1:${server.port}`, token } }
+							: {};
+					socket.send(JSON.stringify({ type: "broker_response", id: frame.id, ok: true, result }));
+					return;
+				}
+				if (frame.type === "query_request") {
+					const items =
+						frame.query === "config.list/get"
+							? [{ mode: "default", model: "openai/gpt", thinking: "medium" }]
+							: frame.query === "models.list/current"
+								? [{ provider: "openai", id: "gpt", name: "GPT" }]
+								: frame.query === "providers.list/active"
+									? [{ providerId: "openai", connectionKind: "credential" }]
+									: [];
+					const result =
+						frame.query === "runtime.capabilities"
+							? { promptTerminalOutcomeVersion: 1 }
+							: frame.query === "context.get"
+								? { usage: { tokens: 0, contextWindow: 200_000, percent: 0, source: "test" } }
+								: { page: { items, complete: true } };
+					socket.send(JSON.stringify({ type: "query_response", id: frame.id, ok: true, result }));
+					return;
+				}
+				if (frame.type !== "control_request") return;
+				if (frame.operation === "turn.prompt") {
+					promptSocket = socket;
+					turnCount += 1;
+					commandId = `watchdog-command-${turnCount}`;
+					turnId = `watchdog-turn-${turnCount}`;
+				}
+				socket.send(
+					JSON.stringify({
+						type: "control_response",
+						id: frame.id,
+						ok: true,
+						result:
+							frame.operation === "turn.prompt"
+								? { commandId, turnId, accepted: true }
+								: frame.operation === "turn.abort"
+									? { aborted: true }
+									: {},
+					}),
+				);
+				// Frames are FIFO on the socket, so the client records the acknowledged
+				// correlation before this start frame reaches the session record.
+				if (frame.operation === "turn.prompt")
+					socket.send(JSON.stringify({ type: "agent_start", sessionId, commandId, turnId }));
+			},
+		},
+	});
+	const port = server.port;
+	if (port === undefined) throw new Error("Expected an ACP fixture server port");
+	await writeBrokerDiscovery(agentDir, {
+		version: 1,
+		protocolVersion: 3,
+		packageGeneration: "test",
+		ownerId: "test-owner",
+		pid: process.pid,
+		host: "127.0.0.1",
+		port,
+		url: `ws://127.0.0.1:${port}`,
+		token,
+		startedAt: Date.now(),
+		heartbeatAt: Date.now(),
+	});
+	const agent = new AcpAgent(
+		{
+			sessionUpdate: async (update: SessionNotification) => updates.push(update),
+			signal: abort.signal,
+			closed: Promise.withResolvers<void>().promise,
+		} as unknown as AgentSideConnection,
+		{ agentDir, promptWatchdogClock: clock },
+	);
+	const created = await bounded(agent.newSession({ cwd, mcpServers: [] }), "new session");
+	await waitFor(() => idleUpdates(updates) > 0, "bootstrap update");
+
+	return {
+		agent,
+		sessionId: created.sessionId,
+		updates,
+		clock,
+		correlation: () => ({ commandId, turnId }),
+		sendAssistantText,
+		sendStopped,
+		dispose: () => {
+			abort.abort();
+			server.stop(true);
+			tempDir.removeSync();
+		},
+	};
+}
+
+function prompt(fixture: Fixture, text: string): Promise<{ stopReason: StoppedReason }> {
+	return fixture.agent.prompt({
+		sessionId: fixture.sessionId,
+		messageId: "00000000-0000-4000-8000-000000000001",
+		prompt: [{ type: "text", text }],
+	} as PromptRequest) as Promise<{ stopReason: StoppedReason }>;
+}
+
+/**
+ * Runs a turn up to its acknowledged, started state; the host then goes silent.
+ * The pending prompt is returned wrapped, because an async function would await it.
+ */
+async function startTurn(fixture: Fixture): Promise<{ pending: Promise<{ stopReason: StoppedReason }> }> {
+	const started = workingUpdates(fixture.updates);
+	const pending = prompt(fixture, "work");
+	await waitFor(() => workingUpdates(fixture.updates) > started, "turn start");
+	return { pending };
+}
+
+test("a prompt that goes silent past the inactivity bound is rejected instead of hanging", async () => {
+	const fixture = await createFixture();
+	try {
+		const { pending } = await startTurn(fixture);
+		const { commandId, turnId } = fixture.correlation();
+		const idleBefore = idleUpdates(fixture.updates);
+
+		fixture.clock.advance(ACP_PROMPT_INACTIVITY_TIMEOUT_MS + 1);
+
+		const error = await bounded(
+			pending.then(
+				() => undefined,
+				(reason: unknown) => reason,
+			),
+			"watchdog rejection",
+		);
+		expect(error).toBeInstanceOf(Error);
+		const message = (error as Error).message;
+		expect(message).toContain("ACP prompt was abandoned");
+		expect(message).toContain(`${Math.round(ACP_PROMPT_INACTIVITY_TIMEOUT_MS / 1_000)}s of silence`);
+		expect(message).toContain("the SDK session host stopped producing frames");
+		expect(message).toContain('"agent_start"');
+		expect(message).toContain(`commandId=${commandId}`);
+		expect(message).toContain(`turnId=${turnId}`);
+		// The client's running phase is released, so the composer stops spinning.
+		expect(idleUpdates(fixture.updates)).toBe(idleBefore + 1);
+	} finally {
+		fixture.dispose();
+	}
+});
+
+test("a prompt refreshed by frames just under the bound is never rejected", async () => {
+	const fixture = await createFixture();
+	try {
+		const { pending } = await startTurn(fixture);
+		let settled = false;
+		void pending.then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			},
+		);
+
+		for (let round = 0; round < 5; round++) {
+			const chunks = textChunks(fixture.updates);
+			fixture.clock.advance(ACP_PROMPT_INACTIVITY_TIMEOUT_MS - 1);
+			expect(settled).toBe(false);
+			fixture.sendAssistantText(`slow chunk ${round}`);
+			await waitFor(() => textChunks(fixture.updates) > chunks, `assistant chunk ${round}`);
+			// The frame re-armed a live watchdog; the bound is per-gap, not per-turn.
+			expect(fixture.clock.pending).toBe(1);
+		}
+
+		// Total elapsed silence is five times the bound, but no single gap ever reached it.
+		expect(settled).toBe(false);
+		fixture.sendStopped("end_turn");
+		expect(await bounded(pending, "prompt completion")).toEqual({ stopReason: "end_turn" });
+	} finally {
+		fixture.dispose();
+	}
+});
+
+test("a session accepts a new prompt after a watchdog rejection", async () => {
+	const fixture = await createFixture();
+	try {
+		const { pending: abandoned } = await startTurn(fixture);
+		const firstCommandId = fixture.correlation().commandId;
+		fixture.clock.advance(ACP_PROMPT_INACTIVITY_TIMEOUT_MS + 1);
+		await bounded(
+			abandoned.then(
+				() => undefined,
+				() => undefined,
+			),
+			"watchdog rejection",
+		);
+
+		const { pending: recovered } = await startTurn(fixture);
+		expect(fixture.correlation().commandId).not.toBe(firstCommandId);
+		fixture.sendStopped("end_turn");
+		expect(await bounded(recovered, "recovered prompt completion")).toEqual({ stopReason: "end_turn" });
+	} finally {
+		fixture.dispose();
+	}
+});
+
+test("a normal agent_end settles the prompt once and disarms the watchdog", async () => {
+	const fixture = await createFixture();
+	try {
+		const { pending } = await startTurn(fixture);
+		// The turn is being watched, so the disarm assertion below cannot pass vacuously.
+		expect(fixture.clock.pending).toBe(1);
+		fixture.sendStopped("end_turn");
+		expect(await bounded(pending, "prompt completion")).toEqual({ stopReason: "end_turn" });
+
+		const updatesAfterSettle = fixture.updates.length;
+		const idleAfterSettle = idleUpdates(fixture.updates);
+		expect(fixture.clock.pending).toBe(0);
+
+		fixture.clock.advance(ACP_PROMPT_INACTIVITY_TIMEOUT_MS * 3);
+		await Bun.sleep(10);
+
+		// No second settlement: no rejection, no extra phase publication.
+		expect(fixture.updates.length).toBe(updatesAfterSettle);
+		expect(idleUpdates(fixture.updates)).toBe(idleAfterSettle);
+		expect(await bounded(pending, "settled prompt")).toEqual({ stopReason: "end_turn" });
+	} finally {
+		fixture.dispose();
+	}
+});

--- a/packages/coding-agent/test/agent-session-todo-reminder.test.ts
+++ b/packages/coding-agent/test/agent-session-todo-reminder.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Agent, type AgentMessage } from "@gajae-code/agent-core";
+import { type DeveloperMessage, getBundledModel, type TextContent } from "@gajae-code/ai";
+import { createMockModel, type MockModelHandle } from "@gajae-code/ai/providers/mock";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { AgentSession, type AgentSessionEvent } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import type { TodoPhase } from "@gajae-code/coding-agent/tools/todo-write";
+import { Snowflake } from "@gajae-code/utils";
+
+/**
+ * Regression coverage for the todo completion reminder reopening a finished turn.
+ *
+ * `#checkTodoCompletion` runs inside the `agent_end` handler, before the deferred
+ * terminal is published. Injecting a developer message plus `#scheduleAgentContinue`
+ * parks that terminal behind a continuation hold, so the prompt never settles for a
+ * consumer that cannot represent a server-initiated turn.
+ */
+describe("AgentSession todo completion reminder", () => {
+	let session: AgentSession;
+	let settings: Settings;
+	let tempDir: string;
+	let mock: MockModelHandle;
+	let authStorage: AuthStorage | undefined;
+	let events: AgentSessionEvent[];
+	/** `mock.calls.length` sampled every time a terminal `agent_end` reaches subscribers. */
+	let modelCallsAtAgentEnd: number[];
+
+	const incompletePhases = (): TodoPhase[] => [
+		{
+			name: "Investigation",
+			tasks: [
+				{ content: "Trace the settlement path", status: "in_progress" },
+				{ content: "Report the mechanism", status: "pending" },
+			],
+		},
+	];
+
+	const completedPhases = (): TodoPhase[] => [
+		{ name: "Investigation", tasks: [{ content: "Trace the settlement path", status: "completed" }] },
+	];
+
+	const isInjectedReminder = (message: AgentMessage): message is DeveloperMessage =>
+		message.role === "developer" &&
+		Array.isArray(message.content) &&
+		message.content.some(block => block.type === "text" && block.text.includes("incomplete todo item(s)"));
+
+	const injectedReminders = (): DeveloperMessage[] => session.agent.state.messages.filter(isInjectedReminder);
+
+	const reminderText = (message: DeveloperMessage | undefined): string => {
+		if (!message) return "";
+		if (typeof message.content === "string") return message.content;
+		return message.content
+			.filter((block): block is TextContent => block.type === "text")
+			.map(block => block.text)
+			.join("");
+	};
+
+	const reminderEvents = (): Extract<AgentSessionEvent, { type: "todo_reminder" }>[] =>
+		events.filter((event): event is Extract<AgentSessionEvent, { type: "todo_reminder" }> => {
+			return event.type === "todo_reminder";
+		});
+
+	beforeEach(async () => {
+		tempDir = path.join(os.tmpdir(), `pi-todo-reminder-test-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) {
+			throw new Error("Test model not found in registry");
+		}
+
+		authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+
+		mock = createMockModel({ handler: () => ({ content: ["Final report delivered."] }) });
+
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: mock.stream,
+		});
+
+		settings = Settings.isolated();
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		events = [];
+		modelCallsAtAgentEnd = [];
+		session.subscribe(event => {
+			events.push(event);
+			if (event.type === "agent_end") modelCallsAtAgentEnd.push(mock.calls.length);
+		});
+	});
+
+	afterEach(async () => {
+		await session.dispose();
+		authStorage?.close();
+		authStorage = undefined;
+		if (fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("settles a finished turn with incomplete todos instead of reopening it for a deferred-turn client", async () => {
+		session.setClientBridge({ capabilities: {}, deferAgentInitiatedTurns: true });
+		session.setTodoPhases(incompletePhases());
+
+		await session.prompt("do the long task");
+
+		// The terminal published right after the single turn the user asked for.
+		expect(modelCallsAtAgentEnd).toEqual([1]);
+		expect(mock.calls).toHaveLength(1);
+		expect(session.isStreaming).toBe(false);
+		// Nothing reopened the conversation.
+		expect(injectedReminders()).toHaveLength(0);
+		// The advisory reminder is still produced for notification consumers.
+		expect(reminderEvents()).toHaveLength(1);
+		expect(reminderEvents()[0]?.todos.map(todo => todo.content)).toEqual([
+			"Trace the settlement path",
+			"Report the mechanism",
+		]);
+		expect(reminderEvents()[0]?.attempt).toBe(1);
+	});
+
+	it("still injects a visible reminder for an interactive session", async () => {
+		settings.set("todo.reminders.max", 2);
+		session.setTodoPhases(incompletePhases());
+
+		await session.prompt("do the long task");
+
+		expect(reminderEvents()).toHaveLength(1);
+		const reminders = injectedReminders();
+		expect(reminders).toHaveLength(1);
+		expect(reminderText(reminders[0])).toContain("You stopped with 2 incomplete todo item(s)");
+		expect(reminderText(reminders[0])).toContain("(Reminder 1/2)");
+
+		// The reminder reopened the turn: it lands between the two assistant messages.
+		expect(mock.calls).toHaveLength(2);
+		const messages = session.agent.state.messages;
+		const assistantIndices = messages
+			.map((message, index) => (message.role === "assistant" ? index : -1))
+			.filter(index => index >= 0);
+		const reminderIndex = messages.findIndex(isInjectedReminder);
+		expect(assistantIndices).toHaveLength(2);
+		expect(reminderIndex).toBeGreaterThan(assistantIndices[0]!);
+		expect(reminderIndex).toBeLessThan(assistantIndices[1]!);
+	});
+
+	it("injects nothing once the todo.reminders.max budget is exhausted", async () => {
+		settings.set("todo.reminders.max", 0);
+		session.setTodoPhases(incompletePhases());
+
+		await session.prompt("do the long task");
+
+		expect(reminderEvents()).toHaveLength(0);
+		expect(injectedReminders()).toHaveLength(0);
+		expect(mock.calls).toHaveLength(1);
+		expect(modelCallsAtAgentEnd).toEqual([1]);
+	});
+
+	it("leaves a turn with no incomplete todos untouched", async () => {
+		session.setTodoPhases(completedPhases());
+
+		await session.prompt("do the short task");
+
+		expect(reminderEvents()).toHaveLength(0);
+		expect(injectedReminders()).toHaveLength(0);
+		expect(mock.calls).toHaveLength(1);
+		expect(modelCallsAtAgentEnd).toEqual([1]);
+	});
+
+	it("resets the reminder counter on the next user prompt", async () => {
+		settings.set("todo.reminders.max", 1);
+		session.setTodoPhases(incompletePhases());
+
+		await session.prompt("first task");
+		expect(injectedReminders()).toHaveLength(1);
+		expect(mock.calls).toHaveLength(2);
+
+		await session.prompt("second task");
+
+		// A stuck counter would have suppressed the second prompt's reminder.
+		expect(injectedReminders()).toHaveLength(2);
+		expect(reminderEvents()).toHaveLength(2);
+		expect(reminderEvents().map(event => event.attempt)).toEqual([1, 1]);
+		expect(mock.calls).toHaveLength(4);
+	});
+});

--- a/packages/coding-agent/test/sdk-acp-prompt-terminal.test.ts
+++ b/packages/coding-agent/test/sdk-acp-prompt-terminal.test.ts
@@ -41,6 +41,15 @@ async function waitFor(predicate: () => boolean, label: string): Promise<void> {
 	throw new Error(`Timed out waiting for ${label}`);
 }
 
+/** ACP `session_info_update` frames that release the client's running phase. */
+function idlePhaseUpdates(updates: SessionNotification[]): number {
+	return updates.filter(
+		update =>
+			update.update.sessionUpdate === "session_info_update" &&
+			(update.update as { _meta?: { gjcPhase?: string } })._meta?.gjcPhase === "idle",
+	).length;
+}
+
 async function createFixture(
 	options: {
 		terminalBeforeAcknowledgement?: boolean;
@@ -264,6 +273,9 @@ for (const reason of ["end_turn", "max_tokens", "max_turn_requests", "refusal", 
 			await bounded(fixture.promptDelivered, "prompt delivery");
 			fixture.sendStopped(reason);
 			expect(await bounded(pending, `${reason} prompt completion`)).toEqual({ stopReason: reason });
+			// The prompt settles on its terminal frame, so the advisory end-of-turn queries
+			// and the phase publication land after it rather than gating it.
+			await waitFor(() => idlePhaseUpdates(fixture.updates) > idleUpdatesBefore, "end-of-turn idle update");
 			expect(fixture.queryCalls.filter(query => query === "context.get")).toHaveLength(contextQueriesBefore + 1);
 			expect(fixture.queryCalls.filter(query => query === "session.metadata")).toHaveLength(
 				metadataQueriesBefore + 1,
@@ -322,6 +334,7 @@ test("ACP prompt settles exactly once when terminal arrives before acknowledgeme
 		});
 		expect(await bounded(pending, "pre-acknowledgement completion")).toEqual({ stopReason: "end_turn" });
 		expect(settleCount).toBe(1);
+		await waitFor(() => idlePhaseUpdates(fixture.updates) > idleUpdatesBefore, "end-of-turn idle update");
 		expect(fixture.queryCalls.filter(query => query === "context.get")).toHaveLength(contextQueriesBefore + 1);
 		expect(fixture.queryCalls.filter(query => query === "session.metadata")).toHaveLength(metadataQueriesBefore + 1);
 		expect(
@@ -541,6 +554,9 @@ test("ACP suppresses partial and duplicate terminals after settlement", async ()
 		await bounded(fixture.promptDelivered, "prompt delivery");
 		fixture.sendStopped("end_turn");
 		expect(await bounded(pending, "terminal completion")).toEqual({ stopReason: "end_turn" });
+		// Settlement precedes the advisory end-of-turn work, so the suppression baseline is
+		// taken once that work has flushed.
+		await waitFor(() => idlePhaseUpdates(fixture.updates) > 1, "end-of-turn idle update");
 		const updatesAfterSettlement = fixture.updates.length;
 		const queriesAfterSettlement = fixture.queryCalls.length;
 		fixture.sendTerminal({


### PR DESCRIPTION
Scoped replacement for the ACP turn-lifecycle portion of the closed #4021. Five commits, 7 files, one subsystem: **an ACP turn that finishes must settle, and a turn that is alive must not be killed.**

Every defect here was reproduced live on this machine while running batches of agents through Paseo, and each fix has a regression test that fails without it.

## The defects

**1. A finished turn never settled** (`75901d5e4`)
An agent delivered its complete final answer, the host went quiet, and the client kept reporting the turn `running` indefinitely. None of the terminal guards were at fault — the bug was ordering. `#handleSdkFrame` awaited `#emitEndOfTurnUpdates` *before* settling, and those advisory `context.get` / `session.metadata` queries are exactly what a host that stops the moment it publishes its terminal never answers. Settlement now happens on the terminal frame; metadata follows it, and a late answer cannot report idle once the next turn has begun.

**2. A silent producer hung the client forever** (`e76d88c76`)
There was a rejection path for a lost owner connection and one for a malformed terminal, but none for "the producer stopped and no terminal will ever arrive". `activePrompt` stayed unsettled and `session/prompt` never returned. Observed twice in one hour: host alive at 0% CPU, only the loopback socket left, last log line then silence, while the orchestrator reported `running` for 21 more minutes. A per-prompt inactivity watchdog now settles it with a diagnosable terminal error carrying the silence duration and last frame type. It settles the ACP prompt only; it never cancels the agent's work.

**3. The watchdog was unusable, then it was wrong** (`68af1d9ac`, `5ea867c48`)
First it was sized at `MAX_TOOL_RUNTIME_MS + 10 * HEARTBEAT_TTL_MS` = **63.3 minutes**, derived from the bash/ssh ceiling a caller may *request* — the rarest possible case, so it could not react to an ordinary hang. Tightening it to an evidence-based bound then exposed the opposite failure: production logs recorded **65 expiries across 27 host pids**, all at the narrow bound, with `agent_start` as the last frame in **49 of them**. Tool execution had evidence (`tool_execution_start` with no matching end); model inference had none, so a turn sitting in a long provider call looked exactly like a dead one. Inference is now tracked the same way, giving three bounds:

| state | bound |
|---|---|
| nothing running, nothing pending | 5.67 min |
| awaiting the model | 10.67 min |
| tool in flight | 60.67 min |

All derived from named constants, all terminating.

**4. The todo reminder reopened finished turns** (`01a40dc85`)
Even with the watchdog correct, a lane sat `running` for 78 minutes with its host at 0% CPU and **zero watchdog expiries** — the watchdog was right, the turn had been reopened. The completion reminder calls `appendMessage`, which parks the terminal `agent_end` behind a continuation hold. The nudge exists for an interactive agent that stopped early; a deferred-turn client (ACP v1, SDK hosts) has nobody to act on it, so injecting there only prevents settlement. Those hosts now get the advisory event and nothing else. Interactive sessions are unchanged.

## Verification

Every regression test was confirmed load-bearing by stashing only `packages/coding-agent/src` and re-running:

```
acp-prompt-settle-on-completion    3 pass / 0 fail   (2 pass / 1 fail without)
acp-prompt-watchdog               10 pass / 0 fail   (0 pass / 1 fail without)
agent-session-todo-reminder        5 pass / 0 fail   (4 pass / 1 fail without)
acp suites + prompt terminal     192 pass / 0 fail
```

`bun --cwd=packages/coding-agent run check` exit 0, `check:schemas` clean, `telegram-daemon-generation-guard` → `v43 no protected changes`.

### End-to-end proof, not just unit tests

The failure this PR fixes is "the agent finishes and the client never notices", which no unit test can fully demonstrate. So it was verified against real Paseo lanes on a binary built from this branch:

- a short task settled on its own in **38 s**;
- a task running `sleep 420` (7 min of silence, which the old 5.67 min bound would have killed) **survived and completed**, with **0 watchdog expiries** for its pids;
- a task that deliberately left incomplete todos — the exact shape that previously hung for 78 minutes — settled on its own in **81 s**.

No `paseo stop` was issued in any of those runs.

## Relationship to #4021

#4021 bundled twelve unrelated defects into 53 files and was closed with the instruction to open fresh, scoped PRs. This is the first of those: one subsystem, one theme. The remaining groups (broker/host lifecycle, chat-daemon reconnect, gc/disk retention, tool diagnostics) will follow as separate PRs, each independently verifiable.
