### PR TITLE
fix(edit): invalidate same-size streamed previews

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Streamed edit preview coalescing now keys on the complete partial-JSON payload rather than its length, so same-size in-place argument replacements recompute and render while repeated payloads remain cached.
+
 ## [0.12.21] - 2026-08-09
 
 ### Fixed

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -83,9 +83,10 @@ function argsCanBeSharedWithRenderer(toolName: string, tool: AgentTool | undefin
 	return !tool?.renderCall && !tool?.renderResult && READONLY_ARG_RENDERER_TOOLS.has(toolName);
 }
 
-function partialJsonLength(args: unknown): number {
-	const value = args && typeof args === "object" ? (args as { __partialJson?: unknown }).__partialJson : undefined;
-	return typeof value === "string" ? value.length : -1;
+function previewPayloadKey(args: unknown): string | undefined {
+	const partialJson =
+		args && typeof args === "object" ? (args as { __partialJson?: unknown }).__partialJson : undefined;
+	return typeof partialJson === "string" ? `${partialJson.length}:${partialJson}` : undefined;
 }
 
 /**
@@ -236,6 +237,7 @@ export class ToolExecutionComponent extends Container {
 	#editDiffLastArgsKey?: string;
 	#argsIdentityVersion = 0;
 	#lastArgsReference: any;
+
 	#shareArgsWithRenderer = false;
 	// Cached converted images for Kitty protocol (which requires PNG), keyed by index and source.
 	#convertedImages: Map<number, { data: string; mimeType: string; source: string }> = new Map();
@@ -314,6 +316,7 @@ export class ToolExecutionComponent extends Container {
 	updateArgs(args: any, _toolCallId?: string): void {
 		const argsChanged = !Bun.deepEquals(this.#args, args);
 		if (!argsChanged && !this.#editMode) return;
+
 		if (args !== this.#lastArgsReference) {
 			this.#lastArgsReference = args;
 			this.#argsIdentityVersion += 1;
@@ -354,11 +357,12 @@ export class ToolExecutionComponent extends Container {
 			effectiveArgs = args;
 		}
 
-		// Coalesce duplicate computes without serializing multi-KB streamed args every delta.
+		// The streamed partial JSON is the exact payload snapshot. Its length alone
+		// cannot distinguish same-size replacements. Completed calls lack that
+		// snapshot, so retain identity invalidation for their distinct arg objects.
 		const argsKey = [
 			this.#toolName,
-			this.#argsIdentityVersion,
-			partialJsonLength(args),
+			previewPayloadKey(args) ?? `identity:${this.#argsIdentityVersion}`,
 			this.#argsComplete ? 1 : 0,
 		].join(":");
 		if (argsKey === this.#editDiffLastArgsKey) return;

--- a/packages/coding-agent/test/g004-streamed-tool-args-qa.test.ts
+++ b/packages/coding-agent/test/g004-streamed-tool-args-qa.test.ts
@@ -262,9 +262,10 @@ describe("G004 streamed tool args QA", () => {
 			pending.push({ resolve: deferred.resolve });
 			return deferred.promise;
 		};
+		const args = makeArgs("edit", 1, true);
 		const component = new ToolExecutionComponent(
 			"edit",
-			makeArgs("edit", 1, true),
+			args,
 			{},
 			{ name: "edit", label: "Edit", mode: "hashline" } as any,
 			ui,
@@ -277,15 +278,46 @@ describe("G004 streamed tool args QA", () => {
 			throw new Error(`Preview did not render ${expected}`);
 		};
 		try {
+			component.setExpanded(true);
 			expect(pending).toHaveLength(1);
 			pending[0].resolve([{ path: "preview-one.txt", diff: "+preview-one" }]);
 			await settleRenderedPreview("preview-one");
 
-			component.updateArgs(makeArgs("edit", 2, true));
+			const changedArgs = makeArgs("edit", 2, true);
+			expect(originalJsonStringify(changedArgs)).toHaveLength(originalJsonStringify(args).length);
+			Object.assign(args, changedArgs);
+			component.updateArgs(args);
 			expect(pending).toHaveLength(2);
 			pending[1].resolve([{ path: "preview-two.txt", diff: "+preview-two" }]);
 			await settleRenderedPreview("preview-two");
 			expect(rendered(component)).not.toContain("preview-one");
+		} finally {
+			strategy.computeDiffPreview = originalCompute;
+			component.dispose();
+		}
+	});
+
+	it("COALESCE-SKIP retains a preview for an unchanged streamed payload", async () => {
+		const editModule = await import("../src/edit/index");
+		const strategy = (editModule.EDIT_MODE_STRATEGIES as any).hashline;
+		const originalCompute = strategy.computeDiffPreview;
+		const pending: Array<{ resolve: (value: unknown) => void }> = [];
+		strategy.computeDiffPreview = () => {
+			const deferred = Promise.withResolvers<unknown>();
+			pending.push({ resolve: deferred.resolve });
+			return deferred.promise;
+		};
+		const args = makeArgs("edit", 1, true);
+		const component = new ToolExecutionComponent(
+			"edit",
+			args,
+			{},
+			{ name: "edit", label: "Edit", mode: "hashline" } as any,
+			ui,
+		);
+		try {
+			component.updateArgs({ ...args });
+			expect(pending).toHaveLength(1);
 		} finally {
 			strategy.computeDiffPreview = originalCompute;
 			component.dispose();


### PR DESCRIPTION
Fixes #4114

Streamed edit preview coalescing now uses the complete partial-JSON payload rather than only its length. Same-size in-place payload replacements recompute; identical streamed payloads remain cached.

Validated:
- G004 streamed tool args QA
- edit streaming, renderer, and viewport suites (103 tests)
- `bun --cwd=packages/coding-agent run check` and types