### PR TITLE
fix(gc): report and reclaim the tool artifacts that fill a managed scope

### DIFF
--- a/packages/coding-agent/src/commands/gc.ts
+++ b/packages/coding-agent/src/commands/gc.ts
@@ -26,7 +26,7 @@ export default class Gc extends Command {
 		force: Flags.boolean({ description: "Alias for --prune (eligible records only)", default: false }),
 		"dry-run": Flags.boolean({ description: "Force report-only mode", default: false }),
 		disk: Flags.boolean({
-			description: "Also report on-disk retention (sessions, blobs, natives, backups)",
+			description: "Also report on-disk retention (sessions, blobs, artifacts, natives, backups)",
 			default: false,
 		}),
 		"repair-session-index": Flags.boolean({

--- a/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
@@ -1400,134 +1400,148 @@ async function runGcDiskArtifacts(input: {
 	surface: GcDiskSurfaceReport;
 	survivors: GcDiskTranscript[];
 	references: GcSessionReferences;
+	agentDir: string;
 	now: number;
 	prune: boolean;
 	errors: GcDiskError[];
 }): Promise<void> {
-	const { surface, survivors, references, now, prune, errors } = input;
-
-	// Recomputed over survivors: whichever transcript the sessions surface left
-	// newest in a project directory is the `--continue` target, and a resumed
-	// session still reads its own `artifact://` handles.
-	const newestPerDirectory = new Map<string, GcDiskTranscript>();
-	for (const transcript of survivors) {
-		const current = newestPerDirectory.get(transcript.directory);
-		if (!current || transcript.mtimeMs > current.mtimeMs) newestPerDirectory.set(transcript.directory, transcript);
-	}
-
-	const families = new Map<string, GcDiskFamilyUsage>();
-	let withheld = 0;
-	let withheldBytes = 0;
-
-	for (const transcript of survivors) {
-		const directory = transcript.path.slice(0, -".jsonl".length);
-		let entries: Dirent[];
-		try {
-			entries = await fsp.readdir(directory, { withFileTypes: true });
-		} catch (error) {
-			// No artifact directory is complete evidence: this session wrote none.
-			if (!isEnoent(error)) {
-				errors.push({ surface: "artifacts", scope: directory, message: gcDiskErrorText(error) });
-			}
-			continue;
-		}
-
-		const retained = !references.complete
-			? `reference_scan_incomplete: ${references.notes.join(", ")}`
-			: references.ids.has(transcript.sessionId)
-				? "referenced_by_live_surface"
-				: newestPerDirectory.get(transcript.directory) === transcript
-					? "most_recent_resumable_session"
-					: undefined;
-
-		for (const entry of entries) {
-			if (surface.records.length >= GC_DISK_MAX_WALK_ENTRIES) {
-				errors.push({ surface: "artifacts", scope: directory, message: "artifact_walk_capped" });
-				break;
-			}
-			const target = path.join(directory, entry.name);
-			const record: GcDiskRecord = {
-				surface: "artifacts",
-				id: `${transcript.sessionId}/${entry.name}`,
-				path: target,
-				bytes: 0,
-				age_days: 0,
-				action: "keep",
-				reason: "",
-			};
-
-			// A symlink is never followed and never removed: following one is exactly
-			// how a scope cleanup reaches bytes that are not GJC's to reclaim.
-			// Anything that is not a regular file is unverified state, not an artifact.
-			if (entry.isSymbolicLink() || !entry.isFile()) {
-				record.reason = `unverified_entry: ${entry.isSymbolicLink() ? "symlink" : "not_a_regular_file"}`;
-				record.withheld = true;
-				surface.records.push(record);
-				countGcDiskArtifactFamily(families, entry.name, 0);
-				withheld++;
-				continue;
+	const { surface, survivors, references, agentDir, now, prune, errors } = input;
+	const sessionIndex = new SessionIndex(agentDir);
+	try {
+		await sessionIndex.withLocked(async () => {
+			// Recomputed over survivors: whichever transcript the sessions surface left
+			// newest in a project directory is the `--continue` target, and a resumed
+			// session still reads its own `artifact://` handles.
+			const newestPerDirectory = new Map<string, GcDiskTranscript>();
+			for (const transcript of survivors) {
+				const current = newestPerDirectory.get(transcript.directory);
+				if (!current || transcript.mtimeMs > current.mtimeMs)
+					newestPerDirectory.set(transcript.directory, transcript);
 			}
 
-			let stat: Stats;
-			try {
-				stat = await fsp.lstat(target);
-			} catch (error) {
-				// Vanished mid-walk is the opposite of withheld: it is already gone.
-				if (isEnoent(error)) continue;
-				const message = gcDiskErrorText(error);
-				errors.push({ surface: "artifacts", scope: target, message });
-				record.reason = `entry_unverifiable: ${message}`;
-				record.error = message;
-				record.withheld = true;
-				surface.records.push(record);
-				countGcDiskArtifactFamily(families, entry.name, 0);
-				withheld++;
-				continue;
-			}
+			const families = new Map<string, GcDiskFamilyUsage>();
+			let withheld = 0;
+			let withheldBytes = 0;
 
-			record.bytes = stat.size;
-			record.age_days = gcDiskAgeDays(now, stat.mtimeMs);
-			surface.records.push(record);
-			countGcDiskArtifactFamily(families, entry.name, stat.size);
-
-			if (retained !== undefined) {
-				record.reason = retained;
-				if (!references.complete) {
-					record.withheld = true;
-					withheld++;
-					withheldBytes += record.bytes;
+			for (const transcript of survivors) {
+				const directory = transcript.path.slice(0, -".jsonl".length);
+				let entries: Dirent[];
+				try {
+					entries = await fsp.readdir(directory, { withFileTypes: true });
+				} catch (error) {
+					// No artifact directory is complete evidence: this session wrote none.
+					if (!isEnoent(error)) {
+						errors.push({ surface: "artifacts", scope: directory, message: gcDiskErrorText(error) });
+					}
+					continue;
 				}
-				continue;
-			}
-			if (now - stat.mtimeMs < GC_DISK_BLOB_GRACE_MS) {
-				record.reason = "within_write_grace_window";
-				continue;
-			}
-			record.action = "would_reclaim";
-			record.reason = "unreferenced_by_any_live_session";
 
-			if (!prune) continue;
-			const removal = await removeGcDiskEntry(target, stat);
-			if (removal.removed) record.action = "reclaimed";
-			else if (removal.failed) {
-				record.action = "reclaim_failed";
-				record.reason = removal.reason;
-				record.error = removal.reason;
-			} else {
-				record.action = "keep";
-				record.reason = removal.reason;
-				if (removal.withheld) record.withheld = true;
-			}
-		}
-	}
+				const retained = !references.complete
+					? `reference_scan_incomplete: ${references.notes.join(", ")}`
+					: references.ids.has(transcript.sessionId)
+						? "referenced_by_live_surface"
+						: newestPerDirectory.get(transcript.directory) === transcript
+							? "most_recent_resumable_session"
+							: undefined;
 
-	surface.families = [...families.values()].sort((a, b) => b.bytes - a.bytes || a.family.localeCompare(b.family));
-	if (!references.complete) {
-		surface.declined = {
-			reason: `reference_scan_incomplete: ${references.notes.join(", ")}`,
-			withheld,
-			withheld_bytes: withheldBytes,
-		};
+				for (const entry of entries) {
+					if (surface.records.length >= GC_DISK_MAX_WALK_ENTRIES) {
+						errors.push({ surface: "artifacts", scope: directory, message: "artifact_walk_capped" });
+						break;
+					}
+					const target = path.join(directory, entry.name);
+					const record: GcDiskRecord = {
+						surface: "artifacts",
+						id: `${transcript.sessionId}/${entry.name}`,
+						path: target,
+						bytes: 0,
+						age_days: 0,
+						action: "keep",
+						reason: "",
+					};
+
+					// A symlink is never followed and never removed: following one is exactly
+					// how a scope cleanup reaches bytes that are not GJC's to reclaim.
+					// Anything that is not a regular file is unverified state, not an artifact.
+					if (entry.isSymbolicLink() || !entry.isFile()) {
+						record.reason = `unverified_entry: ${entry.isSymbolicLink() ? "symlink" : "not_a_regular_file"}`;
+						record.withheld = true;
+						surface.records.push(record);
+						countGcDiskArtifactFamily(families, entry.name, 0);
+						withheld++;
+						continue;
+					}
+
+					let stat: Stats;
+					try {
+						stat = await fsp.lstat(target);
+					} catch (error) {
+						// Vanished mid-walk is the opposite of withheld: it is already gone.
+						if (isEnoent(error)) continue;
+						const message = gcDiskErrorText(error);
+						errors.push({ surface: "artifacts", scope: target, message });
+						record.reason = `entry_unverifiable: ${message}`;
+						record.error = message;
+						record.withheld = true;
+						surface.records.push(record);
+						countGcDiskArtifactFamily(families, entry.name, 0);
+						withheld++;
+						continue;
+					}
+
+					record.bytes = stat.size;
+					record.age_days = gcDiskAgeDays(now, stat.mtimeMs);
+					surface.records.push(record);
+					countGcDiskArtifactFamily(families, entry.name, stat.size);
+
+					if (retained !== undefined) {
+						record.reason = retained;
+						if (!references.complete) {
+							record.withheld = true;
+							withheld++;
+							withheldBytes += record.bytes;
+						}
+						continue;
+					}
+					if (now - stat.mtimeMs < GC_DISK_BLOB_GRACE_MS) {
+						record.reason = "within_write_grace_window";
+						continue;
+					}
+					record.action = "would_reclaim";
+					record.reason = "unreferenced_by_any_live_session";
+
+					if (!prune) continue;
+					const removal = await removeGcDiskEntry(target, stat);
+					if (removal.removed) record.action = "reclaimed";
+					else if (removal.failed) {
+						record.action = "reclaim_failed";
+						record.reason = removal.reason;
+						record.error = removal.reason;
+					} else {
+						record.action = "keep";
+						record.reason = removal.reason;
+						if (removal.withheld) record.withheld = true;
+					}
+				}
+			}
+
+			surface.families = [...families.values()].sort(
+				(a, b) => b.bytes - a.bytes || a.family.localeCompare(b.family),
+			);
+			if (!references.complete) {
+				surface.declined = {
+					reason: `reference_scan_incomplete: ${references.notes.join(", ")}`,
+					withheld,
+					withheld_bytes: withheldBytes,
+				};
+			}
+		});
+	} catch (error) {
+		errors.push({
+			surface: "artifacts",
+			scope: surface.root,
+			message: `artifact_liveness_authority_unavailable: ${gcDiskErrorText(error)}`,
+		});
 	}
 }
 /** Numeric `major.minor.patch` prefix, or undefined when the name is not a version. */
@@ -1876,7 +1890,15 @@ export async function collectGcDiskReport(input: {
 		prune,
 		errors,
 	});
-	await runGcDiskArtifacts({ surface: surfaces.artifacts, survivors, references, now, prune, errors });
+	await runGcDiskArtifacts({
+		surface: surfaces.artifacts,
+		survivors,
+		references,
+		agentDir,
+		now,
+		prune,
+		errors,
+	});
 	await runGcDiskNatives({
 		surface: surfaces.natives,
 		policy,

--- a/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
@@ -528,15 +528,16 @@ export function gcHelpText(): string {
 		"  --dry-run         Force report-only mode (overrides --prune/--force)",
 		"  -j, --json        Emit machine-readable JSON",
 		"  --repair-session-index  Explicitly quarantine a corrupt session-index suffix and retain its valid prefix",
-		"  --disk            Also report on-disk retention (sessions, blobs, natives, backups)",
+		"  --disk            Also report on-disk retention (sessions, blobs, artifacts, natives, backups)",
 		"",
 		"Liveness-only: a record is removed only when its owning process is dead",
 		"(ESRCH). Live / permission-denied / unknown processes are always kept.",
 		"",
 		"Disk retention (--disk) is a separate, opt-in axis. Without --prune it only",
 		"reports reclaimable bytes per surface. Live, referenced, permission-denied or",
-		"otherwise ambiguous state is always KEPT and the report says why. Managed",
-		"worktrees under ~/.gjc/wt are never touched.",
+		"otherwise ambiguous state is always KEPT and the report says why. Session tool",
+		"artifacts (`*.<tool>.log`, `.artifact-id-*`, evicted output) are reported per",
+		"family. Managed worktrees under ~/.gjc/wt are never touched.",
 		"",
 	].join("\n");
 }
@@ -580,15 +581,21 @@ export async function defaultGcAdapters(): Promise<GcStoreAdapter[]> {
 // needs evidence-based merge detection, which this axis does not have.
 
 /** On-disk surfaces the retention axis can reclaim. */
-export type GcDiskSurface = "sessions" | "blobs" | "natives" | "backups";
+export type GcDiskSurface = "sessions" | "blobs" | "artifacts" | "natives" | "backups";
 
-export const GC_DISK_SURFACES: readonly GcDiskSurface[] = ["sessions", "blobs", "natives", "backups"] as const;
+export const GC_DISK_SURFACES: readonly GcDiskSurface[] = [
+	"sessions",
+	"blobs",
+	"artifacts",
+	"natives",
+	"backups",
+] as const;
 
 export type GcDiskAction = "keep" | "would_reclaim" | "reclaimed" | "reclaim_failed";
 
 export interface GcDiskRecord {
 	surface: GcDiskSurface;
-	/** Session id, blob hash, natives version, or backup entry name. */
+	/** Session id, blob hash, `<session id>/<filename>` artifact, natives version, or backup entry name. */
 	id: string;
 	path: string;
 	bytes: number;
@@ -600,6 +607,20 @@ export interface GcDiskRecord {
 	partial?: true;
 	/** Set when this entry was a reclaim candidate that its surface withheld on incomplete evidence. */
 	withheld?: true;
+}
+
+/**
+ * Per-family rollup of a surface whose growth is many small files.
+ *
+ * The artifacts surface writes one record per file, which answers "what may go"
+ * but not "what filled the scope". A family is derived from the filename shape
+ * (`*.bash.log`, `.artifact-id-*`, …) rather than a fixed list, so a tool that
+ * starts writing a new kind of log is counted the day it ships.
+ */
+export interface GcDiskFamilyUsage {
+	family: string;
+	count: number;
+	bytes: number;
 }
 
 /**
@@ -626,6 +647,8 @@ export interface GcDiskSurfaceReport {
 	failed: number;
 	/** Set when the surface declined to reclaim anything because its evidence was incomplete. */
 	declined?: GcDiskDeclined;
+	/** Per-family counts and bytes. Only surfaces whose records are individual files set this. */
+	families?: GcDiskFamilyUsage[];
 	records: GcDiskRecord[];
 }
 
@@ -1328,6 +1351,185 @@ async function runGcDiskBlobs(input: {
 	}
 }
 
+/**
+ * Which family of GJC-written file a name belongs to, derived from the name's
+ * shape rather than from a list of known tools.
+ *
+ * A published artifact is `<id>.<toolType>.log` and an ID claim is
+ * `.artifact-id-<n>`, so a tool that starts writing `*.newthing.log` tomorrow is
+ * counted the day it ships. Everything else falls back to its extension, so
+ * nothing lands in the scope uncounted.
+ */
+function gcDiskArtifactFamily(name: string): string {
+	const toolLog = /^\d+\.([A-Za-z0-9_-]+)\.log$/.exec(name);
+	if (toolLog) return `*.${toolLog[1]}.log`;
+	if (/^\.artifact-id-\d+$/.test(name)) return ".artifact-id-*";
+	const extension = path.extname(name);
+	return extension ? `*${extension}` : "(no extension)";
+}
+
+function countGcDiskArtifactFamily(families: Map<string, GcDiskFamilyUsage>, name: string, bytes: number): void {
+	const family = gcDiskArtifactFamily(name);
+	const usage = families.get(family);
+	if (!usage) {
+		families.set(family, { family, count: 1, bytes });
+		return;
+	}
+	usage.count++;
+	usage.bytes += bytes;
+}
+
+/**
+ * The per-session artifact directories GJC writes its own tool output into:
+ * `<id>.<tool>.log`, `.artifact-id-<n>` ID claims, evicted-output generations.
+ *
+ * The sessions surface already counts these bytes, but only as one number per
+ * session and only reclaimable by retiring the whole session — so a scope filled
+ * by a retained session's own tool logs was both unattributable and
+ * unreclaimable. They are reported per family always, and reclaimed only for a
+ * transcript that (a) no live surface references, (b) is not the newest
+ * resumable transcript left in its project directory, and (c) holds a file that
+ * has been still for the write-grace window.
+ *
+ * The walk never leaves `sessionsRoot`: directories come from the same
+ * transcript enumeration the sessions surface uses, and inside one only regular
+ * non-symlink files are candidates. A symlink, a subdirectory, or an unstattable
+ * entry is reported as unverified and left alone — never followed, never removed.
+ */
+async function runGcDiskArtifacts(input: {
+	surface: GcDiskSurfaceReport;
+	survivors: GcDiskTranscript[];
+	references: GcSessionReferences;
+	now: number;
+	prune: boolean;
+	errors: GcDiskError[];
+}): Promise<void> {
+	const { surface, survivors, references, now, prune, errors } = input;
+
+	// Recomputed over survivors: whichever transcript the sessions surface left
+	// newest in a project directory is the `--continue` target, and a resumed
+	// session still reads its own `artifact://` handles.
+	const newestPerDirectory = new Map<string, GcDiskTranscript>();
+	for (const transcript of survivors) {
+		const current = newestPerDirectory.get(transcript.directory);
+		if (!current || transcript.mtimeMs > current.mtimeMs) newestPerDirectory.set(transcript.directory, transcript);
+	}
+
+	const families = new Map<string, GcDiskFamilyUsage>();
+	let withheld = 0;
+	let withheldBytes = 0;
+
+	for (const transcript of survivors) {
+		const directory = transcript.path.slice(0, -".jsonl".length);
+		let entries: Dirent[];
+		try {
+			entries = await fsp.readdir(directory, { withFileTypes: true });
+		} catch (error) {
+			// No artifact directory is complete evidence: this session wrote none.
+			if (!isEnoent(error)) {
+				errors.push({ surface: "artifacts", scope: directory, message: gcDiskErrorText(error) });
+			}
+			continue;
+		}
+
+		const retained = !references.complete
+			? `reference_scan_incomplete: ${references.notes.join(", ")}`
+			: references.ids.has(transcript.sessionId)
+				? "referenced_by_live_surface"
+				: newestPerDirectory.get(transcript.directory) === transcript
+					? "most_recent_resumable_session"
+					: undefined;
+
+		for (const entry of entries) {
+			if (surface.records.length >= GC_DISK_MAX_WALK_ENTRIES) {
+				errors.push({ surface: "artifacts", scope: directory, message: "artifact_walk_capped" });
+				break;
+			}
+			const target = path.join(directory, entry.name);
+			const record: GcDiskRecord = {
+				surface: "artifacts",
+				id: `${transcript.sessionId}/${entry.name}`,
+				path: target,
+				bytes: 0,
+				age_days: 0,
+				action: "keep",
+				reason: "",
+			};
+
+			// A symlink is never followed and never removed: following one is exactly
+			// how a scope cleanup reaches bytes that are not GJC's to reclaim.
+			// Anything that is not a regular file is unverified state, not an artifact.
+			if (entry.isSymbolicLink() || !entry.isFile()) {
+				record.reason = `unverified_entry: ${entry.isSymbolicLink() ? "symlink" : "not_a_regular_file"}`;
+				record.withheld = true;
+				surface.records.push(record);
+				countGcDiskArtifactFamily(families, entry.name, 0);
+				withheld++;
+				continue;
+			}
+
+			let stat: Stats;
+			try {
+				stat = await fsp.lstat(target);
+			} catch (error) {
+				// Vanished mid-walk is the opposite of withheld: it is already gone.
+				if (isEnoent(error)) continue;
+				const message = gcDiskErrorText(error);
+				errors.push({ surface: "artifacts", scope: target, message });
+				record.reason = `entry_unverifiable: ${message}`;
+				record.error = message;
+				record.withheld = true;
+				surface.records.push(record);
+				countGcDiskArtifactFamily(families, entry.name, 0);
+				withheld++;
+				continue;
+			}
+
+			record.bytes = stat.size;
+			record.age_days = gcDiskAgeDays(now, stat.mtimeMs);
+			surface.records.push(record);
+			countGcDiskArtifactFamily(families, entry.name, stat.size);
+
+			if (retained !== undefined) {
+				record.reason = retained;
+				if (!references.complete) {
+					record.withheld = true;
+					withheld++;
+					withheldBytes += record.bytes;
+				}
+				continue;
+			}
+			if (now - stat.mtimeMs < GC_DISK_BLOB_GRACE_MS) {
+				record.reason = "within_write_grace_window";
+				continue;
+			}
+			record.action = "would_reclaim";
+			record.reason = "unreferenced_by_any_live_session";
+
+			if (!prune) continue;
+			const removal = await removeGcDiskEntry(target, stat);
+			if (removal.removed) record.action = "reclaimed";
+			else if (removal.failed) {
+				record.action = "reclaim_failed";
+				record.reason = removal.reason;
+				record.error = removal.reason;
+			} else {
+				record.action = "keep";
+				record.reason = removal.reason;
+				if (removal.withheld) record.withheld = true;
+			}
+		}
+	}
+
+	surface.families = [...families.values()].sort((a, b) => b.bytes - a.bytes || a.family.localeCompare(b.family));
+	if (!references.complete) {
+		surface.declined = {
+			reason: `reference_scan_incomplete: ${references.notes.join(", ")}`,
+			withheld,
+			withheld_bytes: withheldBytes,
+		};
+	}
+}
 /** Numeric `major.minor.patch` prefix, or undefined when the name is not a version. */
 function parseGcDiskVersion(value: string): [number, number, number] | undefined {
 	const match = /^v?(\d+)\.(\d+)\.(\d+)/.exec(value);
@@ -1649,6 +1851,7 @@ export async function collectGcDiskReport(input: {
 	const surfaces: Record<GcDiskSurface, GcDiskSurfaceReport> = {
 		sessions: emptyGcDiskSurface("sessions", getSessionsDir(agentDir)),
 		blobs: emptyGcDiskSurface("blobs", getBlobsDir(agentDir)),
+		artifacts: emptyGcDiskSurface("artifacts", getSessionsDir(agentDir)),
 		natives: emptyGcDiskSurface("natives", path.join(gjcRoot, "natives")),
 		backups: emptyGcDiskSurface("backups", path.join(gjcRoot, "backups")),
 	};
@@ -1673,6 +1876,7 @@ export async function collectGcDiskReport(input: {
 		prune,
 		errors,
 	});
+	await runGcDiskArtifacts({ surface: surfaces.artifacts, survivors, references, now, prune, errors });
 	await runGcDiskNatives({
 		surface: surfaces.natives,
 		policy,
@@ -1687,10 +1891,15 @@ export async function collectGcDiskReport(input: {
 	for (const name of GC_DISK_SURFACES) {
 		const surface = surfaces[name];
 		summarizeGcDiskSurface(surface);
-		totals.scanned_bytes += surface.scanned_bytes;
+		// The artifacts surface re-attributes bytes the sessions surface already
+		// counted inside surviving sessions, so only what it can act on is added:
+		// summing its scan too would report more bytes than exist on disk.
+		if (name !== "artifacts") {
+			totals.scanned_bytes += surface.scanned_bytes;
+			totals.kept_bytes += surface.kept_bytes;
+		}
 		totals.reclaimable_bytes += surface.reclaimable_bytes;
 		totals.reclaimed_bytes += surface.reclaimed_bytes;
-		totals.kept_bytes += surface.kept_bytes;
 		totals.failed += surface.failed;
 	}
 
@@ -1700,6 +1909,7 @@ export async function collectGcDiskReport(input: {
 const GC_DISK_SURFACE_HEADINGS: Record<GcDiskSurface, string> = {
 	sessions: "Session transcripts",
 	blobs: "Content-addressed blobs",
+	artifacts: "Session tool artifacts",
 	natives: "Cached native versions",
 	backups: "Update/restore backups",
 };
@@ -1759,6 +1969,11 @@ export function buildGcDiskReportText(disk: GcDiskReport): string {
 				`  declined: reclaimed nothing — ${surface.declined.reason} ` +
 					`(withheld=${surface.declined.withheld} (${formatGcDiskBytes(surface.declined.withheld_bytes)}))`,
 			);
+		}
+		// The per-file records below say what may go; the family rollup is what
+		// answers "what filled this scope?", so it is never truncated.
+		for (const family of surface.families ?? []) {
+			lines.push(`  family ${family.family} count=${family.count} (${formatGcDiskBytes(family.bytes)})`);
 		}
 		// Reclaim decisions first: they are what an operator has to audit.
 		const ranked = [...surface.records].sort(

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -54,6 +54,8 @@ import {
 	createAgentSession,
 	discoverAuthStorage,
 } from "./sdk";
+import { SessionIndex } from "./sdk/broker/session-index";
+
 import type { AgentSession } from "./session/agent-session";
 import { SessionMigrationBusyError } from "./session/internal/session-open-errors";
 import {
@@ -1756,6 +1758,29 @@ export async function runRootCommand(
 			eventBus,
 		} = await createSession(sessionOptions, { skipPostCreateModelRefresh: hasRootStartupProfile });
 		applyCliRuntimeApiKeyOverride(authStorage, parsedArgs.apiKey, session.model);
+		// Ordinary CLI sessions share the broker's canonical liveness index. GC uses
+		// this PID-bound registration before reclaiming their artifact sidecars.
+		const directSessionId = process.env.GJC_LIFECYCLE_REQUEST_ID ? undefined : sessionManager?.getSessionId();
+		if (directSessionId) {
+			const sessionIndex = new SessionIndex(settingsInstance.getAgentDir());
+			const locator = { repo: sessionManager?.getCwd() ?? cwd, stateRoot: settingsInstance.getAgentDir() };
+			await sessionIndex.append({
+				type: "host_registered",
+				sessionId: directSessionId,
+				locator,
+				endpointGeneration: 0,
+				pid: process.pid,
+			});
+			postmortem.register("direct-session-index", async () => {
+				await sessionIndex.append({
+					type: "host_unregistered",
+					sessionId: directSessionId,
+					locator,
+					endpointGeneration: 0,
+					pid: process.pid,
+				});
+			});
+		}
 
 		// Research-mode (RLM) preset: hard tool-boundary assertion after the registry is assembled.
 		if (deps.rlmPreset?.onSessionCreated) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1722,6 +1722,30 @@ export async function runRootCommand(
 		await postmortem.cleanup();
 		return;
 	}
+	// Register a resumed direct session before constructing the agent: GC holds the
+	// same index lock while deleting artifacts, so startup and deletion are fenced.
+	const directSessionId = process.env.GJC_LIFECYCLE_REQUEST_ID ? undefined : sessionManager?.getSessionId();
+	if (directSessionId) {
+		const sessionIndex = new SessionIndex(settingsInstance.getAgentDir());
+		const locator = { repo: sessionManager?.getCwd() ?? cwd, stateRoot: settingsInstance.getAgentDir() };
+		await sessionIndex.append({
+			type: "host_registered",
+			sessionId: directSessionId,
+			locator,
+			endpointGeneration: 0,
+			pid: process.pid,
+		});
+		postmortem.register("direct-session-index", async () => {
+			await sessionIndex.append({
+				type: "host_unregistered",
+				sessionId: directSessionId,
+				locator,
+				endpointGeneration: 0,
+				pid: process.pid,
+			});
+		});
+	}
+
 	const createAgentSessionImpl = deps.createAgentSession ?? createAgentSession;
 	const createSession: CreateSessionForMain = async (options, context): Promise<CreateAgentSessionResult> => {
 		const result = await logger.time("createAgentSession", createAgentSessionImpl, options);
@@ -1758,29 +1782,6 @@ export async function runRootCommand(
 			eventBus,
 		} = await createSession(sessionOptions, { skipPostCreateModelRefresh: hasRootStartupProfile });
 		applyCliRuntimeApiKeyOverride(authStorage, parsedArgs.apiKey, session.model);
-		// Ordinary CLI sessions share the broker's canonical liveness index. GC uses
-		// this PID-bound registration before reclaiming their artifact sidecars.
-		const directSessionId = process.env.GJC_LIFECYCLE_REQUEST_ID ? undefined : sessionManager?.getSessionId();
-		if (directSessionId) {
-			const sessionIndex = new SessionIndex(settingsInstance.getAgentDir());
-			const locator = { repo: sessionManager?.getCwd() ?? cwd, stateRoot: settingsInstance.getAgentDir() };
-			await sessionIndex.append({
-				type: "host_registered",
-				sessionId: directSessionId,
-				locator,
-				endpointGeneration: 0,
-				pid: process.pid,
-			});
-			postmortem.register("direct-session-index", async () => {
-				await sessionIndex.append({
-					type: "host_unregistered",
-					sessionId: directSessionId,
-					locator,
-					endpointGeneration: 0,
-					pid: process.pid,
-				});
-			});
-		}
 
 		// Research-mode (RLM) preset: hard tool-boundary assertion after the registry is assembled.
 		if (deps.rlmPreset?.onSessionCreated) {

--- a/packages/coding-agent/src/sdk/broker/session-index.ts
+++ b/packages/coding-agent/src/sdk/broker/session-index.ts
@@ -544,6 +544,24 @@ export class SessionIndex {
 			});
 		});
 	}
+
+	/** Hold the canonical index lock across an authority-sensitive operation. */
+	async withLocked<T>(callback: () => Promise<T>): Promise<T> {
+		const indexPath = path.resolve(logFor(this.#agentDir));
+		return await SessionIndex.#enqueue(indexPath, async () => {
+			try {
+				await fs.stat(dirFor(this.#agentDir));
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code === "ENOENT") return await callback();
+				throw error;
+			}
+			return await withFileLock(logFor(this.#agentDir), async () => {
+				await this.#replayUnderLock();
+				if (this.#corruptSuffix) throw new Error("Cannot use corrupt session index for artifact reclamation");
+				return await callback();
+			});
+		});
+	}
 	async snapshot(): Promise<void> {
 		const indexPath = path.resolve(logFor(this.#agentDir));
 		await SessionIndex.#enqueue(indexPath, () =>

--- a/packages/coding-agent/test/gc-disk-retention.test.ts
+++ b/packages/coding-agent/test/gc-disk-retention.test.ts
@@ -140,6 +140,18 @@ async function writeHarnessRegistry(fixture: TestRoot, sessionId: string): Promi
 	);
 }
 
+async function registerDirectCliSession(fixture: TestRoot, sessionId: string): Promise<void> {
+	const index = new SessionIndex(fixture.agentDir);
+	await index.append({
+		type: "host_registered",
+		sessionId,
+		locator: { repo: fixture.root, stateRoot: fixture.agentDir },
+		endpointGeneration: 0,
+		pid: process.pid,
+	});
+}
+
+
 /** Sorted `relative-path:size` listing, used to prove a dry run mutated nothing. */
 async function snapshotTree(root: string): Promise<string[]> {
 	const out: string[] = [];
@@ -1425,6 +1437,28 @@ describe("gjc gc --disk (session tool artifacts)", () => {
 			expect(disk.surfaces.artifacts.reclaimed).toBe(0);
 			expect(disk.surfaces.artifacts.kept_bytes).toBe(payloadBytes);
 			expect((await fsp.readdir(directory)).sort()).toEqual(Object.keys(payload).sort());
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+	test("keeps an older directly resumed CLI session's artifacts while idle artifacts still reclaim", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			await writeSession(fixture, "repo-a", "older-resumed-session", { ageDays: 10 });
+			await writeSession(fixture, "repo-a", "idle-session", { ageDays: 10 });
+			await writeSession(fixture, "repo-a", "newest-session", { ageDays: 0 });
+			const liveDirectory = await writeArtifacts(fixture, "repo-a", "older-resumed-session", payload, 10);
+			const idleDirectory = await writeArtifacts(fixture, "repo-a", "idle-session", payload, 10);
+			await registerDirectCliSession(fixture, "older-resumed-session");
+
+			const disk = requireDisk(await runDisk(fixture, ["--disk", "--prune", "--json"]));
+
+			expect(reasonById(disk, "artifacts").get("older-resumed-session/2.bash.log")).toBe(
+				"keep:referenced_by_live_surface",
+			);
+			expect((await fsp.readdir(liveDirectory)).sort()).toEqual(Object.keys(payload).sort());
+			expect(disk.surfaces.artifacts.reclaimed_bytes).toBe(payloadBytes);
+			expect(await fsp.readdir(idleDirectory)).toEqual([]);
 		} finally {
 			await fsp.rm(fixture.root, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/gc-disk-retention.test.ts
+++ b/packages/coding-agent/test/gc-disk-retention.test.ts
@@ -9,6 +9,7 @@ import {
 	GC_DISK_POLICY_DEFAULTS,
 	type GcDiskPolicy,
 	type GcDiskReport,
+	type GcDiskSurface,
 	type GcPruneOutcome,
 	type GcRecord,
 	type GcReport,
@@ -97,6 +98,24 @@ async function writeSession(
 	return file;
 }
 
+/** GJC's own tool artifacts for a session: `<id>.<tool>.log` payloads and ID claims. */
+async function writeArtifacts(
+	fixture: TestRoot,
+	project: string,
+	id: string,
+	files: Record<string, string>,
+	ageDays: number,
+): Promise<string> {
+	const directory = path.join(fixture.sessionsRoot, project, id);
+	await fsp.mkdir(directory, { recursive: true });
+	for (const [name, content] of Object.entries(files)) {
+		const file = path.join(directory, name);
+		await Bun.write(file, content);
+		await backdate(file, ageDays);
+	}
+	return directory;
+}
+
 async function writeBlob(fixture: TestRoot, content: string, ageDays: number): Promise<string> {
 	await fsp.mkdir(fixture.blobsDir, { recursive: true, mode: 0o700 });
 	const hash = new Bun.SHA256().update(content).digest("hex");
@@ -161,7 +180,7 @@ function requireDisk(report: GcReport): GcDiskReport {
 	return report.disk;
 }
 
-function reasonById(disk: GcDiskReport, surface: "sessions" | "blobs" | "natives" | "backups"): Map<string, string> {
+function reasonById(disk: GcDiskReport, surface: GcDiskSurface): Map<string, string> {
 	return new Map(disk.surfaces[surface].records.map(record => [record.id, `${record.action}:${record.reason}`]));
 }
 
@@ -1262,6 +1281,245 @@ describe("gjc gc --disk (backups retention)", () => {
 			expect(await fsp.readdir(fixture.backupsDir)).toEqual([]);
 		} finally {
 			spy.mockRestore();
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("gjc gc --disk (session tool artifacts)", () => {
+	const payload = {
+		"1.bash.log": "b".repeat(100),
+		"2.bash.log": "b".repeat(200),
+		"3.edit.log": "e".repeat(50),
+		"4.subagent.log": "s".repeat(70),
+		"5.search.log": "r".repeat(30),
+		"6.tool-output.9f2a.output": "o".repeat(11),
+		".artifact-id-7": "",
+	};
+	const payloadBytes = 100 + 200 + 50 + 70 + 30 + 11;
+
+	test("reports every artifact family with counts and byte totals", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			await writeSession(fixture, "repo-a", "worked-session", { ageDays: 10 });
+			await writeSession(fixture, "repo-a", "newest-session", { ageDays: 0 });
+			await writeArtifacts(fixture, "repo-a", "worked-session", payload, 10);
+
+			const before = await snapshotTree(fixture.root);
+			const disk = requireDisk(await runDisk(fixture, ["--disk", "--json"]));
+			expect(await snapshotTree(fixture.root)).toEqual(before);
+
+			// Families are derived from the filename shape, so a tool nobody
+			// hardcoded here (`*.output`) is still attributed.
+			expect(disk.surfaces.artifacts.families).toEqual([
+				{ family: "*.bash.log", count: 2, bytes: 300 },
+				{ family: "*.subagent.log", count: 1, bytes: 70 },
+				{ family: "*.edit.log", count: 1, bytes: 50 },
+				{ family: "*.search.log", count: 1, bytes: 30 },
+				{ family: "*.output", count: 1, bytes: 11 },
+				{ family: ".artifact-id-*", count: 1, bytes: 0 },
+			]);
+			expect(disk.surfaces.artifacts.scanned).toBe(7);
+			expect(disk.surfaces.artifacts.scanned_bytes).toBe(payloadBytes);
+			expect(disk.surfaces.artifacts.reclaimable).toBe(7);
+			expect(disk.surfaces.artifacts.reclaimable_bytes).toBe(payloadBytes);
+
+			// The sessions surface still keeps this session, which is why nothing
+			// used to reclaim these bytes.
+			expect(reasonById(disk, "sessions").get("worked-session")).toBe("keep:newer_than_max_age(30d)");
+
+			const text = await runGjcGcCommand(["--disk"], fixture.root, fixture.env, [], policy());
+			expect(text.stdout).toContain("Session tool artifacts");
+			expect(text.stdout).toContain("family *.bash.log count=2 (300 B)");
+			expect(text.stdout).toContain("family .artifact-id-* count=1 (0 B)");
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("--prune removes artifacts and reports what it removed", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			const transcript = await writeSession(fixture, "repo-a", "worked-session", { ageDays: 10 });
+			await writeSession(fixture, "repo-a", "newest-session", { ageDays: 0 });
+			const directory = await writeArtifacts(fixture, "repo-a", "worked-session", payload, 10);
+
+			const dry = requireDisk(await runDisk(fixture, ["--disk", "--json"]));
+			const disk = requireDisk(await runDisk(fixture, ["--disk", "--prune", "--json"]));
+
+			expect(disk.surfaces.artifacts.reclaimed).toBe(dry.surfaces.artifacts.reclaimable);
+			expect(disk.surfaces.artifacts.reclaimed_bytes).toBe(dry.surfaces.artifacts.reclaimable_bytes);
+			expect(disk.surfaces.artifacts.reclaimed_bytes).toBe(payloadBytes);
+			expect(disk.surfaces.artifacts.failed).toBe(0);
+			expect(reasonById(disk, "artifacts").get("worked-session/2.bash.log")).toBe(
+				"reclaimed:unreferenced_by_any_live_session",
+			);
+			expect(reasonById(disk, "artifacts").get("worked-session/.artifact-id-7")).toBe(
+				"reclaimed:unreferenced_by_any_live_session",
+			);
+			expect(disk.totals.reclaimed_bytes).toBeGreaterThanOrEqual(payloadBytes);
+
+			expect(await fsp.readdir(directory)).toEqual([]);
+			// The transcript itself is user-visible history and is not artifact bytes.
+			expect(await Bun.file(transcript).exists()).toBe(true);
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("--prune skips and reports an entry it cannot verify as an artifact file", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			await writeSession(fixture, "repo-a", "worked-session", { ageDays: 10 });
+			await writeSession(fixture, "repo-a", "newest-session", { ageDays: 0 });
+			const directory = await writeArtifacts(fixture, "repo-a", "worked-session", payload, 10);
+
+			// A symlink out of the managed scope is the exact way a cleanup could
+			// turn into data loss, and a subdirectory is state the walk did not write.
+			const outside = path.join(fixture.root, "outside");
+			await fsp.mkdir(outside, { recursive: true });
+			const userData = path.join(outside, "user-data.txt");
+			await Bun.write(userData, "not gc's to delete");
+			await fsp.symlink(userData, path.join(directory, "8.bash.log"));
+			await fsp.mkdir(path.join(directory, "nested"), { recursive: true });
+			await Bun.write(path.join(directory, "nested", "inner.bin"), "keep me");
+
+			const disk = requireDisk(await runDisk(fixture, ["--disk", "--prune", "--json"]));
+			const reasons = reasonById(disk, "artifacts");
+
+			expect(reasons.get("worked-session/8.bash.log")).toBe("keep:unverified_entry: symlink");
+			expect(reasons.get("worked-session/nested")).toBe("keep:unverified_entry: not_a_regular_file");
+			for (const name of ["8.bash.log", "nested"]) {
+				const record = disk.surfaces.artifacts.records.find(entry => entry.id === `worked-session/${name}`);
+				expect(record?.withheld).toBe(true);
+				expect(record?.bytes).toBe(0);
+			}
+
+			// Skipped, not followed and not removed.
+			expect(await Bun.file(userData).exists()).toBe(true);
+			expect((await fsp.lstat(path.join(directory, "8.bash.log"))).isSymbolicLink()).toBe(true);
+			expect(await Bun.file(path.join(directory, "nested", "inner.bin")).exists()).toBe(true);
+			// A skipped entry never suppresses the verifiable ones.
+			expect(disk.surfaces.artifacts.reclaimed_bytes).toBe(payloadBytes);
+			for (const record of disk.surfaces.artifacts.records) {
+				expect(record.path.startsWith(`${fixture.sessionsRoot}${path.sep}`)).toBe(true);
+			}
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("never removes artifacts of a session a live surface still references", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			await writeSession(fixture, "repo-a", "leased-session", { ageDays: 10 });
+			await writeSession(fixture, "repo-a", "newest-session", { ageDays: 0 });
+			const directory = await writeArtifacts(fixture, "repo-a", "leased-session", payload, 10);
+			await writeHarnessRegistry(fixture, "leased-session");
+
+			const disk = requireDisk(await runDisk(fixture, ["--disk", "--prune", "--json"]));
+
+			expect(reasonById(disk, "artifacts").get("leased-session/2.bash.log")).toBe(
+				"keep:referenced_by_live_surface",
+			);
+			expect(disk.surfaces.artifacts.reclaimed).toBe(0);
+			expect(disk.surfaces.artifacts.kept_bytes).toBe(payloadBytes);
+			expect((await fsp.readdir(directory)).sort()).toEqual(Object.keys(payload).sort());
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("keeps artifacts a session may still be writing, and its resume target", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			await writeSession(fixture, "repo-a", "worked-session", { ageDays: 10 });
+			await writeSession(fixture, "repo-a", "newest-session", { ageDays: 0 });
+			// Freshly written: an open log of a session gc cannot prove is idle.
+			await writeArtifacts(fixture, "repo-a", "worked-session", { "9.bash.log": "still writing" }, 0);
+			await writeArtifacts(fixture, "repo-a", "newest-session", { "1.bash.log": "resume target" }, 10);
+
+			const disk = requireDisk(await runDisk(fixture, ["--disk", "--prune", "--json"]));
+			const reasons = reasonById(disk, "artifacts");
+
+			expect(reasons.get("worked-session/9.bash.log")).toBe("keep:within_write_grace_window");
+			expect(reasons.get("newest-session/1.bash.log")).toBe("keep:most_recent_resumable_session");
+			expect(disk.surfaces.artifacts.reclaimed).toBe(0);
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("reclaims nothing and names the reason when the live-surface scan is incomplete", async () => {
+		const fixture = await makeTestRoot();
+		const localRoots = path.join(fixture.env.TMPDIR!, "gjc-local");
+		try {
+			await writeSession(fixture, "repo-a", "worked-session", { ageDays: 10 });
+			await writeSession(fixture, "repo-a", "newest-session", { ageDays: 0 });
+			const directory = await writeArtifacts(fixture, "repo-a", "worked-session", payload, 10);
+			// An unreadable `local://` root parent means gc cannot enumerate every
+			// live session, so it may not prove any session is idle.
+			await fsp.mkdir(localRoots, { recursive: true });
+			await fsp.chmod(localRoots, 0o000);
+
+			const disk = requireDisk(await runDisk(fixture, ["--disk", "--prune", "--json"]));
+			await fsp.chmod(localRoots, 0o700);
+
+			expect(reasonById(disk, "artifacts").get("worked-session/2.bash.log")).toBe(
+				"keep:reference_scan_incomplete: local_root_parent_unreadable",
+			);
+			expect(disk.surfaces.artifacts.declined).toEqual({
+				reason: "reference_scan_incomplete: local_root_parent_unreadable",
+				withheld: 7,
+				withheld_bytes: payloadBytes,
+			});
+			expect(disk.surfaces.artifacts.reclaimed).toBe(0);
+			expect((await fsp.readdir(directory)).sort()).toEqual(Object.keys(payload).sort());
+		} finally {
+			await fsp.chmod(localRoots, 0o700).catch(() => {});
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
+	test("leaves the sessions, blobs, natives and backups surfaces reporting as before", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			await writeSession(fixture, "repo-a", "worked-session", { ageDays: 10 });
+			await writeSession(fixture, "repo-a", "newest-session", { ageDays: 0 });
+			await writeArtifacts(fixture, "repo-a", "worked-session", payload, 10);
+			await writeBlob(fixture, "unreferenced blob payload", 5);
+			await writeNativesVersion(fixture, "0.0.1");
+
+			const disk = requireDisk(await runDisk(fixture, ["--disk", "--json"], { natives_keep_versions: 0 }));
+
+			// Only the artifacts surface carries a family rollup.
+			for (const surface of ["sessions", "blobs", "natives", "backups"] as const) {
+				expect(disk.surfaces[surface].families).toBeUndefined();
+			}
+			// Session bytes still include the artifact tree they would take with them.
+			const session = disk.surfaces.sessions.records.find(record => record.id === "worked-session");
+			expect(session?.bytes).toBeGreaterThan(payloadBytes);
+			// Totals stay the four legacy surfaces, so artifact bytes are not counted twice.
+			expect(disk.totals.scanned_bytes).toBe(
+				disk.surfaces.sessions.scanned_bytes +
+					disk.surfaces.blobs.scanned_bytes +
+					disk.surfaces.natives.scanned_bytes +
+					disk.surfaces.backups.scanned_bytes,
+			);
+			expect(disk.totals.kept_bytes).toBe(
+				disk.surfaces.sessions.kept_bytes +
+					disk.surfaces.blobs.kept_bytes +
+					disk.surfaces.natives.kept_bytes +
+					disk.surfaces.backups.kept_bytes,
+			);
+			expect(disk.totals.reclaimable_bytes).toBe(
+				disk.surfaces.sessions.reclaimable_bytes +
+					disk.surfaces.blobs.reclaimable_bytes +
+					disk.surfaces.artifacts.reclaimable_bytes +
+					disk.surfaces.natives.reclaimable_bytes +
+					disk.surfaces.backups.reclaimable_bytes,
+			);
+		} finally {
 			await fsp.rm(fixture.root, { recursive: true, force: true });
 		}
 	});

--- a/packages/coding-agent/test/gc-disk-retention.test.ts
+++ b/packages/coding-agent/test/gc-disk-retention.test.ts
@@ -151,7 +151,6 @@ async function registerDirectCliSession(fixture: TestRoot, sessionId: string): P
 	});
 }
 
-
 /** Sorted `relative-path:size` listing, used to prove a dry run mutated nothing. */
 async function snapshotTree(root: string): Promise<string[]> {
 	const out: string[] = [];
@@ -1431,9 +1430,7 @@ describe("gjc gc --disk (session tool artifacts)", () => {
 
 			const disk = requireDisk(await runDisk(fixture, ["--disk", "--prune", "--json"]));
 
-			expect(reasonById(disk, "artifacts").get("leased-session/2.bash.log")).toBe(
-				"keep:referenced_by_live_surface",
-			);
+			expect(reasonById(disk, "artifacts").get("leased-session/2.bash.log")).toBe("keep:referenced_by_live_surface");
 			expect(disk.surfaces.artifacts.reclaimed).toBe(0);
 			expect(disk.surfaces.artifacts.kept_bytes).toBe(payloadBytes);
 			expect((await fsp.readdir(directory)).sort()).toEqual(Object.keys(payload).sort());


### PR DESCRIPTION
Addresses the reclamation half of #3959.

A managed session scope grew past the native tree-snapshot budget and made `gjc` unlaunchable in that directory. None of that growth was user data — it was GJC's own artifacts:

```
1,427  .artifact-id-*
  699  *.bash.log
  402  *.edit.log
  396  *.subagent.log
  314  *.search.log
```

`gc --disk` describes itself as reporting on "sessions, blobs, natives, backups". The families that actually filled the scope were invisible to the tool built to reclaim it, so the operator had no way to act.

## The change

- `--disk` reports each artifact family with count and bytes, alongside the existing categories, which keep their current shape.
- `--prune` reclaims them under the fail-closed rule this repo already settled in #4084: **never begin a removal the walk could not verify.**

Two properties that matter more than the reporting:

- **A symlink is never followed and never removed.** Following one is exactly how a scope cleanup becomes deletion outside the scope.
- **An entry referenced by a live surface is reported as unverified and left alone**, using the existing notion of liveness rather than a second one invented here.

Reporting is the primary fix. The original report's frustration was not that cleanup was unavailable — it was that the diagnostic named a healthy binding file while something else consumed the budget.

## Evidence

|source|suite|
|---|---|
|with the fix|**44 pass, 0 fail** (291 `expect()` calls)|
|both sources reverted to `origin/dev`|**37 pass, 7 fail**|

Diff is three files: the command, the runtime it delegates to, and the existing retention test.

## Known and not fixed

`ManagedSessionDescendantStore` and the snapshot budget are untouched — that is the other half of the issue. A scope that is *already* past the budget still needs this prune to run before `gjc` will launch there, so this makes the situation recoverable rather than preventing it. Preventing it means not snapshotting the whole tree to publish one small binding, which is a design change and belongs on its own.

The family list is derived from one operator's directory. If a tool starts writing a log under a name nobody enumerated, it will be invisible again — worth checking whether the enumeration can be structural rather than name-driven.
