### PR TITLE
test(setup): redirect the agent dir before onboarding writes a literal key into the real credential store

### DIFF
--- a/packages/coding-agent/test/provider-onboarding.test.ts
+++ b/packages/coding-agent/test/provider-onboarding.test.ts
@@ -26,6 +26,9 @@ const originalAgentDir = getAgentDir();
 
 async function tempModelsPath(): Promise<string> {
 	tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-provider-onboarding-"));
+	// Literal `apiKey` values route through AuthStorage at getAgentDbPath(); without
+	// this the tests write real credential rows into the developer's ~/.gjc/agent/agent.db.
+	setAgentDir(path.join(tempRoot, "agent"));
 	return path.join(tempRoot, "models.yml");
 }
 


### PR DESCRIPTION
Running `provider-onboarding.test.ts` writes a credential row into the developer's real `~/.gjc/agent/agent.db`.

## What happens

The literal-key case creates a temp root for its models file but never moves the agent dir, so `getAgentDbPath()` at `provider-onboarding.test.ts:414` still resolves to the real one. `addApiCompatibleProvider({ apiKey: "literal-secret", ... })` then persists through `AuthStorage` into the developer's own database.

The file looks isolated, which is why this went unnoticed: it imports `setAgentDir`, captures `originalAgentDir`, and restores it in `afterEach`. It restores a value it never changed. The sibling case two tests down — "stores literal keys in the canonical agent database with a custom models path" — already does the right thing:

```ts
tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-provider-onboarding-"));
setAgentDir(path.join(tempRoot, "agent"));
```

This adds the same two lines to the case that was missed.

## Evidence

My own `agent.db` had the fixture sitting in it, dated the day I first ran this suite:

```console
$ sqlite3 ~/.gjc/agent/agent.db "SELECT id, provider, credential_type, datetime(created_at,'unixepoch','localtime') FROM auth_credentials;"
1|jetbrains-junie|oauth|2026-06-24 05:00:59
2|anthropic|oauth|2026-07-20 17:43:38
3|anthropic|oauth|2026-07-20 19:14:47
4|claude-proxy|api_key|2026-07-20 20:52:12
5|literal-key-provider|api_key|2026-07-20 20:52:12
```

Re-running only overwrites that row, so the count never grows and nothing looks wrong. Deleting it first makes the write obvious:

|step|result|
|---|---|
|delete the row, run unpatched|**reappears as a new id** — `6\|literal-key-provider\|api_key`|
|delete the row, run patched|**stays absent**, only the four real credentials remain|

22 pass either way — the suite cannot tell the difference, which is the point.

## Why it matters beyond the junk row

`SqliteAuthCredentialStore.open(getAgentDbPath())` is opened read-write against a file holding live OAuth and API-key credentials, in a test that is expected to be safe to run on any developer machine and in any sandbox that mounts a real home. A test asserting on credential storage should never be able to reach the real store; the failure mode is silent, and the blast radius is whatever else that database holds.

## Not verified

I did not audit whether other suites reach `getAgentDbPath()` without redirecting first. Worth a sweep — the pattern here is that importing `setAgentDir` and restoring it in teardown reads as isolation without providing any.
