### PR TITLE
fix(session): preserve managed append uncertainty

### DIFF
--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -102,7 +102,7 @@ export class ManagedCommittedMutationError extends Error {
 
 function managedAppendFailure(code: string | undefined): Error {
 	const error = new Error(code ?? "managed_append_failed");
-	return code === "identity_mismatch" || code === "not_found" || code === "content_too_large"
+	return code === "content_too_large" || code === "too_large"
 		? error
 		: new ManagedCommittedMutationError("append", error);
 }

--- a/packages/coding-agent/test/session-manager/managed-failure-injection.ts
+++ b/packages/coding-agent/test/session-manager/managed-failure-injection.ts
@@ -34,6 +34,10 @@ export type ManagedInjectionHandle = {
 	assertHit: () => void;
 };
 
+type ManagedAppendOutcomeInjectionHandle = ManagedInjectionHandle & {
+	realAppendCalls: () => number;
+};
+
 function handle(hits: { n: number }, restore: () => void): ManagedInjectionHandle {
 	return {
 		restore,
@@ -181,8 +185,8 @@ export function injectManagedFileRename(
 	return handle(hits, () => spy.mockRestore());
 }
 
-/** Inject managed append failures (moveTo cwd header_patch). */
-export function injectManagedAppend(
+/** Inject a failure before a managed append starts (moveTo cwd header_patch). */
+export function injectManagedAppendPreCommit(
 	impl: (relativePath: string, data: Uint8Array) => { ok: false; code: string } | "passthrough",
 ): ManagedInjectionHandle {
 	const hits = { n: 0 };
@@ -215,7 +219,7 @@ export function injectManagedAppend(
 				);
 			}
 			hits.n += 1;
-			return result;
+			throw new Error(result.code);
 		});
 		return handle(hits, () => spy.mockRestore());
 	}
@@ -238,4 +242,44 @@ export function injectManagedAppend(
 		return realWrite(...args);
 	} as typeof fs.writeSync);
 	return handle(hits, () => spy.mockRestore());
+}
+
+/** Commit a Linux managed append, then report an ambiguous failed outcome. */
+export function injectManagedAppendOutcomeUncertain(
+	impl: (relativePath: string, data: Uint8Array) => { ok: false; code: string } | "passthrough",
+): ManagedAppendOutcomeInjectionHandle {
+	if (process.platform !== "linux") throw new Error("managed_append_post_commit_injection_unsupported");
+	const hits = { n: 0 };
+	const realAppendCalls = { n: 0 };
+	const real = native.RecoveryFsRoot.prototype.appendManaged;
+	const spy = vi.spyOn(native.RecoveryFsRoot.prototype, "appendManaged").mockImplementation(function (
+		this: native.RecoveryFsRoot,
+		relativePath,
+		data,
+		expectedDev,
+		expectedIno,
+		expectedSize,
+		expectedMtimeNs,
+		expectedCtimeNs,
+		expectedSha256,
+	) {
+		const bytes = data instanceof Uint8Array ? data : new Uint8Array(data as ArrayBuffer);
+		const result = impl(String(relativePath), bytes);
+		realAppendCalls.n += 1;
+		const committed = real.call(
+			this,
+			relativePath,
+			data,
+			expectedDev,
+			expectedIno,
+			expectedSize,
+			expectedMtimeNs,
+			expectedCtimeNs,
+			expectedSha256,
+		);
+		if (result === "passthrough" || !committed.ok) return committed;
+		hits.n += 1;
+		return result;
+	});
+	return { ...handle(hits, () => spy.mockRestore()), realAppendCalls: () => realAppendCalls.n };
 }

--- a/packages/coding-agent/test/session-manager/title-source-persistence.test.ts
+++ b/packages/coding-agent/test/session-manager/title-source-persistence.test.ts
@@ -13,7 +13,7 @@ import { FileSessionStorage, type SessionStorageWriter } from "@gajae-code/codin
 import { getConfigRootDir, parseJsonlLenient, setAgentDir } from "@gajae-code/utils";
 
 import { makeAssistantMessage } from "./helpers";
-import { injectManagedAppend } from "./managed-failure-injection";
+import { injectManagedAppendOutcomeUncertain, injectManagedAppendPreCommit } from "./managed-failure-injection";
 
 function getHeader(entries: unknown[]): SessionHeader | undefined {
 	return entries.find(
@@ -305,7 +305,7 @@ describe("session title source persistence", () => {
 	});
 
 	describe("moveTo header patch persistence", () => {
-		it("rejects when the moved session cwd patch cannot be written", async () => {
+		it("retains the causal error and source authority when the cwd patch append is rejected before commit", async () => {
 			const destinationCwd = path.join(testAgentDir, "destination-cwd");
 			fs.mkdirSync(destinationCwd, { recursive: true });
 			const storage = new FileSessionStorage();
@@ -315,8 +315,9 @@ describe("session title source persistence", () => {
 			await session.flush();
 			const originalFile = session.getSessionFile();
 			expect(originalFile).toBeDefined();
+			const originalBytes = fs.readFileSync(originalFile!);
 
-			const injection = injectManagedAppend((_relativePath, data) =>
+			const injection = injectManagedAppendPreCommit((_relativePath, data) =>
 				Buffer.from(data).includes(Buffer.from('"type":"header_patch"'))
 					? { ok: false, code: "header_patch_write_failed" }
 					: "passthrough",
@@ -324,12 +325,68 @@ describe("session title source persistence", () => {
 			try {
 				await expect(session.moveTo(destinationCwd)).rejects.toThrow("header_patch_write_failed");
 				injection.assertHit();
+				expect(injection.hits()).toBe(1);
 			} finally {
 				injection.restore();
 			}
 			expect(session.getCwd()).toBe(cwd);
 			expect(session.getSessionFile()).toBe(originalFile);
+			expect(fs.readFileSync(originalFile!)).toEqual(originalBytes);
 			expect((await loadEntriesFromFile(originalFile!, storage))[0]).toMatchObject({ cwd });
 		});
+
+		for (const failureCode of ["identity_mismatch", "not_found"] as const) {
+			it.skipIf(process.platform !== "linux")(
+				`retains the uncertain ${failureCode} classification without retry after the cwd patch append commits`,
+				async () => {
+					const destinationCwd = path.join(testAgentDir, `post-commit-${failureCode}-destination-cwd`);
+					fs.mkdirSync(destinationCwd, { recursive: true });
+					const storage = new FileSessionStorage();
+					const session = SessionManager.create(cwd, undefined, storage);
+					session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+					session.appendMessage(makeAssistantMessage());
+					await session.flush();
+					const originalFile = session.getSessionFile();
+					expect(originalFile).toBeDefined();
+					const originalBytes = fs.readFileSync(originalFile!);
+					const destinationFile = path.join(
+						SessionManager.getDefaultSessionDir(destinationCwd, testAgentDir, storage),
+						path.basename(originalFile!),
+					);
+
+					const injection = injectManagedAppendOutcomeUncertain((_relativePath, data) =>
+						Buffer.from(data).includes(Buffer.from('"type":"header_patch"'))
+							? { ok: false, code: failureCode }
+							: "passthrough",
+					);
+					let failure: Error | undefined;
+					try {
+						await session.moveTo(destinationCwd);
+					} catch (error) {
+						failure = error instanceof Error ? error : new Error(String(error));
+					} finally {
+						injection.restore();
+					}
+					expect(failure?.message).toBe("managed_append_committed_outcome_uncertain");
+					expect(failure?.cause).toBeInstanceOf(Error);
+					expect((failure?.cause as Error).message).toBe(failureCode);
+					injection.assertHit();
+					expect(injection.hits()).toBe(1);
+					expect(injection.realAppendCalls()).toBe(1);
+					expect(session.getCwd()).toBe(cwd);
+					expect(session.getSessionFile()).toBe(originalFile);
+					expect(fs.readFileSync(originalFile!)).toEqual(originalBytes);
+					const persistedBytes = fs.readFileSync(destinationFile);
+					expect(persistedBytes.subarray(0, originalBytes.byteLength)).toEqual(originalBytes);
+					const patchLines = persistedBytes
+						.toString("utf8")
+						.trimEnd()
+						.split("\n")
+						.filter(line => line.includes('"type":"header_patch"'));
+					expect(patchLines).toHaveLength(1);
+					expect(JSON.parse(patchLines[0]!)).toEqual({ type: "header_patch", patch: { cwd: destinationCwd } });
+				},
+			);
+		}
 	});
 });


### PR DESCRIPTION
## Dev CI repair

Repairs the sole deterministic red in Dev CI run [31414887852](https://github.com/Yeachan-Heo/gajae-code/actions/runs/31414887852), shard `test:@gajae-code/coding-agent:shard-6-of-8`, at exact `dev` `79e4e0a097aeb54cfe94f79b8919af778dbc5c68`.

The failing test expected the injected pre-commit `header_patch_write_failed` cause but the Linux seam returned a synthetic failed native result, which current retained-append semantics correctly treated as potentially committed. Investigation also found a production classification hole: Linux `append_managed` can emit terminal `identity_mismatch` or `not_found` after `write_all`, while TypeScript treated both as definitely pre-commit.

## Causal fix

- Make the failure injection explicitly pre-commit, preserving `header_patch_write_failed`, the byte-identical source transcript, and old cwd/session-file authority.
- Conservatively keep only provable size preflight failures direct; classify `identity_mismatch` and `not_found` as `managed_append_committed_outcome_uncertain` while preserving the native code as `cause`.
- Add Linux post-commit regressions for both terminal codes. Each calls the real append boundary exactly once, proves no retry, retains one destination `header_patch` as physical commit evidence, and restores the byte-identical source authority.

## Overlap search

Searched open/closed issues and PRs for `header_patch_write_failed`, `managed_append_committed_outcome_uncertain`, and session title-source persistence before implementation. No active repair overlapped this failure. #4151 introduced the conservative retained-append classification; #4188 did not change this contract. This PR is the signed tracking context for the Dev CI repair.

## Verification

- Focused three-case cwd patch suite: 10 consecutive repetitions, all passed.
- `bun test packages/coding-agent/test/session-manager/title-source-persistence.test.ts` — 10 passed.
- `bun test packages/coding-agent/test/session-manager/move-to.test.ts packages/coding-agent/test/session-storage.test.ts` — 101 passed, 20 skipped.
- `bun test packages/coding-agent/test/session-manager` — 366 passed, 5 skipped across 30 files.
- `bun --cwd=packages/coding-agent run check` — Biome and TypeScript passed.

No merge or release is requested.

Signed-off-by: GJC Dev CI Repair <dev-ci@gajae.dev>