### PR TITLE
feat(master): add `gjc master` resident session-supervision mode (#4448)

### DIFF
--- a/docs/master-mode.md
+++ b/docs/master-mode.md
@@ -1,0 +1,50 @@
+# Master mode (`gjc master`)
+
+Master mode runs **one resident master session** that supervises other already-running resident GJC sessions through the SDK/ACP control surface. It is session supervision only.
+
+## Launch
+
+```sh
+gjc master                    # interactive resident master session
+gjc master --model opus       # all normal launch flags pass through
+gjc master --continue         # resume the previous master session
+```
+
+`gjc master` is exactly the normal interactive launch path with `--master` added; `gjc --master` is equivalent. A master session is an ordinary agent session with two additions:
+
+1. **System-prompt section.** A dedicated `<master-mode>` block is appended to the system prompt. It states the supervision-only scope, the exact-identity/idempotency/fail-closed invariants, and the non-goals.
+2. **Session-start hook.** An internal inline extension (registered only for master sessions) injects one hidden context message at `session_start` containing:
+   - the SDK supervision quick reference (the `gjc sdk session` command family and its usage rules), and
+   - a bounded snapshot of the current resident-session inventory read from the authoritative SDK broker session index (credential-free v1 rows: `sessionId`, `endpointGeneration`, `hostIncarnation`, `pid`, `live`, `activity`, `ambiguous`, `terminalUncertain`), with per-row classification (`blocked` / `terminal` / `stuck` / `active` / `idle`).
+
+The hook never throws into startup. If the broker is unavailable, the injection fails closed: the guidelines are delivered with an explicit "inventory unavailable — do not act until `gjc sdk session list` succeeds" notice.
+
+## How the master session supervises
+
+The master session acts through the existing broker-bound SDK surfaces (see `docs/sdk-session-cli.md`):
+
+- discovery/reconciliation: `gjc sdk session list`, `inspect`, `status`, `tail`;
+- per-session authoritative state: `gjc sdk session raw query <id> --query goal.list/get` (idle/no-goal), `--query workflow.gates.list` (pending gates);
+- idle/no-goal resume: `gjc sdk session send <id> --text ... --op-ref <ref>` (fresh `turn.prompt` with an idempotent client reference);
+- active-turn boundaries: `turn.steer` for mid-turn correction, `turn.abort_and_prompt` only when the turn must be replaced;
+- questions/gates: `ask.answer` and `workflow.gate_answer` with explicit answers;
+- terminal retirement: `session.close` through the SDK lifecycle surface.
+
+## Safety invariants
+
+- **Exact identity.** Mutations target `sessionId` + `endpointGeneration`/`hostIncarnation` re-verified against a fresh `session.list`. Stale or missing identity means no action.
+- **Fail closed.** Rows with `ambiguous: true` or `terminalUncertain: true` are hands-off (`blocked` class); broker errors abort the action, not degrade it.
+- **Idempotent controls.** One logical operation carries one `clientRef`/`--op-ref`, reused across retries so replays never duplicate a prompt or steer.
+- **Bounded output.** The injected inventory is capped (`MASTER_INVENTORY_ROW_LIMIT`, 50 rows) and credential-free.
+
+## Non-goals
+
+- No team mode, no delegate-team or spawned worker orchestration.
+- No pane scraping or terminal/screen reading; the SDK broker index and per-session query surfaces are the only authority.
+- No automatic editing of other sessions' files; supervision is limited to prompt/steer/answer/retire controls.
+
+## Recovery behavior
+
+- Master session restart (`gjc master --continue`) re-injects a fresh inventory at session start; nothing is cached across restarts.
+- A master crash leaves supervised sessions untouched — all state lives in the broker index and the sessions themselves.
+- If the broker was restarted, the master re-lists before acting; any action rejected with `endpoint_stale`/`terminal_uncertain`/`not_found` is reported, not retried blindly.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -459,6 +459,14 @@
 			"types": "./src/hindsight/*.ts",
 			"import": "./src/hindsight/*.ts"
 		},
+		"./master": {
+			"types": "./src/master/index.ts",
+			"import": "./src/master/index.ts"
+		},
+		"./master/*": {
+			"types": "./src/master/*.ts",
+			"import": "./src/master/*.ts"
+		},
 		"./modes/shared/agent-wire/*": null,
 		"./modes": {
 			"types": "./src/modes/index.ts",

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -50,6 +50,7 @@ export const commands: CommandEntry[] = [
 	{ name: "stats", load: () => import("./commands/stats").then(m => m.default) },
 	{ name: "notify", load: () => import("./commands/notify").then(m => m.default) },
 	{ name: "sdk", load: () => import("./commands/sdk").then(m => m.default) },
+	{ name: "master", load: () => import("./commands/master").then(m => m.default) },
 	{ name: "daemon", load: () => import("./commands/daemon").then(m => m.default) },
 	{ name: "web-search", aliases: ["q"], load: () => import("./commands/web-search").then(m => m.default) },
 	{ name: "local-provider", load: () => import("./commands/local-provider").then(m => m.default) },

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -90,6 +90,8 @@ export interface Args {
 	unknownFlags: Map<string, boolean | string>;
 	/** Exact interactive startup login intent, recognized before model-profile activation. */
 	authBootstrap?: true;
+	/** Launch the session in master mode (resident session supervisor; `gjc master`). */
+	master?: boolean;
 }
 
 const CONSUMER_FLAGS_BY_ARGS = new WeakMap<Args, Map<ConsumerLaunchFlagName, string>>();
@@ -355,6 +357,8 @@ export function parseArgs(args: string[], authority: ParseArgsAuthority = "local
 			result.noRules = true;
 		} else if (arg === "--no-title") {
 			result.noTitle = true;
+		} else if (arg === "--master") {
+			result.master = true;
 		} else if (arg === "--list-models") {
 			// Check if next arg is a search pattern (not a flag or file arg)
 			if (i + 1 < args.length && !args[i + 1].startsWith("-") && !args[i + 1].startsWith("@")) {

--- a/packages/coding-agent/src/cli/root-flags.ts
+++ b/packages/coding-agent/src/cli/root-flags.ts
@@ -73,6 +73,9 @@ export const ROOT_LAUNCH_FLAGS = {
 		optionalValue: true,
 	}),
 	"no-title": Flags.boolean({ description: "Disable title auto-generation" }),
+	master: Flags.boolean({
+		description: "Master mode: resident supervisor session for other GJC sessions (same as `gjc master`)",
+	}),
 };
 
 export type ConsumerLaunchFlagName = "hook" | "extension" | "no-extensions" | "no-skills" | "skills";

--- a/packages/coding-agent/src/commands/master.ts
+++ b/packages/coding-agent/src/commands/master.ts
@@ -1,0 +1,66 @@
+/**
+ * `gjc master` — launch a resident master session.
+ *
+ * A master session is an otherwise normal interactive GJC session launched with
+ * `--master`: the system prompt gains the dedicated master-mode section and the
+ * session-start hook injects the SDK supervision guidelines plus the current
+ * authoritative resident-session inventory. All launch flags pass through
+ * unchanged (e.g. `gjc master --model opus`).
+ */
+import { setProjectDir } from "@gajae-code/utils";
+import { Command } from "@gajae-code/utils/cli";
+import { assertLocalLaunchArgs, parseArgs } from "../cli/args";
+import { launchDefaultTmuxIfNeeded } from "../gjc-runtime/launch-tmux";
+import { type PreparedLaunchWorktree, prepareLaunchWorktree } from "../gjc-runtime/launch-worktree";
+import { runRootCommand } from "../main";
+import { prepareAcpTerminalAuthArgs } from "../modes/acp/terminal-auth";
+import { persistCoordinatorLaunchFailure } from "./launch";
+
+export default class Master extends Command {
+	static description =
+		"Launch a resident master session that supervises other resident GJC sessions through the SDK/ACP control surface";
+
+	static examples = [
+		"# Start a master session\n  gjc master",
+		"# Master session with a specific model\n  gjc master --model opus",
+		"# Master session continuing a previous master session\n  gjc master --continue",
+	];
+
+	static strict = false;
+
+	async run(): Promise<void> {
+		const { args } = prepareAcpTerminalAuthArgs(this.argv);
+		const masterArgs = ["--master", ...args];
+		const parsed = parseArgs([...masterArgs], "deferred");
+		if (parsed.mode !== "acp") assertLocalLaunchArgs(parsed);
+		if (parsed.help || parsed.version) {
+			await runRootCommand(parsed, masterArgs);
+			return;
+		}
+
+		let launch: PreparedLaunchWorktree;
+		try {
+			launch = prepareLaunchWorktree(process.cwd(), masterArgs);
+		} catch (error) {
+			await persistCoordinatorLaunchFailure(error, process.cwd());
+			throw error;
+		}
+		if (launch.worktree.enabled) {
+			process.chdir(launch.cwd);
+			setProjectDir(launch.cwd);
+		}
+		const launchParsed = parseArgs(launch.args, "deferred");
+		if (launchParsed.mode !== "acp") assertLocalLaunchArgs(launchParsed);
+		if (
+			launchDefaultTmuxIfNeeded({
+				parsed: launchParsed,
+				rawArgs: launch.args,
+				cwd: launch.cwd,
+				worktreeBranch: launch.worktree.enabled && !launch.worktree.detached ? launch.worktree.branchName : null,
+				project: launch.cwd,
+			})
+		)
+			return;
+		await runRootCommand(launchParsed, launch.args);
+	}
+}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1092,6 +1092,7 @@ async function buildSessionOptions(
 	const options: CreateAgentSessionOptions = {
 		cwd: parsed.cwd ?? getProjectDir(),
 	};
+	if (parsed.master === true) options.masterMode = true;
 	if (parsed.mcpConfig !== undefined) options.mcpConfigPath = parsed.mcpConfig;
 	if (parsed.noMcp === true) options.enableMcpAutoload = false;
 

--- a/packages/coding-agent/src/master/extension.ts
+++ b/packages/coding-agent/src/master/extension.ts
@@ -1,0 +1,88 @@
+/**
+ * Master-mode session-start hook: an internal inline extension registered only
+ * for master sessions. On `session_start` it injects (a) the SDK supervision
+ * usage guidelines and (b) a bounded snapshot of the current resident-session
+ * inventory from the authoritative SDK broker, so the master session begins
+ * with supervision context instead of a cold start.
+ *
+ * The hook never throws into session startup: when the broker is unavailable
+ * the injection fails closed — the guidelines are still delivered alongside an
+ * explicit "inventory unavailable" notice, and no session action is taken.
+ */
+import { logger } from "@gajae-code/utils";
+import type { ExtensionFactory } from "../extensibility/extensions/types";
+import { loadResidentSessionInventory, type ResidentSessionInventory, renderInventoryMarkdown } from "./inventory";
+import sdkSupervisionGuidance from "./sdk-supervision-guidance.md" with { type: "text" };
+
+/** Custom-message type used for the master-mode session-start injection. */
+export const MASTER_SESSION_CONTEXT_CUSTOM_TYPE = "master-supervision-context";
+
+export interface MasterModeExtensionDeps {
+	/** SDK broker state directory the inventory is read from. */
+	agentDir: string;
+	/** Test seam: overrides the broker-backed inventory loader. */
+	loadInventory?: (agentDir: string) => Promise<ResidentSessionInventory>;
+	/** Test seam: clock used for classification and rendering. */
+	now?: () => number;
+}
+
+/** Compose the session-start injection body (guidance + bounded inventory). */
+export async function composeMasterSessionStartContent(
+	deps: MasterModeExtensionDeps,
+	selfSessionId?: string,
+): Promise<string> {
+	const guidance = sdkSupervisionGuidance.trim();
+	const load = deps.loadInventory ?? loadResidentSessionInventory;
+	const now = deps.now ?? Date.now;
+	let inventorySection: string;
+	try {
+		const inventory = await load(deps.agentDir);
+		inventorySection = renderInventoryMarkdown(inventory, selfSessionId, now());
+	} catch (error) {
+		const reason = error instanceof Error ? error.message : String(error);
+		inventorySection = [
+			"Resident-session inventory is UNAVAILABLE: the SDK broker snapshot could not be loaded",
+			`(${reason}). Fail closed: do not prompt, steer, answer, or retire any session until`,
+			"`gjc sdk session list` succeeds and you hold a fresh authoritative inventory.",
+		].join(" ");
+	}
+	return [
+		"# Master mode session-start context",
+		"",
+		guidance,
+		"",
+		"## Current resident sessions (authoritative broker snapshot)",
+		"",
+		inventorySection,
+	].join("\n");
+}
+
+/**
+ * Internal extension factory for master sessions. Registers the session-start
+ * hook that injects the SDK usage guidelines plus the current resident-session
+ * inventory as a hidden (display:false) context message without starting a turn.
+ */
+export function createMasterModeExtension(deps: MasterModeExtensionDeps): ExtensionFactory {
+	return api => {
+		api.on("session_start", async (_event, ctx) => {
+			try {
+				const selfSessionId = ctx.sessionManager.getSessionId() || undefined;
+				const content = await composeMasterSessionStartContent(deps, selfSessionId);
+				api.sendMessage(
+					{
+						customType: MASTER_SESSION_CONTEXT_CUSTOM_TYPE,
+						content,
+						display: false,
+						attribution: "agent",
+					},
+					{ triggerTurn: false },
+				);
+			} catch (error) {
+				// The session-start hook must never break session startup.
+				logger.warn("Master-mode session-start injection failed", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		});
+	};
+}

--- a/packages/coding-agent/src/master/index.ts
+++ b/packages/coding-agent/src/master/index.ts
@@ -1,0 +1,3 @@
+export * from "./extension";
+export * from "./inventory";
+export * from "./prompt";

--- a/packages/coding-agent/src/master/inventory.ts
+++ b/packages/coding-agent/src/master/inventory.ts
@@ -1,0 +1,201 @@
+/**
+ * Resident-session inventory for master mode: an authoritative, credential-free
+ * snapshot of the sessions the SDK broker currently indexes, plus the pure
+ * classification helpers the master session's supervision semantics rest on.
+ *
+ * The broker session index is the only discovery authority — no pane scraping,
+ * no process guessing. Rows that cannot prove unique authority (`ambiguous`,
+ * `terminalUncertain`) classify as `blocked` and are strictly hands-off.
+ */
+import { ensureBroker } from "../sdk/broker/ensure";
+import { type SdkSessionRowV1, toSessionRowV1 } from "../sdk/cli/rows";
+import { SessionRouter } from "../sdk/router";
+import { sessionListPageFromResponse, traverseSessionList } from "../sdk/session-list";
+
+/** Broker classification of one resident session, derivable from its row alone. */
+export type ResidentSessionClass = "blocked" | "terminal" | "stuck" | "active" | "idle";
+
+/** Default age after which a session reporting an active turn counts as stuck. */
+export const MASTER_STUCK_THRESHOLD_MS = 15 * 60 * 1000;
+
+/** Cap on rendered inventory rows so the session-start injection stays bounded. */
+export const MASTER_INVENTORY_ROW_LIMIT = 50;
+
+export class MasterInventoryError extends Error {
+	readonly code: string;
+	constructor(code: string, message: string) {
+		super(message);
+		this.name = "MasterInventoryError";
+		this.code = code;
+	}
+}
+
+/**
+ * Classify one broker row. Pure and deterministic: the same row and `now`
+ * always produce the same class. `blocked` dominates everything — ambiguous or
+ * terminally uncertain authority means no mutating control may target the row.
+ */
+export function classifyResidentSession(
+	row: Pick<SdkSessionRowV1, "live" | "ambiguous" | "terminalUncertain" | "activity" | "lastHeartbeatAt" | "deleted">,
+	now: number,
+	stuckThresholdMs: number = MASTER_STUCK_THRESHOLD_MS,
+): ResidentSessionClass {
+	if (row.ambiguous === true || row.terminalUncertain === true) return "blocked";
+	if (row.deleted === true || !row.live) return "terminal";
+	if (row.activity?.state === "active") {
+		const activeAt = row.lastHeartbeatAt ?? row.activity.at;
+		if (Number.isFinite(activeAt) && now - activeAt > stuckThresholdMs) return "stuck";
+		return "active";
+	}
+	return "idle";
+}
+
+/** Fine-grained per-session probe state, obtained through SDK queries only. */
+export interface SupervisionProbe {
+	/** goal.list/get reports an active goal/objective. */
+	hasGoal: boolean;
+	/** workflow.gates.list reports a pending gate. */
+	pendingGate: boolean;
+	/** A pending ask/question is outstanding for the session. */
+	pendingAsk: boolean;
+}
+
+export type SupervisionClass = ResidentSessionClass | "idle_no_goal" | "question" | "gate";
+
+/**
+ * Combine the broker-row class with authoritative per-session probe results.
+ * Blocked stays blocked; active/stuck sessions are never reclassified by
+ * probes (their turn owns the session); only idle sessions refine into
+ * question/gate/idle_no_goal, which drive answer vs. fresh-prompt decisions.
+ */
+export function classifySupervisionTarget(row: ResidentSessionClass, probe: SupervisionProbe): SupervisionClass {
+	if (row !== "idle") return row;
+	if (probe.pendingAsk) return "question";
+	if (probe.pendingGate) return "gate";
+	if (!probe.hasGoal) return "idle_no_goal";
+	return "idle";
+}
+
+export interface ResidentSessionInventory {
+	fetchedAt: number;
+	sessions: SdkSessionRowV1[];
+}
+
+const ROUTER_START_TIMEOUT_MS = 10_000;
+const ROUTER_STOP_TIMEOUT_MS = 5_000;
+const MASTER_INVENTORY_ACTOR_KEY = "gjc-master:session.list";
+
+async function bounded<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_resolve, reject) => {
+				timer = setTimeout(() => reject(new MasterInventoryError("timeout", message)), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}
+
+/**
+ * Load the authoritative resident-session inventory from the SDK broker.
+ * Rows are projected through the credential-free v1 DTO mapper; this function
+ * never exposes endpoint credentials. Broker failures throw MasterInventoryError
+ * so callers can fail closed instead of supervising from a partial snapshot.
+ */
+export async function loadResidentSessionInventory(
+	agentDir: string,
+	now: () => number = Date.now,
+): Promise<ResidentSessionInventory> {
+	await bounded(ensureBroker({ agentDir }), ROUTER_START_TIMEOUT_MS, "SDK broker startup timed out.");
+	const router = new SessionRouter({ agentDir });
+	let actionError: unknown;
+	let sessions: SdkSessionRowV1[] = [];
+	try {
+		await bounded(router.start(), ROUTER_START_TIMEOUT_MS, "SDK session Router startup timed out.");
+		const pages = await traverseSessionList(
+			{},
+			async pageInput => {
+				const response = await router.listBrokerSessions(pageInput, MASTER_INVENTORY_ACTOR_KEY);
+				if (response?.ok === false) {
+					const failure = response.error as { code?: unknown; message?: unknown } | undefined;
+					throw new MasterInventoryError(
+						typeof failure?.code === "string" ? failure.code : "broker_error",
+						typeof failure?.message === "string" ? failure.message : "session.list failed",
+					);
+				}
+				return response;
+			},
+			response => sessionListPageFromResponse(response),
+		);
+		try {
+			sessions = pages.flatMap(({ page }) => page.sessions.map(toSessionRowV1));
+		} catch {
+			throw new MasterInventoryError("protocol_error", "session.list returned a malformed session row.");
+		}
+	} catch (error) {
+		actionError = error;
+	}
+	try {
+		await bounded(router.stop(), ROUTER_STOP_TIMEOUT_MS, "SDK session Router shutdown timed out.");
+	} catch {
+		// Router cleanup failure must not mask the inventory result or its error.
+	}
+	if (actionError !== undefined) {
+		if (actionError instanceof MasterInventoryError) throw actionError;
+		throw new MasterInventoryError(
+			"unavailable",
+			actionError instanceof Error ? actionError.message : "Failed to load the resident-session inventory.",
+		);
+	}
+	return { fetchedAt: now(), sessions };
+}
+
+function formatRow(row: SdkSessionRowV1, cls: ResidentSessionClass, selfSessionId: string | undefined): string {
+	const parts = [
+		`session=${row.sessionId}`,
+		`repo=${row.locator.repo}`,
+		`class=${cls}`,
+		`live=${row.live}`,
+		`endpointGeneration=${row.endpointGeneration}`,
+	];
+	if (row.hostIncarnation !== undefined) parts.push(`hostIncarnation=${row.hostIncarnation}`);
+	if (row.activity !== undefined)
+		parts.push(`activity=${row.activity.state}@${new Date(row.activity.at).toISOString()}`);
+	if (row.sessionId === selfSessionId) parts.push("(this master session — do not supervise yourself)");
+	if (cls === "blocked") parts.push("HANDS-OFF: authority is ambiguous/uncertain");
+	return `- ${parts.join(" ")}`;
+}
+
+/**
+ * Render a bounded Markdown inventory for the session-start injection. The
+ * output is deterministic for a fixed `now` and never contains credentials.
+ */
+export function renderInventoryMarkdown(
+	inventory: ResidentSessionInventory,
+	selfSessionId: string | undefined,
+	now: number,
+	stuckThresholdMs: number = MASTER_STUCK_THRESHOLD_MS,
+): string {
+	const lines: string[] = [
+		`Snapshot taken at ${new Date(inventory.fetchedAt).toISOString()} from the SDK broker session index.`,
+		`Re-run \`gjc sdk session list\` before any mutating action; this snapshot goes stale immediately.`,
+		"",
+	];
+	if (inventory.sessions.length === 0) {
+		lines.push("No resident sessions are currently indexed by the broker.");
+		return lines.join("\n");
+	}
+	const rows = inventory.sessions.slice(0, MASTER_INVENTORY_ROW_LIMIT);
+	for (const row of rows) {
+		lines.push(formatRow(row, classifyResidentSession(row, now, stuckThresholdMs), selfSessionId));
+	}
+	if (inventory.sessions.length > rows.length) {
+		lines.push(
+			`- …and ${inventory.sessions.length - rows.length} more; run \`gjc sdk session list\` for the full set.`,
+		);
+	}
+	return lines.join("\n");
+}

--- a/packages/coding-agent/src/master/master-mode-prompt.md
+++ b/packages/coding-agent/src/master/master-mode-prompt.md
@@ -1,0 +1,17 @@
+<master-mode>
+You are running as a **master session**: one resident supervisor session that supervises other already-running resident GJC sessions through the SDK/ACP control surface.
+
+## Scope
+
+- You supervise sessions only: you inspect authoritative session state and issue SDK control operations (`turn.prompt`, `turn.steer`, `turn.abort_and_prompt`, `ask.answer`, workflow gate answers, lifecycle retire) against exact session identities.
+- You NEVER scrape terminal panes, tmux output, or screen state. The SDK broker session index and the per-session SDK query surface are the only authoritative state.
+- You are NOT a team: you do not spawn worker teams, you do not use team mode or delegate-team orchestration, and you do not absorb other sessions' work into yourself.
+
+## Authority and safety invariants
+
+- Target sessions by exact identity: `sessionId` plus the broker-reported `endpointGeneration` / `hostIncarnation`. Never guess a session id from a partial match or a stale listing.
+- Every mutating control carries a `clientRef` (operation reference) so a retry replays idempotently instead of duplicating a prompt or steer. Generate one ULID-style ref per logical operation and reuse it when reconciling a retry.
+- Fail closed: when the broker reports `endpoint_stale`, `terminal_uncertain`, `ambiguous`, or the session row is gone, take no mutating action. Re-list sessions, re-verify identity, and only then act. Report the ambiguity instead of forcing it.
+- Idle or goal-less sessions are resumed with a fresh `turn.prompt`; sessions mid-turn are steered (`turn.steer`) or, only when the turn must be replaced, aborted and re-prompted (`turn.abort_and_prompt`). Pending questions and workflow gates are answered through `ask.answer` / `workflow.gate_answer` with an explicit answer — never by blind key injection.
+- Terminal sessions are retired through the SDK lifecycle close surface, not by killing processes.
+</master-mode>

--- a/packages/coding-agent/src/master/prompt.ts
+++ b/packages/coding-agent/src/master/prompt.ts
@@ -1,0 +1,9 @@
+/**
+ * Master-mode system prompt section (static prompt text only; no runtime deps).
+ */
+import masterModePrompt from "./master-mode-prompt.md" with { type: "text" };
+
+/** Dedicated master-mode block appended to the system prompt of master sessions. */
+export function masterModeSystemPromptSection(): string {
+	return masterModePrompt.trim();
+}

--- a/packages/coding-agent/src/master/sdk-supervision-guidance.md
+++ b/packages/coding-agent/src/master/sdk-supervision-guidance.md
@@ -1,0 +1,22 @@
+## SDK supervision quick reference
+
+All supervision goes through the broker-bound `gjc sdk session` command family. It never renders endpoint credentials and it fails closed with typed errors and a non-zero exit code.
+
+- `gjc sdk session list` — enumerate resident sessions with authoritative identity fields (`sessionId`, `endpointGeneration`, `hostIncarnation`, `pid`, `live`, `activity`, `ambiguous`, `terminalUncertain`).
+- `gjc sdk session inspect <sessionId>` — one session's credential-free row.
+- `gjc sdk session send <sessionId> --text "<prompt>" [--op-ref <ref>] [--wait --timeout-ms <ms>]` — submit a `turn.prompt`; always pass a deterministic `--op-ref` per logical operation so retries replay idempotently. Follow with `status` to reconcile.
+- `gjc sdk session status <sessionId> <opRef>` — authoritative reconciliation of a previously submitted prompt.
+- `gjc sdk session tail <sessionId>` — follow the authoritative event stream (not pane scraping).
+- `gjc sdk session raw query <sessionId> --query goal.list/get` — goal state (idle/no-goal detection).
+- `gjc sdk session raw query <sessionId> --query workflow.gates.list` — pending workflow gates.
+- `gjc sdk session raw control <sessionId> --op turn.steer --json-input '{"text":"...","clientRef":"<ref>"}'` — steer a session mid-turn.
+- `gjc sdk session raw control <sessionId> --op turn.abort_and_prompt --json-input '{"text":"...","clientRef":"<ref>"}'` — replace the active turn only when steering cannot express the correction.
+- `gjc sdk session raw control <sessionId> --op ask.answer --json-input '{"id":"<askId>","answer":"..."}'` — answer a pending question.
+- `gjc sdk session raw global --op session.close --idempotency-key <key> --json-input '{"sessionId":"<sessionId>"}' --confirm` — retire a terminal session.
+
+Rules:
+
+1. Re-run `list` before every mutating action and re-verify the exact `sessionId` + `endpointGeneration`/`hostIncarnation` pair. A stale or ambiguous endpoint means stop and report — never force the action.
+2. Rows with `ambiguous: true` or `terminalUncertain: true` are hands-off: the broker cannot prove unique authority.
+3. One logical operation = one `clientRef`/`--op-ref`, reused across retries; never reuse a ref for a different operation.
+4. Supervision only: no team mode, no worker spawning, no pane scraping, no editing another session's files.

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -108,6 +108,7 @@ import type { HindsightSessionState } from "../hindsight/state";
 import { normalizePluginHook } from "../hooks/normalize";
 import { initializeLocalRoot, LocalProtocolHandler, type LocalProtocolOptions } from "../internal-urls";
 import type { LspStartupServerInfo } from "../lsp";
+import { createMasterModeExtension } from "../master/extension";
 import btwUserPrompt from "../prompts/system/btw-user.md" with { type: "text" };
 import asyncResultTemplate from "../prompts/tools/async-result.md" with { type: "text" };
 import { AgentRegistry, MAIN_AGENT_ID } from "../registry/agent-registry";
@@ -421,6 +422,10 @@ export interface CreateAgentSessionOptions {
 
 	/** System prompt blocks. Array replaces default, function receives default blocks and returns final blocks. */
 	systemPrompt?: string[] | ((defaultPrompt: string[]) => string[]);
+	/** Master session (`gjc master` / `--master`): appends the master-mode system-prompt
+	 *  section and registers the session-start hook that injects SDK supervision
+	 *  guidance plus the authoritative resident-session inventory. Default: false. */
+	masterMode?: boolean;
 	/** Optional provider-facing session identifier for prompt caches and sticky auth selection.
 	 * Keeps persisted session files isolated while reusing provider-side caches. */
 	providerSessionId?: string;
@@ -2360,6 +2365,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		if (customTools.length > 0) {
 			inlineExtensions.push(createCustomToolsExtension(customTools));
 		}
+		if (options.masterMode === true) {
+			inlineExtensions.push(createMasterModeExtension({ agentDir }));
+		}
 		if (!options.disableExtensionDiscovery) {
 			try {
 				const hookExtensions = await discoverAndLoadHookExtensions(cwd);
@@ -2983,6 +2991,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				secretsEnabled,
 				workspaceTree: workspaceTreePromise,
 				subagent: options.parentTaskPrefix !== undefined,
+				masterMode: options.masterMode === true,
 			});
 
 			for (const warning of defaultPrompt.warnings) {

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -11,6 +11,7 @@ import { systemPromptCapability } from "./capability/system-prompt";
 import type { SkillsSettings } from "./config/settings";
 import { type ContextFile, loadCapability, type SystemPrompt as SystemPromptFile } from "./discovery";
 import type { Skill } from "./extensibility/skills";
+import { masterModeSystemPromptSection } from "./master/prompt";
 import customSystemPromptTemplate from "./prompts/system/custom-system-prompt.md" with { type: "text" };
 import projectPromptTemplate from "./prompts/system/project-prompt.md" with { type: "text" };
 import systemPromptTemplate from "./prompts/system/system-prompt.md" with { type: "text" };
@@ -397,6 +398,8 @@ export interface BuildSystemPromptOptions {
 	 * safety, and the completion contract are retained. Default: false.
 	 */
 	subagent?: boolean;
+	/** Master session (`gjc master` / `--master`): appends the dedicated master-mode supervision section. */
+	masterMode?: boolean;
 }
 
 export interface BuildSystemPromptResult {
@@ -455,6 +458,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		secretsEnabled = false,
 		workspaceTree: providedWorkspaceTree,
 		subagent = false,
+		masterMode = false,
 	} = options;
 	const resolvedCwd = cwd ?? getProjectDir();
 
@@ -633,6 +637,9 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 	const projectPrompt = resolvedCustomPrompt ? "" : prompt.render(projectPromptTemplate, data).trim();
 	if (projectPrompt) {
 		systemPrompt.push(projectPrompt);
+	}
+	if (masterMode) {
+		systemPrompt.push(masterModeSystemPromptSection());
 	}
 
 	// Plugin system appendices are appended last as a lower-authority block; they

--- a/packages/coding-agent/test/cli-command-surface.test.ts
+++ b/packages/coding-agent/test/cli-command-surface.test.ts
@@ -167,6 +167,7 @@ process.exitCode = await child.exited;`;
 			"stats",
 			"notify",
 			"sdk",
+			"master",
 			"daemon",
 			"web-search",
 			"local-provider",

--- a/packages/coding-agent/test/master-mode.test.ts
+++ b/packages/coding-agent/test/master-mode.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { parseArgs } from "@gajae-code/coding-agent/cli/args";
+import Master from "@gajae-code/coding-agent/commands/master";
+import {
+	classifyResidentSession,
+	classifySupervisionTarget,
+	createMasterModeExtension,
+	MASTER_INVENTORY_ROW_LIMIT,
+	MASTER_SESSION_CONTEXT_CUSTOM_TYPE,
+	type MasterModeExtensionDeps,
+	type ResidentSessionInventory,
+	renderInventoryMarkdown,
+} from "@gajae-code/coding-agent/master";
+import { masterModeSystemPromptSection } from "@gajae-code/coding-agent/master/prompt";
+import type { SdkSessionRowV1 } from "@gajae-code/coding-agent/sdk/cli/rows";
+import { buildSystemPrompt } from "@gajae-code/coding-agent/system-prompt";
+
+const NOW = Date.parse("2026-03-01T12:00:00.000Z");
+
+function row(partial: Partial<SdkSessionRowV1> & { sessionId: string }): SdkSessionRowV1 {
+	return {
+		locator: { repo: "/repo", stateRoot: "/state" },
+		endpointGeneration: 1,
+		pid: 1234,
+		live: true,
+		deleted: false,
+		indexSeq: 1,
+		...partial,
+	};
+}
+
+function inventory(sessions: SdkSessionRowV1[]): ResidentSessionInventory {
+	return { fetchedAt: NOW, sessions };
+}
+
+describe("gjc master launch surface", () => {
+	it("parses --master as a local launch flag", () => {
+		const parsed = parseArgs(["--master"], "local");
+		expect(parsed.master).toBe(true);
+		expect(parsed.unknownFlags.size).toBe(0);
+	});
+
+	it("leaves master mode off by default", () => {
+		const parsed = parseArgs([], "local");
+		expect(parsed.master).toBeUndefined();
+	});
+
+	it("exposes the gjc master command with a supervision description", () => {
+		expect(Master.description).toContain("master session");
+		expect(Master.description).toContain("SDK");
+	});
+});
+
+describe("master-mode system prompt section", () => {
+	it("is appended only for master sessions", async () => {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-master-prompt-"));
+		const base = { cwd, contextFiles: [], toolNames: ["bash"] };
+		const master = await buildSystemPrompt({ ...base, masterMode: true });
+		const plain = await buildSystemPrompt(base);
+		expect(master.systemPrompt.some(block => block.includes("<master-mode>"))).toBe(true);
+		expect(plain.systemPrompt.some(block => block.includes("<master-mode>"))).toBe(false);
+		fs.rmSync(cwd, { recursive: true, force: true });
+	});
+
+	it("states the supervision-only contract and non-goals", () => {
+		const section = masterModeSystemPromptSection();
+		expect(section).toContain("master session");
+		expect(section).toContain("NEVER scrape terminal panes");
+		expect(section).toContain("NOT a team");
+		expect(section).toContain("Fail closed");
+	});
+});
+
+describe("resident-session classification", () => {
+	it("fails closed on ambiguous or terminal-uncertain rows", () => {
+		expect(classifyResidentSession(row({ sessionId: "a", ambiguous: true }), NOW)).toBe("blocked");
+		expect(classifyResidentSession(row({ sessionId: "b", terminalUncertain: true }), NOW)).toBe("blocked");
+		expect(classifyResidentSession(row({ sessionId: "c", live: false, ambiguous: true }), NOW)).toBe("blocked");
+	});
+
+	it("classifies dead or deleted rows as terminal", () => {
+		expect(classifyResidentSession(row({ sessionId: "a", live: false }), NOW)).toBe("terminal");
+		expect(classifyResidentSession(row({ sessionId: "b", deleted: true }), NOW)).toBe("terminal");
+	});
+
+	it("classifies a live active session as active within the heartbeat window", () => {
+		const active = row({
+			sessionId: "a",
+			activity: { state: "active", at: NOW - 1_000 },
+			lastHeartbeatAt: NOW - 1_000,
+		});
+		expect(classifyResidentSession(active, NOW)).toBe("active");
+	});
+
+	it("classifies a live active session past the stuck threshold as stuck", () => {
+		const stale = row({
+			sessionId: "a",
+			activity: { state: "active", at: NOW - 60 * 60 * 1000 },
+			lastHeartbeatAt: NOW - 60 * 60 * 1000,
+		});
+		expect(classifyResidentSession(stale, NOW)).toBe("stuck");
+	});
+
+	it("classifies a live session without an active turn as idle", () => {
+		expect(classifyResidentSession(row({ sessionId: "a" }), NOW)).toBe("idle");
+		expect(classifyResidentSession(row({ sessionId: "b", activity: { state: "idle", at: NOW - 5_000 } }), NOW)).toBe(
+			"idle",
+		);
+	});
+});
+
+describe("supervision classification with authoritative probes", () => {
+	it("refines an idle session without a goal to idle_no_goal", () => {
+		expect(classifySupervisionTarget("idle", { hasGoal: false, pendingAsk: false, pendingGate: false })).toBe(
+			"idle_no_goal",
+		);
+	});
+
+	it("refines an idle session with a pending ask or gate to question/gate", () => {
+		expect(classifySupervisionTarget("idle", { hasGoal: true, pendingAsk: true, pendingGate: false })).toBe(
+			"question",
+		);
+		expect(classifySupervisionTarget("idle", { hasGoal: true, pendingAsk: false, pendingGate: true })).toBe("gate");
+	});
+
+	it("keeps an idle session with an active goal as idle", () => {
+		expect(classifySupervisionTarget("idle", { hasGoal: true, pendingAsk: false, pendingGate: false })).toBe("idle");
+	});
+
+	it("never reclassifies blocked, active, stuck, or terminal rows from probes", () => {
+		for (const cls of ["blocked", "active", "stuck", "terminal"] as const) {
+			expect(classifySupervisionTarget(cls, { hasGoal: false, pendingAsk: true, pendingGate: true })).toBe(cls);
+		}
+	});
+});
+
+describe("resident-session inventory rendering", () => {
+	it("renders exact identity fields and the master self-annotation", () => {
+		const md = renderInventoryMarkdown(
+			inventory([
+				row({ sessionId: "self", hostIncarnation: "inc-1" }),
+				row({ sessionId: "other", endpointGeneration: 7, live: false }),
+			]),
+			"self",
+			NOW,
+		);
+		expect(md).toContain("session=self");
+		expect(md).toContain("hostIncarnation=inc-1");
+		expect(md).toContain("this master session");
+		expect(md).toContain("session=other");
+		expect(md).toContain("endpointGeneration=7");
+		expect(md).toContain("class=terminal");
+	});
+
+	it("flags blocked rows as hands-off", () => {
+		const md = renderInventoryMarkdown(inventory([row({ sessionId: "x", ambiguous: true })]), undefined, NOW);
+		expect(md).toContain("HANDS-OFF");
+		expect(md).toContain("class=blocked");
+	});
+
+	it("bounds the rendered rows", () => {
+		const sessions = Array.from({ length: MASTER_INVENTORY_ROW_LIMIT + 5 }, (_, i) => row({ sessionId: `s${i}` }));
+		const md = renderInventoryMarkdown(inventory(sessions), undefined, NOW);
+		expect(md).not.toContain(`session=s${MASTER_INVENTORY_ROW_LIMIT}`);
+		expect(md).toContain("5 more");
+	});
+
+	it("reports an empty broker index explicitly", () => {
+		expect(renderInventoryMarkdown(inventory([]), undefined, NOW)).toContain("No resident sessions");
+	});
+});
+
+describe("master session-start hook", () => {
+	function fakeApi(sent: Array<{ message: Record<string, unknown>; options: unknown }>) {
+		const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<void>>();
+		return {
+			handlers,
+			api: {
+				on: (event: string, handler: (event: unknown, ctx: unknown) => Promise<void>) => {
+					handlers.set(event, handler);
+				},
+				sendMessage: (message: Record<string, unknown>, options: unknown) => {
+					sent.push({ message, options });
+				},
+			},
+		};
+	}
+
+	const ctx = { sessionManager: { getSessionId: () => "master-self" } };
+
+	it("injects SDK guidance plus the current inventory on session_start", async () => {
+		const sent: Array<{ message: Record<string, unknown>; options: unknown }> = [];
+		const { handlers, api } = fakeApi(sent);
+		const deps: MasterModeExtensionDeps = {
+			agentDir: "/unused",
+			now: () => NOW,
+			loadInventory: async () => inventory([row({ sessionId: "master-self" }), row({ sessionId: "worker-1" })]),
+		};
+		createMasterModeExtension(deps)(api as never);
+		const handler = handlers.get("session_start");
+		expect(handler).toBeDefined();
+		await handler?.({}, ctx);
+		expect(sent).toHaveLength(1);
+		const [{ message, options }] = sent;
+		expect(message.customType).toBe(MASTER_SESSION_CONTEXT_CUSTOM_TYPE);
+		expect(message.display).toBe(false);
+		expect(options).toEqual({ triggerTurn: false });
+		const content = String(message.content);
+		expect(content).toContain("SDK supervision quick reference");
+		expect(content).toContain("session=worker-1");
+		expect(content).toContain("this master session");
+	});
+
+	it("fails closed with guidance-only content when the broker is unavailable", async () => {
+		const sent: Array<{ message: Record<string, unknown>; options: unknown }> = [];
+		const { handlers, api } = fakeApi(sent);
+		createMasterModeExtension({
+			agentDir: "/unused",
+			now: () => NOW,
+			loadInventory: async () => {
+				throw new Error("broker gone");
+			},
+		})(api as never);
+		await handlers.get("session_start")?.({}, ctx);
+		expect(sent).toHaveLength(1);
+		const content = String(sent[0]?.message.content);
+		expect(content).toContain("SDK supervision quick reference");
+		expect(content).toContain("UNAVAILABLE");
+		expect(content).toContain("Fail closed");
+	});
+});


### PR DESCRIPTION
## Summary

Closes #4448.

Adds a first-class master mode: `gjc master` launches an otherwise normal resident GJC agent session that supervises other already-existing resident sessions through the authoritative SDK/ACP control surface.

- **Launch**: `gjc master` is the normal interactive launch path with `--master` added (all launch flags pass through; `gjc --master` is equivalent).
- **System prompt**: master sessions get a dedicated `<master-mode>` section (`src/master/master-mode-prompt.md`) covering supervision-only scope, exact-identity/idempotency/fail-closed invariants, and non-goals.
- **Session-start hook**: an internal inline extension (registered only when `masterMode` is set) injects one hidden context message at `session_start` with (a) the SDK supervision quick reference for the `gjc sdk session` control family and (b) a bounded snapshot of the current resident-session inventory from the broker session index — credential-free v1 rows with `blocked`/`terminal`/`stuck`/`active`/`idle` classification. Broker unavailability fails closed: guidance-only content plus an explicit do-not-act notice.
- **Supervision controls**: existing SDK surfaces only — `turn.prompt` resume, `turn.steer` / `turn.abort_and_prompt` boundaries, `ask.answer` / `workflow.gate_answer`, lifecycle `session.close` — with exact `sessionId` + `endpointGeneration`/`hostIncarnation` identity and idempotent `clientRef` semantics. Ambiguous/stale endpoints fail closed.

## Non-goals (explicit)

No team mode, no delegate-team or spawned-worker orchestration, no pane scraping. PR #4430 is reference-only and untouched. Coordinator `stop_session` (#4431) is out of scope.

## Tests

- `packages/coding-agent/test/master-mode.test.ts` (20 tests): launch flag parsing, command surface, master-mode prompt section presence/absence, blocked/terminal/stuck/active/idle classification, probe-based idle_no_goal/question/gate classification with stale-authority refusal, bounded inventory rendering, session-start hook injection, broker-unavailable fail-closed behavior.
- `cli-command-surface.test.ts` updated for the new command.
- Adjacent suites green: cli suite (183), system-prompt suites, sdk session cli/client suites; package biome+tsc check clean.

## Docs

`docs/master-mode.md`: launch, scope, non-goals, safety invariants, recovery behavior.

gaebal-gajae