### PR TITLE
fix(session): reconcile Windows replacement receipts safely

### DIFF
--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -1317,7 +1317,7 @@ export class ManagedSessionDescendantStore {
 			const existing = captureIfPresent(destination);
 			if (!currentPending && existing) {
 				if (
-					!sameIdentity(existing.identity, pending.identity) ||
+					!sameReplacementIdentity(existing.identity, pending.identity) ||
 					existing.identity.sha256 !== pending.identity.sha256
 				)
 					throw new Error("managed_replace_cleanup_receipt_invalid");

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -1304,20 +1304,34 @@ export class ManagedSessionDescendantStore {
 			fsyncDirectory(this.#baseDir);
 			return;
 		}
-		if (outcome.reason === "destination_exists") {
-			const existing = captureManagedFilePrefixNoFollow(destination, REPLACEMENT_CLEANUP_RECEIPT_MAX_BYTES);
-			if (existing.identity.sha256 !== pending.identity.sha256)
+		if (outcome.reason === "destination_exists" || outcome.reason === "invalid_request") {
+			const captureIfPresent = (pathname: string): ManagedFileSnapshot | undefined => {
+				try {
+					return captureManagedFilePrefixNoFollow(pathname, REPLACEMENT_CLEANUP_RECEIPT_MAX_BYTES);
+				} catch (error) {
+					if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+					throw error;
+				}
+			};
+			const currentPending = captureIfPresent(receiptPath);
+			const existing = captureIfPresent(destination);
+			if (!currentPending && existing) {
+				fsyncDirectory(this.#baseDir);
+				return;
+			}
+			if (currentPending && !existing) throw publishFailure(outcome);
+			if (!currentPending || !existing || existing.identity.sha256 !== currentPending.identity.sha256)
 				throw new Error("managed_replace_cleanup_receipt_invalid");
 			const removed = nativeSessionStorage().exactUnlink(receiptPath, {
-				dev: pending.identity.dev,
-				ino: pending.identity.ino,
-				nlink: pending.identity.nlink,
+				dev: currentPending.identity.dev,
+				ino: currentPending.identity.ino,
+				nlink: currentPending.identity.nlink,
 				parentDev: this.#subtreeRoot.dev,
 				parentIno: this.#subtreeRoot.ino,
-				size: BigInt(pending.identity.size),
-				mtimeNs: pending.identity.mtimeNs,
-				sha256: pending.identity.sha256,
-				quarantineName: `.gjc-receipt-pending-remove-${pending.identity.dev.toString(16)}-${pending.identity.ino.toString(16)}`,
+				size: BigInt(currentPending.identity.size),
+				mtimeNs: currentPending.identity.mtimeNs,
+				sha256: currentPending.identity.sha256,
+				quarantineName: `.gjc-receipt-pending-remove-${currentPending.identity.dev.toString(16)}-${currentPending.identity.ino.toString(16)}`,
 			});
 			if (!exactUnlinkCompleted(removed) && removed.code !== "not_found")
 				throw new Error(`managed_replace_receipt_cleanup_pending:${removed.code ?? "unknown"}`);

--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -1316,27 +1316,20 @@ export class ManagedSessionDescendantStore {
 			const currentPending = captureIfPresent(receiptPath);
 			const existing = captureIfPresent(destination);
 			if (!currentPending && existing) {
+				if (
+					!sameIdentity(existing.identity, pending.identity) ||
+					existing.identity.sha256 !== pending.identity.sha256
+				)
+					throw new Error("managed_replace_cleanup_receipt_invalid");
 				fsyncDirectory(this.#baseDir);
 				return;
 			}
 			if (currentPending && !existing) throw publishFailure(outcome);
-			if (!currentPending || !existing || existing.identity.sha256 !== currentPending.identity.sha256)
-				throw new Error("managed_replace_cleanup_receipt_invalid");
-			const removed = nativeSessionStorage().exactUnlink(receiptPath, {
-				dev: currentPending.identity.dev,
-				ino: currentPending.identity.ino,
-				nlink: currentPending.identity.nlink,
-				parentDev: this.#subtreeRoot.dev,
-				parentIno: this.#subtreeRoot.ino,
-				size: BigInt(currentPending.identity.size),
-				mtimeNs: currentPending.identity.mtimeNs,
-				sha256: currentPending.identity.sha256,
-				quarantineName: `.gjc-receipt-pending-remove-${currentPending.identity.dev.toString(16)}-${currentPending.identity.ino.toString(16)}`,
-			});
-			if (!exactUnlinkCompleted(removed) && removed.code !== "not_found")
-				throw new Error(`managed_replace_receipt_cleanup_pending:${removed.code ?? "unknown"}`);
-			fsyncDirectory(this.#baseDir);
-			return;
+			// Two names cannot both authoritatively represent the one receipt identity
+			// encoded in the canonical filename. A byte-identical copy has a different
+			// filesystem identity and would make the canonical receipt fail its next
+			// reconciliation, while a hard link violates the single-link capture fence.
+			throw new Error("managed_replace_cleanup_receipt_invalid");
 		}
 		throw publishFailure(outcome);
 	}

--- a/packages/coding-agent/test/session-storage.test.ts
+++ b/packages/coding-agent/test/session-storage.test.ts
@@ -1055,7 +1055,6 @@ describe.skipIf(process.platform !== "darwin")("managed replacement receipt deta
 		store.publishNoReplaceSync(name, Buffer.from("trigger\n"));
 	};
 
-
 	beforeEach(() => {
 		root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-replace-journal-"));
 		leaveReceiptPlaceholder = false;
@@ -1354,20 +1353,35 @@ describe("replacement cleanup receipt reconcile TOCTOU resilience", () => {
 		expect(fs.existsSync(path.join(root, "concurrent-reconcile"))).toBe(true);
 	});
 
-	it("removes an identical pending receipt after invalid_request reports an existing destination", () => {
+	it("rejects invalid_request when the pending receipt disappears into a conflicting destination", () => {
+		const { pending, receipt } = pendingReceipt();
+		const realRename = native.renameNoReplacePath;
+		vi.spyOn(native, "renameNoReplacePath").mockImplementation((source, destination) => {
+			if (source !== pending) return realRename(source, destination);
+			fs.rmSync(source);
+			fs.writeFileSync(destination, "conflicting receipt\n");
+			return invalidRequest();
+		});
+
+		expect(() => replay("conflicting-move")).toThrow("managed_replace_cleanup_receipt_invalid");
+		expect(fs.existsSync(pending)).toBe(false);
+		expect(fs.readFileSync(receipt, "utf8")).toBe("conflicting receipt\n");
+		expect(fs.existsSync(path.join(root, "conflicting-move"))).toBe(false);
+	});
+
+	it("rejects a byte-identical destination copy because it lacks the receipt filesystem identity", () => {
 		const { pending, receipt } = pendingReceipt();
 		fs.copyFileSync(pending, receipt);
 		const realRename = native.renameNoReplacePath;
 		vi.spyOn(native, "renameNoReplacePath").mockImplementation((source, destination) => {
-			if (source === pending)
-				return invalidRequest();
+			if (source === pending) return invalidRequest();
 			return realRename(source, destination);
 		});
 
-		replay("identical-receipt");
-
-		expect(fs.existsSync(pending)).toBe(false);
+		expect(() => replay("identical-receipt")).toThrow("managed_replace_cleanup_receipt_invalid");
+		expect(fs.existsSync(pending)).toBe(true);
 		expect(fs.existsSync(receipt)).toBe(true);
+		expect(fs.existsSync(path.join(root, "identical-receipt"))).toBe(false);
 	});
 
 	it("rejects invalid_request when the existing destination receipt has different contents", () => {
@@ -1375,14 +1389,27 @@ describe("replacement cleanup receipt reconcile TOCTOU resilience", () => {
 		fs.writeFileSync(receipt, "different receipt\n");
 		const realRename = native.renameNoReplacePath;
 		vi.spyOn(native, "renameNoReplacePath").mockImplementation((source, destination) =>
-			source === pending
-				? invalidRequest()
-				: realRename(source, destination),
+			source === pending ? invalidRequest() : realRename(source, destination),
 		);
 
 		expect(() => replay("conflicting-receipt")).toThrow("managed_replace_cleanup_receipt_invalid");
 		expect(fs.existsSync(pending)).toBe(true);
 		expect(fs.existsSync(receipt)).toBe(true);
+	});
+
+	it("rejects invalid_request when both receipt paths disappear", () => {
+		const { pending, receipt } = pendingReceipt();
+		const realRename = native.renameNoReplacePath;
+		vi.spyOn(native, "renameNoReplacePath").mockImplementation((source, destination) => {
+			if (source !== pending) return realRename(source, destination);
+			fs.rmSync(source);
+			return invalidRequest();
+		});
+
+		expect(() => replay("missing-receipts")).toThrow("managed_replace_cleanup_receipt_invalid");
+		expect(fs.existsSync(pending)).toBe(false);
+		expect(fs.existsSync(receipt)).toBe(false);
+		expect(fs.existsSync(path.join(root, "missing-receipts"))).toBe(false);
 	});
 
 	it("preserves invalid_request when only the pending receipt exists", () => {
@@ -1392,7 +1419,7 @@ describe("replacement cleanup receipt reconcile TOCTOU resilience", () => {
 			source === pending ? invalidRequest() : realRename(source, destination),
 		);
 
-		expect(() => replay("genuine-invalid-request")).toThrow("managed_publish_failed:invalid_request");
+		expect(() => replay("genuine-invalid-request")).toThrow("invalid_request");
 		expect(fs.existsSync(pending)).toBe(true);
 		expect(fs.existsSync(receipt)).toBe(false);
 	});

--- a/packages/coding-agent/test/session-storage.test.ts
+++ b/packages/coding-agent/test/session-storage.test.ts
@@ -1055,6 +1055,7 @@ describe.skipIf(process.platform !== "darwin")("managed replacement receipt deta
 		store.publishNoReplaceSync(name, Buffer.from("trigger\n"));
 	};
 
+
 	beforeEach(() => {
 		root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-replace-journal-"));
 		leaveReceiptPlaceholder = false;
@@ -1295,6 +1296,39 @@ describe("replacement cleanup receipt reconcile TOCTOU resilience", () => {
 		const store = new ManagedSessionDescendantStore(managedDirectoryRoot(root), root);
 		store.publishNoReplaceSync(name, Buffer.from("trigger\n"));
 	};
+	const pendingReceipt = () => {
+		const destination = path.join(root, "session.jsonl");
+		const staging = path.join(root, ".session.replacement");
+		const predecessorPath = path.join(root, "predecessor");
+		fs.writeFileSync(destination, "successor\n");
+		fs.writeFileSync(staging, "prepared\n");
+		fs.writeFileSync(predecessorPath, "predecessor\n");
+		const predecessor = snapshot(predecessorPath);
+		const pending = path.join(root, `.gjc-replace-receipt-pending-${randomUUID()}.json`);
+		fs.writeFileSync(
+			pending,
+			JSON.stringify({
+				version: 3,
+				staging,
+				destination,
+				predecessor,
+				successor: snapshot(destination),
+			}),
+		);
+		const receiptIdentity = snapshot(pending);
+		return { pending, receipt: canonicalReceiptPath(predecessor, receiptIdentity) };
+	};
+	const invalidRequest = () =>
+		({
+			ok: false,
+			code: "invalid_request",
+			reason: "invalid_request",
+			phase: "preflight",
+			mutationState: "not_committed",
+			durabilityState: "not_attempted",
+			primitive: "windows_rename_noreplace",
+			diagnostic: { schemaVersion: 1, collectionState: "complete", osCode: 87 },
+		}) as const;
 
 	beforeEach(() => {
 		root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-replace-toctou-"));
@@ -1302,6 +1336,65 @@ describe("replacement cleanup receipt reconcile TOCTOU resilience", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 		fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	it("accepts invalid_request when another reconciler has already moved the pending receipt", () => {
+		const { pending, receipt } = pendingReceipt();
+		const realRename = native.renameNoReplacePath;
+		vi.spyOn(native, "renameNoReplacePath").mockImplementation((source, destination) => {
+			if (source !== pending) return realRename(source, destination);
+			fs.renameSync(source, destination);
+			return invalidRequest();
+		});
+
+		replay("concurrent-reconcile");
+
+		expect(fs.existsSync(pending)).toBe(false);
+		expect(fs.existsSync(receipt)).toBe(true);
+		expect(fs.existsSync(path.join(root, "concurrent-reconcile"))).toBe(true);
+	});
+
+	it("removes an identical pending receipt after invalid_request reports an existing destination", () => {
+		const { pending, receipt } = pendingReceipt();
+		fs.copyFileSync(pending, receipt);
+		const realRename = native.renameNoReplacePath;
+		vi.spyOn(native, "renameNoReplacePath").mockImplementation((source, destination) => {
+			if (source === pending)
+				return invalidRequest();
+			return realRename(source, destination);
+		});
+
+		replay("identical-receipt");
+
+		expect(fs.existsSync(pending)).toBe(false);
+		expect(fs.existsSync(receipt)).toBe(true);
+	});
+
+	it("rejects invalid_request when the existing destination receipt has different contents", () => {
+		const { pending, receipt } = pendingReceipt();
+		fs.writeFileSync(receipt, "different receipt\n");
+		const realRename = native.renameNoReplacePath;
+		vi.spyOn(native, "renameNoReplacePath").mockImplementation((source, destination) =>
+			source === pending
+				? invalidRequest()
+				: realRename(source, destination),
+		);
+
+		expect(() => replay("conflicting-receipt")).toThrow("managed_replace_cleanup_receipt_invalid");
+		expect(fs.existsSync(pending)).toBe(true);
+		expect(fs.existsSync(receipt)).toBe(true);
+	});
+
+	it("preserves invalid_request when only the pending receipt exists", () => {
+		const { pending, receipt } = pendingReceipt();
+		const realRename = native.renameNoReplacePath;
+		vi.spyOn(native, "renameNoReplacePath").mockImplementation((source, destination) =>
+			source === pending ? invalidRequest() : realRename(source, destination),
+		);
+
+		expect(() => replay("genuine-invalid-request")).toThrow("managed_publish_failed:invalid_request");
+		expect(fs.existsSync(pending)).toBe(true);
+		expect(fs.existsSync(receipt)).toBe(false);
 	});
 
 	it("continues reconcile when a canonical receipt disappears between capture and unlink (native not_found)", () => {


### PR DESCRIPTION
Closes #4368.
Supersedes #4370 for maintainer-controlled `dev` targeting while preserving contributor credit: the original commit is cherry-picked as `8026abbd25` with JaeJin Lee (`asdfqwerzxcc`) as author.

## Disposition

Reconciles pending replacement receipts after Windows `windows_rename_noreplace` preflight `invalid_request` or an existing destination without swallowing an error absent authoritative disk proof.

- pending absent + canonical destination present succeeds only when the destination is the exact captured receipt identity and hash;
- pending only preserves the native publish failure;
- both absent, conflicting contents, copied identities, or dual names fail closed;
- cleanup never path-unlinks: native `exactUnlink` remains identity-bound where cleanup is valid;
- reconciliation stays scoped to each managed descendant store mutation and introduces no process-global session-write block.

## Verification

- `bun test packages/coding-agent/test/session-storage.test.ts` — 88 pass, 20 skip, 0 fail
- `bun --cwd=packages/coding-agent run check` — pass (7 pre-existing warnings, 3 infos)
- `bun run check:tools` — pass (same pre-existing warnings/infos)
- `bunx biome check packages/coding-agent/src/session/internal/managed-session-storage.ts packages/coding-agent/test/session-storage.test.ts` — pass
- `git diff --check` — pass

No release actions.