### PR TITLE
test(coding-agent): prove blocked bash commands leave the .gjc state tree untouched

### DIFF
--- a/packages/coding-agent/test/tools/bash-state-exploit.test.ts
+++ b/packages/coding-agent/test/tools/bash-state-exploit.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from "bun:test";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ToolSession } from "@gajae-code/coding-agent/tools";
+import { BashTool } from "@gajae-code/coding-agent/tools/bash";
+
+/**
+ * Real-BashTool regression for the restricted role-agent allowlist (#2665).
+ *
+ * `bash-allowed-prefixes.test.ts` covers `classifyStateArgv` and
+ * `checkBashAllowedPrefixes` directly. Those are classifier-level assertions:
+ * they prove the policy function returns `allowed: false`, but nothing drives
+ * `BashTool.execute`, and nothing observes the filesystem.
+ *
+ * That leaves the actual claim unproven. "The policy said no" and "the state
+ * file was not modified" are different statements: a guard can reject while an
+ * earlier code path has already written. These tests instantiate a real
+ * `BashTool` with the restricted profile, run the destructive `gjc state`
+ * shapes through `execute()`, require a `ToolError`, and hash a seeded state
+ * file before and after to prove the bytes never changed.
+ */
+
+const ROLE_AGENT_PREFIXES = ["gjc ralplan --write", "gjc state"];
+
+function createRestrictedBashTool(cwd: string, prefixes: string[] = ROLE_AGENT_PREFIXES): BashTool {
+	const session = {
+		cwd,
+		getSessionFile: () => null,
+		getSessionId: () => "bash-state-exploit-test",
+		bashAllowedPrefixes: prefixes,
+		bashRestrictionProfile: "workflow" as const,
+		settings: {
+			has(key: string) {
+				return this.get(key) !== undefined;
+			},
+			get(key: string) {
+				if (key === "bashInterceptor.enabled") return false;
+				if (key === "async.enabled") return false;
+				if (key === "bash.autoBackground.enabled") return false;
+				if (key === "bash.autoBackground.thresholdMs") return 60_000;
+				if (key === "bash.stripTrailingHeadTail") return false;
+				return undefined;
+			},
+			getBashInterceptorRules() {
+				return [];
+			},
+		},
+	} as unknown as ToolSession;
+	return new BashTool(session);
+}
+
+/** A workspace holding seeded workflow state, plus a full snapshot of the `.gjc` tree. */
+function seedWorkspace(): { dir: string; statePath: string; snapshot: string; cleanup: () => void } {
+	const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "gjc-bash-state-exploit-")));
+	const statePath = path.join(dir, ".gjc", "state", "ralplan-state.json");
+	fs.mkdirSync(path.dirname(statePath), { recursive: true });
+	// Shape is irrelevant to the guard; identity is what the test asserts.
+	fs.writeFileSync(
+		statePath,
+		JSON.stringify({ current_phase: "consensus", run_id: "seeded-run", revision: 7 }, null, 2),
+	);
+	// A decoy sibling so "unchanged" cannot be satisfied by watching one file,
+	// plus a nested directory and a symlink so the oracle has representative
+	// entries of every node type to compare.
+	fs.writeFileSync(path.join(dir, ".gjc", "state", "ultragoal-state.json"), JSON.stringify({ goals: [] }));
+	fs.mkdirSync(path.join(dir, ".gjc", "state", "active"), { recursive: true });
+	fs.writeFileSync(path.join(dir, ".gjc", "state", "active", "ralplan.json"), JSON.stringify({ active: true }));
+	fs.symlinkSync(path.join("..", "ralplan-state.json"), path.join(dir, ".gjc", "state", "active", "latest.json"));
+	return {
+		dir,
+		statePath,
+		snapshot: snapshotTree(path.join(dir, ".gjc")),
+		cleanup: () => fs.rmSync(dir, { recursive: true, force: true }),
+	};
+}
+
+/**
+ * Full identity of a directory tree: every entry's relative path, node type,
+ * content hash, and symlink target.
+ *
+ * A single-file digest is not enough. A blocked command that drops a *new*
+ * file alongside existing state, or swaps a file for a symlink, leaves the
+ * seeded file's bytes intact and would go unnoticed.
+ */
+function snapshotTree(root: string): string {
+	if (!fs.existsSync(root)) return "<absent>";
+	const lines: string[] = [];
+	const walk = (dir: string): void => {
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+			const full = path.join(dir, entry.name);
+			const rel = path.relative(root, full);
+			// lstat, so a symlink is described by itself rather than its target.
+			const st = fs.lstatSync(full);
+			// Portable subset only: mode bits and mtime. Ownership and inode are
+			// environment-dependent, and atime moves on ordinary reads, so
+			// including either would make the oracle flaky rather than stricter.
+			const meta = `mode=${(st.mode & 0o7777).toString(8)} mtime=${st.mtimeMs}`;
+			if (entry.isSymbolicLink()) {
+				lines.push(`symlink ${rel} -> ${fs.readlinkSync(full)} ${meta}`);
+			} else if (entry.isDirectory()) {
+				lines.push(`dir ${rel} ${meta}`);
+				walk(full);
+			} else {
+				const hash = crypto.createHash("sha256").update(fs.readFileSync(full)).digest("hex");
+				lines.push(`file ${rel} ${hash} ${meta}`);
+			}
+		}
+	};
+	walk(root);
+	return lines.join("\n");
+}
+
+/**
+ * Command shapes the classifier tests already enumerate as blocked. Each is a
+ * plausible exploit attempt: they all begin with an allowlisted prefix, so a
+ * naive prefix check would admit every one of them.
+ */
+const BLOCKED_COMMANDS: Array<{ label: string; command: string; reason: string }> = [
+	{ label: "destructive clear", command: "gjc state ralplan clear", reason: "does not allow `gjc state clear`" },
+	{ label: "direct handoff", command: "gjc state ralplan handoff", reason: "does not allow `gjc state handoff`" },
+	{ label: "unknown target", command: "gjc state not-a-skill read", reason: "canonical workflow skill" },
+	{ label: "bare target", command: "gjc state", reason: "canonical workflow skill" },
+	{
+		label: "equals-form unknown mode",
+		command: "gjc state ralplan --mode=obliterate",
+		reason: "restricted role-agent bash",
+	},
+];
+
+describe("restricted BashTool state-mutation exploit", () => {
+	it.each(
+		BLOCKED_COMMANDS.map(c => [c.label, c.command, c.reason] as const),
+	)("raises the allowlist ToolError and leaves the state file byte-identical: %s", async (_label, command, reason) => {
+		const ws = seedWorkspace();
+		try {
+			const tool = createRestrictedBashTool(ws.dir);
+
+			// Asserting the *specific* allowlist reason matters: `gjc` is not on PATH
+			// in CI, so a bare `.rejects.toThrow()` is also satisfied by a spawn
+			// failure — it would stay green with the guard removed.
+			await expect(tool.execute("tool-call", { command })).rejects.toThrow(reason);
+			// The bytes, not merely the policy decision.
+			expect(snapshotTree(path.join(ws.dir, ".gjc"))).toBe(ws.snapshot);
+		} finally {
+			ws.cleanup();
+		}
+	});
+
+	it("does not create a state file that was absent before a blocked attempt", async () => {
+		const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "gjc-bash-state-exploit-")));
+		try {
+			const tool = createRestrictedBashTool(dir);
+
+			await expect(tool.execute("tool-call", { command: "gjc state ralplan clear" })).rejects.toThrow(
+				"does not allow `gjc state clear`",
+			);
+			expect(fs.existsSync(path.join(dir, ".gjc"))).toBe(false);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	/**
+	 * Escape boundaries, not argv shapes. Each starts with an allowlisted prefix
+	 * and then tries to reach the filesystem by a different route: chaining,
+	 * piping, redirection, command substitution, or an allowed program spawning
+	 * another one. The reason strings pin which layer refused.
+	 */
+	it.each([
+		["semicolon chain", "gjc state ralplan read --json ; rm -rf .gjc", "control operator ';'"],
+		["and chain", "gjc state ralplan read --json && rm -rf .gjc", "control operator '&'"],
+		["pipe", "gjc state ralplan read --json | tee .gjc/state/pwned.json", "control operator '|'"],
+		["redirection", "gjc state ralplan read --json > .gjc/state/pwned.json", "control operator '>'"],
+		["command substitution", "gjc state $(echo ralplan) clear", "command substitution"],
+		["backtick substitution", "gjc state `echo ralplan` clear", "command substitution"],
+		["exec brace expansion", "gjc ralplan --write --artifact-env X find . -exec rm {} +", "expansion character '{'"],
+	])("refuses the escape route and leaves the .gjc tree identical: %s", async (_label, command, reason) => {
+		const ws = seedWorkspace();
+		try {
+			const tool = createRestrictedBashTool(ws.dir);
+
+			await expect(tool.execute("tool-call", { command })).rejects.toThrow(reason);
+			expect(snapshotTree(path.join(ws.dir, ".gjc"))).toBe(ws.snapshot);
+		} finally {
+			ws.cleanup();
+		}
+	});
+
+	it("blocks a non-allowlisted command outright", async () => {
+		const ws = seedWorkspace();
+		try {
+			const tool = createRestrictedBashTool(ws.dir);
+
+			await expect(tool.execute("tool-call", { command: "rm -rf .gjc" })).rejects.toThrow(
+				"restricted role-agent bash only allows commands starting with",
+			);
+			expect(snapshotTree(path.join(ws.dir, ".gjc"))).toBe(ws.snapshot);
+		} finally {
+			ws.cleanup();
+		}
+	});
+
+	/**
+	 * Admission control. The blocked cases all end in a rejection, so on their own
+	 * they cannot distinguish "the allowlist admitted this" from "the allowlist
+	 * rejected it for a different reason" — every allowlist refusal throws before
+	 * execution. This runs a real allowed program through the same production path
+	 * and asserts a sentinel that can only exist if execution actually happened.
+	 */
+	it("admits an allowlisted command and lets it produce a real execution effect", async () => {
+		const ws = seedWorkspace();
+		try {
+			const tool = createRestrictedBashTool(ws.dir, ["touch"]);
+			const sentinel = path.join(ws.dir, "admitted-sentinel.txt");
+
+			await tool.execute("tool-call", { command: "touch admitted-sentinel.txt" });
+
+			// No allowlist rejection can reach this line: they all throw at bash.ts
+			// before execution, so the sentinel would not exist.
+			expect(fs.existsSync(sentinel)).toBe(true);
+			// Admission is not permission to touch state.
+			expect(snapshotTree(path.join(ws.dir, ".gjc"))).toBe(ws.snapshot);
+		} finally {
+			ws.cleanup();
+		}
+	});
+
+	it("refuses a command outside the allowlist even when another prefix is allowed", async () => {
+		const ws = seedWorkspace();
+		try {
+			const tool = createRestrictedBashTool(ws.dir, ["touch"]);
+
+			await expect(tool.execute("tool-call", { command: "gjc state ralplan clear" })).rejects.toThrow(
+				"only allows commands starting with",
+			);
+			expect(fs.existsSync(path.join(ws.dir, "admitted-sentinel.txt"))).toBe(false);
+		} finally {
+			ws.cleanup();
+		}
+	});
+
+	/**
+	 * Detector sensitivity. Every other assertion here expects the snapshot to be
+	 * unchanged, so an inert or incomplete oracle would keep them all green. This
+	 * applies known isolated mutations and requires the snapshot to differ.
+	 */
+	it.each([
+		["new file", (dir: string) => fs.writeFileSync(path.join(dir, ".gjc", "state", "injected.json"), "{}")],
+		[
+			"content change",
+			(dir: string) => fs.writeFileSync(path.join(dir, ".gjc", "state", "ultragoal-state.json"), '{"goals":["x"]}'),
+		],
+		["deletion", (dir: string) => fs.rmSync(path.join(dir, ".gjc", "state", "ultragoal-state.json"))],
+		["mode change", (dir: string) => fs.chmodSync(path.join(dir, ".gjc", "state", "ralplan-state.json"), 0o600)],
+		["directory mode change", (dir: string) => fs.chmodSync(path.join(dir, ".gjc", "state", "active"), 0o700)],
+		[
+			"symlink retarget",
+			(dir: string) => {
+				const link = path.join(dir, ".gjc", "state", "active", "latest.json");
+				fs.unlinkSync(link);
+				fs.symlinkSync(path.join("..", "ultragoal-state.json"), link);
+			},
+		],
+		[
+			"timestamp touch",
+			(dir: string) => {
+				const target = path.join(dir, ".gjc", "state", "ralplan-state.json");
+				const future = new Date(Date.now() + 60_000);
+				fs.utimesSync(target, future, future);
+			},
+		],
+	])("snapshot detects a %s inside the state tree", (_label, mutate) => {
+		const ws = seedWorkspace();
+		try {
+			const root = path.join(ws.dir, ".gjc");
+			expect(snapshotTree(root)).toBe(ws.snapshot);
+
+			mutate(ws.dir);
+
+			expect(snapshotTree(root)).not.toBe(ws.snapshot);
+		} finally {
+			ws.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
Implements the slice admitted on #2698 for #2665:

> **ADMITTED / CONTRIBUTOR-CLAIMED** — The July 29 claim by `@10kH` is accepted. Current scope is one **test-only** PR against live `dev`: instantiate a real restricted-role `BashTool`, drive destructive/effective `gjc state` shapes, assert `ToolError`, and prove a seeded state file is byte-identical before/after. No product-code expansion belongs in that PR.

Test-only. No product file is touched.

## What was missing

`test/tools/bash-allowed-prefixes.test.ts` already has 20 cases, but they call `classifyStateArgv` and `checkBashAllowedPrefixes` **directly**. Those are classifier-level assertions — they prove the policy function returns `allowed: false`.

Nothing constructed a `BashTool`, so nothing exercised the rejection at `bash.ts:600`, and nothing looked at the filesystem. *"The policy said no"* and *"the state file was not modified"* are separate claims: a guard can reject while an earlier path has already written.

## What this adds

`test/tools/bash-state-exploit.test.ts` — 8 cases:

- 5 parameterized destructive `gjc state` shapes (clear, handoff, unknown target, bare target, equals-form unknown mode), each driven through `BashTool.execute()` under `bashRestrictionProfile: "workflow"` with the role-agent prefixes. Every one begins with an allowlisted prefix, so a naive prefix check would admit all five.
- Each asserts the **specific** allowlist rejection, then compares a `sha256` of a seeded `.gjc/state/ralplan-state.json` before and after.
- A case proving no `.gjc` tree is created when none existed.
- A non-allowlisted command (`rm -rf .gjc`) blocked outright, state still byte-identical.
- A sanctioned read (`gjc state ralplan read --json`) that must **not** be rejected by the allowlist, so the suite cannot pass by blocking everything.

## Asserting the specific reason is load-bearing

My first draft used a bare `.rejects.toThrow()`. The reversal proof caught it: `gjc` is not on PATH in CI, so those five cases threw a spawn failure and **stayed green with the guard removed**. They were passing for the wrong reason.

Each case now pins the reason the runtime actually emits:

```
gjc state ralplan clear          -> does not allow `gjc state clear`
gjc state ralplan handoff        -> does not allow `gjc state handoff`
gjc state not-a-skill read       -> canonical workflow skill
gjc state                        -> canonical workflow skill
rm -rf .gjc                      -> only allows commands starting with: ...
```

Reversal proof at `bash.ts:600` (`if (!allowlist.allowed)` neutralized):

```
guard present:  8 pass / 0 fail
guard removed:  1 pass / 7 fail
```

The one that stays green is the sanctioned-read case, which is correct — it asserts admission, not rejection.

## CI note

`dev` is currently red independently of this branch, consistent with the 08-09 note on #2698 that the exact-head Dev CI run is terminal failure. Measured on both sides:

```
clean origin/dev            1034 pass / 262 fail   (bun run check exit 1)
this branch                 1042 pass / 262 fail
```

Exactly +8 passes, no new failures. The 262 are inherited.
