### PR TITLE
feat(coordinator): expose bounded current tool activity

### DIFF
--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -5,13 +5,13 @@ import * as path from "node:path";
 import { getAgentDir, isKnownSinkPeerClosedError } from "@gajae-code/utils";
 import { normalizePathForComparison, VERSION } from "@gajae-code/utils/dirs";
 
+import { withFileLock } from "../config/file-lock";
 import {
 	COORDINATOR_MCP_PROTOCOL_VERSION,
 	COORDINATOR_MCP_SERVER_NAME,
 	COORDINATOR_MCP_TOOL_NAMES,
 	type CoordinatorToolName,
 } from "../coordinator/contract";
-import { readLinuxProcStartTimeSync } from "../gjc-runtime/linux-proc";
 import { listMcpDelegateHostContexts } from "../hooks/mcp-delegate-host-context";
 import type { WorkflowGate, WorkflowGateQueryRecord } from "../modes/shared/agent-wire/workflow-gate-types";
 import type { BrokerDiscovery } from "../sdk/broker/discovery";
@@ -280,6 +280,10 @@ interface CoordinatorSessionState {
 	source: "coordinator" | "agent_session_event";
 	live: boolean | null;
 	reason: string | null;
+	last_activity_at?: string;
+	activity?: unknown;
+	active_tools?: unknown;
+	active_tool_calls?: unknown;
 }
 
 type CoordinatorEventKind =
@@ -1237,7 +1241,7 @@ function publicLifecycleReceipt(result: Record<string, unknown>, sessionId: stri
 
 function publicCoordinatorSessionState(state: CoordinatorSessionState | null): Record<string, unknown> | null {
 	if (!state) return null;
-	return {
+	const result: Record<string, unknown> = {
 		session_id: state.session_id,
 		state: state.state,
 		ready_for_input: state.ready_for_input,
@@ -1246,6 +1250,55 @@ function publicCoordinatorSessionState(state: CoordinatorSessionState | null): R
 		updated_at: state.updated_at,
 		...(typeof state.live === "boolean" ? { live: state.live } : {}),
 	};
+	const activity = asRecord(state.activity);
+	if (
+		typeof state.last_activity_at === "string" &&
+		Number.isFinite(Date.parse(state.last_activity_at)) &&
+		activity &&
+		typeof activity.sequence === "number" &&
+		Number.isSafeInteger(activity.sequence) &&
+		activity.sequence > 0 &&
+		activity.kind === "tool_execution" &&
+		(activity.phase === "started" || activity.phase === "finished") &&
+		typeof activity.tool_name === "string" &&
+		/^[A-Za-z][A-Za-z0-9_-]{0,63}$/.test(activity.tool_name) &&
+		typeof activity.observed_at === "string" &&
+		Number.isFinite(Date.parse(activity.observed_at)) &&
+		typeof activity.active_tool_count === "number" &&
+		Number.isSafeInteger(activity.active_tool_count) &&
+		activity.active_tool_count >= 0
+	) {
+		result.last_activity_at = state.last_activity_at;
+		result.activity = {
+			sequence: activity.sequence,
+			kind: activity.kind,
+			phase: activity.phase,
+			tool_name: activity.tool_name,
+			observed_at: activity.observed_at,
+			...(typeof activity.started_at === "string" && Number.isFinite(Date.parse(activity.started_at))
+				? { started_at: activity.started_at }
+				: {}),
+			...(typeof activity.elapsed_ms === "number" &&
+			Number.isSafeInteger(activity.elapsed_ms) &&
+			activity.elapsed_ms >= 0
+				? { elapsed_ms: activity.elapsed_ms }
+				: {}),
+			...(activity.outcome === "succeeded" || activity.outcome === "failed" ? { outcome: activity.outcome } : {}),
+			active_tool_count: activity.active_tool_count,
+		};
+		if (Array.isArray(state.active_tools))
+			result.active_tools = state.active_tools.slice(0, 8).flatMap(value => {
+				const tool = asRecord(value);
+				return tool &&
+					typeof tool.tool_name === "string" &&
+					/^[A-Za-z][A-Za-z0-9_-]{0,63}$/.test(tool.tool_name) &&
+					typeof tool.started_at === "string" &&
+					Number.isFinite(Date.parse(tool.started_at))
+					? [{ tool_name: tool.tool_name, started_at: tool.started_at }]
+					: [];
+			});
+	}
+	return result;
 }
 
 function eventTimestamp(record: Record<string, unknown>): string | null {
@@ -1838,7 +1891,8 @@ async function writeSessionStateUnlocked(
 		overwrite?: boolean;
 	} = {},
 ): Promise<CoordinatorSessionState> {
-	const previous = options.overwrite ? null : await readSessionState(namespaceDir, sessionId);
+	const existing = await readSessionState(namespaceDir, sessionId);
+	const previous = options.overwrite ? null : existing;
 	const hasCurrentTurn = Object.hasOwn(options, "currentTurnId");
 	const hasLastTurn = Object.hasOwn(options, "lastTurnId");
 	const hasLive = Object.hasOwn(options, "live");
@@ -1857,6 +1911,12 @@ async function writeSessionStateUnlocked(
 		source: options.source ?? "coordinator",
 		live: hasLive ? (options.live ?? null) : (previous?.live ?? null),
 		reason: options.reason ?? null,
+		...(typeof existing?.last_activity_at === "string" ? { last_activity_at: existing.last_activity_at } : {}),
+		...(existing?.activity && typeof existing.activity === "object" ? { activity: existing.activity } : {}),
+		...(Array.isArray(existing?.active_tools) ? { active_tools: existing.active_tools } : {}),
+		...(existing?.active_tool_calls && typeof existing.active_tool_calls === "object"
+			? { active_tool_calls: existing.active_tool_calls }
+			: {}),
 	};
 	await writeJsonFile(sessionStateFile(namespaceDir, sessionId), payload);
 	if (
@@ -1884,108 +1944,8 @@ async function writeSessionStateUnlocked(
 	return payload;
 }
 
-interface SessionStateLockOwner {
-	pid: number;
-	start_time: string;
-	token: string;
-}
-
-function processStartTime(pid: number): string | null {
-	return readLinuxProcStartTimeSync(pid);
-}
-
-function validLockOwner(value: unknown): value is SessionStateLockOwner {
-	if (!value || typeof value !== "object") return false;
-	const owner = value as Partial<SessionStateLockOwner>;
-	return (
-		typeof owner.pid === "number" &&
-		Number.isSafeInteger(owner.pid) &&
-		owner.pid > 0 &&
-		typeof owner.start_time === "string" &&
-		typeof owner.token === "string" &&
-		owner.token.length > 0
-	);
-}
-
-function lockOwnerIsAlive(value: unknown): boolean {
-	if (!validLockOwner(value)) return false;
-	const owner = value;
-	try {
-		process.kill(owner.pid, 0);
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ESRCH") return false;
-		return true;
-	}
-	const currentStartTime = processStartTime(owner.pid);
-	return currentStartTime === null || currentStartTime === owner.start_time;
-}
-
-async function reclaimStaleSessionStateLock(lockFile: string): Promise<void> {
-	let raw: string;
-	try {
-		raw = await fs.readFile(lockFile, "utf8");
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
-		throw error;
-	}
-	let owner: unknown;
-	try {
-		owner = JSON.parse(raw);
-	} catch {
-		owner = null;
-	}
-	if (!validLockOwner(owner)) {
-		const stat = await fs.stat(lockFile);
-		if (Date.now() - stat.mtimeMs < 30_000) return;
-	} else if (lockOwnerIsAlive(owner)) return;
-	try {
-		if ((await fs.readFile(lockFile, "utf8")) === raw) await fs.rm(lockFile);
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-	}
-}
-
 async function withSessionStateLock<T>(stateFile: string, operation: () => Promise<T>): Promise<T> {
-	const lockFile = `${stateFile}.lock`;
-	const owner: SessionStateLockOwner = {
-		pid: process.pid,
-		start_time: processStartTime(process.pid) ?? "unknown",
-		token: randomUUID(),
-	};
-	await ensureDir(path.dirname(stateFile));
-	for (let attempt = 0; attempt < 12_000; attempt++) {
-		let handle: fs.FileHandle | undefined;
-		try {
-			handle = await fs.open(lockFile, "wx");
-			try {
-				await handle.writeFile(JSON.stringify(owner));
-			} catch (error) {
-				await handle.close().catch(() => undefined);
-				handle = undefined;
-				await fs.rm(lockFile, { force: true }).catch(() => undefined);
-				throw error;
-			}
-			const outcome = await operation().then(
-				value => ({ ok: true as const, value }),
-				error => ({ ok: false as const, error }),
-			);
-			await handle.close();
-			try {
-				if ((await fs.readFile(lockFile, "utf8")) === JSON.stringify(owner)) await fs.rm(lockFile);
-			} catch (error) {
-				if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-			}
-			if (!outcome.ok) throw outcome.error;
-			return outcome.value;
-		} catch (error) {
-			if (handle) throw error;
-			if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw new Error("coordinator_state_unreadable");
-
-			await reclaimStaleSessionStateLock(lockFile);
-			await Bun.sleep(5);
-		}
-	}
-	throw new Error("coordinator_state_unreadable");
+	return await withFileLock(stateFile, operation, { staleMs: 30_000, retries: 12_000, retryDelayMs: 5 });
 }
 
 async function writeSessionState(

--- a/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-sidecar.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
@@ -45,6 +45,8 @@ export type RuntimeState = "ready_for_input" | "running" | "needs_user_input" | 
 type FinalResponseSource = "agent_end" | "launch_error";
 const MAX_PUBLIC_ERROR_MESSAGE_LENGTH = 2000;
 const HEARTBEAT_MS = 1000;
+const MAX_PUBLIC_ACTIVE_TOOLS = 8;
+const SAFE_TOOL_NAME = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
 
 type LastPayloadCacheEntry = { mtimeMs: number; size: number; payload: Record<string, unknown> };
 const lastPayloadByStateFile = new Map<string, LastPayloadCacheEntry>();
@@ -61,6 +63,9 @@ export const __sessionStateSidecarPerfCounters = {
 interface RuntimeStateEvent {
 	type: string;
 	messages?: unknown[];
+	toolCallId?: unknown;
+	toolName?: unknown;
+	isError?: unknown;
 }
 
 export interface OwnerTerminalContext {
@@ -369,7 +374,95 @@ export function stateForEvent(event: RuntimeStateEvent): RuntimeState | null {
 }
 
 export function eventAffectsCoordinatorRuntimeState(event: RuntimeStateEvent): boolean {
-	return stateForEvent(event) !== null;
+	return stateForEvent(event) !== null || toolActivityForEvent(event) !== null;
+}
+
+function safeToolName(value: unknown): string {
+	return typeof value === "string" && SAFE_TOOL_NAME.test(value) ? value : "custom";
+}
+
+function toolActivityForEvent(
+	event: RuntimeStateEvent,
+):
+	| { phase: "started"; toolCallKey: string; toolName: string }
+	| { phase: "finished"; toolCallKey: string; toolName: string; outcome: "succeeded" | "failed" }
+	| null {
+	if (event.type !== "tool_execution_start" && event.type !== "tool_execution_end") return null;
+	if (typeof event.toolCallId !== "string") return null;
+	const toolCallKey = createHash("sha256").update(event.toolCallId).digest("hex");
+	if (event.type === "tool_execution_start")
+		return { phase: "started", toolCallKey, toolName: safeToolName(event.toolName) };
+	return {
+		phase: "finished",
+		toolCallKey,
+		toolName: safeToolName(event.toolName),
+		outcome: event.isError === true ? "failed" : "succeeded",
+	};
+}
+
+function runtimeStateFromPrevious(value: unknown): RuntimeState {
+	return value === "ready_for_input" ||
+		value === "running" ||
+		value === "needs_user_input" ||
+		value === "completed" ||
+		value === "errored"
+		? value
+		: "running";
+}
+
+function activityFieldsForEvent(
+	previous: Record<string, unknown>,
+	activityEvent: NonNullable<ReturnType<typeof toolActivityForEvent>>,
+	now: string,
+	nowMs: number,
+): Record<string, unknown> {
+	const activeToolCalls: Record<string, { tool_name: string; started_at: string }> = {};
+	const existing = previous.active_tool_calls;
+	if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+		for (const [key, value] of Object.entries(existing)) {
+			if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+			const entry = value as Record<string, unknown>;
+			if (typeof entry.tool_name !== "string" || typeof entry.started_at !== "string") continue;
+			if (!Number.isFinite(Date.parse(entry.started_at))) continue;
+			activeToolCalls[key] = { tool_name: safeToolName(entry.tool_name), started_at: entry.started_at };
+		}
+	}
+	const prior = activeToolCalls[activityEvent.toolCallKey];
+	if (activityEvent.phase === "started")
+		activeToolCalls[activityEvent.toolCallKey] = { tool_name: activityEvent.toolName, started_at: now };
+	else delete activeToolCalls[activityEvent.toolCallKey];
+	const previousActivity =
+		previous.activity && typeof previous.activity === "object" && !Array.isArray(previous.activity)
+			? (previous.activity as Record<string, unknown>)
+			: null;
+	const sequence =
+		previousActivity &&
+		typeof previousActivity.sequence === "number" &&
+		Number.isSafeInteger(previousActivity.sequence) &&
+		previousActivity.sequence >= 0
+			? Math.min(Number.MAX_SAFE_INTEGER, previousActivity.sequence + 1)
+			: 1;
+	const activeTools = Object.values(activeToolCalls)
+		.sort((left, right) => left.started_at.localeCompare(right.started_at))
+		.slice(0, MAX_PUBLIC_ACTIVE_TOOLS);
+	const startedAt = activityEvent.phase === "started" ? now : prior?.started_at;
+	const elapsedMs = startedAt ? Math.max(0, nowMs - Date.parse(startedAt)) : undefined;
+	return {
+		last_activity_at: now,
+		activity: {
+			sequence,
+			kind: "tool_execution",
+			phase: activityEvent.phase,
+			tool_name: activityEvent.toolName,
+			observed_at: now,
+			...(startedAt ? { started_at: startedAt } : {}),
+			...(elapsedMs === undefined ? {} : { elapsed_ms: elapsedMs }),
+			...(activityEvent.phase === "finished" ? { outcome: activityEvent.outcome } : {}),
+			active_tool_count: Object.keys(activeToolCalls).length,
+		},
+		active_tools: activeTools,
+		active_tool_calls: activeToolCalls,
+	};
 }
 
 class PreviousRuntimeStateReadError extends Error {
@@ -584,6 +677,16 @@ function basePayload(input: {
 		workdir: identity.workdir,
 		branch: branchForContext(input.context),
 		session_file: identity.sessionFile,
+		...(typeof input.previous.last_activity_at === "string"
+			? { last_activity_at: input.previous.last_activity_at }
+			: {}),
+		...(input.previous.activity && typeof input.previous.activity === "object"
+			? { activity: input.previous.activity }
+			: {}),
+		...(Array.isArray(input.previous.active_tools) ? { active_tools: input.previous.active_tools } : {}),
+		...(input.previous.active_tool_calls && typeof input.previous.active_tool_calls === "object"
+			? { active_tool_calls: input.previous.active_tool_calls }
+			: {}),
 		...(input.context.ownerTerminal ? { owner_generation: input.context.ownerTerminal.generation } : {}),
 	};
 }
@@ -784,8 +887,9 @@ export async function persistCoordinatorRuntimeStateFromEvent(
 ): Promise<void> {
 	__sessionStateSidecarPerfCounters.persistFromEventCalls += 1;
 	const stateFile = runtimeStateFileForContext(context);
-	const state = stateForEvent(event);
-	if (!stateFile || !state) return;
+	const eventState = stateForEvent(event);
+	const activityEvent = toolActivityForEvent(event);
+	if (!stateFile || (!eventState && !activityEvent)) return;
 	context = contextWithManagedOwnerGeneration(context);
 	const identity = normalizedIdentity(context);
 	await serializeStateFileWrite(
@@ -799,6 +903,7 @@ export async function persistCoordinatorRuntimeStateFromEvent(
 						const now = new Date(nowMs).toISOString();
 						const previous = await readPreviousPayloadForEvent(stateFile);
 						assertPreviousRuntimeStateIdentity(previous, identity);
+						const state = eventState ?? runtimeStateFromPrevious(previous.state);
 						const payload = {
 							...basePayload({
 								context,
@@ -815,6 +920,7 @@ export async function persistCoordinatorRuntimeStateFromEvent(
 							...(state === "errored"
 								? { error: { code: "agent_error", message: "GJC agent reported an error", recoverable: true } }
 								: {}),
+							...(activityEvent ? activityFieldsForEvent(previous, activityEvent, now, nowMs) : {}),
 						};
 						if (shouldSkipRuntimeStateWrite(previous, payload, nowMs)) return;
 						await writeStateFile(stateFile, payload);

--- a/packages/coding-agent/src/sdk/host/websocket-transport.ts
+++ b/packages/coding-agent/src/sdk/host/websocket-transport.ts
@@ -215,18 +215,22 @@ export async function createSdkWebSocketTransport(
 					});
 					await withFileLock(endpointFile, async () => {
 						try {
-							await filesystem.writeFile(
-								tempEndpointFile,
-								endpoint,
-								{ encoding: "utf8", mode: 0o600, flag: "wx" },
-							);
+							await filesystem.writeFile(tempEndpointFile, endpoint, {
+								encoding: "utf8",
+								mode: 0o600,
+								flag: "wx",
+							});
 						} catch (error) {
 							throw asLifecycleError("endpoint_write_failed", "SDK endpoint file publication failed.", error);
 						}
 						try {
 							await filesystem.chmod(tempEndpointFile, 0o600);
 						} catch (error) {
-							throw asLifecycleError("endpoint_chmod_failed", "SDK endpoint file permission update failed.", error);
+							throw asLifecycleError(
+								"endpoint_chmod_failed",
+								"SDK endpoint file permission update failed.",
+								error,
+							);
 						}
 						try {
 							await filesystem.rename(tempEndpointFile, endpointFile);

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -18584,7 +18584,7 @@ export class SessionManager {
 			const authority = nativeSessionManager().openRecoveryFsRoot(projectGjcDir);
 			try {
 				const observed = authority.stat(relativePath);
-				if (!observed.ok || !observed.identity || !observed.identity.sha256)
+				if (!observed.ok || !observed.identity?.sha256)
 					throw new Error("Project session is no longer an authorized candidate.");
 				const removed = authority.removeManaged(
 					relativePath,

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -410,6 +410,20 @@ describe("Coordinator MCP canonical SDK controls", () => {
 				source: "coordinator",
 				live: true,
 				reason: "Bearer session-state-secret",
+				last_activity_at: "2026-08-11T00:00:00.000Z",
+				activity: {
+					sequence: 4,
+					kind: "tool_execution",
+					phase: "started",
+					tool_name: "bash",
+					observed_at: "2026-08-11T00:00:00.000Z",
+					active_tool_count: 9,
+					private_args: "do not expose",
+				},
+				active_tools: [
+					{ tool_name: "bash", started_at: "2026-08-11T00:00:00.000Z", tool_call_id: "private-tool-id" },
+				],
+				active_tool_calls: { "private-tool-id": { tool_name: "bash", started_at: "2026-08-11T00:00:00.000Z" } },
 			}),
 		);
 		const status = await server.callTool("gjc_coordinator_read_status", { session_id: "visible-session" });
@@ -417,6 +431,11 @@ describe("Coordinator MCP canonical SDK controls", () => {
 			ok: true,
 			session: { session_id: "visible-session" },
 			status: { authority: "sdk_broker", live: true },
+			session_state: {
+				last_activity_at: "2026-08-11T00:00:00.000Z",
+				activity: { sequence: 4, tool_name: "bash", active_tool_count: 9 },
+				active_tools: [{ tool_name: "bash", started_at: "2026-08-11T00:00:00.000Z" }],
+			},
 		});
 		const publicResult = JSON.stringify(status);
 		expect(publicResult).not.toContain("broker-endpoint-secret");
@@ -424,6 +443,8 @@ describe("Coordinator MCP canonical SDK controls", () => {
 		expect(publicResult).not.toContain("session-endpoint-secret");
 		expect(publicResult).not.toContain("session-record-secret");
 		expect(publicResult).not.toContain("session-state-secret");
+		expect(publicResult).not.toContain("private-tool-id");
+		expect(publicResult).not.toContain("do not expose");
 		expect(publicResult).not.toContain(root);
 		expect(controls).toEqual([
 			{ operation: "session.list", input: { cwd: root }, idempotencyKey: undefined },
@@ -438,6 +459,59 @@ describe("Coordinator MCP canonical SDK controls", () => {
 			},
 			{ operation: "session.list", input: { cwd: root }, idempotencyKey: undefined },
 		]);
+		await expect(
+			server.callTool("gjc_coordinator_register_session", {
+				session_id: "visible-session",
+				cwd: root,
+				tmux_session: "visible-session",
+				tmux_target: "visible-session:0.0",
+				idempotency_key: "preserve-activity-registration",
+				allow_mutation: true,
+			}),
+		).resolves.toMatchObject({ ok: true });
+		const lifecyclePayload = JSON.parse(
+			await fs.readFile(
+				path.join(root, ".gjc", "coordinator-state", "local", "repo", "session-states", "visible-session.json"),
+				"utf8",
+			),
+		) as Record<string, unknown>;
+		expect(lifecyclePayload).toMatchObject({
+			last_activity_at: "2026-08-11T00:00:00.000Z",
+			activity: { sequence: 4, active_tool_count: 9 },
+			active_tools: [{ tool_name: "bash", started_at: "2026-08-11T00:00:00.000Z" }],
+			active_tool_calls: { "private-tool-id": { tool_name: "bash", started_at: "2026-08-11T00:00:00.000Z" } },
+		});
+		const sent = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "complete and repair projections",
+			idempotency_key: "repair-activity-turn",
+			allow_mutation: true,
+		});
+		const turnId = (sent as { turn_id?: unknown }).turn_id;
+		if (typeof turnId !== "string") throw new Error("expected turn id");
+		await expect(
+			server.callTool("gjc_coordinator_report_status", {
+				session_id: "visible-session",
+				turn_id: turnId,
+				status: "completed",
+				summary: "repaired terminal projection",
+				idempotency_key: "repair-activity-terminal",
+				allow_mutation: true,
+			}),
+		).resolves.toMatchObject({ ok: true });
+		const repairedPayload = JSON.parse(
+			await fs.readFile(
+				path.join(root, ".gjc", "coordinator-state", "local", "repo", "session-states", "visible-session.json"),
+				"utf8",
+			),
+		) as Record<string, unknown>;
+		expect(repairedPayload).toMatchObject({
+			state: "completed",
+			last_activity_at: "2026-08-11T00:00:00.000Z",
+			activity: { sequence: 4, active_tool_count: 9 },
+			active_tools: [{ tool_name: "bash", started_at: "2026-08-11T00:00:00.000Z" }],
+			active_tool_calls: { "private-tool-id": { tool_name: "bash", started_at: "2026-08-11T00:00:00.000Z" } },
+		});
 	});
 	it("marks lifecycle-created sessions ready after successful SDK lifecycle binding", async () => {
 		const root = await tempRoot();

--- a/packages/coding-agent/test/session-state-sidecar.test.ts
+++ b/packages/coding-agent/test/session-state-sidecar.test.ts
@@ -153,14 +153,102 @@ describe("coordinator runtime state sidecar", () => {
 			{ event: { type: "message_update", message: {}, assistantMessageEvent: {} }, affects: false },
 			{ event: { type: "notice", level: "info", message: "background notice" }, affects: false },
 			{ event: { type: "turn_start" }, affects: true },
+			{ event: { type: "tool_execution_start", toolCallId: "tool-1", toolName: "bash" }, affects: true },
+			{ event: { type: "tool_execution_end", toolCallId: "tool-1", toolName: "bash" }, affects: true },
 			{ event: { type: "agent_start" }, affects: true },
 			{ event: { type: "agent_end", messages: [] }, affects: true },
 		] as const;
 
 		for (const { event, affects } of events) {
 			expect(eventAffectsCoordinatorRuntimeState(event as never)).toBe(affects);
-			expect(eventAffectsCoordinatorRuntimeState(event as never)).toBe(stateForEvent(event as never) !== null);
 		}
+		expect(stateForEvent({ type: "tool_execution_start", toolCallId: "tool-1", toolName: "bash" })).toBeNull();
+	});
+
+	it("persists bounded public-safe tool activity while preserving lifecycle state", async () => {
+		const root = await tempRoot();
+		const stateFile = path.join(root, "state.json");
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "activity-session";
+		try {
+			setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+			await persistCoordinatorRuntimeStateFromEvent(
+				{ type: "turn_start" },
+				{ sessionId: "fallback", cwd: root, sessionFile: null },
+			);
+			setSystemTime(new Date("2026-01-01T00:00:01.000Z"));
+			await persistCoordinatorRuntimeStateFromEvent(
+				{ type: "tool_execution_start", toolCallId: "private-tool-call-id", toolName: "bash" },
+				{ sessionId: "fallback", cwd: root, sessionFile: null },
+			);
+			setSystemTime(new Date("2026-01-01T00:00:03.500Z"));
+			await persistCoordinatorRuntimeStateFromEvent(
+				{ type: "tool_execution_end", toolCallId: "private-tool-call-id", toolName: "bad\nlabel", isError: true },
+				{ sessionId: "fallback", cwd: root, sessionFile: null },
+			);
+
+			const payload = await readJson(stateFile);
+			expect(payload).toMatchObject({
+				state: "running",
+				last_activity_at: "2026-01-01T00:00:03.500Z",
+				activity: {
+					sequence: 2,
+					kind: "tool_execution",
+					phase: "finished",
+					tool_name: "custom",
+					started_at: "2026-01-01T00:00:01.000Z",
+					elapsed_ms: 2500,
+					outcome: "failed",
+					active_tool_count: 0,
+				},
+				active_tools: [],
+			});
+			expect(JSON.stringify(payload.active_tools)).not.toContain("private-tool-call-id");
+		} finally {
+			setSystemTime();
+		}
+	});
+
+	it("keeps the active-tool count truthful when the public list is bounded", async () => {
+		const root = await tempRoot();
+		const stateFile = path.join(root, "state.json");
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "bounded-activity-session";
+		for (let index = 0; index < 9; index++)
+			await persistCoordinatorRuntimeStateFromEvent(
+				{ type: "tool_execution_start", toolCallId: `tool-${index}`, toolName: "read" },
+				{ sessionId: "fallback", cwd: root, sessionFile: null },
+			);
+
+		const payload = await readJson(stateFile);
+		expect(payload.activity).toMatchObject({ sequence: 9, active_tool_count: 9 });
+		expect(payload.active_tools).toHaveLength(8);
+	});
+
+	it("saturates an exhausted activity sequence without wrapping", async () => {
+		const root = await tempRoot();
+		const stateFile = path.join(root, "state.json");
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		process.env[GJC_COORDINATOR_SESSION_ID_ENV] = "saturated-activity-session";
+		await Bun.write(
+			stateFile,
+			JSON.stringify({
+				schema_version: 1,
+				session_id: "saturated-activity-session",
+				state: "running",
+				cwd: root,
+				workdir: root,
+				session_file: null,
+				activity: { sequence: Number.MAX_SAFE_INTEGER },
+			}),
+		);
+
+		await persistCoordinatorRuntimeStateFromEvent(
+			{ type: "tool_execution_start", toolCallId: "tool-1", toolName: "read" },
+			{ sessionId: "fallback", cwd: root, sessionFile: null },
+		);
+
+		expect((await readJson(stateFile)).activity).toMatchObject({ sequence: Number.MAX_SAFE_INTEGER });
 	});
 
 	it("skips duplicate same-state running writes within the heartbeat", async () => {


### PR DESCRIPTION
## Summary
- persist a bounded, safe tool-activity snapshot in coordinator session state
- expose only allowlisted activity fields via `gjc_coordinator_read_status`
- retain snapshots through lifecycle and canonical projection repair

## Validation
- `bun test packages/coding-agent/test/session-state-sidecar.test.ts`
- `bun test packages/coding-agent/test/coordinator-mcp-server.test.ts -t "uses agent-global SDK discovery and returns credential-free broker status"`
- `bun --cwd=packages/coding-agent run check:types`

Full coordinator MCP testing is blocked locally because the native addon is unavailable; rebuilding it exhausts disk space.

Fixes #4195

*Signed: gaebal-gajae*