### PR TITLE
fix(sdk): retain safe agent failure codes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Session contexts no longer retain materialized resident text after the backing cache disappears; subsequent reads rematerialize the existing public-safe missing-blob placeholder. Headless `--export` coverage now expects the established error for a nonexistent source file.
+- SDK prompt reconciliation now preserves bounded safe provider failure codes after `agent_failed`, while retaining the fixed redacted wire/persisted message and recording a bounded local diagnostic.
 
 - Shadow-mode cold-session builds now compare the actual sidecar-derived provider context against the authoritative eager context and expose check/mismatch counters in `/session`; corrupt provider metadata produces a counted mismatch without weakening transcript authority. Cold branch activation now resolves compacted 10k-entry branches through one bounded ordinal-index scan and one bounded transcript range read instead of scanning a dictionary partition for every ancestor, and cold dictionary lookup skips unrelated JSON decoding while retaining full partition-digest verification. Bounded first-open, exact-reopen, and lazy cold-entry paths apply the same stale OpenAI Responses replay-metadata sanitation as eager resume.
 - ACP startup now rejects unrecognized command flags and incompatible terminal-auth modes through the normal CLI usage-error path, while preserving separate dash-leading system-prompt text.

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -93,6 +93,7 @@ import {
 	syntheticModelInputError,
 	syntheticNamespaceCollision,
 } from "../model-profile-model";
+import { formatPromptFailureForLocalLog, sanitizePromptFailure } from "../prompt-failure";
 import { PROMPT_CLIENT_REF_MAX_LENGTH, type SdkPromptTerminalOutcome } from "../prompt-status";
 import { OPERATIONS } from "../protocol/operation-registry";
 import {
@@ -128,7 +129,7 @@ import { imageAttachmentsFromMessage, notificationActionPayload, summaryFromMess
 import { createKindAwareReconciliation } from "./kind-aware-reconciliation";
 import { assertNativeRuntimeCompatibility } from "./native-runtime-compatibility";
 import { proposedTelegramIdentity } from "./notification-orchestration";
-import { createPromptReconciliation, sanitizePromptFailure } from "./prompt-reconciliation";
+import { createPromptReconciliation } from "./prompt-reconciliation";
 import { createReconciliationStore } from "./reconciliation-store";
 import { NotificationSessionController, type NotificationSessionRuntime } from "./session-control";
 import type { SlackConversation } from "./slack-conversation";
@@ -4455,6 +4456,11 @@ export function createNotificationsExtension(
 			}
 		};
 		const emitPromptFailure = (correlation: { commandId: string; turnId: string }, error: unknown) => {
+			logger.error("SDK prompt submission failed", {
+				commandId: correlation.commandId,
+				turnId: correlation.turnId,
+				error: formatPromptFailureForLocalLog(error),
+			});
 			const sanitized = sanitizePromptFailure(error);
 			void terminalizePrompt(
 				correlation,

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -4058,7 +4058,6 @@ export function createNotificationsExtension(
 			connectionId: string;
 			abandoned: boolean;
 			failed: boolean;
-			error: unknown;
 			terminal: boolean;
 			retainCorrelation: boolean;
 			/** Fatal/uncertain closure: transport-level only, never a semantic terminal. */
@@ -4257,7 +4256,6 @@ export function createNotificationsExtension(
 				connectionId: requesterConnectionId,
 				abandoned: false,
 				failed: false,
-				error: undefined,
 				terminal: false,
 				retainCorrelation: trackReconciliation,
 				createdAt: Date.now(),
@@ -4480,7 +4478,6 @@ export function createNotificationsExtension(
 			const submission = promptSubmissions.get(promptSubmissionKey(correlation));
 			if (!submission) return;
 			submission.failed = true;
-			submission.error = error;
 			removePendingPromptCorrelation(correlation);
 			if (
 				runtime?.activePromptCorrelation?.commandId === correlation.commandId &&

--- a/packages/coding-agent/src/sdk/bus/kind-aware-reconciliation.ts
+++ b/packages/coding-agent/src/sdk/bus/kind-aware-reconciliation.ts
@@ -2,13 +2,14 @@
  * Kind-aware invocation reconciliation (prompt | skill) with optional durable store.
  * Preserves Q26 admit/first-terminal/capacity/TTL semantics; indexes and caps are per-kind.
  */
+
+import { sanitizePromptFailure } from "../prompt-failure";
 import type { PromptReconciliationStatus, SdkPromptTerminalOutcome, TurnPromptReconciliation } from "../prompt-status";
 import {
 	PROMPT_RECONCILIATION_ACTIVE_CAPACITY,
 	PROMPT_RECONCILIATION_TERMINAL_CAPACITY,
 	PROMPT_RECONCILIATION_TERMINAL_TTL_MS,
 	type PromptCorrelation,
-	sanitizePromptFailure,
 } from "./prompt-reconciliation";
 import type { DurableReconciliationRecord, ReconciliationKind, ReconciliationStore } from "./reconciliation-store";
 

--- a/packages/coding-agent/src/sdk/bus/prompt-reconciliation.ts
+++ b/packages/coding-agent/src/sdk/bus/prompt-reconciliation.ts
@@ -19,10 +19,13 @@
  * - Terminal transitions settle once: the first terminal outcome wins.
  */
 
+import { PROMPT_FAILURE_CODE_MAX, sanitizePromptFailure } from "../prompt-failure";
+
+export { PROMPT_FAILURE_CODE_MAX, sanitizePromptFailure };
+
 export const PROMPT_RECONCILIATION_ACTIVE_CAPACITY = 128;
 export const PROMPT_RECONCILIATION_TERMINAL_CAPACITY = 256;
 export const PROMPT_RECONCILIATION_TERMINAL_TTL_MS = 15 * 60_000;
-export const PROMPT_FAILURE_CODE_MAX = 64;
 
 export type PromptReconciliationStatus = "accepted" | "in_flight" | "terminal_ok" | "failed";
 
@@ -92,14 +95,6 @@ export interface PromptReconciliation {
 	lookup(selector: { commandId?: string; turnId?: string; clientRef?: string }): TurnPromptReconciliation;
 	cleanup(): void;
 	activeCount(): number;
-}
-
-/** Safe-token code capped at 64; arbitrary failure text is never retained. */
-export function sanitizePromptFailure(error: unknown): { code: string; message: string } {
-	const candidate = error as { code?: unknown } | undefined;
-	const rawCode = typeof candidate?.code === "string" ? candidate.code : "";
-	const code = rawCode.length <= PROMPT_FAILURE_CODE_MAX && /^[A-Za-z0-9._-]+$/.test(rawCode) ? rawCode : "internal";
-	return { code, message: "Prompt submission failed." };
 }
 
 export function createPromptReconciliation(options: { now?: () => number } = {}): PromptReconciliation {

--- a/packages/coding-agent/src/sdk/host/session-runtime.test.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
+	createInvocationReconciliation,
 	createSdkSessionRuntimeExtension,
 	SessionSdkSessionRuntime,
 	type SessionSdkTransport,
@@ -63,6 +64,55 @@ function extensionContext(sessionId: string, cwd: string): any {
 		},
 	};
 }
+
+test("preserves an agent failure code in host prompt reconciliation", async () => {
+	const reconciliation = createInvocationReconciliation();
+	const correlation = { commandId: "failed-command", turnId: "failed-turn" };
+	await reconciliation.noteAccepted("prompt", correlation, "failed-ref");
+	await reconciliation.noteTransition("prompt", correlation, {
+		type: "agent_failed",
+		error: Object.assign(new Error("provider unavailable"), { code: "provider_unavailable" }),
+	});
+	expect(reconciliation.lookup("prompt", { clientRef: "failed-ref" })).toMatchObject({
+		status: "failed",
+		error: { code: "provider_unavailable", message: "Prompt submission failed." },
+	});
+});
+
+test("redacts a persisted host failure during hydration", async () => {
+	const stateRoot = await mkdtemp(path.join(os.tmpdir(), "gjc-sdk-reconciliation-"));
+	const sessionId = "hydrated-failure";
+	try {
+		await Bun.write(
+			path.join(stateRoot, ".sdk-reconciliation", `${sessionId}.json`),
+			JSON.stringify({
+				version: 1,
+				sessionId,
+				records: [
+					{
+						kind: "prompt",
+						commandId: "persisted-command",
+						turnId: "persisted-turn",
+						status: "failed",
+						acceptedAt: 1,
+						terminalAt: Date.now(),
+						error: { code: "unsafe code!", message: "secret provider payload" },
+					},
+				],
+			}),
+		);
+		const reconciliation = createInvocationReconciliation({ stateRoot, sessionId });
+		await reconciliation.hydrate();
+		expect(
+			reconciliation.lookup("prompt", { commandId: "persisted-command", turnId: "persisted-turn" }),
+		).toMatchObject({
+			status: "failed",
+			error: { code: "internal", message: "Prompt submission failed." },
+		});
+	} finally {
+		await rm(stateRoot, { recursive: true, force: true });
+	}
+});
 
 describe("SessionSdkSessionRuntime", () => {
 	test("has no notification adapter or native notification import edge", async () => {

--- a/packages/coding-agent/src/sdk/host/session-runtime.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.ts
@@ -22,6 +22,7 @@ import {
 	syntheticNamespaceCollision,
 } from "../model-profile-model";
 import { projectQ10Models } from "../models.js";
+import { formatPromptFailureForLocalLog, sanitizePromptFailure } from "../prompt-failure";
 import { OPERATIONS } from "../protocol/operation-registry";
 import { type ControlSurface, dispatchControl } from "./control";
 import { SessionSdkHost, type SessionSdkHostOptions } from "./host";
@@ -265,7 +266,7 @@ export interface InvocationReconciliation {
 	hydrate(): Promise<void>;
 }
 
-function createInvocationReconciliation(
+export function createInvocationReconciliation(
 	options: { stateRoot?: string; sessionId?: string } = {},
 ): InvocationReconciliation {
 	const ACTIVE_CAPACITY = 256;
@@ -361,6 +362,7 @@ function createInvocationReconciliation(
 					record.terminalAt = Date.now();
 					record.error = { code: "process_restart", message: "Reconciliation incomplete after process restart." };
 				}
+				if (record.status === "failed") record.error = sanitizePromptFailure(record.error);
 				records.set(key(record.kind, record), { ...record });
 			}
 		}
@@ -416,7 +418,15 @@ function createInvocationReconciliation(
 			} else {
 				record.status = frame.type === "agent_failed" ? "failed" : "terminal_ok";
 				record.terminalAt = Date.now();
-				if (frame.type === "agent_failed") record.error = { code: "prompt_failed", message: "Invocation failed." };
+				if (frame.type === "agent_failed") {
+					logger.error("SDK invocation failed", {
+						kind,
+						commandId: correlation.commandId,
+						turnId: correlation.turnId,
+						error: formatPromptFailureForLocalLog(frame.error),
+					});
+					record.error = sanitizePromptFailure(frame.error);
+				}
 			}
 			await persist();
 		},

--- a/packages/coding-agent/src/sdk/prompt-failure.ts
+++ b/packages/coding-agent/src/sdk/prompt-failure.ts
@@ -1,0 +1,42 @@
+/**
+ * Safe failure shaping shared by SDK transports and reconciliation stores.
+ * Provider error text is retained only in the local diagnostic log; wire and
+ * persisted reconciliation details expose a fixed redacted message.
+ */
+export const PROMPT_FAILURE_CODE_MAX = 64;
+const LOCAL_FAILURE_LOG_MAX = 16_384;
+
+/** Safe-token code capped at 64; arbitrary failure text is never retained. */
+export function sanitizePromptFailure(error: unknown): { code: string; message: string } {
+	let rawCode = "";
+	try {
+		const candidate = error as { code?: unknown } | undefined;
+		rawCode = typeof candidate?.code === "string" ? candidate.code : "";
+	} catch {
+		// Untrusted error records may expose throwing accessors.
+	}
+	const code = rawCode.length <= PROMPT_FAILURE_CODE_MAX && /^[A-Za-z0-9._-]+$/.test(rawCode) ? rawCode : "internal";
+	return { code, message: "Prompt submission failed." };
+}
+
+/** Best-effort local diagnostic text that never crosses the SDK boundary. */
+export function formatPromptFailureForLocalLog(error: unknown): string {
+	try {
+		let detail: string;
+		if (error instanceof Error) {
+			const stack = error.stack;
+			detail = typeof stack === "string" ? stack : error.message;
+		} else if (typeof error === "string") detail = error;
+		else if (error !== null && typeof error === "object") {
+			const candidate = error as { code?: unknown; message?: unknown };
+			const code = typeof candidate.code === "string" ? candidate.code : undefined;
+			const message = typeof candidate.message === "string" ? candidate.message : undefined;
+			detail =
+				[code, message].filter((value): value is string => value !== undefined).join(": ") ||
+				"<object prompt failure>";
+		} else detail = String(error);
+		return detail.length <= LOCAL_FAILURE_LOG_MAX ? detail : `${detail.slice(0, LOCAL_FAILURE_LOG_MAX)}…`;
+	} catch {
+		return "<unserializable prompt failure>";
+	}
+}

--- a/packages/coding-agent/test/sdk-q26-prompt-status.test.ts
+++ b/packages/coding-agent/test/sdk-q26-prompt-status.test.ts
@@ -7,6 +7,7 @@ import {
 	sanitizePromptFailure,
 } from "../src/sdk/bus/prompt-reconciliation";
 import { CursorRegistry, QueryHandlers, RevisionStore } from "../src/sdk/host/query/index.js";
+import { formatPromptFailureForLocalLog } from "../src/sdk/prompt-failure";
 
 const correlation = (n = 1) => ({ commandId: `command-${n}`, turnId: `turn-${n}` });
 
@@ -83,6 +84,18 @@ describe("prompt reconciliation record", () => {
 			code: "ok_code-1.2",
 			message: "Prompt submission failed.",
 		});
+		const throwingCode = Object.create(null, {
+			code: {
+				get() {
+					throw new Error("code accessor failed");
+				},
+			},
+		});
+		expect(sanitizePromptFailure(throwingCode)).toEqual({ code: "internal", message: "Prompt submission failed." });
+		expect(formatPromptFailureForLocalLog(new Error("provider unavailable"))).toContain("provider unavailable");
+		const malformedError = new Error("provider unavailable");
+		Object.defineProperty(malformedError, "stack", { value: { invalid: true } });
+		expect(formatPromptFailureForLocalLog(malformedError)).toBe("provider unavailable");
 	});
 
 	it("reports unknown for a wrong commandId/turnId pair even when the commandId exists", () => {


### PR DESCRIPTION
## Summary
- share bounded SDK failure shaping between host and bus reconciliation
- preserve safe provider failure codes while retaining the fixed wire-redacted message
- log a best-effort bounded local diagnostic before the host shapes the failure

## Verification
- `bun test packages/coding-agent/src/sdk/host/session-runtime.test.ts packages/coding-agent/test/sdk-q26-prompt-status.test.ts packages/coding-agent/test/sdk-acp-prompt-terminal.test.ts`
- `bun --cwd=packages/coding-agent run check:types`

Closes #4068