### PR TITLE
fix(session): repair post-merge persistence races

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -782,8 +782,8 @@ export interface PromptOptions {
 	 */
 	onPreflightAccepted?: () => void;
 	/**
-	 * Awaitable durable-accept fence. Called after preflight and before queue mutation
-	 * or `#promptAgentWithIdleRetry`. SDK bus installs a closure that fsyncs acceptance.
+	 * Awaitable durable-accept fence. Called after preflight and immediately before
+	 * agent execution begins. SDK bus installs a closure that fsyncs acceptance.
 	 */
 	onPreflightAcceptCommit?: () => void | Promise<void>;
 	/** Skill-only: prepared metadata before the durable fence (path/lineCount/cleanedArgs). */
@@ -9074,16 +9074,18 @@ export class AgentSession {
 					if (this.#cancelAndSubmitInProgress) this.#cancelAndSubmitPendingNextTurnDrained = true;
 				},
 			};
-			if (options?.onPreflightAcceptCommit) await options.onPreflightAcceptCommit();
-			else options?.onPreflightAccepted?.();
 			if (options?.onFinalPreflight && !(await options.onFinalPreflight({ hasPendingNextTurnMessages }))) {
 				this.#resetInjectedContextSignatures();
 				return;
 			}
-			this.#throwIfPromptPreflightCancelled(generation, preflightSignal);
 			await this.#promptAgentWithIdleRetry(preSubmit, agentPromptOptions, predecessorAgentEndHold, {
 				signal: preflightSignal,
 				resourceRunId: this.#runResourceLeaseContext.getStore()?.resourceRunId,
+				onPreflightAccepted: () => {
+					this.#throwIfPromptPreflightCancelled(generation, preflightSignal);
+					if (options?.onPreflightAcceptCommit) return options.onPreflightAcceptCommit();
+					options?.onPreflightAccepted?.();
+				},
 			});
 			const terminalAssistant = this.#findLastAssistantMessage();
 			if (
@@ -16096,13 +16098,18 @@ export class AgentSession {
 			onRunAccepted?: (handle: AttemptRunHandle) => void;
 		},
 		predecessorAgentEndHold?: symbol,
-		seam?: { signal?: AbortSignal; resourceRunId?: string },
+		seam?: {
+			signal?: AbortSignal;
+			resourceRunId?: string;
+			onPreflightAccepted?: () => void | Promise<void>;
+		},
 	): Promise<void> {
 		const deadline = Date.now() + 30_000;
 		let continuationHold = predecessorAgentEndHold;
 		// R3.2 helper-local compact-once flag: fresh per prompt; the inline retry
 		// re-runs Phase B via preSubmit after the forced compaction.
 		let overflowRetried = false;
+		let preflightAccepted = false;
 		for (;;) {
 			try {
 				const predecessorAgentEnd = this.#claimDeferredAgentEndForContinuation(
@@ -16111,6 +16118,10 @@ export class AgentSession {
 				continuationHold = undefined;
 				try {
 					const messages = await preSubmit.build();
+					if (!preflightAccepted) {
+						await seam?.onPreflightAccepted?.();
+						preflightAccepted = true;
+					}
 					await this.agent.prompt(messages, options);
 					this.#releaseDeferredAgentEndLease(predecessorAgentEnd);
 					return;

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -7802,7 +7802,7 @@ export class SessionManager {
 	}
 
 	/** Initialize with a specific session file (used by factory methods). */
-	async #initSessionFile(sessionFile: string): Promise<void> {
+	async #initSessionFile(sessionFile: string, initializeMissing = false): Promise<void> {
 		const resolvedSessionFile = this.storage instanceof FileSessionStorage ? path.resolve(sessionFile) : sessionFile;
 		const sidecarRoot = resolvedSessionFile.endsWith(".jsonl")
 			? resolvedSessionFile.slice(0, -6)
@@ -7823,7 +7823,7 @@ export class SessionManager {
 			writeTerminalBreadcrumb(this.cwd, resolvedSessionFile);
 			return;
 		}
-		if (!this.storage.existsSync(resolvedSessionFile)) {
+		if (initializeMissing && !this.storage.existsSync(resolvedSessionFile)) {
 			const fresh = this.#freshSessionState(undefined, resolvedSessionFile);
 			const prepared = this.#prepareFreshSessionTransition(fresh, "memory-fallback");
 			this.#applyFreshSessionMetadata(fresh);
@@ -13480,6 +13480,7 @@ export class SessionManager {
 				await this.#closePersistWriterInternal();
 				this.#flushed = true;
 			}
+			if (this.#needsFullRewriteOnNextPersist) await this.#rewriteFileContents();
 		});
 		this.#retireEphemeralArtifacts();
 		await this.#drainEphemeralArtifactCleanups();
@@ -14481,11 +14482,11 @@ export class SessionManager {
 				}
 				const writer = this.#ensurePersistWriter();
 				if (!writer) {
-					// `#ensurePersistWriter` returns undefined here only when the cached
-					// writer is mid-close (the `!persist`/`!sessionFile` cases are
-					// rejected above). Route through `#rewriteFile` so the entry — which
-					// is already in `#fileEntries` — persists once the close drains.
-					this.#rewriteFile().catch(() => {});
+					// The cached writer is closing. Preserve the appended in-memory entry for
+					// a full rewrite after close drains instead of queueing a rewrite that the
+					// concurrent close could release before it runs.
+					this.#needsFullRewriteOnNextPersist = true;
+					this.#flushed = false;
 					return;
 				}
 				const materializedEntry = materializeResidentEntryForPersistenceSync(
@@ -16727,7 +16728,7 @@ export class SessionManager {
 				if (inspected.error.reason === "missing") {
 					const manager = new SessionManager(getProjectDir(), destination.directory, true, storage, destination);
 					manager.#sessionMemoryMode = sessionMemoryMode;
-					await manager.#initSessionFile(filePath);
+					await manager.#initSessionFile(filePath, true);
 					return manager;
 				}
 				if (inspected.error.reason === "oversized")
@@ -16752,7 +16753,7 @@ export class SessionManager {
 			if (inspected.reason === "missing") {
 				const manager = new SessionManager(getProjectDir(), destination.directory, true, storage, destination);
 				manager.#sessionMemoryMode = sessionMemoryMode;
-				await manager.#initSessionFile(filePath);
+				await manager.#initSessionFile(filePath, true);
 				return manager;
 			}
 			if (inspected.reason === "oversized") throw new SessionTranscriptOversizedError(inspected.size ?? 0);

--- a/packages/coding-agent/test/session-manager-close-race.test.ts
+++ b/packages/coding-agent/test/session-manager-close-race.test.ts
@@ -55,6 +55,9 @@ class CloseHoldingStorage implements SessionStorage {
 			fsync() {
 				return inner.fsync();
 			},
+			fsyncSync() {
+				inner.fsyncSync?.();
+			},
 			async close() {
 				const gate = Promise.withResolvers<void>();
 				gates.push(gate);


### PR DESCRIPTION
Fixes #4078.

Repairs two production seams exposed by post-merge Dev CI:
- preserve entries appended while a persistent writer is closing by forcing the rewrite before session state is released;
- report SDK preflight acceptance only after the final pre-submit build succeeds and the agent is about to receive the prompt.

Focused evidence: `bun test packages/coding-agent/test/session-manager-close-race.test.ts packages/coding-agent/test/agent-session-before-agent-start-attribution.test.ts packages/coding-agent/test/session-manager/move-to.test.ts packages/coding-agent/test/session-resident-cache.test.ts packages/coding-agent/test/resume-headless-process.test.ts` — 43 passing.

Full affected-shard failures remain under investigation on this PR; no resume-confirm assertion patch from #4089 is duplicated here.