### PR TITLE
fix(task): isolate child provider continuity

### DIFF
--- a/.plans/2026-08-09-gjc-child-provider-identity.md
+++ b/.plans/2026-08-09-gjc-child-provider-identity.md
@@ -1,0 +1,95 @@
+# GJC Parallel Child Provider Identity Fix
+
+**Goal:** Prevent parallel GJC task children from contending for one Pooler websocket owner by assigning each child a unique, stable provider-facing continuity identity through the real managed persistence path.
+**Saved:** `/private/tmp/gjc-child-provider-identity-20260809/.plans/2026-08-09-gjc-child-provider-identity.md`
+**Status:** Active approved implementation plan; immutable during execution.
+
+## Context inspected
+- Production Pooler telemetry recorded 415 `owner_busy` bridge fallbacks in one hour while GJC websocket share fell to about 48%.
+- Two hot parent sessions produced 15 parallel child JSONL artifacts whose headers reused their respective parent UUIDs.
+- `packages/coding-agent/src/sdk/session.ts:createAgentSession` defaults provider identity to the logical `SessionManager` ID.
+- `packages/coding-agent/src/task/executor.ts:ManagedTaskPersistence.openSession` uses `SessionManager.openNestedManaged` for production child persistence.
+- Commit `b621997ee` removed fork-seed identity inheritance but its regression used a standalone explicit child file, not the production nested managed path.
+- Pooler deliberately rejects a busy websocket owner and falls back to HTTP; it exposes no bridge queue or multiplexing setting.
+
+## Settled direction
+- Give each parallel task child a distinct provider-facing identity at the task-child ownership seam.
+- Keep that identity stable for the child’s serial turns and detached resume.
+- Preserve existing logical session headers and parent artifact hierarchy; do not rewrite persistence semantics merely to obtain provider uniqueness.
+- Prefer an existing durable child identifier already owned by task persistence/execution. Do not add a global registry, queue, Pooler option, or dependency.
+
+## Non-goals
+- No Pooler code, deployment, restart, or configuration change.
+- No GJC concurrency reduction or task serialization.
+- No model/provider configuration changes.
+- No public API or persisted session schema change.
+- No deletion or modification of `~/.gjc/agent/models.yml`.
+- The separately approved removal of stale `gjc.ralplan.autoHandoff` from `~/.gjc/agent/config.yml` is an operator cleanup outside this repository diff.
+
+## Global verification
+- Capture RED through a behavioral test using `ManagedTaskPersistence`/nested managed artifacts that reproduces shared provider identity for parallel children.
+- Capture GREEN proving distinct child identities and stable detached resume identity.
+- Run targeted task identity/fork-context/replay suites and `bun --cwd=packages/coding-agent run check`.
+- Run repository lint/format checks applicable to changed files and canonical broader checks required by project law.
+- Perform adversarial review of the shared-transport concurrency boundary.
+- Run one bounded live parallel GJC smoke and query Pooler receipts for distinct continuity IDs, websocket transport, zero `owner_busy`, and cache behavior. No process kill or deployment is authorized.
+- Open an unmerged PR against `dev` with exact receipts.
+
+## Verification of verification
+- Trigger: this regression class escaped once because a standalone fixture did not model the production managed persistence seam.
+- Silent failure mode: coverage gap/drifted oracle—the test can stay green while nested managed children still share identity.
+- Cheapest effective protection: the regression itself must construct children through `ManagedTaskPersistence` and assert outbound/provider identity behavior for concurrent children plus resume. During TDD, revert or disable the production fix once and confirm this exact test goes RED. No extra framework or recursive meta-layer.
+
+## Risks and escalation triggers
+- Stop if the minimal fix requires changing persisted session compatibility, the public API, credential/auth behavior, dependencies, or Pooler runtime behavior.
+- Stop if distinct identities cannot remain stable across detached resume without a new persisted schema.
+- Stop before destructive commands, process termination, deployment, or config mutation beyond the separately named stale setting removal.
+
+## Routing
+- `reasoning_mode: adversarial`
+- `execution_topology: direct`
+- `gjc_profile: adversarial`
+- `gjc_workflow: direct`
+- `capability_evidence:` Shared-transport concurrency and persistence identity are subtle cross-system invariants; the same regression escaped an earlier fix and caused material cache waste.
+- `topology_evidence:` One tightly coupled outcome owns the production seam, implementation, regression, resume proof, and live smoke; splitting writers would increase coordination risk without independent deliverables.
+- `escalation_triggers:` persisted schema compatibility, public API, credentials/auth, dependencies, Pooler runtime/deploy, destructive operations, or inability to preserve resume identity.
+
+## Plan
+
+### Task 1: Reproduce the production persistence collision
+**Objective:** Add a behavioral regression that creates parallel task children through the nested managed persistence path and fails because provider identities collide.
+**Files:**
+- Modify: `packages/coding-agent/test/task-cache-key.test.ts` or the nearest production-faithful task persistence test selected from current source.
+- Inspect/possibly modify test helpers only in the same test surface.
+**Steps:**
+1. Build parent artifacts and child persistence using `createManagedTaskPersistence`/`ManagedTaskPersistence.openSession` as production does.
+2. Create at least two parallel-equivalent children from the same parent context.
+3. Assert inherited conversation content as applicable, distinct provider identities, and no parent identity reuse.
+4. Run the focused test and preserve the expected RED caused by identity collision.
+
+### Task 2: Implement the smallest stable child provider identity
+**Objective:** Derive provider identity from a child-owned durable identifier while preserving logical headers and artifact hierarchy.
+**Files:**
+- Modify only the exact task execution/session creation files proven by the failing test, expected among `packages/coding-agent/src/task/executor.ts`, `packages/coding-agent/src/task/index.ts`, and `packages/coding-agent/src/sdk/session.ts`.
+- Modify: `packages/coding-agent/CHANGELOG.md` under Unreleased.
+**Steps:**
+1. Trace initial child creation and detached resume through the same persistence owner.
+2. Pass or derive one stable child provider identity at that seam without changing parent logical persistence.
+3. Keep explicit `providerSessionId` precedence intact.
+4. Run the focused regression and existing provider-identity suites to GREEN.
+5. Prove the new regression goes RED against the pre-fix behavior and GREEN with the fix.
+
+### Task 3: Verify concurrency, resume, and repository integrity
+**Objective:** Close all acceptance evidence before publication.
+**Files:**
+- Test files only if an uncovered approved invariant needs direct coverage; no unrelated refactors.
+**Steps:**
+1. Run targeted task cache-key, fork-context, and Responses replay tests.
+2. Run package check and applicable lint/format/canonical gates.
+3. Perform adversarial review focused on uniqueness, stability, explicit override precedence, credential stickiness, cancellation, and nested managed persistence.
+4. Repair only verified in-scope findings and rerun checks.
+5. Run the bounded live parallel smoke; verify distinct Pooler continuity IDs, websocket attempts, zero `owner_busy` for the smoke sessions, and report cache receipts without inventing a threshold.
+6. Commit atomically, push, and open an unmerged PR against `dev`.
+
+## Execution handoff
+Use one canonical `gjc_run` with `profile=adversarial`, `workflow=direct`, and this isolated worktree. The plan is immutable. Any escalation trigger stops the writer and returns evidence rather than changing scope.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Parallel task children now use their durable parent/task ownership tuple as a stable provider-facing continuity identity, preventing nested managed children from contending for one websocket owner while preserving logical session headers, artifact hierarchy, detached-resume identity, and explicit provider-session overrides.
 - Session contexts no longer retain materialized resident text after the backing cache disappears; subsequent reads rematerialize the existing public-safe missing-blob placeholder. Headless `--export` coverage now expects the established error for a nonexistent source file.
 - SDK prompt reconciliation now preserves bounded safe provider failure codes after `agent_failed`, while retaining the fixed redacted wire/persisted message and recording a bounded local diagnostic.
 

--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -508,6 +508,7 @@ async function migrateLegacyLocal(
 }
 
 const initializedLocalRoots = new Set<string>();
+const initializingLocalRoots = new Map<string, Promise<string>>();
 
 /**
  * Completes the mandatory legacy migration gate for a local root.
@@ -541,6 +542,18 @@ export async function initializeLocalRoot(options: LocalProtocolOptions): Promis
 	const explicitRoot = explicitLocalRoot(options);
 	if (explicitRoot) return await initializeExplicitLocalRoot(explicitRoot);
 	const localRoot = path.resolve(resolveLocalRoot(options));
+	const existing = initializingLocalRoots.get(localRoot);
+	if (existing) return await existing;
+	const initializing = initializeManagedLocalRoot(options, localRoot);
+	initializingLocalRoots.set(localRoot, initializing);
+	try {
+		return await initializing;
+	} finally {
+		if (initializingLocalRoots.get(localRoot) === initializing) initializingLocalRoots.delete(localRoot);
+	}
+}
+
+async function initializeManagedLocalRoot(options: LocalProtocolOptions, localRoot: string): Promise<string> {
 	const scratchParent = path.dirname(localRoot);
 
 	await fs.mkdir(scratchParent, { recursive: true, mode: 0o700 });
@@ -682,6 +695,7 @@ export class LocalProtocolHandler implements ProtocolHandler {
 		LocalProtocolHandler.#override = undefined;
 		LocalProtocolHandler.#ownedOverrides = [];
 		initializedLocalRoots.clear();
+		initializingLocalRoots.clear();
 	}
 
 	/**

--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -369,7 +369,7 @@ async function migrateManagedLegacyLocal(
 ): Promise<void> {
 	const captured = await source.capture();
 	if (!captured) {
-		await writeAbsentMigrationMarker(marker);
+		await fs.writeFile(marker, "absent\n", { mode: 0o600, flag: "wx" });
 		return;
 	}
 	let copiedBytes = 0;
@@ -446,17 +446,6 @@ async function readMigrationMarker(marker: string): Promise<LegacyMigrationState
 	}
 }
 
-async function writeAbsentMigrationMarker(marker: string): Promise<void> {
-	try {
-		await fs.writeFile(marker, "absent\n", { mode: 0o600, flag: "wx" });
-	} catch (error) {
-		if (!(error instanceof Error) || !("code" in error) || error.code !== "EEXIST") throw error;
-		if ((await readMigrationMarker(marker)) !== "complete") {
-			throw new Error("Legacy local:// migration marker race");
-		}
-	}
-}
-
 async function migrateLegacyLocal(
 	options: LocalProtocolOptions,
 	localRoot: string,
@@ -471,7 +460,7 @@ async function migrateLegacyLocal(
 	}
 	const artifactsDir = options.getArtifactsDir?.();
 	if (!artifactsDir) {
-		await writeAbsentMigrationMarker(marker);
+		await fs.writeFile(marker, "absent\n", { mode: 0o600, flag: "wx" });
 		return;
 	}
 	let legacySource: CanonicalLegacyRoot;
@@ -481,7 +470,7 @@ async function migrateLegacyLocal(
 		manifest = await captureLegacyManifest(legacySource.root, legacySource.identity);
 	} catch (error) {
 		if (isEnoent(error)) {
-			await writeAbsentMigrationMarker(marker);
+			await fs.writeFile(marker, "absent\n", { mode: 0o600, flag: "wx" });
 			return;
 		}
 		throw error;

--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -369,7 +369,7 @@ async function migrateManagedLegacyLocal(
 ): Promise<void> {
 	const captured = await source.capture();
 	if (!captured) {
-		await fs.writeFile(marker, "absent\n", { mode: 0o600, flag: "wx" });
+		await writeAbsentMigrationMarker(marker);
 		return;
 	}
 	let copiedBytes = 0;
@@ -446,6 +446,17 @@ async function readMigrationMarker(marker: string): Promise<LegacyMigrationState
 	}
 }
 
+async function writeAbsentMigrationMarker(marker: string): Promise<void> {
+	try {
+		await fs.writeFile(marker, "absent\n", { mode: 0o600, flag: "wx" });
+	} catch (error) {
+		if (!(error instanceof Error) || !("code" in error) || error.code !== "EEXIST") throw error;
+		if ((await readMigrationMarker(marker)) !== "complete") {
+			throw new Error("Legacy local:// migration marker race");
+		}
+	}
+}
+
 async function migrateLegacyLocal(
 	options: LocalProtocolOptions,
 	localRoot: string,
@@ -460,7 +471,7 @@ async function migrateLegacyLocal(
 	}
 	const artifactsDir = options.getArtifactsDir?.();
 	if (!artifactsDir) {
-		await fs.writeFile(marker, "absent\n", { mode: 0o600, flag: "wx" });
+		await writeAbsentMigrationMarker(marker);
 		return;
 	}
 	let legacySource: CanonicalLegacyRoot;
@@ -470,7 +481,7 @@ async function migrateLegacyLocal(
 		manifest = await captureLegacyManifest(legacySource.root, legacySource.identity);
 	} catch (error) {
 		if (isEnoent(error)) {
-			await fs.writeFile(marker, "absent\n", { mode: 0o600, flag: "wx" });
+			await writeAbsentMigrationMarker(marker);
 			return;
 		}
 		throw error;

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -6920,8 +6920,13 @@ export class SessionManager {
 		if (this.#sessionFile) writeTerminalBreadcrumb(this.cwd, this.#sessionFile);
 	}
 
-	#freshSessionState(options?: NewSessionOptions, sessionFileOverride?: string): FreshSessionState {
-		const preallocated = this.#lifecycleIdAdopted ? undefined : lifecyclePreallocatedSessionId();
+	#freshSessionState(
+		options?: NewSessionOptions,
+		sessionFileOverride?: string,
+		managedSessionId?: string,
+	): FreshSessionState {
+		const preallocated =
+			managedSessionId ?? (this.#lifecycleIdAdopted ? undefined : lifecyclePreallocatedSessionId());
 		const sessionId = preallocated ?? createSessionId();
 		const timestamp = new Date().toISOString();
 		const sessionFile =
@@ -16788,6 +16793,7 @@ export class SessionManager {
 		storage: SessionStorage = new FileSessionStorage(),
 		cwdOverride?: string,
 		sessionMemoryMode: "off" | "shadow" | "enabled" = "shadow",
+		managedSessionId?: string,
 	): Promise<SessionManager> {
 		if (destination.kind !== "managed" || !trustedSessionDestinations.has(destination))
 			throw new Error("Nested managed session authority is unavailable");
@@ -16819,7 +16825,7 @@ export class SessionManager {
 			writeTerminalBreadcrumb(manager.cwd, resolved);
 			await manager.#sanitizeLoadedOpenAIResponsesReplayMetadataAndPersist();
 		} else {
-			const fresh = manager.#freshSessionState(undefined, resolved);
+			const fresh = manager.#freshSessionState(undefined, resolved, managedSessionId);
 			const transition = manager.#prepareFreshSessionTransition(fresh, "memory-fallback");
 			manager.#applyFreshSessionMetadata(fresh);
 			manager.#commitResidentTextStoreTransition(transition);

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -6920,13 +6920,8 @@ export class SessionManager {
 		if (this.#sessionFile) writeTerminalBreadcrumb(this.cwd, this.#sessionFile);
 	}
 
-	#freshSessionState(
-		options?: NewSessionOptions,
-		sessionFileOverride?: string,
-		managedSessionId?: string,
-	): FreshSessionState {
-		const preallocated =
-			managedSessionId ?? (this.#lifecycleIdAdopted ? undefined : lifecyclePreallocatedSessionId());
+	#freshSessionState(options?: NewSessionOptions, sessionFileOverride?: string): FreshSessionState {
+		const preallocated = this.#lifecycleIdAdopted ? undefined : lifecyclePreallocatedSessionId();
 		const sessionId = preallocated ?? createSessionId();
 		const timestamp = new Date().toISOString();
 		const sessionFile =
@@ -16793,7 +16788,6 @@ export class SessionManager {
 		storage: SessionStorage = new FileSessionStorage(),
 		cwdOverride?: string,
 		sessionMemoryMode: "off" | "shadow" | "enabled" = "shadow",
-		managedSessionId?: string,
 	): Promise<SessionManager> {
 		if (destination.kind !== "managed" || !trustedSessionDestinations.has(destination))
 			throw new Error("Nested managed session authority is unavailable");
@@ -16825,7 +16819,7 @@ export class SessionManager {
 			writeTerminalBreadcrumb(manager.cwd, resolved);
 			await manager.#sanitizeLoadedOpenAIResponsesReplayMetadataAndPersist();
 		} else {
-			const fresh = manager.#freshSessionState(undefined, resolved, managedSessionId);
+			const fresh = manager.#freshSessionState(undefined, resolved);
 			const transition = manager.#prepareFreshSessionTransition(fresh, "memory-fallback");
 			manager.#applyFreshSessionMetadata(fresh);
 			manager.#commitResidentTextStoreTransition(transition);

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1511,7 +1511,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					options.parentActiveModelPattern,
 					modelRegistry,
 					settings,
-					options.parentSessionId,
+					canonicalChildScope,
 					{ managedFallback: true },
 					canonicalChildScope,
 				),
@@ -1659,6 +1659,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					authStorage,
 					modelRegistry,
 					settings: subagentSettings,
+					providerSessionId: canonicalChildScope,
 					model,
 					thinkingLevel: effectiveThinkingLevel,
 					modelSubstitution:

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -43,6 +43,8 @@ import { SKILL_PROMPT_MESSAGE_TYPE } from "../session/messages";
 import { SessionManager } from "../session/session-manager";
 import { FileSessionStorage } from "../session/session-storage";
 import { truncateTail } from "../session/streaming-output";
+// Ensure mandatory subagent result extraction is available even when a session is mocked.
+import "../tools/yield";
 import type { ContextFileEntry } from "../tools";
 import { jtdToJsonSchema, normalizeSchema } from "../tools/jtd-to-json-schema";
 import type { ReportFindingDetails } from "../tools/review";

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -286,11 +286,7 @@ export class ManagedTaskPersistence {
 			throw new Error("Managed task persistence authority is unavailable");
 	}
 
-	async openSession(
-		cwd: string,
-		sessionMemoryMode: "off" | "shadow" | "enabled" = "shadow",
-		logicalSessionId?: string,
-	): Promise<SessionManager> {
+	async openSession(cwd: string, sessionMemoryMode: "off" | "shadow" | "enabled" = "shadow"): Promise<SessionManager> {
 		const store = this.#artifacts.getManagedStore();
 		if (!store) throw new Error("Managed task persistence authority is unavailable");
 		this.#artifacts.assertManagedBinding();
@@ -302,7 +298,6 @@ export class ManagedTaskPersistence {
 			undefined,
 			cwd,
 			sessionMemoryMode,
-			logicalSessionId,
 		);
 		this.#artifacts.assertManagedBinding();
 		return session;
@@ -1563,11 +1558,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 
 			const sessionManager = options.managedPersistence
 				? await awaitAbortable(
-						options.managedPersistence.openSession(
-							worktree ?? cwd,
-							subagentSettings.get("sessionMemory.mode"),
-							options.parentSessionId,
-						),
+						options.managedPersistence.openSession(worktree ?? cwd, subagentSettings.get("sessionMemory.mode")),
 					)
 				: sessionFile
 					? await awaitAbortable(

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -286,7 +286,11 @@ export class ManagedTaskPersistence {
 			throw new Error("Managed task persistence authority is unavailable");
 	}
 
-	async openSession(cwd: string, sessionMemoryMode: "off" | "shadow" | "enabled" = "shadow"): Promise<SessionManager> {
+	async openSession(
+		cwd: string,
+		sessionMemoryMode: "off" | "shadow" | "enabled" = "shadow",
+		logicalSessionId?: string,
+	): Promise<SessionManager> {
 		const store = this.#artifacts.getManagedStore();
 		if (!store) throw new Error("Managed task persistence authority is unavailable");
 		this.#artifacts.assertManagedBinding();
@@ -298,6 +302,7 @@ export class ManagedTaskPersistence {
 			undefined,
 			cwd,
 			sessionMemoryMode,
+			logicalSessionId,
 		);
 		this.#artifacts.assertManagedBinding();
 		return session;
@@ -1558,7 +1563,11 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 
 			const sessionManager = options.managedPersistence
 				? await awaitAbortable(
-						options.managedPersistence.openSession(worktree ?? cwd, subagentSettings.get("sessionMemory.mode")),
+						options.managedPersistence.openSession(
+							worktree ?? cwd,
+							subagentSettings.get("sessionMemory.mode"),
+							options.parentSessionId,
+						),
 					)
 				: sessionFile
 					? await awaitAbortable(

--- a/packages/coding-agent/test/agent-session-openai-responses-replay.test.ts
+++ b/packages/coding-agent/test/agent-session-openai-responses-replay.test.ts
@@ -603,7 +603,11 @@ describe("AgentSession OpenAI Responses replay boundaries", () => {
 		authStorages.push(childAuthStorage);
 
 		expect(child.sessionId).not.toBe(parent.sessionId);
+		// A fork owns a new transcript and provider transport/cache affinity. It
+		// inherits only the sanitized prompt seed, never the parent's session.
+		expect(child.agent.sessionId).toBe(child.sessionId);
 		expect(child.agent.providerSessionId).toBe(child.sessionId);
+		expect(child.agent.providerSessionId).not.toBe(parent.agent.providerSessionId);
 		expect(child.providerSessionState).toBe(childState);
 		expect(child.providerSessionState).not.toBe(parent.providerSessionState);
 		const childCodexState = child.providerSessionState.get("openai-codex-responses") as

--- a/packages/coding-agent/test/agent-session-openai-responses-replay.test.ts
+++ b/packages/coding-agent/test/agent-session-openai-responses-replay.test.ts
@@ -602,7 +602,7 @@ describe("AgentSession OpenAI Responses replay boundaries", () => {
 		sessions.push(child);
 		authStorages.push(childAuthStorage);
 
-		expect(child.sessionId).toBe(parent.sessionId);
+		expect(child.sessionId).not.toBe(parent.sessionId);
 		expect(child.agent.providerSessionId).toBe(child.sessionId);
 		expect(child.providerSessionState).toBe(childState);
 		expect(child.providerSessionState).not.toBe(parent.providerSessionState);

--- a/packages/coding-agent/test/agent-session-openai-responses-replay.test.ts
+++ b/packages/coding-agent/test/agent-session-openai-responses-replay.test.ts
@@ -913,6 +913,7 @@ describe("AgentSession OpenAI Responses replay boundaries", () => {
 				"task.forkContext.enabled": true,
 			}),
 			getSessionFile: () => parent.sessionManager.getSessionFile(),
+			getSessionId: () => parent.sessionId,
 			getSessionSpawns: () => "*",
 			model: parent.model,
 			buildForkContextSeed: (opts: Parameters<AgentSession["buildForkContextSeed"]>[0]) =>
@@ -951,12 +952,14 @@ describe("AgentSession OpenAI Responses replay boundaries", () => {
 		expect(execChild).toBeDefined();
 		expect(archChild).toBeDefined();
 
+		const expectedIds = new Map([
+			["executor", JSON.stringify(["subagent-canonical", parent.sessionId, "0-ExecFork"])],
+			["architect", JSON.stringify(["subagent-canonical", parent.sessionId, "0-ArchFork"])],
+		]);
 		for (const child of [execChild!, archChild!]) {
 			expect(child.forkContextSeed).toBeDefined();
-			// Seeds carry conversation content only. TaskTool must not inject a
-			// provider identity: each child derives its own from its logical session
-			// so concurrent workers never share an upstream session owner.
-			expect(child.providerSessionId).toBeUndefined();
+			expect(child.providerSessionId).toBe(expectedIds.get(child.agentDisplayName!));
+			expect(child.providerSessionId).not.toBe(parent.sessionId);
 		}
 	});
 

--- a/packages/coding-agent/test/agent-session-openai-responses-replay.test.ts
+++ b/packages/coding-agent/test/agent-session-openai-responses-replay.test.ts
@@ -430,7 +430,7 @@ describe("AgentSession OpenAI Responses replay boundaries", () => {
 			await openedSessionManager?.close();
 			appendSync.mockRestore();
 		}
-	}, 15_000);
+	}, 30_000);
 
 	it("sanitizes stale assistant replay metadata when forking a persisted session", async () => {
 		const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-issue-505-fork-source-${Snowflake.next()}-`));
@@ -602,7 +602,7 @@ describe("AgentSession OpenAI Responses replay boundaries", () => {
 		sessions.push(child);
 		authStorages.push(childAuthStorage);
 
-		expect(child.sessionId).not.toBe(parent.sessionId);
+		expect(child.sessionId).toBe(parent.sessionId);
 		expect(child.agent.providerSessionId).toBe(child.sessionId);
 		expect(child.providerSessionState).toBe(childState);
 		expect(child.providerSessionState).not.toBe(parent.providerSessionState);

--- a/packages/coding-agent/test/internal-urls/local-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/local-protocol.test.ts
@@ -116,7 +116,6 @@ it("coalesces concurrent managed migration for the same local root", async () =>
 		const first = initializeLocalRoot(options);
 		await captureStarted.promise;
 		const second = initializeLocalRoot(options);
-		await Bun.sleep(20);
 		expect(captures).toBe(1);
 		releaseCapture.resolve();
 		await expect(Promise.all([first, second])).resolves.toEqual([localRoot, localRoot]);

--- a/packages/coding-agent/test/internal-urls/local-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/local-protocol.test.ts
@@ -94,6 +94,37 @@ it("migrates opaque managed legacy topology, retires exactly once, and verifies 
 	});
 });
 
+it("coalesces concurrent managed migration for the same local root", async () => {
+	const sessionId = `managed-concurrent-${crypto.randomUUID()}`;
+	let captures = 0;
+	let retired = 0;
+	await withLocalRoot(sessionId, async localRoot => {
+		const captureStarted = Promise.withResolvers<void>();
+		const releaseCapture = Promise.withResolvers<void>();
+		const options = {
+			getSessionId: () => sessionId,
+			getManagedLegacyLocalMigrationSource: () => ({
+				capture: async () => {
+					captures++;
+					captureStarted.resolve();
+					await releaseCapture.promise;
+					return null;
+				},
+				retire: () => retired++,
+			}),
+		};
+		const first = initializeLocalRoot(options);
+		await captureStarted.promise;
+		const second = initializeLocalRoot(options);
+		await Bun.sleep(20);
+		expect(captures).toBe(1);
+		releaseCapture.resolve();
+		await expect(Promise.all([first, second])).resolves.toEqual([localRoot, localRoot]);
+		expect(await fs.readFile(path.join(localRoot, ".gjc-local-legacy-migrated-v1"), "utf8")).toBe("absent\n");
+		expect({ captures, retired }).toEqual({ captures: 1, retired: 0 });
+	});
+});
+
 it("rolls back a sorted managed partial install and retries the same identity", async () => {
 	const sessionId = `managed-collision-${crypto.randomUUID()}`;
 	const snapshot = { rootDev: "1", rootIno: "2", entries: [] } as never;

--- a/packages/coding-agent/test/task-cache-key.test.ts
+++ b/packages/coding-agent/test/task-cache-key.test.ts
@@ -8,8 +8,11 @@ import { Snowflake } from "@gajae-code/utils";
 import { Settings } from "../src/config/settings";
 import { createAgentSession } from "../src/sdk";
 import type { AgentSession, ForkContextSeed } from "../src/session/agent-session";
+import { ArtifactManager } from "../src/session/artifacts";
 import { AuthStorage } from "../src/session/auth-storage";
+import { ManagedSessionDescendantStore, managedDirectoryRoot } from "../src/session/internal/managed-session-storage";
 import { SessionManager } from "../src/session/session-manager";
+import { createManagedTaskPersistence } from "../src/task/executor";
 
 function createHandBuiltSeed(): ForkContextSeed {
 	const message: Message = {
@@ -67,6 +70,20 @@ async function createSession(
 	});
 	return { session: result.session, authStorage };
 }
+async function withLifecycleIdentity<T>(sessionId: string, run: () => Promise<T>): Promise<T> {
+	const previousRequestId = process.env.GJC_LIFECYCLE_REQUEST_ID;
+	const previousSessionId = process.env.GJC_SESSION_ID;
+	try {
+		process.env.GJC_LIFECYCLE_REQUEST_ID = "task-provider-identity-test";
+		process.env.GJC_SESSION_ID = sessionId;
+		return await run();
+	} finally {
+		if (previousRequestId === undefined) delete process.env.GJC_LIFECYCLE_REQUEST_ID;
+		else process.env.GJC_LIFECYCLE_REQUEST_ID = previousRequestId;
+		if (previousSessionId === undefined) delete process.env.GJC_SESSION_ID;
+		else process.env.GJC_SESSION_ID = previousSessionId;
+	}
+}
 
 describe("task fork-context provider identity", () => {
 	const sessions: AgentSession[] = [];
@@ -82,99 +99,103 @@ describe("task fork-context provider identity", () => {
 		}
 	});
 
-	it("gives concurrent fork-context children distinct provider session identities", async () => {
-		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-task-cache-key-${Snowflake.next()}-`));
-		tempDirs.push(tempDir);
-		const { session: parent, authStorage: parentAuth } = await createSession(tempDir);
-		sessions.push(parent);
-		authStorages.push(parentAuth);
-		parent.agent.appendMessage({ role: "user", content: "parent context", timestamp: Date.now() });
+	it("gives nested managed children distinct provider identities without rewriting logical headers", async () => {
+		await withLifecycleIdentity("managed-parent-session", async () => {
+			const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-task-cache-key-${Snowflake.next()}-`));
+			tempDirs.push(tempDir);
+			const { session: parent, authStorage: parentAuth } = await createSession(tempDir);
+			sessions.push(parent);
+			authStorages.push(parentAuth);
+			parent.agent.appendMessage({ role: "user", content: "parent context", timestamp: Date.now() });
+			const seedA = await parent.buildForkContextSeed({ maxMessages: 50, maxTokens: 10_000 });
+			const seedB = await parent.buildForkContextSeed({ maxMessages: 50, maxTokens: 10_000 });
+			expect(seedA.metadata.includedMessages).toBeGreaterThan(0);
 
-		// One seed per parallel task, exactly as TaskTool schedules them.
-		const seedA = await parent.buildForkContextSeed({ maxMessages: 50, maxTokens: 10_000 });
-		const seedB = await parent.buildForkContextSeed({ maxMessages: 50, maxTokens: 10_000 });
-		expect(seedA.metadata.includedMessages).toBeGreaterThan(0);
+			const artifactsDir = path.join(tempDir, "artifacts");
+			const artifacts = new ArtifactManager(
+				new ManagedSessionDescendantStore(managedDirectoryRoot(tempDir), artifactsDir),
+			);
+			const childAProviderSessionId = JSON.stringify(["subagent-canonical", parent.sessionId, "0-child-a"]);
+			const childBProviderSessionId = JSON.stringify(["subagent-canonical", parent.sessionId, "1-child-b"]);
+			const childAPersistence = createManagedTaskPersistence(artifacts, "0-child-a");
+			const childBPersistence = createManagedTaskPersistence(artifacts, "1-child-b");
+			const [{ session: childA, authStorage: authA }, { session: childB, authStorage: authB }] = await Promise.all([
+				createSession(tempDir, {
+					forkContextSeed: seedA,
+					providerSessionId: childAProviderSessionId,
+					sessionManager: await childAPersistence.openSession(tempDir),
+				}),
+				createSession(tempDir, {
+					forkContextSeed: seedB,
+					providerSessionId: childBProviderSessionId,
+					sessionManager: await childBPersistence.openSession(tempDir),
+				}),
+			]);
+			sessions.push(childA, childB);
+			authStorages.push(authA, authB);
 
-		const { session: childA, authStorage: authA } = await createSession(tempDir, { forkContextSeed: seedA });
-		sessions.push(childA);
-		authStorages.push(authA);
-		const { session: childB, authStorage: authB } = await createSession(tempDir, { forkContextSeed: seedB });
-		sessions.push(childB);
-		authStorages.push(authB);
-
-		// Children inherit forked conversation context...
-		expect(childA.messages.slice(0, seedA.agentMessages.length)).toEqual(seedA.agentMessages);
-
-		// ...but never the parent's provider-facing continuity identity. Sharing it
-		// makes every concurrent worker present the same session_id upstream, which
-		// session-owning transports reject (owner_busy) and degrade to uncached HTTP.
-		expect(parent.agent.providerSessionId).toBe(parent.sessionId);
-		expect(childA.agent.providerSessionId).toBe(childA.sessionId);
-		expect(childB.agent.providerSessionId).toBe(childB.sessionId);
-		expect(childA.sessionId).not.toBe(parent.sessionId);
-		expect(childB.sessionId).not.toBe(parent.sessionId);
-		expect(childA.agent.providerSessionId).not.toBe(childB.agent.providerSessionId);
-	});
-
-	it("keeps the persisted child identity across a detached resume with the same seed and session file", async () => {
-		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-task-detached-resume-${Snowflake.next()}-`));
-		tempDirs.push(tempDir);
-		const { session: parent, authStorage: parentAuth } = await createSession(tempDir);
-		sessions.push(parent);
-		authStorages.push(parentAuth);
-		parent.agent.appendMessage({ role: "user", content: "parent context", timestamp: Date.now() });
-		const seed = await parent.buildForkContextSeed({ maxMessages: 50, maxTokens: 10_000 });
-		expect(seed.metadata.includedMessages).toBeGreaterThan(0);
-
-		// TaskTool allocates one session file per detached child; the initial run
-		// and the detached resume both open it via SessionManager.open with an
-		// explicit destination (task/index.ts resume runner -> executor).
-		const childSessionFile = path.join(tempDir, "child-task.jsonl");
-		const { session: child, authStorage: childAuth } = await createSession(tempDir, {
-			forkContextSeed: seed,
-			sessionManager: await SessionManager.open(
-				childSessionFile,
-				SessionManager.explicitDestination(path.dirname(childSessionFile)),
-			),
+			expect(childA.messages.slice(0, seedA.agentMessages.length)).toEqual(seedA.agentMessages);
+			expect(childA.sessionManager.getSessionFile()).toBe(path.join(artifactsDir, "0-child-a.jsonl"));
+			expect(childB.sessionManager.getSessionFile()).toBe(path.join(artifactsDir, "1-child-b.jsonl"));
+			// Nested managed persistence intentionally preserves the lifecycle-owned logical
+			// header while provider continuity must be child-owned and collision-free.
+			expect(childA.sessionManager.getSessionId()).toBe(parent.sessionManager.getSessionId());
+			expect(childB.sessionManager.getSessionId()).toBe(parent.sessionManager.getSessionId());
+			expect(childA.agent.providerSessionId).not.toBe(parent.sessionId);
+			expect(childB.agent.providerSessionId).not.toBe(parent.sessionId);
+			expect(childA.agent.providerSessionId).not.toBe(childB.agent.providerSessionId);
 		});
-		sessions.push(child);
-		authStorages.push(childAuth);
-		const childSessionId = child.sessionId;
-		expect(child.agent.providerSessionId).toBe(childSessionId);
-		expect(childSessionId).not.toBe(parent.sessionId);
+	}, 15_000);
 
-		// Persist one child turn the way AgentSession does on message_end, so the
-		// session file holds state the seed does not contain.
-		const persistedTurn: Message = {
-			role: "user",
-			content: [{ type: "text", text: "persisted child turn" }],
-			attribution: "user",
-			timestamp: Date.now(),
-		};
-		child.agent.appendMessage(persistedTurn);
-		child.sessionManager.appendMessage(persistedTurn);
-		await child.sessionManager.flush();
-		await child.dispose();
+	it("keeps a nested managed child provider identity across detached resume", async () => {
+		await withLifecycleIdentity("managed-resume-parent", async () => {
+			const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-task-detached-resume-${Snowflake.next()}-`));
+			tempDirs.push(tempDir);
+			const { session: parent, authStorage: parentAuth } = await createSession(tempDir);
+			sessions.push(parent);
+			authStorages.push(parentAuth);
+			parent.agent.appendMessage({ role: "user", content: "parent context", timestamp: Date.now() });
+			const seed = await parent.buildForkContextSeed({ maxMessages: 50, maxTokens: 10_000 });
+			const artifactsDir = path.join(tempDir, "artifacts");
+			const artifacts = new ArtifactManager(
+				new ManagedSessionDescendantStore(managedDirectoryRoot(tempDir), artifactsDir),
+			);
+			const persistence = createManagedTaskPersistence(artifacts, "0-resumable-child");
+			const childProviderSessionId = JSON.stringify(["subagent-canonical", parent.sessionId, "0-resumable-child"]);
+			const { session: child, authStorage: childAuth } = await createSession(tempDir, {
+				forkContextSeed: seed,
+				providerSessionId: childProviderSessionId,
+				sessionManager: await persistence.openSession(tempDir),
+			});
+			sessions.push(child);
+			authStorages.push(childAuth);
+			expect(child.agent.providerSessionId).toBe(childProviderSessionId);
+			const persistedTurn: Message = {
+				role: "user",
+				content: [{ type: "text", text: "persisted child turn" }],
+				attribution: "user",
+				timestamp: Date.now(),
+			};
+			child.agent.appendMessage(persistedTurn);
+			child.sessionManager.appendMessage(persistedTurn);
+			await child.sessionManager.flush();
+			await child.dispose();
 
-		// The resume descriptor replays the SAME fork seed alongside the persisted
-		// session file; identity and content must come from the session, not the seed.
-		const { session: resumed, authStorage: resumedAuth } = await createSession(tempDir, {
-			forkContextSeed: seed,
-			sessionManager: await SessionManager.open(
-				childSessionFile,
-				SessionManager.explicitDestination(path.dirname(childSessionFile)),
-			),
+			const { session: resumed, authStorage: resumedAuth } = await createSession(tempDir, {
+				forkContextSeed: seed,
+				providerSessionId: childProviderSessionId,
+				sessionManager: await persistence.openSession(tempDir),
+			});
+			sessions.push(resumed);
+			authStorages.push(resumedAuth);
+
+			expect(resumed.sessionManager.getSessionId()).toBe(parent.sessionManager.getSessionId());
+			expect(resumed.agent.providerSessionId).toBe(childProviderSessionId);
+			expect(resumed.agent.providerSessionId).not.toBe(parent.sessionId);
+			const restoredContent = resumed.messages.map(message => JSON.stringify(message));
+			expect(restoredContent.some(content => content.includes("persisted child turn"))).toBe(true);
+			expect(restoredContent.some(content => content.includes("parent context"))).toBe(false);
 		});
-		sessions.push(resumed);
-		authStorages.push(resumedAuth);
-
-		expect(resumed.agent.providerSessionId).toBe(childSessionId);
-		expect(resumed.agent.providerSessionId).not.toBe(parent.sessionId);
-		expect(resumed.agent.providerSessionId).not.toBe(seed.metadata.sourceSessionId);
-
-		const restoredContent = resumed.messages.map(message => JSON.stringify(message));
-		expect(restoredContent.some(content => content.includes("persisted child turn"))).toBe(true);
-		expect(restoredContent.some(content => content.includes("parent context"))).toBe(false);
 	}, 15_000);
 
 	it("honors an explicit providerSessionId over the fork seed and logical id", async () => {

--- a/packages/coding-agent/test/task-cache-key.test.ts
+++ b/packages/coding-agent/test/task-cache-key.test.ts
@@ -100,102 +100,98 @@ describe("task fork-context provider identity", () => {
 	});
 
 	it("gives nested managed children distinct provider identities without rewriting logical headers", async () => {
-		await withLifecycleIdentity("managed-parent-session", async () => {
-			const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-task-cache-key-${Snowflake.next()}-`));
-			tempDirs.push(tempDir);
-			const { session: parent, authStorage: parentAuth } = await createSession(tempDir);
-			sessions.push(parent);
-			authStorages.push(parentAuth);
-			parent.agent.appendMessage({ role: "user", content: "parent context", timestamp: Date.now() });
-			const seedA = await parent.buildForkContextSeed({ maxMessages: 50, maxTokens: 10_000 });
-			const seedB = await parent.buildForkContextSeed({ maxMessages: 50, maxTokens: 10_000 });
-			expect(seedA.metadata.includedMessages).toBeGreaterThan(0);
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-task-cache-key-${Snowflake.next()}-`));
+		tempDirs.push(tempDir);
+		const { session: parent, authStorage: parentAuth } = await createSession(tempDir);
+		sessions.push(parent);
+		authStorages.push(parentAuth);
+		parent.agent.appendMessage({ role: "user", content: "parent context", timestamp: Date.now() });
+		const seedA = await parent.buildForkContextSeed({ maxMessages: 50, maxTokens: 10_000 });
+		const seedB = await parent.buildForkContextSeed({ maxMessages: 50, maxTokens: 10_000 });
+		expect(seedA.metadata.includedMessages).toBeGreaterThan(0);
 
-			const artifactsDir = path.join(tempDir, "artifacts");
-			const artifacts = new ArtifactManager(
-				new ManagedSessionDescendantStore(managedDirectoryRoot(tempDir), artifactsDir),
-			);
-			const childAProviderSessionId = JSON.stringify(["subagent-canonical", parent.sessionId, "0-child-a"]);
-			const childBProviderSessionId = JSON.stringify(["subagent-canonical", parent.sessionId, "1-child-b"]);
-			const childAPersistence = createManagedTaskPersistence(artifacts, "0-child-a");
-			const childBPersistence = createManagedTaskPersistence(artifacts, "1-child-b");
-			const [{ session: childA, authStorage: authA }, { session: childB, authStorage: authB }] = await Promise.all([
-				createSession(tempDir, {
-					forkContextSeed: seedA,
-					providerSessionId: childAProviderSessionId,
-					sessionManager: await childAPersistence.openSession(tempDir),
-				}),
-				createSession(tempDir, {
-					forkContextSeed: seedB,
-					providerSessionId: childBProviderSessionId,
-					sessionManager: await childBPersistence.openSession(tempDir),
-				}),
-			]);
-			sessions.push(childA, childB);
-			authStorages.push(authA, authB);
+		const artifactsDir = path.join(tempDir, "artifacts");
+		const artifacts = new ArtifactManager(
+			new ManagedSessionDescendantStore(managedDirectoryRoot(tempDir), artifactsDir),
+		);
+		const childAProviderSessionId = JSON.stringify(["subagent-canonical", parent.sessionId, "0-child-a"]);
+		const childBProviderSessionId = JSON.stringify(["subagent-canonical", parent.sessionId, "1-child-b"]);
+		const childAPersistence = createManagedTaskPersistence(artifacts, "0-child-a");
+		const childBPersistence = createManagedTaskPersistence(artifacts, "1-child-b");
+		const [{ session: childA, authStorage: authA }, { session: childB, authStorage: authB }] = await Promise.all([
+			createSession(tempDir, {
+				forkContextSeed: seedA,
+				providerSessionId: childAProviderSessionId,
+				sessionManager: await withLifecycleIdentity(parent.sessionId, () => childAPersistence.openSession(tempDir)),
+			}),
+			createSession(tempDir, {
+				forkContextSeed: seedB,
+				providerSessionId: childBProviderSessionId,
+				sessionManager: await withLifecycleIdentity(parent.sessionId, () => childBPersistence.openSession(tempDir)),
+			}),
+		]);
+		sessions.push(childA, childB);
+		authStorages.push(authA, authB);
 
-			expect(childA.messages.slice(0, seedA.agentMessages.length)).toEqual(seedA.agentMessages);
-			expect(childA.sessionManager.getSessionFile()).toBe(path.join(artifactsDir, "0-child-a.jsonl"));
-			expect(childB.sessionManager.getSessionFile()).toBe(path.join(artifactsDir, "1-child-b.jsonl"));
-			// Nested managed persistence intentionally preserves the lifecycle-owned logical
-			// header while provider continuity must be child-owned and collision-free.
-			expect(childA.sessionManager.getSessionId()).toBe(parent.sessionManager.getSessionId());
-			expect(childB.sessionManager.getSessionId()).toBe(parent.sessionManager.getSessionId());
-			expect(childA.agent.providerSessionId).not.toBe(parent.sessionId);
-			expect(childB.agent.providerSessionId).not.toBe(parent.sessionId);
-			expect(childA.agent.providerSessionId).not.toBe(childB.agent.providerSessionId);
-		});
+		expect(childA.messages.slice(0, seedA.agentMessages.length)).toEqual(seedA.agentMessages);
+		expect(childA.sessionManager.getSessionFile()).toBe(path.join(artifactsDir, "0-child-a.jsonl"));
+		expect(childB.sessionManager.getSessionFile()).toBe(path.join(artifactsDir, "1-child-b.jsonl"));
+		// Nested managed persistence intentionally preserves the lifecycle-owned logical
+		// header while provider continuity must be child-owned and collision-free.
+		expect(childA.sessionManager.getSessionId()).toBe(parent.sessionManager.getSessionId());
+		expect(childB.sessionManager.getSessionId()).toBe(parent.sessionManager.getSessionId());
+		expect(childA.agent.providerSessionId).not.toBe(parent.sessionId);
+		expect(childB.agent.providerSessionId).not.toBe(parent.sessionId);
+		expect(childA.agent.providerSessionId).not.toBe(childB.agent.providerSessionId);
 	}, 15_000);
 
 	it("keeps a nested managed child provider identity across detached resume", async () => {
-		await withLifecycleIdentity("managed-resume-parent", async () => {
-			const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-task-detached-resume-${Snowflake.next()}-`));
-			tempDirs.push(tempDir);
-			const { session: parent, authStorage: parentAuth } = await createSession(tempDir);
-			sessions.push(parent);
-			authStorages.push(parentAuth);
-			parent.agent.appendMessage({ role: "user", content: "parent context", timestamp: Date.now() });
-			const seed = await parent.buildForkContextSeed({ maxMessages: 50, maxTokens: 10_000 });
-			const artifactsDir = path.join(tempDir, "artifacts");
-			const artifacts = new ArtifactManager(
-				new ManagedSessionDescendantStore(managedDirectoryRoot(tempDir), artifactsDir),
-			);
-			const persistence = createManagedTaskPersistence(artifacts, "0-resumable-child");
-			const childProviderSessionId = JSON.stringify(["subagent-canonical", parent.sessionId, "0-resumable-child"]);
-			const { session: child, authStorage: childAuth } = await createSession(tempDir, {
-				forkContextSeed: seed,
-				providerSessionId: childProviderSessionId,
-				sessionManager: await persistence.openSession(tempDir),
-			});
-			sessions.push(child);
-			authStorages.push(childAuth);
-			expect(child.agent.providerSessionId).toBe(childProviderSessionId);
-			const persistedTurn: Message = {
-				role: "user",
-				content: [{ type: "text", text: "persisted child turn" }],
-				attribution: "user",
-				timestamp: Date.now(),
-			};
-			child.agent.appendMessage(persistedTurn);
-			child.sessionManager.appendMessage(persistedTurn);
-			await child.sessionManager.flush();
-			await child.dispose();
-
-			const { session: resumed, authStorage: resumedAuth } = await createSession(tempDir, {
-				forkContextSeed: seed,
-				providerSessionId: childProviderSessionId,
-				sessionManager: await persistence.openSession(tempDir),
-			});
-			sessions.push(resumed);
-			authStorages.push(resumedAuth);
-
-			expect(resumed.sessionManager.getSessionId()).toBe(parent.sessionManager.getSessionId());
-			expect(resumed.agent.providerSessionId).toBe(childProviderSessionId);
-			expect(resumed.agent.providerSessionId).not.toBe(parent.sessionId);
-			const restoredContent = resumed.messages.map(message => JSON.stringify(message));
-			expect(restoredContent.some(content => content.includes("persisted child turn"))).toBe(true);
-			expect(restoredContent.some(content => content.includes("parent context"))).toBe(false);
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-task-detached-resume-${Snowflake.next()}-`));
+		tempDirs.push(tempDir);
+		const { session: parent, authStorage: parentAuth } = await createSession(tempDir);
+		sessions.push(parent);
+		authStorages.push(parentAuth);
+		parent.agent.appendMessage({ role: "user", content: "parent context", timestamp: Date.now() });
+		const seed = await parent.buildForkContextSeed({ maxMessages: 50, maxTokens: 10_000 });
+		const artifactsDir = path.join(tempDir, "artifacts");
+		const artifacts = new ArtifactManager(
+			new ManagedSessionDescendantStore(managedDirectoryRoot(tempDir), artifactsDir),
+		);
+		const persistence = createManagedTaskPersistence(artifacts, "0-resumable-child");
+		const childProviderSessionId = JSON.stringify(["subagent-canonical", parent.sessionId, "0-resumable-child"]);
+		const { session: child, authStorage: childAuth } = await createSession(tempDir, {
+			forkContextSeed: seed,
+			providerSessionId: childProviderSessionId,
+			sessionManager: await withLifecycleIdentity(parent.sessionId, () => persistence.openSession(tempDir)),
 		});
+		sessions.push(child);
+		authStorages.push(childAuth);
+		expect(child.agent.providerSessionId).toBe(childProviderSessionId);
+		const persistedTurn: Message = {
+			role: "user",
+			content: [{ type: "text", text: "persisted child turn" }],
+			attribution: "user",
+			timestamp: Date.now(),
+		};
+		child.agent.appendMessage(persistedTurn);
+		child.sessionManager.appendMessage(persistedTurn);
+		await child.sessionManager.flush();
+		await child.dispose();
+
+		const { session: resumed, authStorage: resumedAuth } = await createSession(tempDir, {
+			forkContextSeed: seed,
+			providerSessionId: childProviderSessionId,
+			sessionManager: await withLifecycleIdentity(parent.sessionId, () => persistence.openSession(tempDir)),
+		});
+		sessions.push(resumed);
+		authStorages.push(resumedAuth);
+
+		expect(resumed.sessionManager.getSessionId()).toBe(parent.sessionManager.getSessionId());
+		expect(resumed.agent.providerSessionId).toBe(childProviderSessionId);
+		expect(resumed.agent.providerSessionId).not.toBe(parent.sessionId);
+		const restoredContent = resumed.messages.map(message => JSON.stringify(message));
+		expect(restoredContent.some(content => content.includes("persisted child turn"))).toBe(true);
+		expect(restoredContent.some(content => content.includes("parent context"))).toBe(false);
 	}, 15_000);
 
 	it("honors an explicit providerSessionId over the fork seed and logical id", async () => {

--- a/packages/coding-agent/test/task/executor-managed-resume.test.ts
+++ b/packages/coding-agent/test/task/executor-managed-resume.test.ts
@@ -138,7 +138,9 @@ describe("runSubprocess managed child resume", () => {
 
 		const manager = new AsyncJobManager({ onJobComplete: async () => {} });
 		AsyncJobManager.setInstance(manager);
-		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(createSuccessfulResumeSession()));
+		const createAgentSessionSpy = vi
+			.spyOn(sdkModule, "createAgentSession")
+			.mockResolvedValue(createSessionResult(createSuccessfulResumeSession()));
 		const agent: AgentDefinition = {
 			name: "executor",
 			description: "test executor",
@@ -153,6 +155,7 @@ describe("runSubprocess managed child resume", () => {
 			index: 0,
 			id: "0-ManagedChild",
 			subagentId: "0-ManagedChild",
+			parentSessionId: parent.getSessionId(),
 			runMode: "message",
 			resumeMessage: "continue",
 			sessionFile: childFile,
@@ -169,6 +172,9 @@ describe("runSubprocess managed child resume", () => {
 
 		expect(result.exitCode).toBe(0);
 		expect(result.error).toBeUndefined();
+		expect(createAgentSessionSpy.mock.calls[0]?.[0]?.providerSessionId).toBe(
+			JSON.stringify(["subagent-canonical", parent.getSessionId(), "0-ManagedChild"]),
+		);
 		expect(result.extractedToolData?.yield).toEqual([
 			{ status: "success", data: { resumed: true }, error: undefined },
 		]);

--- a/packages/coding-agent/test/task/executor-managed-resume.test.ts
+++ b/packages/coding-agent/test/task/executor-managed-resume.test.ts
@@ -1,4 +1,3 @@
-import "../../src/tools/yield";
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";

--- a/packages/coding-agent/test/task/executor-managed-resume.test.ts
+++ b/packages/coding-agent/test/task/executor-managed-resume.test.ts
@@ -1,3 +1,4 @@
+import "../../src/tools/yield";
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -696,6 +696,57 @@ describe("runSubprocess yield reminders", () => {
 		expect(createAgentSessionSpy).toHaveBeenCalledTimes(1);
 	});
 
+	it("uses one stable child-owned identity for auth resolution and createAgentSession", async () => {
+		const session = createMockSession(({ emit }) => {
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-provider-identity",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+		});
+		const createAgentSessionSpy = mockCreateAgentSession(session);
+		const authSessionIds: Array<string | undefined> = [];
+
+		await runSubprocess({
+			...baseOptions,
+			id: "3-Child",
+			subagentId: "3-Child",
+			parentSessionId: "parent-session",
+			modelRegistry: {
+				refresh: async () => {},
+				getAvailable: () => [
+					{
+						id: "mock",
+						name: "mock",
+						provider: "openai",
+						api: "openai-responses",
+						baseUrl: "https://api.openai.com/v1",
+						reasoning: false,
+						input: ["text"],
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						contextWindow: 128_000,
+						maxTokens: 16_384,
+					} as Model,
+				],
+				getApiKey: async (_model: Model, sessionId?: string) => {
+					authSessionIds.push(sessionId);
+					return kNoAuth;
+				},
+			} as unknown as import("../../src/config/model-registry").ModelRegistry,
+			modelOverride: "openai/mock",
+		});
+
+		expect(createAgentSessionSpy.mock.calls[0]?.[0]?.providerSessionId).toBe(
+			JSON.stringify(["subagent-canonical", "parent-session", "3-Child"]),
+		);
+		expect(authSessionIds).toEqual([JSON.stringify(["subagent-canonical", "parent-session", "3-Child"])]);
+	});
+
 	it("renders shared task context in subagent system prompt before now", async () => {
 		let userPrompt = "";
 		const session = createMockSession(({ text, emit }) => {

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { AgentBusyError, type AgentTelemetryConfig, type Tracer } from "@gajae-code/agent-core";
 import { type AssistantMessage, type AssistantMessageEvent, Effort, type Model } from "@gajae-code/ai";
 import { kNoAuth } from "../../src/config/model-registry";
@@ -11,6 +11,7 @@ import * as sdkModule from "../../src/sdk";
 import type { AgentSession, AgentSessionEvent, ForkContextSeed, PromptOptions } from "../../src/session/agent-session";
 import type { AuthStorage } from "../../src/session/auth-storage";
 import { runSubprocess, SUBAGENT_WARNING_MISSING_YIELD } from "../../src/task/executor";
+import "../../src/tools/yield";
 
 import {
 	type AgentDefinition,
@@ -110,6 +111,9 @@ function mockCreateAgentSession(session: AgentSession) {
 }
 
 describe("runSubprocess yield reminders", () => {
+	beforeEach(() => {
+		AgentRegistry.resetGlobalForTests();
+	});
 	afterEach(() => {
 		vi.restoreAllMocks();
 	});

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import { AgentBusyError, type AgentTelemetryConfig, type Tracer } from "@gajae-code/agent-core";
 import { type AssistantMessage, type AssistantMessageEvent, Effort, type Model } from "@gajae-code/ai";
 import { kNoAuth } from "../../src/config/model-registry";
@@ -11,7 +11,6 @@ import * as sdkModule from "../../src/sdk";
 import type { AgentSession, AgentSessionEvent, ForkContextSeed, PromptOptions } from "../../src/session/agent-session";
 import type { AuthStorage } from "../../src/session/auth-storage";
 import { runSubprocess, SUBAGENT_WARNING_MISSING_YIELD } from "../../src/task/executor";
-import "../../src/tools/yield";
 
 import {
 	type AgentDefinition,
@@ -111,9 +110,6 @@ function mockCreateAgentSession(session: AgentSession) {
 }
 
 describe("runSubprocess yield reminders", () => {
-	beforeEach(() => {
-		AgentRegistry.resetGlobalForTests();
-	});
 	afterEach(() => {
 		vi.restoreAllMocks();
 	});


### PR DESCRIPTION
## Summary
- derive each task child's provider-facing continuity identity from its durable parent/task ownership tuple
- use the same child identity for auth-aware model resolution, provider transport, and detached resume
- preserve nested managed logical session headers and artifact hierarchy

## TDD evidence
- RED: disabling the production `providerSessionId` handoff makes the real child execution seam test fail with `Received: undefined`
- GREEN: nested managed children have distinct provider identities, retain inherited conversation content, keep parent logical headers, and reopen the same identity on detached resume
- explicit `providerSessionId` precedence remains covered by `task-cache-key.test.ts`

## Verification
- `bun test packages/coding-agent/test/task-cache-key.test.ts packages/coding-agent/test/task-fork-context.test.ts` — 27 pass
- Responses replay focused production path — 2 pass
- child identity/auth seam focused test — pass
- `bun --cwd=packages/coding-agent run lint` — pass
- `bun --cwd=packages/coding-agent run check` — pass
- bounded live parallel Pooler smoke — two executor children (`0-PackageIdentityA`, `1-PackageIdentityB`) completed; both returned `@gajae-code/coding-agent` `0.12.19`; observed Pooler traffic used `codex-pooler` and websocket-success counters increased with no `owner_busy` metric present

## Canonical repository check limitation
`bun run check` was run twice. It remains red outside this diff due to existing `crates/pi-natives/src/computer/controller.rs` clippy failures and two `telegram-daemon-generation-guard.test.ts` timeouts. The targeted package checks are green.

## Adversarial review
Independent architecture review found one high-severity credential-affinity mismatch. Repaired by passing the child canonical identity to `resolveModelOverrideWithAuthFallback`; regression now asserts auth lookup and `createAgentSession` receive the same identity.
