### PR TITLE
fix(ai): converge Anthropic thinking-replay rejections under managed fallback attempts (#4262)

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- A deterministic Anthropic thinking-replay rejection now converges under a managed fallback attempt instead of repeating forever (#4262). Every coding-agent turn prompts with `fallbackManaged: true`, and the whole in-provider thinking-replay repair sits behind `!options?.fallbackManaged` because the fallback controller owns retries — the shipping CLI therefore never repaired anything: each turn rebuilt the same replay from the same history, drew the same 400, and the session burned one rejected request per turn without ever self-healing (reported as ~1 rejected 1.3 MB request every 12s, ~300/h, never converging). The provider still does not retry inside a managed attempt — it records the full-history repair escalation on the provider session state instead, so the next managed attempt builds a repaired replay at the cost of zero extra round trips. Only the two deterministic rejections (`blocks ... cannot be modified`, ``Invalid `signature` in `thinking` block``) qualify; the proxy-masked generic `api_error` names no cause and may be a transient blip, so it still never costs the session its native replay.
+
 ## [0.13.1] - 2026-08-11
 
 ### Fixed

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2037,6 +2037,32 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 						resetOutputForRetry();
 						continue;
 					}
+					// Managed attempts never take the repair branch above: the fallback
+					// controller owns retries, so the provider must not retry inside the
+					// attempt it was handed. That left the repair unreachable for the
+					// coding agent, which prompts exclusively through managed attempts —
+					// every turn rebuilt the same replay from the same history, drew the
+					// same deterministic 400, and the session never converged (issue
+					// #4262: one rejected 1.3 MB request every 12s, indefinitely).
+					// Recording the escalation costs no round trip and keeps the retry
+					// boundary intact: the next managed attempt builds a repaired replay.
+					// The masked `api_error` stays out — it names no cause and may be a
+					// transient blip, so only a rejection that provably indicts the
+					// replayed thinking blocks may cost the session its native replay.
+					if (
+						options?.fallbackManaged &&
+						providerSessionState &&
+						providerSessionState.thinkingReplayRepairScope !== "all" &&
+						firstTokenTime === undefined &&
+						(thinkingSignatureInvalid || thinkingBlocksImmutable) &&
+						hasNativeThinkingBlocks(params.messages)
+					) {
+						logger.debug("anthropic: recording thinking replay repair for the next managed attempt", {
+							model: model.id,
+							error: streamFailure instanceof Error ? streamFailure.message : String(streamFailure),
+						});
+						providerSessionState.thinkingReplayRepairScope = "all";
+					}
 					if (
 						!options?.fallbackManaged &&
 						!dropFastMode &&

--- a/packages/ai/test/anthropic-managed-thinking-repair.test.ts
+++ b/packages/ai/test/anthropic-managed-thinking-repair.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "bun:test";
+import type Anthropic from "@anthropic-ai/sdk";
+import { streamAnthropic } from "@gajae-code/ai/providers/anthropic";
+import type { AssistantMessage, Context, Model, ProviderSessionState, UserMessage } from "@gajae-code/ai/types";
+
+/**
+ * Issue #4262: the coding-agent drives every turn through `fallbackManaged`
+ * prompts, and the provider's whole thinking-replay repair sits behind
+ * `!options?.fallbackManaged`. A deterministic thinking rejection therefore
+ * never degraded the replay in the shipping CLI: each turn rebuilt the same
+ * body from the same history, the API rejected it identically, and the session
+ * burned one 400 per turn forever (measured in the report at ~1 rejected 1.3 MB
+ * request every 12 s, never self-healing).
+ *
+ * The managed contract still owns retries — the provider must not retry inside
+ * a managed attempt — so the fix records the escalated repair scope on the
+ * provider session state instead. The next managed attempt then builds a
+ * repaired body and the session converges.
+ */
+const model: Model<"anthropic-messages"> = {
+	api: "anthropic-messages",
+	provider: "anthropic",
+	id: "claude-sonnet-4-6",
+	name: "Claude Sonnet 4.6",
+	baseUrl: "https://api.anthropic.com",
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	maxTokens: 8_192,
+	contextWindow: 200_000,
+	reasoning: true,
+};
+
+/** The exact rejection body captured in the report, citing an earlier assistant message. */
+const MUTATION_REJECTION =
+	'{"type":"error","error":{"type":"invalid_request_error","message":"messages.13.content.16: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response."}}';
+const SIGNATURE_REJECTION =
+	'{"type":"error","error":{"type":"invalid_request_error","message":"messages.13.content.16: Invalid `signature` in `thinking` block"}}';
+const MASKED_REJECTION =
+	'{"type":"error","error":{"type":"api_error","message":"An error occurred while processing the request."}}';
+
+type MockAnthropicRequest = {
+	withResponse(): Promise<{
+		data: AsyncIterable<Record<string, unknown>>;
+		response: Response;
+		request_id: string | null;
+	}>;
+};
+
+function rejectingRequest(message: string, status = 400): MockAnthropicRequest {
+	return {
+		async withResponse(): Promise<never> {
+			const error = new Error(message);
+			(error as { status?: number }).status = status;
+			throw error;
+		},
+	};
+}
+
+function signedAssistant(suffix: string, text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [
+			{ type: "thinking", thinking: `thinking ${suffix}`, thinkingSignature: `sig_${suffix}` },
+			{ type: "text", text },
+		],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function replayContext(): Context {
+	const user: UserMessage = { role: "user", content: "first", timestamp: Date.now() };
+	return {
+		messages: [
+			user,
+			signedAssistant("early", "early answer"),
+			{ ...user, content: "second", timestamp: Date.now() + 1 },
+			signedAssistant("late", "late answer"),
+			{ ...user, content: "next prompt", timestamp: Date.now() + 2 },
+		],
+	};
+}
+
+type RecordedBody = { messages?: Array<{ content?: unknown }> };
+
+function replayedThinkingBlockTypes(body: unknown): string[] {
+	const messages = (body as RecordedBody).messages ?? [];
+	return messages.flatMap(message =>
+		Array.isArray(message.content)
+			? (message.content as Array<{ type?: string }>)
+					.map(block => block.type ?? "")
+					.filter(type => type === "thinking" || type === "redacted_thinking")
+			: [],
+	);
+}
+
+function rejectingClient(rejection: string, bodies: unknown[]): Anthropic {
+	const create = ((body: unknown) => {
+		bodies.push(body);
+		return rejectingRequest(rejection) as never;
+	}) as unknown as Anthropic["messages"]["create"];
+	return { messages: { create } } as Anthropic;
+}
+
+describe("Anthropic managed thinking-replay convergence (issue #4262)", () => {
+	it.each([
+		["mutation", MUTATION_REJECTION],
+		["invalid signature", SIGNATURE_REJECTION],
+	])("converges the next managed attempt after a %s rejection", async (_label, rejection) => {
+		const requestBodies: unknown[] = [];
+		const client = rejectingClient(rejection, requestBodies);
+		const providerSessionState = new Map<string, ProviderSessionState>();
+
+		const first = await streamAnthropic(model, replayContext(), {
+			client,
+			fallbackManaged: true,
+			providerSessionState,
+		}).result();
+
+		// The managed controller owns retries: the provider must not retry inside
+		// the attempt, so the rejection surfaces after exactly one request.
+		expect(first.stopReason).toBe("error");
+		expect(requestBodies).toHaveLength(1);
+		expect(replayedThinkingBlockTypes(requestBodies[0])).toEqual(["thinking", "thinking"]);
+
+		const second = await streamAnthropic(model, replayContext(), {
+			client,
+			fallbackManaged: true,
+			providerSessionState,
+		}).result();
+
+		// Without the recorded escalation this body is byte-identical to the first
+		// one and the session 400s forever.
+		expect(second.stopReason).toBe("error");
+		expect(requestBodies).toHaveLength(2);
+		expect(replayedThinkingBlockTypes(requestBodies[1])).toEqual([]);
+		expect(JSON.stringify(requestBodies[1])).not.toContain("sig_early");
+		expect(JSON.stringify(requestBodies[1])).not.toContain("sig_late");
+		// Degrading the replay must not drop the turn's visible content.
+		expect(JSON.stringify(requestBodies[1])).toContain("early answer");
+	});
+
+	it("keeps the escalation in force for later managed turns", async () => {
+		const requestBodies: unknown[] = [];
+		const client = rejectingClient(MUTATION_REJECTION, requestBodies);
+		const providerSessionState = new Map<string, ProviderSessionState>();
+
+		for (let turn = 0; turn < 3; turn++) {
+			await streamAnthropic(model, replayContext(), {
+				client,
+				fallbackManaged: true,
+				providerSessionState,
+			}).result();
+		}
+
+		expect(requestBodies).toHaveLength(3);
+		expect(replayedThinkingBlockTypes(requestBodies[1])).toEqual([]);
+		expect(replayedThinkingBlockTypes(requestBodies[2])).toEqual([]);
+	});
+
+	it("does not degrade the replay for an unclassifiable masked rejection", async () => {
+		const requestBodies: unknown[] = [];
+		const client = rejectingClient(MASKED_REJECTION, requestBodies);
+		const providerSessionState = new Map<string, ProviderSessionState>();
+
+		await streamAnthropic(model, replayContext(), {
+			client,
+			fallbackManaged: true,
+			providerSessionState,
+		}).result();
+		await streamAnthropic(model, replayContext(), {
+			client,
+			fallbackManaged: true,
+			providerSessionState,
+		}).result();
+
+		// A masked `api_error` names no cause and may be a transient blip; only a
+		// deterministic thinking rejection may cost the session its replay.
+		expect(requestBodies).toHaveLength(2);
+		expect(replayedThinkingBlockTypes(requestBodies[1])).toEqual(["thinking", "thinking"]);
+	});
+
+	it("records nothing when the managed caller shares no provider session state", async () => {
+		const requestBodies: unknown[] = [];
+		const client = rejectingClient(MUTATION_REJECTION, requestBodies);
+
+		const result = await streamAnthropic(model, replayContext(), { client, fallbackManaged: true }).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(requestBodies).toHaveLength(1);
+	});
+});

--- a/packages/ai/test/anthropic-unreplayable-thinking.test.ts
+++ b/packages/ai/test/anthropic-unreplayable-thinking.test.ts
@@ -205,6 +205,25 @@ describe("Anthropic unreplayable latest-assistant thinking", () => {
 		expect(nativeThinkingCount(payload)).toBe(1);
 	});
 
+	it("drops signed-empty historical thinking recorded under a different model id (#4262)", async () => {
+		// The same turn recorded under the dated snapshot while the request runs the
+		// alias (or vice versa) is not `isSameModel`, so it takes the cross-identity
+		// branch instead of the #4247 drop. It must still never reach the wire: this
+		// is the shape #4262 reported as replaying from earlier assistant messages.
+		const snapshotModel: Model<"anthropic-messages"> = { ...model, id: `${model.id}-20260101` };
+		const payload = await capturePayload([
+			user,
+			assistantTurn([SIGNED_EMPTY], "toolu_a", snapshotModel),
+			toolResult("toolu_a"),
+			{ ...user, content: "again", timestamp: Date.now() + 1 },
+			assistantTurn([SIGNED_LATE], "toolu_b"),
+			toolResult("toolu_b"),
+		]);
+
+		expect(JSON.stringify(payload.messages)).not.toContain("sig_empty");
+		expect(nativeThinkingCount(payload)).toBe(1);
+	});
+
 	it("does not degrade a non-signing endpoint whose latest turn has signed-empty thinking", async () => {
 		const payload = await capturePayload(
 			[


### PR DESCRIPTION
Closes #4262.

## Root cause (differs from the issue's analysis)

The report's three hypotheses were checked against the code and the wire; only the symptom held.

**Verified from the reporter's environment claims:**

```
$ git log --oneline -1 56450d2a0
56450d2a05 chore: merge main (v0.13.1 release) back into dev
$ git merge-base --is-ancestor 823217f27 56450d2a0 && echo present
present
$ git show 56450d2a0:packages/ai/src/providers/transform-messages.ts | sed -n '106,107p'
                    if (isSameModel && sanitized.thinkingSignature) {
                        if (sanitized.thinking.trim() === "" && model.api === "anthropic-messages") return [];
```

So the #4247 drop really was in the running binary — which makes the reported payload the puzzle, not the fix.

**Suggested direction 1 (widen the pre-flight detector to any assistant message) is unnecessary.** A wire-level probe over `convertAnthropicMessages` shows non-latest signed-empty thinking can never reach the wire, under every model-identity combination:

```
same-model non-latest signed-empty             emptySigned= 0 | -
cross-model-id non-latest signed-empty         emptySigned= 0 | -
cross-provider non-latest signed-empty         emptySigned= 0 | -
latest signed-empty                            emptySigned= 1 | sigEMPTY ON WIRE
consecutive assistants, earlier signed-empty   emptySigned= 0 | -
```

`transformMessages` drops the block on the `isSameModel && thinkingSignature` branch (#4247) and, when identity differs, on the `!sanitized.thinking.trim()` branch. Only the latest assistant message is preserved, and the existing pre-flight already covers that. Adding an any-message scan would be dead code. This PR pins the property instead of adding the scan (new cross-model-id wire test).

**Suggested direction 2 is already on `dev`.** `anthropic.ts` escalates the mutation error straight to full-history scope: `thinkingSignatureInvalid || thinkingBlocksImmutable || scope === "latest" ? "all" : "latest"`.

**The actual defect** is why none of that machinery ever ran. `agent-session.ts` routes every `prompt`/`continue` through `#managedFallbackPromptOptions()` → `fallbackManaged: true`, and the whole in-provider thinking-replay repair is gated on `!options?.fallbackManaged` because the fallback controller owns retries. A deterministic thinking 400 is not in `managedRetryableFailure`'s retryable set, so the controller surfaces it, the turn dies, and the next turn rebuilds a byte-identical body from the identical history — matching the report exactly: one rejected 1.3 MB request per turn, ~300/h, never converging, with all 69 thinking blocks still on the wire because no repair was ever applied.

## Fix

Smallest correct scope: the provider still does **not** retry inside a managed attempt (that would reuse the `beginAttempt()` token and steal retry authority from the controller). It records the full-history repair escalation on `providerSessionState.thinkingReplayRepairScope`, which `streamAnthropic` already reads at stream start, so the next managed attempt ships a repaired replay at zero extra round trips.

Guarded to the two deterministic rejections only. The proxy-masked generic `api_error` names no cause and may be a transient blip, so it still never costs the session its native replay — that asymmetry is the existing #4038 contract and is preserved.

## Reproduction → fix

`packages/ai/test/anthropic-managed-thinking-repair.test.ts` reproduces the loop against `dev` and passes after the change.

Before (on the parent commit, new test file only):

```
(fail) ... > converges the next managed attempt after a mutation rejection
(fail) ... > converges the next managed attempt after a invalid signature rejection
(fail) ... > keeps the escalation in force for later managed turns
 2 pass  3 fail
```

The failure is exactly the reported shape — the second managed attempt replays `["thinking","thinking"]` again instead of `[]`.

After:

```
$ bun test packages/ai/test/anthropic-managed-thinking-repair.test.ts
 5 pass  0 fail  25 expect() calls
```

## Tests

```
$ bun test packages/ai/test/anthropic-managed-thinking-repair.test.ts \
    packages/ai/test/anthropic-unreplayable-thinking.test.ts \
    packages/ai/test/anthropic-thinking-repair-retry.test.ts \
    packages/ai/test/anthropic-thinking-repair-budget.test.ts \
    packages/ai/test/anthropic-thinking-immutability.test.ts \
    packages/ai/test/transform-messages-clear-thinking.test.ts \
    packages/ai/test/anthropic-stream-envelope.test.ts
 91 pass  0 fail
```

Coverage added:
- managed mutation 400 → exactly one request (managed retry boundary intact), next attempt replays zero thinking, content preserved
- managed invalid-signature 400 → same
- escalation stays in force across three managed turns
- masked `api_error` under managed → replay **not** degraded
- managed caller with no shared `providerSessionState` → no-op, error surfaces
- cross-model-id historical signed-empty thinking never reaches the wire (pins the #4247 property this issue suspected was broken)

No guard weakened, no snapshot updated.

## Full-suite delta

```
$ bun test packages/ai/test           # parent commit + new test file
 28 failures
$ bun test packages/ai/test           # this commit
 25 failures
```

Diff of the failure sets is exactly the three new red tests going green. The 25 remaining failures are pre-existing on `origin/dev` at `67b6593761` (unrelated: openai-responses cache affinity, etc.) and are not touched by this change.

## Verification

```
$ bun --cwd=packages/ai run check     # biome + tsc, clean
$ bun run lint                        # clean
$ bun scripts/changelog-history-guard.ts
changelog-history-guard: no released sections removed (67b65937617c..HEAD)
```

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
