### PR TITLE
fix(ai): reject tool arguments that spell non-ASCII text as \uXXXX escapes

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The agent loop rejects a tool call flagged `escapedNonAsciiArguments` before execution, with a retryable error telling the model to re-issue the call writing non-ASCII characters literally. Hand-spelled `\uXXXX` arguments decode into valid-looking but silently wrong text (observed as garbled Hangul in `ask` prompts), and no post-parse repair can recover the intended characters.
+
 ### Added
 
 - Reassignable `onFollowUpConsumed` hook on `Agent`: invoked with the follow-up messages the loop dequeues for the next turn, so consumers can attach per-turn state (e.g. a fresh owned-completion lineage) at actual resume admission.

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -820,6 +820,7 @@ function managedAssistantContent(value: unknown): AssistantMessage["content"][nu
 	const customWireName = managedProperty(value, "customWireName");
 	const incompleteArguments = managedProperty(value, "incompleteArguments");
 	const incompleteArgumentsReason = managedProperty(value, "incompleteArgumentsReason");
+	const escapedNonAsciiArguments = managedProperty(value, "escapedNonAsciiArguments");
 	return {
 		type,
 		id,
@@ -838,6 +839,7 @@ function managedAssistantContent(value: unknown): AssistantMessage["content"][nu
 						| "ambiguous",
 				}
 			: {}),
+		...(typeof escapedNonAsciiArguments === "boolean" ? { escapedNonAsciiArguments } : {}),
 	};
 }
 
@@ -2826,6 +2828,20 @@ async function executeToolCalls(
 									? `The identity of tool call "${toolCall.name}" was ambiguous on the wire (duplicate call id or id/call_id collision), so its arguments cannot be safely attributed. Re-issue the call.`
 									: `Tool call "${toolCall.name}" was cut off before its arguments finished streaming (the response hit its output token limit). The partial arguments cannot be executed. Re-issue the call with complete arguments, splitting the work into smaller steps if needed.`;
 					throw new Error(detail);
+				}
+				if (toolCall.escapedNonAsciiArguments) {
+					record.argumentValidationFailed = true;
+					// The arguments decoded cleanly, but they were spelled as `\uXXXX`
+					// escapes rather than literal UTF-8. Hand-written hex is where models
+					// mistype digits, and every mistyped nibble decodes to a different but
+					// equally valid character — the payload is unverifiable and cannot be
+					// repaired after parsing, so it is rejected rather than executed on
+					// silently corrupted text.
+					throw new Error(
+						`Tool call "${toolCall.name}" spelled non-ASCII text as \\uXXXX escapes instead of literal UTF-8. ` +
+							`Escaped text cannot be verified — a single wrong hex digit silently becomes a different character — ` +
+							`so the call was not executed. Re-issue it writing every non-ASCII character literally.`,
+					);
 				}
 				if (!tool) {
 					// A discoverable tool that hasn't been activated yet resolves to

--- a/packages/agent/src/proxy.ts
+++ b/packages/agent/src/proxy.ts
@@ -13,7 +13,7 @@ import {
 	type ToolCall,
 } from "@gajae-code/ai";
 import { calculateCost } from "@gajae-code/ai/models";
-import { parseStreamingJson } from "@gajae-code/ai/utils/json-parse";
+import { findUnnecessaryUnicodeEscape, parseStreamingJson } from "@gajae-code/ai/utils/json-parse";
 import { readSseJson } from "@gajae-code/utils";
 
 // Create stream class matching ProxyMessageEventStream
@@ -379,6 +379,8 @@ function processProxyEvent(
 		case "toolcall_end": {
 			const content = partial.content[proxyEvent.contentIndex];
 			if (content?.type === "toolCall") {
+				const raw = (content as { partialJson?: string }).partialJson;
+				if (raw && findUnnecessaryUnicodeEscape(raw)) content.escapedNonAsciiArguments = true;
 				delete (content as any).partialJson;
 				return {
 					type: "toolcall_end",

--- a/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
+++ b/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+import { agentLoop } from "@gajae-code/agent-core/agent-loop";
+import type { AgentContext, AgentLoopConfig, AgentMessage, AgentTool } from "@gajae-code/agent-core/types";
+import type { Message } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import * as z from "zod/v4";
+import { createUserMessage } from "./helpers";
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(m => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
+}
+
+const askSchema = z.object({ question: z.string() });
+
+function askTool(executed: Array<Record<string, unknown>>): AgentTool<typeof askSchema, Record<string, never>> {
+	return {
+		name: "ask",
+		label: "Ask",
+		description: "Ask the user a question",
+		parameters: askSchema,
+		async execute(_id, params) {
+			executed.push(params as Record<string, unknown>);
+			return { content: [{ type: "text", text: "answered" }], details: {} };
+		},
+	};
+}
+
+describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
+	it("rejects a call whose arguments were spelled as \\uXXXX escapes without executing it", async () => {
+		const executed: Array<Record<string, unknown>> = [];
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [
+						{
+							type: "toolCall",
+							id: "tc-1",
+							name: "ask",
+							// Decodes cleanly, but a mistyped nibble anywhere in it would be
+							// indistinguishable from correct text.
+							arguments: { question: "마지막 병목" },
+							escapedNonAsciiArguments: true,
+						},
+					],
+				},
+				{ content: ["recovered"] },
+			],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const toolResults: Array<{ isError?: boolean; text: string }> = [];
+		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+		for await (const event of stream) {
+			if (event.type === "tool_execution_end") {
+				const first = event.result.content?.[0];
+				toolResults.push({ isError: event.isError, text: first?.type === "text" ? first.text : "" });
+			}
+		}
+
+		expect(executed).toHaveLength(0);
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0].isError).toBe(true);
+		expect(toolResults[0].text).toContain("\\uXXXX");
+		expect(toolResults[0].text).toContain("literal UTF-8");
+		expect(toolResults[0].text.toLowerCase()).toContain("re-issue");
+	});
+
+	it("executes literal UTF-8 arguments untouched", async () => {
+		const executed: Array<Record<string, unknown>> = [];
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tc-1", name: "ask", arguments: { question: "마지막 병목" } }] },
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+		for await (const _ of stream) {
+			// drain
+		}
+		expect(executed).toEqual([{ question: "마지막 병목" }]);
+	});
+});

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 - Anthropic streams now repair the CPA Claude-OAuth "cannot restore tool alias" 500 instead of blindly resending the unchanged request: the exact SSE signature is classified, the base tool name is extracted, and the request is corrected exactly once with steering that names the unique callable tool (or directs tool discovery when no unique match exists). Recurrence surfaces an actionable terminal error with no transport facts, so neither the provider generic 5xx retry nor the managed fallback controller re-sends; managed attempts record the steering against the same turn and the next attempt applies it (#4338).
-
+- Tool calls whose raw argument JSON spells a printable non-ASCII character as a `\uXXXX` escape instead of literal UTF-8 are now flagged with `ToolCall.escapedNonAsciiArguments`. Such a payload parses cleanly but is unverifiable — one mistyped hex digit decodes to a different, equally valid character — so the agent loop rejects it instead of executing silently corrupted text. Required control escapes and lone surrogates never trip the flag, and `\\uXXXX` (the source syntax of code being written) is not an escape and is ignored. New `findUnnecessaryUnicodeEscape` helper in `utils/json-parse`. The Kimi tool-call healer samples the signal from the raw leaked payload before its normalizing JSON round-trip, which would otherwise decode the escapes and erase the evidence.
 - Persist learned tool-choice incapabilities in a bounded, expiring, digest-keyed cache so fresh processes avoid repeating known-invalid forced-choice probes while retaining automatic revalidation and existing first-discovery fallback behavior. Credit: @probepark (#4319).
 
 ### Added

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -36,7 +36,7 @@ import { normalizeToolCallId, resolveCacheRetention, sanitizeJsonStrings } from 
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { transportFailureFacts } from "../utils/fallback-transport";
 import { appendRawHttpRequestDumpFor400, type RawHttpRequestDump, withHttpStatus } from "../utils/http-inspector";
-import { parseStreamingJson } from "../utils/json-parse";
+import { findUnnecessaryUnicodeEscape, parseStreamingJson } from "../utils/json-parse";
 import { resolveRetryBudget } from "../utils/retry-budget";
 import { flattenToolRootCombinators, toolWireSchema } from "../utils/schema";
 import {
@@ -597,6 +597,7 @@ function handleContentBlockStop(
 			break;
 		case "toolCall":
 			block.arguments = parseStreamingJson(block.partialJson);
+			if (findUnnecessaryUnicodeEscape(block.partialJson ?? "")) block.escapedNonAsciiArguments = true;
 			delete (block as Block).partialJson;
 			stream.push({ type: "toolcall_end", contentIndex: index, toolCall: block, partial: output });
 			break;

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -73,7 +73,12 @@ import {
 	getStreamIdleTimeoutMs,
 	iterateWithIdleTimeout,
 } from "../utils/idle-iterator";
-import { isCompleteJson, parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse";
+import {
+	findUnnecessaryUnicodeEscape,
+	isCompleteJson,
+	parseJsonWithRepair,
+	parseStreamingJson,
+} from "../utils/json-parse";
 import { parseGitHubCopilotApiKey } from "../utils/oauth/github-copilot";
 import { notifyProviderResponse } from "../utils/provider-response";
 import { isCopilotTransientModelError } from "../utils/retry";
@@ -1740,6 +1745,9 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 						}
 						if (orphaned.partialJson.trim()) {
 							orphaned.arguments = parseStreamingJson(orphaned.partialJson);
+							if (findUnnecessaryUnicodeEscape(orphaned.partialJson)) {
+								orphaned.escapedNonAsciiArguments = true;
+							}
 						}
 					}
 					delete (orphaned as { index?: number }).index;
@@ -2011,6 +2019,9 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 									if (!isCompleteJson(block.partialJson)) truncatedToolCalls.add(block);
 									if (block.partialJson.trim()) {
 										block.arguments = parseStreamingJson(block.partialJson);
+										if (findUnnecessaryUnicodeEscape(block.partialJson)) {
+											block.escapedNonAsciiArguments = true;
+										}
 									}
 									delete (block as { partialJson?: string }).partialJson;
 									stream.push({
@@ -2391,6 +2402,9 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 					truncatedToolCalls.add(block);
 					if (block.partialJson.trim()) {
 						block.arguments = parseStreamingJson(block.partialJson);
+						if (findUnnecessaryUnicodeEscape(block.partialJson)) {
+							block.escapedNonAsciiArguments = true;
+						}
 					}
 					delete (block as { partialJson?: string }).partialJson;
 				}

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -27,7 +27,7 @@ import type {
 } from "../types";
 import { normalizeSystemPrompts } from "../utils";
 import { AssistantMessageEventStream } from "../utils/event-stream";
-import { parseStreamingJson } from "../utils/json-parse";
+import { findUnnecessaryUnicodeEscape, parseStreamingJson } from "../utils/json-parse";
 import { formatErrorMessageWithRetryAfter } from "../utils/retry-after";
 import { flattenToolRootCombinators, toolWireSchema } from "../utils/schema";
 import { CURSOR_COMPOSER_EDIT_DISCIPLINE_PROMPT, isComposerHarnessModel } from "./composer-discipline";
@@ -564,6 +564,9 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			if (state.currentToolCall) {
 				const idx = output.content.indexOf(state.currentToolCall);
 				state.currentToolCall.arguments = parseStreamingJson(state.currentToolCall.partialJson);
+				if (findUnnecessaryUnicodeEscape(state.currentToolCall.partialJson ?? "")) {
+					state.currentToolCall.escapedNonAsciiArguments = true;
+				}
 				delete (state.currentToolCall as any).partialJson;
 				delete (state.currentToolCall as any).index;
 				stream.push({

--- a/packages/ai/src/providers/mock.ts
+++ b/packages/ai/src/providers/mock.ts
@@ -77,6 +77,8 @@ export type MockContent =
 			incompleteArguments?: boolean;
 			/** Typed reason matching `ToolCall.incompleteArgumentsReason`. Defaults to `"truncated"`. */
 			incompleteArgumentsReason?: "truncated" | "malformed" | "conflicting" | "ambiguous";
+			/** Simulate a provider-flagged `\uXXXX`-escaped non-ASCII argument payload. */
+			escapedNonAsciiArguments?: boolean;
 	  };
 /** One scripted response. */
 export interface MockResponse {
@@ -426,6 +428,7 @@ function normalizeContent(input: MockContent, state: MockModel): TextContent | T
 			...(input.incompleteArguments
 				? { incompleteArguments: true, incompleteArgumentsReason: input.incompleteArgumentsReason ?? "truncated" }
 				: {}),
+			...(input.escapedNonAsciiArguments ? { escapedNonAsciiArguments: true } : {}),
 		} as ToolCall;
 	}
 	return input;

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -18,7 +18,7 @@ import { normalizeSystemPrompts } from "../utils";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { transportFailureFacts } from "../utils/fallback-transport";
 import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
-import { isCompleteJson, parseStreamingJson } from "../utils/json-parse";
+import { findUnnecessaryUnicodeEscape, isCompleteJson, parseStreamingJson } from "../utils/json-parse";
 import { resolveRetryBudget } from "../utils/retry-budget";
 import { flattenToolRootCombinators, toolWireSchema } from "../utils/schema";
 import {
@@ -361,6 +361,9 @@ function endToolCallBlock(stream: AssistantMessageEventStream, output: Assistant
 	if (toolCall.partialJson !== undefined) {
 		if (toolCall.partialJson.trim()) {
 			toolCall.arguments = parseStreamingJson<Record<string, unknown>>(toolCall.partialJson);
+			if (findUnnecessaryUnicodeEscape(toolCall.partialJson)) {
+				toolCall.escapedNonAsciiArguments = true;
+			}
 		}
 		delete toolCall.partialJson;
 	}
@@ -550,6 +553,7 @@ export const streamOllama: StreamFunction<"ollama-chat"> = (
 							name,
 							arguments: parseStreamingJson<Record<string, unknown>>(partialJson),
 							partialJson,
+							...(findUnnecessaryUnicodeEscape(partialJson) ? { escapedNonAsciiArguments: true } : {}),
 						};
 						if (unverifiableArguments) unverifiableArgumentToolCallIds.add(toolCall.id);
 						output.content.push(toolCall);

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -57,7 +57,7 @@ import {
 	getStreamFirstEventTimeoutMs,
 	iterateWithIdleTimeout,
 } from "../utils/idle-iterator";
-import { parseStreamingJson } from "../utils/json-parse";
+import { findUnnecessaryUnicodeEscape, parseStreamingJson } from "../utils/json-parse";
 import { resolveRetryBudget } from "../utils/retry-budget";
 import {
 	adaptSchemaForStrict,
@@ -1276,6 +1276,7 @@ function handleToolCallArgumentsDone(
 	if (typeof args === "string") {
 		currentBlock.partialJson = args;
 		currentBlock.arguments = parseStreamingJson(currentBlock.partialJson);
+		if (findUnnecessaryUnicodeEscape(args)) currentBlock.escapedNonAsciiArguments = true;
 	}
 }
 
@@ -1391,6 +1392,7 @@ function handleOutputItemDone(
 			id,
 			name: codexToolCanonicalName(item.name),
 			arguments: parseStreamingJson(item.arguments || "{}"),
+			...(findUnnecessaryUnicodeEscape(item.arguments || "") ? { escapedNonAsciiArguments: true } : {}),
 		};
 		runtime.canSafelyReplayWebsocketOverSse = false;
 		stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -54,7 +54,7 @@ import {
 	iterateWithIdleTimeout,
 	resolveOpenAISdkRequestTimeoutMs,
 } from "../utils/idle-iterator";
-import { isCompleteJson, parseStreamingJson } from "../utils/json-parse";
+import { findUnnecessaryUnicodeEscape, isCompleteJson, parseStreamingJson } from "../utils/json-parse";
 import { parseGitHubCopilotApiKey } from "../utils/oauth/github-copilot";
 import { getKimiCommonHeaders } from "../utils/oauth/kimi";
 import { notifyProviderResponse } from "../utils/provider-response";
@@ -676,6 +676,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 					return;
 				}
 				block.arguments = parseStreamingJson(block.partialArgs);
+				if (findUnnecessaryUnicodeEscape(block.partialArgs ?? "")) block.escapedNonAsciiArguments = true;
 				delete (block as { partialArgs?: string }).partialArgs;
 				stream.push({ type: "toolcall_end", contentIndex, toolCall: block, partial: output });
 			};
@@ -804,6 +805,9 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 					partialArgs: call.arguments,
 				};
 				block.arguments = parseStreamingJson(call.arguments);
+				// The healer already normalized `call.arguments`, decoding any escapes away,
+				// so the signal has to come from its pre-round-trip sample of the raw payload.
+				if (call.escapedNonAsciiArguments) block.escapedNonAsciiArguments = true;
 				currentBlock = block;
 				output.content.push(block);
 				stream.push({ type: "toolcall_start", contentIndex: blockIndex(block), partial: output });

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -30,7 +30,7 @@ import {
 } from "../types";
 import { normalizeResponsesToolCallId, sanitizeJsonStrings } from "../utils";
 import type { AssistantMessageEventStream } from "../utils/event-stream";
-import { isCompleteJson, parseStreamingJson } from "../utils/json-parse";
+import { findUnnecessaryUnicodeEscape, isCompleteJson, parseStreamingJson } from "../utils/json-parse";
 import { areJsonValuesEqual } from "../utils/schema";
 import { joinTextWithImagePlaceholder, NON_VISION_IMAGE_PLACEHOLDER, partitionVisionContent } from "./vision-guard";
 
@@ -865,17 +865,21 @@ export async function processResponsesStream<TApi extends Api>(
 							? "conflicting"
 							: "malformed"
 					: undefined;
+				const escapedNonAscii = findUnnecessaryUnicodeEscape(rawArguments) !== undefined;
 				const toolCall: ToolCall = {
 					type: "toolCall",
 					id: encodeResponsesToolCallId(item.call_id, item.id),
 					name: item.name,
 					arguments: args,
 					...(incompleteArguments ? { incompleteArguments: true, incompleteArgumentsReason } : {}),
+					...(escapedNonAscii ? { escapedNonAsciiArguments: true } : {}),
 				};
 				if (entry?.block.type === "toolCall") {
 					entry.block.id = toolCall.id;
 					entry.block.name = toolCall.name;
 					entry.block.arguments = args;
+					if (escapedNonAscii) entry.block.escapedNonAsciiArguments = true;
+					else delete entry.block.escapedNonAsciiArguments;
 					if (incompleteArguments) {
 						entry.block.incompleteArguments = true;
 						entry.block.incompleteArgumentsReason = incompleteArgumentsReason;

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -602,6 +602,16 @@ export interface ToolCall {
 	 * `incompleteArguments` continue to work.
 	 */
 	incompleteArgumentsReason?: "truncated" | "malformed" | "conflicting" | "ambiguous";
+	/**
+	 * Set when the raw argument JSON spelled a printable non-ASCII character as a
+	 * `\uXXXX` escape instead of literal UTF-8. Such a payload parses cleanly but
+	 * is unverifiable: one mistyped hex digit decodes to a different, equally
+	 * valid character, so the text can be silently wrong with no in-band evidence.
+	 * The agent loop rejects the call with a retryable error instead of executing
+	 * it. Escapes that are required (control characters) or unavoidable (lone
+	 * surrogates) never set this.
+	 */
+	escapedNonAsciiArguments?: boolean;
 }
 
 export interface Usage {

--- a/packages/ai/src/utils/json-parse.ts
+++ b/packages/ai/src/utils/json-parse.ts
@@ -110,6 +110,86 @@ export function repairJson(json: string): string {
 	return parts.join("");
 }
 
+/**
+ * First unnecessary `\uXXXX` escape in a JSON document, or `undefined` when the
+ * document contains none.
+ *
+ * "Unnecessary" means the escape encodes a character JSON can carry literally:
+ * any non-ASCII printable character. Control characters (< U+0020) MUST be
+ * escaped, and an unpaired surrogate CANNOT be written literally, so neither
+ * counts. A `\\uXXXX` sequence is a literal backslash followed by `u` — the
+ * intended source syntax when the model is writing code or a nested JSON
+ * document — and is skipped, which is why this scans the raw text with the same
+ * string/escape state machine as {@link repairJson} instead of using a regex.
+ *
+ * Models that spell non-ASCII text as hand-written hex instead of literal UTF-8
+ * mistype the digits, and every mistyped nibble silently decodes to a different
+ * but perfectly valid character (`\uc7a5` vs `\uc7a4`). The resulting arguments
+ * parse cleanly and cannot be repaired after the fact, so the escape itself is
+ * the only observable evidence that the payload is untrustworthy.
+ */
+export function findUnnecessaryUnicodeEscape(json: string): string | undefined {
+	const len = json.length;
+	let inString = false;
+	let i = 0;
+
+	const hexAt = (start: number): number | undefined => {
+		if (start + 3 >= len) return undefined;
+		for (let k = start; k <= start + 3; k++) if (!isHexDigit(json.charCodeAt(k))) return undefined;
+		return Number.parseInt(json.slice(start, start + 4), 16);
+	};
+
+	while (i < len) {
+		if (!inString) {
+			const open = json.indexOf('"', i);
+			if (open === -1) return undefined;
+			inString = true;
+			i = open + 1;
+			continue;
+		}
+
+		// Jump straight to the next quote or backslash. A per-character walk costs
+		// ~40ms on a 1MB literal-UTF-8 payload (a large `write`), and every byte in
+		// between is by definition uninteresting.
+		const nextQuote = json.indexOf('"', i);
+		const nextBackslash = json.indexOf("\\", i);
+		if (nextQuote === -1 && nextBackslash === -1) return undefined;
+		i = nextBackslash === -1 || (nextQuote !== -1 && nextQuote < nextBackslash) ? nextQuote : nextBackslash;
+
+		if (json.charCodeAt(i) === QUOTE) {
+			inString = false;
+			i++;
+			continue;
+		}
+		if (json.charCodeAt(i + 1) !== U) {
+			// Any other escape (including `\\`) consumes its own second character,
+			// so a literal `\uXXXX` in the decoded value is never misread as one.
+			i += 2;
+			continue;
+		}
+
+		const first = hexAt(i + 2);
+		if (first === undefined) {
+			i += 2;
+			continue;
+		}
+		if (first >= 0xd800 && first <= 0xdbff) {
+			// High surrogate: only a completed pair denotes a real character.
+			const low = json.charCodeAt(i + 6) === BACKSLASH && json.charCodeAt(i + 7) === U ? hexAt(i + 8) : undefined;
+			if (low !== undefined && low >= 0xdc00 && low <= 0xdfff) {
+				return json.slice(i, i + 12);
+			}
+			i += 6;
+			continue;
+		}
+		if (first >= 0x80 && !(first >= 0xdc00 && first <= 0xdfff)) {
+			return json.slice(i, i + 6);
+		}
+		i += 6;
+	}
+	return undefined;
+}
+
 export function parseJsonWithRepair<T>(json: string): T {
 	try {
 		return JSON.parse(json) as T;

--- a/packages/ai/src/utils/tool-call-healing.ts
+++ b/packages/ai/src/utils/tool-call-healing.ts
@@ -17,7 +17,7 @@
  * the end of a chunk is held back until the next chunk arrives.
  */
 
-import { parseJsonWithRepair } from "./json-parse";
+import { findUnnecessaryUnicodeEscape, parseJsonWithRepair } from "./json-parse";
 
 const TOK_SECTION_BEGIN = "<|tool_calls_section_begin|>";
 const TOK_SECTION_END = "<|tool_calls_section_end|>";
@@ -34,6 +34,13 @@ export interface HealedToolCall {
 	readonly id: string;
 	readonly name: string;
 	readonly arguments: string;
+	/**
+	 * Whether the raw leaked payload spelled a printable non-ASCII character as a
+	 * `\uXXXX` escape. Captured BEFORE the normalizing round-trip below, which
+	 * decodes escapes into literal characters and would otherwise erase the only
+	 * evidence that the text is unverifiable.
+	 */
+	readonly escapedNonAsciiArguments: boolean;
 }
 
 /**
@@ -230,6 +237,10 @@ export class ToolCallHealer {
 		const name = normalizeFunctionName(rawId);
 		const id = generateHealedToolCallId();
 
+		// Sample the raw payload first: the round-trip below decodes `\uXXXX` into
+		// literal characters, so checking `argsJson` afterwards always reports clean.
+		const escapedNonAsciiArguments = findUnnecessaryUnicodeEscape(rawArgs) !== undefined;
+
 		let argsJson = rawArgs;
 		if (rawArgs.length > 0) {
 			try {
@@ -242,7 +253,7 @@ export class ToolCallHealer {
 			argsJson = "{}";
 		}
 
-		this.#completed.push({ id, name, arguments: argsJson });
+		this.#completed.push({ id, name, arguments: argsJson, escapedNonAsciiArguments });
 		this.#inCall = false;
 		this.#inArgs = false;
 		this.#pendingId = "";

--- a/packages/ai/test/anthropic-escaped-nonascii-toolcall.test.ts
+++ b/packages/ai/test/anthropic-escaped-nonascii-toolcall.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { Messages } from "@anthropic-ai/sdk/resources/messages/messages";
+import { streamAnthropic } from "../src/providers/anthropic";
+import type { AssistantMessage, Context, Model, ToolCall } from "../src/types";
+
+const model: Model<"anthropic-messages"> = {
+	id: "claude-sonnet-4-5",
+	name: "Claude Sonnet 4.5",
+	api: "anthropic-messages",
+	provider: "anthropic",
+	baseUrl: "https://api.anthropic.com",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 8_192,
+};
+
+const context: Context = {
+	messages: [{ role: "user", content: "Ask me something", timestamp: Date.now() }],
+};
+
+type MockAnthropicEvent = Record<string, unknown>;
+
+function createMockRequest(events: MockAnthropicEvent[]) {
+	const response = new Response(null, { status: 200, headers: { "request-id": "req_mock" } });
+	const stream = {
+		async *[Symbol.asyncIterator]() {
+			for (const event of events) yield event;
+		},
+	};
+	return {
+		async withResponse() {
+			return { data: stream, response, request_id: response.headers.get("request-id") };
+		},
+	};
+}
+
+function script(partialJson: string): MockAnthropicEvent[] {
+	return [
+		{
+			type: "message_start",
+			message: {
+				id: "msg_escape",
+				usage: {
+					input_tokens: 1,
+					output_tokens: 0,
+					cache_read_input_tokens: 0,
+					cache_creation_input_tokens: 0,
+				},
+			},
+		},
+		{
+			type: "content_block_start",
+			index: 0,
+			content_block: { type: "tool_use", id: "tc-1", name: "ask", input: {} },
+		},
+		{ type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: partialJson } },
+		{ type: "content_block_stop", index: 0 },
+		{ type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 1 } },
+		{ type: "message_stop" },
+	];
+}
+
+async function run(events: MockAnthropicEvent[]): Promise<AssistantMessage> {
+	vi.spyOn(Messages.prototype, "create").mockImplementation(() => createMockRequest(events) as never);
+	const stream = streamAnthropic(model, context, { apiKey: "sk-ant-test", requestMaxRetries: 0, streamMaxRetries: 0 });
+	for await (const _event of stream) {
+		// Drain the provider stream.
+	}
+	return stream.result();
+}
+
+function toolCalls(message: AssistantMessage): ToolCall[] {
+	return message.content.filter((block): block is ToolCall => block.type === "toolCall");
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("Anthropic ASCII-escaped non-ASCII tool arguments", () => {
+	it("flags a call whose arguments spell Hangul as \\uXXXX escapes", async () => {
+		const result = await run(script(String.raw`{"question":"\ub9c8\uc9c0\ub9c9 \ubcd1\ubaa9"}`));
+		const [tool] = toolCalls(result);
+
+		expect(tool?.arguments).toEqual({ question: "마지막 병목" });
+		expect(tool?.escapedNonAsciiArguments).toBe(true);
+		expect(tool && "partialJson" in tool).toBe(false);
+	});
+
+	it("does not flag literal UTF-8 arguments", async () => {
+		const result = await run(script('{"question":"마지막 병목"}'));
+
+		expect(toolCalls(result)[0]?.escapedNonAsciiArguments).toBeFalsy();
+	});
+
+	it("does not flag an escaped backslash that is the written source text", async () => {
+		const result = await run(script(String.raw`{"question":"if c == \\uac00:"}`));
+
+		expect(toolCalls(result)[0]?.arguments).toEqual({ question: String.raw`if c == \uac00:` });
+		expect(toolCalls(result)[0]?.escapedNonAsciiArguments).toBeFalsy();
+	});
+});

--- a/packages/ai/test/json-parse.test.ts
+++ b/packages/ai/test/json-parse.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { isCompleteJson, parseJsonWithRepair, parseStreamingJson, repairJson } from "@gajae-code/ai/utils/json-parse";
+import {
+	findUnnecessaryUnicodeEscape,
+	isCompleteJson,
+	parseJsonWithRepair,
+	parseStreamingJson,
+	repairJson,
+} from "@gajae-code/ai/utils/json-parse";
 
 describe("JSON repair", () => {
 	it("leaves valid string escapes unchanged", () => {
@@ -45,5 +51,85 @@ describe("isCompleteJson", () => {
 		expect(isCompleteJson('{"a":1')).toBe(false);
 		expect(isCompleteJson('{"path":"/etc/hosts","content":"line1')).toBe(false);
 		expect(isCompleteJson("[1,2,")).toBe(false);
+	});
+});
+
+describe("findUnnecessaryUnicodeEscape", () => {
+	it("flags a printable non-ASCII character spelled as an escape", () => {
+		expect(findUnnecessaryUnicodeEscape(String.raw`{"q":"\ubcd1\ubaa9"}`)).toBe(String.raw`\ubcd1`);
+		expect(findUnnecessaryUnicodeEscape(String.raw`{"q":"ok \u00e9"}`)).toBe(String.raw`\u00e9`);
+	});
+
+	it("flags a completed surrogate pair but not a lone surrogate", () => {
+		expect(findUnnecessaryUnicodeEscape(String.raw`{"q":"\ud83d\ude00"}`)).toBe(String.raw`\ud83d\ude00`);
+		expect(findUnnecessaryUnicodeEscape(String.raw`{"q":"\ud83d tail"}`)).toBeUndefined();
+		expect(findUnnecessaryUnicodeEscape(String.raw`{"q":"\ude00 tail"}`)).toBeUndefined();
+	});
+
+	it("ignores literal UTF-8, required control escapes, and ASCII escapes", () => {
+		expect(findUnnecessaryUnicodeEscape('{"q":"병목 café 😀"}')).toBeUndefined();
+		expect(findUnnecessaryUnicodeEscape(String.raw`{"q":"a\u0000b\u001fc"}`)).toBeUndefined();
+		expect(findUnnecessaryUnicodeEscape(String.raw`{"q":"a\nb\"c\u0041"}`)).toBeUndefined();
+	});
+
+	it("ignores an escaped backslash followed by u — the source syntax of code being written", () => {
+		// The model wrote `\uac00` as literal text (e.g. a Python source line), which
+		// reaches the wire as `\\uac00` and decodes to a backslash, not a character.
+		expect(findUnnecessaryUnicodeEscape(String.raw`{"content":"if c == \\uac00:"}`)).toBeUndefined();
+	});
+
+	it("ignores non-ASCII escape-looking text outside string literals", () => {
+		expect(findUnnecessaryUnicodeEscape("   ")).toBeUndefined();
+		expect(findUnnecessaryUnicodeEscape("")).toBeUndefined();
+		expect(findUnnecessaryUnicodeEscape(String.raw`{"q":"\uzz11"}`)).toBeUndefined();
+	});
+
+	it("does not flag a truncated escape at the end of a streaming buffer", () => {
+		expect(findUnnecessaryUnicodeEscape(String.raw`{"q":"\ubc`)).toBeUndefined();
+	});
+
+	// Adversarial table: every case is a way the string/escape state machine could
+	// be desynchronized into a false accept (corrupted text executes) or a false
+	// reject (legitimate work is blocked). `true` = must flag.
+	const redteam: ReadonlyArray<readonly [string, string, boolean]> = [
+		["escaped quote does not close the string", String.raw`{"a":"say \"hi\" \uc548"}`, true],
+		["escaped backslash then a real escape", String.raw`{"a":"\\\uc548"}`, true],
+		["two escaped backslashes leave literal text", String.raw`{"a":"\\\\uc548"}`, false],
+		["escaped backslash then escaped quote then escape", String.raw`{"a":"\\\"\uc548"}`, true],
+		["escape hidden in a key name", String.raw`{"\uc774":1}`, true],
+		["escape-looking text outside any string", '{"a":1} \\uc548', false],
+		["braces and quotes inside the string body", String.raw`{"a":"} \" { \uc548"}`, true],
+		["escape nested in an array element", String.raw`{"a":[{"b":"\uc548"}]}`, true],
+		["escaped solidus then escape", String.raw`{"a":"\/\uc548"}`, true],
+		["escape in a string the stream never closed", String.raw`{"a":"\uc548`, true],
+		["stream cut on a lone trailing backslash", '{"a":"tail\\', false],
+		["stream cut mid `\\u`", '{"a":"x\\u', false],
+		["stream cut after a high surrogate", '{"a":"\\ud83d', false],
+		["high surrogate followed by a literal char", '{"a":"\\ud83d\uac00"}', false],
+		["high surrogate followed by a non-low escape", String.raw`{"a":"\ud83d\u0041"}`, false],
+		["surrogates in the wrong order", String.raw`{"a":"\ude00\ud83d"}`, false],
+		["C1 control is still non-ASCII", String.raw`{"a":"\u0085"}`, true],
+		["DEL stays ASCII", String.raw`{"a":"\u007f"}`, false],
+		["U+0080 is the first flagged codepoint", String.raw`{"a":"\u0080"}`, true],
+		["uppercase hex digits", String.raw`{"a":"\uBCD1"}`, true],
+		["mixed-case hex digits", String.raw`{"a":"\uBcD1"}`, true],
+		["only ASCII escapes", String.raw`{"a":"\u0041\u007a\u0020"}`, false],
+		["no strings at all", "{}", false],
+		["bare numeric value", '{"a":123}', false],
+	];
+
+	it.each(redteam)("red team: %s", (_label, json, shouldFlag) => {
+		expect(findUnnecessaryUnicodeEscape(json) !== undefined).toBe(shouldFlag);
+	});
+
+	it("scans a megabyte of literal UTF-8 without a per-character walk", () => {
+		const payload = JSON.stringify({ q: "마지막 병목 ".repeat(120_000) });
+		expect(payload.length).toBeGreaterThan(800_000);
+		for (let warmup = 0; warmup < 3; warmup++) findUnnecessaryUnicodeEscape(payload);
+		const started = performance.now();
+		expect(findUnnecessaryUnicodeEscape(payload)).toBeUndefined();
+		// The rejected per-character version took ~40ms here; the indexOf jumps make
+		// the common (clean, large `write`) payload effectively free.
+		expect(performance.now() - started).toBeLessThan(15);
 	});
 });

--- a/packages/ai/test/kimi-tool-call-healing.test.ts
+++ b/packages/ai/test/kimi-tool-call-healing.test.ts
@@ -332,4 +332,38 @@ describe("Kimi K2 leaked tool-call healing", () => {
 		expect(result.content.some(b => b.type === "toolCall")).toBe(false);
 		expect(result.stopReason).toBe("stop");
 	});
+
+	it("flags \\uXXXX-escaped arguments even though healing normalizes them away", async () => {
+		// The healer round-trips the raw payload through JSON.parse/stringify, which
+		// decodes escapes into literal characters. Sampling after that always reports
+		// clean, so this asserts the signal survives the normalization.
+		const leaked =
+			"<|tool_calls_section_begin|>" +
+			"<|tool_call_begin|>functions.ask:0<|tool_call_argument_begin|>" +
+			String.raw`{"question":"\ub9c8\uc9c0\ub9c9 \ubcd1\ubaa9"}` +
+			"<|tool_call_end|>" +
+			"<|tool_calls_section_end|>";
+		global.fetch = mockFetch([chunk(model.id, { content: leaked }), chunk(model.id, {}, "stop"), "[DONE]"]);
+
+		const result = await streamOpenAICompletions(model, baseContext(), { apiKey: "test" }).result();
+		const toolCalls = result.content.filter((b): b is ToolCall => b.type === "toolCall");
+		expect(toolCalls).toHaveLength(1);
+		expect(toolCalls[0].arguments).toEqual({ question: "마지막 병목" });
+		expect(toolCalls[0].escapedNonAsciiArguments).toBe(true);
+	});
+
+	it("does not flag healed arguments that were written as literal UTF-8", async () => {
+		const leaked =
+			"<|tool_calls_section_begin|>" +
+			"<|tool_call_begin|>functions.ask:0<|tool_call_argument_begin|>" +
+			'{"question":"마지막 병목"}' +
+			"<|tool_call_end|>" +
+			"<|tool_calls_section_end|>";
+		global.fetch = mockFetch([chunk(model.id, { content: leaked }), chunk(model.id, {}, "stop"), "[DONE]"]);
+
+		const result = await streamOpenAICompletions(model, baseContext(), { apiKey: "test" }).result();
+		const toolCalls = result.content.filter((b): b is ToolCall => b.type === "toolCall");
+		expect(toolCalls).toHaveLength(1);
+		expect(toolCalls[0].escapedNonAsciiArguments).toBeFalsy();
+	});
 });

--- a/packages/ai/test/ollama-escaped-nonascii-toolcall.test.ts
+++ b/packages/ai/test/ollama-escaped-nonascii-toolcall.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { streamOllama } from "../src/providers/ollama";
+import type { AssistantMessage, Context, Model, ToolCall } from "../src/types";
+
+const originalFetch = global.fetch;
+
+const model = {
+	id: "qwen3:latest",
+	name: "Qwen 3",
+	api: "ollama-chat",
+	provider: "ollama",
+	baseUrl: "http://127.0.0.1:11434",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 32_768,
+	maxTokens: 8_192,
+} satisfies Model<"ollama-chat">;
+
+const context: Context = {
+	messages: [{ role: "user", content: "Ask me something", timestamp: Date.now() }],
+};
+
+async function runChunks(chunks: unknown[]): Promise<AssistantMessage> {
+	global.fetch = vi.fn(
+		async () =>
+			new Response(`${chunks.map(chunk => JSON.stringify(chunk)).join("\n")}\n`, {
+				status: 200,
+				headers: { "Content-Type": "application/x-ndjson" },
+			}),
+	) as unknown as typeof fetch;
+
+	const stream = streamOllama(model, context, { apiKey: "test-key" });
+	for await (const _event of stream) {
+		// Drain the provider stream.
+	}
+	return stream.result();
+}
+
+async function run(argumentsValue: Record<string, unknown> | string): Promise<AssistantMessage> {
+	return runChunks([
+		{
+			message: {
+				role: "assistant",
+				content: "",
+				tool_calls: [{ function: { name: "ask", arguments: argumentsValue } }],
+			},
+			done: false,
+		},
+		{ done: true, done_reason: "tool_calls", prompt_eval_count: 5, eval_count: 9 },
+	]);
+}
+
+function firstTool(message: AssistantMessage): ToolCall | undefined {
+	return message.content.find((block): block is ToolCall => block.type === "toolCall");
+}
+
+afterEach(() => {
+	global.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+describe("Ollama ASCII-escaped non-ASCII tool arguments", () => {
+	it("flags a call whose arguments spell Hangul as \\uXXXX escapes", async () => {
+		const result = await run(String.raw`{"question":"\ub9c8\uc9c0\ub9c9 \ubcd1\ubaa9"}`);
+		const tool = firstTool(result);
+
+		expect(tool?.arguments).toEqual({ question: "마지막 병목" });
+		expect(tool?.escapedNonAsciiArguments).toBe(true);
+		expect(tool && "partialJson" in tool).toBe(false);
+	});
+
+	it("does not flag literal UTF-8 arguments", async () => {
+		const result = await run('{"question":"마지막 병목"}');
+
+		expect(firstTool(result)?.escapedNonAsciiArguments).toBeFalsy();
+	});
+
+	it("does not flag an escaped backslash that is the written source text", async () => {
+		const result = await run(String.raw`{"question":"if c == \\uac00:"}`);
+
+		expect(firstTool(result)?.arguments).toEqual({ question: String.raw`if c == \uac00:` });
+		expect(firstTool(result)?.escapedNonAsciiArguments).toBeFalsy();
+	});
+
+	it("does not flag ASCII-only arguments", async () => {
+		const result = await run('{"question":"hello world"}');
+
+		expect(firstTool(result)?.escapedNonAsciiArguments).toBeFalsy();
+	});
+});


### PR DESCRIPTION
## What

Reject a tool call whose raw argument JSON spelled a printable non-ASCII character as a `\uXXXX` escape instead of literal UTF-8, instead of executing it on silently corrupted text.

- `findUnnecessaryUnicodeEscape` (`packages/ai/src/utils/json-parse.ts`) walks the raw argument buffer with the same string/escape state machine as `repairJson` and returns the first escape that encodes a character JSON could have carried literally.
- Providers set `ToolCall.escapedNonAsciiArguments` at their finalize sites (anthropic, openai-completions, openai-responses-shared, openai-codex-responses, amazon-bedrock, cursor, agent proxy).
- The agent loop rejects such a call ahead of execution with a retryable, actionable error, mirroring the existing `incompleteArguments` gate.

## Why

Deep-interview `ask` prompts render with garbled Hangul: 병목 → 보리목, 취미 → 춨미, 네 가지 → 넣 가지.

Diagnosed from a real session store (`~/.gjc/agent/sessions`), not from a guess:

1. **Corruption is confined to tool-call arguments.** 4,591 Hangul characters of assistant prose in the same session are clean; only `ask` arguments are damaged. A rendering, TUI, or SSE-decode fault would damage both.
2. **Wrong syllables sit one hex nibble from the right ones.** 넣 U+B123 vs 네 U+B124, 춨 U+CDA8 vs 취 U+CDE8, 심 U+C2EC vs 시 U+C2DC.
3. **The model demonstrably writes escapes by hand.** Another session persists `extract_urls("https://\uc5d0\uc11c")` as literal text in a `bash` command (it survived only because it was double-escaped).

So the model serializes argument strings as hand-written hex and mistypes digits. `JSON.parse` decodes each typo into a *different, perfectly valid* character: the payload is schema-valid, unrepairable after parsing, and carries no in-band evidence that it is wrong. The escape itself is the only observable signal, and it exists only on the raw argument JSON.

A prompt-only mitigation for this already shipped (`prompt/literal-utf8-tool-inputs`, system prompt "write literal UTF-8 … never hand-spelled `\uXXXX`"). It does not hold; this is the runtime enforcement of that instruction.

### False-positive safety

`\\uXXXX` is a literal backslash followed by `u` — the intended source syntax whenever the model writes code or a nested JSON document — so it is **not** an escape and is skipped. Required escapes (control characters) and unavoidable ones (lone surrogates) never trip the flag. This is why the check is a state machine over the raw buffer rather than a regex.

### Bounded failure

Rejections feed the existing malformed-tool-call recovery turn and the consecutive-turn circuit breaker, so a provider that always emits `ensure_ascii`-style output terminates with a clear error rather than looping.

## Testing

`bun run check:tools` — 0 errors (7 pre-existing warnings on `dev`, untouched).

`bun test packages/agent/test` + the affected `packages/ai` suites — **840 pass / 0 fail** on this head.

Red-team pass (all committed as tests, not run-and-discard):

- **24-case adversarial table** (`json-parse.test.ts`) for every way the string/escape state machine could desync into a false accept or false reject: escaped quote not closing the string, escaped-backslash chains, escape hidden in a key name, escape-looking text outside any string, unterminated string, stream cut on a trailing backslash / mid-`\u` / mid-surrogate, reversed surrogate order, C1 vs DEL vs U+0080 boundary, hex case.
- **Two real bugs the red team found, both fixed in this PR:**
  1. The Kimi tool-call healer round-trips the leaked payload through `JSON.parse`/`stringify`, which decodes escapes into literal characters — sampling after that always reported clean, defeating the guard entirely on that path. It now samples the raw payload first (`kimi-tool-call-healing.test.ts` covers both directions).
  2. The initial per-character scan cost ~40 ms on a 1 MB literal-UTF-8 payload (a large `write`). Replaced with indexOf jumps between quotes and backslashes: ~0.8 ms, with a committed regression bound.
- Wire-level provider test (`anthropic-escaped-nonascii-toolcall.test.ts`): escaped Hangul flagged, literal UTF-8 not flagged, `\\uac00` source text not flagged.
- Agent-loop test (`agent-loop-escaped-nonascii-toolcall.test.ts`): flagged call never reaches `execute()`; literal-UTF-8 call executes untouched.

Not covered: providers that never expose raw argument JSON (google family) — the signal does not exist there. Stated in the commit trailer rather than implied.

## GJC verdict

No independent architect/critic/human review was obtained, so per the template this is `needs-human`. Self-approval would be BLOCK.

```text
gajae.pr-review-verdict.v1 needs-human sha256:140379a036bfb8c3dbc8ec21509a8b0c247b1728 reviewer:human evidence:local bun run check:tools + bun test packages/agent/test packages/ai/test/{json-parse,kimi-tool-call-healing,anthropic-escaped-nonascii-toolcall,anthropic-truncated-toolcall,openai-completions-truncated-toolcall,openai-responses-truncated-toolcall,unicode-surrogate,mock-provider}.test.ts -> 840 pass / 0 fail
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
