### PR TITLE
test(dev): isolate Bash and file-lock CI fixtures

### DIFF
--- a/packages/coding-agent/src/config/file-lock-gc.ts
+++ b/packages/coding-agent/src/config/file-lock-gc.ts
@@ -35,6 +35,8 @@ interface WalkState {
 export interface FileLocksGcCollectOptions {
 	/** Override per-root entry budget (tests). Defaults to {@link FILE_LOCK_GC_MAX_WALK_ENTRIES}. */
 	maxWalkEntries?: number;
+	/** Override global lock roots for isolated collection tests. */
+	roots?: readonly string[];
 }
 
 // Global, env-aware GJC lock roots. Per the approved scope this covers the
@@ -169,7 +171,8 @@ export async function collectFileLocksForGc(
 	const warnings: GcWarning[] = [];
 	const lockDirs = new Set<string>();
 
-	for (const root of knownFileLockRoots(ctx)) {
+	const roots = options.roots ?? knownFileLockRoots(ctx);
+	for (const root of Array.from(new Set(roots.map(root => path.resolve(root))))) {
 		// Fresh budget per root so a huge agent dir cannot starve config/spool.
 		const state: WalkState = { entries: 0, truncated: false };
 		await walkForLockDirs(root, 0, state, lockDirs, errors, maxWalkEntries);

--- a/packages/coding-agent/test/gc-stores.test.ts
+++ b/packages/coding-agent/test/gc-stores.test.ts
@@ -10,7 +10,6 @@ import {
 	harnessLeasesGcAdapter,
 	registryEntriesGcAdapter,
 } from "@gajae-code/coding-agent/harness-control-plane/gc-adapter";
-import { getAgentDir, setAgentDir } from "@gajae-code/utils";
 
 const DEAD_PID = 4242;
 const ALIVE_PID = 4243;
@@ -151,7 +150,7 @@ describe("fileLocksGcAdapter", () => {
 			env: { ...process.env, GJC_RECEIPT_SPOOL_DIR: spoolDir },
 			cwd: base,
 		};
-		const { records, errors, warnings } = await fileLocksGcAdapter.collect(ctx);
+		const { records, errors, warnings } = await collectFileLocksForGc(ctx, { roots: [spoolDir] });
 		const byPath = new Map(records.map(r => [path.resolve(r.path ?? r.id), r]));
 		expect(byPath.get(path.resolve(deadLock))?.removable).toBe(true);
 		expect(byPath.get(path.resolve(aliveLock))?.removable).toBe(false);
@@ -169,61 +168,55 @@ describe("fileLocksGcAdapter", () => {
 
 	test("walk cap is a per-root warning and does not skip remaining roots (#3852)", async () => {
 		const base = await makeTemp();
-		const originalAgentDir = getAgentDir();
-		// Isolate agent dir under the temp tree so config-root + agent share base.
 		const agentDir = path.join(base, "agent");
 		await fs.mkdir(agentDir, { recursive: true });
-		setAgentDir(agentDir);
-		try {
-			// Flood the agent root so a tiny budget truncates it; spool stays small.
-			const flooded = path.join(agentDir, "flood");
-			await fs.mkdir(flooded, { recursive: true });
-			for (let i = 0; i < 8; i++) {
-				await fs.writeFile(path.join(flooded, `f${i}`), "x", "utf8");
-			}
-
-			const spoolDir = path.join(base, "spool");
-			const spoolLock = path.join(spoolDir, "spool-dead.lock");
-			await writeJson(path.join(spoolLock, "info"), { pid: DEAD_PID, timestamp: Date.now() });
-
-			const ctx: GcContext = {
-				probe: splitProbe,
-				force: false,
-				env: { ...process.env, GJC_RECEIPT_SPOOL_DIR: spoolDir },
-				cwd: base,
-			};
-			// Budget of 3 is enough to start agent root but not exhaust its flood,
-			// while still fully scanning the small spool root (independent budget).
-			const result = await collectFileLocksForGc(ctx, { maxWalkEntries: 3 });
-			expect(result.errors).toEqual([]);
-			const warnings = result.warnings ?? [];
-			expect(warnings.length).toBeGreaterThan(0);
-			for (const warning of warnings) {
-				expect(warning.store).toBe("file_locks");
-				expect(warning.message).toContain("file lock discovery capped at 3 entries for root");
-				expect(warning.message).toContain("scanned");
-			}
-			// Spool lock must still be discovered after agent root truncation.
-			const spoolRec = result.records.find(r => path.resolve(r.path ?? r.id) === path.resolve(spoolLock));
-			expect(spoolRec?.removable).toBe(true);
-
-			const report = await collectGcReport(
-				[
-					{
-						store: "file_locks",
-						collect: async c => collectFileLocksForGc(c, { maxWalkEntries: 3 }),
-						prune: fileLocksGcAdapter.prune.bind(fileLocksGcAdapter),
-					},
-				],
-				ctx,
-				false,
-			);
-			expect(report.errors).toEqual([]);
-			expect(report.warnings.length).toBeGreaterThan(0);
-			expect(computeExitCode(report)).toBe(0);
-		} finally {
-			setAgentDir(originalAgentDir);
+		// Flood the agent root so a tiny budget truncates it; spool stays small.
+		const flooded = path.join(agentDir, "flood");
+		await fs.mkdir(flooded, { recursive: true });
+		for (let i = 0; i < 8; i++) {
+			await fs.writeFile(path.join(flooded, `f${i}`), "x", "utf8");
 		}
+
+		const spoolDir = path.join(base, "spool");
+		const spoolLock = path.join(spoolDir, "spool-dead.lock");
+		await writeJson(path.join(spoolLock, "info"), { pid: DEAD_PID, timestamp: Date.now() });
+
+		const ctx: GcContext = {
+			probe: splitProbe,
+			force: false,
+			env: { ...process.env, GJC_RECEIPT_SPOOL_DIR: spoolDir },
+			cwd: base,
+		};
+		// Budget of 3 is enough to start agent root but not exhaust its flood,
+		// while still fully scanning the small spool root (independent budget).
+		const roots = [agentDir, spoolDir];
+		const result = await collectFileLocksForGc(ctx, { maxWalkEntries: 3, roots });
+		expect(result.errors).toEqual([]);
+		const warnings = result.warnings ?? [];
+		expect(warnings.length).toBeGreaterThan(0);
+		for (const warning of warnings) {
+			expect(warning.store).toBe("file_locks");
+			expect(warning.message).toContain("file lock discovery capped at 3 entries for root");
+			expect(warning.message).toContain("scanned");
+		}
+		// Spool lock must still be discovered after agent root truncation.
+		const spoolRec = result.records.find(r => path.resolve(r.path ?? r.id) === path.resolve(spoolLock));
+		expect(spoolRec?.removable).toBe(true);
+
+		const report = await collectGcReport(
+			[
+				{
+					store: "file_locks",
+					collect: async c => collectFileLocksForGc(c, { maxWalkEntries: 3, roots }),
+					prune: fileLocksGcAdapter.prune.bind(fileLocksGcAdapter),
+				},
+			],
+			ctx,
+			false,
+		);
+		expect(report.errors).toEqual([]);
+		expect(report.warnings.length).toBeGreaterThan(0);
+		expect(computeExitCode(report)).toBe(0);
 	});
 });
 


### PR DESCRIPTION
## Repair scope
- Base: exact current `dev` head `d5b782d8dd6f938dc43dd2b27a0ce4c2c548ff86`.
- Head: signed `74cc4591d1721444a42e1fcd880764f614470d4b`.
- Does not carry the already-merged browser catalog or tmux observer changes.

## Causal findings from superseded run 31451632824
- The affected plan maps the changed Bash state test to `bun test --shard=6/8`. Its controlled `gjc` fixture altered `PATH`, but `@gajae-code/utils/shell-config` had cached the prior shell environment. On a runner without a globally installed `gjc`, BashTool reached its standard non-zero mapping and emitted `Command exited with code 127`; on a workstation with `gjc` installed, the wrong executable ran and the sentinel remained absent. The fixture now resets that cache and disposes the old shell session before and after the controlled executable is active.
- `gc-stores.test.ts` classified the intended temporary locks correctly, but its default adapter call also scanned live `~/.gjc` and `~/.gjc/agent`. Host state with more than 20,000 entries produced `file lock discovery capped` warnings, invalidating the empty-warning assertion. The test now supplies explicit temporary roots; production global-root discovery is unchanged.

## Verification
- `bun test packages/coding-agent/test/tools/bash-state-exploit.test.ts` — 24 pass
- `bun test packages/coding-agent/test/gc-stores.test.ts` — 8 pass
- Clean-HOME `bun --cwd=packages/coding-agent test --shard=6/8` — 2,046 pass, 0 fail
- `bun --cwd=packages/coding-agent run check`

The `dev` CI for the base commit (run 31452584569) was cancelled, so this successor requires fresh exact-head CI.