### PR TITLE
test(read): stop replacing the natives module for the whole run

### DIFF
--- a/packages/coding-agent/test/tools/read-goldens.test.ts
+++ b/packages/coding-agent/test/tools/read-goldens.test.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import { afterAll, beforeAll, describe, expect, it, mock, vi } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -10,38 +10,12 @@ import { computeLineHash } from "@gajae-code/coding-agent/hashline/hash";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
 import { wrapToolWithMetaNotice } from "@gajae-code/coding-agent/tools/output-meta";
+import { ReadTool } from "@gajae-code/coding-agent/tools/read";
+import * as markit from "@gajae-code/coding-agent/utils/markit";
 import * as scrapers from "@gajae-code/coding-agent/web/scrapers/types";
 
-// Bun `mock.module` is process-global and sibling receipt tests replace the
-// natives module. Re-register only the native exports used by ReadTool from a
-// direct loader import, so this harness's structural-summary fixture always uses
-// the actual native implementation rather than another test's wrapper.
-const nativeIndexUrl = import.meta.resolve("@gajae-code/natives");
-const nativeLoaderUrl = new URL("./loader-state.js?read-goldens-real-loader", nativeIndexUrl).href;
-const realNatives = (await import(nativeLoaderUrl)).loadNative();
-function installRealNativesMock(): void {
-	mock.module("@gajae-code/natives", () => realNatives);
-}
-
-installRealNativesMock();
-
-// Keep the same delegation shape as the read receipt tests. The harness owns only
-// the deterministic markit fixture; all other calls use the real implementations.
 const markitContents = new Map<string, string>();
-const realMarkit = await import("@gajae-code/coding-agent/utils/markit");
-
-mock.module("@gajae-code/coding-agent/utils/markit", () => ({
-	...realMarkit,
-	convertFileWithMarkit: async (filePath: string, signal?: AbortSignal) => {
-		const content = markitContents.get(filePath);
-		return content === undefined ? realMarkit.convertFileWithMarkit(filePath, signal) : { ok: true, content };
-	},
-}));
-// Load a fresh ReadTool graph after installing the real natives mock; Bun caches
-// the ordinary module URL even when a sibling test imported it under another mock.
-const readModuleUrl = new URL("../../src/tools/read.ts", import.meta.url);
-readModuleUrl.search = "read-goldens";
-const { ReadTool } = await import(readModuleUrl.href);
+const convertFileWithMarkit = markit.convertFileWithMarkit;
 
 const MANIFEST_PATH = path.join(import.meta.dir, "../fixtures/read-goldens/manifest.json");
 const GOLDEN_ROOT = path.dirname(MANIFEST_PATH);
@@ -140,6 +114,7 @@ const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf8")) as Entry[];
 let fixture: FixtureState;
 let contextManager: SessionManager;
 let urlPageSpy: ReturnType<typeof vi.spyOn> | undefined;
+let markitConvertSpy: { mockRestore(): void } | undefined;
 let artifactCounter = 0;
 
 function variantFor(hashLines: boolean): Variant {
@@ -566,7 +541,10 @@ async function runPhase(currentPhase: GoldenPhase): Promise<number> {
 
 describe("read truncation golden harness", () => {
 	beforeAll(async () => {
-		installRealNativesMock();
+		markitConvertSpy = vi.spyOn(markit, "convertFileWithMarkit").mockImplementation(async (filePath, signal) => {
+			const content = markitContents.get(filePath);
+			return content === undefined ? convertFileWithMarkit(filePath, signal) : { ok: true, content };
+		});
 		fixture = await createFixtures(fs.mkdtempSync(path.join(os.tmpdir(), "read-goldens-")));
 
 		contextManager = SessionManager.inMemory(fixture.root);
@@ -592,6 +570,7 @@ describe("read truncation golden harness", () => {
 
 	afterAll(async () => {
 		urlPageSpy?.mockRestore();
+		markitConvertSpy?.mockRestore();
 		await contextManager?.close();
 		fs.rmSync(fixture.root, { recursive: true, force: true });
 	});

--- a/packages/coding-agent/test/tools/read-receipt.test.ts
+++ b/packages/coding-agent/test/tools/read-receipt.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -7,36 +7,13 @@ import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
 import { wrapToolWithMetaNotice } from "@gajae-code/coding-agent/tools/output-meta";
+import { ReadTool } from "@gajae-code/coding-agent/tools/read";
+import * as markit from "@gajae-code/coding-agent/utils/markit";
+import * as native from "@gajae-code/natives";
 import { Snowflake } from "@gajae-code/utils";
 
 let markitContent = "";
 let summarySegments: Array<{ kind: string; startLine: number; endLine: number; text?: string }> | null = null;
-
-// Bun `mock.module` is process-global and is NOT reverted by `mock.restore()`, so these
-// mocks delegate to the real implementations unless this file's own fixtures are set.
-// That keeps sibling test files (find/glob, sqlite, summary) on the real modules.
-const realMarkit = await import("@gajae-code/coding-agent/utils/markit");
-const realNatives = await import("@gajae-code/natives");
-mock.module("@gajae-code/coding-agent/utils/markit", () => ({
-	...realMarkit,
-	convertFileWithMarkit: async (...args: unknown[]) =>
-		markitContent
-			? { ok: true, content: markitContent }
-			: (realMarkit.convertFileWithMarkit as (...a: unknown[]) => unknown)(...args),
-	convertBufferWithMarkit: async (...args: unknown[]) =>
-		markitContent
-			? { ok: true, content: markitContent }
-			: (realMarkit.convertBufferWithMarkit as (...a: unknown[]) => unknown)(...args),
-}));
-mock.module("@gajae-code/natives", () => ({
-	...realNatives,
-	summarizeCode: (...args: unknown[]) =>
-		summarySegments !== null
-			? { parsed: true, elided: true, segments: summarySegments }
-			: (realNatives.summarizeCode as (...a: unknown[]) => unknown)(...args),
-}));
-const { ReadTool } = await import("@gajae-code/coding-agent/tools/read");
-
 let artifactCounter = 0;
 
 function createSession(cwd: string, settings: Settings = Settings.isolated()): ToolSession {
@@ -91,15 +68,47 @@ function receiptSettings(extra: Record<string, unknown> = {}): Settings {
 
 describe("read receipt by default", () => {
 	let testDir: string;
+	let convertFileSpy: { mockRestore(): void } | undefined;
+	let convertBufferSpy: { mockRestore(): void } | undefined;
+	let summarizeCodeSpy: { mockRestore(): void } | undefined;
 
 	beforeEach(() => {
 		testDir = path.join(os.tmpdir(), `read-receipt-${Snowflake.next()}`);
 		fs.mkdirSync(testDir, { recursive: true });
 		markitContent = "";
 		summarySegments = null;
+
+		const convertFileWithMarkit = markit.convertFileWithMarkit;
+		convertFileSpy = vi
+			.spyOn(markit, "convertFileWithMarkit")
+			.mockImplementation((...args) =>
+				markitContent ? Promise.resolve({ ok: true, content: markitContent }) : convertFileWithMarkit(...args),
+			);
+		const convertBufferWithMarkit = markit.convertBufferWithMarkit;
+		convertBufferSpy = vi
+			.spyOn(markit, "convertBufferWithMarkit")
+			.mockImplementation((...args) =>
+				markitContent ? Promise.resolve({ ok: true, content: markitContent }) : convertBufferWithMarkit(...args),
+			);
+		const summarizeCode = native.summarizeCode;
+		summarizeCodeSpy = vi.spyOn(native, "summarizeCode").mockImplementation((...args) =>
+			summarySegments !== null
+				? {
+						parsed: true,
+						elided: true,
+						totalLines: Math.max(0, ...summarySegments.map(segment => segment.endLine)),
+						segments: summarySegments,
+					}
+				: summarizeCode(...args),
+		);
 	});
 
-	afterEach(() => fs.rmSync(testDir, { recursive: true, force: true }));
+	afterEach(() => {
+		summarizeCodeSpy?.mockRestore();
+		convertBufferSpy?.mockRestore();
+		convertFileSpy?.mockRestore();
+		fs.rmSync(testDir, { recursive: true, force: true });
+	});
 
 	async function read(filePath: string, settings = receiptSettings(), params: Record<string, unknown> = {}) {
 		const tool = wrapToolWithMetaNotice(new ReadTool(createSession(testDir, settings)));


### PR DESCRIPTION
Fixes a cross-file test pollution that made `session-durability-windows.test.ts` fail on `dev` in any broad run while passing in isolation.

## Symptom

```
managed session Windows durability > reconciles a clean receipt left after restoration before a second restart
```

- run the file alone: **12 pass / 0 fail**
- run it inside `--test-name-pattern "reconcil"`: **161 pass / 1 fail**

The assertion expected a stubbed result and instead received a real one, with extra keys including `provenance: "v2"`, `kind: "opened"`, `migrated: true`.

Passing alone and failing in a broad run is the signature of leaked global state, not a bad assertion — so the fix belongs in whatever leaks, not in the victim.

## Root cause

`read-receipt.test.ts` and `read-goldens.test.ts` used `mock.module()` on the natives package. Bun applies that **globally and never unwinds it**. A later file importing the same package through a different specifier then resolved a second, separate exports object.

So when `session-durability-windows` did `vi.spyOn(native, "exactRestore")`, it spied on the copy that `managed-session-scope.ts` does *not* use. The real `exactRestore` ran, the restore genuinely succeeded, and the test observed the actual `{ kind: "opened", migrated: true, … }` rather than its stub.

## Fix

Replaced the global module substitutions with scoped `vi.spyOn` plus explicit cleanup, so nothing survives the file that installed it:

- `packages/coding-agent/test/tools/read-receipt.test.ts:75-110`
- `packages/coding-agent/test/tools/read-goldens.test.ts:543-575`

Also gave the formerly cast-hidden `summarizeCode` fake its required `totalLines` (`read-receipt.test.ts:94-103`) — the `as unknown as` cast was hiding the drift, same pattern as #4133/#4137/#4138/#4139.

This matches the repo's testing rules, which already prohibit `mock.module()` in favour of `vi.spyOn` with cleanup.

## What I did not do

No reordering, no skip, and no defensive re-spy inside `session-durability-windows`. Any of those would have hidden the leak for the next file to trip over it — and the victim is not wrong.

## Verification

| run | result |
|---|---|
| `session-durability-windows.test.ts` alone | **12 pass / 0 fail** |
| broad `--test-name-pattern "reconcil"` | **162 pass / 401 skip / 0 fail** |
| mutation — revert the pollution fix | **161 pass / 1 fail** (the original failure returns) |
| re-apply | **162 pass / 0 fail** |
| `read-receipt.test.ts` + `read-goldens.test.ts` | **24 pass / 0 fail** |
| `bun --cwd=packages/coding-agent run check:types` | clean |
| biome 2.5.2 on changed files | clean |
| preflight (head contains `origin/dev` `06bf6d205`) | PASS |

For a pollution fix the meaningful verification is the **broad** run, not the single file — a single-file run proves nothing here. I ran the mutation with the broad selection and re-confirmed the baseline on a stashed tree.

## Note

This branch originally also carried a fix for `agent-session-auto-compaction-queue.test.ts` (spying `continue` where production routes through `continueQueuedMessages`). `06bf6d205` landed the same change upstream, so the rebase dropped it as already-applied. Only the natives pollution fix remains here.