### PR TITLE
fix(sdk): make terminal receipts and steering durable

### DIFF
--- a/.plans/2026-08-07-sdk-terminal-receipt-correlated-steer.md
+++ b/.plans/2026-08-07-sdk-terminal-receipt-correlated-steer.md
@@ -1,0 +1,188 @@
+# SDK Terminal Receipt and Correlated Steer Plan
+
+**Status:** approved implementation contract
+**Repository:** `/private/tmp/gjc-3825-current-dev-20260807`
+**Branch:** `fix/sdk-terminal-receipt-steer-20260807`
+**Base:** `origin/dev@b9cb17124b9cefadf9e5acc0e1ecabaddb7a0609`
+**Source work:** closed PR #3825 and open issue #3956
+
+## Goal
+
+Make SDK terminal outcomes truthful and retry-safe: execution completion must not imply a usable receipt, and `turn.steer` must support durable caller correlation and authoritative status lookup after uncertain transport or process outcomes.
+
+## Evidence and root constraint
+
+- Current Coordinator code can mark a turn completed while returning only the advisory `completion_missing_final_response`.
+- Current state has no shared receipt-state module, no `receipt_missing` terminal outcome, and no dual execution/receipt projection.
+- Current `turn.steer` accepts text without a caller correlation key and exposes no `turn.steer_status` query.
+- Current architecture has two steering paths: the SDK bus control surface and the host session-runtime control surface. Both must implement one contract.
+- Closed PR #3825 contains reusable pure modules, test cases, and invariants, but its integration predates the current SDK surface factory.
+- Open issue #3956 covers the correlated-steering half and has no implementing pull request at this base.
+
+## Settled behavior
+
+### Terminal receipt truth
+
+- Track execution state separately from receipt state.
+- A terminal execution with a reportable final response has a present receipt.
+- A terminal execution without a reportable final response fails closed as `receipt_missing`; it must not appear as successful completion.
+- Preserve existing terminal failure and cancellation meaning.
+- Persist only outcome metadata. Do not store prompt, steer text, transcript, credentials, or provider response bodies in reconciliation records.
+- Preserve current schema compatibility where existing readers require it.
+
+### Correlated steering
+
+- `turn.steer` accepts optional `clientRef`, using the same trimmed, non-empty, 128-character contract as existing prompt and skill correlation.
+- A retained duplicate `clientRef` is rejected before dispatch.
+- A caller can query `turn.steer_status` using either `clientRef` or the canonical command/turn identity returned at acceptance.
+- A durable accepted record allows callers to reconcile uncertain replies without duplicate delivery.
+- Status hydration after process restart is conservative. Missing durable proof must never become successful delivery.
+- Both current steering entrypoints use the same reconciliation owner and observable contract.
+
+## Non-goals
+
+- Do not restore the old inline SDK factory architecture.
+- Do not revive committed generated docs-index files that current `dev` removed.
+- Do not change prompt or skill correlation semantics.
+- Do not store request or response bodies in durable reconciliation records.
+- Do not change unrelated Coordinator lifecycle, provider, model, workflow, or UI behavior.
+- Do not split receipt truth and steering into separate pull requests without Grant's approval.
+- Do not edit this approved plan during implementation.
+
+## Architecture
+
+Use the current kind-aware reconciliation store as the single durable correlation owner. Add `steer` as a typed record kind and add one small receipt-state module for execution/receipt reduction. Wire current bus and host factory paths to those primitives rather than copying the old PR's integration hunks.
+
+Coordinator and sidecar projections consume the shared receipt-state semantics. The operation registry remains the public SDK authority and regenerates its inventory through the repository generator.
+
+## Implementation tasks
+
+### Task 1: Add receipt-state semantics with failing tests
+
+**Create:**
+- `packages/coding-agent/src/sdk/receipt-state.ts`
+- `packages/coding-agent/test/sdk-receipt-state.test.ts`
+
+**Adapt tests:**
+- `packages/coding-agent/test/agent-session-terminal-receipt-state.test.ts`
+
+Add behavioral tests for reportable output, empty output, failure, cancellation, and conservative unknown states. Run the focused tests and record the expected RED result before implementation. Add the minimum typed reducer required to pass.
+
+### Task 2: Extend durable reconciliation for steering
+
+**Modify:**
+- `packages/coding-agent/src/sdk/bus/reconciliation-store.ts`
+- `packages/coding-agent/src/sdk/bus/kind-aware-reconciliation.ts`
+- `packages/coding-agent/src/sdk/bus/prompt-reconciliation.ts`
+- `packages/coding-agent/src/sdk/prompt-status.ts`
+
+**Add or adapt tests:**
+- `packages/coding-agent/test/sdk-reconciliation-store.test.ts`
+- `packages/coding-agent/test/sdk-reconciliation-recovery.test.ts`
+- `packages/coding-agent/test/sdk-kind-aware-reconciliation.test.ts`
+- `packages/coding-agent/test/sdk-steer-reconciliation.test.ts`
+
+Introduce a discriminated `steer` record with correlation metadata and digest-only request identity. Prove admission, duplicate rejection, accepted/in-flight/terminal status, recovery, eviction, corruption handling, and no body persistence.
+
+### Task 3: Wire both steering entrypoints
+
+**Modify:**
+- `packages/coding-agent/src/sdk/bus/index.ts`
+- `packages/coding-agent/src/sdk/host/session-runtime.ts`
+- `packages/coding-agent/src/sdk/host/control/operations.ts`
+- `packages/coding-agent/src/sdk/host/control/dispatch.ts`
+- `packages/coding-agent/src/sdk/host/query/handlers.ts`
+
+**Add or adapt tests:**
+- `packages/coding-agent/test/sdk-steer-dispatch-integration.test.ts`
+- `packages/coding-agent/test/sdk-q30-steer-status.test.ts`
+- `packages/coding-agent/test/sdk-host-wiring.test.ts`
+- `packages/coding-agent/test/helpers/sdk-production-host.ts`
+
+Add optional `clientRef`, return canonical correlation after durable acceptance, and expose authoritative `turn.steer_status`. Prove the SDK bus and host session-runtime paths behave identically. Prove status-only replay never dispatches another steer.
+
+### Task 4: Make terminal projections fail closed
+
+**Modify:**
+- `packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts`
+- `packages/coding-agent/src/coordinator-mcp/server.ts`
+
+**Adapt tests:**
+- `packages/coding-agent/test/session-state-sidecar.test.ts`
+- `packages/coding-agent/test/coordinator-mcp-server.test.ts`
+- `packages/coding-agent/test/sdk-prompt-terminal-arbiter.test.ts`
+- `packages/coding-agent/test/sdk-q26-prompt-status.test.ts`
+
+Project execution and receipt states independently. Replace advisory success for missing final output with the typed `receipt_missing` failure. Preserve attributable terminal authority and existing failure/cancellation paths.
+
+### Task 5: Update public contract and generated inventory
+
+**Modify:**
+- `packages/coding-agent/src/sdk/protocol/operation-registry.ts`
+- `packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json` through the repository generator
+- `packages/coding-agent/test/sdk-operation-inventory.test.ts`
+- `packages/coding-agent/test/sdk-operation-matrix.test.ts`
+- `packages/coding-agent/test/sdk-adapter-dispositions.test.ts`
+- `packages/coding-agent/test/manifests/sdk-adapter-parity-v1.json`
+- `docs/sdk.md`
+- `packages/coding-agent/CHANGELOG.md`
+
+Document receipt truth, `turn.steer` correlation, `turn.steer_status`, conservative restart semantics, duplicate behavior, and retention limits. Regenerate rather than hand-edit generated authority.
+
+## Verification
+
+Run focused tests after each task. Final verification must include:
+
+- Receipt-state and terminal-receipt tests.
+- Reconciliation store, recovery, kind-aware, prompt arbiter, and Q26 tests.
+- Steering reconciliation, dispatch, Q30, and both control-surface integration tests.
+- Coordinator and sidecar tests.
+- Operation inventory, matrix, and adapter parity tests.
+- Mutation proof that removing receipt classification makes missing-output tests fail.
+- Mutation proof that bypassing durable steer acceptance makes replay/status tests fail.
+- Mutation proof that either steering entrypoint omits correlation makes its path-specific test fail.
+- `bun --cwd=packages/coding-agent run check`.
+- Repository-required generated inventory checks.
+- `bun run build` or the current canonical coding-agent build command.
+- Built artifact `gjc --smoke-test`.
+- `git diff --check`.
+- Independent adversarial review after implementation.
+- Current-head pull-request checks and unresolved-thread review after push.
+
+## Risks and stop conditions
+
+Stop before mutation beyond this contract when:
+
+- Current source requires separate public semantics for the two steering entrypoints.
+- Durable receipt truth requires storing prompt, steer, transcript, credential, or provider-response bodies.
+- Current upstream adds a materially overlapping implementation.
+- The implementation must split into separate pull requests.
+- A generated or public contract change exceeds the behavior settled above.
+
+Mechanical current-source changes needed to apply the settled contract are not material forks.
+
+## Routing
+
+```yaml
+routing:
+  reasoning_mode: investigative
+  execution_topology: direct
+  gjc_profile: investigative
+  gjc_workflow: direct
+  capability_evidence:
+    - The root constraint and public behavior are settled, but integration spans persistence, two control paths, terminal projection, and generated SDK authority.
+    - Current architecture differs materially from the old pull-request integration and requires source-guided adaptation.
+    - Behavioral and mutation tests provide strong oracles, so adversarial architecture routing is unnecessary.
+  topology_evidence:
+    - One coherent SDK outcome owns all changes and can be implemented and proven in one isolated worktree.
+    - No independent long-lived work lanes or cross-session coordination are required.
+  escalation_triggers:
+    - Public SDK behavior differs between current steering entrypoints.
+    - Receipt truth requires sensitive body persistence.
+    - Upstream adds overlapping work.
+    - One-pull-request scope becomes invalid.
+```
+
+## Execution handoff
+
+Run the GJC CLI from `/private/tmp/gjc-3825-current-dev-20260807` so repository `AGENTS.md` applies. Use the approved investigative direct route. The writer must keep this plan unchanged, implement through test-driven development, commit coherent checkpoints, and return exact test and commit receipts. The final pull request must target `Yeachan-Heo/gajae-code:dev`, reference closed PR #3825 and issue #3956, and remain unmerged.

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -340,6 +340,8 @@ The authoritative public reconciliation query is `Q26` /
 field is exposed only after finalization. A pending claim is never represented
 or exposed as a terminal outcome.
 
+Every prompt and skill status response includes `receiptState`: active records are `absent`; terminal records are `present`, `missing`, or `unknown`; unknown lookup is `unknown`. Ordinary success requires `status: "terminal_ok"`, `receiptState: "present"`, and readable non-empty text or an artifact path. A failed execution may retain a partial `present` receipt. Legacy version-1 reconciliation records without this additive field remain readable and project `unknown` rather than optimistic success.
+
 Callers that must recover from a lost acknowledgement should assign one fresh
 `clientRef` (a trimmed, non-empty string of at most 128 characters) to each logical
 prompt. Reconnect to the same session endpoint and query with exactly one selector:
@@ -366,19 +368,7 @@ Correlated `agent_end` and `agent_failed` frames carry the same finalized
 `outcome`. Clients must correlate those frames and Q26 by the prompt identifiers,
 not infer terminality from stream activity or an earlier pending claim.
 
-Reconciliation state survives client disconnect/reconnect. With the session-private
-durable store (`.sdk-reconciliation/`), accepted and terminal prompt records also
-survive **GJC session-process restart** for the same session identity within
-capacity/TTL, subject to crash-consistent fsync. A non-terminal prompt record at
-restart finalizes its pending outcome; if that claim is absent, it finalizes as
-`{ kind: "failed", code: "prompt_failed", ... }`. This prompt-specific recovery
-does not apply to skill records: active `skill.invoke` records retain
-`error.code = process_restart` because their reconciliation is incomplete, not
-proof of a skill failure. Eviction or absence still returns honest `unknown`; that
-means the prior outcome is unknowable, not that execution did not occur. Active
-records are capped at 128 per kind and are never aged into terminal. Terminal
-records are retained for 15 minutes, capped at 256 per kind, and evicted
-oldest-terminal first.
+Reconciliation state survives client disconnect/reconnect. With the session-private durable store (`.sdk-reconciliation/`), accepted and terminal prompt records also survive **GJC session-process restart** for the same session identity within capacity/TTL, subject to crash-consistent fsync. A non-terminal prompt record at restart finalizes its pending outcome and receipt state. A stopped prompt without receipt evidence becomes `terminal_ok + missing`; failed prompt or skill settlement without body evidence becomes `unknown`. Eviction or absence still returns honest `unknown`; that means the prior outcome is unknowable, not that execution did not occur. Active records are capped at 128 per kind and are never aged into terminal. Terminal records are retained for 15 minutes, capped at 256 per kind, and evicted oldest-terminal first. Reconciliation stores no prompt, transcript, credential, or provider-response body.
 
 `turn.prompt` remains ordered and non-idempotent. Its envelope `idempotencyKey`
 does not replay a response or produce `idempotency_conflict`. A retained duplicate
@@ -406,6 +396,18 @@ status with `Q28` / `skill.invoke_status` using the same selectors as Q26. Kind-
 indexes mean prompt and skill `clientRef` values never collide. Skill records use the
 same capacity/TTL limits, but an active skill record at restart settles with
 `error.code = process_restart`.
+
+## Correlated steer acknowledgement (Q30)
+
+`turn.steer` accepts an optional `clientRef` (trimmed, non-empty, at most 128 characters). When present, GJC hashes the exact validated steer text with SHA-256 and durably reserves `dispatching` before queueing. The result contains `sessionId`, `clientRef`, `status: accepted | rejected | uncertain`, known `acceptedAt` or `terminalAt`, and bounded error metadata; it never echoes text.
+
+Replay the same `clientRef` with the same text to recover the retained result without dispatching again. Reuse with different text returns `client_ref_conflict`. A live `dispatching` record and a restart during dispatch both project `uncertain`; GJC never automatically redispatches an ordered control whose first effect is unknowable. Query the same session with:
+
+```json
+{ "type": "query_request", "query": "turn.steer_status", "input": { "clientRef": "steer-018f" } }
+```
+
+Q31 returns `accepted`, `rejected`, `uncertain`, or `unknown` and never dispatches work. Settled steer records share the 15-minute/256-record retention bound; live dispatching records are not terminal-evicted. Existing uncorrelated `turn.steer` calls retain their legacy non-idempotent behavior. Version-1 reconciliation remains additive, and only digest plus bounded metadata is stored—never steer text.
 
 ## Model profile discovery and validation (Q27)
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## [0.13.1] - 2026-08-11
 
 ### Added
+- Terminal receipt state and correlated steering are now durable. Prompt reconciliation tracks whether a terminal turn produced reportable output (`present`/`missing`/`unknown`), failing closed as `receipt_missing` when a completed turn has no final response. `turn.steer` with a `clientRef` hashes the validated text (SHA-256) and durably reserves dispatch before queueing, deduplicating replays, rejecting conflicting text, and settling to `accepted`/`rejected`/`uncertain`. The new `turn.steer_status` query (Q31) looks up durable steer status by `clientRef` or canonical `commandId`/`turnId` pair. Steer delivery is uncertain after process restart; settled records share the 15-minute/256-record retention bound.
+
 - `/model <preset>` and `/model gajae-code/<preset>` now activate a known model profile immediately instead of failing with "Unknown model". Unknown names still fall through to model resolution, and `/model <role> <preset>` keeps assigning a model to the named role.
 - Browser `act` and `run` responses can now surface an opt-in (`open(..., { diagnostics: true })`), bounded mailbox of page exceptions and `console.error` metadata. Entries carry only kind, timestamp, origin-only URL, line/column, and an allowlisted built-in error class; path segments, query strings, messages, arguments, values, and stacks are never retained. Serialization is byte-bounded with an explicit truncation marker.
 - A generated, host-neutral `sdk-skills/` bundle now provides namespaced external-agent skills for direct GJC SDK session discovery, approved trusted-local operations, and TypeScript/Python script authoring, with deterministic drift checks and credential-safe fail-closed templates. The bundle carries a versioned `manifest.json` (format version 1) so installed bundles fail closed on missing or unsupported layouts, and the skill prompts are authored as static Markdown sources under `scripts/gjc-sdk-skills/prompts/` that the generator copies and validates.
@@ -167,6 +169,9 @@
 
 ### Fixed
 - Telegram topic archival no longer corrupts the shared topic registry when an active topic first enters disconnect grace. `beginArchive` changed `authorityState` to `archive_pending` but retained `disconnectGraceExpiresAt`, a field the persisted-state parser permits only for `disconnect_grace`; one closed or stale session therefore made the entire otherwise-valid registry unreadable, after which every daemon scan reported `shared topic authority unavailable` and no new session could create a thread or replay a message. Every transition out of disconnect grace now clears the grace-only deadline before persistence. `DAEMON_GENERATION` bumped to 57.
+
+- Added dual execution/receipt terminal truth across SDK reconciliation, runtime sidecars, and coordinator turns. Empty terminal output now fails closed as `receipt_missing`, while version-1 records without additive receipt fields remain readable as `unknown`.
+- Added retry-safe correlated `turn.steer` acknowledgement and Q30 `turn.steer_status`. GJC durably reserves a SHA-256 digest before dispatch, replays retained status without duplicate steering, and preserves uncertain delivery across restart without storing steer text.
 
 - `notifications-topic-registry.test.ts` pins `DAEMON_GENERATION` at 54 after #3965 (was stale at 53; Dev CI run 31133356543).
 - `smithery-env-trust.test.ts` no longer awaits hung probe pipes past a hard per-attempt deadline: minimal child env, `stdin: "ignore"`, SIGKILL + settled race, and up to 2 timeout-only retries. Fixes the inherited-config case that hit exactly 60001ms on Dev CI run 31133356543 after kill-at-45s left `Promise.all` on stdout/stderr unresolved. Assertions unchanged.

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -20,6 +20,7 @@ import { lifecycleRequestTimeoutMs } from "../sdk/broker/startup-budget";
 import { UnsupportedStateVersionError } from "../sdk/broker/state-version";
 import { SdkClient, SdkClientError } from "../sdk/client/client";
 import { readSdkBrokerDiscovery } from "../sdk/client/discovery";
+import { reduceTerminalReceiptState } from "../sdk/receipt-state";
 import { type SessionAttachment, SessionRouter, type SessionRouterDeps, SessionRouterError } from "../sdk/router";
 import {
 	type ActivatedPreparedSession,
@@ -165,10 +166,11 @@ interface CoordinatorFinalResponse {
 	truncated: boolean;
 }
 
-function reportableFinalResponse(response: CoordinatorFinalResponse): boolean {
-	return (
-		(typeof response.text === "string" && response.text.trim().length > 0) ||
-		(typeof response.artifact_path === "string" && response.artifact_path.trim().length > 0)
+function reportableFinalResponse(response: CoordinatorFinalResponse | undefined): boolean {
+	return Boolean(
+		response &&
+			((typeof response.text === "string" && response.text.trim().length > 0) ||
+				(typeof response.artifact_path === "string" && response.artifact_path.trim().length > 0)),
 	);
 }
 
@@ -1985,7 +1987,12 @@ async function markTurnTerminalFromSessionState(
 	turn: TurnRecord,
 	sessionState: CoordinatorSessionState,
 ): Promise<TurnRecord> {
-	const terminalStatus: TurnStatus = sessionState.state === "errored" ? "failed" : "completed";
+	const receiptState = reduceTerminalReceiptState({
+		execution: sessionState.state === "errored" ? "failed" : "completed",
+		reportable: reportableFinalResponse((sessionState as RuntimeSessionStatePayload).final_response),
+	});
+	const terminalStatus: TurnStatus =
+		receiptState.receipt === "missing" ? "failed" : sessionState.state === "errored" ? "failed" : "completed";
 	const runtimeState = sessionState as RuntimeSessionStatePayload;
 	const finalResponse = runtimeState.final_response ?? {
 		text: null,
@@ -2004,24 +2011,21 @@ async function markTurnTerminalFromSessionState(
 			state: "acknowledged",
 		},
 		final_response: finalResponse,
-		evidence: reportableFinalResponse(finalResponse)
-			? turn.evidence
-			: [
-					...turn.evidence,
-					{
-						type: MISSING_FINAL_RESPONSE_ADVISORY,
-						message: "Runtime completed without reportable final_response text or artifact_path.",
-						created_at: timestamp,
-					},
-				],
+		evidence: turn.evidence,
 		error:
-			terminalStatus === "failed"
-				? (runtimeState.error ?? {
-						code: "runtime_errored",
-						message: sessionState.reason ?? "runtime_errored",
+			receiptState.receipt === "missing"
+				? {
+						code: "receipt_missing",
+						message: "Runtime completed without reportable final_response text or artifact_path.",
 						recoverable: true,
-					})
-				: null,
+					}
+				: terminalStatus === "failed"
+					? (runtimeState.error ?? {
+							code: "runtime_errored",
+							message: sessionState.reason ?? "runtime_errored",
+							recoverable: true,
+						})
+					: null,
 		updated_at: timestamp,
 		completed_at: timestamp,
 	};

--- a/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import type { AssistantMessage } from "@gajae-code/ai/core";
 import { normalizePathForComparison, postmortem } from "@gajae-code/utils";
 import { withFileLock } from "../config/file-lock";
+import { reduceTerminalReceiptState } from "../sdk/receipt-state";
 import { sessionRoot, sessionRuntimeDir } from "./session-layout";
 import {
 	isValidOwnerIntent,
@@ -904,6 +905,14 @@ export async function persistCoordinatorRuntimeStateFromEvent(
 						const previous = await readPreviousPayloadForEvent(stateFile);
 						assertPreviousRuntimeStateIdentity(previous, identity);
 						const state = eventState ?? runtimeStateFromPrevious(previous.state);
+						const finalResponse = finalResponseForEvent(event);
+						const terminalReceipt =
+							state === "completed" || state === "errored"
+								? reduceTerminalReceiptState({
+										execution: state === "errored" ? "failed" : "completed",
+										reportable: Boolean(finalResponse?.text?.trim()),
+									})
+								: null;
 						const payload = {
 							...basePayload({
 								context,
@@ -915,12 +924,32 @@ export async function persistCoordinatorRuntimeStateFromEvent(
 								reason: null,
 								sessionId: identity.sessionId,
 							}),
-							...(state === "completed" || state === "errored" ? { ended_at: now } : {}),
-							...(finalResponseForEvent(event) ? { final_response: finalResponseForEvent(event) } : {}),
-							...(state === "errored"
-								? { error: { code: "agent_error", message: "GJC agent reported an error", recoverable: true } }
+							...(terminalReceipt
+								? {
+										execution_state: terminalReceipt.execution,
+										receipt_state: terminalReceipt.receipt,
+										ended_at: now,
+									}
 								: {}),
 							...(activityEvent ? activityFieldsForEvent(previous, activityEvent, now, nowMs) : {}),
+							...(finalResponse ? { final_response: finalResponse } : {}),
+							...(terminalReceipt?.receipt === "missing"
+								? {
+										error: {
+											code: "receipt_missing",
+											message: "Agent completed without reportable final response text or artifact path.",
+											recoverable: true,
+										},
+									}
+								: state === "errored"
+									? {
+											error: {
+												code: "agent_error",
+												message: "GJC agent reported an error",
+												recoverable: true,
+											},
+										}
+									: {}),
 						};
 						if (shouldSkipRuntimeStateWrite(previous, payload, nowMs)) return;
 						await writeStateFile(stateFile, payload);

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -128,11 +128,11 @@ import {
 	isExistingThreadBindingRequested,
 } from "./existing-thread-readiness";
 import { imageAttachmentsFromMessage, notificationActionPayload, summaryFromMessage, truncate } from "./helpers";
-import { createKindAwareReconciliation } from "./kind-aware-reconciliation";
+import { createKindAwareReconciliation, type KindAwareReconciliation } from "./kind-aware-reconciliation";
 import { assertNativeRuntimeCompatibility } from "./native-runtime-compatibility";
 import { proposedTelegramIdentity } from "./notification-orchestration";
 import { createPromptReconciliation } from "./prompt-reconciliation";
-import { createReconciliationStore } from "./reconciliation-store";
+import { createReconciliationStore, resolveReconciliationSessionFile } from "./reconciliation-store";
 import { NotificationSessionController, type NotificationSessionRuntime } from "./session-control";
 import type { SlackConversation } from "./slack-conversation";
 import {
@@ -2211,6 +2211,9 @@ function sdkQuerySurface(
 		turnId?: string;
 		clientRef?: string;
 	}) => unknown = () => ({ status: "unknown" }),
+	steerStatusLookup: (selector: { commandId?: string; turnId?: string; clientRef?: string }) => unknown = () => ({
+		status: "unknown",
+	}),
 ): SessionSurface {
 	return createSdkSurfaceFactory({
 		ctx,
@@ -2221,6 +2224,7 @@ function sdkQuerySurface(
 		configOverrides,
 		settings,
 		turnResultLookup,
+		steerStatusLookup,
 		hostTools: () => getInstalledDefinitions("host_tools") !== undefined,
 	}).query;
 }
@@ -2318,9 +2322,14 @@ function sdkControlSurface(
 		) => Promise<void>;
 		noteTransition: (
 			correlation: { commandId: string; turnId: string } | undefined,
-			frame: { type: "agent_start" | "agent_end" } | { type: "agent_failed"; error: unknown },
+			frame:
+				| { type: "agent_start" }
+				| { type: "agent_end"; finalText?: string }
+				| { type: "agent_failed"; error: unknown; finalText?: string },
 		) => Promise<void>;
 		lookup: (selector: { commandId?: string; turnId?: string; clientRef?: string }) => unknown;
+		reserveSteer?: KindAwareReconciliation["reserveSteer"];
+		settleSteer?: KindAwareReconciliation["settleSteer"];
 	},
 ): ControlSurface & {
 	cancelPendingPreflights(): void;
@@ -2335,6 +2344,22 @@ function sdkControlSurface(
 		id: ctx.sessionManager.getSessionId(),
 		api,
 	}).policy;
+	const lastAssistantText = () => {
+		for (const entry of ctx.sessionManager.getBranch().toReversed()) {
+			if (entry.type !== "message" || entry.message.role !== "assistant") continue;
+			const content = entry.message.content;
+			if (typeof content === "string") return content;
+			if (Array.isArray(content))
+				return content
+					.filter(
+						(block): block is { type: "text"; text: string } =>
+							block.type === "text" && typeof block.text === "string",
+					)
+					.map(block => block.text)
+					.join("");
+		}
+		return undefined;
+	};
 	const missingExpectedSessionAudits = new Set<"workflow.gate_answer" | "workflow.plan_approve">();
 	const auditMissingExpectedSessionId = (operation: "workflow.gate_answer" | "workflow.plan_approve") => {
 		if (missingExpectedSessionAudits.has(operation)) return;
@@ -2365,11 +2390,29 @@ function sdkControlSurface(
 		}
 		return "unknown";
 	};
-	const sendSteer = async (text: string) => {
-		// Await admission so a rejection (e.g. handoff in progress) surfaces as a
-		// control error instead of a false `accepted: true`.
-		await api.sendUserMessage(text, { deliverAs: "steer" });
-		return { commandId: crypto.randomUUID(), accepted: true };
+	const sendSteer = async (text: string, clientRef?: string) => {
+		if (clientRef === undefined) {
+			const correlation = { commandId: crypto.randomUUID(), turnId: crypto.randomUUID() };
+			await api.sendUserMessage(text, { deliverAs: "steer" });
+			return { ...correlation, accepted: true };
+		}
+		const normalizedClientRef = clientRef.trim();
+		if (!skillRecon?.reserveSteer || !skillRecon.settleSteer)
+			throw Object.assign(new Error("Steer reconciliation is unavailable."), { code: "unavailable" });
+		const reservation = await skillRecon.reserveSteer(normalizedClientRef, text);
+		if (reservation.replay) return { sessionId: ctx.sessionManager.getSessionId(), ...reservation.result };
+		try {
+			await api.sendUserMessage(text, { deliverAs: "steer" });
+			return {
+				sessionId: ctx.sessionManager.getSessionId(),
+				...(await skillRecon.settleSteer(normalizedClientRef, "accepted")),
+			};
+		} catch (error) {
+			return {
+				sessionId: ctx.sessionManager.getSessionId(),
+				...(await skillRecon.settleSteer(normalizedClientRef, "rejected", error)),
+			};
+		}
 	};
 	const resolveModel = (id: string) => {
 		const [provider, ...modelId] = id.split("/");
@@ -2603,7 +2646,7 @@ function sdkControlSurface(
 	} = {
 		prompt: (text, images, clientRef) =>
 			submitPrompt(text, images, false, undefined, true, controlRequesterContext.getStore(), clientRef, true),
-		steer: text => sendSteer(text),
+		steer: (text, clientRef) => sendSteer(text, clientRef),
 		followUp: text => submitPrompt(text, undefined, false, "followUp", false, controlRequesterContext.getStore()),
 		abort: async () => {
 			const requesterConnectionId = controlRequesterContext.getStore();
@@ -2866,7 +2909,11 @@ function sdkControlSurface(
 						if (skillRecon) skillRecon.release(trimmedClientRef);
 						settleReject(error);
 					} else if (skillRecon) {
-						void skillRecon.noteTransition(correlation, { type: "agent_failed", error });
+						void skillRecon.noteTransition(correlation, {
+							type: "agent_failed",
+							error,
+							finalText: lastAssistantText(),
+						});
 					}
 					throw error;
 				},
@@ -4000,10 +4047,13 @@ export function createNotificationsExtension(
 		// (contract documented in ./prompt-reconciliation and ../prompt-status).
 		// Active records never age into terminal; documented TTL/capacity
 		// eviction is the only removal, after which lookups report `unknown`.
-		const sessionFile =
+		const persistedSessionFile =
 			typeof ctx.sessionManager?.getSessionFile === "function" ? ctx.sessionManager.getSessionFile() : null;
 		const reconciliationSessionId =
 			typeof ctx.sessionManager?.getSessionId === "function" ? ctx.sessionManager.getSessionId() : "";
+		const sessionFile = reconciliationSessionId
+			? resolveReconciliationSessionFile(persistedSessionFile, stateRoot, String(reconciliationSessionId))
+			: null;
 		const durableStore =
 			sessionFile && reconciliationSessionId
 				? createReconciliationStore({ sessionFile, sessionId: String(reconciliationSessionId) })
@@ -4284,12 +4334,13 @@ export function createNotificationsExtension(
 			options: { fence?: boolean } = {},
 			extra?: PromptTerminalExtra,
 		) => {
+			const receiptState = extra?.finalText?.trim() ? "present" : "missing";
 			const submission = promptSubmissions.get(promptSubmissionKey(correlation));
 			if (!submission || submission.terminal || submission.phase !== "active") return;
 			submission.phase = "outcome_claimed";
 			let winner: SdkPromptTerminalOutcome;
 			try {
-				winner = await kindReconciliation.claimPendingOutcome(correlation, requestedOutcome);
+				winner = await kindReconciliation.claimPendingOutcome(correlation, requestedOutcome, receiptState);
 			} catch (error) {
 				// The claim is the durability boundary: without it nothing may be published
 				// and the endpoint must fail closed so the client rejects exactly once. The
@@ -4463,6 +4514,7 @@ export function createNotificationsExtension(
 				configOverrides,
 				settings,
 				selector => kindReconciliation.lookupResult(selector.kind, selector),
+				selector => kindReconciliation.lookupSteer(selector),
 			),
 			id,
 			revisions,
@@ -4506,6 +4558,8 @@ export function createNotificationsExtension(
 					kindReconciliation.noteAccepted("skill", correlation, clientRef, extra),
 				noteTransition: (correlation, frame) => kindReconciliation.noteTransition("skill", correlation, frame),
 				lookup: selector => kindReconciliation.lookup("skill", selector),
+				reserveSteer: kindReconciliation.reserveSteer,
+				settleSteer: kindReconciliation.settleSteer,
 			},
 		);
 		cancelPreflightsForConnection = controlSurface.cancelPendingPreflightsForConnection;

--- a/packages/coding-agent/src/sdk/bus/kind-aware-reconciliation.ts
+++ b/packages/coding-agent/src/sdk/bus/kind-aware-reconciliation.ts
@@ -1,3 +1,5 @@
+import { createHash, randomUUID } from "node:crypto";
+
 /**
  * Kind-aware invocation reconciliation (prompt | skill) with optional durable store.
  * Preserves Q26 admit/first-terminal/capacity/TTL semantics; indexes and caps are per-kind.
@@ -5,21 +7,36 @@
 
 import { sanitizePromptFailure } from "../prompt-failure";
 import type { PromptReconciliationStatus, SdkPromptTerminalOutcome, TurnPromptReconciliation } from "../prompt-status";
+import type { ReceiptState } from "../receipt-state";
 import { sanitizeTurnResultContent, type TurnResultContent, type TurnResultPage } from "../turn-result";
-
 import {
 	PROMPT_RECONCILIATION_ACTIVE_CAPACITY,
 	PROMPT_RECONCILIATION_TERMINAL_CAPACITY,
 	PROMPT_RECONCILIATION_TERMINAL_TTL_MS,
 	type PromptCorrelation,
 } from "./prompt-reconciliation";
-import type { DurableReconciliationRecord, ReconciliationKind, ReconciliationStore } from "./reconciliation-store";
+import type {
+	DurableReconciliationRecord,
+	DurableSteerReconciliationRecord,
+	ReconciliationKind,
+	ReconciliationStore,
+} from "./reconciliation-store";
 
 export type { ReconciliationKind };
 
 export interface KindCorrelation extends PromptCorrelation {
 	kind: ReconciliationKind;
 	content?: TurnResultContent;
+}
+
+export interface SteerReconciliationResult {
+	commandId: string;
+	turnId: string;
+	clientRef: string;
+	status: "accepted" | "rejected" | "uncertain";
+	acceptedAt: number;
+	terminalAt?: number;
+	error?: { code: string; message: string };
 }
 
 export interface KindAwareReconciliation {
@@ -41,6 +58,7 @@ export interface KindAwareReconciliation {
 	claimPendingOutcome(
 		correlation: PromptCorrelation,
 		outcome: SdkPromptTerminalOutcome,
+		receiptState: Extract<ReceiptState, "present" | "missing">,
 	): Promise<SdkPromptTerminalOutcome>;
 	finalizePromptOutcome(
 		correlation: PromptCorrelation,
@@ -57,6 +75,15 @@ export interface KindAwareReconciliation {
 		kind: ReconciliationKind,
 		selector: { commandId?: string; turnId?: string; clientRef?: string },
 	): TurnResultPage;
+	reserveSteer(clientRef: string, text: string): Promise<{ replay: boolean; result: SteerReconciliationResult }>;
+	settleSteer(
+		clientRef: string,
+		status: "accepted" | "rejected" | "uncertain",
+		error?: unknown,
+	): Promise<SteerReconciliationResult>;
+	lookupSteer(
+		selector: string | { commandId?: string; turnId?: string; clientRef?: string },
+	): SteerReconciliationResult | { clientRef?: string; status: "unknown" };
 	cleanup(): void;
 	activeCount(kind: ReconciliationKind): number;
 	/** Hydrate from durable store (call once at session host start). */
@@ -77,26 +104,54 @@ export function createKindAwareReconciliation(
 	const keyOf = (kind: ReconciliationKind, correlation: PromptCorrelation) =>
 		`${kind}:${correlation.commandId}:${correlation.turnId}`;
 	const refKey = (kind: ReconciliationKind, clientRef: string) => `${kind}\0${clientRef}`;
+	const steerKey = (clientRef: string) => `steer:${clientRef}`;
+	const steerResult = (record: DurableSteerReconciliationRecord): SteerReconciliationResult => ({
+		commandId: record.commandId,
+		turnId: record.turnId,
+		clientRef: record.clientRef,
+		status: record.status === "dispatching" ? "uncertain" : record.status,
+		acceptedAt: record.acceptedAt,
+		...(record.status !== "dispatching" && record.status !== "accepted" ? { terminalAt: record.settledAt } : {}),
+		...(record.error
+			? { error: record.error }
+			: record.status === "dispatching"
+				? { error: { code: "delivery_uncertain", message: "Steer delivery is still dispatching or uncertain." } }
+				: {}),
+	});
 
 	const indexRecords = (source: Map<string, DurableReconciliationRecord>) => {
 		const index = new Map<string, string>();
 		for (const [key, record] of source)
-			if (record.clientRef !== undefined) index.set(refKey(record.kind, record.clientRef), key);
+			if (record.kind !== "steer" && record.clientRef !== undefined)
+				index.set(refKey(record.kind, record.clientRef), key);
 		return index;
 	};
 
 	const cleanupRecords = (source: Map<string, DurableReconciliationRecord>) => {
 		const at = now();
-		for (const [key, record] of source)
-			if (record.terminalAt !== undefined && record.terminalAt + PROMPT_RECONCILIATION_TERMINAL_TTL_MS <= at)
-				source.delete(key);
+		for (const [key, record] of source) {
+			const terminalAt = record.kind === "steer" ? record.settledAt : record.terminalAt;
+			if (terminalAt !== undefined && terminalAt + PROMPT_RECONCILIATION_TERMINAL_TTL_MS <= at) source.delete(key);
+		}
 		for (const kind of ["prompt", "skill"] as const) {
 			const terminalEntries = [...source.entries()].filter(
 				([, record]) => record.kind === kind && record.terminalAt !== undefined,
 			);
 			if (terminalEntries.length <= PROMPT_RECONCILIATION_TERMINAL_CAPACITY) continue;
-			terminalEntries.sort((a, b) => (a[1].terminalAt as number) - (b[1].terminalAt as number));
+			terminalEntries.sort(
+				(a, b) =>
+					((a[1].kind === "steer" ? a[1].settledAt : a[1].terminalAt) as number) -
+					((b[1].kind === "steer" ? b[1].settledAt : b[1].terminalAt) as number),
+			);
 			for (const [key] of terminalEntries.slice(0, terminalEntries.length - PROMPT_RECONCILIATION_TERMINAL_CAPACITY))
+				source.delete(key);
+		}
+		const settledSteers: Array<[string, DurableSteerReconciliationRecord]> = [];
+		for (const [key, record] of source)
+			if (record.kind === "steer" && record.settledAt !== undefined) settledSteers.push([key, record]);
+		if (settledSteers.length > PROMPT_RECONCILIATION_TERMINAL_CAPACITY) {
+			settledSteers.sort((a, b) => (a[1].settledAt as number) - (b[1].settledAt as number));
+			for (const [key] of settledSteers.slice(0, settledSteers.length - PROMPT_RECONCILIATION_TERMINAL_CAPACITY))
 				source.delete(key);
 		}
 	};
@@ -122,6 +177,67 @@ export function createKindAwareReconciliation(
 		return await pending;
 	};
 
+	const reserveSteer = async (clientRef: string, text: string) => {
+		const textDigest = createHash("sha256").update(text).digest("hex");
+		return await queueMutation(candidate => {
+			cleanupRecords(candidate);
+			const existing = candidate.get(steerKey(clientRef));
+			if (existing?.kind === "steer") {
+				if (existing.textDigest !== textDigest)
+					throw Object.assign(new Error("clientRef is already bound to different steer text."), {
+						code: "client_ref_conflict",
+					});
+				return { value: { replay: true, result: steerResult(existing) }, changed: false };
+			}
+			const correlation = { commandId: randomUUID(), turnId: randomUUID() };
+			const record: DurableSteerReconciliationRecord = {
+				kind: "steer",
+				...correlation,
+				clientRef,
+				textDigest,
+				createdAt: now(),
+				acceptedAt: now(),
+				status: "dispatching",
+			};
+			candidate.set(steerKey(clientRef), record);
+			return { value: { replay: false, result: steerResult(record) }, changed: true };
+		});
+	};
+
+	const settleSteer = async (clientRef: string, status: "accepted" | "rejected" | "uncertain", error?: unknown) =>
+		await queueMutation(candidate => {
+			const record = candidate.get(steerKey(clientRef));
+			if (record?.kind !== "steer")
+				throw Object.assign(new Error("Unknown steer clientRef."), { code: "unknown_client_ref" });
+			if (record.status !== "dispatching") return { value: steerResult(record), changed: false };
+			record.status = status;
+			record.settledAt = now();
+			if (status !== "accepted") record.error = sanitizePromptFailure(error);
+			cleanupRecords(candidate);
+			return { value: steerResult(record), changed: true };
+		});
+
+	const lookupSteer = (selector: string | { commandId?: string; turnId?: string; clientRef?: string }) => {
+		const record =
+			typeof selector === "string"
+				? records.get(steerKey(selector))
+				: selector.clientRef !== undefined
+					? records.get(steerKey(selector.clientRef))
+					: selector.commandId !== undefined && selector.turnId !== undefined
+						? [...records.values()].find(
+								candidate =>
+									candidate.kind === "steer" &&
+									candidate.commandId === selector.commandId &&
+									candidate.turnId === selector.turnId,
+							)
+						: undefined;
+		return record?.kind === "steer"
+			? steerResult(record)
+			: typeof selector === "string"
+				? { clientRef: selector, status: "unknown" as const }
+				: { status: "unknown" as const };
+	};
+
 	const reservedFor = (kind: ReconciliationKind) => {
 		let set = reservedClientRefs.get(kind);
 		if (!set) {
@@ -138,7 +254,8 @@ export function createKindAwareReconciliation(
 
 	const activeCount = (kind: ReconciliationKind) => {
 		let count = 0;
-		for (const record of records.values()) if (record.kind === kind && record.terminalAt === undefined) count++;
+		for (const record of records.values())
+			if (record.kind !== "steer" && record.kind === kind && record.terminalAt === undefined) count++;
 		return count;
 	};
 
@@ -207,7 +324,7 @@ export function createKindAwareReconciliation(
 		if (!correlation) return;
 		await queueMutation(candidate => {
 			const record = candidate.get(keyOf(kind, correlation));
-			if (!record) return { value: undefined, changed: false };
+			if (!record || record.kind === "steer") return { value: undefined, changed: false };
 			if (record.terminalAt !== undefined) {
 				// The terminal is claimed by one delivery path while the reason arrives on
 				// another, so ordering is not the caller's to control. A late agent_failed
@@ -227,16 +344,18 @@ export function createKindAwareReconciliation(
 				record.status = "in_flight";
 				record.startedAt = now();
 				if (frame.content) record.content = sanitizeTurnResultContent(frame.content.text);
-
 				return { value: undefined, changed: true };
 			}
 			record.terminalAt = now();
 			if (frame.content) record.content = sanitizeTurnResultContent(frame.content.text);
-
 			if (frame.type === "agent_failed") {
 				record.status = "failed";
 				record.error = sanitizePromptFailure(frame.error);
-			} else record.status = "terminal_ok";
+				record.receiptState = frame.content?.text?.trim() ? "present" : "missing";
+			} else {
+				record.status = "terminal_ok";
+				record.receiptState = frame.content?.text?.trim() ? "present" : "missing";
+			}
 			cleanupRecords(candidate);
 			return { value: undefined, changed: true };
 		});
@@ -245,13 +364,14 @@ export function createKindAwareReconciliation(
 	const claimPendingOutcome = async (
 		correlation: PromptCorrelation,
 		outcome: SdkPromptTerminalOutcome,
+		receiptState: Extract<ReceiptState, "present" | "missing">,
 	): Promise<SdkPromptTerminalOutcome> =>
 		await queueMutation(candidate => {
 			const record = candidate.get(keyOf("prompt", correlation));
-			if (!record || record.terminalAt !== undefined || record.kind !== "prompt")
-				return { value: outcome, changed: false };
+			if (record?.kind !== "prompt" || record.terminalAt !== undefined) return { value: outcome, changed: false };
 			if (record.pendingOutcome !== undefined) return { value: record.pendingOutcome, changed: false };
 			record.pendingOutcome = outcome;
+			record.pendingReceiptState = receiptState;
 			return { value: outcome, changed: true };
 		});
 
@@ -263,8 +383,7 @@ export function createKindAwareReconciliation(
 	) => {
 		await queueMutation(candidate => {
 			const record = candidate.get(keyOf("prompt", correlation));
-			if (!record || record.terminalAt !== undefined || record.kind !== "prompt")
-				return { value: undefined, changed: false };
+			if (record?.kind !== "prompt" || record.terminalAt !== undefined) return { value: undefined, changed: false };
 			const finalOutcome = outcome ?? record.pendingOutcome;
 			record.terminalAt = now();
 			if (finalOutcome?.kind === "failed") {
@@ -273,14 +392,18 @@ export function createKindAwareReconciliation(
 			} else record.status = "terminal_ok";
 			record.content = sanitizeTurnResultContent(content);
 			record.outcome = finalOutcome;
+			record.receiptState = record.pendingReceiptState ?? "unknown";
 			record.pendingOutcome = undefined;
+			record.pendingReceiptState = undefined;
 			cleanupRecords(candidate);
 			return { value: undefined, changed: true };
 		});
 	};
 
-	const peekPendingOutcome = (correlation: PromptCorrelation) =>
-		records.get(keyOf("prompt", correlation))?.pendingOutcome;
+	const peekPendingOutcome = (correlation: PromptCorrelation) => {
+		const record = records.get(keyOf("prompt", correlation));
+		return record?.kind === "prompt" ? record.pendingOutcome : undefined;
+	};
 
 	const lookup = (
 		kind: ReconciliationKind,
@@ -294,20 +417,22 @@ export function createKindAwareReconciliation(
 					? keyOf(kind, { commandId: selector.commandId, turnId: selector.turnId })
 					: undefined;
 		const record = key === undefined ? undefined : records.get(key);
-		if (!record) return { status: "unknown" };
+		if (!record) return { status: "unknown", receiptState: "unknown" };
+		if (record.kind === "steer") return { status: "unknown", receiptState: "unknown" };
 		const identity = {
 			commandId: record.commandId,
 			turnId: record.turnId,
 			...(record.clientRef !== undefined ? { clientRef: record.clientRef } : {}),
 			acceptedAt: record.acceptedAt,
 		};
-		if (record.status === "accepted") return { status: "accepted", ...identity };
+		if (record.status === "accepted") return { status: "accepted", receiptState: "absent", ...identity };
 		if (record.status === "in_flight")
-			return { status: "in_flight", ...identity, startedAt: record.startedAt as number };
+			return { status: "in_flight", receiptState: "absent", ...identity, startedAt: record.startedAt as number };
 		const terminal = {
 			...identity,
 			...(record.startedAt !== undefined ? { startedAt: record.startedAt } : {}),
 			terminalAt: record.terminalAt as number,
+			receiptState: record.receiptState ?? "unknown",
 			...(record.outcome !== undefined ? { outcome: record.outcome } : {}),
 		};
 		if (record.status === "terminal_ok")
@@ -331,7 +456,7 @@ export function createKindAwareReconciliation(
 					? keyOf(kind, { commandId: selector.commandId, turnId: selector.turnId })
 					: undefined;
 		const record = key === undefined ? undefined : records.get(key);
-		if (!record) return { status: "unknown" };
+		if (!record || record.kind === "steer") return { status: "unknown" };
 		const identity = {
 			kind: record.kind,
 			commandId: record.commandId,
@@ -347,14 +472,38 @@ export function createKindAwareReconciliation(
 			terminalAt: record.terminalAt as number,
 			...(record.content !== undefined ? { content: record.content } : {}),
 		};
-		if (record.status === "terminal_ok") return { status: "terminal_ok", ...terminal };
+		if (record.status === "terminal_ok")
+			return {
+				status: "terminal_ok",
+				...terminal,
+				...(record.error !== undefined ? { error: record.error } : {}),
+			};
 		return { status: "failed", ...terminal, error: record.error ?? sanitizePromptFailure(undefined) };
 	};
 	const hydrateFromStore = async () => {
 		if (!store) return;
 		const run = async () => {
 			const loaded = await store.load();
-			const candidate = new Map(loaded.map(record => [keyOf(record.kind, record), { ...record }] as const));
+			const candidate = new Map(
+				loaded.map(record => {
+					const hydrated =
+						record.kind === "steer" && record.status === "accepted"
+							? {
+									...record,
+									status: "uncertain" as const,
+									settledAt: now(),
+									error: {
+										code: "process_restart_uncertain",
+										message: "Steer delivery cannot be proven after process restart.",
+									},
+								}
+							: { ...record };
+					return [
+						record.kind === "steer" ? steerKey(record.clientRef) : keyOf(record.kind, record),
+						hydrated,
+					] as const;
+				}),
+			);
 			const candidateIndex = indexRecords(candidate);
 			await store.transact(() => [...candidate.values()].map(record => ({ ...record })));
 			records = candidate;
@@ -381,6 +530,9 @@ export function createKindAwareReconciliation(
 		cleanup,
 		activeCount,
 		hydrateFromStore,
+		reserveSteer,
+		settleSteer,
+		lookupSteer,
 	};
 }
 

--- a/packages/coding-agent/src/sdk/bus/prompt-reconciliation.ts
+++ b/packages/coding-agent/src/sdk/bus/prompt-reconciliation.ts
@@ -22,9 +22,9 @@
  */
 
 import { PROMPT_FAILURE_CODE_MAX, sanitizePromptFailure } from "../prompt-failure";
+import type { ReceiptState } from "../receipt-state";
 
 export { PROMPT_FAILURE_CODE_MAX, sanitizePromptFailure };
-
 export const PROMPT_RECONCILIATION_ACTIVE_CAPACITY = 128;
 export const PROMPT_RECONCILIATION_TERMINAL_CAPACITY = 256;
 export const PROMPT_RECONCILIATION_TERMINAL_TTL_MS = 15 * 60_000;
@@ -43,11 +43,13 @@ export interface PromptReconciliationRecord extends PromptCorrelation {
 	acceptedAt: number;
 	startedAt?: number;
 	terminalAt?: number;
+	receiptState?: Exclude<ReceiptState, "absent">;
 }
 
 export type TurnPromptReconciliation =
 	| {
 			status: "accepted";
+			receiptState: "absent";
 			commandId: string;
 			turnId: string;
 			clientRef?: string;
@@ -55,6 +57,7 @@ export type TurnPromptReconciliation =
 	  }
 	| {
 			status: "in_flight";
+			receiptState: "absent";
 			commandId: string;
 			turnId: string;
 			clientRef?: string;
@@ -63,6 +66,7 @@ export type TurnPromptReconciliation =
 	  }
 	| {
 			status: "terminal_ok";
+			receiptState: Exclude<ReceiptState, "absent">;
 			commandId: string;
 			turnId: string;
 			clientRef?: string;
@@ -74,6 +78,7 @@ export type TurnPromptReconciliation =
 	  }
 	| {
 			status: "failed";
+			receiptState: Exclude<ReceiptState, "absent">;
 			commandId: string;
 			turnId: string;
 			clientRef?: string;
@@ -82,7 +87,7 @@ export type TurnPromptReconciliation =
 			terminalAt: number;
 			error: { code: string; message: string };
 	  }
-	| { status: "unknown" };
+	| { status: "unknown"; receiptState: "unknown" };
 
 export interface PromptReconciliation {
 	/** Fail-closed admission BEFORE any execution; holds an identity-bound reservation. */
@@ -94,7 +99,10 @@ export interface PromptReconciliation {
 	/** Lifecycle transition; terminal outcomes settle exactly once. */
 	noteTransition(
 		correlation: PromptCorrelation | undefined,
-		frame: { type: "agent_start" | "agent_end" } | { type: "agent_failed"; error: unknown },
+		frame:
+			| { type: "agent_start" }
+			| { type: "agent_end"; finalText?: string }
+			| { type: "agent_failed"; error: unknown; finalText?: string },
 	): void;
 	lookup(selector: { commandId?: string; turnId?: string; clientRef?: string }): TurnPromptReconciliation;
 	cleanup(): void;
@@ -184,7 +192,10 @@ export function createPromptReconciliation(options: { now?: () => number } = {})
 
 	const noteTransition = (
 		correlation: PromptCorrelation | undefined,
-		frame: { type: "agent_start" | "agent_end" } | { type: "agent_failed"; error: unknown },
+		frame:
+			| { type: "agent_start" }
+			| { type: "agent_end"; finalText?: string }
+			| { type: "agent_failed"; error: unknown; finalText?: string },
 	) => {
 		if (!correlation) return;
 		const record = records.get(keyOf(correlation));
@@ -207,6 +218,7 @@ export function createPromptReconciliation(options: { now?: () => number } = {})
 			return;
 		}
 		record.terminalAt = now();
+		record.receiptState = frame.finalText?.trim() ? "present" : "missing";
 		if (frame.type === "agent_failed") {
 			record.status = "failed";
 			record.error = sanitizePromptFailure(frame.error);
@@ -226,20 +238,21 @@ export function createPromptReconciliation(options: { now?: () => number } = {})
 					? keyOf({ commandId: selector.commandId, turnId: selector.turnId })
 					: undefined;
 		const record = key === undefined ? undefined : records.get(key);
-		if (!record) return { status: "unknown" };
+		if (!record) return { status: "unknown", receiptState: "unknown" };
 		const identity = {
 			commandId: record.commandId,
 			turnId: record.turnId,
 			...(record.clientRef !== undefined ? { clientRef: record.clientRef } : {}),
 			acceptedAt: record.acceptedAt,
 		};
-		if (record.status === "accepted") return { status: "accepted", ...identity };
+		if (record.status === "accepted") return { status: "accepted", receiptState: "absent", ...identity };
 		if (record.status === "in_flight")
-			return { status: "in_flight", ...identity, startedAt: record.startedAt as number };
+			return { status: "in_flight", receiptState: "absent", ...identity, startedAt: record.startedAt as number };
 		const terminal = {
 			...identity,
 			...(record.startedAt !== undefined ? { startedAt: record.startedAt } : {}),
 			terminalAt: record.terminalAt as number,
+			receiptState: record.receiptState ?? "unknown",
 		};
 		if (record.status === "terminal_ok")
 			return {

--- a/packages/coding-agent/src/sdk/bus/reconciliation-store.ts
+++ b/packages/coding-agent/src/sdk/bus/reconciliation-store.ts
@@ -12,17 +12,25 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { PromptReconciliationStatus, SdkPromptTerminalOutcome } from "../prompt-status";
+import type { ReceiptState } from "../receipt-state";
 import { TURN_RESULT_CONTENT_MAX_BYTES, type TurnResultContent } from "../turn-result";
-
 import type { PromptCorrelation } from "./prompt-reconciliation";
 
 export const RECONCILIATION_STORE_VERSION = 1;
 export const RECONCILIATION_SESSION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 export const RECONCILIATION_DIR_NAME = ".sdk-reconciliation";
 
+export function resolveReconciliationSessionFile(
+	sessionFile: string | undefined | null,
+	stateRoot: string,
+	sessionId: string,
+): string {
+	return sessionFile ?? path.join(stateRoot, `${sessionId}.jsonl`);
+}
+
 export type ReconciliationKind = "prompt" | "skill";
 
-export interface DurableReconciliationRecord extends PromptCorrelation {
+export interface DurableExecutionReconciliationRecord extends PromptCorrelation {
 	kind: ReconciliationKind;
 	clientRef?: string;
 	status: PromptReconciliationStatus;
@@ -31,11 +39,35 @@ export interface DurableReconciliationRecord extends PromptCorrelation {
 	startedAt?: number;
 	terminalAt?: number;
 	outcome?: SdkPromptTerminalOutcome;
+	receiptState?: Exclude<ReceiptState, "absent">;
 	pendingOutcome?: SdkPromptTerminalOutcome;
+	pendingReceiptState?: Extract<ReceiptState, "present" | "missing">;
 	/** Skill-only safe token; never skill args bodies. */
 	skillName?: string;
 	content?: TurnResultContent;
 }
+
+export interface DurableSteerReconciliationRecord {
+	kind: "steer";
+	clientRef: string;
+	textDigest: string;
+	createdAt: number;
+	status: "dispatching" | "accepted" | "rejected" | "uncertain";
+	settledAt?: number;
+	error?: { code: string; message: string };
+	commandId: string;
+	turnId: string;
+	acceptedAt: number;
+	startedAt?: never;
+	terminalAt?: never;
+	outcome?: never;
+	receiptState?: never;
+	pendingOutcome?: never;
+	pendingReceiptState?: never;
+	skillName?: never;
+}
+
+export type DurableReconciliationRecord = DurableExecutionReconciliationRecord | DurableSteerReconciliationRecord;
 
 export interface ReconciliationStoreDocument {
 	version: typeof RECONCILIATION_STORE_VERSION;
@@ -88,18 +120,54 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 /** Record-level validation: JSON-valid but malformed entries must be quarantined too. */
 function isValidRecord(value: unknown): boolean {
 	if (!isRecord(value)) return false;
-	const { kind, commandId, turnId, status, acceptedAt, terminalAt, outcome, pendingOutcome } = value;
+	const { kind } = value;
+	if (kind === "steer") {
+		if (typeof value.clientRef !== "string" || !value.clientRef) return false;
+		if (typeof value.textDigest !== "string" || !/^[0-9a-f]{64}$/.test(value.textDigest)) return false;
+		if (typeof value.createdAt !== "number" || !Number.isFinite(value.createdAt)) return false;
+		if (typeof value.commandId !== "string" || !value.commandId || typeof value.turnId !== "string" || !value.turnId)
+			return false;
+		if (typeof value.acceptedAt !== "number" || !Number.isFinite(value.acceptedAt)) return false;
+		if (!["dispatching", "accepted", "rejected", "uncertain"].includes(value.status as string)) return false;
+		const settled = value.status !== "dispatching";
+		if (settled !== (typeof value.settledAt === "number" && Number.isFinite(value.settledAt))) return false;
+		if ((value.status === "rejected" || value.status === "uncertain") !== (value.error !== undefined)) return false;
+		if (
+			value.error !== undefined &&
+			(!isRecord(value.error) || typeof value.error.code !== "string" || typeof value.error.message !== "string")
+		)
+			return false;
+		return value.receiptState === undefined && value.outcome === undefined;
+	}
 	if (kind !== "prompt" && kind !== "skill") return false;
+	const {
+		commandId,
+		turnId,
+		status,
+		acceptedAt,
+		terminalAt,
+		outcome,
+		pendingOutcome,
+		receiptState,
+		pendingReceiptState,
+	} = value;
 	if (typeof commandId !== "string" || !commandId || typeof turnId !== "string" || !turnId) return false;
 	if (status !== "accepted" && status !== "in_flight" && status !== "terminal_ok" && status !== "failed") return false;
 	if (typeof acceptedAt !== "number" || !Number.isFinite(acceptedAt)) return false;
 	if (terminalAt !== undefined && (typeof terminalAt !== "number" || !Number.isFinite(terminalAt))) return false;
+	if (receiptState !== undefined && !["present", "missing", "unknown"].includes(receiptState as string)) return false;
+	if (pendingReceiptState !== undefined && pendingReceiptState !== "present" && pendingReceiptState !== "missing")
+		return false;
 	// Durable invariants: only prompts carry a pending claim, a finalized record has no
 	// pending claim left, and terminal/active status must agree with `terminalAt`.
 	if (pendingOutcome !== undefined && kind !== "prompt") return false;
+	if (pendingReceiptState !== undefined && kind !== "prompt") return false;
+	if (pendingReceiptState !== undefined && pendingOutcome === undefined) return false;
 	if (pendingOutcome !== undefined && terminalAt !== undefined) return false;
 	const isTerminalStatus = status === "terminal_ok" || status === "failed";
 	if (isTerminalStatus !== (terminalAt !== undefined)) return false;
+	if (!isTerminalStatus && receiptState !== undefined) return false;
+	if (isTerminalStatus && pendingReceiptState !== undefined) return false;
 	if (outcome !== undefined && !isTerminalStatus) return false;
 	if (
 		outcome !== undefined &&
@@ -111,10 +179,6 @@ function isValidRecord(value: unknown): boolean {
 		return false;
 	if (value.clientRef !== undefined && typeof value.clientRef !== "string") return false;
 	if (value.skillName !== undefined && typeof value.skillName !== "string") return false;
-	if (value.error !== undefined) {
-		if (!isRecord(value.error)) return false;
-		if (typeof value.error.code !== "string" || typeof value.error.message !== "string") return false;
-	}
 	if (value.content !== undefined) {
 		if (
 			!isRecord(value.content) ||
@@ -127,6 +191,10 @@ function isValidRecord(value: unknown): boolean {
 			value.content.byteLength > TURN_RESULT_CONTENT_MAX_BYTES
 		)
 			return false;
+	}
+	if (value.error !== undefined) {
+		if (!isRecord(value.error)) return false;
+		if (typeof value.error.code !== "string" || typeof value.error.message !== "string") return false;
 	}
 	return [outcome, pendingOutcome].every(candidate => {
 		if (candidate === undefined) return true;
@@ -166,6 +234,15 @@ export function settleProcessRestart(
 	now: number,
 ): DurableReconciliationRecord[] {
 	return records.map(record => {
+		if (record.kind === "steer") {
+			if (record.status !== "dispatching") return record;
+			return {
+				...record,
+				status: "uncertain",
+				settledAt: now,
+				error: { code: "process_restart_uncertain", message: "Steer delivery is uncertain after process restart." },
+			};
+		}
 		if (record.terminalAt !== undefined) return record;
 		if (record.kind === "prompt") {
 			const outcome: SdkPromptTerminalOutcome = record.pendingOutcome ?? {
@@ -179,7 +256,9 @@ export function settleProcessRestart(
 				status: outcome.kind === "stopped" ? "terminal_ok" : "failed",
 				terminalAt: now,
 				outcome,
+				receiptState: record.pendingReceiptState ?? (outcome.kind === "stopped" ? "missing" : "unknown"),
 				pendingOutcome: undefined,
+				pendingReceiptState: undefined,
 				...(outcome.kind === "failed" ? { error: { code: outcome.code, message: outcome.message } } : {}),
 			};
 		}
@@ -188,6 +267,7 @@ export function settleProcessRestart(
 			status: "failed",
 			terminalAt: now,
 			error: { code: "process_restart", message: "Reconciliation incomplete after process restart." },
+			receiptState: "unknown",
 		};
 	});
 }

--- a/packages/coding-agent/src/sdk/host/control/dispatch.ts
+++ b/packages/coding-agent/src/sdk/host/control/dispatch.ts
@@ -173,7 +173,7 @@ function invoke(
 		case "turn.prompt":
 			return surface.prompt(text(input), input.images, input.clientRef as string | undefined);
 		case "turn.steer":
-			return surface.steer(text(input));
+			return surface.steer(text(input), typeof input.clientRef === "string" ? input.clientRef : undefined);
 		case "turn.follow_up":
 			return surface.followUp(text(input));
 		case "turn.abort":

--- a/packages/coding-agent/src/sdk/host/control/operations.ts
+++ b/packages/coding-agent/src/sdk/host/control/operations.ts
@@ -8,7 +8,7 @@ export type ControlInput = Record<string, unknown>;
 export interface ControlSurface {
 	authorizeElevationClaim?(sdkId: string, input: ControlInput, capability: string): boolean;
 	prompt(text: string, images?: ControlValue, clientRef?: string): Promise<ControlValue> | ControlValue;
-	steer(text: string): Promise<ControlValue> | ControlValue;
+	steer(text: string, clientRef?: string): Promise<ControlValue> | ControlValue;
 	followUp(text: string): Promise<ControlValue> | ControlValue;
 	abort(): Promise<ControlValue> | ControlValue;
 	abortAndPrompt(text: string): Promise<ControlValue> | ControlValue;

--- a/packages/coding-agent/src/sdk/host/query/handlers.ts
+++ b/packages/coding-agent/src/sdk/host/query/handlers.ts
@@ -61,6 +61,7 @@ export interface SessionSurface {
 		commandId?: string;
 		turnId?: string;
 	}): unknown | Promise<unknown>;
+	getSteerStatus?(selector: { commandId?: string; turnId?: string; clientRef?: string }): unknown | Promise<unknown>;
 	/** Q27 effective model-profile catalog from the live session registry. */
 	getModelProfiles?(): unknown[] | Promise<unknown[]>;
 	/**
@@ -178,6 +179,7 @@ const names = [
 	"skill.invoke_status",
 	"providers.list/active",
 	"session.checkpoint",
+	"turn.steer_status",
 ];
 
 export class QueryHandlers {
@@ -252,6 +254,7 @@ export class QueryHandlers {
 			if (query === "Q23") return await this.#resourceBody(request);
 			if (query === "Q24") return await this.#artifact(request);
 			if (query === "Q30") return await this.#checkpoint(request);
+			if (query === "Q31") return await this.#steerStatus(request);
 			if (query === "Q27" && request.input && Object.keys(request.input).length > 0)
 				return this.#error(request, "invalid_request", false, "models.profiles.list does not accept input fields.");
 			if (query === "Q27" && typeof this.surface.getModelProfiles !== "function")
@@ -777,6 +780,56 @@ export class QueryHandlers {
 			page.preview = true;
 		}
 		return { id: request.id, ok: true, page };
+	}
+
+	async #steerStatus(request: QueryRequest): Promise<QueryResponse> {
+		if (request.cursor)
+			return this.#error(request, "invalid_request", false, "turn.steer_status does not support cursors.");
+		const input = request.input ?? {};
+		for (const key of Object.keys(input))
+			if (key !== "commandId" && key !== "turnId" && key !== "clientRef")
+				return this.#error(
+					request,
+					"invalid_request",
+					false,
+					`turn.steer_status does not accept selector field "${key}".`,
+				);
+		const commandId = typeof input.commandId === "string" && input.commandId ? input.commandId : undefined;
+		const turnId = typeof input.turnId === "string" && input.turnId ? input.turnId : undefined;
+		const rawClientRef = typeof input.clientRef === "string" ? input.clientRef : undefined;
+		const clientRef = rawClientRef?.trim() || undefined;
+		if (rawClientRef !== undefined && (!clientRef || clientRef.length > PROMPT_CLIENT_REF_MAX_LENGTH))
+			return this.#error(
+				request,
+				"invalid_request",
+				false,
+				"clientRef must be a non-empty string of at most 128 characters.",
+			);
+		if ((commandId === undefined) !== (turnId === undefined))
+			return this.#error(request, "invalid_request", false, "commandId and turnId must be provided together.");
+		if (commandId !== undefined && clientRef !== undefined)
+			return this.#error(
+				request,
+				"invalid_request",
+				false,
+				"Provide exactly one selector: a commandId/turnId pair or a clientRef.",
+			);
+		if (commandId === undefined && clientRef === undefined)
+			return this.#error(
+				request,
+				"invalid_request",
+				false,
+				"turn.steer_status requires a commandId/turnId pair or a clientRef.",
+			);
+		if (typeof this.surface.getSteerStatus !== "function")
+			return this.#error(request, "unavailable", false, "turn.steer_status is unavailable for this session.");
+		return {
+			id: request.id,
+			ok: true,
+			result: await this.surface.getSteerStatus(
+				clientRef !== undefined ? { clientRef } : { commandId: commandId!, turnId: turnId! },
+			),
+		};
 	}
 
 	#error(request: QueryRequest, code: string, restartQuery = false, message = code, details?: unknown): QueryResponse {

--- a/packages/coding-agent/src/sdk/host/session-runtime.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.ts
@@ -26,6 +26,12 @@ import {
 import { projectQ10Models } from "../models.js";
 import { formatPromptFailureForLocalLog, sanitizePromptFailure } from "../prompt-failure";
 import { OPERATIONS } from "../protocol/operation-registry";
+import {
+	createKindAwareReconciliation,
+	createReconciliationStore,
+	type KindAwareReconciliation,
+	resolveReconciliationSessionFile,
+} from "../reconciliation-extensions";
 import { type ControlSurface, dispatchControl } from "./control";
 import { BROKER_RUNTIME_CLOSE_CAPABILITY_FIELD } from "./control/runtime-gate";
 import { SessionSdkHost, type SessionSdkHostOptions } from "./host";
@@ -249,7 +255,7 @@ export interface InvocationCorrelation {
 	turnId: string;
 }
 
-export type InvocationKind = "prompt" | "skill";
+export type InvocationKind = "prompt" | "skill" | "steer";
 type InvocationStatus = "accepted" | "in_flight" | "terminal_ok" | "failed";
 interface InvocationRecord extends InvocationCorrelation {
 	kind: InvocationKind;
@@ -285,6 +291,7 @@ export function createInvocationReconciliation(
 	const reservationCounts = new Map<InvocationKind, number>([
 		["prompt", 0],
 		["skill", 0],
+		["steer", 0],
 	]);
 	const key = (kind: InvocationKind, correlation: InvocationCorrelation) =>
 		`${kind}:${correlation.commandId}:${correlation.turnId}`;
@@ -498,6 +505,7 @@ export interface SdkSurfaceFactoryOptions {
 		turnId?: string;
 		clientRef?: string;
 	}) => unknown;
+	steerStatusLookup?: (selector: { commandId?: string; turnId?: string; clientRef?: string }) => unknown;
 	hostTools?: boolean | (() => boolean);
 }
 
@@ -526,6 +534,7 @@ function createQuerySurface(
 			turnId?: string;
 			clientRef?: string;
 		}) => unknown;
+		steerStatusLookup?: (selector: { commandId?: string; turnId?: string; clientRef?: string }) => unknown;
 		hostTools?: boolean | (() => boolean);
 	} = {},
 ): SessionSurface {
@@ -800,6 +809,8 @@ function createQuerySurface(
 			turnId?: string;
 			clientRef?: string;
 		}) => (options.turnResultLookup ?? (value => reconciliation.lookupResult(value.kind, value)))(selector),
+		getSteerStatus: (selector: { commandId?: string; turnId?: string; clientRef?: string }) =>
+			(options.steerStatusLookup ?? (value => reconciliation.lookup("steer", value)))(selector),
 		getModelProfiles: async () => {
 			const profiles = ctx.modelRegistry.getModelProfiles();
 			const authenticatedProviders = await collectAuthenticatedProfileProviders(profiles, provider =>
@@ -844,6 +855,7 @@ export function createSdkSurfaceFactory(
 		configOverrides: options.configOverrides,
 		settings: options.settings,
 		turnResultLookup: options.turnResultLookup,
+		steerStatusLookup: options.steerStatusLookup,
 		hostTools: options.hostTools,
 	});
 	return {
@@ -959,6 +971,7 @@ function createControlSurface(
 	api: ExtensionAPI,
 	reconciliation: InvocationReconciliation,
 	onAccepted: (kind: InvocationKind, correlation: InvocationCorrelation) => void,
+	steerReconciliation: KindAwareReconciliation,
 	policy?: SdkSurfacePolicy,
 	settings?: Settings,
 	configOverrides?: Map<string, unknown>,
@@ -1133,9 +1146,22 @@ function createControlSurface(
 					options,
 				),
 			),
-		steer: async text => {
-			await api.sendUserMessage(text, { deliverAs: "steer" });
-			return { commandId: crypto.randomUUID(), accepted: true };
+		steer: async (text, clientRef) => {
+			const retainedClientRef = normalizeClientRef(clientRef);
+			if (retainedClientRef === undefined) {
+				const correlation = newCorrelation();
+				await api.sendUserMessage(text, { deliverAs: "steer" });
+				return { accepted: true, ...correlation };
+			}
+			const durable = steerReconciliation;
+			const reservation = await durable.reserveSteer(retainedClientRef, text);
+			if (reservation.replay) return { accepted: reservation.result.status === "accepted", ...reservation.result };
+			try {
+				await api.sendUserMessage(text, { deliverAs: "steer" });
+				return { accepted: true, ...(await durable.settleSteer(retainedClientRef, "accepted")) };
+			} catch (error) {
+				return { accepted: false, ...(await durable.settleSteer(retainedClientRef, "rejected", error)) };
+			}
 		},
 		followUp: async text =>
 			submit(
@@ -1355,6 +1381,7 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 				revisions: RevisionStore;
 				cursors: CursorRegistry;
 				reconciliation: InvocationReconciliation;
+				steerReconciliation: KindAwareReconciliation;
 				pending: Array<{ kind: InvocationKind; correlation: InvocationCorrelation }>;
 				registerBroker: () => Promise<void>;
 				fenceGateResolutions: () => void;
@@ -1403,6 +1430,13 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 		const cursors = new CursorRegistry(token, revisions);
 		const reconciliation = createInvocationReconciliation({ stateRoot, sessionId });
 		await reconciliation.hydrate();
+		const sessionFile =
+			(typeof ctx.sessionManager.getSessionFile === "function" ? ctx.sessionManager.getSessionFile() : undefined) ??
+			resolveReconciliationSessionFile(undefined, stateRoot, sessionId);
+		const steerReconciliation = createKindAwareReconciliation({
+			store: createReconciliationStore({ sessionFile, sessionId }),
+		});
+		await steerReconciliation.hydrateFromStore();
 		const pending: Array<{ kind: InvocationKind; correlation: InvocationCorrelation }> = [];
 		const configRevision = { current: 0 };
 		let acceptingGateResolutions = true;
@@ -1425,6 +1459,7 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 			api,
 			reconciliation,
 			turnResultLookup: selector => reconciliation.lookupResult(selector.kind, selector),
+			steerStatusLookup: selector => steerReconciliation.lookupSteer(selector),
 			configOverrides: options.configOverrides,
 			settings: options.settings,
 		});
@@ -1436,6 +1471,7 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 			(kind, correlation) => {
 				pending.push({ kind, correlation });
 			},
+			steerReconciliation,
 			surfaceFactory.policy,
 			options.settings,
 			options.configOverrides,
@@ -1576,6 +1612,7 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 			revisions,
 			cursors,
 			reconciliation,
+			steerReconciliation,
 			pending,
 			registerBroker,
 			fenceGateResolutions: () => {
@@ -1602,6 +1639,7 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 					revisions,
 					cursors,
 					reconciliation,
+					steerReconciliation,
 					pending,
 					registerBroker,
 					fenceGateResolutions: () => {

--- a/packages/coding-agent/src/sdk/prompt-status.ts
+++ b/packages/coding-agent/src/sdk/prompt-status.ts
@@ -51,6 +51,8 @@ export interface TurnPromptInput {
  * prompt that is active at process restart is finalized from its durable pending
  * outcome (or `prompt_failed` when it has none), so it never reports as unknown.
  */
+import type { ReceiptState } from "./receipt-state";
+
 export type PromptReconciliationStatus = "accepted" | "in_flight" | "terminal_ok" | "failed";
 export type SdkPromptStopReason = "end_turn" | "max_tokens" | "max_turn_requests" | "refusal" | "cancelled";
 export type SdkPromptFailureCode = "prompt_failed" | "prompt_deadline_exceeded";
@@ -71,16 +73,19 @@ interface TurnPromptReconciliationIdentity {
 
 export interface TurnPromptReconciliationAccepted extends TurnPromptReconciliationIdentity {
 	status: "accepted";
+	receiptState: Extract<ReceiptState, "absent">;
 }
 
 export interface TurnPromptReconciliationInFlight extends TurnPromptReconciliationIdentity {
 	status: "in_flight";
+	receiptState: Extract<ReceiptState, "absent">;
 	/** Epoch milliseconds of the agent_start transition. */
 	startedAt: number;
 }
 
 export interface TurnPromptReconciliationTerminalOk extends TurnPromptReconciliationIdentity {
 	status: "terminal_ok";
+	receiptState: Exclude<ReceiptState, "absent">;
 	startedAt?: number;
 	/** Epoch milliseconds of the terminal transition. */
 	terminalAt: number;
@@ -91,6 +96,7 @@ export interface TurnPromptReconciliationTerminalOk extends TurnPromptReconcilia
 
 export interface TurnPromptReconciliationFailed extends TurnPromptReconciliationIdentity {
 	status: "failed";
+	receiptState: Exclude<ReceiptState, "absent">;
 	startedAt?: number;
 	terminalAt: number;
 	/** Bounded, sanitized failure detail (code safe-token ≤64, message ≤512). */
@@ -100,6 +106,7 @@ export interface TurnPromptReconciliationFailed extends TurnPromptReconciliation
 
 export interface TurnPromptReconciliationUnknown {
 	status: "unknown";
+	receiptState: Extract<ReceiptState, "unknown">;
 }
 
 export type TurnPromptReconciliation =

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -1620,6 +1620,24 @@
 		]
 	},
 	{
+		"sourceId": "registry:Q31",
+		"sourceFile": "packages/coding-agent/src/sdk/protocol/operation-registry.ts",
+		"sourceKind": "registry",
+		"decision": "include",
+		"sdkId": "turn.steer_status",
+		"adapterMappings": {
+			"telegram": "prohibited",
+			"discord": "prohibited",
+			"slack": "prohibited",
+			"mcp": "generic_safe",
+			"acp": "generic_safe",
+			"daemonCli": "generic_safe"
+		},
+		"testIds": [
+			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
+		]
+	},
+	{
 		"sourceId": "registry:R01",
 		"sourceFile": "packages/coding-agent/src/sdk/protocol/operation-registry.ts",
 		"sourceKind": "registry",

--- a/packages/coding-agent/src/sdk/protocol/operation-registry.ts
+++ b/packages/coding-agent/src/sdk/protocol/operation-registry.ts
@@ -161,6 +161,7 @@ const queries = [
 
 	["providers.list/active", "List active providers."],
 	["session.checkpoint", "Resolve a durable transcript checkpoint into a connection-owned replay cursor."],
+	["turn.steer_status", "Read the durable acknowledgement status of a correlated steer by clientRef."],
 ] as const;
 
 const reverse = [
@@ -207,6 +208,7 @@ function controlDisposition(id: string): Record<Adapter, AdapterDisposition> {
 function controlErrors(id: string): string[] {
 	const errors: Record<string, string[]> = {
 		C01: ["client_ref_conflict", "reconciliation_capacity", "reconciliation_persist_failed"],
+		C02: ["client_ref_conflict", "reconciliation_capacity", "reconciliation_persist_failed"],
 		C09: ["client_ref_conflict", "reconciliation_capacity", "reconciliation_persist_failed"],
 		C06: ["action_claimed"],
 		C07: ["action_claimed", "terminal_uncertain"],
@@ -249,7 +251,7 @@ function queryContinuityClass(id: string): QueryContinuityClass {
 }
 
 function queryDisposition(id: string): Record<Adapter, AdapterDisposition> {
-	if (["Q23", "Q24", "Q25", "Q26", "Q27", "Q28", "Q29", "Q30"].includes(id))
+	if (["Q23", "Q24", "Q25", "Q26", "Q27", "Q28", "Q29", "Q30", "Q31"].includes(id))
 		return dispositions({ telegram: "prohibited", discord: "prohibited", slack: "prohibited" });
 	return dispositions();
 }

--- a/packages/coding-agent/src/sdk/receipt-state.ts
+++ b/packages/coding-agent/src/sdk/receipt-state.ts
@@ -1,0 +1,43 @@
+export type ReceiptState = "absent" | "present" | "missing" | "unknown";
+
+export type ExecutionState = "accepted" | "in_flight" | "terminal_ok" | "failed" | "cancelled" | "unknown";
+
+export interface ReceiptSource {
+	text?: string | null;
+	artifactPath?: string | null;
+}
+
+export interface TerminalReceiptInput {
+	execution: "accepted" | "in_flight" | "completed" | "failed" | "cancelled" | "unknown";
+	reportable: boolean;
+}
+
+export interface TerminalReceiptState {
+	execution: ExecutionState;
+	receipt: ReceiptState;
+}
+
+export function reportableReceipt({ text, artifactPath }: ReceiptSource): boolean {
+	return Boolean(text?.trim() || artifactPath?.trim());
+}
+
+export function receiptStateForTerminal(source: ReceiptSource): Extract<ReceiptState, "present" | "missing"> {
+	return reportableReceipt(source) ? "present" : "missing";
+}
+
+export function reduceTerminalReceiptState(input: TerminalReceiptInput): TerminalReceiptState {
+	switch (input.execution) {
+		case "accepted":
+			return { execution: "accepted", receipt: "absent" };
+		case "in_flight":
+			return { execution: "in_flight", receipt: "absent" };
+		case "completed":
+			return { execution: "terminal_ok", receipt: input.reportable ? "present" : "missing" };
+		case "failed":
+			return { execution: "failed", receipt: input.reportable ? "present" : "absent" };
+		case "cancelled":
+			return { execution: "cancelled", receipt: input.reportable ? "present" : "absent" };
+		case "unknown":
+			return { execution: "unknown", receipt: "unknown" };
+	}
+}

--- a/packages/coding-agent/src/sdk/reconciliation-extensions.ts
+++ b/packages/coding-agent/src/sdk/reconciliation-extensions.ts
@@ -1,0 +1,14 @@
+export {
+	createKindAwareReconciliation,
+	type KindAwareReconciliation,
+	type ReconciliationKind,
+	type SteerReconciliationResult,
+} from "./bus/kind-aware-reconciliation";
+export {
+	createReconciliationStore,
+	type DurableExecutionReconciliationRecord,
+	type DurableReconciliationRecord,
+	type DurableSteerReconciliationRecord,
+	type ReconciliationStore,
+	resolveReconciliationSessionFile,
+} from "./bus/reconciliation-store";

--- a/packages/coding-agent/test/agent-session-terminal-receipt-state.test.ts
+++ b/packages/coding-agent/test/agent-session-terminal-receipt-state.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@gajae-code/agent-core";
+import { getBundledModel } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import {
+	GJC_COORDINATOR_SESSION_ID_ENV,
+	GJC_COORDINATOR_SESSION_STATE_FILE_ENV,
+} from "@gajae-code/coding-agent/gjc-runtime/session-state-sidecar";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { TempDir } from "@gajae-code/utils";
+
+const originalStateFile = process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV];
+const originalSessionId = process.env[GJC_COORDINATOR_SESSION_ID_ENV];
+let session: AgentSession | undefined;
+let authStorage: AuthStorage | undefined;
+let tempDir: TempDir | undefined;
+
+afterEach(async () => {
+	await session?.dispose();
+	session = undefined;
+	authStorage?.close();
+	authStorage = undefined;
+	tempDir?.removeSync();
+	tempDir = undefined;
+	if (originalStateFile === undefined) delete process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV];
+	else process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = originalStateFile;
+	if (originalSessionId === undefined) delete process.env[GJC_COORDINATOR_SESSION_ID_ENV];
+	else process.env[GJC_COORDINATOR_SESSION_ID_ENV] = originalSessionId;
+});
+
+async function runResponse(content: string) {
+	tempDir = TempDir.createSync("@gjc-terminal-receipt-");
+	const stateFile = path.join(tempDir.path(), "runtime-state.json");
+	process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+	process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "terminal-receipt-session";
+	authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+	authStorage.setRuntimeApiKey("anthropic", "test-key");
+	const modelRegistry = new ModelRegistry(authStorage);
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Expected bundled model");
+	const agent = new Agent({
+		getApiKey: () => "test-key",
+		initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+		streamFn: createMockModel({ responses: [{ content: [content] }] }).stream,
+	});
+	session = new AgentSession({
+		agent,
+		sessionManager: SessionManager.inMemory(),
+		settings: Settings.isolated({ "compaction.enabled": false }),
+		modelRegistry,
+	});
+	const terminal = Promise.withResolvers<void>();
+	session.subscribe(event => {
+		if (event.type === "agent_end") terminal.resolve();
+	});
+	await session.prompt("respond");
+	await terminal.promise;
+	for (let attempt = 0; attempt < 100; attempt++) {
+		if (await Bun.file(stateFile).exists()) {
+			const payload = JSON.parse(await Bun.file(stateFile).text()) as Record<string, unknown>;
+			if (payload.state === "completed" || payload.state === "errored") return payload;
+		}
+		await Bun.sleep(10);
+	}
+	throw new Error("Timed out waiting for terminal runtime state");
+}
+
+describe("AgentSession terminal receipt state", () => {
+	it("writes present receipt truth through the real AgentSession event consumer", async () => {
+		expect(await runResponse("done")).toMatchObject({
+			state: "completed",
+			execution_state: "terminal_ok",
+			receipt_state: "present",
+			final_response: { text: "done" },
+		});
+	});
+
+	it("writes receipt_missing through the real AgentSession event consumer", async () => {
+		expect(await runResponse("   ")).toMatchObject({
+			state: "completed",
+			execution_state: "terminal_ok",
+			receipt_state: "missing",
+			error: { code: "receipt_missing" },
+		});
+	});
+});

--- a/packages/coding-agent/test/helpers/sdk-production-host.ts
+++ b/packages/coding-agent/test/helpers/sdk-production-host.ts
@@ -15,14 +15,13 @@ import {
 } from "./fixture-broker-cleanup";
 import { isolatedNotificationSettings } from "./notification-settings";
 
-export async function startProductionSdkHost(
-	cwd: string,
-	options: { acceptPromptPreflightWithoutExecution?: boolean } = {},
-): Promise<{
+export interface ProductionSdkHost {
 	endpoint: { url: string; token: string; pid: number };
 	sessionId: string;
+	session: Awaited<ReturnType<typeof createAgentSession>>["session"];
 	endpointMtimeMs: number;
 	observed: Array<{ kind: "control" | "query"; operation: string }>;
+	dispatches: Array<{ deliverAs?: string }>;
 	triggerAsk: (
 		question: string,
 		options: string[],
@@ -35,8 +34,13 @@ export async function startProductionSdkHost(
 		>[0],
 	) => { registered: true; result: Promise<unknown> } | { registered: false; reason: "authority_unavailable" };
 	stop: () => Promise<void>;
-}> {
+}
+export async function startProductionSdkHost(
+	cwd: string,
+	options: { acceptPromptPreflightWithoutExecution?: boolean } = {},
+): Promise<ProductionSdkHost> {
 	const observed: Array<{ kind: "control" | "query"; operation: string }> = [];
+	const dispatches: Array<{ deliverAs?: string }> = [];
 	const agentDir = path.join(cwd, ".gjc", "agent");
 	const fixtureEnv = createFixtureBrokerEnvironment(agentDir, agentDir);
 	return withFixtureBrokerEnvironment(async () => {
@@ -90,6 +94,11 @@ export async function startProductionSdkHost(
 				},
 				dispose: () => session.dispose(),
 			});
+			const originalSendUserMessage = session.sendUserMessage.bind(session);
+			session.sendUserMessage = async (content, options) => {
+				dispatches.push({ deliverAs: options?.deliverAs });
+				return await originalSendUserMessage(content, options);
+			};
 			if (options.acceptPromptPreflightWithoutExecution) {
 				session.sendUserMessage = async (_content, promptOptions) => {
 					if (promptOptions?.onPreflightAcceptCommit) await promptOptions.onPreflightAcceptCommit();
@@ -133,7 +142,9 @@ export async function startProductionSdkHost(
 				endpoint,
 				endpointMtimeMs,
 				sessionId: session.sessionId,
+				session,
 				observed,
+				dispatches,
 				triggerAsk,
 				triggerGate,
 				stop: () => cleanupFixtureRoot(cleanup),

--- a/packages/coding-agent/test/manifests/sdk-adapter-parity-v1.json
+++ b/packages/coding-agent/test/manifests/sdk-adapter-parity-v1.json
@@ -8844,6 +8844,102 @@
 			"expected": "forwarded"
 		},
 		{
+			"adapterTestId": "AD-T-Q31",
+			"sdkId": "turn.steer_status",
+			"adapter": "telegram",
+			"disposition": "prohibited",
+			"testFile": "packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+			"testNamePattern": "AD-T-Q31",
+			"argv": [
+				"bun",
+				"test",
+				"packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+				"--test-name-pattern",
+				"^AD-T-Q31:"
+			],
+			"expected": "rejected_before_send"
+		},
+		{
+			"adapterTestId": "AD-D-Q31",
+			"sdkId": "turn.steer_status",
+			"adapter": "discord",
+			"disposition": "prohibited",
+			"testFile": "packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+			"testNamePattern": "AD-D-Q31",
+			"argv": [
+				"bun",
+				"test",
+				"packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+				"--test-name-pattern",
+				"^AD-D-Q31:"
+			],
+			"expected": "rejected_before_send"
+		},
+		{
+			"adapterTestId": "AD-S-Q31",
+			"sdkId": "turn.steer_status",
+			"adapter": "slack",
+			"disposition": "prohibited",
+			"testFile": "packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+			"testNamePattern": "AD-S-Q31",
+			"argv": [
+				"bun",
+				"test",
+				"packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+				"--test-name-pattern",
+				"^AD-S-Q31:"
+			],
+			"expected": "rejected_before_send"
+		},
+		{
+			"adapterTestId": "AD-M-Q31",
+			"sdkId": "turn.steer_status",
+			"adapter": "mcp",
+			"disposition": "generic_safe",
+			"testFile": "packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+			"testNamePattern": "AD-M-Q31",
+			"argv": [
+				"bun",
+				"test",
+				"packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+				"--test-name-pattern",
+				"^AD-M-Q31:"
+			],
+			"expected": "forwarded"
+		},
+		{
+			"adapterTestId": "AD-A-Q31",
+			"sdkId": "turn.steer_status",
+			"adapter": "acp",
+			"disposition": "generic_safe",
+			"testFile": "packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+			"testNamePattern": "AD-A-Q31",
+			"argv": [
+				"bun",
+				"test",
+				"packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+				"--test-name-pattern",
+				"^AD-A-Q31:"
+			],
+			"expected": "forwarded"
+		},
+		{
+			"adapterTestId": "AD-L-Q31",
+			"sdkId": "turn.steer_status",
+			"adapter": "daemonCli",
+			"disposition": "generic_safe",
+			"testFile": "packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+			"testNamePattern": "AD-L-Q31",
+			"argv": [
+				"bun",
+				"test",
+				"packages/coding-agent/test/sdk-adapter-dispositions.test.ts",
+				"--test-name-pattern",
+				"^AD-L-Q31:"
+			],
+			"expected": "forwarded"
+		},
+		{
 			"adapterTestId": "AD-T-R01",
 			"sdkId": "terminal.create/output/release/wait",
 			"adapter": "telegram",

--- a/packages/coding-agent/test/sdk-adapter-dispositions.test.ts
+++ b/packages/coding-agent/test/sdk-adapter-dispositions.test.ts
@@ -29,7 +29,7 @@ const parityRows = (
 		rows: ParityRow[];
 	}
 ).rows;
-expect(parityRows).toHaveLength(576);
+expect(parityRows).toHaveLength(588);
 const parityPrefix: Record<Adapter, string> = {
 	telegram: "T",
 	discord: "D",

--- a/packages/coding-agent/test/sdk-control-dispatch.test.ts
+++ b/packages/coding-agent/test/sdk-control-dispatch.test.ts
@@ -432,6 +432,20 @@ test("preserves typed registry errors and maps unknown failures to internal", as
 		request(tools),
 	);
 	expect(internal.error).toEqual({ code: "internal", message: "Control operation failed." });
+	const steer = OPERATIONS.find(row => row.sdkId === "turn.steer")!;
+	const conflict = await dispatchControl(
+		{
+			steer: () => {
+				throw { code: "client_ref_conflict", message: "clientRef is already bound to different steer text." };
+			},
+		} as unknown as ControlSurface,
+		steer,
+		request(steer),
+	);
+	expect(conflict.error).toEqual({
+		code: "client_ref_conflict",
+		message: "clientRef is already bound to different steer text.",
+	});
 });
 
 test("preserves action_claimed workflow fences through control dispatch", async () => {

--- a/packages/coding-agent/test/sdk-host-steer-integration.test.ts
+++ b/packages/coding-agent/test/sdk-host-steer-integration.test.ts
@@ -1,0 +1,189 @@
+import { expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "../src/extensibility/extensions";
+import { createSdkSessionRuntimeExtension, type SessionSdkTransport } from "../src/sdk/host/session-runtime";
+
+interface Harness {
+	emit(frame: Record<string, unknown>): Promise<Record<string, unknown>>;
+	start(): Promise<void>;
+	stop(): Promise<void>;
+	dispatches: number;
+	persistedAtDispatch?: string;
+}
+
+function createHarness(cwd: string, sessionId: string, sessionFile: string | undefined): Harness {
+	const handlers = new Map<string, (event: unknown, context: ExtensionContext) => unknown>();
+	let receive: ((connectionId: string, frame: never) => void) | undefined;
+	let response: Record<string, unknown> | undefined;
+	let dispatches = 0;
+	let persistedAtDispatch: string | undefined;
+	const transport: SessionSdkTransport = {
+		sessionId,
+		stateRoot: path.join(cwd, ".gjc", "state"),
+		token: "test-token",
+		sendFrame: (_connectionId, frame) => {
+			response = frame as Record<string, unknown>;
+		},
+		onFrame: handler => {
+			receive = handler;
+			return () => {
+				receive = undefined;
+			};
+		},
+		start: async () => ({ url: "memory://host-steer" }),
+		stop: async () => {},
+	};
+	const api = {
+		on: (event: string, handler: (event: unknown, context: ExtensionContext) => unknown) =>
+			handlers.set(event, handler),
+		registerCommand: () => {},
+		sendUserMessage: async () => {
+			dispatches++;
+			persistedAtDispatch = await fs.readFile(
+				path.join(
+					path.dirname(sessionFile ?? path.join(cwd, ".gjc", "state", `${sessionId}.jsonl`)),
+					".sdk-reconciliation",
+					`${sessionId}.json`,
+				),
+				"utf8",
+			);
+		},
+	} as unknown as ExtensionAPI;
+	createSdkSessionRuntimeExtension(api, { agentDir: cwd, createTransport: () => transport });
+	const base = {
+		cwd,
+		sessionMetadata: { kind: "main" },
+		sessionManager: {
+			getSessionId: () => sessionId,
+			getSessionFile: () => sessionFile,
+			getCwd: () => cwd,
+			getSessionName: () => "host steer oracle",
+			getUsageStatistics: () => ({}),
+			getBranch: () => [],
+		},
+		model: { provider: "test", id: "model" },
+		modelRegistry: { getAll: () => [], find: () => undefined },
+		getContextUsage: () => ({ tokens: 0, contextWindow: 1, percent: 0 }),
+		getThinkingLevel: () => "off",
+		getActivePromptHandle: () => undefined,
+		getPendingMessageCounts: () => ({ steering: 0, followUp: 0, nextTurn: 0 }),
+		getTranscript: () => [],
+	} as unknown as ExtensionContext;
+	return {
+		start: async () => {
+			await handlers.get("session_start")?.({ type: "session_start" }, base);
+		},
+		stop: async () => {
+			await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, base);
+		},
+		emit: async frame => {
+			response = undefined;
+			receive?.("client", frame as never);
+			for (let attempts = 0; response === undefined && attempts < 100; attempts++) await Bun.sleep(1);
+			if (!response) throw new Error("host did not respond");
+			return response;
+		},
+		get dispatches() {
+			return dispatches;
+		},
+		get persistedAtDispatch() {
+			return persistedAtDispatch;
+		},
+	};
+}
+
+async function control(harness: Harness, id: string, text: string, clientRef: string) {
+	return await harness.emit({ type: "control_request", id, operation: "turn.steer", input: { text, clientRef } });
+}
+
+async function query(harness: Harness, id: string, input: Record<string, unknown>) {
+	return await harness.emit({ type: "query_request", id, query: "turn.steer_status", input });
+}
+
+test("production SDK host correlates durable steer replay and restart without redispatch", async () => {
+	const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-host-steer-"));
+	try {
+		const sessionId = "host-steer-oracle";
+		const sessionFile = path.join(cwd, "sessions", "session.jsonl");
+		await fs.mkdir(path.dirname(sessionFile), { recursive: true });
+		await fs.writeFile(sessionFile, "");
+		const first = createHarness(cwd, sessionId, sessionFile);
+		await first.start();
+		const accepted = await control(first, "accept", "deliver exactly once", "  caller-ref  ");
+		expect(accepted).toMatchObject({ ok: true, result: { accepted: true, clientRef: "caller-ref" } });
+		const correlation = (accepted.result ?? {}) as Record<string, unknown>;
+		expect(correlation.commandId).toBeString();
+		expect(correlation.turnId).toBeString();
+		expect(first.persistedAtDispatch).toContain('"status":"dispatching"');
+		expect(await control(first, "replay", "deliver exactly once", "caller-ref")).toMatchObject({
+			ok: true,
+			result: { commandId: correlation.commandId, turnId: correlation.turnId },
+		});
+		expect(first.dispatches).toBe(1);
+		expect(await control(first, "conflict", "different text", "caller-ref")).toMatchObject({
+			ok: false,
+		});
+		expect(first.dispatches).toBe(1);
+		expect(await query(first, "by-ref", { clientRef: "caller-ref" })).toMatchObject({
+			ok: true,
+			result: { commandId: correlation.commandId, turnId: correlation.turnId },
+		});
+		expect(
+			await query(first, "by-pair", { commandId: correlation.commandId, turnId: correlation.turnId }),
+		).toMatchObject({
+			ok: true,
+			result: { clientRef: "caller-ref" },
+		});
+		const persisted = await fs.readFile(
+			path.join(path.dirname(sessionFile), ".sdk-reconciliation", `${sessionId}.json`),
+			"utf8",
+		);
+		expect(persisted).not.toContain("deliver exactly once");
+		expect(persisted).not.toContain("different text");
+		await first.stop();
+
+		const restarted = createHarness(cwd, sessionId, sessionFile);
+		await restarted.start();
+		expect(await query(restarted, "restart", { clientRef: "caller-ref" })).toMatchObject({
+			ok: true,
+			result: { status: "uncertain", error: { code: "process_restart_uncertain" } },
+		});
+		expect(await control(restarted, "restart-replay", "deliver exactly once", "caller-ref")).toMatchObject({
+			ok: true,
+			result: { accepted: false, status: "uncertain" },
+		});
+		expect(restarted.dispatches).toBe(0);
+		await restarted.stop();
+	} finally {
+		await fs.rm(cwd, { recursive: true, force: true });
+	}
+});
+
+test("production SDK host persists steer reconciliation under state root when session file is undefined", async () => {
+	const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-host-steer-state-root-"));
+	try {
+		const sessionId = "in-memory-host-steer";
+		const harness = createHarness(cwd, sessionId, undefined);
+		await harness.start();
+		const accepted = await control(harness, "accept", "private steer text", "state-root-ref");
+		expect(accepted).toMatchObject({ ok: true, result: { accepted: true, clientRef: "state-root-ref" } });
+		const persisted = await fs.readFile(
+			path.join(cwd, ".gjc", "state", ".sdk-reconciliation", `${sessionId}.json`),
+			"utf8",
+		);
+		expect(persisted).toContain('"status":"accepted"');
+		expect(persisted).not.toContain("private steer text");
+		await harness.stop();
+		const restarted = createHarness(cwd, sessionId, undefined);
+		await restarted.start();
+		expect(await query(restarted, "restart", { clientRef: "state-root-ref" })).toMatchObject({
+			ok: true,
+			result: { status: "uncertain", error: { code: "process_restart_uncertain" } },
+		});
+		await restarted.stop();
+	} finally {
+		await fs.rm(cwd, { recursive: true, force: true });
+	}
+});

--- a/packages/coding-agent/test/sdk-operation-inventory.test.ts
+++ b/packages/coding-agent/test/sdk-operation-inventory.test.ts
@@ -36,7 +36,7 @@ describe("SDK operation inventory", () => {
 	it("has complete typed operation and adapter coverage", () => {
 		expect(OPERATIONS.filter(operation => operation.kind === "control")).toHaveLength(53);
 		expect(OPERATIONS.filter(operation => operation.kind === "global")).toHaveLength(7);
-		expect(OPERATIONS.filter(operation => operation.kind === "query")).toHaveLength(30);
+		expect(OPERATIONS.filter(operation => operation.kind === "query")).toHaveLength(31);
 		expect(OPERATIONS.filter(operation => operation.kind === "reverse")).toHaveLength(6);
 		for (const operation of OPERATIONS) {
 			expect(Object.keys(operation.adapterDispositions).sort()).toEqual([...ADAPTERS].sort());

--- a/packages/coding-agent/test/sdk-prompt-terminal-arbiter.test.ts
+++ b/packages/coding-agent/test/sdk-prompt-terminal-arbiter.test.ts
@@ -70,8 +70,8 @@ describe("SDK prompt terminal arbiter", () => {
 		const { reconciliation, store } = await accepted();
 		const first = stopped("end_turn");
 
-		expect(await reconciliation.claimPendingOutcome(correlation, first)).toEqual(first);
-		expect(await reconciliation.claimPendingOutcome(correlation, stopped("cancelled"))).toEqual(first);
+		expect(await reconciliation.claimPendingOutcome(correlation, first, "missing")).toEqual(first);
+		expect(await reconciliation.claimPendingOutcome(correlation, stopped("cancelled"), "missing")).toEqual(first);
 		expect(reconciliation.peekPendingOutcome(correlation)).toEqual(first);
 		expect(reconciliation.lookup("prompt", correlation)).toMatchObject({ status: "accepted" });
 		expect(reconciliation.lookup("prompt", correlation)).not.toHaveProperty("outcome");
@@ -85,7 +85,7 @@ describe("SDK prompt terminal arbiter", () => {
 		for (const reason of ["end_turn", "max_tokens", "max_turn_requests", "refusal", "cancelled"] as const) {
 			const { reconciliation } = await accepted();
 			const outcome = stopped(reason);
-			await reconciliation.claimPendingOutcome(correlation, outcome);
+			await reconciliation.claimPendingOutcome(correlation, outcome, "missing");
 			await reconciliation.finalizePromptOutcome(correlation);
 
 			expect(reconciliation.lookup("prompt", correlation)).toMatchObject({
@@ -99,7 +99,7 @@ describe("SDK prompt terminal arbiter", () => {
 		for (const code of ["prompt_failed", "prompt_deadline_exceeded"] as const) {
 			const { reconciliation } = await accepted();
 			const outcome = failed(code);
-			await reconciliation.claimPendingOutcome(correlation, outcome);
+			await reconciliation.claimPendingOutcome(correlation, outcome, "missing");
 			await reconciliation.finalizePromptOutcome(correlation);
 			expect(reconciliation.lookup("prompt", correlation)).toMatchObject({
 				status: "failed",
@@ -109,7 +109,7 @@ describe("SDK prompt terminal arbiter", () => {
 		}
 
 		const { reconciliation } = await accepted();
-		await reconciliation.claimPendingOutcome(correlation, failed("prompt_failed"));
+		await reconciliation.claimPendingOutcome(correlation, failed("prompt_failed"), "missing");
 		await reconciliation.finalizePromptOutcome(correlation, undefined, { code: "overridden", message: "override" });
 		expect(reconciliation.lookup("prompt", correlation)).toMatchObject({
 			status: "failed",
@@ -121,7 +121,7 @@ describe("SDK prompt terminal arbiter", () => {
 		const { reconciliation, store } = await accepted();
 		store.failNext();
 
-		await expect(reconciliation.claimPendingOutcome(correlation, stopped("end_turn"))).rejects.toThrow(
+		await expect(reconciliation.claimPendingOutcome(correlation, stopped("end_turn"), "missing")).rejects.toThrow(
 			"persist failed",
 		);
 		expect(reconciliation.lookup("prompt", correlation)).toMatchObject({ status: "accepted" });
@@ -137,7 +137,7 @@ describe("SDK prompt terminal arbiter", () => {
 		const claimEntered = Promise.withResolvers<void>();
 		store.holdNext(held.promise, claimEntered.resolve);
 
-		const claim = reconciliation.claimPendingOutcome(correlation, stopped("end_turn"));
+		const claim = reconciliation.claimPendingOutcome(correlation, stopped("end_turn"), "missing");
 		await claimEntered.promise;
 		const skill = reconciliation.noteAccepted("skill", { commandId: "skill-command", turnId: "skill-turn" });
 		held.resolve();
@@ -173,7 +173,7 @@ describe("SDK prompt terminal arbiter", () => {
 	});
 	test("surfaces a late agent_failed reason on a terminal_ok record through the production lookup and persists it", async () => {
 		const { reconciliation, store } = await accepted();
-		await reconciliation.claimPendingOutcome(correlation, stopped("end_turn"));
+		await reconciliation.claimPendingOutcome(correlation, stopped("end_turn"), "missing");
 		await reconciliation.finalizePromptOutcome(correlation);
 
 		const settled = reconciliation.lookup("prompt", correlation);
@@ -200,7 +200,7 @@ describe("SDK prompt terminal arbiter", () => {
 
 	test("keeps the first late reason when later agent_failed frames disagree", async () => {
 		const { reconciliation } = await accepted();
-		await reconciliation.claimPendingOutcome(correlation, stopped("end_turn"));
+		await reconciliation.claimPendingOutcome(correlation, stopped("end_turn"), "missing");
 		await reconciliation.finalizePromptOutcome(correlation);
 		await reconciliation.noteTransition("prompt", correlation, {
 			type: "agent_failed",
@@ -218,7 +218,7 @@ describe("SDK prompt terminal arbiter", () => {
 
 	test("does not enrich a terminal record with a late agent_start or agent_end", async () => {
 		const { reconciliation } = await accepted();
-		await reconciliation.claimPendingOutcome(correlation, stopped("end_turn"));
+		await reconciliation.claimPendingOutcome(correlation, stopped("end_turn"), "missing");
 		await reconciliation.finalizePromptOutcome(correlation);
 		const before = reconciliation.lookup("prompt", correlation);
 		await reconciliation.noteTransition("prompt", correlation, { type: "agent_start" });

--- a/packages/coding-agent/test/sdk-q26-prompt-status.test.ts
+++ b/packages/coding-agent/test/sdk-q26-prompt-status.test.ts
@@ -28,6 +28,7 @@ describe("prompt reconciliation record", () => {
 		rec.noteAccepted(correlation(), "ref-1");
 		expect(rec.lookup({ commandId: "command-1", turnId: "turn-1" })).toEqual({
 			status: "accepted",
+			receiptState: "absent",
 			commandId: "command-1",
 			turnId: "turn-1",
 			clientRef: "ref-1",
@@ -36,6 +37,7 @@ describe("prompt reconciliation record", () => {
 		rec.noteTransition(correlation(), { type: "agent_start" });
 		expect(rec.lookup({ clientRef: "ref-1" })).toEqual({
 			status: "in_flight",
+			receiptState: "absent",
 			commandId: "command-1",
 			turnId: "turn-1",
 			clientRef: "ref-1",
@@ -45,6 +47,7 @@ describe("prompt reconciliation record", () => {
 		rec.noteTransition(correlation(), { type: "agent_end" });
 		expect(rec.lookup({ commandId: "command-1", turnId: "turn-1" })).toEqual({
 			status: "terminal_ok",
+			receiptState: "missing",
 			commandId: "command-1",
 			turnId: "turn-1",
 			clientRef: "ref-1",
@@ -101,8 +104,14 @@ describe("prompt reconciliation record", () => {
 	it("reports unknown for a wrong commandId/turnId pair even when the commandId exists", () => {
 		const rec = createPromptReconciliation();
 		rec.noteAccepted(correlation());
-		expect(rec.lookup({ commandId: "command-1", turnId: "turn-other" })).toEqual({ status: "unknown" });
-		expect(rec.lookup({ commandId: "command-other", turnId: "turn-1" })).toEqual({ status: "unknown" });
+		expect(rec.lookup({ commandId: "command-1", turnId: "turn-other" })).toEqual({
+			status: "unknown",
+			receiptState: "unknown",
+		});
+		expect(rec.lookup({ commandId: "command-other", turnId: "turn-1" })).toEqual({
+			status: "unknown",
+			receiptState: "unknown",
+		});
 	});
 
 	it("reports unknown after session-runtime restart", () => {
@@ -110,8 +119,8 @@ describe("prompt reconciliation record", () => {
 		beforeRestart.noteAccepted(correlation(), "restart-ref");
 		expect(beforeRestart.lookup({ clientRef: "restart-ref" })).toMatchObject({ status: "accepted" });
 		const afterRestart = createPromptReconciliation();
-		expect(afterRestart.lookup({ clientRef: "restart-ref" })).toEqual({ status: "unknown" });
-		expect(afterRestart.lookup(correlation())).toEqual({ status: "unknown" });
+		expect(afterRestart.lookup({ clientRef: "restart-ref" })).toEqual({ status: "unknown", receiptState: "unknown" });
+		expect(afterRestart.lookup(correlation())).toEqual({ status: "unknown", receiptState: "unknown" });
 	});
 
 	it("never ages an active record into terminal", () => {
@@ -134,8 +143,11 @@ describe("prompt reconciliation record", () => {
 		clock.advance(PROMPT_RECONCILIATION_TERMINAL_TTL_MS);
 		// Admission itself enforces cleanup; no preceding lookup is required.
 		expect(() => rec.admit("ref-1")).not.toThrow();
-		expect(rec.lookup({ clientRef: "ref-1" })).toEqual({ status: "unknown" });
-		expect(rec.lookup({ commandId: "command-1", turnId: "turn-1" })).toEqual({ status: "unknown" });
+		expect(rec.lookup({ clientRef: "ref-1" })).toEqual({ status: "unknown", receiptState: "unknown" });
+		expect(rec.lookup({ commandId: "command-1", turnId: "turn-1" })).toEqual({
+			status: "unknown",
+			receiptState: "unknown",
+		});
 	});
 
 	it("rejects a retained duplicate clientRef before execution", () => {
@@ -175,7 +187,10 @@ describe("prompt reconciliation record", () => {
 			rec.noteTransition(correlation(n), { type: "agent_end" });
 			clock.advance(1);
 		}
-		expect(rec.lookup({ commandId: "command-1", turnId: "turn-1" })).toEqual({ status: "unknown" });
+		expect(rec.lookup({ commandId: "command-1", turnId: "turn-1" })).toEqual({
+			status: "unknown",
+			receiptState: "unknown",
+		});
 		expect(
 			rec.lookup({
 				commandId: `command-${PROMPT_RECONCILIATION_TERMINAL_CAPACITY + 1}`,
@@ -198,7 +213,10 @@ describe("prompt reconciliation record", () => {
 		// must drop the oldest terminal record, not the newly terminal one.
 		rec.noteTransition({ commandId: "command-early", turnId: "turn-early" }, { type: "agent_end" });
 		expect(rec.lookup({ clientRef: "ref-early" })).toMatchObject({ status: "terminal_ok" });
-		expect(rec.lookup({ commandId: "command-1", turnId: "turn-1" })).toEqual({ status: "unknown" });
+		expect(rec.lookup({ commandId: "command-1", turnId: "turn-1" })).toEqual({
+			status: "unknown",
+			receiptState: "unknown",
+		});
 	});
 
 	it("holds admission reservations across overlapping preflights until acceptance or release", () => {
@@ -334,6 +352,7 @@ describe("prompt reconciliation record", () => {
 			acceptedAt: startedAt,
 			startedAt,
 			terminalAt,
+			receiptState: "missing",
 			error: { code: "transport_reset", message: "Prompt submission failed." },
 		});
 		expect(rec.activeCount()).toBe(0);

--- a/packages/coding-agent/test/sdk-q30-steer-status.test.ts
+++ b/packages/coding-agent/test/sdk-q30-steer-status.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+import { CursorRegistry, QueryHandlers, RevisionStore } from "../src/sdk/host/query/index.js";
+
+function handlers(getSteerStatus?: (selector: { clientRef: string }) => unknown) {
+	const store = new RevisionStore("s1");
+	const cursors = new CursorRegistry("token", store);
+	const surface = {
+		getTranscriptEntries: () => [],
+		getContextSnapshot: () => ({}),
+		getGoalState: () => [],
+		getTodoState: () => [],
+		getDiff: () => [],
+		getUsage: () => ({}),
+		getModels: () => [],
+		getSkillState: () => [],
+		getGates: () => [],
+		getConfigItems: () => [],
+		getSessionMetadata: () => ({}),
+		getStats: () => ({}),
+		getBranchCandidates: () => [],
+		getLastAssistant: () => ({}),
+		getCapabilities: () => ({}),
+		getAuthProviders: () => [],
+		getTools: () => [],
+		getQueueMessages: () => [],
+		getExtensions: () => [],
+		getJobs: () => [],
+		...(getSteerStatus ? { getSteerStatus } : {}),
+	};
+	return new QueryHandlers(surface as never, "s1", store, cursors);
+}
+
+describe("Q31 turn.steer_status query handler", () => {
+	it("normalizes the exact clientRef selector and returns durable status", async () => {
+		const seen: unknown[] = [];
+		const response = await handlers(selector => {
+			seen.push(selector);
+			return { clientRef: selector.clientRef, status: "accepted", acceptedAt: 10 };
+		}).dispatch({ query: "turn.steer_status", input: { clientRef: "  steer-1 " }, connectionId: "c" });
+		expect(response).toEqual({
+			id: undefined,
+			ok: true,
+			result: { clientRef: "steer-1", status: "accepted", acceptedAt: 10 },
+		});
+		expect(seen).toEqual([{ clientRef: "steer-1" }]);
+	});
+
+	it("supports Q31 and returns unknown without dispatching work", async () => {
+		const response = await handlers(selector => ({ clientRef: selector.clientRef, status: "unknown" })).dispatch({
+			query: "Q31",
+			input: { clientRef: "missing" },
+			connectionId: "c",
+		});
+		expect(response).toMatchObject({ ok: true, result: { clientRef: "missing", status: "unknown" } });
+	});
+
+	it("rejects cursors, missing, blank, overlength, and extra selectors", async () => {
+		const h = handlers(() => ({}));
+		for (const input of [
+			{},
+			{ clientRef: "" },
+			{ clientRef: "   " },
+			{ clientRef: "x".repeat(129) },
+			{ clientRef: "steer-1", extra: true },
+		]) {
+			const response = await h.dispatch({ query: "turn.steer_status", input, connectionId: "c" });
+			expect(response).toMatchObject({ ok: false, error: { code: "invalid_request" } });
+		}
+		const cursor = await h.dispatch({
+			query: "turn.steer_status",
+			input: { clientRef: "steer-1" },
+			cursor: "cursor",
+			connectionId: "c",
+		});
+		expect(cursor).toMatchObject({ ok: false, error: { code: "invalid_request" } });
+	});
+
+	it("fails closed when the session has no steer reconciliation surface", async () => {
+		const response = await handlers().dispatch({
+			query: "turn.steer_status",
+			input: { clientRef: "steer-1" },
+			connectionId: "c",
+		});
+		expect(response).toMatchObject({ ok: false, error: { code: "unavailable" } });
+	});
+});

--- a/packages/coding-agent/test/sdk-receipt-state.test.ts
+++ b/packages/coding-agent/test/sdk-receipt-state.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { reduceTerminalReceiptState } from "../src/sdk/receipt-state";
+
+describe("terminal receipt state", () => {
+	it("classifies completed execution with reportable output as present", () => {
+		expect(reduceTerminalReceiptState({ execution: "completed", reportable: true })).toEqual({
+			execution: "terminal_ok",
+			receipt: "present",
+		});
+	});
+
+	it("fails closed for completed execution with empty output", () => {
+		expect(reduceTerminalReceiptState({ execution: "completed", reportable: false })).toEqual({
+			execution: "terminal_ok",
+			receipt: "missing",
+		});
+	});
+
+	it("preserves failure and cancellation execution meaning", () => {
+		expect(reduceTerminalReceiptState({ execution: "failed", reportable: false })).toEqual({
+			execution: "failed",
+			receipt: "absent",
+		});
+		expect(reduceTerminalReceiptState({ execution: "cancelled", reportable: false })).toEqual({
+			execution: "cancelled",
+			receipt: "absent",
+		});
+	});
+
+	it("keeps unknown state conservative", () => {
+		expect(reduceTerminalReceiptState({ execution: "unknown", reportable: true })).toEqual({
+			execution: "unknown",
+			receipt: "unknown",
+		});
+	});
+});

--- a/packages/coding-agent/test/sdk-reconciliation-store.test.ts
+++ b/packages/coding-agent/test/sdk-reconciliation-store.test.ts
@@ -7,6 +7,7 @@ import {
 	type DurableReconciliationRecord,
 	isSafeReconciliationSessionId,
 	reconciliationStorePath,
+	resolveReconciliationSessionFile,
 	settleProcessRestart,
 } from "../src/sdk/bus/reconciliation-store";
 
@@ -25,6 +26,32 @@ describe("reconciliation-store", () => {
 		const storePath = reconciliationStorePath(sessionFile, "abc");
 		expect(storePath).toBe("/home/u/.gjc/agent/sessions/scope/.sdk-reconciliation/abc.json");
 		expect(storePath.includes("abc/")).toBe(false); // not under artifact stem abc/
+	});
+
+	test("bus derives a durable state-root store when session file method returns undefined", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "recon-state-root-"));
+		try {
+			const sessionId = "session-1";
+			const sessionFile = resolveReconciliationSessionFile(undefined, root, sessionId);
+			const store = createReconciliationStore({ sessionFile, sessionId });
+			await store.transact(() => [
+				{
+					kind: "steer",
+					clientRef: "state-root-ref",
+					textDigest: "a".repeat(64),
+					createdAt: 1,
+					status: "accepted",
+					settledAt: 2,
+					commandId: "command",
+					turnId: "turn",
+					acceptedAt: 1,
+				},
+			]);
+			expect(store.path).toBe(path.join(root, ".sdk-reconciliation", `${sessionId}.json`));
+			expect(await fs.readFile(store.path!, "utf8")).toContain('"textDigest"');
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
 	});
 
 	test("settleProcessRestart never invents terminal_ok", () => {

--- a/packages/coding-agent/test/sdk-steer-dispatch-integration.test.ts
+++ b/packages/coding-agent/test/sdk-steer-dispatch-integration.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { SdkClient } from "../src/sdk/client/client";
+import { type ProductionSdkHost, startProductionSdkHost } from "./helpers/sdk-production-host";
+
+const roots: string[] = [];
+let host: ProductionSdkHost | undefined;
+
+afterEach(async () => {
+	await host?.stop();
+	host = undefined;
+	for (const root of roots.splice(0)) await fs.rm(root, { recursive: true, force: true });
+});
+
+describe("correlated steer production dispatch", () => {
+	it("persists normalized canonical correlation before one dispatch, replays, conflicts, and resolves both Q30 selectors", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-steer-production-"));
+		roots.push(root);
+		host = await startProductionSdkHost(root);
+		const client = await SdkClient.connect(host.endpoint.url, host.endpoint.token);
+		try {
+			const first = await client.control("turn.steer", { text: "one steer", clientRef: " logical-steer-1 " });
+			expect(first).toMatchObject({
+				ok: true,
+				result: { sessionId: host.sessionId, clientRef: "logical-steer-1", status: "accepted" },
+			});
+			const accepted = (
+				first as {
+					result: {
+						clientRef: string;
+						commandId: string;
+						turnId: string;
+						status: string;
+						acceptedAt: string;
+					};
+				}
+			).result;
+			expect(accepted.commandId).toEqual(expect.any(String));
+			expect(accepted.turnId).toEqual(expect.any(String));
+			expect(host.dispatches.filter(dispatch => dispatch.deliverAs === "steer")).toHaveLength(1);
+			const replay = await client.control("turn.steer", { text: "one steer", clientRef: "logical-steer-1" });
+			expect(replay).toMatchObject({ ok: true, result: accepted });
+			expect(host.dispatches.filter(dispatch => dispatch.deliverAs === "steer")).toHaveLength(1);
+			await expect(
+				client.control("turn.steer", { text: "different steer", clientRef: "logical-steer-1" }),
+			).rejects.toMatchObject({ code: "client_ref_conflict" });
+			expect(host.dispatches.filter(dispatch => dispatch.deliverAs === "steer")).toHaveLength(1);
+			const byRef = await client.query("turn.steer_status", { clientRef: "logical-steer-1" });
+			const byCanonical = await client.query("turn.steer_status", {
+				commandId: accepted.commandId,
+				turnId: accepted.turnId,
+			});
+			const durableStatus = {
+				clientRef: accepted.clientRef,
+				commandId: accepted.commandId,
+				turnId: accepted.turnId,
+				status: accepted.status,
+				acceptedAt: accepted.acceptedAt,
+			};
+			expect(byRef).toMatchObject({ ok: true, result: durableStatus });
+			expect(byCanonical).toMatchObject({ ok: true, result: durableStatus });
+			expect((byRef as { result: Record<string, unknown> }).result).not.toHaveProperty("sessionId");
+			expect((byCanonical as { result: Record<string, unknown> }).result).not.toHaveProperty("sessionId");
+			const reconciliationPath = path.join(root, ".gjc", "state", ".sdk-reconciliation", `${host.sessionId}.json`);
+			const exists = await fs
+				.stat(reconciliationPath)
+				.then(() => true)
+				.catch(() => false);
+			expect(exists).toBe(true);
+			const state = await fs.readFile(reconciliationPath, "utf8");
+			expect(state).not.toContain("one steer");
+			const uncorrelated = await client.control("turn.steer", { text: "compatibility steer" });
+			expect(uncorrelated).toMatchObject({ ok: true, result: { accepted: true } });
+			const uncorrelatedResult = (uncorrelated as { result: { commandId?: string; turnId?: string } }).result;
+			expect(uncorrelatedResult.commandId).toEqual(expect.any(String));
+			expect(uncorrelatedResult.turnId).toEqual(expect.any(String));
+		} finally {
+			await client.close();
+		}
+	}, 30_000);
+});

--- a/packages/coding-agent/test/sdk-steer-reconciliation.test.ts
+++ b/packages/coding-agent/test/sdk-steer-reconciliation.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { createKindAwareReconciliation } from "../src/sdk/bus/kind-aware-reconciliation";
+import {
+	PROMPT_RECONCILIATION_TERMINAL_CAPACITY,
+	PROMPT_RECONCILIATION_TERMINAL_TTL_MS,
+} from "../src/sdk/bus/prompt-reconciliation";
+import {
+	type DurableReconciliationRecord,
+	type ReconciliationStore,
+	settleProcessRestart,
+} from "../src/sdk/bus/reconciliation-store";
+
+class MemoryStore implements ReconciliationStore {
+	readonly path = null;
+	readonly sessionId = "steer-session";
+	#records: DurableReconciliationRecord[] = [];
+	async transact(mutator: (records: DurableReconciliationRecord[]) => DurableReconciliationRecord[]): Promise<void> {
+		this.#records = mutator(this.snapshot());
+	}
+	async load(): Promise<DurableReconciliationRecord[]> {
+		return this.snapshot();
+	}
+	snapshot(): DurableReconciliationRecord[] {
+		return this.#records.map(record => ({ ...record }));
+	}
+	async delete(): Promise<void> {
+		this.#records = [];
+	}
+}
+
+describe("SDK steer reconciliation", () => {
+	test("reserves digest without storing steer text and replays settled result", async () => {
+		const store = new MemoryStore();
+		const reconciliation = createKindAwareReconciliation({ store, now: () => 10 });
+		const first = await reconciliation.reserveSteer("logical-1", "secret steer body");
+		expect(first.replay).toBe(false);
+		expect(JSON.stringify(store.snapshot())).not.toContain("secret steer body");
+		expect(store.snapshot()[0]).toMatchObject({ kind: "steer", clientRef: "logical-1", status: "dispatching" });
+		expect((store.snapshot()[0] as { textDigest: string }).textDigest).toMatch(/^[0-9a-f]{64}$/);
+		await reconciliation.settleSteer("logical-1", "accepted");
+		const replay = await reconciliation.reserveSteer("logical-1", "secret steer body");
+		expect(replay).toMatchObject({
+			replay: true,
+			result: { clientRef: "logical-1", status: "accepted", acceptedAt: 10 },
+		});
+		expect(replay.result).toMatchObject({ commandId: expect.any(String), turnId: expect.any(String) });
+	});
+
+	test("same reference with another digest conflicts", async () => {
+		const reconciliation = createKindAwareReconciliation({ store: new MemoryStore() });
+		await reconciliation.reserveSteer("logical-1", "first");
+		await expect(reconciliation.reserveSteer("logical-1", "second")).rejects.toMatchObject({
+			code: "client_ref_conflict",
+		});
+	});
+
+	test("dispatching projects uncertain and restart never redispatches", async () => {
+		const store = new MemoryStore();
+		const writer = createKindAwareReconciliation({ store, now: () => 10 });
+		await writer.reserveSteer("logical-1", "body");
+		await store.transact(records => settleProcessRestart(records, 20));
+		const reader = createKindAwareReconciliation({ store, now: () => 20 });
+		await reader.hydrateFromStore();
+		expect(reader.lookupSteer("logical-1")).toMatchObject({
+			status: "uncertain",
+			error: { code: "process_restart_uncertain" },
+		});
+		expect(reader.lookupSteer("missing")).toEqual({ clientRef: "missing", status: "unknown" });
+	});
+
+	test("retains live dispatching records while expiring and capacity-bounding settled steers", async () => {
+		let now = 0;
+		const reconciliation = createKindAwareReconciliation({ store: new MemoryStore(), now: () => now });
+		await reconciliation.reserveSteer("live", "body");
+		for (let index = 0; index <= PROMPT_RECONCILIATION_TERMINAL_CAPACITY; index++) {
+			await reconciliation.reserveSteer(`settled-${index}`, `body-${index}`);
+			await reconciliation.settleSteer(`settled-${index}`, "accepted");
+			now++;
+		}
+		expect(reconciliation.lookupSteer("live")).toMatchObject({ status: "uncertain" });
+		expect(reconciliation.lookupSteer("settled-0")).toMatchObject({ status: "unknown" });
+		now += PROMPT_RECONCILIATION_TERMINAL_TTL_MS;
+		await reconciliation.reserveSteer("new", "body-new");
+		expect(reconciliation.lookupSteer("live")).toMatchObject({ status: "uncertain" });
+		expect(reconciliation.lookupSteer(`settled-${PROMPT_RECONCILIATION_TERMINAL_CAPACITY}`)).toMatchObject({
+			status: "unknown",
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Restores the still-missing behavior from closed PR #3825 on the current SDK architecture and completes the correlated-steering contract tracked by #3956.

This replacement is necessary because GitHub refused to reopen closed PR #3998 after its branch was refreshed onto current `dev`.

- separates terminal execution truth from receipt availability
- fails closed as `receipt_missing` when execution ends without reportable output
- adds digest-only durable `turn.steer` correlation with optional normalized `clientRef`
- returns canonical `commandId` / `turnId` identity at steer acceptance
- adds authoritative `turn.steer_status` lookup by `clientRef` or canonical identity
- reconciles uncertain transport/process outcomes without redispatching steering text
- wires both the SDK bus and real host session-runtime entrypoints to the same durable steer semantics
- preserves prompt/skill correlation behavior and existing failure/cancellation meaning
- persists only bounded outcome, identity, and digest metadata—not prompt/steer text, transcripts, credentials, or provider response bodies

This is a selective current-`dev` adaptation rather than a rebase/cherry-pick of #3825 because the old integration predates the current SDK surface factories and split steering paths.

Closes #3956.
Supersedes the unmerged portion of #3825 and replaces closed PR #3998.

## Current-dev refresh

- Feature head: `17f1058e5bc30e740e777b18e6b4935dc3ae1611`
- Merged exact `dev@f92e98c3d37c3a7fe4ce986348171f3d573941a8`
- Merge completed without textual conflicts or post-merge adaptation edits
- Approved implementation plan remained byte-identical

## Verification

After refreshing onto current `dev`:

- focused receipt/reconciliation/steer/Q26/Q30/inventory/matrix suite: **101 passed, 0 failed, 1,926 assertions across 13 files**
- implementation run's broader non-native focused suite: **139 passed, 0 failed, 2,023 assertions across 13 files**
- `bun --cwd=packages/coding-agent run check`: passed
  - Biome: **2,650 files checked**, no fixes required
  - TypeScript: passed
- generated SDK operation inventory `--check`: passed
- generated adapter parity manifest `--check`: passed
- `git diff --check`: passed
- TruffleHog: clean
- source-aware branch autoreview: clean, **0.98 confidence**, no accepted/actionable P0 findings
- worktree: clean

## Upstream baseline caveat

The exact current upstream `dev` head is not terminal-green. Dev CI run [31300759754](https://github.com/Yeachan-Heo/gajae-code/actions/runs/31300759754) failed all eight coding-agent shards after upstream session-storage changes caused absent transcript/artifact paths to reach `statSync()` and produce `ENOENT`. This branch does not modify that code or those tests.

## Current-head CI classification

After #4079 merged, the owner-integrated exact head `62ca2dda8ab7ba931e6da3887dda87c59afd513a` ran Dev CI [31302619126](https://github.com/Yeachan-Heo/gajae-code/actions/runs/31302619126). Every #4080-specific gate passed, including native build, host session runtime, production-host isolation, host steer integration, native-bus steer dispatch integration, receipt/reconciliation/Q26/Q30 tests, operation matrix/inventory, and TypeScript build.

The repaired baseline removed all three prior `ENOENT` failures. The run now fails only two unchanged upstream assertions in `resume-confirm-continue.test.ts` lines 325 and 350. Upstream commit `95c00d09e7` added `sessionMemoryMode` as the fifth argument to `SessionManager.open` in `main.ts:932`, while these older tests still expect the previous four-argument call. Both the test file and behavior-owning `main.ts` are byte-identical between #4080 and current `dev@3793db0f7`; #4080 does not modify either path. This residual upstream test-oracle mismatch is outside this PR's feature scope.

## Local native caveat

Native-dependent integration/build checks could not run locally because the expected Darwin x64 `pi_natives` addon files are absent. No dependency install or native rebuild was performed. Native-enabled CI passed on the current PR head.

## Non-goals preserved

- no old inline SDK factory revival
- no request/response body persistence
- no prompt or skill correlation semantic change
- no unrelated session-storage, coordinator lifecycle, provider, model, workflow, or UI change
- no upstream baseline-failure repair
