### PR TITLE
fix(ai): collapse adjacent thinking blocks at Anthropic send boundary

### DIFF
--- a/artifacts/issue-3670-anthropic-cache-eval.json
+++ b/artifacts/issue-3670-anthropic-cache-eval.json
@@ -6,8 +6,8 @@
 	"source": {
 		"url": "https://platform.claude.com/docs/en/build-with-claude/prompt-caching",
 		"retrievedAt": "2026-07-18",
-		"providerSourceBlobOid": "a654fcc1d261547c5fa525763058a57cb3dca230",
-		"providerSourceSha256": "c1fa95dcafdbb5e7f4bcc1863c73656bc0184c6614f7b4ac81f382a1bfacf449",
+		"providerSourceBlobOid": "3f5d80f1aa64d483cccfefe183789a0be2543433",
+		"providerSourceSha256": "d1d583880f765f168095d3b99d03342b8b9fb2b92cc32626aa0e207f5c691cdc",
 		"inputFixtureSha256": "562926fba79f003eff4d45c0da2292ac66d84302e3960b2d7493441ade1f9e04"
 	},
 	"derivationCommands": [

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -3393,6 +3393,49 @@ function buildToolResultBlock(model: Model<"anthropic-messages">, msg: ToolResul
 	return block;
 }
 
+/**
+ * Anthropic rejects a replayed assistant message containing adjacent
+ * `thinking`/`redacted_thinking` blocks — even when each block individually
+ * carries a valid signature — with a 400 citing the second block: "cannot be
+ * modified. These blocks must remain as in the original response." (issue #4416)
+ *
+ * The adjacency can originate from the provider stream (two `content_block_start`
+ * events for `thinking` in one message with no intervening `tool_use`), from a
+ * history mutation that removed a separating `tool_use`, or from an earlier
+ * conversion phase in `convertAnthropicMessages` that skipped an empty `text`
+ * block sitting between two thinking blocks. Because that last path exists, the
+ * invariant cannot be enforced in the shared `transformMessages` phase — it must
+ * run on the final wire output.
+ *
+ * This collapses each run of adjacent `thinking`/`redacted_thinking` blocks down
+ * to the first block, preserving its bytes, signature, and type verbatim (never
+ * concatenating, editing, synthesizing, or choosing the last). Blocks separated
+ * by any non-thinking block (`text`, `tool_use`, …) are legitimate
+ * interleaved-thinking shape and pass through unchanged. `thinking` and
+ * `redacted_thinking` are treated as one adjacency class per the API contract.
+ *
+ * The pass is O(n) per message and idempotent: an already-collapsed array is a
+ * no-op, so re-runs through `convertAnthropicMessages` (e.g. forced-tool-choice
+ * or unreplayable-thinking rebuilds) are safe.
+ */
+function collapseAdjacentThinkingBlocks(messages: MessageParam[]): void {
+	for (const message of messages) {
+		if (message.role !== "assistant" || !Array.isArray(message.content)) continue;
+		const content = message.content;
+		let write = 0;
+		let inThinkingRun = false;
+		for (let read = 0; read < content.length; read++) {
+			const block = content[read];
+			if (block === undefined) continue;
+			const isThinkingBlock = block.type === "thinking" || block.type === "redacted_thinking";
+			if (isThinkingBlock && inThinkingRun) continue; // only the first block of a run survives
+			inThinkingRun = isThinkingBlock;
+			content[write++] = block;
+		}
+		if (write < content.length) content.length = write;
+	}
+}
+
 export function convertAnthropicMessages(
 	messages: Message[],
 	model: Model<"anthropic-messages">,
@@ -3530,6 +3573,11 @@ export function convertAnthropicMessages(
 		}
 	}
 
+	// Final send-time invariant (issue #4416): collapse any run of adjacent
+	// `thinking`/`redacted_thinking` blocks within one assistant message down to
+	// the first block. This runs on the wire output because earlier phases here
+	// (e.g. skipping empty text blocks) can themselves create the adjacency.
+	collapseAdjacentThinkingBlocks(params);
 	if (params.length > 0 && params[params.length - 1]?.role === "assistant") {
 		params.push({ role: "user", content: "Continue." });
 	}

--- a/packages/ai/test/anthropic-adjacent-thinking-collapse.test.ts
+++ b/packages/ai/test/anthropic-adjacent-thinking-collapse.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it } from "bun:test";
+import { convertAnthropicMessages } from "@gajae-code/ai/providers/anthropic";
+import type { AssistantMessage, Model, ToolResultMessage, UserMessage } from "@gajae-code/ai/types";
+
+const model: Model<"anthropic-messages"> = {
+	api: "anthropic-messages",
+	provider: "anthropic",
+	id: "claude-opus-5",
+	name: "Claude Opus 5",
+	baseUrl: "https://api.anthropic.com",
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	maxTokens: 8_192,
+	contextWindow: 200_000,
+	reasoning: true,
+};
+
+/**
+ * Minimal same-model Anthropic assistant turn builder for adjacency tests.
+ * Each thinking block carries a distinct signature so the invariant can be
+ * verified by inspecting which signature survived.
+ */
+function makeAssistant(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: Date.now(),
+	};
+}
+
+const userTurn: UserMessage = { role: "user", content: "continue", timestamp: Date.now() };
+
+describe("convertAnthropicMessages: adjacent thinking-block collapse (#4416)", () => {
+	it("collapses [thinking(sigA), thinking(sigB), toolCall] to [thinking(sigA), toolCall]", () => {
+		const assistant = makeAssistant([
+			{ type: "thinking", thinking: "first thinking", thinkingSignature: "sigA" },
+			{ type: "thinking", thinking: "second thinking", thinkingSignature: "sigB" },
+			{ type: "text", text: "answer" },
+			{ type: "toolCall", id: "toolu_1", name: "read", arguments: { path: "README.md" } },
+		]);
+
+		const params = convertAnthropicMessages([userTurn, assistant], model, false);
+		const wire = params.find(m => m.role === "assistant");
+		expect(wire).toBeDefined();
+		expect(wire?.content).toEqual([
+			{ type: "thinking", thinking: "first thinking", signature: "sigA" },
+			{ type: "text", text: "answer" },
+			{ type: "tool_use", id: "toolu_1", name: "read", input: { path: "README.md" } },
+		]);
+	});
+
+	it("collapses a run of three adjacent thinking blocks to the first", () => {
+		const assistant = makeAssistant([
+			{ type: "thinking", thinking: "alpha", thinkingSignature: "sigA" },
+			{ type: "thinking", thinking: "beta", thinkingSignature: "sigB" },
+			{ type: "thinking", thinking: "gamma", thinkingSignature: "sigC" },
+			{ type: "text", text: "answer" },
+		]);
+
+		const params = convertAnthropicMessages([userTurn, assistant], model, false);
+		const wire = params.find(m => m.role === "assistant");
+		expect(wire?.content).toEqual([
+			{ type: "thinking", thinking: "alpha", signature: "sigA" },
+			{ type: "text", text: "answer" },
+		]);
+	});
+
+	it("collapses adjacent mixed thinking/redacted-thinking in thinking-then-redacted order", () => {
+		const assistant = makeAssistant([
+			{ type: "thinking", thinking: "reasoning", thinkingSignature: "sigA" },
+			{ type: "redactedThinking", data: "opaque-redacted" },
+			{ type: "text", text: "answer" },
+		]);
+
+		const params = convertAnthropicMessages([userTurn, assistant], model, false);
+		const wire = params.find(m => m.role === "assistant");
+		expect(wire?.content).toEqual([
+			{ type: "thinking", thinking: "reasoning", signature: "sigA" },
+			{ type: "text", text: "answer" },
+		]);
+	});
+
+	it("collapses adjacent mixed thinking/redacted-thinking in redacted-then-thinking order", () => {
+		const assistant = makeAssistant([
+			{ type: "redactedThinking", data: "opaque-redacted" },
+			{ type: "thinking", thinking: "reasoning", thinkingSignature: "sigB" },
+			{ type: "text", text: "answer" },
+		]);
+
+		const params = convertAnthropicMessages([userTurn, assistant], model, false);
+		const wire = params.find(m => m.role === "assistant");
+		expect(wire?.content).toEqual([
+			{ type: "redacted_thinking", data: "opaque-redacted" },
+			{ type: "text", text: "answer" },
+		]);
+	});
+
+	it("preserves interleaved [thinking, toolCall, thinking, toolCall]", () => {
+		const assistant = makeAssistant([
+			{ type: "thinking", thinking: "first thought", thinkingSignature: "sigA" },
+			{ type: "toolCall", id: "toolu_1", name: "read", arguments: { path: "a.txt" } },
+			{ type: "thinking", thinking: "second thought", thinkingSignature: "sigB" },
+			{ type: "toolCall", id: "toolu_2", name: "read", arguments: { path: "b.txt" } },
+		]);
+
+		const params = convertAnthropicMessages([userTurn, assistant], model, false);
+		const wire = params.find(m => m.role === "assistant");
+		expect(wire?.content).toEqual([
+			{ type: "thinking", thinking: "first thought", signature: "sigA" },
+			{ type: "tool_use", id: "toolu_1", name: "read", input: { path: "a.txt" } },
+			{ type: "thinking", thinking: "second thought", signature: "sigB" },
+			{ type: "tool_use", id: "toolu_2", name: "read", input: { path: "b.txt" } },
+		]);
+	});
+
+	it("preserves thinking separated by a text block", () => {
+		const assistant = makeAssistant([
+			{ type: "thinking", thinking: "first", thinkingSignature: "sigA" },
+			{ type: "text", text: "intermediate text" },
+			{ type: "thinking", thinking: "second", thinkingSignature: "sigB" },
+		]);
+
+		const params = convertAnthropicMessages([userTurn, assistant], model, false);
+		const wire = params.find(m => m.role === "assistant");
+		expect(wire?.content).toEqual([
+			{ type: "thinking", thinking: "first", signature: "sigA" },
+			{ type: "text", text: "intermediate text" },
+			{ type: "thinking", thinking: "second", signature: "sigB" },
+		]);
+	});
+
+	it("collapses a leading run of adjacent thinking blocks", () => {
+		const assistant = makeAssistant([
+			{ type: "thinking", thinking: "keep", thinkingSignature: "sigA" },
+			{ type: "thinking", thinking: "drop", thinkingSignature: "sigB" },
+		]);
+
+		const params = convertAnthropicMessages([userTurn, assistant], model, false);
+		const wire = params.find(m => m.role === "assistant");
+		expect(wire?.content).toEqual([{ type: "thinking", thinking: "keep", signature: "sigA" }]);
+	});
+
+	it("collapses a trailing run of adjacent thinking blocks", () => {
+		const assistant = makeAssistant([
+			{ type: "text", text: "answer" },
+			{ type: "thinking", thinking: "keep", thinkingSignature: "sigA" },
+			{ type: "thinking", thinking: "drop", thinkingSignature: "sigB" },
+		]);
+
+		const params = convertAnthropicMessages([userTurn, assistant], model, false);
+		const wire = params.find(m => m.role === "assistant");
+		expect(wire?.content).toEqual([
+			{ type: "text", text: "answer" },
+			{ type: "thinking", thinking: "keep", signature: "sigA" },
+		]);
+	});
+
+	it("is idempotent: running convertAnthropicMessages output through again is a no-op", () => {
+		const assistant = makeAssistant([
+			{ type: "thinking", thinking: "first", thinkingSignature: "sigA" },
+			{ type: "thinking", thinking: "second", thinkingSignature: "sigB" },
+			{ type: "thinking", thinking: "third", thinkingSignature: "sigC" },
+			{ type: "text", text: "answer" },
+		]);
+
+		const params1 = convertAnthropicMessages([userTurn, assistant], model, false);
+		const wire1 = JSON.stringify(params1.find(m => m.role === "assistant")?.content);
+
+		// Re-run: the collapsed output fed back in must not change further.
+		// We re-build a fresh AssistantMessage from the wire shape to exercise
+		// the full conversion path (transformMessages → convertAnthropicMessages).
+		const replayAssistant: AssistantMessage = {
+			...assistant,
+			content: [
+				{ type: "thinking", thinking: "first", thinkingSignature: "sigA" },
+				{ type: "text", text: "answer" },
+			],
+		};
+		const params2 = convertAnthropicMessages([userTurn, replayAssistant], model, false);
+		const wire2 = JSON.stringify(params2.find(m => m.role === "assistant")?.content);
+
+		expect(wire1).toEqual(wire2);
+	});
+
+	it("collapses adjacency created when convertAnthropicMessages skips an empty text block", () => {
+		// [thinking, text(""), thinking] — the empty text is skipped, which would
+		// create [thinking, thinking] on the wire without the final collapse pass.
+		const assistant = makeAssistant([
+			{ type: "thinking", thinking: "first", thinkingSignature: "sigA" },
+			{ type: "text", text: "   " },
+			{ type: "thinking", thinking: "second", thinkingSignature: "sigB" },
+			{ type: "text", text: "answer" },
+		]);
+
+		const params = convertAnthropicMessages([userTurn, assistant], model, false);
+		const wire = params.find(m => m.role === "assistant");
+		expect(wire?.content).toEqual([
+			{ type: "thinking", thinking: "first", signature: "sigA" },
+			{ type: "text", text: "answer" },
+		]);
+	});
+
+	it("does not collapse cross-model thinking blocks that degrade to text", () => {
+		// Cross-model thinking degrades to text in transformMessages when it is
+		// NOT the latest Anthropic assistant message (isSameModel=false &&
+		// mustPreserveLatestAnthropicThinking=false). Those degraded text blocks
+		// are never native thinking on the wire, so the collapse must leave them
+		// intact. Here an earlier cross-model turn sits before a same-model turn.
+		const crossModelAssistant: AssistantMessage = {
+			...makeAssistant([
+				{ type: "thinking", thinking: "cross-model reasoning A", thinkingSignature: "sigX" },
+				{ type: "thinking", thinking: "cross-model reasoning B", thinkingSignature: "sigY" },
+				{ type: "text", text: "cross-model answer" },
+			]),
+			model: "claude-sonnet-4-6", // different model id
+		};
+		const sameModelAssistant = makeAssistant([
+			{ type: "thinking", thinking: "same-model reasoning", thinkingSignature: "sigSame" },
+			{ type: "text", text: "same-model answer" },
+		]);
+		const userMid: UserMessage = { role: "user", content: "again", timestamp: Date.now() };
+
+		const params = convertAnthropicMessages(
+			[userTurn, crossModelAssistant, userMid, sameModelAssistant],
+			model,
+			false,
+		);
+		const assistants = params.filter(m => m.role === "assistant");
+		// Cross-model thinking degraded to text; both survive (collapse targets
+		// native thinking blocks only).
+		expect(assistants[0]?.content).toEqual([
+			{ type: "text", text: "cross-model reasoning A" },
+			{ type: "text", text: "cross-model reasoning B" },
+			{ type: "text", text: "cross-model answer" },
+		]);
+		// Same-model native thinking is preserved.
+		expect(assistants[1]?.content).toEqual([
+			{ type: "thinking", thinking: "same-model reasoning", signature: "sigSame" },
+			{ type: "text", text: "same-model answer" },
+		]);
+	});
+
+	it("collapses adjacency across multiple assistant messages independently", () => {
+		const assistantA = makeAssistant([
+			{ type: "thinking", thinking: "a-first", thinkingSignature: "sigA1" },
+			{ type: "thinking", thinking: "a-second", thinkingSignature: "sigA2" },
+			{ type: "text", text: "answer a" },
+		]);
+		const assistantB = makeAssistant([
+			{ type: "thinking", thinking: "b-first", thinkingSignature: "sigB1" },
+			{ type: "thinking", thinking: "b-second", thinkingSignature: "sigB2" },
+			{ type: "text", text: "answer b" },
+		]);
+		const toolResult: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: "toolu_1",
+			toolName: "read",
+			content: [{ type: "text", text: "result" }],
+			isError: false,
+			timestamp: Date.now(),
+		};
+
+		const params = convertAnthropicMessages([userTurn, assistantA, toolResult, assistantB], model, false);
+		const assistants = params.filter(m => m.role === "assistant");
+		expect(assistants).toHaveLength(2);
+		expect(assistants[0]?.content).toEqual([
+			{ type: "thinking", thinking: "a-first", signature: "sigA1" },
+			{ type: "text", text: "answer a" },
+		]);
+		expect(assistants[1]?.content).toEqual([
+			{ type: "thinking", thinking: "b-first", signature: "sigB1" },
+			{ type: "text", text: "answer b" },
+		]);
+	});
+
+	it("preserves the surviving block's exact bytes/signature (object identity of first block)", () => {
+		const assistant = makeAssistant([
+			{ type: "thinking", thinking: "first", thinkingSignature: "sigA" },
+			{ type: "thinking", thinking: "second", thinkingSignature: "sigB" },
+		]);
+
+		const params = convertAnthropicMessages([userTurn, assistant], model, false);
+		const wire = params.find(m => m.role === "assistant");
+		const wireContent = Array.isArray(wire?.content) ? wire.content : [];
+		// Only the first thinking block survives; its signature and bytes are unchanged.
+		expect(wireContent).toEqual([{ type: "thinking", thinking: "first", signature: "sigA" }]);
+		expect(wireContent.some(b => "signature" in b && b.signature === "sigB")).toBe(false);
+	});
+
+	it("handles a long adversarial run of alternating thinking types bounded and idempotent", () => {
+		// 200 adjacent thinking/redacted blocks → must collapse to exactly one in O(n).
+		const blocks: AssistantMessage["content"] = [];
+		for (let i = 0; i < 100; i++) {
+			blocks.push({ type: "thinking", thinking: `t${i}`, thinkingSignature: `sig${i}` });
+			blocks.push({ type: "redactedThinking", data: `r${i}` });
+		}
+		blocks.push({ type: "text", text: "answer" });
+		const assistant = makeAssistant(blocks);
+
+		const params = convertAnthropicMessages([userTurn, assistant], model, false);
+		const wire = params.find(m => m.role === "assistant");
+		expect(wire?.content).toEqual([
+			{ type: "thinking", thinking: "t0", signature: "sig0" },
+			{ type: "text", text: "answer" },
+		]);
+	});
+
+	it("reconstructs the minimal #4416 reproducer: [thinking, thinking, text] → [thinking, text]", () => {
+		// probepark's minimal reproducer: two signed thinking blocks lifted
+		// verbatim from a poisoned message, replayed in a 3-message conversation.
+		// Either block alone succeeds; the adjacent pair is rejected by Anthropic.
+		const poisonedAssistant = makeAssistant([
+			{ type: "thinking", thinking: "first reasoning block", thinkingSignature: "sig_1880_chars_A" },
+			{ type: "thinking", thinking: "second reasoning block", thinkingSignature: "sig_2032_chars_B" },
+			{ type: "text", text: "visible response" },
+		]);
+
+		const params = convertAnthropicMessages([userTurn, poisonedAssistant], model, false);
+		const wire = params.find(m => m.role === "assistant");
+		expect(wire?.content).toEqual([
+			{ type: "thinking", thinking: "first reasoning block", signature: "sig_1880_chars_A" },
+			{ type: "text", text: "visible response" },
+		]);
+	});
+});

--- a/packages/ai/test/anthropic-prefill.test.ts
+++ b/packages/ai/test/anthropic-prefill.test.ts
@@ -104,6 +104,7 @@ it("preserves redacted thinking blocks in assistant replay payloads", () => {
 		role: "assistant",
 		content: [
 			{ type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+			{ type: "text", text: "intermediate" },
 			{ type: "redactedThinking", data: "encrypted_payload" },
 			{ type: "text", text: "Final answer" },
 		],
@@ -127,9 +128,11 @@ it("preserves redacted thinking blocks in assistant replay payloads", () => {
 	expect(assistantParam).toBeDefined();
 	expect(Array.isArray(assistantParam?.content)).toBe(true);
 	const blocks = assistantParam?.content as unknown as Array<Record<string, unknown>>;
-	expect(blocks.map(block => block.type)).toEqual(["thinking", "redacted_thinking", "text"]);
+	// The text block separates thinking from redactedThinking so the adjacency
+	// collapse (#4416) does not merge them; both survive as distinct blocks.
+	expect(blocks.map(block => block.type)).toEqual(["thinking", "text", "redacted_thinking", "text"]);
 	expect(blocks[0]?.signature).toBe("sig_1");
-	expect(blocks[1]?.data).toBe("encrypted_payload");
+	expect(blocks[2]?.data).toBe("encrypted_payload");
 });
 
 it("preserves latest Anthropic thinking blocks even when model id changes", () => {


### PR DESCRIPTION
Closes #4416

## Summary

Anthropic rejects a replayed assistant message containing adjacent `thinking`/`redacted_thinking` blocks with a 400 citing the second block: *"cannot be modified. These blocks must remain as in the original response."* Either block alone is accepted; the adjacent pair is not.

@probepark isolated the root cause with a precise minimal reproducer in #4416: two signed thinking blocks lifted verbatim from a poisoned message, replayed in a 3-message conversation. The adjacent pair 400s on every subsequent turn for the session's life, while dropping either block clears it. Thank you for the bisection — it made this a one-site fix.

This complements #4382, whose broader retry/persistence/diagnostic work stays separately owned.

## Fix

The invariant is enforced at the canonical Anthropic transform boundary — `convertAnthropicMessages` — not in transcript mutation/storage or the shared cross-provider `transformMessages`.

**Why the final send output, not `transformMessages`:**
- `convertAnthropicMessages` is the single function through which all Anthropic message conversion flows (initial build, forced-tool-choice rebuild, unreplayable-thinking rebuild). Its output is the final `MessageParam[]` sent to the API.
- `transformMessages` is shared across **all** providers (bedrock, openai-responses, ollama, codex, google, azure, openai-completions). Putting Anthropic-specific logic there violates separation of concerns.
- **Crucially, `convertAnthropicMessages` itself can create adjacency**: it skips empty text blocks, so `[thinking, text(""), thinking]` becomes `[thinking, thinking]` on the wire. The collapse must run **after** that phase.

**What the collapse does:**
- Collapses each run of adjacent `thinking`/`redacted_thinking` blocks within one assistant message to the **first** block.
- Preserves the first block's bytes, signature, and type **verbatim** — never concatenates, edits, synthesizes, or chooses the last.
- `thinking` and `redacted_thinking` are one adjacency class per the API contract.
- Blocks separated by any non-thinking block (`text`, `tool_use`) are legitimate interleaved-thinking shape and pass through unchanged.
- O(n) per message, idempotent.

## What this does NOT do (stays in #4382)
- All-history retry persistence escalation
- Producer instrumentation / SSE envelope dump
- Raw body logging

## Evidence

**Head:** `3df3fe0c37`  
**Base:** `origin/dev` (`8d6784cb37`)

**probepark's minimal reproducer reconstructed as a test:**
```
[thinking(sigA), thinking(sigB), text] → [thinking(sigA), text]
```
Either block alone succeeds; the adjacent pair is rejected. After this fix, the collapsed shape matches the accepted single-block shape.

**Tests:** 15 new focused tests in `anthropic-adjacent-thinking-collapse.test.ts`:
- Adjacent pair collapse `[thinking, thinking, toolCall] → [thinking, toolCall]`
- Triple collapse `[t, t, t, text] → [t, text]`
- Mixed types both orders: `[thinking, redactedThinking]` and `[redactedThinking, thinking]`
- Separators preserved: `[thinking, toolCall, thinking, toolCall]` unchanged
- Thinking separated by text preserved
- Leading/trailing run collapse
- Cross-model thinking degrades to text, NOT collapsed
- Idempotence (re-run is no-op)
- Adjacency created by empty-text-block skip
- Long adversarial run (200 blocks → 1, bounded O(n))
- Multiple assistant messages collapsed independently
- Signature/object identity of surviving block

**Full suite:**
```
100 pass, 0 fail across 10 files (anthropic-adjacent-thinking-collapse, anthropic-thinking-immutability,
anthropic-prefill, anthropic-thinking-repair-retry, anthropic-unreplayable-thinking,
anthropic-managed-thinking-repair, anthropic-thinking-repair-budget, anthropic-cache-eval.integration,
transform-messages-clear-thinking, duplicate-tool-results)

97 pass, 0 fail across 5 files (anthropic-alignment, anthropic-stream-envelope,
anthropic-cpa-tool-alias-recovery, issue-826-repro, issue-814-repro)
```

**Typecheck:** `bun --cwd=packages/ai run check:types` — clean.

## Changed files
- `packages/ai/src/providers/anthropic.ts` — `collapseAdjacentThinkingBlocks()` + call at end of `convertAnthropicMessages`
- `packages/ai/test/anthropic-adjacent-thinking-collapse.test.ts` — 15 new tests
- `packages/ai/test/anthropic-prefill.test.ts` — updated existing test that encoded the buggy adjacency shape
- `artifacts/issue-3670-anthropic-cache-eval.json` — regenerated source-binding identity (expected on any `anthropic.ts` edit)