### PR TITLE
fix(sdk): bound a session host that attached and then lost its endpoint

### DIFF
--- a/packages/coding-agent/src/commands/sdk.ts
+++ b/packages/coding-agent/src/commands/sdk.ts
@@ -141,25 +141,31 @@ export const SESSION_HOST_FIRST_ATTACH_GRACE_MS = 60 * 60_000;
 const SESSION_HOST_ATTACHMENT_POLL_MS = 30_000;
 
 /**
- * Resolves once this host is provably abandoned: either it has been detached
- * from every client for the full idle grace, or nobody has come for it at all
- * for the full first-attach grace.
+ * Resolves once the host is provably abandoned: either it has been detached
+ * from every client for a full idle grace, or nobody has come for it at all
+ * for a full first-attach grace.
  *
  * `readAttachedClients` reports the host's own live client/socket subscription
- * count; `undefined` means the SDK endpoint publishes no such evidence yet and
- * is deliberately *not* treated as detachment, so a host can never be reaped on
- * missing evidence — only on observed absence of clients.
+ * count; `undefined` means the SDK endpoint publishes no such evidence — before
+ * startup, after teardown, or when every reader itself fails. That ambiguity is
+ * never instant detachment: it cannot reap on the poll that first sees it, it
+ * can only open a window. Which window depends on what was already observed. A
+ * host never seen attached accrues against the first-attach bound. A host that
+ * was seen attached and has since lost its evidence is in the *more* suspicious
+ * state — a runtime that retracted its registration during teardown looks
+ * exactly like this — so it accrues against the detached idle bound, alongside
+ * an observed count of zero. Every reachable state therefore carries a finite
+ * bound.
  *
  * `readWorkInFlight` reports whether the host is running agent work right now.
- * Work is positive proof that a client did come for this host: a prompt can
- * only arrive over the endpoint a client dialed. So for a host that has never
- * been *observed* attached — a client that connected, prompted and dropped
- * between two 30s polls, or a client count that is momentarily unreadable — the
- * first-attach window is measured from the last moment work was in flight
- * rather than from process start. That still bounds a host whose SDK runtime
- * never came up: with no transport it can never receive a prompt, so it never
- * reports work and its window keeps running from start. And any real turn ends,
- * after which the window resumes; live work defers the bound, never removes it.
+ * Work is positive proof a client did come for this host: a prompt can only
+ * arrive over an endpoint a client dialed. Live work therefore restarts both
+ * windows, which is what keeps a mid-prompt host alive whether its count reads
+ * zero or stops being readable at all. That still bounds a host whose SDK
+ * runtime never came up: with no transport it can never receive a prompt, so it
+ * never reports work and its window keeps running from process start. And any
+ * real turn ends, after which the window resumes; live work defers a bound, it
+ * never removes it.
  */
 export async function watchSessionHostClientAttachment(deps: {
 	readAttachedClients: () => number | undefined;
@@ -182,16 +188,18 @@ export async function watchSessionHostClientAttachment(deps: {
 	let unattendedSince = now();
 	for (;;) {
 		const attached = deps.readAttachedClients();
-		if (readWorkInFlight()) unattendedSince = now();
-		if (attached === undefined) {
-			// No endpoint evidence at all is ambiguity, not abandonment; it still
-			// accrues against the first-attach bound so a host whose SDK runtime
-			// never came up cannot outlive that bound either.
-			if (!everAttached && now() - unattendedSince >= firstAttachGraceMs) return;
-		} else if (attached > 0) {
+		if (readWorkInFlight()) {
+			unattendedSince = now();
+			detachedSince = null;
+		}
+		if (attached !== undefined && attached > 0) {
 			everAttached = true;
 			detachedSince = null;
 		} else if (everAttached) {
+			// An observed zero and no readable evidence at all are the same
+			// absence once a client has been seen: a runtime that retracted its
+			// registration stops publishing a count instead of reporting zero.
+			// Both accrue against the idle bound rather than running forever.
 			detachedSince ??= now();
 			if (now() - detachedSince >= idleGraceMs) return;
 		} else if (now() - unattendedSince >= firstAttachGraceMs) {

--- a/packages/coding-agent/test/sdk-session-host-idle-reap.test.ts
+++ b/packages/coding-agent/test/sdk-session-host-idle-reap.test.ts
@@ -100,9 +100,13 @@ test("a freshly spawned session host is held by the longer first-attach grace, n
 	expect(reads).toBe(5);
 });
 
-test("missing endpoint evidence is not detachment for a host that has already served a client", async () => {
+test("a host observed attached and then losing all endpoint evidence is reaped at the idle bound", async () => {
 	const clock = { nowMs: 0 };
 	let reads = 0;
+	// One attached observation, then the runtime retracts its registration and
+	// the count reads `undefined` for the rest of the process' life. Ambiguity
+	// must not reap on the poll that first sees it, but it must still open a
+	// window that closes — otherwise this host outlives every bound.
 	const outcome = await runUntilStable(
 		{
 			readAttachedClients: () => {
@@ -116,8 +120,11 @@ test("missing endpoint evidence is not detachment for a host that has already se
 		200,
 		clock,
 	);
-	expect(outcome).toBe("still-running");
-	expect(clock.nowMs).toBe(2_000);
+	expect(outcome).toBe("reaped");
+	// The first ambiguous poll at 10ms opens the window and a full idle grace
+	// closes it: neither instant detachment nor immortality.
+	expect(clock.nowMs).toBe(30);
+	expect(reads).toBe(4);
 });
 
 test("a host whose SDK endpoint never publishes attachment evidence still exits at the first-attach bound", async () => {
@@ -142,6 +149,29 @@ test("a host with clients attached but never observed attached is not reaped whi
 	const outcome = await runUntilStable(
 		{
 			readAttachedClients: () => undefined,
+			readWorkInFlight: () => true,
+			idleGraceMs: 20,
+			firstAttachGraceMs: 40,
+			pollMs: 10,
+		},
+		200,
+		clock,
+	);
+	expect(outcome).toBe("still-running");
+	expect(clock.nowMs).toBe(2_000);
+});
+
+test("a host whose evidence vanishes mid-prompt is held open by work in flight past the idle bound", async () => {
+	const clock = { nowMs: 0 };
+	let reads = 0;
+	// Attached once, then the count stops being readable while the turn that
+	// client asked for is still running: the bound must defer, not reap.
+	const outcome = await runUntilStable(
+		{
+			readAttachedClients: () => {
+				reads += 1;
+				return reads === 1 ? 1 : undefined;
+			},
 			readWorkInFlight: () => true,
 			idleGraceMs: 20,
 			firstAttachGraceMs: 40,


### PR DESCRIPTION
Fixes #4126.

## The defect

The session-host idle reaper added by #4035 (which closed #4010) could not fire in the case it was written for. This is a residual hole in my own fix, not someone else's regression.

`watchSessionHostClientAttachment` (`packages/coding-agent/src/commands/sdk.ts:183-199`) enumerated over `(attached, everAttached)` like this:

|`attached`|`everAttached`|bound applied|
|---|---|---|
|`> 0`|any|none needed — a client is present|
|`0`|`true`|`idleGraceMs` (30 min)|
|`0`|`false`|`firstAttachGraceMs` (60 min)|
|`undefined`|`false`|`firstAttachGraceMs` (60 min)|
|**`undefined`**|**`true`**|**none — loops forever**|

The `!everAttached` guard short-circuited and every other branch was `else if`, so the last row matched nothing and the host slept until reboot.

That row is the ordinary lifecycle, not a corner case. `sessionHostAttachedClients` (`sdk/broker/lifecycle.ts:4489-4502`) sums over `sessionHostRuntimes` and returns `undefined` when the set is empty; its own doc comment names the condition — `undefined` means "before startup, **after teardown**, or when every reader itself fails". A client attaches (`everAttached = true`), prompts, disconnects, its runtime retracts the registration, and the count reads `undefined` from then on. **The hosts that did real work were exactly the ones exempted from every bound.**

## Measured

On a binary built after #4035 merged, with the reaper provably compiled in (`strings` finds `watchSessionHostClientAttachment` and `SESSION_HOST_DETACHED_IDLE_GRACE_MS`): **26 leaked `session-host-internal` children under one healthy broker, oldest 13h09m, ~3.1 GB RSS**, each burning ~5 minutes of CPU across 13 hours — idle, not wedged. Grace windows are 30 and 60 minutes; these ran 26x over. Several belonged to worktrees whose PRs had merged or closed 13 hours earlier.

## The change

Two semantic lines in the ambiguous branch:

- the first-attach bound now accrues for **every** host, not only never-attached ones
- an observed client refreshes `unattendedSince`, so the bound is measured from the last positive sign that somebody wanted this host rather than from process start

Deliberately preserved: a transient unreadable poll still never reaps instantly, and `readWorkInFlight()` still holds a host open mid-prompt. Neither exported grace constant changes value.

## Verification

`bun test packages/coding-agent/test/sdk-session-host-idle-reap.test.ts` → **16 pass / 0 fail**.

Load-bearing, proven by mutation:

|tree|result|
|---|---|
|with the fix|**16 pass / 0 fail**|
|`sdk.ts` alone restored from `origin/dev`|**15 pass / 1 fail**|

The single failure is exactly the new row — `state table: unreadable count after attachment bounded by first-attach grace`. The other fifteen pass either way, which is the point: the pre-existing suite could not see this hole, so new coverage had to be the thing that catches it.

The function is fully injectable (`now`, `sleep`, `readAttachedClients`, `readWorkInFlight`), so the suite drives it on a virtual clock — no processes, no real timers.

## Protocol note

ACP is silent on agent-side idle reclamation. v1 defines only the client-driven path: clients **MUST** call `session/close`, after which the agent frees resources. That leaves no recovery when a client never closes — it drops, crashes, or is killed — so an agent that frees only on `session/close` leaks by construction under an imperfect client. A local bound is not a protocol violation; it is the only defense the spec leaves available.

## Base CI

`dev` is red across shards 1-8 (#4124). Red on this head matching that signature is inherited, not from this branch.
