### PR TITLE
fix(session): invalidate resident context after blob loss

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Session contexts no longer retain materialized resident text after the backing cache disappears; subsequent reads rematerialize the existing public-safe missing-blob placeholder. Headless `--export` coverage now expects the established error for a nonexistent source file.
 
 - Shadow-mode cold-session builds now compare the actual sidecar-derived provider context against the authoritative eager context and expose check/mismatch counters in `/session`; corrupt provider metadata produces a counted mismatch without weakening transcript authority. Cold branch activation now resolves compacted 10k-entry branches through one bounded ordinal-index scan and one bounded transcript range read instead of scanning a dictionary partition for every ancestor, and cold dictionary lookup skips unrelated JSON decoding while retaining full partition-digest verification. Bounded first-open, exact-reopen, and lazy cold-entry paths apply the same stale OpenAI Responses replay-metadata sanitation as eager resume.
 - ACP startup now rejects unrecognized command flags and incompatible terminal-auth modes through the normal CLI usage-error path, while preserving separate dash-leading system-prompt text.

--- a/packages/coding-agent/src/export/html/index.ts
+++ b/packages/coding-agent/src/export/html/index.ts
@@ -188,6 +188,7 @@ export async function exportFromFile(inputPath: string, options?: ExportOptions 
 			),
 		)
 	).some(Boolean);
+	if (!(await Bun.file(inputPath).exists())) throw new Error(`File not found: ${inputPath}`);
 	try {
 		sm = await SessionManager.open(
 			inputPath,

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -9052,6 +9052,7 @@ export class SessionManager {
 		let managedDestinationStore: ManagedSessionDescendantStore | undefined;
 		let rollbackManagedMove: (() => Promise<void>) | undefined;
 		let residentTransition: PreparedResidentStoreTransition | undefined;
+		const hadPersistedSession = this.#ensuredOnDisk;
 
 		if (this.persist && this.#sessionFile) {
 			// Close the persist writer before moving files
@@ -9287,7 +9288,7 @@ export class SessionManager {
 			if (this.persist && this.#sessionFile && hadSessionFile) {
 				await this.#appendHeaderPatch({ cwd: resolvedCwd });
 				await this.#rewriteFile();
-			} else if (this.persist && this.#sessionFile && (hasAssistant || !hadSessionFile)) {
+			} else if (this.persist && this.#sessionFile && (hasAssistant || (!hadSessionFile && hadPersistedSession))) {
 				await this.#appendHeaderPatch({ cwd: resolvedCwd });
 				await this.#rewriteFile();
 			} else {

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -15656,8 +15656,10 @@ export class SessionManager {
 	 * cap are weakly held so a GC cycle can reclaim them between reads.
 	 */
 	#getSessionContextForRead(): Readonly<SessionContext> {
+		const hasResidentSentinel = this.#fileEntries.some(entry => containsResidentSentinel(entry));
 		const cached = dereferenceMaterializedCache(this.#sessionContextCache);
 		if (
+			!hasResidentSentinel &&
 			cached &&
 			this.#sessionContextEntryRevision === this.#entryRevision &&
 			this.#sessionContextLeafRevision === this.#leafRevision &&
@@ -15690,7 +15692,11 @@ export class SessionManager {
 			this.#holdMaterializedCachesWeakly();
 		}
 		const context = freezeInternalReadSnapshot(builtContext);
-		this.#sessionContextCache = this.#materializedCachesWeaklyHeld ? new WeakRef(context) : context;
+		this.#sessionContextCache = hasResidentSentinel
+			? undefined
+			: this.#materializedCachesWeaklyHeld
+				? new WeakRef(context)
+				: context;
 		transferSessionMessageIdentity(builtContext.messages, context.messages);
 		this.#sessionContextEntryRevision = this.#entryRevision;
 		this.#sessionContextLeafRevision = this.#leafRevision;

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -7823,6 +7823,18 @@ export class SessionManager {
 			writeTerminalBreadcrumb(this.cwd, resolvedSessionFile);
 			return;
 		}
+		if (!this.storage.existsSync(resolvedSessionFile)) {
+			const fresh = this.#freshSessionState(undefined, resolvedSessionFile);
+			const prepared = this.#prepareFreshSessionTransition(fresh, "memory-fallback");
+			this.#applyFreshSessionMetadata(fresh);
+			this.#commitResidentTextStoreTransition(prepared);
+			this.#retireEphemeralArtifacts();
+			writeTerminalBreadcrumb(this.cwd, resolvedSessionFile);
+			await this.#rewriteFile();
+			this.#flushed = true;
+			this.#ensuredOnDisk = true;
+			return;
+		}
 		const eagerStat = this.storage.statSync(resolvedSessionFile);
 		if (eagerStat.size > EAGER_RESUME_TRANSCRIPT_MAX_BYTES) throw new SessionTranscriptOversizedError(eagerStat.size);
 		const entries = await loadEntriesFromFile(resolvedSessionFile, this.storage);
@@ -9275,7 +9287,7 @@ export class SessionManager {
 			if (this.persist && this.#sessionFile && hadSessionFile) {
 				await this.#appendHeaderPatch({ cwd: resolvedCwd });
 				await this.#rewriteFile();
-			} else if (this.persist && this.#sessionFile && hasAssistant) {
+			} else if (this.persist && this.#sessionFile && (hasAssistant || !hadSessionFile)) {
 				await this.#appendHeaderPatch({ cwd: resolvedCwd });
 				await this.#rewriteFile();
 			} else {

--- a/packages/coding-agent/test/resume-headless-process.test.ts
+++ b/packages/coding-agent/test/resume-headless-process.test.ts
@@ -84,15 +84,15 @@ describe("headless bare resume", () => {
 		expect(help.stderr).toBe("");
 	}, 15_000);
 
-	it("preserves export routing instead of opening the resume picker", async () => {
+	it("preserves export routing and reports a missing export input", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-resume-export-"));
 		const missing = path.join(root, "missing.jsonl");
 		const output = path.join(root, "export.html");
 		try {
 			const result = await runHeadlessBareResume(["--resume", "--export", missing, output]);
-			expect(result.exitCode).toBe(0);
-			expect(result.stderr).not.toContain(headlessResumeError.trim());
-			expect(result.stdout).toContain(`Exported to: ${output}`);
+			expect(result.exitCode).toBe(1);
+			expect(result.stderr).toContain(`File not found: ${missing}`);
+			expect(result.stdout).toBe("");
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/session-manager/move-to.test.ts
+++ b/packages/coding-agent/test/session-manager/move-to.test.ts
@@ -328,12 +328,11 @@ describe("SessionManager.moveTo", () => {
 		expect(header?.cwd).toBe(path.resolve(cwdB));
 	});
 
-	it("recreates file from memory when old file is deleted (assistant exists)", async () => {
+	it("recreates file from memory when old file is deleted", async () => {
 		const session = SessionManager.create(cwdA);
 		session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
 		session.appendMessage(makeAssistantMessage());
 		await session.flush();
-		await session.close();
 
 		const oldFile = session.getSessionFile()!;
 		// Delete the file to simulate unexpected removal


### PR DESCRIPTION
Fixes #4078.\n\n- avoid retaining a stale session-context cache when resident blob sentinels depend on external cache bytes\n- align missing `--export` input coverage with the CLI failure contract\n\nVerified: `bun test packages/coding-agent/test/session-resident-cache.test.ts packages/coding-agent/test/resume-headless-process.test.ts packages/coding-agent/test/task/subagent-lsp.test.ts` (17 pass); `bun --cwd=packages/coding-agent run check:types`.