### PR TITLE
fix(tui): resolve scratch roots at render time

### DIFF
--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -32,7 +32,7 @@ function normalizePremiumRequests(value: number): number {
 	return Math.round((value + Number.EPSILON) * 100) / 100;
 }
 
-const SCRATCH_ROOTS: readonly string[] = (() => {
+function scratchRoots(): readonly string[] {
 	const roots = new Set<string>([os.tmpdir(), path.join(os.homedir(), "tmp")]);
 	if (process.platform === "win32") {
 		const { TEMP, TMP, SystemRoot } = process.env;
@@ -48,10 +48,10 @@ const SCRATCH_ROOTS: readonly string[] = (() => {
 		}
 	}
 	return [...roots];
-})();
+}
 
 function classifyProjectDir(pwd: string): { scratch: boolean; relative: string | null } {
-	for (const root of SCRATCH_ROOTS) {
+	for (const root of scratchRoots()) {
 		if (pathIsWithin(root, pwd)) {
 			return { scratch: true, relative: relativePathWithinRoot(root, pwd) };
 		}


### PR DESCRIPTION
Fixes the remaining #4436 status-line baseline exposed by fresh-root isolation. The test harness rewrites HOME/TMPDIR during preload after module caching; status-line scratch roots were captured at import time. Resolve them at render time so nested HOME under scratch is classified from the active environment.\n\nVerified: status-line path passes 20 consecutive runs; coding-agent check exits 0 with warnings only.\n\nSigned-off-by: Yeachan-Heo <yeachan-heo@gajae.dev>