### PR TITLE
test(coding-agent): isolate remaining shard fixtures

### DIFF
--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -202,6 +202,7 @@ describe("AgentSession message pipeline", () => {
 	});
 
 	it("forwards stop reasons and reasoning summaries to extension handlers", async () => {
+		const agentEndDelivered = Promise.withResolvers<void>();
 		const extensionEmit = vi.fn(
 			async (
 				_event: {
@@ -221,8 +222,11 @@ describe("AgentSession message pipeline", () => {
 			settings: Settings.isolated({ "compaction.enabled": false }),
 			modelRegistry: {} as never,
 			extensionRunner: {
-				emit: extensionEmit,
-				hasHandlers: (eventType: string) => eventType === "reasoning_summary_end",
+				emit: async (...args: Parameters<typeof extensionEmit>) => {
+					await extensionEmit(...args);
+					if (args[0]?.type === "agent_end") agentEndDelivered.resolve();
+				},
+				hasHandlers: (eventType: string) => eventType === "reasoning_summary_end" || eventType === "agent_end",
 			} as never,
 		});
 		sessions.push(session);
@@ -238,8 +242,7 @@ describe("AgentSession message pipeline", () => {
 				partial: createAssistantMessage("summary"),
 			},
 		} as never);
-		await Bun.sleep(0);
-		await Bun.sleep(0);
+		await agentEndDelivered.promise;
 
 		const emittedEvents = extensionEmit.mock.calls.map(([event]) => event);
 		expect(emittedEvents).toContainEqual({ type: "agent_end", messages: [], stopReason: "cancelled" });

--- a/packages/coding-agent/test/gjc-runtime/ultragoal-nudge-guard.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ultragoal-nudge-guard.test.ts
@@ -357,7 +357,13 @@ describe("ultragoal nudge guard", () => {
 		const probe = path.join(import.meta.dir, "..", "fixtures", "config-root-settings-probe.ts");
 		const userOnly = Bun.spawn([process.execPath, probe], {
 			cwd,
-			env: { ...process.env, HOME: home, GJC_CONFIG_DIR: ".gjc" },
+			env: {
+				...process.env,
+				HOME: home,
+				GJC_CONFIG_DIR: ".gjc",
+				GJC_CODING_AGENT_DIR: path.join(home, ".gjc", "agent"),
+				PI_CODING_AGENT_DIR: path.join(home, ".gjc", "agent"),
+			},
 			stdout: "pipe",
 			stderr: "pipe",
 		});
@@ -369,7 +375,13 @@ describe("ultragoal nudge guard", () => {
 		await setProjectBudget(cwd, 7);
 		const projectWins = Bun.spawn([process.execPath, probe], {
 			cwd,
-			env: { ...process.env, HOME: home, GJC_CONFIG_DIR: ".gjc" },
+			env: {
+				...process.env,
+				HOME: home,
+				GJC_CONFIG_DIR: ".gjc",
+				GJC_CODING_AGENT_DIR: path.join(home, ".gjc", "agent"),
+				PI_CODING_AGENT_DIR: path.join(home, ".gjc", "agent"),
+			},
 			stdout: "pipe",
 			stderr: "pipe",
 		});

--- a/packages/coding-agent/test/session-manager/session-directory.test.ts
+++ b/packages/coding-agent/test/session-manager/session-directory.test.ts
@@ -152,11 +152,16 @@ describe.skipIf(process.platform !== "linux")("managed session scope shared stic
 	}
 
 	it("prepares the managed chain directly below the shared sticky temp directory", async () => {
-		expect((await fs.stat(os.tmpdir())).mode & 0o1000).toBe(0o1000);
-		const stickyRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-managed-shared-sticky-root-"));
+		let tempRoot = path.resolve(os.tmpdir());
+		while (((await fs.stat(tempRoot)).mode & 0o1000) === 0) {
+			const parent = path.dirname(tempRoot);
+			if (parent === tempRoot) throw new Error("No shared sticky temp ancestor is available.");
+			tempRoot = parent;
+		}
+		const stickyRoot = await fs.mkdtemp(path.join(tempRoot, "gjc-managed-shared-sticky-root-"));
 		await fs.rm(stickyRoot, { recursive: true, force: true });
 		temporaryDirectories.push(stickyRoot);
-		const cwdRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-managed-shared-sticky-workspace-"));
+		const cwdRoot = await fs.mkdtemp(path.join(tempRoot, "gjc-managed-shared-sticky-workspace-"));
 		temporaryDirectories.push(cwdRoot);
 		const cwd = path.join(cwdRoot, "workspace");
 		await fs.mkdir(cwd);

--- a/packages/coding-agent/test/status-line-path.test.ts
+++ b/packages/coding-agent/test/status-line-path.test.ts
@@ -64,7 +64,7 @@ describe("status line path segment", () => {
 	it("strips the Projects root for symlink-equivalent aliases", () => {
 		if (process.platform === "win32") return;
 
-		const projectsRoot = path.join(os.homedir(), "Projects");
+		const projectsRoot = path.join(fs.realpathSync(os.homedir()), "Projects");
 		fs.mkdirSync(projectsRoot, { recursive: true });
 
 		const realProjectDir = fs.mkdtempSync(path.join(projectsRoot, "gjc-status-line-"));
@@ -74,7 +74,7 @@ describe("status line path segment", () => {
 
 		try {
 			fs.mkdirSync(nestedDir, { recursive: true });
-			fs.symlinkSync(os.homedir(), homeAlias, "dir");
+			fs.symlinkSync(fs.realpathSync(os.homedir()), homeAlias, "dir");
 
 			const aliasedDir = path.join(homeAlias, "Projects", path.basename(realProjectDir), "nested");
 			setProjectDir(aliasedDir);
@@ -143,7 +143,7 @@ describe("status line path segment", () => {
 	});
 
 	it("keeps the folder icon for paths outside any scratch root", () => {
-		const projectsRoot = path.join(os.homedir(), "Projects");
+		const projectsRoot = path.join(fs.realpathSync(os.homedir()), "Projects");
 		fs.mkdirSync(projectsRoot, { recursive: true });
 		const realProjectDir = fs.mkdtempSync(path.join(projectsRoot, "gjc-status-line-real-"));
 		try {


### PR DESCRIPTION
Continues #4436 after exact current-dev vs #4372 comparison. Repairs the four remaining fresh-process shard fixtures without product behavior changes:\n- await deferred `agent_end` extension delivery;\n- prevent inherited test agent-dir overrides from bypassing synthetic HOME;\n- locate an actual sticky temp ancestor instead of assuming TMPDIR is sticky;\n- resolve the synthetic home physically in status-path tests.\n\nVerified: all four surfaces pass 10 consecutive runs; coding-agent check exits 0 with warnings only.\n\nSigned-off-by: Yeachan-Heo <yeachan-heo@gajae.dev>