### PR TITLE
test(tui): stub getModelProfile in the model selector registry fake

### DIFF
--- a/packages/coding-agent/test/model-selector-action-menu-role-binding.test.ts
+++ b/packages/coding-agent/test/model-selector-action-menu-role-binding.test.ts
@@ -39,6 +39,7 @@ function createSelector(
 		getProviderDiscoveryState: () => undefined,
 		getCanonicalModels: () => [],
 		resolveCanonicalModel: () => undefined,
+		getModelProfile: () => undefined,
 	} as unknown as ModelRegistry;
 	const ui = { requestRender: vi.fn(registryOptions.requestRender ?? (() => {})) } as unknown as TUI;
 


### PR DESCRIPTION
Fixes #4133.

## Diagnosis

The failing assertion is a `toContain` on a fully composed string, so three different defects produce the identical failure — a missing row, a wrong `now:` target, or a moved `(high)` suffix. I made the lane print the actual render before touching anything rather than guess.

It was none of the three in production. **The test's registry fake was behind the code it stands in for.**

`ModelSelectorComponent` reads the active profile through the registry (`packages/coding-agent/src/modes/components/model-selector.ts:536`):

```ts
const activeProfile = this.#activeModelProfile
	? this.#modelRegistry.getModelProfile(this.#activeModelProfile)
	: undefined;
```

`getModelProfile` is a real method on `ModelRegistry` (`packages/coding-agent/src/config/model-registry.ts:1867`). The test's `as unknown as ModelRegistry` fake never declared it, so with `activeModelProfile: "profile-a"` the render threw and the effective-default row never got emitted. The assertion was correct the whole time; the harness could not reach it.

The `as unknown as` cast is what let this rot silently — it turns off exactly the check that would have caught a fake missing a method the component calls.

## The change

One line, in the test's fake:

```ts
getModelProfile: () => undefined,
```

Production code is untouched.

## Verification

`bun test packages/coding-agent/test/model-selector-action-menu-role-binding.test.ts` → **15 pass / 0 fail** (was 14 pass / 1 fail).

Restoring a stub is the kind of change that can trivially produce a green test that asserts nothing, so it was mutation-checked:

|mutation|result|
|---|---|
|`#formatAssignedModelLabel` renders `provider/mutant-id`|**8 pass / 7 fail**|

The row is genuinely asserted, not merely rendered. `git diff` on `packages/coding-agent/src` is empty — the mutation was reverted.

One honest note: my first mutation attempt patched a `${model.provider}/${model.id}` template that turned out not to be on this render path, and the suite stayed green. That is worth stating, because a mutation that fails to fail proves nothing about the test — it only proves you mutated the wrong line. The result above is from the real path at `model-selector.ts:1491`.

## Scope

One file, +1. This clears the second of the two failures keeping `test:@gajae-code/coding-agent:shard-1-of-8` red on `dev`; the first is #4132, fixed by #4134.
