### PR TITLE
fix(secrets): keyed replace-mode replacement derivation (#4166)

### DIFF
--- a/artifacts/issue-4166-reproduction-post-fix.txt
+++ b/artifacts/issue-4166-reproduction-post-fix.txt
@@ -1,0 +1,18 @@
+ISSUE #4166 REPRODUCTION — synthetic secrets only
+secret: acme-staging-2024
+
+replace   mode, key A: db pw = oitcxwbZX7Prcj62r
+replace   mode, key B: db pw = cgk3bBesb0CbWkA02
+replace   identical across keys: false
+
+obfuscate mode, key A: #GJC1_bFh-uukOr7TBEvFUQ6Ty7A#
+obfuscate mode, key B: #GJC1_ck0xz90VeyjA5qLBXYT6ew#
+obfuscate differs across keys: true
+
+OFFLINE CONFIRMATION ORACLE (no key needed)
+observed replacement: oitcxwbZX7Prcj62r
+candidate list: acme-staging-2024, prod-db-pass-1, staging-2024, dev-password-1, acme-prod-2024
+recovered secret: (none)
+length disclosure: observed length 17 == secret length 17
+
+NOT reproduced

--- a/artifacts/issue-4166-reproduction-pre-fix.txt
+++ b/artifacts/issue-4166-reproduction-pre-fix.txt
@@ -1,0 +1,18 @@
+ISSUE #4166 REPRODUCTION — synthetic secrets only
+secret: acme-staging-2024
+
+replace   mode, key A: db pw = Y2tNGUZTSWzL2Y91O
+replace   mode, key B: db pw = Y2tNGUZTSWzL2Y91O
+replace   identical across keys: true
+
+obfuscate mode, key A: #GJC1_bFh-uukOr7TBEvFUQ6Ty7A#
+obfuscate mode, key B: #GJC1_ck0xz90VeyjA5qLBXYT6ew#
+obfuscate differs across keys: true
+
+OFFLINE CONFIRMATION ORACLE (no key needed)
+observed replacement: Y2tNGUZTSWzL2Y91O
+candidate list: acme-staging-2024, prod-db-pass-1, staging-2024, dev-password-1, acme-prod-2024
+recovered secret: acme-staging-2024
+length disclosure: observed length 17 == secret length 17
+
+VULNERABILITY CONFIRMED: offline confirmation without key

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Streamed edit preview coalescing now keys on the complete partial-JSON payload rather than its length, so same-size in-place argument replacements recompute and render while repeated payloads remain cached.
 - CLI parsing now fails closed by default, while launch and ACP explicitly defer only their owned startup options; this preserves ACP-specific diagnostics, SDK startup forwarding, real ACP subprocess framing, and RLM typo rejection without exposing retired flags in root help or completion.
 - Read-tool code summarization and ZIP extraction now run asynchronously instead of blocking the TUI event loop during structural parsing or decompression.
+- `secrets.yml` entries with `mode: "replace"` and no explicit `replacement` now derive their substitute from a keyed, domain-separated HMAC-SHA256 construction over the process key instead of an unkeyed public `Bun.hash`. Derived replacements are no longer confirmable offline without the key (issue #4166); same-process determinism, same-length output, and alphanumeric character behavior are preserved, and explicit `replacement` values are unchanged. Note: derived replacements differ across processes/key rotations — set an explicit `replacement` when a stable value is required.
 
 ## [0.12.21] - 2026-08-09
 

--- a/packages/coding-agent/src/secrets/obfuscator.ts
+++ b/packages/coding-agent/src/secrets/obfuscator.ts
@@ -21,17 +21,95 @@ export interface SecretEntry {
 
 const REPLACEMENT_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
-/** Generate a deterministic same-length replacement string from a secret value. */
-function generateDeterministicReplacement(secret: string): string {
-	// Simple hash: use Bun.hash for speed, seed from the secret bytes
-	const hash = BigInt(Bun.hash(secret));
+/**
+ * Domain separator for replace-mode replacement derivation. Distinct from
+ * `PLACEHOLDER_DOMAIN` so a value minted under one construction can never be
+ * confused with a value minted under the other, even with the same key.
+ */
+const REPLACEMENT_DOMAIN = "gjc.secret-obfuscation.replacement.v1\0";
+
+/** One HMAC-SHA256 digest block length in bytes. */
+const REPLACEMENT_DIGEST_BYTES = 32;
+
+/** Largest accepted byte for uniform rejection sampling (256 - (256 % 62)). */
+const REPLACEMENT_REJECT_THRESHOLD = 248;
+
+/**
+ * Generate a deterministic, keyed, same-length replacement string from a
+ * secret value.
+ *
+ * COMPATIBILITY CONTRACT (required behavior, must never regress):
+ * - Deterministic within a process: the same secret under the same key always
+ *   yields the same replacement, independent of entry order or call order.
+ * - Same length: `result.length === secret.length` (UTF-16 code units, i.e.
+ *   `String.prototype.length` semantics — unchanged from the pre-fix
+ *   implementation). Astral-plane characters count as two units, exactly as
+ *   they did before.
+ * - Allowed characters: output is restricted to `[A-Za-z0-9]` (62 chars).
+ * - Explicit `replacement` values in secrets.yml are authoritative and are
+ *   never derived; this path runs only when `replacement` is undefined.
+ * - Replace mode stays one-way: the derived value is never reversed by
+ *   `deobfuscate()`.
+ *
+ * THREAT MODEL (issue #4166):
+ * - Attacker model: an observer sees one or more replacements (model context,
+ *   provider-side logs, saved/shared transcripts) and has full knowledge of
+ *   the public algorithm. Without the 32-byte obfuscation key they cannot
+ *   confirm a candidate secret offline and cannot predict or precompute the
+ *   replacement for any secret. The construction is a keyed PRF
+ *   (HMAC-SHA256), so output is unpredictable without the key, and keyed
+ *   domain separation keeps this construction distinct from the placeholder
+ *   construction.
+ * - Accepted residual disclosure: the replacement is same-length by design
+ *   (required behavior above), so the secret's exact length is still
+ *   observable. This is inherent to size-preserving substitution and is
+ *   explicitly out of scope; the fix removes the *keyless confirmation*
+ *   oracle, not the length signal.
+ * - Cross-process stability / key rotation: the process key is generated per
+ *   process (`PROCESS_SECRET_OBFUSCATION_KEY`), so derived replacements are
+ *   stable within a process and differ across processes or after a key
+ *   rotation. This is a deliberate decision, identical in scope to the
+ *   obfuscate-mode placeholder behavior. Users who need stable values across
+ *   processes or restarts must set an explicit `replacement` in secrets.yml.
+ * - Collision/bias: output is a keyed pseudorandom mapping. Two distinct
+ *   secrets can in principle collide (birthday bound over the 62^len output
+ *   space); for realistic secret lengths this is negligible. Character
+ *   distribution is uniform by construction: digest bytes are rejection-
+ *   sampled (bytes 248-255 rejected, 256 - (256 % 62) = 248 = 62 * 4), so
+ *   every character is exactly equally likely, with no modulo bias.
+ * - Empty secrets: a zero-length secret yields an empty replacement and the
+ *   obfuscator treats it as a no-op (load-time validation rejects empty
+ *   content anyway). Unicode secrets are hashed as UTF-8 bytes, so encoding
+ *   is canonical. Very long secrets expand via a counter-based HMAC stream
+ *   in O(length) blocks; generation cost is linear in the secret length.
+ * - Overlapping secrets and streaming: derivation is per-secret and does not
+ *   depend on matching semantics (longest-first overlap handling is
+ *   unchanged), and `obfuscate()` runs per complete text payload, so chunked
+ *   output (e.g. streamed LLM messages) sees the same deterministic
+ *   replacement for the same secret within a process.
+ */
+function generateDeterministicReplacement(secret: string, key: Uint8Array): string {
+	const length = secret.length;
+	if (length === 0) return "";
 	const chars: string[] = [];
-	let h = hash;
-	for (let i = 0; i < secret.length; i++) {
-		// Mix the hash for each character position
-		h = h ^ (BigInt(i + 1) * 0x9e3779b97f4a7c15n);
-		const idx = Number((h < 0n ? -h : h) % BigInt(REPLACEMENT_CHARS.length));
-		chars.push(REPLACEMENT_CHARS[idx]);
+	// CTR-style expansion: HMAC(key, DOMAIN || counter || secret) per 32-byte
+	// block. The counter is big-endian and fixed-width, so the stream is
+	// unambiguous and never repeats.
+	const counter = new Uint8Array(8);
+	const counterView = new DataView(counter.buffer);
+	let block: Uint8Array | undefined;
+	let blockOffset = REPLACEMENT_DIGEST_BYTES;
+	let blockIndex = 0;
+	while (chars.length < length) {
+		if (block === undefined || blockOffset >= REPLACEMENT_DIGEST_BYTES) {
+			counterView.setUint32(4, blockIndex, false);
+			block = createHmac("sha256", key).update(REPLACEMENT_DOMAIN).update(counter).update(secret, "utf8").digest();
+			blockOffset = 0;
+			blockIndex++;
+		}
+		const byte = block[blockOffset++]!;
+		if (byte >= REPLACEMENT_REJECT_THRESHOLD) continue;
+		chars.push(REPLACEMENT_CHARS[byte % REPLACEMENT_CHARS.length]!);
 	}
 	return chars.join("");
 }
@@ -115,7 +193,8 @@ export class SecretObfuscator {
 					index++;
 				} else {
 					// replace mode
-					const replacement = entry.replacement ?? generateDeterministicReplacement(entry.content);
+					const replacement =
+						entry.replacement ?? generateDeterministicReplacement(entry.content, this.#placeholderKey);
 					this.#replaceMappings.set(entry.content, replacement);
 				}
 			} else {
@@ -168,7 +247,8 @@ export class SecretObfuscator {
 
 			for (const matchValue of matches) {
 				if (entry.mode === "replace") {
-					const replacement = entry.replacement ?? generateDeterministicReplacement(matchValue);
+					const replacement =
+						entry.replacement ?? generateDeterministicReplacement(matchValue, this.#placeholderKey);
 					result = replaceAll(result, matchValue, replacement);
 				} else {
 					// obfuscate mode — get or create stable index

--- a/packages/coding-agent/test/secrets-obfuscator.test.ts
+++ b/packages/coding-agent/test/secrets-obfuscator.test.ts
@@ -482,3 +482,131 @@ describe("SecretObfuscator authenticated placeholders", () => {
 		expect(crossKey.deobfuscate(obfuscated)).toBe(obfuscated);
 	});
 });
+const REPLACEMENT_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+describe("SecretObfuscator keyed deterministic replacement", () => {
+	const otherKey = Uint8Array.from({ length: 32 }, (_, index) => 255 - index);
+
+	function replaceOutput(key: Uint8Array, secret: string, text = `db pw = ${secret}`): string {
+		return new SecretObfuscator([{ type: "plain", content: secret, mode: "replace" }], key).obfuscate(text);
+	}
+
+	function derivedReplacement(key: Uint8Array, secret: string): string {
+		const output = replaceOutput(key, secret, secret);
+		expect(output.length).toBe(secret.length);
+		return output;
+	}
+
+	it("derives replace-mode replacements from the key (key A/B divergence)", () => {
+		const secret = "acme-staging-2024";
+		expect(replaceOutput(TEST_KEY, secret)).not.toBe(replaceOutput(otherKey, secret));
+	});
+
+	it("is mutation-sensitive to the key: flipping one key byte changes the replacement", () => {
+		const secret = "acme-staging-2024";
+		const flipped = Uint8Array.from(TEST_KEY);
+		flipped[0]! ^= 1;
+		expect(replaceOutput(TEST_KEY, secret)).not.toBe(replaceOutput(flipped, secret));
+	});
+
+	it("is mutation-sensitive to the secret: changing one character changes the replacement", () => {
+		expect(replaceOutput(TEST_KEY, "acme-staging-2024")).not.toBe(replaceOutput(TEST_KEY, "acme-staging-2025"));
+	});
+
+	it("prevents offline confirmation without the key", () => {
+		const secret = "acme-staging-2024";
+		const observed = replaceOutput(TEST_KEY, secret).split("db pw = ")[1]!;
+		const candidates = ["prod-db-pass-1", "staging-2024", "dev-password-1", "acme-prod-2024", "acme-staging-2024"];
+		// Attacker guesses with an attacker-chosen key: no candidate reproduces the observation.
+		for (const candidate of candidates) {
+			expect(replaceOutput(otherKey, candidate).split("db pw = ")[1]).not.toBe(observed);
+		}
+		// Positive control: with the true key, exactly the true secret matches.
+		expect(replaceOutput(TEST_KEY, secret).split("db pw = ")[1]).toBe(observed);
+		expect(replaceOutput(TEST_KEY, "prod-db-pass-1").split("db pw = ")[1]).not.toBe(observed);
+	});
+
+	it("keeps deterministic same-process output regardless of entry order", () => {
+		const secret = "acme-staging-2024";
+		const first = new SecretObfuscator([{ type: "plain", content: secret, mode: "replace" }], TEST_KEY);
+		const second = new SecretObfuscator(
+			[
+				{ type: "plain", content: "other-secret" },
+				{ type: "plain", content: secret, mode: "replace" },
+			],
+			TEST_KEY,
+		);
+		expect(second.obfuscate(`db pw = ${secret}`)).toBe(first.obfuscate(`db pw = ${secret}`));
+	});
+
+	it("preserves same-length alphanumeric output for ASCII, Unicode, and very long secrets", () => {
+		const secrets = ["a", "acme-staging-2024", "héllo🔑secret", "x".repeat(5000)];
+		for (const secret of secrets) {
+			const output = derivedReplacement(TEST_KEY, secret);
+			expect(output).toMatch(/^[A-Za-z0-9]*$/);
+		}
+	});
+
+	it("never exposes the secret in replace-mode output", () => {
+		const secrets = ["acme-staging-2024", "super-secret-token-abc", "x".repeat(64)];
+		for (const secret of secrets) {
+			const output = new SecretObfuscator([{ type: "plain", content: secret, mode: "replace" }], TEST_KEY).obfuscate(
+				`db pw = ${secret} and again ${secret}`,
+			);
+			expect(output).not.toContain(secret);
+			expect(output).toMatch(/^db pw = [A-Za-z0-9]+ and again [A-Za-z0-9]+$/);
+		}
+	});
+
+	it("leaves explicit replacement values byte-identical", () => {
+		const secret = "acme-staging-2024";
+		const obfuscator = new SecretObfuscator(
+			[{ type: "plain", content: secret, mode: "replace", replacement: "FIXED-VALUE" }],
+			TEST_KEY,
+		);
+		expect(obfuscator.obfuscate(`db pw = ${secret}`)).toBe("db pw = FIXED-VALUE");
+		expect(obfuscator.obfuscate(secret)).toBe("FIXED-VALUE");
+	});
+
+	it("keys regex-discovered replace-mode substitutions too", () => {
+		const matchText = "token-ab12";
+		const keyed = new SecretObfuscator([{ type: "regex", content: "token-[a-z0-9]+", mode: "replace" }], TEST_KEY);
+		const other = new SecretObfuscator([{ type: "regex", content: "token-[a-z0-9]+", mode: "replace" }], otherKey);
+		const keyedOut = keyed.obfuscate(`value=${matchText}`);
+		expect(keyedOut).not.toContain(matchText);
+		expect(keyedOut).toMatch(/^value=[A-Za-z0-9]+$/);
+		expect(keyedOut).not.toBe(other.obfuscate(`value=${matchText}`));
+		expect(keyedOut.length).toBe(other.obfuscate(`value=${matchText}`).length);
+	});
+
+	it("treats an empty derived secret as a no-op replacement", () => {
+		const obfuscator = new SecretObfuscator([{ type: "plain", content: "", mode: "replace" }], TEST_KEY);
+		expect(obfuscator.obfuscate("unchanged text")).toBe("unchanged text");
+	});
+
+	it("spreads derived characters across the alphabet without modulo bias", () => {
+		let seed = 0x4166_2024;
+		const random = (): number => {
+			seed = (seed * 1664525 + 1013904223) >>> 0;
+			return seed / 0x100000000;
+		};
+		const counts = new Map<string, number>();
+		let total = 0;
+		for (let round = 0; round < 200; round++) {
+			let secret = "";
+			for (let i = 0; i < 32; i++) secret += REPLACEMENT_ALPHABET[Math.floor(random() * 62)]!;
+			const output = derivedReplacement(TEST_KEY, secret);
+			for (const char of output) {
+				counts.set(char, (counts.get(char) ?? 0) + 1);
+				total++;
+			}
+		}
+		expect(total).toBe(200 * 32);
+		const expected = total / 62;
+		for (const char of REPLACEMENT_ALPHABET) {
+			const count = counts.get(char) ?? 0;
+			expect(count).toBeGreaterThan(expected * 0.5);
+			expect(count).toBeLessThan(expected * 1.5);
+		}
+	});
+});


### PR DESCRIPTION
Closes #4166

## Summary

`secrets.yml` entries with `mode: "replace"` and no explicit `replacement` derived their substitute from an **unkeyed public function** (`Bun.hash(secret)`). An observer who saw one replacement could confirm candidate secrets offline (the algorithm is public and keyless) and read the secret's exact length (the replacement is same-length by construction).

This PR replaces the derivation with a **keyed, domain-separated HMAC-SHA256 construction** over the existing process key (`PROCESS_SECRET_OBFUSCATION_KEY`), expanded counter-style with uniform rejection sampling. The construction mirrors the already-keyed placeholder path and uses a distinct domain (`gjc.secret-obfuscation.replacement.v1`).

## Reproduction evidence (synthetic secrets only — no real credentials)

- `artifacts/issue-4166-reproduction-pre-fix.txt` — pre-fix: replace output identical across key A/B; offline oracle recovers `acme-staging-2024` from one observed replacement with no key; length disclosure 17 == 17.
- `artifacts/issue-4166-reproduction-post-fix.txt` — post-fix: replace output diverges across keys; offline oracle finds nothing; same-length/alphanumeric preserved.

## Compatibility contract (preserved)

- Deterministic within a process: same secret + same key → same replacement, independent of entry order.
- Same length: `result.length === secret.length` (UTF-16 code units, unchanged semantics).
- Allowed characters: `[A-Za-z0-9]` only.
- Explicit `replacement` values in `secrets.yml` are authoritative and byte-identical — the derived path runs only when `replacement` is undefined.
- Replace mode stays one-way: `deobfuscate()` never reverses derived replacements.

## Decisions

| Topic | Decision |
|---|---|
| Threat model | Attacker knows the public algorithm and observes replacements (model context, provider logs, saved/shared transcripts). Without the 32-byte process key they cannot confirm candidates offline or precompute/predict any replacement. |
| Residual disclosure | Same-length output is required behavior, so exact secret length remains observable. The fix removes the *keyless confirmation* oracle, not the length signal. |
| Cross-process / key rotation | Key is process-local, so derived replacements differ across processes and after rotation — deliberate, identical in scope to placeholder behavior. Users needing stable values set an explicit `replacement`. |
| Collision / bias | Keyed pseudorandom mapping; collisions bounded by birthday over the 62^len output space (negligible for realistic lengths). Rejection sampling (reject bytes 248–255) makes every character exactly equally likely — no modulo bias; covered by a deterministic distribution test. |
| Empty / Unicode / very long | Empty → empty replacement, no-op (load-time validation rejects empty content anyway). Unicode hashed as UTF-8 (canonical); length counted in UTF-16 units. Very long secrets expand in O(length) blocks. |
| Overlapping secrets / streaming | Derivation is per-secret and independent of longest-first overlap matching; `obfuscate()` runs per complete payload, so streamed chunks see the same deterministic replacement within a process. |

## Tests

New `SecretObfuscator keyed deterministic replacement` block in `packages/coding-agent/test/secrets-obfuscator.test.ts`:

- key A/B divergence (and one-byte key flip mutation)
- no offline confirmation without the key (attacker-chosen key matches no candidate; positive control with the true key)
- mutation-sensitive secret change
- same-process determinism independent of entry order
- same-length alphanumeric output for ASCII, Unicode (astral), and 5000-char secrets
- no credential exposure in replace-mode output
- explicit replacement byte-identical
- regex-discovered replace substitutions keyed too
- empty-secret no-op
- uniform character distribution (no modulo bias)

Verified: `bun test packages/coding-agent/test/secrets-obfuscator.test.ts packages/coding-agent/test/memories-redact-secrets.test.ts` (42 pass) and `bun --cwd=packages/coding-agent run check` (biome + tsc clean).

## Notes

- No merge by the contributor; awaiting maintainer review.
- No real secrets in tests, logs, or evidence artifacts.
