### PR TITLE
test(coding-agent): make Bash allowlist fixture CI-safe

### DIFF
--- a/packages/coding-agent/test/tools/bash-state-exploit.test.ts
+++ b/packages/coding-agent/test/tools/bash-state-exploit.test.ts
@@ -5,6 +5,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
 import { BashTool } from "@gajae-code/coding-agent/tools/bash";
+import { resetShellConfigCache } from "@gajae-code/utils/shell-config";
 
 const SEEDED_TREE_TIME = new Date("2020-01-01T00:00:00.000Z");
 
@@ -246,6 +247,10 @@ describe("restricted BashTool state-mutation exploit", () => {
 			fs.writeFileSync(path.join(bin, "gjc"), '#!/bin/sh\ntouch "$PWD/admitted-sentinel.txt"\n');
 			fs.chmodSync(path.join(bin, "gjc"), 0o755);
 			process.env.PATH = `${bin}${path.delimiter}${previousPath ?? ""}`;
+			// Shell configuration snapshots the launch environment. Reset it after
+			// installing the fixture so the one-shot managed Bash path sees this
+			// controlled executable instead of requiring a globally installed `gjc`.
+			resetShellConfigCache();
 			const tool = createRestrictedBashTool(ws.dir);
 
 			await tool.execute("tool-call", { command: "gjc state ralplan read --json" });
@@ -258,6 +263,7 @@ describe("restricted BashTool state-mutation exploit", () => {
 		} finally {
 			if (previousPath === undefined) delete process.env.PATH;
 			else process.env.PATH = previousPath;
+			resetShellConfigCache();
 			ws.cleanup();
 		}
 	});


### PR DESCRIPTION
## Summary
- reset the cached shell configuration after installing the temporary `gjc` fixture
- keep the allowlisted BashTool command on its real execution path without relying on a global CLI
- restore the cache after the fixture to avoid leaking its PATH

## Verification
- `HOME="$(mktemp -d)" PATH=/home/bellman/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin bun test packages/coding-agent/test/tools/bash-state-exploit.test.ts` (24 pass)
- `bun --cwd=packages/coding-agent run check`
- Dev-equivalent shard 6/8 with a CI-like PATH: 2045 pass, 32 skip; the targeted regression passed. The sole local failure was pre-existing/environmental package catalog generation (`github` descriptor unavailable), outside this change.

Fixes the Dev CI failure from #4197 where the positive BashTool allowlist test reported `command not found: gjc`.