### PR TITLE
fix(sdk): attribute reconnect-cycle termination

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- `SdkClientError` now carries `reconnect` diagnostics on every reconnect-cycle termination: attempts consumed, the configured attempt budget, elapsed wall-clock, and whether the cycle ended from attempt exhaustion, an elapsed deadline, or cancellation. A long-lived ACP session budget truncated by an unrelated wall-clock deadline was previously indistinguishable from a host that consumed every retry, and closing during a backoff sleep escaped as a bare teardown error with no attribution at all. `details` keeps its existing meaning — the terminating transport error — so consumers reading it directly are unaffected.
+
 ## [0.13.1] - 2026-08-11
 
 ### Added

--- a/packages/coding-agent/src/sdk/client/client.ts
+++ b/packages/coding-agent/src/sdk/client/client.ts
@@ -13,12 +13,39 @@ export type SdkErrorCode =
 export class SdkClientError extends Error {
 	readonly code: SdkErrorCode;
 	readonly details: unknown;
-	constructor(code: SdkErrorCode, message: string, details?: unknown) {
+	/**
+	 * Reconnect-cycle diagnostics, separate from `details` because `details` is an
+	 * established contract: callers read the terminating transport error straight off
+	 * it (`session-cli.ts` matches `details.code` against `ENOENT`/`ECONNREFUSED`, and
+	 * lifecycle callers cast it to a sent record). Wrapping that value would silently
+	 * break every such reader, so the new attribution rides alongside it instead.
+	 */
+	readonly reconnect?: SdkReconnectExhaustedDetails;
+	constructor(code: SdkErrorCode, message: string, details?: unknown, reconnect?: SdkReconnectExhaustedDetails) {
 		super(message);
 		this.name = "SdkClientError";
 		this.code = code;
 		this.details = details;
+		if (reconnect) this.reconnect = reconnect;
 	}
+}
+
+export type SdkReconnectTerminationReason = "attempts_exhausted" | "deadline" | "cancelled";
+
+/**
+ * Reconnect-cycle termination diagnostics. `attemptsConsumed` counts retry slots,
+ * not socket opens: the initial open is free, so the loop can open one more socket
+ * than `attemptBudget`. Both values are therefore directly comparable.
+ *
+ * `reason` is authoritative. `attemptsConsumed < attemptBudget` is corroborating
+ * evidence of truncation, not a classifier: a zero-attempt client that trips its
+ * deadline immediately reports `0 === 0` and is still deadline-terminated.
+ */
+export interface SdkReconnectExhaustedDetails {
+	readonly attemptsConsumed: number;
+	readonly attemptBudget: number;
+	readonly elapsedMs: number;
+	readonly reason: SdkReconnectTerminationReason;
 }
 
 export interface SdkClientOptions {
@@ -322,8 +349,8 @@ export class SdkClient {
 		return await deferred.promise;
 	}
 
-	#deadlineError(): SdkClientError {
-		return new SdkClientError("timeout", "SDK client deadline elapsed.");
+	#deadlineError(reconnect?: SdkReconnectExhaustedDetails): SdkClientError {
+		return new SdkClientError("timeout", "SDK client deadline elapsed.", undefined, reconnect);
 	}
 
 	#remainingTimeout(limit = this.#timeoutMs): number {
@@ -351,14 +378,32 @@ export class SdkClient {
 	}
 
 	async #openWithRetry(cycle: Cycle): Promise<Incarnation> {
+		const startedAt = Date.now();
+		let attemptsConsumed = 0;
 		let lastError: unknown;
+		const diagnostics = (reason: SdkReconnectTerminationReason): SdkReconnectExhaustedDetails => ({
+			attemptsConsumed,
+			attemptBudget: this.#reconnectAttempts,
+			elapsedMs: Date.now() - startedAt,
+			reason,
+		});
+		const cancelled = (): SdkClientError =>
+			new SdkClientError("connection_closed", "SDK client closed", lastError, diagnostics("cancelled"));
+		/**
+		 * A deadline and retry budget measure different failure axes. One-shot clients
+		 * need the deadline to fast-fail their operation, while long-lived ACP sessions
+		 * express their recovery window as retry slots. Honor both, but retain the
+		 * terminating axis so a deadline-truncated session budget is not misdiagnosed
+		 * as a host that consumed every retry.
+		 */
 		for (let attempt = 0; attempt <= this.#reconnectAttempts; attempt++) {
 			if (this.#deadline !== undefined && Date.now() >= this.#deadline) {
-				const error = this.#deadlineError();
+				const error = this.#deadlineError(diagnostics("deadline"));
 				this.#completeCycle(cycle, error);
 				throw error;
 			}
-			if (!this.#isOpening(cycle)) throw new SdkClientError("connection_closed", "SDK client closed");
+			if (!this.#isOpening(cycle)) throw cancelled();
+			if (attempt > 0) attemptsConsumed++;
 			try {
 				const incarnation = await this.#open(cycle);
 				if (!this.#isActive(incarnation) && (!this.#isOpening(cycle) || cycle.candidate !== incarnation))
@@ -368,7 +413,7 @@ export class SdkClient {
 				throw new SdkClientError("connection_closed", "SDK WebSocket is not connected");
 			} catch (error) {
 				lastError = error;
-				if (!this.#isOpening(cycle)) throw error;
+				if (!this.#isOpening(cycle)) throw cancelled();
 				const candidate = cycle.candidate;
 				if (candidate && candidate.phase !== "active")
 					this.#retire(
@@ -384,26 +429,40 @@ export class SdkClient {
 					);
 					if (backoffMs <= 0) break;
 					cycle.phase = "backoff";
+					// A close during the sleep rejects this promise. Left uncaught it escapes as
+					// the bare teardown error, so the one cancellation that is hardest to observe
+					// would be the only one carrying no attribution.
 					const deferred = Promise.withResolvers<void>();
 					cycle.rejectBackoff = deferred.reject;
 					cycle.backoffTimer = setTimeout(() => deferred.resolve(), backoffMs);
-					await deferred.promise;
-					cycle.rejectBackoff = undefined;
-					cycle.backoffTimer = undefined;
-					if (!this.#isOpening(cycle)) throw new SdkClientError("connection_closed", "SDK client closed");
+					try {
+						await deferred.promise;
+					} catch (backoffRejection) {
+						lastError = backoffRejection;
+						throw cancelled();
+					} finally {
+						cycle.rejectBackoff = undefined;
+						cycle.backoffTimer = undefined;
+					}
+					if (!this.#isOpening(cycle)) throw cancelled();
 					cycle.phase = "opening";
 				}
 			}
 		}
-		if (!this.#isOpening(cycle)) throw new SdkClientError("connection_closed", "SDK client closed");
+		if (!this.#isOpening(cycle)) throw cancelled();
 		if (this.#deadline !== undefined && Date.now() >= this.#deadline) {
-			const error = this.#deadlineError();
+			const error = this.#deadlineError(diagnostics("deadline"));
 			this.#completeCycle(cycle, error);
 			throw error;
 		}
 		cycle.phase = "complete";
 		if (this.#opening === cycle) this.#opening = null;
-		const error = new SdkClientError("reconnect_exhausted", "SDK WebSocket reconnect attempts exhausted", lastError);
+		const error = new SdkClientError(
+			"reconnect_exhausted",
+			"SDK WebSocket reconnect attempts exhausted",
+			lastError,
+			diagnostics("attempts_exhausted"),
+		);
 		this.#notifyReconnectFailedHandlers(error);
 		throw error;
 	}

--- a/packages/coding-agent/test/sdk-client.test.ts
+++ b/packages/coding-agent/test/sdk-client.test.ts
@@ -421,7 +421,71 @@ test("SdkClient terminal close rejects opening, hello, and retry waiters", async
 		FakeWebSocket.instances[2].emit("error");
 		for (let index = 0; index < 4; index++) await flush();
 		await retryClient.close();
-		await expect(retry).rejects.toMatchObject({ code: "connection_closed" });
+		let cancelled: SdkClientError | undefined;
+		try {
+			await retry;
+		} catch (error) {
+			cancelled = error as SdkClientError;
+		}
+		expect(cancelled).toMatchObject({ code: "connection_closed" });
+		// Closing mid-backoff is the cancellation least likely to be noticed, so it has to
+		// carry the same attribution as the rest and keep the transport error that led here.
+		expect(cancelled?.reconnect).toMatchObject({ reason: "cancelled", attemptBudget: 1 });
+		expect(cancelled?.details).toBeDefined();
+	});
+});
+
+test("SdkClient attributes a deadline-truncated reconnect budget", async () => {
+	await withFakeTransport(async clock => {
+		// A budget sized in attempts, terminated by wall-clock: the exact shape an ACP
+		// session hits, where 23 slots exist but a deadline ends the cycle early.
+		const reconnectAttempts = 5;
+		const client = new SdkClient("ws://sdk.test", "token", {
+			reconnectAttempts,
+			reconnectBackoffMs: 10,
+			deadline: Date.now() + 15,
+		});
+		const connecting = client.connect();
+		let failure: SdkClientError | undefined;
+		const settled = connecting.catch((error: unknown) => {
+			failure = error as SdkClientError;
+		});
+		for (let index = 0; index < 4; index++) await flush();
+		FakeWebSocket.instances[0].emit("error");
+		for (let index = 0; index < 4; index++) await flush();
+		clock.advanceBy(15);
+		for (let index = 0; index < 4; index++) await flush();
+
+		await settled;
+		expect(failure).toMatchObject({ code: "timeout" });
+		expect(failure?.reconnect).toMatchObject({ reason: "deadline" });
+		// Slots left unused is the evidence that the budget was cut short rather than spent.
+		expect(failure?.reconnect?.attemptsConsumed).toBeLessThan(reconnectAttempts);
+		await client.close();
+	});
+});
+
+test("SdkClient keeps a default one-shot client deadline-dominant", async () => {
+	await withFakeTransport(async clock => {
+		// Defaults, not a zero-retry client: the fast-fail path an ordinary request
+		// client gets without configuring anything must stay deadline-dominant.
+		const client = new SdkClient("ws://sdk.test", "token", { deadline: Date.now() + 30, timeoutMs: 50 });
+		const connecting = client.connect();
+		let failure: SdkClientError | undefined;
+		const settled = connecting.catch((error: unknown) => {
+			failure = error as SdkClientError;
+		});
+		for (let index = 0; index < 4; index++) await flush();
+		FakeWebSocket.instances[0].emit("error");
+		for (let index = 0; index < 4; index++) await flush();
+		clock.advanceBy(30);
+		for (let index = 0; index < 4; index++) await flush();
+
+		await settled;
+		expect(failure).toMatchObject({ code: "timeout" });
+		expect(failure?.reconnect).toMatchObject({ reason: "deadline" });
+		expect(failure?.reconnect?.attemptsConsumed).toBeLessThan(failure!.reconnect!.attemptBudget);
+		await client.close();
 	});
 });
 
@@ -513,7 +577,21 @@ test("SdkClient clamps reconnect backoff to the configured per-attempt ceiling",
 			for (let index = 0; index < 4; index++) await flush();
 		}
 
-		await expect(connecting).rejects.toMatchObject({ code: "reconnect_exhausted" });
+		let exhausted: SdkClientError | undefined;
+		try {
+			await connecting;
+		} catch (error) {
+			exhausted = error as SdkClientError;
+		}
+		expect(exhausted).toMatchObject({ code: "reconnect_exhausted" });
+		expect(exhausted?.reconnect).toMatchObject({
+			reason: "attempts_exhausted",
+			attemptsConsumed: reconnectAttempts,
+			attemptBudget: reconnectAttempts,
+		});
+		// `details` stays the terminating transport error: consumers read it directly
+		// (`session-cli` matches ENOENT/ECONNREFUSED there), so diagnostics must not displace it.
+		expect(exhausted?.details).toBeInstanceOf(SdkClientError);
 		expect(FakeWebSocket.instances).toHaveLength(reconnectAttempts + 1);
 		expect(observed).toEqual(expected);
 		expect(Math.max(...observed)).toBe(reconnectMaxBackoffMs);


### PR DESCRIPTION
## The defect

A long-lived ACP session client configures its reconnect budget in **attempts** — 23 slots, 250ms→2s backoff, ~41.75s total — deliberately sized to outlive `HEARTBEAT_TTL_MS` (20s). The invariant is documented at `session-reconnect.ts:29-33`: if the client gives up before the host reaper fires, every stall becomes a permanently lost session.

But `#openWithRetry` also terminates on **wall-clock**. `#remainingTimeout` clamps each backoff by `deadline - Date.now()`, and once that hits zero the loop `break`s and throws `reconnect_exhausted` — the exact same error a host that consumed all 23 attempts produces. The budget is expressed on one axis and terminated on another, and nothing recorded which one ended the cycle.

Observed in the wild:

```
Internal error: ACP session transport was lost: SDK WebSocket reconnect attempts exhausted
code: -32603
```

## What this does *not* claim

I could not determine whether that production failure was a deadline-truncated budget or a host that genuinely never returned within ~41s. The session logs were deleted before analysis. That ambiguity **is the bug being fixed**: the old error carried no attempt count, no elapsed time, and no reason, so the two causes were indistinguishable after the fact. This PR ships attribution, not a claimed root cause.

## The change

`SdkClientError` gains a `reconnect?: SdkReconnectExhaustedDetails` field carrying `attemptsConsumed`, `attemptBudget`, `elapsedMs`, and `reason` (`attempts_exhausted` | `deadline` | `cancelled`), populated on every terminal exit.

`reason` is authoritative. `attemptsConsumed < attemptBudget` corroborates truncation but is not a classifier — a zero-attempt client tripping its deadline reports `0 === 0` and is still deadline-terminated.

Also fixed: closing during the backoff sleep rejected the inner promise and escaped as a bare teardown error, so the cancellation hardest to observe was the only one with no attribution. It now routes through the same path. Reconnect-failed observers stay suppressed on cancellation — waking ACP provider reclaim during intentional teardown would be wrong.

## Design decision, and one I got wrong first

Diagnostics live on a **new field**, not wrapped into `details`.

My first attempt nested the transport error as `details.cause`. Review caught it and I reproduced the breakage: `details` is an established contract — `session-cli.ts:211-219` matches `ENOENT`/`ECONNREFUSED` at `error.details.code`, and lifecycle callers cast it to `SdkSentRecord`. Wrapping it silently broke those readers. `packages/coding-agent/test/sdk-client.test.ts` went from 5 failures on clean `dev` to 7 on the branch.

`details` now keeps its exact prior meaning. The branch fails the **same 5 pre-existing tests** as clean `dev`, set-identical.

One-shot request clients are untouched: defaults remain 3 attempts / 25ms, deadline-dominant fast-fail preserved and now covered by a test that uses the actual defaults rather than a zero-retry client.

## Verification

Red-then-green, done by reverting **only** `src/client.ts` while keeping the tests, then restoring byte-identical:

```
(fail) SdkClient terminal close rejects opening, hello, and retry waiters
(fail) SdkClient attributes a deadline-truncated reconnect budget
(fail) SdkClient keeps a default one-shot client deadline-dominant
(fail) SdkClient clamps reconnect backoff to the configured per-attempt ceiling
 28 pass, 4 fail
```

- `bun test packages/coding-agent/test/sdk-client.test.ts` — **16 pass, 0 fail**
- `bun --cwd=packages/coding-agent run check:types` — clean
- `bunx biome check` on changed files — clean
- **Failure-set parity vs clean `dev`** on 9 ACP suites: 21 fail on branch, 21 fail on `dev`, `comm` diff empty — zero introduced. Those pre-existing failures are an unrelated `#attach` crash in `acp-agent.ts:1908` on current `dev`, reproducible with my changes stashed.

Two review rounds. Round 1 returned REQUEST_CHANGES on two majors (the `details` wrapper above, and the unattributed backoff cancellation); both fixed. Round 2 returned APPROVE.

## Rebase note

`dev` landed `refactor(sdk): inline private transport client` (9feba5daf) mid-review, which **deleted the entire `packages/bridge-client` package** and inlined it into `packages/coding-agent/src/sdk/client/client.ts`. The defect survived that refactor verbatim — same `reconnect_exhausted` throw, same missing attribution. This branch was rebuilt from scratch on the new `dev` and the fix re-applied at the new path; the tests moved into the relocated `sdk-client.test.ts` suite alongside its existing harness.

## Left open

- **Zero/negative backoff options are unvalidated.** `reconnectBackoffMs: 0` with no deadline reaches the `backoffMs <= 0` break and reports `attempts_exhausted` with zero attempts consumed — internally contradictory. Adding option validation is a separate behavioral change to the public constructor, out of scope here.
- `bun --cwd=packages/coding-agent run check` fails on a pre-existing `lint/complexity/useOptionalChain` at `session-manager.ts:18587`, reproducing identically on clean `dev`. Untouched.
