### PR TITLE
fix(runtime): avoid synchronous memory-pressure GC

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Memory-pressure sweeps now request asynchronous garbage collection instead of forcing a stop-the-world collection on the main event loop, preventing periodic input and rendering stalls under the opt-in memory guard.
 - Follow-up queue auto-continuation now waits for compaction and foreground bash/eval work to settle, preventing queued prompts from starting a model turn concurrently with those operations.
 - Follow-up queue submissions now defer slash/skill text during foreground bash/eval work instead of invoking a competing custom-message turn.
 - Follow-up queues now resume through a dedicated queued-message continuation after Python/Bash execution tails, avoiding an extra stale-turn replay.

--- a/packages/coding-agent/src/tools/resource-gc.ts
+++ b/packages/coding-agent/src/tools/resource-gc.ts
@@ -101,12 +101,17 @@ export interface ResourceGcDeps {
 	) => Promise<void>;
 }
 
+/** Request collection without synchronously stopping the main event loop. */
+export function requestMemoryPressureGc(): void {
+	Bun.gc(false);
+}
+
 const defaultDeps: ResourceGcDeps = {
 	now: () => Date.now(),
 	monotonicNow: () => performance.now(),
 	rssBytes: () => process.memoryUsage().rss,
 	memorySnapshot: () => sampleMemoryPressure(),
-	runGc: () => Bun.gc(true),
+	runGc: requestMemoryPressureGc,
 	logWarn: (msg, meta) => logger.warn(msg, meta),
 	listTabs: () => listTabsForGc(),
 	releaseTab: (name, policy) => releaseTabIfGcEligible(name, policy),

--- a/packages/coding-agent/test/tools/resource-gc.test.ts
+++ b/packages/coding-agent/test/tools/resource-gc.test.ts
@@ -17,6 +17,7 @@ import {
 	__setResourceGcSchedulerNowForTest,
 	type ResourceGcDeps,
 	registerResourceGcSession,
+	requestMemoryPressureGc,
 	resolveBrowserGcPolicy,
 	resolveComputerGcPolicy,
 	resolveSweepIntervalMs,
@@ -319,6 +320,14 @@ describe("resource GC controller", () => {
 		__resetResourceGcForTest();
 		vi.useRealTimers();
 		vi.restoreAllMocks();
+	});
+
+	it("requests memory-pressure GC without forcing a synchronous collection", () => {
+		const gc = vi.spyOn(Bun, "gc").mockImplementation(() => undefined);
+
+		requestMemoryPressureGc();
+
+		expect(gc).toHaveBeenCalledWith(false);
 	});
 
 	it("applies enabled memory policy to GC and sustained restart advisory telemetry", async () => {


### PR DESCRIPTION
## Summary
- request asynchronous garbage collection during memory-pressure sweeps
- avoid stop-the-world event-loop stalls from periodic resource GC
- add regression coverage for the non-forced GC contract
- document the fix in the coding-agent changelog

## Verification
- `bun test packages/coding-agent/test/tools/resource-gc.test.ts`
- `bun --cwd=packages/coding-agent run check`

## Evidence
A representative local heap probe measured `Bun.gc(true)` blocking the event loop for about 48 ms, while `Bun.gc(false)` returned in about 0.5 ms with sub-millisecond observed timer lag.