### PR TITLE
fix(test): keep G013 large valid edit under shard-pressure deadline

### DIFF
--- a/packages/coding-agent/test/streaming-edit-abort.test.ts
+++ b/packages/coding-agent/test/streaming-edit-abort.test.ts
@@ -134,6 +134,24 @@ function buildEditTool(): AgentTool {
 	};
 }
 
+// Yield between stream deltas with a microtask instead of `await Bun.sleep(0)`.
+// Bun.sleep(0) registers a real timer: on a CPU-contended shard (dozens of
+// parallel test-file processes competing for the same cores) the timer phase
+// can be delayed by tens of milliseconds per turn, so an O(lineCount) chain of
+// per-delta timer yields scaled with shard load rather than diff size — this
+// is what pushed the 200-line NO-FALSE-ABORT case past Bun's 5s per-test
+// deadline under full-shard pressure (see #4342). The guard under test
+// (`AgentSession#maybeAbortStreamingEdit`) needs each `toolcall_delta` to be
+// independently observable by the consuming async iterator; it does no real
+// async I/O per delta in the no-removed-lines-missing path, so a microtask
+// yield is sufficient to hand control back to the event stream's `for await`
+// consumer between deltas. Harness overhead stays O(1) per delta instead of
+// O(timer-queue-depth) while the streaming-abort interleaving (producer never
+// runs more than one delta ahead of the consumer) is preserved.
+async function yieldBetweenDeltas(): Promise<void> {
+	await Promise.resolve();
+}
+
 function createStreamForDiff(
 	path: string,
 	chunks: string[],
@@ -192,7 +210,7 @@ function createStreamForDiff(
 					delta: chunk,
 					partial: createAssistantMessage([partialCall], "stop"),
 				});
-				await Bun.sleep(0);
+				await yieldBetweenDeltas();
 			}
 
 			if (aborted) return;


### PR DESCRIPTION
## Summary

Fixes #4342: the 200-line `G013 NO-FALSE-ABORT` streaming-edit test intermittently crossed Bun's 5s per-test deadline in the full coding-agent shard 1/8.

**Root cause (determined):** the test fixture yielded between stream deltas with `await Bun.sleep(0)`, which registers a real timer per delta. The 200-line case drives 401 deltas, so the fixture was an O(lineCount) chain of timer registrations whose latency scales with the shared timer queue under CPU-contended shard load — not with diff size. Focused and pristine-dev runs passed because the timer queue is quiet in isolation. The production guard (`AgentSession#maybeAbortStreamingEdit`) itself is synchronous and incremental in the append-only path (verified: per-delta `slice(lastProcessedOffset)` + prefix check; no per-delta async I/O in the no-removed-lines-missing path), so no production change was needed.

**Fix:** replace the per-delta timer yield with a microtask yield (`await Promise.resolve()`). The guard only needs each `toolcall_delta` to be independently observable by the consuming async iterator; the streaming-abort interleaving (producer never runs more than one delta ahead of the consumer) is preserved with O(1) harness overhead per delta instead of O(timer-queue-depth).

## Verification

- `bun test packages/coding-agent/test/streaming-edit-abort.test.ts` — 18/18 pass (all G013 seam/partial-line/append-only/non-edit correctness preserved)
- 20x serial focused repeats of `G013 NO-FALSE-ABORT` — 0 failures
- 6-way concurrent load A/B of the full file (same load conditions):
  - original (`Bun.sleep(0)`): `[5.09s]` — at the deadline edge (matches the issue's ~5.03s timeout)
  - fixed (microtask): `[2.84s]` — 44% faster, ~2.2s of headroom
- Second 6-way load batch: `[3.91-4.19s]` — all 18/18 pass under heavier concurrent machine load
- Full affected shard `--shard=4/8` (contains `streaming-edit-abort.test.ts`): 1738 pass / 46 skip / 4 fail; `streaming-edit-abort.test.ts` green within it. The 4 failures are timing-sensitive tests in files this change does not touch (`acp-session-delete-wire`, `chat-daemon-session-reconnect` ×2, `sdk-mcp-stdio`) — they exceed the 5s per-test deadline on this heavily loaded shared machine (load avg 27-31) and pass on clean CI runners (base commit 3df33d0a2f has 17 success / 0 failed on GitHub).
- `biome check` + `tsc --noEmit` clean

Not tested: full dev CI matrix (deferred to this PR's CI run).
