### PR TITLE
test(session): intercept renameSync so the EPERM recovery assertions actually run

### DIFF
--- a/packages/coding-agent/test/session-manager/rewrite-rename-eperm.test.ts
+++ b/packages/coding-agent/test/session-manager/rewrite-rename-eperm.test.ts
@@ -23,21 +23,21 @@ class RenameTrackingStorage extends MemorySessionStorage {
 class AsyncRenameEpermStorage extends MemorySessionStorage {
 	mode: "recover" | "rollback-failure" | undefined;
 
-	override rename(source: string, target: string): Promise<void> {
+	// The rewrite publishes inside a non-yielding fence, so replacement goes
+	// through `renameSync`. Intercepting the async `rename` here would never fire.
+	override renameSync(source: string, target: string): void {
 		if (this.mode && source.includes(".tmp") && target.endsWith(".jsonl")) {
 			if (this.mode === "recover") {
 				this.mode = undefined;
-				return Promise.reject(new FsCodeError("EPERM", "initial replacement rejected"));
+				throw new FsCodeError("EPERM", "initial replacement rejected");
 			}
-			if (!this.existsSync(target)) {
-				return Promise.reject(new Error("replacement retry rejected"));
-			}
-			return Promise.reject(new FsCodeError("EPERM", "initial replacement rejected"));
+			if (!this.existsSync(target)) throw new Error("replacement retry rejected");
+			throw new FsCodeError("EPERM", "initial replacement rejected");
 		}
 		if (this.mode === "rollback-failure" && source.endsWith(".bak") && target.endsWith(".jsonl")) {
-			return Promise.reject(new Error("rollback rejected"));
+			throw new Error("rollback rejected");
 		}
-		return super.rename(source, target);
+		return super.renameSync(source, target);
 	}
 }
 


### PR DESCRIPTION
Fixes #4093. Test-only: eight lines in one fake.

`shard-1-of-8` is red on `dev`, so every open PR inherits a failure unrelated to its diff. The cause is not the production code — it is that the fake never fires.

## What was wrong

`AsyncRenameEpermStorage` injects its EPERM by overriding the async `rename`. The rewrite prepares bytes asynchronously and then commits inside a non-yielding fence, so replacement goes through `renameSync`:

- `session-manager.ts:13097` — `written = this.#withSessionPersistenceFenceSync(() => {`
- `session-manager.ts:13099` — `this.#writeEntriesAtomicallySync(entries);`

Publication therefore reaches `#replaceSessionFileAfterEpermSync` (`renameSync` at `:9609`, `:9612`, `:9619`, `:9624`), never the async twin the fake was built for.

A probe as the fake's first statement prints zero times across the whole file while five tests still report green:

```ts
override rename(source: string, target: string): Promise<void> {
    process.stderr.write("RENAME-PROBE\n");   // 0 occurrences
```

Overriding every candidate named the real one in one run:

```
CALLS=["renameSync"]
```

## Why this was worse than a red test

The one failing test was the honest half. The other four asserted against an unobstructed rewrite: the transcript contains `"content":"first"` and no `.bak` is left behind — both true when nothing goes wrong, so they held with the recovery logic deleted.

Mutation, removing the backup/retry/rollback block from `#replaceSessionFileAfterEpermSync`:

| | old fake | this PR |
|---|---|---|
| recovery intact | 5 pass, 1 fail | **6 pass, 0 fail** |
| recovery deleted | 5 pass, 1 fail — *unchanged* | **4 pass, 2 fail** |

The old file returns an identical verdict whether or not the code it names exists. `expect()` calls rise 17 → 19 here, which is the dead assertions starting to execute.

## The change

`renameSync` instead of `rename`, throwing instead of rejecting. The three-phase shape is unchanged — initial replacement rejected, retry rejected, rollback rejected — and every assertion in the file is untouched, because they were already correct. The sync twin composes the same message and sets the same `cause`, so they now pass against the path that actually runs.

## Known and not fixed

The async twin at `session-manager.ts:9653` is a second implementation of transcript replacement that this file no longer exercises. I did not establish whether it still has a live caller, so I left it alone rather than deleting it on a guess — worth a maintainer's read, since an untested duplicate of the path that rewrites session history is exactly where a mistake goes unnoticed.

I also did not audit other suites for the same pattern. Any fake injecting failures through async storage methods is bypassed by the sync publication path in the same way, and would look green while proving nothing.

Found while triaging CI on #4087, whose diff cannot reach `SessionManager`.
