### PR TITLE
fix(notify): report a generation-skewed daemon as unhealthy

### DIFF
--- a/packages/coding-agent/src/sdk/bus/notification-service.ts
+++ b/packages/coding-agent/src/sdk/bus/notification-service.ts
@@ -877,6 +877,19 @@ export async function checkNotificationHealth(opts: HealthOptions): Promise<Noti
 				level: "warn",
 				detail: "a live daemon owns a different bot token or chat id",
 			});
+		} else if (telegramConfigured && !daemon.stopped && daemon.generationRelation !== "current") {
+			// Liveness is not serviceability. `isCurrentCompatibleOwner` refuses to attach
+			// a session to an owner whose generation is not this build's, and
+			// `acquireDaemonOwnership` then answers `provisional`, which `ensureTelegramDaemonRunning`
+			// reports as `blocked_identity`: no transport is ever attached and no
+			// notification is ever published, while the owner keeps heartbeating. Reporting
+			// that as OK is what makes the outage invisible; the generation is inventory
+			// metadata that never forces a reload on its own, so the operator has to.
+			checks.push({
+				name: "daemon",
+				level: "warn",
+				detail: `daemon pid ${daemon.pid} serves generation ${daemon.generation ?? "unknown"} but this build attaches only to generation ${daemon.currentGeneration}; it cannot attach a session transport — run \`gjc daemon reload\``,
+			});
 		} else {
 			checks.push({ name: "daemon", level: "ok", detail: `daemon pid ${daemon.pid} alive with a fresh heartbeat` });
 		}

--- a/packages/coding-agent/test/notifications-service.test.ts
+++ b/packages/coding-agent/test/notifications-service.test.ts
@@ -21,7 +21,9 @@ import {
 	sendNotificationTest,
 	writeNotificationDiagnostic,
 } from "../src/sdk/bus/notification-service";
-import { DAEMON_GENERATION } from "../src/sdk/bus/telegram-daemon-contract";
+import type { DaemonState } from "../src/sdk/bus/telegram-daemon";
+import { isCurrentCompatibleOwner, isFreshLiveOwner } from "../src/sdk/bus/telegram-daemon";
+import { DAEMON_GENERATION, SERVING_EPOCH } from "../src/sdk/bus/telegram-daemon-contract";
 
 const TOKEN = "1234567890:ABCDEFghijkLmnOpQrsTuvWxYz012345678";
 
@@ -380,7 +382,7 @@ describe("notification-service health", () => {
 
 	test("stays clean when the live daemon reports at least one attached endpoint", async () => {
 		const { fs } = mockFs({
-			[statePath]: daemonStateJson({ pid: 1000, heartbeatAt: 1_490 }),
+			[statePath]: daemonStateJson({ pid: 1000, heartbeatAt: 1_490, generation: DAEMON_GENERATION }),
 			[heartbeatPath]: JSON.stringify({ ...ownerSidecarTag, heartbeatAt: 1_490, attachedEndpoints: 1 }),
 			[path.join(attachStateRoot, "sdk", "session-a.json")]: attachEndpoint,
 		});
@@ -396,7 +398,7 @@ describe("notification-service health", () => {
 
 	test("treats a sidecar without an attachment count as unknown rather than zero", async () => {
 		const { fs } = mockFs({
-			[statePath]: daemonStateJson({ pid: 1000, heartbeatAt: 1_490 }),
+			[statePath]: daemonStateJson({ pid: 1000, heartbeatAt: 1_490, generation: DAEMON_GENERATION }),
 			[heartbeatPath]: JSON.stringify({ ...ownerSidecarTag, heartbeatAt: 1_490 }),
 			[path.join(attachStateRoot, "sdk", "session-a.json")]: attachEndpoint,
 		});
@@ -408,6 +410,63 @@ describe("notification-service health", () => {
 		expect(report.daemon.attachedEndpoints).toBeUndefined();
 		expect(report.checks.some(check => check.name === "endpoint_attachment")).toBe(false);
 		expect(report.overall).toBe("ok");
+	});
+
+	test("flags a live daemon whose generation this build refuses to attach a transport to", async () => {
+		const servedGeneration = DAEMON_GENERATION - 1;
+		const stateJson = daemonStateJson({
+			pid: 1000,
+			heartbeatAt: 1_490,
+			generation: servedGeneration,
+			ownershipPhase: "ready",
+			servingEpoch: SERVING_EPOCH,
+		});
+		const attachInput = {
+			state: JSON.parse(stateJson) as DaemonState,
+			now: 1_500,
+			tokenFingerprint: tokenFingerprint(TOKEN),
+			chatId: "12345",
+			pidAlive: (pid: number) => pid === 1000,
+			pidIncarnation: () => "linux:100",
+		};
+		// The runtime's own predicates are what make this owner undeliverable: it is a
+		// fresh live owner, so nothing replaces it, but it is not a current compatible
+		// owner, so `acquireDaemonOwnership` answers `provisional` and no session ever
+		// binds a transport. The generation is the sole discriminator between the two.
+		expect(isFreshLiveOwner(attachInput)).toBe(true);
+		expect(isCurrentCompatibleOwner(attachInput)).toBe(false);
+		expect(
+			isCurrentCompatibleOwner({
+				...attachInput,
+				state: { ...attachInput.state, generation: DAEMON_GENERATION },
+			}),
+		).toBe(true);
+
+		const { fs } = mockFs({
+			[statePath]: stateJson,
+			[heartbeatPath]: JSON.stringify({ ...ownerSidecarTag, heartbeatAt: 1_490 }),
+			[path.join(attachStateRoot, "sdk", "session-a.json")]: attachEndpoint,
+		});
+		const report = await checkNotificationHealth({
+			settings,
+			stateRoot: attachStateRoot,
+			deps: { fs, now: () => 1_500, pidAlive: pid => pid === 1000 },
+		});
+		// Every other signal is green: the process is alive, the heartbeat is fresh, the
+		// identity matches, a live endpoint file is registered, and an owner older than
+		// generation 59 publishes no attachment count, so #4128's detector stays silent.
+		expect(report.daemon.alive).toBe(true);
+		expect(report.daemon.heartbeatFresh).toBe(true);
+		expect(report.daemon.identityMatches).toBe(true);
+		expect(report.endpoints.live).toBe(1);
+		expect(report.daemon.attachedEndpoints).toBeUndefined();
+		expect(report.checks.some(check => check.name === "endpoint_attachment")).toBe(false);
+		expect(report.checks.find(check => check.name === "daemon")).toEqual({
+			name: "daemon",
+			level: "warn",
+			detail: `daemon pid 1000 serves generation ${servedGeneration} but this build attaches only to generation ${DAEMON_GENERATION}; it cannot attach a session transport — run \`gjc daemon reload\``,
+		});
+		expect(report.overall).toBe("warn");
 	});
 
 	test("keeps the no-endpoint-file hint and skips the attachment warn when nothing is registered", async () => {


### PR DESCRIPTION
Fixes the diagnosability half of #4052 — "Telegram notifications fail despite healthy daemon after 0.12.16".

## The defect

`checkNotificationHealth` treated a live heartbeat as proof of service. It is not.

When a running daemon's generation is not this build's:

1. `isCurrentCompatibleOwner` refuses to attach a session to that owner
2. `acquireDaemonOwnership` answers `provisional`
3. `ensureTelegramDaemonRunning` reports `blocked_identity`
4. **no transport is ever attached and no notification is ever published**

Meanwhile the owner keeps heartbeating, so health reported `ok — daemon pid N alive with a fresh heartbeat`. That is precisely the reported symptom: notifications silently dead, daemon confidently healthy. The health check answered "is the process alive" when the operator was asking "will my notifications arrive".

## The fix

Health now detects generation skew and names both the cause and the remedy, instead of falling through to the `ok` branch. `packages/coding-agent/src/sdk/bus/notification-service.ts:880-892`.

## What this deliberately does not do

It does **not** auto-reload a skewed daemon. `telegram-daemon-contract.ts:9-12` documents that a generation bump is inventory metadata and does not force a live reload; inverting that is a product decision, not a bug fix, and it would land inside #4117's file. So the outage becomes *visible* and the operator gets `gjc daemon reload` — the daemon still does not self-heal. That limitation is stated in the commit's `Not-tested` trailer rather than hidden.

## Verification

| run | result |
|---|---|
| `bun test packages/coding-agent/test/notifications-service.test.ts` | **60 pass / 0 fail** |
| mutation — delete the skew branch, keep the test | **59 pass / 1 fail** (`flags a live daemon whose generation this build refuses to attach a transport to`) |
| re-apply | **60 pass / 0 fail** |
| `bun --cwd=packages/coding-agent run check:types` | clean |
| preflight (head contains `origin/dev` `135ae3e2c`) | PASS |

The mutation was run by me against the committed branch, not taken from the implementing lane's self-report.

## Generation guard

No bump needed. The change is in `notification-service.ts`, not under `sdk/bus/telegram-*`, and `checkNotificationHealth` is not in that file's 11-symbol allowlist — `daemonGenerationRelation` is consumed byte-identically, so no manifest hash moves.