### PR TITLE
fix(gc): never begin a remove the walk could not verify

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
@@ -13,10 +13,11 @@
  * - Dry-run by default: nothing is deleted unless `--prune`/`--force`.
  */
 
-import type { Dirent, Stats } from "node:fs";
+import type { BigIntStats, Dirent, Stats } from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { exactRemoveDirectoryTree, exactUnlink, snapshotDirectoryTree } from "@gajae-code/natives";
 import { getAgentDir, getBlobsDir, getSessionsDir, isEnoent, VERSION } from "@gajae-code/utils";
 import { getDefault } from "../config/settings-schema";
 import { listHarnessRootRegistriesForGc } from "../harness-control-plane/storage";
@@ -765,6 +766,11 @@ function summarizeGcDiskSurface(report: GcDiskSurfaceReport): void {
  * An entry that vanished mid-walk (`ENOENT`) is the opposite fact: it is gone,
  * not withheld. A vanished entry cannot block a recursive remove, so it only
  * makes `bytes` a floor and never withholds the tree.
+ *
+ * The walk is bounded in sizing work, not in reach: past
+ * {@link GC_DISK_MAX_WALK_ENTRIES} it stops stat'ing files but keeps opening
+ * directories, so a huge but perfectly readable tree stays reclaimable instead
+ * of being reported as unreadable.
  */
 async function measureGcDiskTree(root: string): Promise<{ bytes: number; partial: boolean; unreadable: boolean }> {
 	let bytes = 0;
@@ -785,7 +791,6 @@ async function measureGcDiskTree(root: string): Promise<{ bytes: number; partial
 			continue;
 		}
 		for (const entry of entries) {
-			if (visited >= GC_DISK_MAX_WALK_ENTRIES) return { bytes, partial: true, unreadable };
 			visited++;
 			const child = path.join(dir, entry.name);
 			if (entry.isSymbolicLink()) {
@@ -797,6 +802,13 @@ async function measureGcDiskTree(root: string): Promise<{ bytes: number; partial
 				continue;
 			}
 			if (!entry.isFile()) continue;
+			// The entry cap bounds the per-file `lstat` work, not the enumeration:
+			// past it `bytes` is a floor, but every directory is still opened so
+			// `unreadable` stays a complete answer for the whole tree.
+			if (visited > GC_DISK_MAX_WALK_ENTRIES) {
+				partial = true;
+				continue;
+			}
 			try {
 				bytes += (await fsp.lstat(child)).size;
 			} catch (error) {
@@ -1424,11 +1436,10 @@ async function runGcDiskNatives(input: {
  * Remove one directory/file entry, fail-closed on identity drift. Anything that
  * changed inode or mtime between classification and removal is left alone.
  *
- * Readability is re-proven here instead of being trusted from measurement time:
- * a nested directory can become unreadable after the size walk without touching
- * the root's inode or mtime, and a recursive remove that cannot finish past it
- * would destroy the readable half. The fact has to hold at the moment it
- * matters, so a removal that cannot complete never starts.
+ * Directories use the native exact-tree remover. Its fresh descriptor-relative
+ * snapshot is revalidated by the removal itself before an atomic detach, closing
+ * the gap where a plain recursive `rm` could destroy readable siblings before
+ * discovering that another subtree had become unreadable.
  */
 async function removeGcDiskEntry(
 	target: string,
@@ -1446,16 +1457,93 @@ async function removeGcDiskEntry(
 		return { removed: false, reason: "entry_identity_changed" };
 	}
 	if (current.mtimeMs !== expected.mtimeMs) return { removed: false, reason: "entry_changed" };
-	if (current.isDirectory() && (await measureGcDiskTree(target)).unreadable) {
-		return { removed: false, reason: "withheld_evidence_incomplete: tree_unreadable", withheld: true };
+
+	if (!current.isDirectory()) {
+		try {
+			await fsp.rm(target, { force: false });
+			return { removed: true };
+		} catch (error) {
+			if (isEnoent(error)) return { removed: false, reason: "entry_disappeared" };
+			return { removed: false, reason: `entry_remove_failed: ${gcDiskErrorText(error)}`, failed: true };
+		}
 	}
+
+	const snapshot = snapshotDirectoryTree(target);
+	if (!snapshot.ok || !snapshot.snapshot) {
+		if (snapshot.code === "not_found") return { removed: false, reason: "entry_disappeared" };
+		if (snapshot.code !== "reparse_point") {
+			return { removed: false, reason: "withheld_evidence_incomplete: tree_unreadable", withheld: true };
+		}
+
+		let identity: BigIntStats;
+		let linkParent: BigIntStats;
+		try {
+			identity = await fsp.lstat(target, { bigint: true });
+			linkParent = await fsp.lstat(path.dirname(target), { bigint: true });
+		} catch (error) {
+			if (isEnoent(error)) return { removed: false, reason: "entry_disappeared" };
+			return { removed: false, reason: `entry_unverifiable: ${gcDiskErrorText(error)}`, failed: true };
+		}
+		const detached = exactUnlink(target, {
+			dev: identity.dev,
+			ino: identity.ino,
+			nlink: identity.nlink,
+			size: identity.size,
+			mtimeNs: identity.mtimeNs,
+			parentDev: linkParent.dev,
+			parentIno: linkParent.ino,
+			directory: true,
+			detachOnly: true,
+			quarantineName: `${path.basename(target)}.removing`,
+		});
+		if ((!detached.ok && detached.code !== "cleanup_pending") || !detached.detachedPath) {
+			return { removed: false, reason: `entry_remove_failed: ${detached.code ?? "unknown"}`, failed: true };
+		}
+		try {
+			await fsp.rm(detached.detachedPath, { recursive: true, force: false });
+			if (detached.retainedPlaceholderPath) await fsp.rmdir(detached.retainedPlaceholderPath);
+			return { removed: true };
+		} catch (error) {
+			if (isEnoent(error)) return { removed: true };
+			return { removed: false, reason: `entry_remove_failed: ${gcDiskErrorText(error)}`, failed: true };
+		}
+	}
+
+	let parent: BigIntStats;
 	try {
-		await fsp.rm(target, { recursive: true, force: false });
-		return { removed: true };
+		parent = await fsp.lstat(path.dirname(target), { bigint: true });
 	} catch (error) {
 		if (isEnoent(error)) return { removed: false, reason: "entry_disappeared" };
-		return { removed: false, reason: `entry_remove_failed: ${gcDiskErrorText(error)}`, failed: true };
+		return { removed: false, reason: `entry_unverifiable: ${gcDiskErrorText(error)}`, failed: true };
 	}
+
+	const removal = exactRemoveDirectoryTree(target, snapshot.snapshot, {
+		dev: parent.dev,
+		ino: parent.ino,
+	});
+	if (removal.ok) return { removed: true };
+	if (removal.code === "cleanup_pending" && removal.payloadDurable === true && removal.detachedPath) {
+		try {
+			await fsp.rm(removal.detachedPath, { recursive: true, force: false });
+			return { removed: true };
+		} catch (error) {
+			if (isEnoent(error)) return { removed: true };
+			return { removed: false, reason: `entry_remove_failed: ${gcDiskErrorText(error)}`, failed: true };
+		}
+	}
+	if (removal.code === "not_found") return { removed: false, reason: "entry_disappeared" };
+	if (removal.code === "identity_mismatch" || removal.code === "parent_mismatch") {
+		return { removed: false, reason: "entry_changed" };
+	}
+	const retainedAtOriginal = !removal.detachedPath || path.resolve(removal.detachedPath) === path.resolve(target);
+	if ((removal.code === "permission_denied" || removal.code === "io_error") && retainedAtOriginal) {
+		return { removed: false, reason: "withheld_evidence_incomplete: tree_unreadable", withheld: true };
+	}
+	return {
+		removed: false,
+		reason: `entry_remove_failed: ${removal.code ?? "unknown"}`,
+		failed: true,
+	};
 }
 
 async function runGcDiskBackups(input: {

--- a/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
@@ -761,6 +761,10 @@ function summarizeGcDiskSurface(report: GcDiskSurfaceReport): void {
  * blind to part of what it just measured. A caller about to remove the tree must
  * treat that as incomplete evidence — a recursive remove cannot finish past an
  * unreadable entry, so it would destroy the readable half and leave the rest.
+ *
+ * An entry that vanished mid-walk (`ENOENT`) is the opposite fact: it is gone,
+ * not withheld. A vanished entry cannot block a recursive remove, so it only
+ * makes `bytes` a floor and never withholds the tree.
  */
 async function measureGcDiskTree(root: string): Promise<{ bytes: number; partial: boolean; unreadable: boolean }> {
 	let bytes = 0;
@@ -795,9 +799,9 @@ async function measureGcDiskTree(root: string): Promise<{ bytes: number; partial
 			if (!entry.isFile()) continue;
 			try {
 				bytes += (await fsp.lstat(child)).size;
-			} catch {
+			} catch (error) {
 				partial = true;
-				unreadable = true;
+				if (!isEnoent(error)) unreadable = true;
 			}
 		}
 	}
@@ -1411,6 +1415,7 @@ async function runGcDiskNatives(input: {
 		} else {
 			record.action = "keep";
 			record.reason = removal.reason;
+			if (removal.withheld) record.withheld = true;
 		}
 	}
 }
@@ -1418,11 +1423,17 @@ async function runGcDiskNatives(input: {
 /**
  * Remove one directory/file entry, fail-closed on identity drift. Anything that
  * changed inode or mtime between classification and removal is left alone.
+ *
+ * Readability is re-proven here instead of being trusted from measurement time:
+ * a nested directory can become unreadable after the size walk without touching
+ * the root's inode or mtime, and a recursive remove that cannot finish past it
+ * would destroy the readable half. The fact has to hold at the moment it
+ * matters, so a removal that cannot complete never starts.
  */
 async function removeGcDiskEntry(
 	target: string,
 	expected: Stats,
-): Promise<{ removed: true } | { removed: false; reason: string; failed?: true }> {
+): Promise<{ removed: true } | { removed: false; reason: string; failed?: true; withheld?: true }> {
 	let current: Stats;
 	try {
 		current = await fsp.lstat(target);
@@ -1435,6 +1446,9 @@ async function removeGcDiskEntry(
 		return { removed: false, reason: "entry_identity_changed" };
 	}
 	if (current.mtimeMs !== expected.mtimeMs) return { removed: false, reason: "entry_changed" };
+	if (current.isDirectory() && (await measureGcDiskTree(target)).unreadable) {
+		return { removed: false, reason: "withheld_evidence_incomplete: tree_unreadable", withheld: true };
+	}
 	try {
 		await fsp.rm(target, { recursive: true, force: false });
 		return { removed: true };
@@ -1523,6 +1537,7 @@ async function runGcDiskBackups(input: {
 		} else {
 			record.action = "keep";
 			record.reason = removal.reason;
+			if (removal.withheld) record.withheld = true;
 		}
 	}
 }

--- a/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
@@ -753,11 +753,20 @@ function summarizeGcDiskSurface(report: GcDiskSurfaceReport): void {
 	}
 }
 
-/** Recursive, bounded byte count. Symlinks are never followed and never counted. */
-async function measureGcDiskTree(root: string): Promise<{ bytes: number; partial: boolean }> {
+/**
+ * Recursive, bounded byte count. Symlinks are never followed and never counted.
+ *
+ * `partial` means `bytes` is only a floor. `unreadable` is the narrower, harder
+ * fact: some entry in the tree could not be enumerated or stat'd, so the walk is
+ * blind to part of what it just measured. A caller about to remove the tree must
+ * treat that as incomplete evidence — a recursive remove cannot finish past an
+ * unreadable entry, so it would destroy the readable half and leave the rest.
+ */
+async function measureGcDiskTree(root: string): Promise<{ bytes: number; partial: boolean; unreadable: boolean }> {
 	let bytes = 0;
 	let visited = 0;
 	let partial = false;
+	let unreadable = false;
 	const stack: string[] = [root];
 	while (stack.length > 0) {
 		const dir = stack.pop()!;
@@ -765,11 +774,14 @@ async function measureGcDiskTree(root: string): Promise<{ bytes: number; partial
 		try {
 			entries = await fsp.readdir(dir, { withFileTypes: true });
 		} catch (error) {
-			if (!isEnoent(error)) partial = true;
+			if (!isEnoent(error)) {
+				partial = true;
+				unreadable = true;
+			}
 			continue;
 		}
 		for (const entry of entries) {
-			if (visited >= GC_DISK_MAX_WALK_ENTRIES) return { bytes, partial: true };
+			if (visited >= GC_DISK_MAX_WALK_ENTRIES) return { bytes, partial: true, unreadable };
 			visited++;
 			const child = path.join(dir, entry.name);
 			if (entry.isSymbolicLink()) {
@@ -785,10 +797,11 @@ async function measureGcDiskTree(root: string): Promise<{ bytes: number; partial
 				bytes += (await fsp.lstat(child)).size;
 			} catch {
 				partial = true;
+				unreadable = true;
 			}
 		}
 	}
-	return { bytes, partial };
+	return { bytes, partial, unreadable };
 }
 
 /**
@@ -1376,7 +1389,13 @@ async function runGcDiskNatives(input: {
 		if (!entry.version) record.reason = "unrecognized_version_directory";
 		else if (entry.name === runningVersion) record.reason = "running_version";
 		else if (keep.has(entry.name)) record.reason = `retained_version(keepVersions=${policy.natives_keep_versions})`;
-		else {
+		else if (usage.unreadable) {
+			// The walk could not read part of the tree this reclaim would remove, so
+			// a recursive remove cannot finish: it would destroy the readable half
+			// and leave the rest. Partial knowledge is never a licence to delete.
+			record.reason = "withheld_evidence_incomplete: tree_unreadable";
+			record.withheld = true;
+		} else {
 			record.action = "would_reclaim";
 			record.reason = `beyond_keep_versions(${policy.natives_keep_versions})`;
 		}
@@ -1468,7 +1487,9 @@ async function runGcDiskBackups(input: {
 			continue;
 		}
 		if (stat.isSymbolicLink()) continue;
-		const usage = stat.isDirectory() ? await measureGcDiskTree(candidate.path) : { bytes: stat.size, partial: false };
+		const usage = stat.isDirectory()
+			? await measureGcDiskTree(candidate.path)
+			: { bytes: stat.size, partial: false, unreadable: false };
 		const record: GcDiskRecord = {
 			surface: "backups",
 			id: candidate.id,
@@ -1480,7 +1501,13 @@ async function runGcDiskBackups(input: {
 			...(usage.partial ? { partial: true as const } : {}),
 		};
 		if (now - stat.mtimeMs < maxAgeMs) record.reason = `newer_than_max_age(${policy.backups_max_age_days}d)`;
-		else {
+		else if (usage.unreadable) {
+			// The walk could not read part of the tree this reclaim would remove, so
+			// a recursive remove cannot finish: it would destroy the readable half
+			// and leave the rest. Partial knowledge is never a licence to delete.
+			record.reason = "withheld_evidence_incomplete: tree_unreadable";
+			record.withheld = true;
+		} else {
 			record.action = "would_reclaim";
 			record.reason = `older_than_max_age(${policy.backups_max_age_days}d)`;
 		}

--- a/packages/coding-agent/test/gc-disk-retention.test.ts
+++ b/packages/coding-agent/test/gc-disk-retention.test.ts
@@ -734,6 +734,38 @@ describe("gjc gc --disk (natives retention)", () => {
 			await fsp.rm(fixture.root, { recursive: true, force: true });
 		}
 	});
+	test("withholds a version whose tree could not be fully read instead of half-deleting it", async () => {
+		const fixture = await makeTestRoot();
+		const locked = path.join(fixture.nativesDir, "0.1.0", "locked");
+		try {
+			for (const version of ["0.1.0", "0.2.0", "0.3.0"]) await writeNativesVersion(fixture, version);
+			// An unreadable subdirectory makes the size walk blind, and makes a
+			// recursive remove impossible to complete: it can only destroy the
+			// readable half.
+			await fsp.mkdir(locked, { recursive: true });
+			await Bun.write(path.join(locked, "inner.bin"), "z".repeat(2048));
+			await fsp.chmod(locked, 0o000);
+
+			const disk = await collectGcDiskReport({
+				agentDir: fixture.agentDir,
+				env: fixture.env,
+				policy: policy({ natives_keep_versions: 1 }),
+				prune: true,
+				runningVersion: "0.3.0",
+			});
+
+			expect(reasonById(disk, "natives").get("0.1.0")).toBe("keep:withheld_evidence_incomplete: tree_unreadable");
+			expect(disk.surfaces.natives.records.find(record => record.id === "0.1.0")?.withheld).toBe(true);
+			expect(disk.surfaces.natives.reclaimed).toBe(0);
+			expect(disk.surfaces.natives.failed).toBe(0);
+			// The readable half is what a half-completed remove destroys first.
+			expect(await Bun.file(path.join(fixture.nativesDir, "0.1.0", "pi-natives.node")).exists()).toBe(true);
+			expect((await fsp.readdir(fixture.nativesDir)).sort()).toEqual(["0.1.0", "0.2.0", "0.3.0"]);
+		} finally {
+			await fsp.chmod(locked, 0o700).catch(() => {});
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
 });
 
 describe("gjc gc --disk (backups retention)", () => {
@@ -770,6 +802,105 @@ describe("gjc gc --disk (backups retention)", () => {
 			expect((await fsp.lstat(fixture.agentDir)).isDirectory()).toBe(true);
 		} finally {
 			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+	test("withholds a backup whose tree could not be fully read instead of half-deleting it", async () => {
+		const fixture = await makeTestRoot();
+		const locked = path.join(fixture.backupsDir, "natives-0.1.0-before-update", "locked");
+		try {
+			const backup = path.join(fixture.backupsDir, "natives-0.1.0-before-update");
+			await fsp.mkdir(locked, { recursive: true });
+			await Bun.write(path.join(backup, "payload.bin"), "x".repeat(64));
+			await Bun.write(path.join(locked, "inner.bin"), "z".repeat(2048));
+			await fsp.chmod(locked, 0o000);
+			await backdate(backup, 40);
+
+			const disk = await collectGcDiskReport({
+				agentDir: fixture.agentDir,
+				env: fixture.env,
+				policy: policy(),
+				prune: true,
+			});
+
+			expect(reasonById(disk, "backups").get("natives-0.1.0-before-update")).toBe(
+				"keep:withheld_evidence_incomplete: tree_unreadable",
+			);
+			expect(
+				disk.surfaces.backups.records.find(record => record.id === "natives-0.1.0-before-update")?.withheld,
+			).toBe(true);
+			expect(disk.surfaces.backups.reclaimed).toBe(0);
+			expect(disk.surfaces.backups.failed).toBe(0);
+			// A recursive remove destroys the readable entries before it fails on
+			// the unreadable one, leaving a backup that is neither intact nor gone.
+			expect(await Bun.file(path.join(backup, "payload.bin")).exists()).toBe(true);
+		} finally {
+			await fsp.chmod(locked, 0o700).catch(() => {});
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("a fully readable backup is still reclaimed when its size walk skipped a symlink", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			const backup = path.join(fixture.backupsDir, "gjc-update-old");
+			await fsp.mkdir(backup, { recursive: true });
+			await Bun.write(path.join(backup, "payload.bin"), "x".repeat(64));
+			// A skipped symlink makes `bytes` a floor, but nothing was unreadable,
+			// so the reclaim must still go through.
+			await fsp.symlink(path.join(backup, "payload.bin"), path.join(backup, "alias"));
+			await backdate(backup, 40);
+
+			const disk = await collectGcDiskReport({
+				agentDir: fixture.agentDir,
+				env: fixture.env,
+				policy: policy(),
+				prune: true,
+			});
+
+			const record = disk.surfaces.backups.records.find(entry => entry.id === "gjc-update-old");
+			expect(record?.partial).toBe(true);
+			expect(record?.withheld).toBeUndefined();
+			expect(reasonById(disk, "backups").get("gjc-update-old")).toBe("reclaimed:older_than_max_age(14d)");
+			expect(await fsp.readdir(fixture.backupsDir)).toEqual([]);
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("dry run and prune agree that an unreadable backup tree is withheld", async () => {
+		const dry = await makeTestRoot();
+		const wet = await makeTestRoot();
+		try {
+			for (const fixture of [dry, wet]) {
+				const backup = path.join(fixture.backupsDir, "gjc-update-old");
+				await fsp.mkdir(path.join(backup, "locked"), { recursive: true });
+				await Bun.write(path.join(backup, "payload.bin"), "x".repeat(64));
+				await fsp.chmod(path.join(backup, "locked"), 0o000);
+				await backdate(backup, 40);
+			}
+
+			const dryDisk = await collectGcDiskReport({
+				agentDir: dry.agentDir,
+				env: dry.env,
+				policy: policy(),
+				prune: false,
+			});
+			const wetDisk = await collectGcDiskReport({
+				agentDir: wet.agentDir,
+				env: wet.env,
+				policy: policy(),
+				prune: true,
+			});
+
+			expect(dryDisk.surfaces.backups.reclaimable).toBe(0);
+			expect(wetDisk.surfaces.backups.reclaimed).toBe(dryDisk.surfaces.backups.reclaimable);
+			expect(wetDisk.surfaces.backups.reclaimed_bytes).toBe(dryDisk.surfaces.backups.reclaimable_bytes);
+			expect(await Bun.file(path.join(wet.backupsDir, "gjc-update-old", "payload.bin")).exists()).toBe(true);
+		} finally {
+			for (const fixture of [dry, wet]) {
+				await fsp.chmod(path.join(fixture.backupsDir, "gjc-update-old", "locked"), 0o700).catch(() => {});
+				await fsp.rm(fixture.root, { recursive: true, force: true });
+			}
 		}
 	});
 });

--- a/packages/coding-agent/test/gc-disk-retention.test.ts
+++ b/packages/coding-agent/test/gc-disk-retention.test.ts
@@ -971,6 +971,251 @@ describe("gjc gc --disk (backups retention)", () => {
 		}
 	});
 
+	test("does not half-delete a backup that goes unreadable inside recursive removal", async () => {
+		const fixture = await makeTestRoot();
+		const backup = path.join(fixture.backupsDir, "gjc-update-old");
+		const locked = path.join(backup, "locked");
+		const realLstat = fsp.lstat as unknown as (target: PathLike, options?: { bigint?: boolean }) => Promise<Stats>;
+		const realRm = fsp.rm;
+		let raceInjected = false;
+		const lstatSpy = spyOn(fsp, "lstat");
+		lstatSpy.mockImplementation((async (target: PathLike, options?: { bigint?: boolean }) => {
+			if (!raceInjected && options?.bigint === true && path.resolve(String(target)) === path.dirname(backup)) {
+				raceInjected = true;
+				await fsp.chmod(locked, 0o000);
+			}
+			return await realLstat(target, options);
+		}) as unknown as typeof fsp.lstat);
+		const rmSpy = spyOn(fsp, "rm");
+		rmSpy.mockImplementation((async (target: PathLike, options?: Parameters<typeof fsp.rm>[1]) => {
+			if (!raceInjected && path.resolve(String(target)) === backup) {
+				raceInjected = true;
+				await fsp.chmod(locked, 0o000);
+			}
+			return await realRm(target, options);
+		}) as typeof fsp.rm);
+		try {
+			await fsp.mkdir(locked, { recursive: true });
+			for (let index = 0; index < 200; index++) {
+				await Bun.write(path.join(backup, `payload-${index}.bin`), "x".repeat(64));
+			}
+			await Bun.write(path.join(locked, "inner.bin"), "z".repeat(2048));
+			await backdate(backup, 40);
+
+			const disk = await collectGcDiskReport({
+				agentDir: fixture.agentDir,
+				env: fixture.env,
+				policy: policy(),
+				prune: true,
+			});
+			lstatSpy.mockRestore();
+			rmSpy.mockRestore();
+			expect(raceInjected).toBe(true);
+
+			expect(reasonById(disk, "backups").get("gjc-update-old")).toBe(
+				"keep:withheld_evidence_incomplete: tree_unreadable",
+			);
+			expect(disk.surfaces.backups.records.find(record => record.id === "gjc-update-old")?.withheld).toBe(true);
+			expect(disk.surfaces.backups.reclaimed).toBe(0);
+			expect(disk.surfaces.backups.failed).toBe(0);
+			expect(await Bun.file(path.join(backup, "payload-0.bin")).exists()).toBe(true);
+			expect((await fsp.readdir(backup)).length).toBe(201);
+		} finally {
+			lstatSpy.mockRestore();
+			rmSpy.mockRestore();
+			await fsp.chmod(locked, 0o700).catch(() => {});
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("withholds a capped walk whose unvisited subtree is unreadable", async () => {
+		const dry = await makeTestRoot();
+		const wet = await makeTestRoot();
+		const syntheticSymlinks = Array.from({ length: 200_000 }, (_unused, index) => {
+			return {
+				name: `vanished-${index}`,
+				isBlockDevice: () => false,
+				isCharacterDevice: () => false,
+				isDirectory: () => false,
+				isFIFO: () => false,
+				isFile: () => false,
+				isSocket: () => false,
+				isSymbolicLink: () => true,
+			} as unknown as Dirent;
+		});
+		const realReaddir = fsp.readdir as unknown as (
+			dir: PathLike,
+			options?: { withFileTypes?: true },
+		) => Promise<Array<string | Dirent>>;
+		const roots = new Set<string>();
+		const spy = spyOn(fsp, "readdir");
+		spy.mockImplementation((async (dir: PathLike, options?: { withFileTypes?: true }) => {
+			if (options?.withFileTypes && roots.has(path.resolve(String(dir)))) {
+				const entries = await realReaddir(dir, options);
+				const locked = entries.find(entry => typeof entry !== "string" && entry.name === "locked");
+				if (!locked) throw new Error("Expected locked fixture directory");
+				return [...syntheticSymlinks, locked];
+			}
+			return await realReaddir(dir, options);
+		}) as unknown as typeof fsp.readdir);
+		try {
+			for (const fixture of [dry, wet]) {
+				const backup = path.join(fixture.backupsDir, "gjc-update-old");
+				roots.add(backup);
+				await fsp.mkdir(path.join(backup, "locked"), { recursive: true });
+				await Bun.write(path.join(backup, "payload-0.bin"), "x".repeat(64));
+				await Bun.write(path.join(backup, "locked", "inner.bin"), "z".repeat(2048));
+				await fsp.chmod(path.join(backup, "locked"), 0o000);
+				await backdate(backup, 40);
+			}
+
+			const dryDisk = await collectGcDiskReport({
+				agentDir: dry.agentDir,
+				env: dry.env,
+				policy: policy(),
+				prune: false,
+			});
+			const wetDisk = await collectGcDiskReport({
+				agentDir: wet.agentDir,
+				env: wet.env,
+				policy: policy(),
+				prune: true,
+			});
+			spy.mockRestore();
+
+			expect(reasonById(dryDisk, "backups").get("gjc-update-old")).toBe(
+				"keep:withheld_evidence_incomplete: tree_unreadable",
+			);
+			expect(reasonById(wetDisk, "backups").get("gjc-update-old")).toBe(
+				"keep:withheld_evidence_incomplete: tree_unreadable",
+			);
+			expect(wetDisk.surfaces.backups.reclaimed).toBe(dryDisk.surfaces.backups.reclaimable);
+			expect(wetDisk.surfaces.backups.failed).toBe(0);
+			expect(await Bun.file(path.join(wet.backupsDir, "gjc-update-old", "payload-0.bin")).exists()).toBe(true);
+			expect((await fsp.readdir(path.join(wet.backupsDir, "gjc-update-old"))).sort()).toEqual([
+				"locked",
+				"payload-0.bin",
+			]);
+		} finally {
+			spy.mockRestore();
+			for (const fixture of [dry, wet]) {
+				await fsp.chmod(path.join(fixture.backupsDir, "gjc-update-old", "locked"), 0o700).catch(() => {});
+				await fsp.rm(fixture.root, { recursive: true, force: true });
+			}
+		}
+	});
+
+	test("reclaims a capped walk whose unvisited subtree is readable", async () => {
+		const dry = await makeTestRoot();
+		const wet = await makeTestRoot();
+		// The same cap that hides an unreadable subtree also hides a readable one.
+		// Running out of sizing budget is not evidence of anything: it must leave
+		// `bytes` a floor without ever withholding a tree that can be removed.
+		const syntheticSymlinks = Array.from({ length: 200_000 }, (_unused, index) => {
+			return {
+				name: `skipped-${index}`,
+				isBlockDevice: () => false,
+				isCharacterDevice: () => false,
+				isDirectory: () => false,
+				isFIFO: () => false,
+				isFile: () => false,
+				isSocket: () => false,
+				isSymbolicLink: () => true,
+			} as unknown as Dirent;
+		});
+		const realReaddir = fsp.readdir as unknown as (
+			dir: PathLike,
+			options?: { withFileTypes?: true },
+		) => Promise<Array<string | Dirent>>;
+		const roots = new Set<string>();
+		const spy = spyOn(fsp, "readdir");
+		spy.mockImplementation((async (dir: PathLike, options?: { withFileTypes?: true }) => {
+			if (options?.withFileTypes && roots.has(path.resolve(String(dir)))) {
+				const entries = await realReaddir(dir, options);
+				const deep = entries.find(entry => typeof entry !== "string" && entry.name === "deep");
+				if (!deep) throw new Error("Expected the deep fixture directory");
+				return [...syntheticSymlinks, deep];
+			}
+			return await realReaddir(dir, options);
+		}) as unknown as typeof fsp.readdir);
+		try {
+			for (const fixture of [dry, wet]) {
+				const backup = path.join(fixture.backupsDir, "gjc-update-old");
+				roots.add(backup);
+				await fsp.mkdir(path.join(backup, "deep"), { recursive: true });
+				await Bun.write(path.join(backup, "payload-0.bin"), "x".repeat(64));
+				await Bun.write(path.join(backup, "deep", "inner.bin"), "z".repeat(2048));
+				await backdate(backup, 40);
+			}
+
+			const dryDisk = await collectGcDiskReport({
+				agentDir: dry.agentDir,
+				env: dry.env,
+				policy: policy(),
+				prune: false,
+			});
+			const wetDisk = await collectGcDiskReport({
+				agentDir: wet.agentDir,
+				env: wet.env,
+				policy: policy(),
+				prune: true,
+			});
+			spy.mockRestore();
+
+			expect(reasonById(dryDisk, "backups").get("gjc-update-old")).toBe("would_reclaim:older_than_max_age(14d)");
+			expect(reasonById(wetDisk, "backups").get("gjc-update-old")).toBe("reclaimed:older_than_max_age(14d)");
+			expect(dryDisk.surfaces.backups.records.find(record => record.id === "gjc-update-old")?.partial).toBe(true);
+			expect(wetDisk.surfaces.backups.reclaimed).toBe(dryDisk.surfaces.backups.reclaimable);
+			expect(wetDisk.surfaces.backups.failed).toBe(0);
+			expect(await fsp.readdir(wet.backupsDir)).toEqual([]);
+		} finally {
+			spy.mockRestore();
+			for (const fixture of [dry, wet]) {
+				await fsp.rm(fixture.root, { recursive: true, force: true });
+			}
+		}
+	});
+
+	test("reports a symlinked backup that vanishes under the detach as gone, not failed", async () => {
+		const fixture = await makeTestRoot();
+		const backup = path.join(fixture.backupsDir, "gjc-update-old");
+		const realLstat = fsp.lstat as unknown as (target: PathLike, options?: { bigint?: boolean }) => Promise<Stats>;
+		let vanished = false;
+		// A tree holding a symlink is detached before it is removed, and the detach
+		// re-reads the root's identity. A concurrent cleanup that wins that race
+		// must be reported as gone, not crash the whole disk pass.
+		const spy = spyOn(fsp, "lstat");
+		spy.mockImplementation((async (target: PathLike, options?: { bigint?: boolean }) => {
+			if (!vanished && options?.bigint === true && path.resolve(String(target)) === backup) {
+				vanished = true;
+				await fsp.rm(backup, { recursive: true, force: true });
+			}
+			return await realLstat(target, options);
+		}) as unknown as typeof fsp.lstat);
+		try {
+			await fsp.mkdir(backup, { recursive: true });
+			await Bun.write(path.join(backup, "payload.bin"), "x".repeat(64));
+			await fsp.symlink(path.join(backup, "payload.bin"), path.join(backup, "alias"));
+			await backdate(backup, 40);
+
+			const disk = await collectGcDiskReport({
+				agentDir: fixture.agentDir,
+				env: fixture.env,
+				policy: policy(),
+				prune: true,
+			});
+			spy.mockRestore();
+
+			expect(vanished).toBe(true);
+			expect(reasonById(disk, "backups").get("gjc-update-old")).toBe("keep:entry_disappeared");
+			expect(disk.surfaces.backups.records.find(record => record.id === "gjc-update-old")?.withheld).toBeUndefined();
+			expect(disk.surfaces.backups.failed).toBe(0);
+			expect(disk.surfaces.backups.reclaimed).toBe(0);
+		} finally {
+			spy.mockRestore();
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
 	test("reclaims a backup whose enumerated files vanished under the walk", async () => {
 		const fixture = await makeTestRoot();
 		const backup = path.join(fixture.backupsDir, "gjc-update-old");

--- a/packages/coding-agent/test/gc-disk-retention.test.ts
+++ b/packages/coding-agent/test/gc-disk-retention.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
+import type { Dirent, PathLike, Stats } from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -901,6 +902,122 @@ describe("gjc gc --disk (backups retention)", () => {
 				await fsp.chmod(path.join(fixture.backupsDir, "gjc-update-old", "locked"), 0o700).catch(() => {});
 				await fsp.rm(fixture.root, { recursive: true, force: true });
 			}
+		}
+	});
+
+	test("withholds a backup that goes unreadable between the size walk and the remove", async () => {
+		const fixture = await makeTestRoot();
+		const backup = path.join(fixture.backupsDir, "gjc-update-old");
+		const locked = path.join(backup, "locked");
+		const realLstat = fsp.lstat as unknown as (target: PathLike, options?: { bigint?: false }) => Promise<Stats>;
+		// The candidate is lstat'd twice: once to classify it, once to verify it
+		// immediately before the remove. Locking the subtree on that second call is
+		// a subtree that goes unreadable after the walk, without touching the root's
+		// own inode or mtime — exactly the window the measurement-time check misses.
+		let candidateStats = 0;
+		const spy = spyOn(fsp, "lstat");
+		spy.mockImplementation((async (target: PathLike, options?: { bigint?: false }) => {
+			if (path.resolve(String(target)) === backup && ++candidateStats === 2) await fsp.chmod(locked, 0o000);
+			return await realLstat(target, options);
+		}) as unknown as typeof fsp.lstat);
+		try {
+			// Wide enough that a recursive remove destroys the readable half before
+			// it reaches the locked subdirectory and gives up.
+			await fsp.mkdir(locked, { recursive: true });
+			await fsp.mkdir(path.join(backup, "sibling"), { recursive: true });
+			for (let index = 0; index < 200; index++) {
+				await Bun.write(path.join(backup, `payload-${index}.bin`), "x".repeat(64));
+				await Bun.write(path.join(backup, "sibling", `s-${index}.bin`), "x".repeat(64));
+			}
+			await Bun.write(path.join(locked, "inner.bin"), "z".repeat(2048));
+			await backdate(backup, 40);
+
+			const disk = await collectGcDiskReport({
+				agentDir: fixture.agentDir,
+				env: fixture.env,
+				policy: policy(),
+				prune: true,
+			});
+			spy.mockRestore();
+
+			// The refusal has to land before anything is destroyed, not after.
+			expect((await fsp.readdir(backup)).sort()).toEqual(
+				["locked", "sibling", ...Array.from({ length: 200 }, (_unused, index) => `payload-${index}.bin`)].sort(),
+			);
+			expect((await fsp.readdir(path.join(backup, "sibling"))).length).toBe(200);
+			expect(reasonById(disk, "backups").get("gjc-update-old")).toBe(
+				"keep:withheld_evidence_incomplete: tree_unreadable",
+			);
+			expect(disk.surfaces.backups.records.find(record => record.id === "gjc-update-old")?.withheld).toBe(true);
+			expect(disk.surfaces.backups.reclaimed).toBe(0);
+			expect(disk.surfaces.backups.failed).toBe(0);
+
+			// A dry run over the state the prune actually faced withholds it for the
+			// same reason, so the two axes never disagree about what is withheld.
+			const dryDisk = await collectGcDiskReport({
+				agentDir: fixture.agentDir,
+				env: fixture.env,
+				policy: policy(),
+				prune: false,
+			});
+			expect(reasonById(dryDisk, "backups").get("gjc-update-old")).toBe(
+				"keep:withheld_evidence_incomplete: tree_unreadable",
+			);
+			expect(dryDisk.surfaces.backups.reclaimable).toBe(0);
+		} finally {
+			spy.mockRestore();
+			await fsp.chmod(locked, 0o700).catch(() => {});
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("reclaims a backup whose enumerated files vanished under the walk", async () => {
+		const fixture = await makeTestRoot();
+		const backup = path.join(fixture.backupsDir, "gjc-update-old");
+		const vanishing = path.join(backup, "many");
+		const realReaddir = fsp.readdir as unknown as (
+			dir: PathLike,
+			options?: { withFileTypes?: true },
+		) => Promise<Array<string | Dirent>>;
+		// Enumerate, then delete: every entry the walk is about to stat answers
+		// ENOENT, exactly like a concurrent cleanup of an already-walked tree. Gone
+		// is the opposite of unreadable — a vanished file cannot block a remove.
+		const spy = spyOn(fsp, "readdir");
+		spy.mockImplementation((async (dir: PathLike, options?: { withFileTypes?: true }) => {
+			const entries = await realReaddir(dir, options);
+			if (path.resolve(String(dir)) === vanishing) {
+				for (const entry of entries) {
+					const name = typeof entry === "string" ? entry : entry.name;
+					await fsp.rm(path.join(vanishing, name), { force: true });
+				}
+			}
+			return entries;
+		}) as unknown as typeof fsp.readdir);
+		try {
+			await fsp.mkdir(vanishing, { recursive: true });
+			await Bun.write(path.join(backup, "payload.bin"), "x".repeat(64));
+			for (let index = 0; index < 200; index++) {
+				await Bun.write(path.join(vanishing, `chunk-${index}.bin`), "y".repeat(32));
+			}
+			await backdate(backup, 40);
+
+			const disk = await collectGcDiskReport({
+				agentDir: fixture.agentDir,
+				env: fixture.env,
+				policy: policy(),
+				prune: true,
+			});
+			spy.mockRestore();
+
+			const record = disk.surfaces.backups.records.find(entry => entry.id === "gjc-update-old");
+			expect(record?.partial).toBe(true);
+			expect(record?.withheld).toBeUndefined();
+			expect(reasonById(disk, "backups").get("gjc-update-old")).toBe("reclaimed:older_than_max_age(14d)");
+			expect(disk.surfaces.backups.reclaimed).toBe(1);
+			expect(await fsp.readdir(fixture.backupsDir)).toEqual([]);
+		} finally {
+			spy.mockRestore();
+			await fsp.rm(fixture.root, { recursive: true, force: true });
 		}
 	});
 });


### PR DESCRIPTION
Follow-up to #4037, from the post-merge audit in #4063.

## The defect

`gc --disk` was fail-closed on incomplete evidence everywhere except where it mattered. The tree walk reported `partial`, meaning the byte count is a floor, and reclamation treated that as good enough. Two different facts were collapsed into one flag: a count that is merely a floor, and a tree the walk could not enumerate at all.

They are not interchangeable before a recursive remove. A remove cannot finish past an entry it cannot read, so proceeding destroys the readable half and leaves the rest — neither a reclaim nor a no-op, which is the worst outcome available here.

## What the rounds found

- A walk that hit the 200,000-entry cap returned `unreadable: false`, so a tree whose remainder was never examined was treated as fully verified and deleted. Exceeding the cap was indistinguishable from a clean walk. A bound that makes the evidence less complete must make the verdict more conservative; it is incomplete evidence now. Raising the cap was rejected — it moves the same hole to a new number and brings back the hang the cap prevents.
- Readability was established before `fsp.rm` rather than by it, so a directory going unreadable in between still let the removal start. The removal reports its own failure now instead of a preflight predicting success.
- Every `lstat` failure set `unreadable`, including `ENOENT` from a concurrent deletion, so a tree being cleaned up elsewhere was withheld forever. `ENOENT` means gone, which is the opposite of unreadable — a vanished file cannot block a remove.

## Verification

`bun test gc-disk-retention.test.ts gc-runtime.test.ts` — 61 pass, 0 fail. `bun --cwd=packages/coding-agent run check` — exit 0.

Reverting `gc-runtime.ts` to `dev` fails 7 tests behaviorally, including a capped walk whose unvisited subtree is unreadable, a backup that goes unreadable inside the recursive remove, and a symlinked backup that vanishes under the detach.

## Known and not fixed

`prune` and `--dry-run` are asserted to agree on unreadable and `ENOENT` trees. That is narrower than "they agree", which an earlier version of this change claimed and a hardlink/fifo fixture falsified.
