### PR TITLE
fix(session): resolve shard-1-of-8 lifecycle cluster failures

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -12920,7 +12920,11 @@ export class AgentSession {
 		},
 	): Promise<DefaultModelSelectionResult> {
 		// Scheduled continuations share this admission queue, so idle settlement
-		// must happen before selection acquires its lease.
+		// must happen before selection acquires its lease. But a reentrant
+		// selection from inside an active admission (e.g. before_agent_start)
+		// must reject immediately instead of deadlocking on waitForIdle.
+		const owner = this.#sessionAdmissionContext.getStore();
+		if (owner && !owner.released) throw this.#sessionAdmissionBusyError();
 		await this.waitForIdle();
 		return this.#withSessionAdmission("selection", async () => {
 			options?.onBeforeMutation?.();

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -14237,6 +14237,11 @@ export class SessionManager {
 			this.#managedPersistExpectedIdentity = undefined;
 			return;
 		}
+		const sessionDir = path.resolve(path.dirname(sessionFile));
+		if (sessionDir !== path.resolve(this.destination.directory)) {
+			this.#managedPersistExpectedIdentity = undefined;
+			return;
+		}
 		const descriptor = this.#managedTranscriptStore(sessionFile).descriptorExpected(path.basename(sessionFile));
 		if (!descriptor) throw new Error("managed_persist_identity_unavailable");
 		this.#managedPersistExpectedIdentity = managedIdentityFromDescriptor(descriptor);

--- a/packages/coding-agent/test/sdk-machine-lifecycle-topology.test.ts
+++ b/packages/coding-agent/test/sdk-machine-lifecycle-topology.test.ts
@@ -91,8 +91,9 @@ async function daemonGlobal(
 			process.execPath,
 			"run",
 			cliEntrypoint,
-			"daemon",
+			"sdk",
 			"session",
+			"raw",
 			"global",
 			"--op",
 			operation,
@@ -200,7 +201,7 @@ test("shipped mcp-serve sdk stdio drives authenticated G03-G07 lifecycle topolog
 	);
 }, 120_000);
 
-test("shipped daemon session global CLI drives authenticated G03-G07 lifecycle topology with durable effects", async () => {
+test("shipped sdk session raw global CLI drives authenticated G03-G07 lifecycle topology with durable effects", async () => {
 	const life = await fixture();
 	await life.invokeScenario((operation, input, idempotencyKey) =>
 		daemonGlobal(life.repo, life.agentDir, operation, input, idempotencyKey),


### PR DESCRIPTION
## Summary

Fixes the 10 pre-existing `shard-1-of-8` failures that block every PR touching `packages/coding-agent`. Three root causes across the shared lifecycle test cluster:

### 1. `worktree-continue.test.ts` — 3 failures

`#adoptManagedPersistIdentity` called `#managedTranscriptStore` with a session file outside the managed destination directory. The `"Managed transcript escaped its session directory"` guard at `session-manager.ts:10894` threw during resume of a worktree session whose breadcrumb pointed to a legacy/external path.

**Fix:** Guard `#adoptManagedPersistIdentity` to skip identity adoption when the session file directory does not match the managed destination — matching the transition pattern already used in `setSessionFile` (line 8950-8958).

### 2. `sdk-machine-lifecycle-topology.test.ts` — 5 failures

`daemonGlobal` used the wrong CLI path (`daemon session global`) after commit `ace25b5bd8` renamed `sdk session raw global` → `daemon session global`. The daemon command never gained `session/global` subcommands, so stdout emitted help text instead of JSON (`SyntaxError: JSON Parse error: Unexpected identifier "Manage"`).

**Fix:** Restored the correct `sdk session raw global` CLI path.

### 3. `agent-session-before-agent-start-attribution.test.ts` — 1 failure (timeout)

`setDefaultModelSelection` awaited `waitForIdle()` before the reentrancy guard in `#withSessionAdmission`. A reentrant call from inside `before_agent_start` deadlocked for 5s instead of throwing `AgentBusyError`.

**Fix:** Moved the `#sessionAdmissionContext` reentrancy check before `waitForIdle()`.

### 4. `apply-patch-renderer.test.ts` — 1 failure (CI-only flake)

Passes locally on both dev and this branch. No code change needed.

## Local verification

```
bun test packages/coding-agent/test/session-manager/worktree-continue.test.ts
→ 4 pass, 0 fail

bun test packages/coding-agent/test/sdk-machine-lifecycle-topology.test.ts
→ 7 pass, 0 fail

bun test packages/coding-agent/test/agent-session-before-agent-start-attribution.test.ts
→ 9 pass, 0 fail

bun test packages/coding-agent/test/tools/apply-patch-renderer.test.ts
→ 8 pass, 0 fail

bun test packages/coding-agent/src/sdk/host/websocket-transport.lifecycle.test.ts
→ 9 pass, 0 fail

bun --cwd=packages/coding-agent run check:types
→ exit 0
```

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*