### PR TITLE
fix(test): restore package-cwd TMPDIR preload without budget pin

### DIFF
--- a/packages/coding-agent/bunfig.toml
+++ b/packages/coding-agent/bunfig.toml
@@ -1,0 +1,11 @@
+# Package-cwd `bun test` (the CI shard invocation: `bun test --shard=N/8` with
+# cwd packages/coding-agent) does not read the repository-root bunfig.toml, so
+# without this file the shared test preload — macOS TMPDIR canonicalization
+# that keeps `mkdtemp(os.tmpdir())` paths symlink-free for the native
+# owner-only primitive — silently never runs in package-cwd shards.
+#
+# The preload no longer pins GJC_SESSION_CONTEXT_BUDGET_BYTES; the two overflow
+# test files pin the budget in-process via SessionManagerTestHooks instead, so
+# this preload does not leak any budget mutation into spawned subprocesses.
+[test]
+preload = ["../../scripts/test-preload.ts"]


### PR DESCRIPTION
Follow-up to #4306 / #4224.

## P2 fix

#4306 deleted `packages/coding-agent/bunfig.toml` entirely to remove the subprocess-leaking budget pin. But the package bunfig.toml also provided macOS TMPDIR canonicalization for package-cwd CI shards (`bun test --shard=N/8` with cwd `packages/coding-agent`), which the root bunfig.toml preload cannot reach. Without it, macOS CI shards create sessions under `mkdtemp(os.tmpdir())` with symlinked `/var -> /private/var` paths that trip the native owner-only no-symlink guard.

The preload no longer pins the budget (moved to `SessionManagerTestHooks.sessionContextBudgetBytesOverride` in #4306), so restoring the package bunfig.toml is safe: it provides only macOS TMPDIR canonicalization (a no-op on Linux CI) without leaking any budget mutation.

## Verification

- `GJC_SESSION_CONTEXT_BUDGET_BYTES` confirmed UNSET in process env
- Overflow + goal-mode + budget test files: 60/0 (package-cwd and root-cwd)
- Typecheck clean

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*