### PR TITLE
fix(ci): regenerate telegram closure manifest after merge (#4436)

### DIFF
--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -526,7 +526,7 @@
     "telegram:packages/coding-agent/src/sdk/bus/daemon-paths.ts:HEARTBEAT_TTL_MS": "62255b5467995d21d3f929c863278ca3e815102001c51ca6d66840e1522ff990",
     "telegram:packages/coding-agent/src/sdk/bus/daemon-paths.ts:daemonPaths": "7043b25a3b8ebefa4ea68ea136f0fc49a1b83e392b4eeb78305d1b3e96d0c9cc",
     "telegram:packages/coding-agent/src/sdk/bus/index.ts:buildIdentity": "246ad10dd6341037a20379a8544736039584d36482f6b2d44e3054f5e7f87724",
-    "telegram:packages/coding-agent/src/sdk/bus/index.ts:createNotificationsExtension": "5b77747eacd1f3659c99b77ac2a3ade36d60e76e06f9fc528d3a123b91debc7b",
+    "telegram:packages/coding-agent/src/sdk/bus/index.ts:createNotificationsExtension": "a16f11a365558c13046644593dd86bca05506aa069495265a110c2b7dd995e41",
     "telegram:packages/coding-agent/src/sdk/bus/notification-service.ts:DaemonTransitionLock": "0fb018a6384bff312aab0345012936f7e0609e4691c841919426ad3d75841dcb",
     "telegram:packages/coding-agent/src/sdk/bus/notification-service.ts:NATIVE_PATH_IDENTITY_CONTRACT_VERSION": "ec669ef396909ce429e08ce4fa9a78b5f0106d8cedf967e634c6ae6974830b8a",
     "telegram:packages/coding-agent/src/sdk/bus/notification-service.ts:acquireDaemonTransitionLock": "0115500fcb5c5797008d607bd69694579c5b372420310f265d33a4759364decc",


### PR DESCRIPTION
Fixes #4436 post-merge blocker.

Post-merge dev `3d836d168698` failed Dev CI guard `94445276819` with:

```
semantic manifest declaration digest mismatch for
telegram:packages/coding-agent/src/sdk/bus/index.ts:createNotificationsExtension
manifest `5b77747e…` actual `a16f11a3…`
```

Root cause: virtual integration of `0cecbaf819` (topic rename watcher) changed protected `createNotificationsExtension` bytes after PR-head `0851c5236a` validation; the manifest in PR-head was `5b77747e` and the merged tree actual is `a16f11a3`. This is not a lifecycle change requiring a generation bump, only a stale manifest digest after merge resolution.

Fix: regenerate `scripts/telegram-daemon-generation-manifest.json` atomically against the exact merged tree via `bun scripts/telegram-daemon-generation-guard.ts --write-manifest` and verify both `validateCurrentTreeManifest` and the guard integration scenario.

`PI_CONFIG_DIR` baseline (#4459/#4430 shard1) was also described as a blocker: `packages/coding-agent/test/discovery/pi-config-dir.test.ts` failing with `.gjc` vs `.config/gjc`. Reproduced in this worktree's clean shard: `bun test packages/.../pi-config-dir.test.ts` passes 3/3 after the prior `tsconfig.publish` fix and with the current sharded env (3 pass, 0 fail). No `discovery/config` overlap in those PR diffs; if it remains red on re-queued CI it will be owned as a follow-up under the same #4436 successor without speculative edits.

Evidence:
- `validateCurrentTreeManifest` OK on exact merged dev
- `ci:check:full` OK (no stray `mcp-test-utils.d.ts`, publish declarations clean)
- `pi-config-dir.test.ts` 3 pass in isolated shard
- Previous PR #4456 head `0851c5236a` validated via Dev CI `31695018653` (in_progress at merge); this successor bumps only the generated closure digest `5b77747e→a16f11a3`.

Co-authored-by: GJC <gajae@gajae.dev>
Signed-off-by: Yeachan-Heo <yeachan.heo@gmail.com>