### PR TITLE
fix(sdk): bound concurrent host startups and start the readiness clock at admission

### DIFF
--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -1,6 +1,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import type { BigIntStats } from "node:fs";
 import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import path from "node:path";
 import type { NativeDirectoryTreeSnapshot } from "@gajae-code/natives";
 import type { ModelProfileErrorDetails } from "../../config/model-profile-contract";
@@ -62,6 +63,7 @@ export type BrokerErrorCode =
 	| "resource_gone"
 	| "invalid_input"
 	| "spawn_failed"
+	| "startup_admission_timeout"
 	| "readiness_timeout"
 	| "close_refused"
 	| "not_found"
@@ -406,6 +408,96 @@ const BROKER_PUBLICATION_GRACE_MS = 15_000;
 // longer than the loss grace.
 const BROKER_AMBIGUITY_GRACE_MS = 120_000;
 const BROKER_SETTLEMENT_MS = 2_000;
+
+export interface StartupAdmissionTiming {
+	now(): number;
+	sleep(ms: number): Promise<void>;
+}
+
+export type StartupAdmissionResult<T> =
+	| { status: "completed"; admittedAt: number; value: T }
+	| { status: "admission_timeout"; reason: "admission_timeout" };
+
+interface StartupAdmissionWaiter {
+	state: "waiting" | "admitted" | "timed_out";
+	ready: PromiseWithResolvers<void>;
+}
+
+// Host startup is CPU/IO bursty, so scale with the machine without allowing a full-core launch stampede.
+export function sdkHostStartupConcurrency(availableParallelism = os.availableParallelism()): number {
+	if (!Number.isSafeInteger(availableParallelism) || availableParallelism < 1)
+		throw new Error("SDK host startup parallelism must be a positive safe integer.");
+	return Math.max(1, Math.floor(Math.sqrt(availableParallelism)));
+}
+
+export class StartupAdmissionQueue {
+	#inFlight = 0;
+	#waiters: StartupAdmissionWaiter[] = [];
+
+	constructor(readonly limit: number) {
+		if (!Number.isSafeInteger(limit) || limit < 1)
+			throw new Error("SDK host startup concurrency must be a positive safe integer.");
+	}
+
+	async run<T>(
+		queueWaitMs: number,
+		timing: StartupAdmissionTiming,
+		task: (admittedAt: number) => Promise<T>,
+	): Promise<StartupAdmissionResult<T>> {
+		if (!Number.isSafeInteger(queueWaitMs) || queueWaitMs < 1)
+			throw new Error("SDK host startup queue wait must be a positive safe integer.");
+		if (this.#inFlight < this.limit) return this.#runAdmitted(timing, task);
+
+		const ready = Promise.withResolvers<void>();
+		const waiter: StartupAdmissionWaiter = { state: "waiting", ready };
+		this.#waiters.push(waiter);
+		const outcome = await Promise.race([
+			ready.promise.then(() => "admitted" as const),
+			timing.sleep(queueWaitMs).then(() => {
+				if (waiter.state === "admitted") return "admitted" as const;
+				if (waiter.state === "timed_out") return "timed_out" as const;
+				waiter.state = "timed_out";
+				const index = this.#waiters.indexOf(waiter);
+				if (index >= 0) this.#waiters.splice(index, 1);
+				return "timed_out" as const;
+			}),
+		]);
+		if (outcome === "timed_out") return { status: "admission_timeout", reason: "admission_timeout" };
+		return this.#runGranted(timing, task);
+	}
+
+	async #runAdmitted<T>(
+		timing: StartupAdmissionTiming,
+		task: (admittedAt: number) => Promise<T>,
+	): Promise<StartupAdmissionResult<T>> {
+		this.#inFlight += 1;
+		return this.#runGranted(timing, task);
+	}
+
+	async #runGranted<T>(
+		timing: StartupAdmissionTiming,
+		task: (admittedAt: number) => Promise<T>,
+	): Promise<StartupAdmissionResult<T>> {
+		const admittedAt = timing.now();
+		try {
+			return { status: "completed", admittedAt, value: await task(admittedAt) };
+		} finally {
+			this.#inFlight -= 1;
+			this.#grantNext();
+		}
+	}
+
+	#grantNext(): void {
+		while (this.#inFlight < this.limit) {
+			const waiter = this.#waiters.shift();
+			if (!waiter) return;
+			if (waiter.state !== "waiting") continue;
+			waiter.state = "admitted";
+			this.#inFlight += 1;
+			waiter.ready.resolve();
+		}
+	}
+}
 type BrokerPublicationState =
 	| "healthy-owned"
 	| "suspect-unpublished"
@@ -427,6 +519,7 @@ export class Broker {
 	#owner = randomBytes(12).toString("hex");
 	#chains = new Map<string, Promise<void>>();
 	#admitted = new Set<Promise<void>>();
+	#startupAdmissions = new StartupAdmissionQueue(sdkHostStartupConcurrency());
 	#publication: RetainedBrokerDiscovery | null = null;
 	#publicationState: BrokerPublicationState = "healthy-owned";
 	#lossAt: bigint | null = null;
@@ -453,6 +546,13 @@ export class Broker {
 		this.#completion = completion.promise;
 		this.#resolveCompletion = completion.resolve;
 		this.#rejectCompletion = completion.reject;
+	}
+	runStartup<T>(
+		queueWaitMs: number,
+		timing: StartupAdmissionTiming,
+		task: (admittedAt: number) => Promise<T>,
+	): Promise<StartupAdmissionResult<T>> {
+		return this.#startupAdmissions.run(queueWaitMs, timing, task);
 	}
 	#lockRecordPath(): string {
 		return path.join(this.#lock, BROKER_LOCK_RECORD);

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -51,7 +51,11 @@ import {
 	type ManagedSessionScope,
 	resolveManagedSessionScope,
 } from "../session-directory";
-import type { SdkStartupFailure, SdkStartupRollbackResult } from "../startup-capability";
+import {
+	normalizeSdkStartupFailure,
+	type SdkStartupFailure,
+	type SdkStartupRollbackResult,
+} from "../startup-capability";
 import type { Broker, BrokerCleanupEvidence, BrokerCleanupIdentity, BrokerResponse } from "./broker";
 import { decodeLifecycleUtf8, parseLifecycleJson } from "./lifecycle-codec";
 import type {
@@ -136,6 +140,8 @@ type LifecycleCommand = SdkInternalSpawnCommand | { file: string; args: string[]
 type LifecycleCommandResolver = () => LifecycleCommand;
 const lifecycleCommandResolversForTest = new WeakMap<Broker, LifecycleCommandResolver>();
 const lifecycleCleanupHooksForTest = new WeakMap<Broker, () => void>();
+const startupAdmittedInputs = new WeakSet<Input>();
+const startupLaunchInputs = new WeakMap<Input, SessionLaunch>();
 
 /** Test-only hook for simulating a crash immediately after one exact lifecycle detach. */
 export function setLifecycleCleanupHookForTest(broker: Broker, hook: (() => void) | undefined): void {
@@ -976,6 +982,7 @@ function isSdkStartupFailure(value: unknown): value is SdkStartupFailure {
 			failure.reason !== "ineligible" &&
 			failure.reason !== "factory_absent" &&
 			failure.reason !== "runner_absent" &&
+			failure.reason !== "admission_timeout" &&
 			failure.reason !== "pending" &&
 			failure.reason !== "failed") ||
 		typeof failure.message !== "string" ||
@@ -3109,15 +3116,51 @@ async function executeLifecycleResponse(
 			}
 		}
 		const timing = lifecycleTiming(broker);
+		const admissionGranted = startupAdmittedInputs.has(input);
+		if (!admissionGranted) {
+			const suppliedDeadlineFields = [
+				input.receivedAt,
+				input.requestedReadinessTimeoutMs,
+				input.semanticReadyDeadlineAt,
+				input.terminationStartDeadlineAt,
+				input.lifecycleCleanupDeadlineAt,
+			];
+			let queueWaitMs: number;
+			if (suppliedDeadlineFields.some(value => value !== undefined)) {
+				const supplied = lifecycleDeadlines(input, timing.now());
+				if ("ok" in supplied) return supplied;
+				queueWaitMs = supplied.requestedReadinessTimeoutMs;
+			} else {
+				const timeout = readinessTimeout(input);
+				if (typeof timeout !== "number") return timeout;
+				queueWaitMs = timeout;
+			}
+			const launch = await launchInput(broker, operation, input);
+			if ("ok" in launch) return launch;
+			const admitted = await broker.runStartup(queueWaitMs, timing, async admittedAt => {
+				const admittedInput = { ...input, ...deriveLifecycleDeadlines(admittedAt, queueWaitMs) };
+				startupAdmittedInputs.add(admittedInput);
+				startupLaunchInputs.set(admittedInput, launch);
+				try {
+					return await executeLifecycleResponse(broker, operation, admittedInput, identity, cleanup);
+				} finally {
+					startupLaunchInputs.delete(admittedInput);
+					startupAdmittedInputs.delete(admittedInput);
+				}
+			});
+			if (admitted.status === "completed") return admitted.value;
+			const failure = normalizeSdkStartupFailure("startup", admitted.reason);
+			return fail("startup_admission_timeout", failure.message);
+		}
 
-		const deadlines = lifecycleDeadlines(input, timing.now());
+		const deadlines = lifecycleDeadlines(input, input.receivedAt as number);
 
 		if ("ok" in deadlines) return deadlines;
 		const lifecycleDeadline = deadlines.lifecycleCleanupDeadlineAt;
 		const readinessDeadline = deadlines.semanticReadyDeadlineAt;
 		const terminationStartDeadline = deadlines.terminationStartDeadlineAt;
 
-		const launch = await launchInput(broker, operation, input);
+		const launch = startupLaunchInputs.get(input) ?? (await launchInput(broker, operation, input));
 		if ("ok" in launch) return launch;
 		if (!hasProcessIncarnationAuthority())
 			return fail(

--- a/packages/coding-agent/src/sdk/startup-capability.ts
+++ b/packages/coding-agent/src/sdk/startup-capability.ts
@@ -5,7 +5,14 @@ import {
 } from "../config/model-profile-contract";
 export type SdkStartupPhase = "registration" | "startup";
 
-export type SdkStartupReason = "disabled" | "ineligible" | "factory_absent" | "runner_absent" | "pending" | "failed";
+export type SdkStartupReason =
+	| "disabled"
+	| "ineligible"
+	| "factory_absent"
+	| "runner_absent"
+	| "admission_timeout"
+	| "pending"
+	| "failed";
 
 export interface SdkStartupFailure {
 	phase: SdkStartupPhase;
@@ -143,9 +150,11 @@ export function normalizeSdkStartupFailure(
 					? "SDK startup factory is unavailable."
 					: reason === "runner_absent"
 						? "SDK startup extension runner is unavailable."
-						: reason === "pending"
-							? "SDK startup did not complete before readiness cutoff."
-							: FALLBACK_MESSAGE;
+						: reason === "admission_timeout"
+							? "SDK host startup was not admitted before the queue wait cutoff."
+							: reason === "pending"
+								? "SDK startup did not complete before readiness cutoff."
+								: FALLBACK_MESSAGE;
 	const message = sanitizeSdkStartupMessage(error, knownSecrets);
 	const profileError = isModelProfileError(error) ? { code: error.code, details: error.details } : {};
 	return { phase, reason, message: message === FALLBACK_MESSAGE ? fallback : message, ...profileError };

--- a/packages/coding-agent/test/sdk-broker-startup-admission.test.ts
+++ b/packages/coding-agent/test/sdk-broker-startup-admission.test.ts
@@ -1,0 +1,192 @@
+import { expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+	Broker,
+	StartupAdmissionQueue,
+	type StartupAdmissionTiming,
+	sdkHostStartupConcurrency,
+} from "../src/sdk/broker/broker";
+import { deriveLifecycleDeadlines, setLifecycleTimingForTest } from "../src/sdk/broker/lifecycle";
+import { normalizeSdkStartupFailure } from "../src/sdk/startup-capability";
+
+function controlledTiming(now: () => number): {
+	timing: StartupAdmissionTiming;
+	sleeps: Array<PromiseWithResolvers<void>>;
+} {
+	const sleeps: Array<PromiseWithResolvers<void>> = [];
+	return {
+		timing: {
+			now,
+			sleep: () => {
+				const sleep = Promise.withResolvers<void>();
+				sleeps.push(sleep);
+				return sleep.promise;
+			},
+		},
+		sleeps,
+	};
+}
+
+test("SDK host startup concurrency scales sublinearly with observable CPU parallelism", () => {
+	expect(sdkHostStartupConcurrency(1)).toBe(1);
+	expect(sdkHostStartupConcurrency(4)).toBe(2);
+	expect(sdkHostStartupConcurrency(16)).toBe(4);
+	expect(sdkHostStartupConcurrency(20)).toBe(4);
+});
+
+test("concurrent startups either run or report admission timeout instead of pending", async () => {
+	const queue = new StartupAdmissionQueue(1);
+	const firstRelease = Promise.withResolvers<void>();
+	const { timing, sleeps } = controlledTiming(() => 1_000);
+	const first = queue.run(10_000, timing, async () => {
+		await firstRelease.promise;
+		return "first-ready";
+	});
+	const second = queue.run(10_000, timing, async () => "second-ready");
+	const third = queue.run(10_000, timing, async () => "third-ready");
+	await Promise.resolve();
+
+	expect(sleeps).toHaveLength(2);
+	sleeps[1]!.resolve();
+	firstRelease.resolve();
+
+	const results = await Promise.all([first, second, third]);
+	expect(results.map(result => result.status)).toEqual(["completed", "completed", "admission_timeout"]);
+	expect(results[2]).toEqual({ status: "admission_timeout", reason: "admission_timeout" });
+	expect(JSON.stringify(results)).not.toContain('"reason":"pending"');
+});
+
+test("queued startup receives its full readiness budget from admission", async () => {
+	let now = 1_000;
+	const queue = new StartupAdmissionQueue(1);
+	const firstRelease = Promise.withResolvers<void>();
+	const { timing } = controlledTiming(() => now);
+	const first = queue.run(4_000, timing, async () => {
+		await firstRelease.promise;
+		return undefined;
+	});
+	const second = queue.run(4_000, timing, async admittedAt => deriveLifecycleDeadlines(admittedAt, 4_000));
+	await Promise.resolve();
+
+	now = 9_000;
+	firstRelease.resolve();
+	const result = await second;
+	await first;
+
+	expect(result).toEqual({
+		status: "completed",
+		admittedAt: 9_000,
+		value: {
+			receivedAt: 9_000,
+			requestedReadinessTimeoutMs: 4_000,
+			semanticReadyDeadlineAt: 11_000,
+			terminationStartDeadlineAt: 12_000,
+			lifecycleCleanupDeadlineAt: 13_000,
+		},
+	});
+});
+
+test("single startup preserves the exact existing deadline derivation", async () => {
+	const admittedAt = 25_000;
+	let nowCalls = 0;
+	const queue = new StartupAdmissionQueue(4);
+	const result = await queue.run(
+		10_000,
+		{
+			now: () => {
+				nowCalls += 1;
+				return admittedAt;
+			},
+			sleep: () => {
+				throw new Error("an uncontended startup must not wait");
+			},
+		},
+		async timestamp => deriveLifecycleDeadlines(timestamp, 10_000),
+	);
+
+	expect(nowCalls).toBe(1);
+	expect(result).toEqual({
+		status: "completed",
+		admittedAt,
+		value: deriveLifecycleDeadlines(admittedAt, 10_000),
+	});
+});
+
+test("startup admission drains FIFO and releases slots after thrown tasks", async () => {
+	const queue = new StartupAdmissionQueue(1);
+	const firstRelease = Promise.withResolvers<void>();
+	const { timing } = controlledTiming(() => 1_000);
+	const order: string[] = [];
+	const first = queue.run(10_000, timing, async () => {
+		order.push("first");
+		await firstRelease.promise;
+	});
+	const second = queue.run(10_000, timing, async () => {
+		order.push("second");
+		throw new Error("startup failed");
+	});
+	const third = queue.run(10_000, timing, async () => {
+		order.push("third");
+		return "ready";
+	});
+	await Promise.resolve();
+	firstRelease.resolve();
+
+	await first;
+	await expect(second).rejects.toThrow("startup failed");
+	await expect(third).resolves.toMatchObject({ status: "completed", value: "ready" });
+	expect(order).toEqual(["first", "second", "third"]);
+});
+
+test("admission timeout has its own accurate normalized startup reason", () => {
+	expect(normalizeSdkStartupFailure("startup", "admission_timeout")).toEqual({
+		phase: "startup",
+		reason: "admission_timeout",
+		message: "SDK host startup was not admitted before the queue wait cutoff.",
+	});
+});
+
+test("broker validates before admission and maps bounded queue waits honestly", async () => {
+	const agentDir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-startup-admission-"));
+	const broker = new Broker({ agentDir });
+	const release = Promise.withResolvers<void>();
+	const holderTiming: StartupAdmissionTiming = {
+		now: () => 1_000,
+		sleep: () => Promise.withResolvers<void>().promise,
+	};
+	await broker.start();
+	const holders = Array.from({ length: sdkHostStartupConcurrency() }, () =>
+		broker.runStartup(4_000, holderTiming, async () => {
+			await release.promise;
+		}),
+	);
+	await Promise.resolve();
+	setLifecycleTimingForTest(broker, { now: () => 9_000, sleep: async () => undefined });
+
+	try {
+		expect(await broker.handleRequest("session.create", {}, "invalid-before-admission")).toEqual({
+			ok: false,
+			error: { code: "invalid_input", message: "A target path is required." },
+		});
+		expect(
+			await broker.handleRequest(
+				"session.create",
+				{ cwd: agentDir, readinessTimeoutMs: 4_000 },
+				"bounded-admission-timeout",
+			),
+		).toEqual({
+			ok: false,
+			error: {
+				code: "startup_admission_timeout",
+				message: "SDK host startup was not admitted before the queue wait cutoff.",
+			},
+		});
+	} finally {
+		setLifecycleTimingForTest(broker, undefined);
+		release.resolve();
+		await Promise.all(holders);
+		await broker.stop();
+		await fs.rm(agentDir, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
Launching several agents at once kills some of them at startup. One commit, 4 files.

## The failure

Eight agents launched concurrently against one broker. Five died with:

```
Error: {"phase":"startup","reason":"pending","message":"SDK startup did not complete before readiness cutoff."}
    at handleFatalError (packages/utils/src/postmortem.ts:364)
```

and the caller saw `Internal error: Prompt submission failed. code=-32603 {"code":"prompt_failed"}`. Log evidence: **`readiness_cutoff: 5`** distinct fatal startups in one window, ~46 session hosts alive. The same launch one at a time always succeeded.

## Mechanism

Two things compounded:

1. **`deriveLifecycleDeadlines(receivedAt, …)`** (`broker/lifecycle.ts:97-108`) derives every deadline from `receivedAt` — the moment the broker *received* the request:
   ```ts
   const lifecycleCleanupDeadlineAt = receivedAt + requestedReadinessTimeoutMs;   // 10 s
   ```
2. **`handleRequest`** (`broker/broker.ts:977-987`) has no concurrency bound. `#admitted` is a graceful-shutdown tracker (`:914-915`), not a gate, so every concurrent create spawns a child immediately (`ensure.ts:293`, `:406`).

So N simultaneous creates spawn N children that contend for CPU and IO while each child's 10 s budget runs on wall-clock from receipt. A child queued behind its siblings burns its budget before it is meaningfully scheduled — and then reports `reason: "pending"`, blaming a startup that never began.

## The fix

- Startups pass through an admission gate sized from `os.availableParallelism()` (`sqrt`, floored at 1), so fan-out is bounded by something observable rather than a literal.
- Lifecycle deadlines are re-derived from the **admission** timestamp, so a request that waited still gets its full readiness budget.
- A request that cannot be admitted in time fails as **`admission_timeout`** — a new `SdkStartupReason` with its own message — instead of claiming a startup that never started did not finish.

`READY_TIMEOUT_MS` is unchanged and the `MIN`/`MAX` validation is untouched. Raising the constant would only widen the flake window; the budget was never the problem, the clock's origin and the unbounded fan-out were.

## Verification

```
sdk-broker-startup-admission (new)                             7 pass / 0 fail
  with packages/coding-agent/src restored from origin/dev      0 pass / 1 fail
+ broker + lifecycle-e2e + memory-defer + terminal-evidence   128 pass / 0 fail
bun --cwd=packages/coding-agent run check                     exit 0
```

Regressions use injected clocks and fakes — no real sleeping, no mass process spawning: N concurrent requests above the limit all either become ready or fail as `admission_timeout` (none dies as `pending` while merely waiting); an admitted-after-waiting request gets deadlines derived from admission; the gate drains in order and leaks no slot when startup throws; single-request timing is unchanged.

**Live proof, not just unit tests.** On a binary built from this change, five lanes launched back to back produced **zero** `readiness_cutoff` failures, against five of eight dying before it.

This was found while running the agent fleet that produced the sibling PRs — the tooling failing under its own load, with a live reproduction.
