### PR TITLE
feat(coding-agent): add result-first edit cards (salvage of #4005)

### DIFF
--- a/packages/coding-agent/src/edit/renderer.ts
+++ b/packages/coding-agent/src/edit/renderer.ts
@@ -412,10 +412,12 @@ function resolveCompletedEditIdentity(
 	args: EditRenderArgs | undefined,
 	editMode: EditMode | undefined,
 	isPartial: boolean,
+
 ): { path: string; op: Operation | undefined; move: string | undefined; firstChangedLine: number | undefined } {
 	const firstEdit = args?.edits?.[0];
 	const inventory = getEditRequestTargetInventory(args, editMode, { isPartial });
 	const detailsPath = details && "path" in details ? details.path : undefined;
+
 	return {
 		path: detailsPath ?? args?.file_path ?? args?.path ?? firstEdit?.path ?? inventory.paths[0] ?? "",
 		op: details?.op ?? args?.op ?? firstEdit?.op,

--- a/packages/coding-agent/src/edit/renderer.ts
+++ b/packages/coding-agent/src/edit/renderer.ts
@@ -356,8 +356,8 @@ export const editToolRenderer = {
 		});
 		const firstEdit = Array.isArray(editArgs.edits) && editArgs.edits.length > 0 ? editArgs.edits[0] : undefined;
 		const rawPath = inventory.paths[0] ?? "";
-		const rename = editArgs.rename || firstEdit?.rename || firstEdit?.move;
-		const op = editArgs.op || firstEdit?.op || inventory.firstOp;
+		const rename = editArgs.rename || firstEdit?.rename || firstEdit?.move || inventory.rename;
+		const op = editArgs.op || firstEdit?.op || inventory.op;
 		const { description } = formatEditDescription(rawPath, uiTheme, options.expanded ? { rename } : undefined);
 		const spinner =
 			options?.spinnerFrame !== undefined ? formatStatusIcon("running", uiTheme, options.spinnerFrame) : "";

--- a/packages/coding-agent/src/edit/renderer.ts
+++ b/packages/coding-agent/src/edit/renderer.ts
@@ -412,7 +412,6 @@ function resolveCompletedEditIdentity(
 	args: EditRenderArgs | undefined,
 	editMode: EditMode | undefined,
 	isPartial: boolean,
-
 ): { path: string; op: Operation | undefined; move: string | undefined; firstChangedLine: number | undefined } {
 	const firstEdit = args?.edits?.[0];
 	const inventory = getEditRequestTargetInventory(args, editMode, { isPartial });

--- a/packages/coding-agent/src/edit/streaming.ts
+++ b/packages/coding-agent/src/edit/streaming.ts
@@ -81,6 +81,10 @@ export interface EditRequestTargetInventory {
 	 * parsed entry, not on the top-level args). */
 	firstOp?: Operation;
 	parseError?: string;
+	/** First envelope entry operation, for free-form modes that carry no structured `edits`. */
+	op?: PatchEditEntry["op"];
+	/** First envelope entry rename target, for free-form modes that carry no structured `edits`. */
+	rename?: string;
 }
 const MISSING_APPLY_PATCH_END_ERROR = `The last line of the patch must be '${END_PATCH_MARKER}'`;
 
@@ -135,6 +139,19 @@ function getHashlineTargetPaths(input: string): string[] {
 	return paths.filter(Boolean);
 }
 
+/**
+ * `apply_patch` carries operation metadata inside the envelope rather than in structured `edits`,
+ * so the collapsed card has to read op/rename off the first parsed entry to stay accurate while live.
+ */
+function applyPatchEntryInventory(entries: readonly ApplyPatchEntry[]): EditRequestTargetInventory {
+	const first = entries[0];
+	return {
+		paths: orderedDistinctPaths(entries.map(entry => entry.path)),
+		op: first?.op,
+		rename: first?.rename,
+	};
+}
+
 export function getEditRequestTargetInventory(
 	args: unknown,
 	editMode: EditMode | undefined,
@@ -154,22 +171,20 @@ export function getEditRequestTargetInventory(
 	if (editMode === "hashline") {
 		const input = typeof values.input === "string" ? values.input : "";
 		const headerPaths = getHashlineTargetPaths(input);
-		return { paths: orderedDistinctPaths(headerPaths.length > 0 ? headerPaths : [topLevelPath]) };
+		// `path` is only a fallback for headerless input; explicit §PATH headers are the full target set.
+		if (headerPaths.length > 0) return { paths: orderedDistinctPaths(headerPaths) };
+		return { paths: orderedDistinctPaths([topLevelPath]) };
 	}
 
 	if (editMode === "apply_patch") {
 		const input = typeof values.input === "string" ? values.input : "";
 		try {
-			const entries = expandApplyPatchToEntries({ input });
-			return { paths: orderedDistinctPaths(entries.map(entry => entry.path)), firstOp: entries[0]?.op };
+			return applyPatchEntryInventory(expandApplyPatchToEntries({ input }));
 		} catch (err) {
 			const parseError = err instanceof Error ? err.message : String(err);
-			const previewEntries = expandApplyPatchToPreviewEntries({ input });
-			const paths = orderedDistinctPaths(previewEntries.map(entry => entry.path));
-			if (options.isPartial && parseError === MISSING_APPLY_PATCH_END_ERROR) {
-				return { paths, firstOp: previewEntries[0]?.op };
-			}
-			return { paths, firstOp: previewEntries[0]?.op, parseError };
+			const inventory = applyPatchEntryInventory(expandApplyPatchToPreviewEntries({ input }));
+			if (options.isPartial && parseError === MISSING_APPLY_PATCH_END_ERROR) return inventory;
+			return { ...inventory, parseError };
 		}
 	}
 

--- a/packages/coding-agent/src/edit/streaming.ts
+++ b/packages/coding-agent/src/edit/streaming.ts
@@ -31,7 +31,7 @@ import { replaceTabs, truncateToWidth } from "../tools/render-utils";
 import { type EditMode, resolveEditMode } from "../utils/edit-mode";
 import { computeEditDiff, type DiffError, type DiffResult } from "./diff";
 import { type ApplyPatchEntry, expandApplyPatchToEntries, expandApplyPatchToPreviewEntries } from "./modes/apply-patch";
-import { computePatchDiff, type Operation, type PatchEditEntry } from "./modes/patch";
+import { computePatchDiff, type PatchEditEntry } from "./modes/patch";
 import type { ReplaceEditEntry } from "./modes/replace";
 
 export interface PerFileDiffPreview {
@@ -76,10 +76,6 @@ export interface EditStreamingStrategy<Args = unknown> {
 }
 export interface EditRequestTargetInventory {
 	paths: string[];
-	/** Operation of the first target (Create/Delete) when derivable from the
-	 * request payload (apply_patch/hashline free-form envelopes carry op on the
-	 * parsed entry, not on the top-level args). */
-	firstOp?: Operation;
 	parseError?: string;
 	/** First envelope entry operation, for free-form modes that carry no structured `edits`. */
 	op?: PatchEditEntry["op"];
@@ -176,7 +172,9 @@ export function getEditRequestTargetInventory(
 		return { paths: orderedDistinctPaths([topLevelPath]) };
 	}
 
-	if (editMode === "apply_patch") {
+	// Legacy call sites render the shared edit card without threading `renderContext.editMode`;
+	// a free-form `input` string is only ever an apply_patch envelope there.
+	if (editMode === "apply_patch" || (editMode === undefined && typeof values.input === "string")) {
 		const input = typeof values.input === "string" ? values.input : "";
 		try {
 			return applyPatchEntryInventory(expandApplyPatchToEntries({ input }));

--- a/packages/coding-agent/test/g004-streamed-tool-args-qa.test.ts
+++ b/packages/coding-agent/test/g004-streamed-tool-args-qa.test.ts
@@ -270,6 +270,7 @@ describe("G004 streamed tool args QA", () => {
 			{ name: "edit", label: "Edit", mode: "hashline" } as any,
 			ui,
 		);
+		component.setExpanded(true);
 		const settleRenderedPreview = async (expected: string): Promise<void> => {
 			for (let attempt = 0; attempt < 20; attempt++) {
 				await Promise.resolve();

--- a/packages/coding-agent/test/modes/components/tool-execution-viewport-output-revision.test.ts
+++ b/packages/coding-agent/test/modes/components/tool-execution-viewport-output-revision.test.ts
@@ -69,6 +69,7 @@ describe("ToolExecutionComponent visible preview revisions", () => {
 			ui,
 			process.cwd(),
 		);
+		component.setExpanded(true);
 
 		component.updateArgs({ input: patch });
 		component.setArgsComplete();
@@ -100,6 +101,7 @@ describe("ToolExecutionComponent visible preview revisions", () => {
 			ui,
 			process.cwd(),
 		);
+		component.setExpanded(true);
 
 		component.updateArgs({ input: patch });
 		await waitFor(() => requests.length >= 2);
@@ -123,6 +125,7 @@ describe("ToolExecutionComponent visible preview revisions", () => {
 			ui,
 			process.cwd(),
 		);
+		component.setExpanded(true);
 
 		await waitFor(() => requests.length === 1);
 		requests[0]!.resolve(preview);
@@ -158,6 +161,7 @@ describe("ToolExecutionComponent visible preview revisions", () => {
 			ui,
 			process.cwd(),
 		);
+		component.setExpanded(true);
 
 		await waitFor(() => requests.length === 1);
 		requests[0]!.resolve(preview);
@@ -194,6 +198,7 @@ describe("ToolExecutionComponent visible preview revisions", () => {
 			ui,
 			process.cwd(),
 		);
+		component.setExpanded(true);
 
 		component.updateArgs({ input: patch });
 		component.setArgsComplete();

--- a/packages/coding-agent/test/modes/controllers/event-controller-viewport-output-revision.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-viewport-output-revision.test.ts
@@ -92,6 +92,7 @@ describe("EventController viewport output revision", () => {
 			args: { input: applyPatch },
 		} as never);
 		const component = ctx.pendingTools.get("preview-1") as ToolExecutionComponent;
+		component.setExpanded(true);
 		await waitFor(() => requests.length === 1);
 		recordVisibleTranscriptMutation.mockClear();
 		requests[0]!.resolve(preview);

--- a/packages/coding-agent/test/tools/apply-patch-renderer.test.ts
+++ b/packages/coding-agent/test/tools/apply-patch-renderer.test.ts
@@ -44,7 +44,6 @@ describe("apply_patch rendering", () => {
 			uiStub,
 		);
 
-		component.setExpanded(true);
 		component.updateResult(
 			{
 				content: [{ type: "text", text: "" }],
@@ -57,10 +56,16 @@ describe("apply_patch rendering", () => {
 			false,
 		);
 
-		const rendered = Bun.stripANSI(component.render(140).join("\n"));
-		expect(rendered).toContain("src/demo.ts");
-		expect(rendered).toContain("+new");
-		expect(rendered).not.toContain("(no output)");
+		const collapsed = Bun.stripANSI(component.render(140).join("\n"));
+		expect(collapsed).toContain("src/demo.ts");
+		expect(collapsed).not.toContain("+new");
+		expect(collapsed).not.toContain("(no output)");
+
+		component.setExpanded(true);
+		const expanded = Bun.stripANSI(component.render(140).join("\n"));
+		expect(expanded).toContain("src/demo.ts");
+		expect(expanded).toContain("+new");
+		expect(expanded).not.toContain("(no output)");
 	});
 	it("derives call path, operation, and file-count hints from apply_patch input", async () => {
 		const uiTheme = await getUiTheme();
@@ -108,7 +113,7 @@ describe("apply_patch rendering", () => {
 
 		const component = editToolRenderer.renderCall(
 			{ input: malformedInput },
-			{ expanded: true, isPartial: true, renderContext: { editMode: "apply_patch" } },
+			{ expanded: true, isPartial: true },
 			uiTheme,
 		);
 		const rendered = Bun.stripANSI(component.render(160).join("\n"));
@@ -133,6 +138,7 @@ describe("apply_patch rendering", () => {
 			].join("\n");
 
 			const component = new ToolExecutionComponent("apply_patch", { input }, {}, undefined, uiStub, tmpDir);
+			component.setExpanded(true);
 			const before = Bun.stripANSI(component.render(160).join("\n"));
 			expect(before).not.toContain("(preview)");
 
@@ -206,6 +212,7 @@ describe("apply_patch rendering", () => {
 			false,
 		);
 
+		component.setExpanded(true);
 		const rendered = Bun.stripANSI(component.render(220).join("\n"));
 		expect(rendered).toContain("  10│}");
 		expect(rendered).toContain(" +11│import");

--- a/packages/coding-agent/test/tools/edit-renderer.test.ts
+++ b/packages/coding-agent/test/tools/edit-renderer.test.ts
@@ -170,6 +170,7 @@ describe("editToolRenderer", () => {
 			uiTheme,
 		);
 
+
 		expect(Bun.stripANSI(partial.render(160).join("\n"))).not.toContain("*** End Patch");
 		expect(Bun.stripANSI(complete.render(160).join("\n"))).toContain("*** End Patch");
 	});

--- a/packages/coding-agent/test/tools/edit-renderer.test.ts
+++ b/packages/coding-agent/test/tools/edit-renderer.test.ts
@@ -656,4 +656,78 @@ describe("editToolRenderer", () => {
 		expect(rendered).not.toContain("https://bad");
 		expect(rendered).not.toContain("\x1b]8;;");
 	});
+
+	it("treats the top-level path as a hashline fallback only when no explicit headers exist", () => {
+		const explicitSingle = getEditRequestTargetInventory(
+			{ path: "default.ts", input: "§actual.ts\n»BOF\n+x" },
+			"hashline",
+			{ isPartial: false },
+		);
+		const explicitMulti = getEditRequestTargetInventory(
+			{ path: "default.ts", input: "§a.ts\n»BOF\n+x\n§b.ts\n»BOF\n+y" },
+			"hashline",
+			{ isPartial: false },
+		);
+		const headerless = getEditRequestTargetInventory({ path: "default.ts", input: "»BOF\n+x" }, "hashline", {
+			isPartial: false,
+		});
+
+		expect(explicitSingle.paths).toEqual(["actual.ts"]);
+		expect(explicitMulti.paths).toEqual(["a.ts", "b.ts"]);
+		expect(headerless.paths).toEqual(["default.ts"]);
+	});
+
+	it("does not advertise extra targets for single-header hashline input with a fallback path", async () => {
+		const uiTheme = await getUiTheme();
+		const component = editToolRenderer.renderCall(
+			{ path: "default.ts", input: "§actual.ts\n»BOF\n+x" },
+			{ expanded: false, isPartial: true, renderContext: { editMode: "hashline" } },
+			uiTheme,
+		);
+		const rendered = Bun.stripANSI(component.render(160).join("\n"));
+		expect(rendered).toContain("actual.ts");
+		expect(rendered).not.toContain("more)");
+		expect(rendered).not.toContain("default.ts");
+	});
+
+	it("keeps apply_patch operation and rename metadata on live cards", async () => {
+		const uiTheme = await getUiTheme();
+		const deleted = editToolRenderer.renderCall(
+			{ input: "*** Begin Patch\n*** Delete File: old.ts\n*** End Patch" },
+			{ expanded: false, isPartial: false, renderContext: { editMode: "apply_patch" } },
+			uiTheme,
+		);
+		const moved = editToolRenderer.renderCall(
+			{ input: "*** Begin Patch\n*** Update File: old.ts\n*** Move to: new.ts\n@@\n-a\n+b\n*** End Patch" },
+			{ expanded: true, isPartial: false, renderContext: { editMode: "apply_patch" } },
+			uiTheme,
+		);
+		const deletedText = Bun.stripANSI(deleted.render(160).join("\n"));
+		const movedText = Bun.stripANSI(moved.render(160).join("\n"));
+
+		expect(deletedText).toContain("Delete");
+		expect(deletedText).toContain("old.ts");
+		expect(movedText).toContain("new.ts");
+	});
+
+	it("sanitizes single-file preview errors on expanded result cards", async () => {
+		const uiTheme = await getUiTheme();
+		const error = 'File not found: \x1b]8;;https://attacker.invalid\x07evil.ts\x1b]8;;\x07\r\ninjected';
+		const component = editToolRenderer.renderResult(
+			{ content: [], details: { path: "target.ts" } },
+			{
+				expanded: true,
+				isPartial: false,
+				renderContext: { editMode: "replace", editDiffPreview: { error } },
+			},
+			uiTheme,
+			{ path: "target.ts" },
+		);
+		const raw = component.render(160).join("\n");
+
+		expect(raw).toContain("File not found");
+		expect(raw).not.toContain("https://attacker.invalid");
+		expect(raw).not.toContain("\x1b]8;;");
+		expect(raw).not.toContain("\r");
+	});
 });

--- a/packages/coding-agent/test/tools/edit-renderer.test.ts
+++ b/packages/coding-agent/test/tools/edit-renderer.test.ts
@@ -170,7 +170,6 @@ describe("editToolRenderer", () => {
 			uiTheme,
 		);
 
-
 		expect(Bun.stripANSI(partial.render(160).join("\n"))).not.toContain("*** End Patch");
 		expect(Bun.stripANSI(complete.render(160).join("\n"))).toContain("*** End Patch");
 	});
@@ -712,9 +711,9 @@ describe("editToolRenderer", () => {
 
 	it("sanitizes single-file preview errors on expanded result cards", async () => {
 		const uiTheme = await getUiTheme();
-		const error = 'File not found: \x1b]8;;https://attacker.invalid\x07evil.ts\x1b]8;;\x07\r\ninjected';
+		const error = "File not found: \x1b]8;;https://attacker.invalid\x07evil.ts\x1b]8;;\x07\r\ninjected";
 		const component = editToolRenderer.renderResult(
-			{ content: [], details: { path: "target.ts" } },
+			{ content: [], details: { path: "target.ts", diff: "" } },
 			{
 				expanded: true,
 				isPartial: false,

--- a/packages/coding-agent/test/tools/edit-renderer.test.ts
+++ b/packages/coding-agent/test/tools/edit-renderer.test.ts
@@ -173,7 +173,6 @@ describe("editToolRenderer", () => {
 		expect(Bun.stripANSI(partial.render(160).join("\n"))).not.toContain("*** End Patch");
 		expect(Bun.stripANSI(complete.render(160).join("\n"))).toContain("*** End Patch");
 	});
-
 	it("hides hashline envelope input while the live card is collapsed", async () => {
 		await getUiTheme();
 		const uiStub = { requestRender() {} } as unknown as TUI;


### PR DESCRIPTION
Salvage of #4005 by @needsbuilder (`feat(coding-agent): add result-first edit cards`), rebased onto current `dev` with the single remaining review blocker resolved.

## What this does

Result-first edit cards keep live calls concise when collapsed and show per-file results, diff statistics, diagnostics availability, and full details consistently when expanded. The implementation corrects hashline target inventory (top-level `path` is now a fallback only when no explicit `§PATH` headers exist), preserves `apply_patch` operation/rename metadata on live cards, and sanitizes single-file preview errors on expanded result cards.

## Salvage rationale

PR #4005 exact head `e5f0328439fdd28730aabb8dbeb884b1dfb0aa5c` was green on exact-head CI but stale against current `dev`. @probepark's latest review confirmed the earlier rendering/operation/hashline/sanitization/test-contract issues are fixed, with one remaining Major: the changelog entry was added under released `0.12.19` instead of `Unreleased`.

On rebase, the changelog entry proved to be a **verbatim duplicate** of text already shipped under released `0.12.16` (`### Changed` → "Edit cards now keep live calls concise..."). The repo contract forbids editing released sections, so the correct resolution is to drop the duplicate addition entirely — the feature is already documented in the shipped `0.12.16` release.

## What changed vs exact head

- **Source + tests**: byte-identical to exact head `e5f0328` (verified via `diff`)
- **CHANGELOG**: dropped the duplicate `### Changed` block that was added under released `0.12.19` (the review blocker)
- **Base**: rebased from stale `6608c20` onto current `dev` (`f43ce870a0`)

## Verification

All five touched suites pass:
- `edit-renderer.test.ts` — 32 pass
- `apply-patch-renderer.test.ts` — 8 pass
- `g004-streamed-tool-args-qa.test.ts` — 9 pass
- `tool-execution-viewport-output-revision.test.ts` — 14 pass
- `event-controller-viewport-output-revision.test.ts` — 12 pass

`tsc --noEmit` clean. `git diff --check` clean.

## Authorship

Original 4 commits by @needsbuilder preserved with original authorship. The CHANGELOG fix is folded into the commit that introduced it.

@probepark — respect for the thorough review. The earlier issues you flagged are all addressed on the exact head; this salvage carries them forward onto current dev with your changelog finding resolved.