### PR TITLE
fix(sdk): classify extensions dashboard inventory seam

### DIFF
--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -39,6 +39,8 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 	"slash_command:exit": "visual/local-only command, not a user-facing SDK control seam",
 	"slash_command:notify":
 		"interactive diagnostics command; session on/off delegate to the notifications extension, not an SDK ingress seam",
+	"slash_command:extensions":
+		"interactive local customization dashboard mutates trusted local skill, hook, and MCP configuration (including filesystem import/removal); ACP and local headless cannot dispatch it, while SDK extension list/enable operations do not expose this dashboard authority",
 	"slash_command:credential":
 		"interactive session credential selector; not a credential-free public SDK operation or independent control seam",
 	"slash_command:pet": "visual/local-only command, not a user-facing SDK control seam",

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -2058,6 +2058,17 @@
 		}
 	},
 	{
+		"sourceId": "slash_command:extensions",
+		"sourceFile": "packages/coding-agent/src/slash-commands/builtin-registry.ts",
+		"sourceKind": "slash_command",
+		"decision": "exclude",
+		"rationale": "interactive local customization dashboard mutates trusted local skill, hook, and MCP configuration (including filesystem import/removal); ACP and local headless cannot dispatch it, while SDK extension list/enable operations do not expose this dashboard authority",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
 		"sourceId": "slash_command:monitors",
 		"sourceFile": "packages/coding-agent/src/slash-commands/builtin-registry.ts",
 		"sourceKind": "slash_command",

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1431,12 +1431,6 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	{
 		name: "extensions",
 		description: "Configure skills, hooks, and MCPs.",
-		handle: async (_command, runtime) => {
-			await runtime.output(
-				"/extensions is an interactive surface for configuring skills, hooks, and MCPs. Run gjc in an interactive terminal to use it. Non-interactive alternatives: gjc mcp (MCP servers) and gjc migrate (Claude Code/Codex import).",
-			);
-			return commandConsumed();
-		},
 		handleTui: (_command, runtime) => {
 			runtime.ctx.showCustomizationDashboard();
 			runtime.ctx.editor.setText("");

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -981,6 +981,9 @@ describe("ACP builtin slash commands", () => {
 	it("does not advertise /copy to ACP clients", () => {
 		expect(ACP_BUILTIN_SLASH_COMMANDS.some(command => command.name === "copy")).toBe(false);
 	});
+	it("does not advertise /extensions to ACP clients", () => {
+		expect(ACP_BUILTIN_SLASH_COMMANDS.some(command => command.name === "extensions")).toBe(false);
+	});
 	// TUI-only and dropped commands fall through as false
 	it("TUI-only and dropped commands return false (fall through to model)", async () => {
 		const fallthroughCommands = [

--- a/packages/coding-agent/test/extensions-command.test.ts
+++ b/packages/coding-agent/test/extensions-command.test.ts
@@ -1,14 +1,16 @@
 /**
  * Issue #4291 acceptance: `/extensions` is registered, discoverable, and
- * described exactly as "Configure skills, hooks, and MCPs."; non-interactive
- * (ACP/text) mode gets an explicit rejection instead of silence.
+ * described exactly as "Configure skills, hooks, and MCPs."; it is strictly
+ * local and interactive because its dashboard mutates trusted configuration.
  */
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import {
 	BUILTIN_SLASH_COMMAND_DEFS,
+	executeBuiltinSlashCommand,
+	executeLocalHeadlessBuiltinSlashCommand,
 	lookupBuiltinSlashCommand,
 } from "@gajae-code/coding-agent/slash-commands/builtin-registry";
-import type { ParsedSlashCommand, SlashCommandRuntime } from "@gajae-code/coding-agent/slash-commands/types";
+import type { SlashCommandRuntime } from "@gajae-code/coding-agent/slash-commands/types";
 
 describe("/extensions slash command registration", () => {
 	test("is registered with the exact owner-contract description", () => {
@@ -28,21 +30,30 @@ describe("/extensions slash command registration", () => {
 		expect(typeof spec?.handleTui).toBe("function");
 	});
 
-	test("non-interactive dispatch outputs an explicit rejection", async () => {
-		const spec = lookupBuiltinSlashCommand("extensions");
-		expect(typeof spec?.handle).toBe("function");
-		const outputs: string[] = [];
+	test("opens the local dashboard but has no headless dispatch authority", async () => {
+		const showCustomizationDashboard = () => {};
+		const setText = () => {};
+		const command = "/extensions";
 		const runtime = {
-			output: async (text: string) => {
-				outputs.push(text);
-			},
-		} as unknown as SlashCommandRuntime;
-		const command = { name: "extensions", args: "" } as unknown as ParsedSlashCommand;
-		const result = await spec!.handle!(command, runtime);
-		expect(result).toEqual({ consumed: true });
-		expect(outputs).toHaveLength(1);
-		expect(outputs[0]).toContain("/extensions");
-		expect(outputs[0]).toContain("interactive");
-		expect(outputs[0]).toContain("skills, hooks, and MCPs");
+			ctx: { showCustomizationDashboard, editor: { setText } },
+		};
+		const dashboard = spyOn(runtime.ctx, "showCustomizationDashboard");
+		const editor = spyOn(runtime.ctx.editor, "setText");
+
+		expect(await executeBuiltinSlashCommand(command, runtime as never)).toBe(true);
+		expect(dashboard).toHaveBeenCalledTimes(1);
+		expect(editor).toHaveBeenCalledWith("");
+		expect(
+			await executeLocalHeadlessBuiltinSlashCommand(command, {
+				output: async () => {},
+			} as unknown as SlashCommandRuntime),
+		).toBe(false);
+	});
+
+	test("has no text or ACP handler", () => {
+		const spec = lookupBuiltinSlashCommand("extensions");
+		expect(spec?.handle).toBeUndefined();
+		expect(spec?.localHeadless).not.toBe(true);
+		expect(spec?.acp).not.toBe(true);
 	});
 });

--- a/packages/coding-agent/test/sdk-operation-inventory.test.ts
+++ b/packages/coding-agent/test/sdk-operation-inventory.test.ts
@@ -126,6 +126,36 @@ describe("SDK operation inventory", () => {
 		}
 	});
 
+	it("locks the interactive extensions dashboard out of the SDK inventory exactly once", async () => {
+		const records = (await Bun.file(inventory).json()) as Array<{
+			sourceId: string;
+			sdkId?: string;
+			sourceFile: string;
+			sourceKind: string;
+			decision: string;
+			rationale?: string;
+			exclusionMetadata?: { adapterMappings: string; testIds: string };
+		}>;
+		const extensions = records.filter(record => record.sourceId === "slash_command:extensions");
+		expect(extensions).toEqual([
+			expect.objectContaining({
+				sourceId: "slash_command:extensions",
+				sourceFile: "packages/coding-agent/src/slash-commands/builtin-registry.ts",
+				sourceKind: "slash_command",
+				decision: "exclude",
+				rationale:
+					"interactive local customization dashboard mutates trusted local skill, hook, and MCP configuration (including filesystem import/removal); ACP and local headless cannot dispatch it, while SDK extension list/enable operations do not expose this dashboard authority",
+				exclusionMetadata: { adapterMappings: "not_applicable", testIds: "not_applicable" },
+			}),
+		]);
+		for (const [sourceId, sdkId] of [
+			["registry:Q22", "extensions.list"],
+			["registry:C46", "extension.set_enabled"],
+		]) {
+			expect(records).toContainEqual(expect.objectContaining({ sourceId, sdkId, decision: "include" }));
+		}
+	});
+
 	it("rejects a generated matrix with a dropped row", async () => {
 		const directory = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-sdk-inventory-"));
 		tempDirs.push(directory);

--- a/packages/coding-agent/test/utility-extensibility-quarantine.test.ts
+++ b/packages/coding-agent/test/utility-extensibility-quarantine.test.ts
@@ -25,10 +25,9 @@ describe("GJC utility extensibility quarantine", () => {
 		expect(registry).toContain("BUILTIN_SLASH_COMMAND_LOOKUP.set(command.name, command)");
 	});
 
-	it("deletes approved non-critical slash command implementations", async () => {
+	it("keeps the explicitly contracted local customization dashboard out of utility surfaces", async () => {
 		const registry = await source("slash-commands", "builtin-registry.ts");
 		for (const removedCommand of [
-			"extensions",
 			"marketplace",
 			"plugins",
 			"reload-plugins",
@@ -45,6 +44,10 @@ describe("GJC utility extensibility quarantine", () => {
 		]) {
 			expect(registry).not.toContain(`name: "${removedCommand}"`);
 		}
+		const extensions = registry.match(/\{\s*name: "extensions",([\s\S]*?)\n\t\},/);
+		expect(extensions?.[1]).toContain("handleTui:");
+		expect(extensions?.[1]).not.toContain("handle:");
+		expect(extensions?.[1]).not.toContain("localHeadless:");
 		// `/changelog` was restored as a first-class built-in (see CHANGELOG
 		// Unreleased), so it is intentionally no longer in the removed set above.
 		expect(registry).toContain(`name: "changelog"`);


### PR DESCRIPTION
## Summary
- classify `/extensions` as a reviewed local-interactive dashboard exclusion
- regenerate the canonical SDK operation inventory
- lock the exact excluded record and distinguish existing `extensions.list` / `extension.set_enabled` SDK controls
- cover TUI, ACP rejection, and local-headless non-dispatch behavior

Fixes #4502

## Evidence
- Base: `e566cd2a1ee80d01c0676d813b6310ef664d0a30`
- Signed commit: `44a96f5b5d2b4382f3b2b0ee265f223497ecc08f`
- `bun packages/coding-agent/scripts/generate-sdk-operation-inventory.ts --check`
- `bun test packages/coding-agent/test/sdk-operation-inventory.test.ts` — 19 pass
- `bun test test/extensions-command.test.ts test/customization-extensions.test.ts` — 48 pass
- `bun --cwd=packages/coding-agent run check`
- Independent adversarial review identified and resolved the local-headless wording and public-control regression gaps.