### PR TITLE
fix(read): keep heavy parsing off the render loop

### DIFF
--- a/crates/pi-natives/src/summary.rs
+++ b/crates/pi-natives/src/summary.rs
@@ -3,6 +3,8 @@
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
+use crate::task;
+
 #[napi(object)]
 pub struct SummaryOptions {
 	/// Source code to summarize.
@@ -67,14 +69,16 @@ impl From<pi_ast::summary::SummaryResult> for SummaryResult {
 }
 
 #[napi]
-pub fn summarize_code(options: SummaryOptions) -> Result<SummaryResult> {
-	pi_ast::summary::summarize_code(pi_ast::summary::SummaryOptions {
-		code:              options.code,
-		lang:              options.lang,
-		path:              options.path,
-		min_body_lines:    options.min_body_lines,
-		min_comment_lines: options.min_comment_lines,
+pub fn summarize_code(options: SummaryOptions) -> task::Promise<SummaryResult> {
+	task::blocking("summarize_code", (), move |_| {
+		pi_ast::summary::summarize_code(pi_ast::summary::SummaryOptions {
+			code:              options.code,
+			lang:              options.lang,
+			path:              options.path,
+			min_body_lines:    options.min_body_lines,
+			min_comment_lines: options.min_comment_lines,
+		})
+		.map(Into::into)
+		.map_err(|error| Error::from_reason(error.to_string()))
 	})
-	.map(Into::into)
-	.map_err(|error| Error::from_reason(error.to_string()))
 }

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Post-maintenance continuation now resumes the current non-assistant tail when no queued messages exist, while consuming queued steering/follow-ups only when present; overflow recovery no longer fails with `No queued messages to continue`, and accepted queued successors reset fallback accounting exactly once.
 - Streamed edit preview coalescing now keys on the complete partial-JSON payload rather than its length, so same-size in-place argument replacements recompute and render while repeated payloads remain cached.
 - CLI parsing now fails closed by default, while launch and ACP explicitly defer only their owned startup options; this preserves ACP-specific diagnostics, SDK startup forwarding, real ACP subprocess framing, and RLM typo rejection without exposing retired flags in root help or completion.
+- Read-tool code summarization and ZIP extraction now run asynchronously instead of blocking the TUI event loop during structural parsing or decompression.
 
 ## [0.12.21] - 2026-08-09
 

--- a/packages/coding-agent/src/tools/archive-reader.ts
+++ b/packages/coding-agent/src/tools/archive-reader.ts
@@ -156,10 +156,19 @@ async function readTarEntries(bytes: Uint8Array): Promise<ArchiveIndexEntry[]> {
 }
 
 async function readZipEntries(bytes: Uint8Array): Promise<ArchiveIndexEntry[]> {
-	const { unzipSync } = await loadFflate();
+	const { unzip } = await loadFflate();
+	const result = Promise.withResolvers<Record<string, Uint8Array>>();
+	unzip(bytes, (error, files) => {
+		if (error) {
+			result.reject(error);
+			return;
+		}
+		result.resolve(files);
+	});
+
 	let files: Record<string, Uint8Array>;
 	try {
-		files = unzipSync(bytes);
+		files = await result.promise;
 	} catch (error) {
 		throw new ToolError(error instanceof Error ? error.message : String(error));
 	}

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -2409,7 +2409,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			if (countTextLines(code) > MAX_SUMMARY_LINES) return null;
 
 			const summarizeCode = (await nativeRead()).summarizeCode;
-			return summarizeCode({
+			return await summarizeCode({
 				code,
 				path: absolutePath,
 				minBodyLines: this.session.settings.get("read.summarize.minBodyLines"),

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Code summarization now runs on the native blocking-work pool and returns a promise, keeping the JavaScript render and input loop responsive while tree-sitter parses source.
+
 ## [0.12.21] - 2026-08-09
 
 ## [0.12.20] - 2026-08-09

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -2291,7 +2291,7 @@ export declare function sliceWithWidth(line: string, startCol: number, length: n
  */
 export declare function snapshotDirectoryTree(path: string): NativeDirectoryTreeResult
 
-export declare function summarizeCode(options: SummaryOptions): SummaryResult
+export declare function summarizeCode(options: SummaryOptions): Promise<SummaryResult>
 
 export interface SummaryOptions {
   /** Source code to summarize. */

--- a/packages/natives/test/native.test.ts
+++ b/packages/natives/test/native.test.ts
@@ -137,8 +137,8 @@ describe("pi-natives", () => {
 	});
 
 	describe("summarize", () => {
-		it("summarizes TypeScript function bodies", () => {
-			const result = summarizeCode({
+		it("summarizes TypeScript function bodies", async () => {
+			const result = await summarizeCode({
 				path: "fixture.ts",
 				code: "export function greet(name: string): string {\n\tconst clean = name.trim();\n\tconst label = clean || 'world';\n\treturn label.toUpperCase();\n}\n",
 			});
@@ -152,12 +152,12 @@ describe("pi-natives", () => {
 			expect(result.segments[2].text).toBe("}");
 		});
 
-		it("summarizes Rust and Python bodies while preserving boundary lines", () => {
-			const rust = summarizeCode({
+		it("summarizes Rust and Python bodies while preserving boundary lines", async () => {
+			const rust = await summarizeCode({
 				path: "fixture.rs",
 				code: 'impl Greeter {\n\tfn greet(&self) -> String {\n\t\tlet name = "world";\n\t\tlet label = name.to_uppercase();\n\t\tformat!("hello {label}")\n\t}\n}\n',
 			});
-			const python = summarizeCode({
+			const python = await summarizeCode({
 				path: "fixture.py",
 				code: "class Greeter:\n    def greet(self, name: str) -> str:\n        clean = name.strip()\n        label = clean or 'world'\n        return f'hello {label}'\n",
 			});
@@ -169,8 +169,8 @@ describe("pi-natives", () => {
 			expect(python.segments.at(-1)?.text).toContain("return");
 		});
 
-		it("summarizes multiline literals and block comments", () => {
-			const result = summarizeCode({
+		it("summarizes multiline literals and block comments", async () => {
+			const result = await summarizeCode({
 				path: "fixture.ts",
 				code: "/*\n * line 1\n * line 2\n * line 3\n * line 4\n */\nexport const config = {\n\ta: 1,\n\tb: 2,\n\tc: 3,\n};\n",
 			});
@@ -183,9 +183,9 @@ describe("pi-natives", () => {
 			);
 		});
 
-		it("falls back for unsupported or empty input", () => {
-			const unsupported = summarizeCode({ path: "fixture.txt", code: "plain text\nwith lines\n" });
-			const empty = summarizeCode({ path: "fixture.ts", code: "" });
+		it("falls back for unsupported or empty input", async () => {
+			const unsupported = await summarizeCode({ path: "fixture.txt", code: "plain text\nwith lines\n" });
+			const empty = await summarizeCode({ path: "fixture.ts", code: "" });
 
 			expect(unsupported.parsed).toBe(false);
 			expect(unsupported.segments).toHaveLength(1);
@@ -194,10 +194,25 @@ describe("pi-natives", () => {
 			expect(empty.segments).toHaveLength(0);
 		});
 
-		it("respects minBodyLines", () => {
+		it("respects minBodyLines", async () => {
 			const code = "function small() {\n\treturn 1;\n}\n";
-			expect(summarizeCode({ path: "fixture.ts", code }).elided).toBe(false);
-			expect(summarizeCode({ path: "fixture.ts", code, minBodyLines: 3 }).elided).toBe(true);
+			expect((await summarizeCode({ path: "fixture.ts", code })).elided).toBe(false);
+			expect((await summarizeCode({ path: "fixture.ts", code, minBodyLines: 3 })).elided).toBe(true);
+		});
+
+		it("runs code summarization off the JavaScript event loop", async () => {
+			const code = Array.from(
+				{ length: 20_000 },
+				(_, index) => `export function value${index}() {\n\tconst value = ${index};\n\treturn value;\n}`,
+			).join("\n");
+			const summary = summarizeCode({ path: "fixture.ts", code });
+			const firstSettled = await Promise.race([
+				summary.then(() => "summary" as const),
+				Bun.sleep(0).then(() => "timer" as const),
+			]);
+
+			expect(firstSettled).toBe("timer");
+			expect((await summary).parsed).toBe(true);
 		});
 	});
 	describe("grep", () => {


### PR DESCRIPTION
## Summary
- run native code summarization on the blocking-work pool
- use asynchronous ZIP decompression in the read tool
- add an event-loop responsiveness regression test

## Verification
- `bun test packages/natives/test/native.test.ts packages/coding-agent/test/tools/read-goldens.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/natives run check`
- `bun run build:native`

## Known unrelated issue
- Full Rust clippy currently reports pre-existing warnings in `crates/pi-natives/src/computer/controller.rs`; these will be fixed in a follow-up.