### PR TITLE
fix(retry): bound repeated idle stream stalls

### DIFF
--- a/docs/non-compaction-retry-policy.md
+++ b/docs/non-compaction-retry-policy.md
@@ -41,7 +41,7 @@ Current retryable inputs are regex/string-classified:
 - service unavailable / server/internal error
 - provider-suggested retry wording, including OpenAI `retry your request` failures
 - network/connection/socket failures, refused/closed connections, upstream connect/reset-before-headers, socket hang up, timeout/timed out, fetch failed, terminated, retry delay wording, and unexpected socket close messages
-- canonical idle-stream watchdog stalls (`stream stalled while waiting for the next event`); these remain retryable but use the bounded `retry.maxRetries` budget
+- canonical idle-stream watchdog stalls (`stream stalled while waiting for the next event`); in the legacy single-model path these remain retryable but use the bounded `retry.maxRetries` budget
 
 Managed fallback uses structured transport facts and typed provider error codes when available. A structured classification of `other` becomes the bounded `unknown` fallback class; error prose cannot promote it to quota or transient. Regex classification is retained only as a legacy fallback.
 
@@ -60,7 +60,7 @@ Flow (`#handleRetryableError`):
 2. If `retry.enabled === false`, stop immediately (`false`, no retry started).
 3. Increment `#retryAttempt`.
 4. Create `#retryPromise` once (first attempt in a chain).
-5. Ordinary transient errors retry without an attempt limit. Canonical idle-stream watchdog stalls and unknown/no-code errors stop after `retry.maxRetries`.
+5. In the legacy single-model path, ordinary transient errors retry without an attempt limit, while canonical idle-stream watchdog stalls and unknown/no-code errors stop after `retry.maxRetries`. Managed fallback instead uses its controller's per-entry `fallback.maxAttempts` budget.
 6. Compute exponential full-jitter delay capped at `retry.maxDelayMs`; legacy parsed provider retry-after values override computed backoff and are capped at `retry.maxDelayMs`, while managed typed Retry-After values are intentionally uncapped.
 7. For usage-limit errors, call auth storage (`markUsageLimitReached(...)`); if credential switching succeeds, force delay to `0`, otherwise use the applicable backoff.
 8. Eligible ordered role-array fallback chains advance on entry-budget exhaustion. A selected fallback entry remains sticky until the head selector's rate-limit cooldown expires, when `retry.fallbackRevertPolicy: cooldown-expiry` probes it again on a new turn.
@@ -102,7 +102,7 @@ Backoff uses capped exponential full jitter. With default settings the maximum j
 - attempt 2: 4000 ms
 - attempt 3: 8000 ms
 
-`retry.maxDelayMs` caps every legacy session retry delay, including provider retry-after hints, which otherwise take precedence over computed backoff. Managed fallback intentionally does not cap typed Retry-After values because it retries within its separate per-entry budget. Legacy transient errors have unbounded attempts except canonical idle-stream watchdog stalls, which are bounded by `retry.maxRetries`; unknown/no-code errors use the same bound.
+`retry.maxDelayMs` caps every legacy session retry delay, including provider retry-after hints, which otherwise take precedence over computed backoff. Managed fallback intentionally does not cap typed Retry-After values because it retries within its separate per-entry `fallback.maxAttempts` budget. In the legacy single-model path, transient errors have unbounded attempts except canonical idle-stream watchdog stalls, which are bounded by `retry.maxRetries`; unknown/no-code errors use the same bound.
 
 ## Abort mechanics
 

--- a/docs/non-compaction-retry-policy.md
+++ b/docs/non-compaction-retry-policy.md
@@ -41,6 +41,7 @@ Current retryable inputs are regex/string-classified:
 - service unavailable / server/internal error
 - provider-suggested retry wording, including OpenAI `retry your request` failures
 - network/connection/socket failures, refused/closed connections, upstream connect/reset-before-headers, socket hang up, timeout/timed out, fetch failed, terminated, retry delay wording, and unexpected socket close messages
+- canonical idle-stream watchdog stalls (`stream stalled while waiting for the next event`); these remain retryable but use the bounded `retry.maxRetries` budget
 
 Managed fallback uses structured transport facts and typed provider error codes when available. A structured classification of `other` becomes the bounded `unknown` fallback class; error prose cannot promote it to quota or transient. Regex classification is retained only as a legacy fallback.
 
@@ -59,7 +60,7 @@ Flow (`#handleRetryableError`):
 2. If `retry.enabled === false`, stop immediately (`false`, no retry started).
 3. Increment `#retryAttempt`.
 4. Create `#retryPromise` once (first attempt in a chain).
-5. Transient errors retry without an attempt limit; unknown/no-code errors stop after `retry.maxRetries`.
+5. Ordinary transient errors retry without an attempt limit. Canonical idle-stream watchdog stalls and unknown/no-code errors stop after `retry.maxRetries`.
 6. Compute exponential full-jitter delay capped at `retry.maxDelayMs`; legacy parsed provider retry-after values override computed backoff and are capped at `retry.maxDelayMs`, while managed typed Retry-After values are intentionally uncapped.
 7. For usage-limit errors, call auth storage (`markUsageLimitReached(...)`); if credential switching succeeds, force delay to `0`, otherwise use the applicable backoff.
 8. Eligible ordered role-array fallback chains advance on entry-budget exhaustion. A selected fallback entry remains sticky until the head selector's rate-limit cooldown expires, when `retry.fallbackRevertPolicy: cooldown-expiry` probes it again on a new turn.
@@ -101,7 +102,7 @@ Backoff uses capped exponential full jitter. With default settings the maximum j
 - attempt 2: 4000 ms
 - attempt 3: 8000 ms
 
-`retry.maxDelayMs` caps every legacy session retry delay, including provider retry-after hints, which otherwise take precedence over computed backoff. Managed fallback intentionally does not cap typed Retry-After values because it retries within its separate per-entry budget. Legacy transient errors have unbounded attempts; unknown/no-code errors are bounded by `retry.maxRetries`.
+`retry.maxDelayMs` caps every legacy session retry delay, including provider retry-after hints, which otherwise take precedence over computed backoff. Managed fallback intentionally does not cap typed Retry-After values because it retries within its separate per-entry budget. Legacy transient errors have unbounded attempts except canonical idle-stream watchdog stalls, which are bounded by `retry.maxRetries`; unknown/no-code errors use the same bound.
 
 ## Abort mechanics
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Repeated provider idle-stream stalls now stop after `retry.maxRetries` instead of inheriting the unbounded transient-error retry path. A one-off stall still retries normally, while a persistently silent stream surfaces its error rather than resubmitting the same billable context indefinitely.
 
 - SDK snapshot spill writes now retry once with a fresh temporary file when Bun reports `EBADF` during write or `fsync` under heavily contended descriptor teardown, and no longer fail when `close()` reports `EBADF` after a successful write and sync. The atomic writer removes the abandoned attempt before retrying, preserves primary I/O failures, accepts only the proven already-closed close case, and keeps every non-`EBADF` error or repeated descriptor failure fatal.
 - ACP now imports the synthetic model-profile provider namespace from a dependency-free SDK constant module, keeping the machine entrypoint out of model-registry, session-host, MCP-manager, and extension-runner closures enforced by `check:runtime`.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -15136,8 +15136,8 @@ export class AgentSession {
 	/**
 	 * Ordered retry classification: typed safety stop (surface) -> legacy safety stop
 	 * (surface) -> overflow (compaction) -> terminal (surface) -> usage_limit
-	 * (rotation) -> first_event_timeout (bounded retry) -> transient (unbounded retry) ->
-	 * unknown (bounded retry).
+	 * (rotation) -> first_event_timeout (bounded retry) -> transient (unbounded retry,
+	 * except canonical idle-stream stalls bounded downstream) -> unknown (bounded retry).
 	 */
 	#classifyErrorForRetry(message: AssistantMessage): RetryErrorClassification {
 		if (message.stopReason !== "error") return "none";

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -15077,6 +15077,9 @@ export class AgentSession {
 			)
 		);
 	}
+	#isIdleStreamStallErrorMessage(errorMessage: string): boolean {
+		return /stream stalled while waiting for the next event/i.test(errorMessage);
+	}
 
 	#isFirstEventTimeoutErrorMessage(errorMessage: string): boolean {
 		// First-event timeout: the stream watchdog aborted because no event
@@ -15692,7 +15695,10 @@ export class AgentSession {
 				return false;
 			}
 		}
-		const legacyUnbounded = !managedFallback && classification === "transient";
+		const legacyUnbounded =
+			!managedFallback &&
+			classification === "transient" &&
+			!this.#isIdleStreamStallErrorMessage(message.errorMessage ?? "");
 		const attemptsUsed = managedFallback ? controller.attemptsUsed || 1 : this.#retryAttempt + 1;
 		const failedSelector = managedFallback ? controller.currentSelector() : undefined;
 		let outcome = managedFallback

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -1672,6 +1672,33 @@ describe("AgentSession resilient retry", () => {
 		expect(retryEndEvents[0]).toMatchObject({ success: true });
 		expect(lastAssistant(session).stopReason).toBe("stop");
 	});
+	it("bounds repeated provider stream idle stalls by retry.maxRetries", async () => {
+		const requestedModels: string[] = [];
+		session = buildSession({
+			responses: [
+				{ throw: "Anthropic stream stalled while waiting for the next event" },
+				{ throw: "Anthropic stream stalled while waiting for the next event" },
+				{ throw: "Anthropic stream stalled while waiting for the next event" },
+				{ content: ["must not be reached"] },
+			],
+			settingsOverrides: { "retry.maxRetries": 2 },
+			requestedModels,
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const { retryStartEvents, retryEndEvents } = track(session);
+
+		await session.prompt("repeated idle stall");
+		await session.waitForIdle();
+
+		expect(retryStartEvents).toHaveLength(2);
+		expect(retryStartEvents.every(event => event.unbounded === false)).toBe(true);
+		expect(requestedModels).toHaveLength(3);
+		expect(retryEndEvents).toEqual([expect.objectContaining({ success: false, attempt: 2 })]);
+		expect(lastAssistant(session)).toMatchObject({
+			stopReason: "error",
+			errorMessage: "Anthropic stream stalled while waiting for the next event",
+		});
+	});
 	it("fails closed on structured watchdog facts and actual streamed partial output under bare defaults", async () => {
 		for (const partialOutput of [false, true]) {
 			const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;


### PR DESCRIPTION
## What

- Keep a one-off provider idle-stream stall eligible for automatic recovery.
- Stop repeated canonical `stream stalled while waiting for the next event` failures after `retry.maxRetries` in the legacy single-model path instead of inheriting its unbounded transient retry behavior.
- Preserve managed fallback's controller-owned `fallback.maxAttempts` accounting and ordinary transient recovery.
- Add a regression proving retry exhaustion issues no extra provider request.
- Align the dedicated retry-policy documentation, classifier comment, and coding-agent changelog with the scoped behavior.

## Why

A persistently silent provider could repeatedly resubmit the same large, billable conversation because idle-stream stalls were classified as transient and all transient failures entered the legacy unbounded retry path. The focused regression reproduced three retries despite a configured limit of two. This change scopes the circuit breaker to canonical idle-stall watchdog failures in the legacy single-model path; it does not alter provider timeout values, managed fallback accounting, replay-safety checks, or other transient recovery.

## Testing

- `bun test packages/coding-agent/test/agent-session-resilient-retry.test.ts packages/coding-agent/test/agent-session-retry-fallback.test.ts packages/coding-agent/test/task/provider-retry-status.test.ts` — 91 pass, 0 fail
- `bun --cwd=packages/coding-agent run check` — passed
- `bun run check` — reached an unrelated existing `sdk-downgrade-rollback.test.ts` historical native-build lane, where `@napi-rs/cli` could not run `cargo metadata` in its detached rollback worktree; reproduced independently with the focused rollback test. No retry-policy test or typecheck failed.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:770c6da8e2b539c029c3eba376e87344d22366116b34996206889aa2019e1038 reviewer:architect evidence:exact-head-review-and-91-focused-tests
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (blocked by the unrelated historical rollback native-build failure described above)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit