### PR TITLE
test(sdk): repair current dev adapter disposition fixture

### DIFF
--- a/packages/coding-agent/test/sdk-adapter-dispositions.test.ts
+++ b/packages/coding-agent/test/sdk-adapter-dispositions.test.ts
@@ -162,6 +162,8 @@ function inputFor(operation: Operation, secret = false): Record<string, unknown>
 		case "turn.follow_up":
 		case "turn.abort_and_prompt":
 			return { text: "adapter disposition probe" };
+		case "turn.steer_status":
+			return { clientRef: "missing-steer" };
 		case "ask.answer":
 			return { id: "missing-ask", answer: "answer" };
 		case "workflow.gate_answer":

--- a/packages/coding-agent/test/session-manager-resume-readonly.test.ts
+++ b/packages/coding-agent/test/session-manager-resume-readonly.test.ts
@@ -1212,10 +1212,10 @@ describe("active managed picker root", () => {
 			receipts: fs.readdirSync(path.join(protocolRoot, "receipts")),
 			tombstones: fs.readdirSync(path.join(protocolRoot, "tombstones")),
 		};
-		const renameNoReplacePath = native.renameNoReplacePath;
+		const renameNoReplacePathAsync = native.renameNoReplacePathAsync;
 		let publicationGuards = 0;
-		vi.spyOn(native, "renameNoReplacePath").mockImplementation((source, destinationPath) => {
-			const result = renameNoReplacePath(source, destinationPath);
+		vi.spyOn(native, "renameNoReplacePathAsync").mockImplementation(async (source, destinationPath) => {
+			const result = await renameNoReplacePathAsync(source, destinationPath);
 			if (
 				result.ok &&
 				String(destinationPath).includes(`${path.sep}receipts${path.sep}`) &&


### PR DESCRIPTION
Fixes #4436.\n\nRepairs current-dev test drift without changing product behavior:\n- supplies the now-required `turn.steer_status` correlation fixture;\n- updates the final migration receipt race regression to intercept the async no-replace publication seam used by production.\n\nVerified: both exact failing assertions pass; coding-agent check exits 0 with warnings only.\n\nSigned-off-by: Yeachan-Heo <yeachan-heo@gajae.dev>