### PR TITLE
fix(lint): clear two dev-inherent biome findings blocking root-check

### DIFF
--- a/packages/coding-agent/src/sdk/host/websocket-transport.ts
+++ b/packages/coding-agent/src/sdk/host/websocket-transport.ts
@@ -215,18 +215,22 @@ export async function createSdkWebSocketTransport(
 					});
 					await withFileLock(endpointFile, async () => {
 						try {
-							await filesystem.writeFile(
-								tempEndpointFile,
-								endpoint,
-								{ encoding: "utf8", mode: 0o600, flag: "wx" },
-							);
+							await filesystem.writeFile(tempEndpointFile, endpoint, {
+								encoding: "utf8",
+								mode: 0o600,
+								flag: "wx",
+							});
 						} catch (error) {
 							throw asLifecycleError("endpoint_write_failed", "SDK endpoint file publication failed.", error);
 						}
 						try {
 							await filesystem.chmod(tempEndpointFile, 0o600);
 						} catch (error) {
-							throw asLifecycleError("endpoint_chmod_failed", "SDK endpoint file permission update failed.", error);
+							throw asLifecycleError(
+								"endpoint_chmod_failed",
+								"SDK endpoint file permission update failed.",
+								error,
+							);
 						}
 						try {
 							await filesystem.rename(tempEndpointFile, endpointFile);

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -18584,7 +18584,7 @@ export class SessionManager {
 			const authority = nativeSessionManager().openRecoveryFsRoot(projectGjcDir);
 			try {
 				const observed = authority.stat(relativePath);
-				if (!observed.ok || !observed.identity || !observed.identity.sha256)
+				if (!observed.ok || !observed.identity?.sha256)
 					throw new Error("Project session is no longer an authorized candidate.");
 				const removed = authority.removeManaged(
 					relativePath,


### PR DESCRIPTION
Dev's own CI and every PR currently fail check:tools on two biome findings in files that are byte-identical to dev: session-manager.ts:18587 (lint/complexity/useOptionalChain — redundant non-null guard before `observed.identity.sha256`) and websocket-transport.ts (formatter-different long throw expression). This blocks root-check and check:@gajae-code/coding-agent on all PRs.

This PR applies the exact biome-suggested fixes. check:tools exits 0 after; websocket-transport lifecycle and session suites pass.