### PR TITLE
fix(tui): repaint the model selector when a background refresh lands

### DIFF
--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1222,6 +1222,7 @@ interface ModelManagerDiscoveryOptions {
  */
 export class ModelRegistry {
 	#models: Model<Api>[] = [];
+	#catalogChangeListeners: Set<() => void> = new Set();
 	#canonicalIndex: CanonicalModelIndex = {
 		records: [],
 		byId: new Map(),
@@ -1298,6 +1299,13 @@ export class ModelRegistry {
 		this.authStorage.onGenerationChanged(() => this.#invalidateAvailableModels());
 		// Load models synchronously in constructor
 		this.#loadModels();
+	}
+
+	onCatalogChanged(listener: () => void): () => void {
+		this.#catalogChangeListeners.add(listener);
+		return () => {
+			this.#catalogChangeListeners.delete(listener);
+		};
 	}
 
 	/**
@@ -3249,6 +3257,7 @@ export class ModelRegistry {
 		}
 		this.#canonicalIndex = buildCanonicalModelIndex(this.#models, this.#equivalenceConfig);
 		this.#invalidateAvailableModels();
+		this.#notifyCatalogChanged();
 		this.#rebuildPending = false;
 	}
 
@@ -3256,6 +3265,16 @@ export class ModelRegistry {
 		this.#availableModelsCache = undefined;
 		this.#availableModelsDisabledProviders = undefined;
 		this.#availableModelsEnvFingerprint = undefined;
+	}
+
+	#notifyCatalogChanged(): void {
+		for (const listener of [...this.#catalogChangeListeners]) {
+			try {
+				listener();
+			} catch (error) {
+				logger.debug("ModelRegistry catalog listener failed", { error: String(error) });
+			}
+		}
 	}
 
 	#suspendRebuild(): void {
@@ -3270,6 +3289,7 @@ export class ModelRegistry {
 			this.#rebuildPending = false;
 			this.#canonicalIndex = buildCanonicalModelIndex(this.#models, this.#equivalenceConfig);
 			this.#invalidateAvailableModels();
+			this.#notifyCatalogChanged();
 		}
 	}
 

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -378,6 +378,8 @@ export class ModelSelectorComponent extends Container {
 	#selectedThinkingIndex: number = 0;
 	#assignmentState: "idle" | "assigning" = "idle";
 	#closeAfterAssignment = false;
+	#unsubscribeCatalogChanged: () => void = () => {};
+	#disposed = false;
 
 	// Preset landing state
 	#viewMode: ModelSelectorViewMode = "presets";
@@ -482,6 +484,13 @@ export class ModelSelectorComponent extends Container {
 		// Add bottom border
 		this.addChild(new DynamicBorder());
 
+		if (typeof this.#modelRegistry.onCatalogChanged === "function") {
+			this.#unsubscribeCatalogChanged = this.#modelRegistry.onCatalogChanged(() => {
+				if (this.#disposed) return;
+				if (this.#refreshCatalogView()) this.#tui.requestRender();
+			});
+		}
+
 		// Load models and do initial render
 		this.#loadModels().then(() => {
 			this.#buildProviderTabs();
@@ -505,6 +514,13 @@ export class ModelSelectorComponent extends Container {
 			// Request re-render after models are loaded
 			this.#tui.requestRender();
 		});
+	}
+
+	override dispose(): void {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		this.#unsubscribeCatalogChanged();
+		super.dispose();
 	}
 
 	#isActiveDefaultFallback(): boolean {

--- a/packages/coding-agent/test/model-selector-batch-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-batch-thinking.test.ts
@@ -1,11 +1,16 @@
 import { beforeAll, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { ThinkingLevel } from "@gajae-code/agent-core";
 import { Effort, type Model } from "@gajae-code/ai";
-import type { GjcModelAssignmentTargetId, ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { type GjcModelAssignmentTargetId, ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { ModelSelectorComponent } from "@gajae-code/coding-agent/modes/components/model-selector";
 import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import type { TUI } from "@gajae-code/tui";
+import { hookFetch } from "@gajae-code/utils";
 
 const DOWN = "\x1b[B";
 
@@ -47,6 +52,7 @@ function createSelector(
 		refresh: async () => {},
 		getAvailable: () => knownModels,
 		getError: () => undefined,
+		onCatalogChanged: () => () => {},
 		hasConfiguredProviderAuth: () => false,
 		getDiscoverableProviders: () => [],
 		getCanonicalModels: () => [],
@@ -253,4 +259,67 @@ describe("ModelSelector batch assignment thinking menu", () => {
 		if (!selectedAssignment) throw new Error("Expected executor assignment selection");
 		expect(selectedAssignment.selector).toBe("anthropic/claude-plain");
 	});
+});
+
+test("updates the rendered catalog when an in-flight registry refresh completes", async () => {
+	installTestTheme();
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-model-selector-catalog-"));
+	const modelsPath = path.join(tempDir, "models.json");
+	const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+	let selector: ModelSelectorComponent | undefined;
+
+	try {
+		await Bun.write(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"catalog-refresh": {
+						baseUrl: "https://catalog-refresh.example.com/v1",
+						api: "openai-responses",
+						discovery: { type: "openai-models-list" },
+					},
+				},
+			}),
+		);
+		authStorage.setRuntimeApiKey("catalog-refresh", "test-key");
+		const response = Promise.withResolvers<Response>();
+		using _hook = hookFetch(input => {
+			expect(String(input)).toBe("https://catalog-refresh.example.com/v1/models");
+			return response.promise;
+		});
+		const registry = new ModelRegistry(authStorage, modelsPath);
+
+		const ui = { requestRender: vi.fn() } as unknown as TUI;
+		selector = new ModelSelectorComponent(
+			ui,
+			undefined,
+			Settings.isolated(),
+			registry,
+			[],
+			() => {},
+			() => {},
+			{ initialSearchInput: "newly" },
+		);
+		await Bun.sleep(0);
+		installTestTheme();
+		const refresh = registry.refresh("online");
+		await Bun.sleep(0);
+		expect(normalizeRenderedText(selector.render(220).join("\n"))).not.toContain("newly-available-model");
+
+		response.resolve(
+			new Response(JSON.stringify({ data: [{ id: "newly-available-model" }] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+		await refresh;
+		await Bun.sleep(0);
+		installTestTheme();
+
+		expect(normalizeRenderedText(selector.render(220).join("\n"))).toContain("newly-available-model");
+	} finally {
+		selector?.dispose();
+		authStorage.close();
+		await fs.rm(tempDir, { recursive: true, force: true });
+	}
 });


### PR DESCRIPTION
Closes the MEDIUM half of #3847. The HIGH half shipped as #4147.

## Defect

`ModelSelectorComponent` snapshots `getAvailable()` at construction. If the registry is still loading — the offline/cold-start case — a catalog that arrives afterwards is never reflected: the user stares at a stale or empty list until they close and reopen the selector.

There was no way to observe completion:

- `ModelRegistry` emits **nothing**. Grepping the whole class (`model-registry.ts:1189` → ~4095) for listener/emitter/subscribe/notify yields two hits, neither usable: an unrelated import at `:80`, and at `:1263` the registry *consuming* someone else's event.
- `refreshInBackground` (`:1283-1299`) returns `void`. Its completion promise lives in `#backgroundRefresh` (`:1235`) — an ES `#private` field with no accessor.
- The catalog actually changes in `#rebuildCanonicalIndex` and `#resumeRebuild`; nothing was notified, the cache was just nulled.

## Fix

`ModelRegistry.onCatalogChanged(listener): () => void` — a listener `Set` returning an unsubscribe closure, mirroring the proven `AuthStorage` shape at `packages/ai/src/auth-storage.ts:1228`. Fired at the two points where `#models` is committed, **not** from `#invalidateAvailableModels` (that only nulls a cache and would emit spurious events).

The selector subscribes and unsubscribes in a new `dispose()`. The selector previously had **zero** `dispose` occurrences even though `Container.clear()` calls `child.dispose?.()` (`packages/tui/src/tui.ts:552`) on the path the selector closes through — so any listener without it would leak on every close.

## Rejected alternatives

- **`authStorage.onGenerationChanged`** — reachable from the selector today via `this.#modelRegistry.authStorage`, and the obvious thing to grab. It is a trap: it fires on *credential* generation bumps, not catalog arrival. A background refresh discovering models over an already-authenticated provider bumps no generation, so it would never fire on the reported bug — while compiling cleanly and passing a test that manually bumped the auth generation. This component has burned three prior attempts on exactly this shape of false positive.
- **Returning the `#backgroundRefresh` promise** — cheaper, but ordering is worse: `refreshInBackground` dedupes concurrent calls, so a selector opened *after* a refresh started gets nothing.
- **Polling `getProviderDiscoveryState()`** — needs a timer. New subsystem.

## The subscription is guarded, deliberately

Calling `onCatalogChanged` unconditionally in the constructor **broke 68 tests** across suites this change never touches:

```
TypeError: this.#modelRegistry.onCatalogChanged is not a function
  at new ModelSelectorComponent (model-selector.ts:487)
```

The repo has many hand-rolled registry fakes built with `as unknown as ModelRegistry`, and the cast hides a missing method from the compiler until runtime. Teaching a dozen fakes the new method is churn that breaks again with the next fake written, so the guard lives in production: a registry without the method simply gets no live catalog updates.

## Verification

| run | result |
|---|---|
| `bun test packages/coding-agent/test/model-selector-batch-thinking.test.ts` | **5 pass / 0 fail** |
| mutation — remove both `#notifyCatalogChanged()` emits | **3 pass / 1 fail** on the new test |
| re-apply | **5 pass / 0 fail** |
| `--test-name-pattern "ModelSelector\|model.selector"` | **83 pass / 0 fail** (was 14 pass / 68 fail before the guard) |
| `bun --cwd=packages/coding-agent run check:types` | clean |
| biome 2.5.2 on all three changed files | clean |
| preflight (head contains `origin/dev`) | PASS |

The mutation was re-run by me against the committed branch. It fails on the catalog path specifically — confirming the test does not merely ride the auth-generation route that defeated earlier attempts.

## Not covered

Repaint behavior when a refresh fails midway. The listener fires only on successful catalog commit; a failed refresh leaves the previous list, which is the current behavior either way.