### PR TITLE
test(startup): give the noninteractive login fixture a session id

### DIFF
--- a/packages/coding-agent/test/startup-update-contract.test.ts
+++ b/packages/coding-agent/test/startup-update-contract.test.ts
@@ -49,9 +49,12 @@ function rootArgs(overrides: Partial<Args> = {}): Args {
 	};
 }
 
+const FAKE_SESSION_ID = "startup-update-contract-session";
+
 function fakeSessionResult(): CreateAgentSessionResult {
 	let activeModel = testModel;
 	const session = {
+		sessionId: FAKE_SESSION_ID,
 		get model() {
 			return activeModel;
 		},
@@ -802,6 +805,10 @@ describe("startup update contract", () => {
 			expect(printModeStarted).toBe(false);
 			expect(settings.get("modelProfile.default")).toBe("codex-medium");
 			expect(stderr.join("")).toContain('Model profile "codex-medium" requires credentials for: openai-codex');
+			expect(getApiKeySpy.mock.calls.map(call => [call[0], call[1]])).toContainEqual([
+				"openai-codex",
+				FAKE_SESSION_ID,
+			]);
 		} finally {
 			stderrSpy.mockRestore();
 			getApiKeySpy.mockRestore();


### PR DESCRIPTION
Fixes #4138.

## What was wrong

`startup update contract > keeps credential validation active for noninteractive login-shaped input` failed with:

```
undefined is not an object (evaluating 'sessionId.trim')
```

The fixture never supplied a `sessionId`, so credential validation crashed **in setup**, before reaching the behaviour the test exists to check. The assertion was never evaluated — this was not a contract break, it was a fixture that could not get off the ground.

## The change

The fixture now supplies a session id, and the test asserts what actually reaches `getApiKey` — provider and session id together — instead of only that it was called.

Production untouched.

## Verification

`bun test packages/coding-agent/test/startup-update-contract.test.ts` → **21 pass / 0 fail**.
