### PR TITLE
fix(acp): skip unreplayable transcript entries instead of failing the load

### DIFF
--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -427,10 +427,21 @@ export interface TranscriptContinuation {
 }
 
 /** Fields replay consumes; `textSummary` and the rest stay unread so recovery costs one query per used field. */
-const RECOVERABLE_TRANSCRIPT_FIELDS = ["role", "body", "toolCallId", "toolName"] as const;
+const RECOVERABLE_TRANSCRIPT_FIELDS = ["role", "body", "content", "toolCallId", "toolName", "isError"] as const;
 
 /** Stands in for a tool result whose transcript entry replay could not restore. */
 const TRANSCRIPT_TOOL_RESULT_UNAVAILABLE = "The transcript entry holding this tool result could not be replayed.";
+
+function decodeTranscriptContinuation(field: string, body: string): unknown {
+	if (field !== "content" && field !== "isError") return body;
+	try {
+		const value: unknown = JSON.parse(body);
+		if (field === "content") return Array.isArray(value) ? value : undefined;
+		return typeof value === "boolean" ? value : undefined;
+	} catch {
+		return undefined;
+	}
+}
 
 export function transcriptContinuations(entry: unknown): TranscriptContinuation[] {
 	const record = object(entry);
@@ -2220,20 +2231,28 @@ export class AcpAgent implements Agent {
 	/**
 	 * Reassembles a body-less `item_too_large` entry from the `continuations` the
 	 * producer already published, reading each field replay consumes through the same
-	 * `resource.body` query the descriptor names. Returns undefined only when the entry
-	 * is genuinely unrecoverable: no readable body, or no role to place it with.
+	 * `resource.body` query the descriptor names. Partial recovery is retained so a
+	 * failed body continuation cannot discard tool-call identity needed to close an
+	 * already-published pending call.
 	 */
-	async #recoverTranscriptEntry(adapter: AcpSdkAdapter, entry: JsonObject): Promise<JsonObject | undefined> {
+	async #recoverTranscriptEntry(adapter: AcpSdkAdapter, entry: JsonObject): Promise<JsonObject> {
 		const continuations = transcriptContinuations(entry);
-		if (continuations.length === 0) return undefined;
 		const recovered: JsonObject = { ...entry };
 		for (const field of RECOVERABLE_TRANSCRIPT_FIELDS) {
 			const continuation = continuations.find(candidate => candidate.field === field);
 			if (!continuation) continue;
-			const value = await this.#readContinuation(adapter, continuation);
-			if (value !== undefined) recovered[field] = value;
+			const body = await this.#readContinuation(adapter, continuation);
+			const value = body === undefined ? undefined : decodeTranscriptContinuation(field, body);
+			// A row that advertises `isError` but will not yield it leaves the outcome
+			// unproven, so replay reports failure rather than claiming a success it cannot
+			// read back. A row that never advertised the field simply had no error flag.
+			if (value === undefined) {
+				if (field === "isError") recovered.isError = true;
+				continue;
+			}
+			recovered[field] = value;
 		}
-		return typeof recovered.body === "string" && typeof recovered.role === "string" ? recovered : undefined;
+		return recovered;
 	}
 
 	/** Follows one continuation to its end, joining every page of that field's bytes. */
@@ -2320,8 +2339,7 @@ export class AcpAgent implements Agent {
 				// A body-less row is usually an oversized message, not a malformed entry:
 				// its `continuations` say exactly how to read it back, so replay follows
 				// them instead of dropping the largest message in the session.
-				const message =
-					typeof raw.body === "string" ? raw : ((await this.#recoverTranscriptEntry(adapter, raw)) ?? raw);
+				const message = typeof raw.body === "string" ? raw : await this.#recoverTranscriptEntry(adapter, raw);
 				const replay = transcriptReplayContent(message);
 				if (!replay.replayable) {
 					unreplayableEntries++;

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -386,16 +386,27 @@ export interface TranscriptReplayContent {
 	images: { available: false; reason: "historical_transcript_images_unavailable" };
 }
 
-export function transcriptReplayContent(entry: unknown): TranscriptReplayContent {
+/** Machine-readable reason replay could not restore a transcript entry. */
+export type TranscriptReplaySkipReason = "transcript_body_unavailable";
+
+/**
+ * Replay decides per entry. An entry whose production body is missing is not
+ * replayable, and the caller reports that boundary instead of failing the whole
+ * load; fabricating an empty body would replay a message that never existed.
+ */
+export type TranscriptReplayEntry =
+	| { replayable: true; content: TranscriptReplayContent }
+	| { replayable: false; reason: TranscriptReplaySkipReason };
+
+export function transcriptReplayContent(entry: unknown): TranscriptReplayEntry {
 	const record = object(entry);
-	if (typeof record?.body !== "string")
-		throw new AcpSdkAdapterError(
-			"transcript_body_unavailable",
-			"ACP cannot replay a transcript entry without its production body.",
-		);
+	if (typeof record?.body !== "string") return { replayable: false, reason: "transcript_body_unavailable" };
 	return {
-		blocks: record.body.length > 0 ? [{ type: "text", text: record.body }] : [],
-		images: { available: false, reason: "historical_transcript_images_unavailable" },
+		replayable: true,
+		content: {
+			blocks: record.body.length > 0 ? [{ type: "text", text: record.body }] : [],
+			images: { available: false, reason: "historical_transcript_images_unavailable" },
+		},
 	};
 }
 
@@ -2163,6 +2174,8 @@ export class AcpAgent implements Agent {
 		if (!record) return;
 		let cursor: string | undefined;
 		let imageLimitationReported = false;
+		let unreplayableEntries = 0;
+		let unreplayableReason: TranscriptReplaySkipReason | undefined;
 		const replayTools = new Map<string, { name: string; args: unknown }>();
 		for (let pageCount = 0; pageCount < MAX_ACP_REPLAY_PAGES; pageCount++) {
 			const response = object(await adapter.query("transcript.list", {}, cursor));
@@ -2171,7 +2184,13 @@ export class AcpAgent implements Agent {
 			for (const item of Array.isArray(page?.items) ? page.items : []) {
 				const message = object(item);
 				if (!message) continue;
-				const content = transcriptReplayContent(message);
+				const replay = transcriptReplayContent(message);
+				if (!replay.replayable) {
+					unreplayableEntries++;
+					unreplayableReason ??= replay.reason;
+					continue;
+				}
+				const content = replay.content;
 				if (!imageLimitationReported) {
 					imageLimitationReported = true;
 					await this.#publishSessionUpdate(
@@ -2292,7 +2311,24 @@ export class AcpAgent implements Agent {
 				}
 			}
 			cursor = typeof page?.continuationCursor === "string" ? page.continuationCursor : undefined;
-			if (!cursor) return;
+			if (cursor) continue;
+			// An entry without its production body is skipped, never fatal: losing one
+			// transcript row must not revoke `session/load` for the whole session.
+			if (unreplayableReason)
+				await this.#publishSessionUpdate(
+					id,
+					{
+						sessionId: id,
+						update: {
+							sessionUpdate: "session_info_update",
+							_meta: {
+								gjcTranscriptReplaySkipped: { count: unreplayableEntries, reason: unreplayableReason },
+							},
+						},
+					},
+					adapter,
+				);
+			return;
 		}
 		throw new AcpSdkAdapterError("resource_exhausted", "ACP transcript replay exceeded the page limit.");
 	}

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -387,7 +387,7 @@ export interface TranscriptReplayContent {
 }
 
 /** Machine-readable reason replay could not restore a transcript entry. */
-export type TranscriptReplaySkipReason = "transcript_body_unavailable";
+export type TranscriptReplaySkipReason = "transcript_body_unavailable" | "transcript_tool_call_unavailable";
 
 /**
  * Replay decides per entry. An entry whose production body is missing is not
@@ -408,6 +408,55 @@ export function transcriptReplayContent(entry: unknown): TranscriptReplayEntry {
 			images: { available: false, reason: "historical_transcript_images_unavailable" },
 		},
 	};
+}
+
+/**
+ * `transcript.list` answers an entry larger than one page with a body-less row
+ * `{ id, error: { code: "item_too_large" }, continuations }`. Each continuation is a
+ * `Q23` (`resource.body`) descriptor for one indexed string field of that entry, so
+ * the row is a pointer to the largest message in the session rather than a broken
+ * entry. Replay follows it instead of dropping the message.
+ */
+export interface TranscriptContinuation {
+	query: string;
+	resourceKind: string;
+	resourceId: string;
+	revision: string;
+	itemId: string;
+	field: string;
+}
+
+/** Fields replay consumes; `textSummary` and the rest stay unread so recovery costs one query per used field. */
+const RECOVERABLE_TRANSCRIPT_FIELDS = ["role", "body", "toolCallId", "toolName"] as const;
+
+/** Stands in for a tool result whose transcript entry replay could not restore. */
+const TRANSCRIPT_TOOL_RESULT_UNAVAILABLE = "The transcript entry holding this tool result could not be replayed.";
+
+export function transcriptContinuations(entry: unknown): TranscriptContinuation[] {
+	const record = object(entry);
+	if (!Array.isArray(record?.continuations)) return [];
+	const descriptors: TranscriptContinuation[] = [];
+	for (const value of record.continuations) {
+		const candidate = object(value);
+		if (
+			typeof candidate?.query !== "string" ||
+			typeof candidate.resourceKind !== "string" ||
+			typeof candidate.resourceId !== "string" ||
+			typeof candidate.revision !== "string" ||
+			typeof candidate.itemId !== "string" ||
+			typeof candidate.field !== "string"
+		)
+			continue;
+		descriptors.push({
+			query: candidate.query,
+			resourceKind: candidate.resourceKind,
+			resourceId: candidate.resourceId,
+			revision: candidate.revision,
+			itemId: candidate.itemId,
+			field: candidate.field,
+		});
+	}
+	return descriptors;
 }
 
 type ReceivedSdkEvent = {
@@ -2168,6 +2217,90 @@ export class AcpAgent implements Agent {
 		);
 	}
 
+	/**
+	 * Reassembles a body-less `item_too_large` entry from the `continuations` the
+	 * producer already published, reading each field replay consumes through the same
+	 * `resource.body` query the descriptor names. Returns undefined only when the entry
+	 * is genuinely unrecoverable: no readable body, or no role to place it with.
+	 */
+	async #recoverTranscriptEntry(adapter: AcpSdkAdapter, entry: JsonObject): Promise<JsonObject | undefined> {
+		const continuations = transcriptContinuations(entry);
+		if (continuations.length === 0) return undefined;
+		const recovered: JsonObject = { ...entry };
+		for (const field of RECOVERABLE_TRANSCRIPT_FIELDS) {
+			const continuation = continuations.find(candidate => candidate.field === field);
+			if (!continuation) continue;
+			const value = await this.#readContinuation(adapter, continuation);
+			if (value !== undefined) recovered[field] = value;
+		}
+		return typeof recovered.body === "string" && typeof recovered.role === "string" ? recovered : undefined;
+	}
+
+	/** Follows one continuation to its end, joining every page of that field's bytes. */
+	async #readContinuation(adapter: AcpSdkAdapter, continuation: TranscriptContinuation): Promise<string | undefined> {
+		const chunks: string[] = [];
+		let cursor: string | undefined;
+		for (let pageCount = 0; pageCount < MAX_ACP_REPLAY_PAGES; pageCount++) {
+			let response: JsonObject | undefined;
+			try {
+				response = object(
+					await adapter.query(
+						continuation.query,
+						cursor
+							? {}
+							: {
+									resourceKind: continuation.resourceKind,
+									resourceId: continuation.resourceId,
+									revision: continuation.revision,
+									itemId: continuation.itemId,
+									field: continuation.field,
+								},
+						cursor,
+					),
+				);
+			} catch {
+				// A continuation that cannot be read costs one entry, never the whole
+				// `session/load`; the caller reports the boundary instead.
+				return undefined;
+			}
+			const result = object(response?.result) ?? response;
+			const page = object(result?.page);
+			const chunk = object(Array.isArray(page?.items) ? page.items[0] : undefined);
+			if (typeof chunk?.body !== "string") return undefined;
+			chunks.push(chunk.body);
+			cursor = typeof page?.continuationCursor === "string" ? page.continuationCursor : undefined;
+			if (!cursor) return chunks.join("");
+		}
+		return undefined;
+	}
+
+	/**
+	 * A skipped `toolResult` would leave its already-published `tool_call` at
+	 * `status: "pending"` forever, so replay closes it with the same
+	 * `tool_execution_end` shape a real result uses. Replay cannot know the outcome, so
+	 * it reports failure rather than claiming a success it cannot prove.
+	 */
+	async #closeUnresolvedReplayToolCall(
+		id: string,
+		adapter: AcpSdkAdapter,
+		cwd: string,
+		toolCallId: string,
+		tool: { name: string; args: unknown },
+	): Promise<void> {
+		for (const notification of mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "tool_execution_end",
+				toolCallId,
+				toolName: tool.name,
+				result: { content: [{ type: "text", text: TRANSCRIPT_TOOL_RESULT_UNAVAILABLE }] },
+				isError: true,
+			} as never,
+			id,
+			{ cwd, getToolArgs: () => tool.args },
+		))
+			await this.#publishSessionUpdate(id, notification, adapter);
+	}
+
 	async #replaySession(id: string): Promise<void> {
 		const adapter = this.#adapter(id);
 		const record = this.#sessions.get(id);
@@ -2182,12 +2315,23 @@ export class AcpAgent implements Agent {
 			const result = object(response?.result) ?? response;
 			const page = object(result?.page);
 			for (const item of Array.isArray(page?.items) ? page.items : []) {
-				const message = object(item);
-				if (!message) continue;
+				const raw = object(item);
+				if (!raw) continue;
+				// A body-less row is usually an oversized message, not a malformed entry:
+				// its `continuations` say exactly how to read it back, so replay follows
+				// them instead of dropping the largest message in the session.
+				const message =
+					typeof raw.body === "string" ? raw : ((await this.#recoverTranscriptEntry(adapter, raw)) ?? raw);
 				const replay = transcriptReplayContent(message);
 				if (!replay.replayable) {
 					unreplayableEntries++;
 					unreplayableReason ??= replay.reason;
+					const unresolvedId = typeof message.toolCallId === "string" ? message.toolCallId : undefined;
+					const unresolved = unresolvedId === undefined ? undefined : replayTools.get(unresolvedId);
+					if (unresolvedId !== undefined && unresolved) {
+						replayTools.delete(unresolvedId);
+						await this.#closeUnresolvedReplayToolCall(id, adapter, record.cwd, unresolvedId, unresolved);
+					}
 					continue;
 				}
 				const content = replay.content;
@@ -2270,7 +2414,13 @@ export class AcpAgent implements Agent {
 				if (message.role === "toolResult" && typeof message.toolCallId === "string") {
 					const replayTool = replayTools.get(message.toolCallId);
 					const toolName = typeof message.toolName === "string" ? message.toolName : replayTool?.name;
-					if (!toolName) continue;
+					// Pairing outranks content: publishing a result whose `tool_call` start
+					// never reached the client renders an update for a call it never saw begin.
+					if (!toolName || !replayTool) {
+						unreplayableEntries++;
+						unreplayableReason ??= "transcript_tool_call_unavailable";
+						continue;
+					}
 					const resultContent = richContent
 						?.map(object)
 						.filter(

--- a/packages/coding-agent/src/sdk/host/query/handlers.ts
+++ b/packages/coding-agent/src/sdk/host/query/handlers.ts
@@ -405,7 +405,7 @@ export class QueryHandlers {
 		const range =
 			itemId === undefined
 				? await this.revisions.readStringRange(kind, id, revision, field, offset, TARGET_PAGE_BYTES)
-				: await this.revisions.readIndexedStringRange(kind, id, revision, itemId, field, offset, TARGET_PAGE_BYTES);
+				: await this.revisions.readIndexedFieldRange(kind, id, revision, itemId, field, offset, TARGET_PAGE_BYTES);
 		if (!range) return this.#error(request, "resource_gone");
 		return this.#chunkRange(request, kind, id, revision, range, selector, {
 			field,

--- a/packages/coding-agent/src/sdk/host/query/revision-store.ts
+++ b/packages/coding-agent/src/sdk/host/query/revision-store.ts
@@ -468,6 +468,25 @@ export class RevisionStore {
 		const range = item?.fields?.[field];
 		return range ? this.#readStringRange(revision, range, offset, length) : undefined;
 	}
+	async readIndexedFieldRange(
+		resourceKind: string,
+		resourceId: string,
+		id: string,
+		itemId: string,
+		field: string,
+		offset: number,
+		length: number,
+	): Promise<{ body: string; complete: boolean; offset: number } | undefined> {
+		const revision = this.#resources.get(`${resourceKind}:${resourceId}`)?.find(item => item.id === id);
+		if (!revision) return undefined;
+		revision.lastAccessed = this.now();
+		const item = revision.index?.items?.find(candidate => candidate.entryId === itemId);
+		const range = item?.fields?.[field];
+		if (!range) return undefined;
+		return range.isString
+			? this.#readStringRange(revision, range, offset, length)
+			: this.#readJsonRange(revision, range, offset, length);
+	}
 	async describeIndexedItem(
 		resourceKind: string,
 		resourceId: string,
@@ -479,9 +498,7 @@ export class RevisionStore {
 		if (!item) return undefined;
 		return {
 			itemId: item.entryId,
-			fields: Object.entries(item.fields ?? {})
-				.filter(([, range]) => range.isString)
-				.map(([field]) => field),
+			fields: Object.keys(item.fields ?? {}),
 		};
 	}
 	async readTranscriptBodyRange(
@@ -799,6 +816,28 @@ export class RevisionStore {
 		const stringIndex = await this.#encodeString(value, append, true);
 		if (!stringIndex) throw new SyntaxError("escaped string index is unavailable");
 		return { isString: true, stringIndex };
+	}
+
+	async #readJsonRange(
+		revision: Revision,
+		range: IndexedField,
+		offset: number,
+		length: number,
+	): Promise<{ body: string; complete: boolean; offset: number } | undefined> {
+		if (offset < 0 || length <= 0) return undefined;
+		const bytes = range.end - range.start;
+		const requestedStart = Math.min(offset, bytes);
+		const source = await this.#readBytes(
+			revision,
+			range.start + requestedStart,
+			range.start + Math.min(bytes, requestedStart + length + 7),
+		);
+		const skipped = utf8ContinuationPrefixLength(source);
+		const start = requestedStart + skipped;
+		const body = source.subarray(skipped);
+		const end = utf8BoundaryAtOrBefore(body, Math.min(body.length, length));
+		if (end === 0 && start < bytes) return undefined;
+		return { body: body.subarray(0, end).toString("utf8"), complete: start + end === bytes, offset: start };
 	}
 
 	async #readStringRange(

--- a/packages/coding-agent/test/acp/acp-transcript-continuation-descriptors.test.ts
+++ b/packages/coding-agent/test/acp/acp-transcript-continuation-descriptors.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { transcriptContinuations } from "@gajae-code/coding-agent/modes/acp/acp-agent";
+
+describe("transcriptContinuations", () => {
+	it("keeps only fully specified continuation descriptors", () => {
+		expect(
+			transcriptContinuations({
+				id: "entry-1",
+				error: { code: "item_too_large" },
+				continuations: [
+					{
+						query: "Q23",
+						resourceKind: "transcript",
+						resourceId: "default",
+						revision: "r1",
+						itemId: "entry-1",
+						field: "body",
+					},
+					{ query: "Q23", resourceKind: "transcript", resourceId: "default", revision: "r1", itemId: "entry-1" },
+					{ field: "role" },
+					"body",
+				],
+			}),
+		).toEqual([
+			{
+				query: "Q23",
+				resourceKind: "transcript",
+				resourceId: "default",
+				revision: "r1",
+				itemId: "entry-1",
+				field: "body",
+			},
+		]);
+	});
+
+	it("reports no continuations for an entry that carries none", () => {
+		expect(transcriptContinuations({ id: "entry-1", role: "user", body: "text" })).toEqual([]);
+		expect(transcriptContinuations({ id: "entry-1", continuations: {} })).toEqual([]);
+		expect(transcriptContinuations(undefined)).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/acp/acp-transcript-replay-continuation.test.ts
+++ b/packages/coding-agent/test/acp/acp-transcript-replay-continuation.test.ts
@@ -112,6 +112,7 @@ describe("ACP transcript replay continuation recovery", () => {
 	/** `${itemId}:${field}` -> full field value the host would serve over `resource.body`. */
 	let continuationFields = new Map<string, string>();
 	let continuationFailure: string | undefined;
+	let continuationFailureField: string | undefined;
 	let resourceBodyQueries: Array<Record<string, unknown>> = [];
 	let updates: SessionNotification[] = [];
 	let agentDir = "";
@@ -123,6 +124,7 @@ describe("ACP transcript replay continuation recovery", () => {
 		transcriptItems = [];
 		continuationFields = new Map();
 		continuationFailure = undefined;
+		continuationFailureField = undefined;
 		resourceBodyQueries = [];
 		updates = [];
 		agentDir = path.join(tempDir.path(), "agent");
@@ -176,7 +178,11 @@ describe("ACP transcript replay continuation recovery", () => {
 								...input,
 								...(frame.cursor === undefined ? {} : { cursor: frame.cursor }),
 							});
-							if (continuationFailure !== undefined) {
+							if (
+								continuationFailure !== undefined ||
+								(continuationFailureField !== undefined &&
+									(frame.input as Record<string, unknown> | undefined)?.field === continuationFailureField)
+							) {
 								socket.send(
 									JSON.stringify({
 										type: "query_response",
@@ -325,6 +331,7 @@ describe("ACP transcript replay continuation recovery", () => {
 		continuationFields.set("result-big:body", "Oversized tool output");
 		continuationFields.set("result-big:toolCallId", "tool-1");
 		continuationFields.set("result-big:toolName", "read");
+		continuationFields.set("result-big:isError", "false");
 		const replayed = await loadReplayedSession([
 			{
 				id: "assistant-1",
@@ -333,7 +340,7 @@ describe("ACP transcript replay continuation recovery", () => {
 				body: "Reading",
 				content: [{ type: "toolCall", id: "tool-1", name: "read", arguments: { file_path: "big.ts" } }],
 			},
-			oversizedRow("result-big", ["id", "role", "body", "toolCallId", "toolName"]),
+			oversizedRow("result-big", ["id", "role", "body", "toolCallId", "toolName", "isError"]),
 		]);
 
 		expect(toolCallStates(replayed)).toEqual(["tool_call:tool-1:pending", "tool_call_update:tool-1:completed"]);
@@ -460,5 +467,110 @@ describe("ACP transcript replay continuation recovery", () => {
 		expect(toolCallStates(replayed)).toEqual(["tool_call:tool-1:pending", "tool_call_update:tool-1:completed"]);
 		expect(skipBoundaries(replayed)).toEqual([]);
 		expect(resourceBodyQueries).toEqual([]);
+	});
+	it("recovers typed content when an oversized assistant entry owns a tool call", async () => {
+		const toolCall = { type: "toolCall", id: "tool-1", name: "read", arguments: { file_path: "large.ts" } };
+		continuationFields.set("assistant-big:role", "assistant");
+		continuationFields.set("assistant-big:body", "Reading a very large file");
+		continuationFields.set("assistant-big:content", JSON.stringify([toolCall]));
+		const replayed = await loadReplayedSession([
+			oversizedRow("assistant-big", ["id", "role", "body", "content"]),
+			{
+				id: "result-1",
+				role: "toolResult",
+				textSummary: "File read",
+				body: "File read",
+				content: [{ type: "text", text: "File read" }],
+				toolCallId: "tool-1",
+				toolName: "read",
+			},
+		]);
+
+		expect(toolCallStates(replayed)).toEqual(["tool_call:tool-1:pending", "tool_call_update:tool-1:completed"]);
+		expect(skipBoundaries(replayed)).toEqual([]);
+	});
+
+	it("preserves typed failure status for an oversized tool result", async () => {
+		continuationFields.set("result-big:role", "toolResult");
+		continuationFields.set("result-big:body", "Permission denied");
+		continuationFields.set("result-big:toolCallId", "tool-1");
+		continuationFields.set("result-big:toolName", "read");
+		continuationFields.set("result-big:isError", "true");
+		const replayed = await loadReplayedSession([
+			{
+				id: "assistant-1",
+				role: "assistant",
+				textSummary: "Reading",
+				body: "Reading",
+				content: [{ type: "toolCall", id: "tool-1", name: "read", arguments: { file_path: "secret.ts" } }],
+			},
+			oversizedRow("result-big", ["id", "role", "body", "toolCallId", "toolName", "isError"]),
+		]);
+
+		expect(toolCallStates(replayed)).toEqual(["tool_call:tool-1:pending", "tool_call_update:tool-1:failed"]);
+		expect(skipBoundaries(replayed)).toEqual([]);
+	});
+
+	it("retains recovered tool identity when only the oversized result body fails", async () => {
+		continuationFields.set("result-big:role", "toolResult");
+		continuationFields.set("result-big:toolCallId", "tool-1");
+		continuationFields.set("result-big:toolName", "read");
+		continuationFields.set("result-big:isError", "false");
+		continuationFailureField = "body";
+		const replayed = await loadReplayedSession([
+			{
+				id: "assistant-1",
+				role: "assistant",
+				textSummary: "Reading",
+				body: "Reading",
+				content: [{ type: "toolCall", id: "tool-1", name: "read", arguments: { file_path: "big.ts" } }],
+			},
+			oversizedRow("result-big", ["id", "role", "body", "toolCallId", "toolName", "isError"]),
+		]);
+
+		expect(toolCallStates(replayed)).toEqual(["tool_call:tool-1:pending", "tool_call_update:tool-1:failed"]);
+		expect(pendingToolCalls(replayed)).toEqual([]);
+	});
+	it("keeps a successful oversized tool result successful when the row advertises no isError", async () => {
+		continuationFields.set("result-big:role", "toolResult");
+		continuationFields.set("result-big:body", "Successful tool output");
+		continuationFields.set("result-big:toolCallId", "tool-1");
+		continuationFields.set("result-big:toolName", "read");
+		const replayed = await loadReplayedSession([
+			{
+				id: "assistant-1",
+				role: "assistant",
+				textSummary: "Reading",
+				body: "Reading",
+				content: [{ type: "toolCall", id: "tool-1", name: "read", arguments: { file_path: "ok.ts" } }],
+			},
+			oversizedRow("result-big", ["id", "role", "body", "toolCallId", "toolName"]),
+		]);
+
+		expect(toolCallStates(replayed)).toEqual(["tool_call:tool-1:pending", "tool_call_update:tool-1:completed"]);
+		expect(JSON.stringify(replayed)).toContain("Successful tool output");
+		expect(skipBoundaries(replayed)).toEqual([]);
+	});
+
+	it("fails an oversized tool result whose advertised isError continuation cannot be read", async () => {
+		continuationFields.set("result-big:role", "toolResult");
+		continuationFields.set("result-big:body", "Tool output of unproven outcome");
+		continuationFields.set("result-big:toolCallId", "tool-1");
+		continuationFields.set("result-big:toolName", "read");
+		continuationFields.set("result-big:isError", "false");
+		continuationFailureField = "isError";
+		const replayed = await loadReplayedSession([
+			{
+				id: "assistant-1",
+				role: "assistant",
+				textSummary: "Reading",
+				body: "Reading",
+				content: [{ type: "toolCall", id: "tool-1", name: "read", arguments: { file_path: "big.ts" } }],
+			},
+			oversizedRow("result-big", ["id", "role", "body", "toolCallId", "toolName", "isError"]),
+		]);
+
+		expect(toolCallStates(replayed)).toEqual(["tool_call:tool-1:pending", "tool_call_update:tool-1:failed"]);
+		expect(pendingToolCalls(replayed)).toEqual([]);
 	});
 });

--- a/packages/coding-agent/test/acp/acp-transcript-replay-continuation.test.ts
+++ b/packages/coding-agent/test/acp/acp-transcript-replay-continuation.test.ts
@@ -1,0 +1,464 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import type { AgentSideConnection, SessionNotification } from "@agentclientprotocol/sdk";
+import { AcpAgent } from "@gajae-code/coding-agent/modes/acp/acp-agent";
+import { writeBrokerDiscovery } from "@gajae-code/coding-agent/sdk/broker/discovery";
+import { TempDir } from "@gajae-code/utils";
+
+const TOKEN = "acp-transcript-continuation-token";
+/** Small enough that every fixture body needs several `resource.body` pages. */
+const CONTINUATION_PAGE_CHARS = 8;
+
+async function bounded<T>(promise: Promise<T>, label: string): Promise<T> {
+	return await Promise.race([
+		promise,
+		Bun.sleep(5_000).then(() => {
+			throw new Error(`Timed out waiting for ${label}`);
+		}),
+	]);
+}
+
+async function waitFor(predicate: () => boolean, label: string): Promise<void> {
+	const deadline = Date.now() + 5_000;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await Bun.sleep(5);
+	}
+	throw new Error(`Timed out waiting for ${label}`);
+}
+
+function updateMeta(notification: SessionNotification): Record<string, unknown> | undefined {
+	const meta = (notification.update as { _meta?: unknown })._meta;
+	return typeof meta === "object" && meta !== null ? (meta as Record<string, unknown>) : undefined;
+}
+
+function skipBoundaries(notifications: SessionNotification[]): unknown[] {
+	return notifications
+		.map(notification => updateMeta(notification)?.gjcTranscriptReplaySkipped)
+		.filter(value => value !== undefined);
+}
+
+function replayKinds(notifications: SessionNotification[]): string[] {
+	return notifications.map(notification => notification.update.sessionUpdate);
+}
+
+function textChunks(notifications: SessionNotification[]): Array<Record<string, unknown>> {
+	const chunks: Array<Record<string, unknown>> = [];
+	for (const notification of notifications) {
+		const update = notification.update as {
+			sessionUpdate: string;
+			content?: { type?: string; text?: string };
+			messageId?: string;
+		};
+		if (
+			update.sessionUpdate !== "user_message_chunk" &&
+			update.sessionUpdate !== "agent_message_chunk" &&
+			update.sessionUpdate !== "agent_thought_chunk"
+		)
+			continue;
+		chunks.push({
+			sessionUpdate: update.sessionUpdate,
+			text: update.content?.text,
+			...(update.messageId === undefined ? {} : { messageId: update.messageId }),
+		});
+	}
+	return chunks;
+}
+
+/** Every tool-call lifecycle update the client saw, in order, as `id:status`. */
+function toolCallStates(notifications: SessionNotification[]): string[] {
+	const states: string[] = [];
+	for (const notification of notifications) {
+		const update = notification.update as { sessionUpdate: string; toolCallId?: string; status?: string };
+		if (update.sessionUpdate !== "tool_call" && update.sessionUpdate !== "tool_call_update") continue;
+		states.push(`${update.sessionUpdate}:${update.toolCallId}:${update.status}`);
+	}
+	return states;
+}
+
+/** Tool call ids the client was told about but never given a terminal state for. */
+function pendingToolCalls(notifications: SessionNotification[]): string[] {
+	const status = new Map<string, string>();
+	for (const notification of notifications) {
+		const update = notification.update as { sessionUpdate: string; toolCallId?: string; status?: string };
+		if (update.sessionUpdate !== "tool_call" && update.sessionUpdate !== "tool_call_update") continue;
+		if (typeof update.toolCallId !== "string") continue;
+		status.set(update.toolCallId, String(update.status));
+	}
+	return [...status].filter(([, value]) => value !== "completed" && value !== "failed").map(([id]) => id);
+}
+
+/** Builds the body-less `item_too_large` row `transcript.list` publishes for an oversized entry. */
+function oversizedRow(itemId: string, fields: string[]): Record<string, unknown> {
+	return {
+		id: itemId,
+		error: { code: "item_too_large" },
+		continuations: fields.map(field => ({
+			query: "Q23",
+			resourceKind: "transcript",
+			resourceId: "default",
+			revision: "rev-1",
+			itemId,
+			field,
+		})),
+	};
+}
+
+describe("ACP transcript replay continuation recovery", () => {
+	let tempDir: TempDir;
+	let connectionAbort: AbortController;
+	let server: Bun.Server<undefined> | undefined;
+	let transcriptItems: unknown[] = [];
+	/** `${itemId}:${field}` -> full field value the host would serve over `resource.body`. */
+	let continuationFields = new Map<string, string>();
+	let continuationFailure: string | undefined;
+	let resourceBodyQueries: Array<Record<string, unknown>> = [];
+	let updates: SessionNotification[] = [];
+	let agentDir = "";
+	let cwd = "";
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@acp-transcript-continuation-");
+		connectionAbort = new AbortController();
+		transcriptItems = [];
+		continuationFields = new Map();
+		continuationFailure = undefined;
+		resourceBodyQueries = [];
+		updates = [];
+		agentDir = path.join(tempDir.path(), "agent");
+		cwd = path.join(tempDir.path(), "workspace");
+		server = Bun.serve({
+			hostname: "127.0.0.1",
+			port: 0,
+			fetch(request, server) {
+				if (new URL(request.url).searchParams.get("token") !== TOKEN)
+					return new Response("Unauthorized", { status: 401 });
+				if (!server.upgrade(request)) return new Response("Upgrade failed", { status: 400 });
+			},
+			websocket: {
+				open(socket) {
+					socket.send(JSON.stringify({ type: "hello", connectionId: "acp-transcript-continuation" }));
+				},
+				message(socket, raw) {
+					const frame = JSON.parse(String(raw)) as Record<string, unknown>;
+					if (frame.type === "register_provider") {
+						socket.send(
+							JSON.stringify({ type: "register_provider_result", id: frame.id, ok: true, leaseId: "lease" }),
+						);
+						return;
+					}
+					if (frame.type === "broker_request") {
+						const result =
+							frame.operation === "session.create"
+								? {
+										sessionId: "replay-session",
+										endpoint: { url: `ws://127.0.0.1:${server!.port}`, token: TOKEN },
+									}
+								: {};
+						socket.send(JSON.stringify({ type: "broker_response", id: frame.id, ok: true, result }));
+						return;
+					}
+					if (frame.type === "query_request") {
+						if (frame.query === "runtime.capabilities") {
+							socket.send(
+								JSON.stringify({
+									type: "query_response",
+									id: frame.id,
+									ok: true,
+									result: { promptTerminalOutcomeVersion: 1 },
+								}),
+							);
+							return;
+						}
+						if (frame.query === "Q23" || frame.query === "resource.body") {
+							const input = (frame.input ?? {}) as Record<string, unknown>;
+							resourceBodyQueries.push({
+								...input,
+								...(frame.cursor === undefined ? {} : { cursor: frame.cursor }),
+							});
+							if (continuationFailure !== undefined) {
+								socket.send(
+									JSON.stringify({
+										type: "query_response",
+										id: frame.id,
+										ok: false,
+										error: { code: continuationFailure, message: continuationFailure },
+									}),
+								);
+								return;
+							}
+							// The cursor carries the selector forward exactly like the real host does.
+							const cursor = typeof frame.cursor === "string" ? frame.cursor.split("|") : undefined;
+							const itemId = cursor ? String(cursor[0]) : String(input.itemId);
+							const field = cursor ? String(cursor[1]) : String(input.field);
+							const offset = cursor ? Number(cursor[2]) : 0;
+							const key = `${itemId}:${field}`;
+							const value = continuationFields.get(key);
+							if (value === undefined) {
+								socket.send(
+									JSON.stringify({
+										type: "query_response",
+										id: frame.id,
+										ok: false,
+										error: { code: "resource_gone", message: "resource_gone" },
+									}),
+								);
+								return;
+							}
+							const body = value.slice(offset, offset + CONTINUATION_PAGE_CHARS);
+							const end = offset + body.length;
+							const complete = end >= value.length;
+							socket.send(
+								JSON.stringify({
+									type: "query_response",
+									id: frame.id,
+									ok: true,
+									result: {
+										page: {
+											items: [{ itemId, field, byteOffset: offset, body, complete }],
+											complete,
+											...(complete ? {} : { continuationCursor: `${itemId}|${field}|${end}` }),
+										},
+									},
+								}),
+							);
+							return;
+						}
+						const items =
+							frame.query === "config.list/get"
+								? [{ mode: "default", model: "openai/gpt", thinking: "medium" }]
+								: frame.query === "models.list/current"
+									? [{ provider: "openai", id: "gpt", name: "GPT" }]
+									: frame.query === "providers.list/active"
+										? [{ provider: "openai", connectionKind: "credential" }]
+										: frame.query === "transcript.list"
+											? transcriptItems
+											: [];
+						const result =
+							frame.query === "context.get"
+								? { usage: { tokens: 0, contextWindow: 200_000, percent: 0, source: "test" } }
+								: { page: { items, complete: true } };
+						socket.send(JSON.stringify({ type: "query_response", id: frame.id, ok: true, result }));
+						return;
+					}
+					if (frame.type !== "control_request") return;
+					socket.send(JSON.stringify({ type: "control_response", id: frame.id, ok: true, result: {} }));
+				},
+			},
+		});
+		const port = server.port;
+		if (port === undefined) throw new Error("Expected the ACP fixture server to expose a port");
+		await writeBrokerDiscovery(agentDir, {
+			version: 1,
+			protocolVersion: 3,
+			packageGeneration: "test",
+			ownerId: "test-owner",
+			pid: process.pid,
+			host: "127.0.0.1",
+			port,
+			url: `ws://127.0.0.1:${port}`,
+			token: TOKEN,
+			startedAt: Date.now(),
+			heartbeatAt: Date.now(),
+		});
+	});
+
+	afterEach(() => {
+		connectionAbort.abort();
+		server?.stop(true);
+		tempDir.removeSync();
+	});
+
+	async function loadReplayedSession(items: unknown[]): Promise<SessionNotification[]> {
+		transcriptItems = items;
+		const connection = {
+			sessionUpdate: async (notification: SessionNotification) => {
+				updates.push(notification);
+			},
+			signal: connectionAbort.signal,
+			closed: Promise.withResolvers<void>().promise,
+		} as unknown as AgentSideConnection;
+		const acp = new AcpAgent(connection, { agentDir });
+		const created = await bounded(acp.newSession({ cwd, mcpServers: [] }), "a new session");
+		await waitFor(
+			() =>
+				updates.some(update => update.update.sessionUpdate === "available_commands_update") &&
+				updates.some(update => updateMeta(update)?.gjcPhase === "idle"),
+			"the new session bootstrap",
+		);
+		updates.length = 0;
+		resourceBodyQueries.length = 0;
+		await bounded(acp.loadSession({ sessionId: created.sessionId, cwd, mcpServers: [] }), "the loaded session");
+		return updates;
+	}
+
+	it("recovers an oversized entry through its continuations instead of skipping it", async () => {
+		const oversizedBody = "Oversized assistant answer that spans several continuation pages.";
+		continuationFields.set("assistant-big:role", "assistant");
+		continuationFields.set("assistant-big:body", oversizedBody);
+		const replayed = await loadReplayedSession([
+			{ id: "user-1", role: "user", textSummary: "Earlier request", body: "Earlier request" },
+			oversizedRow("assistant-big", ["id", "role", "textSummary", "body"]),
+			{ id: "user-2", role: "user", textSummary: "Follow-up", body: "Follow-up" },
+		]);
+
+		expect(textChunks(replayed)).toEqual([
+			{ sessionUpdate: "user_message_chunk", text: "Earlier request", messageId: "user-1" },
+			{ sessionUpdate: "agent_message_chunk", text: oversizedBody, messageId: "assistant-big" },
+			{ sessionUpdate: "user_message_chunk", text: "Follow-up", messageId: "user-2" },
+		]);
+		expect(skipBoundaries(replayed)).toEqual([]);
+		// Only the fields replay consumes are read, and the body is paged to completion.
+		expect(resourceBodyQueries.filter(query => query.field !== undefined).map(query => query.field)).toEqual([
+			"role",
+			"body",
+		]);
+		const expectedPages =
+			Math.ceil("assistant".length / CONTINUATION_PAGE_CHARS) +
+			Math.ceil(oversizedBody.length / CONTINUATION_PAGE_CHARS);
+		expect(expectedPages).toBeGreaterThan(2);
+		expect(resourceBodyQueries.length).toBe(expectedPages);
+	});
+
+	it("recovers an oversized tool result and pairs it with its tool call", async () => {
+		continuationFields.set("result-big:role", "toolResult");
+		continuationFields.set("result-big:body", "Oversized tool output");
+		continuationFields.set("result-big:toolCallId", "tool-1");
+		continuationFields.set("result-big:toolName", "read");
+		const replayed = await loadReplayedSession([
+			{
+				id: "assistant-1",
+				role: "assistant",
+				textSummary: "Reading",
+				body: "Reading",
+				content: [{ type: "toolCall", id: "tool-1", name: "read", arguments: { file_path: "big.ts" } }],
+			},
+			oversizedRow("result-big", ["id", "role", "body", "toolCallId", "toolName"]),
+		]);
+
+		expect(toolCallStates(replayed)).toEqual(["tool_call:tool-1:pending", "tool_call_update:tool-1:completed"]);
+		expect(pendingToolCalls(replayed)).toEqual([]);
+		expect(JSON.stringify(replayed)).toContain("Oversized tool output");
+		expect(skipBoundaries(replayed)).toEqual([]);
+	});
+
+	it("reports and skips an entry that has neither a body nor a usable continuation", async () => {
+		const replayed = await loadReplayedSession([
+			{ id: "user-1", role: "user", textSummary: "Earlier request", body: "Earlier request" },
+			{ id: "lost-1", error: { code: "item_too_large" }, continuations: [] },
+			{ id: "assistant-1", role: "assistant", textSummary: "Earlier response", body: "Earlier response" },
+		]);
+
+		expect(textChunks(replayed)).toEqual([
+			{ sessionUpdate: "user_message_chunk", text: "Earlier request", messageId: "user-1" },
+			{ sessionUpdate: "agent_message_chunk", text: "Earlier response", messageId: "assistant-1" },
+		]);
+		expect(skipBoundaries(replayed)).toEqual([{ count: 1, reason: "transcript_body_unavailable" }]);
+	});
+
+	it("reports and skips an entry whose continuation cannot be read", async () => {
+		continuationFailure = "resource_gone";
+		const replayed = await loadReplayedSession([
+			{ id: "user-1", role: "user", textSummary: "Earlier request", body: "Earlier request" },
+			oversizedRow("assistant-big", ["id", "role", "body"]),
+		]);
+
+		expect(textChunks(replayed)).toEqual([
+			{ sessionUpdate: "user_message_chunk", text: "Earlier request", messageId: "user-1" },
+		]);
+		expect(skipBoundaries(replayed)).toEqual([{ count: 1, reason: "transcript_body_unavailable" }]);
+	});
+
+	it("drops the paired result when the entry owning its tool call was skipped", async () => {
+		const replayed = await loadReplayedSession([
+			{ id: "user-1", role: "user", textSummary: "Earlier request", body: "Earlier request" },
+			{
+				id: "assistant-1",
+				role: "assistant",
+				textSummary: "Body lost",
+				content: [{ type: "toolCall", id: "tool-1", name: "read", arguments: { file_path: "missing.ts" } }],
+			},
+			{
+				id: "result-1",
+				role: "toolResult",
+				textSummary: "File read",
+				body: "File read",
+				content: [{ type: "text", text: "File read" }],
+				toolCallId: "tool-1",
+				toolName: "read",
+			},
+		]);
+
+		expect(toolCallStates(replayed)).toEqual([]);
+		expect(pendingToolCalls(replayed)).toEqual([]);
+		expect(JSON.stringify(replayed)).not.toContain("missing.ts");
+		expect(skipBoundaries(replayed)).toEqual([{ count: 2, reason: "transcript_body_unavailable" }]);
+	});
+
+	it("closes a tool call whose result entry is unrecoverable so nothing stays pending", async () => {
+		const replayed = await loadReplayedSession([
+			{
+				id: "assistant-1",
+				role: "assistant",
+				textSummary: "Reading",
+				body: "Reading",
+				content: [{ type: "toolCall", id: "tool-1", name: "read", arguments: { file_path: "big.ts" } }],
+			},
+			{ id: "result-1", role: "toolResult", textSummary: "Body lost", toolCallId: "tool-1", toolName: "read" },
+		]);
+
+		expect(toolCallStates(replayed)).toEqual(["tool_call:tool-1:pending", "tool_call_update:tool-1:failed"]);
+		expect(pendingToolCalls(replayed)).toEqual([]);
+		expect(JSON.stringify(replayed)).toContain("could not be replayed");
+		expect(skipBoundaries(replayed)).toEqual([{ count: 1, reason: "transcript_body_unavailable" }]);
+	});
+
+	it("loads a session whose entries are all unrecoverable and replays zero messages", async () => {
+		const replayed = await loadReplayedSession([
+			{ id: "user-1", role: "user", textSummary: "Body lost" },
+			oversizedRow("assistant-big", ["id", "role", "body"]),
+			{ id: "result-1", role: "toolResult", textSummary: "Body lost", toolCallId: "tool-1", toolName: "read" },
+		]);
+
+		expect(textChunks(replayed)).toEqual([]);
+		expect(toolCallStates(replayed)).toEqual([]);
+		expect(replayKinds(replayed)).toEqual(["session_info_update"]);
+		expect(skipBoundaries(replayed)).toEqual([{ count: 3, reason: "transcript_body_unavailable" }]);
+	});
+
+	it("replays a healthy transcript without reading any continuation", async () => {
+		const replayed = await loadReplayedSession([
+			{ id: "user-1", role: "user", textSummary: "Earlier request", body: "Earlier request" },
+			{
+				id: "assistant-1",
+				role: "assistant",
+				textSummary: "Earlier response",
+				body: "Earlier response",
+				content: [
+					{ type: "text", text: "Earlier response" },
+					{ type: "toolCall", id: "tool-1", name: "read", arguments: { file_path: "found.ts" } },
+				],
+			},
+			{
+				id: "result-1",
+				role: "toolResult",
+				textSummary: "File read",
+				body: "File read",
+				content: [{ type: "text", text: "File read" }],
+				toolCallId: "tool-1",
+				toolName: "read",
+			},
+		]);
+
+		expect(replayKinds(replayed)).toEqual([
+			"session_info_update",
+			"user_message_chunk",
+			"agent_message_chunk",
+			"tool_call",
+			"tool_call_update",
+		]);
+		expect(toolCallStates(replayed)).toEqual(["tool_call:tool-1:pending", "tool_call_update:tool-1:completed"]);
+		expect(skipBoundaries(replayed)).toEqual([]);
+		expect(resourceBodyQueries).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/acp/acp-transcript-replay-degradation.test.ts
+++ b/packages/coding-agent/test/acp/acp-transcript-replay-degradation.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import type { AgentSideConnection, SessionNotification } from "@agentclientprotocol/sdk";
+import { AcpAgent, transcriptReplayContent } from "@gajae-code/coding-agent/modes/acp/acp-agent";
+import { writeBrokerDiscovery } from "@gajae-code/coding-agent/sdk/broker/discovery";
+import { TempDir } from "@gajae-code/utils";
+
+const TOKEN = "acp-transcript-replay-token";
+
+async function bounded<T>(promise: Promise<T>, label: string): Promise<T> {
+	return await Promise.race([
+		promise,
+		Bun.sleep(5_000).then(() => {
+			throw new Error(`Timed out waiting for ${label}`);
+		}),
+	]);
+}
+
+async function waitFor(predicate: () => boolean, label: string): Promise<void> {
+	const deadline = Date.now() + 5_000;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await Bun.sleep(5);
+	}
+	throw new Error(`Timed out waiting for ${label}`);
+}
+
+function updateMeta(notification: SessionNotification): Record<string, unknown> | undefined {
+	const meta = (notification.update as { _meta?: unknown })._meta;
+	return typeof meta === "object" && meta !== null ? (meta as Record<string, unknown>) : undefined;
+}
+
+function skipBoundaries(notifications: SessionNotification[]): unknown[] {
+	return notifications
+		.map(notification => updateMeta(notification)?.gjcTranscriptReplaySkipped)
+		.filter(value => value !== undefined);
+}
+
+function replayKinds(notifications: SessionNotification[]): string[] {
+	return notifications.map(notification => notification.update.sessionUpdate);
+}
+
+function textChunks(notifications: SessionNotification[]): Array<Record<string, unknown>> {
+	const chunks: Array<Record<string, unknown>> = [];
+	for (const notification of notifications) {
+		const update = notification.update as {
+			sessionUpdate: string;
+			content?: { type?: string; text?: string };
+			messageId?: string;
+		};
+		if (
+			update.sessionUpdate !== "user_message_chunk" &&
+			update.sessionUpdate !== "agent_message_chunk" &&
+			update.sessionUpdate !== "agent_thought_chunk"
+		)
+			continue;
+		chunks.push({
+			sessionUpdate: update.sessionUpdate,
+			text: update.content?.text,
+			...(update.messageId === undefined ? {} : { messageId: update.messageId }),
+		});
+	}
+	return chunks;
+}
+
+describe("ACP transcript replay degradation", () => {
+	let tempDir: TempDir;
+	let connectionAbort: AbortController;
+	let server: Bun.Server<undefined> | undefined;
+	let transcriptItems: unknown[] = [];
+	let updates: SessionNotification[] = [];
+	let agentDir = "";
+	let cwd = "";
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@acp-transcript-replay-");
+		connectionAbort = new AbortController();
+		transcriptItems = [];
+		updates = [];
+		agentDir = path.join(tempDir.path(), "agent");
+		cwd = path.join(tempDir.path(), "workspace");
+
+		server = Bun.serve({
+			hostname: "127.0.0.1",
+			port: 0,
+			fetch(request, server) {
+				if (new URL(request.url).searchParams.get("token") !== TOKEN)
+					return new Response("Unauthorized", { status: 401 });
+				if (!server.upgrade(request)) return new Response("Upgrade failed", { status: 400 });
+			},
+			websocket: {
+				open(socket) {
+					socket.send(JSON.stringify({ type: "hello", connectionId: "acp-transcript-replay" }));
+				},
+				message(socket, raw) {
+					const frame = JSON.parse(String(raw)) as Record<string, unknown>;
+					if (frame.type === "register_provider") {
+						socket.send(
+							JSON.stringify({ type: "register_provider_result", id: frame.id, ok: true, leaseId: "lease" }),
+						);
+						return;
+					}
+					if (frame.type === "broker_request") {
+						const result =
+							frame.operation === "session.create"
+								? {
+										sessionId: "replay-session",
+										endpoint: { url: `ws://127.0.0.1:${server!.port}`, token: TOKEN },
+									}
+								: {};
+						socket.send(JSON.stringify({ type: "broker_response", id: frame.id, ok: true, result }));
+						return;
+					}
+					if (frame.type === "query_request") {
+						if (frame.query === "runtime.capabilities") {
+							socket.send(
+								JSON.stringify({
+									type: "query_response",
+									id: frame.id,
+									ok: true,
+									result: { promptTerminalOutcomeVersion: 1 },
+								}),
+							);
+							return;
+						}
+						const items =
+							frame.query === "config.list/get"
+								? [{ mode: "default", model: "openai/gpt", thinking: "medium" }]
+								: frame.query === "models.list/current"
+									? [{ provider: "openai", id: "gpt", name: "GPT" }]
+									: frame.query === "providers.list/active"
+										? [{ provider: "openai", connectionKind: "credential" }]
+										: frame.query === "transcript.list"
+											? transcriptItems
+											: [];
+						const result =
+							frame.query === "context.get"
+								? { usage: { tokens: 0, contextWindow: 200_000, percent: 0, source: "test" } }
+								: { page: { items, complete: true } };
+						socket.send(JSON.stringify({ type: "query_response", id: frame.id, ok: true, result }));
+						return;
+					}
+					if (frame.type !== "control_request") return;
+					socket.send(JSON.stringify({ type: "control_response", id: frame.id, ok: true, result: {} }));
+				},
+			},
+		});
+
+		const port = server.port;
+		if (port === undefined) throw new Error("Expected ACP fixture server port");
+		await writeBrokerDiscovery(agentDir, {
+			version: 1,
+			protocolVersion: 3,
+			packageGeneration: "test",
+			ownerId: "test-owner",
+			pid: process.pid,
+			host: "127.0.0.1",
+			port,
+			url: `ws://127.0.0.1:${port}`,
+			token: TOKEN,
+			startedAt: Date.now(),
+			heartbeatAt: Date.now(),
+		});
+	});
+
+	afterEach(() => {
+		connectionAbort.abort();
+		server?.stop(true);
+		tempDir.removeSync();
+	});
+
+	/** Creates a session, drains its bootstrap updates, then replays it through `session/load`. */
+	async function loadReplayedSession(items: unknown[]): Promise<SessionNotification[]> {
+		transcriptItems = items;
+		const connection = {
+			sessionUpdate: async (notification: SessionNotification) => {
+				updates.push(notification);
+			},
+			signal: connectionAbort.signal,
+			closed: Promise.withResolvers<void>().promise,
+		} as unknown as AgentSideConnection;
+		const acp = new AcpAgent(connection, { agentDir });
+		const created = await bounded(acp.newSession({ cwd, mcpServers: [] }), "new session");
+		await waitFor(
+			() =>
+				updates.some(update => update.update.sessionUpdate === "available_commands_update") &&
+				updates.some(update => updateMeta(update)?.gjcPhase === "idle"),
+			"new session bootstrap",
+		);
+		updates.length = 0;
+		await bounded(acp.loadSession({ sessionId: created.sessionId, cwd, mcpServers: [] }), "load session");
+		return updates;
+	}
+
+	it("skips a transcript entry without a production body and reports the boundary", async () => {
+		const replayed = await loadReplayedSession([
+			{ id: "user-1", role: "user", textSummary: "Earlier request", body: "Earlier request" },
+			{
+				id: "user-2",
+				role: "user",
+				textSummary: "Body lost",
+				content: [{ type: "text", text: "Never replayed" }],
+			},
+			{ id: "assistant-1", role: "assistant", textSummary: "Earlier response", body: "Earlier response" },
+		]);
+
+		expect(textChunks(replayed)).toEqual([
+			{ sessionUpdate: "user_message_chunk", text: "Earlier request", messageId: "user-1" },
+			{ sessionUpdate: "agent_message_chunk", text: "Earlier response", messageId: "assistant-1" },
+		]);
+		expect(JSON.stringify(replayed)).not.toContain("Never replayed");
+		expect(skipBoundaries(replayed)).toEqual([{ count: 1, reason: "transcript_body_unavailable" }]);
+	});
+
+	it("loads a session whose transcript entries are all unreplayable and replays zero messages", async () => {
+		const replayed = await loadReplayedSession([
+			{ id: "user-1", role: "user", textSummary: "Body lost" },
+			{ id: "assistant-1", role: "assistant", textSummary: "Body lost", body: null },
+			{ id: "result-1", role: "toolResult", textSummary: "Body lost", toolCallId: "tool-1", toolName: "read" },
+		]);
+
+		expect(textChunks(replayed)).toEqual([]);
+		expect(replayKinds(replayed)).toEqual(["session_info_update"]);
+		expect(skipBoundaries(replayed)).toEqual([{ count: 3, reason: "transcript_body_unavailable" }]);
+	});
+
+	it("replays a healthy transcript unchanged and reports no skip boundary", async () => {
+		const replayed = await loadReplayedSession([
+			{ id: "user-1", role: "user", textSummary: "Earlier request", body: "Earlier request" },
+			{
+				id: "assistant-1",
+				role: "assistant",
+				textSummary: "Earlier response",
+				body: "Earlier thought\nEarlier response",
+				content: [
+					{ type: "thinking", thinking: "Earlier thought" },
+					{ type: "text", text: "Earlier response" },
+					{ type: "toolCall", id: "replay-tool-1", name: "read", arguments: { path: "missing.ts" } },
+				],
+			},
+			{
+				id: "result-1",
+				role: "toolResult",
+				textSummary: "File not found",
+				body: "File not found",
+				content: [{ type: "text", text: "File not found" }],
+				toolCallId: "replay-tool-1",
+				toolName: "read",
+				isError: true,
+			},
+		]);
+
+		expect(replayKinds(replayed)).toEqual([
+			"session_info_update",
+			"user_message_chunk",
+			"agent_thought_chunk",
+			"agent_message_chunk",
+			"tool_call",
+			"tool_call_update",
+		]);
+		expect(textChunks(replayed)).toEqual([
+			{ sessionUpdate: "user_message_chunk", text: "Earlier request", messageId: "user-1" },
+			{ sessionUpdate: "agent_thought_chunk", text: "Earlier thought", messageId: "assistant-1" },
+			{ sessionUpdate: "agent_message_chunk", text: "Earlier response", messageId: "assistant-1" },
+		]);
+		expect(updateMeta(replayed[0]!)).toEqual({
+			gjcTranscriptImageReplay: { available: false, reason: "historical_transcript_images_unavailable" },
+		});
+		expect(skipBoundaries(replayed)).toEqual([]);
+	});
+});
+
+describe("transcriptReplayContent", () => {
+	it("signals an unavailable production body instead of throwing", () => {
+		expect(transcriptReplayContent({ id: "user-1", role: "user", textSummary: "Body lost" })).toEqual({
+			replayable: false,
+			reason: "transcript_body_unavailable",
+		});
+	});
+
+	it("keeps the replayable body contract for healthy entries", () => {
+		expect(transcriptReplayContent({ id: "user-1", role: "user", body: "Earlier request" })).toEqual({
+			replayable: true,
+			content: {
+				blocks: [{ type: "text", text: "Earlier request" }],
+				images: { available: false, reason: "historical_transcript_images_unavailable" },
+			},
+		});
+		expect(transcriptReplayContent({ id: "user-1", role: "user", body: "" })).toEqual({
+			replayable: true,
+			content: {
+				blocks: [],
+				images: { available: false, reason: "historical_transcript_images_unavailable" },
+			},
+		});
+	});
+});

--- a/packages/coding-agent/test/sdk-query-pagination.test.ts
+++ b/packages/coding-agent/test/sdk-query-pagination.test.ts
@@ -499,6 +499,40 @@ describe("SDK query pagination", () => {
 		});
 		expect(crossQuery.error).toMatchObject({ code: "invalid_input", message: "cursor does not match query" });
 	});
+	it("streams typed indexed fields through resource body continuations", async () => {
+		const content = [{ type: "toolCall", id: "tool-1", name: "read", arguments: { file_path: "large.ts" } }];
+		const query = handlers([
+			{
+				id: "oversized",
+				role: "assistant",
+				body: "x".repeat(300_000),
+				content,
+				isError: true,
+			},
+		]);
+		const list = await query.handlers.dispatch({ query: "Q01", connectionId: "c" });
+		const descriptor = list.page?.items[0] as {
+			continuations: Array<{ field: string; itemId: string; revision: string }>;
+		};
+		expect(descriptor.continuations.map(item => item.field)).toEqual(["id", "role", "body", "content", "isError"]);
+
+		const contentContinuation = descriptor.continuations.find(item => item.field === "content");
+		const errorContinuation = descriptor.continuations.find(item => item.field === "isError");
+		expect(contentContinuation).toBeDefined();
+		expect(errorContinuation).toBeDefined();
+		const contentResponse = await query.handlers.dispatch({
+			query: "Q23",
+			input: contentContinuation,
+			connectionId: "c",
+		});
+		const errorResponse = await query.handlers.dispatch({
+			query: "Q23",
+			input: errorContinuation,
+			connectionId: "c",
+		});
+		expect(JSON.parse(String((contentResponse.page?.items[0] as { body?: unknown })?.body))).toEqual(content);
+		expect(JSON.parse(String((errorResponse.page?.items[0] as { body?: unknown })?.body))).toBe(true);
+	});
 });
 it("retrieves a large Q13 indexed item field by stable ID across revisions", async () => {
 	const config = [{ id: "large-config", value: "é".repeat(700_000) }];


### PR DESCRIPTION
Scoped replacement for the transcript-replay portion of the closed #4021. One commit, 2 files.

Fixes #4019.

## The problem

One transcript entry without a production body makes `session/load` fail for the whole session, permanently. Since that is the documented recovery path after a transport drop, a session whose transport dropped can never be recovered — it ends `closed` with its work unreachable.

Captured while running a batch of agents:

1. A session lost its transport (`SDK WebSocket reconnect attempts exhausted`).
2. Sending a new prompt returned `Unknown session, not found: ad9903df-…` (`not_found`).
3. The client then tried the documented recovery — a refresh, which drives `session/load`:
   ```
   Internal error: ACP cannot replay a transcript entry without its production body.
   requestType=refresh_agent_request  code=agent_refresh_failed
   ```
4. Reproduced **after a full SDK broker restart** and **after switching to a freshly compiled binary**. The agent stayed `closed`.

Step 2 alone is fine — gjc advertises `loadSession: true`, so a client is entitled to recover via `session/load`. Step 3 is what removes that guarantee.

## Mechanism

`transcriptReplayContent` threw `transcript_body_unavailable` when `record.body` was not a string, and `#replaySession` calls it for **every** item on every transcript page. A single bad entry aborted the entire replay, so the failure was total and permanent rather than partial — and deterministic, so every retry died identically.

## The fix

Replay decides per entry. `transcriptReplayContent` returns a discriminated `{ replayable: true, content } | { replayable: false, reason }` instead of throwing, and the replay walk skips unreplayable entries, reporting a count and a stable machine-readable reason through the same `session_info_update` `_meta` channel already used for unavailable historical images:

```ts
images: { available: false, reason: "historical_transcript_images_unavailable" }
```

No fabricated body — that would replay a message that never existed. A session whose entries are all unreplayable still loads, reporting zero replayed messages.

## Verification

Load-bearing proof — restoring `packages/coding-agent/src` from `origin/dev` and re-running:

```
with fix:     5 pass / 0 fail
without fix:  1 pass / 4 fail
```

```
packages/coding-agent/test/acp (14 files)   160 pass / 0 fail
bun --cwd=packages/coding-agent run check   exit 0
```

Coverage: one bad entry among good ones — the good ones replay, the bad one is skipped and reported with count and reason; every entry unreplayable — load still succeeds with zero replayed messages; healthy transcripts replay with an unchanged update sequence.

## Relationship to #4021

#4021 bundled twelve unrelated defects into 53 files and was closed with the instruction to open fresh, scoped PRs. This is one of those, alongside #4031, #4033, #4035, #4036, #4037, #4038 and #4039.

Closes #4019
