### PR TITLE
test(models): cover numeric colon-tagged model selectors

### DIFF
--- a/packages/coding-agent/test/custom-model-preset-creation.test.ts
+++ b/packages/coding-agent/test/custom-model-preset-creation.test.ts
@@ -248,6 +248,35 @@ describe("custom model preset creation", () => {
 
 		expect(await Bun.file(modelsPath).text()).toBe(original);
 	});
+	it("saves a new preset when an existing mapping uses a colon-tagged concrete model id", async () => {
+		const modelsPath = path.join(tempDir, "models.yml");
+		await Bun.write(
+			modelsPath,
+			[
+				"profiles:",
+				"  repro:",
+				"    required_providers: [ollama-cloud]",
+				"    model_mapping:",
+				"      default: ollama-cloud/deepseek-v4-flash:0731",
+				"",
+			].join("\n"),
+		);
+		const registry = new ModelRegistry(authStorage, modelsPath);
+
+		await expect(
+			registry.saveCustomModelProfile("my-fast", {
+				display_name: "my-fast",
+				required_providers: ["my-oai"],
+				model_mapping: { default: "my-oai/gpt-custom:low" },
+			}),
+		).resolves.toBeDefined();
+
+		const parsed = YAML.parse(await Bun.file(modelsPath).text()) as {
+			profiles: Record<string, { model_mapping: Record<string, string> }>;
+		};
+		expect(parsed.profiles.repro.model_mapping.default).toBe("ollama-cloud/deepseek-v4-flash:0731");
+		expect(parsed.profiles["my-fast"].model_mapping.default).toBe("my-oai/gpt-custom:low");
+	});
 
 	it("rejects duplicate custom preset ids without overwriting existing profiles or providers", async () => {
 		const modelsPath = path.join(tempDir, "models.yml");

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -1355,6 +1355,33 @@ describe("model profile activation", () => {
 		});
 		expect(session.getActiveModelProfile()).toBeUndefined();
 	});
+	test("colon-tagged concrete model selector materializes whole with optional effort", async () => {
+		const session = fakeSession();
+		const settings = Settings.isolated({ "task.agentModelOverrides": { executor: "provider-a/old-executor" } });
+		const registry = fakeRegistry({
+			profiles: [
+				{
+					name: "colon-tag",
+					requiredProviders: ["ollama-cloud"],
+					modelMapping: {
+						default: "ollama-cloud/deepseek-v4-flash:0731",
+						executor: "ollama-cloud/deepseek-v4-flash:0731:xhigh",
+					},
+					source: "user",
+				},
+			],
+		});
+		registry.getAll = () => [model("ollama-cloud", "deepseek-v4-flash:0731"), ...fakeRegistry().getAll()];
+
+		await activateModelProfile({ session, modelRegistry: registry, settings, profileName: "colon-tag" });
+
+		expect(session.getConfiguredModelChain("default")).toEqual(["ollama-cloud/deepseek-v4-flash:0731"]);
+		expect(session.model?.provider).toBe("ollama-cloud");
+		expect(session.model?.id).toBe("deepseek-v4-flash:0731");
+		expect(settings.get("task.agentModelOverrides")).toEqual({
+			executor: "ollama-cloud/deepseek-v4-flash:0731:xhigh",
+		});
+	});
 
 	test("batch materialization is inactive without an active profile", () => {
 		const session = fakeSession();

--- a/packages/coding-agent/test/model-profiles-schema.test.ts
+++ b/packages/coding-agent/test/model-profiles-schema.test.ts
@@ -112,6 +112,31 @@ describe("model profile schema", () => {
 		expect(badEffort.success).toBe(true);
 		expect(colonRoute.success).toBe(true);
 	});
+	test("colon-tagged concrete model IDs parse whole with optional effort suffix", () => {
+		const exactTag = ModelsConfigSchema.safeParse({
+			profiles: {
+				repro: {
+					required_providers: ["ollama-cloud"],
+					model_mapping: { default: "ollama-cloud/deepseek-v4-flash:0731" },
+				},
+			},
+		});
+		const tagPlusEffort = ModelsConfigSchema.safeParse({
+			profiles: {
+				repro: {
+					required_providers: ["ollama-cloud"],
+					model_mapping: { default: "ollama-cloud/deepseek-v4-flash:0731:xhigh" },
+				},
+			},
+		});
+		const bareTag = ModelsConfigSchema.safeParse({
+			profiles: { repro: { required_providers: [], model_mapping: { default: "deepseek-v4-flash:0731" } } },
+		});
+
+		expect(exactTag.success).toBe(true);
+		expect(tagPlusEffort.success).toBe(true);
+		expect(bareTag.success).toBe(true);
+	});
 
 	test("comma-chain selectors are rejected with model_mapping path", () => {
 		const commaChain = ModelsConfigSchema.safeParse({

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -13,6 +13,7 @@ import {
 	resolveModelOverride,
 	resolveModelRoleValue,
 	resolveModelScope,
+	resolveSelector,
 	restoreModelFromSession,
 } from "@gajae-code/coding-agent/config/model-resolver";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
@@ -718,6 +719,29 @@ describe("resolveModelFromString", () => {
 		const resolved = resolveModelFromString("openrouter/qwen/qwen3-coder:exacto", allModels);
 		expect(resolved?.provider).toBe("openrouter");
 		expect(resolved?.id).toBe("qwen/qwen3-coder:exacto");
+	});
+	test("resolves a concrete colon-tagged model id whole and consumes only a recognized effort suffix", () => {
+		const catalog = [
+			...allModels,
+			{ ...mockModels[0], provider: "ollama-cloud", id: "deepseek-v4-flash:0731" },
+		] as Model[];
+
+		const exact = resolveModelFromString("ollama-cloud/deepseek-v4-flash:0731", catalog);
+		expect(exact?.provider).toBe("ollama-cloud");
+		expect(exact?.id).toBe("deepseek-v4-flash:0731");
+
+		const withEffort = resolveSelector("ollama-cloud/deepseek-v4-flash:0731:xhigh", catalog);
+		expect(withEffort.model?.provider).toBe("ollama-cloud");
+		expect(withEffort.model?.id).toBe("deepseek-v4-flash:0731");
+		expect(withEffort.thinkingLevel).toBe(Effort.XHigh);
+		expect(withEffort.explicitThinkingLevel).toBe(true);
+
+		const parsed = parseModelString("ollama-cloud/deepseek-v4-flash:0731:xhigh");
+		expect(parsed).toEqual({
+			provider: "ollama-cloud",
+			id: "deepseek-v4-flash:0731",
+			thinkingLevel: Effort.XHigh,
+		});
 	});
 });
 


### PR DESCRIPTION
## Summary

`dev` already contains the #4006 schema fix for colon-bearing concrete model IDs. This PR adds exact end-to-end regression coverage for numeric colon tags in model selectors; it contains only four test files and no production source changes.

Closes #4187

## Verification

- 220 focused tests passed across the six model suites
- `packages/coding-agent` typecheck passed

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*