### PR TITLE
fix(agent): resample escaped-non-ASCII tool turns instead of failing them

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixed
 
-- The agent loop rejects a tool call flagged `escapedNonAsciiArguments` before execution, with a retryable error telling the model to re-issue the call writing non-ASCII characters literally. Hand-spelled `\uXXXX` arguments decode into valid-looking but silently wrong text (observed as garbled Hangul in `ask` prompts), and no post-parse repair can recover the intended characters.
+- A turn whose tool arguments arrive flagged `escapedNonAsciiArguments` is now resampled instead of being reported as a tool failure: the defective assistant turn is dropped from history and the request is re-issued, up to twice per turn, before the terminal per-call rejection takes over. Hand-spelled `\uXXXX` arguments decode into valid-looking but silently wrong text (observed as garbled Hangul in `ask` prompts) and no post-parse repair can recover them, but the defect is a wire-format accident that resampling clears - surfacing it as a tool error instead burned the whole turn and fed the literal escape syntax back into the context the model samples from next. Scoped to the non-managed session path, matching the existing `invalid_prompt` and reasoning-content repairs; managed fallback keeps owning its own retry policy.
+- The agent loop still rejects a tool call flagged `escapedNonAsciiArguments` before execution once the resample budget is spent, with a retryable error telling the model to re-issue the call writing non-ASCII characters literally.
 - The emergency compaction system now includes a `transcriptFileBytes` floor (48 MiB, 75% of the managed-storage per-file cap) so a long-running session compacts before its append-only transcript reaches the 64 MiB limit. `CompactionTriggerReason` adds `"transcriptFile"`, `EmergencyCompactionSample` adds `transcriptFileBytes`, and `EmergencyCompactionLimits` adds `transcriptFileBytes`.
 
 ### Added

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -144,6 +144,21 @@ const standaloneOwnershipStates = new WeakMap<StandaloneRunOwnership, Standalone
  */
 const MAX_CONSECUTIVE_MALFORMED_TURNS = 5;
 
+/**
+ * How many times a single turn may be re-requested because its tool arguments
+ * arrived as `\uXXXX` escapes instead of literal UTF-8.
+ *
+ * The defect is a wire-format accident that resampling clears, so a small
+ * budget recovers the overwhelming majority of turns; past it the terminal
+ * per-call rejection takes over rather than spending the run on retries.
+ */
+const MAX_ESCAPED_NONASCII_RESAMPLES = 2;
+
+/** Whether any tool call in the turn carried `\uXXXX`-escaped arguments. */
+function hasEscapedNonAsciiToolCall(message: AssistantMessage): boolean {
+	return message.content.some(block => block.type === "toolCall" && block.escapedNonAsciiArguments === true);
+}
+
 function isComposerBashPolicyBlockedToolResult(result: ToolResultMessage): boolean {
 	return (
 		result.isError &&
@@ -1491,6 +1506,10 @@ async function runLoopBody(
 	// Fires at most one repaired resend per run for the reasoning-content replay
 	// breaker below (DeepSeek "reasoning_content ... must be passed back").
 	let reasoningContentRepairAttempted = false;
+	// Consecutive resamples spent on the current turn because its tool arguments
+	// arrived `\uXXXX`-escaped. Reset once a turn gets past the check, so every
+	// turn is judged on its own wire bytes.
+	let escapedNonAsciiResampleAttempt = 0;
 	let previousMalformedToolSignatures = new Set<string>();
 	type SyntheticRecoveryKind = "malformed-tool-call" | "composer-bash-policy" | "provider";
 	let pendingRecovery:
@@ -1794,6 +1813,38 @@ async function runLoopBody(
 					continue;
 				}
 			}
+
+			// Escaped-non-ASCII tool arguments: bounded turn resample.
+			//
+			// Arguments that spell a printable non-ASCII character as `\uXXXX`
+			// instead of literal UTF-8 are a wire-format defect, not a decision the
+			// model needs to be told about. The payload parses cleanly, but one
+			// mistyped nibble decodes to a different, equally valid character, so it
+			// can never be verified or repaired after the fact. Reporting it as a
+			// tool error spends the whole turn and writes the literal escape syntax
+			// back into the context the model samples from next. Drop the defective
+			// turn and re-request instead; the per-call rejection in
+			// `executeToolCalls` stays as the terminal answer once this budget is
+			// spent. Managed fallback owns its own retry policy, so this is scoped
+			// to the non-managed session path, matching the repairs above.
+			if (
+				!config.fallbackManaged &&
+				message.stopReason !== "error" &&
+				message.stopReason !== "aborted" &&
+				escapedNonAsciiResampleAttempt < MAX_ESCAPED_NONASCII_RESAMPLES &&
+				hasEscapedNonAsciiToolCall(message)
+			) {
+				escapedNonAsciiResampleAttempt++;
+				// The defective turn was already committed to the context by the
+				// streaming path. Drop it so the resample neither replays the escaped
+				// arguments as history nor leaves a second assistant tail behind.
+				const escapedIndex = currentContext.messages.length - 1;
+				if (escapedIndex >= 0 && currentContext.messages[escapedIndex]?.role === "assistant") {
+					currentContext.messages.splice(escapedIndex, 1);
+				}
+				continue;
+			}
+			escapedNonAsciiResampleAttempt = 0;
 
 			const overflow = managedContextOverflow(message, config);
 			if (config.fallbackManaged && overflow) {

--- a/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
+++ b/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
@@ -12,6 +12,10 @@ function identityConverter(messages: AgentMessage[]): Message[] {
 
 const askSchema = z.object({ question: z.string() });
 
+// Decodes cleanly, but a mistyped nibble anywhere in it would be
+// indistinguishable from the correct text.
+const QUESTION = "마지막 병목";
+
 function askTool(executed: Array<Record<string, unknown>>): AgentTool<typeof askSchema, Record<string, never>> {
 	return {
 		name: "ask",
@@ -25,27 +29,60 @@ function askTool(executed: Array<Record<string, unknown>>): AgentTool<typeof ask
 	};
 }
 
+/** A turn whose raw arguments arrived spelled as `\uXXXX` instead of literal UTF-8. */
+function escapedTurn(id: string) {
+	return {
+		content: [
+			{
+				type: "toolCall" as const,
+				id,
+				name: "ask",
+				arguments: { question: QUESTION },
+				escapedNonAsciiArguments: true,
+			},
+		],
+	};
+}
+
+/** The same turn as the model would have produced it with literal UTF-8 on the wire. */
+function literalTurn(id: string) {
+	return { content: [{ type: "toolCall" as const, id, name: "ask", arguments: { question: QUESTION } }] };
+}
+
 describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
-	it("rejects a call whose arguments were spelled as \\uXXXX escapes without executing it", async () => {
+	it("resamples the turn instead of executing or reporting escaped arguments", async () => {
 		const executed: Array<Record<string, unknown>> = [];
 		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };
 		const mock = createMockModel({
-			responses: [
-				{
-					content: [
-						{
-							type: "toolCall",
-							id: "tc-1",
-							name: "ask",
-							// Decodes cleanly, but a mistyped nibble anywhere in it would be
-							// indistinguishable from correct text.
-							arguments: { question: "마지막 병목" },
-							escapedNonAsciiArguments: true,
-						},
-					],
-				},
-				{ content: ["recovered"] },
-			],
+			responses: [escapedTurn("tc-1"), literalTurn("tc-2"), { content: ["done"] }],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const toolResults: Array<{ isError?: boolean; text: string }> = [];
+		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+		for await (const event of stream) {
+			if (event.type === "tool_execution_end") {
+				const first = event.result.content?.[0];
+				toolResults.push({ isError: event.isError, text: first?.type === "text" ? first.text : "" });
+			}
+		}
+
+		// The resampled call ran; the defective one neither ran nor produced an error.
+		expect(executed).toEqual([{ question: QUESTION }]);
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0].isError).toBeFalsy();
+		// The resample must not replay the escaped arguments back to the model as
+		// its own prior output: the retried request carries no assistant turn.
+		const resampleRequest = mock.model.calls[1];
+		expect(resampleRequest).toBeDefined();
+		expect(resampleRequest.context.messages.some(message => message.role === "assistant")).toBe(false);
+	});
+
+	it("rejects the call once the resample budget is spent", async () => {
+		const executed: Array<Record<string, unknown>> = [];
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };
+		const mock = createMockModel({
+			responses: [escapedTurn("tc-1"), escapedTurn("tc-2"), escapedTurn("tc-3"), { content: ["recovered"] }],
 		});
 		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
 
@@ -69,18 +106,14 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 	it("executes literal UTF-8 arguments untouched", async () => {
 		const executed: Array<Record<string, unknown>> = [];
 		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };
-		const mock = createMockModel({
-			responses: [
-				{ content: [{ type: "toolCall", id: "tc-1", name: "ask", arguments: { question: "마지막 병목" } }] },
-				{ content: ["done"] },
-			],
-		});
+		const mock = createMockModel({ responses: [literalTurn("tc-1"), { content: ["done"] }] });
 		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
 
 		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
 		for await (const _ of stream) {
 			// drain
 		}
-		expect(executed).toEqual([{ question: "마지막 병목" }]);
+
+		expect(executed).toEqual([{ question: QUESTION }]);
 	});
 });


### PR DESCRIPTION
Closes #4489.

## What

A tool call whose raw argument JSON spelled a printable non-ASCII character as `\uXXXX` was rejected outright. The detection stays; the handling changes: the defective assistant turn is now dropped from history and the request is re-issued, up to twice per turn, before the terminal per-call rejection takes over.

## Why

The escape is a wire-format accident that resampling clears, not an intent the model needs told back to it. Reporting it as a tool error spent the whole turn and wrote the literal `\uXXXX` syntax into the context the model samples from next.

Measured on local session logs (60 most recent sessions, 7910 tool calls): 175 calls carried non-ASCII, 116 (66%) were rejected. Hangul specifically: 66 of 85. All of it on the `anthropic-messages` path (`claude-opus-5` 53/54, `claude-sonnet-5` 13/13); the codex path was 0/18.

It is not a transport defect. 25+ direct probes against the same endpoint and model (payload length, thinking on/off, `fine-grained-tool-streaming` beta on/off, 30 extra tools, cloaked `mcp__...` names, 40-turn filler context, history primed with the rejection error itself) plus 6 real `gjc -p` runs with wire capture all returned literal UTF-8 with zero escapes. The flag clusters in long sessions (700-1000 assistant messages) and fires in consecutive bursts.

## How

`packages/agent/src/agent-loop.ts`, in the same position as the existing `invalid_prompt` and reasoning-content repairs (after the turn returns, before it is committed to `newMessages`):

- `hasEscapedNonAsciiToolCall(message)` + `MAX_ESCAPED_NONASCII_RESAMPLES = 2`.
- The defective turn, already committed to the context by the streaming path, is spliced out so the resample neither replays the escaped arguments as history nor leaves a second assistant tail behind.
- The counter resets once a turn gets past the check, so every turn is judged on its own wire bytes.
- Scoped to `!config.fallbackManaged`; managed fallback keeps owning its retry policy.
- `MAX_CONSECUTIVE_MALFORMED_TURNS` stays reachable as the terminal backstop, since escaped arguments still set `argumentValidationFailed`.

The rejection wording is byte-for-byte unchanged for downstream consumers.

## Tests

`packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts` rewritten to three cases:

1. escaped turn is resampled - the retried call executes, no tool error is emitted, and the resample request carries no assistant turn (verified through `mock.model.calls[1].context.messages`, which is the contract that makes the drop meaningful).
2. three consecutive escaped turns - budget spent, terminal rejection surfaces with the unchanged message.
3. literal UTF-8 arguments execute untouched.

## Verification

- `bun test packages/agent/test` - 744 pass, 0 fail
- `bun test packages/ai/test/anthropic-escaped-nonascii-toolcall.test.ts packages/ai/test/ollama-escaped-nonascii-toolcall.test.ts packages/ai/test/kimi-tool-call-healing.test.ts` - 22 pass (provider-side detection untouched)
- `bun --cwd=packages/agent run check`, `bun --cwd=packages/ai run check` - clean
