### PR TITLE
fix(ai): stop declaring provider-reserved tool names on Responses

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- OpenAI Responses transports no longer send tool declarations whose names the provider reserves for its own built-ins. OpenCode Zen/Go reject `web_search` as a custom function with `invalid tools in request: custom function name "web_search" is reserved`, and that rejection is request-scoped — one colliding declaration failed the entire tools array before any token streamed, so the bundled `critic`, `planner`, and `architect` agents failed 100% of the time on those providers (#4104). The collision is dropped rather than renamed, because a renamed function tool returns as a `function_call` under the wire alias and that path does not populate `Tool.customWireName`, which would leave the agent-loop dispatcher unable to route the call. `compat.reservedToolNames` overrides the per-provider default.
+
 ## [0.12.19] - 2026-08-08
 
 ## [0.12.18] - 2026-08-08

--- a/packages/ai/src/openai-completions-compat.ts
+++ b/packages/ai/src/openai-completions-compat.ts
@@ -12,6 +12,7 @@ export type ResolvedOpenAICompat = Required<
 		| "toolStrictMode"
 		| "toolChoiceSupport"
 		| "supportsResponsesSessionAffinity"
+		| "reservedToolNames"
 	>
 > & {
 	openRouterRouting?: OpenAICompat["openRouterRouting"];

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -860,10 +860,37 @@ function isForcedOpenAIResponsesToolChoice(choice: unknown): boolean {
 	return !!choice && choice !== "none" && choice !== "auto";
 }
 
+/**
+ * Tool names an OpenAI-compatible endpoint reserves for its own built-ins and
+ * refuses as custom function declarations.
+ *
+ * OpenCode Zen/Go reject `web_search` with
+ * `invalid tools in request: custom function name "web_search" is reserved`.
+ * The rejection is request-scoped: one colliding declaration fails the WHOLE
+ * tools array before any token streams, so every agent carrying that tool is
+ * permanently broken on the provider rather than losing a single capability.
+ *
+ * The collision is dropped rather than renamed. A renamed function tool would
+ * come back as a `function_call` under the wire alias, and that path does not
+ * populate `Tool.customWireName`, so the agent-loop dispatcher could not route
+ * it — trading a loud 400 for a silent unresolvable call. Dropping leaves the
+ * agent in the same state as any provider that simply has no web search.
+ */
+const PROVIDER_RESERVED_TOOL_NAMES: Record<string, readonly string[]> = {
+	"opencode-go": ["web_search"],
+	"opencode-zen": ["web_search"],
+};
+
+/** @internal Exported for tests. */
+export function resolveReservedToolNames(model: Model<"openai-responses">): readonly string[] {
+	return model.compat?.reservedToolNames ?? PROVIDER_RESERVED_TOOL_NAMES[model.provider] ?? [];
+}
 /** @internal Exported for tests. */
 export function convertTools(tools: Tool[], strictMode: boolean, model: Model<"openai-responses">): OpenAITool[] {
 	const allowFreeform = supportsFreeformApplyPatch(model);
-	const payloads = tools.map(tool => {
+	const reserved = resolveReservedToolNames(model);
+	const declarable = reserved.length === 0 ? tools : tools.filter(tool => !reserved.includes(tool.name));
+	const payloads = declarable.map(tool => {
 		if (allowFreeform && tool.customFormat) {
 			return {
 				type: "custom",

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -888,14 +888,23 @@ export interface OpenAICompat extends ToolChoiceCompat {
 	supportsResponsesSessionAffinity?: boolean;
 	/**
 	 * Tool names the provider reserves for its own built-ins and refuses to
-	 * accept as custom function declarations. A colliding tool is sent under a
-	 * prefixed wire alias instead of being dropped, so the capability survives
-	 * and the agent-loop dispatcher still resolves the call through
-	 * `Tool.customWireName`.
+	 * accept as custom function declarations. A colliding tool is **dropped**
+	 * from the declared tools array rather than renamed: a renamed function
+	 * tool would come back as a `function_call` under the wire alias, and that
+	 * path does not populate `Tool.customWireName`, leaving the agent-loop
+	 * dispatcher unable to route it — trading a loud 400 for a silent
+	 * unresolvable call. Dropping the declaration is intentionally a loss of
+	 * capability, leaving the agent in the same state as any provider that
+	 * simply has no such tool. The filter preserves declaration order and does
+	 * not mutate the caller's array.
 	 *
 	 * Without this, one reserved name rejects the ENTIRE tools array with a
 	 * single 400 and no tokens ever stream — every agent carrying that tool
 	 * fails 100% of the time on that provider.
+	 *
+	 * Resolution precedence: an explicit array (including `[]`) on the model's
+	 * `compat` replaces the built-in provider default, so `[]` opts a reserved
+	 * provider out of the drop entirely.
 	 */
 	reservedToolNames?: string[];
 	/**

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -887,6 +887,18 @@ export interface OpenAICompat extends ToolChoiceCompat {
 	 */
 	supportsResponsesSessionAffinity?: boolean;
 	/**
+	 * Tool names the provider reserves for its own built-ins and refuses to
+	 * accept as custom function declarations. A colliding tool is sent under a
+	 * prefixed wire alias instead of being dropped, so the capability survives
+	 * and the agent-loop dispatcher still resolves the call through
+	 * `Tool.customWireName`.
+	 *
+	 * Without this, one reserved name rejects the ENTIRE tools array with a
+	 * single 400 and no tokens ever stream — every agent carrying that tool
+	 * fails 100% of the time on that provider.
+	 */
+	reservedToolNames?: string[];
+	/**
 	 * Whether the provider's chat-completions endpoint accepts multiple
 	 * leading `system`/`developer` messages. When false, ordered system
 	 * prompts are coalesced into a single message joined by `\n\n` so

--- a/packages/ai/test/composer-discipline.test.ts
+++ b/packages/ai/test/composer-discipline.test.ts
@@ -25,6 +25,7 @@ const compat: Required<OpenAICompat> = {
 	supportsDeveloperRole: false,
 	sendSessionHeaders: false,
 	supportsResponsesSessionAffinity: false,
+	reservedToolNames: [],
 	supportsMultipleSystemMessages: true,
 	supportsReasoningEffort: false,
 	reasoningEffortMap: {},

--- a/packages/ai/test/issue-967-vision-guard.test.ts
+++ b/packages/ai/test/issue-967-vision-guard.test.ts
@@ -24,6 +24,7 @@ const compat: Required<OpenAICompat> = {
 	supportsDeveloperRole: true,
 	sendSessionHeaders: false,
 	supportsResponsesSessionAffinity: false,
+	reservedToolNames: [],
 	supportsMultipleSystemMessages: true,
 	supportsReasoningEffort: true,
 	reasoningEffortMap: {},

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -73,6 +73,7 @@ describe("openai-completions compatibility", () => {
 			supportsDeveloperRole: true,
 			sendSessionHeaders: false,
 			supportsResponsesSessionAffinity: false,
+			reservedToolNames: [],
 			supportsMultipleSystemMessages: true,
 			supportsReasoningEffort: true,
 			reasoningEffortMap: {},

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -17,6 +17,7 @@ const compat: Required<OpenAICompat> = {
 	supportsDeveloperRole: true,
 	sendSessionHeaders: false,
 	supportsResponsesSessionAffinity: false,
+	reservedToolNames: [],
 	supportsMultipleSystemMessages: true,
 	supportsReasoningEffort: true,
 	reasoningEffortMap: {},

--- a/packages/ai/test/openai-responses-reserved-tool-names.test.ts
+++ b/packages/ai/test/openai-responses-reserved-tool-names.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+import { convertTools, resolveReservedToolNames } from "../src/providers/openai-responses";
+import type { Model, Tool } from "../src/types";
+
+/**
+ * OpenCode Zen/Go reserve `web_search` for their own built-in and reject it as a
+ * custom function declaration with a request-scoped 400:
+ *
+ *   invalid tools in request: custom function name "web_search" is reserved
+ *
+ * One colliding declaration fails the entire tools array before any token
+ * streams, so every agent carrying that tool (critic/planner/architect) is
+ * permanently broken on the provider.
+ */
+
+function model(provider: string, compat?: Model<"openai-responses">["compat"]): Model<"openai-responses"> {
+	return {
+		id: "grok-4.5",
+		name: "Grok 4.5",
+		api: "openai-responses",
+		provider,
+		baseUrl: "https://opencode.ai/zen/v1",
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 500_000,
+		maxTokens: 500_000,
+		...(compat ? { compat } : {}),
+	} as Model<"openai-responses">;
+}
+
+function tool(name: string): Tool {
+	return { name, description: `${name} tool`, parameters: { type: "object", properties: {} } } as Tool;
+}
+
+const TOOLS = [tool("read"), tool("web_search"), tool("bash")];
+
+describe("resolveReservedToolNames", () => {
+	it("reserves web_search on opencode-go", () => {
+		expect(resolveReservedToolNames(model("opencode-go"))).toEqual(["web_search"]);
+	});
+
+	it("reserves web_search on opencode-zen", () => {
+		expect(resolveReservedToolNames(model("opencode-zen"))).toEqual(["web_search"]);
+	});
+
+	it("reserves nothing on unrelated providers", () => {
+		expect(resolveReservedToolNames(model("openai"))).toEqual([]);
+	});
+
+	it("lets an explicit compat override replace the provider default", () => {
+		const compat = { reservedToolNames: ["bash"] } as Model<"openai-responses">["compat"];
+		expect(resolveReservedToolNames(model("opencode-go", compat))).toEqual(["bash"]);
+	});
+
+	it("lets an explicit empty compat override opt out of the provider default", () => {
+		const compat = { reservedToolNames: [] } as Model<"openai-responses">["compat"];
+		expect(resolveReservedToolNames(model("opencode-go", compat))).toEqual([]);
+	});
+});
+
+describe("convertTools reserved-name handling", () => {
+	it("omits the reserved declaration so the request is accepted", () => {
+		const names = convertTools(TOOLS, false, model("opencode-go")).map(t => (t as { name: string }).name);
+		expect(names).toEqual(["read", "bash"]);
+	});
+
+	it("keeps every non-reserved tool intact", () => {
+		const converted = convertTools(TOOLS, false, model("opencode-go"));
+		expect(converted).toHaveLength(2);
+		expect((converted[0] as { type: string }).type).toBe("function");
+	});
+
+	it("declares web_search normally on providers that do not reserve it", () => {
+		const names = convertTools(TOOLS, false, model("openai")).map(t => (t as { name: string }).name);
+		expect(names).toEqual(["read", "web_search", "bash"]);
+	});
+
+	it("drops the reserved name selected by a compat override", () => {
+		const compat = { reservedToolNames: ["bash"] } as Model<"openai-responses">["compat"];
+		const names = convertTools(TOOLS, false, model("opencode-go", compat)).map(t => (t as { name: string }).name);
+		expect(names).toEqual(["read", "web_search"]);
+	});
+
+	it("leaves the caller's tool array unmutated", () => {
+		convertTools(TOOLS, false, model("opencode-go"));
+		expect(TOOLS.map(t => t.name)).toEqual(["read", "web_search", "bash"]);
+	});
+});


### PR DESCRIPTION
## Summary

- stop declaring tool names that an OpenAI Responses provider reserves for its own built-ins
- add `compat.reservedToolNames` with per-provider defaults for `opencode-go` / `opencode-zen`
- add regression coverage for resolution, filtering, opt-out, and caller-array immutability

Fixes #4104.

## Why

OpenCode Zen/Go reject `web_search` as a custom function declaration:

```text
400 invalid request: invalid tools in request: custom function name "web_search" is reserved
```

The rejection is **request-scoped**, not tool-scoped. One colliding declaration fails the entire tools array before any token streams, so the bundled `critic`, `planner`, and `architect` agents — all three declare `web_search` — fail 100% of the time on those providers. `executor` does not declare it and was unaffected, which is why this looked like a role-routing problem rather than a transport one.

Minimal isolation, single variable:

```bash
gjc -p --model opencode-go/grok-4.5 --tools read,web_search 'Say OK.'   # 400
gjc -p --model opencode-go/grok-4.5 --tools read,search,bash 'Say OK.'  # OK.
```

## Why drop instead of rename

A wire-prefix rename was implemented first and rejected. Renaming works for custom-format tools because `custom_tool_call` replies populate `Tool.customWireName`, which `findActiveTool` matches. A plain function tool comes back as `function_call`, and that path (`openai-responses-shared.ts`) sets only `name` — no `customWireName`. The dispatcher would receive `gjc_web_search` and resolve nothing, converting a loud 400 into a silent unroutable tool call.

Dropping leaves the agent in exactly the state it already has on any provider without web search.

Editing the three bundled agent definitions was also rejected: that removes a working capability on every provider that accepts `web_search`, to fix a problem belonging to one provider's wire contract.

## Verification

- `bun test packages/ai/test/openai-responses-reserved-tool-names.test.ts` — 10 pass
- `bun test` on the four touched compat suites — 76 pass total
- `bun --cwd=packages/ai run check` — Biome + TypeScript pass
- `git diff --check`

## Scope

`convertTools` behavior is unchanged for every provider with no reserved names — the filter is skipped entirely when the reserved list is empty. `reservedToolNames` is excluded from `ResolvedOpenAICompat` since it is Responses-only.
