### PR TITLE
fix(sdk): expose sent-request timeout uncertainty

### DIFF
--- a/packages/bridge-client/CHANGELOG.md
+++ b/packages/bridge-client/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- `SdkClient` request-timeout errors now expose `SdkRequestTimeoutDetails`, including whether `WebSocket.send()` returned. A sent request remains execution-uncertain; ordered prompt and skill callers must reconcile through their existing `clientRef` rather than retry.
 
 ## [0.12.19] - 2026-08-08
 

--- a/packages/bridge-client/README.md
+++ b/packages/bridge-client/README.md
@@ -20,6 +20,8 @@ The client adds the endpoint token as a WebSocket query parameter, waits for a s
 
 A request that has been sent is never replayed after reconnect. Callers that need retry semantics must decide whether retrying their operation is safe and provide their own idempotency protocol where appropriate.
 
+For a request timeout, `SdkClientError.details` is an `SdkRequestTimeoutDetails` object. `requestSent: true` means `WebSocket.send()` returned, not that the server accepted or completed the request. Treat it as execution uncertainty: do not resend an ordered `turn.prompt` or `skill.invoke`; retain a fresh `clientRef` before sending and query `turn.prompt_status` or `skill.invoke_status` with that reference.
+
 ## Scope and compatibility
 
 This package is transport-only. It does not import, instantiate, dispatch to, or otherwise own `AgentSession`, broker lifecycle, backend process management, or application operation handlers.

--- a/packages/bridge-client/src/client.ts
+++ b/packages/bridge-client/src/client.ts
@@ -78,7 +78,17 @@ type Pending = {
 	resolve: (value: unknown) => void;
 	reject: (error: Error) => void;
 	timer: ReturnType<typeof setTimeout>;
+	sent: boolean;
 };
+
+/**
+ * Transport facts attached to an SdkClientError with code "timeout" for a request.
+ * `requestSent` proves only that WebSocket.send() returned; it never proves server acceptance.
+ */
+export interface SdkRequestTimeoutDetails {
+	requestId: string;
+	requestSent: boolean;
+}
 
 function errorFrom(frame: Frame): SdkClientError {
 	const error = frame.error;
@@ -272,12 +282,16 @@ export class SdkClient {
 				incarnation,
 				resolve,
 				reject,
+				sent: false,
 				timer: setTimeout(
 					() =>
 						this.#settlePending(
 							id,
 							pending,
-							new SdkClientError("timeout", `SDK request timed out after ${timeoutMs}ms`),
+							new SdkClientError("timeout", `SDK request timed out after ${timeoutMs}ms`, {
+								requestId: id,
+								requestSent: pending.sent,
+							} satisfies SdkRequestTimeoutDetails),
 						),
 					timeoutMs,
 				),
@@ -295,6 +309,7 @@ export class SdkClient {
 						...(options.idempotencyKey ? { idempotencyKey: options.idempotencyKey } : {}),
 					}),
 				);
+				pending.sent = true;
 			} catch (error) {
 				this.#settlePending(
 					id,

--- a/packages/bridge-client/test/client.test.ts
+++ b/packages/bridge-client/test/client.test.ts
@@ -324,7 +324,10 @@ test("SdkClient owns request timeout, reconnect backoff, and absolute deadline d
 		const timedOut = client.control("wait");
 		await flush();
 		clock.advanceBy(50);
-		await expect(timedOut).rejects.toMatchObject({ code: "timeout" });
+		await expect(timedOut).rejects.toMatchObject({
+			code: "timeout",
+			details: { requestSent: true, requestId: expect.any(String) },
+		});
 
 		socket.readyState = FakeWebSocket.CLOSED;
 		socket.emit("close");


### PR DESCRIPTION
## Summary
- attach typed `SdkRequestTimeoutDetails` to request-timer failures
- distinguish a locally sent request from a request that was never written without claiming server acceptance
- document ordered `turn.prompt` / `skill.invoke` reconciliation through existing `clientRef` status queries

## Scope
This is the narrow bridge-client contract gap in #3986. It does not duplicate #4057's pending create/connect/submit composite, which the issue census explicitly says does not close generic `SdkClient.control()` ambiguity.

## Verification
- `bun test packages/bridge-client/test/client.test.ts` — 14 passed
- `bun --cwd=packages/bridge-client run check` — passed (`biome check` and package typecheck)

The attempted frozen dependency install could not finish its `node-pty` postinstall because the host Node installation lacks `node-gyp`'s `gyp` module; existing package dependencies were sufficient for the focused checks.