### PR TITLE
fix(docs): restore accurate removed-surface wording in bot integration docs (#4472)

### DIFF
--- a/docs/bot-integration.md
+++ b/docs/bot-integration.md
@@ -340,9 +340,9 @@ Key SDK workflow-gate facts:
 The prior documented invariant `action_needed.id == gate_id` is incorrect for
 v3 and must not be implemented by controllers. See [the SDK session CLI guide](./sdk-session-cli.md)
 for broker-bound controls and [the SDK guide](./sdk.md) for Router and lifecycle
-ownership. Retired RPC and bridge transports have no compatibility shim; migrate
-controllers to Coordinator MCP, `gjc sdk session`, or a managed Telegram,
-Discord, or Slack adapter.
+ownership. `--mode rpc`, `--mode rpc-ui`, and `--mode bridge` have been removed
+and have no compatibility shim; migrate controllers to Coordinator MCP,
+`gjc sdk session`, or a managed Telegram, Discord, or Slack adapter.
 
 ## Error handling playbook
 

--- a/docs/external-control-readiness.md
+++ b/docs/external-control-readiness.md
@@ -1,8 +1,9 @@
 # External control readiness
 
-Process-isolated controllers use broker-bound or managed surfaces. Endpoint
-records, transport credentials, and raw session transports remain inside SDK
-core; see [SDK machine interfaces](./sdk.md) for the ownership boundary.
+Process-isolated controllers use broker-bound or managed surfaces. The SDK WebSocket
+endpoint is not a public controller interface; endpoint records, transport
+credentials, and raw session transports remain inside SDK core; see
+[SDK machine interfaces](./sdk.md) for the ownership boundary.
 
 ## Supported surfaces
 
@@ -13,7 +14,7 @@ core; see [SDK machine interfaces](./sdk.md) for the ownership boundary.
 | Managed adapter | Configured Telegram, Discord, or Slack integration | A provider renders session presentation through opaque Router attachments. |
 | ACP | `gjc --mode acp` or `gjc acp` | An editor or ACP-compatible client supplies the session frontend. |
 
-`--mode rpc`, `--mode rpc-ui`, `--mode bridge`, and `gjc sdk serve` are removed;
+`--mode rpc`, `--mode rpc-ui`, `--mode bridge`, and `gjc sdk serve` have been removed;
 they are not compatibility interfaces.
 
 ## SDK session CLI readiness


### PR DESCRIPTION
Fixes #4472. Two deterministic bot-integration-docs.test.ts failures caused by #4199 revert inheriting #4281 wording drift. Minimally restore accurate wording. 7 pass (was 5 pass 2 fail). Docs-only change.