### PR TITLE
fix(session): unbreak managed nested reads and resident cache assertions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -334,6 +334,7 @@
 
 ### Fixed
 
+- Managed session forks no longer fail with `managed_nested_path_unsupported` on platforms without retained root authority. Nested reads verify each intermediate directory component as a real same-device directory instead of being rejected outright, restoring artifact copying during `fork()` and `moveTo()`.
 - Terminal input now normalizes Option/Meta navigation and psmux modified-Enter encodings through the native key parser, keeping legacy, Kitty CSI-u, and modifyOtherKeys behavior consistent.
 - Ultragoal CLI replay no longer executes model-authored test source or trusts `replaySafe: true` as arbitrary command authority. Runtime replay is limited to the pinned Bun runtime for `--version` and literal `-e "console.log(...)"`; shells, interpreter code strings, path-qualified executables, tests, install/publish/network/git mutation commands, and arbitrary argv are rejected. Replay cwd/artifact files are realpath-confined, ambiguous rows fail closed, stdout and stderr are checked, and POSIX timeout cleanup signals the process group. Structured test-report fallback remains deliberately unsupported pending a separate trusted-provenance design (#3533).
 - Ultragoal CLI replay evidence now reads the replay file referenced by an `executorQa.artifactRefs` entry whose `kind` is `cli-replay`. Inline, nested, and file-backed replay forms are disambiguated explicitly; mixed or malformed rows fail closed (#3533).

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -1501,6 +1501,25 @@ export class ManagedSessionDescendantStore {
 			throw new Error("managed_nested_path_unsupported");
 	}
 
+	/**
+	 * Without retained root authority a nested read resolves through intermediate
+	 * directories that `O_NOFOLLOW` does not cover, so each component between the
+	 * bound base directory and the target is verified as a real same-device
+	 * directory before the capture opens the leaf.
+	 */
+	#assertPathBackedDirectoryChain(resolved: string): void {
+		if (this.#authority) return;
+		const relative = path.relative(this.#baseDir, resolved);
+		const components = relative.split(path.sep);
+		let current = this.#baseDir;
+		for (const component of components.slice(0, -1)) {
+			current = path.join(current, component);
+			const stat = fs.lstatSync(current, { bigint: true });
+			if (!stat.isDirectory() || stat.isSymbolicLink() || stat.dev !== this.#subtreeRoot.dev)
+				throw new Error("Managed descendant path escapes retained store");
+		}
+	}
+
 	#relative(resolved: string): string {
 		return path.relative(this.#authorityBaseDir, resolved).split(path.sep).join("/");
 	}
@@ -1789,12 +1808,13 @@ export class ManagedSessionDescendantStore {
 	}
 	/** Read an exact managed file without exposing its pathname as authority. */
 	readExpected(relativePath: string): ManagedFileSnapshot | null {
-		this.#assertPathBackedReadRelative(relativePath);
 		this.#assertBound();
-		const relative = this.#relative(this.#resolve(relativePath));
+		const resolved = this.#resolve(relativePath);
+		const relative = this.#relative(resolved);
 		if (!this.#authority) {
 			try {
-				const captured = captureManagedFileNoFollow(this.#resolve(relativePath));
+				this.#assertPathBackedDirectoryChain(resolved);
+				const captured = captureManagedFileNoFollow(resolved);
 				this.#assertBound();
 				return captured;
 			} catch (error) {

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -15601,6 +15601,16 @@ export class SessionManager {
 		};
 	}
 
+	/**
+	 * Directory backing the resident *text* blob store, or undefined when the
+	 * store is in-memory. The resident-cache root also holds the managed sidecar
+	 * cache instance, so callers must not infer the text store from directory
+	 * counts.
+	 */
+	residentTextCacheDirForTests(): string | undefined {
+		return this.#residentTextBlobStore instanceof EphemeralBlobStore ? this.#residentTextBlobStore.dir : undefined;
+	}
+
 	setSidecarHotSuffixBudgetForTests(bytes: number): void {
 		if (!Number.isSafeInteger(bytes) || bytes < 0) throw new RangeError("invalid_sidecar_hot_suffix_budget");
 		this.#sidecarHotSuffixBudgetBytes = bytes;

--- a/packages/coding-agent/test/session-resident-cache-root-derivation.test.ts
+++ b/packages/coding-agent/test/session-resident-cache-root-derivation.test.ts
@@ -64,6 +64,12 @@ function residentInstanceDirs(root: string): string[] {
 		});
 }
 
+function residentTextCacheDir(manager: SessionManager): string {
+	const directory = manager.residentTextCacheDirForTests();
+	if (!directory) throw new Error("Expected a directory-backed resident text cache");
+	return directory;
+}
+
 function appendLargeUserText(manager: SessionManager, text: string): void {
 	manager.appendMessage({ role: "user", content: text, timestamp: Date.now() });
 }
@@ -100,7 +106,7 @@ describe.skipIf(process.platform === "win32")("resident cache root derivation", 
 			await manager.flush();
 
 			expect(getResidentCacheRootDir(getAgentDir())).toBe(expectedCacheRoot);
-			expect(residentInstanceDirs(expectedCacheRoot)).toHaveLength(1);
+			expect(residentInstanceDirs(expectedCacheRoot)).toContain(residentTextCacheDir(manager));
 			expect(isWithin(xdgDataRoot, manager.getSessionDir())).toBe(true);
 			expect(fs.existsSync(path.join(xdgDataRoot, "resident-cache"))).toBe(false);
 		} finally {
@@ -122,7 +128,7 @@ describe.skipIf(process.platform === "win32")("resident cache root derivation", 
 			await manager.ensureOnDisk();
 
 			expect(getResidentCacheRootDir(customAgentDir)).toBe(expectedCacheRoot);
-			expect(residentInstanceDirs(expectedCacheRoot)).toHaveLength(1);
+			expect(residentInstanceDirs(expectedCacheRoot)).toContain(residentTextCacheDir(manager));
 			expect(fs.existsSync(path.join(getAgentDir(), "resident-cache"))).toBe(false);
 		} finally {
 			await manager.close().catch(() => {});
@@ -149,10 +155,10 @@ describe.skipIf(process.platform === "win32")("resident cache root derivation", 
 			await second.ensureOnDisk();
 
 			expect(firstRoot).not.toBe(secondRoot);
-			expect(residentInstanceDirs(firstRoot)).toHaveLength(1);
-			expect(residentInstanceDirs(secondRoot)).toHaveLength(1);
-			expect(residentInstanceDirs(firstRoot)[0]!.startsWith(firstRoot)).toBe(true);
-			expect(residentInstanceDirs(secondRoot)[0]!.startsWith(secondRoot)).toBe(true);
+			expect(residentInstanceDirs(firstRoot)).toContain(residentTextCacheDir(first));
+			expect(residentInstanceDirs(secondRoot)).toContain(residentTextCacheDir(second));
+			expect(residentTextCacheDir(first).startsWith(firstRoot)).toBe(true);
+			expect(residentTextCacheDir(second).startsWith(secondRoot)).toBe(true);
 		} finally {
 			await Promise.all([first.close().catch(() => {}), second.close().catch(() => {})]);
 		}
@@ -191,7 +197,7 @@ describe.skipIf(process.platform === "win32")("resident cache root derivation", 
 			appendLargeUserText(nested, `nested profile ${"n".repeat(4096)}`);
 			await nested.flush();
 
-			expect(residentInstanceDirs(expectedCacheRoot)).toHaveLength(1);
+			expect(residentInstanceDirs(expectedCacheRoot)).toContain(residentTextCacheDir(nested));
 			expect(fs.existsSync(path.join(nestedStore.dir, "resident-cache"))).toBe(false);
 		} finally {
 			await nested.close().catch(() => {});

--- a/packages/coding-agent/test/session-resident-cache.test.ts
+++ b/packages/coding-agent/test/session-resident-cache.test.ts
@@ -59,20 +59,10 @@ function residentCacheRoot(): string {
 	return getResidentCacheRootDir(getAgentDir());
 }
 
-function residentCacheDirs(): string[] {
-	const root = residentCacheRoot();
-	return fs.existsSync(root)
-		? fs
-				.readdirSync(root)
-				.map(name => path.join(root, name))
-				.filter(dir => path.basename(dir).startsWith("i-") && fs.statSync(dir).isDirectory())
-		: [];
-}
-
-function activeResidentCacheDir(): string {
-	const dirs = residentCacheDirs();
-	if (dirs.length !== 1) throw new Error(`Expected one active resident cache dir, got ${dirs.length}`);
-	return dirs[0]!;
+function residentTextCacheDir(sm: SessionManager): string {
+	const dir = sm.residentTextCacheDirForTests();
+	if (!dir) throw new Error("Expected a directory-backed resident text cache");
+	return dir;
 }
 
 async function createPersistedLargeTextSession(
@@ -86,7 +76,7 @@ async function createPersistedLargeTextSession(
 	const sessionFile = sm.getSessionFile();
 	const artifactsDir = sm.getArtifactsDir();
 	if (!sessionFile || !artifactsDir) throw new Error("Expected persisted session paths");
-	const cacheDir = activeResidentCacheDir();
+	const cacheDir = residentTextCacheDir(sm);
 	expect(fs.existsSync(cacheDir)).toBe(true);
 
 	return { sm, sessionFile, artifactsDir, cacheDir, entryId };
@@ -124,7 +114,7 @@ describe("resident text cache missing-blob and reference hygiene", () => {
 		expect(fs.existsSync(cacheDir)).toBe(false);
 
 		const reopened = await SessionManager.open(sessionFile);
-		const reopenedCacheDir = activeResidentCacheDir();
+		const reopenedCacheDir = residentTextCacheDir(reopened);
 		await fs.promises.rm(reopenedCacheDir, { recursive: true, force: true });
 
 		vi.spyOn(EphemeralBlobStore.prototype, "getSync").mockImplementation(function (
@@ -168,7 +158,7 @@ describe("resident text cache missing-blob and reference hygiene", () => {
 	it("exports and rewrites a public-safe placeholder after disk cache deletion", async () => {
 		const sentinel = `corrupt resident text ${"z".repeat(2048)}`;
 		const { sm, sessionFile } = await createPersistedLargeTextSession(sentinel);
-		const liveCacheDir = activeResidentCacheDir();
+		const liveCacheDir = residentTextCacheDir(sm);
 		await fs.promises.rm(liveCacheDir, { recursive: true, force: true });
 		vi.spyOn(EphemeralBlobStore.prototype, "getSync").mockImplementation(function (
 			this: EphemeralBlobStore,
@@ -183,7 +173,7 @@ describe("resident text cache missing-blob and reference hygiene", () => {
 		await sm.close();
 
 		const standalone = await SessionManager.open(sessionFile);
-		const standaloneCacheDir = activeResidentCacheDir();
+		const standaloneCacheDir = residentTextCacheDir(standalone);
 		await fs.promises.rm(standaloneCacheDir, { recursive: true, force: true });
 		const standaloneHtml = path.join(makeTempDir(), "standalone-corrupt.html");
 		await exportSessionToHtml(standalone, undefined, {
@@ -193,7 +183,7 @@ describe("resident text cache missing-blob and reference hygiene", () => {
 		await standalone.close();
 		const fromFileHtml = path.join(makeTempDir(), "from-file-corrupt.html");
 		const exportManager = await SessionManager.open(sessionFile);
-		const exportCacheDir = activeResidentCacheDir();
+		const exportCacheDir = residentTextCacheDir(exportManager);
 		await fs.promises.rm(exportCacheDir, { recursive: true, force: true });
 		await exportSessionToHtml(exportManager, undefined, {
 			outputPath: fromFileHtml,
@@ -202,7 +192,7 @@ describe("resident text cache missing-blob and reference hygiene", () => {
 		await expectFileContainsResidentPlaceholder(fromFileHtml);
 
 		const rewrite = await SessionManager.open(sessionFile);
-		const rewriteCacheDir = activeResidentCacheDir();
+		const rewriteCacheDir = residentTextCacheDir(rewrite);
 		await fs.promises.rm(rewriteCacheDir, { recursive: true, force: true });
 		await rewrite.rewriteEntries();
 		await rewrite.close().catch(() => {});

--- a/packages/coding-agent/test/session-resident-lifecycle.test.ts
+++ b/packages/coding-agent/test/session-resident-lifecycle.test.ts
@@ -142,10 +142,10 @@ function residentCacheDirs(): string[] {
 		: [];
 }
 
-function activeResidentCacheDir(): string {
-	const dirs = residentCacheDirs();
-	if (dirs.length !== 1) throw new Error(`Expected one active resident cache dir, got ${dirs.length}`);
-	return dirs[0]!;
+function residentTextCacheDir(sm: SessionManager): string {
+	const dir = sm.residentTextCacheDirForTests();
+	if (!dir) throw new Error("Expected a directory-backed resident text cache");
+	return dir;
 }
 
 async function makeLargeSession(
@@ -160,7 +160,7 @@ async function makeLargeSession(
 	const sessionFile = sm.getSessionFile();
 	const artifactsDir = sm.getArtifactsDir();
 	if (!sessionFile || !artifactsDir) throw new Error("Expected persisted paths");
-	return { sm, root, sessionFile, artifactsDir, cacheDir: activeResidentCacheDir() };
+	return { sm, root, sessionFile, artifactsDir, cacheDir: residentTextCacheDir(sm) };
 }
 
 describe("resident cache prune retention, lifecycle cleanup, and JSONL parity", () => {
@@ -193,7 +193,7 @@ describe("resident cache prune retention, lifecycle cleanup, and JSONL parity", 
 		await sm.setSessionFile(second.sessionFile);
 		expect(fs.existsSync(switchCacheDir)).toBe(false);
 		expect(JSON.stringify(sm.getEntries())).toContain("cleanup two");
-		const activeCacheDir = activeResidentCacheDir();
+		const activeCacheDir = residentTextCacheDir(sm);
 		expect(fs.existsSync(activeCacheDir)).toBe(true);
 		await sm.close();
 		expect(fs.existsSync(activeCacheDir)).toBe(false);
@@ -238,7 +238,7 @@ describe("resident cache prune retention, lifecycle cleanup, and JSONL parity", 
 		if (!forked) throw new Error("Expected fork result");
 		expect(forked.oldSessionFile).toBe(oldSessionFile);
 		expect(forked.newSessionFile).not.toBe(oldSessionFile);
-		const forkCacheDir = activeResidentCacheDir();
+		const forkCacheDir = residentTextCacheDir(sm);
 		expect(forkCacheDir).not.toBe(oldCacheDir);
 		expect(JSON.stringify(sm.getEntries())).toContain(sentinel);
 		expect(JSON.stringify(sm.buildSessionContext())).toContain(sentinel);
@@ -246,9 +246,10 @@ describe("resident cache prune retention, lifecycle cleanup, and JSONL parity", 
 		const oldManager = await SessionManager.open(oldSessionFile);
 		expect(JSON.stringify(oldManager.getEntries())).toContain(sentinel);
 		const cacheDirs = residentCacheDirs();
-		expect(cacheDirs).toHaveLength(2);
+		const oldManagerCacheDir = residentTextCacheDir(oldManager);
+		expect(oldManagerCacheDir).not.toBe(forkCacheDir);
 		expect(cacheDirs).toContain(forkCacheDir);
-		expect(cacheDirs.filter(dir => dir !== forkCacheDir)).toHaveLength(1);
+		expect(cacheDirs).toContain(oldManagerCacheDir);
 		await oldManager.close();
 		await sm.close();
 	});
@@ -266,9 +267,13 @@ describe("resident cache prune retention, lifecycle cleanup, and JSONL parity", 
 		expect(await readPersistedJsonl(movedFile)).toContain(sentinel.slice(0, 100));
 		expect(await readPersistedJsonl(movedFile)).not.toContain("__gjcResidentBlob");
 		expect(await readPersistedJsonl(movedFile)).not.toContain("blob:sha256:");
-		const movedCacheDir = activeResidentCacheDir();
+		const movedCacheDir = residentTextCacheDir(sm);
 		expect(movedCacheDir).not.toBe(cacheDir);
+		// The superseded text store must not survive the move, even though the
+		// managed sidecar cache keeps its own instance dir under the same root.
+		expect(residentCacheDirs()).not.toContain(cacheDir);
 		await sm.close();
+		expect(residentCacheDirs()).toEqual([]);
 	});
 
 	it("restoreState re-owns resident text before resetting the resident store", async () => {

--- a/packages/coding-agent/test/ultragoal-redteam-resident-cache.test.ts
+++ b/packages/coding-agent/test/ultragoal-redteam-resident-cache.test.ts
@@ -143,6 +143,12 @@ function residentInstanceDirs(root = residentCacheRoot()): string[] {
 	}
 }
 
+function residentTextCacheDir(manager: SessionManager): string {
+	const directory = manager.residentTextCacheDirForTests();
+	if (!directory) throw new Error("Expected a directory-backed resident text cache");
+	return directory;
+}
+
 function residentBlobFiles(instanceDir: string): string[] {
 	return fs
 		.readdirSync(instanceDir)
@@ -224,9 +230,9 @@ describe.skipIf(process.platform === "win32")("ultragoal resident-cache adversar
 				const atId = appendUserText(manager, at);
 				const aboveId = appendUserText(manager, above);
 				const sessionFile = await persist(manager);
-				const instances = residentInstanceDirs();
-				expect(instances).toHaveLength(1);
-				expect(residentBlobFiles(instances[0]!)).toHaveLength(2);
+				const activeInstance = residentTextCacheDir(manager);
+				expect(residentInstanceDirs()).toContain(activeInstance);
+				expect(residentBlobFiles(activeInstance)).toHaveLength(2);
 				expect(messageText(manager, belowId)).toBe(below);
 				expect(messageText(manager, atId)).toBe(at);
 				expect(messageText(manager, aboveId)).toBe(above);
@@ -524,8 +530,8 @@ describe.skipIf(process.platform === "win32")("ultragoal resident-cache adversar
 		const seed = `C7-seed-${"s".repeat(4096)}`;
 		appendUserText(manager, seed);
 		await persist(manager);
-		const active = residentInstanceDirs(root);
-		expect(active).toHaveLength(1);
+		const activeInstance = residentTextCacheDir(manager);
+		expect(residentInstanceDirs(root)).toContain(activeInstance);
 		const stale = path.join(root, "i-redteam-dead");
 		ensureOwnerOnlyDirectory(stale);
 		fs.writeFileSync(
@@ -541,7 +547,7 @@ describe.skipIf(process.platform === "win32")("ultragoal resident-cache adversar
 				}
 			})();
 			await Promise.all([sweepResidentCacheRoot(root, { maxDirectories: 64, maxDurationMs: 250 }), appendRace]);
-			expect(fs.existsSync(active[0]!)).toBe(true);
+			expect(fs.existsSync(activeInstance)).toBe(true);
 			expect(fs.existsSync(stale)).toBe(false);
 			expectReadable(manager, seed);
 			expectReadable(manager, "C7-race-3-");


### PR DESCRIPTION
## Problem

`dev` has been red since #4151 (`17cdad163`). Bisect: `dev~4` green, `dev~3` red.

Two regressions from that merge:

1. **Managed sidecar cache shares the resident-cache root.** `#managedSidecarRoot()` allocates its own `i-` instance directory under `getResidentCacheRootDir(...)`. Seven tests assumed "exactly one `i-` dir == the resident text store" and started failing as soon as a code path (`moveTo`) rebuilt sidecars.
2. **`#assertPathBackedReadRelative` rejects every nested read without retained root authority.** `readExpected` is exactly the call `copyArtifactsForFork` uses to copy `<session>/<artifact>` during `fork()` and `moveTo()`, so both blow up with `managed_nested_path_unsupported` on any platform without a retained native root (macOS, Windows).

The guard was also inconsistent with the write side: `publishNoReplace` has always accepted nested relative paths on the same no-authority path.

Fallout on open PRs: `Affected path validation / test:@gajae-code/coding-agent:shard-1-of-8` fails on #4153 and #4108 with a failure neither PR caused.

## Change

- `readExpected` resolves once, then verifies the directory chain instead of refusing nesting: every component between the bound base dir and the leaf must be a real, non-symlink, same-device directory. `O_NOFOLLOW` only covers the leaf, so this closes the gap the blanket guard was reaching for while keeping the operation available. `descriptorExpected` and `readRange` keep the original guard — neither is called with nested paths.
- Added `SessionManager.residentTextCacheDirForTests()` so tests address the resident text store directly.
- Reworked the affected assertions to check membership/identity rather than instance-dir counts.

## Verification

| suite | before | after |
| --- | --- | --- |
| `session-resident-lifecycle` | 8 pass / 1 fail | 9 pass |
| `session-resident-transition-seam` | 24 pass / 2 fail | 26 pass |
| `session-resident-cache-root-derivation` | 1 pass / 4 fail | 5 pass |
| `ultragoal-redteam-resident-cache` | 6 pass / 3 fail | 9 pass |

Also green: `session-resident-cache`, `session-manager/**`, `session/**`, `session-resident-root-security`, `task-managed-descendants` (364 pass), plus `bun --cwd=packages/coding-agent run check`.

The 4 `FileSessionStorageWriter path security` failures in `session-storage.test.ts` are unrelated and predate #4151 — they assert fd-based owner-only security, which is Linux-only, so they only fail on macOS.