### PR TITLE
fix(macos): stabilize TCC permissions for GJC binaries

### DIFF
--- a/crates/pi-natives/src/computer/capture.rs
+++ b/crates/pi-natives/src/computer/capture.rs
@@ -7,10 +7,12 @@
 //! the captured physical pixel size versus the logical display bounds, so the
 //! coordinate contract stays correct on Retina/HiDPI.
 //!
-//! Capture requires the macOS Screen Recording (TCC) permission. When it is not
-//! granted, `CGDisplayCreateImage` returns null and this surfaces
-//! [`CaptureError::CaptureFailed`] rather than silently returning a black
-//! frame.
+//! Capture requires the macOS Screen & System Audio Recording (TCC)
+//! permission. When it is not granted, `CGDisplayCreateImage` returns null and
+//! this surfaces [`CaptureError::PermissionRequired`] rather than silently
+//! returning a black frame. A preflight result is consulted only after the
+//! real capture call fails, so a stale or overly conservative preflight cannot
+//! reject a capture that the OS actually permits.
 //!
 //! Implemented with raw CoreGraphics FFI (no extra crates); the buffer is owned
 //! Rust memory and every Core Graphics handle is released exactly once.
@@ -90,8 +92,11 @@ unsafe extern "C" {
 /// Reason a primary-display capture failed.
 #[derive(Debug, Clone)]
 pub enum CaptureError {
-	/// `CGDisplayCreateImage` returned null or a zero-sized image — commonly the
-	/// Screen Recording permission is not granted.
+	/// The OS denied capture and the current process preflight also reports no
+	/// Screen & System Audio Recording grant.
+	PermissionRequired,
+	/// `CGDisplayCreateImage` returned null or a zero-sized image after the
+	/// current-process permission preflight passed.
 	CaptureFailed,
 	/// A Core Graphics color space or bitmap context could not be created.
 	ContextFailed,
@@ -102,11 +107,29 @@ pub enum CaptureError {
 impl fmt::Display for CaptureError {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
+			Self::PermissionRequired => write!(
+				f,
+				"screen capture was denied because the current process lacks the Screen & System \
+				 Audio Recording permission; grant it for this GJC launcher and relaunch. {}",
+				crate::computer::permissions::current_process_diagnostic()
+			),
 			Self::CaptureFailed => {
-				write!(f, "screen capture failed; the Screen Recording permission may not be granted")
+				write!(f, "screen capture failed after the current process preflight passed")
 			},
 			Self::ContextFailed => write!(f, "failed to create a Core Graphics bitmap context"),
 			Self::Encode(reason) => write!(f, "failed to encode captured frame as PNG: {reason}"),
+		}
+	}
+}
+
+impl CaptureError {
+	#[must_use]
+	pub const fn code(&self) -> &'static str {
+		match self {
+			Self::PermissionRequired => "COMPUTER_PERMISSION_REQUIRED",
+			Self::CaptureFailed | Self::ContextFailed | Self::Encode(_) => {
+				"COMPUTER_SCREENSHOT_FAILED"
+			},
 		}
 	}
 }
@@ -132,9 +155,8 @@ pub struct CapturedFrame {
 /// Capture the current primary display as a PNG plus its coordinate descriptor.
 ///
 /// # Errors
-/// Returns [`CaptureError`] when the OS capture call fails (often a missing
-/// Screen Recording grant), a bitmap context cannot be created, or PNG encoding
-/// fails.
+/// Returns [`CaptureError`] when the OS capture call fails, a bitmap context
+/// cannot be created, or PNG encoding fails.
 pub fn capture_primary_display() -> Result<CapturedFrame, CaptureError> {
 	// SAFETY: pure Core Graphics geometry queries for the active primary display;
 	// no image capture occurs before `CGDisplayCreateImage` below.
@@ -149,14 +171,29 @@ pub fn capture_primary_display() -> Result<CapturedFrame, CaptureError> {
 	// released exactly once below regardless of the `frame_from_image` result.
 	let image = unsafe { CGDisplayCreateImage(display_id) };
 	if image.is_null() {
-		return Err(CaptureError::CaptureFailed);
+		return Err(classify_capture_failure(CaptureError::CaptureFailed));
 	}
 
 	let result = frame_from_image(image, bounds, capture_id);
 
 	// SAFETY: `image` is non-null (checked above) and not used after release.
 	unsafe { CGImageRelease(image) };
-	result
+	match result {
+		Err(CaptureError::CaptureFailed) => {
+			Err(classify_capture_failure(CaptureError::CaptureFailed))
+		},
+		other => other,
+	}
+}
+
+fn classify_capture_failure(error: CaptureError) -> CaptureError {
+	if crate::computer::permissions::screen_recording_granted() {
+		return error;
+	}
+	let _ = crate::computer::permissions::open_settings(
+		crate::computer::permissions::TccPermission::ScreenRecording,
+	);
+	CaptureError::PermissionRequired
 }
 
 #[must_use]

--- a/crates/pi-natives/src/computer/controller.rs
+++ b/crates/pi-natives/src/computer/controller.rs
@@ -342,9 +342,9 @@ impl ComputerController {
 								results,
 								ExecError::ActionFailed {
 									index,
-									source: Box::new(ExecError::ScreenshotFailed),
+									source: Box::new(capture_exec_error(err.clone())),
 								},
-								Some(format!("COMPUTER_SCREENSHOT_FAILED: {err}")),
+								Some(format!("{}: {err}", err.code())),
 							);
 						},
 					},
@@ -383,8 +383,8 @@ impl ComputerController {
 			Err(err) => {
 				return batch_failure(
 					results,
-					ExecError::ScreenshotFailed,
-					Some(format!("COMPUTER_SCREENSHOT_FAILED: {err}")),
+					capture_exec_error(err.clone()),
+					Some(format!("{}: {err}", err.code())),
 				);
 			},
 		};
@@ -397,15 +397,18 @@ impl ComputerController {
 			.iter()
 			.position(|action| matches!(action, BatchAction::Input { action, .. } if !matches!(action, InputAction::Wait { .. })))
 			.unwrap_or(0);
-		let Ok(mut controller) = guarded_controller() else {
-			return batch_failure(
-				results,
-				ExecError::ActionFailed {
-					index:  first_input_index,
-					source: Box::new(ExecError::PermissionRequired),
-				},
-				None,
-			);
+		let mut controller = match guarded_controller() {
+			Ok(controller) => controller,
+			Err(err) => {
+				return batch_failure(
+					results,
+					ExecError::ActionFailed {
+						index:  first_input_index,
+						source: Box::new(ExecError::PermissionRequired),
+					},
+					Some(err.to_string()),
+				);
+			},
 		};
 		let mut hooks = MacCursorHooks;
 		let transaction =
@@ -422,11 +425,9 @@ impl ComputerController {
 					}
 					match action {
 						BatchAction::Screenshot { .. } => {
-							let frame =
-								capture_primary_display().map_err(|_| ExecError::ActionFailed {
-									index,
-									source: Box::new(ExecError::ScreenshotFailed),
-								})?;
+							let frame = capture_primary_display().map_err(|err| {
+								ExecError::ActionFailed { index, source: Box::new(capture_exec_error(err)) }
+							})?;
 							if step_cancelled() {
 								return Err(ExecError::ActionFailed {
 									index,
@@ -658,8 +659,20 @@ fn epoch_from_f64(value: f64) -> u64 {
 fn exec_error(err: ExecError) -> napi::Error {
 	napi_error(err.code(), err.to_string())
 }
-fn capture_error(err: impl std::fmt::Display) -> napi::Error {
-	napi_error("COMPUTER_SCREENSHOT_FAILED", err.to_string())
+fn capture_exec_error(err: crate::computer::capture::CaptureError) -> ExecError {
+	match err {
+		crate::computer::capture::CaptureError::PermissionRequired => {
+			ExecError::ScreenRecordingPermissionRequired(
+				crate::computer::capture::CaptureError::PermissionRequired.to_string(),
+			)
+		},
+		crate::computer::capture::CaptureError::CaptureFailed
+		| crate::computer::capture::CaptureError::ContextFailed
+		| crate::computer::capture::CaptureError::Encode(_) => ExecError::ScreenshotFailed,
+	}
+}
+fn capture_error(err: crate::computer::capture::CaptureError) -> napi::Error {
+	napi_error(err.code(), err.to_string())
 }
 fn napi_error(code: &'static str, reason: String) -> napi::Error {
 	napi::Error::new(napi::Status::GenericFailure, format!("{code}: {reason}"))
@@ -741,5 +754,24 @@ mod tests {
 		assert_eq!(grouped, now + Duration::from_secs(1));
 		assert_eq!(final_screenshot, now + Duration::from_secs(6));
 		assert_eq!(deadlines.len(), 1);
+	}
+
+	#[test]
+	fn capture_permission_errors_keep_the_permission_code_in_batches() {
+		let error = capture_exec_error(crate::computer::capture::CaptureError::PermissionRequired);
+
+		assert_eq!(error.code(), "COMPUTER_PERMISSION_REQUIRED");
+		assert!(
+			error
+				.to_string()
+				.contains("Screen & System Audio Recording")
+		);
+	}
+
+	#[test]
+	fn non_permission_capture_errors_keep_the_screenshot_code_in_batches() {
+		let error = capture_exec_error(crate::computer::capture::CaptureError::CaptureFailed);
+
+		assert_eq!(error.code(), "COMPUTER_SCREENSHOT_FAILED");
 	}
 }

--- a/crates/pi-natives/src/computer/controller.rs
+++ b/crates/pi-natives/src/computer/controller.rs
@@ -226,8 +226,8 @@ impl ComputerController {
 		hotkey::start();
 		let frame = capture_primary_display().map_err(capture_error)?;
 		let display = frame.display;
-		let mut controller = guarded_controller()
-			.map_err(|err| napi_error("COMPUTER_PERMISSION_REQUIRED", err.to_string()))?;
+		let mut controller =
+			guarded_controller().map_err(|err| napi::Error::from_reason(err.to_string()))?;
 		let cancel = || Supervisor::global().is_suspended();
 		let mut hooks = MacCursorHooks;
 		execute_input_transaction(

--- a/crates/pi-natives/src/computer/executor.rs
+++ b/crates/pi-natives/src/computer/executor.rs
@@ -87,6 +87,8 @@ pub enum ExecError {
 	UnknownKey(String),
 	/// A screenshot step could not capture the display.
 	ScreenshotFailed,
+	/// The current process lacks Screen & System Audio Recording permission.
+	ScreenRecordingPermissionRequired(String),
 	/// A batch action failed at this zero-based index.
 	ActionFailed { index: usize, source: Box<Self> },
 	/// The cursor could not be captured before an input transaction began.
@@ -113,6 +115,7 @@ impl ExecError {
 			Self::UnknownKey(_) => "COMPUTER_UNKNOWN_KEY",
 			Self::Cancelled => "COMPUTER_CANCELLED",
 			Self::ScreenshotFailed => "COMPUTER_SCREENSHOT_FAILED",
+			Self::ScreenRecordingPermissionRequired(_) => "COMPUTER_PERMISSION_REQUIRED",
 			Self::ActionFailed { source, .. } => source.code(),
 			Self::CursorCaptureFailed => "COMPUTER_CURSOR_CAPTURE_FAILED",
 			Self::CursorRestoreFailed { .. } => "COMPUTER_CURSOR_RESTORE_FAILED",
@@ -142,6 +145,9 @@ impl std::fmt::Display for ExecError {
 			Self::ActionFailed { index, source } => write!(f, "action {index}: {source}"),
 			Self::CursorRestoreFailed { primary: Some(primary) } => {
 				write!(f, "{} after {primary}", self.code())
+			},
+			Self::ScreenRecordingPermissionRequired(reason) => {
+				write!(f, "{}: {reason}", self.code())
 			},
 			Self::TransactionPoisoned => {
 				write!(f, "{}: input transaction mutex is poisoned", self.code())
@@ -1042,6 +1048,10 @@ mod tests {
 		assert_eq!(ExecError::Suspended.code(), "COMPUTER_SUSPENDED");
 		assert_eq!(ExecError::SupervisorNotLive.code(), "COMPUTER_SUPERVISOR_NOT_LIVE");
 		assert_eq!(ExecError::PermissionRequired.code(), "COMPUTER_PERMISSION_REQUIRED");
+		assert_eq!(
+			ExecError::ScreenRecordingPermissionRequired("denied".to_string()).code(),
+			"COMPUTER_PERMISSION_REQUIRED"
+		);
 		assert_eq!(ExecError::DisplayStale.code(), "COMPUTER_DISPLAY_STALE");
 		assert_eq!(ExecError::CursorWarpFailed(1).code(), "COMPUTER_CURSOR_WARP_FAILED");
 		assert_eq!(ExecError::CursorCaptureFailed.code(), "COMPUTER_CURSOR_CAPTURE_FAILED");

--- a/crates/pi-natives/src/computer/mod.rs
+++ b/crates/pi-natives/src/computer/mod.rs
@@ -77,9 +77,10 @@ pub struct ComputerScreenshot {
 
 /// Capture the primary display for JS callers (macOS).
 ///
-/// Requires the Screen Recording permission. This is the read-only `screenshot`
-/// primitive of the computer-use tool; input primitives land behind the same
-/// surface once the Accessibility gate is satisfied in a granted `gjc` process.
+/// Requires the Screen & System Audio Recording permission. This is the
+/// read-only `screenshot` primitive of the computer-use tool; input primitives
+/// land behind the same surface once the Accessibility gate is satisfied in a
+/// granted `gjc` process.
 ///
 /// # Errors
 /// Returns an error when capture fails (e.g. Screen Recording not granted).
@@ -88,7 +89,7 @@ pub fn computer_screenshot() -> napi::Result<ComputerScreenshot> {
 	#[cfg(target_os = "macos")]
 	{
 		let frame = capture::capture_primary_display()
-			.map_err(|err| napi::Error::from_reason(format!("{err}")))?;
+			.map_err(|err| napi::Error::from_reason(format!("{}: {err}", err.code())))?;
 		Ok(ComputerScreenshot {
 			png:           Uint8Array::from(frame.png),
 			width_px:      frame.display.width_px,

--- a/crates/pi-natives/src/computer/permissions.rs
+++ b/crates/pi-natives/src/computer/permissions.rs
@@ -2,16 +2,19 @@
 //!
 //! # Overview
 //! Two distinct TCC permissions gate the computer tool:
-//! - **Screen Recording** — required for `screenshot` capture (see
-//!   [`super::capture`]).
+//! - **Screen & System Audio Recording** — required for `screenshot` capture
+//!   (see [`super::capture`]).
 //! - **Accessibility** — required for input injection (click/type/etc.). This
-//!   is a *separate* grant from Screen Recording.
+//!   is a *separate* grant from screen capture.
 //!
 //! This module performs non-prompting preflight checks and can open the correct
 //! System Settings pane so the user can grant a missing permission, then retry.
 //! It never injects input and never blocks; callers gate side effects on
 //! [`preflight`] and surface [`PermissionError`] when a required grant is
-//! missing rather than acting on a stale assumption.
+//! missing rather than acting on a stale assumption. TCC grants are evaluated
+//! for the current executable identity, so diagnostics include the actual
+//! launcher path and pid instead of implying that a grant for Terminal, Bun,
+//! or a previous GJC binary applies automatically.
 
 use std::process::Command;
 
@@ -34,7 +37,7 @@ unsafe extern "C" {
 pub enum TccPermission {
 	/// Accessibility — required for input injection.
 	Accessibility,
-	/// Screen Recording — required for screen capture.
+	/// Screen & System Audio Recording — required for screen capture.
 	ScreenRecording,
 }
 
@@ -58,7 +61,7 @@ impl TccPermission {
 pub struct PreflightStatus {
 	/// Whether Accessibility (input injection) is granted.
 	pub accessibility:    bool,
-	/// Whether Screen Recording (capture) is granted.
+	/// Whether Screen & System Audio Recording (capture) is granted.
 	pub screen_recording: bool,
 }
 
@@ -75,12 +78,16 @@ impl std::fmt::Display for PermissionError {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		let (name, what) = match self.missing {
 			TccPermission::Accessibility => ("Accessibility", "inject input"),
-			TccPermission::ScreenRecording => ("Screen Recording", "capture the screen"),
+			TccPermission::ScreenRecording => {
+				("Screen & System Audio Recording", "capture the screen")
+			},
 		};
 		write!(
 			f,
 			"COMPUTER_PERMISSION_REQUIRED: {name} permission is required to {what}. Grant it in \
-			 System Settings (opened for you), then retry."
+			 System Settings for the current GJC launcher, then fully quit and relaunch GJC before \
+			 retrying. {}",
+			current_process_diagnostic()
 		)
 	}
 }
@@ -95,12 +102,25 @@ pub fn accessibility_granted() -> bool {
 	unsafe { AXIsProcessTrusted() }
 }
 
-/// Whether the process already has Screen Recording access (no prompt).
+/// Whether the process already has Screen & System Audio Recording access (no
+/// prompt).
 #[must_use]
 pub fn screen_recording_granted() -> bool {
 	// SAFETY: `CGPreflightScreenCaptureAccess` takes no arguments and only reads
-	// the current process's capture-access state.
+	// the current process's TCC access state.
 	unsafe { CGPreflightScreenCaptureAccess() }
+}
+
+/// Identify the process whose TCC grant is being queried.
+///
+/// macOS privacy grants are evaluated for the current executable's code
+/// identity. The path is especially important in development, where GJC may
+/// run as Bun, a compiled ad-hoc binary, or a launcher from another terminal.
+#[must_use]
+pub fn current_process_diagnostic() -> String {
+	let executable = std::env::current_exe()
+		.map_or_else(|_| "<unavailable>".to_string(), |path| path.display().to_string());
+	format!("TCC identity: executable={executable}, pid={}", std::process::id())
 }
 
 /// Read the current grant state for both required permissions.
@@ -137,13 +157,13 @@ pub fn require_accessibility_for_input() -> Result<(), PermissionError> {
 	Err(PermissionError { missing: TccPermission::Accessibility })
 }
 
-/// Ensure Screen Recording is granted for capture.
+/// Ensure Screen & System Audio Recording is granted for capture.
 ///
 /// On failure, opens the Screen Recording settings pane and returns
 /// [`PermissionError`].
 ///
 /// # Errors
-/// Returns [`PermissionError`] when Screen Recording is not granted.
+/// Returns [`PermissionError`] when screen capture permission is not granted.
 pub fn require_screen_recording_for_capture() -> Result<(), PermissionError> {
 	if screen_recording_granted() {
 		return Ok(());
@@ -154,7 +174,7 @@ pub fn require_screen_recording_for_capture() -> Result<(), PermissionError> {
 
 #[cfg(test)]
 mod tests {
-	use super::{TccPermission, preflight};
+	use super::{PermissionError, TccPermission, current_process_diagnostic, preflight};
 
 	#[test]
 	fn settings_urls_target_the_privacy_panes() {
@@ -168,6 +188,21 @@ mod tests {
 				.settings_url()
 				.contains("Privacy_ScreenCapture")
 		);
+	}
+
+	#[test]
+	fn diagnostic_identifies_the_process_being_checked() {
+		let diagnostic = current_process_diagnostic();
+		assert!(diagnostic.contains("TCC identity: executable="));
+		assert!(diagnostic.contains("pid="));
+	}
+
+	#[test]
+	fn permission_error_explains_launcher_identity_and_relaunch() {
+		let message = PermissionError { missing: TccPermission::Accessibility }.to_string();
+		assert!(message.contains("current GJC launcher"));
+		assert!(message.contains("fully quit and relaunch"));
+		assert!(message.contains("TCC identity:"));
 	}
 
 	/// Reports the live TCC grant state. Ignored by default (result depends on

--- a/docs/computer-use/README.md
+++ b/docs/computer-use/README.md
@@ -30,9 +30,12 @@ the committed summary and roadmap.
 - **Coordinate contract:** a single normalized virtual display. The returned
   screenshot's pixel dimensions *are* the action coordinate space; Rust owns the
   transform to macOS logical points (Retina/HiDPI-safe) and display selection.
-- **Permissions:** macOS TCC (Accessibility + Screen Recording) auto-preflighted;
-  on a missing grant, open the relevant Settings pane and return a clear
-  "grant then retry/relaunch" error.
+- **Permissions:** macOS TCC (Accessibility + Screen & System Audio Recording)
+  is checked for the actual GJC launcher; on a missing grant, open the
+  relevant Settings pane and return a clear "grant then fully relaunch" error.
+  macOS grants belong to the launcher's code identity, so a permission granted
+  to Terminal, Bun, or an older rebuilt binary is not proof that the current
+  executable can capture or inject input.
 - **Gating:** off by default; opt-in config flag (per session) plus a persistent
   always-on option.
 - **Safety:** no per-action approval (autonomous), **but** a daemon-enforced
@@ -58,8 +61,9 @@ invalid scale) and requires no display or granted permissions.
 `crates/pi-natives/src/computer/capture.rs` (macOS) implements the read-only
 `screenshot` primitive: it captures the primary display via CoreGraphics into a
 PNG and derives the `NormalizedDisplay` scale from captured physical pixels vs
-logical bounds, surfacing a missing Screen Recording grant as
-`CaptureError::CaptureFailed` (never a silent black frame). Verified live: a
+logical bounds. It only classifies a failed capture as a missing permission
+when the real capture fails and the current-process preflight also reports no
+grant, avoiding false negatives from a stale preflight result. Verified live: a
 real, non-uniform primary-display capture decodes as a PNG with matching
 dimensions (`cargo test -p pi-natives --ignored captures_non_uniform_primary_display`).
 

--- a/docs/tools/computer.md
+++ b/docs/tools/computer.md
@@ -65,8 +65,8 @@ Stable computer error codes include:
 - `COMPUTER_DISABLED`
 - `COMPUTER_SUSPENDED`
 - `COMPUTER_SUPERVISOR_NOT_LIVE`
-- `COMPUTER_PERMISSION_REQUIRED`
-- `COMPUTER_SCREENSHOT_FAILED` (including missing Screen Recording permission)
+- `COMPUTER_PERMISSION_REQUIRED` (Accessibility or Screen & System Audio Recording)
+- `COMPUTER_SCREENSHOT_FAILED` (capture failed after the current-process preflight passed)
 - `COMPUTER_DISPLAY_STALE`
 - `COMPUTER_COORD_INVALID`
 - `COMPUTER_CANCELLED`
@@ -75,6 +75,13 @@ Stable computer error codes include:
 - `COMPUTER_TRANSACTION_FAILED`
 
 TS handles settings/platform exposure, UX mapping, screenshot persistence, and audit output. Native execution remains the side-effect authority for supervisor state, permissions, display freshness, coordinate validation, cancellation, release-all behavior, and the serialized cursor capture/restore transaction. Whole batches cross the native boundary once; TypeScript does not perform cursor cleanup.
+
+macOS TCC checks apply to the executable that is currently running the tool.
+For source-linked GJC this is normally Bun; for a compiled launch it is the
+compiled `gjc` binary. Grant the permission to that launcher and fully quit
+and relaunch GJC after changing the grant. GJC's macOS development and
+single-host release builds use a stable ad-hoc designated requirement so a
+rebuild does not silently become a new TCC identity.
 
 ## Rendering
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - `SdkClientError` now carries `reconnect` diagnostics on every reconnect-cycle termination: attempts consumed, the configured attempt budget, elapsed wall-clock, and whether the cycle ended from attempt exhaustion, an elapsed deadline, or cancellation. A long-lived ACP session budget truncated by an unrelated wall-clock deadline was previously indistinguishable from a host that consumed every retry, and closing during a backoff sleep escaped as a bare teardown error with no attribution at all. `details` keeps its existing meaning — the terminating transport error — so consumers reading it directly are unaffected.
+- macOS computer-use permission failures now distinguish a real Screen & System Audio Recording denial from a capture failure after a successful preflight, include the current launcher identity in diagnostics, and preserve TCC grants across GJC ad-hoc rebuilds with a stable designated requirement. Accessibility errors now carry the same launcher/relaunch guidance.
 
 ## [0.13.1] - 2026-08-11
 

--- a/packages/coding-agent/scripts/build-binary.ts
+++ b/packages/coding-agent/scripts/build-binary.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import * as path from "node:path";
+import { signMacOSBinary } from "../../../scripts/macos-code-signing";
 import { buildDevCompileArgs } from "./compile-args";
 
 const packageDir = path.join(import.meta.dir, "..");
@@ -40,7 +41,7 @@ async function main(): Promise<void> {
 			await stageWorkspaceNativeAddons();
 			// Bun 1.3.12 emits a truncated Mach-O signature on darwin builds.
 			if (shouldAdhocSignDarwinBinary()) {
-				await runCommand(["codesign", "--force", "--sign", "-", outputPath]);
+				await signMacOSBinary(outputPath, runCommand);
 			}
 		} finally {
 			await runCommand(["bun", "--cwd=../natives", "run", "embed:native", "--reset"]);

--- a/packages/coding-agent/src/tools/computer.ts
+++ b/packages/coding-agent/src/tools/computer.ts
@@ -1120,10 +1120,11 @@ function mapComputerError(error: unknown, hotkey?: string): { code: string; mess
 		COMPUTER_SUSPENDED: `Stop and wait for the user${hotkey ? ` (kill-switch hotkey: ${hotkey})` : ""}.`,
 		COMPUTER_CANCELLED: `Stop and wait for the user${hotkey ? ` (kill-switch hotkey: ${hotkey})` : ""}.`,
 		COMPUTER_PERMISSION_REQUIRED:
-			"The host needs screen-recording or accessibility permission. Ask the user to grant it.",
+			"Grant Screen & System Audio Recording or Accessibility to the exact GJC launcher named in the diagnostic, then fully quit and relaunch GJC.",
 		COMPUTER_DISABLED:
 			"The computer tool is disabled or unsupported. Do not retry without enabling it on Apple Silicon macOS.",
-		COMPUTER_SCREENSHOT_FAILED: "Capture failed. Check screen-recording permission and retry the screenshot.",
+		COMPUTER_SCREENSHOT_FAILED:
+			"Capture failed after the current-process permission preflight passed. Check display availability and retry the screenshot.",
 		COMPUTER_CURSOR_RESTORE_FAILED:
 			"Input may have completed, but the cursor could not be restored. Stop and ask the user to inspect the desktop before retrying.",
 	};

--- a/packages/coding-agent/test/tools/computer.test.ts
+++ b/packages/coding-agent/test/tools/computer.test.ts
@@ -326,6 +326,29 @@ describe("computer tool dispatch", () => {
 		expect(calls[3].args).toEqual([42, 1, 2, 5, -6]);
 	});
 
+	it("preserves native launcher permission diagnostics for direct screenshots", async () => {
+		setComputerPlatformForTests("darwin");
+		setComputerArchForTests("arm64");
+		setComputerControllerFactoryForTests(() => ({
+			screenshot: () => {
+				throw Object.assign(
+					new Error(
+						"COMPUTER_PERMISSION_REQUIRED: Screen & System Audio Recording is missing. TCC identity: executable=/tmp/gjc, pid=123",
+					),
+					{ code: "COMPUTER_PERMISSION_REQUIRED" },
+				);
+			},
+		}));
+		const tool = new ComputerTool(createSession(Settings.isolated({ "computer.enabled": true })));
+
+		const result = await tool.execute("permission-diagnostic", { action: "screenshot" });
+
+		expect(result.isError).toBe(true);
+		expect(result.details?.code).toBe("COMPUTER_PERMISSION_REQUIRED");
+		expect(textOf(result)).toContain("TCC identity: executable=/tmp/gjc");
+		expect(textOf(result)).toContain("fully quit and relaunch GJC");
+	});
+
 	it("does not invent a display epoch before any screenshot context exists", async () => {
 		setComputerPlatformForTests("darwin");
 		setComputerArchForTests("arm64");

--- a/scripts/ci-release-build-binaries.ts
+++ b/scripts/ci-release-build-binaries.ts
@@ -3,6 +3,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { buildReleaseCompileArgs } from "../packages/coding-agent/scripts/compile-args";
+import { signMacOSBinary } from "./macos-code-signing";
 
 interface BinaryTarget {
 	id: string;
@@ -132,7 +133,7 @@ async function buildBinary(target: BinaryTarget): Promise<void> {
 
 	// Bun 1.3.12 emits a truncated Mach-O signature on darwin builds.
 	if (shouldAdhocSignDarwinBinary(target)) {
-		await runCommand(["codesign", "--force", "--sign", "-", path.join(repoRoot, target.outfile)], repoRoot);
+		await signMacOSBinary(path.join(repoRoot, target.outfile), command => runCommand(command, repoRoot));
 	}
 }
 

--- a/scripts/macos-code-signing.test.ts
+++ b/scripts/macos-code-signing.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import {
+	GJC_MACOS_CODE_SIGNING_IDENTIFIER,
+	GJC_MACOS_DESIGNATED_REQUIREMENT,
+	buildMacOSAdHocCodeSignCommand,
+	signMacOSBinary,
+} from "./macos-code-signing";
+
+describe("macOS GJC code signing", () => {
+	test("uses a stable identifier requirement instead of the binary CDHash", () => {
+		const command = buildMacOSAdHocCodeSignCommand("/tmp/gjc.req", "/tmp/gjc");
+
+		expect(command).toEqual([
+			"codesign",
+			"--force",
+			"--sign",
+			"-",
+			"--identifier",
+			GJC_MACOS_CODE_SIGNING_IDENTIFIER,
+			"--requirements",
+			"/tmp/gjc.req",
+			"/tmp/gjc",
+		]);
+		expect(GJC_MACOS_DESIGNATED_REQUIREMENT).toBe(
+			`designated => identifier "${GJC_MACOS_CODE_SIGNING_IDENTIFIER}"`,
+		);
+	});
+
+	test("removes the temporary requirement after signing succeeds", async () => {
+		let command: string[] | undefined;
+		let requirement: string | undefined;
+		await signMacOSBinary("/tmp/gjc", async value => {
+			command = value;
+			requirement = await Bun.file(value[7]!).text();
+		});
+
+		expect(command?.[5]).toBe(GJC_MACOS_CODE_SIGNING_IDENTIFIER);
+		expect(requirement).toBe(`${GJC_MACOS_DESIGNATED_REQUIREMENT}\n`);
+		expect(command?.[7] ? await Bun.file(command[7]).exists() : true).toBe(false);
+	});
+
+	test("removes the temporary requirement when signing fails", async () => {
+		let requirementPath: string | undefined;
+		await expect(
+			signMacOSBinary("/tmp/gjc", async command => {
+				requirementPath = command[7];
+				throw new Error("codesign failed");
+			}),
+		).rejects.toThrow("codesign failed");
+
+		expect(requirementPath ? await Bun.file(requirementPath).exists() : true).toBe(false);
+	});
+});

--- a/scripts/macos-code-signing.ts
+++ b/scripts/macos-code-signing.ts
@@ -1,0 +1,49 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/** Stable code identity used by GJC's ad-hoc macOS development binaries. */
+export const GJC_MACOS_CODE_SIGNING_IDENTIFIER = "com.gajae-code.gjc";
+
+/**
+ * TCC stores the designated requirement, not only the display identifier.
+ * An ad-hoc signature's default requirement is its changing CDHash, so every
+ * rebuild otherwise looks like a new app to macOS privacy services.
+ */
+export const GJC_MACOS_DESIGNATED_REQUIREMENT =
+	`designated => identifier "${GJC_MACOS_CODE_SIGNING_IDENTIFIER}"`;
+
+export function buildMacOSAdHocCodeSignCommand(requirementPath: string, binaryPath: string): string[] {
+	return [
+		"codesign",
+		"--force",
+		"--sign",
+		"-",
+		"--identifier",
+		GJC_MACOS_CODE_SIGNING_IDENTIFIER,
+		"--requirements",
+		requirementPath,
+		binaryPath,
+	];
+}
+
+/**
+ * Sign a Darwin binary with a stable ad-hoc designated requirement.
+ *
+ * The requirement is passed through a temporary file because `codesign -r`
+ * accepts a requirement file, not an inline requirement string. The caller
+ * owns command execution so build scripts can preserve their cwd/env policy.
+ */
+export async function signMacOSBinary(
+	binaryPath: string,
+	runCommand: (command: string[]) => Promise<void>,
+): Promise<void> {
+	const requirementPath = path.join(os.tmpdir(), `gjc-codesign-${process.pid}-${crypto.randomUUID()}.req`);
+	await Bun.write(requirementPath, `${GJC_MACOS_DESIGNATED_REQUIREMENT}\n`);
+	try {
+		await runCommand(buildMacOSAdHocCodeSignCommand(requirementPath, binaryPath));
+	} finally {
+		await fs.rm(requirementPath, { force: true });
+	}
+}

--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -638,7 +638,7 @@
     "crates/pi-natives/src/path_identity.rs": "c432ead23fdd22241bdff8b882d9d4556acfffcb94424d1c417162f948398690",
     "crates/pi-natives/src/ps.rs": "7696078e123b9beecc7252371c71eab2cec590413be6e6ddf4692ff6fe8c41e1",
     "crates/pi-shell/src/process.rs": "45b222432a70eb056807507f8b4d28cf5fb73a7441ee9a0e28349ec85ef9b177",
-    "crates/pi-shell/src/shell.rs": "66cacfe63d495b23156d023f2f34f354b657534ee3cdaf01e30d6694af253982",
+    "crates/pi-shell/src/shell.rs": "cc0584dbd21a35838e464e6a10f2e974362a800a9a5747b7bac34cb9d2a1f9cd",
     "crates/brush-core-vendored/src/commands.rs": "55e9dceffad7d829051547e91592ca8e392a9073e2d4ee2f7546e3b6c1b75a9d",
     "packages/natives/native/index.d.ts": "c61e02fd4712c822d30fb4b1496f064097a38718c9443bef526711f828165c50",
     "packages/coding-agent/src/sdk/broker/process-incarnation.ts": "3846556b59c8850f584d13d2eec8a482f6a9b7f4ff66d126f8bd66cad4329a9c"


### PR DESCRIPTION
## Summary

- keep the ad-hoc macOS GJC code identity stable across development and release binary rebuilds
- classify Core Graphics capture failures using the real capture result plus current-process TCC preflight
- preserve Screen & System Audio Recording failures through native batches and expose the exact launcher identity/pid
- improve computer-tool recovery guidance and add regression coverage

## Root cause

Bun's compiled Darwin output was ad-hoc signed with a changing CDHash/designated requirement. macOS TCC therefore treated each rebuild as a different executable even when System Settings still showed an older GJC binary as allowed. Source-linked launches can also be Bun or another launcher, so checking a grant for Terminal or a previous binary is not evidence for the current process.

## Verification

- `cargo test -p pi-natives computer::` — 61 passed
- `cargo test -p pi-natives captures_non_uniform_primary_display -- --ignored` — passed on macOS with live capture
- live `ComputerController.screenshot()` probe — 3456x2234 PNG succeeded
- `bun --cwd=packages/coding-agent run build` plus `codesign -dvvv --requirements -` — stable identifier `com.gajae-code.gjc` and designated requirement verified
- `bun --cwd=packages/coding-agent run check` — passed
- focused computer/signing tests — passed
- full repository check reaches only two pre-existing SDK canonicalization violations on `dev`: the stale daemon session route and the internal `commands/sdk.ts` dispatch contract

The PR is intentionally limited to macOS signing/TCC diagnostics and computer-use permission behavior.
