### PR TITLE
test(coding-agent): stabilize Bash allowlist fixture path

### DIFF
--- a/packages/coding-agent/test/tools/bash-state-exploit.test.ts
+++ b/packages/coding-agent/test/tools/bash-state-exploit.test.ts
@@ -5,7 +5,6 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
 import { BashTool } from "@gajae-code/coding-agent/tools/bash";
-import { resetShellConfigCache } from "@gajae-code/utils/shell-config";
 
 const SEEDED_TREE_TIME = new Date("2020-01-01T00:00:00.000Z");
 
@@ -52,6 +51,23 @@ function createRestrictedBashTool(cwd: string, prefixes: string[] = ROLE_AGENT_P
 		},
 	} as unknown as ToolSession;
 	return new BashTool(session);
+}
+
+function findFixtureBin(): string {
+	for (const entry of (process.env.PATH ?? "").split(path.delimiter)) {
+		if (!entry || !fs.existsSync(entry)) continue;
+		const fixturePath = path.join(entry, "gjc");
+		if (fs.existsSync(fixturePath)) {
+			throw new Error(`Cannot install the controlled gjc fixture: ${fixturePath} already exists.`);
+		}
+		try {
+			fs.accessSync(entry, fs.constants.W_OK | fs.constants.X_OK);
+			return entry;
+		} catch {
+			// Try the next inherited PATH entry.
+		}
+	}
+	throw new Error("No writable inherited PATH entry is available for the controlled gjc fixture.");
 }
 
 /** A workspace holding seeded workflow state, plus a full snapshot of the `.gjc` tree. */
@@ -239,18 +255,12 @@ describe("restricted BashTool state-mutation exploit", () => {
 	 */
 	it("admits a canonical allowlisted command and lets it produce a real execution effect", async () => {
 		const ws = seedWorkspace();
-		const bin = path.join(ws.dir, "bin");
+		const bin = findFixtureBin();
+		const fixturePath = path.join(bin, "gjc");
 		const sentinel = path.join(ws.dir, "admitted-sentinel.txt");
-		const previousPath = process.env.PATH;
 		try {
-			fs.mkdirSync(bin);
-			fs.writeFileSync(path.join(bin, "gjc"), '#!/bin/sh\ntouch "$PWD/admitted-sentinel.txt"\n');
-			fs.chmodSync(path.join(bin, "gjc"), 0o755);
-			process.env.PATH = `${bin}${path.delimiter}${previousPath ?? ""}`;
-			// Shell configuration snapshots the launch environment. Reset it after
-			// installing the fixture so the one-shot managed Bash path sees this
-			// controlled executable instead of requiring a globally installed `gjc`.
-			resetShellConfigCache();
+			fs.writeFileSync(fixturePath, '#!/bin/sh\ntouch "$PWD/admitted-sentinel.txt"\n');
+			fs.chmodSync(fixturePath, 0o755);
 			const tool = createRestrictedBashTool(ws.dir);
 
 			await tool.execute("tool-call", { command: "gjc state ralplan read --json" });
@@ -261,9 +271,7 @@ describe("restricted BashTool state-mutation exploit", () => {
 			// Admission is not permission to touch state.
 			expect(snapshotTree(path.join(ws.dir, ".gjc"))).toBe(ws.snapshot);
 		} finally {
-			if (previousPath === undefined) delete process.env.PATH;
-			else process.env.PATH = previousPath;
-			resetShellConfigCache();
+			fs.rmSync(fixturePath, { force: true });
 			ws.cleanup();
 		}
 	});


### PR DESCRIPTION
## Summary
- install the controlled `gjc` test executable in an inherited writable PATH directory
- avoid mutating `process.env.PATH` and invalidating the process-wide shell-config cache
- remove the fixture executable in `finally`

## Validation
- `bun test packages/coding-agent/test/tools/bash-state-exploit.test.ts`
- `bun test --shard=7/8` from `packages/coding-agent`
- `bun --cwd=packages/coding-agent run check`