### PR TITLE
feat: add Muse Spark 1.2 open-weights presets

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the authoritative OpenRouter `meta/muse-spark-1.2` catalog fallback with a 1,048,576-token context window and `minimal` through `xhigh` reasoning effort, so stale or credential-limited catalog generation still closes the Muse Spark preset alias deterministically.
+
 ### Fixed
 
 - A deterministic Anthropic thinking-replay rejection now converges under a managed fallback attempt instead of repeating forever (#4262). Every coding-agent turn prompts with `fallbackManaged: true`, and the whole in-provider thinking-replay repair sits behind `!options?.fallbackManaged` because the fallback controller owns retries — the shipping CLI therefore never repaired anything: each turn rebuilt the same replay from the same history, drew the same 400, and the session burned one rejected request per turn without ever self-healing (reported as ~1 rejected 1.3 MB request every 12s, ~300/h, never converging). The provider still does not retry inside a managed attempt — it records the full-history repair escalation on the provider session state instead, so the next managed attempt builds a repaired replay at the cost of zero extra round trips. Only the two deterministic rejections (`blocks ... cannot be modified`, ``Invalid `signature` in `thinking` block``) qualify; the proxy-masked generic `api_error` names no cause and may be a transient blip, so it still never costs the session its native replay.

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -176,10 +176,14 @@ export function injectMuseSparkModels(models: Model[]): void {
 		provider: "openrouter",
 		baseUrl: "https://openrouter.ai/api/v1",
 		reasoning: true,
+		// GJC's current Model.input contract represents only text/image. Meta and
+		// OpenRouter also accept video, audio, and PDF/file inputs for this model;
+		// those modalities remain intentionally unadvertised until the shared model
+		// contract and request pipelines can represent them end to end.
 		input: ["text", "image"],
 		cost: { input: 1.25, output: 4.25, cacheRead: 0.15, cacheWrite: 0 },
 		contextWindow: 1_048_576,
-		maxTokens: 1_048_576,
+		maxTokens: 131_072,
 		thinking: {
 			mode: "effort",
 			minLevel: Effort.Minimal,

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -17,6 +17,7 @@ import { RETIRED_MODEL_KEYS } from "../src/model-retirements";
 import {
 	applyGeneratedModelPolicies,
 	CLOUDFLARE_FALLBACK_MODEL,
+	Effort,
 	linkOpenAIPromotionTargets,
 } from "../src/model-thinking";
 import prevModelsJson from "../src/models.json" with { type: "json" };
@@ -156,6 +157,40 @@ export function injectAlibabaTokenPlanModels(models: Model[]): void {
 		} else {
 			models.push(metadata);
 		}
+	}
+}
+
+/**
+ * Keep Muse Spark 1.2 available through OpenRouter when live catalog
+ * regeneration is unavailable or the bundled seed predates the release.
+ *
+ * Meta's model catalog and reasoning documentation are authoritative for the
+ * model id, context window, and effort range. OpenRouter's public catalog is
+ * authoritative for this provider route and pricing.
+ */
+export function injectMuseSparkModels(models: Model[]): void {
+	const metadata: Model<"openai-completions"> = {
+		id: "meta/muse-spark-1.2",
+		name: "Meta: Muse Spark 1.2",
+		api: "openai-completions",
+		provider: "openrouter",
+		baseUrl: "https://openrouter.ai/api/v1",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 1.25, output: 4.25, cacheRead: 0.15, cacheWrite: 0 },
+		contextWindow: 1_048_576,
+		maxTokens: 1_048_576,
+		thinking: {
+			mode: "effort",
+			minLevel: Effort.Minimal,
+			maxLevel: Effort.XHigh,
+		},
+	};
+	const existing = models.find(model => model.provider === metadata.provider && model.id === metadata.id);
+	if (existing) {
+		Object.assign(existing, metadata);
+	} else {
+		models.push(metadata);
 	}
 }
 
@@ -682,6 +717,9 @@ async function generateModels() {
 	injectAlibabaTokenPlanModels(allModels);
 	injectJetBrainsJunieModels(allModels);
 	applyGeneratedModelPolicies(allModels);
+	// This provider-specific correction must run after generic policy inference,
+	// which otherwise caps unknown OpenAI-compatible models at `high`.
+	injectMuseSparkModels(allModels);
 	linkOpenAIPromotionTargets(allModels);
 	injectImageGenerationModels(allModels);
 

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -210,6 +210,9 @@ export function applyGeneratedModelPolicies(models: ApiModel<Api>[]): void {
 			source.reasoning = true;
 			source.name = "DeepSeek V4 Flash 0731";
 		}
+		if (source.id.split("/").at(-1)?.toLowerCase() === "muse-spark-1.2") {
+			source.reasoning = true;
+		}
 		const model = refreshModelThinking(source);
 		applyGeneratedModelPolicy(model);
 		models[index] = model;

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -730,6 +730,13 @@ function inferAnthropicSupportedEfforts<TApi extends Api>(
 }
 
 function inferFallbackEfforts<TApi extends Api>(model: ApiModel<TApi>): readonly Effort[] {
+	// Meta documents Muse Spark 1.2 as accepting the full minimal..xhigh
+	// reasoning range. Keep that capability provider-independent so runtime
+	// model discovery/merge cannot downgrade the bundled OpenRouter entry to
+	// the generic openai-completions ceiling of `high`.
+	if (model.id.split("/").at(-1)?.toLowerCase() === "muse-spark-1.2") {
+		return DEFAULT_REASONING_EFFORTS_WITH_XHIGH;
+	}
 	if (model.api === "anthropic-messages") {
 		return DEFAULT_REASONING_EFFORTS_WITH_XHIGH;
 	}

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -65253,6 +65253,31 @@
 				"maxLevel": "high"
 			}
 		},
+		"meta/muse-spark-1.2": {
+			"id": "meta/muse-spark-1.2",
+			"name": "Meta: Muse Spark 1.2",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 4.25,
+				"cacheRead": 0.15,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 1048576,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"minimax/minimax-m1": {
 			"id": "minimax/minimax-m1",
 			"name": "MiniMax: MiniMax M1",

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -65271,7 +65271,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 1048576,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",

--- a/packages/ai/test/generate-models.test.ts
+++ b/packages/ai/test/generate-models.test.ts
@@ -107,7 +107,8 @@ describe("injectMuseSparkModels", () => {
 				api: "openai-completions",
 				reasoning: true,
 				contextWindow: 1_048_576,
-				maxTokens: 1_048_576,
+				maxTokens: 131_072,
+				input: ["text", "image"],
 				thinking: {
 					mode: "effort",
 					minLevel: "minimal",

--- a/packages/ai/test/generate-models.test.ts
+++ b/packages/ai/test/generate-models.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { injectAlibabaTokenPlanModels, injectImageGenerationModels } from "../scripts/generate-models";
+import {
+	injectAlibabaTokenPlanModels,
+	injectImageGenerationModels,
+	injectMuseSparkModels,
+} from "../scripts/generate-models";
 import type { Model } from "../src/types";
 
 describe("injectImageGenerationModels", () => {
@@ -84,5 +88,32 @@ describe("injectAlibabaTokenPlanModels", () => {
 		expect(
 			models.filter(model => model.provider === "alibaba-token-plan" && model.id === "qwen3.8-max"),
 		).toHaveLength(1);
+	});
+});
+
+describe("injectMuseSparkModels", () => {
+	it("adds and corrects the authoritative OpenRouter Muse Spark route exactly once", () => {
+		const models: Model[] = [];
+
+		injectMuseSparkModels(models);
+		models[0]!.reasoning = false;
+		models[0]!.contextWindow = 1;
+		injectMuseSparkModels(models);
+
+		expect(models).toEqual([
+			expect.objectContaining({
+				id: "meta/muse-spark-1.2",
+				provider: "openrouter",
+				api: "openai-completions",
+				reasoning: true,
+				contextWindow: 1_048_576,
+				maxTokens: 1_048_576,
+				thinking: {
+					mode: "effort",
+					minLevel: "minimal",
+					maxLevel: "xhigh",
+				},
+			}),
+		]);
 	});
 });

--- a/packages/ai/test/model-manager-cache.test.ts
+++ b/packages/ai/test/model-manager-cache.test.ts
@@ -243,7 +243,7 @@ describe("online-if-uncached model refresh", () => {
 				providerId,
 				staticModels: [muse],
 				cacheDbPath,
-				fetchDynamicModels: async () => [{ ...muse, thinking: undefined }],
+				fetchDynamicModels: async () => [{ ...muse, reasoning: false, thinking: undefined }],
 			},
 			"online",
 		);

--- a/packages/ai/test/model-manager-cache.test.ts
+++ b/packages/ai/test/model-manager-cache.test.ts
@@ -235,7 +235,7 @@ describe("online-if-uncached model refresh", () => {
 			baseUrl: "https://openrouter.ai/api/v1",
 			reasoning: true,
 			contextWindow: 1_048_576,
-			maxTokens: 1_048_576,
+			maxTokens: 131_072,
 		};
 
 		const result = await resolveProviderModels<Api>(

--- a/packages/ai/test/model-manager-cache.test.ts
+++ b/packages/ai/test/model-manager-cache.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readModelCache, writeModelCache } from "../src/model-cache";
 import { resolveProviderModels } from "../src/model-manager";
+import { Effort } from "../src/model-thinking";
 import type { Api, Model } from "../src/types";
 
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
@@ -224,5 +225,38 @@ describe("online-if-uncached model refresh", () => {
 				models: [expect.objectContaining({ id: "dynamic" })],
 			});
 		}
+	});
+
+	test("preserves Muse Spark xhigh after dynamic OpenRouter discovery merges", async () => {
+		const providerId = "openrouter";
+		const muse = {
+			...model(providerId, "meta/muse-spark-1.2"),
+			name: "Meta: Muse Spark 1.2",
+			baseUrl: "https://openrouter.ai/api/v1",
+			reasoning: true,
+			contextWindow: 1_048_576,
+			maxTokens: 1_048_576,
+		};
+
+		const result = await resolveProviderModels<Api>(
+			{
+				providerId,
+				staticModels: [muse],
+				cacheDbPath,
+				fetchDynamicModels: async () => [{ ...muse, thinking: undefined }],
+			},
+			"online",
+		);
+
+		expect(result.models).toContainEqual(
+			expect.objectContaining({
+				id: "meta/muse-spark-1.2",
+				thinking: {
+					mode: "effort",
+					minLevel: Effort.Minimal,
+					maxLevel: Effort.XHigh,
+				},
+			}),
+		);
 	});
 });

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -741,6 +741,34 @@ describe("model thinking runtime helpers", () => {
 		expect(requireSupportedEffort(model, Effort.XHigh)).toBe(Effort.XHigh);
 	});
 
+	it("marks generic dynamically discovered Muse Spark routes as reasoning-capable", () => {
+		const models: Model<"openai-completions">[] = [
+			{
+				id: "meta/muse-spark-1.2",
+				name: "Meta: Muse Spark 1.2",
+				api: "openai-completions",
+				provider: "kilo",
+				baseUrl: "https://api.kilo.ai/api/gateway",
+				reasoning: false,
+				input: ["text", "image"],
+				cost: { input: 1.25, output: 4.25, cacheRead: 0.15, cacheWrite: 0 },
+				contextWindow: 1_048_576,
+				maxTokens: 131_072,
+			},
+		];
+
+		applyGeneratedModelPolicies(models);
+
+		expect(models[0]).toMatchObject({
+			reasoning: true,
+			thinking: {
+				mode: "effort",
+				minLevel: Effort.Minimal,
+				maxLevel: Effort.XHigh,
+			},
+		});
+	});
+
 	it("enables xhigh for openai-responses and openai-codex-responses APIs", () => {
 		const responsesModel = createModel({
 			id: "custom-responses",

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -726,7 +726,7 @@ describe("model thinking runtime helpers", () => {
 				input: ["text", "image"],
 				cost: { input: 1.25, output: 4.25, cacheRead: 0.15, cacheWrite: 0 },
 				contextWindow: 1_048_576,
-				maxTokens: 1_048_576,
+				maxTokens: 131_072,
 			},
 		];
 

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -714,6 +714,33 @@ describe("model thinking runtime helpers", () => {
 		);
 	});
 
+	it("preserves Muse Spark xhigh through shared runtime policy inference", () => {
+		const models: Model<"openai-completions">[] = [
+			{
+				id: "meta/muse-spark-1.2",
+				name: "Meta: Muse Spark 1.2",
+				api: "openai-completions",
+				provider: "openrouter",
+				baseUrl: "https://openrouter.ai/api/v1",
+				reasoning: true,
+				input: ["text", "image"],
+				cost: { input: 1.25, output: 4.25, cacheRead: 0.15, cacheWrite: 0 },
+				contextWindow: 1_048_576,
+				maxTokens: 1_048_576,
+			},
+		];
+
+		applyGeneratedModelPolicies(models);
+		const model = models[0]!;
+
+		expect(model.thinking).toEqual({
+			mode: "effort",
+			minLevel: Effort.Minimal,
+			maxLevel: Effort.XHigh,
+		});
+		expect(requireSupportedEffort(model, Effort.XHigh)).toBe(Effort.XHigh);
+	});
+
 	it("enables xhigh for openai-responses and openai-codex-responses APIs", () => {
 		const responsesModel = createModel({
 			id: "custom-responses",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added three provider-agnostic Muse Spark 1.2 presets: Muse Spark across all roles, plus DeepSeek and Luna executor variants.
 - Hook discovery now records one canonical six-kind normalization contract while preserving each existing runtime's real authority and semantics. Native/Claude/Codex directory modules are validated before import and adapted into the session `ExtensionRunner`, constrained plugin batches validate atomically before registration and route after-phases to the post-tool path without gaining blocking authority, unsupported aliases and malformed matchers fail closed with stable diagnostics, and Codex-managed command timing/trust/redaction remain explicitly provider-owned.
 
 - GJC plugin bundle manifests now accept the Claude Code/Codex-familiar `mcpServers` map alias and normalize transport-relevant, end-to-end representable fields into the canonical `mcps` array (per-server `type` maps to `transport`; `command` implies `stdio`, a bare `url` implies `http`), so canonical and alias manifests compile to byte-equivalent normalized surfaces. Ambiguous or unrepresentable aliases (`mcp`, a top-level `skills`/`agents`/`commands`/`slash-commands`, Claude Code-shaped or hybrid hooks, transport-incompatible MCP fields, or `mcpServers` entries with `env`/`auth`/`oauth`/`headers`/enablement controls) now fail with targeted migration diagnostics naming the canonical form and the loose `.gjc/` surface, instead of generic unknown/forbidden-key failures.

--- a/packages/coding-agent/src/config/model-profile-activation.ts
+++ b/packages/coding-agent/src/config/model-profile-activation.ts
@@ -575,7 +575,9 @@ function rewriteSelectorForProxy(
 	const proxyModels = allModels.filter(model => model.provider === proxyProvider);
 	if (slash < 0) {
 		if (proxyMode === "fallback") return selector;
-		const matches = proxyModels.filter(model => model.id === baseSelector);
+		const exactMatches = proxyModels.filter(model => model.id === baseSelector);
+		const finalSegmentMatches = proxyModels.filter(model => model.id.split("/").at(-1) === baseSelector);
+		const matches = exactMatches.length > 0 ? exactMatches : finalSegmentMatches;
 		if (matches.length !== 1) {
 			throw new Error(
 				`Configured proxy "${proxyProvider}" does not expose an unambiguous model for "${baseSelector}"`,

--- a/packages/coding-agent/src/config/model-profiles.ts
+++ b/packages/coding-agent/src/config/model-profiles.ts
@@ -134,6 +134,27 @@ export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
 		critic: "gpt-5.6-luna:xhigh",
 		architect: "gpt-5.6-luna:xhigh",
 	}),
+	profile("open-weights-spark", [], {
+		default: "muse-spark-1.2:medium",
+		executor: "muse-spark-1.2:low",
+		planner: "muse-spark-1.2:high",
+		critic: "muse-spark-1.2:high",
+		architect: "muse-spark-1.2:xhigh",
+	}),
+	profile("open-weights-spark-deepseek", [], {
+		default: "muse-spark-1.2:medium",
+		executor: "deepseek-v4-flash:high",
+		planner: "muse-spark-1.2:high",
+		critic: "muse-spark-1.2:high",
+		architect: "muse-spark-1.2:xhigh",
+	}),
+	profile("open-weights-spark-luna", [], {
+		default: "muse-spark-1.2:medium",
+		executor: "gpt-5.6-luna:high",
+		planner: "muse-spark-1.2:high",
+		critic: "muse-spark-1.2:high",
+		architect: "muse-spark-1.2:xhigh",
+	}),
 	profile("open-weights-glm-deepseek", [], {
 		default: "glm-5.2:medium",
 		executor: "deepseek-v4-flash:high",
@@ -444,6 +465,15 @@ const PROFILE_PRESENTATION: Record<string, ModelProfilePresentation> = {
 	},
 	"open-weights-kimi": { displayName: "Kimi", providerGroup: "OPEN WEIGHT MODELS (PROVIDER AGNOSTIC)" },
 	"open-weights-luna": { displayName: "Luna", providerGroup: "OPEN WEIGHT MODELS (PROVIDER AGNOSTIC)" },
+	"open-weights-spark": { displayName: "Muse Spark", providerGroup: "OPEN WEIGHT MODELS (PROVIDER AGNOSTIC)" },
+	"open-weights-spark-deepseek": {
+		displayName: "Muse Spark + DeepSeek",
+		providerGroup: "OPEN WEIGHT MODELS (PROVIDER AGNOSTIC)",
+	},
+	"open-weights-spark-luna": {
+		displayName: "Muse Spark + Luna",
+		providerGroup: "OPEN WEIGHT MODELS (PROVIDER AGNOSTIC)",
+	},
 	"open-weights-glm-deepseek": {
 		displayName: "GLM + DeepSeek",
 		providerGroup: "OPEN WEIGHT MODELS (PROVIDER AGNOSTIC)",
@@ -518,6 +548,9 @@ const OPEN_WEIGHT_PROFILE_ORDER = [
 	"open-weights-deepseek",
 	"open-weights-kimi",
 	"open-weights-luna",
+	"open-weights-spark",
+	"open-weights-spark-deepseek",
+	"open-weights-spark-luna",
 	"open-weights-glm-deepseek",
 	"open-weights-kimi-deepseek",
 	"open-weights-kimi-glm",

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1653,6 +1653,7 @@ export class ModelRegistry {
 					this.#applyProviderCompat(providerConfig.compat, [...models]),
 				),
 			);
+			applyGeneratedModelPolicies(normalized);
 			cachedModels.push(...normalized);
 		}
 		return cachedModels;

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -5,6 +5,7 @@ import {
 	type AssistantMessageEventStream,
 	type AuthCredentialSelector,
 	applyFinalCodexGpt56ContextCap,
+	applyGeneratedModelPolicies,
 	type CacheRetention,
 	CODEX_GPT_5_6_CONTEXT_CAP,
 	type Context,
@@ -1634,7 +1635,9 @@ export class ModelRegistry {
 			const withTransport = providerOverride
 				? models.map(model => this.#applyProviderTransportOverride(model, providerOverride))
 				: models;
-			cachedModels.push(...this.#applyProviderModelOverrides(descriptor.providerId, withTransport));
+			const normalized = this.#applyProviderModelOverrides(descriptor.providerId, withTransport);
+			applyGeneratedModelPolicies(normalized);
+			cachedModels.push(...normalized);
 		}
 		return cachedModels;
 	}

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -350,6 +350,75 @@ describe("model profile activation", () => {
 		expect(prepared.agentModelOverrides.executor).toBe("glm-5.2:low");
 	});
 
+	test("resolves Muse Spark through an authenticated provider and preserves xhigh effort", async () => {
+		const profile = BUILTIN_MODEL_PROFILES.find(candidate => candidate.name === "open-weights-spark");
+		if (!profile) throw new Error("Missing open-weights-spark profile");
+		const kilo = model("kilo", "meta/muse-spark-1.2", {
+			mode: "effort",
+			minLevel: ThinkingLevel.Minimal,
+			maxLevel: ThinkingLevel.XHigh,
+		});
+		const openrouter = model("openrouter", "meta/muse-spark-1.2", {
+			mode: "effort",
+			minLevel: ThinkingLevel.Minimal,
+			maxLevel: ThinkingLevel.XHigh,
+		});
+		const baseRegistry = fakeRegistry({ profiles: [profile] });
+		const registry = {
+			...baseRegistry,
+			getAll: () => [kilo, openrouter],
+			getAvailable: () => [kilo, openrouter],
+			getApiKeyForProvider: async (provider: string) => (provider === "openrouter" ? "key-openrouter" : undefined),
+			lookupAliasExists: (alias: string) => alias === "muse-spark-1.2",
+			resolveModelByLookupAlias: (_alias: string, options?: { candidates?: readonly Model[] }) =>
+				options?.candidates?.[0],
+		};
+
+		const prepared = await prepareModelProfileActivation({
+			session: fakeSession(),
+			modelRegistry: registry as unknown as ModelRegistry,
+			settings: Settings.isolated(),
+			profileName: profile.name,
+		});
+
+		expect(prepared.defaultModel).toBe(openrouter);
+		expect(prepared.defaultThinkingLevel).toBe(ThinkingLevel.Medium);
+		expect(prepared.agentModelOverrides).toEqual({
+			executor: "muse-spark-1.2:low",
+			planner: "muse-spark-1.2:high",
+			critic: "muse-spark-1.2:high",
+			architect: "muse-spark-1.2:xhigh",
+		});
+	});
+
+	test("fails Muse Spark preset activation before mutation when no provider exposes the alias", async () => {
+		const profile = BUILTIN_MODEL_PROFILES.find(candidate => candidate.name === "open-weights-spark");
+		if (!profile) throw new Error("Missing open-weights-spark profile");
+		const registry = {
+			...fakeRegistry({ profiles: [profile] }),
+			getAll: () => [],
+			getAvailable: () => [],
+			lookupAliasExists: (alias: string) => alias === "muse-spark-1.2",
+			resolveModelByLookupAlias: () => undefined,
+		};
+		const session = fakeSession();
+
+		await expect(
+			prepareModelProfileActivation({
+				session,
+				modelRegistry: registry as unknown as ModelRegistry,
+				settings: Settings.isolated(),
+				profileName: profile.name,
+			}),
+		).rejects.toMatchObject({
+			constructor: ModelProfileCredentialError,
+			code: "authentication_failed",
+			providers: ["muse-spark-1.2"],
+		});
+		expect(session.model?.id).toBe("initial");
+		expect(session.getActiveModelProfile()).toBeUndefined();
+	});
+
 	test("keeps unauthenticated fallback heads and authenticated mixed-provider tails", async () => {
 		const profile: ModelProfileDefinition = {
 			name: "fallback-profile",

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -2306,6 +2306,56 @@ describe("model-profile-activation: OpenAI-compatible proxy routing", () => {
 		expect(prepared.defaultChain).toEqual(["litellm/grok-4.3:medium"]);
 	});
 
+	test("routes Muse Spark's bare alias through a unique provider-prefixed proxy model in always mode", async () => {
+		const profile = BUILTIN_MODEL_PROFILES.find(candidate => candidate.name === "open-weights-spark");
+		if (!profile) throw new Error("Missing open-weights-spark profile");
+		const registry = proxyRegistry({ profiles: [profile] });
+		const prepared = await prepareModelProfileActivation({
+			session: fakeSession(),
+			modelRegistry: {
+				...registry,
+				getAll: () => [
+					...registry.getAll(),
+					proxyModel("meta/muse-spark-1.2", {
+						mode: "effort",
+						minLevel: ThinkingLevel.Minimal,
+						maxLevel: ThinkingLevel.XHigh,
+					}),
+				],
+			} as unknown as ModelRegistry,
+			settings: Settings.isolated({ "modelProfile.proxyProvider": "litellm", "modelProfile.proxyMode": "always" }),
+			profileName: profile.name,
+		});
+
+		expect(prepared.defaultChain).toEqual(["litellm/meta/muse-spark-1.2:medium"]);
+		expect(prepared.agentModelOverrides.architect).toBe("litellm/meta/muse-spark-1.2:xhigh");
+	});
+
+	test("fails closed when multiple provider-prefixed proxy models share the Muse Spark alias", async () => {
+		const profile = BUILTIN_MODEL_PROFILES.find(candidate => candidate.name === "open-weights-spark");
+		if (!profile) throw new Error("Missing open-weights-spark profile");
+		const registry = proxyRegistry({ profiles: [profile] });
+
+		await expect(
+			prepareModelProfileActivation({
+				session: fakeSession(),
+				modelRegistry: {
+					...registry,
+					getAll: () => [
+						...registry.getAll(),
+						proxyModel("meta/muse-spark-1.2"),
+						proxyModel("other/muse-spark-1.2"),
+					],
+				} as unknown as ModelRegistry,
+				settings: Settings.isolated({
+					"modelProfile.proxyProvider": "litellm",
+					"modelProfile.proxyMode": "always",
+				}),
+				profileName: profile.name,
+			}),
+		).rejects.toThrow(/does not expose an unambiguous model for "muse-spark-1\.2"/);
+	});
+
 	test("fails closed pointing at the proxy when a routable provider is missing and the proxy is unauthenticated", async () => {
 		const settings = Settings.isolated({ "modelProfile.proxyProvider": "litellm" });
 		await expect(

--- a/packages/coding-agent/test/model-profiles-catalog.test.ts
+++ b/packages/coding-agent/test/model-profiles-catalog.test.ts
@@ -119,6 +119,39 @@ const expectedProfiles: Array<{ name: string; requiredProviders: string[]; mappi
 		},
 	},
 	{
+		name: "open-weights-spark",
+		requiredProviders: [],
+		mapping: {
+			default: "muse-spark-1.2:medium",
+			executor: "muse-spark-1.2:low",
+			planner: "muse-spark-1.2:high",
+			critic: "muse-spark-1.2:high",
+			architect: "muse-spark-1.2:xhigh",
+		},
+	},
+	{
+		name: "open-weights-spark-deepseek",
+		requiredProviders: [],
+		mapping: {
+			default: "muse-spark-1.2:medium",
+			executor: "deepseek-v4-flash:high",
+			planner: "muse-spark-1.2:high",
+			critic: "muse-spark-1.2:high",
+			architect: "muse-spark-1.2:xhigh",
+		},
+	},
+	{
+		name: "open-weights-spark-luna",
+		requiredProviders: [],
+		mapping: {
+			default: "muse-spark-1.2:medium",
+			executor: "gpt-5.6-luna:high",
+			planner: "muse-spark-1.2:high",
+			critic: "muse-spark-1.2:high",
+			architect: "muse-spark-1.2:xhigh",
+		},
+	},
+	{
 		name: "open-weights-glm-deepseek",
 		requiredProviders: [],
 		mapping: {
@@ -589,7 +622,7 @@ const fixedNonCodexComboMappings: Record<string, Partial<Record<Role, string>>> 
 };
 
 describe("built-in model profile catalog", () => {
-	test("contains exact 46-profile matrix cell-for-cell", () => {
+	test("contains exact 49-profile matrix cell-for-cell", () => {
 		expect(BUILTIN_MODEL_PROFILES.map(profile => profile.name)).toEqual(
 			expectedProfiles.map(profile => profile.name),
 		);
@@ -607,6 +640,9 @@ describe("built-in model profile catalog", () => {
 			"open-weights-deepseek",
 			"open-weights-kimi",
 			"open-weights-luna",
+			"open-weights-spark",
+			"open-weights-spark-deepseek",
+			"open-weights-spark-luna",
 			"open-weights-glm-deepseek",
 			"open-weights-kimi-deepseek",
 			"open-weights-kimi-glm",
@@ -786,6 +822,9 @@ describe("built-in model profile catalog", () => {
 			"open-weights-deepseek",
 			"open-weights-kimi",
 			"open-weights-luna",
+			"open-weights-spark",
+			"open-weights-spark-deepseek",
+			"open-weights-spark-luna",
 			"open-weights-glm-deepseek",
 			"open-weights-kimi-deepseek",
 			"open-weights-kimi-glm",

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -5040,6 +5040,33 @@ describe("ModelRegistry", () => {
 		expect(registry.find("ollama-cloud", "deepseek-v4-pro")?.maxTokens).toBe(384_000);
 	});
 
+	test("normalizes cached Muse Spark discovery metadata through shared policy", () => {
+		const cachedModel: Model<"openai-completions"> = {
+			id: "meta/muse-spark-1.2",
+			name: "Meta: Muse Spark 1.2",
+			api: "openai-completions",
+			provider: "kilo",
+			baseUrl: "https://api.kilo.ai/api/gateway",
+			reasoning: false,
+			input: ["text", "image"],
+			cost: { input: 1.25, output: 4.25, cacheRead: 0.15, cacheWrite: 0 },
+			contextWindow: 1_048_576,
+			maxTokens: 131_072,
+		};
+		writeModelCache("kilo", Date.now(), [cachedModel], true, "", cacheDbPath);
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+
+		expect(registry.find("kilo", "meta/muse-spark-1.2")).toMatchObject({
+			reasoning: true,
+			thinking: {
+				mode: "effort",
+				minLevel: Effort.Minimal,
+				maxLevel: Effort.XHigh,
+			},
+		});
+	});
+
 	test("preserves request shaping and wire aliases when replacing a built-in model", () => {
 		writeRawModelsJson({
 			openai: {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -5067,6 +5067,41 @@ describe("ModelRegistry", () => {
 		});
 	});
 
+	test("normalizes configured discovery Muse caches through shared policy", () => {
+		writeRawModelsJson({
+			"muse-proxy": {
+				baseUrl: "https://proxy.example/v1",
+				apiKey: "TEST_KEY",
+				api: "openai-completions",
+				discovery: { type: "openai-models-list" },
+			},
+		});
+		const cachedModel: Model<"openai-completions"> = {
+			id: "meta/muse-spark-1.2",
+			name: "Meta: Muse Spark 1.2",
+			api: "openai-completions",
+			provider: "muse-proxy",
+			baseUrl: "https://proxy.example/v1",
+			reasoning: false,
+			input: ["text", "image"],
+			cost: { input: 1.25, output: 4.25, cacheRead: 0.15, cacheWrite: 0 },
+			contextWindow: 1_048_576,
+			maxTokens: 131_072,
+		};
+		writeModelCache("muse-proxy", Date.now(), [cachedModel], true, "", cacheDbPath);
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+
+		expect(registry.find("muse-proxy", "meta/muse-spark-1.2")).toMatchObject({
+			reasoning: true,
+			thinking: {
+				mode: "effort",
+				minLevel: Effort.Minimal,
+				maxLevel: Effort.XHigh,
+			},
+		});
+	});
+
 	test("preserves request shaping and wire aliases when replacing a built-in model", () => {
 		writeRawModelsJson({
 			openai: {


### PR DESCRIPTION
## Summary

Adds provider-agnostic (`open-weights-*`) model profile presets for Meta's **Muse Spark 1.2** frontier reasoning model (released 2026-08-05, minimal→xhigh effort, 1M context).

Spark drives the reasoning-heavy roles (default/planner/critic/architect); executor is offloaded to a cheaper lane in the combos:

| Preset | default | executor | planner | critic | architect |
|---|---|---|---|---|---|
| `open-weights-spark` | spark `medium` | spark `low` | spark `high` | spark `high` | spark `xhigh` |
| `open-weights-spark-deepseek` | spark `medium` | deepseek-v4-flash `high` | spark `high` | spark `high` | spark `xhigh` |
| `open-weights-spark-luna` | spark `medium` | gpt-5.6-luna `high` | spark `high` | spark `high` | spark `xhigh` |

Bare-alias selectors (no provider prefix) resolve through any authenticated provider (kilo/openrouter/vercel-ai-gateway) or a configured proxy. Per-provider effort clamping is handled by `clampThinkingLevelForModel`.

Deliberately kept to one family rather than a 3-tier eco/medium/pro spread to avoid bloating the open-weights group.

## Changes
- `packages/ai/src/models.json` — regenerated; `meta/muse-spark-1.2` now bundled across kilo, openrouter, vercel-ai-gateway (was missing — only 1.1 was present).
- `packages/coding-agent/src/config/model-profiles.ts` — three new presets, presentation entries, registered in `OPEN_WEIGHT_PROFILE_ORDER`.
- `packages/coding-agent/test/model-profiles-catalog.test.ts` — expected profiles, count bump 46→49, both open-weight list assertions.

## Verification
- `bun test packages/coding-agent/test/model-profile*` — 146 pass
- `bun test packages/coding-agent/test/model-preset-landing-redteam-qa.test.ts` — 14 pass
- `bun test packages/ai/test/preset-catalog-models.test.ts` — 4 pass
- `check-visible-definitions.ts` / `rebrand-inventory.ts --strict` — no violations

> Pre-existing on base: `verify-g002-gates.ts` (missing `docs-index.generated.ts`) and one `default-gjc-definitions` skill-inspection case both fail with these changes stashed.