### PR TITLE
test(session): coordinate Cursor split publication

### DIFF
--- a/packages/coding-agent/test/agent-session-midrun-compaction.test.ts
+++ b/packages/coding-agent/test/agent-session-midrun-compaction.test.ts
@@ -253,7 +253,7 @@ describe("AgentSession mid-run compaction (issue #2035)", () => {
 		toolResultText?: string;
 		extensionSource?: string;
 		partialForStream?: (message: AssistantMessage) => AssistantMessage;
-
+		publishTextStartBeforeAfterStreamStart?: boolean;
 		afterStreamStart?: (options: Parameters<StreamFn>[2]) => Promise<void>;
 	}): Promise<{
 		session: AgentSession;
@@ -299,6 +299,10 @@ describe("AgentSession mid-run compaction (issue #2035)", () => {
 						const message = options.responder(call);
 						const partial = options.partialForStream?.(message) ?? message;
 						stream.push({ type: "start", partial });
+						if (options.publishTextStartBeforeAfterStreamStart) {
+							stream.push({ type: "text_start", contentIndex: 0, partial });
+							await stream.waitForConsumerDrain(streamOptions?.signal ?? new AbortController().signal);
+						}
 						await options.afterStreamStart?.(streamOptions);
 						stream.push({ type: "done", reason: message.stopReason as never, message });
 					})();
@@ -340,7 +344,7 @@ describe("AgentSession mid-run compaction (issue #2035)", () => {
 		for (const message of messages) {
 			session.agent.emitExternalEvent({ type: "message_end", message: message as never });
 		}
-		await Bun.sleep(10);
+		await session.awaitSessionSettlement();
 	}
 
 	async function seedPrunableLoop(session: AgentSession, count: number, toolCallPrefix: string): Promise<void> {
@@ -576,6 +580,7 @@ describe("AgentSession mid-run compaction (issue #2035)", () => {
 
 		const loop = await buildLoopSession({
 			extensionSource: shortCircuitExtensionSource(),
+			publishTextStartBeforeAfterStreamStart: true,
 			responder: call => {
 				if (call === 1) {
 					originalAnchor = assistantFor(model, {
@@ -634,9 +639,25 @@ describe("AgentSession mid-run compaction (issue #2035)", () => {
 
 			expect(originalAnchor).toBeDefined();
 			expect(loop.session.messages.includes(originalAnchor!)).toBe(false);
+			const cursorMessages = loop.agentEvents.flatMap(event => {
+				if (event.type !== "message_end") return [];
+				const content = JSON.stringify((event.message as { content?: unknown }).content ?? "");
+				return content.includes("Cursor") || content.includes("and continuation") ? [event.message] : [];
+			});
+			expect(cursorMessages.map(message => message.role)).toEqual(["assistant", "toolResult", "assistant"]);
+			expect(JSON.stringify((cursorMessages[0] as { content?: unknown } | undefined)?.content)).toContain(
+				"Cursor preamble",
+			);
+			expect(JSON.stringify((cursorMessages[1] as { content?: unknown } | undefined)?.content)).toContain(
+				"Cursor server-side result",
+			);
+			expect(JSON.stringify((cursorMessages[2] as { content?: unknown } | undefined)?.content)).toContain(
+				"and continuation",
+			);
 			expect(
 				loop.agentEvents.filter(event => event.type === "agent_end" && event.stopReason === "maintenance"),
 			).toHaveLength(1);
+			expect(loop.events.filter(event => event.type === "agent_end")).toHaveLength(1);
 			expect(loop.streamCallCount()).toBe(2);
 		} finally {
 			unsubscribeCursorStart();


### PR DESCRIPTION
## Summary

- publish a visible provider text event before the T3 Cursor fixture waits on the agent-side `message_start`
- drain that provider event explicitly before injecting the server-side Cursor tool result
- replace loop seeding sleeps with `awaitSessionSettlement()` and assert the canonical assistant → tool result → continuation split
- retain the existing 30s timeout and production compaction implementation unchanged

## Root cause

The fixture pushed only the provider `start` event and then awaited `cursorStart.promise`. `agent-loop` staged the resulting assistant `message_start` inside `ManagedAttemptTransaction` until either a visible text event or provider completion. Provider completion was itself blocked behind `afterStreamStart`, producing a circular wait:

`afterStreamStart → cursorStart → staged message_start → provider completion → afterStreamStart`

The explicit `text_start` plus `waitForConsumerDrain()` breaks that cycle at the real publication boundary and keeps abort/dispose governed by the provider signal.

## Verification

- focused file repeated 3x at existing 30s timeout: 18/18 each run
- focused file after final signed amend: 18/18, 100 assertions
- related maintenance/auto-compaction/EventStream suites: 36 passed, 3,133 assertions
- `bun --cwd=packages/coding-agent run check`: passed
- exact shard-2: T3 passed in exact order; full shard still running locally, with unrelated LSP trust flake reproduced green in isolation
- commit signature: good git signature, `hurrc04@gmail.com`

Closes #4505