### PR TITLE
fix(agent): resample escaped non-ASCII tool turns

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixed
 
-- The agent loop rejects a tool call flagged `escapedNonAsciiArguments` before execution, with a retryable error telling the model to re-issue the call writing non-ASCII characters literally. Hand-spelled `\uXXXX` arguments decode into valid-looking but silently wrong text (observed as garbled Hangul in `ask` prompts), and no post-parse repair can recover the intended characters.
+- A turn whose tool arguments arrive flagged `escapedNonAsciiArguments` is now resampled instead of being reported as a tool failure: the defective assistant turn is dropped from history and the request is re-issued, up to twice per turn, before the terminal per-call rejection takes over. Hand-spelled `\uXXXX` arguments decode into valid-looking but silently wrong text (observed as garbled Hangul in `ask` prompts) and no post-parse repair can recover them, but the defect is a wire-format accident that resampling clears - surfacing it as a tool error instead burned the whole turn and fed the literal escape syntax back into the context the model samples from next. Scoped to the non-managed session path, matching the existing `invalid_prompt` and reasoning-content repairs; managed fallback keeps owning its own retry policy.
+- The agent loop still rejects a tool call flagged `escapedNonAsciiArguments` before execution once the resample budget is spent, with a retryable error telling the model to re-issue the call writing non-ASCII characters literally.
 - The emergency compaction system now includes a `transcriptFileBytes` floor (48 MiB, 75% of the managed-storage per-file cap) so a long-running session compacts before its append-only transcript reaches the 64 MiB limit. `CompactionTriggerReason` adds `"transcriptFile"`, `EmergencyCompactionSample` adds `transcriptFileBytes`, and `EmergencyCompactionLimits` adds `transcriptFileBytes`.
 
 ### Added

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -144,6 +144,21 @@ const standaloneOwnershipStates = new WeakMap<StandaloneRunOwnership, Standalone
  */
 const MAX_CONSECUTIVE_MALFORMED_TURNS = 5;
 
+/**
+ * How many times a single turn may be re-requested because its tool arguments
+ * arrived as `\uXXXX` escapes instead of literal UTF-8.
+ *
+ * The defect is a wire-format accident that resampling clears, so a small
+ * budget recovers the overwhelming majority of turns; past it the terminal
+ * per-call rejection takes over rather than spending the run on retries.
+ */
+const MAX_ESCAPED_NONASCII_RESAMPLES = 2;
+
+/** Whether any tool call in the turn carried `\uXXXX`-escaped arguments. */
+function hasEscapedNonAsciiToolCall(message: AssistantMessage): boolean {
+	return message.content.some(block => block.type === "toolCall" && block.escapedNonAsciiArguments === true);
+}
+
 function isComposerBashPolicyBlockedToolResult(result: ToolResultMessage): boolean {
 	return (
 		result.isError &&
@@ -1491,6 +1506,10 @@ async function runLoopBody(
 	// Fires at most one repaired resend per run for the reasoning-content replay
 	// breaker below (DeepSeek "reasoning_content ... must be passed back").
 	let reasoningContentRepairAttempted = false;
+	// Consecutive resamples spent on the current turn because its tool arguments
+	// arrived `\uXXXX`-escaped. Reset once a turn gets past the check, so every
+	// turn is judged on its own wire bytes.
+	let escapedNonAsciiResampleAttempt = 0;
 	let previousMalformedToolSignatures = new Set<string>();
 	type SyntheticRecoveryKind = "malformed-tool-call" | "composer-bash-policy" | "provider";
 	let pendingRecovery:
@@ -1794,6 +1813,38 @@ async function runLoopBody(
 					continue;
 				}
 			}
+
+			// Escaped-non-ASCII tool arguments: bounded turn resample.
+			//
+			// Arguments that spell a printable non-ASCII character as `\uXXXX`
+			// instead of literal UTF-8 are a wire-format defect, not a decision the
+			// model needs to be told about. The payload parses cleanly, but one
+			// mistyped nibble decodes to a different, equally valid character, so it
+			// can never be verified or repaired after the fact. Reporting it as a
+			// tool error spends the whole turn and writes the literal escape syntax
+			// back into the context the model samples from next. Drop the defective
+			// turn and re-request instead; the per-call rejection in
+			// `executeToolCalls` stays as the terminal answer once this budget is
+			// spent. Managed fallback owns its own retry policy, so this is scoped
+			// to the non-managed session path, matching the repairs above.
+			if (
+				!config.fallbackManaged &&
+				message.stopReason !== "error" &&
+				message.stopReason !== "aborted" &&
+				escapedNonAsciiResampleAttempt < MAX_ESCAPED_NONASCII_RESAMPLES &&
+				hasEscapedNonAsciiToolCall(message)
+			) {
+				escapedNonAsciiResampleAttempt++;
+				// The defective turn was already committed to the context by the
+				// streaming path. Drop it so the resample neither replays the escaped
+				// arguments as history nor leaves a second assistant tail behind.
+				const escapedIndex = currentContext.messages.length - 1;
+				if (escapedIndex >= 0 && currentContext.messages[escapedIndex]?.role === "assistant") {
+					currentContext.messages.splice(escapedIndex, 1);
+				}
+				continue;
+			}
+			escapedNonAsciiResampleAttempt = 0;
 
 			const overflow = managedContextOverflow(message, config);
 			if (config.fallbackManaged && overflow) {

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -14,6 +14,7 @@ import {
 	EventStream,
 	isZodSchema,
 	streamSimple,
+	type ToolChoice,
 	type ToolResultMessage,
 	type TSchema,
 	transportFailureFacts,
@@ -1526,6 +1527,11 @@ async function runLoopBody(
 	// arrived `\uXXXX`-escaped. Reset once a turn gets past the check, so every
 	// turn is judged on its own wire bytes.
 	let escapedNonAsciiResampleAttempt = 0;
+	// A queue-backed dynamic tool choice belongs to the logical turn, not to one
+	// wire attempt. Capture it once and replay it across escaped-argument
+	// resamples; reset only after a response is accepted for normal processing.
+	let escapedNonAsciiToolChoiceCaptured = false;
+	let escapedNonAsciiToolChoice: ToolChoice | undefined;
 	let previousMalformedToolSignatures = new Set<string>();
 	type SyntheticRecoveryKind = "malformed-tool-call" | "composer-bash-policy" | "provider";
 	let pendingRecovery:
@@ -1645,6 +1651,12 @@ async function runLoopBody(
 			const recoveryAttempt = pendingRecovery;
 			const wasMalformedToolRecoveryAttempt = recoveryAttempt?.kind === "malformed-tool-call";
 			try {
+				const getLogicalTurnToolChoice = (): ToolChoice | undefined => {
+					if (escapedNonAsciiToolChoiceCaptured) return escapedNonAsciiToolChoice;
+					escapedNonAsciiToolChoice = config.getToolChoice?.();
+					escapedNonAsciiToolChoiceCaptured = true;
+					return escapedNonAsciiToolChoice;
+				};
 				const attemptConfig = attemptTransaction
 					? {
 							...config,
@@ -1688,6 +1700,7 @@ async function runLoopBody(
 							}
 						: undefined,
 					escapedToolTransaction,
+					recoveryAttempt ? undefined : { value: getLogicalTurnToolChoice() },
 				);
 				const detection = detectHarmonyLeakInAssistantMessage(message);
 				if (detection && shouldMitigateHarmonyLeak(config.model, detection)) {
@@ -1866,6 +1879,8 @@ async function runLoopBody(
 				continue;
 			}
 			escapedNonAsciiResampleAttempt = 0;
+			escapedNonAsciiToolChoiceCaptured = false;
+			escapedNonAsciiToolChoice = undefined;
 
 			const overflow = managedContextOverflow(message, config);
 			if (config.fallbackManaged && overflow) {
@@ -1921,6 +1936,13 @@ async function runLoopBody(
 
 			// One provider invocation is committed before any tool can run.
 			transaction?.flush();
+			if (escapedToolTransaction) {
+				// Tool-call updates are staged so an escaped turn can disappear
+				// atomically. Once accepted, drain every published update through the
+				// Agent/AgentSession consumers before dispatch: streaming edit guards
+				// can then abort the run before any tool execute() is entered.
+				if (!loopSignal.aborted && stream.hasActiveConsumer) await stream.waitForConsumerDrain(loopSignal);
+			}
 			if (config.fallbackManaged && message.stopReason !== "error" && message.stopReason !== "aborted") {
 				await config.onManagedAttemptAccepted?.();
 			}
@@ -2167,6 +2189,7 @@ async function streamAssistantResponse(
 		forceAutoToolChoice?: boolean;
 	},
 	provisionalToolTransaction?: ManagedAttemptTransaction,
+	toolChoiceOverride?: { value: ToolChoice | undefined },
 ): Promise<AssistantMessage> {
 	// Apply context transform if configured (AgentMessage[] → AgentMessage[])
 	let messages = context.messages;
@@ -2229,7 +2252,11 @@ async function streamAssistantResponse(
 
 	// Synthetic recovery requests choose their tool mode explicitly below and
 	// must never consume a queued dynamic choice intended for an ordinary turn.
-	const dynamicToolChoice = recoveryMode ? undefined : config.getToolChoice?.();
+	const dynamicToolChoice = recoveryMode
+		? undefined
+		: toolChoiceOverride
+			? toolChoiceOverride.value
+			: config.getToolChoice?.();
 	const dynamicReasoning = config.getReasoning?.();
 	const harmonyMitigationEnabled = isHarmonyLeakMitigationTarget(config.model);
 	const harmonyAbortController = harmonyMitigationEnabled ? new AbortController() : undefined;

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -984,6 +984,10 @@ class ManagedAttemptTransaction {
 
 	stageAssistantMessageEvent(message: AssistantMessage, event: AssistantMessageEvent): void {
 		const partial = managedAssistantShell(message, this.model);
+		if (this.#committed) {
+			this.onAssistantMessageEvent?.(partial, managedAssistantEventSnapshot(event, partial));
+			return;
+		}
 		this.#batch.push({
 			type: "assistant_event",
 			message: partial,

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -1006,6 +1006,10 @@ class ManagedAttemptTransaction {
 		this.#committed = true;
 	}
 
+	get committed(): boolean {
+		return this.#committed;
+	}
+
 	discard(): void {
 		this.#batch = [];
 		this.#stagedBytes = 0;
@@ -1547,11 +1551,15 @@ async function runLoopBody(
 			const scope =
 				initialScope ?? (firstTurn ? config.initialScope : undefined) ?? config.attemptMinter?.mint("main");
 			initialScope = undefined;
-			const transaction =
+			const managedTransaction =
 				initialTransaction ??
 				(config.fallbackManaged
 					? new ManagedAttemptTransaction(stream, config.onAssistantMessageEvent, config.model, scope)
 					: undefined);
+			const escapedToolTransaction = config.fallbackManaged
+				? undefined
+				: new ManagedAttemptTransaction(stream, config.onAssistantMessageEvent, config.model, scope);
+			const transaction = managedTransaction ?? escapedToolTransaction;
 			initialTransaction = undefined;
 			const attemptScope = transaction?.scope ?? scope;
 			lastAttemptScope = attemptScope;
@@ -1629,7 +1637,7 @@ async function runLoopBody(
 			// Stream assistant response
 			let recovered: HarmonyRecoveredToolCall | undefined;
 			let message: AssistantMessage;
-			const attemptTransaction = transaction;
+			const attemptTransaction = managedTransaction;
 			const recoveryAttempt = pendingRecovery;
 			const wasMalformedToolRecoveryAttempt = recoveryAttempt?.kind === "malformed-tool-call";
 			try {
@@ -1661,7 +1669,7 @@ async function runLoopBody(
 					currentContext,
 					attemptConfig,
 					loopSignal,
-					attemptTransaction ? (attemptTransaction as unknown as EventStream<AgentEvent, AgentMessage[]>) : stream,
+					transaction ? (transaction as unknown as EventStream<AgentEvent, AgentMessage[]>) : stream,
 					telemetry,
 					invokeAgentSpan,
 					stepCounter,
@@ -1675,6 +1683,7 @@ async function runLoopBody(
 								forceAutoToolChoice: !wasMalformedToolRecoveryAttempt,
 							}
 						: undefined,
+					escapedToolTransaction,
 				);
 				const detection = detectHarmonyLeakInAssistantMessage(message);
 				if (detection && shouldMitigateHarmonyLeak(config.model, detection)) {
@@ -1840,9 +1849,11 @@ async function runLoopBody(
 				message.stopReason !== "error" &&
 				message.stopReason !== "aborted" &&
 				escapedNonAsciiResampleAttempt < MAX_ESCAPED_NONASCII_RESAMPLES &&
+				!escapedToolTransaction?.committed &&
 				hasEscapedNonAsciiToolCall(message)
 			) {
 				escapedNonAsciiResampleAttempt++;
+				escapedToolTransaction?.discard();
 				// The defective turn was already committed to the context by the
 				// streaming path. Remove that exact object rather than assuming it is
 				// still the tail: callbacks may append user/system history while the
@@ -2151,6 +2162,7 @@ async function streamAssistantResponse(
 		disableTools?: boolean;
 		forceAutoToolChoice?: boolean;
 	},
+	provisionalToolTransaction?: ManagedAttemptTransaction,
 ): Promise<AssistantMessage> {
 	// Apply context transform if configured (AgentMessage[] → AgentMessage[])
 	let messages = context.messages;
@@ -2501,7 +2513,11 @@ async function streamAssistantResponse(
 									: event.partial;
 								const partialEvent = config.fallbackManaged ? { ...event, partial: partialMessage } : event;
 								context.messages[context.messages.length - 1] = partialMessage;
-								config.onAssistantMessageEvent?.(partialMessage, partialEvent);
+								if (provisionalToolTransaction) {
+									provisionalToolTransaction.stageAssistantMessageEvent(partialMessage, partialEvent);
+								} else {
+									config.onAssistantMessageEvent?.(partialMessage, partialEvent);
+								}
 								if (signal?.aborted) continue;
 								stream.push({
 									type: "message_update",
@@ -2509,6 +2525,13 @@ async function streamAssistantResponse(
 									message: { ...partialMessage },
 									scope,
 								});
+								// Preserve ordinary text streaming. Once visible text is
+								// published, this response can no longer be silently resampled;
+								// a later escaped tool call therefore falls through to the
+								// existing terminal per-call rejection instead.
+								if (event.type === "text_start" || event.type === "text_delta" || event.type === "text_end") {
+									provisionalToolTransaction?.flush();
+								}
 							}
 							break;
 

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -159,6 +159,14 @@ function hasEscapedNonAsciiToolCall(message: AssistantMessage): boolean {
 	return message.content.some(block => block.type === "toolCall" && block.escapedNonAsciiArguments === true);
 }
 
+/** Remove only the exact assistant response committed by its streaming attempt. */
+function removeCommittedAssistantMessage(messages: AgentMessage[], message: AssistantMessage): boolean {
+	const index = messages.lastIndexOf(message);
+	if (index < 0) return false;
+	messages.splice(index, 1);
+	return true;
+}
+
 function isComposerBashPolicyBlockedToolResult(result: ToolResultMessage): boolean {
 	return (
 		result.isError &&
@@ -1836,12 +1844,10 @@ async function runLoopBody(
 			) {
 				escapedNonAsciiResampleAttempt++;
 				// The defective turn was already committed to the context by the
-				// streaming path. Drop it so the resample neither replays the escaped
-				// arguments as history nor leaves a second assistant tail behind.
-				const escapedIndex = currentContext.messages.length - 1;
-				if (escapedIndex >= 0 && currentContext.messages[escapedIndex]?.role === "assistant") {
-					currentContext.messages.splice(escapedIndex, 1);
-				}
+				// streaming path. Remove that exact object rather than assuming it is
+				// still the tail: callbacks may append user/system history while the
+				// response settles, and none of that history belongs to this retry.
+				removeCommittedAssistantMessage(currentContext.messages, message);
 				continue;
 			}
 			escapedNonAsciiResampleAttempt = 0;

--- a/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
+++ b/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
@@ -213,6 +213,35 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		expect(toolEnds[0]?.type === "tool_execution_end" ? toolEnds[0].isError : false).toBe(true);
 	});
 
+	it("delivers every assistant stream callback exactly once after visible text commits the turn", async () => {
+		const executed: Array<Record<string, unknown>> = [];
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };
+		const mock = createMockModel({ responses: [escapedTurnWithText("tc-visible"), { content: ["done"] }] });
+		const callbackTypes: string[] = [];
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			onAssistantMessageEvent: (_message, event) => callbackTypes.push(event.type),
+		};
+
+		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+		for await (const _event of stream) {
+			// drain
+		}
+
+		expect(callbackTypes).toEqual([
+			"text_start",
+			"text_delta",
+			"text_end",
+			"toolcall_start",
+			"toolcall_delta",
+			"toolcall_end",
+			"text_start",
+			"text_delta",
+			"text_end",
+		]);
+	});
+
 	it("executes no calls from a mixed batch before validating the whole turn", async () => {
 		const executed: Array<Record<string, unknown>> = [];
 		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };

--- a/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
+++ b/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
@@ -315,6 +315,56 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		expect(mock.calls).toHaveLength(6);
 	});
 
+	it("preserves a queue-backed tool choice across a resample", async () => {
+		const executed: Array<Record<string, unknown>> = [];
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };
+		const queuedChoices = ["required" as const, "none" as const];
+		let getterCalls = 0;
+		const mock = createMockModel({
+			responses: [escapedTurn("tc-1"), literalTurn("tc-2"), { content: ["done"] }],
+		});
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			getToolChoice: () => {
+				getterCalls += 1;
+				return queuedChoices.shift();
+			},
+		};
+
+		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+		for await (const _event of stream) {
+			// drain
+		}
+
+		expect(mock.calls.map(call => call.options?.toolChoice)).toEqual(["required", "required", "none"]);
+		expect(getterCalls).toBe(2);
+		expect(executed).toEqual([{ question: QUESTION }]);
+	});
+
+	it("drains accepted tool-call updates before entering tool execution", async () => {
+		const observed: string[] = [];
+		const tool: AgentTool<typeof askSchema, Record<string, never>> = {
+			...askTool([]),
+			async execute() {
+				observed.push("execute");
+				return { content: [{ type: "text", text: "answered" }], details: {} };
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({ responses: [literalTurn("tc-live"), { content: ["done"] }] });
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+
+		for await (const event of stream) {
+			if (event.type === "message_update" && event.assistantMessageEvent.type === "toolcall_end") {
+				observed.push("toolcall_end");
+			}
+		}
+
+		expect(observed).toEqual(["toolcall_end", "execute"]);
+	});
+
 	it("rejects the call once the resample budget is spent", async () => {
 		const executed: Array<Record<string, unknown>> = [];
 		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };

--- a/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
+++ b/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
@@ -12,6 +12,10 @@ function identityConverter(messages: AgentMessage[]): Message[] {
 
 const askSchema = z.object({ question: z.string() });
 
+// Decodes cleanly, but a mistyped nibble anywhere in it would be
+// indistinguishable from the correct text.
+const QUESTION = "마지막 병목";
+
 function askTool(executed: Array<Record<string, unknown>>): AgentTool<typeof askSchema, Record<string, never>> {
 	return {
 		name: "ask",
@@ -25,27 +29,60 @@ function askTool(executed: Array<Record<string, unknown>>): AgentTool<typeof ask
 	};
 }
 
+/** A turn whose raw arguments arrived spelled as `\uXXXX` instead of literal UTF-8. */
+function escapedTurn(id: string) {
+	return {
+		content: [
+			{
+				type: "toolCall" as const,
+				id,
+				name: "ask",
+				arguments: { question: QUESTION },
+				escapedNonAsciiArguments: true,
+			},
+		],
+	};
+}
+
+/** The same turn as the model would have produced it with literal UTF-8 on the wire. */
+function literalTurn(id: string) {
+	return { content: [{ type: "toolCall" as const, id, name: "ask", arguments: { question: QUESTION } }] };
+}
+
 describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
-	it("rejects a call whose arguments were spelled as \\uXXXX escapes without executing it", async () => {
+	it("resamples the turn instead of executing or reporting escaped arguments", async () => {
 		const executed: Array<Record<string, unknown>> = [];
 		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };
 		const mock = createMockModel({
-			responses: [
-				{
-					content: [
-						{
-							type: "toolCall",
-							id: "tc-1",
-							name: "ask",
-							// Decodes cleanly, but a mistyped nibble anywhere in it would be
-							// indistinguishable from correct text.
-							arguments: { question: "마지막 병목" },
-							escapedNonAsciiArguments: true,
-						},
-					],
-				},
-				{ content: ["recovered"] },
-			],
+			responses: [escapedTurn("tc-1"), literalTurn("tc-2"), { content: ["done"] }],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const toolResults: Array<{ isError?: boolean; text: string }> = [];
+		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+		for await (const event of stream) {
+			if (event.type === "tool_execution_end") {
+				const first = event.result.content?.[0];
+				toolResults.push({ isError: event.isError, text: first?.type === "text" ? first.text : "" });
+			}
+		}
+
+		// The resampled call ran; the defective one neither ran nor produced an error.
+		expect(executed).toEqual([{ question: QUESTION }]);
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0].isError).toBeFalsy();
+		// The resample must not replay the escaped arguments back to the model as
+		// its own prior output: the retried request carries no assistant turn.
+		const resampleRequest = mock.model.calls[1];
+		expect(resampleRequest).toBeDefined();
+		expect(resampleRequest.context.messages.some(message => message.role === "assistant")).toBe(false);
+	});
+
+	it("rejects the call once the resample budget is spent", async () => {
+		const executed: Array<Record<string, unknown>> = [];
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };
+		const mock = createMockModel({
+			responses: [escapedTurn("tc-1"), escapedTurn("tc-2"), escapedTurn("tc-3"), { content: ["recovered"] }],
 		});
 		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
 
@@ -69,18 +106,14 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 	it("executes literal UTF-8 arguments untouched", async () => {
 		const executed: Array<Record<string, unknown>> = [];
 		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };
-		const mock = createMockModel({
-			responses: [
-				{ content: [{ type: "toolCall", id: "tc-1", name: "ask", arguments: { question: "마지막 병목" } }] },
-				{ content: ["done"] },
-			],
-		});
+		const mock = createMockModel({ responses: [literalTurn("tc-1"), { content: ["done"] }] });
 		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
 
 		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
 		for await (const _ of stream) {
 			// drain
 		}
-		expect(executed).toEqual([{ question: "마지막 병목" }]);
+
+		expect(executed).toEqual([{ question: QUESTION }]);
 	});
 });

--- a/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
+++ b/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { agentLoop } from "@gajae-code/agent-core/agent-loop";
-import type { AgentContext, AgentLoopConfig, AgentMessage, AgentTool } from "@gajae-code/agent-core/types";
+import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AgentTool } from "@gajae-code/agent-core/types";
 import type { Message } from "@gajae-code/ai";
 import { createMockModel } from "@gajae-code/ai/providers/mock";
 import * as z from "zod/v4";
@@ -30,7 +30,7 @@ function askTool(executed: Array<Record<string, unknown>>): AgentTool<typeof ask
 }
 
 /** A turn whose raw arguments arrived spelled as `\uXXXX` instead of literal UTF-8. */
-function escapedTurn(id: string) {
+function escapedTurn(id: string, stopReason?: "aborted" | "error") {
 	return {
 		content: [
 			{
@@ -41,6 +41,7 @@ function escapedTurn(id: string) {
 				escapedNonAsciiArguments: true,
 			},
 		],
+		...(stopReason ? { stopReason } : {}),
 	};
 }
 
@@ -78,6 +79,147 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		expect(resampleRequest.context.messages.some(message => message.role === "assistant")).toBe(false);
 	});
 
+	it("preserves all pre-existing history and removes only the defective assistant turn", async () => {
+		const executed: Array<Record<string, unknown>> = [];
+		const priorAssistant = {
+			role: "assistant" as const,
+			content: [{ type: "text" as const, text: "prior answer" }],
+			api: "mock" as const,
+			provider: "mock",
+			model: "mock-model",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop" as const,
+			timestamp: 1,
+		};
+		const priorUser = createUserMessage("prior question");
+		const context: AgentContext = {
+			systemPrompt: ["system authority"],
+			messages: [priorUser, priorAssistant],
+			tools: [askTool(executed)],
+		};
+		const mock = createMockModel({ responses: [escapedTurn("tc-1"), literalTurn("tc-2"), { content: ["done"] }] });
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+		for await (const _event of stream) {
+			// drain
+		}
+
+		expect(context.systemPrompt).toEqual(["system authority"]);
+		expect(context.messages[0]).toBe(priorUser);
+		expect(context.messages[1]).toBe(priorAssistant);
+		expect(
+			context.messages.filter(
+				message =>
+					message.role === "assistant" &&
+					message.content.some(block => block.type === "toolCall" && block.id === "tc-1"),
+			),
+		).toHaveLength(0);
+	});
+
+	it("does not resample cancelled or errored turns", async () => {
+		for (const stopReason of ["aborted", "error"] as const) {
+			const executed: Array<Record<string, unknown>> = [];
+			const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };
+			const mock = createMockModel({ responses: [escapedTurn(`tc-${stopReason}`, stopReason)] });
+			const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+			const events: AgentEvent[] = [];
+
+			const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+			for await (const event of stream) events.push(event);
+
+			expect(mock.calls).toHaveLength(1);
+			expect(executed).toHaveLength(0);
+			expect(events.filter(event => event.type === "tool_execution_start")).toHaveLength(1);
+			expect(events.filter(event => event.type === "tool_execution_end")).toHaveLength(1);
+			const messageEnd = events.findLast(
+				(event): event is Extract<AgentEvent, { type: "message_end" }> =>
+					event.type === "message_end" && event.message.role === "assistant",
+			);
+			expect(messageEnd?.message.role === "assistant" ? messageEnd.message.stopReason : undefined).toBe(stopReason);
+		}
+	});
+
+	it("executes no calls from a mixed batch before validating the whole turn", async () => {
+		const executed: Array<Record<string, unknown>> = [];
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [
+						{ type: "toolCall", id: "tc-clean-never", name: "ask", arguments: { question: "ASCII" } },
+						...escapedTurn("tc-escaped").content,
+					],
+				},
+				literalTurn("tc-retry"),
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+		const toolEvents: AgentEvent[] = [];
+
+		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+		for await (const event of stream) {
+			if (event.type === "tool_execution_start" || event.type === "tool_execution_end") toolEvents.push(event);
+		}
+
+		expect(executed).toEqual([{ question: QUESTION }]);
+		expect(toolEvents.map(event => ("toolCallId" in event ? event.toolCallId : undefined))).toEqual([
+			"tc-retry",
+			"tc-retry",
+		]);
+	});
+
+	it("recovers on the second resample with clean history and one tool publication", async () => {
+		const executed: Array<Record<string, unknown>> = [];
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };
+		const mock = createMockModel({
+			responses: [escapedTurn("tc-1"), escapedTurn("tc-2"), literalTurn("tc-3"), { content: ["done"] }],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+		const toolEnds: AgentEvent[] = [];
+
+		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+		for await (const event of stream) if (event.type === "tool_execution_end") toolEnds.push(event);
+
+		expect(mock.calls).toHaveLength(4);
+		expect(mock.calls[1]?.context.messages.some(message => message.role === "assistant")).toBe(false);
+		expect(mock.calls[2]?.context.messages.some(message => message.role === "assistant")).toBe(false);
+		expect(executed).toEqual([{ question: QUESTION }]);
+		expect(toolEnds).toHaveLength(1);
+	});
+
+	it("resets the resample budget after each accepted logical turn", async () => {
+		const executed: Array<Record<string, unknown>> = [];
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };
+		const mock = createMockModel({
+			responses: [
+				escapedTurn("tc-1a"),
+				literalTurn("tc-1b"),
+				escapedTurn("tc-2a"),
+				escapedTurn("tc-2b"),
+				literalTurn("tc-2c"),
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const stream = agentLoop([createUserMessage("ask twice")], context, config, undefined, mock.stream);
+		for await (const _event of stream) {
+			// drain
+		}
+
+		expect(executed).toEqual([{ question: QUESTION }, { question: QUESTION }]);
+		expect(mock.calls).toHaveLength(6);
+	});
+
 	it("rejects the call once the resample budget is spent", async () => {
 		const executed: Array<Record<string, unknown>> = [];
 		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };
@@ -101,6 +243,54 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		expect(toolResults[0].text).toContain("\\uXXXX");
 		expect(toolResults[0].text).toContain("literal UTF-8");
 		expect(toolResults[0].text.toLowerCase()).toContain("re-issue");
+	});
+
+	it("still reaches the malformed-turn circuit breaker after persistent escaped calls", async () => {
+		const executed: Array<Record<string, unknown>> = [];
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };
+		let calls = 0;
+		const mock = createMockModel({
+			handler: () => {
+				calls += 1;
+				if (calls > 20) return { content: ["runaway"] };
+				return escapedTurn(`tc-${calls}`);
+			},
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+		for await (const _event of stream) {
+			// drain
+		}
+		const produced = await stream.result();
+		const lastAssistant = produced.findLast(message => message.role === "assistant");
+
+		expect(calls).toBeLessThan(20);
+		expect(executed).toHaveLength(0);
+		expect(lastAssistant?.role === "assistant" ? lastAssistant.stopReason : undefined).toBe("error");
+		expect(lastAssistant?.role === "assistant" ? lastAssistant.errorMessage : undefined).toContain(
+			"consecutive turns of malformed tool calls",
+		);
+	});
+
+	it("leaves managed fallback handling unchanged", async () => {
+		const executed: Array<Record<string, unknown>> = [];
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };
+		const mock = createMockModel({ responses: [escapedTurn("tc-managed"), { content: ["done"] }] });
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			fallbackManaged: true,
+		};
+		const toolResults: AgentEvent[] = [];
+
+		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+		for await (const event of stream) if (event.type === "tool_execution_end") toolResults.push(event);
+
+		expect(mock.calls).toHaveLength(2);
+		expect(executed).toHaveLength(0);
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults[0]?.type === "tool_execution_end" ? toolResults[0].isError : false).toBe(true);
 	});
 
 	it("executes literal UTF-8 arguments untouched", async () => {

--- a/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
+++ b/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { Agent } from "@gajae-code/agent-core";
 import { agentLoop } from "@gajae-code/agent-core/agent-loop";
 import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AgentTool } from "@gajae-code/agent-core/types";
 import type { Message } from "@gajae-code/ai";
@@ -45,6 +46,12 @@ function escapedTurn(id: string, stopReason?: "aborted" | "error") {
 	};
 }
 
+function escapedTurnWithText(id: string) {
+	return {
+		content: [{ type: "text" as const, text: "I will ask." }, ...escapedTurn(id).content],
+	};
+}
+
 /** The same turn as the model would have produced it with literal UTF-8 on the wire. */
 function literalTurn(id: string) {
 	return { content: [{ type: "toolCall" as const, id, name: "ask", arguments: { question: QUESTION } }] };
@@ -77,6 +84,49 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		const resampleRequest = mock.model.calls[1];
 		expect(resampleRequest).toBeDefined();
 		expect(resampleRequest.context.messages.some(message => message.role === "assistant")).toBe(false);
+	});
+
+	it("publishes and stores only the accepted assistant lifecycle", async () => {
+		const executed: Array<Record<string, unknown>> = [];
+		const mock = createMockModel({
+			responses: [escapedTurn("tc-defective"), literalTurn("tc-accepted"), { content: ["done"] }],
+		});
+		const agent = new Agent({
+			initialState: {
+				systemPrompt: [""],
+				model: mock.model,
+				tools: [askTool(executed)],
+				messages: [],
+			},
+			convertToLlm: identityConverter,
+			streamFn: mock.stream,
+		});
+		const events: AgentEvent[] = [];
+		agent.subscribe(event => events.push(event));
+
+		await agent.prompt("ask me");
+
+		const assistantEnds = events.filter(
+			(event): event is Extract<AgentEvent, { type: "message_end" }> =>
+				event.type === "message_end" && event.message.role === "assistant",
+		);
+		expect(assistantEnds).toHaveLength(2);
+		expect(
+			assistantEnds.some(event =>
+				event.message.role === "assistant"
+					? event.message.content.some(block => block.type === "toolCall" && block.id === "tc-defective")
+					: false,
+			),
+		).toBe(false);
+		expect(
+			agent.state.messages.some(
+				message =>
+					message.role === "assistant" &&
+					message.content.some(block => block.type === "toolCall" && block.id === "tc-defective"),
+			),
+		).toBe(false);
+		expect(events.filter(event => event.type === "turn_start")).toHaveLength(3);
+		expect(events.filter(event => event.type === "turn_end")).toHaveLength(2);
 	});
 
 	it("preserves all pre-existing history and removes only the defective assistant turn", async () => {
@@ -145,6 +195,22 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 			);
 			expect(messageEnd?.message.role === "assistant" ? messageEnd.message.stopReason : undefined).toBe(stopReason);
 		}
+	});
+
+	it("does not retract a turn after visible text has streamed", async () => {
+		const executed: Array<Record<string, unknown>> = [];
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };
+		const mock = createMockModel({ responses: [escapedTurnWithText("tc-visible"), { content: ["done"] }] });
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+		const toolEnds: AgentEvent[] = [];
+
+		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, mock.stream);
+		for await (const event of stream) if (event.type === "tool_execution_end") toolEnds.push(event);
+
+		expect(mock.calls).toHaveLength(2);
+		expect(executed).toHaveLength(0);
+		expect(toolEnds).toHaveLength(1);
+		expect(toolEnds[0]?.type === "tool_execution_end" ? toolEnds[0].isError : false).toBe(true);
 	});
 
 	it("executes no calls from a mixed batch before validating the whole turn", async () => {

--- a/packages/ai/src/utils/event-stream.ts
+++ b/packages/ai/src/utils/event-stream.ts
@@ -82,6 +82,11 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 		return this.#pendingConsumerDrains.size;
 	}
 
+	/** Whether an async iterator is currently consuming this stream. */
+	get hasActiveConsumer(): boolean {
+		return this.#activeConsumerCount > 0;
+	}
+
 	#settleConsumerDrain(drain: ConsumerDrain, status: "resolve" | "reject", reason?: unknown): void {
 		if (drain.settled) return;
 		drain.settled = true;


### PR DESCRIPTION
Supersedes #4490 on current `dev` while preserving probepark's authorship, measured evidence, and implementation intent.

The contributor commit is reconstructed as signed commit `d55549dc5d32a18a05085f6003fdb27b7a1fd5f5` with original author `probe <re2rar@gmail.com>`. Maintainer hardening is signed commit `bcfe159d9c8947f38a77bbc13a1de2a4bc5870d9`.

## Why a successor

#4490 head `f91f20e3457b5e49de6525b3b62644176a1c7a21` was based on `61f443d9bff05ef24cc7f2e6380da1d23e6a863b`, not its recorded PR base `cf07293f7404b35c085dde35013aa5a12d595ad5`; the exact PR head was therefore not a descendant of the PR base. Dev CI's affected-path plan failed closed because merge-base planning could not produce plan digest/source/mode. Current `dev` is `f0a44081afe3dbebeba3afb9ab380517ebd6c8d7`.

## Behavior

- Keep escaped arguments unverifiable and never execute them.
- Resample only the unmanaged path, bounded to two retries per logical turn.
- Remove exactly the defective assistant response object from history.
- Preserve user/system/prior assistant history and managed fallback policy.
- Keep terminal per-call rejection and `MAX_CONSECUTIVE_MALFORMED_TURNS` reachable.

## Added adversarial coverage

- cancellation and provider-error turns
- mixed batches with multiple tool calls before validation
- second-attempt success and clean retry history
- per-logical-turn budget reset
- persistent malformed backstop
- managed fallback unchanged
- exact prior-history preservation and single tool event publication

Closes #4489.

Signed-off evidence will be posted after exact-head CI and independent review settle.
