### PR TITLE
test(telegram): sync topic-registry generation assertion to 60 (#4200)

### DIFF
--- a/packages/coding-agent/test/notifications-topic-registry.test.ts
+++ b/packages/coding-agent/test/notifications-topic-registry.test.ts
@@ -620,13 +620,15 @@ test("preserves a no-provenance endpoint claim before a held create can stage it
 	await creating;
 	expect(reg.endpointAuthority(binding)).toEqual({ state: "unique", sessionId: "B" });
 });
-test("publishes generation 59 at serving epoch 5", () => {
+test("publishes generation 60 at serving epoch 5", () => {
 	// Generation 55: shared-topic-authority outage hardening (#3974).
 	// Generation 56: lazy native authority for startup-cost cut (#3846).
 	// Generation 57: parser-valid archive transitions after disconnect grace.
 	// Generation 58: parser-valid durable-fence promotion and rollback.
 	// Generation 59: attached OPEN-socket count in the heartbeat sidecar (#4128).
-	expect(DAEMON_GENERATION).toBe(59);
+	// Generation 60: transient heartbeat-sidecar publication failures are
+	// contained instead of crashing the daemon (#4200).
+	expect(DAEMON_GENERATION).toBe(60);
 	expect(SERVING_EPOCH).toBe(5);
 });
 test("archives pending topics into retained inactive records", async () => {


### PR DESCRIPTION
Fixes the post-merge regression from #4217: DAEMON_GENERATION was bumped 59->60 for transient heartbeat-sidecar publication containment (#4200), but notifications-topic-registry.test.ts still asserted 59. That test lives outside #4217's affected-path CI scope, so it only failed on the full-dev shard run after merge.

This PR aligns the assertion with the shipped constant (57/0 topic-registry tests pass; related suites 117/0 and 560/0).