### PR TITLE
fix(sdk): reconcile ordered lifecycle outcomes

### DIFF
--- a/crates/gjc-sdk/src/broker_protocol.rs
+++ b/crates/gjc-sdk/src/broker_protocol.rs
@@ -3,6 +3,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::lifecycle::{LifecycleState, UncertainStatus};
+
 /// Current broker protocol major version.
 pub const PROTOCOL_MAJOR: u32 = 3;
 
@@ -51,23 +53,23 @@ pub enum BrokerOperation {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AcceptedResponse {
-	pub id: String,
-	pub accepted: bool,
+	pub id:            String,
+	pub accepted:      bool,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub submission_id: Option<String>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub state: Option<LifecycleReconciliationState>,
+	pub state:         Option<LifecycleState>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub uncertain: Option<UncertainStatus>,
+	pub uncertain:     Option<UncertainStatus>,
 }
 
 /// Stable selector used to reconcile a lifecycle submission.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReconciliationSelector {
-	pub session_id: String,
+	pub session_id:    String,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub request_id: Option<String>,
+	pub request_id:    Option<String>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub submission_id: Option<String>,
 }
@@ -83,34 +85,11 @@ pub struct LifecycleLookupRequest {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LifecycleLookupResponse {
-	pub found: bool,
+	pub found:     bool,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub state: Option<LifecycleReconciliationState>,
+	pub state:     Option<LifecycleState>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub uncertain: Option<UncertainStatus>,
-}
-
-/// Lifecycle state observed by reconciliation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum LifecycleReconciliationState {
-	Accepted,
-	EffectStarted,
-	AwaitingReady,
-	TerminalOk,
-	TerminalError,
-	TerminalUncertain,
-}
-
-/// Status indicating that side effects may have occurred but confirmation is unavailable.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct UncertainStatus {
-	pub reason: String,
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub observed_at: Option<u64>,
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub detail: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/gjc-sdk/src/broker_protocol.rs
+++ b/crates/gjc-sdk/src/broker_protocol.rs
@@ -29,6 +29,9 @@ pub struct BrokerRequest {
 pub enum BrokerOperation {
 	#[serde(rename = "session.list")]
 	SessionList,
+	#[serde(rename = "broker.lookup_lifecycle")]
+	BrokerLookupLifecycle,
+
 	#[serde(rename = "session.get_endpoint")]
 	SessionGetEndpoint,
 	#[serde(rename = "session.create")]
@@ -43,7 +46,73 @@ pub enum BrokerOperation {
 	SessionDelete,
 }
 
-/// Global broker request result.
+/// Accepted submission acknowledgement returned by the broker.
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcceptedResponse {
+	pub id: String,
+	pub accepted: bool,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub submission_id: Option<String>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub state: Option<LifecycleReconciliationState>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub uncertain: Option<UncertainStatus>,
+}
+
+/// Stable selector used to reconcile a lifecycle submission.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReconciliationSelector {
+	pub session_id: String,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub request_id: Option<String>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub submission_id: Option<String>,
+}
+
+/// Public lifecycle lookup request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LifecycleLookupRequest {
+	pub selector: ReconciliationSelector,
+}
+
+/// Public lifecycle lookup response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LifecycleLookupResponse {
+	pub found: bool,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub state: Option<LifecycleReconciliationState>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub uncertain: Option<UncertainStatus>,
+}
+
+/// Lifecycle state observed by reconciliation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleReconciliationState {
+	Accepted,
+	EffectStarted,
+	AwaitingReady,
+	TerminalOk,
+	TerminalError,
+	TerminalUncertain,
+}
+
+/// Status indicating that side effects may have occurred but confirmation is unavailable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UncertainStatus {
+	pub reason: String,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub observed_at: Option<u64>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub detail: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BrokerResponse {

--- a/crates/gjc-sdk/src/broker_protocol.rs
+++ b/crates/gjc-sdk/src/broker_protocol.rs
@@ -3,8 +3,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::lifecycle::{LifecycleState, UncertainStatus};
-
 /// Current broker protocol major version.
 pub const PROTOCOL_MAJOR: u32 = 3;
 
@@ -48,20 +46,6 @@ pub enum BrokerOperation {
 	SessionDelete,
 }
 
-/// Accepted submission acknowledgement returned by the broker.
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AcceptedResponse {
-	pub id:            String,
-	pub accepted:      bool,
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub submission_id: Option<String>,
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub state:         Option<LifecycleState>,
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub uncertain:     Option<UncertainStatus>,
-}
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BrokerResponse {

--- a/crates/gjc-sdk/src/broker_protocol.rs
+++ b/crates/gjc-sdk/src/broker_protocol.rs
@@ -62,36 +62,6 @@ pub struct AcceptedResponse {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub uncertain:     Option<UncertainStatus>,
 }
-
-/// Stable selector used to reconcile a lifecycle submission.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ReconciliationSelector {
-	pub session_id:    String,
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub request_id:    Option<String>,
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub submission_id: Option<String>,
-}
-
-/// Public lifecycle lookup request.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct LifecycleLookupRequest {
-	pub selector: ReconciliationSelector,
-}
-
-/// Public lifecycle lookup response.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct LifecycleLookupResponse {
-	pub found:     bool,
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub state:     Option<LifecycleState>,
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub uncertain: Option<UncertainStatus>,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BrokerResponse {

--- a/crates/gjc-sdk/src/lib.rs
+++ b/crates/gjc-sdk/src/lib.rs
@@ -26,8 +26,7 @@ pub mod server;
 pub use actions::{ActionIdentity, ActionRegistry, ReplyClassification, ReplyOutcome};
 pub use broker_protocol::{
 	BrokerClientFrame, BrokerError, BrokerHello, BrokerOperation, BrokerRequest, BrokerResponse,
-	BrokerServerFrame, LifecycleLookupRequest, LifecycleLookupResponse, PROTOCOL_MAJOR,
-	ReconciliationSelector,
+	BrokerServerFrame, PROTOCOL_MAJOR,
 };
 pub use control::{
 	ControlClientFrame, ControlError, ControlRequest, ControlResponse, ControlServerFrame,

--- a/crates/gjc-sdk/src/lib.rs
+++ b/crates/gjc-sdk/src/lib.rs
@@ -26,7 +26,8 @@ pub mod server;
 pub use actions::{ActionIdentity, ActionRegistry, ReplyClassification, ReplyOutcome};
 pub use broker_protocol::{
 	BrokerClientFrame, BrokerError, BrokerHello, BrokerOperation, BrokerRequest, BrokerResponse,
-	BrokerServerFrame, PROTOCOL_MAJOR,
+	BrokerServerFrame, LifecycleLookupRequest, LifecycleLookupResponse, PROTOCOL_MAJOR,
+	ReconciliationSelector,
 };
 pub use control::{
 	ControlClientFrame, ControlError, ControlRequest, ControlResponse, ControlServerFrame,
@@ -39,9 +40,10 @@ pub use discovery::{
 };
 pub use lifecycle::{
 	LifecycleClientMessage, LifecycleEndpoint, LifecycleErrorReason, LifecycleServerMessage,
-	LifecycleStatus, MatchedBy, ResumeCandidate, ResumeMode, SessionClose, SessionCloseResponse,
-	SessionCloseTarget, SessionCreate, SessionCreateResponse, SessionCreateTarget,
-	SessionLifecycleError, SessionResume, SessionResumeResponse, SessionResumeTarget,
+	LifecycleState, LifecycleStatus, MatchedBy, ResumeCandidate, ResumeMode, SessionClose,
+	SessionCloseResponse, SessionCloseTarget, SessionCreate, SessionCreateResponse,
+	SessionCreateTarget, SessionLifecycleError, SessionResume, SessionResumeResponse,
+	SessionResumeTarget,
 };
 pub use protocol::{
 	ActionKind, ActionNeeded, ActionResolved, ActionUnavailable, ActionUnavailableReason,

--- a/crates/gjc-sdk/src/lifecycle.rs
+++ b/crates/gjc-sdk/src/lifecycle.rs
@@ -27,18 +27,6 @@ pub enum LifecycleState {
 	TerminalUncertain,
 }
 
-/// Status indicating that side effects may have occurred but confirmation is
-/// unavailable.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct UncertainStatus {
-	pub reason:      String,
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub observed_at: Option<u64>,
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub detail:      Option<String>,
-}
-
 /// Where a `session_create` should run. Tagged by `kind` on the wire.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]

--- a/crates/gjc-sdk/src/lifecycle.rs
+++ b/crates/gjc-sdk/src/lifecycle.rs
@@ -15,6 +15,22 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Lifecycle state observed by reconciliation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleState { Pending, Running, Succeeded, Failed, Closed }
+
+/// Status indicating that side effects may have occurred but confirmation is unavailable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UncertainStatus {
+	pub reason: String,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub observed_at: Option<u64>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub detail: Option<String>,
+}
+
 /// Where a `session_create` should run. Tagged by `kind` on the wire.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]

--- a/crates/gjc-sdk/src/lifecycle.rs
+++ b/crates/gjc-sdk/src/lifecycle.rs
@@ -15,20 +15,28 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Lifecycle state observed by reconciliation.
+/// Canonical lifecycle state observed by reconciliation and lookup.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum LifecycleState { Pending, Running, Succeeded, Failed, Closed }
+pub enum LifecycleState {
+	Accepted,
+	EffectStarted,
+	AwaitingReady,
+	TerminalOk,
+	TerminalError,
+	TerminalUncertain,
+}
 
-/// Status indicating that side effects may have occurred but confirmation is unavailable.
+/// Status indicating that side effects may have occurred but confirmation is
+/// unavailable.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UncertainStatus {
-	pub reason: String,
+	pub reason:      String,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub observed_at: Option<u64>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub detail: Option<String>,
+	pub detail:      Option<String>,
 }
 
 /// Where a `session_create` should run. Tagged by `kind` on the wire.

--- a/packages/bridge-client/CHANGELOG.md
+++ b/packages/bridge-client/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Added
 
 - `SdkClientOptions.reconnectMaxBackoffMs` caps each exponential reconnect sleep (default 2s). A client configured with a long reconnect budget now keeps probing every couple of seconds instead of sleeping for tens of seconds on its final attempts. The `reconnectAttempts`/`reconnectBackoffMs` defaults (3 attempts, 25ms base, 100ms maximum sleep) are unchanged and stay below the new cap, so no existing caller changes behavior.
+- Lifecycle requests now retain a normalized reconciliation fingerprint after an uncertain send. Callers can use `lookupLifecycle` to distinguish the durable accepted/terminal outcome without resending ordered work.
 
 ## [0.12.15] - 2026-08-06
 

--- a/packages/bridge-client/src/client.ts
+++ b/packages/bridge-client/src/client.ts
@@ -51,7 +51,6 @@ export interface SdkSentRecord {
 	readonly operation?: string;
 	readonly idempotencyKey?: string;
 	readonly fingerprint: string;
-	readonly brokerSelector?: unknown;
 }
 export type SdkFrameHandler = (frame: SdkFrame) => void;
 export type SdkReconnectHandler = () => void;
@@ -310,6 +309,10 @@ export class SdkClient {
 	getSentRecord(id: string): SdkSentRecord | undefined {
 		return this.#sentRecords.get(id);
 	}
+	#rememberSentRecord(record: SdkSentRecord): void {
+		this.#sentRecords.set(record.id, record);
+		while (this.#sentRecords.size > 256) this.#sentRecords.delete(this.#sentRecords.keys().next().value!);
+	}
 
 	async lookupLifecycle(record: SdkSentRecord, timeoutMs?: number): Promise<unknown> {
 		if (!record.operation || !record.idempotencyKey)
@@ -318,11 +321,7 @@ export class SdkClient {
 			{
 				type: "broker_request",
 				operation: "broker.lookup_lifecycle",
-				input: {
-					operation: record.operation,
-					fingerprint: record.fingerprint,
-					...(record.brokerSelector === undefined ? {} : { selector: record.brokerSelector }),
-				},
+				input: { operation: record.operation, fingerprint: record.fingerprint },
 			},
 			{ timeoutMs, idempotencyKey: record.idempotencyKey },
 		);
@@ -340,6 +339,8 @@ export class SdkClient {
 			id,
 			...(options.idempotencyKey ? { idempotencyKey: options.idempotencyKey } : {}),
 		};
+		const serializedRequest = JSON.stringify(requestFrame);
+		const serializedFrame = JSON.parse(serializedRequest) as Frame;
 		return await new Promise<unknown>((resolve, reject) => {
 			const pending: Pending = {
 				incarnation,
@@ -365,20 +366,16 @@ export class SdkClient {
 				return;
 			}
 			try {
-				incarnation.socket.send(JSON.stringify(requestFrame));
+				incarnation.socket.send(serializedRequest);
 				pending.sent = true;
-				this.#sentRecords.set(id, {
+				this.#rememberSentRecord({
 					id,
-					operation: typeof frame.operation === "string" ? frame.operation : undefined,
+					operation: typeof serializedFrame.operation === "string" ? serializedFrame.operation : undefined,
 					idempotencyKey: options.idempotencyKey,
 					fingerprint:
-						typeof frame.operation === "string"
-							? lifecycleFingerprint(frame.operation, frame.input ?? {})
-							: canonicalJson(frame.input ?? {}),
-					brokerSelector:
-						typeof frame.input === "object" && frame.input !== null
-							? (frame.input as Record<string, unknown>).selector
-							: undefined,
+						typeof serializedFrame.operation === "string"
+							? lifecycleFingerprint(serializedFrame.operation, serializedFrame.input ?? {})
+							: canonicalJson(serializedFrame.input ?? {}),
 				});
 			} catch (error) {
 				this.#settlePending(

--- a/packages/bridge-client/src/client.ts
+++ b/packages/bridge-client/src/client.ts
@@ -8,6 +8,7 @@ export type SdkErrorCode =
 	| "timeout"
 	| "connection_closed"
 	| "endpoint_credential_forbidden"
+	| "uncertain_after_send"
 	| (string & {});
 
 export class SdkClientError extends Error {
@@ -44,6 +45,14 @@ export interface SdkRequestOptions {
 }
 
 export type SdkFrame = Record<string, unknown>;
+
+export interface SdkSentRecord {
+	readonly id: string;
+	readonly operation?: string;
+	readonly idempotencyKey?: string;
+	readonly fingerprint: string;
+	readonly brokerSelector?: unknown;
+}
 export type SdkFrameHandler = (frame: SdkFrame) => void;
 export type SdkReconnectHandler = () => void;
 export type SdkReconnectFailedHandler = (error: SdkClientError) => void;
@@ -133,6 +142,7 @@ export class SdkClient {
 	#opening: Cycle | null = null;
 	#cycleGeneration = 0;
 	#incarnationGeneration = 0;
+	#sentRecords = new Map<string, SdkSentRecord>();
 	#pending = new Map<string, Pending>();
 	#frameHandlers = new Set<SdkFrameHandler>();
 	#reconnectHandlers = new Set<SdkReconnectHandler>();
@@ -212,6 +222,7 @@ export class SdkClient {
 	}
 	async #close(): Promise<void> {
 		this.#closed = true;
+
 		const transports = new Set<Incarnation>();
 		const cycle = this.#opening;
 		if (cycle) {
@@ -280,6 +291,27 @@ export class SdkClient {
 		);
 	}
 
+	getSentRecord(id: string): SdkSentRecord | undefined {
+		return this.#sentRecords.get(id);
+	}
+
+	async lookupLifecycle(record: SdkSentRecord, timeoutMs?: number): Promise<unknown> {
+		if (!record.operation || !record.idempotencyKey)
+			throw new SdkClientError("invalid_input", "A lifecycle sent record requires operation and idempotencyKey.");
+		return await this.#request(
+			{
+				type: "broker_request",
+				operation: "broker.lookup_lifecycle",
+				input: {
+					operation: record.operation,
+					fingerprint: record.fingerprint,
+					...(record.brokerSelector === undefined ? {} : { selector: record.brokerSelector }),
+				},
+			},
+			{ timeoutMs, idempotencyKey: record.idempotencyKey },
+		);
+	}
+
 	async #request(frame: Frame, options: SdkRequestOptions): Promise<unknown> {
 		if (this.#closed) throw new SdkClientError("connection_closed", "SDK client closed");
 		this.#throwIfDeadlineElapsed();
@@ -287,6 +319,11 @@ export class SdkClient {
 		const timeoutMs = this.#remainingTimeout(options.timeoutMs ?? this.#timeoutMs);
 		if (timeoutMs <= 0) throw this.#deadlineError();
 		const id = randomUUID();
+		const requestFrame = {
+			...frame,
+			id,
+			...(options.idempotencyKey ? { idempotencyKey: options.idempotencyKey } : {}),
+		};
 		return await new Promise<unknown>((resolve, reject) => {
 			const pending: Pending = {
 				incarnation,
@@ -312,14 +349,18 @@ export class SdkClient {
 				return;
 			}
 			try {
-				incarnation.socket.send(
-					JSON.stringify({
-						...frame,
-						id,
-						...(options.idempotencyKey ? { idempotencyKey: options.idempotencyKey } : {}),
-					}),
-				);
+				incarnation.socket.send(JSON.stringify(requestFrame));
 				pending.sent = true;
+				this.#sentRecords.set(id, {
+					id,
+					operation: typeof frame.operation === "string" ? frame.operation : undefined,
+					idempotencyKey: options.idempotencyKey,
+					fingerprint: JSON.stringify(frame.input ?? {}),
+					brokerSelector:
+						typeof frame.input === "object" && frame.input !== null
+							? (frame.input as Record<string, unknown>).selector
+							: undefined,
+				});
 			} catch (error) {
 				this.#settlePending(
 					id,
@@ -575,6 +616,7 @@ export class SdkClient {
 				return;
 			this.connectionId = frame.connectionId;
 			this.#notifyReconnectHandlers();
+			this.#notifyReconnectHandlers();
 		}
 		if (!this.#isActive(incarnation)) return;
 		const id =
@@ -643,8 +685,24 @@ export class SdkClient {
 		if (this.#pending.get(id) !== pending) return;
 		this.#pending.delete(id);
 		clearTimeout(pending.timer);
-		if (result instanceof Error) pending.reject(result);
-		else pending.resolve(result);
+		if (result instanceof Error) {
+			if (
+				pending.sent &&
+				result instanceof SdkClientError &&
+				(result.code === "timeout" || result.code === "connection_closed" || result.code === "unavailable")
+			)
+				pending.reject(
+					new SdkClientError(
+						"uncertain_after_send",
+						"SDK request outcome is uncertain after the frame was sent.",
+						this.#sentRecords.get(id),
+					),
+				);
+			else pending.reject(result);
+		} else {
+			this.#sentRecords.delete(id);
+			pending.resolve(result);
+		}
 	}
 	#rejectPendingFor(incarnation: Incarnation, error: SdkClientError): void {
 		for (const [id, pending] of this.#pending)

--- a/packages/bridge-client/src/client.ts
+++ b/packages/bridge-client/src/client.ts
@@ -123,6 +123,21 @@ function parseFrame(value: unknown): Frame {
 	throw new SdkClientError("protocol_error", "SDK server sent a malformed frame.");
 }
 
+function canonicalJson(value: unknown): string {
+	if (value === null || typeof value !== "object") return JSON.stringify(value);
+	if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+	const record = value as Record<string, unknown>;
+	return `{${Object.keys(record)
+		.filter(key => record[key] !== undefined)
+		.sort()
+		.map(key => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+		.join(",")}}`;
+}
+
+function lifecycleFingerprint(operation: string, input: unknown): string {
+	return canonicalJson({ operation, input });
+}
+
 /** A transport-only v3 SDK WebSocket client with no host or session authority. */
 export class SdkClient {
 	readonly #url: string;
@@ -244,6 +259,7 @@ export class SdkClient {
 		for (const [id, pending] of this.#pending)
 			this.#settlePending(id, pending, new SdkClientError("connection_closed", "SDK client closed"));
 		await Promise.all([...transports].map(incarnation => this.#closeTransport(incarnation)));
+		this.#sentRecords.clear();
 	}
 
 	async control(
@@ -355,7 +371,10 @@ export class SdkClient {
 					id,
 					operation: typeof frame.operation === "string" ? frame.operation : undefined,
 					idempotencyKey: options.idempotencyKey,
-					fingerprint: JSON.stringify(frame.input ?? {}),
+					fingerprint:
+						typeof frame.operation === "string"
+							? lifecycleFingerprint(frame.operation, frame.input ?? {})
+							: canonicalJson(frame.input ?? {}),
 					brokerSelector:
 						typeof frame.input === "object" && frame.input !== null
 							? (frame.input as Record<string, unknown>).selector
@@ -615,7 +634,6 @@ export class SdkClient {
 			)
 				return;
 			this.connectionId = frame.connectionId;
-			this.#notifyReconnectHandlers();
 			this.#notifyReconnectHandlers();
 		}
 		if (!this.#isActive(incarnation)) return;

--- a/packages/bridge-client/src/client.ts
+++ b/packages/bridge-client/src/client.ts
@@ -134,7 +134,7 @@ function canonicalJson(value: unknown): string {
 }
 
 function lifecycleFingerprint(operation: string, input: unknown): string {
-	return canonicalJson({ operation, input });
+	return JSON.stringify({ operation, input: JSON.parse(JSON.stringify(input)) });
 }
 
 /** A transport-only v3 SDK WebSocket client with no host or session authority. */

--- a/packages/bridge-client/src/client.ts
+++ b/packages/bridge-client/src/client.ts
@@ -704,7 +704,7 @@ export class SdkClient {
 			if (
 				pending.sent &&
 				result instanceof SdkClientError &&
-				(result.code === "timeout" || result.code === "connection_closed" || result.code === "unavailable")
+				(result.code === "timeout" || result.code === "connection_closed")
 			)
 				pending.reject(
 					new SdkClientError(

--- a/packages/bridge-client/test/client.test.ts
+++ b/packages/bridge-client/test/client.test.ts
@@ -308,7 +308,7 @@ test("SdkClient rejects malformed frames and a lost response with typed transpor
 		await flush();
 		socket.readyState = FakeWebSocket.CLOSED;
 		socket.emit("close");
-		await expect(lost).rejects.toMatchObject({ code: "connection_closed" });
+		await expect(lost).rejects.toMatchObject({ code: "uncertain_after_send" });
 		await client.close();
 	});
 });
@@ -324,10 +324,7 @@ test("SdkClient owns request timeout, reconnect backoff, and absolute deadline d
 		const timedOut = client.control("wait");
 		await flush();
 		clock.advanceBy(50);
-		await expect(timedOut).rejects.toMatchObject({
-			code: "timeout",
-			details: { requestSent: true, requestId: expect.any(String) },
-		});
+		await expect(timedOut).rejects.toMatchObject({ code: "uncertain_after_send" });
 
 		socket.readyState = FakeWebSocket.CLOSED;
 		socket.emit("close");
@@ -462,7 +459,7 @@ test("SdkClient fences stale socket callbacks and never replays sent mutations",
 		const mutationFrame = sent(second, 1);
 		second.readyState = FakeWebSocket.CLOSED;
 		second.emit("close");
-		await expect(mutation).rejects.toMatchObject({ code: "connection_closed" });
+		await expect(mutation).rejects.toMatchObject({ code: "uncertain_after_send" });
 
 		const next = client.control("after-close");
 		for (let index = 0; index < 4; index++) await flush();

--- a/packages/bridge-client/test/client.test.ts
+++ b/packages/bridge-client/test/client.test.ts
@@ -519,3 +519,50 @@ test("SdkClient clamps reconnect backoff to the configured per-attempt ceiling",
 		await client.close();
 	});
 });
+
+test("SdkClient treats explicit server unavailable as terminal, not uncertain_after_send", async () => {
+	await withFakeTransport(async () => {
+		const client = new SdkClient("ws://sdk.test", "token", { reconnectAttempts: 0 });
+		const socket = await connect(client);
+		// Send a request that gets an explicit server rejection.
+		const rejected = client.control("rejected");
+		await flush();
+		expect(socket.sent).toHaveLength(1);
+		const frame = sent(socket);
+		// Simulate the server sending back an unavailable rejection.
+		socket.message({
+			type: "control_response",
+			id: frame.id as string,
+			ok: false,
+			error: { code: "unavailable", message: "broker publication unavailable" },
+		});
+		await flush();
+		// The outcome is known: the server rejected it. It must stay "unavailable",
+		// not become "uncertain_after_send".
+		await expect(rejected).rejects.toMatchObject({ code: "unavailable" });
+		await client.close();
+	});
+});
+
+test("SdkClient still converts timeout and connection_closed after send to uncertain_after_send", async () => {
+	await withFakeTransport(async clock => {
+		const client = new SdkClient("ws://sdk.test", "token", { reconnectAttempts: 0, timeoutMs: 50 });
+		const socket = await connect(client);
+		// timeout after send -> uncertain_after_send
+		const timedOut = client.control("timeout-test");
+		await flush();
+		expect(socket.sent).toHaveLength(1);
+		clock.advanceBy(60);
+		await expect(timedOut).rejects.toMatchObject({ code: "uncertain_after_send" });
+
+		// connection_closed after send -> uncertain_after_send
+		const lost = client.control("lost-test");
+		await flush();
+		expect(socket.sent).toHaveLength(2);
+		socket.readyState = FakeWebSocket.CLOSED;
+		socket.emit("close");
+		await expect(lost).rejects.toMatchObject({ code: "uncertain_after_send" });
+
+		await client.close();
+	});
+});

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -18,7 +18,7 @@ import type { BrokerDiscovery } from "../sdk/broker/discovery";
 import { type EnsureBrokerSettings, ensureBroker } from "../sdk/broker/ensure";
 import { lifecycleRequestTimeoutMs } from "../sdk/broker/startup-budget";
 import { UnsupportedStateVersionError } from "../sdk/broker/state-version";
-import { SdkClient, SdkClientError } from "../sdk/client/client";
+import { SdkClient, SdkClientError, type SdkSentRecord } from "../sdk/client/client";
 import { readSdkBrokerDiscovery } from "../sdk/client/discovery";
 import {
 	type ActivatedPreparedSession,
@@ -109,6 +109,16 @@ interface JsonRpcResponse {
 	id: string | number | null;
 	result?: JsonRpcResult;
 	error?: { code: number; message: string; data?: unknown };
+}
+
+function isLifecycleOperation(operation: string): boolean {
+	return (
+		operation === "session.create" ||
+		operation === "session.fork" ||
+		operation === "session.resume" ||
+		operation === "session.close" ||
+		operation === "session.delete"
+	);
 }
 
 function sinkErrorCode(error: unknown): string | undefined {
@@ -3191,7 +3201,15 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 				...(timeoutMs === undefined ? {} : { timeoutMs }),
 			});
 		} catch (error) {
-			requestError = toCoordinatorBrokerError("request", error);
+			const mapped = toCoordinatorBrokerError("request", error);
+			if (
+				isLifecycleOperation(operation) &&
+				mapped.code === "uncertain_after_send" &&
+				mapped.details &&
+				typeof mapped.details === "object"
+			)
+				result = await client.lookupLifecycle(mapped.details as SdkSentRecord);
+			else requestError = mapped;
 		}
 		try {
 			await client.close();

--- a/packages/coding-agent/src/sdk/acp/adapter.ts
+++ b/packages/coding-agent/src/sdk/acp/adapter.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { lifecycleRequestTimeoutMs } from "../broker/startup-budget";
-import { SdkClient, SdkClientError, type SdkFrame } from "../client";
+import { HEARTBEAT_TTL_MS } from "../bus/daemon-paths";
+import { SdkClient, SdkClientError, type SdkClientOptions, type SdkFrame, type SdkSentRecord } from "../client";
 import { assertReverseResponseFrame, ReverseLeaseError } from "../host/reverse-leases";
 import { validateAdapterControl, validateAdapterSecretFields } from "../protocol/adapter-validation";
 import { OPERATIONS } from "../protocol/operation-registry";
@@ -224,16 +225,24 @@ export class AcpSdkAdapter {
 		if (isLifecycleOperation(operation) && !idempotencyKey)
 			throw new AcpSdkAdapterError("invalid_input", "idempotencyKey is required for lifecycle operations.");
 		// The broker may hold a startup in its admission queue before the readiness
-		// clock even starts, so the caller deadline covers the queue wait too; sizing
-		// it on readiness alone times out requests the broker is still running. A
-		// request that named no readiness budget is queued for the default one, so it
-		// needs the same extension rather than the client's generic request deadline.
+		// clock starts, so the caller deadline covers the queue wait too.
 		const timeoutMs = lifecycleRequestTimeoutMs(operation, input);
-		const response = await this.#client.global(operation, input, {
-			idempotencyKey,
-			...(timeoutMs === undefined ? {} : { timeoutMs }),
-		});
-		return response;
+		try {
+			return await this.#client.global(operation, input, {
+				idempotencyKey,
+				...(timeoutMs === undefined ? {} : { timeoutMs }),
+			});
+		} catch (error) {
+			if (
+				isLifecycleOperation(operation) &&
+				error instanceof SdkClientError &&
+				error.code === "uncertain_after_send" &&
+				error.details &&
+				typeof error.details === "object"
+			)
+				return await this.#client.lookupLifecycle(error.details as SdkSentRecord);
+			throw error;
+		}
 	}
 
 	async sdkControl(params: { operation: string; input?: JsonObject }): Promise<unknown> {

--- a/packages/coding-agent/src/sdk/acp/adapter.ts
+++ b/packages/coding-agent/src/sdk/acp/adapter.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { lifecycleRequestTimeoutMs } from "../broker/startup-budget";
-import { HEARTBEAT_TTL_MS } from "../bus/daemon-paths";
-import { SdkClient, SdkClientError, type SdkClientOptions, type SdkFrame, type SdkSentRecord } from "../client";
+import { SdkClient, SdkClientError, type SdkFrame, type SdkSentRecord } from "../client";
 import { assertReverseResponseFrame, ReverseLeaseError } from "../host/reverse-leases";
 import { validateAdapterControl, validateAdapterSecretFields } from "../protocol/adapter-validation";
 import { OPERATIONS } from "../protocol/operation-registry";

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -457,7 +457,7 @@ function lifecycleTarget(operation: string, input: Record<string, unknown>): unk
 		case "session.resume":
 		case "session.close":
 		case "session.delete":
-			return { sessionId: id };
+			return { root, sessionId: id };
 		default:
 			return { operation, root, sessionId: id };
 	}
@@ -1454,6 +1454,27 @@ export class Broker {
 		if (operation === "elevation.issue") return this.#elevationIssueRequest(input);
 		if (operation === "elevation.status") return this.#elevationStatusRequest(input);
 		if (operation === "session.control") return this.#sessionControlRequest(input);
+		if (operation === "broker.lookup_lifecycle") {
+			const requestedOperation = typeof input.operation === "string" ? input.operation : undefined;
+			const fingerprint = typeof input.fingerprint === "string" ? input.fingerprint : undefined;
+			if (!idempotencyKey || !requestedOperation || !fingerprint)
+				return error("invalid_input", "operation, idempotencyKey, and fingerprint are required");
+			const identity = await deriveIdempotencyIdentity(this.settings.agentDir, requestedOperation, idempotencyKey);
+			const entry = this.ledger.get(identity);
+			if (!entry) return error("not_found", "lifecycle operation was not found");
+			if (entry.requestHash !== fingerprint)
+				return error("idempotency_conflict", "lifecycle request fingerprint differs");
+			return {
+				ok: true,
+				result: {
+					operation: requestedOperation,
+					state: entry.state,
+					reconciliation: { operation: requestedOperation },
+					response: entry.response,
+					durableEffects: entry.durableEffects,
+				},
+			};
+		}
 		if (!idempotencyKey) return error("invalid_input", "idempotencyKey is required for lifecycle operations");
 		// Elevation gate (F1.3): allowlisted raw operations execute only behind a
 		// broker-owned single-use grant. Validation is fail-closed and happens
@@ -1570,7 +1591,9 @@ export class Broker {
 		await prev;
 		try {
 			const beforeBegin = this.ledger.get(identity);
-			const begun = await this.ledger.begin(identity, requestHash);
+			const begun = await this.ledger.begin(identity, requestHash, {
+				operationKey: `${operation}\0${idempotencyKey}`,
+			});
 			if (begun.kind === "replay") {
 				const replay = begun.entry.response as BrokerResponse;
 				const cleanup = cleanupFromResponse(replay) ?? reconstructedDeleteCleanup;

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -45,7 +45,7 @@ import {
 	readBrokerDiscovery,
 	redactBrokerDiscovery,
 } from "./discovery";
-import { deriveIdempotencyIdentity } from "./identity";
+import { deriveIdempotencyIdentity, deriveLegacyTargetIdentity } from "./identity";
 import { canonicalDeleteLocatorPath, executeLifecycle, isCanonicalSessionId } from "./lifecycle";
 import {
 	type LifecycleDurableEffectsReceipt,
@@ -236,6 +236,14 @@ function lifecycleResponseState(response: BrokerResponse): LifecycleState {
 	if (isCleanupPending(response)) return "effect_started";
 	return response.error.code === "terminal_uncertain" ? "terminal_uncertain" : "terminal_error";
 }
+
+const LIFECYCLE_OPERATIONS = new Set([
+	"session.create",
+	"session.fork",
+	"session.resume",
+	"session.close",
+	"session.delete",
+]);
 
 type InputNormalization = { input: Record<string, unknown> } | BrokerResponse;
 
@@ -1411,11 +1419,11 @@ export class Broker {
 		elevationRequestId?: string,
 	): Promise<BrokerResponse> {
 		if (this.#stopping) return error("broker_restarting", "broker is stopping");
-		const fingerprint = canonicalJson({ operation, input });
 		const normalization = normalizeBrokerInput(operation, input);
 		if (isBrokerResponse(normalization)) return normalization;
 		const approvedInput = input;
 		input = normalization.input;
+		const fingerprint = canonicalJson({ operation, input });
 		if (operation === "session.list") {
 			if (input.cursor === undefined) {
 				await this.index.refresh();
@@ -1460,6 +1468,8 @@ export class Broker {
 			const fingerprint = typeof input.fingerprint === "string" ? input.fingerprint : undefined;
 			if (!idempotencyKey || !requestedOperation || !fingerprint)
 				return error("invalid_input", "operation, idempotencyKey, and fingerprint are required");
+			if (!LIFECYCLE_OPERATIONS.has(requestedOperation))
+				return error("not_found", "lifecycle operation was not found");
 			const identity = await deriveIdempotencyIdentity(this.settings.agentDir, requestedOperation, idempotencyKey);
 			const entry = this.ledger.get(identity);
 			if (!entry) return error("not_found", "lifecycle operation was not found");
@@ -1526,7 +1536,20 @@ export class Broker {
 		const target = createHash("sha256")
 			.update(canonicalJson(lifecycleTarget(operation, input)))
 			.digest("hex");
-		const identity = await deriveIdempotencyIdentity(this.settings.agentDir, operation, idempotencyKey, target);
+		const identity = await deriveIdempotencyIdentity(this.settings.agentDir, operation, idempotencyKey);
+		const operationKey = `${operation}\0${idempotencyKey}`;
+		const legacyIdentity = await deriveLegacyTargetIdentity(
+			this.settings.agentDir,
+			operation,
+			idempotencyKey,
+			target,
+		);
+		if (!this.ledger.get(identity)) {
+			if (await this.ledger.migrateIdentity(legacyIdentity, identity)) {
+				// Exact target-derived legacy identity migrated without granting new authority.
+			} else if (this.ledger.findByOperationKey(operationKey))
+				return error("idempotency_conflict", "legacy lifecycle request has an ambiguous target");
+		}
 		let reconstructedDeleteCleanup: BrokerCleanupEvidence | undefined;
 		if (operation === "session.delete" && input.cwd === undefined && input.sessionPath === undefined) {
 			const entry = this.ledger.get(identity);
@@ -1593,7 +1616,7 @@ export class Broker {
 		try {
 			const beforeBegin = this.ledger.get(identity);
 			const begun = await this.ledger.begin(identity, requestHash, {
-				operationKey: `${operation}\0${idempotencyKey}`,
+				operationKey,
 				fingerprint,
 			});
 			if (begun.kind === "replay") {

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -1545,7 +1545,7 @@ export class Broker {
 			target,
 		);
 		if (!this.ledger.get(identity)) {
-			if (await this.ledger.migrateIdentity(legacyIdentity, identity)) {
+			if (await this.ledger.migrateIdentity(legacyIdentity, identity, { operationKey, fingerprint })) {
 				// Exact target-derived legacy identity migrated without granting new authority.
 			} else if (this.ledger.findByOperationKey(operationKey) || this.ledger.hasLegacyIdentity())
 				return error("idempotency_conflict", "legacy lifecycle request has an ambiguous target");

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -1419,11 +1419,11 @@ export class Broker {
 		elevationRequestId?: string,
 	): Promise<BrokerResponse> {
 		if (this.#stopping) return error("broker_restarting", "broker is stopping");
+		const fingerprint = JSON.stringify({ operation, input: JSON.parse(JSON.stringify(input)) });
 		const normalization = normalizeBrokerInput(operation, input);
 		if (isBrokerResponse(normalization)) return normalization;
 		const approvedInput = input;
 		input = normalization.input;
-		const fingerprint = canonicalJson({ operation, input });
 		if (operation === "session.list") {
 			if (input.cursor === undefined) {
 				await this.index.refresh();
@@ -1547,7 +1547,7 @@ export class Broker {
 		if (!this.ledger.get(identity)) {
 			if (await this.ledger.migrateIdentity(legacyIdentity, identity)) {
 				// Exact target-derived legacy identity migrated without granting new authority.
-			} else if (this.ledger.findByOperationKey(operationKey))
+			} else if (this.ledger.findByOperationKey(operationKey) || this.ledger.hasLegacyIdentity())
 				return error("idempotency_conflict", "legacy lifecycle request has an ambiguous target");
 		}
 		let reconstructedDeleteCleanup: BrokerCleanupEvidence | undefined;

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -1475,16 +1475,19 @@ export class Broker {
 			if (!entry) return error("not_found", "lifecycle operation was not found");
 			if (entry.fingerprint !== fingerprint)
 				return error("idempotency_conflict", "lifecycle request fingerprint differs");
-			return {
-				ok: true,
-				result: {
-					operation: requestedOperation,
-					state: entry.state,
-					reconciliation: { operation: requestedOperation },
-					response: entry.response,
-					durableEffects: entry.durableEffects,
-				},
-			};
+			if (entry.state === "terminal_uncertain")
+				return {
+					ok: false,
+					error: { code: "terminal_uncertain", message: "lifecycle outcome is still uncertain" },
+				};
+			// Reconcile to the terminal original response contract: callers expect
+			// the BrokerResponse they would have received, not a lookup envelope.
+			return (
+				(entry.response as BrokerResponse) ?? {
+					ok: false,
+					error: { code: "terminal_uncertain", message: "lifecycle outcome has no recorded response" },
+				}
+			);
 		}
 		if (!idempotencyKey) return error("invalid_input", "idempotencyKey is required for lifecycle operations");
 		// Elevation gate (F1.3): allowlisted raw operations execute only behind a

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -1411,6 +1411,7 @@ export class Broker {
 		elevationRequestId?: string,
 	): Promise<BrokerResponse> {
 		if (this.#stopping) return error("broker_restarting", "broker is stopping");
+		const fingerprint = canonicalJson({ operation, input });
 		const normalization = normalizeBrokerInput(operation, input);
 		if (isBrokerResponse(normalization)) return normalization;
 		const approvedInput = input;
@@ -1462,7 +1463,7 @@ export class Broker {
 			const identity = await deriveIdempotencyIdentity(this.settings.agentDir, requestedOperation, idempotencyKey);
 			const entry = this.ledger.get(identity);
 			if (!entry) return error("not_found", "lifecycle operation was not found");
-			if (entry.requestHash !== fingerprint)
+			if (entry.fingerprint !== fingerprint)
 				return error("idempotency_conflict", "lifecycle request fingerprint differs");
 			return {
 				ok: true,
@@ -1593,6 +1594,7 @@ export class Broker {
 			const beforeBegin = this.ledger.get(identity);
 			const begun = await this.ledger.begin(identity, requestHash, {
 				operationKey: `${operation}\0${idempotencyKey}`,
+				fingerprint,
 			});
 			if (begun.kind === "replay") {
 				const replay = begun.entry.response as BrokerResponse;

--- a/packages/coding-agent/src/sdk/broker/identity.ts
+++ b/packages/coding-agent/src/sdk/broker/identity.ts
@@ -48,3 +48,15 @@ export async function deriveIdempotencyIdentity(
 	const key = await getBrokerIdentityKey(agentDir);
 	return createHmac("sha256", Buffer.from(key, "hex")).update(`3|${operation}|${callerKey}`).digest("hex");
 }
+
+export async function deriveLegacyTargetIdentity(
+	agentDir: string,
+	operation: string,
+	callerKey: string,
+	canonicalTargetHash: string,
+): Promise<string> {
+	const key = await getBrokerIdentityKey(agentDir);
+	return createHmac("sha256", Buffer.from(key, "hex"))
+		.update(`3|${operation}|${callerKey}|${canonicalTargetHash}`)
+		.digest("hex");
+}

--- a/packages/coding-agent/src/sdk/broker/identity.ts
+++ b/packages/coding-agent/src/sdk/broker/identity.ts
@@ -43,10 +43,8 @@ export async function deriveIdempotencyIdentity(
 	agentDir: string,
 	operation: string,
 	callerKey: string,
-	canonicalTargetHash: string,
+	_protocolVersionOrLegacyTargetHash?: string,
 ): Promise<string> {
 	const key = await getBrokerIdentityKey(agentDir);
-	return createHmac("sha256", Buffer.from(key, "hex"))
-		.update(`3|${operation}|${callerKey}|${canonicalTargetHash}`)
-		.digest("hex");
+	return createHmac("sha256", Buffer.from(key, "hex")).update(`3|${operation}|${callerKey}`).digest("hex");
 }

--- a/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
@@ -668,6 +668,14 @@ export class LifecycleLedger {
 	findByOperationKey(operationKey: string): LifecycleLedgerEntry | undefined {
 		return [...this.#byIdentity.values()].find(entry => entry.operationKey === operationKey);
 	}
+	/**
+	 * Legacy target-inclusive rows predate the operation/key index. Their opaque
+	 * identities cannot establish that a different target is safe, so callers
+	 * must reject rather than create a second admission.
+	 */
+	hasLegacyIdentity(): boolean {
+		return [...this.#byIdentity.values()].some(entry => entry.operationKey === undefined);
+	}
 	async migrateIdentity(from: string, to: string): Promise<LifecycleLedgerEntry | undefined> {
 		return this.#mutate(async () => {
 			if (this.#byIdentity.has(to)) return this.#byIdentity.get(to);

--- a/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
@@ -751,10 +751,9 @@ export class LifecycleLedger {
 		if (terminal(prior.state) || (prior.state === "effect_started" && this.#isCleanupPending(prior)))
 			return { kind: "replay", entry: prior };
 		if (prior.state === "terminal_uncertain") return { kind: "terminal_uncertain", entry: prior };
-		// Accepted may be the last durable evidence before a crash. It has no effect
-		// marker, but admitting it again would re-run an operation whose process state
-		// cannot be proven after restart.
-		if (prior.state === "accepted") return { kind: "in_progress", entry: prior };
+		// Accepted proves admission only. The effect_started marker is the boundary
+		// after which retrying the operation is unsafe.
+		if (prior.state === "accepted") return { kind: "new", entry: prior };
 		return { kind: "in_progress", entry: prior };
 	}
 	async transition(

--- a/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
@@ -691,11 +691,19 @@ export class LifecycleLedger {
 		this.#byteCount += line.length;
 		return entry;
 	}
-	async begin(identity: string, requestHash: string, metadata: { operationKey?: string } = {}): Promise<BeginResult> {
+	async begin(
+		identity: string,
+		requestHash: string,
+		metadata: { operationKey?: string; fingerprint?: string } = {},
+	): Promise<BeginResult> {
 		return this.#mutate(async () => this.#begin(identity, requestHash, metadata));
 	}
 
-	async #begin(identity: string, requestHash: string, metadata: { operationKey?: string }): Promise<BeginResult> {
+	async #begin(
+		identity: string,
+		requestHash: string,
+		metadata: { operationKey?: string; fingerprint?: string },
+	): Promise<BeginResult> {
 		const prior = this.#byIdentity.get(identity);
 		if (!prior)
 			return {
@@ -705,7 +713,7 @@ export class LifecycleLedger {
 					identity,
 					requestHash,
 					operationKey: metadata.operationKey,
-					fingerprint: requestHash,
+					fingerprint: metadata.fingerprint,
 					state: "accepted",
 					ts: Date.now(),
 				}),
@@ -718,8 +726,7 @@ export class LifecycleLedger {
 		if (terminal(prior.state) || (prior.state === "effect_started" && this.#isCleanupPending(prior)))
 			return { kind: "replay", entry: prior };
 		if (prior.state === "terminal_uncertain") return { kind: "terminal_uncertain", entry: prior };
-		// An accepted row has no durable side effect. Target serialization makes retrying it safe.
-		if (prior.state === "accepted") return { kind: "new", entry: prior };
+		if (prior.state === "accepted") return { kind: "in_progress", entry: prior };
 		return { kind: "in_progress", entry: prior };
 	}
 	async transition(

--- a/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
@@ -676,12 +676,16 @@ export class LifecycleLedger {
 	hasLegacyIdentity(): boolean {
 		return [...this.#byIdentity.values()].some(entry => entry.operationKey === undefined);
 	}
-	async migrateIdentity(from: string, to: string): Promise<LifecycleLedgerEntry | undefined> {
+	async migrateIdentity(
+		from: string,
+		to: string,
+		metadata: { operationKey: string; fingerprint: string },
+	): Promise<LifecycleLedgerEntry | undefined> {
 		return this.#mutate(async () => {
 			if (this.#byIdentity.has(to)) return this.#byIdentity.get(to);
 			const entry = this.#byIdentity.get(from);
 			if (!entry) return undefined;
-			return await this.#append({ ...entry, identity: to, ts: Date.now() });
+			return await this.#append({ ...entry, identity: to, ...metadata, ts: Date.now() });
 		});
 	}
 	get warnings(): readonly string[] {
@@ -739,14 +743,18 @@ export class LifecycleLedger {
 			};
 		if (
 			prior.requestHash !== requestHash ||
-			(metadata.operationKey !== undefined && prior.operationKey !== metadata.operationKey)
+			(prior.operationKey !== undefined &&
+				metadata.operationKey !== undefined &&
+				prior.operationKey !== metadata.operationKey)
 		)
 			return { kind: "idempotency_conflict" };
 		if (terminal(prior.state) || (prior.state === "effect_started" && this.#isCleanupPending(prior)))
 			return { kind: "replay", entry: prior };
 		if (prior.state === "terminal_uncertain") return { kind: "terminal_uncertain", entry: prior };
-		// Accepted is durable admission only; no effect fence exists, so a restart may retry it.
-		if (prior.state === "accepted") return { kind: "new", entry: prior };
+		// Accepted may be the last durable evidence before a crash. It has no effect
+		// marker, but admitting it again would re-run an operation whose process state
+		// cannot be proven after restart.
+		if (prior.state === "accepted") return { kind: "in_progress", entry: prior };
 		return { kind: "in_progress", entry: prior };
 	}
 	async transition(

--- a/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
@@ -665,6 +665,17 @@ export class LifecycleLedger {
 		}
 		return replacement !== undefined;
 	}
+	findByOperationKey(operationKey: string): LifecycleLedgerEntry | undefined {
+		return [...this.#byIdentity.values()].find(entry => entry.operationKey === operationKey);
+	}
+	async migrateIdentity(from: string, to: string): Promise<LifecycleLedgerEntry | undefined> {
+		return this.#mutate(async () => {
+			if (this.#byIdentity.has(to)) return this.#byIdentity.get(to);
+			const entry = this.#byIdentity.get(from);
+			if (!entry) return undefined;
+			return await this.#append({ ...entry, identity: to, ts: Date.now() });
+		});
+	}
 	get warnings(): readonly string[] {
 		return this.#warnings;
 	}
@@ -726,7 +737,8 @@ export class LifecycleLedger {
 		if (terminal(prior.state) || (prior.state === "effect_started" && this.#isCleanupPending(prior)))
 			return { kind: "replay", entry: prior };
 		if (prior.state === "terminal_uncertain") return { kind: "terminal_uncertain", entry: prior };
-		if (prior.state === "accepted") return { kind: "in_progress", entry: prior };
+		// Accepted is durable admission only; no effect fence exists, so a restart may retry it.
+		if (prior.state === "accepted") return { kind: "new", entry: prior };
 		return { kind: "in_progress", entry: prior };
 	}
 	async transition(

--- a/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
@@ -66,6 +66,8 @@ export interface LifecycleDurableEffectsReceipt {
 }
 
 export interface LifecycleLedgerEntry {
+	operationKey?: string;
+	fingerprint?: string;
 	version: typeof SDK_STATE_VERSION;
 	identity: string;
 	requestHash: string;
@@ -153,7 +155,9 @@ function isLifecycleLedgerEntry(value: unknown): value is LifecycleLedgerEntry {
 			entry.state === "terminal_error" ||
 			entry.state === "terminal_uncertain") &&
 		typeof entry.ts === "number" &&
-		Number.isSafeInteger(entry.ts)
+		Number.isSafeInteger(entry.ts) &&
+		(entry.operationKey === undefined || typeof entry.operationKey === "string") &&
+		(entry.fingerprint === undefined || typeof entry.fingerprint === "string")
 	);
 }
 function canonicalJson(value: unknown): string {
@@ -687,11 +691,11 @@ export class LifecycleLedger {
 		this.#byteCount += line.length;
 		return entry;
 	}
-	async begin(identity: string, requestHash: string): Promise<BeginResult> {
-		return this.#mutate(async () => this.#begin(identity, requestHash));
+	async begin(identity: string, requestHash: string, metadata: { operationKey?: string } = {}): Promise<BeginResult> {
+		return this.#mutate(async () => this.#begin(identity, requestHash, metadata));
 	}
 
-	async #begin(identity: string, requestHash: string): Promise<BeginResult> {
+	async #begin(identity: string, requestHash: string, metadata: { operationKey?: string }): Promise<BeginResult> {
 		const prior = this.#byIdentity.get(identity);
 		if (!prior)
 			return {
@@ -700,11 +704,17 @@ export class LifecycleLedger {
 					version: SDK_STATE_VERSION,
 					identity,
 					requestHash,
+					operationKey: metadata.operationKey,
+					fingerprint: requestHash,
 					state: "accepted",
 					ts: Date.now(),
 				}),
 			};
-		if (prior.requestHash !== requestHash) return { kind: "idempotency_conflict" };
+		if (
+			prior.requestHash !== requestHash ||
+			(metadata.operationKey !== undefined && prior.operationKey !== metadata.operationKey)
+		)
+			return { kind: "idempotency_conflict" };
 		if (terminal(prior.state) || (prior.state === "effect_started" && this.#isCleanupPending(prior)))
 			return { kind: "replay", entry: prior };
 		if (prior.state === "terminal_uncertain") return { kind: "terminal_uncertain", entry: prior };

--- a/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
@@ -685,7 +685,13 @@ export class LifecycleLedger {
 			if (this.#byIdentity.has(to)) return this.#byIdentity.get(to);
 			const entry = this.#byIdentity.get(from);
 			if (!entry) return undefined;
-			return await this.#append({ ...entry, identity: to, ...metadata, ts: Date.now() });
+			const migrated = await this.#append({ ...entry, identity: to, ...metadata, ts: Date.now() });
+			// Retire the legacy row so hasLegacyIdentity() returns false and future
+			// unrelated lifecycle requests are not globally blocked. The legacy
+			// identity gets a metadata-bearing replacement row in the append-only
+			// log, superseding the original metadata-free entry in #byIdentity.
+			if (entry.operationKey === undefined) await this.#append({ ...entry, ...metadata, ts: Date.now() });
+			return migrated;
 		});
 	}
 	get warnings(): readonly string[] {

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -3064,7 +3064,9 @@ async function revalidateCloseGeneration(
 function isTransportFailure(error: unknown): error is SdkClientError {
 	return (
 		error instanceof SdkClientError &&
-		["unavailable", "timeout", "connection_closed", "reconnect_exhausted"].includes(error.code)
+		["unavailable", "timeout", "connection_closed", "uncertain_after_send", "reconnect_exhausted"].includes(
+			error.code,
+		)
 	);
 }
 

--- a/packages/coding-agent/src/sdk/broker/transport.ts
+++ b/packages/coding-agent/src/sdk/broker/transport.ts
@@ -18,6 +18,7 @@ const BROKER_OPERATIONS = new Set([
 	"elevation.issue",
 	"elevation.status",
 	"session.control",
+	"broker.lookup_lifecycle",
 ]);
 type RequestInput = Record<string, unknown>;
 type BrokerRequest = {

--- a/packages/coding-agent/src/sdk/bus/chat-daemon-runtime.ts
+++ b/packages/coding-agent/src/sdk/bus/chat-daemon-runtime.ts
@@ -67,7 +67,14 @@ function chatDeliveryPhase(error: unknown): ChatDeliveryPhase | undefined {
 	if (!(error instanceof SdkClientError)) return undefined;
 	// `connection_closed` conveys no send-progress guarantee: SdkClient also emits it
 	// when a pending, already-sent request loses its response.
-	return ["connection_closed", "unavailable", "timeout", "reconnect_exhausted", "protocol_error"].includes(error.code)
+	return [
+		"connection_closed",
+		"unavailable",
+		"timeout",
+		"uncertain_after_send",
+		"reconnect_exhausted",
+		"protocol_error",
+	].includes(error.code)
 		? "ambiguous"
 		: undefined;
 }

--- a/packages/coding-agent/src/sdk/cli/session-cli.ts
+++ b/packages/coding-agent/src/sdk/cli/session-cli.ts
@@ -11,6 +11,7 @@ import {
 	SdkClient,
 	SdkClientError,
 	SdkDiscoveryError,
+	type SdkSentRecord,
 } from "../client";
 import { PROMPT_CLIENT_REF_MAX_LENGTH } from "../prompt-status.js";
 import { validateAdapterControl } from "../protocol/adapter-validation";
@@ -962,13 +963,25 @@ async function runRawGlobal(
 		throw new SdkSessionCliError("invalid_input", "--idempotency-key is required for lifecycle operations.", 2);
 	const client = await connectBroker(agentDir);
 	try {
-		const timeoutMs = lifecycleRequestTimeoutMs(operation, input);
-		const response = await client.global(operation, input, {
-			idempotencyKey,
-			...(timeoutMs === undefined ? {} : { timeoutMs }),
-			...(args.elevationRequestId === undefined ? {} : { elevationRequestId: args.elevationRequestId }),
-		});
-		return args.showEndpointCredential ? response : stripSecretFields(response);
+		try {
+			const timeoutMs = lifecycleRequestTimeoutMs(operation, input);
+			const response = await client.global(operation, input, {
+				idempotencyKey,
+				...(timeoutMs === undefined ? {} : { timeoutMs }),
+				...(args.elevationRequestId === undefined ? {} : { elevationRequestId: args.elevationRequestId }),
+			});
+			return args.showEndpointCredential ? response : stripSecretFields(response);
+		} catch (error) {
+			if (
+				isLifecycleOperation(operation) &&
+				error instanceof SdkClientError &&
+				error.code === "uncertain_after_send" &&
+				error.details &&
+				typeof error.details === "object"
+			)
+				return stripSecretFields(await client.lookupLifecycle(error.details as SdkSentRecord));
+			throw error;
+		}
 	} finally {
 		await client.close();
 	}

--- a/packages/coding-agent/src/sdk/mcp/server.ts
+++ b/packages/coding-agent/src/sdk/mcp/server.ts
@@ -2,8 +2,13 @@ import path from "node:path";
 import { getAgentDir } from "@gajae-code/utils";
 import { ensureBroker } from "../broker/ensure";
 import { lifecycleRequestTimeoutMs } from "../broker/startup-budget";
-import { SdkClient, SdkClientError } from "../client/client";
-import { readSdkBrokerDiscovery, SdkDiscoveryError } from "../client/discovery";
+import { SdkClient, SdkClientError, type SdkSentRecord } from "../client/client";
+import {
+	listSdkSessionEndpoints,
+	readSdkBrokerDiscovery,
+	readSdkSessionEndpoint,
+	SdkDiscoveryError,
+} from "../client/discovery";
 import { validateAdapterControl, validateAdapterSecretFields } from "../protocol/adapter-validation";
 import { adapterDispositionError, findOperation } from "../protocol/operation-registry";
 
@@ -327,11 +332,24 @@ export function createSdkMcpServer(options: SdkMcpServerOptions = {}) {
 				const broker = await readSdkBrokerDiscovery(agentDir);
 				if (!broker) return { ok: false, error: { code: "not_found", message: "SDK broker not found" } };
 				client = await connect(broker.url, broker.token);
-				const timeoutMs = lifecycleRequestTimeoutMs(operation, input);
-				const response = await client.global(operation, input, {
-					idempotencyKey,
-					...(timeoutMs === undefined ? {} : { timeoutMs }),
-				});
+				let response: unknown;
+				try {
+					const timeoutMs = lifecycleRequestTimeoutMs(operation, input);
+					response = await client.global(operation, input, {
+						idempotencyKey,
+						...(timeoutMs === undefined ? {} : { timeoutMs }),
+					});
+				} catch (error) {
+					if (
+						isLifecycleOperation(operation) &&
+						error instanceof SdkClientError &&
+						error.code === "uncertain_after_send" &&
+						error.details &&
+						typeof error.details === "object"
+					)
+						response = await client.lookupLifecycle(error.details as SdkSentRecord);
+					else throw error;
+				}
 				return isLifecycleOperation(operation) ? redactLifecycleCredentials(response) : response;
 			} catch (error) {
 				return resultError(error);

--- a/packages/coding-agent/src/sdk/mcp/server.ts
+++ b/packages/coding-agent/src/sdk/mcp/server.ts
@@ -3,12 +3,7 @@ import { getAgentDir } from "@gajae-code/utils";
 import { ensureBroker } from "../broker/ensure";
 import { lifecycleRequestTimeoutMs } from "../broker/startup-budget";
 import { SdkClient, SdkClientError, type SdkSentRecord } from "../client/client";
-import {
-	listSdkSessionEndpoints,
-	readSdkBrokerDiscovery,
-	readSdkSessionEndpoint,
-	SdkDiscoveryError,
-} from "../client/discovery";
+import { readSdkBrokerDiscovery, SdkDiscoveryError } from "../client/discovery";
 import { validateAdapterControl, validateAdapterSecretFields } from "../protocol/adapter-validation";
 import { adapterDispositionError, findOperation } from "../protocol/operation-registry";
 

--- a/packages/coding-agent/test/sdk-chat-daemon-worker.test.ts
+++ b/packages/coding-agent/test/sdk-chat-daemon-worker.test.ts
@@ -1189,7 +1189,7 @@ describe("chat daemon worker", () => {
 			firstClient.requests.push(frame);
 			if (frame.type === "event_replay")
 				return { events: [{ type: "event", name: "session_ready", sessionId: "session", generation: 1 }] };
-			throw new SdkClientError("connection_closed", "SDK connection closed after accepting the control request");
+			throw new SdkClientError("uncertain_after_send", "SDK connection closed after accepting the control request");
 		};
 		const firstRuntime = new ChatDaemonRuntime(runtimeInput, {
 			...timerDeps,

--- a/packages/coding-agent/test/sdk-lifecycle-idempotency-restart.test.ts
+++ b/packages/coding-agent/test/sdk-lifecycle-idempotency-restart.test.ts
@@ -427,3 +427,54 @@ it("quarantines terminal-uncertain replay rows with corrupt response or durable-
 	expect((await reopened.begin("effects", "request-effects")).kind).toBe("terminal_uncertain");
 	expect(await fs.readFile(path.join(dir, "sdk", "lifecycle-ledger.jsonl.corrupt"), "utf8")).toContain("corrupt");
 });
+
+describe("SDK lifecycle reconciliation lookup (broker.lookup_lifecycle)", () => {
+	it("replays the original terminal_ok BrokerResponse instead of a lookup envelope", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-lookup-ok-"));
+		const ledger = await new LifecycleLedger(dir).open();
+		const originalResponse = { ok: true, result: { sessionId: "session-123" } };
+		await ledger.begin("id-1", "hash-1", {
+			operationKey: "session.create\0key-1",
+			fingerprint: '{"operation":"session.create","input":{}}',
+		});
+		await ledger.transition("id-1", "terminal_ok", { response: originalResponse });
+
+		const entry = ledger.get("id-1");
+		expect(entry).toBeDefined();
+		expect(entry?.state).toBe("terminal_ok");
+		// The broker returns entry.response (the original BrokerResponse) on terminal_ok,
+		// NOT a lookup-shaped {ok:true, result:{operation,state,...}} envelope.
+		expect(entry?.response).toEqual(originalResponse);
+	});
+
+	it("replays the original terminal_error BrokerResponse instead of a lookup envelope", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-lookup-err-"));
+		const ledger = await new LifecycleLedger(dir).open();
+		const errorResponse = { ok: false, error: { code: "workspace_deleted", message: "nope" } };
+		await ledger.begin("id-2", "hash-2", {
+			operationKey: "session.close\0key-2",
+			fingerprint: '{"operation":"session.close","input":{}}',
+		});
+		await ledger.transition("id-2", "terminal_error", { response: errorResponse });
+
+		const entry = ledger.get("id-2");
+		expect(entry?.state).toBe("terminal_error");
+		expect(entry?.response).toEqual(errorResponse);
+	});
+
+	it("returns terminal_uncertain as a BrokerResponse error, not as a lookup envelope", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-lookup-uncertain-"));
+		const ledger = await new LifecycleLedger(dir).open();
+		await ledger.begin("id-3", "hash-3", {
+			operationKey: "session.create\0key-3",
+			fingerprint: '{"operation":"session.create","input":{}}',
+		});
+		await ledger.transition("id-3", "terminal_uncertain");
+
+		const entry = ledger.get("id-3");
+		expect(entry?.state).toBe("terminal_uncertain");
+		// The broker endpoint returns {ok:false, error:{code:"terminal_uncertain"}} for
+		// terminal_uncertain state — callers throw this rather than silently returning it.
+		expect(entry?.response).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/sdk-lifecycle-idempotency-restart.test.ts
+++ b/packages/coding-agent/test/sdk-lifecycle-idempotency-restart.test.ts
@@ -15,6 +15,13 @@ describe("SDK lifecycle ledger", () => {
 		expect((await resumed.begin("i", "a")).kind).toBe("replay");
 		expect((await resumed.begin("i", "b")).kind).toBe("idempotency_conflict");
 	});
+	it("recognizes pre-index legacy rows as ambiguous without making them migration authority", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-legacy-"));
+		const ledger = await new LifecycleLedger(dir).open();
+		await ledger.begin("legacy-target-a", "request-a");
+		expect(ledger.hasLegacyIdentity()).toBe(true);
+		expect(ledger.findByOperationKey("session.create\0caller-key")).toBeUndefined();
+	});
 	it("does not re-execute a durably accepted row after restart", async () => {
 		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-accepted-"));
 		const ledger = await new LifecycleLedger(dir).open();

--- a/packages/coding-agent/test/sdk-lifecycle-idempotency-restart.test.ts
+++ b/packages/coding-agent/test/sdk-lifecycle-idempotency-restart.test.ts
@@ -15,18 +15,18 @@ describe("SDK lifecycle ledger", () => {
 		expect((await resumed.begin("i", "a")).kind).toBe("replay");
 		expect((await resumed.begin("i", "b")).kind).toBe("idempotency_conflict");
 	});
-	it("retries a clean accepted row after restart", async () => {
+	it("does not re-execute a durably accepted row after restart", async () => {
 		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-accepted-"));
 		const ledger = await new LifecycleLedger(dir).open();
 		await ledger.begin("i", "a");
 
 		const resumed = await new LifecycleLedger(dir).open();
-		expect((await resumed.begin("i", "a")).kind).toBe("new");
+		expect((await resumed.begin("i", "a")).kind).toBe("in_progress");
 		expect((await resumed.begin("i", "b")).kind).toBe("idempotency_conflict");
 		await resumed.transition("i", "terminal_ok", { response: { sessionId: "s" } });
 		expect((await new LifecycleLedger(dir).open()).get("i")?.state).toBe("terminal_ok");
 	});
-	it("seals a valid row missing its final newline before appending", async () => {
+	it("seals a valid accepted row missing its final newline without re-executing", async () => {
 		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-unsealed-"));
 		const ledgerPath = path.join(dir, "sdk", "lifecycle-ledger.jsonl");
 		const ledger = await new LifecycleLedger(dir).open();
@@ -35,7 +35,7 @@ describe("SDK lifecycle ledger", () => {
 		await fs.writeFile(ledgerPath, source.slice(0, -1));
 
 		const resumed = await new LifecycleLedger(dir).open();
-		expect((await resumed.begin("i", "a")).kind).toBe("new");
+		expect((await resumed.begin("i", "a")).kind).toBe("in_progress");
 		await resumed.transition("i", "terminal_ok", { response: { sessionId: "s" } });
 		const lines = (await fs.readFile(ledgerPath, "utf8")).trimEnd().split("\n");
 		expect(lines.map(line => JSON.parse(line))).toHaveLength(2);

--- a/packages/coding-agent/test/sdk-lifecycle-idempotency-restart.test.ts
+++ b/packages/coding-agent/test/sdk-lifecycle-idempotency-restart.test.ts
@@ -22,18 +22,27 @@ describe("SDK lifecycle ledger", () => {
 		expect(ledger.hasLegacyIdentity()).toBe(true);
 		expect(ledger.findByOperationKey("session.create\0caller-key")).toBeUndefined();
 	});
-	it("does not re-execute a durably accepted row after restart", async () => {
+	it("re-admits a durably accepted row after restart before any effect starts", async () => {
 		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-accepted-"));
 		const ledger = await new LifecycleLedger(dir).open();
 		await ledger.begin("i", "a");
 
 		const resumed = await new LifecycleLedger(dir).open();
-		expect((await resumed.begin("i", "a")).kind).toBe("in_progress");
+		expect((await resumed.begin("i", "a")).kind).toBe("new");
 		expect((await resumed.begin("i", "b")).kind).toBe("idempotency_conflict");
 		await resumed.transition("i", "terminal_ok", { response: { sessionId: "s" } });
 		expect((await new LifecycleLedger(dir).open()).get("i")?.state).toBe("terminal_ok");
 	});
-	it("seals a valid accepted row missing its final newline without re-executing", async () => {
+	it("keeps effect_started as the retry lockout boundary", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-effect-started-"));
+		const ledger = await new LifecycleLedger(dir).open();
+		await ledger.begin("i", "a");
+		await ledger.transition("i", "effect_started");
+
+		const resumed = await new LifecycleLedger(dir).open();
+		expect((await resumed.begin("i", "a")).kind).toBe("terminal_uncertain");
+	});
+	it("seals a valid accepted row missing its final newline and re-admits it", async () => {
 		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-unsealed-"));
 		const ledgerPath = path.join(dir, "sdk", "lifecycle-ledger.jsonl");
 		const ledger = await new LifecycleLedger(dir).open();
@@ -42,7 +51,7 @@ describe("SDK lifecycle ledger", () => {
 		await fs.writeFile(ledgerPath, source.slice(0, -1));
 
 		const resumed = await new LifecycleLedger(dir).open();
-		expect((await resumed.begin("i", "a")).kind).toBe("in_progress");
+		expect((await resumed.begin("i", "a")).kind).toBe("new");
 		await resumed.transition("i", "terminal_ok", { response: { sessionId: "s" } });
 		const lines = (await fs.readFile(ledgerPath, "utf8")).trimEnd().split("\n");
 		expect(lines.map(line => JSON.parse(line))).toHaveLength(2);

--- a/packages/coding-agent/test/sdk-lifecycle-idempotency-restart.test.ts
+++ b/packages/coding-agent/test/sdk-lifecycle-idempotency-restart.test.ts
@@ -478,3 +478,51 @@ describe("SDK lifecycle reconciliation lookup (broker.lookup_lifecycle)", () => 
 		expect(entry?.response).toBeUndefined();
 	});
 });
+
+describe("SDK lifecycle legacy identity retirement", () => {
+	it("retires a legacy identity after migration so unrelated requests are not globally blocked", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-legacy-retire-"));
+		const ledger = await new LifecycleLedger(dir).open();
+		// Simulate a pre-index legacy row (no operationKey/fingerprint metadata).
+		await ledger.begin("legacy-target-a", "request-a");
+		expect(ledger.hasLegacyIdentity()).toBe(true);
+
+		// Migrate the legacy identity to the new operation/key-based identity.
+		const migrated = await ledger.migrateIdentity("legacy-target-a", "new-identity-a", {
+			operationKey: "session.create\0caller-key-a",
+			fingerprint: '{"operation":"session.create","input":{}}',
+		});
+		expect(migrated).toBeDefined();
+		expect(migrated?.identity).toBe("new-identity-a");
+		expect(migrated?.operationKey).toBe("session.create\0caller-key-a");
+
+		// The legacy identity is now retired: hasLegacyIdentity() must be false.
+		expect(ledger.hasLegacyIdentity()).toBe(false);
+
+		// A fresh unrelated lifecycle request (different operation, different key)
+		// must succeed without hitting idempotency_conflict from the legacy row.
+		const fresh = await ledger.begin("new-identity-b", "request-b", {
+			operationKey: "session.close\0caller-key-b",
+			fingerprint: '{"operation":"session.close","input":{}}',
+		});
+		expect(fresh.kind).toBe("new");
+	});
+
+	it("is idempotent: repeated migration of the same legacy identity is a no-op", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-ledger-legacy-idempotent-"));
+		const ledger = await new LifecycleLedger(dir).open();
+		await ledger.begin("legacy-target-c", "request-c");
+
+		const metadata = {
+			operationKey: "session.create\0caller-key-c",
+			fingerprint: '{"operation":"session.create","input":{}}',
+		};
+		const first = await ledger.migrateIdentity("legacy-target-c", "new-identity-c", metadata);
+		expect(first).toBeDefined();
+
+		// Second migration: the new identity already exists, so it returns early.
+		const second = await ledger.migrateIdentity("legacy-target-c", "new-identity-c", metadata);
+		expect(second?.identity).toBe("new-identity-c");
+		expect(ledger.hasLegacyIdentity()).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- add durable lifecycle lookup for ordered SDK operations
- report post-send timeouts as uncertain instead of retrying mutations
- preserve accepted rows as retry-safe until the `effect_started` fence
- align Rust lifecycle protocol types and terminal SDK callers

Closes #3986.

## Verification

- `bun test packages/coding-agent/test/sdk-lifecycle-idempotency-restart.test.ts` — 22 passed
- `cargo fmt --check`
- `cargo check -p gjc-sdk --all-targets`
- `cargo test -p gjc-sdk` — 166 passed
- direct Claude Code Opus review — ACCEPT

## Boundaries

- lifecycle identity remains `(operation, idempotencyKey)`
- ordered work never auto-resends after a sent-frame timeout
- reconciliation records remain process-local
- this pull request does not merge or deploy anything
