### PR TITLE
fix(tui): drop an inherited reasoning level the new model cannot serve

### DIFF
--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -2329,7 +2329,13 @@ export class ModelSelectorComponent extends Container {
 			return;
 		}
 
-		const selectedThinkingLevel = itemThinkingLevel ?? this.#getCurrentRoleThinkingLevel(role);
+		const currentThinkingLevel = this.#getCurrentRoleThinkingLevel(role);
+		const selectedThinkingLevel =
+			itemThinkingLevel ??
+			(currentThinkingLevel === ThinkingLevel.Inherit ||
+			getSelectableThinkingLevels(item.model).includes(currentThinkingLevel)
+				? currentThinkingLevel
+				: ThinkingLevel.Inherit);
 		const selectorValue = roles
 			? formatModelSelectorValue(item.selector, selectedThinkingLevel)
 			: role === "default"

--- a/packages/coding-agent/test/model-selector-batch-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-batch-thinking.test.ts
@@ -37,9 +37,16 @@ function createSelector(
 	model: Model,
 	settings: Settings,
 	onSelect: (selection: TestModelSelectorSelection) => void,
+	knownModels: readonly Model[] = [model],
+	scopedModels: ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }> = [
+		{ model, thinkingLevel: ThinkingLevel.Off },
+	],
 ): ModelSelectorComponent {
 	const modelRegistry = {
-		getAll: () => [model],
+		getAll: () => knownModels,
+		refresh: async () => {},
+		getAvailable: () => knownModels,
+		getError: () => undefined,
 		hasConfiguredProviderAuth: () => false,
 		getDiscoverableProviders: () => [],
 		getCanonicalModels: () => [],
@@ -51,7 +58,7 @@ function createSelector(
 		model,
 		settings,
 		modelRegistry,
-		[{ model, thinkingLevel: ThinkingLevel.Off }],
+		scopedModels,
 		selection => onSelect(selection as TestModelSelectorSelection),
 		() => {},
 		{},
@@ -212,5 +219,38 @@ describe("ModelSelector batch assignment thinking menu", () => {
 		const actionRendered = normalizeRenderedText(selector.render(220).join("\n"));
 		expect(actionRendered).toContain("Action for:");
 		expect(actionRendered).toContain("Set for all targets");
+	});
+	test("drops an unsupported inherited thinking level when selecting a plain model", async () => {
+		installTestTheme();
+		const previousModel = createAnthropicReasoningModel("claude-fable-5");
+		const targetModel = {
+			...previousModel,
+			id: "claude-plain",
+			name: "claude-plain",
+			reasoning: false,
+			thinking: undefined,
+		} as Model;
+		const settings = Settings.isolated({
+			"task.agentModelOverrides": { executor: `${previousModel.provider}/${previousModel.id}:xhigh` },
+		});
+		let selected: SelectionCapture | undefined;
+		const selector = createSelector(
+			targetModel,
+			settings,
+			selection => {
+				if (selection.kind === "assignment") selected = selection;
+			},
+			[targetModel, previousModel],
+			[{ model: targetModel }],
+		);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selectActionRow(selector, 1);
+		await Bun.sleep(0);
+
+		const selectedAssignment = selected;
+		if (!selectedAssignment) throw new Error("Expected executor assignment selection");
+		expect(selectedAssignment.selector).toBe("anthropic/claude-plain");
 	});
 });


### PR DESCRIPTION
Fixes the HIGH-severity half of #3847.

## Defect

`ModelSelectorComponent#handleSelect` computed the level to persist as:

```ts
const selectedThinkingLevel = itemThinkingLevel ?? this.#getCurrentRoleThinkingLevel(role);
```

`#getCurrentRoleThinkingLevel` returns `this.#roles[role]?.thinkingLevel ?? ThinkingLevel.Inherit` — the level bound to the **previously** assigned model for that role. It was never validated against the newly selected `item.model`.

So assigning a non-reasoning model to a role that previously held an `:xhigh` model persisted `anthropic/claude-plain:xhigh` through `formatModelSelectorValue` → the selection payload → `settings.setModelRole`. The runtime then clamps that separately at request time, so **disk intent and the live level disagree permanently** and neither surface tells the user which one won.

The guard directly above at `:2309-2318` only covers models that *require* an explicit choice (`requiresExplicitThinkingChoice`). The bug is the fall-through path, where no choice is demanded and the stale level is inherited unchecked.

## Fix

Validate the inherited fallback against the new model before it becomes the persisted level, reusing the existing `getSelectableThinkingLevels` helper. `ThinkingLevel.Inherit` is passed through unchanged — it is not a concrete level and needs no capability check.

The fix is at **selection time**, where the intent is formed. The runtime clamp in `thinking.ts` / `model-thinking.ts` is untouched and stays as defence in depth.

## Why not the alternatives

- *Clamp only at request time* — that is what already happens, and it is exactly what leaves disk lying about user intent.
- *Route into the explicit-choice prompt at :2312* — that guard exists for models that require a deliberate choice, not for repairing an inherited one. Reusing it would prompt on assignments the user never asked to configure.

## Verification

| run | result |
|---|---|
| `bun test packages/coding-agent/test/model-selector-batch-thinking.test.ts` | **4 pass / 0 fail** |
| mutation — restore the unvalidated fallback | **3 pass / 1 fail**, received `anthropic/claude-plain:xhigh` |
| re-apply the fix | **4 pass / 0 fail** |
| `--test-name-pattern "thinking\|reasoning"` (578 tests) | **177 pass / 0 fail** |
| `--test-name-pattern "ModelSelector"` (446 tests) | **45 pass / 0 fail** |
| `bun --cwd=packages/coding-agent run check:types` | clean |

The mutation was re-run by the reviewer against the exact committed line, not accepted from the implementing lane's self-report — earlier attempts on this component mutated lines the tests never executed.

## Still open on #3847

The MEDIUM half is **not** addressed here: the selector snapshots `getAvailable()` during an offline load and has no `refreshInBackground` completion hook, so a catalog that arrives late never repaints. That is a separate change and #3847 should stay open for it.