### PR TITLE
fix(acp): reject unknown command flags

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -80,6 +80,14 @@ function isStartupLoginCommandArg(args: readonly string[], index: number): boole
 	return argumentCount === 0 || (argumentCount === 1 && !args[index + 1].startsWith("-"));
 }
 
+function takeFlagValue(args: readonly string[], index: number, flag: string, allowDashPrefixed = false): string {
+	const value = args[index + 1];
+	if (!value || (!allowDashPrefixed && value.startsWith("-"))) {
+		throw new CliParseError(`${flag} requires a value`);
+	}
+	return value;
+}
+
 export function parseArgs(args: string[]): Args {
 	const result: Args = {
 		messages: [],
@@ -89,6 +97,7 @@ export function parseArgs(args: string[]): Args {
 
 	for (let i = 0; i < args.length; i++) {
 		let arg = args[i];
+		let hasInlineValue = false;
 
 		if (isStartupLoginCommandArg(args, i)) {
 			result.authBootstrap = true;
@@ -106,6 +115,7 @@ export function parseArgs(args: string[]): Args {
 			const eqIdx = arg.indexOf("=");
 			const value = arg.slice(eqIdx + 1);
 			arg = arg.slice(0, eqIdx);
+			hasInlineValue = true;
 			// Insert the value so the existing "args[++i]" logic picks it up
 			args.splice(i + 1, 0, value);
 		}
@@ -116,8 +126,9 @@ export function parseArgs(args: string[]): Args {
 			result.version = true;
 		} else if (arg === "--allow-home") {
 			result.allowHome = true;
-		} else if (arg === "--mode" && i + 1 < args.length) {
-			const mode = args[++i];
+		} else if (arg === "--mode") {
+			const mode = takeFlagValue(args, i, "--mode");
+			i++;
 			if (mode === "text" || mode === "json" || mode === "acp") {
 				result.mode = mode;
 			} else {
@@ -137,34 +148,34 @@ export function parseArgs(args: string[]): Args {
 			} else {
 				result.resume = true;
 			}
-		} else if (arg === "--fork" && i + 1 < args.length) {
-			result.fork = args[++i];
-		} else if (arg === "--provider" && i + 1 < args.length) {
-			result.provider = args[++i];
-		} else if (arg === "--model" && i + 1 < args.length) {
-			result.model = args[++i];
-		} else if (arg === "--smol" && i + 1 < args.length) {
-			result.smol = args[++i];
-		} else if (arg === "--slow" && i + 1 < args.length) {
-			result.slow = args[++i];
-		} else if (arg === "--plan" && i + 1 < args.length) {
-			result.plan = args[++i];
-		} else if (arg === "--mpreset" && i + 1 < args.length) {
-			result.mpreset = args[++i];
+		} else if (arg === "--fork") {
+			result.fork = takeFlagValue(args, i++, "--fork");
+		} else if (arg === "--provider") {
+			result.provider = takeFlagValue(args, i++, "--provider");
+		} else if (arg === "--model") {
+			result.model = takeFlagValue(args, i++, "--model");
+		} else if (arg === "--smol") {
+			result.smol = takeFlagValue(args, i++, "--smol");
+		} else if (arg === "--slow") {
+			result.slow = takeFlagValue(args, i++, "--slow");
+		} else if (arg === "--plan") {
+			result.plan = takeFlagValue(args, i++, "--plan");
+		} else if (arg === "--mpreset") {
+			result.mpreset = takeFlagValue(args, i++, "--mpreset");
 		} else if (arg === "--default") {
 			result.default = true;
-		} else if (arg === "--api-key" && i + 1 < args.length) {
-			result.apiKey = args[++i];
+		} else if (arg === "--api-key") {
+			result.apiKey = takeFlagValue(args, i++, "--api-key");
 		} else if (arg === "--credential") {
 			const next = args[i + 1];
 			if (!next || next.startsWith("-")) {
 				throw new CliParseError("--credential requires <selector>");
 			}
 			result.credential = args[++i];
-		} else if (arg === "--system-prompt" && i + 1 < args.length) {
-			result.systemPrompt = args[++i];
-		} else if (arg === "--append-system-prompt" && i + 1 < args.length) {
-			result.appendSystemPrompt = args[++i];
+		} else if (arg === "--system-prompt") {
+			result.systemPrompt = takeFlagValue(args, i++, "--system-prompt", hasInlineValue);
+		} else if (arg === "--append-system-prompt") {
+			result.appendSystemPrompt = takeFlagValue(args, i++, "--append-system-prompt", hasInlineValue);
 		} else if (arg === "--clipboard-transport") {
 			const next = args[i + 1];
 			if (!next || next.startsWith("-")) {
@@ -196,14 +207,16 @@ export function parseArgs(args: string[]): Args {
 				throw new CliParseError("--mcp-config requires <absolute-path>");
 			}
 			result.mcpConfig = args[++i];
-		} else if (arg === "--provider-session-id" && i + 1 < args.length) {
-			result.providerSessionId = args[++i];
+		} else if (arg === "--provider-session-id") {
+			result.providerSessionId = takeFlagValue(args, i++, "--provider-session-id");
 		} else if (arg === "--no-session") {
 			result.noSession = true;
-		} else if (arg === "--session-dir" && i + 1 < args.length) {
-			result.sessionDir = args[++i];
-		} else if (arg === "--models" && i + 1 < args.length) {
-			result.models = args[++i].split(",").map(s => s.trim());
+		} else if (arg === "--session-dir") {
+			result.sessionDir = takeFlagValue(args, i++, "--session-dir");
+		} else if (arg === "--models") {
+			result.models = takeFlagValue(args, i++, "--models")
+				.split(",")
+				.map(s => s.trim());
 		} else if (arg === "--no-tools") {
 			result.noTools = true;
 		} else if (arg === "--no-lsp") {
@@ -212,8 +225,8 @@ export function parseArgs(args: string[]): Args {
 			result.noPty = true;
 		} else if (arg === "--tmux") {
 			result.tmux = true;
-		} else if (arg === "--tools" && i + 1 < args.length) {
-			const toolNames = args[++i]
+		} else if (arg === "--tools") {
+			const toolNames = takeFlagValue(args, i++, "--tools")
 				.split(",")
 				.map(s => s.trim().toLowerCase())
 				.filter(Boolean);
@@ -248,8 +261,8 @@ export function parseArgs(args: string[]): Args {
 			result.thinking = thinking;
 		} else if (arg === "--print" || arg === "-p") {
 			result.print = true;
-		} else if (arg === "--export" && i + 1 < args.length) {
-			result.export = args[++i];
+		} else if (arg === "--export") {
+			result.export = takeFlagValue(args, i++, "--export");
 		} else if (arg === "--no-rules") {
 			result.noRules = true;
 		} else if (arg === "--no-title") {
@@ -263,7 +276,9 @@ export function parseArgs(args: string[]): Args {
 			}
 		} else if (arg.startsWith("@")) {
 			result.fileArgs.push(arg.slice(1)); // Remove @ prefix
-		} else if (!arg.startsWith("-")) {
+		} else if (arg.startsWith("-")) {
+			result.unknownFlags.set(arg, true);
+		} else {
 			result.messages.push(arg);
 		}
 	}

--- a/packages/coding-agent/src/commands/acp.ts
+++ b/packages/coding-agent/src/commands/acp.ts
@@ -16,6 +16,12 @@ export default class Acp extends Command {
 	async run(): Promise<void> {
 		const { args, terminalAuth } = prepareAcpTerminalAuthArgs(this.argv);
 		const parsed = parseArgs(args);
+		if (parsed.unknownFlags.size > 0) {
+			throw new Error(`Unknown ACP option: ${[...parsed.unknownFlags.keys()].join(", ")}`);
+		}
+		if (terminalAuth && parsed.mode !== undefined) {
+			throw new Error("--acp-terminal-auth only supports --mode acp");
+		}
 		if (!terminalAuth) {
 			parsed.mode = "acp";
 		}

--- a/packages/coding-agent/src/modes/acp/terminal-auth.ts
+++ b/packages/coding-agent/src/modes/acp/terminal-auth.ts
@@ -23,11 +23,11 @@ export function prepareAcpTerminalAuthArgs(rawArgs: readonly string[]): AcpTermi
 	const args: string[] = [];
 	for (let i = 0; i < withoutAuthFlag.length; i++) {
 		const arg = withoutAuthFlag[i];
-		if (arg === "--mode") {
+		if (arg === "--mode" && withoutAuthFlag[i + 1] === "acp") {
 			i++;
 			continue;
 		}
-		if (arg.startsWith("--mode=")) {
+		if (arg === "--mode=acp") {
 			continue;
 		}
 		args.push(arg);

--- a/packages/coding-agent/test/acp-initialize-conformance.test.ts
+++ b/packages/coding-agent/test/acp-initialize-conformance.test.ts
@@ -113,6 +113,14 @@ describe("ACP initialize conformance", () => {
 			args: [],
 			terminalAuth: true,
 		});
+		expect(prepareAcpTerminalAuthArgs([ACP_TERMINAL_AUTH_FLAG, "--mode", "--mpresett"])).toEqual({
+			args: ["--mode", "--mpresett"],
+			terminalAuth: true,
+		});
+		expect(prepareAcpTerminalAuthArgs(["--mode=--mpresett", ACP_TERMINAL_AUTH_FLAG])).toEqual({
+			args: ["--mode=--mpresett"],
+			terminalAuth: true,
+		});
 	});
 
 	it("declares agentInfo.version that matches the published package version", async () => {

--- a/packages/coding-agent/test/acp-startup-options.test.ts
+++ b/packages/coding-agent/test/acp-startup-options.test.ts
@@ -500,6 +500,28 @@ test("ACP fails closed for local-only startup flags while translating model and 
 		"--model could not be resolved to a canonical model ID",
 	);
 });
+
+test("ACP rejects unknown flags instead of silently ignoring them", () => {
+	const parsed = parseArgs(["--mpreset", "codex-medium", "--mpresett"]);
+	expect(parsed.unknownFlags).toEqual(new Map([["--mpresett", true]]));
+	expect(() => resolveAcpStartupOptions(parsed, {})).toThrow("Unsupported under SDK-backed ACP: extension flags");
+});
+
+test("ACP option values cannot consume dash-prefixed unknown flags", () => {
+	for (const args of [
+		["--mpreset", "--mystery"],
+		["--mpreset=--mystery"],
+		["--tools", "--mystery"],
+		["--model", "--mystery"],
+	]) {
+		expect(() => parseArgs(args)).toThrow(/requires a value/);
+	}
+});
+
+test("inline opaque prompt values may start with a dash", () => {
+	expect(parseArgs(["--system-prompt=-literal"]).systemPrompt).toBe("-literal");
+	expect(parseArgs(["--append-system-prompt=-literal"]).appendSystemPrompt).toBe("-literal");
+});
 test("ACP rejects --mcp-config instead of ignoring it", () => {
 	const parsed = parseArgs(["--mcp-config", "/tmp/gjc-mcp.json"]);
 	expect(() => resolveAcpStartupOptions(parsed, {})).toThrow("Unsupported under SDK-backed ACP: --mcp-config");


### PR DESCRIPTION
## Summary
- fail closed when `gjc acp` receives an unrecognized option
- preserve parsed unknown flags so SDK-backed ACP rejects them too
- cover misspelled option parsing and rejection

## Verification
- `bun test packages/coding-agent/test/acp-startup-options.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `bun run dev -- acp --mpresett` exits 1 with `Unknown ACP option: --mpresett`

Fixes #4062