### PR TITLE
docs(readme): restore contract lines dropped by the compact rewrite (#4219 fallout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The session command selector accepts only "gjc" or "gjc --worktree [name]".
 
 For a controller that drives one live session directly, every session also exposes a loopback **SDK WebSocket** endpoint, the `gjc sdk session` CLI (`list|inspect|send|status|tail`), and the bundled `sdk-skills/` (`gjc-sdk-discover` · `gjc-sdk-operate` · `gjc-sdk-author`) — reviewed, approval-gated procedures any controller-hosted agent can follow.
 
-- [External controller integration guide](docs/bot-integration.md) · [Coordinator MCP bridge](docs/hermes-mcp-bridge.md)
+- [External controller / bot integration guide](docs/bot-integration.md) — generic third-party bot setup and provider-independent smokes · [Coordinator MCP bridge](docs/hermes-mcp-bridge.md)
 - [SDK & wire protocol](docs/sdk.md) · [SDK session CLI](docs/sdk-session-cli.md) · [External-control readiness](docs/external-control-readiness.md)
 
 ## Documentation
@@ -183,9 +183,11 @@ Start at **[gajae-code.com](https://gajae-code.com)** or `docs/`:
 - [Install & updates](docs/install.md) · [Environment variables](docs/environment-variables.md) · [Keybindings](docs/keybindings.md) · [Themes](docs/theme.md)
 - [Models & providers](docs/models.md) · [Custom providers & multi-account routing](docs/custom-providers-and-multi-account.md) · [Multi-vendor profiles](docs/multi-vendor-profiles.md) · [Auth broker](docs/auth-broker-gateway.md)
 - [Telegram](docs/telegram-onboarding.md) · [Bot integration](docs/bot-integration.md) · [SDK](docs/sdk.md) · [SDK session CLI](docs/sdk-session-cli.md)
-- [Sessions](docs/session.md) · [Compaction](docs/compaction.md) · [Memory](docs/memory.md) · [Secrets](docs/secrets.md)
+- [Sessions](docs/session.md) · [Compaction](docs/compaction.md) · [Memory](docs/memory.md) · [Secrets](docs/secrets.md) · [Aside sidecar](docs/aside-integration.md)
 - [Codebase overview](docs/codebase-overview.md) · [Contributing / dev setup](CONTRIBUTING.md)
 - [macOS Option/Alt key setup (iTerm2)](docs/macos-option-key.md) · [GEO visibility benchmark](docs/geobench.md)
+
+The default dark TUI identity is the GJC red-claw theme, while light-appearance terminals default to the bundled blue-crab theme; migration themes (`claude-code`, `codex`, `opencode`) are selectable from Settings or `/theme`, and explicit user theme settings always win.
 
 ## SDK extensions
 


### PR DESCRIPTION
Dev root-check and shard 1 are red on every push since #4219 merged (run 31470950469):

- `check:gjc-ui` → `FAIL public docs current GJC crustacean theme direction` — the rewrite dropped the exact phrases `default dark TUI identity is the GJC red-claw theme` / `light-appearance terminals default to the bundled blue-crab theme` that `scripts/verify-gjc-ui-redesign.ts` requires in the root README.
- `bot-integration-docs.test.ts` → README no longer contains `External controller / bot`, `provider-independent smokes`, and `docs/aside-integration.md`.

This PR restores the three statements in the rewrite's compact style (one link-line amendment, one doc-index entry, one theme sentence) instead of reverting the i18n/compact work.

## Verification
- `bun run check:gjc-ui`: 4/4 PASS (was 3/4)
- `bot-integration-docs.test.ts`: 7 pass / 0 fail (was 5/2)
- docs-contract sweep (`lifecycle-notification-docs` + `bot-integration-docs`): 9/0
- `bun scripts/rebrand-inventory.ts --strict`: clean

Second dev repair in this release-blocker lane (after #4221); unblocks #4217 and every other open PR.