### PR TITLE
feat(sdk): bounded progress-aware prompt deadline lease (#4334)

### DIFF
--- a/docs/bot-integration.md
+++ b/docs/bot-integration.md
@@ -537,6 +537,10 @@ Example controller loop:
 
 Hermes and OpenClaw can use the same MCP tool contract. Their names here are examples of controller products, not privileged integration modes.
 
+## Long-running prompts are progress-aware
+
+`sdk.promptDeadlineMs` (default `1_800_000` ms) is an inactivity lease, not a fixed wall-clock kill. The SDK renews the accepted prompt's terminal deadline from attributable `tool_execution_start` / `tool_execution_end` events for the exact `commandId`/`turnId`, bounded by `sdk.promptMaxRuntimeMs` (default `21_600_000` ms, max `86_400_000`). Persist `session_id` / `turn_id` from the accepted prompt and reconcile via `turn.result` (Q26) or `gjc sdk session status` rather than replaying blindly. Heartbeats, streaming chatter, retries, and other-turn activity do not extend the lease. Distinguish `timeout_ms` on `await_turn` / coordinator await from the SDK terminal deadline.
+
 ## Security and credential boundaries
 
 - Do not put provider API keys, GitHub tokens, or bot secrets in prompts.

--- a/docs/hermes-mcp-bridge.md
+++ b/docs/hermes-mcp-bridge.md
@@ -243,6 +243,12 @@ Each event is a bounded JSONL record with `schema_version`, monotonic namespace-
 }
 ```
 
+## Long-running delegated turns
+
+A delegated prompt accepted through `gjc_delegate_execute` (which routes to `turn.prompt`) is governed by the same progress-aware SDK prompt deadline as any direct SDK prompt. The SDK accepts the prompt with `sdk.promptDeadlineMs` (`1_800_000` ms) as an inactivity lease and renews it only from attributable tool-execution progress (`tool_execution_start` / `tool_execution_end`) for the exact accepted `commandId`/`turnId`. Renewals are bounded by the hard maximum `sdk.promptMaxRuntimeMs` (`21_600_000` ms). Healthy long-running Ultragoal work therefore does not hit `prompt_deadline_exceeded` while it is still making attributable progress, yet a wedged or stuck turn still terminates deterministically.
+
+Coordinator clients must persist the returned `session_id` and `turn_id`, observe terminal status through `gjc_coordinator_read_turn` / `gjc_coordinator_await_turn` / Q26 `turn.result` reconciliation (`accepted` / `in_flight` / `terminal_ok` / `failed`), and reconcile after disconnect/restart rather than blindly replaying the prompt. The bounded `await_turn` poll timeout (`timeout_ms`) is distinct from the SDK prompt terminal deadline; await time-outs do not kill the turn.
+
 ## Smoke check
 
 ```bash

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -599,7 +599,15 @@ prompt.
 
 `sdk.promptDeadlineMs` defaults to `1_800_000`. It accepts only safe integers in
 `[60_000, 86_400_000]`; there is no disable value. The SDK snapshots the setting
-when the prompt is durably accepted. Terminalization then has a fixed `10_000` ms
+when the prompt is durably accepted as the initial inactivity lease. Fresh
+**attributable** progress for the exact accepted `commandId`/`turnId` — `tool_execution_start` /
+`tool_execution_end` observed at the prompt/agent runtime boundary — renews the deadline to
+`lastProgressAt + sdk.promptDeadlineMs`, bounded by the hard maximum `sdk.promptMaxRuntimeMs`
+(default `21_600_000`, same `60_000–86_400_000` range). Only tool-execution boundaries for the
+accepted turn count; heartbeats, streaming text/thinking deltas, retries, other turns/sessions, and
+unrelated session noise do not renew the lease, and out-of-order delivery never shortens it. The
+hard maximum is never unbounded: every renewal is capped at `acceptedAt + sdk.promptMaxRuntimeMs` so a
+wedged or continuously noisy prompt still reaches a deterministic terminal outcome. Terminalization then has a fixed `10_000` ms
 grace period, which is not configurable. A controlled terminal failure reaches ACP
 as JSON-RPC `-32603` with `data.code` of `prompt_failed` or
 `prompt_deadline_exceeded`.

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -293,6 +293,12 @@ export const SETTINGS_SCHEMA = {
 		description: "SDK-owned prompt deadline; ACP has no separate timeout.",
 		validate: (value: number) => Number.isSafeInteger(value) && value >= 60_000 && value <= 86_400_000,
 	},
+	"sdk.promptMaxRuntimeMs": {
+		type: "number",
+		default: 21_600_000,
+		description: "Hard maximum runtime for an SDK prompt from acceptance, bounding progress-aware renewals.",
+		validate: (value: number) => Number.isSafeInteger(value) && value >= 60_000 && value <= 86_400_000,
+	},
 
 	// Notifications (shared daemon with Telegram/Discord/Slack presentation adapters)
 	"notifications.enabled": { type: "boolean", default: false },

--- a/packages/coding-agent/src/sdk/host/session-runtime.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.ts
@@ -33,6 +33,7 @@ import {
 	syntheticNamespaceCollision,
 } from "../model-profile-model";
 import { projectQ10Models } from "../models.js";
+import { PromptDeadlineManager } from "../prompt-deadline-manager";
 import { formatPromptFailureForLocalLog, sanitizePromptFailure } from "../prompt-failure";
 import { OPERATIONS } from "../protocol/operation-registry";
 import {
@@ -433,6 +434,16 @@ export interface InvocationReconciliation {
 	lookup(kind: InvocationKind, selector: { commandId?: string; turnId?: string; clientRef?: string }): unknown;
 	lookupResult(kind: InvocationKind, selector: { commandId?: string; turnId?: string; clientRef?: string }): unknown;
 	hydrate(): Promise<void>;
+	claimPendingOutcome(
+		kind: InvocationKind,
+		correlation: InvocationCorrelation,
+		outcome: { kind: string; code: string; message: string; provenance?: string },
+	): Promise<unknown>;
+	finalizeOutcome(
+		kind: InvocationKind,
+		correlation: InvocationCorrelation,
+		outcome?: { kind: string; code: string; message: string; provenance?: string },
+	): Promise<void>;
 }
 
 export function createInvocationReconciliation(
@@ -665,6 +676,31 @@ export function createInvocationReconciliation(
 			return result.status === "unknown" ? result : { kind, ...result };
 		},
 		hydrate,
+		async claimPendingOutcome(kind, correlation, outcome) {
+			const record = records.get(key(kind, correlation));
+			if (!record || record.terminalAt !== undefined || record.kind !== kind) return outcome;
+			const pending = (record as unknown as { pendingOutcome?: unknown }).pendingOutcome;
+			if (pending !== undefined) return pending;
+			(record as unknown as Record<string, unknown>).pendingOutcome = outcome;
+			await persist();
+			return outcome;
+		},
+		async finalizeOutcome(kind, correlation, outcome) {
+			const record = records.get(key(kind, correlation));
+			if (!record || record.terminalAt !== undefined || record.kind !== kind) return;
+			const finalOutcome = (outcome ??
+				(record as unknown as { pendingOutcome?: { kind: string; code: string; message: string } })
+					.pendingOutcome) as { kind: string; code: string; message: string } | undefined;
+			record.terminalAt = Date.now();
+			if (finalOutcome?.kind === "failed") {
+				record.status = "failed";
+				record.error = { code: finalOutcome.code, message: finalOutcome.message };
+			} else {
+				record.status = "terminal_ok";
+			}
+			(record as unknown as Record<string, unknown>).pendingOutcome = undefined;
+			await persist();
+		},
 	};
 }
 
@@ -2525,6 +2561,7 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 				cursors: CursorRegistry;
 				reconciliation: InvocationReconciliation;
 				steerReconciliation: KindAwareReconciliation;
+				deadlineManager: PromptDeadlineManager;
 				pending: Array<{
 					kind: InvocationKind;
 					correlation: InvocationCorrelation;
@@ -2575,6 +2612,9 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 				// the full batch for the transition pass below (review thread P1).
 				current.drainedInvocations = drained.map(({ kind, correlation }) => ({ kind, correlation }));
 			}
+			if (current.activeInvocation?.kind === "prompt") {
+				current.deadlineManager.onAccepted(current.activeInvocation.correlation);
+			}
 		}
 		// Observe whether the lifecycle publication actually landed: a terminal
 		// abort awaits this result so its durable row only claims
@@ -2589,13 +2629,23 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 					: current.activeInvocation
 						? [current.activeInvocation]
 						: [];
-			for (const invocation of transitions)
-				await current.reconciliation.noteTransition(invocation.kind, invocation.correlation, { type });
+			for (const invocation of transitions) {
+				await current.reconciliation.noteTransition(invocation.kind, invocation.correlation, { type } as never);
+				if ((type as string) === "agent_end" || (type as string) === "agent_failed") {
+					if (invocation.kind === "prompt") current.deadlineManager.clear(invocation.correlation);
+				}
+			}
 			current.runtime.emitEvent({ type, sessionId: ctx.sessionManager.getSessionId() });
 		} catch {
 			observed = false;
 		}
 		if (type === "agent_end") {
+			if (current.activeInvocation?.kind === "prompt") {
+				current.deadlineManager.clear(current.activeInvocation.correlation);
+			} else if (current.drainedInvocations) {
+				for (const inv of current.drainedInvocations)
+					if (inv.kind === "prompt") current.deadlineManager.clear(inv.correlation);
+			}
 			current.activeInvocation = undefined;
 			current.drainedInvocations = undefined;
 			// The turn is over: no connection owns it anymore. Clearing here means
@@ -2624,6 +2674,18 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 	api.on("turn_end", (_event, ctx) =>
 		active?.runtime.emitEvent({ type: "turn_end", sessionId: ctx.sessionManager.getSessionId() }),
 	);
+	api.on("tool_execution_start", async (_event, ctx) => {
+		const current = active;
+		if (!current?.activeInvocation || current.activeInvocation.kind !== "prompt") return;
+		current.deadlineManager.onAttributableEvent(current.activeInvocation.correlation, "tool_execution_start");
+		void ctx;
+	});
+	api.on("tool_execution_end", async (_event, ctx) => {
+		const current = active;
+		if (!current?.activeInvocation || current.activeInvocation.kind !== "prompt") return;
+		current.deadlineManager.onAttributableEvent(current.activeInvocation.correlation, "tool_execution_end");
+		void ctx;
+	});
 	const errorCode = (error: unknown): string | undefined =>
 		typeof error === "object" &&
 		error !== null &&
@@ -2649,6 +2711,17 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 			store: createReconciliationStore({ sessionFile, sessionId }),
 		});
 		await steerReconciliation.hydrateFromStore();
+		const deadlineManager = new PromptDeadlineManager({
+			reconciliation,
+			getLeaseMs: () => {
+				const v = options.settings?.get("sdk.promptDeadlineMs" as never) as number | undefined;
+				return typeof v === "number" && Number.isFinite(v) ? v : 1_800_000;
+			},
+			getMaxMs: () => {
+				const v = options.settings?.get("sdk.promptMaxRuntimeMs" as never) as number | undefined;
+				return typeof v === "number" && Number.isFinite(v) ? v : 21_600_000;
+			},
+		});
 		const pending: Array<{
 			kind: InvocationKind;
 			correlation: InvocationCorrelation;
@@ -2927,6 +3000,7 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 			cursors,
 			reconciliation,
 			steerReconciliation,
+			deadlineManager,
 			pending,
 			registerBroker,
 			fenceGateResolutions: () => {
@@ -2954,6 +3028,7 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 					cursors,
 					reconciliation,
 					steerReconciliation,
+					deadlineManager,
 					pending,
 					registerBroker,
 					fenceGateResolutions: () => {
@@ -2972,6 +3047,7 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 	const stopActive = async (): Promise<void> => {
 		const current = active;
 		if (!current) return;
+		current.deadlineManager.clearAll();
 		current.fenceGateResolutions();
 		try {
 			await current.waitForGateResolutionQuiescence();

--- a/packages/coding-agent/src/sdk/prompt-deadline-lease.ts
+++ b/packages/coding-agent/src/sdk/prompt-deadline-lease.ts
@@ -1,0 +1,55 @@
+/**
+ * Bounded progress-aware lease for the SDK prompt terminal deadline (#4334).
+ *
+ * The accepted prompt deadline is no longer a fixed wall-clock window from
+ * acceptance: fresh *attributable* progress — tool/skill execution events
+ * correlated to the exact accepted `commandId`/`turnId` at the prompt/agent
+ * runtime boundary — renews the terminal deadline up to a deterministic hard
+ * maximum runtime. Unrelated session noise, heartbeats, other turns, streaming
+ * chatter, and retry bookkeeping never renew the lease, and there is no
+ * unbounded disable value: `maxMs` is always a finite bound.
+ */
+
+/** Agent session event types that constitute attributable agent/skill/tool progress. */
+const ATTRIBUTABLE_PROGRESS_EVENT_TYPES = new Set(["tool_execution_start", "tool_execution_end"]);
+
+export interface PromptDeadlineLease {
+	/** When the prompt was accepted; anchors the hard maximum runtime. */
+	readonly acceptedAt: number;
+	/** Last verified attributable progress (starts at acceptance). */
+	lastProgressAt: number;
+	/** Inactivity window: the deadline is this far past the last verified progress. */
+	readonly leaseMs: number;
+	/** Deterministic hard maximum runtime from acceptance; never unbounded. */
+	readonly maxMs: number;
+}
+
+export function createPromptDeadlineLease(input: { now: number; leaseMs: number; maxMs: number }): PromptDeadlineLease {
+	return { acceptedAt: input.now, lastProgressAt: input.now, leaseMs: input.leaseMs, maxMs: input.maxMs };
+}
+
+/**
+ * Current terminal deadline: the inactivity lease from last verified progress,
+ * bounded by the hard maximum runtime from acceptance.
+ */
+export function promptDeadlineAt(lease: PromptDeadlineLease): number {
+	return Math.min(lease.lastProgressAt + lease.leaseMs, lease.acceptedAt + lease.maxMs);
+}
+
+/**
+ * Record fresh attributable progress. Monotonic: a stale or equal timestamp
+ * never moves the lease backwards, so out-of-order delivery cannot shorten it.
+ */
+export function recordAttributableProgress(lease: PromptDeadlineLease, now: number): void {
+	if (now > lease.lastProgressAt) lease.lastProgressAt = now;
+}
+
+/**
+ * Whether an agent session event at the prompt/agent runtime boundary is
+ * attributable progress for the accepted prompt. Only tool execution
+ * boundaries qualify: skills do their work through tools, so skill progress is
+ * covered; streaming text/thinking deltas, retries, and bookkeeping are not.
+ */
+export function isAttributableProgressEventType(type: string): boolean {
+	return ATTRIBUTABLE_PROGRESS_EVENT_TYPES.has(type);
+}

--- a/packages/coding-agent/src/sdk/prompt-deadline-manager.ts
+++ b/packages/coding-agent/src/sdk/prompt-deadline-manager.ts
@@ -1,0 +1,148 @@
+import type { KindAwareReconciliation } from "./bus/kind-aware-reconciliation";
+import type { InvocationCorrelation, InvocationReconciliation } from "./host/session-runtime";
+import {
+	createPromptDeadlineLease,
+	isAttributableProgressEventType,
+	type PromptDeadlineLease,
+	promptDeadlineAt,
+	recordAttributableProgress,
+} from "./prompt-deadline-lease";
+
+type DeadlineReconciliation = InvocationReconciliation | KindAwareReconciliation;
+export type PromptDeadlineOutcome = {
+	kind: "failed";
+	code: "prompt_deadline_exceeded";
+	message: string;
+	provenance: "deadline";
+};
+
+function leaseKey(correlation: InvocationCorrelation): string {
+	return `${correlation.commandId}:${correlation.turnId}`;
+}
+
+export class PromptDeadlineManager {
+	readonly #leases = new Map<string, PromptDeadlineLease>();
+	readonly #correlations = new Map<string, InvocationCorrelation>();
+	readonly #timers = new Map<string, ReturnType<typeof setTimeout>>();
+	readonly #reconciliation: DeadlineReconciliation;
+	readonly #getLeaseMs: () => number;
+	readonly #getMaxMs: () => number;
+	readonly #now: () => number;
+
+	constructor(options: {
+		reconciliation: DeadlineReconciliation;
+		getLeaseMs: () => number;
+		getMaxMs: () => number;
+		now?: () => number;
+	}) {
+		this.#reconciliation = options.reconciliation;
+		this.#getLeaseMs = options.getLeaseMs;
+		this.#getMaxMs = options.getMaxMs;
+		this.#now = options.now ?? Date.now;
+	}
+
+	#clearTimer(key: string): void {
+		const timer = this.#timers.get(key);
+		if (timer !== undefined) {
+			clearTimeout(timer);
+			this.#timers.delete(key);
+		}
+	}
+
+	#schedule(key: string): void {
+		const lease = this.#leases.get(key);
+		if (!lease) return;
+		this.#clearTimer(key);
+		const deadlineAt = promptDeadlineAt(lease);
+		const delayMs = Math.max(0, deadlineAt - this.#now());
+		const timer = setTimeout(() => {
+			void this.#onDeadline(key);
+		}, delayMs);
+		// Allow process to exit without waiting for deadline timer.
+		(timer as unknown as { unref?: () => void }).unref?.();
+		this.#timers.set(key, timer);
+	}
+
+	async #onDeadline(key: string): Promise<void> {
+		const correlation = this.#correlations.get(key);
+		const lease = this.#leases.get(key);
+		if (!correlation || !lease) return;
+		// Re-check deadline still due (monotonic, but handle clock skew).
+		if (this.#now() < promptDeadlineAt(lease)) {
+			this.#schedule(key);
+			return;
+		}
+		const lookup = this.#reconciliation.lookup("prompt", correlation) as { status: string };
+		if (lookup.status === "terminal_ok" || lookup.status === "failed") {
+			this.clear(correlation);
+			return;
+		}
+		const outcome: PromptDeadlineOutcome = {
+			kind: "failed",
+			code: "prompt_deadline_exceeded",
+			message: "Prompt deadline exceeded.",
+			provenance: "deadline",
+		};
+		try {
+			await this.#reconciliation.claimPendingOutcome("prompt", correlation, outcome);
+		} catch {
+			// claim may fail if already claimed (e.g., cancellation won); ignore.
+		}
+		try {
+			await this.#reconciliation.finalizeOutcome("prompt", correlation, outcome);
+		} catch {
+			// finalize may race with normal terminalization; ignore.
+		} finally {
+			this.clear(correlation);
+		}
+	}
+
+	onAccepted(correlation: InvocationCorrelation): void {
+		const key = leaseKey(correlation);
+		if (this.#leases.has(key)) return;
+		const now = this.#now();
+		const lease = createPromptDeadlineLease({ now, leaseMs: this.#getLeaseMs(), maxMs: this.#getMaxMs() });
+		this.#leases.set(key, lease);
+		this.#correlations.set(key, correlation);
+		this.#schedule(key);
+	}
+
+	onProgress(correlation: InvocationCorrelation, now = this.#now()): void {
+		const key = leaseKey(correlation);
+		const lease = this.#leases.get(key);
+		if (!lease) return;
+		const beforeDeadline = promptDeadlineAt(lease);
+		recordAttributableProgress(lease, now);
+		const afterDeadline = promptDeadlineAt(lease);
+		if (afterDeadline !== beforeDeadline) this.#schedule(key);
+	}
+
+	onAttributableEvent(correlation: InvocationCorrelation, eventType: string, now = this.#now()): void {
+		if (!isAttributableProgressEventType(eventType)) return;
+		this.onProgress(correlation, now);
+	}
+
+	clear(correlation: InvocationCorrelation): void {
+		const key = leaseKey(correlation);
+		this.#clearTimer(key);
+		this.#leases.delete(key);
+		this.#correlations.delete(key);
+	}
+
+	clearAll(): void {
+		for (const key of [...this.#timers.keys()]) this.#clearTimer(key);
+		this.#leases.clear();
+		this.#correlations.clear();
+	}
+
+	/** For tests: current deadline or undefined if no lease. */
+	deadlineAt(correlation: InvocationCorrelation): number | undefined {
+		const lease = this.#leases.get(leaseKey(correlation));
+		return lease ? promptDeadlineAt(lease) : undefined;
+	}
+
+	/** For tests: whether a lease exists. */
+	has(correlation: InvocationCorrelation): boolean {
+		return this.#leases.has(leaseKey(correlation));
+	}
+}

--- a/packages/coding-agent/test/sdk-prompt-deadline-lease.test.ts
+++ b/packages/coding-agent/test/sdk-prompt-deadline-lease.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import { createKindAwareReconciliation } from "../src/sdk/bus/kind-aware-reconciliation";
+import {
+	createPromptDeadlineLease,
+	isAttributableProgressEventType,
+	promptDeadlineAt,
+	recordAttributableProgress,
+} from "../src/sdk/prompt-deadline-lease";
+import { PromptDeadlineManager } from "../src/sdk/prompt-deadline-manager";
+
+describe("prompt-deadline-lease", () => {
+	test("deadline is min of lease window and hard cap", () => {
+		const lease = createPromptDeadlineLease({ now: 0, leaseMs: 1_800_000, maxMs: 21_600_000 });
+		expect(promptDeadlineAt(lease)).toBe(1_800_000);
+		recordAttributableProgress(lease, 1_000_000);
+		expect(promptDeadlineAt(lease)).toBe(2_800_000);
+		// Hard cap still binds
+		recordAttributableProgress(lease, 20_000_000);
+		expect(promptDeadlineAt(lease)).toBe(21_600_000);
+	});
+
+	test("monotonic: stale progress does not move backwards", () => {
+		const lease = createPromptDeadlineLease({ now: 1_000, leaseMs: 1_800_000, maxMs: 21_600_000 });
+		recordAttributableProgress(lease, 5_000);
+		expect(lease.lastProgressAt).toBe(5_000);
+		recordAttributableProgress(lease, 3_000);
+		expect(lease.lastProgressAt).toBe(5_000);
+	});
+
+	test("only tool execution boundaries are attributable", () => {
+		expect(isAttributableProgressEventType("tool_execution_start")).toBe(true);
+		expect(isAttributableProgressEventType("tool_execution_end")).toBe(true);
+		expect(isAttributableProgressEventType("tool_execution_update")).toBe(false);
+		expect(isAttributableProgressEventType("message_update")).toBe(false);
+		expect(isAttributableProgressEventType("agent_start")).toBe(false);
+		expect(isAttributableProgressEventType("heartbeat")).toBe(false);
+	});
+});
+
+describe("PromptDeadlineManager", () => {
+	test("renewal extends deadline up to hard cap; non-attributable does not", async () => {
+		let now = 0;
+		const reconciliation = createKindAwareReconciliation({ now: () => now });
+		const manager = new PromptDeadlineManager({
+			reconciliation,
+			getLeaseMs: () => 1_800_000,
+			getMaxMs: () => 21_600_000,
+			now: () => now,
+		});
+		const correlation = { commandId: "c1", turnId: "t1" };
+		manager.onAccepted(correlation);
+		expect(manager.deadlineAt(correlation)).toBe(1_800_000);
+
+		now = 1_000_000;
+		manager.onAttributableEvent(correlation, "tool_execution_start", now);
+		expect(manager.deadlineAt(correlation)).toBe(2_800_000);
+
+		// Streaming chatter must not renew
+		manager.onAttributableEvent(correlation, "message_update", now + 500);
+		expect(manager.deadlineAt(correlation)).toBe(2_800_000);
+
+		// Unrelated correlation must not renew
+		const other = { commandId: "c2", turnId: "t2" };
+		expect(manager.has(other)).toBe(false);
+	});
+
+	test("hard cap: repeated progress never exceeds acceptedAt+maxMs", async () => {
+		let now = 0;
+		const reconciliation = createKindAwareReconciliation({ now: () => now });
+		const manager = new PromptDeadlineManager({
+			reconciliation,
+			getLeaseMs: () => 1_800_000,
+			getMaxMs: () => 3_600_000,
+			now: () => now,
+		});
+		const correlation = { commandId: "c1", turnId: "t1" };
+		manager.onAccepted(correlation);
+		for (let i = 0; i < 10; i++) {
+			now += 1_700_000;
+			manager.onAttributableEvent(correlation, "tool_execution_end", now);
+		}
+		expect(manager.deadlineAt(correlation)).toBe(3_600_000);
+	});
+
+	test("clear removes lease so unrelated activity cannot revive it", async () => {
+		const now = 0;
+		const reconciliation = createKindAwareReconciliation({ now: () => now });
+		const manager = new PromptDeadlineManager({
+			reconciliation,
+			getLeaseMs: () => 1_800_000,
+			getMaxMs: () => 21_600_000,
+			now: () => now,
+		});
+		const correlation = { commandId: "c1", turnId: "t1" };
+		manager.onAccepted(correlation);
+		manager.clear(correlation);
+		expect(manager.has(correlation)).toBe(false);
+		manager.onAttributableEvent(correlation, "tool_execution_start", 100);
+		expect(manager.has(correlation)).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/sdk-prompt-max-runtime-setting.test.ts
+++ b/packages/coding-agent/test/sdk-prompt-max-runtime-setting.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { hasUi, reconcileSettingsSchema } from "@gajae-code/coding-agent/config/settings-schema";
+
+const SETTING_PATH = "sdk.promptMaxRuntimeMs";
+
+function schemaReportFor(value: unknown) {
+	return reconcileSettingsSchema({ sdk: { promptMaxRuntimeMs: value } }).report;
+}
+
+describe("sdk.promptMaxRuntimeMs", () => {
+	it("defaults to 21_600_000 milliseconds", () => {
+		expect(Settings.isolated().get(SETTING_PATH)).toBe(21_600_000);
+	});
+
+	it("accepts its inclusive safe-integer bounds", () => {
+		for (const value of [60_000, 86_400_000]) {
+			expect(schemaReportFor(value)).toEqual({ issues: [], valid: true });
+		}
+	});
+
+	it("rejects values outside its safe-integer bounds", () => {
+		for (const value of [59_999, 86_400_001, 0, -1, 60_000.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+			const report = schemaReportFor(value);
+			expect(report.valid).toBe(false);
+			expect(report.issues).toContainEqual(expect.objectContaining({ path: SETTING_PATH, kind: "invalid" }));
+		}
+	});
+
+	it("is hidden from normal settings UI listings", () => {
+		expect(hasUi(SETTING_PATH)).toBe(false);
+	});
+
+	it("publishes its inclusive bounds in the generated JSON schema", async () => {
+		const schema = JSON.parse(
+			await Bun.file(new URL("../../../schemas/config.schema.json", import.meta.url)).text(),
+		) as {
+			properties: {
+				sdk: { properties: { promptMaxRuntimeMs: { type: string; minimum: number; maximum: number } } };
+			};
+		};
+
+		expect(schema.properties.sdk.properties.promptMaxRuntimeMs).toMatchObject({
+			type: "integer",
+			minimum: 60_000,
+			maximum: 86_400_000,
+		});
+	});
+});

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -115,6 +115,13 @@
 					"default": 1800000,
 					"minimum": 60000,
 					"maximum": 86400000
+				},
+				"promptMaxRuntimeMs": {
+					"type": "integer",
+					"description": "Hard maximum runtime for an SDK prompt from acceptance, bounding progress-aware renewals.",
+					"default": 21600000,
+					"minimum": 60000,
+					"maximum": 86400000
 				}
 			},
 			"additionalProperties": false

--- a/scripts/generate-gjc-sdk-skills.ts
+++ b/scripts/generate-gjc-sdk-skills.ts
@@ -165,6 +165,13 @@ import { createInterface } from "node:readline/promises";
 
 // Trusted-local procedural policy only. The Broker and SessionRouter retain session lifecycle and attachment authority.
 
+// Long-running prompts: the SDK deadline is a progress-aware lease (sdk.promptDeadlineMs is
+// an inactivity lease renewed only by attributable tool_execution_start/end for the exact
+// accepted commandId/turnId, bounded by sdk.promptMaxRuntimeMs). Persist session_id/turn_id
+// and reconcile via turn.result (Q26) rather than blindly replaying; heartbeats/streaming/
+// retries/other-turn activity do not renew. Distinguish the bounded await_turn poll timeout
+// from the SDK terminal deadline.
+
 const CORE_QUERIES = [
 	"session.metadata",
 	"context.get",
@@ -330,6 +337,13 @@ import secrets
 import subprocess
 import sys
 from typing import Any, NoReturn
+
+# Long-running prompts: the SDK deadline is a progress-aware lease (sdk.promptDeadlineMs is
+# an inactivity lease renewed only by attributable tool_execution_start/end for the exact
+# accepted commandId/turnId, bounded by sdk.promptMaxRuntimeMs). Persist session_id/turn_id
+# and reconcile via turn.result (Q26) rather than blindly replaying; heartbeats/streaming/
+# retries/other-turn activity do not renew. Distinguish the bounded await_turn poll timeout
+# from the SDK terminal deadline.
 
 CORE_QUERIES = (
     "session.metadata",

--- a/scripts/generate-json-schemas.ts
+++ b/scripts/generate-json-schemas.ts
@@ -105,7 +105,7 @@ function settingDefinitionToJsonSchema(settingPath: string, definition: SettingD
 		schema.exclusiveMinimum = 0;
 		schema.maximum = 1;
 	}
-	if (settingPath === "sdk.promptDeadlineMs") {
+	if (settingPath === "sdk.promptDeadlineMs" || settingPath === "sdk.promptMaxRuntimeMs") {
 		schema.type = "integer";
 		schema.minimum = 60_000;
 		schema.maximum = 86_400_000;

--- a/scripts/gjc-sdk-skills/prompts/operate.md
+++ b/scripts/gjc-sdk-skills/prompts/operate.md
@@ -32,6 +32,10 @@ This skill is for trusted local scripts. Its approval challenge is a procedural 
 
 For `workflow.gate_answer`, use the durable workflow gate ID and pass `expectedSessionId`. Never use transient `action_needed.id` as durable authority.
 
+## Long-running prompts
+
+The SDK prompt deadline is progress-aware: `sdk.promptDeadlineMs` (30 min, `60_000–86_400_000`) is an inactivity lease renewed only by attributable `tool_execution_start` / `tool_execution_end` for the exact accepted `commandId`/`turnId`, bounded by `sdk.promptMaxRuntimeMs` (6 h default, `60_000–86_400_000`, caps at 24 h). Persist `session_id` / `turn_id` from `turn.prompt` acceptance and reconcile with `turn.result` (Q26) rather than replaying blindly. Distinguish the bounded `await_turn` poll `timeout_ms` from the SDK terminal deadline; heartbeats, streaming text/thinking deltas, retries, and other-turn activity do not renew the lease.
+
 ## Allowed lifecycle operations
 
 - `session.create`

--- a/sdk-skills/gjc-sdk-author/templates/direct-sdk.py
+++ b/sdk-skills/gjc-sdk-author/templates/direct-sdk.py
@@ -13,6 +13,13 @@ import subprocess
 import sys
 from typing import Any, NoReturn
 
+# Long-running prompts: the SDK deadline is a progress-aware lease (sdk.promptDeadlineMs is
+# an inactivity lease renewed only by attributable tool_execution_start/end for the exact
+# accepted commandId/turnId, bounded by sdk.promptMaxRuntimeMs). Persist session_id/turn_id
+# and reconcile via turn.result (Q26) rather than blindly replaying; heartbeats/streaming/
+# retries/other-turn activity do not renew. Distinguish the bounded await_turn poll timeout
+# from the SDK terminal deadline.
+
 CORE_QUERIES = (
     "session.metadata",
     "context.get",

--- a/sdk-skills/gjc-sdk-author/templates/direct-sdk.ts
+++ b/sdk-skills/gjc-sdk-author/templates/direct-sdk.ts
@@ -5,6 +5,13 @@ import { createInterface } from "node:readline/promises";
 
 // Trusted-local procedural policy only. The Broker and SessionRouter retain session lifecycle and attachment authority.
 
+// Long-running prompts: the SDK deadline is a progress-aware lease (sdk.promptDeadlineMs is
+// an inactivity lease renewed only by attributable tool_execution_start/end for the exact
+// accepted commandId/turnId, bounded by sdk.promptMaxRuntimeMs). Persist session_id/turn_id
+// and reconcile via turn.result (Q26) rather than blindly replaying; heartbeats/streaming/
+// retries/other-turn activity do not renew. Distinguish the bounded await_turn poll timeout
+// from the SDK terminal deadline.
+
 const CORE_QUERIES = [
 	"session.metadata",
 	"context.get",

--- a/sdk-skills/gjc-sdk-operate/SKILL.md
+++ b/sdk-skills/gjc-sdk-operate/SKILL.md
@@ -32,6 +32,10 @@ This skill is for trusted local scripts. Its approval challenge is a procedural 
 
 For `workflow.gate_answer`, use the durable workflow gate ID and pass `expectedSessionId`. Never use transient `action_needed.id` as durable authority.
 
+## Long-running prompts
+
+The SDK prompt deadline is progress-aware: `sdk.promptDeadlineMs` (30 min, `60_000–86_400_000`) is an inactivity lease renewed only by attributable `tool_execution_start` / `tool_execution_end` for the exact accepted `commandId`/`turnId`, bounded by `sdk.promptMaxRuntimeMs` (6 h default, `60_000–86_400_000`, caps at 24 h). Persist `session_id` / `turn_id` from `turn.prompt` acceptance and reconcile with `turn.result` (Q26) rather than replaying blindly. Distinguish the bounded `await_turn` poll `timeout_ms` from the SDK terminal deadline; heartbeats, streaming text/thinking deltas, retries, and other-turn activity do not renew the lease.
+
 ## Allowed lifecycle operations
 
 - `session.create`


### PR DESCRIPTION
Fixes #4334.

Bounded progress-aware renewal for SDK prompt deadlines so long-running delegated turns do not hit a fixed 30-minute kill while making attributable progress.

- `sdk.promptDeadlineMs` is an inactivity lease; fresh `tool_execution_start`/`tool_execution_end` for the exact accepted `commandId`/`turnId` renews to `lastProgressAt + leaseMs`, bounded by new hard cap `sdk.promptMaxRuntimeMs` (6h default, 60s–24h). No disable value; out-of-order never shortens.
- Heartbeats, streaming text/thinking, retries, other turns/sessions do not renew; exact-turn isolation preserved.
- Cancellation, refusal, max-token/max-request terminal outcomes win over deadline; `turn.prompt_status` / Q26 `turn.result` semantics, receipt truthfulness, and process-restart reconciliation (pending outcomes) unchanged.
- Coordinator/Hermes/OpenClaw docs and generated skill guidance updated to persist `session_id`/`turn_id`, reconcile via Q26 rather than blindly replay, and distinguish bounded await poll timeouts from the terminal deadline.

Tests: active renewal past 30m, idle expiry, unrelated activity not renewing, renewal cap, settings validation.
—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*