### PR TITLE
fix: correct iTerm2 Option escape verification

### DIFF
--- a/docs/macos-option-key.md
+++ b/docs/macos-option-key.md
@@ -9,7 +9,7 @@ In **Settings → Profiles → Keys → General** for the profile you use:
 - Left Option Key: `+Esc`
 - Right Option Key: `+Esc`
 
-A verified live configuration sets `Option Key Sends = 1` and `Right Option Key Sends = 1` for both the `Default` and `tmux` profiles. `+Esc` delivers `Option+Q` as `ESC q` and `Option+I` as `ESC i`.
+A verified live configuration sets `Option Key Sends = 2` and `Right Option Key Sends = 2` for both the `Default` and `tmux` profiles. iTerm2's `+Esc` setting (`OPTION_KEY_ESC = 2`) prepends ESC to Option input, delivering `Option+Q` as `ESC q` and `Option+I` as `ESC i`. Value `1` is Meta mode and is not an ESC prefix.
 
 In **Settings → Profiles → Keys → Key Mappings**, remove any `Send Text`, `Send Escape Sequence`, or other mappings that intercept `Option+Q` or `Option+I`, then open a new session for each profile after changing settings.
 

--- a/scripts/_plist-helpers.ts
+++ b/scripts/_plist-helpers.ts
@@ -1,0 +1,55 @@
+/**
+ * Minimal plist writer for hermetic tests.
+ *
+ * The verifier script reads plists via Python's `plistlib.load`, which
+ * transparently handles both binary and XML formats. We emit XML plists
+ * (the simpler, human-readable format) so fixtures are inspectable and
+ * require no native binary serializer.
+ */
+import * as fs from "node:fs";
+
+function escapeXml(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;");
+}
+
+function isPlistDict(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function plistValueXml(value: unknown, indent: number): string {
+	const pad = "\t".repeat(indent);
+	if (typeof value === "string") {
+		return `${pad}<string>${escapeXml(value)}</string>`;
+	}
+	if (typeof value === "number") {
+		if (Number.isInteger(value)) {
+			return `${pad}<integer>${value}</integer>`;
+		}
+		return `${pad}<real>${value}</real>`;
+	}
+	if (typeof value === "boolean") {
+		return `${pad}<${value ? "true" : "false"}/>`;
+	}
+	if (Array.isArray(value)) {
+		const items = value.map((v) => plistValueXml(v, indent + 1));
+		return `${pad}<array>\n${items.join("\n")}\n${pad}</array>`;
+	}
+	if (isPlistDict(value)) {
+		const entries = Object.entries(value).map(([k, v]) => {
+			return `${pad}\t<key>${escapeXml(k)}</key>\n${plistValueXml(v, indent + 1)}`;
+		});
+		return `${pad}<dict>\n${entries.join("\n")}\n${pad}</dict>`;
+	}
+	throw new Error(`Unsupported plist value type: ${typeof value}`);
+}
+
+/** Write `data` as an XML plist to `filePath`. */
+export function write(filePath: string, data: Record<string, unknown>): void {
+	const body = plistValueXml(data, 0);
+	const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n${body}\n</plist>\n`;
+	fs.writeFileSync(filePath, xml);
+}

--- a/scripts/verify-option-key.sh
+++ b/scripts/verify-option-key.sh
@@ -53,9 +53,18 @@ def check_iterm(prefs, emit):
         return False
     profiles = prefs.get("New Bookmarks", [])
     required = {"Default", "tmux"}
-    by_name = {profile.get("Name"): profile for profile in profiles}
+    by_name = {}
+    duplicate_names = []
+    for profile in profiles:
+        name = profile.get("Name")
+        if name in required:
+            if name in by_name:
+                duplicate_names.append(name)
+            else:
+                by_name[name] = profile
     missing = sorted(required - by_name.keys())
     problems = [f"required iTerm2 profiles are missing: {', '.join(missing)}"] if missing else []
+    problems.extend(f"duplicate iTerm2 profile name: {name}" for name in sorted(set(duplicate_names)))
 
     # iTerm2 key maps may encode letter keys as physical macOS keycodes (Q=12, I=34)
     # or as character codes (q=0x71, i=0x69). Option is 0x80000.
@@ -68,8 +77,8 @@ def check_iterm(prefs, emit):
             right = profile.get("Right Option Key Sends")
             if emit:
                 print(f"iTerm2 profile {name}: left={left}, right={right}")
-            if left != 1 or right != 1:
-                problems.append(f"{name}: Option keys are not +Esc")
+            if left != 2 or right != 2:
+                problems.append(f"{name}: Option keys are not +Esc (expected 2)")
             keyboard_map = profile.get("Keyboard Map", {}) or {}
             for map_key, mapping in keyboard_map.items():
                 mapping = mapping if isinstance(mapping, dict) else {}
@@ -90,7 +99,7 @@ def check_iterm(prefs, emit):
         if problems:
             print("FAIL: " + "; ".join(problems))
         else:
-            print("PASS: iTerm2 Default and tmux send both Option keys as +Esc with no Option+Q/I overrides")
+            print("PASS: iTerm2 Default and tmux send both Option keys as +Esc (value 2) with no Option+Q/I overrides")
     return not problems
 
 

--- a/scripts/verify-option-key.test.ts
+++ b/scripts/verify-option-key.test.ts
@@ -1,0 +1,406 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as plistlib from "./_plist-helpers";
+
+const repoRoot = path.join(import.meta.dir, "..");
+const scriptPath = path.join(repoRoot, "scripts", "verify-option-key.sh");
+
+const tempRoots: string[] = [];
+
+function makeExecutable(file: string, content: string): void {
+	fs.writeFileSync(file, content);
+	fs.chmodSync(file, 0o755);
+}
+
+function makeSandbox(): { root: string; binDir: string } {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-option-key-test-"));
+	tempRoots.push(root);
+	const binDir = path.join(root, "bin");
+	fs.mkdirSync(binDir, { recursive: true });
+	return { root, binDir };
+}
+
+/**
+ * Write a stub `defaults` command that serves pre-built plist files
+ * based on the domain argument.
+ *
+ * The stub imitates `defaults export <domain> <output-path>`:
+ * it copies the matching fixture plist to the output path and exits 0,
+ * or exits 1 if no fixture is registered for the domain.
+ */
+function writeDefaultsStub(
+	binDir: string,
+	fixtures: { iterm?: string; terminal?: string; input?: string; itermFail?: boolean },
+): void {
+	const lines = ["#!/bin/sh", 'domain="$2"', 'output="$3"', ""];
+	if (fixtures.iterm !== undefined) {
+		lines.push(
+			`if [ "$domain" = "com.googlecode.iterm2" ]; then`,
+			`  ${fixtures.itermFail ? "exit 1" : `cp "${fixtures.iterm}" "$output"`}`,
+			`  exit 0`,
+			`fi`,
+		);
+	} else {
+		lines.push(
+			`if [ "$domain" = "com.googlecode.iterm2" ]; then exit 1; fi`,
+		);
+	}
+	if (fixtures.terminal !== undefined) {
+		lines.push(
+			`if [ "$domain" = "com.apple.Terminal" ]; then`,
+			`  cp "${fixtures.terminal}" "$output"`,
+			`  exit 0`,
+			`fi`,
+		);
+	} else {
+		lines.push(`if [ "$domain" = "com.apple.Terminal" ]; then exit 1; fi`);
+	}
+	if (fixtures.input !== undefined) {
+		lines.push(
+			`if [ "$domain" = "com.apple.HIToolbox" ]; then`,
+			`  cp "${fixtures.input}" "$output"`,
+			`  exit 0`,
+			`fi`,
+		);
+	} else {
+		lines.push(`if [ "$domain" = "com.apple.HIToolbox" ]; then exit 1; fi`);
+	}
+	lines.push('echo "unknown domain: $domain" >&2', "exit 1");
+	makeExecutable(path.join(binDir, "defaults"), lines.join("\n"));
+}
+
+function writeBunStub(binDir: string): void {
+	makeExecutable(
+		path.join(binDir, "bun"),
+		'#!/bin/sh\nif [ "$1" = "--version" ]; then echo "1.3.14"; exit 0; fi\nexit 0\n',
+	);
+}
+
+function writeGjcStub(binDir: string): void {
+	makeExecutable(
+		path.join(binDir, "gjc"),
+		'#!/bin/sh\ncase "$1" in\n  --version) echo "gjc/0.12.16"; exit 0;;\n  --smoke-test) exit 0;;\nesac\nexit 0\n',
+	);
+}
+
+interface RunResult {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+}
+
+async function runScript(
+	binDir: string,
+	envOverrides?: Record<string, string>,
+): Promise<RunResult> {
+	const proc = Bun.spawn(["sh", scriptPath], {
+		env: {
+			...process.env,
+			PATH: `${binDir}:/usr/bin:/bin`,
+			...envOverrides,
+		},
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	return { exitCode, stdout, stderr };
+}
+
+/** Build a valid iTerm2 plist with the given profiles. */
+function writeItermFixture(
+	root: string,
+	profiles: Array<{
+		name: string;
+		leftOption: number;
+		rightOption: number;
+		keyboardMap?: Record<string, { Keycode: number; Modifiers: number }>;
+	}>,
+): string {
+	const filePath = path.join(root, "iterm.plist");
+	const bookmarks = profiles.map((p) => ({
+		Name: p.name,
+		"Option Key Sends": p.leftOption,
+		"Right Option Key Sends": p.rightOption,
+		"Keyboard Map": p.keyboardMap ?? {},
+	}));
+	plistlib.write(filePath, { "New Bookmarks": bookmarks });
+	return filePath;
+}
+
+function writeTerminalFixture(
+	root: string,
+	profileName: string,
+	useOptionAsMetaKey: boolean,
+): string {
+	const filePath = path.join(root, "terminal.plist");
+	plistlib.write(filePath, {
+		"Default Window Settings": profileName,
+		"Startup Window Settings": profileName,
+		"Window Settings": {
+			[profileName]: { useOptionAsMetaKey },
+		},
+	});
+	return filePath;
+}
+
+function writeInputFixture(root: string): string {
+	const filePath = path.join(root, "input.plist");
+	plistlib.write(filePath, {
+		AppleCurrentKeyboardLayoutInputSourceID: "com.apple.keylayout.ABC",
+		AppleSelectedInputSources: [
+			{ InputSourceKind: "Keyboard Layout", "KeyboardLayout Name": "ABC" },
+		],
+	});
+	return filePath;
+}
+
+afterEach(() => {
+	for (const root of tempRoots) {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+	tempRoots.length = 0;
+});
+
+describe("verify-option-key.sh", () => {
+	describe("iTerm2 value 2 (OPT_ESC) passes", () => {
+		test("both Default and tmux profiles with value 2 pass", async () => {
+			const { root, binDir } = makeSandbox();
+			const itermFix = writeItermFixture(root, [
+				{ name: "Default", leftOption: 2, rightOption: 2 },
+				{ name: "tmux", leftOption: 2, rightOption: 2 },
+			]);
+			const inputFix = writeInputFixture(root);
+			writeDefaultsStub(binDir, { iterm: itermFix, input: inputFix });
+			writeBunStub(binDir);
+			writeGjcStub(binDir);
+
+			const result = await runScript(binDir, { TERM_PROGRAM: "iTerm.app" });
+
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout).toContain("PASS");
+			expect(result.stdout).toContain("value 2");
+		});
+	});
+
+	describe("iTerm2 value 1 (OPT_META) fails", () => {
+		test("value 1 for left option fails with exit 1", async () => {
+			const { root, binDir } = makeSandbox();
+			const itermFix = writeItermFixture(root, [
+				{ name: "Default", leftOption: 1, rightOption: 2 },
+				{ name: "tmux", leftOption: 2, rightOption: 2 },
+			]);
+			const inputFix = writeInputFixture(root);
+			writeDefaultsStub(binDir, { iterm: itermFix, input: inputFix });
+			writeBunStub(binDir);
+			writeGjcStub(binDir);
+
+			const result = await runScript(binDir, { TERM_PROGRAM: "iTerm.app" });
+
+			expect(result.exitCode).toBe(1);
+			expect(result.stdout).toContain("FAIL");
+			expect(result.stdout).toContain("expected 2");
+		});
+
+		test("value 1 for right option fails with exit 1", async () => {
+			const { root, binDir } = makeSandbox();
+			const itermFix = writeItermFixture(root, [
+				{ name: "Default", leftOption: 2, rightOption: 2 },
+				{ name: "tmux", leftOption: 2, rightOption: 1 },
+			]);
+			const inputFix = writeInputFixture(root);
+			writeDefaultsStub(binDir, { iterm: itermFix, input: inputFix });
+			writeBunStub(binDir);
+			writeGjcStub(binDir);
+
+			const result = await runScript(binDir, { TERM_PROGRAM: "iTerm.app" });
+
+			expect(result.exitCode).toBe(1);
+			expect(result.stdout).toContain("FAIL");
+			expect(result.stdout).toContain("expected 2");
+		});
+	});
+
+	describe("duplicate Default/tmux profiles fail", () => {
+		test("duplicate Default profile name fails with exit 1", async () => {
+			const { root, binDir } = makeSandbox();
+			const itermFix = writeItermFixture(root, [
+				{ name: "Default", leftOption: 2, rightOption: 2 },
+				{ name: "Default", leftOption: 2, rightOption: 2 },
+				{ name: "tmux", leftOption: 2, rightOption: 2 },
+			]);
+			const inputFix = writeInputFixture(root);
+			writeDefaultsStub(binDir, { iterm: itermFix, input: inputFix });
+			writeBunStub(binDir);
+			writeGjcStub(binDir);
+
+			const result = await runScript(binDir, { TERM_PROGRAM: "iTerm.app" });
+
+			expect(result.exitCode).toBe(1);
+			expect(result.stdout).toContain("FAIL");
+			expect(result.stdout).toContain("duplicate");
+		});
+
+		test("duplicate tmux profile name fails with exit 1", async () => {
+			const { root, binDir } = makeSandbox();
+			const itermFix = writeItermFixture(root, [
+				{ name: "Default", leftOption: 2, rightOption: 2 },
+				{ name: "tmux", leftOption: 2, rightOption: 2 },
+				{ name: "tmux", leftOption: 2, rightOption: 2 },
+			]);
+			const inputFix = writeInputFixture(root);
+			writeDefaultsStub(binDir, { iterm: itermFix, input: inputFix });
+			writeBunStub(binDir);
+			writeGjcStub(binDir);
+
+			const result = await runScript(binDir, { TERM_PROGRAM: "iTerm.app" });
+
+			expect(result.exitCode).toBe(1);
+			expect(result.stdout).toContain("FAIL");
+			expect(result.stdout).toContain("duplicate");
+		});
+	});
+
+	describe("physical-keycode Option+Q/I mappings fail", () => {
+		test("Option+Q physical keycode 0x0c with Option mask fails", async () => {
+			const { root, binDir } = makeSandbox();
+			const itermFix = writeItermFixture(root, [
+				{
+					name: "Default",
+					leftOption: 2,
+					rightOption: 2,
+					keyboardMap: {
+						"0xc-80000": { Keycode: 0x0c, Modifiers: 0x80000 },
+					},
+				},
+				{ name: "tmux", leftOption: 2, rightOption: 2 },
+			]);
+			const inputFix = writeInputFixture(root);
+			writeDefaultsStub(binDir, { iterm: itermFix, input: inputFix });
+			writeBunStub(binDir);
+			writeGjcStub(binDir);
+
+			const result = await runScript(binDir, { TERM_PROGRAM: "iTerm.app" });
+
+			expect(result.exitCode).toBe(1);
+			expect(result.stdout).toContain("FAIL");
+			expect(result.stdout).toContain("Option+Q");
+		});
+
+		test("Option+I physical keycode 0x22 with Option mask fails", async () => {
+			const { root, binDir } = makeSandbox();
+			const itermFix = writeItermFixture(root, [
+				{ name: "Default", leftOption: 2, rightOption: 2 },
+				{
+					name: "tmux",
+					leftOption: 2,
+					rightOption: 2,
+					keyboardMap: {
+						"0x22-80000": { Keycode: 0x22, Modifiers: 0x80000 },
+					},
+				},
+			]);
+			const inputFix = writeInputFixture(root);
+			writeDefaultsStub(binDir, { iterm: itermFix, input: inputFix });
+			writeBunStub(binDir);
+			writeGjcStub(binDir);
+
+			const result = await runScript(binDir, { TERM_PROGRAM: "iTerm.app" });
+
+			expect(result.exitCode).toBe(1);
+			expect(result.stdout).toContain("FAIL");
+			expect(result.stdout).toContain("Option+I");
+		});
+	});
+
+	describe("character-code Option+Q/I mappings fail", () => {
+		test("Option+Q character code 0x71 with Option mask fails", async () => {
+			const { root, binDir } = makeSandbox();
+			const itermFix = writeItermFixture(root, [
+				{
+					name: "Default",
+					leftOption: 2,
+					rightOption: 2,
+					keyboardMap: {
+						"0x71-80000": { Keycode: 0x71, Modifiers: 0x80000 },
+					},
+				},
+				{ name: "tmux", leftOption: 2, rightOption: 2 },
+			]);
+			const inputFix = writeInputFixture(root);
+			writeDefaultsStub(binDir, { iterm: itermFix, input: inputFix });
+			writeBunStub(binDir);
+			writeGjcStub(binDir);
+
+			const result = await runScript(binDir, { TERM_PROGRAM: "iTerm.app" });
+
+			expect(result.exitCode).toBe(1);
+			expect(result.stdout).toContain("FAIL");
+			expect(result.stdout).toContain("Option+Q");
+		});
+
+		test("Option+I character code 0x69 with Option mask fails", async () => {
+			const { root, binDir } = makeSandbox();
+			const itermFix = writeItermFixture(root, [
+				{ name: "Default", leftOption: 2, rightOption: 2 },
+				{
+					name: "tmux",
+					leftOption: 2,
+					rightOption: 2,
+					keyboardMap: {
+						"0x69-80000": { Keycode: 0x69, Modifiers: 0x80000 },
+					},
+				},
+			]);
+			const inputFix = writeInputFixture(root);
+			writeDefaultsStub(binDir, { iterm: itermFix, input: inputFix });
+			writeBunStub(binDir);
+			writeGjcStub(binDir);
+
+			const result = await runScript(binDir, { TERM_PROGRAM: "iTerm.app" });
+
+			expect(result.exitCode).toBe(1);
+			expect(result.stdout).toContain("FAIL");
+			expect(result.stdout).toContain("Option+I");
+		});
+	});
+
+	describe("non-Darwin execution fails", () => {
+		test("missing defaults command fails with exit 1", async () => {
+			const { root, binDir } = makeSandbox();
+			// Do NOT write a defaults stub — only bun and gjc
+			writeBunStub(binDir);
+			writeGjcStub(binDir);
+
+			const result = await runScript(binDir, { TERM_PROGRAM: "iTerm.app" });
+
+			expect(result.exitCode).toBe(1);
+			expect(result.stderr).toContain("defaults");
+		});
+	});
+
+	describe("Terminal.app fallback", () => {
+		test("Terminal.app with useOptionAsMetaKey=true passes when iTerm absent", async () => {
+			const { root, binDir } = makeSandbox();
+			const terminalFix = writeTerminalFixture(root, "Basic", true);
+			const inputFix = writeInputFixture(root);
+			writeDefaultsStub(binDir, {
+				itermFail: true,
+				terminal: terminalFix,
+				input: inputFix,
+			});
+			writeBunStub(binDir);
+			writeGjcStub(binDir);
+
+			const result = await runScript(binDir, { TERM_PROGRAM: "Apple_Terminal" });
+
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout).toContain("PASS");
+		});
+	});
+});


### PR DESCRIPTION
Fix: correct iTerm2 Option escape verification (OPT_ESC=2 not OPT_META=1) + hermetic black-box test

## Changes
- **scripts/verify-option-key.sh**: Option Key Sends check changed from value 1 (OPT_META) to value 2 (OPT_ESC). Adds duplicate-profile-name rejection. Updates PASS message.
- **docs/macos-option-key.md**: Fixes line 12 from = 1 to = 2 with OPT_ESC explanation.
- **scripts/verify-option-key.test.ts + _plist-helpers.ts**: Hermetic black-box test (11 tests) with synthetic plists and stubbed commands.

## Test coverage
value 2 passes, value 1 fails, duplicate Default/tmux fails, physical+character keycode Option+Q/I conflicts fail, non-Darwin fails, Terminal.app fallback passes.

sh -n scripts/verify-option-key.sh && bun test scripts/verify-option-key.test.ts → 11 pass

This resolves the review blocker from @probepark: corrected verifier semantics now has a black-box regression test reproducible from the tree.

— *[repo owner's gaebal-gajae (clawdbot) 🦞]*