### PR TITLE
fix(coding-agent): open staged conversation files writable

### DIFF
--- a/packages/coding-agent/src/sdk/bus/conversation-store.ts
+++ b/packages/coding-agent/src/sdk/bus/conversation-store.ts
@@ -349,7 +349,7 @@ export class ConversationStore<T extends ConversationRecord> {
 		try {
 			await this.#fs.writeFile(temporary, `${JSON.stringify(document)}\n`, { mode: 0o600 });
 			await this.#fs.chmod(temporary, 0o600);
-			const handle = await this.#fs.open(temporary, "r");
+			const handle = await this.#fs.open(temporary, "r+");
 			try {
 				await handle.sync();
 			} finally {

--- a/packages/coding-agent/test/sdk-daemon-concurrency.test.ts
+++ b/packages/coding-agent/test/sdk-daemon-concurrency.test.ts
@@ -220,6 +220,31 @@ describe("ConversationStore", () => {
 		expect(bounded.at(-1)).toBe(`event-${MAX_DEDUPE_IDS + 1}`);
 	});
 
+	test("opens staged documents writable before fsync for Windows compatibility", async () => {
+		class WindowsFsyncFs extends MemoryConversationStoreFs {
+			temporaryOpenFlags: string | undefined;
+
+			override async open(file: string, flags: string) {
+				const handle = await super.open(file, flags);
+				if (!file.endsWith(".tmp")) return handle;
+				this.temporaryOpenFlags = flags;
+				return {
+					...handle,
+					sync: async () => {
+						if (!flags.includes("+")) {
+							throw Object.assign(new Error("EPERM: operation not permitted, fsync"), { code: "EPERM" });
+						}
+						await handle.sync();
+					},
+				};
+			}
+		}
+
+		const fs = new WindowsFsyncFs();
+		const store = new ConversationStore<TestConversation>({ agentDir: "/agent", kind: "discord", fs, now: () => 4 });
+		await expect(store.write("mapping", undefined, record(1))).resolves.toBe(true);
+		expect(fs.temporaryOpenFlags).toBe("r+");
+	});
 	test("keeps the prior document intact when fsync or rename fails", async () => {
 		const fs = new MemoryConversationStoreFs();
 		const store = new ConversationStore<TestConversation>({ agentDir: "/agent", kind: "discord", fs, now: () => 4 });


### PR DESCRIPTION
## Summary
- open staged conversation-store documents with read/write access before calling fsync
- prevent Bun on Windows from throwing EPERM when Discord or Slack daemons persist conversations
- add a regression test that models Windows rejecting fsync on a read-only handle

## Reproduction
On Windows 11 with Bun 1.3.14, setting up Discord notifications succeeds, but the daemon exits while creating its conversation store:

```text
EPERM: operation not permitted, fsync
at ConversationStore.#persist (.../conversation-store.ts:354)
```

Opening the already-written temporary file with `r+` preserves the existing durability flow while making the handle fsync-compatible on Windows.

## Verification
- `bun test packages/coding-agent/test/sdk-daemon-concurrency.test.ts --test-name-pattern "opens staged documents writable"` (1 pass)
- `bun run --cwd packages/coding-agent check:types` (pass)

The complete concurrency test file currently has pre-existing Windows path-separator failures because several fixtures assert POSIX paths such as `/agent/sdk/...`.