### PR TITLE
test(slash): expect provider-qualified selectors from /model assignment

### DIFF
--- a/packages/coding-agent/test/slash-commands/model.test.ts
+++ b/packages/coding-agent/test/slash-commands/model.test.ts
@@ -21,8 +21,10 @@ function createRuntime() {
 				selector: string,
 				options?: { candidates?: Array<{ provider: string; id: string }> },
 			) => (selector === "claude-sonnet" ? options?.candidates?.[0] : undefined),
+			getAvailable: () => [availableModel],
 		},
 		getAvailableModels: () => [availableModel],
+		setConfiguredModelChain: () => {},
 		async setModel(model: { provider: string; id: string }, _role: "default", _options?: unknown) {
 			this.model = model;
 		},
@@ -124,12 +126,12 @@ describe("/model batch assignments", () => {
 
 		expect(setActiveSpy).toHaveBeenCalledTimes(1);
 		expect(setActiveSpy).toHaveBeenCalledWith(undefined);
-		expect(settings.getModelRole("default")).toBe("claude-sonnet:low");
+		expect(settings.getModelRole("default")).toBe("anthropic/claude-3-5-sonnet:low");
 		expect(settings.get("task.agentModelOverrides")).toEqual({
-			executor: "claude-sonnet:low",
-			architect: "claude-sonnet:low",
-			planner: "claude-sonnet:low",
-			critic: "claude-sonnet:low",
+			executor: "anthropic/claude-3-5-sonnet:low",
+			architect: "anthropic/claude-3-5-sonnet:low",
+			planner: "anthropic/claude-3-5-sonnet:low",
+			critic: "anthropic/claude-3-5-sonnet:low",
 		});
 		expect(settings.get("modelProfile.default")).toBeUndefined();
 		expect(output).toEqual([


### PR DESCRIPTION
Fixes #4137.

## What was wrong

Two independent problems in the same fixture, both test-side:

1. **Stale expectation.** The test expected a bare selector, `claude-sonnet:low`. Persistence is provider-qualified — `formatModelSelectorValue` is handed `provider/id` (`packages/coding-agent/src/slash-commands/builtin-registry.ts:776`), so settings legitimately hold `anthropic/claude-3-5-sonnet:low`.
2. **Incomplete fake.** The registry fake lacked `getAvailable` and `setConfiguredModelChain`, so the batch assignment path could not resolve a model at all.

Production untouched.

## Verification

`bun test packages/coding-agent/test/slash-commands/model.test.ts` → **4 pass / 0 fail**.

|mutation|result|
|---|---|
|strip the provider prefix at `builtin-registry.ts:776`|**3 pass / 1 fail**|

Worth recording how that mutation was found: my first attempt patched `model-selector.ts:1113`, which also composes `provider/id` — and the suite stayed at 4 pass. That proved nothing except that I had mutated a line this test never executes. The `/model` slash path goes through `builtin-registry.ts`, and mutating there is what actually fails.

A mutation that does not fail is not evidence of a robust test. It is evidence of a mutation aimed at the wrong file.

Source restored; `git diff` on `packages/coding-agent/src` is empty.

## Not covered

Settings written by an older build carrying bare ids are not migrated or tested here. If such values exist in the wild, that is a separate question from what this fixture asserts.
