### PR TITLE
fix(test): apply the shared test preload to package-cwd bun test runs

### DIFF
--- a/packages/coding-agent/bunfig.toml
+++ b/packages/coding-agent/bunfig.toml
@@ -1,0 +1,8 @@
+# Package-cwd `bun test` (the CI shard invocation: `bun test --shard=N/8` with
+# cwd packages/coding-agent) does not read the repository-root bunfig.toml, so
+# without this file the shared test preload — macOS TMPDIR canonicalization and
+# the 64 MiB session-context budget pin that keeps the overflow fixtures in
+# session-context-overflow.test.ts and goal-mode-request.test.ts deterministic
+# under the 512 MiB production default (#4196) — silently never runs.
+[test]
+preload = ["../../scripts/test-preload.ts"]


### PR DESCRIPTION
Dev CI shard 1 is failing on every push since #4196 merged (e.g. run 31468453309: `GJC ultragoal goal mode request > surfaces the exported typed overflow` — "Expected promise that rejects").

## Root cause

The CI shards run `bun test --shard=N/8` with **cwd `packages/coding-agent`** (`scripts/ci-dev-affected.ts`), and bun does not read the repository-root `bunfig.toml` from a package cwd — so the shared test preload (`scripts/test-preload.ts`) silently never ran in shards. That was harmless until #4196 made the preload load-bearing: it pins `GJC_SESSION_CONTEXT_BUDGET_BYTES` to 64 MiB so the overflow fixtures authored against the old 64 MiB default keep overflowing under the new 512 MiB production default. Without the pin, the 40 MiB fixtures resolve instead of rejecting.

Deterministic repro (7 failures): `cd packages/coding-agent && bun test test/session/session-context-overflow.test.ts test/gjc-runtime/goal-mode-request.test.ts`

## Fix

Add `packages/coding-agent/bunfig.toml` with `[test] preload = ["../../scripts/test-preload.ts"]` so package-cwd and root-cwd runs share one test environment (budget pin + macOS TMPDIR canonicalization).

Rejected alternatives: rewriting fixtures against 512 MiB (inflates per-fixture memory >512 MiB); per-file env mutation (budget constant is captured at module load — order-dependent in the shared bun test process).

## Verification

- package-cwd run of both fixture files: **34 pass / 0 fail** (7 failures without this file)
- root-cwd behavior unchanged (root bunfig already preloads the same script)

Unblocks shard 1 for all open PRs including #4217.