### PR TITLE
test(task): guard subagent provider-scope isolation instead of its absence

### DIFF
--- a/packages/coding-agent/test/task-fork-context.test.ts
+++ b/packages/coding-agent/test/task-fork-context.test.ts
@@ -440,7 +440,10 @@ describe("fork context policy surface", () => {
 
 		expect(seedBuilder).toHaveBeenCalledWith({ maxMessages: 50, maxTokens: 8000, signal: undefined });
 		expect(getOptions()?.forkContextSeed).toBe(seed);
-		expect(getOptions()?.providerSessionId).toBeUndefined();
+		const parentSessionId = parent.getSessionId?.();
+		const forkScope = getOptions()?.providerSessionId;
+		expect(forkScope).toBeDefined();
+		expect(forkScope).not.toBe(parentSessionId);
 		expect(getOptions()?.credentialSessionId).toBe("credential-pool");
 		expect(getOptions()?.providerSessionState).toBeUndefined();
 		expect(getOptions()?.toolNames).toEqual(["read"]);
@@ -449,6 +452,23 @@ describe("fork context policy surface", () => {
 			typeof systemPromptOption === "function" ? systemPromptOption(["base", "tail"]) : systemPromptOption;
 		expect(renderedPrompt?.join("\n")).toContain("executor system prompt");
 		expect(renderedPrompt?.join("\n")).toContain("forked snapshot of the parent conversation");
+
+		await executeDetached(tool, {
+			agent: "executor",
+			tasks: [
+				{
+					id: "ForkSeedSibling",
+					description: "seed",
+					assignment: "Use inherited context.",
+					inheritContext: "bounded",
+				},
+			],
+		});
+
+		const siblingScope = getOptions()?.providerSessionId;
+		expect(siblingScope).toBeDefined();
+		expect(siblingScope).not.toBe(parentSessionId);
+		expect(siblingScope).not.toBe(forkScope);
 	});
 
 	test("suppresses fork-context prompt notice for zero-message seeds", async () => {


### PR DESCRIPTION
Fixes #4132.

## What was actually wrong

I filed #4132 claiming a forked subagent inherits its parent's `providerSessionId`. **That framing was wrong and I corrected it on the issue.** There is no leak. The production code is right; the test was stale.

`c2ddfb7c1` (*fix(routing): isolate resumed subagent model stickiness*, already in `dev`) gives each subagent a composite canonical scope — `packages/coding-agent/src/task/executor.ts:120-123`:

```ts
function getSubagentCanonicalScope(parentSessionId: string | undefined, subagentId: string): string | undefined {
	if (!parentSessionId) return undefined;
	return JSON.stringify(["subagent-canonical", parentSessionId, subagentId]);
}
```

The parent session id is a **component** of the key, not the value. Siblings differ; no child equals its parent. Isolation holds. The test was still asserting the pre-`c2ddfb7c1` shape:

```ts
expect(getOptions()?.providerSessionId).toBeUndefined();   // task-fork-context.test.ts:443
```

## Why not just delete the line

The property the test was written for — *"passes a sanitized fork seed and cache identity **without sharing provider state**"* — still matters. It was just aimed at an implementation detail that changed. So the assertion is re-aimed at the invariant itself:

1. a scope exists for a forked subagent
2. it is not equal to the parent's session id — no child adopts its parent's identity
3. it is distinct per subagent — **two subagents of one parent must not collide**

Point 3 is the hazard the test's own name describes, and the old `toBeUndefined()` could not see it: sibling collision passed that assertion trivially, since a shared scope is no more "undefined" than a distinct one. The new guard is strictly stronger than what it replaces.

## Verification

`bun test packages/coding-agent/test/task-fork-context.test.ts` → **24 pass / 0 fail**, 85 `expect()` calls.

Load-bearing, proven by mutating the source to simulate each real hazard, one at a time:

|mutation of `getSubagentCanonicalScope`|meaning|result|
|---|---|---|
|return `parentSessionId` verbatim|a genuine parent-identity leak|**23 pass / 1 fail**|
|drop `subagentId` from the key|siblings share one scope|**23 pass / 1 fail**|

Both were caught. Neither would have been caught by the assertion this PR replaces. `executor.ts` was restored after each and its `git diff` is empty — production code is untouched by this PR.

## Scope

One file, +21/−1. This clears one of the two failures that keep `test:@gajae-code/coding-agent:shard-1-of-8` red on `dev`; the other is #4133 (`model-selector-action-menu-role-binding.test.ts`), filed separately since the subsystems do not overlap.
