### PR TITLE
fix(ai): widen Anthropic reasoning idle window

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - OpenAI Responses transports no longer send tool declarations whose names the provider reserves for its own built-ins. OpenCode Zen/Go reject `web_search` as a custom function with `invalid tools in request: custom function name "web_search" is reserved`, and that rejection is request-scoped — one colliding declaration failed the entire tools array before any token streamed, so the bundled `critic`, `planner`, and `architect` agents failed 100% of the time on those providers (#4104). The collision is dropped rather than renamed, because a renamed function tool returns as a `function_call` under the wire alias and that path does not populate `Tool.customWireName`, which would leave the agent-loop dispatcher unable to route the call. `compat.reservedToolNames` overrides the per-provider default.
-
+- Anthropic streams now use a 300-second default idle window so long extended-thinking gaps do not trip the shared 120-second watchdog; explicit stream timeout overrides still take precedence.
 ## [0.12.19] - 2026-08-08
 
 ## [0.12.18] - 2026-08-08

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -68,6 +68,7 @@ import { finalizeErrorMessage, type RawHttpRequestDump, rewriteCopilotError } fr
 import {
 	FirstEventTimeoutError,
 	getProviderFirstEventTimeoutFallbackMs,
+	getProviderStreamIdleTimeoutFallbackMs,
 	getStreamFirstEventTimeoutMs,
 	getStreamIdleTimeoutMs,
 	iterateWithIdleTimeout,
@@ -1579,7 +1580,9 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 				truncatedToolCalls.clear();
 				sawTerminalStopReason = false;
 			};
-			const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getStreamIdleTimeoutMs();
+			const idleTimeoutMs =
+				options?.streamIdleTimeoutMs ??
+				getStreamIdleTimeoutMs(getProviderStreamIdleTimeoutFallbackMs(model.provider));
 			const firstEventFallbackMs = getProviderFirstEventTimeoutFallbackMs(model.provider);
 			const firstEventTimeoutMs =
 				options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs, firstEventFallbackMs);

--- a/packages/ai/src/utils/idle-iterator.ts
+++ b/packages/ai/src/utils/idle-iterator.ts
@@ -6,6 +6,12 @@ const DEFAULT_STREAM_FIRST_EVENT_TIMEOUT_MS = 100_000;
 const ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS = 600_000;
 const KIMI_CODE_FIRST_EVENT_TIMEOUT_MS = 300_000;
 
+const ANTHROPIC_STREAM_IDLE_TIMEOUT_MS = 300_000;
+
+export function getProviderStreamIdleTimeoutFallbackMs(provider: string): number | undefined {
+	return provider === "anthropic" ? ANTHROPIC_STREAM_IDLE_TIMEOUT_MS : undefined;
+}
+
 export function getProviderFirstEventTimeoutFallbackMs(provider: string): number | undefined {
 	if (provider === "alibaba-token-plan") return ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS;
 	return provider === "kimi-code" ? KIMI_CODE_FIRST_EVENT_TIMEOUT_MS : undefined;

--- a/packages/ai/test/stream-timeout-defaults.test.ts
+++ b/packages/ai/test/stream-timeout-defaults.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
 	getOpenAIStreamIdleTimeoutMs,
 	getProviderFirstEventTimeoutFallbackMs,
+	getProviderStreamIdleTimeoutFallbackMs,
 	getStreamFirstEventTimeoutMs,
 	getStreamIdleTimeoutMs,
 	resolveOpenAISdkRequestTimeoutMs,
@@ -43,6 +44,15 @@ afterEach(() => {
 	}
 });
 
+describe("getProviderStreamIdleTimeoutFallbackMs(provider)", () => {
+	it("gives Anthropic a 300-second idle window for long reasoning gaps", () => {
+		expect(getProviderStreamIdleTimeoutFallbackMs("anthropic")).toBe(300_000);
+	});
+
+	it("does not widen unrelated providers", () => {
+		expect(getProviderStreamIdleTimeoutFallbackMs("kimi-code")).toBeUndefined();
+	});
+});
 describe("getProviderFirstEventTimeoutFallbackMs(provider)", () => {
 	it("gives Alibaba Token Plan one continuous 600-second first-event window", () => {
 		expect(getProviderFirstEventTimeoutFallbackMs("alibaba-token-plan")).toBe(600_000);


### PR DESCRIPTION
## Summary

- give Anthropic streams a provider-specific 300-second steady-state idle fallback
- preserve explicit `streamIdleTimeoutMs` and environment overrides, including `0`
- keep Anthropic ping events non-progress so genuinely stalled streams remain bounded
- add provider-fallback regression coverage and an unreleased changelog entry

Fixes #4096.

## Why

Persisted Sonnet 5 `max`-reasoning turns repeatedly show this sequence:

- response ID assigned
- thinking block opened (`ttft` 1.8–3.1s)
- no thinking delta before the shared 120s deadline
- terminal `Anthropic stream stalled while waiting for the next event` at 121.9–130.4s

That is a healthy long-reasoning gap after semantic startup, not a first-event failure. The existing remediation hint already recommends 300 seconds. Applying that value only as Anthropic's default avoids weakening the watchdog for other providers.

Counting pings as progress was rejected because it would regress #3167 and allow a ping-only dead stream to live forever.

## Verification

- `bun test packages/ai/test/stream-timeout-defaults.test.ts packages/ai/test/anthropic-stream-timeout.test.ts` — 30 pass
- `bun --cwd=packages/ai run check` — Biome and TypeScript pass
- `git diff --check`

## Scope

No retry policy, ping classification, first-event timeout, or non-Anthropic default changes.