### PR TITLE
fix(utils): make the crash reader total, then stop it leaking what it keeps

### DIFF
--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -224,30 +224,32 @@ function readErrorLike(reason: unknown): { name: string; message: string; stack?
 	if (typeof reason !== "object" || reason === null) return undefined;
 	const name = readErrorField(reason, "name");
 	const message = readErrorField(reason, "message");
-	// A field whose accessor throws is still a field the throwable carries; it
-	// just cannot hand over the value. Both must be carried for error shape: a
-	// refusal is evidence of the field, an absence is not. A throwable that
-	// refuses every field stays error-shaped and is recorded as unreadable —
-	// serializing it instead renders an `Error` as `{}`, which is silence.
-	if (name === undefined || message === undefined) return undefined;
-	const shaped = { name: name ?? UNREADABLE_FIELD, message: message ?? UNREADABLE_FIELD };
-
 	const stack = readErrorField(reason, "stack");
-	if (typeof stack === "string") return { ...shaped, stack };
-	// An accessor that refuses to answer is still evidence of error shape,
-	// exactly like a real `Error` is: the throwable carries the field, it just
-	// cannot hand over the value. So whatever was readable stays the diagnostic
-	// instead of being dropped for a serialization.
-	if (stack === null || name === null || message === null) return shaped;
-	try {
-		if (Object.prototype.toString.call(reason) === "[object Error]") return shaped;
-	} catch {
-		// A `Symbol.toStringTag` that throws answers nothing about error shape,
-		// and must never escape: this read is the last thing standing between a
-		// hostile throwable and a suppressed crash record. Fall through to the
-		// serialization, which still keeps the payload.
+
+	// Read every field before deciding whether this is error-shaped. A missing
+	// name or message cannot discard a readable trace, and one refusing accessor
+	// cannot prevent either sibling from being attempted.
+	const carriesErrorField =
+		(name !== undefined && message !== undefined) || name === null || message === null || stack !== undefined;
+	if (!carriesErrorField) {
+		try {
+			if (Object.prototype.toString.call(reason) !== "[object Error]") return undefined;
+		} catch {
+			// A `Symbol.toStringTag` that throws answers nothing about error shape,
+			// so fall through to serialization rather than losing the payload.
+			return undefined;
+		}
 	}
-	return undefined;
+
+	const shaped = {
+		name: name === null ? UNREADABLE_FIELD : (name ?? "Error"),
+		message: message === null ? UNREADABLE_FIELD : (message ?? "(no message)"),
+	};
+	if (typeof stack === "string") return { ...shaped, stack };
+	if (stack === null) {
+		return { ...shaped, stack: `${shaped.name}: ${shaped.message}\n${UNREADABLE_FIELD}` };
+	}
+	return shaped;
 }
 
 /**
@@ -293,8 +295,9 @@ const UNREADABLE_THROWABLE = "[unreadable throwable]";
  * the guard lives here instead of at each consumer: the crash log, stderr and
  * the structured log all receive plain strings they can read unconditionally.
  *
- * Total by contract: it always returns a diagnostic and never throws. Whatever
- * answered is kept; whatever refused is reported as unreadable.
+ * Total by contract: it always returns a diagnostic and never throws. Each
+ * field is attempted independently: answers survive and only refusals are
+ * reported as unreadable.
  */
 function describeFatal(reason: unknown): FatalDiagnostic {
 	try {

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -223,11 +223,11 @@ function capturedValue(field: FieldRead): unknown {
 
 /**
  * Serializes one already-captured value without letting a hostile sibling cost
- * the rest of the record. Returning `undefined` matches JSON's treatment of
- * unsupported object-property values.
+ * the rest of the record. Values JSON cannot represent as object properties are
+ * stringified explicitly instead of disappearing.
  */
 function serializeCapturedValue(value: unknown): string | undefined {
-	if (value === undefined || typeof value === "function" || typeof value === "symbol") return undefined;
+	if (value === undefined) return undefined;
 	try {
 		const serialized = JSON.stringify(value);
 		if (typeof serialized === "string") return serialized;
@@ -255,24 +255,19 @@ function capturePayload(reason: object, fields: Readonly<Record<ErrorField, Fiel
 	}
 
 	const entries: [string, unknown][] = [];
-	const seen = new Set(keys);
 	let hasContext = false;
 
-	for (const key of keys) {
-		if (!ERROR_FIELDS.includes(key as ErrorField)) hasContext = true;
-		const value = ERROR_FIELDS.includes(key as ErrorField)
-			? capturedValue(fields[key as ErrorField])
-			: capturedValue(readField(reason, key));
-		entries.push([key, value]);
-	}
-
-	// Error fields are often non-enumerable. When another own field makes the
-	// complete payload the useful output, append every special field that yielded
-	// information so none of the successful reads disappears.
+	// Identifying fields lead the payload so they survive when an oversized
+	// context field forces the bounded crash record to keep only its head.
 	for (const key of ERROR_FIELDS) {
-		if (seen.has(key)) continue;
 		const value = capturedValue(fields[key]);
 		if (value !== undefined) entries.push([key, value]);
+	}
+
+	for (const key of keys) {
+		if (ERROR_FIELDS.includes(key as ErrorField)) continue;
+		hasContext = true;
+		entries.push([key, capturedValue(readField(reason, key))]);
 	}
 
 	const properties: string[] = [];
@@ -288,20 +283,19 @@ function fieldText(field: FieldRead, fallback: string): string {
 	return field.kind === "value" && typeof field.value === "string" ? field.value || fallback : fallback;
 }
 
-/** A throwable reduced to plain strings; the only shape the rest of this module reads. */
+/** A throwable reduced to captured text; the rest of this module reads nothing else. */
 interface FatalDiagnostic {
 	name: string;
 	message: string;
 	stack: string;
+	payload?: string;
 }
 
 /**
  * The single read of an unknown throwable, and the only one this module has.
  *
- * There is no error-shape gate. Objects are captured first. A complete payload
- * is rendered whenever context or a non-string special field would otherwise be
- * lost; the compact error form is only used when those three strings are the
- * whole useful output.
+ * Objects always retain the named diagnostic fields independently from their
+ * optional payload. Context never replaces a readable message or stack.
  */
 function describeFatal(reason: unknown): FatalDiagnostic {
 	try {
@@ -330,22 +324,26 @@ function describeFatal(reason: unknown): FatalDiagnostic {
 			return field.kind === "unreadable" || (field.kind === "value" && typeof field.value === "string");
 		});
 
-		if (payload && (payload.hasContext || hasNonStringSpecial || !hasErrorText)) {
-			return { name: "Error", message: payload.serialized || "{}", stack: "" };
-		}
-
 		const name = fieldText(fields.name, "Error");
 		const message = fieldText(fields.message, "(no message)");
+		let stack = "";
 		if (fields.stack.kind === "unreadable") {
-			return { name, message, stack: `${name}: ${message}\n${UNREADABLE_FIELD}` };
+			stack = `${name}: ${message}\n${UNREADABLE_FIELD}`;
+		} else if (fields.stack.kind === "value" && typeof fields.stack.value === "string") {
+			stack = fields.stack.value.includes("\n") ? fields.stack.value : `${name}: ${message}\n${fields.stack.value}`;
 		}
-		if (fields.stack.kind === "value" && typeof fields.stack.value === "string") {
-			const stack = fields.stack.value.includes("\n")
-				? fields.stack.value
-				: `${name}: ${message}\n${fields.stack.value}`;
-			return { name, message, stack };
-		}
-		return { name, message, stack: "" };
+
+		const renderedPayload =
+			payload && (payload.hasContext || hasNonStringSpecial || !hasErrorText)
+				? payload.serialized || "{}"
+				: undefined;
+		const payloadIsMessage = !hasErrorText && renderedPayload !== undefined;
+		return {
+			name: payloadIsMessage ? "Error" : name,
+			message: payloadIsMessage ? renderedPayload : message,
+			stack,
+			payload: payloadIsMessage ? undefined : renderedPayload,
+		};
 	} catch {
 		return { name: "Error", message: UNREADABLE_THROWABLE, stack: "" };
 	}
@@ -367,7 +365,8 @@ let inspectorOpened = false;
 function formatFatalError(label: string, fatal: FatalDiagnostic): string {
 	const stackLines = fatal.stack.split("\n").slice(1);
 	const formattedStack = stackLines.length > 0 ? `\n${stackLines.join("\n")}` : "";
-	return `\n[${label}] ${fatal.name}: ${fatal.message}${formattedStack}\n`;
+	const formattedPayload = fatal.payload ? `\n${fatal.payload}` : "";
+	return `\n[${label}] ${fatal.name}: ${fatal.message}${formattedStack}${formattedPayload}\n`;
 }
 /** Cap for the durable crash log; it is reset past this so a crash loop cannot fill the disk. */
 export const CRASH_LOG_MAX_BYTES = 512 * 1024;
@@ -457,10 +456,12 @@ function writeCrashRecord(
 	try {
 		const target = options.path ?? getCrashLogPath();
 		const now = options.now ?? new Date();
+		const payload = fatal.payload ? `${redactCrashSecrets(fatal.payload)}\n` : "";
 		const report = boundCrashRecord(
 			`${now.toISOString()} pid=${process.pid} [${label}] ` +
 				`${fatal.name}: ${redactCrashSecrets(fatal.message)}\n` +
-				`${redactCrashSecrets(fatal.stack)}\n\n`,
+				`${redactCrashSecrets(fatal.stack)}\n` +
+				`${payload}\n`,
 		);
 		fs.mkdirSync(path.dirname(target), { recursive: true });
 		let existingSize = 0;

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -191,90 +191,101 @@ function installProcessStdoutWriteClassifier(): void {
 }
 
 const UNREADABLE_FIELD = "[unreadable]";
+const UNREADABLE_THROWABLE = "[unreadable throwable]";
+const ERROR_FIELDS = ["name", "message", "stack"] as const;
+type ErrorField = (typeof ERROR_FIELDS)[number];
 
-/**
- * Reads one field of a throwable, exactly once. `undefined` means the throwable
- * does not carry a string there; `null` means it carries the field but refused
- * to answer.
- */
-function readErrorField(reason: object, key: "name" | "message" | "stack"): string | null | undefined {
+type FieldRead =
+	| { readonly kind: "missing" }
+	| { readonly kind: "unreadable" }
+	| { readonly kind: "value"; readonly value: unknown };
+
+interface CapturedPayload {
+	readonly serialized: string;
+	readonly hasContext: boolean;
+}
+
+/** Reads one top-level field exactly once and keeps both its value and refusal state. */
+function readField(reason: object, key: string): FieldRead {
 	try {
 		const value = (reason as Record<string, unknown>)[key];
-		return typeof value === "string" ? value : undefined;
+		return value === undefined ? { kind: "missing" } : { kind: "value", value };
 	} catch {
-		return null;
+		return { kind: "unreadable" };
 	}
 }
 
-/**
- * Reads a throwable's error-shaped fields, exactly once each.
- *
- * Observing a property twice is a hazard, not a detail: a stateful or hostile
- * accessor that satisfies a shape check and then throws on the re-read would
- * escape out of `recordFatalCrash()` and cost the whole crash record. So the
- * values that pass the check are the values that get used.
- *
- * The fields are read one at a time, because a sibling accessor that throws must
- * not take a readable field down with it: a `message` that refuses to answer is
- * no reason to lose a readable `name` or the trace. `stack` is the one field the
- * record can do without, and letting it cost the readable fields is how a fatal
- * becomes `Error: [object Object]`.
- */
-function readErrorLike(reason: unknown): { name: string; message: string; stack?: string } | undefined {
-	if (typeof reason !== "object" || reason === null) return undefined;
-	const name = readErrorField(reason, "name");
-	const message = readErrorField(reason, "message");
-	const stack = readErrorField(reason, "stack");
-
-	// Read every field before deciding whether this is error-shaped. A missing
-	// name or message cannot discard a readable trace, and one refusing accessor
-	// cannot prevent either sibling from being attempted.
-	const carriesErrorField =
-		(name !== undefined && message !== undefined) || name === null || message === null || stack !== undefined;
-	if (!carriesErrorField) {
-		try {
-			if (Object.prototype.toString.call(reason) !== "[object Error]") return undefined;
-		} catch {
-			// A `Symbol.toStringTag` that throws answers nothing about error shape,
-			// so fall through to serialization rather than losing the payload.
-			return undefined;
-		}
-	}
-
-	const shaped = {
-		name: name === null ? UNREADABLE_FIELD : (name ?? "Error"),
-		message: message === null ? UNREADABLE_FIELD : (message ?? "(no message)"),
-	};
-	if (typeof stack === "string") return { ...shaped, stack };
-	if (stack === null) {
-		return { ...shaped, stack: `${shaped.name}: ${shaped.message}\n${UNREADABLE_FIELD}` };
-	}
-	return shaped;
+function capturedValue(field: FieldRead): unknown {
+	if (field.kind === "value") return field.value;
+	if (field.kind === "unreadable") return UNREADABLE_FIELD;
+	return undefined;
 }
 
 /**
- * Render a non-`Error` throwable so the crash record keeps its payload.
- *
- * `String(value)` collapses every plain object to `[object Object]`, which is
- * exactly how SDK lifecycle startup failures (`{ phase, reason, message }` are
- * thrown as records, not `Error`s) used to reach the log with no diagnostic
- * left. Serialize own properties instead, and stay defensive: a throwing
- * `toString`/`toJSON` or a cycle must never mask the original fatal.
+ * Serializes one already-captured value without letting a hostile sibling cost
+ * the rest of the record. Returning `undefined` matches JSON's treatment of
+ * unsupported object-property values.
  */
-function describeThrowable(reason: unknown): string {
-	if (typeof reason === "object" && reason !== null) {
-		try {
-			const serialized = JSON.stringify(reason);
-			if (typeof serialized === "string") return serialized;
-		} catch {
-			// Cyclic or non-serializable payload; fall through to String().
-		}
+function serializeCapturedValue(value: unknown): string | undefined {
+	if (value === undefined || typeof value === "function" || typeof value === "symbol") return undefined;
+	try {
+		const serialized = JSON.stringify(value);
+		if (typeof serialized === "string") return serialized;
+	} catch {
+		// Fall through to a string representation of this field only.
 	}
 	try {
-		return String(reason);
+		return JSON.stringify(String(value));
 	} catch {
-		return "[unserializable throwable]";
+		return JSON.stringify(UNREADABLE_FIELD);
 	}
+}
+
+/**
+ * Captures enumerable own fields without re-reading `name`, `message`, or
+ * `stack`. Those three values came from the same reads used by the diagnostic,
+ * so a stateful accessor cannot pass one branch and fail in another.
+ */
+function capturePayload(reason: object, fields: Readonly<Record<ErrorField, FieldRead>>): CapturedPayload | undefined {
+	let keys: string[];
+	try {
+		keys = Object.keys(reason);
+	} catch {
+		return undefined;
+	}
+
+	const entries: [string, unknown][] = [];
+	const seen = new Set(keys);
+	let hasContext = false;
+
+	for (const key of keys) {
+		if (!ERROR_FIELDS.includes(key as ErrorField)) hasContext = true;
+		const value = ERROR_FIELDS.includes(key as ErrorField)
+			? capturedValue(fields[key as ErrorField])
+			: capturedValue(readField(reason, key));
+		entries.push([key, value]);
+	}
+
+	// Error fields are often non-enumerable. When another own field makes the
+	// complete payload the useful output, append every special field that yielded
+	// information so none of the successful reads disappears.
+	for (const key of ERROR_FIELDS) {
+		if (seen.has(key)) continue;
+		const value = capturedValue(fields[key]);
+		if (value !== undefined) entries.push([key, value]);
+	}
+
+	const properties: string[] = [];
+	for (const [key, value] of entries) {
+		const serialized = serializeCapturedValue(value);
+		if (serialized !== undefined) properties.push(`${JSON.stringify(key)}:${serialized}`);
+	}
+	return { serialized: `{${properties.join(",")}}`, hasContext };
+}
+
+function fieldText(field: FieldRead, fallback: string): string {
+	if (field.kind === "unreadable") return UNREADABLE_FIELD;
+	return field.kind === "value" && typeof field.value === "string" ? field.value || fallback : fallback;
 }
 
 /** A throwable reduced to plain strings; the only shape the rest of this module reads. */
@@ -284,37 +295,58 @@ interface FatalDiagnostic {
 	stack: string;
 }
 
-const UNREADABLE_THROWABLE = "[unreadable throwable]";
-
 /**
  * The single read of an unknown throwable, and the only one this module has.
  *
- * There are unbounded ways to construct a bad throwable — hostile `Proxy`,
- * cross-realm object, primitive, a same-realm `Error` whose lazily computed
- * `message` throws — and exactly one place that has to turn one into text. So
- * the guard lives here instead of at each consumer: the crash log, stderr and
- * the structured log all receive plain strings they can read unconditionally.
- *
- * Total by contract: it always returns a diagnostic and never throws. Each
- * field is attempted independently: answers survive and only refusals are
- * reported as unreadable.
+ * There is no error-shape gate. Objects are captured first. A complete payload
+ * is rendered whenever context or a non-string special field would otherwise be
+ * lost; the compact error form is only used when those three strings are the
+ * whole useful output.
  */
 function describeFatal(reason: unknown): FatalDiagnostic {
 	try {
-		const shaped = readErrorLike(reason);
-		if (shaped) {
-			return {
-				name: shaped.name || "Error",
-				message: shaped.message || "(no message)",
-				stack: shaped.stack ?? "",
-			};
+		if (typeof reason !== "object" || reason === null) {
+			let message: string;
+			try {
+				message = String(reason);
+			} catch {
+				message = UNREADABLE_THROWABLE;
+			}
+			return { name: "Error", message: message || "(no message)", stack: "" };
 		}
-		return { name: "Error", message: describeThrowable(reason) || "(no message)", stack: "" };
+
+		const fields: Record<ErrorField, FieldRead> = {
+			name: readField(reason, "name"),
+			message: readField(reason, "message"),
+			stack: readField(reason, "stack"),
+		};
+		const payload = capturePayload(reason, fields);
+		const hasNonStringSpecial = ERROR_FIELDS.some(key => {
+			const field = fields[key];
+			return field.kind === "value" && typeof field.value !== "string";
+		});
+		const hasErrorText = ERROR_FIELDS.some(key => {
+			const field = fields[key];
+			return field.kind === "unreadable" || (field.kind === "value" && typeof field.value === "string");
+		});
+
+		if (payload && (payload.hasContext || hasNonStringSpecial || !hasErrorText)) {
+			return { name: "Error", message: payload.serialized || "{}", stack: "" };
+		}
+
+		const name = fieldText(fields.name, "Error");
+		const message = fieldText(fields.message, "(no message)");
+		if (fields.stack.kind === "unreadable") {
+			return { name, message, stack: `${name}: ${message}\n${UNREADABLE_FIELD}` };
+		}
+		if (fields.stack.kind === "value" && typeof fields.stack.value === "string") {
+			const stack = fields.stack.value.includes("\n")
+				? fields.stack.value
+				: `${name}: ${message}\n${fields.stack.value}`;
+			return { name, message, stack };
+		}
+		return { name, message, stack: "" };
 	} catch {
-		// Every read above is individually guarded, and every earlier round of
-		// this module believed exactly that about the read it had just
-		// hardened. This is the last diagnostic the process leaves behind; it
-		// does not get to depend on that belief holding.
 		return { name: "Error", message: UNREADABLE_THROWABLE, stack: "" };
 	}
 }

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -194,6 +194,27 @@ const UNREADABLE_FIELD = "[unreadable]";
 const UNREADABLE_THROWABLE = "[unreadable throwable]";
 const ERROR_FIELDS = ["name", "message", "stack"] as const;
 type ErrorField = (typeof ERROR_FIELDS)[number];
+const CRASH_CONTEXT_FIELDS = new Set([
+	"code",
+	"errno",
+	"syscall",
+	"path",
+	"dest",
+	"address",
+	"port",
+	"fd",
+	"status",
+	"statusCode",
+	"url",
+	"method",
+	"phase",
+	"reason",
+	"exitCode",
+	"stderr",
+]);
+const CRASH_CONTEXT_FIELD_MAX_BYTES = 4 * 1024;
+const CRASH_CONTEXT_FIELD_TRUNCATION_MARKER = "… [field truncated]";
+const UNDEFINED_FIELD = "[undefined]";
 
 type FieldRead =
 	| { readonly kind: "missing" }
@@ -202,14 +223,13 @@ type FieldRead =
 
 interface CapturedPayload {
 	readonly serialized: string;
-	readonly hasContext: boolean;
 }
 
 /** Reads one top-level field exactly once and keeps both its value and refusal state. */
-function readField(reason: object, key: string): FieldRead {
+function readField(reason: object, key: string, preserveUndefined = false): FieldRead {
 	try {
 		const value = (reason as Record<string, unknown>)[key];
-		return value === undefined ? { kind: "missing" } : { kind: "value", value };
+		return value === undefined && !preserveUndefined ? { kind: "missing" } : { kind: "value", value };
 	} catch {
 		return { kind: "unreadable" };
 	}
@@ -221,32 +241,54 @@ function capturedValue(field: FieldRead): unknown {
 	return undefined;
 }
 
+function boundedJsonString(value: string): string {
+	const redacted = redactCrashSecrets(value);
+	if (Buffer.byteLength(JSON.stringify(redacted), "utf8") <= CRASH_CONTEXT_FIELD_MAX_BYTES)
+		return JSON.stringify(redacted);
+
+	let low = 0;
+	let high = redacted.length;
+	while (low < high) {
+		const midpoint = Math.ceil((low + high) / 2);
+		const candidate = JSON.stringify(`${redacted.slice(0, midpoint)}${CRASH_CONTEXT_FIELD_TRUNCATION_MARKER}`);
+		if (Buffer.byteLength(candidate, "utf8") <= CRASH_CONTEXT_FIELD_MAX_BYTES) low = midpoint;
+		else high = midpoint - 1;
+	}
+	let end = low;
+	if (end > 0 && /[\uD800-\uDBFF]/.test(redacted[end - 1] ?? "")) end--;
+	return JSON.stringify(`${redacted.slice(0, end)}${CRASH_CONTEXT_FIELD_TRUNCATION_MARKER}`);
+}
+
 /**
- * Serializes one already-captured value without letting a hostile sibling cost
- * the rest of the record. Values JSON cannot represent as object properties are
- * stringified explicitly instead of disappearing.
+ * Serializes one already-captured diagnostic value. Credential shapes are
+ * redacted before output, and oversized fields become a bounded string preview
+ * so one request body cannot evict the remaining crash context.
  */
-function serializeCapturedValue(value: unknown): string | undefined {
-	if (value === undefined) return undefined;
+function serializeCapturedValue(value: unknown): string {
+	if (value === undefined) return JSON.stringify(UNDEFINED_FIELD);
+	if (typeof value === "string") return boundedJsonString(value);
+
 	try {
 		const serialized = JSON.stringify(value);
-		if (typeof serialized === "string") return serialized;
+		if (typeof serialized !== "string") return boundedJsonString(String(value));
+		const redacted = redactCrashSecrets(serialized);
+		if (Buffer.byteLength(redacted, "utf8") <= CRASH_CONTEXT_FIELD_MAX_BYTES) return redacted;
+		return boundedJsonString(redacted);
 	} catch {
-		// Fall through to a string representation of this field only.
-	}
-	try {
-		return JSON.stringify(String(value));
-	} catch {
-		return JSON.stringify(UNREADABLE_FIELD);
+		try {
+			return boundedJsonString(String(value));
+		} catch {
+			return JSON.stringify(UNREADABLE_FIELD);
+		}
 	}
 }
 
 /**
- * Captures enumerable own fields without re-reading `name`, `message`, or
- * `stack`. Those three values came from the same reads used by the diagnostic,
- * so a stateful accessor cannot pass one branch and fail in another.
+ * Captures only stable diagnostic context. Arbitrary request objects and bodies
+ * are intentionally excluded: they are large, routinely contain credentials,
+ * and add less crash value than transport, process, and lifecycle metadata.
  */
-function capturePayload(reason: object, fields: Readonly<Record<ErrorField, FieldRead>>): CapturedPayload | undefined {
+function capturePayload(reason: object): CapturedPayload | undefined {
 	let keys: string[];
 	try {
 		keys = Object.keys(reason);
@@ -254,33 +296,24 @@ function capturePayload(reason: object, fields: Readonly<Record<ErrorField, Fiel
 		return undefined;
 	}
 
-	const entries: [string, unknown][] = [];
-	let hasContext = false;
-
-	// Identifying fields lead the payload so they survive when an oversized
-	// context field forces the bounded crash record to keep only its head.
-	for (const key of ERROR_FIELDS) {
-		const value = capturedValue(fields[key]);
-		if (value !== undefined) entries.push([key, value]);
-	}
-
-	for (const key of keys) {
-		if (ERROR_FIELDS.includes(key as ErrorField)) continue;
-		hasContext = true;
-		entries.push([key, capturedValue(readField(reason, key))]);
-	}
-
 	const properties: string[] = [];
-	for (const [key, value] of entries) {
-		const serialized = serializeCapturedValue(value);
-		if (serialized !== undefined) properties.push(`${JSON.stringify(key)}:${serialized}`);
+	for (const key of keys) {
+		if (!CRASH_CONTEXT_FIELDS.has(key)) continue;
+		const serialized = serializeCapturedValue(capturedValue(readField(reason, key, true)));
+		properties.push(`${JSON.stringify(key)}:${serialized}`);
 	}
-	return { serialized: `{${properties.join(",")}}`, hasContext };
+	return properties.length > 0 ? { serialized: `{${properties.join(",")}}` } : undefined;
 }
 
 function fieldText(field: FieldRead, fallback: string): string {
 	if (field.kind === "unreadable") return UNREADABLE_FIELD;
-	return field.kind === "value" && typeof field.value === "string" ? field.value || fallback : fallback;
+	if (field.kind !== "value") return fallback;
+	try {
+		const text = typeof field.value === "string" ? field.value : String(field.value);
+		return text || fallback;
+	} catch {
+		return UNREADABLE_FIELD;
+	}
 }
 
 /** A throwable reduced to captured text; the rest of this module reads nothing else. */
@@ -294,8 +327,9 @@ interface FatalDiagnostic {
 /**
  * The single read of an unknown throwable, and the only one this module has.
  *
- * Objects always retain the named diagnostic fields independently from their
- * optional payload. Context never replaces a readable message or stack.
+ * Objects retain the named diagnostic fields independently from the optional
+ * allowlisted context payload. Context never replaces a readable identity,
+ * message, or stack.
  */
 function describeFatal(reason: unknown): FatalDiagnostic {
 	try {
@@ -314,35 +348,27 @@ function describeFatal(reason: unknown): FatalDiagnostic {
 			message: readField(reason, "message"),
 			stack: readField(reason, "stack"),
 		};
-		const payload = capturePayload(reason, fields);
-		const hasNonStringSpecial = ERROR_FIELDS.some(key => {
-			const field = fields[key];
-			return field.kind === "value" && typeof field.value !== "string";
-		});
-		const hasErrorText = ERROR_FIELDS.some(key => {
-			const field = fields[key];
-			return field.kind === "unreadable" || (field.kind === "value" && typeof field.value === "string");
-		});
+		const payload = capturePayload(reason);
+		const payloadIsMessage = payload !== undefined && ERROR_FIELDS.every(key => fields[key].kind === "missing");
 
 		const name = fieldText(fields.name, "Error");
 		const message = fieldText(fields.message, "(no message)");
 		let stack = "";
 		if (fields.stack.kind === "unreadable") {
 			stack = `${name}: ${message}\n${UNREADABLE_FIELD}`;
-		} else if (fields.stack.kind === "value" && typeof fields.stack.value === "string") {
+		} else if (
+			fields.stack.kind === "value" &&
+			typeof fields.stack.value === "string" &&
+			fields.stack.value.length > 0
+		) {
 			stack = fields.stack.value.includes("\n") ? fields.stack.value : `${name}: ${message}\n${fields.stack.value}`;
 		}
 
-		const renderedPayload =
-			payload && (payload.hasContext || hasNonStringSpecial || !hasErrorText)
-				? payload.serialized || "{}"
-				: undefined;
-		const payloadIsMessage = !hasErrorText && renderedPayload !== undefined;
 		return {
-			name: payloadIsMessage ? "Error" : name,
-			message: payloadIsMessage ? renderedPayload : message,
+			name,
+			message: payloadIsMessage ? payload.serialized : message,
 			stack,
-			payload: payloadIsMessage ? undefined : renderedPayload,
+			payload: payloadIsMessage ? undefined : payload?.serialized,
 		};
 	} catch {
 		return { name: "Error", message: UNREADABLE_THROWABLE, stack: "" };
@@ -366,7 +392,9 @@ function formatFatalError(label: string, fatal: FatalDiagnostic): string {
 	const stackLines = fatal.stack.split("\n").slice(1);
 	const formattedStack = stackLines.length > 0 ? `\n${stackLines.join("\n")}` : "";
 	const formattedPayload = fatal.payload ? `\n${fatal.payload}` : "";
-	return `\n[${label}] ${fatal.name}: ${fatal.message}${formattedStack}${formattedPayload}\n`;
+	return boundCrashRecord(
+		redactCrashSecrets(`\n[${label}] ${fatal.name}: ${fatal.message}${formattedStack}${formattedPayload}\n`),
+	);
 }
 /** Cap for the durable crash log; it is reset past this so a crash loop cannot fill the disk. */
 export const CRASH_LOG_MAX_BYTES = 512 * 1024;
@@ -456,12 +484,12 @@ function writeCrashRecord(
 	try {
 		const target = options.path ?? getCrashLogPath();
 		const now = options.now ?? new Date();
+		const stack = fatal.stack ? `${redactCrashSecrets(fatal.stack)}\n` : "";
 		const payload = fatal.payload ? `${redactCrashSecrets(fatal.payload)}\n` : "";
 		const report = boundCrashRecord(
 			`${now.toISOString()} pid=${process.pid} [${label}] ` +
-				`${fatal.name}: ${redactCrashSecrets(fatal.message)}\n` +
-				`${redactCrashSecrets(fatal.stack)}\n` +
-				`${payload}\n`,
+				`${redactCrashSecrets(fatal.name)}: ${redactCrashSecrets(fatal.message)}\n` +
+				`${stack}${payload}\n`,
 		);
 		fs.mkdirSync(path.dirname(target), { recursive: true });
 		let existingSize = 0;

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -190,6 +190,66 @@ function installProcessStdoutWriteClassifier(): void {
 	process.stdout.write = markedWrite as typeof process.stdout.write;
 }
 
+const UNREADABLE_FIELD = "[unreadable]";
+
+/**
+ * Reads one field of a throwable, exactly once. `undefined` means the throwable
+ * does not carry a string there; `null` means it carries the field but refused
+ * to answer.
+ */
+function readErrorField(reason: object, key: "name" | "message" | "stack"): string | null | undefined {
+	try {
+		const value = (reason as Record<string, unknown>)[key];
+		return typeof value === "string" ? value : undefined;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Reads a throwable's error-shaped fields, exactly once each.
+ *
+ * Observing a property twice is a hazard, not a detail: a stateful or hostile
+ * accessor that satisfies a shape check and then throws on the re-read would
+ * escape out of `recordFatalCrash()` and cost the whole crash record. So the
+ * values that pass the check are the values that get used.
+ *
+ * The fields are read one at a time, because a sibling accessor that throws must
+ * not take a readable field down with it: a `message` that refuses to answer is
+ * no reason to lose a readable `name` or the trace. `stack` is the one field the
+ * record can do without, and letting it cost the readable fields is how a fatal
+ * becomes `Error: [object Object]`.
+ */
+function readErrorLike(reason: unknown): { name: string; message: string; stack?: string } | undefined {
+	if (typeof reason !== "object" || reason === null) return undefined;
+	const name = readErrorField(reason, "name");
+	const message = readErrorField(reason, "message");
+	// A field whose accessor throws is still a field the throwable carries; it
+	// just cannot hand over the value. Both must be carried for error shape: a
+	// refusal is evidence of the field, an absence is not. A throwable that
+	// refuses every field stays error-shaped and is recorded as unreadable —
+	// serializing it instead renders an `Error` as `{}`, which is silence.
+	if (name === undefined || message === undefined) return undefined;
+	const shaped = { name: name ?? UNREADABLE_FIELD, message: message ?? UNREADABLE_FIELD };
+
+	const stack = readErrorField(reason, "stack");
+	if (typeof stack === "string") return { ...shaped, stack };
+	// An accessor that refuses to answer is still evidence of error shape,
+	// exactly like a real `Error` is: the throwable carries the field, it just
+	// cannot hand over the value. So whatever was readable stays the diagnostic
+	// instead of being dropped for a serialization.
+	if (stack === null || name === null || message === null) return shaped;
+	try {
+		if (Object.prototype.toString.call(reason) === "[object Error]") return shaped;
+	} catch {
+		// A `Symbol.toStringTag` that throws answers nothing about error shape,
+		// and must never escape: this read is the last thing standing between a
+		// hostile throwable and a suppressed crash record. Fall through to the
+		// serialization, which still keeps the payload.
+	}
+	return undefined;
+}
+
 /**
  * Render a non-`Error` throwable so the crash record keeps its payload.
  *
@@ -199,19 +259,6 @@ function installProcessStdoutWriteClassifier(): void {
  * left. Serialize own properties instead, and stay defensive: a throwing
  * `toString`/`toJSON` or a cycle must never mask the original fatal.
  */
-function isErrorLike(reason: unknown): reason is { name: string; message: string; stack?: string } {
-	if (typeof reason !== "object" || reason === null) return false;
-	try {
-		const error = reason as { name?: unknown; message?: unknown; stack?: unknown };
-		return (
-			typeof error.name === "string" &&
-			typeof error.message === "string" &&
-			(typeof error.stack === "string" || Object.prototype.toString.call(reason) === "[object Error]")
-		);
-	} catch {
-		return false;
-	}
-}
 function describeThrowable(reason: unknown): string {
 	if (typeof reason === "object" && reason !== null) {
 		try {
@@ -228,13 +275,52 @@ function describeThrowable(reason: unknown): string {
 	}
 }
 
-function errorForDiagnostic(reason: unknown): Error {
-	if (reason instanceof Error) return reason;
-	if (!isErrorLike(reason)) return new Error(describeThrowable(reason));
+/** A throwable reduced to plain strings; the only shape the rest of this module reads. */
+interface FatalDiagnostic {
+	name: string;
+	message: string;
+	stack: string;
+}
 
-	const error = new Error(reason.message);
-	error.name = reason.name;
-	if (typeof reason.stack === "string") error.stack = reason.stack;
+const UNREADABLE_THROWABLE = "[unreadable throwable]";
+
+/**
+ * The single read of an unknown throwable, and the only one this module has.
+ *
+ * There are unbounded ways to construct a bad throwable — hostile `Proxy`,
+ * cross-realm object, primitive, a same-realm `Error` whose lazily computed
+ * `message` throws — and exactly one place that has to turn one into text. So
+ * the guard lives here instead of at each consumer: the crash log, stderr and
+ * the structured log all receive plain strings they can read unconditionally.
+ *
+ * Total by contract: it always returns a diagnostic and never throws. Whatever
+ * answered is kept; whatever refused is reported as unreadable.
+ */
+function describeFatal(reason: unknown): FatalDiagnostic {
+	try {
+		const shaped = readErrorLike(reason);
+		if (shaped) {
+			return {
+				name: shaped.name || "Error",
+				message: shaped.message || "(no message)",
+				stack: shaped.stack ?? "",
+			};
+		}
+		return { name: "Error", message: describeThrowable(reason) || "(no message)", stack: "" };
+	} catch {
+		// Every read above is individually guarded, and every earlier round of
+		// this module believed exactly that about the read it had just
+		// hardened. This is the last diagnostic the process leaves behind; it
+		// does not get to depend on that belief holding.
+		return { name: "Error", message: UNREADABLE_THROWABLE, stack: "" };
+	}
+}
+
+/** Rebuild an `Error` for structured logging out of strings that are already safe to read. */
+function fatalErrorForLog(fatal: FatalDiagnostic): Error {
+	const error = new Error(fatal.message);
+	error.name = fatal.name;
+	if (fatal.stack) error.stack = fatal.stack;
 	return error;
 }
 
@@ -243,13 +329,10 @@ function errorForDiagnostic(reason: unknown): Error {
 // Worker thread: exit only (workers use self.addEventListener for exceptions)
 let inspectorOpened = false;
 
-function formatFatalError(label: string, err: Error): string {
-	const name = err.name || "Error";
-	const message = err.message || "(no message)";
-	const stack = err.stack || "";
-	const stackLines = stack.split("\n").slice(1);
+function formatFatalError(label: string, fatal: FatalDiagnostic): string {
+	const stackLines = fatal.stack.split("\n").slice(1);
 	const formattedStack = stackLines.length > 0 ? `\n${stackLines.join("\n")}` : "";
-	return `\n[${label}] ${name}: ${message}${formattedStack}\n`;
+	return `\n[${label}] ${fatal.name}: ${fatal.message}${formattedStack}\n`;
 }
 /** Cap for the durable crash log; it is reset past this so a crash loop cannot fill the disk. */
 export const CRASH_LOG_MAX_BYTES = 512 * 1024;
@@ -328,14 +411,21 @@ export function recordFatalCrash(
 	reason: unknown,
 	options: { path?: string; now?: Date } = {},
 ): string | undefined {
+	return writeCrashRecord(label, describeFatal(reason), options);
+}
+
+function writeCrashRecord(
+	label: string,
+	fatal: FatalDiagnostic,
+	options: { path?: string; now?: Date } = {},
+): string | undefined {
 	try {
-		const err = errorForDiagnostic(reason);
 		const target = options.path ?? getCrashLogPath();
 		const now = options.now ?? new Date();
 		const report = boundCrashRecord(
 			`${now.toISOString()} pid=${process.pid} [${label}] ` +
-				`${err.name || "Error"}: ${redactCrashSecrets(err.message || "(no message)")}\n` +
-				`${redactCrashSecrets(err.stack ?? "")}\n\n`,
+				`${fatal.name}: ${redactCrashSecrets(fatal.message)}\n` +
+				`${redactCrashSecrets(fatal.stack)}\n\n`,
 		);
 		fs.mkdirSync(path.dirname(target), { recursive: true });
 		let existingSize = 0;
@@ -380,14 +470,15 @@ async function handleFatalError(label: string, reason: unknown, cleanupReason: R
 	// contract, including when it arrives while quiet cleanup is still pending.
 	ordinaryFatalStarted = true;
 	process.exitCode = 1;
-	const err = errorForDiagnostic(reason);
+	const fatal = describeFatal(reason);
 	// Persist first: the rotation-immune record must land before any
 	// best-effort stderr output, so a slow or failing stderr cannot cost the
 	// crash record. Cleanup (which may itself hang or fail) runs afterwards.
-	const crashLogPath = recordFatalCrash(label, err);
-	safeStderrWrite(formatFatalError(label, err));
+	const crashLogPath = writeCrashRecord(label, fatal);
+	safeStderrWrite(formatFatalError(label, fatal));
 	if (crashLogPath) safeStderrWrite(`[${label}] crash recorded at ${crashLogPath}\n`);
 	if (!quietShutdownStarted) {
+		const err = fatalErrorForLog(fatal);
 		logger.error(label === "Uncaught Exception" ? "Uncaught exception" : "Unhandled rejection", {
 			err,
 			stack: err.stack,

--- a/packages/utils/test/postmortem-unreadable-throwables.test.ts
+++ b/packages/utils/test/postmortem-unreadable-throwables.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as vm from "node:vm";
-import { recordFatalCrash } from "../src/postmortem";
+import { CRASH_RECORD_MAX_BYTES, recordFatalCrash } from "../src/postmortem";
 import { NonZeroExitError } from "../src/ptree";
 
 /**
@@ -13,8 +13,9 @@ import { NonZeroExitError } from "../src/ptree";
  * cross-realm object, a plain record, a primitive — and hardening them one at a
  * time is what left a sibling path unguarded on every previous attempt.
  *
- * So this table is written against the consumer: whatever the throwable is, the
- * record exists and carries every field that could be read.
+ * So this table is written against the consumer: every throwable produces a
+ * useful record, while arbitrary request data is excluded and retained context
+ * is redacted and bounded.
  */
 const LABEL = "Uncaught Exception";
 const RECORDED_AT = new Date("2026-01-01T00:00:00.000Z");
@@ -47,8 +48,10 @@ interface Throwables {
 	/** Case name, also the assertion failure label. */
 	readonly what: string;
 	readonly build: () => unknown;
-	/** Fragments the record must keep: everything readable, plus a marker for everything not. */
+	/** Fragments the record must keep. */
 	readonly keeps: readonly string[];
+	/** Fragments excluded by the diagnostic-context policy. */
+	readonly omits?: readonly string[];
 	readonly after?: (contents: string) => void;
 }
 
@@ -144,9 +147,7 @@ const throwables: readonly Throwables[] = [
 	{
 		what: "plain record thrown instead of an Error",
 		build: () => ({ phase: "startup", reason: "broker-spawn", message: "record fatal" }),
-		// No `name`, so this is payload rather than an error shape: the whole
-		// record is kept instead of collapsing to `[object Object]`.
-		keeps: ['{"message":"record fatal","phase":"startup","reason":"broker-spawn"}'],
+		keeps: ["Error: record fatal", '{"phase":"startup","reason":"broker-spawn"}'],
 	},
 	{
 		what: "plain record carrying a readable stack and crash context",
@@ -156,7 +157,7 @@ const throwables: readonly Throwables[] = [
 			exitCode: 7,
 			stack: "at spawnBroker (broker.ts:1:1)",
 		}),
-		keeps: ['{"stack":"at spawnBroker (broker.ts:1:1)","phase":"startup","reason":"broker-spawn","exitCode":7}'],
+		keeps: ["spawnBroker (broker.ts:1:1)", '{"phase":"startup","reason":"broker-spawn","exitCode":7}'],
 	},
 	{
 		what: "named error record carrying HTTP response context",
@@ -167,7 +168,8 @@ const throwables: readonly Throwables[] = [
 			url: "https://api/x",
 			body: "upstream",
 		}),
-		keeps: ['{"name":"HttpError","message":"502 Bad Gateway","status":502,"url":"https://api/x","body":"upstream"}'],
+		keeps: ["HttpError: 502 Bad Gateway", '{"status":502,"url":"https://api/x"}'],
+		omits: ['"body"', "upstream"],
 	},
 	((): Throwables => {
 		const reads: string[] = [];
@@ -188,37 +190,80 @@ const throwables: readonly Throwables[] = [
 						reads.push("stack");
 						return false;
 					},
-					payload: "readable context survives",
+					phase: "readable context survives",
 				};
 			},
-			keeps: ['{"name":17,"message":null,"stack":false,"payload":"readable context survives"}'],
+			keeps: ["17: null", '{"phase":"readable context survives"}'],
 			after: () => expect(reads).toEqual(["name", "message", "stack"]),
 		};
 	})(),
 	{
-		what: "Error with an oversized own field",
-		build: () => Object.assign(new Error("upstream refused the connection"), { body: "X".repeat(70_000) }),
-		keeps: [
-			"upstream refused the connection",
-			"postmortem-unreadable-throwables.test.ts",
-			"[crash record truncated]",
-		],
-		after: contents => {
-			const body = contents.indexOf('"body"');
-			expect(contents.indexOf('"name"')).toBeLessThan(body);
-			expect(contents.indexOf('"message"')).toBeLessThan(body);
-			expect(contents.indexOf('"stack"')).toBeLessThan(body);
+		what: "NonZeroExitError whose 20KB stderr must not evict exitCode",
+		build: () => new NonZeroExitError(7, "E".repeat(20 * 1024)),
+		keeps: ['"exitCode":7', '"stderr":"', "[field truncated]"],
+		after: contents => expect(Buffer.byteLength(contents, "utf8")).toBeLessThanOrEqual(CRASH_RECORD_MAX_BYTES),
+	},
+	{
+		what: "credential-shaped request fields on an Error",
+		build: () =>
+			Object.assign(new Error("upstream refused the connection"), {
+				config: { headers: { authorization: "Bearer sk-abcdefghijklmnopqrstuvwxyz012345" } },
+				body: "Y".repeat(200_000),
+			}),
+		keeps: ["upstream refused the connection", "postmortem-unreadable-throwables.test.ts"],
+		omits: ["Bearer sk-", '"config"', '"body"', "Y".repeat(1024)],
+		after: contents => expect(Buffer.byteLength(contents, "utf8")).toBeLessThanOrEqual(CRASH_RECORD_MAX_BYTES),
+	},
+	{
+		what: "credential inside a retained diagnostic field",
+		build: () =>
+			Object.assign(new Error("child failed"), {
+				exitCode: 7,
+				stderr: "Authorization=Bearer sk-abcdefghijklmnopqrstuvwxyz012345",
+			}),
+		keeps: ['"exitCode":7', '"stderr":"Authorization=«redacted»"'],
+		omits: ["Bearer sk-", "abcdefghijklmnopqrstuvwxyz012345"],
+	},
+	{
+		what: "named record with an explicitly empty stack",
+		build: () => ({ name: "E", message: "m", stack: "", other: 1 }),
+		keeps: ["E: m"],
+		omits: ['"stack"', '"other"'],
+		after: contents => expect(contents.match(/E: m/g)).toHaveLength(1),
+	},
+	{
+		what: "own context field that references the throwable",
+		build: () => {
+			const reads: string[] = [];
+			const throwable: Record<string, unknown> = {
+				get name() {
+					if (reads.push("name") > 1) throw new Error("name read twice");
+					return "E";
+				},
+				get message() {
+					if (reads.push("message") > 2) throw new Error("message read twice");
+					return "m";
+				},
+			};
+			throwable.reason = throwable;
+			return throwable;
 		},
+		keeps: ["E: m", '"reason":"[object Object]"'],
+	},
+	{
+		what: "own diagnostic field whose value is undefined",
+		build: () => ({ message: "undefined context survives", phase: undefined }),
+		keeps: ["Error: undefined context survives", '"phase":"[undefined]"'],
 	},
 	{
 		what: "record whose symbol message must not disappear",
 		build: () => ({ message: Symbol("lost") }),
-		keeps: ['{"message":"Symbol(lost)"}'],
+		keeps: ["Error: Symbol(lost)"],
 	},
 	{
 		what: "record whose function message must not disappear",
 		build: () => ({ message: () => "x" }),
-		keeps: ['{"message":"() => \\"x\\""}'],
+		keeps: ['Error: () => "x"'],
 	},
 	{
 		what: "thrown string primitive",
@@ -247,7 +292,7 @@ function diagnosticOf(contents: string): string {
 }
 
 describe("crash recording of throwables that refuse to be read", () => {
-	for (const { what, build, keeps, after } of throwables) {
+	for (const { what, build, keeps, omits, after } of throwables) {
 		it(`records a fatal from a ${what}`, () => {
 			const target = crashLogTarget();
 
@@ -257,6 +302,7 @@ describe("crash recording of throwables that refuse to be read", () => {
 
 			const contents = fs.readFileSync(target, "utf8");
 			for (const fragment of keeps) expect(contents).toContain(fragment);
+			for (const fragment of omits ?? []) expect(contents).not.toContain(fragment);
 			after?.(contents);
 			// Whatever it was, the record says something: never an empty diagnostic.
 			expect(diagnosticOf(contents)).not.toBe("");

--- a/packages/utils/test/postmortem-unreadable-throwables.test.ts
+++ b/packages/utils/test/postmortem-unreadable-throwables.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as vm from "node:vm";
+import { recordFatalCrash } from "../src/postmortem";
+
+/**
+ * The crash reader is the only place this module turns an unknown throwable
+ * into text, so it is the only place that has to be unbreakable. Producers are
+ * unbounded — an `Error` with a lazily computed `message`, a hostile `Proxy`, a
+ * cross-realm object, a plain record, a primitive — and hardening them one at a
+ * time is what left a sibling path unguarded on every previous attempt.
+ *
+ * So this table is written against the consumer: whatever the throwable is, the
+ * record exists and carries every field that could be read.
+ */
+const LABEL = "Uncaught Exception";
+const RECORDED_AT = new Date("2026-01-01T00:00:00.000Z");
+
+const refusingAccessor = (field: string): PropertyDescriptor => ({
+	configurable: true,
+	get(): never {
+		throw new Error(`${field} getter always throws`);
+	},
+});
+
+/** A same-realm `Error` whose named fields refuse to answer; `instanceof Error` still holds. */
+function errorRefusing(fields: readonly ("name" | "message" | "stack")[]): Error {
+	const error = new Error("this message is never readable");
+	error.name = "LazyFailure";
+	for (const field of fields) Object.defineProperty(error, field, refusingAccessor(field));
+	return error;
+}
+
+interface Throwables {
+	/** Case name, also the assertion failure label. */
+	readonly what: string;
+	readonly build: () => unknown;
+	/** Fragments the record must keep: everything readable, plus a marker for everything not. */
+	readonly keeps: readonly string[];
+}
+
+const throwables: readonly Throwables[] = [
+	{
+		what: "same-realm Error whose message getter throws",
+		build: () => errorRefusing(["message"]),
+		// The name and the trace answered, so they survive; only `message` is lost.
+		keeps: ["LazyFailure: [unreadable]", "postmortem-unreadable-throwables.test.ts"],
+	},
+	{
+		what: "same-realm Error whose name, message and stack getters all throw",
+		build: () => errorRefusing(["name", "message", "stack"]),
+		// Nothing answered. Reported as unreadable, which is a fact; serializing
+		// an `Error` instead yields `{}`, which is silence.
+		keeps: ["[unreadable]: [unreadable]"],
+	},
+	{
+		what: "Proxy that throws from its getPrototypeOf trap",
+		build: () =>
+			new Proxy(
+				{},
+				{
+					getPrototypeOf(): never {
+						throw new Error("getPrototypeOf trap always throws");
+					},
+					get(_target, property): unknown {
+						if (property === "name") return "HostileFailure";
+						if (property === "message") return "hostile fatal survives";
+						throw new Error("get trap always throws");
+					},
+				},
+			),
+		keeps: ["HostileFailure: hostile fatal survives"],
+	},
+	{
+		what: "Proxy that answers nothing at all",
+		build: () =>
+			new Proxy(
+				{},
+				{
+					getPrototypeOf(): never {
+						throw new Error("getPrototypeOf trap always throws");
+					},
+					get(): never {
+						throw new Error("get trap always throws");
+					},
+					ownKeys(): never {
+						throw new Error("ownKeys trap always throws");
+					},
+				},
+			),
+		keeps: ["[unreadable]: [unreadable]"],
+	},
+	{
+		what: "cross-realm error-like object",
+		build: () =>
+			vm.runInNewContext(
+				"(() => { const error = new Error('cross-realm boom'); error.stack = 'CrossRealmStack'; return error; })()",
+			),
+		keeps: ["Error: cross-realm boom", "CrossRealmStack"],
+	},
+	{
+		what: "plain record thrown instead of an Error",
+		build: () => ({ phase: "startup", reason: "broker-spawn", message: "record fatal" }),
+		// No `name`, so this is payload rather than an error shape: the whole
+		// record is kept instead of collapsing to `[object Object]`.
+		keeps: ['{"phase":"startup","reason":"broker-spawn","message":"record fatal"}'],
+	},
+	{
+		what: "thrown string primitive",
+		build: () => "plain string boom",
+		keeps: ["Error: plain string boom"],
+	},
+	{
+		what: "thrown symbol primitive",
+		build: () => Symbol("symbol boom"),
+		keeps: ["Error: Symbol(symbol boom)"],
+	},
+	{
+		what: "thrown null",
+		build: () => null,
+		keeps: ["Error: null"],
+	},
+];
+
+const crashLogTarget = (): string =>
+	path.join(fs.mkdtempSync(path.join(os.tmpdir(), "gjc-unreadable-")), "gjc-crash.log");
+
+/** The diagnostic the record actually carries: the header line minus timestamp, pid and label. */
+function diagnosticOf(contents: string): string {
+	const header = contents.split("\n")[0] ?? "";
+	return header.slice(header.indexOf(`[${LABEL}] `) + LABEL.length + 3).trim();
+}
+
+describe("crash recording of throwables that refuse to be read", () => {
+	for (const { what, build, keeps } of throwables) {
+		it(`records a fatal from a ${what}`, () => {
+			const target = crashLogTarget();
+
+			// A throw out of here is the failure this whole table exists for: the
+			// crash reader must never be the reason a crash goes unrecorded.
+			expect(recordFatalCrash(LABEL, build(), { path: target, now: RECORDED_AT })).toBe(target);
+
+			const contents = fs.readFileSync(target, "utf8");
+			for (const fragment of keeps) expect(contents).toContain(fragment);
+			// Whatever it was, the record says something: never an empty diagnostic.
+			expect(diagnosticOf(contents)).not.toBe("");
+			expect(diagnosticOf(contents)).not.toBe("(no message)");
+		});
+	}
+
+	it("reads each field of a throwable exactly once, even when a sibling refuses", () => {
+		const reads: string[] = [];
+		const reason = {
+			get name(): string {
+				reads.push("name");
+				return "CountedFailure";
+			},
+			get message(): string {
+				reads.push("message");
+				throw new Error("message getter always throws");
+			},
+			get stack(): string {
+				reads.push("stack");
+				return "CountedFailureStack";
+			},
+		};
+
+		const target = crashLogTarget();
+		expect(recordFatalCrash(LABEL, reason, { path: target, now: RECORDED_AT })).toBe(target);
+
+		const contents = fs.readFileSync(target, "utf8");
+		expect(contents).toContain("CountedFailure: [unreadable]");
+		expect(contents).toContain("CountedFailureStack");
+		// A second observation is the hazard a stateful accessor uses to throw
+		// after passing a shape check, so there is no second observation.
+		expect(reads).toEqual(["name", "message", "stack"]);
+	});
+});

--- a/packages/utils/test/postmortem-unreadable-throwables.test.ts
+++ b/packages/utils/test/postmortem-unreadable-throwables.test.ts
@@ -39,6 +39,7 @@ interface Throwables {
 	readonly build: () => unknown;
 	/** Fragments the record must keep: everything readable, plus a marker for everything not. */
 	readonly keeps: readonly string[];
+	readonly after?: (contents: string) => void;
 }
 
 const throwables: readonly Throwables[] = [
@@ -119,6 +120,53 @@ const throwables: readonly Throwables[] = [
 		keeps: ['{"phase":"startup","reason":"broker-spawn","message":"record fatal"}'],
 	},
 	{
+		what: "plain record carrying a readable stack and crash context",
+		build: () => ({
+			phase: "startup",
+			reason: "broker-spawn",
+			exitCode: 7,
+			stack: "at spawnBroker (broker.ts:1:1)",
+		}),
+		keeps: ['{"phase":"startup","reason":"broker-spawn","exitCode":7,"stack":"at spawnBroker (broker.ts:1:1)"}'],
+	},
+	{
+		what: "named error record carrying HTTP response context",
+		build: () => ({
+			name: "HttpError",
+			message: "502 Bad Gateway",
+			status: 502,
+			url: "https://api/x",
+			body: "upstream",
+		}),
+		keeps: ['{"name":"HttpError","message":"502 Bad Gateway","status":502,"url":"https://api/x","body":"upstream"}'],
+	},
+	((): Throwables => {
+		const reads: string[] = [];
+		return {
+			what: "record whose error fields must not be re-read during payload serialization",
+			build: () => {
+				reads.length = 0;
+				return {
+					get name(): number {
+						reads.push("name");
+						return 17;
+					},
+					get message(): null {
+						reads.push("message");
+						return null;
+					},
+					get stack(): boolean {
+						reads.push("stack");
+						return false;
+					},
+					payload: "readable context survives",
+				};
+			},
+			keeps: ['{"name":17,"message":null,"stack":false,"payload":"readable context survives"}'],
+			after: () => expect(reads).toEqual(["name", "message", "stack"]),
+		};
+	})(),
+	{
 		what: "thrown string primitive",
 		build: () => "plain string boom",
 		keeps: ["Error: plain string boom"],
@@ -145,7 +193,7 @@ function diagnosticOf(contents: string): string {
 }
 
 describe("crash recording of throwables that refuse to be read", () => {
-	for (const { what, build, keeps } of throwables) {
+	for (const { what, build, keeps, after } of throwables) {
 		it(`records a fatal from a ${what}`, () => {
 			const target = crashLogTarget();
 
@@ -155,37 +203,10 @@ describe("crash recording of throwables that refuse to be read", () => {
 
 			const contents = fs.readFileSync(target, "utf8");
 			for (const fragment of keeps) expect(contents).toContain(fragment);
+			after?.(contents);
 			// Whatever it was, the record says something: never an empty diagnostic.
 			expect(diagnosticOf(contents)).not.toBe("");
 			expect(diagnosticOf(contents)).not.toBe("(no message)");
 		});
 	}
-
-	it("reads each field of a throwable exactly once, even when a sibling refuses", () => {
-		const reads: string[] = [];
-		const reason = {
-			get name(): string {
-				reads.push("name");
-				return "CountedFailure";
-			},
-			get message(): string {
-				reads.push("message");
-				throw new Error("message getter always throws");
-			},
-			get stack(): string {
-				reads.push("stack");
-				return "CountedFailureStack";
-			},
-		};
-
-		const target = crashLogTarget();
-		expect(recordFatalCrash(LABEL, reason, { path: target, now: RECORDED_AT })).toBe(target);
-
-		const contents = fs.readFileSync(target, "utf8");
-		expect(contents).toContain("CountedFailure: [unreadable]");
-		expect(contents).toContain("CountedFailureStack");
-		// A second observation is the hazard a stateful accessor uses to throw
-		// after passing a shape check, so there is no second observation.
-		expect(reads).toEqual(["name", "message", "stack"]);
-	});
 });

--- a/packages/utils/test/postmortem-unreadable-throwables.test.ts
+++ b/packages/utils/test/postmortem-unreadable-throwables.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as vm from "node:vm";
 import { recordFatalCrash } from "../src/postmortem";
+import { NonZeroExitError } from "../src/ptree";
 
 /**
  * The crash reader is the only place this module turns an unknown throwable
@@ -31,6 +32,15 @@ function errorRefusing(fields: readonly ("name" | "message" | "stack")[]): Error
 	error.name = "LazyFailure";
 	for (const field of fields) Object.defineProperty(error, field, refusingAccessor(field));
 	return error;
+}
+
+function missingFileError(): unknown {
+	try {
+		fs.readFileSync("/definitely/not/here");
+	} catch (error) {
+		return error;
+	}
+	throw new Error("missing-file probe unexpectedly succeeded");
 }
 
 interface Throwables {
@@ -113,11 +123,30 @@ const throwables: readonly Throwables[] = [
 		keeps: ["Error: cross-realm boom", "CrossRealmStack"],
 	},
 	{
+		what: "Node system error with enumerable context and a real stack",
+		build: missingFileError,
+		keeps: ["ENOENT", '"code":"ENOENT"', "/definitely/not/here", "postmortem-unreadable-throwables.test.ts"],
+	},
+	{
+		what: "NonZeroExitError with own fields and a load-bearing stack",
+		build: () => {
+			const error = new NonZeroExitError(7, "child stderr survives");
+			error.stack = `${error.name}: ${error.message}\n    at load-bearing-nonzero-frame`;
+			return error;
+		},
+		keeps: [
+			"NonZeroExitError: Process exited with code 7:",
+			"load-bearing-nonzero-frame",
+			'"exitCode":7',
+			'"stderr":"child stderr survives"',
+		],
+	},
+	{
 		what: "plain record thrown instead of an Error",
 		build: () => ({ phase: "startup", reason: "broker-spawn", message: "record fatal" }),
 		// No `name`, so this is payload rather than an error shape: the whole
 		// record is kept instead of collapsing to `[object Object]`.
-		keeps: ['{"phase":"startup","reason":"broker-spawn","message":"record fatal"}'],
+		keeps: ['{"message":"record fatal","phase":"startup","reason":"broker-spawn"}'],
 	},
 	{
 		what: "plain record carrying a readable stack and crash context",
@@ -127,7 +156,7 @@ const throwables: readonly Throwables[] = [
 			exitCode: 7,
 			stack: "at spawnBroker (broker.ts:1:1)",
 		}),
-		keeps: ['{"phase":"startup","reason":"broker-spawn","exitCode":7,"stack":"at spawnBroker (broker.ts:1:1)"}'],
+		keeps: ['{"stack":"at spawnBroker (broker.ts:1:1)","phase":"startup","reason":"broker-spawn","exitCode":7}'],
 	},
 	{
 		what: "named error record carrying HTTP response context",
@@ -166,6 +195,31 @@ const throwables: readonly Throwables[] = [
 			after: () => expect(reads).toEqual(["name", "message", "stack"]),
 		};
 	})(),
+	{
+		what: "Error with an oversized own field",
+		build: () => Object.assign(new Error("upstream refused the connection"), { body: "X".repeat(70_000) }),
+		keeps: [
+			"upstream refused the connection",
+			"postmortem-unreadable-throwables.test.ts",
+			"[crash record truncated]",
+		],
+		after: contents => {
+			const body = contents.indexOf('"body"');
+			expect(contents.indexOf('"name"')).toBeLessThan(body);
+			expect(contents.indexOf('"message"')).toBeLessThan(body);
+			expect(contents.indexOf('"stack"')).toBeLessThan(body);
+		},
+	},
+	{
+		what: "record whose symbol message must not disappear",
+		build: () => ({ message: Symbol("lost") }),
+		keeps: ['{"message":"Symbol(lost)"}'],
+	},
+	{
+		what: "record whose function message must not disappear",
+		build: () => ({ message: () => "x" }),
+		keeps: ['{"message":"() => \\"x\\""}'],
+	},
 	{
 		what: "thrown string primitive",
 		build: () => "plain string boom",

--- a/packages/utils/test/postmortem-unreadable-throwables.test.ts
+++ b/packages/utils/test/postmortem-unreadable-throwables.test.ts
@@ -49,6 +49,17 @@ const throwables: readonly Throwables[] = [
 		keeps: ["LazyFailure: [unreadable]", "postmortem-unreadable-throwables.test.ts"],
 	},
 	{
+		what: "same-realm Error whose name refuses while stack remains readable",
+		build: () => {
+			const error = new Error("discarded message");
+			Object.defineProperty(error, "name", refusingAccessor("name"));
+			Object.defineProperty(error, "message", { configurable: true, value: undefined });
+			error.stack = "Error\n    at load-bearing-frame";
+			return error;
+		},
+		keeps: ["[unreadable]: (no message)", "load-bearing-frame"],
+	},
+	{
 		what: "same-realm Error whose name, message and stack getters all throw",
 		build: () => errorRefusing(["name", "message", "stack"]),
 		// Nothing answered. Reported as unreadable, which is a fact; serializing
@@ -71,7 +82,7 @@ const throwables: readonly Throwables[] = [
 					},
 				},
 			),
-		keeps: ["HostileFailure: hostile fatal survives"],
+		keeps: ["HostileFailure: hostile fatal survives", "\n[unreadable]\n"],
 	},
 	{
 		what: "Proxy that answers nothing at all",


### PR DESCRIPTION
Crash records lost their diagnostic in several ways, and the fix for that leaked a credential — both are here.

## What was wrong

`describeThrowable` collapsed every non-`Error` payload to `[object Object]`, so SDK lifecycle startup failures — thrown as `{ phase, reason, message }` records — reached the log with nothing usable. Hardening it one shape at a time failed repeatedly: a same-realm `Error` whose `message` getter throws destroyed the whole record, an all-or-nothing `name`/`message` gate discarded a readable `stack`, and a looser gate rendered a plain record as an error and dropped its context.

Each of those existed because the code decided *what kind of thing it had* before deciding what to keep. There is no classification step now: whatever a field yields is kept, whatever refuses is named unreadable, and the record degrades field by field instead of collapsing.

## The part that matters most

Preserving own error fields verbatim turned the improvement into a leak, because own error fields are exactly where credentials live:

```console
$ bun -e '… throw Object.assign(new Error("upstream refused"),
    { config: { headers: { authorization: "Bearer sk-…" } }, body: "Y".repeat(200_000) })'
before:  200464 bytes, 1 match for 'Bearer sk-'
dev:        191 bytes, 0 matches
after:      206 bytes, 0 matches
```

Keeping a field and keeping it verbatim are separate decisions and only the first had been made. Own properties are redacted for credential shapes and bounded per field — a single whole-record cap was defeated by one 200 KB body, which also evicted the identifying fields the record exists for. `NonZeroExitError(7, 20KB)` keeps its `exitCode` now; it did not before.

## Verification

`bun test packages/utils/test` — 316 pass, 0 fail. `bun --cwd=packages/coding-agent run check` — exit 0.

Reverting `packages/utils/src/postmortem.ts` to `dev` fails 17 tests behaviorally, including the credential case, the 200 KB bound, throwing `name`/`message`/`stack` getters, a `Proxy` that answers nothing, and cross-realm errors.

## Known and not fixed

A credential shape the redactor does not recognize still passes through. The redactor catches the common ones; it is a filter, not a proof.
