### PR TITLE
test(coding-agent): sandbox the bash admission fixture instead of writing into inherited PATH

### DIFF
--- a/packages/coding-agent/test/tools/bash-state-exploit.test.ts
+++ b/packages/coding-agent/test/tools/bash-state-exploit.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, vi } from "bun:test";
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
 import { BashTool } from "@gajae-code/coding-agent/tools/bash";
+import * as shellSnapshot from "@gajae-code/coding-agent/utils/shell-snapshot";
+import { resetShellConfigCache } from "@gajae-code/utils/shell-config";
 
 const SEEDED_TREE_TIME = new Date("2020-01-01T00:00:00.000Z");
 
@@ -51,23 +53,6 @@ function createRestrictedBashTool(cwd: string, prefixes: string[] = ROLE_AGENT_P
 		},
 	} as unknown as ToolSession;
 	return new BashTool(session);
-}
-
-function findFixtureBin(): string {
-	for (const entry of (process.env.PATH ?? "").split(path.delimiter)) {
-		if (!entry || !fs.existsSync(entry)) continue;
-		const fixturePath = path.join(entry, "gjc");
-		if (fs.existsSync(fixturePath)) {
-			throw new Error(`Cannot install the controlled gjc fixture: ${fixturePath} already exists.`);
-		}
-		try {
-			fs.accessSync(entry, fs.constants.W_OK | fs.constants.X_OK);
-			return entry;
-		} catch {
-			// Try the next inherited PATH entry.
-		}
-	}
-	throw new Error("No writable inherited PATH entry is available for the controlled gjc fixture.");
 }
 
 /** A workspace holding seeded workflow state, plus a full snapshot of the `.gjc` tree. */
@@ -255,12 +240,25 @@ describe("restricted BashTool state-mutation exploit", () => {
 	 */
 	it("admits a canonical allowlisted command and lets it produce a real execution effect", async () => {
 		const ws = seedWorkspace();
-		const bin = findFixtureBin();
-		const fixturePath = path.join(bin, "gjc");
+		const bin = path.join(ws.dir, "bin");
 		const sentinel = path.join(ws.dir, "admitted-sentinel.txt");
+		const previousPath = process.env.PATH;
 		try {
-			fs.writeFileSync(fixturePath, '#!/bin/sh\ntouch "$PWD/admitted-sentinel.txt"\n');
-			fs.chmodSync(fixturePath, 0o755);
+			fs.mkdirSync(bin);
+			fs.writeFileSync(path.join(bin, "gjc"), '#!/bin/sh\ntouch "$PWD/admitted-sentinel.txt"\n');
+			fs.chmodSync(path.join(bin, "gjc"), 0o755);
+			process.env.PATH = `${bin}${path.delimiter}${previousPath ?? ""}`;
+			// Shell configuration snapshots the launch environment. Reset it after
+			// installing the fixture so the one-shot managed Bash path sees this
+			// controlled executable instead of requiring a globally installed `gjc`.
+			resetShellConfigCache();
+			// The sourced shell snapshot bakes the *creation-time* PATH into the
+			// snapshot file (`export PATH='$PATH'`) and is cached per process, so
+			// any earlier bash-driving test in the shard would re-export a PATH
+			// that predates this fixture and clobber the controlled `gjc`
+			// (observed in CI as `command not found: gjc`). Skip the snapshot so
+			// the session environment installed above stays authoritative.
+			vi.spyOn(shellSnapshot, "getOrCreateSnapshot").mockResolvedValue(null);
 			const tool = createRestrictedBashTool(ws.dir);
 
 			await tool.execute("tool-call", { command: "gjc state ralplan read --json" });
@@ -271,7 +269,10 @@ describe("restricted BashTool state-mutation exploit", () => {
 			// Admission is not permission to touch state.
 			expect(snapshotTree(path.join(ws.dir, ".gjc"))).toBe(ws.snapshot);
 		} finally {
-			fs.rmSync(fixturePath, { force: true });
+			vi.restoreAllMocks();
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+			resetShellConfigCache();
 			ws.cleanup();
 		}
 	});


### PR DESCRIPTION
## Context

Shard 7 of Dev CI was red on `bash-state-exploit.test.ts` ("admits a canonical allowlisted command...") with `command not found: gjc`. #4207 landed first and unblocked CI, so this PR is rebased on top of it and now replaces its fixture mechanism with a strictly safer one that addresses the same root cause.

## Root cause (why the original fixture failed only in CI shards)

The fixture prepended a sandbox `bin` to `process.env.PATH` and called `resetShellConfigCache()` — but the **sourced shell snapshot** (`src/utils/shell-snapshot.ts`) is a separate per-process cache, and the snapshot script bakes the creation-time PATH into the snapshot file:

```sh
echo "export PATH='$PATH'" >> "$SNAPSHOT_FILE"
```

Any earlier bash-driving test in the shard creates the snapshot with the stock runner PATH; sourcing it later re-exports that stale PATH and clobbers the fixture. Solo runs pass because the snapshot is first created inside the test. Reproduced deterministically on macOS by running `bash-executor.test.ts` before this file in one process: pre-fix fails with the exact CI signature, post-fix passes.

## Why replace the #4207 mechanism

#4207 sidesteps the snapshot by installing the controlled `gjc` into the **first writable inherited PATH entry** (e.g. `/opt/homebrew/bin`, `~/bin`). That works, but:

- a killed test process leaks a fake `gjc` (`#!/bin/sh` touch script) in a real shared PATH directory, shadowing the developer's actual CLI;
- it throws outright when the selected entry already contains `gjc` (dev-linked setups are PATH-order lucky, not safe);
- parallel shards race on the same shared directory.

## This fix

Keep the fixture inside the test's own temp workspace, prepend it to PATH, and spy `getOrCreateSnapshot` → `null` for the single dispatch (same spy precedent as `bash-executor.test.ts` / `bash-interceptor.test.ts`), restored in `finally`. `findFixtureBin()` is removed. The allowlist admission path under test is untouched and still proves a real execution effect (sentinel) through production `BashTool.execute`.

## Verification

- solo: 24 pass / 0 fail (56 expect calls), darwin-arm64 with a real `gjc` dev-linked on PATH
- poisoned order (`bash-executor.test.ts` + this file, one process): 0 failures
- `biome check` + `tsc --noEmit` clean

Refs #4124, supersedes the fixture mechanism of #4207.