### PR TITLE
docs(readme): restore controller, Aside, and theme-default contracts

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -132,6 +132,8 @@ gjc @screenshot.png "何を変えるべき？"   # 画像入力
 gjc ultragoal create-goals --brief-file <承認済み計画>
 ```
 
+デフォルトのダーク TUI アイデンティティは GJC red-claw テーマで、ライト外観ターミナルは同梱の blue-crab テーマがデフォルトです。他のテーマは Settings または `/theme` から選択してください。
+
 ## OpenClaw / Hermes に GJC を使わせる
 
 GJC はネイティブの Coordinator MCP ブリッジを同梱しており、OpenClaw や Hermes のような外部コントローラが永続 turn を通じて実際の GJC セッションをオーケストレーションします — ターミナルスクレイピングは一切不要です。
@@ -176,6 +178,7 @@ The session command selector accepts only "gjc" or "gjc --worktree [name]".
 ライブセッションを直接操作するコントローラのために、各セッションはループバック **SDK WebSocket** エンドポイント、`gjc sdk session` CLI（`list|inspect|send|status|tail`）、同梱の `sdk-skills/`（`gjc-sdk-discover` · `gjc-sdk-operate` · `gjc-sdk-author`）も公開しています — レビュー済みで承認ゲート付きの手順であり、コントローラ上のどんなエージェントでも従えます。
 
 - [外部コントローラ統合ガイド](docs/bot-integration.md) · [Coordinator MCP ブリッジ](docs/hermes-mcp-bridge.md)
+- [外部コントローラ / ボット](docs/bot-integration.md) — プロバイダ非依存スモーク；[`docs/aside-integration.md`](docs/aside-integration.md) はオプトインの検索/コンテキストサイドカーを扱います
 - [SDK & ワイヤプロトコル](docs/sdk.md) · [SDK セッション CLI](docs/sdk-session-cli.md) · [外部制御レディネス](docs/external-control-readiness.md)
 
 ## ドキュメント

--- a/README.ko.md
+++ b/README.ko.md
@@ -132,6 +132,8 @@ gjc @screenshot.png "뭘 바꿔야 할까?"   # 이미지 입력
 gjc ultragoal create-goals --brief-file <승인된-계획>
 ```
 
+기본 다크 TUI 정체성은 GJC red-claw 테마이며, 라이트 외형 터미널은 번들 blue-crab 테마가 기본입니다. 더 많은 테마는 Settings 또는 `/theme`에서 선택하세요.
+
 ## OpenClaw / Hermes가 GJC를 부리게 하기
 
 GJC는 네이티브 Coordinator MCP 브리지를 내장하고 있어 OpenClaw나 Hermes 같은 외부 컨트롤러가 터미널 스크래핑 없이 durable turn으로 실제 GJC 세션을 오케스트레이션합니다.
@@ -176,6 +178,7 @@ The session command selector accepts only "gjc" or "gjc --worktree [name]".
 라이브 세션 하나를 직접 다루는 컨트롤러를 위해 모든 세션은 루프백 **SDK WebSocket** 엔드포인트, `gjc sdk session` CLI(`list|inspect|send|status|tail`), 번들 `sdk-skills/`(`gjc-sdk-discover` · `gjc-sdk-operate` · `gjc-sdk-author`)를 함께 노출합니다 — 컨트롤러에 올라탄 에이전트가 따라갈 수 있는, 검토되고 승인 게이트가 있는 절차입니다.
 
 - [외부 컨트롤러 통합 가이드](docs/bot-integration.md) · [Coordinator MCP 브리지](docs/hermes-mcp-bridge.md)
+- [외부 컨트롤러 / 봇](docs/bot-integration.md) — 프로바이더 독립 스모크; [`docs/aside-integration.md`](docs/aside-integration.md)는 옵트인 검색/컨텍스트 사이드카를 다룹니다
 - [SDK & 와이어 프로토콜](docs/sdk.md) · [SDK 세션 CLI](docs/sdk-session-cli.md) · [외부 제어 준비도](docs/external-control-readiness.md)
 
 ## 문서

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Inside a session:
 gjc ultragoal create-goals --brief-file <approved-plan>
 ```
 
+The default dark TUI identity is the GJC red-claw theme, while light-appearance terminals default to the bundled blue-crab theme. Pick more from Settings or `/theme`.
+
 ## Let OpenClaw / Hermes drive GJC
 
 GJC ships a native Coordinator MCP bridge, so an external controller like OpenClaw or Hermes orchestrates real GJC sessions through durable turns — never terminal scraping.
@@ -174,6 +176,7 @@ The session command selector accepts only "gjc" or "gjc --worktree [name]".
 For a controller that drives one live session directly, every session also exposes a loopback **SDK WebSocket** endpoint, the `gjc sdk session` CLI (`list|inspect|send|status|tail`), and the bundled `sdk-skills/` (`gjc-sdk-discover` · `gjc-sdk-operate` · `gjc-sdk-author`) — reviewed, approval-gated procedures any controller-hosted agent can follow.
 
 - [External controller integration guide](docs/bot-integration.md) · [Coordinator MCP bridge](docs/hermes-mcp-bridge.md)
+- [External controller / bot](docs/bot-integration.md) — provider-independent smokes; [`docs/aside-integration.md`](docs/aside-integration.md) covers the opt-in search/context sidecar
 - [SDK & wire protocol](docs/sdk.md) · [SDK session CLI](docs/sdk-session-cli.md) · [External-control readiness](docs/external-control-readiness.md)
 
 ## Documentation

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -132,6 +132,8 @@ gjc @screenshot.png "我该改什么？"    # 图片输入
 gjc ultragoal create-goals --brief-file <已批准的计划>
 ```
 
+默认暗色 TUI 身份是 GJC red-claw 主题，亮色外观终端默认使用捆绑的 blue-crab 主题。更多主题从 Settings 或 `/theme` 选择。
+
 ## 让 OpenClaw / Hermes 驱动 GJC
 
 GJC 内置原生 Coordinator MCP 桥，让 OpenClaw、Hermes 之类的外部控制器通过持久 turn 编排真实的 GJC 会话 —— 绝不抓取终端。
@@ -176,6 +178,7 @@ The session command selector accepts only "gjc" or "gjc --worktree [name]".
 对于直接驱动单个实时会话的控制器，每个会话还暴露回环 **SDK WebSocket** 端点、`gjc sdk session` CLI（`list|inspect|send|status|tail`），以及内置的 `sdk-skills/`（`gjc-sdk-discover` · `gjc-sdk-operate` · `gjc-sdk-author`）—— 经过评审、带审批门控的流程，任何控制器上的代理都可以遵循。
 
 - [外部控制器集成指南](docs/bot-integration.md) · [Coordinator MCP 桥](docs/hermes-mcp-bridge.md)
+- [外部控制器 / 机器人](docs/bot-integration.md) — 提供商无关冒烟测试；[`docs/aside-integration.md`](docs/aside-integration.md) 涵盖可选的搜索/上下文边车
 - [SDK & 线协议](docs/sdk.md) · [SDK 会话 CLI](docs/sdk-session-cli.md) · [外部控制就绪度](docs/external-control-readiness.md)
 
 ## 文档


### PR DESCRIPTION
## Summary

PR #4219 compact SSOT rewrite accidentally removed five public contract strings that two CI gates assert. This restores them as concise single-line references, preserving the compact SSOT direction with ko/zh-CN/ja parity.

## Evidence (exact failures from CI)

From #4117 workflow 31473392687 (cross-PR baseline blocker):
- shard-1: bot-integration-docs.test.ts — 2 failures (2311 pass / 68 skip / 2 fail)
- root-check: verify-gjc-ui-redesign.ts — public docs current GJC crustacean theme direction FAIL

## Restored strings

Each README gets exactly 2 additions:

1. Theme-defaults line (restores verify-gjc-ui-redesign.ts contract):
   - default dark TUI identity is the GJC red-claw theme
   - light-appearance terminals default to the bundled blue-crab theme

2. Controller/Aside discoverability line (restores bot-integration-docs.test.ts contract):
   - External controller / bot
   - docs/aside-integration.md
   - provider-independent smokes

## Verification

- bot-integration-docs.test.ts: 7 pass, 0 fail
- verify-gjc-ui-redesign.ts: 4/4 PASS
- docs-index-lazy.test.ts: 5 pass, 0 fail
- check-public-version-sync.test.ts: 19 pass, 0 fail
- check:types (packages/coding-agent): clean

Closes #4225