### PR TITLE
fix(natives): wrapTextWithAnsi non-termination on lone ESC in over-width word (frozen interactive resume)

### DIFF
--- a/crates/pi-natives/src/text.rs
+++ b/crates/pi-natives/src/text.rs
@@ -713,15 +713,23 @@ fn break_long_word(
 	let mut i = 0usize;
 
 	while i < word.len() {
-		if word[i] == ESC
-			&& let Some(seq_len) = ansi_seq_len_u16(word, i)
-		{
-			let seq = &word[i..i + seq_len];
-			current_line.extend_from_slice(seq);
-			if is_sgr_u16(seq) {
-				state.apply_sgr_u16(&seq[2..seq_len - 1]);
+		if word[i] == ESC {
+			if let Some(seq_len) = ansi_seq_len_u16(word, i) {
+				let seq = &word[i..i + seq_len];
+				current_line.extend_from_slice(seq);
+				if is_sgr_u16(seq) {
+					state.apply_sgr_u16(&seq[2..seq_len - 1]);
+				}
+				i += seq_len;
+				continue;
 			}
-			i += seq_len;
+			// A lone ESC that does not start a recognizable ANSI sequence
+			// (e.g. binary tool output persisted into a session). Consume it
+			// as a zero-width scalar like truncate/slice do; without this the
+			// segment scan below stops at the ESC without advancing `i` and
+			// the outer loop never terminates.
+			current_line.push(ESC);
+			i += 1;
 			continue;
 		}
 
@@ -1599,6 +1607,44 @@ mod tests {
 		assert!(first.starts_with("\x1b[38;2;156;163;176m"));
 		assert!(second.starts_with("\x1b[38;2;156;163;176m"));
 		assert!(second.contains("world"));
+	}
+
+	#[test]
+	fn test_wrap_text_with_ansi_terminates_on_lone_esc_in_long_word() {
+		// Regression: a word wider than the wrap width containing an ESC that
+		// does not start a recognizable ANSI sequence (binary tool output,
+		// e.g. `head` on a compiled binary persisted into a session) made
+		// `break_long_word` loop forever: the segment scan stops at ESC
+		// without consuming it. Interactive session resume then spun at 100%
+		// CPU while wrapping history.
+		let cases: &[Vec<u16>] = &[
+			// lone ESC followed by NUL inside an over-width word
+			to_u16(&format!("{}\u{1b}\0{}", "x".repeat(85), "y".repeat(85))),
+			// lone ESC at the very end of an over-width word
+			to_u16(&format!("{}\u{1b}", "x".repeat(85))),
+			// ESC followed by a byte outside every recognized sequence class
+			to_u16(&format!("{}\u{1b}5{}", "x".repeat(85), "y".repeat(85))),
+			// Mach-O-flavored soup: NUL runs, replacement chars, trailing ESC
+			to_u16(&format!(
+				"__TEXT{}\u{fffd}F{}__literals{}\u{fffd}\u{fffd}\u{1b}",
+				"\0".repeat(20),
+				"\0".repeat(40),
+				"\0".repeat(30),
+			)),
+		];
+		for data in cases {
+			let lines = wrap_text_with_ansi_impl(data, 80, DEFAULT_TAB_WIDTH);
+			assert!(!lines.is_empty());
+			// Zero-width scalars must not be dropped by the wrap.
+			let total: usize = lines.iter().map(Vec::len).sum();
+			let esc_in: usize = data.iter().filter(|&&u| u == ESC).count();
+			let esc_out: usize = lines
+				.iter()
+				.map(|l| l.iter().filter(|&&u| u == ESC).count())
+				.sum();
+			assert!(esc_out >= esc_in, "lone ESC dropped: {esc_in} in, {esc_out} out");
+			assert!(total > 0);
+		}
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary

`wrapTextWithAnsi` never terminates when a word wider than the wrap width contains an ESC character that does not start a recognizable ANSI sequence (raw binary in tool output). Interactive `--resume` of a session containing such a record spins at ~100% CPU while wrapping history, so the TUI appears frozen. Headless `-p` resume is unaffected because it never wraps history.

Trivial reproducer against the current prebuilt (hangs forever):

```js
const n = await import("@gajae-code/natives");
n.wrapTextWithAnsi("x".repeat(85) + "\x1b", 80, 4); // never returns
```

## Root cause

In `break_long_word` (`crates/pi-natives/src/text.rs`), the ESC branch only handles the case where `ansi_seq_len_u16` recognizes a sequence. When it returns `None` (lone ESC: followed by NUL/unrecognized byte, unterminated CSI/OSC/DCS, or ESC at end of input), control falls through to the segment scan `while i < word.len() && word[i] != ESC`, which stops immediately at the ESC **without advancing `i`**. The segment is empty, both width branches are no-ops, and the outer loop spins forever.

Every sibling scanner (`truncate_to_width_u16_impl`, `slice_with_width_impl`, `visible_width_u16_up_to`, `extract_segments_impl`) already has the lone-ESC fallback (`push(ESC); i += 1;`). `break_long_word` was the only one missing it.

This is reachable from real usage: a bash tool call that `head`s a compiled binary (e.g. the Bun-compiled `claude` launcher) persists control-character soup into the session's toolResult. Resuming that session hangs the TUI on every attempt. Verified end-to-end on a real session: dirty file = resume spins at 100% CPU indefinitely; same file with control chars stripped = full history render in ~12s.

## Fix

Mirror the sibling implementations: consume a lone ESC as a zero-width scalar and advance. No behavior change for valid ANSI sequences.

## Tests

- New regression test `test_wrap_text_with_ansi_terminates_on_lone_esc_in_long_word` covering: lone ESC + NUL inside an over-width word, ESC at end of word, ESC + unrecognized byte (`\x1b5`), and a Mach-O-flavored NUL/U+FFFD soup. Also asserts lone ESCs are not silently dropped.
- RED confirmed: with the fix reverted, the new test hangs (killed by timeout). GREEN with the fix.
- `cargo test --lib text::` 17/17 pass; `cargo fmt --check` clean. (`pty::kill_path_reaps_sigterm_trapping_child` and `shell::embedded_external_command_runs_in_its_own_session` are flaky under parallel load on my machine both with and without this change; they pass when run individually.)

## Follow-ups (out of scope, happy to file separately)

- A display-safe escaping layer before wrap in the TUI would keep control characters from other code paths from reaching the renderer/terminal.
- Persisting binary-looking tool output as size+hash+artifact reference instead of raw text would avoid storing control-character soup in sessions in the first place.
