### PR TITLE
fix(sdk): drain the startup queue when a broker loses its root

### DIFF
--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -16,6 +16,7 @@ import { listMcpDelegateHostContexts } from "../hooks/mcp-delegate-host-context"
 import type { WorkflowGate, WorkflowGateQueryRecord } from "../modes/shared/agent-wire/workflow-gate-types";
 import type { BrokerDiscovery } from "../sdk/broker/discovery";
 import { type EnsureBrokerSettings, ensureBroker } from "../sdk/broker/ensure";
+import { lifecycleRequestTimeoutMs } from "../sdk/broker/startup-budget";
 import { UnsupportedStateVersionError } from "../sdk/broker/state-version";
 import { SdkClient, SdkClientError } from "../sdk/client/client";
 import { readSdkBrokerDiscovery } from "../sdk/client/discovery";
@@ -3183,7 +3184,11 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 		let requestError: SdkClientError | undefined;
 		let result: unknown;
 		try {
-			result = await client.global(operation, input, { ...(idempotencyKey ? { idempotencyKey } : {}) });
+			const timeoutMs = lifecycleRequestTimeoutMs(operation, input);
+			result = await client.global(operation, input, {
+				...(idempotencyKey ? { idempotencyKey } : {}),
+				...(timeoutMs === undefined ? {} : { timeoutMs }),
+			});
 		} catch (error) {
 			requestError = toCoordinatorBrokerError("request", error);
 		}

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -43,6 +43,7 @@ import {
 	type AcpReverseConnection,
 	AcpSdkAdapter,
 	AcpSdkAdapterError,
+	acpMcpLaunchFailure,
 } from "../../sdk/acp";
 import { resolveAcpFinalText } from "../../sdk/acp/final-text";
 import { ACP_MCP_LIFECYCLE_TIMEOUT_MS, type SessionLifecycleMcpServer } from "../../sdk/acp/mcp";
@@ -3010,24 +3011,7 @@ export class AcpAgent implements Agent {
 		try {
 			return await (await this.#brokerAdapter()).global(operation, input, idempotencyKey);
 		} catch (error) {
-			const code =
-				typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
-					? error.code
-					: undefined;
-			if (
-				mcpServers.length === 0 ||
-				code === "invalid_input" ||
-				code === "authentication_failed" ||
-				code === "unknown_model_profile" ||
-				code === "model_profile_registry_error"
-			)
-				throw error;
-			const names = mcpServers
-				.slice(0, 8)
-				.map(server => server.name)
-				.join(", ");
-			const suffix = mcpServers.length > 8 ? `, and ${mcpServers.length - 8} more` : "";
-			throw new AcpSdkAdapterError("unavailable", `MCP server request failed to start (${names}${suffix}).`);
+			throw acpMcpLaunchFailure(error, mcpServers);
 		}
 	}
 

--- a/packages/coding-agent/src/sdk/acp/adapter.ts
+++ b/packages/coding-agent/src/sdk/acp/adapter.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { lifecycleStartupBudgetMs } from "../broker/startup-budget";
+import { lifecycleRequestTimeoutMs } from "../broker/startup-budget";
 import { SdkClient, SdkClientError, type SdkFrame } from "../client";
 import { assertReverseResponseFrame, ReverseLeaseError } from "../host/reverse-leases";
 import { validateAdapterControl, validateAdapterSecretFields } from "../protocol/adapter-validation";
@@ -188,16 +188,15 @@ export class AcpSdkAdapter {
 		this.#assertGenericDisposition("global", operation);
 		if (isLifecycleOperation(operation) && !idempotencyKey)
 			throw new AcpSdkAdapterError("invalid_input", "idempotencyKey is required for lifecycle operations.");
-		const readinessTimeoutMs =
-			typeof input.readinessTimeoutMs === "number" && Number.isSafeInteger(input.readinessTimeoutMs)
-				? input.readinessTimeoutMs
-				: undefined;
+		// The broker may hold a startup in its admission queue before the readiness
+		// clock even starts, so the caller deadline covers the queue wait too; sizing
+		// it on readiness alone times out requests the broker is still running. A
+		// request that named no readiness budget is queued for the default one, so it
+		// needs the same extension rather than the client's generic request deadline.
+		const timeoutMs = lifecycleRequestTimeoutMs(operation, input);
 		return await this.#client.global(operation, input, {
 			idempotencyKey,
-			// The broker may hold a startup in its admission queue before the readiness
-			// clock even starts, so the caller deadline covers the queue wait too; sizing
-			// it on readiness alone times out requests the broker is still running.
-			...(readinessTimeoutMs ? { timeoutMs: lifecycleStartupBudgetMs(readinessTimeoutMs) + 1_000 } : {}),
+			...(timeoutMs === undefined ? {} : { timeoutMs }),
 		});
 	}
 

--- a/packages/coding-agent/src/sdk/acp/adapter.ts
+++ b/packages/coding-agent/src/sdk/acp/adapter.ts
@@ -44,9 +44,9 @@ export class AcpSdkAdapterError extends Error {
 /**
  * Lifecycle failures the ACP MCP launch wrapper must report verbatim. Everything else
  * is re-attributed to the configured MCP servers, which is the useful answer for a
- * launch that actually reached them — but a startup the broker refused before
- * admission never opened an MCP handshake, so blaming the servers would hide both the
- * real authority reason and the fact that the request is safely retryable.
+ * launch that actually reached them — but a startup the broker ended before admission
+ * never opened an MCP handshake, so blaming the servers would hide both the real
+ * authority reason and the fact that the request is safely retryable.
  */
 const ACP_MCP_PRESERVED_LAUNCH_CODES = new Set([
 	"invalid_input",
@@ -54,6 +54,7 @@ const ACP_MCP_PRESERVED_LAUNCH_CODES = new Set([
 	"unknown_model_profile",
 	"model_profile_registry_error",
 	"startup_admission_refused",
+	"startup_admission_timeout",
 ]);
 
 /**

--- a/packages/coding-agent/src/sdk/acp/adapter.ts
+++ b/packages/coding-agent/src/sdk/acp/adapter.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { lifecycleStartupBudgetMs } from "../broker/startup-budget";
 import { SdkClient, SdkClientError, type SdkFrame } from "../client";
 import { assertReverseResponseFrame, ReverseLeaseError } from "../host/reverse-leases";
 import { validateAdapterControl, validateAdapterSecretFields } from "../protocol/adapter-validation";
@@ -193,7 +194,10 @@ export class AcpSdkAdapter {
 				: undefined;
 		return await this.#client.global(operation, input, {
 			idempotencyKey,
-			...(readinessTimeoutMs ? { timeoutMs: readinessTimeoutMs + 1_000 } : {}),
+			// The broker may hold a startup in its admission queue before the readiness
+			// clock even starts, so the caller deadline covers the queue wait too; sizing
+			// it on readiness alone times out requests the broker is still running.
+			...(readinessTimeoutMs ? { timeoutMs: lifecycleStartupBudgetMs(readinessTimeoutMs) + 1_000 } : {}),
 		});
 	}
 

--- a/packages/coding-agent/src/sdk/acp/adapter.ts
+++ b/packages/coding-agent/src/sdk/acp/adapter.ts
@@ -5,6 +5,7 @@ import { assertReverseResponseFrame, ReverseLeaseError } from "../host/reverse-l
 import { validateAdapterControl, validateAdapterSecretFields } from "../protocol/adapter-validation";
 import { OPERATIONS } from "../protocol/operation-registry";
 import { ACP_SESSION_RECONNECT } from "../session-reconnect";
+import type { SessionLifecycleMcpServer } from "./mcp";
 
 type JsonObject = Record<string, unknown>;
 
@@ -38,6 +39,39 @@ export class AcpSdkAdapterError extends Error {
 		this.name = "AcpSdkAdapterError";
 		this.code = code;
 	}
+}
+
+/**
+ * Lifecycle failures the ACP MCP launch wrapper must report verbatim. Everything else
+ * is re-attributed to the configured MCP servers, which is the useful answer for a
+ * launch that actually reached them — but a startup the broker refused before
+ * admission never opened an MCP handshake, so blaming the servers would hide both the
+ * real authority reason and the fact that the request is safely retryable.
+ */
+const ACP_MCP_PRESERVED_LAUNCH_CODES = new Set([
+	"invalid_input",
+	"authentication_failed",
+	"unknown_model_profile",
+	"model_profile_registry_error",
+	"startup_admission_refused",
+]);
+
+/**
+ * The error an ACP session launch must throw once a lifecycle request that carried MCP
+ * servers has failed.
+ */
+export function acpMcpLaunchFailure(error: unknown, mcpServers: SessionLifecycleMcpServer[]): unknown {
+	const code =
+		typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
+			? error.code
+			: undefined;
+	if (mcpServers.length === 0 || (code !== undefined && ACP_MCP_PRESERVED_LAUNCH_CODES.has(code))) return error;
+	const names = mcpServers
+		.slice(0, 8)
+		.map(server => server.name)
+		.join(", ");
+	const suffix = mcpServers.length > 8 ? `, and ${mcpServers.length - 8} more` : "";
+	return new AcpSdkAdapterError("unavailable", `MCP server request failed to start (${names}${suffix}).`);
 }
 
 export type AcpReconnectFailedHandler = (error: SdkClientError) => void;

--- a/packages/coding-agent/src/sdk/acp/index.ts
+++ b/packages/coding-agent/src/sdk/acp/index.ts
@@ -1,2 +1,2 @@
 export type { AcpProviderRegistration, AcpReverseConnection, AcpSdkAdapterOptions } from "./adapter";
-export { ACP_SESSION_RECONNECT, AcpSdkAdapter, AcpSdkAdapterError } from "./adapter";
+export { ACP_SESSION_RECONNECT, AcpSdkAdapter, AcpSdkAdapterError, acpMcpLaunchFailure } from "./adapter";

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -1039,11 +1039,14 @@ export class Broker {
 			this.#fence("heartbeat-ambiguous");
 			return;
 		}
-		this.#publicationState = "healthy-owned";
-		this.#startupAdmissions.reopen();
-		this.#lossAt = null;
-		this.#ambiguousAt = null;
-		this.discovery = { ...this.discovery, heartbeatAt };
+		const recovery = this.runSynchronousEffectWithFreshPublicationAuthority(() => {
+			this.#publicationState = "healthy-owned";
+			this.#startupAdmissions.reopen();
+			this.#lossAt = null;
+			this.#ambiguousAt = null;
+			this.discovery = { ...this.discovery!, heartbeatAt };
+		});
+		if (!recovery.authorized) return;
 	}
 	async heartbeat(): Promise<void> {
 		if (this.#publicationState !== "healthy-owned") return;
@@ -1098,6 +1101,32 @@ export class Broker {
 		} catch {
 			return false;
 		}
+	}
+	/**
+	 * Revalidate retained publication ownership and begin one synchronous effect in
+	 * the same stack. The callback is the authority boundary: callers must perform
+	 * the authorized effect inside it, so no awaited work can separate proof from
+	 * the effect it authorizes.
+	 */
+	runSynchronousEffectWithFreshPublicationAuthority<T>(
+		effect: () => T,
+		..._synchronousOnly: T extends PromiseLike<unknown> ? [never] : []
+	): { authorized: true; value: T } | { authorized: false } {
+		if (!this.#publication || this.#publicationState === "stopping") return { authorized: false };
+		let observation: BrokerPublicationObservation;
+		try {
+			observation = publicationObservationOverridesForTest.get(this) ?? this.#publication.observe();
+		} catch {
+			this.#fence("observation-ambiguous");
+			if (this.#fencedBeyondDeadline()) void this.#complete("lost-root");
+			return { authorized: false };
+		}
+		if (observation !== "owned") {
+			this.#fence(observation === "ambiguous" ? "observation-ambiguous" : "suspect-unpublished");
+			if (this.#fencedBeyondDeadline()) void this.#complete("lost-root");
+			return { authorized: false };
+		}
+		return { authorized: true, value: effect() };
 	}
 	/**
 	 * A stop may take the owning path only while it can prove it still owns the root.

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -565,6 +565,7 @@ export type StartupAdmissionResult<T> =
 
 interface StartupAdmissionWaiter {
 	state: "waiting" | "admitted" | "timed_out" | "refused";
+	admissionEpoch?: number;
 	ready: PromiseWithResolvers<void>;
 }
 
@@ -578,6 +579,7 @@ export function sdkHostStartupConcurrency(availableParallelism = os.availablePar
 export class StartupAdmissionQueue {
 	#inFlight = 0;
 	#closed = false;
+	#epoch = 0;
 	#waiters: StartupAdmissionWaiter[] = [];
 
 	constructor(readonly limit: number) {
@@ -612,23 +614,27 @@ export class StartupAdmissionQueue {
 		]);
 		if (outcome === "timed_out") return { status: "admission_timeout", reason: "admission_timeout" };
 		if (outcome === "refused") return { status: "admission_refused", reason: "admission_refused" };
-		return this.#runGranted(timing, task);
+		return this.#runGranted(waiter.admissionEpoch!, timing, task);
 	}
 
 	async #runAdmitted<T>(
 		timing: StartupAdmissionTiming,
 		task: (admittedAt: number) => Promise<T>,
 	): Promise<StartupAdmissionResult<T>> {
+		const admissionEpoch = this.#epoch;
 		this.#inFlight += 1;
-		return this.#runGranted(timing, task);
+		return this.#runGranted(admissionEpoch, timing, task);
 	}
 
 	async #runGranted<T>(
+		admissionEpoch: number,
 		timing: StartupAdmissionTiming,
 		task: (admittedAt: number) => Promise<T>,
 	): Promise<StartupAdmissionResult<T>> {
-		const admittedAt = timing.now();
 		try {
+			const admittedAt = timing.now();
+			if (this.#closed || admissionEpoch !== this.#epoch)
+				return { status: "admission_refused", reason: "admission_refused" };
 			return { status: "completed", admittedAt, value: await task(admittedAt) };
 		} finally {
 			this.#inFlight -= 1;
@@ -637,11 +643,13 @@ export class StartupAdmissionQueue {
 	}
 
 	#grantNext(): void {
+		if (this.#closed) return;
 		while (this.#inFlight < this.limit) {
 			const waiter = this.#waiters.shift();
 			if (!waiter) return;
 			if (waiter.state !== "waiting") continue;
 			waiter.state = "admitted";
+			waiter.admissionEpoch = this.#epoch;
 			this.#inFlight += 1;
 			waiter.ready.resolve();
 		}
@@ -650,16 +658,24 @@ export class StartupAdmissionQueue {
 	/**
 	 * Refuse every queued startup and every later one. A broker that can no longer
 	 * prove it owns the published root must not spawn children through slots that
-	 * free up after it stops, and a waiter must never be silently granted or left
-	 * pending, so each one is woken with an explicit non-success outcome.
+	 * free up while it is fenced. The epoch also invalidates a waiter that was
+	 * granted but has not crossed the task execution boundary yet.
 	 */
 	close(): void {
+		if (this.#closed) return;
 		this.#closed = true;
+		this.#epoch += 1;
 		for (const waiter of this.#waiters.splice(0)) {
 			if (waiter.state !== "waiting") continue;
 			waiter.state = "refused";
 			waiter.ready.resolve();
 		}
+	}
+
+	/** Accept later startups after fresh publication ownership has been proven. */
+	reopen(): void {
+		this.#closed = false;
+		this.#grantNext();
 	}
 }
 type BrokerPublicationState =
@@ -959,6 +975,7 @@ export class Broker {
 	#fence(kind: "suspect-unpublished" | "observation-ambiguous" | "heartbeat-ambiguous"): void {
 		if (this.#publicationState === "stopping") return;
 		this.#publicationState = kind;
+		this.#startupAdmissions.close();
 		if (kind === "suspect-unpublished") {
 			this.#lossAt ??= process.hrtime.bigint();
 			this.#ambiguousAt = null;
@@ -991,14 +1008,14 @@ export class Broker {
 			return;
 		}
 		if (observation === "owned") {
-			if (this.#publicationState === "heartbeat-ambiguous") {
-				if (writeHeartbeat) await this.#writeHeartbeat();
+			if (writeHeartbeat) {
+				await this.#writeHeartbeat();
 				return;
 			}
 			this.#publicationState = "healthy-owned";
+			this.#startupAdmissions.reopen();
 			this.#lossAt = null;
 			this.#ambiguousAt = null;
-			if (writeHeartbeat) await this.#writeHeartbeat();
 			return;
 		}
 		this.#fence(observation === "ambiguous" ? "observation-ambiguous" : "suspect-unpublished");
@@ -1017,6 +1034,7 @@ export class Broker {
 			return;
 		}
 		this.#publicationState = "healthy-owned";
+		this.#startupAdmissions.reopen();
 		this.#lossAt = null;
 		this.#ambiguousAt = null;
 		this.discovery = { ...this.discovery, heartbeatAt };

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -555,7 +555,7 @@ const BROKER_SETTLEMENT_MS = 2_000;
 
 export interface StartupAdmissionTiming {
 	now(): number;
-	sleep(ms: number): Promise<void>;
+	sleep(ms: number, signal?: AbortSignal): Promise<void>;
 }
 
 export type StartupAdmissionResult<T> =
@@ -600,18 +600,24 @@ export class StartupAdmissionQueue {
 		const ready = Promise.withResolvers<void>();
 		const waiter: StartupAdmissionWaiter = { state: "waiting", ready };
 		this.#waiters.push(waiter);
-		const outcome = await Promise.race([
-			ready.promise.then(() => (waiter.state === "refused" ? ("refused" as const) : ("admitted" as const))),
-			timing.sleep(queueWaitMs).then(() => {
-				if (waiter.state === "admitted") return "admitted" as const;
-				if (waiter.state === "refused") return "refused" as const;
-				if (waiter.state === "timed_out") return "timed_out" as const;
-				waiter.state = "timed_out";
-				const index = this.#waiters.indexOf(waiter);
-				if (index >= 0) this.#waiters.splice(index, 1);
-				return "timed_out" as const;
-			}),
-		]);
+		const cutoff = new AbortController();
+		let outcome: "admitted" | "timed_out" | "refused";
+		try {
+			outcome = await Promise.race([
+				ready.promise.then(() => (waiter.state === "refused" ? ("refused" as const) : ("admitted" as const))),
+				timing.sleep(queueWaitMs, cutoff.signal).then(() => {
+					if (waiter.state === "admitted") return "admitted" as const;
+					if (waiter.state === "refused") return "refused" as const;
+					if (waiter.state === "timed_out") return "timed_out" as const;
+					waiter.state = "timed_out";
+					const index = this.#waiters.indexOf(waiter);
+					if (index >= 0) this.#waiters.splice(index, 1);
+					return "timed_out" as const;
+				}),
+			]);
+		} finally {
+			cutoff.abort();
+		}
 		if (outcome === "timed_out") return { status: "admission_timeout", reason: "admission_timeout" };
 		if (outcome === "refused") return { status: "admission_refused", reason: "admission_refused" };
 		return this.#runGranted(waiter.admissionEpoch!, timing, task);

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -854,6 +854,9 @@ export class Broker {
 			this.#resolveCompletion = completion.resolve;
 			this.#rejectCompletion = completion.reject;
 			this.#completionTask = null;
+			// A drained queue refuses every later startup by design, so a restarted broker
+			// needs a new one or it would admit nothing for the rest of the process.
+			this.#startupAdmissions = new StartupAdmissionQueue(sdkHostStartupConcurrency());
 		}
 		this.#stopping = false;
 		this.#publicationState = "healthy-owned";
@@ -1059,8 +1062,27 @@ export class Broker {
 		void this.#completionTask.then(this.#resolveCompletion, this.#rejectCompletion);
 		return this.#completionTask;
 	}
+	/**
+	 * Fresh, uncached proof that this broker still publishes the discovery root.
+	 * The cached state is not proof: the watchdog observes on a cadence, so a
+	 * replacement can already be on disk without having been seen yet.
+	 */
+	#provenOwnedRoot(): boolean {
+		if (!this.#publication || this.#publicationState !== "healthy-owned") return false;
+		try {
+			return (publicationObservationOverridesForTest.get(this) ?? this.#publication.observe()) === "owned";
+		} catch {
+			return false;
+		}
+	}
+	/**
+	 * A stop may take the owning path only while it can prove it still owns the root.
+	 * Claiming ownership it cannot prove keeps the admission queue open, so a startup
+	 * queued behind this broker is granted a slot that frees after completion and
+	 * spawns a child the broker has no authority over.
+	 */
 	async stop(): Promise<void> {
-		await this.#complete("owned-root");
+		await this.#complete(this.#provenOwnedRoot() ? "owned-root" : "lost-root");
 	}
 	async #endpoint(input: Record<string, unknown>): Promise<BrokerResponse> {
 		const sessionId = input.sessionId;

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -65,6 +65,7 @@ export type BrokerErrorCode =
 	| "invalid_input"
 	| "spawn_failed"
 	| "startup_admission_timeout"
+	| "startup_admission_refused"
 	| "readiness_timeout"
 	| "close_refused"
 	| "not_found"
@@ -559,10 +560,11 @@ export interface StartupAdmissionTiming {
 
 export type StartupAdmissionResult<T> =
 	| { status: "completed"; admittedAt: number; value: T }
-	| { status: "admission_timeout"; reason: "admission_timeout" };
+	| { status: "admission_timeout"; reason: "admission_timeout" }
+	| { status: "admission_refused"; reason: "admission_refused" };
 
 interface StartupAdmissionWaiter {
-	state: "waiting" | "admitted" | "timed_out";
+	state: "waiting" | "admitted" | "timed_out" | "refused";
 	ready: PromiseWithResolvers<void>;
 }
 
@@ -575,6 +577,7 @@ export function sdkHostStartupConcurrency(availableParallelism = os.availablePar
 
 export class StartupAdmissionQueue {
 	#inFlight = 0;
+	#closed = false;
 	#waiters: StartupAdmissionWaiter[] = [];
 
 	constructor(readonly limit: number) {
@@ -589,15 +592,17 @@ export class StartupAdmissionQueue {
 	): Promise<StartupAdmissionResult<T>> {
 		if (!Number.isSafeInteger(queueWaitMs) || queueWaitMs < 1)
 			throw new Error("SDK host startup queue wait must be a positive safe integer.");
+		if (this.#closed) return { status: "admission_refused", reason: "admission_refused" };
 		if (this.#inFlight < this.limit) return this.#runAdmitted(timing, task);
 
 		const ready = Promise.withResolvers<void>();
 		const waiter: StartupAdmissionWaiter = { state: "waiting", ready };
 		this.#waiters.push(waiter);
 		const outcome = await Promise.race([
-			ready.promise.then(() => "admitted" as const),
+			ready.promise.then(() => (waiter.state === "refused" ? ("refused" as const) : ("admitted" as const))),
 			timing.sleep(queueWaitMs).then(() => {
 				if (waiter.state === "admitted") return "admitted" as const;
+				if (waiter.state === "refused") return "refused" as const;
 				if (waiter.state === "timed_out") return "timed_out" as const;
 				waiter.state = "timed_out";
 				const index = this.#waiters.indexOf(waiter);
@@ -606,6 +611,7 @@ export class StartupAdmissionQueue {
 			}),
 		]);
 		if (outcome === "timed_out") return { status: "admission_timeout", reason: "admission_timeout" };
+		if (outcome === "refused") return { status: "admission_refused", reason: "admission_refused" };
 		return this.#runGranted(timing, task);
 	}
 
@@ -637,6 +643,21 @@ export class StartupAdmissionQueue {
 			if (waiter.state !== "waiting") continue;
 			waiter.state = "admitted";
 			this.#inFlight += 1;
+			waiter.ready.resolve();
+		}
+	}
+
+	/**
+	 * Refuse every queued startup and every later one. A broker that can no longer
+	 * prove it owns the published root must not spawn children through slots that
+	 * free up after it stops, and a waiter must never be silently granted or left
+	 * pending, so each one is woken with an explicit non-success outcome.
+	 */
+	close(): void {
+		this.#closed = true;
+		for (const waiter of this.#waiters.splice(0)) {
+			if (waiter.state !== "waiting") continue;
+			waiter.state = "refused";
 			waiter.ready.resolve();
 		}
 	}
@@ -1005,6 +1026,13 @@ export class Broker {
 		if (this.#completionTask) return this.#completionTask;
 		this.#stopping = true;
 		this.#publicationState = "stopping";
+		// A lost-root broker has been fenced: it no longer owns the published root, and
+		// its settlement is bounded, so any startup still queued behind it would be
+		// granted after completion and spawn a child the broker has no authority over.
+		// An owned-root stop keeps the queue open on purpose: the broker still owns
+		// everything it admitted, and completion waits unbounded for those startups, so
+		// draining would abandon work that is about to finish correctly.
+		if (mode === "lost-root") this.#startupAdmissions.close();
 		if (this.#heartbeatTimer) clearInterval(this.#heartbeatTimer);
 		this.#heartbeatTimer = null;
 		this.#completionTask = (async () => {

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -1014,14 +1014,16 @@ export class Broker {
 			return;
 		}
 		if (observation === "owned") {
-			if (writeHeartbeat) {
-				await this.#writeHeartbeat();
-				return;
-			}
+			// Recover the cached publication state synchronously with the observation
+			// so request admission does not lag behind the awaited heartbeat IO.
+			// The heartbeat write that follows re-checks fresh publication authority
+			// and fences (downgrading this optimistic recovery) if ownership changed
+			// between the observation and the write.
 			this.#publicationState = "healthy-owned";
 			this.#startupAdmissions.reopen();
 			this.#lossAt = null;
 			this.#ambiguousAt = null;
+			if (writeHeartbeat) await this.#writeHeartbeat();
 			return;
 		}
 		this.#fence(observation === "ambiguous" ? "observation-ambiguous" : "suspect-unpublished");
@@ -1040,10 +1042,6 @@ export class Broker {
 			return;
 		}
 		const recovery = this.runSynchronousEffectWithFreshPublicationAuthority(() => {
-			this.#publicationState = "healthy-owned";
-			this.#startupAdmissions.reopen();
-			this.#lossAt = null;
-			this.#ambiguousAt = null;
 			this.discovery = { ...this.discovery!, heartbeatAt };
 		});
 		if (!recovery.authorized) return;

--- a/packages/coding-agent/src/sdk/broker/index.ts
+++ b/packages/coding-agent/src/sdk/broker/index.ts
@@ -5,4 +5,5 @@ export * from "./identity";
 export * from "./lifecycle";
 export * from "./lifecycle-ledger";
 export * from "./session-index";
+export * from "./startup-budget";
 export * from "./transport";

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -73,6 +73,7 @@ import {
 } from "./process-incarnation";
 import { resolveSdkInternalSpawnCommand, type SdkInternalSpawnCommand } from "./runtime";
 import {
+	cancellableSleep,
 	DEFAULT_READINESS_TIMEOUT_MS,
 	isValidReadinessTimeoutMs,
 	READINESS_TIMEOUT_INVALID_MESSAGE,
@@ -126,13 +127,10 @@ export function deriveLifecycleDeadlines(receivedAt: number, requestedReadinessT
 
 export interface LifecycleTiming {
 	now(): number;
-	sleep(ms: number): Promise<void>;
+	sleep(ms: number, signal?: AbortSignal): Promise<void>;
 }
 
-const defaultLifecycleTiming: LifecycleTiming = {
-	now: Date.now,
-	sleep: ms => new Promise(resolve => setTimeout(resolve, ms)),
-};
+const defaultLifecycleTiming: LifecycleTiming = { now: Date.now, sleep: cancellableSleep };
 const lifecycleTimingsForTest = new WeakMap<Broker, LifecycleTiming>();
 type LifecycleCommand = SdkInternalSpawnCommand | { file: string; args: string[] };
 type LifecycleCommandResolver = () => LifecycleCommand;

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -3243,41 +3243,49 @@ async function executeLifecycleResponse(
 		let child: ChildProcess | undefined;
 		let spawnedAuthority: EffectMarker | undefined;
 		try {
-			const cmd = command(broker);
-			const spawned = spawn(cmd.file, cmd.args, {
-				cwd: launch.cwd,
-				detached: true,
-				stdio: "ignore",
-				env: {
-					...("kind" in cmd ? cmd.env : process.env),
-					GJC_AGENT_DIR: broker.settings.agentDir,
-					GJC_CODING_AGENT_DIR: broker.settings.agentDir,
-					GJC_SESSION_ID: launch.id,
-					GJC_STATE_ROOT: launch.root,
-					GJC_LIFECYCLE_REQUEST_ID: effectMarker,
-					GJC_SDK_LIFECYCLE_REQUEST: JSON.stringify(request),
-					// Coordinator-correlation env scoped to this designated launch only (#2549).
-					// The runtime sidecar reads these to write terminal state to the
-					// coordinator-shared file instead of an unread session-local fallback.
-					// The broker computes the file path from coordinatorStateDir + launch.id
-					// because the session ID is generated at spawn time.
-					...(launch.coordinatorStateDir
-						? {
-								[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]: path.join(
-									launch.coordinatorStateDir,
-									"session-states",
-									`${launch.id}.json`,
-								),
-							}
-						: {}),
-					...(launch.coordinatorSessionId
-						? { [GJC_COORDINATOR_SESSION_ID_ENV]: launch.coordinatorSessionId }
-						: {}),
-					...(launch.coordinatorSessionBranch
-						? { [GJC_COORDINATOR_SESSION_BRANCH_ENV]: launch.coordinatorSessionBranch }
-						: {}),
-				},
+			const authorizedSpawn = broker.runSynchronousEffectWithFreshPublicationAuthority(() => {
+				const cmd = command(broker);
+				return spawn(cmd.file, cmd.args, {
+					cwd: launch.cwd,
+					detached: true,
+					stdio: "ignore",
+					env: {
+						...("kind" in cmd ? cmd.env : process.env),
+						GJC_AGENT_DIR: broker.settings.agentDir,
+						GJC_CODING_AGENT_DIR: broker.settings.agentDir,
+						GJC_SESSION_ID: launch.id,
+						GJC_STATE_ROOT: launch.root,
+						GJC_LIFECYCLE_REQUEST_ID: effectMarker,
+						GJC_SDK_LIFECYCLE_REQUEST: JSON.stringify(request),
+						// Coordinator-correlation env scoped to this designated launch only (#2549).
+						// The runtime sidecar reads these to write terminal state to the
+						// coordinator-shared file instead of an unread session-local fallback.
+						// The broker computes the file path from coordinatorStateDir + launch.id
+						// because the session ID is generated at spawn time.
+						...(launch.coordinatorStateDir
+							? {
+									[GJC_COORDINATOR_SESSION_STATE_FILE_ENV]: path.join(
+										launch.coordinatorStateDir,
+										"session-states",
+										`${launch.id}.json`,
+									),
+								}
+							: {}),
+						...(launch.coordinatorSessionId
+							? { [GJC_COORDINATOR_SESSION_ID_ENV]: launch.coordinatorSessionId }
+							: {}),
+						...(launch.coordinatorSessionBranch
+							? { [GJC_COORDINATOR_SESSION_BRANCH_ENV]: launch.coordinatorSessionBranch }
+							: {}),
+					},
+				});
 			});
+			if (!authorizedSpawn.authorized)
+				return fail(
+					"startup_admission_refused",
+					"SDK host startup was refused because the broker no longer owns the session root.",
+				);
+			const spawned = authorizedSpawn.value;
 			child = spawned;
 			const pid = spawned.pid;
 			if (!pid) throw new Error("spawned session has no pid");

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -72,7 +72,7 @@ import {
 	processIncarnation,
 } from "./process-incarnation";
 import { resolveSdkInternalSpawnCommand, type SdkInternalSpawnCommand } from "./runtime";
-import { startupQueueWaitMs } from "./startup-budget";
+import { DEFAULT_READINESS_TIMEOUT_MS, startupQueueWaitMs } from "./startup-budget";
 
 export {
 	type ProcessIncarnationCommandRunner,
@@ -81,7 +81,6 @@ export {
 	processIncarnation,
 };
 
-const READY_TIMEOUT_MS = 10_000;
 const MIN_READY_TIMEOUT_MS = 4_000;
 const MAX_READY_TIMEOUT_MS = 60_000;
 const POLL_MS = 50;
@@ -493,7 +492,7 @@ export function validateBrokerModelPresetForTest(agentDir: string, requestedProf
 
 function readinessTimeout(input: Input): number | BrokerResponse {
 	const value = input.readinessTimeoutMs;
-	if (value === undefined) return READY_TIMEOUT_MS;
+	if (value === undefined) return DEFAULT_READINESS_TIMEOUT_MS;
 	if (
 		typeof value !== "number" ||
 		!Number.isSafeInteger(value) ||

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -72,7 +72,12 @@ import {
 	processIncarnation,
 } from "./process-incarnation";
 import { resolveSdkInternalSpawnCommand, type SdkInternalSpawnCommand } from "./runtime";
-import { DEFAULT_READINESS_TIMEOUT_MS, startupQueueWaitMs } from "./startup-budget";
+import {
+	DEFAULT_READINESS_TIMEOUT_MS,
+	isValidReadinessTimeoutMs,
+	READINESS_TIMEOUT_INVALID_MESSAGE,
+	startupQueueWaitMs,
+} from "./startup-budget";
 
 export {
 	type ProcessIncarnationCommandRunner,
@@ -81,8 +86,6 @@ export {
 	processIncarnation,
 };
 
-const MIN_READY_TIMEOUT_MS = 4_000;
-const MAX_READY_TIMEOUT_MS = 60_000;
 const POLL_MS = 50;
 const CLOSE_TIMEOUT_MS = 2_000;
 const MAX_RECEIVED_AT_SKEW_MS = 5_000;
@@ -99,12 +102,7 @@ export interface LifecycleDeadlines {
 }
 
 export function deriveLifecycleDeadlines(receivedAt: number, requestedReadinessTimeoutMs: number): LifecycleDeadlines {
-	if (
-		!Number.isSafeInteger(receivedAt) ||
-		!Number.isSafeInteger(requestedReadinessTimeoutMs) ||
-		requestedReadinessTimeoutMs < MIN_READY_TIMEOUT_MS ||
-		requestedReadinessTimeoutMs > MAX_READY_TIMEOUT_MS
-	)
+	if (!Number.isSafeInteger(receivedAt) || !isValidReadinessTimeoutMs(requestedReadinessTimeoutMs))
 		throw new Error("Lifecycle timing values must be safe integers in the approved readiness range.");
 	const phaseWindowMs = Math.min(1_000, Math.max(500, Math.floor(requestedReadinessTimeoutMs / 4)));
 	const lifecycleCleanupDeadlineAt = receivedAt + requestedReadinessTimeoutMs;
@@ -493,16 +491,7 @@ export function validateBrokerModelPresetForTest(agentDir: string, requestedProf
 function readinessTimeout(input: Input): number | BrokerResponse {
 	const value = input.readinessTimeoutMs;
 	if (value === undefined) return DEFAULT_READINESS_TIMEOUT_MS;
-	if (
-		typeof value !== "number" ||
-		!Number.isSafeInteger(value) ||
-		value < MIN_READY_TIMEOUT_MS ||
-		value > MAX_READY_TIMEOUT_MS
-	)
-		return fail(
-			"invalid_input",
-			`readinessTimeoutMs must be an integer between ${MIN_READY_TIMEOUT_MS} and ${MAX_READY_TIMEOUT_MS}.`,
-		);
+	if (!isValidReadinessTimeoutMs(value)) return fail("invalid_input", READINESS_TIMEOUT_INVALID_MESSAGE);
 	return value;
 }
 

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -72,6 +72,7 @@ import {
 	processIncarnation,
 } from "./process-incarnation";
 import { resolveSdkInternalSpawnCommand, type SdkInternalSpawnCommand } from "./runtime";
+import { startupQueueWaitMs } from "./startup-budget";
 
 export {
 	type ProcessIncarnationCommandRunner,
@@ -3125,20 +3126,21 @@ async function executeLifecycleResponse(
 				input.terminationStartDeadlineAt,
 				input.lifecycleCleanupDeadlineAt,
 			];
-			let queueWaitMs: number;
+			let requestedReadinessTimeoutMs: number;
 			if (suppliedDeadlineFields.some(value => value !== undefined)) {
 				const supplied = lifecycleDeadlines(input, timing.now());
 				if ("ok" in supplied) return supplied;
-				queueWaitMs = supplied.requestedReadinessTimeoutMs;
+				requestedReadinessTimeoutMs = supplied.requestedReadinessTimeoutMs;
 			} else {
 				const timeout = readinessTimeout(input);
 				if (typeof timeout !== "number") return timeout;
-				queueWaitMs = timeout;
+				requestedReadinessTimeoutMs = timeout;
 			}
+			const queueWaitMs = startupQueueWaitMs(requestedReadinessTimeoutMs);
 			const launch = await launchInput(broker, operation, input);
 			if ("ok" in launch) return launch;
 			const admitted = await broker.runStartup(queueWaitMs, timing, async admittedAt => {
-				const admittedInput = { ...input, ...deriveLifecycleDeadlines(admittedAt, queueWaitMs) };
+				const admittedInput = { ...input, ...deriveLifecycleDeadlines(admittedAt, requestedReadinessTimeoutMs) };
 				startupAdmittedInputs.add(admittedInput);
 				startupLaunchInputs.set(admittedInput, launch);
 				try {
@@ -3149,6 +3151,11 @@ async function executeLifecycleResponse(
 				}
 			});
 			if (admitted.status === "completed") return admitted.value;
+			if (admitted.status === "admission_refused")
+				return fail(
+					"startup_admission_refused",
+					"SDK host startup was refused because the broker no longer owns the session root.",
+				);
 			const failure = normalizeSdkStartupFailure("startup", admitted.reason);
 			return fail("startup_admission_timeout", failure.message);
 		}

--- a/packages/coding-agent/src/sdk/broker/startup-budget.ts
+++ b/packages/coding-agent/src/sdk/broker/startup-budget.ts
@@ -1,5 +1,18 @@
 /** Readiness budget the broker grants a lifecycle request that does not size one itself. */
 export const DEFAULT_READINESS_TIMEOUT_MS = 10_000;
+export const MIN_READINESS_TIMEOUT_MS = 4_000;
+export const MAX_READINESS_TIMEOUT_MS = 60_000;
+
+export function isValidReadinessTimeoutMs(value: unknown): value is number {
+	return (
+		typeof value === "number" &&
+		Number.isSafeInteger(value) &&
+		value >= MIN_READINESS_TIMEOUT_MS &&
+		value <= MAX_READINESS_TIMEOUT_MS
+	);
+}
+
+export const READINESS_TIMEOUT_INVALID_MESSAGE = `readinessTimeoutMs must be an integer between ${MIN_READINESS_TIMEOUT_MS} and ${MAX_READINESS_TIMEOUT_MS}.`;
 
 /**
  * Slack a caller adds over the broker-side budget so that a startup which runs to the
@@ -50,7 +63,8 @@ export function lifecycleStartupBudgetMs(requestedReadinessTimeoutMs: number): n
  */
 export function lifecycleRequestTimeoutMs(operation: string, input: Record<string, unknown>): number | undefined {
 	const requested = input.readinessTimeoutMs;
-	const supplied = typeof requested === "number" && Number.isSafeInteger(requested) ? requested : undefined;
+	if (requested !== undefined && !isValidReadinessTimeoutMs(requested)) return undefined;
+	const supplied = requested as number | undefined;
 	if (isStartupLifecycleOperation(operation))
 		return lifecycleStartupBudgetMs(supplied ?? DEFAULT_READINESS_TIMEOUT_MS) + CALLER_DEADLINE_SLACK_MS;
 	return supplied === undefined ? undefined : supplied + CALLER_DEADLINE_SLACK_MS;

--- a/packages/coding-agent/src/sdk/broker/startup-budget.ts
+++ b/packages/coding-agent/src/sdk/broker/startup-budget.ts
@@ -13,6 +13,23 @@ export function isValidReadinessTimeoutMs(value: unknown): value is number {
 }
 
 export const READINESS_TIMEOUT_INVALID_MESSAGE = `readinessTimeoutMs must be an integer between ${MIN_READINESS_TIMEOUT_MS} and ${MAX_READINESS_TIMEOUT_MS}.`;
+/**
+ * Sleep until the duration elapses or the caller cancels the wait. Queue admission
+ * uses this so a granted or refused waiter does not retain its cutoff timer for the
+ * rest of the readiness budget.
+ */
+export function cancellableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+	if (signal?.aborted || ms <= 0) return Promise.resolve();
+	const settled = Promise.withResolvers<void>();
+	const cancel = (): void => {
+		clearTimeout(timer);
+		signal?.removeEventListener("abort", cancel);
+		settled.resolve();
+	};
+	const timer = setTimeout(cancel, ms);
+	signal?.addEventListener("abort", cancel, { once: true });
+	return settled.promise;
+}
 
 /**
  * Slack a caller adds over the broker-side budget so that a startup which runs to the
@@ -62,9 +79,24 @@ export function lifecycleStartupBudgetMs(requestedReadinessTimeoutMs: number): n
  * the startup to a durably persisted terminal result.
  */
 export function lifecycleRequestTimeoutMs(operation: string, input: Record<string, unknown>): number | undefined {
-	const requested = input.readinessTimeoutMs;
-	if (requested !== undefined && !isValidReadinessTimeoutMs(requested)) return undefined;
-	const supplied = requested as number | undefined;
+	const deadlineFields = [
+		input.receivedAt,
+		input.requestedReadinessTimeoutMs,
+		input.semanticReadyDeadlineAt,
+		input.terminationStartDeadlineAt,
+		input.lifecycleCleanupDeadlineAt,
+	];
+	const hasDeadlineTuple = deadlineFields.some(value => value !== undefined);
+	let supplied: number | undefined;
+	if (hasDeadlineTuple) {
+		if (!deadlineFields.every(value => typeof value === "number" && Number.isSafeInteger(value))) return undefined;
+		if (!isValidReadinessTimeoutMs(input.requestedReadinessTimeoutMs)) return undefined;
+		supplied = input.requestedReadinessTimeoutMs;
+	} else {
+		const requested = input.readinessTimeoutMs;
+		if (requested !== undefined && !isValidReadinessTimeoutMs(requested)) return undefined;
+		supplied = requested as number | undefined;
+	}
 	if (isStartupLifecycleOperation(operation))
 		return lifecycleStartupBudgetMs(supplied ?? DEFAULT_READINESS_TIMEOUT_MS) + CALLER_DEADLINE_SLACK_MS;
 	return supplied === undefined ? undefined : supplied + CALLER_DEADLINE_SLACK_MS;

--- a/packages/coding-agent/src/sdk/broker/startup-budget.ts
+++ b/packages/coding-agent/src/sdk/broker/startup-budget.ts
@@ -1,3 +1,22 @@
+/** Readiness budget the broker grants a lifecycle request that does not size one itself. */
+export const DEFAULT_READINESS_TIMEOUT_MS = 10_000;
+
+/**
+ * Slack a caller adds over the broker-side budget so that a startup which runs to the
+ * very edge of its window is reported as the broker's own terminal result rather than
+ * as the caller's timeout.
+ */
+const CALLER_DEADLINE_SLACK_MS = 1_000;
+
+/**
+ * Whether a broker operation waits in the host-startup admission queue before it runs.
+ * Only these spawn a host, so only these can be parked behind a full queue; the other
+ * lifecycle operations start their readiness clock as soon as they are received.
+ */
+export function isStartupLifecycleOperation(operation: string): boolean {
+	return operation === "session.create" || operation === "session.fork" || operation === "session.resume";
+}
+
 /**
  * Bounded time a lifecycle startup may wait for a host-startup admission slot. It
  * is the readiness budget itself: a startup still queued after that long has spent
@@ -17,4 +36,22 @@ export function startupQueueWaitMs(requestedReadinessTimeoutMs: number): number 
  */
 export function lifecycleStartupBudgetMs(requestedReadinessTimeoutMs: number): number {
 	return startupQueueWaitMs(requestedReadinessTimeoutMs) + requestedReadinessTimeoutMs;
+}
+
+/**
+ * Request deadline a caller MUST grant a broker operation, or `undefined` when the
+ * operation carries no readiness budget of its own and the client default already
+ * covers it.
+ *
+ * A request that omits `readinessTimeoutMs` is sized against the broker's default
+ * rather than left unextended: the broker queues it for exactly as long as one that
+ * asked, so the common path would otherwise fail client-side while the broker runs
+ * the startup to a durably persisted terminal result.
+ */
+export function lifecycleRequestTimeoutMs(operation: string, input: Record<string, unknown>): number | undefined {
+	const requested = input.readinessTimeoutMs;
+	const supplied = typeof requested === "number" && Number.isSafeInteger(requested) ? requested : undefined;
+	if (isStartupLifecycleOperation(operation))
+		return lifecycleStartupBudgetMs(supplied ?? DEFAULT_READINESS_TIMEOUT_MS) + CALLER_DEADLINE_SLACK_MS;
+	return supplied === undefined ? undefined : supplied + CALLER_DEADLINE_SLACK_MS;
 }

--- a/packages/coding-agent/src/sdk/broker/startup-budget.ts
+++ b/packages/coding-agent/src/sdk/broker/startup-budget.ts
@@ -1,0 +1,20 @@
+/**
+ * Bounded time a lifecycle startup may wait for a host-startup admission slot. It
+ * is the readiness budget itself: a startup still queued after that long has spent
+ * the whole window the request was sized for, so refusing it beats launching a host
+ * that is already late.
+ */
+export function startupQueueWaitMs(requestedReadinessTimeoutMs: number): number {
+	return requestedReadinessTimeoutMs;
+}
+
+/**
+ * Broker-side wall clock a lifecycle startup may consume: the admission wait plus
+ * the readiness budget, which is granted fresh at admission and so is never shortened
+ * by queueing. Callers MUST size their own request deadline against this rather than
+ * `readinessTimeoutMs` alone, or a request admitted late fails client-side while the
+ * broker keeps running it to a durably persisted terminal result.
+ */
+export function lifecycleStartupBudgetMs(requestedReadinessTimeoutMs: number): number {
+	return startupQueueWaitMs(requestedReadinessTimeoutMs) + requestedReadinessTimeoutMs;
+}

--- a/packages/coding-agent/src/sdk/bus/chat-daemon-runtime.ts
+++ b/packages/coding-agent/src/sdk/bus/chat-daemon-runtime.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { logger } from "@gajae-code/utils";
 import { type IndexedSession, SessionIndex } from "../broker/session-index";
+import { lifecycleRequestTimeoutMs } from "../broker/startup-budget";
 import { SdkClient, SdkClientError } from "../client/client";
 import { readSdkBrokerDiscovery, readSdkSessionEndpoint, type SdkSessionEndpoint } from "../client/discovery";
 import { SESSION_PREPARED_EVENT } from "../host/host";
@@ -46,7 +47,7 @@ export interface ChatDaemonSdkClient {
 	onReconnect?(handler: () => void): () => void;
 	/** Re-dials a retired socket; a no-op on a live one. */
 	connect?(): Promise<void>;
-	request(frame: Record<string, unknown>): Promise<Record<string, unknown>>;
+	request(frame: Record<string, unknown>, options?: { timeoutMs?: number }): Promise<Record<string, unknown>>;
 	close(): Promise<void>;
 	send(frame: Record<string, unknown>): void;
 }
@@ -1272,7 +1273,11 @@ export class ChatDaemonRuntime {
 			throw new ChatDeliveryError("pre_send");
 		}
 		try {
-			return await client.request({ type: "broker_request", operation, input, idempotencyKey });
+			const timeoutMs = lifecycleRequestTimeoutMs(operation, input);
+			return await client.request(
+				{ type: "broker_request", operation, input, idempotencyKey },
+				timeoutMs === undefined ? undefined : { timeoutMs },
+			);
 		} finally {
 			await client.close();
 		}

--- a/packages/coding-agent/src/sdk/cli/session-cli.ts
+++ b/packages/coding-agent/src/sdk/cli/session-cli.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs/promises";
 import { createInterface } from "node:readline/promises";
 import { getAgentDir } from "@gajae-code/utils";
 import { ensureBroker } from "../broker/ensure";
+import { lifecycleRequestTimeoutMs } from "../broker/startup-budget";
 import {
 	listSdkSessionEndpoints,
 	readSdkBrokerDiscovery,
@@ -242,7 +243,13 @@ export async function runSdkSessionCli(
 				throw new SdkSessionCliError("invalid_input", "--idempotency-key is required for lifecycle operations.", 2);
 			const client = await connectBroker(agentDir);
 			try {
-				writeOutput(await client.global(operation, input, { idempotencyKey }));
+				const timeoutMs = lifecycleRequestTimeoutMs(operation, input);
+				writeOutput(
+					await client.global(operation, input, {
+						idempotencyKey,
+						...(timeoutMs === undefined ? {} : { timeoutMs }),
+					}),
+				);
 			} finally {
 				await client.close();
 			}

--- a/packages/coding-agent/src/sdk/mcp/server.ts
+++ b/packages/coding-agent/src/sdk/mcp/server.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { getAgentDir } from "@gajae-code/utils";
 import { ensureBroker } from "../broker/ensure";
+import { lifecycleRequestTimeoutMs } from "../broker/startup-budget";
 import { SdkClient, SdkClientError } from "../client/client";
 import {
 	listSdkSessionEndpoints,
@@ -253,7 +254,11 @@ export function createSdkMcpServer(options: SdkMcpServerOptions = {}) {
 				const broker = await readSdkBrokerDiscovery(agentDir);
 				if (!broker) return { ok: false, error: { code: "not_found", message: "SDK broker not found" } };
 				client = await connect(broker.url, broker.token);
-				const response = await client.global(operation, input, { idempotencyKey });
+				const timeoutMs = lifecycleRequestTimeoutMs(operation, input);
+				const response = await client.global(operation, input, {
+					idempotencyKey,
+					...(timeoutMs === undefined ? {} : { timeoutMs }),
+				});
 				return isLifecycleOperation(operation) ? redactLifecycleCredentials(response) : response;
 			} catch (error) {
 				return resultError(error);

--- a/packages/coding-agent/test/sdk-acp-adapter.test.ts
+++ b/packages/coding-agent/test/sdk-acp-adapter.test.ts
@@ -130,6 +130,7 @@ test("ACP SDK adapter exposes SDK event frames while rejecting raw lifecycle glo
 		operation: "session.create",
 		input: { cwd: "/workspace" },
 		idempotencyKey: "lifecycle-key",
+		timeoutMs: 21_000,
 	});
 	expect(received).toContainEqual({ type: "event", payload: { type: "turn_end" } });
 	unsubscribe();
@@ -175,6 +176,7 @@ test("ACP lifecycle aliases forward caller idempotency keys outside operation in
 			operation: alias.operation,
 			input: alias.input,
 			idempotencyKey: `alias-${index}`,
+			...(alias.operation === "session.close" ? {} : { timeoutMs: 21_000 }),
 		})),
 	);
 	await adapter.close();

--- a/packages/coding-agent/test/sdk-acp-adapter.test.ts
+++ b/packages/coding-agent/test/sdk-acp-adapter.test.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import type { AgentSideConnection } from "@agentclientprotocol/sdk";
+import { AcpAgent } from "../src/modes/acp/acp-agent";
 import { AcpSdkAdapter, type AcpSdkAdapterError, acpMcpLaunchFailure } from "../src/sdk/acp";
+import { writeBrokerDiscovery } from "../src/sdk/broker/discovery";
 import { SdkClientError } from "../src/sdk/client";
 import { MAX_REVERSE_PAYLOAD_BYTES } from "../src/sdk/host";
 
@@ -434,21 +440,18 @@ test("ACP reverse cancellation and stale failures suppress responses over the re
 	}
 });
 
-test("the ACP MCP launch wrapper reports a broker refusal instead of blaming the MCP servers", () => {
+test("the ACP MCP launch wrapper reports broker refusal and re-attributes spawn failures", () => {
 	const mcpServers = [
 		{ name: "docs", command: "docs-mcp", args: [] },
 		{ name: "search", command: "search-mcp", args: [] },
 	];
 
-	// A refused admission never opened an MCP handshake: the broker declined it because it
-	// no longer owns the session root, and that reason is what tells a caller to retry.
 	const refused = new SdkClientError(
 		"startup_admission_refused",
 		"SDK host startup was refused because the broker no longer owns the session root.",
 	);
 	expect(acpMcpLaunchFailure(refused, mcpServers)).toBe(refused);
 
-	// A launch that did reach the servers keeps naming them, which is the useful answer.
 	const masked = acpMcpLaunchFailure(new SdkClientError("spawn_failed", "child exited"), mcpServers) as {
 		code: string;
 		message: string;
@@ -458,7 +461,80 @@ test("the ACP MCP launch wrapper reports a broker refusal instead of blaming the
 		message: "MCP server request failed to start (docs, search).",
 	});
 
-	// Without MCP servers there is nothing to re-attribute to in the first place.
 	const bare = new SdkClientError("spawn_failed", "child exited");
 	expect(acpMcpLaunchFailure(bare, [])).toBe(bare);
+});
+test("the production ACP MCP launch path preserves broker admission timeout failures", async () => {
+	const root = await fs.mkdtemp(path.join(tmpdir(), "gjc-acp-mcp-admission-timeout-"));
+	const agentDir = path.join(root, "agent");
+	const cwd = path.join(root, "workspace");
+	const token = "acp-admission-timeout-token";
+	const controller = new AbortController();
+	let server!: ReturnType<typeof Bun.serve>;
+	try {
+		await fs.mkdir(cwd, { recursive: true });
+		server = Bun.serve({
+			hostname: "127.0.0.1",
+			port: 0,
+			fetch(request) {
+				if (new URL(request.url).searchParams.get("token") !== token)
+					return new Response("Unauthorized", { status: 401 });
+				if (!server.upgrade(request, { data: undefined })) return new Response("Upgrade failed", { status: 400 });
+			},
+			websocket: {
+				open(socket) {
+					socket.send(JSON.stringify({ type: "broker_hello", protocolVersion: 3 }));
+				},
+				message(socket, raw) {
+					const frame = JSON.parse(String(raw)) as Record<string, unknown>;
+					socket.send(
+						JSON.stringify({
+							type: "broker_response",
+							id: frame.id,
+							ok: false,
+							error: {
+								code: "startup_admission_timeout",
+								message: "SDK host startup was not admitted before the queue wait cutoff.",
+							},
+						}),
+					);
+				},
+			},
+		});
+		await writeBrokerDiscovery(agentDir, {
+			version: 1,
+			protocolVersion: 3,
+			packageGeneration: "test",
+			ownerId: "acp-admission-timeout-owner",
+			pid: process.pid,
+			host: "127.0.0.1",
+			port: server.port!,
+			url: `ws://127.0.0.1:${server.port}`,
+			token,
+			startedAt: Date.now(),
+			heartbeatAt: Date.now(),
+		});
+		const agent = new AcpAgent(
+			{
+				signal: controller.signal,
+				closed: Promise.withResolvers<void>().promise,
+			} as unknown as AgentSideConnection,
+			{ agentDir },
+		);
+		await agent.initialize({ protocolVersion: 1, clientCapabilities: {} });
+		await expect(
+			agent.newSession({
+				cwd,
+				additionalDirectories: [],
+				mcpServers: [{ name: "docs", command: process.execPath, args: [], env: [] }],
+			}),
+		).rejects.toMatchObject({
+			code: "startup_admission_timeout",
+			message: "SDK host startup was not admitted before the queue wait cutoff.",
+		});
+	} finally {
+		controller.abort();
+		server?.stop(true);
+		await fs.rm(root, { recursive: true, force: true });
+	}
 });

--- a/packages/coding-agent/test/sdk-acp-adapter.test.ts
+++ b/packages/coding-agent/test/sdk-acp-adapter.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { AcpSdkAdapter, type AcpSdkAdapterError } from "../src/sdk/acp";
+import { AcpSdkAdapter, type AcpSdkAdapterError, acpMcpLaunchFailure } from "../src/sdk/acp";
+import { SdkClientError } from "../src/sdk/client";
 import { MAX_REVERSE_PAYLOAD_BYTES } from "../src/sdk/host";
 
 class FakeSdkClient {
@@ -431,4 +432,33 @@ test("ACP reverse cancellation and stale failures suppress responses over the re
 		await adapter.close();
 		server.stop(true);
 	}
+});
+
+test("the ACP MCP launch wrapper reports a broker refusal instead of blaming the MCP servers", () => {
+	const mcpServers = [
+		{ name: "docs", command: "docs-mcp", args: [] },
+		{ name: "search", command: "search-mcp", args: [] },
+	];
+
+	// A refused admission never opened an MCP handshake: the broker declined it because it
+	// no longer owns the session root, and that reason is what tells a caller to retry.
+	const refused = new SdkClientError(
+		"startup_admission_refused",
+		"SDK host startup was refused because the broker no longer owns the session root.",
+	);
+	expect(acpMcpLaunchFailure(refused, mcpServers)).toBe(refused);
+
+	// A launch that did reach the servers keeps naming them, which is the useful answer.
+	const masked = acpMcpLaunchFailure(new SdkClientError("spawn_failed", "child exited"), mcpServers) as {
+		code: string;
+		message: string;
+	};
+	expect(masked).toMatchObject({
+		code: "unavailable",
+		message: "MCP server request failed to start (docs, search).",
+	});
+
+	// Without MCP servers there is nothing to re-attribute to in the first place.
+	const bare = new SdkClientError("spawn_failed", "child exited");
+	expect(acpMcpLaunchFailure(bare, [])).toBe(bare);
 });

--- a/packages/coding-agent/test/sdk-broker-startup-admission.test.ts
+++ b/packages/coding-agent/test/sdk-broker-startup-admission.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { AcpSdkAdapter } from "../src/sdk/acp";
@@ -350,6 +350,88 @@ test("suspect-unpublished fence refuses queued startup before loss grace expires
 
 test("observation-ambiguous fence refuses queued startup before ambiguity grace expires", async () => {
 	await expectGraceWindowFenceRefusesQueuedStartup("ambiguous");
+});
+
+test("publication replacement during heartbeat persistence cannot reopen startup admission", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-heartbeat-reopen-fence-"));
+	const broker = new Broker({ agentDir: path.join(root, "agent") });
+	try {
+		await broker.start();
+		const heartbeat = broker.heartbeat();
+		setPublicationObservationForTest(broker, "replaced");
+		await heartbeat;
+
+		expect(await broker.handleRequest("session.list", {})).toEqual({
+			ok: false,
+			error: { code: "unavailable", message: "broker publication is unavailable" },
+		});
+	} finally {
+		setPublicationObservationForTest(broker, undefined);
+		await broker.stop().catch(() => undefined);
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});
+test("an admitted startup fenced during ledger persistence cannot reach synchronous spawn", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-admitted-ledger-fence-"));
+	const agentDir = path.join(root, "agent");
+	const previousCommand = process.env.GJC_SDK_SESSION_COMMAND;
+	const broker = new Broker({ agentDir, heartbeatTtlMs: 300 });
+	const transitionEntered = Promise.withResolvers<void>();
+	const releaseTransition = Promise.withResolvers<void>();
+	let spawnCalls = 0;
+	let paused = false;
+	try {
+		delete process.env.GJC_SDK_SESSION_COMMAND;
+		await broker.start();
+		const transition = broker.ledger.transition.bind(broker.ledger);
+		const transitionSpy = spyOn(broker.ledger, "transition").mockImplementation(async (identity, state, fields) => {
+			if (!paused && state === "effect_started") {
+				paused = true;
+				transitionEntered.resolve();
+				await releaseTransition.promise;
+			}
+			return transition(identity, state, fields);
+		});
+		setLifecycleCommandResolverForTest(broker, () => {
+			spawnCalls += 1;
+			throw new Error("SDK internal launch refused: fenced broker must not spawn.");
+		});
+
+		const startup = broker.handleRequest(
+			"session.create",
+			{ cwd: root, stateRoot: path.join(root, ".gjc", "state"), readinessTimeoutMs: 4_000 },
+			"admitted-before-ledger-fence",
+		);
+		await transitionEntered.promise;
+
+		setPublicationObservationForTest(broker, "replaced");
+		const fenceDeadline = Date.now() + 2_000;
+		let listResponse = await broker.handleRequest("session.list", {});
+		while ((listResponse.ok || listResponse.error.code !== "unavailable") && Date.now() < fenceDeadline) {
+			await Bun.sleep(10);
+			listResponse = await broker.handleRequest("session.list", {});
+		}
+		expect(listResponse).toMatchObject({ ok: false, error: { code: "unavailable" } });
+
+		releaseTransition.resolve();
+		expect(await startup).toEqual({
+			ok: false,
+			error: {
+				code: "startup_admission_refused",
+				message: "SDK host startup was refused because the broker no longer owns the session root.",
+			},
+		});
+		expect({ fenced: !listResponse.ok, spawnCalls }).toEqual({ fenced: true, spawnCalls: 0 });
+		transitionSpy.mockRestore();
+	} finally {
+		setLifecycleCommandResolverForTest(broker, undefined);
+		setPublicationObservationForTest(broker, undefined);
+		if (previousCommand === undefined) delete process.env.GJC_SDK_SESSION_COMMAND;
+		else process.env.GJC_SDK_SESSION_COMMAND = previousCommand;
+		releaseTransition.resolve();
+		await broker.stop().catch(() => undefined);
+		await fs.rm(root, { recursive: true, force: true });
+	}
 });
 
 test("a broker that lost the root refuses queued startups instead of spawning children", async () => {

--- a/packages/coding-agent/test/sdk-broker-startup-admission.test.ts
+++ b/packages/coding-agent/test/sdk-broker-startup-admission.test.ts
@@ -1,13 +1,21 @@
 import { expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { AcpSdkAdapter } from "../src/sdk/acp";
 import {
 	Broker,
 	StartupAdmissionQueue,
 	type StartupAdmissionTiming,
 	sdkHostStartupConcurrency,
+	setAmbiguityGraceForTest,
+	setPublicationObservationForTest,
 } from "../src/sdk/broker/broker";
-import { deriveLifecycleDeadlines, setLifecycleTimingForTest } from "../src/sdk/broker/lifecycle";
+import {
+	deriveLifecycleDeadlines,
+	setLifecycleCommandResolverForTest,
+	setLifecycleTimingForTest,
+} from "../src/sdk/broker/lifecycle";
+import { startupQueueWaitMs } from "../src/sdk/broker/startup-budget";
 import { normalizeSdkStartupFailure } from "../src/sdk/startup-capability";
 
 function controlledTiming(now: () => number): {
@@ -26,6 +34,19 @@ function controlledTiming(now: () => number): {
 		},
 		sleeps,
 	};
+}
+
+/** Records the request deadline the ACP caller actually grants a lifecycle startup. */
+class TimeoutCapturingSdkClient {
+	timeoutMs: number | undefined;
+	async global(
+		_operation: string,
+		_input: Record<string, unknown>,
+		options?: { timeoutMs?: number },
+	): Promise<{ ok: true }> {
+		this.timeoutMs = options?.timeoutMs;
+		return { ok: true };
+	}
 }
 
 test("SDK host startup concurrency scales sublinearly with observable CPU parallelism", () => {
@@ -189,4 +210,140 @@ test("broker validates before admission and maps bounded queue waits honestly", 
 		await broker.stop();
 		await fs.rm(agentDir, { recursive: true, force: true });
 	}
+});
+
+test("closing the startup queue refuses its waiters instead of granting or stranding them", async () => {
+	const queue = new StartupAdmissionQueue(1);
+	const release = Promise.withResolvers<void>();
+	const { timing, sleeps } = controlledTiming(() => 1_000);
+	let queuedTaskRuns = 0;
+	const holder = queue.run(4_000, timing, async () => {
+		await release.promise;
+	});
+	const queued = queue.run(4_000, timing, async () => {
+		queuedTaskRuns += 1;
+	});
+	await Promise.resolve();
+	expect(sleeps).toHaveLength(1);
+
+	queue.close();
+	expect(await queued).toEqual({ status: "admission_refused", reason: "admission_refused" });
+
+	release.resolve();
+	await holder;
+	expect(queuedTaskRuns).toBe(0);
+
+	// A free slot must not resurrect a closed queue either.
+	expect(
+		await queue.run(4_000, timing, async () => {
+			queuedTaskRuns += 1;
+		}),
+	).toEqual({ status: "admission_refused", reason: "admission_refused" });
+	expect(queuedTaskRuns).toBe(0);
+});
+
+test("a broker that lost the root refuses queued startups instead of spawning children", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-lost-root-admission-"));
+	const agentDir = path.join(root, "agent");
+	const previousCommand = process.env.GJC_SDK_SESSION_COMMAND;
+	// A short TTL drives the publication watchdog at `ttl/3`, so the fence lands fast.
+	const broker = new Broker({ agentDir, heartbeatTtlMs: 300 });
+	const release = Promise.withResolvers<void>();
+	const parked: StartupAdmissionTiming = { now: Date.now, sleep: () => Promise.withResolvers<void>().promise };
+	const queuedInAdmission = Promise.withResolvers<void>();
+	let brokerCompleted = false;
+	let spawnPathEnteredAfterCompletion = 0;
+	try {
+		delete process.env.GJC_SDK_SESSION_COMMAND;
+		await broker.start();
+		setLifecycleCommandResolverForTest(broker, () => {
+			if (brokerCompleted) spawnPathEnteredAfterCompletion += 1;
+			throw new Error("SDK internal launch refused: fenced broker must not spawn.");
+		});
+		// Hold every startup slot so the lifecycle request has to queue behind them.
+		const holders = Array.from({ length: sdkHostStartupConcurrency() }, () =>
+			broker.runStartup(4_000, parked, async () => {
+				await release.promise;
+			}),
+		);
+		await Promise.resolve();
+		// The queued request may only be woken by the drain, never by its own cutoff.
+		setLifecycleTimingForTest(broker, {
+			now: Date.now,
+			sleep: () => {
+				queuedInAdmission.resolve();
+				return Promise.withResolvers<void>().promise;
+			},
+		});
+		const queued = broker.handleRequest(
+			"session.create",
+			{ cwd: root, stateRoot: path.join(root, ".gjc", "state"), readinessTimeoutMs: 4_000 },
+			"queued-behind-lost-root",
+		);
+		await queuedInAdmission.promise;
+
+		// Fence the broker past its bounded ambiguity deadline so it completes as lost-root.
+		setAmbiguityGraceForTest(broker, 1);
+		setPublicationObservationForTest(broker, "ambiguous");
+		await broker.completion;
+		brokerCompleted = true;
+
+		// Slots only free up once the fenced broker is already gone.
+		release.resolve();
+		await Promise.all(holders);
+
+		expect(await queued).toEqual({
+			ok: false,
+			error: {
+				code: "startup_admission_refused",
+				message: "SDK host startup was refused because the broker no longer owns the session root.",
+			},
+		});
+		expect(spawnPathEnteredAfterCompletion).toBe(0);
+	} finally {
+		setLifecycleCommandResolverForTest(broker, undefined);
+		setLifecycleTimingForTest(broker, undefined);
+		setPublicationObservationForTest(broker, undefined);
+		setAmbiguityGraceForTest(broker, undefined);
+		if (previousCommand === undefined) delete process.env.GJC_SDK_SESSION_COMMAND;
+		else process.env.GJC_SDK_SESSION_COMMAND = previousCommand;
+		release.resolve();
+		await broker.stop().catch(() => undefined);
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}, 15_000);
+
+test("the ACP caller deadline covers admission wait, not only the readiness budget", async () => {
+	const readinessTimeoutMs = 4_000;
+	const sdk = new TimeoutCapturingSdkClient();
+	const adapter = new AcpSdkAdapter({ url: "ws://unused", token: "secret", client: sdk as never });
+	await adapter.global("session.create", { cwd: "/workspace", readinessTimeoutMs }, "late-admission");
+	const callerDeadlineMs = sdk.timeoutMs;
+	if (callerDeadlineMs === undefined) throw new Error("ACP caller did not bound the lifecycle request.");
+
+	// The broker parks the request, then starts the readiness clock at admission, so its
+	// terminal instant is measured from `admittedAt` and not from when the caller sent it.
+	let now = 0;
+	const queue = new StartupAdmissionQueue(1);
+	const release = Promise.withResolvers<void>();
+	const { timing } = controlledTiming(() => now);
+	const holder = queue.run(startupQueueWaitMs(readinessTimeoutMs), timing, () => release.promise);
+	const queued = queue.run(startupQueueWaitMs(readinessTimeoutMs), timing, async admittedAt =>
+		deriveLifecycleDeadlines(admittedAt, readinessTimeoutMs),
+	);
+	await Promise.resolve();
+
+	now = 3_700;
+	release.resolve();
+	const admitted = await queued;
+	await holder;
+	if (admitted.status !== "completed") throw new Error(`expected a late admission, got ${admitted.status}.`);
+	expect(admitted.value.receivedAt).toBe(3_700);
+	expect(admitted.value.lifecycleCleanupDeadlineAt).toBe(7_700);
+
+	// The broker runs to that instant and persists a terminal result there, so a caller
+	// that stopped listening earlier abandons a request that is still going to finish.
+	expect(admitted.value.lifecycleCleanupDeadlineAt).toBeLessThanOrEqual(callerDeadlineMs);
+	// Worst case: admitted at the very edge of the queue wait.
+	expect(callerDeadlineMs).toBeGreaterThanOrEqual(startupQueueWaitMs(readinessTimeoutMs) + readinessTimeoutMs);
 });

--- a/packages/coding-agent/test/sdk-broker-startup-admission.test.ts
+++ b/packages/coding-agent/test/sdk-broker-startup-admission.test.ts
@@ -246,6 +246,111 @@ test("closing the startup queue refuses its waiters instead of granting or stran
 	expect(queuedTaskRuns).toBe(0);
 });
 
+test("closing after grant but before task execution refuses the admitted startup", async () => {
+	const queue = new StartupAdmissionQueue(1);
+	const release = Promise.withResolvers<void>();
+	let nowCalls = 0;
+	let queuedTaskRuns = 0;
+	const timing: StartupAdmissionTiming = {
+		now: () => {
+			nowCalls += 1;
+			if (nowCalls === 2) queue.close();
+			return 1_000;
+		},
+		sleep: () => Promise.withResolvers<void>().promise,
+	};
+	const holder = queue.run(4_000, timing, async () => {
+		await release.promise;
+	});
+	const queued = queue.run(4_000, timing, async () => {
+		queuedTaskRuns += 1;
+	});
+	await Promise.resolve();
+
+	release.resolve();
+	await holder;
+
+	expect(await queued).toEqual({ status: "admission_refused", reason: "admission_refused" });
+	expect(queuedTaskRuns).toBe(0);
+});
+
+async function expectGraceWindowFenceRefusesQueuedStartup(observation: "replaced" | "ambiguous"): Promise<void> {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", `gjc-${observation}-fence-admission-`));
+	const agentDir = path.join(root, "agent");
+	const previousCommand = process.env.GJC_SDK_SESSION_COMMAND;
+	const broker = new Broker({ agentDir, heartbeatTtlMs: 300 });
+	const release = Promise.withResolvers<void>();
+	const parked: StartupAdmissionTiming = { now: Date.now, sleep: () => Promise.withResolvers<void>().promise };
+	const queuedInAdmission = Promise.withResolvers<void>();
+	let spawnCalls = 0;
+	try {
+		delete process.env.GJC_SDK_SESSION_COMMAND;
+		await broker.start();
+		if (observation === "ambiguous") setAmbiguityGraceForTest(broker, 60_000);
+		setLifecycleCommandResolverForTest(broker, () => {
+			spawnCalls += 1;
+			throw new Error("SDK internal launch refused: fenced broker must not spawn.");
+		});
+		const holders = Array.from({ length: sdkHostStartupConcurrency() }, () =>
+			broker.runStartup(4_000, parked, async () => {
+				await release.promise;
+			}),
+		);
+		await Promise.resolve();
+		setLifecycleTimingForTest(broker, {
+			now: Date.now,
+			sleep: () => {
+				queuedInAdmission.resolve();
+				return Promise.withResolvers<void>().promise;
+			},
+		});
+		const queued = broker.handleRequest(
+			"session.create",
+			{ cwd: root, stateRoot: path.join(root, ".gjc", "state"), readinessTimeoutMs: 4_000 },
+			`queued-during-${observation}-fence`,
+		);
+		await queuedInAdmission.promise;
+
+		setPublicationObservationForTest(broker, observation);
+		const fenceDeadline = Date.now() + 2_000;
+		let listResponse = await broker.handleRequest("session.list", {});
+		while ((listResponse.ok || listResponse.error.code !== "unavailable") && Date.now() < fenceDeadline) {
+			await Bun.sleep(10);
+			listResponse = await broker.handleRequest("session.list", {});
+		}
+		expect(listResponse).toMatchObject({ ok: false, error: { code: "unavailable" } });
+
+		release.resolve();
+		await Promise.all(holders);
+		expect(await queued).toEqual({
+			ok: false,
+			error: {
+				code: "startup_admission_refused",
+				message: "SDK host startup was refused because the broker no longer owns the session root.",
+			},
+		});
+		expect(spawnCalls).toBe(0);
+	} finally {
+		setLifecycleCommandResolverForTest(broker, undefined);
+		setLifecycleTimingForTest(broker, undefined);
+		setPublicationObservationForTest(broker, undefined);
+		setAmbiguityGraceForTest(broker, undefined);
+		if (previousCommand === undefined) delete process.env.GJC_SDK_SESSION_COMMAND;
+		else process.env.GJC_SDK_SESSION_COMMAND = previousCommand;
+		release.resolve();
+		await broker.stop().catch(() => undefined);
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}
+
+test("suspect-unpublished fence refuses queued startup before loss grace expires", async () => {
+	await expectGraceWindowFenceRefusesQueuedStartup("replaced");
+});
+
+test("observation-ambiguous fence refuses queued startup before ambiguity grace expires", async () => {
+	await expectGraceWindowFenceRefusesQueuedStartup("ambiguous");
+});
+
 test("a broker that lost the root refuses queued startups instead of spawning children", async () => {
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-lost-root-admission-"));
 	const agentDir = path.join(root, "agent");

--- a/packages/coding-agent/test/sdk-broker-startup-admission.test.ts
+++ b/packages/coding-agent/test/sdk-broker-startup-admission.test.ts
@@ -16,6 +16,7 @@ import {
 	setLifecycleTimingForTest,
 } from "../src/sdk/broker/lifecycle";
 import {
+	cancellableSleep,
 	DEFAULT_READINESS_TIMEOUT_MS,
 	lifecycleStartupBudgetMs,
 	startupQueueWaitMs,
@@ -607,3 +608,97 @@ test("a default startup admitted late by the production broker stays inside the 
 		await fs.rm(root, { recursive: true, force: true });
 	}
 }, 15_000);
+
+test("a refused waiter cancels the queue-wait cutoff it no longer needs", async () => {
+	const queue = new StartupAdmissionQueue(1);
+	const release = Promise.withResolvers<void>();
+	const cutoffs: Array<AbortSignal | undefined> = [];
+	const timing: StartupAdmissionTiming = {
+		now: () => 1_000,
+		sleep: (_ms, signal) => {
+			cutoffs.push(signal);
+			return Promise.withResolvers<void>().promise;
+		},
+	};
+	const holder = queue.run(4_000, timing, () => release.promise);
+	const queued = queue.run(4_000, timing, async () => "queued");
+	await Promise.resolve();
+
+	// While the waiter is still queued its cutoff is the only thing that can end the wait.
+	expect(cutoffs).toHaveLength(1);
+	expect(cutoffs[0]?.aborted).toBe(false);
+
+	queue.close();
+	expect(await queued).toEqual({ status: "admission_refused", reason: "admission_refused" });
+	// A refusal is terminal, so the cutoff must not outlive it holding a timer that could
+	// run for the rest of the queue-wait budget.
+	expect(cutoffs[0]?.aborted).toBe(true);
+
+	release.resolve();
+	await holder;
+});
+
+test("the production queue-wait sleep ends with its cutoff instead of its duration", async () => {
+	const cutoff = new AbortController();
+	let settled = false;
+	const sleeping = cancellableSleep(600_000, cutoff.signal).then(() => {
+		settled = true;
+	});
+	await Bun.sleep(5);
+	expect(settled).toBe(false);
+
+	cutoff.abort();
+	await sleeping;
+	expect(settled).toBe(true);
+
+	// An already-cancelled cutoff never arms a timer at all.
+	const cancelled = new AbortController();
+	cancelled.abort();
+	await cancellableSleep(600_000, cancelled.signal);
+});
+
+test("the ACP caller deadline follows a supplied lifecycle deadline tuple, not the field it overrides", async () => {
+	const receivedAt = 1_000_000;
+	const tuple = deriveLifecycleDeadlines(receivedAt, 30_000);
+
+	// The broker sizes both the admission wait and the readiness window from the tuple and
+	// ignores `readinessTimeoutMs` entirely, so budgeting the overridden field would cut the
+	// caller off long before the broker reaches its own terminal.
+	const supplied = new TimeoutCapturingSdkClient();
+	await new AcpSdkAdapter({ url: "ws://unused", token: "secret", client: supplied as never }).global(
+		"session.create",
+		{ cwd: "/workspace", readinessTimeoutMs: 4_000, ...tuple },
+		"supplied-deadline-tuple",
+	);
+	expect(supplied.timeoutMs).toBe(lifecycleStartupBudgetMs(30_000) + 1_000);
+
+	// A close carries no admission wait, so it is budgeted on the tuple's readiness alone.
+	const closing = new TimeoutCapturingSdkClient();
+	await new AcpSdkAdapter({ url: "ws://unused", token: "secret", client: closing as never }).global(
+		"session.close",
+		{ sessionId: "s", ...tuple },
+		"closing-deadline-tuple",
+	);
+	expect(closing.timeoutMs).toBe(31_000);
+});
+
+test("the ACP caller leaves an unbudgetable lifecycle request on the generic client deadline", async () => {
+	// A partial tuple conflicts with the broker's all-or-nothing deadline contract, and an
+	// out-of-range readiness value is out of contract on its own. Both are refused as invalid
+	// input before anything is queued, so neither may claim a startup-sized caller deadline.
+	const partial = new TimeoutCapturingSdkClient();
+	await new AcpSdkAdapter({ url: "ws://unused", token: "secret", client: partial as never }).global(
+		"session.create",
+		{ cwd: "/workspace", receivedAt: 1_000_000, requestedReadinessTimeoutMs: 30_000 },
+		"partial-deadline-tuple",
+	);
+	expect(partial.timeoutMs).toBeUndefined();
+
+	const outOfRange = new TimeoutCapturingSdkClient();
+	await new AcpSdkAdapter({ url: "ws://unused", token: "secret", client: outOfRange as never }).global(
+		"session.create",
+		{ cwd: "/workspace", readinessTimeoutMs: 600_000 },
+		"out-of-range-readiness",
+	);
+	expect(outOfRange.timeoutMs).toBeUndefined();
+});

--- a/packages/coding-agent/test/sdk-broker-startup-admission.test.ts
+++ b/packages/coding-agent/test/sdk-broker-startup-admission.test.ts
@@ -15,7 +15,11 @@ import {
 	setLifecycleCommandResolverForTest,
 	setLifecycleTimingForTest,
 } from "../src/sdk/broker/lifecycle";
-import { startupQueueWaitMs } from "../src/sdk/broker/startup-budget";
+import {
+	DEFAULT_READINESS_TIMEOUT_MS,
+	lifecycleStartupBudgetMs,
+	startupQueueWaitMs,
+} from "../src/sdk/broker/startup-budget";
 import { normalizeSdkStartupFailure } from "../src/sdk/startup-capability";
 
 function controlledTiming(now: () => number): {
@@ -313,37 +317,188 @@ test("a broker that lost the root refuses queued startups instead of spawning ch
 	}
 }, 15_000);
 
-test("the ACP caller deadline covers admission wait, not only the readiness budget", async () => {
-	const readinessTimeoutMs = 4_000;
-	const sdk = new TimeoutCapturingSdkClient();
-	const adapter = new AcpSdkAdapter({ url: "ws://unused", token: "secret", client: sdk as never });
-	await adapter.global("session.create", { cwd: "/workspace", readinessTimeoutMs }, "late-admission");
-	const callerDeadlineMs = sdk.timeoutMs;
-	if (callerDeadlineMs === undefined) throw new Error("ACP caller did not bound the lifecycle request.");
-
-	// The broker parks the request, then starts the readiness clock at admission, so its
-	// terminal instant is measured from `admittedAt` and not from when the caller sent it.
-	let now = 0;
-	const queue = new StartupAdmissionQueue(1);
+test("a stop that cannot prove it still owns the root drains the queued startups", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-unproven-stop-"));
+	const agentDir = path.join(root, "agent");
+	const previousCommand = process.env.GJC_SDK_SESSION_COMMAND;
+	const broker = new Broker({ agentDir });
 	const release = Promise.withResolvers<void>();
-	const { timing } = controlledTiming(() => now);
-	const holder = queue.run(startupQueueWaitMs(readinessTimeoutMs), timing, () => release.promise);
-	const queued = queue.run(startupQueueWaitMs(readinessTimeoutMs), timing, async admittedAt =>
-		deriveLifecycleDeadlines(admittedAt, readinessTimeoutMs),
+	const parked: StartupAdmissionTiming = { now: Date.now, sleep: () => Promise.withResolvers<void>().promise };
+	const queuedInAdmission = Promise.withResolvers<void>();
+	let spawnCalls = 0;
+	try {
+		delete process.env.GJC_SDK_SESSION_COMMAND;
+		await broker.start();
+		setLifecycleCommandResolverForTest(broker, () => {
+			spawnCalls += 1;
+			throw new Error("SDK internal launch refused: a broker that lost the root must not spawn.");
+		});
+		// Hold every startup slot so the lifecycle request has to queue behind them.
+		const holders = Array.from({ length: sdkHostStartupConcurrency() }, () =>
+			broker.runStartup(4_000, parked, async () => {
+				await release.promise;
+			}),
+		);
+		await Promise.resolve();
+		// The queued request may only be woken by a drain, never by its own cutoff.
+		setLifecycleTimingForTest(broker, {
+			now: Date.now,
+			sleep: () => {
+				queuedInAdmission.resolve();
+				return Promise.withResolvers<void>().promise;
+			},
+		});
+		const queued = broker.handleRequest(
+			"session.create",
+			{ cwd: root, stateRoot: path.join(root, ".gjc", "state"), readinessTimeoutMs: 4_000 },
+			"queued-behind-replaced-root",
+		);
+		await queuedInAdmission.promise;
+
+		// A replacement already owns the published root. The watchdog runs on a 5s cadence
+		// and has not observed it, so the broker's cached publication state is still healthy
+		// and only a fresh observation can tell the stop what it may still claim.
+		setPublicationObservationForTest(broker, "replaced");
+		const stopped = broker.stop();
+
+		// Slots only free up once the stop has already decided what it owns.
+		release.resolve();
+		await Promise.all(holders);
+		expect(await queued).toEqual({
+			ok: false,
+			error: {
+				code: "startup_admission_refused",
+				message: "SDK host startup was refused because the broker no longer owns the session root.",
+			},
+		});
+		expect(spawnCalls).toBe(0);
+		await stopped;
+
+		// A drained queue refuses every later startup, so a restart must not inherit it.
+		setPublicationObservationForTest(broker, undefined);
+		await broker.start();
+		const restarted = await broker.runStartup(
+			4_000,
+			{ now: Date.now, sleep: async () => undefined },
+			async () => "ready",
+		);
+		if (restarted.status !== "completed") throw new Error(`restart refused its own startup: ${restarted.status}.`);
+		expect(restarted.value).toBe("ready");
+	} finally {
+		setLifecycleCommandResolverForTest(broker, undefined);
+		setLifecycleTimingForTest(broker, undefined);
+		setPublicationObservationForTest(broker, undefined);
+		if (previousCommand === undefined) delete process.env.GJC_SDK_SESSION_COMMAND;
+		else process.env.GJC_SDK_SESSION_COMMAND = previousCommand;
+		release.resolve();
+		await broker.stop().catch(() => undefined);
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}, 15_000);
+
+test("the ACP caller deadline covers the admission wait even when readiness is defaulted", async () => {
+	const defaulted = new TimeoutCapturingSdkClient();
+	await new AcpSdkAdapter({ url: "ws://unused", token: "secret", client: defaulted as never }).global(
+		"session.create",
+		{ cwd: "/workspace" },
+		"defaulted-readiness",
 	);
-	await Promise.resolve();
+	expect(defaulted.timeoutMs).toBe(lifecycleStartupBudgetMs(DEFAULT_READINESS_TIMEOUT_MS) + 1_000);
 
-	now = 3_700;
-	release.resolve();
-	const admitted = await queued;
-	await holder;
-	if (admitted.status !== "completed") throw new Error(`expected a late admission, got ${admitted.status}.`);
-	expect(admitted.value.receivedAt).toBe(3_700);
-	expect(admitted.value.lifecycleCleanupDeadlineAt).toBe(7_700);
+	const requested = new TimeoutCapturingSdkClient();
+	await new AcpSdkAdapter({ url: "ws://unused", token: "secret", client: requested as never }).global(
+		"session.create",
+		{ cwd: "/workspace", readinessTimeoutMs: 4_000 },
+		"requested-readiness",
+	);
+	expect(requested.timeoutMs).toBe(lifecycleStartupBudgetMs(4_000) + 1_000);
 
-	// The broker runs to that instant and persists a terminal result there, so a caller
-	// that stopped listening earlier abandons a request that is still going to finish.
-	expect(admitted.value.lifecycleCleanupDeadlineAt).toBeLessThanOrEqual(callerDeadlineMs);
-	// Worst case: admitted at the very edge of the queue wait.
-	expect(callerDeadlineMs).toBeGreaterThanOrEqual(startupQueueWaitMs(readinessTimeoutMs) + readinessTimeoutMs);
+	// An operation that never queues for a startup slot keeps its own readiness sizing.
+	const closing = new TimeoutCapturingSdkClient();
+	await new AcpSdkAdapter({ url: "ws://unused", token: "secret", client: closing as never }).global(
+		"session.close",
+		{ sessionId: "s", readinessTimeoutMs: 4_000 },
+		"closing",
+	);
+	expect(closing.timeoutMs).toBe(5_000);
 });
+
+test("a default startup admitted late by the production broker stays inside the ACP caller deadline", async () => {
+	const sdk = new TimeoutCapturingSdkClient();
+	await new AcpSdkAdapter({ url: "ws://unused", token: "secret", client: sdk as never }).global(
+		"session.create",
+		{ cwd: "/workspace" },
+		"default-late-admission",
+	);
+	const callerDeadlineMs = sdk.timeoutMs;
+	if (callerDeadlineMs === undefined) throw new Error("ACP caller did not bound the default lifecycle request.");
+
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-late-admission-"));
+	const agentDir = path.join(root, "agent");
+	const previousCommand = process.env.GJC_SDK_SESSION_COMMAND;
+	const broker = new Broker({ agentDir });
+	const release = Promise.withResolvers<void>();
+	const parked: StartupAdmissionTiming = { now: Date.now, sleep: () => Promise.withResolvers<void>().promise };
+	const admissionParked = Promise.withResolvers<void>();
+	const receivedAt = 1_000_000;
+	let now = receivedAt;
+	let observedQueueWaitMs: number | undefined;
+	let spawnCalls = 0;
+	try {
+		delete process.env.GJC_SDK_SESSION_COMMAND;
+		await broker.start();
+		setLifecycleCommandResolverForTest(broker, () => {
+			spawnCalls += 1;
+			throw new Error("SDK internal launch refused: this test only needs to reach the spawn seam.");
+		});
+		const holders = Array.from({ length: sdkHostStartupConcurrency() }, () =>
+			broker.runStartup(startupQueueWaitMs(DEFAULT_READINESS_TIMEOUT_MS), parked, async () => {
+				await release.promise;
+			}),
+		);
+		await Promise.resolve();
+		setLifecycleTimingForTest(broker, {
+			now: () => now,
+			sleep: ms => {
+				observedQueueWaitMs ??= ms;
+				admissionParked.resolve();
+				return Promise.withResolvers<void>().promise;
+			},
+		});
+		// No `readinessTimeoutMs`: the default request every ACP caller sends.
+		const queued = broker.handleRequest(
+			"session.create",
+			{ cwd: root, stateRoot: path.join(root, ".gjc", "state") },
+			"default-late-admission",
+		);
+		await admissionParked.promise;
+		expect(observedQueueWaitMs).toBe(startupQueueWaitMs(DEFAULT_READINESS_TIMEOUT_MS));
+
+		// Admit at the last instant the queue allows.
+		const admittedAt = receivedAt + startupQueueWaitMs(DEFAULT_READINESS_TIMEOUT_MS) - 1;
+		now = admittedAt;
+		release.resolve();
+		await Promise.all(holders);
+		const response = await queued;
+
+		// Reaching the spawn seam here proves readiness is granted fresh at admission:
+		// measured from arrival the readiness deadline had already passed, and the broker
+		// would have returned `readiness_timeout` before resolving any command.
+		expect(spawnCalls).toBe(1);
+		expect(response).toMatchObject({ ok: false, error: { code: "spawn_failed" } });
+
+		// So the broker's own terminal instant for this admission, derived by the same
+		// function its startup path uses, must still fit inside the deadline the ACP caller
+		// granted the identical default request.
+		const terminalAt = deriveLifecycleDeadlines(admittedAt, DEFAULT_READINESS_TIMEOUT_MS).lifecycleCleanupDeadlineAt;
+		expect(terminalAt - receivedAt).toBeLessThanOrEqual(callerDeadlineMs);
+	} finally {
+		setLifecycleCommandResolverForTest(broker, undefined);
+		setLifecycleTimingForTest(broker, undefined);
+		if (previousCommand === undefined) delete process.env.GJC_SDK_SESSION_COMMAND;
+		else process.env.GJC_SDK_SESSION_COMMAND = previousCommand;
+		release.resolve();
+		await broker.stop().catch(() => undefined);
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}, 15_000);

--- a/packages/coding-agent/test/sdk-broker.test.ts
+++ b/packages/coding-agent/test/sdk-broker.test.ts
@@ -865,6 +865,37 @@ describe("SDK broker identity and discovery", () => {
 			await fs.rm(dir, { recursive: true, force: true });
 		}
 	});
+	it("recovers request admission synchronously with the watchdog observation, not after the heartbeat write", async () => {
+		// Regression: #watchPublication must restore the cached publicationState
+		// before the awaited heartbeat IO so a request that follows the watchdog
+		// in the same async tick sees healthy ownership without an extra sleep.
+		const dir = await temp();
+		let watchdog: (() => void) | undefined;
+		const realSetInterval = globalThis.setInterval;
+		const interval = vi.spyOn(globalThis, "setInterval").mockImplementation(((callback: () => void) => {
+			watchdog = callback;
+			return realSetInterval(() => {}, 2 ** 31 - 1);
+		}) as typeof setInterval);
+		const broker = new Broker({ agentDir: dir });
+		try {
+			await broker.start();
+
+			const retainedRoot = path.join(dir, "retained-sdk");
+			await fs.rename(path.join(dir, "sdk"), retainedRoot);
+			watchdog!();
+			await new Promise(r => setTimeout(r, 10));
+			expect(await broker.handleRequest("session.list", {})).toMatchObject({ ok: false });
+
+			await fs.rename(retainedRoot, path.join(dir, "sdk"));
+			// No sleep, no extra microtask drain between the watchdog and the request.
+			watchdog!();
+			expect(await broker.handleRequest("session.list", {})).toMatchObject({ ok: true });
+		} finally {
+			interval.mockRestore();
+			await broker.stop();
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
 	it("terminates and reaps the spawned broker when discovery times out", async () => {
 		const dir = await temp();
 		// Force ensureBroker's discovery reads to never resolve a live record so the

--- a/packages/coding-agent/test/sdk-mcp-adapter.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-adapter.test.ts
@@ -2,6 +2,7 @@ import { afterEach, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import path from "node:path";
+import { Broker } from "../src/sdk/broker/broker";
 import { brokerProcessIncarnation } from "../src/sdk/broker/discovery";
 import { brokerOwnerForTest } from "../src/sdk/broker/ensure";
 import { createSdkMcpServer } from "../src/sdk/mcp";
@@ -120,6 +121,30 @@ test("MCP lifecycle responses never expose broker endpoint credentials", async (
 	});
 	expect(result).toEqual({ ok: true, result: { sessionId: "created-session" } });
 	expect(JSON.stringify(result)).not.toContain("secret");
+});
+
+test("MCP invalid readiness budgets reach broker validation before client deadlines", async () => {
+	const repo = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-mcp-invalid-readiness-"));
+	dirs.push(repo);
+	const agentDir = path.join(repo, "agent");
+	const broker = new Broker({ agentDir });
+	await broker.start();
+	try {
+		const result = await createSdkMcpServer({ repo, agentDir }).callTool("gjc_session_global", {
+			operation: "session.create",
+			input: { cwd: repo, readinessTimeoutMs: -1_000 },
+			idempotencyKey: "invalid-readiness",
+		});
+		expect(result).toEqual({
+			ok: false,
+			error: {
+				code: "invalid_input",
+				message: "readinessTimeoutMs must be an integer between 4000 and 60000.",
+			},
+		});
+	} finally {
+		await broker.stop();
+	}
 });
 
 test("MCP global schema exposes and requires caller lifecycle idempotency keys", async () => {

--- a/packages/coding-agent/test/sdk-mcp-adapter.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-adapter.test.ts
@@ -123,25 +123,36 @@ test("MCP lifecycle responses never expose broker endpoint credentials", async (
 	expect(JSON.stringify(result)).not.toContain("secret");
 });
 
-test("MCP invalid readiness budgets reach broker validation before client deadlines", async () => {
-	const repo = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-mcp-invalid-readiness-"));
+test("MCP forwards the lifecycle startup budget to the broker client deadline", async () => {
+	const repo = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-mcp-startup-budget-"));
 	dirs.push(repo);
 	const agentDir = path.join(repo, "agent");
 	const broker = new Broker({ agentDir });
+	let forwardedTimeoutMs: number | undefined;
 	await broker.start();
 	try {
-		const result = await createSdkMcpServer({ repo, agentDir }).callTool("gjc_session_global", {
+		const result = await createSdkMcpServer({
+			repo,
+			agentDir,
+			connect: async () =>
+				({
+					global: async (
+						_operation: string,
+						_input: Record<string, unknown>,
+						options?: { timeoutMs?: number },
+					) => {
+						forwardedTimeoutMs = options?.timeoutMs;
+						return { ok: true, result: { sessionId: "created-session" } };
+					},
+					close: async () => {},
+				}) as never,
+		}).callTool("gjc_session_global", {
 			operation: "session.create",
-			input: { cwd: repo, readinessTimeoutMs: -1_000 },
-			idempotencyKey: "invalid-readiness",
+			input: { cwd: repo, readinessTimeoutMs: 4_000 },
+			idempotencyKey: "forward-startup-budget",
 		});
-		expect(result).toEqual({
-			ok: false,
-			error: {
-				code: "invalid_input",
-				message: "readinessTimeoutMs must be an integer between 4000 and 60000.",
-			},
-		});
+		expect(result).toEqual({ ok: true, result: { sessionId: "created-session" } });
+		expect(forwardedTimeoutMs).toBe(9_000);
 	} finally {
 		await broker.stop();
 	}


### PR DESCRIPTION
Follow-up to #4060, which was merged without a review verdict. A post-merge audit (#4063) found two defects in it; this fixes both.

## The queue could not let go

`StartupAdmissionQueue` had no drain path. `#waiters` was appended to, spliced by a per-waiter timeout, and shifted on grant — nothing cleared it when the broker stopped. A broker fenced into `lost-root` still granted the startups queued behind it and spawned children over a root it no longer owned.

`close()` now refuses every waiter with an explicit outcome, so none is silently granted or left pending, and `admit()` refuses immediately once closed.

`owned-root` stop deliberately keeps the queue open. That broker still owns everything it admitted and its completion waits for those startups, so draining there would abandon work that is about to finish correctly. The distinction is commented at the call site.

## The wait was not paid for

Admission time was added to a request's total latency while the caller's deadline was still sized against `readinessTimeoutMs` alone. A startup admitted late could be failed client-side while the broker ran it through to a durably persisted terminal result — a split-brain between what the client believes and what the broker recorded.

`startup-budget.ts` makes the coupling explicit: the queue wait is the readiness budget, and a caller's deadline is the wait plus the budget. The readiness budget is granted fresh at admission, so queueing never shortens it.

## Verification

```
bun test sdk-broker-startup-admission.test.ts sdk-broker.test.ts sdk-broker-publication-fence.test.ts
  74 pass, 0 fail
bun --cwd=packages/coding-agent run check
  exit 0
```

Load-bearing proof — reverting only `broker.ts` and re-running:

```
(fail) closing the startup queue refuses its waiters instead of granting or stranding them
(fail) a broker that lost the root refuses queued startups instead of spawning children
  8 pass, 2 fail
```

## Note on #4015

`bd80cbcf5` (#4060) is the only commit on `dev` touching #4015's files since its merge-base, and it is what turned that PR DIRTY. A trial merge conflicts only on the changelog; `broker.ts` auto-merges. If #4015 is the authoritative broker-startup repair, reverting #4060 may be cleaner than stacking this on top — I will follow whichever the maintainer prefers.