### PR TITLE
fix(ai): repair CPA Claude-OAuth tool-alias restore 500 with one-shot steering

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Anthropic streams now repair the CPA Claude-OAuth "cannot restore tool alias" 500 instead of blindly resending the unchanged request: the exact SSE signature is classified, the base tool name is extracted, and the request is corrected exactly once with steering that names the unique callable tool (or directs tool discovery when no unique match exists). Recurrence surfaces an actionable terminal error with no transport facts, so neither the provider generic 5xx retry nor the managed fallback controller re-sends; managed attempts record the steering against the same turn and the next attempt applies it (#4338).
+
 - Persist learned tool-choice incapabilities in a bounded, expiring, digest-keyed cache so fresh processes avoid repeating known-invalid forced-choice probes while retaining automatic revalidation and existing first-discovery fallback behavior. Credit: @probepark (#4319).
 
 ### Added

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -344,6 +344,24 @@ type AnthropicProviderSessionState = ProviderSessionState & {
 	generatedCacheBudget: GeneratedCacheBudget;
 	thinkingReplayRepairScope: AnthropicThinkingReplayRepairScope;
 	thinkingReplayRepairAttempts: number;
+	/**
+	 * Managed-mode escalation for the CPA alias-restore failure (issue #4338):
+	 * corrective steering recorded against one exact turn, applied by the next
+	 * managed attempt that rebuilds the same turn and released on success.
+	 */
+	cpaToolAliasSteering?: AnthropicCpaToolAliasSteering;
+};
+
+type AnthropicCpaToolAliasSteering = {
+	/** Corrective steering text appended to the next build of the same turn. */
+	message: string;
+	/**
+	 * Fingerprint of the last user message when the failure was recorded. The
+	 * steering only applies to a rebuild of the same logical turn; a later turn
+	 * with a different prompt expires it instead of replaying a stale
+	 * correction.
+	 */
+	turnFingerprint: string;
 };
 
 function createAnthropicProviderSessionState(): AnthropicProviderSessionState {
@@ -359,6 +377,7 @@ function createAnthropicProviderSessionState(): AnthropicProviderSessionState {
 			state.generatedCacheBudget = 2;
 			state.thinkingReplayRepairScope = "none";
 			state.thinkingReplayRepairAttempts = 0;
+			state.cpaToolAliasSteering = undefined;
 		},
 	};
 	return state;
@@ -507,6 +526,60 @@ export function isAnthropicCacheBreakpointOverflowError(error: unknown): boolean
 	// Observed: "A maximum of 4 blocks with cache_control may be provided. Found 5."
 	// Stay tolerant of phrasing drift around the limit and the reported total.
 	return /maximum of \d+ blocks/i.test(message) || /at most \d+ blocks/i.test(message);
+}
+
+/**
+ * CPA's Claude-OAuth layer cloaks downstream tool names into
+ * `mcp__<server>__<token>_<base>` aliases upstream. When the model emits a
+ * tool call whose alias embeds a token that appears nowhere in the request,
+ * CPA cannot restore the name and kills the whole stream with an HTTP 500 SSE
+ * `error` event instead of forwarding the call (issue #4338). The signature is
+ * precise and machine-parseable: it quotes the rejected alias and the failure
+ * mode verbatim. Native Anthropic never emits this phrasing, so the text itself
+ * is the route gate.
+ */
+const CPA_TOOL_ALIAS_RESTORE_PATTERN =
+	/cannot restore Claude OAuth MCP tool alias \\?"([^"\\\\]+)\\?": no unique request-local match/i;
+
+/**
+ * Aliases observed as `mcp__<server>__<token>_<base>` with a 12-character
+ * lowercase-alphanumeric token segment (`find` = `yw7zaf6emg3l` in both
+ * captured traces). Tolerate 8-16 chars so extraction survives token-length
+ * drift while staying out of the base name; a base that itself contains
+ * underscores (`todo_write`) is preserved by the trailing `.+`.
+ */
+const CPA_TOOL_ALIAS_BASE_PATTERN = /^mcp__[^_]+__[a-z0-9]{8,16}_(.+)$/;
+
+export interface CpaToolAliasRestoreFailure {
+	/** The rejected tool-call name exactly as CPA quoted it. */
+	alias: string;
+	/**
+	 * Base tool name parsed out of the alias (`mcp__<server>__<token>_<base>`
+	 * → `<base>`), when the alias shape is well-formed. `undefined` for a
+	 * malformed alias — callers must then fall back to direct discovery and
+	 * never invent a name.
+	 */
+	baseName?: string;
+}
+
+/**
+ * Classifies the CPA alias-restore signature and extracts the rejected alias
+ * plus its base tool name. Claims only statusless in-stream SSE error events
+ * and HTTP 5xx failures: a non-5xx status carrying this text is not the
+ * observed CPA delivery shape and is left to the other classifiers.
+ */
+export function parseCpaToolAliasRestoreFailure(error: unknown): CpaToolAliasRestoreFailure | undefined {
+	const status = extractHttpStatusFromError(error);
+	if (status !== undefined && status < 500) return undefined;
+	const message = error instanceof Error ? error.message : String(error);
+	const match = CPA_TOOL_ALIAS_RESTORE_PATTERN.exec(message);
+	if (!match) return undefined;
+	const alias = match[1]!;
+	return { alias, baseName: CPA_TOOL_ALIAS_BASE_PATTERN.exec(alias)?.[1] };
+}
+
+export function isCpaToolAliasRestoreFailure(error: unknown): boolean {
+	return parseCpaToolAliasRestoreFailure(error) !== undefined;
 }
 
 function hasStrictAnthropicTools(params: MessageCreateParamsStreaming): boolean {
@@ -1398,6 +1471,93 @@ export function applyAnthropicUsageExtras(usage: Usage, source: AnthropicUsageLi
 	}
 }
 
+/**
+ * Unique request-local tool whose wire name equals the parsed base, if any.
+ * Only an exact, singular match is trusted; zero or multiple matches yield
+ * `undefined` so the repair never guesses among ambiguous aliases.
+ */
+function resolveCpaCallableToolName(
+	params: MessageCreateParamsStreaming,
+	failure: CpaToolAliasRestoreFailure,
+): string | undefined {
+	if (failure.baseName === undefined) return undefined;
+	const tools = params.tools as Array<{ name?: string }> | undefined;
+	if (!tools) return undefined;
+	let match: string | undefined;
+	for (const tool of tools) {
+		if (tool.name !== failure.baseName) continue;
+		if (match !== undefined) return undefined;
+		match = tool.name;
+	}
+	return match;
+}
+
+/**
+ * Corrective steering for the one retry after a CPA alias-restore failure. A
+ * provable unique callable name is stated deterministically; otherwise the
+ * model is directed at tool discovery instead of being handed an invented
+ * name, mirroring the agent loop's "not found → discover and activate"
+ * guidance. The rejected alias is echoed verbatim so the model knows which
+ * call was wrong; nothing else from the request is quoted.
+ */
+function buildCpaToolAliasSteering(failure: CpaToolAliasRestoreFailure, callableToolName?: string): string {
+	const rejected = `Your previous tool call "${failure.alias}" was rejected by the Claude OAuth proxy: the tool name is not callable in this request.`;
+	if (callableToolName !== undefined) {
+		return `${rejected} The callable tool is "${callableToolName}". Call it by exactly that name; do not construct or reconstruct prefixed or aliased tool names.`;
+	}
+	return `${rejected} If you need this capability, call \`search_tool_bm25\` to discover and activate the matching tool, then retry.`;
+}
+
+/**
+ * Actionable terminal error for a CPA alias-restore failure that survived the
+ * single corrective attempt. Deliberately statusless: no HTTP status, no
+ * transport facts, and no recognizable status phrase, so neither the provider
+ * generic 5xx retry nor the managed fallback controller re-sends the unchanged
+ * request. Only the rejected alias and the deterministic callable name (when
+ * provable) are quoted — never the request body or headers.
+ */
+function createCpaToolAliasTerminalError(failure: CpaToolAliasRestoreFailure, callableToolName?: string): Error {
+	const base = `Claude OAuth proxy rejected tool call "${failure.alias}": the proxy cannot restore the Claude OAuth MCP tool alias (no unique request-local match), and the corrective retry was rejected again.`;
+	const guidance =
+		callableToolName !== undefined
+			? ` The callable tool name is "${callableToolName}"; call it by exactly that name.`
+			: ` No unique callable tool name could be determined; discover the correct tool name before retrying.`;
+	return new Error(`${base}${guidance} The turn was not re-sent.`);
+}
+
+/**
+ * Stable identity for the logical turn currently being prompted: the
+ * serialized content of the last user message. Fallback rebuilds of the same
+ * turn keep the same fingerprint; the next user prompt changes it.
+ */
+function cpaTurnFingerprint(messages: Message[]): string {
+	for (let index = messages.length - 1; index >= 0; index--) {
+		const message = messages[index];
+		if (message.role !== "user") continue;
+		const content = message.content;
+		const serialized = typeof content === "string" ? content : JSON.stringify(content);
+		return `${serialized.length}:${serialized}`;
+	}
+	return "";
+}
+
+/**
+ * Append corrective steering as a trailing user turn, preserving role
+ * alternation by merging into the last user message when it is already a user
+ * turn.
+ */
+function appendCpaSteeringToMessages(params: MessageCreateParamsStreaming, text: string): void {
+	const messages = params.messages as MessageParam[];
+	const last = messages[messages.length - 1];
+	if (last && last.role === "user") {
+		last.content = Array.isArray(last.content)
+			? [...last.content, { type: "text", text }]
+			: `${last.content}\n\n${text}`;
+	} else {
+		messages.push({ role: "user", content: text });
+	}
+}
+
 export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 	model: Model<"anthropic-messages">,
 	context: Context,
@@ -1477,6 +1637,9 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 			let strictFallbackErrorMessage: string | undefined;
 			let dropFastMode = providerSessionState?.fastModeDisabled ?? false;
 			let droppedForcedToolChoice = false;
+			// Exactly one corrective retry per request for the CPA alias-restore
+			// signature (issue #4338); recurrence terminalizes instead of resending.
+			let cpaAliasRepairApplied = false;
 			let thinkingReplayRepairScope: AnthropicThinkingReplayRepairScope =
 				providerSessionState?.thinkingReplayRepairScope ?? "none";
 			let thinkingReplayRepairAttempts = providerSessionState?.thinkingReplayRepairAttempts ?? 0;
@@ -1516,6 +1679,18 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 				const replacementPayload = await options?.onPayload?.(nextParams, model, options?.attemptScope);
 				if (replacementPayload !== undefined) {
 					nextParams = replacementPayload as typeof nextParams;
+				}
+				// Managed-mode CPA steering (issue #4338): a previous managed attempt of
+				// this exact turn recorded a corrective tool-name message. Apply it only
+				// while the turn is unchanged; a different user prompt expires it so a
+				// stale correction never leaks into a later turn.
+				const cpaSteering = providerSessionState?.cpaToolAliasSteering;
+				if (cpaSteering) {
+					if (cpaSteering.turnFingerprint === cpaTurnFingerprint(context.messages)) {
+						appendCpaSteeringToMessages(nextParams, cpaSteering.message);
+					} else {
+						providerSessionState.cpaToolAliasSteering = undefined;
+					}
 				}
 				validateCacheControls(nextParams as AnthropicCacheParams);
 				rawRequestDump = {
@@ -1937,6 +2112,12 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 						providerSessionState.thinkingReplayRepairScope = "none";
 						providerSessionState.thinkingReplayRepairAttempts = 0;
 					}
+					// Release a recorded CPA steering once any stream completes: a
+					// successful stream consumed it, and a failed one ends the turn (a
+					// later turn's different user prompt would expire it anyway).
+					if (providerSessionState?.cpaToolAliasSteering) {
+						providerSessionState.cpaToolAliasSteering = undefined;
+					}
 					break;
 				} catch (streamError) {
 					const localAbortReason = activeAbortTracker.getLocalAbortReason();
@@ -2111,6 +2292,75 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 						providerRetryAttempt = 0;
 						resetOutputForRetry();
 						continue;
+					}
+					// CPA (Claude-OAuth proxy) alias-restore failure (issue #4338): the
+					// proxy 500s the whole stream because the model emitted a cloaked
+					// `mcp__<server>__<token>_<base>` tool name whose random token segment
+					// matches nothing in the request. The generic 5xx retry below would
+					// blindly re-send the unchanged request and re-sample the same drift;
+					// instead, correct the request exactly once and terminalize on
+					// recurrence. The narrow CPA phrase is the route gate, so native
+					// Anthropic and non-CPA proxies are untouched.
+					const cpaAliasFailure = parseCpaToolAliasRestoreFailure(streamFailure);
+					if (cpaAliasFailure && firstTokenTime === undefined) {
+						if (options?.fallbackManaged) {
+							// The managed fallback controller owns retries: never retry
+							// inside the attempt it handed us. Record the corrective
+							// steering against this exact turn and surface the raw error;
+							// the controller's next attempt rebuilds the request with the
+							// steering. Without shared session state there is nowhere to
+							// record, so fall through to the controller unchanged.
+							if (!providerSessionState) throw streamFailure;
+							const turnFingerprint = cpaTurnFingerprint(context.messages);
+							if (providerSessionState.cpaToolAliasSteering?.turnFingerprint === turnFingerprint) {
+								// The steering was already applied to this attempt and the proxy
+								// rejected again: the single corrective attempt is spent. Surface
+								// an actionable terminal error instead of another unchanged
+								// resend.
+								throw createCpaToolAliasTerminalError(
+									cpaAliasFailure,
+									resolveCpaCallableToolName(params, cpaAliasFailure),
+								);
+							}
+							providerSessionState.cpaToolAliasSteering = {
+								message: buildCpaToolAliasSteering(
+									cpaAliasFailure,
+									resolveCpaCallableToolName(params, cpaAliasFailure),
+								),
+								turnFingerprint,
+							};
+							logger.debug("anthropic: recording CPA tool alias steering for the next managed attempt", {
+								model: model.id,
+								alias: cpaAliasFailure.alias,
+								baseName: cpaAliasFailure.baseName,
+								error: streamFailure instanceof Error ? streamFailure.message : String(streamFailure),
+							});
+							throw streamFailure;
+						}
+						if (!cpaAliasRepairApplied) {
+							cpaAliasRepairApplied = true;
+							logger.debug("anthropic: repairing CPA tool alias restore failure with corrective steering", {
+								model: model.id,
+								alias: cpaAliasFailure.alias,
+								baseName: cpaAliasFailure.baseName,
+								error: streamFailure instanceof Error ? streamFailure.message : String(streamFailure),
+							});
+							appendCpaSteeringToMessages(
+								params,
+								buildCpaToolAliasSteering(cpaAliasFailure, resolveCpaCallableToolName(params, cpaAliasFailure)),
+							);
+							// Exactly one corrective attempt per request: the provider retry
+							// budget is deliberately NOT reset, so a persistent failure runs
+							// out instead of renewing the budget it is supposed to consume
+							// (issue #4011), and the recurrence branch below terminalizes
+							// before the generic 5xx retry can re-send the unchanged request.
+							resetOutputForRetry();
+							continue;
+						}
+						throw createCpaToolAliasTerminalError(
+							cpaAliasFailure,
+							resolveCpaCallableToolName(params, cpaAliasFailure),
+						);
 					}
 					const isTransientEnvelopeFailure =
 						isTransientStreamParseError(streamFailure) || isTransientStreamEnvelopeError(streamFailure);

--- a/packages/ai/test/anthropic-cpa-tool-alias-recovery.test.ts
+++ b/packages/ai/test/anthropic-cpa-tool-alias-recovery.test.ts
@@ -1,0 +1,469 @@
+import { describe, expect, it } from "bun:test";
+import type Anthropic from "@anthropic-ai/sdk";
+import {
+	isCpaToolAliasRestoreFailure,
+	parseCpaToolAliasRestoreFailure,
+	streamAnthropic,
+} from "@gajae-code/ai/providers/anthropic";
+import type { Context, Model, ProviderSessionState, Tool, UserMessage } from "@gajae-code/ai/types";
+
+const model: Model<"anthropic-messages"> = {
+	api: "anthropic-messages",
+	provider: "anthropic",
+	id: "claude-sonnet-4-6",
+	name: "Claude Sonnet 4.6",
+	baseUrl: "https://api.anthropic.com",
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	maxTokens: 8_192,
+	contextWindow: 200_000,
+	reasoning: true,
+};
+
+type MockAnthropicEvent = Record<string, unknown>;
+type MockAnthropicRequest = {
+	withResponse(): Promise<{
+		data: AsyncIterable<MockAnthropicEvent>;
+		response: Response;
+		request_id: string | null;
+	}>;
+};
+
+// Exact public signature from issue #4338 (both captured CPA traces): the proxy
+// 500s the stream with an SSE `error` event naming the rejected cloaked alias
+// and the failure mode. Only synthetic fixtures derived from the public issue
+// are used — no private capture content is ingested.
+const CPA_ALIAS_FIND = "mcp__jzi2uzmxd57z__1olzmojrukyw_find";
+const CPA_ALIAS_SEARCH = "mcp__jzi2uzmxd57z__cn0i1zsn4b0j_search";
+
+function cpaAliasErrorMessage(alias: string): string {
+	return `{"type":"error","error":{"type":"api_error","message":"restore Claude OAuth tool name from streaming response: cannot restore Claude OAuth MCP tool alias \\"${alias}\\": no unique request-local match"}}`;
+}
+
+function createCpaAlias500(alias: string): MockAnthropicRequest {
+	return {
+		async withResponse() {
+			const error = Object.assign(new Error(`500 ${cpaAliasErrorMessage(alias)}`), { status: 500 });
+			throw error;
+		},
+	};
+}
+
+function createStatuslessCpaAliasError(alias: string): MockAnthropicRequest {
+	return {
+		async withResponse() {
+			throw new Error(cpaAliasErrorMessage(alias));
+		},
+	};
+}
+
+function createGeneric500(): MockAnthropicRequest {
+	return {
+		async withResponse() {
+			const error = Object.assign(
+				new Error(
+					'500 {"type":"error","error":{"type":"api_error","message":"An error occurred while processing the request."}}',
+				),
+				{ status: 500 },
+			);
+			throw error;
+		},
+	};
+}
+
+function createSuccessfulRequest(): MockAnthropicRequest {
+	const response = new Response(null, {
+		status: 200,
+		headers: { "request-id": "req_cpa_recovered" },
+	});
+	const events: MockAnthropicEvent[] = [
+		{
+			type: "message_start",
+			message: {
+				id: "msg_cpa_recovered",
+				usage: {
+					input_tokens: 1,
+					output_tokens: 0,
+					cache_read_input_tokens: 0,
+					cache_creation_input_tokens: 0,
+				},
+			},
+		},
+		{ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+		{ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "recovered" } },
+		{ type: "content_block_stop", index: 0 },
+		{
+			type: "message_delta",
+			delta: { stop_reason: "end_turn" },
+			usage: {
+				input_tokens: 1,
+				output_tokens: 1,
+				cache_read_input_tokens: 0,
+				cache_creation_input_tokens: 0,
+			},
+		},
+		{ type: "message_stop" },
+	];
+
+	return {
+		async withResponse() {
+			return {
+				data: {
+					async *[Symbol.asyncIterator]() {
+						for (const event of events) yield event;
+					},
+				},
+				response,
+				request_id: response.headers.get("request-id"),
+			};
+		},
+	};
+}
+
+// A stream that yields one content block (so firstTokenTime is set) and then
+// dies with the CPA signature: the repair must NOT fire after partial content.
+function createPartialThenCpaAliasError(alias: string): MockAnthropicRequest {
+	const response = new Response(null, { status: 200, headers: { "request-id": "req_cpa_partial" } });
+	return {
+		async withResponse() {
+			return {
+				data: {
+					async *[Symbol.asyncIterator]() {
+						yield {
+							type: "message_start",
+							message: {
+								id: "msg_cpa_partial",
+								usage: {
+									input_tokens: 1,
+									output_tokens: 0,
+									cache_read_input_tokens: 0,
+									cache_creation_input_tokens: 0,
+								},
+							},
+						};
+						yield { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } };
+						yield { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "partial" } };
+						throw new Error(cpaAliasErrorMessage(alias));
+					},
+				},
+				response,
+				request_id: response.headers.get("request-id"),
+			};
+		},
+	};
+}
+
+const findTool: Tool = {
+	name: "find",
+	description: "Find files",
+	parameters: { type: "object", properties: { path: { type: "string" } }, required: ["path"] },
+};
+const searchTool: Tool = {
+	name: "search",
+	description: "Search the workspace",
+	parameters: { type: "object", properties: { query: { type: "string" } }, required: ["query"] },
+};
+const bashTool: Tool = {
+	name: "bash",
+	description: "Run a shell command",
+	parameters: { type: "object", properties: {} },
+};
+
+function makeContext(messages: UserMessage[], tools: Tool[]): Context {
+	return { messages, tools };
+}
+
+function userMessage(content: string): UserMessage {
+	return { role: "user", content, timestamp: Date.now() };
+}
+
+/** The merged text of the last user turn of a captured request body. */
+function lastUserContent(params: unknown): string {
+	const messages = (params as { messages: Array<{ role: string; content: string }> }).messages ?? [];
+	const last = [...messages].reverse().find(message => message.role === "user");
+	return last?.content ?? "";
+}
+
+describe("CPA tool alias restore failure classification (issue #4338)", () => {
+	it("claims the exact 500 SSE signature and extracts the base tool", () => {
+		const error = Object.assign(new Error(`500 ${cpaAliasErrorMessage(CPA_ALIAS_FIND)}`), { status: 500 });
+		expect(isCpaToolAliasRestoreFailure(error)).toBe(true);
+		expect(parseCpaToolAliasRestoreFailure(error)).toEqual({ alias: CPA_ALIAS_FIND, baseName: "find" });
+	});
+
+	it("claims the statusless in-stream SSE error event form", () => {
+		const error = new Error(cpaAliasErrorMessage(CPA_ALIAS_SEARCH));
+		expect(isCpaToolAliasRestoreFailure(error)).toBe(true);
+		expect(parseCpaToolAliasRestoreFailure(error)).toEqual({ alias: CPA_ALIAS_SEARCH, baseName: "search" });
+	});
+
+	it("preserves underscore-bearing base names (todo_write)", () => {
+		const alias = "mcp__jzi2uzmxd57z__mr6er53iidr3_todo_write";
+		const error = new Error(cpaAliasErrorMessage(alias));
+		expect(isCpaToolAliasRestoreFailure(error)).toBe(true);
+		expect(parseCpaToolAliasRestoreFailure(error)).toEqual({ alias, baseName: "todo_write" });
+	});
+
+	it("still claims a malformed alias but yields no base name", () => {
+		// The signature is present but the alias has no `_<base>` tail to parse:
+		// the classifier must not crash and must not invent a base name.
+		const malformed = "mcp__jzi2uzmxd57z__1olzmojrukyw";
+		const error = new Error(cpaAliasErrorMessage(malformed));
+		expect(isCpaToolAliasRestoreFailure(error)).toBe(true);
+		expect(parseCpaToolAliasRestoreFailure(error)).toEqual({ alias: malformed, baseName: undefined });
+	});
+
+	it("rejects unrelated 500s, non-5xx statuses, and non-Error inputs", () => {
+		// The generic masked CPA rejection body must stay on its own classifier.
+		const masked = Object.assign(
+			new Error(
+				'500 {"type":"error","error":{"type":"api_error","message":"An error occurred while processing the request."}}',
+			),
+			{ status: 500 },
+		);
+		expect(isCpaToolAliasRestoreFailure(masked)).toBe(false);
+		// The signature on a 400 (or any non-5xx) status is not the observed CPA
+		// delivery shape and must not be claimed.
+		const fourHundred = Object.assign(new Error(`400 ${cpaAliasErrorMessage(CPA_ALIAS_FIND)}`), { status: 400 });
+		expect(isCpaToolAliasRestoreFailure(fourHundred)).toBe(false);
+		// A thinking-immutability 400 stays with its own matchers.
+		const thinking = Object.assign(
+			new Error(
+				'400 {"type":"error","error":{"type":"invalid_request_error","message":"The `thinking` blocks in the latest assistant message cannot be modified."}}',
+			),
+			{ status: 400 },
+		);
+		expect(isCpaToolAliasRestoreFailure(thinking)).toBe(false);
+		expect(isCpaToolAliasRestoreFailure(undefined)).toBe(false);
+		expect(isCpaToolAliasRestoreFailure("unrelated error text")).toBe(false);
+	});
+});
+
+describe("CPA tool alias restore failure recovery (issue #4338)", () => {
+	it("repairs once with corrective steering naming the unique callable tool", async () => {
+		const bodies: unknown[] = [];
+		let attempt = 0;
+		const create = ((body: unknown) => {
+			bodies.push(JSON.parse(JSON.stringify(body)));
+			attempt += 1;
+			return (attempt === 1 ? createCpaAlias500(CPA_ALIAS_FIND) : createSuccessfulRequest()) as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+
+		const context = makeContext([userMessage("find me the config")], [findTool, searchTool, bashTool]);
+		const result = await streamAnthropic(model, context, { client }).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toEqual([{ type: "text", text: "recovered" }]);
+		expect(bodies).toHaveLength(2);
+		// The first request carries no steering; the corrective retry names the
+		// deterministic callable tool and never guesses.
+		expect(lastUserContent(bodies[0])).not.toContain("callable tool");
+		const repaired = lastUserContent(bodies[1]);
+		expect(repaired).toContain(`Your previous tool call "${CPA_ALIAS_FIND}"`);
+		expect(repaired).toContain('The callable tool is "find"');
+		expect(repaired).not.toContain("search_tool_bm25");
+	});
+
+	it("terminalizes after exactly one corrective attempt on recurrence", async () => {
+		const bodies: unknown[] = [];
+		const create = ((body: unknown) => {
+			bodies.push(JSON.parse(JSON.stringify(body)));
+			return createCpaAlias500(CPA_ALIAS_FIND) as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+
+		const context = makeContext([userMessage("find me the config")], [findTool, searchTool, bashTool]);
+		const result = await streamAnthropic(model, context, { client }).result();
+
+		// Exactly 2 requests: the initial one and the single corrective retry.
+		// The generic 5xx budget (3 more blind resends) must never fire, and the
+		// terminal error must carry no status/transport facts so neither the
+		// provider nor the managed fallback controller re-sends.
+		expect(bodies).toHaveLength(2);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain(CPA_ALIAS_FIND);
+		expect(result.errorMessage).toContain("corrective retry was rejected again");
+		expect(result.errorMessage).toContain('callable tool name is "find"');
+		expect(result.errorMessage).toContain("The turn was not re-sent");
+		expect(result.errorMessage).not.toContain("cannot restore Claude OAuth MCP tool alias");
+		expect(result.errorStatus).toBeUndefined();
+		expect(result.transportFailure).toBeUndefined();
+	});
+
+	it("repairs a statusless SSE error event and still bounds the retry", async () => {
+		const bodies: unknown[] = [];
+		let attempt = 0;
+		const create = ((body: unknown) => {
+			bodies.push(JSON.parse(JSON.stringify(body)));
+			attempt += 1;
+			if (attempt === 1) return createStatuslessCpaAliasError(CPA_ALIAS_FIND) as never;
+			if (attempt === 2) return createCpaAlias500(CPA_ALIAS_SEARCH) as never;
+			return createSuccessfulRequest() as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+
+		const context = makeContext([userMessage("search for it")], [findTool, searchTool, bashTool]);
+		const result = await streamAnthropic(model, context, { client }).result();
+
+		// The first repair corrects `find`; the SECOND CPA failure (a different
+		// alias) is recurrence for this request and terminalizes — one corrective
+		// attempt per request, never a loop.
+		expect(bodies).toHaveLength(2);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain(CPA_ALIAS_SEARCH);
+	});
+
+	it("steers to direct discovery when no unique callable tool matches", async () => {
+		const bodies: unknown[] = [];
+		let attempt = 0;
+		const create = ((body: unknown) => {
+			bodies.push(JSON.parse(JSON.stringify(body)));
+			attempt += 1;
+			if (attempt === 1) return createCpaAlias500(CPA_ALIAS_FIND) as never;
+			return createSuccessfulRequest() as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+
+		// `find` is not offered in this request, so no deterministic callable
+		// name exists: the repair must direct the model at tool discovery instead
+		// of inventing a name.
+		const context = makeContext([userMessage("find me the config")], [searchTool, bashTool]);
+		const result = await streamAnthropic(model, context, { client }).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(bodies).toHaveLength(2);
+		const repaired = lastUserContent(bodies[1]);
+		expect(repaired).toContain("search_tool_bm25");
+		expect(repaired).not.toContain('The callable tool is "');
+	});
+
+	it("does not repair after partial content has streamed", async () => {
+		const bodies: unknown[] = [];
+		const create = ((body: unknown) => {
+			bodies.push(JSON.parse(JSON.stringify(body)));
+			return createPartialThenCpaAliasError(CPA_ALIAS_FIND) as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+
+		const context = makeContext([userMessage("find me the config")], [findTool, searchTool, bashTool]);
+		const result = await streamAnthropic(model, context, { client }).result();
+
+		// A token was already emitted: no corrective retry, no blind resend.
+		expect(bodies).toHaveLength(1);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("cannot restore Claude OAuth MCP tool alias");
+	});
+
+	it("leaves unrelated 500s on the generic retry path untouched", async () => {
+		const bodies: unknown[] = [];
+		const create = ((body: unknown) => {
+			bodies.push(JSON.parse(JSON.stringify(body)));
+			return createGeneric500() as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+
+		const context = makeContext([userMessage("hello")], [findTool, searchTool, bashTool]);
+		const result = await streamAnthropic(model, context, {
+			client,
+			providerRetryWait: async () => {},
+		}).result();
+
+		// Generic server errors keep their existing bounded retry behavior (1
+		// initial + 3 retries) and never pick up CPA steering.
+		expect(bodies).toHaveLength(4);
+		expect(result.stopReason).toBe("error");
+		for (const body of bodies) {
+			expect(JSON.stringify(body)).not.toContain("callable tool");
+		}
+	});
+});
+
+describe("CPA tool alias restore failure under managed fallback (issue #4338)", () => {
+	it("records steering for the same turn and converges on the next managed attempt", async () => {
+		const bodies: unknown[] = [];
+		let attempt = 0;
+		const create = ((body: unknown) => {
+			bodies.push(JSON.parse(JSON.stringify(body)));
+			attempt += 1;
+			if (attempt === 1) return createCpaAlias500(CPA_ALIAS_FIND) as never;
+			return createSuccessfulRequest() as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+		const providerSessionState = new Map<string, ProviderSessionState>();
+
+		const context = makeContext([userMessage("find me the config")], [findTool, searchTool, bashTool]);
+		const options = { client, fallbackManaged: true, providerSessionState };
+
+		const first = await streamAnthropic(model, context, options).result();
+		// The managed controller owns retries: the provider surfaces the raw
+		// error after exactly one request, carrying server-class transport facts
+		// so the controller retries the turn.
+		expect(first.stopReason).toBe("error");
+		expect(bodies).toHaveLength(1);
+		expect(lastUserContent(bodies[0])).not.toContain("callable tool");
+		expect(first.transportFailure?.status).toBe(500);
+
+		const second = await streamAnthropic(model, context, options).result();
+		// The next managed attempt rebuilt the same turn with the recorded
+		// corrective steering and succeeded.
+		expect(second.stopReason).toBe("stop");
+		expect(bodies).toHaveLength(2);
+		expect(lastUserContent(bodies[1])).toContain('The callable tool is "find"');
+
+		// A later turn with a different user prompt must not inherit the stale
+		// steering: the successful stream released it.
+		const nextTurn = await streamAnthropic(
+			model,
+			makeContext([userMessage("different turn")], [findTool]),
+			options,
+		).result();
+		expect(nextTurn.stopReason).toBe("stop");
+		expect(bodies).toHaveLength(3);
+		expect(lastUserContent(bodies[2])).not.toContain("callable tool");
+	});
+
+	it("terminalizes on recurrence after the steering was already applied", async () => {
+		const bodies: unknown[] = [];
+		const create = ((body: unknown) => {
+			bodies.push(JSON.parse(JSON.stringify(body)));
+			return createCpaAlias500(CPA_ALIAS_FIND) as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+		const providerSessionState = new Map<string, ProviderSessionState>();
+
+		const context = makeContext([userMessage("find me the config")], [findTool, searchTool, bashTool]);
+		const options = { client, fallbackManaged: true, providerSessionState };
+
+		const first = await streamAnthropic(model, context, options).result();
+		expect(first.stopReason).toBe("error");
+		expect(bodies).toHaveLength(1);
+
+		const second = await streamAnthropic(model, context, options).result();
+		// The second attempt consumed the recorded steering and was rejected
+		// again: the actionable terminal error must surface with no transport
+		// facts so the fallback controller does not re-send unchanged.
+		expect(bodies).toHaveLength(2);
+		expect(lastUserContent(bodies[1])).toContain('The callable tool is "find"');
+		expect(second.stopReason).toBe("error");
+		expect(second.errorMessage).toContain("corrective retry was rejected again");
+		expect(second.errorStatus).toBeUndefined();
+		expect(second.transportFailure).toBeUndefined();
+	});
+
+	it("does not repair a managed attempt that shares no session state", async () => {
+		const bodies: unknown[] = [];
+		const create = ((body: unknown) => {
+			bodies.push(JSON.parse(JSON.stringify(body)));
+			return createCpaAlias500(CPA_ALIAS_FIND) as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+
+		const context = makeContext([userMessage("find me the config")], [findTool, searchTool, bashTool]);
+		const result = await streamAnthropic(model, context, { client, fallbackManaged: true }).result();
+
+		expect(bodies).toHaveLength(1);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("cannot restore Claude OAuth MCP tool alias");
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #4338: CPA's Claude-OAuth layer cloaks downstream tool names into `mcp__<server>__<token>_<base>` aliases upstream. When the model drifts a single character in the 12-char random token segment, CPA cannot restore the tool name and kills the whole stream with an HTTP 500 SSE `error` event. The generic "status >= 500 is retryable" path then blindly re-sends the unchanged ~160 KB request, re-sampling the same drift until the turn dies as an opaque `api_error` — the loop's own "tool not found → discover" repair never fires because the malformed call is discarded at the proxy.

This PR classifies the exact machine-parseable signature and performs **one bounded corrective retry** instead of the blind resend:

- `isCpaToolAliasRestoreFailure` / `parseCpaToolAliasRestoreFailure` (next to the other CPA classifiers in `packages/ai/src/providers/anthropic.ts`) claim the exact `cannot restore Claude OAuth MCP tool alias "<alias>": no unique request-local match` phrase on HTTP 5xx or statusless in-stream SSE error events, extracting `<alias>` → base name (`mcp__<server>__<token>_<base>` → `<base>`).
- On match, the request is corrected **exactly once** with steering that names the unique request-local callable tool (resolved by exact wire-name match against `params.tools` — never a guess). When no unique match exists, the steering directs the model at tool discovery (`search_tool_bm25`) instead of inventing a name.
- If the signature recurs, the turn terminalizes with an actionable, sanitized error naming the tool and the proxy — deliberately statusless so neither the provider generic 5xx retry nor the managed fallback controller re-sends an unchanged request (no generic retry multiplication).
- Managed (fallback-chain) attempts keep the "controller owns retries" invariant: the steering is recorded in provider session state against a fingerprint of the exact turn, the controller's next attempt rebuilds the same turn corrected, a later turn with a different prompt expires it, and a successful stream releases it.

**Boundary decision (from code ownership):** provider request retry in `streamAnthropic`, alongside the existing thinking-signature / masked-proxy / cache-breakpoint / fast-mode repairs. The agent loop never sees the malformed call (it dies at the proxy), and the request-local `params.tools` is the wire-accurate registry, so a loop-level or registry-level mapping would be a second, redundant boundary.

## Red-team matrix

| Case | Behavior | Test |
| --- | --- | --- |
| Exact quoted 500 SSE signature; base extraction (`find`, `search`, `todo_write`) | Classified; base extracted; underscore-bearing bases preserved | `anthropic-cpa-tool-alias-recovery.test.ts` |
| Statusless in-stream SSE error event form | Classified (CPA delivers error bodies as SSE events) | same |
| Malformed alias (no `_<base>` tail) | Classified but no base name → discovery path, never a guess | same |
| Unrelated 500s (masked `api_error`, thinking 400s, non-5xx statuses, non-Error inputs) | Not claimed; stay on their existing classifiers/paths | same |
| Exactly one corrective attempt; recurrence terminalization | 2 requests max per request; terminal error, no 3rd blind resend | same |
| No generic retry multiplication | CPA signature never reaches the generic 5xx branch; unrelated 500s keep their existing bounded 4-attempt behavior (regression-guarded) | same |
| Partial stream boundaries | Repair only before `firstTokenTime`; a post-token failure surfaces raw | same |
| Ambiguous / no request-local match | Exact singular wire-name match only; zero/multiple → discovery steering, never a name guess | same |
| Deferred vs surfaced tools / `customWireName` | All tools are in `params.tools` (GJC sends the full list; `defer_loading` is CPA-injected); Anthropic conversion uses `tool.name`, never `customWireName`; matching is against the actual wire names | same |
| Existing repairs stay non-overlapping | Disjoint signatures; thinking/masked/cache suites unchanged (56 adjacent tests pass) | full adjacent suite run |
| Actionable sanitized terminal error | Quotes only the rejected alias + callable name; statusless so no request dump; no headers/body | same |

## Verification

- `bun --cwd=packages/ai run check` — biome + `tsc` clean.
- New suite `packages/ai/test/anthropic-cpa-tool-alias-recovery.test.ts` — 14 tests, all pass (classifier matrix, one-shot repair, recurrence terminalization, managed record/apply/release/expiry, partial-stream guard, unrelated-500 regression, no-state managed fallthrough).
- Adjacent suites: `anthropic-thinking-repair-retry`, `anthropic-thinking-immutability`, `anthropic-managed-thinking-repair`, `anthropic-cache`, `anthropic-stream-envelope` — 86 tests pass.
- Full `packages/ai/test/` run shows no new failures vs the pristine base (the 58 failures are pre-existing/environmental — auth-broker port binding, fake-timer contention, and an `api.layofflabs.com` env override in this environment; verified identical on the unmodified base).
- Rebased onto current `origin/dev` (`759811d139`); the 6 drifted commits since the integration base are ACP/session-CLI only and do not touch `packages/ai/`.

Not tested: a live CPA proxy round-trip (no CPA environment available); synthetic fixtures are derived only from the public issue signature.

Closes #4338

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*