### PR TITLE
fix(bash): own one-shot native shells

### DIFF
--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -19,7 +19,7 @@ import { formatArtifactReference, resolveOutputMaxColumns, resolveOutputSinkHead
 import { getOrCreateSnapshot } from "../utils/shell-snapshot";
 import { NON_INTERACTIVE_ENV } from "./non-interactive-env";
 
-type NativeShellBindings = Pick<typeof import("@gajae-code/natives"), "Shell" | "executeShell">;
+type NativeShellBindings = Pick<typeof import("@gajae-code/natives"), "Shell">;
 let nativeShellBindingsLoad: Promise<NativeShellBindings> | undefined;
 
 async function shellNatives(): Promise<NativeShellBindings> {
@@ -288,7 +288,7 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 			...(await sink.dump("Command cancelled")),
 		};
 	}
-	const { Shell, executeShell } = await shellNatives();
+	const { Shell } = await shellNatives();
 
 	const usePersistentShell = options?.oneShot !== true;
 	const sessionKey = buildSessionKey(shell, configuredPrefix, snapshotPath, shellEnv, options?.sessionKey, minimizer);
@@ -303,14 +303,26 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 		});
 		shellSessions.set(sessionKey, shellSession);
 	}
+	// Non-persistent invocations still need an owned native Shell so its lifetime
+	// can be ended explicitly. executeShell creates a native shell outside the
+	// persistent registry, leaving its cleanup untrackable by the host process.
+	const oneShotShell =
+		!usePersistentShell || persistentSessionBroken
+			? new Shell({
+					sessionEnv: shellEnv,
+					snapshotPath: snapshotPath ?? undefined,
+					minimizer,
+				})
+			: undefined;
+	const activeShell = shellSession ?? oneShotShell;
 	const userSignal = options?.signal;
 	const runAbortController = new AbortController();
 	const abortCurrentExecution = () => {
 		if (!runAbortController.signal.aborted) {
 			runAbortController.abort();
 		}
-		if (shellSession && !abortPromise) {
-			abortPromise = shellSession.abort();
+		if (activeShell && !abortPromise) {
+			abortPromise = activeShell.abort();
 		}
 	};
 	const abortDeferred = Promise.withResolvers<"abort">();
@@ -351,38 +363,20 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 	let runSettled = false;
 
 	try {
-		const runPromise = shellSession
-			? shellSession.run(
-					{
-						command: finalCommand,
-						cwd: commandCwd,
-						env: commandEnv,
-						timeoutMs: executionTimeoutMs,
-						signal: runAbortController.signal,
-					},
-					(err, chunk) => {
-						if (!err) {
-							enqueueChunk(chunk);
-						}
-					},
-				)
-			: executeShell(
-					{
-						command: finalCommand,
-						cwd: commandCwd,
-						env: commandEnv,
-						sessionEnv: shellEnv,
-						snapshotPath: snapshotPath ?? undefined,
-						minimizer,
-						timeoutMs: executionTimeoutMs,
-						signal: runAbortController.signal,
-					},
-					(err, chunk) => {
-						if (!err) {
-							enqueueChunk(chunk);
-						}
-					},
-				);
+		const runPromise = activeShell!.run(
+			{
+				command: finalCommand,
+				cwd: commandCwd,
+				env: commandEnv,
+				timeoutMs: executionTimeoutMs,
+				signal: runAbortController.signal,
+			},
+			(err, chunk) => {
+				if (!err) {
+					enqueueChunk(chunk);
+				}
+			},
+		);
 
 		const winner = await Promise.race([
 			runPromise.then(result => ({ kind: "result" as const, result })),
@@ -413,7 +407,8 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 						.catch(() => undefined);
 				}
 			} else {
-				void runPromise.catch(() => undefined);
+				runSettled = await awaitAbortCleanup(runPromise);
+				if (!runSettled) void runPromise.catch(() => undefined);
 			}
 			return {
 				exitCode: undefined,
@@ -511,6 +506,10 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 		}
 		if (resetSession && runSettled && shellSessions.get(sessionKey) === shellSession) {
 			shellSessions.delete(sessionKey);
+		}
+		if (oneShotShell) {
+			const disposePromise = abortPromise ?? oneShotShell.abort();
+			await Promise.race([disposePromise.catch(() => undefined), Bun.sleep(CANCEL_CLEANUP_WAIT_MS)]);
 		}
 	}
 }

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -100,6 +100,17 @@ describe("executeBash", () => {
 		expect(getShellSessionCount()).toBe(0);
 	});
 
+	it("owns and disposes one-shot native shells", async () => {
+		await disposeAllShellSessions();
+		const abortSpy = vi.spyOn(piNatives.Shell.prototype, "abort");
+
+		const result = await executeBash("echo one-shot", { cwd: tempDir, timeout: 5000, oneShot: true });
+
+		expect(result.output.trim()).toBe("one-shot");
+		expect(getShellSessionCount()).toBe(0);
+		expect(abortSpy).toHaveBeenCalledTimes(1);
+	});
+
 	it("reports the bash shell-session owner count via runtime resource gauges", async () => {
 		await disposeAllShellSessions();
 		expect(getRuntimeResourceCounts()["bash.shellSessions"]).toBe(0);
@@ -299,7 +310,7 @@ describe("executeBash", () => {
 			sessionKey: "hung-native-abort",
 		});
 		expect(next.output.trim()).toBe("next");
-		expect(runCalls).toBe(1);
+		expect(runCalls).toBe(2);
 	});
 
 	it("restores persistent sessions after native abort cleanup settles", async () => {


### PR DESCRIPTION
## Summary
- execute one-shot and broken-session fallback bash work through an owned native `Shell`
- dispose that shell with bounded cleanup so native resources remain host-trackable
- cover one-shot ownership and update the broken-session fallback expectation

Fixes #4228

## Verification
- `bun test packages/coding-agent/test/bash-executor.test.ts`
- `bun --cwd=packages/coding-agent run check` (passes typecheck; existing unrelated optional-chain lint warning remains)

gaebal-gajae