### PR TITLE
feat(slash-commands): activate model preset from /model <preset>

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- `/model <preset>` and `/model gajae-code/<preset>` now activate a known model profile immediately instead of failing with "Unknown model". Unknown names still fall through to model resolution, and `/model <role> <preset>` keeps assigning a model to the named role.
 - Browser `act` and `run` responses can now surface an opt-in (`open(..., { diagnostics: true })`), bounded mailbox of page exceptions and `console.error` metadata. Entries carry only kind, timestamp, origin-only URL, line/column, and an allowlisted built-in error class; path segments, query strings, messages, arguments, values, and stacks are never retained. Serialization is byte-bounded with an explicit truncation marker.
 
 ### Fixed

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -6,7 +6,8 @@ import { getOAuthProviders } from "@gajae-code/ai/utils/oauth";
 import { PET_SKINS, type PetMode, Spacer, Text } from "@gajae-code/tui";
 import { setProjectDir } from "@gajae-code/utils";
 import { jobElapsedMs } from "../async";
-import { materializeActiveModelProfileAssignments } from "../config/model-profile-activation";
+import { activateModelProfile, materializeActiveModelProfileAssignments } from "../config/model-profile-activation";
+import { formatModelProfileDisplayLabel } from "../config/model-profiles";
 import {
 	GJC_MODEL_ASSIGNMENT_TARGET_IDS,
 	GJC_MODEL_ASSIGNMENT_TARGETS,
@@ -243,6 +244,54 @@ function parseModelCommandArgs(args: string): ParsedModelCommandArgs {
 	}
 	return { kind: "assign", targetId: "default", selector: args.trim() };
 }
+/**
+ * Optional namespace prefix accepted on `/model <preset>` selectors so users
+ * can disambiguate preset names from model ids with `gajae-code/<preset>`.
+ * The bare preset name remains the canonical form.
+ */
+const MODEL_PRESET_NAMESPACE_PREFIX = "gajae-code/";
+
+/**
+ * Resolve a `/model <selector>` argument against the merged model-profile
+ * registry. Returns the canonical profile name when `selector` is either a
+ * bare preset name (`codex-medium`) or a namespaced one
+ * (`gajae-code/codex-medium`); returns `undefined` otherwise so the caller
+ * falls through to ordinary model resolution.
+ *
+ * Only selectors that do NOT look like `provider/model` references are
+ * considered, so `/model anthropic/claude-...` is never hijacked by a preset.
+ */
+export function resolvePresetSelector(
+	selector: string,
+	modelRegistry: { getModelProfile?: (name: string) => unknown; getError?: () => unknown },
+): string | undefined {
+	const trimmed = selector.trim();
+	if (!trimmed) return undefined;
+
+	// Reject `provider/model` references outright: even if a preset happened to
+	// be named `anthropic/claude`, the slash form is a model selector, not a
+	// preset shortcut. The only accepted slash form is the `gajae-code/`
+	// namespace prefix.
+	if (trimmed.includes("/")) {
+		if (!trimmed.toLowerCase().startsWith(MODEL_PRESET_NAMESPACE_PREFIX)) return undefined;
+		const stripped = trimmed.slice(MODEL_PRESET_NAMESPACE_PREFIX.length);
+		if (!stripped || stripped.includes("/")) return undefined;
+		return matchProfileName(stripped, modelRegistry);
+	}
+
+	return matchProfileName(trimmed, modelRegistry);
+}
+
+function matchProfileName(
+	candidate: string,
+	modelRegistry: { getModelProfile?: (name: string) => unknown; getError?: () => unknown },
+): string | undefined {
+	// A registry load error means we cannot trust the profile index; fall
+	// through to model resolution rather than guessing. A registry without a
+	// getModelProfile surface (e.g. a minimal test fixture) has no presets.
+	if (modelRegistry.getError?.()) return undefined;
+	return modelRegistry.getModelProfile?.(candidate) ? candidate : undefined;
+}
 
 function splitExplicitThinkingSelector(selector: string): { baseSelector: string; thinkingLevel?: ThinkingLevel } {
 	const trimmed = selector.trim();
@@ -402,6 +451,7 @@ function modelSelectionUsage(runtime: SlashCommandRuntime, currentModelLine?: st
 		currentModelLine,
 		formatModelAssignmentSummary(runtime),
 		"Use /model <model> for DEFAULT, or /model <target> <model[:effort]> for EXECUTOR, ARCHITECT, PLANNER, or CRITIC.",
+		"Use /model <preset> or /model gajae-code/<preset> to activate a known model profile.",
 		formatModelOnboardingGuidance(),
 	]
 		.filter((line): line is string => Boolean(line))
@@ -746,6 +796,36 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 						modelSelectionUsage(runtime, `Missing model for ${parsedArgs.targetId.toUpperCase()}.`),
 						runtime,
 					);
+				}
+				// Preset shortcut: when the selector names a known model profile
+				// (optionally `gajae-code/`-prefixed) and no explicit role target
+				// was given, activate the profile immediately instead of treating
+				// the preset name as a model id and failing with "Unknown model".
+				// `/model <role> <preset>` keeps assigning to the named role.
+				if (parsedArgs.targetId === "default") {
+					const presetName = resolvePresetSelector(modelId, runtime.session.modelRegistry);
+					if (presetName) {
+						try {
+							const profileLabel = formatModelProfileDisplayLabel(
+								runtime.session.modelRegistry.getModelProfile(presetName) ?? { name: presetName },
+							);
+							await activateModelProfile(
+								{
+									session: runtime.session,
+									modelRegistry: runtime.session.modelRegistry,
+									settings: runtime.settings,
+									profileName: presetName,
+								},
+								{ persistDefault: false },
+							);
+							await runtime.output(`Model profile: ${profileLabel}`);
+							await runtime.notifyTitleChanged?.();
+							await runtime.notifyConfigChanged?.();
+							return commandConsumed();
+						} catch (err) {
+							return usage(`Failed to activate model profile: ${errorMessage(err)}`, runtime);
+						}
+					}
 				}
 				const resolution = await resolveModelCommandSelection(runtime, modelId);
 				if (!resolution.ok) {

--- a/packages/coding-agent/test/slash-commands/model-preset.test.ts
+++ b/packages/coding-agent/test/slash-commands/model-preset.test.ts
@@ -1,0 +1,229 @@
+import { afterAll, afterEach, describe, expect, spyOn, test } from "bun:test";
+import * as modelProfileActivation from "../../src/config/model-profile-activation";
+import { Settings } from "../../src/config/settings";
+import type { AgentSession } from "../../src/session/agent-session";
+import type { SessionManager } from "../../src/session/session-manager";
+import { executeAcpBuiltinSlashCommand } from "../../src/slash-commands/acp-builtins";
+import { resolvePresetSelector } from "../../src/slash-commands/builtin-registry";
+
+interface StubRegistry {
+	getModelProfile: (name: string) => unknown;
+	getError?: () => unknown;
+}
+
+function registryWithProfiles(...names: string[]): StubRegistry {
+	return {
+		getModelProfile: (name: string) => (names.includes(name) ? { name } : undefined),
+	};
+}
+
+describe("resolvePresetSelector", () => {
+	test("matches a bare preset name", () => {
+		expect(resolvePresetSelector("codex-medium", registryWithProfiles("codex-medium"))).toBe("codex-medium");
+	});
+
+	test("matches a gajae-code/-namespaced preset name", () => {
+		expect(resolvePresetSelector("gajae-code/codex-medium", registryWithProfiles("codex-medium"))).toBe(
+			"codex-medium",
+		);
+	});
+
+	test("matches a gajae-code/-namespaced preset name case-insensitively on the prefix", () => {
+		expect(resolvePresetSelector("GAJAE-CODE/codex-medium", registryWithProfiles("codex-medium"))).toBe(
+			"codex-medium",
+		);
+	});
+
+	test("returns undefined for an unknown preset name so the caller falls through", () => {
+		expect(resolvePresetSelector("not-a-preset", registryWithProfiles("codex-medium"))).toBeUndefined();
+	});
+
+	test("returns undefined for a provider/model reference even if the suffix matches a preset", () => {
+		// `anthropic/codex-medium` is a model selector, not a preset shortcut.
+		expect(resolvePresetSelector("anthropic/codex-medium", registryWithProfiles("codex-medium"))).toBeUndefined();
+	});
+
+	test("returns undefined for other slash-prefixed namespaces", () => {
+		expect(resolvePresetSelector("other/codex-medium", registryWithProfiles("codex-medium"))).toBeUndefined();
+	});
+
+	test("returns undefined for gajae-code/ with a nested slash", () => {
+		expect(resolvePresetSelector("gajae-code/foo/bar", registryWithProfiles("foo"))).toBeUndefined();
+	});
+
+	test("returns undefined for an empty selector", () => {
+		expect(resolvePresetSelector("", registryWithProfiles("codex-medium"))).toBeUndefined();
+		expect(resolvePresetSelector("   ", registryWithProfiles("codex-medium"))).toBeUndefined();
+	});
+
+	test("returns undefined when the registry reports a load error", () => {
+		const reg: StubRegistry = {
+			getModelProfile: () => ({ name: "codex-medium" }),
+			getError: () => new Error("registry corrupt"),
+		};
+		expect(resolvePresetSelector("codex-medium", reg)).toBeUndefined();
+	});
+
+	test("trims surrounding whitespace before matching", () => {
+		expect(resolvePresetSelector("  codex-medium  ", registryWithProfiles("codex-medium"))).toBe("codex-medium");
+	});
+});
+
+function createRuntime() {
+	const output: string[] = [];
+	const settings = Settings.isolated();
+	let activeModelProfile: string | undefined;
+	const availableModel = { provider: "anthropic", id: "claude-3-5-sonnet", contextWindow: 200_000 };
+	const knownProfiles = new Set<string>(["codex-medium"]);
+	const session = {
+		sessionId: "session-1",
+		model: undefined as { provider: string; id: string; contextWindow?: number } | undefined,
+		thinkingLevel: undefined as string | undefined,
+		modelRegistry: {
+			async getApiKey(_model: { provider: string; id: string }, _sessionId?: string) {
+				return "test-api-key";
+			},
+			resolveCanonicalModel: (
+				_selector: string,
+				_options?: { candidates?: Array<{ provider: string; id: string }> },
+			) => undefined,
+			getAvailable: () => [availableModel],
+			getModelProfile: (name: string) => (knownProfiles.has(name) ? { name } : undefined),
+			getError: () => undefined,
+		},
+		getAvailableModels: () => [availableModel],
+		setConfiguredModelChain: () => {},
+		async setModel(model: { provider: string; id: string }, _role: "default", _options?: unknown) {
+			this.model = model;
+		},
+		setThinkingLevel(thinkingLevel: string) {
+			this.thinkingLevel = thinkingLevel;
+		},
+		getActiveModelProfile() {
+			return activeModelProfile;
+		},
+		setActiveModelProfile(name: string | undefined) {
+			activeModelProfile = name;
+		},
+	};
+	const sessionManager = {
+		getSessionId: () => "session-1",
+		getSessionFile: () => undefined,
+		getCwd: () => "/tmp/project",
+		getEntries: () => [],
+		getBranch: () => [],
+		appendCustomEntry: () => "entry-1",
+		flush: async () => {},
+		buildSessionContext: () => ({ messages: [], thinkingLevel: "off", models: {}, injectedTtsrRules: [] }),
+		getUsageStatistics: () => ({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, premiumRequests: 0, cost: 0 }),
+	};
+	return {
+		output,
+		settings,
+		session,
+		knownProfiles,
+		runtime: {
+			session: session as unknown as AgentSession,
+			sessionManager: sessionManager as unknown as SessionManager,
+			settings,
+			cwd: "/tmp/project",
+			output: (text: string) => {
+				output.push(text);
+			},
+			refreshCommands: () => {},
+			reloadPlugins: async () => {},
+			notifyTitleChanged: undefined as (() => Promise<void> | void) | undefined,
+			notifyConfigChanged: undefined as (() => Promise<void> | void) | undefined,
+		},
+	};
+}
+
+describe("/model <preset> activation", () => {
+	const activateSpy = spyOn(modelProfileActivation, "activateModelProfile").mockResolvedValue(undefined);
+
+	afterEach(() => {
+		activateSpy.mockClear();
+	});
+	afterAll(() => {
+		activateSpy.mockRestore();
+	});
+
+	test("/model <preset> activates the named profile for the session", async () => {
+		const { output, runtime } = createRuntime();
+		let titleNotified = 0;
+		let configNotified = 0;
+		runtime.notifyTitleChanged = () => {
+			titleNotified++;
+		};
+		runtime.notifyConfigChanged = () => {
+			configNotified++;
+		};
+
+		const result = await executeAcpBuiltinSlashCommand("/model codex-medium", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(activateSpy).toHaveBeenCalledTimes(1);
+		const [options, applyOptions] = activateSpy.mock.calls[0]!;
+		expect(options.profileName).toBe("codex-medium");
+		expect(applyOptions).toEqual({ persistDefault: false });
+		expect(output[0]).toContain("Model profile: codex-medium");
+		expect(titleNotified).toBe(1);
+		expect(configNotified).toBe(1);
+	});
+
+	test("/model gajae-code/<preset> activates the named profile after stripping the namespace", async () => {
+		const { runtime } = createRuntime();
+
+		await executeAcpBuiltinSlashCommand("/model gajae-code/codex-medium", runtime);
+
+		const [options, applyOptions] = activateSpy.mock.calls[0]!;
+		expect(options.profileName).toBe("codex-medium");
+		expect(applyOptions).toEqual({ persistDefault: false });
+	});
+
+	test("/model <preset> surfaces an activation failure as a usage message", async () => {
+		const { output, runtime } = createRuntime();
+		activateSpy.mockRejectedValueOnce(
+			new Error('Model profile "codex-medium" requires credentials for: openai-codex.'),
+		);
+
+		const result = await executeAcpBuiltinSlashCommand("/model codex-medium", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toContain("Failed to activate model profile");
+		expect(output[0]).toContain("requires credentials");
+	});
+
+	test("/model <role> <preset-name> does NOT activate a preset — it assigns to the role", async () => {
+		const { runtime, session } = createRuntime();
+		session.getAvailableModels = () => [{ provider: "anthropic", id: "codex-medium", contextWindow: 200_000 }];
+
+		await executeAcpBuiltinSlashCommand("/model executor codex-medium", runtime);
+
+		// Preset activation must not fire for an explicit role target.
+		expect(activateSpy).not.toHaveBeenCalled();
+		expect(runtime.settings.get("task.agentModelOverrides")).toEqual({
+			executor: "anthropic/codex-medium",
+		});
+	});
+
+	test("/model <unknown-name> falls through to model resolution", async () => {
+		const { output, runtime } = createRuntime();
+
+		const result = await executeAcpBuiltinSlashCommand("/model not-a-preset", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(activateSpy).not.toHaveBeenCalled();
+		expect(output[0]).toContain("Unknown model: not-a-preset");
+	});
+
+	test("/model <provider>/<model> still resolves as a model even with profiles present", async () => {
+		const { output, runtime } = createRuntime();
+
+		const result = await executeAcpBuiltinSlashCommand("/model anthropic/claude-3-5-sonnet", runtime);
+
+		expect(result).toEqual({ consumed: true });
+		expect(activateSpy).not.toHaveBeenCalled();
+		expect(output[0]).toContain("Default model set to anthropic/claude-3-5-sonnet");
+	});
+});


### PR DESCRIPTION
## Summary

`/model <preset>` (e.g. `/model codex-medium`) and the namespaced form `/model gajae-code/<preset>` now detect a matching model profile/preset name and activate it immediately, instead of trying to resolve the preset name as a bare model id and failing with "Unknown model".

Previously presets were only reachable through the interactive model selector UI.

## Behavior

- `/model codex-medium` → activates the `codex-medium` profile for the session (not persisted as the startup default, mirroring the selector UI's non-setDefault preset selection).
- `/model gajae-code/codex-medium` → same, after stripping the optional `gajae-code/` namespace prefix (case-insensitive on the prefix).
- `/model anthropic/claude-...` → unchanged; `provider/model` references are never hijacked by preset matching.
- `/model executor codex-medium` → unchanged; explicit role targets keep assigning a model to the named role. Preset activation only applies to the DEFAULT target.
- `/model not-a-preset` → falls through to the existing model-resolution path and surfaces the "Unknown model" message.
- Activation errors (missing credentials, registry errors) surface the existing `ModelProfileCredentialError` / `UnknownModelProfileError` messages via a `Failed to activate model profile: ...` usage line.

## Implementation

- New exported helper `resolvePresetSelector(selector, modelRegistry)` in `packages/coding-agent/src/slash-commands/builtin-registry.ts` — a pure resolver that strips the optional `gajae-code/` prefix, rejects `provider/model` references, and matches against `modelRegistry.getModelProfile`. Returns `undefined` on registry errors or when `getModelProfile` is absent so callers fall through cleanly.
- The `/model` `handle` function gains an early branch (only when `parsedArgs.targetId === "default"`) that calls `activateModelProfile({ persistDefault: false })` when the selector resolves to a preset, then emits the profile label and the title/config notifications.
- The `/model` usage text now mentions the preset shortcut.

## Verification

- `bun --cwd=packages/coding-agent run check` (biome + tsc)
- `bun test packages/coding-agent/test/slash-commands/model-preset.test.ts` — 16 new tests covering `resolvePresetSelector` (bare/namespaced/unknown/provider-model/error/empty) and the `/model <preset>` command routing (activate, namespace strip, failure surface, role-target bypass, unknown-name fallthrough, provider/model still resolves).
- `bun test packages/coding-agent/test/slash-commands/` (8 files, 40 tests) — no regressions.
- `bun test packages/coding-agent/test/acp-builtins.test.ts` — existing `/model` tests still pass.