### PR TITLE
fix(ai): collapse adjacent thinking blocks before Anthropic replay

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Assistant turns that carry two directly adjacent `thinking` blocks are now collapsed to the first block before replay on `anthropic-messages`. Anthropic rejects that shape with `messages.N.content.M: thinking or redacted_thinking blocks in the latest assistant message cannot be modified`, citing the second block of the pair, and because the offending message keeps its index as the transcript grows, one such turn made every later request in the session fail - observed on two live sessions stuck for 9+ hours, each turn spending two rejected ~1.5 MB uploads, with the cited index frozen (`messages.5.content.118`) while the history grew from 103 to 430 messages. Verified against the captured transcript: the unmodified 430-message replay returns 400 and the collapsed replay returns 200. Thinking blocks separated by a `tool_use` are ordinary interleaved-thinking shape and are preserved, and a `redacted_thinking` blob following a thinking block is untouched (#4416).
 - Dev CI now runs each AI test file in a fresh process instead of sharing one Bun test runtime across the package. This prevents leaked fetch spies, fake timers, environment overrides, auth-broker state, and module caches from contaminating later files while using the same bounded, root-preloaded harness as coding-agent shards (#4378).
 - Anthropic thinking-replay repair now fingerprints the exact serialized outbound body before any application-level resend. A no-op latest-assistant transform is skipped in favor of a safe all-assistant transform, and if neither changes the body the turn fails without uploading the same large request again. The rejected request, transform disposition, hashes, sizes, and cited `messages.N.content.M` mismatch are recorded through the existing redacted HTTP-400 capture and warn path; thinking mode and the `context-management-2025-06-27` beta remain unchanged (#4382).
 - Anthropic 400 errors that name a `clear_thinking_*` context-management strategy now explain when GJC's captured outgoing body contains neither `thinking` nor `context_management`: an intermediary at the redacted configured base URL likely injected the strategy. The diagnostic recommends explicitly enabling thinking or fixing/replacing the intermediary, never silently enables thinking or retries, and annotates the sanitized raw-request capture without changing its body. Credit: @probepark (#4380).
@@ -87,7 +88,6 @@
 
 ### Fixed
 
-
 - `todo_write` raw argument rejections now carry bounded, authority-controlled correction codes for each rejected shape: unknown root keys, unknown operation-entry keys, done/drop entries missing a task or phase target, and unknown init list-entry keys. Each code maps to a fixed correction message naming the accepted shape (never echoing the offending input), so invalid calls surface specific guidance while valid payloads keep the existing passthrough/coercion path (#3916).
 - Anthropic Sonnet 5 now exposes Anthropic's real `xhigh` and `max` thinking efforts on the Messages API (`minimal`/`low`/`medium`/`high`/`xhigh`/`max`), matching official support. The previous generic `kind === opus` gate excluded it from the full preset range; the capability predicate is now an explicit version-scoped list (Opus 4.7+, Sonnet 5+), so older Sonnet generations and Bedrock Converse routes stay fail-closed at their previously advertised levels (issue #3913).
 - Alibaba Token Plan now exposes Qwen 3.8 Max under the provider-supported `qwen3.8-max` wire id instead of the rejected `qwen-3.8-max` spelling; catalog regeneration canonicalizes a legacy discovered alias rather than retaining a broken duplicate (#3909).
@@ -151,7 +151,6 @@
 ### Added
 
 - Reproducible Alibaba Token Plan header-parity A/B latency benchmark (`packages/ai/scripts/alibaba-token-plan-latency-ab.ts`): a fixed-seed interleaved A/B comparison of legacy vs Qwen-identical headers against a deterministic local HTTP server, reporting n/success/error/timeout and TTFT/total latency median/p90/p95/mean/stddev. No live credentials are required; a public-safe blocked-live-data receipt is included (`packages/ai/test/fixtures/alibaba-token-plan-latency-blocked-receipt.md`) (#3557).
-
 
 ## [0.12.4] - 2026-07-30
 

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -27,6 +27,38 @@ const enum ToolCallStatus {
  * - Injects synthetic "aborted" tool results
  * - Adds a <turn-aborted> guidance marker for the model
  */
+/**
+ * Collapse a run of directly adjacent `thinking` blocks inside one assistant message down
+ * to its first block.
+ *
+ * Anthropic accepts a replayed assistant turn carrying a single thinking block, and accepts
+ * thinking blocks separated by a `tool_use` (ordinary interleaved-thinking shape), but
+ * rejects two directly adjacent `thinking` blocks with
+ * `messages.N.content.M: thinking or redacted_thinking blocks in the latest assistant
+ * message cannot be modified`, citing the *second* block of the pair. Because the offending
+ * message keeps its index as history grows, a single such turn makes every later request in
+ * that session fail, and the mutation repair - scoped to the latest assistant message -
+ * can never reach it (#4416).
+ *
+ * `redactedThinking` is deliberately not folded: a redacted blob following a thinking block
+ * is a shape the API itself emits and replays cleanly.
+ */
+function collapseAdjacentThinking<T extends { type: string }>(content: T[]): T[] {
+	let previousWasThinking = false;
+	let dropped = false;
+	const collapsed: T[] = [];
+	for (const block of content) {
+		const thinking = block.type === "thinking";
+		if (thinking && previousWasThinking) {
+			dropped = true;
+			continue;
+		}
+		previousWasThinking = thinking;
+		collapsed.push(block);
+	}
+	return dropped ? collapsed : content;
+}
+
 export function transformMessages<TApi extends Api>(
 	messages: Message[],
 	model: Model<TApi>,
@@ -160,9 +192,14 @@ export function transformMessages<TApi extends Api>(
 				return block;
 			});
 
+			// Only the Anthropic wire shape rejects adjacent private blocks; other targets
+			// either degrade reasoning to text above or carry their own encoding rules.
+			const replayableContent =
+				model.api === "anthropic-messages" ? collapseAdjacentThinking(transformedContent) : transformedContent;
+
 			return {
 				...assistantMsg,
-				content: transformedContent,
+				content: replayableContent,
 			};
 		}
 		return msg;

--- a/packages/ai/test/anthropic-thinking-immutability.test.ts
+++ b/packages/ai/test/anthropic-thinking-immutability.test.ts
@@ -328,6 +328,80 @@ describe("Anthropic thinking replay immutability", () => {
 	});
 });
 
+describe("Anthropic adjacent thinking collapse", () => {
+	const usage = {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+	const user: UserMessage = { role: "user", content: "continue", timestamp: Date.now() };
+	const assistantWith = (content: AssistantMessage["content"]): AssistantMessage => ({
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: model.id,
+		usage,
+		stopReason: "toolUse",
+		timestamp: Date.now(),
+	});
+
+	it("keeps only the first of two directly adjacent thinking blocks", () => {
+		const assistant = assistantWith([
+			{ type: "thinking", thinking: "first", thinkingSignature: "sig_first" },
+			{ type: "thinking", thinking: "second", thinkingSignature: "sig_second" },
+			{ type: "toolCall", id: "toolu_1", name: "read", arguments: { path: "README.md" } },
+		]);
+
+		const params = convertAnthropicMessages([user, assistant], model, false);
+		const assistantParam = params.find(message => message.role === "assistant");
+
+		expect(assistantParam?.content).toEqual([
+			{ type: "thinking", thinking: "first", signature: "sig_first" },
+			{ type: "tool_use", id: "toolu_1", name: "read", input: { path: "README.md" } },
+		]);
+	});
+
+	it("preserves thinking blocks separated by a tool call", () => {
+		const assistant = assistantWith([
+			{ type: "thinking", thinking: "first", thinkingSignature: "sig_first" },
+			{ type: "toolCall", id: "toolu_1", name: "read", arguments: { path: "a.md" } },
+			{ type: "thinking", thinking: "second", thinkingSignature: "sig_second" },
+			{ type: "toolCall", id: "toolu_2", name: "read", arguments: { path: "b.md" } },
+		]);
+
+		const params = convertAnthropicMessages([user, assistant], model, false);
+		const assistantParam = params.find(message => message.role === "assistant");
+
+		expect(assistantParam?.content).toEqual([
+			{ type: "thinking", thinking: "first", signature: "sig_first" },
+			{ type: "tool_use", id: "toolu_1", name: "read", input: { path: "a.md" } },
+			{ type: "thinking", thinking: "second", signature: "sig_second" },
+			{ type: "tool_use", id: "toolu_2", name: "read", input: { path: "b.md" } },
+		]);
+	});
+
+	it("keeps a redacted block that directly follows a thinking block", () => {
+		const assistant = assistantWith([
+			{ type: "thinking", thinking: "first", thinkingSignature: "sig_first" },
+			{ type: "redactedThinking", data: "redacted-blob" },
+			{ type: "toolCall", id: "toolu_1", name: "read", arguments: { path: "README.md" } },
+		]);
+
+		const params = convertAnthropicMessages([user, assistant], model, false);
+		const assistantParam = params.find(message => message.role === "assistant");
+
+		expect(assistantParam?.content).toEqual([
+			{ type: "thinking", thinking: "first", signature: "sig_first" },
+			{ type: "redacted_thinking", data: "redacted-blob" },
+			{ type: "tool_use", id: "toolu_1", name: "read", input: { path: "README.md" } },
+		]);
+	});
+});
+
 describe("Anthropic thinking replay 400 classification", () => {
 	const status400 = (message: string): Error => Object.assign(new Error(message), { status: 400 });
 	// Captured from a real session failure (2026-07-23): a historical thinking block


### PR DESCRIPTION
Closes #4416.

## Problem

An assistant turn carrying **two directly adjacent `thinking` blocks** is rejected by Anthropic:

```
messages.N.content.M: `thinking` or `redacted_thinking` blocks in the latest assistant
message cannot be modified. These blocks must remain as in the original response.
```

The citation points at the **second** block of the pair. The offending message keeps its index as the transcript grows, so one such turn makes every later request in that session fail. The mutation repair is scoped to the latest assistant message and can therefore never reach it - two live sessions here sat in that state for 9+ hours, spending two rejected ~1.5 MB uploads per turn while the cited index stayed frozen at `messages.5.content.118` and the history grew from 103 to 430 messages.

## Change

`transformMessages` collapses a run of adjacent `thinking` blocks to its first block when the target api is `anthropic-messages`.

Deliberately narrow:

- thinking blocks separated by a `tool_use` are ordinary interleaved-thinking shape and are preserved
- a `redacted_thinking` blob following a thinking block is a shape the API itself emits, so it is not folded
- non-Anthropic targets are untouched (reasoning already degrades to text there)

## Verification

Minimal reproducer against the live endpoint, blocks lifted verbatim from the poisoned message:

```
assistant = [thinking(sigA), thinking(sigB), text]  -> 400  messages.1.content.1 ... cannot be modified
assistant = [thinking(sigA), text]                  -> 200
assistant = [thinking(sigB), text]                  -> 200
```

End-to-end against the captured 430-message transcript of the wedged session:

```
full history, unmodified                      -> 400  messages.5.content.118  (909 KB)
full history, adjacent thinking collapsed     -> 200                          (906 KB)
```

Tests: 3 added in `packages/ai/test/anthropic-thinking-immutability.test.ts` (collapse the pair / preserve tool-call-separated thinking / preserve a following redacted block). `bun test packages/ai/test/anthropic-thinking-immutability.test.ts` -> 21 pass.

Suite comparison on `packages/ai/test` before vs after this change: identical failure sets except one flaky test (`durable tool-choice capability cache > serializes concurrent process writes`, fails ~1 run in 4 with and without the change; the other 42 failures are pre-existing on `origin/dev`).

`biome check` and `tsc --noEmit` for `packages/ai` are clean, `git diff --check` is clean.

## Relation to #4382

#4382 (already merged) stops the wasted resend and escalates a no-op latest-assistant transform to the all-assistant transform. That is the mitigation - it recovers by dropping *every* thinking block. This PR removes the cause, so the escalation stops being needed for this failure mode.

Still open from that investigation and not in this PR:

- instrument the stream assembler to dump the SSE envelope when a completed assistant message ends up with adjacent thinking blocks, to name the producer (provider stream vs. a later history mutation that removed the separating `tool_use`)
- #4380, the proxy-injected `context_management` `clear_thinking_20251015`, which is independent of this bug
