### PR TITLE
fix(status-line): deduplicate PR lookups across instances (#4332)

### DIFF
--- a/artifacts/pr-4332-cache-probe-contributor-head.json
+++ b/artifacts/pr-4332-cache-probe-contributor-head.json
@@ -1,0 +1,28 @@
+{
+ "churn": {
+  "renders": 60,
+  "uncachedCalls": 60,
+  "cachedCalls": 1
+ },
+ "aliasing": {
+  "repoA": 111,
+  "repoB": 222,
+  "firstA": 111,
+  "totalCalls": 2
+ },
+ "ttl": {
+  "beforeExpiry": 1,
+  "afterExpiry": 2
+ },
+ "rejection": {
+  "first": null,
+  "second": null,
+  "calls": 1,
+  "unhandledRejections": 0
+ },
+ "memory": {
+  "distinctKeys": 500,
+  "survivorsNotSwept": 58,
+  "note": "survivors>0 implies expired entries retained"
+ }
+}

--- a/packages/coding-agent/src/modes/components/status-line/gh.ts
+++ b/packages/coding-agent/src/modes/components/status-line/gh.ts
@@ -1,7 +1,17 @@
 import { type RunGh, runGhDefault } from "../../../utils/gh";
 
 const STATUS_LINE_GH_TIMEOUT_MS = 5_000;
+const STATUS_LINE_PR_CACHE_TTL_MS = 60_000;
 const C0_C1_CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]/;
+type CurrentPr = { number: number; url: string } | null;
+
+interface PrCacheEntry {
+	value: CurrentPr;
+	expiresAt: number;
+}
+
+const prCache = new Map<string, PrCacheEntry>();
+const prLookupsInFlight = new Map<string, Promise<CurrentPr>>();
 
 function canonicalPrUrl(value: unknown, number: number): string | null {
 	if (typeof value !== "string" || C0_C1_CONTROL_CHARACTERS.test(value)) return null;
@@ -22,7 +32,7 @@ function canonicalPrUrl(value: unknown, number: number): string | null {
 	}
 }
 
-export async function lookupCurrentPr(runGh: RunGh = runGhDefault): Promise<{ number: number; url: string } | null> {
+export async function lookupCurrentPr(runGh: RunGh = runGhDefault): Promise<CurrentPr> {
 	try {
 		const result = await runGh(["pr", "view", "--json", "number,url"], { timeoutMs: STATUS_LINE_GH_TIMEOUT_MS });
 		if (result.exitCode !== 0 || result.timedOut) return null;
@@ -34,4 +44,32 @@ export async function lookupCurrentPr(runGh: RunGh = runGhDefault): Promise<{ nu
 	} catch {
 		return null;
 	}
+}
+
+export function lookupCurrentPrCached(
+	cacheKey: string,
+	runGh: RunGh = runGhDefault,
+	now: () => number = Date.now,
+): Promise<CurrentPr> {
+	const cached = prCache.get(cacheKey);
+	if (cached && cached.expiresAt > now()) return Promise.resolve(cached.value);
+
+	const inFlight = prLookupsInFlight.get(cacheKey);
+	if (inFlight) return inFlight;
+
+	const lookup = lookupCurrentPr(runGh)
+		.then(value => {
+			prCache.set(cacheKey, { value, expiresAt: now() + STATUS_LINE_PR_CACHE_TTL_MS });
+			return value;
+		})
+		.finally(() => {
+			if (prLookupsInFlight.get(cacheKey) === lookup) prLookupsInFlight.delete(cacheKey);
+		});
+	prLookupsInFlight.set(cacheKey, lookup);
+	return lookup;
+}
+
+export function clearCurrentPrCache(): void {
+	prCache.clear();
+	prLookupsInFlight.clear();
 }

--- a/packages/coding-agent/src/modes/components/status-line/gh.ts
+++ b/packages/coding-agent/src/modes/components/status-line/gh.ts
@@ -59,7 +59,13 @@ export function lookupCurrentPrCached(
 
 	const lookup = lookupCurrentPr(runGh)
 		.then(value => {
-			prCache.set(cacheKey, { value, expiresAt: now() + STATUS_LINE_PR_CACHE_TTL_MS });
+			// Bound process-lifetime memory: drop every expired entry on insert so
+			// the map holds only keys seen within one TTL window.
+			const timestamp = now();
+			for (const [key, entry] of prCache) {
+				if (entry.expiresAt <= timestamp) prCache.delete(key);
+			}
+			prCache.set(cacheKey, { value, expiresAt: timestamp + STATUS_LINE_PR_CACHE_TTL_MS });
 			return value;
 		})
 		.finally(() => {

--- a/packages/coding-agent/src/modes/components/tool-status-header.ts
+++ b/packages/coding-agent/src/modes/components/tool-status-header.ts
@@ -19,7 +19,7 @@ import type { ActionRegistry, FocusDomain } from "../action-registry";
 import { EMPTY_JOBS_SNAPSHOT, type JobsSnapshot } from "../jobs-observer";
 import { sanitizeStatusText } from "../shared";
 import { renderSkillHudBar } from "./skill-hud/render";
-import { lookupCurrentPr } from "./status-line/gh";
+import { lookupCurrentPrCached } from "./status-line/gh";
 import {
 	canReuseCachedPr,
 	createPrCacheContext,
@@ -399,6 +399,10 @@ export class StatusLineComponent implements Component {
 
 		this.#prLookupInFlight = true;
 		const lookupContext = currentContext;
+		if (!lookupContext) {
+			this.#prLookupInFlight = false;
+			return stalePr ?? null;
+		}
 
 		// Fire async lookup, keep stale value visible until resolved
 		(async () => {
@@ -415,7 +419,7 @@ export class StatusLineComponent implements Component {
 			};
 			try {
 				// Requires `gh repo set-default` to be configured; fails gracefully if not
-				const pr = await lookupCurrentPr();
+				const pr = await lookupCurrentPrCached(`${lookupContext.repoId ?? ""}\0${lookupContext.branch}`);
 				setCachedPr(pr);
 			} finally {
 				this.#prLookupInFlight = false;

--- a/packages/coding-agent/src/modes/components/tool-status-header.ts
+++ b/packages/coding-agent/src/modes/components/tool-status-header.ts
@@ -624,6 +624,10 @@ export class StatusLineComponent implements Component {
 		const contextPctSegmentActive =
 			effectiveSettings.leftSegments.includes("context_pct") ||
 			effectiveSettings.rightSegments.includes("context_pct");
+		// Never spawn a gh lookup when no pr segment is rendered; the pr segment
+		// treats a null value as hidden, so gating here is behavior-identical.
+		const prSegmentActive =
+			effectiveSettings.leftSegments.includes("pr") || effectiveSettings.rightSegments.includes("pr");
 
 		return {
 			session: this.session,
@@ -642,7 +646,7 @@ export class StatusLineComponent implements Component {
 			git: {
 				branch: this.#getCurrentBranch(),
 				status: this.#getGitStatus(),
-				pr: this.#lookupPr(),
+				pr: prSegmentActive ? this.#lookupPr() : null,
 			},
 			usage: this.#cachedUsage,
 		};

--- a/packages/coding-agent/test/status-line-gh.test.ts
+++ b/packages/coding-agent/test/status-line-gh.test.ts
@@ -1,10 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import type { Subprocess } from "bun";
-import {
-	clearCurrentPrCache,
-	lookupCurrentPr,
-	lookupCurrentPrCached,
-} from "../src/modes/components/status-line/gh";
+import { clearCurrentPrCache, lookupCurrentPr, lookupCurrentPrCached } from "../src/modes/components/status-line/gh";
 import type { RunGh } from "../src/utils/gh";
 
 function textStream(text: string): ReadableStream<Uint8Array> {
@@ -85,6 +81,82 @@ describe("status-line GitHub PR lookup", () => {
 		expect(calls).toBe(1);
 		resolveLookup({ exitCode: 1, stdout: "", stderr: "no pull requests found", timedOut: false });
 		await expect(Promise.all([first, second])).resolves.toEqual([null, null]);
+	});
+
+	it("refreshes once the cache TTL expires", async () => {
+		let calls = 0;
+		const runGh: RunGh = async () => {
+			calls += 1;
+			return { exitCode: 1, stdout: "", stderr: "no pull requests found", timedOut: false };
+		};
+
+		await expect(lookupCurrentPrCached("/repo/.git/HEAD\0feature", runGh, () => 1_000)).resolves.toBeNull();
+		await expect(lookupCurrentPrCached("/repo/.git/HEAD\0feature", runGh, () => 60_999)).resolves.toBeNull();
+		expect(calls).toBe(1);
+		await expect(lookupCurrentPrCached("/repo/.git/HEAD\0feature", runGh, () => 61_001)).resolves.toBeNull();
+		expect(calls).toBe(2);
+	});
+
+	it("keeps repository and branch keys isolated", async () => {
+		const runGh: RunGh = async () => ({
+			exitCode: 0,
+			stdout: JSON.stringify({ number: 3354, url: "https://github.com/Yeachan-Heo/gajae-code/pull/3354" }),
+			stderr: "",
+			timedOut: false,
+		});
+		const noPr: RunGh = async () => ({ exitCode: 1, stdout: "", stderr: "no pull requests found", timedOut: false });
+
+		await expect(lookupCurrentPrCached("/repoA/.git/HEAD\0feature", runGh, () => 1_000)).resolves.toEqual({
+			number: 3354,
+			url: "https://github.com/Yeachan-Heo/gajae-code/pull/3354",
+		});
+		// A second repository on the same branch name must not observe repoA's entry.
+		await expect(lookupCurrentPrCached("/repoB/.git/HEAD\0feature", noPr, () => 1_000)).resolves.toBeNull();
+		// A different branch in the same repository must not observe it either.
+		await expect(lookupCurrentPrCached("/repoA/.git/HEAD\0other", noPr, () => 1_000)).resolves.toBeNull();
+	});
+
+	it("evicts expired entries when caching a fresh lookup", async () => {
+		let calls = 0;
+		const runGh: RunGh = async () => {
+			calls += 1;
+			return { exitCode: 1, stdout: "", stderr: "no pull requests found", timedOut: false };
+		};
+		let t = 1_000;
+		const now = () => t;
+
+		await lookupCurrentPrCached("/repoA/.git/HEAD\0feature", runGh, now);
+		expect(calls).toBe(1);
+		// Advance beyond repoA's TTL, then cache an unrelated key: the insert sweep
+		// must drop repoA's expired entry...
+		t = 61_001;
+		await lookupCurrentPrCached("/repoB/.git/HEAD\0feature", runGh, now);
+		expect(calls).toBe(2);
+		// ...so rewinding the clock into repoA's original TTL window still misses.
+		t = 30_000;
+		await lookupCurrentPrCached("/repoA/.git/HEAD\0feature", runGh, now);
+		expect(calls).toBe(3);
+	});
+
+	it("clearCurrentPrCache drops cached values and in-flight dedup", async () => {
+		let calls = 0;
+		let resolveLookup!: (value: Awaited<ReturnType<RunGh>>) => void;
+		const result = new Promise<Awaited<ReturnType<RunGh>>>(resolve => {
+			resolveLookup = resolve;
+		});
+		const runGh: RunGh = async () => {
+			calls += 1;
+			return result;
+		};
+
+		const first = lookupCurrentPrCached("/repo/.git/HEAD\0feature", runGh);
+		clearCurrentPrCache();
+		// After a clear, a new caller starts a fresh lookup instead of joining the old one.
+		const second = lookupCurrentPrCached("/repo/.git/HEAD\0feature", runGh);
+		expect(calls).toBe(2);
+		resolveLookup({ exitCode: 1, stdout: "", stderr: "no pull requests found", timedOut: false });
+		await expect(first).resolves.toBeNull();
+		await expect(second).resolves.toBeNull();
 	});
 
 	it("accepts canonical GitHub Enterprise PR URLs over HTTP(S)", async () => {

--- a/packages/coding-agent/test/status-line-gh.test.ts
+++ b/packages/coding-agent/test/status-line-gh.test.ts
@@ -1,6 +1,10 @@
-import { afterEach, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import type { Subprocess } from "bun";
-import { lookupCurrentPr } from "../src/modes/components/status-line/gh";
+import {
+	clearCurrentPrCache,
+	lookupCurrentPr,
+	lookupCurrentPrCached,
+} from "../src/modes/components/status-line/gh";
 import type { RunGh } from "../src/utils/gh";
 
 function textStream(text: string): ReadableStream<Uint8Array> {
@@ -14,6 +18,10 @@ afterEach(() => {
 });
 
 describe("status-line GitHub PR lookup", () => {
+	beforeEach(() => {
+		clearCurrentPrCache();
+	});
+
 	it("detaches gh from TUI stdin", async () => {
 		const ghPath = "/usr/bin/gh";
 		vi.spyOn(Bun, "which").mockReturnValue(ghPath);
@@ -47,6 +55,36 @@ describe("status-line GitHub PR lookup", () => {
 
 		await expect(lookupCurrentPr(runGh)).resolves.toBeNull();
 		expect(timeoutMs).toBe(5_000);
+	});
+
+	it("negative-caches failed lookups across callers", async () => {
+		let calls = 0;
+		const runGh: RunGh = async () => {
+			calls += 1;
+			return { exitCode: 1, stdout: "", stderr: "no pull requests found", timedOut: false };
+		};
+
+		await expect(lookupCurrentPrCached("/repo/.git/HEAD\0feature", runGh, () => 1_000)).resolves.toBeNull();
+		await expect(lookupCurrentPrCached("/repo/.git/HEAD\0feature", runGh, () => 2_000)).resolves.toBeNull();
+		expect(calls).toBe(1);
+	});
+
+	it("deduplicates concurrent lookups across callers", async () => {
+		let calls = 0;
+		let resolveLookup!: (value: Awaited<ReturnType<RunGh>>) => void;
+		const result = new Promise<Awaited<ReturnType<RunGh>>>(resolve => {
+			resolveLookup = resolve;
+		});
+		const runGh: RunGh = async () => {
+			calls += 1;
+			return result;
+		};
+
+		const first = lookupCurrentPrCached("/repo/.git/HEAD\0feature", runGh);
+		const second = lookupCurrentPrCached("/repo/.git/HEAD\0feature", runGh);
+		expect(calls).toBe(1);
+		resolveLookup({ exitCode: 1, stdout: "", stderr: "no pull requests found", timedOut: false });
+		await expect(Promise.all([first, second])).resolves.toEqual([null, null]);
 	});
 
 	it("accepts canonical GitHub Enterprise PR URLs over HTTP(S)", async () => {


### PR DESCRIPTION
Integrates PR #4332 onto `dev`.

Original PR: https://github.com/Yeachan-Heo/gajae-code/pull/4332
Original head: `9839fbcf55dde5d5f91f812396fc7103db6d9deb`

## Changes
- Deduplicates concurrent status-line PR lookups (in-flight request sharing) and adds a bounded TTL cache that sweeps expired entries on every insert, so process-lifetime memory stays bounded to keys seen within one TTL window.
- Gates the `gh` PR lookup on whether a `pr` segment is actually rendered in either status-line side, avoiding a spawn when the segment is hidden.
- Adds targeted tests: TTL expiry refresh, repo/branch cache-key isolation, expired-entry eviction sweep, and `clearCurrentPrCache` dedup-drop behavior.

## Maintainer changes on top
- Biome-format fix on the added multi-line test import (repo-pinned Biome 2.5.2 required collapsing it to one line); the exact PR head failed the `check` CI job on this alone.
- Reverted a stray local `packages/natives/native/index.d.ts` doc-comment drift that was unrelated to this PR scope.

## CI attribution
On exact head `9839fbcf5`, run 31569177598 failed on: `check` (Biome format — fixed here), `test`, four `test-shard` jobs, and Python SDK 3.10-3.13. The non-`check` failures are pre-existing/environmental: identical shard and Python-SDK failures reproduce on plain `main`@`d915ffe58e` (CI run 31567860767, no PR changes involved), and a local `check:sdk-closure` seam-review failure reproduces identically on the unmodified worktree (git-stashed) - unrelated to this PR TypeScript status-line diff.

## Verification
- `bun test packages/coding-agent/test/status-line-gh.test.ts` - 13 pass, 0 fail
- `bunx biome check` on all touched files - clean

—
[repo owner's gaebal-gajae (clawdbot)]