### PR TITLE
fix(models): retain authoritative provider catalog IDs

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Added the authoritative OpenRouter `meta/muse-spark-1.2` catalog fallback with a 1,048,576-token context window and `minimal` through `xhigh` reasoning effort, so stale or credential-limited catalog generation still closes the Muse Spark preset alias deterministically.
 
+### Changed
+
+- Model discovery now retains the authoritative dynamic provider model IDs separately from the merged static/cache catalog. Consumers can distinguish a fresh provider omission from bundled offline availability through `ModelResolutionResult.dynamicModelIds`; cache schema v5 persists those IDs through fresh-cache reuse and static transport re-merges, scoped to the credential-and-endpoint provenance that produced them.
 ### Fixed
 
 - A deterministic Anthropic thinking-replay rejection now converges under a managed fallback attempt instead of repeating forever (#4262). Every coding-agent turn prompts with `fallbackManaged: true`, and the whole in-provider thinking-replay repair sits behind `!options?.fallbackManaged` because the fallback controller owns retries — the shipping CLI therefore never repaired anything: each turn rebuilt the same replay from the same history, drew the same 400, and the session burned one rejected request per turn without ever self-healing (reported as ~1 rejected 1.3 MB request every 12s, ~300/h, never converging). The provider still does not retry inside a managed attempt — it records the full-history repair escalation on the provider session state instead, so the next managed attempt builds a repaired replay at the cost of zero extra round trips. Only the two deterministic rejections (`blocks ... cannot be modified`, ``Invalid `signature` in `thinking` block``) qualify; the proxy-masked generic `api_error` names no cause and may be a transient blip, so it still never costs the session its native replay.

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Model discovery now retains the authoritative dynamic provider model IDs separately from the merged static/cache catalog. Consumers can distinguish a fresh provider omission from bundled offline availability through `ModelResolutionResult.dynamicModelIds`; cache schema v5 persists those IDs through fresh-cache reuse and static transport re-merges, scoped to the credential-and-endpoint provenance that produced them.
+
 ### Fixed
 
 - A deterministic Anthropic thinking-replay rejection now converges under a managed fallback attempt instead of repeating forever (#4262). Every coding-agent turn prompts with `fallbackManaged: true`, and the whole in-provider thinking-replay repair sits behind `!options?.fallbackManaged` because the fallback controller owns retries — the shipping CLI therefore never repaired anything: each turn rebuilt the same replay from the same history, drew the same 400, and the session burned one rejected request per turn without ever self-healing (reported as ~1 rejected 1.3 MB request every 12s, ~300/h, never converging). The provider still does not retry inside a managed attempt — it records the full-history repair escalation on the provider session state instead, so the next managed attempt builds a repaired replay at the cost of zero extra round trips. Only the two deterministic rejections (`blocks ... cannot be modified`, ``Invalid `signature` in `thinking` block``) qualify; the proxy-masked generic `api_error` names no cause and may be a transient blip, so it still never costs the session its native replay.

--- a/packages/ai/src/model-cache.ts
+++ b/packages/ai/src/model-cache.ts
@@ -6,7 +6,7 @@ import { Database } from "bun:sqlite";
 import { getModelDbPath } from "@gajae-code/utils/dirs";
 import type { Api, Model } from "./types";
 
-const CACHE_SCHEMA_VERSION = 3;
+const CACHE_SCHEMA_VERSION = 4;
 
 interface CacheRow {
 	provider_id: string;
@@ -14,6 +14,7 @@ interface CacheRow {
 	updated_at: number;
 	authoritative: number;
 	static_fingerprint: string;
+	dynamic_model_ids: string | null;
 	models: string;
 }
 
@@ -33,6 +34,8 @@ interface CacheEntry<TApi extends Api = Api> {
 	 * match — the cache already incorporates the same static state.
 	 */
 	staticFingerprint: string;
+	/** IDs returned by the authoritative dynamic provider catalog, when retained. */
+	dynamicModelIds: string[] | undefined;
 }
 
 let sharedDb: Database | null = null;
@@ -56,6 +59,7 @@ function getDb(dbPath?: string): Database {
 			updated_at INTEGER NOT NULL,
 			authoritative INTEGER NOT NULL DEFAULT 0,
 			static_fingerprint TEXT NOT NULL DEFAULT '',
+			dynamic_model_ids TEXT,
 			models TEXT NOT NULL
 		)
 	`);
@@ -81,7 +85,10 @@ function migrateCacheSchema(db: Database): void {
 	if (!columns.some(column => column.name === "static_fingerprint")) {
 		db.run("ALTER TABLE model_cache ADD COLUMN static_fingerprint TEXT NOT NULL DEFAULT ''");
 	}
-	db.run("UPDATE model_cache SET version = ? WHERE version = 2", [CACHE_SCHEMA_VERSION]);
+	if (!columns.some(column => column.name === "dynamic_model_ids")) {
+		db.run("ALTER TABLE model_cache ADD COLUMN dynamic_model_ids TEXT");
+	}
+	db.run("UPDATE model_cache SET version = ? WHERE version IN (2, 3)", [CACHE_SCHEMA_VERSION]);
 }
 
 export function readModelCache<TApi extends Api>(
@@ -105,6 +112,7 @@ export function readModelCache<TApi extends Api>(
 			authoritative: row.authoritative === 1,
 			updatedAt: row.updated_at,
 			staticFingerprint: row.static_fingerprint ?? "",
+			dynamicModelIds: row.dynamic_model_ids === null ? undefined : (JSON.parse(row.dynamic_model_ids) as string[]),
 		};
 	} catch {
 		return null;
@@ -118,18 +126,20 @@ export function writeModelCache<TApi extends Api>(
 	authoritative: boolean,
 	staticFingerprint: string,
 	dbPath?: string,
+	dynamicModelIds?: readonly string[],
 ): void {
 	try {
 		const db = getDb(dbPath);
 		db.run(
-			`INSERT OR REPLACE INTO model_cache (provider_id, version, updated_at, authoritative, static_fingerprint, models)
-			 VALUES (?, ?, ?, ?, ?, ?)`,
+			`INSERT OR REPLACE INTO model_cache (provider_id, version, updated_at, authoritative, static_fingerprint, dynamic_model_ids, models)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
 			[
 				providerId,
 				CACHE_SCHEMA_VERSION,
 				updatedAt,
 				authoritative ? 1 : 0,
 				staticFingerprint,
+				dynamicModelIds === undefined ? null : JSON.stringify(dynamicModelIds),
 				JSON.stringify(models),
 			],
 		);

--- a/packages/ai/src/model-cache.ts
+++ b/packages/ai/src/model-cache.ts
@@ -94,7 +94,10 @@ function migrateCacheSchema(db: Database): void {
 	if (!columns.some(column => column.name === "dynamic_model_provenance")) {
 		db.run("ALTER TABLE model_cache ADD COLUMN dynamic_model_provenance TEXT");
 	}
-	db.run("UPDATE model_cache SET version = ? WHERE version IN (2, 3, 4)", [CACHE_SCHEMA_VERSION]);
+	db.run(
+		"UPDATE model_cache SET version = ? WHERE version IN (2, 3, 4) AND dynamic_model_ids IS NOT NULL AND dynamic_model_provenance IS NOT NULL",
+		[CACHE_SCHEMA_VERSION],
+	);
 }
 
 export function readModelCache<TApi extends Api>(

--- a/packages/ai/src/model-cache.ts
+++ b/packages/ai/src/model-cache.ts
@@ -94,10 +94,7 @@ function migrateCacheSchema(db: Database): void {
 	if (!columns.some(column => column.name === "dynamic_model_provenance")) {
 		db.run("ALTER TABLE model_cache ADD COLUMN dynamic_model_provenance TEXT");
 	}
-	db.run(
-		"UPDATE model_cache SET version = ? WHERE version IN (2, 3, 4) AND dynamic_model_ids IS NOT NULL AND dynamic_model_provenance IS NOT NULL",
-		[CACHE_SCHEMA_VERSION],
-	);
+	db.run("UPDATE model_cache SET version = ? WHERE version IN (2, 3, 4)", [CACHE_SCHEMA_VERSION]);
 }
 
 export function readModelCache<TApi extends Api>(

--- a/packages/ai/src/model-cache.ts
+++ b/packages/ai/src/model-cache.ts
@@ -6,7 +6,7 @@ import { Database } from "bun:sqlite";
 import { getModelDbPath } from "@gajae-code/utils/dirs";
 import type { Api, Model } from "./types";
 
-const CACHE_SCHEMA_VERSION = 4;
+const CACHE_SCHEMA_VERSION = 5;
 
 interface CacheRow {
 	provider_id: string;
@@ -15,6 +15,7 @@ interface CacheRow {
 	authoritative: number;
 	static_fingerprint: string;
 	dynamic_model_ids: string | null;
+	dynamic_model_provenance: string | null;
 	models: string;
 }
 
@@ -36,6 +37,7 @@ interface CacheEntry<TApi extends Api = Api> {
 	staticFingerprint: string;
 	/** IDs returned by the authoritative dynamic provider catalog, when retained. */
 	dynamicModelIds: string[] | undefined;
+	dynamicModelProvenance: string | undefined;
 }
 
 let sharedDb: Database | null = null;
@@ -60,6 +62,7 @@ function getDb(dbPath?: string): Database {
 			authoritative INTEGER NOT NULL DEFAULT 0,
 			static_fingerprint TEXT NOT NULL DEFAULT '',
 			dynamic_model_ids TEXT,
+			dynamic_model_provenance TEXT,
 			models TEXT NOT NULL
 		)
 	`);
@@ -88,7 +91,10 @@ function migrateCacheSchema(db: Database): void {
 	if (!columns.some(column => column.name === "dynamic_model_ids")) {
 		db.run("ALTER TABLE model_cache ADD COLUMN dynamic_model_ids TEXT");
 	}
-	db.run("UPDATE model_cache SET version = ? WHERE version IN (2, 3)", [CACHE_SCHEMA_VERSION]);
+	if (!columns.some(column => column.name === "dynamic_model_provenance")) {
+		db.run("ALTER TABLE model_cache ADD COLUMN dynamic_model_provenance TEXT");
+	}
+	db.run("UPDATE model_cache SET version = ? WHERE version IN (2, 3, 4)", [CACHE_SCHEMA_VERSION]);
 }
 
 export function readModelCache<TApi extends Api>(
@@ -113,6 +119,7 @@ export function readModelCache<TApi extends Api>(
 			updatedAt: row.updated_at,
 			staticFingerprint: row.static_fingerprint ?? "",
 			dynamicModelIds: row.dynamic_model_ids === null ? undefined : (JSON.parse(row.dynamic_model_ids) as string[]),
+			dynamicModelProvenance: row.dynamic_model_provenance ?? undefined,
 		};
 	} catch {
 		return null;
@@ -127,12 +134,13 @@ export function writeModelCache<TApi extends Api>(
 	staticFingerprint: string,
 	dbPath?: string,
 	dynamicModelIds?: readonly string[],
+	dynamicModelProvenance?: string,
 ): void {
 	try {
 		const db = getDb(dbPath);
 		db.run(
-			`INSERT OR REPLACE INTO model_cache (provider_id, version, updated_at, authoritative, static_fingerprint, dynamic_model_ids, models)
-			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			`INSERT OR REPLACE INTO model_cache (provider_id, version, updated_at, authoritative, static_fingerprint, dynamic_model_ids, dynamic_model_provenance, models)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 			[
 				providerId,
 				CACHE_SCHEMA_VERSION,
@@ -140,6 +148,7 @@ export function writeModelCache<TApi extends Api>(
 				authoritative ? 1 : 0,
 				staticFingerprint,
 				dynamicModelIds === undefined ? null : JSON.stringify(dynamicModelIds),
+				dynamicModelProvenance ?? null,
 				JSON.stringify(models),
 			],
 		);

--- a/packages/ai/src/model-manager.ts
+++ b/packages/ai/src/model-manager.ts
@@ -58,6 +58,10 @@ export interface ModelManagerOptions<TApi extends Api = Api, TModelsDevPayload =
 export interface ModelResolutionResult<TApi extends Api = Api> {
 	models: Model<TApi>[];
 	stale: boolean;
+	/** Whether the cache row consulted for this resolution was still within its TTL. */
+	cacheFresh: boolean;
+	/** Whether the consulted cache row was authoritative. */
+	cacheAuthoritative: boolean;
 	/** Whether this resolution successfully fetched dynamic models. */
 	fetched: boolean;
 	/**
@@ -164,6 +168,8 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 			return {
 				models: cachedModels,
 				stale: false,
+				cacheFresh: true,
+				cacheAuthoritative: true,
 				fetched: false,
 				dynamicModelIds:
 					strategy === "online-if-uncached" && cacheDynamicModelIdsCurrent ? cache.dynamicModelIds : undefined,
@@ -185,6 +191,8 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 		return {
 			models: repairedModels,
 			stale: false,
+			cacheFresh: true,
+			cacheAuthoritative: true,
 			fetched: false,
 			dynamicModelIds:
 				strategy === "online-if-uncached" && cacheDynamicModelIdsCurrent ? cache.dynamicModelIds : undefined,
@@ -244,6 +252,8 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 	return {
 		models,
 		stale: !dynamicAuthoritative,
+		cacheFresh: cache?.fresh ?? false,
+		cacheAuthoritative: cache?.authoritative ?? false,
 		fetched: shouldFetchFromNetwork && dynamicFetchSucceeded,
 		dynamicModelIds: dynamicFetchSucceeded
 			? dynamicModels.map(model => model.id)

--- a/packages/ai/src/model-manager.ts
+++ b/packages/ai/src/model-manager.ts
@@ -163,7 +163,8 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				models: cachedModels,
 				stale: false,
 				fetched: false,
-				dynamicModelIds: cacheDynamicModelIdsCurrent ? cache.dynamicModelIds : undefined,
+				dynamicModelIds:
+					strategy === "online-if-uncached" && cacheDynamicModelIdsCurrent ? cache.dynamicModelIds : undefined,
 			};
 		}
 		const repairedModels = mergeDynamicModels(staticModels, cachedModels);
@@ -183,7 +184,8 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 			models: repairedModels,
 			stale: false,
 			fetched: false,
-			dynamicModelIds: cacheDynamicModelIdsCurrent ? cache.dynamicModelIds : undefined,
+			dynamicModelIds:
+				strategy === "online-if-uncached" && cacheDynamicModelIdsCurrent ? cache.dynamicModelIds : undefined,
 		};
 	}
 

--- a/packages/ai/src/model-manager.ts
+++ b/packages/ai/src/model-manager.ts
@@ -137,7 +137,9 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 		cache.dynamicModelProvenance !== undefined &&
 		cache.dynamicModelProvenance === options.cacheDynamicModelProvenance;
 	const cacheProvenanceMismatch = cache?.dynamicModelIds !== undefined && !cacheDynamicModelIdsCurrent;
-	const hasAuthoritativeCache = (cache?.authoritative ?? false) || !hasDynamicFetcher;
+	const hasAuthoritativeCache =
+		!hasDynamicFetcher ||
+		((cache?.authoritative ?? false) && (cache?.dynamicModelIds === undefined || cacheDynamicModelIdsCurrent));
 	const cacheAgeMs = cache ? now() - cache.updatedAt : Number.POSITIVE_INFINITY;
 	const shouldFetchFromNetwork =
 		cacheProvenanceMismatch && strategy !== "offline"

--- a/packages/ai/src/model-manager.ts
+++ b/packages/ai/src/model-manager.ts
@@ -58,6 +58,11 @@ export interface ModelResolutionResult<TApi extends Api = Api> {
 	stale: boolean;
 	/** Whether this resolution successfully fetched dynamic models. */
 	fetched: boolean;
+	/**
+	 * IDs returned by a current authoritative dynamic provider catalog. This is
+	 * deliberately distinct from `models`, which merges static and cached data.
+	 */
+	dynamicModelIds?: readonly string[];
 }
 
 /**
@@ -149,13 +154,21 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 	) {
 		const cachedModels = passModelList<TApi>(cache.models);
 		if (!hasStaticTransportDrift(staticModels, cachedModels)) {
-			return { models: cachedModels, stale: false, fetched: false };
+			return { models: cachedModels, stale: false, fetched: false, dynamicModelIds: cache.dynamicModelIds };
 		}
 		const repairedModels = mergeDynamicModels(staticModels, cachedModels);
 		if (options.canPublishCache?.() ?? true) {
-			writeModelCache(options.providerId, now(), repairedModels, true, staticFingerprint, dbPath);
+			writeModelCache(
+				options.providerId,
+				now(),
+				repairedModels,
+				true,
+				staticFingerprint,
+				dbPath,
+				cache.dynamicModelIds,
+			);
 		}
-		return { models: repairedModels, stale: false, fetched: false };
+		return { models: repairedModels, stale: false, fetched: false, dynamicModelIds: cache.dynamicModelIds };
 	}
 
 	const [fetchedModelsDevModels, fetchedDynamicModels] = shouldFetchFromNetwork
@@ -176,7 +189,15 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				mergeDynamicModels(mergeModelSources(staticModels, modelsDevModels), dynamicModels),
 			);
 			if (options.canPublishCache?.() ?? true) {
-				writeModelCache(options.providerId, now(), snapshotModels, true, staticFingerprint, dbPath);
+				writeModelCache(
+					options.providerId,
+					now(),
+					snapshotModels,
+					true,
+					staticFingerprint,
+					dbPath,
+					dynamicModels.map(model => model.id),
+				);
 			}
 		} else {
 			// Dynamic fetch failed — update cache with a non-authoritative snapshot so
@@ -203,6 +224,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 		models,
 		stale: !dynamicAuthoritative,
 		fetched: shouldFetchFromNetwork && dynamicFetchSucceeded,
+		dynamicModelIds: dynamicFetchSucceeded ? dynamicModels.map(model => model.id) : undefined,
 	};
 }
 

--- a/packages/ai/src/model-manager.ts
+++ b/packages/ai/src/model-manager.ts
@@ -224,7 +224,11 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 		models,
 		stale: !dynamicAuthoritative,
 		fetched: shouldFetchFromNetwork && dynamicFetchSucceeded,
-		dynamicModelIds: dynamicFetchSucceeded ? dynamicModels.map(model => model.id) : undefined,
+		dynamicModelIds: dynamicFetchSucceeded
+			? dynamicModels.map(model => model.id)
+			: shouldUseFreshCacheAsAuthoritative
+				? cache?.dynamicModelIds
+				: undefined,
 	};
 }
 

--- a/packages/ai/src/model-manager.ts
+++ b/packages/ai/src/model-manager.ts
@@ -43,6 +43,8 @@ export interface ModelManagerOptions<TApi extends Api = Api, TModelsDevPayload =
 	now?: () => number;
 	/** Optional guard that must permit cache publication. Default: writes are permitted. */
 	canPublishCache?: () => boolean;
+	/** Credential-and-endpoint identity required to reuse dynamic catalog IDs. */
+	cacheDynamicModelProvenance?: string;
 }
 
 /**
@@ -130,14 +132,17 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 	const cache = readModelCache<TApi>(options.providerId, ttlMs, now, dbPath);
 	const dynamicFetcher = options.fetchDynamicModels;
 	const hasDynamicFetcher = typeof dynamicFetcher === "function";
+	const cacheDynamicModelIdsCurrent =
+		cache?.dynamicModelIds !== undefined &&
+		cache.dynamicModelProvenance !== undefined &&
+		cache.dynamicModelProvenance === options.cacheDynamicModelProvenance;
+	const cacheProvenanceMismatch = cache?.dynamicModelIds !== undefined && !cacheDynamicModelIdsCurrent;
 	const hasAuthoritativeCache = (cache?.authoritative ?? false) || !hasDynamicFetcher;
 	const cacheAgeMs = cache ? now() - cache.updatedAt : Number.POSITIVE_INFINITY;
-	const shouldFetchFromNetwork = shouldFetchRemoteSources(
-		strategy,
-		cache?.fresh ?? false,
-		hasAuthoritativeCache,
-		cacheAgeMs,
-	);
+	const shouldFetchFromNetwork =
+		cacheProvenanceMismatch && strategy !== "offline"
+			? true
+			: shouldFetchRemoteSources(strategy, cache?.fresh ?? false, hasAuthoritativeCache, cacheAgeMs);
 	const staticFingerprint = fingerprintStatic(staticModels);
 
 	// Cold-start fast path: when a fresh, authoritative cache exists, the network
@@ -154,7 +159,12 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 	) {
 		const cachedModels = passModelList<TApi>(cache.models);
 		if (!hasStaticTransportDrift(staticModels, cachedModels)) {
-			return { models: cachedModels, stale: false, fetched: false, dynamicModelIds: cache.dynamicModelIds };
+			return {
+				models: cachedModels,
+				stale: false,
+				fetched: false,
+				dynamicModelIds: cacheDynamicModelIdsCurrent ? cache.dynamicModelIds : undefined,
+			};
 		}
 		const repairedModels = mergeDynamicModels(staticModels, cachedModels);
 		if (options.canPublishCache?.() ?? true) {
@@ -166,9 +176,15 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				staticFingerprint,
 				dbPath,
 				cache.dynamicModelIds,
+				cache.dynamicModelProvenance,
 			);
 		}
-		return { models: repairedModels, stale: false, fetched: false, dynamicModelIds: cache.dynamicModelIds };
+		return {
+			models: repairedModels,
+			stale: false,
+			fetched: false,
+			dynamicModelIds: cacheDynamicModelIdsCurrent ? cache.dynamicModelIds : undefined,
+		};
 	}
 
 	const [fetchedModelsDevModels, fetchedDynamicModels] = shouldFetchFromNetwork
@@ -197,6 +213,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 					staticFingerprint,
 					dbPath,
 					dynamicModels.map(model => model.id),
+					options.cacheDynamicModelProvenance,
 				);
 			}
 		} else {
@@ -227,7 +244,9 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 		dynamicModelIds: dynamicFetchSucceeded
 			? dynamicModels.map(model => model.id)
 			: shouldUseFreshCacheAsAuthoritative
-				? cache?.dynamicModelIds
+				? cacheDynamicModelIdsCurrent
+					? cache?.dynamicModelIds
+					: undefined
 				: undefined,
 	};
 }

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -1977,36 +1977,36 @@ export function anthropicModelManagerOptions(
 					.then(payload => mapAnthropicModelsDev(payload, baseUrl))
 					.catch(() => []);
 				const references = buildAnthropicReferenceMap(modelsDevModels);
-				return (
-					fetchOpenAICompatibleModels({
-						api: "anthropic-messages",
-						provider: "anthropic",
-						baseUrl,
-						headers: buildAnthropicDiscoveryHeaders(apiKey),
-						mapModel: (
-							entry: OpenAICompatibleModelRecord,
-							defaults: Model<"anthropic-messages">,
-							_context: OpenAICompatibleModelMapperContext<"anthropic-messages">,
-						): Model<"anthropic-messages"> => {
-							const discoveredName = typeof entry.display_name === "string" ? entry.display_name : defaults.name;
-							const reference = references.get(defaults.id);
-							if (!reference) {
-								return {
-									...defaults,
-									name: discoveredName,
-								};
-							}
+				const models = await fetchOpenAICompatibleModels({
+					api: "anthropic-messages",
+					provider: "anthropic",
+					baseUrl,
+					headers: buildAnthropicDiscoveryHeaders(apiKey),
+					mapModel: (
+						entry: OpenAICompatibleModelRecord,
+						defaults: Model<"anthropic-messages">,
+						_context: OpenAICompatibleModelMapperContext<"anthropic-messages">,
+					): Model<"anthropic-messages"> => {
+						const discoveredName = typeof entry.display_name === "string" ? entry.display_name : defaults.name;
+						const reference = references.get(defaults.id);
+						if (!reference) {
 							return {
-								...reference,
-								id: defaults.id,
+								...defaults,
 								name: discoveredName,
-								api: "anthropic-messages",
-								provider: "anthropic",
-								baseUrl,
 							};
-						},
-					}) ?? null
-				);
+						}
+						return {
+							...reference,
+							id: defaults.id,
+							name: discoveredName,
+							api: "anthropic-messages",
+							provider: "anthropic",
+							baseUrl,
+						};
+					},
+				});
+				if (models === null) return null;
+				return models;
 			},
 		}),
 	};

--- a/packages/ai/test/model-cache.test.ts
+++ b/packages/ai/test/model-cache.test.ts
@@ -48,7 +48,7 @@ describe("model cache migrations", () => {
 		}
 	});
 
-	it("invalidates v2 cached models so the next discovery replaces them", () => {
+	it("preserves v2 cached models and lets the next discovery overwrite them", () => {
 		const legacyModel = createModel("legacy-cloud-model", "Legacy Cloud Model");
 		const legacyDb = new Database(dbPath, { create: true });
 		legacyDb.run(`
@@ -67,7 +67,8 @@ describe("model cache migrations", () => {
 		legacyDb.close();
 
 		const migrated = readModelCache<"openai-completions">("ollama-cloud", TTL_MS, Date.now, dbPath);
-		expect(migrated).toBeNull();
+		expect(migrated?.models.map(model => model.id)).toEqual(["legacy-cloud-model"]);
+		expect(migrated?.staticFingerprint).toBe("");
 
 		const replacementModel = createModel("fresh-cloud-model", "Fresh Cloud Model");
 		writeModelCache("ollama-cloud", Date.now(), [replacementModel], true, "static-v3", dbPath);

--- a/packages/ai/test/model-cache.test.ts
+++ b/packages/ai/test/model-cache.test.ts
@@ -48,7 +48,7 @@ describe("model cache migrations", () => {
 		}
 	});
 
-	it("preserves v2 cached models and lets the next discovery overwrite them", () => {
+	it("invalidates v2 cached models so the next discovery replaces them", () => {
 		const legacyModel = createModel("legacy-cloud-model", "Legacy Cloud Model");
 		const legacyDb = new Database(dbPath, { create: true });
 		legacyDb.run(`
@@ -67,8 +67,7 @@ describe("model cache migrations", () => {
 		legacyDb.close();
 
 		const migrated = readModelCache<"openai-completions">("ollama-cloud", TTL_MS, Date.now, dbPath);
-		expect(migrated?.models.map(model => model.id)).toEqual(["legacy-cloud-model"]);
-		expect(migrated?.staticFingerprint).toBe("");
+		expect(migrated).toBeNull();
 
 		const replacementModel = createModel("fresh-cloud-model", "Fresh Cloud Model");
 		writeModelCache("ollama-cloud", Date.now(), [replacementModel], true, "static-v3", dbPath);

--- a/packages/ai/test/model-cache.test.ts
+++ b/packages/ai/test/model-cache.test.ts
@@ -77,6 +77,43 @@ describe("model cache migrations", () => {
 		expect(overwritten?.staticFingerprint).toBe("static-v3");
 	});
 
+	it("preserves a v4 row with authoritative dynamic IDs and provenance", () => {
+		const legacyModel = createModel("dynamic-cloud-model", "Dynamic Cloud Model");
+		const legacyDb = new Database(dbPath, { create: true });
+		legacyDb.run(`
+			CREATE TABLE model_cache (
+				provider_id TEXT PRIMARY KEY,
+				version INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				authoritative INTEGER NOT NULL DEFAULT 0,
+				static_fingerprint TEXT NOT NULL DEFAULT '',
+				dynamic_model_ids TEXT,
+				dynamic_model_provenance TEXT,
+				models TEXT NOT NULL
+			)
+		`);
+		legacyDb.run(
+			`INSERT INTO model_cache (provider_id, version, updated_at, authoritative, static_fingerprint, dynamic_model_ids, dynamic_model_provenance, models)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			[
+				"ollama-cloud",
+				4,
+				Date.now(),
+				1,
+				"static-v4",
+				JSON.stringify([legacyModel.id]),
+				"provenance-v4",
+				JSON.stringify([legacyModel]),
+			],
+		);
+		legacyDb.close();
+
+		const migrated = readModelCache<"openai-completions">("ollama-cloud", TTL_MS, Date.now, dbPath);
+		expect(migrated?.models.map(model => model.id)).toEqual(["dynamic-cloud-model"]);
+		expect(migrated?.dynamicModelIds).toEqual(["dynamic-cloud-model"]);
+		expect(migrated?.dynamicModelProvenance).toBe("provenance-v4");
+	});
+
 	it("closes only the exact shared database owner before root removal", async () => {
 		writeModelCache("ollama-cloud", Date.now(), [createModel("owned", "Owned")], true, "static", dbPath);
 		expect(closeModelCache(path.join(tempDir, "other.db"))).toBe(false);

--- a/packages/ai/test/model-manager-cache.test.ts
+++ b/packages/ai/test/model-manager-cache.test.ts
@@ -103,6 +103,40 @@ describe("online-if-uncached model refresh", () => {
 		expect(cached.dynamicModelIds).toEqual(["dynamic"]);
 	});
 
+	test("retains fresh cached dynamic IDs when static transport drift forces a cache re-merge", async () => {
+		const providerId = "cache-authoritative-remerge";
+		const now = 1_700_000_000_000;
+		const initialStatic = [model(providerId, "static")];
+		await resolveProviderModels<Api>(
+			{
+				providerId,
+				staticModels: initialStatic,
+				cacheDbPath,
+				now: () => now,
+				fetchDynamicModels: async () => [model(providerId, "dynamic")],
+			},
+			"online",
+		);
+
+		const changedStatic = [{ ...model(providerId, "static"), baseUrl: "https://changed.example.test/v1" }];
+		const cached = await resolveProviderModels<Api>(
+			{
+				providerId,
+				staticModels: changedStatic,
+				cacheDbPath,
+				now: () => now,
+				fetchDynamicModels: async () => {
+					throw new Error("fresh cache must be reused");
+				},
+			},
+			"online-if-uncached",
+		);
+
+		expect(cached.fetched).toBe(false);
+		expect(cached.stale).toBe(false);
+		expect(cached.dynamicModelIds).toEqual(["dynamic"]);
+	});
+
 	test("refreshes missing and stale caches", async () => {
 		const now = 1_700_000_000_000;
 		for (const [providerId, cachedAt] of [

--- a/packages/ai/test/model-manager-cache.test.ts
+++ b/packages/ai/test/model-manager-cache.test.ts
@@ -69,6 +69,40 @@ describe("online-if-uncached model refresh", () => {
 		expect(result.models.map(entry => entry.id)).toEqual(["static", "cached"]);
 	});
 
+	test("retains authoritative dynamic IDs separately from merged static models", async () => {
+		const providerId = "cache-authoritative-ids";
+		const staticModels = [model(providerId, "static")];
+		const now = 1_700_000_000_000;
+
+		const fetched = await resolveProviderModels<Api>(
+			{
+				providerId,
+				staticModels,
+				cacheDbPath,
+				now: () => now,
+				fetchDynamicModels: async () => [model(providerId, "dynamic")],
+			},
+			"online",
+		);
+		expect(fetched.models.map(entry => entry.id)).toEqual(["static", "dynamic"]);
+		expect(fetched.dynamicModelIds).toEqual(["dynamic"]);
+
+		const cached = await resolveProviderModels<Api>(
+			{
+				providerId,
+				staticModels,
+				cacheDbPath,
+				now: () => now,
+				fetchDynamicModels: async () => {
+					throw new Error("fresh cache must be reused");
+				},
+			},
+			"online-if-uncached",
+		);
+		expect(cached.models.map(entry => entry.id)).toEqual(["static", "dynamic"]);
+		expect(cached.dynamicModelIds).toEqual(["dynamic"]);
+	});
+
 	test("refreshes missing and stale caches", async () => {
 		const now = 1_700_000_000_000;
 		for (const [providerId, cachedAt] of [
@@ -158,6 +192,24 @@ describe("online-if-uncached model refresh", () => {
 				failure,
 			).toEqual(["static"]);
 		}
+	});
+
+	test("does not present stale or failed catalog IDs as live evidence", async () => {
+		const providerId = "cache-unproven-ids";
+		const staticModels = [model(providerId, "static")];
+		const result = await resolveProviderModels<Api>(
+			{
+				providerId,
+				staticModels,
+				cacheDbPath,
+				fetchDynamicModels: async () => null,
+			},
+			"online",
+		);
+
+		expect(result.models.map(entry => entry.id)).toEqual(["static"]);
+		expect(result.stale).toBe(true);
+		expect(result.dynamicModelIds).toBeUndefined();
 	});
 
 	test("does not publish successful dynamic models when the cache guard denies publication", async () => {

--- a/packages/ai/test/model-manager-cache.test.ts
+++ b/packages/ai/test/model-manager-cache.test.ts
@@ -176,6 +176,41 @@ describe("online-if-uncached model refresh", () => {
 		expect(offline.dynamicModelIds).toBeUndefined();
 	});
 
+	test("withholds matching cached dynamic IDs during offline refresh", async () => {
+		const providerId = "cache-offline-provenance";
+		const staticModels = [model(providerId, "static")];
+		const now = 1_700_000_000_000;
+		const provenance = "credential-a\u0000https://provider-a.example.test";
+		await resolveProviderModels<Api>(
+			{
+				providerId,
+				staticModels,
+				cacheDbPath,
+				cacheDynamicModelProvenance: provenance,
+				now: () => now,
+				fetchDynamicModels: async () => [model(providerId, "dynamic")],
+			},
+			"online",
+		);
+
+		const offline = await resolveProviderModels<Api>(
+			{
+				providerId,
+				staticModels,
+				cacheDbPath,
+				cacheDynamicModelProvenance: provenance,
+				now: () => now,
+				fetchDynamicModels: async () => {
+					throw new Error("offline refresh must not fetch");
+				},
+			},
+			"offline",
+		);
+
+		expect(offline.models.map(entry => entry.id)).toEqual(["static", "dynamic"]);
+		expect(offline.dynamicModelIds).toBeUndefined();
+	});
+
 	test("refreshes missing and stale caches", async () => {
 		const now = 1_700_000_000_000;
 		for (const [providerId, cachedAt] of [

--- a/packages/ai/test/model-manager-cache.test.ts
+++ b/packages/ai/test/model-manager-cache.test.ts
@@ -55,6 +55,7 @@ describe("online-if-uncached model refresh", () => {
 				providerId,
 				staticModels,
 				cacheDbPath,
+				cacheDynamicModelProvenance: "credential-a\u0000https://provider-a.example.test",
 				now: () => now,
 				fetchDynamicModels: async () => {
 					discoveryCalls += 1;
@@ -79,6 +80,7 @@ describe("online-if-uncached model refresh", () => {
 				providerId,
 				staticModels,
 				cacheDbPath,
+				cacheDynamicModelProvenance: "credential-a\u0000https://provider-a.example.test",
 				now: () => now,
 				fetchDynamicModels: async () => [model(providerId, "dynamic")],
 			},
@@ -92,6 +94,7 @@ describe("online-if-uncached model refresh", () => {
 				providerId,
 				staticModels,
 				cacheDbPath,
+				cacheDynamicModelProvenance: "credential-a\u0000https://provider-a.example.test",
 				now: () => now,
 				fetchDynamicModels: async () => {
 					throw new Error("fresh cache must be reused");
@@ -112,6 +115,7 @@ describe("online-if-uncached model refresh", () => {
 				providerId,
 				staticModels: initialStatic,
 				cacheDbPath,
+				cacheDynamicModelProvenance: "credential-a\u0000https://provider-a.example.test",
 				now: () => now,
 				fetchDynamicModels: async () => [model(providerId, "dynamic")],
 			},
@@ -124,6 +128,7 @@ describe("online-if-uncached model refresh", () => {
 				providerId,
 				staticModels: changedStatic,
 				cacheDbPath,
+				cacheDynamicModelProvenance: "credential-a\u0000https://provider-a.example.test",
 				now: () => now,
 				fetchDynamicModels: async () => {
 					throw new Error("fresh cache must be reused");
@@ -135,6 +140,40 @@ describe("online-if-uncached model refresh", () => {
 		expect(cached.fetched).toBe(false);
 		expect(cached.stale).toBe(false);
 		expect(cached.dynamicModelIds).toEqual(["dynamic"]);
+	});
+
+	test("does not reuse cached dynamic IDs after an offline credential or endpoint change", async () => {
+		const providerId = "cache-provenance-change";
+		const staticModels = [model(providerId, "static")];
+		const now = 1_700_000_000_000;
+		await resolveProviderModels<Api>(
+			{
+				providerId,
+				staticModels,
+				cacheDbPath,
+				cacheDynamicModelProvenance: "credential-a\u0000https://provider-a.example.test",
+				now: () => now,
+				fetchDynamicModels: async () => [model(providerId, "dynamic")],
+			},
+			"online",
+		);
+
+		const offline = await resolveProviderModels<Api>(
+			{
+				providerId,
+				staticModels,
+				cacheDbPath,
+				cacheDynamicModelProvenance: "credential-b\u0000https://provider-b.example.test",
+				now: () => now,
+				fetchDynamicModels: async () => {
+					throw new Error("offline refresh must not fetch");
+				},
+			},
+			"offline",
+		);
+
+		expect(offline.models.map(entry => entry.id)).toEqual(["static", "dynamic"]);
+		expect(offline.dynamicModelIds).toBeUndefined();
 	});
 
 	test("refreshes missing and stale caches", async () => {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2646,6 +2646,7 @@ export class ModelRegistry {
 			if (
 				isCurrentDiscovery() &&
 				(result.fetched ||
+					result.dynamicModelIds !== undefined ||
 					result.stale ||
 					this.#descriptorDiscoveryEvidence.get(options.providerId)?.authGeneration !== authGeneration ||
 					this.#descriptorDiscoveryEvidence.get(options.providerId)?.endpoint !== endpoint)

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2643,8 +2643,13 @@ export class ModelRegistry {
 					...(baseUrl !== model.baseUrl ? { baseUrl } : {}),
 				};
 			});
+			const preservesExistingDescriptorEvidence =
+				(result.dynamicModelIds === undefined && !result.fetched && !result.stale) ||
+				(result.stale && result.cacheFresh && result.cacheAuthoritative && evidence?.fresh === true) ||
+				(strategy === "offline" && result.dynamicModelIds === undefined);
 			if (
 				isCurrentDiscovery() &&
+				!preservesExistingDescriptorEvidence &&
 				(result.fetched ||
 					result.dynamicModelIds !== undefined ||
 					result.stale ||

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1246,7 +1246,13 @@ export class ModelRegistry {
 	#configuredDiscoveryProviderIds: ReadonlySet<string> = new Set();
 	#descriptorDiscoveryEvidence = new Map<
 		string,
-		{ fresh: boolean; modelIds: ReadonlySet<string>; authGeneration: string; endpoint: string }
+		{
+			fresh: boolean;
+			modelIds: ReadonlySet<string>;
+			profileModelIds?: ReadonlySet<string>;
+			authGeneration: string;
+			endpoint: string;
+		}
 	>();
 	#descriptorDiscoveryGenerations = new Map<string, number>();
 	#configuredDiscoveryEvidence = new Map<
@@ -2600,7 +2606,7 @@ export class ModelRegistry {
 					? {
 							fetchDynamicModels: async () => {
 								const models = await options.fetchDynamicModels?.();
-								if (models === null) return null;
+								if (models === null || models === undefined) return null;
 								const sanitizedModels = this.#stripModelBaseUrlQueries(models ?? []);
 								if (canUseCredentialDerivedXiaomiEndpoint) {
 									credentialDerivedEndpoint = sanitizedModels[0]?.baseUrl;
@@ -2642,10 +2648,11 @@ export class ModelRegistry {
 					this.#descriptorDiscoveryEvidence.get(options.providerId)?.endpoint !== endpoint)
 			) {
 				this.#descriptorDiscoveryEvidence.set(options.providerId, {
-					fresh: result.fetched,
+					fresh: !result.stale,
 					modelIds: new Set(models.map(model => model.id)),
+					...(result.dynamicModelIds === undefined ? {} : { profileModelIds: new Set(result.dynamicModelIds) }),
 					authGeneration,
-					endpoint: this.#normalizeDiscoveryEvidenceEndpoint(models[0]?.baseUrl ?? endpoint),
+					endpoint,
 				});
 			}
 			if (!isCurrentDiscovery()) {
@@ -3705,16 +3712,20 @@ export class ModelRegistry {
 	getAvailableForProfileActivation(): Model<Api>[] {
 		return this.getAvailable().filter(model => {
 			const evidence = this.#descriptorDiscoveryEvidence.get(model.provider);
-			if (!evidence?.fresh) return true;
+			if (!evidence?.fresh || evidence.profileModelIds === undefined) return true;
+			const bundledModelIds = new Set(
+				(getBundledModels(model.provider as Parameters<typeof getBundledModels>[0]) as Model<Api>[]).map(
+					candidate => candidate.id,
+				),
+			);
+			if (!bundledModelIds.has(model.id)) return true;
 			if (
 				evidence.authGeneration !== this.#getProviderEvidenceGeneration(model.provider) ||
 				evidence.endpoint !==
-					this.#normalizeDiscoveryEvidenceEndpoint(
-						this.#getProviderBaseUrlForDiscovery(model.provider) ?? model.baseUrl ?? "",
-					)
+					this.#normalizeDiscoveryEvidenceEndpoint(this.#getProviderBaseUrlForDiscovery(model.provider) ?? "")
 			)
 				return true;
-			return evidence.modelIds.has(model.id);
+			return evidence.profileModelIds.has(model.id);
 		});
 	}
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2662,10 +2662,10 @@ export class ModelRegistry {
 					...(result.dynamicModelIds === undefined
 						? {}
 						: {
-							profileModelIds: new Set(result.dynamicModelIds),
-							profileFresh: !result.stale,
-							profileEndpoint: endpoint,
-						}),
+								profileModelIds: new Set(result.dynamicModelIds),
+								profileFresh: !result.stale,
+								profileEndpoint: endpoint,
+							}),
 					authGeneration,
 					endpoint: this.#normalizeDiscoveryEvidenceEndpoint(models[0]?.baseUrl ?? endpoint),
 				});

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -3722,6 +3722,7 @@ export class ModelRegistry {
 		return this.getAvailable().filter(model => {
 			const evidence = this.#descriptorDiscoveryEvidence.get(model.provider);
 			if (!evidence?.profileFresh || evidence.profileModelIds === undefined) return true;
+			if (this.#hasCustomModelOverlay(model.provider, model.id)) return true;
 			const bundledModelIds = new Set(
 				(getBundledModels(model.provider as Parameters<typeof getBundledModels>[0]) as Model<Api>[]).map(
 					candidate => candidate.id,
@@ -3736,6 +3737,12 @@ export class ModelRegistry {
 				return true;
 			return evidence.profileModelIds.has(model.id);
 		});
+	}
+
+	#hasCustomModelOverlay(provider: string, id: string): boolean {
+		return [...this.#customModelOverlays, ...this.#runtimeModelOverlays].some(
+			overlay => overlay.provider === provider && overlay.id === id,
+		);
 	}
 
 	#hasFreshOrStaticModelEvidence(model: Model<Api>): boolean {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1250,6 +1250,8 @@ export class ModelRegistry {
 			fresh: boolean;
 			modelIds: ReadonlySet<string>;
 			profileModelIds?: ReadonlySet<string>;
+			profileFresh?: boolean;
+			profileEndpoint?: string;
 			authGeneration: string;
 			endpoint: string;
 		}
@@ -2601,6 +2603,7 @@ export class ModelRegistry {
 			const manager = createModelManager({
 				...options,
 				cacheDbPath: this.#cacheDbPath,
+				cacheDynamicModelProvenance: Bun.hash(`${authGeneration}\u0000${endpoint}`).toString(36),
 				canPublishCache: isCurrentDiscovery,
 				...(options.fetchDynamicModels
 					? {
@@ -2648,11 +2651,17 @@ export class ModelRegistry {
 					this.#descriptorDiscoveryEvidence.get(options.providerId)?.endpoint !== endpoint)
 			) {
 				this.#descriptorDiscoveryEvidence.set(options.providerId, {
-					fresh: !result.stale,
+					fresh: result.fetched,
 					modelIds: new Set(models.map(model => model.id)),
-					...(result.dynamicModelIds === undefined ? {} : { profileModelIds: new Set(result.dynamicModelIds) }),
+					...(result.dynamicModelIds === undefined
+						? {}
+						: {
+							profileModelIds: new Set(result.dynamicModelIds),
+							profileFresh: !result.stale,
+							profileEndpoint: endpoint,
+						}),
 					authGeneration,
-					endpoint,
+					endpoint: this.#normalizeDiscoveryEvidenceEndpoint(models[0]?.baseUrl ?? endpoint),
 				});
 			}
 			if (!isCurrentDiscovery()) {
@@ -3712,7 +3721,7 @@ export class ModelRegistry {
 	getAvailableForProfileActivation(): Model<Api>[] {
 		return this.getAvailable().filter(model => {
 			const evidence = this.#descriptorDiscoveryEvidence.get(model.provider);
-			if (!evidence?.fresh || evidence.profileModelIds === undefined) return true;
+			if (!evidence?.profileFresh || evidence.profileModelIds === undefined) return true;
 			const bundledModelIds = new Set(
 				(getBundledModels(model.provider as Parameters<typeof getBundledModels>[0]) as Model<Api>[]).map(
 					candidate => candidate.id,
@@ -3721,7 +3730,7 @@ export class ModelRegistry {
 			if (!bundledModelIds.has(model.id)) return true;
 			if (
 				evidence.authGeneration !== this.#getProviderEvidenceGeneration(model.provider) ||
-				evidence.endpoint !==
+				evidence.profileEndpoint !==
 					this.#normalizeDiscoveryEvidenceEndpoint(this.#getProviderBaseUrlForDiscovery(model.provider) ?? "")
 			)
 				return true;

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, test, vi } from "bun:test";
 import { Agent, ThinkingLevel } from "@gajae-code/agent-core";
 
 import type { Model } from "@gajae-code/ai";
-import { TempDir } from "@gajae-code/utils";
+import { hookFetch, TempDir } from "@gajae-code/utils";
 import {
 	activateModelProfile,
 	applyPreparedModelProfileActivation,
@@ -17,9 +17,10 @@ import {
 
 import type { ModelProfileDefinition } from "../src/config/model-profiles";
 import { BUILTIN_MODEL_PROFILES, mergeModelProfiles } from "../src/config/model-profiles";
-import { kNoAuth, type ModelRegistry } from "../src/config/model-registry";
+import { kNoAuth, ModelRegistry } from "../src/config/model-registry";
 import { Settings } from "../src/config/settings";
 import { AgentSession, type DefaultFallbackRuntimeState } from "../src/session/agent-session";
+import { AuthStorage } from "../src/session/auth-storage";
 import { SessionManager } from "../src/session/session-manager";
 
 const model = (provider: string, id: string, thinking?: Model["thinking"]): Model =>
@@ -259,6 +260,67 @@ describe("model profile activation", () => {
 
 		expect(prepared.defaultModel).toMatchObject({ provider: "anthropic", id: "claude-opus-5" });
 		expect(prepared.defaultThinkingLevel).toBe(ThinkingLevel.XHigh);
+	});
+
+	test("built-in claude-opus skips a bundled Opus 5 absent from fresh live catalog evidence", async () => {
+		const tempDir = TempDir.createSync("@gjc-profile-live-catalog-");
+		const authStorage = await AuthStorage.create(`${tempDir.path()}/auth.db`);
+		try {
+			authStorage.setRuntimeApiKey("anthropic", "test-anthropic-key");
+			const requests: string[] = [];
+			using _hook = hookFetch(input => {
+				const url = String(input);
+				requests.push(url);
+				switch (url) {
+					case "https://models.dev/api.json":
+						return new Response(JSON.stringify({ anthropic: { models: {} } }), {
+							headers: { "Content-Type": "application/json" },
+						});
+					case "https://api.layofflabs.com/models":
+						return new Response(
+							JSON.stringify({ data: [{ id: "claude-opus-4-6" }, { id: "claude-sonnet-5" }] }),
+							{ headers: { "Content-Type": "application/json" } },
+						);
+					default:
+						throw new Error(`Unexpected model discovery request: ${input}`);
+				}
+			});
+			const registry = new ModelRegistry(authStorage, `${tempDir.path()}/models.yml`);
+			await registry.refreshProvider("anthropic", "online");
+
+			expect(requests).toContain("https://api.layofflabs.com/models");
+			expect(registry.getAvailable().some(candidate => candidate.id === "claude-opus-5")).toBe(true);
+			expect(
+				registry
+					.getAvailableForProfileActivation()
+					.filter(candidate => candidate.provider === "anthropic")
+					.map(candidate => candidate.id),
+			).not.toContain("claude-opus-5");
+			const session = fakeSession();
+			session.model = undefined;
+			session.thinkingLevel = undefined;
+			session.sessionId = "parent-session";
+			const prepared = await prepareModelProfileActivation({
+				session: session as unknown as AgentSession,
+				modelRegistry: registry,
+				settings: Settings.isolated(),
+				profileName: "claude-opus",
+			});
+
+			expect(prepared.defaultModel).toMatchObject({ provider: "anthropic", id: "claude-opus-4-6" });
+			expect(prepared.defaultResolutionSkips).toEqual([
+				{ selector: "anthropic/claude-opus-5:xhigh", reason: "unknown_model" },
+			]);
+			expect(prepared.agentModelOverrides).toMatchObject({
+				executor: "anthropic/claude-sonnet-5",
+				planner: ["anthropic/claude-opus-5:low", "anthropic/claude-opus-4-6:low"],
+				critic: ["anthropic/claude-opus-5:high", "anthropic/claude-opus-4-6:high"],
+				architect: ["anthropic/claude-opus-5:xhigh", "anthropic/claude-opus-4-6:high"],
+			});
+		} finally {
+			authStorage.close();
+			tempDir.removeSync();
+		}
 	});
 
 	test("rejects a mixed provider-agnostic profile before mutation when a role alias is unavailable", async () => {

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -276,19 +276,20 @@ describe("model profile activation", () => {
 						return new Response(JSON.stringify({ anthropic: { models: {} } }), {
 							headers: { "Content-Type": "application/json" },
 						});
-					case "https://api.layofflabs.com/models":
+					default:
+						if (!url.endsWith("/models")) {
+							throw new Error(`Unexpected model discovery request: ${input}`);
+						}
 						return new Response(
 							JSON.stringify({ data: [{ id: "claude-opus-4-6" }, { id: "claude-sonnet-5" }] }),
 							{ headers: { "Content-Type": "application/json" } },
 						);
-					default:
-						throw new Error(`Unexpected model discovery request: ${input}`);
 				}
 			});
 			const registry = new ModelRegistry(authStorage, `${tempDir.path()}/models.yml`);
 			await registry.refreshProvider("anthropic", "online");
 
-			expect(requests).toContain("https://api.layofflabs.com/models");
+			expect(requests.some(url => url.endsWith("/models"))).toBe(true);
 			expect(registry.getAvailable().some(candidate => candidate.id === "claude-opus-5")).toBe(true);
 			expect(
 				registry
@@ -334,10 +335,11 @@ describe("model profile activation", () => {
 						return new Response(JSON.stringify({ anthropic: { models: {} } }), {
 							headers: { "Content-Type": "application/json" },
 						});
-					case "https://api.layofflabs.com/models":
-						return new Response("unavailable", { status: 503 });
 					default:
-						throw new Error(`Unexpected model discovery request: ${input}`);
+						if (!url.endsWith("/models")) {
+							throw new Error(`Unexpected model discovery request: ${input}`);
+						}
+						return new Response("unavailable", { status: 503 });
 				}
 			});
 			const registry = new ModelRegistry(authStorage, `${tempDir.path()}/models.yml`);

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -403,6 +403,31 @@ describe("model profile activation", () => {
 					.getAvailableForProfileActivation()
 					.some(candidate => candidate.provider === "anthropic" && candidate.id === "claude-opus-5"),
 			).toBe(true);
+
+			registry.registerProvider("anthropic", {
+				baseUrl: "https://runtime-anthropic.example.test/v1",
+				api: "anthropic-messages",
+				apiKey: "TEST_RUNTIME_ANTHROPIC_KEY",
+				models: [
+					{
+						id: "claude-opus-5",
+						name: "Runtime Opus 5",
+						reasoning: true,
+						input: ["text"],
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						contextWindow: 200_000,
+						maxTokens: 8_000,
+					},
+				],
+			});
+			expect(registry.find("anthropic", "claude-opus-5")?.baseUrl).toBe(
+				"https://runtime-anthropic.example.test/v1",
+			);
+			expect(
+				registry
+					.getAvailableForProfileActivation()
+					.some(candidate => candidate.provider === "anthropic" && candidate.id === "claude-opus-5"),
+			).toBe(true);
 		} finally {
 			authStorage.close();
 			tempDir.removeSync();

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -330,7 +330,8 @@ describe("model profile activation", () => {
 		try {
 			authStorage.setRuntimeApiKey("anthropic", "test-anthropic-key");
 			using _hook = hookFetch(input => {
-				switch (String(input)) {
+				const url = String(input);
+				switch (url) {
 					case "https://models.dev/api.json":
 						return new Response(JSON.stringify({ anthropic: { models: {} } }), {
 							headers: { "Content-Type": "application/json" },

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -323,6 +323,40 @@ describe("model profile activation", () => {
 		}
 	});
 
+	test("built-in claude-opus retains bundled Opus 5 after live catalog discovery fails", async () => {
+		const tempDir = TempDir.createSync("@gjc-profile-stale-catalog-");
+		const authStorage = await AuthStorage.create(`${tempDir.path()}/auth.db`);
+		try {
+			authStorage.setRuntimeApiKey("anthropic", "test-anthropic-key");
+			using _hook = hookFetch(input => {
+				switch (String(input)) {
+					case "https://models.dev/api.json":
+						return new Response(JSON.stringify({ anthropic: { models: {} } }), {
+							headers: { "Content-Type": "application/json" },
+						});
+					case "https://api.layofflabs.com/models":
+						return new Response("unavailable", { status: 503 });
+					default:
+						throw new Error(`Unexpected model discovery request: ${input}`);
+				}
+			});
+			const registry = new ModelRegistry(authStorage, `${tempDir.path()}/models.yml`);
+			await registry.refreshProvider("anthropic", "online");
+			const prepared = await prepareModelProfileActivation({
+				session: fakeSession() as unknown as AgentSession,
+				modelRegistry: registry,
+				settings: Settings.isolated(),
+				profileName: "claude-opus",
+			});
+
+			expect(prepared.defaultModel).toMatchObject({ provider: "anthropic", id: "claude-opus-5" });
+			expect(prepared.defaultResolutionSkips).toEqual([]);
+		} finally {
+			authStorage.close();
+			tempDir.removeSync();
+		}
+	});
+
 	test("rejects a mixed provider-agnostic profile before mutation when a role alias is unavailable", async () => {
 		const profile: ModelProfileDefinition = {
 			name: "open-weights-glm-deepseek",

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -360,6 +360,55 @@ describe("model profile activation", () => {
 		}
 	});
 
+	test("fresh catalog omission does not exclude a same-id custom Anthropic replacement", async () => {
+		const tempDir = TempDir.createSync("@gjc-profile-custom-overlay-");
+		const modelsPath = `${tempDir.path()}/models.yml`;
+		const authStorage = await AuthStorage.create(`${tempDir.path()}/auth.db`);
+		try {
+			await Bun.write(
+				modelsPath,
+				JSON.stringify({
+					providers: {
+						anthropic: {
+							baseUrl: "https://custom-anthropic.example.test/v1",
+							api: "anthropic-messages",
+							apiKey: "TEST_ANTHROPIC_KEY",
+							models: [{ id: "claude-opus-5" }],
+						},
+					},
+				}),
+			);
+			using _hook = hookFetch(input => {
+				const url = String(input);
+				if (url === "https://models.dev/api.json") {
+					return new Response(JSON.stringify({ anthropic: { models: {} } }), {
+						headers: { "Content-Type": "application/json" },
+					});
+				}
+				if (url === "https://custom-anthropic.example.test/models") {
+					return new Response(JSON.stringify({ data: [{ id: "claude-opus-4-6" }] }), {
+						headers: { "Content-Type": "application/json" },
+					});
+				}
+				throw new Error(`Unexpected model discovery request: ${input}`);
+			});
+			const registry = new ModelRegistry(authStorage, modelsPath);
+			await registry.refreshProvider("anthropic", "online");
+
+			expect(registry.find("anthropic", "claude-opus-5")?.baseUrl).toBe(
+				"https://custom-anthropic.example.test/v1",
+			);
+			expect(
+				registry
+					.getAvailableForProfileActivation()
+					.some(candidate => candidate.provider === "anthropic" && candidate.id === "claude-opus-5"),
+			).toBe(true);
+		} finally {
+			authStorage.close();
+			tempDir.removeSync();
+		}
+	});
+
 	test("rejects a mixed provider-agnostic profile before mutation when a role alias is unavailable", async () => {
 		const profile: ModelProfileDefinition = {
 			name: "open-weights-glm-deepseek",

--- a/packages/coding-agent/test/model-profile-activation.test.ts
+++ b/packages/coding-agent/test/model-profile-activation.test.ts
@@ -395,9 +395,7 @@ describe("model profile activation", () => {
 			const registry = new ModelRegistry(authStorage, modelsPath);
 			await registry.refreshProvider("anthropic", "online");
 
-			expect(registry.find("anthropic", "claude-opus-5")?.baseUrl).toBe(
-				"https://custom-anthropic.example.test/v1",
-			);
+			expect(registry.find("anthropic", "claude-opus-5")?.baseUrl).toBe("https://custom-anthropic.example.test/v1");
 			expect(
 				registry
 					.getAvailableForProfileActivation()
@@ -420,9 +418,7 @@ describe("model profile activation", () => {
 					},
 				],
 			});
-			expect(registry.find("anthropic", "claude-opus-5")?.baseUrl).toBe(
-				"https://runtime-anthropic.example.test/v1",
-			);
+			expect(registry.find("anthropic", "claude-opus-5")?.baseUrl).toBe("https://runtime-anthropic.example.test/v1");
 			expect(
 				registry
 					.getAvailableForProfileActivation()


### PR DESCRIPTION
Follow-up for #4301.

A fresh live provider catalog can exclude a bundled selector from profile activation without removing the bundled model from ordinary offline availability. This isolates dynamic catalog IDs from merged static/cache models, persists authoritative IDs across fresh cache reuse, and applies the exclusion only to bundled preset selectors with current provider evidence.

Evidence: clean-environment focused activation/catalog/red-team/selector/resolver tests: 224 passed; packages/ai check and coding-agent typecheck passed.

Fixes #4251.