### PR TITLE
test(task): assert the child's credential scope, not its provider identity

### DIFF
--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -696,7 +696,7 @@ describe("runSubprocess yield reminders", () => {
 		expect(createAgentSessionSpy).toHaveBeenCalledTimes(1);
 	});
 
-	it("uses one stable child-owned identity for auth resolution and createAgentSession", async () => {
+	it("keeps child-owned provider identity separate from the parent credential scope", async () => {
 		const session = createMockSession(({ emit }) => {
 			emit({
 				type: "tool_execution_end",
@@ -717,6 +717,7 @@ describe("runSubprocess yield reminders", () => {
 			id: "3-Child",
 			subagentId: "3-Child",
 			parentSessionId: "parent-session",
+			parentCredentialSessionId: "credential-pool",
 			modelRegistry: {
 				refresh: async () => {},
 				getAvailable: () => [
@@ -744,7 +745,8 @@ describe("runSubprocess yield reminders", () => {
 		expect(createAgentSessionSpy.mock.calls[0]?.[0]?.providerSessionId).toBe(
 			JSON.stringify(["subagent-canonical", "parent-session", "3-Child"]),
 		);
-		expect(authSessionIds).toEqual([JSON.stringify(["subagent-canonical", "parent-session", "3-Child"])]);
+		expect(createAgentSessionSpy.mock.calls[0]?.[0]?.credentialSessionId).toBe("credential-pool");
+		expect(authSessionIds).toEqual(["credential-pool"]);
 	});
 
 	it("renders shared task context in subagent system prompt before now", async () => {


### PR DESCRIPTION
Fixes #4139.

## What was wrong

The test demanded that auth resolution use the subagent's **canonical provider scope**:

```ts
expect(authSessionIds).toEqual([JSON.stringify(["subagent-canonical", "parent-session", "3-Child"])]);
```

Production deliberately keeps those two identities apart (`packages/coding-agent/src/task/executor.ts:1675-1679`):

```ts
providerSessionId: canonicalChildScope,                                        // child-owned
credentialSessionId: options.parentCredentialSessionId ?? options.parentSessionId,  // shared pool
```

The split is the point. The **provider** session is child-owned so siblings cannot share model state with each other. **Credentials** resolve through the parent's pool so every child reuses one auth entry instead of re-authenticating per subagent.

The test asserted an implementation the code never promised, and has been failing on `dev` since.

## The change

The assertion now pins the contract that actually exists, and the test name says what it checks rather than what it happened to observe:

- `credentialSessionId` reaching `createAgentSession` is the parent pool
- auth resolves under that pool, not under the child's provider scope

Production untouched.

## Verification

`bun test packages/coding-agent/test/task/executor-subagent-reminders.test.ts` → **28 pass / 0 fail**.

Mutation-proven, since a renamed test with relaxed assertions is exactly the kind of change that can assert nothing:

|mutation|result|
|---|---|
|route `credentialSessionId` through the child scope instead of the parent pool|**27 pass / 1 fail**|

Source restored; `git diff` on `executor.ts` is empty.
