### PR TITLE
fix(acp): preserve usage errors for invalid command flags

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Shadow-mode cold-session builds now compare the actual sidecar-derived provider context against the authoritative eager context and expose check/mismatch counters in `/session`; corrupt provider metadata produces a counted mismatch without weakening transcript authority. Cold branch activation now resolves compacted 10k-entry branches through one bounded ordinal-index scan and one bounded transcript range read instead of scanning a dictionary partition for every ancestor, and cold dictionary lookup skips unrelated JSON decoding while retaining full partition-digest verification. Bounded first-open, exact-reopen, and lazy cold-entry paths apply the same stale OpenAI Responses replay-metadata sanitation as eager resume.
+- ACP startup now rejects unrecognized command flags and incompatible terminal-auth modes through the normal CLI usage-error path, while preserving separate dash-leading system-prompt text.
 
 ### Added
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -88,6 +88,17 @@ function takeFlagValue(args: readonly string[], index: number, flag: string, all
 	return value;
 }
 
+function takePromptValue(
+	args: readonly string[],
+	index: number,
+	flag: string,
+	allowInlineDashPrefixed: boolean,
+): string {
+	const value = args[index + 1];
+	const allowSeparatedDashPrefixed = value === "-" || value?.startsWith("- ") === true;
+	return takeFlagValue(args, index, flag, allowInlineDashPrefixed || allowSeparatedDashPrefixed);
+}
+
 export function parseArgs(args: string[]): Args {
 	const result: Args = {
 		messages: [],
@@ -173,9 +184,9 @@ export function parseArgs(args: string[]): Args {
 			}
 			result.credential = args[++i];
 		} else if (arg === "--system-prompt") {
-			result.systemPrompt = takeFlagValue(args, i++, "--system-prompt", hasInlineValue);
+			result.systemPrompt = takePromptValue(args, i++, "--system-prompt", hasInlineValue);
 		} else if (arg === "--append-system-prompt") {
-			result.appendSystemPrompt = takeFlagValue(args, i++, "--append-system-prompt", hasInlineValue);
+			result.appendSystemPrompt = takePromptValue(args, i++, "--append-system-prompt", hasInlineValue);
 		} else if (arg === "--clipboard-transport") {
 			const next = args[i + 1];
 			if (!next || next.startsWith("-")) {
@@ -284,7 +295,7 @@ export function parseArgs(args: string[]): Args {
 	}
 
 	if (result.default && !result.mpreset) {
-		throw new Error("--default requires --mpreset <name>");
+		throw new CliParseError("--default requires --mpreset <name>");
 	}
 	if (
 		result.mcpConfig !== undefined &&

--- a/packages/coding-agent/src/commands/acp.ts
+++ b/packages/coding-agent/src/commands/acp.ts
@@ -4,7 +4,7 @@
  * Thin wrapper around the launch flow that forces `mode: "acp"` unless the
  * ACP terminal-auth flag asks the same command to open the interactive TUI.
  */
-import { Command } from "@gajae-code/utils/cli";
+import { CliParseError, Command } from "@gajae-code/utils/cli";
 import { parseArgs } from "../cli/args";
 import { runRootCommand } from "../main";
 import { prepareAcpTerminalAuthArgs } from "../modes/acp/terminal-auth";
@@ -17,10 +17,10 @@ export default class Acp extends Command {
 		const { args, terminalAuth } = prepareAcpTerminalAuthArgs(this.argv);
 		const parsed = parseArgs(args);
 		if (parsed.unknownFlags.size > 0) {
-			throw new Error(`Unknown ACP option: ${[...parsed.unknownFlags.keys()].join(", ")}`);
+			throw new CliParseError(`Unknown ACP option: ${[...parsed.unknownFlags.keys()].join(", ")}`);
 		}
 		if (terminalAuth && parsed.mode !== undefined) {
-			throw new Error("--acp-terminal-auth only supports --mode acp");
+			throw new CliParseError("--acp-terminal-auth only supports --mode acp");
 		}
 		if (!terminalAuth) {
 			parsed.mode = "acp";

--- a/packages/coding-agent/test/acp-startup-options.test.ts
+++ b/packages/coding-agent/test/acp-startup-options.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "bun:test";
+import * as path from "node:path";
 import type { AgentSideConnection } from "@agentclientprotocol/sdk";
+import { type CliConfig, CliParseError } from "@gajae-code/utils/cli";
 import { parseArgs } from "../src/cli/args";
+import Acp from "../src/commands/acp";
 import { resolveAcpStartupOptions } from "../src/main";
 import {
 	acpProviderRegistrations,
@@ -21,6 +24,26 @@ import {
 } from "../src/sdk/acp/final-text";
 
 const model = { provider: "openai-codex", id: "gpt-5.6" } as CreateAgentSessionOptions["model"];
+
+const TEST_CONFIG: CliConfig = {
+	bin: "gjc",
+	version: "0.0.0-test",
+	commands: new Map(),
+};
+
+async function runAcpCli(args: string[]): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+	const proc = Bun.spawn({
+		cmd: [process.execPath, path.join(import.meta.dir, "../src/cli.ts"), "acp", ...args],
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [exitCode, stdout, stderr] = await Promise.all([
+		proc.exited,
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+	]);
+	return { exitCode, stdout, stderr };
+}
 
 function providerNames(capabilities: unknown, env: NodeJS.ProcessEnv = {}): string[] {
 	return acpProviderRegistrations(capabilities as never, env).map(provider => provider.capability);
@@ -507,20 +530,57 @@ test("ACP rejects unknown flags instead of silently ignoring them", () => {
 	expect(() => resolveAcpStartupOptions(parsed, {})).toThrow("Unsupported under SDK-backed ACP: extension flags");
 });
 
+test("--default without --mpreset is a typed CLI parse error", () => {
+	expect(() => parseArgs(["--default"])).toThrow(CliParseError);
+	expect(() => parseArgs(["--default"])).toThrow("--default requires --mpreset <name>");
+});
+
+test("ACP command maps invalid argv to typed CLI usage errors", async () => {
+	await expect(new Acp(["--mpresett"], TEST_CONFIG).run()).rejects.toBeInstanceOf(CliParseError);
+	await expect(new Acp(["--mpresett"], TEST_CONFIG).run()).rejects.toThrow("Unknown ACP option: --mpresett");
+
+	for (const modeArgs of [
+		["--acp-terminal-auth", "--mode", "text"],
+		["--acp-terminal-auth", "--mode=text"],
+	]) {
+		await expect(new Acp(modeArgs, TEST_CONFIG).run()).rejects.toBeInstanceOf(CliParseError);
+		await expect(new Acp(modeArgs, TEST_CONFIG).run()).rejects.toThrow(
+			"--acp-terminal-auth only supports --mode acp",
+		);
+	}
+});
+
+test("ACP command renders usage and exits nonzero for invalid argv", async () => {
+	for (const [args, message] of [
+		[["--mpresett"], "Unknown ACP option: --mpresett"],
+		[["--default"], "--default requires --mpreset <name>"],
+		[["--acp-terminal-auth", "--mode", "text"], "--acp-terminal-auth only supports --mode acp"],
+	] as const) {
+		const result = await runAcpCli([...args]);
+		expect(result.exitCode).toBe(2);
+		expect(result.stderr).toContain(message);
+		expect(result.stdout).toContain("USAGE");
+	}
+}, 15_000);
+
 test("ACP option values cannot consume dash-prefixed unknown flags", () => {
 	for (const args of [
 		["--mpreset", "--mystery"],
 		["--mpreset=--mystery"],
 		["--tools", "--mystery"],
 		["--model", "--mystery"],
+		["--system-prompt", "--mystery"],
+		["--append-system-prompt", "--mystery"],
 	]) {
 		expect(() => parseArgs(args)).toThrow(/requires a value/);
 	}
 });
 
-test("inline opaque prompt values may start with a dash", () => {
+test("opaque prompt values may start with a dash in explicit or separated form", () => {
 	expect(parseArgs(["--system-prompt=-literal"]).systemPrompt).toBe("-literal");
 	expect(parseArgs(["--append-system-prompt=-literal"]).appendSystemPrompt).toBe("-literal");
+	expect(parseArgs(["--system-prompt", "- Be concise"]).systemPrompt).toBe("- Be concise");
+	expect(parseArgs(["--append-system-prompt", "- Be concise"]).appendSystemPrompt).toBe("- Be concise");
 });
 test("ACP rejects --mcp-config instead of ignoring it", () => {
 	const parsed = parseArgs(["--mcp-config", "/tmp/gjc-mcp.json"]);


### PR DESCRIPTION
## Summary
- route invalid ACP command options through CliParseError so the CLI renders usage and exits 2
- preserve separated dash-leading opaque prompt text without consuming option-shaped values
- add command-level argv regression coverage and the missing Unreleased changelog entry

## Verification
- bun test packages/coding-agent/test/acp-startup-options.test.ts (twice: 26 pass each)
- bun --cwd=packages/coding-agent run check

Follow-up repair for #4066.