### PR TITLE
fix(acp): give every replayed tool call a terminal, or none at all

### DIFF
--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -466,6 +466,16 @@ const TRANSCRIPT_TOOL_CALL_UNRESOLVED = "The session transcript ends without a r
 /** Stands in for a tool call replay abandoned before it could read back a result. */
 const TRANSCRIPT_REPLAY_INTERRUPTED = "Transcript replay stopped before this tool call reached a result.";
 
+/**
+ * The published tool calls a replay cleanup pass could not close, with the frame failures
+ * that refused them. `#replaySession` reads `unclosedToolCallIds` to name every stranded
+ * call in the `session/load` rejection, so a close that could not happen is reported to the
+ * caller instead of being discarded with the session record.
+ */
+interface UnclosedReplayToolCalls {
+	unclosedToolCallIds: string[];
+	failures: unknown[];
+}
 function decodeTranscriptContinuation(field: string, body: string): unknown {
 	if (field !== "content" && field !== "isError") return body;
 	try {
@@ -2477,89 +2487,68 @@ export class AcpAgent implements Agent {
 	}
 
 	/**
-	 * A skipped `toolResult` would leave its already-published `tool_call` at
-	 * `status: "pending"` forever, so replay closes it with the same
-	 * `tool_execution_end` shape a real result uses. Replay cannot know the outcome, so
-	 * it reports failure rather than claiming a success it cannot prove.
+	 * Publishes the terminal update for one replayed tool call and reports whether the client
+	 * took it. A `toolResult` replay cannot use leaves its already-published `tool_call` at
+	 * `status: "pending"` forever, so replay closes it with the same `tool_execution_end`
+	 * shape a real result uses. Replay cannot know the outcome, so it reports failure rather
+	 * than claiming a success it cannot prove.
+	 *
+	 * Publication runs straight off the connection instead of through
+	 * {@link AcpAgent.#publishSessionUpdate}: that helper fails the session and deletes its
+	 * record on the first rejected frame, which turns every later close into a silent no-op
+	 * and would strand every call queued behind the first refusal.
 	 */
-	async #closeUnresolvedReplayToolCall(
+	async #closeReplayToolCall(
 		id: string,
-		adapter: AcpSdkAdapter,
 		cwd: string,
 		toolCallId: string,
 		tool: { name: string; args: unknown },
-		reason: string = TRANSCRIPT_TOOL_RESULT_UNAVAILABLE,
-	): Promise<void> {
-		for (const notification of mapAgentSessionEventToAcpSessionUpdates(
-			{
-				type: "tool_execution_end",
-				toolCallId,
-				toolName: tool.name,
-				result: { content: [{ type: "text", text: reason }] },
-				isError: true,
-			} as never,
-			id,
-			{ cwd, getToolArgs: () => tool.args },
-		))
-			await this.#publishSessionUpdate(id, notification, adapter);
+		reason: string,
+	): Promise<AcpSdkAdapterError | undefined> {
+		try {
+			for (const notification of mapAgentSessionEventToAcpSessionUpdates(
+				{
+					type: "tool_execution_end",
+					toolCallId,
+					toolName: tool.name,
+					result: { content: [{ type: "text", text: reason }] },
+					isError: true,
+				} as never,
+				id,
+				{ cwd, getToolArgs: () => tool.args },
+			))
+				await this.#connection.sessionUpdate(notification);
+			return undefined;
+		} catch (error) {
+			return this.#frameProcessingFailure(error);
+		}
 	}
 
 	/**
-	 * Closes every tool call still open when replay stops, in a single pass.
+	 * Closes every tool call still open when replay stops, in a single pass, and hands back
+	 * the ones the client refused.
 	 *
-	 * Publication runs straight off the connection instead of through
-	 * {@link AcpAgent.#publishSessionUpdate}, because that helper fails the session on the
-	 * first rejected frame and a deleted session record turns every later publication into
-	 * a silent no-op — the calls queued behind the first failure would stay `pending` for
-	 * the life of the client. Teardown therefore happens once, after every call has been
-	 * attempted, and the calls that could not be closed are reported instead of dropped.
+	 * An entry leaves `replayTools` only once its close was accepted. Removing it on the
+	 * attempt is what made a refused close disappear from the map before anything could name
+	 * it, so the one call the report exists to surface was the one call it never mentioned.
 	 */
 	async #closeOpenReplayToolCalls(
 		id: string,
-		adapter: AcpSdkAdapter,
 		cwd: string,
 		replayTools: Map<string, { name: string; args: unknown }>,
 		reason: string,
-	): Promise<void> {
-		const open = [...replayTools];
-		replayTools.clear();
-		if (open.length === 0) return;
-		const unclosed: string[] = [];
-		const failures: unknown[] = [];
-		for (const [toolCallId, tool] of open) {
-			const record = this.#sessions.get(id);
-			// The session can only be gone here through a teardown this loop did not cause.
-			// The call is unclosable either way, and saying so beats publishing into nothing.
-			if (!record || record.adapter !== adapter) {
-				unclosed.push(toolCallId);
+	): Promise<UnclosedReplayToolCalls> {
+		const unclosed: UnclosedReplayToolCalls = { unclosedToolCallIds: [], failures: [] };
+		for (const [toolCallId, tool] of [...replayTools]) {
+			const failure = await this.#closeReplayToolCall(id, cwd, toolCallId, tool, reason);
+			if (failure === undefined) {
+				replayTools.delete(toolCallId);
 				continue;
 			}
-			try {
-				for (const notification of mapAgentSessionEventToAcpSessionUpdates(
-					{
-						type: "tool_execution_end",
-						toolCallId,
-						toolName: tool.name,
-						result: { content: [{ type: "text", text: reason }] },
-						isError: true,
-					} as never,
-					id,
-					{ cwd, getToolArgs: () => tool.args },
-				))
-					await this.#connection.sessionUpdate(notification);
-			} catch (error) {
-				unclosed.push(toolCallId);
-				failures.push(this.#frameProcessingFailure(error));
-			}
+			unclosed.unclosedToolCallIds.push(toolCallId);
+			unclosed.failures.push(failure);
 		}
-		if (unclosed.length === 0) return;
-		const failure = aggregateAcpFailure(
-			"frame_processing_failed",
-			`ACP transcript replay could not close published tool calls: ${unclosed.join(", ")}`,
-			failures,
-		);
-		await this.#failSession(id, adapter, failure);
-		throw failure;
+		return unclosed;
 	}
 
 	async #replaySession(id: string): Promise<void> {
@@ -2573,26 +2562,39 @@ export class AcpAgent implements Agent {
 		} catch (error) {
 			replayFailure = error;
 		}
-		// One boundary for every way the replay body can end: normal return, early exit, or a
-		// `transcript.list` page that throws. Whatever is still open was abandoned mid-replay,
-		// so it reaches a terminal status now instead of spinning at `pending` for the life of
-		// the session.
-		try {
-			await this.#closeOpenReplayToolCalls(id, adapter, record.cwd, replayTools, TRANSCRIPT_REPLAY_INTERRUPTED);
-		} catch (cleanupFailure) {
-			if (replayFailure === undefined) throw cleanupFailure;
-			// Both facts matter: what stopped replay, and which calls it left open. Reporting
-			// only one is what kept a whole session's orphaned tool calls invisible.
-			const detail = [replayFailure, cleanupFailure]
-				.map(failure => (failure instanceof Error ? failure.message : String(failure)))
-				.join("; ");
-			throw aggregateAcpFailure(
-				"frame_processing_failed",
-				`ACP transcript replay failed and left published tool calls unclosed: ${detail}`,
-				[replayFailure, cleanupFailure],
-			);
+		// The one boundary that closes replayed tool calls, covering every way the replay body
+		// can end: normal return, early exit, or a `transcript.list` page that throws. Whatever
+		// is still open was abandoned mid-replay, so it reaches a terminal status now instead of
+		// spinning at `pending` for the life of the session.
+		const unclosed = await this.#closeOpenReplayToolCalls(
+			id,
+			record.cwd,
+			replayTools,
+			replayFailure === undefined ? TRANSCRIPT_TOOL_CALL_UNRESOLVED : TRANSCRIPT_REPLAY_INTERRUPTED,
+		);
+		if (unclosed.unclosedToolCallIds.length === 0) {
+			if (replayFailure !== undefined) throw replayFailure;
+			return;
 		}
-		if (replayFailure !== undefined) throw replayFailure;
+		const cleanupFailure = aggregateAcpFailure(
+			"frame_processing_failed",
+			`ACP transcript replay could not close published tool calls: ${unclosed.unclosedToolCallIds.join(", ")}`,
+			unclosed.failures,
+		);
+		// A client refusing this session's frames leaves no usable record behind, but teardown
+		// runs only after every open call has been attempted and every refusal named above.
+		await this.#failSession(id, adapter, cleanupFailure);
+		if (replayFailure === undefined) throw cleanupFailure;
+		// Both facts matter: what stopped replay, and which calls it left open. Reporting
+		// only one is what kept a whole session's orphaned tool calls invisible.
+		const detail = [replayFailure, cleanupFailure]
+			.map(failure => (failure instanceof Error ? failure.message : String(failure)))
+			.join("; ");
+		throw aggregateAcpFailure(
+			"frame_processing_failed",
+			`ACP transcript replay failed and left published tool calls unclosed: ${detail}`,
+			[replayFailure, cleanupFailure],
+		);
 	}
 
 	/**
@@ -2627,9 +2629,17 @@ export class AcpAgent implements Agent {
 					unreplayableReason ??= replay.reason;
 					const unresolvedId = typeof message.toolCallId === "string" ? message.toolCallId : undefined;
 					const unresolved = unresolvedId === undefined ? undefined : replayTools.get(unresolvedId);
+					// The start keeps its place in `replayTools` until the close is accepted, so a
+					// refused close is retried and named by the boundary instead of dropped here.
 					if (unresolvedId !== undefined && unresolved) {
-						replayTools.delete(unresolvedId);
-						await this.#closeUnresolvedReplayToolCall(id, adapter, record.cwd, unresolvedId, unresolved);
+						const failure = await this.#closeReplayToolCall(
+							id,
+							record.cwd,
+							unresolvedId,
+							unresolved,
+							TRANSCRIPT_TOOL_RESULT_UNAVAILABLE,
+						);
+						if (failure === undefined) replayTools.delete(unresolvedId);
 					}
 					continue;
 				}
@@ -2728,8 +2738,16 @@ export class AcpAgent implements Agent {
 					if (!toolName) {
 						unreplayableEntries++;
 						unreplayableReason ??= "transcript_tool_call_unavailable";
-						replayTools.delete(message.toolCallId);
-						await this.#closeUnresolvedReplayToolCall(id, adapter, record.cwd, message.toolCallId, replayTool);
+						// The start keeps its place in `replayTools` until the close is accepted, so a
+						// refused close is retried and named by the boundary instead of dropped here.
+						const failure = await this.#closeReplayToolCall(
+							id,
+							record.cwd,
+							message.toolCallId,
+							replayTool,
+							TRANSCRIPT_TOOL_RESULT_UNAVAILABLE,
+						);
+						if (failure === undefined) replayTools.delete(message.toolCallId);
 						continue;
 					}
 					const resultContent = richContent
@@ -2773,12 +2791,11 @@ export class AcpAgent implements Agent {
 			}
 			cursor = typeof page?.continuationCursor === "string" ? page.continuationCursor : undefined;
 			if (cursor) continue;
-			// Every start still parked here outlived its result row, so replay ends it
-			// instead of handing the client a tool call nothing will ever complete.
+			// Every start still parked here outlived its result row. `#replaySession` owns the
+			// close at its single boundary, so this pass only accounts for them.
 			if (replayTools.size > 0) {
 				unreplayableEntries += replayTools.size;
 				unreplayableReason ??= "transcript_tool_call_unavailable";
-				await this.#closeOpenReplayToolCalls(id, adapter, record.cwd, replayTools, TRANSCRIPT_TOOL_CALL_UNRESOLVED);
 			}
 			// An entry without its production body is skipped, never fatal: losing one
 			// transcript row must not revoke `session/load` for the whole session.

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -2499,10 +2499,12 @@ export class AcpAgent implements Agent {
 	 * Publication runs straight off the connection instead of through
 	 * {@link AcpAgent.#publishSessionUpdate}: that helper fails the session and deletes its
 	 * record on the first rejected frame, which turns every later close into a silent no-op
-	 * and would strand every call queued behind the first refusal.
+	 * and would strand every call queued behind the first refusal. The direct path still
+	 * checks session ownership before every frame so a concurrent `session/close` stops it.
 	 */
 	async #closeReplayToolCall(
 		id: string,
+		expectedAdapter: AcpSdkAdapter,
 		cwd: string,
 		toolCallId: string,
 		tool: { name: string; args: unknown },
@@ -2519,8 +2521,11 @@ export class AcpAgent implements Agent {
 				} as never,
 				id,
 				{ cwd, getToolArgs: () => tool.args },
-			))
+			)) {
+				const record = this.#sessions.get(id);
+				if (!record || record.adapter !== expectedAdapter) return undefined;
 				await this.#connection.sessionUpdate(notification);
+			}
 			return undefined;
 		} catch (error) {
 			return this.#frameProcessingFailure(error);
@@ -2537,13 +2542,14 @@ export class AcpAgent implements Agent {
 	 */
 	async #closeOpenReplayToolCalls(
 		id: string,
+		adapter: AcpSdkAdapter,
 		cwd: string,
 		replayTools: Map<string, { name: string; args: unknown }>,
 		reason: string,
 	): Promise<UnclosedReplayToolCalls> {
 		const unclosed: UnclosedReplayToolCalls = { unclosedToolCallIds: [], failures: [] };
 		for (const [toolCallId, tool] of [...replayTools]) {
-			const failure = await this.#closeReplayToolCall(id, cwd, toolCallId, tool, reason);
+			const failure = await this.#closeReplayToolCall(id, adapter, cwd, toolCallId, tool, reason);
 			if (failure === undefined) {
 				replayTools.delete(toolCallId);
 				continue;
@@ -2570,11 +2576,10 @@ export class AcpAgent implements Agent {
 		// client's view of these calls with it: nothing is left to observe a `pending` one,
 		// and a frame carrying a closed session id is one the client asked to stop receiving.
 		// The obligation ends where the session ends; the next `session/load` replays the same
-		// transcript rows from scratch. Read once here rather than at each exit, because
-		// `#closeReplayToolCall` bypasses `#publishSessionUpdate` on purpose — so its own
-		// failures cannot silence the calls behind it — and therefore cannot notice the
-		// session is gone. `#sessionState` reports that missing session to the caller more
-		// accurately than any replay failure about it would.
+		// transcript rows from scratch. The boundary check avoids entering cleanup for an
+		// already-closed session, while `#closeReplayToolCall` repeats the ownership check before
+		// each direct publication so a close during cleanup stops the remaining frames without
+		// restoring the failure side effects that used to silence calls behind a refused close.
 		if (this.#sessions.get(id)?.adapter !== adapter) return;
 		// The one boundary that closes replayed tool calls, covering every way the replay body
 		// can end: normal return, early exit, or a `transcript.list` page that throws. Whatever
@@ -2582,6 +2587,7 @@ export class AcpAgent implements Agent {
 		// spinning at `pending` for the life of the session.
 		const unclosed = await this.#closeOpenReplayToolCalls(
 			id,
+			adapter,
 			record.cwd,
 			replayTools,
 			replayFailure === undefined ? TRANSCRIPT_TOOL_CALL_UNRESOLVED : TRANSCRIPT_REPLAY_INTERRUPTED,
@@ -2648,6 +2654,7 @@ export class AcpAgent implements Agent {
 					if (unresolvedId !== undefined && unresolved) {
 						const failure = await this.#closeReplayToolCall(
 							id,
+							adapter,
 							record.cwd,
 							unresolvedId,
 							unresolved,
@@ -2756,6 +2763,7 @@ export class AcpAgent implements Agent {
 						// refused close is retried and named by the boundary instead of dropped here.
 						const failure = await this.#closeReplayToolCall(
 							id,
+							adapter,
 							record.cwd,
 							message.toolCallId,
 							replayTool,

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -2504,35 +2504,95 @@ export class AcpAgent implements Agent {
 			await this.#publishSessionUpdate(id, notification, adapter);
 	}
 
+	/**
+	 * Closes every tool call still open when replay stops, in a single pass.
+	 *
+	 * Publication runs straight off the connection instead of through
+	 * {@link AcpAgent.#publishSessionUpdate}, because that helper fails the session on the
+	 * first rejected frame and a deleted session record turns every later publication into
+	 * a silent no-op — the calls queued behind the first failure would stay `pending` for
+	 * the life of the client. Teardown therefore happens once, after every call has been
+	 * attempted, and the calls that could not be closed are reported instead of dropped.
+	 */
+	async #closeOpenReplayToolCalls(
+		id: string,
+		adapter: AcpSdkAdapter,
+		cwd: string,
+		replayTools: Map<string, { name: string; args: unknown }>,
+		reason: string,
+	): Promise<void> {
+		const open = [...replayTools];
+		replayTools.clear();
+		if (open.length === 0) return;
+		const unclosed: string[] = [];
+		const failures: unknown[] = [];
+		for (const [toolCallId, tool] of open) {
+			const record = this.#sessions.get(id);
+			// The session can only be gone here through a teardown this loop did not cause.
+			// The call is unclosable either way, and saying so beats publishing into nothing.
+			if (!record || record.adapter !== adapter) {
+				unclosed.push(toolCallId);
+				continue;
+			}
+			try {
+				for (const notification of mapAgentSessionEventToAcpSessionUpdates(
+					{
+						type: "tool_execution_end",
+						toolCallId,
+						toolName: tool.name,
+						result: { content: [{ type: "text", text: reason }] },
+						isError: true,
+					} as never,
+					id,
+					{ cwd, getToolArgs: () => tool.args },
+				))
+					await this.#connection.sessionUpdate(notification);
+			} catch (error) {
+				unclosed.push(toolCallId);
+				failures.push(this.#frameProcessingFailure(error));
+			}
+		}
+		if (unclosed.length === 0) return;
+		const failure = aggregateAcpFailure(
+			"frame_processing_failed",
+			`ACP transcript replay could not close published tool calls: ${unclosed.join(", ")}`,
+			failures,
+		);
+		await this.#failSession(id, adapter, failure);
+		throw failure;
+	}
+
 	async #replaySession(id: string): Promise<void> {
 		const adapter = this.#adapter(id);
 		const record = this.#sessions.get(id);
 		if (!record) return;
 		const replayTools = new Map<string, { name: string; args: unknown }>();
+		let replayFailure: unknown;
 		try {
 			await this.#replayTranscriptPages(id, adapter, record, replayTools);
-		} finally {
-			// One boundary for every way the replay body can end: a normal return, an early
-			// exit, or a `transcript.list` page that throws. A start still open here was
-			// abandoned mid-replay, so it reaches a terminal status now instead of spinning
-			// at `pending` for the life of the session.
-			for (const [toolCallId, tool] of replayTools) {
-				try {
-					await this.#closeUnresolvedReplayToolCall(
-						id,
-						adapter,
-						record.cwd,
-						toolCallId,
-						tool,
-						TRANSCRIPT_REPLAY_INTERRUPTED,
-					);
-				} catch {
-					// The failure that aborted replay is the one worth propagating; a cleanup
-					// publish that fails as well must not replace it.
-				}
-			}
-			replayTools.clear();
+		} catch (error) {
+			replayFailure = error;
 		}
+		// One boundary for every way the replay body can end: normal return, early exit, or a
+		// `transcript.list` page that throws. Whatever is still open was abandoned mid-replay,
+		// so it reaches a terminal status now instead of spinning at `pending` for the life of
+		// the session.
+		try {
+			await this.#closeOpenReplayToolCalls(id, adapter, record.cwd, replayTools, TRANSCRIPT_REPLAY_INTERRUPTED);
+		} catch (cleanupFailure) {
+			if (replayFailure === undefined) throw cleanupFailure;
+			// Both facts matter: what stopped replay, and which calls it left open. Reporting
+			// only one is what kept a whole session's orphaned tool calls invisible.
+			const detail = [replayFailure, cleanupFailure]
+				.map(failure => (failure instanceof Error ? failure.message : String(failure)))
+				.join("; ");
+			throw aggregateAcpFailure(
+				"frame_processing_failed",
+				`ACP transcript replay failed and left published tool calls unclosed: ${detail}`,
+				[replayFailure, cleanupFailure],
+			);
+		}
+		if (replayFailure !== undefined) throw replayFailure;
 	}
 
 	/**
@@ -2715,19 +2775,11 @@ export class AcpAgent implements Agent {
 			if (cursor) continue;
 			// Every start still parked here outlived its result row, so replay ends it
 			// instead of handing the client a tool call nothing will ever complete.
-			for (const [toolCallId, tool] of replayTools) {
-				unreplayableEntries++;
+			if (replayTools.size > 0) {
+				unreplayableEntries += replayTools.size;
 				unreplayableReason ??= "transcript_tool_call_unavailable";
-				await this.#closeUnresolvedReplayToolCall(
-					id,
-					adapter,
-					record.cwd,
-					toolCallId,
-					tool,
-					TRANSCRIPT_TOOL_CALL_UNRESOLVED,
-				);
+				await this.#closeOpenReplayToolCalls(id, adapter, record.cwd, replayTools, TRANSCRIPT_TOOL_CALL_UNRESOLVED);
 			}
-			replayTools.clear();
 			// An entry without its production body is skipped, never fatal: losing one
 			// transcript row must not revoke `session/load` for the whole session.
 			if (unreplayableReason)

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -2357,6 +2357,9 @@ export class AcpAgent implements Agent {
 		notification: SessionNotification,
 		expectedAdapter?: AcpSdkAdapter,
 	): Promise<void> {
+		// A session that is gone has no update channel, so this is a drop and not a failure:
+		// whoever owned the frame is the one that ended the session. Callers whose bookkeeping
+		// assumes delivery have to end at the session too — see `#replaySession`.
 		const record = this.#sessions.get(id);
 		if (!record || (expectedAdapter && record.adapter !== expectedAdapter)) return;
 		try {
@@ -2562,6 +2565,17 @@ export class AcpAgent implements Agent {
 		} catch (error) {
 			replayFailure = error;
 		}
+		// Every terminal below is addressed to this session, and `session/close`, a failed
+		// session, or connection teardown can remove it mid-replay. That removal takes the
+		// client's view of these calls with it: nothing is left to observe a `pending` one,
+		// and a frame carrying a closed session id is one the client asked to stop receiving.
+		// The obligation ends where the session ends; the next `session/load` replays the same
+		// transcript rows from scratch. Read once here rather than at each exit, because
+		// `#closeReplayToolCall` bypasses `#publishSessionUpdate` on purpose — so its own
+		// failures cannot silence the calls behind it — and therefore cannot notice the
+		// session is gone. `#sessionState` reports that missing session to the caller more
+		// accurately than any replay failure about it would.
+		if (this.#sessions.get(id)?.adapter !== adapter) return;
 		// The one boundary that closes replayed tool calls, covering every way the replay body
 		// can end: normal return, early exit, or a `transcript.list` page that throws. Whatever
 		// is still open was abandoned mid-replay, so it reaches a terminal status now instead of

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -463,6 +463,9 @@ const TRANSCRIPT_TOOL_RESULT_UNAVAILABLE = "The transcript entry holding this to
 /** Stands in for a tool call the transcript never recorded a result for. */
 const TRANSCRIPT_TOOL_CALL_UNRESOLVED = "The session transcript ends without a result for this tool call.";
 
+/** Stands in for a tool call replay abandoned before it could read back a result. */
+const TRANSCRIPT_REPLAY_INTERRUPTED = "Transcript replay stopped before this tool call reached a result.";
+
 function decodeTranscriptContinuation(field: string, body: string): unknown {
 	if (field !== "content" && field !== "isError") return body;
 	try {
@@ -2505,11 +2508,48 @@ export class AcpAgent implements Agent {
 		const adapter = this.#adapter(id);
 		const record = this.#sessions.get(id);
 		if (!record) return;
+		const replayTools = new Map<string, { name: string; args: unknown }>();
+		try {
+			await this.#replayTranscriptPages(id, adapter, record, replayTools);
+		} finally {
+			// One boundary for every way the replay body can end: a normal return, an early
+			// exit, or a `transcript.list` page that throws. A start still open here was
+			// abandoned mid-replay, so it reaches a terminal status now instead of spinning
+			// at `pending` for the life of the session.
+			for (const [toolCallId, tool] of replayTools) {
+				try {
+					await this.#closeUnresolvedReplayToolCall(
+						id,
+						adapter,
+						record.cwd,
+						toolCallId,
+						tool,
+						TRANSCRIPT_REPLAY_INTERRUPTED,
+					);
+				} catch {
+					// The failure that aborted replay is the one worth propagating; a cleanup
+					// publish that fails as well must not replace it.
+				}
+			}
+			replayTools.clear();
+		}
+	}
+
+	/**
+	 * Walks the transcript pages for {@link AcpAgent.#replaySession}. `replayTools` stays
+	 * owned by the caller so every start this pass published is still closable once it
+	 * exits, however it exits.
+	 */
+	async #replayTranscriptPages(
+		id: string,
+		adapter: AcpSdkAdapter,
+		record: SessionRecord,
+		replayTools: Map<string, { name: string; args: unknown }>,
+	): Promise<void> {
 		let cursor: string | undefined;
 		let imageLimitationReported = false;
 		let unreplayableEntries = 0;
 		let unreplayableReason: TranscriptReplaySkipReason | undefined;
-		const replayTools = new Map<string, { name: string; args: unknown }>();
 		for (let pageCount = 0; pageCount < MAX_ACP_REPLAY_PAGES; pageCount++) {
 			const response = object(await adapter.query("transcript.list", {}, cursor));
 			const result = object(response?.result) ?? response;

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -460,6 +460,9 @@ const RECOVERABLE_TRANSCRIPT_FIELDS = ["role", "body", "content", "toolCallId", 
 /** Stands in for a tool result whose transcript entry replay could not restore. */
 const TRANSCRIPT_TOOL_RESULT_UNAVAILABLE = "The transcript entry holding this tool result could not be replayed.";
 
+/** Stands in for a tool call the transcript never recorded a result for. */
+const TRANSCRIPT_TOOL_CALL_UNRESOLVED = "The session transcript ends without a result for this tool call.";
+
 function decodeTranscriptContinuation(field: string, body: string): unknown {
 	if (field !== "content" && field !== "isError") return body;
 	try {
@@ -2482,13 +2485,14 @@ export class AcpAgent implements Agent {
 		cwd: string,
 		toolCallId: string,
 		tool: { name: string; args: unknown },
+		reason: string = TRANSCRIPT_TOOL_RESULT_UNAVAILABLE,
 	): Promise<void> {
 		for (const notification of mapAgentSessionEventToAcpSessionUpdates(
 			{
 				type: "tool_execution_end",
 				toolCallId,
 				toolName: tool.name,
-				result: { content: [{ type: "text", text: TRANSCRIPT_TOOL_RESULT_UNAVAILABLE }] },
+				result: { content: [{ type: "text", text: reason }] },
 				isError: true,
 			} as never,
 			id,
@@ -2608,12 +2612,24 @@ export class AcpAgent implements Agent {
 				}
 				if (message.role === "toolResult" && typeof message.toolCallId === "string") {
 					const replayTool = replayTools.get(message.toolCallId);
-					const toolName = typeof message.toolName === "string" ? message.toolName : replayTool?.name;
 					// Pairing outranks content: publishing a result whose `tool_call` start
 					// never reached the client renders an update for a call it never saw begin.
-					if (!toolName || !replayTool) {
+					if (!replayTool) {
 						unreplayableEntries++;
 						unreplayableReason ??= "transcript_tool_call_unavailable";
+						continue;
+					}
+					// The start already named the call, so a result row that lost its own name
+					// falls back to it rather than dropping a result the client can still place.
+					const toolName =
+						typeof message.toolName === "string" && message.toolName ? message.toolName : replayTool.name;
+					// A start with no usable name anywhere still has to reach a terminal status:
+					// skipping it here is what left the call spinning at `pending` forever.
+					if (!toolName) {
+						unreplayableEntries++;
+						unreplayableReason ??= "transcript_tool_call_unavailable";
+						replayTools.delete(message.toolCallId);
+						await this.#closeUnresolvedReplayToolCall(id, adapter, record.cwd, message.toolCallId, replayTool);
 						continue;
 					}
 					const resultContent = richContent
@@ -2657,6 +2673,21 @@ export class AcpAgent implements Agent {
 			}
 			cursor = typeof page?.continuationCursor === "string" ? page.continuationCursor : undefined;
 			if (cursor) continue;
+			// Every start still parked here outlived its result row, so replay ends it
+			// instead of handing the client a tool call nothing will ever complete.
+			for (const [toolCallId, tool] of replayTools) {
+				unreplayableEntries++;
+				unreplayableReason ??= "transcript_tool_call_unavailable";
+				await this.#closeUnresolvedReplayToolCall(
+					id,
+					adapter,
+					record.cwd,
+					toolCallId,
+					tool,
+					TRANSCRIPT_TOOL_CALL_UNRESOLVED,
+				);
+			}
+			replayTools.clear();
 			// An entry without its production body is skipped, never fatal: losing one
 			// transcript row must not revoke `session/load` for the whole session.
 			if (unreplayableReason)

--- a/packages/coding-agent/test/acp/acp-transcript-replay-degradation.test.ts
+++ b/packages/coding-agent/test/acp/acp-transcript-replay-degradation.test.ts
@@ -63,6 +63,29 @@ function textChunks(notifications: SessionNotification[]): Array<Record<string, 
 	return chunks;
 }
 
+/** Every tool-call lifecycle update the client saw, in order, as `id:status`. */
+function toolCallStates(notifications: SessionNotification[]): string[] {
+	const states: string[] = [];
+	for (const notification of notifications) {
+		const update = notification.update as { sessionUpdate: string; toolCallId?: string; status?: string };
+		if (update.sessionUpdate !== "tool_call" && update.sessionUpdate !== "tool_call_update") continue;
+		states.push(`${update.sessionUpdate}:${update.toolCallId}:${update.status}`);
+	}
+	return states;
+}
+
+/** Tool calls the client is still showing as unfinished after replay returned. */
+function pendingToolCalls(notifications: SessionNotification[]): string[] {
+	const status = new Map<string, string>();
+	for (const notification of notifications) {
+		const update = notification.update as { sessionUpdate: string; toolCallId?: string; status?: string };
+		if (update.sessionUpdate !== "tool_call" && update.sessionUpdate !== "tool_call_update") continue;
+		if (typeof update.toolCallId !== "string") continue;
+		status.set(update.toolCallId, String(update.status));
+	}
+	return [...status].filter(([, value]) => value !== "completed" && value !== "failed").map(([id]) => id);
+}
+
 describe("ACP transcript replay degradation", () => {
 	let tempDir: TempDir;
 	let connectionAbort: AbortController;
@@ -267,6 +290,94 @@ describe("ACP transcript replay degradation", () => {
 			gjcTranscriptImageReplay: { available: false, reason: "historical_transcript_images_unavailable" },
 		});
 		expect(skipBoundaries(replayed)).toEqual([]);
+	});
+
+	// A `tool_call` start is published before its result is read, so every path that
+	// passes over the matching `toolResult` owes the client an end event: a skipped
+	// row otherwise leaves the call at `pending` for the life of the session (#4063).
+	it("names a replayed tool result from its start when the result row lost the name", async () => {
+		const replayed = await loadReplayedSession([
+			{
+				id: "assistant-1",
+				role: "assistant",
+				textSummary: "Reading",
+				body: "Reading",
+				content: [{ type: "toolCall", id: "tool-1", name: "read", arguments: { path: "missing.ts" } }],
+			},
+			{
+				id: "result-1",
+				role: "toolResult",
+				textSummary: "File not found",
+				body: "File not found",
+				content: [{ type: "text", text: "File not found" }],
+				toolCallId: "tool-1",
+				toolName: "",
+			},
+		]);
+
+		expect(toolCallStates(replayed)).toEqual(["tool_call:tool-1:pending", "tool_call_update:tool-1:completed"]);
+		expect(pendingToolCalls(replayed)).toEqual([]);
+		expect(skipBoundaries(replayed)).toEqual([]);
+	});
+
+	it("fails a replayed tool call that no transcript field can name", async () => {
+		const replayed = await loadReplayedSession([
+			{
+				id: "assistant-1",
+				role: "assistant",
+				textSummary: "Reading",
+				body: "Reading",
+				content: [{ type: "toolCall", id: "tool-1", name: "", arguments: {} }],
+			},
+			{
+				id: "result-1",
+				role: "toolResult",
+				textSummary: "File not found",
+				body: "File not found",
+				content: [{ type: "text", text: "File not found" }],
+				toolCallId: "tool-1",
+			},
+		]);
+
+		expect(toolCallStates(replayed)).toEqual(["tool_call:tool-1:pending", "tool_call_update:tool-1:failed"]);
+		expect(pendingToolCalls(replayed)).toEqual([]);
+		expect(JSON.stringify(replayed)).toContain("could not be replayed");
+		expect(skipBoundaries(replayed)).toEqual([{ count: 1, reason: "transcript_tool_call_unavailable" }]);
+	});
+
+	it("fails a replayed tool call the transcript never resolved", async () => {
+		const replayed = await loadReplayedSession([
+			{
+				id: "assistant-1",
+				role: "assistant",
+				textSummary: "Reading",
+				body: "Reading",
+				content: [{ type: "toolCall", id: "tool-1", name: "read", arguments: { path: "missing.ts" } }],
+			},
+		]);
+
+		expect(toolCallStates(replayed)).toEqual(["tool_call:tool-1:pending", "tool_call_update:tool-1:failed"]);
+		expect(pendingToolCalls(replayed)).toEqual([]);
+		expect(JSON.stringify(replayed)).toContain("without a result for this tool call");
+		expect(skipBoundaries(replayed)).toEqual([{ count: 1, reason: "transcript_tool_call_unavailable" }]);
+	});
+
+	it("drops a tool result whose call was never published without stranding one", async () => {
+		const replayed = await loadReplayedSession([
+			{ id: "user-1", role: "user", textSummary: "Earlier request", body: "Earlier request" },
+			{
+				id: "result-1",
+				role: "toolResult",
+				textSummary: "File not found",
+				body: "File not found",
+				content: [{ type: "text", text: "File not found" }],
+				toolCallId: "ghost-tool",
+			},
+		]);
+
+		expect(toolCallStates(replayed)).toEqual([]);
+		expect(pendingToolCalls(replayed)).toEqual([]);
+		expect(skipBoundaries(replayed)).toEqual([{ count: 1, reason: "transcript_tool_call_unavailable" }]);
 	});
 });
 

--- a/packages/coding-agent/test/acp/acp-transcript-replay-degradation.test.ts
+++ b/packages/coding-agent/test/acp/acp-transcript-replay-degradation.test.ts
@@ -587,12 +587,10 @@ describe("ACP transcript replay degradation", () => {
 		expect(skipBoundaries(replayed)).toEqual([{ count: 3, reason: "transcript_tool_call_unavailable" }]);
 	});
 
-	// `session/close` lands mid-replay: the session record is removed while a `tool_call`
-	// start is already on the wire. The client asked for that session to end, so its view
-	// of the call ends with it — there is no observer left to owe a terminal to, and the
-	// transcript row that would name one is replayed from scratch by the next
-	// `session/load`. Replay therefore stops at the session, publishing nothing more (#4063).
-	it("stops replaying into a session the client closed from a tool-call start", async () => {
+	// `session/close` lands after the start but before an unreplayable result can close it.
+	// The direct cleanup path must still honor the session boundary even though it bypasses
+	// normal publication failure handling so one refused close cannot silence later calls.
+	it("publishes no terminal for an unreplayable result after the session closes", async () => {
 		const replayed = await loadReplayedSession(
 			[
 				{
@@ -605,9 +603,7 @@ describe("ACP transcript replay degradation", () => {
 				{
 					id: "result-1",
 					role: "toolResult",
-					textSummary: "File not found",
-					body: "File not found",
-					content: [{ type: "text", text: "File not found" }],
+					textSummary: "Body lost",
 					toolCallId: "tool-race",
 					toolName: "read",
 				},
@@ -615,29 +611,24 @@ describe("ACP transcript replay degradation", () => {
 			true,
 			undefined,
 			async (notification, agent) => {
-				if (terminalToolCallId(notification) !== undefined) return;
 				const update = notification.update as { sessionUpdate: string; toolCallId?: string };
 				if (update.sessionUpdate !== "tool_call" || update.toolCallId !== "tool-race") return;
 				await agent.closeSession({ sessionId: notification.sessionId });
 			},
 		);
 
-		// The start reached the client before the close; nothing after it was addressed to a
-		// session the client had already closed.
 		expect(toolCallStates(replayed)).toEqual(["tool_call:tool-race:pending"]);
 		expect(attempted.map(terminalToolCallId).filter(id => id !== undefined)).toEqual([]);
 		expect(skipBoundaries(replayed)).toEqual([]);
-		// `session/load` fails on the session itself, not on tool calls it could not close.
 		const reported = String((loadRejection as Error).message);
 		expect(reported).toContain("Unknown session, not found");
 		expect(reported).not.toContain("tool-race");
 	});
 
-	// Same race, but the transcript never resolves the call, so the replay boundary is the
-	// one holding it open. The boundary publishes straight to the connection — by design,
-	// so a failed session cannot silence it — which is exactly how a terminal reached a
-	// session id the client had closed. Session gone means boundary gone too (#4063).
-	it("closes no replayed tool call once the session it was replaying into is gone", async () => {
+	// `session/close` can also land between entries in the final cleanup pass. The first
+	// terminal is already delivered, but the pass must re-check session ownership before
+	// publishing the next while still continuing after ordinary publication failures.
+	it("stops final cleanup when the session closes between tool calls", async () => {
 		const replayed = await loadReplayedSession(
 			[
 				{
@@ -646,27 +637,29 @@ describe("ACP transcript replay degradation", () => {
 					textSummary: "Reading",
 					body: "Reading",
 					content: [
-						{ type: "toolCall", id: "tool-race", name: "read", arguments: { path: "missing.ts" } },
-						{ type: "toolCall", id: "tool-after", name: "read", arguments: { path: "other.ts" } },
+						{ type: "toolCall", id: "tool-before-close", name: "read", arguments: { path: "missing.ts" } },
+						{ type: "toolCall", id: "tool-after-close", name: "read", arguments: { path: "other.ts" } },
 					],
 				},
 			],
 			true,
 			undefined,
 			async (notification, agent) => {
-				const update = notification.update as { sessionUpdate: string; toolCallId?: string };
-				if (update.sessionUpdate !== "tool_call" || update.toolCallId !== "tool-race") return;
+				if (terminalToolCallId(notification) !== "tool-before-close") return;
 				await agent.closeSession({ sessionId: notification.sessionId });
 			},
 		);
 
-		// No terminal was even attempted: the boundary bypasses the session check on purpose,
-		// so the rule has to be read before it runs, not inside it.
-		expect(attempted.map(terminalToolCallId).filter(id => id !== undefined)).toEqual([]);
-		expect(toolCallStates(replayed)).toEqual(["tool_call:tool-race:pending"]);
-		expect(pendingToolCalls(replayed)).toEqual(["tool-race"]);
+		expect(attempted.map(terminalToolCallId).filter(id => id !== undefined)).toEqual(["tool-before-close"]);
+		expect(toolCallStates(replayed)).toEqual([
+			"tool_call:tool-before-close:pending",
+			"tool_call:tool-after-close:pending",
+			"tool_call_update:tool-before-close:failed",
+		]);
+		expect(pendingToolCalls(replayed)).toEqual(["tool-after-close"]);
 		const reported = String((loadRejection as Error).message);
 		expect(reported).toContain("Unknown session, not found");
+		expect(reported).not.toContain("tool-after-close");
 	});
 });
 

--- a/packages/coding-agent/test/acp/acp-transcript-replay-degradation.test.ts
+++ b/packages/coding-agent/test/acp/acp-transcript-replay-degradation.test.ts
@@ -86,6 +86,14 @@ function pendingToolCalls(notifications: SessionNotification[]): string[] {
 	return [...status].filter(([, value]) => value !== "completed" && value !== "failed").map(([id]) => id);
 }
 
+/** The tool call a terminal `tool_call_update` closes, when that is what the notification is. */
+function terminalToolCallId(notification: SessionNotification): string | undefined {
+	const update = notification.update as { sessionUpdate: string; toolCallId?: string; status?: string };
+	if (update.sessionUpdate !== "tool_call_update") return undefined;
+	if (update.status !== "completed" && update.status !== "failed") return undefined;
+	return typeof update.toolCallId === "string" ? update.toolCallId : undefined;
+}
+
 describe("ACP transcript replay degradation", () => {
 	let tempDir: TempDir;
 	let connectionAbort: AbortController;
@@ -93,6 +101,9 @@ describe("ACP transcript replay degradation", () => {
 	let transcriptItems: unknown[] = [];
 	let transcriptSecondPageFailure: string | undefined;
 	let updates: SessionNotification[] = [];
+	/** Every update the agent handed the connection, including the ones the client rejected. */
+	let attempted: SessionNotification[] = [];
+	let loadRejection: unknown;
 	let agentDir = "";
 	let cwd = "";
 
@@ -102,6 +113,8 @@ describe("ACP transcript replay degradation", () => {
 		transcriptItems = [];
 		transcriptSecondPageFailure = undefined;
 		updates = [];
+		attempted = [];
+		loadRejection = undefined;
 		agentDir = path.join(tempDir.path(), "agent");
 		cwd = path.join(tempDir.path(), "workspace");
 
@@ -225,10 +238,17 @@ describe("ACP transcript replay degradation", () => {
 	});
 
 	/** Creates a session, drains its bootstrap updates, then replays it through `session/load`. */
-	async function loadReplayedSession(items: unknown[], expectLoadRejection = false): Promise<SessionNotification[]> {
+	async function loadReplayedSession(
+		items: unknown[],
+		expectLoadRejection = false,
+		rejectSessionUpdate?: (notification: SessionNotification) => boolean,
+	): Promise<SessionNotification[]> {
 		transcriptItems = items;
 		const connection = {
 			sessionUpdate: async (notification: SessionNotification) => {
+				attempted.push(notification);
+				// A client that refuses one frame never saw it, so it must not count as delivered.
+				if (rejectSessionUpdate?.(notification)) throw new Error("client rejected session update");
 				updates.push(notification);
 			},
 			signal: connectionAbort.signal,
@@ -243,8 +263,15 @@ describe("ACP transcript replay degradation", () => {
 			"new session bootstrap",
 		);
 		updates.length = 0;
+		attempted.length = 0;
 		const load = bounded(acp.loadSession({ sessionId: created.sessionId, cwd, mcpServers: [] }), "load session");
-		if (expectLoadRejection) await expect(load).rejects.toThrow();
+		if (expectLoadRejection)
+			loadRejection = await load.then(
+				() => {
+					throw new Error("Expected session/load to reject");
+				},
+				(error: unknown) => error,
+			);
 		else await load;
 		return updates;
 	}
@@ -436,6 +463,45 @@ describe("ACP transcript replay degradation", () => {
 		expect(JSON.stringify(replayed)).toContain("Transcript replay stopped before this tool call reached a result.");
 		expect(JSON.stringify(replayed)).not.toContain("without a result for this tool call");
 		expect(skipBoundaries(replayed)).toEqual([]);
+	});
+
+	// The cleanup itself can fail. Publishing tool-1's terminal update used to tear the
+	// session record down, after which every later cleanup publication was a silent no-op:
+	// tool-2 stayed pending and nothing said so (#4063).
+	it("closes the calls behind a failing cleanup publication and reports the ones it could not close", async () => {
+		transcriptSecondPageFailure = "unavailable";
+		const replayed = await loadReplayedSession(
+			[
+				{
+					id: "assistant-1",
+					role: "assistant",
+					textSummary: "Reading",
+					body: "Reading",
+					content: [
+						{ type: "toolCall", id: "tool-1", name: "read", arguments: { path: "missing.ts" } },
+						{ type: "toolCall", id: "tool-2", name: "read", arguments: { path: "other.ts" } },
+					],
+				},
+			],
+			true,
+			notification => terminalToolCallId(notification) === "tool-1",
+		);
+
+		// Every open call is attempted, not only the ones ahead of the first failure.
+		expect(attempted.map(terminalToolCallId).filter(id => id !== undefined)).toEqual(["tool-1", "tool-2"]);
+		// tool-2 queued behind the failure still reaches a terminal status on the client.
+		expect(toolCallStates(replayed)).toEqual([
+			"tool_call:tool-1:pending",
+			"tool_call:tool-2:pending",
+			"tool_call_update:tool-2:failed",
+		]);
+		// tool-1's terminal frame was refused by the client, so it cannot be closed — and every
+		// call left pending is named by the failure `session/load` reports.
+		expect(pendingToolCalls(replayed)).toEqual(["tool-1"]);
+		const reported = String((loadRejection as Error).message);
+		expect(reported).toContain("ACP transcript replay could not close published tool calls: tool-1");
+		expect(reported).not.toContain("tool-2");
+		for (const toolCallId of pendingToolCalls(replayed)) expect(reported).toContain(toolCallId);
 	});
 });
 

--- a/packages/coding-agent/test/acp/acp-transcript-replay-degradation.test.ts
+++ b/packages/coding-agent/test/acp/acp-transcript-replay-degradation.test.ts
@@ -91,6 +91,7 @@ describe("ACP transcript replay degradation", () => {
 	let connectionAbort: AbortController;
 	let server: Bun.Server<undefined> | undefined;
 	let transcriptItems: unknown[] = [];
+	let transcriptSecondPageFailure: string | undefined;
 	let updates: SessionNotification[] = [];
 	let agentDir = "";
 	let cwd = "";
@@ -99,6 +100,7 @@ describe("ACP transcript replay degradation", () => {
 		tempDir = TempDir.createSync("@acp-transcript-replay-");
 		connectionAbort = new AbortController();
 		transcriptItems = [];
+		transcriptSecondPageFailure = undefined;
 		updates = [];
 		agentDir = path.join(tempDir.path(), "agent");
 		cwd = path.join(tempDir.path(), "workspace");
@@ -142,6 +144,36 @@ describe("ACP transcript replay degradation", () => {
 									id: frame.id,
 									ok: true,
 									result: { promptTerminalOutcomeVersion: 1 },
+								}),
+							);
+							return;
+						}
+						// A paged transcript whose second page fails: the first page replays, the
+						// cursor promises more, and the follow-up query rejects.
+						if (frame.query === "transcript.list" && transcriptSecondPageFailure !== undefined) {
+							if (frame.cursor === undefined) {
+								socket.send(
+									JSON.stringify({
+										type: "query_response",
+										id: frame.id,
+										ok: true,
+										result: {
+											page: {
+												items: transcriptItems,
+												complete: false,
+												continuationCursor: "transcript-page-2",
+											},
+										},
+									}),
+								);
+								return;
+							}
+							socket.send(
+								JSON.stringify({
+									type: "query_response",
+									id: frame.id,
+									ok: false,
+									error: { code: transcriptSecondPageFailure, message: transcriptSecondPageFailure },
 								}),
 							);
 							return;
@@ -193,7 +225,7 @@ describe("ACP transcript replay degradation", () => {
 	});
 
 	/** Creates a session, drains its bootstrap updates, then replays it through `session/load`. */
-	async function loadReplayedSession(items: unknown[]): Promise<SessionNotification[]> {
+	async function loadReplayedSession(items: unknown[], expectLoadRejection = false): Promise<SessionNotification[]> {
 		transcriptItems = items;
 		const connection = {
 			sessionUpdate: async (notification: SessionNotification) => {
@@ -211,7 +243,9 @@ describe("ACP transcript replay degradation", () => {
 			"new session bootstrap",
 		);
 		updates.length = 0;
-		await bounded(acp.loadSession({ sessionId: created.sessionId, cwd, mcpServers: [] }), "load session");
+		const load = bounded(acp.loadSession({ sessionId: created.sessionId, cwd, mcpServers: [] }), "load session");
+		if (expectLoadRejection) await expect(load).rejects.toThrow();
+		else await load;
 		return updates;
 	}
 
@@ -378,6 +412,30 @@ describe("ACP transcript replay degradation", () => {
 		expect(toolCallStates(replayed)).toEqual([]);
 		expect(pendingToolCalls(replayed)).toEqual([]);
 		expect(skipBoundaries(replayed)).toEqual([{ count: 1, reason: "transcript_tool_call_unavailable" }]);
+	});
+
+	// A start the transcript never resolved is closed as unresolved; a start the replay
+	// itself abandoned mid-page is a different failure and must read differently (#4063).
+	it("closes published tool calls when a later transcript page throws", async () => {
+		transcriptSecondPageFailure = "unavailable";
+		const replayed = await loadReplayedSession(
+			[
+				{
+					id: "assistant-1",
+					role: "assistant",
+					textSummary: "Reading",
+					body: "Reading",
+					content: [{ type: "toolCall", id: "tool-1", name: "read", arguments: { path: "missing.ts" } }],
+				},
+			],
+			true,
+		);
+
+		expect(toolCallStates(replayed)).toEqual(["tool_call:tool-1:pending", "tool_call_update:tool-1:failed"]);
+		expect(pendingToolCalls(replayed)).toEqual([]);
+		expect(JSON.stringify(replayed)).toContain("Transcript replay stopped before this tool call reached a result.");
+		expect(JSON.stringify(replayed)).not.toContain("without a result for this tool call");
+		expect(skipBoundaries(replayed)).toEqual([]);
 	});
 });
 

--- a/packages/coding-agent/test/acp/acp-transcript-replay-degradation.test.ts
+++ b/packages/coding-agent/test/acp/acp-transcript-replay-degradation.test.ts
@@ -503,6 +503,85 @@ describe("ACP transcript replay degradation", () => {
 		expect(reported).not.toContain("tool-2");
 		for (const toolCallId of pendingToolCalls(replayed)) expect(reported).toContain(toolCallId);
 	});
+
+	// A refused close must not take the session record down before the calls behind it have
+	// been attempted: the cleanup used to publish through `#publishSessionUpdate`, which fails
+	// the session on the first rejected frame and left every later close a silent no-op (#4063).
+	it("closes the calls behind a refused mid-replay close and names the one it could not close", async () => {
+		const replayed = await loadReplayedSession(
+			[
+				{
+					id: "assistant-1",
+					role: "assistant",
+					textSummary: "Reading",
+					body: "Reading",
+					content: [
+						{ type: "toolCall", id: "tool-1", name: "read", arguments: {} },
+						{ type: "toolCall", id: "tool-2", name: "read", arguments: {} },
+					],
+				},
+				{ id: "toolresult-1", role: "toolResult", toolCallId: "tool-1", textSummary: "Body lost" },
+			],
+			true,
+			notification => terminalToolCallId(notification) === "tool-1",
+		);
+
+		// Every published start is attempted, not only the ones ahead of the refused close.
+		expect([...new Set(attempted.map(terminalToolCallId).filter(id => id !== undefined))]).toEqual([
+			"tool-1",
+			"tool-2",
+		]);
+		// tool-2 queued behind the refusal still reaches a terminal status on the client.
+		expect(toolCallStates(replayed)).toEqual([
+			"tool_call:tool-1:pending",
+			"tool_call:tool-2:pending",
+			"tool_call_update:tool-2:failed",
+		]);
+		// tool-1 stayed in `replayTools` because its close was never accepted, so the failure
+		// `session/load` reports names it instead of dropping it on the attempt.
+		expect(pendingToolCalls(replayed)).toEqual(["tool-1"]);
+		const reported = String((loadRejection as Error).message);
+		expect(reported).toContain("ACP transcript replay could not close published tool calls: tool-1");
+		for (const toolCallId of pendingToolCalls(replayed)) expect(reported).toContain(toolCallId);
+		expect(skipBoundaries(replayed)).toEqual([{ count: 3, reason: "transcript_body_unavailable" }]);
+	});
+
+	// Same invariant on the other mid-replay close: a result row that can be read but names
+	// nothing, whose start is equally nameless (#4063).
+	it("closes the calls behind a refused close of an unnameable tool call and names it", async () => {
+		const replayed = await loadReplayedSession(
+			[
+				{
+					id: "assistant-1",
+					role: "assistant",
+					textSummary: "Reading",
+					body: "Reading",
+					content: [
+						{ type: "toolCall", id: "tool-1", name: "", arguments: {} },
+						{ type: "toolCall", id: "tool-2", name: "read", arguments: {} },
+					],
+				},
+				{ id: "toolresult-1", role: "toolResult", toolCallId: "tool-1", textSummary: "done", body: "done" },
+			],
+			true,
+			notification => terminalToolCallId(notification) === "tool-1",
+		);
+
+		expect([...new Set(attempted.map(terminalToolCallId).filter(id => id !== undefined))]).toEqual([
+			"tool-1",
+			"tool-2",
+		]);
+		expect(toolCallStates(replayed)).toEqual([
+			"tool_call:tool-1:pending",
+			"tool_call:tool-2:pending",
+			"tool_call_update:tool-2:failed",
+		]);
+		expect(pendingToolCalls(replayed)).toEqual(["tool-1"]);
+		const reported = String((loadRejection as Error).message);
+		expect(reported).toContain("ACP transcript replay could not close published tool calls: tool-1");
+		for (const toolCallId of pendingToolCalls(replayed)) expect(reported).toContain(toolCallId);
+		expect(skipBoundaries(replayed)).toEqual([{ count: 3, reason: "transcript_tool_call_unavailable" }]);
+	});
 });
 
 describe("transcriptReplayContent", () => {

--- a/packages/coding-agent/test/acp/acp-transcript-replay-degradation.test.ts
+++ b/packages/coding-agent/test/acp/acp-transcript-replay-degradation.test.ts
@@ -242,19 +242,23 @@ describe("ACP transcript replay degradation", () => {
 		items: unknown[],
 		expectLoadRejection = false,
 		rejectSessionUpdate?: (notification: SessionNotification) => boolean,
+		onSessionUpdate?: (notification: SessionNotification, agent: AcpAgent) => Promise<void>,
 	): Promise<SessionNotification[]> {
 		transcriptItems = items;
+		let agent: AcpAgent | undefined;
 		const connection = {
 			sessionUpdate: async (notification: SessionNotification) => {
 				attempted.push(notification);
 				// A client that refuses one frame never saw it, so it must not count as delivered.
 				if (rejectSessionUpdate?.(notification)) throw new Error("client rejected session update");
 				updates.push(notification);
+				if (agent) await onSessionUpdate?.(notification, agent);
 			},
 			signal: connectionAbort.signal,
 			closed: Promise.withResolvers<void>().promise,
 		} as unknown as AgentSideConnection;
 		const acp = new AcpAgent(connection, { agentDir });
+		agent = acp;
 		const created = await bounded(acp.newSession({ cwd, mcpServers: [] }), "new session");
 		await waitFor(
 			() =>
@@ -581,6 +585,88 @@ describe("ACP transcript replay degradation", () => {
 		expect(reported).toContain("ACP transcript replay could not close published tool calls: tool-1");
 		for (const toolCallId of pendingToolCalls(replayed)) expect(reported).toContain(toolCallId);
 		expect(skipBoundaries(replayed)).toEqual([{ count: 3, reason: "transcript_tool_call_unavailable" }]);
+	});
+
+	// `session/close` lands mid-replay: the session record is removed while a `tool_call`
+	// start is already on the wire. The client asked for that session to end, so its view
+	// of the call ends with it — there is no observer left to owe a terminal to, and the
+	// transcript row that would name one is replayed from scratch by the next
+	// `session/load`. Replay therefore stops at the session, publishing nothing more (#4063).
+	it("stops replaying into a session the client closed from a tool-call start", async () => {
+		const replayed = await loadReplayedSession(
+			[
+				{
+					id: "assistant-1",
+					role: "assistant",
+					textSummary: "Reading",
+					body: "Reading",
+					content: [{ type: "toolCall", id: "tool-race", name: "read", arguments: { path: "missing.ts" } }],
+				},
+				{
+					id: "result-1",
+					role: "toolResult",
+					textSummary: "File not found",
+					body: "File not found",
+					content: [{ type: "text", text: "File not found" }],
+					toolCallId: "tool-race",
+					toolName: "read",
+				},
+			],
+			true,
+			undefined,
+			async (notification, agent) => {
+				if (terminalToolCallId(notification) !== undefined) return;
+				const update = notification.update as { sessionUpdate: string; toolCallId?: string };
+				if (update.sessionUpdate !== "tool_call" || update.toolCallId !== "tool-race") return;
+				await agent.closeSession({ sessionId: notification.sessionId });
+			},
+		);
+
+		// The start reached the client before the close; nothing after it was addressed to a
+		// session the client had already closed.
+		expect(toolCallStates(replayed)).toEqual(["tool_call:tool-race:pending"]);
+		expect(attempted.map(terminalToolCallId).filter(id => id !== undefined)).toEqual([]);
+		expect(skipBoundaries(replayed)).toEqual([]);
+		// `session/load` fails on the session itself, not on tool calls it could not close.
+		const reported = String((loadRejection as Error).message);
+		expect(reported).toContain("Unknown session, not found");
+		expect(reported).not.toContain("tool-race");
+	});
+
+	// Same race, but the transcript never resolves the call, so the replay boundary is the
+	// one holding it open. The boundary publishes straight to the connection — by design,
+	// so a failed session cannot silence it — which is exactly how a terminal reached a
+	// session id the client had closed. Session gone means boundary gone too (#4063).
+	it("closes no replayed tool call once the session it was replaying into is gone", async () => {
+		const replayed = await loadReplayedSession(
+			[
+				{
+					id: "assistant-1",
+					role: "assistant",
+					textSummary: "Reading",
+					body: "Reading",
+					content: [
+						{ type: "toolCall", id: "tool-race", name: "read", arguments: { path: "missing.ts" } },
+						{ type: "toolCall", id: "tool-after", name: "read", arguments: { path: "other.ts" } },
+					],
+				},
+			],
+			true,
+			undefined,
+			async (notification, agent) => {
+				const update = notification.update as { sessionUpdate: string; toolCallId?: string };
+				if (update.sessionUpdate !== "tool_call" || update.toolCallId !== "tool-race") return;
+				await agent.closeSession({ sessionId: notification.sessionId });
+			},
+		);
+
+		// No terminal was even attempted: the boundary bypasses the session check on purpose,
+		// so the rule has to be read before it runs, not inside it.
+		expect(attempted.map(terminalToolCallId).filter(id => id !== undefined)).toEqual([]);
+		expect(toolCallStates(replayed)).toEqual(["tool_call:tool-race:pending"]);
+		expect(pendingToolCalls(replayed)).toEqual(["tool-race"]);
+		const reported = String((loadRejection as Error).message);
+		expect(reported).toContain("Unknown session, not found");
 	});
 });
 


### PR DESCRIPTION
Follow-up to #4040, from the post-merge audit in #4063.

## The defect

`session/load` replays a transcript and publishes each tool call's start before its end. When a replayed `toolResult` resolved no tool name, the loop `continue`d — skipping the `tool_execution_end` notification and the `replayTools` bookkeeping. The call stayed `pending` in the client for the life of the session, which is the opposite of the all-or-nothing recovery #4040 claimed.

Closing that one exit was not enough, and the rounds it took are the interesting part: a later `transcript.list` page that threw exited before any cleanup; then the cleanup's own publication failed and took the session record with it, so every later close became a silent no-op; then `replayTools.delete` ran before the close was attempted, so a call whose close was refused never appeared in the report meant to name it.

The invariant is now structural rather than guarded per exit: **once a tool call start has been published, no exit from the replay leaves it without a terminal status, while a client exists to observe one.** Entries leave the map only after their close succeeds, and the cleanup does not publish through the path that fails the session.

## Where the obligation ends

A concurrent `session/close`, a failed session, or a connection teardown removes the session mid-replay. That removal takes the client's view with it, and a frame carrying a closed session id is one the client asked to stop receiving — so no terminal is emitted there. That was verified rather than assumed: an earlier attempt asserted the boundary in a comment while the code kept writing past it, and a review caught frames still going out (`expected no post-close terminal, received tool-race`).

## Verification

`bun test packages/coding-agent/test/acp` — 202 pass, 0 fail. `bun --cwd=packages/coding-agent run check` — exit 0.

Reverting `acp-agent.ts` to `dev` fails 8 tests behaviorally: a page that throws mid-replay, a cleanup publication failing partway, an unnameable call, a call the transcript never resolved, and a close landing during an unreplayable result and between cleanup entries.

## Known and not fixed

A close that lands between the session read and the first publish is untested.
