### PR TITLE
fix(ai): stop sending provider-reserved names as custom tool declarations

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -98,6 +98,7 @@ import {
 	hasCopilotVisionInput,
 	resolveGitHubCopilotBaseUrl,
 } from "./github-copilot-headers";
+import { filterProviderReservedTools } from "./provider-reserved-tools";
 import { transformMessages } from "./transform-messages";
 import { NON_VISION_IMAGE_PLACEHOLDER } from "./vision-guard";
 
@@ -2620,7 +2621,7 @@ function buildParams(
 
 	if (context.tools) {
 		params.tools = convertTools(
-			context.tools,
+			filterProviderReservedTools(context.tools, model.provider),
 			isOAuthToken,
 			// The Claude Code OAuth surface mishandles `strict: true` tools:
 			// streamed tool_use blocks arrive with empty/undefined arguments and

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -39,6 +39,7 @@ import type {
 	ThinkingConfig,
 	ThinkingLevel,
 } from "./google-types";
+import { filterProviderReservedTools } from "./provider-reserved-tools";
 import { transformMessages } from "./transform-messages";
 import { NON_VISION_IMAGE_PLACEHOLDER } from "./vision-guard";
 
@@ -378,7 +379,8 @@ export function convertTools(
 	tools: Tool[],
 	model: Model<"google-generative-ai" | "google-gemini-cli" | "google-vertex">,
 ): { functionDeclarations: Record<string, unknown>[] }[] | undefined {
-	if (tools.length === 0) return undefined;
+	const declaredTools = filterProviderReservedTools(tools, model.provider);
+	if (declaredTools.length === 0) return undefined;
 
 	/**
 	 * Anthropic model models on Cloud Code Assist need the legacy `parameters` field;
@@ -388,7 +390,7 @@ export function convertTools(
 
 	return [
 		{
-			functionDeclarations: tools.map(tool => ({
+			functionDeclarations: declaredTools.map(tool => ({
 				name: tool.name,
 				description: tool.description || "",
 				...(useParameters

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -84,6 +84,7 @@ import {
 	wrapFetchForOpenAIRequestTransform,
 } from "./openai-request-transform";
 import { createInitialResponsesAssistantMessage } from "./openai-responses-shared";
+import { filterProviderReservedTools } from "./provider-reserved-tools";
 import { transformMessages } from "./transform-messages";
 import { joinTextWithImagePlaceholder, NON_VISION_IMAGE_PLACEHOLDER } from "./vision-guard";
 
@@ -1343,7 +1344,8 @@ function buildParams(
 	}
 
 	if (context.tools?.length) {
-		const builtTools = convertTools(context.tools, compat, toolStrictModeOverride);
+		const tools = filterProviderReservedTools(context.tools, model.provider);
+		const builtTools = convertTools(tools, compat, toolStrictModeOverride);
 		params.tools = builtTools.tools;
 		toolStrictMode = builtTools.toolStrictMode;
 	} else if (context.tools === undefined && hasToolHistory(context.messages)) {

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -92,6 +92,7 @@ import {
 	processResponsesStream,
 	repairOrphanResponsesToolOutputs,
 } from "./openai-responses-shared";
+import { filterProviderReservedTools } from "./provider-reserved-tools";
 import { transformMessages } from "./transform-messages";
 
 /**
@@ -684,7 +685,8 @@ function buildParams(
 	// `StreamOptions.frequencyPenalty` is intentionally dropped for this provider.
 
 	if (context.tools) {
-		params.tools = convertTools(context.tools, supportsStrictMode(model), model);
+		const tools = filterProviderReservedTools(context.tools, model.provider);
+		params.tools = convertTools(tools, supportsStrictMode(model), model);
 		if (options?.toolChoice) {
 			const toolChoice = resolveToolChoice(model, options.toolChoice);
 			if (toolChoice.degraded && toolChoice.supportSource === "runtime") {
@@ -695,7 +697,7 @@ function buildParams(
 					reason: toolChoice.reason,
 				});
 			}
-			params.tool_choice = mapOpenAIResponsesToolChoiceForTools(toolChoice.resolvedChoice, context.tools, model);
+			params.tool_choice = mapOpenAIResponsesToolChoiceForTools(toolChoice.resolvedChoice, tools, model);
 		}
 		// The apply_patch spec §1 marks only `apply_patch` itself as
 		// `supports_parallel_tool_calls = false`. OpenAI's Responses API

--- a/packages/ai/src/providers/provider-reserved-tools.ts
+++ b/packages/ai/src/providers/provider-reserved-tools.ts
@@ -1,0 +1,44 @@
+import type { KnownProvider, Provider, Tool } from "../types";
+
+/**
+ * Tool names a provider's endpoint reserves for its own built-in tools.
+ *
+ * A collision is a *request-level* rejection, not a per-tool one: the endpoint
+ * refuses the whole turn before any work starts (OpenCode Console Go answers
+ * `400 invalid request: invalid tools in request: custom function name
+ * "web_search" is reserved`), so every tool in the request dies with it.
+ *
+ * A reservation belongs to the endpoint, not to the wire API: OpenCode Go
+ * fronts `openai-completions`, `openai-responses`, and `anthropic-messages`
+ * behind one gateway that validates tool names the same way on all three. So
+ * the list is keyed by provider and consulted by every api that provider is
+ * routed to.
+ *
+ * Each entry is owned by the provider that declares it. There is no shared
+ * default: a provider absent from this map reserves nothing, and keeps every
+ * declared tool exactly as the caller offered it.
+ */
+const PROVIDER_RESERVED_TOOL_NAMES: Readonly<Record<string, readonly string[]>> = {
+	// https://opencode.ai/zen/go — serves `web_search` itself.
+	"opencode-go": ["web_search"],
+} satisfies Partial<Record<KnownProvider, readonly string[]>>;
+
+/** @internal Exported for tests. */
+export function getProviderReservedToolNames(provider: Provider): readonly string[] {
+	return PROVIDER_RESERVED_TOOL_NAMES[provider] ?? [];
+}
+
+/**
+ * Drop the declarations `provider` reserves, keeping every other tool in its
+ * original order. Returns the caller's array untouched when the provider
+ * reserves nothing or declares none of the reserved names.
+ *
+ * Matches the name that actually reaches the wire: custom-format tools are
+ * emitted under `customWireName` when present, so both are checked.
+ */
+export function filterProviderReservedTools(tools: Tool[], provider: Provider): Tool[] {
+	const reserved = PROVIDER_RESERVED_TOOL_NAMES[provider];
+	if (!reserved || reserved.length === 0) return tools;
+	const kept = tools.filter(tool => !reserved.includes(tool.customWireName ?? tool.name));
+	return kept.length === tools.length ? tools : kept;
+}

--- a/packages/ai/test/anthropic-tool-schema.test.ts
+++ b/packages/ai/test/anthropic-tool-schema.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { normalizeAnthropicToolSchema } from "@gajae-code/ai/providers/anthropic";
+import type { MessageCreateParamsStreaming } from "@anthropic-ai/sdk/resources/messages";
+import { getBundledModel } from "@gajae-code/ai/models";
+import { normalizeAnthropicToolSchema, streamAnthropic } from "@gajae-code/ai/providers/anthropic";
+import type { Context, Model, TJsonSchema } from "@gajae-code/ai/types";
 import { flattenToolRootCombinators } from "@gajae-code/ai/utils/schema";
 
 describe("normalizeAnthropicToolSchema — SDK whitelist", () => {
@@ -528,5 +531,48 @@ describe("normalizeAnthropicToolSchema — parity with anthropic-sdk-python tran
 		expect(out.type).toBe("object");
 		const props = out.properties as Record<string, unknown>;
 		expect(props.self).toBe(out); // memoized → same reference
+	});
+});
+
+function reservedNameContext(): Context {
+	const parameters = { type: "object", properties: {} } as TJsonSchema;
+	return {
+		messages: [{ role: "user", content: "Continue", timestamp: 1 }],
+		tools: [
+			{ name: "read", description: "Read a file", parameters },
+			{ name: "web_search", description: "Search the web", parameters },
+			{ name: "irc", description: "Message a peer", parameters },
+		],
+	};
+}
+
+function captureToolNames(model: Model<"anthropic-messages">): Promise<string[]> {
+	const { promise, resolve } = Promise.withResolvers<string[]>();
+	const controller = new AbortController();
+	controller.abort();
+	streamAnthropic(model, reservedNameContext(), {
+		apiKey: "sk-ant-api-test",
+		isOAuth: false,
+		signal: controller.signal,
+		onPayload: payload => {
+			const { tools } = payload as MessageCreateParamsStreaming;
+			resolve((tools ?? []).map(tool => tool.name));
+			return undefined;
+		},
+	});
+	return promise;
+}
+
+describe("anthropic-messages provider-reserved tool declarations", () => {
+	it("omits reserved declarations but keeps every other tool on opencode-go", async () => {
+		const model = getBundledModel("opencode-go", "minimax-m2.5") as Model<"anthropic-messages">;
+
+		expect(await captureToolNames(model)).toEqual(["read", "irc"]);
+	});
+
+	it("keeps web_search on a provider that does not reserve it", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5") as Model<"anthropic-messages">;
+
+		expect(await captureToolNames(model)).toEqual(["read", "web_search", "irc"]);
 	});
 });

--- a/packages/ai/test/google-tool-choice.test.ts
+++ b/packages/ai/test/google-tool-choice.test.ts
@@ -130,3 +130,30 @@ describe("Google shared tool choice", () => {
 		expect(result.stopReason).toBe("error");
 	});
 });
+
+// `opencode-go`'s own api-resolution rules route an `@ai-sdk/google` catalog row
+// to `google-generative-ai`, so this assembly path is reachable for a provider
+// that reserves tool names.
+describe("Google shared provider-reserved tool declarations", () => {
+	const reservedContext: Context = {
+		messages: [{ role: "user", content: "hi", timestamp: 1 }],
+		tools: [
+			tool,
+			{ name: "web_search", description: "Search the web", parameters: { type: "object", properties: {} } },
+			{ name: "irc", description: "Message a peer", parameters: { type: "object", properties: {} } },
+		],
+	};
+
+	function declaredNames(target: Model<"google-generative-ai">): unknown {
+		const params = buildGoogleGenerateContentParams(target, reservedContext, {});
+		return params.config?.tools?.[0]?.functionDeclarations?.map(declaration => declaration.name);
+	}
+
+	it("omits reserved declarations but keeps every other tool on opencode-go", () => {
+		expect(declaredNames({ ...model, provider: "opencode-go" })).toEqual(["read", "irc"]);
+	});
+
+	it("keeps web_search on a provider that does not reserve it", () => {
+		expect(declaredNames(model)).toEqual(["read", "web_search", "irc"]);
+	});
+});

--- a/packages/ai/test/openai-tool-strict-mode.test.ts
+++ b/packages/ai/test/openai-tool-strict-mode.test.ts
@@ -431,3 +431,61 @@ describe("OpenAI tool strict mode", () => {
 		expect(payload.tools?.[0]?.strict).toBe(true);
 	});
 });
+
+const reservedNameContext: Context = {
+	...testContext,
+	tools: [
+		testTool,
+		{
+			name: "web_search",
+			description: "Search the web",
+			parameters: z.object({ query: z.string() }),
+		},
+		{
+			name: "report_finding",
+			description: "Report a review finding",
+			parameters: z.object({ note: z.string() }),
+		},
+	],
+};
+
+describe("provider-reserved tool declarations", () => {
+	it("omits reserved declarations but keeps every other tool on opencode-go openai-responses", async () => {
+		const model = getBundledModel("opencode-go", "grok-4.5") as Model<"openai-responses">;
+
+		const payload = (await captureResponsesPayload(model, reservedNameContext)) as {
+			tools?: Array<{ name?: string }>;
+		};
+		expect(payload.tools?.map(tool => tool.name)).toEqual(["echo", "report_finding"]);
+	});
+
+	it("omits reserved declarations but keeps every other tool on opencode-go openai-completions", async () => {
+		const model = getBundledModel("opencode-go", "kimi-k2.5") as Model<"openai-completions">;
+
+		const payload = (await captureCompletionsPayload(model, reservedNameContext)) as {
+			tools?: Array<{ function?: { name?: string } }>;
+		};
+		expect(payload.tools?.map(tool => tool.function?.name)).toEqual(["echo", "report_finding"]);
+	});
+
+	it("keeps web_search on an openai-responses provider that does not reserve it", async () => {
+		const model = getBundledModel("openai", "gpt-5-mini") as Model<"openai-responses">;
+
+		const payload = (await captureResponsesPayload(model, reservedNameContext)) as {
+			tools?: Array<{ name?: string }>;
+		};
+		expect(payload.tools?.map(tool => tool.name)).toEqual(["echo", "web_search", "report_finding"]);
+	});
+
+	it("keeps web_search on an openai-completions provider that does not reserve it", async () => {
+		const model: Model<"openai-completions"> = {
+			...(getBundledModel("openai", "gpt-4o-mini") as unknown as Model<"openai-completions">),
+			api: "openai-completions",
+		};
+
+		const payload = (await captureCompletionsPayload(model, reservedNameContext)) as {
+			tools?: Array<{ function?: { name?: string } }>;
+		};
+		expect(payload.tools?.map(tool => tool.function?.name)).toEqual(["echo", "web_search", "report_finding"]);
+	});
+});

--- a/packages/coding-agent/test/task-bundled-agent-surface.test.ts
+++ b/packages/coding-agent/test/task-bundled-agent-surface.test.ts
@@ -11,6 +11,11 @@ function extractEmbeddedAgentFileNames(source: string): string[] {
 	return [...defsBlock[1].matchAll(/fileName: "([^"]+)"/g)].map(match => match[1]).sort();
 }
 
+function extractDeclaredTools(source: string): string[] | undefined {
+	const declaration = source.match(/^tools:\s*(.+)$/m);
+	return declaration?.[1].split(",").map(name => name.trim());
+}
+
 describe("GJC bundled task agent surface", () => {
 	it("ships exactly the four canonical role agents", async () => {
 		const source = await Bun.file(agentsEntry).text();
@@ -25,5 +30,30 @@ describe("GJC bundled task agent surface", () => {
 			"init.md",
 			"planner.md",
 		]);
+	});
+});
+
+describe("GJC bundled role agent tool declarations", () => {
+	it("keeps web_search declared on the role agents that ask for it", async () => {
+		const declared = new Map<string, string[] | undefined>();
+		for (const agent of ["architect", "critic", "executor", "planner"]) {
+			const source = await Bun.file(path.join(promptsDir, `${agent}.md`)).text();
+			declared.set(agent, extractDeclaredTools(source));
+		}
+
+		expect(declared.get("critic")).toEqual(["read", "search", "find", "lsp", "ast_grep", "web_search", "bash", "irc"]);
+		expect(declared.get("planner")).toEqual(["read", "search", "find", "lsp", "ast_grep", "web_search", "bash", "irc"]);
+		expect(declared.get("architect")).toEqual([
+			"read",
+			"search",
+			"find",
+			"lsp",
+			"ast_grep",
+			"web_search",
+			"bash",
+			"report_finding",
+			"irc",
+		]);
+		expect(declared.get("executor")).toBeUndefined();
 	});
 });


### PR DESCRIPTION
Fixes #4104.

Every `critic`, `planner` and `architect` subagent fails immediately when seated on an `opencode-go` model:

```
400 invalid request: invalid tools in request: custom function name "web_search" is reserved
```

Those three bundled agents declare `web_search` in their frontmatter. `executor` does not, and works — the control that isolates the variable.

## The change

A provider-keyed table of reserved names, and a filter applied where declarations are assembled:

```ts
const PROVIDER_RESERVED_TOOL_NAMES = {
    "opencode-go": ["web_search"],
} satisfies Partial<Record<KnownProvider, readonly string[]>>;

export function filterProviderReservedTools(tools: Tool[], provider: Provider): Tool[] {
    const reserved = PROVIDER_RESERVED_TOOL_NAMES[provider];
    if (!reserved || reserved.length === 0) return tools;
    const kept = tools.filter(tool => !reserved.includes(tool.customWireName ?? tool.name));
    return kept.length === tools.length ? tools : kept;
}
```

Three properties worth naming:

- **Keyed by provider, not global.** A provider that accepts `web_search` still receives it. Stripping it everywhere to satisfy one provider would remove the capability from every seat.
- **Matches the wire name.** Custom-format tools are emitted under `customWireName`, so both that and `name` are checked; matching only `name` would miss exactly the case that 400s.
- **Order preserved, identity preserved.** The original array is returned untouched when nothing is dropped.

The frontmatters of the three agents are unchanged.

## Evidence

Mutation, both directions, on the suites this touches:

|source|result|
|---|---|
|with the fix|**42 pass, 0 fail** (102 `expect()` calls)|
|four provider sources reverted to `origin/dev`|**40 pass, 2 fail**|

## A CI failure you will see that is not from this branch

`packages/ai/test/openai-tool-strict-mode.test.ts` fails 8 tests. That is pre-existing — a clean `origin/dev` worktree with nothing applied gives the same **6 pass / 8 fail**. I nearly misattributed it to this change; checking `dev` first is what settled it. It is untouched here.

## Known and not fixed

Only the assembly sites edited here are covered. If a retry path rebuilds a request without passing through the filter, the 400 returns under that flow, and I did not exhaustively prove those are the only sites — that is the first thing worth attacking in review.

The issue's second half — a terminal provider 400 in a subagent collapsing to `Task failed; error recorded.` with no recoverable message — is untouched and still worth fixing. It is what made this take a reproduction to find rather than a log line.
