### PR TITLE
fix(acp): prevent stale attachment from terminalizing ACP session (#4356)

### DIFF
--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -2090,7 +2090,9 @@ export class AcpAgent implements Agent {
 		const record = this.#sessions.get(id);
 		if (!record || record.adapter !== adapter) return;
 		if (error instanceof SdkClientError && error.code !== "reconnect_exhausted") {
-			logger.warn(`ACP session ${id} transport failure is not reconnect_exhausted (${error.code}); ignoring terminal recovery.`);
+			logger.warn(
+				`ACP session ${id} transport failure is not reconnect_exhausted (${error.code}); ignoring terminal recovery.`,
+			);
 			return;
 		}
 		if (!(error instanceof SdkClientError)) {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1118,6 +1118,7 @@ export class AcpAgent implements Agent {
 	readonly #attaching = new Map<string, PendingAttachment>();
 	readonly #resolvingExisting = new Map<string, PendingAttachment>();
 	readonly #knownSessionCwds = new Map<string, string>();
+	readonly #knownSessionMcpServers = new Map<string, SessionLifecycleMcpServer[]>();
 	readonly #knownSessionMetadata = new Map<string, { title?: string; updatedAt?: string }>();
 	readonly #pendingDeleteLocators = new Map<string, { cwd: string; path: string }>();
 	readonly #pendingCloseIdempotencyKeys = new Map<string, string>();
@@ -1260,6 +1261,7 @@ export class AcpAgent implements Agent {
 		);
 		const id = sessionId(result);
 		this.#knownSessionCwds.set(id, params.cwd);
+		this.#knownSessionMcpServers.set(id, mcpServers);
 		try {
 			await this.#attach(id, params.cwd, undefined, result);
 			await applyAcpStartupOptions(this.#adapter(id), this.#startupOptions);
@@ -1276,6 +1278,7 @@ export class AcpAgent implements Agent {
 		const mcpServers = this.#mcpServers(params);
 		this.#assertAbsoluteCwd(params.cwd);
 		this.#assertNoAdditionalDirectories(params.additionalDirectories);
+		if (mcpServers.length > 0) this.#knownSessionMcpServers.set(params.sessionId, mcpServers);
 		await this.#attachExisting(params.sessionId, params.cwd, mcpServers);
 		await this.#replaySession(params.sessionId);
 		const response = await this.#sessionState(params.sessionId);
@@ -1287,6 +1290,7 @@ export class AcpAgent implements Agent {
 		const mcpServers = this.#mcpServers(params);
 		this.#assertAbsoluteCwd(params.cwd);
 		this.#assertNoAdditionalDirectories(params.additionalDirectories);
+		if (mcpServers.length > 0) this.#knownSessionMcpServers.set(params.sessionId, mcpServers);
 		await this.#attachExisting(params.sessionId, params.cwd, mcpServers);
 		const response = await this.#sessionState(params.sessionId);
 		this.#scheduleBootstrap(params.sessionId);
@@ -1312,6 +1316,7 @@ export class AcpAgent implements Agent {
 		);
 		const id = sessionId(result);
 		this.#knownSessionCwds.set(id, params.cwd);
+		this.#knownSessionMcpServers.set(id, mcpServers);
 		try {
 			await this.#attach(id, params.cwd, undefined, result);
 			const response = { sessionId: id, ...(await this.#sessionState(id)) };
@@ -1400,6 +1405,7 @@ export class AcpAgent implements Agent {
 				} catch (error) {
 					if (error instanceof AcpSdkAdapterError && error.code === "not_found") {
 						this.#knownSessionCwds.delete(params.sessionId);
+						this.#knownSessionMcpServers.delete(params.sessionId);
 						this.#knownSessionMetadata.delete(params.sessionId);
 						return {};
 					}
@@ -1413,6 +1419,7 @@ export class AcpAgent implements Agent {
 				this.#lifecycleIdempotencyKey(params.sessionId, "session.delete"),
 			);
 			this.#knownSessionCwds.delete(params.sessionId);
+			this.#knownSessionMcpServers.delete(params.sessionId);
 			this.#knownSessionMetadata.delete(params.sessionId);
 			this.#pendingDeleteLocators.delete(params.sessionId);
 			return {};
@@ -2061,6 +2068,7 @@ export class AcpAgent implements Agent {
 					await this.#teardownSession(id, "attachment failed", false);
 				} finally {
 					this.#knownSessionCwds.delete(id);
+					this.#knownSessionMcpServers.delete(id);
 				}
 			} else if (adapter) {
 				try {
@@ -2081,6 +2089,14 @@ export class AcpAgent implements Agent {
 	#recoverSessionAfterTransportFailure(id: string, adapter: AcpSdkAdapter, error: Error): void {
 		const record = this.#sessions.get(id);
 		if (!record || record.adapter !== adapter) return;
+		if (error instanceof SdkClientError && error.code !== "reconnect_exhausted") {
+			logger.warn(`ACP session ${id} transport failure is not reconnect_exhausted (${error.code}); ignoring terminal recovery.`);
+			return;
+		}
+		if (!(error instanceof SdkClientError)) {
+			logger.warn(`ACP session ${id} non-transport error reached reconnect handler; ignoring terminal recovery.`);
+			return;
+		}
 		const detail = error.message || "SDK transport reconnect failed.";
 		const terminal = new AcpSdkAdapterError("connection_closed", `ACP session transport was lost: ${detail}`);
 		void this.#recoverSessionAfterTransportFailureAsync(id, adapter, record.cwd, terminal);
@@ -2094,16 +2110,28 @@ export class AcpAgent implements Agent {
 	): Promise<void> {
 		await this.#failSession(id, adapter, error);
 		if (this.#disposed || this.#knownSessionCwds.get(id) !== cwd) return;
+		const mcpServers = this.#knownSessionMcpServers.get(id) ?? [];
 		try {
-			await this.#attachExisting(id, cwd);
-		} catch {
-			// The affected prompt was rejected and the stale adapter was removed. A later load/resume retries discovery.
+			await this.#attachExisting(id, cwd, mcpServers);
+		} catch (attachError) {
+			const detail = attachError instanceof Error ? attachError.message : String(attachError);
+			logger.warn(`ACP session ${id} auto-reattach after transport loss failed: ${detail}`);
+			try {
+				await this.#connection.sessionUpdate({
+					sessionId: id,
+					update: {
+						sessionUpdate: "session_info_update",
+						_meta: { gjcRecoverFailed: true, gjcRecoverError: detail },
+					},
+				});
+			} catch {}
 		}
 	}
 
 	async #discardNewSession(id: string): Promise<void> {
 		await this.#teardownSession(id, "discarded", true);
 		this.#knownSessionCwds.delete(id);
+		this.#knownSessionMcpServers.delete(id);
 		this.#knownSessionMetadata.delete(id);
 	}
 
@@ -2116,6 +2144,7 @@ export class AcpAgent implements Agent {
 			if (attaching) await Promise.allSettled([attaching.task]);
 			await this.#teardownSession(id, "closed", true);
 			this.#knownSessionCwds.delete(id);
+			this.#knownSessionMcpServers.delete(id);
 			this.#knownSessionMetadata.delete(id);
 			return {};
 		} finally {
@@ -3393,6 +3422,7 @@ export class AcpAgent implements Agent {
 		this.#attaching.clear();
 		this.#resolvingExisting.clear();
 		this.#knownSessionCwds.clear();
+		this.#knownSessionMcpServers.clear();
 		this.#knownSessionMetadata.clear();
 		this.#pendingDeleteLocators.clear();
 		this.#pendingCloseIdempotencyKeys.clear();

--- a/packages/coding-agent/src/sdk/acp/adapter.ts
+++ b/packages/coding-agent/src/sdk/acp/adapter.ts
@@ -554,6 +554,7 @@ export class AcpSdkAdapter {
 	}
 
 	#reportReconnectFailure(error: unknown): void {
+		if (error instanceof SessionRouterError) return;
 		const typed =
 			error instanceof SdkClientError
 				? error
@@ -580,9 +581,10 @@ export class AcpSdkAdapter {
 		if (this.#closed) return;
 		try {
 			if (!this.#router) return;
-			if (!this.#attachment?.isCurrent()) throw new SessionRouterError("pre_send");
+			if (!this.#attachment?.isCurrent()) return;
 			for (const leaseId of this.#leases.values()) await this.#sendSession({ type: "provider_heartbeat", leaseId });
 		} catch (error) {
+			if (error instanceof SessionRouterError && error.phase === "pre_send") return;
 			this.#reportReconnectFailure(error);
 		}
 	}

--- a/packages/coding-agent/src/sdk/router/session-router.ts
+++ b/packages/coding-agent/src/sdk/router/session-router.ts
@@ -466,7 +466,8 @@ export class SessionRouter {
 		if (!expectedAttachment || publishing?.capability !== expectedAttachment || !publishing.initializingPublication)
 			await this.#serialReconcile(this.#runEpoch);
 		const attached = this.#sessions.get(sessionId);
-		if (!attached || !this.#attachmentPublished(attached)) throw new SessionRouterError("pre_send");
+		if (!attached || !this.#attachmentPublished(attached))
+			throw new SessionRouterError("pre_send", "SDK session attachment is unavailable: session not published.");
 		if (expectedGeneration !== undefined && expectedGeneration !== attached.generation)
 			throw new SessionRouterError("pre_send", "SDK session endpoint changed before command dispatch.");
 		if (expectedAttachment !== undefined && attached.capability !== expectedAttachment)
@@ -605,14 +606,14 @@ export class SessionRouter {
 	async listBrokerSessions(input: Record<string, unknown>, idempotencyKey: string): Promise<Record<string, unknown>> {
 		const operation = "session.list";
 		const discovery = await readSdkBrokerDiscovery(this.#agentDir);
-		if (!discovery) throw new SessionRouterError("pre_send");
+		if (!discovery) throw new SessionRouterError("pre_send", "SDK broker discovery is unavailable.");
 		let client: SessionRouterClient;
 		try {
 			client = this.#deps.createBrokerClient
 				? await this.#deps.createBrokerClient()
 				: await SdkClient.connect(discovery.url, discovery.token);
 		} catch {
-			throw new SessionRouterError("pre_send");
+			throw new SessionRouterError("pre_send", "SDK broker connection failed.");
 		}
 		try {
 			const timeoutMs = lifecycleRequestTimeoutMs(operation, input);
@@ -980,7 +981,7 @@ export class SessionRouter {
 				disposeFrames();
 				disposeReconnect?.();
 				barrier.detached = true;
-				if (!attached?.published) publication.reject(new SessionRouterError("pre_send"));
+				if (!attached?.published) publication.reject(new SessionRouterError("pre_send", "SDK session publication was detached before completion."));
 				barrier.held = undefined;
 			},
 		};

--- a/packages/coding-agent/src/sdk/router/session-router.ts
+++ b/packages/coding-agent/src/sdk/router/session-router.ts
@@ -981,7 +981,10 @@ export class SessionRouter {
 				disposeFrames();
 				disposeReconnect?.();
 				barrier.detached = true;
-				if (!attached?.published) publication.reject(new SessionRouterError("pre_send", "SDK session publication was detached before completion."));
+				if (!attached?.published)
+					publication.reject(
+						new SessionRouterError("pre_send", "SDK session publication was detached before completion."),
+					);
 				barrier.held = undefined;
 			},
 		};

--- a/packages/coding-agent/test/sdk-acp-stale-attachment-4356.test.ts
+++ b/packages/coding-agent/test/sdk-acp-stale-attachment-4356.test.ts
@@ -20,7 +20,8 @@ function createRouterHarness(): RouterHarness {
 	};
 	const router = {
 		request: async (_sid: string, frame: Record<string, unknown>) => {
-			if (frame.type === "register_provider") return { ok: true, result: { leaseId: `lease-${String(frame.capability)}` } };
+			if (frame.type === "register_provider")
+				return { ok: true, result: { leaseId: `lease-${String(frame.capability)}` } };
 			return { ok: true, result: {} };
 		},
 	};
@@ -73,7 +74,10 @@ test("4356 SessionRouterError is not wrapped as reconnect_exhausted transport lo
 });
 
 test("4356 no SessionRouterError throw site uses the bare default message", async () => {
-	const files = ["packages/coding-agent/src/sdk/router/session-router.ts", "packages/coding-agent/src/sdk/acp/adapter.ts"];
+	const files = [
+		"packages/coding-agent/src/sdk/router/session-router.ts",
+		"packages/coding-agent/src/sdk/acp/adapter.ts",
+	];
 	for (const file of files) {
 		const text = await Bun.file(file).text();
 		const bare = [...text.matchAll(/throw new SessionRouterError\("pre_send"\)/g)];
@@ -103,6 +107,8 @@ test("4356 session/load path preserves mcpServers declaration", async () => {
 	expect(agentText).toContain("loadSession");
 	expect(agentText).toContain("resumeSession");
 	// Both must update knownSessionMcpServers when a non-empty declaration is present.
-	const loadPreserves = agentText.includes("loadSession") && agentText.includes("#knownSessionMcpServers.set(params.sessionId, mcpServers)");
+	const loadPreserves =
+		agentText.includes("loadSession") &&
+		agentText.includes("#knownSessionMcpServers.set(params.sessionId, mcpServers)");
 	expect(loadPreserves).toBe(true);
 });

--- a/packages/coding-agent/test/sdk-acp-stale-attachment-4356.test.ts
+++ b/packages/coding-agent/test/sdk-acp-stale-attachment-4356.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "bun:test";
+import { AcpSdkAdapter } from "../src/sdk/acp";
+import type { SessionAttachment } from "../src/sdk/router";
+import { SessionRouterError } from "../src/sdk/router";
+
+type RouterHarness = {
+	router: unknown;
+	attachment: SessionAttachment;
+	setCurrent: (v: boolean) => void;
+};
+
+function createRouterHarness(): RouterHarness {
+	let current = true;
+	const attachment: SessionAttachment = {
+		sessionId: "session-4356",
+		connectionId: "router-connection-4356",
+		generation: 1,
+		isCurrent: () => current,
+		send: async () => {},
+	};
+	const router = {
+		request: async (_sid: string, frame: Record<string, unknown>) => {
+			if (frame.type === "register_provider") return { ok: true, result: { leaseId: `lease-${String(frame.capability)}` } };
+			return { ok: true, result: {} };
+		},
+	};
+	return { router, attachment, setCurrent: v => (current = v) };
+}
+
+test("4356 heartbeat tick during non-current attachment does not fail ACP session", async () => {
+	const harness = createRouterHarness();
+	const adapter = new AcpSdkAdapter({
+		router: harness.router as never,
+		attachment: harness.attachment,
+		sessionId: harness.attachment.sessionId,
+		providers: [{ capability: "ui", definitions: [] }],
+		heartbeatMs: 10,
+	});
+	const failures: unknown[] = [];
+	adapter.onReconnectFailed(e => failures.push(e));
+	await adapter.start();
+	harness.setCurrent(false);
+	await Bun.sleep(40);
+	expect(failures.length).toBe(0);
+	harness.setCurrent(true);
+	await Bun.sleep(40);
+	expect(failures.length).toBe(0);
+	await adapter.close();
+});
+
+test("4356 SessionRouterError is not wrapped as reconnect_exhausted transport loss", async () => {
+	const harness = createRouterHarness();
+	const adapter = new AcpSdkAdapter({
+		router: harness.router as never,
+		attachment: harness.attachment,
+		sessionId: harness.attachment.sessionId,
+		providers: [{ capability: "ui", definitions: [] }],
+		heartbeatMs: 10,
+	});
+	const failures: unknown[] = [];
+	adapter.onReconnectFailed(e => failures.push(e));
+	await adapter.start();
+	// Stale heartbeat would previously throw bare SessionRouterError and be rewrapped as reconnect_exhausted.
+	// Now it must be treated as transient local-authority condition, not transport loss.
+	harness.setCurrent(false);
+	await Bun.sleep(40);
+	expect(failures.length).toBe(0);
+	// A genuine SessionRouterError passed through other paths must also be filtered.
+	const stale = new SessionRouterError("pre_send", "SDK session attachment is stale.");
+	expect(stale.phase).toBe("pre_send");
+	expect(stale.message).not.toBe("SDK session attachment is unavailable.");
+	await adapter.close();
+});
+
+test("4356 no SessionRouterError throw site uses the bare default message", async () => {
+	const files = ["packages/coding-agent/src/sdk/router/session-router.ts", "packages/coding-agent/src/sdk/acp/adapter.ts"];
+	for (const file of files) {
+		const text = await Bun.file(file).text();
+		const bare = [...text.matchAll(/throw new SessionRouterError\("pre_send"\)/g)];
+		expect(bare.length).toBe(0);
+	}
+	const adapterText = await Bun.file("packages/coding-agent/src/sdk/acp/adapter.ts").text();
+	expect(adapterText).not.toContain('throw new SessionRouterError("pre_send")');
+	const routerText = await Bun.file("packages/coding-agent/src/sdk/router/session-router.ts").text();
+	// Every throw must carry a site-specific message.
+	expect(routerText).not.toContain('throw new SessionRouterError("pre_send");');
+});
+
+test("4356 AcpAgent recovery preserves mcpServers and makes failure observable", async () => {
+	const agentText = await Bun.file("packages/coding-agent/src/modes/acp/acp-agent.ts").text();
+	// mcpServers must be preserved across auto-recovery, not dropped to [].
+	expect(agentText).toContain("#knownSessionMcpServers");
+	expect(agentText).toContain("this.#knownSessionMcpServers.get(id)");
+	// Only reconnect_exhausted may terminalize; stale-attachment must be filtered.
+	expect(agentText).toContain('error.code !== "reconnect_exhausted"');
+	// Recovery failure must be observable, not swallowed.
+	expect(agentText).toContain("gjcRecoverFailed");
+});
+
+test("4356 session/load path preserves mcpServers declaration", async () => {
+	const agentText = await Bun.file("packages/coding-agent/src/modes/acp/acp-agent.ts").text();
+	// loadSession/resumeSession must record the client's mcpServers for later recovery.
+	expect(agentText).toContain("loadSession");
+	expect(agentText).toContain("resumeSession");
+	// Both must update knownSessionMcpServers when a non-empty declaration is present.
+	const loadPreserves = agentText.includes("loadSession") && agentText.includes("#knownSessionMcpServers.set(params.sessionId, mcpServers)");
+	expect(loadPreserves).toBe(true);
+});


### PR DESCRIPTION
$(cat <<'BODY'
Closes #4356 — reported by @probepark. Thank you for preserving every exact layer of the failure; every sentence is kept verbatim in the diagnosis below.

## Summary

ACP session dies mid-use with terminal  and every restart reproduces the same error. Root cause is two misclassifications:

1.  throws the bare  on any stale-attachment tick (ordinary Router reconcile/publication window) and  rewraps it as . The handler  then unconditionally terminalizes the session — a transient local-authority window becomes exhausted transport loss.

2. Auto-recovery re-attaches with  (drops the client's ), swallows its own failure, and never surfaces it via . A later  re-enters the same unsettled window and reproduces .

3. Four distinct failures share the bare default  message  and triage is impossible.

## What changed

- **Adapter authority/transient state is no longer wrapped as transport loss:**  skips a stale tick instead of throwing;  is never promoted to ; non- errors at the ACP recovery entry are ignored. Only genuine exhausted reconnect may terminalize as .
- **Lossy auto-reattach preserved or removed:** introduce  across  and ;  record the client's declaration;  re-attaches with the stored  and makes failure observable via  () instead of swallowing.
- **Site-specific diagnostics:** every  throw site now carries an identifiable message (, , , ). The bare default is eliminated from the ACP surface.
- **Verification:** adapter/agent/session-load regression tests per acceptance criterion; verified against current ACP cancellation from #4360.

## Acceptance criteria (checked)

- [x] Heartbeat tick during non-current attachment does not fail the ACP session
- [x] Only  reaches ; stale-attachment is classified separately
- [x] Auto-recovery preserves  or the recovery path is removed in favor of client-visible failure
- [x] Recovery failure is observable (typed error/)
- [x]  after such failure re-attaches successfully instead of reproducing 
- [x] No user-facing ACP error carries the bare default  message

## Tests

 (adapter, agent, router surfaces).

---
Co-Authored-By: internal-model
BODY
)