### PR TITLE
fix(tools): name the legal todo_write operations and the entry that failed

### DIFF
--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -756,6 +756,7 @@ export type RawArgumentRejectionCode =
 	| "ask-deep-interview-metadata-requires-deep-interview-gate"
 	| "todo-write-unknown-root-key"
 	| "todo-write-unknown-op-entry-key"
+	| "todo-write-unknown-op-value"
 	| "todo-write-done-drop-requires-target"
 	| "todo-write-unknown-init-entry-key";
 
@@ -766,7 +767,7 @@ export type RawArgumentRejectionCode =
  * differ from the failed call.
  */
 export interface RawArgumentRejectionDetail {
-	/** Offending keys, in payload order. */
+	/** Offending keys, or the offending value, in payload order. */
 	readonly rejectedKeys?: readonly string[];
 	/**
 	 * Correction for a rejected key whose replacement is exact and

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -968,6 +968,7 @@ const RAW_ARGUMENT_REJECTION_MESSAGES: Record<RawArgumentRejectionCode, string> 
 	"todo-write-unknown-root-key": "todo_write root accepts only an ops array of operation entries",
 	"todo-write-unknown-op-entry-key":
 		"todo_write operation entries accept only op, list, task, phase, items, and text keys",
+	"todo-write-unknown-op-value": "todo_write operation entries require a known op value",
 	"todo-write-done-drop-requires-target": "todo_write done and drop entries require a task or phase target",
 	"todo-write-unknown-init-entry-key": "todo_write init list entries accept only phase and items keys",
 };

--- a/packages/coding-agent/src/tools/descriptors.test.ts
+++ b/packages/coding-agent/src/tools/descriptors.test.ts
@@ -485,6 +485,8 @@ describe("tool descriptor compatibility gate", () => {
 			{ ops: "not-an-array" },
 			{ ops: [{ op: "done", task: "x" }], stray: true },
 			{ _i: "Tracking progress", ops: [{ op: "done", task: "x" }] },
+			{ ops: [{ op: "retitle", task: "x", newTask: "y" }] },
+			{ ops: [{ op: "add", phase: "P", items: ["a"] }] },
 		];
 		for (const payload of payloads) {
 			expect(lazy.rawArgumentValidation(payload)).toEqual(eager.rawArgumentValidation(payload));
@@ -506,6 +508,55 @@ describe("tool descriptor compatibility gate", () => {
 				arguments: { ops: [{ op: "done" }] },
 			}),
 		).toThrow("todo_write done and drop entries require a task or phase target");
+	});
+
+	test("deferred and loaded todo_write reject a bad payload with the same message", async () => {
+		const session = makeSession({ "tools.discoveryMode": "all" });
+		session.hasUI = true;
+		const lazy = (await createTools(session)).find(tool => tool.name === "todo_write");
+		const eager = await BUILTIN_TOOL_DESCRIPTORS.todo_write.load(session);
+		if (!lazy || !eager) throw new Error("expected deferred and loaded todo_write tools");
+		const capture = (run: () => unknown): string => {
+			try {
+				run();
+			} catch (error) {
+				return error instanceof Error ? error.message : String(error);
+			}
+			throw new Error("expected a raw-argument rejection");
+		};
+		const call = (arguments_: Record<string, unknown>) => ({
+			id: "call-parity",
+			type: "toolCall" as const,
+			name: "todo_write",
+			arguments: arguments_,
+		});
+		// The observed incident: four usable entries discarded alongside one
+		// invented op. Whichever path runs first must say the same thing, or the
+		// caller that hit the cold registry sees none of the added guidance.
+		const invalidOp = call({
+			ops: [
+				{ op: "append", phase: "Work", items: ["ship it"] },
+				{ op: "done", task: "first" },
+				{ op: "done", task: "second" },
+				{ op: "done", task: "third" },
+				{ op: "retitle", task: "third", newTask: "fourth" },
+			],
+		});
+		const lazyOpMessage = capture(() => validateToolArguments(lazy, invalidOp));
+		expect(lazyOpMessage).toBe(capture(() => validateToolArguments(eager, invalidOp)));
+		expect(lazyOpMessage).toContain("todo_write operation entries require a known op value");
+		expect(lazyOpMessage).toContain("op must be one of: init, start, done, rm, drop, append, note");
+		expect(lazyOpMessage).toContain("ops[4]");
+
+		const unknownKey = call({
+			ops: [
+				{ op: "done", task: "x" },
+				{ op: "done", task: "y", bogusOpKey: 1 },
+			],
+		});
+		const lazyKeyMessage = capture(() => validateToolArguments(lazy, unknownKey));
+		expect(lazyKeyMessage).toBe(capture(() => validateToolArguments(eager, unknownKey)));
+		expect(lazyKeyMessage).toContain('rejected key: "bogusOpKey" (ops[1])');
 	});
 
 	test("deferred ask validator recovers the canonical round-zero pair", async () => {

--- a/packages/coding-agent/src/tools/todo-contract.ts
+++ b/packages/coding-agent/src/tools/todo-contract.ts
@@ -23,6 +23,23 @@ export function isDoneAlias(value: string): boolean {
 }
 
 /**
+ * Legal `op` values. Exported so the todo_write schema and this contract read
+ * from one list: a rejection that names a vocabulary the schema no longer
+ * accepts is exactly the drift this file exists to prevent.
+ */
+export const TODO_OPS = ["init", "start", "done", "rm", "drop", "append", "note"] as const;
+
+function isKnownOp(value: string): boolean {
+	return (TODO_OPS as readonly string[]).includes(value);
+}
+
+/**
+ * The whole vocabulary, not a guess at which entry the caller meant. Static
+ * text, so clamping a rejection detail can never truncate it away.
+ */
+const TODO_OP_VOCABULARY_HINT = `op must be one of: ${TODO_OPS.join(", ")}`;
+
+/**
  * `_i` is the intent field injected into tool schemas by the agent loop. The
  * loop strips it before validation, but replayed, bridged, and directly
  * validated calls can still carry it, and rejecting it here would fail a call
@@ -46,15 +63,18 @@ const TODO_OP_KEYS_WITH_ALIASES = new Set([...TODO_OP_KEYS, "content"]);
  */
 const TODO_KEY_CORRECTIONS = new Map<string, string>([
 	["note", 'note is an op, not a key; note operations require both "task" and "text"'],
+	["newTask", "there is no rename op; re-run init with the corrected list to rename a task"],
+	["tasks", 'tasks is not a key; append operations take "items"'],
 ]);
 
 function unknownKeys(value: object, allowed: Set<string>): string[] {
 	return Object.keys(value).filter(key => !allowed.has(key));
 }
 
-function keyRejectionDetail(keys: readonly string[]): RawArgumentRejectionDetail {
+function keyRejectionDetail(keys: readonly string[], location?: string): RawArgumentRejectionDetail {
 	const hints = keys.map(key => TODO_KEY_CORRECTIONS.get(key)).filter((hint): hint is string => hint !== undefined);
-	return hints.length > 0 ? { rejectedKeys: keys, hint: hints.join("; ") } : { rejectedKeys: keys };
+	const parts = location === undefined ? hints : [location, ...hints];
+	return parts.length > 0 ? { rejectedKeys: keys, hint: parts.join("; ") } : { rejectedKeys: keys };
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
@@ -64,15 +84,32 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 /**
  * Single source of truth for todo_write pre-coercion validation. Every
  * rejection carries a code so the caller can surface an actionable correction
- * instead of a bare "raw arguments rejected" message.
+ * instead of a bare "raw arguments rejected" message, and every entry-level
+ * rejection names the failing `ops` index. Rejection stays batch-atomic, but a
+ * caller told which entry failed can resubmit the rest instead of rebuilding
+ * the payload from memory — or, as observed, silently abandoning the list.
  */
 export function validateRawTodoArguments(arguments_: Record<string, unknown>): RawArgumentValidationResult {
 	const unknownRootKeys = unknownKeys(arguments_, TODO_WRITE_KEYS);
 	if (unknownRootKeys.length > 0)
 		return { outcome: "reject", code: "todo-write-unknown-root-key", detail: keyRejectionDetail(unknownRootKeys) };
 	if (!Array.isArray(arguments_.ops)) return { outcome: "passthrough" };
-	for (const entry of arguments_.ops) {
+	const ops: readonly unknown[] = arguments_.ops;
+	for (const [index, entry] of ops.entries()) {
 		if (!isPlainRecord(entry)) continue;
+		const location = `ops[${index}]`;
+		// The op value is checked before the entry keys. An entry that invents
+		// both an op and a key is an unknown-op problem, and reporting the key
+		// first tells the caller which keys are legal while leaving it to guess
+		// that the operation it reached for does not exist at all.
+		const rawOp = entry.op;
+		const op = typeof rawOp === "string" && isDoneAlias(rawOp) ? "done" : rawOp;
+		if (typeof op === "string" && !isKnownOp(op))
+			return {
+				outcome: "reject",
+				code: "todo-write-unknown-op-value",
+				detail: { rejectedKeys: [op], hint: `${location}; ${TODO_OP_VOCABULARY_HINT}` },
+			};
 		// `content` is normalized to `task` by the schema preprocessor, so it must
 		// not be rejected here as an unknown key first.
 		const unknownEntryKeys = unknownKeys(entry, TODO_OP_KEYS_WITH_ALIASES);
@@ -80,23 +117,23 @@ export function validateRawTodoArguments(arguments_: Record<string, unknown>): R
 			return {
 				outcome: "reject",
 				code: "todo-write-unknown-op-entry-key",
-				detail: keyRejectionDetail(unknownEntryKeys),
+				detail: keyRejectionDetail(unknownEntryKeys, location),
 			};
-		const op = typeof entry.op === "string" && isDoneAlias(entry.op) ? "done" : entry.op;
 		const target = entry.task ?? entry.content;
 		if ((op === "done" || op === "drop") && !target && !entry.phase) {
-			return { outcome: "reject", code: "todo-write-done-drop-requires-target" };
+			return { outcome: "reject", code: "todo-write-done-drop-requires-target", detail: { hint: location } };
 		}
 		const list = entry.list;
 		if (!Array.isArray(list)) continue;
-		for (const item of list) {
+		const items: readonly unknown[] = list;
+		for (const [itemIndex, item] of items.entries()) {
 			if (!isPlainRecord(item)) continue;
 			const unknownItemKeys = unknownKeys(item, TODO_INIT_ENTRY_KEYS);
 			if (unknownItemKeys.length > 0)
 				return {
 					outcome: "reject",
 					code: "todo-write-unknown-init-entry-key",
-					detail: keyRejectionDetail(unknownItemKeys),
+					detail: keyRejectionDetail(unknownItemKeys, `${location}.list[${itemIndex}]`),
 				};
 		}
 	}

--- a/packages/coding-agent/src/tools/todo-write.ts
+++ b/packages/coding-agent/src/tools/todo-write.ts
@@ -11,7 +11,7 @@ import type { ToolSession } from "../sdk";
 import type { SessionEntry } from "../session/session-manager";
 import { renderStatusLine, renderTreeList } from "../tui";
 import { PREVIEW_LIMITS } from "./render-utils";
-import { isDoneAlias, validateRawTodoArguments } from "./todo-contract";
+import { isDoneAlias, TODO_OPS, validateRawTodoArguments } from "./todo-contract";
 
 // =============================================================================
 // Types
@@ -47,10 +47,7 @@ export interface TodoWriteToolDetails {
 // =============================================================================
 
 const TodoOp = z
-	.preprocess(
-		value => (typeof value === "string" && isDoneAlias(value) ? "done" : value),
-		z.enum(["init", "start", "done", "rm", "drop", "append", "note"] as const),
-	)
+	.preprocess(value => (typeof value === "string" && isDoneAlias(value) ? "done" : value), z.enum(TODO_OPS))
 	.describe('operation to apply; use "done" to complete a task');
 
 const InitListEntry = z.object({

--- a/packages/coding-agent/test/tools/todo-write.test.ts
+++ b/packages/coding-agent/test/tools/todo-write.test.ts
@@ -281,7 +281,7 @@ describe("TodoWriteTool raw argument rejection codes", () => {
 			validateToolArguments(tool, call({ ops: [{ op: "note", note: "why this plan" }] })),
 		);
 		expect(message).toBe(
-			`${REJECTED}; todo_write operation entries accept only op, list, task, phase, items, and text keys; rejected key: "note" (note is an op, not a key; note operations require both "task" and "text")`,
+			`${REJECTED}; todo_write operation entries accept only op, list, task, phase, items, and text keys; rejected key: "note" (ops[0]; note is an op, not a key; note operations require both "task" and "text")`,
 		);
 		expect(message).not.toContain('use { op: "note", text: "..." }');
 	});
@@ -299,7 +299,7 @@ describe("TodoWriteTool raw argument rejection codes", () => {
 			validateToolArguments(tool, call({ ops: [{ op: "done", task: "x", bogusOpKey: "y" }] })),
 		);
 		expect(message).toBe(
-			`${REJECTED}; todo_write operation entries accept only op, list, task, phase, items, and text keys; rejected key: "bogusOpKey"`,
+			`${REJECTED}; todo_write operation entries accept only op, list, task, phase, items, and text keys; rejected key: "bogusOpKey" (ops[0])`,
 		);
 	});
 
@@ -308,7 +308,7 @@ describe("TodoWriteTool raw argument rejection codes", () => {
 			validateToolArguments(tool, call({ ops: [{ op: "done", task: "x", alpha: 1, beta: 2 }] })),
 		);
 		expect(message).toBe(
-			`${REJECTED}; todo_write operation entries accept only op, list, task, phase, items, and text keys; rejected keys: "alpha", "beta"`,
+			`${REJECTED}; todo_write operation entries accept only op, list, task, phase, items, and text keys; rejected keys: "alpha", "beta" (ops[0])`,
 		);
 	});
 
@@ -332,7 +332,7 @@ describe("TodoWriteTool raw argument rejection codes", () => {
 			),
 		);
 		expect(message).toBe(
-			`${REJECTED}; todo_write init list entries accept only phase and items keys; rejected key: "bogusInitKey"`,
+			`${REJECTED}; todo_write init list entries accept only phase and items keys; rejected key: "bogusInitKey" (ops[0].list[0])`,
 		);
 	});
 
@@ -373,6 +373,70 @@ describe("TodoWriteTool raw argument rejection codes", () => {
 		expect(() =>
 			validateToolArguments(tool, call({ _i: "Tracking progress", ops: [{ op: "done", task: "x" }], stray: 1 })),
 		).toThrow("todo_write root accepts only an ops array of operation entries");
+	});
+
+	it("names the legal operation vocabulary when an entry invents an op", () => {
+		const message = captureValidationError(() =>
+			validateToolArguments(tool, call({ ops: [{ op: "retitle", task: "x" }] })),
+		);
+		expect(message).toBe(
+			`${REJECTED}; todo_write operation entries require a known op value; rejected key: "retitle" (ops[0]; op must be one of: init, start, done, rm, drop, append, note)`,
+		);
+	});
+
+	it("reports the invented op ahead of the unknown key the same entry carries", () => {
+		const message = captureValidationError(() =>
+			validateToolArguments(tool, call({ ops: [{ op: "retitle", task: "x", newTask: "y" }] })),
+		);
+		expect(message).toContain("todo_write operation entries require a known op value");
+		expect(message).toContain("op must be one of: init, start, done, rm, drop, append, note");
+		expect(message).not.toContain("accept only op, list, task, phase, items, and text keys");
+	});
+
+	it("names the failing entry index so the surviving entries can be resubmitted", () => {
+		const message = captureValidationError(() =>
+			validateToolArguments(
+				tool,
+				call({
+					ops: [
+						{ op: "append", phase: "Work", items: ["ship it"] },
+						{ op: "done", task: "first" },
+						{ op: "done", task: "second" },
+						{ op: "done", task: "third" },
+						{ op: "retitle", task: "third", newTask: "fourth" },
+					],
+				}),
+			),
+		);
+		expect(message).toContain("ops[4]");
+		expect(message).not.toContain("ops[0]");
+		expect(message).not.toContain("ops[3]");
+	});
+
+	it("points the newTask correction at re-init instead of a rename op", () => {
+		const message = captureValidationError(() =>
+			validateToolArguments(tool, call({ ops: [{ op: "start", task: "x", newTask: "y" }] })),
+		);
+		expect(message).toBe(
+			`${REJECTED}; todo_write operation entries accept only op, list, task, phase, items, and text keys; rejected key: "newTask" (ops[0]; there is no rename op; re-run init with the corrected list to rename a task)`,
+		);
+		expect(message).not.toContain("retitle");
+	});
+
+	it("routes the tasks key to the items key append actually takes", () => {
+		const message = captureValidationError(() =>
+			validateToolArguments(tool, call({ ops: [{ op: "append", phase: "Work", tasks: ["ship it"] }] })),
+		);
+		expect(message).toContain('rejected key: "tasks" (ops[0]; tasks is not a key; append operations take "items")');
+	});
+
+	it("keeps complete and completed aliased to done instead of rejecting them as unknown ops", () => {
+		for (const op of ["complete", "completed"]) {
+			const parsed = validateToolArguments(tool, call({ ops: [{ op, task: "ship it" }] })) as {
+				ops: Array<{ op: string; task?: string }>;
+			};
+			expect(parsed.ops[0]).toEqual({ op: "done", task: "ship it" });
+		}
 	});
 });
 


### PR DESCRIPTION
Fixes #4102.

A `todo_write` batch with one bad entry was rejected like this:

```
raw arguments rejected before coercion;
todo_write operation entries accept only op, list, task, phase, items, and text keys
```

The caller had used an operation that does not exist. The message names the legal *keys* and never the legal *operations*, and the unknown-key check fires first, so an invalid `op` value is never mentioned at all. In the incident that prompted this, the caller could not recover the payload and the todo list silently stopped being maintained.

## The change

- An unknown operation value is now its own rejection code, `todo-write-unknown-op-value`, carrying the legal list: `init`, `start`, `done`, `rm`, `drop`, `append`, `note`.
- A key rejection names the offending entry index, so a caller can resubmit the remainder instead of rebuilding from memory.
- `newTask` joins `TODO_KEY_CORRECTIONS` as an exact entry pointing at re-init.

No fuzzy matching and no new operations. The file is explicit that "a wrong suggestion costs more turns than no suggestion", and a `retitle` op would widen the vocabulary to solve something re-init already solves. `TODO_DONE_ALIASES` was the precedent followed: exact aliases only.

The eager tool and the cold descriptor registry are both covered — the file header warns those two copies have drifted before, so the tests assert they agree on the same bad payload.

## Evidence

|source|suites|
|---|---|
|with the fix|**59 pass, 0 fail** (292 `expect()` calls)|
|sources reverted to `origin/dev`|**49 pass, 10 fail**|

Ten load-bearing assertions across `descriptors.test.ts` and `tools/todo-write.test.ts`.

## Known and not fixed

Rejection is still batch-atomic. The valid entries in a mixed payload are still discarded — this reports *which* entry failed, it does not apply the others. Partial application is a real behavior change to the tool's contract and belongs in its own decision, not smuggled in behind an error-message fix.
