### PR TITLE
fix(secrets): key the replace-mode substitute derivation

### DIFF
--- a/packages/coding-agent/src/secrets/obfuscator.ts
+++ b/packages/coding-agent/src/secrets/obfuscator.ts
@@ -21,17 +21,12 @@ export interface SecretEntry {
 
 const REPLACEMENT_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
-/** Generate a deterministic same-length replacement string from a secret value. */
-function generateDeterministicReplacement(secret: string): string {
-	// Simple hash: use Bun.hash for speed, seed from the secret bytes
-	const hash = BigInt(Bun.hash(secret));
+/** Generate a deterministic same-length replacement string from keyed secret bytes. */
+function generateDeterministicReplacement(secret: string, key: Uint8Array): string {
+	const digest = deriveSecretDigest(secret, key);
 	const chars: string[] = [];
-	let h = hash;
 	for (let i = 0; i < secret.length; i++) {
-		// Mix the hash for each character position
-		h = h ^ (BigInt(i + 1) * 0x9e3779b97f4a7c15n);
-		const idx = Number((h < 0n ? -h : h) % BigInt(REPLACEMENT_CHARS.length));
-		chars.push(REPLACEMENT_CHARS[idx]);
+		chars.push(REPLACEMENT_CHARS[digest[i % digest.length]! % REPLACEMENT_CHARS.length]!);
 	}
 	return chars.join("");
 }
@@ -43,14 +38,13 @@ function generateDeterministicReplacement(secret: string): string {
 const PLACEHOLDER_DOMAIN = "gjc.secret-obfuscation.placeholder.v1\0";
 const PLACEHOLDER_RE = /#GJC1_[A-Za-z0-9_-]{22}#/g;
 
+function deriveSecretDigest(secret: string, key: Uint8Array): Uint8Array {
+	return createHmac("sha256", key).update(PLACEHOLDER_DOMAIN).update(secret, "utf8").digest();
+}
+
 /** Build a versioned, authenticated placeholder whose identity depends only on the key and secret. */
 function buildPlaceholder(secret: string, key: Uint8Array): string {
-	const tag = createHmac("sha256", key)
-		.update(PLACEHOLDER_DOMAIN)
-		.update(secret, "utf8")
-		.digest()
-		.subarray(0, 16)
-		.toString("base64url");
+	const tag = Buffer.from(deriveSecretDigest(secret, key)).subarray(0, 16).toString("base64url");
 	return `#GJC1_${tag}#`;
 }
 
@@ -115,7 +109,8 @@ export class SecretObfuscator {
 					index++;
 				} else {
 					// replace mode
-					const replacement = entry.replacement ?? generateDeterministicReplacement(entry.content);
+					const replacement =
+						entry.replacement ?? generateDeterministicReplacement(entry.content, this.#placeholderKey);
 					this.#replaceMappings.set(entry.content, replacement);
 				}
 			} else {
@@ -168,7 +163,8 @@ export class SecretObfuscator {
 
 			for (const matchValue of matches) {
 				if (entry.mode === "replace") {
-					const replacement = entry.replacement ?? generateDeterministicReplacement(matchValue);
+					const replacement =
+						entry.replacement ?? generateDeterministicReplacement(matchValue, this.#placeholderKey);
 					result = replaceAll(result, matchValue, replacement);
 				} else {
 					// obfuscate mode — get or create stable index

--- a/packages/coding-agent/test/secrets-obfuscator.test.ts
+++ b/packages/coding-agent/test/secrets-obfuscator.test.ts
@@ -407,6 +407,44 @@ describe("SecretObfuscator sorted mapping cache", () => {
 	});
 });
 
+describe("SecretObfuscator keyed replacements", () => {
+	const otherKey = Uint8Array.from({ length: 32 }, (_, index) => 255 - index);
+
+	it("keeps plain replacements stable, keyed, same-length, and alphanumeric", () => {
+		const value = "synthetic-credential-value-longer-than-one-digest-block";
+		const entries = [{ type: "plain" as const, content: value, mode: "replace" as const }];
+		const replacement = new SecretObfuscator(entries, TEST_KEY).obfuscate(value);
+
+		expect(new SecretObfuscator(entries, TEST_KEY).obfuscate(value)).toBe(replacement);
+		expect(new SecretObfuscator(entries, otherKey).obfuscate(value)).not.toBe(replacement);
+		expect(replacement).toHaveLength(value.length);
+		expect(replacement).toMatch(/^[A-Za-z0-9]+$/);
+	});
+
+	it("keeps regex-derived replacements stable, keyed, same-length, and alphanumeric", () => {
+		const value = "synthetic-regex-value";
+		const entries = [{ type: "regex" as const, content: "synthetic-[a-z-]+", mode: "replace" as const }];
+		const replacement = new SecretObfuscator(entries, TEST_KEY).obfuscate(value);
+
+		expect(new SecretObfuscator(entries, TEST_KEY).obfuscate(value)).toBe(replacement);
+		expect(new SecretObfuscator(entries, otherKey).obfuscate(value)).not.toBe(replacement);
+		expect(replacement).toHaveLength(value.length);
+		expect(replacement).toMatch(/^[A-Za-z0-9]+$/);
+	});
+
+	it("preserves explicit plain and regex replacements", () => {
+		const entries = [
+			{ type: "plain", content: "synthetic-plain-value", mode: "replace", replacement: "PLAIN_REPLACEMENT" },
+			{ type: "regex", content: "synthetic-regex-[a-z]+", mode: "replace", replacement: "REGEX_REPLACEMENT" },
+		] as const;
+		const obfuscator = new SecretObfuscator([...entries], TEST_KEY);
+
+		expect(obfuscator.obfuscate("synthetic-plain-value synthetic-regex-value")).toBe(
+			"PLAIN_REPLACEMENT REGEX_REPLACEMENT",
+		);
+	});
+});
+
 describe("SecretObfuscator authenticated placeholders", () => {
 	const otherKey = Uint8Array.from({ length: 32 }, (_, index) => 255 - index);
 


### PR DESCRIPTION
Fixes #4166.

## The asymmetry

`packages/coding-agent/src/secrets/obfuscator.ts` held two derivations eight lines apart:

- **obfuscate mode** — keyed: `createHmac("sha256", key).update(PLACEHOLDER_DOMAIN).update(secret)`
- **replace mode**, when `entry.replacement` is undefined — **unkeyed and public**

Unkeyed plus deterministic is the problem. An attacker with a candidate secret can compute the substitute themselves and compare it against observed output, so the substitution **confirms guesses instead of hiding them**. Determinism is required here; being unkeyed is not.

## Fix

Both paths now share `deriveSecretDigest` — the same HMAC construction `buildPlaceholder` already used. Every property the code depends on is preserved:

- deterministic within a process
- **identical length** to what it replaces
- same alphanumeric alphabet

Length mattered more than it looks: a wrong-length substitute would corrupt offsets in redacted output.

Explicit `replacement` values in `secrets.yml` are untouched — the derived path only runs when `entry.replacement` is undefined (`obfuscator.ts:118`, `:171`).

## Rejected

- **A second bespoke KDF for replace mode** — two constructions is exactly how this asymmetry appeared. Reuse, don't reinvent.
- **Asserting a fixed digest in the test** — that pins the implementation, not the security property, and breaks on any harmless refactor.

## Verification

| run | result |
|---|---|
| `bun test packages/coding-agent/test/secrets-obfuscator.test.ts` | **31 pass / 0 fail** |
| mutation — revert to an unkeyed derivation | **29 pass / 2 fail** |
| re-apply | **31 pass / 0 fail** |
| `bun --cwd=packages/coding-agent run check:types` | exit 0 |
| biome 2.5.2 on both changed files | clean |
| preflight (head contains `origin/dev`) | PASS |

The two mutation failures are the **different-key** assertions — the property that actually defeats guessing. The tests assert behaviour, not a digest:

- same secret + same key → same replacement (determinism preserved)
- same secret + **different key → different replacement** (the load-bearing one)
- length and alphabet unchanged
- an explicit `replacement` still wins

Mutation and typecheck re-run by me against the committed branch.

## Pre-existing failures

`--test-name-pattern "secret|obfusc"` across the repo gives 38 pass / 232 fail both with this change **and** on a stashed tree at the same head. Unrelated and pre-existing; flagging rather than absorbing.

## Note

Replacement values change across processes only if the key rotates per process, which `PROCESS_SECRET_OBFUSCATION_KEY` already scopes. Users needing a fixed value can still set `replacement` explicitly.

No real secret values appear in the tests or fixtures.