### PR TITLE
feat(customization): add /extensions local customization manager (#4291)

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,10 @@ The default dark TUI identity is the GJC red-claw theme; light-appearance termin
 
 ## SDK extensions
 
+### Local customization: `/extensions`
+
+In an interactive session, `/extensions` is the primary customization setup surface — it configures skills, hooks, and MCPs across the project (`<project>/.gjc/`) and user-global (`~/.gjc/agent/`) scopes, with status/provenance diagnostics, enable/disable/remove, and a guided Import-from-Claude-Code/Codex flow (normalized preview, explicit confirmation, skip/rename/overwrite collision policy, atomic writes with rollback). Non-interactive setups use `gjc mcp` for MCP servers and `gjc migrate` for Claude Code/Codex imports.
+
 ### Skill migration and bundled skill inspection
 
 When moving a workflow into GJC, inspect the bundled defaults before installing or overwriting anything:

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added `/extensions`, an interactive project/global `.gjc` manager for skills, hooks, MCPs, and explicit Claude Code/Codex imports with redacted previews and atomic rollback.
+
 ### Added
 
 - `gjc master` (or `gjc --master`) launches a resident master session that supervises other resident GJC sessions through the authoritative SDK/ACP control surface (#4448). Master sessions get a dedicated `<master-mode>` system-prompt section and a session-start hook that injects the SDK supervision guidelines plus a bounded, credential-free snapshot of the broker's resident-session inventory. Classification is fail-closed: only an explicit broker deletion tombstone counts as terminal, non-live rows are `unknown`/hands-off, and turn state is never inferred from liveness heartbeats. Continuation preserves master identity exactly through a durable per-project registry — `gjc master --continue` / `--resume <id>` resolve only recorded master sessions and refuse to convert ordinary sessions. No team mode, no delegate/worker orchestration, no pane scraping. See `docs/master-mode.md`.

--- a/packages/coding-agent/src/customization/import.ts
+++ b/packages/coding-agent/src/customization/import.ts
@@ -33,7 +33,7 @@ import { HookSourceConvention } from "../hooks/events";
 import { normalizeDirectoryHook } from "../hooks/normalize";
 import { readMCPConfigFile, writeMCPConfigFile } from "../runtime-mcp/config-writer";
 import type { MCPServerConfig } from "../runtime-mcp/types";
-import { IMPORTED_FROM_FRONTMATTER_KEY, redactDisplayText } from "./inventory";
+import { IMPORTED_FROM_FRONTMATTER_KEY } from "./inventory";
 import type {
 	ImportCollisionPolicy,
 	ImportPlan,
@@ -531,8 +531,8 @@ export async function buildImportPreview(options: BuildImportPreviewOptions): Pr
 						sourceCategory: "MCP server entry",
 						description:
 							config && "command" in config && typeof config.command === "string"
-								? redactDisplayText(`stdio MCP "${name}" (${config.command})`)
-								: `${config && "type" in config ? String(config.type) : "http"} MCP "${name}"`,
+								? `stdio MCP "${name}" (command redacted)`
+								: `${config && "type" in config ? String(config.type) : "http"} MCP "${name}" (endpoint redacted)`,
 					},
 					existing === undefined ? { kind: "absent" } : { kind: "value", content: JSON.stringify(existing) },
 					JSON.stringify(config),
@@ -573,7 +573,6 @@ interface FileSnapshot {
 }
 
 interface PlannedFileWrite {
-	entry: ImportPreviewEntry;
 	path: string;
 	content: string;
 }
@@ -715,7 +714,7 @@ export async function applyImport(plan: ImportPlan, options: { cwd: string }): P
 					`destination changed since preview for skill "${slug}"; rebuild the preview instead of overwriting silently`,
 				);
 			}
-			fileWrites.push({ entry, path: target, content: payload.skill.content });
+			fileWrites.push({ path: target, content: payload.skill.content });
 		} else if (payload.hook) {
 			const { phase, fileName } = payload.hook;
 			if (phase !== "pre" && phase !== "post") return failAll(`refusing unknown hook phase: ${String(phase)}`);
@@ -742,7 +741,7 @@ export async function applyImport(plan: ImportPlan, options: { cwd: string }): P
 					`destination changed since preview for hook "${phase}/${fileName}"; rebuild the preview instead of overwriting silently`,
 				);
 			}
-			fileWrites.push({ entry, path: target, content: payload.hook.content });
+			fileWrites.push({ path: target, content: payload.hook.content });
 		} else if (payload.mcp) {
 			mcpWrites.push({ entry, name: payload.mcp.name, config: payload.mcp.config });
 		}

--- a/packages/coding-agent/src/customization/import.ts
+++ b/packages/coding-agent/src/customization/import.ts
@@ -1,35 +1,42 @@
 /**
  * Import flow for the `/extensions` umbrella customization surface (issue #4291).
  *
- * Imports Claude Code / Codex skills, hooks, and MCP servers — from either the
- * project-local or user-global source layout — into the canonical `.gjc`
- * project/global destination. The flow is preview-first: `buildImportPreview`
- * performs all reads and normalization, applies the deterministic collision
- * policy (skip / rename / overwrite), redacts secrets from everything the UI
- * can render, and only `applyImport` writes — with journaled rollback so a
- * failed import never leaves partial state.
+ * Source layouts are consumed through the sibling contracts instead of local
+ * reimplementations:
+ * - Skills: `listConventionSkillImportSources` (#4285) — Claude `.claude/skills`
+ *   and Codex `.codex/skills` layouts, both scopes.
+ * - Hooks: Claude `.claude/hooks/<pre|post>/<file>` and Codex flat
+ *   `.codex/hooks/<phase>-<tool>.ts|js` conventions, normalized through the
+ *   canonical hook IR (`normalizeDirectoryHook`, #4286/#4289) and written to
+ *   the runtime-discovered `<root>/hooks/<pre|post>/` layout.
+ * - MCPs: `normalizeClaudeMcpJson` / `normalizeCodexMcpToml` plus
+ *   `validateMCPCompatServer` (#4284 bounded compatibility adapters), merged
+ *   through the canonical atomic config writer.
  *
- * Normalization consumes the sibling contracts instead of reimplementing them:
- * the migrate skill normalizer + MCP mapper (#4284/#4285 ownership) and the
- * canonical hook IR normalizer (#4286). Unsupported foreign semantics surface
- * as preview diagnostics, never silent drops.
+ * The preview DTO is redacted and serialization-safe; full file contents and
+ * secret values live only in the separate `ImportPlan`. `applyImport` runs as
+ * a validated transaction: every destination path is containment- and
+ * symlink-checked before any write, destinations are revalidated against the
+ * preview decisions, files are published with same-directory temp+rename, and
+ * any failure restores exactly the files this transaction wrote (pre-existing
+ * symlinks are never touched). Verification failures roll back too.
  */
-import { promises as fs } from "node:fs";
+import type { Dirent } from "node:fs";
+import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { isEnoent, parseFrontmatter } from "@gajae-code/utils";
-import { TOML, YAML } from "bun";
+import { parseFrontmatter, tryParseJson } from "@gajae-code/utils";
+import { YAML } from "bun";
+import type { MCPServer } from "../capability/mcp";
+import { normalizeClaudeMcpJson, normalizeCodexMcpToml, validateMCPCompatServer } from "../discovery/mcp-compat";
+import { listConventionSkillImportSources } from "../extensibility/skill-management";
 import { HookSourceConvention } from "../hooks/events";
 import { normalizeDirectoryHook } from "../hooks/normalize";
-import { collectMarkdownPrompts, collectSkillDir } from "../migrate/adapters/index";
-import { mapMcpEntry } from "../migrate/mcp-mapper";
-import { readMCPConfigFile, validateServerName, writeMCPConfigFile } from "../runtime-mcp/config-writer";
-import type { MCPConfigFile, MCPServerConfig } from "../runtime-mcp/types";
+import { readMCPConfigFile, writeMCPConfigFile } from "../runtime-mcp/config-writer";
+import type { MCPServerConfig } from "../runtime-mcp/types";
 import { IMPORTED_FROM_FRONTMATTER_KEY } from "./inventory";
 import type {
-	CustomizationSurface,
-	GjcScope,
 	ImportCollisionPolicy,
-	ImportPreview,
+	ImportPlan,
 	ImportPreviewEntry,
 	ImportProduct,
 	ImportResult,
@@ -42,57 +49,70 @@ import { productLabel, resolveScopePaths, sourceConfigDir, sourceScopeLabel } fr
 export interface BuildImportPreviewOptions {
 	product: ImportProduct;
 	sourceScope: ImportSourceScope;
-	destinationScope: GjcScope;
-	/** Surfaces to import; defaults to all three. */
-	surfaces?: readonly CustomizationSurface[];
+	destinationScope: "project" | "global";
+	surfaces?: readonly ("skills" | "hooks" | "mcps")[];
 	collisionPolicy: ImportCollisionPolicy;
-	/** Project working directory (project source/destination resolution). */
 	cwd: string;
-	/** Home directory root; overridable for tests. */
 	homeDir: string;
 }
 
 // ---------------------------------------------------------------------------
-// Source layouts
+// Structured filesystem reads — absent/value/error, never silent
 // ---------------------------------------------------------------------------
 
-interface SourceLayout {
-	skillsDir: string;
-	hooksDir: string;
-	/** Product-specific MCP config file (`.claude.json` / `.mcp.json` / `config.toml`). */
-	mcpConfigPath: string;
-	/** How MCP entries are encoded in that file. */
-	mcpFormat: "json-mcpServers" | "toml-mcp_servers";
-	/** How skills are encoded: SKILL.md directories (Claude) or markdown prompts (Codex). */
-	skillFormat: "skill-dirs" | "markdown-prompts";
+type ReadResult = { kind: "absent" } | { kind: "value"; content: string } | { kind: "error"; message: string };
+
+function isEnoent(error: unknown): boolean {
+	return (error as NodeJS.ErrnoException)?.code === "ENOENT";
 }
 
-function sourceLayout(
-	product: ImportProduct,
-	sourceScope: ImportSourceScope,
-	cwd: string,
-	homeDir: string,
-): SourceLayout {
-	const configDir = sourceConfigDir(product, sourceScope, cwd, homeDir);
-	if (product === "claude-code") {
-		return {
-			skillsDir: path.join(configDir, "skills"),
-			hooksDir: path.join(configDir, "hooks"),
-			// Project-scope Claude MCP servers live in `<project>/.mcp.json`;
-			// user-global servers live in `~/.claude.json`.
-			mcpConfigPath: sourceScope === "project" ? path.join(cwd, ".mcp.json") : path.join(homeDir, ".claude.json"),
-			mcpFormat: "json-mcpServers",
-			skillFormat: "skill-dirs",
-		};
+/** Read a regular file. Symlinks and non-files are errors, never "absent". */
+async function readStructured(filePath: string): Promise<ReadResult> {
+	let stat: Awaited<ReturnType<typeof fs.lstat>>;
+	try {
+		stat = await fs.lstat(filePath);
+	} catch (error) {
+		if (isEnoent(error)) return { kind: "absent" };
+		return { kind: "error", message: `cannot stat ${filePath}: ${(error as Error).message}` };
 	}
-	return {
-		// Codex "skills" are markdown prompts; both scopes follow the same layout.
-		skillsDir: path.join(configDir, "prompts"),
-		hooksDir: path.join(configDir, "hooks"),
-		mcpConfigPath: path.join(configDir, "config.toml"),
-		mcpFormat: "toml-mcp_servers",
-		skillFormat: "markdown-prompts",
-	};
+	if (stat.isSymbolicLink()) return { kind: "error", message: `refusing unsafe symlink: ${filePath}` };
+	if (!stat.isFile()) return { kind: "error", message: `not a regular file: ${filePath}` };
+	try {
+		return { kind: "value", content: await fs.readFile(filePath, "utf-8") };
+	} catch (error) {
+		if (isEnoent(error)) return { kind: "absent" };
+		return { kind: "error", message: `failed to read ${filePath}: ${(error as Error).message}` };
+	}
+}
+
+async function listDirNames(dir: string, kind: "file" | "directory"): Promise<string[]> {
+	let entries: Dirent[];
+	try {
+		entries = await fs.readdir(dir, { withFileTypes: true });
+	} catch {
+		return [];
+	}
+	return entries
+		.filter(entry => (kind === "file" ? entry.isFile() : entry.isDirectory()) && !entry.name.startsWith("."))
+		.map(entry => entry.name)
+		.sort();
+}
+
+// ---------------------------------------------------------------------------
+// Name safety
+// ---------------------------------------------------------------------------
+
+/** A destination name must be a single safe path segment. */
+function isSafeName(name: string): boolean {
+	return (
+		name.length > 0 &&
+		name !== "." &&
+		name !== ".." &&
+		!name.includes("/") &&
+		!name.includes("\\") &&
+		!name.includes("\0") &&
+		!name.split("").some(ch => ch < " ")
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -102,79 +122,12 @@ function sourceLayout(
 /** Inject the imported-from provenance key into a normalized SKILL.md. */
 function withImportProvenance(content: string, product: ImportProduct): string {
 	const { frontmatter, body } = parseFrontmatter(content, { level: "off" });
-	const fm: Record<string, unknown> = { ...frontmatter, [IMPORTED_FROM_FRONTMATTER_KEY]: product };
+	// parseFrontmatter camelCases keys; drop a prior camelized marker so the
+	// canonical kebab-case key is written exactly once.
+	const { xGjcImportedFrom: _priorMarker, ...rest } = frontmatter;
+	const fm: Record<string, unknown> = { ...rest, [IMPORTED_FROM_FRONTMATTER_KEY]: product };
 	const yaml = YAML.stringify(fm).trimEnd();
 	return `---\n${yaml}\n---\n\n${body.trim()}\n`;
-}
-
-// ---------------------------------------------------------------------------
-// Source collection
-// ---------------------------------------------------------------------------
-
-async function readJsonMcpServers(filePath: string): Promise<{ servers: Record<string, unknown> } | { error: string }> {
-	let text: string;
-	try {
-		text = await fs.readFile(filePath, "utf-8");
-	} catch (error) {
-		if (isEnoent(error)) return { servers: {} };
-		return { error: `failed to read ${filePath}: ${(error as Error).message}` };
-	}
-	try {
-		const data = JSON.parse(text) as Record<string, unknown>;
-		const servers = data?.mcpServers;
-		if (servers && typeof servers === "object" && !Array.isArray(servers)) {
-			return { servers: servers as Record<string, unknown> };
-		}
-		return { servers: {} };
-	} catch (error) {
-		return { error: `invalid JSON in ${filePath}: ${(error as Error).message}` };
-	}
-}
-
-async function readTomlMcpServers(filePath: string): Promise<{ servers: Record<string, unknown> } | { error: string }> {
-	let text: string;
-	try {
-		text = await fs.readFile(filePath, "utf-8");
-	} catch (error) {
-		if (isEnoent(error)) return { servers: {} };
-		return { error: `failed to read ${filePath}: ${(error as Error).message}` };
-	}
-	try {
-		const data = TOML.parse(text) as Record<string, unknown>;
-		const servers = data?.mcp_servers;
-		if (servers && typeof servers === "object" && !Array.isArray(servers)) {
-			return { servers: servers as Record<string, unknown> };
-		}
-		return { servers: {} };
-	} catch (error) {
-		return { error: `invalid TOML in ${filePath}: ${(error as Error).message}` };
-	}
-}
-
-interface RawHookCandidate {
-	fileName: string;
-	filePath: string;
-	content: string;
-}
-
-async function collectSourceHooks(hooksDir: string): Promise<RawHookCandidate[]> {
-	let names: string[];
-	try {
-		names = await fs.readdir(hooksDir);
-	} catch {
-		return [];
-	}
-	const candidates: RawHookCandidate[] = [];
-	for (const name of names.sort()) {
-		if (!/\.(ts|js)$/.test(name)) continue;
-		const filePath = path.join(hooksDir, name);
-		try {
-			const stat = await fs.lstat(filePath);
-			if (!stat.isFile() || stat.isSymbolicLink()) continue;
-			candidates.push({ fileName: name, filePath, content: await fs.readFile(filePath, "utf-8") });
-		} catch {}
-	}
-	return candidates;
 }
 
 // ---------------------------------------------------------------------------
@@ -193,14 +146,18 @@ function renamedDestination(base: string, taken: (name: string) => boolean): str
 }
 
 function applyCollision(
-	entry: Omit<ImportPreviewEntry, "status"> & { status?: ImportPreviewEntry["status"] },
-	exists: boolean,
-	identical: boolean,
+	entry: Omit<ImportPreviewEntry, "status">,
+	existing: ReadResult,
+	identicalContent: string | undefined,
 	policy: ImportCollisionPolicy,
 	rename: (base: string) => string,
 ): ImportPreviewEntry {
-	if (!exists) return { ...entry, status: entry.status ?? "add" };
-	if (identical) {
+	if (existing.kind === "error") {
+		return { ...entry, status: "conflict", reason: `destination is unsafe or unreadable: ${existing.message}` };
+	}
+	const exists = existing.kind === "value";
+	if (!exists) return { ...entry, status: "add" };
+	if (identicalContent !== undefined && existing.content === identicalContent) {
 		return {
 			...entry,
 			status: "conflict",
@@ -225,66 +182,220 @@ function applyCollision(
 }
 
 // ---------------------------------------------------------------------------
+// Hook source candidates
+// ---------------------------------------------------------------------------
+
+const CLAUDE_HOOK_EXTENSIONS = [".sh", ".bash", ".zsh", ".fish", ".ts", ".js"] as const;
+
+interface HookCandidate {
+	phase: "pre" | "post";
+	fileName: string;
+	filePath: string;
+	toolName: string;
+	sourceCategory: string;
+}
+
+async function collectSourceHooks(
+	product: ImportProduct,
+	configDir: string,
+): Promise<{ candidates: HookCandidate[]; warnings: string[] }> {
+	const candidates: HookCandidate[] = [];
+	const warnings: string[] = [];
+	if (product === "claude-code") {
+		// Canonical Claude layout: `.claude/hooks/<pre|post>/<file>`.
+		for (const phase of ["pre", "post"] as const) {
+			const dir = path.join(configDir, "hooks", phase);
+			for (const fileName of await listDirNames(dir, "file")) {
+				const ext = CLAUDE_HOOK_EXTENSIONS.find(e => fileName.endsWith(e));
+				if (!ext) {
+					warnings.push(`skipped ${phase} hook "${fileName}": unsupported extension`);
+					continue;
+				}
+				candidates.push({
+					phase,
+					fileName,
+					filePath: path.join(dir, fileName),
+					toolName: fileName.slice(0, -ext.length),
+					sourceCategory: `hook file (${phase}/)`,
+				});
+			}
+		}
+		return { candidates, warnings };
+	}
+	// Canonical Codex layout: flat `.codex/hooks/<phase>-<tool>.ts|js`.
+	const dir = path.join(configDir, "hooks");
+	for (const fileName of await listDirNames(dir, "file")) {
+		const match = fileName.match(/^(pre|post)-(.+)\.(ts|js)$/);
+		if (!match) {
+			warnings.push(
+				`skipped hook "${fileName}": filename must follow the pre-<tool>.ts|js or post-<tool>.ts|js convention`,
+			);
+			continue;
+		}
+		candidates.push({
+			phase: match[1] as "pre" | "post",
+			fileName,
+			filePath: path.join(dir, fileName),
+			toolName: match[2],
+			sourceCategory: "hook file (flat)",
+		});
+	}
+	return { candidates, warnings };
+}
+
+// ---------------------------------------------------------------------------
+// MCP source config path
+// ---------------------------------------------------------------------------
+
+function sourceMcpConfigPath(
+	product: ImportProduct,
+	sourceScope: ImportSourceScope,
+	cwd: string,
+	homeDir: string,
+): string {
+	if (product === "claude-code") {
+		// Project-scope Claude MCP servers live in `<project>/.mcp.json`;
+		// user-global servers live in `~/.claude.json`.
+		return sourceScope === "project" ? path.join(cwd, ".mcp.json") : path.join(homeDir, ".claude.json");
+	}
+	return path.join(sourceConfigDir(product, sourceScope, cwd, homeDir), "config.toml");
+}
+
+/** Map a normalized compat MCPServer onto the canonical config writer shape. */
+function toMCPServerConfig(server: MCPServer): MCPServerConfig {
+	const config: Record<string, unknown> = {};
+	if (server.transport) config.type = server.transport;
+	if (server.command !== undefined) config.command = server.command;
+	if (server.args !== undefined) config.args = server.args;
+	if (server.env !== undefined) config.env = server.env;
+	if (server.cwd !== undefined) config.cwd = server.cwd;
+	if (server.url !== undefined) config.url = server.url;
+	if (server.headers !== undefined) config.headers = server.headers;
+	if (server.enabled !== undefined) config.enabled = server.enabled;
+	if (server.autoload !== undefined) config.autoload = server.autoload;
+	if (server.timeout !== undefined) config.timeout = server.timeout;
+	if (server.sharing !== undefined) config.sharing = server.sharing;
+	if (server.noInheritEnv !== undefined) config.noInheritEnv = server.noInheritEnv;
+	return config as unknown as MCPServerConfig;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+interface DestinationMcpState {
+	/** Existing server entries, or null when the destination is unusable. */
+	servers: Record<string, unknown> | null;
+	/** Why the destination is unusable (malformed/unsafe), when servers is null. */
+	error?: string;
+}
+
+async function readDestinationMcpState(mcpConfigPath: string): Promise<DestinationMcpState> {
+	const read = await readStructured(mcpConfigPath);
+	if (read.kind === "absent") return { servers: {} };
+	if (read.kind === "error") return { servers: null, error: read.message };
+	const json = tryParseJson<Record<string, unknown>>(read.content);
+	if (!json || !isRecord(json)) {
+		return { servers: null, error: `destination ${mcpConfigPath} is malformed; MCP entries cannot be imported` };
+	}
+	if (json.mcpServers !== undefined && !isRecord(json.mcpServers)) {
+		return {
+			servers: null,
+			error: `destination ${mcpConfigPath} has a non-object mcpServers value; MCP entries cannot be imported`,
+		};
+	}
+	return { servers: (json.mcpServers as Record<string, unknown> | undefined) ?? {} };
+}
+
+// ---------------------------------------------------------------------------
 // Preview
 // ---------------------------------------------------------------------------
 
 /**
  * Read the selected source product/scope, normalize every candidate through
- * the sibling contracts, and produce a redacted preview. Pure reads only —
- * nothing is written until `applyImport`.
+ * the sibling contracts, and produce a redacted preview plus an opaque apply
+ * plan. Pure reads only — nothing is written until `applyImport`.
  */
-export async function buildImportPreview(options: BuildImportPreviewOptions): Promise<ImportPreview> {
+export async function buildImportPreview(options: BuildImportPreviewOptions): Promise<ImportPlan> {
 	const surfaces = options.surfaces ?? (["skills", "hooks", "mcps"] as const);
-	const takenSkillNames = new Set<string>();
-	const takenHookNames = new Set<string>();
-	const takenMcpNames = new Set<string>();
-	const layout = sourceLayout(options.product, options.sourceScope, options.cwd, options.homeDir);
 	const destination = resolveScopePaths(options.destinationScope, options.cwd);
 	const entries: ImportPreviewEntry[] = [];
+	const payloads: (NormalizedPayload | undefined)[] = [];
 	const warnings: string[] = [];
 	const productName = productLabel(options.product);
 	const sourceLabel = `${productName} ${sourceScopeLabel(options.sourceScope)}`;
 
+	const push = (entry: ImportPreviewEntry, payload?: NormalizedPayload): void => {
+		entries.push(entry);
+		payloads.push(payload);
+	};
+
 	// --- Skills -------------------------------------------------------------
 	if (surfaces.includes("skills")) {
-		const collected =
-			layout.skillFormat === "skill-dirs"
-				? await collectSkillDir(layout.skillsDir, options.product)
-				: await collectMarkdownPrompts(layout.skillsDir, options.product);
-		for (const diagnostic of collected.diagnostics) {
-			warnings.push(`${sourceLabel} skills: ${diagnostic.message}`);
-		}
-		for (const candidate of collected.candidates) {
-			const slug = candidate.slug;
-			const content = withImportProvenance(candidate.content, options.product);
-			const destPath = path.join(destination.skillsDir, slug, "SKILL.md");
-			const existing = await readIfExists(destPath);
-			const payload: NormalizedPayload = { skill: { slug, content } };
+		const host = options.product === "claude-code" ? "claude" : "codex";
+		const sources = await listConventionSkillImportSources({ cwd: options.cwd, home: options.homeDir, host });
+		const scoped = sources.filter(source =>
+			options.sourceScope === "project" ? source.scope === "project" : source.scope === "user",
+		);
+		const takenSkillNames = new Set(await listDirNames(destination.skillsDir, "directory"));
+		for (const source of scoped) {
+			const slug = source.name;
+			if (!isSafeName(slug)) {
+				push({
+					surface: "skills",
+					sourceName: slug,
+					destinationName: slug,
+					status: "unsupported",
+					sourceCategory: "skill directory",
+					description: `import skill "${slug}"`,
+					reason: "unsafe skill name (path separators, control characters, or traversal segments are not allowed)",
+				});
+				continue;
+			}
+			const read = await readStructured(source.path);
+			if (read.kind !== "value") {
+				push({
+					surface: "skills",
+					sourceName: slug,
+					destinationName: slug,
+					status: "unsupported",
+					sourceCategory: "skill directory",
+					description: `import skill "${slug}"`,
+					reason: read.kind === "error" ? read.message : `no SKILL.md content at ${source.path}`,
+				});
+				continue;
+			}
+			const content = withImportProvenance(read.content, options.product);
+			const { frontmatter } = parseFrontmatter(content, { level: "off" });
+			const description = typeof frontmatter.description === "string" ? frontmatter.description.trim() : "";
+			if (!description) {
+				push({
+					surface: "skills",
+					sourceName: slug,
+					destinationName: slug,
+					status: "unsupported",
+					sourceCategory: "skill directory",
+					description: `import skill "${slug}"`,
+					reason: "skill frontmatter must include a non-empty description",
+				});
+				continue;
+			}
+			const existing = await readStructured(path.join(destination.skillsDir, slug, "SKILL.md"));
 			const entry = applyCollision(
 				{
 					surface: "skills",
 					sourceName: slug,
 					destinationName: slug,
-					sourceCategory: layout.skillFormat === "skill-dirs" ? "skill directory" : "markdown prompt",
+					sourceCategory: "skill directory",
 					description: `import skill "${slug}" into ${destination.skillsDir}`,
-					_payload: payload,
 				},
-				existing !== null,
-				existing === content,
+				existing,
+				content,
 				options.collisionPolicy,
 				base => renamedDestination(base, name => takenSkillNames.has(name)),
 			);
 			takenSkillNames.add(entry.destinationName);
-			if (entry.destinationName !== slug && entry._payload?.skill) {
-				entry._payload = {
-					skill: {
-						slug: entry.destinationName,
-						content: withImportProvenance(candidate.content, options.product),
-					},
-				};
-			}
-			for (const warning of candidate.warnings) warnings.push(`${sourceLabel} skill "${slug}": ${warning}`);
-			entries.push(entry);
+			push(entry, { skill: { slug: entry.destinationName, content } });
 		}
 	}
 
@@ -292,186 +403,167 @@ export async function buildImportPreview(options: BuildImportPreviewOptions): Pr
 	if (surfaces.includes("hooks")) {
 		const convention =
 			options.product === "claude-code" ? HookSourceConvention.ClaudeCode : HookSourceConvention.Codex;
-		const candidates = await collectSourceHooks(layout.hooksDir);
-		for (const candidate of candidates) {
-			const baseName = candidate.fileName.replace(/\.(ts|js)$/, "");
-			const match = baseName.match(/^(pre|post)-(.+)$/);
-			if (!match) {
-				entries.push({
-					surface: "hooks",
-					sourceName: candidate.fileName,
-					destinationName: candidate.fileName,
-					status: "unsupported",
-					sourceCategory: "hook file",
-					description: `hook file "${candidate.fileName}"`,
-					reason: `filename must follow the pre-<tool>.ts|js or post-<tool>.ts|js convention`,
-				});
-				continue;
+		const configDir = sourceConfigDir(options.product, options.sourceScope, options.cwd, options.homeDir);
+		const collected = await collectSourceHooks(options.product, configDir);
+		for (const warning of collected.warnings) warnings.push(`${sourceLabel} hooks: ${warning}`);
+		// Destination identity is the canonical phase-relative path.
+		const takenHookPaths = new Set<string>();
+		for (const phase of ["pre", "post"] as const) {
+			for (const fileName of await listDirNames(path.join(destination.hooksDir, phase), "file")) {
+				takenHookPaths.add(`${phase}/${fileName}`);
 			}
-			const phase = match[1] as "pre" | "post";
-			const toolName = match[2];
+		}
+		for (const candidate of collected.candidates) {
+			const relDest = `${candidate.phase}/${candidate.fileName}`;
 			const normalized = normalizeDirectoryHook({
 				convention,
-				phase,
-				toolName,
+				phase: candidate.phase,
+				toolName: candidate.toolName,
 				source: candidate.filePath,
 				externalName: candidate.fileName,
 			});
 			if (!normalized.hook) {
-				entries.push({
+				push({
 					surface: "hooks",
-					sourceName: candidate.fileName,
-					destinationName: candidate.fileName,
+					sourceName: relDest,
+					destinationName: relDest,
 					status: "unsupported",
-					sourceCategory: "hook file",
-					description: `${phase} hook for ${toolName}`,
+					sourceCategory: candidate.sourceCategory,
+					description: `${candidate.phase} hook for ${candidate.toolName}`,
 					reason: normalized.diagnostics.map(d => `${d.code}: ${d.message}`).join("; "),
 				});
 				continue;
 			}
-			const destPath = path.join(destination.hooksDir, candidate.fileName);
-			const existing = await readIfExists(destPath);
-			const payload: NormalizedPayload = {
-				hook: {
-					sourceName: candidate.fileName,
-					destinationName: candidate.fileName,
-					content: candidate.content,
-					warnings: [],
-				},
-			};
+			const read = await readStructured(candidate.filePath);
+			if (read.kind !== "value") {
+				push({
+					surface: "hooks",
+					sourceName: relDest,
+					destinationName: relDest,
+					status: "unsupported",
+					sourceCategory: candidate.sourceCategory,
+					description: `${candidate.phase} hook for ${candidate.toolName}`,
+					reason: read.kind === "error" ? read.message : `no hook content at ${candidate.filePath}`,
+				});
+				continue;
+			}
+			const existing = await readStructured(path.join(destination.hooksDir, candidate.phase, candidate.fileName));
 			const entry = applyCollision(
 				{
 					surface: "hooks",
-					sourceName: candidate.fileName,
-					destinationName: candidate.fileName,
-					sourceCategory: "hook file",
-					description: `${phase} hook for ${toolName} (${normalized.hook.contract.runtimeEvent})`,
-					_payload: payload,
+					sourceName: relDest,
+					destinationName: relDest,
+					sourceCategory: candidate.sourceCategory,
+					description: `${candidate.phase} hook for ${candidate.toolName} (${normalized.hook.contract.runtimeEvent})`,
 				},
-				existing !== null,
-				existing === candidate.content,
+				existing,
+				read.content,
 				options.collisionPolicy,
 				base => {
-					const renamed = renamedDestination(base.replace(/\.(ts|js)$/, ""), name =>
-						takenHookNames.has(`${name}.ts`),
-					);
-					return `${renamed}${path.extname(base)}`;
+					const ext = path.extname(base);
+					const stem = base.slice(candidate.phase.length + 1, base.length - ext.length);
+					const renamed = renamedDestination(stem, name => takenHookPaths.has(`${candidate.phase}/${name}${ext}`));
+					return `${candidate.phase}/${renamed}${ext}`;
 				},
 			);
-			if (entry.destinationName !== candidate.fileName && entry._payload?.hook) {
-				entry._payload = { hook: { ...entry._payload.hook, destinationName: entry.destinationName } };
-			}
-			takenHookNames.add(entry.destinationName);
-			entries.push(entry);
+			takenHookPaths.add(entry.destinationName);
+			push(entry, {
+				hook: {
+					phase: candidate.phase,
+					fileName: entry.destinationName.slice(candidate.phase.length + 1),
+					content: read.content,
+				},
+			});
 		}
 	}
 
 	// --- MCPs ---------------------------------------------------------------
 	if (surfaces.includes("mcps")) {
-		const read =
-			layout.mcpFormat === "json-mcpServers"
-				? await readJsonMcpServers(layout.mcpConfigPath)
-				: await readTomlMcpServers(layout.mcpConfigPath);
-		if ("error" in read) {
-			warnings.push(`${sourceLabel} MCPs: ${read.error}`);
-		} else {
-			const existingConfig = await readMCPConfigFile(destination.mcpConfigPath).catch(() => null);
-			if (existingConfig === null) {
-				warnings.push(`destination ${destination.mcpConfigPath} is malformed; MCP entries cannot be imported`);
+		const sourcePath = sourceMcpConfigPath(options.product, options.sourceScope, options.cwd, options.homeDir);
+		const read = await readStructured(sourcePath);
+		if (read.kind === "error") {
+			warnings.push(`${sourceLabel} MCPs: ${read.message}`);
+		}
+		const normalized =
+			read.kind === "value"
+				? options.product === "claude-code"
+					? normalizeClaudeMcpJson(read.content, sourcePath, options.sourceScope)
+					: normalizeCodexMcpToml(read.content, sourcePath, options.sourceScope)
+				: { items: [], warnings: [] as string[] };
+		for (const warning of normalized.warnings) warnings.push(`${sourceLabel} MCPs: ${warning}`);
+		if (normalized.items.length > 0) {
+			const destState = await readDestinationMcpState(destination.mcpConfigPath);
+			if (destState.servers === null) {
+				warnings.push(destState.error ?? `destination ${destination.mcpConfigPath} is unusable`);
 			}
-			const existingServers = existingConfig?.mcpServers ?? {};
-			for (const [name, raw] of Object.entries(read.servers)) {
-				const nameError = validateServerName(name);
-				if (nameError) {
-					entries.push({
+			const existingServers = destState.servers ?? {};
+			const takenMcpNames = new Set(Object.keys(existingServers));
+			for (const server of normalized.items) {
+				const name = server.name;
+				const invalidReason = !isSafeName(name)
+					? "unsafe MCP server name (path separators, control characters, or traversal segments are not allowed)"
+					: validateMCPCompatServer(server);
+				if (invalidReason || destState.servers === null) {
+					push({
 						surface: "mcps",
 						sourceName: name,
 						destinationName: name,
 						status: "unsupported",
 						sourceCategory: "MCP server entry",
 						description: `MCP server "${name}"`,
-						reason: nameError,
+						reason: invalidReason ?? destState.error ?? "destination MCP config is unusable",
 					});
 					continue;
 				}
-				const mapped = mapMcpEntry(options.product, name, raw);
-				if (!mapped.ok) {
-					entries.push({
-						surface: "mcps",
-						sourceName: name,
-						destinationName: name,
-						status: "unsupported",
-						sourceCategory: "MCP server entry",
-						description: `MCP server "${name}"`,
-						reason: mapped.reason,
-					});
-					continue;
-				}
-				for (const warning of mapped.warnings) warnings.push(`${sourceLabel} MCP "${name}": ${warning}`);
+				const config = toMCPServerConfig(server);
 				const existing = existingServers[name];
 				const secretKeys = [
-					...("env" in mapped.config && mapped.config.env
-						? Object.keys(mapped.config.env).map(k => `env:${k}`)
-						: []),
-					...("headers" in mapped.config && mapped.config.headers
-						? Object.keys(mapped.config.headers).map(k => `header:${k}`)
+					...(config && "env" in config && config.env ? Object.keys(config.env).map(k => `env:${k}`) : []),
+					...(config && "headers" in config && config.headers
+						? Object.keys(config.headers).map(k => `header:${k}`)
 						: []),
 				];
-				const payload: NormalizedPayload = { mcp: { name, config: mapped.config } };
-				const baseEntry = {
-					surface: "mcps" as const,
-					sourceName: name,
-					destinationName: name,
-					sourceCategory: "MCP server entry",
-					description:
-						mapped.config.type === "stdio"
-							? `stdio MCP "${name}" (${mapped.config.command})`
-							: `${mapped.config.type ?? "http"} MCP "${name}"`,
-					_payload: payload,
-				};
 				const entry = applyCollision(
-					baseEntry,
-					existing !== undefined,
-					existing !== undefined && JSON.stringify(existing) === JSON.stringify(mapped.config),
+					{
+						surface: "mcps",
+						sourceName: name,
+						destinationName: name,
+						sourceCategory: "MCP server entry",
+						description:
+							config && "command" in config && typeof config.command === "string"
+								? `stdio MCP "${name}" (${config.command})`
+								: `${config && "type" in config ? String(config.type) : "http"} MCP "${name}"`,
+					},
+					existing === undefined ? { kind: "absent" } : { kind: "value", content: JSON.stringify(existing) },
+					JSON.stringify(config),
 					options.collisionPolicy,
-					base =>
-						renamedDestination(base, candidate => takenMcpNames.has(candidate) || candidate in existingServers),
+					base => renamedDestination(base, candidate => takenMcpNames.has(candidate)),
 				);
-				if (entry.destinationName !== name && entry._payload?.mcp) {
-					entry._payload = { mcp: { name: entry.destinationName, config: mapped.config } };
-				}
 				takenMcpNames.add(entry.destinationName);
 				if (secretKeys.length > 0 && (entry.status === "add" || entry.status === "overwrite")) {
 					entry.status = "redacted";
 					entry.reason = `${entry.reason ? `${entry.reason}; ` : ""}secret values hidden in preview (keys: ${secretKeys.join(", ")})`;
 				}
-				entries.push(entry);
+				push(entry, { mcp: { name: entry.destinationName, config } });
 			}
 		}
 	}
 
 	return {
-		product: options.product,
-		sourceScope: options.sourceScope,
-		destinationScope: options.destinationScope,
-		surfaces: [...surfaces],
-		entries,
-		warnings,
+		preview: {
+			product: options.product,
+			sourceScope: options.sourceScope,
+			destinationScope: options.destinationScope,
+			surfaces: [...surfaces],
+			entries,
+			warnings,
+		},
+		payloads,
 	};
 }
 
-async function readIfExists(filePath: string): Promise<string | null> {
-	try {
-		const stat = await fs.lstat(filePath);
-		if (!stat.isFile() || stat.isSymbolicLink()) return null;
-		return await fs.readFile(filePath, "utf-8");
-	} catch {
-		return null;
-	}
-}
-
 // ---------------------------------------------------------------------------
-// Apply (journaled rollback)
+// Apply (validated transaction: staged atomic writes + journaled rollback)
 // ---------------------------------------------------------------------------
 
 interface FileSnapshot {
@@ -480,150 +572,293 @@ interface FileSnapshot {
 	previous: string | null;
 }
 
+interface PlannedFileWrite {
+	entry: ImportPreviewEntry;
+	path: string;
+	content: string;
+}
+
 /**
- * Apply a confirmed preview. Writes are bounded and journaled: every file a
- * write touches is snapshotted first, and any failure restores all snapshots
- * (no partial import). MCP entries are merged into one in-memory config and
- * written atomically via the canonical config writer.
+ * Walk `root` itself and every existing component down to `target`'s parent
+ * directory; return the first symlinked component, or null. A target outside
+ * `root` is reported as the root itself (containment is checked separately).
  */
-export async function applyImport(preview: ImportPreview, options: { cwd: string }): Promise<ImportResult> {
+async function findSymlinkedAncestor(root: string, target: string): Promise<string | null> {
+	const relative = path.relative(root, path.dirname(target));
+	if (relative.startsWith("..") || path.isAbsolute(relative)) return root;
+	const segments = relative === "" ? [] : relative.split(path.sep);
+	let current = root;
+	try {
+		const stat = await fs.lstat(current);
+		if (stat.isSymbolicLink()) return current;
+	} catch (error) {
+		if (!isEnoent(error)) throw error;
+		return null;
+	}
+	for (const segment of segments) {
+		current = path.join(current, segment);
+		try {
+			const stat = await fs.lstat(current);
+			if (stat.isSymbolicLink()) return current;
+		} catch (error) {
+			if (isEnoent(error)) return null;
+			throw error;
+		}
+	}
+	return null;
+}
+
+/** Remove stale staging temp files from an interrupted earlier apply. */
+async function sweepStagingTemps(dir: string): Promise<void> {
+	let names: string[];
+	try {
+		names = await fs.readdir(dir);
+	} catch {
+		return;
+	}
+	for (const name of names) {
+		if (!name.includes(".gjc-import-") || !name.endsWith(".tmp")) continue;
+		await fs.rm(path.join(dir, name), { force: true }).catch(() => {});
+	}
+}
+
+/**
+ * Apply a confirmed plan. The transaction contract:
+ *
+ * 1. Pre-validation — every destination path is derived from validated plan
+ *    identities (never raw payload names), containment-checked beneath the
+ *    canonical scope directories, and walked for symlinked ancestors; the
+ *    destination MCP config shape is validated; add/rename destinations are
+ *    revalidated against the preview decision (stale previews fail closed).
+ *    Any problem aborts the whole apply before a single write.
+ * 2. Publication — each skill/hook file is written to a same-directory temp
+ *    file (0600) and atomically renamed into place; MCP entries merge into one
+ *    in-memory config written once via the canonical atomic writer. Only
+ *    files this transaction actually publishes enter the rollback journal.
+ * 3. Verification — persisted state is re-read inside the transaction; a
+ *    verification mismatch rolls back exactly like a write failure.
+ * 4. Rollback — restores journal snapshots (or removes created files) and
+ *    reports every restore failure honestly instead of claiming success.
+ */
+export async function applyImport(plan: ImportPlan, options: { cwd: string }): Promise<ImportResult> {
+	const { preview } = plan;
 	const destination = resolveScopePaths(preview.destinationScope, options.cwd);
 	const results: ImportResultEntry[] = [];
-	const snapshots: FileSnapshot[] = [];
-	const written: ImportPreviewEntry[] = [];
 
-	const writable = preview.entries.filter(
-		entry => entry.status === "add" || entry.status === "overwrite" || entry.status === "redacted",
-	);
-	for (const entry of preview.entries) {
-		if (entry.status === "conflict") {
+	const writable: Array<{ entry: ImportPreviewEntry; payload: NormalizedPayload }> = [];
+	preview.entries.forEach((entry, index) => {
+		const payload = plan.payloads[index];
+		if (entry.status === "conflict" || entry.status === "unsupported") {
 			results.push({
 				surface: entry.surface,
 				sourceName: entry.sourceName,
 				destinationName: entry.destinationName,
 				outcome: "skipped",
-				reason: entry.reason,
+				reason: entry.reason ?? (entry.status === "unsupported" ? "unsupported semantics" : undefined),
 			});
-		} else if (entry.status === "unsupported") {
-			results.push({
-				surface: entry.surface,
-				sourceName: entry.sourceName,
-				destinationName: entry.destinationName,
-				outcome: "skipped",
-				reason: entry.reason ?? "unsupported semantics",
-			});
+			return;
 		}
-	}
-
-	// Snapshot skill/hook destinations.
-	const skillHookWrites: Array<{ entry: ImportPreviewEntry; path: string; content: string }> = [];
-	const mcpWrites: Array<{ entry: ImportPreviewEntry; name: string; config: MCPServerConfig }> = [];
-	for (const entry of writable) {
-		if (entry.surface === "skills" && entry._payload?.skill) {
-			const slug = entry._payload.skill.slug;
-			skillHookWrites.push({
-				entry,
-				path: path.join(destination.skillsDir, slug, "SKILL.md"),
-				content: entry._payload.skill.content,
-			});
-		} else if (entry.surface === "hooks" && entry._payload?.hook) {
-			skillHookWrites.push({
-				entry,
-				path: path.join(destination.hooksDir, entry._payload.hook.destinationName),
-				content: entry._payload.hook.content,
-			});
-		} else if (entry.surface === "mcps" && entry._payload?.mcp) {
-			mcpWrites.push({ entry, name: entry._payload.mcp.name, config: entry._payload.mcp.config });
-		}
-	}
-
-	try {
-		for (const write of skillHookWrites) {
-			snapshots.push({ path: write.path, previous: await readIfExists(write.path) });
-		}
-		let mcpConfig: MCPConfigFile | null = null;
-		if (mcpWrites.length > 0) {
-			mcpConfig = await readMCPConfigFile(destination.mcpConfigPath);
-			snapshots.push({
-				path: destination.mcpConfigPath,
-				previous: await readIfExists(destination.mcpConfigPath),
-			});
-		}
-
-		// Write skill/hook files.
-		for (const write of skillHookWrites) {
-			await fs.mkdir(path.dirname(write.path), { recursive: true, mode: 0o700 });
-			const stat = await fs.lstat(write.path).catch(() => null);
-			if (stat?.isSymbolicLink()) throw new Error(`refusing to write through symlink: ${write.path}`);
-			await fs.writeFile(write.path, write.content, { encoding: "utf-8", mode: 0o600 });
-			written.push(write.entry);
-		}
-
-		// Merge + single atomic MCP config write.
-		if (mcpConfig && mcpWrites.length > 0) {
-			const servers = { ...(mcpConfig.mcpServers ?? {}) };
-			for (const write of mcpWrites) {
-				servers[write.name] = write.config;
-				written.push(write.entry);
-			}
-			await writeMCPConfigFile(destination.mcpConfigPath, { ...mcpConfig, mcpServers: servers });
-		}
-	} catch (error) {
-		// Roll back every snapshot: restore previous content or remove created files.
-		const reason = (error as Error).message;
-		for (const snapshot of snapshots.reverse()) {
-			try {
-				if (snapshot.previous === null) {
-					await fs.rm(snapshot.path, { force: true });
-				} else {
-					await fs.writeFile(snapshot.path, snapshot.previous, "utf-8");
-				}
-			} catch {
-				// best-effort rollback; the failure reason still reports the original error
-			}
-		}
-		for (const entry of writable) {
+		if (!payload) {
 			results.push({
 				surface: entry.surface,
 				sourceName: entry.sourceName,
 				destinationName: entry.destinationName,
 				outcome: "failed",
-				reason: `import failed and was rolled back: ${reason}`,
+				reason: "internal error: writable preview entry has no plan payload",
+			});
+			return;
+		}
+		writable.push({ entry, payload });
+	});
+
+	const failAll = (reason: string): ImportResult => {
+		for (const { entry } of writable) {
+			results.push({
+				surface: entry.surface,
+				sourceName: entry.sourceName,
+				destinationName: entry.destinationName,
+				outcome: "failed",
+				reason,
 			});
 		}
 		return { entries: results, ok: false };
-	}
+	};
 
-	// Post-import verification against the persisted destination state.
-	let verifyFailure: string | null = null;
-	for (const entry of written) {
-		if (entry.surface === "skills" && entry._payload?.skill) {
-			const destPath = path.join(destination.skillsDir, entry._payload.skill.slug, "SKILL.md");
-			const content = await readIfExists(destPath);
-			if (content !== entry._payload.skill.content)
-				verifyFailure = `skill "${entry._payload.skill.slug}" not persisted`;
-		} else if (entry.surface === "hooks" && entry._payload?.hook) {
-			const destPath = path.join(destination.hooksDir, entry._payload.hook.destinationName);
-			const content = await readIfExists(destPath);
-			if (content !== entry._payload.hook.content)
-				verifyFailure = `hook "${entry._payload.hook.destinationName}" not persisted`;
-		} else if (entry.surface === "mcps" && entry._payload?.mcp) {
-			const config = await readMCPConfigFile(destination.mcpConfigPath).catch(() => null);
-			if (!config?.mcpServers?.[entry._payload.mcp.name])
-				verifyFailure = `MCP "${entry._payload.mcp.name}" not persisted`;
+	// --- Phase 1: pre-validation -------------------------------------------
+	const fileWrites: PlannedFileWrite[] = [];
+	const mcpWrites: Array<{ entry: ImportPreviewEntry; name: string; config: MCPServerConfig }> = [];
+	let mcpConfig: Awaited<ReturnType<typeof readMCPConfigFile>> | null = null;
+
+	for (const { entry, payload } of writable) {
+		if (payload.skill) {
+			const slug = payload.skill.slug;
+			if (!isSafeName(slug)) return failAll(`refusing unsafe skill destination name: ${slug}`);
+			const target = path.join(destination.skillsDir, slug, "SKILL.md");
+			const relative = path.relative(destination.skillsDir, target);
+			if (relative.startsWith("..") || path.isAbsolute(relative)) {
+				return failAll(`refusing skill destination outside ${destination.skillsDir}: ${slug}`);
+			}
+			const symlinked = await findSymlinkedAncestor(destination.root, target).catch(error => {
+				return `error:${(error as Error).message}`;
+			});
+			if (typeof symlinked === "string") {
+				return failAll(
+					symlinked.startsWith("error:")
+						? `cannot validate destination ancestors: ${symlinked.slice(6)}`
+						: `refusing to write through symlinked ancestor: ${symlinked}`,
+				);
+			}
+			const existing = await readStructured(target);
+			if (existing.kind === "error") return failAll(existing.message);
+			if (entry.status !== "overwrite" && existing.kind === "value" && existing.content !== payload.skill.content) {
+				return failAll(
+					`destination changed since preview for skill "${slug}"; rebuild the preview instead of overwriting silently`,
+				);
+			}
+			fileWrites.push({ entry, path: target, content: payload.skill.content });
+		} else if (payload.hook) {
+			const { phase, fileName } = payload.hook;
+			if (phase !== "pre" && phase !== "post") return failAll(`refusing unknown hook phase: ${String(phase)}`);
+			if (!isSafeName(fileName)) return failAll(`refusing unsafe hook destination name: ${fileName}`);
+			const target = path.join(destination.hooksDir, phase, fileName);
+			const relative = path.relative(destination.hooksDir, target);
+			if (relative.startsWith("..") || path.isAbsolute(relative)) {
+				return failAll(`refusing hook destination outside ${destination.hooksDir}: ${fileName}`);
+			}
+			const symlinked = await findSymlinkedAncestor(destination.root, target).catch(error => {
+				return `error:${(error as Error).message}`;
+			});
+			if (typeof symlinked === "string") {
+				return failAll(
+					symlinked.startsWith("error:")
+						? `cannot validate destination ancestors: ${symlinked.slice(6)}`
+						: `refusing to write through symlinked ancestor: ${symlinked}`,
+				);
+			}
+			const existing = await readStructured(target);
+			if (existing.kind === "error") return failAll(existing.message);
+			if (entry.status !== "overwrite" && existing.kind === "value" && existing.content !== payload.hook.content) {
+				return failAll(
+					`destination changed since preview for hook "${phase}/${fileName}"; rebuild the preview instead of overwriting silently`,
+				);
+			}
+			fileWrites.push({ entry, path: target, content: payload.hook.content });
+		} else if (payload.mcp) {
+			mcpWrites.push({ entry, name: payload.mcp.name, config: payload.mcp.config });
 		}
-		if (verifyFailure) break;
 	}
 
-	for (const entry of writable) {
+	if (mcpWrites.length > 0) {
+		const destState = await readDestinationMcpState(destination.mcpConfigPath);
+		if (destState.servers === null) {
+			return failAll(destState.error ?? `destination ${destination.mcpConfigPath} is unusable`);
+		}
+		const raw = await readStructured(destination.mcpConfigPath);
+		mcpConfig =
+			raw.kind === "value"
+				? (tryParseJson<Record<string, unknown>>(raw.content) as Awaited<ReturnType<typeof readMCPConfigFile>>)
+				: { mcpServers: {} };
+		for (const write of mcpWrites) {
+			if (!isSafeName(write.name)) return failAll(`refusing unsafe MCP destination name: ${write.name}`);
+			const existing = destState.servers[write.name];
+			if (
+				write.entry.status !== "overwrite" &&
+				existing !== undefined &&
+				JSON.stringify(existing) !== JSON.stringify(write.config)
+			) {
+				return failAll(
+					`destination changed since preview for MCP "${write.name}"; rebuild the preview instead of overwriting silently`,
+				);
+			}
+		}
+	}
+
+	// --- Phase 2: publication ------------------------------------------------
+	const snapshots: FileSnapshot[] = [];
+	const written: Array<{ entry: ImportPreviewEntry }> = [];
+	for (const dir of [destination.skillsDir, destination.hooksDir]) {
+		await sweepStagingTemps(dir).catch(() => {});
+	}
+
+	try {
+		for (const [index, write] of fileWrites.entries()) {
+			await fs.mkdir(path.dirname(write.path), { recursive: true, mode: 0o700 });
+			const stat = await fs.lstat(write.path).catch(() => null);
+			if (stat?.isSymbolicLink()) throw new Error(`refusing to write through symlink: ${write.path}`);
+			const prior = await readStructured(write.path);
+			if (prior.kind === "error") throw new Error(prior.message);
+			const staged = path.join(
+				path.dirname(write.path),
+				`.gjc-import-${process.pid}-${index}-${path.basename(write.path)}.tmp`,
+			);
+			await fs.writeFile(staged, write.content, { encoding: "utf-8", mode: 0o600 });
+			await fs.rename(staged, write.path);
+			snapshots.push({ path: write.path, previous: prior.kind === "value" ? prior.content : null });
+			written.push({ entry: write.entry });
+		}
+
+		if (mcpConfig && mcpWrites.length > 0) {
+			const priorRaw = await readStructured(destination.mcpConfigPath);
+			snapshots.push({
+				path: destination.mcpConfigPath,
+				previous: priorRaw.kind === "value" ? priorRaw.content : null,
+			});
+			const servers = { ...(mcpConfig.mcpServers ?? {}) };
+			for (const write of mcpWrites) {
+				servers[write.name] = write.config;
+				written.push({ entry: write.entry });
+			}
+			await writeMCPConfigFile(destination.mcpConfigPath, { ...mcpConfig, mcpServers: servers });
+		}
+
+		// --- Phase 3: verification (inside the transaction) ------------------
+		for (const write of fileWrites) {
+			const persisted = await readStructured(write.path);
+			if (persisted.kind !== "value" || persisted.content !== write.content) {
+				throw new Error(`post-import verification failed: ${write.path} was not persisted`);
+			}
+		}
+		if (mcpWrites.length > 0) {
+			const persistedConfig = await readMCPConfigFile(destination.mcpConfigPath).catch(() => null);
+			for (const write of mcpWrites) {
+				if (!persistedConfig?.mcpServers?.[write.name]) {
+					throw new Error(`post-import verification failed: MCP "${write.name}" was not persisted`);
+				}
+			}
+		}
+	} catch (error) {
+		// --- Phase 4: rollback — restore exactly what this transaction wrote --
+		const reason = (error as Error).message;
+		const rollbackErrors: string[] = [];
+		for (const snapshot of snapshots.reverse()) {
+			try {
+				if (snapshot.previous === null) {
+					await fs.rm(snapshot.path, { force: true });
+				} else {
+					const staged = `${snapshot.path}.gjc-rollback-${process.pid}.tmp`;
+					await fs.writeFile(staged, snapshot.previous, { encoding: "utf-8", mode: 0o600 });
+					await fs.rename(staged, snapshot.path);
+				}
+			} catch (rollbackError) {
+				rollbackErrors.push(`${snapshot.path}: ${(rollbackError as Error).message}`);
+			}
+		}
+		for (const dir of new Set(fileWrites.map(write => path.dirname(write.path)))) {
+			await sweepStagingTemps(dir).catch(() => {});
+		}
+		return failAll(
+			`import failed and was rolled back: ${reason}` +
+				(rollbackErrors.length > 0 ? `; ROLLBACK ERRORS (manual repair needed): ${rollbackErrors.join("; ")}` : ""),
+		);
+	}
+
+	for (const { entry } of writable) {
 		const base = {
 			surface: entry.surface,
 			sourceName: entry.sourceName,
 			destinationName: entry.destinationName,
 		};
-		if (verifyFailure) {
-			results.push({ ...base, outcome: "failed", reason: `post-import verification failed: ${verifyFailure}` });
-		} else if (entry.status === "overwrite") {
+		if (entry.status === "overwrite") {
 			results.push({ ...base, outcome: "overwritten" });
 		} else if (entry.destinationName !== entry.sourceName) {
 			results.push({ ...base, outcome: "renamed" });
@@ -631,5 +866,5 @@ export async function applyImport(preview: ImportPreview, options: { cwd: string
 			results.push({ ...base, outcome: "imported" });
 		}
 	}
-	return { entries: results, ok: verifyFailure === null };
+	return { entries: results, ok: true };
 }

--- a/packages/coding-agent/src/customization/import.ts
+++ b/packages/coding-agent/src/customization/import.ts
@@ -748,6 +748,16 @@ export async function applyImport(plan: ImportPlan, options: { cwd: string }): P
 	}
 
 	if (mcpWrites.length > 0) {
+		const mcpSymlink = await findSymlinkedAncestor(destination.root, destination.mcpConfigPath).catch(error => {
+			return `error:${(error as Error).message}`;
+		});
+		if (typeof mcpSymlink === "string") {
+			return failAll(
+				mcpSymlink.startsWith("error:")
+					? `cannot validate MCP destination ancestors: ${mcpSymlink.slice(6)}`
+					: `refusing to write MCP config through symlinked ancestor: ${mcpSymlink}`,
+			);
+		}
 		const destState = await readDestinationMcpState(destination.mcpConfigPath);
 		if (destState.servers === null) {
 			return failAll(destState.error ?? `destination ${destination.mcpConfigPath} is unusable`);
@@ -795,6 +805,12 @@ export async function applyImport(plan: ImportPlan, options: { cwd: string }): P
 		}
 
 		if (mcpConfig && mcpWrites.length > 0) {
+			const mcpSymlink = await findSymlinkedAncestor(destination.root, destination.mcpConfigPath);
+			if (mcpSymlink) throw new Error(`refusing to write MCP config through symlinked ancestor: ${mcpSymlink}`);
+			const mcpStat = await fs.lstat(destination.mcpConfigPath).catch(() => null);
+			if (mcpStat?.isSymbolicLink()) {
+				throw new Error(`refusing to write through symlinked MCP config: ${destination.mcpConfigPath}`);
+			}
 			const priorRaw = await readStructured(destination.mcpConfigPath);
 			snapshots.push({
 				path: destination.mcpConfigPath,

--- a/packages/coding-agent/src/customization/import.ts
+++ b/packages/coding-agent/src/customization/import.ts
@@ -1,0 +1,635 @@
+/**
+ * Import flow for the `/extensions` umbrella customization surface (issue #4291).
+ *
+ * Imports Claude Code / Codex skills, hooks, and MCP servers — from either the
+ * project-local or user-global source layout — into the canonical `.gjc`
+ * project/global destination. The flow is preview-first: `buildImportPreview`
+ * performs all reads and normalization, applies the deterministic collision
+ * policy (skip / rename / overwrite), redacts secrets from everything the UI
+ * can render, and only `applyImport` writes — with journaled rollback so a
+ * failed import never leaves partial state.
+ *
+ * Normalization consumes the sibling contracts instead of reimplementing them:
+ * the migrate skill normalizer + MCP mapper (#4284/#4285 ownership) and the
+ * canonical hook IR normalizer (#4286). Unsupported foreign semantics surface
+ * as preview diagnostics, never silent drops.
+ */
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import { isEnoent, parseFrontmatter } from "@gajae-code/utils";
+import { TOML, YAML } from "bun";
+import { HookSourceConvention } from "../hooks/events";
+import { normalizeDirectoryHook } from "../hooks/normalize";
+import { collectMarkdownPrompts, collectSkillDir } from "../migrate/adapters/index";
+import { mapMcpEntry } from "../migrate/mcp-mapper";
+import { readMCPConfigFile, validateServerName, writeMCPConfigFile } from "../runtime-mcp/config-writer";
+import type { MCPConfigFile, MCPServerConfig } from "../runtime-mcp/types";
+import { IMPORTED_FROM_FRONTMATTER_KEY } from "./inventory";
+import type {
+	CustomizationSurface,
+	GjcScope,
+	ImportCollisionPolicy,
+	ImportPreview,
+	ImportPreviewEntry,
+	ImportProduct,
+	ImportResult,
+	ImportResultEntry,
+	ImportSourceScope,
+	NormalizedPayload,
+} from "./types";
+import { productLabel, resolveScopePaths, sourceConfigDir, sourceScopeLabel } from "./types";
+
+export interface BuildImportPreviewOptions {
+	product: ImportProduct;
+	sourceScope: ImportSourceScope;
+	destinationScope: GjcScope;
+	/** Surfaces to import; defaults to all three. */
+	surfaces?: readonly CustomizationSurface[];
+	collisionPolicy: ImportCollisionPolicy;
+	/** Project working directory (project source/destination resolution). */
+	cwd: string;
+	/** Home directory root; overridable for tests. */
+	homeDir: string;
+}
+
+// ---------------------------------------------------------------------------
+// Source layouts
+// ---------------------------------------------------------------------------
+
+interface SourceLayout {
+	skillsDir: string;
+	hooksDir: string;
+	/** Product-specific MCP config file (`.claude.json` / `.mcp.json` / `config.toml`). */
+	mcpConfigPath: string;
+	/** How MCP entries are encoded in that file. */
+	mcpFormat: "json-mcpServers" | "toml-mcp_servers";
+	/** How skills are encoded: SKILL.md directories (Claude) or markdown prompts (Codex). */
+	skillFormat: "skill-dirs" | "markdown-prompts";
+}
+
+function sourceLayout(
+	product: ImportProduct,
+	sourceScope: ImportSourceScope,
+	cwd: string,
+	homeDir: string,
+): SourceLayout {
+	const configDir = sourceConfigDir(product, sourceScope, cwd, homeDir);
+	if (product === "claude-code") {
+		return {
+			skillsDir: path.join(configDir, "skills"),
+			hooksDir: path.join(configDir, "hooks"),
+			// Project-scope Claude MCP servers live in `<project>/.mcp.json`;
+			// user-global servers live in `~/.claude.json`.
+			mcpConfigPath: sourceScope === "project" ? path.join(cwd, ".mcp.json") : path.join(homeDir, ".claude.json"),
+			mcpFormat: "json-mcpServers",
+			skillFormat: "skill-dirs",
+		};
+	}
+	return {
+		// Codex "skills" are markdown prompts; both scopes follow the same layout.
+		skillsDir: path.join(configDir, "prompts"),
+		hooksDir: path.join(configDir, "hooks"),
+		mcpConfigPath: path.join(configDir, "config.toml"),
+		mcpFormat: "toml-mcp_servers",
+		skillFormat: "markdown-prompts",
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Provenance marker
+// ---------------------------------------------------------------------------
+
+/** Inject the imported-from provenance key into a normalized SKILL.md. */
+function withImportProvenance(content: string, product: ImportProduct): string {
+	const { frontmatter, body } = parseFrontmatter(content, { level: "off" });
+	const fm: Record<string, unknown> = { ...frontmatter, [IMPORTED_FROM_FRONTMATTER_KEY]: product };
+	const yaml = YAML.stringify(fm).trimEnd();
+	return `---\n${yaml}\n---\n\n${body.trim()}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Source collection
+// ---------------------------------------------------------------------------
+
+async function readJsonMcpServers(filePath: string): Promise<{ servers: Record<string, unknown> } | { error: string }> {
+	let text: string;
+	try {
+		text = await fs.readFile(filePath, "utf-8");
+	} catch (error) {
+		if (isEnoent(error)) return { servers: {} };
+		return { error: `failed to read ${filePath}: ${(error as Error).message}` };
+	}
+	try {
+		const data = JSON.parse(text) as Record<string, unknown>;
+		const servers = data?.mcpServers;
+		if (servers && typeof servers === "object" && !Array.isArray(servers)) {
+			return { servers: servers as Record<string, unknown> };
+		}
+		return { servers: {} };
+	} catch (error) {
+		return { error: `invalid JSON in ${filePath}: ${(error as Error).message}` };
+	}
+}
+
+async function readTomlMcpServers(filePath: string): Promise<{ servers: Record<string, unknown> } | { error: string }> {
+	let text: string;
+	try {
+		text = await fs.readFile(filePath, "utf-8");
+	} catch (error) {
+		if (isEnoent(error)) return { servers: {} };
+		return { error: `failed to read ${filePath}: ${(error as Error).message}` };
+	}
+	try {
+		const data = TOML.parse(text) as Record<string, unknown>;
+		const servers = data?.mcp_servers;
+		if (servers && typeof servers === "object" && !Array.isArray(servers)) {
+			return { servers: servers as Record<string, unknown> };
+		}
+		return { servers: {} };
+	} catch (error) {
+		return { error: `invalid TOML in ${filePath}: ${(error as Error).message}` };
+	}
+}
+
+interface RawHookCandidate {
+	fileName: string;
+	filePath: string;
+	content: string;
+}
+
+async function collectSourceHooks(hooksDir: string): Promise<RawHookCandidate[]> {
+	let names: string[];
+	try {
+		names = await fs.readdir(hooksDir);
+	} catch {
+		return [];
+	}
+	const candidates: RawHookCandidate[] = [];
+	for (const name of names.sort()) {
+		if (!/\.(ts|js)$/.test(name)) continue;
+		const filePath = path.join(hooksDir, name);
+		try {
+			const stat = await fs.lstat(filePath);
+			if (!stat.isFile() || stat.isSymbolicLink()) continue;
+			candidates.push({ fileName: name, filePath, content: await fs.readFile(filePath, "utf-8") });
+		} catch {}
+	}
+	return candidates;
+}
+
+// ---------------------------------------------------------------------------
+// Collision handling
+// ---------------------------------------------------------------------------
+
+/** Find a free `<base>-imported` / `<base>-imported-N` destination name. */
+function renamedDestination(base: string, taken: (name: string) => boolean): string {
+	let candidate = `${base}-imported`;
+	let index = 2;
+	while (taken(candidate)) {
+		candidate = `${base}-imported-${index}`;
+		index += 1;
+	}
+	return candidate;
+}
+
+function applyCollision(
+	entry: Omit<ImportPreviewEntry, "status"> & { status?: ImportPreviewEntry["status"] },
+	exists: boolean,
+	identical: boolean,
+	policy: ImportCollisionPolicy,
+	rename: (base: string) => string,
+): ImportPreviewEntry {
+	if (!exists) return { ...entry, status: entry.status ?? "add" };
+	if (identical) {
+		return {
+			...entry,
+			status: "conflict",
+			reason: "identical content already present at destination (import is a no-op)",
+		};
+	}
+	switch (policy) {
+		case "skip":
+			return { ...entry, status: "conflict", reason: "destination exists (collision policy: skip)" };
+		case "overwrite":
+			return { ...entry, status: "overwrite", reason: "destination exists (collision policy: overwrite)" };
+		case "rename": {
+			const destinationName = rename(entry.destinationName);
+			return {
+				...entry,
+				destinationName,
+				status: "add",
+				reason: `destination "${entry.destinationName}" exists; renamed under collision policy: rename`,
+			};
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Preview
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the selected source product/scope, normalize every candidate through
+ * the sibling contracts, and produce a redacted preview. Pure reads only —
+ * nothing is written until `applyImport`.
+ */
+export async function buildImportPreview(options: BuildImportPreviewOptions): Promise<ImportPreview> {
+	const surfaces = options.surfaces ?? (["skills", "hooks", "mcps"] as const);
+	const takenSkillNames = new Set<string>();
+	const takenHookNames = new Set<string>();
+	const takenMcpNames = new Set<string>();
+	const layout = sourceLayout(options.product, options.sourceScope, options.cwd, options.homeDir);
+	const destination = resolveScopePaths(options.destinationScope, options.cwd);
+	const entries: ImportPreviewEntry[] = [];
+	const warnings: string[] = [];
+	const productName = productLabel(options.product);
+	const sourceLabel = `${productName} ${sourceScopeLabel(options.sourceScope)}`;
+
+	// --- Skills -------------------------------------------------------------
+	if (surfaces.includes("skills")) {
+		const collected =
+			layout.skillFormat === "skill-dirs"
+				? await collectSkillDir(layout.skillsDir, options.product)
+				: await collectMarkdownPrompts(layout.skillsDir, options.product);
+		for (const diagnostic of collected.diagnostics) {
+			warnings.push(`${sourceLabel} skills: ${diagnostic.message}`);
+		}
+		for (const candidate of collected.candidates) {
+			const slug = candidate.slug;
+			const content = withImportProvenance(candidate.content, options.product);
+			const destPath = path.join(destination.skillsDir, slug, "SKILL.md");
+			const existing = await readIfExists(destPath);
+			const payload: NormalizedPayload = { skill: { slug, content } };
+			const entry = applyCollision(
+				{
+					surface: "skills",
+					sourceName: slug,
+					destinationName: slug,
+					sourceCategory: layout.skillFormat === "skill-dirs" ? "skill directory" : "markdown prompt",
+					description: `import skill "${slug}" into ${destination.skillsDir}`,
+					_payload: payload,
+				},
+				existing !== null,
+				existing === content,
+				options.collisionPolicy,
+				base => renamedDestination(base, name => takenSkillNames.has(name)),
+			);
+			takenSkillNames.add(entry.destinationName);
+			if (entry.destinationName !== slug && entry._payload?.skill) {
+				entry._payload = {
+					skill: {
+						slug: entry.destinationName,
+						content: withImportProvenance(candidate.content, options.product),
+					},
+				};
+			}
+			for (const warning of candidate.warnings) warnings.push(`${sourceLabel} skill "${slug}": ${warning}`);
+			entries.push(entry);
+		}
+	}
+
+	// --- Hooks --------------------------------------------------------------
+	if (surfaces.includes("hooks")) {
+		const convention =
+			options.product === "claude-code" ? HookSourceConvention.ClaudeCode : HookSourceConvention.Codex;
+		const candidates = await collectSourceHooks(layout.hooksDir);
+		for (const candidate of candidates) {
+			const baseName = candidate.fileName.replace(/\.(ts|js)$/, "");
+			const match = baseName.match(/^(pre|post)-(.+)$/);
+			if (!match) {
+				entries.push({
+					surface: "hooks",
+					sourceName: candidate.fileName,
+					destinationName: candidate.fileName,
+					status: "unsupported",
+					sourceCategory: "hook file",
+					description: `hook file "${candidate.fileName}"`,
+					reason: `filename must follow the pre-<tool>.ts|js or post-<tool>.ts|js convention`,
+				});
+				continue;
+			}
+			const phase = match[1] as "pre" | "post";
+			const toolName = match[2];
+			const normalized = normalizeDirectoryHook({
+				convention,
+				phase,
+				toolName,
+				source: candidate.filePath,
+				externalName: candidate.fileName,
+			});
+			if (!normalized.hook) {
+				entries.push({
+					surface: "hooks",
+					sourceName: candidate.fileName,
+					destinationName: candidate.fileName,
+					status: "unsupported",
+					sourceCategory: "hook file",
+					description: `${phase} hook for ${toolName}`,
+					reason: normalized.diagnostics.map(d => `${d.code}: ${d.message}`).join("; "),
+				});
+				continue;
+			}
+			const destPath = path.join(destination.hooksDir, candidate.fileName);
+			const existing = await readIfExists(destPath);
+			const payload: NormalizedPayload = {
+				hook: {
+					sourceName: candidate.fileName,
+					destinationName: candidate.fileName,
+					content: candidate.content,
+					warnings: [],
+				},
+			};
+			const entry = applyCollision(
+				{
+					surface: "hooks",
+					sourceName: candidate.fileName,
+					destinationName: candidate.fileName,
+					sourceCategory: "hook file",
+					description: `${phase} hook for ${toolName} (${normalized.hook.contract.runtimeEvent})`,
+					_payload: payload,
+				},
+				existing !== null,
+				existing === candidate.content,
+				options.collisionPolicy,
+				base => {
+					const renamed = renamedDestination(base.replace(/\.(ts|js)$/, ""), name =>
+						takenHookNames.has(`${name}.ts`),
+					);
+					return `${renamed}${path.extname(base)}`;
+				},
+			);
+			if (entry.destinationName !== candidate.fileName && entry._payload?.hook) {
+				entry._payload = { hook: { ...entry._payload.hook, destinationName: entry.destinationName } };
+			}
+			takenHookNames.add(entry.destinationName);
+			entries.push(entry);
+		}
+	}
+
+	// --- MCPs ---------------------------------------------------------------
+	if (surfaces.includes("mcps")) {
+		const read =
+			layout.mcpFormat === "json-mcpServers"
+				? await readJsonMcpServers(layout.mcpConfigPath)
+				: await readTomlMcpServers(layout.mcpConfigPath);
+		if ("error" in read) {
+			warnings.push(`${sourceLabel} MCPs: ${read.error}`);
+		} else {
+			const existingConfig = await readMCPConfigFile(destination.mcpConfigPath).catch(() => null);
+			if (existingConfig === null) {
+				warnings.push(`destination ${destination.mcpConfigPath} is malformed; MCP entries cannot be imported`);
+			}
+			const existingServers = existingConfig?.mcpServers ?? {};
+			for (const [name, raw] of Object.entries(read.servers)) {
+				const nameError = validateServerName(name);
+				if (nameError) {
+					entries.push({
+						surface: "mcps",
+						sourceName: name,
+						destinationName: name,
+						status: "unsupported",
+						sourceCategory: "MCP server entry",
+						description: `MCP server "${name}"`,
+						reason: nameError,
+					});
+					continue;
+				}
+				const mapped = mapMcpEntry(options.product, name, raw);
+				if (!mapped.ok) {
+					entries.push({
+						surface: "mcps",
+						sourceName: name,
+						destinationName: name,
+						status: "unsupported",
+						sourceCategory: "MCP server entry",
+						description: `MCP server "${name}"`,
+						reason: mapped.reason,
+					});
+					continue;
+				}
+				for (const warning of mapped.warnings) warnings.push(`${sourceLabel} MCP "${name}": ${warning}`);
+				const existing = existingServers[name];
+				const secretKeys = [
+					...("env" in mapped.config && mapped.config.env
+						? Object.keys(mapped.config.env).map(k => `env:${k}`)
+						: []),
+					...("headers" in mapped.config && mapped.config.headers
+						? Object.keys(mapped.config.headers).map(k => `header:${k}`)
+						: []),
+				];
+				const payload: NormalizedPayload = { mcp: { name, config: mapped.config } };
+				const baseEntry = {
+					surface: "mcps" as const,
+					sourceName: name,
+					destinationName: name,
+					sourceCategory: "MCP server entry",
+					description:
+						mapped.config.type === "stdio"
+							? `stdio MCP "${name}" (${mapped.config.command})`
+							: `${mapped.config.type ?? "http"} MCP "${name}"`,
+					_payload: payload,
+				};
+				const entry = applyCollision(
+					baseEntry,
+					existing !== undefined,
+					existing !== undefined && JSON.stringify(existing) === JSON.stringify(mapped.config),
+					options.collisionPolicy,
+					base =>
+						renamedDestination(base, candidate => takenMcpNames.has(candidate) || candidate in existingServers),
+				);
+				if (entry.destinationName !== name && entry._payload?.mcp) {
+					entry._payload = { mcp: { name: entry.destinationName, config: mapped.config } };
+				}
+				takenMcpNames.add(entry.destinationName);
+				if (secretKeys.length > 0 && (entry.status === "add" || entry.status === "overwrite")) {
+					entry.status = "redacted";
+					entry.reason = `${entry.reason ? `${entry.reason}; ` : ""}secret values hidden in preview (keys: ${secretKeys.join(", ")})`;
+				}
+				entries.push(entry);
+			}
+		}
+	}
+
+	return {
+		product: options.product,
+		sourceScope: options.sourceScope,
+		destinationScope: options.destinationScope,
+		surfaces: [...surfaces],
+		entries,
+		warnings,
+	};
+}
+
+async function readIfExists(filePath: string): Promise<string | null> {
+	try {
+		const stat = await fs.lstat(filePath);
+		if (!stat.isFile() || stat.isSymbolicLink()) return null;
+		return await fs.readFile(filePath, "utf-8");
+	} catch {
+		return null;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Apply (journaled rollback)
+// ---------------------------------------------------------------------------
+
+interface FileSnapshot {
+	path: string;
+	/** Previous content, or null when the file did not exist. */
+	previous: string | null;
+}
+
+/**
+ * Apply a confirmed preview. Writes are bounded and journaled: every file a
+ * write touches is snapshotted first, and any failure restores all snapshots
+ * (no partial import). MCP entries are merged into one in-memory config and
+ * written atomically via the canonical config writer.
+ */
+export async function applyImport(preview: ImportPreview, options: { cwd: string }): Promise<ImportResult> {
+	const destination = resolveScopePaths(preview.destinationScope, options.cwd);
+	const results: ImportResultEntry[] = [];
+	const snapshots: FileSnapshot[] = [];
+	const written: ImportPreviewEntry[] = [];
+
+	const writable = preview.entries.filter(
+		entry => entry.status === "add" || entry.status === "overwrite" || entry.status === "redacted",
+	);
+	for (const entry of preview.entries) {
+		if (entry.status === "conflict") {
+			results.push({
+				surface: entry.surface,
+				sourceName: entry.sourceName,
+				destinationName: entry.destinationName,
+				outcome: "skipped",
+				reason: entry.reason,
+			});
+		} else if (entry.status === "unsupported") {
+			results.push({
+				surface: entry.surface,
+				sourceName: entry.sourceName,
+				destinationName: entry.destinationName,
+				outcome: "skipped",
+				reason: entry.reason ?? "unsupported semantics",
+			});
+		}
+	}
+
+	// Snapshot skill/hook destinations.
+	const skillHookWrites: Array<{ entry: ImportPreviewEntry; path: string; content: string }> = [];
+	const mcpWrites: Array<{ entry: ImportPreviewEntry; name: string; config: MCPServerConfig }> = [];
+	for (const entry of writable) {
+		if (entry.surface === "skills" && entry._payload?.skill) {
+			const slug = entry._payload.skill.slug;
+			skillHookWrites.push({
+				entry,
+				path: path.join(destination.skillsDir, slug, "SKILL.md"),
+				content: entry._payload.skill.content,
+			});
+		} else if (entry.surface === "hooks" && entry._payload?.hook) {
+			skillHookWrites.push({
+				entry,
+				path: path.join(destination.hooksDir, entry._payload.hook.destinationName),
+				content: entry._payload.hook.content,
+			});
+		} else if (entry.surface === "mcps" && entry._payload?.mcp) {
+			mcpWrites.push({ entry, name: entry._payload.mcp.name, config: entry._payload.mcp.config });
+		}
+	}
+
+	try {
+		for (const write of skillHookWrites) {
+			snapshots.push({ path: write.path, previous: await readIfExists(write.path) });
+		}
+		let mcpConfig: MCPConfigFile | null = null;
+		if (mcpWrites.length > 0) {
+			mcpConfig = await readMCPConfigFile(destination.mcpConfigPath);
+			snapshots.push({
+				path: destination.mcpConfigPath,
+				previous: await readIfExists(destination.mcpConfigPath),
+			});
+		}
+
+		// Write skill/hook files.
+		for (const write of skillHookWrites) {
+			await fs.mkdir(path.dirname(write.path), { recursive: true, mode: 0o700 });
+			const stat = await fs.lstat(write.path).catch(() => null);
+			if (stat?.isSymbolicLink()) throw new Error(`refusing to write through symlink: ${write.path}`);
+			await fs.writeFile(write.path, write.content, { encoding: "utf-8", mode: 0o600 });
+			written.push(write.entry);
+		}
+
+		// Merge + single atomic MCP config write.
+		if (mcpConfig && mcpWrites.length > 0) {
+			const servers = { ...(mcpConfig.mcpServers ?? {}) };
+			for (const write of mcpWrites) {
+				servers[write.name] = write.config;
+				written.push(write.entry);
+			}
+			await writeMCPConfigFile(destination.mcpConfigPath, { ...mcpConfig, mcpServers: servers });
+		}
+	} catch (error) {
+		// Roll back every snapshot: restore previous content or remove created files.
+		const reason = (error as Error).message;
+		for (const snapshot of snapshots.reverse()) {
+			try {
+				if (snapshot.previous === null) {
+					await fs.rm(snapshot.path, { force: true });
+				} else {
+					await fs.writeFile(snapshot.path, snapshot.previous, "utf-8");
+				}
+			} catch {
+				// best-effort rollback; the failure reason still reports the original error
+			}
+		}
+		for (const entry of writable) {
+			results.push({
+				surface: entry.surface,
+				sourceName: entry.sourceName,
+				destinationName: entry.destinationName,
+				outcome: "failed",
+				reason: `import failed and was rolled back: ${reason}`,
+			});
+		}
+		return { entries: results, ok: false };
+	}
+
+	// Post-import verification against the persisted destination state.
+	let verifyFailure: string | null = null;
+	for (const entry of written) {
+		if (entry.surface === "skills" && entry._payload?.skill) {
+			const destPath = path.join(destination.skillsDir, entry._payload.skill.slug, "SKILL.md");
+			const content = await readIfExists(destPath);
+			if (content !== entry._payload.skill.content)
+				verifyFailure = `skill "${entry._payload.skill.slug}" not persisted`;
+		} else if (entry.surface === "hooks" && entry._payload?.hook) {
+			const destPath = path.join(destination.hooksDir, entry._payload.hook.destinationName);
+			const content = await readIfExists(destPath);
+			if (content !== entry._payload.hook.content)
+				verifyFailure = `hook "${entry._payload.hook.destinationName}" not persisted`;
+		} else if (entry.surface === "mcps" && entry._payload?.mcp) {
+			const config = await readMCPConfigFile(destination.mcpConfigPath).catch(() => null);
+			if (!config?.mcpServers?.[entry._payload.mcp.name])
+				verifyFailure = `MCP "${entry._payload.mcp.name}" not persisted`;
+		}
+		if (verifyFailure) break;
+	}
+
+	for (const entry of writable) {
+		const base = {
+			surface: entry.surface,
+			sourceName: entry.sourceName,
+			destinationName: entry.destinationName,
+		};
+		if (verifyFailure) {
+			results.push({ ...base, outcome: "failed", reason: `post-import verification failed: ${verifyFailure}` });
+		} else if (entry.status === "overwrite") {
+			results.push({ ...base, outcome: "overwritten" });
+		} else if (entry.destinationName !== entry.sourceName) {
+			results.push({ ...base, outcome: "renamed" });
+		} else {
+			results.push({ ...base, outcome: "imported" });
+		}
+	}
+	return { entries: results, ok: verifyFailure === null };
+}

--- a/packages/coding-agent/src/customization/import.ts
+++ b/packages/coding-agent/src/customization/import.ts
@@ -290,6 +290,32 @@ interface DestinationMcpState {
 	error?: string;
 }
 
+function nestedAuthServerNames(product: ImportProduct, content: string): Set<string> {
+	const names = new Set<string>();
+	if (product === "claude-code") {
+		const parsed = tryParseJson<Record<string, unknown>>(content);
+		const servers = parsed?.mcpServers;
+		if (!servers || !isRecord(servers)) return names;
+		for (const [name, value] of Object.entries(servers)) {
+			if (!isRecord(value)) continue;
+			if (value.auth !== undefined || value.oauth !== undefined) names.add(name);
+		}
+		return names;
+	}
+	try {
+		const parsed = Bun.TOML.parse(content) as Record<string, unknown>;
+		const servers = parsed.mcp_servers;
+		if (!servers || !isRecord(servers)) return names;
+		for (const [name, value] of Object.entries(servers)) {
+			if (!isRecord(value)) continue;
+			if (value.auth !== undefined || value.oauth !== undefined) names.add(name);
+		}
+	} catch {
+		// The canonical normalizer reports parse diagnostics.
+	}
+	return names;
+}
+
 async function readDestinationMcpState(mcpConfigPath: string): Promise<DestinationMcpState> {
 	const read = await readStructured(mcpConfigPath);
 	if (read.kind === "absent") return { servers: {} };
@@ -491,6 +517,8 @@ export async function buildImportPreview(options: BuildImportPreviewOptions): Pr
 					: normalizeCodexMcpToml(read.content, sourcePath, options.sourceScope)
 				: { items: [], warnings: [] as string[] };
 		for (const warning of normalized.warnings) warnings.push(`${sourceLabel} MCPs: ${warning}`);
+		const unsupportedNestedAuth =
+			read.kind === "value" ? nestedAuthServerNames(options.product, read.content) : new Set<string>();
 		if (normalized.items.length > 0) {
 			const destState = await readDestinationMcpState(destination.mcpConfigPath);
 			if (destState.servers === null) {
@@ -500,6 +528,19 @@ export async function buildImportPreview(options: BuildImportPreviewOptions): Pr
 			const takenMcpNames = new Set(Object.keys(existingServers));
 			for (const server of normalized.items) {
 				const name = server.name;
+				if (unsupportedNestedAuth.has(name)) {
+					push({
+						surface: "mcps",
+						sourceName: name,
+						destinationName: name,
+						status: "unsupported",
+						sourceCategory: "MCP server entry",
+						description: `MCP server "${name}" (credentials redacted)`,
+						reason:
+							"nested auth/oauth configuration is not supported by the canonical GJC MCP contract; import was skipped to avoid dropping credentials",
+					});
+					continue;
+				}
 				const invalidReason = !isSafeName(name)
 					? "unsafe MCP server name (path separators, control characters, or traversal segments are not allowed)"
 					: validateMCPCompatServer(server);

--- a/packages/coding-agent/src/customization/import.ts
+++ b/packages/coding-agent/src/customization/import.ts
@@ -33,6 +33,7 @@ import { HookSourceConvention } from "../hooks/events";
 import { normalizeDirectoryHook } from "../hooks/normalize";
 import { readMCPConfigFile, writeMCPConfigFile } from "../runtime-mcp/config-writer";
 import type { MCPServerConfig } from "../runtime-mcp/types";
+import { CANONICAL_GJC_WORKFLOW_SKILLS } from "../skill-state/canonical-skills";
 import { IMPORTED_FROM_FRONTMATTER_KEY } from "./inventory";
 import type {
 	ImportCollisionPolicy,
@@ -55,6 +56,8 @@ export interface BuildImportPreviewOptions {
 	cwd: string;
 	homeDir: string;
 }
+
+const PROTECTED_SKILL_NAMES = new Set<string>(CANONICAL_GJC_WORKFLOW_SKILLS);
 
 // ---------------------------------------------------------------------------
 // Structured filesystem reads — absent/value/error, never silent
@@ -366,6 +369,18 @@ export async function buildImportPreview(options: BuildImportPreviewOptions): Pr
 		const takenSkillNames = new Set(await listDirNames(destination.skillsDir, "directory"));
 		for (const source of scoped) {
 			const slug = source.name;
+			if (PROTECTED_SKILL_NAMES.has(slug)) {
+				push({
+					surface: "skills",
+					sourceName: slug,
+					destinationName: slug,
+					status: "unsupported",
+					sourceCategory: "skill directory",
+					description: `import skill "${slug}"`,
+					reason: "protected bundled GJC workflow skill name; foreign copies cannot override bundled authority",
+				});
+				continue;
+			}
 			if (!isSafeName(slug)) {
 				push({
 					surface: "skills",
@@ -421,7 +436,12 @@ export async function buildImportPreview(options: BuildImportPreviewOptions): Pr
 				base => renamedDestination(base, name => takenSkillNames.has(name)),
 			);
 			takenSkillNames.add(entry.destinationName);
-			push(entry, { skill: { slug: entry.destinationName, content } });
+			let destinationContent = content;
+			if (entry.destinationName !== slug) {
+				const { frontmatter, body } = parseFrontmatter(content, { level: "off" });
+				destinationContent = `---\n${YAML.stringify({ ...frontmatter, name: entry.destinationName }).trimEnd()}\n---\n\n${body.trim()}\n`;
+			}
+			push(entry, { skill: { slug: entry.destinationName, content: destinationContent } });
 		}
 	}
 
@@ -440,7 +460,11 @@ export async function buildImportPreview(options: BuildImportPreviewOptions): Pr
 			}
 		}
 		for (const candidate of collected.candidates) {
-			const relDest = `${candidate.phase}/${candidate.fileName}`;
+			const canonicalFileName =
+				options.product === "codex"
+					? `${candidate.toolName}${path.extname(candidate.fileName)}`
+					: candidate.fileName;
+			const relDest = `${candidate.phase}/${canonicalFileName}`;
 			const normalized = normalizeDirectoryHook({
 				convention,
 				phase: candidate.phase,
@@ -473,7 +497,7 @@ export async function buildImportPreview(options: BuildImportPreviewOptions): Pr
 				});
 				continue;
 			}
-			const existing = await readStructured(path.join(destination.hooksDir, candidate.phase, candidate.fileName));
+			const existing = await readStructured(path.join(destination.hooksDir, candidate.phase, canonicalFileName));
 			const entry = applyCollision(
 				{
 					surface: "hooks",
@@ -582,7 +606,6 @@ export async function buildImportPreview(options: BuildImportPreviewOptions): Pr
 				);
 				takenMcpNames.add(entry.destinationName);
 				if (secretKeys.length > 0 && (entry.status === "add" || entry.status === "overwrite")) {
-					entry.status = "redacted";
 					entry.reason = `${entry.reason ? `${entry.reason}; ` : ""}secret values hidden in preview (keys: ${secretKeys.join(", ")})`;
 				}
 				push(entry, { mcp: { name: entry.destinationName, config } });

--- a/packages/coding-agent/src/customization/import.ts
+++ b/packages/coding-agent/src/customization/import.ts
@@ -33,7 +33,7 @@ import { HookSourceConvention } from "../hooks/events";
 import { normalizeDirectoryHook } from "../hooks/normalize";
 import { readMCPConfigFile, writeMCPConfigFile } from "../runtime-mcp/config-writer";
 import type { MCPServerConfig } from "../runtime-mcp/types";
-import { IMPORTED_FROM_FRONTMATTER_KEY } from "./inventory";
+import { IMPORTED_FROM_FRONTMATTER_KEY, redactDisplayText } from "./inventory";
 import type {
 	ImportCollisionPolicy,
 	ImportPlan,
@@ -531,7 +531,7 @@ export async function buildImportPreview(options: BuildImportPreviewOptions): Pr
 						sourceCategory: "MCP server entry",
 						description:
 							config && "command" in config && typeof config.command === "string"
-								? `stdio MCP "${name}" (${config.command})`
+								? redactDisplayText(`stdio MCP "${name}" (${config.command})`)
 								: `${config && "type" in config ? String(config.type) : "http"} MCP "${name}"`,
 					},
 					existing === undefined ? { kind: "absent" } : { kind: "value", content: JSON.stringify(existing) },
@@ -775,7 +775,6 @@ export async function applyImport(plan: ImportPlan, options: { cwd: string }): P
 
 	// --- Phase 2: publication ------------------------------------------------
 	const snapshots: FileSnapshot[] = [];
-	const written: Array<{ entry: ImportPreviewEntry }> = [];
 	for (const dir of [destination.skillsDir, destination.hooksDir]) {
 		await sweepStagingTemps(dir).catch(() => {});
 	}
@@ -794,7 +793,6 @@ export async function applyImport(plan: ImportPlan, options: { cwd: string }): P
 			await fs.writeFile(staged, write.content, { encoding: "utf-8", mode: 0o600 });
 			await fs.rename(staged, write.path);
 			snapshots.push({ path: write.path, previous: prior.kind === "value" ? prior.content : null });
-			written.push({ entry: write.entry });
 		}
 
 		if (mcpConfig && mcpWrites.length > 0) {
@@ -806,7 +804,6 @@ export async function applyImport(plan: ImportPlan, options: { cwd: string }): P
 			const servers = { ...(mcpConfig.mcpServers ?? {}) };
 			for (const write of mcpWrites) {
 				servers[write.name] = write.config;
-				written.push({ entry: write.entry });
 			}
 			await writeMCPConfigFile(destination.mcpConfigPath, { ...mcpConfig, mcpServers: servers });
 		}

--- a/packages/coding-agent/src/customization/index.ts
+++ b/packages/coding-agent/src/customization/index.ts
@@ -1,0 +1,4 @@
+export * from "./import";
+export * from "./inventory";
+export * from "./mutations";
+export * from "./types";

--- a/packages/coding-agent/src/customization/inventory.ts
+++ b/packages/coding-agent/src/customization/inventory.ts
@@ -1,0 +1,458 @@
+/**
+ * Inventory aggregation for the `/extensions` umbrella customization surface.
+ *
+ * Rows are derived from the same authoritative loaders the runtime/session
+ * uses — the capability skill scan semantics (`.gjc` native scopes), the
+ * hook capability discovery plus the canonical hook IR normalizer, and the
+ * runtime-mcp per-file config loader — so the dashboard agrees with actual
+ * session discovery. Foreign Claude/Codex conventions appear as read-only
+ * provenance rows; they are import sources, never managed in place.
+ *
+ * Nothing here ever renders raw credential material: MCP display fields keep
+ * env-var references unexpanded, redact endpoints, and never include env or
+ * header values.
+ */
+import { type Dirent, promises as fs } from "node:fs";
+import * as path from "node:path";
+import { parseFrontmatter } from "@gajae-code/utils";
+import type { Hook } from "../capability/hook";
+import { hookCapability } from "../capability/hook";
+import { type MCPServer, mcpCapability } from "../capability/mcp";
+import type { SkillFrontmatter } from "../capability/skill";
+import { BUNDLED_GJC_SKILL_CATALOG } from "../defaults/gjc-skills.generated";
+import { loadCapability } from "../discovery";
+import { SKILL_FRONTMATTER_SCAN_TOTAL_BYTES } from "../discovery/helpers";
+import { loadMCPJsonFile } from "../discovery/mcp-json";
+import { HookSourceConvention } from "../hooks/events";
+import { normalizeDirectoryHook } from "../hooks/normalize";
+import { redactMCPEndpoint } from "../runtime-mcp/redaction";
+import type { CustomizationSurface, GjcScope, InventoryRow, InventoryStatus } from "./types";
+import { resolveScopePaths, scopeLabel } from "./types";
+
+/** Frontmatter key written by the import flow to record provenance. */
+export const IMPORTED_FROM_FRONTMATTER_KEY = "x-gjc-imported-from";
+
+export interface LoadCustomizationInventoryOptions {
+	/** Project working directory (project `.gjc` root resolution). */
+	cwd: string;
+	/** `disabledExtensions` setting entries (`skill:<name>` disables a skill). */
+	disabledExtensions?: readonly string[];
+	/** Master skills switch from settings (default true). */
+	skillsEnabled?: boolean;
+	/** Project-scope skill gate from settings (default true). */
+	enableProjectSkills?: boolean;
+	/** User-scope skill gate from settings (default true). */
+	enableUserSkills?: boolean;
+}
+
+export interface CustomizationInventory {
+	rows: InventoryRow[];
+	/** Human-facing diagnostics (redacted). */
+	warnings: string[];
+}
+
+const BUNDLED_SKILL_NAMES: ReadonlySet<string> = new Set(
+	BUNDLED_GJC_SKILL_CATALOG.flatMap(entry =>
+		entry.kind === "skill" && typeof entry.name === "string" ? [entry.name] : [],
+	),
+);
+
+/** Stable row identity used for in-session mutation tracking (restart-required). */
+export function inventoryRowId(surface: CustomizationSurface, scope: GjcScope, name: string): string {
+	return `${surface}:${scope}:${name}`;
+}
+
+// ---------------------------------------------------------------------------
+// Skills
+// ---------------------------------------------------------------------------
+
+interface SkillCandidate {
+	scope: GjcScope;
+	dirName: string;
+	skillPath: string;
+	frontmatter: SkillFrontmatter | null;
+	/** Present when the SKILL.md could not be read/parsed at all. */
+	parseError?: string;
+}
+
+async function scanSkillDir(scope: GjcScope, skillsDir: string): Promise<SkillCandidate[]> {
+	let entries: Dirent[];
+	try {
+		entries = await fs.readdir(skillsDir, { withFileTypes: true });
+	} catch {
+		return [];
+	}
+	const candidates: SkillCandidate[] = [];
+	for (const entry of entries) {
+		if (entry.name.startsWith(".")) continue;
+		if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+		const skillPath = path.join(skillsDir, entry.name, "SKILL.md");
+		let text: string;
+		try {
+			const stat = await fs.stat(skillPath);
+			const file = Bun.file(skillPath);
+			text = await file.slice(0, Math.min(stat.size, SKILL_FRONTMATTER_SCAN_TOTAL_BYTES)).text();
+		} catch {
+			continue; // no SKILL.md — not a skill directory
+		}
+		const parsed = parseFrontmatter(text, { source: skillPath });
+		const frontmatter = parsed.frontmatter as SkillFrontmatter;
+		const hasFrontmatter = /^---[ \t]*(?:\r?\n|$)/.test(text) && Object.keys(frontmatter).length > 0;
+		candidates.push({
+			scope,
+			dirName: entry.name,
+			skillPath,
+			frontmatter: hasFrontmatter ? frontmatter : null,
+			parseError: hasFrontmatter ? undefined : "missing or unparseable YAML frontmatter",
+		});
+	}
+	return candidates;
+}
+
+async function loadSkillRows(options: LoadCustomizationInventoryOptions, warnings: string[]): Promise<InventoryRow[]> {
+	const candidates = [
+		...(await scanSkillDir("project", resolveScopePaths("project", options.cwd).skillsDir)),
+		...(await scanSkillDir("global", resolveScopePaths("global", options.cwd).skillsDir)),
+	];
+	const disabledExtensions = new Set(
+		(options.disabledExtensions ?? []).filter(id => id.startsWith("skill:")).map(id => id.slice("skill:".length)),
+	);
+	const skillsEnabled = options.skillsEnabled ?? true;
+	const levelEnabled = (scope: GjcScope): boolean =>
+		scope === "project" ? (options.enableProjectSkills ?? true) : (options.enableUserSkills ?? true);
+
+	const rows: InventoryRow[] = [];
+	// Project scope shadows global scope for identical names (runtime order:
+	// project config dirs load before user dirs and first name wins).
+	const claimedNames = new Set<string>();
+	const shadowed: InventoryRow[] = [];
+
+	for (const candidate of candidates) {
+		const frontmatter = candidate.frontmatter;
+		const name =
+			typeof frontmatter?.name === "string" && frontmatter.name.trim().length > 0
+				? frontmatter.name.trim()
+				: candidate.dirName;
+		const description = typeof frontmatter?.description === "string" ? frontmatter.description : undefined;
+		const diagnostics: string[] = [];
+
+		let status: InventoryStatus;
+		if (candidate.parseError || !frontmatter) {
+			status = "invalid";
+			diagnostics.push(candidate.parseError ?? "missing frontmatter");
+			diagnostics.push("Fix the SKILL.md frontmatter (--- delimited YAML with name/description).");
+		} else if (!description || description.trim().length === 0) {
+			status = "invalid";
+			diagnostics.push("frontmatter.description is required — the runtime loader skips skills without one");
+		} else if (!skillsEnabled) {
+			status = "disabled";
+			diagnostics.push("skills are disabled globally by settings (skills.enabled=false)");
+		} else if (frontmatter.enabled === false) {
+			status = "disabled";
+			diagnostics.push("disabled via frontmatter enabled:false");
+		} else if (disabledExtensions.has(name)) {
+			status = "disabled";
+			diagnostics.push(`disabled via settings disabledExtensions entry "skill:${name}"`);
+		} else if (!levelEnabled(candidate.scope)) {
+			status = "disabled";
+			diagnostics.push(
+				candidate.scope === "project"
+					? "project skills are disabled by settings (skills.enablePiProject=false)"
+					: "user skills are disabled by settings (skills.enablePiUser=false)",
+			);
+		} else {
+			status = "enabled";
+		}
+
+		if (BUNDLED_SKILL_NAMES.has(name)) {
+			diagnostics.push(
+				`"${name}" is a protected bundled workflow skill name; local overrides are unsupported and may be reverted on upgrade`,
+			);
+		}
+
+		// parseFrontmatter camelCases keys; check both the persisted and parsed forms.
+		const importedFrom =
+			frontmatter?.[IMPORTED_FROM_FRONTMATTER_KEY] ?? frontmatter?.["xGjcImportedFrom" as keyof SkillFrontmatter];
+		const provenance =
+			typeof importedFrom === "string" && importedFrom.length > 0
+				? `${scopeLabel(candidate.scope)} · imported from ${importedFrom === "claude-code" ? "Claude Code" : importedFrom}`
+				: scopeLabel(candidate.scope);
+
+		const row: InventoryRow = {
+			surface: "skills",
+			name,
+			displayName: name,
+			status: status === "enabled" && typeof importedFrom === "string" && importedFrom ? "imported" : status,
+			provenance,
+			path: candidate.skillPath,
+			scope: candidate.scope,
+			description,
+			diagnostics: diagnostics.length > 0 ? diagnostics : undefined,
+			raw: frontmatter ? { name, description, hide: frontmatter.hide === true } : null,
+		};
+
+		if ((row.status === "enabled" || row.status === "imported") && claimedNames.has(name)) {
+			row.status = "shadowed";
+			row.diagnostics = [
+				...(row.diagnostics ?? []),
+				`shadowed by the project-scope skill named "${name}" (project .gjc wins over global .gjc)`,
+			];
+			shadowed.push(row);
+		} else {
+			if (row.status === "enabled" || row.status === "imported") claimedNames.add(name);
+			rows.push(row);
+		}
+	}
+
+	// Project candidates were scanned first; re-append shadowed global rows so
+	// every candidate remains visible with its effective status.
+	rows.push(...shadowed);
+	rows.sort((a, b) => a.name.localeCompare(b.name) || a.scope.localeCompare(b.scope));
+	return rows;
+}
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+const HOOK_CONVENTIONS: Readonly<Record<string, HookSourceConvention>> = {
+	native: HookSourceConvention.NativeGjc,
+	claude: HookSourceConvention.ClaudeCode,
+	codex: HookSourceConvention.Codex,
+};
+
+function hookProvenance(hook: Hook): string {
+	const provider = hook._source.provider;
+	if (provider === "native") return hook.level === "project" ? scopeLabel("project") : scopeLabel("global");
+	if (provider === "claude") return "Claude Code (project) — import to manage";
+	if (provider === "codex") return "Codex (project) — import to manage";
+	return provider;
+}
+
+async function loadHookRows(options: LoadCustomizationInventoryOptions, warnings: string[]): Promise<InventoryRow[]> {
+	const result = await loadCapability<Hook>(hookCapability.id, { cwd: options.cwd });
+	for (const warning of result.warnings ?? []) warnings.push(warning);
+
+	const rows: InventoryRow[] = [];
+	for (const hook of result.items) {
+		const provider = hook._source.provider;
+		const convention = HOOK_CONVENTIONS[provider];
+		if (!convention) continue; // plugin-owned or unknown hook providers are not local customization
+
+		const normalized = normalizeDirectoryHook({
+			convention,
+			phase: hook.type,
+			toolName: hook.tool,
+			source: hook.path,
+			externalName: hook.name,
+		});
+		const scope: GjcScope = hook.level === "project" ? "project" : "global";
+		const status: InventoryStatus = normalized.hook ? "enabled" : "invalid";
+		const diagnostics = normalized.diagnostics.map(d => `${d.code}: ${d.message}`);
+		rows.push({
+			surface: "hooks",
+			name: `${hook.type}-${hook.tool}`,
+			displayName: hook.name,
+			status,
+			provenance: hookProvenance(hook),
+			path: hook.path,
+			scope,
+			description: normalized.hook
+				? `${normalized.hook.contract.kind} via ${normalized.hook.contract.runtimeEvent} (${hook.tool})`
+				: `${hook.type} hook for ${hook.tool}`,
+			diagnostics: diagnostics.length > 0 ? diagnostics : undefined,
+			raw: normalized.hook
+				? {
+						convention,
+						kind: normalized.hook.contract.kind,
+						runtimeEvent: normalized.hook.contract.runtimeEvent,
+						authority: normalized.hook.contract.authority,
+						timeoutMs: normalized.hook.contract.timeoutMs,
+					}
+				: { convention, phase: hook.type, tool: hook.tool },
+		});
+	}
+	rows.sort((a, b) => a.name.localeCompare(b.name) || a.path.localeCompare(b.path));
+	return rows;
+}
+
+// ---------------------------------------------------------------------------
+// MCPs
+// ---------------------------------------------------------------------------
+
+function mcpDescription(server: MCPServer): string {
+	const transport = server.transport ?? (server.command ? "stdio" : server.url ? "http" : "stdio");
+	if (transport === "stdio") {
+		const command = server.command ?? "(missing command)";
+		const argCount = Array.isArray(server.args) ? server.args.length : 0;
+		return `stdio: ${command}${argCount > 0 ? ` (${argCount} arg${argCount === 1 ? "" : "s"})` : ""}`;
+	}
+	return `${transport}: ${redactMCPEndpoint(server.url) ?? "(missing url)"}`;
+}
+
+async function loadMcpRows(options: LoadCustomizationInventoryOptions, warnings: string[]): Promise<InventoryRow[]> {
+	const rows: InventoryRow[] = [];
+	const perScope = new Map<GjcScope, { items: MCPServer[]; disabledServers: string[]; fileExists: boolean }>();
+	let userDisabledServers: string[] = [];
+
+	for (const scope of ["project", "global"] as const) {
+		const paths = resolveScopePaths(scope, options.cwd);
+		const level = scope === "project" ? "project" : "user";
+		let fileExists = false;
+		try {
+			await fs.stat(paths.mcpConfigPath);
+			fileExists = true;
+		} catch {
+			fileExists = false;
+		}
+		const result = await loadMCPJsonFile(paths.mcpConfigPath, level, { quiet: false, useCache: false });
+		if (result.warnings && result.warnings.length > 0) {
+			if (fileExists && result.items.length === 0) {
+				rows.push({
+					surface: "mcps",
+					name: `${scope}-mcp-json`,
+					displayName: path.basename(paths.mcpConfigPath),
+					status: "invalid",
+					provenance: scopeLabel(scope),
+					path: paths.mcpConfigPath,
+					scope,
+					description: "MCP configuration file could not be parsed",
+					diagnostics: [
+						...result.warnings.map(w => `malformed MCP configuration: ${w}`),
+						"Fix or remove the malformed JSON; the runtime ignores unparseable config files.",
+					],
+					raw: null,
+				});
+			} else {
+				for (const warning of result.warnings) warnings.push(`${scopeLabel(scope)} mcp.json: ${warning}`);
+			}
+		}
+		perScope.set(scope, { items: result.items, disabledServers: result.disabledServers, fileExists });
+		if (scope === "global") userDisabledServers = result.disabledServers;
+	}
+
+	// Effective-runtime shadowing: the capability merge keeps the last same-name
+	// server in provider load order (project files before user files), so a
+	// user-scope definition silently wins over a project-scope one today.
+	const effectiveWinnerPath = new Map<string, string>();
+	for (const scope of ["project", "global"] as const) {
+		const scopeData = perScope.get(scope);
+		if (!scopeData) continue;
+		for (const server of scopeData.items) {
+			if (server.enabled === false || userDisabledServers.includes(server.name)) continue;
+			effectiveWinnerPath.set(server.name, server._source.path);
+		}
+	}
+
+	for (const scope of ["project", "global"] as const) {
+		const scopeData = perScope.get(scope);
+		if (!scopeData) continue;
+		for (const server of scopeData.items) {
+			const validationError = mcpCapability.validate?.(server);
+			const diagnostics: string[] = [];
+			let status: InventoryStatus;
+			if (validationError) {
+				status = "invalid";
+				diagnostics.push(validationError);
+				diagnostics.push("Fix the server entry in mcp.json; invalid entries are skipped by the runtime.");
+			} else if (server.enabled === false) {
+				status = "disabled";
+				diagnostics.push("disabled via enabled:false in mcp.json");
+			} else if (userDisabledServers.includes(server.name)) {
+				status = "disabled";
+				diagnostics.push("disabled via disabledServers in the user-global mcp.json");
+			} else if (effectiveWinnerPath.get(server.name) !== server._source.path) {
+				status = "shadowed";
+				diagnostics.push(
+					`shadowed by the user-global mcp.json entry named "${server.name}" (runtime merge keeps the later definition)`,
+				);
+			} else {
+				status = "enabled";
+			}
+			if (scope === "project" && scopeData.disabledServers.includes(server.name)) {
+				diagnostics.push(
+					"project-scope disabledServers is not honored by the runtime; use enabled:false or the user-global disabledServers list",
+				);
+			}
+			rows.push({
+				surface: "mcps",
+				name: server.name,
+				displayName: server.name,
+				status,
+				provenance: scopeLabel(scope),
+				path: server._source.path,
+				scope,
+				description: mcpDescription(server),
+				diagnostics: diagnostics.length > 0 ? diagnostics : undefined,
+				raw: {
+					transport: server.transport ?? (server.command ? "stdio" : "http"),
+					url: redactMCPEndpoint(server.url),
+					command: server.command,
+					argCount: Array.isArray(server.args) ? server.args.length : 0,
+					envKeys: server.env ? Object.keys(server.env) : [],
+					headerKeys: server.headers ? Object.keys(server.headers) : [],
+					enabled: server.enabled !== false,
+					autoload: server.autoload !== false,
+				},
+			});
+		}
+	}
+	// Read-only foreign-convention rows so the inventory reflects everything the
+	// session capability scan discovers (Claude/Codex/root mcp.json providers).
+	// These are import sources only — never managed in place.
+	const discovered = await loadCapability<MCPServer>(mcpCapability.id, { cwd: options.cwd });
+	for (const warning of discovered.warnings ?? []) warnings.push(String(warning));
+	for (const server of discovered.items) {
+		const provider = server._source.provider;
+		if (provider === "native") continue;
+		const providerLabel =
+			provider === "claude"
+				? "Claude Code"
+				: provider === "codex"
+					? "Codex"
+					: provider === "mcp-json"
+						? "project mcp.json"
+						: provider;
+		rows.push({
+			surface: "mcps",
+			name: server.name,
+			displayName: server.name,
+			status: server.enabled === false ? "disabled" : "enabled",
+			provenance: `${providerLabel} (${server._source.level}) — import to manage`,
+			path: server._source.path,
+			scope: server._source.level === "project" ? "project" : "global",
+			description: mcpDescription(server),
+			diagnostics: ["discovered outside .gjc; use Import to normalize it into a canonical .gjc scope"],
+			raw: {
+				transport: server.transport ?? (server.command ? "stdio" : "http"),
+				url: redactMCPEndpoint(server.url),
+				command: server.command,
+				envKeys: server.env ? Object.keys(server.env) : [],
+				headerKeys: server.headers ? Object.keys(server.headers) : [],
+			},
+		});
+	}
+	rows.sort((a, b) => a.name.localeCompare(b.name) || a.scope.localeCompare(b.scope));
+	return rows;
+}
+
+// ---------------------------------------------------------------------------
+// Aggregate
+// ---------------------------------------------------------------------------
+
+/**
+ * Load the full Skills/Hooks/MCPs inventory for the `/extensions` dashboard.
+ * Reads only the canonical `.gjc` scopes plus the same hook capability scan
+ * the session performs; never scans foreign home directories.
+ */
+export async function loadCustomizationInventory(
+	options: LoadCustomizationInventoryOptions,
+): Promise<CustomizationInventory> {
+	const warnings: string[] = [];
+	const [skills, hooks, mcps] = await Promise.all([
+		loadSkillRows(options, warnings),
+		loadHookRows(options, warnings),
+		loadMcpRows(options, warnings),
+	]);
+	return { rows: [...skills, ...hooks, ...mcps], warnings };
+}

--- a/packages/coding-agent/src/customization/inventory.ts
+++ b/packages/coding-agent/src/customization/inventory.ts
@@ -53,29 +53,19 @@ export function inventoryRowId(surface: CustomizationSurface, scope: GjcScope, r
 // Display redaction
 // ---------------------------------------------------------------------------
 
-// Free-form command/argument/URL strings are not a safe credential boundary:
-// quoting, auth schemes, shell syntax, and provider-specific flags make
-// heuristic partial redaction incomplete. Structured env/header maps expose
-// keys only; opaque free-form fields are omitted from display entirely.
-export function redactDisplayText(text: string): string {
-	if (/\b(bearer|basic|digest|token|secret|password|api[-_]?key|authorization)\b/i.test(text)) {
-		return "[credential-bearing text redacted]";
-	}
-	return text;
-}
-
 function redactServerForDisplay(server: Record<string, unknown>): Record<string, unknown> {
-	const copy: Record<string, unknown> = { ...server };
-	if (copy.env && typeof copy.env === "object") {
-		copy.env = Object.fromEntries(Object.keys(copy.env as Record<string, unknown>).map(k => [k, "•••"]));
-	}
-	if (copy.headers && typeof copy.headers === "object") {
-		copy.headers = Object.fromEntries(Object.keys(copy.headers as Record<string, unknown>).map(k => [k, "•••"]));
-	}
-	if (copy.command !== undefined) copy.command = "[command redacted]";
-	if (copy.args !== undefined) copy.args = "[arguments redacted]";
-	if (copy.url !== undefined) copy.url = "[URL redacted]";
-	return copy;
+	return {
+		type: typeof server.type === "string" ? server.type : undefined,
+		enabled: typeof server.enabled === "boolean" ? server.enabled : undefined,
+		autoload: typeof server.autoload === "boolean" ? server.autoload : undefined,
+		sharing: typeof server.sharing === "string" ? server.sharing : undefined,
+		timeout: typeof server.timeout === "number" ? server.timeout : undefined,
+		command: server.command === undefined ? undefined : "[command redacted]",
+		args: server.args === undefined ? undefined : "[arguments redacted]",
+		url: server.url === undefined ? undefined : "[URL redacted]",
+		envKeys: server.env && typeof server.env === "object" ? Object.keys(server.env) : undefined,
+		headerKeys: server.headers && typeof server.headers === "object" ? Object.keys(server.headers) : undefined,
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -98,7 +88,7 @@ function importedProductLabel(marker: string): string {
 	return marker === "claude-code" ? "Claude Code" : marker === "codex" ? "Codex" : marker;
 }
 
-async function loadSkillRows(options: LoadCustomizationInventoryOptions, warnings: string[]): Promise<InventoryRow[]> {
+async function loadSkillRows(options: LoadCustomizationInventoryOptions, _warnings: string[]): Promise<InventoryRow[]> {
 	const rows: InventoryRow[] = [];
 	const records = await listNativeSkillsForManagement({
 		cwd: options.cwd,
@@ -241,14 +231,22 @@ function mcpDescription(name: string, server: Record<string, unknown>): string {
 
 async function loadMcpRows(options: LoadCustomizationInventoryOptions, warnings: string[]): Promise<InventoryRow[]> {
 	const rows: InventoryRow[] = [];
-	const disabled = new Set(
+	const disabledExtensions = new Set(
 		(options.disabledExtensions ?? []).filter(id => id.startsWith("mcp:")).map(id => id.slice("mcp:".length)),
+	);
+	const scopeConfigs = await Promise.all(
+		(["project", "global"] as const).map(async scope => {
+			const configPath = resolveScopePaths(scope, options.cwd).mcpConfigPath;
+			const config = await readMCPConfigFile(configPath).catch(() => null);
+			return { scope, configPath, config };
+		}),
+	);
+	const disabledServers = new Set(
+		scopeConfigs.flatMap(({ config }) => (Array.isArray(config?.disabledServers) ? config.disabledServers : [])),
 	);
 	// Runtime semantics: project scope wins; the user-global entry is shadowed.
 	const seen = new Set<string>();
-	for (const scope of ["project", "global"] as const) {
-		const mcpConfigPath = resolveScopePaths(scope, options.cwd).mcpConfigPath;
-		const config = await readMCPConfigFile(mcpConfigPath).catch(() => null);
+	for (const { scope, configPath: mcpConfigPath, config } of scopeConfigs) {
 		if (config === null) {
 			let exists = false;
 			try {
@@ -282,7 +280,7 @@ async function loadMcpRows(options: LoadCustomizationInventoryOptions, warnings:
 				name,
 				...record,
 			} as Parameters<NonNullable<typeof mcpCapability.validate>>[0]);
-			const isDisabled = disabled.has(name) || record.enabled === false;
+			const isDisabled = disabledExtensions.has(name) || disabledServers.has(name) || record.enabled === false;
 			const status: InventoryStatus = validationError
 				? "invalid"
 				: shadowed

--- a/packages/coding-agent/src/customization/inventory.ts
+++ b/packages/coding-agent/src/customization/inventory.ts
@@ -102,7 +102,10 @@ async function loadSkillRows(options: LoadCustomizationInventoryOptions, _warnin
 		const marker = await readImportMarker(record.path);
 		let status: InventoryStatus;
 		const diagnostics: string[] = [];
-		if (record.enabled) {
+		if (options.policy?.enabled === false) {
+			status = "disabled";
+			diagnostics.push("native skills are disabled globally (skills.enabled=false)");
+		} else if (record.enabled) {
 			status = marker ? "imported" : "enabled";
 		} else if (record.disabledReason === "protected") {
 			// Bundled workflow skills are always active; the name is protected.

--- a/packages/coding-agent/src/customization/inventory.ts
+++ b/packages/coding-agent/src/customization/inventory.ts
@@ -53,11 +53,15 @@ export function inventoryRowId(surface: CustomizationSurface, scope: GjcScope, r
 // Display redaction
 // ---------------------------------------------------------------------------
 
-const SECRET_ASSIGNMENT_RE = /(bearer|token|secret|password|api[-_]?key|authorization)([\s:=]+)\S+/gi;
-
-/** Mask token-shaped assignments and env/header values from display text. */
+// Free-form command/argument/URL strings are not a safe credential boundary:
+// quoting, auth schemes, shell syntax, and provider-specific flags make
+// heuristic partial redaction incomplete. Structured env/header maps expose
+// keys only; opaque free-form fields are omitted from display entirely.
 export function redactDisplayText(text: string): string {
-	return text.replace(SECRET_ASSIGNMENT_RE, (_match, key: string, sep: string) => `${key}${sep}•••`);
+	if (/\b(bearer|basic|digest|token|secret|password|api[-_]?key|authorization)\b/i.test(text)) {
+		return "[credential-bearing text redacted]";
+	}
+	return text;
 }
 
 function redactServerForDisplay(server: Record<string, unknown>): Record<string, unknown> {
@@ -68,10 +72,9 @@ function redactServerForDisplay(server: Record<string, unknown>): Record<string,
 	if (copy.headers && typeof copy.headers === "object") {
 		copy.headers = Object.fromEntries(Object.keys(copy.headers as Record<string, unknown>).map(k => [k, "•••"]));
 	}
-	if (typeof copy.command === "string") copy.command = redactDisplayText(copy.command);
-	if (Array.isArray(copy.args))
-		copy.args = copy.args.map(arg => (typeof arg === "string" ? redactDisplayText(arg) : arg));
-	if (typeof copy.url === "string") copy.url = redactDisplayText(copy.url);
+	if (copy.command !== undefined) copy.command = "[command redacted]";
+	if (copy.args !== undefined) copy.args = "[arguments redacted]";
+	if (copy.url !== undefined) copy.url = "[URL redacted]";
 	return copy;
 }
 
@@ -230,10 +233,10 @@ async function loadHookRows(options: LoadCustomizationInventoryOptions, _warning
 
 function mcpDescription(name: string, server: Record<string, unknown>): string {
 	if (typeof server.command === "string" && server.command) {
-		return redactDisplayText(`stdio MCP "${name}" (${server.command})`);
+		return `stdio MCP "${name}" (command redacted)`;
 	}
 	const type = typeof server.type === "string" ? server.type : "http";
-	return `${type} MCP "${name}"`;
+	return `${type} MCP "${name}" (endpoint redacted)`;
 }
 
 async function loadMcpRows(options: LoadCustomizationInventoryOptions, warnings: string[]): Promise<InventoryRow[]> {

--- a/packages/coding-agent/src/customization/inventory.ts
+++ b/packages/coding-agent/src/customization/inventory.ts
@@ -1,31 +1,28 @@
 /**
  * Inventory aggregation for the `/extensions` umbrella customization surface.
  *
- * Rows are derived from the same authoritative loaders the runtime/session
- * uses — the capability skill scan semantics (`.gjc` native scopes), the
- * hook capability discovery plus the canonical hook IR normalizer, and the
- * runtime-mcp per-file config loader — so the dashboard agrees with actual
- * session discovery. Foreign Claude/Codex conventions appear as read-only
- * provenance rows; they are import sources, never managed in place.
+ * Status authority is the runtime's own contracts, not a parallel state model:
+ * - Skills: `listNativeSkillsForManagement` (#4285) — the authoritative
+ *   discovery/policy model (trust, include/ignore, disabledExtensions,
+ *   bundled-name protection). A narrow supplemental scan flags SKILL.md files
+ *   the management loader rejects as `invalid` rows.
+ * - Hooks: canonical `<root>/hooks/<pre|post>/` layout with the runtime's
+ *   project-first, first-wins dedupe key (`<type>:<tool>:<name>`); losers are
+ *   shown as `shadowed`.
+ * - MCPs: canonical config files for both scopes with the runtime's
+ *   project-first precedence and the union of disabled markers; malformed
+ *   files surface as `invalid` rows without leaking raw JSON.
  *
- * Nothing here ever renders raw credential material: MCP display fields keep
- * env-var references unexpanded, redact endpoints, and never include env or
- * header values.
+ * All display fields are secret-safe: env/header values are never rendered,
+ * and command/argument text is masked for token-shaped assignments.
  */
-import { type Dirent, promises as fs } from "node:fs";
+import type { Dirent } from "node:fs";
+import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { parseFrontmatter } from "@gajae-code/utils";
-import type { Hook } from "../capability/hook";
-import { hookCapability } from "../capability/hook";
-import { type MCPServer, mcpCapability } from "../capability/mcp";
-import type { SkillFrontmatter } from "../capability/skill";
-import { BUNDLED_GJC_SKILL_CATALOG } from "../defaults/gjc-skills.generated";
-import { loadCapability } from "../discovery";
-import { SKILL_FRONTMATTER_SCAN_TOTAL_BYTES } from "../discovery/helpers";
-import { loadMCPJsonFile } from "../discovery/mcp-json";
-import { HookSourceConvention } from "../hooks/events";
-import { normalizeDirectoryHook } from "../hooks/normalize";
-import { redactMCPEndpoint } from "../runtime-mcp/redaction";
+import { mcpCapability } from "../capability/mcp";
+import { listNativeSkillsForManagement, type SkillManagementPolicy } from "../extensibility/skill-management";
+import { readMCPConfigFile } from "../runtime-mcp/config-writer";
 import type { CustomizationSurface, GjcScope, InventoryRow, InventoryStatus } from "./types";
 import { resolveScopePaths, scopeLabel } from "./types";
 
@@ -33,181 +30,151 @@ import { resolveScopePaths, scopeLabel } from "./types";
 export const IMPORTED_FROM_FRONTMATTER_KEY = "x-gjc-imported-from";
 
 export interface LoadCustomizationInventoryOptions {
-	/** Project working directory (project `.gjc` root resolution). */
 	cwd: string;
-	/** `disabledExtensions` setting entries (`skill:<name>` disables a skill). */
-	disabledExtensions?: readonly string[];
-	/** Master skills switch from settings (default true). */
-	skillsEnabled?: boolean;
-	/** Project-scope skill gate from settings (default true). */
-	enableProjectSkills?: boolean;
-	/** User-scope skill gate from settings (default true). */
-	enableUserSkills?: boolean;
+	/** Runtime home override (tests); defaults to the process home. */
+	home?: string;
+	/** Skill management policy snapshot (trust, include/ignore, disabledExtensions). */
+	policy?: SkillManagementPolicy;
+	/** Disabled extension ids (`skill:<name>` / `mcp:<name>`) from settings. */
+	disabledExtensions?: string[];
 }
 
 export interface CustomizationInventory {
 	rows: InventoryRow[];
-	/** Human-facing diagnostics (redacted). */
 	warnings: string[];
 }
 
-const BUNDLED_SKILL_NAMES: ReadonlySet<string> = new Set(
-	BUNDLED_GJC_SKILL_CATALOG.flatMap(entry =>
-		entry.kind === "skill" && typeof entry.name === "string" ? [entry.name] : [],
-	),
-);
+/** Stable row identity used for selection and mutations. */
+export function inventoryRowId(surface: CustomizationSurface, scope: GjcScope, rowPath: string): string {
+	return `${surface}:${scope}:${rowPath}`;
+}
 
-/** Stable row identity used for in-session mutation tracking (restart-required). */
-export function inventoryRowId(surface: CustomizationSurface, scope: GjcScope, name: string): string {
-	return `${surface}:${scope}:${name}`;
+// ---------------------------------------------------------------------------
+// Display redaction
+// ---------------------------------------------------------------------------
+
+const SECRET_ASSIGNMENT_RE = /(bearer|token|secret|password|api[-_]?key|authorization)([\s:=]+)\S+/gi;
+
+/** Mask token-shaped assignments and env/header values from display text. */
+export function redactDisplayText(text: string): string {
+	return text.replace(SECRET_ASSIGNMENT_RE, (_match, key: string, sep: string) => `${key}${sep}•••`);
+}
+
+function redactServerForDisplay(server: Record<string, unknown>): Record<string, unknown> {
+	const copy: Record<string, unknown> = { ...server };
+	if (copy.env && typeof copy.env === "object") {
+		copy.env = Object.fromEntries(Object.keys(copy.env as Record<string, unknown>).map(k => [k, "•••"]));
+	}
+	if (copy.headers && typeof copy.headers === "object") {
+		copy.headers = Object.fromEntries(Object.keys(copy.headers as Record<string, unknown>).map(k => [k, "•••"]));
+	}
+	if (typeof copy.command === "string") copy.command = redactDisplayText(copy.command);
+	if (Array.isArray(copy.args))
+		copy.args = copy.args.map(arg => (typeof arg === "string" ? redactDisplayText(arg) : arg));
+	if (typeof copy.url === "string") copy.url = redactDisplayText(copy.url);
+	return copy;
 }
 
 // ---------------------------------------------------------------------------
 // Skills
 // ---------------------------------------------------------------------------
 
-interface SkillCandidate {
-	scope: GjcScope;
-	dirName: string;
-	skillPath: string;
-	frontmatter: SkillFrontmatter | null;
-	/** Present when the SKILL.md could not be read/parsed at all. */
-	parseError?: string;
+async function readImportMarker(skillPath: string): Promise<string | null> {
+	try {
+		const content = await fs.readFile(skillPath, "utf-8");
+		const { frontmatter } = parseFrontmatter(content, { level: "off" });
+		// parseFrontmatter camelCases keys: x-gjc-imported-from → xGjcImportedFrom.
+		const marker = frontmatter[IMPORTED_FROM_FRONTMATTER_KEY] ?? frontmatter.xGjcImportedFrom;
+		return typeof marker === "string" ? marker : null;
+	} catch {
+		return null;
+	}
 }
 
-async function scanSkillDir(scope: GjcScope, skillsDir: string): Promise<SkillCandidate[]> {
-	let entries: Dirent[];
-	try {
-		entries = await fs.readdir(skillsDir, { withFileTypes: true });
-	} catch {
-		return [];
-	}
-	const candidates: SkillCandidate[] = [];
-	for (const entry of entries) {
-		if (entry.name.startsWith(".")) continue;
-		if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
-		const skillPath = path.join(skillsDir, entry.name, "SKILL.md");
-		let text: string;
-		try {
-			const stat = await fs.stat(skillPath);
-			const file = Bun.file(skillPath);
-			text = await file.slice(0, Math.min(stat.size, SKILL_FRONTMATTER_SCAN_TOTAL_BYTES)).text();
-		} catch {
-			continue; // no SKILL.md — not a skill directory
-		}
-		const parsed = parseFrontmatter(text, { source: skillPath });
-		const frontmatter = parsed.frontmatter as SkillFrontmatter;
-		const hasFrontmatter = /^---[ \t]*(?:\r?\n|$)/.test(text) && Object.keys(frontmatter).length > 0;
-		candidates.push({
-			scope,
-			dirName: entry.name,
-			skillPath,
-			frontmatter: hasFrontmatter ? frontmatter : null,
-			parseError: hasFrontmatter ? undefined : "missing or unparseable YAML frontmatter",
-		});
-	}
-	return candidates;
+function importedProductLabel(marker: string): string {
+	return marker === "claude-code" ? "Claude Code" : marker === "codex" ? "Codex" : marker;
 }
 
 async function loadSkillRows(options: LoadCustomizationInventoryOptions, warnings: string[]): Promise<InventoryRow[]> {
-	const candidates = [
-		...(await scanSkillDir("project", resolveScopePaths("project", options.cwd).skillsDir)),
-		...(await scanSkillDir("global", resolveScopePaths("global", options.cwd).skillsDir)),
-	];
-	const disabledExtensions = new Set(
-		(options.disabledExtensions ?? []).filter(id => id.startsWith("skill:")).map(id => id.slice("skill:".length)),
-	);
-	const skillsEnabled = options.skillsEnabled ?? true;
-	const levelEnabled = (scope: GjcScope): boolean =>
-		scope === "project" ? (options.enableProjectSkills ?? true) : (options.enableUserSkills ?? true);
-
 	const rows: InventoryRow[] = [];
-	// Project scope shadows global scope for identical names (runtime order:
-	// project config dirs load before user dirs and first name wins).
-	const claimedNames = new Set<string>();
-	const shadowed: InventoryRow[] = [];
-
-	for (const candidate of candidates) {
-		const frontmatter = candidate.frontmatter;
-		const name =
-			typeof frontmatter?.name === "string" && frontmatter.name.trim().length > 0
-				? frontmatter.name.trim()
-				: candidate.dirName;
-		const description = typeof frontmatter?.description === "string" ? frontmatter.description : undefined;
-		const diagnostics: string[] = [];
-
+	const records = await listNativeSkillsForManagement({
+		cwd: options.cwd,
+		home: options.home,
+		policy: options.policy,
+	});
+	const managedPaths = new Set<string>();
+	for (const record of records) {
+		managedPaths.add(path.resolve(record.path));
+		const scope: GjcScope = record.scope === "project" ? "project" : "global";
+		const marker = await readImportMarker(record.path);
 		let status: InventoryStatus;
-		if (candidate.parseError || !frontmatter) {
-			status = "invalid";
-			diagnostics.push(candidate.parseError ?? "missing frontmatter");
-			diagnostics.push("Fix the SKILL.md frontmatter (--- delimited YAML with name/description).");
-		} else if (!description || description.trim().length === 0) {
-			status = "invalid";
-			diagnostics.push("frontmatter.description is required — the runtime loader skips skills without one");
-		} else if (!skillsEnabled) {
-			status = "disabled";
-			diagnostics.push("skills are disabled globally by settings (skills.enabled=false)");
-		} else if (frontmatter.enabled === false) {
-			status = "disabled";
-			diagnostics.push("disabled via frontmatter enabled:false");
-		} else if (disabledExtensions.has(name)) {
-			status = "disabled";
-			diagnostics.push(`disabled via settings disabledExtensions entry "skill:${name}"`);
-		} else if (!levelEnabled(candidate.scope)) {
-			status = "disabled";
-			diagnostics.push(
-				candidate.scope === "project"
-					? "project skills are disabled by settings (skills.enablePiProject=false)"
-					: "user skills are disabled by settings (skills.enablePiUser=false)",
-			);
-		} else {
+		const diagnostics: string[] = [];
+		if (record.enabled) {
+			status = marker ? "imported" : "enabled";
+		} else if (record.disabledReason === "protected") {
+			// Bundled workflow skills are always active; the name is protected.
 			status = "enabled";
-		}
-
-		if (BUNDLED_SKILL_NAMES.has(name)) {
-			diagnostics.push(
-				`"${name}" is a protected bundled workflow skill name; local overrides are unsupported and may be reverted on upgrade`,
-			);
-		}
-
-		// parseFrontmatter camelCases keys; check both the persisted and parsed forms.
-		const importedFrom =
-			frontmatter?.[IMPORTED_FROM_FRONTMATTER_KEY] ?? frontmatter?.["xGjcImportedFrom" as keyof SkillFrontmatter];
-		const provenance =
-			typeof importedFrom === "string" && importedFrom.length > 0
-				? `${scopeLabel(candidate.scope)} · imported from ${importedFrom === "claude-code" ? "Claude Code" : importedFrom}`
-				: scopeLabel(candidate.scope);
-
-		const row: InventoryRow = {
-			surface: "skills",
-			name,
-			displayName: name,
-			status: status === "enabled" && typeof importedFrom === "string" && importedFrom ? "imported" : status,
-			provenance,
-			path: candidate.skillPath,
-			scope: candidate.scope,
-			description,
-			diagnostics: diagnostics.length > 0 ? diagnostics : undefined,
-			raw: frontmatter ? { name, description, hide: frontmatter.hide === true } : null,
-		};
-
-		if ((row.status === "enabled" || row.status === "imported") && claimedNames.has(name)) {
-			row.status = "shadowed";
-			row.diagnostics = [
-				...(row.diagnostics ?? []),
-				`shadowed by the project-scope skill named "${name}" (project .gjc wins over global .gjc)`,
-			];
-			shadowed.push(row);
+			diagnostics.push("bundled GJC workflow skill — protected name, always available");
 		} else {
-			if (row.status === "enabled" || row.status === "imported") claimedNames.add(name);
-			rows.push(row);
+			status = "disabled";
+			if (record.disabledReason) diagnostics.push(`disabled (${record.disabledReason})`);
 		}
+		const provenance = marker ? `${record.source} · imported from ${importedProductLabel(marker)}` : record.source;
+		rows.push({
+			id: inventoryRowId("skills", scope, record.path),
+			surface: "skills",
+			name: record.name,
+			displayName: record.name,
+			status,
+			provenance,
+			path: record.path,
+			scope,
+			description: record.description || undefined,
+			diagnostics: diagnostics.length > 0 ? diagnostics : undefined,
+			raw: { name: record.name, source: record.source, hidden: record.hidden },
+		});
 	}
 
-	// Project candidates were scanned first; re-append shadowed global rows so
-	// every candidate remains visible with its effective status.
-	rows.push(...shadowed);
-	rows.sort((a, b) => a.name.localeCompare(b.name) || a.scope.localeCompare(b.scope));
+	// Narrow supplemental pass: flag SKILL.md files the management loader
+	// rejected (missing/invalid frontmatter) as invalid rows with remediation.
+	for (const scope of ["project", "global"] as const) {
+		const skillsDir = resolveScopePaths(scope, options.cwd).skillsDir;
+		let dirNames: string[];
+		try {
+			dirNames = (await fs.readdir(skillsDir, { withFileTypes: true }))
+				.filter(entry => entry.isDirectory() && !entry.name.startsWith("."))
+				.map(entry => entry.name)
+				.sort();
+		} catch {
+			continue;
+		}
+		for (const dirName of dirNames) {
+			const skillPath = path.join(skillsDir, dirName, "SKILL.md");
+			if (managedPaths.has(path.resolve(skillPath))) continue;
+			try {
+				const stat = await fs.lstat(skillPath);
+				if (stat.isSymbolicLink() || !stat.isFile()) continue;
+				const content = await fs.readFile(skillPath, "utf-8");
+				const { frontmatter } = parseFrontmatter(content, { level: "off" });
+				const description = typeof frontmatter.description === "string" ? frontmatter.description.trim() : "";
+				if (description) continue; // valid but shadowed/deduped — authority is the loader
+				rows.push({
+					id: inventoryRowId("skills", scope, skillPath),
+					surface: "skills",
+					name: dirName,
+					displayName: dirName,
+					status: "invalid",
+					provenance: `${scopeLabel(scope)} skills`,
+					path: skillPath,
+					scope,
+					diagnostics: ["invalid skill frontmatter: add a YAML frontmatter block with a non-empty description"],
+					raw: { name: dirName },
+				});
+			} catch {
+				// Unreadable files are simply not listed; the loader remains authority.
+			}
+		}
+	}
 	return rows;
 }
 
@@ -215,64 +182,45 @@ async function loadSkillRows(options: LoadCustomizationInventoryOptions, warning
 // Hooks
 // ---------------------------------------------------------------------------
 
-const HOOK_CONVENTIONS: Readonly<Record<string, HookSourceConvention>> = {
-	native: HookSourceConvention.NativeGjc,
-	claude: HookSourceConvention.ClaudeCode,
-	codex: HookSourceConvention.Codex,
-};
+const HOOK_PHASES = ["pre", "post"] as const;
 
-function hookProvenance(hook: Hook): string {
-	const provider = hook._source.provider;
-	if (provider === "native") return hook.level === "project" ? scopeLabel("project") : scopeLabel("global");
-	if (provider === "claude") return "Claude Code (project) — import to manage";
-	if (provider === "codex") return "Codex (project) — import to manage";
-	return provider;
-}
-
-async function loadHookRows(options: LoadCustomizationInventoryOptions, warnings: string[]): Promise<InventoryRow[]> {
-	const result = await loadCapability<Hook>(hookCapability.id, { cwd: options.cwd });
-	for (const warning of result.warnings ?? []) warnings.push(warning);
-
+async function loadHookRows(options: LoadCustomizationInventoryOptions, _warnings: string[]): Promise<InventoryRow[]> {
 	const rows: InventoryRow[] = [];
-	for (const hook of result.items) {
-		const provider = hook._source.provider;
-		const convention = HOOK_CONVENTIONS[provider];
-		if (!convention) continue; // plugin-owned or unknown hook providers are not local customization
-
-		const normalized = normalizeDirectoryHook({
-			convention,
-			phase: hook.type,
-			toolName: hook.tool,
-			source: hook.path,
-			externalName: hook.name,
-		});
-		const scope: GjcScope = hook.level === "project" ? "project" : "global";
-		const status: InventoryStatus = normalized.hook ? "enabled" : "invalid";
-		const diagnostics = normalized.diagnostics.map(d => `${d.code}: ${d.message}`);
-		rows.push({
-			surface: "hooks",
-			name: `${hook.type}-${hook.tool}`,
-			displayName: hook.name,
-			status,
-			provenance: hookProvenance(hook),
-			path: hook.path,
-			scope,
-			description: normalized.hook
-				? `${normalized.hook.contract.kind} via ${normalized.hook.contract.runtimeEvent} (${hook.tool})`
-				: `${hook.type} hook for ${hook.tool}`,
-			diagnostics: diagnostics.length > 0 ? diagnostics : undefined,
-			raw: normalized.hook
-				? {
-						convention,
-						kind: normalized.hook.contract.kind,
-						runtimeEvent: normalized.hook.contract.runtimeEvent,
-						authority: normalized.hook.contract.authority,
-						timeoutMs: normalized.hook.contract.timeoutMs,
-					}
-				: { convention, phase: hook.type, tool: hook.tool },
-		});
+	// Runtime semantics: project-first, first-wins on `<type>:<tool>:<name>`.
+	const seen = new Set<string>();
+	for (const scope of ["project", "global"] as const) {
+		const hooksDir = resolveScopePaths(scope, options.cwd).hooksDir;
+		for (const phase of HOOK_PHASES) {
+			const phaseDir = path.join(hooksDir, phase);
+			let entries: Dirent[];
+			try {
+				entries = await fs.readdir(phaseDir, { withFileTypes: true });
+			} catch {
+				continue;
+			}
+			for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+				if (entry.name.startsWith(".") || !entry.isFile()) continue;
+				const hookPath = path.join(phaseDir, entry.name);
+				const baseName = entry.name.includes(".") ? entry.name.slice(0, entry.name.lastIndexOf(".")) : entry.name;
+				const key = `${phase}:${baseName}:${entry.name}`;
+				const shadowed = seen.has(key);
+				seen.add(key);
+				rows.push({
+					id: inventoryRowId("hooks", scope, hookPath),
+					surface: "hooks",
+					name: entry.name,
+					displayName: `${phase}/${entry.name}`,
+					status: shadowed ? "shadowed" : "enabled",
+					provenance: `${scopeLabel(scope)} hooks/${phase}`,
+					path: hookPath,
+					scope,
+					description: `${phase}-tool hook for ${baseName}`,
+					diagnostics: shadowed ? ["shadowed by the same hook at higher-precedence scope"] : undefined,
+					raw: { name: entry.name, type: phase, tool: baseName },
+				});
+			}
+		}
 	}
-	rows.sort((a, b) => a.name.localeCompare(b.name) || a.path.localeCompare(b.path));
 	return rows;
 }
 
@@ -280,159 +228,84 @@ async function loadHookRows(options: LoadCustomizationInventoryOptions, warnings
 // MCPs
 // ---------------------------------------------------------------------------
 
-function mcpDescription(server: MCPServer): string {
-	const transport = server.transport ?? (server.command ? "stdio" : server.url ? "http" : "stdio");
-	if (transport === "stdio") {
-		const command = server.command ?? "(missing command)";
-		const argCount = Array.isArray(server.args) ? server.args.length : 0;
-		return `stdio: ${command}${argCount > 0 ? ` (${argCount} arg${argCount === 1 ? "" : "s"})` : ""}`;
+function mcpDescription(name: string, server: Record<string, unknown>): string {
+	if (typeof server.command === "string" && server.command) {
+		return redactDisplayText(`stdio MCP "${name}" (${server.command})`);
 	}
-	return `${transport}: ${redactMCPEndpoint(server.url) ?? "(missing url)"}`;
+	const type = typeof server.type === "string" ? server.type : "http";
+	return `${type} MCP "${name}"`;
 }
 
 async function loadMcpRows(options: LoadCustomizationInventoryOptions, warnings: string[]): Promise<InventoryRow[]> {
 	const rows: InventoryRow[] = [];
-	const perScope = new Map<GjcScope, { items: MCPServer[]; disabledServers: string[]; fileExists: boolean }>();
-	let userDisabledServers: string[] = [];
-
+	const disabled = new Set(
+		(options.disabledExtensions ?? []).filter(id => id.startsWith("mcp:")).map(id => id.slice("mcp:".length)),
+	);
+	// Runtime semantics: project scope wins; the user-global entry is shadowed.
+	const seen = new Set<string>();
 	for (const scope of ["project", "global"] as const) {
-		const paths = resolveScopePaths(scope, options.cwd);
-		const level = scope === "project" ? "project" : "user";
-		let fileExists = false;
-		try {
-			await fs.stat(paths.mcpConfigPath);
-			fileExists = true;
-		} catch {
-			fileExists = false;
-		}
-		const result = await loadMCPJsonFile(paths.mcpConfigPath, level, { quiet: false, useCache: false });
-		if (result.warnings && result.warnings.length > 0) {
-			if (fileExists && result.items.length === 0) {
+		const mcpConfigPath = resolveScopePaths(scope, options.cwd).mcpConfigPath;
+		const config = await readMCPConfigFile(mcpConfigPath).catch(() => null);
+		if (config === null) {
+			let exists = false;
+			try {
+				exists = (await fs.lstat(mcpConfigPath)).isFile();
+			} catch {
+				exists = false;
+			}
+			if (exists) {
+				warnings.push(`${mcpConfigPath} is malformed; fix or remove it to manage MCP servers`);
 				rows.push({
+					id: inventoryRowId("mcps", scope, mcpConfigPath),
 					surface: "mcps",
-					name: `${scope}-mcp-json`,
-					displayName: path.basename(paths.mcpConfigPath),
+					name: path.basename(mcpConfigPath),
+					displayName: path.basename(mcpConfigPath),
 					status: "invalid",
-					provenance: scopeLabel(scope),
-					path: paths.mcpConfigPath,
+					provenance: `${scopeLabel(scope)} MCP config`,
+					path: mcpConfigPath,
 					scope,
-					description: "MCP configuration file could not be parsed",
-					diagnostics: [
-						...result.warnings.map(w => `malformed MCP configuration: ${w}`),
-						"Fix or remove the malformed JSON; the runtime ignores unparseable config files.",
-					],
-					raw: null,
+					diagnostics: ["malformed MCP config file; fix or remove it (contents not shown)"],
+					raw: { path: mcpConfigPath },
 				});
-			} else {
-				for (const warning of result.warnings) warnings.push(`${scopeLabel(scope)} mcp.json: ${warning}`);
 			}
+			continue;
 		}
-		perScope.set(scope, { items: result.items, disabledServers: result.disabledServers, fileExists });
-		if (scope === "global") userDisabledServers = result.disabledServers;
-	}
-
-	// Effective-runtime shadowing: the capability merge keeps the last same-name
-	// server in provider load order (project files before user files), so a
-	// user-scope definition silently wins over a project-scope one today.
-	const effectiveWinnerPath = new Map<string, string>();
-	for (const scope of ["project", "global"] as const) {
-		const scopeData = perScope.get(scope);
-		if (!scopeData) continue;
-		for (const server of scopeData.items) {
-			if (server.enabled === false || userDisabledServers.includes(server.name)) continue;
-			effectiveWinnerPath.set(server.name, server._source.path);
-		}
-	}
-
-	for (const scope of ["project", "global"] as const) {
-		const scopeData = perScope.get(scope);
-		if (!scopeData) continue;
-		for (const server of scopeData.items) {
-			const validationError = mcpCapability.validate?.(server);
-			const diagnostics: string[] = [];
-			let status: InventoryStatus;
-			if (validationError) {
-				status = "invalid";
-				diagnostics.push(validationError);
-				diagnostics.push("Fix the server entry in mcp.json; invalid entries are skipped by the runtime.");
-			} else if (server.enabled === false) {
-				status = "disabled";
-				diagnostics.push("disabled via enabled:false in mcp.json");
-			} else if (userDisabledServers.includes(server.name)) {
-				status = "disabled";
-				diagnostics.push("disabled via disabledServers in the user-global mcp.json");
-			} else if (effectiveWinnerPath.get(server.name) !== server._source.path) {
-				status = "shadowed";
-				diagnostics.push(
-					`shadowed by the user-global mcp.json entry named "${server.name}" (runtime merge keeps the later definition)`,
-				);
-			} else {
-				status = "enabled";
-			}
-			if (scope === "project" && scopeData.disabledServers.includes(server.name)) {
-				diagnostics.push(
-					"project-scope disabledServers is not honored by the runtime; use enabled:false or the user-global disabledServers list",
-				);
-			}
+		const servers = config.mcpServers ?? {};
+		for (const [name, server] of Object.entries(servers).sort(([a], [b]) => a.localeCompare(b))) {
+			const shadowed = seen.has(name);
+			seen.add(name);
+			const record = server as unknown as Record<string, unknown>;
+			const validationError = mcpCapability.validate?.({
+				name,
+				...record,
+			} as Parameters<NonNullable<typeof mcpCapability.validate>>[0]);
+			const isDisabled = disabled.has(name) || record.enabled === false;
+			const status: InventoryStatus = validationError
+				? "invalid"
+				: shadowed
+					? "shadowed"
+					: isDisabled
+						? "disabled"
+						: "enabled";
 			rows.push({
+				id: inventoryRowId("mcps", scope, `${mcpConfigPath}#${name}`),
 				surface: "mcps",
-				name: server.name,
-				displayName: server.name,
+				name,
+				displayName: name,
 				status,
-				provenance: scopeLabel(scope),
-				path: server._source.path,
+				provenance: `${scopeLabel(scope)} mcp.json`,
+				path: mcpConfigPath,
 				scope,
-				description: mcpDescription(server),
-				diagnostics: diagnostics.length > 0 ? diagnostics : undefined,
-				raw: {
-					transport: server.transport ?? (server.command ? "stdio" : "http"),
-					url: redactMCPEndpoint(server.url),
-					command: server.command,
-					argCount: Array.isArray(server.args) ? server.args.length : 0,
-					envKeys: server.env ? Object.keys(server.env) : [],
-					headerKeys: server.headers ? Object.keys(server.headers) : [],
-					enabled: server.enabled !== false,
-					autoload: server.autoload !== false,
-				},
+				description: mcpDescription(name, record),
+				diagnostics: validationError
+					? [validationError]
+					: shadowed
+						? ["shadowed by the same server at higher-precedence scope"]
+						: undefined,
+				raw: redactServerForDisplay(record),
 			});
 		}
 	}
-	// Read-only foreign-convention rows so the inventory reflects everything the
-	// session capability scan discovers (Claude/Codex/root mcp.json providers).
-	// These are import sources only — never managed in place.
-	const discovered = await loadCapability<MCPServer>(mcpCapability.id, { cwd: options.cwd });
-	for (const warning of discovered.warnings ?? []) warnings.push(String(warning));
-	for (const server of discovered.items) {
-		const provider = server._source.provider;
-		if (provider === "native") continue;
-		const providerLabel =
-			provider === "claude"
-				? "Claude Code"
-				: provider === "codex"
-					? "Codex"
-					: provider === "mcp-json"
-						? "project mcp.json"
-						: provider;
-		rows.push({
-			surface: "mcps",
-			name: server.name,
-			displayName: server.name,
-			status: server.enabled === false ? "disabled" : "enabled",
-			provenance: `${providerLabel} (${server._source.level}) — import to manage`,
-			path: server._source.path,
-			scope: server._source.level === "project" ? "project" : "global",
-			description: mcpDescription(server),
-			diagnostics: ["discovered outside .gjc; use Import to normalize it into a canonical .gjc scope"],
-			raw: {
-				transport: server.transport ?? (server.command ? "stdio" : "http"),
-				url: redactMCPEndpoint(server.url),
-				command: server.command,
-				envKeys: server.env ? Object.keys(server.env) : [],
-				headerKeys: server.headers ? Object.keys(server.headers) : [],
-			},
-		});
-	}
-	rows.sort((a, b) => a.name.localeCompare(b.name) || a.scope.localeCompare(b.scope));
 	return rows;
 }
 
@@ -442,8 +315,8 @@ async function loadMcpRows(options: LoadCustomizationInventoryOptions, warnings:
 
 /**
  * Load the full Skills/Hooks/MCPs inventory for the `/extensions` dashboard.
- * Reads only the canonical `.gjc` scopes plus the same hook capability scan
- * the session performs; never scans foreign home directories.
+ * Reads only the canonical `.gjc` scopes; foreign Claude/Codex layouts are
+ * import sources handled by the explicit import flow, never managed entries.
  */
 export async function loadCustomizationInventory(
 	options: LoadCustomizationInventoryOptions,

--- a/packages/coding-agent/src/customization/mutations.ts
+++ b/packages/coding-agent/src/customization/mutations.ts
@@ -16,7 +16,12 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { setNativeSkillEnabled } from "../extensibility/skill-management";
-import { readMCPConfigFile, removeMCPServer, setServerDisabled } from "../runtime-mcp/config-writer";
+import {
+	readMCPConfigFile,
+	removeMCPServer,
+	setServerDisabled,
+	writeMCPConfigFile,
+} from "../runtime-mcp/config-writer";
 import { CANONICAL_GJC_WORKFLOW_SKILLS } from "../skill-state/canonical-skills";
 
 const BUNDLED_SKILL_NAMES: ReadonlySet<string> = new Set(CANONICAL_GJC_WORKFLOW_SKILLS);
@@ -79,13 +84,30 @@ export async function setMcpServerEnabled(
 	mcpConfigPath: string,
 	name: string,
 	enabled: boolean,
+	disabledExtensions: string[] = [],
 ): Promise<MutationResult> {
 	const config = await readMCPConfigFile(mcpConfigPath).catch(() => null);
 	if (!config) return { ok: false, reason: `${mcpConfigPath} is malformed; fix or remove it first` };
 	const server = config.mcpServers?.[name];
 	if (!server) return { ok: false, reason: `server "${name}" not found in ${mcpConfigPath}` };
+	if (enabled && server.enabled === false) {
+		const updatedServer = { ...server };
+		delete updatedServer.enabled;
+		await writeMCPConfigFile(mcpConfigPath, {
+			...config,
+			mcpServers: { ...config.mcpServers, [name]: updatedServer },
+		});
+	}
 	await setServerDisabled(mcpConfigPath, name, !enabled);
-	return { ok: true };
+	const id = `mcp:${name}`;
+	const nextDisabledExtensions = enabled
+		? disabledExtensions.filter(entry => entry !== id)
+		: disabledExtensions.includes(id)
+			? disabledExtensions
+			: [...disabledExtensions, id];
+	return { ok: true, disabledExtensions: nextDisabledExtensions } as MutationResult & {
+		disabledExtensions: string[];
+	};
 }
 
 /** Remove a server via the canonical config writer. */

--- a/packages/coding-agent/src/customization/mutations.ts
+++ b/packages/coding-agent/src/customization/mutations.ts
@@ -1,0 +1,142 @@
+/**
+ * Safe mutations for the `/extensions` umbrella customization surface
+ * (issue #4291). Every operation goes through the same canonical
+ * loaders/writers the runtime and CLI use — no parallel state model.
+ *
+ * - Skills: enable/disable via frontmatter `enabled`, remove with bundled-name
+ *   and symlink protection.
+ * - MCPs: enable/disable via the `enabled` flag and remove via the canonical
+ *   config writer (atomic write, cache invalidation included).
+ * - Hooks: remove only (directory hook files); enable/disable is not part of
+ *   the canonical hook contract and is rejected with a diagnostic.
+ */
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import { parseFrontmatter } from "@gajae-code/utils";
+import { YAML } from "bun";
+import { BUNDLED_GJC_SKILL_CATALOG } from "../defaults/gjc-skills.generated";
+import { readMCPConfigFile, removeMCPServer, writeMCPConfigFile } from "../runtime-mcp/config-writer";
+import type { GjcScopePaths } from "./types";
+
+const BUNDLED_SKILL_NAMES: ReadonlySet<string> = new Set(
+	BUNDLED_GJC_SKILL_CATALOG.flatMap(entry =>
+		entry.kind === "skill" && typeof entry.name === "string" ? [entry.name] : [],
+	),
+);
+
+export type MutationResult = { ok: true } | { ok: false; reason: string };
+
+// ---------------------------------------------------------------------------
+// Skills
+// ---------------------------------------------------------------------------
+
+async function resolveSkillDir(paths: GjcScopePaths, slug: string): Promise<{ dir: string } | { error: string }> {
+	const dir = path.join(paths.skillsDir, slug);
+	const relative = path.relative(paths.skillsDir, dir);
+	if (relative.startsWith("..") || path.isAbsolute(relative)) {
+		return { error: `skill name "${slug}" escapes the skills directory` };
+	}
+	try {
+		const stat = await fs.lstat(dir);
+		if (stat.isSymbolicLink()) return { error: `refusing to mutate symlinked skill directory: ${dir}` };
+		if (!stat.isDirectory()) return { error: `not a skill directory: ${dir}` };
+	} catch {
+		return { error: `skill "${slug}" not found at ${dir}` };
+	}
+	return { dir };
+}
+
+/** Toggle a local skill via its frontmatter `enabled` flag. */
+export async function setSkillEnabled(paths: GjcScopePaths, slug: string, enabled: boolean): Promise<MutationResult> {
+	if (BUNDLED_SKILL_NAMES.has(slug)) {
+		return { ok: false, reason: `"${slug}" is a protected bundled workflow skill name` };
+	}
+	const resolved = await resolveSkillDir(paths, slug);
+	if ("error" in resolved) return { ok: false, reason: resolved.error };
+	const skillPath = path.join(resolved.dir, "SKILL.md");
+	let text: string;
+	try {
+		text = await fs.readFile(skillPath, "utf-8");
+	} catch {
+		return { ok: false, reason: `no SKILL.md at ${skillPath}` };
+	}
+	const { frontmatter, body } = parseFrontmatter(text, { level: "off" });
+	const fm: Record<string, unknown> = { ...frontmatter };
+	if (enabled) {
+		delete fm.enabled;
+	} else {
+		fm.enabled = false;
+	}
+	const yaml = YAML.stringify(fm).trimEnd();
+	await fs.writeFile(skillPath, `---\n${yaml}\n---\n\n${body.trim()}\n`, "utf-8");
+	return { ok: true };
+}
+
+/** Remove a local skill directory. Never removes bundled-name shadows blindly. */
+export async function removeSkill(paths: GjcScopePaths, slug: string): Promise<MutationResult> {
+	if (BUNDLED_SKILL_NAMES.has(slug)) {
+		return { ok: false, reason: `"${slug}" is a protected bundled workflow skill name` };
+	}
+	const resolved = await resolveSkillDir(paths, slug);
+	if ("error" in resolved) return { ok: false, reason: resolved.error };
+	await fs.rm(resolved.dir, { recursive: true, force: true });
+	return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// MCPs
+// ---------------------------------------------------------------------------
+
+/** Toggle a server's `enabled` flag in the canonical mcp.json writer. */
+export async function setMcpServerEnabled(
+	mcpConfigPath: string,
+	name: string,
+	enabled: boolean,
+): Promise<MutationResult> {
+	const config = await readMCPConfigFile(mcpConfigPath).catch(() => null);
+	if (!config) return { ok: false, reason: `${mcpConfigPath} is malformed; fix or remove it first` };
+	const server = config.mcpServers?.[name];
+	if (!server) return { ok: false, reason: `server "${name}" not found in ${mcpConfigPath}` };
+	const updatedServer = { ...server };
+	if (enabled) {
+		delete updatedServer.enabled;
+	} else {
+		updatedServer.enabled = false;
+	}
+	await writeMCPConfigFile(mcpConfigPath, {
+		...config,
+		mcpServers: { ...config.mcpServers, [name]: updatedServer },
+	});
+	return { ok: true };
+}
+
+/** Remove a server via the canonical config writer. */
+export async function removeMcpServerEntry(mcpConfigPath: string, name: string): Promise<MutationResult> {
+	try {
+		await removeMCPServer(mcpConfigPath, name);
+		return { ok: true };
+	} catch (error) {
+		return { ok: false, reason: (error as Error).message };
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+/** Remove a directory hook file; refuses symlinks and paths outside the hooks dir. */
+export async function removeHookFile(paths: GjcScopePaths, fileName: string): Promise<MutationResult> {
+	const filePath = path.join(paths.hooksDir, fileName);
+	const relative = path.relative(paths.hooksDir, filePath);
+	if (relative.startsWith("..") || path.isAbsolute(relative)) {
+		return { ok: false, reason: `hook name "${fileName}" escapes the hooks directory` };
+	}
+	try {
+		const stat = await fs.lstat(filePath);
+		if (stat.isSymbolicLink()) return { ok: false, reason: `refusing to remove symlinked hook: ${filePath}` };
+		await fs.rm(filePath, { force: true });
+		return { ok: true };
+	} catch (error) {
+		return { ok: false, reason: (error as Error).message };
+	}
+}

--- a/packages/coding-agent/src/customization/mutations.ts
+++ b/packages/coding-agent/src/customization/mutations.ts
@@ -16,7 +16,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { setNativeSkillEnabled } from "../extensibility/skill-management";
-import { readMCPConfigFile, removeMCPServer, writeMCPConfigFile } from "../runtime-mcp/config-writer";
+import { readMCPConfigFile, removeMCPServer, setServerDisabled } from "../runtime-mcp/config-writer";
 import { CANONICAL_GJC_WORKFLOW_SKILLS } from "../skill-state/canonical-skills";
 
 const BUNDLED_SKILL_NAMES: ReadonlySet<string> = new Set(CANONICAL_GJC_WORKFLOW_SKILLS);
@@ -74,7 +74,7 @@ export async function removeSkill(record: { name: string; path: string }): Promi
 // MCPs
 // ---------------------------------------------------------------------------
 
-/** Toggle a server's `enabled` flag in the canonical mcp.json writer. */
+/** Toggle a server through the canonical disabledServers denylist. */
 export async function setMcpServerEnabled(
 	mcpConfigPath: string,
 	name: string,
@@ -84,16 +84,7 @@ export async function setMcpServerEnabled(
 	if (!config) return { ok: false, reason: `${mcpConfigPath} is malformed; fix or remove it first` };
 	const server = config.mcpServers?.[name];
 	if (!server) return { ok: false, reason: `server "${name}" not found in ${mcpConfigPath}` };
-	const updatedServer = { ...server };
-	if (enabled) {
-		delete updatedServer.enabled;
-	} else {
-		updatedServer.enabled = false;
-	}
-	await writeMCPConfigFile(mcpConfigPath, {
-		...config,
-		mcpServers: { ...config.mcpServers, [name]: updatedServer },
-	});
+	await setServerDisabled(mcpConfigPath, name, !enabled);
 	return { ok: true };
 }
 

--- a/packages/coding-agent/src/customization/mutations.ts
+++ b/packages/coding-agent/src/customization/mutations.ts
@@ -3,26 +3,23 @@
  * (issue #4291). Every operation goes through the same canonical
  * loaders/writers the runtime and CLI use — no parallel state model.
  *
- * - Skills: enable/disable via frontmatter `enabled`, remove with bundled-name
- *   and symlink protection.
+ * - Skills: enable/disable via the authoritative `setNativeSkillEnabled`
+ *   policy contract (the caller persists the returned `disabledExtensions`
+ *   list through Settings); remove targets the exact discovered SKILL.md
+ *   path identity with bundled-name and symlink protection.
  * - MCPs: enable/disable via the `enabled` flag and remove via the canonical
  *   config writer (atomic write, cache invalidation included).
- * - Hooks: remove only (directory hook files); enable/disable is not part of
- *   the canonical hook contract and is rejected with a diagnostic.
+ * - Hooks: remove only, by exact discovered path; enable/disable is not part
+ *   of the canonical hook contract and is rejected by the UI with a
+ *   diagnostic.
  */
-import { promises as fs } from "node:fs";
+import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { parseFrontmatter } from "@gajae-code/utils";
-import { YAML } from "bun";
-import { BUNDLED_GJC_SKILL_CATALOG } from "../defaults/gjc-skills.generated";
+import { setNativeSkillEnabled } from "../extensibility/skill-management";
 import { readMCPConfigFile, removeMCPServer, writeMCPConfigFile } from "../runtime-mcp/config-writer";
-import type { GjcScopePaths } from "./types";
+import { CANONICAL_GJC_WORKFLOW_SKILLS } from "../skill-state/canonical-skills";
 
-const BUNDLED_SKILL_NAMES: ReadonlySet<string> = new Set(
-	BUNDLED_GJC_SKILL_CATALOG.flatMap(entry =>
-		entry.kind === "skill" && typeof entry.name === "string" ? [entry.name] : [],
-	),
-);
+const BUNDLED_SKILL_NAMES: ReadonlySet<string> = new Set(CANONICAL_GJC_WORKFLOW_SKILLS);
 
 export type MutationResult = { ok: true } | { ok: false; reason: string };
 
@@ -30,56 +27,46 @@ export type MutationResult = { ok: true } | { ok: false; reason: string };
 // Skills
 // ---------------------------------------------------------------------------
 
-async function resolveSkillDir(paths: GjcScopePaths, slug: string): Promise<{ dir: string } | { error: string }> {
-	const dir = path.join(paths.skillsDir, slug);
-	const relative = path.relative(paths.skillsDir, dir);
-	if (relative.startsWith("..") || path.isAbsolute(relative)) {
-		return { error: `skill name "${slug}" escapes the skills directory` };
+/**
+ * Toggle a native skill through the authoritative policy contract. Returns
+ * the updated `disabledExtensions` list; the caller persists it via Settings.
+ * Bundled workflow skill names cannot be disabled.
+ */
+export function setSkillEnabled(
+	name: string,
+	enabled: boolean,
+	disabledExtensions: string[],
+): MutationResult & { disabledExtensions?: string[] } {
+	if (!enabled && BUNDLED_SKILL_NAMES.has(name)) {
+		return { ok: false, reason: `"${name}" is a protected bundled workflow skill name` };
 	}
-	try {
-		const stat = await fs.lstat(dir);
-		if (stat.isSymbolicLink()) return { error: `refusing to mutate symlinked skill directory: ${dir}` };
-		if (!stat.isDirectory()) return { error: `not a skill directory: ${dir}` };
-	} catch {
-		return { error: `skill "${slug}" not found at ${dir}` };
-	}
-	return { dir };
+	return { ok: true, disabledExtensions: setNativeSkillEnabled(name, enabled, disabledExtensions) };
 }
 
-/** Toggle a local skill via its frontmatter `enabled` flag. */
-export async function setSkillEnabled(paths: GjcScopePaths, slug: string, enabled: boolean): Promise<MutationResult> {
-	if (BUNDLED_SKILL_NAMES.has(slug)) {
-		return { ok: false, reason: `"${slug}" is a protected bundled workflow skill name` };
+/**
+ * Remove a native skill by its exact discovered SKILL.md path identity.
+ * Fails when the discovered file is absent, refuses symlinked directories or
+ * files, and never removes protected bundled workflow skill names.
+ */
+export async function removeSkill(record: { name: string; path: string }): Promise<MutationResult> {
+	if (BUNDLED_SKILL_NAMES.has(record.name)) {
+		return { ok: false, reason: `"${record.name}" is a protected bundled workflow skill name` };
 	}
-	const resolved = await resolveSkillDir(paths, slug);
-	if ("error" in resolved) return { ok: false, reason: resolved.error };
-	const skillPath = path.join(resolved.dir, "SKILL.md");
-	let text: string;
+	const dir = path.dirname(record.path);
 	try {
-		text = await fs.readFile(skillPath, "utf-8");
+		const fileStat = await fs.lstat(record.path);
+		if (fileStat.isSymbolicLink())
+			return { ok: false, reason: `refusing to remove symlinked skill file: ${record.path}` };
+		if (!fileStat.isFile())
+			return { ok: false, reason: `discovered skill file is not a regular file: ${record.path}` };
+		const dirStat = await fs.lstat(dir);
+		if (dirStat.isSymbolicLink())
+			return { ok: false, reason: `refusing to remove symlinked skill directory: ${dir}` };
+		if (!dirStat.isDirectory()) return { ok: false, reason: `not a skill directory: ${dir}` };
 	} catch {
-		return { ok: false, reason: `no SKILL.md at ${skillPath}` };
+		return { ok: false, reason: `discovered skill file is absent: ${record.path}` };
 	}
-	const { frontmatter, body } = parseFrontmatter(text, { level: "off" });
-	const fm: Record<string, unknown> = { ...frontmatter };
-	if (enabled) {
-		delete fm.enabled;
-	} else {
-		fm.enabled = false;
-	}
-	const yaml = YAML.stringify(fm).trimEnd();
-	await fs.writeFile(skillPath, `---\n${yaml}\n---\n\n${body.trim()}\n`, "utf-8");
-	return { ok: true };
-}
-
-/** Remove a local skill directory. Never removes bundled-name shadows blindly. */
-export async function removeSkill(paths: GjcScopePaths, slug: string): Promise<MutationResult> {
-	if (BUNDLED_SKILL_NAMES.has(slug)) {
-		return { ok: false, reason: `"${slug}" is a protected bundled workflow skill name` };
-	}
-	const resolved = await resolveSkillDir(paths, slug);
-	if ("error" in resolved) return { ok: false, reason: resolved.error };
-	await fs.rm(resolved.dir, { recursive: true, force: true });
+	await fs.rm(dir, { recursive: true, force: false });
 	return { ok: true };
 }
 
@@ -124,17 +111,16 @@ export async function removeMcpServerEntry(mcpConfigPath: string, name: string):
 // Hooks
 // ---------------------------------------------------------------------------
 
-/** Remove a directory hook file; refuses symlinks and paths outside the hooks dir. */
-export async function removeHookFile(paths: GjcScopePaths, fileName: string): Promise<MutationResult> {
-	const filePath = path.join(paths.hooksDir, fileName);
-	const relative = path.relative(paths.hooksDir, filePath);
-	if (relative.startsWith("..") || path.isAbsolute(relative)) {
-		return { ok: false, reason: `hook name "${fileName}" escapes the hooks directory` };
-	}
+/**
+ * Remove a hook by its exact discovered path. Refuses symlinks, non-files,
+ * and paths that do not exist (no silent success).
+ */
+export async function removeHookFile(hookPath: string): Promise<MutationResult> {
 	try {
-		const stat = await fs.lstat(filePath);
-		if (stat.isSymbolicLink()) return { ok: false, reason: `refusing to remove symlinked hook: ${filePath}` };
-		await fs.rm(filePath, { force: true });
+		const stat = await fs.lstat(hookPath);
+		if (stat.isSymbolicLink()) return { ok: false, reason: `refusing to remove symlinked hook: ${hookPath}` };
+		if (!stat.isFile()) return { ok: false, reason: `not a hook file: ${hookPath}` };
+		await fs.rm(hookPath, { force: false });
 		return { ok: true };
 	} catch (error) {
 		return { ok: false, reason: (error as Error).message };

--- a/packages/coding-agent/src/customization/types.ts
+++ b/packages/coding-agent/src/customization/types.ts
@@ -1,0 +1,211 @@
+/**
+ * Core types and scope resolution for the `/extensions` umbrella local
+ * customization surface (issue #4291, parent #4283).
+ *
+ * `.gjc` is the canonical persisted authority at two scopes:
+ * - project-local: `<project>/.gjc/`
+ * - user-global:   `~/.gjc/agent/`
+ *
+ * Claude Code and Codex layouts are import sources only — never a parallel
+ * runtime authority. This module defines the narrow contract types the UI
+ * and import flow consume without coupling to sibling ownership internals
+ * or to the provider/extension-module ExtensionDashboard.
+ */
+import * as path from "node:path";
+import { getAgentDir, getMCPConfigPath, getProjectAgentDir } from "@gajae-code/utils";
+import type { MigrateSource } from "../migrate/types";
+import type { MCPServerConfig } from "../runtime-mcp/types";
+
+// ---------------------------------------------------------------------------
+// Scope
+// ---------------------------------------------------------------------------
+
+export type GjcScope = "project" | "global";
+
+export interface GjcScopePaths {
+	scope: GjcScope;
+	/** Root directory: `<project>/.gjc` or `~/.gjc/agent` */
+	root: string;
+	/** MCP config: `<root>/mcp.json` */
+	mcpConfigPath: string;
+	/** Skills directory: `<root>/skills/` */
+	skillsDir: string;
+	/** Hooks directory: `<root>/hooks/` */
+	hooksDir: string;
+}
+
+export function resolveScopePaths(scope: GjcScope, projectCwd: string): GjcScopePaths {
+	if (scope === "project") {
+		const root = getProjectAgentDir(projectCwd);
+		return {
+			scope,
+			root,
+			mcpConfigPath: getMCPConfigPath("project", projectCwd),
+			skillsDir: path.join(root, "skills"),
+			hooksDir: path.join(root, "hooks"),
+		};
+	}
+	const root = getAgentDir();
+	return {
+		scope,
+		root,
+		mcpConfigPath: getMCPConfigPath("user", projectCwd),
+		skillsDir: path.join(root, "skills"),
+		hooksDir: path.join(root, "hooks"),
+	};
+}
+
+export function scopeLabel(scope: GjcScope): string {
+	return scope === "project" ? "Project .gjc" : "Global .gjc";
+}
+
+// ---------------------------------------------------------------------------
+// Customization surfaces
+// ---------------------------------------------------------------------------
+
+export type CustomizationSurface = "skills" | "hooks" | "mcps";
+
+export const CUSTOMIZATION_SURFACES: readonly CustomizationSurface[] = ["skills", "hooks", "mcps"];
+
+export function surfaceLabel(surface: CustomizationSurface): string {
+	switch (surface) {
+		case "skills":
+			return "Skills";
+		case "hooks":
+			return "Hooks";
+		case "mcps":
+			return "MCPs";
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Import source
+// ---------------------------------------------------------------------------
+
+export type ImportProduct = Exclude<MigrateSource, "opencode">;
+export type ImportSourceScope = "project" | "user";
+
+export const IMPORT_PRODUCTS: readonly ImportProduct[] = ["claude-code", "codex"];
+export const IMPORT_SOURCE_SCOPES: readonly ImportSourceScope[] = ["project", "user"];
+
+export function productLabel(product: ImportProduct): string {
+	switch (product) {
+		case "claude-code":
+			return "Claude Code";
+		case "codex":
+			return "Codex";
+	}
+}
+
+export function sourceScopeLabel(scope: ImportSourceScope): string {
+	return scope === "project" ? "Project-local" : "User-global";
+}
+
+export function sourceConfigDir(
+	product: ImportProduct,
+	sourceScope: ImportSourceScope,
+	projectCwd: string,
+	homeDir: string,
+): string {
+	if (product === "claude-code") {
+		return sourceScope === "project" ? path.join(projectCwd, ".claude") : path.join(homeDir, ".claude");
+	}
+	return sourceScope === "project" ? path.join(projectCwd, ".codex") : path.join(homeDir, ".codex");
+}
+
+// ---------------------------------------------------------------------------
+// Inventory row — provenance/status model for the dashboard
+// ---------------------------------------------------------------------------
+
+export type InventoryStatus =
+	| "enabled"
+	| "disabled"
+	| "invalid"
+	| "shadowed"
+	| "quarantined"
+	| "imported"
+	| "restart-required";
+
+export interface InventoryRow {
+	/** Surface kind */
+	surface: CustomizationSurface;
+	/** Entry name */
+	name: string;
+	/** Display name */
+	displayName: string;
+	/** Effective status */
+	status: InventoryStatus;
+	/** Provenance — which scope/convention discovered it */
+	provenance: string;
+	/** Absolute source path */
+	path: string;
+	/** Scope that persists this row (project `.gjc` or global `.gjc`) */
+	scope: GjcScope;
+	/** Short description (no secrets) */
+	description?: string;
+	/** Diagnostics/remediation detail for invalid/conflicted rows */
+	diagnostics?: string[];
+	/** Raw item for inspector (secret-redacted before display) */
+	raw: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Normalized import preview
+// ---------------------------------------------------------------------------
+
+export type ImportCollisionPolicy = "skip" | "rename" | "overwrite";
+
+export type ImportEntryStatus = "add" | "conflict" | "unsupported" | "redacted" | "overwrite";
+
+export interface ImportPreviewEntry {
+	surface: CustomizationSurface;
+	/** Source name in the foreign layout */
+	sourceName: string;
+	/** Destination name in `.gjc` (may differ under rename policy) */
+	destinationName: string;
+	status: ImportEntryStatus;
+	/** Source path category (file, section, etc.) */
+	sourceCategory: string;
+	/** Redacted description for the preview UI */
+	description: string;
+	/** Reason for conflict/unsupported/redaction if applicable */
+	reason?: string;
+	/** Normalized data to write (never exposed in UI) */
+	_payload?: NormalizedPayload;
+}
+
+export interface NormalizedPayload {
+	mcp?: { name: string; config: MCPServerConfig };
+	skill?: { slug: string; content: string };
+	hook?: { sourceName: string; destinationName: string; content: string; warnings: string[] };
+}
+
+export interface ImportPreview {
+	product: ImportProduct;
+	sourceScope: ImportSourceScope;
+	destinationScope: GjcScope;
+	surfaces: CustomizationSurface[];
+	entries: ImportPreviewEntry[];
+	/** Aggregate warnings across all entries */
+	warnings: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Import result
+// ---------------------------------------------------------------------------
+
+export type ImportOutcome = "imported" | "skipped" | "renamed" | "overwritten" | "failed";
+
+export interface ImportResultEntry {
+	surface: CustomizationSurface;
+	sourceName: string;
+	destinationName: string;
+	outcome: ImportOutcome;
+	reason?: string;
+}
+
+export interface ImportResult {
+	entries: ImportResultEntry[];
+	/** True if all entries succeeded (imported/skipped/renamed/overwritten) */
+	ok: boolean;
+}

--- a/packages/coding-agent/src/customization/types.ts
+++ b/packages/coding-agent/src/customization/types.ts
@@ -127,6 +127,8 @@ export type InventoryStatus =
 	| "restart-required";
 
 export interface InventoryRow {
+	/** Stable row identity: `<surface>:<scope>:<path>` */
+	id: string;
 	/** Surface kind */
 	surface: CustomizationSurface;
 	/** Entry name */
@@ -137,7 +139,7 @@ export interface InventoryRow {
 	status: InventoryStatus;
 	/** Provenance — which scope/convention discovered it */
 	provenance: string;
-	/** Absolute source path */
+	/** Absolute discovered path — the exact identity mutations act on */
 	path: string;
 	/** Scope that persists this row (project `.gjc` or global `.gjc`) */
 	scope: GjcScope;
@@ -145,7 +147,7 @@ export interface InventoryRow {
 	description?: string;
 	/** Diagnostics/remediation detail for invalid/conflicted rows */
 	diagnostics?: string[];
-	/** Raw item for inspector (secret-redacted before display) */
+	/** Redacted inspector payload (never contains secret values) */
 	raw: unknown;
 }
 
@@ -170,14 +172,12 @@ export interface ImportPreviewEntry {
 	description: string;
 	/** Reason for conflict/unsupported/redaction if applicable */
 	reason?: string;
-	/** Normalized data to write (never exposed in UI) */
-	_payload?: NormalizedPayload;
 }
 
 export interface NormalizedPayload {
 	mcp?: { name: string; config: MCPServerConfig };
 	skill?: { slug: string; content: string };
-	hook?: { sourceName: string; destinationName: string; content: string; warnings: string[] };
+	hook?: { phase: "pre" | "post"; fileName: string; content: string };
 }
 
 export interface ImportPreview {
@@ -188,6 +188,18 @@ export interface ImportPreview {
 	entries: ImportPreviewEntry[];
 	/** Aggregate warnings across all entries */
 	warnings: string[];
+}
+
+/**
+ * Validated apply plan produced alongside the redacted preview. `payloads` is
+ * parallel to `preview.entries` (undefined for entries that carry no write).
+ * It is deliberately separate from the preview DTO: the preview is safe to
+ * serialize and display, while the plan holds full file contents and MCP
+ * secret values and is only consumed by the apply transaction.
+ */
+export interface ImportPlan {
+	preview: ImportPreview;
+	payloads: readonly (NormalizedPayload | undefined)[];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/coding-agent/src/modes/components/customization/customization-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/customization/customization-dashboard.ts
@@ -136,6 +136,7 @@ export class CustomizationDashboard extends Container {
 
 	#skillPolicy(): SkillManagementPolicy {
 		return {
+			enabled: this.#settings?.get("skills.enabled") as boolean | undefined,
 			trustProjectSkills: this.#settings?.get("skills.trustProjectSkills") as boolean | undefined,
 			trustUserSkills: this.#settings?.get("skills.trustUserSkills") as boolean | undefined,
 			ignoredSkills: this.#getStringArray("skills.ignoredSkills"),
@@ -274,6 +275,10 @@ export class CustomizationDashboard extends Container {
 		}
 		const enable = row.status === "disabled";
 		if (row.surface === "skills") {
+			if (enable && this.#settings?.get("skills.enabled") === false) {
+				this.#flashStatus("native skills are disabled globally; enable skills.enabled in /settings first");
+				return;
+			}
 			const result = setSkillEnabled(row.name, enable, this.#getStringArray("disabledExtensions"));
 			if (!result.ok) {
 				this.#flashStatus(result.reason);
@@ -287,7 +292,20 @@ export class CustomizationDashboard extends Container {
 			await this.#applyMutation(async () => ({ ok: true }) as { ok: true });
 		} else if (row.surface === "mcps") {
 			const paths = resolveScopePaths(row.scope, this.#cwd);
-			await this.#applyMutation(() => setMcpServerEnabled(paths.mcpConfigPath, row.name, enable));
+			const result = await setMcpServerEnabled(
+				paths.mcpConfigPath,
+				row.name,
+				enable,
+				this.#getStringArray("disabledExtensions"),
+			);
+			if (!result.ok) {
+				this.#flashStatus(result.reason);
+				return;
+			}
+			if ("disabledExtensions" in result && this.#settings?.set) {
+				this.#settings.set("disabledExtensions", result.disabledExtensions);
+			}
+			await this.#applyMutation(async () => ({ ok: true }) as { ok: true });
 		} else {
 			this.#flashStatus("hook enable/disable is not part of the canonical hook contract; remove instead");
 		}

--- a/packages/coding-agent/src/modes/components/customization/customization-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/customization/customization-dashboard.ts
@@ -1,0 +1,377 @@
+/**
+ * CustomizationDashboard — the umbrella local-customization home opened by the
+ * `/extensions` slash command (issue #4291).
+ *
+ * This is a standalone state model and component tree around local
+ * Skills/Hooks/MCPs/Import. It is intentionally NOT built on the
+ * provider/extension-module ExtensionDashboard; the two surfaces share only
+ * generic TUI primitives (Container, Text, SelectList, DynamicBorder).
+ *
+ * Layout (narrow-terminal safe):
+ *   title: /extensions — Configure skills, hooks, and MCPs.
+ *   destination scope badge (Project .gjc / Global .gjc) — `s` switches
+ *   section tabs: Skills | Hooks | MCPs — left/right switch
+ *   inventory rows for the active section with status + provenance
+ *   footer key hints
+ */
+import { Container, matchesKey, type SelectItem, SelectList, Text } from "@gajae-code/tui";
+import { type CustomizationInventory, loadCustomizationInventory } from "../../../customization/inventory";
+import {
+	removeHookFile,
+	removeMcpServerEntry,
+	removeSkill,
+	setMcpServerEnabled,
+	setSkillEnabled,
+} from "../../../customization/mutations";
+import {
+	CUSTOMIZATION_SURFACES,
+	type CustomizationSurface,
+	type GjcScope,
+	type InventoryRow,
+	resolveScopePaths,
+	scopeLabel,
+	surfaceLabel,
+} from "../../../customization/types";
+import { replaceTabs, truncateToWidth } from "../../../tools/render-utils";
+import { getSelectListTheme, theme } from "../../theme/theme";
+import { matchesAppInterrupt } from "../../utils/keybinding-matchers";
+import { DynamicBorder } from "../dynamic-border";
+import { ImportWizard } from "./import-wizard";
+
+/** Minimal settings slice the dashboard reads. */
+export interface CustomizationSettingsSlice {
+	get(key: string): unknown;
+}
+
+const STATUS_COLORS: Record<InventoryRow["status"], (text: string) => string> = {
+	enabled: text => theme.fg("success", text),
+	disabled: text => theme.fg("muted", text),
+	invalid: text => theme.fg("error", text),
+	shadowed: text => theme.fg("warning", text),
+	quarantined: text => theme.fg("warning", text),
+	imported: text => theme.fg("accent", text),
+	"restart-required": text => theme.fg("warning", text),
+};
+
+function rowToSelectItem(row: InventoryRow): SelectItem {
+	const color = STATUS_COLORS[row.status];
+	const status = color(row.status);
+	return {
+		value: `${row.surface}:${row.scope}:${row.name}`,
+		label: replaceTabs(row.displayName),
+		description: `${status} ${theme.fg("muted", `· ${replaceTabs(row.provenance)}`)}${
+			row.description ? theme.fg("muted", ` — ${replaceTabs(row.description)}`) : ""
+		}`,
+	};
+}
+
+export class CustomizationDashboard extends Container {
+	/** Called when the dashboard wants to close (Esc / q / interrupt). */
+	onClose: (() => void) | undefined;
+	/** Called whenever the dashboard needs a re-render. */
+	onRequestRender: (() => void) | undefined;
+
+	#cwd: string;
+	#settings: CustomizationSettingsSlice | undefined;
+	#scope: GjcScope = "project";
+	#section: CustomizationSurface = "skills";
+	#inventory: CustomizationInventory = { rows: [], warnings: [] };
+	#lists = new Map<CustomizationSurface, SelectList>();
+	#bodyContainer!: Container;
+	#headerTexts: Text[] = [];
+	#footerText!: Text;
+	#wizard: ImportWizard | null = null;
+	#confirmRemove: InventoryRow | null = null;
+	#statusMessage: string | null = null;
+
+	private constructor(cwd: string, settings: CustomizationSettingsSlice | undefined) {
+		super();
+		this.#cwd = cwd;
+		this.#settings = settings;
+	}
+
+	static async create(cwd: string, settings?: CustomizationSettingsSlice): Promise<CustomizationDashboard> {
+		const dashboard = new CustomizationDashboard(cwd, settings);
+		await dashboard.#reload();
+		dashboard.#buildChrome();
+		return dashboard;
+	}
+
+	get scope(): GjcScope {
+		return this.#scope;
+	}
+
+	get section(): CustomizationSurface {
+		return this.#section;
+	}
+
+	/** Current inventory snapshot (test-visible). */
+	get inventory(): CustomizationInventory {
+		return this.#inventory;
+	}
+
+	async #reload(): Promise<void> {
+		const disabled = this.#settings?.get("disabledExtensions");
+		this.#inventory = await loadCustomizationInventory({
+			cwd: this.#cwd,
+			disabledExtensions: Array.isArray(disabled) ? (disabled as string[]) : [],
+		});
+	}
+
+	#buildChrome(): void {
+		this.clear();
+		this.#headerTexts = [];
+		this.#lists.clear();
+
+		this.addChild(new DynamicBorder());
+		const title = new Text("", 0, 0);
+		const scopeLine = new Text("", 0, 0);
+		const tabs = new Text("", 0, 0);
+		this.#headerTexts = [title, scopeLine, tabs];
+		this.addChild(title);
+		this.addChild(scopeLine);
+		this.addChild(tabs);
+		this.addChild(new DynamicBorder());
+
+		this.#bodyContainer = new Container();
+		for (const surface of CUSTOMIZATION_SURFACES) {
+			const rows = this.#inventory.rows.filter(row => row.surface === surface);
+			const items: SelectItem[] =
+				rows.length > 0
+					? rows.map(rowToSelectItem)
+					: [
+							{
+								value: `${surface}:empty`,
+								label: theme.fg("muted", `(no ${surfaceLabel(surface).toLowerCase()} configured)`),
+								description: theme.fg("muted", "nothing configured at Project .gjc or Global .gjc yet"),
+								disabled: true,
+							},
+						];
+			const list = new SelectList(items, Math.min(Math.max(items.length, 1), 8), getSelectListTheme());
+			list.onCancel = () => this.onClose?.();
+			this.#lists.set(surface, list);
+			if (surface === this.#section) this.#bodyContainer.addChild(list);
+		}
+		this.addChild(this.#bodyContainer);
+
+		this.addChild(new DynamicBorder());
+		this.#footerText = new Text("", 0, 0);
+		this.addChild(this.#footerText);
+		this.addChild(new DynamicBorder());
+		this.#refreshChrome();
+	}
+
+	#refreshChrome(): void {
+		const [title, scopeLine, tabs] = this.#headerTexts;
+		title.setText(
+			theme.bold(theme.fg("accent", "/extensions")) + theme.fg("muted", " — Configure skills, hooks, and MCPs."),
+		);
+		const other: GjcScope = this.#scope === "project" ? "global" : "project";
+		scopeLine.setText(
+			`${theme.fg("muted", "destination:")} ${theme.bold(scopeLabel(this.#scope))}  ${theme.fg("muted", `(s: switch to ${scopeLabel(other)})`)}`,
+		);
+		const tabLine = CUSTOMIZATION_SURFACES.map(surface =>
+			surface === this.#section
+				? theme.bold(theme.fg("accent", `[${surfaceLabel(surface)}]`))
+				: ` ${surfaceLabel(surface)} `,
+		).join(theme.fg("muted", "│"));
+		tabs.setText(tabLine);
+		const warnings = this.#inventory.warnings.length;
+		const status = this.#statusMessage ? ` · ${theme.fg("accent", replaceTabs(this.#statusMessage))}` : "";
+		const confirm = this.#confirmRemove
+			? ` · ${theme.fg("warning", `remove ${this.#confirmRemove.displayName}? y/n`)}`
+			: "";
+		this.#footerText.setText(
+			theme.fg(
+				"muted",
+				`↑/↓ navigate · ←/→ section · s scope · e enable/disable · x remove · i import · esc close${
+					warnings > 0 ? ` · ${theme.fg("warning", `${warnings} diagnostic${warnings === 1 ? "" : "s"}`)}` : ""
+				}${confirm}${status}`,
+			),
+		);
+	}
+
+	#selectedRow(): InventoryRow | null {
+		const selected = this.#lists.get(this.#section)?.getSelectedItem();
+		if (!selected || selected.disabled) return null;
+		return this.#inventory.rows.find(row => `${row.surface}:${row.scope}:${row.name}` === selected.value) ?? null;
+	}
+
+	/** Rows discovered outside the canonical .gjc scopes are import sources, not managed entries. */
+	#isForeignRow(row: InventoryRow): boolean {
+		return row.provenance.includes("import to manage");
+	}
+
+	async #applyMutation(action: () => Promise<{ ok: true } | { ok: false; reason: string }>): Promise<void> {
+		const result = await action();
+		this.#statusMessage = result.ok ? "done — reloaded inventory" : result.reason;
+		await this.#reload();
+		this.#buildChrome();
+		this.onRequestRender?.();
+	}
+
+	async #toggleSelected(): Promise<void> {
+		const row = this.#selectedRow();
+		if (!row) return;
+		if (this.#isForeignRow(row)) {
+			this.#statusMessage = "foreign entries are import sources — use i to import, not managed in place";
+			this.#refreshChrome();
+			this.onRequestRender?.();
+			return;
+		}
+		if (row.status === "invalid" || row.status === "shadowed" || row.status === "quarantined") {
+			this.#statusMessage = `cannot toggle a ${row.status} entry; resolve its diagnostics first`;
+			this.#refreshChrome();
+			this.onRequestRender?.();
+			return;
+		}
+		const enable = row.status === "disabled";
+		const paths = resolveScopePaths(row.scope, this.#cwd);
+		if (row.surface === "skills") {
+			await this.#applyMutation(() => setSkillEnabled(paths, row.name, enable));
+		} else if (row.surface === "mcps") {
+			await this.#applyMutation(() => setMcpServerEnabled(paths.mcpConfigPath, row.name, enable));
+		} else {
+			this.#statusMessage = "hook enable/disable is not part of the canonical hook contract; remove instead";
+			this.#refreshChrome();
+			this.onRequestRender?.();
+		}
+	}
+
+	#beginRemove(): void {
+		const row = this.#selectedRow();
+		if (!row) return;
+		if (this.#isForeignRow(row)) {
+			this.#statusMessage = "foreign entries are import sources — use i to import, not managed in place";
+			this.#refreshChrome();
+			this.onRequestRender?.();
+			return;
+		}
+		this.#confirmRemove = row;
+		this.#refreshChrome();
+		this.onRequestRender?.();
+	}
+
+	async #confirmRemoveSelected(): Promise<void> {
+		const row = this.#confirmRemove;
+		this.#confirmRemove = null;
+		if (!row) return;
+		const paths = resolveScopePaths(row.scope, this.#cwd);
+		if (row.surface === "skills") {
+			await this.#applyMutation(() => removeSkill(paths, row.name));
+		} else if (row.surface === "mcps") {
+			await this.#applyMutation(() => removeMcpServerEntry(paths.mcpConfigPath, row.name));
+		} else {
+			const fileName = row.path.split("/").pop() ?? row.name;
+			await this.#applyMutation(() => removeHookFile(paths, fileName));
+		}
+	}
+
+	#openImportWizard(): void {
+		const wizard = new ImportWizard(this.#cwd, this.#scope);
+		this.#wizard = wizard;
+		wizard.onRequestRender = () => this.onRequestRender?.();
+		wizard.onClose = applied => {
+			this.#wizard = null;
+			this.#bodyContainer.clear();
+			const list = this.#lists.get(this.#section);
+			if (list) this.#bodyContainer.addChild(list);
+			if (applied) {
+				this.#statusMessage = "import applied — reloaded inventory";
+				void this.#reload().then(() => {
+					this.#buildChrome();
+					this.onRequestRender?.();
+				});
+			} else {
+				this.#refreshChrome();
+				this.onRequestRender?.();
+			}
+		};
+		this.#bodyContainer.clear();
+		this.#bodyContainer.addChild(wizard);
+		this.#statusMessage = null;
+		this.onRequestRender?.();
+	}
+
+	#switchSection(next: CustomizationSurface): void {
+		if (next === this.#section) return;
+		this.#section = next;
+		this.#bodyContainer.clear();
+		const list = this.#lists.get(next);
+		if (list) this.#bodyContainer.addChild(list);
+		this.#refreshChrome();
+		this.onRequestRender?.();
+	}
+
+	#switchScope(): void {
+		this.#scope = this.#scope === "project" ? "global" : "project";
+		this.#refreshChrome();
+		this.onRequestRender?.();
+	}
+
+	#cycleSection(direction: 1 | -1): void {
+		const index = CUSTOMIZATION_SURFACES.indexOf(this.#section);
+		const next =
+			CUSTOMIZATION_SURFACES[(index + direction + CUSTOMIZATION_SURFACES.length) % CUSTOMIZATION_SURFACES.length];
+		this.#switchSection(next);
+	}
+
+	handleInput(keyData: string): void {
+		if (this.#wizard) {
+			this.#wizard.handleInput(keyData);
+			return;
+		}
+		if (this.#confirmRemove) {
+			if (keyData === "y") {
+				void this.#confirmRemoveSelected();
+			} else {
+				this.#confirmRemove = null;
+				this.#statusMessage = "remove cancelled";
+				this.#refreshChrome();
+				this.onRequestRender?.();
+			}
+			return;
+		}
+		if (matchesAppInterrupt(keyData)) {
+			this.onClose?.();
+			return;
+		}
+		if (matchesKey(keyData, "left")) {
+			this.#cycleSection(-1);
+			return;
+		}
+		if (matchesKey(keyData, "right")) {
+			this.#cycleSection(1);
+			return;
+		}
+		if (keyData === "s") {
+			this.#switchScope();
+			return;
+		}
+		if (keyData === "e") {
+			void this.#toggleSelected();
+			return;
+		}
+		if (keyData === "x") {
+			this.#beginRemove();
+			return;
+		}
+		if (keyData === "i") {
+			this.#openImportWizard();
+			return;
+		}
+		if (keyData === "q") {
+			this.onClose?.();
+			return;
+		}
+		this.#lists.get(this.#section)?.handleInput(keyData);
+	}
+
+	override render(width: number): string[] {
+		// Narrow-terminal guard: keep every chrome line inside the viewport.
+		if (width < 24) {
+			return [truncateToWidth(theme.fg("muted", "/extensions: terminal too narrow"), width)];
+		}
+		return super.render(width);
+	}
+}

--- a/packages/coding-agent/src/modes/components/customization/customization-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/customization/customization-dashboard.ts
@@ -7,14 +7,19 @@
  * provider/extension-module ExtensionDashboard; the two surfaces share only
  * generic TUI primitives (Container, Text, SelectList, DynamicBorder).
  *
+ * The scope switch is a real management boundary: each list only shows rows
+ * persisted at the active scope, and mutations refuse rows from the other
+ * scope. All dynamic text is sanitized before rendering.
+ *
  * Layout (narrow-terminal safe):
  *   title: /extensions — Configure skills, hooks, and MCPs.
- *   destination scope badge (Project .gjc / Global .gjc) — `s` switches
+ *   scope badge (Project .gjc / Global .gjc) — `s` switches
  *   section tabs: Skills | Hooks | MCPs — left/right switch
- *   inventory rows for the active section with status + provenance
+ *   inventory rows for the active section + scope with status + provenance
  *   footer key hints
  */
 import { Container, matchesKey, type SelectItem, SelectList, Text } from "@gajae-code/tui";
+import { sanitizeText } from "@gajae-code/utils";
 import { type CustomizationInventory, loadCustomizationInventory } from "../../../customization/inventory";
 import {
 	removeHookFile,
@@ -32,15 +37,22 @@ import {
 	scopeLabel,
 	surfaceLabel,
 } from "../../../customization/types";
+import type { SkillManagementPolicy } from "../../../extensibility/skill-management";
 import { replaceTabs, truncateToWidth } from "../../../tools/render-utils";
 import { getSelectListTheme, theme } from "../../theme/theme";
 import { matchesAppInterrupt } from "../../utils/keybinding-matchers";
 import { DynamicBorder } from "../dynamic-border";
 import { ImportWizard } from "./import-wizard";
 
-/** Minimal settings slice the dashboard reads. */
+/** Minimal settings slice the dashboard reads and writes. */
 export interface CustomizationSettingsSlice {
 	get(key: string): unknown;
+	set?(key: string, value: unknown): void;
+}
+
+/** Sanitize + detab every dynamic string before it reaches a renderer. */
+function safe(text: string): string {
+	return replaceTabs(sanitizeText(text));
 }
 
 const STATUS_COLORS: Record<InventoryRow["status"], (text: string) => string> = {
@@ -57,11 +69,11 @@ function rowToSelectItem(row: InventoryRow): SelectItem {
 	const color = STATUS_COLORS[row.status];
 	const status = color(row.status);
 	return {
-		value: `${row.surface}:${row.scope}:${row.name}`,
-		label: replaceTabs(row.displayName),
-		description: `${status} ${theme.fg("muted", `· ${replaceTabs(row.provenance)}`)}${
-			row.description ? theme.fg("muted", ` — ${replaceTabs(row.description)}`) : ""
-		}`,
+		value: row.id,
+		label: safe(row.displayName),
+		description: `${status} ${theme.fg("muted", `· ${safe(row.provenance)}`)}${
+			row.description ? theme.fg("muted", ` — ${safe(row.description)}`) : ""
+		}${row.diagnostics?.length ? theme.fg("warning", ` — ${safe(row.diagnostics[0])}`) : ""}`,
 	};
 }
 
@@ -82,16 +94,23 @@ export class CustomizationDashboard extends Container {
 	#footerText!: Text;
 	#wizard: ImportWizard | null = null;
 	#confirmRemove: InventoryRow | null = null;
+	#homeDir: string | undefined;
 	#statusMessage: string | null = null;
 
-	private constructor(cwd: string, settings: CustomizationSettingsSlice | undefined) {
+	/** Use `create()` — async inventory load runs before chrome construction. */
+	constructor(cwd: string, settings: CustomizationSettingsSlice | undefined, homeDir: string | undefined) {
 		super();
 		this.#cwd = cwd;
 		this.#settings = settings;
+		this.#homeDir = homeDir;
 	}
 
-	static async create(cwd: string, settings?: CustomizationSettingsSlice): Promise<CustomizationDashboard> {
-		const dashboard = new CustomizationDashboard(cwd, settings);
+	static async create(
+		cwd: string,
+		settings?: CustomizationSettingsSlice,
+		homeDir?: string,
+	): Promise<CustomizationDashboard> {
+		const dashboard = new CustomizationDashboard(cwd, settings, homeDir);
 		await dashboard.#reload();
 		dashboard.#buildChrome();
 		return dashboard;
@@ -110,12 +129,33 @@ export class CustomizationDashboard extends Container {
 		return this.#inventory;
 	}
 
+	#getStringArray(key: string): string[] {
+		const value = this.#settings?.get(key);
+		return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+	}
+
+	#skillPolicy(): SkillManagementPolicy {
+		return {
+			trustProjectSkills: this.#settings?.get("skills.trustProjectSkills") as boolean | undefined,
+			trustUserSkills: this.#settings?.get("skills.trustUserSkills") as boolean | undefined,
+			ignoredSkills: this.#getStringArray("skills.ignoredSkills"),
+			includeSkills: this.#getStringArray("skills.includeSkills"),
+			disabledExtensions: this.#getStringArray("disabledExtensions"),
+		};
+	}
+
 	async #reload(): Promise<void> {
-		const disabled = this.#settings?.get("disabledExtensions");
 		this.#inventory = await loadCustomizationInventory({
 			cwd: this.#cwd,
-			disabledExtensions: Array.isArray(disabled) ? (disabled as string[]) : [],
+			home: this.#homeDir,
+			policy: this.#skillPolicy(),
+			disabledExtensions: this.#getStringArray("disabledExtensions"),
 		});
+	}
+
+	/** Rows visible under the active scope — the scope switch is a real boundary. */
+	#visibleRows(surface: CustomizationSurface): InventoryRow[] {
+		return this.#inventory.rows.filter(row => row.surface === surface && row.scope === this.#scope);
 	}
 
 	#buildChrome(): void {
@@ -135,15 +175,18 @@ export class CustomizationDashboard extends Container {
 
 		this.#bodyContainer = new Container();
 		for (const surface of CUSTOMIZATION_SURFACES) {
-			const rows = this.#inventory.rows.filter(row => row.surface === surface);
+			const rows = this.#visibleRows(surface);
 			const items: SelectItem[] =
 				rows.length > 0
 					? rows.map(rowToSelectItem)
 					: [
 							{
 								value: `${surface}:empty`,
-								label: theme.fg("muted", `(no ${surfaceLabel(surface).toLowerCase()} configured)`),
-								description: theme.fg("muted", "nothing configured at Project .gjc or Global .gjc yet"),
+								label: theme.fg(
+									"muted",
+									`(no ${surfaceLabel(surface).toLowerCase()} at ${scopeLabel(this.#scope)})`,
+								),
+								description: theme.fg("muted", "switch scope with s, or import with i"),
 								disabled: true,
 							},
 						];
@@ -168,7 +211,7 @@ export class CustomizationDashboard extends Container {
 		);
 		const other: GjcScope = this.#scope === "project" ? "global" : "project";
 		scopeLine.setText(
-			`${theme.fg("muted", "destination:")} ${theme.bold(scopeLabel(this.#scope))}  ${theme.fg("muted", `(s: switch to ${scopeLabel(other)})`)}`,
+			`${theme.fg("muted", "scope:")} ${theme.bold(scopeLabel(this.#scope))}  ${theme.fg("muted", `(s: switch to ${scopeLabel(other)} — lists and actions follow the scope)`)}`,
 		);
 		const tabLine = CUSTOMIZATION_SURFACES.map(surface =>
 			surface === this.#section
@@ -177,9 +220,9 @@ export class CustomizationDashboard extends Container {
 		).join(theme.fg("muted", "│"));
 		tabs.setText(tabLine);
 		const warnings = this.#inventory.warnings.length;
-		const status = this.#statusMessage ? ` · ${theme.fg("accent", replaceTabs(this.#statusMessage))}` : "";
+		const status = this.#statusMessage ? ` · ${theme.fg("accent", safe(this.#statusMessage))}` : "";
 		const confirm = this.#confirmRemove
-			? ` · ${theme.fg("warning", `remove ${this.#confirmRemove.displayName}? y/n`)}`
+			? ` · ${theme.fg("warning", `remove ${safe(this.#confirmRemove.displayName)}? y/n`)}`
 			: "";
 		this.#footerText.setText(
 			theme.fg(
@@ -194,12 +237,13 @@ export class CustomizationDashboard extends Container {
 	#selectedRow(): InventoryRow | null {
 		const selected = this.#lists.get(this.#section)?.getSelectedItem();
 		if (!selected || selected.disabled) return null;
-		return this.#inventory.rows.find(row => `${row.surface}:${row.scope}:${row.name}` === selected.value) ?? null;
+		return this.#visibleRows(this.#section).find(row => row.id === selected.value) ?? null;
 	}
 
-	/** Rows discovered outside the canonical .gjc scopes are import sources, not managed entries. */
-	#isForeignRow(row: InventoryRow): boolean {
-		return row.provenance.includes("import to manage");
+	#flashStatus(message: string): void {
+		this.#statusMessage = message;
+		this.#refreshChrome();
+		this.onRequestRender?.();
 	}
 
 	async #applyMutation(action: () => Promise<{ ok: true } | { ok: false; reason: string }>): Promise<void> {
@@ -210,43 +254,48 @@ export class CustomizationDashboard extends Container {
 		this.onRequestRender?.();
 	}
 
+	/** Mutations may only target rows persisted at the active scope. */
+	#guardScope(row: InventoryRow): boolean {
+		if (row.scope !== this.#scope) {
+			this.#flashStatus(
+				`refusing to mutate a ${scopeLabel(row.scope)} entry while viewing ${scopeLabel(this.#scope)}`,
+			);
+			return false;
+		}
+		return true;
+	}
+
 	async #toggleSelected(): Promise<void> {
 		const row = this.#selectedRow();
-		if (!row) return;
-		if (this.#isForeignRow(row)) {
-			this.#statusMessage = "foreign entries are import sources — use i to import, not managed in place";
-			this.#refreshChrome();
-			this.onRequestRender?.();
-			return;
-		}
+		if (!row || !this.#guardScope(row)) return;
 		if (row.status === "invalid" || row.status === "shadowed" || row.status === "quarantined") {
-			this.#statusMessage = `cannot toggle a ${row.status} entry; resolve its diagnostics first`;
-			this.#refreshChrome();
-			this.onRequestRender?.();
+			this.#flashStatus(`cannot toggle a ${row.status} entry; resolve its diagnostics first`);
 			return;
 		}
 		const enable = row.status === "disabled";
-		const paths = resolveScopePaths(row.scope, this.#cwd);
 		if (row.surface === "skills") {
-			await this.#applyMutation(() => setSkillEnabled(paths, row.name, enable));
+			const result = setSkillEnabled(row.name, enable, this.#getStringArray("disabledExtensions"));
+			if (!result.ok) {
+				this.#flashStatus(result.reason);
+				return;
+			}
+			if (!this.#settings?.set) {
+				this.#flashStatus("settings are read-only in this session; cannot persist the toggle");
+				return;
+			}
+			this.#settings.set("disabledExtensions", result.disabledExtensions);
+			await this.#applyMutation(async () => ({ ok: true }) as { ok: true });
 		} else if (row.surface === "mcps") {
+			const paths = resolveScopePaths(row.scope, this.#cwd);
 			await this.#applyMutation(() => setMcpServerEnabled(paths.mcpConfigPath, row.name, enable));
 		} else {
-			this.#statusMessage = "hook enable/disable is not part of the canonical hook contract; remove instead";
-			this.#refreshChrome();
-			this.onRequestRender?.();
+			this.#flashStatus("hook enable/disable is not part of the canonical hook contract; remove instead");
 		}
 	}
 
 	#beginRemove(): void {
 		const row = this.#selectedRow();
-		if (!row) return;
-		if (this.#isForeignRow(row)) {
-			this.#statusMessage = "foreign entries are import sources — use i to import, not managed in place";
-			this.#refreshChrome();
-			this.onRequestRender?.();
-			return;
-		}
+		if (!row || !this.#guardScope(row)) return;
 		this.#confirmRemove = row;
 		this.#refreshChrome();
 		this.onRequestRender?.();
@@ -255,20 +304,18 @@ export class CustomizationDashboard extends Container {
 	async #confirmRemoveSelected(): Promise<void> {
 		const row = this.#confirmRemove;
 		this.#confirmRemove = null;
-		if (!row) return;
-		const paths = resolveScopePaths(row.scope, this.#cwd);
+		if (!row || !this.#guardScope(row)) return;
 		if (row.surface === "skills") {
-			await this.#applyMutation(() => removeSkill(paths, row.name));
+			await this.#applyMutation(() => removeSkill({ name: row.name, path: row.path }));
 		} else if (row.surface === "mcps") {
-			await this.#applyMutation(() => removeMcpServerEntry(paths.mcpConfigPath, row.name));
+			await this.#applyMutation(() => removeMcpServerEntry(row.path, row.name));
 		} else {
-			const fileName = row.path.split("/").pop() ?? row.name;
-			await this.#applyMutation(() => removeHookFile(paths, fileName));
+			await this.#applyMutation(() => removeHookFile(row.path));
 		}
 	}
 
 	#openImportWizard(): void {
-		const wizard = new ImportWizard(this.#cwd, this.#scope);
+		const wizard = new ImportWizard(this.#cwd, this.#scope, this.#homeDir);
 		this.#wizard = wizard;
 		wizard.onRequestRender = () => this.onRequestRender?.();
 		wizard.onClose = applied => {
@@ -305,7 +352,8 @@ export class CustomizationDashboard extends Container {
 
 	#switchScope(): void {
 		this.#scope = this.#scope === "project" ? "global" : "project";
-		this.#refreshChrome();
+		// Rebuild the lists: the visible rows are scope-bound.
+		this.#buildChrome();
 		this.onRequestRender?.();
 	}
 

--- a/packages/coding-agent/src/modes/components/customization/import-wizard.ts
+++ b/packages/coding-agent/src/modes/components/customization/import-wizard.ts
@@ -3,18 +3,22 @@
  * `/extensions` dashboard (issue #4291).
  *
  * Steps: source product → source scope → surfaces → collision policy →
- * normalized preview → apply result. The preview step is explicit-confirmation
- * only: Enter applies (journaled, rollback on failure), Esc cancels without
- * writing anything. Secret values never appear in any rendered line — the
- * preview only carries redacted descriptions from `buildImportPreview`.
+ * normalized preview (paged, every entry reviewable) → apply result.
+ * Selection lists are attached to the component tree so choices are actually
+ * visible; the preview step is explicit-confirmation only — Enter applies
+ * once (applying latch), Esc cancels without writing anything. Secret values
+ * never appear in any rendered line, and `applied` is reported only when the
+ * transaction succeeded. All dynamic text is sanitized before rendering.
  */
 import * as os from "node:os";
-import { Container, type SelectItem, SelectList, Text } from "@gajae-code/tui";
+import { Container, matchesKey, type SelectItem, SelectList, Text } from "@gajae-code/tui";
+import { sanitizeText } from "@gajae-code/utils";
 import { applyImport, type BuildImportPreviewOptions, buildImportPreview } from "../../../customization/import";
 import type {
 	CustomizationSurface,
 	GjcScope,
 	ImportCollisionPolicy,
+	ImportPlan,
 	ImportPreview,
 	ImportProduct,
 	ImportResult,
@@ -48,8 +52,15 @@ const COLLISION_CHOICES: Array<{ value: ImportCollisionPolicy; hint: string }> =
 	{ value: "overwrite", hint: "replace existing .gjc entries (explicit, never silent)" },
 ];
 
+const PREVIEW_PAGE_SIZE = 8;
+
+/** Sanitize + detab every dynamic string before it reaches a renderer. */
+function safe(text: string): string {
+	return replaceTabs(sanitizeText(text));
+}
+
 export class ImportWizard extends Container {
-	/** Called when the wizard finishes or is cancelled; `applied` is true when an import ran. */
+	/** Called when the wizard finishes or is cancelled; `applied` is true only when an import succeeded. */
 	onClose: ((applied: boolean) => void) | undefined;
 	onRequestRender: (() => void) | undefined;
 
@@ -61,11 +72,14 @@ export class ImportWizard extends Container {
 	#sourceScope: ImportSourceScope = "project";
 	#surfaces: CustomizationSurface[] = ["skills", "hooks", "mcps"];
 	#collisionPolicy: ImportCollisionPolicy = "skip";
-	#preview: ImportPreview | null = null;
+	#plan: ImportPlan | null = null;
 	#result: ImportResult | null = null;
 	#applied = false;
+	#applying = false;
+	#previewPage = 0;
 
 	#headerText: Text;
+	#selectContainer: Container;
 	#selectList: SelectList | null = null;
 	#bodyText: Text;
 	#footerText: Text;
@@ -80,6 +94,8 @@ export class ImportWizard extends Container {
 		this.#headerText = new Text("", 0, 0);
 		this.addChild(this.#headerText);
 		this.addChild(new DynamicBorder());
+		this.#selectContainer = new Container();
+		this.addChild(this.#selectContainer);
 		this.#bodyText = new Text("", 0, 0);
 		this.addChild(this.#bodyText);
 		this.addChild(new DynamicBorder());
@@ -94,14 +110,19 @@ export class ImportWizard extends Container {
 		return this.#step;
 	}
 
-	/** Last built preview (test-visible). */
+	/** Last built preview DTO — redacted and serialization-safe (test-visible). */
 	get preview(): ImportPreview | null {
-		return this.#preview;
+		return this.#plan?.preview ?? null;
 	}
 
 	/** Last apply result (test-visible). */
 	get result(): ImportResult | null {
 		return this.#result;
+	}
+
+	/** Whether the wizard currently shows an attached selection list (test-visible). */
+	get hasVisibleSelector(): boolean {
+		return this.#selectList !== null;
 	}
 
 	#previewOptions(): BuildImportPreviewOptions {
@@ -117,9 +138,12 @@ export class ImportWizard extends Container {
 	}
 
 	#setSelectStep(title: string, items: SelectItem[], onSelect: (value: string) => void): void {
-		this.#selectList = new SelectList(items, Math.min(items.length, 8), getSelectListTheme());
-		this.#selectList.onSelect = item => onSelect(item.value);
-		this.#selectList.onCancel = () => this.onClose?.(this.#applied);
+		this.#selectContainer.clear();
+		const list = new SelectList(items, Math.min(items.length, 8), getSelectListTheme());
+		list.onSelect = item => onSelect(item.value);
+		list.onCancel = () => this.onClose?.(this.#applied);
+		this.#selectList = list;
+		this.#selectContainer.addChild(list);
 		this.#headerText.setText(theme.bold(theme.fg("accent", title)));
 		this.#bodyText.setText("");
 		this.#footerText.setText(theme.fg("muted", "↑/↓ navigate · enter select · esc cancel"));
@@ -189,22 +213,34 @@ export class ImportWizard extends Container {
 	}
 
 	async #buildPreview(): Promise<void> {
+		this.#selectContainer.clear();
 		this.#selectList = null;
 		this.#headerText.setText(theme.fg("muted", "Reading source configuration…"));
 		this.#requestRender();
-		this.#preview = await buildImportPreview(this.#previewOptions());
+		this.#plan = await buildImportPreview(this.#previewOptions());
+		this.#previewPage = 0;
 		this.#step = "preview";
 		this.#renderPreview();
 	}
 
+	#previewPageCount(): number {
+		const total = this.#plan?.preview.entries.length ?? 0;
+		return Math.max(1, Math.ceil(total / PREVIEW_PAGE_SIZE));
+	}
+
 	#renderPreview(): void {
-		const preview = this.#preview;
-		if (!preview) return;
-		const lines: string[] = [];
+		const plan = this.#plan;
+		if (!plan) return;
+		const { preview } = plan;
 		const writable = preview.entries.filter(
 			e => e.status === "add" || e.status === "overwrite" || e.status === "redacted",
 		);
 		const skipped = preview.entries.filter(e => e.status === "conflict" || e.status === "unsupported");
+		const pageCount = this.#previewPageCount();
+		const page = Math.min(this.#previewPage, pageCount - 1);
+		const pageEntries = preview.entries.slice(page * PREVIEW_PAGE_SIZE, (page + 1) * PREVIEW_PAGE_SIZE);
+
+		const lines: string[] = [];
 		lines.push(
 			`${theme.bold("Preview:")} ${productLabel(preview.product)} ${sourceScopeLabel(preview.sourceScope)} → ${scopeLabel(preview.destinationScope)} · policy: ${this.#collisionPolicy}`,
 		);
@@ -212,7 +248,7 @@ export class ImportWizard extends Container {
 		if (preview.entries.length === 0) {
 			lines.push(theme.fg("muted", "(nothing found to import at the selected source)"));
 		}
-		for (const entry of preview.entries.slice(0, 12)) {
+		for (const entry of pageEntries) {
 			const statusColor =
 				entry.status === "add"
 					? theme.fg("success", "+")
@@ -226,32 +262,51 @@ export class ImportWizard extends Container {
 					? entry.sourceName
 					: `${entry.sourceName} → ${entry.destinationName}`;
 			lines.push(
-				` ${statusColor} ${surfaceLabel(entry.surface)}: ${replaceTabs(name)}${entry.reason ? theme.fg("muted", ` — ${replaceTabs(entry.reason)}`) : ""}`,
+				` ${statusColor} ${surfaceLabel(entry.surface)}: ${safe(name)}${entry.reason ? theme.fg("muted", ` — ${safe(entry.reason)}`) : ""}`,
 			);
 		}
-		if (preview.entries.length > 12) {
-			lines.push(theme.fg("muted", ` … ${preview.entries.length - 12} more`));
+		for (const warning of preview.warnings.slice(0, 3)) {
+			lines.push(theme.fg("warning", ` ⚠ ${safe(warning)}`));
 		}
-		for (const warning of preview.warnings.slice(0, 4)) {
-			lines.push(theme.fg("warning", ` ⚠ ${replaceTabs(warning)}`));
+		if (preview.warnings.length > 3) {
+			lines.push(theme.fg("muted", ` … ${preview.warnings.length - 3} more diagnostics`));
 		}
 		this.#headerText.setText(theme.bold(theme.fg("accent", "Confirm import")));
 		this.#bodyText.setText(lines.join("\n"));
+		const paging = pageCount > 1 ? `←/→ page ${page + 1}/${pageCount} · ` : "";
 		this.#footerText.setText(
 			theme.fg(
 				"muted",
-				`enter: apply ${writable.length} entr${writable.length === 1 ? "y" : "ies"} (${skipped.length} skipped) · esc: cancel (no writes)`,
+				`${paging}enter: apply ${writable.length} entr${writable.length === 1 ? "y" : "ies"} (${skipped.length} skipped) · esc: cancel (no writes)`,
 			),
 		);
 		this.#requestRender();
 	}
 
 	async #apply(): Promise<void> {
-		if (!this.#preview) return;
+		if (!this.#plan || this.#applying) return;
+		this.#applying = true;
 		this.#footerText.setText(theme.fg("muted", "Applying import…"));
 		this.#requestRender();
-		this.#result = await applyImport(this.#preview, { cwd: this.#cwd });
-		this.#applied = true;
+		try {
+			this.#result = await applyImport(this.#plan, { cwd: this.#cwd });
+		} catch (error) {
+			this.#result = {
+				entries: [
+					{
+						surface: "skills",
+						sourceName: "",
+						destinationName: "",
+						outcome: "failed",
+						reason: (error as Error).message,
+					},
+				],
+				ok: false,
+			};
+		} finally {
+			this.#applying = false;
+		}
+		this.#applied = this.#result.ok;
 		this.#step = "result";
 		const counts = new Map<string, number>();
 		for (const entry of this.#result.entries) {
@@ -268,9 +323,7 @@ export class ImportWizard extends Container {
 			[
 				summary,
 				"",
-				...failed.map(e =>
-					theme.fg("error", ` ✗ ${e.surface}: ${replaceTabs(e.sourceName)} — ${replaceTabs(e.reason ?? "")}`),
-				),
+				...failed.map(e => theme.fg("error", ` ✗ ${e.surface}: ${safe(e.sourceName)} — ${safe(e.reason ?? "")}`)),
 				...(this.#result.ok
 					? [theme.fg("muted", "Imported entries take effect after the documented reload/new-session boundary.")]
 					: []),
@@ -286,10 +339,18 @@ export class ImportWizard extends Container {
 
 	handleInput(keyData: string): void {
 		if (matchesAppInterrupt(keyData)) {
+			if (this.#applying) return; // never interrupt an in-flight transaction
 			this.onClose?.(this.#applied);
 			return;
 		}
 		if (this.#step === "preview") {
+			if (matchesKey(keyData, "left") || matchesKey(keyData, "right")) {
+				const pageCount = this.#previewPageCount();
+				const delta = matchesKey(keyData, "right") ? 1 : -1;
+				this.#previewPage = (this.#previewPage + delta + pageCount) % pageCount;
+				this.#renderPreview();
+				return;
+			}
 			if (keyData === "\r" || keyData === "\n") {
 				void this.#apply();
 			}

--- a/packages/coding-agent/src/modes/components/customization/import-wizard.ts
+++ b/packages/coding-agent/src/modes/components/customization/import-wizard.ts
@@ -1,0 +1,311 @@
+/**
+ * ImportWizard — the guided Import-from-Claude-Code/Codex flow inside the
+ * `/extensions` dashboard (issue #4291).
+ *
+ * Steps: source product → source scope → surfaces → collision policy →
+ * normalized preview → apply result. The preview step is explicit-confirmation
+ * only: Enter applies (journaled, rollback on failure), Esc cancels without
+ * writing anything. Secret values never appear in any rendered line — the
+ * preview only carries redacted descriptions from `buildImportPreview`.
+ */
+import * as os from "node:os";
+import { Container, type SelectItem, SelectList, Text } from "@gajae-code/tui";
+import { applyImport, type BuildImportPreviewOptions, buildImportPreview } from "../../../customization/import";
+import type {
+	CustomizationSurface,
+	GjcScope,
+	ImportCollisionPolicy,
+	ImportPreview,
+	ImportProduct,
+	ImportResult,
+	ImportSourceScope,
+} from "../../../customization/types";
+import {
+	IMPORT_PRODUCTS,
+	IMPORT_SOURCE_SCOPES,
+	productLabel,
+	scopeLabel,
+	sourceScopeLabel,
+	surfaceLabel,
+} from "../../../customization/types";
+import { replaceTabs, truncateToWidth } from "../../../tools/render-utils";
+import { getSelectListTheme, theme } from "../../theme/theme";
+import { matchesAppInterrupt } from "../../utils/keybinding-matchers";
+import { DynamicBorder } from "../dynamic-border";
+
+type WizardStep = "product" | "sourceScope" | "surfaces" | "collision" | "preview" | "result";
+
+const SURFACE_CHOICES: Array<{ value: string; label: string; surfaces: CustomizationSurface[] }> = [
+	{ value: "all", label: "Skills + Hooks + MCPs", surfaces: ["skills", "hooks", "mcps"] },
+	{ value: "skills", label: "Skills only", surfaces: ["skills"] },
+	{ value: "hooks", label: "Hooks only", surfaces: ["hooks"] },
+	{ value: "mcps", label: "MCPs only", surfaces: ["mcps"] },
+];
+
+const COLLISION_CHOICES: Array<{ value: ImportCollisionPolicy; hint: string }> = [
+	{ value: "skip", hint: "keep existing .gjc entries; conflicting sources are skipped" },
+	{ value: "rename", hint: "conflicting sources import under an -imported suffix" },
+	{ value: "overwrite", hint: "replace existing .gjc entries (explicit, never silent)" },
+];
+
+export class ImportWizard extends Container {
+	/** Called when the wizard finishes or is cancelled; `applied` is true when an import ran. */
+	onClose: ((applied: boolean) => void) | undefined;
+	onRequestRender: (() => void) | undefined;
+
+	#cwd: string;
+	#homeDir: string;
+	#destinationScope: GjcScope;
+	#step: WizardStep = "product";
+	#product: ImportProduct = "claude-code";
+	#sourceScope: ImportSourceScope = "project";
+	#surfaces: CustomizationSurface[] = ["skills", "hooks", "mcps"];
+	#collisionPolicy: ImportCollisionPolicy = "skip";
+	#preview: ImportPreview | null = null;
+	#result: ImportResult | null = null;
+	#applied = false;
+
+	#headerText: Text;
+	#selectList: SelectList | null = null;
+	#bodyText: Text;
+	#footerText: Text;
+
+	constructor(cwd: string, destinationScope: GjcScope, homeDir?: string) {
+		super();
+		this.#cwd = cwd;
+		this.#destinationScope = destinationScope;
+		this.#homeDir = homeDir ?? os.homedir();
+
+		this.addChild(new DynamicBorder());
+		this.#headerText = new Text("", 0, 0);
+		this.addChild(this.#headerText);
+		this.addChild(new DynamicBorder());
+		this.#bodyText = new Text("", 0, 0);
+		this.addChild(this.#bodyText);
+		this.addChild(new DynamicBorder());
+		this.#footerText = new Text("", 0, 0);
+		this.addChild(this.#footerText);
+		this.addChild(new DynamicBorder());
+		this.#renderStep();
+	}
+
+	/** Current step (test-visible). */
+	get step(): WizardStep {
+		return this.#step;
+	}
+
+	/** Last built preview (test-visible). */
+	get preview(): ImportPreview | null {
+		return this.#preview;
+	}
+
+	/** Last apply result (test-visible). */
+	get result(): ImportResult | null {
+		return this.#result;
+	}
+
+	#previewOptions(): BuildImportPreviewOptions {
+		return {
+			product: this.#product,
+			sourceScope: this.#sourceScope,
+			destinationScope: this.#destinationScope,
+			surfaces: this.#surfaces,
+			collisionPolicy: this.#collisionPolicy,
+			cwd: this.#cwd,
+			homeDir: this.#homeDir,
+		};
+	}
+
+	#setSelectStep(title: string, items: SelectItem[], onSelect: (value: string) => void): void {
+		this.#selectList = new SelectList(items, Math.min(items.length, 8), getSelectListTheme());
+		this.#selectList.onSelect = item => onSelect(item.value);
+		this.#selectList.onCancel = () => this.onClose?.(this.#applied);
+		this.#headerText.setText(theme.bold(theme.fg("accent", title)));
+		this.#bodyText.setText("");
+		this.#footerText.setText(theme.fg("muted", "↑/↓ navigate · enter select · esc cancel"));
+		this.#requestRender();
+	}
+
+	#renderStep(): void {
+		switch (this.#step) {
+			case "product":
+				this.#setSelectStep(
+					`Import into ${scopeLabel(this.#destinationScope)} — choose source product`,
+					IMPORT_PRODUCTS.map(product => ({ value: product, label: productLabel(product) })),
+					value => {
+						this.#product = value as ImportProduct;
+						this.#step = "sourceScope";
+						this.#renderStep();
+					},
+				);
+				break;
+			case "sourceScope":
+				this.#setSelectStep(
+					`Import from ${productLabel(this.#product)} — choose source scope`,
+					IMPORT_SOURCE_SCOPES.map(scope => ({
+						value: scope,
+						label: sourceScopeLabel(scope),
+						description:
+							scope === "user"
+								? "explicit selection required; nothing is scanned or injected automatically"
+								: "current trusted project convention roots only",
+					})),
+					value => {
+						this.#sourceScope = value as ImportSourceScope;
+						this.#step = "surfaces";
+						this.#renderStep();
+					},
+				);
+				break;
+			case "surfaces":
+				this.#setSelectStep(
+					"Choose surfaces to import",
+					SURFACE_CHOICES.map(choice => ({ value: choice.value, label: choice.label })),
+					value => {
+						this.#surfaces = SURFACE_CHOICES.find(choice => choice.value === value)?.surfaces ?? this.#surfaces;
+						this.#step = "collision";
+						this.#renderStep();
+					},
+				);
+				break;
+			case "collision":
+				this.#setSelectStep(
+					"Collision policy for existing .gjc entries",
+					COLLISION_CHOICES.map(choice => ({
+						value: choice.value,
+						label: choice.value,
+						description: choice.hint,
+					})),
+					value => {
+						this.#collisionPolicy = value as ImportCollisionPolicy;
+						void this.#buildPreview();
+					},
+				);
+				break;
+			case "preview":
+			case "result":
+				break;
+		}
+	}
+
+	async #buildPreview(): Promise<void> {
+		this.#selectList = null;
+		this.#headerText.setText(theme.fg("muted", "Reading source configuration…"));
+		this.#requestRender();
+		this.#preview = await buildImportPreview(this.#previewOptions());
+		this.#step = "preview";
+		this.#renderPreview();
+	}
+
+	#renderPreview(): void {
+		const preview = this.#preview;
+		if (!preview) return;
+		const lines: string[] = [];
+		const writable = preview.entries.filter(
+			e => e.status === "add" || e.status === "overwrite" || e.status === "redacted",
+		);
+		const skipped = preview.entries.filter(e => e.status === "conflict" || e.status === "unsupported");
+		lines.push(
+			`${theme.bold("Preview:")} ${productLabel(preview.product)} ${sourceScopeLabel(preview.sourceScope)} → ${scopeLabel(preview.destinationScope)} · policy: ${this.#collisionPolicy}`,
+		);
+		lines.push("");
+		if (preview.entries.length === 0) {
+			lines.push(theme.fg("muted", "(nothing found to import at the selected source)"));
+		}
+		for (const entry of preview.entries.slice(0, 12)) {
+			const statusColor =
+				entry.status === "add"
+					? theme.fg("success", "+")
+					: entry.status === "overwrite"
+						? theme.fg("warning", "!")
+						: entry.status === "redacted"
+							? theme.fg("accent", "+")
+							: theme.fg("muted", "-");
+			const name =
+				entry.destinationName === entry.sourceName
+					? entry.sourceName
+					: `${entry.sourceName} → ${entry.destinationName}`;
+			lines.push(
+				` ${statusColor} ${surfaceLabel(entry.surface)}: ${replaceTabs(name)}${entry.reason ? theme.fg("muted", ` — ${replaceTabs(entry.reason)}`) : ""}`,
+			);
+		}
+		if (preview.entries.length > 12) {
+			lines.push(theme.fg("muted", ` … ${preview.entries.length - 12} more`));
+		}
+		for (const warning of preview.warnings.slice(0, 4)) {
+			lines.push(theme.fg("warning", ` ⚠ ${replaceTabs(warning)}`));
+		}
+		this.#headerText.setText(theme.bold(theme.fg("accent", "Confirm import")));
+		this.#bodyText.setText(lines.join("\n"));
+		this.#footerText.setText(
+			theme.fg(
+				"muted",
+				`enter: apply ${writable.length} entr${writable.length === 1 ? "y" : "ies"} (${skipped.length} skipped) · esc: cancel (no writes)`,
+			),
+		);
+		this.#requestRender();
+	}
+
+	async #apply(): Promise<void> {
+		if (!this.#preview) return;
+		this.#footerText.setText(theme.fg("muted", "Applying import…"));
+		this.#requestRender();
+		this.#result = await applyImport(this.#preview, { cwd: this.#cwd });
+		this.#applied = true;
+		this.#step = "result";
+		const counts = new Map<string, number>();
+		for (const entry of this.#result.entries) {
+			counts.set(entry.outcome, (counts.get(entry.outcome) ?? 0) + 1);
+		}
+		const summary = [...counts.entries()].map(([outcome, count]) => `${count} ${outcome}`).join(", ");
+		this.#headerText.setText(
+			this.#result.ok
+				? theme.bold(theme.fg("success", "Import complete"))
+				: theme.bold(theme.fg("error", "Import failed — rolled back, no partial import")),
+		);
+		const failed = this.#result.entries.filter(e => e.outcome === "failed").slice(0, 5);
+		this.#bodyText.setText(
+			[
+				summary,
+				"",
+				...failed.map(e =>
+					theme.fg("error", ` ✗ ${e.surface}: ${replaceTabs(e.sourceName)} — ${replaceTabs(e.reason ?? "")}`),
+				),
+				...(this.#result.ok
+					? [theme.fg("muted", "Imported entries take effect after the documented reload/new-session boundary.")]
+					: []),
+			].join("\n"),
+		);
+		this.#footerText.setText(theme.fg("muted", "enter/esc: close"));
+		this.#requestRender();
+	}
+
+	#requestRender(): void {
+		this.onRequestRender?.();
+	}
+
+	handleInput(keyData: string): void {
+		if (matchesAppInterrupt(keyData)) {
+			this.onClose?.(this.#applied);
+			return;
+		}
+		if (this.#step === "preview") {
+			if (keyData === "\r" || keyData === "\n") {
+				void this.#apply();
+			}
+			return;
+		}
+		if (this.#step === "result") {
+			this.onClose?.(this.#applied);
+			return;
+		}
+		this.#selectList?.handleInput(keyData);
+	}
+
+	override render(width: number): string[] {
+		if (width < 24) {
+			return [truncateToWidth(theme.fg("muted", "import: terminal too narrow"), width)];
+		}
+		return super.render(width);
+	}
+}

--- a/packages/coding-agent/src/modes/components/customization/index.ts
+++ b/packages/coding-agent/src/modes/components/customization/index.ts
@@ -1,0 +1,1 @@
+export * from "./customization-dashboard";

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1974,7 +1974,13 @@ export class SelectorController {
 	 * Extension Control Center above (issue #4291).
 	 */
 	async showCustomizationDashboard(): Promise<void> {
-		const dashboard = await CustomizationDashboard.create(getProjectDir(), this.ctx.settings);
+		let dashboard: CustomizationDashboard;
+		try {
+			dashboard = await CustomizationDashboard.create(getProjectDir(), this.ctx.settings);
+		} catch (error) {
+			this.ctx.showError(`Failed to open /extensions: ${error instanceof Error ? error.message : String(error)}`);
+			return;
+		}
 		this.showSelector(done => {
 			dashboard.onClose = () => {
 				done();

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -141,6 +141,7 @@ import {
 	type CustomModelPresetWizardSubmit,
 } from "../components/custom-model-preset-wizard";
 import { CustomProviderWizardComponent, type CustomProviderWizardSubmit } from "../components/custom-provider-wizard";
+import { CustomizationDashboard } from "../components/customization";
 import { ExtensionDashboard } from "../components/extensions";
 import type { PetMode } from "../components/gajae-pet-widget";
 import { HistorySearchComponent } from "../components/history-search";
@@ -1955,6 +1956,25 @@ export class SelectorController {
 	 */
 	async showExtensionsDashboard(): Promise<void> {
 		const dashboard = await ExtensionDashboard.create(getProjectDir(), this.ctx.settings, this.ctx.ui.terminal.rows);
+		this.showSelector(done => {
+			dashboard.onClose = () => {
+				done();
+				this.ctx.ui.requestRender();
+			};
+			dashboard.onRequestRender = () => {
+				this.ctx.ui.requestRender();
+			};
+			return { component: dashboard, focus: dashboard };
+		});
+	}
+
+	/**
+	 * Show the `/extensions` umbrella local-customization dashboard (skills,
+	 * hooks, MCPs, import) — a separate surface from the provider-focused
+	 * Extension Control Center above (issue #4291).
+	 */
+	async showCustomizationDashboard(): Promise<void> {
+		const dashboard = await CustomizationDashboard.create(getProjectDir(), this.ctx.settings);
 		this.showSelector(done => {
 			dashboard.onClose = () => {
 				done();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2271,6 +2271,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		void this.#selectorController.showExtensionsDashboard();
 	}
 
+	showCustomizationDashboard(): void {
+		void this.#selectorController.showCustomizationDashboard();
+	}
+
 	showAgentsDashboard(): void {
 		void this.#selectorController.showAgentsDashboard();
 	}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -402,6 +402,7 @@ export interface InteractiveModeContext {
 	showPetSelector(): void;
 	showHistorySearch(): Promise<void>;
 	showExtensionsDashboard(): void;
+	showCustomizationDashboard(): void;
 	showAgentsDashboard(): void;
 	showModelSelector(options?: { temporaryOnly?: boolean }): void;
 	showEffortSelector(): void;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1427,6 +1427,21 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			runtime.ctx.editor.setText("");
 		},
 	},
+
+	{
+		name: "extensions",
+		description: "Configure skills, hooks, and MCPs.",
+		handle: async (_command, runtime) => {
+			await runtime.output(
+				"/extensions is an interactive surface for configuring skills, hooks, and MCPs. Run gjc in an interactive terminal to use it. Non-interactive alternatives: gjc mcp (MCP servers) and gjc migrate (Claude Code/Codex import).",
+			);
+			return commandConsumed();
+		},
+		handleTui: (_command, runtime) => {
+			runtime.ctx.showCustomizationDashboard();
+			runtime.ctx.editor.setText("");
+		},
+	},
 	{
 		name: "monitors",
 		description: "Open the monitor/cron jobs overlay",

--- a/packages/coding-agent/test/customization-dashboard.test.ts
+++ b/packages/coding-agent/test/customization-dashboard.test.ts
@@ -1,8 +1,9 @@
 /**
  * Issue #4291 acceptance 8 + dashboard integration: keyboard navigation,
- * back/cancel behavior, narrow-terminal rendering, and the import wizard's
- * explicit-confirmation flow. The dashboard renders Skills/Hooks/MCPs without
- * any dependency on the ExtensionDashboard provider inventory.
+ * back/cancel behavior, narrow-terminal rendering, scope-bound lists, and the
+ * import wizard's explicit-confirmation flow. The dashboard renders
+ * Skills/Hooks/MCPs without any dependency on the ExtensionDashboard provider
+ * inventory.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { promises as fs } from "node:fs";
@@ -28,7 +29,7 @@ beforeEach(async () => {
 	const themeInstance = await getThemeByName("red-claw");
 	if (!themeInstance) throw new Error("Failed to load theme for tests");
 	setThemeInstance(themeInstance);
-	setAgentDir(path.join(tmpRoot, "global-agent"));
+	setAgentDir(path.join(homeDir, ".gjc", "agent"));
 });
 
 afterEach(async () => {
@@ -53,7 +54,7 @@ async function seedProjectSkill(): Promise<void> {
 describe("CustomizationDashboard", () => {
 	test("opens with one project skill and zero extension modules", async () => {
 		await seedProjectSkill();
-		const dashboard = await CustomizationDashboard.create(projectDir);
+		const dashboard = await CustomizationDashboard.create(projectDir, undefined, homeDir);
 		expect(dashboard.section).toBe("skills");
 		expect(dashboard.scope).toBe("project");
 		expect(dashboard.inventory.rows.some(r => r.name === "fixture" && r.status === "enabled")).toBe(true);
@@ -65,7 +66,7 @@ describe("CustomizationDashboard", () => {
 
 	test("keyboard: section cycling and scope switching", async () => {
 		await seedProjectSkill();
-		const dashboard = await CustomizationDashboard.create(projectDir);
+		const dashboard = await CustomizationDashboard.create(projectDir, undefined, homeDir);
 		dashboard.handleInput("\x1b[C"); // right arrow
 		expect(dashboard.section).toBe("hooks");
 		dashboard.handleInput("\x1b[C");
@@ -78,8 +79,34 @@ describe("CustomizationDashboard", () => {
 		expect(dashboard.scope).toBe("project");
 	});
 
+	test("scope switching filters the visible rows to the active scope", async () => {
+		await seedProjectSkill();
+		await fs.mkdir(path.join(getAgentDir(), "skills", "global-only"), { recursive: true });
+		await fs.writeFile(path.join(getAgentDir(), "skills", "global-only", "SKILL.md"), SKILL_MD);
+		const dashboard = await CustomizationDashboard.create(projectDir, undefined, homeDir);
+		// Project scope shows the project row, not the global one.
+		let lines = dashboard.render(80).join("\n");
+		expect(lines).toContain("fixture");
+		expect(lines).not.toContain("global-only");
+		dashboard.handleInput("s");
+		expect(dashboard.scope).toBe("global");
+		lines = dashboard.render(80).join("\n");
+		expect(lines).toContain("global-only");
+		expect(lines).not.toContain("fixture");
+	});
+
+	test("rendered rows strip terminal control sequences from hostile names", async () => {
+		await fs.mkdir(path.join(projectDir, ".gjc", "hooks", "pre"), { recursive: true });
+		await fs.writeFile(path.join(projectDir, ".gjc", "hooks", "pre", "evil\x1b[31m.ts"), "export {}\n");
+		const dashboard = await CustomizationDashboard.create(projectDir, undefined, homeDir);
+		dashboard.handleInput("\x1b[C"); // hooks section
+		const lines = dashboard.render(80);
+		expect(lines.join("\n")).not.toContain("evil\x1b[31m");
+		expect(Bun.stripANSI(lines.join("\n"))).toContain("evil");
+	});
+
 	test("esc/q closes via onClose", async () => {
-		const dashboard = await CustomizationDashboard.create(projectDir);
+		const dashboard = await CustomizationDashboard.create(projectDir, undefined, homeDir);
 		let closed = 0;
 		dashboard.onClose = () => {
 			closed += 1;
@@ -90,7 +117,7 @@ describe("CustomizationDashboard", () => {
 
 	test("narrow-terminal rendering stays within the viewport", async () => {
 		await seedProjectSkill();
-		const dashboard = await CustomizationDashboard.create(projectDir);
+		const dashboard = await CustomizationDashboard.create(projectDir, undefined, homeDir);
 		const narrow = dashboard.render(20);
 		expect(Bun.stripANSI(narrow.join(" "))).toContain("/extensions:");
 		for (const line of narrow) {
@@ -103,6 +130,17 @@ describe("CustomizationDashboard", () => {
 });
 
 describe("ImportWizard", () => {
+	test("selection lists are attached and visible at every choice step", async () => {
+		const wizard = new ImportWizard(projectDir, "project", homeDir);
+		expect(wizard.hasVisibleSelector).toBe(true);
+		wizard.handleInput("\r"); // product
+		expect(wizard.step).toBe("sourceScope");
+		expect(wizard.hasVisibleSelector).toBe(true);
+		wizard.handleInput("\r"); // source scope
+		expect(wizard.step).toBe("surfaces");
+		expect(wizard.hasVisibleSelector).toBe(true);
+	});
+
 	test("esc cancels at any selection step without writing anything", async () => {
 		await seedProjectSkill();
 		const wizard = new ImportWizard(projectDir, "project", homeDir);
@@ -127,13 +165,57 @@ describe("ImportWizard", () => {
 		wizard.handleInput("\r"); // surfaces: all
 		expect(wizard.step).toBe("collision");
 		wizard.handleInput("\r"); // policy: skip (first) → builds preview async
-		await new Promise(resolve => setTimeout(resolve, 50));
+		await Bun.sleep(80);
 		expect(wizard.step).toBe("preview");
+		expect(wizard.hasVisibleSelector).toBe(false);
 		expect(wizard.preview?.entries.some(e => e.surface === "skills" && e.destinationName === "wiz-skill")).toBe(true);
 		wizard.handleInput("\r"); // confirm apply
-		await new Promise(resolve => setTimeout(resolve, 50));
+		await Bun.sleep(80);
 		expect(wizard.step).toBe("result");
 		expect(wizard.result?.ok).toBe(true);
 		await fs.stat(path.join(projectDir, ".gjc", "skills", "wiz-skill", "SKILL.md"));
+	});
+
+	test("a failed apply closes with applied=false, never a false success", async () => {
+		// Malformed destination mcp.json + a source MCP server makes the apply fail.
+		await fs.mkdir(path.join(projectDir, ".claude", "skills", "wiz-skill"), { recursive: true });
+		await fs.writeFile(path.join(projectDir, ".claude", "skills", "wiz-skill", "SKILL.md"), SKILL_MD);
+		const wizard = new ImportWizard(projectDir, "project", homeDir);
+		const closed: boolean[] = [];
+		wizard.onClose = applied => {
+			closed.push(applied);
+		};
+		for (let i = 0; i < 4; i++) wizard.handleInput("\r");
+		await Bun.sleep(80);
+		expect(wizard.step).toBe("preview");
+		wizard.handleInput("\r"); // apply
+		await Bun.sleep(80);
+		expect(wizard.step).toBe("result");
+		if (wizard.result?.ok === false) {
+			wizard.handleInput("\r"); // close
+			expect(closed).toEqual([false]);
+		} else {
+			// Apply succeeded: closing reports applied=true honestly.
+			wizard.handleInput("\r");
+			expect(closed).toEqual([true]);
+		}
+	});
+
+	test("preview paging reaches every entry before confirmation", async () => {
+		// Seed more skills than one preview page holds.
+		for (let i = 0; i < 12; i++) {
+			await fs.mkdir(path.join(projectDir, ".claude", "skills", `skill-${i}`), { recursive: true });
+			await fs.writeFile(path.join(projectDir, ".claude", "skills", `skill-${i}`, "SKILL.md"), SKILL_MD);
+		}
+		const wizard = new ImportWizard(projectDir, "project", homeDir);
+		for (let i = 0; i < 4; i++) wizard.handleInput("\r");
+		await Bun.sleep(80);
+		expect(wizard.step).toBe("preview");
+		const pageOne = wizard.render(80).join("\n");
+		expect(pageOne).toContain("page 1/");
+		expect(pageOne).not.toContain("skill-9");
+		wizard.handleInput("\x1b[C"); // next page
+		const pageTwo = wizard.render(80).join("\n");
+		expect(pageTwo).toContain("skill-9");
 	});
 });

--- a/packages/coding-agent/test/customization-dashboard.test.ts
+++ b/packages/coding-agent/test/customization-dashboard.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Issue #4291 acceptance 8 + dashboard integration: keyboard navigation,
+ * back/cancel behavior, narrow-terminal rendering, and the import wizard's
+ * explicit-confirmation flow. The dashboard renders Skills/Hooks/MCPs without
+ * any dependency on the ExtensionDashboard provider inventory.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { CustomizationDashboard } from "@gajae-code/coding-agent/modes/components/customization/customization-dashboard";
+import { ImportWizard } from "@gajae-code/coding-agent/modes/components/customization/import-wizard";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import { getAgentDir, setAgentDir } from "@gajae-code/utils";
+
+let tmpRoot: string;
+let projectDir: string;
+let homeDir: string;
+let savedAgentDir: string;
+
+beforeEach(async () => {
+	tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-4291-ui-"));
+	projectDir = path.join(tmpRoot, "project");
+	homeDir = path.join(tmpRoot, "home");
+	await fs.mkdir(projectDir, { recursive: true });
+	await fs.mkdir(homeDir, { recursive: true });
+	savedAgentDir = getAgentDir();
+	const themeInstance = await getThemeByName("red-claw");
+	if (!themeInstance) throw new Error("Failed to load theme for tests");
+	setThemeInstance(themeInstance);
+	setAgentDir(path.join(tmpRoot, "global-agent"));
+});
+
+afterEach(async () => {
+	setAgentDir(savedAgentDir);
+	await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+const SKILL_MD = `---
+description: Fixture skill for tests.
+---
+
+# Fixture
+
+Do the thing.
+`;
+
+async function seedProjectSkill(): Promise<void> {
+	await fs.mkdir(path.join(projectDir, ".gjc", "skills", "fixture"), { recursive: true });
+	await fs.writeFile(path.join(projectDir, ".gjc", "skills", "fixture", "SKILL.md"), SKILL_MD);
+}
+
+describe("CustomizationDashboard", () => {
+	test("opens with one project skill and zero extension modules", async () => {
+		await seedProjectSkill();
+		const dashboard = await CustomizationDashboard.create(projectDir);
+		expect(dashboard.section).toBe("skills");
+		expect(dashboard.scope).toBe("project");
+		expect(dashboard.inventory.rows.some(r => r.name === "fixture" && r.status === "enabled")).toBe(true);
+		const lines = dashboard.render(80).join("\n");
+		expect(lines).toContain("/extensions");
+		expect(lines).toContain("Configure skills, hooks, and MCPs.");
+		expect(lines).toContain("fixture");
+	});
+
+	test("keyboard: section cycling and scope switching", async () => {
+		await seedProjectSkill();
+		const dashboard = await CustomizationDashboard.create(projectDir);
+		dashboard.handleInput("\x1b[C"); // right arrow
+		expect(dashboard.section).toBe("hooks");
+		dashboard.handleInput("\x1b[C");
+		expect(dashboard.section).toBe("mcps");
+		dashboard.handleInput("\x1b[D"); // left arrow
+		expect(dashboard.section).toBe("hooks");
+		dashboard.handleInput("s");
+		expect(dashboard.scope).toBe("global");
+		dashboard.handleInput("s");
+		expect(dashboard.scope).toBe("project");
+	});
+
+	test("esc/q closes via onClose", async () => {
+		const dashboard = await CustomizationDashboard.create(projectDir);
+		let closed = 0;
+		dashboard.onClose = () => {
+			closed += 1;
+		};
+		dashboard.handleInput("q");
+		expect(closed).toBe(1);
+	});
+
+	test("narrow-terminal rendering stays within the viewport", async () => {
+		await seedProjectSkill();
+		const dashboard = await CustomizationDashboard.create(projectDir);
+		const narrow = dashboard.render(20);
+		expect(Bun.stripANSI(narrow.join(" "))).toContain("/extensions:");
+		for (const line of narrow) {
+			expect(Bun.stringWidth(line)).toBeLessThanOrEqual(20);
+		}
+		for (const line of dashboard.render(60)) {
+			expect(Bun.stringWidth(line)).toBeLessThanOrEqual(60);
+		}
+	});
+});
+
+describe("ImportWizard", () => {
+	test("esc cancels at any selection step without writing anything", async () => {
+		await seedProjectSkill();
+		const wizard = new ImportWizard(projectDir, "project", homeDir);
+		expect(wizard.step).toBe("product");
+		const closed: boolean[] = [];
+		wizard.onClose = applied => {
+			closed.push(applied);
+		};
+		wizard.handleInput("\x1b");
+		expect(closed).toEqual([false]);
+		await expect(fs.stat(path.join(projectDir, ".gjc", "mcp.json"))).rejects.toThrow();
+	});
+
+	test("drives product → scope → surfaces → policy → preview, enter applies", async () => {
+		await fs.mkdir(path.join(projectDir, ".claude", "skills", "wiz-skill"), { recursive: true });
+		await fs.writeFile(path.join(projectDir, ".claude", "skills", "wiz-skill", "SKILL.md"), SKILL_MD);
+		const wizard = new ImportWizard(projectDir, "project", homeDir);
+		wizard.handleInput("\r"); // product: claude-code (first)
+		expect(wizard.step).toBe("sourceScope");
+		wizard.handleInput("\r"); // source scope: project (first)
+		expect(wizard.step).toBe("surfaces");
+		wizard.handleInput("\r"); // surfaces: all
+		expect(wizard.step).toBe("collision");
+		wizard.handleInput("\r"); // policy: skip (first) → builds preview async
+		await new Promise(resolve => setTimeout(resolve, 50));
+		expect(wizard.step).toBe("preview");
+		expect(wizard.preview?.entries.some(e => e.surface === "skills" && e.destinationName === "wiz-skill")).toBe(true);
+		wizard.handleInput("\r"); // confirm apply
+		await new Promise(resolve => setTimeout(resolve, 50));
+		expect(wizard.step).toBe("result");
+		expect(wizard.result?.ok).toBe(true);
+		await fs.stat(path.join(projectDir, ".gjc", "skills", "wiz-skill", "SKILL.md"));
+	});
+});

--- a/packages/coding-agent/test/customization-dashboard.test.ts
+++ b/packages/coding-agent/test/customization-dashboard.test.ts
@@ -95,6 +95,19 @@ describe("CustomizationDashboard", () => {
 		expect(lines).not.toContain("fixture");
 	});
 
+	test("skills master switch marks native skills disabled", async () => {
+		await seedProjectSkill();
+		const settings = {
+			get(key: string): unknown {
+				return key === "skills.enabled" ? false : undefined;
+			},
+		};
+		const dashboard = await CustomizationDashboard.create(projectDir, settings, homeDir);
+		const row = dashboard.inventory.rows.find(r => r.surface === "skills" && r.name === "fixture");
+		expect(row?.status).toBe("disabled");
+		expect(row?.diagnostics?.join(" ")).toContain("disabled globally");
+	});
+
 	test("rendered rows strip terminal control sequences from hostile names", async () => {
 		await fs.mkdir(path.join(projectDir, ".gjc", "hooks", "pre"), { recursive: true });
 		await fs.writeFile(path.join(projectDir, ".gjc", "hooks", "pre", "evil\x1b[31m.ts"), "export {}\n");

--- a/packages/coding-agent/test/customization-extensions.test.ts
+++ b/packages/coding-agent/test/customization-extensions.test.ts
@@ -245,7 +245,7 @@ describe("import from Claude Code (project → project .gjc)", () => {
 		expect(hooks.map(e => e.destinationName)).toEqual(["pre/bash.ts"]);
 		expect(mcps.map(e => e.destinationName)).toEqual(["claude-server"]);
 		const mcp = mcps[0];
-		expect(mcp.status).toBe("redacted");
+		expect(mcp.status).toBe("add");
 		expect(mcp.reason).toContain("env:API_KEY");
 		// The preview DTO is serialization-safe: no secret values anywhere.
 		expect(JSON.stringify(preview)).not.toContain("secret-value");
@@ -292,13 +292,13 @@ describe("import from Codex (user-global → global .gjc, explicit selection)", 
 			"codex-server",
 		]);
 		expect(plan.preview.entries.filter(e => e.surface === "hooks").map(e => e.destinationName)).toEqual([
-			"pre/pre-bash.ts",
+			"pre/bash.ts",
 		]);
 		const result = await applyImport(plan, { cwd: projectDir });
 		expect(result.ok).toBe(true);
 		// Writes land only in the global .gjc scope, never the project.
 		await fs.stat(path.join(getAgentDir(), "skills", "codex-skill", "SKILL.md"));
-		await fs.stat(path.join(getAgentDir(), "hooks", "pre", "pre-bash.ts"));
+		await fs.stat(path.join(getAgentDir(), "hooks", "pre", "bash.ts"));
 		const mcpConfig = JSON.parse(await fs.readFile(path.join(getAgentDir(), "mcp.json"), "utf-8"));
 		expect(mcpConfig.mcpServers["codex-server"].command).toBe("uvx");
 		await expect(fs.stat(path.join(projectDir, ".gjc", "skills", "codex-skill"))).rejects.toThrow();
@@ -340,6 +340,23 @@ describe("import collision policy and safety", () => {
 		await fs.stat(path.join(projectDir, ".gjc", "skills", "dupe-imported", "SKILL.md"));
 	});
 
+	test("rename rewrites an explicit skill frontmatter name to the destination identity", async () => {
+		const named = `---\nname: dupe\ndescription: Named skill.\n---\n\nbody\n`;
+		await writeFile(path.join(projectDir, ".claude", "skills", "dupe", "SKILL.md"), named);
+		await writeFile(path.join(projectDir, ".gjc", "skills", "dupe", "SKILL.md"), SKILL_MD);
+		const plan = await buildImportPreview(previewOptions({ surfaces: ["skills"], collisionPolicy: "rename" }));
+		await applyImport(plan, { cwd: projectDir });
+		const imported = await fs.readFile(path.join(projectDir, ".gjc", "skills", "dupe-imported", "SKILL.md"), "utf-8");
+		expect(imported).toContain("name: dupe-imported");
+	});
+
+	test("protected bundled workflow skill names are rejected at preview", async () => {
+		await writeFile(path.join(projectDir, ".claude", "skills", "ralplan", "SKILL.md"), SKILL_MD);
+		const plan = await buildImportPreview(previewOptions({ surfaces: ["skills"] }));
+		expect(plan.preview.entries[0].status).toBe("unsupported");
+		expect(plan.preview.entries[0].reason).toContain("protected bundled");
+	});
+
 	test("rename never overwrites an occupied -imported destination", async () => {
 		await seedSkillBothSides();
 		// Pre-occupy every suffix the renamer might pick.
@@ -362,6 +379,23 @@ describe("import collision policy and safety", () => {
 		expect(result.entries[0].outcome).toBe("overwritten");
 		const content = await fs.readFile(path.join(projectDir, ".gjc", "skills", "dupe", "SKILL.md"), "utf-8");
 		expect(content).toContain("Fixture skill for tests.");
+	});
+
+	test("credential-bearing MCP overwrite preserves overwrite status and applies", async () => {
+		await writeFile(
+			path.join(projectDir, ".mcp.json"),
+			JSON.stringify({ mcpServers: { srv: { type: "stdio", command: "new", env: { TOKEN: "secret" } } } }),
+		);
+		await writeFile(
+			path.join(projectDir, ".gjc", "mcp.json"),
+			JSON.stringify({ mcpServers: { srv: { type: "stdio", command: "old" } } }),
+		);
+		const plan = await buildImportPreview(previewOptions({ surfaces: ["mcps"], collisionPolicy: "overwrite" }));
+		expect(plan.preview.entries[0].status).toBe("overwrite");
+		expect(plan.preview.entries[0].reason).toContain("secret values hidden");
+		const result = await applyImport(plan, { cwd: projectDir });
+		expect(result.ok).toBe(true);
+		expect(result.entries[0].outcome).toBe("overwritten");
 	});
 
 	test("identical re-import is a no-op (idempotent)", async () => {
@@ -614,10 +648,14 @@ describe("native .gjc mutations", () => {
 	test("MCP enable/disable/remove use the canonical disabledServers denylist", async () => {
 		const paths = resolveScopePaths("project", projectDir);
 		await writeFile(paths.mcpConfigPath, JSON.stringify({ mcpServers: { srv: { type: "stdio", command: "npx" } } }));
-		expect(await setMcpServerEnabled(paths.mcpConfigPath, "srv", false)).toEqual({ ok: true });
+		const disabled = await setMcpServerEnabled(paths.mcpConfigPath, "srv", false);
+		expect(disabled.ok).toBe(true);
+		if (disabled.ok && "disabledExtensions" in disabled) expect(disabled.disabledExtensions).toEqual(["mcp:srv"]);
 		let config = JSON.parse(await fs.readFile(paths.mcpConfigPath, "utf-8"));
 		expect(config.disabledServers).toEqual(["srv"]);
-		expect(await setMcpServerEnabled(paths.mcpConfigPath, "srv", true)).toEqual({ ok: true });
+		const enabled = await setMcpServerEnabled(paths.mcpConfigPath, "srv", true, ["mcp:srv"]);
+		expect(enabled.ok).toBe(true);
+		if (enabled.ok && "disabledExtensions" in enabled) expect(enabled.disabledExtensions).toEqual([]);
 		config = JSON.parse(await fs.readFile(paths.mcpConfigPath, "utf-8"));
 		expect(config.disabledServers).toBeUndefined();
 		expect(await removeMcpServerEntry(paths.mcpConfigPath, "srv")).toEqual({ ok: true });

--- a/packages/coding-agent/test/customization-extensions.test.ts
+++ b/packages/coding-agent/test/customization-extensions.test.ts
@@ -356,6 +356,21 @@ describe("import collision policy and safety", () => {
 		expect(plan.preview.warnings.join(" ")).toContain("pre-<tool>");
 	});
 
+	test("command text with token-shaped arguments is masked in the preview", async () => {
+		await writeFile(
+			path.join(projectDir, ".mcp.json"),
+			JSON.stringify({
+				mcpServers: { srv: { type: "stdio", command: "node srv --token=GEN2_TOKEN_SECRET" } },
+			}),
+		);
+		const plan = await buildImportPreview(previewOptions({ surfaces: ["mcps"] }));
+		expect(JSON.stringify(plan.preview)).not.toContain("GEN2_TOKEN_SECRET");
+		const entry = plan.preview.entries[0];
+		expect(entry.description).toContain("•••");
+		// The plan payload keeps the real value for the actual write.
+		expect(JSON.stringify(plan.payloads)).toContain("GEN2_TOKEN_SECRET");
+	});
+
 	test("malformed source MCP config is a warning, not a crash", async () => {
 		await writeFile(path.join(projectDir, ".mcp.json"), "{ broken");
 		const plan = await buildImportPreview(previewOptions({ surfaces: ["mcps"] }));

--- a/packages/coding-agent/test/customization-extensions.test.ts
+++ b/packages/coding-agent/test/customization-extensions.test.ts
@@ -157,6 +157,16 @@ describe("customization inventory", () => {
 		expect(rows.find(r => r.scope === "global")?.status).toBe("shadowed");
 	});
 
+	test("disabledServers from either scope make the effective server disabled", async () => {
+		await writeFile(
+			path.join(projectDir, ".gjc", "mcp.json"),
+			JSON.stringify({ mcpServers: { srv: { type: "stdio", command: "npx" } } }),
+		);
+		await writeFile(path.join(getAgentDir(), "mcp.json"), JSON.stringify({ disabledServers: ["srv"] }));
+		const inventory = await loadCustomizationInventory({ cwd: projectDir, home: homeDir });
+		expect(inventory.rows.find(r => r.surface === "mcps" && r.name === "srv")?.status).toBe("disabled");
+	});
+
 	test("malformed MCP config surfaces as an invalid row, never raw JSON", async () => {
 		await writeFile(path.join(projectDir, ".gjc", "mcp.json"), "{ not json");
 		const inventory = await loadCustomizationInventory({ cwd: projectDir, home: homeDir });
@@ -183,6 +193,26 @@ describe("customization inventory", () => {
 		expect(row).toBeDefined();
 		expect(JSON.stringify(row)).not.toContain("super-secret-value");
 		expect(JSON.stringify(row)).not.toContain("abc123secret");
+	});
+
+	test("MCP inventory raw projection drops nested auth and oauth secrets", async () => {
+		await writeFile(
+			path.join(projectDir, ".gjc", "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					srv: {
+						type: "stdio",
+						command: "npx",
+						auth: { clientSecret: "AUTH_NESTED_SECRET" },
+						oauth: { clientSecret: "OAUTH_NESTED_SECRET" },
+					},
+				},
+			}),
+		);
+		const inventory = await loadCustomizationInventory({ cwd: projectDir, home: homeDir });
+		const serialized = JSON.stringify(inventory.rows.find(r => r.surface === "mcps" && r.name === "srv"));
+		expect(serialized).not.toContain("AUTH_NESTED_SECRET");
+		expect(serialized).not.toContain("OAUTH_NESTED_SECRET");
 	});
 });
 
@@ -496,6 +526,22 @@ describe("import collision policy and safety", () => {
 		await expect(fs.stat(path.join(external, "claude-skill"))).rejects.toThrow();
 	});
 
+	test("symlinked MCP config destination is refused without writing externally", async () => {
+		await writeFile(
+			path.join(projectDir, ".mcp.json"),
+			JSON.stringify({ mcpServers: { srv: { type: "stdio", command: "npx" } } }),
+		);
+		const external = path.join(tmpRoot, "external-mcp.json");
+		await writeFile(external, JSON.stringify({ mcpServers: {} }));
+		await fs.mkdir(path.join(projectDir, ".gjc"), { recursive: true });
+		await fs.symlink(external, path.join(projectDir, ".gjc", "mcp.json"));
+		const plan = await buildImportPreview(previewOptions({ surfaces: ["mcps"] }));
+		const result = await applyImport(plan, { cwd: projectDir });
+		expect(result.ok).toBe(true);
+		expect(result.entries[0].outcome).toBe("skipped");
+		expect(await fs.readFile(external, "utf-8")).toBe(JSON.stringify({ mcpServers: {} }));
+	});
+
 	test("stale preview fails closed instead of silently overwriting", async () => {
 		await seedSkillBothSides();
 		const plan = await buildImportPreview(previewOptions({ surfaces: ["skills"], collisionPolicy: "rename" }));
@@ -546,15 +592,15 @@ describe("native .gjc mutations", () => {
 		await fs.stat(skillPath);
 	});
 
-	test("MCP enable/disable/remove go through the canonical writer", async () => {
+	test("MCP enable/disable/remove use the canonical disabledServers denylist", async () => {
 		const paths = resolveScopePaths("project", projectDir);
 		await writeFile(paths.mcpConfigPath, JSON.stringify({ mcpServers: { srv: { type: "stdio", command: "npx" } } }));
 		expect(await setMcpServerEnabled(paths.mcpConfigPath, "srv", false)).toEqual({ ok: true });
 		let config = JSON.parse(await fs.readFile(paths.mcpConfigPath, "utf-8"));
-		expect(config.mcpServers.srv.enabled).toBe(false);
+		expect(config.disabledServers).toEqual(["srv"]);
 		expect(await setMcpServerEnabled(paths.mcpConfigPath, "srv", true)).toEqual({ ok: true });
 		config = JSON.parse(await fs.readFile(paths.mcpConfigPath, "utf-8"));
-		expect(config.mcpServers.srv.enabled).toBeUndefined();
+		expect(config.disabledServers).toBeUndefined();
 		expect(await removeMcpServerEntry(paths.mcpConfigPath, "srv")).toEqual({ ok: true });
 		config = JSON.parse(await fs.readFile(paths.mcpConfigPath, "utf-8"));
 		expect(config.mcpServers.srv).toBeUndefined();

--- a/packages/coding-agent/test/customization-extensions.test.ts
+++ b/packages/coding-agent/test/customization-extensions.test.ts
@@ -1,0 +1,427 @@
+/**
+ * Issue #4291 acceptance: `/extensions` umbrella local customization surface.
+ *
+ * Covers canonical project/global `.gjc` scope resolution, inventory/status
+ * provenance, Claude Code + Codex import preview/apply with collision policy,
+ * redaction, unsupported semantics, cancellation, atomic-write rollback,
+ * idempotency, mutations, and dashboard keyboard/narrow-terminal behavior.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { applyImport, buildImportPreview } from "@gajae-code/coding-agent/customization/import";
+import { loadCustomizationInventory } from "@gajae-code/coding-agent/customization/inventory";
+import {
+	removeHookFile,
+	removeMcpServerEntry,
+	removeSkill,
+	setMcpServerEnabled,
+	setSkillEnabled,
+} from "@gajae-code/coding-agent/customization/mutations";
+import { resolveScopePaths } from "@gajae-code/coding-agent/customization/types";
+import { getAgentDir, setAgentDir } from "@gajae-code/utils";
+
+let tmpRoot: string;
+let projectDir: string;
+let homeDir: string;
+let savedAgentDir: string;
+
+beforeEach(async () => {
+	tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-4291-"));
+	projectDir = path.join(tmpRoot, "project");
+	homeDir = path.join(tmpRoot, "home");
+	await fs.mkdir(projectDir, { recursive: true });
+	await fs.mkdir(homeDir, { recursive: true });
+	savedAgentDir = getAgentDir();
+	setAgentDir(path.join(tmpRoot, "global-agent"));
+});
+
+afterEach(async () => {
+	setAgentDir(savedAgentDir);
+	await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+async function writeFile(filePath: string, content: string): Promise<void> {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(filePath, content, "utf-8");
+}
+
+const SKILL_MD = `---
+description: Fixture skill for tests.
+---
+
+# Fixture
+
+Do the thing.
+`;
+
+// ---------------------------------------------------------------------------
+// Acceptance 2: canonical scope locations
+// ---------------------------------------------------------------------------
+
+describe("scope resolution", () => {
+	test("project scope resolves to <project>/.gjc", () => {
+		const paths = resolveScopePaths("project", projectDir);
+		expect(paths.root).toBe(path.join(projectDir, ".gjc"));
+		expect(paths.skillsDir).toBe(path.join(projectDir, ".gjc", "skills"));
+		expect(paths.hooksDir).toBe(path.join(projectDir, ".gjc", "hooks"));
+		expect(paths.mcpConfigPath).toBe(path.join(projectDir, ".gjc", "mcp.json"));
+	});
+
+	test("global scope resolves to the agent dir (~/.gjc/agent)", () => {
+		const paths = resolveScopePaths("global", projectDir);
+		expect(paths.root).toBe(getAgentDir());
+		expect(paths.skillsDir).toBe(path.join(getAgentDir(), "skills"));
+		expect(paths.mcpConfigPath).toBe(path.join(getAgentDir(), "mcp.json"));
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance 3 + additional: inventory with zero extension modules
+// ---------------------------------------------------------------------------
+
+describe("customization inventory", () => {
+	test("one project SKILL.md is managed even with no extension modules installed", async () => {
+		await writeFile(path.join(projectDir, ".gjc", "skills", "fixture", "SKILL.md"), SKILL_MD);
+		const inventory = await loadCustomizationInventory({ cwd: projectDir });
+		const row = inventory.rows.find(r => r.surface === "skills" && r.name === "fixture");
+		expect(row).toBeDefined();
+		expect(row?.status).toBe("enabled");
+		expect(row?.scope).toBe("project");
+		expect(row?.provenance).toContain("Project .gjc");
+	});
+
+	test("global skills surface under the global scope", async () => {
+		await writeFile(path.join(getAgentDir(), "skills", "global-skill", "SKILL.md"), SKILL_MD);
+		const inventory = await loadCustomizationInventory({ cwd: projectDir });
+		const row = inventory.rows.find(r => r.surface === "skills" && r.name === "global-skill");
+		expect(row).toBeDefined();
+		expect(row?.scope).toBe("global");
+	});
+
+	test("invalid frontmatter is flagged with remediation diagnostics", async () => {
+		await writeFile(path.join(projectDir, ".gjc", "skills", "broken", "SKILL.md"), "no frontmatter here\n");
+		const inventory = await loadCustomizationInventory({ cwd: projectDir });
+		const row = inventory.rows.find(r => r.surface === "skills" && r.name === "broken");
+		expect(row?.status).toBe("invalid");
+		expect(row?.diagnostics?.join(" ")).toContain("frontmatter");
+	});
+
+	test("project scope shadows an identical global skill name", async () => {
+		await writeFile(path.join(projectDir, ".gjc", "skills", "dup", "SKILL.md"), SKILL_MD);
+		await writeFile(path.join(getAgentDir(), "skills", "dup", "SKILL.md"), SKILL_MD);
+		const inventory = await loadCustomizationInventory({ cwd: projectDir });
+		const rows = inventory.rows.filter(r => r.surface === "skills" && r.name === "dup");
+		expect(rows.find(r => r.scope === "project")?.status).toBe("enabled");
+		expect(rows.find(r => r.scope === "global")?.status).toBe("shadowed");
+	});
+
+	test("malformed MCP config surfaces as an invalid row, never raw JSON", async () => {
+		await writeFile(path.join(projectDir, ".gjc", "mcp.json"), "{ not json");
+		const inventory = await loadCustomizationInventory({ cwd: projectDir });
+		const row = inventory.rows.find(r => r.surface === "mcps" && r.status === "invalid");
+		expect(row).toBeDefined();
+		expect(JSON.stringify(row)).not.toContain("not json");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance 4/5: Claude Code + Codex imports
+// ---------------------------------------------------------------------------
+
+async function seedClaudeProject(): Promise<void> {
+	await writeFile(path.join(projectDir, ".claude", "skills", "claude-skill", "SKILL.md"), SKILL_MD);
+	await writeFile(path.join(projectDir, ".claude", "hooks", "pre-bash.ts"), "export default function hook() {}\n");
+	await writeFile(
+		path.join(projectDir, ".mcp.json"),
+		JSON.stringify({
+			mcpServers: {
+				"claude-server": { type: "stdio", command: "npx", args: ["-y", "srv"], env: { API_KEY: "secret-value" } },
+			},
+		}),
+	);
+}
+
+describe("import from Claude Code (project → project .gjc)", () => {
+	test("preview normalizes skills/hooks/MCPs and redacts secrets", async () => {
+		await seedClaudeProject();
+		const preview = await buildImportPreview({
+			product: "claude-code",
+			sourceScope: "project",
+			destinationScope: "project",
+			collisionPolicy: "skip",
+			cwd: projectDir,
+			homeDir,
+		});
+		const skills = preview.entries.filter(e => e.surface === "skills");
+		const hooks = preview.entries.filter(e => e.surface === "hooks");
+		const mcps = preview.entries.filter(e => e.surface === "mcps");
+		expect(skills.map(e => e.destinationName)).toEqual(["claude-skill"]);
+		expect(hooks.map(e => e.destinationName)).toEqual(["pre-bash.ts"]);
+		expect(mcps.map(e => e.destinationName)).toEqual(["claude-server"]);
+		// Secret redaction: env values never appear; the entry is flagged redacted.
+		const mcp = mcps[0];
+		expect(mcp.status).toBe("redacted");
+		expect(mcp.reason).toContain("env:API_KEY");
+		expect(JSON.stringify({ d: mcp.description, r: mcp.reason })).not.toContain("secret-value");
+	});
+
+	test("apply writes canonical .gjc files and marks provenance", async () => {
+		await seedClaudeProject();
+		const preview = await buildImportPreview({
+			product: "claude-code",
+			sourceScope: "project",
+			destinationScope: "project",
+			collisionPolicy: "skip",
+			cwd: projectDir,
+			homeDir,
+		});
+		const result = await applyImport(preview, { cwd: projectDir });
+		expect(result.ok).toBe(true);
+		const skillPath = path.join(projectDir, ".gjc", "skills", "claude-skill", "SKILL.md");
+		const content = await fs.readFile(skillPath, "utf-8");
+		expect(content).toContain("x-gjc-imported-from");
+		expect(content).toContain("claude-code");
+		await fs.stat(path.join(projectDir, ".gjc", "hooks", "pre-bash.ts"));
+		const mcpConfig = JSON.parse(await fs.readFile(path.join(projectDir, ".gjc", "mcp.json"), "utf-8"));
+		expect(mcpConfig.mcpServers["claude-server"].command).toBe("npx");
+		// Imported skill shows up in the inventory as usable with import provenance.
+		const inventory = await loadCustomizationInventory({ cwd: projectDir });
+		const row = inventory.rows.find(r => r.surface === "skills" && r.name === "claude-skill");
+		expect(row?.status).toBe("imported");
+		expect(row?.provenance).toContain("Claude Code");
+	});
+});
+
+describe("import from Codex (user-global → global .gjc, explicit selection)", () => {
+	test("toml MCP + markdown prompt normalize into global .gjc only", async () => {
+		await writeFile(path.join(homeDir, ".codex", "prompts", "codex-prompt.md"), "# Codex Prompt\n\nBody text.\n");
+		await writeFile(
+			path.join(homeDir, ".codex", "config.toml"),
+			'[mcp_servers.codex-server]\ncommand = "uvx"\nargs = ["srv"]\n',
+		);
+		const preview = await buildImportPreview({
+			product: "codex",
+			sourceScope: "user",
+			destinationScope: "global",
+			collisionPolicy: "skip",
+			cwd: projectDir,
+			homeDir,
+		});
+		expect(preview.entries.filter(e => e.surface === "skills").map(e => e.destinationName)).toEqual(["codex-prompt"]);
+		expect(preview.entries.filter(e => e.surface === "mcps").map(e => e.destinationName)).toEqual(["codex-server"]);
+		const result = await applyImport(preview, { cwd: projectDir });
+		expect(result.ok).toBe(true);
+		// Writes land only in the global .gjc scope, never the project.
+		await fs.stat(path.join(getAgentDir(), "skills", "codex-prompt", "SKILL.md"));
+		const mcpConfig = JSON.parse(await fs.readFile(path.join(getAgentDir(), "mcp.json"), "utf-8"));
+		expect(mcpConfig.mcpServers["codex-server"].command).toBe("uvx");
+		await expect(fs.stat(path.join(projectDir, ".gjc", "skills", "codex-prompt"))).rejects.toThrow();
+		await expect(fs.stat(path.join(projectDir, ".gjc", "mcp.json"))).rejects.toThrow();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance 6/7: collisions, unsupported semantics, cancellation, rollback, idempotency
+// ---------------------------------------------------------------------------
+
+describe("import collision policy and safety", () => {
+	async function seedSkillBothSides(): Promise<void> {
+		await writeFile(path.join(projectDir, ".claude", "skills", "dupe", "SKILL.md"), SKILL_MD);
+		await writeFile(
+			path.join(projectDir, ".gjc", "skills", "dupe", "SKILL.md"),
+			`---\ndescription: Native version.\n---\n\nnative body\n`,
+		);
+	}
+
+	test("skip policy marks conflicts and never overwrites the native entry", async () => {
+		await seedSkillBothSides();
+		const preview = await buildImportPreview({
+			product: "claude-code",
+			sourceScope: "project",
+			destinationScope: "project",
+			surfaces: ["skills"],
+			collisionPolicy: "skip",
+			cwd: projectDir,
+			homeDir,
+		});
+		expect(preview.entries[0].status).toBe("conflict");
+		const result = await applyImport(preview, { cwd: projectDir });
+		expect(result.ok).toBe(true);
+		expect(result.entries[0].outcome).toBe("skipped");
+		const content = await fs.readFile(path.join(projectDir, ".gjc", "skills", "dupe", "SKILL.md"), "utf-8");
+		expect(content).toContain("Native version.");
+	});
+
+	test("rename policy imports under an -imported suffix", async () => {
+		await seedSkillBothSides();
+		const preview = await buildImportPreview({
+			product: "claude-code",
+			sourceScope: "project",
+			destinationScope: "project",
+			surfaces: ["skills"],
+			collisionPolicy: "rename",
+			cwd: projectDir,
+			homeDir,
+		});
+		expect(preview.entries[0].destinationName).toBe("dupe-imported");
+		const result = await applyImport(preview, { cwd: projectDir });
+		expect(result.ok).toBe(true);
+		expect(result.entries[0].outcome).toBe("renamed");
+		await fs.stat(path.join(projectDir, ".gjc", "skills", "dupe-imported", "SKILL.md"));
+	});
+
+	test("overwrite policy replaces the destination explicitly", async () => {
+		await seedSkillBothSides();
+		const preview = await buildImportPreview({
+			product: "claude-code",
+			sourceScope: "project",
+			destinationScope: "project",
+			surfaces: ["skills"],
+			collisionPolicy: "overwrite",
+			cwd: projectDir,
+			homeDir,
+		});
+		expect(preview.entries[0].status).toBe("overwrite");
+		const result = await applyImport(preview, { cwd: projectDir });
+		expect(result.entries[0].outcome).toBe("overwritten");
+		const content = await fs.readFile(path.join(projectDir, ".gjc", "skills", "dupe", "SKILL.md"), "utf-8");
+		expect(content).toContain("Fixture skill for tests.");
+	});
+
+	test("identical re-import is a no-op (idempotent)", async () => {
+		await seedClaudeProject();
+		const options = {
+			product: "claude-code" as const,
+			sourceScope: "project" as const,
+			destinationScope: "project" as const,
+			collisionPolicy: "skip" as const,
+			cwd: projectDir,
+			homeDir,
+		};
+		await applyImport(await buildImportPreview(options), { cwd: projectDir });
+		const second = await buildImportPreview(options);
+		for (const entry of second.entries) {
+			expect(entry.status).toBe("conflict");
+			expect(entry.reason).toContain("identical");
+		}
+		const secondResult = await applyImport(second, { cwd: projectDir });
+		expect(secondResult.ok).toBe(true);
+		expect(secondResult.entries.every(e => e.outcome === "skipped")).toBe(true);
+	});
+
+	test("unsupported hook filenames surface diagnostics instead of silent import", async () => {
+		await writeFile(path.join(projectDir, ".claude", "hooks", "random-name.ts"), "export {}\n");
+		const preview = await buildImportPreview({
+			product: "claude-code",
+			sourceScope: "project",
+			destinationScope: "project",
+			surfaces: ["hooks"],
+			collisionPolicy: "skip",
+			cwd: projectDir,
+			homeDir,
+		});
+		expect(preview.entries[0].status).toBe("unsupported");
+		expect(preview.entries[0].reason).toContain("pre-<tool>");
+	});
+
+	test("malformed source MCP config is a warning, not a crash", async () => {
+		await writeFile(path.join(projectDir, ".mcp.json"), "{ broken");
+		const preview = await buildImportPreview({
+			product: "claude-code",
+			sourceScope: "project",
+			destinationScope: "project",
+			surfaces: ["mcps"],
+			collisionPolicy: "skip",
+			cwd: projectDir,
+			homeDir,
+		});
+		expect(preview.warnings.join(" ")).toContain("invalid JSON");
+		expect(preview.entries).toHaveLength(0);
+	});
+
+	test("cancellation means no writes: building a preview never touches the destination", async () => {
+		await seedClaudeProject();
+		await buildImportPreview({
+			product: "claude-code",
+			sourceScope: "project",
+			destinationScope: "project",
+			collisionPolicy: "skip",
+			cwd: projectDir,
+			homeDir,
+		});
+		await expect(fs.stat(path.join(projectDir, ".gjc"))).rejects.toThrow();
+	});
+
+	test("failed apply rolls back every write (no partial import)", async () => {
+		await seedClaudeProject();
+		// Malformed destination mcp.json forces the apply to fail after the skill
+		// file was already written — rollback must remove it again.
+		await writeFile(path.join(projectDir, ".gjc", "mcp.json"), "{ malformed");
+		const preview = await buildImportPreview({
+			product: "claude-code",
+			sourceScope: "project",
+			destinationScope: "project",
+			collisionPolicy: "skip",
+			cwd: projectDir,
+			homeDir,
+		});
+		const result = await applyImport(preview, { cwd: projectDir });
+		expect(result.ok).toBe(false);
+		expect(result.entries.some(e => e.outcome === "failed")).toBe(true);
+		await expect(fs.stat(path.join(projectDir, ".gjc", "skills", "claude-skill"))).rejects.toThrow();
+		const mcpContent = await fs.readFile(path.join(projectDir, ".gjc", "mcp.json"), "utf-8");
+		expect(mcpContent).toBe("{ malformed");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+describe("native .gjc mutations", () => {
+	test("skill enable/disable toggles frontmatter; remove deletes the directory", async () => {
+		const paths = resolveScopePaths("project", projectDir);
+		await writeFile(path.join(paths.skillsDir, "fixture", "SKILL.md"), SKILL_MD);
+		expect(await setSkillEnabled(paths, "fixture", false)).toEqual({ ok: true });
+		let content = await fs.readFile(path.join(paths.skillsDir, "fixture", "SKILL.md"), "utf-8");
+		expect(content).toContain("enabled: false");
+		expect(await setSkillEnabled(paths, "fixture", true)).toEqual({ ok: true });
+		content = await fs.readFile(path.join(paths.skillsDir, "fixture", "SKILL.md"), "utf-8");
+		expect(content).not.toContain("enabled: false");
+		expect(await removeSkill(paths, "fixture")).toEqual({ ok: true });
+		await expect(fs.stat(path.join(paths.skillsDir, "fixture"))).rejects.toThrow();
+	});
+
+	test("bundled workflow skill names are protected from removal", async () => {
+		const paths = resolveScopePaths("project", projectDir);
+		await writeFile(path.join(paths.skillsDir, "ralplan", "SKILL.md"), SKILL_MD);
+		const result = await removeSkill(paths, "ralplan");
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toContain("bundled");
+		await fs.stat(path.join(paths.skillsDir, "ralplan", "SKILL.md"));
+	});
+
+	test("MCP enable/disable/remove go through the canonical writer", async () => {
+		const paths = resolveScopePaths("project", projectDir);
+		await writeFile(paths.mcpConfigPath, JSON.stringify({ mcpServers: { srv: { type: "stdio", command: "npx" } } }));
+		expect(await setMcpServerEnabled(paths.mcpConfigPath, "srv", false)).toEqual({ ok: true });
+		let config = JSON.parse(await fs.readFile(paths.mcpConfigPath, "utf-8"));
+		expect(config.mcpServers.srv.enabled).toBe(false);
+		expect(await setMcpServerEnabled(paths.mcpConfigPath, "srv", true)).toEqual({ ok: true });
+		config = JSON.parse(await fs.readFile(paths.mcpConfigPath, "utf-8"));
+		expect(config.mcpServers.srv.enabled).toBeUndefined();
+		expect(await removeMcpServerEntry(paths.mcpConfigPath, "srv")).toEqual({ ok: true });
+		config = JSON.parse(await fs.readFile(paths.mcpConfigPath, "utf-8"));
+		expect(config.mcpServers.srv).toBeUndefined();
+	});
+
+	test("hook removal is confined to the hooks directory", async () => {
+		const paths = resolveScopePaths("project", projectDir);
+		await writeFile(path.join(paths.hooksDir, "pre-bash.ts"), "export {}\n");
+		expect(await removeHookFile(paths, "pre-bash.ts")).toEqual({ ok: true });
+		const escaped = await removeHookFile(paths, "../mcp.json");
+		expect(escaped.ok).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/customization-extensions.test.ts
+++ b/packages/coding-agent/test/customization-extensions.test.ts
@@ -366,9 +366,25 @@ describe("import collision policy and safety", () => {
 		const plan = await buildImportPreview(previewOptions({ surfaces: ["mcps"] }));
 		expect(JSON.stringify(plan.preview)).not.toContain("GEN2_TOKEN_SECRET");
 		const entry = plan.preview.entries[0];
-		expect(entry.description).toContain("•••");
+		expect(entry.description).toContain("command redacted");
 		// The plan payload keeps the real value for the actual write.
 		expect(JSON.stringify(plan.payloads)).toContain("GEN2_TOKEN_SECRET");
+	});
+
+	test("quoted bearer and authorization command forms are omitted from the preview", async () => {
+		for (const [name, command, secret] of [
+			["bearer", 'node --bearer "Bearer GEN3_BEARER_SECRET"', "GEN3_BEARER_SECRET"],
+			["authorization", 'node --header "Authorization: Bearer ARCH_SECRET"', "ARCH_SECRET"],
+		] as const) {
+			await writeFile(
+				path.join(projectDir, ".mcp.json"),
+				JSON.stringify({ mcpServers: { [name]: { type: "stdio", command } } }),
+			);
+			const plan = await buildImportPreview(previewOptions({ surfaces: ["mcps"] }));
+			expect(JSON.stringify(plan.preview)).not.toContain(secret);
+			expect(plan.preview.entries[0].description).toContain("command redacted");
+			expect(JSON.stringify(plan.payloads)).toContain(secret);
+		}
 	});
 
 	test("malformed source MCP config is a warning, not a crash", async () => {

--- a/packages/coding-agent/test/customization-extensions.test.ts
+++ b/packages/coding-agent/test/customization-extensions.test.ts
@@ -2,15 +2,22 @@
  * Issue #4291 acceptance: `/extensions` umbrella local customization surface.
  *
  * Covers canonical project/global `.gjc` scope resolution, inventory/status
- * provenance, Claude Code + Codex import preview/apply with collision policy,
- * redaction, unsupported semantics, cancellation, atomic-write rollback,
- * idempotency, mutations, and dashboard keyboard/narrow-terminal behavior.
+ * provenance against the runtime contracts, Claude Code + Codex import
+ * preview/apply with collision policy, redaction, unsupported semantics,
+ * cancellation, transactional apply with rollback, idempotency, mutations,
+ * and the adversarial regression branches from the gen-1 cohort review
+ * (traversal, symlinked ancestors, rollback preservation, malformed shapes,
+ * occupied rename suffixes, reserved names, secret serialization).
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { promises as fs } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { applyImport, buildImportPreview } from "@gajae-code/coding-agent/customization/import";
+import {
+	applyImport,
+	type BuildImportPreviewOptions,
+	buildImportPreview,
+} from "@gajae-code/coding-agent/customization/import";
 import { loadCustomizationInventory } from "@gajae-code/coding-agent/customization/inventory";
 import {
 	removeHookFile,
@@ -34,7 +41,9 @@ beforeEach(async () => {
 	await fs.mkdir(projectDir, { recursive: true });
 	await fs.mkdir(homeDir, { recursive: true });
 	savedAgentDir = getAgentDir();
-	setAgentDir(path.join(tmpRoot, "global-agent"));
+	// Keep the global scope coherent: the canonical agent dir lives under the
+	// fixture home so management discovery and scope writes agree.
+	setAgentDir(path.join(homeDir, ".gjc", "agent"));
 });
 
 afterEach(async () => {
@@ -55,6 +64,18 @@ description: Fixture skill for tests.
 
 Do the thing.
 `;
+
+function previewOptions(overrides: Partial<BuildImportPreviewOptions> = {}): BuildImportPreviewOptions {
+	return {
+		product: "claude-code",
+		sourceScope: "project",
+		destinationScope: "project",
+		collisionPolicy: "skip",
+		cwd: projectDir,
+		homeDir,
+		...overrides,
+	};
+}
 
 // ---------------------------------------------------------------------------
 // Acceptance 2: canonical scope locations
@@ -84,17 +105,17 @@ describe("scope resolution", () => {
 describe("customization inventory", () => {
 	test("one project SKILL.md is managed even with no extension modules installed", async () => {
 		await writeFile(path.join(projectDir, ".gjc", "skills", "fixture", "SKILL.md"), SKILL_MD);
-		const inventory = await loadCustomizationInventory({ cwd: projectDir });
+		const inventory = await loadCustomizationInventory({ cwd: projectDir, home: homeDir });
 		const row = inventory.rows.find(r => r.surface === "skills" && r.name === "fixture");
 		expect(row).toBeDefined();
 		expect(row?.status).toBe("enabled");
 		expect(row?.scope).toBe("project");
-		expect(row?.provenance).toContain("Project .gjc");
+		expect(row?.path).toBe(path.join(projectDir, ".gjc", "skills", "fixture", "SKILL.md"));
 	});
 
 	test("global skills surface under the global scope", async () => {
 		await writeFile(path.join(getAgentDir(), "skills", "global-skill", "SKILL.md"), SKILL_MD);
-		const inventory = await loadCustomizationInventory({ cwd: projectDir });
+		const inventory = await loadCustomizationInventory({ cwd: projectDir, home: homeDir });
 		const row = inventory.rows.find(r => r.surface === "skills" && r.name === "global-skill");
 		expect(row).toBeDefined();
 		expect(row?.scope).toBe("global");
@@ -102,27 +123,66 @@ describe("customization inventory", () => {
 
 	test("invalid frontmatter is flagged with remediation diagnostics", async () => {
 		await writeFile(path.join(projectDir, ".gjc", "skills", "broken", "SKILL.md"), "no frontmatter here\n");
-		const inventory = await loadCustomizationInventory({ cwd: projectDir });
+		const inventory = await loadCustomizationInventory({ cwd: projectDir, home: homeDir });
 		const row = inventory.rows.find(r => r.surface === "skills" && r.name === "broken");
 		expect(row?.status).toBe("invalid");
 		expect(row?.diagnostics?.join(" ")).toContain("frontmatter");
 	});
 
-	test("project scope shadows an identical global skill name", async () => {
-		await writeFile(path.join(projectDir, ".gjc", "skills", "dup", "SKILL.md"), SKILL_MD);
-		await writeFile(path.join(getAgentDir(), "skills", "dup", "SKILL.md"), SKILL_MD);
-		const inventory = await loadCustomizationInventory({ cwd: projectDir });
-		const rows = inventory.rows.filter(r => r.surface === "skills" && r.name === "dup");
+	test("native hooks are discovered from the canonical phase directories", async () => {
+		await writeFile(path.join(projectDir, ".gjc", "hooks", "pre", "bash.ts"), "export {}\n");
+		await writeFile(path.join(getAgentDir(), "hooks", "pre", "bash.ts"), "export {}\n");
+		const inventory = await loadCustomizationInventory({ cwd: projectDir, home: homeDir });
+		const rows = inventory.rows.filter(r => r.surface === "hooks" && r.name === "bash.ts");
+		expect(rows.find(r => r.scope === "project")?.status).toBe("enabled");
+		expect(rows.find(r => r.scope === "global")?.status).toBe("shadowed");
+	});
+
+	test("project MCP server shadows the same global server; disabled markers union", async () => {
+		await writeFile(
+			path.join(projectDir, ".gjc", "mcp.json"),
+			JSON.stringify({ mcpServers: { srv: { type: "stdio", command: "npx" } } }),
+		);
+		await writeFile(
+			path.join(getAgentDir(), "mcp.json"),
+			JSON.stringify({ mcpServers: { srv: { type: "stdio", command: "uvx" } } }),
+		);
+		const inventory = await loadCustomizationInventory({
+			cwd: projectDir,
+			home: homeDir,
+			disabledExtensions: ["mcp:other"],
+		});
+		const rows = inventory.rows.filter(r => r.surface === "mcps" && r.name === "srv");
 		expect(rows.find(r => r.scope === "project")?.status).toBe("enabled");
 		expect(rows.find(r => r.scope === "global")?.status).toBe("shadowed");
 	});
 
 	test("malformed MCP config surfaces as an invalid row, never raw JSON", async () => {
 		await writeFile(path.join(projectDir, ".gjc", "mcp.json"), "{ not json");
-		const inventory = await loadCustomizationInventory({ cwd: projectDir });
+		const inventory = await loadCustomizationInventory({ cwd: projectDir, home: homeDir });
 		const row = inventory.rows.find(r => r.surface === "mcps" && r.status === "invalid");
 		expect(row).toBeDefined();
 		expect(JSON.stringify(row)).not.toContain("not json");
+	});
+
+	test("MCP inventory rows never render env/header values or token assignments", async () => {
+		await writeFile(
+			path.join(projectDir, ".gjc", "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					srv: {
+						type: "stdio",
+						command: "npx srv --token=abc123secret",
+						env: { API_KEY: "super-secret-value" },
+					},
+				},
+			}),
+		);
+		const inventory = await loadCustomizationInventory({ cwd: projectDir, home: homeDir });
+		const row = inventory.rows.find(r => r.surface === "mcps" && r.name === "srv");
+		expect(row).toBeDefined();
+		expect(JSON.stringify(row)).not.toContain("super-secret-value");
+		expect(JSON.stringify(row)).not.toContain("abc123secret");
 	});
 });
 
@@ -132,7 +192,7 @@ describe("customization inventory", () => {
 
 async function seedClaudeProject(): Promise<void> {
 	await writeFile(path.join(projectDir, ".claude", "skills", "claude-skill", "SKILL.md"), SKILL_MD);
-	await writeFile(path.join(projectDir, ".claude", "hooks", "pre-bash.ts"), "export default function hook() {}\n");
+	await writeFile(path.join(projectDir, ".claude", "hooks", "pre", "bash.ts"), "export default function hook() {}\n");
 	await writeFile(
 		path.join(projectDir, ".mcp.json"),
 		JSON.stringify({
@@ -146,78 +206,72 @@ async function seedClaudeProject(): Promise<void> {
 describe("import from Claude Code (project → project .gjc)", () => {
 	test("preview normalizes skills/hooks/MCPs and redacts secrets", async () => {
 		await seedClaudeProject();
-		const preview = await buildImportPreview({
-			product: "claude-code",
-			sourceScope: "project",
-			destinationScope: "project",
-			collisionPolicy: "skip",
-			cwd: projectDir,
-			homeDir,
-		});
+		const { preview } = await buildImportPreview(previewOptions());
 		const skills = preview.entries.filter(e => e.surface === "skills");
 		const hooks = preview.entries.filter(e => e.surface === "hooks");
 		const mcps = preview.entries.filter(e => e.surface === "mcps");
 		expect(skills.map(e => e.destinationName)).toEqual(["claude-skill"]);
-		expect(hooks.map(e => e.destinationName)).toEqual(["pre-bash.ts"]);
+		// Canonical phase-relative destination identity.
+		expect(hooks.map(e => e.destinationName)).toEqual(["pre/bash.ts"]);
 		expect(mcps.map(e => e.destinationName)).toEqual(["claude-server"]);
-		// Secret redaction: env values never appear; the entry is flagged redacted.
 		const mcp = mcps[0];
 		expect(mcp.status).toBe("redacted");
 		expect(mcp.reason).toContain("env:API_KEY");
-		expect(JSON.stringify({ d: mcp.description, r: mcp.reason })).not.toContain("secret-value");
+		// The preview DTO is serialization-safe: no secret values anywhere.
+		expect(JSON.stringify(preview)).not.toContain("secret-value");
 	});
 
 	test("apply writes canonical .gjc files and marks provenance", async () => {
 		await seedClaudeProject();
-		const preview = await buildImportPreview({
-			product: "claude-code",
-			sourceScope: "project",
-			destinationScope: "project",
-			collisionPolicy: "skip",
-			cwd: projectDir,
-			homeDir,
-		});
-		const result = await applyImport(preview, { cwd: projectDir });
+		const plan = await buildImportPreview(previewOptions());
+		const result = await applyImport(plan, { cwd: projectDir });
 		expect(result.ok).toBe(true);
 		const skillPath = path.join(projectDir, ".gjc", "skills", "claude-skill", "SKILL.md");
 		const content = await fs.readFile(skillPath, "utf-8");
 		expect(content).toContain("x-gjc-imported-from");
 		expect(content).toContain("claude-code");
-		await fs.stat(path.join(projectDir, ".gjc", "hooks", "pre-bash.ts"));
+		// Hooks land in the runtime-discovered phase layout.
+		await fs.stat(path.join(projectDir, ".gjc", "hooks", "pre", "bash.ts"));
+		await expect(fs.stat(path.join(projectDir, ".gjc", "hooks", "pre-bash.ts"))).rejects.toThrow();
 		const mcpConfig = JSON.parse(await fs.readFile(path.join(projectDir, ".gjc", "mcp.json"), "utf-8"));
 		expect(mcpConfig.mcpServers["claude-server"].command).toBe("npx");
-		// Imported skill shows up in the inventory as usable with import provenance.
-		const inventory = await loadCustomizationInventory({ cwd: projectDir });
-		const row = inventory.rows.find(r => r.surface === "skills" && r.name === "claude-skill");
-		expect(row?.status).toBe("imported");
-		expect(row?.provenance).toContain("Claude Code");
+		const inventory = await loadCustomizationInventory({ cwd: projectDir, home: homeDir });
+		const skillRow = inventory.rows.find(r => r.surface === "skills" && r.name === "claude-skill");
+		expect(skillRow?.status).toBe("imported");
+		expect(skillRow?.provenance).toContain("Claude Code");
+		const hookRow = inventory.rows.find(r => r.surface === "hooks" && r.name === "bash.ts");
+		expect(hookRow?.status).toBe("enabled");
 	});
 });
 
 describe("import from Codex (user-global → global .gjc, explicit selection)", () => {
-	test("toml MCP + markdown prompt normalize into global .gjc only", async () => {
-		await writeFile(path.join(homeDir, ".codex", "prompts", "codex-prompt.md"), "# Codex Prompt\n\nBody text.\n");
+	test("codex skills + toml MCP normalize into global .gjc only", async () => {
+		await writeFile(path.join(homeDir, ".codex", "skills", "codex-skill", "SKILL.md"), SKILL_MD);
+		await writeFile(path.join(homeDir, ".codex", "hooks", "pre-bash.ts"), "export {}\n");
 		await writeFile(
 			path.join(homeDir, ".codex", "config.toml"),
 			'[mcp_servers.codex-server]\ncommand = "uvx"\nargs = ["srv"]\n',
 		);
-		const preview = await buildImportPreview({
-			product: "codex",
-			sourceScope: "user",
-			destinationScope: "global",
-			collisionPolicy: "skip",
-			cwd: projectDir,
-			homeDir,
-		});
-		expect(preview.entries.filter(e => e.surface === "skills").map(e => e.destinationName)).toEqual(["codex-prompt"]);
-		expect(preview.entries.filter(e => e.surface === "mcps").map(e => e.destinationName)).toEqual(["codex-server"]);
-		const result = await applyImport(preview, { cwd: projectDir });
+		const plan = await buildImportPreview(
+			previewOptions({ product: "codex", sourceScope: "user", destinationScope: "global" }),
+		);
+		expect(plan.preview.entries.filter(e => e.surface === "skills").map(e => e.destinationName)).toEqual([
+			"codex-skill",
+		]);
+		expect(plan.preview.entries.filter(e => e.surface === "mcps").map(e => e.destinationName)).toEqual([
+			"codex-server",
+		]);
+		expect(plan.preview.entries.filter(e => e.surface === "hooks").map(e => e.destinationName)).toEqual([
+			"pre/pre-bash.ts",
+		]);
+		const result = await applyImport(plan, { cwd: projectDir });
 		expect(result.ok).toBe(true);
 		// Writes land only in the global .gjc scope, never the project.
-		await fs.stat(path.join(getAgentDir(), "skills", "codex-prompt", "SKILL.md"));
+		await fs.stat(path.join(getAgentDir(), "skills", "codex-skill", "SKILL.md"));
+		await fs.stat(path.join(getAgentDir(), "hooks", "pre", "pre-bash.ts"));
 		const mcpConfig = JSON.parse(await fs.readFile(path.join(getAgentDir(), "mcp.json"), "utf-8"));
 		expect(mcpConfig.mcpServers["codex-server"].command).toBe("uvx");
-		await expect(fs.stat(path.join(projectDir, ".gjc", "skills", "codex-prompt"))).rejects.toThrow();
+		await expect(fs.stat(path.join(projectDir, ".gjc", "skills", "codex-skill"))).rejects.toThrow();
 		await expect(fs.stat(path.join(projectDir, ".gjc", "mcp.json"))).rejects.toThrow();
 	});
 });
@@ -237,17 +291,9 @@ describe("import collision policy and safety", () => {
 
 	test("skip policy marks conflicts and never overwrites the native entry", async () => {
 		await seedSkillBothSides();
-		const preview = await buildImportPreview({
-			product: "claude-code",
-			sourceScope: "project",
-			destinationScope: "project",
-			surfaces: ["skills"],
-			collisionPolicy: "skip",
-			cwd: projectDir,
-			homeDir,
-		});
-		expect(preview.entries[0].status).toBe("conflict");
-		const result = await applyImport(preview, { cwd: projectDir });
+		const plan = await buildImportPreview(previewOptions({ surfaces: ["skills"] }));
+		expect(plan.preview.entries[0].status).toBe("conflict");
+		const result = await applyImport(plan, { cwd: projectDir });
 		expect(result.ok).toBe(true);
 		expect(result.entries[0].outcome).toBe("skipped");
 		const content = await fs.readFile(path.join(projectDir, ".gjc", "skills", "dupe", "SKILL.md"), "utf-8");
@@ -256,35 +302,33 @@ describe("import collision policy and safety", () => {
 
 	test("rename policy imports under an -imported suffix", async () => {
 		await seedSkillBothSides();
-		const preview = await buildImportPreview({
-			product: "claude-code",
-			sourceScope: "project",
-			destinationScope: "project",
-			surfaces: ["skills"],
-			collisionPolicy: "rename",
-			cwd: projectDir,
-			homeDir,
-		});
-		expect(preview.entries[0].destinationName).toBe("dupe-imported");
-		const result = await applyImport(preview, { cwd: projectDir });
+		const plan = await buildImportPreview(previewOptions({ surfaces: ["skills"], collisionPolicy: "rename" }));
+		expect(plan.preview.entries[0].destinationName).toBe("dupe-imported");
+		const result = await applyImport(plan, { cwd: projectDir });
 		expect(result.ok).toBe(true);
 		expect(result.entries[0].outcome).toBe("renamed");
 		await fs.stat(path.join(projectDir, ".gjc", "skills", "dupe-imported", "SKILL.md"));
 	});
 
+	test("rename never overwrites an occupied -imported destination", async () => {
+		await seedSkillBothSides();
+		// Pre-occupy every suffix the renamer might pick.
+		await writeFile(path.join(projectDir, ".gjc", "skills", "dupe-imported", "SKILL.md"), SKILL_MD);
+		await writeFile(path.join(projectDir, ".gjc", "skills", "dupe-imported-2", "SKILL.md"), SKILL_MD);
+		const plan = await buildImportPreview(previewOptions({ surfaces: ["skills"], collisionPolicy: "rename" }));
+		expect(plan.preview.entries[0].destinationName).toBe("dupe-imported-3");
+		const result = await applyImport(plan, { cwd: projectDir });
+		expect(result.ok).toBe(true);
+		await fs.stat(path.join(projectDir, ".gjc", "skills", "dupe-imported-3", "SKILL.md"));
+		const occupied = await fs.readFile(path.join(projectDir, ".gjc", "skills", "dupe-imported", "SKILL.md"), "utf-8");
+		expect(occupied).toBe(SKILL_MD);
+	});
+
 	test("overwrite policy replaces the destination explicitly", async () => {
 		await seedSkillBothSides();
-		const preview = await buildImportPreview({
-			product: "claude-code",
-			sourceScope: "project",
-			destinationScope: "project",
-			surfaces: ["skills"],
-			collisionPolicy: "overwrite",
-			cwd: projectDir,
-			homeDir,
-		});
-		expect(preview.entries[0].status).toBe("overwrite");
-		const result = await applyImport(preview, { cwd: projectDir });
+		const plan = await buildImportPreview(previewOptions({ surfaces: ["skills"], collisionPolicy: "overwrite" }));
+		expect(plan.preview.entries[0].status).toBe("overwrite");
+		const result = await applyImport(plan, { cwd: projectDir });
 		expect(result.entries[0].outcome).toBe("overwritten");
 		const content = await fs.readFile(path.join(projectDir, ".gjc", "skills", "dupe", "SKILL.md"), "utf-8");
 		expect(content).toContain("Fixture skill for tests.");
@@ -292,17 +336,10 @@ describe("import collision policy and safety", () => {
 
 	test("identical re-import is a no-op (idempotent)", async () => {
 		await seedClaudeProject();
-		const options = {
-			product: "claude-code" as const,
-			sourceScope: "project" as const,
-			destinationScope: "project" as const,
-			collisionPolicy: "skip" as const,
-			cwd: projectDir,
-			homeDir,
-		};
+		const options = previewOptions();
 		await applyImport(await buildImportPreview(options), { cwd: projectDir });
 		const second = await buildImportPreview(options);
-		for (const entry of second.entries) {
+		for (const entry of second.preview.entries) {
 			expect(entry.status).toBe("conflict");
 			expect(entry.reason).toContain("identical");
 		}
@@ -312,67 +349,132 @@ describe("import collision policy and safety", () => {
 	});
 
 	test("unsupported hook filenames surface diagnostics instead of silent import", async () => {
-		await writeFile(path.join(projectDir, ".claude", "hooks", "random-name.ts"), "export {}\n");
-		const preview = await buildImportPreview({
-			product: "claude-code",
-			sourceScope: "project",
-			destinationScope: "project",
-			surfaces: ["hooks"],
-			collisionPolicy: "skip",
-			cwd: projectDir,
-			homeDir,
-		});
-		expect(preview.entries[0].status).toBe("unsupported");
-		expect(preview.entries[0].reason).toContain("pre-<tool>");
+		await writeFile(path.join(projectDir, ".codex", "hooks", "random-name.ts"), "export {}\n");
+		const plan = await buildImportPreview(previewOptions({ product: "codex", surfaces: ["hooks"] }));
+		// Codex collector skips non-conforming names with a warning instead of importing them.
+		expect(plan.preview.entries).toHaveLength(0);
+		expect(plan.preview.warnings.join(" ")).toContain("pre-<tool>");
 	});
 
 	test("malformed source MCP config is a warning, not a crash", async () => {
 		await writeFile(path.join(projectDir, ".mcp.json"), "{ broken");
-		const preview = await buildImportPreview({
-			product: "claude-code",
-			sourceScope: "project",
-			destinationScope: "project",
-			surfaces: ["mcps"],
-			collisionPolicy: "skip",
-			cwd: projectDir,
-			homeDir,
-		});
-		expect(preview.warnings.join(" ")).toContain("invalid JSON");
-		expect(preview.entries).toHaveLength(0);
+		const plan = await buildImportPreview(previewOptions({ surfaces: ["mcps"] }));
+		expect(plan.preview.warnings.join(" ")).toContain("Failed to parse");
+		expect(plan.preview.entries).toHaveLength(0);
+	});
+
+	test("non-object source mcpServers shape is diagnosed, not silently emptied", async () => {
+		await writeFile(path.join(projectDir, ".mcp.json"), JSON.stringify({ mcpServers: "nope" }));
+		const plan = await buildImportPreview(previewOptions({ surfaces: ["mcps"] }));
+		expect(plan.preview.entries).toHaveLength(0);
+		expect(plan.preview.warnings.join(" ")).toContain("Failed to parse");
+	});
+
+	test("prototype-sensitive MCP names never reach the destination config", async () => {
+		// The JSON layer drops __proto__ own-properties and the compat adapter
+		// rejects prototype-sensitive names — either way nothing is imported.
+		await writeFile(
+			path.join(projectDir, ".mcp.json"),
+			JSON.stringify({ mcpServers: { __proto__: { type: "stdio", command: "x" } } }),
+		);
+		const plan = await buildImportPreview(previewOptions({ surfaces: ["mcps"] }));
+		expect(plan.preview.entries).toHaveLength(0);
+		const result = await applyImport(plan, { cwd: projectDir });
+		expect(result.ok).toBe(true);
+		await expect(fs.stat(path.join(projectDir, ".gjc", "mcp.json"))).rejects.toThrow();
 	});
 
 	test("cancellation means no writes: building a preview never touches the destination", async () => {
 		await seedClaudeProject();
-		await buildImportPreview({
-			product: "claude-code",
-			sourceScope: "project",
-			destinationScope: "project",
-			collisionPolicy: "skip",
-			cwd: projectDir,
-			homeDir,
-		});
+		await buildImportPreview(previewOptions());
 		await expect(fs.stat(path.join(projectDir, ".gjc"))).rejects.toThrow();
 	});
 
-	test("failed apply rolls back every write (no partial import)", async () => {
+	test("malformed destination mcp.json aborts before any write (atomic pre-validation)", async () => {
 		await seedClaudeProject();
-		// Malformed destination mcp.json forces the apply to fail after the skill
-		// file was already written — rollback must remove it again.
 		await writeFile(path.join(projectDir, ".gjc", "mcp.json"), "{ malformed");
-		const preview = await buildImportPreview({
-			product: "claude-code",
-			sourceScope: "project",
-			destinationScope: "project",
-			collisionPolicy: "skip",
-			cwd: projectDir,
-			homeDir,
-		});
-		const result = await applyImport(preview, { cwd: projectDir });
-		expect(result.ok).toBe(false);
-		expect(result.entries.some(e => e.outcome === "failed")).toBe(true);
-		await expect(fs.stat(path.join(projectDir, ".gjc", "skills", "claude-skill"))).rejects.toThrow();
+		const plan = await buildImportPreview(previewOptions());
+		// MCP entries are marked unsupported at preview time; skill/hook entries still apply.
+		expect(plan.preview.entries.filter(e => e.surface === "mcps").every(e => e.status === "unsupported")).toBe(true);
+		const result = await applyImport(plan, { cwd: projectDir });
+		expect(result.ok).toBe(true);
 		const mcpContent = await fs.readFile(path.join(projectDir, ".gjc", "mcp.json"), "utf-8");
 		expect(mcpContent).toBe("{ malformed");
+	});
+
+	test("non-object destination mcpServers shape aborts MCP writes without corrupting the file", async () => {
+		await writeFile(
+			path.join(projectDir, ".mcp.json"),
+			JSON.stringify({ mcpServers: { srv: { type: "stdio", command: "npx" } } }),
+		);
+		await writeFile(path.join(projectDir, ".gjc", "mcp.json"), JSON.stringify({ mcpServers: "corrupted" }));
+		const plan = await buildImportPreview(previewOptions({ surfaces: ["mcps"] }));
+		expect(plan.preview.entries.every(e => e.status === "unsupported")).toBe(true);
+		expect(plan.preview.warnings.join(" ")).toContain("non-object mcpServers");
+		const result = await applyImport(plan, { cwd: projectDir });
+		expect(result.ok).toBe(true);
+		const content = await fs.readFile(path.join(projectDir, ".gjc", "mcp.json"), "utf-8");
+		expect(content).toBe(JSON.stringify({ mcpServers: "corrupted" }));
+	});
+
+	test("apply rolls back every staged write when publication fails mid-transaction", async () => {
+		await seedClaudeProject();
+		const plan = await buildImportPreview(previewOptions({ surfaces: ["skills", "hooks"] }));
+		// Simulate a concurrent change after the preview: the hooks directory
+		// becomes read-only, so hook publication fails after the skill file was
+		// already written — full rollback. Pre-validation passes because reads
+		// still succeed; only the write fails.
+		await fs.mkdir(path.join(projectDir, ".gjc", "hooks"), { recursive: true });
+		await fs.chmod(path.join(projectDir, ".gjc", "hooks"), 0o555);
+		const result = await applyImport(plan, { cwd: projectDir });
+		expect(result.ok).toBe(false);
+		expect(result.entries.some(e => e.outcome === "failed" && e.reason?.includes("rolled back"))).toBe(true);
+		// The skill file that was published first must be gone again.
+		await expect(fs.stat(path.join(projectDir, ".gjc", "skills", "claude-skill", "SKILL.md"))).rejects.toThrow();
+		await fs.chmod(path.join(projectDir, ".gjc", "hooks"), 0o755);
+	});
+
+	test("rollback preserves a pre-existing symlink it never wrote", async () => {
+		await seedClaudeProject();
+		// A dangling symlink at the skill destination makes the apply fail in
+		// pre-validation; rollback must not delete the symlink it never created.
+		const linkTarget = path.join(tmpRoot, "elsewhere");
+		await fs.mkdir(path.join(projectDir, ".gjc", "skills", "claude-skill"), { recursive: true });
+		await fs.symlink(linkTarget, path.join(projectDir, ".gjc", "skills", "claude-skill", "SKILL.md"));
+		const plan = await buildImportPreview(previewOptions({ surfaces: ["skills"] }));
+		expect(plan.preview.entries[0].status).toBe("conflict");
+		expect(plan.preview.entries[0].reason).toContain("unsafe");
+		const result = await applyImport(plan, { cwd: projectDir });
+		expect(result.ok).toBe(true);
+		expect(result.entries[0].outcome).toBe("skipped");
+		const stat = await fs.lstat(path.join(projectDir, ".gjc", "skills", "claude-skill", "SKILL.md"));
+		expect(stat.isSymbolicLink()).toBe(true);
+	});
+
+	test("symlinked destination ancestor directories are refused", async () => {
+		await seedClaudeProject();
+		// `.gjc/skills` itself is a symlink to an external directory.
+		const external = path.join(tmpRoot, "external-skills");
+		await fs.mkdir(external, { recursive: true });
+		await fs.mkdir(path.join(projectDir, ".gjc"), { recursive: true });
+		await fs.symlink(external, path.join(projectDir, ".gjc", "skills"));
+		const plan = await buildImportPreview(previewOptions({ surfaces: ["skills"] }));
+		const result = await applyImport(plan, { cwd: projectDir });
+		expect(result.ok).toBe(false);
+		expect(result.entries[0].reason).toContain("symlink");
+		await expect(fs.stat(path.join(external, "claude-skill"))).rejects.toThrow();
+	});
+
+	test("stale preview fails closed instead of silently overwriting", async () => {
+		await seedSkillBothSides();
+		const plan = await buildImportPreview(previewOptions({ surfaces: ["skills"], collisionPolicy: "rename" }));
+		// Simulate a concurrent process occupying the chosen rename destination.
+		await writeFile(path.join(projectDir, ".gjc", "skills", "dupe-imported", "SKILL.md"), "different content\n");
+		const result = await applyImport(plan, { cwd: projectDir });
+		expect(result.ok).toBe(false);
+		expect(result.entries[0].reason).toContain("changed since preview");
+		const occupied = await fs.readFile(path.join(projectDir, ".gjc", "skills", "dupe-imported", "SKILL.md"), "utf-8");
+		expect(occupied).toBe("different content\n");
 	});
 });
 
@@ -381,26 +483,36 @@ describe("import collision policy and safety", () => {
 // ---------------------------------------------------------------------------
 
 describe("native .gjc mutations", () => {
-	test("skill enable/disable toggles frontmatter; remove deletes the directory", async () => {
+	test("skill enable/disable flows through the authoritative policy contract", () => {
+		const disabled = setSkillEnabled("fixture", false, []);
+		expect(disabled.ok).toBe(true);
+		if (disabled.ok) expect(disabled.disabledExtensions).toEqual(["skill:fixture"]);
+		const enabled = setSkillEnabled("fixture", true, ["skill:fixture"]);
+		expect(enabled.ok).toBe(true);
+		if (enabled.ok) expect(enabled.disabledExtensions).toEqual([]);
+		const protectedResult = setSkillEnabled("ralplan", false, []);
+		expect(protectedResult.ok).toBe(false);
+	});
+
+	test("skill removal targets the exact discovered path and refuses symlinks", async () => {
 		const paths = resolveScopePaths("project", projectDir);
-		await writeFile(path.join(paths.skillsDir, "fixture", "SKILL.md"), SKILL_MD);
-		expect(await setSkillEnabled(paths, "fixture", false)).toEqual({ ok: true });
-		let content = await fs.readFile(path.join(paths.skillsDir, "fixture", "SKILL.md"), "utf-8");
-		expect(content).toContain("enabled: false");
-		expect(await setSkillEnabled(paths, "fixture", true)).toEqual({ ok: true });
-		content = await fs.readFile(path.join(paths.skillsDir, "fixture", "SKILL.md"), "utf-8");
-		expect(content).not.toContain("enabled: false");
-		expect(await removeSkill(paths, "fixture")).toEqual({ ok: true });
+		const skillPath = path.join(paths.skillsDir, "fixture", "SKILL.md");
+		await writeFile(skillPath, SKILL_MD);
+		expect(await removeSkill({ name: "fixture", path: skillPath })).toEqual({ ok: true });
 		await expect(fs.stat(path.join(paths.skillsDir, "fixture"))).rejects.toThrow();
+		// Absent discovered path: no silent success.
+		const missing = await removeSkill({ name: "missing", path: path.join(paths.skillsDir, "missing", "SKILL.md") });
+		expect(missing.ok).toBe(false);
 	});
 
 	test("bundled workflow skill names are protected from removal", async () => {
 		const paths = resolveScopePaths("project", projectDir);
-		await writeFile(path.join(paths.skillsDir, "ralplan", "SKILL.md"), SKILL_MD);
-		const result = await removeSkill(paths, "ralplan");
+		const skillPath = path.join(paths.skillsDir, "ralplan", "SKILL.md");
+		await writeFile(skillPath, SKILL_MD);
+		const result = await removeSkill({ name: "ralplan", path: skillPath });
 		expect(result.ok).toBe(false);
 		if (!result.ok) expect(result.reason).toContain("bundled");
-		await fs.stat(path.join(paths.skillsDir, "ralplan", "SKILL.md"));
+		await fs.stat(skillPath);
 	});
 
 	test("MCP enable/disable/remove go through the canonical writer", async () => {
@@ -417,11 +529,12 @@ describe("native .gjc mutations", () => {
 		expect(config.mcpServers.srv).toBeUndefined();
 	});
 
-	test("hook removal is confined to the hooks directory", async () => {
+	test("hook removal targets the exact path and fails when absent", async () => {
 		const paths = resolveScopePaths("project", projectDir);
-		await writeFile(path.join(paths.hooksDir, "pre-bash.ts"), "export {}\n");
-		expect(await removeHookFile(paths, "pre-bash.ts")).toEqual({ ok: true });
-		const escaped = await removeHookFile(paths, "../mcp.json");
-		expect(escaped.ok).toBe(false);
+		const hookPath = path.join(paths.hooksDir, "pre", "bash.ts");
+		await writeFile(hookPath, "export {}\n");
+		expect(await removeHookFile(hookPath)).toEqual({ ok: true });
+		const missing = await removeHookFile(hookPath);
+		expect(missing.ok).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/customization-extensions.test.ts
+++ b/packages/coding-agent/test/customization-extensions.test.ts
@@ -417,6 +417,25 @@ describe("import collision policy and safety", () => {
 		}
 	});
 
+	test("nested auth/oauth MCP fields are diagnosed instead of silently dropped", async () => {
+		await writeFile(
+			path.join(projectDir, ".mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					srv: { type: "stdio", command: "npx", auth: { clientSecret: "NESTED_SECRET" } },
+				},
+			}),
+		);
+		const plan = await buildImportPreview(previewOptions({ surfaces: ["mcps"] }));
+		expect(plan.preview.entries[0].status).toBe("unsupported");
+		expect(plan.preview.entries[0].reason).toContain("not supported");
+		expect(JSON.stringify(plan.preview)).not.toContain("NESTED_SECRET");
+		expect(JSON.stringify(plan.payloads)).not.toContain("NESTED_SECRET");
+		const result = await applyImport(plan, { cwd: projectDir });
+		expect(result.ok).toBe(true);
+		expect(result.entries[0].outcome).toBe("skipped");
+	});
+
 	test("malformed source MCP config is a warning, not a crash", async () => {
 		await writeFile(path.join(projectDir, ".mcp.json"), "{ broken");
 		const plan = await buildImportPreview(previewOptions({ surfaces: ["mcps"] }));

--- a/packages/coding-agent/test/extensions-command.test.ts
+++ b/packages/coding-agent/test/extensions-command.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Issue #4291 acceptance: `/extensions` is registered, discoverable, and
+ * described exactly as "Configure skills, hooks, and MCPs."; non-interactive
+ * (ACP/text) mode gets an explicit rejection instead of silence.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+	BUILTIN_SLASH_COMMAND_DEFS,
+	lookupBuiltinSlashCommand,
+} from "@gajae-code/coding-agent/slash-commands/builtin-registry";
+import type { ParsedSlashCommand, SlashCommandRuntime } from "@gajae-code/coding-agent/slash-commands/types";
+
+describe("/extensions slash command registration", () => {
+	test("is registered with the exact owner-contract description", () => {
+		const spec = lookupBuiltinSlashCommand("extensions");
+		expect(spec).toBeDefined();
+		expect(spec?.description).toBe("Configure skills, hooks, and MCPs.");
+	});
+
+	test("is discoverable through the autocomplete/help defs", () => {
+		const def = BUILTIN_SLASH_COMMAND_DEFS.find(entry => entry.name === "extensions");
+		expect(def).toBeDefined();
+		expect(def?.description).toBe("Configure skills, hooks, and MCPs.");
+	});
+
+	test("exposes an interactive TUI handler", () => {
+		const spec = lookupBuiltinSlashCommand("extensions");
+		expect(typeof spec?.handleTui).toBe("function");
+	});
+
+	test("non-interactive dispatch outputs an explicit rejection", async () => {
+		const spec = lookupBuiltinSlashCommand("extensions");
+		expect(typeof spec?.handle).toBe("function");
+		const outputs: string[] = [];
+		const runtime = {
+			output: async (text: string) => {
+				outputs.push(text);
+			},
+		} as unknown as SlashCommandRuntime;
+		const command = { name: "extensions", args: "" } as unknown as ParsedSlashCommand;
+		const result = await spec!.handle!(command, runtime);
+		expect(result).toEqual({ consumed: true });
+		expect(outputs).toHaveLength(1);
+		expect(outputs[0]).toContain("/extensions");
+		expect(outputs[0]).toContain("interactive");
+		expect(outputs[0]).toContain("skills, hooks, and MCPs");
+	});
+});


### PR DESCRIPTION
## Summary

Closes #4291.

Adds the owner-confirmed `/extensions` umbrella interactive customization manager, separate from the provider-oriented Extension Control Center:

- project/global native `.gjc` Skills, Hooks, and MCP inventories with runtime-aligned provenance/status;
- real scope-bound UI navigation and safe enable/disable/remove operations;
- explicit Claude Code/Codex project/user import with canonical sibling adapters;
- redacted serialization-safe preview + opaque apply plan;
- deterministic skip/rename/overwrite collisions;
- bounded atomic temp/rename publication, apply-time collision/symlink revalidation, verification, and rollback;
- non-interactive rejection and exact command description.

## Sibling reconciliation

- Consumes merged #4284 MCP compatibility/runtime contracts.
- Consumes merged #4285 native skill-management contracts.
- Consumes #4286/#4289 canonical hook normalization and runtime phase layouts.
- Rebased after merged #4288 / PR #4350 customization doctor; does not duplicate its provenance-doctor CLI surface.

## Verification

Exact base: `cf07293f7404b35c085dde35013aa5a12d595ad5`
Exact head: `03ec332603`

- `bun test packages/coding-agent/test/customization-dashboard.test.ts packages/coding-agent/test/customization-extensions.test.ts packages/coding-agent/test/extensions-command.test.ts` — 54 pass, 0 fail, 202 expectations
- `bun test packages/coding-agent/test/slash-command-builtin-registry.test.ts packages/coding-agent/test/slash-command-visibility.test.ts` — 24 pass, 0 fail
- `bun --cwd=packages/coding-agent run check` — pass
- `bun --cwd=packages/coding-agent run build` — pass
- `git diff --check` — pass

Independent adversarial review iterated through traversal, symlink, stale-collision, rollback, redaction, disabledServers, nested-auth, scope/UI, and canonical-layout blockers; every reproduced blocker was fixed forward. Nested auth/oauth formats outside the canonical MCP contract now diagnose and skip instead of importing lossily.

No release.