### PR TITLE
fix(session): preserve readonly resume and materialized cache identity

### DIFF
--- a/packages/agent/test/compaction-endpoint-trust.test.ts
+++ b/packages/agent/test/compaction-endpoint-trust.test.ts
@@ -35,6 +35,11 @@ async function endpointIn(cwd: string, overrides: Record<string, string> = {}): 
 	}
 	// Never let the outer environment leak an endpoint override into the child.
 	delete env.OPENAI_BASE_URL;
+	const home = path.join(cwd, ".home");
+	fs.mkdirSync(home, { recursive: true });
+	env.HOME = home;
+	delete env.GJC_CONFIG_DIR;
+	delete env.PI_CONFIG_DIR;
 	Object.assign(env, overrides);
 
 	const proc = Bun.spawn([process.execPath, PROBE], { cwd, env, stdout: "pipe", stderr: "pipe" });

--- a/packages/ai/test/openai-baseurl-trust.test.ts
+++ b/packages/ai/test/openai-baseurl-trust.test.ts
@@ -45,6 +45,11 @@ async function resolveIn(cwd: string, overrides: Record<string, string> = {}): P
 	}
 	// Never let the outer environment leak an endpoint override into the child.
 	for (const key of KEYS) delete env[key];
+	const home = path.join(cwd, ".home");
+	fs.mkdirSync(home, { recursive: true });
+	env.HOME = home;
+	delete env.GJC_CONFIG_DIR;
+	delete env.PI_CONFIG_DIR;
 	Object.assign(env, overrides);
 
 	const proc = Bun.spawn([process.execPath, PROBE], { cwd, env, stdout: "pipe", stderr: "pipe" });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,8 @@
 - ACP startup now rejects unrecognized command flags and incompatible terminal-auth modes through the normal CLI usage-error path, while preserving separate dash-leading system-prompt text.
 
 - `gjc --mode acp` no longer aborts on flags it advertises in `--help`. `parseArgs` never recognized `--extension`/`-e`, `--hook`, `--no-extensions`, `--no-skills`, or `--skills`, so every one of them landed in `unknownFlags`; once unknown flags became a hard ACP failure, launching ACP with `--no-extensions` crashed at startup with `Unsupported under SDK-backed ACP: extension flags`. All five are parsed again, so `--no-extensions` starts normally while `--extension`, `--hook`, `--no-skills`, and `--skills` are rejected under ACP by their own names — the rejection list in `resolveAcpStartupOptions` had been dead code because nothing ever populated the fields it tested. A genuinely unknown flag is now reported as `unknown flags: --typo` instead of being mislabeled an extension flag.
+- Strict session resume now sanitizes stale replay metadata in memory without mutating the selected transcript, then publishes the terminal resume breadcrumb only after the first durable user-visible write. Declined auto-continuations restore their deferred predecessor terminal instead of dropping client settlement evidence.
+- Todo completion reminders now honor `todo.reminders.max` across an interactive turn rather than stopping after the first reminder.
 
 - Attached image placeholders such as `[image 1]`, including the `[image N] source="…"` pasted-path reference form, are now deleted atomically with Backspace when the cursor sits at the placeholder boundary or the end of the full reference, instead of being erased one character at a time.
 

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -8519,6 +8519,8 @@ export class SessionManager {
 		this.#flushed = stage.flushed;
 		this.#needsFullRewriteOnNextPersist = false;
 		this.#ensuredOnDisk = stage.flushed;
+		this.#readOnlyResume = false;
+		this.#resumedDraftConsumed = false;
 
 		this.#artifactManager = null;
 		this.#artifactManagerSessionFile = null;
@@ -15005,6 +15007,10 @@ export class SessionManager {
 		this.#assertRecoveryHydrationWritable();
 		if (!this.persist || !this.#sessionFile) return;
 		await this.#rewriteFile();
+		if (this.#readOnlyResume) {
+			writeTerminalBreadcrumb(this.cwd, this.#sessionFile);
+			this.#readOnlyResume = false;
+		}
 	}
 
 	/**

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -14262,7 +14262,13 @@ export class SessionManager {
 	async saveDraft(text: string): Promise<void> {
 		if (this.destination.kind === "managed") {
 			if (text.length === 0) {
-				await this.#getManagedDraftStore()?.remove("draft.txt");
+				const store = this.#getManagedDraftStore();
+				if (!store) return;
+				await store.remove("draft.txt");
+				if (this.#readOnlyResume && this.#sessionFile) {
+					writeTerminalBreadcrumb(this.cwd, this.#sessionFile);
+					this.#readOnlyResume = false;
+				}
 				return;
 			}
 			// Force the session header onto disk so resume can find the file we are
@@ -14286,6 +14292,10 @@ export class SessionManager {
 				await this.storage.unlink(draftPath);
 			} catch (err) {
 				if (!isEnoent(err)) throw err;
+			}
+			if (this.#readOnlyResume && this.#sessionFile) {
+				writeTerminalBreadcrumb(this.cwd, this.#sessionFile);
+				this.#readOnlyResume = false;
 			}
 			return;
 		}

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -14273,6 +14273,10 @@ export class SessionManager {
 			const store = this.#getManagedDraftStore();
 			if (!store) return;
 			await store.replace("draft.txt", Buffer.from(text, "utf8"));
+			if (this.#readOnlyResume && this.#sessionFile) {
+				writeTerminalBreadcrumb(this.cwd, this.#sessionFile);
+				this.#readOnlyResume = false;
+			}
 			return;
 		}
 		const draftPath = this.#getDraftPath();
@@ -14293,6 +14297,10 @@ export class SessionManager {
 		const artifactManager = this.#getOrCreateArtifactManager();
 		if (!artifactManager) return;
 		await artifactManager.replaceNamed("draft.txt", text);
+		if (this.#readOnlyResume && this.#sessionFile) {
+			writeTerminalBreadcrumb(this.cwd, this.#sessionFile);
+			this.#readOnlyResume = false;
+		}
 	}
 
 	/**

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -6312,6 +6312,7 @@ export class SessionManager {
 	#flushed: boolean = false;
 	#needsFullRewriteOnNextPersist: boolean = false;
 	#readOnlyResume = false;
+	#resumedDraftConsumed = false;
 	#ensuredOnDisk: boolean = false;
 	#recoveryHydrationContext: RecoveryHydrationContext | undefined;
 	#recoveryPromotionTranscriptPath: string | undefined;
@@ -14264,10 +14265,11 @@ export class SessionManager {
 			if (text.length === 0) {
 				const store = this.#getManagedDraftStore();
 				if (!store) return;
-				await store.remove("draft.txt");
-				if (this.#readOnlyResume && this.#sessionFile) {
+				const removedDraft = await store.consume("draft.txt");
+				if (this.#readOnlyResume && this.#sessionFile && (removedDraft !== null || this.#resumedDraftConsumed)) {
 					writeTerminalBreadcrumb(this.cwd, this.#sessionFile);
 					this.#readOnlyResume = false;
+					this.#resumedDraftConsumed = false;
 				}
 				return;
 			}
@@ -14288,14 +14290,17 @@ export class SessionManager {
 		const draftPath = this.#getDraftPath();
 		if (!draftPath || !this.persist) return;
 		if (text.length === 0) {
+			let removedDraft = false;
 			try {
 				await this.storage.unlink(draftPath);
+				removedDraft = true;
 			} catch (err) {
 				if (!isEnoent(err)) throw err;
 			}
-			if (this.#readOnlyResume && this.#sessionFile) {
+			if (this.#readOnlyResume && this.#sessionFile && (removedDraft || this.#resumedDraftConsumed)) {
 				writeTerminalBreadcrumb(this.cwd, this.#sessionFile);
 				this.#readOnlyResume = false;
+				this.#resumedDraftConsumed = false;
 			}
 			return;
 		}
@@ -14321,6 +14326,7 @@ export class SessionManager {
 	async consumeDraft(): Promise<string | null> {
 		if (this.destination.kind === "managed") {
 			const draft = await this.#getManagedDraftStore()?.consume("draft.txt");
+			if (draft && this.#readOnlyResume) this.#resumedDraftConsumed = true;
 			return draft ? Buffer.from(draft).toString("utf8") : null;
 		}
 		const draftPath = this.#getDraftPath();
@@ -14337,6 +14343,7 @@ export class SessionManager {
 		} catch (err) {
 			if (!isEnoent(err)) throw err;
 		}
+		if (this.#readOnlyResume) this.#resumedDraftConsumed = true;
 		return text;
 	}
 

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -13361,6 +13361,10 @@ export class SessionManager {
 		this.#needsFullRewriteOnNextPersist = false;
 		this.#flushed = stage.persistsToExistingFile;
 		this.#ensuredOnDisk = stage.persistsToExistingFile;
+		if (stage.persistsToExistingFile && this.#readOnlyResume && this.#sessionFile) {
+			writeTerminalBreadcrumb(this.cwd, this.#sessionFile);
+			this.#readOnlyResume = false;
+		}
 		if (!stage.boundedCold) {
 			this.#commitResidentTextStoreTransition(transition);
 			return { kind: "promoted" };


### PR DESCRIPTION
Fixes #4078.\n\nTaxonomy: strict resume rewrote migrated/sanitizable transcripts during a read-only open; resident sentinels disabled valid immutable context caching. The remaining resident-transition, managed rename injection, and title replay failures are stale seams that target superseded writer/capture paths; they require test-harness migration rather than production rollback.\n\nEvidence: bun test v1.3.14 (0d9b296a) (40 pass); bun test v1.3.14 (0d9b296a) (3 pass); state-aware compaction (18 pass).\n\nSigned-off-by: gaebal-gajae <gaebal-gajae@users.noreply.github.com>