### PR TITLE
fix(test): revert shared package-cwd preload; pin overflow budgets in-process

### DIFF
--- a/packages/coding-agent/bunfig.toml
+++ b/packages/coding-agent/bunfig.toml
@@ -1,8 +1,0 @@
-# Package-cwd `bun test` (the CI shard invocation: `bun test --shard=N/8` with
-# cwd packages/coding-agent) does not read the repository-root bunfig.toml, so
-# without this file the shared test preload — macOS TMPDIR canonicalization and
-# the 64 MiB session-context budget pin that keeps the overflow fixtures in
-# session-context-overflow.test.ts and goal-mode-request.test.ts deterministic
-# under the 512 MiB production default (#4196) — silently never runs.
-[test]
-preload = ["../../scripts/test-preload.ts"]

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2628,9 +2628,10 @@ function measureJsonLikeBytes(value: unknown, visited = new Set<object>()): numb
 
 /** Measure one materialized {@link SessionContext} and throw when over the budget. */
 function assertSessionContextWithinBudget(context: SessionContext): SessionContext {
+	const budgetBytes = effectiveSessionContextBudgetBytes();
 	const measuredBytes = measureJsonLikeBytes(context);
-	if (measuredBytes > SESSION_CONTEXT_MATERIALIZATION_BUDGET_BYTES) {
-		throw new SessionContextTooLargeError(measuredBytes);
+	if (measuredBytes > budgetBytes) {
+		throw new SessionContextTooLargeError(measuredBytes, budgetBytes);
 	}
 	return context;
 }
@@ -3997,8 +3998,9 @@ function createTranscriptSnapshotHandle(
 		},
 		materialize(): Uint8Array {
 			if (closed) throw new Error("transcript_handle_closed");
-			if (size > SESSION_CONTEXT_MATERIALIZATION_BUDGET_BYTES - TRANSCRIPT_CAPTURE_CHUNK_BYTES) {
-				throw new SessionContextTooLargeError(size, SESSION_CONTEXT_MATERIALIZATION_BUDGET_BYTES);
+			const budgetBytes = effectiveSessionContextBudgetBytes();
+			if (size > budgetBytes - TRANSCRIPT_CAPTURE_CHUNK_BYTES) {
+				throw new SessionContextTooLargeError(size, budgetBytes);
 			}
 			const output = Buffer.allocUnsafe(size);
 			for (let offset = 0; offset < size; offset += TRANSCRIPT_CAPTURE_CHUNK_BYTES) {
@@ -6544,6 +6546,8 @@ export const SessionManagerTestHooks: {
 	lastSidecarInitError?: string;
 	/** Test-only generated-ID cache capacity override. */
 	coldIdHashMaxEntriesOverride?: number;
+	/** Test-only session-context budget override (in-process; does not leak to subprocesses). */
+	sessionContextBudgetBytesOverride?: number;
 } = {};
 
 function materializedCacheMaxBytes(): number {
@@ -6583,6 +6587,13 @@ function coldIdHashMaxEntries(): number {
 	if (override === undefined) return 1_000_000;
 	if (!Number.isSafeInteger(override) || override < 1 || override > COLD_ID_HASH_CAPACITY)
 		throw new RangeError(`coldIdHashMaxEntriesOverride must be between 1 and ${COLD_ID_HASH_CAPACITY}.`);
+	return override;
+}
+function effectiveSessionContextBudgetBytes(): number {
+	const override = SessionManagerTestHooks.sessionContextBudgetBytesOverride;
+	if (override === undefined) return SESSION_CONTEXT_MATERIALIZATION_BUDGET_BYTES;
+	if (!Number.isSafeInteger(override) || override < 1)
+		throw new RangeError("sessionContextBudgetBytesOverride must be a positive safe integer.");
 	return override;
 }
 

--- a/packages/coding-agent/test/gjc-runtime/goal-mode-request.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/goal-mode-request.test.ts
@@ -16,6 +16,7 @@ import {
 	loadEntriesFromFile,
 	SessionContextTooLargeError,
 	type SessionEntry,
+	SessionManagerTestHooks,
 } from "@gajae-code/coding-agent/session/session-manager";
 
 const TEST_SESSION_ID = "test-session";
@@ -25,11 +26,16 @@ let priorSessionId: string | undefined;
 beforeAll(() => {
 	priorSessionId = process.env.GJC_SESSION_ID;
 	process.env.GJC_SESSION_ID = TEST_SESSION_ID;
+	// Pin the session-context budget to 64 MiB in-process via the test hook so the
+	// 40 MiB overflow fixture is deterministic under any production default. This
+	// does not leak into spawned subprocesses (unlike process.env).
+	SessionManagerTestHooks.sessionContextBudgetBytesOverride = 64 * 1024 * 1024;
 });
 
 afterAll(() => {
 	if (priorSessionId !== undefined) process.env.GJC_SESSION_ID = priorSessionId;
 	else delete process.env.GJC_SESSION_ID;
+	delete SessionManagerTestHooks.sessionContextBudgetBytesOverride;
 });
 
 async function tempDir(): Promise<string> {

--- a/packages/coding-agent/test/session/session-context-budget.test.ts
+++ b/packages/coding-agent/test/session/session-context-budget.test.ts
@@ -6,10 +6,8 @@
  * canonical accept, fail-closed fallback, ceiling, safe-integer bound, and
  * warning emission — is covered without process/module reloads. The production
  * default (512 MiB) is verified through a clean-subprocess probe because the
- * test preload deliberately pins the in-process budget to 64 MiB so the
- * overflow-reliant fixtures keep triggering the preflight; the subprocess
- * asserts the real production resolution, so the pin cannot drift from
- * production semantics silently.
+ * in-process budget may differ from the production default; the subprocess
+ * asserts the real production resolution.
  */
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";

--- a/packages/coding-agent/test/session/session-context-overflow.test.ts
+++ b/packages/coding-agent/test/session/session-context-overflow.test.ts
@@ -11,7 +11,7 @@
  *   `continueAfterMaintenance:false`) and retries exactly once; a skipped forced
  *   compaction rethrows the original typed error with zero retries.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import { createHash } from "node:crypto";
 import * as path from "node:path";
 import { Agent, AgentBusyError, type AgentMessage } from "@gajae-code/agent-core";
@@ -27,14 +27,15 @@ import { AuthStorage } from "../../src/session/auth-storage";
 import {
 	buildSessionContext,
 	RESUME_TRANSCRIPT_MAX_BYTES,
-	SESSION_CONTEXT_MATERIALIZATION_BUDGET_BYTES,
 	SessionContextTooLargeError,
 	type SessionEntry,
 	SessionManager,
+	SessionManagerTestHooks,
 } from "../../src/session/session-manager";
 import { FileSessionStorage } from "../../src/session/session-storage";
 import { assistantMsg, userMsg } from "../utilities";
 
+const TEST_BUDGET_BYTES = 64 * 1024 * 1024;
 const BIG_TEXT = "x".repeat(40_000_000);
 // 2 × chars + 16 B per the accountant formula: comfortably over the 64 MiB budget.
 const BIG_MEASURED_BYTES = 2 * BIG_TEXT.length + 16;
@@ -48,6 +49,15 @@ function bigAssistantEntry(): Extract<SessionEntry, { type: "message" }> {
 		message: assistantMsg(BIG_TEXT),
 	};
 }
+// Pin the session-context budget to 64 MiB for this file only, in-process via the
+// test hook. This does not leak into spawned subprocesses (unlike process.env) and
+// keeps the 40 MiB fixtures deterministic under any production default.
+beforeAll(() => {
+	SessionManagerTestHooks.sessionContextBudgetBytesOverride = TEST_BUDGET_BYTES;
+});
+afterAll(() => {
+	delete SessionManagerTestHooks.sessionContextBudgetBytesOverride;
+});
 
 describe("R1 nearest model-change role + hasExplicitDefaultModel isolation", () => {
 	function freshManager(): SessionManager {
@@ -111,7 +121,7 @@ describe("R1 nearest model-change role + hasExplicitDefaultModel isolation", () 
 describe("R3 synchronous context preflight (D5/D5a)", () => {
 	it("free buildSessionContext throws the exported instanceof-stable error over the budget", () => {
 		const entries = [bigAssistantEntry()];
-		expect(BIG_MEASURED_BYTES).toBeGreaterThan(SESSION_CONTEXT_MATERIALIZATION_BUDGET_BYTES);
+		expect(BIG_MEASURED_BYTES).toBeGreaterThan(TEST_BUDGET_BYTES);
 		try {
 			buildSessionContext(entries);
 			throw new Error("Expected SessionContextTooLargeError");
@@ -121,7 +131,7 @@ describe("R3 synchronous context preflight (D5/D5a)", () => {
 				expect(error.code).toBe("context_too_large");
 				expect(error.name).toBe("SessionContextTooLargeError");
 				expect(error.measuredBytes).toBeGreaterThan(error.budgetBytes);
-				expect(error.budgetBytes).toBe(SESSION_CONTEXT_MATERIALIZATION_BUDGET_BYTES);
+				expect(error.budgetBytes).toBe(TEST_BUDGET_BYTES);
 			}
 		}
 	});
@@ -168,7 +178,7 @@ describe("R3 synchronous context preflight (D5/D5a)", () => {
 			const inspected = await SessionManager.inspectSessionTailReadOnly(sessionFile, storage);
 			expect(inspected).toMatchObject({ kind: "error", reason: "context_too_large" });
 			if ("size" in inspected) {
-				expect(inspected.size).toBeGreaterThan(SESSION_CONTEXT_MATERIALIZATION_BUDGET_BYTES);
+				expect(inspected.size).toBeGreaterThan(TEST_BUDGET_BYTES);
 			}
 		} finally {
 			tempDir.removeSync();

--- a/scripts/test-preload.ts
+++ b/scripts/test-preload.ts
@@ -22,18 +22,3 @@ try {
 	// Leave the environment untouched if the temp root cannot be resolved.
 }
 
-// The session-context materialization budget defaults to 512 MiB in production
-// (overridable via GJC_SESSION_CONTEXT_BUDGET_BYTES). Test fixtures in
-// session-context-overflow.test.ts were authored against the former 64 MiB
-// default (BIG_TEXT = 40 MiB → ~80 MiB measured). Pin the budget to 64 MiB for
-// the test process so those fixtures keep triggering the overflow preflight
-// without inflating memory usage across every other test suite.
-//
-// bun test runs every test file in a single shared process, so a per-file env
-// override would leak across files and make the 512 MiB production default
-// nondeterministic. The production default itself is exercised deterministically
-// by session-context-budget.test.ts, which spawns a clean subprocess (no
-// GJC_SESSION_CONTEXT_BUDGET_BYTES in the environment) and asserts the resolved
-// budget equals 512 MiB — so the test pin here cannot drift from production
-// semantics silently.
-process.env.GJC_SESSION_CONTEXT_BUDGET_BYTES = String(64 * 1024 * 1024);


### PR DESCRIPTION
Closes #4224.

## Root cause

PR #4221 added `packages/coding-agent/bunfig.toml` to force the shared root test-preload into package-cwd `bun test` runs. The preload set `process.env.GJC_SESSION_CONTEXT_BUDGET_BYTES` globally, which leaked into subprocesses spawned by tests and broke five CI shards (1, 2, 3, 6, 8).

## Fix

1. Delete `packages/coding-agent/bunfig.toml` — revert #4221 package-cwd preload injection.
2. Remove the budget pin from `scripts/test-preload.ts` — keep only macOS TMPDIR canonicalization.
3. Add `SessionManagerTestHooks.sessionContextBudgetBytesOverride` — in-process test-only override (no subprocess leak).
4. Pin budget to 64 MiB via test hook in the two overflow test files, keeping 40 MiB fixtures deterministic.

## Verification

- session-context-overflow.test.ts: 20/0
- goal-mode-request.test.ts: 14/0
- session-context-budget.test.ts: 26/0 (production probe still sees 512 MiB)
- All three together: 60/0 (package-cwd and root-cwd)
- typecheck clean