### PR TITLE
fix(session): defer managed identity adoption in moveTo when no destination transcript exists

### DIFF
--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -10369,7 +10369,13 @@ export class SessionManager {
 			managedMove && managedDestinationStore
 				? { directory: path.resolve(newSessionDir), store: managedDestinationStore }
 				: null;
-		this.#adoptManagedPersistIdentity(this.#sessionFile);
+		// A transcript is only guaranteed to exist at the destination when the old file was
+		// actually present and moved (hadSessionFile). Absent/fresh/deleted-source sessions
+		// have no destination transcript yet, so adopting a strict expected identity here
+		// would invent identity for a nonexistent file; defer adoption until the first real
+		// publication (#writeEntriesAtomicallySync / #appendManagedRecordsSync) instead.
+		if (hadSessionFile) this.#adoptManagedPersistIdentity(this.#sessionFile);
+		else this.#managedPersistExpectedIdentity = undefined;
 
 		const hasAssistant = this.#fileEntries.some(e => e.type === "message" && e.message.role === "assistant");
 		try {
@@ -10406,7 +10412,10 @@ export class SessionManager {
 					managedMove && managedSourceStore
 						? { directory: path.resolve(previousSessionDir), store: managedSourceStore }
 						: null;
-				this.#adoptManagedPersistIdentity(previousSessionFile);
+				// Same rationale as the forward path: only adopt strict identity when the source
+				// transcript actually existed (and was thus restorable) before the failed move.
+				if (hadSessionFile) this.#adoptManagedPersistIdentity(previousSessionFile);
+				else this.#managedPersistExpectedIdentity = undefined;
 				const header = this.#fileEntries.find(entry => entry.type === "session") as SessionHeader | undefined;
 				if (header) applyHeaderPatch(header, { cwd: previousCwd });
 				this.#headerExportRevision++;


### PR DESCRIPTION
## Problem

Current `dev` had four deterministic `SessionManager.moveTo` regressions throwing `managed_persist_identity_unavailable` while moving sessions whose destination transcript is absent/fresh/deleted:

- moves an artifact directory without pre-creating the copy destination
- succeeds on fresh session without ENOENT, then deferred persistence works
- recreates file from memory when old file is deleted
- moves artifact dir independently when session file does not exist

The failure occurred in `#adoptManagedPersistIdentity` when `descriptorExpected(path.basename(sessionFile))` returned no descriptor, because `moveTo` unconditionally adopted managed persist identity for the destination `sessionFile` even when no transcript had actually been published there yet.

## Fix

Guard both the forward adoption (after a successful move) and the rollback adoption (after a failed move) in `moveTo` on `hadSessionFile` — the existing flag that already tracks whether a transcript genuinely existed at the source and was moved/is restorable:

- When `hadSessionFile` is true, adopt strict expected identity as before (unchanged behavior for the common "session file existed and moved" path).
- When `hadSessionFile` is false, clear `#managedPersistExpectedIdentity` instead of throwing. The first real publication (`#writeEntriesAtomicallySync` via `replaceSync`/`publishNoReplace`, or `#appendManagedRecordsSync` via `appendSync`) establishes identity normally through the existing publish-then-adopt code paths that already handle the "no expected identity yet" case.

This preserves strict identity/TOCTOU authority: no identity is ever invented for a nonexistent file, and once a file is actually published, expected-identity is captured from that publication's real descriptor exactly as before. No duplicate append, artifact loss, or cross-session adoption is introduced — the change is scoped to skipping a premature adoption call, not to any publish/append/replace logic.

Distinct from #4330 (Windows transient namespace replacement / sharing-violation retries): this is identity adoption after valid move/recreation semantics, not a Windows sharing violation retry.

## Testing

- `bun test packages/coding-agent/test/session-manager/move-to.test.ts` — 21/21 pass (was 17 pass / 4 fail before the fix, reproducing exactly the four issue scenarios)
- `bun test packages/coding-agent/test/session-manager/ packages/coding-agent/test/session/` — 657 pass, 24 skip, 3 fail. The 3 failures are in `worktree-continue.test.ts` (`Managed transcript escaped its session directory` in `openExistingStrict`/`hydrateExistingSession`, unrelated resume/open code path) and were confirmed present on baseline `dev` HEAD `94f48b7758` without this change (verified via `git stash` before/after comparison).
- `bun test packages/coding-agent/test/sdk-move-cwd.test.ts packages/coding-agent/test/session-resident-lifecycle.test.ts packages/coding-agent/test/session-manager/title-source-persistence.test.ts packages/coding-agent/test/session-manager/symlinked-root.test.ts packages/coding-agent/test/session-manager/windows-canonical-path.test.ts packages/coding-agent/test/sdk-session-directory.windows.test.ts packages/coding-agent/test/sdk-session-index-fsync.windows.test.ts packages/coding-agent/test/session/managed-lock-lease.windows.test.ts packages/coding-agent/test/session-manager/session-durability-windows.test.ts packages/coding-agent/test/session/resident-cache-win32-gate.windows.test.ts` — 39 pass, 11 skip (platform-gated on Linux), 0 fail
- `bun --cwd=packages/coding-agent run check` — exit 0 (only 7 pre-existing lint warnings unrelated to this file)

Closes #4341
