### PR TITLE
fix(sdk): let a late agent_failed supply the reason a settled prompt lacks

### DIFF
--- a/packages/coding-agent/src/sdk/bus/kind-aware-reconciliation.ts
+++ b/packages/coding-agent/src/sdk/bus/kind-aware-reconciliation.ts
@@ -195,7 +195,21 @@ export function createKindAwareReconciliation(
 		if (!correlation) return;
 		await queueMutation(candidate => {
 			const record = candidate.get(keyOf(kind, correlation));
-			if (!record || record.terminalAt !== undefined) return { value: undefined, changed: false };
+			if (!record) return { value: undefined, changed: false };
+			if (record.terminalAt !== undefined) {
+				// The terminal is claimed by one delivery path while the reason arrives on
+				// another, so ordering is not the caller's to control. A late agent_failed
+				// enriches the settled record instead of being dropped; it must not resurrect
+				// it, so status, terminalAt, retention order, and the clientRef index stay
+				// as-is (cleanupRecords is intentionally not re-run). First reason wins: a
+				// late generic frame never overwrites a specific one. Persisted so the reason
+				// survives reconnect/restart reconciliation.
+				if (frame.type === "agent_failed" && record.error === undefined) {
+					record.error = sanitizePromptFailure(frame.error);
+					return { value: undefined, changed: true };
+				}
+				return { value: undefined, changed: false };
+			}
 			if (frame.type === "agent_start") {
 				if (record.status !== "accepted") return { value: undefined, changed: false };
 				record.status = "in_flight";
@@ -278,7 +292,12 @@ export function createKindAwareReconciliation(
 			terminalAt: record.terminalAt as number,
 			...(record.outcome !== undefined ? { outcome: record.outcome } : {}),
 		};
-		if (record.status === "terminal_ok") return { status: "terminal_ok", ...terminal };
+		if (record.status === "terminal_ok")
+			return {
+				status: "terminal_ok",
+				...terminal,
+				...(record.error !== undefined ? { error: record.error } : {}),
+			};
 		return { status: "failed", ...terminal, error: record.error ?? sanitizePromptFailure(undefined) };
 	};
 

--- a/packages/coding-agent/src/sdk/bus/prompt-reconciliation.ts
+++ b/packages/coding-agent/src/sdk/bus/prompt-reconciliation.ts
@@ -16,7 +16,9 @@
  *   Session-scoped durable retention (kind-aware store) is provided by reconciliation-store.ts (#3032).
  * - The clientRef index is session-runtime scoped; a ref conflicts only while
  *   retained and must never be reused as a retry mechanism.
- * - Terminal transitions settle once: the first terminal outcome wins.
+ * - Terminal transitions settle once: first terminal outcome wins. A late
+ *   `agent_failed` may still attach its sanitized reason to an already-terminal
+ *   record that has none, but never changes status, terminalAt, or retention.
  */
 
 import { PROMPT_FAILURE_CODE_MAX, sanitizePromptFailure } from "../prompt-failure";
@@ -67,6 +69,8 @@ export type TurnPromptReconciliation =
 			acceptedAt: number;
 			startedAt?: number;
 			terminalAt: number;
+			/** Present when a late `agent_failed` supplied the only failure reason. */
+			error?: { code: string; message: string };
 	  }
 	| {
 			status: "failed";
@@ -184,7 +188,17 @@ export function createPromptReconciliation(options: { now?: () => number } = {})
 	) => {
 		if (!correlation) return;
 		const record = records.get(keyOf(correlation));
-		if (!record || record.terminalAt !== undefined) return;
+		if (!record) return;
+		if (record.terminalAt !== undefined) {
+			// The terminal is claimed by one path while the reason arrives on another,
+			// so ordering is not the caller's to control. A late agent_failed enriches
+			// the settled record instead of being dropped; it must not resurrect it,
+			// so status, terminalAt, retention order, and clientRefIndex stay as-is.
+			// First reason wins: a late generic frame never overwrites a specific one.
+			if (frame.type === "agent_failed" && record.error === undefined)
+				record.error = sanitizePromptFailure(frame.error);
+			return;
+		}
 		if (frame.type === "agent_start") {
 			if (record.status === "accepted") {
 				record.status = "in_flight";
@@ -227,7 +241,12 @@ export function createPromptReconciliation(options: { now?: () => number } = {})
 			...(record.startedAt !== undefined ? { startedAt: record.startedAt } : {}),
 			terminalAt: record.terminalAt as number,
 		};
-		if (record.status === "terminal_ok") return { status: "terminal_ok", ...terminal };
+		if (record.status === "terminal_ok")
+			return {
+				status: "terminal_ok",
+				...terminal,
+				...(record.error !== undefined ? { error: record.error } : {}),
+			};
 		return { status: "failed", ...terminal, error: record.error ?? sanitizePromptFailure(undefined) };
 	};
 

--- a/packages/coding-agent/src/sdk/host/session-runtime.test.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.test.ts
@@ -104,6 +104,38 @@ test("a late agent failure never overwrites the reason an already terminal recor
 	expect(reconciliation.lookup("prompt", { clientRef: "first-reason-ref" })).toEqual(claimed);
 });
 
+test("a reason attached after a prompt settled is never replaced by a later failure", async () => {
+	const reconciliation = createInvocationReconciliation();
+	const correlation = { commandId: "late-reason-command", turnId: "late-reason-turn" };
+	await reconciliation.noteAccepted("prompt", correlation, "late-reason-ref");
+	await reconciliation.noteTransition("prompt", correlation, { type: "agent_end" });
+	const claimed = reconciliation.lookup("prompt", { clientRef: "late-reason-ref" }) as Record<string, unknown>;
+	expect(claimed).toEqual({
+		status: "terminal_ok",
+		commandId: "late-reason-command",
+		turnId: "late-reason-turn",
+		clientRef: "late-reason-ref",
+		acceptedAt: expect.any(Number),
+		terminalAt: expect.any(Number),
+	});
+	// A failure delivered after the record settled enriches it with the sanitized reason and
+	// leaves the terminal claim itself (status, terminalAt, identity) untouched.
+	await reconciliation.noteTransition("prompt", correlation, {
+		type: "agent_failed",
+		error: Object.assign(new Error("late provider failure"), { code: "upstream_error" }),
+	});
+	const enriched = reconciliation.lookup("prompt", { clientRef: "late-reason-ref" });
+	expect(enriched).toEqual({ ...claimed, error: { code: "upstream_error", message: "Prompt submission failed." } });
+	// First reason wins on the enrichment path too: a second, different late failure changes
+	// nothing. The sleep makes a re-stamped terminalAt observable.
+	await Bun.sleep(2);
+	await reconciliation.noteTransition("prompt", correlation, {
+		type: "agent_failed",
+		error: Object.assign(new Error("transport reset"), { code: "transport_reset" }),
+	});
+	expect(reconciliation.lookup("prompt", { clientRef: "late-reason-ref" })).toEqual(enriched);
+});
+
 test("redacts a persisted host failure during hydration", async () => {
 	const stateRoot = await mkdtemp(path.join(os.tmpdir(), "gjc-sdk-reconciliation-"));
 	const sessionId = "hydrated-failure";
@@ -509,16 +541,13 @@ describe("post-acceptance invocation terminalization", () => {
 			// A lifecycle frame arriving after the terminal must not resurrect the record either.
 			await harness.emit("agent_start");
 			const settled = await harness.query("turn.prompt_status", { commandId, turnId });
-			// A late reason may attach to a settled record that has none (#4105), so `error` is the
-			// only field allowed to appear; status, terminalAt, and identity stay exactly as claimed.
+			// The late reason attaches to the settled record, so `error` is the only field that may
+			// appear; status, terminalAt, and identity stay exactly as claimed.
 			const { error: _claimedReason, ...claimedTerminal } = claimed;
 			const { error: _lateReason, ...settledTerminal } = settled.result ?? {};
 			expect(settledTerminal).toEqual(claimedTerminal);
-			// Recorded or not, the reason is the sanitized late failure: never fabricated, never raw.
-			// Once #4105 lands the reason is always recorded, and this allow-list collapses to one shape.
-			expect([undefined, { code: "upstream_error", message: "Prompt submission failed." }]).toContainEqual(
-				settled.result?.error,
-			);
+			// The recorded reason is the sanitized late failure: never fabricated, never raw.
+			expect(settled.result?.error).toEqual({ code: "upstream_error", message: "Prompt submission failed." });
 			await harness.stop();
 		} finally {
 			await Bun.sleep(50);

--- a/packages/coding-agent/src/sdk/host/session-runtime.test.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.test.ts
@@ -80,6 +80,30 @@ test("preserves an agent failure code in host prompt reconciliation", async () =
 	});
 });
 
+test("a late agent failure never overwrites the reason an already terminal record carries", async () => {
+	const reconciliation = createInvocationReconciliation();
+	const correlation = { commandId: "first-reason-command", turnId: "first-reason-turn" };
+	await reconciliation.noteAccepted("prompt", correlation, "first-reason-ref");
+	await reconciliation.noteTransition("prompt", correlation, {
+		type: "agent_failed",
+		error: Object.assign(new Error("stream interrupted"), { code: "upstream_stream_interrupted" }),
+	});
+	const claimed = reconciliation.lookup("prompt", { clientRef: "first-reason-ref" });
+	expect(claimed).toMatchObject({
+		status: "failed",
+		error: { code: "upstream_stream_interrupted", message: "Prompt submission failed." },
+		terminalAt: expect.any(Number),
+	});
+	// First reason wins: a second, different late failure neither replaces the recorded
+	// reason nor re-stamps the terminal. The sleep makes a re-stamped terminalAt observable.
+	await Bun.sleep(2);
+	await reconciliation.noteTransition("prompt", correlation, {
+		type: "agent_failed",
+		error: Object.assign(new Error("transport reset"), { code: "transport_reset" }),
+	});
+	expect(reconciliation.lookup("prompt", { clientRef: "first-reason-ref" })).toEqual(claimed);
+});
+
 test("redacts a persisted host failure during hydration", async () => {
 	const stateRoot = await mkdtemp(path.join(os.tmpdir(), "gjc-sdk-reconciliation-"));
 	const sessionId = "hydrated-failure";
@@ -463,7 +487,7 @@ describe("post-acceptance invocation terminalization", () => {
 		}
 	});
 
-	test("a later provider error never overwrites an already terminal prompt", async () => {
+	test("a later provider error enriches but never re-opens an already terminal prompt", async () => {
 		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-terminalize-once-"));
 		try {
 			const inflight = Promise.withResolvers<void>();
@@ -477,14 +501,23 @@ describe("post-acceptance invocation terminalization", () => {
 			const { commandId, turnId } = accepted.result ?? {};
 			await harness.emit("agent_start");
 			await harness.emit("agent_end");
-			expect(await settledStatus(harness, "turn.prompt_status", { commandId, turnId })).toMatchObject({
-				status: "terminal_ok",
-			});
+			const claimed = await settledStatus(harness, "turn.prompt_status", { commandId, turnId });
+			expect(claimed).toMatchObject({ status: "terminal_ok" });
 			inflight.reject(Object.assign(new Error("late provider failure"), { code: "upstream_error" }));
 			await Bun.sleep(20);
+			// A lifecycle frame arriving after the terminal must not resurrect the record either.
+			await harness.emit("agent_start");
 			const settled = await harness.query("turn.prompt_status", { commandId, turnId });
-			expect(settled.result?.status).toBe("terminal_ok");
-			expect(settled.result?.error).toBeUndefined();
+			// A late reason may attach to a settled record that has none (#4105), so `error` is the
+			// only field allowed to appear; status, terminalAt, and identity stay exactly as claimed.
+			const { error: _claimedReason, ...claimedTerminal } = claimed;
+			const { error: _lateReason, ...settledTerminal } = settled.result ?? {};
+			expect(settledTerminal).toEqual(claimedTerminal);
+			// Recorded or not, the reason is the sanitized late failure: never fabricated, never raw.
+			// Once #4105 lands the reason is always recorded, and this allow-list collapses to one shape.
+			expect([undefined, { code: "upstream_error", message: "Prompt submission failed." }]).toContainEqual(
+				settled.result?.error,
+			);
 			await harness.stop();
 		} finally {
 			await Bun.sleep(50);

--- a/packages/coding-agent/src/sdk/host/session-runtime.test.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.test.ts
@@ -357,7 +357,8 @@ async function invocationHarness(
 	};
 	await handlers.get("session_start")?.({}, ctx);
 	const request = (frame: Record<string, unknown>): Promise<ResponseFrame> => {
-		const id = `frame-${(nextId += 1)}`;
+		const id = `frame-${nextId}`;
+		nextId += 1;
 		const { promise, resolve } = Promise.withResolvers<ResponseFrame>();
 		waiters.set(id, resolve);
 		deliver?.("client", { ...frame, id } as SdkFrame);

--- a/packages/coding-agent/src/sdk/host/session-runtime.test.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import type { ExtensionAPI } from "../../extensibility/extensions";
 import {
 	createInvocationReconciliation,
 	createSdkSessionRuntimeExtension,
@@ -256,6 +257,237 @@ describe("SessionSdkSessionRuntime", () => {
 			await handlers.get("session_shutdown")?.({}, firstContext);
 			expect(transports[1]?.stops).toBe(1);
 		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+});
+interface PreflightHooks {
+	onPreflightAccepted?: () => void;
+	onPreflightAcceptCommit?: () => void | Promise<void>;
+}
+
+interface ResponseFrame {
+	id?: string;
+	ok?: boolean;
+	result?: { status?: string; commandId?: string; turnId?: string; error?: { code: string; message: string } };
+}
+
+interface InvocationHarness {
+	control(operation: string, input: Record<string, unknown>): Promise<ResponseFrame>;
+	query(name: string, input: Record<string, unknown>): Promise<ResponseFrame>;
+	emit(event: string): Promise<void>;
+	stop(): Promise<void>;
+}
+
+/**
+ * Drives the SDK host through its wire surface: control/query frames in,
+ * response frames out. Nothing reaches into the reconciliation maps.
+ */
+async function invocationHarness(
+	sessionId: string,
+	cwd: string,
+	hooks: {
+		sendUserMessage?: (content: unknown, options?: PreflightHooks & { deliverAs?: string }) => Promise<void>;
+		invokeSkill?: (name: string, args?: string, options?: PreflightHooks) => Promise<unknown>;
+		abort?: () => void;
+	},
+): Promise<InvocationHarness> {
+	const waiters = new Map<string, (frame: ResponseFrame) => void>();
+	const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<void> | void>();
+	let deliver: ((connectionId: string, frame: SdkFrame) => void) | undefined;
+	let nextId = 0;
+	const api = {
+		on(event: string, handler: (event: unknown, ctx: unknown) => Promise<void> | void) {
+			handlers.set(event, handler);
+		},
+		sendUserMessage: hooks.sendUserMessage ?? (async () => {}),
+	} as unknown as ExtensionAPI;
+	createSdkSessionRuntimeExtension(api, {
+		createTransport: async ({ sessionId: id, stateRoot, token }) => ({
+			sessionId: id,
+			stateRoot,
+			token,
+			onFrame(handler) {
+				deliver = handler;
+				return () => {
+					if (deliver === handler) deliver = undefined;
+				};
+			},
+			sendFrame(_connectionId, frame) {
+				const response = frame as ResponseFrame;
+				if (typeof response.id === "string") waiters.get(response.id)?.(response);
+			},
+			broadcastFrame: () => {},
+			start: async () => ({ url: "ws://127.0.0.1:1" }),
+			stop: async () => {},
+		}),
+	});
+	const ctx = {
+		cwd,
+		workflowGate: undefined,
+		sdkBindings: () => (hooks.invokeSkill ? ["invokeSkill"] : []),
+		isIdle: () => true,
+		abort: hooks.abort ?? (() => {}),
+		...(hooks.invokeSkill ? { invokeSkill: hooks.invokeSkill } : {}),
+		sessionManager: { getSessionId: () => sessionId, getSessionName: () => undefined },
+	};
+	await handlers.get("session_start")?.({}, ctx);
+	const request = (frame: Record<string, unknown>): Promise<ResponseFrame> => {
+		const id = `frame-${(nextId += 1)}`;
+		const { promise, resolve } = Promise.withResolvers<ResponseFrame>();
+		waiters.set(id, resolve);
+		deliver?.("client", { ...frame, id } as SdkFrame);
+		return promise;
+	};
+	return {
+		control: (operation, input) => request({ type: "control_request", operation, input }),
+		query: (name, input) => request({ type: "query_request", query: name, input }),
+		emit: async event => {
+			await handlers.get(event)?.({}, ctx);
+		},
+		stop: async () => {
+			await handlers.get("session_shutdown")?.({}, ctx);
+		},
+	};
+}
+
+/** Polls a status query until the invocation reports a terminal reconciliation state. */
+async function settledStatus(
+	harness: InvocationHarness,
+	name: string,
+	input: Record<string, unknown>,
+): Promise<NonNullable<ResponseFrame["result"]>> {
+	for (let attempt = 0; attempt < 200; attempt += 1) {
+		const frame = await harness.query(name, input);
+		const result = frame.result;
+		if (result && (result.status === "failed" || result.status === "terminal_ok")) return result;
+		await Bun.sleep(1);
+	}
+	throw new Error(`${name} never reported a terminal reconciliation status`);
+}
+
+describe("post-acceptance invocation terminalization", () => {
+	test("a prompt killed by a provider stream interrupt reports a terminal failed status", async () => {
+		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-terminalize-prompt-"));
+		try {
+			const harness = await invocationHarness("terminalize-prompt", cwd, {
+				sendUserMessage: async (_content, options) => {
+					await options?.onPreflightAcceptCommit?.();
+					throw Object.assign(
+						new Error("upstream request failed: stream interrupted before terminal response event"),
+						{ code: "upstream_stream_interrupted" },
+					);
+				},
+			});
+			const accepted = await harness.control("turn.prompt", { text: "hello" });
+			expect(accepted.ok).toBe(true);
+			const { commandId, turnId } = accepted.result ?? {};
+			// Provider text is redacted on the wire by contract (sanitizePromptFailure);
+			// the failure reason survives as the safe-token code.
+			expect(await settledStatus(harness, "turn.prompt_status", { commandId, turnId })).toMatchObject({
+				status: "failed",
+				error: { code: "upstream_stream_interrupted", message: "Prompt submission failed." },
+			});
+			await harness.stop();
+		} finally {
+			// Let the reconciliation store finish its atomic write before the state root disappears.
+			await Bun.sleep(50);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("an aborted prompt reports a terminal failed status instead of hanging", async () => {
+		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-terminalize-abort-"));
+		try {
+			const inflight = Promise.withResolvers<void>();
+			const harness = await invocationHarness("terminalize-abort", cwd, {
+				sendUserMessage: async (_content, options) => {
+					await options?.onPreflightAcceptCommit?.();
+					await inflight.promise;
+				},
+				abort: () => inflight.reject(Object.assign(new Error("turn aborted"), { code: "aborted" })),
+			});
+			const accepted = await harness.control("turn.prompt", { text: "hello" });
+			const { commandId, turnId } = accepted.result ?? {};
+			expect(await harness.control("turn.abort", {})).toMatchObject({ ok: true });
+			expect(await settledStatus(harness, "turn.prompt_status", { commandId, turnId })).toMatchObject({
+				status: "failed",
+				error: { code: "aborted" },
+			});
+			await harness.stop();
+		} finally {
+			await Bun.sleep(50);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("a failed skill invocation still reports a terminal failed status", async () => {
+		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-terminalize-skill-"));
+		try {
+			const harness = await invocationHarness("terminalize-skill", cwd, {
+				invokeSkill: async (_name, _args, options) => {
+					await options?.onPreflightAcceptCommit?.();
+					throw Object.assign(new Error("skill provider stream interrupted"), { code: "upstream_error" });
+				},
+			});
+			const accepted = await harness.control("skill.invoke", { name: "ralplan" });
+			expect(accepted.ok).toBe(true);
+			const { commandId, turnId } = accepted.result ?? {};
+			expect(await settledStatus(harness, "skill.invoke_status", { commandId, turnId })).toMatchObject({
+				status: "failed",
+				error: { code: "upstream_error" },
+			});
+			await harness.stop();
+		} finally {
+			await Bun.sleep(50);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("a pre-acceptance failure rejects the submission without creating a record", async () => {
+		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-terminalize-preflight-"));
+		try {
+			const harness = await invocationHarness("terminalize-preflight", cwd, {
+				sendUserMessage: async () => {
+					throw Object.assign(new Error("session is busy"), { code: "busy" });
+				},
+			});
+			const rejected = await harness.control("turn.prompt", { text: "hello", clientRef: "preflight-ref" });
+			expect(rejected.ok).toBe(false);
+			const status = await harness.query("turn.prompt_status", { clientRef: "preflight-ref" });
+			expect(status.result).toEqual({ status: "unknown" });
+			await harness.stop();
+		} finally {
+			await Bun.sleep(50);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("a later provider error never overwrites an already terminal prompt", async () => {
+		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-terminalize-once-"));
+		try {
+			const inflight = Promise.withResolvers<void>();
+			const harness = await invocationHarness("terminalize-once", cwd, {
+				sendUserMessage: async (_content, options) => {
+					await options?.onPreflightAcceptCommit?.();
+					await inflight.promise;
+				},
+			});
+			const accepted = await harness.control("turn.prompt", { text: "hello" });
+			const { commandId, turnId } = accepted.result ?? {};
+			await harness.emit("agent_start");
+			await harness.emit("agent_end");
+			expect(await settledStatus(harness, "turn.prompt_status", { commandId, turnId })).toMatchObject({
+				status: "terminal_ok",
+			});
+			inflight.reject(Object.assign(new Error("late provider failure"), { code: "upstream_error" }));
+			await Bun.sleep(20);
+			const settled = await harness.query("turn.prompt_status", { commandId, turnId });
+			expect(settled.result?.status).toBe("terminal_ok");
+			expect(settled.result?.error).toBeUndefined();
+			await harness.stop();
+		} finally {
+			await Bun.sleep(50);
 			await rm(cwd, { recursive: true, force: true });
 		}
 	});

--- a/packages/coding-agent/src/sdk/host/session-runtime.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.ts
@@ -411,7 +411,24 @@ export function createInvocationReconciliation(
 		async noteTransition(kind, correlation, frame) {
 			if (!correlation) return;
 			const record = records.get(key(kind, correlation));
-			if (!record || record.terminalAt !== undefined) return;
+			if (!record) return;
+			if (record.terminalAt !== undefined) {
+				// Same late agent_failed enrichment as the kind-aware bus reconciler: a
+				// failure reason may arrive on a different delivery path than the one that
+				// claimed the terminal. Enrich the settled record instead of dropping it;
+				// never resurrect (status/terminalAt untouched), and first reason wins.
+				if (frame.type === "agent_failed" && record.error === undefined) {
+					logger.error("SDK invocation failed (late)", {
+						kind,
+						commandId: correlation.commandId,
+						turnId: correlation.turnId,
+						error: formatPromptFailureForLocalLog(frame.error),
+					});
+					record.error = sanitizePromptFailure(frame.error);
+					await persist();
+				}
+				return;
+			}
 			if (frame.type === "agent_start") {
 				record.status = "in_flight";
 				record.startedAt = Date.now();

--- a/packages/coding-agent/src/sdk/host/session-runtime.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.ts
@@ -994,8 +994,11 @@ function createControlSurface(
 				},
 				error => {
 					if (settled) {
-						if (kind === "skill")
-							void reconciliation.noteTransition(kind, correlation, { type: "agent_failed", error });
+						// The submission promise rejects after preflight acceptance only when the
+						// work itself is over (provider stream interrupt, abort, queue failure).
+						// Every kind must terminalize here or the record stays non-terminal
+						// forever; `noteTransition` ignores an already-terminal record.
+						void reconciliation.noteTransition(kind, correlation, { type: "agent_failed", error });
 						return;
 					}
 					settled = true;

--- a/packages/coding-agent/src/sdk/prompt-status.ts
+++ b/packages/coding-agent/src/sdk/prompt-status.ts
@@ -24,6 +24,12 @@
  * - Q26 tracks prompts accepted through the SDK control surface (which always
  *   carries a requesting connection); submissions without a delivery owner are
  *   outside the reconciliation contract and hold no reservation.
+ * - A terminal outcome settles once: the first terminal transition wins. A late
+ *   `agent_failed` (arriving on a different delivery path than the one that
+ *   claimed the terminal) may still attach its bounded, sanitized reason to an
+ *   already-terminal record that has none, surfaced as `error` on `terminal_ok`.
+ *   It never changes status, `terminalAt`, retention order, or the clientRef
+ *   index, and the first recorded reason always wins over a later frame.
  */
 
 export const PROMPT_CLIENT_REF_MAX_LENGTH = 128;
@@ -79,6 +85,8 @@ export interface TurnPromptReconciliationTerminalOk extends TurnPromptReconcilia
 	/** Epoch milliseconds of the terminal transition. */
 	terminalAt: number;
 	outcome?: SdkPromptTerminalOutcome;
+	/** Present when a late `agent_failed` supplied the only failure reason. */
+	error?: { code: string; message: string };
 }
 
 export interface TurnPromptReconciliationFailed extends TurnPromptReconciliationIdentity {

--- a/packages/coding-agent/test/sdk-prompt-terminal-arbiter.test.ts
+++ b/packages/coding-agent/test/sdk-prompt-terminal-arbiter.test.ts
@@ -171,4 +171,58 @@ describe("SDK prompt terminal arbiter", () => {
 		});
 		expect(settled[2]).toMatchObject({ status: "failed", error: { code: "process_restart" } });
 	});
+	test("surfaces a late agent_failed reason on a terminal_ok record through the production lookup and persists it", async () => {
+		const { reconciliation, store } = await accepted();
+		await reconciliation.claimPendingOutcome(correlation, stopped("end_turn"));
+		await reconciliation.finalizePromptOutcome(correlation);
+
+		const settled = reconciliation.lookup("prompt", correlation);
+		expect(settled).toMatchObject({ status: "terminal_ok" });
+		expect(settled).not.toHaveProperty("error");
+
+		// The reason arrives from a different path than the one that claimed the terminal.
+		await reconciliation.noteTransition("prompt", correlation, {
+			type: "agent_failed",
+			error: Object.assign(new Error("socket closed"), { code: "transport_reset" }),
+		});
+
+		const enriched = reconciliation.lookup("prompt", correlation);
+		expect(enriched).toMatchObject({
+			status: "terminal_ok",
+			error: { code: "transport_reset", message: "Prompt submission failed." },
+		});
+		// Enrichment only: status/terminalAt unchanged, no new active slot.
+		expect((enriched as { terminalAt: number }).terminalAt).toBe((settled as { terminalAt: number }).terminalAt);
+		expect(reconciliation.activeCount("prompt")).toBe(0);
+		// The reason is durable: it survives store reload reconciliation.
+		expect(store.snapshot()[0]?.error).toEqual({ code: "transport_reset", message: "Prompt submission failed." });
+	});
+
+	test("keeps the first late reason when later agent_failed frames disagree", async () => {
+		const { reconciliation } = await accepted();
+		await reconciliation.claimPendingOutcome(correlation, stopped("end_turn"));
+		await reconciliation.finalizePromptOutcome(correlation);
+		await reconciliation.noteTransition("prompt", correlation, {
+			type: "agent_failed",
+			error: Object.assign(new Error("first"), { code: "transport_reset" }),
+		});
+		await reconciliation.noteTransition("prompt", correlation, {
+			type: "agent_failed",
+			error: Object.assign(new Error("second"), { code: "generic_late" }),
+		});
+		expect(reconciliation.lookup("prompt", correlation)).toMatchObject({
+			status: "terminal_ok",
+			error: { code: "transport_reset" },
+		});
+	});
+
+	test("does not enrich a terminal record with a late agent_start or agent_end", async () => {
+		const { reconciliation } = await accepted();
+		await reconciliation.claimPendingOutcome(correlation, stopped("end_turn"));
+		await reconciliation.finalizePromptOutcome(correlation);
+		const before = reconciliation.lookup("prompt", correlation);
+		await reconciliation.noteTransition("prompt", correlation, { type: "agent_start" });
+		await reconciliation.noteTransition("prompt", correlation, { type: "agent_end" });
+		expect(reconciliation.lookup("prompt", correlation)).toEqual(before);
+	});
 });

--- a/packages/coding-agent/test/sdk-q26-prompt-status.test.ts
+++ b/packages/coding-agent/test/sdk-q26-prompt-status.test.ts
@@ -254,6 +254,90 @@ describe("prompt reconciliation record", () => {
 		for (let n = 1; n <= PROMPT_RECONCILIATION_ACTIVE_CAPACITY - 1; n++) rec.admit();
 		expect(() => rec.admit()).toThrowError(/Too many active/);
 	});
+
+	it("surfaces a late agent_failed reason on a record already made terminal by agent_end", () => {
+		const clock = clocked();
+		const rec = createPromptReconciliation({ now: clock.now });
+		rec.noteAccepted(correlation(), "ref-late");
+		rec.noteTransition(correlation(), { type: "agent_start" });
+		rec.noteTransition(correlation(), { type: "agent_end" });
+		const settled = rec.lookup({ clientRef: "ref-late" });
+		if (settled.status !== "terminal_ok") throw new Error("expected terminal_ok");
+		expect(settled.error).toBeUndefined();
+		const activeBefore = rec.activeCount();
+		// The reason arrives from a different path than the one that claimed the terminal.
+		clock.advance(5_000);
+		rec.noteTransition(correlation(), {
+			type: "agent_failed",
+			error: Object.assign(new Error("socket closed"), { code: "transport_reset" }),
+		});
+		const enriched = rec.lookup({ clientRef: "ref-late" });
+		if (enriched.status !== "terminal_ok") throw new Error("expected the terminal outcome to be preserved");
+		expect(enriched.error).toEqual({ code: "transport_reset", message: "Prompt submission failed." });
+		// Enrichment only: no resurrection, no re-timestamping, no new active slot.
+		expect(enriched.terminalAt).toBe(settled.terminalAt);
+		expect(rec.activeCount()).toBe(activeBefore);
+		expect(rec.activeCount()).toBe(0);
+	});
+
+	it("keeps the first recorded reason when later agent_failed frames disagree", () => {
+		const rec = createPromptReconciliation();
+		rec.noteAccepted(correlation(1), "ref-first");
+		rec.noteTransition(correlation(1), { type: "agent_end" });
+		rec.noteTransition(correlation(1), {
+			type: "agent_failed",
+			error: Object.assign(new Error("first"), { code: "transport_reset" }),
+		});
+		rec.noteTransition(correlation(1), {
+			type: "agent_failed",
+			error: Object.assign(new Error("second"), { code: "generic_late" }),
+		});
+		const enriched = rec.lookup({ clientRef: "ref-first" });
+		if (enriched.status !== "terminal_ok") throw new Error("expected terminal_ok");
+		expect(enriched.error?.code).toBe("transport_reset");
+		// A record that already failed with a specific reason is equally immune.
+		rec.noteAccepted(correlation(2));
+		rec.noteTransition(correlation(2), {
+			type: "agent_failed",
+			error: Object.assign(new Error("specific"), { code: "provider_down" }),
+		});
+		rec.noteTransition(correlation(2), {
+			type: "agent_failed",
+			error: Object.assign(new Error("generic"), { code: "generic_late" }),
+		});
+		const failed = rec.lookup(correlation(2));
+		if (failed.status !== "failed") throw new Error("expected failed");
+		expect(failed.error.code).toBe("provider_down");
+	});
+
+	it("ignores agent_start and agent_end after terminal while keeping the enriched reason", () => {
+		const clock = clocked();
+		const rec = createPromptReconciliation({ now: clock.now });
+		rec.noteAccepted(correlation(3), "ref-frozen");
+		rec.noteTransition(correlation(3), { type: "agent_start" });
+		const startedAt = clock.now();
+		clock.advance(10);
+		rec.noteTransition(correlation(3), { type: "agent_end" });
+		const terminalAt = clock.now();
+		rec.noteTransition(correlation(3), {
+			type: "agent_failed",
+			error: Object.assign(new Error("late"), { code: "transport_reset" }),
+		});
+		clock.advance(60_000);
+		rec.noteTransition(correlation(3), { type: "agent_start" });
+		rec.noteTransition(correlation(3), { type: "agent_end" });
+		expect(rec.lookup({ clientRef: "ref-frozen" })).toEqual({
+			status: "terminal_ok",
+			commandId: "command-3",
+			turnId: "turn-3",
+			clientRef: "ref-frozen",
+			acceptedAt: startedAt,
+			startedAt,
+			terminalAt,
+			error: { code: "transport_reset", message: "Prompt submission failed." },
+		});
+		expect(rec.activeCount()).toBe(0);
+	});
 });
 
 function surface(getPromptStatus?: (selector: { commandId?: string; turnId?: string; clientRef?: string }) => unknown) {


### PR DESCRIPTION
Fixes #4088.

`noteTransition` returned as soon as `terminalAt` was set:

```ts
if (!record || record.terminalAt !== undefined) return;   // prompt-reconciliation.ts:187
```

The terminal is claimed on one path while the failure reason arrives on another, so the ordering is not the caller's to control. When the reason lost that race it was discarded, and consumers were left with a settled record carrying no reason at all — which is what #4068 asked for and what #4077 fixed everywhere except here.

## The change

A late `agent_failed` now enriches the settled record; `agent_start` and `agent_end` still return early.

```ts
if (record.terminalAt !== undefined) {
    if (frame.type === "agent_failed" && record.error === undefined)
        record.error = sanitizePromptFailure(frame.error);
    return;
}
```

It cannot resurrect the record: `status`, `terminalAt`, retention order and the `clientRef` index are all untouched, so `activeCount()` does not move. First reason wins, so a late generic frame never overwrites a specific one. The reason is sanitized through the same `sanitizePromptFailure` the non-terminal path already uses — no second shape — and `lookup` now surfaces it on `terminal_ok` as well, since that is the case where a failure reason arriving late is the only signal a consumer will ever get.

## Evidence

Mutation, both directions:

|source|suite|
|---|---|
|with the fix|**25 pass, 0 fail** (70 `expect()` calls)|
|reverted to `origin/dev`|**22 pass, 3 fail**|

The three new assertions fail without the change, so they are load-bearing rather than describing whatever the code already did. Adjacent suites are unaffected: `sdk-prompt-terminal-diagnostics` and `sdk-host-wiring` stay at 93 pass, 0 fail.

Diff is two files — the reconciliation source and its existing test file.

## Known and not fixed

A consumer that stops polling once it sees the terminal event will not observe the enriched reason; this makes the reason available on the record, it does not re-publish a terminal that already went out. If clients need a push, that is a separate change to the publication path and I did not make it here.

I also did not widen this to `agent_start`/`agent_end` arriving late. Those carry no information the settled record lacks, and accepting them would be the resurrection this fix specifically avoids.
