### PR TITLE
fix(subagent): contain a throwing await progress consumer (#4465 follow-up)

### DIFF
--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -539,7 +539,7 @@ export class AsyncJobManager {
 	readonly #inFlightDeliveries: AsyncJobDelivery[] = [];
 	readonly #suppressedDeliveries = new Set<string>();
 	readonly #deliveryAckOwners = new Map<string, string>();
-	readonly #watchedJobs = new Set<string>();
+	readonly #watchedJobs = new Map<string, number>();
 	readonly #evictionTimers = new Map<string, NodeJS.Timeout>();
 	readonly #outputState = new Map<string, AsyncJobOutputState>();
 	readonly #ownerCleanups = new Map<string, Set<() => void>>();
@@ -2097,7 +2097,7 @@ export class AsyncJobManager {
 	watchJobs(jobIds: string[]): number {
 		const uniqueJobIds = Array.from(new Set(jobIds.map(id => id.trim()).filter(id => id.length > 0)));
 		for (const jobId of uniqueJobIds) {
-			this.#watchedJobs.add(jobId);
+			this.#watchedJobs.set(jobId, (this.#watchedJobs.get(jobId) ?? 0) + 1);
 		}
 		return uniqueJobIds.length;
 	}
@@ -2106,9 +2106,11 @@ export class AsyncJobManager {
 		const uniqueJobIds = Array.from(new Set(jobIds.map(id => id.trim()).filter(id => id.length > 0)));
 		let removed = 0;
 		for (const jobId of uniqueJobIds) {
-			if (this.#watchedJobs.delete(jobId)) {
+			const watchers = this.#watchedJobs.get(jobId) ?? 0;
+			if (watchers === 1) {
+				this.#watchedJobs.delete(jobId);
 				removed += 1;
-			}
+			} else if (watchers > 1) this.#watchedJobs.set(jobId, watchers - 1);
 		}
 		if (removed > 0) this.#ensureDeliveryLoop();
 		return removed;
@@ -2450,7 +2452,7 @@ export class AsyncJobManager {
 	}
 
 	isDeliverySuppressed(jobId: string, generation?: string): boolean {
-		return this.#isDeliveryAcknowledged(jobId, generation) || this.#watchedJobs.has(jobId);
+		return this.#isDeliveryAcknowledged(jobId, generation) || (this.#watchedJobs.get(jobId) ?? 0) > 0;
 	}
 
 	#pruneEvictedDeadLetters(): void {

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -2368,7 +2368,6 @@ export class AsyncJobManager {
 		this.#deadLetteredDeliveryOwners.delete(jobId);
 		this.#suppressedDeliveries.delete(jobId);
 		if (job) this.#publishedTerminalGenerations.delete(job.generation);
-		this.#watchedJobs.delete(jobId);
 		this.#outputState.delete(jobId);
 	}
 

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -344,6 +344,10 @@ export interface AsyncJobWaitHandle {
 	close(): void;
 }
 
+export interface AsyncJobWatchHandle {
+	close(): number;
+}
+
 interface TerminalEvent {
 	generation: string;
 	jobId: string | null;
@@ -540,6 +544,7 @@ export class AsyncJobManager {
 	readonly #suppressedDeliveries = new Set<string>();
 	readonly #deliveryAckOwners = new Map<string, string>();
 	readonly #watchedJobs = new Map<string, number>();
+	readonly #watchedGenerations = new Map<string, number>();
 	readonly #evictionTimers = new Map<string, NodeJS.Timeout>();
 	readonly #outputState = new Map<string, AsyncJobOutputState>();
 	readonly #ownerCleanups = new Map<string, Set<() => void>>();
@@ -2094,6 +2099,34 @@ export class AsyncJobManager {
 		return this.getDeliveryState(filter).queued > 0;
 	}
 
+	watchJobGenerations(jobIds: string[]): AsyncJobWatchHandle {
+		const uniqueJobIds = Array.from(new Set(jobIds.map(id => id.trim()).filter(id => id.length > 0)));
+		const generations: string[] = [];
+		for (const jobId of uniqueJobIds) {
+			const generation = this.#jobs.get(jobId)?.generation;
+			if (!generation) continue;
+			generations.push(generation);
+			this.#watchedGenerations.set(generation, (this.#watchedGenerations.get(generation) ?? 0) + 1);
+		}
+		let closed = false;
+		return {
+			close: () => {
+				if (closed) return 0;
+				closed = true;
+				let removed = 0;
+				for (const generation of generations) {
+					const watchers = this.#watchedGenerations.get(generation) ?? 0;
+					if (watchers === 1) {
+						this.#watchedGenerations.delete(generation);
+						removed += 1;
+					} else if (watchers > 1) this.#watchedGenerations.set(generation, watchers - 1);
+				}
+				if (removed > 0) this.#ensureDeliveryLoop();
+				return removed;
+			},
+		};
+	}
+
 	watchJobs(jobIds: string[]): number {
 		const uniqueJobIds = Array.from(new Set(jobIds.map(id => id.trim()).filter(id => id.length > 0)));
 		for (const jobId of uniqueJobIds) {
@@ -2295,6 +2328,7 @@ export class AsyncJobManager {
 		this.#deliveryAckOwners.clear();
 		this.#waitGenerationAliases.clear();
 		this.#watchedJobs.clear();
+		this.#watchedGenerations.clear();
 		this.#outputState.clear();
 		this.#ownerCleanups.clear();
 		this.#subagentRecords.clear();
@@ -2451,7 +2485,12 @@ export class AsyncJobManager {
 	}
 
 	isDeliverySuppressed(jobId: string, generation?: string): boolean {
-		return this.#isDeliveryAcknowledged(jobId, generation) || (this.#watchedJobs.get(jobId) ?? 0) > 0;
+		const watchedGeneration = generation ?? this.#jobs.get(jobId)?.generation;
+		return (
+			this.#isDeliveryAcknowledged(jobId, generation) ||
+			(this.#watchedJobs.get(jobId) ?? 0) > 0 ||
+			(watchedGeneration !== undefined && (this.#watchedGenerations.get(watchedGeneration) ?? 0) > 0)
+		);
 	}
 
 	#pruneEvictedDeadLetters(): void {

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@gajae-code/agent-core";
-import { prompt } from "@gajae-code/utils";
+import { formatDuration, logger, prompt } from "@gajae-code/utils";
 import * as z from "zod/v4";
 import { type AsyncJob, AsyncJobManager, jobElapsedMs, type SubagentRecord } from "../async";
 import subagentDescription from "../prompts/tools/subagent.md" with { type: "text" };
@@ -447,23 +447,47 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		const nowMs = this.#livenessNowMs ?? Date.now;
 		let lastEmitMs = nowMs();
 		let lastEmittedSignature: string | undefined;
+		let streamingDisabled = false;
+		let stopProgressTimer = (): void => {};
 		const emitIfChanged = (force: boolean): void => {
-			if (!onUpdate) return;
-			const result = this.#progressResult(manager, records, true);
-			const signature = subagentAwaitRenderedStateSignature(result.details?.subagents ?? []);
-			const t = nowMs();
-			const livenessDue = force || t - lastEmitMs >= livenessIntervalMs;
-			if (!livenessDue && signature === lastEmittedSignature) return;
-			lastEmittedSignature = signature;
-			lastEmitMs = t;
-			onUpdate(result);
+			if (!onUpdate || streamingDisabled) return;
+			try {
+				const result = this.#progressResult(manager, records, true);
+				const signature = subagentAwaitRenderedStateSignature(result.details?.subagents ?? []);
+				const t = nowMs();
+				const livenessDue = force || t - lastEmitMs >= livenessIntervalMs;
+				if (!livenessDue && signature === lastEmittedSignature) return;
+				lastEmittedSignature = signature;
+				lastEmitMs = t;
+				onUpdate(result);
+			} catch (error) {
+				// The liveness timer fires outside this function's promise chain, so a
+				// throwing progress consumer would otherwise escape `setInterval` as an
+				// uncaught exception, leave the wait's cleanup unreached, and let the
+				// interval keep firing and rethrowing for the rest of the await. Retire
+				// the streaming channel instead and keep waiting: losing progress output
+				// is recoverable, losing the timer and the watch registration is not.
+				streamingDisabled = true;
+				stopProgressTimer();
+				logger.warn("Subagent await progress update failed; streaming disabled for this wait", {
+					error: String(error),
+				});
+			}
 		};
-		const progressTimer =
-			onUpdate && heartbeatMs > 0 ? setInterval(() => emitIfChanged(false), heartbeatMs) : undefined;
-		emitIfChanged(true);
+		// The initial emission and the timer own process-lifetime resources together
+		// with the watch registration and the terminal-wait handle, so they all live
+		// inside one guarded span rather than straddling it.
+		let progressTimer: Timer | undefined;
 		let waitOutcome: "completed" | "timed_out_wait" | "interrupted";
 		let onAbort: (() => void) | undefined;
+		let terminalJobIds: string[] | undefined;
 		try {
+			progressTimer = onUpdate && heartbeatMs > 0 ? setInterval(() => emitIfChanged(false), heartbeatMs) : undefined;
+			stopProgressTimer = () => {
+				if (progressTimer) clearInterval(progressTimer);
+				progressTimer = undefined;
+			};
+			emitIfChanged(true);
 			const abortPromise = new Promise<"interrupted">(resolve => {
 				onAbort = () => resolve("interrupted");
 				if (signal?.aborted) onAbort();
@@ -477,14 +501,16 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 							Bun.sleep(timeoutMs).then(() => "timed_out_wait" as const),
 							abortPromise,
 						]);
+			if (waitOutcome === "completed") {
+				terminalJobIds = (await handle.result).terminalJobIds;
+				handle.acknowledge(terminalJobIds);
+			}
 		} finally {
 			if (signal && onAbort) signal.removeEventListener("abort", onAbort);
-			if (progressTimer) clearInterval(progressTimer);
+			stopProgressTimer();
+			manager.unwatchJobs(watchedJobIds);
+			handle.close();
 		}
-		const waitResult = waitOutcome === "completed" ? await handle.result : undefined;
-		if (waitOutcome === "completed") handle.acknowledge(waitResult?.terminalJobIds);
-		manager.unwatchJobs(watchedJobIds);
-		handle.close();
 		const awaitOutcome: SubagentAwaitOutcome =
 			waitOutcome === "completed" ? "completed" : waitOutcome === "timed_out_wait" ? "timed_out" : "interrupted";
 		const finalRecords = this.#visibleRecordsByIds(
@@ -501,7 +527,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			awaitOutcome,
 			waitOutcome,
 			condition,
-			terminalIds: waitResult?.terminalJobIds,
+			terminalIds: terminalJobIds,
 		});
 	}
 
@@ -603,11 +629,10 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		records: SubagentRecord[],
 		attachLiveProgress = false,
 	): AgentToolResult<SubagentToolDetails> {
+		const subagents = this.#recordSnapshots(manager, records, false, "receipt", new Set(), attachLiveProgress);
 		return {
-			content: [{ type: "text", text: "" }],
-			details: {
-				subagents: this.#recordSnapshots(manager, records, false, "receipt", new Set(), attachLiveProgress),
-			},
+			content: [{ type: "text", text: awaitProgressSummary(subagents) }],
+			details: { subagents },
 		};
 	}
 
@@ -853,6 +878,27 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			guidance,
 		};
 	}
+}
+
+/**
+ * Human-readable line for streamed `await` progress.
+ *
+ * Consumers that render structured content (ACP) previously received an empty
+ * text block here, which made `extractStructuredText` fail and the mapper fall
+ * back to serializing the whole result object as the human-readable content. A
+ * real sentence keeps the elapsed time legible there and in any log that only
+ * shows tool text.
+ */
+function awaitProgressSummary(subagents: readonly SubagentSnapshot[]): string {
+	const waiting = subagents.filter(snapshot => !isTerminalStatus(snapshot.status));
+	if (waiting.length === 0) return "";
+	// Accumulate rather than spreading into Math.max: explicit `ids` are not
+	// capped by MAX_LIST_LIMIT, so a large await would hit the argument limit.
+	let longestMs = 0;
+	for (const snapshot of waiting) if (snapshot.durationMs > longestMs) longestMs = snapshot.durationMs;
+	return `Awaiting ${waiting.length} subagent(s) for ${formatDuration(longestMs)}: ${waiting
+		.map(snapshot => snapshot.id)
+		.join(", ")}`;
 }
 
 function isTerminalStatus(status: SubagentStatus): boolean {

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -436,7 +436,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 			});
 		}
 		const watchedJobIds = targets.map(target => target.jobId).filter((jobId): jobId is string => jobId !== null);
-		manager.watchJobs(watchedJobIds);
+		const watchHandle = manager.watchJobGenerations(watchedJobIds);
 		const heartbeatMs = params.heartbeat_ms === undefined ? 500 : params.heartbeat_ms;
 		// Liveness interval: force a re-emit even when the rendered-state signature
 		// is stable so a healthy wait never looks like a hung session (#4465). The
@@ -521,7 +521,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		} finally {
 			if (signal && onAbort) signal.removeEventListener("abort", onAbort);
 			stopProgressTimer();
-			manager.unwatchJobs(watchedJobIds);
+			watchHandle.close();
 			handle.close();
 		}
 		const awaitOutcome: SubagentAwaitOutcome =

--- a/packages/coding-agent/src/tools/subagent.ts
+++ b/packages/coding-agent/src/tools/subagent.ts
@@ -449,6 +449,19 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 		let lastEmittedSignature: string | undefined;
 		let streamingDisabled = false;
 		let stopProgressTimer = (): void => {};
+		const disableStreaming = (error: unknown): void => {
+			if (streamingDisabled) return;
+			streamingDisabled = true;
+			stopProgressTimer();
+			try {
+				logger.warn("Subagent await progress update failed; streaming disabled for this wait", {
+					error: safeThrownValue(error),
+				});
+			} catch {
+				// Diagnostics must never turn a recoverable progress-channel failure
+				// into an await or process-lifecycle failure.
+			}
+		};
 		const emitIfChanged = (force: boolean): void => {
 			if (!onUpdate || streamingDisabled) return;
 			try {
@@ -459,7 +472,11 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 				if (!livenessDue && signature === lastEmittedSignature) return;
 				lastEmittedSignature = signature;
 				lastEmitMs = t;
-				onUpdate(result);
+				// A TypeScript void-return callback may still be implemented by an
+				// async function. Observe its runtime result so a rejected promise or
+				// thenable cannot become an unhandled rejection outside this span.
+				const updateResult = (onUpdate as (update: AgentToolResult<SubagentToolDetails>) => unknown)(result);
+				if (isPromiseLike(updateResult)) void Promise.resolve(updateResult).catch(disableStreaming);
 			} catch (error) {
 				// The liveness timer fires outside this function's promise chain, so a
 				// throwing progress consumer would otherwise escape `setInterval` as an
@@ -467,11 +484,7 @@ export class SubagentTool implements AgentTool<typeof subagentSchema, SubagentTo
 				// interval keep firing and rethrowing for the rest of the await. Retire
 				// the streaming channel instead and keep waiting: losing progress output
 				// is recoverable, losing the timer and the watch registration is not.
-				streamingDisabled = true;
-				stopProgressTimer();
-				logger.warn("Subagent await progress update failed; streaming disabled for this wait", {
-					error: String(error),
-				});
+				disableStreaming(error);
 			}
 		};
 		// The initial emission and the timer own process-lifetime resources together
@@ -899,6 +912,20 @@ function awaitProgressSummary(subagents: readonly SubagentSnapshot[]): string {
 	return `Awaiting ${waiting.length} subagent(s) for ${formatDuration(longestMs)}: ${waiting
 		.map(snapshot => snapshot.id)
 		.join(", ")}`;
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+	if ((typeof value !== "object" || value === null) && typeof value !== "function") return false;
+	return typeof (value as { then?: unknown }).then === "function";
+}
+
+function safeThrownValue(error: unknown): string {
+	try {
+		if (error instanceof Error) return error.message;
+		return String(error);
+	} catch {
+		return "[unprintable thrown value]";
+	}
 }
 
 function isTerminalStatus(status: SubagentStatus): boolean {

--- a/packages/coding-agent/test/async/owner-subagent-shutdown.test.ts
+++ b/packages/coding-agent/test/async/owner-subagent-shutdown.test.ts
@@ -397,6 +397,34 @@ describe("owner subagent shutdown leases", () => {
 		await manager.dispose();
 	});
 
+	test("retains delivery suppression until every watcher releases the job", async () => {
+		const delivered: string[] = [];
+		const manager = new AsyncJobManager({
+			onJobComplete: async jobId => {
+				delivered.push(jobId);
+			},
+			retentionMs: 60_000,
+		});
+		const gate = Promise.withResolvers<string>();
+		const jobId = manager.register("task", "multiply watched completion", async () => gate.promise, {
+			ownerId: "owner-a",
+			metadata: { subagent: { id: "multiply-watched", agent: "executor", agentSource: "bundled" } },
+		});
+		manager.watchJobs([jobId]);
+		manager.watchJobs([jobId]);
+		manager.unwatchJobs([jobId]);
+		gate.resolve("done while one watcher remains");
+		await manager.getJob(jobId)?.promise;
+		await Bun.sleep(10);
+		expect(manager.isDeliverySuppressed(jobId, manager.getJob(jobId)?.generation)).toBe(true);
+		expect(delivered).toEqual([]);
+
+		manager.unwatchJobs([jobId]);
+		await manager.drainDeliveries({ filter: { ownerId: "owner-a" }, timeoutMs: 100 });
+		expect(delivered).toEqual([jobId]);
+		await manager.dispose();
+	});
+
 	test("acknowledging another job preserves a watched completion", async () => {
 		const delivered: string[] = [];
 		const manager = new AsyncJobManager({

--- a/packages/coding-agent/test/async/owner-subagent-shutdown.test.ts
+++ b/packages/coding-agent/test/async/owner-subagent-shutdown.test.ts
@@ -425,6 +425,40 @@ describe("owner subagent shutdown leases", () => {
 		await manager.dispose();
 	});
 
+	test("retains every watch across immediate terminal eviction", async () => {
+		const delivered: string[] = [];
+		const manager = new AsyncJobManager({
+			onJobComplete: async jobId => {
+				delivered.push(jobId);
+			},
+			retentionMs: 0,
+		});
+		const gate = Promise.withResolvers<string>();
+		const jobId = manager.register("task", "immediately evicted watched completion", async () => gate.promise, {
+			ownerId: "owner-a",
+			metadata: { subagent: { id: "evicted-watched", agent: "executor", agentSource: "bundled" } },
+		});
+		const generation = manager.getJob(jobId)?.generation;
+		manager.watchJobs([jobId]);
+		manager.watchJobs([jobId]);
+		gate.resolve("done before eviction");
+		await manager.getJob(jobId)?.promise;
+		await Bun.sleep(10);
+		expect(manager.getJob(jobId)).toBeUndefined();
+		expect(manager.isDeliverySuppressed(jobId, generation)).toBe(true);
+		expect(delivered).toEqual([]);
+
+		manager.unwatchJobs([jobId]);
+		expect(manager.isDeliverySuppressed(jobId, generation)).toBe(true);
+		await Bun.sleep(10);
+		expect(delivered).toEqual([]);
+
+		manager.unwatchJobs([jobId]);
+		await manager.drainDeliveries({ filter: { ownerId: "owner-a" }, timeoutMs: 100 });
+		expect(delivered).toEqual([jobId]);
+		await manager.dispose();
+	});
+
 	test("acknowledging another job preserves a watched completion", async () => {
 		const delivered: string[] = [];
 		const manager = new AsyncJobManager({

--- a/packages/coding-agent/test/async/owner-subagent-shutdown.test.ts
+++ b/packages/coding-agent/test/async/owner-subagent-shutdown.test.ts
@@ -459,6 +459,43 @@ describe("owner subagent shutdown leases", () => {
 		await manager.dispose();
 	});
 
+	test("does not suppress a reused job id with an evicted generation watch", async () => {
+		const delivered: string[] = [];
+		const manager = new AsyncJobManager({
+			onJobComplete: async jobId => {
+				delivered.push(jobId);
+			},
+			retentionMs: 0,
+		});
+		const firstGate = Promise.withResolvers<string>();
+		const jobId = manager.register("task", "first generation", async () => firstGate.promise, {
+			id: "reused-watched-job",
+			ownerId: "owner-a",
+		});
+		const firstGeneration = manager.getJob(jobId)?.generation;
+		const firstWatch = manager.watchJobGenerations([jobId]);
+		firstGate.resolve("first done");
+		await manager.getJob(jobId)?.promise;
+		await Bun.sleep(10);
+		expect(manager.getJob(jobId)).toBeUndefined();
+		expect(manager.isDeliverySuppressed(jobId, firstGeneration)).toBe(true);
+
+		const secondJobId = manager.register("task", "second generation", async () => "second done", {
+			id: jobId,
+			ownerId: "owner-b",
+		});
+		const secondGeneration = manager.getJob(secondJobId)?.generation;
+		expect(secondGeneration).not.toBe(firstGeneration);
+		await manager.getJob(secondJobId)?.promise;
+		expect(await manager.drainDeliveries({ filter: { ownerId: "owner-b" }, timeoutMs: 100 })).toBe(true);
+		expect(delivered).toEqual([secondJobId]);
+
+		firstWatch.close();
+		expect(await manager.drainDeliveries({ filter: { ownerId: "owner-a" }, timeoutMs: 100 })).toBe(true);
+		expect(delivered).toEqual([secondJobId, jobId]);
+		await manager.dispose();
+	});
+
 	test("acknowledging another job preserves a watched completion", async () => {
 		const delivered: string[] = [];
 		const manager = new AsyncJobManager({

--- a/packages/coding-agent/test/tools/subagent-await-consumer-failure.test.ts
+++ b/packages/coding-agent/test/tools/subagent-await-consumer-failure.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { logger } from "@gajae-code/utils";
+import { AsyncJobManager, type SubagentRecord } from "../../src/async";
+import { Settings } from "../../src/config/settings";
+import { mapAgentSessionEventToAcpSessionUpdates } from "../../src/modes/acp/acp-event-mapper";
+import type { AgentSessionEvent } from "../../src/session/agent-session";
+import type { ToolSession } from "../../src/tools";
+import { SubagentTool } from "../../src/tools/subagent";
+
+function createSession(): ToolSession {
+	return {
+		cwd: "/tmp",
+		hasUI: false,
+		settings: Settings.isolated({}),
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		getAgentId: () => "0-Main",
+	} as ToolSession;
+}
+
+function createManager(): AsyncJobManager {
+	const manager = new AsyncJobManager({ onJobComplete: async () => {}, retentionMs: 10_000 });
+	AsyncJobManager.setInstance(manager);
+	return manager;
+}
+
+function runningRecord(subagentId: string, jobId: string): SubagentRecord {
+	return {
+		subagentId,
+		ownerId: "0-Main",
+		currentJobId: jobId,
+		historicalJobIds: [],
+		status: "running",
+		sessionFile: null,
+		resumable: false,
+	};
+}
+
+function addRunningChild(
+	manager: AsyncJobManager,
+	subagentId: string,
+): { jobId: string; gate: PromiseWithResolvers<string> } {
+	const gate = Promise.withResolvers<string>();
+	const jobId = manager.register("task", subagentId, async () => gate.promise, {
+		id: `job-${subagentId}`,
+		ownerId: "0-Main",
+		metadata: { subagent: { id: subagentId, agent: "executor", agentSource: "bundled" } },
+	});
+	manager.registerSubagentRecord(runningRecord(subagentId, jobId));
+	return { jobId, gate };
+}
+
+describe("subagent await progress consumer failure", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		AsyncJobManager.resetForTests();
+	});
+
+	it("contains a throwing consumer on the liveness timer instead of escaping it", async () => {
+		vi.useFakeTimers();
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const { jobId, gate } = addRunningChild(manager, "0-ThrowOnTick");
+		const observer = vi.fn();
+		// Containment is only honest if the failure is still reported, so the
+		// diagnostic is part of the contract rather than an implementation detail.
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const controller = new AbortController();
+		const awaiting = tool.execute(
+			"await-throw-on-tick",
+			{ action: "await", ids: ["0-ThrowOnTick"], timeout_ms: 3_600_000, heartbeat_ms: 500 },
+			controller.signal,
+			() => {
+				observer();
+				// Fail on a timer tick, not on the synchronous initial emission.
+				if (observer.mock.calls.length === 2) throw new Error("consumer failed");
+			},
+		);
+
+		try {
+			await Promise.resolve();
+			// A timer callback runs outside the wait's promise chain. Without
+			// containment at the emission site the throw escapes `setInterval`
+			// as an uncaught exception and the interval keeps rethrowing.
+			expect(() => vi.advanceTimersByTime(500 * 40)).not.toThrow();
+			expect(observer).toHaveBeenCalledTimes(2);
+			expect(warn).toHaveBeenCalledTimes(1);
+			expect(warn.mock.calls[0]?.[0]).toContain("streaming disabled");
+			expect(String(warn.mock.calls[0]?.[1]?.error)).toContain("consumer failed");
+
+			// The wait is untouched and still owns the child's delivery.
+			expect(manager.getJob(jobId)?.status).toBe("running");
+			controller.abort();
+			await awaiting;
+			// And it still releases everything on the way out.
+			expect(manager.getJob(jobId)?.status).toBe("running");
+			expect(manager.isDeliverySuppressed(jobId, manager.getJob(jobId)?.generation)).toBe(false);
+		} finally {
+			controller.abort();
+			gate.resolve("done");
+			await awaiting.catch(() => {});
+			await manager.getJob(jobId)?.promise;
+			await manager.dispose({ timeoutMs: 100 });
+			warn.mockRestore();
+		}
+	});
+
+	it("contains a throwing consumer on the initial emission and still releases the wait", async () => {
+		vi.useFakeTimers();
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const { jobId, gate } = addRunningChild(manager, "0-ThrowOnInitial");
+		const observer = vi.fn(() => {
+			throw new Error("initial consumer failed");
+		});
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+		// The initial emission runs before the wait's guarded span, so an
+		// uncontained throw here leaks the timer, the watch registration and the
+		// terminal-wait handle all at once.
+		const awaiting = tool.execute(
+			"await-throw-on-initial",
+			{ action: "await", ids: ["0-ThrowOnInitial"], timeout_ms: 5_000 },
+			undefined,
+			observer,
+		);
+		await Promise.resolve();
+		vi.advanceTimersByTime(5_000);
+		const result = await awaiting;
+
+		expect(result.details?.awaitOutcome).toBe("timed_out");
+		vi.advanceTimersByTime(180_000);
+		expect(observer).toHaveBeenCalledTimes(1);
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(manager.getJob(jobId)?.status).toBe("running");
+		expect(manager.isDeliverySuppressed(jobId, manager.getJob(jobId)?.generation)).toBe(false);
+
+		gate.resolve("done");
+		await manager.getJob(jobId)?.promise;
+		await manager.dispose({ timeoutMs: 100 });
+		warn.mockRestore();
+	});
+
+	it("streams a readable summary so ACP does not fall back to a serialized receipt", async () => {
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const { jobId, gate } = addRunningChild(manager, "0-AcpText");
+		const updates: Array<{ content: Array<{ type: string; text?: string }> }> = [];
+		const awaiting = tool.execute(
+			"await-acp-text",
+			{ action: "await", ids: ["0-AcpText"], timeout_ms: 50 },
+			undefined,
+			update => updates.push(update as { content: Array<{ type: string; text?: string }> }),
+		);
+		const partialResult = updates[0];
+		await awaiting;
+
+		const streamed = partialResult?.content.find(part => part.type === "text");
+		expect(streamed?.text).toContain("0-AcpText");
+
+		const notifications = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "tool_execution_update",
+				toolCallId: "call-1",
+				toolName: "subagent",
+				args: { action: "await", ids: ["0-AcpText"] },
+				partialResult,
+			} as AgentSessionEvent,
+			"session-1",
+		);
+		const update = notifications[0]?.update as { content?: Array<{ type: string; content?: { text?: string } }> };
+		const texts = (update.content ?? [])
+			.filter(item => item.type === "content")
+			.map(item => item.content?.text ?? "");
+		expect(texts.some(text => text.includes("0-AcpText"))).toBe(true);
+		// An empty text block makes extractStructuredText fail, so the mapper
+		// dumps the whole result object as the human-readable content instead.
+		expect(texts.some(text => text.includes('"subagents"'))).toBe(false);
+
+		gate.resolve("done");
+		await manager.getJob(jobId)?.promise;
+		await manager.dispose({ timeoutMs: 100 });
+	});
+});

--- a/packages/coding-agent/test/tools/subagent-await-consumer-failure.test.ts
+++ b/packages/coding-agent/test/tools/subagent-await-consumer-failure.test.ts
@@ -141,6 +141,163 @@ describe("subagent await progress consumer failure", () => {
 		warn.mockRestore();
 	});
 
+	it("contains a rejected initial emission without affecting the wait", async () => {
+		vi.useFakeTimers();
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const { jobId, gate } = addRunningChild(manager, "0-RejectOnInitial");
+		const observer = vi.fn(() => Promise.reject(new Error("initial rejection")));
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const controller = new AbortController();
+		const awaiting = tool.execute(
+			"await-reject-on-initial",
+			{ action: "await", ids: ["0-RejectOnInitial"], timeout_ms: 3_600_000, heartbeat_ms: 500 },
+			controller.signal,
+			observer,
+		);
+
+		await Promise.resolve();
+		await Promise.resolve();
+		vi.advanceTimersByTime(60_000);
+		expect(observer).toHaveBeenCalledTimes(1);
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0]?.[1]?.error).toBe("initial rejection");
+		expect(manager.getJob(jobId)?.status).toBe("running");
+
+		controller.abort();
+		await awaiting;
+		gate.resolve("done");
+		await manager.getJob(jobId)?.promise;
+		await manager.dispose({ timeoutMs: 100 });
+		warn.mockRestore();
+	});
+
+	it("contains a rejected timer emission and stops later progress", async () => {
+		vi.useFakeTimers();
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const { jobId, gate } = addRunningChild(manager, "0-RejectOnTick");
+		let calls = 0;
+		const observer = vi.fn(() => {
+			calls += 1;
+			return calls === 2 ? Promise.reject(new Error("timer rejection")) : undefined;
+		});
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const controller = new AbortController();
+		const awaiting = tool.execute(
+			"await-reject-on-tick",
+			{ action: "await", ids: ["0-RejectOnTick"], timeout_ms: 3_600_000, heartbeat_ms: 500 },
+			controller.signal,
+			observer,
+		);
+
+		await Promise.resolve();
+		vi.advanceTimersByTime(15_000);
+		await Promise.resolve();
+		await Promise.resolve();
+		vi.advanceTimersByTime(60_000);
+		expect(observer).toHaveBeenCalledTimes(2);
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0]?.[1]?.error).toBe("timer rejection");
+
+		controller.abort();
+		await awaiting;
+		gate.resolve("done");
+		await manager.getJob(jobId)?.promise;
+		await manager.dispose({ timeoutMs: 100 });
+		warn.mockRestore();
+	});
+
+	it("contains a hostile non-stringifiable thrown value", async () => {
+		vi.useFakeTimers();
+		const manager = createManager();
+		const tool = new SubagentTool(createSession());
+		const { jobId, gate } = addRunningChild(manager, "0-HostileThrow");
+		const hostile = Object.create(null) as { toString?: () => string };
+		hostile.toString = () => {
+			throw new Error("formatting escaped");
+		};
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const controller = new AbortController();
+		const awaiting = tool.execute(
+			"await-hostile-throw",
+			{ action: "await", ids: ["0-HostileThrow"], timeout_ms: 3_600_000 },
+			controller.signal,
+			() => {
+				throw hostile;
+			},
+		);
+
+		await Promise.resolve();
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0]?.[1]?.error).toBe("[unprintable thrown value]");
+		expect(manager.getJob(jobId)?.status).toBe("running");
+
+		controller.abort();
+		await awaiting;
+		gate.resolve("done");
+		await manager.getJob(jobId)?.promise;
+		await manager.dispose({ timeoutMs: 100 });
+		warn.mockRestore();
+	});
+
+	it("preserves sibling and future waits after one consumer rejects", async () => {
+		const delivered: string[] = [];
+		const manager = new AsyncJobManager({
+			onJobComplete: async jobId => {
+				delivered.push(jobId);
+			},
+			retentionMs: 10_000,
+		});
+		AsyncJobManager.setInstance(manager);
+		const tool = new SubagentTool(createSession());
+		const first = addRunningChild(manager, "0-SharedWait");
+		const failedController = new AbortController();
+		const siblingUpdates = vi.fn();
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const failedAwait = tool.execute(
+			"await-shared-failed",
+			{ action: "await", ids: ["0-SharedWait"], timeout_ms: 3_600_000 },
+			failedController.signal,
+			() => Promise.reject(new Error("isolated rejection")),
+		);
+		const siblingAwait = tool.execute(
+			"await-shared-sibling",
+			{ action: "await", ids: ["0-SharedWait"], timeout_ms: 3_600_000 },
+			undefined,
+			siblingUpdates,
+		);
+
+		await Promise.resolve();
+		await Promise.resolve();
+		failedController.abort();
+		await failedAwait;
+		expect(manager.isDeliverySuppressed(first.jobId, manager.getJob(first.jobId)?.generation)).toBe(true);
+		first.gate.resolve("shared done");
+		const siblingResult = await siblingAwait;
+		expect(siblingResult.details?.awaitOutcome).toBe("completed");
+		expect(delivered).toEqual([]);
+		expect(siblingUpdates).toHaveBeenCalled();
+
+		const future = addRunningChild(manager, "0-FutureWait");
+		const futureUpdates = vi.fn();
+		const futureAwait = tool.execute(
+			"await-future",
+			{ action: "await", ids: ["0-FutureWait"], timeout_ms: 3_600_000 },
+			undefined,
+			futureUpdates,
+		);
+		future.gate.resolve("future done");
+		const futureResult = await futureAwait;
+		expect(futureResult.details?.awaitOutcome).toBe("completed");
+		expect(futureUpdates).toHaveBeenCalled();
+		expect(delivered).toEqual([]);
+		expect(warn).toHaveBeenCalledTimes(1);
+
+		await manager.dispose({ timeoutMs: 100 });
+		warn.mockRestore();
+	});
+
 	it("streams a readable summary so ACP does not fall back to a serialized receipt", async () => {
 		const manager = createManager();
 		const tool = new SubagentTool(createSession());


### PR DESCRIPTION
## What

Two follow-up defects in the `subagent await` liveness path introduced by #4469.

1. **A throwing progress consumer escapes the liveness timer.** `emitIfChanged` calls `onUpdate(result)` with no guard, and it runs from inside `setInterval`. A consumer that throws therefore never propagates into `#awaitSubagents`: the wait's cleanup is never reached and the interval keeps firing and rethrowing for the rest of the await. At the default 500ms heartbeat a ten-minute wait produces on the order of a thousand uncaught exceptions.
2. **The streamed progress update carries no readable text.** `#progressResult` emits `{ type: "text", text: "" }`. An empty text block makes the ACP mapper's `extractStructuredText` fail, so `extractReadableText` falls through to `safeJsonStringify` and ACP clients render the entire result object as the human-readable content.

Also folded in, because it is the same failure surface: the initial forced emission and the timer sat outside the guarded span while `manager.unwatchJobs` and `handle.close` sat after it, so a throw on the very first emission leaked the timer, the watch registration and the terminal-wait handle at once.

## Why

Follow-up to #4465 / #4469. The liveness fix is sound and this PR does not change its design - the `AWAIT_LIVENESS_MIN_INTERVAL_MS` / multiplier cadence is untouched. These are two holes left in the surrounding path.

Reproduced against `origin/dev` before the fix:

```
error: consumer failed
  at emitIfChanged (packages/coding-agent/src/tools/subagent.ts:459:4)
  at <anonymous> (probe:73)      <- vi.advanceTimersByTime

D1 observerCalls=2
D3 firstStreamedText=""
```

The stack trace shows the throw leaving the timer callback and taking the surrounding operation with it.

## How

`emitIfChanged` now wraps its body. On a consumer throw it retires the streaming channel for that wait, stops the timer, and logs once at warn - the wait itself keeps waiting and settles normally. Losing progress output is recoverable; losing the timer and the watch registration is not.

The initial emission, the timer, the race, `unwatchJobs` and `handle.close` now live inside one `try`/`finally`, with `handle.acknowledge` still reached only for a completed wait.

`#progressResult` builds a short summary (`Awaiting N subagent(s) for <elapsed>: <ids>`) from the snapshots it already computes. It accumulates the maximum elapsed rather than spreading into `Math.max`, because explicit `ids` are not bounded by `MAX_LIST_LIMIT`.

The initial-emission throw is contained the same way as a tick throw rather than propagating, so one broken consumer behaves identically regardless of which tick it fires on. That is a deliberate behavior change and is covered by a test.

## Testing

New `packages/coding-agent/test/tools/subagent-await-consumer-failure.test.ts`, three tests, all verified failing on `origin/dev` before the fix (`0 pass / 3 fail`) and passing after (`3 pass / 0 fail`):

- a consumer that throws on a liveness tick is contained, warns once carrying the original error, does not fire again, leaves the child running, and releases delivery suppression on settle
- a consumer that throws on the initial emission is contained and the wait still settles by its own timeout
- the streamed payload carries readable text and the ACP mapper renders it as structured content rather than a serialized receipt

```
bun test packages/coding-agent/test/tools/subagent-await-consumer-failure.test.ts
3 pass / 0 fail

bun test packages/coding-agent/test/tools/ packages/coding-agent/test/modes/
2184 pass / 300 skip / 5 fail
```

The five failures are pre-existing on clean `origin/dev` (`2181 pass / 300 skip / 5 fail`): two in `issue-2643-openai-completions-wire.test.ts`, two in `skill-discovery.test.ts` (environment-dependent - it reads the operator's real `~/.gjc/agent/skills`), and one in `tool-catalog.test.ts`. The delta is exactly the three added tests, with no regressions.

`tsc` error sets are byte-identical between this branch and clean `origin/dev` (7 both sides, all worktree-environment artifacts from an unbuilt natives addon and a missing generated docs index). Zero new type errors.

### Unrelated pre-existing issue noticed

`tool-catalog.test.ts` fails on clean `origin/dev` - the committed `tool-catalog.generated.ts` is stale against the `task` tool description. Deliberately **not** fixed here to keep this PR scoped; it needs its own change.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:220fe7e5f2960a31c54f5ea58fb9a03871bbe03eade7bfd79fc78cc3173e89f1 reviewer:human reviewer-id:Yeachan-Heo evidence:local:latest-dev-four-file-generation-watch-validation
```

Exact head: `088566601545dbb55161c268242a5040d334085b`  
Exact base: `7af9f0f401153b57343b94a53c3d6da035a8c9d2`

The PR diff remains exactly the four authorized async/subagent files. Fresh current-base focused verification covers progress consumer failures and generation-bound watch lifecycle: 94/94 tests passed and coding-agent check/types passed.

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] Verdict matches the exact PR head

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
