### PR TITLE
fix(sdk): fence endpoint cleanup by publication ownership

### DIFF
--- a/packages/coding-agent/src/sdk/host/websocket-transport.lifecycle.test.ts
+++ b/packages/coding-agent/src/sdk/host/websocket-transport.lifecycle.test.ts
@@ -72,6 +72,7 @@ describe("SDK WebSocket transport lifecycle", () => {
 					await releaseRename.promise;
 					await fs.rename(from, to);
 				},
+				readFile: fs.readFile,
 				rm: fs.rm,
 			},
 		});
@@ -186,7 +187,7 @@ describe("SDK WebSocket transport lifecycle", () => {
 		try {
 			const first = await transport.start();
 			const stopPromise = transport.stop();
-			await Bun.sleep(0);
+			for (let attempt = 0; attempt < 100 && !stopEntered; attempt += 1) await Bun.sleep(1);
 			expect(stopEntered).toBe(true);
 			let secondResolved = false;
 			const secondPromise = transport.start().then(endpoint => {
@@ -227,6 +228,7 @@ describe("SDK WebSocket transport lifecycle", () => {
 					throw Object.assign(new Error("chmod injected failure"), { code: "EACCES" });
 				},
 				rename: real.rename,
+				readFile: real.readFile,
 				rm: real.rm,
 			},
 		};
@@ -244,6 +246,85 @@ describe("SDK WebSocket transport lifecycle", () => {
 		await fs.rm(stateRoot, { recursive: true, force: true });
 	});
 
+	test("failed duplicate startup preserves a canonical endpoint it did not publish", async () => {
+		const stateRoot = await tempStateRoot();
+		const endpointPath = path.join(stateRoot, "sdk", "duplicate-cleanup.json");
+		await fs.mkdir(path.dirname(endpointPath), { recursive: true });
+		const canonicalEndpoint = JSON.stringify({
+			version: 1,
+			sessionId: "duplicate-cleanup",
+			url: "ws://127.0.0.1:12345/",
+			token: "canonical-token",
+			pid: process.pid,
+		});
+		await fs.writeFile(endpointPath, canonicalEndpoint, { mode: 0o600 });
+		const transport = await createSdkWebSocketTransport({
+			sessionId: "duplicate-cleanup",
+			stateRoot,
+			token: "duplicate-token",
+			filesystem: {
+				mkdir: fs.mkdir,
+				writeFile: async () => {
+					throw Object.assign(new Error("duplicate startup failed"), { code: "EIO" });
+				},
+				chmod: fs.chmod,
+				rename: fs.rename,
+				readFile: fs.readFile,
+				rm: fs.rm,
+			},
+		});
+		try {
+			await expect(transport.start()).rejects.toMatchObject({ code: "endpoint_write_failed" });
+			expect(await fs.readFile(endpointPath, "utf8")).toBe(canonicalEndpoint);
+		} finally {
+			await transport.stop();
+			await fs.rm(stateRoot, { recursive: true, force: true });
+		}
+	});
+
+	test("serializes a successor publication behind an owner endpoint cleanup", async () => {
+		const stateRoot = await tempStateRoot();
+		const sessionId = "serialized-cleanup";
+		const endpointPath = path.join(stateRoot, "sdk", `${sessionId}.json`);
+		const readEntered = Promise.withResolvers<void>();
+		const releaseRead = Promise.withResolvers<void>();
+		const owner = await createSdkWebSocketTransport({
+			sessionId,
+			stateRoot,
+			token: "owner-token",
+			filesystem: {
+				mkdir: fs.mkdir,
+				writeFile: fs.writeFile,
+				chmod: fs.chmod,
+				rename: fs.rename,
+				readFile: (async (...args: Parameters<typeof fs.readFile>) => {
+					readEntered.resolve();
+					await releaseRead.promise;
+					return await fs.readFile(...args);
+				}) as typeof fs.readFile,
+				rm: fs.rm,
+			},
+		});
+		const successor = await createSdkWebSocketTransport({ sessionId, stateRoot, token: "successor-token" });
+		try {
+			await owner.start();
+			const stop = owner.stop();
+			await readEntered.promise;
+			const start = successor.start();
+			await Bun.sleep(20);
+			expect(JSON.parse(await fs.readFile(endpointPath, "utf8"))).toMatchObject({ token: "owner-token" });
+			releaseRead.resolve();
+			await stop;
+			await start;
+			expect(JSON.parse(await fs.readFile(endpointPath, "utf8"))).toMatchObject({ token: "successor-token" });
+		} finally {
+			releaseRead.resolve();
+			await owner.stop().catch(() => undefined);
+			await successor.stop().catch(() => undefined);
+			await fs.rm(stateRoot, { recursive: true, force: true });
+		}
+	});
+
 	test("endpoint removal failures are typed and do not prevent server release", async () => {
 		const stateRoot = await tempStateRoot();
 		let rmCalls = 0;
@@ -254,6 +335,7 @@ describe("SDK WebSocket transport lifecycle", () => {
 				writeFile: real.writeFile,
 				chmod: real.chmod,
 				rename: real.rename,
+				readFile: real.readFile,
 				rm: async (...args: Parameters<typeof real.rm>) => {
 					rmCalls += 1;
 					if (rmCalls === 1) throw Object.assign(new Error("rm injected failure"), { code: "EIO" });

--- a/packages/coding-agent/src/sdk/host/websocket-transport.ts
+++ b/packages/coding-agent/src/sdk/host/websocket-transport.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { withFileLock } from "../../config/file-lock";
 import type { SessionSdkTransport } from "./session-runtime";
 import type { SdkFrame } from "./types";
 
@@ -8,7 +9,7 @@ type SocketData = { connectionId: string };
 type Socket = { readonly data: SocketData; send(message: string): void; close(): void; terminate?(): void };
 
 export interface SdkWebSocketTransportDependencies {
-	readonly filesystem?: Pick<typeof fs, "mkdir" | "writeFile" | "chmod" | "rename" | "rm">;
+	readonly filesystem?: Pick<typeof fs, "mkdir" | "writeFile" | "chmod" | "rename" | "readFile" | "rm">;
 	readonly serve?: typeof Bun.serve;
 }
 type SdkServer = ReturnType<typeof Bun.serve<SocketData>>;
@@ -70,6 +71,7 @@ export async function createSdkWebSocketTransport(
 	let started = false;
 	let startPromise: Promise<{ url: string }> | undefined;
 	let stopPromise: Promise<void> | undefined;
+	let publishedEndpoint: string | undefined;
 
 	const stopServer = async (current: SdkServer): Promise<void> => {
 		try {
@@ -96,10 +98,18 @@ export async function createSdkWebSocketTransport(
 		if (current) await stopServer(current);
 	};
 
-	const removeEndpoint = async (): Promise<void> => {
+	const removePublishedEndpoint = async (): Promise<void> => {
+		if (publishedEndpoint === undefined) return;
 		try {
+			const endpoint = await filesystem.readFile(endpointFile, "utf8");
+			if (endpoint !== publishedEndpoint) return;
 			await filesystem.rm(endpointFile, { force: true });
+			publishedEndpoint = undefined;
 		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+				publishedEndpoint = undefined;
+				return;
+			}
 			throw asLifecycleError("endpoint_remove_failed", "SDK endpoint file removal failed.", error);
 		}
 	};
@@ -196,31 +206,35 @@ export async function createSdkWebSocketTransport(
 					});
 					server = localServer;
 					const url = endpointUrl(localServer);
-					try {
-						await filesystem.writeFile(
-							tempEndpointFile,
-							JSON.stringify({
-								version: 1,
-								sessionId: input.sessionId,
-								url,
-								token: input.token,
-								pid: process.pid,
-							}),
-							{ encoding: "utf8", mode: 0o600, flag: "wx" },
-						);
-					} catch (error) {
-						throw asLifecycleError("endpoint_write_failed", "SDK endpoint file publication failed.", error);
-					}
-					try {
-						await filesystem.chmod(tempEndpointFile, 0o600);
-					} catch (error) {
-						throw asLifecycleError("endpoint_chmod_failed", "SDK endpoint file permission update failed.", error);
-					}
-					try {
-						await filesystem.rename(tempEndpointFile, endpointFile);
-					} catch (error) {
-						throw asLifecycleError("endpoint_write_failed", "SDK endpoint file publication failed.", error);
-					}
+					const endpoint = JSON.stringify({
+						version: 1,
+						sessionId: input.sessionId,
+						url,
+						token: input.token,
+						pid: process.pid,
+					});
+					await withFileLock(endpointFile, async () => {
+						try {
+							await filesystem.writeFile(
+								tempEndpointFile,
+								endpoint,
+								{ encoding: "utf8", mode: 0o600, flag: "wx" },
+							);
+						} catch (error) {
+							throw asLifecycleError("endpoint_write_failed", "SDK endpoint file publication failed.", error);
+						}
+						try {
+							await filesystem.chmod(tempEndpointFile, 0o600);
+						} catch (error) {
+							throw asLifecycleError("endpoint_chmod_failed", "SDK endpoint file permission update failed.", error);
+						}
+						try {
+							await filesystem.rename(tempEndpointFile, endpointFile);
+						} catch (error) {
+							throw asLifecycleError("endpoint_write_failed", "SDK endpoint file publication failed.", error);
+						}
+						publishedEndpoint = endpoint;
+					});
 					started = true;
 					return { url };
 				} catch (error) {
@@ -238,11 +252,6 @@ export async function createSdkWebSocketTransport(
 						failures.push(
 							asLifecycleError("endpoint_remove_failed", "SDK endpoint temp file removal failed.", cleanupError),
 						);
-					}
-					try {
-						await removeEndpoint();
-					} catch (cleanupError) {
-						failures.push(cleanupError);
 					}
 					started = false;
 					server = undefined;
@@ -268,12 +277,10 @@ export async function createSdkWebSocketTransport(
 				if (startPromise) await startPromise.catch(() => undefined);
 				const failures: unknown[] = [];
 				try {
-					await closeServer();
-				} catch (error) {
-					failures.push(error);
-				}
-				try {
-					await removeEndpoint();
+					await withFileLock(endpointFile, async () => {
+						await closeServer();
+						await removePublishedEndpoint();
+					});
 				} catch (error) {
 					failures.push(error);
 				}


### PR DESCRIPTION
Fixes #4146.

A failed duplicate TypeScript SDK transport startup previously performed unconditional endpoint cleanup. That could delete a canonical discovery record published by another transport, recreating the reported uncontrollable/disappearing discovery failure.

This change records the exact discovery payload published by each transport and removes the endpoint only when that payload is still present. Failed startup therefore only removes its private temporary file and server; it cannot retract an endpoint it never published.

## Verification

- `TMPDIR="$PWD/.tmp" bun test packages/coding-agent/src/sdk/host/websocket-transport.lifecycle.test.ts` — 8 pass
- `TMPDIR="$PWD/.tmp" bun test packages/coding-agent/test/sdk-session-index.test.ts` — 51 pass
- `TMPDIR="$PWD/.tmp" bun test packages/coding-agent/test/sdk-host-wiring.test.ts --test-name-pattern 'late Telegram ownership races preserve the published canonical core endpoint'` — 1 pass\n- `bun --cwd=packages/coding-agent run check:types` — pass\n\nThe broader three-file command reached 153 passing tests, then hit a pre-existing unrelated `diff queries return typed errors outside a Git working tree` fixture failure in `sdk-host-wiring.test.ts`; the affected ownership test passes in isolation.\n\n—\n*[repo owner\x27s gaebal-gajae (clawdbot) 🦞]*