### PR TITLE
test(coding-agent): stabilize isolated baseline guards

### DIFF
--- a/packages/coding-agent/test/agent-session-coordinator-activity.test.ts
+++ b/packages/coding-agent/test/agent-session-coordinator-activity.test.ts
@@ -273,7 +273,13 @@ function emitExternalStart(
 
 async function activityAfterSeq(stateFile: string, seq: number): Promise<Record<string, unknown>> {
 	for (let attempt = 0; attempt < 200; attempt++) {
-		const payload = JSON.parse(await Bun.file(stateFile).text()) as Record<string, unknown>;
+		let payload: Record<string, unknown>;
+		try {
+			payload = JSON.parse(await Bun.file(stateFile).text()) as Record<string, unknown>;
+		} catch {
+			await Bun.sleep(5);
+			continue;
+		}
 		const activity = payload.activity as Record<string, unknown> | undefined;
 		if (activity && activity.seq === seq) return activity;
 		await Bun.sleep(5);
@@ -282,8 +288,15 @@ async function activityAfterSeq(stateFile: string, seq: number): Promise<Record<
 }
 
 async function readActivity(stateFile: string): Promise<Record<string, unknown> | undefined> {
-	const payload = JSON.parse(await Bun.file(stateFile).text()) as Record<string, unknown>;
-	return payload.activity as Record<string, unknown> | undefined;
+	for (let attempt = 0; attempt < 200; attempt++) {
+		try {
+			const payload = JSON.parse(await Bun.file(stateFile).text()) as Record<string, unknown>;
+			return payload.activity as Record<string, unknown> | undefined;
+		} catch {
+			await Bun.sleep(5);
+		}
+	}
+	throw new Error("coordinator activity snapshot was never readable");
 }
 
 /** Wait until the sidecar stops writing, so the LAST published snapshot can be asserted. */

--- a/packages/coding-agent/test/sdk-memory-startup.test.ts
+++ b/packages/coding-agent/test/sdk-memory-startup.test.ts
@@ -7,7 +7,11 @@ import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { localBackend } from "@gajae-code/coding-agent/memory-backend/local-backend";
 import { createAgentSession } from "@gajae-code/coding-agent/sdk";
-import { SessionContextTooLargeError, SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import {
+	SessionContextTooLargeError,
+	SessionManager,
+	SessionManagerTestHooks,
+} from "@gajae-code/coding-agent/session/session-manager";
 
 const createdDirs = new Set<string>();
 
@@ -20,6 +24,7 @@ describe("createAgentSession memory startup", () => {
 
 	afterEach(async () => {
 		vi.restoreAllMocks();
+		delete SessionManagerTestHooks.sessionContextBudgetBytesOverride;
 		authStorage.close();
 		for (const dir of createdDirs) {
 			await fs.promises.rm(dir, { recursive: true, force: true });
@@ -72,9 +77,10 @@ describe("createAgentSession memory startup", () => {
 		createdDirs.add(cwd);
 		const modelRegistry = new ModelRegistry(authStorage);
 		const sessionManager = SessionManager.inMemory();
+		SessionManagerTestHooks.sessionContextBudgetBytesOverride = 1024;
 		sessionManager.appendMessage({
 			role: "user",
-			content: "x".repeat(34 * 1024 * 1024),
+			content: "x".repeat(2048),
 			timestamp: Date.now(),
 		});
 


### PR DESCRIPTION
Fixes the remaining #4436 current-dev isolated shard failures exposed while validating #4372.\n\n- retries transient unreadable coordinator state snapshots at the existing bounded poll cadence;\n- uses `SessionManagerTestHooks.sessionContextBudgetBytesOverride` for a small deterministic typed overflow instead of relying on the old 32 MiB budget.\n\nVerified: both files pass 20 consecutive isolated runs; coding-agent check exits 0 with warnings only.\n\nSigned-off-by: Yeachan-Heo <yeachan-heo@gajae.dev>