### PR TITLE
fix(agent): preserve provisional assistant metadata

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -969,6 +969,7 @@ class ManagedAttemptTransaction {
 			| undefined,
 		private readonly model: AgentLoopConfig["model"],
 		readonly scope?: AttemptScope,
+		private readonly snapshotMode: "managed" | "lossless" = "managed",
 	) {}
 
 	push(event: AgentEvent): void {
@@ -984,15 +985,15 @@ class ManagedAttemptTransaction {
 	}
 
 	stageAssistantMessageEvent(message: AssistantMessage, event: AssistantMessageEvent): void {
-		const partial = managedAssistantShell(message, this.model);
+		const partial = this.#assistantSnapshot(message);
 		if (this.#committed) {
-			this.onAssistantMessageEvent?.(partial, managedAssistantEventSnapshot(event, partial));
+			this.onAssistantMessageEvent?.(partial, this.#assistantEventSnapshot(event, partial));
 			return;
 		}
 		this.#batch.push({
 			type: "assistant_event",
 			message: partial,
-			event: managedAssistantEventSnapshot(event, partial),
+			event: this.#assistantEventSnapshot(event, partial),
 		});
 	}
 
@@ -1046,7 +1047,11 @@ class ManagedAttemptTransaction {
 			this.discard();
 			throw new ManagedAttemptBufferOverflowError();
 		}
-		const detailed = managedAttemptSnapshotDetailed(this.#repairAssistantEvent(event));
+		const repaired = this.#repairAssistantEvent(event);
+		const detailed =
+			this.snapshotMode === "lossless"
+				? { snapshot: this.#losslessSnapshot(repaired), degraded: false }
+				: managedAttemptSnapshotDetailed(repaired);
 		let snapshot = detailed.snapshot;
 		if (bytes === undefined || detailed.degraded) {
 			// Account the bytes of what is actually retained: a degraded
@@ -1083,6 +1088,7 @@ class ManagedAttemptTransaction {
 	}
 
 	#repairAssistantEvent(event: AgentEvent): AgentEvent {
+		if (this.snapshotMode === "lossless") return event;
 		if (event.type === "message_start" || event.type === "message_end" || event.type === "turn_end") {
 			return event.message.role === "assistant"
 				? { ...event, message: managedAssistantShell(event.message, this.model) }
@@ -1105,6 +1111,30 @@ class ManagedAttemptTransaction {
 			};
 		}
 		return event;
+	}
+
+	#losslessSnapshot<T>(value: T): T {
+		try {
+			return structuredClone(value);
+		} catch {
+			this.discard();
+			throw new ManagedAttemptSnapshotError();
+		}
+	}
+
+	#assistantSnapshot(message: AssistantMessage): AssistantMessage {
+		return this.snapshotMode === "lossless"
+			? this.#losslessSnapshot(message)
+			: managedAssistantShell(message, this.model);
+	}
+
+	#assistantEventSnapshot(event: AssistantMessageEvent, message: AssistantMessage): AssistantMessageEvent {
+		if (this.snapshotMode === "managed") return managedAssistantEventSnapshot(event, message);
+		const snapshot = this.#losslessSnapshot(event);
+		if (snapshot.type === "done") return { ...snapshot, message };
+		if (snapshot.type === "error") return { ...snapshot, error: message };
+		if ("partial" in snapshot) return { ...snapshot, partial: message };
+		return snapshot;
 	}
 }
 
@@ -1568,7 +1598,7 @@ async function runLoopBody(
 					: undefined);
 			const escapedToolTransaction = config.fallbackManaged
 				? undefined
-				: new ManagedAttemptTransaction(stream, config.onAssistantMessageEvent, config.model, scope);
+				: new ManagedAttemptTransaction(stream, config.onAssistantMessageEvent, config.model, scope, "lossless");
 			const transaction = managedTransaction ?? escapedToolTransaction;
 			initialTransaction = undefined;
 			const attemptScope = transaction?.scope ?? scope;

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -764,7 +764,33 @@ function managedAttemptSnapshot<T>(value: T): T {
 	return managedAttemptSnapshotDetailed(value).snapshot;
 }
 
-const NON_CLONEABLE = Symbol("non-cloneable");
+const LOSSLESS_SNAPSHOT_KEYS = [
+	"role",
+	"content",
+	"api",
+	"provider",
+	"model",
+	"responseId",
+	"usage",
+	"stopReason",
+	"errorMessage",
+	"errorKind",
+	"errorStatus",
+	"transportFailure",
+	"disabledFeatures",
+	"providerPayload",
+	"timestamp",
+	"duration",
+	"ttft",
+	"type",
+	"contentIndex",
+	"delta",
+	"partial",
+	"toolCall",
+	"reason",
+	"message",
+	"error",
+] as const;
 
 /**
  * Detach unmanaged provider metadata without normalizing the cloneable parts.
@@ -776,46 +802,24 @@ function losslessDetachedClone<T>(value: T): T {
 	try {
 		return structuredClone(value);
 	} catch {
-		let budget = MANAGED_SNAPSHOT_MAX_NODES;
-		const seen = new Map<object, unknown>();
-		const clone = (input: unknown): unknown | typeof NON_CLONEABLE => {
-			if (budget-- <= 0) return NON_CLONEABLE;
-			if (typeof input === "function" || typeof input === "symbol") return NON_CLONEABLE;
-			if (input === null || typeof input !== "object") return input;
-			if (nodeUtilTypes.isProxy(input)) return NON_CLONEABLE;
-			const prior = seen.get(input);
-			if (prior !== undefined) return prior;
+		// The managed sanitizer is explicitly bounded and total. Use it only to
+		// identify which top-level assistant metadata surfaces are cloneable; the
+		// cloneable surfaces themselves still come from structuredClone and remain
+		// lossless. This avoids recursive/unbounded traversal of hostile provider
+		// metadata while stripping only the failed top-level surface.
+		if (!isManagedPlainRecord(value)) return sanitizedDetachedClone(value);
+		const output: Record<string, unknown> = {};
+		for (const key of LOSSLESS_SNAPSHOT_KEYS) {
+			const descriptor = Object.getOwnPropertyDescriptor(value, key);
+			if (!descriptor || !("value" in descriptor)) continue;
 			try {
-				return structuredClone(input);
+				output[key] = structuredClone(descriptor.value);
 			} catch {
-				// Only recurse into ordinary records/arrays. Host objects such as live
-				// Headers are stripped as one surface rather than flattened into a
-				// misleading normalized representation.
-				if (!Array.isArray(input)) {
-					const prototype = Object.getPrototypeOf(input);
-					if (prototype !== Object.prototype && prototype !== null) return NON_CLONEABLE;
-				}
-				const output: unknown[] | Record<string, unknown> = Array.isArray(input) ? [] : {};
-				seen.set(input, output);
-				const keys = Object.keys(input);
-				const keyLimit = Math.min(keys.length, Math.max(0, budget));
-				for (let index = 0; index < keyLimit && budget > 0; index++) {
-					const key = keys[index]!;
-					const descriptor = Object.getOwnPropertyDescriptor(input, key);
-					if (!descriptor || !("value" in descriptor)) continue;
-					const child = clone(descriptor.value);
-					if (child !== NON_CLONEABLE) {
-						(output as Record<string, unknown>)[key] = child;
-					}
-				}
-				return output;
+				const detached = sanitizedDetachedClone(descriptor.value);
+				if (detached !== "[unserializable]") output[key] = detached;
 			}
-		};
-		const cloned = clone(value);
-		if (cloned === NON_CLONEABLE) {
-			throw new ManagedAttemptSnapshotError();
 		}
-		return cloned as T;
+		return output as T;
 	}
 }
 
@@ -2613,6 +2617,9 @@ async function streamAssistantResponse(
 								: event.partial;
 							context.messages.push(partialMessage);
 							addedPartial = true;
+							if (provisionalToolTransaction) {
+								config.onProvisionalAssistantMessageEvent?.(partialMessage, event);
+							}
 							stream.push({ type: "message_start", message: { ...partialMessage }, scope });
 							break;
 
@@ -2639,6 +2646,7 @@ async function streamAssistantResponse(
 								const partialEvent = config.fallbackManaged ? { ...event, partial: partialMessage } : event;
 								context.messages[context.messages.length - 1] = partialMessage;
 								if (provisionalToolTransaction) {
+									config.onProvisionalAssistantMessageEvent?.(partialMessage, partialEvent);
 									provisionalToolTransaction.stageAssistantMessageEvent(partialMessage, partialEvent);
 								} else {
 									config.onAssistantMessageEvent?.(partialMessage, partialEvent);

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -797,7 +797,10 @@ function losslessDetachedClone<T>(value: T): T {
 				}
 				const output: unknown[] | Record<string, unknown> = Array.isArray(input) ? [] : {};
 				seen.set(input, output);
-				for (const key of Object.keys(input)) {
+				const keys = Object.keys(input);
+				const keyLimit = Math.min(keys.length, Math.max(0, budget));
+				for (let index = 0; index < keyLimit && budget > 0; index++) {
+					const key = keys[index]!;
 					const descriptor = Object.getOwnPropertyDescriptor(input, key);
 					if (!descriptor || !("value" in descriptor)) continue;
 					const child = clone(descriptor.value);
@@ -2030,7 +2033,7 @@ async function runLoopBody(
 				// can then abort the run before any tool execute() is entered.
 				if (message.stopReason !== "aborted" && message.stopReason !== "error") {
 					if (loopSignal.aborted) break;
-					if (stream.hasActiveConsumer) await stream.waitForConsumerDrain(loopSignal);
+					if (stream.hasActiveConsumer) await stream.waitForConsumerDrain(new AbortController().signal);
 					if (loopSignal.aborted) break;
 				}
 			}

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -764,6 +764,58 @@ function managedAttemptSnapshot<T>(value: T): T {
 	return managedAttemptSnapshotDetailed(value).snapshot;
 }
 
+const NON_CLONEABLE = Symbol("non-cloneable");
+
+/**
+ * Detach unmanaged provider metadata without normalizing the cloneable parts.
+ * A failed subtree is removed at its own property boundary; siblings retain
+ * their exact structured-clone representation. The bounded recursive path is
+ * used only after cloning the complete value fails.
+ */
+function losslessDetachedClone<T>(value: T): T {
+	try {
+		return structuredClone(value);
+	} catch {
+		let budget = MANAGED_SNAPSHOT_MAX_NODES;
+		const seen = new Map<object, unknown>();
+		const clone = (input: unknown): unknown | typeof NON_CLONEABLE => {
+			if (budget-- <= 0) return NON_CLONEABLE;
+			if (typeof input === "function" || typeof input === "symbol") return NON_CLONEABLE;
+			if (input === null || typeof input !== "object") return input;
+			if (nodeUtilTypes.isProxy(input)) return NON_CLONEABLE;
+			const prior = seen.get(input);
+			if (prior !== undefined) return prior;
+			try {
+				return structuredClone(input);
+			} catch {
+				// Only recurse into ordinary records/arrays. Host objects such as live
+				// Headers are stripped as one surface rather than flattened into a
+				// misleading normalized representation.
+				if (!Array.isArray(input)) {
+					const prototype = Object.getPrototypeOf(input);
+					if (prototype !== Object.prototype && prototype !== null) return NON_CLONEABLE;
+				}
+				const output: unknown[] | Record<string, unknown> = Array.isArray(input) ? [] : {};
+				seen.set(input, output);
+				for (const key of Object.keys(input)) {
+					const descriptor = Object.getOwnPropertyDescriptor(input, key);
+					if (!descriptor || !("value" in descriptor)) continue;
+					const child = clone(descriptor.value);
+					if (child !== NON_CLONEABLE) {
+						(output as Record<string, unknown>)[key] = child;
+					}
+				}
+				return output;
+			}
+		};
+		const cloned = clone(value);
+		if (cloned === NON_CLONEABLE) {
+			throw new ManagedAttemptSnapshotError();
+		}
+		return cloned as T;
+	}
+}
+
 /**
  * Recover the required assistant-message shell when a managed snapshot degrades
  * at its root (notably for Proxy-wrapped provider messages). Only known fields
@@ -1016,6 +1068,10 @@ class ManagedAttemptTransaction {
 		return this.#committed;
 	}
 
+	acceptedAssistantSnapshot(message: AssistantMessage): AssistantMessage {
+		return this.#assistantSnapshot(message);
+	}
+
 	discard(): void {
 		this.#batch = [];
 		this.#stagedBytes = 0;
@@ -1114,12 +1170,7 @@ class ManagedAttemptTransaction {
 	}
 
 	#losslessSnapshot<T>(value: T): T {
-		try {
-			return structuredClone(value);
-		} catch {
-			this.discard();
-			throw new ManagedAttemptSnapshotError();
-		}
+		return losslessDetachedClone(value);
 	}
 
 	#assistantSnapshot(message: AssistantMessage): AssistantMessage {
@@ -1967,11 +2018,21 @@ async function runLoopBody(
 			// One provider invocation is committed before any tool can run.
 			transaction?.flush();
 			if (escapedToolTransaction) {
+				const acceptedMessage = escapedToolTransaction.acceptedAssistantSnapshot(message);
+				const acceptedIndex = currentContext.messages.lastIndexOf(message);
+				if (acceptedIndex >= 0) currentContext.messages[acceptedIndex] = acceptedMessage;
+				const producedIndex = newMessages.lastIndexOf(message);
+				if (producedIndex >= 0) newMessages[producedIndex] = acceptedMessage;
+				message = acceptedMessage;
 				// Tool-call updates are staged so an escaped turn can disappear
 				// atomically. Once accepted, drain every published update through the
 				// Agent/AgentSession consumers before dispatch: streaming edit guards
 				// can then abort the run before any tool execute() is entered.
-				if (!loopSignal.aborted && stream.hasActiveConsumer) await stream.waitForConsumerDrain(loopSignal);
+				if (message.stopReason !== "aborted" && message.stopReason !== "error") {
+					if (loopSignal.aborted) break;
+					if (stream.hasActiveConsumer) await stream.waitForConsumerDrain(loopSignal);
+					if (loopSignal.aborted) break;
+				}
 			}
 			if (config.fallbackManaged && message.stopReason !== "error" && message.stopReason !== "aborted") {
 				await config.onManagedAttemptAccepted?.();

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -809,14 +809,27 @@ function losslessDetachedClone<T>(value: T): T {
 		// metadata while stripping only the failed top-level surface.
 		if (!isManagedPlainRecord(value)) return sanitizedDetachedClone(value);
 		const output: Record<string, unknown> = {};
+		let remaining = MANAGED_SNAPSHOT_MAX_NODES;
 		for (const key of LOSSLESS_SNAPSHOT_KEYS) {
+			if (remaining-- <= 0) break;
 			const descriptor = Object.getOwnPropertyDescriptor(value, key);
 			if (!descriptor || !("value" in descriptor)) continue;
 			try {
 				output[key] = structuredClone(descriptor.value);
 			} catch {
-				const detached = sanitizedDetachedClone(descriptor.value);
-				if (detached !== "[unserializable]") output[key] = detached;
+				if (key === "transportFailure" && isManagedPlainRecord(descriptor.value)) {
+					const transport: Record<string, unknown> = {};
+					for (const transportKey of ["kind", "status", "code", "providerCode", "retryAfterMs"] as const) {
+						const transportDescriptor = Object.getOwnPropertyDescriptor(descriptor.value, transportKey);
+						if (!transportDescriptor || !("value" in transportDescriptor)) continue;
+						try {
+							transport[transportKey] = structuredClone(transportDescriptor.value);
+						} catch {
+							// Strip only this non-cloneable transport fact.
+						}
+					}
+					output[key] = transport;
+				}
 			}
 		}
 		return output as T;
@@ -1094,6 +1107,31 @@ class ManagedAttemptTransaction {
 	}
 
 	#stage(event: AgentEvent): void {
+		if (this.snapshotMode === "lossless") {
+			const snapshot = this.#repairAssistantEvent(event);
+			let detached: AgentEvent;
+			try {
+				detached = this.#losslessSnapshot(snapshot);
+			} catch {
+				this.discard();
+				throw new ManagedAttemptSnapshotError();
+			}
+			let detachedBytes: number;
+			try {
+				detachedBytes = managedAttemptTextEncoder.encode(JSON.stringify(detached)).byteLength;
+			} catch {
+				this.discard();
+				throw new ManagedAttemptSnapshotError();
+			}
+			if (this.#wouldOverflow(detachedBytes)) {
+				this.discard();
+				throw new ManagedAttemptSnapshotError();
+			}
+			this.#batch.push({ type: "event", event: detached });
+			this.#stagedEventCount++;
+			this.#stagedBytes += detachedBytes;
+			return;
+		}
 		// Measure the raw event FIRST so an oversized payload is rejected
 		// before the snapshot duplicates it — the staged-byte cap exists to
 		// bound memory, so cloning ahead of the check would defeat it.
@@ -1111,10 +1149,7 @@ class ManagedAttemptTransaction {
 			throw new ManagedAttemptBufferOverflowError();
 		}
 		const repaired = this.#repairAssistantEvent(event);
-		const detailed =
-			this.snapshotMode === "lossless"
-				? { snapshot: this.#losslessSnapshot(repaired), degraded: false }
-				: managedAttemptSnapshotDetailed(repaired);
+		const detailed = managedAttemptSnapshotDetailed(repaired);
 		let snapshot = detailed.snapshot;
 		if (bytes === undefined || detailed.degraded) {
 			// Account the bytes of what is actually retained: a degraded

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -411,6 +411,7 @@ export class Agent {
 	#onResponse?: SimpleStreamOptions["onResponse"];
 	#onSseEvent?: SimpleStreamOptions["onSseEvent"];
 	#onAssistantMessageEvent?: (message: AssistantMessage, event: AssistantMessageEvent) => void;
+	#onProvisionalAssistantMessageEvent?: (message: AssistantMessage, event: AssistantMessageEvent) => void;
 	#onToolChoiceIncapability?: AgentLoopConfig["onToolChoiceIncapability"];
 	#onHarmonyLeak?: (event: HarmonyAuditEvent) => void | Promise<void>;
 	#onBeforeYield?: () => Promise<void> | void;
@@ -782,6 +783,12 @@ export class Agent {
 		fn: ((message: AssistantMessage, event: AssistantMessageEvent) => void) | undefined,
 	): void {
 		this.#onAssistantMessageEvent = fn;
+	}
+
+	setProvisionalAssistantMessageEventInterceptor(
+		fn: ((message: AssistantMessage, event: AssistantMessageEvent) => void) | undefined,
+	): void {
+		this.#onProvisionalAssistantMessageEvent = fn;
 	}
 
 	setOnBeforeYield(fn: (() => Promise<void> | void) | undefined): void {
@@ -1752,12 +1759,16 @@ export class Agent {
 						return result;
 					}
 				: undefined,
-			onAssistantMessageEvent: this.#onAssistantMessageEvent
-				? (message, event) => {
-						if (this.#activeRunId !== runId) return;
-						this.#onAssistantMessageEvent?.(message, event);
-					}
-				: undefined,
+			onAssistantMessageEvent: (message, event) => {
+				if (this.#activeRunId !== runId) return;
+				this.#onAssistantMessageEvent?.(message, event);
+			},
+			onProvisionalAssistantMessageEvent: (message, event) => {
+				if (this.#activeRunId !== runId) return;
+				this.#state.streamMessage = message;
+				this.#onProvisionalAssistantMessageEvent?.(message, event);
+			},
+			hasProvisionalAssistantMessageEventConsumer: this.#onProvisionalAssistantMessageEvent !== undefined,
 			onToolChoiceIncapability: this.#onToolChoiceIncapability
 				? event => {
 						if (this.#activeRunId !== runId) return;

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -424,6 +424,10 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 * Callers may abort synchronously to stop consuming buffered provider events.
 	 */
 	onAssistantMessageEvent?: (message: AssistantMessage, event: AssistantMessageEvent) => void;
+	/** Observe unmanaged provisional assistant deltas before public publication. */
+	onProvisionalAssistantMessageEvent?: (message: AssistantMessage, event: AssistantMessageEvent) => void;
+	/** True when the host consumes provisional assistant events for live safety checks. */
+	hasProvisionalAssistantMessageEventConsumer?: boolean;
 
 	/** Called for non-content tool-choice incapability stream events. */
 	onToolChoiceIncapability?: (event: Extract<AssistantMessageEvent, { type: "toolChoiceIncapability" }>) => void;

--- a/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
+++ b/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
@@ -601,6 +601,7 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		expect(failure?.role === "assistant" ? failure.transportFailure : undefined).toEqual({
 			kind: "transport",
 			status: 429,
+			headers: {},
 		});
 	});
 

--- a/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
+++ b/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
@@ -4,6 +4,7 @@ import { agentLoop } from "@gajae-code/agent-core/agent-loop";
 import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AgentTool } from "@gajae-code/agent-core/types";
 import type { AssistantMessage, Message } from "@gajae-code/ai";
 import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { AssistantMessageEventStream } from "@gajae-code/ai/utils/event-stream";
 import * as z from "zod/v4";
 import { createUserMessage } from "./helpers";
 
@@ -447,6 +448,160 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		}
 
 		expect(observed).toEqual(["toolcall_end", "execute"]);
+	});
+
+	it("does not dispatch when an accepted assistant callback aborts during commit", async () => {
+		let executions = 0;
+		const tool: AgentTool<typeof askSchema, Record<string, never>> = {
+			...askTool([]),
+			async execute() {
+				executions += 1;
+				return { content: [{ type: "text", text: "answered" }], details: {} };
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({ responses: [literalTurn("tc-abort")] });
+		const controller = new AbortController();
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			onAssistantMessageEvent: (_message, event) => {
+				if (event.type === "toolcall_end") controller.abort();
+			},
+		};
+
+		const stream = agentLoop([createUserMessage("ask me")], context, config, controller.signal, mock.stream);
+		for await (const _event of stream) {
+			// drain
+		}
+
+		expect(executions).toBe(0);
+	});
+
+	it("promotes a detached accepted assistant for execution state and replay", async () => {
+		const executed: Array<Record<string, unknown>> = [];
+		const mock = createMockModel({ responses: [{ content: ["done"] }] });
+		const providerOwned: AssistantMessage = {
+			role: "assistant",
+			content: thinkingToolTurn("tc-detached").content,
+			api: mock.model.api,
+			provider: mock.model.provider,
+			model: mock.model.id,
+			usage: structuredClone(PROVIDER_USAGE),
+			stopReason: "toolUse",
+			responseId: "provider-response-id",
+			disabledFeatures: ["priority"],
+			providerPayload: { type: "openaiResponsesHistory", provider: "mock", items: [{ id: "native-item" }] },
+			timestamp: Date.now(),
+		};
+		let calls = 0;
+		const streamFn: typeof mock.stream = (_model, llmContext, options) => {
+			if (calls++ > 0) return mock.stream(mock.model, llmContext, options);
+			const providerStream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				providerStream.push({ type: "start", partial: providerOwned });
+				providerStream.push({ type: "thinking_start", contentIndex: 0, partial: providerOwned });
+				providerStream.push({
+					type: "thinking_delta",
+					contentIndex: 0,
+					delta: "provider reasoning",
+					partial: providerOwned,
+				});
+				providerStream.push({
+					type: "thinking_end",
+					contentIndex: 0,
+					content: "provider reasoning",
+					partial: providerOwned,
+				});
+				providerStream.push({ type: "toolcall_start", contentIndex: 1, partial: providerOwned });
+				providerStream.push({
+					type: "toolcall_delta",
+					contentIndex: 1,
+					delta: JSON.stringify({ question: QUESTION }),
+					partial: providerOwned,
+				});
+				const toolCall = providerOwned.content[1];
+				if (toolCall?.type !== "toolCall") throw new Error("Expected tool call");
+				providerStream.push({ type: "toolcall_end", contentIndex: 1, toolCall, partial: providerOwned });
+				providerStream.push({ type: "done", reason: "toolUse", message: providerOwned });
+			});
+			return providerStream;
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [askTool(executed)] };
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, streamFn);
+		for await (const _event of stream) {
+			// drain
+		}
+
+		const accepted = (await stream.result()).find(
+			(message): message is AssistantMessage =>
+				message.role === "assistant" &&
+				message.content.some(block => block.type === "toolCall" && block.id === "tc-detached"),
+		);
+		expect(accepted).toBeDefined();
+		expect(accepted).not.toBe(providerOwned);
+		providerOwned.usage.reasoningTokens = 999;
+		providerOwned.disabledFeatures?.push("mutated");
+		providerOwned.providerPayload?.items.push({ id: "mutated" });
+		expect(accepted?.usage.reasoningTokens).toBe(5);
+		expect(accepted?.disabledFeatures).toEqual(["priority"]);
+		expect(accepted?.providerPayload).toEqual({
+			type: "openaiResponsesHistory",
+			provider: "mock",
+			items: [{ id: "native-item" }],
+		});
+		const replayed = mock.calls[0]?.context.messages.find(
+			(message): message is AssistantMessage =>
+				message.role === "assistant" &&
+				message.content.some(block => block.type === "toolCall" && block.id === "tc-detached"),
+		);
+		expect(replayed).toBe(accepted);
+	});
+
+	it("does not mask an ordinary unmanaged provider error with non-cloneable metadata", async () => {
+		const mock = createMockModel();
+		const streamFn: typeof mock.stream = () => {
+			const providerStream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				const failure: AssistantMessage = {
+					role: "assistant",
+					content: [],
+					api: mock.model.api,
+					provider: mock.model.provider,
+					model: mock.model.id,
+					usage: structuredClone(PROVIDER_USAGE),
+					stopReason: "error",
+					errorMessage: "rate limited",
+					errorStatus: 429,
+					transportFailure: {
+						kind: "transport",
+						status: 429,
+						headers: new Headers({ "retry-after": "0" }) as unknown as Record<string, string>,
+					},
+					timestamp: Date.now(),
+				};
+				providerStream.push({ type: "error", reason: "error", error: failure });
+			});
+			return providerStream;
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [] };
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const stream = agentLoop([createUserMessage("ask me")], context, config, undefined, streamFn);
+		for await (const _event of stream) {
+			// drain
+		}
+		const result = await stream.result();
+		const failure = result.findLast(message => message.role === "assistant");
+
+		expect(failure?.role === "assistant" ? failure.errorMessage : undefined).toBe("rate limited");
+		expect(failure?.role === "assistant" ? failure.errorStatus : undefined).toBe(429);
+		expect(failure?.role === "assistant" ? failure.transportFailure : undefined).toEqual({
+			kind: "transport",
+			status: 429,
+		});
 	});
 
 	it("rejects the call once the resample budget is spent", async () => {

--- a/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
+++ b/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
@@ -601,7 +601,6 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		expect(failure?.role === "assistant" ? failure.transportFailure : undefined).toEqual({
 			kind: "transport",
 			status: 429,
-			headers: {},
 		});
 	});
 

--- a/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
+++ b/packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { Agent } from "@gajae-code/agent-core";
 import { agentLoop } from "@gajae-code/agent-core/agent-loop";
 import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AgentTool } from "@gajae-code/agent-core/types";
-import type { Message } from "@gajae-code/ai";
+import type { AssistantMessage, Message } from "@gajae-code/ai";
 import { createMockModel } from "@gajae-code/ai/providers/mock";
 import * as z from "zod/v4";
 import { createUserMessage } from "./helpers";
@@ -55,6 +55,47 @@ function escapedTurnWithText(id: string) {
 /** The same turn as the model would have produced it with literal UTF-8 on the wire. */
 function literalTurn(id: string) {
 	return { content: [{ type: "toolCall" as const, id, name: "ask", arguments: { question: QUESTION } }] };
+}
+
+const PROVIDER_USAGE = {
+	input: 7,
+	output: 11,
+	cacheRead: 13,
+	cacheWrite: 17,
+	totalTokens: 48,
+	premiumRequests: 2,
+	reasoningTokens: 5,
+	cttl: { ephemeral5m: 3, ephemeral1h: 14 },
+	server: { webSearch: 2, webFetch: 1 },
+	cost: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4, total: 10 },
+};
+
+function thinkingToolTurn(id: string, escaped = false) {
+	return {
+		content: [
+			{
+				type: "thinking" as const,
+				thinking: "provider reasoning",
+				thinkingSignature: "reasoning-signature",
+				itemId: "reasoning-item",
+				provenance: "mixed" as const,
+				summaryText: "summary",
+				rawText: "raw",
+			},
+			{
+				type: "toolCall" as const,
+				id,
+				name: "ask",
+				arguments: { question: QUESTION },
+				thoughtSignature: "tool-thought-signature",
+				...(escaped ? { escapedNonAsciiArguments: true } : {}),
+			},
+		],
+		usage: PROVIDER_USAGE,
+		responseId: "provider-response-id",
+		disabledFeatures: ["priority"],
+		providerPayload: { type: "openaiResponsesHistory" as const, provider: "mock", items: [{ id: "native-item" }] },
+	};
 }
 
 describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
@@ -127,6 +168,49 @@ describe("agentLoop: ASCII-escaped non-ASCII argument guard", () => {
 		).toBe(false);
 		expect(events.filter(event => event.type === "turn_start")).toHaveLength(3);
 		expect(events.filter(event => event.type === "turn_end")).toHaveLength(2);
+	});
+
+	it("preserves provider-native thinking and usage metadata through accepted Agent state and replay", async () => {
+		const executed: Array<Record<string, unknown>> = [];
+		const mock = createMockModel({
+			responses: [thinkingToolTurn("tc-defective", true), thinkingToolTurn("tc-accepted"), { content: ["done"] }],
+		});
+		const agent = new Agent({
+			initialState: { systemPrompt: [""], model: mock.model, tools: [askTool(executed)], messages: [] },
+			convertToLlm: identityConverter,
+			streamFn: mock.stream,
+		});
+
+		await agent.prompt("ask me");
+
+		const accepted = agent.state.messages.find(
+			(message): message is AssistantMessage =>
+				message.role === "assistant" &&
+				message.content.some(block => block.type === "toolCall" && block.id === "tc-accepted"),
+		);
+		expect(accepted).toBeDefined();
+		expect(accepted?.content[0]).toEqual(thinkingToolTurn("unused").content[0]);
+		expect(accepted?.usage).toEqual(PROVIDER_USAGE);
+		expect(accepted?.responseId).toBe("provider-response-id");
+		expect(accepted?.disabledFeatures).toEqual(["priority"]);
+		expect(accepted?.providerPayload).toEqual({
+			type: "openaiResponsesHistory",
+			provider: "mock",
+			items: [{ id: "native-item" }],
+		});
+		expect(
+			agent.state.messages.some(
+				message =>
+					message.role === "assistant" &&
+					message.content.some(block => block.type === "toolCall" && block.id === "tc-defective"),
+			),
+		).toBe(false);
+		const replayed = mock.calls[2]?.context.messages.find(
+			(message): message is AssistantMessage =>
+				message.role === "assistant" &&
+				message.content.some(block => block.type === "toolCall" && block.id === "tc-accepted"),
+		);
+		expect(replayed).toEqual(accepted);
 	});
 
 	it("preserves all pre-existing history and removes only the defective assistant turn", async () => {

--- a/packages/ai/src/providers/mock.ts
+++ b/packages/ai/src/providers/mock.ts
@@ -79,6 +79,7 @@ export type MockContent =
 			incompleteArgumentsReason?: "truncated" | "malformed" | "conflicting" | "ambiguous";
 			/** Simulate a provider-flagged `\uXXXX`-escaped non-ASCII argument payload. */
 			escapedNonAsciiArguments?: boolean;
+			thoughtSignature?: string;
 	  };
 /** One scripted response. */
 export interface MockResponse {
@@ -90,6 +91,9 @@ export interface MockResponse {
 	usage?: Partial<Omit<Usage, "cost">> & { cost?: Partial<Usage["cost"]> };
 	/** Pre-set responseId. */
 	responseId?: string;
+	/** Optional provider metadata copied onto the final assistant message. */
+	disabledFeatures?: string[];
+	providerPayload?: AssistantMessage["providerPayload"];
 	/** Optional typed provider failure metadata for retry/fallback tests. */
 	transportFailure?: AssistantMessage["transportFailure"];
 	/** If set, the stream emits a terminal error event instead of completing. */
@@ -368,6 +372,8 @@ async function runMock(
 		provider: model.provider,
 		model: model.id,
 		responseId: response.responseId,
+		disabledFeatures: response.disabledFeatures,
+		providerPayload: response.providerPayload,
 		transportFailure: response.transportFailure,
 		usage: emptyUsage(),
 		stopReason: "stop",
@@ -429,6 +435,7 @@ function normalizeContent(input: MockContent, state: MockModel): TextContent | T
 				? { incompleteArguments: true, incompleteArgumentsReason: input.incompleteArgumentsReason ?? "truncated" }
 				: {}),
 			...(input.escapedNonAsciiArguments ? { escapedNonAsciiArguments: true } : {}),
+			...(input.thoughtSignature ? { thoughtSignature: input.thoughtSignature } : {}),
 		} as ToolCall;
 	}
 	return input;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1926,6 +1926,7 @@ function deobfuscateSessionContext(context: SessionContext, obfuscator: SecretOb
 }
 
 export class AgentSession {
+	#provisionalStreamingToolCallIds = new Set<string>();
 	readonly agent: Agent;
 	sessionManager: SessionManager;
 	readonly settings: Settings;
@@ -3025,6 +3026,27 @@ export class AgentSession {
 
 	constructor(config: AgentSessionConfig) {
 		this.agent = config.agent;
+		this.agent.setProvisionalAssistantMessageEventInterceptor((message, assistantMessageEvent) => {
+			const contentIndex = assistantMessageEvent.contentIndex ?? 0;
+			const block = message.content[contentIndex];
+			if (block?.type === "toolCall" && block.id) this.#provisionalStreamingToolCallIds.add(block.id);
+			if (
+				assistantMessageEvent.type !== "toolcall_start" &&
+				assistantMessageEvent.type !== "toolcall_delta" &&
+				assistantMessageEvent.type !== "toolcall_end"
+			) {
+				return;
+			}
+			const event: AgentEvent = {
+				type: "message_update",
+				message,
+				assistantMessageEvent,
+			};
+			void this.#preCacheStreamingEditFile(event);
+			if (assistantMessageEvent.type === "toolcall_delta" || assistantMessageEvent.type === "toolcall_end") {
+				this.#maybeAbortStreamingEdit(event, this.#promptGeneration);
+			}
+		});
 		this.agent.bindRunCancellationDomainBridge(this.#runCancellationDomains, this.#agentSessionClaimKey);
 		this.sessionManager = config.sessionManager;
 		this.settings = config.settings;
@@ -4984,6 +5006,7 @@ export class AgentSession {
 
 		if (
 			event.type === "message_update" &&
+			!this.#isProvisionalStreamingToolEvent(event) &&
 			(event.assistantMessageEvent.type === "toolcall_start" ||
 				event.assistantMessageEvent.type === "toolcall_delta" ||
 				event.assistantMessageEvent.type === "toolcall_end")
@@ -4993,6 +5016,7 @@ export class AgentSession {
 
 		if (
 			event.type === "message_update" &&
+			!this.#isProvisionalStreamingToolEvent(event) &&
 			(event.assistantMessageEvent.type === "toolcall_end" || event.assistantMessageEvent.type === "toolcall_delta")
 		) {
 			this.#maybeAbortStreamingEdit(event, this.#promptGeneration);
@@ -6196,6 +6220,13 @@ export class AgentSession {
 			// if priming hasn't completed by the time removed lines appear.
 			void this.#preCacheFileAsync(streamingEdit.resolvedPath);
 		}
+	}
+
+	#isProvisionalStreamingToolEvent(event: AgentEvent): boolean {
+		if (event.type !== "message_update") return false;
+		const contentIndex = event.assistantMessageEvent.contentIndex ?? 0;
+		const block = event.message.role === "assistant" ? event.message.content[contentIndex] : undefined;
+		return block?.type === "toolCall" && this.#provisionalStreamingToolCallIds.has(block.id);
 	}
 
 	#streamingEditPrecachePending = new Set<string>();

--- a/packages/coding-agent/test/agent-session-escaped-nonascii-metadata.test.ts
+++ b/packages/coding-agent/test/agent-session-escaped-nonascii-metadata.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent, type AgentMessage, type AgentTool } from "@gajae-code/agent-core";
+import type { AssistantMessage, Message } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { TempDir } from "@gajae-code/utils";
+import * as z from "zod/v4";
+
+const QUESTION = "마지막 병목";
+const usage = {
+	input: 7,
+	output: 11,
+	cacheRead: 13,
+	cacheWrite: 17,
+	totalTokens: 48,
+	premiumRequests: 2,
+	reasoningTokens: 5,
+	cttl: { ephemeral5m: 3, ephemeral1h: 14 },
+	server: { webSearch: 2, webFetch: 1 },
+	cost: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4, total: 10 },
+};
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(
+		message => message.role === "user" || message.role === "assistant" || message.role === "toolResult",
+	) as Message[];
+}
+
+function turn(id: string, escaped: boolean) {
+	return {
+		content: [
+			{
+				type: "thinking" as const,
+				thinking: "provider reasoning",
+				thinkingSignature: "reasoning-signature",
+				itemId: "reasoning-item",
+				provenance: "mixed" as const,
+				summaryText: "summary",
+				rawText: "raw",
+			},
+			{
+				type: "toolCall" as const,
+				id,
+				name: "ask",
+				arguments: { question: QUESTION },
+				thoughtSignature: "tool-thought-signature",
+				...(escaped ? { escapedNonAsciiArguments: true } : {}),
+			},
+		],
+		usage,
+		responseId: "provider-response-id",
+		disabledFeatures: ["priority"],
+		providerPayload: { type: "openaiResponsesHistory" as const, provider: "mock", items: [{ id: "native-item" }] },
+	};
+}
+
+const schema = z.object({ question: z.string() });
+
+function askTool(): AgentTool<typeof schema, Record<string, never>> {
+	return {
+		name: "ask",
+		label: "Ask",
+		description: "Ask",
+		parameters: schema,
+		async execute() {
+			return { content: [{ type: "text", text: "answered" }], details: {} };
+		},
+	};
+}
+
+describe("AgentSession escaped non-ASCII metadata fidelity", () => {
+	let tempDir: TempDir | undefined;
+	let authStorage: AuthStorage | undefined;
+	let session: AgentSession | undefined;
+
+	afterEach(async () => {
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+	});
+
+	it("persists and replays accepted provider metadata without the defective turn", async () => {
+		tempDir = TempDir.createSync("@gjc-escaped-metadata-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		authStorage.setRuntimeApiKey("mock", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage);
+		const manager = SessionManager.create(tempDir.path(), tempDir.path());
+		const mock = createMockModel({
+			responses: [turn("tc-defective", true), turn("tc-accepted", false), { content: ["done"] }],
+		});
+		const agent = new Agent({
+			initialState: { model: mock.model, systemPrompt: ["test"], tools: [askTool()], messages: [] },
+			convertToLlm: identityConverter,
+			streamFn: mock.stream,
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: manager,
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+		});
+
+		await session.prompt("ask me");
+		await manager.flush();
+
+		const persisted = manager
+			.buildSessionContext()
+			.messages.find(
+				(message): message is AssistantMessage =>
+					message.role === "assistant" &&
+					message.content.some(block => block.type === "toolCall" && block.id === "tc-accepted"),
+			);
+		expect(persisted).toBeDefined();
+		expect(persisted?.content[0]).toEqual(turn("unused", false).content[0]);
+		expect(persisted?.usage).toEqual(usage);
+		expect(persisted?.responseId).toBe("provider-response-id");
+		expect(persisted?.disabledFeatures).toEqual(["priority"]);
+		expect(persisted?.providerPayload).toEqual({
+			type: "openaiResponsesHistory",
+			provider: "mock",
+			items: [{ id: "native-item" }],
+		});
+		expect(
+			manager
+				.buildSessionContext()
+				.messages.some(
+					message =>
+						message.role === "assistant" &&
+						message.content.some(block => block.type === "toolCall" && block.id === "tc-defective"),
+				),
+		).toBe(false);
+		const replayed = mock.calls[2]?.context.messages.find(
+			(message): message is AssistantMessage =>
+				message.role === "assistant" &&
+				message.content.some(block => block.type === "toolCall" && block.id === "tc-accepted"),
+		);
+		expect(replayed).toEqual(persisted);
+	});
+});


### PR DESCRIPTION
Postmerge fix-forward for #4491 / #4489.

A newer exact-head review found that accepted unmanaged provisional turns were passed through the managed fallback's defensive normalized shell, losing provider-native thinking/tool/usage metadata. This commit switches only unmanaged provisional staging to detached lossless structured-clone snapshots; managed fallback remains unchanged.

Deterministic coverage verifies thinking signatures, reasoning item IDs/provenance, tool thought signatures, response ID, disabled features, provider payload, premium/reasoning/cache-TTL/server-tool usage through Agent state, SessionManager persistence, and next-turn replay. The defective escaped attempt remains absent.

Local evidence on `4eab74ec3a`:
- full agent suite: 757 pass
- focused metadata/transaction/event-stream suites: 61 pass
- agent, AI, coding-agent package checks/types: pass

Closes #4489.

Signed-off-by: Yeachan Heo <yeachan.heo@gmail.com>
