### PR TITLE
fix(ai): harden capability cache corruption retirement (#4319)

### DIFF
--- a/packages/ai/src/utils/tool-choice-capability.ts
+++ b/packages/ai/src/utils/tool-choice-capability.ts
@@ -28,6 +28,8 @@ let nowForTests: (() => number) | undefined;
 let beforeExpiredDeleteForTests: (() => void) | undefined;
 let beforeMalformedDeleteForTests: (() => void) | undefined;
 let onCacheOpenForTests: (() => void) | undefined;
+let simulateCacheOperationErrorForTests: (() => Error | undefined) | undefined;
+let beforeCorruptRetireForTests: (() => void) | undefined;
 
 /**
  * Claude Mythos accepts tools but rejects forced tool use (Anthropic 400:
@@ -81,12 +83,16 @@ export function configureToolChoiceCapabilityCacheForTests(options?: {
 	beforeExpiredDelete?: () => void;
 	beforeMalformedDelete?: () => void;
 	onCacheOpen?: () => void;
+	simulateOperationError?: () => Error | undefined;
+	beforeCorruptRetire?: () => void;
 }): void {
 	cachePathOverride = options?.path;
 	nowForTests = options?.now;
 	beforeExpiredDeleteForTests = options?.beforeExpiredDelete;
 	beforeMalformedDeleteForTests = options?.beforeMalformedDelete;
 	onCacheOpenForTests = options?.onCacheOpen;
+	simulateCacheOperationErrorForTests = options?.simulateOperationError;
+	beforeCorruptRetireForTests = options?.beforeCorruptRetire;
 	clearToolChoiceIncapabilityRegistryForTests();
 }
 
@@ -370,8 +376,14 @@ function persistToolChoiceCapability(
 function withCapabilityCache<T>(operation: (database: Database) => T): T | undefined {
 	if (process.env.NODE_ENV === "test" && cachePathOverride === undefined) return;
 	const cachePath = cachePathOverride ?? getToolChoiceCapabilityCachePath();
+	let openedFileSize: number | undefined;
 	try {
 		fs.mkdirSync(path.dirname(cachePath), { recursive: true, mode: 0o700 });
+		try {
+			openedFileSize = fs.statSync(cachePath).size;
+		} catch {
+			// File does not exist yet (first run); nothing to identity-check on retirement.
+		}
 		const database = openCapabilityCache(cachePath);
 		try {
 			try {
@@ -379,6 +391,8 @@ function withCapabilityCache<T>(operation: (database: Database) => T): T | undef
 			} catch {
 				// Cache access remains fail-open on filesystems without POSIX modes.
 			}
+			const simulatedError = simulateCacheOperationErrorForTests?.();
+			if (simulatedError) throw simulatedError;
 			return operation(database);
 		} finally {
 			database.close();
@@ -388,7 +402,10 @@ function withCapabilityCache<T>(operation: (database: Database) => T): T | undef
 			cachePath: path.basename(cachePath),
 			error: error instanceof Error ? error.message : String(error),
 		});
-		if (isCorruptCapabilityCacheError(error)) retireCorruptCapabilityCache(cachePath);
+		if (isCorruptCapabilityCacheError(error)) {
+			beforeCorruptRetireForTests?.();
+			retireCorruptCapabilityCache(cachePath, openedFileSize);
+		}
 	}
 }
 
@@ -453,13 +470,24 @@ function isCorruptCapabilityCacheError(error: unknown): boolean {
 	if (error instanceof CapabilityCacheCorruptionError) return true;
 	if (!error || typeof error !== "object") return false;
 	const code = (error as { code?: unknown }).code;
-	return code === "SQLITE_CORRUPT" || code === "SQLITE_NOTADB" || code === "SQLITE_ERROR";
+	return code === "SQLITE_CORRUPT" || code === "SQLITE_NOTADB";
 }
 
-function retireCorruptCapabilityCache(cachePath: string): void {
+/**
+ * Removes a confirmed-corrupt cache file and its WAL/SHM siblings. The file
+ * size captured before the corrupt open (`openedFileSize`) is checked before
+ * unlinking so a concurrently recreated valid replacement database with a
+ * different file size is never deleted.
+ */
+function retireCorruptCapabilityCache(cachePath: string, openedFileSize?: number): void {
 	for (const suffix of ["", "-wal", "-shm"]) {
+		const target = `${cachePath}${suffix}`;
 		try {
-			fs.rmSync(`${cachePath}${suffix}`, { force: true });
+			if (openedFileSize !== undefined && suffix === "") {
+				const stat = fs.statSync(target);
+				if (stat.size !== openedFileSize) continue;
+			}
+			fs.rmSync(target, { force: true });
 		} catch {
 			// A best-effort cache reset must never break provider fallback behavior.
 		}

--- a/packages/ai/test/tool-choice-capability.test.ts
+++ b/packages/ai/test/tool-choice-capability.test.ts
@@ -1,5 +1,6 @@
 import { Database } from "bun:sqlite";
 import { beforeEach, describe, expect, it } from "bun:test";
+import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { TempDir } from "@gajae-code/utils";
@@ -385,8 +386,76 @@ describe("durable tool-choice capability cache", () => {
 			database.close();
 		}
 	});
-});
 
+	it("does not retire the cache when a transient SQLITE_ERROR occurs during operation", () => {
+		using tempDir = TempDir.createSync("tool-choice-capability-transient-");
+		const cachePath = path.join(tempDir.path(), "capabilities.db");
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath });
+		markToolChoiceIncapability(model("named"), "auto");
+
+		expect(fsSync.existsSync(cachePath)).toBe(true);
+
+		// A generic SQLITE_ERROR (e.g. from a future binding or driver edge case)
+		// must not be treated as corruption and must not delete the cache.
+		let injected = false;
+		configureToolChoiceCapabilityCacheForTests({
+			path: cachePath,
+			simulateOperationError: () => {
+				if (injected) return undefined;
+				injected = true;
+				return Object.assign(new Error("simulated transient SQLITE_ERROR"), { code: "SQLITE_ERROR" });
+			},
+		});
+		expect(resolveToolChoice(model("named"), "required").support).toBe("named");
+		expect(fsSync.existsSync(cachePath)).toBe(true);
+
+		// After the transient error, the cache is intact and data is still hydrated.
+		configureToolChoiceCapabilityCacheForTests({ path: cachePath });
+		expect(resolveToolChoice(model("named"), "required").support).toBe("auto");
+	});
+
+	it("does not delete a concurrently recreated valid cache during corruption retirement", async () => {
+		using tempDir = TempDir.createSync("tool-choice-capability-recreate-race-");
+		const cachePath = path.join(tempDir.path(), "capabilities.db");
+		await fs.writeFile(cachePath, "not a sqlite database");
+
+		// Race scenario:
+		// 1. withCapabilityCache stats the corrupt file → captures its byte size
+		// 2. openCapabilityCache opens the corrupt file → fails with SQLITE_NOTADB
+		// 3. beforeCorruptRetire replaces the file with a valid DB (concurrent recreation)
+		// 4. retireCorruptCapabilityCache size-checks: size differs → skips deletion
+		configureToolChoiceCapabilityCacheForTests({
+			path: cachePath,
+			beforeCorruptRetire: () => {
+				fsSync.rmSync(cachePath, { force: true });
+				const replacement = new Database(cachePath, { create: true });
+				replacement.run(`
+					CREATE TABLE IF NOT EXISTS tool_choice_capabilities (
+						key_digest TEXT PRIMARY KEY NOT NULL,
+						max_support TEXT NOT NULL,
+						support_rank INTEGER NOT NULL,
+						observed_at INTEGER NOT NULL
+					) STRICT
+				`);
+				replacement.run("INSERT INTO tool_choice_capabilities VALUES ('test', 'auto', 1, 1000)");
+				replacement.run("PRAGMA user_version = 1");
+				replacement.close();
+			},
+		});
+
+		expect(resolveToolChoice(model("named"), "required").support).toBe("named");
+		// The valid replacement must survive — identity check prevented deletion.
+		expect(fsSync.existsSync(cachePath)).toBe(true);
+		const replacement = new Database(cachePath, { readonly: true });
+		try {
+			expect(replacement.query("SELECT COUNT(*) AS count FROM tool_choice_capabilities").get()).toEqual({
+				count: 1,
+			});
+		} finally {
+			replacement.close();
+		}
+	});
+});
 describe("isForcedToolChoiceUnsupportedError", () => {
 	it("matches unsupported forced tool_choice 400s", () => {
 		expect(


### PR DESCRIPTION
## Summary

Follow-up fix for issue #4319: the merged durable tool-choice capability cache (dev `2067b93976`, PR #4322) had two defects in corruption retirement that a retained post-merge architect review surfaced.

## Defects fixed

1. ** treated generic  as confirmed corruption.**  is a catch-all that includes transient operational failures (busy database, lock contention). Treating it as corruption destructively deleted healthy caches on transient errors, forcing repeated provider probes — the exact regression issue #4319 was meant to prevent.

2. ** unlinked by pathname with no identity check.** A concurrently recreated valid replacement database could be deleted.

## Changes

- ****: removed  from the corruption classifier. Only  and  (genuine file-level corruption) trigger retirement.
- ****: captures the file size before opening the database, so retirement can skip deletion when the file was replaced between detection and cleanup.
- ****: checks the file size before unlinking the main database file; skips deletion if the size changed (concurrent recreation).
- Added focused regression tests for both defects: transient `SQLITE_ERROR` no-delete, and concurrent-recreation race safety.

## Validation

- 52 capability tests pass (including 3 new regression tests)
- 96 cross-suite tests pass (redteam, 400-fallback, codex-responses, completions-tool-choice)
- 21 eager-todo tests pass
- `bun --cwd=packages/ai run check` passes (biome + tsc)
- `bun --cwd=packages/coding-agent run check:types` passes

Closes #4319 (terminal resolution).