### PR TITLE
fix(notify): report generation-skewed daemon as unhealthy

### DIFF
--- a/packages/coding-agent/src/sdk/bus/notification-service.ts
+++ b/packages/coding-agent/src/sdk/bus/notification-service.ts
@@ -883,12 +883,12 @@ export async function checkNotificationHealth(opts: HealthOptions): Promise<Noti
 			// `acquireDaemonOwnership` then answers `provisional`, which `ensureTelegramDaemonRunning`
 			// reports as `blocked_identity`: no transport is ever attached and no
 			// notification is ever published, while the owner keeps heartbeating. Reporting
-			// that as OK is what makes the outage invisible; the generation is inventory
-			// metadata that never forces a reload on its own, so the operator has to.
+			// that as OK is what makes the outage invisible. Recovery is platform-dependent,
+			// so health identifies the condition without prescribing an unsupported command.
 			checks.push({
 				name: "daemon",
 				level: "warn",
-				detail: `daemon pid ${daemon.pid} serves generation ${daemon.generation ?? "unknown"} but this build attaches only to generation ${daemon.currentGeneration}; it cannot attach a session transport — run \`gjc daemon reload\``,
+				detail: `daemon pid ${daemon.pid} serves generation ${daemon.generation ?? "unknown"} but this build attaches only to generation ${daemon.currentGeneration}; it cannot attach a session transport — inspect daemon lifecycle status before attempting recovery`,
 			});
 		} else {
 			checks.push({ name: "daemon", level: "ok", detail: `daemon pid ${daemon.pid} alive with a fresh heartbeat` });

--- a/packages/coding-agent/test/notifications-service.test.ts
+++ b/packages/coding-agent/test/notifications-service.test.ts
@@ -464,7 +464,7 @@ describe("notification-service health", () => {
 		expect(report.checks.find(check => check.name === "daemon")).toEqual({
 			name: "daemon",
 			level: "warn",
-			detail: `daemon pid 1000 serves generation ${servedGeneration} but this build attaches only to generation ${DAEMON_GENERATION}; it cannot attach a session transport — run \`gjc daemon reload\``,
+			detail: `daemon pid 1000 serves generation ${servedGeneration} but this build attaches only to generation ${DAEMON_GENERATION}; it cannot attach a session transport — inspect daemon lifecycle status before attempting recovery`,
 		});
 		expect(report.overall).toBe("warn");
 	});


### PR DESCRIPTION
Fix-forward from #4153 after exact-head review found its unconditional `gjc daemon reload` guidance unsafe on Windows.

This PR is deliberately **diagnostic-only**: it turns a false healthy result for an unattachable generation-skewed Telegram daemon into an actionable warning, while not claiming endpoint attachment, daemon recovery, or message delivery. #4052 remains open and actively owned until those acceptance criteria are proven.

Verification on the predecessor exact head and its clean current-dev cherry-pick: `bun test packages/coding-agent/test/notifications-service.test.ts` — 60 pass, 0 fail.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*