### PR TITLE
fix(ci): serialize virtual integration candidates

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -883,18 +883,18 @@ jobs:
   # Stable pre-merge status: this runs for every PR after the protected affected
   # aggregate, then only materializes a virtual merge when the canonical planner
   # selected risk canaries. A dispatch remains available for exact-head bootstrap
-  # evidence. The job-level group is scoped per merge candidate (per PR/head ref)
-  # so an unrelated PR can never evict this run while it waits behind a single
-  # global queue slot; a fresh push to the same head still cancels its stale run.
-  # Dispatch validation keeps its own non-cancelling lane so manual re-validations
-  # cannot race a different base/head merge candidate.
+  # evidence. Every merge candidate shares one non-cancelling lane: a candidate
+  # selects and materializes against dev, so overlapping candidates could otherwise
+  # validate against incompatible integration state. Keep up to 100 candidates
+  # pending instead of replacing an older pending validation.
   virtual-integration:
     name: Virtual integration validation
     needs: [affected-plan, affected]
     if: ${{ always() && ((github.event_name == 'pull_request' && needs.affected.result == 'success') || (github.event_name == 'workflow_dispatch' && inputs.head_sha != '')) }}
     concurrency:
-      group: ${{ github.event_name == 'workflow_dispatch' && inputs.head_sha != '' && 'dev-ci-virtual-integration' || format('dev-ci-virtual-integration-{0}', github.ref) }}
-      cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.head_sha != '') }}
+      group: dev-ci-virtual-integration
+      cancel-in-progress: false
+      queue: max
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     permissions:

--- a/scripts/dev-ci-guard-topology.test.ts
+++ b/scripts/dev-ci-guard-topology.test.ts
@@ -19,7 +19,7 @@ interface WorkflowJob {
 	needs?: string[];
 	if?: string;
 	env?: Record<string, string>;
-	concurrency?: { group: string; "cancel-in-progress"?: string | boolean };
+	concurrency?: { group: string; "cancel-in-progress"?: string | boolean; queue?: string };
 	steps: WorkflowStep[];
 }
 
@@ -187,15 +187,9 @@ describe("dev-ci Telegram daemon generation guard topology", () => {
 		// it is selected per-step from the authoritative terminal-green dev push.
 		expect(virtual.env).not.toHaveProperty("CI_VI_BASE_SHA");
 		const source = await Bun.file(".github/workflows/dev-ci.yml").text();
-		// The virtual-integration job is scoped per merge candidate (per PR/head ref)
-		// so unrelated PRs cannot evict each other on the shared queue, while a fresh
-		// push to the same head still cancels its stale run via cancel-in-progress.
-		// Dispatch validation keeps its own non-cancelling lane (mirrors the top-level
-		// concurrency guard) so manual exact-head re-validations serialize without
-		// racing a different base/head merge candidate.
-		expect(source).toContain("group: ${{ github.event_name == 'workflow_dispatch' && inputs.head_sha != '' && 'dev-ci-virtual-integration' || format('dev-ci-virtual-integration-{0}', github.ref) }}");
-		expect(source).toContain("cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.head_sha != '') }}");
-		expect(source).not.toContain("group: dev-ci-virtual-integration\n      cancel-in-progress: false");
+		// Every candidate must serialize: each one selects a dev base and materializes
+		// a merge, so concurrent runs could validate incompatible integration states.
+		expect(source).toContain("group: dev-ci-virtual-integration\n      cancel-in-progress: false\n      queue: max");
 		expect(source).toContain("Select authoritative terminal-green dev base");
 		expect(source).toContain("bun scripts/ci-virtual-integration.ts --select-base");
 		expect(source).toContain("CI_VI_BASE_SHA: ${{ steps.green-dev.outputs.base_sha }}");
@@ -232,116 +226,13 @@ describe("dev-ci Telegram daemon generation guard topology", () => {
 		}
 		expect(offenders).toEqual([]);
 	});
-	test("virtual integration never evicts unrelated PRs but still cancels stale same-ref runs", async () => {
+	test("virtual integration serializes every merge candidate without cancellation", async () => {
 		const d = await workflow();
 		const virtual = requiredJob(d, "virtual-integration");
 		const raw = virtual.concurrency;
 		expect(raw).toBeDefined();
-		const group = raw!.group;
-		const cancel = raw!["cancel-in-progress"];
-
-		// Pull the two expressions out of the ${{ ... }} interpolations so the
-		// assertions exercise the live workflow text, not a hand-copied copy.
-		const groupExpr = group.replace(/^\$\{\{/, "").replace(/\}\}$/, "").trim();
-		const cancelExpr = String(cancel).replace(/^\$\{\{/, "").replace(/\}\}$/, "").trim();
-
-		type Ctx = { eventName: string; headSha: string; ref: string };
-		const varValue = (name: string, ctx: Ctx): string | boolean => {
-			if (name === "github.event_name") return ctx.eventName;
-			if (name === "inputs.head_sha") return ctx.headSha;
-			if (name === "github.ref") return ctx.ref;
-			throw new Error(`Unknown variable: ${name}`);
-		};
-		const splitTop = (expr: string, op: string): string[] => {
-			const parts: string[] = [];
-			let depth = 0;
-			let current = "";
-			let i = 0;
-			while (i < expr.length) {
-				const ch = expr[i];
-				if (ch === "(" || ch === "[") depth++;
-				else if (ch === ")" || ch === "]") depth--;
-				if (depth === 0 && expr.slice(i, i + op.length) === op) {
-					parts.push(current.trim());
-					current = "";
-					i += op.length;
-					continue;
-				}
-				current += ch;
-				i++;
-			}
-			parts.push(current.trim());
-			return parts;
-		};
-		const evalExpr = (expr: string, ctx: Ctx): string | boolean => {
-			expr = expr.trim();
-			if (expr.startsWith("!(") && expr.endsWith(")")) {
-				return !evalExpr(expr.slice(2, -1), ctx);
-			}
-			const orParts = splitTop(expr, "||");
-			if (orParts.length > 1) {
-				let result = evalExpr(orParts[0], ctx);
-				for (let i = 1; i < orParts.length; i++) {
-					if (result) return result;
-					result = evalExpr(orParts[i], ctx);
-				}
-				return result;
-			}
-			const andParts = splitTop(expr, "&&");
-			if (andParts.length > 1) {
-				let result = evalExpr(andParts[0], ctx);
-				for (let i = 1; i < andParts.length; i++) {
-					if (!result) return result;
-					result = evalExpr(andParts[i], ctx);
-				}
-				return result;
-			}
-			const formatMatch = expr.match(/^format\(([^)]+)\)$/);
-			if (formatMatch) {
-				const inner = formatMatch[1];
-				const comma = inner.indexOf(",");
-				const template = inner.slice(0, comma).trim().replace(/^'|'$/g, "");
-				const arg = inner.slice(comma + 1).trim();
-				return template.replace(/\{0\}/, String(varValue(arg, ctx)));
-			}
-			const resolveValue = (token: string): string | boolean => {
-				token = token.trim();
-				if (token.startsWith("'") && token.endsWith("'")) return token.slice(1, -1);
-				return varValue(token, ctx);
-			};
-			const eq = splitTop(expr, "==");
-			if (eq.length === 2) {
-				return String(resolveValue(eq[0])) === String(resolveValue(eq[1]));
-			}
-			const ne = splitTop(expr, "!=");
-			if (ne.length === 2) {
-				return String(resolveValue(ne[0])) !== String(resolveValue(ne[1]));
-			}
-			if (expr.startsWith("'") && expr.endsWith("'")) return expr.slice(1, -1);
-			return varValue(expr, ctx);
-		};
-		const groupFor = (ctx: Ctx): string => String(evalExpr(groupExpr, ctx));
-		const cancelsFor = (ctx: Ctx): boolean => Boolean(evalExpr(cancelExpr, ctx));
-
-		// Two unrelated PRs map to distinct groups, so neither can evict the other
-		// while queued behind a single global slot (the #4176 regression).
-		const prA = { eventName: "pull_request", headSha: "", ref: "refs/pull/4135/merge" };
-		const prB = { eventName: "pull_request", headSha: "", ref: "refs/pull/4108/merge" };
-		expect(groupFor(prA)).not.toBe(groupFor(prB));
-		expect(groupFor(prA)).toBe("dev-ci-virtual-integration-refs/pull/4135/merge");
-		expect(groupFor(prB)).toBe("dev-ci-virtual-integration-refs/pull/4108/merge");
-
-		// A fresh push to the same head keeps the same group and cancels the stale
-		// run, so same-ref stale-run cancellation is preserved and load stays bounded
-		// (never more than one running job per ref).
-		const sameRefPush = { eventName: "pull_request", headSha: "", ref: "refs/pull/4135/merge" };
-		expect(groupFor(sameRefPush)).toBe(groupFor(prA));
-		expect(cancelsFor(sameRefPush)).toBe(true);
-
-		// Manual dispatch validation keeps its own non-cancelling lane so a dispatch
-		// cannot race a PR and cannot be displaced by the next dispatch.
-		const dispatch = { eventName: "workflow_dispatch", headSha: "abc", ref: "refs/heads/dev" };
-		expect(groupFor(dispatch)).toBe("dev-ci-virtual-integration");
-		expect(cancelsFor(dispatch)).toBe(false);
+		expect(raw!.group).toBe("dev-ci-virtual-integration");
+		expect(raw!["cancel-in-progress"]).toBe(false);
+		expect(raw!.queue).toBe("max");
 	});
 });


### PR DESCRIPTION
## Summary
- serialize every virtual-integration merge candidate in one non-cancelling FIFO queue
- retain pending candidates with GitHub Actions `queue: max`
- pin the topology contract for group, cancellation, and queue policy

Closes #3350

## Validation
- `bun test scripts/dev-ci-guard-topology.test.ts`
- `bun scripts/check-workflow-yaml.ts`
- `bun test scripts/ci-risk-canary-manifest.test.ts scripts/ci-virtual-integration.test.ts scripts/ci-dev-affected.test.ts`

*[repo owner's gaebal-gajae (clawdbot) 🦞]*