### PR TITLE
fix(hooks): validate constrained metadata before import

### DIFF
--- a/packages/coding-agent/src/extensibility/gjc-plugins/constrained-hooks.ts
+++ b/packages/coding-agent/src/extensibility/gjc-plugins/constrained-hooks.ts
@@ -185,6 +185,25 @@ export async function loadConstrainedPluginHooks(input: { cwd: string }): Promis
 	const invalidHookIds = new Set<string>();
 	for (const entry of effective) {
 		if (!entry.enabled) continue;
+		for (const hook of entry.surfaces.hooks) {
+			if (entry.disabledSurfaceIds.includes(hook.extensionId)) continue;
+			const normalized = normalizePluginHook({
+				declaredEvent: hook.event,
+				target: hook.target,
+				phase: hook.phase,
+				plugin: entry.name,
+				source: hook.relativePath,
+			});
+			if (normalized.hook) continue;
+			invalidHookIds.add(`${entry.scope}:${entry.name}:${hook.extensionId}`);
+			preQuarantine.push({
+				identity: bundleIdentity(entry.scope, entry.name),
+				plugin: entry.name,
+				surfaceId: hook.extensionId,
+				code: "invalid_hook",
+				message: normalized.diagnostics.map(diagnostic => `${diagnostic.code}: ${diagnostic.message}`).join("; "),
+			});
+		}
 		const drift = await verifyEntryHashes(entry);
 		if (drift) preQuarantine.push(drift);
 		for (const hook of entry.surfaces.hooks) {

--- a/packages/coding-agent/src/extensibility/gjc-plugins/constrained-hooks.ts
+++ b/packages/coding-agent/src/extensibility/gjc-plugins/constrained-hooks.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { logger } from "@gajae-code/utils";
+import { normalizePluginHook } from "../../hooks/normalize";
 import { bundleIdentity } from "./lifecycle-reconciliation";
 import { verifyImplementationHash } from "./metadata";
 import { resolveWithinRoot } from "./paths";
@@ -106,6 +107,19 @@ export class ConstrainedPluginHookDescriptor {
 	}
 
 	async load(): Promise<ConstrainedPluginHook> {
+		const normalized = normalizePluginHook({
+			declaredEvent: this.event,
+			target: this.target,
+			phase: this.phase,
+			plugin: this.plugin,
+			source: this.relativePath,
+		});
+		if (!normalized.hook) {
+			throw new GjcPluginLoadError(
+				"invalid_hook",
+				normalized.diagnostics.map(diagnostic => `${diagnostic.code}: ${diagnostic.message}`).join("; "),
+			);
+		}
 		if (this.implementationHash) await verifyImplementationHash(this.relativePath, this.implementationHash);
 		const registered: { event: string; handler: (...a: any[]) => unknown }[] = [];
 		const deny = (method: string) => () => {

--- a/packages/coding-agent/test/gjc-plugin-constrained-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-plugin-constrained-hooks.test.ts
@@ -7,6 +7,7 @@ import {
 	ConstrainedPluginHookDescriptor,
 	installGjcBundle,
 	loadConstrainedPluginHooks,
+	registryPathForScope,
 } from "../src/extensibility/gjc-plugins";
 
 const fixturesRoot = path.join(import.meta.dir, "fixtures", "gjc-plugins");
@@ -94,7 +95,7 @@ describe("constrained plugin hooks", () => {
 		expect(res.quarantine.some(q => q.code === "runtime_mismatch")).toBe(true);
 	});
 
-	test("rejects malformed declared metadata before importing plugin code", async () => {
+	test("rejects malformed declared metadata before hashing or importing plugin code", async () => {
 		const root = await mkCwd();
 		const hookPath = path.join(root, "malformed.ts");
 		const markerPath = path.join(root, "imported");
@@ -109,9 +110,32 @@ describe("constrained plugin hooks", () => {
 			target: "read",
 			phase: "during" as never,
 			relativePath: hookPath,
+			implementationHash: "not-a-real-hash",
 		});
 
 		await expect(descriptor.load()).rejects.toThrow("invalid_plugin_phase");
+		expect(await Bun.file(markerPath).exists()).toBe(false);
+	});
+
+	test("quarantines malformed registry metadata before evaluating an installed hook", async () => {
+		const cwd = await mkCwd();
+		const markerPath = path.join(cwd, "imported");
+		const src = await bundleWithHook(
+			`await Bun.write(${JSON.stringify(markerPath)}, "imported"); export default function(api){ api.on('tool_call', ()=>({})); }\n`,
+		);
+		await installGjcBundle({ cwd }, "project", src);
+		const registryPath = registryPathForScope("project", cwd);
+		const registry = JSON.parse(await fs.readFile(registryPath, "utf8")) as {
+			plugins: Array<{ surfaces: { hooks: Array<{ phase?: string }> } }>;
+		};
+		const hook = registry.plugins[0]?.surfaces.hooks[0];
+		if (!hook) throw new Error("expected installed hook metadata");
+		hook.phase = "during";
+		await fs.writeFile(registryPath, JSON.stringify(registry));
+
+		const res = await loadConstrainedPluginHooks({ cwd });
+		expect(res.hooks).toHaveLength(0);
+		expect(res.quarantine.some(q => q.code === "invalid_hook")).toBe(true);
 		expect(await Bun.file(markerPath).exists()).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/gjc-plugin-constrained-hooks.test.ts
+++ b/packages/coding-agent/test/gjc-plugin-constrained-hooks.test.ts
@@ -3,7 +3,11 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getAgentDir, setAgentDir } from "@gajae-code/utils";
-import { installGjcBundle, loadConstrainedPluginHooks } from "../src/extensibility/gjc-plugins";
+import {
+	ConstrainedPluginHookDescriptor,
+	installGjcBundle,
+	loadConstrainedPluginHooks,
+} from "../src/extensibility/gjc-plugins";
 
 const fixturesRoot = path.join(import.meta.dir, "fixtures", "gjc-plugins");
 const sixSurface = path.join(fixturesRoot, "valid-six-surface-bundle");
@@ -88,5 +92,26 @@ describe("constrained plugin hooks", () => {
 		const res = await loadConstrainedPluginHooks({ cwd });
 		expect(res.hooks).toHaveLength(0);
 		expect(res.quarantine.some(q => q.code === "runtime_mismatch")).toBe(true);
+	});
+
+	test("rejects malformed declared metadata before importing plugin code", async () => {
+		const root = await mkCwd();
+		const hookPath = path.join(root, "malformed.ts");
+		const markerPath = path.join(root, "imported");
+		await fs.writeFile(
+			hookPath,
+			`await Bun.write(${JSON.stringify(markerPath)}, "imported"); export default () => undefined;\n`,
+		);
+		const descriptor = new ConstrainedPluginHookDescriptor({
+			plugin: "malformed",
+			scope: "project",
+			event: "tool_call",
+			target: "read",
+			phase: "during" as never,
+			relativePath: hookPath,
+		});
+
+		await expect(descriptor.load()).rejects.toThrow("invalid_plugin_phase");
+		expect(await Bun.file(markerPath).exists()).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary
- validate constrained plugin hook event/phase/target metadata before hash verification, `import()`, or factory invocation
- quarantine malformed descriptors without executing ambient-host plugin code
- retain registration-time full-batch validation as defense in depth
- add a regression proving an import-time marker is never written for invalid metadata

Follow-up to merged #4289 / issue #4286 after delayed independent architecture review found the loader-boundary gap.

## Verification
- `bun test packages/coding-agent/test/gjc-plugin-constrained-hooks.test.ts packages/coding-agent/test/gjc-plugin-hook-extension.test.ts packages/coding-agent/test/hook-event-normalization.test.ts` — 39 pass
- `bun --cwd=packages/coding-agent run check:types` — pass

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*