### PR TITLE
fix(sdk): stop the broker and its session hosts from leaking, wedging, and failing silently

### DIFF
--- a/packages/coding-agent/src/commands/sdk.ts
+++ b/packages/coding-agent/src/commands/sdk.ts
@@ -16,6 +16,8 @@ import {
 	readSessionLifecycleLaunchRequest,
 	type SessionLifecycleLaunchRequest,
 	type SessionLifecycleTranscriptIdentity,
+	sessionHostAttachedClients,
+	startBrokerDeadRegistrationSweep,
 	writeSessionLifecycleFailure,
 	writeSessionLifecycleReady,
 } from "../sdk/broker/lifecycle";
@@ -102,6 +104,81 @@ export async function watchSessionHostBrokerLiveness(deps: {
 		} else {
 			absentSince ??= now();
 			if (now() - absentSince >= graceMs) return;
+		}
+		await sleep(pollMs);
+	}
+}
+
+/**
+ * How long a session host that has served at least one client tolerates having
+ * no client attached before treating itself as abandoned.
+ *
+ * This cannot fire during healthy work. "Attached" is the host's own live
+ * socket-subscription count, so a client that is merely idle — an editor
+ * sitting on an open ACP session, a long agent turn with nobody typing — still
+ * holds a socket and resets the window on every poll. Only a client that is
+ * actually gone opens it, and 30 minutes is far longer than any client
+ * reconnect budget (ACP's is seconds), so a crashed-and-restarted client
+ * reattaches long before the window closes.
+ */
+export const SESSION_HOST_DETACHED_IDLE_GRACE_MS = 30 * 60_000;
+
+/**
+ * How long a freshly spawned session host waits for its very first client
+ * before treating itself as abandoned.
+ *
+ * A host is ready before its client has finished dialing, so a host that has
+ * never seen an attachment must not be judged by the detached window above. One
+ * hour is orders of magnitude beyond the slowest observed cold start (worktree
+ * preparation, MCP server launch, model-profile application) and beyond any
+ * lifecycle readiness deadline the broker will wait on, so it can only elapse
+ * for a host nobody ever came for.
+ */
+export const SESSION_HOST_FIRST_ATTACH_GRACE_MS = 60 * 60_000;
+
+const SESSION_HOST_ATTACHMENT_POLL_MS = 30_000;
+
+/**
+ * Resolves once this host is provably abandoned: either it has been detached
+ * from every client for the full idle grace, or it was never attached at all
+ * for the full first-attach grace.
+ *
+ * `readAttachedClients` reports the host's own live client/socket subscription
+ * count; `undefined` means the SDK endpoint publishes no such evidence yet and
+ * is deliberately *not* treated as detachment, so a host can never be reaped on
+ * missing evidence — only on observed absence of clients.
+ */
+export async function watchSessionHostClientAttachment(deps: {
+	readAttachedClients: () => number | undefined;
+	now?: () => number;
+	sleep?: (ms: number) => Promise<void>;
+	idleGraceMs?: number;
+	firstAttachGraceMs?: number;
+	pollMs?: number;
+}): Promise<void> {
+	const now = deps.now ?? Date.now;
+	const sleep = deps.sleep ?? (async ms => await Bun.sleep(ms));
+	const idleGraceMs = deps.idleGraceMs ?? SESSION_HOST_DETACHED_IDLE_GRACE_MS;
+	const firstAttachGraceMs = deps.firstAttachGraceMs ?? SESSION_HOST_FIRST_ATTACH_GRACE_MS;
+	const pollMs = deps.pollMs ?? SESSION_HOST_ATTACHMENT_POLL_MS;
+	const startedAt = now();
+	let everAttached = false;
+	let detachedSince: number | null = null;
+	for (;;) {
+		const attached = deps.readAttachedClients();
+		if (attached === undefined) {
+			// No endpoint evidence at all is ambiguity, not abandonment; it still
+			// accrues against the first-attach bound so a host whose SDK runtime
+			// never came up cannot outlive that bound either.
+			if (!everAttached && now() - startedAt >= firstAttachGraceMs) return;
+		} else if (attached > 0) {
+			everAttached = true;
+			detachedSince = null;
+		} else if (everAttached) {
+			detachedSince ??= now();
+			if (now() - detachedSince >= idleGraceMs) return;
+		} else if (now() - startedAt >= firstAttachGraceMs) {
+			return;
 		}
 		await sleep(pollMs);
 	}
@@ -555,10 +632,15 @@ export async function runSessionHost(
 	}
 	process.once("SIGTERM", stop);
 	process.once("SIGINT", stop);
-	// A detached host whose broker is gone for good would otherwise live (and
-	// hold its session's memory) forever; reap it through the same graceful
-	// teardown a SIGTERM would take once the bounded absence grace elapses.
-	await watchSessionHostBrokerLiveness({ agentDir });
+	// Two independent bounds, either of which reaps this detached host through
+	// the same graceful teardown a SIGTERM would take. The first covers a broker
+	// that is gone for good; the second covers the opposite case, a perfectly
+	// healthy broker whose host nobody is attached to any more and for which no
+	// `session.close` will ever arrive.
+	await Promise.race([
+		watchSessionHostBrokerLiveness({ agentDir }),
+		watchSessionHostClientAttachment({ readAttachedClients: sessionHostAttachedClients }),
+	]);
 	stop();
 	await new Promise<void>(() => {});
 }
@@ -617,9 +699,19 @@ export default class Sdk extends Command {
 		});
 		await broker.start();
 		if (!broker.ownsDiscovery) return;
-		const stop = () => void broker.stop();
+		// A live broker must not keep advertising sessions whose host process is
+		// gone; the sweep is the broker-side half of the host reaping bound.
+		const stopSweep = startBrokerDeadRegistrationSweep(broker);
+		const stop = () => {
+			stopSweep();
+			void broker.stop();
+		};
 		process.once("SIGTERM", stop);
 		process.once("SIGINT", stop);
-		await completeBrokerProcess(broker);
+		try {
+			await completeBrokerProcess(broker);
+		} finally {
+			stopSweep();
+		}
 	}
 }

--- a/packages/coding-agent/src/commands/sdk.ts
+++ b/packages/coding-agent/src/commands/sdk.ts
@@ -18,6 +18,7 @@ import {
 	type SessionLifecycleLaunchRequest,
 	type SessionLifecycleTranscriptIdentity,
 	sessionHostAttachedClients,
+	sessionHostWorkInFlight,
 	startBrokerDeadRegistrationSweep,
 	writeSessionLifecycleFailure,
 	writeSessionLifecycleReady,
@@ -141,16 +142,28 @@ const SESSION_HOST_ATTACHMENT_POLL_MS = 30_000;
 
 /**
  * Resolves once this host is provably abandoned: either it has been detached
- * from every client for the full idle grace, or it was never attached at all
+ * from every client for the full idle grace, or nobody has come for it at all
  * for the full first-attach grace.
  *
  * `readAttachedClients` reports the host's own live client/socket subscription
  * count; `undefined` means the SDK endpoint publishes no such evidence yet and
  * is deliberately *not* treated as detachment, so a host can never be reaped on
  * missing evidence — only on observed absence of clients.
+ *
+ * `readWorkInFlight` reports whether the host is running agent work right now.
+ * Work is positive proof that a client did come for this host: a prompt can
+ * only arrive over the endpoint a client dialed. So for a host that has never
+ * been *observed* attached — a client that connected, prompted and dropped
+ * between two 30s polls, or a client count that is momentarily unreadable — the
+ * first-attach window is measured from the last moment work was in flight
+ * rather than from process start. That still bounds a host whose SDK runtime
+ * never came up: with no transport it can never receive a prompt, so it never
+ * reports work and its window keeps running from start. And any real turn ends,
+ * after which the window resumes; live work defers the bound, never removes it.
  */
 export async function watchSessionHostClientAttachment(deps: {
 	readAttachedClients: () => number | undefined;
+	readWorkInFlight?: () => boolean;
 	now?: () => number;
 	sleep?: (ms: number) => Promise<void>;
 	idleGraceMs?: number;
@@ -159,26 +172,29 @@ export async function watchSessionHostClientAttachment(deps: {
 }): Promise<void> {
 	const now = deps.now ?? Date.now;
 	const sleep = deps.sleep ?? (async ms => await Bun.sleep(ms));
+	const readWorkInFlight = deps.readWorkInFlight ?? (() => false);
 	const idleGraceMs = deps.idleGraceMs ?? SESSION_HOST_DETACHED_IDLE_GRACE_MS;
 	const firstAttachGraceMs = deps.firstAttachGraceMs ?? SESSION_HOST_FIRST_ATTACH_GRACE_MS;
 	const pollMs = deps.pollMs ?? SESSION_HOST_ATTACHMENT_POLL_MS;
-	const startedAt = now();
 	let everAttached = false;
 	let detachedSince: number | null = null;
+	/** Start of the current window in which nobody has been shown to want this host. */
+	let unattendedSince = now();
 	for (;;) {
 		const attached = deps.readAttachedClients();
+		if (readWorkInFlight()) unattendedSince = now();
 		if (attached === undefined) {
 			// No endpoint evidence at all is ambiguity, not abandonment; it still
 			// accrues against the first-attach bound so a host whose SDK runtime
 			// never came up cannot outlive that bound either.
-			if (!everAttached && now() - startedAt >= firstAttachGraceMs) return;
+			if (!everAttached && now() - unattendedSince >= firstAttachGraceMs) return;
 		} else if (attached > 0) {
 			everAttached = true;
 			detachedSince = null;
 		} else if (everAttached) {
 			detachedSince ??= now();
 			if (now() - detachedSince >= idleGraceMs) return;
-		} else if (now() - startedAt >= firstAttachGraceMs) {
+		} else if (now() - unattendedSince >= firstAttachGraceMs) {
 			return;
 		}
 		await sleep(pollMs);
@@ -660,7 +676,10 @@ export async function runSessionHost(
 	// `session.close` will ever arrive.
 	await Promise.race([
 		watchSessionHostBrokerLiveness({ agentDir }),
-		watchSessionHostClientAttachment({ readAttachedClients: sessionHostAttachedClients }),
+		watchSessionHostClientAttachment({
+			readAttachedClients: sessionHostAttachedClients,
+			readWorkInFlight: sessionHostWorkInFlight,
+		}),
 	]);
 	stop();
 	await new Promise<void>(() => {});

--- a/packages/coding-agent/src/commands/sdk.ts
+++ b/packages/coding-agent/src/commands/sdk.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { logger } from "@gajae-code/utils";
 import { Args, CliParseError, Command, Flags, renderCommandHelp } from "@gajae-code/utils/cli";
 import type { Args as ParsedArgs } from "../cli/args";
 import { Settings } from "../config/settings";
@@ -323,6 +324,22 @@ export async function openLifecycleSessionManager(
 	return { parsed, sessionManager };
 }
 
+/**
+ * Starts the memory backend a lifecycle session deferred past its readiness
+ * window.
+ *
+ * Deliberately not awaited: the local backend summarises every queued rollout
+ * through the model, so its duration scales with the backlog and would eat the
+ * broker's readiness budget. The session is already published as ready here, so
+ * a failure is a degraded-memory condition, not a startup failure — it is
+ * logged and swallowed instead of surfacing as an unhandled rejection.
+ */
+export function startMemoryBackendAfterReadiness(start: () => Promise<void>): void {
+	void start().catch(error => {
+		logger.warn("Deferred memory backend startup failed after readiness", { error: String(error) });
+	});
+}
+
 /** Runs the same persisted AgentSession bootstrap used by the production CLI. */
 export async function runSessionHost(
 	timing: {
@@ -515,7 +532,7 @@ export async function runSessionHost(
 
 		throw created.failure;
 	}
-	const { session, capability, rollback } = created;
+	const { session, capability, rollback, startDeferredMemoryBackend } = created;
 	let sessionDisposal: Promise<void> | undefined;
 	const disposeSession = (): Promise<void> => {
 		sessionDisposal ??= session.dispose().catch(() => {});
@@ -630,6 +647,10 @@ export async function runSessionHost(
 		await failAfterRollback(durableFailure);
 		throw error;
 	}
+	// Readiness is published; the session is live. Memory startup issues one LLM
+	// request per queued rollout, so it must run outside the readiness window and
+	// its failure must never take the session down.
+	startMemoryBackendAfterReadiness(startDeferredMemoryBackend);
 	process.once("SIGTERM", stop);
 	process.once("SIGINT", stop);
 	// Two independent bounds, either of which reaps this detached host through

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1632,8 +1632,11 @@ export async function runRootCommand(
 		sessionOptions.deferMcpConfigStartup = true;
 	}
 	const hasRootStartupProfile = Boolean(settingsInstance.get("modelProfile.default") || parsedArgs.mpreset);
-	const deferMemoryBackendStartup =
-		hasRootStartupProfile && !(parsedArgs.authBootstrap === true && isInteractive) && mode !== "acp";
+	// ACP is not carved out: `gjc acp` is broker-backed and never builds a local
+	// session here, and the broker-launched lifecycle child defers memory startup
+	// unconditionally (createLifecycleAgentSession) so readiness never waits on
+	// the memory pipeline's LLM work.
+	const deferMemoryBackendStartup = hasRootStartupProfile && !(parsedArgs.authBootstrap === true && isInteractive);
 	sessionOptions.deferMemoryBackendStartup = deferMemoryBackendStartup;
 
 	// Research-mode (RLM) preset: augment session options before session creation.

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -3,6 +3,7 @@ import type { BigIntStats } from "node:fs";
 import * as fs from "node:fs/promises";
 import path from "node:path";
 import type { NativeDirectoryTreeSnapshot } from "@gajae-code/natives";
+import { logger } from "@gajae-code/utils";
 import type { ModelProfileErrorDetails } from "../../config/model-profile-contract";
 import {
 	type DirectoryMigrationPolicy,
@@ -395,6 +396,148 @@ type BrokerLockSnapshot = {
 	lockIdentity: string;
 };
 
+/** Tombstone prefix used by {@link Broker.reclaimStaleLock} when a dead owner's lock is renamed aside. */
+export const BROKER_LOCK_TOMBSTONE_PREFIX = ".broker.lock.stale-";
+
+/**
+ * Recovery directories left beside the lock by manual and older automated broker
+ * restarts. Nothing writes them today, but installs that ever recovered by hand
+ * still carry them, so the reaper owns them alongside its own tombstones.
+ */
+export const BROKER_LOCK_BACKUP_PREFIXES = ["broker-restart-backup-", "broker-stale-backup-"] as const;
+
+/**
+ * Age bound before a reclaimed lock artifact may be removed. Generous enough
+ * that a broker still settling after a reclaim can never have its own successor
+ * state deleted underneath it.
+ */
+export const BROKER_LOCK_ARTIFACT_GRACE_MS = 24 * 60 * 60 * 1_000;
+
+/** Why a candidate lock artifact survived a reap pass. */
+export type BrokerLockArtifactRetentionReason =
+	| "within-grace"
+	| "owner-alive"
+	| "owner-record-unreadable"
+	| "owner-record-missing"
+	| "not-a-directory"
+	| "removal-failed";
+
+export interface BrokerLockArtifactRetention {
+	path: string;
+	reason: BrokerLockArtifactRetentionReason;
+}
+
+export interface BrokerLockArtifactReapResult {
+	removed: string[];
+	retained: BrokerLockArtifactRetention[];
+}
+
+function isBrokerLockArtifactName(name: string): boolean {
+	return (
+		name.startsWith(BROKER_LOCK_TOMBSTONE_PREFIX) ||
+		BROKER_LOCK_BACKUP_PREFIXES.some(prefix => name.startsWith(prefix))
+	);
+}
+
+/**
+ * Decide whether one candidate directory is provably abandoned.
+ *
+ * Fail-closed by construction: every branch that cannot prove abandonment
+ * returns a retention reason. A tombstone is only abandoned when its owner
+ * record parses and names a dead PID — an unreadable, permission-denied, or
+ * absent record keeps it forever. Backup directories carry no owner contract,
+ * so an absent record there is not ambiguity and age alone governs.
+ */
+async function classifyBrokerLockArtifact(
+	directory: string,
+	name: string,
+	now: number,
+	graceMs: number,
+	pidAlive: (pid: number) => boolean,
+): Promise<BrokerLockArtifactRetentionReason | "abandoned"> {
+	const target = path.join(directory, name);
+	// lstat, never stat: a symlink pointing at live state must never be followed
+	// into a recursive removal.
+	const stat = await fs.lstat(target);
+	if (!stat.isDirectory()) return "not-a-directory";
+	if (!Number.isFinite(stat.mtimeMs) || now - stat.mtimeMs < graceMs) return "within-grace";
+	let raw: string;
+	try {
+		raw = await fs.readFile(path.join(target, BROKER_LOCK_RECORD), "utf8");
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code !== "ENOENT" && code !== "ENOTDIR") return "owner-record-unreadable";
+		return name.startsWith(BROKER_LOCK_TOMBSTONE_PREFIX) ? "owner-record-missing" : "abandoned";
+	}
+	let pid: unknown;
+	try {
+		pid = (JSON.parse(raw) as { pid?: unknown }).pid;
+	} catch {
+		return "owner-record-unreadable";
+	}
+	if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return "owner-record-unreadable";
+	return pidAlive(pid) ? "owner-alive" : "abandoned";
+}
+
+/**
+ * Remove reclaimed broker lock tombstones and legacy restart backups older than
+ * the grace window.
+ *
+ * `#reclaimStaleLock` renames a dead owner's lock to a tombstone named by a hash
+ * of the lock's dev+ino, so a machine accrues one directory per dead owner and
+ * nothing ever removed them (54 on the install in #3963). Reaping is
+ * best-effort and fail-closed: anything live, unreadable, permission-denied, or
+ * otherwise ambiguous is kept and the reason is logged.
+ */
+export async function reapStaleBrokerLockArtifacts(input: {
+	agentDir: string;
+	now?: number;
+	graceMs?: number;
+	pidAlive?: (pid: number) => boolean;
+}): Promise<BrokerLockArtifactReapResult> {
+	const directory = path.join(input.agentDir, "sdk");
+	const now = input.now ?? Date.now();
+	const graceMs = input.graceMs ?? BROKER_LOCK_ARTIFACT_GRACE_MS;
+	const pidAlive = input.pidAlive ?? isPidAlive;
+	const removed: string[] = [];
+	const retained: BrokerLockArtifactRetention[] = [];
+	let names: string[];
+	try {
+		names = await fs.readdir(directory);
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT" || code === "ENOTDIR") return { removed, retained };
+		throw error;
+	}
+	for (const name of names) {
+		if (!isBrokerLockArtifactName(name)) continue;
+		const target = path.join(directory, name);
+		let verdict: BrokerLockArtifactRetentionReason | "abandoned";
+		try {
+			verdict = await classifyBrokerLockArtifact(directory, name, now, graceMs, pidAlive);
+		} catch (error) {
+			// A vanished candidate needs no decision; anything else is ambiguous.
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+			verdict = "owner-record-unreadable";
+		}
+		if (verdict !== "abandoned") {
+			retained.push({ path: target, reason: verdict });
+			if (verdict !== "within-grace") logger.warn(`sdk broker: retained stale lock artifact ${name} (${verdict})`);
+			continue;
+		}
+		try {
+			await fs.rm(target, { recursive: true });
+			removed.push(target);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+			retained.push({ path: target, reason: "removal-failed" });
+			logger.warn(`sdk broker: retained stale lock artifact ${name} (removal-failed)`);
+		}
+	}
+	if (removed.length > 0) logger.info(`sdk broker: reaped ${removed.length} stale lock artifact(s)`);
+	return { removed, retained };
+}
+
 const BROKER_PUBLICATION_CADENCE_MS = 5_000;
 const BROKER_PUBLICATION_GRACE_MS = 15_000;
 // A broker that cannot observe its own publication is not provably the root, but
@@ -417,6 +560,7 @@ type BrokerStopMode = "owned-root" | "lost-root";
 const terminalPersistenceHooksForTest = new WeakMap<Broker, () => void>();
 const ambiguityGraceOverridesForTest = new WeakMap<Broker, number>();
 const publicationObservationOverridesForTest = new WeakMap<Broker, BrokerPublicationObservation>();
+const lockArtifactGraceOverridesForTest = new WeakMap<Broker, number>();
 
 export class Broker {
 	readonly settings: ResolvedBrokerSettings;
@@ -565,6 +709,22 @@ export class Broker {
 		}
 	}
 
+	/**
+	 * Best-effort startup reap of reclaimed lock tombstones and legacy restart
+	 * backups. Cleanup debris must never fail an otherwise healthy startup, so a
+	 * fault here is logged and swallowed.
+	 */
+	async #reapLockArtifacts(): Promise<void> {
+		try {
+			await reapStaleBrokerLockArtifacts({
+				agentDir: this.settings.agentDir,
+				graceMs: lockArtifactGraceOverridesForTest.get(this),
+			});
+		} catch (error) {
+			logger.warn(`sdk broker: stale lock artifact reap failed: ${String(error)}`);
+		}
+	}
+
 	async start(): Promise<BrokerDiscovery> {
 		if (this.#completionTask) {
 			await this.#completionTask;
@@ -590,6 +750,11 @@ export class Broker {
 
 			const live = await readBrokerDiscovery(this.settings.agentDir, this.settings.heartbeatTtlMs);
 			if (live) {
+				// This process loses the ownership race and its caller only ever sees a
+				// clean exit, so name the reason here (#3963).
+				logger.info(
+					`sdk broker: lock contention, yielding to the live broker owner (ownerId=${live.ownerId}, pid=${live.pid}); this process exits without owning discovery`,
+				);
 				this.discovery = live;
 				return live;
 			}
@@ -598,16 +763,25 @@ export class Broker {
 			if (snapshot.pid > 0 && isPidAlive(snapshot.pid)) {
 				const starting = await this.#waitForBrokerDiscovery();
 				if (starting) {
+					logger.info(
+						`sdk broker: lock contention, yielding to the broker that just started (ownerId=${starting.ownerId}, pid=${starting.pid}); this process exits without owning discovery`,
+					);
 					this.discovery = starting;
 					return starting;
 				}
 				const current = await this.#readLock();
-				if (current && current.identity === snapshot.identity && current.pid > 0 && isPidAlive(current.pid))
-					throw new Error("Broker lock is held by a live owner");
+				if (current && current.identity === snapshot.identity && current.pid > 0 && isPidAlive(current.pid)) {
+					logger.warn(
+						`sdk broker: lock contention, refusing to start because ${this.#lock} is held by live pid ${current.pid} that published no discovery record`,
+					);
+					throw new Error(`Broker lock is held by a live owner (pid ${current.pid})`);
+				}
 				continue;
 			}
 			await this.#reclaimStaleLock(snapshot);
 		}
+		// Only the lock holder reaps, so concurrent brokers cannot race the removal.
+		await this.#reapLockArtifacts();
 		try {
 			await this.index.open();
 			await this.ledger.open();
@@ -1006,6 +1180,12 @@ export function setTerminalPersistenceHookForTest(broker: Broker, hook: (() => v
 export function setAmbiguityGraceForTest(broker: Broker, graceMs: number | undefined): void {
 	if (graceMs === undefined) ambiguityGraceOverridesForTest.delete(broker);
 	else ambiguityGraceOverridesForTest.set(broker, graceMs);
+}
+
+/** Test-only hook for shortening the startup lock-artifact reap bound. */
+export function setLockArtifactGraceForTest(broker: Broker, graceMs: number | undefined): void {
+	if (graceMs === undefined) lockArtifactGraceOverridesForTest.delete(broker);
+	else lockArtifactGraceOverridesForTest.set(broker, graceMs);
 }
 
 /** Test-only hook for forcing the observation the publication watchdog sees. */

--- a/packages/coding-agent/src/sdk/broker/ensure.ts
+++ b/packages/coding-agent/src/sdk/broker/ensure.ts
@@ -1,4 +1,5 @@
 import { type ChildProcess, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import type { FileHandle } from "node:fs/promises";
 import * as fs from "node:fs/promises";
 import path from "node:path";
@@ -30,36 +31,46 @@ const REAP_SIGKILL_CAP_MS = 2_000;
  * file instead of a pipe because the child is detached and outlives this
  * process: a pipe would break under it the moment the parent exits.
  */
-const BROKER_SPAWN_LOG_TAIL_BYTES = 4_096;
+export const BROKER_SPAWN_LOG_TAIL_BYTES = 4_096;
 
-function brokerSpawnLogPath(agentDir: string): string {
-	return path.join(agentDir, "sdk", "broker-spawn.log");
+export interface BrokerSpawnLog {
+	path: string;
+	handle: FileHandle;
 }
 
-/**
- * Open the diagnostic sink for one spawn. Truncating on every open bounds the
- * file to a single broker's output, so the sink cannot become the next
- * unbounded artifact.
- */
-async function openBrokerSpawnLog(agentDir: string): Promise<FileHandle | undefined> {
+function brokerSpawnLogPath(agentDir: string): string {
+	return path.join(agentDir, "sdk", `broker-spawn.${randomUUID()}.log`);
+}
+
+/** Opens an isolated, bounded-lifetime diagnostic sink for one broker spawn. */
+export async function openBrokerSpawnLog(agentDir: string): Promise<BrokerSpawnLog | undefined> {
 	try {
 		await fs.mkdir(path.join(agentDir, "sdk"), { recursive: true, mode: 0o700 });
-		return await fs.open(brokerSpawnLogPath(agentDir), "w", 0o600);
+		const spawnLogPath = brokerSpawnLogPath(agentDir);
+		return { path: spawnLogPath, handle: await fs.open(spawnLogPath, "w", 0o600) };
 	} catch {
 		// Diagnostics are never allowed to block a broker spawn.
 		return undefined;
 	}
 }
 
-async function readBrokerSpawnLogTail(agentDir: string): Promise<string> {
+export async function readBrokerSpawnLogTail(spawnLogPath: string): Promise<string> {
 	try {
-		const file = Bun.file(brokerSpawnLogPath(agentDir));
+		const file = Bun.file(spawnLogPath);
 		const size = file.size;
 		if (!Number.isFinite(size) || size <= 0) return "";
 		const tail = size > BROKER_SPAWN_LOG_TAIL_BYTES ? file.slice(size - BROKER_SPAWN_LOG_TAIL_BYTES) : file;
 		return (await tail.text()).trim();
 	} catch {
 		return "";
+	}
+}
+
+async function removeBrokerSpawnLog(spawnLogPath: string): Promise<void> {
+	try {
+		await fs.unlink(spawnLogPath);
+	} catch {
+		// Diagnostics are best-effort and must not affect broker ownership.
 	}
 }
 export interface FixtureBrokerLease {
@@ -290,81 +301,88 @@ async function ensureBrokerOnce(settings: EnsureBrokerSettings, initiator: Ensur
 
 	const command = resolveSdkInternalSpawnCommand("broker-internal");
 	const spawnLog = await openBrokerSpawnLog(settings.agentDir);
-	const child = spawn(command.file, [...command.args, "--agent-dir", settings.agentDir], {
-		detached: true,
-		stdio: ["ignore", "ignore", spawnLog ? spawnLog.fd : "ignore"],
-		env: brokerSpawnEnvironment(command, settings.env),
-		...(command.kind === "bun-source" ? { cwd: command.cwd } : {}),
-	});
-	// The child holds its own duplicate of the descriptor; this one is done.
-	await spawnLog?.close();
-	child.unref();
-	let spawnError: Error | undefined;
-	child.once("error", error => {
-		spawnError = error;
-	});
-	const owner = registerBrokerOwner(settings.agentDir, child);
-	const discoveryTimeoutMs = initiator === "fixture-lease" ? FIXTURE_DISCOVERY_TIMEOUT_MS : DISCOVERY_TIMEOUT_MS;
-	const deadline = Date.now() + discoveryTimeoutMs;
-	let discoveryError: unknown;
-	while (Date.now() < deadline) {
-		if (spawnError || child.exitCode !== null || child.signalCode !== null) break;
-		try {
-			const discovered = await readBrokerDiscovery(settings.agentDir, settings.heartbeatTtlMs);
-			if (discovered) {
-				if (owner.markReady(discovered)) {
-					return initiator === "fixture-lease"
-						? { kind: "local-started-fixture", discovery: discovered, owner, child }
-						: { kind: "local-started-discovery", discovery: discovered };
-				}
-				await owner.stop();
-				return { kind: "external-discovery", discovery: discovered };
-			}
-		} catch (error) {
-			discoveryError = error;
-		}
-		await sleep(50);
-	}
-	const exitedBeforeDiscovery = child.exitCode !== null || child.signalCode !== null;
-	if (exitedBeforeDiscovery && child.exitCode === 0) {
-		// A clean exit means another broker won the ownership lock (two ACP
-		// processes racing a cold broker state, e.g. a provider probe and an
-		// agent launch). The winner may publish its discovery right after our
-		// last poll; reuse it instead of failing the caller. Transient discovery
-		// read failures fall through to the common cleanup + failure path below.
-		try {
-			for (let retry = 0; retry < 20; retry++) {
-				const winner = await readBrokerDiscovery(settings.agentDir, settings.heartbeatTtlMs);
-				if (winner) {
-					await owner.stop();
-					return { kind: "external-discovery", discovery: winner };
-				}
-				await sleep(50);
-			}
-		} catch {
-			// fall through to cleanup + failure
-		}
-	}
-	const spawnLogTail = exitedBeforeDiscovery ? await readBrokerSpawnLogTail(settings.agentDir) : "";
-	const failure = spawnError
-		? new Error(`Failed to spawn detached SDK broker: ${spawnError.message}`)
-		: exitedBeforeDiscovery
-			? new Error(
-					`Detached SDK broker exited before discovery (code=${child.exitCode}, signal=${child.signalCode}).${
-						spawnLogTail
-							? ` Broker stderr: ${spawnLogTail}`
-							: " The broker wrote no stderr; see the gjc log for its lock-contention diagnostic."
-					}`,
-				)
-			: discoveryError
-				? discoveryError
-				: new Error("Timed out waiting for detached SDK broker discovery.");
 	try {
-		await owner.stop();
-	} catch (cleanupError) {
-		throw new AggregateError([failure, cleanupError], "SDK broker discovery and spawned broker cleanup both failed.");
+		const child = spawn(command.file, [...command.args, "--agent-dir", settings.agentDir], {
+			detached: true,
+			stdio: ["ignore", "ignore", spawnLog ? spawnLog.handle.fd : "ignore"],
+			env: brokerSpawnEnvironment(command, settings.env),
+			...(command.kind === "bun-source" ? { cwd: command.cwd } : {}),
+		});
+		// The child holds its own duplicate of the descriptor; this one is done.
+		await spawnLog?.handle.close();
+		child.unref();
+		let spawnError: Error | undefined;
+		child.once("error", error => {
+			spawnError = error;
+		});
+		const owner = registerBrokerOwner(settings.agentDir, child);
+		const discoveryTimeoutMs = initiator === "fixture-lease" ? FIXTURE_DISCOVERY_TIMEOUT_MS : DISCOVERY_TIMEOUT_MS;
+		const deadline = Date.now() + discoveryTimeoutMs;
+		let discoveryError: unknown;
+		while (Date.now() < deadline) {
+			if (spawnError || child.exitCode !== null || child.signalCode !== null) break;
+			try {
+				const discovered = await readBrokerDiscovery(settings.agentDir, settings.heartbeatTtlMs);
+				if (discovered) {
+					if (owner.markReady(discovered)) {
+						return initiator === "fixture-lease"
+							? { kind: "local-started-fixture", discovery: discovered, owner, child }
+							: { kind: "local-started-discovery", discovery: discovered };
+					}
+					await owner.stop();
+					return { kind: "external-discovery", discovery: discovered };
+				}
+			} catch (error) {
+				discoveryError = error;
+			}
+			await sleep(50);
+		}
+		const exitedBeforeDiscovery = child.exitCode !== null || child.signalCode !== null;
+		if (exitedBeforeDiscovery && child.exitCode === 0) {
+			// A clean exit means another broker won the ownership lock (two ACP
+			// processes racing a cold broker state, e.g. a provider probe and an
+			// agent launch). The winner may publish its discovery right after our
+			// last poll; reuse it instead of failing the caller. Transient discovery
+			// read failures fall through to the common cleanup + failure path below.
+			try {
+				for (let retry = 0; retry < 20; retry++) {
+					const winner = await readBrokerDiscovery(settings.agentDir, settings.heartbeatTtlMs);
+					if (winner) {
+						await owner.stop();
+						return { kind: "external-discovery", discovery: winner };
+					}
+					await sleep(50);
+				}
+			} catch {
+				// fall through to cleanup + failure
+			}
+		}
+		const spawnLogTail = exitedBeforeDiscovery && spawnLog ? await readBrokerSpawnLogTail(spawnLog.path) : "";
+		const failure = spawnError
+			? new Error(`Failed to spawn detached SDK broker: ${spawnError.message}`)
+			: exitedBeforeDiscovery
+				? new Error(
+						`Detached SDK broker exited before discovery (code=${child.exitCode}, signal=${child.signalCode}).${
+							spawnLogTail
+								? ` Broker stderr: ${spawnLogTail}`
+								: " The broker wrote no stderr; see the gjc log for its lock-contention diagnostic."
+						}`,
+					)
+				: discoveryError
+					? discoveryError
+					: new Error("Timed out waiting for detached SDK broker discovery.");
+		try {
+			await owner.stop();
+		} catch (cleanupError) {
+			throw new AggregateError(
+				[failure, cleanupError],
+				"SDK broker discovery and spawned broker cleanup both failed.",
+			);
+		}
+		throw failure;
+	} finally {
+		if (spawnLog) await removeBrokerSpawnLog(spawnLog.path);
 	}
-	throw failure;
 }
 
 function startEnsure(settings: EnsureBrokerSettings, initiator: EnsureInitiator): EnsureInFlight {

--- a/packages/coding-agent/src/sdk/broker/ensure.ts
+++ b/packages/coding-agent/src/sdk/broker/ensure.ts
@@ -1,4 +1,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
+import type { FileHandle } from "node:fs/promises";
+import * as fs from "node:fs/promises";
+import path from "node:path";
 import { type BrokerDiscovery, brokerProcessIncarnation, readBrokerDiscovery } from "./discovery";
 import { resolveSdkInternalSpawnCommand, type SdkInternalSpawnCommand } from "./runtime";
 export interface EnsureBrokerSettings {
@@ -18,6 +21,47 @@ const FIXTURE_DISCOVERY_TIMEOUT_MS = 30_000;
 // owned-process teardown convention (SIGTERM -> grace -> SIGKILL -> hard cap).
 const REAP_GRACEFUL_MS = 2_000;
 const REAP_SIGKILL_CAP_MS = 2_000;
+
+/**
+ * Tail of the detached broker's stderr folded into a discovery failure.
+ *
+ * The broker used to spawn with `stdio: "ignore"`, so a broker that exited
+ * cleanly told the caller nothing beyond `code=0` (#3963). Its stderr goes to a
+ * file instead of a pipe because the child is detached and outlives this
+ * process: a pipe would break under it the moment the parent exits.
+ */
+const BROKER_SPAWN_LOG_TAIL_BYTES = 4_096;
+
+function brokerSpawnLogPath(agentDir: string): string {
+	return path.join(agentDir, "sdk", "broker-spawn.log");
+}
+
+/**
+ * Open the diagnostic sink for one spawn. Truncating on every open bounds the
+ * file to a single broker's output, so the sink cannot become the next
+ * unbounded artifact.
+ */
+async function openBrokerSpawnLog(agentDir: string): Promise<FileHandle | undefined> {
+	try {
+		await fs.mkdir(path.join(agentDir, "sdk"), { recursive: true, mode: 0o700 });
+		return await fs.open(brokerSpawnLogPath(agentDir), "w", 0o600);
+	} catch {
+		// Diagnostics are never allowed to block a broker spawn.
+		return undefined;
+	}
+}
+
+async function readBrokerSpawnLogTail(agentDir: string): Promise<string> {
+	try {
+		const file = Bun.file(brokerSpawnLogPath(agentDir));
+		const size = file.size;
+		if (!Number.isFinite(size) || size <= 0) return "";
+		const tail = size > BROKER_SPAWN_LOG_TAIL_BYTES ? file.slice(size - BROKER_SPAWN_LOG_TAIL_BYTES) : file;
+		return (await tail.text()).trim();
+	} catch {
+		return "";
+	}
+}
 export interface FixtureBrokerLease {
 	/** Backward-compatible fixture cleanup alias for exact child termination. */
 	close(): Promise<void>;
@@ -245,12 +289,15 @@ async function ensureBrokerOnce(settings: EnsureBrokerSettings, initiator: Ensur
 	}
 
 	const command = resolveSdkInternalSpawnCommand("broker-internal");
+	const spawnLog = await openBrokerSpawnLog(settings.agentDir);
 	const child = spawn(command.file, [...command.args, "--agent-dir", settings.agentDir], {
 		detached: true,
-		stdio: "ignore",
+		stdio: ["ignore", "ignore", spawnLog ? spawnLog.fd : "ignore"],
 		env: brokerSpawnEnvironment(command, settings.env),
 		...(command.kind === "bun-source" ? { cwd: command.cwd } : {}),
 	});
+	// The child holds its own duplicate of the descriptor; this one is done.
+	await spawnLog?.close();
 	child.unref();
 	let spawnError: Error | undefined;
 	child.once("error", error => {
@@ -298,11 +345,16 @@ async function ensureBrokerOnce(settings: EnsureBrokerSettings, initiator: Ensur
 			// fall through to cleanup + failure
 		}
 	}
+	const spawnLogTail = exitedBeforeDiscovery ? await readBrokerSpawnLogTail(settings.agentDir) : "";
 	const failure = spawnError
 		? new Error(`Failed to spawn detached SDK broker: ${spawnError.message}`)
 		: exitedBeforeDiscovery
 			? new Error(
-					`Detached SDK broker exited before discovery (code=${child.exitCode}, signal=${child.signalCode}).`,
+					`Detached SDK broker exited before discovery (code=${child.exitCode}, signal=${child.signalCode}).${
+						spawnLogTail
+							? ` Broker stderr: ${spawnLogTail}`
+							: " The broker wrote no stderr; see the gjc log for its lock-contention diagnostic."
+					}`,
 				)
 			: discoveryError
 				? discoveryError

--- a/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
@@ -99,6 +99,11 @@ export interface LifecycleLedgerLimits {
 	maxBytes?: number;
 	maxLineBytes?: number;
 	maxRows?: number;
+	/**
+	 * Cap for the `.corrupt` quarantine sidecar. Reaching it rotates one
+	 * generation aside instead of appending forever.
+	 */
+	maxCorruptBytes?: number;
 }
 function canonicalCleanupSessionId(value: unknown): value is string {
 	return typeof value === "string" && /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(value);
@@ -108,7 +113,11 @@ const DEFAULT_LIFECYCLE_LEDGER_LIMITS: Required<LifecycleLedgerLimits> = {
 	maxBytes: 64 * 1024 * 1024,
 	maxLineBytes: 8 * 1024 * 1024,
 	maxRows: 10_000,
+	maxCorruptBytes: 8 * 1024 * 1024,
 };
+
+/** Appended when a quarantined row is clipped to the sidecar cap. */
+const LIFECYCLE_QUARANTINE_TRUNCATION_MARKER = "\n[gjc: quarantined row truncated at the corrupt-ledger cap]";
 const MAX_LIFECYCLE_LEDGER_JSON_DEPTH = 64;
 const MAX_LIFECYCLE_LEDGER_JSON_FIELDS = 1024;
 
@@ -251,6 +260,7 @@ export class LifecycleLedger {
 			maxBytes: limits.maxBytes ?? DEFAULT_LIFECYCLE_LEDGER_LIMITS.maxBytes,
 			maxLineBytes: limits.maxLineBytes ?? DEFAULT_LIFECYCLE_LEDGER_LIMITS.maxLineBytes,
 			maxRows: limits.maxRows ?? DEFAULT_LIFECYCLE_LEDGER_LIMITS.maxRows,
+			maxCorruptBytes: limits.maxCorruptBytes ?? DEFAULT_LIFECYCLE_LEDGER_LIMITS.maxCorruptBytes,
 		};
 	}
 	async open(): Promise<this> {
@@ -533,11 +543,43 @@ export class LifecycleLedger {
 			await h.close();
 		}
 	}
+	/**
+	 * Rotate the quarantine sidecar aside once it would exceed its cap.
+	 *
+	 * Quarantine is diagnostic, not durable state: an unreadable ledger
+	 * re-quarantines its whole contents on every open, so a plain append grows
+	 * the sidecar without bound (a 126 MB `.corrupt` next to a 6 MB live ledger,
+	 * #3963). One retained generation keeps the newest evidence while bounding
+	 * the pair at twice the cap.
+	 */
+	async #rotateCorruptWhenFull(incomingBytes: number): Promise<void> {
+		let size: number;
+		try {
+			const stat = await fs.lstat(this.#corruptFile);
+			// A non-regular quarantine path is never rotated; the append guard rejects it.
+			if (!stat.isFile()) return;
+			size = stat.size;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+			throw error;
+		}
+		if (size + incomingBytes <= this.#limits.maxCorruptBytes) return;
+		await fs.rename(this.#corruptFile, `${this.#corruptFile}.1`);
+	}
+
 	async #quarantine(line: string | Uint8Array): Promise<void> {
+		const payload =
+			typeof line === "string" ? Buffer.from(line) : Buffer.from(line.buffer, line.byteOffset, line.byteLength);
+		// A single quarantined row can be as large as the whole ledger, so the
+		// write itself is capped too; otherwise one oversized row would blow past
+		// the rotation bound it just triggered.
+		const truncated = payload.length > this.#limits.maxCorruptBytes;
+		const retained = truncated ? payload.subarray(0, this.#limits.maxCorruptBytes) : payload;
+		await this.#rotateCorruptWhenFull(retained.length + 1);
 		const h = await this.#openAppendRegular(this.#corruptFile);
 		try {
-			await h.writeFile(line);
-			await h.writeFile("\n");
+			await h.writeFile(retained);
+			await h.writeFile(truncated ? `${LIFECYCLE_QUARANTINE_TRUNCATION_MARKER}\n` : "\n");
 			await h.sync();
 		} finally {
 			await h.close();

--- a/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
@@ -363,12 +363,16 @@ export class LifecycleLedger {
 		return this;
 	}
 	/**
-	 * Reads terminal proof for one request without recovering or changing the ledger.
+	 * Reads the durable terminal record for one request without recovering or changing the ledger.
 	 *
 	 * This intentionally accepts an unrelated unterminated final write: concurrent
 	 * appenders may have started a different row after this request's synced terminal
 	 * row. Complete rows are still decoded and validated strictly, and any incomplete
 	 * tail that identifies this request withholds proof.
+	 *
+	 * `terminal_uncertain` is a durable terminal record too: an operation that concluded
+	 * uncertainly persists that conclusion, and refusing to read it back would report a
+	 * synced row as unpersisted and replace its true reason with a generic one.
 	 */
 	async readTerminal(identity: string, requestHash: string): Promise<LifecycleLedgerEntry | undefined> {
 		const source = await this.#readBoundedSourceReadOnly();
@@ -413,12 +417,20 @@ export class LifecycleLedger {
 			const identityMarker = Buffer.from(`"identity":${JSON.stringify(identity)}`);
 			if (tail.includes(identityMarker)) return undefined;
 		}
-		return latest && terminal(latest.state) ? latest : undefined;
+		return latest && final(latest.state) ? latest : undefined;
 	}
 
+	/**
+	 * A recovery pass appends `terminal_uncertain` for every row it finds mid-flight, so a
+	 * long-running operation can have that marker interleaved before its own terminal row
+	 * lands. The marker records unresolved work, not a proven outcome: the owner that ran
+	 * the effects stays authoritative and may still resolve it. A proven terminal row is
+	 * immutable and admits no successor.
+	 */
 	#isValidHistoryContinuation(previous: LifecycleLedgerEntry | undefined, next: LifecycleLedgerEntry): boolean {
 		if (!previous) return next.state === "accepted";
-		if (previous.requestHash !== next.requestHash || final(previous.state)) return false;
+		if (previous.requestHash !== next.requestHash || terminal(previous.state)) return false;
+		if (previous.state === "terminal_uncertain") return final(next.state);
 		if (previous.state === "accepted") return true;
 		return next.state === "effect_started" || next.state === "awaiting_ready" || final(next.state);
 	}

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -4393,30 +4393,83 @@ export async function executeLifecycle(
  */
 export type SessionHostAttachmentReader = () => number;
 
-let sessionHostAttachmentReader: SessionHostAttachmentReader | undefined;
+/** What one serving runtime reports about itself while its transport is up. */
+export interface SessionHostRuntimeEvidence {
+	/** This runtime's own live SDK client/socket subscription count. */
+	attachedClients: SessionHostAttachmentReader;
+	/** Whether this runtime currently has agent work in flight. */
+	workInFlight: () => boolean;
+}
 
-/**
- * Publishes (or, with `undefined`, retracts) this process's SDK client-count
- * reader. Called by the SDK session runtime around its transport lifetime.
- */
-export function publishSessionHostAttachmentReader(reader: SessionHostAttachmentReader | undefined): void {
-	sessionHostAttachmentReader = reader;
+/** One runtime's live publication, retractable only by its owner. */
+export interface SessionHostRuntimePublication {
+	/**
+	 * Withdraws the evidence this handle published. Idempotent, and never able
+	 * to touch a sibling runtime's evidence.
+	 */
+	retract(): void;
 }
 
 /**
- * This process's currently attached SDK client count, or `undefined` when no
- * SDK endpoint is serving (before startup, after teardown, or when the reader
- * itself fails). Never guesses: absence of a reader is absence of evidence.
+ * Every runtime in this process that currently serves an SDK endpoint.
+ *
+ * A process can serve more than one at a time: an identity-rotating control op
+ * starts the successor before the predecessor's deferred stop runs. A single
+ * global slot let that predecessor's teardown retract the live successor's
+ * reader and manufacture "no evidence" for a host with clients attached, so
+ * publications are held per runtime and retracted only through their own handle.
+ */
+const sessionHostRuntimes = new Set<SessionHostRuntimeEvidence>();
+
+/**
+ * Publishes this runtime's own liveness evidence for the lifetime of its
+ * transport. Retraction goes through the returned handle, so a runtime can only
+ * ever withdraw evidence it owns.
+ */
+export function publishSessionHostRuntimeEvidence(evidence: SessionHostRuntimeEvidence): SessionHostRuntimePublication {
+	const published: SessionHostRuntimeEvidence = { ...evidence };
+	sessionHostRuntimes.add(published);
+	return {
+		retract(): void {
+			sessionHostRuntimes.delete(published);
+		},
+	};
+}
+
+/**
+ * This process's currently attached SDK client count, summed across every
+ * serving runtime, or `undefined` when no runtime publishes a readable count
+ * (before startup, after teardown, or when every reader itself fails). Never
+ * guesses: absence of a reader is absence of evidence.
  */
 export function sessionHostAttachedClients(): number | undefined {
-	const reader = sessionHostAttachmentReader;
-	if (!reader) return undefined;
-	try {
-		const count = reader();
-		return Number.isSafeInteger(count) && count >= 0 ? count : undefined;
-	} catch {
-		return undefined;
+	let total: number | undefined;
+	for (const { attachedClients } of sessionHostRuntimes) {
+		let count: number;
+		try {
+			count = attachedClients();
+		} catch {
+			continue;
+		}
+		if (!Number.isSafeInteger(count) || count < 0) continue;
+		total = (total ?? 0) + count;
 	}
+	return total;
+}
+
+/**
+ * Whether any runtime in this process has agent work in flight right now.
+ *
+ * Positive evidence only: a runtime that publishes nothing, or whose reader
+ * fails, reports no work, so this can never keep an abandoned host alive.
+ */
+export function sessionHostWorkInFlight(): boolean {
+	for (const { workInFlight } of sessionHostRuntimes) {
+		try {
+			if (workInFlight()) return true;
+		} catch {}
+	}
+	return false;
 }
 
 /**

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -13,7 +13,7 @@ function nativeLifecycle(): typeof import("@gajae-code/natives") {
 	return nativeLifecycleBindings;
 }
 
-import { $credentialEnv, resolveEquivalentPath } from "@gajae-code/utils";
+import { $credentialEnv, logger, resolveEquivalentPath } from "@gajae-code/utils";
 
 import {
 	isModelProfileError,
@@ -4381,4 +4381,122 @@ export async function executeLifecycle(
 		...(durableEffects ? { durableEffects } : {}),
 		...(startupFailure ? { startupFailure } : {}),
 	};
+}
+
+/**
+ * The live client/socket subscription count of the SDK session endpoint this
+ * process serves, or `undefined` while this process serves no endpoint.
+ *
+ * Only the SDK session runtime owns the real socket table, so it publishes a
+ * reader here instead of every consumer re-deriving attachment from the OS.
+ * Consumers must treat `undefined` as "no evidence" and never as "detached".
+ */
+export type SessionHostAttachmentReader = () => number;
+
+let sessionHostAttachmentReader: SessionHostAttachmentReader | undefined;
+
+/**
+ * Publishes (or, with `undefined`, retracts) this process's SDK client-count
+ * reader. Called by the SDK session runtime around its transport lifetime.
+ */
+export function publishSessionHostAttachmentReader(reader: SessionHostAttachmentReader | undefined): void {
+	sessionHostAttachmentReader = reader;
+}
+
+/**
+ * This process's currently attached SDK client count, or `undefined` when no
+ * SDK endpoint is serving (before startup, after teardown, or when the reader
+ * itself fails). Never guesses: absence of a reader is absence of evidence.
+ */
+export function sessionHostAttachedClients(): number | undefined {
+	const reader = sessionHostAttachmentReader;
+	if (!reader) return undefined;
+	try {
+		const count = reader();
+		return Number.isSafeInteger(count) && count >= 0 ? count : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * How often a live broker re-checks its own session registrations against OS
+ * process liveness.
+ *
+ * This sweep can never disturb healthy work: a registration is only dropped
+ * when `process.kill(pid, 0)` proves the exact published pid is gone, and a
+ * working host answers that probe for its entire life no matter how long a turn
+ * runs. One minute keeps `gjc_sessions`/`session.get_endpoint` from advertising
+ * a corpse for longer than a single poll while costing one index refresh per
+ * minute on an otherwise idle broker.
+ */
+export const BROKER_DEAD_REGISTRATION_SWEEP_MS = 60_000;
+
+/** One reaped registration, as recorded by {@link reapDeadSessionRegistrations}. */
+export interface ReapedSessionRegistration {
+	sessionId: string;
+	pid: number;
+	endpointGeneration: number;
+}
+
+/**
+ * Drops every indexed session registration whose host process is provably gone.
+ *
+ * Liveness is the session index's own `alive(pid)` probe (`listSessions().live`),
+ * which reports live for both a running pid and an EPERM pid, so an alien or
+ * unreadable process is never mistaken for a dead one. Registrations already
+ * marked `terminalUncertain` are left alone: their disposition belongs to the
+ * terminal-uncertainty reconciliation path, and silently dropping them would
+ * turn a fail-closed `session.close`/`session.delete` refusal into `not_found`.
+ */
+export async function reapDeadSessionRegistrations(
+	broker: Pick<Broker, "index">,
+): Promise<ReapedSessionRegistration[]> {
+	await broker.index.refresh();
+	const dead = broker.index.listSessions().sessions.filter(session => !session.live && !session.terminalUncertain);
+	const reaped: ReapedSessionRegistration[] = [];
+	for (const session of dead) {
+		await broker.index.append({
+			type: "host_unregistered",
+			sessionId: session.sessionId,
+			locator: session.locator,
+			endpointGeneration: session.endpointGeneration,
+			pid: session.pid,
+			...(session.endpointMtimeMs === undefined ? {} : { endpointMtimeMs: session.endpointMtimeMs }),
+			...(session.lifecycleRequestId ? { lifecycleRequestId: session.lifecycleRequestId } : {}),
+		});
+		const record = {
+			sessionId: session.sessionId,
+			pid: session.pid,
+			endpointGeneration: session.endpointGeneration,
+		};
+		reaped.push(record);
+		logger.warn("sdk broker reaped a session registration whose host process is gone", record);
+	}
+	return reaped;
+}
+
+/**
+ * Runs {@link reapDeadSessionRegistrations} on {@link BROKER_DEAD_REGISTRATION_SWEEP_MS}.
+ * The timer is unref'd, so it never keeps an otherwise idle broker process alive.
+ * Returns a disposer.
+ */
+export function startBrokerDeadRegistrationSweep(
+	broker: Pick<Broker, "index">,
+	intervalMs = BROKER_DEAD_REGISTRATION_SWEEP_MS,
+): () => void {
+	let running = false;
+	const timer = setInterval(() => {
+		if (running) return;
+		running = true;
+		void reapDeadSessionRegistrations(broker)
+			.catch(error => {
+				logger.warn("sdk broker dead-registration sweep failed", { error: String(error) });
+			})
+			.finally(() => {
+				running = false;
+			});
+	}, intervalMs);
+	timer.unref();
+	return () => clearInterval(timer);
 }

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -80,6 +80,7 @@ import {
 } from "../../tools/ask-answer-registry";
 import { acpFinalTextFromMessage } from "../acp/final-text";
 import { ensureBroker } from "../broker/ensure";
+import { publishSessionHostAttachmentReader } from "../broker/lifecycle";
 import { SessionIndex } from "../broker/session-index";
 import { createSdkSurfaceFactory, type SessionSdkHost, SessionSdkSessionRuntime, shouldHostSdk } from "../host";
 import { type ControlSurface, dispatchControl } from "../host/control";
@@ -3749,6 +3750,9 @@ export function createNotificationsExtension(
 				await rt.server.stopAndWait();
 				serverStopped = true;
 				rt.serverStopped = true;
+				// This process no longer serves an SDK endpoint, so it publishes no
+				// attachment evidence either (absence of a reader is not detachment).
+				publishSessionHostAttachmentReader(undefined);
 			} catch (e) {
 				ownerReleaseFailures.push(e);
 				logger.warn(`notifications: stop failed: ${String(e)}`);
@@ -5503,6 +5507,10 @@ export function createNotificationsExtension(
 			};
 			host.emitEvent({ kind: identityHeader.type, payload: identityHeader });
 			const endpoint = await sdkRuntime.startTransport();
+			// The native server owns the only authoritative view of this host's live
+			// SDK client sockets; publish it so a detached session host can bound its
+			// own lifetime without probing the OS (#4010).
+			publishSessionHostAttachmentReader(() => server.clientCount());
 			ephemeralTurns.configureAuthority({
 				sessionId: id,
 				endpointDigest: endpointAuthorityDigest(endpoint.url, token),

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -80,7 +80,7 @@ import {
 } from "../../tools/ask-answer-registry";
 import { acpFinalTextFromMessage } from "../acp/final-text";
 import { ensureBroker } from "../broker/ensure";
-import { publishSessionHostAttachmentReader } from "../broker/lifecycle";
+import { publishSessionHostRuntimeEvidence, type SessionHostRuntimePublication } from "../broker/lifecycle";
 import { SessionIndex } from "../broker/session-index";
 import { createSdkSurfaceFactory, type SessionSdkHost, SessionSdkSessionRuntime, shouldHostSdk } from "../host";
 import { type ControlSurface, dispatchControl } from "../host/control";
@@ -1171,6 +1171,8 @@ interface SessionRuntime {
 	/** Terminal cleanup proof retained across retries; each owner is released at most once after proof. */
 	hostStopped: boolean;
 	serverStopped: boolean;
+	/** This runtime's own host-liveness publication; only its teardown may retract it. */
+	evidencePublication?: SessionHostRuntimePublication;
 	brokerRegistrationReleased: boolean;
 	/** Managed Telegram root registration released during terminal teardown. */
 	notificationRootRegistration?: { settings: Settings; cwd: string; registrationToken: string };
@@ -3750,9 +3752,13 @@ export function createNotificationsExtension(
 				await rt.server.stopAndWait();
 				serverStopped = true;
 				rt.serverStopped = true;
-				// This process no longer serves an SDK endpoint, so it publishes no
-				// attachment evidence either (absence of a reader is not detachment).
-				publishSessionHostAttachmentReader(undefined);
+				// This runtime no longer serves an SDK endpoint, so it withdraws its
+				// own evidence — and only its own. A predecessor's deferred teardown
+				// runs while an identity successor is already serving, and clearing
+				// that live runtime's reader would manufacture "no evidence" for a
+				// host whose clients are still attached.
+				rt.evidencePublication?.retract();
+				rt.evidencePublication = undefined;
 			} catch (e) {
 				ownerReleaseFailures.push(e);
 				logger.warn(`notifications: stop failed: ${String(e)}`);
@@ -5509,8 +5515,12 @@ export function createNotificationsExtension(
 			const endpoint = await sdkRuntime.startTransport();
 			// The native server owns the only authoritative view of this host's live
 			// SDK client sockets; publish it so a detached session host can bound its
-			// own lifetime without probing the OS (#4010).
-			publishSessionHostAttachmentReader(() => server.clientCount());
+			// own lifetime without probing the OS (#4010). The handle is this
+			// runtime's alone, so only this runtime's teardown can retract it.
+			initializedRuntime.evidencePublication = publishSessionHostRuntimeEvidence({
+				attachedClients: () => server.clientCount(),
+				workInFlight: () => initializedRuntime.busy || initializedRuntime.pendingPromptCorrelations.length > 0,
+			});
 			ephemeralTurns.configureAuthority({
 				sessionId: id,
 				endpointDigest: endpointAuthorityDigest(endpoint.url, token),

--- a/packages/coding-agent/src/sdk/lifecycle-session.ts
+++ b/packages/coding-agent/src/sdk/lifecycle-session.ts
@@ -13,11 +13,22 @@ export type CreateLifecycleAgentSessionResult =
 			session: AgentSession;
 			capability: SdkStartupCapability;
 			rollback: SdkStartupRollbackTracker;
+			/**
+			 * Starts the memory backend that construction deliberately skipped. The
+			 * caller MUST run it only after readiness is published.
+			 */
+			startDeferredMemoryBackend: () => Promise<void>;
 	  }
 	| { capability: SdkStartupCapability; rollback: SdkStartupRollbackTracker; failure: SdkStartupFailure };
 
-/** Options accepted by lifecycle-only session construction. */
-export type CreateLifecycleAgentSessionOptions = CreateAgentSessionOptions & {
+/**
+ * Options accepted by lifecycle-only session construction.
+ *
+ * `deferMemoryBackendStartup` is not accepted: lifecycle sessions are launched
+ * by the broker under a fixed readiness deadline, and memory startup runs
+ * unbounded LLM work, so deferral is an invariant rather than a caller choice.
+ */
+export type CreateLifecycleAgentSessionOptions = Omit<CreateAgentSessionOptions, "deferMemoryBackendStartup"> & {
 	/**
 	 * Startup budget for ACP lifecycle MCP launches, in milliseconds. Set only
 	 * when the lifecycle request supplies `mcpServers`; ordinary consumers keep
@@ -42,6 +53,11 @@ export async function createLifecycleAgentSession(
 		const { mcpStartupTimeoutMs, readiness: _readiness, ...sessionOptions } = options;
 		const internalOptions = {
 			...sessionOptions,
+			// Memory startup (rollout summarisation) issues one LLM request per
+			// claimed rollout, so its duration scales with the backlog. Keeping it
+			// inside the broker's readiness window is what kills the child at the
+			// cutoff; the host resumes it once readiness is published.
+			deferMemoryBackendStartup: true,
 			[lifecycleStartupCapabilityOption]: capability,
 			...(mcpStartupTimeoutMs !== undefined ? { [lifecycleMcpStartupTimeoutOption]: mcpStartupTimeoutMs } : {}),
 		} as CreateAgentSessionOptions & {
@@ -51,7 +67,14 @@ export async function createLifecycleAgentSession(
 		const result = await createAgentSession(internalOptions);
 		if (!result.session.extensionRunner)
 			capability.settleFailure(capability.normalizeFailure("registration", "runner_absent"));
-		return { session: result.session, capability, rollback };
+		if (!result.startDeferredMemoryBackend)
+			throw new Error("Lifecycle session construction did not return a deferred memory backend starter.");
+		return {
+			session: result.session,
+			capability,
+			rollback,
+			startDeferredMemoryBackend: result.startDeferredMemoryBackend,
+		};
 	} catch (error) {
 		const settled = capability.settleFailure(capability.normalizeFailure("registration", "failed", error));
 		const failure =

--- a/packages/coding-agent/test/sdk-broker-lock-artifacts.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lock-artifacts.test.ts
@@ -320,10 +320,17 @@ describe("detached broker spawn diagnostics", () => {
 		await fs.mkdir(path.join(agentDir, "sdk", "sessions"), { recursive: true });
 		await Bun.write(path.join(agentDir, "sdk", "sessions", "index.snapshot.json"), JSON.stringify({ version: 99 }));
 
-		await expect(ensureBroker({ agentDir })).rejects.toThrow(/exited before discovery[\s\S]*Broker stderr:/);
+		const failure = await ensureBroker({ agentDir }).then(
+			() => undefined,
+			(error: unknown) => (error instanceof Error ? error : new Error(String(error))),
+		);
+		expect(failure?.message).toMatch(/exited before discovery[\s\S]*Broker stderr:/);
+		expect(failure?.message).toContain("index.snapshot.json");
 
-		const captured = await Bun.file(path.join(agentDir, "sdk", "broker-spawn.log")).text();
-		expect(captured).toContain("index.snapshot.json");
+		// The sink is per-spawn and removed once folded into the failure, so the
+		// diagnostic lives in the error and leaves no retained artifact behind.
+		const retained = await fs.readdir(path.join(agentDir, "sdk"));
+		expect(retained.filter(name => name.startsWith("broker-spawn"))).toEqual([]);
 	}, 20_000);
 });
 

--- a/packages/coding-agent/test/sdk-broker-lock-artifacts.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lock-artifacts.test.ts
@@ -1,0 +1,377 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import path from "node:path";
+import { logger } from "@gajae-code/utils";
+import {
+	BROKER_LOCK_ARTIFACT_GRACE_MS,
+	Broker,
+	reapStaleBrokerLockArtifacts,
+	setLockArtifactGraceForTest,
+} from "../src/sdk/broker/broker";
+import { brokerProcessIncarnation, writeBrokerDiscovery } from "../src/sdk/broker/discovery";
+import { ensureBroker } from "../src/sdk/broker/ensure";
+import { LifecycleLedger } from "../src/sdk/broker/lifecycle-ledger";
+
+const HOUR_MS = 60 * 60 * 1_000;
+
+/** Temp state roots created by this file; `~/.gjc` is never touched. */
+const roots: string[] = [];
+/** Paths chmod-ed to 0 that must be reopened before the temp root can be removed. */
+const restoreModes: string[] = [];
+
+async function makeAgentDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-artifacts-"));
+	roots.push(dir);
+	await fs.mkdir(path.join(dir, "sdk"), { recursive: true, mode: 0o700 });
+	return dir;
+}
+
+async function ageTo(target: string, ageMs: number, now: number): Promise<void> {
+	const stamp = new Date(now - ageMs);
+	await fs.utimes(target, stamp, stamp);
+}
+
+/** Materialize one lock artifact directory with an optional owner record. */
+async function writeArtifact(
+	agentDir: string,
+	name: string,
+	owner: { pid: number } | "no-record" | "unparseable",
+	ageMs: number,
+	now: number,
+): Promise<string> {
+	const target = path.join(agentDir, "sdk", name);
+	await fs.mkdir(target, { recursive: true, mode: 0o700 });
+	if (owner === "unparseable") await Bun.write(path.join(target, "owner.json"), "{not json");
+	else if (owner !== "no-record")
+		await Bun.write(
+			path.join(target, "owner.json"),
+			JSON.stringify({ version: 1, ownerId: "owner-a", pid: owner.pid, acquiredAt: now - ageMs }),
+		);
+	await ageTo(target, ageMs, now);
+	return target;
+}
+
+async function exists(target: string): Promise<boolean> {
+	try {
+		await fs.lstat(target);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+const isRoot = process.getuid?.() === 0;
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	for (const target of restoreModes.splice(0)) await fs.chmod(target, 0o700).catch(() => {});
+	for (const root of roots.splice(0)) await fs.rm(root, { recursive: true, force: true });
+});
+
+describe("broker lock artifact reaper", () => {
+	it("removes tombstones past the grace bound and keeps newer ones", async () => {
+		const now = Date.now();
+		const agentDir = await makeAgentDir();
+		const stale = await writeArtifact(agentDir, ".broker.lock.stale-aaaa", { pid: 999_999 }, 4 * HOUR_MS, now);
+		const fresh = await writeArtifact(agentDir, ".broker.lock.stale-bbbb", { pid: 999_998 }, 5 * 60_000, now);
+
+		const result = await reapStaleBrokerLockArtifacts({
+			agentDir,
+			now,
+			graceMs: HOUR_MS,
+			pidAlive: () => false,
+		});
+
+		expect(result.removed).toEqual([stale]);
+		expect(result.retained).toEqual([{ path: fresh, reason: "within-grace" }]);
+		expect(await exists(stale)).toBe(false);
+		expect(await exists(fresh)).toBe(true);
+	});
+
+	it("never removes a tombstone whose owner pid is alive", async () => {
+		const now = Date.now();
+		const agentDir = await makeAgentDir();
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const live = await writeArtifact(agentDir, ".broker.lock.stale-live", { pid: process.pid }, 30 * HOUR_MS, now);
+
+		const result = await reapStaleBrokerLockArtifacts({
+			agentDir,
+			now,
+			graceMs: HOUR_MS,
+			pidAlive: pid => pid === process.pid,
+		});
+
+		expect(result.removed).toEqual([]);
+		expect(result.retained).toEqual([{ path: live, reason: "owner-alive" }]);
+		expect(await exists(path.join(live, "owner.json"))).toBe(true);
+		expect(warn.mock.calls.map(call => String(call[0]))).toEqual([
+			"sdk broker: retained stale lock artifact .broker.lock.stale-live (owner-alive)",
+		]);
+	});
+
+	it("keeps a tombstone whose owner record cannot be parsed", async () => {
+		const now = Date.now();
+		const agentDir = await makeAgentDir();
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const broken = await writeArtifact(agentDir, ".broker.lock.stale-broken", "unparseable", 30 * HOUR_MS, now);
+
+		const result = await reapStaleBrokerLockArtifacts({ agentDir, now, graceMs: HOUR_MS, pidAlive: () => false });
+
+		expect(result.removed).toEqual([]);
+		expect(result.retained).toEqual([{ path: broken, reason: "owner-record-unreadable" }]);
+		expect(await exists(broken)).toBe(true);
+		expect(warn).toHaveBeenCalledWith(
+			"sdk broker: retained stale lock artifact .broker.lock.stale-broken (owner-record-unreadable)",
+		);
+	});
+
+	it("keeps a tombstone whose owner record is missing", async () => {
+		const now = Date.now();
+		const agentDir = await makeAgentDir();
+		const orphan = await writeArtifact(agentDir, ".broker.lock.stale-orphan", "no-record", 30 * HOUR_MS, now);
+
+		const result = await reapStaleBrokerLockArtifacts({ agentDir, now, graceMs: HOUR_MS, pidAlive: () => false });
+
+		expect(result.removed).toEqual([]);
+		expect(result.retained).toEqual([{ path: orphan, reason: "owner-record-missing" }]);
+		expect(await exists(orphan)).toBe(true);
+	});
+
+	it.skipIf(isRoot)("keeps a permission-denied entry, logs it, and still reaps the rest of the pass", async () => {
+		const now = Date.now();
+		const agentDir = await makeAgentDir();
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const denied = await writeArtifact(agentDir, ".broker.lock.stale-denied", { pid: 999_999 }, 30 * HOUR_MS, now);
+		const reapable = await writeArtifact(agentDir, ".broker.lock.stale-open", { pid: 999_998 }, 30 * HOUR_MS, now);
+		await fs.chmod(denied, 0o000);
+		restoreModes.push(denied);
+		await ageTo(denied, 30 * HOUR_MS, now);
+
+		const result = await reapStaleBrokerLockArtifacts({ agentDir, now, graceMs: HOUR_MS, pidAlive: () => false });
+
+		expect(result.removed).toEqual([reapable]);
+		expect(result.retained).toEqual([{ path: denied, reason: "owner-record-unreadable" }]);
+		expect(await exists(denied)).toBe(true);
+		expect(warn).toHaveBeenCalledWith(
+			"sdk broker: retained stale lock artifact .broker.lock.stale-denied (owner-record-unreadable)",
+		);
+	});
+
+	it("removes legacy restart and stale backups that carry no owner record", async () => {
+		const now = Date.now();
+		const agentDir = await makeAgentDir();
+		const restart = await writeArtifact(
+			agentDir,
+			"broker-restart-backup-20260722-223542",
+			"no-record",
+			30 * HOUR_MS,
+			now,
+		);
+		const staleBackup = await writeArtifact(
+			agentDir,
+			"broker-stale-backup-20260722-221524",
+			"no-record",
+			30 * HOUR_MS,
+			now,
+		);
+		// Backups carry arbitrary salvaged state, not an owner record.
+		await Bun.write(path.join(restart, "broker.json"), "{}");
+		await ageTo(restart, 30 * HOUR_MS, now);
+
+		const result = await reapStaleBrokerLockArtifacts({ agentDir, now, graceMs: HOUR_MS, pidAlive: () => false });
+
+		expect(result.removed.toSorted()).toEqual([restart, staleBackup].toSorted());
+		expect(await exists(restart)).toBe(false);
+		expect(await exists(staleBackup)).toBe(false);
+	});
+
+	it("never follows a symlink shaped like a tombstone", async () => {
+		const now = Date.now();
+		const agentDir = await makeAgentDir();
+		const victim = path.join(agentDir, "victim");
+		await fs.mkdir(victim, { recursive: true });
+		await Bun.write(path.join(victim, "keep.txt"), "keep");
+		const link = path.join(agentDir, "sdk", ".broker.lock.stale-link");
+		await fs.symlink(victim, link);
+
+		const result = await reapStaleBrokerLockArtifacts({ agentDir, now, graceMs: 0, pidAlive: () => false });
+
+		expect(result.removed).toEqual([]);
+		expect(result.retained).toEqual([{ path: link, reason: "not-a-directory" }]);
+		expect(await exists(path.join(victim, "keep.txt"))).toBe(true);
+	});
+
+	it("leaves live broker state in the sdk directory untouched", async () => {
+		const now = Date.now();
+		const agentDir = await makeAgentDir();
+		const lock = path.join(agentDir, "sdk", "broker.lock");
+		await fs.mkdir(lock, { recursive: true });
+		await Bun.write(path.join(lock, "owner.json"), JSON.stringify({ version: 1, pid: 4, ownerId: "a" }));
+		await Bun.write(path.join(agentDir, "sdk", "broker.json"), "{}");
+		await Bun.write(path.join(agentDir, "sdk", "lifecycle-ledger.jsonl"), "");
+		await ageTo(lock, 30 * HOUR_MS, now);
+
+		const result = await reapStaleBrokerLockArtifacts({ agentDir, now, graceMs: HOUR_MS, pidAlive: () => false });
+
+		expect(result).toEqual({ removed: [], retained: [] });
+		expect(await exists(path.join(lock, "owner.json"))).toBe(true);
+		expect(await exists(path.join(agentDir, "sdk", "broker.json"))).toBe(true);
+	});
+
+	it("returns empty for a state root that has no sdk directory yet", async () => {
+		const agentDir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-artifacts-"));
+		roots.push(agentDir);
+
+		expect(await reapStaleBrokerLockArtifacts({ agentDir })).toEqual({ removed: [], retained: [] });
+	});
+
+	it("bounds the default grace window to one day", () => {
+		expect(BROKER_LOCK_ARTIFACT_GRACE_MS).toBe(24 * HOUR_MS);
+	});
+
+	it("reaps stale tombstones on broker startup and keeps newer ones", async () => {
+		const now = Date.now();
+		const agentDir = await makeAgentDir();
+		const stale = await writeArtifact(agentDir, ".broker.lock.stale-startup", { pid: 999_999 }, 4 * HOUR_MS, now);
+		const fresh = await writeArtifact(agentDir, ".broker.lock.stale-recent", { pid: 999_998 }, 60_000, now);
+		const broker = new Broker({ agentDir });
+		setLockArtifactGraceForTest(broker, HOUR_MS);
+
+		try {
+			await broker.start();
+			expect(broker.ownsDiscovery).toBe(true);
+		} finally {
+			await broker.stop();
+		}
+
+		expect(await exists(stale)).toBe(false);
+		expect(await exists(fresh)).toBe(true);
+	});
+});
+
+describe("broker clean-exit lock contention diagnostics", () => {
+	it("names lock contention when yielding to a live broker owner", async () => {
+		const agentDir = await makeAgentDir();
+		const info = vi.spyOn(logger, "info").mockImplementation(() => {});
+		const lock = path.join(agentDir, "sdk", "broker.lock");
+		await fs.mkdir(lock, { recursive: true, mode: 0o700 });
+		await Bun.write(
+			path.join(lock, "owner.json"),
+			JSON.stringify({ version: 1, ownerId: "foreign-owner", pid: process.pid, acquiredAt: Date.now() }),
+		);
+		await writeBrokerDiscovery(agentDir, {
+			version: 1,
+			protocolVersion: 3,
+			packageGeneration: "test",
+			ownerId: "foreign-owner",
+			pid: process.pid,
+			incarnation: brokerProcessIncarnation(process.pid) ?? "",
+			host: "127.0.0.1",
+			port: 1,
+			url: "ws://127.0.0.1:1",
+			token: "t".repeat(64),
+			startedAt: Date.now(),
+			heartbeatAt: Date.now(),
+		});
+
+		const broker = new Broker({ agentDir });
+		const discovery = await broker.start();
+
+		expect(discovery.ownerId).toBe("foreign-owner");
+		expect(broker.ownsDiscovery).toBe(false);
+		const contention = info.mock.calls
+			.map(call => String(call[0]))
+			.filter(message => message.includes("lock contention"));
+		expect(contention).toHaveLength(1);
+		expect(contention[0]).toContain("yielding to the live broker owner");
+		expect(contention[0]).toContain("ownerId=foreign-owner");
+		expect(contention[0]).toContain("exits without owning discovery");
+	});
+
+	it("warns with the holding pid before refusing a lock held by a live owner", async () => {
+		const agentDir = await makeAgentDir();
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const lock = path.join(agentDir, "sdk", "broker.lock");
+		await fs.mkdir(lock, { recursive: true, mode: 0o700 });
+		await Bun.write(
+			path.join(lock, "owner.json"),
+			JSON.stringify({ version: 1, ownerId: "holder", pid: process.pid, acquiredAt: Date.now() }),
+		);
+
+		const broker = new Broker({ agentDir });
+
+		await expect(broker.start()).rejects.toThrow(`Broker lock is held by a live owner (pid ${process.pid})`);
+
+		const refusals = warn.mock.calls
+			.map(call => String(call[0]))
+			.filter(message => message.includes("lock contention"));
+		expect(refusals).toHaveLength(1);
+		expect(refusals[0]).toContain("refusing to start");
+		expect(refusals[0]).toContain(`live pid ${process.pid}`);
+	});
+});
+
+describe("detached broker spawn diagnostics", () => {
+	it("folds the spawned broker's stderr into the exited-before-discovery failure", async () => {
+		const agentDir = await makeAgentDir();
+		// An unsupported session-index snapshot makes the spawned broker's start()
+		// reject, so it exits before publishing discovery. Under `stdio: "ignore"`
+		// the caller saw only an exit code; the reason must now reach the error.
+		await fs.mkdir(path.join(agentDir, "sdk", "sessions"), { recursive: true });
+		await Bun.write(path.join(agentDir, "sdk", "sessions", "index.snapshot.json"), JSON.stringify({ version: 99 }));
+
+		await expect(ensureBroker({ agentDir })).rejects.toThrow(/exited before discovery[\s\S]*Broker stderr:/);
+
+		const captured = await Bun.file(path.join(agentDir, "sdk", "broker-spawn.log")).text();
+		expect(captured).toContain("index.snapshot.json");
+	}, 20_000);
+});
+
+describe("lifecycle ledger quarantine bound", () => {
+	/** A syntactically valid row that fails entry validation, so `open()` quarantines it. */
+	function badRow(index: number, padBytes: number): string {
+		return `${JSON.stringify({ version: 1, identity: "", requestHash: `r${index}`, state: "accepted", ts: index, pad: "x".repeat(padBytes) })}\n`;
+	}
+
+	it("rotates the corrupt sidecar instead of growing past its cap", async () => {
+		const agentDir = await makeAgentDir();
+		const ledgerFile = path.join(agentDir, "sdk", "lifecycle-ledger.jsonl");
+		const corrupt = `${ledgerFile}.corrupt`;
+		const maxCorruptBytes = 4_096;
+		await Bun.write(ledgerFile, Array.from({ length: 12 }, (_, index) => badRow(index, 512)).join(""));
+
+		for (let pass = 0; pass < 4; pass++) {
+			await new LifecycleLedger(agentDir, { maxCorruptBytes }).open();
+			expect(Bun.file(corrupt).size).toBeLessThanOrEqual(maxCorruptBytes + 1);
+		}
+
+		expect(Bun.file(`${corrupt}.1`).size).toBeGreaterThan(0);
+		expect(Bun.file(`${corrupt}.1`).size).toBeLessThanOrEqual(maxCorruptBytes + 1);
+	});
+
+	it("clips a single oversized quarantined row to the cap and marks the truncation", async () => {
+		const agentDir = await makeAgentDir();
+		const ledgerFile = path.join(agentDir, "sdk", "lifecycle-ledger.jsonl");
+		const corrupt = `${ledgerFile}.corrupt`;
+		const maxCorruptBytes = 256;
+		await Bun.write(ledgerFile, badRow(0, 4_096));
+
+		await new LifecycleLedger(agentDir, { maxCorruptBytes }).open();
+
+		const quarantined = await Bun.file(corrupt).text();
+		expect(quarantined).toContain("[gjc: quarantined row truncated at the corrupt-ledger cap]");
+		expect(Bun.file(corrupt).size).toBeLessThan(maxCorruptBytes + 128);
+	});
+
+	it("appends within the cap without rotating", async () => {
+		const agentDir = await makeAgentDir();
+		const ledgerFile = path.join(agentDir, "sdk", "lifecycle-ledger.jsonl");
+		const corrupt = `${ledgerFile}.corrupt`;
+		await Bun.write(ledgerFile, badRow(0, 16));
+
+		await new LifecycleLedger(agentDir, { maxCorruptBytes: 64 * 1024 }).open();
+
+		expect(Bun.file(corrupt).size).toBeGreaterThan(0);
+		expect(await Bun.file(`${corrupt}.1`).exists()).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/sdk-broker-spawn-log.test.ts
+++ b/packages/coding-agent/test/sdk-broker-spawn-log.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import path from "node:path";
+import { BROKER_SPAWN_LOG_TAIL_BYTES, openBrokerSpawnLog, readBrokerSpawnLogTail } from "../src/sdk/broker/ensure";
+
+test("concurrent broker spawn logs retain only their own diagnostics", async () => {
+	const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-spawnlog-"));
+	let firstPath: string | undefined;
+	let secondPath: string | undefined;
+	try {
+		const [first, second] = await Promise.all([openBrokerSpawnLog(agentDir), openBrokerSpawnLog(agentDir)]);
+		expect(first).toBeDefined();
+		expect(second).toBeDefined();
+		if (!first || !second) throw new Error("Broker spawn log could not be opened.");
+		firstPath = first.path;
+		secondPath = second.path;
+		expect(first.path).not.toBe(second.path);
+
+		await first.handle.writeFile(`${"A".repeat(BROKER_SPAWN_LOG_TAIL_BYTES + 1_904)}\n`);
+		await second.handle.writeFile("B: entrypoint is not a readable regular file\n");
+		await first.handle.writeFile("A: later diagnostic\n");
+		await Promise.all([first.handle.close(), second.handle.close()]);
+
+		const secondTail = await readBrokerSpawnLogTail(second.path);
+		expect(secondTail).toBe("B: entrypoint is not a readable regular file");
+		expect(secondTail).not.toContain("A: later diagnostic");
+		expect(secondTail).not.toContain("\0");
+	} finally {
+		await Promise.all([
+			...(firstPath ? [fs.unlink(firstPath).catch(() => {})] : []),
+			...(secondPath ? [fs.unlink(secondPath).catch(() => {})] : []),
+		]);
+		await fs.rm(agentDir, { recursive: true, force: true });
+	}
+});

--- a/packages/coding-agent/test/sdk-broker.test.ts
+++ b/packages/coding-agent/test/sdk-broker.test.ts
@@ -1844,8 +1844,7 @@ describe("SDK broker identity and discovery", () => {
 				ok: false,
 				error: {
 					code: "terminal_uncertain",
-					message:
-						"Lifecycle terminal evidence could not be verified after persistence; retained artifacts require reconciliation.",
+					message: "Prior cleanup authority for this session is corrupt or incomplete.",
 				},
 			});
 			expect(calls).toBe(1);

--- a/packages/coding-agent/test/sdk-lifecycle-memory-defer.test.ts
+++ b/packages/coding-agent/test/sdk-lifecycle-memory-defer.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AuthStorage, getBundledModel } from "@gajae-code/ai";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { localBackend } from "@gajae-code/coding-agent/memory-backend/local-backend";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { logger } from "@gajae-code/utils";
+import { startMemoryBackendAfterReadiness } from "../src/commands/sdk";
+import { createLifecycleAgentSession } from "../src/sdk/lifecycle-session";
+
+const createdDirs = new Set<string>();
+
+describe("lifecycle session memory startup", () => {
+	let authStorage: AuthStorage;
+
+	beforeEach(async () => {
+		authStorage = await AuthStorage.create(":memory:");
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		authStorage.close();
+		for (const dir of createdDirs) {
+			await fs.promises.rm(dir, { recursive: true, force: true });
+		}
+		createdDirs.clear();
+	});
+
+	// The broker kills a lifecycle child that misses its readiness deadline, and
+	// local memory startup summarises every queued rollout through the model, so
+	// construction must never reach the backend.
+	test("never starts the memory backend while building the session", async () => {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-lifecycle-memory-"));
+		createdDirs.add(cwd);
+		const startSpy = vi.spyOn(localBackend, "start").mockImplementation(() => {});
+
+		const created = await createLifecycleAgentSession({
+			cwd,
+			agentDir: cwd,
+			authStorage,
+			modelRegistry: new ModelRegistry(authStorage),
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "memory.backend": "local" }),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableLsp: false,
+			toolNames: [],
+		});
+
+		if ("failure" in created) throw new Error(`Lifecycle session construction failed: ${created.failure.message}`);
+		try {
+			expect(startSpy).not.toHaveBeenCalled();
+
+			// The post-readiness resume must reach the same backend, exactly once.
+			await created.startDeferredMemoryBackend();
+			expect(startSpy).toHaveBeenCalledTimes(1);
+			expect(startSpy.mock.calls[0]?.[0].session).toBe(created.session);
+
+			await created.startDeferredMemoryBackend();
+			expect(startSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			await created.session.dispose();
+		}
+	}, 30_000);
+});
+
+describe("startMemoryBackendAfterReadiness", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	test("returns before the memory backend has started", async () => {
+		const started = Promise.withResolvers<void>();
+		let resolved = false;
+		startMemoryBackendAfterReadiness(async () => {
+			await started.promise;
+			resolved = true;
+		});
+
+		// Readiness is already published: the caller must not be blocked here.
+		await Bun.sleep(1);
+		expect(resolved).toBe(false);
+		started.resolve();
+		await Bun.sleep(1);
+		expect(resolved).toBe(true);
+	});
+
+	test("logs a failed startup instead of rejecting the session", async () => {
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const rejections: unknown[] = [];
+		const onRejection = (reason: unknown) => rejections.push(reason);
+		process.on("unhandledRejection", onRejection);
+		try {
+			startMemoryBackendAfterReadiness(async () => {
+				throw new Error("phase1 stage1 job failed");
+			});
+			await Bun.sleep(1);
+		} finally {
+			process.off("unhandledRejection", onRejection);
+		}
+
+		expect(rejections).toHaveLength(0);
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0]?.[0]).toBe("Deferred memory backend startup failed after readiness");
+		expect(String(warn.mock.calls[0]?.[1]?.error)).toContain("phase1 stage1 job failed");
+	});
+});

--- a/packages/coding-agent/test/sdk-lifecycle-terminal-evidence.test.ts
+++ b/packages/coding-agent/test/sdk-lifecycle-terminal-evidence.test.ts
@@ -1,0 +1,148 @@
+import { expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import path from "node:path";
+
+import { Broker } from "../src/sdk/broker/broker";
+import { LifecycleLedger, type LifecycleLedgerEntry } from "../src/sdk/broker/lifecycle-ledger";
+
+const temp = () => fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-terminal-evidence-"));
+const ledgerFile = (agentDir: string) => path.join(agentDir, "sdk", "lifecycle-ledger.jsonl");
+
+async function ledgerRows(agentDir: string): Promise<LifecycleLedgerEntry[]> {
+	return (await fs.readFile(ledgerFile(agentDir), "utf8"))
+		.split("\n")
+		.filter(Boolean)
+		.map(line => JSON.parse(line) as LifecycleLedgerEntry);
+}
+
+/**
+ * A slow session host keeps its lifecycle row in `awaiting_ready` for as long as the child
+ * takes to start. Any other broker recovering the shared ledger inside that window stamps the
+ * row `terminal_uncertain`, and the owner still owns the operation and writes its own terminal
+ * row afterwards. The owner's row is the authoritative outcome.
+ */
+it("reads the owner's terminal record after a concurrent recovery stamps its in-flight row", async () => {
+	const agentDir = await temp();
+	try {
+		const owner = await new LifecycleLedger(agentDir).open();
+		await owner.begin("create", "request-hash");
+		await owner.transition("create", "effect_started", {
+			effectIntent: { sessionId: "slow-session", stateRoot: path.join(agentDir, "state") },
+		});
+		await owner.transition("create", "awaiting_ready", {
+			intendedSessionId: "slow-session",
+			effectMarker: "marker",
+		});
+
+		const recovery = await new LifecycleLedger(agentDir).open();
+		expect(recovery.get("create")?.state).toBe("terminal_uncertain");
+
+		const response = { ok: true, result: { sessionId: "slow-session" } };
+		await owner.transition("create", "terminal_ok", { response, resultSessionId: "slow-session" });
+
+		expect(await owner.readTerminal("create", "request-hash")).toMatchObject({
+			state: "terminal_ok",
+			response,
+		});
+	} finally {
+		await fs.rm(agentDir, { recursive: true, force: true });
+	}
+});
+
+it("reads back a durable terminal_uncertain record instead of reporting it unpersisted", async () => {
+	const agentDir = await temp();
+	try {
+		const ledger = await new LifecycleLedger(agentDir).open();
+		await ledger.begin("uncertain", "request-hash");
+		const response = {
+			ok: false,
+			error: { code: "terminal_uncertain", message: "Lifecycle startup cleanup could not be proven." },
+		};
+		await ledger.transition("uncertain", "terminal_uncertain", { response });
+
+		expect(await ledger.readTerminal("uncertain", "request-hash")).toMatchObject({
+			state: "terminal_uncertain",
+			response,
+		});
+	} finally {
+		await fs.rm(agentDir, { recursive: true, force: true });
+	}
+});
+
+it("withholds proof when a persisted terminal row cannot be reproduced", async () => {
+	const agentDir = await temp();
+	try {
+		const ledger = await new LifecycleLedger(agentDir).open();
+		await ledger.begin("tampered", "request-hash");
+		await ledger.transition("tampered", "terminal_ok", { response: { ok: true, result: { sessionId: "s" } } });
+
+		const rows = await ledgerRows(agentDir);
+		rows[rows.length - 1]!.responseDigest = "0".repeat(64);
+		await fs.writeFile(ledgerFile(agentDir), `${rows.map(row => JSON.stringify(row)).join("\n")}\n`);
+
+		expect(await new LifecycleLedger(agentDir).readTerminal("tampered", "request-hash")).toBeUndefined();
+	} finally {
+		await fs.rm(agentDir, { recursive: true, force: true });
+	}
+});
+
+it("withholds proof when a row follows a proven terminal outcome", async () => {
+	const agentDir = await temp();
+	try {
+		const ledger = await new LifecycleLedger(agentDir).open();
+		await ledger.begin("successor", "request-hash");
+		const terminal = await ledger.transition("successor", "terminal_ok", {
+			response: { ok: true, result: { sessionId: "s" } },
+		});
+		await fs.appendFile(ledgerFile(agentDir), `${JSON.stringify({ ...terminal, ts: terminal.ts + 1 })}\n`);
+
+		expect(await new LifecycleLedger(agentDir).readTerminal("successor", "request-hash")).toBeUndefined();
+	} finally {
+		await fs.rm(agentDir, { recursive: true, force: true });
+	}
+});
+
+it("returns the real terminal outcome when a slow spawn is stamped by a concurrent recovery", async () => {
+	const agentDir = await temp();
+	const previousCommand = process.env.GJC_SDK_SESSION_COMMAND;
+	process.env.GJC_SDK_SESSION_COMMAND = "/bin/sleep 60";
+	const broker = new Broker({ agentDir });
+	await broker.start();
+	try {
+		const lifecycle = broker.handleRequest(
+			"session.create",
+			{ cwd: agentDir, readinessTimeoutMs: 4_000 },
+			"slow-spawn-recovery",
+		);
+
+		const deadline = Date.now() + 10_000;
+		let inFlight: LifecycleLedgerEntry | undefined;
+		while (Date.now() < deadline) {
+			const rows = await ledgerRows(agentDir).catch(() => []);
+			inFlight = rows.find(row => row.state === "awaiting_ready");
+			if (inFlight) break;
+			await Bun.sleep(10);
+		}
+		if (!inFlight) throw new Error("Expected the slow spawn to reach awaiting_ready");
+		// A concurrent broker recovering the shared ledger stamps the in-flight row uncertain.
+		const recovery = await new LifecycleLedger(agentDir).open();
+		expect(recovery.get(inFlight.identity)?.state).toBe("terminal_uncertain");
+
+		expect(await lifecycle).toMatchObject({
+			ok: false,
+			error: {
+				code: "terminal_uncertain",
+				message: "Lifecycle startup cleanup could not be proven; retained artifacts require reconciliation.",
+			},
+		});
+		const rows = await ledgerRows(agentDir);
+		expect(
+			rows.filter(row => JSON.stringify(row.response ?? "").includes("terminal evidence could not be verified")),
+		).toHaveLength(0);
+	} finally {
+		if (previousCommand === undefined) delete process.env.GJC_SDK_SESSION_COMMAND;
+		else process.env.GJC_SDK_SESSION_COMMAND = previousCommand;
+		await broker.stop();
+		await fs.rm(agentDir, { recursive: true, force: true });
+	}
+}, 20_000);

--- a/packages/coding-agent/test/sdk-session-host-idle-reap.test.ts
+++ b/packages/coding-agent/test/sdk-session-host-idle-reap.test.ts
@@ -1,0 +1,209 @@
+import { expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { logger } from "@gajae-code/utils";
+import { watchSessionHostClientAttachment } from "../src/commands/sdk";
+import {
+	publishSessionHostAttachmentReader,
+	reapDeadSessionRegistrations,
+	sessionHostAttachedClients,
+} from "../src/sdk/broker/lifecycle";
+import { SessionIndex } from "../src/sdk/broker/session-index";
+
+const HALT = "halt-attachment-watch";
+
+/**
+ * Drives the watcher until it either resolves or the fake clock has advanced
+ * past `polls` iterations. Returns "reaped" only when the watcher decided the
+ * host is abandoned.
+ */
+async function runUntilStable(
+	deps: Parameters<typeof watchSessionHostClientAttachment>[0] & { sleep?: never },
+	polls: number,
+	clock: { nowMs: number },
+): Promise<"reaped" | "still-running"> {
+	let seen = 0;
+	try {
+		await watchSessionHostClientAttachment({
+			...deps,
+			now: () => clock.nowMs,
+			sleep: async ms => {
+				clock.nowMs += ms;
+				seen += 1;
+				if (seen >= polls) throw new Error(HALT);
+			},
+		});
+		return "reaped";
+	} catch (error) {
+		if (error instanceof Error && error.message === HALT) return "still-running";
+		throw error;
+	}
+}
+
+test("a session host is reaped only after its last client has stayed detached for the full idle grace", async () => {
+	let nowMs = 0;
+	// One attached observation, two detached polls, a reattachment that resets
+	// the window, then three detached polls whose last crosses the 20ms grace.
+	const observations = [1, 0, 0, 1, 0, 0, 0];
+	let reads = 0;
+	await watchSessionHostClientAttachment({
+		readAttachedClients: () => {
+			const observed = observations[reads] ?? 0;
+			reads += 1;
+			return observed;
+		},
+		now: () => nowMs,
+		sleep: async ms => {
+			nowMs += ms;
+		},
+		idleGraceMs: 20,
+		firstAttachGraceMs: 1_000,
+		pollMs: 10,
+	});
+	expect(reads).toBe(7);
+	expect(nowMs).toBe(60);
+});
+
+test("a session host with an attached client is never reaped, however long it runs", async () => {
+	const clock = { nowMs: 0 };
+	const outcome = await runUntilStable(
+		{ readAttachedClients: () => 1, idleGraceMs: 20, firstAttachGraceMs: 40, pollMs: 10 },
+		500,
+		clock,
+	);
+	expect(outcome).toBe("still-running");
+	// 500 polls is 250x the idle grace and 125x the first-attach grace.
+	expect(clock.nowMs).toBe(5_000);
+});
+
+test("a freshly spawned session host is held by the longer first-attach grace, not the idle grace", async () => {
+	let nowMs = 0;
+	let reads = 0;
+	await watchSessionHostClientAttachment({
+		readAttachedClients: () => {
+			reads += 1;
+			return 0;
+		},
+		now: () => nowMs,
+		sleep: async ms => {
+			nowMs += ms;
+		},
+		idleGraceMs: 20,
+		firstAttachGraceMs: 40,
+		pollMs: 10,
+	});
+	// Reaping at 20ms would mean the idle grace was wrongly applied to a host
+	// that never saw a client; only the 40ms first-attach grace may end it.
+	expect(nowMs).toBe(40);
+	expect(reads).toBe(5);
+});
+
+test("missing endpoint evidence is not detachment for a host that has already served a client", async () => {
+	const clock = { nowMs: 0 };
+	let reads = 0;
+	const outcome = await runUntilStable(
+		{
+			readAttachedClients: () => {
+				reads += 1;
+				return reads === 1 ? 1 : undefined;
+			},
+			idleGraceMs: 20,
+			firstAttachGraceMs: 40,
+			pollMs: 10,
+		},
+		200,
+		clock,
+	);
+	expect(outcome).toBe("still-running");
+	expect(clock.nowMs).toBe(2_000);
+});
+
+test("a host whose SDK endpoint never publishes attachment evidence still exits at the first-attach bound", async () => {
+	let nowMs = 0;
+	await watchSessionHostClientAttachment({
+		readAttachedClients: () => undefined,
+		now: () => nowMs,
+		sleep: async ms => {
+			nowMs += ms;
+		},
+		idleGraceMs: 20,
+		firstAttachGraceMs: 40,
+		pollMs: 10,
+	});
+	expect(nowMs).toBe(40);
+});
+
+test("the published attachment reader is the host's own client count and retracts to no-evidence", () => {
+	let clients = 3;
+	publishSessionHostAttachmentReader(() => clients);
+	try {
+		expect(sessionHostAttachedClients()).toBe(3);
+		clients = 0;
+		expect(sessionHostAttachedClients()).toBe(0);
+		publishSessionHostAttachmentReader(() => {
+			throw new Error("native server is gone");
+		});
+		expect(sessionHostAttachedClients()).toBeUndefined();
+	} finally {
+		publishSessionHostAttachmentReader(undefined);
+	}
+	expect(sessionHostAttachedClients()).toBeUndefined();
+});
+
+test("the broker drops registrations whose host process is gone, keeps live ones, and logs each reap", async () => {
+	const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-host-reap-"));
+	// A pid beyond any platform's allocation range: process.kill must report ESRCH.
+	const deadPid = 4_194_304;
+	expect(() => process.kill(deadPid, 0)).toThrow();
+	const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+	try {
+		const index = await new SessionIndex(agentDir).open();
+		const locator = { repo: agentDir, stateRoot: agentDir };
+		await index.append({
+			type: "host_registered",
+			sessionId: "live",
+			locator,
+			endpointGeneration: 1,
+			pid: process.pid,
+		});
+		await index.append({
+			type: "host_registered",
+			sessionId: "leaked",
+			locator,
+			endpointGeneration: 2,
+			pid: deadPid,
+			lifecycleRequestId: "request-leaked",
+		});
+		await index.append({
+			type: "lifecycle_terminal",
+			sessionId: "uncertain",
+			locator,
+			endpointGeneration: 3,
+			pid: deadPid,
+			terminalUncertain: true,
+		});
+
+		const reaped = await reapDeadSessionRegistrations({ index });
+		expect(reaped).toEqual([{ sessionId: "leaked", pid: deadPid, endpointGeneration: 2 }]);
+		expect(
+			index
+				.listSessions()
+				.sessions.map(session => session.sessionId)
+				.sort(),
+		).toEqual(["live", "uncertain"]);
+		expect(warn.mock.calls.filter(call => String(call[0]).includes("reaped a session registration")).length).toBe(1);
+
+		// A second sweep has nothing left to prove gone.
+		expect(await reapDeadSessionRegistrations({ index })).toEqual([]);
+		expect(
+			index
+				.listSessions()
+				.sessions.map(session => session.sessionId)
+				.sort(),
+		).toEqual(["live", "uncertain"]);
+	} finally {
+		warn.mockRestore();
+		await fs.rm(agentDir, { recursive: true, force: true });
+	}
+});

--- a/packages/coding-agent/test/sdk-session-host-idle-reap.test.ts
+++ b/packages/coding-agent/test/sdk-session-host-idle-reap.test.ts
@@ -188,6 +188,11 @@ test("a host whose SDK runtime never came up reports no work and still exits at 
 });
 
 test("published runtime evidence is the host's own client count and work, and retracts to no-evidence", () => {
+	// Shard peers may legitimately hold their own publications; every assertion is
+	// relative to that baseline, since a foreign publication is exactly what the
+	// identity-scoped registry must leave untouched.
+	const baseClients = sessionHostAttachedClients();
+	const baseWork = sessionHostWorkInFlight();
 	let clients = 3;
 	let busy = false;
 	const publication = publishSessionHostRuntimeEvidence({
@@ -195,23 +200,24 @@ test("published runtime evidence is the host's own client count and work, and re
 		workInFlight: () => busy,
 	});
 	try {
-		expect(sessionHostAttachedClients()).toBe(3);
-		expect(sessionHostWorkInFlight()).toBe(false);
+		expect(sessionHostAttachedClients()).toBe((baseClients ?? 0) + 3);
+		expect(sessionHostWorkInFlight()).toBe(baseWork || false);
 		clients = 0;
 		busy = true;
-		expect(sessionHostAttachedClients()).toBe(0);
+		expect(sessionHostAttachedClients()).toBe((baseClients ?? 0) + 0);
 		expect(sessionHostWorkInFlight()).toBe(true);
 	} finally {
 		publication.retract();
 	}
-	expect(sessionHostAttachedClients()).toBeUndefined();
-	expect(sessionHostWorkInFlight()).toBe(false);
+	expect(sessionHostAttachedClients()).toEqual(baseClients);
+	expect(sessionHostWorkInFlight()).toBe(baseWork);
 	// Retraction is idempotent and still owns nothing else.
 	publication.retract();
-	expect(sessionHostAttachedClients()).toBeUndefined();
+	expect(sessionHostAttachedClients()).toEqual(baseClients);
 });
 
 test("a retracting runtime cannot clear the evidence of the runtime that succeeded it", () => {
+	const baseClients = sessionHostAttachedClients();
 	const predecessor = publishSessionHostRuntimeEvidence({
 		attachedClients: () => 2,
 		workInFlight: () => false,
@@ -221,21 +227,22 @@ test("a retracting runtime cannot clear the evidence of the runtime that succeed
 		workInFlight: () => true,
 	});
 	try {
-		expect(sessionHostAttachedClients()).toBe(3);
+		expect(sessionHostAttachedClients()).toBe((baseClients ?? 0) + 3);
 		// The predecessor's deferred teardown runs late, while the successor serves.
 		predecessor.retract();
-		expect(sessionHostAttachedClients()).toBe(1);
+		expect(sessionHostAttachedClients()).toBe((baseClients ?? 0) + 1);
 		expect(sessionHostWorkInFlight()).toBe(true);
 		predecessor.retract();
-		expect(sessionHostAttachedClients()).toBe(1);
+		expect(sessionHostAttachedClients()).toBe((baseClients ?? 0) + 1);
 	} finally {
 		successor.retract();
 	}
-	expect(sessionHostAttachedClients()).toBeUndefined();
-	expect(sessionHostWorkInFlight()).toBe(false);
+	expect(sessionHostAttachedClients()).toEqual(baseClients);
 });
 
 test("a reader that fails is no evidence, and never fakes attachment or work for a sibling", () => {
+	const baseClients = sessionHostAttachedClients();
+	const baseWork = sessionHostWorkInFlight();
 	const broken = publishSessionHostRuntimeEvidence({
 		attachedClients: () => {
 			throw new Error("native server is gone");
@@ -245,14 +252,14 @@ test("a reader that fails is no evidence, and never fakes attachment or work for
 		},
 	});
 	try {
-		expect(sessionHostAttachedClients()).toBeUndefined();
-		expect(sessionHostWorkInFlight()).toBe(false);
+		expect(sessionHostAttachedClients()).toEqual(baseClients);
+		expect(sessionHostWorkInFlight()).toBe(baseWork);
 		const healthy = publishSessionHostRuntimeEvidence({
 			attachedClients: () => 4,
 			workInFlight: () => true,
 		});
 		try {
-			expect(sessionHostAttachedClients()).toBe(4);
+			expect(sessionHostAttachedClients()).toBe((baseClients ?? 0) + 4);
 			expect(sessionHostWorkInFlight()).toBe(true);
 		} finally {
 			healthy.retract();
@@ -260,7 +267,7 @@ test("a reader that fails is no evidence, and never fakes attachment or work for
 	} finally {
 		broken.retract();
 	}
-	expect(sessionHostAttachedClients()).toBeUndefined();
+	expect(sessionHostAttachedClients()).toEqual(baseClients);
 });
 
 test("the broker drops registrations whose host process is gone, keeps live ones, and logs each reap", async () => {

--- a/packages/coding-agent/test/sdk-session-host-idle-reap.test.ts
+++ b/packages/coding-agent/test/sdk-session-host-idle-reap.test.ts
@@ -5,9 +5,10 @@ import * as path from "node:path";
 import { logger } from "@gajae-code/utils";
 import { watchSessionHostClientAttachment } from "../src/commands/sdk";
 import {
-	publishSessionHostAttachmentReader,
+	publishSessionHostRuntimeEvidence,
 	reapDeadSessionRegistrations,
 	sessionHostAttachedClients,
+	sessionHostWorkInFlight,
 } from "../src/sdk/broker/lifecycle";
 import { SessionIndex } from "../src/sdk/broker/session-index";
 
@@ -134,19 +135,130 @@ test("a host whose SDK endpoint never publishes attachment evidence still exits 
 	expect(nowMs).toBe(40);
 });
 
-test("the published attachment reader is the host's own client count and retracts to no-evidence", () => {
+test("a host with clients attached but never observed attached is not reaped while work is in flight", async () => {
+	const clock = { nowMs: 0 };
+	// The client connected, prompted and dropped its socket between two polls, so
+	// the count is never observed above zero — but the turn it asked for is running.
+	const outcome = await runUntilStable(
+		{
+			readAttachedClients: () => undefined,
+			readWorkInFlight: () => true,
+			idleGraceMs: 20,
+			firstAttachGraceMs: 40,
+			pollMs: 10,
+		},
+		200,
+		clock,
+	);
+	expect(outcome).toBe("still-running");
+	expect(clock.nowMs).toBe(2_000);
+});
+
+test("work in flight defers the first-attach bound to the end of the work, it does not remove it", async () => {
+	let nowMs = 0;
+	await watchSessionHostClientAttachment({
+		readAttachedClients: () => undefined,
+		readWorkInFlight: () => nowMs < 20,
+		now: () => nowMs,
+		sleep: async ms => {
+			nowMs += ms;
+		},
+		idleGraceMs: 20,
+		firstAttachGraceMs: 40,
+		pollMs: 10,
+	});
+	// Last work seen at 10ms; the full first-attach grace runs from there, not from start.
+	expect(nowMs).toBe(50);
+});
+
+test("a host whose SDK runtime never came up reports no work and still exits at the first-attach bound", async () => {
+	let nowMs = 0;
+	await watchSessionHostClientAttachment({
+		readAttachedClients: () => undefined,
+		readWorkInFlight: () => false,
+		now: () => nowMs,
+		sleep: async ms => {
+			nowMs += ms;
+		},
+		idleGraceMs: 20,
+		firstAttachGraceMs: 40,
+		pollMs: 10,
+	});
+	expect(nowMs).toBe(40);
+});
+
+test("published runtime evidence is the host's own client count and work, and retracts to no-evidence", () => {
 	let clients = 3;
-	publishSessionHostAttachmentReader(() => clients);
+	let busy = false;
+	const publication = publishSessionHostRuntimeEvidence({
+		attachedClients: () => clients,
+		workInFlight: () => busy,
+	});
 	try {
 		expect(sessionHostAttachedClients()).toBe(3);
+		expect(sessionHostWorkInFlight()).toBe(false);
 		clients = 0;
+		busy = true;
 		expect(sessionHostAttachedClients()).toBe(0);
-		publishSessionHostAttachmentReader(() => {
-			throw new Error("native server is gone");
-		});
-		expect(sessionHostAttachedClients()).toBeUndefined();
+		expect(sessionHostWorkInFlight()).toBe(true);
 	} finally {
-		publishSessionHostAttachmentReader(undefined);
+		publication.retract();
+	}
+	expect(sessionHostAttachedClients()).toBeUndefined();
+	expect(sessionHostWorkInFlight()).toBe(false);
+	// Retraction is idempotent and still owns nothing else.
+	publication.retract();
+	expect(sessionHostAttachedClients()).toBeUndefined();
+});
+
+test("a retracting runtime cannot clear the evidence of the runtime that succeeded it", () => {
+	const predecessor = publishSessionHostRuntimeEvidence({
+		attachedClients: () => 2,
+		workInFlight: () => false,
+	});
+	const successor = publishSessionHostRuntimeEvidence({
+		attachedClients: () => 1,
+		workInFlight: () => true,
+	});
+	try {
+		expect(sessionHostAttachedClients()).toBe(3);
+		// The predecessor's deferred teardown runs late, while the successor serves.
+		predecessor.retract();
+		expect(sessionHostAttachedClients()).toBe(1);
+		expect(sessionHostWorkInFlight()).toBe(true);
+		predecessor.retract();
+		expect(sessionHostAttachedClients()).toBe(1);
+	} finally {
+		successor.retract();
+	}
+	expect(sessionHostAttachedClients()).toBeUndefined();
+	expect(sessionHostWorkInFlight()).toBe(false);
+});
+
+test("a reader that fails is no evidence, and never fakes attachment or work for a sibling", () => {
+	const broken = publishSessionHostRuntimeEvidence({
+		attachedClients: () => {
+			throw new Error("native server is gone");
+		},
+		workInFlight: () => {
+			throw new Error("native server is gone");
+		},
+	});
+	try {
+		expect(sessionHostAttachedClients()).toBeUndefined();
+		expect(sessionHostWorkInFlight()).toBe(false);
+		const healthy = publishSessionHostRuntimeEvidence({
+			attachedClients: () => 4,
+			workInFlight: () => true,
+		});
+		try {
+			expect(sessionHostAttachedClients()).toBe(4);
+			expect(sessionHostWorkInFlight()).toBe(true);
+		} finally {
+			healthy.retract();
+		}
+	} finally {
+		broken.retract();
 	}
 	expect(sessionHostAttachedClients()).toBeUndefined();
 });

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -190,8 +190,33 @@ function installProcessStdoutWriteClassifier(): void {
 	process.stdout.write = markedWrite as typeof process.stdout.write;
 }
 
+/**
+ * Render a non-`Error` throwable so the crash record keeps its payload.
+ *
+ * `String(value)` collapses every plain object to `[object Object]`, which is
+ * exactly how SDK lifecycle startup failures (`{ phase, reason, message }` are
+ * thrown as records, not `Error`s) used to reach the log with no diagnostic
+ * left. Serialize own properties instead, and stay defensive: a throwing
+ * `toString`/`toJSON` or a cycle must never mask the original fatal.
+ */
+function describeThrowable(reason: unknown): string {
+	if (typeof reason === "object" && reason !== null) {
+		try {
+			const serialized = JSON.stringify(reason);
+			if (typeof serialized === "string") return serialized;
+		} catch {
+			// Cyclic or non-serializable payload; fall through to String().
+		}
+	}
+	try {
+		return String(reason);
+	} catch {
+		return "[unserializable throwable]";
+	}
+}
+
 function errorForDiagnostic(reason: unknown): Error {
-	return reason instanceof Error ? reason : new Error(String(reason));
+	return reason instanceof Error ? reason : new Error(describeThrowable(reason));
 }
 
 // Register signal and error event handlers to trigger cleanup before exit.

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -199,6 +199,19 @@ function installProcessStdoutWriteClassifier(): void {
  * left. Serialize own properties instead, and stay defensive: a throwing
  * `toString`/`toJSON` or a cycle must never mask the original fatal.
  */
+function isErrorLike(reason: unknown): reason is { name: string; message: string; stack?: string } {
+	if (typeof reason !== "object" || reason === null) return false;
+	try {
+		const error = reason as { name?: unknown; message?: unknown; stack?: unknown };
+		return (
+			typeof error.name === "string" &&
+			typeof error.message === "string" &&
+			(typeof error.stack === "string" || Object.prototype.toString.call(reason) === "[object Error]")
+		);
+	} catch {
+		return false;
+	}
+}
 function describeThrowable(reason: unknown): string {
 	if (typeof reason === "object" && reason !== null) {
 		try {
@@ -216,7 +229,13 @@ function describeThrowable(reason: unknown): string {
 }
 
 function errorForDiagnostic(reason: unknown): Error {
-	return reason instanceof Error ? reason : new Error(describeThrowable(reason));
+	if (reason instanceof Error) return reason;
+	if (!isErrorLike(reason)) return new Error(describeThrowable(reason));
+
+	const error = new Error(reason.message);
+	error.name = reason.name;
+	if (typeof reason.stack === "string") error.stack = reason.stack;
+	return error;
 }
 
 // Register signal and error event handlers to trigger cleanup before exit.

--- a/packages/utils/test/postmortem-crash-log.test.ts
+++ b/packages/utils/test/postmortem-crash-log.test.ts
@@ -53,6 +53,33 @@ describe("recordFatalCrash", () => {
 		expect(contents).toContain("Request was aborted");
 	});
 
+	it("keeps the payload of a non-Error object throwable", () => {
+		// SDK lifecycle startup failures are thrown as plain records, not Errors;
+		// String(record) used to reduce the whole crash to "[object Object]".
+		const target = tempCrashLog();
+		const written = recordFatalCrash(
+			"Uncaught Exception",
+			{ phase: "startup", reason: "pending", message: "SDK startup did not complete before readiness cutoff." },
+			{ path: target },
+		);
+		expect(written).toBe(target);
+		const contents = fs.readFileSync(target, "utf8");
+		expect(contents).not.toContain("[object Object]");
+		expect(contents).toContain('"phase":"startup"');
+		expect(contents).toContain('"reason":"pending"');
+		expect(contents).toContain("SDK startup did not complete before readiness cutoff.");
+	});
+
+	it("still records a throwable that cannot be serialized", () => {
+		const target = tempCrashLog();
+		const cyclic: { self?: unknown; marker: string } = { marker: "cyclic-throwable" };
+		cyclic.self = cyclic;
+		const written = recordFatalCrash("Unhandled Rejection", cyclic, { path: target });
+		expect(written).toBe(target);
+		const contents = fs.readFileSync(target, "utf8");
+		expect(contents).toContain("[Unhandled Rejection]");
+	});
+
 	it("appends successive crashes rather than overwriting", () => {
 		const target = tempCrashLog();
 		recordFatalCrash("Uncaught Exception", new Error("first"), { path: target });

--- a/packages/utils/test/postmortem-crossrealm.test.ts
+++ b/packages/utils/test/postmortem-crossrealm.test.ts
@@ -1,0 +1,32 @@
+import { expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as vm from "node:vm";
+import { recordFatalCrash } from "../src/postmortem";
+
+const tempCrashLog = (): string =>
+	path.join(fs.mkdtempSync(path.join(os.tmpdir(), "gjc-crossrealm-")), "gjc-crash.log");
+
+const record = (reason: unknown): string => {
+	const target = tempCrashLog();
+	recordFatalCrash("Uncaught Exception", reason, { path: target, now: new Date("2026-01-01T00:00:00.000Z") });
+	return fs.readFileSync(target, "utf8");
+};
+
+it("keeps the message and stack of a cross-realm Error", () => {
+	const thrown = vm.runInNewContext(
+		"(() => { const error = new Error('cross-realm boom'); error.stack = 'CrossRealmStack'; return error; })()",
+	) as unknown;
+	expect(thrown instanceof Error).toBe(false);
+
+	const contents = record(thrown);
+	expect(contents).toContain("Error: cross-realm boom");
+	expect(contents).toContain("CrossRealmStack");
+});
+
+it("keeps existing rendering for plain objects, strings, and null", () => {
+	expect(record({ phase: "startup", reason: "broken" })).toContain('Error: {"phase":"startup","reason":"broken"}');
+	expect(record("plain string")).toContain("Error: plain string");
+	expect(record(null)).toContain("Error: null");
+});


### PR DESCRIPTION
Scoped replacement for the SDK broker/host lifecycle portion of the closed #4021. Four commits, 15 files, one subsystem: **the broker and its session hosts must not leak, wedge, or fail without saying why.**

Fixes #3963, #4010, #4013, #3903. Every defect was reproduced on a real machine; three of them were actively breaking agent launches while this work was being done.

## The defects

**1. `session/new` intermittently reported `terminal_uncertain`, poisoning an ACP host** (`dd563b442`, #3903)
~29% failure in a large tree, 0% in small ones, non-deterministic. One failed probe marks the provider `status: "error"` for a host's entire lifetime, so gjc cannot be selected until the host restarts.

The race: a recovery pass stamps `terminal_uncertain` on every row it finds mid-flight, so a slow operation can have that marker interleaved before its own terminal row lands. `readTerminal` treated only `terminal_ok`/`terminal_error` as terminal, so it reported a row that **was on disk** as unpersisted and replaced its real reason with the generic uncertainty error. Reading back the durable record fixes the report at its source. A genuinely unverifiable terminal still reports `terminal_uncertain` — the signal is not suppressed.

**2. Memory phase-1 LLM jobs ran inside the readiness window** (`97b77562a`, #4013)
Every broker-launched session ran the local memory backend's stage-1 jobs synchronously inside the 10 s readiness budget. Whenever the queue had pending rollouts, those model calls ate the whole budget, the child was killed at the cutoff, and the broker answered `No ready SDK endpoint remains available.` Six such failures in ~15 h, and it recurred while running this very batch — it is why parallel agent launches intermittently refused to start.

Lifecycle sessions now defer memory startup as an invariant and resume it once readiness is published, unawaited, with failure logged rather than fatal. The ACP carve-out in `main.ts` goes away with it.

Deliberately **not** done: widening `READY_TIMEOUT_MS`. Startup work scales with rollout backlog and provider latency, so any constant is just a wider flake window.

Secondary half: `handleFatalError` collapsed a thrown record to `[object Object]`, which is why six earlier occurrences left no diagnostic at all. Non-`Error` throwables now keep their payload.

**3. Session hosts leaked indefinitely under a healthy broker** (`5b4c42576`, #4010)
`watchSessionHostBrokerLiveness` is conditioned on broker discovery going **absent**, and the default warm broker never disappears — so the grace window never opened. The other leg, `session.close`, is never issued by ordinary SDK usage. The reporter measured 119 leaked hosts holding 4.1 GB under one healthy 6-day broker; this machine reached 29 hosts for 9 agents with 20 holding **zero connections**, within hours.

Hosts now self-reap after a bounded idle interval with no attached client, and the broker drops registrations whose host is provably gone. Attachment is decided from the host's own subscription state — never by scraping `ps` or `lsof` — and a host that has not yet seen its first attachment survives a startup grace. `detached: true` + `unref()` stays; the spawn shape is deliberate, the missing bound was the bug.

**4. Stale broker lock artifacts accumulated, and a clean exit said nothing** (`b51ca2256`, #3963)
54 `.broker.lock.stale-*` tombstones, a 126 MB `lifecycle-ledger.jsonl.corrupt` beside a 6 MB live ledger, and a dead-owner lock that wedged startup — with `stdio: "ignore"` on the spawn, the caller saw only "exited before discovery". Confirmed live: 17 zombie processes from a deleted checkout held the lock and made every launch fail with `CLI entrypoint is not a readable regular file`.

Startup now reaps abandoned lock artifacts (after acquiring the lock, so concurrent brokers cannot race the removal), the corrupt sidecar rotates at a bounded size preserving the evidence, and the spawn writes a truncated per-spawn log whose stderr tail is attached to the discovery failure. Reaping is fail-closed: owner-alive, unreadable, or ambiguous artifacts are kept **with a reason**.

## Verification

Load-bearing proof — restoring `packages/coding-agent/src` and `packages/utils/src` from `origin/dev` and re-running the four new suites:

```
with fix:     170 pass / 0 fail
without fix:    2 pass / 6 fail
```

```
sdk-broker + lock-artifacts + lifecycle-e2e + host-idle-reap
  + memory-defer + terminal-evidence + postmortem-crash-log   170 pass / 0 fail
bun --cwd=packages/coding-agent run check                     exit 0
bun --cwd=packages/utils run check                            exit 0
```

Tests run against temp state roots only; the real `~/.gjc` is never touched.

## Relationship to #4021

#4021 bundled twelve unrelated defects into 53 files and was closed with the instruction to open fresh, scoped PRs. This is the third, after #4031 (ACP turn lifecycle) and #4033 (chat daemon reconnect). Remaining: gc/disk retention, tool diagnostics.

Closes #3963, #4010, #4013, #3903
