### PR TITLE
test(gjc-plugins): use named normalized bundle type

### DIFF
--- a/packages/coding-agent/test/gjc-plugin-aliases.test.ts
+++ b/packages/coding-agent/test/gjc-plugin-aliases.test.ts
@@ -25,6 +25,7 @@ import {
 	type GjcPluginMcpManifestEntry,
 	type GjcPluginRegistryEntry,
 	installGjcBundle,
+	type NormalizedGjcPluginBundle,
 	parseManifest,
 	previewGjcBundleUpdate,
 	readRegistry,
@@ -440,7 +441,7 @@ describe("issue #4287 acceptance 2: ambiguous/unsafe aliases fail with actionabl
 async function compileAliasWithMcpServers(manifest: Record<string, unknown>): Promise<{
 	entries: GjcPluginMcpManifestEntry[];
 	registryEntry: GjcPluginRegistryEntry;
-	bundle: Awaited<ReturnType<typeof compileGjcPluginBundle>>;
+	bundle: NormalizedGjcPluginBundle;
 }> {
 	const root = await mkTemp("gjc-alias-sec-");
 	await writeManifestBundle(root, manifest);


### PR DESCRIPTION
Post-merge terminal-critic correction for #4290.

Replaces the prohibited `Awaited<ReturnType<typeof compileGjcPluginBundle>>` annotation with the existing named `NormalizedGjcPluginBundle` type, satisfying the repository contract without behavioral change.

Verification:
- `bun test packages/coding-agent/test/gjc-plugin-aliases.test.ts` — 32 passed
- `bun --cwd=packages/coding-agent run check` — typecheck passed; unrelated existing warnings only
- Biome and diff hygiene passed

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*