### PR TITLE
fix(coding-agent): accept plain Discord prompts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Discord threads now accept ordinary non-empty messages as agent prompts while preserving explicit `/sdk` commands. Gateway messages decode both text and binary payloads, resolve missing thread-parent metadata through Discord's REST API, and stop reconnecting after terminal close codes. Discord output now contains only completed turn text and actionable questions instead of lifecycle, identity, activity, idle, partial-stream, duplicate, and plain-prompt acknowledgement noise.
+
 ## [0.12.16] - 2026-08-08
 
 ### Added

--- a/packages/coding-agent/src/sdk/bus/chat-adapters.ts
+++ b/packages/coding-agent/src/sdk/bus/chat-adapters.ts
@@ -71,6 +71,12 @@ function frameText(event: Extract<NotificationEvent, { type: "frame" }>): string
 	return lines.join("\n");
 }
 
+function discordFrameText(event: Extract<NotificationEvent, { type: "frame" }>): string | undefined {
+	const frame = event.frame;
+	if (frame.type !== "turn_stream" || frame.phase === "live") return undefined;
+	return text(frame.text) ?? text(frame.lastMessage) ?? text(frame.caption);
+}
+
 function routeFromInbound(input: unknown): NotificationReplyRoute | undefined {
 	const raw = input as InboundShape;
 	if (!raw || typeof raw !== "object") return undefined;
@@ -87,8 +93,8 @@ class DiscordNotificationAdapter implements NotificationPresentationAdapter {
 	constructor(private readonly opts: ChatAdapterOptions) {}
 
 	render(event: NotificationEvent): NotificationAdapterPayload[] {
-		if (event.type === "action_resolved") return [];
-		const content = event.type === "action_needed" ? actionText(event, "discord") : frameText(event);
+		if (event.type === "action_resolved" || (event.type === "action_needed" && event.kind === "idle")) return [];
+		const content = event.type === "action_needed" ? actionText(event, "discord") : discordFrameText(event);
 		if (!content) return [];
 		const payload: Record<string, unknown> = {
 			content,

--- a/packages/coding-agent/src/sdk/bus/chat-daemon-runtime.ts
+++ b/packages/coding-agent/src/sdk/bus/chat-daemon-runtime.ts
@@ -685,18 +685,29 @@ export class ChatDaemonRuntime {
 		idempotencyKey: string = randomUUID(),
 	): Promise<boolean> {
 		const match = /^\/sdk\s+(control|query|global)\s+([^\s]+)(?:\s+(.+))?\s*$/.exec(content);
-		if (!match) return false;
-		const kind = match[1] as "control" | "query" | "global";
-		let input: unknown = {};
-		if (match[3]) {
-			try {
-				input = JSON.parse(match[3]);
-			} catch {
-				return false;
+		const plainPrompt = match === null;
+		let kind: "control" | "query" | "global";
+		let operation: string;
+		let input: unknown;
+		if (match) {
+			kind = match[1] as "control" | "query" | "global";
+			operation = match[2]!;
+			input = {};
+			if (match[3]) {
+				try {
+					input = JSON.parse(match[3]);
+				} catch {
+					return false;
+				}
 			}
+		} else {
+			const text = content.trim();
+			if (!text) return false;
+			kind = "control";
+			operation = "turn.prompt";
+			input = { text };
 		}
 		if (!input || typeof input !== "object" || Array.isArray(input)) return false;
-		const operation = match[2]!;
 		let outcome: { ok: true; result: unknown } | { ok: false; error: { code: string; message: string } };
 		try {
 			outcome = await sendAuthorizedChatOperation(transport, { kind, operation, input }, async () => {
@@ -722,7 +733,7 @@ export class ChatDaemonRuntime {
 				},
 			};
 		}
-		await this.#postCommandOutcome(transport, sessionId, { kind, operation }, outcome);
+		if (!plainPrompt) await this.#postCommandOutcome(transport, sessionId, { kind, operation }, outcome);
 		return outcome.ok;
 	}
 	async #runGlobalCommand(

--- a/packages/coding-agent/src/sdk/bus/discord-daemon.ts
+++ b/packages/coding-agent/src/sdk/bus/discord-daemon.ts
@@ -476,7 +476,7 @@ export class DiscordNotificationDaemon {
 	): Promise<DiscordInboundClaim | "invalid" | undefined> {
 		if (record.state !== "active" || closingIntent(record)) return "invalid";
 		const route = event.interaction ? decodeCustomId(event.interaction.customId) : undefined;
-		const command = !event.interaction && event.content?.startsWith("/sdk ");
+		const command = !event.interaction && typeof event.content === "string" && event.content.trim().length > 0;
 		if (!command && (!route || !event.interaction || route.generation !== record.endpointGeneration))
 			return "invalid";
 		const key = discordConversationKey({

--- a/packages/coding-agent/src/sdk/bus/discord-live-provider.ts
+++ b/packages/coding-agent/src/sdk/bus/discord-live-provider.ts
@@ -13,6 +13,7 @@ const GATEWAY_INTENTS = 1 + 512 + 32_768;
 const MAX_RATE_LIMIT_RETRIES = 2;
 const NONCE_PREFIX = "<!-- gjc-thread-nonce:";
 const INVALID_SESSION_RECONNECT_DELAY_MS = 1_000;
+const TERMINAL_GATEWAY_CLOSE_CODES: ReadonlySet<number> = new Set([4_004, 4_010, 4_011, 4_012, 4_013, 4_014]);
 
 const NONCE_SUFFIX = " -->";
 
@@ -329,15 +330,35 @@ export class DiscordLiveProvider implements DiscordProvider, DiscordDiagnosticPr
 		socket.addEventListener("message", event => {
 			void this.#handleGateway(socket, event).catch(error => this.#handleGatewayFailure(socket, error));
 		});
-		socket.addEventListener("close", () => this.#scheduleReconnect(socket));
+		socket.addEventListener("close", event => {
+			const code = typeof (event as CloseEvent).code === "number" ? (event as CloseEvent).code : 0;
+			if (TERMINAL_GATEWAY_CLOSE_CODES.has(code)) {
+				this.#gatewayError = new Error(`Discord gateway rejected the connection (close code ${code})`);
+				this.#heartbeat?.cancel();
+				this.#heartbeat = undefined;
+				this.#gatewayReady = false;
+				return;
+			}
+			this.#scheduleReconnect(socket);
+		});
 		socket.addEventListener("error", () => {
 			if (socket.readyState !== 3) socket.close();
 		});
 	}
 
 	async #handleGateway(socket: DiscordGatewaySocket, event: Event): Promise<void> {
-		const data = (event as MessageEvent).data;
-		if (typeof data !== "string") return;
+		const raw = (event as MessageEvent).data;
+		const data =
+			typeof raw === "string"
+				? raw
+				: raw instanceof ArrayBuffer
+					? Buffer.from(raw).toString("utf8")
+					: ArrayBuffer.isView(raw)
+						? Buffer.from(raw.buffer, raw.byteOffset, raw.byteLength).toString("utf8")
+						: raw instanceof Blob
+							? await raw.text()
+							: undefined;
+		if (data === undefined) return;
 		let frame: JsonRecord;
 		try {
 			frame = JSON.parse(data) as JsonRecord;
@@ -387,7 +408,7 @@ export class DiscordLiveProvider implements DiscordProvider, DiscordDiagnosticPr
 			this.#resumeGatewayUrl = this.#string(payload, "resume_gateway_url");
 		}
 		if (frame.t === "READY" || frame.t === "RESUMED") this.#gatewayReady = true;
-		const inbound = this.#inbound(frame.t, payload);
+		const inbound = await this.#inbound(frame.t, payload);
 		if (inbound && !inbound.bot && inbound.authorId !== this.#botUserId) await this.#onEvent?.(inbound);
 	}
 	#handleGatewayFailure(socket: DiscordGatewaySocket, error: unknown): void {
@@ -526,14 +547,21 @@ export class DiscordLiveProvider implements DiscordProvider, DiscordDiagnosticPr
 			this.#string(this.#record(data.channel), "parent_id")
 		);
 	}
-	#inbound(type: unknown, data: JsonRecord): DiscordInboundEvent | undefined {
+	async #inbound(type: unknown, data: JsonRecord): Promise<DiscordInboundEvent | undefined> {
 		if (type === "MESSAGE_CREATE") {
 			const id = this.#string(data, "id");
 			const guildId = this.#string(data, "guild_id");
 			const threadId = this.#string(data, "channel_id");
 			const author = this.#record(data.author);
 			const authorId = this.#string(author, "id");
-			const parentId = this.#parentId(data);
+			let parentId = this.#parentId(data);
+			if (!parentId && threadId) {
+				try {
+					parentId = this.#string(this.#record(await this.#request(`/channels/${threadId}`)), "parent_id");
+				} catch {
+					return undefined;
+				}
+			}
 			if (!id || !guildId || !threadId || !parentId || !authorId) return undefined;
 			return {
 				id,

--- a/packages/coding-agent/test/notifications-chat-adapters.test.ts
+++ b/packages/coding-agent/test/notifications-chat-adapters.test.ts
@@ -62,6 +62,28 @@ describe("Discord and Slack notification adapters", () => {
 		for (const secret of secretCorpus) expect(serialized).not.toContain(secret);
 	});
 
+	test("Discord emits only completed turn text and suppresses lifecycle noise", () => {
+		const engine = new NotificationPresentationEngine([createDiscordAdapter()], {
+			redact: false,
+			sessionTag: () => "abcdef",
+		});
+		for (const frame of [
+			{ type: "agent_start" },
+			{ type: "activity" },
+			{ type: "identity_header", title: "Session" },
+			{ type: "turn_stream", phase: "live", text: "partial" },
+			{ type: "agent_end", lastMessage: "duplicate" },
+		])
+			expect(engine.fanout({ type: "frame", sessionId: "session", frame })).toEqual([]);
+		const payloads = engine.fanout({
+			type: "frame",
+			sessionId: "session",
+			frame: { type: "turn_stream", phase: "completed", text: "final answer" },
+		});
+		expect(payloads).toHaveLength(1);
+		expect(payloads[0]?.body).toEqual(expect.objectContaining({ content: "final answer" }));
+	});
+
 	test("ignore unknown or stale inbound replies", () => {
 		const engine = new NotificationPresentationEngine([createDiscordAdapter()], {
 			redact: false,

--- a/packages/coding-agent/test/sdk-chat-daemon-worker.test.ts
+++ b/packages/coding-agent/test/sdk-chat-daemon-worker.test.ts
@@ -345,11 +345,8 @@ describe("chat daemon worker", () => {
 		);
 		expect(startupQueries).toHaveLength(1);
 		expect(startupQueries[0]).toMatchObject({ type: "query_request", query: "todo.list", input: {} });
-		const turnStreamPosted = provider.waitForMessage(message => message.content === "GJC turn stream\noutbound");
-		expect(provider.messages).toContainEqual({
-			threadId: "thread-1",
-			content: "GJC identity header\ntitle: Replay identity\nrepo: replay-repo\nbranch: replay-branch",
-		});
+		const turnStreamPosted = provider.waitForMessage(message => message.content === "outbound");
+		expect(provider.messages.some(message => message.content.includes("Replay identity"))).toBe(false);
 		client.handler?.({ type: "turn_stream", phase: "live", sessionId: "session", text: "direct live" });
 		client.handler?.({
 			type: "event",
@@ -360,15 +357,11 @@ describe("chat daemon worker", () => {
 		expect(provider.messages.some(message => /(?:replayed|direct|wrapped) live/.test(message.content))).toBe(false);
 		client.handler?.({ type: "turn_stream", sessionId: "session", text: "outbound" });
 		await turnStreamPosted;
-		expect(provider.messages).toContainEqual({ threadId: "thread-1", content: "GJC turn stream\noutbound" });
-		const finalizedTurnStreamPosted = provider.waitForMessage(
-			message => message.content === "GJC turn stream\nfinalized",
-		);
+		expect(provider.messages).toContainEqual({ threadId: "thread-1", content: "outbound" });
+		const finalizedTurnStreamPosted = provider.waitForMessage(message => message.content === "finalized");
 		client.handler?.({ type: "turn_stream", phase: "finalized", sessionId: "session", text: "finalized" });
 		await finalizedTurnStreamPosted;
-		const wrappedMissingPhasePosted = provider.waitForMessage(
-			message => message.content === "GJC turn stream\nwrapped missing phase",
-		);
+		const wrappedMissingPhasePosted = provider.waitForMessage(message => message.content === "wrapped missing phase");
 		client.handler?.({
 			type: "event",
 			name: "turn_stream",
@@ -425,6 +418,23 @@ describe("chat daemon worker", () => {
 		expect(provider.messages.filter(message => message.content === queryResultBody)).toHaveLength(
 			queryResultBaseline + 1,
 		);
+		const promptKey = "discord:app:guild:parent:thread-1:prompt";
+		const promptRequest = client.waitForRequest(
+			request =>
+				request.type === "control_request" &&
+				request.operation === "turn.prompt" &&
+				(request.input as Record<string, unknown>)?.text === "plain Discord instruction" &&
+				request.idempotencyKey === promptKey,
+		);
+		await provider.handler?.({
+			id: "prompt",
+			guildId: "guild",
+			parentId: "parent",
+			threadId: "thread-1",
+			authorId: "human",
+			content: "plain Discord instruction",
+		});
+		await promptRequest;
 		expect(JSON.stringify(provider.messages)).not.toContain("daemon-result-secret");
 		const prohibitedResult = provider.waitForMessage(
 			message =>

--- a/packages/coding-agent/test/sdk-discord-live-provider.test.ts
+++ b/packages/coding-agent/test/sdk-discord-live-provider.test.ts
@@ -11,9 +11,9 @@ class FakeSocket implements DiscordGatewaySocket {
 	send(data: string): void {
 		this.sent.push(data);
 	}
-	close(): void {
+	close(code = 1_000, reason = ""): void {
 		this.readyState = 3;
-		this.emit("close", new Event("close"));
+		this.emit("close", new CloseEvent("close", { code, reason }));
 	}
 	addEventListener(type: "open" | "message" | "close" | "error", listener: Listener): void {
 		this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
@@ -23,6 +23,9 @@ class FakeSocket implements DiscordGatewaySocket {
 	}
 	message(frame: Record<string, unknown>): void {
 		this.emit("message", new MessageEvent("message", { data: JSON.stringify(frame) }));
+	}
+	binary(frame: Record<string, unknown>): void {
+		this.emit("message", new MessageEvent("message", { data: Buffer.from(JSON.stringify(frame)) }));
 	}
 }
 
@@ -298,7 +301,7 @@ describe("DiscordLiveProvider protocol", () => {
 		expect(socket.sent.map(value => JSON.parse(value))).toContainEqual(
 			expect.objectContaining({ op: 2, d: expect.objectContaining({ token: "discord-secret-token" }) }),
 		);
-		socket.message({
+		socket.binary({
 			op: 0,
 			t: "MESSAGE_CREATE",
 			s: 4,
@@ -306,7 +309,6 @@ describe("DiscordLiveProvider protocol", () => {
 				id: "message",
 				guild_id: "guild",
 				channel_id: "thread",
-				thread: { parent_id: "parent" },
 				author: { id: "member", bot: false },
 				content: "reply",
 			},
@@ -325,8 +327,9 @@ describe("DiscordLiveProvider protocol", () => {
 				data: { custom_id: "gjc:1:ask", value: "yes" },
 			},
 		});
-		await Promise.resolve();
-		expect(events).toEqual(["message", "interaction"]);
+		await Bun.sleep(10);
+		expect(events.sort()).toEqual(["interaction", "message"]);
+		expect(requests.map(request => request.path)).toContain("https://discord.test/api/channels/thread");
 		socket.close();
 		expect(sockets).toHaveLength(2);
 		await live.stop();
@@ -469,6 +472,17 @@ describe("DiscordLiveProvider protocol", () => {
 			op: 6,
 			d: { token: "discord-secret-token", session_id: "resume-me", seq: 7 },
 		});
+		await live.stop();
+	});
+	test("does not reconnect after a terminal Gateway close code", async () => {
+		const requests: Array<{ path: string; init: RequestInit }> = [];
+		const sockets: FakeSocket[] = [];
+		const live = provider(requests, sockets);
+		await live.start(async () => {});
+		sockets[0]!.close(4_014, "disallowed intents");
+		expect(sockets).toHaveLength(1);
+		expect(live.gatewayError?.message).toContain("4014");
+		expect(live.transportHealthy).toBe(false);
 		await live.stop();
 	});
 	test("requires READY or RESUMED plus a heartbeat ACK before reporting a healthy transport", async () => {


### PR DESCRIPTION
## Summary
- route non-empty Discord thread messages to `turn.prompt` while preserving explicit `/sdk` commands
- decode binary Discord Gateway frames and recover missing thread parent metadata through REST
- stop reconnecting on terminal Gateway close codes
- reduce Discord output to completed turn text and actionable questions
- document the user-facing fix under the coding-agent Unreleased changelog

## Verification
- `bun test packages/coding-agent/test/notifications-chat-adapters.test.ts` — 4 passed
- `bun test packages/coding-agent/test/sdk-discord-live-provider.test.ts` — 15 passed
- `bun --cwd=packages/coding-agent run check` — passed
- live Discord session verified a plain-text prompt round-trip

## Local limitation
Filesystem-backed daemon/worker acceptance tests are blocked on this Windows checkout by the existing `conversation-store.ts` read-only `fsync` failure (`EPERM`). The focused adapter/provider tests and package checks pass.