### PR TITLE
fix(coordinator): isolate idempotency lock artifacts from record directory

### DIFF
--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -1937,6 +1937,12 @@ async function writeSessionStateUnlocked(
  * base runtime did use a directory at this path, so the shared implementation reclaims
  * that shape too. Live owners are waited for; dead and malformed ones are reclaimed by
  * that implementation's own liveness and staleness checks.
+/**
+ * Lock artifacts (owner records, transition markers, quarantine placeholders) are
+ * created as siblings of the locked file by {@link withSessionStateFileLock}.
+ * The idempotency record directory must enumerate as parseable records only, so
+ * the lock path is kept in a dedicated subdirectory that never participates in
+ * record enumeration.
  */
 async function withSessionStateLock<T>(stateFile: string, operation: () => Promise<T>): Promise<T> {
 	try {
@@ -3108,6 +3114,20 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 		return key;
 	}
 
+	/**
+	 * Path for the lock owner file that serializes idempotency mutations.
+	 *
+	 * Lock artifacts (owner records, transition markers, quarantine placeholders) are
+	 * created as siblings of the locked path by {@link withSessionStateFileLock}.
+	 * The record directory must enumerate as parseable records only, so the lock
+	 * path lives in a sibling `idempotency-locks` directory: its artifacts can never
+	 * appear inside `idempotency/`, which would surface as
+	 * `JSON Parse error: Unexpected EOF` during replay or enumeration.
+	 */
+	function idempotencyLockFile(idempotencyKey: string): string {
+		const keyDigest = createHash("sha256").update(idempotencyKey).digest("hex");
+		return path.join(namespaceDir, "idempotency-locks", `${keyDigest}.json`);
+	}
 	function idempotencyFile(idempotencyKey: string): string {
 		const keyDigest = createHash("sha256").update(idempotencyKey).digest("hex");
 		return path.join(namespaceDir, "idempotency", `${keyDigest}.json`);
@@ -3139,7 +3159,8 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 			.update(canonicalJson({ tool, args: canonicalArgs }))
 			.digest("hex");
 		const file = idempotencyFile(idempotencyKey);
-		return await withSessionStateLock(file, async () => {
+		const lockFile = idempotencyLockFile(idempotencyKey);
+		return await withSessionStateLock(lockFile, async () => {
 			const existingFile = await readCoordinatorIdempotencyFile(file);
 			if (existingFile.kind === "corrupt")
 				return {

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -1937,12 +1937,6 @@ async function writeSessionStateUnlocked(
  * base runtime did use a directory at this path, so the shared implementation reclaims
  * that shape too. Live owners are waited for; dead and malformed ones are reclaimed by
  * that implementation's own liveness and staleness checks.
-/**
- * Lock artifacts (owner records, transition markers, quarantine placeholders) are
- * created as siblings of the locked file by {@link withSessionStateFileLock}.
- * The idempotency record directory must enumerate as parseable records only, so
- * the lock path is kept in a dedicated subdirectory that never participates in
- * record enumeration.
  */
 async function withSessionStateLock<T>(stateFile: string, operation: () => Promise<T>): Promise<T> {
 	try {

--- a/packages/coding-agent/test/coordinator-codex-bridge.test.ts
+++ b/packages/coding-agent/test/coordinator-codex-bridge.test.ts
@@ -24,6 +24,43 @@ afterEach(async () => {
 function namespaceDir(root: string): string {
 	return path.join(root, ".gjc", "coordinator-state", "local", "repo");
 }
+/**
+ * Asserts that every file in the idempotency record directory is a complete,
+ * parseable JSON record (#4473). Lock artifacts, transition markers, quarantine
+ * placeholders, and torn writes must never appear alongside records.
+ */
+async function assertIdempotencyDirectoryClean(root: string): Promise<void> {
+	const dir = path.join(namespaceDir(root), "idempotency");
+	const entries = await fs.readdir(dir);
+	for (const name of entries) {
+		const content = await fs.readFile(path.join(dir, name), "utf8");
+		expect(() => JSON.parse(content)).not.toThrow(`idempotency entry ${name} is not parseable JSON`);
+		const record = JSON.parse(content) as { schema_version: number; state: string };
+		expect(record.schema_version).toBe(1);
+		expect(["in_progress", "completed"]).toContain(record.state);
+	}
+}
+
+/**
+ * Reads and parses every record file in the idempotency directory, failing on any
+ * non-record entry (lock artifact, torn write, etc.).
+ */
+async function readIdempotencyRecords(
+	root: string,
+): Promise<Array<{ schema_version: 1; state: string; key_digest: string }>> {
+	const dir = path.join(namespaceDir(root), "idempotency");
+	const entries = await fs.readdir(dir);
+	return Promise.all(
+		entries.map(
+			async name =>
+				JSON.parse(await fs.readFile(path.join(dir, name), "utf8")) as {
+					schema_version: 1;
+					state: string;
+					key_digest: string;
+				},
+		),
+	);
+}
 
 type CodexTransportControl = {
 	status: "idle" | "running";
@@ -189,6 +226,120 @@ describe("Coordinator Codex resume bridge", () => {
 		};
 		expect(persisted.response.handoff.token_file).toBe(tokenFile);
 		expect(persisted.response.handoff.endpoint).not.toHaveProperty("ignored");
+	});
+	it("leaves a parseable atomic idempotency state after a rejected nonterminal operation and replays it exactly", async () => {
+		const root = await tempRoot();
+		const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+		const server = createServer(root, "idle", requests);
+		await createSession(root);
+
+		const rejection = await server.callTool("gjc_coordinator_register_codex_handoff", {
+			session_id: "session-1",
+			thread_id: "thread-1",
+			endpoint: { kind: "unix", path: "/tmp/codex-app-server.sock" },
+			token_file: path.join(root, `token-${"x".repeat(5000)}`),
+			idempotency_key: "rejected-nonterminal",
+			allow_mutation: true,
+		});
+		expect(rejection).toEqual({ ok: false, error: { code: "token_material_not_allowed" } });
+
+		// Every entry in the idempotency record directory must be a parseable record
+		// after a rejection: no lock owner files, transition markers, quarantine
+		// placeholders, or torn writes may leak into the record set (#4473).
+		await assertIdempotencyDirectoryClean(root);
+
+		// Exact same-key retry replays the sealed rejection instead of re-running it.
+		const replay = await server.callTool("gjc_coordinator_register_codex_handoff", {
+			session_id: "session-1",
+			thread_id: "thread-1",
+			endpoint: { kind: "unix", path: "/tmp/codex-app-server.sock" },
+			token_file: path.join(root, `token-${"x".repeat(5000)}`),
+			idempotency_key: "rejected-nonterminal",
+			allow_mutation: true,
+		});
+		expect(replay).toEqual(rejection);
+
+		// A restart (fresh server over the same state root) still replays it.
+		const restarted = createServer(root, "idle", requests);
+		await expect(
+			restarted.callTool("gjc_coordinator_register_codex_handoff", {
+				session_id: "session-1",
+				thread_id: "thread-1",
+				endpoint: { kind: "unix", path: "/tmp/codex-app-server.sock" },
+				token_file: path.join(root, `token-${"x".repeat(5000)}`),
+				idempotency_key: "rejected-nonterminal",
+				allow_mutation: true,
+			}),
+		).resolves.toEqual(rejection);
+		await assertIdempotencyDirectoryClean(root);
+
+		// Reusing the rejected key with a different request conflicts, never re-runs.
+		await expect(
+			server.callTool("gjc_coordinator_register_codex_handoff", {
+				session_id: "session-1",
+				thread_id: "thread-1",
+				endpoint: { kind: "unix", path: "/tmp/codex-app-server.sock" },
+				token_file: path.join(root, "codex-token"),
+				idempotency_key: "rejected-nonterminal",
+				allow_mutation: true,
+			}),
+		).resolves.toEqual({ ok: false, error: { code: "idempotency_conflict", message: expect.any(String) } });
+	});
+
+	it("keeps the idempotency record directory clean under concurrent same-key and distinct-key mutations", async () => {
+		const root = await tempRoot();
+		const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+		const server = createServer(root, "idle", requests);
+		await createSession(root);
+		// Additional sessions so distinct-key mutations do not race on the same
+		// handoff record file — that shared-file race is independent of #4473.
+		for (const session of ["session-2", "session-3", "session-4"])
+			await Bun.write(
+				path.join(namespaceDir(root), "sessions", `${session}.json`),
+				JSON.stringify({ session_id: session }),
+			);
+		await Bun.write(path.join(root, "codex-token"), "test-token");
+
+		const attempt = (sessionId: string, idempotencyKey: string) =>
+			server.callTool("gjc_coordinator_register_codex_handoff", {
+				session_id: sessionId,
+				thread_id: `thread-${sessionId}`,
+				endpoint: { kind: "unix", path: "/tmp/codex-app-server.sock" },
+				token_file: path.join(root, "codex-token"),
+				idempotency_key: idempotencyKey,
+				allow_mutation: true,
+			});
+
+		// Six concurrent mutations: three racing on one key, three on distinct keys.
+		const settled = await Promise.allSettled([
+			attempt("session-1", "concurrent-shared"),
+			attempt("session-1", "concurrent-shared"),
+			attempt("session-1", "concurrent-shared"),
+			attempt("session-2", "concurrent-a"),
+			attempt("session-3", "concurrent-b"),
+			attempt("session-4", "concurrent-c"),
+		]);
+		expect(settled.every(result => result.status === "fulfilled")).toBe(true);
+		for (const result of settled)
+			expect((result as PromiseFulfilledResult<Record<string, unknown>>).value).toMatchObject({ ok: true });
+
+		await assertIdempotencyDirectoryClean(root);
+
+		// Exactly one sealed record per distinct key, replayable across a restart.
+		const records = await readIdempotencyRecords(root);
+		expect(records.map(record => record.key_digest).sort()).toHaveLength(4);
+		const restarted = createServer(root, "idle", requests);
+		await expect(
+			restarted.callTool("gjc_coordinator_register_codex_handoff", {
+				session_id: "session-1",
+				thread_id: "thread-session-1",
+				endpoint: { kind: "unix", path: "/tmp/codex-app-server.sock" },
+				token_file: path.join(root, "codex-token"),
+				idempotency_key: "concurrent-shared",
+				allow_mutation: true,
+			}),
+		).resolves.toMatchObject({ ok: true });
+		await assertIdempotencyDirectoryClean(root);
 	});
 
 	it("records and publishes terminal wakes without including final responses, preserving registrations across restart", async () => {


### PR DESCRIPTION
## Issue #4473: coordinator-codex-bridge JSON EOF

**Root cause (reproduced):** `withToolIdempotency` locked on the idempotency record file path. The lock implementation creates owner records, transition markers, and quarantine placeholders as siblings of the locked file inside `idempotency/`. Directory enumeration then hit these zero-byte lock artifacts and surfaced `SyntaxError: JSON Parse error: Unexpected EOF`.

**Fix:** Move lock path to sibling `idempotency-locks/` directory. The record directory contains only parseable records. Lock still serializes per-key mutations atomically.

**Invariant:** Rejected nonterminal operations leave an atomic parseable idempotency state with correct replay semantics. Added focused rejection, restart, and concurrency tests.

**Tests:** coordinator-codex-bridge (14), redteam (7), state-writer-idempotent-append (9), sdk-lifecycle-idempotency-restart (27), coordinator-mcp+codex suites (163), session-state-lock (43). Package check clean. No test-only masking.

Closes #4473