### PR TITLE
fix(session): resume maintenance continuations correctly

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Follow-up queue auto-continuation now waits for compaction and foreground bash/eval work to settle, preventing queued prompts from starting a model turn concurrently with those operations.
 - Follow-up queue submissions now defer slash/skill text during foreground bash/eval work instead of invoking a competing custom-message turn.
 - Follow-up queues now resume through a dedicated queued-message continuation after Python/Bash execution tails, avoiding an extra stale-turn replay.
+- Post-maintenance continuation now resumes the current non-assistant tail when no queued messages exist, while consuming queued steering/follow-ups only when present; overflow recovery no longer fails with `No queued messages to continue`, and accepted queued successors reset fallback accounting exactly once.
 - Streamed edit preview coalescing now keys on the complete partial-JSON payload rather than its length, so same-size in-place argument replacements recompute and render while repeated payloads remain cached.
 - CLI parsing now fails closed by default, while launch and ACP explicitly defer only their owned startup options; this preserves ACP-specific diagnostics, SDK startup forwarding, real ACP subprocess framing, and RLM typo rejection without exposing retired flags in root help or completion.
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4968,10 +4968,10 @@ export class AgentSession {
 							predecessorAccepted = true;
 							this.#releaseDeferredAgentEndLease(predecessorAgentEnd);
 						};
-						const startsQueuedSuccessor =
-							this.agent.state.messages.at(-1)?.role === "assistant" && this.agent.hasQueuedMessages();
+						const hasQueuedMessages = this.agent.hasQueuedMessages();
+						const startsQueuedSuccessor = hasQueuedMessages;
 						const continueQueued =
-							this.agent.state.messages.at(-1)?.role === "assistant"
+							this.agent.state.messages.at(-1)?.role === "assistant" || !hasQueuedMessages
 								? this.agent.continue.bind(this.agent)
 								: this.agent.continueQueuedMessages.bind(this.agent);
 						try {


### PR DESCRIPTION
## Summary
- resume the current non-assistant tail when maintenance has no queued successor
- use the queued-message-only path only when steering/follow-up input is actually queued
- reset fallback accounting when any queued successor is accepted

## Verification
- `bun test packages/coding-agent/test/agent-session-fallback-upstream-count.e2e.test.ts packages/coding-agent/test/agent-session-queued-prompts.test.ts packages/coding-agent/test/agent-session-resilient-retry.test.ts`
- `bun --cwd=packages/coding-agent run check`