### PR TITLE
fix(tui): keep isolated home paths non-scratch

### DIFF
--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -51,6 +51,7 @@ function scratchRoots(): readonly string[] {
 }
 
 function classifyProjectDir(pwd: string): { scratch: boolean; relative: string | null } {
+	if (pathIsWithin(os.homedir(), pwd)) return { scratch: false, relative: null };
 	for (const root of scratchRoots()) {
 		if (pathIsWithin(root, pwd)) {
 			return { scratch: true, relative: relativePathWithinRoot(root, pwd) };


### PR DESCRIPTION
Completes #4436 status-path isolation. Test sandboxes can place HOME beneath TMPDIR; home-owned projects must retain normal project display semantics. Classify active HOME before generic scratch roots.\n\nVerified: status-line-path passes 20 consecutive runs; coding-agent check exits 0 with warnings only.\n\nSigned-off-by: Yeachan-Heo <yeachan-heo@gajae.dev>