### PR TITLE
fix(ai): validate Synthetic API key via models endpoint, not retired Kimi probe

### DIFF
--- a/packages/ai/src/utils/oauth/synthetic.ts
+++ b/packages/ai/src/utils/oauth/synthetic.ts
@@ -8,9 +8,8 @@ export const loginSynthetic = createApiKeyLogin({
 	promptMessage: "Paste your Synthetic API key",
 	placeholder: "sk-...",
 	validation: {
-		kind: "chat-completions",
+		kind: "models-endpoint",
 		provider: "Synthetic",
-		baseUrl: "https://api.synthetic.new/openai/v1",
-		model: "hf:moonshotai/Kimi-K2.5",
+		modelsUrl: "https://api.synthetic.new/openai/v1/models",
 	},
 });

--- a/packages/ai/test/synthetic-login.test.ts
+++ b/packages/ai/test/synthetic-login.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { loginSynthetic } from "../src/utils/oauth/synthetic";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+	global.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+describe("synthetic login", () => {
+	it("validates the API key against the models endpoint, not chat completions", async () => {
+		let authUrl: string | undefined;
+		let authInstructions: string | undefined;
+		let promptMessage: string | undefined;
+		let promptPlaceholder: string | undefined;
+
+		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input.toString();
+			// Must hit the models endpoint, never the retired chat-completions probe.
+			expect(url).toBe("https://api.synthetic.new/openai/v1/models");
+			expect(init?.method).toBe("GET");
+			expect(init?.headers).toEqual({ Authorization: "Bearer sk-synthetic-test" });
+
+			// The retired Kimi selector must never appear in any request payload.
+			const body = init?.body;
+			if (typeof body === "string") {
+				expect(body).not.toContain("hf:moonshotai/Kimi-K2.5");
+			}
+
+			return new Response(JSON.stringify({ object: "list", data: [] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		const apiKey = await loginSynthetic({
+			onAuth: info => {
+				authUrl = info.url;
+				authInstructions = info.instructions;
+			},
+			onPrompt: async prompt => {
+				promptMessage = prompt.message;
+				promptPlaceholder = prompt.placeholder;
+				return "sk-synthetic-test";
+			},
+		});
+
+		expect(authUrl).toBe("https://dev.synthetic.new/docs/api/overview");
+		expect(authInstructions).toContain("Copy your API key from the Synthetic dashboard");
+		expect(promptMessage).toBe("Paste your Synthetic API key");
+		expect(promptPlaceholder).toBe("sk-...");
+		expect(apiKey).toBe("sk-synthetic-test");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		// Regression guard: the request must not target chat/completions at all.
+		const calledUrl = String(fetchMock.mock.calls[0][0]);
+		expect(calledUrl).not.toContain("chat/completions");
+	});
+
+	it("surfaces models endpoint validation errors", async () => {
+		global.fetch = vi.fn(
+			async () => new Response('{"error":"invalid_api_key"}', { status: 401 }),
+		) as unknown as typeof fetch;
+
+		await expect(
+			loginSynthetic({
+				onPrompt: async () => "sk-synthetic-test",
+			}),
+		).rejects.toThrow("Synthetic API key validation failed (401)");
+	});
+
+	it("rejects empty keys before any network call", async () => {
+		const fetchMock = vi.fn(async () => new Response("", { status: 200 }));
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		await expect(
+			loginSynthetic({
+				onPrompt: async () => "   ",
+			}),
+		).rejects.toThrow("API key is required");
+
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("requires the onPrompt callback", async () => {
+		await expect(loginSynthetic({})).rejects.toThrow("Synthetic login requires onPrompt callback");
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #4384.

Synthetic `/login` API-key validation returned **HTTP 404** on every key paste because the chat-completions probe hard-coded the now-retired model `hf:moonshotai/Kimi-K2.5`. The provider's suggested replacement (`hf:zai-org/GLM-5.2`) would just recreate the same single-point-of-failure when it is inevitably retired too.

## Fix

Switch Synthetic's login validation from the `chat-completions` kind to the existing `models-endpoint` kind, validating the key against the provider's model catalog (`https://api.synthetic.new/openai/v1/models`) instead of a single model. This is the durable pattern already used by **NanoGPT, OpenGateway, ZenMux, DeepSeek, Fireworks, DeepInfra, Fugu, and BizRouter** — key validation no longer breaks when any individual model is delisted.

`packages/ai/src/utils/oauth/synthetic.ts`:

```diff
 	validation: {
-		kind: "chat-completions",
+		kind: "models-endpoint",
 		provider: "Synthetic",
-		baseUrl: "https://api.synthetic.new/openai/v1",
-		model: "hf:moonshotai/Kimi-K2.5",
+		modelsUrl: "https://api.synthetic.new/openai/v1/models",
 	},
```

This is the smallest durable fix using the existing architecture — no provider/auth redesign, no new model hard-coded, no change to other providers' `/login` behavior.

## Regression coverage

New `packages/ai/test/synthetic-login.test.ts` asserts:
- The login hits `…/v1/models` (GET), **not** `chat/completions`.
- The retired `hf:moonshotai/Kimi-K2.5` selector never appears in any request payload.
- Validation errors from the models endpoint are surfaced.
- Empty keys are rejected before any network call.
- The `onPrompt` callback is required.

The test would fail if the retired Kimi selector is sent again.

## Verification

- `bun test packages/ai/test/synthetic-login.test.ts` — 4 pass.
- `bun test` over the full login-surface cohort (synthetic, nanogpt, opengateway, zenmux, bizrouter, mara, kagi, kilo, deepseek, ollama-cloud) — 38 pass.
- `tsc -p tsconfig.json --noEmit` (packages/ai) — clean.
- `biome check` on touched files — clean.
- `startup-imports` + `register-builtins` — 19 pass.

No live user keys were used in tests; no credentials exposed.

Closes #4384.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
