### PR TITLE
fix(session): make replacement receipt reconciliation idempotent on Windows

### DIFF
--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -1273,20 +1273,34 @@ export class ManagedSessionDescendantStore {
 			fsyncDirectory(this.#baseDir);
 			return;
 		}
-		if (outcome.reason === "destination_exists") {
-			const existing = captureManagedFilePrefixNoFollow(destination, REPLACEMENT_CLEANUP_RECEIPT_MAX_BYTES);
-			if (existing.identity.sha256 !== pending.identity.sha256)
+		if (outcome.reason === "destination_exists" || outcome.reason === "invalid_request") {
+			const captureIfPresent = (pathname: string): ManagedFileSnapshot | undefined => {
+				try {
+					return captureManagedFilePrefixNoFollow(pathname, REPLACEMENT_CLEANUP_RECEIPT_MAX_BYTES);
+				} catch (error) {
+					if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+					throw error;
+				}
+			};
+			const currentPending = captureIfPresent(receiptPath);
+			const existing = captureIfPresent(destination);
+			if (!currentPending && existing) {
+				fsyncDirectory(this.#baseDir);
+				return;
+			}
+			if (currentPending && !existing) throw publishFailure(outcome);
+			if (!currentPending || !existing || existing.identity.sha256 !== currentPending.identity.sha256)
 				throw new Error("managed_replace_cleanup_receipt_invalid");
 			const removed = nativeSessionStorage().exactUnlink(receiptPath, {
-				dev: pending.identity.dev,
-				ino: pending.identity.ino,
-				nlink: pending.identity.nlink,
+				dev: currentPending.identity.dev,
+				ino: currentPending.identity.ino,
+				nlink: currentPending.identity.nlink,
 				parentDev: this.#subtreeRoot.dev,
 				parentIno: this.#subtreeRoot.ino,
-				size: BigInt(pending.identity.size),
-				mtimeNs: pending.identity.mtimeNs,
-				sha256: pending.identity.sha256,
-				quarantineName: `.gjc-receipt-pending-remove-${pending.identity.dev.toString(16)}-${pending.identity.ino.toString(16)}`,
+				size: BigInt(currentPending.identity.size),
+				mtimeNs: currentPending.identity.mtimeNs,
+				sha256: currentPending.identity.sha256,
+				quarantineName: `.gjc-receipt-pending-remove-${currentPending.identity.dev.toString(16)}-${currentPending.identity.ino.toString(16)}`,
 			});
 			if (!exactUnlinkCompleted(removed) && removed.code !== "not_found")
 				throw new Error(`managed_replace_receipt_cleanup_pending:${removed.code ?? "unknown"}`);

--- a/packages/coding-agent/test/session-storage.test.ts
+++ b/packages/coding-agent/test/session-storage.test.ts
@@ -1055,6 +1055,7 @@ describe.skipIf(process.platform !== "darwin")("managed replacement receipt deta
 		store.publishNoReplaceSync(name, Buffer.from("trigger\n"));
 	};
 
+
 	beforeEach(() => {
 		root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-replace-journal-"));
 		leaveReceiptPlaceholder = false;
@@ -1295,6 +1296,39 @@ describe("replacement cleanup receipt reconcile TOCTOU resilience", () => {
 		const store = new ManagedSessionDescendantStore(managedDirectoryRoot(root), root);
 		store.publishNoReplaceSync(name, Buffer.from("trigger\n"));
 	};
+	const pendingReceipt = () => {
+		const destination = path.join(root, "session.jsonl");
+		const staging = path.join(root, ".session.replacement");
+		const predecessorPath = path.join(root, "predecessor");
+		fs.writeFileSync(destination, "successor\n");
+		fs.writeFileSync(staging, "prepared\n");
+		fs.writeFileSync(predecessorPath, "predecessor\n");
+		const predecessor = snapshot(predecessorPath);
+		const pending = path.join(root, `.gjc-replace-receipt-pending-${randomUUID()}.json`);
+		fs.writeFileSync(
+			pending,
+			JSON.stringify({
+				version: 3,
+				staging,
+				destination,
+				predecessor,
+				successor: snapshot(destination),
+			}),
+		);
+		const receiptIdentity = snapshot(pending);
+		return { pending, receipt: canonicalReceiptPath(predecessor, receiptIdentity) };
+	};
+	const invalidRequest = () =>
+		({
+			ok: false,
+			code: "invalid_request",
+			reason: "invalid_request",
+			phase: "preflight",
+			mutationState: "not_committed",
+			durabilityState: "not_attempted",
+			primitive: "windows_rename_noreplace",
+			diagnostic: { schemaVersion: 1, collectionState: "complete", osCode: 87 },
+		}) as const;
 
 	beforeEach(() => {
 		root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-replace-toctou-"));
@@ -1302,6 +1336,65 @@ describe("replacement cleanup receipt reconcile TOCTOU resilience", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 		fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	it("accepts invalid_request when another reconciler has already moved the pending receipt", () => {
+		const { pending, receipt } = pendingReceipt();
+		const realRename = native.renameNoReplacePath;
+		vi.spyOn(native, "renameNoReplacePath").mockImplementation((source, destination) => {
+			if (source !== pending) return realRename(source, destination);
+			fs.renameSync(source, destination);
+			return invalidRequest();
+		});
+
+		replay("concurrent-reconcile");
+
+		expect(fs.existsSync(pending)).toBe(false);
+		expect(fs.existsSync(receipt)).toBe(true);
+		expect(fs.existsSync(path.join(root, "concurrent-reconcile"))).toBe(true);
+	});
+
+	it("removes an identical pending receipt after invalid_request reports an existing destination", () => {
+		const { pending, receipt } = pendingReceipt();
+		fs.copyFileSync(pending, receipt);
+		const realRename = native.renameNoReplacePath;
+		vi.spyOn(native, "renameNoReplacePath").mockImplementation((source, destination) => {
+			if (source === pending)
+				return invalidRequest();
+			return realRename(source, destination);
+		});
+
+		replay("identical-receipt");
+
+		expect(fs.existsSync(pending)).toBe(false);
+		expect(fs.existsSync(receipt)).toBe(true);
+	});
+
+	it("rejects invalid_request when the existing destination receipt has different contents", () => {
+		const { pending, receipt } = pendingReceipt();
+		fs.writeFileSync(receipt, "different receipt\n");
+		const realRename = native.renameNoReplacePath;
+		vi.spyOn(native, "renameNoReplacePath").mockImplementation((source, destination) =>
+			source === pending
+				? invalidRequest()
+				: realRename(source, destination),
+		);
+
+		expect(() => replay("conflicting-receipt")).toThrow("managed_replace_cleanup_receipt_invalid");
+		expect(fs.existsSync(pending)).toBe(true);
+		expect(fs.existsSync(receipt)).toBe(true);
+	});
+
+	it("preserves invalid_request when only the pending receipt exists", () => {
+		const { pending, receipt } = pendingReceipt();
+		const realRename = native.renameNoReplacePath;
+		vi.spyOn(native, "renameNoReplacePath").mockImplementation((source, destination) =>
+			source === pending ? invalidRequest() : realRename(source, destination),
+		);
+
+		expect(() => replay("genuine-invalid-request")).toThrow("managed_publish_failed:invalid_request");
+		expect(fs.existsSync(pending)).toBe(true);
+		expect(fs.existsSync(receipt)).toBe(false);
 	});
 
 	it("continues reconcile when a canonical receipt disappears between capture and unlink (native not_found)", () => {


### PR DESCRIPTION
Closes #4368.

## Summary

Makes pending replacement-receipt reconciliation idempotent after `destination_exists` or Windows preflight `invalid_request`. The reconciler re-captures both paths and accepts success only when final disk state proves it:

* pending absent and canonical destination present: another reconciler completed the move;
* both present with equal SHA-256: exact-unlink the captured pending receipt;
* pending only: preserve the original publish failure;
* both absent or unequal content: fail closed with a receipt-integrity error.

No `invalid_request` is ignored without state and hash verification.

## Regression coverage

* another reconciler moves pending to destination before the result is observed;
* an identical destination already exists;
* destination hash conflict remains fail-closed;
* a genuine pending-only `invalid_request` remains a publish error.

## Validation

* Reproduced and manually validated using an installed-package patch on Windows; session writes recovered after the preflight race.
* `bunx tsc --noEmit -p packages/coding-agent/tsconfig.json` passes.
* `git diff --check` passes.
* Focused Bun tests could not run on the authoring macOS host because the repository native addon is absent and Cargo is unavailable to build it. CI should provide the native test environment.