### PR TITLE
fix(cli): keep root flags aligned

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,7 @@
 - A transient Windows `io_error` while detaching a managed replacement cleanup receipt now defers that receipt for later reconciliation instead of aborting the current session mutation. Invalid receipt and non-I/O cleanup failures remain fail-closed.
 
 - Attached image placeholders such as `[image 1]`, including the `[image N] source="…"` pasted-path reference form, are now deleted atomically with Backspace when the cursor sits at the placeholder boundary or the end of the full reference, instead of being erased one character at a time.
+- Root CLI help and shell completion now share the launch flag table instead of maintaining divergent copies, advertise the working `--fork` and `--worktree` options, omit retired extension/skill flags, and reject unknown options instead of silently dropping typos (#4023).
 
 ### Added
 
@@ -47,7 +48,6 @@
 
 ### Fixed
 - Repeated provider idle-stream stalls now stop after `retry.maxRetries` instead of inheriting the unbounded transient-error retry path. A one-off stall still retries normally, while a persistently silent stream surfaces its error rather than resubmitting the same billable context indefinitely.
-
 - SDK snapshot spill writes now retry once with a fresh temporary file when Bun reports `EBADF` during write or `fsync` under heavily contended descriptor teardown, and no longer fail when `close()` reports `EBADF` after a successful write and sync. The atomic writer removes the abandoned attempt before retrying, preserves primary I/O failures, accepts only the proven already-closed close case, and keeps every non-`EBADF` error or repeated descriptor failure fatal.
 - Discord Gateway ingestion now decodes text and binary WebSocket payloads, resolves a thread's missing parent-channel metadata through Discord's REST API, and stops reconnecting after terminal authentication, sharding, version, or intent close codes.
 

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -5,9 +5,10 @@
  * lightweight CLI runner from pi-utils.
  */
 import "@gajae-code/utils/postmortem";
-import { Args, type CliConfig, Command, type CommandEntry, Flags, run } from "@gajae-code/utils/cli";
+import { Args, type CliConfig, Command, type CommandEntry, run } from "@gajae-code/utils/cli";
 import { APP_NAME, formatBunRuntimeError, MIN_BUN_VERSION, VERSION } from "@gajae-code/utils/dirs";
 import { runFixtureReport } from "./cli/fixture-report";
+import { ROOT_LAUNCH_FLAGS } from "./cli/root-flags";
 import { smokeTestTabWorker } from "./tools/browser/tab-worker-smoke";
 
 if (Bun.semver.order(Bun.version, MIN_BUN_VERSION) < 0) {
@@ -24,7 +25,6 @@ if (Bun.semver.order(Bun.version, MIN_BUN_VERSION) < 0) {
 process.title = APP_NAME;
 const rootHelpFlags = ["--help", "-h", "help"];
 const versionFlags = ["--version", "-v"];
-const THINKING_EFFORTS = ["minimal", "low", "medium", "high", "xhigh", "max"] as const;
 const MANAGED_OWNER_SUPERVISOR_ARG = "--internal-managed-owner-supervisor";
 const MANAGED_OWNER_CHILD_TOKEN_ENV = "GJC_MANAGED_OWNER_CHILD_TOKEN";
 const TMUX_OWNER_ISOLATION_ARG = "--internal-tmux-owner-isolation";
@@ -221,21 +221,42 @@ async function runMemoryGuardNativeSmokeFastPathFromCli(): Promise<void> {
 	runMemoryGuardNativeSmoke();
 }
 
+function rootFlagDescriptor(arg: string) {
+	if (arg.startsWith("--") && !arg.includes("="))
+		return ROOT_LAUNCH_FLAGS[arg.slice(2) as keyof typeof ROOT_LAUNCH_FLAGS];
+	if (/^-[^-]$/.test(arg))
+		return Object.values(ROOT_LAUNCH_FLAGS).find(descriptor => descriptor.char === arg.slice(1));
+	return undefined;
+}
+
+function rootFlagValueIndex(argv: readonly string[], index: number): number {
+	const descriptor = rootFlagDescriptor(argv[index] ?? "");
+	if (!descriptor || descriptor.kind === "boolean") return index;
+	const value = argv[index + 1];
+	return value && !value.startsWith("-") ? index + 1 : index;
+}
+
 function rootFixtureArg(argv: string[]): { present: boolean; id: string | undefined } {
 	for (let i = 0; i < argv.length; i++) {
-		const arg = argv[i];
-		// Stop at the first subcommand token so a `--fixture` flag belonging to a
-		// subcommand never hijacks the root fast-path into fixture-report mode.
-		if (isSubcommand(arg)) return { present: false, id: undefined };
+		const arg = argv[i] ?? "";
+		if (arg === "--" || isSubcommand(arg)) return { present: false, id: undefined };
 		if (arg === "--fixture") return { present: true, id: argv[i + 1] };
+		const descriptor = rootFlagDescriptor(arg);
+		if (descriptor && descriptor.kind !== "boolean") {
+			const value = argv[i + 1];
+			if (!value || value.startsWith("-")) return { present: false, id: undefined };
+			i++;
+		}
 	}
 	return { present: false, id: undefined };
 }
 
 function hasRootFastFlag(argv: string[], flags: readonly string[]): boolean {
-	for (const arg of argv) {
-		if (isSubcommand(arg)) return false;
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i] ?? "";
+		if (arg === "--" || isSubcommand(arg)) return false;
 		if (flags.includes(arg)) return true;
+		i = rootFlagValueIndex(argv, i);
 	}
 	return false;
 }
@@ -258,63 +279,7 @@ export class RootHelpCommand extends Command {
 			multiple: true,
 		}),
 	};
-	static flags = {
-		model: Flags.string({ description: 'Model to use (fuzzy match: "opus", "gpt-5.2", or "openai/gpt-5.2")' }),
-		smol: Flags.string({ description: "Smol/fast model for lightweight tasks (or GJC_SMOL_MODEL env)" }),
-		slow: Flags.string({ description: "Slow/reasoning model for thorough analysis (or GJC_SLOW_MODEL env)" }),
-		plan: Flags.string({ description: "Plan model for architectural planning (or GJC_PLAN_MODEL env)" }),
-		mpreset: Flags.string({ description: "Model profile preset to activate for this session" }),
-		default: Flags.boolean({ description: "Persist --mpreset as the default model profile" }),
-		provider: Flags.string({ description: "Provider to use (legacy; prefer --model)" }),
-		"api-key": Flags.string({ description: "API key (defaults to env vars)" }),
-		credential: Flags.string({
-			description:
-				"Stored credential selector: email:<addr>, id:<n>, account:<id>, project:<id>, or provider/email:<addr>",
-		}),
-		"system-prompt": Flags.string({ description: "System prompt (default: coding assistant prompt)" }),
-		"append-system-prompt": Flags.string({ description: "Append text or file contents to the system prompt" }),
-		"mcp-config": Flags.string({ description: "Tools-only MCP config file (absolute path)" }),
-		"clipboard-transport": Flags.string({
-			description: "Clipboard transport: auto (default), native, osc52, or ssh",
-			options: ["auto", "native", "osc52", "ssh"],
-		}),
-		"clipboard-ssh-host": Flags.string({
-			description: "SSH host alias for --clipboard-transport ssh (from ~/.ssh/config)",
-		}),
-		"allow-home": Flags.boolean({ description: "Allow starting in ~ without auto-switching to a temp dir" }),
-		mode: Flags.string({
-			description: "Output mode: text (default), json, or acp",
-			options: ["text", "json", "acp"],
-		}),
-		print: Flags.boolean({ char: "p", description: "Non-interactive mode: process prompt and exit" }),
-		continue: Flags.boolean({ char: "c", description: "Continue previous session" }),
-		resume: Flags.string({ char: "r", description: "Resume a session (by ID prefix, path, or picker if omitted)" }),
-		"session-dir": Flags.string({ description: "Directory for session storage and lookup" }),
-		"no-session": Flags.boolean({ description: "Don't save session (ephemeral)" }),
-		models: Flags.string({ description: "Comma-separated model patterns for Alt+N cycling" }),
-		"no-tools": Flags.boolean({ description: "Disable all built-in tools" }),
-		"no-lsp": Flags.boolean({ description: "Disable LSP tools, formatting, and diagnostics" }),
-		"no-pty": Flags.boolean({ description: "Disable PTY-based interactive bash execution" }),
-		tmux: Flags.boolean({ description: "Launch interactive startup inside tmux" }),
-		tools: Flags.string({ description: "Comma-separated list of tools to enable (default: all)" }),
-		thinking: Flags.string({
-			description: `Set thinking level: ${THINKING_EFFORTS.join(", ")}`,
-			options: [...THINKING_EFFORTS],
-		}),
-		hook: Flags.string({ description: "Load a hook/extension file (can be used multiple times)", multiple: true }),
-		extension: Flags.string({
-			char: "e",
-			description: "Load an extension file (can be used multiple times)",
-			multiple: true,
-		}),
-		"no-extensions": Flags.boolean({ description: "Disable extension discovery (explicit -e paths still work)" }),
-		"no-skills": Flags.boolean({ description: "Disable skills discovery and loading" }),
-		skills: Flags.string({ description: "Comma-separated glob patterns to filter skills (e.g., git-*,docker)" }),
-		"no-rules": Flags.boolean({ description: "Disable rules discovery and loading" }),
-		export: Flags.string({ description: "Export session file to HTML and exit" }),
-		"list-models": Flags.string({ description: "List available models (with optional fuzzy search)" }),
-		"no-title": Flags.boolean({ description: "Disable title auto-generation" }),
-	};
+	static flags = ROOT_LAUNCH_FLAGS;
 	static examples = [
 		`# Interactive mode\n  ${APP_NAME}`,
 		`# Interactive mode with initial prompt\n  ${APP_NAME} "List all .ts files in src/"`,

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -221,6 +221,16 @@ async function runMemoryGuardNativeSmokeFastPathFromCli(): Promise<void> {
 	runMemoryGuardNativeSmoke();
 }
 
+function isLaunchWorktreeSelector(arg: string): boolean {
+	return (
+		arg === "--worktree" ||
+		arg === "-w" ||
+		arg.startsWith("--worktree=") ||
+		arg.startsWith("-w=") ||
+		(arg.startsWith("-w") && arg.length > 2)
+	);
+}
+
 function rootFlagDescriptor(arg: string) {
 	if (arg.startsWith("--") && !arg.includes("="))
 		return ROOT_LAUNCH_FLAGS[arg.slice(2) as keyof typeof ROOT_LAUNCH_FLAGS];
@@ -254,7 +264,7 @@ function rootFixtureArg(argv: string[]): { present: boolean; id: string | undefi
 function hasRootFastFlag(argv: string[], flags: readonly string[]): boolean {
 	for (let i = 0; i < argv.length; i++) {
 		const arg = argv[i] ?? "";
-		if (arg === "--" || isSubcommand(arg)) return false;
+		if (arg === "--" || isSubcommand(arg) || isLaunchWorktreeSelector(arg)) return false;
 		if (flags.includes(arg)) return true;
 		i = rootFlagValueIndex(argv, i);
 	}

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -7,6 +7,29 @@ import { logger } from "@gajae-code/utils";
 import { CliParseError } from "@gajae-code/utils/cli";
 import { parseEffort } from "../thinking";
 import { BUILTIN_TOOLS } from "../tools";
+import { ROOT_LAUNCH_FLAGS } from "./root-flags";
+
+const ROOT_FLAG_TOKENS = new Set<string>();
+for (const [name, descriptor] of Object.entries(ROOT_LAUNCH_FLAGS)) {
+	ROOT_FLAG_TOKENS.add(`--${name}`);
+	if (descriptor.char) ROOT_FLAG_TOKENS.add(`-${descriptor.char}`);
+}
+
+const INTERNAL_ROOT_FLAG_TOKENS = new Set(["--help", "-h", "--version", "-v", "--session", "--provider-session-id"]);
+
+function isExternallyParsedRootFlagToken(arg: string): boolean {
+	return (
+		arg === "--acp-terminal-auth" ||
+		arg === "--worktree" ||
+		arg === "-w" ||
+		arg.startsWith("-w=") ||
+		arg.startsWith("-w")
+	);
+}
+
+function isKnownRootFlagToken(arg: string): boolean {
+	return ROOT_FLAG_TOKENS.has(arg) || INTERNAL_ROOT_FLAG_TOKENS.has(arg) || isExternallyParsedRootFlagToken(arg);
+}
 
 export type Mode = "text" | "json" | "acp";
 
@@ -120,6 +143,13 @@ export function parseArgs(args: string[]): Args {
 			result.messages.push(args.slice(i).join(" "));
 			break;
 		}
+		if (arg === "--") {
+			for (const positional of args.slice(i + 1)) {
+				if (positional.startsWith("@")) result.fileArgs.push(positional.slice(1));
+				else result.messages.push(positional);
+			}
+			break;
+		}
 
 		// Support --flag=value syntax (e.g. --tools=ask,read)
 		if (arg.startsWith("--") && arg.includes("=")) {
@@ -129,6 +159,9 @@ export function parseArgs(args: string[]): Args {
 			hasInlineValue = true;
 			// Insert the value so the existing "args[++i]" logic picks it up
 			args.splice(i + 1, 0, value);
+		}
+		if (arg.startsWith("-") && !isKnownRootFlagToken(arg)) {
+			throw new CliParseError(`Unknown option: ${arg}`);
 		}
 
 		if (arg === "--help" || arg === "-h") {
@@ -302,10 +335,10 @@ export function parseArgs(args: string[]): Args {
 			}
 		} else if (arg.startsWith("@")) {
 			result.fileArgs.push(arg.slice(1)); // Remove @ prefix
-		} else if (arg.startsWith("-")) {
-			result.unknownFlags.set(arg, true);
-		} else {
+		} else if (!arg.startsWith("-")) {
 			result.messages.push(arg);
+		} else if (!isExternallyParsedRootFlagToken(arg)) {
+			throw new CliParseError(`Root option is declared but not parsed: ${arg}`);
 		}
 	}
 

--- a/packages/coding-agent/src/cli/completion-cli.ts
+++ b/packages/coding-agent/src/cli/completion-cli.ts
@@ -107,6 +107,7 @@ function figOptionFromFlag(name: string, descriptor: FlagDescriptor): FigOption 
 		const arg: FigArg = { name: optionArgName(name, descriptor) };
 		const suggestions = argSuggestions(descriptor.options);
 		if (suggestions) arg.suggestions = suggestions;
+		if (descriptor.optionalValue) arg.isOptional = true;
 		option.args = arg;
 	}
 	return option;

--- a/packages/coding-agent/src/cli/root-flags.ts
+++ b/packages/coding-agent/src/cli/root-flags.ts
@@ -1,0 +1,68 @@
+import { Flags } from "@gajae-code/utils/cli";
+
+const ROOT_THINKING_EFFORTS = ["minimal", "low", "medium", "high", "xhigh", "max"] as const;
+
+/** Public launch flags shared by root help, completion, and the launch command. */
+export const ROOT_LAUNCH_FLAGS = {
+	model: Flags.string({ description: 'Model to use (fuzzy match: "opus", "gpt-5.2", or "openai/gpt-5.2")' }),
+	smol: Flags.string({ description: "Smol/fast model for lightweight tasks (or GJC_SMOL_MODEL env)" }),
+	slow: Flags.string({ description: "Slow/reasoning model for thorough analysis (or GJC_SLOW_MODEL env)" }),
+	plan: Flags.string({ description: "Plan model for architectural planning (or GJC_PLAN_MODEL env)" }),
+	mpreset: Flags.string({ description: "Model profile preset to activate for this session" }),
+	default: Flags.boolean({ description: "Persist --mpreset as the default model profile" }),
+	provider: Flags.string({ description: "Provider to use (legacy; prefer --model)" }),
+	"api-key": Flags.string({ description: "API key (defaults to env vars)" }),
+	credential: Flags.string({
+		description:
+			"Stored credential selector: email:<addr>, id:<n>, account:<id>, project:<id>, or provider/email:<addr>",
+	}),
+	"system-prompt": Flags.string({ description: "System prompt (default: coding assistant prompt)" }),
+	"append-system-prompt": Flags.string({ description: "Append text or file contents to the system prompt" }),
+	"mcp-config": Flags.string({ description: "Tools-only MCP config file (absolute path)" }),
+	"clipboard-transport": Flags.string({
+		description: "Clipboard transport: auto (default), native, osc52, or ssh",
+		options: ["auto", "native", "osc52", "ssh"],
+	}),
+	"clipboard-ssh-host": Flags.string({
+		description: "SSH host alias for --clipboard-transport ssh (from ~/.ssh/config)",
+	}),
+	"allow-home": Flags.boolean({ description: "Allow starting in ~ without auto-switching to a temp dir" }),
+	mode: Flags.string({
+		description: "Output mode: text (default), json, or acp",
+		options: ["text", "json", "acp"],
+	}),
+	print: Flags.boolean({ char: "p", description: "Non-interactive mode: process prompt and exit" }),
+	continue: Flags.boolean({ char: "c", description: "Continue previous session" }),
+	resume: Flags.string({
+		char: "r",
+		description: "Resume a session (by ID prefix, path, or picker if omitted)",
+		optionalValue: true,
+	}),
+	fork: Flags.string({ description: "Fork a session (by ID prefix or path)" }),
+	worktree: Flags.string({
+		char: "w",
+		description: "Launch in a managed worktree (optional branch name)",
+		optionalValue: true,
+	}),
+	"session-dir": Flags.string({
+		description: "Explicit session storage directory and lookup override (default uses managed v2 workspace scope)",
+	}),
+	"no-session": Flags.boolean({ description: "Don't save session (ephemeral)" }),
+	models: Flags.string({ description: "Comma-separated model patterns for Alt+N cycling" }),
+	"no-tools": Flags.boolean({ description: "Disable all built-in tools" }),
+	"no-lsp": Flags.boolean({ description: "Disable LSP tools, formatting, and diagnostics" }),
+	"no-pty": Flags.boolean({ description: "Disable PTY-based interactive bash execution" }),
+	tmux: Flags.boolean({ description: "Launch interactive startup inside tmux" }),
+	tools: Flags.string({ description: "Comma-separated list of tools to enable (default: all)" }),
+	thinking: Flags.string({
+		description: `Set thinking level: ${ROOT_THINKING_EFFORTS.join(", ")}`,
+		options: ROOT_THINKING_EFFORTS,
+	}),
+	"no-rules": Flags.boolean({ description: "Disable rules discovery and loading" }),
+	export: Flags.string({ description: "Export session file to HTML and exit" }),
+	"list-models": Flags.string({
+		description: "List available models (with optional fuzzy search)",
+		optionalValue: true,
+	}),
+	"no-title": Flags.boolean({ description: "Disable title auto-generation" }),
+};

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -4,10 +4,10 @@
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { THINKING_EFFORTS } from "@gajae-code/ai/core";
 import { APP_NAME, setProjectDir } from "@gajae-code/utils";
-import { Args, Command, Flags } from "@gajae-code/utils/cli";
+import { Args, Command } from "@gajae-code/utils/cli";
 import { parseArgs } from "../cli/args";
+import { ROOT_LAUNCH_FLAGS } from "../cli/root-flags";
 import { launchDefaultTmuxIfNeeded } from "../gjc-runtime/launch-tmux";
 import { type PreparedLaunchWorktree, prepareLaunchWorktree } from "../gjc-runtime/launch-worktree";
 import {
@@ -70,130 +70,7 @@ export default class Index extends Command {
 		}),
 	};
 
-	static flags = {
-		model: Flags.string({
-			description: 'Model to use (fuzzy match: "opus", "gpt-5.2", or "openai/gpt-5.2")',
-		}),
-		smol: Flags.string({
-			description: "Smol/fast model for lightweight tasks (or GJC_SMOL_MODEL env)",
-		}),
-		slow: Flags.string({
-			description: "Slow/reasoning model for thorough analysis (or GJC_SLOW_MODEL env)",
-		}),
-		plan: Flags.string({
-			description: "Plan model for architectural planning (or GJC_PLAN_MODEL env)",
-		}),
-		mpreset: Flags.string({
-			description: "Model profile preset to activate for this session",
-		}),
-		default: Flags.boolean({
-			description: "Persist --mpreset as the default model profile",
-		}),
-		provider: Flags.string({
-			description: "Provider to use (legacy; prefer --model)",
-		}),
-		"api-key": Flags.string({
-			description: "API key (defaults to env vars)",
-		}),
-		credential: Flags.string({
-			description:
-				"Stored credential selector: email:<addr>, id:<n>, account:<id>, project:<id>, or provider/email:<addr>",
-		}),
-		"system-prompt": Flags.string({
-			description: "System prompt (default: coding assistant prompt)",
-		}),
-		"append-system-prompt": Flags.string({
-			description: "Append text or file contents to the system prompt",
-		}),
-		"mcp-config": Flags.string({
-			description: "Tools-only MCP config file (absolute path)",
-		}),
-		"clipboard-transport": Flags.string({
-			description: "Clipboard transport: auto (default), native, osc52, or ssh",
-			options: ["auto", "native", "osc52", "ssh"],
-		}),
-		"clipboard-ssh-host": Flags.string({
-			description: "SSH host alias for --clipboard-transport ssh (from ~/.ssh/config)",
-		}),
-		"allow-home": Flags.boolean({
-			description: "Allow starting in ~ without auto-switching to a temp dir",
-		}),
-		mode: Flags.string({
-			description: "Output mode: text (default), json, or acp",
-			options: ["text", "json", "acp"],
-		}),
-		print: Flags.boolean({
-			char: "p",
-			description: "Non-interactive mode: process prompt and exit",
-		}),
-		continue: Flags.boolean({
-			char: "c",
-			description: "Continue previous session",
-		}),
-		resume: Flags.string({
-			char: "r",
-			description: "Resume a session (by ID prefix, path, or picker if omitted)",
-		}),
-		"session-dir": Flags.string({
-			description:
-				"Explicit session storage directory and lookup override (default uses managed v2 workspace scope)",
-		}),
-		"no-session": Flags.boolean({
-			description: "Don't save session (ephemeral)",
-		}),
-		models: Flags.string({
-			description: "Comma-separated model patterns for Alt+N cycling",
-		}),
-		"no-tools": Flags.boolean({
-			description: "Disable all built-in tools",
-		}),
-		"no-lsp": Flags.boolean({
-			description: "Disable LSP tools, formatting, and diagnostics",
-		}),
-		"no-pty": Flags.boolean({
-			description: "Disable PTY-based interactive bash execution",
-		}),
-		tmux: Flags.boolean({
-			description: "Launch interactive startup inside tmux",
-		}),
-		tools: Flags.string({
-			description: "Comma-separated list of tools to enable (default: all)",
-		}),
-		thinking: Flags.string({
-			description: `Set thinking level: ${THINKING_EFFORTS.join(", ")}`,
-			options: [...THINKING_EFFORTS],
-		}),
-		hook: Flags.string({
-			description: "Load a hook/extension file (can be used multiple times)",
-			multiple: true,
-		}),
-		extension: Flags.string({
-			char: "e",
-			description: "Load an extension file (can be used multiple times)",
-			multiple: true,
-		}),
-		"no-extensions": Flags.boolean({
-			description: "Disable extension discovery (explicit -e paths still work)",
-		}),
-		"no-skills": Flags.boolean({
-			description: "Disable skills discovery and loading",
-		}),
-		skills: Flags.string({
-			description: "Comma-separated glob patterns to filter skills (e.g., git-*,docker)",
-		}),
-		"no-rules": Flags.boolean({
-			description: "Disable rules discovery and loading",
-		}),
-		export: Flags.string({
-			description: "Export session file to HTML and exit",
-		}),
-		"list-models": Flags.string({
-			description: "List available models (with optional fuzzy search)",
-		}),
-		"no-title": Flags.boolean({
-			description: "Disable title auto-generation",
-		}),
-	};
+	static flags = ROOT_LAUNCH_FLAGS;
 
 	static examples = [
 		`# Interactive mode\n  ${APP_NAME}`,

--- a/packages/coding-agent/src/gjc-runtime/launch-worktree.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-worktree.ts
@@ -274,7 +274,7 @@ function isWorktreeDirty(worktreePath: string): boolean {
 function resolveOptionalWorktreeName(args: string[], index: number): { name: string | null; nextIndex: number } {
 	const next = args[index + 1];
 	if (!next) return { name: null, nextIndex: index };
-	if (next === "--") return { name: null, nextIndex: index + 1 };
+	if (next === "--") return { name: null, nextIndex: index };
 	if (next.startsWith("-")) return { name: null, nextIndex: index };
 	return { name: next.trim() || null, nextIndex: index + 1 };
 }
@@ -285,6 +285,10 @@ export function parseLaunchWorktreeMode(args: string[]): ParsedLaunchWorktreeMod
 
 	for (let index = 0; index < args.length; index += 1) {
 		const arg = args[index] ?? "";
+		if (arg === "--") {
+			remainingArgs.push(...args.slice(index));
+			break;
+		}
 		if (arg === "--worktree" || arg === "-w") {
 			const parsed = resolveOptionalWorktreeName(args, index);
 			mode = parsed.name

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -335,6 +335,54 @@ process.exitCode = await child.exited;`;
 		}
 	}, 30_000);
 
+	it("routes compact worktree selectors before root help and version fast paths", () => {
+		for (const args of [
+			["-winvalid..branch", "--help"],
+			["-w=invalid..branch", "--help"],
+		]) {
+			const result = Bun.spawnSync(["bun", cliEntry, ...args], {
+				cwd: repoRoot,
+				stderr: "pipe",
+				stdout: "pipe",
+			});
+			const output = `${result.stdout.toString()}\n${result.stderr.toString()}`;
+
+			expect(result.exitCode, output).toBe(0);
+			expect(result.stdout.toString()).toContain("$ gjc launch");
+		}
+
+		for (const args of [
+			["-winvalid..branch", "--version"],
+			["-w=invalid..branch", "--version"],
+		]) {
+			const result = Bun.spawnSync(["bun", cliEntry, ...args], {
+				cwd: repoRoot,
+				stderr: "pipe",
+				stdout: "pipe",
+			});
+
+			expect(result.exitCode, result.stderr.toString()).toBe(0);
+			expect(result.stdout.toString()).toBe(`${packageJson.version}\n`);
+		}
+
+		const delimiter = Bun.spawnSync(["bun", cliEntry, "-winvalid..branch", "--", "--help"], {
+			cwd: repoRoot,
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+		const delimiterOutput = `${delimiter.stdout.toString()}\n${delimiter.stderr.toString()}`;
+		expect(delimiter.exitCode, delimiterOutput).not.toBe(0);
+		expect(delimiterOutput).toContain("invalid..branch");
+
+		const unrelated = Bun.spawnSync(["bun", cliEntry, "-xnot-worktree", "--version"], {
+			cwd: repoRoot,
+			stderr: "pipe",
+			stdout: "pipe",
+		});
+		expect(unrelated.exitCode, unrelated.stderr.toString()).toBe(0);
+		expect(unrelated.stdout.toString()).toMatch(/^gjc\/\d+\.\d+\.\d+\n$/);
+	}, 30_000);
+
 	it("does not capture absolute-path prompts as startup slash commands", () => {
 		const parsed = parseArgs(["/tmp/request.md", "--model", "opus", "summarize"]);
 

--- a/packages/coding-agent/test/cli-root-flags.test.ts
+++ b/packages/coding-agent/test/cli-root-flags.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { parseArgs } from "../src/cli/args";
+import { ROOT_LAUNCH_FLAGS } from "../src/cli/root-flags";
+import { parseLaunchWorktreeMode } from "../src/gjc-runtime/launch-worktree";
+
+const FLAG_VALUES: Record<string, string> = {
+	"mcp-config": "/tmp/gjc-mcp.json",
+};
+
+describe("CLI root flag parity", () => {
+	it("keeps every advertised flag connected to its runtime parser", () => {
+		for (const [name, descriptor] of Object.entries(ROOT_LAUNCH_FLAGS)) {
+			if (name === "worktree") {
+				expect(parseLaunchWorktreeMode(["--worktree", "feature/root-flags"]).mode).toEqual({
+					enabled: true,
+					detached: false,
+					name: "feature/root-flags",
+				});
+				continue;
+			}
+
+			const argv = [`--${name}`];
+			if (name === "default") argv.unshift("--mpreset", "test");
+			if (descriptor.kind === "string") argv.push(descriptor.options?.[0] ?? FLAG_VALUES[name] ?? "value");
+			expect(() => parseArgs(argv)).not.toThrow();
+		}
+	});
+
+	it("keeps compact worktree forms and the literal delimiter intact", () => {
+		for (const flag of ["-wfeature/root-flags", "-w=feature/root-flags"]) {
+			expect(() => parseArgs([flag])).not.toThrow();
+			expect(parseLaunchWorktreeMode([flag]).mode).toEqual({
+				enabled: true,
+				detached: false,
+				name: "feature/root-flags",
+			});
+		}
+		expect(parseLaunchWorktreeMode(["--worktree", "--", "--modle", "@prompt.md"]).remainingArgs).toEqual([
+			"--",
+			"--modle",
+			"@prompt.md",
+		]);
+	});
+
+	it("rejects retired extension and skill flags", () => {
+		for (const flag of ["--hook", "--extension", "-e", "--no-extensions", "--skills", "--no-skills"]) {
+			expect(() => parseArgs([flag])).toThrow(`Unknown option: ${flag}`);
+		}
+	});
+
+	it("rejects unknown options while preserving dash-prefixed prompt text after --", () => {
+		expect(() => parseArgs(["--modle", "opus"])).toThrow("Unknown option: --modle");
+		expect(parseArgs(["--", "--modle", "@prompt.md"])).toMatchObject({
+			messages: ["--modle"],
+			fileArgs: ["prompt.md"],
+		});
+	});
+});

--- a/packages/coding-agent/test/completion-cli.test.ts
+++ b/packages/coding-agent/test/completion-cli.test.ts
@@ -139,8 +139,14 @@ describe("GJC inshellisense completion spec", () => {
 			"ssh",
 		]);
 		expect(findOption(spec.options, "--clipboard-ssh-host")).toBeDefined();
+		expect(findOption(spec.options, "--fork")).toBeDefined();
+		expect(findOption(spec.options, "--worktree")).toBeDefined();
+		for (const retired of ["--hook", "--extension", "--no-extensions", "--skills", "--no-skills"]) {
+			expect(findOption(spec.options, retired), retired).toBeUndefined();
+		}
 		expect(findOption(spec.options, "--model")?.args).toEqual({ name: "value" });
-		expect(findOption(spec.options, "--resume")?.args).toEqual({ name: "value" });
+		expect(findOption(spec.options, "--resume")?.args).toEqual({ name: "value", isOptional: true });
+		expect(findOption(spec.options, "--list-models")?.args).toEqual({ name: "value", isOptional: true });
 		expect(findOption(spec.options, "-p")?.description).toContain("Non-interactive");
 		expect(renderFigSpecModule(spec)).toContain("export default completionSpec");
 	});

--- a/packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts
@@ -74,7 +74,7 @@ describe("default launch worktrees", () => {
 		});
 		expect(parseLaunchWorktreeMode(["--worktree", "--", "hello"])).toEqual({
 			mode: { enabled: true, detached: true, name: null },
-			remainingArgs: ["hello"],
+			remainingArgs: ["--", "hello"],
 		});
 		expect(parseLaunchWorktreeMode(["--worktree", "--model", "opus"]).mode).toEqual({
 			enabled: true,
@@ -91,11 +91,15 @@ describe("default launch worktrees", () => {
 		});
 		expect(parseLaunchWorktreeMode(["-w", "--", "hello"])).toEqual({
 			mode: { enabled: true, detached: true, name: null },
-			remainingArgs: ["hello"],
+			remainingArgs: ["--", "hello"],
 		});
 		expect(parseLaunchWorktreeMode(["-w=feature/demo", "hello"])).toEqual({
 			mode: { enabled: true, detached: false, name: "feature/demo" },
 			remainingArgs: ["hello"],
+		});
+		expect(parseLaunchWorktreeMode(["--", "--worktree", "feature/demo"])).toEqual({
+			mode: { enabled: false },
+			remainingArgs: ["--", "--worktree", "feature/demo"],
 		});
 	});
 
@@ -108,7 +112,7 @@ describe("default launch worktrees", () => {
 		const expectedPath = path.join(path.dirname(repo), `${path.basename(repo)}.gajae-code-worktrees`, branchSlug);
 
 		expect(await fs.realpath(first.cwd)).toBe(await fs.realpath(expectedPath));
-		expect(first.args).toEqual(["hello"]);
+		expect(first.args).toEqual(["--", "hello"]);
 		expect(first.worktree.enabled && first.worktree.created).toBe(true);
 		expect(first.worktree.enabled && first.worktree.detached).toBe(true);
 		expect(await Bun.file(path.join(expectedPath, ".git")).exists()).toBe(true);

--- a/packages/utils/src/cli.ts
+++ b/packages/utils/src/cli.ts
@@ -23,6 +23,8 @@ export interface FlagDescriptor<K extends "string" | "boolean" | "integer" = "st
 	multiple?: boolean;
 	options?: readonly string[];
 	required?: boolean;
+	/** The string value may be omitted; parsers decide whether to consume it. */
+	optionalValue?: boolean;
 }
 
 export interface ArgDescriptor {
@@ -40,6 +42,8 @@ interface FlagInput {
 	multiple?: boolean;
 	options?: readonly string[];
 	required?: boolean;
+	/** The string value may be omitted; parsers decide whether to consume it. */
+	optionalValue?: boolean;
 }
 
 interface ArgInput {
@@ -352,7 +356,14 @@ function renderCommandBody(lines: string[], Cmd: CommandCtor): void {
 		for (const [name, desc] of flagEntries) {
 			const charPart = desc.char ? `-${desc.char}, ` : "    ";
 			const namePart = `--${name}`;
-			const typePart = desc.kind === "boolean" ? "" : desc.kind === "integer" ? "=<int>" : "=<value>";
+			const typePart =
+				desc.kind === "boolean"
+					? ""
+					: desc.kind === "integer"
+						? "=<int>"
+						: desc.optionalValue
+							? "[=<value>]"
+							: "=<value>";
 			formatted.push([`  ${charPart}${namePart}${typePart}`, desc.description ?? ""]);
 		}
 		const maxLeft = Math.max(...formatted.map(([l]) => l.length));
@@ -430,7 +441,9 @@ export async function run(opts: RunOptions): Promise<void> {
 
 	// Per-command help. Commands with nested subcommands can opt into receiving
 	// help flags themselves so `cmd subcommand --help` can render subcommand help.
-	if (commandArgv.includes("--help") || commandArgv.includes("-h")) {
+	const delimiterIndex = commandArgv.indexOf("--");
+	const helpArgs = delimiterIndex === -1 ? commandArgv : commandArgv.slice(0, delimiterIndex);
+	if (helpArgs.includes("--help") || helpArgs.includes("-h")) {
 		const entry = findEntry(opts.commands, commandId);
 		if (!entry) {
 			process.stderr.write(`Unknown command: ${commandId}\n`);


### PR DESCRIPTION
## Summary

- share one root launch flag table between fast help, shell completion, and the launch command
- advertise the working `--fork` and `--worktree` flags while removing retired extension/skill flags
- reject unknown root options instead of silently dropping typos, with `--` preserving dash-prefixed prompt text
- exercise every advertised flag against its runtime parser in a parity regression test

## Verification

- `bun --cwd=packages/coding-agent run check`
- 169 focused CLI/startup/worktree tests passed
- 24 root-help/parity tests passed again after rebasing onto current `upstream/dev`

Fixes #4023