### PR TITLE
fix(ai,agent): close fail-open Responses tool-call identity/lifecycle edge cases

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -809,6 +809,7 @@ function managedAssistantContent(value: unknown): AssistantMessage["content"][nu
 	const intent = managedProperty(value, "intent");
 	const customWireName = managedProperty(value, "customWireName");
 	const incompleteArguments = managedProperty(value, "incompleteArguments");
+	const incompleteArgumentsReason = managedProperty(value, "incompleteArgumentsReason");
 	return {
 		type,
 		id,
@@ -818,6 +819,15 @@ function managedAssistantContent(value: unknown): AssistantMessage["content"][nu
 		...(typeof intent === "string" ? { intent } : {}),
 		...(typeof customWireName === "string" ? { customWireName } : {}),
 		...(typeof incompleteArguments === "boolean" ? { incompleteArguments } : {}),
+		...(typeof incompleteArgumentsReason === "string"
+			? {
+					incompleteArgumentsReason: incompleteArgumentsReason as
+						| "truncated"
+						| "malformed"
+						| "conflicting"
+						| "ambiguous",
+				}
+			: {}),
 	};
 }
 
@@ -2733,15 +2743,19 @@ async function executeToolCalls(
 			try {
 				if (toolCall.incompleteArguments) {
 					record.argumentValidationFailed = true;
-					// The provider flagged this call's argument JSON as truncated
-					// (the model hit its output-token limit mid-call). Executing the
-					// best-effort partial parse would run the tool on wrong input, so
-					// reject with a retryable, actionable error instead.
-					throw new Error(
-						`Tool call "${toolCall.name}" was cut off before its arguments finished streaming ` +
-							`(the response hit its output token limit). The partial arguments cannot be executed. ` +
-							`Re-issue the call with complete arguments, splitting the work into smaller steps if needed.`,
-					);
+					// The provider flagged this call's arguments as unsafe to execute.
+					// The typed reason selects accurate recovery guidance; callers that
+					// only read the boolean still get a safe, actionable rejection.
+					const reason = toolCall.incompleteArgumentsReason;
+					const detail =
+						reason === "malformed"
+							? `The terminal arguments for tool call "${toolCall.name}" did not decode to a valid JSON object. The arguments cannot be executed. Re-issue the call with valid, complete arguments.`
+							: reason === "conflicting"
+								? `The streamed and terminal arguments for tool call "${toolCall.name}" disagree. The arguments cannot be executed safely. Re-issue the call with consistent arguments.`
+								: reason === "ambiguous"
+									? `The identity of tool call "${toolCall.name}" was ambiguous on the wire (duplicate call id or id/call_id collision), so its arguments cannot be safely attributed. Re-issue the call.`
+									: `Tool call "${toolCall.name}" was cut off before its arguments finished streaming (the response hit its output token limit). The partial arguments cannot be executed. Re-issue the call with complete arguments, splitting the work into smaller steps if needed.`;
+					throw new Error(detail);
 				}
 				if (!tool) {
 					// A discoverable tool that hasn't been activated yet resolves to

--- a/packages/agent/test/agent-loop-truncated-toolcall.test.ts
+++ b/packages/agent/test/agent-loop-truncated-toolcall.test.ts
@@ -94,3 +94,125 @@ describe("agentLoop: truncated tool-call guard", () => {
 		expect(executed).toEqual([{ path: "a.ts" }]);
 	});
 });
+
+describe("agentLoop: reason-specific incompleteArguments guidance", () => {
+	function identityConverter(messages: AgentMessage[]): Message[] {
+		return messages.filter(m => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
+	}
+
+	async function runWithReason(reason: "truncated" | "malformed" | "conflicting" | "ambiguous"): Promise<string> {
+		const toolSchema = z.object({ path: z.string(), content: z.string() });
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "write_file",
+			label: "Write",
+			description: "Write a file",
+			parameters: toolSchema,
+			async execute() {
+				return { content: [{ type: "text", text: "wrote" }], details: {} };
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [
+						{
+							type: "toolCall",
+							id: "tc-1",
+							name: "write_file",
+							arguments: { path: "a.ts", content: "partial" },
+							incompleteArguments: true,
+							incompleteArgumentsReason: reason,
+						},
+					],
+					stopReason: "length",
+				},
+				{ content: ["recovered"] },
+			],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter, fallbackManaged: true };
+		const toolResults: Array<{ isError?: boolean; text: string }> = [];
+		const stream = agentLoop([createUserMessage("write the file")], context, config, undefined, mock.stream);
+		for await (const event of stream) {
+			if (event.type === "tool_execution_end") {
+				const first = event.result.content?.[0];
+				toolResults.push({ isError: event.isError, text: first?.type === "text" ? first.text : "" });
+			}
+		}
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0].isError).toBe(true);
+		return toolResults[0].text;
+	}
+
+	it("gives malformed-specific guidance (not truncation) for malformed terminal arguments", async () => {
+		const text = await runWithReason("malformed");
+		expect(text).toContain("did not decode to a valid JSON object");
+		expect(text).not.toContain("cut off");
+		expect(text.toLowerCase()).toContain("re-issue");
+	});
+
+	it("gives conflicting-specific guidance for streamed/terminal payload disagreement", async () => {
+		const text = await runWithReason("conflicting");
+		expect(text).toContain("disagree");
+		expect(text).not.toContain("cut off");
+		expect(text.toLowerCase()).toContain("re-issue");
+	});
+
+	it("gives ambiguous-identity guidance for duplicate call_id / id collision", async () => {
+		const text = await runWithReason("ambiguous");
+		expect(text).toContain("ambiguous");
+		expect(text).toContain("call id");
+		expect(text.toLowerCase()).toContain("re-issue");
+	});
+
+	it("still gives truncation guidance when reason is truncated", async () => {
+		const text = await runWithReason("truncated");
+		expect(text).toContain("cut off");
+		expect(text.toLowerCase()).toContain("re-issue");
+	});
+
+	it("falls back to truncation guidance when reason is absent but boolean is set", async () => {
+		const toolSchema = z.object({ path: z.string(), content: z.string() });
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "write_file",
+			label: "Write",
+			description: "Write a file",
+			parameters: toolSchema,
+			async execute() {
+				return { content: [{ type: "text", text: "wrote" }], details: {} };
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [
+						{
+							type: "toolCall",
+							id: "tc-1",
+							name: "write_file",
+							arguments: { path: "a.ts", content: "partial" },
+							incompleteArguments: true,
+							// No reason — backward-compatible callers.
+						},
+					],
+					stopReason: "length",
+				},
+				{ content: ["recovered"] },
+			],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter, fallbackManaged: true };
+		const toolResults: Array<{ isError?: boolean; text: string }> = [];
+		const stream = agentLoop([createUserMessage("write the file")], context, config, undefined, mock.stream);
+		for await (const event of stream) {
+			if (event.type === "tool_execution_end") {
+				const first = event.result.content?.[0];
+				toolResults.push({ isError: event.isError, text: first?.type === "text" ? first.text : "" });
+			}
+		}
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0].isError).toBe(true);
+		expect(toolResults[0].text).toContain("cut off");
+		expect(toolResults[0].text.toLowerCase()).toContain("re-issue");
+	});
+});

--- a/packages/agent/test/managed-attempt-trajectory.test.ts
+++ b/packages/agent/test/managed-attempt-trajectory.test.ts
@@ -65,6 +65,7 @@ describe("managed attempt trajectory", () => {
 			name: "write_file",
 			arguments: { path: "a.ts" },
 			incompleteArguments: true,
+			incompleteArgumentsReason: "truncated",
 		});
 		expect(executed).toHaveLength(0);
 		expect(toolResults).toHaveLength(1);

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1560,6 +1560,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 					if (orphaned.type === "toolCall") {
 						if (!isCompleteJson(orphaned.partialJson)) {
 							orphaned.incompleteArguments = true;
+							orphaned.incompleteArgumentsReason = "truncated";
 							truncatedToolCalls.add(orphaned);
 						}
 						if (orphaned.partialJson.trim()) {
@@ -2149,6 +2150,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 				for (const block of output.content) {
 					if (block.type === "toolCall" && truncatedToolCalls.has(block)) {
 						block.incompleteArguments = true;
+						block.incompleteArgumentsReason = "truncated";
 					}
 				}
 			}

--- a/packages/ai/src/providers/mock.ts
+++ b/packages/ai/src/providers/mock.ts
@@ -75,8 +75,9 @@ export type MockContent =
 			arguments: Record<string, unknown> | string;
 			/** Simulate a provider-flagged truncated call (cut off mid-arguments). */
 			incompleteArguments?: boolean;
+			/** Typed reason matching `ToolCall.incompleteArgumentsReason`. Defaults to `"truncated"`. */
+			incompleteArgumentsReason?: "truncated" | "malformed" | "conflicting" | "ambiguous";
 	  };
-
 /** One scripted response. */
 export interface MockResponse {
 	/** Content blocks to emit, in order. Strings become text blocks. */
@@ -422,7 +423,9 @@ function normalizeContent(input: MockContent, state: MockModel): TextContent | T
 			id: input.id ?? generateToolCallId(state),
 			name: input.name,
 			arguments: typeof input.arguments === "string" ? input.arguments : { ...input.arguments },
-			...(input.incompleteArguments ? { incompleteArguments: true } : {}),
+			...(input.incompleteArguments
+				? { incompleteArguments: true, incompleteArgumentsReason: input.incompleteArgumentsReason ?? "truncated" }
+				: {}),
 		} as ToolCall;
 	}
 	return input;

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -591,7 +591,10 @@ export const streamOllama: StreamFunction<"ollama-chat"> = (
 						for (const block of output.content) {
 							if (block.type !== "toolCall") continue;
 							const partialJson = (block as InternalToolCallBlock).partialJson;
-							if (partialJson !== undefined && !isCompleteJson(partialJson)) block.incompleteArguments = true;
+							if (partialJson !== undefined && !isCompleteJson(partialJson)) {
+								block.incompleteArguments = true;
+								block.incompleteArgumentsReason = "truncated";
+							}
 						}
 					}
 					for (const index of activeToolIndices) {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1020,6 +1020,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				const partial = (currentBlock as { partialArgs?: string }).partialArgs;
 				if (partial !== undefined && !isCompleteJson(partial)) {
 					currentBlock.incompleteArguments = true;
+					currentBlock.incompleteArgumentsReason = "truncated";
 				}
 			}
 

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -413,6 +413,20 @@ export async function processResponsesStream<TApi extends Api>(
 		 * real payload only in that snapshot.
 		 */
 		addedArguments: string;
+		/**
+		 * Set when this entry's tool identity is ambiguous (a duplicate `call_id`,
+		 * an `id`/`call_id` namespace collision, or any other shape where a delta
+		 * cannot be unambiguously attributed). The entry is finalized as
+		 * `incompleteArguments` so the agent loop rejects it instead of executing
+		 * possibly-misattributed arguments.
+		 */
+		ambiguousIdentity: boolean;
+		/**
+		 * Whether this entry has already been finalized by a terminal
+		 * `response.output_item.done`. A duplicate terminal event for the same item
+		 * must not emit a second `toolcall_end`/`text_end`/`thinking_end`.
+		 */
+		finalized: boolean;
 	}
 	// Per-item argument buffer keyed on stable item identity. Multiple tool-call
 	// items can stream interleaved argument deltas in one response, so a single
@@ -437,8 +451,17 @@ export async function processResponsesStream<TApi extends Api>(
 	): ItemEntry | undefined => {
 		if (itemId) {
 			const byId = items.get(idKey(itemId));
-			if (byId) return byId;
 			const byCallId = items.get(callKey(itemId));
+			// Ambiguous identity: `item_id` matches one entry as its canonical id and
+			// a *different* entry as its `call_id` (an id/call_id namespace collision).
+			// Picking either silently mis-attributes the payload, so mark both
+			// ambiguous and drop the delta instead of resolving.
+			if (byId && byCallId && byId !== byCallId) {
+				byId.ambiguousIdentity = true;
+				byCallId.ambiguousIdentity = true;
+				return undefined;
+			}
+			if (byId) return byId;
 			if (byCallId) return byCallId;
 		}
 		if (hasIndex(outputIndex)) {
@@ -460,15 +483,45 @@ export async function processResponsesStream<TApi extends Api>(
 			rawBuffer: "",
 			summaryStarted: false,
 			addedArguments: item.type === "function_call" ? (item.arguments ?? "") : "",
+			ambiguousIdentity: false,
+			finalized: false,
 		};
 		// Primary key prefers the stable item id; if the wire omits it, fall back to
 		// the positional index. A synthetic key keeps the entry addressable as lastKey
 		// for continuation-style non-tool events even when neither is present.
 		const key = item.id ? idKey(item.id) : hasIndex(outputIndex) ? idxKey(outputIndex) : `seq:${items.size}`;
 		items.set(key, entry);
-		if (item.id && hasIndex(outputIndex)) items.set(idxKey(outputIndex), entry);
+		// Index alias: only claim it when no other entry already holds it. Two items
+		// sharing one `output_index` (a relay defect) must not have the second steal
+		// the alias and drop the first's index-routed deltas; each stays addressable
+		// by its own stable id/call_id, and the index keeps resolving to the first
+		// occupant rather than silently reassigning.
+		if (hasIndex(outputIndex)) {
+			const idxK = idxKey(outputIndex);
+			if (!items.has(idxK)) items.set(idxK, entry);
+		}
 		if ((item.type === "function_call" || item.type === "custom_tool_call") && item.call_id) {
-			items.set(callKey(item.call_id), entry);
+			const callK = callKey(item.call_id);
+			const existing = items.get(callK);
+			// Duplicate `call_id` in one response: two distinct items claim the same
+			// alias. Fail closed for both — neither's arguments can be trusted to
+			// belong to the right call once their deltas and terminals are aliased.
+			if (existing && existing !== entry) {
+				existing.ambiguousIdentity = true;
+				entry.ambiguousIdentity = true;
+			} else if (!existing) {
+				items.set(callK, entry);
+			}
+		}
+		// Detect an id/call_id collision at registration too: a new item whose id
+		// equals another item's call_id (or vice versa) makes id-based resolution
+		// ambiguous for any delta keyed on that shared string.
+		if (item.id) {
+			const callAliasOfOther = items.get(callKey(item.id));
+			if (callAliasOfOther && callAliasOfOther !== entry) {
+				callAliasOfOther.ambiguousIdentity = true;
+				entry.ambiguousIdentity = true;
+			}
 		}
 		lastKey = key;
 		return entry;
@@ -479,6 +532,7 @@ export async function processResponsesStream<TApi extends Api>(
 			(callId ? items.get(callKey(callId)) : undefined) ??
 			(hasIndex(outputIndex) ? items.get(idxKey(outputIndex)) : undefined);
 		if (!entry) return;
+		entry.finalized = true;
 		for (const [key, candidate] of items) {
 			if (candidate !== entry) continue;
 			items.delete(key);
@@ -675,6 +729,14 @@ export async function processResponsesStream<TApi extends Api>(
 			const entry =
 				resolveEntry(item.id, event.output_index, "never") ??
 				(isToolItem && item.call_id ? resolveEntry(item.call_id, event.output_index, "never") : undefined);
+			// A duplicate terminal event for an item already finalized (dropped) must
+			// not emit a second end event. After finalization the entry is gone from
+			// the map, so a second `output_item.done` for the same tool item resolves
+			// to no live entry — skip it rather than re-emitting.
+			// An orphan terminal event (no preceding `output_item.added`, so no live
+			// entry) for a tool item must not synthesize a phantom block at a stale
+			// content index. Only finalize tool items that resolved to a live entry.
+			if (isToolItem && !entry) continue;
 			if (item.type === "reasoning") {
 				// Prefer the streamed summary buffer only when it carries real text. When it
 				// holds only synthetic separators (e.g. a part.done arrived before/without any
@@ -787,22 +849,40 @@ export async function processResponsesStream<TApi extends Api>(
 						: parseStreamingJson(rawArguments);
 				// Function-call arguments must decode to a JSON object; `null`, arrays and
 				// scalars cannot be dispatched against a tool schema, so they fail closed
-				// instead of reaching validation as a non-record value.
-				const incompleteArguments = !isJsonRecord(decodedArguments);
+				// instead of reaching validation as a non-record value. An ambiguous
+				// tool-call identity (duplicate call_id, id/call_id collision) also fails
+				// closed: attribution of the streamed/terminal payload is unsafe.
+				const ambiguousIdentity = entry?.ambiguousIdentity ?? false;
+				const incompleteArguments = ambiguousIdentity || !isJsonRecord(decodedArguments);
 				const args = incompleteArguments ? {} : (decodedArguments as Record<string, unknown>);
+				// Typed reason lets the agent loop give accurate recovery guidance instead
+				// of always suggesting "split the work" (truncation-only) for a malformed
+				// or conflicting terminal payload, or an ambiguous identity.
+				const incompleteArgumentsReason: "malformed" | "conflicting" | "ambiguous" | undefined = incompleteArguments
+					? ambiguousIdentity
+						? "ambiguous"
+						: conflictingArgumentSources
+							? "conflicting"
+							: "malformed"
+					: undefined;
 				const toolCall: ToolCall = {
 					type: "toolCall",
 					id: encodeResponsesToolCallId(item.call_id, item.id),
 					name: item.name,
 					arguments: args,
-					...(incompleteArguments ? { incompleteArguments: true } : {}),
+					...(incompleteArguments ? { incompleteArguments: true, incompleteArgumentsReason } : {}),
 				};
 				if (entry?.block.type === "toolCall") {
 					entry.block.id = toolCall.id;
 					entry.block.name = toolCall.name;
 					entry.block.arguments = args;
-					if (incompleteArguments) entry.block.incompleteArguments = true;
-					else delete entry.block.incompleteArguments;
+					if (incompleteArguments) {
+						entry.block.incompleteArguments = true;
+						entry.block.incompleteArgumentsReason = incompleteArgumentsReason;
+					} else {
+						delete entry.block.incompleteArguments;
+						delete entry.block.incompleteArgumentsReason;
+					}
 				}
 				const contentIndex = entry?.blockContentIndex ?? output.content.length - 1;
 				dropEntry(item.id, event.output_index, item.call_id);
@@ -918,13 +998,17 @@ export function flagTruncatedToolCalls(
 		if (block.type !== "toolCall") continue;
 		if (!isFinalized(block)) {
 			block.incompleteArguments = true;
+			block.incompleteArgumentsReason = "truncated";
 			continue;
 		}
 		// Finalized: custom tools carry raw (non-JSON) input and are complete once
 		// finalized; only JSON function calls get the parse double-check.
 		if (!block.customWireName) {
 			const partial = (block as { partialJson?: string }).partialJson;
-			if (partial !== undefined && !isCompleteJson(partial)) block.incompleteArguments = true;
+			if (partial !== undefined && !isCompleteJson(partial)) {
+				block.incompleteArguments = true;
+				block.incompleteArgumentsReason = "truncated";
+			}
 		}
 	}
 }

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -577,13 +577,27 @@ export interface ToolCall {
 	 */
 	customWireName?: string;
 	/**
-	 * Set when the provider detected the argument JSON was truncated — the model
-	 * hit its output-token limit (or the response was otherwise cut short) before
-	 * emitting a complete arguments object. The `arguments` field then holds a
-	 * best-effort partial parse and must not be executed as-is; the agent loop
-	 * rejects the call with a retryable error instead.
+	 * Set when the provider detected the argument JSON was not safely executable —
+	 * the model hit its output-token limit (or the response was otherwise cut short)
+	 * before emitting a complete arguments object, the terminal payload was malformed,
+	 * the streamed and terminal payloads conflicted, or the tool-call identity was
+	 * ambiguous on the wire. The `arguments` field then holds a best-effort partial
+	 * parse and must not be executed as-is; the agent loop rejects the call with a
+	 * retryable, reason-specific error instead.
 	 */
 	incompleteArguments?: boolean;
+	/**
+	 * When `incompleteArguments` is set, the typed cause so the agent loop can give
+	 * reason-specific recovery guidance:
+	 *  - `"truncated"`: the response was cut short mid-arguments (output-token limit).
+	 *  - `"malformed"`: the terminal arguments did not decode to a valid JSON object.
+	 *  - `"conflicting"`: the streamed and terminal argument payloads disagree.
+	 *  - `"ambiguous"`: the tool-call identity could not be unambiguously resolved
+	 *    (duplicate `call_id`, id/call_id collision, etc.), so attribution is unsafe.
+	 * Absent when `incompleteArguments` is not set. Existing callers that read only
+	 * `incompleteArguments` continue to work.
+	 */
+	incompleteArgumentsReason?: "truncated" | "malformed" | "conflicting" | "ambiguous";
 }
 
 export interface Usage {

--- a/packages/ai/test/openai-responses-multi-toolcall-stream-adversarial.test.ts
+++ b/packages/ai/test/openai-responses-multi-toolcall-stream-adversarial.test.ts
@@ -587,4 +587,214 @@ describe("Adversarial Responses stream red-team", () => {
 		expect((preTool.arguments as Record<string, unknown>).text).toBeUndefined();
 		expect((postTool.arguments as Record<string, unknown>).text).toBeUndefined();
 	});
+
+	// -----------------------------------------------------------------------
+	// Issue #4274: five fail-open identity/lifecycle shapes that must now
+	// fail closed. Each was verified to reproduce on the exact base before fix.
+	// -----------------------------------------------------------------------
+
+	test("#4274-1: duplicate call_id fails closed for both items", async () => {
+		const events = [
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "function_call", id: "fc_a", call_id: "dup", name: "alpha_tool", arguments: "" },
+			},
+			{
+				type: "response.output_item.added",
+				output_index: 1,
+				item: { type: "function_call", id: "fc_b", call_id: "dup", name: "beta_tool", arguments: "" },
+			},
+			{ type: "response.function_call_arguments.delta", item_id: "fc_a", output_index: 0, delta: '{"x":1}' },
+			{ type: "response.function_call_arguments.delta", item_id: "fc_b", output_index: 1, delta: '{"y":2}' },
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: { type: "function_call", id: "fc_a", call_id: "dup", name: "alpha_tool", arguments: '{"x":1}' },
+			},
+			{
+				type: "response.output_item.done",
+				output_index: 1,
+				item: { type: "function_call", id: "fc_b", call_id: "dup", name: "beta_tool", arguments: '{"y":2}' },
+			},
+		];
+		const output = makeOutput();
+		const { emitted, stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		const blocks = toolBlocks(output);
+		expect(blocks).toHaveLength(2);
+		// Both must be fail-closed — ambiguous identity means neither is executable.
+		for (const block of blocks) {
+			expect(block.incompleteArguments).toBe(true);
+			expect(block.incompleteArgumentsReason).toBe("ambiguous");
+		}
+		const ends = toolCallEnds(emitted);
+		expect(ends).toHaveLength(2);
+		for (const end of ends) {
+			expect(end.toolCall.incompleteArguments).toBe(true);
+			expect(end.toolCall.incompleteArgumentsReason).toBe("ambiguous");
+		}
+	});
+
+	test("#4274-2: item_id/call_id namespace collision fails closed", async () => {
+		// item A has id "shared"; item B has call_id "shared". A delta keyed on
+		// "shared" is ambiguous — it matches A's id and B's call_id.
+		const events = [
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "function_call", id: "shared", call_id: "call_a", name: "alpha_tool", arguments: "" },
+			},
+			{
+				type: "response.output_item.added",
+				output_index: 1,
+				item: { type: "function_call", id: "fc_b", call_id: "shared", name: "beta_tool", arguments: "" },
+			},
+			// Ambiguous delta: item_id "shared" resolves to both A (by id) and B (by call_id).
+			{ type: "response.function_call_arguments.delta", item_id: "shared", delta: '{"poison":true}' },
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: { type: "function_call", id: "shared", call_id: "call_a", name: "alpha_tool", arguments: "" },
+			},
+			{
+				type: "response.output_item.done",
+				output_index: 1,
+				item: { type: "function_call", id: "fc_b", call_id: "shared", name: "beta_tool", arguments: "{}" },
+			},
+		];
+		const output = makeOutput();
+		const { stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		const blocks = toolBlocks(output);
+		expect(blocks).toHaveLength(2);
+		// At least the colliding items must be fail-closed (ambiguous identity).
+		const ambiguous = blocks.filter(b => b.incompleteArgumentsReason === "ambiguous");
+		expect(ambiguous.length).toBeGreaterThanOrEqual(1);
+		// No poison leaked into either block's arguments.
+		for (const block of blocks) {
+			expect((block.arguments as Record<string, unknown>).poison).toBeUndefined();
+		}
+	});
+
+	test("#4274-3: duplicate output_item.done does not emit a second toolcall_end", async () => {
+		const events = [
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "function_call", id: "fc_x", call_id: "call_x", name: "alpha_tool", arguments: "" },
+			},
+			{ type: "response.function_call_arguments.delta", item_id: "fc_x", output_index: 0, delta: '{"a":1}' },
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: { type: "function_call", id: "fc_x", call_id: "call_x", name: "alpha_tool", arguments: '{"a":1}' },
+			},
+			// Duplicate terminal event for the same item.
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: { type: "function_call", id: "fc_x", call_id: "call_x", name: "alpha_tool", arguments: '{"a":1}' },
+			},
+		];
+		const output = makeOutput();
+		const { emitted, stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		const ends = toolCallEnds(emitted);
+		// Exactly one toolcall_end — the duplicate is ignored.
+		expect(ends).toHaveLength(1);
+		expect(ends[0]?.contentIndex).toBe(0);
+		expect(ends[0]?.toolCall.arguments).toEqual({ a: 1 });
+	});
+
+	test("#4274-4: orphan output_item.done emits no phantom toolcall_end", async () => {
+		// No output_item.added precedes this terminal event — it is an orphan.
+		const events = [
+			{
+				type: "response.output_item.done",
+				output_index: 99,
+				item: {
+					type: "function_call",
+					id: "fc_orphan",
+					call_id: "call_orphan",
+					name: "alpha_tool",
+					arguments: '{"a":1}',
+				},
+			},
+		];
+		const output = makeOutput();
+		const { emitted, stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		const ends = toolCallEnds(emitted);
+		// No phantom toolcall_end at contentIndex -1, no synthesized block.
+		expect(ends).toHaveLength(0);
+		expect(output.content).toHaveLength(0);
+	});
+
+	test("#4274-5: two active items sharing output_index preserve custom-tool live input delta", async () => {
+		// Both items share output_index 0 (a relay defect). The custom tool must
+		// still receive its live streaming delta even when idx:0 is shared.
+		const events = [
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "custom_tool_call", id: "ctc", call_id: "c_custom", name: "apply_patch", input: "" },
+			},
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "function_call", id: "fc", call_id: "c_fn", name: "alpha_tool", arguments: "" },
+			},
+			// Custom-tool delta keyed on output_index 0 (no item_id) — must reach the custom tool.
+			{ type: "response.custom_tool_call_input.delta", output_index: 0, delta: "*** Begin Patch ***" },
+			// Function-call delta keyed on output_index 0 — must reach the function tool.
+			{ type: "response.function_call_arguments.delta", output_index: 0, delta: '{"command":"go"}' },
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: {
+					type: "custom_tool_call",
+					id: "ctc",
+					call_id: "c_custom",
+					name: "apply_patch",
+					input: "*** Begin Patch ***",
+				},
+			},
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: {
+					type: "function_call",
+					id: "fc",
+					call_id: "c_fn",
+					name: "alpha_tool",
+					arguments: '{"command":"go"}',
+				},
+			},
+		];
+		const output = makeOutput();
+		const { emitted, stream } = makeCapture();
+		await processResponsesStream(makeStream(events), output, stream, makeModel());
+
+		const blocks = toolBlocks(output);
+		expect(blocks).toHaveLength(2);
+		const custom = blocks.find(b => b.name === "apply_patch");
+		const fn = blocks.find(b => b.name === "alpha_tool");
+		expect(custom?.arguments).toEqual({ input: "*** Begin Patch ***" });
+		expect(fn?.arguments).toEqual({ command: "go" });
+		// The custom tool's live streaming delta is preserved (previously lost when
+		// the second item stole the shared idx alias). The function-call delta
+		// routed by output_index alone is inherently ambiguous when two items share
+		// the index; it is dropped rather than mis-attributed, but the function call
+		// still receives its terminal arguments from output_item.done above.
+		const deltas = emitted.filter(e => e.type === "toolcall_delta");
+		expect(deltas.length).toBe(1);
+		const customDelta = deltas[0] as { contentIndex: number };
+		expect(customDelta.contentIndex).toBe(custom ? output.content.indexOf(custom) : -1);
+		expect(customDelta.contentIndex).toBeGreaterThanOrEqual(0);
+	});
 });

--- a/packages/ai/test/openai-responses-multi-toolcall-stream.test.ts
+++ b/packages/ai/test/openai-responses-multi-toolcall-stream.test.ts
@@ -557,7 +557,9 @@ describe("Responses multi-tool-call stream correlation", () => {
 		const block = toolBlocks(output)[0];
 		expect(block?.arguments).toEqual({});
 		expect(block?.incompleteArguments).toBe(true);
+		expect(block?.incompleteArgumentsReason).toBe("conflicting");
 		expect(toolCallEnds(emitted)[0]?.toolCall.incompleteArguments).toBe(true);
+		expect(toolCallEnds(emitted)[0]?.toolCall.incompleteArgumentsReason).toBe("conflicting");
 	});
 
 	test("accepts a re-serialized terminal payload that matches the streamed arguments", async () => {
@@ -623,6 +625,7 @@ describe("Responses multi-tool-call stream correlation", () => {
 		const block = toolBlocks(output)[0];
 		expect(block?.arguments).toEqual({});
 		expect(block?.incompleteArguments).toBe(true);
+		expect(block?.incompleteArgumentsReason).toBe("malformed");
 	});
 
 	test("falls back to added-item arguments when neither deltas nor terminal arguments carry them", async () => {

--- a/packages/ai/test/openai-responses-truncated-toolcall.test.ts
+++ b/packages/ai/test/openai-responses-truncated-toolcall.test.ts
@@ -85,6 +85,7 @@ describe("Responses provider: truncated tool-call detection", () => {
 		expect(tools).toHaveLength(1);
 		expect(tools[0].name).toBe("write_file");
 		expect(tools[0].incompleteArguments).toBe(true);
+		expect(tools[0].incompleteArgumentsReason).toBe("truncated");
 	});
 
 	test("does NOT flag a completed tool call even if the turn later truncates", async () => {


### PR DESCRIPTION
## Fixes #4274

`processResponsesStream` was fail-open for five malformed/out-of-contract Responses wire shapes, all pre-existing on `44f4e75b0e` and verified to reproduce on the post-#4264 tree. This PR closes all five and adds a typed `incompleteArgumentsReason` across the `ToolCall` contract into agent-loop guidance.

### Reproduction matrix (all five on exact base `678e26c4`)

| Shape | Pre-fix behavior | Post-fix behavior |
|---|---|---|
| **S1** Duplicate `call_id` | First item executable, second silently aliased | Both fail-closed (`ambiguous`) |
| **S2** `id`/`call_id` collision | Delta routed to wrong item (id match wins) | Both marked ambiguous, delta dropped |
| **S3** Duplicate `output_item.done` | Second `toolcall_end` emitted | Ignored (no live entry) |
| **S4** Orphan `output_item.done` | `toolcall_end` at `contentIndex: -1` | Skipped (no phantom block) |
| **S5** Two items sharing `output_index` | Custom tool loses live input delta | First occupant keeps idx alias; both addressable by id/call_id |

### Typed incomplete reason

`incompleteArguments` now carries `incompleteArgumentsReason: "truncated" | "malformed" | "conflicting" | "ambiguous"`. The agent-loop gives reason-specific recovery guidance instead of always suggesting "split the work". The boolean remains the primary signal; callers reading only `incompleteArguments` are unaffected.

### Contract evidence

- `ToolCall.incompleteArgumentsReason` added to `packages/ai/src/types.ts` (optional, backward-safe)
- All providers that set `incompleteArguments` for truncation now set `reason: "truncated"`: `anthropic`, `ollama`, `openai-completions`, `openai-responses-shared`
- `openai-responses-shared` sets `"malformed"` / `"conflicting"` / `"ambiguous"` where applicable
- `mock` provider supports the typed reason (defaults to `"truncated"`)
- `agent-loop.ts` deserializes the reason and gives reason-specific error messages
- `#4264`'s decoded semantic comparison (`isEquivalentJsonPayload`) and execution block are unchanged

### Tests

- 5 adversarial tests in `openai-responses-multi-toolcall-stream-adversarial.test.ts` (one per shape)
- Reason-specific assertions added to existing conflict/malformed/truncated tests
- 5 new agent-loop tests for reason-specific guidance (`truncated`/`malformed`/`conflicting`/`ambiguous`/backward-compat)
- All 42 targeted tests pass; no new regressions

### Exact head

`23de1bac1e` on `fix/issue-4274-responses-fail-closed`, base `678e26c4` (origin/dev).

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*