### PR TITLE
fix(ai): persist tool-choice incapability

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Persist learned tool-choice incapabilities in a bounded, expiring, digest-keyed cache so fresh processes avoid repeating known-invalid forced-choice probes while retaining automatic revalidation and existing first-discovery fallback behavior. Credit: @probepark (#4319).
+
 ### Added
 
 - Added the authoritative OpenRouter `meta/muse-spark-1.2` catalog fallback with a 1,048,576-token context window and `minimal` through `xhigh` reasoning effort, so stale or credential-limited catalog generation still closes the Muse Spark preset alias deterministically.

--- a/packages/ai/src/utils/tool-choice-capability.ts
+++ b/packages/ai/src/utils/tool-choice-capability.ts
@@ -21,6 +21,7 @@ const CACHE_SCHEMA_VERSION = 1;
 const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const EMPTY_CACHE_TTL_MS = 5 * 60 * 1000;
 const CACHE_MAX_ENTRIES = 256;
+const REGISTRY_MAX_ENTRIES = 256;
 
 let cachePathOverride: string | undefined;
 let nowForTests: (() => number) | undefined;
@@ -336,6 +337,7 @@ function hydrateToolChoiceCapability(registryKey: string): void {
 	if (hydrated === false && !registryExpiresAt.has(registryKey)) {
 		registryExpiresAt.set(registryKey, now + EMPTY_CACHE_TTL_MS);
 	}
+	pruneRegistry(now);
 }
 
 function persistToolChoiceCapability(
@@ -478,4 +480,19 @@ function isValidObservedAt(value: unknown, now: number): value is number {
 
 function currentTime(): number {
 	return nowForTests?.() ?? Date.now();
+}
+
+function pruneRegistry(now: number): void {
+	for (const [key, expiresAt] of registryExpiresAt) {
+		if (expiresAt <= now) {
+			registryExpiresAt.delete(key);
+			registry.delete(key);
+		}
+	}
+	while (registryExpiresAt.size > REGISTRY_MAX_ENTRIES) {
+		const oldestKey = registryExpiresAt.keys().next().value;
+		if (typeof oldestKey !== "string") break;
+		registryExpiresAt.delete(oldestKey);
+		registry.delete(oldestKey);
+	}
 }

--- a/packages/ai/src/utils/tool-choice-capability.ts
+++ b/packages/ai/src/utils/tool-choice-capability.ts
@@ -19,12 +19,14 @@ const loggedRegistryKeys = new Set<string>();
 const registryExpiresAt = new Map<string, number>();
 const CACHE_SCHEMA_VERSION = 1;
 const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const EMPTY_CACHE_TTL_MS = 5 * 60 * 1000;
 const CACHE_MAX_ENTRIES = 256;
 
 let cachePathOverride: string | undefined;
 let nowForTests: (() => number) | undefined;
 let beforeExpiredDeleteForTests: (() => void) | undefined;
 let beforeMalformedDeleteForTests: (() => void) | undefined;
+let onCacheOpenForTests: (() => void) | undefined;
 
 /**
  * Claude Mythos accepts tools but rejects forced tool use (Anthropic 400:
@@ -77,11 +79,13 @@ export function configureToolChoiceCapabilityCacheForTests(options?: {
 	now?: () => number;
 	beforeExpiredDelete?: () => void;
 	beforeMalformedDelete?: () => void;
+	onCacheOpen?: () => void;
 }): void {
 	cachePathOverride = options?.path;
 	nowForTests = options?.now;
 	beforeExpiredDeleteForTests = options?.beforeExpiredDelete;
 	beforeMalformedDeleteForTests = options?.beforeMalformedDelete;
+	onCacheOpenForTests = options?.onCacheOpen;
 	clearToolChoiceIncapabilityRegistryForTests();
 }
 
@@ -294,12 +298,12 @@ function hydrateToolChoiceCapability(registryKey: string): void {
 	if (expiresAt !== undefined && now < expiresAt) return;
 	registry.delete(registryKey);
 	registryExpiresAt.delete(registryKey);
-	withCapabilityCache(database => {
+	const hydrated = withCapabilityCache(database => {
 		const digest = capabilityKeyDigest(registryKey);
 		const row = database
 			.query("SELECT max_support, support_rank, observed_at FROM tool_choice_capabilities WHERE key_digest = ?")
 			.get(digest) as { max_support?: unknown; support_rank?: unknown; observed_at?: unknown } | null;
-		if (!row) return;
+		if (!row) return false;
 		if (
 			!isToolChoiceSupport(row.max_support) ||
 			row.support_rank !== supportRank[row.max_support] ||
@@ -315,7 +319,7 @@ function hydrateToolChoiceCapability(registryKey: string): void {
 					typeof row.observed_at === "number" ? row.observed_at : -1,
 				],
 			);
-			return;
+			return false;
 		}
 		if (now - row.observed_at >= CACHE_TTL_MS) {
 			beforeExpiredDeleteForTests?.();
@@ -323,11 +327,15 @@ function hydrateToolChoiceCapability(registryKey: string): void {
 				digest,
 				row.observed_at,
 			]);
-			return;
+			return false;
 		}
 		registry.set(registryKey, row.max_support);
 		registryExpiresAt.set(registryKey, row.observed_at + CACHE_TTL_MS);
+		return true;
 	});
+	if (hydrated === false && !registryExpiresAt.has(registryKey)) {
+		registryExpiresAt.set(registryKey, now + EMPTY_CACHE_TTL_MS);
+	}
 }
 
 function persistToolChoiceCapability(
@@ -383,6 +391,7 @@ function withCapabilityCache<T>(operation: (database: Database) => T): T | undef
 }
 
 function openCapabilityCache(cachePath: string): Database {
+	onCacheOpenForTests?.();
 	const database = new Database(cachePath, { create: true, strict: true });
 	try {
 		database.run("PRAGMA busy_timeout = 3000");

--- a/packages/ai/src/utils/tool-choice-capability.ts
+++ b/packages/ai/src/utils/tool-choice-capability.ts
@@ -23,6 +23,7 @@ const CACHE_MAX_ENTRIES = 256;
 
 let cachePathOverride: string | undefined;
 let nowForTests: (() => number) | undefined;
+let beforeExpiredDeleteForTests: (() => void) | undefined;
 
 /**
  * Claude Mythos accepts tools but rejects forced tool use (Anthropic 400:
@@ -70,9 +71,14 @@ export function clearToolChoiceIncapabilityRegistryForTests(): void {
 }
 
 /** Overrides durable-cache dependencies for isolated tests. */
-export function configureToolChoiceCapabilityCacheForTests(options?: { path?: string; now?: () => number }): void {
+export function configureToolChoiceCapabilityCacheForTests(options?: {
+	path?: string;
+	now?: () => number;
+	beforeExpiredDelete?: () => void;
+}): void {
 	cachePathOverride = options?.path;
 	nowForTests = options?.now;
+	beforeExpiredDeleteForTests = options?.beforeExpiredDelete;
 	clearToolChoiceIncapabilityRegistryForTests();
 }
 
@@ -83,8 +89,9 @@ export function markToolChoiceIncapability(model: Model<Api>, maxSupport: ToolCh
 	const existing = registry.get(key);
 	const next = existing && supportRank[existing] < supportRank[maxSupport] ? existing : maxSupport;
 	registry.set(key, next);
-	registryExpiresAt.set(key, currentTime() + CACHE_TTL_MS);
-	persistToolChoiceCapability(key, next);
+	const persisted = persistToolChoiceCapability(key, next);
+	if (persisted) registry.set(key, persisted.support);
+	registryExpiresAt.set(key, (persisted?.observedAt ?? currentTime()) + CACHE_TTL_MS);
 
 	if (!loggedRegistryKeys.has(key)) {
 		loggedRegistryKeys.add(key);
@@ -290,12 +297,16 @@ function hydrateToolChoiceCapability(registryKey: string): void {
 			.query("SELECT max_support, observed_at FROM tool_choice_capabilities WHERE key_digest = ?")
 			.get(digest) as { max_support?: unknown; observed_at?: unknown } | null;
 		if (!row) return;
-		if (!isToolChoiceSupport(row.max_support) || typeof row.observed_at !== "number") {
+		if (!isToolChoiceSupport(row.max_support) || !isValidObservedAt(row.observed_at, now)) {
 			database.run("DELETE FROM tool_choice_capabilities WHERE key_digest = ?", [digest]);
 			return;
 		}
 		if (now - row.observed_at >= CACHE_TTL_MS) {
-			database.run("DELETE FROM tool_choice_capabilities WHERE key_digest = ?", [digest]);
+			beforeExpiredDeleteForTests?.();
+			database.run("DELETE FROM tool_choice_capabilities WHERE key_digest = ? AND observed_at = ?", [
+				digest,
+				row.observed_at,
+			]);
 			return;
 		}
 		registry.set(registryKey, row.max_support);
@@ -303,31 +314,41 @@ function hydrateToolChoiceCapability(registryKey: string): void {
 	});
 }
 
-function persistToolChoiceCapability(registryKey: string, maxSupport: ToolChoiceSupport): void {
-	withCapabilityCache(database => {
+function persistToolChoiceCapability(
+	registryKey: string,
+	maxSupport: ToolChoiceSupport,
+): { support: ToolChoiceSupport; observedAt: number } | undefined {
+	return withCapabilityCache(database => {
 		const write = database.transaction(() => {
 			const digest = capabilityKeyDigest(registryKey);
+			const observedAt = currentTime();
 			database.run(
-				"INSERT INTO tool_choice_capabilities (key_digest, max_support, support_rank, observed_at) VALUES (?, ?, ?, ?) ON CONFLICT(key_digest) DO UPDATE SET max_support = excluded.max_support, support_rank = excluded.support_rank, observed_at = excluded.observed_at WHERE excluded.support_rank < tool_choice_capabilities.support_rank",
-				[digest, maxSupport, supportRank[maxSupport], currentTime()],
+				"INSERT INTO tool_choice_capabilities (key_digest, max_support, support_rank, observed_at) VALUES (?, ?, ?, ?) ON CONFLICT(key_digest) DO UPDATE SET max_support = excluded.max_support, support_rank = excluded.support_rank, observed_at = excluded.observed_at WHERE excluded.support_rank <= tool_choice_capabilities.support_rank",
+				[digest, maxSupport, supportRank[maxSupport], observedAt],
 			);
 			database.run(
 				"DELETE FROM tool_choice_capabilities WHERE key_digest NOT IN (SELECT key_digest FROM tool_choice_capabilities ORDER BY observed_at DESC, key_digest DESC LIMIT ?)",
 				[CACHE_MAX_ENTRIES],
 			);
+			const row = database
+				.query("SELECT max_support, observed_at FROM tool_choice_capabilities WHERE key_digest = ?")
+				.get(digest) as { max_support?: unknown; observed_at?: unknown } | null;
+			return row && isToolChoiceSupport(row.max_support) && typeof row.observed_at === "number"
+				? { support: row.max_support, observedAt: row.observed_at }
+				: undefined;
 		});
-		write();
+		return write();
 	});
 }
 
-function withCapabilityCache(operation: (database: Database) => void): void {
+function withCapabilityCache<T>(operation: (database: Database) => T): T | undefined {
 	if (process.env.NODE_ENV === "test" && cachePathOverride === undefined) return;
 	const cachePath = cachePathOverride ?? getToolChoiceCapabilityCachePath();
 	try {
 		fs.mkdirSync(path.dirname(cachePath), { recursive: true, mode: 0o700 });
 		const database = openCapabilityCache(cachePath);
 		try {
-			operation(database);
+			return operation(database);
 		} finally {
 			database.close();
 		}
@@ -345,18 +366,22 @@ function openCapabilityCache(cachePath: string): Database {
 	database.run("PRAGMA busy_timeout = 3000");
 	database.run("PRAGMA journal_mode = WAL");
 	database.run("PRAGMA synchronous = FULL");
-	database.run(`
-		CREATE TABLE IF NOT EXISTS tool_choice_capabilities (
-			key_digest TEXT PRIMARY KEY NOT NULL,
-			max_support TEXT NOT NULL,
-			support_rank INTEGER NOT NULL,
-			observed_at INTEGER NOT NULL
-		) STRICT
-	`);
 	const version = database.query("PRAGMA user_version").get() as { user_version?: number } | null;
 	const schemaVersion = version?.user_version ?? 0;
 	if (schemaVersion === 0) {
-		database.run(`PRAGMA user_version = ${CACHE_SCHEMA_VERSION}`);
+		const initialize = database.transaction(() => {
+			database.run("DROP TABLE IF EXISTS tool_choice_capabilities");
+			database.run(`
+				CREATE TABLE tool_choice_capabilities (
+					key_digest TEXT PRIMARY KEY NOT NULL,
+					max_support TEXT NOT NULL,
+					support_rank INTEGER NOT NULL,
+					observed_at INTEGER NOT NULL
+				) STRICT
+			`);
+			database.run(`PRAGMA user_version = ${CACHE_SCHEMA_VERSION}`);
+		});
+		initialize();
 	} else if (schemaVersion !== CACHE_SCHEMA_VERSION) {
 		database.close();
 		throw new CapabilityCacheCorruptionError("unsupported cache schema version");
@@ -370,7 +395,7 @@ function isCorruptCapabilityCacheError(error: unknown): boolean {
 	if (error instanceof CapabilityCacheCorruptionError) return true;
 	if (!error || typeof error !== "object") return false;
 	const code = (error as { code?: unknown }).code;
-	return code === "SQLITE_CORRUPT" || code === "SQLITE_NOTADB";
+	return code === "SQLITE_CORRUPT" || code === "SQLITE_NOTADB" || code === "SQLITE_ERROR";
 }
 
 function retireCorruptCapabilityCache(cachePath: string): void {
@@ -389,6 +414,10 @@ function capabilityKeyDigest(registryKey: string): string {
 
 function isToolChoiceSupport(value: unknown): value is ToolChoiceSupport {
 	return value === "none" || value === "auto" || value === "required" || value === "named";
+}
+
+function isValidObservedAt(value: unknown, now: number): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 && value <= now;
 }
 
 function currentTime(): number {

--- a/packages/ai/src/utils/tool-choice-capability.ts
+++ b/packages/ai/src/utils/tool-choice-capability.ts
@@ -24,6 +24,7 @@ const CACHE_MAX_ENTRIES = 256;
 let cachePathOverride: string | undefined;
 let nowForTests: (() => number) | undefined;
 let beforeExpiredDeleteForTests: (() => void) | undefined;
+let beforeMalformedDeleteForTests: (() => void) | undefined;
 
 /**
  * Claude Mythos accepts tools but rejects forced tool use (Anthropic 400:
@@ -75,10 +76,12 @@ export function configureToolChoiceCapabilityCacheForTests(options?: {
 	path?: string;
 	now?: () => number;
 	beforeExpiredDelete?: () => void;
+	beforeMalformedDelete?: () => void;
 }): void {
 	cachePathOverride = options?.path;
 	nowForTests = options?.now;
 	beforeExpiredDeleteForTests = options?.beforeExpiredDelete;
+	beforeMalformedDeleteForTests = options?.beforeMalformedDelete;
 	clearToolChoiceIncapabilityRegistryForTests();
 }
 
@@ -294,11 +297,24 @@ function hydrateToolChoiceCapability(registryKey: string): void {
 	withCapabilityCache(database => {
 		const digest = capabilityKeyDigest(registryKey);
 		const row = database
-			.query("SELECT max_support, observed_at FROM tool_choice_capabilities WHERE key_digest = ?")
-			.get(digest) as { max_support?: unknown; observed_at?: unknown } | null;
+			.query("SELECT max_support, support_rank, observed_at FROM tool_choice_capabilities WHERE key_digest = ?")
+			.get(digest) as { max_support?: unknown; support_rank?: unknown; observed_at?: unknown } | null;
 		if (!row) return;
-		if (!isToolChoiceSupport(row.max_support) || !isValidObservedAt(row.observed_at, now)) {
-			database.run("DELETE FROM tool_choice_capabilities WHERE key_digest = ?", [digest]);
+		if (
+			!isToolChoiceSupport(row.max_support) ||
+			row.support_rank !== supportRank[row.max_support] ||
+			!isValidObservedAt(row.observed_at, now)
+		) {
+			beforeMalformedDeleteForTests?.();
+			database.run(
+				"DELETE FROM tool_choice_capabilities WHERE key_digest = ? AND max_support = ? AND support_rank = ? AND observed_at = ?",
+				[
+					digest,
+					typeof row.max_support === "string" ? row.max_support : String(row.max_support),
+					typeof row.support_rank === "number" ? row.support_rank : -1,
+					typeof row.observed_at === "number" ? row.observed_at : -1,
+				],
+			);
 			return;
 		}
 		if (now - row.observed_at >= CACHE_TTL_MS) {
@@ -348,6 +364,11 @@ function withCapabilityCache<T>(operation: (database: Database) => T): T | undef
 		fs.mkdirSync(path.dirname(cachePath), { recursive: true, mode: 0o700 });
 		const database = openCapabilityCache(cachePath);
 		try {
+			try {
+				fs.chmodSync(cachePath, 0o600);
+			} catch {
+				// Cache access remains fail-open on filesystems without POSIX modes.
+			}
 			return operation(database);
 		} finally {
 			database.close();
@@ -366,27 +387,48 @@ function openCapabilityCache(cachePath: string): Database {
 	database.run("PRAGMA busy_timeout = 3000");
 	database.run("PRAGMA journal_mode = WAL");
 	database.run("PRAGMA synchronous = FULL");
-	const version = database.query("PRAGMA user_version").get() as { user_version?: number } | null;
-	const schemaVersion = version?.user_version ?? 0;
-	if (schemaVersion === 0) {
-		const initialize = database.transaction(() => {
-			database.run("DROP TABLE IF EXISTS tool_choice_capabilities");
+	const initialize = database.transaction(() => {
+		const version = database.query("PRAGMA user_version").get() as { user_version?: number } | null;
+		const schemaVersion = version?.user_version ?? 0;
+		if (schemaVersion === 0) {
 			database.run(`
-				CREATE TABLE tool_choice_capabilities (
+				CREATE TABLE IF NOT EXISTS tool_choice_capabilities (
 					key_digest TEXT PRIMARY KEY NOT NULL,
 					max_support TEXT NOT NULL,
 					support_rank INTEGER NOT NULL,
 					observed_at INTEGER NOT NULL
 				) STRICT
 			`);
+			assertCapabilityCacheSchema(database);
 			database.run(`PRAGMA user_version = ${CACHE_SCHEMA_VERSION}`);
-		});
-		initialize();
-	} else if (schemaVersion !== CACHE_SCHEMA_VERSION) {
-		database.close();
-		throw new CapabilityCacheCorruptionError("unsupported cache schema version");
-	}
+			return;
+		}
+		if (schemaVersion !== CACHE_SCHEMA_VERSION) {
+			throw new CapabilityCacheCorruptionError("unsupported cache schema version");
+		}
+		assertCapabilityCacheSchema(database);
+	});
+	initialize();
 	return database;
+}
+
+function assertCapabilityCacheSchema(database: Database): void {
+	const columns = database.query("PRAGMA table_info(tool_choice_capabilities)").all() as Array<{
+		name?: unknown;
+		type?: unknown;
+		notnull?: unknown;
+		pk?: unknown;
+	}>;
+	const actual = columns.map(column => [column.name, column.type, column.notnull, column.pk]);
+	const expected = [
+		["key_digest", "TEXT", 1, 1],
+		["max_support", "TEXT", 1, 0],
+		["support_rank", "INTEGER", 1, 0],
+		["observed_at", "INTEGER", 1, 0],
+	];
+	if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+		throw new CapabilityCacheCorruptionError("invalid cache schema");
+	}
 }
 
 class CapabilityCacheCorruptionError extends Error {}

--- a/packages/ai/src/utils/tool-choice-capability.ts
+++ b/packages/ai/src/utils/tool-choice-capability.ts
@@ -1,3 +1,8 @@
+import { Database } from "bun:sqlite";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getToolChoiceCapabilityCachePath } from "@gajae-code/utils/dirs";
 import { extractHttpStatusFromError } from "@gajae-code/utils/fetch-retry";
 import * as logger from "@gajae-code/utils/logger";
 import type { Api, Model, ToolChoice, ToolChoiceCompat, ToolChoiceSupport, ToolChoiceSupportSource } from "../types";
@@ -11,6 +16,13 @@ const supportRank: Record<ToolChoiceSupport, number> = {
 
 const registry = new Map<string, ToolChoiceSupport>();
 const loggedRegistryKeys = new Set<string>();
+const registryExpiresAt = new Map<string, number>();
+const CACHE_SCHEMA_VERSION = 1;
+const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const CACHE_MAX_ENTRIES = 256;
+
+let cachePathOverride: string | undefined;
+let nowForTests: (() => number) | undefined;
 
 /**
  * Claude Mythos accepts tools but rejects forced tool use (Anthropic 400:
@@ -45,21 +57,34 @@ export function toolChoiceRegistryKey(model: Model<Api>): string {
 
 /** Returns the current runtime tool-choice capability override for a model. */
 export function getToolChoiceCapabilityOverride(model: Model<Api>): ToolChoiceSupport | undefined {
-	return registry.get(toolChoiceRegistryKey(model));
+	const key = toolChoiceRegistryKey(model);
+	hydrateToolChoiceCapability(key);
+	return registry.get(key);
 }
 
 /** Clears runtime tool-choice capability overrides for tests. */
 export function clearToolChoiceIncapabilityRegistryForTests(): void {
 	registry.clear();
 	loggedRegistryKeys.clear();
+	registryExpiresAt.clear();
+}
+
+/** Overrides durable-cache dependencies for isolated tests. */
+export function configureToolChoiceCapabilityCacheForTests(options?: { path?: string; now?: () => number }): void {
+	cachePathOverride = options?.path;
+	nowForTests = options?.now;
+	clearToolChoiceIncapabilityRegistryForTests();
 }
 
 /** Records a discovered maximum supported tool-choice level for a model. */
 export function markToolChoiceIncapability(model: Model<Api>, maxSupport: ToolChoiceSupport, reason?: string): void {
 	const key = toolChoiceRegistryKey(model);
+	hydrateToolChoiceCapability(key);
 	const existing = registry.get(key);
 	const next = existing && supportRank[existing] < supportRank[maxSupport] ? existing : maxSupport;
 	registry.set(key, next);
+	registryExpiresAt.set(key, currentTime() + CACHE_TTL_MS);
+	persistToolChoiceCapability(key, next);
 
 	if (!loggedRegistryKeys.has(key)) {
 		loggedRegistryKeys.add(key);
@@ -85,12 +110,13 @@ export function resolveToolChoice(
 	compat?: ToolChoiceCompat,
 ): ResolveToolChoiceResult {
 	const derived = deriveToolChoiceSupport(compat ?? model.compat);
-	const runtime = registry.get(toolChoiceRegistryKey(model));
+	const registryKey = toolChoiceRegistryKey(model);
+	hydrateToolChoiceCapability(registryKey);
+	const runtime = registry.get(registryKey);
 	const support = runtime && supportRank[runtime] < supportRank[derived.support] ? runtime : derived.support;
 	const supportSource: ToolChoiceSupportSource = support === derived.support ? derived.source : "runtime";
 	const requestedInfo = requestedToolChoiceLevel(requested);
 	const clampLevel = requestedInfo.requestedLevel === "none" ? "auto" : requestedInfo.requestedLevel;
-	const registryKey = toolChoiceRegistryKey(model);
 
 	if (requested === undefined) {
 		return {
@@ -250,4 +276,121 @@ function safeHostname(baseUrl: string): string | undefined {
 	} catch {
 		return undefined;
 	}
+}
+
+function hydrateToolChoiceCapability(registryKey: string): void {
+	const now = currentTime();
+	const expiresAt = registryExpiresAt.get(registryKey);
+	if (expiresAt !== undefined && now < expiresAt) return;
+	registry.delete(registryKey);
+	registryExpiresAt.delete(registryKey);
+	withCapabilityCache(database => {
+		const digest = capabilityKeyDigest(registryKey);
+		const row = database
+			.query("SELECT max_support, observed_at FROM tool_choice_capabilities WHERE key_digest = ?")
+			.get(digest) as { max_support?: unknown; observed_at?: unknown } | null;
+		if (!row) return;
+		if (!isToolChoiceSupport(row.max_support) || typeof row.observed_at !== "number") {
+			database.run("DELETE FROM tool_choice_capabilities WHERE key_digest = ?", [digest]);
+			return;
+		}
+		if (now - row.observed_at >= CACHE_TTL_MS) {
+			database.run("DELETE FROM tool_choice_capabilities WHERE key_digest = ?", [digest]);
+			return;
+		}
+		registry.set(registryKey, row.max_support);
+		registryExpiresAt.set(registryKey, row.observed_at + CACHE_TTL_MS);
+	});
+}
+
+function persistToolChoiceCapability(registryKey: string, maxSupport: ToolChoiceSupport): void {
+	withCapabilityCache(database => {
+		const write = database.transaction(() => {
+			const digest = capabilityKeyDigest(registryKey);
+			database.run(
+				"INSERT INTO tool_choice_capabilities (key_digest, max_support, support_rank, observed_at) VALUES (?, ?, ?, ?) ON CONFLICT(key_digest) DO UPDATE SET max_support = excluded.max_support, support_rank = excluded.support_rank, observed_at = excluded.observed_at WHERE excluded.support_rank < tool_choice_capabilities.support_rank",
+				[digest, maxSupport, supportRank[maxSupport], currentTime()],
+			);
+			database.run(
+				"DELETE FROM tool_choice_capabilities WHERE key_digest NOT IN (SELECT key_digest FROM tool_choice_capabilities ORDER BY observed_at DESC, key_digest DESC LIMIT ?)",
+				[CACHE_MAX_ENTRIES],
+			);
+		});
+		write();
+	});
+}
+
+function withCapabilityCache(operation: (database: Database) => void): void {
+	if (process.env.NODE_ENV === "test" && cachePathOverride === undefined) return;
+	const cachePath = cachePathOverride ?? getToolChoiceCapabilityCachePath();
+	try {
+		fs.mkdirSync(path.dirname(cachePath), { recursive: true, mode: 0o700 });
+		const database = openCapabilityCache(cachePath);
+		try {
+			operation(database);
+		} finally {
+			database.close();
+		}
+	} catch (error) {
+		logger.debug("Tool-choice capability cache unavailable", {
+			cachePath: path.basename(cachePath),
+			error: error instanceof Error ? error.message : String(error),
+		});
+		if (isCorruptCapabilityCacheError(error)) retireCorruptCapabilityCache(cachePath);
+	}
+}
+
+function openCapabilityCache(cachePath: string): Database {
+	const database = new Database(cachePath, { create: true, strict: true });
+	database.run("PRAGMA busy_timeout = 3000");
+	database.run("PRAGMA journal_mode = WAL");
+	database.run("PRAGMA synchronous = FULL");
+	database.run(`
+		CREATE TABLE IF NOT EXISTS tool_choice_capabilities (
+			key_digest TEXT PRIMARY KEY NOT NULL,
+			max_support TEXT NOT NULL,
+			support_rank INTEGER NOT NULL,
+			observed_at INTEGER NOT NULL
+		) STRICT
+	`);
+	const version = database.query("PRAGMA user_version").get() as { user_version?: number } | null;
+	const schemaVersion = version?.user_version ?? 0;
+	if (schemaVersion === 0) {
+		database.run(`PRAGMA user_version = ${CACHE_SCHEMA_VERSION}`);
+	} else if (schemaVersion !== CACHE_SCHEMA_VERSION) {
+		database.close();
+		throw new CapabilityCacheCorruptionError("unsupported cache schema version");
+	}
+	return database;
+}
+
+class CapabilityCacheCorruptionError extends Error {}
+
+function isCorruptCapabilityCacheError(error: unknown): boolean {
+	if (error instanceof CapabilityCacheCorruptionError) return true;
+	if (!error || typeof error !== "object") return false;
+	const code = (error as { code?: unknown }).code;
+	return code === "SQLITE_CORRUPT" || code === "SQLITE_NOTADB";
+}
+
+function retireCorruptCapabilityCache(cachePath: string): void {
+	for (const suffix of ["", "-wal", "-shm"]) {
+		try {
+			fs.rmSync(`${cachePath}${suffix}`, { force: true });
+		} catch {
+			// A best-effort cache reset must never break provider fallback behavior.
+		}
+	}
+}
+
+function capabilityKeyDigest(registryKey: string): string {
+	return crypto.createHash("sha256").update(registryKey).digest("hex");
+}
+
+function isToolChoiceSupport(value: unknown): value is ToolChoiceSupport {
+	return value === "none" || value === "auto" || value === "required" || value === "named";
+}
+
+function currentTime(): number {
+	return nowForTests?.() ?? Date.now();
 }

--- a/packages/ai/src/utils/tool-choice-capability.ts
+++ b/packages/ai/src/utils/tool-choice-capability.ts
@@ -384,14 +384,15 @@ function withCapabilityCache<T>(operation: (database: Database) => T): T | undef
 
 function openCapabilityCache(cachePath: string): Database {
 	const database = new Database(cachePath, { create: true, strict: true });
-	database.run("PRAGMA busy_timeout = 3000");
-	database.run("PRAGMA journal_mode = WAL");
-	database.run("PRAGMA synchronous = FULL");
-	const initialize = database.transaction(() => {
-		const version = database.query("PRAGMA user_version").get() as { user_version?: number } | null;
-		const schemaVersion = version?.user_version ?? 0;
-		if (schemaVersion === 0) {
-			database.run(`
+	try {
+		database.run("PRAGMA busy_timeout = 3000");
+		database.run("PRAGMA journal_mode = WAL");
+		database.run("PRAGMA synchronous = FULL");
+		const initialize = database.transaction(() => {
+			const version = database.query("PRAGMA user_version").get() as { user_version?: number } | null;
+			const schemaVersion = version?.user_version ?? 0;
+			if (schemaVersion === 0) {
+				database.run(`
 				CREATE TABLE IF NOT EXISTS tool_choice_capabilities (
 					key_digest TEXT PRIMARY KEY NOT NULL,
 					max_support TEXT NOT NULL,
@@ -399,17 +400,21 @@ function openCapabilityCache(cachePath: string): Database {
 					observed_at INTEGER NOT NULL
 				) STRICT
 			`);
+				assertCapabilityCacheSchema(database);
+				database.run(`PRAGMA user_version = ${CACHE_SCHEMA_VERSION}`);
+				return;
+			}
+			if (schemaVersion !== CACHE_SCHEMA_VERSION) {
+				throw new CapabilityCacheCorruptionError("unsupported cache schema version");
+			}
 			assertCapabilityCacheSchema(database);
-			database.run(`PRAGMA user_version = ${CACHE_SCHEMA_VERSION}`);
-			return;
-		}
-		if (schemaVersion !== CACHE_SCHEMA_VERSION) {
-			throw new CapabilityCacheCorruptionError("unsupported cache schema version");
-		}
-		assertCapabilityCacheSchema(database);
-	});
-	initialize();
-	return database;
+		});
+		initialize();
+		return database;
+	} catch (error) {
+		database.close();
+		throw error;
+	}
 }
 
 function assertCapabilityCacheSchema(database: Database): void {

--- a/packages/ai/test/tool-choice-capability.test.ts
+++ b/packages/ai/test/tool-choice-capability.test.ts
@@ -180,6 +180,21 @@ describe("durable tool-choice capability cache", () => {
 		expect(resolved.supportSource).toBe("runtime");
 	});
 
+	it("memoizes an empty durable lookup without hiding later revalidation", () => {
+		using tempDir = TempDir.createSync("tool-choice-capability-empty-");
+		const cachePath = path.join(tempDir.path(), "capabilities.db");
+		let now = 1_000;
+		let opens = 0;
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath, now: () => now, onCacheOpen: () => opens++ });
+		expect(resolveToolChoice(model("named"), "required").support).toBe("named");
+		expect(resolveToolChoice(model("named"), "required").support).toBe("named");
+		expect(opens).toBe(1);
+
+		now += 5 * 60 * 1000;
+		expect(resolveToolChoice(model("named"), "required").support).toBe("named");
+		expect(opens).toBe(2);
+	});
+
 	it("expires learned support so provider behavior is re-probed", () => {
 		using tempDir = TempDir.createSync("tool-choice-capability-ttl-");
 		const cachePath = path.join(tempDir.path(), "capabilities.db");

--- a/packages/ai/test/tool-choice-capability.test.ts
+++ b/packages/ai/test/tool-choice-capability.test.ts
@@ -257,6 +257,51 @@ describe("durable tool-choice capability cache", () => {
 		expect(resolveToolChoice(model("named"), "required").support).toBe("auto");
 	});
 
+	it("recovers from an invalid version-zero schema", () => {
+		using tempDir = TempDir.createSync("tool-choice-capability-schema-");
+		const cachePath = path.join(tempDir.path(), "capabilities.db");
+		const database = new Database(cachePath);
+		try {
+			database.run("CREATE TABLE tool_choice_capabilities (wrong TEXT)");
+		} finally {
+			database.close();
+		}
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath });
+
+		expect(resolveToolChoice(model("named"), "required").support).toBe("named");
+		markToolChoiceIncapability(model("named"), "auto");
+		expect(resolveToolChoice(model("named"), "required").support).toBe("auto");
+	});
+
+	it("does not delete a row repaired while malformed data is being cleaned", () => {
+		using tempDir = TempDir.createSync("tool-choice-capability-malformed-race-");
+		const cachePath = path.join(tempDir.path(), "capabilities.db");
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath });
+		markToolChoiceIncapability(model("named"), "auto");
+		const database = new Database(cachePath);
+		try {
+			database.run("UPDATE tool_choice_capabilities SET support_rank = 3");
+		} finally {
+			database.close();
+		}
+
+		configureToolChoiceCapabilityCacheForTests({
+			path: cachePath,
+			beforeMalformedDelete: () => {
+				const repair = new Database(cachePath);
+				try {
+					repair.run("UPDATE tool_choice_capabilities SET support_rank = 1");
+				} finally {
+					repair.close();
+				}
+			},
+		});
+		expect(resolveToolChoice(model("named"), "required").support).toBe("named");
+
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath });
+		expect(resolveToolChoice(model("named"), "required").support).toBe("auto");
+	});
+
 	it("isolates api, provider, base URL, and wire model without persisting raw keys or errors", async () => {
 		using tempDir = TempDir.createSync("tool-choice-capability-isolation-");
 		const cachePath = path.join(tempDir.path(), "capabilities.db");
@@ -274,6 +319,7 @@ describe("durable tool-choice capability cache", () => {
 		}
 
 		const bytes = await fs.readFile(cachePath);
+		expect((await fs.stat(cachePath)).mode & 0o777).toBe(0o600);
 		const persisted = bytes.toString("utf8");
 		expect(persisted).not.toContain(target.baseUrl);
 		expect(persisted).not.toContain(target.provider);

--- a/packages/ai/test/tool-choice-capability.test.ts
+++ b/packages/ai/test/tool-choice-capability.test.ts
@@ -204,6 +204,48 @@ describe("durable tool-choice capability cache", () => {
 		expect(resolveToolChoice(model("named"), "required").support).toBe("named");
 	});
 
+	it("does not delete a capability refreshed while an expired row is being revalidated", () => {
+		using tempDir = TempDir.createSync("tool-choice-capability-expiry-race-");
+		const cachePath = path.join(tempDir.path(), "capabilities.db");
+		let now = 1_000;
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath, now: () => now });
+		markToolChoiceIncapability(model("named"), "auto");
+
+		now += 30 * 24 * 60 * 60 * 1000;
+		configureToolChoiceCapabilityCacheForTests({
+			path: cachePath,
+			now: () => now,
+			beforeExpiredDelete: () => {
+				const database = new Database(cachePath);
+				try {
+					database.run("UPDATE tool_choice_capabilities SET observed_at = ? WHERE max_support = ?", [now, "auto"]);
+				} finally {
+					database.close();
+				}
+			},
+		});
+		expect(resolveToolChoice(model("named"), "required").support).toBe("named");
+
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath, now: () => now });
+		expect(resolveToolChoice(model("named"), "required").support).toBe("auto");
+	});
+
+	it("refreshes durable and in-memory expiry when the same incapability is observed again", () => {
+		using tempDir = TempDir.createSync("tool-choice-capability-refresh-");
+		const cachePath = path.join(tempDir.path(), "capabilities.db");
+		let now = 1_000;
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath, now: () => now });
+		markToolChoiceIncapability(model("named"), "auto");
+
+		now += 29 * 24 * 60 * 60 * 1000;
+		markToolChoiceIncapability(model("named"), "auto");
+		now += 2 * 24 * 60 * 60 * 1000;
+		expect(resolveToolChoice(model("named"), "required").support).toBe("auto");
+
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath, now: () => now });
+		expect(resolveToolChoice(model("named"), "required").support).toBe("auto");
+	});
+
 	it("recovers from a corrupted cache without changing fallback behavior", async () => {
 		using tempDir = TempDir.createSync("tool-choice-capability-corrupt-");
 		const cachePath = path.join(tempDir.path(), "capabilities.db");

--- a/packages/ai/test/tool-choice-capability.test.ts
+++ b/packages/ai/test/tool-choice-capability.test.ts
@@ -1,7 +1,12 @@
+import { Database } from "bun:sqlite";
 import { beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { TempDir } from "@gajae-code/utils";
 import type { Model, ToolChoice, ToolChoiceSupport } from "../src/types";
 import {
 	clearToolChoiceIncapabilityRegistryForTests,
+	configureToolChoiceCapabilityCacheForTests,
 	deriveToolChoiceSupport,
 	getToolChoiceCapabilityOverride,
 	isCodexStatuslessNamedToolChoiceNotFoundError,
@@ -33,6 +38,7 @@ function statusError(status: number, message: string): Error & { status: number 
 }
 
 beforeEach(() => {
+	configureToolChoiceCapabilityCacheForTests();
 	clearToolChoiceIncapabilityRegistryForTests();
 });
 
@@ -157,6 +163,108 @@ describe("tool-choice registry", () => {
 		expect(toolChoiceRegistryKey(model("named"))).toBe(
 			"openai-completions|openai|https://api.openai.example/v1|wire-id",
 		);
+	});
+});
+
+describe("durable tool-choice capability cache", () => {
+	it("hydrates a learned incapability across simulated fresh processes", () => {
+		using tempDir = TempDir.createSync("tool-choice-capability-");
+		const cachePath = path.join(tempDir.path(), "capabilities.db");
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath });
+		markToolChoiceIncapability(model("named"), "auto", "secret raw provider error");
+
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath });
+		const resolved = resolveToolChoice(model("named"), { type: "function", name: "todo_write" });
+		expect(resolved.support).toBe("auto");
+		expect(resolved.resolvedChoice).toBeUndefined();
+		expect(resolved.supportSource).toBe("runtime");
+	});
+
+	it("expires learned support so provider behavior is re-probed", () => {
+		using tempDir = TempDir.createSync("tool-choice-capability-ttl-");
+		const cachePath = path.join(tempDir.path(), "capabilities.db");
+		let now = 1_000;
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath, now: () => now });
+		markToolChoiceIncapability(model("named"), "auto");
+
+		now += 30 * 24 * 60 * 60 * 1000;
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath, now: () => now });
+		expect(resolveToolChoice(model("named"), "required").support).toBe("named");
+	});
+
+	it("revalidates expiry inside a long-lived process", () => {
+		using tempDir = TempDir.createSync("tool-choice-capability-live-ttl-");
+		const cachePath = path.join(tempDir.path(), "capabilities.db");
+		let now = 1_000;
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath, now: () => now });
+		markToolChoiceIncapability(model("named"), "auto");
+		expect(resolveToolChoice(model("named"), "required").support).toBe("auto");
+
+		now += 30 * 24 * 60 * 60 * 1000;
+		expect(resolveToolChoice(model("named"), "required").support).toBe("named");
+	});
+
+	it("recovers from a corrupted cache without changing fallback behavior", async () => {
+		using tempDir = TempDir.createSync("tool-choice-capability-corrupt-");
+		const cachePath = path.join(tempDir.path(), "capabilities.db");
+		await fs.writeFile(cachePath, "not a sqlite database");
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath });
+
+		expect(resolveToolChoice(model("named"), "required").support).toBe("named");
+		markToolChoiceIncapability(model("named"), "auto");
+		expect(resolveToolChoice(model("named"), "required").support).toBe("auto");
+	});
+
+	it("isolates api, provider, base URL, and wire model without persisting raw keys or errors", async () => {
+		using tempDir = TempDir.createSync("tool-choice-capability-isolation-");
+		const cachePath = path.join(tempDir.path(), "capabilities.db");
+		const target = model("named");
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath });
+		markToolChoiceIncapability(target, "auto", "credential=super-secret raw-error-body");
+
+		for (const isolated of [
+			{ ...target, api: "openai-responses" as const },
+			{ ...target, provider: "other-provider" },
+			{ ...target, baseUrl: "https://other.example/v1" },
+			{ ...target, wireModelId: "other-wire-id" },
+		]) {
+			expect(resolveToolChoice(isolated, "required").support).toBe("named");
+		}
+
+		const bytes = await fs.readFile(cachePath);
+		const persisted = bytes.toString("utf8");
+		expect(persisted).not.toContain(target.baseUrl);
+		expect(persisted).not.toContain(target.provider);
+		expect(persisted).not.toContain(target.wireModelId ?? "");
+		expect(persisted).not.toContain("super-secret");
+		expect(persisted).not.toContain("raw-error-body");
+	});
+
+	it("serializes concurrent process writes and preserves the lowest support", async () => {
+		using tempDir = TempDir.createSync("tool-choice-capability-concurrent-");
+		const cachePath = path.join(tempDir.path(), "capabilities.db");
+		const script = `
+			import { configureToolChoiceCapabilityCacheForTests, markToolChoiceIncapability } from ${JSON.stringify(
+				path.resolve(import.meta.dir, "../src/utils/tool-choice-capability.ts"),
+			)};
+			const model = ${JSON.stringify(model("named"))};
+			configureToolChoiceCapabilityCacheForTests({ path: process.argv[1] });
+			markToolChoiceIncapability(model, process.argv[2]);
+		`;
+		const processes = ["required", "auto", "required", "auto"].map(support =>
+			Bun.spawn([process.execPath, "-e", script, cachePath, support], { stdout: "pipe", stderr: "pipe" }),
+		);
+		const exits = await Promise.all(processes.map(process => process.exited));
+		expect(exits).toEqual([0, 0, 0, 0]);
+
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath });
+		expect(resolveToolChoice(model("named"), "required").support).toBe("auto");
+		const database = new Database(cachePath, { readonly: true });
+		try {
+			expect(database.query("SELECT COUNT(*) AS count FROM tool_choice_capabilities").get()).toEqual({ count: 1 });
+		} finally {
+			database.close();
+		}
 	});
 });
 

--- a/packages/ai/test/tool-choice-capability.test.ts
+++ b/packages/ai/test/tool-choice-capability.test.ts
@@ -195,6 +195,22 @@ describe("durable tool-choice capability cache", () => {
 		expect(opens).toBe(2);
 	});
 
+	it("bounds empty lookup memoization", () => {
+		using tempDir = TempDir.createSync("tool-choice-capability-empty-bound-");
+		const cachePath = path.join(tempDir.path(), "capabilities.db");
+		let opens = 0;
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath, onCacheOpen: () => opens++ });
+		for (let index = 0; index < 300; index++) {
+			resolveToolChoice({ ...model("named"), wireModelId: `wire-${index}` }, "required");
+		}
+		expect(opens).toBe(300);
+
+		resolveToolChoice({ ...model("named"), wireModelId: "wire-0" }, "required");
+		expect(opens).toBe(301);
+		resolveToolChoice({ ...model("named"), wireModelId: "wire-299" }, "required");
+		expect(opens).toBe(301);
+	});
+
 	it("expires learned support so provider behavior is re-probed", () => {
 		using tempDir = TempDir.createSync("tool-choice-capability-ttl-");
 		const cachePath = path.join(tempDir.path(), "capabilities.db");

--- a/packages/coding-agent/test/agent-session-eager-todo.test.ts
+++ b/packages/coding-agent/test/agent-session-eager-todo.test.ts
@@ -4,6 +4,11 @@ import * as path from "node:path";
 import { Agent, type AgentMessage, type AgentTool } from "@gajae-code/agent-core";
 import { type AssistantMessage, getBundledModel, type TextContent, type ToolCall } from "@gajae-code/ai";
 import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
+import {
+	clearToolChoiceIncapabilityRegistryForTests,
+	configureToolChoiceCapabilityCacheForTests,
+	markToolChoiceIncapability,
+} from "@gajae-code/ai/utils/tool-choice-capability";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { initializeLocalRoot } from "@gajae-code/coding-agent/internal-urls";
@@ -202,6 +207,8 @@ describe("AgentSession eager todo enforcement", () => {
 	});
 
 	afterEach(async () => {
+		configureToolChoiceCapabilityCacheForTests();
+		clearToolChoiceIncapabilityRegistryForTests();
 		managedAppendSpy?.mockRestore();
 		managedAppendSpy = undefined;
 		fileWriterSpy?.mockRestore();
@@ -383,6 +390,20 @@ describe("AgentSession eager todo enforcement", () => {
 			lastMessageText: "list all work trees",
 		});
 		expect(observedCalls[0]?.messageTexts[0]).toContain("todo_write");
+	});
+
+	it("sends the reminder without named forcing after cached incapability hydration", async () => {
+		const cachePath = path.join(tempDir.path(), "tool-choice-capabilities.db");
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath });
+		markToolChoiceIncapability(session.model!, "auto", "first-process discovery");
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath });
+
+		await session.prompt("list all work trees");
+
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]?.toolChoice).toBeUndefined();
+		expect(observedCalls[0]?.toolNames).toEqual(["todo_write", "bash"]);
+		expect(observedCalls[0]?.messageTexts).toEqual([expect.any(String), "list all work trees"]);
 	});
 
 	it("drops the eager choice when todo_write becomes inactive before the model call", async () => {

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -487,6 +487,11 @@ export function getGithubCacheDbPath(): string {
 	return dirs.rootSubdir(path.join("cache", "github-cache.db"), "cache");
 }
 
+/** Get the durable tool-choice capability cache path. */
+export function getToolChoiceCapabilityCachePath(): string {
+	return dirs.rootSubdir(path.join("cache", "tool-choice-capabilities.db"), "cache");
+}
+
 /** Get the natives directory (~/.gjc/natives). */
 export function getNativesDir(): string {
 	return dirs.rootSubdir("natives", "cache");


### PR DESCRIPTION
## Summary
- persist learned tool-choice capability floors in a bounded, versioned SQLite cache
- scope entries by SHA-256 digest of api/provider/base-url/wire-model without storing URL material, credentials, prompts, request bodies, or raw provider errors
- expire observations after 30 days for automatic re-probing, including long-lived processes
- preserve first-discovery retry/degradation behavior and let eager-todo omit named forcing after cached degradation

Closes #4319

Credit to @probepark for the precise report, production evidence, classifier analysis, and suggested persistence direction.

## Safety contract
- WAL-backed transactional writes with busy timeout and monotonic lower-support updates across processes
- strict schema versioning, 256-entry bound, corruption-tolerant retirement, and non-fatal cache failures
- no new user-visible configuration or schema surface
- no provider-wide hardcode

## Validation
- focused capability, Codex fallback, and eager-todo suites: 121 pass, 1 skip
- affected AI and utils package checks plus coding-agent typecheck passed
- architect review: CLEAR / APPROVE
- executor QA/red-team: passed, no blockers

Aggregate `bun run check:ts` was attempted and stopped on the current dev SDK closure gate: `Pending review source seam: agent_session:syncEagerDelegation`; this change does not touch that surface.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*