### PR TITLE
fix(sdk): surface the real startup failure instead of a generic one

### DIFF
--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -4445,7 +4445,7 @@ export async function executeLifecycle(
 									}
 								: {
 										code: "spawn_failed",
-										message: "No ready SDK endpoint remains available.",
+										message: startupFailure.message,
 										endpoint: "unavailable" as const,
 									},
 							...(durableEffects ? { durableEffects } : {}),

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -2336,6 +2336,46 @@ test("broker propagates an owned lifecycle startup failure without semantic read
 	}
 });
 
+test("broker preserves a code-less lifecycle startup failure message", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-startup-message-"));
+	const agentDir = path.join(root, "agent");
+	const fixture = path.join(root, "startup-failure.ts");
+	const previousCommand = process.env.GJC_SDK_SESSION_COMMAND;
+	const broker = new Broker({ agentDir });
+	try {
+		await fs.writeFile(
+			fixture,
+			`import { writeSessionLifecycleFailure } from ${JSON.stringify(path.resolve(import.meta.dir, "../src/sdk/broker/lifecycle.ts"))};
+const request = JSON.parse(process.env.GJC_SDK_LIFECYCLE_REQUEST!);
+await writeSessionLifecycleFailure(
+	request.stateRoot,
+	request.sessionId,
+	request.effectMarker,
+	{ phase: "startup", reason: "failed", message: "owned synthetic startup failure" },
+	{ endpointGeneration: null, fenced: true, runtimeRemoved: true, hostStopped: true, brokerRegistrationReleased: true },
+);
+await Bun.sleep(60_000);
+`,
+		);
+		process.env.GJC_SDK_SESSION_COMMAND = `${process.execPath} ${fixture}`;
+		await broker.start();
+		const response = await broker.handleRequest(
+			"session.create",
+			{ cwd: root, readinessTimeoutMs: 4_000 },
+			"code-less-startup-failure",
+		);
+		expect(response).toMatchObject({
+			ok: false,
+			error: { code: "spawn_failed", message: "owned synthetic startup failure" },
+		});
+	} finally {
+		if (previousCommand === undefined) delete process.env.GJC_SDK_SESSION_COMMAND;
+		else process.env.GJC_SDK_SESSION_COMMAND = previousCommand;
+		await broker.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});
+
 test("broker replays immutable lifecycle cleanup after a crash immediately after an exact detach", async () => {
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-ledger-crash-"));
 	const agentDir = path.join(root, "agent");
@@ -2455,7 +2495,10 @@ await fs.rm(endpoint);
 				{ cwd: normalRoot, sessionId: normalSessionId, sessionPath: normalSessionPath },
 				"normal-after-verification",
 			);
-			expect(normalResponse).toMatchObject({ ok: false, error: { code: "spawn_failed" } });
+			expect(normalResponse).toMatchObject({
+				ok: false,
+				error: { code: "spawn_failed", message: "owned synthetic startup failure" },
+			});
 			const normalTerminal = (await fs.readFile(path.join(normalAgentDir, "sdk", "lifecycle-ledger.jsonl"), "utf8"))
 				.split("\n")
 				.filter(Boolean)
@@ -3309,7 +3352,7 @@ test("production post-registration startup failure proves cleanup and exact repl
 			ok: false,
 			error: {
 				code: "spawn_failed",
-				message: "No ready SDK endpoint remains available.",
+				message: "Lifecycle test failure after SDK host registration.",
 				endpoint: "unavailable",
 			},
 			startupFailure: {


### PR DESCRIPTION
Refs #4146. Fixes the diagnosability half — the part that made this issue hard to work on.

## The message was lying

`session.create` fails with:

```
Failed to create agent: Internal error: No ready SDK endpoint remains available.
```

That names a resource which was **never exhausted**. `packages/coding-agent/src/sdk/broker/lifecycle.ts:4404-4407` rewrote any *code-less* startup failure into that string, discarding the real one.

The live ledger on my machine records the truth — 33 occurrences of:

```json
{ "phase": "startup", "reason": "pending",
  "message": "SDK startup did not complete before readiness cutoff.",
  "endpointGeneration": null, "code": null }
```

`endpointGeneration: null` is the giveaway: startup never reached generation recording (`sdk/bus/index.ts:5529-5530`), so no endpoint or broker registration existed to run out of. `code: null` is why the rewrite branch fired.

## What is actually exhausted

The **semantic-readiness time budget**, not a pool:

- default lifecycle budget **10,000 ms** (`startup-budget.ts`)
- two 1,000 ms cleanup/termination windows reserved (`lifecycle.ts:105-125`)
- so the child gets roughly **8 seconds** to become semantically ready
- `commands/sdk.ts:615-673` fails when `semanticReadyDeadlineAt` wins the `Promise.race`

I chased a leak first — I posted a wrong "4336 dead index rows" figure on the issue and corrected it there. The index is an append-only event log; folded, it is ~11 net-registered / 10 alive, and the reaper (`lifecycle.ts:4549`, sweep at `:4581`) works. Anyone reading that first comment should read the correction.

## Fix

One line: when a startup failure carries a message but no code, surface **its** message rather than the generic one. A genuinely absent failure still gets the old text.

## Deliberately not done

- **Not raising the readiness budget.** That hides whatever is slow instead of naming it.
- **Not logging-only.** Operators read the error, not the ledger.

## Verification

| run | result |
|---|---|
| `bun test packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts` | **62 pass / 0 fail** |
| mutation — restore the generic message | **60 pass / 2 fail** |
| re-apply | **62 pass / 0 fail** |
| `bun --cwd=packages/coding-agent run check:types` | exit 0 |
| biome 2.5.2 on both changed files | clean |
| preflight (head contains `origin/dev`) | PASS |

Mutation re-run by me against the committed branch, and typecheck included — I shipped a regression earlier today that every test passed and only `tsc` caught.

## Ruled out while investigating

- Ledger growth **is** bounded: 64 MB / 10,000 rows, corrupt sidecars rotate at 8 MB (`lifecycle-ledger.ts:112-117, 494-600`). The 279 MB `.corrupt.1` predates that bound.
- `broker-spawn.log` covers broker spawning, not detached session-host stderr.
- **#4149 would not have prevented this.** It fixes a concurrent-launch publication race; this was a single `session.create` against a healthy broker. #4146 has two distinct causes and this PR addresses neither the race nor the timeout itself — only the misreporting.

## Still open on #4146

Which startup stage consumes the ~8 s. The evidence cannot distinguish model-profile startup from extension initialization from waiting on the SDK capability, because detached child stderr is discarded at `lifecycle.ts:3248-3252`. Pinning it needs the active stage plus elapsed/remaining ms persisted into the failure artifact around `commands/sdk.ts:632-657`. Keeping the issue open for that.