### PR TITLE
fix(sdk): keep core ask and idle always active

### DIFF
--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -1123,13 +1123,13 @@ interface SessionRuntime {
 	idleSeq: number;
 	/** Interactive asks awaiting a remote answer, by action id. */
 	pendingInteractive: Map<string, PendingInteractiveAsk>;
-	/** Deregisters this session's ask answer source. */
+	/** Deregisters this session's core SDK ask answer source. */
 	disposeAnswerSource: () => void;
-	/** Deregisters this session's Telegram file sink. */
+	/** Deregisters this session's notification-only Telegram file sink. */
 	disposeFileSink: () => void;
 	/** Deregisters this session's workflow-gate listener. */
 	disposeGateListener: () => void;
-	/** Whether notification-only delivery and answer resources are active. */
+	/** Whether notification-only delivery resources are active. */
 	notificationsActive: boolean;
 	/** Provider ownership state is independent from the already-published core SDK runtime. */
 	notificationOwnerState: "ready" | "retry" | "blocked";
@@ -4021,14 +4021,8 @@ export function createNotificationsExtension(
 			rt.notificationsActive = false;
 			rt.disableEphemeralTurns();
 			try {
-				rt.disposeAnswerSource();
-			} catch {}
-			try {
 				rt.disposeFileSink();
 			} catch {}
-			rt.gatePresentations?.cancelInteractive();
-			for (const pending of rt.pendingInteractive.values()) pending.resolve(undefined);
-			rt.pendingInteractive.clear();
 			return true;
 		}
 		// Keep this exact object authoritative for the full terminal release, including
@@ -4236,8 +4230,11 @@ export function createNotificationsExtension(
 			if (lifecycleRequired) return failLifecycleStartup("failed", error);
 			throw error;
 		}
-		const gatePresentations = new PresentationArbiter(server, () => runtime?.redact ?? true, tag);
-		gatePresentations.setPublicationSuspended(true);
+		const gatePresentations = new PresentationArbiter(
+			server,
+			() => (runtime?.notificationsActive ? runtime.redact : false),
+			tag,
+		);
 		let inboundSdkFrame: ((connectionId: string, frame: Record<string, unknown>) => void) | undefined;
 		const inFlightGateResolutions = new Set<Promise<void>>();
 		const trackGateResolution = <T>(resolution: Promise<T>): Promise<T> => {
@@ -6692,12 +6689,7 @@ export function createNotificationsExtension(
 
 			server.onReply((err, reply) => {
 				if (err || !reply) return;
-				if (
-					runtime?.inboundFenced ||
-					runtime?.stopping ||
-					runtime?.policySuspended ||
-					runtimes.get(id) !== runtime
-				) {
+				if (runtime?.inboundFenced || runtime?.stopping || runtimes.get(id) !== runtime) {
 					try {
 						server.closeClaimInvalid(reply.replyReceiptId, "session_stopping");
 					} catch {}
@@ -6705,10 +6697,7 @@ export function createNotificationsExtension(
 				}
 				const replyGeneration = runtime.policyGeneration;
 				const replyIsCurrent = (): boolean =>
-					runtimes.get(id) === runtime &&
-					!runtime.stopping &&
-					!runtime.policySuspended &&
-					runtime.policyGeneration === replyGeneration;
+					runtimes.get(id) === runtime && !runtime.stopping && runtime.policyGeneration === replyGeneration;
 				const native = server as unknown as {
 					resolveClaim(receiptId: string, answerJson?: string, idempotencyKey?: string): void;
 					closeClaimInvalid(receiptId: string, reason: string): void;
@@ -7136,6 +7125,11 @@ export function createNotificationsExtension(
 			// daemon ownership. A blocked adapter must not make an interactive session
 			// undiscoverable or uncontrollable.
 			const endpoint = await sdkRuntime.startTransport();
+			initializedRuntime.disposeAnswerSource = registerInteractiveAnswerSource(
+				initializedRuntime.id,
+				pendingInteractive,
+				gatePresentations,
+			);
 			initializedRuntime.notificationOwnerState = "ready";
 			if (notificationsEnabledForSession && settingsAvailable && settings) {
 				initializedRuntime.notificationOwnerState = "retry";
@@ -7241,11 +7235,6 @@ export function createNotificationsExtension(
 				if (runtime.notificationsActive) return;
 				ephemeralTurns.enable();
 				runtime.notificationsActive = true;
-				runtime.disposeAnswerSource = registerInteractiveAnswerSource(
-					runtime.id,
-					pendingInteractive,
-					gatePresentations,
-				);
 				runtime.disposeFileSink = registerTelegramFileSink(runtime.id, async file => {
 					const generation = runtime.policyGeneration;
 					if (!canDeliverAsync(runtime, generation)) return { ok: false, error: TELEGRAM_FILE_REDACTION_ERROR };
@@ -7480,7 +7469,6 @@ export function createNotificationsExtension(
 			if (policy.mode === "provisional") {
 				runtime.policyGeneration++;
 				runtime.policySuspended = true;
-				runtime.gatePresentations?.setPublicationSuspended(true);
 				runtime.redact = true;
 				runtime.verbosity = "lean";
 				runtime.stream = false;
@@ -7511,7 +7499,6 @@ export function createNotificationsExtension(
 			if (runtime.policySuspended) return;
 			if (runtime.notificationOwnerState !== "ready") return;
 			runtime.enableNotifications();
-			runtime.gatePresentations?.setPublicationSuspended(false);
 			runtime.gatePresentations?.activateDeferred(runtime.workflowGatePublicationEpoch);
 			flushPendingFinal(runtime, runtime.id);
 			for (const processControl of runtime.deferredInboundControls.splice(0)) processControl();
@@ -8013,10 +8000,6 @@ export function createNotificationsExtension(
 		} catch (e) {
 			logger.warn(`notifications: activity (idle) failed: ${String(e)}`);
 		}
-		if (!rt.notificationsActive) return;
-		void (typeof rt.workflowGate?.recoverAcceptedGates === "function"
-			? rt.trackGateResolution(rt.workflowGate.recoverAcceptedGates()).catch(() => {})
-			: Promise.resolve());
 		const seq = rt.idleSeq++;
 		// Re-assert the identity header so the daemon renames the topic once the
 		// session title has been auto-generated ("{repo}/{branch} - {title}"). The
@@ -8038,13 +8021,17 @@ export function createNotificationsExtension(
 							sessionId: id,
 							summary: undefined,
 						},
-						{ redact: rt.redact, sessionTag: rt.sessionTag },
+						{ redact: rt.notificationsActive ? rt.redact : false, sessionTag: rt.sessionTag },
 					),
 				),
 			);
 		} catch (e) {
 			logger.warn(`notifications: noteIdle failed: ${String(e)}`);
 		}
+		if (!rt.notificationsActive) return;
+		void (typeof rt.workflowGate?.recoverAcceptedGates === "function"
+			? rt.trackGateResolution(rt.workflowGate.recoverAcceptedGates()).catch(() => {})
+			: Promise.resolve());
 
 		// Lean: emit the latest deferred assistant answer exactly once at idle.
 		// Intermediate tool-turn narration was held on turn_end; ask lead-ins were

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -4830,6 +4830,74 @@ test("context.get reports live streaming state and typed queue depths without no
 	expect(settled).toMatchObject({ isStreaming: false, steeringQueueDepth: 0, followupQueueDepth: 0 });
 });
 
+test("SDK host publishes interactive asks and idle without notification providers", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-host-ask-core-"));
+	dirs.push(cwd);
+	const sessionId = `ask-core-${Date.now()}`;
+	// Notification providers intentionally remain disabled: interactive asks are a
+	// core SDK capability used by clients such as the Stream Deck.
+	const handlers = start(context(cwd, sessionId));
+	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+	const frames: Record<string, unknown>[] = [];
+	const socket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	sockets.push(socket);
+	socket.addEventListener("message", event => frames.push(JSON.parse(String(event.data))));
+	await new Promise<void>((resolve, reject) => {
+		socket.addEventListener("open", () => resolve(), { once: true });
+		socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+	});
+	socket.send(JSON.stringify({ type: "hello", protocolVersion: 3, capabilities: ["ask_controls_v1"] }));
+	await waitFor(() => getAskAnswerSource(sessionId) !== undefined, "core SDK ask source");
+	expect(getTelegramFileSink(sessionId)).toBeUndefined();
+
+	const answer = getAskAnswerSource(sessionId)!.awaitAnswerRequest!(
+		{
+			question: "Choose the rebase strategy",
+			options: ["rebase", "merge"],
+			interaction: "selector",
+			controls: [],
+			recommendedIndex: 0,
+		},
+		new AbortController().signal,
+	);
+	await waitFor(
+		() => frames.some(frame => frame.type === "action_needed" && frame.kind === "ask"),
+		"core SDK action_needed ask",
+	);
+	const action = frames.find(frame => frame.type === "action_needed" && frame.kind === "ask")!;
+	expect(action).toMatchObject({
+		question: "Choose the rebase strategy",
+		options: ["rebase", "merge"],
+		recommendedIndex: 0,
+	});
+
+	socket.send(
+		JSON.stringify({
+			type: "reply",
+			id: action.id,
+			answer: 0,
+			token: endpoint.token,
+		}),
+	);
+	const receipt = await answer;
+	expect(receipt).toMatchObject({ source: "remote", interaction: { kind: "value", value: "rebase" } });
+	if (!receipt || typeof receipt === "string") throw new Error("Expected remote ask receipt");
+	expect(await receipt.settle({ kind: "commit" })).toMatchObject({ kind: "committed" });
+
+	const sessionContext = context(cwd, sessionId);
+	void handlers.get("agent_end")?.({ type: "agent_end", messages: [] }, sessionContext);
+	await waitFor(
+		() => frames.some(frame => frame.type === "action_needed" && frame.kind === "idle"),
+		"core SDK idle action",
+	);
+	expect(frames.find(frame => frame.type === "action_needed" && frame.kind === "idle")).toMatchObject({
+		sessionId,
+		kind: "idle",
+	});
+}, 30_000);
+
 test("SDK endpoint applies typed skill, plan, goal, and config controls with observable readback", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-host-typed-controls-"));
 	dirs.push(cwd);


### PR DESCRIPTION
## Summary
- register interactive ask handling with the core SDK host instead of notification-provider activation
- accept ask replies while chat notification policy is disabled or provisional
- emit SDK idle actions before returning from the notification-only path
- keep Telegram/Slack/Discord delivery, file sinks, and ephemeral turns notification-only

## Root cause
The SDK endpoint stayed live with notifications disabled, but its interactive answer source, ask presentation, reply acceptance, and idle action were all coupled to notification activation. Stream Deck clients could discover and focus the session but never receive deep-interview questions or idle actions.

## Verification
- focused SDK host ask/idle and related regression tests: 4 passed
- coding-agent typecheck
- Biome check on changed files
- git diff check
