### PR TITLE
fix(ai): skip no-op thinking repair resends

### DIFF
--- a/artifacts/issue-3670-anthropic-cache-eval.json
+++ b/artifacts/issue-3670-anthropic-cache-eval.json
@@ -7,7 +7,7 @@
 		"url": "https://platform.claude.com/docs/en/build-with-claude/prompt-caching",
 		"retrievedAt": "2026-07-18",
 		"providerSourceBlobOid": "a654fcc1d261547c5fa525763058a57cb3dca230",
-		"providerSourceSha256": "c1fa95dcafdbb5e7f4bcc1863c73656bc0184c6614f7b4ac81f382a1bfacf449",
+		"providerSourceSha256": "8debae1adf66b013b4ce3b03c396915a4867bf551ac111acd1951827ec461188",
 		"inputFixtureSha256": "562926fba79f003eff4d45c0da2292ac66d84302e3960b2d7493441ade1f9e04"
 	},
 	"derivationCommands": [

--- a/artifacts/issue-3670-anthropic-cache-eval.json
+++ b/artifacts/issue-3670-anthropic-cache-eval.json
@@ -6,7 +6,7 @@
 	"source": {
 		"url": "https://platform.claude.com/docs/en/build-with-claude/prompt-caching",
 		"retrievedAt": "2026-07-18",
-		"providerSourceBlobOid": "a654fcc1d261547c5fa525763058a57cb3dca230",
+		"providerSourceBlobOid": "f32963c12f37671f2158042ff87382cb9b72e502",
 		"providerSourceSha256": "8debae1adf66b013b4ce3b03c396915a4867bf551ac111acd1951827ec461188",
 		"inputFixtureSha256": "562926fba79f003eff4d45c0da2292ac66d84302e3960b2d7493441ade1f9e04"
 	},

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Anthropic thinking-replay repairs no longer resend when the failed request carried no native `thinking`/`redacted_thinking` blocks. The invalid-signature and blocks-immutable 400 arms fired the repair unconditionally, but with nothing to drop the rebuilt replay is byte-identical, so each resend drew the same deterministic rejection and burned the repair budget on no-ops before the error surfaced (up to two wasted full-size round trips; the masked proxy-rejection arm already guarded against this). The repair now requires native thinking blocks in flight for every trigger class, and a rejection that provably cannot be repaired surfaces immediately.
+
 ## [0.13.1] - 2026-08-11
 
 ### Fixed

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1997,12 +1997,15 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 						thinkingReplayRepairScope !== "all" &&
 						thinkingReplayRepairAttempts < ANTHROPIC_MAX_THINKING_REPAIRS &&
 						firstTokenTime === undefined &&
-						(thinkingSignatureInvalid ||
-							thinkingBlocksImmutable ||
-							// Masked proxy rejection: unclassifiable on its own, so the replayed
-							// request shape is the evidence. Without signed thinking blocks in
-							// flight there is nothing to repair and the error must surface.
-							(maskedProxyRejection && hasNativeThinkingBlocks(params.messages)))
+						(thinkingSignatureInvalid || thinkingBlocksImmutable || maskedProxyRejection) &&
+						// The repair can only change the request when native thinking blocks are
+						// actually in flight. Without them the rebuilt replay is byte-identical,
+						// so resending would draw the same deterministic rejection and burn the
+						// repair budget on no-ops — the error must surface instead. (For the
+						// masked proxy rejection this guard is also the classifier: the body is
+						// unclassifiable on its own, so the replayed request shape is the only
+						// evidence a thinking repair is worth attempting.)
+						hasNativeThinkingBlocks(params.messages)
 					) {
 						// "cannot be modified" means the cited blocks must be replayed byte for
 						// byte, so editing that turn again can never converge — the only recovery

--- a/packages/ai/test/anthropic-thinking-repair-retry.test.ts
+++ b/packages/ai/test/anthropic-thinking-repair-retry.test.ts
@@ -442,6 +442,92 @@ describe("Anthropic thinking replay repair retry", () => {
 		expect(requestBodies).toHaveLength(1);
 	});
 
+	// A repair that cannot drop any native thinking block rebuilds a byte-identical
+	// request, so resending it can only draw the same deterministic 400 again. The
+	// invalid-signature rejection must surface on the first attempt when no
+	// thinking blocks are in flight instead of burning the repair budget on no-ops.
+	it("surfaces an invalid-signature 400 without resending when the request replays no thinking blocks", async () => {
+		const user: UserMessage = {
+			role: "user",
+			content: "first",
+			timestamp: Date.now(),
+		};
+		const assistant: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: "plain answer" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+		const context: Context = {
+			messages: [user, assistant, { ...user, content: "next prompt", timestamp: Date.now() + 1 }],
+		};
+
+		const requestBodies: unknown[] = [];
+		const create = ((body: unknown) => {
+			requestBodies.push(body);
+			return createAnthropicSignatureInvalid400() as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+
+		const result = await streamAnthropic(model, context, { client }).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("signature");
+		expect(requestBodies).toHaveLength(1);
+	});
+
+	it("surfaces a mutation 400 without resending when the request replays no thinking blocks", async () => {
+		const user: UserMessage = {
+			role: "user",
+			content: "first",
+			timestamp: Date.now(),
+		};
+		const assistant: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: "plain answer" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+		const context: Context = {
+			messages: [user, assistant, { ...user, content: "next prompt", timestamp: Date.now() + 1 }],
+		};
+
+		const requestBodies: unknown[] = [];
+		const create = ((body: unknown) => {
+			requestBodies.push(body);
+			return createAnthropicThinking400() as never;
+		}) as unknown as Anthropic["messages"]["create"];
+		const client = { messages: { create } } as Anthropic;
+
+		const result = await streamAnthropic(model, context, { client }).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("cannot be modified");
+		expect(requestBodies).toHaveLength(1);
+	});
+
 	// Real captured session failure (2026-07-29): the mutation 400 says "latest
 	// assistant message" but cites `messages.1.content.1` — a HISTORICAL turn. The
 	// provider demands those blocks be replayed verbatim, so a latest-only edit is
@@ -725,30 +811,46 @@ describe("Anthropic thinking replay repair retry", () => {
 			tools: [tool],
 		});
 
-		it("keeps thinking repair active when a later forced-tool_choice fallback rebuilds params", async () => {
+		it("keeps thinking repair active when a later fast-mode fallback rebuilds params", async () => {
+			// A forced tool_choice can never carry native thinking (prepareParams
+			// strips it proactively), so the fallback that follows the repair must be
+			// one that coexists with replayed thinking: fast mode.
+			const createFastModeUnsupported400 = (): MockAnthropicRequest => ({
+				async withResponse() {
+					const error = new Error(
+						"400 invalid_request_error: 'claude-sonnet-4-6' does not support the `speed` parameter.",
+					);
+					(error as { status?: number }).status = 400;
+					throw error;
+				},
+			});
 			const requestBodies: unknown[] = [];
 			let attempt = 0;
 			const create = ((body: unknown) => {
 				requestBodies.push(body);
 				attempt += 1;
 				if (attempt === 1) return createAnthropicSignatureInvalid400() as never;
-				if (attempt === 2) return createForcedToolChoice400() as never;
+				if (attempt === 2) return createFastModeUnsupported400() as never;
 				return createSuccessfulRequest() as never;
 			}) as unknown as Anthropic["messages"]["create"];
 			const client = { messages: { create } } as Anthropic;
 
-			const result = await streamAnthropic(model, makeContext(), { client, toolChoice: "any" }).result();
+			const result = await streamAnthropic(model, makeContext(), { client, serviceTier: "priority" }).result();
 
 			expect(result.stopReason).toBe("stop");
 			expect(requestBodies).toHaveLength(3);
-			// Signature repair activates on attempt 2; the forced-tool_choice fallback
-			// rebuild (attempt 3) must not reintroduce the dropped signature, and must
-			// drop the forced tool_choice.
+			// The rejected first attempt replayed native thinking, so the repair is
+			// exercised for real, not vacuously.
+			expect(JSON.stringify(requestBodies[0])).toContain("sig_history");
+			expect((requestBodies[0] as { speed?: unknown }).speed).toBe("fast");
+			// Signature repair activates on attempt 2; the fast-mode fallback rebuild
+			// (attempt 3) must not reintroduce the dropped signature, and must drop
+			// the speed parameter.
 			expect(JSON.stringify(requestBodies[1])).not.toContain("sig_history");
+			expect((requestBodies[1] as { speed?: unknown }).speed).toBe("fast");
 			const thirdBody = JSON.stringify(requestBodies[2]);
 			expect(thirdBody).not.toContain("sig_history");
-			expect(thirdBody).not.toContain("tool_choice");
-			expect((requestBodies[2] as { tool_choice?: unknown }).tool_choice).toBeUndefined();
+			expect((requestBodies[2] as { speed?: unknown }).speed).toBeUndefined();
 			expect(thirdBody).toContain("history answer");
 		});
 


### PR DESCRIPTION
## Problem

The invalid-signature and blocks-immutable 400 arms of the Anthropic thinking-replay repair (`streamAnthropic`) fire unconditionally. But the repair can only change the request when native `thinking`/`redacted_thinking` blocks are actually in flight — without them, `prepareParams()` rebuilds a **byte-identical** replay. Each resend draws the same deterministic 400 and burns the repair budget (`ANTHROPIC_MAX_THINKING_REPAIRS = 2`) on no-ops before the error finally surfaces: up to two wasted full-size round trips per rejection.

The masked proxy-rejection arm already carries exactly this guard ("without signed thinking blocks in flight there is nothing to repair and the error must surface") — the other two classes were missing it.

## Change

`hasNativeThinkingBlocks(params.messages)` is now the shared gate for all three trigger classes. A rejection that provably cannot be repaired surfaces immediately.

## Test fallout (pre-existing vacuous fixture)

`keeps thinking repair active when a later forced-tool_choice fallback rebuilds params` relied on the removed no-op: `prepareParams` proactively strips native thinking whenever tool choice is forced ("A forced tool choice strips `thinking` from the request"), so that fixture's attempt 1 never carried `sig_history`, its "repair" resend never changed a byte, and its `not.toContain("sig_history")` assertions were vacuously true. Debug capture of its first request body confirms: only the text block goes to the wire.

The test's real intent — repair state survives a later fallback rebuild — is preserved with a fallback that genuinely coexists with replayed thinking: fast mode (`serviceTier: "priority"` → `speed` 400 → rebuild). The reshaped test additionally asserts the first attempt **really** carried the signature, so it can never go vacuous again.

## Tests

- new: invalid-signature 400 with no thinking blocks in flight → surfaces on attempt 1, no resend
- new: mutation 400 with no thinking blocks in flight → surfaces on attempt 1, no resend
- reshaped: repair + fast-mode fallback composition (non-vacuous)
- regenerated: issue-3670 eval source binding (sha256 of `anthropic.ts`) via `WRITE_ISSUE_3670_EVAL=1`, same as 31cea9d24

`bun test packages/ai/test/`: 2316 pass / 0 fail (337 env-gated skips). Biome + `tsc --noEmit` clean.