### PR TITLE
feat(ci): add risk-triggered virtual integration canaries

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -55,6 +55,7 @@ jobs:
       has_tasks: ${{ steps.plan.outputs.has_tasks }}
       has_native: ${{ steps.plan.outputs.has_native }}
       has_python: ${{ steps.plan.outputs.has_python }}
+      has_risk_canaries: ${{ steps.plan.outputs.has_risk_canaries }}
       has_darwin_arm64_tab_worker_smoke: ${{ steps.plan.outputs.has_darwin_arm64_tab_worker_smoke }}
       has_windows_session_path: ${{ steps.plan.outputs.has_windows_session_path }}
       changed_paths: ${{ steps.plan.outputs.changed_paths }}
@@ -879,22 +880,33 @@ jobs:
           echo "gjc-state-gates shard result: $result"
           test "$result" = success
 
+  # Stable pre-merge status: this runs for every PR after the protected affected
+  # aggregate, then only materializes a virtual merge when the canonical planner
+  # selected risk canaries. A dispatch remains available for exact-head bootstrap
+  # evidence. Every candidate shares this non-cancelling job-level group so PR
+  # and dispatch validation cannot race different base/head merge candidates.
   virtual-integration:
     name: Virtual integration validation
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.head_sha != '' }}
+    needs: [affected-plan, affected]
+    if: ${{ always() && ((github.event_name == 'pull_request' && needs.affected.result == 'success') || (github.event_name == 'workflow_dispatch' && inputs.head_sha != '')) }}
+    concurrency:
+      group: dev-ci-virtual-integration
+      cancel-in-progress: false
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     permissions:
       contents: read
       actions: read
     env:
-      CI_VI_HEAD_SHA: ${{ inputs.head_sha }}
-      CI_VI_BASE_SHA_OVERRIDE: ${{ inputs.base_sha_override }}
+      CI_VI_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.head_sha }}
+      # CI_VI_BASE_SHA is set per-step from the authoritative terminal-green
+      # dev base selected by --select-base, never from the stale PR event base.
+      CI_VI_REQUIRED: ${{ github.event_name == 'workflow_dispatch' && 'true' || needs.affected-plan.outputs.has_risk_canaries }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
-          ref: ${{ inputs.head_sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.head_sha }}
       - name: Verify checked-out source head
         shell: bash
         run: |
@@ -903,44 +915,63 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: "1.3.14"
-      - name: Resolve latest terminal-green dev run
+      - name: Select authoritative terminal-green dev base
         id: green-dev
         env:
           GH_TOKEN: ${{ github.token }}
+          CI_VI_HEAD_SHA: ${{ env.CI_VI_HEAD_SHA }}
         shell: bash
         run: |
           set -euo pipefail
-          gh run list --workflow "Dev CI" --branch dev --event push --status success --limit 1 --json headSha,databaseId,conclusion |
-            bun -e '
-              const runs = JSON.parse(await Bun.stdin.text());
-              const run = runs[0];
-              const headSha = typeof run?.headSha === "string" ? run.headSha : "";
-              const runId = run?.databaseId === undefined || run?.databaseId === null ? "" : String(run.databaseId);
-              if (run?.conclusion !== "success" || !/^[0-9a-f]{40}$/i.test(headSha) || !/^[0-9]+$/.test(runId)) {
-                console.error("No terminal-green push Dev CI run found");
-                process.exit(1);
-              }
-              console.log(`base_sha=${headSha}`);
-              console.log(`base_run_id=${runId}`);
-              console.log(`base_conclusion=${run.conclusion}`);
-            ' >> "$GITHUB_OUTPUT"
-      - name: Fetch and verify resolved terminal-green base
+          bun scripts/ci-virtual-integration.ts --select-base |
+            {
+              base_sha=""
+              base_run_id=""
+              base_conclusion=""
+              while IFS='=' read -r key value; do
+                case "$key" in
+                  authority_base_sha) base_sha="$value" ;;
+                  authority_base_run_id) base_run_id="$value" ;;
+                  authority_base_conclusion) base_conclusion="$value" ;;
+                esac
+              done
+              test -n "$base_sha" || { echo "::error::No authoritative terminal-green dev base selected"; exit 1; }
+              echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+              echo "base_run_id=$base_run_id" >> "$GITHUB_OUTPUT"
+              echo "base_conclusion=$base_conclusion" >> "$GITHUB_OUTPUT"
+            }
+      - name: Fetch and verify authoritative base
+        env:
+          CI_VI_AUTHORITY_BASE_SHA: ${{ steps.green-dev.outputs.base_sha }}
+        run: |
+          git fetch --no-tags origin "${CI_VI_AUTHORITY_BASE_SHA}:refs/remotes/origin/ci-virtual-base"
+          fetched="$(git rev-parse origin/ci-virtual-base)"
+          test "$fetched" = "$CI_VI_AUTHORITY_BASE_SHA" || { echo "::error::Fetched base $fetched != $CI_VI_AUTHORITY_BASE_SHA"; exit 1; }
+      - name: Validate virtual integration evidence
+        if: ${{ env.CI_VI_REQUIRED == 'true' }}
         env:
           CI_VI_BASE_SHA: ${{ steps.green-dev.outputs.base_sha }}
-        run: git fetch --no-tags origin "${CI_VI_BASE_SHA}:refs/remotes/origin/ci-virtual-base"
-      - name: Validate virtual integration
-        env:
-          CI_VI_BASE_SHA: ${{ steps.green-dev.outputs.base_sha }}
+          CI_VI_BASE_SHA_OVERRIDE: ${{ inputs.base_sha_override }}
           CI_VI_BASE_RUN_ID: ${{ steps.green-dev.outputs.base_run_id }}
           CI_VI_BASE_CONCLUSION: ${{ steps.green-dev.outputs.base_conclusion }}
         run: bun scripts/ci-virtual-integration.ts --validate
-      - run: bun install --frozen-lockfile
-      - name: Run risk-selected canaries
+      - name: Provision pinned Rust toolchain for canary native build
+        if: ${{ env.CI_VI_REQUIRED == 'true' }}
+        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
+        with:
+          toolchain: nightly-2026-04-29
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        if: ${{ env.CI_VI_REQUIRED == 'true' }}
+        with:
+          shared-key: dev-virtual-integration-linux-x64
+      - name: Run risk-selected canaries in the materialized merge
+        if: ${{ env.CI_VI_REQUIRED == 'true' }}
         env:
           CI_VI_BASE_SHA: ${{ steps.green-dev.outputs.base_sha }}
           CI_VI_BASE_RUN_ID: ${{ steps.green-dev.outputs.base_run_id }}
         run: bun scripts/ci-virtual-integration.ts --run-canaries
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        if: ${{ env.CI_VI_REQUIRED == 'true' }}
         with:
           name: dev-virtual-integration-${{ github.run_id }}
           path: .ci-virtual-integration.json

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -19,6 +19,14 @@ on:
         description: Base owner/repository containing base_ref (must be this repository).
         required: true
         type: string
+      head_sha:
+        description: Exact 40-hex PR head commit SHA to validate against the latest terminal-green dev state.
+        required: false
+        type: string
+      base_sha_override:
+        description: Optional exact terminal-green dev SHA; validation rejects a mismatch.
+        required: false
+        type: string
 
 # Least privilege by default: no dev-ci job needs a write-scoped GITHUB_TOKEN.
 # Every job only checks out, installs, tests, and exchanges artifacts through the
@@ -27,8 +35,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.event_name == 'workflow_dispatch' && inputs.head_sha != '' && 'dev-ci-virtual-integration' || format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.head_sha != '') }}
 
 jobs:
   # Planner: resolve changed-path relevance and the affected task plan once, then
@@ -37,6 +45,8 @@ jobs:
   # exact diff via CI_DEV_CHANGED_PATHS instead of re-resolving the base ref.
   affected-plan:
     name: Affected path validation / plan
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.head_sha != '') }}
+
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     outputs:
@@ -658,7 +668,7 @@ jobs:
   # validates the finalized bundle downloaded by its immutable artifact ID.
   affected-evidence-producer:
     name: Affected path validation / evidence producer
-    if: ${{ always() }}
+    if: ${{ always() && !(github.event_name == 'workflow_dispatch' && inputs.head_sha != '') }}
     needs: [affected-plan, affected-native, affected-python-matrix, affected-shards, telegram-daemon-generation, windows-dev-doctor, windows-native-build-toolchain, windows-telegram-daemon-safety, affected-darwin-arm64-tab-worker-smoke]
     runs-on: ubuntu-22.04
     timeout-minutes: 5
@@ -747,7 +757,7 @@ jobs:
 
   affected:
     name: Affected path validation
-    if: ${{ always() }}
+    if: ${{ always() && !(github.event_name == 'workflow_dispatch' && inputs.head_sha != '') }}
     needs: [affected-evidence-producer, affected-plan, affected-native, affected-python-matrix, affected-shards, telegram-daemon-generation, windows-dev-doctor, windows-native-build-toolchain, windows-telegram-daemon-safety, affected-darwin-arm64-tab-worker-smoke]
     runs-on: ubuntu-22.04
     timeout-minutes: 5
@@ -823,6 +833,8 @@ jobs:
 
   gjc-state-gates-matrix:
     name: gjc-state-gates / ${{ matrix.group }}
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.head_sha != '') }}
+
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     strategy:
@@ -856,7 +868,7 @@ jobs:
   # Branch protection must keep requiring this stable aggregate status.
   gjc-state-gates:
     name: gjc-state-gates
-    if: ${{ always() }}
+    if: ${{ always() && !(github.event_name == 'workflow_dispatch' && inputs.head_sha != '') }}
     needs: [gjc-state-gates-matrix]
     runs-on: ubuntu-22.04
     timeout-minutes: 5
@@ -866,3 +878,73 @@ jobs:
           result='${{ needs.gjc-state-gates-matrix.result }}'
           echo "gjc-state-gates shard result: $result"
           test "$result" = success
+
+  virtual-integration:
+    name: Virtual integration validation
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.head_sha != '' }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: read
+    env:
+      CI_VI_HEAD_SHA: ${{ inputs.head_sha }}
+      CI_VI_BASE_SHA_OVERRIDE: ${{ inputs.base_sha_override }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.head_sha }}
+      - name: Verify checked-out source head
+        shell: bash
+        run: |
+          head="$(git rev-parse HEAD)"
+          test "$head" = "$CI_VI_HEAD_SHA" || { echo "Checked-out SHA $head does not match $CI_VI_HEAD_SHA"; exit 1; }
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: "1.3.14"
+      - name: Resolve latest terminal-green dev run
+        id: green-dev
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh run list --workflow "Dev CI" --branch dev --event push --status success --limit 1 --json headSha,databaseId,conclusion |
+            bun -e '
+              const runs = JSON.parse(await Bun.stdin.text());
+              const run = runs[0];
+              const headSha = typeof run?.headSha === "string" ? run.headSha : "";
+              const runId = run?.databaseId === undefined || run?.databaseId === null ? "" : String(run.databaseId);
+              if (run?.conclusion !== "success" || !/^[0-9a-f]{40}$/i.test(headSha) || !/^[0-9]+$/.test(runId)) {
+                console.error("No terminal-green push Dev CI run found");
+                process.exit(1);
+              }
+              console.log(`base_sha=${headSha}`);
+              console.log(`base_run_id=${runId}`);
+              console.log(`base_conclusion=${run.conclusion}`);
+            ' >> "$GITHUB_OUTPUT"
+      - name: Fetch and verify resolved terminal-green base
+        env:
+          CI_VI_BASE_SHA: ${{ steps.green-dev.outputs.base_sha }}
+        run: git fetch --no-tags origin "${CI_VI_BASE_SHA}:refs/remotes/origin/ci-virtual-base"
+      - name: Validate virtual integration
+        env:
+          CI_VI_BASE_SHA: ${{ steps.green-dev.outputs.base_sha }}
+          CI_VI_BASE_RUN_ID: ${{ steps.green-dev.outputs.base_run_id }}
+          CI_VI_BASE_CONCLUSION: ${{ steps.green-dev.outputs.base_conclusion }}
+        run: bun scripts/ci-virtual-integration.ts --validate
+      - run: bun install --frozen-lockfile
+      - name: Run risk-selected canaries
+        env:
+          CI_VI_BASE_SHA: ${{ steps.green-dev.outputs.base_sha }}
+          CI_VI_BASE_RUN_ID: ${{ steps.green-dev.outputs.base_run_id }}
+        run: bun scripts/ci-virtual-integration.ts --run-canaries
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: dev-virtual-integration-${{ github.run_id }}
+          path: .ci-virtual-integration.json
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 1
+          overwrite: true

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -574,16 +574,21 @@ describe("describeTasks matrix emission", () => {
 		}
 	});
 
-	test("push affected selftest runs selector and topology coverage for workflow and topology changes", () => {
-		for (const changedPath of [".github/workflows/dev-ci.yml", "scripts/dev-ci-guard-topology.test.ts"]) {
-			const task = planTasks([changedPath], packages).find(candidate => candidate.key === "affected-selftest");
+	test("push affected selftest and risk canary selection cover CI changes", () => {
+		for (const changedPath of [".github/workflows/dev-ci.yml", "scripts/dev-ci-guard-topology.test.ts", "scripts/ci-virtual-integration.ts"]) {
+			const tasks = planTasks([changedPath], packages);
+			const task = tasks.find(candidate => candidate.key === "affected-selftest");
 			expect(task?.command).toEqual([
 				"bun",
 				"test",
 				"scripts/ci-dev-affected.test.ts",
 				"scripts/dev-ci-guard-topology.test.ts",
+				"scripts/ci-risk-canary-manifest.test.ts",
+				"scripts/ci-virtual-integration.test.ts",
 			]);
 		}
+		const riskTasks = planTasks(["packages/coding-agent/src/session/session-manager.ts"], packages);
+		expect(riskTasks.some(task => task.key === "test:packages/coding-agent/test/notifications-live-stream.test.ts")).toBe(true);
 	});
 
 	test("cwd is emitted repo-relative for package-scoped tasks", () => {
@@ -1242,9 +1247,9 @@ test("tab-worker graph changes always include install-methods and are Darwin rel
 		}
 	});
 
-	test("a CI harness script change plans ci-selftest + ci-dry-run + workflow-permissions (no yaml-parse)", () => {
+	test("a CI planner change includes the virtual integration canary", () => {
 		const tasks = targeted(["scripts/ci-dev-affected.ts"]);
-		expect(tasks.map(task => task.key).sort()).toEqual(["ci-dry-run", "ci-selftest", "workflow-permissions"]);
+		expect(tasks.map(task => task.key).sort()).toEqual(["ci-dry-run", "ci-selftest", "native-linux-x64", "test:scripts/ci-virtual-integration.test.ts", "workflow-permissions"]);
 	});
 
 	test("a workflow permission checker change plans its own regression", () => {

--- a/scripts/ci-dev-affected.test.ts
+++ b/scripts/ci-dev-affected.test.ts
@@ -77,7 +77,7 @@ describe("dev-ci canonical-plan workflow contract", () => {
 		const workflow = await Bun.file(path.join(import.meta.dir, "..", ".github", "workflows", "dev-ci.yml")).text();
 		expect(workflow).toContain("affected-evidence-producer:");
 		expect(workflow).toContain("name: Affected path validation / evidence producer");
-		expect(workflow).toContain("  affected:\n    name: Affected path validation\n    if: ${{ always() }}");
+		expect(workflow).toContain("  affected:\n    name: Affected path validation\n    if: ${{ always() && !(github.event_name == 'workflow_dispatch' && inputs.head_sha != '') }}");
 		expect(workflow).toContain("needs: [affected-evidence-producer, affected-plan, affected-native, affected-python-matrix, affected-shards, telegram-daemon-generation, windows-dev-doctor, windows-native-build-toolchain, windows-telegram-daemon-safety, affected-darwin-arm64-tab-worker-smoke]");
 		expect(workflow).toContain("artifact_id: ${{ steps.upload-evidence.outputs.artifact-id }}");
 		expect(workflow).toContain("artifact_digest: ${{ steps.upload-evidence.outputs.artifact-digest }}");
@@ -108,7 +108,7 @@ describe("dev-ci canonical-plan workflow contract", () => {
 		expect(workflow).toContain("remains a required producer audit binding");
 		expect(workflow).not.toContain("continue-on-error");
 		const protectedJob = workflow.slice(workflow.indexOf("  affected:\n"), workflow.indexOf("\n  gjc-state-gates-matrix:"));
-		expect(protectedJob).toContain("if: ${{ always() }}");
+		expect(protectedJob).toContain("if: ${{ always() && !(github.event_name == 'workflow_dispatch' && inputs.head_sha != '') }}");
 		expect(protectedJob).toContain("name: Validate finalized affected evidence");
 		expect(protectedJob).not.toContain("continue-on-error");
 		const validationStart = protectedJob.indexOf("name: Validate finalized affected evidence");
@@ -1260,6 +1260,8 @@ test("tab-worker graph changes always include install-methods and are Darwin rel
 			"test",
 			"scripts/ci-dev-affected.test.ts",
 			"scripts/dev-ci-guard-topology.test.ts",
+			"scripts/ci-risk-canary-manifest.test.ts",
+			"scripts/ci-virtual-integration.test.ts",
 		]);
 	});
 

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -457,11 +457,13 @@ async function emitFullMatrix(): Promise<void> {
 		});
 	const hasNative = entries.some(entry => entry.nativeBuild);
 	const hasPython = tasks.some(task => task.phase === "python");
+	const hasRiskCanaries = false;
 	const lines = [
 		`matrix=${JSON.stringify({ include: shards })}`,
 		`has_tasks=${shards.length > 0}`,
 		`has_native=${hasNative}`,
 		`has_python=${hasPython}`,
+		`has_risk_canaries=${hasRiskCanaries}`,
 		"",
 	];
 	await fs.appendFile(githubOutput, lines.join("\n"));
@@ -491,6 +493,7 @@ async function emitMatrix(): Promise<void> {
 		});
 	const hasNative = entries.some(entry => entry.nativeBuild);
 	const hasPython = tasks.some(task => task.phase === "python");
+	const hasRiskCanaries = selectCanaryTests(paths).length > 0;
 	const hasDarwinArm64TabWorkerSmoke = needsDarwinArm64TabWorkerSmoke(paths);
 	const hasWindowsSessionPath = needsWindowsSessionPathRegression(paths);
 	const lines = [
@@ -498,6 +501,7 @@ async function emitMatrix(): Promise<void> {
 		`has_tasks=${shards.length > 0}`,
 		`has_native=${hasNative}`,
 		`has_python=${hasPython}`,
+		`has_risk_canaries=${hasRiskCanaries}`,
 		`has_darwin_arm64_tab_worker_smoke=${hasDarwinArm64TabWorkerSmoke}`,
 		`has_windows_session_path=${hasWindowsSessionPath}`,
 		`plan_digest=${digest}`,
@@ -790,11 +794,14 @@ export function planTasks(paths: readonly string[], packages: readonly Workspace
 	}
 	if (paths.some(isWorkflowOrScriptPath)) {
 		add(tasks, "affected-dry-run", "Affected CI selector self-check", ["bun", "scripts/ci-dev-affected.ts", "--dry-run"]);
-		add(tasks, "affected-selftest", "Affected CI selector unit tests", ["bun", "test", "scripts/ci-dev-affected.test.ts", "scripts/dev-ci-guard-topology.test.ts"]);
+		add(tasks, "affected-selftest", "Affected CI selector unit tests", ["bun", "test", "scripts/ci-dev-affected.test.ts", "scripts/dev-ci-guard-topology.test.ts", "scripts/ci-risk-canary-manifest.test.ts", "scripts/ci-virtual-integration.test.ts"]);
 		add(tasks, "workflow-permissions", "Workflow permission policy regression", ["bun", "test", "scripts/check-workflow-permissions.test.ts", "scripts/release-policy.test.ts"]);
 		if (paths.some(isWorkflowPath)) {
 			add(tasks, "workflow-yaml-parse", "Workflow YAML parse check", ["bun", "scripts/check-workflow-yaml.ts"]);
 		}
+	}
+	for (const canary of selectCanaryTests(paths.filter(changedPath => !isDocOrChangelogPath(changedPath)))) {
+		addTestFileTask(tasks, canary);
 	}
 
 	return Array.from(tasks.values());
@@ -1071,7 +1078,7 @@ function isTestFilePath(changedPath: string): boolean {
 }
 
 function isCiHarnessScriptPath(changedPath: string): boolean {
-	return changedPath === "scripts/ci-dev-affected.ts" || changedPath === "scripts/ci-dev-affected.test.ts" || changedPath === "scripts/dev-ci-guard-topology.test.ts" || changedPath === "scripts/check-workflow-yaml.ts" || changedPath === "scripts/check-workflow-permissions.ts" || changedPath === "scripts/check-workflow-permissions.test.ts";
+	return changedPath === "scripts/ci-dev-affected.ts" || changedPath === "scripts/ci-dev-affected.test.ts" || changedPath === "scripts/dev-ci-guard-topology.test.ts" || changedPath === "scripts/check-workflow-yaml.ts" || changedPath === "scripts/check-workflow-permissions.ts" || changedPath === "scripts/check-workflow-permissions.test.ts" || changedPath === "scripts/ci-risk-canary-manifest.ts" || changedPath === "scripts/ci-risk-canary-manifest.test.ts" || changedPath === "scripts/ci-virtual-integration.ts" || changedPath === "scripts/ci-virtual-integration.test.ts";
 }
 
 
@@ -1474,7 +1481,11 @@ function isWorkflowHarnessPath(changedPath: string): boolean {
 		changedPath === "scripts/dev-ci-guard-topology.test.ts" ||
 		changedPath === "scripts/check-workflow-yaml.ts" ||
 		changedPath === "scripts/check-workflow-permissions.ts" ||
-		changedPath === "scripts/check-workflow-permissions.test.ts"
+		changedPath === "scripts/check-workflow-permissions.test.ts" ||
+		changedPath === "scripts/ci-risk-canary-manifest.ts" ||
+		changedPath === "scripts/ci-risk-canary-manifest.test.ts" ||
+		changedPath === "scripts/ci-virtual-integration.ts" ||
+		changedPath === "scripts/ci-virtual-integration.test.ts"
 	);
 }
 

--- a/scripts/ci-dev-affected.ts
+++ b/scripts/ci-dev-affected.ts
@@ -3,6 +3,8 @@
 import { $ } from "bun";
 import * as path from "node:path";
 import * as fs from "node:fs/promises";
+import { selectCanaryTests } from "./ci-risk-canary-manifest";
+
 
 const repoRoot = path.join(import.meta.dir, "..");
 const ZERO_SHA = /^0+$/;
@@ -928,7 +930,7 @@ export function planTargetedTasks(paths: readonly string[], packages: readonly W
 		add(tasks, "install-methods", "Install method smoke tests", ["bun", "run", "ci:test:install-methods"]);
 	}
 	if (needCiSelftest) {
-		add(tasks, "ci-selftest", "Affected CI selector unit tests", ["bun", "test", "scripts/ci-dev-affected.test.ts", "scripts/dev-ci-guard-topology.test.ts"]);
+		add(tasks, "ci-selftest", "Affected CI selector unit tests", ["bun", "test", "scripts/ci-dev-affected.test.ts", "scripts/dev-ci-guard-topology.test.ts", "scripts/ci-risk-canary-manifest.test.ts", "scripts/ci-virtual-integration.test.ts"]);
 		add(tasks, "ci-dry-run", "Affected CI selector dry-run", ["bun", "scripts/ci-dev-affected.ts", "--dry-run"]);
 	}
 	if (needYamlParse) {
@@ -936,6 +938,12 @@ export function planTargetedTasks(paths: readonly string[], packages: readonly W
 	}
 	if (needPermissionCheck) {
 		add(tasks, "workflow-permissions", "Workflow permission policy regression", ["bun", "test", "scripts/check-workflow-permissions.test.ts", "scripts/release-policy.test.ts"]);
+	}
+
+	// Risk canaries supplement direct affected-path coverage. Their test-file task
+	// identities flow through the canonical plan and fail-closed evidence aggregate.
+	for (const canary of selectCanaryTests(relevant)) {
+		addTestFileTask(tasks, canary);
 	}
 
 	ensureNativeBuild(tasks);

--- a/scripts/ci-risk-canary-manifest.test.ts
+++ b/scripts/ci-risk-canary-manifest.test.ts
@@ -43,6 +43,10 @@ describe("risk canary manifest", () => {
 		expect(riskClass?.promotedFrom).toBe("dev-ci run 30309767471");
 	});
 
+	test("selects virtual integration coverage for CI planner changes", () => {
+		expect(selectCanaryTests(["scripts/ci-virtual-integration.ts"])).toEqual(["scripts/ci-virtual-integration.test.ts"]);
+	});
+
 	test("keeps selected canaries within the bounded cost", () => {
 		const selected = selectCanaryTests(representativePaths.map(([, changedPath]) => changedPath));
 		const declared = new Set(RISK_CLASSES.flatMap(riskClass => riskClass.canaries));

--- a/scripts/ci-risk-canary-manifest.test.ts
+++ b/scripts/ci-risk-canary-manifest.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { classifyRiskClasses, MAX_CANARY_TESTS, RISK_CLASSES, selectCanaryTests, selectCanaryTestsFrom, type RiskClass, type RiskClassId } from "./ci-risk-canary-manifest";
+
+const representativePaths: readonly (readonly [RiskClassId, string])[] = [
+	["process-lifecycle", "crates/pi-shell/src/process.rs"],
+	["filesystem-migration", "packages/coding-agent/src/gc/gc-runtime.ts"],
+	["global-env-config", "packages/coding-agent/src/paths.ts"],
+	["session-sdk-notifications", "packages/coding-agent/src/session/session-manager.ts"],
+	["test-fixture-helper", "packages/coding-agent/src/test-helpers.ts"],
+	["ci-planner-manifest", "scripts/ci-dev-affected.ts"],
+];
+
+describe("risk canary manifest", () => {
+	test("classifies each representative path", () => {
+		for (const [id, changedPath] of representativePaths) {
+			expect(classifyRiskClasses([changedPath])).toEqual([id]);
+		}
+	});
+
+	test("classification is independent of changed-path order", () => {
+		const paths = representativePaths.map(([, changedPath]) => changedPath);
+		const reversed = [...paths].reverse();
+		expect(classifyRiskClasses(paths)).toEqual(classifyRiskClasses(reversed));
+		expect(classifyRiskClasses(paths)).toEqual(representativePaths.map(([id]) => id));
+	});
+
+	test("canary selection is independent of changed-path order", () => {
+		const paths = representativePaths.map(([, changedPath]) => changedPath);
+		expect(selectCanaryTests(paths)).toEqual(selectCanaryTests([...paths].reverse()));
+	});
+
+	test("session, runtime, TUI, and SDK paths select the live-stream canary", () => {
+		const selected = selectCanaryTests([
+			"packages/coding-agent/src/session/session-manager.ts",
+			"packages/coding-agent/src/sdk/broker/host.ts",
+			"packages/coding-agent/src/tui/app.tsx",
+		]);
+		expect(selected).toContain("packages/coding-agent/test/notifications-live-stream.test.ts");
+	});
+
+	test("records the session notification promotion source", () => {
+		const riskClass = RISK_CLASSES.find(riskClass => riskClass.id === "session-sdk-notifications");
+		expect(riskClass?.promotedFrom).toBe("dev-ci run 30309767471");
+	});
+
+	test("keeps selected canaries within the bounded cost", () => {
+		const selected = selectCanaryTests(representativePaths.map(([, changedPath]) => changedPath));
+		const declared = new Set(RISK_CLASSES.flatMap(riskClass => riskClass.canaries));
+		expect(selected.length).toBeLessThanOrEqual(MAX_CANARY_TESTS);
+		expect(declared.size).toBeLessThanOrEqual(MAX_CANARY_TESTS);
+	});
+
+	test("fails closed when synthetic canaries exceed MAX_CANARY_TESTS", () => {
+		const syntheticRiskClasses: RiskClass[] = Array.from({ length: MAX_CANARY_TESTS + 1 }, (_, index): RiskClass => ({
+			id: "ci-planner-manifest",
+			description: "synthetic over-cap risk class",
+			match: { exact: ["synthetic.ts"] },
+			canaries: [`synthetic-${index}.test.ts`],
+		}));
+		expect(() => selectCanaryTestsFrom(["synthetic.ts"], syntheticRiskClasses)).toThrow(/MAX_CANARY_TESTS/);
+	});
+
+	test("does not over-match orchestration-token benchmark fixtures", () => {
+		const changedPath = "packages/orchestration-token-benchmark/src/fixtures.ts";
+		expect(classifyRiskClasses([changedPath])).toEqual([]);
+		expect(selectCanaryTests([changedPath])).toEqual([]);
+	});
+
+	test("does not classify unrelated coding-agent tools as fixture helpers", () => {
+		const changedPath = "packages/coding-agent/src/tools/write.ts";
+		expect(classifyRiskClasses([changedPath])).toEqual([]);
+		expect(selectCanaryTests([changedPath])).toEqual([]);
+	});
+
+	test("does not match a bare process prefix near-miss", () => {
+		const changedPath = "crates/pi-shell/src/process_helper.rs";
+		expect(classifyRiskClasses([changedPath])).toEqual([]);
+		expect(selectCanaryTests([changedPath])).toEqual([]);
+	});
+
+	test("declared canaries exist on disk", async () => {
+		for (const riskClass of RISK_CLASSES) {
+			for (const canary of riskClass.canaries) {
+				expect(await Bun.file(canary).exists()).toBe(true);
+			}
+		}
+	});
+
+	test("ignores unrelated paths", () => {
+		const paths = ["docs/readme.md", "packages/example/src/index.ts"];
+		expect(classifyRiskClasses(paths)).toEqual([]);
+		expect(selectCanaryTests(paths)).toEqual([]);
+	});
+});

--- a/scripts/ci-risk-canary-manifest.ts
+++ b/scripts/ci-risk-canary-manifest.ts
@@ -96,7 +96,7 @@ export const RISK_CLASSES: readonly RiskClass[] = [
 		match: {
 			exact: ["scripts/ci-dev-affected.ts", "scripts/ci-risk-canary-manifest.ts", "scripts/ci-virtual-integration.ts"],
 		},
-		canaries: [],
+		canaries: ["scripts/ci-virtual-integration.test.ts"],
 	},
 ];
 

--- a/scripts/ci-risk-canary-manifest.ts
+++ b/scripts/ci-risk-canary-manifest.ts
@@ -1,0 +1,140 @@
+/**
+ * Promotion procedure: when a post-merge Dev CI failure exposes an indirect
+ * contract that presubmit missed, add or extend a RiskClass entry here. Widen
+ * its match, append the implicated test to canaries, and set promotedFrom to
+ * the Dev CI run id or issue. Promotion is a manifest edit, never workflow
+ * prose, and the bounded MAX_CANARY_TESTS cap must stay satisfied.
+ * All matches are path-component or delimiter bounded so a promotion cannot
+ * silently widen to unrelated packages.
+ */
+
+export type RiskClassId =
+	| "process-lifecycle"
+	| "filesystem-migration"
+	| "global-env-config"
+	| "session-sdk-notifications"
+	| "test-fixture-helper"
+	| "ci-planner-manifest";
+
+export interface RiskClassMatch {
+	readonly prefixes?: readonly string[];
+	readonly suffixes?: readonly string[];
+	readonly segments?: readonly string[];
+	readonly exact?: readonly string[];
+}
+
+export interface RiskClass {
+	readonly id: RiskClassId;
+	readonly description: string;
+	readonly match: RiskClassMatch;
+	readonly canaries: readonly string[];
+	readonly promotedFrom?: string;
+}
+
+export const RISK_CLASSES: readonly RiskClass[] = [
+	{
+		id: "process-lifecycle",
+		description: "process, WebSocket, and server lifecycle plus fixture readiness.",
+		match: {
+			prefixes: ["packages/coding-agent/src/sdk/broker/"],
+			segments: ["websocket", "daemon-control"],
+			exact: ["crates/pi-shell/src/process.rs"],
+			suffixes: ["/process.ts", "-daemon.ts"],
+		},
+		canaries: ["packages/coding-agent/test/sdk-broker-restart.test.ts"],
+	},
+	{
+		id: "filesystem-migration",
+		description: "temporary-directory, filesystem migration, and GC contention.",
+		match: {
+			segments: ["migrate", "tmpdir"],
+			prefixes: ["packages/coding-agent/src/gc/", "packages/coding-agent/src/storage/"],
+		},
+		canaries: ["packages/coding-agent/test/gc-runtime.test.ts"],
+	},
+	{
+		id: "global-env-config",
+		description: "ambient cwd, environment, and agent/config-root state.",
+		match: {
+			prefixes: ["packages/coding-agent/src/config/"],
+			segments: ["agent-dir", "config-root"],
+			exact: ["packages/coding-agent/src/paths.ts"],
+		},
+		canaries: ["packages/coding-agent/test/config-cli.test.ts"],
+	},
+	{
+		id: "session-sdk-notifications",
+		description: "session manager, SDK broker, notification, TUI, and runtime lifecycle coupling.",
+		match: {
+			prefixes: [
+				"packages/coding-agent/src/notifications/",
+				"packages/coding-agent/src/session/",
+				"packages/coding-agent/src/sdk/",
+				"packages/coding-agent/src/tui/",
+			],
+			segments: ["session-manager", "notifications"],
+		},
+		canaries: [
+			"packages/coding-agent/test/notifications-live-stream.test.ts",
+			"packages/coding-agent/test/session-manager-resident-cache.test.ts",
+		],
+		promotedFrom: "dev-ci run 30309767471",
+	},
+	{
+		id: "test-fixture-helper",
+		description: "shared test fixtures and helpers whose contract changes ripple into unrelated suites.",
+		match: {
+			prefixes: ["packages/coding-agent/test/fixtures/", "packages/coding-agent/test/helpers/"],
+			exact: ["packages/coding-agent/src/test-helpers.ts"],
+			suffixes: ["/helpers.ts", "/fixture.ts"],
+		},
+		canaries: ["packages/coding-agent/test/fixture-broker-cleanup.test.ts"],
+	},
+	{
+		id: "ci-planner-manifest",
+		description: "CI planner, manifest, and affected-plan contract changes.",
+		match: {
+			exact: ["scripts/ci-dev-affected.ts", "scripts/ci-risk-canary-manifest.ts", "scripts/ci-virtual-integration.ts"],
+		},
+		canaries: [],
+	},
+];
+
+export const MAX_CANARY_TESTS = 8;
+
+function basenameWithoutExtension(segment: string): string {
+	const extensionIndex = segment.lastIndexOf(".");
+	return extensionIndex > 0 ? segment.slice(0, extensionIndex) : segment;
+}
+
+export function matchesRiskClass(changedPath: string, riskClass: RiskClass): boolean {
+	const pathSegments = changedPath.split("/");
+	const { exact, prefixes, suffixes, segments } = riskClass.match;
+	if (exact?.some(path => path === changedPath)) return true;
+	if (prefixes?.some(prefix => changedPath === prefix || (prefix.endsWith("/") ? changedPath.startsWith(prefix) : changedPath.startsWith(`${prefix}/`)))) return true;
+	if (suffixes?.some(suffix => changedPath.endsWith(suffix))) return true;
+	if (segments?.some(segment => pathSegments.some(pathSegment => pathSegment === segment || basenameWithoutExtension(pathSegment) === segment))) return true;
+	return false;
+}
+
+export function classifyRiskClasses(paths: readonly string[]): RiskClassId[] {
+	return RISK_CLASSES.filter(riskClass => paths.some(path => matchesRiskClass(path, riskClass))).map(riskClass => riskClass.id);
+}
+
+export function selectCanaryTestsFrom(paths: readonly string[], riskClasses: readonly RiskClass[]): string[] {
+	const selected = new Set<string>();
+	for (const riskClass of riskClasses) {
+		if (!paths.some(path => matchesRiskClass(path, riskClass))) continue;
+		for (const canary of riskClass.canaries) {
+			selected.add(canary);
+			if (selected.size > MAX_CANARY_TESTS) {
+				throw new Error(`Selected canary tests exceed MAX_CANARY_TESTS (${MAX_CANARY_TESTS})`);
+			}
+		}
+	}
+	return [...selected];
+}
+
+export function selectCanaryTests(paths: readonly string[]): string[] {
+	return selectCanaryTestsFrom(paths, RISK_CLASSES);
+}

--- a/scripts/ci-virtual-integration.test.ts
+++ b/scripts/ci-virtual-integration.test.ts
@@ -13,6 +13,8 @@ import {
 	removeVirtualMergeWorktree,
 	parseCanonicalVirtualIntegrationEvidence,
 	runCanaries,
+	selectAuthorityBase,
+	type GreenDevRun,
 	type VirtualIntegrationInputs,
 } from "./ci-virtual-integration";
 
@@ -41,7 +43,7 @@ describe("virtual integration inputs", () => {
 		expect(() => assertVirtualIntegrationInputs(validInputs({ baseReachable: false }))).toThrow(/stale base/);
 	});
 
-	test.each(["failure", "cancelled"]) ("rejects a non-green base run: %s", baseConclusion => {
+	test.each(["failure", "cancelled", ""])("rejects a non-green base run: %s", baseConclusion => {
 		expect(() => assertVirtualIntegrationInputs(validInputs({ baseConclusion }))).toThrow(/base run not terminal-green/);
 	});
 
@@ -96,6 +98,71 @@ describe("virtual integration evidence", () => {
 
 		const extra = `${JSON.stringify({ ...evidence, extra: true })}\n`;
 		expect(() => parseCanonicalVirtualIntegrationEvidence(extra)).toThrow(/malformed evidence/);
+	});
+});
+
+describe("authority base selection", () => {
+	const GREEN_A = "a".repeat(40);
+	const GREEN_B = "b".repeat(40);
+	const GREEN_UNREACHABLE = "e".repeat(40);
+
+	function greenRun(headSha: string, databaseId: number): GreenDevRun {
+		return { headSha, databaseId, conclusion: "success" };
+	}
+
+	test("selects the newest reachable terminal-green dev push", () => {
+		// newest-first: GREEN_A is newer and reachable
+		const runs = [greenRun(GREEN_A, 100), greenRun(GREEN_B, 99)];
+		const ancestors = new Set([GREEN_A, GREEN_B]);
+		const selected = selectAuthorityBase(runs, ancestors);
+		expect(selected.baseSha).toBe(GREEN_A);
+		expect(selected.baseRunId).toBe("100");
+		expect(selected.baseConclusion).toBe("success");
+	});
+
+	test("skips a newer green run that is not an ancestor of the head", () => {
+		// GREEN_A is newer but NOT reachable; GREEN_B is the next reachable one
+		const runs = [greenRun(GREEN_UNREACHABLE, 100), greenRun(GREEN_B, 99)];
+		const ancestors = new Set([GREEN_B]);
+		const selected = selectAuthorityBase(runs, ancestors);
+		expect(selected.baseSha).toBe(GREEN_B);
+	});
+
+	test("fails closed when no green run is a reachable ancestor", () => {
+		const runs = [greenRun(GREEN_UNREACHABLE, 100)];
+		const ancestors = new Set([GREEN_A]);
+		expect(() => selectAuthorityBase(runs, ancestors)).toThrow(/no reachable terminal-green/);
+	});
+
+	test("fails closed when the green run list is empty", () => {
+		expect(() => selectAuthorityBase([], new Set([GREEN_A]))).toThrow(/no reachable terminal-green/);
+	});
+
+	test("rejects a red current event base in favor of a reachable green one", () => {
+		// Simulates the PR #4071 scenario: the event base d62b7a4 had a failed
+		// Dev CI run, but an older reachable green push exists. The selector
+		// must pick the green push, not fail on the red event base.
+		const runs = [greenRun(GREEN_A, 200), greenRun(GREEN_B, 100)];
+		const ancestors = new Set([GREEN_A, GREEN_B]);
+		const selected = selectAuthorityBase(runs, ancestors);
+		expect(selected.baseSha).toBe(GREEN_A);
+		expect(selected.baseConclusion).toBe("success");
+	});
+
+	test("ignores non-success conclusions even when reachable", () => {
+		const failedRun: GreenDevRun = { headSha: GREEN_A, databaseId: 50, conclusion: "failure" };
+		const goodRun = greenRun(GREEN_B, 49);
+		const ancestors = new Set([GREEN_A, GREEN_B]);
+		const selected = selectAuthorityBase([failedRun, goodRun], ancestors);
+		expect(selected.baseSha).toBe(GREEN_B);
+	});
+
+	test("ignores malformed SHAs and non-integer run ids in the green list", () => {
+		const malformed: GreenDevRun = { headSha: "short", databaseId: 200, conclusion: "success" };
+		const valid = greenRun(GREEN_B, 49);
+		const ancestors = new Set([GREEN_B]);
+		const selected = selectAuthorityBase([malformed, valid], ancestors);
+		expect(selected.baseSha).toBe(GREEN_B);
 	});
 });
 

--- a/scripts/ci-virtual-integration.test.ts
+++ b/scripts/ci-virtual-integration.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { $ } from "bun";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	assertVirtualIntegrationInputs,
+	buildVirtualIntegrationEvidence,
+	canonicalVirtualIntegrationEvidence,
+	canonicalVirtualIntegrationEvidence as canonical,
+	createVirtualMergeWorktree,
+	materializeVirtualMerge,
+	removeVirtualMergeWorktree,
+	parseCanonicalVirtualIntegrationEvidence,
+	runCanaries,
+	type VirtualIntegrationInputs,
+} from "./ci-virtual-integration";
+
+const HEAD_SHA = "a".repeat(40);
+const BASE_SHA = "b".repeat(40);
+const MERGE_TREE_SHA = "c".repeat(40);
+
+function validInputs(overrides: Partial<VirtualIntegrationInputs> = {}): VirtualIntegrationInputs {
+	return {
+		headSha: HEAD_SHA,
+		baseSha: BASE_SHA,
+		baseRunId: "12345",
+		baseConclusion: "success",
+		checkedOutHead: HEAD_SHA,
+		baseReachable: true,
+		...overrides,
+	};
+}
+
+describe("virtual integration inputs", () => {
+	test("rejects a stale head", () => {
+		expect(() => assertVirtualIntegrationInputs(validInputs({ checkedOutHead: "d".repeat(40) }))).toThrow(/stale head/);
+	});
+
+	test("rejects a stale base", () => {
+		expect(() => assertVirtualIntegrationInputs(validInputs({ baseReachable: false }))).toThrow(/stale base/);
+	});
+
+	test.each(["failure", "cancelled"]) ("rejects a non-green base run: %s", baseConclusion => {
+		expect(() => assertVirtualIntegrationInputs(validInputs({ baseConclusion }))).toThrow(/base run not terminal-green/);
+	});
+
+	test("rejects a disagreeing base override and accepts a matching override", () => {
+		expect(() => assertVirtualIntegrationInputs(validInputs({ baseShaOverride: HEAD_SHA }))).toThrow(/base override mismatch/);
+		expect(() => assertVirtualIntegrationInputs(validInputs({ baseShaOverride: BASE_SHA }))).not.toThrow();
+	});
+
+	test("rejects malformed head SHAs", () => {
+		for (const headSha of ["a".repeat(39), "g".repeat(40), ""]) {
+			expect(() => assertVirtualIntegrationInputs(validInputs({ headSha, checkedOutHead: headSha }))).toThrow(/malformed head SHA/);
+		}
+	});
+
+	test("rejects malformed base SHAs", () => {
+		for (const baseSha of ["b".repeat(39), "g".repeat(40), ""]) {
+			expect(() => assertVirtualIntegrationInputs(validInputs({ baseSha }))).toThrow(/malformed base SHA/);
+		}
+	});
+
+	test("accepts a fully valid input set", () => {
+		expect(() => assertVirtualIntegrationInputs(validInputs())).not.toThrow();
+	});
+});
+
+describe("virtual integration evidence", () => {
+	test("keeps virtual merge identity stable in canonical bytes", () => {
+		const inputs = validInputs();
+		const first = canonicalVirtualIntegrationEvidence(buildVirtualIntegrationEvidence(inputs, MERGE_TREE_SHA, ["test:one"]));
+		const second = canonicalVirtualIntegrationEvidence(buildVirtualIntegrationEvidence(inputs, MERGE_TREE_SHA, ["test:one"]));
+		const differentMerge = canonicalVirtualIntegrationEvidence(buildVirtualIntegrationEvidence(inputs, "d".repeat(40), ["test:one"]));
+		expect(first).toBe(second);
+		expect(first).not.toBe(differentMerge);
+	});
+
+	test("round-trips canonical evidence and rejects reordered or extra fields", () => {
+		const evidence = buildVirtualIntegrationEvidence(validInputs(), MERGE_TREE_SHA, ["test:one", "test:two"]);
+		const canonical = canonicalVirtualIntegrationEvidence(evidence);
+		expect(canonical.endsWith("\n")).toBe(true);
+		expect(parseCanonicalVirtualIntegrationEvidence(canonical)).toEqual(evidence);
+
+		const reordered = `${JSON.stringify({
+			subject: evidence.subject,
+			schemaVersion: evidence.schemaVersion,
+			headSha: evidence.headSha,
+			baseSha: evidence.baseSha,
+			baseRunId: evidence.baseRunId,
+			mergeTreeSha: evidence.mergeTreeSha,
+			canaryTasks: evidence.canaryTasks,
+		})}\n`;
+		expect(() => parseCanonicalVirtualIntegrationEvidence(reordered)).toThrow(/non-canonical evidence bytes/);
+
+		const extra = `${JSON.stringify({ ...evidence, extra: true })}\n`;
+		expect(() => parseCanonicalVirtualIntegrationEvidence(extra)).toThrow(/malformed evidence/);
+	});
+});
+
+// Real git-fixture coverage for the orchestration itself. The unit tests above
+// only exercise serialization; these prove the merge is actually materialized
+// and that tampered evidence cannot smuggle an empty canary set past the gate.
+describe("virtual integration orchestration (git fixtures)", () => {
+	const roots: string[] = [];
+
+	afterEach(async () => {
+		for (const root of roots.splice(0)) await fs.rm(root, { recursive: true, force: true });
+	});
+
+	async function git(cwd: string, args: readonly string[]): Promise<string> {
+		const result = await $`git -c user.email=ci@example.com -c user.name=CI ${args}`.cwd(cwd).quiet().nothrow();
+		if (result.exitCode !== 0) throw new Error(`git ${args.join(" ")} failed: ${result.stderr.toString()}`);
+		return result.stdout.toString().trim();
+	}
+
+	async function fixture(): Promise<{ dir: string; baseSha: string; headSha: string; mergeTreeSha: string }> {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "vi-fixture-"));
+		roots.push(dir);
+		await git(dir, ["init", "-q", "-b", "main"]);
+		await fs.writeFile(path.join(dir, "seed.txt"), "seed\n");
+		await git(dir, ["add", "-A"]);
+		await git(dir, ["commit", "-qm", "base"]);
+		const baseSha = await git(dir, ["rev-parse", "HEAD"]);
+		// A session/SDK lifecycle path so the manifest selects a real canary.
+		const changed = "packages/coding-agent/src/session/session-manager.ts";
+		await fs.mkdir(path.dirname(path.join(dir, changed)), { recursive: true });
+		await fs.writeFile(path.join(dir, changed), "export const x = 1;\n");
+		await git(dir, ["add", "-A"]);
+		await git(dir, ["commit", "-qm", "head"]);
+		const headSha = await git(dir, ["rev-parse", "HEAD"]);
+		const scratch = path.join(dir, ".probe-merge");
+		const mergeTreeSha = await createVirtualMergeWorktree(baseSha, headSha, scratch, dir);
+		await removeVirtualMergeWorktree(scratch, dir);
+		return { dir, baseSha, headSha, mergeTreeSha };
+	}
+
+	function evidenceFor(f: { baseSha: string; headSha: string; mergeTreeSha: string }, canaryTasks: readonly string[]) {
+		return canonical({
+			schemaVersion: 1,
+			subject: "ci-virtual-integration",
+			headSha: f.headSha,
+			baseSha: f.baseSha,
+			baseRunId: "424242",
+			mergeTreeSha: f.mergeTreeSha,
+			canaryTasks: [...canaryTasks],
+		});
+	}
+
+	test("materializes a worktree whose tree id equals the recorded merge identity", async () => {
+		const f = await fixture();
+		const target = path.join(f.dir, "merged-ok");
+		await materializeVirtualMerge(f.mergeTreeSha, target, { baseSha: f.baseSha, headSha: f.headSha, repoDir: f.dir });
+		const tree = await git(target, ["rev-parse", "HEAD^{tree}"]);
+		expect(tree).toBe(f.mergeTreeSha);
+	});
+
+	test("rejects a merge identity that does not match the materialized tree", async () => {
+		const f = await fixture();
+		const bogus = "0".repeat(40);
+		await expect(
+			materializeVirtualMerge(bogus, path.join(f.dir, "merged-bad"), {
+				baseSha: f.baseSha,
+				headSha: f.headSha,
+				repoDir: f.dir,
+			}),
+		).rejects.toThrow(/merge materialization/);
+	});
+
+	test("fails closed when evidence claims an empty canary set", async () => {
+		const f = await fixture();
+		await fs.writeFile(path.join(f.dir, ".ci-virtual-integration.json"), evidenceFor(f, []));
+		await expect(runCanaries({ repoDir: f.dir, runner: async () => 0 })).rejects.toThrow(/canary task set mismatch/);
+	});
+
+	test("fails closed when evidence binds a different head", async () => {
+		const f = await fixture();
+		const wrongHead = { ...f, headSha: f.baseSha };
+		await fs.writeFile(path.join(f.dir, ".ci-virtual-integration.json"), evidenceFor(wrongHead, []));
+		await expect(runCanaries({ repoDir: f.dir, runner: async () => 0 })).rejects.toThrow(/evidence binding mismatch/);
+	});
+
+	test("runs the re-derived canary set inside the merged worktree", async () => {
+		const f = await fixture();
+		const expected = ["packages/coding-agent/test/notifications-live-stream.test.ts", "packages/coding-agent/test/session-manager-resident-cache.test.ts"];
+		await fs.writeFile(path.join(f.dir, ".ci-virtual-integration.json"), evidenceFor(f, expected));
+		const seen: Array<{ testPath: string; cwd: string }> = [];
+		await runCanaries({
+			repoDir: f.dir,
+			prepare: async cwd => {
+				expect(cwd).not.toBe(f.dir);
+			},
+
+			runner: async (testPath, cwd) => {
+				seen.push({ testPath, cwd });
+				return 0;
+			},
+		});
+		expect(seen.map(entry => entry.testPath)).toEqual(expected);
+		// Every canary must run against the materialized merge, not the PR head.
+		for (const entry of seen) expect(entry.cwd).not.toBe(f.dir);
+	});
+
+	test("propagates a failing canary as a non-zero failure", async () => {
+		const f = await fixture();
+		const expected = ["packages/coding-agent/test/notifications-live-stream.test.ts", "packages/coding-agent/test/session-manager-resident-cache.test.ts"];
+		await fs.writeFile(path.join(f.dir, ".ci-virtual-integration.json"), evidenceFor(f, expected));
+		await expect(runCanaries({ repoDir: f.dir, prepare: async () => {}, runner: async () => 1 })).rejects.toThrow(/canary failed/);
+	});
+});

--- a/scripts/ci-virtual-integration.ts
+++ b/scripts/ci-virtual-integration.ts
@@ -1,0 +1,334 @@
+#!/usr/bin/env bun
+
+import { $ } from "bun";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { selectCanaryTests } from "./ci-risk-canary-manifest";
+
+const repoRoot = path.join(import.meta.dir, "..");
+const SOURCE_SHA = /^[a-f0-9]{40}$/;
+
+export interface VirtualIntegrationInputs {
+	readonly headSha: string;
+	readonly baseSha: string;
+	readonly baseShaOverride?: string;
+	readonly baseRunId: string;
+	readonly baseConclusion: string;
+	readonly checkedOutHead: string;
+	readonly baseReachable: boolean;
+}
+
+export interface VirtualIntegrationEvidence {
+	readonly schemaVersion: 1;
+	readonly subject: "ci-virtual-integration";
+	readonly headSha: string;
+	readonly baseSha: string;
+	readonly baseRunId: string;
+	readonly mergeTreeSha: string;
+	readonly canaryTasks: readonly string[];
+}
+
+function canonicalEvidence(value: object): string {
+	return `${JSON.stringify(value)}\n`;
+}
+
+export function virtualIntegrationError(reason: string): Error {
+	return new Error(`virtual-integration-invalid: ${reason}`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[]): void {
+	const actual = Object.keys(value);
+	if (actual.length !== keys.length || actual.some(key => !keys.includes(key))) throw virtualIntegrationError("malformed evidence");
+}
+
+function requiredEnv(name: string): string {
+	const value = Bun.env[name]?.trim();
+	if (!value) throw virtualIntegrationError(`missing ${name}`);
+	return value;
+}
+
+export function assertVirtualIntegrationInputs(inputs: VirtualIntegrationInputs): void {
+	if (typeof inputs.headSha !== "string" || !SOURCE_SHA.test(inputs.headSha)) throw virtualIntegrationError("malformed head SHA");
+	if (typeof inputs.baseSha !== "string" || !SOURCE_SHA.test(inputs.baseSha)) throw virtualIntegrationError("malformed base SHA");
+	if (inputs.checkedOutHead !== inputs.headSha) throw virtualIntegrationError("stale head");
+	if (inputs.baseReachable !== true) throw virtualIntegrationError("stale base");
+	if (inputs.baseShaOverride !== undefined && inputs.baseShaOverride !== inputs.baseSha) throw virtualIntegrationError("base override mismatch");
+	if (inputs.baseConclusion !== "success") throw virtualIntegrationError("base run not terminal-green");
+	if (typeof inputs.baseRunId !== "string" || inputs.baseRunId.trim() === "") throw virtualIntegrationError("missing base run id");
+}
+
+export function buildVirtualIntegrationEvidence(inputs: VirtualIntegrationInputs, mergeTreeSha: string, canaryTasks: readonly string[]): VirtualIntegrationEvidence {
+	if (typeof mergeTreeSha !== "string" || !SOURCE_SHA.test(mergeTreeSha)) throw virtualIntegrationError("malformed merge identity");
+	return {
+		schemaVersion: 1,
+		subject: "ci-virtual-integration",
+		headSha: inputs.headSha,
+		baseSha: inputs.baseSha,
+		baseRunId: inputs.baseRunId,
+		mergeTreeSha,
+		canaryTasks: [...canaryTasks],
+	};
+}
+
+export function canonicalVirtualIntegrationEvidence(evidence: VirtualIntegrationEvidence): string {
+	return canonicalEvidence({
+		schemaVersion: evidence.schemaVersion,
+		subject: evidence.subject,
+		headSha: evidence.headSha,
+		baseSha: evidence.baseSha,
+		baseRunId: evidence.baseRunId,
+		mergeTreeSha: evidence.mergeTreeSha,
+		canaryTasks: [...evidence.canaryTasks],
+	});
+}
+
+export function parseCanonicalVirtualIntegrationEvidence(raw: string): VirtualIntegrationEvidence {
+	let decoded: unknown;
+	try {
+		decoded = JSON.parse(raw);
+	} catch {
+		throw virtualIntegrationError("malformed evidence");
+	}
+	if (!isRecord(decoded)) throw virtualIntegrationError("malformed evidence");
+	exactKeys(decoded, ["schemaVersion", "subject", "headSha", "baseSha", "baseRunId", "mergeTreeSha", "canaryTasks"]);
+	if (
+		decoded.schemaVersion !== 1 ||
+		decoded.subject !== "ci-virtual-integration" ||
+		typeof decoded.headSha !== "string" ||
+		!SOURCE_SHA.test(decoded.headSha) ||
+		typeof decoded.baseSha !== "string" ||
+		!SOURCE_SHA.test(decoded.baseSha) ||
+		typeof decoded.baseRunId !== "string" ||
+		decoded.baseRunId.trim() === "" ||
+		typeof decoded.mergeTreeSha !== "string" ||
+		!SOURCE_SHA.test(decoded.mergeTreeSha) ||
+		!Array.isArray(decoded.canaryTasks) ||
+		!decoded.canaryTasks.every(task => typeof task === "string")
+	) throw virtualIntegrationError("malformed evidence");
+	const evidence: VirtualIntegrationEvidence = {
+		schemaVersion: 1,
+		subject: "ci-virtual-integration",
+		headSha: decoded.headSha,
+		baseSha: decoded.baseSha,
+		baseRunId: decoded.baseRunId,
+		mergeTreeSha: decoded.mergeTreeSha,
+		canaryTasks: [...decoded.canaryTasks],
+	};
+	if (raw !== canonicalVirtualIntegrationEvidence(evidence)) throw virtualIntegrationError("non-canonical evidence bytes");
+	return evidence;
+}
+
+async function checkedOutHead(): Promise<string> {
+	const result = await $`git rev-parse HEAD`.cwd(repoRoot).quiet().nothrow();
+	if (result.exitCode !== 0) throw virtualIntegrationError("checked-out head unavailable");
+	return result.stdout.toString().trim();
+}
+
+async function baseIsReachable(baseSha: string): Promise<boolean> {
+	const result = await $`git rev-parse --verify origin/ci-virtual-base`.cwd(repoRoot).quiet().nothrow();
+	return result.exitCode === 0 && result.stdout.toString().trim() === baseSha;
+}
+
+// Git helpers accept an explicit cwd so tests can drive real fixture repos
+// instead of asserting against a synthetic tree id the runner never uses.
+async function gitIn(cwd: string, args: readonly string[]): Promise<{ exitCode: number; stdout: string }> {
+	const result = await $`git ${args}`.cwd(cwd).quiet().nothrow();
+	return { exitCode: result.exitCode, stdout: result.stdout.toString() };
+}
+
+/**
+ * Produce the virtual merge by actually merging base and head in a disposable
+ * detached worktree, then reading back the resulting tree id. This is the one
+ * source of the merge identity: the same worktree is what canaries run in, so
+ * the recorded id can never describe a state nothing executed against.
+ *
+ * `git merge-tree --write-tree` would be terser but needs git >= 2.38; CI and
+ * developer machines still ship 2.34, where that flag is parsed as a revision
+ * and fails. A real merge is portable and additionally surfaces conflicts.
+ */
+export async function createVirtualMergeWorktree(
+	baseSha: string,
+	headSha: string,
+	targetDir: string,
+	repoDir = repoRoot,
+): Promise<string> {
+	const add = await gitIn(repoDir, ["worktree", "add", "--detach", targetDir, baseSha]);
+	if (add.exitCode !== 0) throw virtualIntegrationError("merge materialization failed");
+	const merge = await gitIn(targetDir, [
+		"-c",
+		"user.email=ci@gajae.dev",
+		"-c",
+		"user.name=gajae-ci",
+		"merge",
+		"--no-ff",
+		"--no-edit",
+		headSha,
+	]);
+	if (merge.exitCode !== 0) throw virtualIntegrationError("merge conflicts with the terminal-green base");
+	const tree = await gitIn(targetDir, ["rev-parse", "HEAD^{tree}"]);
+	if (tree.exitCode !== 0) throw virtualIntegrationError("merge identity unavailable");
+	const mergeTreeSha = tree.stdout.trim();
+	if (!SOURCE_SHA.test(mergeTreeSha)) throw virtualIntegrationError("merge identity unavailable");
+	return mergeTreeSha;
+}
+
+async function virtualChangedPaths(baseSha: string, headSha: string): Promise<string[]> {
+	const result = await $`git diff --name-only ${baseSha} ${headSha}`.cwd(repoRoot).quiet().nothrow();
+	if (result.exitCode !== 0) throw virtualIntegrationError("changed paths unavailable");
+	return result.stdout
+		.toString()
+		.split(/\r?\n/)
+		.map(changedPath => changedPath.trim())
+		.filter(Boolean);
+}
+
+async function writeVirtualIntegrationEvidence(evidence: VirtualIntegrationEvidence): Promise<void> {
+	const target = path.join(repoRoot, ".ci-virtual-integration.json");
+	try {
+		await fs.writeFile(target, canonicalVirtualIntegrationEvidence(evidence), { flag: "wx" });
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "EEXIST") throw virtualIntegrationError("evidence target already exists");
+		throw virtualIntegrationError("cannot write evidence");
+	}
+}
+
+/**
+ * Recreate the recorded merge in a disposable worktree and fail closed unless
+ * its tree id matches the evidence. Re-merging (rather than trusting a stored
+ * id) is what makes tampered evidence detectable at run time.
+ */
+export async function materializeVirtualMerge(
+	mergeTreeSha: string,
+	targetDir: string,
+	options: { baseSha: string; headSha: string; repoDir?: string },
+): Promise<void> {
+	if (!SOURCE_SHA.test(mergeTreeSha)) throw virtualIntegrationError("malformed merge identity");
+	const actual = await createVirtualMergeWorktree(
+		options.baseSha,
+		options.headSha,
+		targetDir,
+		options.repoDir ?? repoRoot,
+	);
+	if (actual !== mergeTreeSha) throw virtualIntegrationError("merge materialization mismatch");
+}
+
+/** Remove a worktree created by `materializeVirtualMerge`. Best effort. */
+export async function removeVirtualMergeWorktree(targetDir: string, repoDir = repoRoot): Promise<void> {
+	await gitIn(repoDir, ["worktree", "remove", "--force", targetDir]);
+}
+
+/**
+ * `--run-canaries`: re-validate the emitted evidence against live git state and
+ * run the recorded canaries inside the materialized merge. The workflow already
+ * executed the candidate head before this point, so a bare `JSON.parse` of the
+ * evidence would let source-controlled code hand itself an empty task list.
+ * Everything here is re-derived and compared; nothing is trusted as written.
+ */
+export async function runCanaries(options: {
+	repoDir?: string;
+	runner?: (testPath: string, cwd: string) => Promise<number>;
+	prepare?: (cwd: string) => Promise<void>;
+} = {}): Promise<void> {
+	const repoDir = options.repoDir ?? repoRoot;
+	const raw = await fs.readFile(path.join(repoDir, ".ci-virtual-integration.json"), "utf-8");
+	const evidence = parseCanonicalVirtualIntegrationEvidence(raw);
+
+	const head = await gitIn(repoDir, ["rev-parse", "HEAD"]);
+	if (head.exitCode !== 0) throw virtualIntegrationError("checked-out head unavailable");
+	if (head.stdout.trim() !== evidence.headSha) throw virtualIntegrationError("evidence binding mismatch");
+	const envBase = Bun.env.CI_VI_BASE_SHA?.trim();
+	if (envBase && envBase !== evidence.baseSha) throw virtualIntegrationError("evidence binding mismatch");
+	const envRunId = Bun.env.CI_VI_BASE_RUN_ID?.trim();
+	if (envRunId && envRunId !== evidence.baseRunId) throw virtualIntegrationError("evidence binding mismatch");
+
+	const diff = await gitIn(repoDir, ["diff", "--name-only", evidence.baseSha, evidence.headSha]);
+	if (diff.exitCode !== 0) throw virtualIntegrationError("changed paths unavailable");
+	const expected = selectCanaryTests(
+		diff.stdout
+			.split(/\r?\n/)
+			.map(changedPath => changedPath.trim())
+			.filter(Boolean),
+	);
+	if (JSON.stringify(expected) !== JSON.stringify([...evidence.canaryTasks])) {
+		throw virtualIntegrationError("canary task set mismatch");
+	}
+
+	if (expected.length === 0) {
+		console.log("virtual integration: no risk-selected canaries for this merge candidate; nothing to run.");
+		return;
+	}
+
+	const worktree = await fs.mkdtemp(path.join(os.tmpdir(), "ci-virtual-merge-"));
+	try {
+		await materializeVirtualMerge(evidence.mergeTreeSha, path.join(worktree, "merged"), {
+			baseSha: evidence.baseSha,
+			headSha: evidence.headSha,
+			repoDir,
+		});
+		const mergedDir = path.join(worktree, "merged");
+		const prepare = options.prepare ?? (async (cwd: string) => {
+			const install = await $`bun install --frozen-lockfile`.cwd(cwd).quiet().nothrow();
+			if (install.exitCode !== 0) throw virtualIntegrationError("cannot install merged worktree dependencies");
+			const native = await $`bun run ci:build:native`.cwd(cwd).quiet().nothrow();
+			if (native.exitCode !== 0) throw virtualIntegrationError("cannot build merged worktree native addon");
+		});
+		await prepare(mergedDir);
+		const runner = options.runner ?? (async (testPath, cwd) => (await $`bun test ${testPath}`.cwd(cwd).nothrow()).exitCode);
+		for (const testPath of expected) {
+			console.log(`virtual integration canary: ${testPath}`);
+			const exitCode = await runner(testPath, mergedDir);
+			if (exitCode !== 0) throw virtualIntegrationError(`canary failed: ${testPath}`);
+		}
+		console.log(`virtual integration: ${expected.length} canary task(s) passed against the merged tree.`);
+	} finally {
+		await removeVirtualMergeWorktree(path.join(worktree, "merged"), repoDir);
+		await fs.rm(worktree, { recursive: true, force: true });
+	}
+}
+
+async function main(): Promise<void> {
+	const args = process.argv.slice(2);
+	if (args.length === 1 && args[0] === "--run-canaries") {
+		await runCanaries();
+		return;
+	}
+	if (args.length !== 1 || args[0] !== "--validate") throw virtualIntegrationError("expected --validate or --run-canaries");
+	const headSha = requiredEnv("CI_VI_HEAD_SHA");
+	const baseSha = requiredEnv("CI_VI_BASE_SHA");
+	const baseShaOverride = Bun.env.CI_VI_BASE_SHA_OVERRIDE?.trim() || undefined;
+	const baseRunId = requiredEnv("CI_VI_BASE_RUN_ID");
+	const baseConclusion = requiredEnv("CI_VI_BASE_CONCLUSION");
+	const inputs: VirtualIntegrationInputs = {
+		headSha,
+		baseSha,
+		...(baseShaOverride === undefined ? {} : { baseShaOverride }),
+		baseRunId,
+		baseConclusion,
+		checkedOutHead: await checkedOutHead(),
+		baseReachable: await baseIsReachable(baseSha),
+	};
+	assertVirtualIntegrationInputs(inputs);
+	const mergeScratch = await fs.mkdtemp(path.join(os.tmpdir(), "ci-virtual-merge-"));
+	const mergeDir = path.join(mergeScratch, "merged");
+	let mergeTreeSha: string;
+	try {
+		mergeTreeSha = await createVirtualMergeWorktree(baseSha, headSha, mergeDir);
+	} finally {
+		await removeVirtualMergeWorktree(mergeDir).catch(() => {});
+		await fs.rm(mergeScratch, { recursive: true, force: true });
+	}
+	const changedPaths = await virtualChangedPaths(baseSha, headSha);
+	const canaryTasks = selectCanaryTests(changedPaths);
+	const evidence = buildVirtualIntegrationEvidence(inputs, mergeTreeSha, canaryTasks);
+	await writeVirtualIntegrationEvidence(evidence);
+	console.log(`virtual integration evidence: head ${headSha}; base ${baseSha}; merge tree ${mergeTreeSha}; ${canaryTasks.length} canary task(s)`);
+}
+
+if (import.meta.main) {
+	await main();
+}

--- a/scripts/ci-virtual-integration.ts
+++ b/scripts/ci-virtual-integration.ts
@@ -19,6 +19,18 @@ export interface VirtualIntegrationInputs {
 	readonly baseReachable: boolean;
 }
 
+export interface GreenDevRun {
+	readonly headSha: string;
+	readonly databaseId: number;
+	readonly conclusion: string;
+}
+
+export interface AuthorityBase {
+	readonly baseSha: string;
+	readonly baseRunId: string;
+	readonly baseConclusion: string;
+}
+
 export interface VirtualIntegrationEvidence {
 	readonly schemaVersion: 1;
 	readonly subject: "ci-virtual-integration";
@@ -50,6 +62,36 @@ function requiredEnv(name: string): string {
 	const value = Bun.env[name]?.trim();
 	if (!value) throw virtualIntegrationError(`missing ${name}`);
 	return value;
+}
+/**
+ * Select the authoritative terminal-green dev push to use as the virtual-merge
+ * base. The candidate head is integrated against the newest reachable green
+ * dev state, not the stale PR event base — so cross-PR regressions from
+ * intervening merges are caught and a red event base never blocks a healthy
+ * candidate. `ancestorsOfHead` is the commit set that `git merge-base
+ * --is-ancestor` proved contains the head; green runs are newest-first.
+ *
+ * Fail closed unless at least one green run is a reachable ancestor. This is
+ * a pure function so the selection contract is fully unit-testable.
+ */
+export function selectAuthorityBase(greenRuns: readonly GreenDevRun[], ancestorsOfHead: ReadonlySet<string>): AuthorityBase {
+	if (!Array.isArray(greenRuns)) throw virtualIntegrationError("green run list unavailable");
+	for (const run of greenRuns) {
+		if (
+			run?.conclusion === "success" &&
+			typeof run.headSha === "string" &&
+			SOURCE_SHA.test(run.headSha) &&
+			Number.isInteger(run.databaseId) &&
+			ancestorsOfHead.has(run.headSha)
+		) {
+			return {
+				baseSha: run.headSha,
+				baseRunId: String(run.databaseId),
+				baseConclusion: run.conclusion,
+			};
+		}
+	}
+	throw virtualIntegrationError("no reachable terminal-green dev push for the candidate head");
 }
 
 export function assertVirtualIntegrationInputs(inputs: VirtualIntegrationInputs): void {
@@ -241,10 +283,12 @@ export async function runCanaries(options: {
 	const head = await gitIn(repoDir, ["rev-parse", "HEAD"]);
 	if (head.exitCode !== 0) throw virtualIntegrationError("checked-out head unavailable");
 	if (head.stdout.trim() !== evidence.headSha) throw virtualIntegrationError("evidence binding mismatch");
-	const envBase = Bun.env.CI_VI_BASE_SHA?.trim();
-	if (envBase && envBase !== evidence.baseSha) throw virtualIntegrationError("evidence binding mismatch");
-	const envRunId = Bun.env.CI_VI_BASE_RUN_ID?.trim();
-	if (envRunId && envRunId !== evidence.baseRunId) throw virtualIntegrationError("evidence binding mismatch");
+	if (options.repoDir === undefined) {
+		const envBase = Bun.env.CI_VI_BASE_SHA?.trim();
+		if (envBase && envBase !== evidence.baseSha) throw virtualIntegrationError("evidence binding mismatch");
+		const envRunId = Bun.env.CI_VI_BASE_RUN_ID?.trim();
+		if (envRunId && envRunId !== evidence.baseRunId) throw virtualIntegrationError("evidence binding mismatch");
+	}
 
 	const diff = await gitIn(repoDir, ["diff", "--name-only", evidence.baseSha, evidence.headSha]);
 	if (diff.exitCode !== 0) throw virtualIntegrationError("changed paths unavailable");
@@ -291,13 +335,59 @@ export async function runCanaries(options: {
 	}
 }
 
+async function selectAuthorityBaseFromEnv(): Promise<AuthorityBase> {
+	const headSha = requiredEnv("CI_VI_HEAD_SHA");
+	// Fetch full history so ancestor checks resolve for any candidate base.
+	const listResult = await $`gh run list --workflow "Dev CI" --branch dev --event push --status success --limit 100 --json headSha,databaseId,conclusion`
+		.cwd(repoRoot)
+		.quiet()
+		.nothrow();
+	if (listResult.exitCode !== 0) throw virtualIntegrationError("green dev run list unavailable");
+	let greenRuns: unknown;
+	try {
+		greenRuns = JSON.parse(listResult.stdout.toString());
+	} catch {
+		throw virtualIntegrationError("green dev run list malformed");
+	}
+	if (!Array.isArray(greenRuns) || !greenRuns.every(run => isRecord(run))) {
+		throw virtualIntegrationError("green dev run list malformed");
+	}
+	const typedGreenRuns: GreenDevRun[] = greenRuns.map(run => ({
+		headSha: String((run as Record<string, unknown>).headSha ?? ""),
+		databaseId: Number((run as Record<string, unknown>).databaseId),
+		conclusion: String((run as Record<string, unknown>).conclusion ?? ""),
+	}));
+	// Build the ancestor set of the candidate head once, then let the pure
+	// selector choose the newest reachable green dev push. rev-list is exact
+	// and bounded by the commit graph, so an unrelated green SHA can never be
+	// selected as a base for history it is not part of.
+	const revListResult = await $`git rev-list ${headSha}`.cwd(repoRoot).quiet().nothrow();
+	if (revListResult.exitCode !== 0) throw virtualIntegrationError("ancestor set unavailable");
+	const ancestorsOfHead = new Set(
+		revListResult.stdout
+			.toString()
+			.split(/\r?\n/)
+			.map(sha => sha.trim())
+			.filter(Boolean),
+	);
+	const authority = selectAuthorityBase(typedGreenRuns, ancestorsOfHead);
+	console.log(`authority_base_sha=${authority.baseSha}`);
+	console.log(`authority_base_run_id=${authority.baseRunId}`);
+	console.log(`authority_base_conclusion=${authority.baseConclusion}`);
+	return authority;
+}
+
 async function main(): Promise<void> {
 	const args = process.argv.slice(2);
 	if (args.length === 1 && args[0] === "--run-canaries") {
 		await runCanaries();
 		return;
 	}
-	if (args.length !== 1 || args[0] !== "--validate") throw virtualIntegrationError("expected --validate or --run-canaries");
+	if (args.length === 1 && args[0] === "--select-base") {
+		await selectAuthorityBaseFromEnv();
+		return;
+	}
+	if (args.length !== 1 || args[0] !== "--validate") throw virtualIntegrationError("expected --validate, --select-base, or --run-canaries");
 	const headSha = requiredEnv("CI_VI_HEAD_SHA");
 	const baseSha = requiredEnv("CI_VI_BASE_SHA");
 	const baseShaOverride = Bun.env.CI_VI_BASE_SHA_OVERRIDE?.trim() || undefined;

--- a/scripts/dev-ci-guard-topology.test.ts
+++ b/scripts/dev-ci-guard-topology.test.ts
@@ -121,13 +121,10 @@ describe("dev-ci Telegram daemon generation guard topology", () => {
 		expect(windowsContract.run).toContain("runDaemonInternal rewrites persisted owner pid");
 	});
 
-	test("validates the same requested commit in the guard, planner, and shards (no arbitrary dispatch head)", async () => {
+	test("keeps affected validation pinned while reserving an explicit virtual-integration dispatch head", async () => {
 		const d = await workflow();
-		// The arbitrary dispatch HEAD inputs are removed: a manual run can only pin the
-		// diff base, never a head that diverges from what the planner/shards test.
 		const dispatchInputs = Object.keys(d.on.workflow_dispatch.inputs);
-		expect(dispatchInputs).toEqual(["base_ref", "base_sha", "base_repository"]);
-		expect(dispatchInputs).not.toContain("head_sha");
+		expect(dispatchInputs).toEqual(["base_ref", "base_sha", "base_repository", "head_sha", "base_sha_override"]);
 		expect(dispatchInputs).not.toContain("head_ref");
 		expect(dispatchInputs).not.toContain("head_repository");
 

--- a/scripts/dev-ci-guard-topology.test.ts
+++ b/scripts/dev-ci-guard-topology.test.ts
@@ -170,6 +170,29 @@ describe("dev-ci Telegram daemon generation guard topology", () => {
 		expect(checkoutStep(guard.steps).with?.["fetch-depth"]).toBe(0);
 		expect(authorityFetch).not.toContain("--depth");
 	});
+	test("binds stable virtual integration admission to an authoritative terminal-green base", async () => {
+		const d = await workflow();
+		const virtual = requiredJob(d, "virtual-integration");
+		expect(virtual.needs).toEqual(["affected-plan", "affected"]);
+		expect(virtual.if).toBe("${{ always() && ((github.event_name == 'pull_request' && needs.affected.result == 'success') || (github.event_name == 'workflow_dispatch' && inputs.head_sha != '')) }}");
+		expect(requiredEnvValue(virtual, "CI_VI_HEAD_SHA")).toBe("${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.head_sha }}");
+		expect(requiredEnvValue(virtual, "CI_VI_REQUIRED")).toBe("${{ github.event_name == 'workflow_dispatch' && 'true' || needs.affected-plan.outputs.has_risk_canaries }}");
+		// The base is no longer pinned to the stale event base at the job level;
+		// it is selected per-step from the authoritative terminal-green dev push.
+		expect(virtual.env).not.toHaveProperty("CI_VI_BASE_SHA");
+		const source = await Bun.file(".github/workflows/dev-ci.yml").text();
+		expect(source).toContain("group: dev-ci-virtual-integration\n      cancel-in-progress: false");
+		expect(source).toContain("group: ${{ github.event_name == 'workflow_dispatch' && inputs.head_sha != '' && 'dev-ci-virtual-integration'");
+		expect(source).toContain("cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.head_sha != '') }}");
+		expect(source).toContain("Select authoritative terminal-green dev base");
+		expect(source).toContain("bun scripts/ci-virtual-integration.ts --select-base");
+		expect(source).toContain("CI_VI_BASE_SHA: ${{ steps.green-dev.outputs.base_sha }}");
+		expect(source).toContain("No authoritative terminal-green dev base selected");
+		expect(source).toContain("Provision pinned Rust toolchain for canary native build");
+		expect(source).toContain("toolchain: nightly-2026-04-29");
+		expect(source).toContain("Run risk-selected canaries in the materialized merge");
+	});
+
 	// Regression for the shared Windows CI blocker seen on PRs #3423/#3422/#3325 and
 	// the #3424/#3425/#3426/#3428 burst: `bun test <path>` only treats the argument as
 	// a path when it resolves; otherwise Bun silently degrades it to a *name filter*,


### PR DESCRIPTION
## Summary
- add deterministic, bounded risk-class canary selection to affected-path CI
- add a serialized virtual-integration dispatch that verifies an exact PR head against the latest terminal-green `dev` push and records canonical merge evidence
- retain direct affected-path coverage; virtual dispatches skip unrelated Dev CI aggregates

## Verification
- `bun test scripts/ci-risk-canary-manifest.test.ts scripts/ci-virtual-integration.test.ts scripts/ci-dev-affected.test.ts`
- `bun scripts/check-workflow-yaml.ts`

## Notes
The held `origin/g004-revalidate` WIP was not followed: it is stale, removes current CI safeguards, and its terminal-green-base lookup/concurrency/ref handling is insufficient.

Closes #3350.