### PR TITLE
fix(tui): emit a coalesced multi-Esc chunk as individual Escape presses

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- A fast double-Esc (or triple-Esc) whose ESC bytes coalesce into one stdin chunk — which tmux always produces within its escape-time window, and SSH batching produces routinely — is now emitted as individual Escape key presses instead of a single `"\x1b\x1b"` sequence that parsed as the unbound `alt+escape` and silently swallowed both presses. This restores the double-Esc draft-clear and double-Esc selector gestures under tmux/SSH. Option-as-Meta sequences with a real continuation (e.g. Option+Up as `ESC ESC [ A`) remain atomic, and an ESC-cancelled incomplete sequence is still emitted whole.
 - Apple Terminal.app now retains its default keyboard mode when it does not support the Kitty keyboard protocol, avoiding the modifyOtherKeys fallback that breaks Korean/Hangul IME composition.
 
 ## [0.13.1] - 2026-08-11

--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -315,7 +315,13 @@ function extractCompleteSequences(buffer: string): { sequences: string[]; remain
 					// here keeps an unterminated sequence from swallowing the next key.
 					// seqEnd === 1 is excluded so Meta sequences (ESC ESC) still parse.
 					if (remaining[seqEnd] === ESC && seqEnd >= 2 && !continuesAsStringTerminator(remaining, seqEnd)) {
-						sequences.push(candidate);
+						// A cut candidate of nothing but ESC bytes is real Escape key
+						// presses, not an Option-as-Meta prefix: a following ESC proves
+						// no continuation (like "[A") belongs to it. Emitting the pair
+						// as one sequence would parse as the unbound "alt+escape" and
+						// silently swallow both presses.
+						if (/^\x1b+$/.test(candidate)) sequences.push(...candidate.split(""));
+						else sequences.push(candidate);
 						pos += seqEnd;
 						break;
 					}
@@ -713,7 +719,16 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 			return pendingMeta === undefined ? [] : [pendingMeta];
 		}
 
-		const sequences = pendingMeta === undefined ? [this.#buffer] : [pendingMeta, this.#buffer];
+		// A buffer of nothing but ESC bytes at flush time is N real Escape key
+		// presses that arrived faster than the flush window (tmux forwards a
+		// quick double-Esc as one "\x1b\x1b" chunk within escape-time). Keeping
+		// the pair atomic is only correct while a continuation can still turn it
+		// into an Option-as-Meta sequence (ESC ESC [ A); once the flush timeout
+		// fires, no continuation is coming, and emitting the pair as one
+		// sequence parses as the unbound "alt+escape" — silently swallowing
+		// both presses and breaking the double-Esc draft-clear gesture.
+		const flushedBuffer = /^\x1b{2,}$/.test(this.#buffer) ? this.#buffer.split("") : [this.#buffer];
+		const sequences = pendingMeta === undefined ? flushedBuffer : [pendingMeta, ...flushedBuffer];
 		this.#buffer = "";
 		this.#pendingKittyPrintableCodepoint = undefined;
 		return sequences;

--- a/packages/tui/test/stdin-buffer.test.ts
+++ b/packages/tui/test/stdin-buffer.test.ts
@@ -353,6 +353,55 @@ describe("StdinBuffer", () => {
 			expect(flushed).toEqual(["\x1b"]);
 		});
 
+		it("emits a coalesced double-Esc chunk as two Escape presses after the flush timeout", async () => {
+			// tmux forwards a quick double-Esc as one "\x1b\x1b" chunk within
+			// escape-time; emitting it as a single sequence parses as the unbound
+			// "alt+escape" and swallows both presses (double-Esc draft clear).
+			processInput("\x1b\x1b");
+			expect(emittedSequences).toEqual([]);
+
+			await Bun.sleep(15);
+			expect(emittedSequences).toEqual(["\x1b", "\x1b"]);
+		});
+
+		it("emits two Esc presses split across chunks inside the flush window as two Escapes", async () => {
+			processInput("\x1b");
+			await Bun.sleep(5);
+			processInput("\x1b");
+			expect(emittedSequences).toEqual([]);
+
+			await Bun.sleep(15);
+			expect(emittedSequences).toEqual(["\x1b", "\x1b"]);
+		});
+
+		it("emits a triple-Esc chunk as three Escape presses", async () => {
+			processInput("\x1b\x1b\x1b");
+
+			await Bun.sleep(15);
+			expect(emittedSequences).toEqual(["\x1b", "\x1b", "\x1b"]);
+		});
+
+		it("flushes a coalesced double-Esc explicitly as two Escapes", () => {
+			processInput("\x1b\x1b");
+			expect(buffer.flush()).toEqual(["\x1b", "\x1b"]);
+		});
+
+		it("keeps Option-as-Meta ESC ESC sequences atomic when the continuation is present", () => {
+			// macOS Terminal "Use Option as Meta key": Option+Up arrives as ESC ESC [ A
+			// in one write and must stay one sequence.
+			processInput("\x1b\x1b[A");
+			expect(emittedSequences).toEqual(["\x1b\x1b[A"]);
+		});
+
+		it("still cuts an ESC-cancelled incomplete sequence without splitting it", async () => {
+			// An incomplete alt-CSI prefix cancelled by a new ESC is not a pure
+			// ESC run and must be emitted whole, exactly as before.
+			processInput("\x1b\x1b[1;\x1b");
+
+			await Bun.sleep(15);
+			expect(emittedSequences).toEqual(["\x1b\x1b[1;", "\x1b"]);
+		});
+
 		it("should handle buffer input", () => {
 			processInput(Buffer.from("\x1b[A"));
 			expect(emittedSequences).toEqual(["\x1b[A"]);


### PR DESCRIPTION
## What

Emit a coalesced pure-ESC run (`"\x1b\x1b"`, `"\x1b\x1b\x1b"`) as individual Escape key presses — at flush-timeout time and at the ESC-cancel cut — instead of one sequence that parses as the unbound `alt+escape` and silently swallows every press.

## Why

Reported symptom: "Esc Esc sometimes doesn't clear the TUI input." Root cause chain, each step verified against source and by an executable probe against `StdinBuffer`:

1. Two Esc presses within the ~10 ms stdin flush window coalesce into one `"\x1b\x1b"` buffer. **tmux always produces this chunk** for a quick double-Esc (it holds a lone ESC for its escape-time window and forwards the pair together); SSH byte batching produces it routinely.
2. `isCompleteSequence("\x1b\x1b")` is `incomplete` (correctly — it may become Option-as-Meta `ESC ESC [ A`), so the pair waits for a continuation that never comes and is flushed **as a single sequence**.
3. `parseKey("\x1b\x1b")` = `"alt+escape"` (meta-wrapped path in `keys.rs`), which is bound to nothing: `matchesKey(data, "escape")` is false, the editor's `app.interrupt` dispatch never fires, and `onEscape` runs **zero** times.
4. Result: not only the double-Esc draft-clear gesture but *both* Esc presses are lost — under streaming this can also eat an intended abort.

Probe results on unpatched `StdinBuffer` (timeout 10 ms):

| input | events before | events after |
|---|---|---|
| `"\x1b\x1b"` one chunk | 1 × `"\x1b\x1b"` | 2 × `"\x1b"` |
| two chunks 5 ms apart | 1 × `"\x1b\x1b"` | 2 × `"\x1b"` |
| two chunks 30 ms apart | 2 × `"\x1b"` (already correct) | unchanged |
| `"\x1b\x1b\x1b"` one chunk | `"\x1b\x1b"` + `"\x1b"` | 3 × `"\x1b"` |
| `"\x1b\x1b[A"` (Option+Up) | 1 atomic sequence | unchanged |
| `"\x1b\x1b[1;\x1b"` (ESC-cancelled prefix) | whole + `"\x1b"` | unchanged |

The fix is scoped to buffers/candidates matching `/^\x1b+$/`: once a pure ESC run is being flushed (no continuation arrived within the window) or cut (the next byte is another ESC, proving no continuation belongs to it), it is N real key presses. Option-as-Meta pairs with a real continuation and ESC-cancelled incomplete sequences are byte-for-byte unaffected. With two real `escape` events delivered, the existing draft-clear gesture (`input-controller.ts`: arm on first Esc, clear on second within 800 ms with unchanged text) completes naturally.

Tradeoff, stated: a genuine Option+Esc keystroke (macOS "Use Option as Meta") also arrives as `"\x1b\x1b"` and now yields two Escapes. `alt+escape` is bound to nothing anywhere in the tree today (the combination was already a silent no-op), so no existing behavior is lost.

## Testing

- 6 new regression tests in `packages/tui/test/stdin-buffer.test.ts` (coalesced double/triple Esc, split-chunk within window, explicit `flush()`, Option+Up atomicity, ESC-cancelled prefix preservation).
- `bun test packages/tui/test/stdin-buffer.test.ts` — 83 pass / 0 fail.
- `bun test packages/tui/test/` — 1100 pass / 6 skip / 2 fail; both failures (`await-panel-redraw-metrics`, `render-helper-counts`) reproduce with this change stashed, i.e. pre-existing on base `efbe4eef8`.
- `bun --cwd=packages/tui run check` — biome + tsc clean.

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:837282b9e9d08959dc50b054406138297dd25df0 reviewer:human evidence:bun test packages/tui/test/stdin-buffer.test.ts
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes (package-scoped; 2 pre-existing perf-counter failures on base are unrelated)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
