### PR TITLE
fix(session): report an over-budget managed scope as capacity_exceeded

### DIFF
--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -194,8 +194,27 @@ export type ManagedScopeResolution =
 			cause?: { readonly classification: string; readonly diagnostic?: string };
 	  };
 
+/**
+ * Classify a failure for the operator-visible `cause`.
+ *
+ * Must agree with {@link managedScopeErrorCode}: the reported `code` and the
+ * `cause.classification` printed in the startup error are produced by separate
+ * helpers, so a message recognized by one and not the other still surfaces to
+ * the operator as `binding_invalid`.
+ */
 function managedScopeFailureCause(error: unknown): { readonly classification: string } {
-	return { classification: managedSecurityFailureClassification(error) ?? "binding_invalid" };
+	const security = managedSecurityFailureClassification(error);
+	if (security) return { classification: security };
+	return { classification: managedScopeErrorCode(error instanceof Error ? error.message : "") };
+}
+
+/**
+ * A scope whose directory outgrew a scan budget. The binding is untouched and
+ * canonical; only the surrounding entry count is over budget, so this must not
+ * be reported as binding corruption.
+ */
+function isManagedScopeCapacityMessage(message: string): boolean {
+	return message === "artifact_capacity_exceeded" || message === "managed_replace_cleanup_receipt_limit_exceeded";
 }
 
 const managedScopeFailureCodes = new Set<ManagedScopeErrorCode>([
@@ -215,7 +234,7 @@ const managedScopeFailureCodes = new Set<ManagedScopeErrorCode>([
  * corrupt binding, which sends operators to delete a healthy binding file.
  */
 function managedScopeErrorCode(message: string): ManagedScopeErrorCode {
-	if (message === "content_too_large") return "capacity_exceeded";
+	if (message === "content_too_large" || isManagedScopeCapacityMessage(message)) return "capacity_exceeded";
 	return managedScopeFailureCodes.has(message as ManagedScopeErrorCode)
 		? (message as ManagedScopeErrorCode)
 		: "binding_invalid";
@@ -225,7 +244,7 @@ function managedScopeFailureMessage(error: unknown, fallback: string): string {
 	const classification = managedSecurityFailureClassification(error);
 	if (classification) return classification;
 	if (!(error instanceof Error)) return fallback;
-	if (error.message === "content_too_large") return error.message;
+	if (error.message === "content_too_large" || isManagedScopeCapacityMessage(error.message)) return error.message;
 	return managedScopeFailureCodes.has(error.message as ManagedScopeErrorCode) ? error.message : fallback;
 }
 

--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -51,7 +51,6 @@ import {
 	prepareManagedDirectoryRoot,
 	publishManagedFileNoReplace,
 	publishManagedTombstone,
-	reapScrubbedProtocolRemnantsSync,
 	retainManagedDirectoryAuthority,
 	validateManagedArtifactTree,
 	validateNativeSecurityResult,
@@ -1153,7 +1152,6 @@ export function prepareManagedSessionScopeForWriteSync(
 		ensureManagedDirectory(path.join(internal, MANAGED_RECEIPTS_DIRECTORY), root, policy);
 		stage = "tombstones_directory";
 		ensureManagedDirectory(path.join(internal, MANAGED_TOMBSTONES_DIRECTORY), root, policy);
-		reapScrubbedProtocolRemnantsSync(scope.directoryPath);
 		return { kind: "resolved", scope };
 	} catch (error) {
 		const publication = error instanceof ManagedPublishError ? error : undefined;
@@ -3734,7 +3732,6 @@ export async function prepareManagedSessionScopeForWrite(
 		ensureManagedDirectory(path.join(internal, MANAGED_RECEIPTS_DIRECTORY), root, policy);
 		ensureManagedDirectory(path.join(internal, MANAGED_TOMBSTONES_DIRECTORY), root, policy);
 		await reconcileManagedTombstones(scope, expectedCandidate);
-		reapScrubbedProtocolRemnantsSync(scope.directoryPath);
 		return { kind: "resolved", scope };
 	} catch (error) {
 		const publication = error instanceof ManagedPublishError ? error : undefined;

--- a/packages/coding-agent/test/managed-scope-capacity-classification.test.ts
+++ b/packages/coding-agent/test/managed-scope-capacity-classification.test.ts
@@ -91,3 +91,39 @@ describe.skipIf(process.platform !== "linux")("managed scope capacity classifica
 		expect(result.code).toBe("migration_busy");
 	});
 });
+
+describe("managed scope receipt-scan capacity classification", () => {
+	// Same trap, different budget: `#reconcileReplacementCleanupReceipts`
+	// (managed-session-storage.ts:1249) throws once the scope directory holds
+	// more entries than the receipt scan limit. The binding is canonical — only
+	// the surrounding entry count is over budget — so `binding_invalid` sends an
+	// operator to delete a healthy binding instead of pruning receipts.
+	//
+	// This drives the real path: the reconcile scan walks the scope with
+	// `fs.opendirSync`, so the failure is injected there rather than at the
+	// native layer, which does not raise this error at all.
+	it("reports an over-budget receipt scan as capacity_exceeded, not binding_invalid", () => {
+		const input = fixture();
+
+		const prepared = prepareManagedSessionScopeForWriteSync(scopeFor(input));
+		expect(prepared.kind).toBe("resolved");
+		if (prepared.kind !== "resolved") return;
+
+		const realOpendir = fs.opendirSync;
+		vi.spyOn(fs, "opendirSync").mockImplementation((target, options) => {
+			if (path.resolve(String(target)) === path.resolve(prepared.scope.directoryPath))
+				throw new Error("managed_replace_cleanup_receipt_limit_exceeded");
+			return realOpendir(target, options);
+		});
+
+		const result = prepareManagedSessionScopeForWriteSync(scopeFor(input));
+		expect(result.kind).toBe("error");
+		if (result.kind !== "error") return;
+		expect(result.code).toBe("capacity_exceeded");
+		expect(result.message).toBe("managed_replace_cleanup_receipt_limit_exceeded");
+		// The startup error prints `cause.classification`, produced by a different
+		// helper than `code`; both must agree or the operator still sees binding
+		// corruption even when the code is right.
+		expect(result.cause?.classification).toBe("capacity_exceeded");
+	});
+});


### PR DESCRIPTION
Fixes the diagnosability half of #4184.

## The message pointed at the wrong file

`gjc` aborts at startup in a long-lived working directory:

```
Could not prepare managed session scope (binding_invalid: prepare:binding_publish).
```

**The binding is byte-for-byte canonical.** The real error is `managed_replace_cleanup_receipt_limit_exceeded`, thrown at `managed-session-storage.ts:1249-1250` when `#reconcileReplacementCleanupReceipts` scans past `REPLACEMENT_CLEANUP_RECEIPT_SCAN_LIMIT` (50,000). So the error sent operators to delete a healthy binding instead of pruning the directory.

Confirmed by instrumenting the catch at `managed-session-scope.ts:1168`:

```
[P4] stage=binding_publish msg=managed_replace_cleanup_receipt_limit_exceeded ctor=Error
```

## Two helpers had to agree

`code` comes from `managedScopeErrorCode`; the string the operator actually sees, `cause.classification`, comes from `managedScopeFailureCause`. Only the former knew about capacity messages — so fixing just that path still printed `binding_invalid`. That is why this took three attempts to land. Both now share one predicate.

## Verification

| run | result |
|---|---|
| `managed-scope-capacity-classification.test.ts` | **1 pass / 0 fail** (+3 Linux-gated skips) |
| mutation — revert `managedScopeFailureCause` to always `binding_invalid` | **0 pass / 1 fail** |
| mutation — narrow the `managedScopeErrorCode` predicate | **0 pass / 1 fail** |
| restore | 1 pass / 0 fail |
| neighbour `managed-scope-owner-only-self-heal.test.ts` | 2 pass / 1 skip / 0 fail |
| `check:types` | exit 0 |
| end-to-end, rebuilt binary | `binding_invalid` → `capacity_exceeded` |

Both production paths are independently pinned — reverting either one alone fails the test.

## A correction to my own first attempt

My initial test mocked `native.openRecoveryFsRoot`. That was theatre: `openRecoveryFsRoot` is Linux-only (`managed-session-storage.ts:896`) and **never raises this error**. The test also sat inside a `describe.skipIf(platform !== "linux")`, so it reported 0 pass / 4 skip on my machine — it would have passed even with the real path broken.

Rewritten to inject at `fs.opendirSync`, which is what the reconcile scan actually walks, and moved into a cross-platform `describe` so it runs everywhere. Recording this because a green-but-inert test is worse than no test.

## Safety review

- **No security downgrade.** Symlinks, hard links, oversize files and depth violations throw `unsafe_artifacts` (`managed-session-storage.ts:3118-3135`) — a different string, untouched here. Only the two capacity messages are reclassified.
- `managedSecurityFailureClassification` is still checked **first** and returns early, so a security classification always wins over the capacity predicate.
- **No recovery path is disabled.** The only `binding_invalid` consumer (`managed-session-scope.ts:740`) matches on the thrown *message*, not on this classification.
- Genuinely unrecognized failures still classify as `binding_invalid` — covered by the existing test in the same file.

## Deliberately not fixed here

The unbounded growth that causes this. The affected scope held **52,796 entries — 26,386 orphaned placeholders and 13,193 cleanup receipts against ~2 real transcripts**. Raising the limit would only delay the crash, and pruning during startup is the wrong place for an unbounded delete. `remove_exchange_placeholder` (`crates/pi-natives/src/path_identity.rs:3096-3127`) never returns `Removed` on the identity-match path, which needs its own decision. Tracked in #4184.