### PR TITLE
fix(acp): preserve cleanup-pending delete authority

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed ACP `session/delete` retries so a durable artifact `cleanup_pending` result remains authoritative instead of re-closing the already-terminated session and misclassifying an unreaped Linux zombie as unverifiable SIGKILL uncertainty. Broker close now recognizes an identity-matching zombie as exited without weakening PID-reuse checks, and repeated deletes resume the authorized cleanup receipt idempotently.
+
 - Added `/extensions`, an interactive project/global `.gjc` manager for skills, hooks, MCPs, and explicit Claude Code/Codex imports with redacted previews and atomic rollback.
 
 ### Added

--- a/packages/coding-agent/src/gjc-runtime/linux-proc.ts
+++ b/packages/coding-agent/src/gjc-runtime/linux-proc.ts
@@ -12,6 +12,7 @@ import * as nodeFsSync from "node:fs";
 import * as nodeFs from "node:fs/promises";
 
 export interface LinuxProcStatIdentity {
+	state?: string;
 	startTime: string;
 	ttyDevice: string;
 }
@@ -40,7 +41,7 @@ function parseLinuxProcIdentity(stat: string | null | undefined): LinuxProcStatI
 	const ttyDevice = fields[4];
 	const startTime = fields[19];
 	if (!ttyDevice || !/^-?\d+$/.test(ttyDevice) || !/^\d+$/.test(startTime)) return null;
-	return { startTime, ttyDevice };
+	return { state: fields[0], startTime, ttyDevice };
 }
 
 function classifyProcReadError(error: unknown): Extract<LinuxProcPidProbeResult, { kind: "absent" | "unverifiable" }> {
@@ -58,6 +59,11 @@ export function parseLinuxProcStartTime(stat: string | null | undefined): string
 /** Parse field 7 (`tty_nr`) from a `/proc/<pid>/stat` record. */
 export function parseLinuxProcTtyDevice(stat: string | null | undefined): string | null {
 	return parseLinuxProcIdentity(stat)?.ttyDevice ?? null;
+}
+
+/** Parse field 3 (single-letter process state) from a `/proc/<pid>/stat` record. */
+export function parseLinuxProcState(stat: string | null | undefined): string | null {
+	return parseLinuxProcIdentity(stat)?.state ?? null;
 }
 
 export function probeLinuxProcPidSync(pid: number): LinuxProcPidProbeResult {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1416,7 +1416,7 @@ export class AcpAgent implements Agent {
 			// connection/process teardown and reached durable artifact cleanup. Re-closing
 			// that terminal session can only replace the authoritative cleanup_pending
 			// result with unrelated close uncertainty, so retries resume deletion directly.
-			await this.#teardownSession(params.sessionId, "deleted", pendingLocator === undefined);
+			await this.#teardownSession(params.sessionId, "deleted", pendingLocator === undefined || record !== undefined);
 			let saved = pendingLocator?.cwd === cwd ? pendingLocator.path : undefined;
 			if (!saved) {
 				try {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1412,7 +1412,11 @@ export class AcpAgent implements Agent {
 		}
 		this.#beginTeardown(params.sessionId);
 		try {
-			await this.#teardownSession(params.sessionId, "deleted", true);
+			// A retained delete locator proves the prior attempt already completed
+			// connection/process teardown and reached durable artifact cleanup. Re-closing
+			// that terminal session can only replace the authoritative cleanup_pending
+			// result with unrelated close uncertainty, so retries resume deletion directly.
+			await this.#teardownSession(params.sessionId, "deleted", pendingLocator === undefined);
 			let saved = pendingLocator?.cwd === cwd ? pendingLocator.path : undefined;
 			if (!saved) {
 				try {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1954,6 +1954,7 @@ export class AcpAgent implements Agent {
 			// ACP clients replay their declared MCP servers when reconnecting. The live
 			// session host remains authoritative for its immutable configuration, so
 			// attachment must not reinterpret the replay as a mutation request.
+			this.#pendingDeleteLocators.delete(id);
 			return;
 		}
 		const knownCwd = this.#knownSessionCwds.get(id);
@@ -2136,6 +2137,10 @@ export class AcpAgent implements Agent {
 			this.#knownSessionCwds.set(id, cwd);
 			await applyAcpPermissionMode(adapter, this.#clientCapabilities);
 			this.#assertSessionEpoch(id, epoch);
+			// A successful attachment establishes a new live-owner epoch. Any locator
+			// retained from an earlier cleanup_pending delete belongs to the terminal
+			// owner and must not suppress remote close when this live session is deleted.
+			this.#pendingDeleteLocators.delete(id);
 			this.#pendingCloseIdempotencyKeys.delete(id);
 		} catch (error) {
 			unsubscribePendingFrames();

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -28,6 +28,7 @@ import {
 	type GjcLaunchWorktreePlan,
 	planLaunchWorktree,
 } from "../../gjc-runtime/launch-worktree";
+import { probeLinuxProcPidSync } from "../../gjc-runtime/linux-proc";
 import {
 	GJC_COORDINATOR_SESSION_BRANCH_ENV,
 	GJC_COORDINATOR_SESSION_ID_ENV,
@@ -831,6 +832,10 @@ function observeProcess(
 	} catch (error) {
 		return (error as NodeJS.ErrnoException).code === "ESRCH" ? "exited" : "uncertain";
 	}
+	if (process.platform === "linux") {
+		const probe = probeLinuxProcPidSync(pid);
+		if (probe.kind === "live" && probe.state === "Z") return "exited";
+	}
 	if (!expectedIncarnation) return "uncertain";
 	const actualIncarnation = readIncarnation(pid);
 	if (!actualIncarnation) return "uncertain";
@@ -844,6 +849,41 @@ function hasObservedProcessExit(pid: number): boolean {
 	} catch (error) {
 		return (error as NodeJS.ErrnoException).code === "ESRCH";
 	}
+}
+
+type StableProcessExitObserver = {
+	hasExited(): boolean;
+};
+
+/**
+ * Pin the indexed process before shutdown so exit remains observable after it
+ * becomes a zombie. `kill(pid, 0)` and `/proc/<pid>/stat` continue to describe
+ * an unreaped zombie as present, which otherwise makes a timely SIGTERM exit
+ * look unverifiable and incorrectly escalates the close to terminal uncertainty.
+ */
+function stableProcessExitObserver(record: CloseRecord): StableProcessExitObserver | undefined {
+	if (!record.processIncarnation) return undefined;
+	try {
+		const reference = nativeLifecycle().Process.fromPid(record.pid);
+		if (!reference || reference.incarnation !== record.processIncarnation) return undefined;
+		return { hasExited: () => reference.status() === "exited" };
+	} catch {
+		return undefined;
+	}
+}
+
+function observedProcessExited(
+	pid: number,
+	expectedIncarnation: string | undefined,
+	observer: StableProcessExitObserver | undefined,
+): boolean {
+	try {
+		if (observer?.hasExited()) return true;
+	} catch {}
+	if (hasObservedProcessExit(pid)) return true;
+	if (process.platform !== "linux" || !expectedIncarnation?.startsWith("linux:")) return false;
+	const probe = probeLinuxProcPidSync(pid);
+	return probe.kind === "live" && probe.state === "Z" && `linux:${probe.startTime}` === expectedIncarnation;
 }
 
 function isEffectMarker(value: unknown): value is EffectMarker {
@@ -2112,7 +2152,7 @@ async function removeOwnedLifecycleArtifacts(
 		} catch {
 			return false;
 		}
-		if (parsed.pid !== expected.pid || !hasObservedProcessExit(expected.pid)) return false;
+		if (parsed.pid !== expected.pid || observeProcess(expected.pid, expected.incarnation) !== "exited") return false;
 		if (createHash("sha256").update(endpoint.bytes).digest("hex") !== endpoint.digest) return false;
 		const endpointRemoval = exactUnlinkLifecycleFile(
 			endpointSource,
@@ -2513,7 +2553,13 @@ async function hasOwnedEndpointPayload(
 	}
 	return false;
 }
-async function waitForClose(broker: Broker, id: string, record: CloseRecord, timeoutMs: number): Promise<boolean> {
+async function waitForClose(
+	broker: Broker,
+	id: string,
+	record: CloseRecord,
+	timeoutMs: number,
+	processExitObserver?: StableProcessExitObserver,
+): Promise<boolean> {
 	const timing = lifecycleTiming(broker);
 	const deadline = timing.now() + timeoutMs;
 	const durablePlaceholders = new Set<string>();
@@ -2529,7 +2575,7 @@ async function waitForClose(broker: Broker, id: string, record: CloseRecord, tim
 			registration &&
 			broker.index.hostUnregisteredAfter(registration) &&
 			(await endpointRemoved(record.locator.stateRoot, id)) &&
-			hasObservedProcessExit(record.pid) &&
+			observedProcessExited(record.pid, record.processIncarnation, processExitObserver) &&
 			(!record.lifecycleRequestId ||
 				!(await hasOwnedEndpointPayload(
 					record.locator.stateRoot,
@@ -2545,7 +2591,7 @@ async function waitForClose(broker: Broker, id: string, record: CloseRecord, tim
 		// That is exactly the evidence the dead-registration sweep retires records
 		// on, so retire it here too instead of escalating signals at a pid that no
 		// longer exists and then reporting the teardown as unfinished.
-		if (registration && hasObservedProcessExit(record.pid)) {
+		if (registration && observedProcessExited(record.pid, record.processIncarnation, processExitObserver)) {
 			const expected =
 				typeof record.lifecycleRequestId === "string" && typeof record.processIncarnation === "string"
 					? {
@@ -3771,6 +3817,7 @@ async function executeLifecycleResponse(
 			typeof record.lifecycleRequestId === "string" && typeof record.processIncarnation === "string"
 				? { pid: record.pid, effectMarker: record.lifecycleRequestId, incarnation: record.processIncarnation }
 				: undefined;
+		let processExitObserver = stableProcessExitObserver(record);
 
 		let usedSignalFallback = false;
 		let note: string | undefined;
@@ -3844,6 +3891,7 @@ async function executeLifecycleResponse(
 				if (record.lifecycleRequestId === undefined) {
 					usedSignalFallback = true;
 				} else {
+					processExitObserver ??= stableProcessExitObserver(record);
 					const response = await client.control("session.close", {
 						[BROKER_RUNTIME_CLOSE_CAPABILITY_FIELD]: record.lifecycleRequestId,
 					});
@@ -3877,6 +3925,7 @@ async function executeLifecycleResponse(
 		if (usedSignalFallback) {
 			const stale = await revalidateCloseGeneration(broker, id, record, requestedAuthority.authority);
 			if (stale) return stale;
+			processExitObserver ??= stableProcessExitObserver(record);
 			const exited =
 				typeof record.processIncarnation === "string" &&
 				observeProcess(record.pid, record.processIncarnation, value =>
@@ -3892,7 +3941,7 @@ async function executeLifecycleResponse(
 			}
 		}
 
-		let closed = await waitForClose(broker, id, record, CLOSE_TIMEOUT_MS);
+		let closed = await waitForClose(broker, id, record, CLOSE_TIMEOUT_MS, processExitObserver);
 		if (!closed && !usedSignalFallback) {
 			const stale = await revalidateCloseGeneration(broker, id, record, requestedAuthority.authority);
 			if (stale) return stale;
@@ -3905,7 +3954,7 @@ async function executeLifecycleResponse(
 			}
 			note =
 				"Session acknowledged session.close but graceful teardown did not complete within the bounded deadline; sent SIGTERM to the durably identified session process.";
-			closed = await waitForClose(broker, id, record, CLOSE_TIMEOUT_MS);
+			closed = await waitForClose(broker, id, record, CLOSE_TIMEOUT_MS, processExitObserver);
 		}
 		if (!closed) {
 			const stale = await revalidateCloseGeneration(broker, id, record, requestedAuthority.authority);
@@ -3919,7 +3968,7 @@ async function executeLifecycleResponse(
 			}
 			note =
 				"Session teardown did not complete after SIGTERM within the bounded deadline; sent SIGKILL to the durably identified session process.";
-			closed = await waitForClose(broker, id, record, CLOSE_TIMEOUT_MS);
+			closed = await waitForClose(broker, id, record, CLOSE_TIMEOUT_MS, processExitObserver);
 		}
 		if (!closed) {
 			await recordTerminalUncertain(broker, id, record.locator.stateRoot, record.pid);

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -834,7 +834,8 @@ function observeProcess(
 	}
 	if (process.platform === "linux") {
 		const probe = probeLinuxProcPidSync(pid);
-		if (probe.kind === "live" && probe.state === "Z") return "exited";
+		if (probe.kind === "live" && probe.state === "Z" && expectedIncarnation === `linux:${probe.startTime}`)
+			return "exited";
 	}
 	if (!expectedIncarnation) return "uncertain";
 	const actualIncarnation = readIncarnation(pid);

--- a/packages/coding-agent/test/acp-session-delete-wire.test.ts
+++ b/packages/coding-agent/test/acp-session-delete-wire.test.ts
@@ -336,7 +336,7 @@ describe("ACP session/delete wire oracle (real subprocess stdio)", () => {
 			await fs.promises.writeFile(path.join(artifactsDir, ".oracle.txt"), "artifact");
 
 			await expect(connection.deleteSession({ sessionId })).rejects.toThrow(
-				"Exact detached artifact removal rejected: cleanup_pending",
+				"Saved session cleanup is pending in artifacts: Exact detached artifact removal rejected: cleanup_pending",
 			);
 			expect(fs.existsSync(sessionPath)).toBe(true);
 			expect(fs.existsSync(artifactsDir)).toBe(false);
@@ -349,7 +349,7 @@ describe("ACP session/delete wire oracle (real subprocess stdio)", () => {
 			);
 
 			await expect(connection.deleteSession({ sessionId })).rejects.toThrow(
-				"Exact detached artifact removal rejected: cleanup_pending",
+				"Saved session cleanup is pending in artifacts: Exact detached artifact removal rejected: cleanup_pending",
 			);
 			expect(fs.existsSync(sessionPath)).toBe(true);
 			const payloadsAfterRetry = (await fs.promises.readdir(path.dirname(sessionPath), { recursive: true })).filter(

--- a/packages/coding-agent/test/gjc-runtime/linux-proc.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/linux-proc.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
 	parseLinuxProcStartTime,
+	parseLinuxProcState,
 	parseLinuxProcTtyDevice,
 	probeLinuxProcPid,
 	probeLinuxProcPidSync,
@@ -74,6 +75,17 @@ describe("parseLinuxProcStartTime", () => {
 	});
 });
 
+describe("parseLinuxProcState", () => {
+	it("returns the exact single-letter process state", () => {
+		expect(parseLinuxProcState(procStat("running", "1234", "0", "", "R"))).toBe("R");
+		expect(parseLinuxProcState(procStat("zombie", "1234", "0", "", "Z"))).toBe("Z");
+	});
+
+	it("rejects malformed process states", () => {
+		expect(parseLinuxProcState(procStat("owner", "1234").replace(") S", ") ZZ"))).toBeNull();
+	});
+});
+
 describe("parseLinuxProcTtyDevice", () => {
 	it("parses field 7 from a valid stat string", () => {
 		expect(parseLinuxProcTtyDevice(procStat("owner", "1234", "2049"))).toBe("2049");
@@ -91,6 +103,7 @@ describe("probeLinuxProcPidSync", () => {
 		const probe = probeLinuxProcPidSync(process.pid);
 		expect(probe.kind).toBe("live");
 		if (probe.kind !== "live") return;
+		expect(probe.state).toMatch(/^[A-Za-z]$/);
 		expect(probe.startTime).toMatch(/^\d+$/);
 		expect(probe.ttyDevice).toMatch(/^-?\d+$/);
 	});


### PR DESCRIPTION
Closes #4501

## Cause
A session host could exit promptly after SIGTERM but remain as an unreaped Linux zombie. `kill(pid, 0)` and `/proc/<pid>/stat` still presented the PID as existing, so ACP teardown retried SIGKILL identity verification and replaced the real durable artifact `cleanup_pending` result with `terminal_uncertain`. A repeated ACP delete also re-ran remote close even after the first attempt had reached an authorized durable cleanup receipt.

## Fix
- classify an identity-matching Linux zombie as exited while retaining PID-reuse/foreign-process rejection
- retain a stable native process reference across close waits when available
- resume a pending ACP delete directly from its durable locator rather than re-closing the terminal session
- align the wire error assertion with the public broker classification, preserving `cleanup_pending` authority on repeated delete

## Safety invariants
- never SIGKILL without stable verified identity
- never report deletion success while cleanup remains pending
- never remove exact detached artifacts without authorized cleanup evidence
- repeated delete preserves and replays uncertainty evidence

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/linux-proc.test.ts packages/coding-agent/test/acp-session-delete-wire.test.ts packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts packages/coding-agent/test/sdk-lifecycle-idempotency-restart.test.ts packages/coding-agent/test/sdk-acp-production-path.test.ts` — 144 pass, 719 assertions
- `bun --cwd=packages/coding-agent run check`

## Exact evidence
- lane base: `origin/dev` = `e566cd2a1ee80d01c0676d813b6310ef664d0a30`
- failing dev CI: run `31725430586`, shard-5 job `94540327176`, commit `a6a3974dcbb9dd50c890e9e86d29310a0dd2b9ce`
- independent of #4471 and merged #4494
