### PR TITLE
fix(eval): synchronize Python lifecycle fixtures

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -37,6 +37,7 @@
 - New `modelProfile.proxyProvider` and `modelProfile.proxyMode` settings route built-in model-preset selectors through an authenticated OpenAI-compatible proxy (e.g. `xai/grok-4.3` → `litellm/xai/grok-4.3`). `fallback` preserves directly authenticated providers by default; `always` forces every proxy-routable built-in selector through the configured gateway. Routing fails closed for unconfigured or unauthenticated proxies and missing or ambiguous proxy models (#4123).
 - SDK-only session hosts now publish their session ID and register their endpoint lifecycle with the broker, matching its identity and staleness fences. This restores broker/coordinator resolution for durable workflow-gate controls (`workflow.gates.list` and `workflow.gate_answer`) without relying on tmux pane input; broker unavailability leaves non-lifecycle local hosts usable and retries publication later.
 
+- Python eval now settles managed-runtime provisioning before cancellation, retires cancelled initialization without sharing it with successors, and retains late kernels whose shutdown is unconfirmed for postmortem retry.
 ## [0.12.21] - 2026-08-09
 
 ### Fixed

--- a/packages/coding-agent/src/config/file-lock.ts
+++ b/packages/coding-agent/src/config/file-lock.ts
@@ -312,7 +312,10 @@ async function acquireLock(filePath: string, options: FileLockOptions = {}): Pro
 	for (let attempt = 0; attempt < opts.retries; attempt++) {
 		if (opts.signal?.aborted) throw opts.signal.reason ?? new Error("File lock acquisition aborted");
 		const owner = await tryAcquireLock(lockPath, opts.ownerHostId);
-		if (owner) return () => releaseLock(lockPath, owner);
+		if (owner) {
+			opts.onAcquired?.();
+			return () => releaseLock(lockPath, owner);
+		}
 		const stale = await staleLockSnapshot(lockPath, opts.staleMs, opts.ownerHostId, contentionStartTimes);
 		if (await removeStaleLockForAcquire(lockPath, stale)) continue;
 		if (!opts.signal) {
@@ -344,7 +347,6 @@ export async function withFileLock<T>(
 	options: FileLockOptions = {},
 ): Promise<T> {
 	const release = await acquireLock(filePath, options);
-	options.onAcquired?.();
 	let result: T;
 	try {
 		result = await fn();

--- a/packages/coding-agent/src/config/file-lock.ts
+++ b/packages/coding-agent/src/config/file-lock.ts
@@ -8,11 +8,12 @@ export interface FileLockOptions {
 	staleMs?: number;
 	retries?: number;
 	retryDelayMs?: number;
+	signal?: AbortSignal;
 	/** Stable host identity required to safely reclaim locks on a shared volume. */
 	ownerHostId?: string;
 }
 
-const DEFAULT_OPTIONS: Required<Omit<FileLockOptions, "ownerHostId">> = {
+const DEFAULT_OPTIONS: Required<Omit<FileLockOptions, "ownerHostId" | "signal">> = {
 	staleMs: 10_000,
 	retries: 50,
 	retryDelayMs: 100,
@@ -308,12 +309,24 @@ async function acquireLock(filePath: string, options: FileLockOptions = {}): Pro
 	const lockPath = getLockPath(filePath);
 	const contentionStartTimes = new Map<string, string | null>();
 	for (let attempt = 0; attempt < opts.retries; attempt++) {
+		if (opts.signal?.aborted) throw opts.signal.reason ?? new Error("File lock acquisition aborted");
 		const owner = await tryAcquireLock(lockPath, opts.ownerHostId);
 		if (owner) return () => releaseLock(lockPath, owner);
-
 		const stale = await staleLockSnapshot(lockPath, opts.staleMs, opts.ownerHostId, contentionStartTimes);
 		if (await removeStaleLockForAcquire(lockPath, stale)) continue;
-		await Bun.sleep(opts.retryDelayMs);
+		if (!opts.signal) {
+			await Bun.sleep(opts.retryDelayMs);
+			continue;
+		}
+		const { promise, resolve, reject } = Promise.withResolvers<void>();
+		const onAbort = (): void => reject(opts.signal?.reason ?? new Error("File lock acquisition aborted"));
+		opts.signal.addEventListener("abort", onAbort, { once: true });
+		void Bun.sleep(opts.retryDelayMs).then(resolve);
+		try {
+			await promise;
+		} finally {
+			opts.signal.removeEventListener("abort", onAbort);
+		}
 	}
 	throw new Error(`Failed to acquire lock for ${filePath} after ${opts.retries} attempts`);
 }

--- a/packages/coding-agent/src/config/file-lock.ts
+++ b/packages/coding-agent/src/config/file-lock.ts
@@ -9,11 +9,12 @@ export interface FileLockOptions {
 	retries?: number;
 	retryDelayMs?: number;
 	signal?: AbortSignal;
+	onAcquired?: () => void;
 	/** Stable host identity required to safely reclaim locks on a shared volume. */
 	ownerHostId?: string;
 }
 
-const DEFAULT_OPTIONS: Required<Omit<FileLockOptions, "ownerHostId" | "signal">> = {
+const DEFAULT_OPTIONS: Required<Omit<FileLockOptions, "ownerHostId" | "signal" | "onAcquired">> = {
 	staleMs: 10_000,
 	retries: 50,
 	retryDelayMs: 100,
@@ -343,6 +344,7 @@ export async function withFileLock<T>(
 	options: FileLockOptions = {},
 ): Promise<T> {
 	const release = await acquireLock(filePath, options);
+	options.onAcquired?.();
 	let result: T;
 	try {
 		result = await fn();

--- a/packages/coding-agent/src/config/file-lock.ts
+++ b/packages/coding-agent/src/config/file-lock.ts
@@ -260,13 +260,18 @@ async function removeStaleLockForAcquire(lockPath: string, snapshot: LockStaleSn
 	}
 }
 
-async function tryAcquireLock(lockPath: string, ownerHostId?: string): Promise<LockInfo | null> {
+async function tryAcquireLock(
+	lockPath: string,
+	ownerHostId?: string,
+	onAcquired?: () => void,
+): Promise<LockInfo | null> {
 	await fs.mkdir(path.dirname(lockPath), { recursive: true });
 	const afterParentMkdir = FileLockTestHooks.afterParentMkdir;
 	if (afterParentMkdir) await afterParentMkdir(lockPath);
 	if (ownerHostId === undefined) {
 		try {
 			await fs.mkdir(lockPath);
+			onAcquired?.();
 			return await writeLockInfo(lockPath, lockInfo());
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code === "EEXIST") return null;
@@ -281,6 +286,7 @@ async function tryAcquireLock(lockPath: string, ownerHostId?: string): Promise<L
 		await writeLockInfo(pendingPath, owner);
 		try {
 			await fs.rename(pendingPath, lockPath);
+			onAcquired?.();
 			return owner;
 		} catch (error) {
 			const code = (error as NodeJS.ErrnoException).code;
@@ -311,11 +317,8 @@ async function acquireLock(filePath: string, options: FileLockOptions = {}): Pro
 	const contentionStartTimes = new Map<string, string | null>();
 	for (let attempt = 0; attempt < opts.retries; attempt++) {
 		if (opts.signal?.aborted) throw opts.signal.reason ?? new Error("File lock acquisition aborted");
-		const owner = await tryAcquireLock(lockPath, opts.ownerHostId);
-		if (owner) {
-			opts.onAcquired?.();
-			return () => releaseLock(lockPath, owner);
-		}
+		const owner = await tryAcquireLock(lockPath, opts.ownerHostId, opts.onAcquired);
+		if (owner) return () => releaseLock(lockPath, owner);
 		const stale = await staleLockSnapshot(lockPath, opts.staleMs, opts.ownerHostId, contentionStartTimes);
 		if (await removeStaleLockForAcquire(lockPath, stale)) continue;
 		if (!opts.signal) {

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -361,6 +361,7 @@ async function acquireSession(sessionId: string, cwd: string, options: PythonExe
 		}),
 	};
 	sessions.set(sessionId, initializing);
+	ensurePythonResourceCleanup();
 	let cancellationTimer: NodeJS.Timeout | undefined;
 	const retireCancelledInitialization = (timedOut: boolean): void => {
 		if (initializing.cancelled) return;

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -744,11 +744,20 @@ export async function executePythonWithKernel(
 export async function executePython(code: string, options?: PythonExecutorOptions): Promise<PythonResult> {
 	const cwd = options?.cwd ?? getProjectDir();
 	const deadlineMs = getExecutionDeadlineMs(options);
+	const deadlineController =
+		deadlineMs !== undefined && options?.signal === undefined ? new AbortController() : undefined;
+	const signal = deadlineController ?? options?.signal;
+	const remainingMs = getRemainingTimeoutMs(deadlineMs);
+	const deadlineTimer =
+		deadlineController && remainingMs !== undefined
+			? setTimeout(() => deadlineController.abort(new PythonExecutionCancelledError(true)), Math.max(0, remainingMs))
+			: undefined;
+	deadlineTimer?.unref();
 	const executionOptions: PythonExecutorOptions = {
 		...(options ?? {}),
+		signal,
 		deadlineMs,
 	};
-
 	try {
 		requireRemainingTimeoutMs(deadlineMs);
 		if (executionOptions.signal?.aborted) {
@@ -769,5 +778,7 @@ export async function executePython(code: string, options?: PythonExecutorOption
 			return createCancelledPythonResult(isTimedOutCancellation(err, executionOptions.signal));
 		}
 		throw err;
+	} finally {
+		if (deadlineTimer) clearTimeout(deadlineTimer);
 	}
 }

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -746,7 +746,7 @@ export async function executePython(code: string, options?: PythonExecutorOption
 	const deadlineMs = getExecutionDeadlineMs(options);
 	const deadlineController =
 		deadlineMs !== undefined && options?.signal === undefined ? new AbortController() : undefined;
-	const signal = deadlineController ?? options?.signal;
+	const signal = deadlineController?.signal ?? options?.signal;
 	const remainingMs = getRemainingTimeoutMs(deadlineMs);
 	const deadlineTimer =
 		deadlineController && remainingMs !== undefined

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -744,9 +744,17 @@ export async function executePythonWithKernel(
 export async function executePython(code: string, options?: PythonExecutorOptions): Promise<PythonResult> {
 	const cwd = options?.cwd ?? getProjectDir();
 	const deadlineMs = getExecutionDeadlineMs(options);
-	const deadlineController =
-		deadlineMs !== undefined && options?.signal === undefined ? new AbortController() : undefined;
-	const signal = deadlineController?.signal ?? options?.signal;
+	const deadlineController = deadlineMs === undefined ? undefined : new AbortController();
+	const combinedController = deadlineController && options?.signal ? new AbortController() : undefined;
+	const forwardAbort = (): void => combinedController?.abort(options?.signal?.reason);
+	if (combinedController) {
+		if (options?.signal?.aborted) forwardAbort();
+		else options?.signal?.addEventListener("abort", forwardAbort, { once: true });
+	}
+	const forwardDeadlineAbort = (): void => combinedController?.abort(deadlineController?.signal.reason);
+	if (combinedController && deadlineController)
+		deadlineController.signal.addEventListener("abort", forwardDeadlineAbort, { once: true });
+	const signal = combinedController?.signal ?? deadlineController?.signal ?? options?.signal;
 	const remainingMs = getRemainingTimeoutMs(deadlineMs);
 	const deadlineTimer =
 		deadlineController && remainingMs !== undefined
@@ -780,5 +788,9 @@ export async function executePython(code: string, options?: PythonExecutorOption
 		throw err;
 	} finally {
 		if (deadlineTimer) clearTimeout(deadlineTimer);
+		if (combinedController) {
+			options?.signal?.removeEventListener("abort", forwardAbort);
+			deadlineController?.signal.removeEventListener("abort", forwardDeadlineAbort);
+		}
 	}
 }

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -321,9 +321,23 @@ function attachOwner(session: PythonSession, sessionId: string, ownerId: string 
 async function acquireSession(sessionId: string, cwd: string, options: PythonExecutorOptions): Promise<PythonSession> {
 	const existing = sessions.get(sessionId);
 	if (existing) {
-		const session = isInitializingSession(existing)
-			? await waitForPromiseWithCancellation(existing.promise, options)
-			: existing;
+		let session: PythonSession;
+		if (isInitializingSession(existing)) {
+			try {
+				session = await waitForPromiseWithCancellation(existing.promise, options);
+			} catch (error) {
+				const remainingMs = getRemainingTimeoutMs(options.deadlineMs);
+				if (
+					isCancellationError(error) &&
+					!options.signal?.aborted &&
+					(remainingMs === undefined || remainingMs > 0)
+				)
+					return await acquireSession(sessionId, cwd, options);
+				throw error;
+			}
+		} else {
+			session = existing;
+		}
 		attachOwner(session, sessionId, options.kernelOwnerId);
 		ensurePythonResourceCleanup();
 		return session;

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -116,6 +116,7 @@ interface PythonSession {
 interface InitializingPythonSession {
 	sessionId: string;
 	promise: Promise<PythonSession>;
+	cancelled?: PythonExecutionCancelledError;
 }
 
 let pythonResourceCleanupRegistered = false;
@@ -324,6 +325,10 @@ async function acquireSession(sessionId: string, cwd: string, options: PythonExe
 		sessionId,
 		promise: Promise.resolve().then(async () => {
 			const kernel = await startKernel(cwd, options);
+			if (initializing.cancelled) {
+				await kernel.shutdown().catch(() => undefined);
+				throw initializing.cancelled;
+			}
 			const current = sessions.get(sessionId);
 			if (current !== initializing) {
 				await kernel.shutdown().catch(() => undefined);
@@ -354,7 +359,13 @@ async function acquireSession(sessionId: string, cwd: string, options: PythonExe
 		ensurePythonResourceCleanup();
 		return session;
 	} catch (err) {
-		if (sessions.get(sessionId) === initializing) sessions.delete(sessionId);
+		if (sessions.get(sessionId) === initializing) {
+			if (isCancellationError(err)) {
+				initializing.cancelled = new PythonExecutionCancelledError(isTimedOutCancellation(err, options.signal));
+				await initializing.promise.catch(() => undefined);
+			}
+			if (sessions.get(sessionId) === initializing) sessions.delete(sessionId);
+		}
 		throw err;
 	}
 }

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -353,20 +353,47 @@ async function acquireSession(sessionId: string, cwd: string, options: PythonExe
 		}),
 	};
 	sessions.set(sessionId, initializing);
+	let cancellationTimer: NodeJS.Timeout | undefined;
+	const retireCancelledInitialization = (timedOut: boolean): void => {
+		if (initializing.cancelled) return;
+		initializing.cancelled = new PythonExecutionCancelledError(timedOut);
+		if (sessions.get(sessionId) === initializing) sessions.delete(sessionId);
+	};
+	const onAbort = (): void => {
+		options.signal?.removeEventListener("abort", onAbort);
+		retireCancelledInitialization(isTimedOutCancellation(options.signal?.reason, options.signal));
+	};
+	if (options.signal?.aborted) {
+		onAbort();
+	} else if (options.signal) {
+		options.signal.addEventListener("abort", onAbort, { once: true });
+	}
+	const remainingMs = getRemainingTimeoutMs(options.deadlineMs);
+	if (remainingMs !== undefined) {
+		if (remainingMs <= 0) {
+			retireCancelledInitialization(true);
+		} else {
+			cancellationTimer = setTimeout(() => retireCancelledInitialization(true), remainingMs);
+			cancellationTimer.unref();
+		}
+	}
+	void initializing.promise
+		.finally(() => {
+			options.signal?.removeEventListener("abort", onAbort);
+			if (cancellationTimer) clearTimeout(cancellationTimer);
+		})
+		.catch(() => undefined);
 	try {
 		const session = await waitForPromiseWithCancellation(initializing.promise, options);
 		attachOwner(session, sessionId, options.kernelOwnerId);
 		ensurePythonResourceCleanup();
 		return session;
 	} catch (err) {
-		if (sessions.get(sessionId) === initializing) {
-			if (isCancellationError(err)) {
-				initializing.cancelled = new PythonExecutionCancelledError(isTimedOutCancellation(err, options.signal));
-				sessions.delete(sessionId);
-				await initializing.promise.catch(() => undefined);
-			} else {
-				sessions.delete(sessionId);
-			}
+		if (isCancellationError(err)) {
+			retireCancelledInitialization(isTimedOutCancellation(err, options.signal));
+			await initializing.promise.catch(() => undefined);
+		} else if (sessions.get(sessionId) === initializing) {
+			sessions.delete(sessionId);
 		}
 		throw err;
 	}

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -657,10 +657,10 @@ async function executeWithKernel(
 }
 
 async function ensureKernelAvailable(cwd: string, options: PythonExecutorOptions): Promise<void> {
-	const availability = await waitForPromiseWithCancellation(
-		checkPythonKernelAvailability(cwd, options.runtimeOptions),
-		options,
-	);
+	const availability = await checkPythonKernelAvailability(cwd, options.runtimeOptions, {
+		signal: options.signal,
+		deadlineMs: options.deadlineMs,
+	});
 	if (!availability.ok) {
 		throw new Error(availability.reason ?? "Python kernel unavailable");
 	}

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -362,9 +362,11 @@ async function acquireSession(sessionId: string, cwd: string, options: PythonExe
 		if (sessions.get(sessionId) === initializing) {
 			if (isCancellationError(err)) {
 				initializing.cancelled = new PythonExecutionCancelledError(isTimedOutCancellation(err, options.signal));
+				sessions.delete(sessionId);
 				await initializing.promise.catch(() => undefined);
+			} else {
+				sessions.delete(sessionId);
 			}
-			if (sessions.get(sessionId) === initializing) sessions.delete(sessionId);
 		}
 		throw err;
 	}

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -127,6 +127,14 @@ function ensurePythonResourceCleanup(): void {
 	registerResourceOwner("python-kernel-sessions", disposeAllKernelSessions);
 }
 const sessions = new Map<string, PythonSession | InitializingPythonSession>();
+const retiringKernels = new Set<PythonKernel>();
+
+async function shutdownOrRetainKernel(kernel: PythonKernel): Promise<void> {
+	const result = await kernel.shutdown().catch(() => undefined);
+	if (result?.confirmed) return;
+	retiringKernels.add(kernel);
+	logger.warn("Python kernel shutdown not confirmed", { kernelId: kernel.id });
+}
 
 function isInitializingSession(
 	session: PythonSession | InitializingPythonSession,
@@ -326,12 +334,12 @@ async function acquireSession(sessionId: string, cwd: string, options: PythonExe
 		promise: Promise.resolve().then(async () => {
 			const kernel = await startKernel(cwd, options);
 			if (initializing.cancelled) {
-				await kernel.shutdown().catch(() => undefined);
+				await shutdownOrRetainKernel(kernel);
 				throw initializing.cancelled;
 			}
 			const current = sessions.get(sessionId);
 			if (current !== initializing) {
-				await kernel.shutdown().catch(() => undefined);
+				await shutdownOrRetainKernel(kernel);
 				const winner = current
 					? isInitializingSession(current)
 						? await waitForPromiseWithCancellation(current.promise, options)
@@ -469,6 +477,8 @@ async function runQueued<T>(
 
 export async function disposeAllKernelSessions(): Promise<void> {
 	const all = [...sessions.entries()];
+	const retiring = [...retiringKernels];
+	retiringKernels.clear();
 	for (const [id, session] of all) {
 		if (sessions.get(id) === session) sessions.delete(id);
 	}
@@ -489,6 +499,16 @@ export async function disposeAllKernelSessions(): Promise<void> {
 		const reason = result.status === "rejected" ? result.reason : "not confirmed";
 		logger.warn("Python kernel shutdown not confirmed", { sessionId: id, reason });
 		if (!sessions.has(id)) sessions.set(id, session);
+	}
+	const retiringResults = await Promise.allSettled(retiring.map(kernel => kernel.shutdown()));
+	for (let i = 0; i < retiring.length; i += 1) {
+		const result = retiringResults[i];
+		if (result.status === "fulfilled" && result.value.confirmed) continue;
+		retiringKernels.add(retiring[i]);
+		logger.warn("Python kernel shutdown not confirmed", {
+			kernelId: retiring[i].id,
+			reason: result.status === "rejected" ? result.reason : "not confirmed",
+		});
 	}
 }
 

--- a/packages/coding-agent/src/eval/py/kernel.ts
+++ b/packages/coding-agent/src/eval/py/kernel.ts
@@ -10,7 +10,6 @@
  */
 import { $env, isBunTestRuntime, logger, Snowflake } from "@gajae-code/utils";
 import type { Subprocess } from "bun";
-import { $ } from "bun";
 import { Settings } from "../../config/settings";
 import { type KernelDisplayOutput, renderKernelDisplay } from "./display";
 import { resolvePythonIpcTrace, resolvePythonSkipCheck } from "./env";
@@ -108,6 +107,46 @@ function throwIfAborted(signal: AbortSignal | undefined, fallbackReason: string)
 	throw createAbortError("AbortError", typeof reason === "string" ? reason : fallbackReason);
 }
 
+async function waitForLifecycle<T>(
+	value: Promise<T>,
+	lifecycle: PythonRuntimeLifecycleOptions | undefined,
+	message: string,
+): Promise<T> {
+	const { promise, resolve, reject } = Promise.withResolvers<T>();
+	const cleanups: Array<() => void> = [];
+	const finish = (callback: () => void): void => {
+		while (cleanups.length > 0) cleanups.pop()?.();
+		callback();
+	};
+	if (lifecycle?.signal?.aborted) {
+		return Promise.reject(lifecycle.signal.reason ?? createAbortError("AbortError", message));
+	}
+	if (lifecycle?.signal) {
+		const onAbort = (): void =>
+			finish(() => reject(lifecycle.signal?.reason ?? createAbortError("AbortError", message)));
+		lifecycle.signal.addEventListener("abort", onAbort, { once: true });
+		cleanups.push(() => lifecycle.signal?.removeEventListener("abort", onAbort));
+	}
+	const remainingMs = getRemainingTimeMs(lifecycle?.deadlineMs);
+	if (remainingMs !== undefined) {
+		if (remainingMs <= 0) {
+			finish(() => reject(createAbortError("TimeoutError", `${message} timed out`)));
+		} else {
+			const timer = setTimeout(
+				() => finish(() => reject(createAbortError("TimeoutError", `${message} timed out`))),
+				remainingMs,
+			);
+			timer.unref();
+			cleanups.push(() => clearTimeout(timer));
+		}
+	}
+	void value.then(
+		result => finish(() => resolve(result)),
+		error => finish(() => reject(error)),
+	);
+	return await promise;
+}
+
 export async function checkPythonKernelAvailability(
 	cwd: string,
 	runtimeOptions?: PythonRuntimeOptions,
@@ -121,22 +160,39 @@ export async function checkPythonKernelAvailability(
 		throw createAbortError("TimeoutError", "Python kernel availability check timed out");
 	}
 	try {
-		const settings = await Settings.init();
+		const settings = await waitForLifecycle(Settings.init(), lifecycle, "Python kernel settings initialization");
 		const { env } = settings.getShellConfig();
 		const baseEnv = filterEnv(env);
 		const runtime = await ensurePythonRuntime(cwd, baseEnv, runtimeOptions, lifecycle);
-		const probe = await $`${runtime.pythonPath} -c "import sys;sys.exit(0)"`
-			.quiet()
-			.nothrow()
-			.cwd(cwd)
-			.env(runtime.env);
-		if (probe.exitCode === 0) {
+		const probeEnv: Record<string, string> = {};
+		for (const [key, value] of Object.entries(runtime.env)) {
+			if (typeof value === "string") probeEnv[key] = value;
+		}
+		const remainingMs = getRemainingTimeMs(lifecycle?.deadlineMs);
+		if (remainingMs !== undefined && remainingMs <= 0) {
+			throw createAbortError("TimeoutError", "Python kernel availability check timed out");
+		}
+		const probe = Bun.spawn([runtime.pythonPath, "-c", "import sys;sys.exit(0)"], {
+			cwd,
+			env: probeEnv,
+			stdout: "ignore",
+			stderr: "ignore",
+			windowsHide: true,
+			signal: lifecycle?.signal,
+			timeout: remainingMs,
+		});
+		const exitCode = await probe.exited;
+		throwIfAborted(lifecycle?.signal, "Python kernel availability check aborted");
+		if (lifecycle?.deadlineMs !== undefined && lifecycle.deadlineMs <= Date.now()) {
+			throw createAbortError("TimeoutError", "Python kernel availability check timed out");
+		}
+		if (exitCode === 0) {
 			return { ok: true, pythonPath: runtime.pythonPath };
 		}
 		return {
 			ok: false,
 			pythonPath: runtime.pythonPath,
-			reason: `Python interpreter at ${runtime.pythonPath} returned exit code ${probe.exitCode}`,
+			reason: `Python interpreter at ${runtime.pythonPath} returned exit code ${exitCode}`,
 		};
 	} catch (err) {
 		throwIfAborted(lifecycle?.signal, "Python kernel availability check aborted");

--- a/packages/coding-agent/src/eval/py/kernel.ts
+++ b/packages/coding-agent/src/eval/py/kernel.ts
@@ -16,7 +16,12 @@ import { type KernelDisplayOutput, renderKernelDisplay } from "./display";
 import { resolvePythonIpcTrace, resolvePythonSkipCheck } from "./env";
 import { PYTHON_PRELUDE } from "./prelude";
 import { ensureRunnerScript } from "./runner-artifact";
-import { ensurePythonRuntime, filterEnv, type PythonRuntimeOptions } from "./runtime";
+import {
+	ensurePythonRuntime,
+	filterEnv,
+	type PythonRuntimeLifecycleOptions,
+	type PythonRuntimeOptions,
+} from "./runtime";
 
 export type { KernelDisplayOutput, PythonStatusEvent } from "./display";
 export { renderKernelDisplay } from "./display";
@@ -106,15 +111,20 @@ function throwIfAborted(signal: AbortSignal | undefined, fallbackReason: string)
 export async function checkPythonKernelAvailability(
 	cwd: string,
 	runtimeOptions?: PythonRuntimeOptions,
+	lifecycle?: PythonRuntimeLifecycleOptions,
 ): Promise<PythonKernelAvailability> {
 	if (isBunTestRuntime() || resolvePythonSkipCheck($env)) {
 		return { ok: true };
+	}
+	throwIfAborted(lifecycle?.signal, "Python kernel availability check aborted");
+	if (lifecycle?.deadlineMs !== undefined && lifecycle.deadlineMs <= Date.now()) {
+		throw createAbortError("TimeoutError", "Python kernel availability check timed out");
 	}
 	try {
 		const settings = await Settings.init();
 		const { env } = settings.getShellConfig();
 		const baseEnv = filterEnv(env);
-		const runtime = await ensurePythonRuntime(cwd, baseEnv, runtimeOptions);
+		const runtime = await ensurePythonRuntime(cwd, baseEnv, runtimeOptions, lifecycle);
 		const probe = await $`${runtime.pythonPath} -c "import sys;sys.exit(0)"`
 			.quiet()
 			.nothrow()
@@ -129,6 +139,10 @@ export async function checkPythonKernelAvailability(
 			reason: `Python interpreter at ${runtime.pythonPath} returned exit code ${probe.exitCode}`,
 		};
 	} catch (err) {
+		throwIfAborted(lifecycle?.signal, "Python kernel availability check aborted");
+		if (lifecycle?.deadlineMs !== undefined && lifecycle.deadlineMs <= Date.now()) {
+			throw createAbortError("TimeoutError", "Python kernel availability check timed out");
+		}
 		return { ok: false, reason: err instanceof Error ? err.message : String(err) };
 	}
 }
@@ -186,6 +200,7 @@ export class PythonKernel {
 			checkPythonKernelAvailability,
 			options.cwd,
 			options.runtimeOptions,
+			{ signal: options.signal, deadlineMs: options.deadlineMs },
 		);
 		if (!availability.ok) {
 			throw new Error(availability.reason ?? "Python kernel unavailable");

--- a/packages/coding-agent/src/eval/py/kernel.ts
+++ b/packages/coding-agent/src/eval/py/kernel.ts
@@ -194,7 +194,10 @@ export class PythonKernel {
 		const settings = await Settings.init();
 		const { env: shellEnv } = settings.getShellConfig();
 		const baseEnv = filterEnv(shellEnv);
-		const runtime = await ensurePythonRuntime(options.cwd, baseEnv, options.runtimeOptions);
+		const runtime = await ensurePythonRuntime(options.cwd, baseEnv, options.runtimeOptions, {
+			signal: options.signal,
+			deadlineMs: options.deadlineMs,
+		});
 		const spawnEnv: Record<string, string> = {};
 		for (const [key, value] of Object.entries(runtime.env)) {
 			if (typeof value === "string") spawnEnv[key] = value;

--- a/packages/coding-agent/src/eval/py/runtime.ts
+++ b/packages/coding-agent/src/eval/py/runtime.ts
@@ -321,7 +321,27 @@ async function runRuntimeCommand(
 	}
 }
 
+const managedVenvProvisioning = new Map<string, Promise<void>>();
+
 async function ensureWorkspaceManagedVenv(
+	cwd: string,
+	baseEnv: Record<string, string | undefined>,
+	seedPackages: readonly string[],
+	lifecycle?: PythonRuntimeLifecycleOptions,
+): Promise<void> {
+	const venvPath = resolveWorkspaceManagedPythonCandidate(cwd).venvPath;
+	const existing = managedVenvProvisioning.get(venvPath);
+	if (existing) return await existing;
+	const provisioning = ensureWorkspaceManagedVenvInner(cwd, baseEnv, seedPackages, lifecycle);
+	managedVenvProvisioning.set(venvPath, provisioning);
+	try {
+		await provisioning;
+	} finally {
+		if (managedVenvProvisioning.get(venvPath) === provisioning) managedVenvProvisioning.delete(venvPath);
+	}
+}
+
+async function ensureWorkspaceManagedVenvInner(
 	cwd: string,
 	baseEnv: Record<string, string | undefined>,
 	seedPackages: readonly string[],

--- a/packages/coding-agent/src/eval/py/runtime.ts
+++ b/packages/coding-agent/src/eval/py/runtime.ts
@@ -18,6 +18,11 @@ export interface PythonRuntimeOptions {
 	seedPackages?: readonly string[];
 }
 
+export interface PythonRuntimeLifecycleOptions {
+	signal?: AbortSignal;
+	deadlineMs?: number;
+}
+
 const DEFAULT_ENV_ALLOWLIST = new Set([
 	"PATH",
 	"HOME",
@@ -195,11 +200,18 @@ export function resolveVenvPath(cwd: string): string | undefined {
 	return undefined;
 }
 
+function createRuntimeCancellationError(timedOut: boolean): Error {
+	const error = new Error(timedOut ? "Python runtime startup timed out" : "Python runtime startup aborted");
+	error.name = timedOut ? "TimeoutError" : "AbortError";
+	return error;
+}
+
 async function runRuntimeCommand(
 	cmd: string[],
 	cwd: string,
 	env: Record<string, string | undefined>,
 	description: string,
+	lifecycle?: PythonRuntimeLifecycleOptions,
 ): Promise<void> {
 	const spawnEnv: Record<string, string> = {};
 	for (const [key, value] of Object.entries(env)) {
@@ -212,14 +224,50 @@ async function runRuntimeCommand(
 		stderr: "pipe",
 		windowsHide: true,
 	});
-	const [stdout, stderr, exitCode] = await Promise.all([
-		new Response(proc.stdout).text(),
-		new Response(proc.stderr).text(),
-		proc.exited,
-	]);
+	const output = Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text(), proc.exited]);
+	const { promise, resolve, reject } = Promise.withResolvers<number>();
+	const cleanups: Array<() => void> = [];
+	const finish = (callback: () => void): void => {
+		while (cleanups.length > 0) cleanups.pop()?.();
+		callback();
+	};
+	const cancel = (timedOut: boolean): void => {
+		try {
+			proc.kill("SIGTERM");
+		} catch {
+			// The process may have exited between the cancellation check and signal.
+		}
+		finish(() => reject(createRuntimeCancellationError(timedOut)));
+	};
+	if (lifecycle?.signal?.aborted) {
+		cancel(false);
+	} else if (lifecycle?.signal) {
+		const onAbort = (): void => cancel(false);
+		lifecycle.signal.addEventListener("abort", onAbort, { once: true });
+		cleanups.push(() => lifecycle.signal?.removeEventListener("abort", onAbort));
+	}
+	const remainingMs = lifecycle?.deadlineMs === undefined ? undefined : lifecycle.deadlineMs - Date.now();
+	if (remainingMs !== undefined) {
+		if (remainingMs <= 0) {
+			cancel(true);
+		} else {
+			const timer = setTimeout(() => cancel(true), remainingMs);
+			timer.unref();
+			cleanups.push(() => clearTimeout(timer));
+		}
+	}
+	proc.exited.then(code => finish(() => resolve(code)));
+	let exitCode: number;
+	try {
+		exitCode = await promise;
+	} catch (error) {
+		void output.catch(() => undefined);
+		throw error;
+	}
+	const [stdout, stderr] = await output;
 	if (exitCode !== 0) {
-		const output = [stdout.trim(), stderr.trim()].filter(Boolean).join("\n");
-		throw new Error(`${description} failed with exit code ${exitCode}${output ? `: ${output}` : ""}`);
+		const text = [stdout.trim(), stderr.trim()].filter(Boolean).join("\n");
+		throw new Error(`${description} failed with exit code ${exitCode}${text ? `: ${text}` : ""}`);
 	}
 }
 
@@ -227,6 +275,7 @@ async function ensureWorkspaceManagedVenv(
 	cwd: string,
 	baseEnv: Record<string, string | undefined>,
 	seedPackages: readonly string[],
+	lifecycle?: PythonRuntimeLifecycleOptions,
 ): Promise<void> {
 	const managed = resolveWorkspaceManagedPythonCandidate(cwd);
 	if (!fs.existsSync(managed.pythonPath)) {
@@ -238,6 +287,7 @@ async function ensureWorkspaceManagedVenv(
 			cwd,
 			baseEnv,
 			"Managed Python venv creation",
+			lifecycle,
 		);
 	}
 	if (seedPackages.length === 0) return;
@@ -257,12 +307,14 @@ async function ensureWorkspaceManagedVenv(
 		cwd,
 		runtimeEnv,
 		"Managed Python pip bootstrap",
+		lifecycle,
 	);
 	await runRuntimeCommand(
 		[managed.pythonPath, "-m", "pip", "install", ...seedPackages],
 		cwd,
 		runtimeEnv,
 		"Managed Python package seed",
+		lifecycle,
 	);
 	await fs.promises.writeFile(
 		markerPath,
@@ -315,6 +367,7 @@ export async function ensurePythonRuntime(
 	cwd: string,
 	baseEnv: Record<string, string | undefined>,
 	options: PythonRuntimeOptions = {},
+	lifecycle?: PythonRuntimeLifecycleOptions,
 ): Promise<PythonRuntime> {
 	if (options.managedWorkspaceVenv) {
 		const env = { ...baseEnv };
@@ -325,7 +378,7 @@ export async function ensurePythonRuntime(
 				return runtimeFromVenv(candidate.venvPath, candidate.pythonPath, candidate.binDir, env);
 			}
 		}
-		await ensureWorkspaceManagedVenv(cwd, baseEnv, options.seedPackages ?? RLM_MANAGED_PYTHON_PACKAGES);
+		await ensureWorkspaceManagedVenv(cwd, baseEnv, options.seedPackages ?? RLM_MANAGED_PYTHON_PACKAGES, lifecycle);
 	}
 	return resolvePythonRuntime(cwd, baseEnv, options);
 }

--- a/packages/coding-agent/src/eval/py/runtime.ts
+++ b/packages/coding-agent/src/eval/py/runtime.ts
@@ -235,6 +235,17 @@ async function runRuntimeCommand(
 		callback();
 	};
 	let cancellation: { timedOut: boolean } | undefined;
+	const waitForProcessTreeExit = async (): Promise<void> => {
+		if (process.platform === "win32") return;
+		while (true) {
+			try {
+				process.kill(-proc.pid, 0);
+				await Bun.sleep(10);
+			} catch {
+				return;
+			}
+		}
+	};
 	const cancel = (timedOut: boolean): void => {
 		if (cancellation) return;
 		cancellation = { timedOut };
@@ -271,9 +282,10 @@ async function runRuntimeCommand(
 			cleanups.push(() => clearTimeout(timer));
 		}
 	}
-	proc.exited.then(code => {
+	void proc.exited.then(async code => {
 		const cancelled = cancellation;
 		if (cancelled) {
+			await waitForProcessTreeExit();
 			finish(() => reject(createRuntimeCancellationError(cancelled.timedOut)));
 			return;
 		}

--- a/packages/coding-agent/src/eval/py/runtime.ts
+++ b/packages/coding-agent/src/eval/py/runtime.ts
@@ -209,6 +209,39 @@ function createRuntimeCancellationError(timedOut: boolean): Error {
 	return error;
 }
 
+async function waitForRuntimeLifecycle<T>(
+	value: Promise<T>,
+	lifecycle: PythonRuntimeLifecycleOptions | undefined,
+): Promise<T> {
+	const { promise, resolve, reject } = Promise.withResolvers<T>();
+	const cleanups: Array<() => void> = [];
+	const finish = (callback: () => void): void => {
+		while (cleanups.length > 0) cleanups.pop()?.();
+		callback();
+	};
+	if (lifecycle?.signal?.aborted) throw lifecycle.signal.reason ?? createRuntimeCancellationError(false);
+	if (lifecycle?.signal) {
+		const onAbort = (): void =>
+			finish(() => reject(lifecycle.signal?.reason ?? createRuntimeCancellationError(false)));
+		lifecycle.signal.addEventListener("abort", onAbort, { once: true });
+		cleanups.push(() => lifecycle.signal?.removeEventListener("abort", onAbort));
+	}
+	const remainingMs = lifecycle?.deadlineMs === undefined ? undefined : lifecycle.deadlineMs - Date.now();
+	if (remainingMs !== undefined) {
+		if (remainingMs <= 0) finish(() => reject(createRuntimeCancellationError(true)));
+		else {
+			const timer = setTimeout(() => finish(() => reject(createRuntimeCancellationError(true))), remainingMs);
+			timer.unref();
+			cleanups.push(() => clearTimeout(timer));
+		}
+	}
+	void value.then(
+		result => finish(() => resolve(result)),
+		error => finish(() => reject(error)),
+	);
+	return await promise;
+}
+
 async function runRuntimeCommand(
 	cmd: string[],
 	cwd: string,
@@ -329,11 +362,17 @@ async function ensureWorkspaceManagedVenv(
 	lifecycle?: PythonRuntimeLifecycleOptions,
 ): Promise<void> {
 	const venvPath = resolveWorkspaceManagedPythonCandidate(cwd).venvPath;
-	return await withFileLock(
+	const provisioning = withFileLock(
 		venvPath,
-		async () => await ensureWorkspaceManagedVenvInner(cwd, baseEnv, seedPackages, lifecycle),
+		async () => {
+			if (lifecycle?.signal?.aborted) throw lifecycle.signal.reason ?? createRuntimeCancellationError(false);
+			if (lifecycle?.deadlineMs !== undefined && lifecycle.deadlineMs <= Date.now())
+				throw createRuntimeCancellationError(true);
+			await ensureWorkspaceManagedVenvInner(cwd, baseEnv, seedPackages, lifecycle);
+		},
 		{ retries: 600 },
 	);
+	return await waitForRuntimeLifecycle(provisioning, lifecycle);
 }
 
 async function ensureWorkspaceManagedVenvInner(

--- a/packages/coding-agent/src/eval/py/runtime.ts
+++ b/packages/coding-agent/src/eval/py/runtime.ts
@@ -235,8 +235,24 @@ async function runRuntimeCommand(
 		callback();
 	};
 	let cancellation: { timedOut: boolean } | undefined;
+	let windowsTermination: Promise<void> | undefined;
+	const terminateWindowsProcessTree = (): void => {
+		if (windowsTermination) return;
+		const taskkill = Bun.spawn(["taskkill", "/pid", String(proc.pid), "/t", "/f"], {
+			stdout: "ignore",
+			stderr: "ignore",
+			windowsHide: true,
+		});
+		windowsTermination = taskkill.exited.then(
+			() => undefined,
+			() => undefined,
+		);
+	};
 	const waitForProcessTreeExit = async (): Promise<void> => {
-		if (process.platform === "win32") return;
+		if (process.platform === "win32") {
+			await windowsTermination;
+			return;
+		}
 		while (true) {
 			try {
 				process.kill(-proc.pid, 0);
@@ -252,7 +268,7 @@ async function runRuntimeCommand(
 		const signalProcessTree = (signal: NodeJS.Signals): void => {
 			try {
 				if (process.platform === "win32") {
-					proc.kill(signal);
+					terminateWindowsProcessTree();
 				} else {
 					process.kill(-proc.pid, signal);
 				}

--- a/packages/coding-agent/src/eval/py/runtime.ts
+++ b/packages/coding-agent/src/eval/py/runtime.ts
@@ -23,6 +23,8 @@ export interface PythonRuntimeLifecycleOptions {
 	deadlineMs?: number;
 }
 
+const RUNTIME_CANCEL_GRACE_MS = 1_000;
+
 const DEFAULT_ENV_ALLOWLIST = new Set([
 	"PATH",
 	"HOME",
@@ -231,13 +233,24 @@ async function runRuntimeCommand(
 		while (cleanups.length > 0) cleanups.pop()?.();
 		callback();
 	};
+	let cancellation: { timedOut: boolean } | undefined;
 	const cancel = (timedOut: boolean): void => {
+		if (cancellation) return;
+		cancellation = { timedOut };
 		try {
 			proc.kill("SIGTERM");
 		} catch {
 			// The process may have exited between the cancellation check and signal.
 		}
-		finish(() => reject(createRuntimeCancellationError(timedOut)));
+		const escalation = setTimeout(() => {
+			try {
+				proc.kill("SIGKILL");
+			} catch {
+				// The process may have exited during the graceful cancellation window.
+			}
+		}, RUNTIME_CANCEL_GRACE_MS);
+		escalation.unref();
+		cleanups.push(() => clearTimeout(escalation));
 	};
 	if (lifecycle?.signal?.aborted) {
 		cancel(false);
@@ -256,7 +269,14 @@ async function runRuntimeCommand(
 			cleanups.push(() => clearTimeout(timer));
 		}
 	}
-	proc.exited.then(code => finish(() => resolve(code)));
+	proc.exited.then(code => {
+		const cancelled = cancellation;
+		if (cancelled) {
+			finish(() => reject(createRuntimeCancellationError(cancelled.timedOut)));
+			return;
+		}
+		finish(() => resolve(code));
+	});
 	let exitCode: number;
 	try {
 		exitCode = await promise;

--- a/packages/coding-agent/src/eval/py/runtime.ts
+++ b/packages/coding-agent/src/eval/py/runtime.ts
@@ -362,6 +362,12 @@ async function ensureWorkspaceManagedVenv(
 	lifecycle?: PythonRuntimeLifecycleOptions,
 ): Promise<void> {
 	const venvPath = resolveWorkspaceManagedPythonCandidate(cwd).venvPath;
+	const lockSignal =
+		lifecycle?.deadlineMs === undefined
+			? lifecycle?.signal
+			: lifecycle.signal
+				? AbortSignal.any([lifecycle.signal, AbortSignal.timeout(Math.max(0, lifecycle.deadlineMs - Date.now()))])
+				: AbortSignal.timeout(Math.max(0, lifecycle.deadlineMs - Date.now()));
 	const provisioning = withFileLock(
 		venvPath,
 		async () => {
@@ -370,7 +376,7 @@ async function ensureWorkspaceManagedVenv(
 				throw createRuntimeCancellationError(true);
 			await ensureWorkspaceManagedVenvInner(cwd, baseEnv, seedPackages, lifecycle);
 		},
-		{ retries: 600 },
+		{ retries: Number.POSITIVE_INFINITY, signal: lockSignal },
 	);
 	return await waitForRuntimeLifecycle(provisioning, lifecycle);
 }

--- a/packages/coding-agent/src/eval/py/runtime.ts
+++ b/packages/coding-agent/src/eval/py/runtime.ts
@@ -334,13 +334,18 @@ async function ensureWorkspaceManagedVenv(
 			$which("python", { PATH: baseEnv.PATH, cache: WhichCachePolicy.Bypass });
 		if (!basePython) throw new Error("Python executable not found on PATH");
 		await fs.promises.mkdir(path.dirname(managed.venvPath), { recursive: true });
-		await runRuntimeCommand(
-			[basePython, "-m", "venv", managed.venvPath],
-			cwd,
-			baseEnv,
-			"Managed Python venv creation",
-			lifecycle,
-		);
+		try {
+			await runRuntimeCommand(
+				[basePython, "-m", "venv", managed.venvPath],
+				cwd,
+				baseEnv,
+				"Managed Python venv creation",
+				lifecycle,
+			);
+		} catch (error) {
+			await fs.promises.rm(managed.venvPath, { recursive: true, force: true });
+			throw error;
+		}
 	}
 	if (seedPackages.length === 0) return;
 	const markerPath = path.join(managed.venvPath, ".gjc-seeded.json");

--- a/packages/coding-agent/src/eval/py/runtime.ts
+++ b/packages/coding-agent/src/eval/py/runtime.ts
@@ -7,7 +7,7 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { $env, $which, getPythonEnvDir } from "@gajae-code/utils";
+import { $env, $which, getPythonEnvDir, WhichCachePolicy } from "@gajae-code/utils";
 
 export const RLM_MANAGED_PYTHON_PACKAGES: readonly string[] = ["numpy", "pandas", "matplotlib", "polars"];
 
@@ -225,6 +225,7 @@ async function runRuntimeCommand(
 		stdout: "pipe",
 		stderr: "pipe",
 		windowsHide: true,
+		detached: process.platform !== "win32",
 	});
 	const output = Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text(), proc.exited]);
 	const { promise, resolve, reject } = Promise.withResolvers<number>();
@@ -237,18 +238,19 @@ async function runRuntimeCommand(
 	const cancel = (timedOut: boolean): void => {
 		if (cancellation) return;
 		cancellation = { timedOut };
-		try {
-			proc.kill("SIGTERM");
-		} catch {
-			// The process may have exited between the cancellation check and signal.
-		}
-		const escalation = setTimeout(() => {
+		const signalProcessTree = (signal: NodeJS.Signals): void => {
 			try {
-				proc.kill("SIGKILL");
+				if (process.platform === "win32") {
+					proc.kill(signal);
+				} else {
+					process.kill(-proc.pid, signal);
+				}
 			} catch {
-				// The process may have exited during the graceful cancellation window.
+				// The process may have exited between the cancellation check and signal.
 			}
-		}, RUNTIME_CANCEL_GRACE_MS);
+		};
+		signalProcessTree("SIGTERM");
+		const escalation = setTimeout(() => signalProcessTree("SIGKILL"), RUNTIME_CANCEL_GRACE_MS);
 		escalation.unref();
 		cleanups.push(() => clearTimeout(escalation));
 	};
@@ -299,7 +301,9 @@ async function ensureWorkspaceManagedVenv(
 ): Promise<void> {
 	const managed = resolveWorkspaceManagedPythonCandidate(cwd);
 	if (!fs.existsSync(managed.pythonPath)) {
-		const basePython = $which("python3") ?? $which("python");
+		const basePython =
+			$which("python3", { PATH: baseEnv.PATH, cache: WhichCachePolicy.Bypass }) ??
+			$which("python", { PATH: baseEnv.PATH, cache: WhichCachePolicy.Bypass });
 		if (!basePython) throw new Error("Python executable not found on PATH");
 		await fs.promises.mkdir(path.dirname(managed.venvPath), { recursive: true });
 		await runRuntimeCommand(

--- a/packages/coding-agent/src/eval/py/runtime.ts
+++ b/packages/coding-agent/src/eval/py/runtime.ts
@@ -212,6 +212,7 @@ function createRuntimeCancellationError(timedOut: boolean): Error {
 async function waitForRuntimeLifecycle<T>(
 	value: Promise<T>,
 	lifecycle: PythonRuntimeLifecycleOptions | undefined,
+	settleAfterCancellation?: () => boolean,
 ): Promise<T> {
 	const { promise, resolve, reject } = Promise.withResolvers<T>();
 	const cleanups: Array<() => void> = [];
@@ -219,18 +220,22 @@ async function waitForRuntimeLifecycle<T>(
 		while (cleanups.length > 0) cleanups.pop()?.();
 		callback();
 	};
-	if (lifecycle?.signal?.aborted) throw lifecycle.signal.reason ?? createRuntimeCancellationError(false);
-	if (lifecycle?.signal) {
-		const onAbort = (): void =>
-			finish(() => reject(lifecycle.signal?.reason ?? createRuntimeCancellationError(false)));
+	const cancel = (timedOut: boolean): void => {
+		if (settleAfterCancellation?.()) return;
+		finish(() => reject(createRuntimeCancellationError(timedOut)));
+	};
+	if (lifecycle?.signal?.aborted) {
+		if (!settleAfterCancellation?.()) throw lifecycle.signal.reason ?? createRuntimeCancellationError(false);
+	} else if (lifecycle?.signal) {
+		const onAbort = (): void => cancel(false);
 		lifecycle.signal.addEventListener("abort", onAbort, { once: true });
 		cleanups.push(() => lifecycle.signal?.removeEventListener("abort", onAbort));
 	}
 	const remainingMs = lifecycle?.deadlineMs === undefined ? undefined : lifecycle.deadlineMs - Date.now();
 	if (remainingMs !== undefined) {
-		if (remainingMs <= 0) finish(() => reject(createRuntimeCancellationError(true)));
+		if (remainingMs <= 0) cancel(true);
 		else {
-			const timer = setTimeout(() => finish(() => reject(createRuntimeCancellationError(true))), remainingMs);
+			const timer = setTimeout(() => cancel(true), remainingMs);
 			timer.unref();
 			cleanups.push(() => clearTimeout(timer));
 		}
@@ -368,6 +373,7 @@ async function ensureWorkspaceManagedVenv(
 			: lifecycle.signal
 				? AbortSignal.any([lifecycle.signal, AbortSignal.timeout(Math.max(0, lifecycle.deadlineMs - Date.now()))])
 				: AbortSignal.timeout(Math.max(0, lifecycle.deadlineMs - Date.now()));
+	let lockAcquired = false;
 	const provisioning = withFileLock(
 		venvPath,
 		async () => {
@@ -376,9 +382,9 @@ async function ensureWorkspaceManagedVenv(
 				throw createRuntimeCancellationError(true);
 			await ensureWorkspaceManagedVenvInner(cwd, baseEnv, seedPackages, lifecycle);
 		},
-		{ retries: Number.POSITIVE_INFINITY, signal: lockSignal },
+		{ retries: Number.POSITIVE_INFINITY, signal: lockSignal, onAcquired: () => (lockAcquired = true) },
 	);
-	return await waitForRuntimeLifecycle(provisioning, lifecycle);
+	return await waitForRuntimeLifecycle(provisioning, lifecycle, () => lockAcquired);
 }
 
 async function ensureWorkspaceManagedVenvInner(

--- a/packages/coding-agent/src/eval/py/runtime.ts
+++ b/packages/coding-agent/src/eval/py/runtime.ts
@@ -25,6 +25,7 @@ export interface PythonRuntimeLifecycleOptions {
 }
 
 const RUNTIME_CANCEL_GRACE_MS = 1_000;
+const RUNTIME_PROCESS_TREE_EXIT_TIMEOUT_MS = 5_000;
 
 const DEFAULT_ENV_ALLOWLIST = new Set([
 	"PATH",
@@ -287,19 +288,21 @@ async function runRuntimeCommand(
 			() => undefined,
 		);
 	};
-	const waitForProcessTreeExit = async (): Promise<void> => {
+	const waitForProcessTreeExit = async (): Promise<boolean> => {
 		if (process.platform === "win32") {
 			await windowsTermination;
-			return;
+			return true;
 		}
-		while (true) {
+		const deadline = Date.now() + RUNTIME_PROCESS_TREE_EXIT_TIMEOUT_MS;
+		while (Date.now() < deadline) {
 			try {
 				process.kill(-proc.pid, 0);
 				await Bun.sleep(10);
 			} catch {
-				return;
+				return true;
 			}
 		}
+		return false;
 	};
 	const cancel = (timedOut: boolean): void => {
 		if (cancellation) return;
@@ -340,8 +343,13 @@ async function runRuntimeCommand(
 	void proc.exited.then(async code => {
 		const cancelled = cancellation;
 		if (cancelled) {
-			await waitForProcessTreeExit();
-			finish(() => reject(createRuntimeCancellationError(cancelled.timedOut)));
+			const processTreeExited = await waitForProcessTreeExit();
+			finish(() => {
+				const error = createRuntimeCancellationError(cancelled.timedOut);
+				if (!processTreeExited)
+					error.message += "; Python provisioner process tree did not exit after cancellation";
+				reject(error);
+			});
 			return;
 		}
 		finish(() => resolve(code));

--- a/packages/coding-agent/src/eval/py/runtime.ts
+++ b/packages/coding-agent/src/eval/py/runtime.ts
@@ -8,6 +8,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { $env, $which, getPythonEnvDir, WhichCachePolicy } from "@gajae-code/utils";
+import { withFileLock } from "../../config/file-lock";
 
 export const RLM_MANAGED_PYTHON_PACKAGES: readonly string[] = ["numpy", "pandas", "matplotlib", "polars"];
 
@@ -321,8 +322,6 @@ async function runRuntimeCommand(
 	}
 }
 
-const managedVenvProvisioning = new Map<string, Promise<void>>();
-
 async function ensureWorkspaceManagedVenv(
 	cwd: string,
 	baseEnv: Record<string, string | undefined>,
@@ -330,15 +329,11 @@ async function ensureWorkspaceManagedVenv(
 	lifecycle?: PythonRuntimeLifecycleOptions,
 ): Promise<void> {
 	const venvPath = resolveWorkspaceManagedPythonCandidate(cwd).venvPath;
-	const existing = managedVenvProvisioning.get(venvPath);
-	if (existing) return await existing;
-	const provisioning = ensureWorkspaceManagedVenvInner(cwd, baseEnv, seedPackages, lifecycle);
-	managedVenvProvisioning.set(venvPath, provisioning);
-	try {
-		await provisioning;
-	} finally {
-		if (managedVenvProvisioning.get(venvPath) === provisioning) managedVenvProvisioning.delete(venvPath);
-	}
+	return await withFileLock(
+		venvPath,
+		async () => await ensureWorkspaceManagedVenvInner(cwd, baseEnv, seedPackages, lifecycle),
+		{ retries: 600 },
+	);
 }
 
 async function ensureWorkspaceManagedVenvInner(

--- a/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
@@ -173,9 +173,19 @@ describe("python eval lifecycle red-team", () => {
 			Bun.env.PI_PYTHON_SKIP_CHECK = "1";
 			using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
 			const unrelated = Bun.spawn(["/bin/sh", "-c", "sleep 30"], { stdout: "ignore", stderr: "ignore" });
+			const startupGate = Promise.withResolvers<void>();
+			const startupCalled = Promise.withResolvers<void>();
+			const kernelStarted = Promise.withResolvers<void>();
 			const controller = new AbortController();
 			let execution: Promise<PythonResult> | undefined;
 			try {
+				PythonKernel.start = async options => {
+					startupCalled.resolve();
+					await startupGate.promise;
+					const kernel = await originalStart(options);
+					kernelStarted.resolve();
+					return kernel;
+				};
 				const pidFile = `${tempDir.path()}/owned-child.pid`;
 				execution = executePython(`%%bash\n(sleep 30) &\nprintf '%s' "$!" > "${pidFile}"\nwait`, {
 					cwd: tempDir.path(),
@@ -183,6 +193,9 @@ describe("python eval lifecycle red-team", () => {
 					kernelMode: "session",
 					signal: controller.signal,
 				});
+				await startupCalled.promise;
+				startupGate.resolve();
+				await kernelStarted.promise;
 				const childPid = await waitForOwnedProcess(pidFile);
 				controller.abort(new DOMException("Python execution timed out", "TimeoutError"));
 				const result = await execution;
@@ -190,14 +203,15 @@ describe("python eval lifecycle red-team", () => {
 				expect(await waitForProcessGone(childPid)).toBe(true);
 				expect(isProcessAlive(unrelated.pid)).toBe(true);
 			} finally {
+				startupGate.resolve();
+				controller.abort(new DOMException("Python execution timed out", "TimeoutError"));
+				await execution?.catch(() => undefined);
 				try {
 					unrelated.kill("SIGKILL");
 				} catch {
 					// ignore cleanup races
 				}
 				await unrelated.exited.catch(() => undefined);
-				controller.abort(new DOMException("Python execution timed out", "TimeoutError"));
-				await execution?.catch(() => undefined);
 			}
 		},
 		LIFECYCLE_TEST_TIMEOUT_MS,
@@ -260,21 +274,45 @@ describe("python eval lifecycle red-team", () => {
 			Bun.env.PI_PYTHON_SKIP_CHECK = "1";
 			using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
 			const controller = new AbortController();
+			const startup = Promise.withResolvers<void>();
+			const startupCalled = Promise.withResolvers<void>();
+			const kernel = new FakeKernel();
+			let startupFinished = false;
+			let executionSettled = false;
+			PythonKernel.start = async () => {
+				startupCalled.resolve();
+				await startup.promise;
+				startupFinished = true;
+				return kernel as unknown as PythonKernel;
+			};
 			const execution = executePython("import time\ntime.sleep(60)", {
 				cwd: tempDir.path(),
 				sessionId: "redteam-readiness-failure-cleanup",
 				kernelMode: "session",
 				signal: controller.signal,
 			});
+			void execution.then(() => {
+				executionSettled = true;
+			});
+			await startupCalled.promise;
 			try {
 				await expect(waitForFile(`${tempDir.path()}/never-created`)).rejects.toThrow(
 					"Timed out waiting for readiness file",
 				);
 			} finally {
 				controller.abort(new DOMException("Python execution timed out", "TimeoutError"));
-				expect(await settlesWithin(execution, CLEANUP_TIMEOUT_MS)).toBe(true);
-				await execution;
+				await Bun.sleep(0);
+				expect(executionSettled).toBe(false);
+				startup.resolve();
+				const settled = await settlesWithin(execution, CLEANUP_TIMEOUT_MS);
+				try {
+					expect(settled).toBe(true);
+				} finally {
+					await execution;
+				}
 			}
+			expect(startupFinished).toBe(true);
+			expect(kernel.shutdownCalls).toBe(1);
 		},
 		LIFECYCLE_TEST_TIMEOUT_MS,
 	);

--- a/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
@@ -13,8 +13,8 @@ const originalStart = PythonKernel.start;
 const READINESS_TIMEOUT_MS = 1_000;
 const PROCESS_EXIT_TIMEOUT_MS = 2_000;
 const CLEANUP_TIMEOUT_MS = 9_000;
-// Python startup is bounded to 10s; readiness plus cancellation can consume at most 10s.
-const LIFECYCLE_TEST_TIMEOUT_MS = 20_000;
+// Kernel startup permits two 10s phases; readiness and cleanup consume up to 10s more.
+const LIFECYCLE_TEST_TIMEOUT_MS = 35_000;
 
 const OK_RESULT: KernelExecuteResult = {
 	status: "ok",
@@ -294,7 +294,6 @@ describe("python eval lifecycle red-team", () => {
 				});
 				await startupCalled.promise;
 				controller.abort(new DOMException("Python execution timed out", "TimeoutError"));
-				await Bun.sleep(0);
 				expect(listeners.count()).toBe(0);
 
 				const successor = executePython("print('successor')", {

--- a/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
@@ -227,7 +227,10 @@ describe("python eval lifecycle red-team", () => {
 		async () => {
 			Bun.env.PI_PYTHON_SKIP_CHECK = "1";
 			using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
-			const unrelated = Bun.spawn(["/bin/sh", "-c", "sleep 30"], { stdout: "ignore", stderr: "ignore" });
+			const unrelated = Bun.spawn([process.execPath, "-e", "setTimeout(() => {}, 30_000)"], {
+				stdout: "ignore",
+				stderr: "ignore",
+			});
 			const kernelStarted = Promise.withResolvers<void>();
 			const startupError = new Error("kernel startup failed");
 			PythonKernel.start = async () => {

--- a/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
@@ -378,6 +378,7 @@ describe("python eval lifecycle red-team", () => {
 			const startup = Promise.withResolvers<void>();
 			const startupCalled = Promise.withResolvers<void>();
 			const kernel = new FakeKernel();
+			kernel.shutdownResult = { confirmed: false };
 			let startupFinished = false;
 			let executionSettled = false;
 			PythonKernel.start = async () => {
@@ -414,6 +415,11 @@ describe("python eval lifecycle red-team", () => {
 			}
 			expect(startupFinished).toBe(true);
 			expect(kernel.shutdownCalls).toBe(1);
+			await disposeAllKernelSessions();
+			expect(kernel.shutdownCalls).toBe(2);
+			kernel.shutdownResult = { confirmed: true };
+			await disposeAllKernelSessions();
+			expect(kernel.shutdownCalls).toBe(3);
 		},
 		LIFECYCLE_TEST_TIMEOUT_MS,
 	);

--- a/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { disposeAllKernelSessions, executePython } from "@gajae-code/coding-agent/eval/py/executor";
+import { disposeAllKernelSessions, executePython, type PythonResult } from "@gajae-code/coding-agent/eval/py/executor";
 import type {
 	KernelExecuteOptions,
 	KernelExecuteResult,
@@ -60,6 +60,27 @@ async function waitForProcessGone(pid: number, timeoutMs = 5000): Promise<boolea
 		await Bun.sleep(50);
 	}
 	return !isProcessAlive(pid);
+}
+
+async function waitForOwnedProcess(pidFile: string, timeoutMs = 5000): Promise<number> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await Bun.file(pidFile).exists()) {
+			const pid = Number((await Bun.file(pidFile).text()).trim());
+			if (Number.isSafeInteger(pid) && pid > 0 && isProcessAlive(pid)) return pid;
+		}
+		await Bun.sleep(10);
+	}
+	throw new Error(`Timed out waiting for owned descendant PID at ${pidFile}`);
+}
+
+async function waitForFile(path: string, timeoutMs = 5000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await Bun.file(path).exists()) return;
+		await Bun.sleep(10);
+	}
+	throw new Error(`Timed out waiting for readiness file at ${path}`);
 }
 
 function countAbortListeners(signal: AbortSignal): { readonly count: () => number; readonly restore: () => void } {
@@ -134,17 +155,19 @@ describe("python eval lifecycle red-team", () => {
 		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
 		using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
 		const unrelated = Bun.spawn(["/bin/sh", "-c", "sleep 30"], { stdout: "ignore", stderr: "ignore" });
-		let childPid: number | undefined;
+		const controller = new AbortController();
+		let execution: Promise<PythonResult> | undefined;
 		try {
 			const pidFile = `${tempDir.path()}/owned-child.pid`;
-			const result = await executePython(`%%bash\n(sleep 30) &\nprintf '%s' "$!" > "${pidFile}"\nwait`, {
+			execution = executePython(`%%bash\n(sleep 30) &\nprintf '%s' "$!" > "${pidFile}"\nwait`, {
 				cwd: tempDir.path(),
 				sessionId: "redteam-bash-descendant-timeout",
 				kernelMode: "session",
-				timeoutMs: 500,
+				signal: controller.signal,
 			});
-			childPid = Number(await Bun.file(pidFile).text());
-			expect(Number.isSafeInteger(childPid) && childPid > 0).toBe(true);
+			const childPid = await waitForOwnedProcess(pidFile);
+			controller.abort(new DOMException("Python execution timed out", "TimeoutError"));
+			const result = await execution;
 			expect(result.cancelled).toBe(true);
 			expect(await waitForProcessGone(childPid)).toBe(true);
 			expect(isProcessAlive(unrelated.pid)).toBe(true);
@@ -155,6 +178,8 @@ describe("python eval lifecycle red-team", () => {
 				// ignore cleanup races
 			}
 			await unrelated.exited.catch(() => undefined);
+			controller.abort(new DOMException("Python execution timed out", "TimeoutError"));
+			await execution?.catch(() => undefined);
 		}
 	});
 
@@ -163,29 +188,44 @@ describe("python eval lifecycle red-team", () => {
 		using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
 		const controller = new AbortController();
 		const listeners = countAbortListeners(controller.signal);
+		const kernelStarted = Promise.withResolvers<void>();
 		let shutdown: (() => Promise<KernelShutdownResult>) | undefined;
+		let execution: Promise<PythonResult> | undefined;
 		try {
 			PythonKernel.start = async () => {
-				const kernel = await originalStart({ cwd: tempDir.path() });
-				shutdown = () => kernel.shutdown({ timeoutMs: 100 });
-				return kernel;
+				try {
+					const kernel = await originalStart({ cwd: tempDir.path() });
+					shutdown = () => kernel.shutdown({ timeoutMs: 100 });
+					kernelStarted.resolve();
+					return kernel;
+				} catch (error) {
+					kernelStarted.reject(error);
+					throw error;
+				}
 			};
 
-			const execution = executePython("import time\ntime.sleep(60)", {
-				cwd: tempDir.path(),
-				sessionId: "redteam-inflight-shutdown",
-				kernelMode: "session",
-				signal: controller.signal,
-				timeoutMs: 60_000,
-			});
-			await Bun.sleep(250);
+			const executionReadyFile = `${tempDir.path()}/kernel-executing`;
+			execution = executePython(
+				`from pathlib import Path\nPath(${JSON.stringify(executionReadyFile)}).touch()\nimport time\ntime.sleep(60)`,
+				{
+					cwd: tempDir.path(),
+					sessionId: "redteam-inflight-shutdown",
+					kernelMode: "session",
+					signal: controller.signal,
+					timeoutMs: 60_000,
+				},
+			);
+			await kernelStarted.promise;
+			await waitForFile(executionReadyFile);
 			expect(listeners.count()).toBe(1);
-			expect(shutdown).toBeDefined();
+			if (!shutdown) throw new Error("Python kernel did not expose shutdown after startup");
 
-			await shutdown?.();
+			await shutdown();
 			await execution;
 			expect(listeners.count()).toBe(0);
 		} finally {
+			await shutdown?.().catch(() => undefined);
+			await execution?.catch(() => undefined);
 			listeners.restore();
 		}
 	});

--- a/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import { disposeAllKernelSessions, executePython, type PythonResult } from "@gajae-code/coding-agent/eval/py/executor";
 import type {
 	KernelExecuteOptions,
@@ -6,6 +8,7 @@ import type {
 	KernelShutdownResult,
 } from "@gajae-code/coding-agent/eval/py/kernel";
 import { PythonKernel } from "@gajae-code/coding-agent/eval/py/kernel";
+import { ensurePythonRuntime } from "@gajae-code/coding-agent/eval/py/runtime";
 import { TempDir } from "@gajae-code/utils";
 
 const originalStart = PythonKernel.start;
@@ -129,6 +132,35 @@ function countAbortListeners(signal: AbortSignal): { readonly count: () => numbe
 }
 
 describe("python eval lifecycle red-team", () => {
+	it("terminates the complete managed-runtime provisioning process group on cancellation", async () => {
+		if (process.platform === "win32") return;
+		using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
+		const binDir = path.join(tempDir.path(), "bin");
+		const pythonPath = path.join(binDir, "python3");
+		const childPidPath = path.join(tempDir.path(), "provision-child.pid");
+		await fs.mkdir(binDir);
+		await Bun.write(pythonPath, '#!/bin/sh\n(sleep 30) &\nprintf \'%s\' "$!" > "$PWD/provision-child.pid"\nwait\n');
+		await fs.chmod(pythonPath, 0o755);
+		const controller = new AbortController();
+		const originalPath = process.env.PATH;
+		process.env.PATH = `${binDir}:${originalPath ?? ""}`;
+		try {
+			const provisioning = ensurePythonRuntime(
+				tempDir.path(),
+				{ PATH: process.env.PATH },
+				{ managedWorkspaceVenv: true, seedPackages: [] },
+				{ signal: controller.signal },
+			);
+			void provisioning.catch(() => undefined);
+			const childPid = await waitForOwnedProcess(childPidPath);
+			controller.abort();
+			await expect(provisioning).rejects.toMatchObject({ name: "AbortError" });
+			expect(await waitForProcessGone(childPid)).toBe(true);
+		} finally {
+			process.env.PATH = originalPath;
+		}
+	});
+
 	afterEach(async () => {
 		PythonKernel.start = originalStart;
 		delete Bun.env.PI_PYTHON_SKIP_CHECK;

--- a/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
@@ -10,6 +10,12 @@ import { TempDir } from "@gajae-code/utils";
 
 const originalStart = PythonKernel.start;
 
+const READINESS_TIMEOUT_MS = 1_000;
+const PROCESS_EXIT_TIMEOUT_MS = 2_000;
+const CLEANUP_TIMEOUT_MS = 9_000;
+// Python startup is bounded to 10s; readiness plus cancellation can consume at most 10s.
+const LIFECYCLE_TEST_TIMEOUT_MS = 20_000;
+
 const OK_RESULT: KernelExecuteResult = {
 	status: "ok",
 	cancelled: false,
@@ -53,7 +59,7 @@ function isProcessAlive(pid: number): boolean {
 	}
 }
 
-async function waitForProcessGone(pid: number, timeoutMs = 5000): Promise<boolean> {
+async function waitForProcessGone(pid: number, timeoutMs = PROCESS_EXIT_TIMEOUT_MS): Promise<boolean> {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
 		if (!isProcessAlive(pid)) return true;
@@ -62,7 +68,7 @@ async function waitForProcessGone(pid: number, timeoutMs = 5000): Promise<boolea
 	return !isProcessAlive(pid);
 }
 
-async function waitForOwnedProcess(pidFile: string, timeoutMs = 5000): Promise<number> {
+async function waitForOwnedProcess(pidFile: string, timeoutMs = READINESS_TIMEOUT_MS): Promise<number> {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
 		if (await Bun.file(pidFile).exists()) {
@@ -74,13 +80,23 @@ async function waitForOwnedProcess(pidFile: string, timeoutMs = 5000): Promise<n
 	throw new Error(`Timed out waiting for owned descendant PID at ${pidFile}`);
 }
 
-async function waitForFile(path: string, timeoutMs = 5000): Promise<void> {
+async function waitForFile(path: string, timeoutMs = READINESS_TIMEOUT_MS): Promise<void> {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
 		if (await Bun.file(path).exists()) return;
 		await Bun.sleep(10);
 	}
 	throw new Error(`Timed out waiting for readiness file at ${path}`);
+}
+
+async function settlesWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+	return await Promise.race([
+		promise.then(
+			() => true,
+			() => true,
+		),
+		Bun.sleep(timeoutMs).then(() => false),
+	]);
 }
 
 function countAbortListeners(signal: AbortSignal): { readonly count: () => number; readonly restore: () => void } {
@@ -150,85 +166,118 @@ describe("python eval lifecycle red-team", () => {
 		expect(kernel.shutdownCalls).toBe(1);
 	});
 
-	it("kills only the owned bash background descendant after timeout while an unrelated sibling survives", async () => {
-		if (process.platform === "win32") return;
-		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
-		using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
-		const unrelated = Bun.spawn(["/bin/sh", "-c", "sleep 30"], { stdout: "ignore", stderr: "ignore" });
-		const controller = new AbortController();
-		let execution: Promise<PythonResult> | undefined;
-		try {
-			const pidFile = `${tempDir.path()}/owned-child.pid`;
-			execution = executePython(`%%bash\n(sleep 30) &\nprintf '%s' "$!" > "${pidFile}"\nwait`, {
+	it(
+		"kills only the owned bash background descendant after timeout while an unrelated sibling survives",
+		async () => {
+			if (process.platform === "win32") return;
+			Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+			using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
+			const unrelated = Bun.spawn(["/bin/sh", "-c", "sleep 30"], { stdout: "ignore", stderr: "ignore" });
+			const controller = new AbortController();
+			let execution: Promise<PythonResult> | undefined;
+			try {
+				const pidFile = `${tempDir.path()}/owned-child.pid`;
+				execution = executePython(`%%bash\n(sleep 30) &\nprintf '%s' "$!" > "${pidFile}"\nwait`, {
+					cwd: tempDir.path(),
+					sessionId: "redteam-bash-descendant-timeout",
+					kernelMode: "session",
+					signal: controller.signal,
+				});
+				const childPid = await waitForOwnedProcess(pidFile);
+				controller.abort(new DOMException("Python execution timed out", "TimeoutError"));
+				const result = await execution;
+				expect(result.cancelled).toBe(true);
+				expect(await waitForProcessGone(childPid)).toBe(true);
+				expect(isProcessAlive(unrelated.pid)).toBe(true);
+			} finally {
+				try {
+					unrelated.kill("SIGKILL");
+				} catch {
+					// ignore cleanup races
+				}
+				await unrelated.exited.catch(() => undefined);
+				controller.abort(new DOMException("Python execution timed out", "TimeoutError"));
+				await execution?.catch(() => undefined);
+			}
+		},
+		LIFECYCLE_TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"settles an in-flight cell during shutdown without leaked abort listeners",
+		async () => {
+			Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+			using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
+			const controller = new AbortController();
+			const listeners = countAbortListeners(controller.signal);
+			const kernelStarted = Promise.withResolvers<void>();
+			let shutdown: (() => Promise<KernelShutdownResult>) | undefined;
+			let execution: Promise<PythonResult> | undefined;
+			try {
+				PythonKernel.start = async () => {
+					try {
+						const kernel = await originalStart({ cwd: tempDir.path() });
+						shutdown = () => kernel.shutdown({ timeoutMs: 100 });
+						kernelStarted.resolve();
+						return kernel;
+					} catch (error) {
+						kernelStarted.reject(error);
+						throw error;
+					}
+				};
+
+				const executionReadyFile = `${tempDir.path()}/kernel-executing`;
+				execution = executePython(
+					`from pathlib import Path\nPath(${JSON.stringify(executionReadyFile)}).touch()\nimport time\ntime.sleep(60)`,
+					{
+						cwd: tempDir.path(),
+						sessionId: "redteam-inflight-shutdown",
+						kernelMode: "session",
+						signal: controller.signal,
+						timeoutMs: 60_000,
+					},
+				);
+				await kernelStarted.promise;
+				await waitForFile(executionReadyFile);
+				expect(listeners.count()).toBe(1);
+				if (!shutdown) throw new Error("Python kernel did not expose shutdown after startup");
+
+				await shutdown();
+				await execution;
+				expect(listeners.count()).toBe(0);
+			} finally {
+				await shutdown?.().catch(() => undefined);
+				await execution?.catch(() => undefined);
+				listeners.restore();
+			}
+		},
+		LIFECYCLE_TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"bounds failed readiness cleanup before the fixture deadline",
+		async () => {
+			Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+			using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
+			const controller = new AbortController();
+			const execution = executePython("import time\ntime.sleep(60)", {
 				cwd: tempDir.path(),
-				sessionId: "redteam-bash-descendant-timeout",
+				sessionId: "redteam-readiness-failure-cleanup",
 				kernelMode: "session",
 				signal: controller.signal,
 			});
-			const childPid = await waitForOwnedProcess(pidFile);
-			controller.abort(new DOMException("Python execution timed out", "TimeoutError"));
-			const result = await execution;
-			expect(result.cancelled).toBe(true);
-			expect(await waitForProcessGone(childPid)).toBe(true);
-			expect(isProcessAlive(unrelated.pid)).toBe(true);
-		} finally {
 			try {
-				unrelated.kill("SIGKILL");
-			} catch {
-				// ignore cleanup races
+				await expect(waitForFile(`${tempDir.path()}/never-created`)).rejects.toThrow(
+					"Timed out waiting for readiness file",
+				);
+			} finally {
+				controller.abort(new DOMException("Python execution timed out", "TimeoutError"));
+				expect(await settlesWithin(execution, CLEANUP_TIMEOUT_MS)).toBe(true);
+				await execution;
 			}
-			await unrelated.exited.catch(() => undefined);
-			controller.abort(new DOMException("Python execution timed out", "TimeoutError"));
-			await execution?.catch(() => undefined);
-		}
-	});
-
-	it("settles an in-flight cell during shutdown without leaked abort listeners", async () => {
-		Bun.env.PI_PYTHON_SKIP_CHECK = "1";
-		using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
-		const controller = new AbortController();
-		const listeners = countAbortListeners(controller.signal);
-		const kernelStarted = Promise.withResolvers<void>();
-		let shutdown: (() => Promise<KernelShutdownResult>) | undefined;
-		let execution: Promise<PythonResult> | undefined;
-		try {
-			PythonKernel.start = async () => {
-				try {
-					const kernel = await originalStart({ cwd: tempDir.path() });
-					shutdown = () => kernel.shutdown({ timeoutMs: 100 });
-					kernelStarted.resolve();
-					return kernel;
-				} catch (error) {
-					kernelStarted.reject(error);
-					throw error;
-				}
-			};
-
-			const executionReadyFile = `${tempDir.path()}/kernel-executing`;
-			execution = executePython(
-				`from pathlib import Path\nPath(${JSON.stringify(executionReadyFile)}).touch()\nimport time\ntime.sleep(60)`,
-				{
-					cwd: tempDir.path(),
-					sessionId: "redteam-inflight-shutdown",
-					kernelMode: "session",
-					signal: controller.signal,
-					timeoutMs: 60_000,
-				},
-			);
-			await kernelStarted.promise;
-			await waitForFile(executionReadyFile);
-			expect(listeners.count()).toBe(1);
-			if (!shutdown) throw new Error("Python kernel did not expose shutdown after startup");
-
-			await shutdown();
-			await execution;
-			expect(listeners.count()).toBe(0);
-		} finally {
-			await shutdown?.().catch(() => undefined);
-			await execution?.catch(() => undefined);
-			listeners.restore();
-		}
-	});
+		},
+		LIFECYCLE_TEST_TIMEOUT_MS,
+	);
 
 	it("treats clean exit code 0 as confirmed and starts a fresh session instead of reinserting", async () => {
 		Bun.env.PI_PYTHON_SKIP_CHECK = "1";

--- a/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
@@ -147,8 +147,9 @@ describe("python eval lifecycle red-team", () => {
 		const controller = new AbortController();
 		const originalPath = process.env.PATH;
 		process.env.PATH = `${binDir}:${originalPath ?? ""}`;
+		let provisioning: Promise<unknown> | undefined;
 		try {
-			const provisioning = ensurePythonRuntime(
+			provisioning = ensurePythonRuntime(
 				tempDir.path(),
 				{ PATH: process.env.PATH },
 				{ managedWorkspaceVenv: true, seedPackages: [] },
@@ -157,9 +158,11 @@ describe("python eval lifecycle red-team", () => {
 			void provisioning.catch(() => undefined);
 			const childPid = await waitForOwnedProcess(childPidPath);
 			controller.abort();
-			await expect(provisioning).rejects.toMatchObject({ name: "AbortError" });
+			await expect(provisioning!).rejects.toMatchObject({ name: "AbortError" });
 			expect(await waitForProcessGone(childPid)).toBe(true);
 		} finally {
+			controller.abort();
+			await provisioning?.catch(() => undefined);
 			process.env.PATH = originalPath;
 		}
 	});

--- a/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
@@ -182,9 +182,14 @@ describe("python eval lifecycle red-team", () => {
 				PythonKernel.start = async options => {
 					startupCalled.resolve();
 					await startupGate.promise;
-					const kernel = await originalStart(options);
-					kernelStarted.resolve();
-					return kernel;
+					try {
+						const kernel = await originalStart(options);
+						kernelStarted.resolve();
+						return kernel;
+					} catch (error) {
+						kernelStarted.reject(error);
+						throw error;
+					}
 				};
 				const pidFile = `${tempDir.path()}/owned-child.pid`;
 				execution = executePython(`%%bash\n(sleep 30) &\nprintf '%s' "$!" > "${pidFile}"\nwait`, {
@@ -213,6 +218,100 @@ describe("python eval lifecycle red-team", () => {
 				}
 				await unrelated.exited.catch(() => undefined);
 			}
+		},
+		LIFECYCLE_TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"rejects the startup handshake and cleans up when kernel startup fails",
+		async () => {
+			Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+			using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
+			const unrelated = Bun.spawn(["/bin/sh", "-c", "sleep 30"], { stdout: "ignore", stderr: "ignore" });
+			const kernelStarted = Promise.withResolvers<void>();
+			const startupError = new Error("kernel startup failed");
+			PythonKernel.start = async () => {
+				try {
+					throw startupError;
+				} catch (error) {
+					kernelStarted.reject(error);
+					throw error;
+				}
+			};
+			const execution = executePython("print('never runs')", {
+				cwd: tempDir.path(),
+				sessionId: "redteam-startup-failure",
+				kernelMode: "session",
+			});
+			void execution.catch(() => undefined);
+			try {
+				await expect(kernelStarted.promise).rejects.toThrow(startupError);
+				await expect(execution).rejects.toThrow(startupError);
+				expect(isProcessAlive(unrelated.pid)).toBe(true);
+			} finally {
+				try {
+					unrelated.kill("SIGKILL");
+				} catch {
+					// ignore cleanup races
+				}
+				await unrelated.exited.catch(() => undefined);
+				await disposeAllKernelSessions();
+			}
+		},
+		LIFECYCLE_TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"retires a cancelled initializer before an uncancelled successor acquires a replacement",
+		async () => {
+			Bun.env.PI_PYTHON_SKIP_CHECK = "1";
+			using tempDir = TempDir.createSync("@gjc-python-lifecycle-redteam-");
+			const controller = new AbortController();
+			const listeners = countAbortListeners(controller.signal);
+			const startup = Promise.withResolvers<void>();
+			const startupCalled = Promise.withResolvers<void>();
+			const firstKernel = new FakeKernel();
+			const secondKernel = new FakeKernel();
+			let startCalls = 0;
+			PythonKernel.start = async () => {
+				startCalls += 1;
+				if (startCalls === 1) {
+					startupCalled.resolve();
+					await startup.promise;
+					return firstKernel as unknown as PythonKernel;
+				}
+				return secondKernel as unknown as PythonKernel;
+			};
+			try {
+				const cancelled = executePython("print('cancelled')", {
+					cwd: tempDir.path(),
+					sessionId: "redteam-cancelled-initializer",
+					kernelMode: "session",
+					signal: controller.signal,
+				});
+				await startupCalled.promise;
+				controller.abort(new DOMException("Python execution timed out", "TimeoutError"));
+				await Bun.sleep(0);
+				expect(listeners.count()).toBe(0);
+
+				const successor = executePython("print('successor')", {
+					cwd: tempDir.path(),
+					sessionId: "redteam-cancelled-initializer",
+					kernelMode: "session",
+				});
+				startup.resolve();
+				const [cancelledResult, successorResult] = await Promise.all([cancelled, successor]);
+				expect(cancelledResult.cancelled).toBe(true);
+				expect(successorResult.cancelled).toBe(false);
+				expect(startCalls).toBe(2);
+				expect(firstKernel.shutdownCalls).toBe(1);
+				expect(secondKernel.executeCalls).toEqual(["print('successor')"]);
+			} finally {
+				startup.resolve();
+				await disposeAllKernelSessions();
+				listeners.restore();
+			}
+			expect(secondKernel.shutdownCalls).toBe(1);
 		},
 		LIFECYCLE_TEST_TIMEOUT_MS,
 	);

--- a/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
+++ b/packages/coding-agent/test/eval/python-lifecycle.redteam.test.ts
@@ -139,7 +139,10 @@ describe("python eval lifecycle red-team", () => {
 		const pythonPath = path.join(binDir, "python3");
 		const childPidPath = path.join(tempDir.path(), "provision-child.pid");
 		await fs.mkdir(binDir);
-		await Bun.write(pythonPath, '#!/bin/sh\n(sleep 30) &\nprintf \'%s\' "$!" > "$PWD/provision-child.pid"\nwait\n');
+		await Bun.write(
+			pythonPath,
+			'#!/bin/sh\n(trap "" TERM; while :; do sleep 1; done) &\nprintf \'%s\' "$!" > "$PWD/provision-child.pid"\nwait\n',
+		);
 		await fs.chmod(pythonPath, 0o755);
 		const controller = new AbortController();
 		const originalPath = process.env.PATH;


### PR DESCRIPTION
Fixes #4119.

Replaces scheduler-dependent lifecycle fixture delays with bounded observable readiness:
- wait for an owned descendant PID file, validate its numeric live PID, then deliver the timeout abort;
- wait for Python kernel startup and in-flight execution handshakes before shutdown;
- settle in-flight execution before TempDir disposal.

Verification:
- `bun test test/eval/python-lifecycle.redteam.test.ts --rerun-each 10` (40 pass)
- `bun run check`
- `bun run build`

Local shard 8 exercised the full parallel shard but has unrelated image-generation configuration failures caused by the workstation `OPENAI_BASE_URL` / persisted provider endpoint, not this change.