### PR TITLE
fix(sdk): log why a prompt terminal failed, since the wire text cannot say

### DIFF
--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -173,6 +173,7 @@ type PromptTerminalExtra = {
 	finalText?: string;
 	error?: { code: string; message: string };
 	diagnostic?: PromptTerminalDiagnostic;
+	diagnosticAlreadyLogged?: boolean;
 };
 
 function formatPromptTerminalFailureReason(reason: unknown): string {
@@ -4466,7 +4467,11 @@ export function createNotificationsExtension(
 			}
 			if (submission.deadlineTimer) clearTimeout(submission.deadlineTimer);
 			if (!recordPromptTerminal(correlation) || !runtime) return;
-			if (winner.kind === "failed" && extra?.diagnostic?.intentionalCancellation !== true) {
+			if (
+				winner.kind === "failed" &&
+				extra?.diagnostic?.intentionalCancellation !== true &&
+				extra?.diagnosticAlreadyLogged !== true
+			) {
 				const diagnostic = extra?.diagnostic;
 				logger.error("sdk_prompt_terminal_failed", {
 					sessionId: id,
@@ -4505,18 +4510,29 @@ export function createNotificationsExtension(
 				error: formatPromptFailureForLocalLog(error),
 			});
 			const sanitized = sanitizePromptFailure(error);
+			const outcome: SdkPromptTerminalOutcome = {
+				kind: "failed",
+				code: "prompt_failed",
+				message: sanitized.message,
+				provenance: "agent_failed",
+			};
+			// This rejection bypasses `agent_end`, so record its local-only reason at
+			// the accepted submission failure boundary before terminalization begins.
+			logger.error("sdk_prompt_terminal_failed", {
+				sessionId: id,
+				commandId: correlation.commandId,
+				turnId: correlation.turnId,
+				code: outcome.code,
+				provenance: outcome.provenance,
+				reason: formatPromptTerminalFailureReason(error),
+			});
 			void terminalizePrompt(
 				correlation,
-				{
-					kind: "failed",
-					code: "prompt_failed",
-					message: sanitized.message,
-					provenance: "agent_failed",
-				},
+				outcome,
 				{},
-				// The raw reason is local-only diagnostic input. The normalized outcome
-				// and wire error retain the fixed safe token required by SDK/ACP.
-				{ error: sanitized, diagnostic: { reason: error } },
+				// The normalized outcome and wire error retain the fixed safe token.
+				// Mark the diagnostic as recorded so terminalization does not duplicate it.
+				{ error: sanitized, diagnostic: { reason: error }, diagnosticAlreadyLogged: true },
 			);
 		};
 		const recordPromptFailure = (correlation: { commandId: string; turnId: string }, error: unknown) => {

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -161,6 +161,33 @@ const PROMPT_SETTLEMENT_DIAGNOSTIC_MAX_AGE_MS = 86_400_000;
  * provider error cannot flood the log file.
  */
 const PROMPT_TERMINAL_FAILURE_REASON_LOG_MAX = 512;
+type PromptTerminalDiagnostic = {
+	reason?: unknown;
+	loopStopReason?: string;
+	assistantStopReason?: string;
+	errorKind?: string;
+	intentionalCancellation?: boolean;
+};
+
+type PromptTerminalExtra = {
+	finalText?: string;
+	error?: { code: string; message: string };
+	diagnostic?: PromptTerminalDiagnostic;
+};
+
+function formatPromptTerminalFailureReason(reason: unknown): string {
+	let rawReason: string;
+	if (reason instanceof Error) rawReason = reason.message;
+	else if (typeof reason === "string") rawReason = reason;
+	else if (reason === undefined || reason === null) return "unreported";
+	else
+		try {
+			rawReason = String(reason);
+		} catch {
+			return "unreported";
+		}
+	return rawReason ? rawReason.slice(0, PROMPT_TERMINAL_FAILURE_REASON_LOG_MAX) : "unreported";
+}
 
 export function formatPromptSettlementDiagnostic(
 	proof: Extract<RunSettlementProof, { status: "unfenced" }>,
@@ -1202,11 +1229,8 @@ interface SessionRuntime {
 	terminalizePrompt: (
 		correlation: { commandId: string; turnId: string },
 		outcome: SdkPromptTerminalOutcome,
-		extra?: { finalText?: string },
+		extra?: PromptTerminalExtra,
 	) => Promise<void>;
-	/** Records a correlated prompt terminal boundary after agent unwind. */
-	/** Atomically claims a correlated prompt terminal boundary after agent unwind. */
-	recordPromptTerminal: (correlation: { commandId: string; turnId: string } | undefined) => boolean;
 	/** Transitions the authoritative reconciliation record at lifecycle ingress; terminal outcomes settle once. */
 	notePromptReconciliation: (
 		correlation: { commandId: string; turnId: string } | undefined,
@@ -4283,6 +4307,7 @@ export function createNotificationsExtension(
 						provenance: "deadline",
 					},
 					{ fence: true },
+					{ diagnostic: { reason: "Prompt deadline exceeded." } },
 				);
 			}, submission.deadlineMs);
 		};
@@ -4369,7 +4394,7 @@ export function createNotificationsExtension(
 			// run and prove settlement. A natural `agent_end`/`agent_failed` already unwound,
 			// so aborting there would cancel the next turn instead of fencing this one.
 			options: { fence?: boolean } = {},
-			extra?: { finalText?: string; error?: { code: string; message: string } },
+			extra?: PromptTerminalExtra,
 		) => {
 			const submission = promptSubmissions.get(promptSubmissionKey(correlation));
 			if (!submission || submission.terminal || submission.phase !== "active") return;
@@ -4441,6 +4466,20 @@ export function createNotificationsExtension(
 			}
 			if (submission.deadlineTimer) clearTimeout(submission.deadlineTimer);
 			if (!recordPromptTerminal(correlation) || !runtime) return;
+			if (winner.kind === "failed" && extra?.diagnostic?.intentionalCancellation !== true) {
+				const diagnostic = extra?.diagnostic;
+				logger.error("sdk_prompt_terminal_failed", {
+					sessionId: id,
+					commandId: correlation.commandId,
+					turnId: correlation.turnId,
+					code: winner.code,
+					provenance: winner.provenance,
+					...(diagnostic?.loopStopReason ? { loopStopReason: diagnostic.loopStopReason } : {}),
+					...(diagnostic?.assistantStopReason ? { assistantStopReason: diagnostic.assistantStopReason } : {}),
+					...(diagnostic?.errorKind ? { errorKind: diagnostic.errorKind } : {}),
+					reason: formatPromptTerminalFailureReason(diagnostic?.reason),
+				});
+			}
 			if (winner.kind === "failed") {
 				emitPromptLifecycle(correlation, {
 					type: "agent_failed",
@@ -4475,9 +4514,9 @@ export function createNotificationsExtension(
 					provenance: "agent_failed",
 				},
 				{},
-				// The normalized outcome is the ACP contract; the wire error keeps the
-				// existing sanitized discriminator so SDK clients keep branching on it.
-				{ error: sanitized },
+				// The raw reason is local-only diagnostic input. The normalized outcome
+				// and wire error retain the fixed safe token required by SDK/ACP.
+				{ error: sanitized, diagnostic: { reason: error } },
 			);
 		};
 		const recordPromptFailure = (correlation: { commandId: string; turnId: string }, error: unknown) => {
@@ -4913,7 +4952,6 @@ export function createNotificationsExtension(
 			bindPromptExecutionHandle,
 			peekPromptPendingOutcome: correlation => kindReconciliation.peekPendingOutcome(correlation),
 			terminalizePrompt: (correlation, outcome, extra) => terminalizePrompt(correlation, outcome, {}, extra),
-			recordPromptTerminal,
 			notePromptReconciliation: (correlation, frame) => {
 				void kindReconciliation.noteTransition("prompt", correlation, frame);
 			},
@@ -6321,24 +6359,23 @@ export function createNotificationsExtension(
 							: undefined;
 			// The SDK wire outcome and ACP error envelope use a fixed safe token by
 			// contract (see `sanitizePromptFailure`). Assistant failure messages may
-			// still remain in the local session transcript; this bounded operator log
-			// preserves diagnostics without widening the SDK/ACP redaction boundary.
-			// Client cancellation is intent, not a defect, so it is not logged as an error.
-			if (outcome.kind === "failed" && event.stopReason !== "cancelled") {
-				const rawReason = typeof terminalAssistant?.errorMessage === "string" ? terminalAssistant.errorMessage : "";
-				const errorKind = typeof terminalAssistant?.errorKind === "string" ? terminalAssistant.errorKind : "";
-				logger.error("sdk_prompt_terminal_failed", {
-					sessionId: id,
-					commandId: correlation.commandId,
-					turnId: correlation.turnId,
-					loopStopReason: event.stopReason ?? "none",
-					assistantStopReason: terminalAssistant?.stopReason ?? "none",
-					...(errorKind ? { errorKind } : {}),
-					reason: rawReason ? rawReason.slice(0, PROMPT_TERMINAL_FAILURE_REASON_LOG_MAX) : "unreported",
-				});
-			}
+			// still remain in the local session transcript; terminalization copies only
+			// a bounded reason into the local operator log.
 			void rt.terminalizePrompt(correlation, outcome, {
 				...(finalText ? { finalText } : {}),
+				...(outcome.kind === "failed"
+					? {
+							diagnostic: {
+								reason: terminalAssistant?.errorMessage,
+								loopStopReason: event.stopReason ?? "none",
+								assistantStopReason: terminalAssistant?.stopReason ?? "none",
+								...(event.stopReason === "cancelled" ? { intentionalCancellation: true } : {}),
+								...(typeof terminalAssistant?.errorKind === "string"
+									? { errorKind: terminalAssistant.errorKind }
+									: {}),
+							},
+						}
+					: {}),
 				...(outcome.kind === "failed" && legacyCode
 					? {
 							// Only the legacy discriminator is preserved; provider text is never

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -155,6 +155,12 @@ export {
 
 const PROMPT_SETTLEMENT_DIAGNOSTIC_ENTRY_LIMIT = 8;
 const PROMPT_SETTLEMENT_DIAGNOSTIC_MAX_AGE_MS = 86_400_000;
+/**
+ * Upper bound on the failure reason copied into the local operator log. Mirrors
+ * the 512-char bound documented for reconciliation failure messages so a runaway
+ * provider error cannot flood the log file.
+ */
+const PROMPT_TERMINAL_FAILURE_REASON_LOG_MAX = 512;
 
 export function formatPromptSettlementDiagnostic(
 	proof: Extract<RunSettlementProof, { status: "unfenced" }>,
@@ -6304,7 +6310,7 @@ export function createNotificationsExtension(
 				message =>
 					(message as { stopReason?: unknown }).stopReason === "error" ||
 					(message as { stopReason?: unknown }).stopReason === "aborted",
-			) as { stopReason?: "error" | "aborted"; errorMessage?: unknown } | undefined;
+			) as { stopReason?: "error" | "aborted"; errorMessage?: unknown; errorKind?: unknown } | undefined;
 			const legacyCode =
 				event.stopReason === "cancelled"
 					? "cancelled"
@@ -6313,6 +6319,24 @@ export function createNotificationsExtension(
 						: terminalAssistant?.stopReason === "aborted"
 							? "aborted"
 							: undefined;
+			// The wire outcome is a fixed safe token by contract (see `sanitizePromptFailure`):
+			// SDK clients, the ACP `-32603` envelope, and therefore every lane transcript only
+			// ever see "Prompt submission failed." This local log is the ONLY place the reason
+			// a turn died survives, so a turn that ends with no visible error stays diagnosable.
+			// Client cancellation is intent, not a defect, so it is not logged as an error.
+			if (outcome.kind === "failed" && event.stopReason !== "cancelled") {
+				const rawReason = typeof terminalAssistant?.errorMessage === "string" ? terminalAssistant.errorMessage : "";
+				const errorKind = typeof terminalAssistant?.errorKind === "string" ? terminalAssistant.errorKind : "";
+				logger.error("sdk_prompt_terminal_failed", {
+					sessionId: id,
+					commandId: correlation.commandId,
+					turnId: correlation.turnId,
+					loopStopReason: event.stopReason ?? "none",
+					assistantStopReason: terminalAssistant?.stopReason ?? "none",
+					...(errorKind ? { errorKind } : {}),
+					reason: rawReason ? rawReason.slice(0, PROMPT_TERMINAL_FAILURE_REASON_LOG_MAX) : "unreported",
+				});
+			}
 			void rt.terminalizePrompt(correlation, outcome, {
 				...(finalText ? { finalText } : {}),
 				...(outcome.kind === "failed" && legacyCode

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -6319,10 +6319,10 @@ export function createNotificationsExtension(
 						: terminalAssistant?.stopReason === "aborted"
 							? "aborted"
 							: undefined;
-			// The wire outcome is a fixed safe token by contract (see `sanitizePromptFailure`):
-			// SDK clients, the ACP `-32603` envelope, and therefore every lane transcript only
-			// ever see "Prompt submission failed." This local log is the ONLY place the reason
-			// a turn died survives, so a turn that ends with no visible error stays diagnosable.
+			// The SDK wire outcome and ACP error envelope use a fixed safe token by
+			// contract (see `sanitizePromptFailure`). Assistant failure messages may
+			// still remain in the local session transcript; this bounded operator log
+			// preserves diagnostics without widening the SDK/ACP redaction boundary.
 			// Client cancellation is intent, not a defect, so it is not logged as an error.
 			if (outcome.kind === "failed" && event.stopReason !== "cancelled") {
 				const rawReason = typeof terminalAssistant?.errorMessage === "string" ? terminalAssistant.errorMessage : "";

--- a/packages/coding-agent/test/sdk-prompt-terminal-diagnostics.test.ts
+++ b/packages/coding-agent/test/sdk-prompt-terminal-diagnostics.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, expect, spyOn, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { logger } from "@gajae-code/utils";
+import { brokerOwnerForTest } from "../src/sdk/broker/ensure";
+import { createNotificationsExtension } from "../src/sdk/bus";
+
+/**
+ * A turn that dies abnormally publishes a terminal whose wire text is the fixed
+ * safe token "Prompt submission failed." (see `sanitizePromptFailure`), so an ACP
+ * client can only render `-32603 ... {"code":"prompt_failed"}` and a lane whose
+ * transport lost even that frame shows a turn that simply ended: no error, no
+ * edit, nothing to act on. The reason a turn died must therefore survive in the
+ * local operator log, including for loop-level terminals that carry no legacy
+ * discriminator and no assistant message at all.
+ */
+
+const dirs: string[] = [];
+const sockets: WebSocket[] = [];
+
+afterEach(async () => {
+	await Promise.all(sockets.splice(0).map(closeSocket));
+	for (const dir of dirs) await brokerOwnerForTest(dir)?.stop();
+	for (const dir of dirs.splice(0)) await fs.promises.rm(dir, { recursive: true, force: true });
+});
+
+async function closeSocket(socket: WebSocket): Promise<void> {
+	if (socket.readyState === WebSocket.CLOSED) return;
+	const { promise, resolve } = Promise.withResolvers<void>();
+	socket.addEventListener("close", () => resolve(), { once: true });
+	socket.close();
+	await Promise.race([promise, Bun.sleep(500)]);
+}
+
+async function waitFor(predicate: () => boolean, label: string): Promise<void> {
+	const deadline = Date.now() + 15_000;
+	while (!predicate()) {
+		if (Date.now() > deadline) throw new Error(`Timed out waiting for ${label}`);
+		await Bun.sleep(20);
+	}
+}
+
+function context(cwd: string, sessionId: string): Record<string, unknown> {
+	return {
+		cwd,
+		sessionMetadata: { kind: "main", taskDepth: 0 },
+		sessionManager: {
+			getSessionId: () => sessionId,
+			getCwd: () => cwd,
+			getSessionName: () => "prompt terminal diagnostics",
+			getUsageStatistics: () => ({ input: 1, output: 2, cacheRead: 0, cacheWrite: 0, premiumRequests: 0, cost: 0 }),
+			getBranch: () => [],
+		},
+		getContextUsage: () => ({ tokens: 3, contextWindow: 100, percent: 3 }),
+		model: { provider: "fixture-provider", id: "fixture-model" },
+		getThinkingLevel: () => "low",
+		getActivePromptHandle: () => undefined,
+		getSystemPrompt: () => ["test"],
+		isIdle: () => true,
+		hasPendingMessages: () => false,
+		getPendingMessageCounts: () => ({ steering: 0, followUp: 0, nextTurn: 0 }),
+		resolveTool: () => undefined,
+	};
+}
+
+function start(ctx: Record<string, unknown>): Map<string, (event: unknown, context: unknown) => unknown> {
+	const handlers = new Map<string, (event: unknown, context: unknown) => unknown>();
+	const api = {
+		on: (event: string, handler: (event: unknown, context: unknown) => unknown) => handlers.set(event, handler),
+		registerCommand: () => {},
+		getThinkingLevel: () => undefined,
+		sendUserMessage: (_content: unknown, options?: Record<string, unknown>) => {
+			const commit = options?.onPreflightAcceptCommit as (() => unknown) | undefined;
+			const accepted = options?.onPreflightAccepted as (() => void) | undefined;
+			if (commit) return Promise.resolve(commit()).then(() => accepted?.());
+			accepted?.();
+			return Promise.resolve(undefined);
+		},
+	} as never;
+	createNotificationsExtension(api, undefined);
+	void handlers.get("session_start")?.({ type: "session_start" }, ctx);
+	return handlers;
+}
+
+test("SDK host logs why a prompt terminal failed even though the wire text is a fixed safe token", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-prompt-terminal-diagnostics-"));
+	dirs.push(cwd);
+	const sessionId = `sdk-prompt-terminal-diagnostics-${Date.now()}`;
+	const sessionContext = context(cwd, sessionId);
+	const handlers = start(sessionContext);
+	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+
+	const frames: Record<string, unknown>[] = [];
+	const socket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	sockets.push(socket);
+	socket.addEventListener("message", event => frames.push(JSON.parse(String(event.data))));
+	await new Promise<void>((resolve, reject) => {
+		socket.addEventListener("open", () => resolve(), { once: true });
+		socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+	});
+
+	const diagnostics: Record<string, unknown>[] = [];
+	const errorSpy = spyOn(logger, "error").mockImplementation((...args: unknown[]) => {
+		if (args[0] === "sdk_prompt_terminal_failed") diagnostics.push(args[1] as Record<string, unknown>);
+	});
+
+	const submit = async (requestId: string): Promise<{ commandId: unknown; turnId: unknown }> => {
+		socket.send(
+			JSON.stringify({
+				type: "control_request",
+				id: requestId,
+				operation: "turn.prompt",
+				input: { text: "reproduce the reviewer findings" },
+			}),
+		);
+		await waitFor(
+			() => frames.some(frame => frame.type === "control_response" && frame.id === requestId),
+			`prompt acknowledgement ${requestId}`,
+		);
+		const acknowledgement = frames.find(frame => frame.type === "control_response" && frame.id === requestId) as {
+			result?: { commandId?: unknown; turnId?: unknown };
+		};
+		return { commandId: acknowledgement.result?.commandId, turnId: acknowledgement.result?.turnId };
+	};
+
+	try {
+		// 1. Provider-side turn failure: only the assistant message carries the reason.
+		const first = await submit("failing-prompt");
+		await handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
+		await handlers.get("agent_end")?.(
+			{
+				type: "agent_end",
+				stopReason: "completed",
+				messages: [
+					{
+						role: "assistant",
+						stopReason: "error",
+						errorKind: "provider_error",
+						errorMessage: "Session context exceeds materialization budget (99 > 64 bytes)",
+					},
+				],
+			} as never,
+			sessionContext,
+		);
+		await waitFor(() => frames.some(frame => frame.type === "agent_failed"), "failed prompt terminal");
+
+		// Reproduction: the wire never names the cause, only the fixed safe token.
+		const failure = frames.find(frame => frame.type === "agent_failed") as Record<string, unknown>;
+		expect(failure).toMatchObject({
+			commandId: first.commandId,
+			turnId: first.turnId,
+			error: { code: "agent_error", message: "Prompt submission failed." },
+			outcome: { kind: "failed", code: "prompt_failed", message: "Prompt submission failed." },
+		});
+		expect(JSON.stringify(failure)).not.toContain("materialization budget");
+
+		// The local diagnostic is the only surviving record of why the turn died.
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0]).toMatchObject({
+			sessionId,
+			commandId: first.commandId,
+			turnId: first.turnId,
+			loopStopReason: "completed",
+			assistantStopReason: "error",
+			errorKind: "provider_error",
+			reason: "Session context exceeds materialization budget (99 > 64 bytes)",
+		});
+
+		// 2. Loop-level exhaustion carries no legacy discriminator and no assistant at
+		// all, so without the diagnostic an operator has literally nothing to act on.
+		const second = await submit("exhausted-prompt");
+		await handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
+		await handlers.get("agent_end")?.(
+			{ type: "agent_end", stopReason: "exhausted", messages: [] } as never,
+			sessionContext,
+		);
+		await waitFor(() => diagnostics.length > 1, "exhausted prompt diagnostic");
+		expect(diagnostics[1]).toMatchObject({
+			commandId: second.commandId,
+			turnId: second.turnId,
+			loopStopReason: "exhausted",
+			assistantStopReason: "none",
+			reason: "unreported",
+		});
+		expect(diagnostics[1]).not.toHaveProperty("errorKind");
+	} finally {
+		errorSpy.mockRestore();
+	}
+
+	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
+});
+
+test("SDK host does not log a client cancellation as a prompt terminal failure", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-prompt-terminal-cancel-"));
+	dirs.push(cwd);
+	const sessionId = `sdk-prompt-terminal-cancel-${Date.now()}`;
+	const sessionContext = context(cwd, sessionId);
+	const handlers = start(sessionContext);
+	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+
+	const frames: Record<string, unknown>[] = [];
+	const socket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	sockets.push(socket);
+	socket.addEventListener("message", event => frames.push(JSON.parse(String(event.data))));
+	await new Promise<void>((resolve, reject) => {
+		socket.addEventListener("open", () => resolve(), { once: true });
+		socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+	});
+
+	const diagnostics: unknown[] = [];
+	const errorSpy = spyOn(logger, "error").mockImplementation((...args: unknown[]) => {
+		if (args[0] === "sdk_prompt_terminal_failed") diagnostics.push(args[1]);
+	});
+
+	try {
+		socket.send(
+			JSON.stringify({
+				type: "control_request",
+				id: "cancelled-prompt",
+				operation: "turn.prompt",
+				input: { text: "work the user interrupts" },
+			}),
+		);
+		await waitFor(
+			() => frames.some(frame => frame.type === "control_response" && frame.id === "cancelled-prompt"),
+			"prompt acknowledgement",
+		);
+		await handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
+		await handlers.get("agent_end")?.(
+			{ type: "agent_end", stopReason: "cancelled", messages: [] } as never,
+			sessionContext,
+		);
+		await waitFor(() => frames.some(frame => frame.type === "agent_failed"), "cancelled prompt terminal");
+
+		// A user interrupt is intent, not an undiagnosable defect, so it must not
+		// pollute the operator log with an error for every cancel.
+		expect(diagnostics).toHaveLength(0);
+	} finally {
+		errorSpy.mockRestore();
+	}
+
+	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
+});

--- a/packages/coding-agent/test/sdk-prompt-terminal-diagnostics.test.ts
+++ b/packages/coding-agent/test/sdk-prompt-terminal-diagnostics.test.ts
@@ -2,22 +2,24 @@ import { afterEach, expect, spyOn, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { Agent, type AgentEvent } from "@gajae-code/agent-core";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
 import { logger } from "@gajae-code/utils";
+import type { ExtensionActions, ExtensionAPI } from "../src/extensibility/extensions/types";
 import { brokerOwnerForTest } from "../src/sdk/broker/ensure";
 import { createNotificationsExtension } from "../src/sdk/bus";
 
 /**
- * A turn that dies abnormally publishes a terminal whose wire text is the fixed
- * safe token "Prompt submission failed." (see `sanitizePromptFailure`), so an ACP
- * client can only render `-32603 ... {"code":"prompt_failed"}` and a lane whose
- * transport lost even that frame shows a turn that simply ended: no error, no
- * edit, nothing to act on. The reason a turn died must therefore survive in the
- * local operator log, including for loop-level terminals that carry no legacy
- * discriminator and no assistant message at all.
+ * A provider failure reaches this extension as an `agent_end` carrying an error
+ * assistant message. The SDK/ACP failure envelope uses the fixed safe token
+ * "Prompt submission failed." (see `sanitizePromptFailure`), while the assistant
+ * message can remain in the local session transcript. The bounded operator log
+ * keeps that failure diagnosable without widening the SDK/ACP redaction boundary.
  */
 
 const dirs: string[] = [];
 const sockets: WebSocket[] = [];
+type AgentEndEvent = Extract<AgentEvent, { type: "agent_end" }>;
 
 afterEach(async () => {
 	await Promise.all(sockets.splice(0).map(closeSocket));
@@ -64,31 +66,56 @@ function context(cwd: string, sessionId: string): Record<string, unknown> {
 	};
 }
 
-function start(ctx: Record<string, unknown>): Map<string, (event: unknown, context: unknown) => unknown> {
+function start(
+	ctx: Record<string, unknown>,
+	deliverUserMessage: ExtensionActions["sendUserMessage"] = () => undefined,
+): Map<string, (event: unknown, context: unknown) => unknown> {
 	const handlers = new Map<string, (event: unknown, context: unknown) => unknown>();
 	const api = {
 		on: (event: string, handler: (event: unknown, context: unknown) => unknown) => handlers.set(event, handler),
 		registerCommand: () => {},
 		getThinkingLevel: () => undefined,
-		sendUserMessage: (_content: unknown, options?: Record<string, unknown>) => {
-			const commit = options?.onPreflightAcceptCommit as (() => unknown) | undefined;
-			const accepted = options?.onPreflightAccepted as (() => void) | undefined;
-			if (commit) return Promise.resolve(commit()).then(() => accepted?.());
+		sendUserMessage: (
+			content: Parameters<ExtensionActions["sendUserMessage"]>[0],
+			options?: Parameters<ExtensionActions["sendUserMessage"]>[1],
+		) => {
+			const commit = options?.onPreflightAcceptCommit;
+			const accepted = options?.onPreflightAccepted;
+			const deliver = () => Promise.resolve(deliverUserMessage(content));
+			if (commit)
+				return Promise.resolve(commit()).then(() => {
+					accepted?.();
+					return deliver();
+				});
 			accepted?.();
-			return Promise.resolve(undefined);
+			return deliver();
 		},
-	} as never;
+	} as unknown as ExtensionAPI;
 	createNotificationsExtension(api, undefined);
 	void handlers.get("session_start")?.({ type: "session_start" }, ctx);
 	return handlers;
 }
 
-test("SDK host logs why a prompt terminal failed even though the wire text is a fixed safe token", async () => {
+test("SDK host logs a bounded reason from a reachable provider failure", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-prompt-terminal-diagnostics-"));
 	dirs.push(cwd);
 	const sessionId = `sdk-prompt-terminal-diagnostics-${Date.now()}`;
 	const sessionContext = context(cwd, sessionId);
-	const handlers = start(sessionContext);
+	const reason = `Session context exceeds materialization budget (99 > 64 bytes): ${"x".repeat(600)}`;
+	const model = createMockModel({ handler: { throw: new Error(reason) } });
+	const agent = new Agent({
+		initialState: { model, systemPrompt: ["test"], messages: [], tools: [] },
+		streamFn: model.stream,
+		requestMaxRetries: 0,
+		streamMaxRetries: 0,
+	});
+	let handlers!: Map<string, (event: unknown, context: unknown) => unknown>;
+	handlers = start(sessionContext, async () => {
+		await agent.prompt("reproduce the reviewer findings");
+	});
+	const unsubscribe = agent.subscribe(event => {
+		void handlers.get(event.type)?.(event, sessionContext);
+	});
 	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
 	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
 	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
@@ -127,27 +154,12 @@ test("SDK host logs why a prompt terminal failed even though the wire text is a 
 	};
 
 	try {
-		// 1. Provider-side turn failure: only the assistant message carries the reason.
+		// A real provider exception is converted by Agent into an error assistant
+		// and a normal loop terminal; the assistant error makes the SDK terminal fail.
 		const first = await submit("failing-prompt");
-		await handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
-		await handlers.get("agent_end")?.(
-			{
-				type: "agent_end",
-				stopReason: "completed",
-				messages: [
-					{
-						role: "assistant",
-						stopReason: "error",
-						errorKind: "provider_error",
-						errorMessage: "Session context exceeds materialization budget (99 > 64 bytes)",
-					},
-				],
-			} as never,
-			sessionContext,
-		);
 		await waitFor(() => frames.some(frame => frame.type === "agent_failed"), "failed prompt terminal");
 
-		// Reproduction: the wire never names the cause, only the fixed safe token.
+		// The SDK failure envelope never names the cause, only the fixed safe token.
 		const failure = frames.find(frame => frame.type === "agent_failed") as Record<string, unknown>;
 		expect(failure).toMatchObject({
 			commandId: first.commandId,
@@ -157,7 +169,6 @@ test("SDK host logs why a prompt terminal failed even though the wire text is a 
 		});
 		expect(JSON.stringify(failure)).not.toContain("materialization budget");
 
-		// The local diagnostic is the only surviving record of why the turn died.
 		expect(diagnostics).toHaveLength(1);
 		expect(diagnostics[0]).toMatchObject({
 			sessionId,
@@ -165,28 +176,11 @@ test("SDK host logs why a prompt terminal failed even though the wire text is a 
 			turnId: first.turnId,
 			loopStopReason: "completed",
 			assistantStopReason: "error",
-			errorKind: "provider_error",
-			reason: "Session context exceeds materialization budget (99 > 64 bytes)",
+			reason: reason.slice(0, 512),
 		});
-
-		// 2. Loop-level exhaustion carries no legacy discriminator and no assistant at
-		// all, so without the diagnostic an operator has literally nothing to act on.
-		const second = await submit("exhausted-prompt");
-		await handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
-		await handlers.get("agent_end")?.(
-			{ type: "agent_end", stopReason: "exhausted", messages: [] } as never,
-			sessionContext,
-		);
-		await waitFor(() => diagnostics.length > 1, "exhausted prompt diagnostic");
-		expect(diagnostics[1]).toMatchObject({
-			commandId: second.commandId,
-			turnId: second.turnId,
-			loopStopReason: "exhausted",
-			assistantStopReason: "none",
-			reason: "unreported",
-		});
-		expect(diagnostics[1]).not.toHaveProperty("errorKind");
+		expect(diagnostics[0]?.reason).toHaveLength(512);
 	} finally {
+		unsubscribe();
 		errorSpy.mockRestore();
 	}
 
@@ -230,11 +224,9 @@ test("SDK host does not log a client cancellation as a prompt terminal failure",
 			() => frames.some(frame => frame.type === "control_response" && frame.id === "cancelled-prompt"),
 			"prompt acknowledgement",
 		);
+		const cancelled: AgentEndEvent = { type: "agent_end", stopReason: "cancelled", messages: [] };
 		await handlers.get("agent_start")?.({ type: "agent_start" }, sessionContext);
-		await handlers.get("agent_end")?.(
-			{ type: "agent_end", stopReason: "cancelled", messages: [] } as never,
-			sessionContext,
-		);
+		await handlers.get("agent_end")?.(cancelled, sessionContext);
 		await waitFor(() => frames.some(frame => frame.type === "agent_failed"), "cancelled prompt terminal");
 
 		// A user interrupt is intent, not an undiagnosable defect, so it must not

--- a/packages/coding-agent/test/sdk-prompt-terminal-diagnostics.test.ts
+++ b/packages/coding-agent/test/sdk-prompt-terminal-diagnostics.test.ts
@@ -187,6 +187,73 @@ test("SDK host logs a bounded reason from a reachable provider failure", async (
 	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
 });
 
+test("SDK host logs a bounded reason from an accepted sendUserMessage rejection", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-prompt-terminal-accepted-rejection-"));
+	dirs.push(cwd);
+	const sessionId = `sdk-prompt-terminal-accepted-rejection-${Date.now()}`;
+	const sessionContext = context(cwd, sessionId);
+	const reason = `Accepted sendUserMessage rejected after commit: ${"y".repeat(600)}`;
+	const handlers = start(sessionContext, async () => {
+		throw new Error(reason);
+	});
+	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+
+	const frames: Record<string, unknown>[] = [];
+	const socket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	sockets.push(socket);
+	socket.addEventListener("message", event => frames.push(JSON.parse(String(event.data))));
+	await new Promise<void>((resolve, reject) => {
+		socket.addEventListener("open", () => resolve(), { once: true });
+		socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+	});
+
+	const diagnostics: Record<string, unknown>[] = [];
+	const errorSpy = spyOn(logger, "error").mockImplementation((...args: unknown[]) => {
+		if (args[0] === "sdk_prompt_terminal_failed") diagnostics.push(args[1] as Record<string, unknown>);
+	});
+
+	try {
+		socket.send(
+			JSON.stringify({
+				type: "control_request",
+				id: "accepted-rejection",
+				operation: "turn.prompt",
+				input: { text: "fail after acceptance" },
+			}),
+		);
+		await waitFor(
+			() => frames.some(frame => frame.type === "control_response" && frame.id === "accepted-rejection"),
+			"accepted prompt acknowledgement",
+		);
+		await waitFor(() => frames.some(frame => frame.type === "agent_failed"), "accepted rejection terminal");
+
+		const acknowledgement = frames.find(
+			frame => frame.type === "control_response" && frame.id === "accepted-rejection",
+		) as { result?: { commandId?: unknown; turnId?: unknown } };
+		const failure = frames.find(frame => frame.type === "agent_failed") as Record<string, unknown>;
+		expect(failure).toMatchObject({
+			commandId: acknowledgement.result?.commandId,
+			turnId: acknowledgement.result?.turnId,
+			error: { code: "internal", message: "Prompt submission failed." },
+			outcome: { kind: "failed", code: "prompt_failed", message: "Prompt submission failed." },
+		});
+		expect(JSON.stringify(failure)).not.toContain("Accepted sendUserMessage rejected");
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0]).toMatchObject({
+			sessionId,
+			commandId: acknowledgement.result?.commandId,
+			turnId: acknowledgement.result?.turnId,
+			reason: reason.slice(0, 512),
+		});
+		expect(diagnostics[0]?.reason).toHaveLength(512);
+	} finally {
+		errorSpy.mockRestore();
+	}
+
+	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
+});
 test("SDK host does not log a client cancellation as a prompt terminal failure", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-prompt-terminal-cancel-"));
 	dirs.push(cwd);

--- a/packages/coding-agent/test/sdk-prompt-terminal-diagnostics.test.ts
+++ b/packages/coding-agent/test/sdk-prompt-terminal-diagnostics.test.ts
@@ -209,9 +209,12 @@ test("SDK host logs a bounded reason from an accepted sendUserMessage rejection"
 		socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
 	});
 
-	const diagnostics: Record<string, unknown>[] = [];
+	let sdkPromptTerminalFailedCount = 0;
+	let diagnostic: Record<string, unknown> | undefined;
 	const errorSpy = spyOn(logger, "error").mockImplementation((...args: unknown[]) => {
-		if (args[0] === "sdk_prompt_terminal_failed") diagnostics.push(args[1] as Record<string, unknown>);
+		if (args[0] !== "sdk_prompt_terminal_failed") return;
+		sdkPromptTerminalFailedCount++;
+		diagnostic = args[1] as Record<string, unknown>;
 	});
 
 	try {
@@ -240,14 +243,14 @@ test("SDK host logs a bounded reason from an accepted sendUserMessage rejection"
 			outcome: { kind: "failed", code: "prompt_failed", message: "Prompt submission failed." },
 		});
 		expect(JSON.stringify(failure)).not.toContain("Accepted sendUserMessage rejected");
-		expect(diagnostics).toHaveLength(1);
-		expect(diagnostics[0]).toMatchObject({
+		expect(sdkPromptTerminalFailedCount).toBe(1);
+		expect(diagnostic).toMatchObject({
 			sessionId,
 			commandId: acknowledgement.result?.commandId,
 			turnId: acknowledgement.result?.turnId,
 			reason: reason.slice(0, 512),
 		});
-		expect(diagnostics[0]?.reason).toHaveLength(512);
+		expect(diagnostic?.reason).toHaveLength(512);
 	} finally {
 		errorSpy.mockRestore();
 	}


### PR DESCRIPTION
Found by an automated diagnosis lane that fires when an agent lane dies. Sibling of #4086.

## The defect

`sanitizePromptFailure` replaces a failure message with a fixed safe token by contract, so SDK clients, the ACP `-32603` envelope and every agent transcript see only `Prompt submission failed.` That redaction is deliberate and unchanged here.

What was missing is the other half: nothing wrote the unredacted reason anywhere, not even locally. Redaction protects a boundary, and the operator's own machine is not that boundary — `~/.gjc/logs/` is already where local diagnostics go, and `grep -c prompt_failed` there returned zero.

The reason now reaches the local operator log, bounded to 512 characters to match the documented reconciliation limit so a runaway provider error cannot flood the file.

## Covering the routes, not the convenient one

The first version fired only on `agent_end`. A post-acceptance `sendUserMessage` rejection reaches `recordPromptTerminal` by another route and produced nothing, so the failure class this exists to surface stayed invisible there.

The test was worse than the gap. It passed while a logger spy measured `SDK_PROMPT_TERMINAL_FAILED_COUNT=0` — it asserted an observable that exists whether or not the line is written, so the route was never actually covered. A test that passes while the behavior it names never occurs converts an open defect into a closed one on paper. It asserts the line now.

An earlier version reached the failure only by fabricating `stopReason: "exhausted"` with `as never`, a state production strips before that point. Removing the cast removed the coverage, which is the signal that the fabricated state was the only path there. It was not — a provider failure reaches this log by an ordinary route, and the test drives that one.

## Verification

`bun test sdk-prompt-terminal-diagnostics.test.ts` — 3 pass, 0 fail. `bun --cwd=packages/coding-agent run check` — exit 0.

Reverting `sdk/bus/index.ts` to `dev` fails 2 tests behaviorally: a reachable provider failure and an accepted-then-rejected `sendUserMessage`.

## Known and not fixed

A terminal raised below the transport layer is untested.
