### PR TITLE
style(broker): drop the stray blank line that fails repo-pinned biome on dev

### DIFF
--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -183,7 +183,6 @@ function pendingCleanupSessionId(response: BrokerResponse): string | undefined {
 	return typeof response.error.cleanup?.sessionId === "string" ? response.error.cleanup.sessionId : undefined;
 }
 
-
 const LIFECYCLE_OPERATIONS = new Set([
 	"session.create",
 	"session.fork",


### PR DESCRIPTION
## Problem

`packages/coding-agent/src/sdk/broker/broker.ts` carries a double blank line before `LIFECYCLE_OPERATIONS` that the repo-pinned biome 2.5.2 rejects:

```
     184  184 │   }
     185  185 │   
     186      │ - 
     187  186 │   const LIFECYCLE_OPERATIONS = new Set([
```

That makes `check:@gajae-code/coding-agent` (`biome check .`) and `root-check` (`check:tools` → `biome check .`) fail **on dev itself**, so every open PR inherits two red jobs plus the aggregate/evidence cascades regardless of its own content.

## Attribution

Introduced by `0d1d94d3fa` (`fix(sdk): land the PR #4098 review-cohort fix generations 4-7`, #4281). Reproduced with the pinned binary on pristine dev at both `364cbfe6108d145daf9f55697ab83c4d0e84b314` and `8ed14208c43323a1c1deb799d804e4caf8a06db5`:

```sh
git checkout 8ed14208c4
./node_modules/.bin/biome --version      # 2.5.2
./node_modules/.bin/biome check packages/coding-agent/src/sdk/broker/broker.ts
# Found 1 error.  (format)
```

An unpinned `bunx biome` resolves a newer version that does not flag it, which is why this slipped through locally.

## Fix

`biome check --write` on that one file: a single blank line removed, no semantic change.

```
1 file changed, 1 deletion(-)
```

Verified clean with the pinned binary afterwards. Filed as its own single-purpose PR rather than folded into an unrelated feature branch; relates to the dev-red umbrella #4263. Observed while driving #4271.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
