### PR TITLE
fix(broker): avoid PowerShell fallback for absent Windows processes

### DIFF
--- a/packages/coding-agent/src/sdk/broker/process-incarnation.ts
+++ b/packages/coding-agent/src/sdk/broker/process-incarnation.ts
@@ -111,6 +111,7 @@ export function processIncarnation(pid: number, options: ProcessIncarnationOptio
 	if (platform === process.platform && options.runCommand === undefined) {
 		try {
 			const nativeProcess = nativeProcessBindings().Process.fromPid(pid) as { incarnation?: unknown } | null;
+			if (nativeProcess === null) return undefined;
 			if (isProcessIncarnation(nativeProcess?.incarnation)) return nativeProcess.incarnation;
 		} catch {
 			// Fall through to the platform-specific reader.

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -6,6 +6,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as native from "@gajae-code/natives";
 import { NotificationServer } from "@gajae-code/natives";
+import { nativeProcessBindings } from "@gajae-code/utils/native-process";
 import { openLifecycleSessionManager, runSessionHost, watchSessionHostBrokerLiveness } from "../src/commands/sdk";
 import { planLaunchWorktree } from "../src/gjc-runtime/launch-worktree";
 import { AcpAgent } from "../src/modes/acp/acp-agent";
@@ -814,6 +815,22 @@ test("broker reads Windows process incarnations as canonical FILETIME ticks with
 		}),
 	).toBe("windows:133830291061234568");
 });
+
+test.skipIf(process.platform !== "win32")(
+	"broker does not spawn PowerShell when the native binding authoritatively reports an absent process",
+	() => {
+		const fromPid = vi.spyOn(nativeProcessBindings().Process, "fromPid").mockReturnValue(null);
+		const spawn = vi.spyOn(Bun, "spawnSync");
+		try {
+			expect(processIncarnation(2_147_483_647)).toBeUndefined();
+			expect(fromPid).toHaveBeenCalledWith(2_147_483_647);
+			expect(spawn).not.toHaveBeenCalled();
+		} finally {
+			spawn.mockRestore();
+			fromPid.mockRestore();
+		}
+	},
+);
 
 test("broker fails closed for failed or malformed Windows FILETIME process-incarnation output", () => {
 	const options = {


### PR DESCRIPTION
Closes #4367.

## Summary

Treats `Process.fromPid(pid) === null` as the native binding's authoritative absent-process result. This avoids repeatedly spawning PowerShell for an exited Windows PID while retaining the existing fallback when the binding throws or returns a non-canonical incarnation.

Explicit `runCommand` remains unchanged and continues to test the PowerShell path.

## Regression coverage

Adds a Windows test asserting that:

* the native lookup receives the dead PID;
* `processIncarnation` returns `undefined`;
* `Bun.spawnSync` is not called.

## Validation

* Reproduced and manually validated by patching an installed package on Windows; repeated PowerShell process creation stopped.
* `bunx tsc --noEmit -p packages/coding-agent/tsconfig.json` passes.
* `git diff --check` passes.
* Focused Bun tests could not run on the authoring macOS host because the repository native addon is absent and Cargo is unavailable to build it. Windows CI is expected to execute the platform-gated regression.