### PR TITLE
fix(tui): avoid modifyOtherKeys in Apple Terminal

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -556,7 +556,7 @@ These are read as runtime signals; they are usually set by the terminal/OS rathe
 | `GJC_DEBUG_REDRAW`         | If `1`, enables redraw debug logging                                                  |
 | `GJC_TUI_DEBUG`            | If `1`, enables deep TUI debug dump path                                              |
 | `GJC_FORCE_IMAGE_PROTOCOL` | Forces terminal image protocol detection (`kitty`, `iterm2`/`iterm`, `sixel`, `none`) |
-| `GJC_TUI_KEYBOARD_PROTOCOL` | Enhanced keyboard input (Kitty keyboard protocol + xterm modifyOtherKeys). Enabled by default; set `0` / `false` to leave the keyboard in its default mode. Use this when a terminal (e.g. Android Termius) breaks IME/Hangul composition while these enhanced modes are active. |
+| `GJC_TUI_KEYBOARD_PROTOCOL` | Enhanced keyboard input (Kitty keyboard protocol + xterm modifyOtherKeys). Enabled by default; set `0` / `false` to leave the keyboard in its default mode. GJC automatically skips the modifyOtherKeys fallback on Windows and Apple Terminal because it breaks CJK/Hangul IME composition there; use the full opt-out for other affected terminals such as Android Termius. |
 | `GJC_TUI_SYNCHRONIZED_OUTPUT` | Synchronized-output framing (`CSI ?2026h/l`) is enabled by default. Set `0` / `false` / `off` / `no` before starting or restarting GJC to remove that framing for terminal parsers that render it incorrectly. This is a process-wide compatibility and diagnostic switch, not tmux/Byobu client detection or per-client negotiation. Disabling it may expose visible tearing; return to the default after diagnosis unless the client requires the workaround. |
 
 ---

--- a/docs/tui-runtime-internals.md
+++ b/docs/tui-runtime-internals.md
@@ -45,7 +45,7 @@ A forced render (`requestRender(true)`) resets previous-line caches and cursor b
 1. Enables raw mode and bracketed paste.
 2. Attaches resize handler.
 3. Creates a `StdinBuffer` to split partial escape chunks into complete sequences.
-4. Queries Kitty keyboard protocol support (`CSI ? u`), then enables protocol flags if supported; otherwise enables modifyOtherKeys fallback after a short timeout.
+4. Queries Kitty keyboard protocol support (`CSI ? u`), then enables protocol flags if supported; otherwise enables the modifyOtherKeys fallback after a short timeout, except on Windows and Apple Terminal where that fallback breaks CJK/Hangul IME composition.
 5. Queries OSC 11 background color and enables Mode 2031 appearance notifications for dark/light theme detection.
 6. On Windows, attempts VT input enablement via `kernel32` mode flags.
    `StdinBuffer` behavior:

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Apple Terminal.app now retains its default keyboard mode when it does not support the Kitty keyboard protocol, avoiding the modifyOtherKeys fallback that breaks Korean/Hangul IME composition.
+
 ## [0.13.1] - 2026-08-11
 
 ### Added

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -51,6 +51,10 @@ export function keyboardEnhancementEnabled(): boolean {
 	return $flag("GJC_TUI_KEYBOARD_PROTOCOL", true);
 }
 
+function isAppleTerminal(): boolean {
+	return $env.TERM_PROGRAM === "Apple_Terminal";
+}
+
 /**
  * Minimal terminal interface for TUI
  */
@@ -794,18 +798,18 @@ export class ProcessTerminal implements Terminal {
 		}
 		this.#safeWrite("\x1b[?u");
 		this.#stdinBuffer?.noteProbeIssued();
-		// Windows Terminal and conhost do not implement the Kitty keyboard
+		// Windows Terminal and Apple Terminal do not implement the Kitty keyboard
 		// protocol, so the query above never activates it there. They do honor the
-		// modifyOtherKeys fallback below — but that mode breaks Windows CJK/Hangul
-		// IME composition: Alt+Enter (and other chords) bypass the IME commit, so
-		// the syllable still being composed is never delivered to the app and the
+		// modifyOtherKeys fallback below — but that mode breaks CJK/Hangul IME
+		// composition: Alt+Enter (and other chords) bypass the IME commit, so the
+		// syllable still being composed is never delivered to the app and the
 		// action fires on empty text (e.g. queue-message no-ops unless the user
 		// types a trailing space to force a commit first). Skip the fallback on
-		// win32; legacy encodings still deliver Alt+Enter (ESC CR) and the newline
-		// chords, and IME composition works again. Opt back in with
+		// these terminals; legacy encodings still deliver Alt+Enter (ESC CR) and
+		// the newline chords, and IME composition works again. Opt back in with
 		// GJC_TUI_KEYBOARD_PROTOCOL=0 disabling all enhancement, or force-enable
-		// elsewhere if a Kitty-capable Windows terminal appears.
-		if (process.platform === "win32") {
+		// elsewhere if a Kitty-capable terminal appears.
+		if (process.platform === "win32" || isAppleTerminal()) {
 			return;
 		}
 		this.#modifyOtherKeysTimeout = setTimeout(() => {

--- a/packages/tui/test/keyboard-protocol-optout.test.ts
+++ b/packages/tui/test/keyboard-protocol-optout.test.ts
@@ -37,6 +37,7 @@ describe("ProcessTerminal keyboard-protocol opt-out (GJC_TUI_KEYBOARD_PROTOCOL)"
 		Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
 		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
 		Object.defineProperty(process.stdin, "setRawMode", { value: vi.fn(), configurable: true });
+		delete Bun.env.TERM_PROGRAM;
 	});
 
 	afterEach(() => {

--- a/packages/tui/test/keyboard-protocol-optout.test.ts
+++ b/packages/tui/test/keyboard-protocol-optout.test.ts
@@ -5,6 +5,7 @@ const stdinIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isT
 const stdoutIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
 const stdinSetRawModeDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "setRawMode");
 const originalKeyboardProtocolEnv = Bun.env.GJC_TUI_KEYBOARD_PROTOCOL;
+const originalTermProgram = Bun.env.TERM_PROGRAM;
 const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
 
 function setPlatform(platform: NodeJS.Platform): void {
@@ -45,6 +46,7 @@ describe("ProcessTerminal keyboard-protocol opt-out (GJC_TUI_KEYBOARD_PROTOCOL)"
 		restoreProperty(process.stdout, "isTTY", stdoutIsTtyDescriptor);
 		restoreProperty(process.stdin, "setRawMode", stdinSetRawModeDescriptor);
 		restoreEnv("GJC_TUI_KEYBOARD_PROTOCOL", originalKeyboardProtocolEnv);
+		restoreEnv("TERM_PROGRAM", originalTermProgram);
 		restoreProperty(process, "platform", platformDescriptor);
 	});
 
@@ -111,6 +113,25 @@ describe("ProcessTerminal keyboard-protocol opt-out (GJC_TUI_KEYBOARD_PROTOCOL)"
 
 		// The Kitty query is still emitted (harmless where unsupported), but the
 		// modifyOtherKeys fallback that breaks Windows Hangul/CJK IME is skipped.
+		expect(writes).toContain(KITTY_QUERY);
+
+		vi.advanceTimersByTime(150);
+		expect(writes).not.toContain(MODIFY_OTHER_KEYS);
+
+		terminal.stop();
+	});
+
+	it("skips only the modifyOtherKeys fallback in Apple Terminal to preserve Hangul IME composition", () => {
+		vi.useFakeTimers();
+		setPlatform("darwin");
+		delete Bun.env.GJC_TUI_KEYBOARD_PROTOCOL;
+		Bun.env.TERM_PROGRAM = "Apple_Terminal";
+		expect(keyboardEnhancementEnabled()).toBe(true);
+
+		const { terminal, writes } = setupTerminal();
+
+		// Apple Terminal does not answer the Kitty query. Its modifyOtherKeys mode
+		// breaks CJK/Hangul IME composition, so only the fallback is withheld.
 		expect(writes).toContain(KITTY_QUERY);
 
 		vi.advanceTimersByTime(150);


### PR DESCRIPTION
## Summary

- preserve Apple Terminal.app’s default keyboard mode when its Kitty query is unanswered
- retain the Kitty capability query while skipping only the incompatible `modifyOtherKeys` fallback
- cover the macOS Apple Terminal / Hangul IME contract and document the platform behavior

Fixes #4025

## Verification

- `bun test packages/tui/test/keyboard-protocol-optout.test.ts`
- `bun run --cwd=packages/tui check:types`

## Limits

The tested regression proves the emitted terminal control-sequence contract. Physical Apple Terminal.app + Korean IME execution requires macOS hardware and was not available in this Linux environment.