### PR TITLE
fix(ci): repair coding-agent shard baseline

### DIFF
--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -37,6 +37,8 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 	"slash_command:exit": "visual/local-only command, not a user-facing SDK control seam",
 	"slash_command:notify":
 		"interactive diagnostics command; session on/off delegate to the notifications extension, not an SDK ingress seam",
+	"slash_command:credential":
+		"interactive session credential selector; not a credential-free public SDK operation or independent control seam",
 	"slash_command:pet": "visual/local-only command, not a user-facing SDK control seam",
 	"slash_command:transcript": "visual/local-only transcript viewer, not a user-facing SDK control seam",
 	"slash_command:sessions": "visual/local-only sessions dashboard, not a user-facing SDK control seam",
@@ -45,6 +47,10 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 		"internal session-scoped agent-directory accessor, not a user-facing SDK control seam",
 	"agent_session:captureTerminalAbortSteeringSnapshot":
 		"internal terminal-abort steering snapshot, not a user-facing SDK control seam",
+	"agent_session:rebindTerminalAbortSteeringSnapshot":
+		"internal terminal-abort steering snapshot rebind, not a user-facing SDK control seam",
+	"agent_session:discardTerminalAbortSteeringSnapshot":
+		"internal terminal-abort steering snapshot cleanup, not a user-facing SDK control seam",
 	"agent_session:getConfiguredModelChainState":
 		"internal model-profile transaction snapshot, not a user-facing SDK control seam",
 	"agent_session:getDefaultFallbackRuntimeState":
@@ -229,6 +235,8 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 		"internal fallback runtime bookkeeping, not a user-facing SDK control seam",
 	"agent_session:seedDefaultFallbackResolution":
 		"internal fallback resolution bookkeeping, not a user-facing SDK control seam",
+	"agent_session:syncEagerDelegation":
+		"internal profile-derived eager delegation synchronization, not a user-facing SDK control seam",
 };
 /** Maps reviewed source seams to registry SDK operation IDs. */
 const SEAM_TO_SDK: Readonly<Record<string, string>> = {

--- a/packages/coding-agent/src/crash/index-store.ts
+++ b/packages/coding-agent/src/crash/index-store.ts
@@ -491,7 +491,7 @@ export async function recordCrashStateEvent(
 	const paths = options.paths ?? resolveCrashStatePaths();
 	await fs.mkdir(path.dirname(paths.events), { recursive: true, mode: 0o700 });
 	appendCrashEvent(event, paths.events);
-	return compactCrashIndex({ paths, now: options.now });
+	return compactCrashIndex({ paths, now: options.now ?? event.at });
 }
 
 export interface CrashSignatureView extends CrashSignatureEntry {

--- a/packages/coding-agent/src/crash/index-store.ts
+++ b/packages/coding-agent/src/crash/index-store.ts
@@ -491,7 +491,7 @@ export async function recordCrashStateEvent(
 	const paths = options.paths ?? resolveCrashStatePaths();
 	await fs.mkdir(path.dirname(paths.events), { recursive: true, mode: 0o700 });
 	appendCrashEvent(event, paths.events);
-	return compactCrashIndex({ paths, now: options.now ?? event.at });
+	return compactCrashIndex({ paths, now: options.now });
 }
 
 export interface CrashSignatureView extends CrashSignatureEntry {

--- a/packages/coding-agent/src/crash/report.ts
+++ b/packages/coding-agent/src/crash/report.ts
@@ -394,9 +394,10 @@ export async function runCrashReportFlow(deps: CrashReportDeps): Promise<CrashRe
 	]);
 	if (action === undefined || action === 2) return { status: "cancelled" };
 	if (action === 1) {
+		const eventAt = now().getTime();
 		await recordCrashStateEvent(
-			{ kind: "acknowledged", fingerprint: signature.fingerprint, at: now().getTime() },
-			{ paths: deps.paths },
+			{ kind: "acknowledged", fingerprint: signature.fingerprint, at: eventAt },
+			{ paths: deps.paths, now: eventAt },
 		);
 		deps.io.print(`Dismissed ${signature.fingerprint}.\n`);
 		return { status: "acknowledged", fingerprint: signature.fingerprint };
@@ -512,15 +513,16 @@ export async function runCrashReportFlow(deps: CrashReportDeps): Promise<CrashRe
 			deps.io.print(`Comment failed: ${comment.stderr.trim() || "unknown error"}\n`);
 			return { status: "refused", reason: "comment failed" };
 		}
+		const eventAt = now().getTime();
 		await recordCrashStateEvent(
 			{
 				kind: "reported",
 				fingerprint: signature.fingerprint,
-				at: now().getTime(),
+				at: eventAt,
 				issueUrl: candidate.url,
 				commented: true,
 			},
-			{ paths: deps.paths },
+			{ paths: deps.paths, now: eventAt },
 		);
 		deps.io.print(`Commented on ${candidate.url}\n`);
 		return { status: "commented", url: candidate.url };
@@ -539,9 +541,10 @@ export async function runCrashReportFlow(deps: CrashReportDeps): Promise<CrashRe
 		deps.io.print(`Issue creation returned an unexpected URL; not recording it: ${url}\n`);
 		return { status: "refused", reason: "non-canonical issue URL" };
 	}
+	const eventAt = now().getTime();
 	await recordCrashStateEvent(
-		{ kind: "reported", fingerprint: signature.fingerprint, at: now().getTime(), issueUrl: url },
-		{ paths: deps.paths },
+		{ kind: "reported", fingerprint: signature.fingerprint, at: eventAt, issueUrl: url },
+		{ paths: deps.paths, now: eventAt },
 	);
 	deps.io.print(`Created ${url}\n`);
 	return { status: "created", url };

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -1974,6 +1974,17 @@
 		]
 	},
 	{
+		"sourceId": "slash_command:credential",
+		"sourceFile": "packages/coding-agent/src/slash-commands/builtin-registry.ts",
+		"sourceKind": "slash_command",
+		"decision": "exclude",
+		"rationale": "interactive session credential selector; not a credential-free public SDK operation or independent control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
 		"sourceId": "slash_command:changelog",
 		"sourceFile": "packages/coding-agent/src/slash-commands/builtin-registry.ts",
 		"sourceKind": "slash_command",
@@ -3759,6 +3770,28 @@
 		}
 	},
 	{
+		"sourceId": "agent_session:rebindTerminalAbortSteeringSnapshot",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "internal terminal-abort steering snapshot rebind, not a user-facing SDK control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
+		"sourceId": "agent_session:discardTerminalAbortSteeringSnapshot",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "internal terminal-abort steering snapshot cleanup, not a user-facing SDK control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
 		"sourceId": "agent_session:getTerminalTurnEpoch",
 		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
 		"sourceKind": "agent_session",
@@ -3898,6 +3931,17 @@
 		"sourceKind": "agent_session",
 		"decision": "exclude",
 		"rationale": "internal accessor/plumbing, not a user-facing control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
+		"sourceId": "agent_session:syncEagerDelegation",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "internal profile-derived eager delegation synchronization, not a user-facing SDK control seam",
 		"exclusionMetadata": {
 			"adapterMappings": "not_applicable",
 			"testIds": "not_applicable"

--- a/packages/coding-agent/test/crash-index-store.test.ts
+++ b/packages/coding-agent/test/crash-index-store.test.ts
@@ -127,6 +127,30 @@ describe("compactCrashIndex", () => {
 		expect(index.overflow).toBe(false);
 	});
 
+	it("uses the production clock when no compaction time is injected", async () => {
+		const paths = await tempPaths();
+		const future = Date.now() + 2 * 24 * 60 * 60 * 1000;
+		appendCrashEvent(occurrence(fingerprintFor(8), recordId(8), future - 1000), paths.events);
+		const index = await recordCrashStateEvent(
+			{ kind: "acknowledged", fingerprint: fingerprintFor(8), at: future },
+			{ paths },
+		);
+
+		expect(index.signatures[fingerprintFor(8)]).toBeUndefined();
+	});
+
+	it("preserves an injected event time when the caller also injects compaction time", async () => {
+		const paths = await tempPaths();
+		const future = Date.now() + 2 * 24 * 60 * 60 * 1000;
+		appendCrashEvent(occurrence(fingerprintFor(9), recordId(9), future - 1000), paths.events);
+		const index = await recordCrashStateEvent(
+			{ kind: "acknowledged", fingerprint: fingerprintFor(9), at: future },
+			{ paths, now: future },
+		);
+
+		expect(index.signatures[fingerprintFor(9)]?.acknowledgedAt).toBe(future);
+	});
+
 	it("quarantines a hostile index and rebuilds from the journal", async () => {
 		const paths = await tempPaths();
 		await fs.mkdir(path.dirname(paths.index), { recursive: true });


### PR DESCRIPTION
Fixes #4374.\n\nRepairs the three repository-baseline assertions blocking unrelated affected shards: preserve injected crash-event time during compaction and review/exclude the newly introduced internal operation seams.\n\nVerified: 32 focused tests pass; coding-agent check exits 0 with only pre-existing warnings.\n\nSigned-off-by: Yeachan-Heo <yeachan-heo@gajae.dev>