### PR TITLE
fix(sdk): await reserved spill writes during close

### DIFF
--- a/packages/coding-agent/src/sdk/host/query/revision-store.ts
+++ b/packages/coding-agent/src/sdk/host/query/revision-store.ts
@@ -312,8 +312,7 @@ export class RevisionStore {
 	readonly #onReadRange?: (start: number, end: number) => void;
 	#closing = false;
 	#closePromise: Promise<void> | undefined;
-	#writesInFlight = 0;
-	#writesDrained: PromiseWithResolvers<void> | undefined;
+	readonly #pendingWrites = new Set<Promise<void>>();
 
 	constructor(
 		readonly sessionId: string,
@@ -326,10 +325,11 @@ export class RevisionStore {
 
 	createRevision(resourceKind: string, resourceId: string, payload: unknown): Promise<string> {
 		if (this.#closing) return Promise.reject(new RevisionStoreError("resource_gone", "snapshot store is closing"));
-		this.#writesInFlight++;
+		const settled = Promise.withResolvers<void>();
+		this.#pendingWrites.add(settled.promise);
 		return this.#createRevision(resourceKind, resourceId, payload).finally(() => {
-			this.#writesInFlight--;
-			if (this.#writesInFlight === 0) this.#writesDrained?.resolve();
+			this.#pendingWrites.delete(settled.promise);
+			settled.resolve();
 		});
 	}
 
@@ -531,10 +531,7 @@ export class RevisionStore {
 		if (this.#closePromise) return this.#closePromise;
 		this.#closing = true;
 		this.#closePromise = (async () => {
-			if (this.#writesInFlight > 0) {
-				this.#writesDrained ??= Promise.withResolvers<void>();
-				await this.#writesDrained.promise;
-			}
+			await Promise.all(this.#pendingWrites);
 			this.#resources.clear();
 			this.#pinIndex.clear();
 			this.#memoryBytes = 0;


### PR DESCRIPTION
## #3350 Dev CI repair

Dev CI run 31246947834 failed only `SDK query pagination > settles in-progress spill writes before terminal cleanup` in coding-agent shard 2.

This replaces the counter/deferred close barrier with per-write settlement reservations created synchronously with `createRevision()`. Once `close()` fences new writes, it awaits the exact reservation set before terminal spill cleanup.

Validation:
- `bun test packages/coding-agent/test/sdk-query-pagination.test.ts --test-name-pattern='settles in-progress spill writes before terminal cleanup'`
- `bun test packages/coding-agent/test/sdk-query-pagination.test.ts`

The repair commit is locally SSH-signed (`git` verified it with RSA SHA256:sMm/mlKbgfQ8MIZwP9ALVJIJujUtUjAEteVdQc03iSI). GitHub commit evidence: `980a575d0a078a70f974e17af9a5f72d8b5f604d`.

Local shard 2 was additionally attempted after building the native addon; unrelated pre-existing docs-index/documentation failures prevented a clean package shard result.