### PR TITLE
fix(anthropic): keep deterministic thinking-replay repair across turns

### DIFF
--- a/artifacts/issue-3670-anthropic-cache-eval.json
+++ b/artifacts/issue-3670-anthropic-cache-eval.json
@@ -6,8 +6,8 @@
 	"source": {
 		"url": "https://platform.claude.com/docs/en/build-with-claude/prompt-caching",
 		"retrievedAt": "2026-07-18",
-		"providerSourceBlobOid": "c6edec53ae5f35801dece11b0a425986270fb452",
-		"providerSourceSha256": "7832bf7a5efbeff0fa16ed39ecd391ca01df12f683eb29041a90a47e9e33507c",
+		"providerSourceBlobOid": "b9448188a92345add77a3f70e699ab8c8142af74",
+		"providerSourceSha256": "a3f3e58177a459f81e1d0e457c4a6472de2f40b0c689e088b15f75d376c3f60b",
 		"inputFixtureSha256": "562926fba79f003eff4d45c0da2292ac66d84302e3960b2d7493441ade1f9e04"
 	},
 	"derivationCommands": [

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Anthropic thinking-replay repairs caused by a deterministic rejection now stay in force for the rest of the session instead of being released as soon as the repaired retry succeeds. `thinking`/`redacted_thinking` blocks that draw a 400 (`blocks ... cannot be modified`, `Invalid \`signature\` in \`thinking\` block`) stay in the session history, so releasing the repair made the very next turn replay the same blocks and spend another rejected round trip — every turn, indefinitely. Observed against a proxied Claude Code session as a sustained ~50% 400 rate that never converged. The speculative masked-`api_error` probe is still released on the first completed stream, since that one may have been a transient blip (#4011).
+
 ## [0.12.21] - 2026-08-09
 
 ## [0.12.20] - 2026-08-09

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1480,6 +1480,10 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 			let thinkingReplayRepairScope: AnthropicThinkingReplayRepairScope =
 				providerSessionState?.thinkingReplayRepairScope ?? "none";
 			let thinkingReplayRepairAttempts = providerSessionState?.thinkingReplayRepairAttempts ?? 0;
+			// A scope inherited from an earlier turn can only have come from the
+			// deterministic branch below — the speculative masked-`api_error` probe is
+			// never persisted — so a completed stream must not release it.
+			let thinkingReplayRepairPersistent = thinkingReplayRepairScope !== "none";
 			let generatedCacheBudget: GeneratedCacheBudget = providerSessionState?.generatedCacheBudget ?? 2;
 			const prepareParams = async (): Promise<MessageCreateParamsStreaming> => {
 				// Degradation state is cumulative: every fallback rebuild must merge all
@@ -1918,7 +1922,17 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 					// branch above fires on an error nobody can classify, so keeping its
 					// guess would silently strip native thinking replay from every later
 					// turn of the session over what may have been one transient blip.
-					if (providerSessionState && (thinkingReplayRepairScope !== "none" || thinkingReplayRepairAttempts > 0)) {
+					//
+					// A deterministic rejection ("cannot be modified" / invalid signature) is
+					// the opposite case: it cites blocks that stay in this session's history,
+					// so releasing the repair here makes the next turn replay the same blocks
+					// and spend another rejected round trip on every turn that follows. That
+					// repair has to outlive the stream it fixed.
+					if (
+						providerSessionState &&
+						!thinkingReplayRepairPersistent &&
+						(thinkingReplayRepairScope !== "none" || thinkingReplayRepairAttempts > 0)
+					) {
 						providerSessionState.thinkingReplayRepairScope = "none";
 						providerSessionState.thinkingReplayRepairAttempts = 0;
 					}
@@ -2007,6 +2021,9 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 							error: streamFailure instanceof Error ? streamFailure.message : String(streamFailure),
 						});
 						thinkingReplayRepairScope = nextScope;
+						// Anything but the masked probe is caused by blocks that remain in
+						// history, so this repair must survive the stream it is about to fix.
+						if (!maskedProxyRejection) thinkingReplayRepairPersistent = true;
 						if (providerSessionState) {
 							providerSessionState.thinkingReplayRepairAttempts = thinkingReplayRepairAttempts;
 							if (!maskedProxyRejection) {

--- a/packages/ai/test/anthropic-thinking-repair-retry.test.ts
+++ b/packages/ai/test/anthropic-thinking-repair-retry.test.ts
@@ -355,6 +355,49 @@ describe("Anthropic thinking replay repair retry", () => {
 		expect(JSON.stringify(requestBodies[3])).toContain("sig_late");
 	});
 
+	// A "cannot be modified" rejection is caused by blocks that stay in this
+	// session's history, so a repair that fixed one turn has to stay in force.
+	// Releasing it once the retry succeeds makes the next turn replay the same
+	// blocks and burn another rejected round trip — on every turn, indefinitely.
+	it("keeps a deterministic thinking repair in force on later turns", async () => {
+		const user: UserMessage = {
+			role: "user",
+			content: "first",
+			timestamp: Date.now(),
+		};
+		const context: Context = {
+			messages: [
+				user,
+				makeSignedAssistant("early", "early answer"),
+				{ ...user, content: "second", timestamp: Date.now() + 1 },
+				makeSignedAssistant("late", "late answer"),
+				{ ...user, content: "next prompt", timestamp: Date.now() + 2 },
+			],
+		};
+		const requestBodies: unknown[] = [];
+		// Anthropic rejects exactly the requests that replay native thinking, which
+		// is what makes this failure deterministic rather than a transient blip.
+		const create = ((body: unknown) => {
+			requestBodies.push(body);
+			const replaysThinking = JSON.stringify(body).includes("sig_");
+			return (replaysThinking ? createAnthropicThinking400() : createSuccessfulRequest()) as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+		const providerSessionState = new Map<string, ProviderSessionState>();
+
+		const firstTurn = await streamAnthropic(model, context, { client, providerSessionState }).result();
+
+		// Rejected replay, then a repaired retry with thinking dropped.
+		expect(firstTurn.stopReason).toBe("stop");
+		expect(requestBodies).toHaveLength(2);
+
+		const secondTurn = await streamAnthropic(model, context, { client, providerSessionState }).result();
+
+		expect(secondTurn.stopReason).toBe("stop");
+		expect(requestBodies).toHaveLength(3);
+		expect(JSON.stringify(requestBodies[2])).not.toContain("sig_");
+	});
+
 	// The masked body says nothing, so the guard must be the request: with no
 	// replayed thinking blocks the failure is somebody else's and retrying would
 	// only hide it behind a second identical request.


### PR DESCRIPTION
## What

A deterministic Anthropic thinking-replay repair now stays in force for the rest of the session instead of being released the moment the repaired retry succeeds.

## Why

`thinking`/`redacted_thinking` blocks that draw a 400 (`blocks ... cannot be modified`, or `Invalid \`signature\` in \`thinking\` block`) sit in the session's message history. Dropping them repairs the turn, but the history is unchanged, so the rejection is guaranteed to recur.

The repair branch persisted its scope to `providerSessionState` (`!maskedProxyRejection`), and then the success path erased it unconditionally — including for the very retry that persistence enabled:

```ts
if (providerSessionState && (thinkingReplayRepairScope !== "none" || thinkingReplayRepairAttempts > 0)) {
	providerSessionState.thinkingReplayRepairScope = "none";
	providerSessionState.thinkingReplayRepairAttempts = 0;
}
```

Every turn therefore paid a full rejected round trip before recovering, forever. Found on a proxied Claude Code session (headroom -> CLIProxyAPI -> Anthropic) that ran a sustained **~50% 400 rate for over a day** without ever converging: 481 requests / 266 rejections in one window, 226 / 122 in the next.

The speculative masked-`api_error` probe is deliberately unchanged — it fires on an error nobody can classify, so it must still be released on the first completed stream (#4011).

## Testing

New regression test `keeps a deterministic thinking repair in force on later turns` drives a responder that rejects exactly the requests replaying native thinking, then asserts the second turn costs one request rather than two.

- Before fix: `expect(requestBodies).toHaveLength(3)` -> `Received length: 4`
- After fix: 41 pass across the three thinking-repair/immutability files
- `bun test packages/ai/test`: 2291 pass / 337 skip / 4 fail — the same 4 failures the tree has on a clean checkout (`buildAnthropicAuthConfig` base-URL, 3x `openai-responses cache affinity`), verified by stashing this diff and re-running
- `bun --cwd=packages/ai run check`: biome + tsc clean
- `artifacts/issue-3670-anthropic-cache-eval.json` regenerated, since it pins the sha256 of `providers/anthropic.ts`

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:0f71acbe2388823cadcb016e3cc74db37de20900 reviewer:human evidence:local bun test packages/ai/test + bun --cwd=packages/ai run check
```

---

- [x] Target branch `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict matches exact PR head, not earlier commit
