### PR TITLE
fix(coordinator-mcp): answer ping keepalive with empty result

### DIFF
--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -5698,6 +5698,9 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 				},
 			};
 		}
+		if (request.method === "ping") {
+			return { jsonrpc: "2.0", id, result: {} };
+		}
 		if (request.method === "tools/list") {
 			return { jsonrpc: "2.0", id, result: { tools: COORDINATOR_MCP_TOOL_NAMES.map(toolSchema) } };
 		}

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -423,6 +423,56 @@ async function registerSdkSession(server: ReturnType<typeof createCoordinatorMcp
 }
 
 describe("Coordinator MCP canonical SDK controls", () => {
+	async function pingServer(root: string) {
+		const server = createCoordinatorMcpServer({
+			env: {
+				GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
+				GJC_COORDINATOR_MCP_STATE_ROOT: path.join(root, ".gjc", "coordinator-state"),
+				GJC_COORDINATOR_MCP_PROFILE: "local",
+				GJC_COORDINATOR_MCP_REPO: "repo",
+			},
+			services: { getAgentDir: () => path.join(root, "agent-global") },
+		});
+		return server;
+	}
+
+	it("answers the MCP ping keepalive with an empty result instead of method-not-found", async () => {
+		const root = await tempRoot();
+		const server = await pingServer(root);
+		const response = await server.handleJsonRpc({ jsonrpc: "2.0", id: 1, method: "ping" });
+		expect(response).toEqual({ jsonrpc: "2.0", id: 1, result: {} });
+	});
+
+	it("preserves a string request id in the ping response", async () => {
+		const root = await tempRoot();
+		const server = await pingServer(root);
+		const response = await server.handleJsonRpc({ jsonrpc: "2.0", id: "keepalive-1", method: "ping" });
+		expect(response).toEqual({ jsonrpc: "2.0", id: "keepalive-1", result: {} });
+	});
+
+	it("answers ping with extra params by ignoring them (params carry no payload)", async () => {
+		const root = await tempRoot();
+		const server = await pingServer(root);
+		const response = await server.handleJsonRpc({
+			jsonrpc: "2.0",
+			id: 42,
+			method: "ping",
+			params: { unexpected: "ignored" },
+		});
+		expect(response).toEqual({ jsonrpc: "2.0", id: 42, result: {} });
+	});
+
+	it("does not write any coordinator state files for a ping keepalive", async () => {
+		const root = await tempRoot();
+		const stateRoot = path.join(root, ".gjc", "coordinator-state");
+		const server = await pingServer(root);
+		await server.handleJsonRpc({ jsonrpc: "2.0", id: 1, method: "ping" });
+		const exists = await fs
+			.stat(stateRoot)
+			.then(() => true)
+			.catch(() => false);
+		expect(exists).toBe(false);
+	});
 	it("uses agent-global SDK discovery and returns credential-free broker status", async () => {
 		const root = await tempRoot();
 		const controls: SdkControl[] = [];

--- a/packages/coding-agent/test/coordinator-mcp/pump.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp/pump.test.ts
@@ -352,4 +352,14 @@ describe("pumpCoordinatorMcpStream — frame handling", () => {
 		await pumpCoordinatorMcpStream(handler as never, ch, l => void writes.push(JSON.parse(l)));
 		expect(writes.map(w => w.id)).toEqual([7]);
 	});
+	it("answers a ping request but emits nothing for a ping notification (no id)", async () => {
+		const handler = async (req: Rpc): Promise<Rpc> => ({ jsonrpc: "2.0", id: req.id ?? null, result: {} });
+		const writes: Rpc[] = [];
+		const ch = channel();
+		ch.push(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" })}\n`); // request → answered
+		ch.push(`${JSON.stringify({ jsonrpc: "2.0", method: "ping" })}\n`); // notification (no id) → no response
+		ch.close();
+		await pumpCoordinatorMcpStream(handler as never, ch, l => void writes.push(JSON.parse(l)));
+		expect(writes.map(w => w.id)).toEqual([1]); // only the request id gets a response
+	});
 });


### PR DESCRIPTION
handleJsonRpc handled initialize, tools/list, prompts/list, resources/list and tools/call but had no branch for the MCP `ping` method, so clients using ping as a liveness probe (e.g. Claude Code) received `-32601 unknown_method:ping` and kept reconnecting.

Per the MCP spec, ping MUST return an empty result `{}`. The pump's dispatch already routes ping as a control frame bypassing the data-concurrency cap (and pump.test.ts already assumes ping returns an empty result), but the handler never actually answered it.

Add the missing `ping` branch returning `{ result: {} }` and a focused regression test against the real handleJsonRpc.

## What

<!-- Brief description of the change -->

## Why

<!-- Motivation, context, or link to issue (fixes #N) -->

## Testing

<!-- How was this tested? -->

## GJC verdict

<!-- Paste one exact-head verdict. Self-approval is BLOCK. If there was no independent architect/critic/human review, write needs-human and stop. -->

```text
gajae.pr-review-verdict.v1 <merge-approved|merge-blocked|needs-human> sha256:<exact-head-or-diff-hash> reviewer:<architect|critic|human> evidence:<ci-run-url-or-local-command>
```

---

- [ ] Target branch is `dev`
- [ ] `bun check` passes
- [ ] Tested locally
- [ ] CHANGELOG updated (if user-facing)
- [ ] Verdict above matches the exact PR head, not an earlier commit
