### PR TITLE
fix(session): repair dev after the #4185 merge — classification test + restored remnant reaping

### DIFF
--- a/packages/coding-agent/src/session/internal/managed-session-scope.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-scope.ts
@@ -51,6 +51,7 @@ import {
 	prepareManagedDirectoryRoot,
 	publishManagedFileNoReplace,
 	publishManagedTombstone,
+	reapScrubbedProtocolRemnantsSync,
 	retainManagedDirectoryAuthority,
 	validateManagedArtifactTree,
 	validateNativeSecurityResult,
@@ -1152,6 +1153,7 @@ export function prepareManagedSessionScopeForWriteSync(
 		ensureManagedDirectory(path.join(internal, MANAGED_RECEIPTS_DIRECTORY), root, policy);
 		stage = "tombstones_directory";
 		ensureManagedDirectory(path.join(internal, MANAGED_TOMBSTONES_DIRECTORY), root, policy);
+		reapScrubbedProtocolRemnantsSync(scope.directoryPath);
 		return { kind: "resolved", scope };
 	} catch (error) {
 		const publication = error instanceof ManagedPublishError ? error : undefined;
@@ -3732,6 +3734,7 @@ export async function prepareManagedSessionScopeForWrite(
 		ensureManagedDirectory(path.join(internal, MANAGED_RECEIPTS_DIRECTORY), root, policy);
 		ensureManagedDirectory(path.join(internal, MANAGED_TOMBSTONES_DIRECTORY), root, policy);
 		await reconcileManagedTombstones(scope, expectedCandidate);
+		reapScrubbedProtocolRemnantsSync(scope.directoryPath);
 		return { kind: "resolved", scope };
 	} catch (error) {
 		const publication = error instanceof ManagedPublishError ? error : undefined;

--- a/packages/coding-agent/test/session-manager/session-directory.test.ts
+++ b/packages/coding-agent/test/session-manager/session-directory.test.ts
@@ -2782,7 +2782,10 @@ describe("managed session write protocol", () => {
 				await expect(prepareManagedSessionScopeForWrite(restarted.scope)).resolves.toMatchObject({
 					kind: "error",
 					code: "durability_failed",
-					cause: { classification: "binding_invalid" },
+					// Since #4185 the operator-visible classification mirrors the
+					// recognized error code instead of falling back to a false
+					// `binding_invalid` corruption report (#4184).
+					cause: { classification: "durability_failed" },
 				});
 			} finally {
 				FileSessionStorage.prototype.deleteSessionVerified = originalDelete;


### PR DESCRIPTION
Dev is red after the #4185 merge (session-directory.test.ts: 63 pass / 2 fail). This PR repairs both failures; it no longer carries #4185 itself (merged as 9ef8cffcc while this was in review — the cherry-pick was dropped on rebase).

## Failure 1: quarantine-rejection classification (predicted pre-merge)

#4185 makes `cause.classification` mirror the recognized error code instead of falling back to `binding_invalid`. Dev's newer "rejects an unauthorized transcript quarantine during reconciliation" test (from the #3596 lane, written before #4185) pins `code: "durability_failed"` **with** `classification: "binding_invalid"` — the exact two-helper disagreement #4184 documents as the defect. The amendment updates the pinned expectation to `durability_failed`. `cause.classification` is display-only (`managedScopeStartupError`); nothing branches on `binding_invalid`.

## Failure 2: remnant reaper regressed by the scope repair

`827719d51` ("keep capacity correction classification-only") removed the `reapScrubbedProtocolRemnantsSync` calls from scope preparation, treating them as fork-PR scope creep. They are dev's own #4205 fix (`7d6cc213b`) for the unbounded remnant growth behind #4184 part 2 — the fork's rebase merely carried them from dev. The removal regressed the reaper, broke its regression test, and landed with "focused Bun test unavailable". This PR reverts that removal.

## Verification

- `session-manager/session-directory.test.ts` + `managed-scope-capacity-classification.test.ts`: **65 pass / 0 fail** on this branch (origin/dev: 63 pass / 2 fail)
- `tsc --noEmit` + biome clean

Refs #4184, #4185, #4205.