### PR TITLE
fix(session): put a deferred block in the transcript when the user sees it

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2029,7 +2029,11 @@ export class AgentSession {
 
 	// Bash execution state
 	#bashAbortControllers = new Set<AbortController>();
-	#pendingBashMessages: Array<{ message: BashExecutionMessage; onPersisted?: () => void }> = [];
+	#pendingBashMessages: Array<{
+		message: BashExecutionMessage;
+		onPersisted?: () => void;
+		appendedToAgent: boolean;
+	}> = [];
 	#foregroundBashBackgroundRequestHandler: (() => void) | undefined;
 
 	// Python execution state
@@ -2046,7 +2050,11 @@ export class AgentSession {
 	readonly #ownedAsyncJobManager: AsyncJobManager | undefined;
 	readonly #ownedMcpManager: MCPManager | undefined;
 	#startupTurnBarrier: Promise<void> | undefined;
-	#pendingPythonMessages: Array<{ message: PythonExecutionMessage; onPersisted?: () => void }> = [];
+	#pendingPythonMessages: Array<{
+		message: PythonExecutionMessage;
+		onPersisted?: () => void;
+		appendedToAgent: boolean;
+	}> = [];
 	#activeEvalExecutions = new Set<Promise<unknown>>();
 	#evalExecutionDisposing = false;
 
@@ -2604,16 +2612,41 @@ export class AgentSession {
 		if (this.#promptInFlightCount === 0) {
 			this.#releasePowerAssertion();
 			this.#refreshTeamWorkerHeartbeat();
-			// The turn is over, so nothing can split a tool_use/tool_result pair any
-			// more: a `!`/`$` block that finished mid-stream must own its place in
-			// agent state and the session now, not at the next prompt. Until it does,
-			// the TUI shows output the transcript lacks and `onPersisted` stays unfired,
-			// so a rebuild in that gap drops the only rendering of the execution.
-			this.#flushPendingBashMessages();
-			this.#flushPendingPythonMessages();
-			this.#flushPendingBackgroundExchanges();
+			let flushError: unknown;
+			try {
+				// The turn is over, so nothing can split a tool_use/tool_result pair any
+				// more: a `!`/`$` block that finished mid-stream must own its place in
+				// agent state and the session now, not at the next prompt. Until it does,
+				// the TUI shows output the transcript lacks and `onPersisted` stays unfired,
+				// so a rebuild in that gap drops the only rendering of the execution.
+				this.#flushPendingPromptMessages();
+			} catch (error) {
+				flushError = error;
+			}
 			this.#flushPendingAgentEnd();
+			if (flushError) throw flushError;
 		}
+	}
+
+	#flushPendingPromptMessages(): void {
+		const errors: unknown[] = [];
+		try {
+			this.#flushPendingBashMessages();
+		} catch (error) {
+			errors.push(error);
+		}
+		try {
+			this.#flushPendingPythonMessages();
+		} catch (error) {
+			errors.push(error);
+		}
+		try {
+			this.#flushPendingBackgroundExchanges();
+		} catch (error) {
+			errors.push(error);
+		}
+		if (errors.length === 1) throw errors[0];
+		if (errors.length > 1) throw new AggregateError(errors, "Multiple deferred prompt messages failed to flush");
 	}
 
 	#refreshTeamWorkerHeartbeat(): void {
@@ -8831,10 +8864,8 @@ export class AgentSession {
 				this.#overflowMaintenanceAttempts = 0;
 				this.#throwIfPromptPreflightCancelled(generation, preflightSignal);
 			}
-			// Flush any pending bash messages before the new prompt
-			this.#flushPendingBashMessages();
-			this.#flushPendingPythonMessages();
-			this.#flushPendingBackgroundExchanges();
+			// Retry anything whose previous post-turn persistence failed before the new prompt.
+			this.#flushPendingPromptMessages();
 
 			// Reset todo reminder count on new user prompt
 			this.#todoReminderCount = 0;
@@ -16342,7 +16373,11 @@ export class AgentSession {
 		// If agent is streaming, defer adding to avoid breaking tool_use/tool_result ordering
 		if (this.isStreaming) {
 			// Queue for later - will be flushed on agent_end
-			this.#pendingBashMessages.push({ message: bashMessage, onPersisted: options?.onPersisted });
+			this.#pendingBashMessages.push({
+				message: bashMessage,
+				onPersisted: options?.onPersisted,
+				appendedToAgent: false,
+			});
 		} else {
 			// Add to agent state immediately
 			this.agent.appendMessage(bashMessage);
@@ -16377,18 +16412,7 @@ export class AgentSession {
 	 * Called after agent turn completes to maintain proper message ordering.
 	 */
 	#flushPendingBashMessages(): void {
-		if (this.#pendingBashMessages.length === 0) return;
-
-		for (const pending of this.#pendingBashMessages) {
-			// Add to agent state
-			this.agent.appendMessage(pending.message);
-
-			// Save to session
-			this.sessionManager.appendMessage(pending.message);
-			pending.onPersisted?.();
-		}
-
-		this.#pendingBashMessages = [];
+		this.#flushPendingExecutionMessages(this.#pendingBashMessages, "bash");
 	}
 
 	// =========================================================================
@@ -16495,7 +16519,11 @@ export class AgentSession {
 
 		// If agent is streaming, defer adding to avoid breaking tool_use/tool_result ordering
 		if (this.isStreaming) {
-			this.#pendingPythonMessages.push({ message: pythonMessage, onPersisted: options?.onPersisted });
+			this.#pendingPythonMessages.push({
+				message: pythonMessage,
+				onPersisted: options?.onPersisted,
+				appendedToAgent: false,
+			});
 		} else {
 			this.agent.appendMessage(pythonMessage);
 			this.sessionManager.appendMessage(pythonMessage);
@@ -16558,15 +16586,54 @@ export class AgentSession {
 	 * Flush pending Python messages to agent state and session.
 	 */
 	#flushPendingPythonMessages(): void {
-		if (this.#pendingPythonMessages.length === 0) return;
+		this.#flushPendingExecutionMessages(this.#pendingPythonMessages, "python");
+	}
 
-		for (const pending of this.#pendingPythonMessages) {
-			this.agent.appendMessage(pending.message);
-			this.sessionManager.appendMessage(pending.message);
-			pending.onPersisted?.();
+	#flushPendingExecutionMessages<T extends BashExecutionMessage | PythonExecutionMessage>(
+		pendingMessages: Array<{ message: T; onPersisted?: () => void; appendedToAgent: boolean }>,
+		kind: "bash" | "python",
+	): void {
+		if (pendingMessages.length === 0) return;
+
+		const total = pendingMessages.length;
+		const remaining: typeof pendingMessages = [];
+		const errors: unknown[] = [];
+		let callbackFailureCount = 0;
+		for (const pending of pendingMessages) {
+			try {
+				if (!pending.appendedToAgent) {
+					this.agent.appendMessage(pending.message);
+					pending.appendedToAgent = true;
+				}
+				this.sessionManager.appendMessage(pending.message);
+			} catch (error) {
+				remaining.push(pending);
+				errors.push(error);
+				continue;
+			}
+
+			try {
+				pending.onPersisted?.();
+			} catch (error) {
+				callbackFailureCount++;
+				errors.push(error);
+			}
 		}
 
-		this.#pendingPythonMessages = [];
+		pendingMessages.splice(0, pendingMessages.length, ...remaining);
+		if (errors.length === 0) return;
+
+		const persistedCount = total - remaining.length;
+		const persistenceFailureCount = remaining.length;
+		const persistenceSummary =
+			persistenceFailureCount > 0
+				? `Failed to persist ${persistenceFailureCount} of ${total} deferred ${kind} execution message${total === 1 ? "" : "s"}; ${persistedCount} persisted, failed messages remain pending for retry`
+				: `Persisted all ${total} deferred ${kind} execution message${total === 1 ? "" : "s"}`;
+		const callbackSummary =
+			callbackFailureCount > 0
+				? `; ${callbackFailureCount} onPersisted callback${callbackFailureCount === 1 ? "" : "s"} failed`
+				: "";
+		throw new AggregateError(errors, `${persistenceSummary}${callbackSummary}`);
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2607,25 +2607,37 @@ export class AgentSession {
 		}
 	}
 
-	#endInFlight(): void {
+	#endInFlight(): unknown {
 		this.#promptInFlightCount = Math.max(0, this.#promptInFlightCount - 1);
-		if (this.#promptInFlightCount === 0) {
-			this.#releasePowerAssertion();
-			this.#refreshTeamWorkerHeartbeat();
-			let flushError: unknown;
-			try {
-				// The turn is over, so nothing can split a tool_use/tool_result pair any
-				// more: a `!`/`$` block that finished mid-stream must own its place in
-				// agent state and the session now, not at the next prompt. Until it does,
-				// the TUI shows output the transcript lacks and `onPersisted` stays unfired,
-				// so a rebuild in that gap drops the only rendering of the execution.
-				this.#flushPendingPromptMessages();
-			} catch (error) {
-				flushError = error;
-			}
-			this.#flushPendingAgentEnd();
-			if (flushError) throw flushError;
+		if (this.#promptInFlightCount !== 0) return undefined;
+
+		this.#releasePowerAssertion();
+		this.#refreshTeamWorkerHeartbeat();
+		let flushError: unknown;
+		try {
+			// The turn is over, so nothing can split a tool_use/tool_result pair any
+			// more: a `!`/`$` block that finished mid-stream must own its place in
+			// agent state and the session now, not at the next prompt. Until it does,
+			// the TUI shows output the transcript lacks and `onPersisted` stays unfired,
+			// so a rebuild in that gap drops the only rendering of the execution.
+			this.#flushPendingPromptMessages();
+		} catch (error) {
+			flushError = error;
 		}
+		this.#flushPendingAgentEnd();
+		return flushError;
+	}
+	async #settleEndedInFlight(promptWait?: "publication" | "full"): Promise<void> {
+		const flushError = this.#endInFlight();
+		if (promptWait === "publication") {
+			await this.#agentEndPublicationPromise;
+		} else if (promptWait === "full") {
+			await this.#agentEndHandlingPromise;
+			await this.#waitForPostPromptRecovery();
+			await this.#agentEndPublicationPromise;
+		}
+		await this.#waitForSessionSettlement();
+		if (flushError) throw flushError;
 	}
 
 	#flushPendingPromptMessages(): void {
@@ -7669,8 +7681,7 @@ export class AgentSession {
 			await this.#waitForPostPromptRecovery();
 		} finally {
 			this.#removeEphemeralCustomMessages();
-			this.#endInFlight();
-			await this.#waitForSessionSettlement();
+			await this.#settleEndedInFlight();
 		}
 	}
 
@@ -9157,14 +9168,7 @@ export class AgentSession {
 				this.#releaseIrcRosterClaim(rosterClaim.token, rosterClaim.epoch);
 			}
 			this.#releaseDeferredAgentEndContinuation(predecessorAgentEndHold);
-			this.#endInFlight();
-			if (options?.skipPostPromptRecoveryWait) {
-				await this.#agentEndPublicationPromise;
-			} else {
-				await this.#agentEndHandlingPromise;
-				await this.#waitForPostPromptRecovery();
-				await this.#agentEndPublicationPromise;
-			}
+			await this.#settleEndedInFlight(options?.skipPostPromptRecoveryWait ? "publication" : "full");
 		}
 	}
 
@@ -16598,20 +16602,46 @@ export class AgentSession {
 		const total = pendingMessages.length;
 		const remaining: typeof pendingMessages = [];
 		const errors: unknown[] = [];
+		const persisted: string[] = [];
 		let callbackFailureCount = 0;
+		let persistenceBlocked = false;
+		let agentAppendBlocked = false;
 		for (const pending of pendingMessages) {
-			try {
-				if (!pending.appendedToAgent) {
+			if (!pending.appendedToAgent) {
+				if (agentAppendBlocked) {
+					remaining.push(pending);
+					continue;
+				}
+				try {
 					this.agent.appendMessage(pending.message);
 					pending.appendedToAgent = true;
+				} catch (error) {
+					agentAppendBlocked = true;
+					persistenceBlocked = true;
+					remaining.push(pending);
+					errors.push(error);
+					continue;
 				}
+			}
+
+			if (persistenceBlocked) {
+				remaining.push(pending);
+				continue;
+			}
+
+			try {
 				this.sessionManager.appendMessage(pending.message);
 			} catch (error) {
+				// Session entries form a leaf-linked transcript. Once one append fails,
+				// later entries must remain queued behind it or a retry would append the
+				// failed entry after messages that originally followed it.
+				persistenceBlocked = true;
 				remaining.push(pending);
 				errors.push(error);
 				continue;
 			}
 
+			persisted.push("command" in pending.message ? pending.message.command : pending.message.code);
 			try {
 				pending.onPersisted?.();
 			} catch (error) {
@@ -16633,7 +16663,11 @@ export class AgentSession {
 			callbackFailureCount > 0
 				? `; ${callbackFailureCount} onPersisted callback${callbackFailureCount === 1 ? "" : "s"} failed`
 				: "";
-		throw new AggregateError(errors, `${persistenceSummary}${callbackSummary}`);
+		const pending = remaining.map(item => ("command" in item.message ? item.message.command : item.message.code));
+		throw new AggregateError(
+			errors,
+			`${persistenceSummary}${callbackSummary}; persisted: ${JSON.stringify(persisted)}; pending: ${JSON.stringify(pending)}`,
+		);
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2604,6 +2604,13 @@ export class AgentSession {
 		if (this.#promptInFlightCount === 0) {
 			this.#releasePowerAssertion();
 			this.#refreshTeamWorkerHeartbeat();
+			// The turn is over, so nothing can split a tool_use/tool_result pair any
+			// more: a `!`/`$` block that finished mid-stream must own its place in
+			// agent state and the session now, not at the next prompt. Until it does,
+			// the TUI shows output the transcript lacks and `onPersisted` stays unfired,
+			// so a rebuild in that gap drops the only rendering of the execution.
+			this.#flushPendingBashMessages();
+			this.#flushPendingPythonMessages();
 			this.#flushPendingBackgroundExchanges();
 			this.#flushPendingAgentEnd();
 		}

--- a/packages/coding-agent/test/agent-session-deferred-shell-flush.test.ts
+++ b/packages/coding-agent/test/agent-session-deferred-shell-flush.test.ts
@@ -177,6 +177,57 @@ describe("deferred shell execution publication boundary", () => {
 		expect(persistedShellMessages(harness.sessionManager, "pythonExecution")).toHaveLength(1);
 		expect(harness.session.hasPendingPythonMessages).toBe(false);
 	});
+	it("reports partial publication and retries persistence without duplicating agent state", async () => {
+		const harness = createHarness(sessions);
+		const first = await harness.startTurn("hello");
+
+		const persistedCalls: string[] = [];
+		harness.session.recordBashResult("printf retry", shellResult("retry"), {
+			onPersisted: () => persistedCalls.push("bash"),
+		});
+		harness.session.recordPythonResult("print('still flushes')", shellResult("python"), {
+			onPersisted: () => persistedCalls.push("python"),
+		});
+		await harness.session.respondAsBackground({ from: "0-Main", message: "ping", awaitReply: false });
+
+		const appendMessage = harness.sessionManager.appendMessage.bind(harness.sessionManager);
+		let failBashOnce = true;
+		vi.spyOn(harness.sessionManager, "appendMessage").mockImplementation(message => {
+			if (message.role === "bashExecution" && failBashOnce) {
+				failBashOnce = false;
+				throw new Error("transient bash persistence failure");
+			}
+			return appendMessage(message);
+		});
+
+		first.turn.finish();
+		await expect(first.prompt).rejects.toThrow(
+			"Failed to persist 1 of 1 deferred bash execution message; 0 persisted, failed messages remain pending for retry",
+		);
+
+		expect(shellMessages(harness.agent.state.messages, "bashExecution")).toHaveLength(1);
+		expect(persistedShellMessages(harness.sessionManager, "bashExecution")).toHaveLength(0);
+		expect(harness.session.hasPendingBashMessages).toBe(true);
+
+		expect(shellMessages(harness.agent.state.messages, "pythonExecution")).toHaveLength(1);
+		expect(persistedShellMessages(harness.sessionManager, "pythonExecution")).toHaveLength(1);
+		expect(harness.session.hasPendingPythonMessages).toBe(false);
+		expect(persistedCalls).toEqual(["python"]);
+		expect(
+			harness.agent.state.messages.filter(
+				message => message.role === "custom" && String(message.customType).startsWith("irc:"),
+			),
+		).toHaveLength(1);
+
+		const second = await harness.startTurn("again");
+		second.turn.finish();
+		await second.prompt;
+
+		expect(shellMessages(harness.agent.state.messages, "bashExecution")).toHaveLength(1);
+		expect(persistedShellMessages(harness.sessionManager, "bashExecution")).toHaveLength(1);
+		expect(harness.session.hasPendingBashMessages).toBe(false);
+		expect(persistedCalls).toEqual(["python", "bash"]);
+	});
 
 	it("does not republish a turn-end-published block on the following prompt", async () => {
 		const harness = createHarness(sessions);

--- a/packages/coding-agent/test/agent-session-deferred-shell-flush.test.ts
+++ b/packages/coding-agent/test/agent-session-deferred-shell-flush.test.ts
@@ -119,6 +119,14 @@ function persistedShellMessages(
 		.map(entry => (entry as { message: AgentMessage }).message)
 		.filter(message => message.role === role);
 }
+function bashCommands(messages: readonly AgentMessage[]): string[] {
+	return messages
+		.filter(
+			(message): message is AgentMessage & { role: "bashExecution"; command: string } =>
+				message.role === "bashExecution",
+		)
+		.map(message => message.command);
+}
 
 describe("deferred shell execution publication boundary", () => {
 	const sessions: AgentSession[] = [];
@@ -202,7 +210,7 @@ describe("deferred shell execution publication boundary", () => {
 
 		first.turn.finish();
 		await expect(first.prompt).rejects.toThrow(
-			"Failed to persist 1 of 1 deferred bash execution message; 0 persisted, failed messages remain pending for retry",
+			'Failed to persist 1 of 1 deferred bash execution message; 0 persisted, failed messages remain pending for retry; persisted: []; pending: ["printf retry"]',
 		);
 
 		expect(shellMessages(harness.agent.state.messages, "bashExecution")).toHaveLength(1);
@@ -229,6 +237,107 @@ describe("deferred shell execution publication boundary", () => {
 		expect(persistedCalls).toEqual(["python", "bash"]);
 	});
 
+	it("retries failed bash blocks without reordering the persisted transcript", async () => {
+		const harness = createHarness(sessions);
+		const first = await harness.startTurn("hello");
+
+		for (let index = 1; index <= 5; index++) {
+			harness.session.recordBashResult(`cmd${index}`, shellResult(`out${index}`), {});
+		}
+
+		const appendMessage = harness.sessionManager.appendMessage.bind(harness.sessionManager);
+		let failCmd3Once = true;
+		vi.spyOn(harness.sessionManager, "appendMessage").mockImplementation(message => {
+			if (message.role === "bashExecution" && message.command === "cmd3" && failCmd3Once) {
+				failCmd3Once = false;
+				throw new Error("transient cmd3 persistence failure");
+			}
+			return appendMessage(message);
+		});
+
+		first.turn.finish();
+		await expect(first.prompt).rejects.toThrow(
+			'Failed to persist 3 of 5 deferred bash execution messages; 2 persisted, failed messages remain pending for retry; persisted: ["cmd1","cmd2"]; pending: ["cmd3","cmd4","cmd5"]',
+		);
+
+		expect(bashCommands(harness.agent.state.messages)).toEqual(["cmd1", "cmd2", "cmd3", "cmd4", "cmd5"]);
+		expect(bashCommands(persistedShellMessages(harness.sessionManager, "bashExecution"))).toEqual(["cmd1", "cmd2"]);
+
+		const second = await harness.startTurn("again");
+		second.turn.finish();
+		await second.prompt;
+
+		expect(bashCommands(harness.agent.state.messages)).toEqual(["cmd1", "cmd2", "cmd3", "cmd4", "cmd5"]);
+		expect(bashCommands(persistedShellMessages(harness.sessionManager, "bashExecution"))).toEqual([
+			"cmd1",
+			"cmd2",
+			"cmd3",
+			"cmd4",
+			"cmd5",
+		]);
+	});
+
+	it("preserves bash block order across multiple persistence failures", async () => {
+		const harness = createHarness(sessions);
+		const first = await harness.startTurn("hello");
+
+		for (let index = 1; index <= 5; index++) {
+			harness.session.recordBashResult(`cmd${index}`, shellResult(`out${index}`), {});
+		}
+
+		const appendMessage = harness.sessionManager.appendMessage.bind(harness.sessionManager);
+		const remainingFailures = new Set(["cmd2", "cmd4"]);
+		vi.spyOn(harness.sessionManager, "appendMessage").mockImplementation(message => {
+			if (message.role === "bashExecution" && remainingFailures.delete(message.command)) {
+				throw new Error(`transient ${message.command} persistence failure`);
+			}
+			return appendMessage(message);
+		});
+
+		first.turn.finish();
+		await expect(first.prompt).rejects.toThrow(
+			'Failed to persist 4 of 5 deferred bash execution messages; 1 persisted, failed messages remain pending for retry; persisted: ["cmd1"]; pending: ["cmd2","cmd3","cmd4","cmd5"]',
+		);
+
+		await expect(harness.session.prompt("again")).rejects.toThrow(
+			'Failed to persist 2 of 4 deferred bash execution messages; 2 persisted, failed messages remain pending for retry; persisted: ["cmd2","cmd3"]; pending: ["cmd4","cmd5"]',
+		);
+
+		const third = await harness.startTurn("again");
+		third.turn.finish();
+		await third.prompt;
+
+		expect(bashCommands(harness.agent.state.messages)).toEqual(["cmd1", "cmd2", "cmd3", "cmd4", "cmd5"]);
+		expect(bashCommands(persistedShellMessages(harness.sessionManager, "bashExecution"))).toEqual([
+			"cmd1",
+			"cmd2",
+			"cmd3",
+			"cmd4",
+			"cmd5",
+		]);
+	});
+
+	it("publishes agent_end before a deferred persistence rejection settles", async () => {
+		const harness = createHarness(sessions);
+		const events: string[] = [];
+		harness.session.subscribe(event => events.push(event.type));
+		const first = await harness.startTurn("hello");
+		harness.session.recordBashResult("cmd1", shellResult("out1"), {});
+
+		const appendMessage = harness.sessionManager.appendMessage.bind(harness.sessionManager);
+		vi.spyOn(harness.sessionManager, "appendMessage").mockImplementation(message => {
+			if (message.role === "bashExecution") throw new Error("transient persistence failure");
+			return appendMessage(message);
+		});
+
+		first.turn.finish();
+		await expect(first.prompt).rejects.toThrow(
+			'Failed to persist 1 of 1 deferred bash execution message; 0 persisted, failed messages remain pending for retry; persisted: []; pending: ["cmd1"]',
+		);
+
+		expect(events.at(-1)).toBe("agent_end");
+		expect(events.indexOf("turn_end")).toBeLessThan(events.indexOf("agent_end"));
+	});
 	it("does not republish a turn-end-published block on the following prompt", async () => {
 		const harness = createHarness(sessions);
 		const first = await harness.startTurn("hello");

--- a/packages/coding-agent/test/agent-session-deferred-shell-flush.test.ts
+++ b/packages/coding-agent/test/agent-session-deferred-shell-flush.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Regression coverage for the deferred `!`/`$` publication boundary (PR #4039).
+ *
+ * A shell block submitted while the agent is streaming is deferred so it cannot
+ * split a tool_use/tool_result pair. The deferral must end when that turn ends:
+ * `AgentSession.prompt()` resolving is the point where the block's output has to
+ * own a place in agent state and in the session. Holding it until the *next*
+ * prompt leaves the TUI showing output the transcript does not have, and leaves
+ * `onPersisted` (the signal a transcript rebuild uses to decide whether the live
+ * block or the session row renders the execution) unfired for the whole gap.
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { Agent, type AgentMessage } from "@gajae-code/agent-core";
+import type { Model } from "@gajae-code/ai";
+import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import type { PythonResult } from "@gajae-code/coding-agent/eval/py/executor";
+import type { BashResult } from "@gajae-code/coding-agent/exec/bash-executor";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { createAssistantMessage } from "./helpers/agent-session-setup";
+
+const model: Model = {
+	id: "deferred-shell-model",
+	name: "deferred-shell-model",
+	provider: "mock",
+	api: "mock",
+	baseUrl: "mock://",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 32_768,
+};
+
+function shellResult(output: string): BashResult & PythonResult {
+	return {
+		output,
+		exitCode: 0,
+		cancelled: false,
+		truncated: false,
+		totalLines: 1,
+		totalBytes: output.length,
+		outputLines: 1,
+		outputBytes: output.length,
+		displayOutputs: [],
+		stdinRequested: false,
+	};
+}
+
+interface Turn {
+	/** Resolves once the model stream has opened and the session reports streaming. */
+	readonly started: Promise<void>;
+	/** Ends the model stream, letting the turn tear down. */
+	finish(): void;
+}
+
+interface Harness {
+	session: AgentSession;
+	agent: Agent;
+	sessionManager: SessionManager;
+	/** Starts a turn and waits until the stream is open. */
+	startTurn(text: string): Promise<{ prompt: Promise<void>; turn: Turn }>;
+}
+
+function createHarness(sessions: AgentSession[]): Harness {
+	let pendingTurn: { started: PromiseWithResolvers<void>; finish: PromiseWithResolvers<void> } | undefined;
+	const agent = new Agent({
+		getApiKey: () => "test-key",
+		initialState: { model, systemPrompt: ["system prompt"], messages: [], tools: [] },
+		streamFn: () => {
+			const turn = pendingTurn;
+			const stream = new AssistantMessageEventStream();
+			void (async () => {
+				stream.push({ type: "start", partial: createAssistantMessage("") });
+				turn?.started.resolve();
+				await turn?.finish.promise;
+				stream.push({ type: "done", reason: "stop", message: createAssistantMessage("done") });
+			})();
+			return stream;
+		},
+	});
+	const sessionManager = SessionManager.inMemory();
+	const session = new AgentSession({
+		agent,
+		sessionManager,
+		settings: Settings.isolated({ "compaction.enabled": false }),
+		modelRegistry: { getApiKey: async () => "test-key" } as never,
+	});
+	sessions.push(session);
+
+	return {
+		session,
+		agent,
+		sessionManager,
+		startTurn: async (text: string) => {
+			const started = Promise.withResolvers<void>();
+			const finish = Promise.withResolvers<void>();
+			pendingTurn = { started, finish };
+			const prompt = session.prompt(text);
+			await started.promise;
+			expect(session.isStreaming).toBe(true);
+			return { prompt, turn: { started: started.promise, finish: () => finish.resolve() } };
+		},
+	};
+}
+
+function shellMessages(messages: readonly AgentMessage[], role: "bashExecution" | "pythonExecution"): AgentMessage[] {
+	return messages.filter(message => message.role === role);
+}
+
+function persistedShellMessages(
+	sessionManager: SessionManager,
+	role: "bashExecution" | "pythonExecution",
+): AgentMessage[] {
+	return sessionManager
+		.getEntries()
+		.filter(entry => entry.type === "message")
+		.map(entry => (entry as { message: AgentMessage }).message)
+		.filter(message => message.role === role);
+}
+
+describe("deferred shell execution publication boundary", () => {
+	const sessions: AgentSession[] = [];
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		for (const session of sessions.splice(0)) {
+			await session.dispose();
+		}
+	});
+
+	it("publishes a bash block that completed mid-stream when that same turn ends", async () => {
+		const harness = createHarness(sessions);
+		const { prompt, turn } = await harness.startTurn("hello");
+
+		const persistedCalls: string[] = [];
+		harness.session.recordBashResult("printf mid", shellResult("mid"), {
+			onPersisted: () => persistedCalls.push("printf mid"),
+		});
+
+		// Still streaming: publishing here would split the in-flight turn's messages.
+		expect(shellMessages(harness.agent.state.messages, "bashExecution")).toHaveLength(0);
+		expect(persistedCalls).toEqual([]);
+
+		turn.finish();
+		await prompt;
+
+		// The turn is over. The output the user already saw must now be transcript.
+		expect(persistedCalls).toEqual(["printf mid"]);
+		const inAgentState = shellMessages(harness.agent.state.messages, "bashExecution");
+		expect(inAgentState).toHaveLength(1);
+		expect(inAgentState[0]).toMatchObject({ command: "printf mid", output: "mid", exitCode: 0 });
+		expect(persistedShellMessages(harness.sessionManager, "bashExecution")).toHaveLength(1);
+		expect(harness.session.hasPendingBashMessages).toBe(false);
+	});
+
+	it("publishes a python block that completed mid-stream when that same turn ends", async () => {
+		const harness = createHarness(sessions);
+		const { prompt, turn } = await harness.startTurn("hello");
+
+		const persistedCalls: string[] = [];
+		harness.session.recordPythonResult("print('mid')", shellResult("mid"), {
+			onPersisted: () => persistedCalls.push("print('mid')"),
+		});
+
+		expect(shellMessages(harness.agent.state.messages, "pythonExecution")).toHaveLength(0);
+		expect(persistedCalls).toEqual([]);
+
+		turn.finish();
+		await prompt;
+
+		expect(persistedCalls).toEqual(["print('mid')"]);
+		const inAgentState = shellMessages(harness.agent.state.messages, "pythonExecution");
+		expect(inAgentState).toHaveLength(1);
+		expect(inAgentState[0]).toMatchObject({ code: "print('mid')", output: "mid", exitCode: 0 });
+		expect(persistedShellMessages(harness.sessionManager, "pythonExecution")).toHaveLength(1);
+		expect(harness.session.hasPendingPythonMessages).toBe(false);
+	});
+
+	it("does not republish a turn-end-published block on the following prompt", async () => {
+		const harness = createHarness(sessions);
+		const first = await harness.startTurn("hello");
+
+		harness.session.recordBashResult("printf once", shellResult("once"), {});
+		first.turn.finish();
+		await first.prompt;
+		expect(shellMessages(harness.agent.state.messages, "bashExecution")).toHaveLength(1);
+
+		const second = await harness.startTurn("again");
+		second.turn.finish();
+		await second.prompt;
+
+		expect(shellMessages(harness.agent.state.messages, "bashExecution")).toHaveLength(1);
+		expect(persistedShellMessages(harness.sessionManager, "bashExecution")).toHaveLength(1);
+	});
+
+	it("publishes a block recorded after the turn already ended immediately", async () => {
+		const harness = createHarness(sessions);
+		const { prompt, turn } = await harness.startTurn("hello");
+		turn.finish();
+		await prompt;
+
+		const persistedCalls: string[] = [];
+		harness.session.recordBashResult("printf late", shellResult("late"), {
+			onPersisted: () => persistedCalls.push("printf late"),
+		});
+
+		expect(persistedCalls).toEqual(["printf late"]);
+		expect(shellMessages(harness.agent.state.messages, "bashExecution")).toHaveLength(1);
+		expect(persistedShellMessages(harness.sessionManager, "bashExecution")).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
Follow-up to #4039, from the post-merge audit in #4063.

## The defect

A deferred bash or python block that finished while the agent was still streaming was moved into chat, but its session message stayed queued until the following turn. The user saw the output; the agent's own transcript did not have it, so the agent answered as though the command had never run.

## The two things that fixing it exposed

Publishing at completion made the flush non-atomic: a transient `SessionManager.appendMessage()` failure rejected the completed prompt while items it had already appended stayed in the session, so the prompt reported failure for work that partly landed.

Append-and-report was chosen over all-or-nothing. Buffering until everything can commit would discard output the user has already watched scroll past, which is the defect this change exists to fix — so partial writes are allowed and the outcome names exactly what landed.

The retry then re-appended the failed item at the current session leaf, so the persisted order diverged from what the user saw. That is subtler than dropping: every block is present, so nothing looks lost, while the agent's next turn reads back a sequence that never happened and reasons over it as fact. A retried item is restored at its original position.

## Verification

`bun test agent-session-deferred-shell-flush.test.ts agent-session-deferred-shell.test.ts` — 8 pass, 0 fail. `bun --cwd=packages/coding-agent run check` — exit 0.

Reverting `agent-session.ts` to `dev` fails 4 tests behaviorally: bash and python blocks completing mid-stream, no republish after a turn-end publication, and five queued blocks with `appendMessage` throwing once on `cmd3` keeping their order.

## Known and not fixed

A failure during the reordering itself is untested.
