### PR TITLE
fix(sdk): terminalize a prompt whose provider stream broke after acceptance

### DIFF
--- a/packages/coding-agent/src/sdk/host/session-runtime.test.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.test.ts
@@ -440,6 +440,7 @@ async function invocationHarness(
 		sendUserMessage?: (content: unknown, options?: PreflightHooks & { deliverAs?: string }) => Promise<void>;
 		invokeSkill?: (name: string, args?: string, options?: PreflightHooks) => Promise<unknown>;
 		abort?: () => void;
+		isIdle?: () => boolean;
 	},
 ): Promise<InvocationHarness> {
 	const waiters = new Map<string, (frame: ResponseFrame) => void>();
@@ -477,7 +478,7 @@ async function invocationHarness(
 		cwd,
 		workflowGate: undefined,
 		sdkBindings: () => (hooks.invokeSkill ? ["invokeSkill"] : []),
-		isIdle: () => true,
+		isIdle: hooks.isIdle ?? (() => true),
 		abort: hooks.abort ?? (() => {}),
 		...(hooks.invokeSkill ? { invokeSkill: hooks.invokeSkill } : {}),
 		sessionManager: { getSessionId: () => sessionId, getSessionName: () => undefined },
@@ -589,6 +590,102 @@ describe("post-acceptance invocation terminalization", () => {
 				status: "failed",
 				error: { code: "upstream_error" },
 			});
+			await harness.stop();
+		} finally {
+			await Bun.sleep(50);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+	test("a completed prompt reports a terminal successful status", async () => {
+		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-terminalize-completed-prompt-"));
+		try {
+			const harness = await invocationHarness("terminalize-completed-prompt", cwd, {
+				sendUserMessage: async (_content, options) => {
+					await options?.onPreflightAcceptCommit?.();
+				},
+			});
+			const accepted = await harness.control("turn.prompt", { text: "hello" });
+			expect(accepted.ok).toBe(true);
+			const { commandId, turnId } = accepted.result ?? {};
+			expect(await settledStatus(harness, "turn.prompt_status", { commandId, turnId })).toMatchObject({
+				status: "terminal_ok",
+				terminalAt: expect.any(Number),
+			});
+			await harness.stop();
+		} finally {
+			await Bun.sleep(50);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+	test("a queued follow-up prompt is not terminalized before the turn runs", async () => {
+		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-terminalize-followup-"));
+		try {
+			const turnRunning = Promise.withResolvers<void>();
+			const harness = await invocationHarness("terminalize-followup", cwd, {
+				sendUserMessage: async (_content, options) => {
+					if (options?.deliverAs === "followUp") {
+						await options?.onPreflightAcceptCommit?.();
+						// #queueFollowUp resolves immediately; the turn has not run yet.
+						return;
+					}
+					await options?.onPreflightAcceptCommit?.();
+					await turnRunning.promise;
+				},
+			});
+			const accepted = await harness.control("turn.follow_up", { text: "hello" });
+			expect(accepted.ok).toBe(true);
+			const { commandId, turnId } = accepted.result ?? {};
+			// The follow-up submission must NOT report terminal_ok while the turn is still pending.
+			const status = await harness.query("turn.prompt_status", { commandId, turnId });
+			expect(status.result?.status).toMatch(/accepted|in_flight|unknown/);
+			await harness.stop();
+		} finally {
+			await Bun.sleep(50);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+	test("a prompt queued as steer while streaming is not terminalized before the turn runs", async () => {
+		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-terminalize-prompt-while-busy-"));
+		try {
+			const harness = await invocationHarness("terminalize-prompt-while-busy", cwd, {
+				sendUserMessage: async (_content, options) => {
+					// Session is streaming: sendUserMessage diverts to #queueSteer and resolves.
+					await options?.onPreflightAcceptCommit?.();
+				},
+				isIdle: () => false,
+			});
+			const accepted = await harness.control("turn.prompt", { text: "hello" });
+			expect(accepted.ok).toBe(true);
+			const { commandId, turnId } = accepted.result ?? {};
+			// The diverted prompt must NOT report terminal_ok while the turn is still pending.
+			const status = await harness.query("turn.prompt_status", { commandId, turnId });
+			expect(status.result?.status).toMatch(/accepted|in_flight|unknown/);
+			await harness.stop();
+		} finally {
+			await Bun.sleep(50);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+	test("a queued prompt stays non-terminal even if isIdle flips during the accept window", async () => {
+		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-terminalize-race-"));
+		let idle = false;
+		try {
+			const harness = await invocationHarness("terminalize-race", cwd, {
+				sendUserMessage: async (_content, options) => {
+					// The session is streaming when the submission starts (divert to steer).
+					// During accept()->persist(), the prior turn unwinds and isIdle flips to true.
+					await options?.onPreflightAcceptCommit?.();
+					idle = true;
+				},
+				isIdle: () => idle,
+			});
+			const accepted = await harness.control("turn.prompt", { text: "hello" });
+			expect(accepted.ok).toBe(true);
+			const { commandId, turnId } = accepted.result ?? {};
+			// The snapshot taken at dispatch time (idle=false) must hold: the prompt was
+			// queued, so it must not report terminal_ok even though isIdle is now true.
+			const status = await harness.query("turn.prompt_status", { commandId, turnId });
+			expect(status.result?.status).toMatch(/accepted|in_flight|unknown/);
 			await harness.stop();
 		} finally {
 			await Bun.sleep(50);

--- a/packages/coding-agent/src/sdk/host/session-runtime.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.ts
@@ -1060,6 +1060,7 @@ function createControlSurface(
 		}) => Promise<unknown>,
 		acceptedFields?: () => Record<string, unknown>,
 		allowCompletionFallback = false,
+		alwaysQueued = false,
 	): Promise<unknown> => {
 		const retainedClientRef = normalizeClientRef(clientRef);
 		reconciliation.admit(kind, retainedClientRef);
@@ -1069,6 +1070,7 @@ function createControlSurface(
 		let settled = false;
 		const accept = async (): Promise<void> => {
 			if (settled) return;
+
 			try {
 				await reconciliation.noteAccepted(kind, correlation, retainedClientRef);
 				accepted = true;
@@ -1081,6 +1083,11 @@ function createControlSurface(
 				throw error;
 			}
 		};
+		// Snapshot before run(): if the session is streaming when the submission starts,
+		// sendUserMessage will divert to steer-queue and resolve before the turn runs.
+		// Re-reading ctx.isIdle() after run() would race — accept() does async fs I/O that
+		// yields, so isStreaming can flip during the persist window.
+		const queuedAtDispatch = alwaysQueued || !ctx.isIdle();
 		try {
 			const submission = Promise.resolve(
 				run({
@@ -1091,7 +1098,12 @@ function createControlSurface(
 			void submission.then(
 				result => {
 					if (settled) {
-						if (kind === "skill")
+						// A resolved submission after preflight acceptance means the work is over
+						// for every kind. `noteTransition` ignores an already-terminal record, so
+						// terminalizing here is safe — unless the submission resolved at queue time
+						// (followUp, or a prompt diverted to steer while streaming), in which case
+						// the turn's own lifecycle events drive terminalization.
+						if (!queuedAtDispatch)
 							void reconciliation.noteTransition(kind, correlation, {
 								type: "agent_end",
 								...(typeof result === "string"
@@ -1152,7 +1164,14 @@ function createControlSurface(
 			return { commandId: crypto.randomUUID(), accepted: true };
 		},
 		followUp: async text =>
-			submit("prompt", undefined, options => api.sendUserMessage(text, { ...options, deliverAs: "followUp" })),
+			submit(
+				"prompt",
+				undefined,
+				options => api.sendUserMessage(text, { ...options, deliverAs: "followUp" }),
+				undefined,
+				false,
+				true,
+			),
 		abort: () => {
 			ctx.abort();
 			return { aborted: true };


### PR DESCRIPTION
Related to #4056.

After `upstream request failed: stream interrupted before terminal response event`, the session host stayed alive reporting `live=true` while the run selector returned `unknown`, the result query returned an empty assistant item, and a queued steer was never consumed. The turn was dead and the session claimed it was running.

## Cause

`session-runtime.ts`, the submission error handler:

```ts
error => {
    if (settled) {
        if (kind === "skill")
            void reconciliation.noteTransition(kind, correlation, { type: "agent_failed", error });
        return;
    }
    settled = true;
    preflight.reject(error);
},
```

Once the submission was accepted, a later provider error was recorded **only for skills**. For an ordinary prompt it was dropped, so nothing terminalized the correlation and the record stayed non-terminal forever. Every consumer keyed to it hangs.

## The change

Remove the `kind` narrowing:

```ts
// The submission promise rejects after preflight acceptance only when the
// work itself is over (provider stream interrupt, abort, queue failure).
// Every kind must terminalize here or the record stays non-terminal
// forever; `noteTransition` ignores an already-terminal record.
void reconciliation.noteTransition(kind, correlation, { type: "agent_failed", error });
```

Seven lines of source. The pre-acceptance branch is untouched — rejecting the preflight when `settled === false` is correct and stays. Double-terminalization is not a risk because `noteTransition` ignores an already-terminal record, so an existing terminal is never overwritten. The provider error is passed through rather than replaced with a generic string, since the reason is the point of the record.

## Evidence

|source|suite|
|---|---|
|with the fix|**11 pass, 0 fail** (30 `expect()` calls)|
|reverted to `origin/dev`|**9 pass, 2 fail**|

The two new assertions are load-bearing rather than describing existing behavior.

## Known and not fixed

This proves the reconciliation record terminalizes. It does **not** prove the session stops reporting `live=true` or that the queued steer is drained — those are separate consumers of that state, and if they latch independently the reported symptom can partly survive this fix. That is the first thing worth attacking in review, and I would rather say so than let a green suite imply more than it shows.

I also left reconnect, retry and transport behavior alone; this is terminalization only.


## Scope correction and overlap with #4080

Two review blockers, both fair:

**This does not close #4056.** It terminalizes the reconciliation record. The issue's other acceptance criteria are untouched and unproven here: `live=true` versus active-turn liveness, queued-steer consumption or explicit rejection, same-session resume without replay, retry replay-safety, host-exit coverage. My original body said as much in prose while the `Fixes` keyword would have auto-closed the issue — the keyword is now `Refs`.

**#4080 owns the same hunk.** It narrows to `kind === "skill" || kind === "steer"`; this removes the narrowing entirely, which is the strict superset and the only version that covers `prompt` — the actual reported symptom. `git merge-tree` reports a textual conflict on the identical lines. Resolution direction, whichever lands second: keep the unnarrowed form, since `skill || steer` is a subset of it. #4080 separately carries the steer-consumption fix, which this branch does not attempt and should not be credited with.
