### PR TITLE
fix(ai): drop stale signature from clear_thinking emptied thinking blocks (#4247)

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2396,12 +2396,15 @@ function latestAssistantThinkingIsUnreplayable(messages: Message[], model: Model
 		if (block.type !== "thinking") return false;
 		// A block with empty text and no signature cannot go back on the wire:
 		// `convertAnthropicMessages` drops it, and Anthropic rejects the turn for
-		// arriving without it. A block with a valid signature is replayable even
-		// when the text is empty, and non-signing endpoints replay unsigned blocks
-		// verbatim, so only signing endpoints treat a missing signature as
-		// unreplayable.
+		// arriving without it. A block with a valid signature AND non-empty text is
+		// replayable. But a signed block whose text was emptied — e.g. by
+		// clear_thinking_20251015 — carries a stale signature that signing endpoints
+		// reject on replay (issue #4247). Non-signing endpoints replay unsigned
+		// blocks verbatim, so only they treat a missing signature as unreplayable.
 		const hasSignature = !!block.thinkingSignature?.trim();
+		const isEmpty = !block.thinking.trim();
 		if (!hasSignature) return requiresSignature;
+		if (isEmpty && requiresSignature) return true;
 		return false;
 	});
 }

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -98,8 +98,15 @@ export function transformMessages<TApi extends Api>(
 					if (dropAssistantThinkingForRepair && replaysAsNativeThinking) return [];
 					if (mustPreserveLatestAnthropicThinking) return sanitized;
 					// For same model: keep thinking blocks with signatures (needed for replay)
-					// even if the thinking text is empty (OpenAI encrypted reasoning)
-					if (isSameModel && sanitized.thinkingSignature) return sanitized;
+					// even if the thinking text is empty — but only for non-Anthropic APIs where
+					// the signature represents OpenAI encrypted reasoning. For anthropic-messages,
+					// a signed block with empty text means clear_thinking_20251015 stripped the
+					// content server-side while the stale signature remained; replaying it
+					// produces `thinking ... cannot be modified` 400s on every turn (#4247).
+					if (isSameModel && sanitized.thinkingSignature) {
+						if (sanitized.thinking.trim() === "" && model.api === "anthropic-messages") return [];
+						return sanitized;
+					}
 					// Skip empty thinking blocks, convert others to plain text
 					if (!sanitized.thinking || sanitized.thinking.trim() === "") return [];
 					if (isSameModel) return sanitized;

--- a/packages/ai/test/anthropic-unreplayable-thinking.test.ts
+++ b/packages/ai/test/anthropic-unreplayable-thinking.test.ts
@@ -88,7 +88,8 @@ const user: UserMessage = { role: "user", content: "go", timestamp: Date.now() }
 const HOLLOW_THINKING = { type: "thinking" as const, thinking: "", thinkingSignature: "" };
 const SIGNED_EARLY = { type: "thinking" as const, thinking: "early reasoning", thinkingSignature: "sig_early" };
 const SIGNED_LATE = { type: "thinking" as const, thinking: "late reasoning", thinkingSignature: "sig_late" };
-/** A block with empty text but a valid signature — natively replayable via the signed-thinking path. */
+/** A block with empty text but a valid signature — stale after clear_thinking_20251015.
+ *  Signing Anthropic endpoints must treat this as unreplayable (issue #4247). */
 const SIGNED_EMPTY = { type: "thinking" as const, thinking: "", thinkingSignature: "sig_empty" };
 
 function nativeThinkingCount(payload: { messages: unknown[] }): number {
@@ -169,7 +170,7 @@ describe("Anthropic unreplayable latest-assistant thinking", () => {
 		expect(JSON.stringify(payload.messages)).toContain("sig_early");
 	});
 
-	it("does not degrade when the latest turn has signed-but-empty thinking", async () => {
+	it("degrades when the latest turn has signed-but-empty thinking (clear_thinking)", async () => {
 		const payload = await capturePayload([
 			user,
 			assistantTurn([SIGNED_EARLY], "toolu_a"),
@@ -179,10 +180,46 @@ describe("Anthropic unreplayable latest-assistant thinking", () => {
 			toolResult("toolu_b"),
 		]);
 
-		// A block with empty text but a valid signature is natively replayable —
-		// convertAnthropicMessages forwards it via the signed-thinking path — so
-		// both signed blocks are preserved.
-		expect(nativeThinkingCount(payload)).toBe(2);
-		expect(JSON.stringify(payload.messages)).toContain("sig_empty");
+		// A signed block whose text was emptied by clear_thinking_20251015 carries
+		// a stale signature. Signing endpoints reject it, so the pre-emptive local
+		// degrade drops all native thinking from the replay (issue #4247).
+		expect(nativeThinkingCount(payload)).toBe(0);
+		expect(JSON.stringify(payload.messages)).not.toContain("sig_empty");
+		expect(JSON.stringify(payload.messages)).not.toContain("sig_early");
+	});
+
+	it("drops signed-empty historical thinking on signing endpoints (clear_thinking)", async () => {
+		const payload = await capturePayload([
+			user,
+			assistantTurn([SIGNED_EMPTY], "toolu_a"),
+			toolResult("toolu_a"),
+			{ ...user, content: "again", timestamp: Date.now() + 1 },
+			assistantTurn([SIGNED_LATE], "toolu_b"),
+			toolResult("toolu_b"),
+		]);
+
+		// The historical signed-empty block is dropped by transform-messages, so it
+		// never reaches the wire. The latest turn's valid signed thinking survives.
+		expect(JSON.stringify(payload.messages)).not.toContain("sig_empty");
+		expect(JSON.stringify(payload.messages)).toContain("sig_late");
+		expect(nativeThinkingCount(payload)).toBe(1);
+	});
+
+	it("does not degrade a non-signing endpoint whose latest turn has signed-empty thinking", async () => {
+		const payload = await capturePayload(
+			[
+				user,
+				assistantTurn([SIGNED_EARLY], "toolu_a", deepseekModel),
+				toolResult("toolu_a"),
+				{ ...user, content: "again", timestamp: Date.now() + 1 },
+				assistantTurn([SIGNED_EMPTY], "toolu_b", deepseekModel),
+				toolResult("toolu_b"),
+			],
+			deepseekModel,
+		);
+
+		// DeepSeek does not sign thinking and does not validate thinking presence.
+		// Signed-empty blocks are harmless on non-signing endpoints.
+		expect(JSON.stringify(payload.messages)).toContain("sig_early");
 	});
 });

--- a/packages/ai/test/transform-messages-clear-thinking.test.ts
+++ b/packages/ai/test/transform-messages-clear-thinking.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "bun:test";
+import { transformMessages } from "@gajae-code/ai/providers/transform-messages";
+import type { AssistantMessage, Message, Model, ToolResultMessage, UserMessage } from "@gajae-code/ai/types";
+
+// ---------------------------------------------------------------------------
+// Issue #4247: replayed thinking blocks emptied by clear_thinking_20251015
+// keep their stale signature and 400 every request. These tests verify the
+// transform-messages layer drops signed-empty thinking for anthropic-messages
+// replay while preserving it for non-Anthropic APIs (OpenAI encrypted reasoning).
+// ---------------------------------------------------------------------------
+
+const anthropicModel: Model<"anthropic-messages"> = {
+	api: "anthropic-messages",
+	provider: "anthropic",
+	id: "claude-opus-5",
+	name: "Claude Opus 5",
+	baseUrl: "https://api.anthropic.com",
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	maxTokens: 8_192,
+	contextWindow: 200_000,
+	reasoning: true,
+};
+
+const openaiResponsesModel: Model<"openai-responses"> = {
+	api: "openai-responses",
+	provider: "openai",
+	id: "o3",
+	name: "o3",
+	baseUrl: "https://api.openai.com",
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	maxTokens: 8_192,
+	contextWindow: 200_000,
+	reasoning: true,
+};
+
+const usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+const user: UserMessage = { role: "user", content: "go", timestamp: Date.now() };
+
+function assistantTurn(
+	content: AssistantMessage["content"],
+	activeModel: Model<AssistantMessage["api"]>,
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [...content, { type: "toolCall", id: "toolu_1", name: "bash", arguments: { command: "echo hi" } }],
+		api: activeModel.api,
+		provider: activeModel.provider,
+		model: activeModel.id,
+		usage,
+		stopReason: "toolUse",
+		timestamp: Date.now(),
+	};
+}
+
+function toolResult(): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: "toolu_1",
+		toolName: "bash",
+		content: [{ type: "text", text: "hi" }],
+		isError: false,
+		timestamp: Date.now(),
+	} as ToolResultMessage;
+}
+
+const SIGNED_FULL = { type: "thinking" as const, thinking: "real reasoning", thinkingSignature: "sig_full" };
+const SIGNED_EMPTY = { type: "thinking" as const, thinking: "", thinkingSignature: "sig_empty" };
+const UNSIGNED_EMPTY = { type: "thinking" as const, thinking: "", thinkingSignature: undefined };
+const UNSIGNED_FULL = { type: "thinking" as const, thinking: "unsigned reasoning", thinkingSignature: undefined };
+
+function thinkingBlocks(messages: Message[]): Array<{ thinking: string; signature?: string }> {
+	const blocks: Array<{ thinking: string; signature?: string }> = [];
+	for (const msg of messages) {
+		if (msg.role !== "assistant") continue;
+		for (const block of msg.content) {
+			if (block.type === "thinking") {
+				blocks.push({ thinking: block.thinking, signature: block.thinkingSignature });
+			}
+		}
+	}
+	return blocks;
+}
+
+describe("transform-messages clear_thinking signed-empty blocks (#4247)", () => {
+	it("drops signed-empty thinking for anthropic-messages historical replay", () => {
+		const messages: Message[] = [
+			user,
+			assistantTurn([SIGNED_EMPTY], anthropicModel),
+			toolResult(),
+			{ ...user, content: "again", timestamp: Date.now() + 1 },
+			assistantTurn([SIGNED_FULL], anthropicModel),
+			toolResult(),
+		];
+
+		const result = transformMessages(messages, anthropicModel);
+		const blocks = thinkingBlocks(result);
+
+		// Historical signed-empty dropped; latest signed-full preserved.
+		expect(blocks).toHaveLength(1);
+		expect(blocks[0].signature).toBe("sig_full");
+	});
+
+	it("preserves signed-empty thinking for openai-responses replay (encrypted reasoning)", () => {
+		const messages: Message[] = [
+			user,
+			assistantTurn([SIGNED_EMPTY], openaiResponsesModel),
+			toolResult(),
+			{ ...user, content: "again", timestamp: Date.now() + 1 },
+			assistantTurn([SIGNED_FULL], openaiResponsesModel),
+			toolResult(),
+		];
+
+		const result = transformMessages(messages, openaiResponsesModel);
+		const blocks = thinkingBlocks(result);
+
+		// Both preserved: OpenAI encrypted reasoning allows signed-empty blocks.
+		expect(blocks).toHaveLength(2);
+		expect(blocks.some(b => b.signature === "sig_empty")).toBe(true);
+		expect(blocks.some(b => b.signature === "sig_full")).toBe(true);
+	});
+
+	it("preserves valid signed thinking with non-empty text for anthropic-messages", () => {
+		const messages: Message[] = [user, assistantTurn([SIGNED_FULL], anthropicModel), toolResult()];
+
+		const result = transformMessages(messages, anthropicModel);
+		const blocks = thinkingBlocks(result);
+
+		expect(blocks).toHaveLength(1);
+		expect(blocks[0].thinking).toBe("real reasoning");
+		expect(blocks[0].signature).toBe("sig_full");
+	});
+
+	it("drops unsigned-empty thinking for anthropic-messages historical replay", () => {
+		const messages: Message[] = [
+			user,
+			assistantTurn([UNSIGNED_EMPTY], anthropicModel),
+			toolResult(),
+			{ ...user, content: "again", timestamp: Date.now() + 1 },
+			assistantTurn([SIGNED_FULL], anthropicModel),
+			toolResult(),
+		];
+
+		const result = transformMessages(messages, anthropicModel);
+		// Historical unsigned-empty is dropped; only latest SIGNED_FULL survives.
+		expect(thinkingBlocks(result)).toHaveLength(1);
+	});
+
+	it("converts unsigned non-empty thinking to text for cross-model anthropic replay", () => {
+		const messages: Message[] = [user, assistantTurn([UNSIGNED_FULL], openaiResponsesModel), toolResult()];
+
+		const result = transformMessages(messages, anthropicModel);
+		const blocks = thinkingBlocks(result);
+
+		// Cross-model: unsigned thinking degrades to text, no native thinking block.
+		expect(blocks).toHaveLength(0);
+		expect(
+			result.some(
+				msg =>
+					msg.role === "assistant" &&
+					msg.content.some(b => b.type === "text" && (b as { text: string }).text === "unsigned reasoning"),
+			),
+		).toBe(true);
+	});
+
+	it("drops all signed-empty blocks across multiple historical turns for anthropic-messages", () => {
+		const messages: Message[] = [
+			user,
+			assistantTurn([SIGNED_EMPTY], anthropicModel),
+			toolResult(),
+			{ ...user, content: "turn 2", timestamp: Date.now() + 1 },
+			assistantTurn([SIGNED_EMPTY, SIGNED_FULL], anthropicModel),
+			toolResult(),
+			{ ...user, content: "turn 3", timestamp: Date.now() + 2 },
+			assistantTurn([SIGNED_FULL], anthropicModel),
+			toolResult(),
+		];
+
+		const result = transformMessages(messages, anthropicModel);
+		const blocks = thinkingBlocks(result);
+
+		// Two SIGNED_FULL blocks survive (one historical, one latest); two SIGNED_EMPTY dropped.
+		expect(blocks).toHaveLength(2);
+		expect(blocks.every(b => b.signature === "sig_full")).toBe(true);
+		expect(blocks.some(b => b.signature === "sig_empty")).toBe(false);
+	});
+
+	it("handles whitespace-only signed thinking as empty for anthropic-messages historical replay", () => {
+		const whitespaceSigned = { type: "thinking" as const, thinking: "   \n\t  ", thinkingSignature: "sig_ws" };
+		const messages: Message[] = [
+			user,
+			assistantTurn([whitespaceSigned], anthropicModel),
+			toolResult(),
+			{ ...user, content: "again", timestamp: Date.now() + 1 },
+			assistantTurn([SIGNED_FULL], anthropicModel),
+			toolResult(),
+		];
+
+		const result = transformMessages(messages, anthropicModel);
+		// Whitespace-only signed block dropped as empty; latest SIGNED_FULL survives.
+		expect(thinkingBlocks(result)).toHaveLength(1);
+		expect(thinkingBlocks(result)[0].signature).toBe("sig_full");
+	});
+
+	it("preserves whitespace-only signed thinking for openai-responses (encrypted reasoning)", () => {
+		const whitespaceSigned = { type: "thinking" as const, thinking: "   \n\t  ", thinkingSignature: "sig_ws" };
+		const messages: Message[] = [user, assistantTurn([whitespaceSigned], openaiResponsesModel), toolResult()];
+
+		const result = transformMessages(messages, openaiResponsesModel);
+		const blocks = thinkingBlocks(result);
+
+		expect(blocks).toHaveLength(1);
+		expect(blocks[0].signature).toBe("sig_ws");
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #4247

`clear_thinking_20251015` strips thinking text server-side but leaves the original signature in the persisted block. When `gjc` replays that history, it sends `{thinking: "", signature: "<stale>"}` — a modified block that Anthropic rejects with `thinking ... cannot be modified` on **every** subsequent turn. The failure is deterministic, not intermittent.

Evidence from the issue: 39 of 96 thinking blocks are empty-with-signature in one conversation; 61 of 111 in another. In every dump the emptied blocks originate in `gjc`, not in the CPA proxy.

## Root cause

Two code paths assumed signed-empty thinking blocks are always replayable:

1. **`transform-messages.ts:100-104`** — `isSameModel && thinkingSignature` returned the block for all same-model replays, including `anthropic-messages`. This was correct for OpenAI encrypted reasoning but invalid for Anthropic after `clear_thinking`.

2. **`anthropic.ts:2394-2406`** — `latestAssistantThinkingIsUnreplayable` treated any signed block as replayable regardless of text content, missing the pre-emptive local degrade.

## Fix

**Primary (`transform-messages.ts`):** Gate the signed-empty thinking preservation on API. Only keep signed-empty blocks for non-`anthropic-messages` APIs. For `anthropic-messages`, drop them so they never reach the wire. This is the established repair behaviour, just moved earlier.

**Secondary (`anthropic.ts`):** Treat signed-empty thinking as unreplayable on signing endpoints in `latestAssistantThinkingIsUnreplayable`. This turns the latest-message case from a 400 round trip into a local degrade.

The fix does **not** strip valid signed thinking (non-empty text + signature) or weaken provider constraints. Non-signing endpoints (DeepSeek, Z.AI) are unaffected. OpenAI encrypted reasoning (signed-empty blocks on `openai-responses`) continues to work.

## Test plan

- [x] `transform-messages-clear-thinking.test.ts` — 8 new tests: historical signed-empty dropped for Anthropic, preserved for OpenAI Responses, valid signatures preserved, unsigned-empty dropped, whitespace-only handled, cross-model degradation
- [x] `anthropic-unreplayable-thinking.test.ts` — updated: signed-empty latest turn now triggers pre-emptive degrade (was incorrectly expected to be replayable); new tests for historical signed-empty and non-signing endpoint
- [x] All 88 existing thinking/reasoning/provenance tests pass
- [x] Full `packages/ai` suite: 2314 pass (10 pre-existing env-specific failures unrelated to this change)
- [x] `bun --cwd=packages/ai run check` passes (biome + tsc)