### PR TITLE
fix(coding-agent): sync session import postmerge checks

### DIFF
--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -1732,7 +1732,7 @@
 		"sourceFile": "packages/coding-agent/src/slash-commands/builtin-registry.ts",
 		"sourceKind": "slash_command",
 		"decision": "exclude",
-		"rationale": "local-only trusted command (acp: false, localHeadless: true) that imports external sessions on the operator's machine, not a user-facing SDK control seam",
+		"rationale": "local transcript-file import into a new session; no SDK operation counterpart, not a user-facing SDK control seam",
 		"exclusionMetadata": {
 			"adapterMappings": "not_applicable",
 			"testIds": "not_applicable"
@@ -1871,17 +1871,6 @@
 		"testIds": [
 			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
 		]
-	},
-	{
-		"sourceId": "slash_command:import-session",
-		"sourceFile": "packages/coding-agent/src/slash-commands/builtin-registry.ts",
-		"sourceKind": "slash_command",
-		"decision": "exclude",
-		"rationale": "local transcript-file import into a new session; no SDK operation counterpart, not a user-facing SDK control seam",
-		"exclusionMetadata": {
-			"adapterMappings": "not_applicable",
-			"testIds": "not_applicable"
-		}
 	},
 	{
 		"sourceId": "slash_command:copy",

--- a/packages/coding-agent/test/session-manager-resume-oversized.test.ts
+++ b/packages/coding-agent/test/session-manager-resume-oversized.test.ts
@@ -10,6 +10,7 @@ import {
 	SessionTranscriptOversizedError,
 } from "@gajae-code/coding-agent/session/session-manager";
 import { FileSessionStorage } from "@gajae-code/coding-agent/session/session-storage";
+import { MANAGED_ARTIFACT_MAX_FILE_BYTES } from "../src/session/internal/managed-session-storage";
 
 const tempDirs: string[] = [];
 
@@ -169,6 +170,6 @@ describe("SessionManager oversized resume graceful fallback (#3851)", () => {
 
 	it("RESUME_TRANSCRIPT_MAX_BYTES matches the managed-storage per-file bound", () => {
 		// Guard against silently decoupling the resume limit from the artifact bound.
-		expect(RESUME_TRANSCRIPT_MAX_BYTES).toBe(64 * 1024 * 1024);
+		expect(RESUME_TRANSCRIPT_MAX_BYTES).toBe(MANAGED_ARTIFACT_MAX_FILE_BYTES);
 	});
 });


### PR DESCRIPTION
## Scope

Focused postmerge successor for merged PR #3731. Owns only the two exact-dev CI signatures from run `31721865608`:

1. Align the oversized-resume contract test with exported `MANAGED_ARTIFACT_MAX_FILE_BYTES` instead of the stale 64 MiB literal. Production capacity remains 128 MiB.
2. Regenerate the SDK operation inventory, removing the duplicate stale `/import-session` record and synchronizing the retained local-only rationale.

No shard 3/5/8 or unrelated CI work is included.

## Verification

- `bun test packages/coding-agent/test/session-manager-resume-oversized.test.ts packages/coding-agent/test/sdk-operation-inventory.test.ts --timeout 30000` — 24 pass
- `bun packages/coding-agent/scripts/generate-sdk-operation-inventory.ts --check` — pass
- Session-import/native focused suites — 98 pass
- `bun --cwd=packages/coding-agent run check` — pass
- `git diff --check` — pass

Signed-off-by: GJC <gjc@local>
