### PR TITLE
feat(gc): add an opt-in disk-retention pass

### DIFF
--- a/packages/coding-agent/src/commands/gc.ts
+++ b/packages/coding-agent/src/commands/gc.ts
@@ -1,5 +1,21 @@
 import { Command, Flags } from "@gajae-code/utils/cli";
-import { runGjcGcCommand } from "../gjc-runtime/gc-runtime";
+import { isSettingsInitialized, settings } from "../config/settings";
+import { type GcDiskPolicy, runGjcGcCommand } from "../gjc-runtime/gc-runtime";
+
+/**
+ * Resolve the `gc.*` retention knobs from settings. When settings are not
+ * initialized (headless/early invocation) the runtime falls back to its
+ * schema-backed defaults, so this returns nothing rather than guessing.
+ */
+function resolveDiskPolicyFromSettings(): Partial<GcDiskPolicy> | undefined {
+	if (!isSettingsInitialized()) return undefined;
+	return {
+		sessions_max_age_days: settings.get("gc.sessions.maxAgeDays"),
+		sessions_max_total_bytes: settings.get("gc.sessions.maxTotalBytes"),
+		natives_keep_versions: settings.get("gc.natives.keepVersions"),
+		backups_max_age_days: settings.get("gc.backups.maxAgeDays"),
+	};
+}
 
 export default class Gc extends Command {
 	static description = "Garbage-collect stale GJC session/PID records (dry-run by default)";
@@ -9,6 +25,10 @@ export default class Gc extends Command {
 		prune: Flags.boolean({ description: "Remove stale records (default: report only)", default: false }),
 		force: Flags.boolean({ description: "Alias for --prune (eligible records only)", default: false }),
 		"dry-run": Flags.boolean({ description: "Force report-only mode", default: false }),
+		disk: Flags.boolean({
+			description: "Also report on-disk retention (sessions, blobs, natives, backups)",
+			default: false,
+		}),
 		"repair-session-index": Flags.boolean({
 			description: "Quarantine a corrupt session-index suffix and retain its valid prefix",
 			default: false,
@@ -20,11 +40,20 @@ export default class Gc extends Command {
 		"gjc gc --json",
 		"gjc gc --prune",
 		"gjc gc --prune --json",
+		"gjc gc --disk",
+		"gjc gc --disk --json",
+		"gjc gc --disk --prune",
 		"gjc gc --repair-session-index --json",
 	];
 
 	async run(): Promise<void> {
-		const result = await runGjcGcCommand(this.argv, process.cwd(), process.env);
+		const result = await runGjcGcCommand(
+			this.argv,
+			process.cwd(),
+			process.env,
+			undefined,
+			resolveDiskPolicyFromSettings(),
+		);
 		if (result.stdout) process.stdout.write(result.stdout);
 		if (result.stderr) process.stderr.write(result.stderr);
 		process.exitCode = result.status;

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2810,6 +2810,29 @@ export const SETTINGS_SCHEMA = {
 			description: "Parent-process RSS (MB) above which idle tabs are opportunistically evicted LRU.",
 		},
 	},
+	// `gjc gc --disk` retention policy. Report-only unless `--prune` is also passed;
+	// these knobs never run implicitly and never affect the PID-liveness axis.
+	"gc.sessions.maxAgeDays": {
+		type: "number",
+		default: 60,
+		validate: (value: number) => Number.isFinite(value) && value >= 0,
+	},
+	// 0 disables the size axis; only the age axis retires transcripts then.
+	"gc.sessions.maxTotalBytes": {
+		type: "number",
+		default: 0,
+		validate: (value: number) => Number.isFinite(value) && value >= 0,
+	},
+	"gc.natives.keepVersions": {
+		type: "number",
+		default: 2,
+		validate: (value: number) => Number.isInteger(value) && value >= 0,
+	},
+	"gc.backups.maxAgeDays": {
+		type: "number",
+		default: 30,
+		validate: (value: number) => Number.isFinite(value) && value >= 0,
+	},
 	"resourceGc.sweepIntervalMs": {
 		type: "number",
 		default: 30_000,

--- a/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
@@ -13,9 +13,23 @@
  * - Dry-run by default: nothing is deleted unless `--prune`/`--force`.
  */
 
-import { getAgentDir } from "@gajae-code/utils";
+import type { Dirent, Stats } from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getAgentDir, getBlobsDir, getSessionsDir, isEnoent, VERSION } from "@gajae-code/utils";
+import { getDefault } from "../config/settings-schema";
+import { listHarnessRootRegistriesForGc } from "../harness-control-plane/storage";
 import { SessionIndex } from "../sdk/broker/session-index";
 import { UnsupportedStateVersionError } from "../sdk/broker/state-version";
+import {
+	BLOB_REFERENCE_MAX_LENGTH,
+	type CanonicalBlobEntry,
+	collectBlobReferences,
+	listCanonicalBlobs,
+	removeCanonicalBlob,
+} from "../session/blob-store";
+import { FileSessionStorage, retireSessionTranscript } from "../session/session-storage";
 
 import { buildGcReportText } from "./gc-render";
 import { collectSessionScopeUsage, type GcSessionScopeUsage, shouldReportSessionScope } from "./gc-session-scope";
@@ -155,6 +169,11 @@ export interface GcReport {
 	session_index?: GcSessionIndexHealth;
 	/** Managed-scope capacity, reported only when it is near or past the budget. */
 	session_scope?: GcSessionScopeUsage;
+	/**
+	 * Disk-retention findings. Present only when `--disk` was passed; the
+	 * PID-liveness axis above is unchanged by its absence or presence.
+	 */
+	disk?: GcDiskReport;
 }
 
 export interface GcRunResult {
@@ -261,6 +280,8 @@ interface ParsedGcArgs {
 	json: boolean;
 	prune: boolean;
 	repairSessionIndex: boolean;
+	/** Opt-in second axis: report (and with `--prune`, reclaim) on-disk retention. */
+	disk: boolean;
 	help: boolean;
 }
 
@@ -270,6 +291,7 @@ function parseGcArgs(argv: string[]): ParsedGcArgs {
 	let json = false;
 	let prune = false;
 	let repairSessionIndex = false;
+	let disk = false;
 
 	let dryRun = false;
 	let help = false;
@@ -285,6 +307,9 @@ function parseGcArgs(argv: string[]): ParsedGcArgs {
 				break;
 			case "--repair-session-index":
 				repairSessionIndex = true;
+				break;
+			case "--disk":
+				disk = true;
 				break;
 
 			case "--dry-run":
@@ -302,7 +327,7 @@ function parseGcArgs(argv: string[]): ParsedGcArgs {
 	if (repairSessionIndex && dryRun) throw new GcUsageError("repair_session_index_cannot_combine_with_dry_run");
 	// Explicit --dry-run always wins over --prune/--force.
 	if (dryRun) prune = false;
-	return { json, prune, repairSessionIndex, help };
+	return { json, prune, repairSessionIndex, disk, help };
 }
 
 /**
@@ -376,10 +401,19 @@ export async function collectGcReport(adapters: GcStoreAdapter[], ctx: GcContext
  * - prune mode with a failed intended removal => 1
  * - warnings alone never fail the run
  * - otherwise => 0
+ *
+ * The disk axis reuses the same policy against its own errors/failures, and is
+ * inert when `--disk` was not passed (`report.disk` is then undefined). A
+ * fail-closed KEEP is never a failure — only a hard scan error or a reclaim
+ * that was attempted and threw.
  */
 export function computeExitCode(report: GcReport): number {
 	if (report.errors.length > 0) return 1;
 	if (!report.dry_run && report.counts.failed > 0) return 1;
+	if (report.disk) {
+		if (report.disk.errors.length > 0) return 1;
+		if (!report.disk.dry_run && report.disk.totals.failed > 0) return 1;
+	}
 	return 0;
 }
 
@@ -440,6 +474,7 @@ export async function runGjcGcCommand(
 	cwd: string = process.cwd(),
 	env: NodeJS.ProcessEnv = process.env,
 	adapters?: GcStoreAdapter[],
+	diskPolicy?: Partial<GcDiskPolicy>,
 ): Promise<GcRunResult> {
 	let parsed: ParsedGcArgs;
 	try {
@@ -458,6 +493,14 @@ export async function runGjcGcCommand(
 	const report = await collectGcReport(resolvedAdapters, ctx, parsed.prune);
 	report.operation = parsed.repairSessionIndex ? "repair_session_index" : parsed.prune ? "prune" : "dry_run";
 	report.session_index = await collectSessionIndexHealth(parsed.repairSessionIndex, resolveGcAgentDir(env));
+	if (parsed.disk) {
+		report.disk = await collectGcDiskReport({
+			agentDir: resolveGcAgentDir(env),
+			env,
+			policy: resolveGcDiskPolicy(diskPolicy),
+			prune: parsed.prune,
+		});
+	}
 	const scopeUsage = await collectGcSessionScope(cwd, resolveGcAgentDir(env));
 	if (scopeUsage && shouldReportSessionScope(scopeUsage)) report.session_scope = scopeUsage;
 	const sessionIndexFailed =
@@ -465,7 +508,9 @@ export async function runGjcGcCommand(
 		report.session_index?.status === "unsupported" ||
 		report.session_index?.status === "repair_failed";
 	const status = sessionIndexFailed ? 1 : computeExitCode(report);
-	const stdout = parsed.json ? `${JSON.stringify(report, null, 2)}\n` : buildGcReportText(report);
+	const stdout = parsed.json
+		? `${JSON.stringify(report, null, 2)}\n`
+		: `${buildGcReportText(report)}${report.disk ? buildGcDiskReportText(report.disk) : ""}`;
 	return { stdout, stderr: "", status };
 }
 
@@ -474,7 +519,7 @@ export function gcHelpText(): string {
 		"gjc gc - garbage-collect stale GJC session/PID records",
 		"",
 		"USAGE",
-		"  $ gjc gc [--prune|--force] [--repair-session-index] [--json]",
+		"  $ gjc gc [--prune|--force] [--disk] [--repair-session-index] [--json]",
 
 		"",
 		"FLAGS",
@@ -482,9 +527,15 @@ export function gcHelpText(): string {
 		"  --dry-run         Force report-only mode (overrides --prune/--force)",
 		"  -j, --json        Emit machine-readable JSON",
 		"  --repair-session-index  Explicitly quarantine a corrupt session-index suffix and retain its valid prefix",
+		"  --disk            Also report on-disk retention (sessions, blobs, natives, backups)",
 		"",
 		"Liveness-only: a record is removed only when its owning process is dead",
 		"(ESRCH). Live / permission-denied / unknown processes are always kept.",
+		"",
+		"Disk retention (--disk) is a separate, opt-in axis. Without --prune it only",
+		"reports reclaimable bytes per surface. Live, referenced, permission-denied or",
+		"otherwise ambiguous state is always KEPT and the report says why. Managed",
+		"worktrees under ~/.gjc/wt are never touched.",
 		"",
 	].join("\n");
 }
@@ -512,4 +563,869 @@ export async function defaultGcAdapters(): Promise<GcStoreAdapter[]> {
 		registryEntriesGcAdapter,
 		localRootsGcAdapter,
 	];
+}
+
+// =============================================================================
+// Disk-retention axis (`gjc gc --disk`)
+// =============================================================================
+//
+// A second, explicitly opt-in axis. The PID-liveness axis above answers "is the
+// owner of this record dead?"; this one answers "are these bytes still reachable
+// from anything live?". Both share the same posture: dry-run by default, and
+// anything live, referenced, permission-denied, unreadable or ambiguous is KEPT
+// with the reason recorded in the report.
+//
+// Deliberately out of scope: `~/.gjc/wt` managed worktrees. Removing a worktree
+// needs evidence-based merge detection, which this axis does not have.
+
+/** On-disk surfaces the retention axis can reclaim. */
+export type GcDiskSurface = "sessions" | "blobs" | "natives" | "backups";
+
+export const GC_DISK_SURFACES: readonly GcDiskSurface[] = ["sessions", "blobs", "natives", "backups"] as const;
+
+export type GcDiskAction = "keep" | "would_reclaim" | "reclaimed" | "reclaim_failed";
+
+export interface GcDiskRecord {
+	surface: GcDiskSurface;
+	/** Session id, blob hash, natives version, or backup entry name. */
+	id: string;
+	path: string;
+	bytes: number;
+	age_days: number;
+	action: GcDiskAction;
+	reason: string;
+	error?: string;
+	/** Set when `bytes` is a floor because a walk was capped or partially unreadable. */
+	partial?: true;
+}
+
+export interface GcDiskSurfaceReport {
+	surface: GcDiskSurface;
+	root: string;
+	scanned: number;
+	scanned_bytes: number;
+	reclaimable: number;
+	reclaimable_bytes: number;
+	reclaimed: number;
+	reclaimed_bytes: number;
+	kept: number;
+	kept_bytes: number;
+	failed: number;
+	records: GcDiskRecord[];
+}
+
+export interface GcDiskError {
+	surface: GcDiskSurface;
+	scope: string;
+	message: string;
+}
+
+/** Retention policy, mirroring the `gc.*` settings one-for-one. */
+export interface GcDiskPolicy {
+	sessions_max_age_days: number;
+	/** 0 disables the size axis; only the age axis retires transcripts then. */
+	sessions_max_total_bytes: number;
+	natives_keep_versions: number;
+	backups_max_age_days: number;
+}
+
+export interface GcDiskReport {
+	dry_run: boolean;
+	policy: GcDiskPolicy;
+	surfaces: Record<GcDiskSurface, GcDiskSurfaceReport>;
+	totals: {
+		scanned_bytes: number;
+		reclaimable_bytes: number;
+		reclaimed_bytes: number;
+		kept_bytes: number;
+		failed: number;
+	};
+	errors: GcDiskError[];
+}
+
+const GC_DISK_DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * A blob younger than this is never swept: a live session may have written the
+ * bytes but not yet appended the entry that references them.
+ */
+const GC_DISK_BLOB_GRACE_MS = GC_DISK_DAY_MS;
+
+/** Bound every recursive size walk so a pathological tree cannot stall `gjc gc`. */
+const GC_DISK_MAX_WALK_ENTRIES = 200_000;
+
+/** Cap per-surface record rendering; the JSON output always carries every record. */
+const GC_DISK_MAX_RENDERED_RECORDS = 20;
+
+/** Schema-backed defaults, so the CLI and the settings surface cannot drift. */
+export const GC_DISK_POLICY_DEFAULTS: GcDiskPolicy = {
+	sessions_max_age_days: getDefault("gc.sessions.maxAgeDays"),
+	sessions_max_total_bytes: getDefault("gc.sessions.maxTotalBytes"),
+	natives_keep_versions: getDefault("gc.natives.keepVersions"),
+	backups_max_age_days: getDefault("gc.backups.maxAgeDays"),
+};
+
+export function resolveGcDiskPolicy(overrides: Partial<GcDiskPolicy> = {}): GcDiskPolicy {
+	return {
+		sessions_max_age_days: overrides.sessions_max_age_days ?? GC_DISK_POLICY_DEFAULTS.sessions_max_age_days,
+		sessions_max_total_bytes: overrides.sessions_max_total_bytes ?? GC_DISK_POLICY_DEFAULTS.sessions_max_total_bytes,
+		natives_keep_versions: overrides.natives_keep_versions ?? GC_DISK_POLICY_DEFAULTS.natives_keep_versions,
+		backups_max_age_days: overrides.backups_max_age_days ?? GC_DISK_POLICY_DEFAULTS.backups_max_age_days,
+	};
+}
+
+function gcDiskErrorText(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function gcDiskAgeDays(now: number, mtimeMs: number): number {
+	return Math.round(((now - mtimeMs) / GC_DISK_DAY_MS) * 100) / 100;
+}
+
+function emptyGcDiskSurface(surface: GcDiskSurface, root: string): GcDiskSurfaceReport {
+	return {
+		surface,
+		root,
+		scanned: 0,
+		scanned_bytes: 0,
+		reclaimable: 0,
+		reclaimable_bytes: 0,
+		reclaimed: 0,
+		reclaimed_bytes: 0,
+		kept: 0,
+		kept_bytes: 0,
+		failed: 0,
+		records: [],
+	};
+}
+
+function summarizeGcDiskSurface(report: GcDiskSurfaceReport): void {
+	report.scanned = report.records.length;
+	report.scanned_bytes = 0;
+	report.reclaimable = 0;
+	report.reclaimable_bytes = 0;
+	report.reclaimed = 0;
+	report.reclaimed_bytes = 0;
+	report.kept = 0;
+	report.kept_bytes = 0;
+	report.failed = 0;
+	for (const record of report.records) {
+		report.scanned_bytes += record.bytes;
+		switch (record.action) {
+			case "would_reclaim":
+				report.reclaimable++;
+				report.reclaimable_bytes += record.bytes;
+				break;
+			case "reclaimed":
+				report.reclaimed++;
+				report.reclaimed_bytes += record.bytes;
+				break;
+			case "reclaim_failed":
+				report.failed++;
+				report.kept_bytes += record.bytes;
+				break;
+			default:
+				report.kept++;
+				report.kept_bytes += record.bytes;
+		}
+	}
+}
+
+/** Recursive, bounded byte count. Symlinks are never followed and never counted. */
+async function measureGcDiskTree(root: string): Promise<{ bytes: number; partial: boolean }> {
+	let bytes = 0;
+	let visited = 0;
+	let partial = false;
+	const stack: string[] = [root];
+	while (stack.length > 0) {
+		const dir = stack.pop()!;
+		let entries: Dirent[];
+		try {
+			entries = await fsp.readdir(dir, { withFileTypes: true });
+		} catch (error) {
+			if (!isEnoent(error)) partial = true;
+			continue;
+		}
+		for (const entry of entries) {
+			if (visited >= GC_DISK_MAX_WALK_ENTRIES) return { bytes, partial: true };
+			visited++;
+			const child = path.join(dir, entry.name);
+			if (entry.isSymbolicLink()) {
+				partial = true;
+				continue;
+			}
+			if (entry.isDirectory()) {
+				stack.push(child);
+				continue;
+			}
+			if (!entry.isFile()) continue;
+			try {
+				bytes += (await fsp.lstat(child)).size;
+			} catch {
+				partial = true;
+			}
+		}
+	}
+	return { bytes, partial };
+}
+
+/**
+ * Session ids reachable from a live surface. `complete: false` means at least
+ * one reference source could not be enumerated, in which case NO session may be
+ * retired — an unproven reference is treated as a live one.
+ */
+interface GcSessionReferences {
+	ids: Set<string>;
+	complete: boolean;
+	notes: string[];
+}
+
+async function collectGcSessionReferences(agentDir: string, env: NodeJS.ProcessEnv): Promise<GcSessionReferences> {
+	const ids = new Set<string>();
+	const notes: string[] = [];
+	let complete = true;
+	const incomplete = (note: string): void => {
+		complete = false;
+		if (!notes.includes(note)) notes.push(note);
+	};
+
+	// 1. Harness root registries and every per-session lease directory beneath
+	//    their roots. A registry entry or a session directory is a reference even
+	//    when its lease owner is already dead: the liveness axis reaps those.
+	try {
+		for (const registry of await listHarnessRootRegistriesForGc(env)) {
+			if (registry.error) {
+				incomplete("harness_root_registry_unreadable");
+				continue;
+			}
+			if (registry.sessionId) ids.add(registry.sessionId);
+			for (const entry of registry.roots) {
+				const harnessSessions = path.join(path.resolve(entry.root), "sessions");
+				try {
+					for (const name of await fsp.readdir(harnessSessions)) ids.add(name);
+				} catch (error) {
+					if (!isEnoent(error)) incomplete("harness_session_dir_unreadable");
+				}
+			}
+		}
+	} catch {
+		incomplete("harness_root_registry_scan_failed");
+	}
+
+	// 2. SDK hosts registered in the broker session index.
+	const indexDir = path.join(agentDir, "sdk", "sessions");
+	const indexFiles = [path.join(indexDir, "index.jsonl"), path.join(indexDir, "index.snapshot.json")];
+	let indexPresent = false;
+	for (const file of indexFiles) {
+		try {
+			await fsp.stat(file);
+			indexPresent = true;
+		} catch (error) {
+			if (!isEnoent(error)) incomplete("sdk_session_index_unreadable");
+		}
+	}
+	if (indexPresent) {
+		try {
+			const index = new SessionIndex(agentDir);
+			await index.replay();
+			for (const session of index.listSessions().sessions) ids.add(session.sessionId);
+		} catch {
+			incomplete("sdk_session_index_replay_failed");
+		}
+	}
+
+	// 3. `local://` session roots: one directory per session id.
+	const localRoots = path.join(env.TMPDIR?.trim() || os.tmpdir(), "gjc-local");
+	try {
+		for (const name of await fsp.readdir(localRoots)) ids.add(name);
+	} catch (error) {
+		if (!isEnoent(error)) incomplete("local_root_parent_unreadable");
+	}
+
+	return { ids, complete, notes };
+}
+
+/** One managed session transcript plus its sibling artifact directory. */
+interface GcDiskTranscript {
+	sessionId: string;
+	path: string;
+	directory: string;
+	bytes: number;
+	mtimeMs: number;
+	partial: boolean;
+}
+
+async function discoverGcDiskTranscripts(sessionsRoot: string, errors: GcDiskError[]): Promise<GcDiskTranscript[]> {
+	let projectDirs: Dirent[];
+	try {
+		projectDirs = await fsp.readdir(sessionsRoot, { withFileTypes: true });
+	} catch (error) {
+		if (!isEnoent(error)) errors.push({ surface: "sessions", scope: sessionsRoot, message: gcDiskErrorText(error) });
+		return [];
+	}
+
+	const transcripts: GcDiskTranscript[] = [];
+	for (const projectDir of projectDirs) {
+		if (!projectDir.isDirectory() || projectDir.isSymbolicLink()) continue;
+		const directory = path.join(sessionsRoot, projectDir.name);
+		let files: Dirent[];
+		try {
+			files = await fsp.readdir(directory, { withFileTypes: true });
+		} catch (error) {
+			errors.push({ surface: "sessions", scope: directory, message: gcDiskErrorText(error) });
+			continue;
+		}
+		for (const file of files) {
+			if (!file.name.endsWith(".jsonl") || !file.isFile() || file.isSymbolicLink()) continue;
+			const transcriptPath = path.join(directory, file.name);
+			let stat: Stats;
+			try {
+				stat = await fsp.lstat(transcriptPath);
+			} catch (error) {
+				errors.push({ surface: "sessions", scope: transcriptPath, message: gcDiskErrorText(error) });
+				continue;
+			}
+			const artifacts = await measureGcDiskTree(transcriptPath.slice(0, -".jsonl".length));
+			transcripts.push({
+				sessionId: file.name.slice(0, -".jsonl".length),
+				path: transcriptPath,
+				directory,
+				bytes: stat.size + artifacts.bytes,
+				mtimeMs: stat.mtimeMs,
+				partial: artifacts.partial,
+			});
+		}
+	}
+	return transcripts;
+}
+
+/**
+ * Classify (and optionally retire) session transcripts. Returns the transcripts
+ * that survived, which is exactly the mark set for the blob sweep.
+ */
+async function runGcDiskSessions(input: {
+	surface: GcDiskSurfaceReport;
+	transcripts: GcDiskTranscript[];
+	references: GcSessionReferences;
+	policy: GcDiskPolicy;
+	now: number;
+	prune: boolean;
+}): Promise<GcDiskTranscript[]> {
+	const { surface, transcripts, references, policy, now, prune } = input;
+	const maxAgeMs = policy.sessions_max_age_days * GC_DISK_DAY_MS;
+
+	// The newest transcript in each project directory is the `--continue` resume
+	// target, so it is never a retention candidate regardless of age.
+	const newestPerDirectory = new Map<string, GcDiskTranscript>();
+	for (const transcript of transcripts) {
+		const current = newestPerDirectory.get(transcript.directory);
+		if (!current || transcript.mtimeMs > current.mtimeMs) newestPerDirectory.set(transcript.directory, transcript);
+	}
+
+	interface Classified {
+		transcript: GcDiskTranscript;
+		record: GcDiskRecord;
+		/** Only transcripts kept purely because they are recent may be retired for size. */
+		sizeEligible: boolean;
+	}
+
+	const classified: Classified[] = [];
+	for (const transcript of transcripts) {
+		const record: GcDiskRecord = {
+			surface: "sessions",
+			id: transcript.sessionId,
+			path: transcript.path,
+			bytes: transcript.bytes,
+			age_days: gcDiskAgeDays(now, transcript.mtimeMs),
+			action: "keep",
+			reason: "",
+			...(transcript.partial ? { partial: true as const } : {}),
+		};
+		let sizeEligible = false;
+		if (!references.complete) {
+			record.reason = `reference_scan_incomplete: ${references.notes.join(", ")}`;
+		} else if (references.ids.has(transcript.sessionId)) {
+			record.reason = "referenced_by_live_surface";
+		} else if (newestPerDirectory.get(transcript.directory) === transcript) {
+			record.reason = "most_recent_resumable_session";
+		} else if (now - transcript.mtimeMs < maxAgeMs) {
+			record.reason = `newer_than_max_age(${policy.sessions_max_age_days}d)`;
+			sizeEligible = true;
+		} else {
+			record.action = "would_reclaim";
+			record.reason = `older_than_max_age(${policy.sessions_max_age_days}d)`;
+		}
+		classified.push({ transcript, record, sizeEligible });
+		surface.records.push(record);
+	}
+
+	// Size axis: when the store would still be over budget after the age pass,
+	// retire the oldest recent-but-unreferenced transcripts until it fits. A
+	// liveness keep is never overridden.
+	if (policy.sessions_max_total_bytes > 0) {
+		let projected = classified.reduce(
+			(sum, item) => (item.record.action === "would_reclaim" ? sum : sum + item.transcript.bytes),
+			0,
+		);
+		if (projected > policy.sessions_max_total_bytes) {
+			const eligible = classified
+				.filter(item => item.sizeEligible && item.record.action === "keep")
+				.sort((a, b) => a.transcript.mtimeMs - b.transcript.mtimeMs);
+			for (const item of eligible) {
+				if (projected <= policy.sessions_max_total_bytes) break;
+				item.record.action = "would_reclaim";
+				item.record.reason = `over_max_total_bytes(${policy.sessions_max_total_bytes})`;
+				projected -= item.transcript.bytes;
+			}
+		}
+	}
+
+	if (!prune) return classified.filter(item => item.record.action !== "would_reclaim").map(item => item.transcript);
+
+	// Retirement goes through the identity-bound verified delete authority, which
+	// re-reads and re-verifies the transcript. A declined retirement is a KEEP,
+	// not a failure — the same posture the pid probe takes on EPERM/unknown.
+	const storage = new FileSessionStorage();
+	const survivors: GcDiskTranscript[] = [];
+	for (const item of classified) {
+		if (item.record.action !== "would_reclaim") {
+			survivors.push(item.transcript);
+			continue;
+		}
+		const outcome = await retireSessionTranscript(storage, surface.root, item.transcript.path);
+		if (outcome.kind === "retired") {
+			item.record.action = "reclaimed";
+			continue;
+		}
+		item.record.action = "keep";
+		item.record.reason = `retention_declined: ${outcome.reason}`;
+		survivors.push(item.transcript);
+	}
+	return survivors;
+}
+
+/** Stream a transcript and collect every blob reference it still holds. */
+async function markGcDiskBlobReferences(transcriptPath: string, into: Set<string>): Promise<boolean> {
+	try {
+		const decoder = new TextDecoder("utf-8");
+		let carry = "";
+		for await (const chunk of Bun.file(transcriptPath).stream()) {
+			const text = carry + decoder.decode(chunk, { stream: true });
+			collectBlobReferences(text, into);
+			// Retain a reference-length tail so a hash split across chunks is still seen.
+			carry = text.slice(-BLOB_REFERENCE_MAX_LENGTH);
+		}
+		collectBlobReferences(carry + decoder.decode(), into);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function runGcDiskBlobs(input: {
+	surface: GcDiskSurfaceReport;
+	survivors: GcDiskTranscript[];
+	now: number;
+	prune: boolean;
+	errors: GcDiskError[];
+}): Promise<void> {
+	const { surface, survivors, now, prune, errors } = input;
+	let blobs: CanonicalBlobEntry[];
+	try {
+		blobs = await listCanonicalBlobs(surface.root);
+	} catch (error) {
+		errors.push({ surface: "blobs", scope: surface.root, message: gcDiskErrorText(error) });
+		return;
+	}
+	if (blobs.length === 0) return;
+
+	const referenced = new Set<string>();
+	let markComplete = true;
+	for (const transcript of survivors) {
+		if (await markGcDiskBlobReferences(transcript.path, referenced)) continue;
+		markComplete = false;
+		errors.push({ surface: "blobs", scope: transcript.path, message: "transcript_unreadable_during_mark" });
+	}
+
+	for (const blob of blobs) {
+		const record: GcDiskRecord = {
+			surface: "blobs",
+			id: blob.hash,
+			path: blob.path,
+			bytes: blob.bytes,
+			age_days: gcDiskAgeDays(now, blob.mtimeMs),
+			action: "keep",
+			reason: "",
+		};
+		if (!markComplete) record.reason = "mark_scan_incomplete";
+		else if (referenced.has(blob.hash)) record.reason = "referenced_by_surviving_session";
+		else if (now - blob.mtimeMs < GC_DISK_BLOB_GRACE_MS) record.reason = "within_write_grace_window";
+		else {
+			record.action = "would_reclaim";
+			record.reason = "unreferenced_by_any_surviving_session";
+		}
+		surface.records.push(record);
+
+		if (!prune || record.action !== "would_reclaim") continue;
+		const removal = await removeCanonicalBlob(blob);
+		if (removal.removed) {
+			record.action = "reclaimed";
+		} else if (removal.failed) {
+			record.action = "reclaim_failed";
+			record.reason = removal.reason;
+			record.error = removal.reason;
+		} else {
+			record.action = "keep";
+			record.reason = removal.reason;
+		}
+	}
+}
+
+/** Numeric `major.minor.patch` prefix, or undefined when the name is not a version. */
+function parseGcDiskVersion(value: string): [number, number, number] | undefined {
+	const match = /^v?(\d+)\.(\d+)\.(\d+)/.exec(value);
+	if (!match) return undefined;
+	return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareGcDiskVersions(a: [number, number, number], b: [number, number, number]): number {
+	for (let index = 0; index < 3; index++) {
+		if (a[index] !== b[index]) return a[index] - b[index];
+	}
+	return 0;
+}
+
+async function runGcDiskNatives(input: {
+	surface: GcDiskSurfaceReport;
+	policy: GcDiskPolicy;
+	now: number;
+	prune: boolean;
+	errors: GcDiskError[];
+	runningVersion: string;
+}): Promise<void> {
+	const { surface, policy, now, prune, errors, runningVersion } = input;
+	let entries: Dirent[];
+	try {
+		entries = await fsp.readdir(surface.root, { withFileTypes: true });
+	} catch (error) {
+		if (!isEnoent(error)) errors.push({ surface: "natives", scope: surface.root, message: gcDiskErrorText(error) });
+		return;
+	}
+
+	const running = parseGcDiskVersion(runningVersion);
+	const versioned = entries
+		.filter(entry => entry.isDirectory() && !entry.isSymbolicLink())
+		.map(entry => ({ name: entry.name, version: parseGcDiskVersion(entry.name) }));
+	const ordered = versioned
+		.filter((entry): entry is { name: string; version: [number, number, number] } => entry.version !== undefined)
+		.sort((a, b) => compareGcDiskVersions(b.version, a.version) || b.name.localeCompare(a.name));
+
+	// Keep the running version, anything newer than it, and the configured number
+	// of immediate predecessors. Everything else is a cached leftover.
+	const keep = new Set<string>();
+	let predecessors = 0;
+	for (const entry of ordered) {
+		if (!running || compareGcDiskVersions(entry.version, running) >= 0) {
+			keep.add(entry.name);
+			continue;
+		}
+		if (predecessors < policy.natives_keep_versions) {
+			keep.add(entry.name);
+			predecessors++;
+		}
+	}
+
+	for (const entry of versioned) {
+		const directory = path.join(surface.root, entry.name);
+		let stat: Stats;
+		try {
+			stat = await fsp.lstat(directory);
+		} catch (error) {
+			errors.push({ surface: "natives", scope: directory, message: gcDiskErrorText(error) });
+			continue;
+		}
+		const usage = await measureGcDiskTree(directory);
+		const record: GcDiskRecord = {
+			surface: "natives",
+			id: entry.name,
+			path: directory,
+			bytes: usage.bytes,
+			age_days: gcDiskAgeDays(now, stat.mtimeMs),
+			action: "keep",
+			reason: "",
+			...(usage.partial ? { partial: true as const } : {}),
+		};
+		if (!entry.version) record.reason = "unrecognized_version_directory";
+		else if (entry.name === runningVersion) record.reason = "running_version";
+		else if (keep.has(entry.name)) record.reason = `retained_version(keepVersions=${policy.natives_keep_versions})`;
+		else {
+			record.action = "would_reclaim";
+			record.reason = `beyond_keep_versions(${policy.natives_keep_versions})`;
+		}
+		surface.records.push(record);
+
+		if (!prune || record.action !== "would_reclaim") continue;
+		const removal = await removeGcDiskEntry(directory, stat);
+		if (removal.removed) record.action = "reclaimed";
+		else if (removal.failed) {
+			record.action = "reclaim_failed";
+			record.reason = removal.reason;
+			record.error = removal.reason;
+		} else {
+			record.action = "keep";
+			record.reason = removal.reason;
+		}
+	}
+}
+
+/**
+ * Remove one directory/file entry, fail-closed on identity drift. Anything that
+ * changed inode or mtime between classification and removal is left alone.
+ */
+async function removeGcDiskEntry(
+	target: string,
+	expected: Stats,
+): Promise<{ removed: true } | { removed: false; reason: string; failed?: true }> {
+	let current: Stats;
+	try {
+		current = await fsp.lstat(target);
+	} catch (error) {
+		if (isEnoent(error)) return { removed: false, reason: "entry_disappeared" };
+		return { removed: false, reason: `entry_unverifiable: ${gcDiskErrorText(error)}`, failed: true };
+	}
+	if (current.isSymbolicLink()) return { removed: false, reason: "entry_is_symlink" };
+	if (current.ino !== expected.ino || current.dev !== expected.dev) {
+		return { removed: false, reason: "entry_identity_changed" };
+	}
+	if (current.mtimeMs !== expected.mtimeMs) return { removed: false, reason: "entry_changed" };
+	try {
+		await fsp.rm(target, { recursive: true, force: false });
+		return { removed: true };
+	} catch (error) {
+		if (isEnoent(error)) return { removed: false, reason: "entry_disappeared" };
+		return { removed: false, reason: `entry_remove_failed: ${gcDiskErrorText(error)}`, failed: true };
+	}
+}
+
+async function runGcDiskBackups(input: {
+	surface: GcDiskSurfaceReport;
+	gjcRoot: string;
+	policy: GcDiskPolicy;
+	now: number;
+	prune: boolean;
+	errors: GcDiskError[];
+}): Promise<void> {
+	const { surface, gjcRoot, policy, now, prune, errors } = input;
+	const maxAgeMs = policy.backups_max_age_days * GC_DISK_DAY_MS;
+	const candidates: Array<{ id: string; path: string }> = [];
+
+	// `~/.gjc/backups/<entry>` — update/restore backup roots.
+	try {
+		for (const entry of await fsp.readdir(surface.root, { withFileTypes: true })) {
+			if (entry.isSymbolicLink()) continue;
+			candidates.push({ id: entry.name, path: path.join(surface.root, entry.name) });
+		}
+	} catch (error) {
+		if (!isEnoent(error)) errors.push({ surface: "backups", scope: surface.root, message: gcDiskErrorText(error) });
+	}
+
+	// `~/.gjc/*.bak` — sibling roots left by update/restore (agent.bak, natives-*.bak).
+	try {
+		for (const entry of await fsp.readdir(gjcRoot, { withFileTypes: true })) {
+			if (!entry.name.endsWith(".bak") || entry.isSymbolicLink()) continue;
+			candidates.push({ id: entry.name, path: path.join(gjcRoot, entry.name) });
+		}
+	} catch (error) {
+		if (!isEnoent(error)) errors.push({ surface: "backups", scope: gjcRoot, message: gcDiskErrorText(error) });
+	}
+
+	for (const candidate of candidates) {
+		let stat: Stats;
+		try {
+			stat = await fsp.lstat(candidate.path);
+		} catch (error) {
+			if (!isEnoent(error)) {
+				errors.push({ surface: "backups", scope: candidate.path, message: gcDiskErrorText(error) });
+			}
+			continue;
+		}
+		if (stat.isSymbolicLink()) continue;
+		const usage = stat.isDirectory() ? await measureGcDiskTree(candidate.path) : { bytes: stat.size, partial: false };
+		const record: GcDiskRecord = {
+			surface: "backups",
+			id: candidate.id,
+			path: candidate.path,
+			bytes: usage.bytes,
+			age_days: gcDiskAgeDays(now, stat.mtimeMs),
+			action: "keep",
+			reason: "",
+			...(usage.partial ? { partial: true as const } : {}),
+		};
+		if (now - stat.mtimeMs < maxAgeMs) record.reason = `newer_than_max_age(${policy.backups_max_age_days}d)`;
+		else {
+			record.action = "would_reclaim";
+			record.reason = `older_than_max_age(${policy.backups_max_age_days}d)`;
+		}
+		surface.records.push(record);
+
+		if (!prune || record.action !== "would_reclaim") continue;
+		const removal = await removeGcDiskEntry(candidate.path, stat);
+		if (removal.removed) record.action = "reclaimed";
+		else if (removal.failed) {
+			record.action = "reclaim_failed";
+			record.reason = removal.reason;
+			record.error = removal.reason;
+		} else {
+			record.action = "keep";
+			record.reason = removal.reason;
+		}
+	}
+}
+
+/**
+ * Run the disk-retention axis. Nothing is mutated unless `prune` is true; the
+ * dry-run report projects exactly the same decisions a prune would make.
+ */
+export async function collectGcDiskReport(input: {
+	agentDir: string;
+	env: NodeJS.ProcessEnv;
+	policy: GcDiskPolicy;
+	prune: boolean;
+	now?: number;
+	runningVersion?: string;
+}): Promise<GcDiskReport> {
+	const { agentDir, env, policy, prune } = input;
+	const now = input.now ?? Date.now();
+	const gjcRoot = path.dirname(path.resolve(agentDir));
+	const errors: GcDiskError[] = [];
+	const surfaces: Record<GcDiskSurface, GcDiskSurfaceReport> = {
+		sessions: emptyGcDiskSurface("sessions", getSessionsDir(agentDir)),
+		blobs: emptyGcDiskSurface("blobs", getBlobsDir(agentDir)),
+		natives: emptyGcDiskSurface("natives", path.join(gjcRoot, "natives")),
+		backups: emptyGcDiskSurface("backups", path.join(gjcRoot, "backups")),
+	};
+
+	const transcripts = await discoverGcDiskTranscripts(surfaces.sessions.root, errors);
+	const references = await collectGcSessionReferences(agentDir, env);
+	const survivors = await runGcDiskSessions({
+		surface: surfaces.sessions,
+		transcripts,
+		references,
+		policy,
+		now,
+		prune,
+	});
+	await runGcDiskBlobs({ surface: surfaces.blobs, survivors, now, prune, errors });
+	await runGcDiskNatives({
+		surface: surfaces.natives,
+		policy,
+		now,
+		prune,
+		errors,
+		runningVersion: input.runningVersion ?? VERSION,
+	});
+	await runGcDiskBackups({ surface: surfaces.backups, gjcRoot, policy, now, prune, errors });
+
+	const totals = { scanned_bytes: 0, reclaimable_bytes: 0, reclaimed_bytes: 0, kept_bytes: 0, failed: 0 };
+	for (const name of GC_DISK_SURFACES) {
+		const surface = surfaces[name];
+		summarizeGcDiskSurface(surface);
+		totals.scanned_bytes += surface.scanned_bytes;
+		totals.reclaimable_bytes += surface.reclaimable_bytes;
+		totals.reclaimed_bytes += surface.reclaimed_bytes;
+		totals.kept_bytes += surface.kept_bytes;
+		totals.failed += surface.failed;
+	}
+
+	return { dry_run: !prune, policy, surfaces, totals, errors };
+}
+
+const GC_DISK_SURFACE_HEADINGS: Record<GcDiskSurface, string> = {
+	sessions: "Session transcripts",
+	blobs: "Content-addressed blobs",
+	natives: "Cached native versions",
+	backups: "Update/restore backups",
+};
+
+function formatGcDiskBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	const units = ["KiB", "MiB", "GiB", "TiB"];
+	let value = bytes / 1024;
+	let unit = 0;
+	while (value >= 1024 && unit < units.length - 1) {
+		value /= 1024;
+		unit++;
+	}
+	return `${value.toFixed(1)} ${units[unit]}`;
+}
+
+function gcDiskActionLabel(record: GcDiskRecord): string {
+	switch (record.action) {
+		case "would_reclaim":
+			return "would reclaim";
+		case "reclaimed":
+			return "reclaimed";
+		case "reclaim_failed":
+			return `reclaim failed${record.error ? `: ${record.error}` : ""}`;
+		default:
+			return "keep";
+	}
+}
+
+export function buildGcDiskReportText(disk: GcDiskReport): string {
+	const lines: string[] = [];
+	lines.push(
+		disk.dry_run
+			? "gjc gc --disk — report only (no bytes reclaimed; pass --prune to reclaim)"
+			: "gjc gc --disk --prune — reclaim",
+	);
+	lines.push(
+		`  policy: sessions.maxAgeDays=${disk.policy.sessions_max_age_days} ` +
+			`sessions.maxTotalBytes=${disk.policy.sessions_max_total_bytes} ` +
+			`natives.keepVersions=${disk.policy.natives_keep_versions} ` +
+			`backups.maxAgeDays=${disk.policy.backups_max_age_days}`,
+	);
+	lines.push("");
+
+	for (const name of GC_DISK_SURFACES) {
+		const surface = disk.surfaces[name];
+		lines.push(`${GC_DISK_SURFACE_HEADINGS[name]} (${surface.root})`);
+		lines.push(
+			`  scanned=${surface.scanned} (${formatGcDiskBytes(surface.scanned_bytes)}) ` +
+				(disk.dry_run
+					? `reclaimable=${surface.reclaimable} (${formatGcDiskBytes(surface.reclaimable_bytes)}) `
+					: `reclaimed=${surface.reclaimed} (${formatGcDiskBytes(surface.reclaimed_bytes)}) failed=${surface.failed} `) +
+				`kept=${surface.kept} (${formatGcDiskBytes(surface.kept_bytes)})`,
+		);
+		// Reclaim decisions first: they are what an operator has to audit.
+		const ranked = [...surface.records].sort(
+			(a, b) => Number(a.action === "keep") - Number(b.action === "keep") || b.bytes - a.bytes,
+		);
+		for (const record of ranked.slice(0, GC_DISK_MAX_RENDERED_RECORDS)) {
+			lines.push(
+				`  [${gcDiskActionLabel(record)}] ${record.path} ${formatGcDiskBytes(record.bytes)}` +
+					`${record.partial ? "+" : ""} age=${record.age_days}d — ${record.reason}`,
+			);
+		}
+		if (ranked.length > GC_DISK_MAX_RENDERED_RECORDS) {
+			lines.push(`  … ${ranked.length - GC_DISK_MAX_RENDERED_RECORDS} more (use --json for the full list)`);
+		}
+		lines.push("");
+	}
+
+	if (disk.errors.length > 0) {
+		lines.push(`Disk errors (${disk.errors.length})`);
+		for (const error of disk.errors) lines.push(`  [${error.surface}/${error.scope}] ${error.message}`);
+		lines.push("");
+	}
+
+	lines.push(
+		`Disk summary: scanned=${formatGcDiskBytes(disk.totals.scanned_bytes)} ` +
+			(disk.dry_run
+				? `reclaimable=${formatGcDiskBytes(disk.totals.reclaimable_bytes)}`
+				: `reclaimed=${formatGcDiskBytes(disk.totals.reclaimed_bytes)} failed=${disk.totals.failed}`) +
+			` kept=${formatGcDiskBytes(disk.totals.kept_bytes)}`,
+	);
+	lines.push("");
+	return `${lines.join("\n")}`;
 }

--- a/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
@@ -665,6 +665,14 @@ const GC_DISK_DAY_MS = 24 * 60 * 60 * 1000;
  */
 const GC_DISK_BLOB_GRACE_MS = GC_DISK_DAY_MS;
 
+/**
+ * How many extra times the blob mark may re-absorb transcripts that appeared or
+ * grew while it was running. Ordinary concurrent session activity settles in one
+ * extra round; a store that still will not settle is not evidence anyone can
+ * sweep on, so the sweep withholds instead.
+ */
+const GC_DISK_MARK_REMARK_ROUNDS = 2;
+
 /** Bound every recursive size walk so a pathological tree cannot stall `gjc gc`. */
 const GC_DISK_MAX_WALK_ENTRIES = 200_000;
 
@@ -898,21 +906,32 @@ interface GcDiskTranscriptScan {
 	evidence: GcDiskEvidence;
 }
 
-async function discoverGcDiskTranscripts(sessionsRoot: string, errors: GcDiskError[]): Promise<GcDiskTranscriptScan> {
-	const evidence: GcDiskEvidence = { complete: true, notes: [] };
+/**
+ * Walk every managed session transcript under `sessionsRoot` through exactly one
+ * enumeration filter. Discovery and the blob sweep's staleness re-check both go
+ * through here, so their two views of the store are comparable by construction;
+ * anything the walk cannot read degrades `evidence` instead of quietly
+ * shrinking the result.
+ */
+async function walkGcDiskTranscripts(input: {
+	sessionsRoot: string;
+	surface: GcDiskSurface;
+	evidence: GcDiskEvidence;
+	errors: GcDiskError[];
+	visit: (transcriptPath: string, directory: string, stat: Stats) => Promise<void> | void;
+}): Promise<void> {
+	const { sessionsRoot, surface, evidence, errors, visit } = input;
 	let projectDirs: Dirent[];
 	try {
 		projectDirs = await fsp.readdir(sessionsRoot, { withFileTypes: true });
 	} catch (error) {
 		// A missing sessions root is complete evidence: there are no transcripts.
-		if (!isEnoent(error)) {
-			errors.push({ surface: "sessions", scope: sessionsRoot, message: gcDiskErrorText(error) });
-			markGcDiskEvidenceIncomplete(evidence, "sessions_root_unreadable");
-		}
-		return { transcripts: [], evidence };
+		if (isEnoent(error)) return;
+		errors.push({ surface, scope: sessionsRoot, message: gcDiskErrorText(error) });
+		markGcDiskEvidenceIncomplete(evidence, "sessions_root_unreadable");
+		return;
 	}
 
-	const transcripts: GcDiskTranscript[] = [];
 	for (const projectDir of projectDirs) {
 		if (!projectDir.isDirectory() || projectDir.isSymbolicLink()) continue;
 		const directory = path.join(sessionsRoot, projectDir.name);
@@ -920,7 +939,7 @@ async function discoverGcDiskTranscripts(sessionsRoot: string, errors: GcDiskErr
 		try {
 			files = await fsp.readdir(directory, { withFileTypes: true });
 		} catch (error) {
-			errors.push({ surface: "sessions", scope: directory, message: gcDiskErrorText(error) });
+			errors.push({ surface, scope: directory, message: gcDiskErrorText(error) });
 			markGcDiskEvidenceIncomplete(evidence, "session_project_dir_unreadable");
 			continue;
 		}
@@ -931,21 +950,35 @@ async function discoverGcDiskTranscripts(sessionsRoot: string, errors: GcDiskErr
 			try {
 				stat = await fsp.lstat(transcriptPath);
 			} catch (error) {
-				errors.push({ surface: "sessions", scope: transcriptPath, message: gcDiskErrorText(error) });
+				errors.push({ surface, scope: transcriptPath, message: gcDiskErrorText(error) });
 				markGcDiskEvidenceIncomplete(evidence, "transcript_unstattable");
 				continue;
 			}
+			await visit(transcriptPath, directory, stat);
+		}
+	}
+}
+
+async function discoverGcDiskTranscripts(sessionsRoot: string, errors: GcDiskError[]): Promise<GcDiskTranscriptScan> {
+	const evidence: GcDiskEvidence = { complete: true, notes: [] };
+	const transcripts: GcDiskTranscript[] = [];
+	await walkGcDiskTranscripts({
+		sessionsRoot,
+		surface: "sessions",
+		evidence,
+		errors,
+		visit: async (transcriptPath, directory, stat) => {
 			const artifacts = await measureGcDiskTree(transcriptPath.slice(0, -".jsonl".length));
 			transcripts.push({
-				sessionId: file.name.slice(0, -".jsonl".length),
+				sessionId: path.basename(transcriptPath, ".jsonl"),
 				path: transcriptPath,
 				directory,
 				bytes: stat.size + artifacts.bytes,
 				mtimeMs: stat.mtimeMs,
 				partial: artifacts.partial,
 			});
-		}
-	}
+		},
+	});
 	return { transcripts, evidence };
 }
 
@@ -1095,6 +1128,73 @@ async function markGcDiskBlobReferences(transcriptPath: string, into: Set<string
 	}
 }
 
+/** What a completed mark read: the exact transcript bytes its references came from. */
+interface GcDiskMarkedTranscript {
+	size: number;
+	mtimeMs: number;
+}
+
+/**
+ * Read one transcript's blob references and bind the result to the bytes that
+ * produced it. An append landing after this lstat can introduce a reference the
+ * pass never saw, which is precisely what the drift check below looks for.
+ */
+async function markGcDiskTranscript(
+	transcriptPath: string,
+	referenced: Set<string>,
+	marked: Map<string, GcDiskMarkedTranscript>,
+	evidence: GcDiskEvidence,
+	errors: GcDiskError[],
+): Promise<void> {
+	if (!(await markGcDiskBlobReferences(transcriptPath, referenced))) {
+		markGcDiskEvidenceIncomplete(evidence, "transcript_unreadable_during_mark");
+		errors.push({ surface: "blobs", scope: transcriptPath, message: "transcript_unreadable_during_mark" });
+		return;
+	}
+	try {
+		const stat = await fsp.lstat(transcriptPath);
+		marked.set(transcriptPath, { size: stat.size, mtimeMs: stat.mtimeMs });
+	} catch (error) {
+		markGcDiskEvidenceIncomplete(evidence, "transcript_unstattable_after_mark");
+		errors.push({ surface: "blobs", scope: transcriptPath, message: gcDiskErrorText(error) });
+	}
+}
+
+/**
+ * Transcripts the store holds that nobody has accounted for: created after the
+ * session walk enumerated the store, or written to after their own bytes were
+ * read.
+ *
+ * `accounted` is the session walk's enumeration. A transcript in it that is not
+ * in the mark set is one the session surface decided to retire, and a dry run
+ * leaves those on disk — re-marking them would make the dry run promise fewer
+ * reclaimable blobs than `--prune` actually removes.
+ */
+async function findGcDiskMarkDrift(input: {
+	sessionsRoot: string;
+	accounted: ReadonlySet<string>;
+	marked: Map<string, GcDiskMarkedTranscript>;
+	evidence: GcDiskEvidence;
+	errors: GcDiskError[];
+}): Promise<string[]> {
+	const drifted: string[] = [];
+	await walkGcDiskTranscripts({
+		sessionsRoot: input.sessionsRoot,
+		surface: "blobs",
+		evidence: input.evidence,
+		errors: input.errors,
+		visit: (transcriptPath, _directory, stat) => {
+			const mark = input.marked.get(transcriptPath);
+			if (mark) {
+				if (mark.size !== stat.size || mark.mtimeMs !== stat.mtimeMs) drifted.push(transcriptPath);
+				return;
+			}
+			if (!input.accounted.has(transcriptPath)) drifted.push(transcriptPath);
+		},
+	});
+	return drifted;
+}
+
 /**
  * Mark and sweep the content-addressed blob store.
  *
@@ -1104,16 +1204,25 @@ async function markGcDiskBlobReferences(transcriptPath: string, into: Set<string
  * fails to stream here degrades it further. On incomplete evidence the sweep
  * still reports what it would have reclaimed and reclaims nothing, even under
  * `--prune`: an unproven reference is treated as a real one.
+ *
+ * The session walk is a snapshot, and a snapshot goes stale: a session started
+ * or appended to while `gjc gc` was measuring the store can reference a blob the
+ * mark never saw. So the mark re-walks the store, absorbs whatever appeared or
+ * grew, and only sweeps once the store stops moving under it. Drift that
+ * outlasts {@link GC_DISK_MARK_REMARK_ROUNDS} is incomplete evidence, not a
+ * licence to delete.
  */
 async function runGcDiskBlobs(input: {
 	surface: GcDiskSurfaceReport;
+	sessionsRoot: string;
+	accounted: ReadonlySet<string>;
 	survivors: GcDiskTranscript[];
 	discovery: GcDiskEvidence;
 	now: number;
 	prune: boolean;
 	errors: GcDiskError[];
 }): Promise<void> {
-	const { surface, survivors, discovery, now, prune, errors } = input;
+	const { surface, sessionsRoot, accounted, survivors, discovery, now, prune, errors } = input;
 	const evidence: GcDiskEvidence = { complete: discovery.complete, notes: [...discovery.notes] };
 	let blobs: CanonicalBlobEntry[];
 	try {
@@ -1125,10 +1234,21 @@ async function runGcDiskBlobs(input: {
 	if (blobs.length === 0) return;
 
 	const referenced = new Set<string>();
-	for (const transcript of survivors) {
-		if (await markGcDiskBlobReferences(transcript.path, referenced)) continue;
-		markGcDiskEvidenceIncomplete(evidence, "transcript_unreadable_during_mark");
-		errors.push({ surface: "blobs", scope: transcript.path, message: "transcript_unreadable_during_mark" });
+	const marked = new Map<string, GcDiskMarkedTranscript>();
+	let pending = survivors.map(transcript => transcript.path);
+	for (let round = 0; ; round++) {
+		for (const transcriptPath of pending) {
+			await markGcDiskTranscript(transcriptPath, referenced, marked, evidence, errors);
+		}
+		// Already-incomplete evidence withholds the sweep anyway; re-walking would
+		// only re-report the same failure.
+		if (!evidence.complete) break;
+		pending = await findGcDiskMarkDrift({ sessionsRoot, accounted, marked, evidence, errors });
+		if (pending.length === 0 || !evidence.complete) break;
+		if (round === GC_DISK_MARK_REMARK_ROUNDS) {
+			markGcDiskEvidenceIncomplete(evidence, "sessions_changed_during_mark");
+			break;
+		}
 	}
 
 	let withheld = 0;
@@ -1413,7 +1533,16 @@ export async function collectGcDiskReport(input: {
 		now,
 		prune,
 	});
-	await runGcDiskBlobs({ surface: surfaces.blobs, survivors, discovery: scan.evidence, now, prune, errors });
+	await runGcDiskBlobs({
+		surface: surfaces.blobs,
+		sessionsRoot: surfaces.sessions.root,
+		accounted: new Set(scan.transcripts.map(transcript => transcript.path)),
+		survivors,
+		discovery: scan.evidence,
+		now,
+		prune,
+		errors,
+	});
 	await runGcDiskNatives({
 		surface: surfaces.natives,
 		policy,

--- a/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
@@ -29,7 +29,7 @@ import {
 	listCanonicalBlobs,
 	removeCanonicalBlob,
 } from "../session/blob-store";
-import { FileSessionStorage, retireSessionTranscript } from "../session/session-storage";
+import { FileSessionStorage, probeSessionRetirement, retireSessionTranscript } from "../session/session-storage";
 
 import { buildGcReportText } from "./gc-render";
 import { collectSessionScopeUsage, type GcSessionScopeUsage, shouldReportSessionScope } from "./gc-session-scope";
@@ -597,6 +597,18 @@ export interface GcDiskRecord {
 	error?: string;
 	/** Set when `bytes` is a floor because a walk was capped or partially unreadable. */
 	partial?: true;
+	/** Set when this entry was a reclaim candidate that its surface withheld on incomplete evidence. */
+	withheld?: true;
+}
+
+/**
+ * Why a surface refused to reclaim anything, and how much it withheld to stay
+ * fail-closed. Present only when the surface declined.
+ */
+export interface GcDiskDeclined {
+	reason: string;
+	withheld: number;
+	withheld_bytes: number;
 }
 
 export interface GcDiskSurfaceReport {
@@ -611,6 +623,8 @@ export interface GcDiskSurfaceReport {
 	kept: number;
 	kept_bytes: number;
 	failed: number;
+	/** Set when the surface declined to reclaim anything because its evidence was incomplete. */
+	declined?: GcDiskDeclined;
 	records: GcDiskRecord[];
 }
 
@@ -845,6 +859,21 @@ async function collectGcSessionReferences(agentDir: string, env: NodeJS.ProcessE
 	return { ids, complete, notes };
 }
 
+/**
+ * Whether a reference scan saw every file its conclusions depend on.
+ * `complete: false` is a hard veto on reclamation for any surface whose evidence
+ * lives in a file the scan could not open.
+ */
+interface GcDiskEvidence {
+	complete: boolean;
+	notes: string[];
+}
+
+function markGcDiskEvidenceIncomplete(evidence: GcDiskEvidence, note: string): void {
+	evidence.complete = false;
+	if (!evidence.notes.includes(note)) evidence.notes.push(note);
+}
+
 /** One managed session transcript plus its sibling artifact directory. */
 interface GcDiskTranscript {
 	sessionId: string;
@@ -855,13 +884,32 @@ interface GcDiskTranscript {
 	partial: boolean;
 }
 
-async function discoverGcDiskTranscripts(sessionsRoot: string, errors: GcDiskError[]): Promise<GcDiskTranscript[]> {
+/**
+ * Every managed transcript, plus whether that enumeration is complete evidence.
+ *
+ * A transcript that could not be enumerated or stat'd is absent from
+ * `transcripts`, which leaves the session surface fail-closed by construction
+ * (an unseen transcript is never retired). It does NOT leave the blob sweep
+ * safe: a blob referenced only by an unseen transcript would look unreferenced,
+ * so `evidence` is threaded to every surface that marks across all transcripts.
+ */
+interface GcDiskTranscriptScan {
+	transcripts: GcDiskTranscript[];
+	evidence: GcDiskEvidence;
+}
+
+async function discoverGcDiskTranscripts(sessionsRoot: string, errors: GcDiskError[]): Promise<GcDiskTranscriptScan> {
+	const evidence: GcDiskEvidence = { complete: true, notes: [] };
 	let projectDirs: Dirent[];
 	try {
 		projectDirs = await fsp.readdir(sessionsRoot, { withFileTypes: true });
 	} catch (error) {
-		if (!isEnoent(error)) errors.push({ surface: "sessions", scope: sessionsRoot, message: gcDiskErrorText(error) });
-		return [];
+		// A missing sessions root is complete evidence: there are no transcripts.
+		if (!isEnoent(error)) {
+			errors.push({ surface: "sessions", scope: sessionsRoot, message: gcDiskErrorText(error) });
+			markGcDiskEvidenceIncomplete(evidence, "sessions_root_unreadable");
+		}
+		return { transcripts: [], evidence };
 	}
 
 	const transcripts: GcDiskTranscript[] = [];
@@ -873,6 +921,7 @@ async function discoverGcDiskTranscripts(sessionsRoot: string, errors: GcDiskErr
 			files = await fsp.readdir(directory, { withFileTypes: true });
 		} catch (error) {
 			errors.push({ surface: "sessions", scope: directory, message: gcDiskErrorText(error) });
+			markGcDiskEvidenceIncomplete(evidence, "session_project_dir_unreadable");
 			continue;
 		}
 		for (const file of files) {
@@ -883,6 +932,7 @@ async function discoverGcDiskTranscripts(sessionsRoot: string, errors: GcDiskErr
 				stat = await fsp.lstat(transcriptPath);
 			} catch (error) {
 				errors.push({ surface: "sessions", scope: transcriptPath, message: gcDiskErrorText(error) });
+				markGcDiskEvidenceIncomplete(evidence, "transcript_unstattable");
 				continue;
 			}
 			const artifacts = await measureGcDiskTree(transcriptPath.slice(0, -".jsonl".length));
@@ -896,7 +946,7 @@ async function discoverGcDiskTranscripts(sessionsRoot: string, errors: GcDiskErr
 			});
 		}
 	}
-	return transcripts;
+	return { transcripts, evidence };
 }
 
 /**
@@ -980,12 +1030,25 @@ async function runGcDiskSessions(input: {
 		}
 	}
 
-	if (!prune) return classified.filter(item => item.record.action !== "would_reclaim").map(item => item.transcript);
+	const storage = new FileSessionStorage();
+	if (!prune) {
+		// Dry run must project the prune verdict, not just the policy verdict: the
+		// retention pass re-checks its own preconditions before it may call the
+		// delete authority, and a candidate that fails them is never removable.
+		for (const item of classified) {
+			if (item.record.action !== "would_reclaim") continue;
+			const probe = probeSessionRetirement(storage, surface.root, item.transcript.path);
+			if (probe.kind === "retirable") continue;
+			item.record.action = "keep";
+			item.record.reason = `retention_declined: ${probe.reason}`;
+		}
+		return classified.filter(item => item.record.action !== "would_reclaim").map(item => item.transcript);
+	}
 
 	// Retirement goes through the identity-bound verified delete authority, which
 	// re-reads and re-verifies the transcript. A declined retirement is a KEEP,
-	// not a failure — the same posture the pid probe takes on EPERM/unknown.
-	const storage = new FileSessionStorage();
+	// not a failure — the same posture the pid probe takes on EPERM/unknown. A
+	// half-completed one is a failure: bytes are already gone.
 	const survivors: GcDiskTranscript[] = [];
 	for (const item of classified) {
 		if (item.record.action !== "would_reclaim") {
@@ -995,6 +1058,16 @@ async function runGcDiskSessions(input: {
 		const outcome = await retireSessionTranscript(storage, surface.root, item.transcript.path);
 		if (outcome.kind === "retired") {
 			item.record.action = "reclaimed";
+			continue;
+		}
+		if (outcome.kind === "cleanup_pending") {
+			// The transcript survives but its artifact tree was already detached or
+			// partially removed. Reporting that as a plain keep would hide a
+			// destructive partial failure behind a green exit code.
+			item.record.action = "reclaim_failed";
+			item.record.reason = `retention_incomplete: ${outcome.reason}`;
+			item.record.error = outcome.reason;
+			survivors.push(item.transcript);
 			continue;
 		}
 		item.record.action = "keep";
@@ -1022,14 +1095,26 @@ async function markGcDiskBlobReferences(transcriptPath: string, into: Set<string
 	}
 }
 
+/**
+ * Mark and sweep the content-addressed blob store.
+ *
+ * A blob's only evidence of being referenced lives inside session transcripts,
+ * so the sweep is sound only when every transcript was enumerated AND read.
+ * `discovery` carries that verdict from the session walk; a transcript that
+ * fails to stream here degrades it further. On incomplete evidence the sweep
+ * still reports what it would have reclaimed and reclaims nothing, even under
+ * `--prune`: an unproven reference is treated as a real one.
+ */
 async function runGcDiskBlobs(input: {
 	surface: GcDiskSurfaceReport;
 	survivors: GcDiskTranscript[];
+	discovery: GcDiskEvidence;
 	now: number;
 	prune: boolean;
 	errors: GcDiskError[];
 }): Promise<void> {
-	const { surface, survivors, now, prune, errors } = input;
+	const { surface, survivors, discovery, now, prune, errors } = input;
+	const evidence: GcDiskEvidence = { complete: discovery.complete, notes: [...discovery.notes] };
 	let blobs: CanonicalBlobEntry[];
 	try {
 		blobs = await listCanonicalBlobs(surface.root);
@@ -1040,13 +1125,14 @@ async function runGcDiskBlobs(input: {
 	if (blobs.length === 0) return;
 
 	const referenced = new Set<string>();
-	let markComplete = true;
 	for (const transcript of survivors) {
 		if (await markGcDiskBlobReferences(transcript.path, referenced)) continue;
-		markComplete = false;
+		markGcDiskEvidenceIncomplete(evidence, "transcript_unreadable_during_mark");
 		errors.push({ surface: "blobs", scope: transcript.path, message: "transcript_unreadable_during_mark" });
 	}
 
+	let withheld = 0;
+	let withheldBytes = 0;
 	for (const blob of blobs) {
 		const record: GcDiskRecord = {
 			surface: "blobs",
@@ -1057,10 +1143,14 @@ async function runGcDiskBlobs(input: {
 			action: "keep",
 			reason: "",
 		};
-		if (!markComplete) record.reason = "mark_scan_incomplete";
-		else if (referenced.has(blob.hash)) record.reason = "referenced_by_surviving_session";
+		if (referenced.has(blob.hash)) record.reason = "referenced_by_surviving_session";
 		else if (now - blob.mtimeMs < GC_DISK_BLOB_GRACE_MS) record.reason = "within_write_grace_window";
-		else {
+		else if (!evidence.complete) {
+			record.reason = `withheld_evidence_incomplete: ${evidence.notes.join(", ")}`;
+			record.withheld = true;
+			withheld++;
+			withheldBytes += blob.bytes;
+		} else {
 			record.action = "would_reclaim";
 			record.reason = "unreferenced_by_any_surviving_session";
 		}
@@ -1078,6 +1168,14 @@ async function runGcDiskBlobs(input: {
 			record.action = "keep";
 			record.reason = removal.reason;
 		}
+	}
+
+	if (!evidence.complete) {
+		surface.declined = {
+			reason: `evidence_incomplete: ${evidence.notes.join(", ")}`,
+			withheld,
+			withheld_bytes: withheldBytes,
+		};
 	}
 }
 
@@ -1305,17 +1403,17 @@ export async function collectGcDiskReport(input: {
 		backups: emptyGcDiskSurface("backups", path.join(gjcRoot, "backups")),
 	};
 
-	const transcripts = await discoverGcDiskTranscripts(surfaces.sessions.root, errors);
+	const scan = await discoverGcDiskTranscripts(surfaces.sessions.root, errors);
 	const references = await collectGcSessionReferences(agentDir, env);
 	const survivors = await runGcDiskSessions({
 		surface: surfaces.sessions,
-		transcripts,
+		transcripts: scan.transcripts,
 		references,
 		policy,
 		now,
 		prune,
 	});
-	await runGcDiskBlobs({ surface: surfaces.blobs, survivors, now, prune, errors });
+	await runGcDiskBlobs({ surface: surfaces.blobs, survivors, discovery: scan.evidence, now, prune, errors });
 	await runGcDiskNatives({
 		surface: surfaces.natives,
 		policy,
@@ -1397,6 +1495,12 @@ export function buildGcDiskReportText(disk: GcDiskReport): string {
 					: `reclaimed=${surface.reclaimed} (${formatGcDiskBytes(surface.reclaimed_bytes)}) failed=${surface.failed} `) +
 				`kept=${surface.kept} (${formatGcDiskBytes(surface.kept_bytes)})`,
 		);
+		if (surface.declined) {
+			lines.push(
+				`  declined: reclaimed nothing — ${surface.declined.reason} ` +
+					`(withheld=${surface.declined.withheld} (${formatGcDiskBytes(surface.declined.withheld_bytes)}))`,
+			);
+		}
 		// Reclaim decisions first: they are what an operator has to audit.
 		const ranked = [...surface.records].sort(
 			(a, b) => Number(a.action === "keep") - Number(b.action === "keep") || b.bytes - a.bytes,

--- a/packages/coding-agent/src/session/blob-store.ts
+++ b/packages/coding-agent/src/session/blob-store.ts
@@ -1523,3 +1523,92 @@ export function resolveResidentImageDataSync(
 	}
 	return buffer.toString("base64");
 }
+
+// =============================================================================
+// Canonical-store mark-and-sweep primitives (`gjc gc --disk`)
+// =============================================================================
+//
+// The resident-cache sweep above bounds *cache* directories. These primitives
+// expose the canonical `~/.gjc/agent/blobs` store to an out-of-process retention
+// pass so it can mark live hashes from surviving transcripts and sweep the rest.
+// They own no policy: the caller decides what "unreferenced" means.
+
+/** One canonical blob file (`<blobsDir>/<sha256-hex>`) observed on disk. */
+export interface CanonicalBlobEntry {
+	readonly hash: string;
+	readonly path: string;
+	readonly bytes: number;
+	readonly mtimeMs: number;
+}
+
+const CANONICAL_BLOB_NAME = /^[0-9a-f]{64}$/;
+const BLOB_REFERENCE = /blob:sha256:([0-9a-f]{64})/g;
+
+/** Longest possible `blob:sha256:<hash>` reference, used to bound chunked scans. */
+export const BLOB_REFERENCE_MAX_LENGTH = BLOB_PREFIX.length + 64;
+
+/** Collect every `blob:sha256:<hash>` reference that appears in `text`. */
+export function collectBlobReferences(text: string, into: Set<string>): void {
+	for (const match of text.matchAll(BLOB_REFERENCE)) into.add(match[1]!);
+}
+
+/**
+ * List canonical blob files. Anything that is not a plain, owner-visible regular
+ * file named after its own hash (temp files, symlinks, subdirectories) is
+ * skipped: a sweep must never reason about entries it cannot classify.
+ */
+export async function listCanonicalBlobs(dir: string): Promise<CanonicalBlobEntry[]> {
+	let names: string[];
+	try {
+		names = await fsp.readdir(dir);
+	} catch (error) {
+		if (isEnoent(error)) return [];
+		throw error;
+	}
+
+	const entries: CanonicalBlobEntry[] = [];
+	for (const name of names) {
+		if (!CANONICAL_BLOB_NAME.test(name)) continue;
+		const blobPath = path.join(dir, name);
+		let stat: fs.Stats;
+		try {
+			stat = await fsp.lstat(blobPath);
+		} catch {
+			continue;
+		}
+		if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1) continue;
+		entries.push({ hash: name, path: blobPath, bytes: stat.size, mtimeMs: stat.mtimeMs });
+	}
+	return entries;
+}
+
+/**
+ * Remove one canonical blob, fail-closed on identity drift. The entry captured
+ * at scan time must still describe the file at unlink time (same inode, size and
+ * mtime, still a single-link regular file), otherwise the blob is left in place.
+ *
+ * `failed` distinguishes an actual IO failure (which a caller should surface as
+ * a failed reclaim) from a revalidation refusal (which is an ordinary KEEP).
+ */
+export async function removeCanonicalBlob(
+	entry: CanonicalBlobEntry,
+): Promise<{ removed: true } | { removed: false; reason: string; failed?: true }> {
+	let stat: fs.Stats;
+	try {
+		stat = await fsp.lstat(entry.path);
+	} catch (error) {
+		if (isEnoent(error)) return { removed: false, reason: "blob_disappeared" };
+		return { removed: false, reason: `blob_unverifiable: ${String(error)}`, failed: true };
+	}
+	if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1) {
+		return { removed: false, reason: "blob_not_plain_file" };
+	}
+	if (stat.size !== entry.bytes || stat.mtimeMs !== entry.mtimeMs) return { removed: false, reason: "blob_changed" };
+	try {
+		await fsp.unlink(entry.path);
+		return { removed: true };
+	} catch (error) {
+		if (isEnoent(error)) return { removed: false, reason: "blob_disappeared" };
+		return { removed: false, reason: `blob_unlink_failed: ${String(error)}`, failed: true };
+	}
+}

--- a/packages/coding-agent/src/session/session-storage.ts
+++ b/packages/coding-agent/src/session/session-storage.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -1816,5 +1816,78 @@ export class MemorySessionStorage implements SessionStorage {
 
 	openWriter(path: string, options?: SessionStorageWriterOpenOptions): SessionStorageWriter {
 		return new MemorySessionStorageWriter(this, path, options);
+	}
+}
+
+/**
+ * Outcome of a disk-retention retirement attempt. `kept` carries the exact
+ * reason the transcript survived so `gjc gc --disk` can report it.
+ */
+export type SessionRetirementOutcome = { kind: "retired" } | { kind: "kept"; reason: string };
+
+/**
+ * Retire one managed session transcript through the verified hard-delete
+ * authority.
+ *
+ * This is the only supported way for a retention pass to remove a transcript:
+ * identity, containment, header id/cwd, artifact tree and parent directory are
+ * all re-verified inside {@link FileSessionStorage.deleteSessionVerified}, and
+ * anything ambiguous fails closed as `kept` rather than deleting bytes. The
+ * caller owns the retention policy; this function owns nothing but the delete
+ * authority.
+ */
+export async function retireSessionTranscript(
+	storage: FileSessionStorage,
+	sessionsRoot: string,
+	transcriptPath: string,
+): Promise<SessionRetirementOutcome> {
+	let snapshot: SessionStorageSnapshot;
+	try {
+		snapshot = storage.readSnapshotSync(transcriptPath);
+	} catch (err) {
+		return { kind: "kept", reason: `transcript_unreadable: ${toError(err).message}` };
+	}
+
+	const header = parseFirstJsonlLine(snapshot.bytes);
+	if (header?.type !== "session" || typeof header.id !== "string" || typeof header.cwd !== "string") {
+		return { kind: "kept", reason: "transcript_header_unusable" };
+	}
+
+	const directory = path.dirname(transcriptPath);
+	const target: VerifiedSessionDeleteTarget = {
+		sessionsRoot,
+		transcriptPath,
+		sessionId: header.id,
+		cwd: header.cwd,
+		transcriptIdentity: {
+			dev: snapshot.stat.dev,
+			ino: snapshot.stat.ino,
+			nlink: snapshot.stat.nlink,
+			size: snapshot.stat.size,
+			mtimeNs: snapshot.stat.mtimeNs,
+			sha256: createHash("sha256").update(snapshot.bytes).digest("hex"),
+		},
+		plannedArtifactsPath: path.join(directory, `.gjc-delete-gc-${randomUUID()}-artifacts`),
+		plannedTranscriptPath: path.join(directory, `.gjc-delete-gc-${randomUUID()}-transcript`),
+	};
+
+	try {
+		// Phase 1 removes the sibling artifact directory (or proves it absent);
+		// phase 2 unlinks the transcript only against the same bound identity.
+		const artifacts = await storage.deleteSessionVerified(target);
+		if (artifacts.kind === "deleted") return { kind: "retired" };
+		if (artifacts.kind === "cleanup_pending") {
+			return { kind: "kept", reason: `cleanup_pending_${artifacts.phase}: ${artifacts.error.message}` };
+		}
+		const deletion = await storage.deleteSessionVerified({ ...target, artifactsRemoved: true });
+		if (deletion.kind === "deleted") return { kind: "retired" };
+		if (deletion.kind === "cleanup_pending") {
+			return { kind: "kept", reason: `cleanup_pending_${deletion.phase}: ${deletion.error.message}` };
+		}
+		return { kind: "kept", reason: "transcript_not_deleted" };
+	} catch (err) {
+		const error = toError(err);
+		const kind = err instanceof SessionDeleteVerificationError ? err.kind : "error";
+		return { kind: "kept", reason: `verified_delete_rejected(${kind}): ${error.message}` };
 	}
 }

--- a/packages/coding-agent/src/session/session-storage.ts
+++ b/packages/coding-agent/src/session/session-storage.ts
@@ -1820,10 +1820,95 @@ export class MemorySessionStorage implements SessionStorage {
 }
 
 /**
- * Outcome of a disk-retention retirement attempt. `kept` carries the exact
- * reason the transcript survived so `gjc gc --disk` can report it.
+ * Outcome of a disk-retention retirement attempt.
+ *
+ * `kept` means the transcript survived and nothing of the session was
+ * destroyed, with the exact reason so `gjc gc --disk` can report it.
+ * `cleanup_pending` means the delete authority already detached or removed the
+ * session's artifact tree (or quarantined the transcript) before it stopped:
+ * the record survives, the session does not, and a caller must NOT report that
+ * as an ordinary keep.
  */
-export type SessionRetirementOutcome = { kind: "retired" } | { kind: "kept"; reason: string };
+export type SessionRetirementOutcome =
+	| { kind: "retired" }
+	| { kind: "kept"; reason: string }
+	| { kind: "cleanup_pending"; reason: string };
+
+/** A retirement that cleared every precondition the retention pass itself owns. */
+type SessionRetirementPlan =
+	| { kind: "retirable"; target: VerifiedSessionDeleteTarget; artifactsPresent: boolean }
+	| { kind: "kept"; reason: string };
+
+/**
+ * Evaluate the preconditions retirement owns — the transcript must be readable
+ * and carry a usable session header — and bind the delete target to the exact
+ * bytes just read. Nothing here mutates the store.
+ */
+function planSessionRetirement(
+	storage: FileSessionStorage,
+	sessionsRoot: string,
+	transcriptPath: string,
+): SessionRetirementPlan {
+	let snapshot: SessionStorageSnapshot;
+	try {
+		snapshot = storage.readSnapshotSync(transcriptPath);
+	} catch (err) {
+		return { kind: "kept", reason: `transcript_unreadable: ${toError(err).message}` };
+	}
+
+	const header = parseFirstJsonlLine(snapshot.bytes);
+	if (header?.type !== "session" || typeof header.id !== "string" || typeof header.cwd !== "string") {
+		return { kind: "kept", reason: "transcript_header_unusable" };
+	}
+
+	const directory = path.dirname(transcriptPath);
+	return {
+		kind: "retirable",
+		artifactsPresent: storage.existsSync(transcriptPath.slice(0, -".jsonl".length)),
+		target: {
+			sessionsRoot,
+			transcriptPath,
+			sessionId: header.id,
+			cwd: header.cwd,
+			transcriptIdentity: {
+				dev: snapshot.stat.dev,
+				ino: snapshot.stat.ino,
+				nlink: snapshot.stat.nlink,
+				size: snapshot.stat.size,
+				mtimeNs: snapshot.stat.mtimeNs,
+				sha256: createHash("sha256").update(snapshot.bytes).digest("hex"),
+			},
+			plannedArtifactsPath: path.join(directory, `.gjc-delete-gc-${randomUUID()}-artifacts`),
+			plannedTranscriptPath: path.join(directory, `.gjc-delete-gc-${randomUUID()}-transcript`),
+		},
+	};
+}
+
+/**
+ * Non-mutating projection of {@link retireSessionTranscript}: would the
+ * retention pass's own preconditions let this transcript be retired at all?
+ *
+ * `gjc gc --disk` runs it so a dry run reports the verdict a prune would reach
+ * instead of promising bytes the delete authority will refuse to release. The
+ * authority's verdict (containment, identity, artifact tree) is deliberately
+ * not predicted here — it is re-derived against live state at delete time.
+ */
+export function probeSessionRetirement(
+	storage: FileSessionStorage,
+	sessionsRoot: string,
+	transcriptPath: string,
+): { kind: "retirable" } | { kind: "kept"; reason: string } {
+	const plan = planSessionRetirement(storage, sessionsRoot, transcriptPath);
+	return plan.kind === "retirable" ? { kind: "retirable" } : plan;
+}
+
+/**
+ * A transcript that survives after its artifacts are already gone is not a
+ * benign keep: the session is half-destroyed and the caller has to surface it.
+ */
+function retirementIncomplete(artifactsRemoved: boolean, reason: string): SessionRetirementOutcome {
+	return artifactsRemoved ? { kind: "cleanup_pending", reason } : { kind: "kept", reason };
+}
 
 /**
  * Retire one managed session transcript through the verified hard-delete
@@ -1841,53 +1926,30 @@ export async function retireSessionTranscript(
 	sessionsRoot: string,
 	transcriptPath: string,
 ): Promise<SessionRetirementOutcome> {
-	let snapshot: SessionStorageSnapshot;
-	try {
-		snapshot = storage.readSnapshotSync(transcriptPath);
-	} catch (err) {
-		return { kind: "kept", reason: `transcript_unreadable: ${toError(err).message}` };
-	}
+	const plan = planSessionRetirement(storage, sessionsRoot, transcriptPath);
+	if (plan.kind === "kept") return plan;
 
-	const header = parseFirstJsonlLine(snapshot.bytes);
-	if (header?.type !== "session" || typeof header.id !== "string" || typeof header.cwd !== "string") {
-		return { kind: "kept", reason: "transcript_header_unusable" };
-	}
-
-	const directory = path.dirname(transcriptPath);
-	const target: VerifiedSessionDeleteTarget = {
-		sessionsRoot,
-		transcriptPath,
-		sessionId: header.id,
-		cwd: header.cwd,
-		transcriptIdentity: {
-			dev: snapshot.stat.dev,
-			ino: snapshot.stat.ino,
-			nlink: snapshot.stat.nlink,
-			size: snapshot.stat.size,
-			mtimeNs: snapshot.stat.mtimeNs,
-			sha256: createHash("sha256").update(snapshot.bytes).digest("hex"),
-		},
-		plannedArtifactsPath: path.join(directory, `.gjc-delete-gc-${randomUUID()}-artifacts`),
-		plannedTranscriptPath: path.join(directory, `.gjc-delete-gc-${randomUUID()}-transcript`),
-	};
-
+	let artifactsRemoved = false;
 	try {
 		// Phase 1 removes the sibling artifact directory (or proves it absent);
 		// phase 2 unlinks the transcript only against the same bound identity.
-		const artifacts = await storage.deleteSessionVerified(target);
+		const artifacts = await storage.deleteSessionVerified(plan.target);
 		if (artifacts.kind === "deleted") return { kind: "retired" };
 		if (artifacts.kind === "cleanup_pending") {
-			return { kind: "kept", reason: `cleanup_pending_${artifacts.phase}: ${artifacts.error.message}` };
+			return { kind: "cleanup_pending", reason: `cleanup_pending_${artifacts.phase}: ${artifacts.error.message}` };
 		}
-		const deletion = await storage.deleteSessionVerified({ ...target, artifactsRemoved: true });
+		// Phase 1 is durable: whatever artifact tree the session had is gone, so
+		// every later refusal leaves a record without its artifacts.
+		artifactsRemoved = plan.artifactsPresent;
+		const deletion = await storage.deleteSessionVerified({ ...plan.target, artifactsRemoved: true });
 		if (deletion.kind === "deleted") return { kind: "retired" };
 		if (deletion.kind === "cleanup_pending") {
-			return { kind: "kept", reason: `cleanup_pending_${deletion.phase}: ${deletion.error.message}` };
+			return { kind: "cleanup_pending", reason: `cleanup_pending_${deletion.phase}: ${deletion.error.message}` };
 		}
-		return { kind: "kept", reason: "transcript_not_deleted" };
+		return retirementIncomplete(artifactsRemoved, "transcript_not_deleted");
 	} catch (err) {
 		const error = toError(err);
 		const kind = err instanceof SessionDeleteVerificationError ? err.kind : "error";
-		return { kind: "kept", reason: `verified_delete_rejected(${kind}): ${error.message}` };
+		return retirementIncomplete(artifactsRemoved, `verified_delete_rejected(${kind}): ${error.message}`);
 	}
 }

--- a/packages/coding-agent/src/session/session-storage.ts
+++ b/packages/coding-agent/src/session/session-storage.ts
@@ -1861,6 +1861,15 @@ function planSessionRetirement(
 		return { kind: "kept", reason: "transcript_header_unusable" };
 	}
 
+	// The verified delete authority only unlinks a single-link transcript, so a
+	// hard-linked one can never be retired. Refusing here keeps the dry run from
+	// promising bytes prune cannot release, and — because this runs before the
+	// artifact phase — keeps a doomed retirement from destroying the artifact
+	// tree of a session whose transcript will survive anyway.
+	if (snapshot.stat.nlink === undefined || snapshot.stat.nlink !== 1n) {
+		return { kind: "kept", reason: "transcript_not_single_link" };
+	}
+
 	const directory = path.dirname(transcriptPath);
 	return {
 		kind: "retirable",

--- a/packages/coding-agent/test/gc-disk-retention.test.ts
+++ b/packages/coding-agent/test/gc-disk-retention.test.ts
@@ -61,18 +61,33 @@ async function backdate(target: string, ageDays: number): Promise<void> {
 	await fsp.utimes(target, when, when);
 }
 
+/** Restore write permission on every directory so a fixture can always be removed. */
+async function unlockTree(root: string): Promise<void> {
+	await fsp.chmod(root, 0o700).catch(() => {});
+	let entries: string[];
+	try {
+		entries = await fsp.readdir(root);
+	} catch {
+		return;
+	}
+	for (const name of entries) {
+		const child = path.join(root, name);
+		if ((await fsp.lstat(child)).isDirectory()) await unlockTree(child);
+	}
+}
+
 async function writeSession(
 	fixture: TestRoot,
 	project: string,
 	id: string,
-	options: { ageDays: number; blobRefs?: string[] },
+	options: { ageDays: number; blobRefs?: string[]; brokenHeader?: boolean },
 ): Promise<string> {
 	const directory = path.join(fixture.sessionsRoot, project);
 	await fsp.mkdir(directory, { recursive: true });
 	const file = path.join(directory, `${id}.jsonl`);
-	const lines = [
-		JSON.stringify({ type: "session", version: 3, id, timestamp: "2025-01-01T00:00:00Z", cwd: fixture.root }),
-	];
+	const lines = options.brokenHeader
+		? [JSON.stringify({ type: "message", role: "user", content: "no session header here" })]
+		: [JSON.stringify({ type: "session", version: 3, id, timestamp: "2025-01-01T00:00:00Z", cwd: fixture.root })];
 	for (const ref of options.blobRefs ?? []) {
 		lines.push(JSON.stringify({ type: "message", role: "user", content: `blob:sha256:${ref}` }));
 	}
@@ -323,9 +338,231 @@ describe("gjc gc --disk --prune (blob mark and sweep)", () => {
 			const disk = requireDisk(await runDisk(fixture, ["--disk", "--json"]));
 			await fsp.chmod(transcript, 0o600);
 
-			expect(reasonById(disk, "blobs").get(orphan)).toBe("keep:mark_scan_incomplete");
+			expect(reasonById(disk, "blobs").get(orphan)).toBe(
+				"keep:withheld_evidence_incomplete: transcript_unreadable_during_mark",
+			);
+			expect(disk.surfaces.blobs.declined).toEqual({
+				reason: "evidence_incomplete: transcript_unreadable_during_mark",
+				withheld: 1,
+				withheld_bytes: "orphan attachment".length,
+			});
 			expect(disk.surfaces.blobs.reclaimable).toBe(0);
 			expect(disk.errors.some(error => error.surface === "blobs")).toBe(true);
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("gjc gc --disk --prune (blob sweep on incomplete evidence)", () => {
+	test("keeps a blob whose only reference lives in an unreadable project directory", async () => {
+		const fixture = await makeTestRoot();
+		const projectDir = path.join(fixture.sessionsRoot, "repo-a");
+		try {
+			// Older than the write grace window, so only the reference held by the
+			// live transcript stands between this blob and the sweep.
+			const hash = await writeBlob(fixture, "precious user payload", 3);
+			const transcript = await writeSession(fixture, "repo-a", "live-session", { ageDays: 0, blobRefs: [hash] });
+			await fsp.chmod(projectDir, 0o000);
+
+			const report = await runDisk(fixture, ["--disk", "--prune", "--json"]);
+			await fsp.chmod(projectDir, 0o700);
+			const disk = requireDisk(report);
+
+			expect(await Bun.file(path.join(fixture.blobsDir, hash)).exists()).toBe(true);
+			expect(await Bun.file(transcript).exists()).toBe(true);
+			expect(disk.surfaces.blobs.reclaimed).toBe(0);
+			expect(reasonById(disk, "blobs").get(hash)).toBe(
+				"keep:withheld_evidence_incomplete: session_project_dir_unreadable",
+			);
+			expect(disk.surfaces.blobs.records.find(record => record.id === hash)?.withheld).toBe(true);
+			expect(disk.surfaces.blobs.declined).toEqual({
+				reason: "evidence_incomplete: session_project_dir_unreadable",
+				withheld: 1,
+				withheld_bytes: "precious user payload".length,
+			});
+		} finally {
+			await fsp.chmod(projectDir, 0o700).catch(() => {});
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("reclaims nothing and names the reason when the sessions root cannot be read", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			const hash = await writeBlob(fixture, "payload past the age bound", 3);
+			await writeSession(fixture, "repo-a", "live-session", { ageDays: 0, blobRefs: [hash] });
+			await fsp.chmod(fixture.sessionsRoot, 0o000);
+
+			const report = await runDisk(fixture, ["--disk", "--prune", "--json"]);
+			await fsp.chmod(fixture.sessionsRoot, 0o700);
+			const disk = requireDisk(report);
+
+			expect(await Bun.file(path.join(fixture.blobsDir, hash)).exists()).toBe(true);
+			expect(disk.surfaces.blobs.reclaimed).toBe(0);
+			expect(disk.surfaces.blobs.declined?.reason).toBe("evidence_incomplete: sessions_root_unreadable");
+			expect(disk.surfaces.blobs.declined?.withheld).toBe(1);
+			expect(disk.errors.some(error => error.surface === "sessions")).toBe(true);
+		} finally {
+			await fsp.chmod(fixture.sessionsRoot, 0o700).catch(() => {});
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("the text report states that the blob surface declined and what it withheld", async () => {
+		const fixture = await makeTestRoot();
+		const projectDir = path.join(fixture.sessionsRoot, "repo-a");
+		try {
+			const hash = await writeBlob(fixture, "withheld payload", 3);
+			await writeSession(fixture, "repo-a", "live-session", { ageDays: 0, blobRefs: [hash] });
+			await fsp.chmod(projectDir, 0o000);
+
+			const result = await runGjcGcCommand(["--disk", "--prune"], fixture.root, fixture.env, [], policy());
+			await fsp.chmod(projectDir, 0o700);
+
+			expect(result.stdout).toContain(
+				"declined: reclaimed nothing — evidence_incomplete: session_project_dir_unreadable (withheld=1",
+			);
+			expect(await Bun.file(path.join(fixture.blobsDir, hash)).exists()).toBe(true);
+		} finally {
+			await fsp.chmod(projectDir, 0o700).catch(() => {});
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("gjc gc --disk dry-run parity", () => {
+	for (const evidence of ["complete", "incomplete"] as const) {
+		test(`--disk reports exactly what --disk --prune removes (${evidence} evidence)`, async () => {
+			// Two identical state roots: one is only reported on, the other pruned.
+			const dry = await makeTestRoot();
+			const wet = await makeTestRoot();
+			const orphans: string[] = [];
+			try {
+				for (const fixture of [dry, wet]) {
+					const referenced = await writeBlob(fixture, "referenced payload", 10);
+					orphans.push(await writeBlob(fixture, "orphan payload", 10));
+					await writeSession(fixture, "repo-a", "live-session", { ageDays: 0, blobRefs: [referenced] });
+					if (evidence === "incomplete") await fsp.chmod(path.join(fixture.sessionsRoot, "repo-a"), 0o000);
+				}
+
+				const dryReport = await runDisk(dry, ["--disk", "--json"]);
+				const wetReport = await runDisk(wet, ["--disk", "--prune", "--json"]);
+				for (const fixture of [dry, wet]) {
+					await fsp.chmod(path.join(fixture.sessionsRoot, "repo-a"), 0o700).catch(() => {});
+				}
+				const dryDisk = requireDisk(dryReport);
+				const wetDisk = requireDisk(wetReport);
+
+				for (const surface of ["sessions", "blobs", "natives", "backups"] as const) {
+					expect(wetDisk.surfaces[surface].reclaimed).toBe(dryDisk.surfaces[surface].reclaimable);
+					expect(wetDisk.surfaces[surface].reclaimed_bytes).toBe(dryDisk.surfaces[surface].reclaimable_bytes);
+					expect(wetDisk.surfaces[surface].declined).toEqual(dryDisk.surfaces[surface].declined);
+				}
+
+				// Complete evidence still sweeps; incomplete evidence sweeps nothing.
+				expect(dryDisk.surfaces.blobs.reclaimable).toBe(evidence === "complete" ? 1 : 0);
+				expect(await Bun.file(path.join(wet.blobsDir, orphans[1]!)).exists()).toBe(evidence !== "complete");
+				expect(await Bun.file(path.join(dry.blobsDir, orphans[0]!)).exists()).toBe(true);
+			} finally {
+				for (const fixture of [dry, wet]) {
+					await fsp.chmod(path.join(fixture.sessionsRoot, "repo-a"), 0o700).catch(() => {});
+					await fsp.rm(fixture.root, { recursive: true, force: true });
+				}
+			}
+		});
+	}
+
+	test("a transcript the delete authority will refuse is never reported as reclaimable", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			const corrupt = await writeSession(fixture, "repo-a", "corrupt-old", { ageDays: 120, brokenHeader: true });
+			await writeSession(fixture, "repo-a", "newest", { ageDays: 0 });
+
+			const dryDisk = requireDisk(await runDisk(fixture, ["--disk", "--json"]));
+			expect(reasonById(dryDisk, "sessions").get("corrupt-old")).toBe(
+				"keep:retention_declined: transcript_header_unusable",
+			);
+			expect(dryDisk.surfaces.sessions.reclaimable).toBe(0);
+
+			const wetDisk = requireDisk(await runDisk(fixture, ["--disk", "--prune", "--json"]));
+			expect(wetDisk.surfaces.sessions.reclaimed).toBe(dryDisk.surfaces.sessions.reclaimable);
+			expect(await Bun.file(corrupt).exists()).toBe(true);
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("gjc gc --disk --prune (half-completed retirement)", () => {
+	test("a session whose artifacts were destroyed is reported as failed, not kept", async () => {
+		const fixture = await makeTestRoot();
+		const transcript = await writeSession(fixture, "repo-a", "old-session", { ageDays: 120 });
+		const artifactsDir = transcript.slice(0, -".jsonl".length);
+		const locked = path.join(artifactsDir, "locked");
+		try {
+			await fsp.mkdir(locked, { recursive: true });
+			await Bun.write(path.join(artifactsDir, "tool-output.txt"), "tool output");
+			await Bun.write(path.join(locked, "inner.txt"), "inner payload");
+			// Read-only directory: the recursive artifact removal cannot empty it,
+			// so retirement stops after the artifact tree has already been detached.
+			await fsp.chmod(locked, 0o500);
+			await writeSession(fixture, "repo-a", "newest", { ageDays: 0 });
+
+			const result = await runGjcGcCommand(["--disk", "--prune", "--json"], fixture.root, fixture.env, [], policy());
+			await fsp.chmod(locked, 0o700).catch(() => {});
+			const disk = requireDisk(JSON.parse(result.stdout) as GcReport);
+			const record = disk.surfaces.sessions.records.find(entry => entry.id === "old-session");
+
+			expect(await Bun.file(transcript).exists()).toBe(true);
+			expect(await Bun.file(path.join(artifactsDir, "tool-output.txt")).exists()).toBe(false);
+			expect(record?.action).toBe("reclaim_failed");
+			expect(record?.reason.startsWith("retention_incomplete: cleanup_pending_")).toBe(true);
+			expect(disk.totals.failed).toBe(1);
+			expect(result.status).toBe(1);
+		} finally {
+			await unlockTree(fixture.root);
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("gjc gc --disk (path containment)", () => {
+	test("never follows a symlinked project directory or transcript out of the state root", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			const outside = path.join(fixture.root, "outside");
+			await fsp.mkdir(outside, { recursive: true });
+			const outsideTranscript = path.join(outside, "escapee.jsonl");
+			await Bun.write(
+				outsideTranscript,
+				`${JSON.stringify({ type: "session", version: 3, id: "escapee", timestamp: "2025-01-01T00:00:00Z", cwd: fixture.root })}\n`,
+			);
+			await backdate(outsideTranscript, 900);
+
+			await writeSession(fixture, "repo-a", "newest", { ageDays: 0 });
+			// A session id that tries to traverse, a symlinked project directory and
+			// a symlinked transcript: none of them may reach outside the root.
+			const traversal = path.join(fixture.sessionsRoot, "repo-a", "..escape.jsonl");
+			await Bun.write(
+				traversal,
+				`${JSON.stringify({ type: "session", version: 3, id: "../../escape", timestamp: "2025-01-01T00:00:00Z", cwd: fixture.root })}\n`,
+			);
+			await backdate(traversal, 900);
+			await fsp.symlink(outside, path.join(fixture.sessionsRoot, "linked-project"));
+			await fsp.symlink(outsideTranscript, path.join(fixture.sessionsRoot, "repo-a", "linked.jsonl"));
+
+			const disk = requireDisk(await runDisk(fixture, ["--disk", "--prune", "--json"]));
+
+			for (const record of disk.surfaces.sessions.records) {
+				expect(record.path.startsWith(`${fixture.sessionsRoot}${path.sep}`)).toBe(true);
+			}
+			expect(disk.surfaces.sessions.records.map(record => record.id).sort()).toEqual(["..escape", "newest"]);
+			expect(await Bun.file(outsideTranscript).exists()).toBe(true);
+			expect((await fsp.lstat(path.join(fixture.sessionsRoot, "linked-project"))).isSymbolicLink()).toBe(true);
+			expect((await fsp.lstat(path.join(fixture.sessionsRoot, "repo-a", "linked.jsonl"))).isSymbolicLink()).toBe(
+				true,
+			);
 		} finally {
 			await fsp.rm(fixture.root, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/gc-disk-retention.test.ts
+++ b/packages/coding-agent/test/gc-disk-retention.test.ts
@@ -1,0 +1,527 @@
+import { describe, expect, test } from "bun:test";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getDefault } from "../src/config/settings-schema";
+import {
+	collectGcDiskReport,
+	GC_DISK_POLICY_DEFAULTS,
+	type GcDiskPolicy,
+	type GcDiskReport,
+	type GcPruneOutcome,
+	type GcRecord,
+	type GcReport,
+	type GcStore,
+	type GcStoreAdapter,
+	resolveGcDiskPolicy,
+	runGjcGcCommand,
+} from "../src/gjc-runtime/gc-runtime";
+import { SessionIndex } from "../src/sdk/broker/session-index";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Every test runs against a private state root. `GJC_CODING_AGENT_DIR` pins the
+ * agent dir, `GJC_HARNESS_ROOT_REGISTRY_DIR` pins the harness registry and
+ * `TMPDIR` pins the `local://` root parent, so nothing here can reach ~/.gjc.
+ */
+interface TestRoot {
+	root: string;
+	agentDir: string;
+	sessionsRoot: string;
+	blobsDir: string;
+	nativesDir: string;
+	backupsDir: string;
+	env: NodeJS.ProcessEnv;
+}
+
+async function makeTestRoot(): Promise<TestRoot> {
+	// realpath: the verified-delete authority rejects reparse points anywhere in
+	// the sessions root, and macOS temp dirs live behind /var -> /private/var.
+	const root = await fsp.realpath(await fsp.mkdtemp(path.join(os.tmpdir(), "gjc-gc-disk-")));
+	const agentDir = path.join(root, "agent");
+	await fsp.mkdir(agentDir, { recursive: true });
+	return {
+		root,
+		agentDir,
+		sessionsRoot: path.join(agentDir, "sessions"),
+		blobsDir: path.join(agentDir, "blobs"),
+		nativesDir: path.join(root, "natives"),
+		backupsDir: path.join(root, "backups"),
+		env: {
+			GJC_CODING_AGENT_DIR: agentDir,
+			GJC_HARNESS_ROOT_REGISTRY_DIR: path.join(root, "harness-roots"),
+			TMPDIR: path.join(root, "tmp"),
+		},
+	};
+}
+
+async function backdate(target: string, ageDays: number): Promise<void> {
+	const when = new Date(Date.now() - ageDays * DAY_MS);
+	await fsp.utimes(target, when, when);
+}
+
+async function writeSession(
+	fixture: TestRoot,
+	project: string,
+	id: string,
+	options: { ageDays: number; blobRefs?: string[] },
+): Promise<string> {
+	const directory = path.join(fixture.sessionsRoot, project);
+	await fsp.mkdir(directory, { recursive: true });
+	const file = path.join(directory, `${id}.jsonl`);
+	const lines = [
+		JSON.stringify({ type: "session", version: 3, id, timestamp: "2025-01-01T00:00:00Z", cwd: fixture.root }),
+	];
+	for (const ref of options.blobRefs ?? []) {
+		lines.push(JSON.stringify({ type: "message", role: "user", content: `blob:sha256:${ref}` }));
+	}
+	await Bun.write(file, `${lines.join("\n")}\n`);
+	await backdate(file, options.ageDays);
+	return file;
+}
+
+async function writeBlob(fixture: TestRoot, content: string, ageDays: number): Promise<string> {
+	await fsp.mkdir(fixture.blobsDir, { recursive: true, mode: 0o700 });
+	const hash = new Bun.SHA256().update(content).digest("hex");
+	const file = path.join(fixture.blobsDir, hash);
+	await Bun.write(file, content);
+	await backdate(file, ageDays);
+	return hash;
+}
+
+async function writeNativesVersion(fixture: TestRoot, version: string): Promise<void> {
+	const directory = path.join(fixture.nativesDir, version);
+	await fsp.mkdir(directory, { recursive: true });
+	await Bun.write(path.join(directory, "pi-natives.node"), `native-${version}`);
+}
+
+async function writeHarnessRegistry(fixture: TestRoot, sessionId: string): Promise<void> {
+	const dir = fixture.env.GJC_HARNESS_ROOT_REGISTRY_DIR!;
+	await fsp.mkdir(dir, { recursive: true });
+	await Bun.write(
+		path.join(dir, `${sessionId}.json`),
+		JSON.stringify({ sessionId, roots: [{ root: path.join(fixture.root, "harness"), updatedAt: "2026-01-01" }] }),
+	);
+}
+
+/** Sorted `relative-path:size` listing, used to prove a dry run mutated nothing. */
+async function snapshotTree(root: string): Promise<string[]> {
+	const out: string[] = [];
+	const stack = [root];
+	while (stack.length > 0) {
+		const dir = stack.pop()!;
+		for (const entry of await fsp.readdir(dir, { withFileTypes: true })) {
+			const child = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				out.push(`${path.relative(root, child)}/`);
+				stack.push(child);
+				continue;
+			}
+			out.push(`${path.relative(root, child)}:${(await fsp.lstat(child)).size}`);
+		}
+	}
+	return out.sort();
+}
+
+function policy(overrides: Partial<GcDiskPolicy> = {}): GcDiskPolicy {
+	return resolveGcDiskPolicy({
+		sessions_max_age_days: 30,
+		sessions_max_total_bytes: 0,
+		natives_keep_versions: 2,
+		backups_max_age_days: 14,
+		...overrides,
+	});
+}
+
+async function runDisk(fixture: TestRoot, argv: string[], overrides: Partial<GcDiskPolicy> = {}): Promise<GcReport> {
+	const result = await runGjcGcCommand(argv, fixture.root, fixture.env, [], policy(overrides));
+	expect(result.stderr).toBe("");
+	return JSON.parse(result.stdout) as GcReport;
+}
+
+function requireDisk(report: GcReport): GcDiskReport {
+	if (!report.disk) throw new Error("Expected a disk report");
+	return report.disk;
+}
+
+function reasonById(disk: GcDiskReport, surface: "sessions" | "blobs" | "natives" | "backups"): Map<string, string> {
+	return new Map(disk.surfaces[surface].records.map(record => [record.id, `${record.action}:${record.reason}`]));
+}
+
+function fakeAdapter(store: GcStore, records: GcRecord[], prune?: () => Promise<GcPruneOutcome>): GcStoreAdapter {
+	return {
+		store,
+		collect: async () => ({ records: records.map(record => ({ ...record })), errors: [] }),
+		prune: prune ?? (async () => ({ removed: true })),
+	};
+}
+
+describe("gjc gc --disk (report only)", () => {
+	test("mutates nothing and reports reclaimable bytes per surface", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			await writeSession(fixture, "repo-a", "stale-session", { ageDays: 90 });
+			await writeSession(fixture, "repo-a", "recent-session", { ageDays: 1 });
+			await writeBlob(fixture, "unreferenced blob payload", 5);
+			// Both predate any shipped release, so the running version is always newer.
+			await writeNativesVersion(fixture, "0.0.1");
+			await writeNativesVersion(fixture, "0.0.2");
+			await fsp.mkdir(fixture.backupsDir, { recursive: true });
+			await Bun.write(path.join(fixture.backupsDir, "gjc-update-old"), "old backup payload");
+			await backdate(path.join(fixture.backupsDir, "gjc-update-old"), 40);
+
+			const before = await snapshotTree(fixture.root);
+			const report = await runDisk(fixture, ["--disk", "--json"], { natives_keep_versions: 1 });
+			const disk = requireDisk(report);
+
+			expect(disk.dry_run).toBe(true);
+			expect(await snapshotTree(fixture.root)).toEqual(before);
+
+			expect(disk.surfaces.sessions.reclaimable).toBe(1);
+			expect(disk.surfaces.sessions.reclaimable_bytes).toBeGreaterThan(0);
+			expect(disk.surfaces.blobs.reclaimable).toBe(1);
+			expect(disk.surfaces.blobs.reclaimable_bytes).toBe("unreferenced blob payload".length);
+			expect(disk.surfaces.natives.reclaimable).toBe(1);
+			expect(disk.surfaces.backups.reclaimable).toBe(1);
+			expect(disk.totals.reclaimable_bytes).toBe(
+				disk.surfaces.sessions.reclaimable_bytes +
+					disk.surfaces.blobs.reclaimable_bytes +
+					disk.surfaces.natives.reclaimable_bytes +
+					disk.surfaces.backups.reclaimable_bytes,
+			);
+			expect(reasonById(disk, "sessions").get("recent-session")).toBe("keep:most_recent_resumable_session");
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("text output names each surface and its reclaimable total", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			await writeSession(fixture, "repo-a", "stale-session", { ageDays: 90 });
+			const result = await runGjcGcCommand(["--disk"], fixture.root, fixture.env, [], policy());
+			expect(result.status).toBe(0);
+			expect(result.stdout).toContain("gjc gc --disk — report only");
+			expect(result.stdout).toContain("Session transcripts");
+			expect(result.stdout).toContain("Content-addressed blobs");
+			expect(result.stdout).toContain("Cached native versions");
+			expect(result.stdout).toContain("Update/restore backups");
+			expect(result.stdout).toContain("Disk summary:");
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("gjc gc --disk --prune (sessions)", () => {
+	test("reclaims only transcripts passing both the age policy and the reference check", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			const stale = await writeSession(fixture, "repo-a", "stale-session", { ageDays: 90 });
+			const leased = await writeSession(fixture, "repo-a", "leased-session", { ageDays: 91 });
+			const recent = await writeSession(fixture, "repo-a", "recent-session", { ageDays: 1 });
+			await writeHarnessRegistry(fixture, "leased-session");
+
+			const report = await runDisk(fixture, ["--disk", "--prune", "--json"]);
+			const disk = requireDisk(report);
+			const reasons = reasonById(disk, "sessions");
+
+			expect(reasons.get("stale-session")).toBe("reclaimed:older_than_max_age(30d)");
+			expect(reasons.get("leased-session")).toBe("keep:referenced_by_live_surface");
+			expect(reasons.get("recent-session")).toBe("keep:most_recent_resumable_session");
+			expect(await Bun.file(stale).exists()).toBe(false);
+			expect(await Bun.file(leased).exists()).toBe(true);
+			expect(await Bun.file(recent).exists()).toBe(true);
+			expect(disk.dry_run).toBe(false);
+			expect(disk.surfaces.sessions.reclaimed).toBe(1);
+			expect(report.disk?.totals.failed).toBe(0);
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("keeps an aged transcript whose session is registered as an SDK host", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			const hosted = await writeSession(fixture, "repo-a", "hosted-session", { ageDays: 120 });
+			await writeSession(fixture, "repo-a", "recent-session", { ageDays: 1 });
+			const index = await new SessionIndex(fixture.agentDir).open();
+			await index.append({
+				type: "host_registered",
+				sessionId: "hosted-session",
+				locator: { repo: fixture.root, stateRoot: fixture.root },
+				endpointGeneration: 1,
+				pid: process.pid,
+				endpointMtimeMs: Date.now(),
+			});
+
+			const disk = requireDisk(await runDisk(fixture, ["--disk", "--prune", "--json"]));
+			expect(reasonById(disk, "sessions").get("hosted-session")).toBe("keep:referenced_by_live_surface");
+			expect(await Bun.file(hosted).exists()).toBe(true);
+			expect(disk.surfaces.sessions.reclaimed).toBe(0);
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("the size axis only retires transcripts that the age axis already cleared for liveness", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			await writeSession(fixture, "repo-a", "older-recent", { ageDays: 5 });
+			await writeSession(fixture, "repo-a", "newer-recent", { ageDays: 1 });
+			await writeHarnessRegistry(fixture, "older-recent");
+
+			// Budget of 1 byte forces the size axis on, but the only age-eligible
+			// candidate is referenced, so nothing may be retired.
+			const referenced = requireDisk(await runDisk(fixture, ["--disk", "--json"], { sessions_max_total_bytes: 1 }));
+			expect(referenced.surfaces.sessions.reclaimable).toBe(0);
+
+			await fsp.rm(path.join(fixture.env.GJC_HARNESS_ROOT_REGISTRY_DIR!, "older-recent.json"));
+			const unreferenced = requireDisk(
+				await runDisk(fixture, ["--disk", "--json"], { sessions_max_total_bytes: 1 }),
+			);
+			expect(reasonById(unreferenced, "sessions").get("older-recent")).toBe("would_reclaim:over_max_total_bytes(1)");
+			expect(reasonById(unreferenced, "sessions").get("newer-recent")).toBe("keep:most_recent_resumable_session");
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("gjc gc --disk --prune (blob mark and sweep)", () => {
+	test("removes only blobs unreferenced by every surviving session", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			const shared = await writeBlob(fixture, "shared attachment", 5);
+			const staleOnly = await writeBlob(fixture, "stale attachment", 5);
+			const fresh = await writeBlob(fixture, "just written", 0);
+			await writeSession(fixture, "repo-a", "stale-session", { ageDays: 90, blobRefs: [shared, staleOnly] });
+			await writeSession(fixture, "repo-a", "keeper-session", { ageDays: 1, blobRefs: [shared] });
+
+			const disk = requireDisk(await runDisk(fixture, ["--disk", "--prune", "--json"]));
+			const reasons = reasonById(disk, "blobs");
+
+			expect(reasons.get(shared)).toBe("keep:referenced_by_surviving_session");
+			expect(reasons.get(staleOnly)).toBe("reclaimed:unreferenced_by_any_surviving_session");
+			expect(reasons.get(fresh)).toBe("keep:within_write_grace_window");
+			expect(await Bun.file(path.join(fixture.blobsDir, shared)).exists()).toBe(true);
+			expect(await Bun.file(path.join(fixture.blobsDir, staleOnly)).exists()).toBe(false);
+			expect(await Bun.file(path.join(fixture.blobsDir, fresh)).exists()).toBe(true);
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("keeps every blob when a surviving transcript could not be read for marking", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			const orphan = await writeBlob(fixture, "orphan attachment", 5);
+			const transcript = await writeSession(fixture, "repo-a", "keeper-session", { ageDays: 1 });
+			await fsp.chmod(transcript, 0o000);
+
+			const disk = requireDisk(await runDisk(fixture, ["--disk", "--json"]));
+			await fsp.chmod(transcript, 0o600);
+
+			expect(reasonById(disk, "blobs").get(orphan)).toBe("keep:mark_scan_incomplete");
+			expect(disk.surfaces.blobs.reclaimable).toBe(0);
+			expect(disk.errors.some(error => error.surface === "blobs")).toBe(true);
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("gjc gc --disk (natives retention)", () => {
+	test("keeps the running version plus the configured number of predecessors", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			for (const version of ["0.1.0", "0.2.0", "0.3.0", "0.4.0", "0.5.0"]) {
+				await writeNativesVersion(fixture, version);
+			}
+			await fsp.mkdir(path.join(fixture.nativesDir, "not-a-version"), { recursive: true });
+
+			const disk = await collectGcDiskReport({
+				agentDir: fixture.agentDir,
+				env: fixture.env,
+				policy: policy({ natives_keep_versions: 2 }),
+				prune: false,
+				runningVersion: "0.4.0",
+			});
+			const reasons = reasonById(disk, "natives");
+
+			expect(reasons.get("0.5.0")).toBe("keep:retained_version(keepVersions=2)");
+			expect(reasons.get("0.4.0")).toBe("keep:running_version");
+			expect(reasons.get("0.3.0")).toBe("keep:retained_version(keepVersions=2)");
+			expect(reasons.get("0.2.0")).toBe("keep:retained_version(keepVersions=2)");
+			expect(reasons.get("0.1.0")).toBe("would_reclaim:beyond_keep_versions(2)");
+			expect(reasons.get("not-a-version")).toBe("keep:unrecognized_version_directory");
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("prune removes only the versions beyond the retention window", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			for (const version of ["0.1.0", "0.2.0", "0.3.0"]) await writeNativesVersion(fixture, version);
+
+			await collectGcDiskReport({
+				agentDir: fixture.agentDir,
+				env: fixture.env,
+				policy: policy({ natives_keep_versions: 1 }),
+				prune: true,
+				runningVersion: "0.3.0",
+			});
+
+			expect((await fsp.readdir(fixture.nativesDir)).sort()).toEqual(["0.2.0", "0.3.0"]);
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("gjc gc --disk (backups retention)", () => {
+	test("ages out backup roots and *.bak siblings, keeping recent ones", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			await fsp.mkdir(fixture.backupsDir, { recursive: true });
+			const old = path.join(fixture.backupsDir, "natives-0.1.0-before-update");
+			await fsp.mkdir(old, { recursive: true });
+			await Bun.write(path.join(old, "payload.bin"), "x".repeat(64));
+			await backdate(old, 40);
+			const recent = path.join(fixture.backupsDir, "gjc-update-2026-08-01");
+			await Bun.write(recent, "recent backup");
+			await backdate(recent, 2);
+			const agentBak = path.join(fixture.root, "agent.bak");
+			await fsp.mkdir(agentBak, { recursive: true });
+			await Bun.write(path.join(agentBak, "settings.json"), "{}");
+			await backdate(agentBak, 40);
+
+			const disk = await collectGcDiskReport({
+				agentDir: fixture.agentDir,
+				env: fixture.env,
+				policy: policy(),
+				prune: true,
+			});
+			const reasons = reasonById(disk, "backups");
+
+			expect(reasons.get("natives-0.1.0-before-update")).toBe("reclaimed:older_than_max_age(14d)");
+			expect(reasons.get("agent.bak")).toBe("reclaimed:older_than_max_age(14d)");
+			expect(reasons.get("gjc-update-2026-08-01")).toBe("keep:newer_than_max_age(14d)");
+			expect(await fsp.readdir(fixture.backupsDir)).toEqual(["gjc-update-2026-08-01"]);
+			expect(await Bun.file(path.join(agentBak, "settings.json")).exists()).toBe(false);
+			// The live agent directory is never a backup candidate.
+			expect((await fsp.lstat(fixture.agentDir)).isDirectory()).toBe(true);
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("liveness axis is unchanged without --disk", () => {
+	test("no disk section is produced and the dry-run report is byte-identical", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			await writeSession(fixture, "repo-a", "stale-session", { ageDays: 900 });
+			await writeBlob(fixture, "orphan", 30);
+
+			const before = await snapshotTree(fixture.root);
+			const result = await runGjcGcCommand(["--json"], fixture.root, fixture.env, []);
+			const report = JSON.parse(result.stdout) as GcReport;
+
+			expect(report.disk).toBeUndefined();
+			expect(result.status).toBe(0);
+			expect(await snapshotTree(fixture.root)).toEqual(before);
+
+			// Even an explicit prune leaves every byte in place without --disk.
+			const pruned = await runGjcGcCommand(["--prune", "--json"], fixture.root, fixture.env, []);
+			expect((JSON.parse(pruned.stdout) as GcReport).disk).toBeUndefined();
+			expect(await snapshotTree(fixture.root)).toEqual(before);
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("exit-code policy for the liveness stores is untouched", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			const record: GcRecord = {
+				store: "file_locks",
+				id: "lock",
+				status: "dead",
+				stale: true,
+				removable: true,
+				action: "none",
+				reason: "owner pid is dead",
+			};
+			const failing = fakeAdapter("file_locks", [record], async () => ({ removed: false, error: "EACCES" }));
+
+			const withoutDisk = await runGjcGcCommand(["--prune", "--json"], fixture.root, fixture.env, [failing]);
+			expect(withoutDisk.status).toBe(1);
+			expect((JSON.parse(withoutDisk.stdout) as GcReport).counts.failed).toBe(1);
+
+			// The disk axis must not mask or change that outcome.
+			const withDisk = await runGjcGcCommand(
+				["--prune", "--disk", "--json"],
+				fixture.root,
+				fixture.env,
+				[failing],
+				policy(),
+			);
+			expect(withDisk.status).toBe(1);
+			expect((JSON.parse(withDisk.stdout) as GcReport).counts.failed).toBe(1);
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("--disk is rejected as an unknown flag nowhere and never implies --prune", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			const stale = await writeSession(fixture, "repo-a", "stale-session", { ageDays: 900 });
+			await writeSession(fixture, "repo-a", "recent-session", { ageDays: 1 });
+
+			const result = await runGjcGcCommand(["--disk", "--json"], fixture.root, fixture.env, [], policy());
+			expect(result.status).toBe(0);
+			expect(await Bun.file(stale).exists()).toBe(true);
+
+			const explicitDryRun = await runGjcGcCommand(
+				["--disk", "--prune", "--dry-run", "--json"],
+				fixture.root,
+				fixture.env,
+				[],
+				policy(),
+			);
+			expect(requireDisk(JSON.parse(explicitDryRun.stdout) as GcReport).dry_run).toBe(true);
+			expect(await Bun.file(stale).exists()).toBe(true);
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("gc disk policy defaults", () => {
+	test("mirror the gc.* settings schema", () => {
+		expect(GC_DISK_POLICY_DEFAULTS).toEqual({
+			sessions_max_age_days: getDefault("gc.sessions.maxAgeDays"),
+			sessions_max_total_bytes: getDefault("gc.sessions.maxTotalBytes"),
+			natives_keep_versions: getDefault("gc.natives.keepVersions"),
+			backups_max_age_days: getDefault("gc.backups.maxAgeDays"),
+		});
+		expect(GC_DISK_POLICY_DEFAULTS).toEqual({
+			sessions_max_age_days: 60,
+			sessions_max_total_bytes: 0,
+			natives_keep_versions: 2,
+			backups_max_age_days: 30,
+		});
+	});
+
+	test("overrides replace only the knobs they supply", () => {
+		expect(resolveGcDiskPolicy({ natives_keep_versions: 5 })).toEqual({
+			...GC_DISK_POLICY_DEFAULTS,
+			natives_keep_versions: 5,
+		});
+		expect(resolveGcDiskPolicy()).toEqual(GC_DISK_POLICY_DEFAULTS);
+	});
+});

--- a/packages/coding-agent/test/gc-disk-retention.test.ts
+++ b/packages/coding-agent/test/gc-disk-retention.test.ts
@@ -352,6 +352,65 @@ describe("gjc gc --disk --prune (blob mark and sweep)", () => {
 			await fsp.rm(fixture.root, { recursive: true, force: true });
 		}
 	});
+
+	test("a session created while the store is being measured keeps its blob", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			// Older than the write grace window, so the only thing that can save it is
+			// a reference — and that reference is written after the session walk has
+			// already enumerated the store.
+			const blob = await writeBlob(fixture, "payload referenced by a session that starts mid-sweep", 10);
+			const survivor = await writeSession(fixture, "repo-a", "survivor", { ageDays: 0 });
+			// A wide artifact tree keeps the session walk busy long enough for the
+			// late session to land after enumeration and before the blob sweep.
+			const artifacts = survivor.slice(0, -".jsonl".length);
+			await fsp.mkdir(artifacts, { recursive: true });
+			for (let index = 0; index < 6000; index++) await Bun.write(path.join(artifacts, `entry-${index}`), "x");
+
+			const run = runGjcGcCommand(["--disk", "--prune", "--json"], fixture.root, fixture.env, [], policy());
+			await Bun.sleep(10);
+			await writeSession(fixture, "repo-b", "late-session", { ageDays: 0, blobRefs: [blob] });
+
+			const disk = requireDisk(JSON.parse((await run).stdout) as GcReport);
+			expect(reasonById(disk, "blobs").get(blob)).toBe("keep:referenced_by_surviving_session");
+			expect(await Bun.file(path.join(fixture.blobsDir, blob)).exists()).toBe(true);
+			expect(disk.errors).toEqual([]);
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	}, 30000);
+
+	test("withholds the sweep when a transcript keeps changing under the mark", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			const orphan = await writeBlob(fixture, "orphan payload under a moving mark", 10);
+			const transcript = await writeSession(fixture, "repo-a", "busy-session", { ageDays: 0 });
+
+			let appending = true;
+			const appender = (async () => {
+				for (let index = 0; appending && index < 20000; index++) {
+					await fsp.appendFile(
+						transcript,
+						`${JSON.stringify({ type: "message", role: "user", content: index })}\n`,
+					);
+					await Bun.sleep(0);
+				}
+			})();
+			const report = await runGjcGcCommand(["--disk", "--prune", "--json"], fixture.root, fixture.env, [], policy());
+			appending = false;
+			await appender;
+
+			const disk = requireDisk(JSON.parse(report.stdout) as GcReport);
+			expect(reasonById(disk, "blobs").get(orphan)).toBe(
+				"keep:withheld_evidence_incomplete: sessions_changed_during_mark",
+			);
+			expect(disk.surfaces.blobs.declined?.reason).toBe("evidence_incomplete: sessions_changed_during_mark");
+			expect(disk.surfaces.blobs.reclaimable).toBe(0);
+			expect(await Bun.file(path.join(fixture.blobsDir, orphan)).exists()).toBe(true);
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	}, 30000);
 });
 
 describe("gjc gc --disk --prune (blob sweep on incomplete evidence)", () => {
@@ -490,6 +549,65 @@ describe("gjc gc --disk dry-run parity", () => {
 			expect(await Bun.file(corrupt).exists()).toBe(true);
 		} finally {
 			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("a hard-linked transcript is neither promised by the dry run nor retired by prune", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			// The verified delete authority refuses anything but a single-link
+			// transcript, so the age policy alone must not report it as reclaimable.
+			const linked = await writeSession(fixture, "repo-a", "linked-old", { ageDays: 120 });
+			const artifacts = linked.slice(0, -".jsonl".length);
+			await fsp.mkdir(artifacts, { recursive: true });
+			await Bun.write(path.join(artifacts, "attachment"), "artifact bytes");
+			await fsp.link(linked, path.join(fixture.sessionsRoot, "repo-a", "linked-old.alias"));
+			await writeSession(fixture, "repo-a", "newest", { ageDays: 0 });
+
+			const dryDisk = requireDisk(await runDisk(fixture, ["--disk", "--json"]));
+			expect(reasonById(dryDisk, "sessions").get("linked-old")).toBe(
+				"keep:retention_declined: transcript_not_single_link",
+			);
+			expect(dryDisk.surfaces.sessions.reclaimable).toBe(0);
+
+			const wetDisk = requireDisk(await runDisk(fixture, ["--disk", "--prune", "--json"]));
+			expect(wetDisk.surfaces.sessions.reclaimed).toBe(dryDisk.surfaces.sessions.reclaimable);
+			expect(wetDisk.surfaces.sessions.reclaimed_bytes).toBe(dryDisk.surfaces.sessions.reclaimable_bytes);
+			expect(await Bun.file(linked).exists()).toBe(true);
+			// The refusal lands before the artifact phase, so nothing of the session
+			// is destroyed on the way to a keep.
+			expect(await Bun.file(path.join(artifacts, "attachment")).exists()).toBe(true);
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("a blob whose only reference is a retiring transcript stays reclaimable in the dry run", async () => {
+		// The dry run leaves the retiring transcript on disk, so the blob sweep must
+		// not treat it as live evidence and quietly under-report what prune removes.
+		const dry = await makeTestRoot();
+		const wet = await makeTestRoot();
+		const blobs: string[] = [];
+		try {
+			for (const fixture of [dry, wet]) {
+				const blob = await writeBlob(fixture, "payload referenced only by an aged session", 10);
+				blobs.push(blob);
+				await writeSession(fixture, "repo-a", "aged-session", { ageDays: 120, blobRefs: [blob] });
+				await writeSession(fixture, "repo-a", "newest", { ageDays: 0 });
+			}
+
+			const dryDisk = requireDisk(await runDisk(dry, ["--disk", "--json"]));
+			const wetDisk = requireDisk(await runDisk(wet, ["--disk", "--prune", "--json"]));
+
+			expect(dryDisk.surfaces.sessions.reclaimable).toBe(1);
+			expect(dryDisk.surfaces.blobs.reclaimable).toBe(1);
+			expect(wetDisk.surfaces.sessions.reclaimed).toBe(dryDisk.surfaces.sessions.reclaimable);
+			expect(wetDisk.surfaces.blobs.reclaimed).toBe(dryDisk.surfaces.blobs.reclaimable);
+			expect(await Bun.file(path.join(wet.blobsDir, blobs[1]!)).exists()).toBe(false);
+			expect(await Bun.file(path.join(dry.blobsDir, blobs[0]!)).exists()).toBe(true);
+		} finally {
+			await fsp.rm(dry.root, { recursive: true, force: true });
+			await fsp.rm(wet.root, { recursive: true, force: true });
 		}
 	});
 });

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -2254,6 +2254,46 @@
 			},
 			"additionalProperties": false
 		},
+		"gc": {
+			"type": "object",
+			"properties": {
+				"sessions": {
+					"type": "object",
+					"properties": {
+						"maxAgeDays": {
+							"type": "number",
+							"default": 60
+						},
+						"maxTotalBytes": {
+							"type": "number",
+							"default": 0
+						}
+					},
+					"additionalProperties": false
+				},
+				"natives": {
+					"type": "object",
+					"properties": {
+						"keepVersions": {
+							"type": "number",
+							"default": 2
+						}
+					},
+					"additionalProperties": false
+				},
+				"backups": {
+					"type": "object",
+					"properties": {
+						"maxAgeDays": {
+							"type": "number",
+							"default": 30
+						}
+					},
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		},
 		"resourceGc": {
 			"type": "object",
 			"properties": {


### PR DESCRIPTION
Scoped replacement for the disk-retention portion of the closed #4021. One commit, 7 files, one feature.

Fixes #3853.

## The problem

`gjc gc` is a liveness reaper, not a garbage collector for disk. It classifies six stores (`harness_leases`, `team_workers`, `file_locks`, `tmux_sessions`, `registry_entries`, `local_roots`) and removes a record only when its owning PID is provably dead. That contract is good and stays exactly as it is. But **nothing in GJC ever reclaimed bytes** — no age-based, size-based or orphan-based retention for the session store, the blob store, cached native versions, or update backups.

Measured on one daily-driver workstation after ~3 weeks of normal use:

```
13 GB   ~/.gjc
 6.9 GB   agent/sessions          (5.21 GB older than 7d, 3.50 GB older than 14d)
 371 MB   agent/blobs
 552 MB   natives                 (14 cached versions)
 717 MB   backups
 719 MB   agent.bak
```

None of it reachable through any command. The only remedy was `rm -rf` with hand-written `find` predicates against a live session store — exactly the operation users should not be improvising.

## What this adds

- `gjc gc --disk` — reports reclaimable bytes per surface and **mutates nothing**, honouring the existing `--json` output.
- `gjc gc --disk --prune` — performs the reclaim.
- Policy knobs with conservative defaults: `gc.sessions.maxAgeDays` (60), `gc.sessions.maxTotalBytes`, `gc.natives.keepVersions` (2), `gc.backups.maxAgeDays`.

Surfaces, in order: session transcripts (reference-aware, reusing the identity-bound deletion authority in `session-storage.ts` rather than deleting files directly), then a mark-and-sweep of blobs left unreferenced by the retirement, then cached native versions (running version plus N predecessors), then backups and `*.bak` roots.

Guardrails, mirroring the existing design:

- Dry-run by default; `--prune` required to delete.
- Fail-closed: anything live, referenced, permission-denied, unreadable or ambiguous is **kept, with a reason** — same posture as `gcPidProbe`.
- A session referenced by an active lease or recently resumable is never removed.
- Per-surface counts and reclaimed bytes in the report, so the effect is auditable.
- No auto-GC on startup. An implicit deletion pass over resumable user work must never be a startup side effect.

Deliberately **out of scope**: reclaiming `~/.gjc/wt` managed worktrees. Deleting worktrees needs evidence-based merge detection and belongs in its own change.

## Verification

Load-bearing proof — restoring `packages/coding-agent/src` from `origin/dev` and re-running:

```
with fix:     15 pass / 0 fail
without fix:   0 pass / 1 fail
```

```
gc-disk-retention + gc-runtime              39 pass / 0 fail
bun --cwd=packages/coding-agent run check   exit 0
bun run check:schemas                       clean
```

`schemas/config.schema.json` is regenerated by `bun run generate-schemas`, not hand-edited. The blob test proves the sweep is reference-aware by retiring one session while a second still references the same blob hash. All tests run against a temp state root; the real `~/.gjc` is never touched.

## Relationship to #4021

#4021 bundled twelve unrelated defects into 53 files and was closed with the instruction to open fresh, scoped PRs. This is the last of those, after #4031 (ACP turn lifecycle), #4033 (chat daemon reconnect), #4035 (broker/host lifecycle) and #4036 (tool diagnostics).

Closes #3853
