### PR TITLE
fix(tui): preserve images in terminal scrollback

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Kitty inline images are no longer deleted when live output moves their anchor above the viewport, so terminal-native scrollback keeps previously rendered images visible.
 
 - A fast double-Esc (or triple-Esc) whose ESC bytes coalesce into one stdin chunk — which tmux always produces within its escape-time window, and SSH batching produces routinely — is now emitted as individual Escape key presses instead of a single `"\x1b\x1b"` sequence that parsed as the unbound `alt+escape` and silently swallowed both presses. This restores the double-Esc draft-clear and double-Esc selector gestures under tmux/SSH. Option-as-Meta sequences with a real continuation (e.g. Option+Up as `ESC ESC [ A`) remain atomic, and an ESC-cancelled incomplete sequence is still emitted whole.
 - An ambiguous trailing run of Escape bytes now stays buffered until a continuation or the flush timeout resolves it, so `ESC ESC ESC` followed by `[A` in the next chunk still decodes as Escape then `alt+up` instead of two Escapes plus a plain Up that fired the destructive double-Escape gesture.

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -4040,21 +4040,6 @@ export class TUI extends Container {
 			viewportRepaint(`content contraction changed viewport top (${prevViewportTop} -> ${nextLiveViewportTop})`);
 			return;
 		}
-		if (
-			appendedLines &&
-			nextLiveViewportTop > prevViewportTop &&
-			previousKittyPlacementSpans.some(placement =>
-				this.#kittyPlacementIntersectsRegion(placement, {
-					top: prevViewportTop,
-					bottom: prevViewportTop + height,
-				}),
-			)
-		) {
-			viewportRepaint(
-				`content append moved a Kitty placement viewport (${prevViewportTop} -> ${nextLiveViewportTop})`,
-			);
-			return;
-		}
 		if (distinctPostContractionRows) this.#scrollbackResumeViewportTop = undefined;
 		if (
 			appendedLines &&

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -556,7 +556,7 @@ describe("TUI terminal-state regressions", () => {
 			}
 		});
 
-		it("removes a Kitty placement when sticky live viewport repaint moves its anchor into scrollback", async () => {
+		it("preserves a Kitty placement when sticky live output moves its anchor into native scrollback", async () => {
 			const originalProtocol = TERMINAL.imageProtocol;
 			const originalCellDimensions = getCellDimensions();
 			setCellDimensions({ widthPx: 10, heightPx: 10 });
@@ -591,7 +591,7 @@ describe("TUI terminal-state regressions", () => {
 				tui.requestRender();
 				await settle(term);
 				const liveOutput = term.getWriteLog().join("");
-				expect(liveOutput).toContain(encodeKittyPlacementDelete(placement!));
+				expect(liveOutput).not.toContain(encodeKittyPlacementDelete(placement!));
 				expect(extractKittyPlacementReferences(liveOutput)).toEqual([]);
 
 				term.clearWriteLog();

--- a/packages/tui/test/viewport-scroll.test.ts
+++ b/packages/tui/test/viewport-scroll.test.ts
@@ -1614,7 +1614,7 @@ describe("registered viewport anchor", () => {
 			tui.requestRender();
 			await settle(term);
 			const grownOutput = term.getWriteLog().join("");
-			expect(grownOutput).toContain(encodeKittyPlacementDelete(replacementPlacement!));
+			expect(grownOutput).not.toContain(encodeKittyPlacementDelete(replacementPlacement!));
 			expect(extractKittyPlacementReferences(grownOutput)).toEqual([]);
 		} finally {
 			tui.stop();


### PR DESCRIPTION
## Summary
- stop deleting Kitty image placements when ordinary live output moves their anchors above the viewport
- preserve already-rendered images in terminal-native scrollback
- retain stale-placement cleanup for manual follow-live, replacement, resize, removal, pinned components, and overlays

## Verification
- bun test packages/tui/test/render-regressions.test.ts
- bun test packages/tui/test/image-render.test.ts
- bun --cwd=packages/tui run check

## Review
- Ultragoal architect review: CLEAR / APPROVE
- Ultragoal executor QA/red-team: passed
- Ultragoal terminal critic: OKAY