### PR TITLE
fix(ai): bound Anthropic thinking-replay repairs across a session

### DIFF
--- a/artifacts/issue-3670-anthropic-cache-eval.json
+++ b/artifacts/issue-3670-anthropic-cache-eval.json
@@ -6,8 +6,8 @@
 	"source": {
 		"url": "https://platform.claude.com/docs/en/build-with-claude/prompt-caching",
 		"retrievedAt": "2026-07-18",
-		"providerSourceBlobOid": "f36330e0a4d661d7f945060b500cc5270ea0b3c1",
-		"providerSourceSha256": "7dd532f42baabfebe45aad127f0baebb42ef6cfd7ebfd9f350f252734b7f36b3",
+		"providerSourceBlobOid": "782cfc659e07c5a297481712a804e7934f5772cd",
+		"providerSourceSha256": "7e34f6e02e80a586ec357c6d429d0dbbcf8093883721478c51e3a7f635c138d0",
 		"inputFixtureSha256": "562926fba79f003eff4d45c0da2292ac66d84302e3960b2d7493441ade1f9e04"
 	},
 	"derivationCommands": [

--- a/artifacts/issue-3670-anthropic-cache-eval.json
+++ b/artifacts/issue-3670-anthropic-cache-eval.json
@@ -6,8 +6,8 @@
 	"source": {
 		"url": "https://platform.claude.com/docs/en/build-with-claude/prompt-caching",
 		"retrievedAt": "2026-07-18",
-		"providerSourceBlobOid": "782cfc659e07c5a297481712a804e7934f5772cd",
-		"providerSourceSha256": "7e34f6e02e80a586ec357c6d429d0dbbcf8093883721478c51e3a7f635c138d0",
+		"providerSourceBlobOid": "d9091edf97f8cfcc7e0ef4c2aafa9af587a12196",
+		"providerSourceSha256": "a80ded06f044bff701ebfd6ee41829b7daa8e17445fe3e00ccb177f42b0978a8",
 		"inputFixtureSha256": "562926fba79f003eff4d45c0da2292ac66d84302e3960b2d7493441ade1f9e04"
 	},
 	"derivationCommands": [

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -317,14 +317,14 @@ let warnedStopSequencesTrim = false;
 const ANTHROPIC_PROVIDER_SESSION_STATE_KEY = "anthropic-messages";
 
 /**
- * Scope of the replayed-thinking repair currently applied to this session:
- * `latest` drops native thinking from the newest assistant turn, `all` stops
- * replaying native thinking entirely. Persisted across stream re-invocations so
- * a repair that keeps being rejected is not re-attempted from scratch on every
- * turn (issue #4011), and released again by the first stream that completes: the
- * masked `api_error` that can trigger a repair is unclassifiable and may have
- * been transient, so an escalation that no completed request ever confirmed must
- * not pin the rest of the session to a degraded replay.
+ * Scope of a classified replayed-thinking repair currently applied to this
+ * session: `latest` drops native thinking from the newest assistant turn, `all`
+ * stops replaying native thinking entirely. Persisted across stream
+ * re-invocations so a repair that keeps being rejected is not re-attempted from
+ * scratch on every turn (issue #4011), and released again by the first stream
+ * that completes. Unclassifiable masked `api_error` repairs remain local to the
+ * current stream invocation because a transient masked failure must not degrade
+ * later turns.
  */
 type AnthropicThinkingReplayRepairScope = "none" | "latest" | "all";
 
@@ -1974,6 +1974,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 					}
 					const thinkingSignatureInvalid = isAnthropicThinkingSignatureInvalidError(streamFailure);
 					const thinkingBlocksImmutable = isAnthropicThinkingBlockMutationError(streamFailure);
+					const maskedProxyRejection = isAnthropicMaskedProxyRejection(streamFailure);
 					if (
 						!options?.fallbackManaged &&
 						thinkingReplayRepairScope !== "all" &&
@@ -1984,7 +1985,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 							// Masked proxy rejection: unclassifiable on its own, so the replayed
 							// request shape is the evidence. Without signed thinking blocks in
 							// flight there is nothing to repair and the error must surface.
-							(isAnthropicMaskedProxyRejection(streamFailure) && hasNativeThinkingBlocks(params.messages)))
+							(maskedProxyRejection && hasNativeThinkingBlocks(params.messages)))
 					) {
 						// "cannot be modified" means the cited blocks must be replayed byte for
 						// byte, so editing that turn again can never converge — the only recovery
@@ -2004,8 +2005,10 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 						});
 						thinkingReplayRepairScope = nextScope;
 						if (providerSessionState) {
-							providerSessionState.thinkingReplayRepairScope = nextScope;
 							providerSessionState.thinkingReplayRepairAttempts = thinkingReplayRepairAttempts;
+							if (!maskedProxyRejection) {
+								providerSessionState.thinkingReplayRepairScope = nextScope;
+							}
 						}
 						params = await prepareParams();
 						// The provider retry budget is deliberately NOT reset here: a repair that

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -316,10 +316,28 @@ let warnedStopSequencesTrim = false;
 
 const ANTHROPIC_PROVIDER_SESSION_STATE_KEY = "anthropic-messages";
 
+/**
+ * Scope of the replayed-thinking repair currently applied to this session:
+ * `latest` drops native thinking from the newest assistant turn, `all` stops
+ * replaying native thinking entirely. Persisted so a repair that already
+ * converged is not undone (and not re-attempted) when the stream is
+ * re-invoked for the same session.
+ */
+type AnthropicThinkingReplayRepairScope = "none" | "latest" | "all";
+
+/**
+ * Repairs are bounded independently of `PROVIDER_MAX_RETRIES` because they do
+ * not consume the provider retry budget: without their own ceiling an
+ * unacceptable request shape retries forever (issue #4011).
+ */
+const ANTHROPIC_MAX_THINKING_REPAIRS = 2;
+
 type AnthropicProviderSessionState = ProviderSessionState & {
 	strictToolsDisabled: boolean;
 	fastModeDisabled: boolean;
 	generatedCacheBudget: GeneratedCacheBudget;
+	thinkingReplayRepairScope: AnthropicThinkingReplayRepairScope;
+	thinkingReplayRepairAttempts: number;
 };
 
 function createAnthropicProviderSessionState(): AnthropicProviderSessionState {
@@ -327,10 +345,14 @@ function createAnthropicProviderSessionState(): AnthropicProviderSessionState {
 		strictToolsDisabled: false,
 		fastModeDisabled: false,
 		generatedCacheBudget: 2,
+		thinkingReplayRepairScope: "none",
+		thinkingReplayRepairAttempts: 0,
 		close: () => {
 			state.strictToolsDisabled = false;
 			state.fastModeDisabled = false;
 			state.generatedCacheBudget = 2;
+			state.thinkingReplayRepairScope = "none";
+			state.thinkingReplayRepairAttempts = 0;
 		},
 	};
 	return state;
@@ -1449,8 +1471,9 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 			let strictFallbackErrorMessage: string | undefined;
 			let dropFastMode = providerSessionState?.fastModeDisabled ?? false;
 			let droppedForcedToolChoice = false;
-			let repairLatestAssistantThinking = false;
-			let repairAllAssistantThinking = false;
+			let thinkingReplayRepairScope: AnthropicThinkingReplayRepairScope =
+				providerSessionState?.thinkingReplayRepairScope ?? "none";
+			let thinkingReplayRepairAttempts = providerSessionState?.thinkingReplayRepairAttempts ?? 0;
 			let generatedCacheBudget: GeneratedCacheBudget = providerSessionState?.generatedCacheBudget ?? 2;
 			const prepareParams = async (): Promise<MessageCreateParamsStreaming> => {
 				// Degradation state is cumulative: every fallback rebuild must merge all
@@ -1465,7 +1488,10 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 					isOAuthToken,
 					options,
 					disableStrictTools,
-					{ repairLatestAssistantThinking, repairAllAssistantThinking },
+					{
+						repairLatestAssistantThinking: thinkingReplayRepairScope === "latest",
+						repairAllAssistantThinking: thinkingReplayRepairScope === "all",
+					},
 					generatedCacheBudget,
 				);
 				if (droppedForcedToolChoice) {
@@ -1932,31 +1958,44 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 						continue;
 					}
 					const thinkingSignatureInvalid = isAnthropicThinkingSignatureInvalidError(streamFailure);
+					const thinkingBlocksImmutable = isAnthropicThinkingBlockMutationError(streamFailure);
 					if (
 						!options?.fallbackManaged &&
-						!repairAllAssistantThinking &&
+						thinkingReplayRepairScope !== "all" &&
+						thinkingReplayRepairAttempts < ANTHROPIC_MAX_THINKING_REPAIRS &&
 						firstTokenTime === undefined &&
 						(thinkingSignatureInvalid ||
-							isAnthropicThinkingBlockMutationError(streamFailure) ||
+							thinkingBlocksImmutable ||
 							// Masked proxy rejection: unclassifiable on its own, so the replayed
 							// request shape is the evidence. Without signed thinking blocks in
 							// flight there is nothing to repair and the error must surface.
 							(isAnthropicMaskedProxyRejection(streamFailure) && hasNativeThinkingBlocks(params.messages)))
 					) {
-						// The mutation 400 blames the "latest assistant message", but its cited
-						// `messages.N.content.M` path can point at an EARLIER replayed turn, so the
-						// latest-only repair gets rejected identically. Escalate to the full-history
-						// repair instead of burning the single retry on one scope.
-						const escalateToAll: boolean = thinkingSignatureInvalid || repairLatestAssistantThinking;
+						// "cannot be modified" means the cited blocks must be replayed byte for
+						// byte, so editing that turn again can never converge — the only recovery
+						// is to stop replaying native thinking at all. The invalid-signature 400
+						// cites blocks anywhere in history and needs the same full-history scope.
+						// Only the unclassifiable masked rejection is worth probing latest-first.
+						const nextScope: AnthropicThinkingReplayRepairScope =
+							thinkingSignatureInvalid || thinkingBlocksImmutable || thinkingReplayRepairScope === "latest"
+								? "all"
+								: "latest";
+						thinkingReplayRepairAttempts++;
 						logger.debug("anthropic: repairing assistant thinking replay after provider rejection", {
 							model: model.id,
-							scope: escalateToAll ? "all" : "latest",
+							scope: nextScope,
+							attempt: thinkingReplayRepairAttempts,
 							error: streamFailure instanceof Error ? streamFailure.message : String(streamFailure),
 						});
-						repairLatestAssistantThinking = !escalateToAll;
-						repairAllAssistantThinking = escalateToAll;
+						thinkingReplayRepairScope = nextScope;
+						if (providerSessionState) {
+							providerSessionState.thinkingReplayRepairScope = nextScope;
+							providerSessionState.thinkingReplayRepairAttempts = thinkingReplayRepairAttempts;
+						}
 						params = await prepareParams();
-						providerRetryAttempt = 0;
+						// The provider retry budget is deliberately NOT reset here: a repair that
+						// keeps being rejected must run out instead of renewing the budget it is
+						// supposed to consume (issue #4011).
 						resetOutputForRetry();
 						continue;
 					}

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -319,16 +319,21 @@ const ANTHROPIC_PROVIDER_SESSION_STATE_KEY = "anthropic-messages";
 /**
  * Scope of the replayed-thinking repair currently applied to this session:
  * `latest` drops native thinking from the newest assistant turn, `all` stops
- * replaying native thinking entirely. Persisted so a repair that already
- * converged is not undone (and not re-attempted) when the stream is
- * re-invoked for the same session.
+ * replaying native thinking entirely. Persisted across stream re-invocations so
+ * a repair that keeps being rejected is not re-attempted from scratch on every
+ * turn (issue #4011), and released again by the first stream that completes: the
+ * masked `api_error` that can trigger a repair is unclassifiable and may have
+ * been transient, so an escalation that no completed request ever confirmed must
+ * not pin the rest of the session to a degraded replay.
  */
 type AnthropicThinkingReplayRepairScope = "none" | "latest" | "all";
 
 /**
  * Repairs are bounded independently of `PROVIDER_MAX_RETRIES` because they do
  * not consume the provider retry budget: without their own ceiling an
- * unacceptable request shape retries forever (issue #4011).
+ * unacceptable request shape retries forever (issue #4011). The ceiling spans
+ * the session rather than a single stream, and only a completed stream re-arms
+ * it — an unacceptable shape never completes, so it can never buy more repairs.
  */
 const ANTHROPIC_MAX_THINKING_REPAIRS = 2;
 
@@ -1903,6 +1908,16 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 
 					if (output.stopReason === "aborted" || output.stopReason === "error") {
 						throw new Error(output.errorMessage ?? "An unknown error occurred");
+					}
+					// The first stream that completes is the only evidence available that this
+					// session is not the #4011 loop, which never produced one. Release the
+					// repair escalation and the budget it consumed: the masked `api_error`
+					// branch above fires on an error nobody can classify, so keeping its
+					// guess would silently strip native thinking replay from every later
+					// turn of the session over what may have been one transient blip.
+					if (providerSessionState && (thinkingReplayRepairScope !== "none" || thinkingReplayRepairAttempts > 0)) {
+						providerSessionState.thinkingReplayRepairScope = "none";
+						providerSessionState.thinkingReplayRepairAttempts = 0;
 					}
 					break;
 				} catch (streamError) {

--- a/packages/ai/test/anthropic-thinking-repair-budget.test.ts
+++ b/packages/ai/test/anthropic-thinking-repair-budget.test.ts
@@ -233,9 +233,9 @@ describe("Anthropic thinking-replay repair budget (issue #4011)", () => {
 		expect(second.stopReason).toBe("error");
 		expect(second.errorMessage).toContain("An error occurred while processing the request.");
 		expect(requestBodies).toHaveLength(4);
-		// The degradation the first call converged on is still applied: nothing
-		// completed, so nothing released the escalation.
-		expect(replayedThinkingBlockTypes(requestBodies[3])).toEqual([]);
+		// The spent budget remains session-scoped, but the unclassifiable masked
+		// rejection does not carry its speculative degradation into the next turn.
+		expect(replayedThinkingBlockTypes(requestBodies[3])).toEqual(["thinking", "thinking"]);
 	});
 
 	it("stays bounded across three turns that never complete a stream", async () => {

--- a/packages/ai/test/anthropic-thinking-repair-budget.test.ts
+++ b/packages/ai/test/anthropic-thinking-repair-budget.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it, vi } from "bun:test";
+import type Anthropic from "@anthropic-ai/sdk";
+import { streamAnthropic } from "@gajae-code/ai/providers/anthropic";
+import type {
+	AssistantMessage,
+	AssistantMessageEvent,
+	Context,
+	Model,
+	ProviderSessionState,
+	UserMessage,
+} from "@gajae-code/ai/types";
+
+/**
+ * Issue #4011: a single ACP session burned 121 rejected Anthropic requests over
+ * 29m17s because the thinking-replay repair reset the provider retry budget and
+ * nothing bounded how often the repair pair was re-entered. The captured
+ * rejection stream is exactly the shape stubbed here: a thinking-block mutation
+ * `invalid_request_error` first, then the proxy-masked generic `api_error`.
+ */
+const model: Model<"anthropic-messages"> = {
+	api: "anthropic-messages",
+	provider: "anthropic",
+	id: "claude-sonnet-4-6",
+	name: "Claude Sonnet 4.6",
+	baseUrl: "https://api.anthropic.com",
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	maxTokens: 8_192,
+	contextWindow: 200_000,
+	reasoning: true,
+};
+
+type MockAnthropicRequest = {
+	withResponse(): Promise<{
+		data: AsyncIterable<Record<string, unknown>>;
+		response: Response;
+		request_id: string | null;
+	}>;
+};
+
+const MUTATION_REJECTION =
+	'{"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.24: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response."}}';
+const MASKED_REJECTION =
+	'{"type":"error","error":{"type":"api_error","message":"An error occurred while processing the request."}}';
+
+function rejectingRequest(message: string, status?: number): MockAnthropicRequest {
+	return {
+		async withResponse(): Promise<never> {
+			const error = new Error(message);
+			if (status !== undefined) {
+				(error as { status?: number }).status = status;
+			}
+			throw error;
+		},
+	};
+}
+
+function successfulRequest(): MockAnthropicRequest {
+	const response = new Response(null, { status: 200, headers: { "request-id": "req_ok" } });
+	const events: Record<string, unknown>[] = [
+		{
+			type: "message_start",
+			message: {
+				id: "msg_ok",
+				usage: { input_tokens: 1, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+			},
+		},
+		{ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+		{ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "recovered" } },
+		{ type: "content_block_stop", index: 0 },
+		{
+			type: "message_delta",
+			delta: { stop_reason: "end_turn" },
+			usage: { input_tokens: 1, output_tokens: 1, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+		},
+		{ type: "message_stop" },
+	];
+	return {
+		async withResponse() {
+			return {
+				data: {
+					async *[Symbol.asyncIterator]() {
+						for (const event of events) yield event;
+					},
+				},
+				response,
+				request_id: response.headers.get("request-id"),
+			};
+		},
+	};
+}
+
+function signedAssistant(suffix: string, text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [
+			{ type: "thinking", thinking: `thinking ${suffix}`, thinkingSignature: `sig_${suffix}` },
+			{ type: "text", text },
+		],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function replayContext(): Context {
+	const user: UserMessage = { role: "user", content: "first", timestamp: Date.now() };
+	return {
+		messages: [
+			user,
+			signedAssistant("early", "early answer"),
+			{ ...user, content: "second", timestamp: Date.now() + 1 },
+			signedAssistant("late", "late answer"),
+			{ ...user, content: "next prompt", timestamp: Date.now() + 2 },
+		],
+	};
+}
+
+type RecordedBody = { messages?: Array<{ content?: unknown }> };
+
+function replayedThinkingBlockTypes(body: unknown): string[] {
+	const messages = (body as RecordedBody).messages ?? [];
+	return messages.flatMap(message =>
+		Array.isArray(message.content)
+			? (message.content as Array<{ type?: string }>)
+					.map(block => block.type ?? "")
+					.filter(type => type === "thinking" || type === "redacted_thinking")
+			: [],
+	);
+}
+
+describe("Anthropic thinking-replay repair budget (issue #4011)", () => {
+	it("stops after two requests when a mutation 400 degrades into the masked api_error", async () => {
+		const requestBodies: unknown[] = [];
+		let attempt = 0;
+		const create = ((body: unknown) => {
+			requestBodies.push(body);
+			attempt += 1;
+			return (attempt === 1 ? rejectingRequest(MUTATION_REJECTION) : rejectingRequest(MASKED_REJECTION)) as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+
+		const stream = streamAnthropic(model, replayContext(), { client });
+		const observed: AssistantMessageEvent[] = [];
+		for await (const event of stream) {
+			observed.push(event);
+		}
+		const result = await stream.result();
+
+		// One repair, one confirming request. The captured session made 121.
+		expect(requestBodies).toHaveLength(2);
+		// The turn dies loudly: a terminal frame carrying the provider's own message.
+		expect(observed.filter(event => event.type === "error")).toHaveLength(1);
+		expect(observed.at(-1)?.type).toBe("error");
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("An error occurred while processing the request.");
+	});
+
+	it("replays no thinking blocks at all after a mutation rejection", async () => {
+		const requestBodies: unknown[] = [];
+		let attempt = 0;
+		const create = ((body: unknown) => {
+			requestBodies.push(body);
+			attempt += 1;
+			return (attempt === 1 ? rejectingRequest(MUTATION_REJECTION) : successfulRequest()) as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+
+		const result = await streamAnthropic(model, replayContext(), { client }).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(requestBodies).toHaveLength(2);
+		expect(replayedThinkingBlockTypes(requestBodies[0])).toEqual(["thinking", "thinking"]);
+		// "cannot be modified" means the blocks must be replayed verbatim, so the
+		// retry must not ship a re-mutated version of them — it ships none.
+		expect(replayedThinkingBlockTypes(requestBodies[1])).toEqual([]);
+		expect(JSON.stringify(requestBodies[1])).not.toContain("sig_early");
+		expect(JSON.stringify(requestBodies[1])).not.toContain("sig_late");
+		expect(JSON.stringify(requestBodies[1])).toContain("early answer");
+	});
+
+	it("does not renew the provider retry budget when a repair fires", async () => {
+		const requestBodies: unknown[] = [];
+		let attempt = 0;
+		const create = ((body: unknown) => {
+			requestBodies.push(body);
+			attempt += 1;
+			// Burn the whole provider retry budget, then trip the repair, then fail
+			// again: the repair must not hand the budget back.
+			if (attempt === 4) return rejectingRequest(MUTATION_REJECTION) as never;
+			return rejectingRequest("529 Overloaded", 529) as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+		const providerRetryWait = vi.fn(async () => {});
+
+		const result = await streamAnthropic(model, replayContext(), { client, providerRetryWait }).result();
+
+		// 3 provider retries + the repaired request + the request that exhausts the
+		// budget. Resetting the budget on repair would allow 3 more.
+		expect(requestBodies).toHaveLength(5);
+		expect(providerRetryWait).toHaveBeenCalledTimes(3);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("Overloaded");
+	});
+
+	it("carries the repair budget across stream re-invocation for the same session", async () => {
+		const requestBodies: unknown[] = [];
+		const create = ((body: unknown) => {
+			requestBodies.push(body);
+			return rejectingRequest(MASKED_REJECTION) as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+		const providerSessionState = new Map<string, ProviderSessionState>();
+
+		const first = await streamAnthropic(model, replayContext(), { client, providerSessionState }).result();
+		// latest-scope repair, full-history repair, then the budget is spent.
+		expect(first.stopReason).toBe("error");
+		expect(requestBodies).toHaveLength(3);
+
+		const second = await streamAnthropic(model, replayContext(), { client, providerSessionState }).result();
+
+		// Re-invoking the stream must not hand out a fresh pair of repairs.
+		expect(second.stopReason).toBe("error");
+		expect(second.errorMessage).toContain("An error occurred while processing the request.");
+		expect(requestBodies).toHaveLength(4);
+		// The degradation the first call converged on is still applied.
+		expect(replayedThinkingBlockTypes(requestBodies[3])).toEqual([]);
+	});
+});

--- a/packages/ai/test/anthropic-thinking-repair-budget.test.ts
+++ b/packages/ai/test/anthropic-thinking-repair-budget.test.ts
@@ -233,7 +233,92 @@ describe("Anthropic thinking-replay repair budget (issue #4011)", () => {
 		expect(second.stopReason).toBe("error");
 		expect(second.errorMessage).toContain("An error occurred while processing the request.");
 		expect(requestBodies).toHaveLength(4);
-		// The degradation the first call converged on is still applied.
+		// The degradation the first call converged on is still applied: nothing
+		// completed, so nothing released the escalation.
 		expect(replayedThinkingBlockTypes(requestBodies[3])).toEqual([]);
+	});
+
+	it("stays bounded across three turns that never complete a stream", async () => {
+		const requestBodies: unknown[] = [];
+		const create = ((body: unknown) => {
+			requestBodies.push(body);
+			return rejectingRequest(MASKED_REJECTION) as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+		const providerSessionState = new Map<string, ProviderSessionState>();
+
+		for (let turn = 0; turn < 3; turn++) {
+			const result = await streamAnthropic(model, replayContext(), { client, providerSessionState }).result();
+			expect(result.stopReason).toBe("error");
+		}
+
+		// Two repairs on the first turn, then one bare request per later turn.
+		expect(requestBodies).toHaveLength(5);
+	});
+});
+
+/**
+ * Issue #4038: the repair branch also fires on the proxy-masked generic
+ * `api_error`, which nothing can classify and which may simply be transient.
+ * Persisting an escalation triggered by it stripped native thinking replay from
+ * every remaining turn of the session. A stream that completes releases the
+ * escalation and the budget it consumed; a session that never completes one
+ * keeps the #4011 ceiling.
+ */
+describe("Anthropic thinking-replay repair scope release (issue #4038)", () => {
+	it("replays native thinking again on the next turn after a transient masked api_error", async () => {
+		const requestBodies: unknown[] = [];
+		let attempt = 0;
+		const create = ((body: unknown) => {
+			requestBodies.push(body);
+			attempt += 1;
+			return (attempt <= 2 ? rejectingRequest(MASKED_REJECTION) : successfulRequest()) as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+		const providerSessionState = new Map<string, ProviderSessionState>();
+
+		const first = await streamAnthropic(model, replayContext(), { client, providerSessionState }).result();
+
+		expect(first.stopReason).toBe("stop");
+		expect(requestBodies).toHaveLength(3);
+		expect(replayedThinkingBlockTypes(requestBodies[0])).toEqual(["thinking", "thinking"]);
+		expect(replayedThinkingBlockTypes(requestBodies[1])).toEqual(["thinking"]);
+		expect(replayedThinkingBlockTypes(requestBodies[2])).toEqual([]);
+
+		const second = await streamAnthropic(model, replayContext(), { client, providerSessionState }).result();
+
+		expect(second.stopReason).toBe("stop");
+		expect(requestBodies).toHaveLength(4);
+		// The blip is over and nothing ever proved the replay was at fault, so the
+		// next turn ships the signed blocks instead of staying degraded forever.
+		expect(replayedThinkingBlockTypes(requestBodies[3])).toEqual(["thinking", "thinking"]);
+		expect(JSON.stringify(requestBodies[3])).toContain("sig_early");
+		expect(JSON.stringify(requestBodies[3])).toContain("sig_late");
+	});
+
+	it("re-arms the repair budget for the next turn once a stream completes", async () => {
+		const requestBodies: unknown[] = [];
+		let attempt = 0;
+		const create = ((body: unknown) => {
+			requestBodies.push(body);
+			attempt += 1;
+			// Turn 1 spends both repairs, then completes. Turn 2 is rejected once more.
+			const rejects = attempt <= 2 || attempt === 4;
+			return (rejects ? rejectingRequest(MASKED_REJECTION) : successfulRequest()) as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+		const providerSessionState = new Map<string, ProviderSessionState>();
+
+		const first = await streamAnthropic(model, replayContext(), { client, providerSessionState }).result();
+		expect(first.stopReason).toBe("stop");
+		expect(requestBodies).toHaveLength(3);
+
+		const second = await streamAnthropic(model, replayContext(), { client, providerSessionState }).result();
+
+		// A spent budget would have surfaced the rejection instead of repairing it.
+		expect(second.stopReason).toBe("stop");
+		expect(requestBodies).toHaveLength(5);
+		expect(replayedThinkingBlockTypes(requestBodies[3])).toEqual(["thinking", "thinking"]);
+		expect(replayedThinkingBlockTypes(requestBodies[4])).toEqual(["thinking"]);
 	});
 });

--- a/packages/ai/test/anthropic-thinking-repair-retry.test.ts
+++ b/packages/ai/test/anthropic-thinking-repair-retry.test.ts
@@ -354,9 +354,10 @@ describe("Anthropic thinking replay repair retry", () => {
 	});
 
 	// Real captured session failure (2026-07-29): the mutation 400 says "latest
-	// assistant message" but cites `messages.1.content.1` — a HISTORICAL turn — so the
-	// latest-only repair is rejected identically and the turn used to die.
-	it("escalates to a full-history repair when the mutation 400 survives the latest-only repair", async () => {
+	// assistant message" but cites `messages.1.content.1` — a HISTORICAL turn. The
+	// provider demands those blocks be replayed verbatim, so a latest-only edit is
+	// just another mutation; the only recovery is to stop replaying native thinking.
+	it("drops thinking from EVERY assistant turn on the first mutation 400", async () => {
 		const user: UserMessage = {
 			role: "user",
 			content: "first",
@@ -376,26 +377,26 @@ describe("Anthropic thinking replay repair retry", () => {
 		const create = ((body: unknown) => {
 			requestBodies.push(body);
 			attempt += 1;
-			return (attempt <= 2 ? createAnthropicThinking400() : createSuccessfulRequest()) as never;
+			return (attempt === 1 ? createAnthropicThinking400() : createSuccessfulRequest()) as never;
 		}) as unknown as Anthropic["messages"]["create"];
 		const client = { messages: { create } } as Anthropic;
 
 		const result = await streamAnthropic(model, context, { client }).result();
 
 		expect(result.stopReason).toBe("stop");
-		expect(requestBodies).toHaveLength(3);
-		// Attempt 2: latest-only repair keeps the historical signature.
+		expect(requestBodies).toHaveLength(2);
+		const firstBody = JSON.stringify(requestBodies[0]);
+		expect(firstBody).toContain("sig_early");
+		expect(firstBody).toContain("sig_late");
+		// The single repair drops every replayed signature rather than re-editing the
+		// turn the provider just refused.
 		const secondBody = JSON.stringify(requestBodies[1]);
-		expect(secondBody).toContain("sig_early");
+		expect(secondBody).not.toContain("sig_early");
 		expect(secondBody).not.toContain("sig_late");
-		// Attempt 3: escalated full-history repair drops every replayed signature.
-		const thirdBody = JSON.stringify(requestBodies[2]);
-		expect(thirdBody).not.toContain("sig_early");
-		expect(thirdBody).not.toContain("sig_late");
-		expect(thirdBody).toContain("early answer");
+		expect(secondBody).toContain("early answer");
 	});
 
-	it("stops after exactly three requests when the mutation 400 persists through both repair scopes", async () => {
+	it("stops after exactly two requests when the mutation 400 persists", async () => {
 		const user: UserMessage = {
 			role: "user",
 			content: "first",
@@ -415,7 +416,7 @@ describe("Anthropic thinking replay repair retry", () => {
 
 		expect(result.stopReason).toBe("error");
 		expect(result.errorStatus).toBe(400);
-		expect(requestBodies).toHaveLength(3);
+		expect(requestBodies).toHaveLength(2);
 	});
 
 	it("retries once with thinking dropped from EVERY assistant turn after the invalid-signature 400", async () => {

--- a/packages/ai/test/anthropic-thinking-repair-retry.test.ts
+++ b/packages/ai/test/anthropic-thinking-repair-retry.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 import type Anthropic from "@anthropic-ai/sdk";
 import { streamAnthropic } from "@gajae-code/ai/providers/anthropic";
-import type { AssistantMessage, Context, Model, Tool, UserMessage } from "@gajae-code/ai/types";
-import { clearToolChoiceIncapabilityRegistryForTests } from "@gajae-code/ai/utils/tool-choice-capability";
+import type { AssistantMessage, Context, Model, ProviderSessionState, Tool, UserMessage } from "@gajae-code/ai/types";
+import {
+	clearToolChoiceIncapabilityRegistryForTests,
+	getToolChoiceCapabilityOverride,
+} from "@gajae-code/ai/utils/tool-choice-capability";
 
 const model: Model<"anthropic-messages"> = {
 	api: "anthropic-messages",
@@ -153,6 +156,11 @@ function makeSignedAssistant(suffix: string, text: string): AssistantMessage {
 }
 
 describe("Anthropic thinking replay repair retry", () => {
+	// The runtime tool-choice capability registry is module-global, so a forced
+	// tool_choice 400 raised by any test in this file leaks into every later test
+	// (and into repeated file runs). Isolate every test, not just the fallback block.
+	beforeEach(() => clearToolChoiceIncapabilityRegistryForTests());
+
 	it("retries once without latest assistant thinking blocks after the Anthropic 400 invariant error", async () => {
 		const user: UserMessage = {
 			role: "user",
@@ -307,6 +315,44 @@ describe("Anthropic thinking replay repair retry", () => {
 		const thirdBody = JSON.stringify(requestBodies[2]);
 		expect(thirdBody).not.toContain("sig_early");
 		expect(thirdBody).not.toContain("sig_late");
+	});
+
+	it("does not carry an exhausted masked repair into the next turn", async () => {
+		const user: UserMessage = {
+			role: "user",
+			content: "first",
+			timestamp: Date.now(),
+		};
+		const context: Context = {
+			messages: [
+				user,
+				makeSignedAssistant("early", "early answer"),
+				{ ...user, content: "second", timestamp: Date.now() + 1 },
+				makeSignedAssistant("late", "late answer"),
+				{ ...user, content: "next prompt", timestamp: Date.now() + 2 },
+			],
+		};
+		const requestBodies: unknown[] = [];
+		let attempt = 0;
+		const create = ((body: unknown) => {
+			requestBodies.push(body);
+			attempt += 1;
+			return (attempt <= 3 ? createMaskedProxyRejection() : createSuccessfulRequest()) as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+		const providerSessionState = new Map<string, ProviderSessionState>();
+
+		const failedTurn = await streamAnthropic(model, context, { client, providerSessionState }).result();
+
+		expect(failedTurn.stopReason).toBe("error");
+		expect(requestBodies).toHaveLength(3);
+
+		const recoveredTurn = await streamAnthropic(model, context, { client, providerSessionState }).result();
+
+		expect(recoveredTurn.stopReason).toBe("stop");
+		expect(requestBodies).toHaveLength(4);
+		expect(JSON.stringify(requestBodies[3])).toContain("sig_early");
+		expect(JSON.stringify(requestBodies[3])).toContain("sig_late");
 	});
 
 	// The masked body says nothing, so the guard must be the request: with no
@@ -518,6 +564,10 @@ describe("Anthropic thinking replay repair retry", () => {
 		}) as unknown as Anthropic["messages"]["create"];
 		const client = { messages: { create } } as Anthropic;
 
+		// Guards the isolation above: a leaked runtime incapability would silently
+		// strip `tool_choice` from the request and make the assertions below lie.
+		expect(getToolChoiceCapabilityOverride(model)).toBeUndefined();
+
 		const result = await streamAnthropic(model, context, {
 			client,
 			thinkingEnabled: true,
@@ -609,8 +659,6 @@ describe("Anthropic thinking replay repair retry", () => {
 	});
 
 	describe("cumulative degradation across fallbacks", () => {
-		beforeEach(() => clearToolChoiceIncapabilityRegistryForTests());
-
 		const tool: Tool = {
 			name: "read",
 			description: "Read",


### PR DESCRIPTION
Scoped replacement for the Anthropic repair-loop portion of the closed #4021. One commit, 3 files.

Fixes #4011, and #3900 as the same defect with older evidence.

## The problem

A single ACP session burned **121 rejected Anthropic requests over 29 minutes 17 seconds**, produced no output, surfaced no error, and then went silent while the client still reported the session `running` for another 13 minutes.

```
first rejection: 2026-08-08T01:39:20.816+09:00
last  rejection: 2026-08-08T02:08:37.965+09:00
count:           121
```

Two distinct provider errors, with `scope` alternating strictly `latest` → `all` across **59 complete pairs**:

```
113x  api_error          "An error occurred while processing the request."
  8x  invalid_request_error
      "messages.1.content.24: `thinking` or `redacted_thinking` blocks in the latest
       assistant message cannot be modified. These blocks must remain as they were
       in the original response."
```

## Mechanism

The thinking-replay repair is bounded to two repairs *per call* (`latest`, then `all`), but:

1. **The repair reset the retry budget it was meant to consume.** `providerRetryAttempt = 0` inside the repair branch meant the `PROVIDER_MAX_RETRIES` check below it was never reached while repairs kept firing.
2. **Nothing bounded re-entry.** The repair flags were declared per-call, so a layer above re-invoked the stream ~60 times with fresh flags, each time repeating the identical `latest` → `all` pair against a request the provider would never accept.
3. **The repair was the wrong strategy for this rejection.** The 400 states the blocks *cannot be modified* and must be replayed verbatim, so escalating `latest` → `all` can never converge. After the first few 400s the API degraded to generic `api_error` (113 of 121), which `isAnthropicMaskedProxyRejection` then treated as another repairable masked rejection — closing the loop.
4. **The turn died silently.** No terminal frame, no error, work in progress lost.

## The fix

The repair budget now lives in `providerSessionState`, alongside `strictToolsDisabled` / `fastModeDisabled` / `generatedCacheBudget`, so it survives stream re-invocation for the same session. The provider retry budget is no longer reset by a repair. A "blocks cannot be modified" 400 is answered by dropping native thinking replay entirely rather than mutating the very blocks the provider demands verbatim. When repairs are exhausted the turn fails with the provider error attached — a turn that stops now produces a terminal frame.

## Verification

Load-bearing proof — restoring `packages/ai/src` from `origin/dev` and re-running:

```
with fix:     18 pass / 0 fail
without fix:   0 pass / 4 fail
```

```
anthropic-thinking-repair-budget + anthropic-thinking-repair-retry   18 pass / 0 fail
bun --cwd=packages/ai run check                                      exit 0
```

The regression drives the captured failure directly: the stream rejects with the mutation `invalid_request_error`, then with the generic `api_error`, and the test asserts a **bounded exact request count**, a terminal error carrying the provider's own message, that the budget is not renewed by a repair, that it survives re-invocation with shared `providerSessionState`, and that the retried request ships no re-mutated thinking blocks.

## Relationship to #3900

#3915 fixed the statusless/masked CPA path this reproduces behind CLIProxyAPI. What remained was the unbounded cross-invocation lifecycle and the silent death, which is what this fixes. #3900 was closed as a duplicate of #4011 for that reason.

## Relationship to #4021

#4021 bundled twelve unrelated defects into 53 files and was closed with the instruction to open fresh, scoped PRs. This is one of those, alongside #4031, #4033, #4035, #4036 and #4037.

Closes #4011
