### PR TITLE
fix(gc): fence transcript replacement during blob mark

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
@@ -1194,6 +1194,9 @@ async function markGcDiskBlobReferences(transcriptPath: string, into: Set<string
 interface GcDiskMarkedTranscript {
 	size: number;
 	mtimeMs: number;
+	ctimeMs: number;
+	dev: number;
+	ino: number;
 }
 
 /**
@@ -1233,14 +1236,26 @@ async function markGcDiskTranscript(
 		errors.push({ surface: "blobs", scope: transcriptPath, message: gcDiskErrorText(error) });
 		return;
 	}
-	if (before.size !== after.size || before.mtimeMs !== after.mtimeMs) {
+	if (
+		before.size !== after.size ||
+		before.mtimeMs !== after.mtimeMs ||
+		before.ctimeMs !== after.ctimeMs ||
+		before.dev !== after.dev ||
+		before.ino !== after.ino
+	) {
 		// The transcript changed while its references were being read: the
 		// reference set is not bound to a stable snapshot, so it cannot vouch
 		// for any blob. Same posture as the drift rounds exhausting below.
 		markGcDiskEvidenceIncomplete(evidence, "sessions_changed_during_mark");
 		return;
 	}
-	marked.set(transcriptPath, { size: after.size, mtimeMs: after.mtimeMs });
+	marked.set(transcriptPath, {
+		size: after.size,
+		mtimeMs: after.mtimeMs,
+		ctimeMs: after.ctimeMs,
+		dev: after.dev,
+		ino: after.ino,
+	});
 }
 
 /**
@@ -1269,7 +1284,14 @@ async function findGcDiskMarkDrift(input: {
 		visit: (transcriptPath, _directory, stat) => {
 			const mark = input.marked.get(transcriptPath);
 			if (mark) {
-				if (mark.size !== stat.size || mark.mtimeMs !== stat.mtimeMs) drifted.push(transcriptPath);
+				if (
+					mark.size !== stat.size ||
+					mark.mtimeMs !== stat.mtimeMs ||
+					mark.ctimeMs !== stat.ctimeMs ||
+					mark.dev !== stat.dev ||
+					mark.ino !== stat.ino
+				)
+					drifted.push(transcriptPath);
 				return;
 			}
 			if (!input.accounted.has(transcriptPath)) drifted.push(transcriptPath);

--- a/packages/coding-agent/src/session/blob-store.ts
+++ b/packages/coding-agent/src/session/blob-store.ts
@@ -2,6 +2,7 @@ import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
+import { exactUnlink } from "@gajae-code/natives";
 import { isEnoent, logger, postmortem } from "@gajae-code/utils";
 
 const BLOB_PREFIX = "blob:sha256:";
@@ -1618,8 +1619,10 @@ export interface CanonicalBlobEntry {
 	readonly path: string;
 	readonly bytes: number;
 	readonly mtimeMs: number;
-	readonly dev: number;
-	readonly ino: number;
+	readonly mtimeNs: bigint;
+	readonly dev: bigint;
+	readonly ino: bigint;
+	readonly nlink: bigint;
 }
 
 const CANONICAL_BLOB_NAME = /^[0-9a-f]{64}$/;
@@ -1651,20 +1654,22 @@ export async function listCanonicalBlobs(dir: string): Promise<CanonicalBlobEntr
 	for (const name of names) {
 		if (!CANONICAL_BLOB_NAME.test(name)) continue;
 		const blobPath = path.join(dir, name);
-		let stat: fs.Stats;
+		let stat: fs.BigIntStats;
 		try {
-			stat = await fsp.lstat(blobPath);
+			stat = await fsp.lstat(blobPath, { bigint: true });
 		} catch {
 			continue;
 		}
-		if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1) continue;
+		if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1n) continue;
 		entries.push({
 			hash: name,
 			path: blobPath,
-			bytes: stat.size,
-			mtimeMs: stat.mtimeMs,
+			bytes: Number(stat.size),
+			mtimeMs: Number(stat.mtimeMs),
+			mtimeNs: stat.mtimeNs,
 			dev: stat.dev,
 			ino: stat.ino,
+			nlink: stat.nlink,
 		});
 	}
 	return entries;
@@ -1687,32 +1692,45 @@ export async function removeCanonicalBlob(
 	entry: CanonicalBlobEntry,
 	options: { beforeUnlink?: () => Promise<boolean> } = {},
 ): Promise<{ removed: true } | { removed: false; reason: string; failed?: true }> {
-	let stat: fs.Stats;
+	let stat: fs.BigIntStats;
 	try {
-		stat = await fsp.lstat(entry.path);
+		stat = await fsp.lstat(entry.path, { bigint: true });
 	} catch (error) {
 		if (isEnoent(error)) return { removed: false, reason: "blob_disappeared" };
 		return { removed: false, reason: `blob_unverifiable: ${String(error)}`, failed: true };
 	}
-	if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1) {
+	if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1n) {
 		return { removed: false, reason: "blob_not_plain_file" };
 	}
 	if (
 		stat.dev !== entry.dev ||
 		stat.ino !== entry.ino ||
-		stat.size !== entry.bytes ||
-		stat.mtimeMs !== entry.mtimeMs
+		stat.size !== BigInt(entry.bytes) ||
+		stat.mtimeNs !== entry.mtimeNs
 	) {
 		return { removed: false, reason: "blob_changed" };
 	}
 	if (options.beforeUnlink && !(await options.beforeUnlink())) {
 		return { removed: false, reason: "blob_reference_evidence_changed" };
 	}
-	try {
-		await fsp.unlink(entry.path);
-		return { removed: true };
-	} catch (error) {
-		if (isEnoent(error)) return { removed: false, reason: "blob_disappeared" };
-		return { removed: false, reason: `blob_unlink_failed: ${String(error)}`, failed: true };
+	const removed = exactUnlink(entry.path, {
+		dev: entry.dev,
+		ino: entry.ino,
+		nlink: entry.nlink,
+		size: BigInt(entry.bytes),
+		mtimeNs: entry.mtimeNs,
+		sha256: entry.hash,
+		quarantineName: `.gjc-gc-blob-${entry.hash}`,
+	});
+	if (removed.ok) return { removed: true };
+	if (removed.code === "cleanup_pending" && removed.detachedPath) {
+		try {
+			await fsp.unlink(removed.detachedPath);
+			return { removed: true };
+		} catch (error) {
+			return { removed: false, reason: `blob_cleanup_failed: ${String(error)}`, failed: true };
+		}
 	}
+	if (removed.code === "not_found") return { removed: false, reason: "blob_disappeared" };
+	return { removed: false, reason: `blob_unlink_failed: ${removed.code ?? "unknown"}`, failed: true };
 }

--- a/packages/coding-agent/test/gc-disk-retention.test.ts
+++ b/packages/coding-agent/test/gc-disk-retention.test.ts
@@ -520,6 +520,44 @@ describe("gjc gc --disk --prune (blob mark and sweep)", () => {
 		}
 	});
 
+	test("withholds the sweep when a transcript is replaced with preserved size and mtime during marking", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			const precious = await writeBlob(fixture, "payload referenced after transcript replacement", 10);
+			const replaced = await writeBlob(fixture, "payload replaced in the transcript reference", 10);
+			const transcript = await writeSession(fixture, "repo-a", "replaced-mid-mark-session", {
+				ageDays: 0,
+				blobRefs: [replaced],
+			});
+			const original = await fsp.lstat(transcript);
+			const realLstat = fsp.lstat as unknown as (target: PathLike, options?: { bigint?: false }) => Promise<Stats>;
+			let transcriptStats = 0;
+			const spy = spyOn(fsp, "lstat");
+			spy.mockImplementation((async (target: PathLike, options?: { bigint?: false }) => {
+				if (path.resolve(String(target)) === transcript && ++transcriptStats === 3) {
+					const replacement = `${transcript}.replacement`;
+					const content = (await Bun.file(transcript).text()).replace(replaced, precious);
+					await Bun.write(replacement, content);
+					await fsp.utimes(replacement, original.atime, original.mtime);
+					await fsp.rename(replacement, transcript);
+				}
+				return await realLstat(target, options);
+			}) as unknown as typeof fsp.lstat);
+			try {
+				const disk = requireDisk(await runDisk(fixture, ["--disk", "--prune", "--json"]));
+				expect(reasonById(disk, "blobs").get(precious)).toBe(
+					"keep:withheld_evidence_incomplete: sessions_changed_during_mark",
+				);
+				expect(disk.surfaces.blobs.reclaimed).toBe(0);
+				expect(await Bun.file(path.join(fixture.blobsDir, precious)).exists()).toBe(true);
+			} finally {
+				spy.mockRestore();
+			}
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
 	test("withholds the sweep when a transcript is appended to during the sweep", async () => {
 		const fixture = await makeTestRoot();
 		try {

--- a/packages/coding-agent/test/gc-disk-retention.test.ts
+++ b/packages/coding-agent/test/gc-disk-retention.test.ts
@@ -649,6 +649,31 @@ describe("gjc gc --disk --prune (blob mark and sweep)", () => {
 		}
 	});
 
+	test("refuses a canonical blob replacement after the final sweep fence", async () => {
+		const fixture = await makeTestRoot();
+		try {
+			const hash = await writeBlob(fixture, "canonical identity must survive the final fence", 10);
+			const blobPath = path.join(fixture.blobsDir, hash);
+			const entry = (await listCanonicalBlobs(fixture.blobsDir))[0]!;
+			const original = await fsp.lstat(blobPath);
+			const replacement = `${blobPath}.replacement`;
+			await Bun.write(replacement, "canonical identity must survive the final fence");
+			await fsp.utimes(replacement, original.atime, original.mtime);
+
+			expect(
+				await removeCanonicalBlob(entry, {
+					beforeUnlink: async () => {
+						await fsp.rename(replacement, blobPath);
+						return true;
+					},
+				}),
+			).toEqual({ removed: false, reason: "blob_unlink_failed: identity_mismatch", failed: true });
+			expect(await Bun.file(blobPath).exists()).toBe(true);
+		} finally {
+			await fsp.rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+
 	test("never reclaims a blob a changing transcript can still reference", async () => {
 		const fixture = await makeTestRoot();
 		try {


### PR DESCRIPTION
Closes #4158.

## Fix

Bind each marked transcript reference set to its full filesystem identity (`dev`, `ino`, `ctimeMs`) in addition to size and mtime, and re-check that identity at every drift/fence pass. A same-size replacement that restores mtime can otherwise introduce a new `blob:sha256:` reference after marking while appearing unchanged to the sweep.

## Verification

- `bun test packages/coding-agent/test/gc-disk-retention.test.ts` — 52 pass, 0 fail, 324 expectations
- `bun --cwd=packages/coding-agent run check` — passed (pre-existing unrelated Biome warning in `session-manager.ts`)

—
*[repo owner’s gaebal-gajae (clawdbot) 🦞]*