### PR TITLE
fix(cli): defer consumer-owned startup flags

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 - Streamed edit preview coalescing now keys on the complete partial-JSON payload rather than its length, so same-size in-place argument replacements recompute and render while repeated payloads remain cached.
-- Root flag validation now defers ACP- and local-startup-owned options to their owning consumers, preserving ACP-specific diagnostics, SDK startup forwarding, and real ACP subprocess framing without exposing retired flags in root help or completion.
+- CLI parsing now fails closed by default, while launch and ACP explicitly defer only their owned startup options; this preserves ACP-specific diagnostics, SDK startup forwarding, real ACP subprocess framing, and RLM typo rejection without exposing retired flags in root help or completion.
 
 ## [0.12.21] - 2026-08-09
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Streamed edit preview coalescing now keys on the complete partial-JSON payload rather than its length, so same-size in-place argument replacements recompute and render while repeated payloads remain cached.
+- Root flag validation now defers ACP- and local-startup-owned options to their owning consumers, preserving ACP-specific diagnostics, SDK startup forwarding, and real ACP subprocess framing without exposing retired flags in root help or completion.
 
 ## [0.12.21] - 2026-08-09
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -33,6 +33,8 @@ function isKnownRootFlagToken(arg: string): boolean {
 
 export type Mode = "text" | "json" | "acp";
 
+export type ParseArgsAuthority = "local" | "acp" | "deferred";
+
 export interface Args {
 	cwd?: string;
 	allowHome?: boolean;
@@ -124,7 +126,7 @@ function takePromptValue(
 	return takeFlagValue(args, index, flag, allowInlineDashPrefixed || allowSeparatedDashPrefixed);
 }
 
-export function parseArgs(args: string[]): Args {
+export function parseArgs(args: string[], authority: ParseArgsAuthority = "local"): Args {
 	const result: Args = {
 		messages: [],
 		fileArgs: [],
@@ -362,6 +364,7 @@ export function parseArgs(args: string[]): Args {
 	}
 
 	CONSUMER_FLAGS_BY_ARGS.set(result, consumerFlags);
+	if (authority === "local") assertLocalLaunchArgs(result);
 	return result;
 }
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -7,10 +7,10 @@ import { logger } from "@gajae-code/utils";
 import { CliParseError } from "@gajae-code/utils/cli";
 import { parseEffort } from "../thinking";
 import { BUILTIN_TOOLS } from "../tools";
-import { ROOT_LAUNCH_FLAGS } from "./root-flags";
+import { type ConsumerLaunchFlagName, LAUNCH_PARSE_FLAGS, launchFlagIsOwnedBy } from "./root-flags";
 
 const ROOT_FLAG_TOKENS = new Set<string>();
-for (const [name, descriptor] of Object.entries(ROOT_LAUNCH_FLAGS)) {
+for (const [name, descriptor] of Object.entries(LAUNCH_PARSE_FLAGS)) {
 	ROOT_FLAG_TOKENS.add(`--${name}`);
 	if (descriptor.char) ROOT_FLAG_TOKENS.add(`-${descriptor.char}`);
 }
@@ -81,11 +81,13 @@ export interface Args {
 	noTitle?: boolean;
 	messages: string[];
 	fileArgs: string[];
-	/** Retained for test/runtime compatibility; extension-defined flags are no longer parsed. */
+	/** Flags unknown to every launch parser; their consumer supplies the diagnostic. */
 	unknownFlags: Map<string, boolean | string>;
 	/** Exact interactive startup login intent, recognized before model-profile activation. */
 	authBootstrap?: true;
 }
+
+const CONSUMER_FLAGS_BY_ARGS = new WeakMap<Args, Map<ConsumerLaunchFlagName, string>>();
 
 function isStartupSlashCommandArg(arg: string | undefined): boolean {
 	return (
@@ -128,6 +130,7 @@ export function parseArgs(args: string[]): Args {
 		fileArgs: [],
 		unknownFlags: new Map(),
 	};
+	const consumerFlags = new Map<ConsumerLaunchFlagName, string>();
 
 	for (let i = 0; i < args.length; i++) {
 		let arg = args[i];
@@ -161,7 +164,9 @@ export function parseArgs(args: string[]): Args {
 			args.splice(i + 1, 0, value);
 		}
 		if (arg.startsWith("-") && !isKnownRootFlagToken(arg)) {
-			throw new CliParseError(`Unknown option: ${arg}`);
+			result.unknownFlags.set(arg, true);
+			if (hasInlineValue) i++;
+			continue;
 		}
 
 		if (arg === "--help" || arg === "-h") {
@@ -272,18 +277,23 @@ export function parseArgs(args: string[]): Args {
 		} else if (arg === "--extension" || arg === "-e") {
 			const extension = takeFlagValue(args, i++, "--extension");
 			result.extensions = [...(result.extensions ?? []), extension];
+			consumerFlags.set("extension", "--extension");
 		} else if (arg === "--hook") {
 			const hook = takeFlagValue(args, i++, "--hook");
 			result.hooks = [...(result.hooks ?? []), hook];
+			consumerFlags.set("hook", "--hook");
 		} else if (arg === "--no-extensions") {
 			result.noExtensions = true;
+			consumerFlags.set("no-extensions", "--no-extensions");
 		} else if (arg === "--no-skills") {
 			result.noSkills = true;
+			consumerFlags.set("no-skills", "--no-skills");
 		} else if (arg === "--skills") {
 			result.skills = takeFlagValue(args, i++, "--skills")
 				.split(",")
 				.map(s => s.trim())
 				.filter(Boolean);
+			consumerFlags.set("skills", "--skills");
 		} else if (arg === "--tools") {
 			const toolNames = takeFlagValue(args, i++, "--tools")
 				.split(",")
@@ -345,14 +355,21 @@ export function parseArgs(args: string[]): Args {
 	if (result.default && !result.mpreset) {
 		throw new CliParseError("--default requires --mpreset <name>");
 	}
-	if (
-		result.mcpConfig !== undefined &&
-		(result.mode === "acp" || result.listModels !== undefined || result.export !== undefined)
-	) {
+	if (result.mcpConfig !== undefined && (result.listModels !== undefined || result.export !== undefined)) {
 		throw new CliParseError(
 			"--mcp-config is only supported in standalone interactive, tmux, print, text, or json modes.",
 		);
 	}
 
+	CONSUMER_FLAGS_BY_ARGS.set(result, consumerFlags);
 	return result;
+}
+
+/** Reject flags whose only owners are non-local startup consumers. */
+export function assertLocalLaunchArgs(parsed: Args): void {
+	const unknown = parsed.unknownFlags.keys().next().value;
+	if (unknown) throw new CliParseError(`Unknown option: ${unknown}`);
+	for (const [name, token] of CONSUMER_FLAGS_BY_ARGS.get(parsed) ?? []) {
+		if (!launchFlagIsOwnedBy(name, "local")) throw new CliParseError(`Unknown option: ${token}`);
+	}
 }

--- a/packages/coding-agent/src/cli/root-flags.ts
+++ b/packages/coding-agent/src/cli/root-flags.ts
@@ -1,4 +1,4 @@
-import { Flags } from "@gajae-code/utils/cli";
+import { type FlagDescriptor, Flags } from "@gajae-code/utils/cli";
 
 const ROOT_THINKING_EFFORTS = ["minimal", "low", "medium", "high", "xhigh", "max"] as const;
 
@@ -66,3 +66,35 @@ export const ROOT_LAUNCH_FLAGS = {
 	}),
 	"no-title": Flags.boolean({ description: "Disable title auto-generation" }),
 };
+
+export type ConsumerLaunchFlagName = "hook" | "extension" | "no-extensions" | "no-skills" | "skills";
+
+export type LaunchFlagConsumer = "acp" | "local";
+
+/**
+ * Flags accepted only so their owning startup consumer can classify them. They
+ * deliberately stay out of root help and completion.
+ */
+export const CONSUMER_LAUNCH_FLAGS: Record<ConsumerLaunchFlagName, FlagDescriptor> = {
+	hook: Flags.string({ multiple: true }),
+	extension: Flags.string({ char: "e", multiple: true }),
+	"no-extensions": Flags.boolean(),
+	"no-skills": Flags.boolean(),
+	skills: Flags.string(),
+};
+
+/** Every flag understood by the launch argument parser, including hidden consumer-owned flags. */
+export const LAUNCH_PARSE_FLAGS = { ...ROOT_LAUNCH_FLAGS, ...CONSUMER_LAUNCH_FLAGS };
+
+/** Startup consumers that may receive a hidden launch flag. */
+export const LAUNCH_FLAG_CONSUMERS: Record<ConsumerLaunchFlagName, readonly LaunchFlagConsumer[]> = {
+	hook: ["acp"],
+	extension: ["acp"],
+	"no-extensions": ["acp"],
+	"no-skills": ["acp", "local"],
+	skills: ["acp"],
+};
+
+export function launchFlagIsOwnedBy(name: ConsumerLaunchFlagName, consumer: LaunchFlagConsumer): boolean {
+	return LAUNCH_FLAG_CONSUMERS[name].includes(consumer);
+}

--- a/packages/coding-agent/src/commands/acp.ts
+++ b/packages/coding-agent/src/commands/acp.ts
@@ -15,7 +15,7 @@ export default class Acp extends Command {
 
 	async run(): Promise<void> {
 		const { args, terminalAuth } = prepareAcpTerminalAuthArgs(this.argv);
-		const parsed = parseArgs(args);
+		const parsed = parseArgs(args, terminalAuth ? "local" : "acp");
 		if (parsed.unknownFlags.size > 0) {
 			throw new CliParseError(`Unknown ACP option: ${[...parsed.unknownFlags.keys()].join(", ")}`);
 		}

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -6,7 +6,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { APP_NAME, setProjectDir } from "@gajae-code/utils";
 import { Args, Command } from "@gajae-code/utils/cli";
-import { parseArgs } from "../cli/args";
+import { assertLocalLaunchArgs, parseArgs } from "../cli/args";
 import { ROOT_LAUNCH_FLAGS } from "../cli/root-flags";
 import { launchDefaultTmuxIfNeeded } from "../gjc-runtime/launch-tmux";
 import { type PreparedLaunchWorktree, prepareLaunchWorktree } from "../gjc-runtime/launch-worktree";
@@ -93,6 +93,7 @@ export default class Index extends Command {
 	async run(): Promise<void> {
 		const { args } = prepareAcpTerminalAuthArgs(this.argv);
 		const parsed = parseArgs([...args]);
+		if (parsed.mode !== "acp") assertLocalLaunchArgs(parsed);
 		if (parsed.help || parsed.version) {
 			await runRootCommand(parsed, args);
 			return;
@@ -110,6 +111,7 @@ export default class Index extends Command {
 			setProjectDir(launch.cwd);
 		}
 		const launchParsed = parseArgs(launch.args);
+		if (launchParsed.mode !== "acp") assertLocalLaunchArgs(launchParsed);
 		if (
 			launchDefaultTmuxIfNeeded({
 				parsed: launchParsed,

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -92,7 +92,7 @@ export default class Index extends Command {
 
 	async run(): Promise<void> {
 		const { args } = prepareAcpTerminalAuthArgs(this.argv);
-		const parsed = parseArgs([...args]);
+		const parsed = parseArgs([...args], "deferred");
 		if (parsed.mode !== "acp") assertLocalLaunchArgs(parsed);
 		if (parsed.help || parsed.version) {
 			await runRootCommand(parsed, args);
@@ -110,7 +110,7 @@ export default class Index extends Command {
 			process.chdir(launch.cwd);
 			setProjectDir(launch.cwd);
 		}
-		const launchParsed = parseArgs(launch.args);
+		const launchParsed = parseArgs(launch.args, "deferred");
 		if (launchParsed.mode !== "acp") assertLocalLaunchArgs(launchParsed);
 		if (
 			launchDefaultTmuxIfNeeded({

--- a/packages/coding-agent/src/rlm/index.ts
+++ b/packages/coding-agent/src/rlm/index.ts
@@ -262,6 +262,7 @@ export async function runRlmCommand(argv: string[]): Promise<void> {
 	const cwd = getProjectDir();
 	ensureRlmGjcSessionId();
 	const { dataPath, resumeSessionId, minSuccessfulRuns, rest } = extractRlmFlags(argv);
+	const parsed = parseArgs(rest, "local");
 	const dataContext = await loadRlmDataContext(cwd, dataPath);
 
 	const sessionId = resumeSessionId ?? generateRlmSessionId();
@@ -297,7 +298,6 @@ export async function runRlmCommand(argv: string[]): Promise<void> {
 		},
 	});
 
-	const parsed = parseArgs(rest);
 	parsed.sessionDir = paths.agentSessionDir;
 	if (resumeSessionId) {
 		parsed.continue = true;

--- a/packages/coding-agent/test/acp-startup-options.test.ts
+++ b/packages/coding-agent/test/acp-startup-options.test.ts
@@ -525,7 +525,7 @@ test("ACP fails closed for local-only startup flags while translating model and 
 });
 
 test("ACP rejects unknown flags instead of silently ignoring them", () => {
-	const parsed = parseArgs(["--mpreset", "codex-medium", "--mpresett"]);
+	const parsed = parseArgs(["--mpreset", "codex-medium", "--mpresett"], "acp");
 	expect(parsed.unknownFlags).toEqual(new Map([["--mpresett", true]]));
 	expect(() => resolveAcpStartupOptions(parsed, {})).toThrow(
 		"Unsupported under SDK-backed ACP: unknown flags: --mpresett",
@@ -533,7 +533,7 @@ test("ACP rejects unknown flags instead of silently ignoring them", () => {
 });
 
 test("ACP accepts --no-extensions and still names every unsupported discovery flag", () => {
-	const accepted = parseArgs(["--no-extensions"]);
+	const accepted = parseArgs(["--no-extensions"], "acp");
 	expect(accepted.unknownFlags.size).toBe(0);
 	expect(accepted.noExtensions).toBe(true);
 	expect(() => resolveAcpStartupOptions(accepted, {})).not.toThrow();
@@ -544,7 +544,7 @@ test("ACP accepts --no-extensions and still names every unsupported discovery fl
 		[["--skills", ",,"], "--skills"],
 		[["--skills", "git-*", "--skills", ",,"], "--skills"],
 	] as const) {
-		const parsed = parseArgs([...args]);
+		const parsed = parseArgs([...args], "acp");
 		expect(parsed.unknownFlags.size).toBe(0);
 		expect(() => resolveAcpStartupOptions(parsed, {})).toThrow(`Unsupported under SDK-backed ACP: ${expectedFlag}`);
 	}
@@ -555,11 +555,11 @@ test("ACP rejects registered extension-loading flags by name", () => {
 		["--extension", "/tmp/a.ts"],
 		["-e", "/tmp/a.ts"],
 	] as const) {
-		expect(() => resolveAcpStartupOptions(parseArgs([...args]), {})).toThrow(
+		expect(() => resolveAcpStartupOptions(parseArgs([...args], "acp"), {})).toThrow(
 			"Unsupported under SDK-backed ACP: --extension",
 		);
 	}
-	expect(() => resolveAcpStartupOptions(parseArgs(["--hook", "/tmp/a.ts"]), {})).toThrow(
+	expect(() => resolveAcpStartupOptions(parseArgs(["--hook", "/tmp/a.ts"], "acp"), {})).toThrow(
 		"Unsupported under SDK-backed ACP: --hook. Use ACP session configuration",
 	);
 });
@@ -582,6 +582,9 @@ test("ACP command maps invalid argv to typed CLI usage errors", async () => {
 			"--acp-terminal-auth only supports --mode acp",
 		);
 	}
+	await expect(new Acp(["--acp-terminal-auth", "--no-extensions"], TEST_CONFIG).run()).rejects.toThrow(
+		"Unknown option: --no-extensions",
+	);
 });
 
 test("ACP command renders usage and exits nonzero for invalid argv", async () => {

--- a/packages/coding-agent/test/cli-args-mpreset.test.ts
+++ b/packages/coding-agent/test/cli-args-mpreset.test.ts
@@ -168,13 +168,12 @@ describe("MCP config CLI args", () => {
 		}
 	});
 
-	test("rejects non-standalone config routes during parsing", () => {
-		const rejectedArgs = [
-			["--mcp-config", "/tmp/gjc-mcp.json", "--mode", "acp"],
+	test("defers ACP config validation to the ACP startup owner", () => {
+		expect(parseArgs(["--mcp-config", "/tmp/gjc-mcp.json", "--mode", "acp"]).mcpConfig).toBe("/tmp/gjc-mcp.json");
+		for (const args of [
 			["--mcp-config", "/tmp/gjc-mcp.json", "--export", "/tmp/session.jsonl"],
 			["--mcp-config", "/tmp/gjc-mcp.json", "--list-models"],
-		];
-		for (const args of rejectedArgs) {
+		]) {
 			expect(() => parseArgs(args)).toThrow(CliParseError);
 		}
 	});

--- a/packages/coding-agent/test/cli-root-flags.test.ts
+++ b/packages/coding-agent/test/cli-root-flags.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { parseArgs } from "../src/cli/args";
+import { assertLocalLaunchArgs, parseArgs } from "../src/cli/args";
 import { ROOT_LAUNCH_FLAGS } from "../src/cli/root-flags";
 import { parseLaunchWorktreeMode } from "../src/gjc-runtime/launch-worktree";
 
@@ -22,7 +22,7 @@ describe("CLI root flag parity", () => {
 			const argv = [`--${name}`];
 			if (name === "default") argv.unshift("--mpreset", "test");
 			if (descriptor.kind === "string") argv.push(descriptor.options?.[0] ?? FLAG_VALUES[name] ?? "value");
-			expect(() => parseArgs(argv)).not.toThrow();
+			expect(() => assertLocalLaunchArgs(parseArgs(argv))).not.toThrow();
 		}
 	});
 
@@ -42,14 +42,23 @@ describe("CLI root flag parity", () => {
 		]);
 	});
 
-	it("rejects retired extension and skill flags", () => {
-		for (const flag of ["--hook", "--extension", "-e", "--no-extensions", "--skills", "--no-skills"]) {
-			expect(() => parseArgs([flag])).toThrow(`Unknown option: ${flag}`);
+	it("rejects ACP-only extension and skill flags while forwarding local startup flags", () => {
+		for (const [args, expected] of [
+			[["--hook", "/tmp/hook.ts"], "--hook"],
+			[["--extension", "/tmp/extension.ts"], "--extension"],
+			[["-e", "/tmp/extension.ts"], "--extension"],
+			[["--no-extensions"], "--no-extensions"],
+			[["--skills", "git-*"], "--skills"],
+		] as const) {
+			expect(() => assertLocalLaunchArgs(parseArgs([...args]))).toThrow(`Unknown option: ${expected}`);
 		}
+		expect(() => assertLocalLaunchArgs(parseArgs(["--no-skills"]))).not.toThrow();
 	});
 
-	it("rejects unknown options while preserving dash-prefixed prompt text after --", () => {
-		expect(() => parseArgs(["--modle", "opus"])).toThrow("Unknown option: --modle");
+	it("defers unknown options to the owning startup path while preserving dash-prefixed prompt text after --", () => {
+		const unknown = parseArgs(["--modle", "opus"]);
+		expect(unknown.unknownFlags).toEqual(new Map([["--modle", true]]));
+		expect(() => assertLocalLaunchArgs(unknown)).toThrow("Unknown option: --modle");
 		expect(parseArgs(["--", "--modle", "@prompt.md"])).toMatchObject({
 			messages: ["--modle"],
 			fileArgs: ["prompt.md"],

--- a/packages/coding-agent/test/cli-root-flags.test.ts
+++ b/packages/coding-agent/test/cli-root-flags.test.ts
@@ -55,10 +55,8 @@ describe("CLI root flag parity", () => {
 		expect(() => assertLocalLaunchArgs(parseArgs(["--no-skills"]))).not.toThrow();
 	});
 
-	it("defers unknown options to the owning startup path while preserving dash-prefixed prompt text after --", () => {
-		const unknown = parseArgs(["--modle", "opus"]);
-		expect(unknown.unknownFlags).toEqual(new Map([["--modle", true]]));
-		expect(() => assertLocalLaunchArgs(unknown)).toThrow("Unknown option: --modle");
+	it("rejects unknown options by default while preserving dash-prefixed prompt text after --", () => {
+		expect(() => parseArgs(["--modle", "opus"])).toThrow("Unknown option: --modle");
 		expect(parseArgs(["--", "--modle", "@prompt.md"])).toMatchObject({
 			messages: ["--modle"],
 			fileArgs: ["prompt.md"],

--- a/packages/coding-agent/test/rlm.test.ts
+++ b/packages/coding-agent/test/rlm.test.ts
@@ -14,7 +14,12 @@ import {
 	resolveRlmArtifactPaths,
 } from "@gajae-code/coding-agent/rlm/artifacts";
 import { loadRlmDataContext } from "@gajae-code/coding-agent/rlm/data-context";
-import { buildRlmGoalObjective, createRlmPreset, ensureRlmGjcSessionId } from "@gajae-code/coding-agent/rlm/index";
+import {
+	buildRlmGoalObjective,
+	createRlmPreset,
+	ensureRlmGjcSessionId,
+	runRlmCommand,
+} from "@gajae-code/coding-agent/rlm/index";
 import { RlmNotebookWriter } from "@gajae-code/coding-agent/rlm/notebook";
 import {
 	assertRlmToolAllowlist,
@@ -54,6 +59,18 @@ const okCell = (output: string): RlmCellResult => ({
 });
 
 describe("rlm artifacts", () => {
+	describe("RLM command parsing", () => {
+		test("rejects unknown startup flags before creating research artifacts", async () => {
+			const priorSessionId = process.env.GJC_SESSION_ID;
+			try {
+				await expect(runRlmCommand(["--modle", "opus"])).rejects.toThrow("Unknown option: --modle");
+			} finally {
+				if (priorSessionId !== undefined) process.env.GJC_SESSION_ID = priorSessionId;
+				else delete process.env.GJC_SESSION_ID;
+			}
+		});
+	});
+
 	test("validates session ids", () => {
 		expect(isValidRlmSessionId("2026-06-16-abc")).toBe(true);
 		expect(isValidRlmSessionId("../escape")).toBe(false);


### PR DESCRIPTION
Fixes reopened #4023 after #4053 made root parsing reject flags before ACP and local startup could own them.

- centralizes hidden startup flag ownership separately from root help/completion descriptors
- preserves ACP typed unknown/unsupported diagnostics and real subprocess framing
- forwards local `--no-skills` / `--mcp-config` startup paths while retaining root rejection for ACP-only retired flags
- retains compact worktree, delimiter, and optional-value behavior

Verification:
- `bun --cwd=packages/coding-agent run check`
- focused root/ACP/startup/resume: 72 passing
- affected CLI/worktree/completion/ACP suites: 286 passing
- `bun --cwd=packages/coding-agent run build`