### PR TITLE
fix(find): bound uncached glob traversal

### DIFF
--- a/crates/pi-natives/src/glob.rs
+++ b/crates/pi-natives/src/glob.rs
@@ -14,7 +14,12 @@
 //! // JS: await native.glob({ pattern: "*.rs", path: "." })
 //! ```
 
-use std::path::Path;
+use std::{
+	cmp::Ordering,
+	collections::BinaryHeap,
+	path::Path,
+	time::{Duration, Instant},
+};
 
 use globset::GlobSet;
 use napi::{
@@ -26,6 +31,9 @@ use napi_derive::napi;
 // Re-export entry types so existing `glob::FileType` / `glob::GlobMatch` paths still work.
 pub use crate::fs_cache::{FileType, GlobMatch};
 use crate::{fs_cache, glob_util, task};
+
+const MAX_PROGRESS_SNAPSHOTS: usize = 32;
+const DEFAULT_PROGRESS_INTERVAL_MS: u64 = 200;
 
 /// Input options for `glob`, including traversal, filtering, and cancellation.
 #[napi(object)]
@@ -79,6 +87,79 @@ struct GlobConfig {
 	mentions_node_modules: bool,
 	sort_by_mtime:         bool,
 	use_cache:             bool,
+	progress_interval:     Duration,
+}
+
+fn compare_matches(left: &GlobMatch, right: &GlobMatch) -> Ordering {
+	right
+		.mtime
+		.unwrap_or(0.0)
+		.total_cmp(&left.mtime.unwrap_or(0.0))
+		.then_with(|| left.path.cmp(&right.path))
+}
+
+#[derive(Clone)]
+struct RankedMatch(GlobMatch);
+
+impl PartialEq for RankedMatch {
+	fn eq(&self, other: &Self) -> bool {
+		compare_matches(&self.0, &other.0) == Ordering::Equal
+	}
+}
+
+impl Eq for RankedMatch {}
+
+impl PartialOrd for RankedMatch {
+	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+		Some(self.cmp(other))
+	}
+}
+
+impl Ord for RankedMatch {
+	fn cmp(&self, other: &Self) -> Ordering {
+		compare_matches(&self.0, &other.0)
+	}
+}
+
+struct BoundedMatches {
+	limit: usize,
+	heap:  BinaryHeap<RankedMatch>,
+}
+
+impl BoundedMatches {
+	const fn new(limit: usize) -> Self {
+		Self { limit, heap: BinaryHeap::new() }
+	}
+
+	fn insert(&mut self, entry: GlobMatch) -> bool {
+		if self.limit == 0 {
+			return false;
+		}
+		if self.heap.len() < self.limit {
+			self.heap.push(RankedMatch(entry));
+			return true;
+		}
+		let Some(worst) = self.heap.peek() else {
+			return false;
+		};
+		if compare_matches(&entry, &worst.0) != Ordering::Less {
+			return false;
+		}
+		self.heap.pop();
+		self.heap.push(RankedMatch(entry));
+		true
+	}
+
+	fn sorted(&self) -> Vec<GlobMatch> {
+		let mut entries: Vec<_> = self.heap.iter().map(|entry| entry.0.clone()).collect();
+		entries.sort_by(compare_matches);
+		entries
+	}
+
+	#[cfg(test)]
+	fn len(&self) -> usize {
+		self.heap.len()
+	}
 }
 
 fn resolve_symlink_target_type(root: &Path, relative_path: &str) -> Option<FileType> {
@@ -156,6 +237,88 @@ fn filter_entries(
 	Ok(matches)
 }
 
+fn emit_snapshot(entries: &[GlobMatch], on_match: Option<&ThreadsafeFunction<GlobMatch>>) {
+	let Some(callback) = on_match else {
+		return;
+	};
+	for entry in entries {
+		callback.call(Ok(entry.clone()), ThreadsafeFunctionCallMode::NonBlocking);
+	}
+}
+
+fn collect_uncached_entries(
+	glob_set: &GlobSet,
+	config: &GlobConfig,
+	on_match: Option<&ThreadsafeFunction<GlobMatch>>,
+	ct: &task::CancelToken,
+) -> Result<Vec<GlobMatch>> {
+	let builder = fs_cache::build_walker(
+		&config.root,
+		config.include_hidden,
+		config.use_gitignore,
+		!config.mentions_node_modules,
+		false,
+	);
+	let mut unsorted = Vec::new();
+	let mut ranked = BoundedMatches::new(config.max_results);
+	let mut progress_snapshots = 0;
+	let mut progress_dirty = false;
+	let now = Instant::now();
+	let mut last_progress = now.checked_sub(config.progress_interval).unwrap_or(now);
+
+	for walked in builder.build() {
+		ct.heartbeat()?;
+		let Ok(walked) = walked else {
+			continue;
+		};
+		let relative = fs_cache::normalize_relative_path(&config.root, walked.path()).into_owned();
+		if relative.is_empty()
+			|| fs_cache::should_skip_path(Path::new(&relative), config.mentions_node_modules)
+			|| !glob_set.is_match(&relative)
+		{
+			continue;
+		}
+		let Some((file_type, mtime, size)) = fs_cache::classify_file_type(walked.path()) else {
+			continue;
+		};
+		let mut entry =
+			GlobMatch { path: relative, file_type, mtime, size: size.map(|value| value as f64) };
+		let Some(effective_file_type) = apply_file_type_filter(&entry, config) else {
+			continue;
+		};
+		entry.file_type = effective_file_type;
+
+		if !config.sort_by_mtime {
+			if let Some(callback) = on_match {
+				callback.call(Ok(entry.clone()), ThreadsafeFunctionCallMode::NonBlocking);
+			}
+			unsorted.push(entry);
+			if unsorted.len() >= config.max_results {
+				break;
+			}
+			continue;
+		}
+
+		progress_dirty |= ranked.insert(entry);
+		if progress_dirty
+			&& progress_snapshots < MAX_PROGRESS_SNAPSHOTS
+			&& last_progress.elapsed() >= config.progress_interval
+		{
+			emit_snapshot(&ranked.sorted(), on_match);
+			progress_snapshots += 1;
+			progress_dirty = false;
+			last_progress = Instant::now();
+		}
+	}
+
+	if !config.sort_by_mtime {
+		return Ok(unsorted);
+	}
+	let matches = ranked.sorted();
+	emit_snapshot(&matches, on_match);
+	Ok(matches)
+}
+
 /// Executes matching/filtering over scanned entries and optionally streams each
 /// hit.
 fn run_glob(
@@ -191,19 +354,13 @@ fn run_glob(
 		}
 		matches
 	} else {
-		let fresh = fs_cache::force_rescan(&config.root, scan_options, false, &ct)?;
-		filter_entries(&fresh, &glob_set, &config, on_match, &ct)?
+		collect_uncached_entries(&glob_set, &config, on_match, &ct)?
 	};
 
 	if config.sort_by_mtime {
-		// Sorting mode: rank by mtime descending, then apply max-results truncation.
-		matches.sort_by(|a, b| {
-			let a_mtime = a.mtime.unwrap_or(0.0);
-			let b_mtime = b.mtime.unwrap_or(0.0);
-			b_mtime
-				.partial_cmp(&a_mtime)
-				.unwrap_or(std::cmp::Ordering::Equal)
-		});
+		// Cached sorting still ranks the complete snapshot; uncached collection is
+		// already bounded.
+		matches.sort_by(compare_matches);
 		matches.truncate(config.max_results);
 	}
 	let total_matches = matches.len().min(u32::MAX as usize) as u32;
@@ -247,6 +404,10 @@ pub fn glob(
 	let pattern = if pattern.is_empty() { "*" } else { pattern };
 	let pattern = pattern.to_string();
 
+	let progress_interval_ms = timeout_ms.map_or(DEFAULT_PROGRESS_INTERVAL_MS, |value| {
+		u64::from(value).div_ceil(MAX_PROGRESS_SNAPSHOTS as u64)
+	});
+	let progress_interval = Duration::from_millis(progress_interval_ms.max(1));
 	let ct = task::CancelToken::new(timeout_ms, signal);
 
 	task::blocking("glob", ct, move |ct| {
@@ -262,10 +423,55 @@ pub fn glob(
 					.unwrap_or_else(|| pattern.contains("node_modules")),
 				sort_by_mtime: sort_by_mtime.unwrap_or(false),
 				use_cache: cache.unwrap_or(false),
+				progress_interval,
 				pattern,
 			},
 			on_match.as_ref(),
 			ct,
 		)
 	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn candidate(path: String, mtime: f64) -> GlobMatch {
+		GlobMatch { path, file_type: FileType::File, mtime: Some(mtime), size: Some(0.0) }
+	}
+
+	#[test]
+	fn bounded_matches_keeps_newest_entries_beyond_the_old_scan_limit() {
+		let mut matches = BoundedMatches::new(3);
+		for index in 0..250_003 {
+			matches.insert(candidate(format!("entry-{index:06}.txt"), index as f64));
+		}
+
+		assert_eq!(matches.len(), 3);
+		assert_eq!(
+			matches
+				.sorted()
+				.into_iter()
+				.map(|entry| entry.path)
+				.collect::<Vec<_>>(),
+			["entry-250002.txt", "entry-250001.txt", "entry-250000.txt"],
+		);
+	}
+
+	#[test]
+	fn bounded_matches_breaks_mtime_ties_by_path() {
+		let mut matches = BoundedMatches::new(2);
+		for path in ["z.txt", "a.txt", "m.txt"] {
+			matches.insert(candidate(path.to_string(), 42.0));
+		}
+
+		assert_eq!(
+			matches
+				.sorted()
+				.into_iter()
+				.map(|entry| entry.path)
+				.collect::<Vec<_>>(),
+			["a.txt", "m.txt"],
+		);
+	}
 }

--- a/packages/coding-agent/src/tools/find.ts
+++ b/packages/coding-agent/src/tools/find.ts
@@ -59,6 +59,25 @@ const DEFAULT_GLOB_TIMEOUT_MS = 5000;
 const MIN_GLOB_TIMEOUT_MS = 500;
 const MAX_GLOB_TIMEOUT_MS = 60_000;
 
+function comparePaths(left: string, right: string): number {
+	let leftIndex = 0;
+	let rightIndex = 0;
+	while (leftIndex < left.length && rightIndex < right.length) {
+		const leftCodePoint = left.codePointAt(leftIndex);
+		const rightCodePoint = right.codePointAt(rightIndex);
+		if (leftCodePoint === undefined || rightCodePoint === undefined) break;
+		if (leftCodePoint !== rightCodePoint) return leftCodePoint - rightCodePoint;
+		leftIndex += leftCodePoint > 0xffff ? 2 : 1;
+		rightIndex += rightCodePoint > 0xffff ? 2 : 1;
+	}
+	return left.length - right.length;
+}
+
+function compareMtimePath(left: { path: string; mtime?: number }, right: { path: string; mtime?: number }): number {
+	const mtimeOrder = (right.mtime ?? 0) - (left.mtime ?? 0);
+	return mtimeOrder || comparePaths(left.path, right.path);
+}
+
 /**
  * Reject comma-separated path lists packed into a single array element
  * (`["a.py,b.py"]`). The schema is array-of-string; agents that pass a
@@ -317,29 +336,43 @@ export class FindTool implements AgentTool<typeof findSchema, FindToolDetails> {
 			}
 
 			let matches: natives.GlobMatch[];
-			const onUpdateMatches: string[] = [];
+			const onUpdateMatches = new Map<string, number>();
+			const rankedUpdateMatches = (): Array<{ path: string; mtime: number }> =>
+				Array.from(onUpdateMatches, ([matchPath, mtime]) => ({ path: matchPath, mtime })).sort(compareMtimePath);
+			const retainUpdateMatch = (matchPath: string, mtime: number) => {
+				onUpdateMatches.set(matchPath, mtime);
+				if (onUpdateMatches.size <= effectiveLimit) return;
+				let worst: { path: string; mtime: number } | undefined;
+				for (const [candidatePath, candidateMtime] of onUpdateMatches) {
+					const candidate = { path: candidatePath, mtime: candidateMtime };
+					if (!worst || compareMtimePath(candidate, worst) > 0) worst = candidate;
+				}
+				if (worst) onUpdateMatches.delete(worst.path);
+			};
 			const updateIntervalMs = 200;
 			let lastUpdate = 0;
+			let terminal = false;
 			const emitUpdate = () => {
 				if (!onUpdate) return;
 				const now = Date.now();
 				if (now - lastUpdate < updateIntervalMs) return;
 				lastUpdate = now;
+				const ranked = rankedUpdateMatches().map(entry => entry.path);
 				const details: FindToolDetails = {
 					scopePath,
-					fileCount: onUpdateMatches.length,
-					files: onUpdateMatches.slice(),
+					fileCount: ranked.length,
+					files: ranked,
 					truncated: false,
 				};
 				onUpdate({
-					content: [{ type: "text", text: onUpdateMatches.join("\n") }],
+					content: [{ type: "text", text: ranked.join("\n") }],
 					details,
 				});
 			};
 			const onMatch = (err: Error | null, match: natives.GlobMatch | null) => {
-				if (err || signal?.aborted || !match?.path) return;
+				if (err || terminal || combinedSignal.aborted || !match?.path) return;
 				const relativePath = formatMatchPath(match.path, match.fileType);
-				onUpdateMatches.push(relativePath);
+				retainUpdateMatch(relativePath, match.mtime ?? 0);
 				emitUpdate();
 			};
 
@@ -355,6 +388,7 @@ export class FindTool implements AgentTool<typeof findSchema, FindToolDetails> {
 							sortByMtime: true,
 							gitignore: useGitignore,
 							signal: combinedSignal,
+							timeoutMs,
 						},
 						onMatch,
 					),
@@ -363,34 +397,29 @@ export class FindTool implements AgentTool<typeof findSchema, FindToolDetails> {
 			let timedOut = false;
 			try {
 				const result = await doGlob(useGitignore);
-				// Sort by mtime descending (most recent first) in JS instead of native.
-				// This allows native glob to early-terminate at maxResults.
-				result.matches.sort((a, b) => (b.mtime ?? 0) - (a.mtime ?? 0));
+				// Native uncached glob retains a bounded newest set; keep the same tie-break after callback delivery.
+				result.matches.sort(compareMtimePath);
 				matches = result.matches;
 			} catch (error) {
-				if (error instanceof Error && error.name === "AbortError") {
-					if (timeoutSignal.aborted && !signal?.aborted) {
-						timedOut = true;
-						matches = [];
-					} else {
-						throw new ToolAbortError();
-					}
+				const nativeTimedOut = error instanceof Error && error.message === "Aborted: Timeout";
+				if (
+					(error instanceof Error && error.name === "AbortError" && timeoutSignal.aborted && !signal?.aborted) ||
+					(nativeTimedOut && !signal?.aborted)
+				) {
+					timedOut = true;
+					matches = [];
+				} else if (error instanceof Error && error.name === "AbortError") {
+					throw new ToolAbortError();
 				} else {
 					throw error;
 				}
+			} finally {
+				terminal = true;
 			}
 
 			if (timedOut) {
-				// Drain the partial matches accumulated during streaming and return them
-				// instead of throwing — empty results after a multi-second wait force the
-				// caller to retry blind, which is the worst possible outcome.
-				const seen = new Set<string>();
-				const partial: string[] = [];
-				for (const entry of onUpdateMatches) {
-					if (seen.has(entry)) continue;
-					seen.add(entry);
-					partial.push(entry);
-				}
+				// Return the bounded, deterministically ranked candidates observed before timeout.
+				const partial = rankedUpdateMatches().map(entry => entry.path);
 				const seconds = timeoutMs % 1000 === 0 ? `${timeoutMs / 1000}` : (timeoutMs / 1000).toFixed(1);
 				const notice = `find timed out after ${seconds}s; returning ${partial.length} partial matches — increase timeout or narrow pattern`;
 				return buildResult(partial, { notice, forceTruncated: true });

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -2366,6 +2366,39 @@ function b() {
 			expect(outputLines).toEqual(["z/auth-actions.spec.ts", "a/auth-actions.spec.ts"]);
 		});
 
+		it("should bound progress and break equal-mtime ties by path", async () => {
+			const fixedTime = new Date(Date.now() - 30_000);
+			for (const name of ["z.txt", "a.txt", "m.txt"]) {
+				const filePath = path.join(testDir, name);
+				fs.writeFileSync(filePath, name);
+				fs.utimesSync(filePath, fixedTime, fixedTime);
+			}
+			const updates: string[][] = [];
+			const result = await findTool.execute(
+				"test-call-14f",
+				{
+					paths: [`${testDir}/**/*.txt`],
+					limit: 2,
+				},
+				undefined,
+				update => {
+					if (update.details?.files) updates.push(update.details.files);
+				},
+			);
+			const updatesAtCompletion = updates.length;
+			await Bun.sleep(25);
+
+			const outputLines = getTextOutput(result)
+				.split("\n")
+				.map(line => line.trim())
+				.filter(Boolean);
+			expect(outputLines.slice(0, 2)).toEqual(["a.txt", "m.txt"]);
+			expect(outputLines).not.toContain("z.txt");
+			expect(updates.length).toBeGreaterThan(0);
+			expect(updates.every(files => files.length <= 2)).toBe(true);
+			expect(updates).toHaveLength(updatesAtCompletion);
+		});
+
 		it("should render nested glob results relative to the session cwd", async () => {
 			const nestedDir = path.join(testDir, "apps", "daemon", "src", "telemetry");
 			fs.mkdirSync(nestedDir, { recursive: true });

--- a/packages/natives/test/native.test.ts
+++ b/packages/natives/test/native.test.ts
@@ -459,6 +459,44 @@ describe("pi-natives", () => {
 			expect(result.matches).toHaveLength(0);
 		});
 
+		it("should bound sorted callbacks and keep the newest matches", async () => {
+			const scopedDir = await fs.mkdtemp(path.join(os.tmpdir(), "natives-glob-bounded-"));
+			try {
+				const baseTime = Date.now() - 10_000;
+				for (let index = 0; index < 100; index++) {
+					const filePath = path.join(scopedDir, `entry-${index.toString().padStart(3, "0")}.txt`);
+					await fs.writeFile(filePath, "");
+					const timestamp = new Date(baseTime + index);
+					await fs.utimes(filePath, timestamp, timestamp);
+				}
+				const callbacks: GlobMatch[] = [];
+				const result = await glob(
+					{
+						pattern: "*.txt",
+						path: scopedDir,
+						maxResults: 3,
+						sortByMtime: true,
+						timeoutMs: 1000,
+					},
+					(error, match) => {
+						expect(error).toBeNull();
+						callbacks.push(match);
+					},
+				);
+
+				await Bun.sleep(25);
+				expect(result.matches.map(match => match.path)).toEqual([
+					"entry-099.txt",
+					"entry-098.txt",
+					"entry-097.txt",
+				]);
+				expect(callbacks.length).toBeGreaterThan(0);
+				expect(callbacks.length).toBeLessThanOrEqual(33 * 3);
+			} finally {
+				await fs.rm(scopedDir, { recursive: true, force: true });
+			}
+		});
+
 		it("should fast-recheck empty cached results when threshold is reached", async () => {
 			const fileName = "cache-empty-recheck-target.txt";
 			const filePath = path.join(testDir, fileName);


### PR DESCRIPTION
## Summary

- match uncached sorted globs during traversal and retain only the newest K entries with deterministic `mtime desc, path asc` ordering
- cap native progress delivery at 32 snapshots plus one final snapshot and keep FindTool progress state deduplicated and bounded to K
- preserve cached complete-or-error scans, existing hidden/ignore/node_modules/symlink/file-type behavior, lazy native loading, MCP routing, and explicit `.gjc`/global-store routing

This is intentionally limited to the four files in the approved broad-find plan. It does not change shared fs-cache limits, Darwin session storage, runtime state, or global-store routing.

Related context: #3769 established the real large-root native scan ownership problem; #3780 added complete-or-error shared-scan bounds. This PR fixes the user-facing uncached `find` path that otherwise materializes that complete snapshot before applying K.

## Verification

- `cargo test -p pi-natives glob --lib` — 16 passed
- `bun run build:native` — passed
- `bun test packages/natives/test/native.test.ts` — 37 passed
- `bun test packages/coding-agent/test/tools.test.ts -t "find tool"` — 8 passed, 17 assertions
- `bun run --cwd=packages/natives check` — passed
- `bun run --cwd=packages/coding-agent generate-docs-index && bun run --cwd=packages/coding-agent check` — passed
- scoped Clippy with the six unchanged `origin/dev` computer/controller diagnostics allowed — passed with `-D warnings`
- local 250,004-entry regression — returned exactly `zz-target-c.txt`, `zz-target-b.txt`, `zz-target-a.txt`; 4 callbacks for K=3
- `FS_SCAN_MAX_ENTRIES=10` contract probe — cached scan failed closed with `FS_SCAN_LIMIT` and zero callbacks; uncached scan returned the newest K=3

## Base-only gate note

`bun run check:rs` currently fails on six denied Clippy diagnostics already present in `origin/dev@3bddcc579`, all in `crates/pi-natives/src/computer/controller.rs`. No changed file is implicated; the affected crate passes scoped Clippy after allowing only those three base-only lint classes.