### PR TITLE
docs(streamdeck): add cmux integration operator guide

### DIFF
--- a/docs/streamdeck-integration-guide-with-cmux.md
+++ b/docs/streamdeck-integration-guide-with-cmux.md
@@ -62,7 +62,7 @@ The control surface should:
 8. Send `Shift+Tab` as one atomic key event. Do not emulate it with separately delivered `Esc`-prefixed text.
 9. Do not create duplicate browser tabs when an existing Chrome or Safari tab matches.
 10. Reuse a focused non-GJC terminal when the operator explicitly wants an in-place worktree launch.
-11. Keep Stream Deck profiles, local plugin installations, generated artwork, and SDK state outside the repository.
+11. Keep Stream Deck profiles, local plugin installations, generated artwork, and SDK state outside version control. Repository-local `.gjc/state/` is gitignored and is the authoritative SDK discovery location; do not move, delete, or copy it elsewhere.
 
 ## Reference environment
 
@@ -124,6 +124,7 @@ Before changing a profile:
 ```sh
 stamp="$(date +%Y%m%d-%H%M%S)"
 base="$HOME/Library/Application Support/com.elgato.StreamDeck"
+mkdir -p "$base/ManualBackups"
 ditto -c -k --sequesterRsrc --keepParent \
   "$base/ProfilesV3/<profile>.sdProfile" \
   "$base/ManualBackups/streamdeck-before-change-$stamp.zip"
@@ -189,7 +190,7 @@ Use explicit paths instead of recent-project discovery:
 - `gajae-code` -> `$HOME/Documents/Workspace/gajae-code`;
 - `HOME` -> `$HOME`.
 
-Parameterize these values for each operator. A fixed folder key creates a terminal surface in the current pane and sends `cd -- '<path>'`.
+Parameterize these values for each operator. A fixed folder key creates a terminal surface in the current pane and sends `cd -- '<path>'`. Store fully expanded absolute paths (or `$HOME`-relative values the plugin normalizes before shell-quoting) so single-quoting never suppresses tilde expansion.
 
 ### Page 3: focused GJC operations
 
@@ -210,7 +211,7 @@ Model profile keys submit commands to the focused GJC editor:
 /model gajae-code/kimi-gpt
 ```
 
-A profile must exist and be available to the current session. `kimi-gpt` is typically a user-defined profile in `~/.gjc/agent/models.yml`; do not document it as a bundled default unless the product adds it to the bundled profile set.
+A profile must exist and be available to the current session. The names shown above (`frontier-heavy`, `gpt-heavy`, `glm-deepseek`, `kimi-gpt`) are operator-defined examples, not bundled defaults; none of them ships with GJC. Provide matching definitions in `~/.gjc/agent/models.yml` or replace them with bundled profile names before the keys will work.
 
 #### Session controls
 
@@ -356,16 +357,17 @@ Reply with the exact active presentation ID:
 }
 ```
 
-Return to the ordinary profile controls when `action_resolved` arrives. If `reply_rejected` arrives, show an error and do not guess from question text, option text, workflow IDs, or earlier presentations.
+Return to the ordinary profile controls only when `action_resolved` arrives for the **same presentation ID currently displayed**; an `action_resolved` for a different session can arrive while another question's pad is still active, so match the frame `id` against the displayed presentation before clearing it. If `reply_rejected` arrives, show an error and do not guess from question text, option text, workflow IDs, or earlier presentations.
 
 Only display the fixed answer pad when:
 
 - the question belongs to the focused GJC session;
 - the session-to-surface mapping is exact;
 - the action is still active;
-- the question has one to four scalar options.
+- the question has one to four scalar options;
+- the action has no negotiated `controls` (multi-select and other controlled asks are not safe for a fixed numeric reply).
 
-Leave free-text, multi-select, and larger option sets to the native GJC UI.
+Leave free-text, multi-select, controlled, and larger option sets to the native GJC UI.
 
 ## Mascot artwork
 
@@ -389,7 +391,7 @@ Represent each key with an action UUID and small settings payload. A generic con
 
 ```json
 { "name": "new-website-tab", "type": "newWebsiteTab" }
-{ "name": "folder-gajae", "type": "fixedFolder", "path": "~/src/gajae-code", "label": "gajae-code" }
+{ "name": "folder-gajae", "type": "fixedFolder", "path": "$HOME/src/gajae-code", "label": "gajae-code" }
 { "name": "set-kimi-gpt", "type": "command", "value": "/model gajae-code/kimi-gpt", "submit": true, "answerSlot": 3 }
 { "name": "thinking-level", "type": "key", "value": "shift+tab" }
 ```
@@ -405,7 +407,7 @@ After each behavioral change, verify the narrow observable contract.
 ```sh
 bun build ~/.local/share/gjc-streamdeck-plugin/plugin.js \
   --target=bun \
-  --outfile=~/tmp/gjc-streamdeck-plugin-verify.js
+  --outfile="$HOME/tmp/gjc-streamdeck-plugin-verify.js"
 
 cmp ~/.local/share/gjc-streamdeck-plugin/plugin.js \
   "$HOME/Library/Application Support/com.elgato.StreamDeck/Plugins/dev.gajae.streamdeck.sdPlugin/plugin.js"

--- a/docs/streamdeck-integration-guide-with-cmux.md
+++ b/docs/streamdeck-integration-guide-with-cmux.md
@@ -160,7 +160,7 @@ BACK | VibeQuant | gajae-code | HOME | NEXT
 
 #### Session and surface controls
 
-- `NEW SESSION`: create a terminal surface, ask for a worktree name, and run `gjc --worktree <name>` without selecting a profile.
+- `NEW SESSION`: create a terminal surface and ask for a worktree name; a blank answer starts a plain `gjc` session, while a name starts `gjc --worktree <name>`. Do not select a profile here.
 - `CLOSE TAB`: close the focused cmux surface.
 - `NEW WEBSITE`: create a native cmux browser surface in the current pane.
 - `STEER`: send `Esc`, wait 100 ms, then send `Enter`.
@@ -172,10 +172,10 @@ A session-only launcher can be implemented as:
 #!/bin/zsh
 set -u
 
-printf 'GJC worktree name (blank = auto): '
+printf 'GJC worktree name (blank = plain session): '
 IFS= read -r worktree_name
-args=(--worktree)
-[[ -n "$worktree_name" ]] && args+=("$worktree_name")
+args=()
+[[ -n "$worktree_name" ]] && args+=(--worktree "$worktree_name")
 exec "$HOME/.local/bin/gjc" "${args[@]}"
 ```
 
@@ -457,7 +457,7 @@ Check the focused cmux surface title. GJC-only commands intentionally fail close
 
 ### Worktree prompting does not appear
 
-Confirm the helper is executable, the new terminal inherited or entered a Git repository, and the helper invokes `gjc --worktree [name]`. Do not pass a filesystem path as the worktree name.
+Confirm the helper is executable. A blank name must invoke plain `gjc`; a non-empty name must invoke `gjc --worktree <name>` from a Git repository. Do not pass a filesystem path as the worktree name.
 
 ### Think level aborts the operation
 

--- a/docs/streamdeck-integration-guide-with-cmux.md
+++ b/docs/streamdeck-integration-guide-with-cmux.md
@@ -1,0 +1,496 @@
+# Stream Deck integration guide with cmux
+
+This guide captures a production-style Elgato Stream Deck control surface for Gajae-Code (`gjc`) running inside [cmux](https://github.com/manaflow-ai/cmux). It is formatted as an installable AI skill template so an operator or coding agent can reproduce, audit, repair, or extend the integration without relying on undocumented UI automation.
+
+The installable skill body starts at the first frontmatter marker. To install it as a user skill:
+
+```sh
+mkdir -p ~/.gjc/agent/skills/streamdeck-cmux
+sed -n '/^---$/,$p' docs/streamdeck-integration-guide-with-cmux.md \
+  > ~/.gjc/agent/skills/streamdeck-cmux/SKILL.md
+
+gjc config set skills.enabled true
+gjc config set skills.enablePiUser true
+```
+
+Start a new GJC session and invoke `/skill:streamdeck-cmux`.
+
+---
+name: streamdeck-cmux
+description: Configure, operate, verify, or repair an Elgato Stream Deck integration for Gajae-Code sessions hosted in cmux.
+argument-hint: "[install|audit|repair|extend]"
+level: 2
+---
+
+# Gajae-Code Stream Deck + cmux operator skill
+
+## Purpose
+
+Build a Stream Deck control surface that treats cmux as the terminal and browser host, GJC as the interactive coding runtime, and the GJC SDK as the authoritative machine interface for pending questions.
+
+The control surface should:
+
+- navigate cmux panes and surface tabs;
+- open fixed project and home-directory terminal tabs;
+- create worktree-scoped GJC sessions;
+- change the model profile of the focused GJC session;
+- invoke common GJC skills without submitting them prematurely;
+- send precise keyboard controls such as `Shift+Tab`, `Esc`, and `Enter`;
+- render and answer the focused session's SDK questions;
+- open and close native cmux terminal and browser surfaces;
+- reuse existing Chrome or Safari tabs for ordinary web shortcuts;
+- use distinct, readable mascot artwork for each operation;
+- preserve the operator's original Stream Deck profile and unrelated repository work.
+
+## Do not use when
+
+- cmux is not the terminal host;
+- the Stream Deck application or hardware is unavailable;
+- the target GJC session has SDK hosting disabled with `GJC_SDK_DISABLE=1` and SDK question answering is required;
+- the requested action would overwrite a shared checkout containing unrelated work;
+- the operator expects generic UI automation instead of deterministic cmux and SDK commands.
+
+## Safety invariants
+
+1. Back up the full Stream Deck profile before every structural layout change.
+2. Preserve the original/default profile instead of reconstructing it manually.
+3. Never log or commit SDK tokens, provider API keys, browser credentials, or endpoint discovery files.
+4. Resolve the focused cmux surface with `cmux identify --no-caller`; do not infer focus only from tree decorations.
+5. Send GJC-only controls only when the focused surface title starts with `GJC:`.
+6. Use `action_needed.id` as the only authority for a generic SDK question reply.
+7. Do not answer stale, resolved, hidden, non-focused, free-text, or unsupported multi-select questions from fixed answer keys.
+8. Send `Shift+Tab` as one atomic key event. Do not emulate it with separately delivered `Esc`-prefixed text.
+9. Do not create duplicate browser tabs when an existing Chrome or Safari tab matches.
+10. Reuse a focused non-GJC terminal when the operator explicitly wants an in-place worktree launch.
+11. Keep Stream Deck profiles, local plugin installations, generated artwork, and SDK state outside the repository.
+
+## Reference environment
+
+The implementation described here was validated with:
+
+- Elgato Stream Deck application `7.5.1`;
+- Stream Deck device model `20GBA9901`;
+- Gajae-Code `0.12.21`;
+- cmux installed at `/Applications/cmux.app`;
+- cmux CLI at `/Applications/cmux.app/Contents/Resources/bin/cmux`;
+- GJC installed at `~/.local/bin/gjc`;
+- official mascot source at `assets/character.png`.
+
+Treat versions and absolute paths as environment inputs, not permanent product constants.
+
+## Architecture
+
+```text
+Stream Deck hardware
+  -> Elgato Stream Deck application
+     -> native Stream Deck plugin
+        -> cmux CLI / socket RPC
+        -> GJC SDK WebSocket endpoints
+        -> local launch helpers
+        -> generated key images
+```
+
+Use a native Stream Deck plugin instead of a collection of shell-command actions. The plugin provides dynamic titles, per-key settings, hold/tap handling, SDK subscriptions, focused-session guards, question-state rendering, deterministic cmux routing, and success/error feedback.
+
+A representative local installation is:
+
+```text
+~/.local/share/gjc-streamdeck-plugin/
+  manifest.json
+  plugin.js
+  bin/plugin
+  images/*.png
+
+~/Library/Application Support/com.elgato.StreamDeck/Plugins/
+  dev.gajae.streamdeck.sdPlugin/
+    manifest.json
+    plugin.js
+    bin/plugin
+    images/*.png
+```
+
+Keep one editable source copy and synchronize it to the installed plugin directory. Verify deployment with `cmp` before restarting Stream Deck.
+
+## Preserve and separate profiles
+
+Maintain separate profiles for separate concerns:
+
+- `Default Profile`: the restored original profile;
+- `Daily Control`: browser, cmux, and active-session controls;
+- an optional session inventory profile when dedicated session slots are useful.
+
+Before changing a profile:
+
+```sh
+stamp="$(date +%Y%m%d-%H%M%S)"
+base="$HOME/Library/Application Support/com.elgato.StreamDeck"
+ditto -c -k --sequesterRsrc --keepParent \
+  "$base/ProfilesV3/<profile>.sdProfile" \
+  "$base/ManualBackups/streamdeck-before-change-$stamp.zip"
+```
+
+Restore from a known backup instead of reverse-engineering a damaged default profile.
+
+## Three-page operating model
+
+### Page 1: daily web shortcuts
+
+Use ordinary daily shortcuts here. Browser actions should:
+
+1. search every Chrome window and tab;
+2. search every Safari window and tab;
+3. focus an existing matching tab;
+4. create a Chrome tab only when neither browser contains a match.
+
+Compiled AppleScript applications are suitable when Stream Deck's built-in website action cannot enforce tab reuse. Match stable URL fragments rather than volatile titles.
+
+### Page 2: cmux navigation and session entry
+
+```text
+PANE PREV | PANE NEXT | TAB PREV | TAB NEXT | GJC FOCUS
+NEW SESSION | CLOSE TAB | NEW WEBSITE | STEER | ESC X2
+BACK | VibeQuant | gajae-code | HOME | NEXT
+```
+
+#### Navigation controls
+
+- `PANE PREV` / `PANE NEXT`: select the previous or next pane in the current workspace.
+- `TAB PREV` / `TAB NEXT`: select the previous or next surface in the focused pane.
+- `GJC FOCUS`: keep the text-focused visual style; when pressed, submit `proceed` plus `Enter` only to a focused `GJC:` surface.
+
+#### Session and surface controls
+
+- `NEW SESSION`: create a terminal surface, ask for a worktree name, and run `gjc --worktree <name>` without selecting a profile.
+- `CLOSE TAB`: close the focused cmux surface.
+- `NEW WEBSITE`: create a native cmux browser surface in the current pane.
+- `STEER`: send `Esc`, wait 100 ms, then send `Enter`.
+- `ESC X2`: send `Esc`, wait 100 ms, then send `Esc` again.
+
+A session-only launcher can be implemented as:
+
+```zsh
+#!/bin/zsh
+set -u
+
+printf 'GJC worktree name (blank = auto): '
+IFS= read -r worktree_name
+args=(--worktree)
+[[ -n "$worktree_name" ]] && args+=("$worktree_name")
+exec "$HOME/.local/bin/gjc" "${args[@]}"
+```
+
+Do not prompt for a model profile here. Apply the profile after the GJC session starts.
+
+#### Fixed folder controls
+
+Use explicit paths instead of recent-project discovery:
+
+- `VibeQuant` -> `$HOME/Documents/Workspace/VibeQuant`;
+- `gajae-code` -> `$HOME/Documents/Workspace/gajae-code`;
+- `HOME` -> `$HOME`.
+
+Parameterize these values for each operator. A fixed folder key creates a terminal surface in the current pane and sends `cd -- '<path>'`.
+
+### Page 3: focused GJC operations
+
+```text
+SET FRONTIER | SET GPT | SET GLM DS | KIMI GPT | BTW EXPLAIN
+RESUME | EXIT | PR TO DEV | THINK LEVEL | CLEAR CTX
+BACK | DEEP INTERVIEW | RALPLAN | ULTRAGOAL | NEXT
+```
+
+#### Model profile controls
+
+Model profile keys submit commands to the focused GJC editor:
+
+```text
+/model gajae-code/frontier-heavy
+/model gajae-code/gpt-heavy
+/model gajae-code/glm-deepseek
+/model gajae-code/kimi-gpt
+```
+
+A profile must exist and be available to the current session. `kimi-gpt` is typically a user-defined profile in `~/.gjc/agent/models.yml`; do not document it as a bundled default unless the product adds it to the bundled profile set.
+
+#### Session controls
+
+- `RESUME`: submit `/resume` and open the saved-session selector.
+- `EXIT`: submit `/exit` for a clean GJC shutdown.
+- `PR TO DEV`: submit the operator macro `make a PR targeting dev and make it LGTM` plus `Enter`.
+- `THINK LEVEL`: send atomic `Shift+Tab` through `cmux send-key`.
+- `CLEAR CTX`: submit `/clear`, preserving the session ID while clearing context.
+- `BTW EXPLAIN`: submit `/btw 설명해봐 이거` for an ephemeral side question.
+
+The PR macro is an operator convenience, not a policy bypass. GJC must still inspect repository rules, run required verification, use an isolated branch or worktree when appropriate, create a focused commit, and open a PR against `dev` only when that branch exists and is the repository's intended integration branch.
+
+#### Skill controls
+
+Skill keys type but do not submit:
+
+```text
+/skill:deep-interview
+/skill:ralplan
+/skill:ultragoal
+```
+
+Leaving the command in the editor allows the operator to add arguments before pressing `Enter`.
+
+## cmux command patterns
+
+Use the installed cmux CLI directly:
+
+```sh
+CMUX=/Applications/cmux.app/Contents/Resources/bin/cmux
+
+$CMUX identify --no-caller
+$CMUX tree --all
+$CMUX focus-panel --panel surface:7 --workspace workspace:1 --window window:1
+$CMUX new-surface --type terminal --pane pane:1 --focus true
+$CMUX new-surface --type browser --pane pane:1 --focus true
+$CMUX close-surface --surface surface:7 --workspace workspace:1 --window window:1
+```
+
+A new surface response contains a `surface:<n>` reference. Capture that exact reference and use it for subsequent send, rename, focus, read-screen, or close operations.
+
+Do not use selected/active decorations from `cmux tree --all` as the sole focus authority. `cmux identify --no-caller` returns the actual focused window, workspace, pane, and surface.
+
+## Keyboard delivery
+
+### Text and Enter
+
+```sh
+cmux send \
+  --surface surface:7 \
+  --workspace workspace:1 \
+  --window window:1 \
+  'make a PR targeting dev and make it LGTM'
+
+cmux send-key \
+  --surface surface:7 \
+  --workspace workspace:1 \
+  --window window:1 \
+  enter
+```
+
+### Shift+Tab
+
+Send `Shift+Tab` atomically:
+
+```sh
+cmux send-key \
+  --surface surface:7 \
+  --workspace workspace:1 \
+  --window window:1 \
+  'shift+tab'
+```
+
+The expected terminal byte sequence is:
+
+```text
+[27, 91, 90]
+```
+
+Do not send `\x1b[Z` through a text API when the TUI may consume the leading escape independently and abort the active operation.
+
+### Steer and abort
+
+```text
+STEER: Esc -> wait 100 ms -> Enter
+ABORT: Esc -> wait 100 ms -> Esc
+```
+
+Keep these as distinct controls. The abort control should not require a hold unless the operator explicitly requests one.
+
+## SDK question answer pad
+
+Every top-level GJC session publishes a loopback SDK discovery file:
+
+```text
+<repo>/.gjc/state/sdk/<sessionId>.json
+```
+
+The file contains the session WebSocket URL and token. Connect with the token as a query parameter and never persist or log it elsewhere.
+
+When the focused session emits:
+
+```json
+{
+  "type": "action_needed",
+  "id": "act_9e31",
+  "kind": "ask",
+  "sessionId": "sess-1",
+  "question": "Choose a target",
+  "options": ["A", "B"],
+  "recommendedIndex": 1
+}
+```
+
+temporarily replace the four profile keys with:
+
+```text
+ANSWER 1 | ANSWER 2 | ANSWER 3 | ANSWER 4
+```
+
+Render the real option labels with bounded wrapping. Highlight the valid recommended index, but never decorate or modify the submitted answer value.
+
+Reply with the exact active presentation ID:
+
+```json
+{
+  "type": "reply",
+  "id": "act_9e31",
+  "answer": 1,
+  "token": "<session token>",
+  "idempotencyKey": "streamdeck-act_9e31-1"
+}
+```
+
+Return to the ordinary profile controls when `action_resolved` arrives. If `reply_rejected` arrives, show an error and do not guess from question text, option text, workflow IDs, or earlier presentations.
+
+Only display the fixed answer pad when:
+
+- the question belongs to the focused GJC session;
+- the session-to-surface mapping is exact;
+- the action is still active;
+- the question has one to four scalar options.
+
+Leave free-text, multi-select, and larger option sets to the native GJC UI.
+
+## Mascot artwork
+
+Use `assets/character.png` as the identity reference. Generate a distinct pose, expression, prop, and task scene for every key. Optimize for a 144-by-144 display:
+
+- dark background;
+- strong silhouette;
+- high-contrast border;
+- large central action;
+- short bottom label;
+- no small decorative text;
+- dim artwork behind dynamic titles such as the focused session name or folder label.
+
+Suitable task scenes include pane dividers, tabs, browser windows, model cores, emergency controls, git branches, approval checks, interview notebooks, planning blueprints, and goal summits.
+
+Generate artwork through a configured image provider without embedding credentials in commands, logs, documentation, or committed files. Environment variables should contain only operator-managed values; commit neither the values nor local shell configuration.
+
+## Manifest and plugin behavior
+
+Represent each key with an action UUID and small settings payload. A generic control action can dispatch by `settings.type`:
+
+```json
+{ "name": "new-website-tab", "type": "newWebsiteTab" }
+{ "name": "folder-gajae", "type": "fixedFolder", "path": "~/src/gajae-code", "label": "gajae-code" }
+{ "name": "set-kimi-gpt", "type": "command", "value": "/model gajae-code/kimi-gpt", "submit": true, "answerSlot": 3 }
+{ "name": "thinking-level", "type": "key", "value": "shift+tab" }
+```
+
+Use separate actions only when Stream Deck behavior differs materially, such as cmux navigation, focused status, skill typing, steer, or double-escape abort.
+
+## Verification protocol
+
+After each behavioral change, verify the narrow observable contract.
+
+### Build and installation
+
+```sh
+bun build ~/.local/share/gjc-streamdeck-plugin/plugin.js \
+  --target=bun \
+  --outfile=~/tmp/gjc-streamdeck-plugin-verify.js
+
+cmp ~/.local/share/gjc-streamdeck-plugin/plugin.js \
+  "$HOME/Library/Application Support/com.elgato.StreamDeck/Plugins/dev.gajae.streamdeck.sdPlugin/plugin.js"
+```
+
+### Layout
+
+- Every referenced image exists.
+- Moved actions have new action IDs.
+- Page navigation keys still point in the intended direction.
+- Dynamic title keys have `ShowTitle: true`.
+- Question answer slots are zero-based and unique.
+- Removed controls do not remain in another page or plugin manifest.
+
+### cmux behavior
+
+Use temporary surfaces and restore the original focus after each test:
+
+- pane previous/next;
+- tab previous/next;
+- terminal creation in the requested pane;
+- browser-surface creation;
+- fixed-folder `cd` behavior;
+- focused tab closure;
+- same-tab worktree prompting when required;
+- exact `Shift+Tab` bytes;
+- exact `Esc`, delay, and `Esc` sequence;
+- exact macro text plus carriage return.
+
+### SDK behavior
+
+Use a temporary token-authenticated SDK WebSocket server and a temporary GJC-titled cmux surface to prove:
+
+- discovery;
+- focused session mapping;
+- `action_needed` rendering;
+- option wrapping;
+- recommended-option highlighting;
+- exact zero-based reply;
+- `action_resolved` restoration;
+- stale/rejected reply handling.
+
+### Stream Deck restart
+
+After synchronizing the plugin:
+
+```sh
+pkill -TERM -f '^/Applications/Elgato Stream Deck.app/Contents/MacOS/Stream Deck$' || true
+sleep 2
+open -a '/Applications/Elgato Stream Deck.app'
+```
+
+Confirm the plugin reconnects, contexts render, and the active profile remains correct.
+
+## Troubleshooting
+
+### A GJC control shows an error
+
+Check the focused cmux surface title. GJC-only commands intentionally fail closed unless the raw title starts with `GJC:`.
+
+### Worktree prompting does not appear
+
+Confirm the helper is executable, the new terminal inherited or entered a Git repository, and the helper invokes `gjc --worktree [name]`. Do not pass a filesystem path as the worktree name.
+
+### Think level aborts the operation
+
+The integration is probably sending escape-prefixed text. Replace it with atomic `cmux send-key ... shift+tab`.
+
+### Question options do not appear
+
+Check:
+
+- SDK hosting is enabled;
+- the endpoint PID is alive;
+- the token-authenticated WebSocket connected;
+- the focused surface maps to the endpoint TTY;
+- the focused session was retained even when the session inventory is capped;
+- the question has no more than four scalar options.
+
+### A browser shortcut creates duplicates
+
+Search all Chrome and Safari windows before creating a tab. Do not limit the search to the frontmost window.
+
+### Artwork is unreadable
+
+Remove small details, enlarge the action, darken the dynamic-title background, shorten the label, and render a complete two-page contact sheet before deployment.
+
+## Completion report
+
+Report only verified facts:
+
+- profile IDs or names changed;
+- page and coordinate layout;
+- plugin source and installed locations;
+- backup path;
+- exact cmux and SDK checks run;
+- number of plugin keys rendered;
+- remaining environment-specific paths or optional profiles;
+- failures that could not be reproduced or verified.

--- a/docs/streamdeck-integration-guide-with-cmux.md
+++ b/docs/streamdeck-integration-guide-with-cmux.md
@@ -162,7 +162,7 @@ BACK | VibeQuant | gajae-code | HOME | NEXT
 
 - `NEW SESSION`: create a terminal surface and ask for a worktree name; a blank answer starts a plain `gjc` session, while a name starts `gjc --worktree <name>`. Do not select a profile here.
 - `CLOSE TAB`: close the focused cmux surface.
-- `VOICE`: toggle GJC speech-to-text with `Option+H` (`Alt+H`) on the focused `GJC:` surface.
+- `VOICE`: invoke GJC's `Toggle speech-to-text` action on the focused `GJC:` surface. This is the same action bound to `Option+H` (`Alt+H`).
 - `STEER`: send `Esc`, wait 100 ms, then send `Enter`.
 - `ESC X2`: send `Esc`, wait 100 ms, then send `Esc` again.
 
@@ -273,13 +273,13 @@ cmux send-key \
 
 ### Voice (`Option+H`)
 
-GJC maps speech-to-text to `Alt+H`. Deliver the terminal equivalent in one cmux surface write:
+GJC binds speech-to-text to `Alt+H`, but cmux does not reliably forward that modifier through `send-key`, and macOS blocks Stream Deck plugin keystroke automation unless the plugin host has Accessibility permission. Use the focused GJC command palette instead:
 
-```sh
-cmux rpc surface.send_text '{"surface":"surface:7","text":"\u001bh"}'
+```text
+Ctrl+P -> type "Toggle speech-to-text" -> Enter
 ```
 
-The expected bytes are `[27, 104]`. Guard this control with the same focused `GJC:` title check as other interactive GJC keys.
+This invokes the same registered `app.stt.toggle` action without inserting a stray `h` into the editor or requiring macOS Accessibility access.
 
 ### Shift+Tab
 
@@ -425,7 +425,7 @@ Use temporary surfaces and restore the original focus after each test:
 - pane previous/next;
 - tab previous/next;
 - terminal creation in the requested pane;
-- exact `Option+H` bytes (`[27, 104]`) and voice-mode toggle;
+- voice action toggles through the GJC command palette without inserting `h`;
 - fixed-folder `cd` behavior;
 - focused tab closure;
 - same-tab worktree prompting when required;

--- a/docs/streamdeck-integration-guide-with-cmux.md
+++ b/docs/streamdeck-integration-guide-with-cmux.md
@@ -162,7 +162,7 @@ BACK | VibeQuant | gajae-code | HOME | NEXT
 
 - `NEW SESSION`: create a terminal surface and ask for a worktree name; a blank answer starts a plain `gjc` session, while a name starts `gjc --worktree <name>`. Do not select a profile here.
 - `CLOSE TAB`: close the focused cmux surface.
-- `VOICE`: invoke GJC's `Toggle speech-to-text` action on the focused `GJC:` surface. This is the same action bound to `Option+H` (`Alt+H`).
+- `VOICE`: invoke GJC's local Whisper speech-to-text action with a user remap to `Ctrl+H` on the focused `GJC:` surface.
 - `STEER`: send `Esc`, wait 100 ms, then send `Enter`.
 - `ESC X2`: send `Esc`, wait 100 ms, then send `Esc` again.
 
@@ -271,11 +271,17 @@ cmux send-key \
   enter
 ```
 
-### Voice (`Option+H`)
+### Voice (`Ctrl+H`)
 
-GJC binds local Whisper speech-to-text to `Alt+H`, but cmux does not reliably forward that modifier through `send-key`. Use a dedicated, signed local helper app that posts the real macOS `Option+H` event after focusing the exact `GJC:` surface.
+Remap local Whisper speech-to-text in `~/.gjc/agent/keybindings.json`:
 
-The helper requires one-time macOS Accessibility approval. Keep that permission scoped to the helper app; do not fall back to typing command-palette search text into the active editor.
+```json
+{
+  "app.stt.toggle": "Ctrl+H"
+}
+```
+
+The Stream Deck plugin sends atomic `ctrl+h` through `cmux send-key`. New GJC sessions load the remap; already-running sessions keep the keybindings they started with and should not be modified in place.
 
 ### Shift+Tab
 
@@ -421,7 +427,7 @@ Use temporary surfaces and restore the original focus after each test:
 - pane previous/next;
 - tab previous/next;
 - terminal creation in the requested pane;
-- voice helper posts a real `Option+H` event without inserting text;
+- voice sends atomic `Ctrl+H` to a session that loaded the remap without inserting text;
 - fixed-folder `cd` behavior;
 - focused tab closure;
 - same-tab worktree prompting when required;

--- a/docs/streamdeck-integration-guide-with-cmux.md
+++ b/docs/streamdeck-integration-guide-with-cmux.md
@@ -26,7 +26,7 @@ level: 2
 
 ## Purpose
 
-Build a Stream Deck control surface that treats cmux as the terminal and browser host, GJC as the interactive coding runtime, and the GJC SDK as the authoritative machine interface for pending questions.
+Build a Stream Deck control surface that treats cmux as the terminal host, GJC as the interactive coding runtime, and the GJC SDK as the authoritative machine interface for pending questions.
 
 The control surface should:
 
@@ -37,7 +37,7 @@ The control surface should:
 - invoke common GJC skills without submitting them prematurely;
 - send precise keyboard controls such as `Shift+Tab`, `Esc`, and `Enter`;
 - render and answer the focused session's SDK questions;
-- open and close native cmux terminal and browser surfaces;
+- open and close native cmux terminal surfaces;
 - reuse existing Chrome or Safari tabs for ordinary web shortcuts;
 - use distinct, readable mascot artwork for each operation;
 - preserve the operator's original Stream Deck profile and unrelated repository work.
@@ -147,8 +147,8 @@ Compiled AppleScript applications are suitable when Stream Deck's built-in websi
 ### Page 2: cmux navigation and session entry
 
 ```text
-PANE PREV | PANE NEXT | TAB PREV | TAB NEXT | GJC FOCUS
-NEW SESSION | CLOSE TAB | NEW WEBSITE | STEER | ESC X2
+PANE PREV | PANE NEXT | NEW SESSION | CLOSE TAB | GJC FOCUS
+TAB PREV | TAB NEXT | VOICE | STEER | ESC X2
 BACK | VibeQuant | gajae-code | HOME | NEXT
 ```
 
@@ -162,7 +162,7 @@ BACK | VibeQuant | gajae-code | HOME | NEXT
 
 - `NEW SESSION`: create a terminal surface and ask for a worktree name; a blank answer starts a plain `gjc` session, while a name starts `gjc --worktree <name>`. Do not select a profile here.
 - `CLOSE TAB`: close the focused cmux surface.
-- `NEW WEBSITE`: create a native cmux browser surface in the current pane.
+- `VOICE`: toggle GJC speech-to-text with `Option+H` (`Alt+H`) on the focused `GJC:` surface.
 - `STEER`: send `Esc`, wait 100 ms, then send `Enter`.
 - `ESC X2`: send `Esc`, wait 100 ms, then send `Esc` again.
 
@@ -246,7 +246,6 @@ $CMUX identify --no-caller
 $CMUX tree --all
 $CMUX focus-panel --panel surface:7 --workspace workspace:1 --window window:1
 $CMUX new-surface --type terminal --pane pane:1 --focus true
-$CMUX new-surface --type browser --pane pane:1 --focus true
 $CMUX close-surface --surface surface:7 --workspace workspace:1 --window window:1
 ```
 
@@ -271,6 +270,16 @@ cmux send-key \
   --window window:1 \
   enter
 ```
+
+### Voice (`Option+H`)
+
+GJC maps speech-to-text to `Alt+H`. Deliver the terminal equivalent in one cmux surface write:
+
+```sh
+cmux rpc surface.send_text '{"surface":"surface:7","text":"\u001bh"}'
+```
+
+The expected bytes are `[27, 104]`. Guard this control with the same focused `GJC:` title check as other interactive GJC keys.
 
 ### Shift+Tab
 
@@ -416,7 +425,7 @@ Use temporary surfaces and restore the original focus after each test:
 - pane previous/next;
 - tab previous/next;
 - terminal creation in the requested pane;
-- browser-surface creation;
+- exact `Option+H` bytes (`[27, 104]`) and voice-mode toggle;
 - fixed-folder `cd` behavior;
 - focused tab closure;
 - same-tab worktree prompting when required;

--- a/docs/streamdeck-integration-guide-with-cmux.md
+++ b/docs/streamdeck-integration-guide-with-cmux.md
@@ -273,13 +273,9 @@ cmux send-key \
 
 ### Voice (`Option+H`)
 
-GJC binds speech-to-text to `Alt+H`, but cmux does not reliably forward that modifier through `send-key`, and macOS blocks Stream Deck plugin keystroke automation unless the plugin host has Accessibility permission. Use the focused GJC command palette instead:
+GJC binds local Whisper speech-to-text to `Alt+H`, but cmux does not reliably forward that modifier through `send-key`. Use a dedicated, signed local helper app that posts the real macOS `Option+H` event after focusing the exact `GJC:` surface.
 
-```text
-Ctrl+P -> type "Toggle speech-to-text" -> Enter
-```
-
-This invokes the same registered `app.stt.toggle` action without inserting a stray `h` into the editor or requiring macOS Accessibility access.
+The helper requires one-time macOS Accessibility approval. Keep that permission scoped to the helper app; do not fall back to typing command-palette search text into the active editor.
 
 ### Shift+Tab
 
@@ -425,7 +421,7 @@ Use temporary surfaces and restore the original focus after each test:
 - pane previous/next;
 - tab previous/next;
 - terminal creation in the requested pane;
-- voice action toggles through the GJC command palette without inserting `h`;
+- voice helper posts a real `Option+H` event without inserting text;
 - fixed-folder `cd` behavior;
 - focused tab closure;
 - same-tab worktree prompting when required;


### PR DESCRIPTION
## Summary
- add `docs/streamdeck-integration-guide-with-cmux.md`
- structure the guide as an installable `streamdeck-cmux` AI skill template
- document the three-page layout, cmux routing, worktree sessions, profile controls, SDK answer pad, mascot artwork, safety boundaries, and verification protocol

## Verification
- `git diff --check`
- guide frontmatter and required contract assertions

## Review
Docs-only, no runtime or bundled-default changes. LGTM after verifying commands and SDK identity rules against the current docs.