### PR TITLE
test(read): pin the summarizeCode stub to the async SummaryResult schema

### DIFF
--- a/packages/coding-agent/test/tools/read-receipt.test.ts
+++ b/packages/coding-agent/test/tools/read-receipt.test.ts
@@ -220,6 +220,34 @@ describe("read receipt by default", () => {
 		const small = await read(file, receiptSettings({ "read.summarize.enabled": true }));
 		expect(textOf(small)).not.toContain("Summary truncated at");
 	});
+	it("stubs summarizeCode as a real async SummaryResult with the full schema", async () => {
+		const file = path.join(testDir, "summary-schema-regression.ts");
+		fs.writeFileSync(file, "export const x = 1;\n");
+		summarySegments = [
+			{ kind: "code", startLine: 1, endLine: 1, text: "export const x = 1;" },
+			{ kind: "elided", startLine: 2, endLine: 40 },
+		];
+
+		// The stub branch must honor the native async contract exactly: it
+		// resolves a full SummaryResult (parsed/elided/totalLines/segments).
+		// A bare object return, a dropped totalLines, or a cast that hides
+		// the sync/async drift fails the type check or these assertions.
+		const pending = native.summarizeCode({ path: file, code: "export const x = 1;\n" });
+		expect(pending).toBeInstanceOf(Promise);
+		const summary = await pending;
+		expect(summary).toEqual({
+			parsed: true,
+			elided: true,
+			totalLines: 40,
+			segments: summarySegments,
+		});
+
+		// The stubbed schema also flows through the tool end to end.
+		const result = await read(file, receiptSettings({ "read.summarize.enabled": true }));
+		expect(result.details?.summary?.elidedSpans).toBe(1);
+		expect(result.details?.summary?.elidedLines).toBe(39);
+		expect(textOf(result)).toContain("elided");
+	});
 
 	it("bounds directories by bytes and lines without spilling while preserving small listings", async () => {
 		const large = path.join(testDir, "large-dir");


### PR DESCRIPTION
Fixes #4162

## What

6bbd4f8fcc restored the `Promise.resolve(...)` wrapper on `dev`, but the issue's remaining ask — **a focused type/runtime regression** proving the stub branch still honors the async native contract — was not landed. This PR adds exactly that.

The new test asserts the stub branch:

1. returns a real `Promise` (a bare-object return fails `toBeInstanceOf(Promise)` — the original `TS2322` async drift),
2. resolves the exact `SummaryResult` schema including `totalLines` (a dropped `totalLines` fails `toEqual` plus `check:types` with the same `TS2322` missing-property diagnostic),
3. flows through the `ReadTool` end to end (stubbed elided span renders with `elidedSpans: 1`, `elidedLines: 39`).

## Scope preserved from #4155

- Scoped `vi.spyOn` + `afterEach` `mockRestore()` cleanup — unchanged.
- No `mock.module`, no victim patches, no reordering/skips.

## Verification

| run | result |
|---|---|
| `read-receipt.test.ts` + `read-goldens.test.ts` | **25 pass / 0 fail** |
| broad `--test-name-pattern "reconcil"` | **166 pass / 639 skip / 0 fail** |
| `check:@gajae-code/coding-agent` (tsc) | clean |
| biome on changed file | clean |
| mutation — bare-object return | fails `toBeInstanceOf(Promise)` + `check:types` (TS2322 returns) |
| mutation — dropped `totalLines` | fails `toEqual` + `check:types` (missing-property TS2322) |

Base is exactly `origin/dev` `6bbd4f8fcc`. Diff is +28 lines in one test file, purely additive.