### PR TITLE
fix(auth): align multi-account test authorities

### DIFF
--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -239,6 +239,10 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 		"internal profile and fallback-chain state, not a user-facing SDK control seam",
 	"agent_session:setDefaultFallbackRuntimeModel":
 		"internal fallback runtime bookkeeping, not a user-facing SDK control seam",
+	"agent_session:setCredentialPin":
+		"interactive session-scoped OAuth account selector mutation behind the locked /credential and OAuth selector surfaces; the public SDK has no credential-selection operation and must not gain credential authority implicitly",
+	"agent_session:setCredentialAuto":
+		"interactive session-scoped OAuth AUTO-ranking mutation behind the locked /credential and OAuth selector surfaces; the public SDK has no credential-selection operation and must not gain credential authority implicitly",
 	"agent_session:seedDefaultFallbackResolution":
 		"internal fallback resolution bookkeeping, not a user-facing SDK control seam",
 	"agent_session:syncEagerDelegation":

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -3123,6 +3123,28 @@
 		}
 	},
 	{
+		"sourceId": "agent_session:setCredentialPin",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "interactive session-scoped OAuth account selector mutation behind the locked /credential and OAuth selector surfaces; the public SDK has no credential-selection operation and must not gain credential authority implicitly",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
+		"sourceId": "agent_session:setCredentialAuto",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "interactive session-scoped OAuth AUTO-ranking mutation behind the locked /credential and OAuth selector surfaces; the public SDK has no credential-selection operation and must not gain credential authority implicitly",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
 		"sourceId": "agent_session:getPlanModeState",
 		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
 		"sourceKind": "agent_session",

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, spyOn } from "bun:test";
 import { type AgentMessage, ThinkingLevel } from "@gajae-code/agent-core";
-import type { Usage } from "@gajae-code/ai";
+import type { CachedUsageReport, CredentialInventoryRecord, Usage } from "@gajae-code/ai";
 import { Settings } from "../src/config/settings";
 import { createMemoryBackendService } from "../src/memory-backend";
 import { getThemeByName, setThemeInstance, theme } from "../src/modes/theme/theme";
@@ -90,11 +90,8 @@ interface FakeAcpBuiltinSession {
 function createRuntime() {
 	const output: string[] = [];
 	const settings = Settings.isolated();
-	let credentialInventory: ReturnType<AgentSession["modelRegistry"]["authStorage"]["listCredentialInventory"]> = [];
-	const cachedUsage = new Map<
-		number,
-		ReturnType<AgentSession["modelRegistry"]["authStorage"]["getCachedUsageReport"]>
-	>();
+	let credentialInventory: CredentialInventoryRecord[] = [];
+	const cachedUsage = new Map<number, CachedUsageReport | undefined>();
 	const activeCredentialRows = new Map<string, number>();
 	const authStorage = {
 		listCredentialInventory: () => credentialInventory,
@@ -262,10 +259,7 @@ function createRuntime() {
 		fakeSessionManager,
 		setAccountInventory(
 			inventory: typeof credentialInventory,
-			usageByCredentialId: ReadonlyMap<
-				number,
-				NonNullable<ReturnType<AgentSession["modelRegistry"]["authStorage"]["getCachedUsageReport"]>>
-			>,
+			usageByCredentialId: ReadonlyMap<number, CachedUsageReport>,
 			activeRows: ReadonlyMap<string, number> = new Map(),
 		): void {
 			credentialInventory = inventory;

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -95,13 +95,14 @@ function createRuntime() {
 		number,
 		ReturnType<AgentSession["modelRegistry"]["authStorage"]["getCachedUsageReport"]>
 	>();
+	const activeCredentialRows = new Map<string, number>();
 	const authStorage = {
 		listCredentialInventory: () => credentialInventory,
 		listCredentialRemovalTargets: () => [],
 		getGeneration: () => 0,
 		getCachedCredentialHealth: () => ({ status: "unknown", reason: null }),
 		getCachedUsageReport: (_provider: string, credentialId: number) => cachedUsage.get(credentialId),
-		getSessionCredentialRowId: () => undefined,
+		getSessionCredentialRowId: (provider: string) => activeCredentialRows.get(provider),
 		hasRuntimeApiKey: () => false,
 		hasConfigApiKey: () => false,
 		getEffectiveCredentialType: () => undefined,
@@ -259,13 +260,19 @@ function createRuntime() {
 		output,
 		session,
 		fakeSessionManager,
-		setAccountUsage(
+		setAccountInventory(
 			inventory: typeof credentialInventory,
-			usage: NonNullable<ReturnType<AgentSession["modelRegistry"]["authStorage"]["getCachedUsageReport"]>>,
+			usageByCredentialId: ReadonlyMap<
+				number,
+				NonNullable<ReturnType<AgentSession["modelRegistry"]["authStorage"]["getCachedUsageReport"]>>
+			>,
+			activeRows: ReadonlyMap<string, number> = new Map(),
 		): void {
 			credentialInventory = inventory;
 			cachedUsage.clear();
-			for (const row of inventory) cachedUsage.set(row.id, usage);
+			for (const [credentialId, usage] of usageByCredentialId) cachedUsage.set(credentialId, usage);
+			activeCredentialRows.clear();
+			for (const [provider, credentialId] of activeRows) activeCredentialRows.set(provider, credentialId);
 		},
 		runtime: {
 			session: typedSession,
@@ -353,9 +360,9 @@ describe("ACP builtin slash commands", () => {
 	});
 
 	it("renders provider usage reports when the session can fetch them", async () => {
-		const { output, runtime, setAccountUsage } = createRuntime();
+		const { output, runtime, setAccountInventory } = createRuntime();
 		const now = Date.now();
-		setAccountUsage(
+		setAccountInventory(
 			[
 				{
 					id: 1,
@@ -365,27 +372,63 @@ describe("ACP builtin slash commands", () => {
 					disabled: false,
 					disabledCause: null,
 				},
-			],
-			{
-				report: {
+				{
+					id: 2,
 					provider: "openai-codex",
-					fetchedAt: now,
-					limits: [
-						{
-							id: "codex-5h",
-							label: "5 hours",
-							scope: { provider: "openai-codex", tier: "prolite", accountId: "account-1" },
-							window: { id: "5h", label: "5 hours", resetsAt: now + 60 * 60 * 1000 },
-							amount: { used: 0.24, usedFraction: 0.24, unit: "unknown" },
-						},
-					],
-					metadata: { email: "user@example.com" },
+					credentialKind: "oauth",
+					identityLabel: "selected@example.com",
+					disabled: false,
+					disabledCause: null,
 				},
-				fetchedAt: now,
-				freshUntil: now + 60_000,
-				retainUntil: now + 86_400_000,
-				freshness: "fresh",
-			},
+			],
+			new Map([
+				[
+					1,
+					{
+						report: {
+							provider: "openai-codex",
+							fetchedAt: now,
+							limits: [
+								{
+									id: "codex-5h",
+									label: "5 hours",
+									scope: { provider: "openai-codex", tier: "prolite", accountId: "account-1" },
+									window: { id: "5h", label: "5 hours", resetsAt: now + 60 * 60 * 1000 },
+									amount: { used: 0.24, usedFraction: 0.24, unit: "unknown" },
+								},
+							],
+							metadata: { email: "user@example.com" },
+						},
+						fetchedAt: now,
+						freshUntil: now + 60_000,
+						retainUntil: now + 86_400_000,
+						freshness: "fresh",
+					},
+				],
+				[
+					2,
+					{
+						report: {
+							provider: "openai-codex",
+							fetchedAt: now,
+							limits: [
+								{
+									id: "codex-weekly",
+									label: "Weekly",
+									scope: { provider: "openai-codex", accountId: "account-2" },
+									amount: { used: 2, usedFraction: 0.02, unit: "requests" },
+								},
+							],
+							metadata: { email: "selected@example.com" },
+						},
+						fetchedAt: now,
+						freshUntil: now + 60_000,
+						retainUntil: now + 86_400_000,
+						freshness: "fresh",
+					},
+				],
+			]),
+			new Map([["openai-codex", 2]]),
 		);
 
 		const result = await executeAcpBuiltinSlashCommand("/usage", runtime);
@@ -394,12 +437,24 @@ describe("ACP builtin slash commands", () => {
 		expect(output[0]).toContain("openai-codex:stored:1");
 		expect(output[0]).toContain("user@example.com");
 		expect(output[0]).toContain("5 hours: 0.24 unknown used (76.0% left)");
+		expect(output[0]).toContain("openai-codex:stored:2");
+		expect(output[0]).toContain("selected@example.com [active]");
+		expect(output[0]).toContain("Weekly: 2.00 requests used (98.0% left)");
+	});
+
+	it("renders the deterministic empty stored-account inventory without probing", async () => {
+		const { output, runtime } = createRuntime();
+
+		await expect(executeAcpBuiltinSlashCommand("/usage", runtime)).resolves.toEqual({ consumed: true });
+
+		expect(output[0]).toContain("Accounts (cache only)");
+		expect(output[0]).not.toContain(":stored:");
 	});
 
 	it("keeps one fallback account identity across multiple quota windows in one report", async () => {
-		const { output, runtime, setAccountUsage } = createRuntime();
+		const { output, runtime, setAccountInventory } = createRuntime();
 		const now = Date.now();
-		setAccountUsage(
+		setAccountInventory(
 			[
 				{
 					id: 1,
@@ -410,33 +465,38 @@ describe("ACP builtin slash commands", () => {
 					disabledCause: null,
 				},
 			],
-			{
-				report: {
-					provider: "grok-build",
-					fetchedAt: now,
-					limits: [
-						{
-							id: "grok-build:7d",
-							label: "SuperGrok monthly credits",
-							scope: { provider: "grok-build", windowId: "7d" },
-							window: { id: "7d", label: "Monthly credits", resetsAt: now + 20 * 86400_000 },
-							amount: { used: 25, usedFraction: 0.25, unit: "percent" },
+			new Map([
+				[
+					1,
+					{
+						report: {
+							provider: "grok-build",
+							fetchedAt: now,
+							limits: [
+								{
+									id: "grok-build:7d",
+									label: "SuperGrok monthly credits",
+									scope: { provider: "grok-build", windowId: "7d" },
+									window: { id: "7d", label: "Monthly credits", resetsAt: now + 20 * 86400_000 },
+									amount: { used: 25, usedFraction: 0.25, unit: "percent" },
+								},
+								{
+									id: "grok-build:weekly",
+									label: "SuperGrok weekly credits",
+									scope: { provider: "grok-build", windowId: "weekly" },
+									window: { id: "weekly", label: "Weekly", resetsAt: now + 6 * 86400_000 },
+									amount: { used: 6, usedFraction: 0.06, unit: "percent" },
+								},
+							],
+							metadata: {},
 						},
-						{
-							id: "grok-build:weekly",
-							label: "SuperGrok weekly credits",
-							scope: { provider: "grok-build", windowId: "weekly" },
-							window: { id: "weekly", label: "Weekly", resetsAt: now + 6 * 86400_000 },
-							amount: { used: 6, usedFraction: 0.06, unit: "percent" },
-						},
-					],
-					metadata: {},
-				},
-				fetchedAt: now,
-				freshUntil: now + 60_000,
-				retainUntil: now + 86_400_000,
-				freshness: "fresh",
-			},
+						fetchedAt: now,
+						freshUntil: now + 60_000,
+						retainUntil: now + 86_400_000,
+						freshness: "fresh",
+					},
+				],
+			]),
 		);
 
 		await expect(executeAcpBuiltinSlashCommand("/usage", runtime)).resolves.toEqual({ consumed: true });
@@ -1477,9 +1537,9 @@ describe("wave 5 — adapters and polish", () => {
 
 	// /usage bar character
 	it("/usage: includes bar character when usedFraction is 0.5", async () => {
-		const { output, runtime, setAccountUsage } = createRuntime();
+		const { output, runtime, setAccountInventory } = createRuntime();
 		const now = Date.now();
-		setAccountUsage(
+		setAccountInventory(
 			[
 				{
 					id: 1,
@@ -1490,26 +1550,31 @@ describe("wave 5 — adapters and polish", () => {
 					disabledCause: null,
 				},
 			],
-			{
-				report: {
-					provider: "test-provider",
-					fetchedAt: now,
-					limits: [
-						{
-							id: "test-limit",
-							label: "Monthly",
-							scope: { provider: "test-provider", tier: "pro", accountId: "acct-1" },
-							window: { id: "monthly", label: "monthly", resetsAt: now + 30 * 86400_000 },
-							amount: { used: 50, usedFraction: 0.5, unit: "requests" },
+			new Map([
+				[
+					1,
+					{
+						report: {
+							provider: "test-provider",
+							fetchedAt: now,
+							limits: [
+								{
+									id: "test-limit",
+									label: "Monthly",
+									scope: { provider: "test-provider", tier: "pro", accountId: "acct-1" },
+									window: { id: "monthly", label: "monthly", resetsAt: now + 30 * 86400_000 },
+									amount: { used: 50, usedFraction: 0.5, unit: "requests" },
+								},
+							],
+							metadata: {},
 						},
-					],
-					metadata: {},
-				},
-				fetchedAt: now,
-				freshUntil: now + 60_000,
-				retainUntil: now + 86_400_000,
-				freshness: "fresh",
-			},
+						fetchedAt: now,
+						freshUntil: now + 60_000,
+						retainUntil: now + 86_400_000,
+						freshness: "fresh",
+					},
+				],
+			]),
 		);
 		const result = await executeAcpBuiltinSlashCommand("/usage", runtime);
 		expect(result).toEqual({ consumed: true });

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -477,9 +477,16 @@ describe("ACP builtin slash commands", () => {
 
 	it("renders the deterministic empty stored-account inventory without probing", async () => {
 		const { output, runtime } = createRuntime();
+		runtime.session.fetchUsageReports = async () => {
+			throw new Error("plain /usage must not probe providers");
+		};
+		const fetchUsageReports = spyOn(runtime.session, "fetchUsageReports").mockRejectedValue(
+			new Error("plain /usage must not probe providers"),
+		);
 
 		await expect(executeAcpBuiltinSlashCommand("/usage", runtime)).resolves.toEqual({ consumed: true });
 
+		expect(fetchUsageReports).not.toHaveBeenCalled();
 		expect(output[0]).toContain("Accounts (cache only)");
 		expect(output[0]).not.toContain(":stored:");
 	});

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -47,6 +47,7 @@ interface FakeAcpBuiltinSession {
 	getLastAssistantText: () => string | undefined;
 	messages: unknown[];
 	modelRegistry: {
+		authStorage: AgentSession["modelRegistry"]["authStorage"];
 		getApiKey(model: { provider: string; id: string }, sessionId?: string): Promise<string | undefined>;
 		resolveCanonicalModel?: (
 			canonicalId: string,
@@ -89,6 +90,24 @@ interface FakeAcpBuiltinSession {
 function createRuntime() {
 	const output: string[] = [];
 	const settings = Settings.isolated();
+	let credentialInventory: ReturnType<AgentSession["modelRegistry"]["authStorage"]["listCredentialInventory"]> = [];
+	const cachedUsage = new Map<
+		number,
+		ReturnType<AgentSession["modelRegistry"]["authStorage"]["getCachedUsageReport"]>
+	>();
+	const authStorage = {
+		listCredentialInventory: () => credentialInventory,
+		listCredentialRemovalTargets: () => [],
+		getGeneration: () => 0,
+		getCachedCredentialHealth: () => ({ status: "unknown", reason: null }),
+		getCachedUsageReport: (_provider: string, credentialId: number) => cachedUsage.get(credentialId),
+		getSessionCredentialRowId: () => undefined,
+		hasRuntimeApiKey: () => false,
+		hasConfigApiKey: () => false,
+		getEffectiveCredentialType: () => undefined,
+		peekCachedCredentialHealthForSource: () => ({ status: "unknown", reason: null }),
+		recordCredentialHealthForSource: () => {},
+	} as unknown as AgentSession["modelRegistry"]["authStorage"];
 	const session: FakeAcpBuiltinSession = {
 		memoryBackend: createMemoryBackendService(settings),
 		fastMode: false,
@@ -158,6 +177,7 @@ function createRuntime() {
 		getLastAssistantText: () => undefined,
 		messages: [],
 		modelRegistry: {
+			authStorage,
 			async getApiKey(_model: { provider: string; id: string }, _sessionId?: string) {
 				return "test-api-key";
 			},
@@ -179,7 +199,6 @@ function createRuntime() {
 		},
 		async refreshSshTool(_options?: { activateIfAvailable?: boolean }) {},
 	};
-	const typedSession = session as unknown as AgentSession & FakeAcpBuiltinSession;
 	const fakeSessionManager = {
 		_sessionFile: undefined as string | undefined,
 		_cwd: "/tmp/project",
@@ -233,10 +252,21 @@ function createRuntime() {
 			return true;
 		},
 	};
+	const typedSession = Object.assign(session, {
+		sessionManager: fakeSessionManager as unknown as SessionManager,
+	}) as unknown as AgentSession & FakeAcpBuiltinSession;
 	return {
 		output,
 		session,
 		fakeSessionManager,
+		setAccountUsage(
+			inventory: typeof credentialInventory,
+			usage: NonNullable<ReturnType<AgentSession["modelRegistry"]["authStorage"]["getCachedUsageReport"]>>,
+		): void {
+			credentialInventory = inventory;
+			cachedUsage.clear();
+			for (const row of inventory) cachedUsage.set(row.id, usage);
+		},
 		runtime: {
 			session: typedSession,
 			sessionManager: fakeSessionManager as unknown as SessionManager,
@@ -323,63 +353,97 @@ describe("ACP builtin slash commands", () => {
 	});
 
 	it("renders provider usage reports when the session can fetch them", async () => {
-		const { output, runtime } = createRuntime();
-		runtime.session.fetchUsageReports = async () => [
+		const { output, runtime, setAccountUsage } = createRuntime();
+		const now = Date.now();
+		setAccountUsage(
+			[
+				{
+					id: 1,
+					provider: "openai-codex",
+					credentialKind: "oauth",
+					identityLabel: "user@example.com",
+					disabled: false,
+					disabledCause: null,
+				},
+			],
 			{
-				provider: "openai-codex",
-				fetchedAt: Date.now(),
-				limits: [
-					{
-						id: "codex-5h",
-						label: "5 hours",
-						scope: { provider: "openai-codex", tier: "prolite", accountId: "account-1" },
-						window: { id: "5h", label: "5 hours", resetsAt: Date.now() + 60 * 60 * 1000 },
-						amount: { used: 0.24, usedFraction: 0.24, unit: "unknown" },
-					},
-				],
-				metadata: { email: "user@example.com" },
+				report: {
+					provider: "openai-codex",
+					fetchedAt: now,
+					limits: [
+						{
+							id: "codex-5h",
+							label: "5 hours",
+							scope: { provider: "openai-codex", tier: "prolite", accountId: "account-1" },
+							window: { id: "5h", label: "5 hours", resetsAt: now + 60 * 60 * 1000 },
+							amount: { used: 0.24, usedFraction: 0.24, unit: "unknown" },
+						},
+					],
+					metadata: { email: "user@example.com" },
+				},
+				fetchedAt: now,
+				freshUntil: now + 60_000,
+				retainUntil: now + 86_400_000,
+				freshness: "fresh",
 			},
-		];
+		);
 
 		const result = await executeAcpBuiltinSlashCommand("/usage", runtime);
 
 		expect(result).toEqual({ consumed: true });
-		expect(output[0]).toContain("Openai Codex");
-		expect(output[0]).toContain("5 hours (prolite)");
-		expect(output[0]).toContain("user@example.com: 0.24 unknown used (76.0% left)");
-		expect(output[0]).toContain("resets in");
+		expect(output[0]).toContain("openai-codex:stored:1");
+		expect(output[0]).toContain("user@example.com");
+		expect(output[0]).toContain("5 hours: 0.24 unknown used (76.0% left)");
 	});
 
 	it("keeps one fallback account identity across multiple quota windows in one report", async () => {
-		const { output, runtime } = createRuntime();
-		runtime.session.fetchUsageReports = async () => [
+		const { output, runtime, setAccountUsage } = createRuntime();
+		const now = Date.now();
+		setAccountUsage(
+			[
+				{
+					id: 1,
+					provider: "grok-build",
+					credentialKind: "oauth",
+					identityLabel: "account 1",
+					disabled: false,
+					disabledCause: null,
+				},
+			],
 			{
-				provider: "grok-build",
-				fetchedAt: Date.now(),
-				limits: [
-					{
-						id: "grok-build:7d",
-						label: "SuperGrok monthly credits",
-						scope: { provider: "grok-build", windowId: "7d" },
-						window: { id: "7d", label: "Monthly credits", resetsAt: Date.now() + 20 * 86400_000 },
-						amount: { used: 25, usedFraction: 0.25, unit: "percent" },
-					},
-					{
-						id: "grok-build:weekly",
-						label: "SuperGrok weekly credits",
-						scope: { provider: "grok-build", windowId: "weekly" },
-						window: { id: "weekly", label: "Weekly", resetsAt: Date.now() + 6 * 86400_000 },
-						amount: { used: 6, usedFraction: 0.06, unit: "percent" },
-					},
-				],
-				metadata: {},
+				report: {
+					provider: "grok-build",
+					fetchedAt: now,
+					limits: [
+						{
+							id: "grok-build:7d",
+							label: "SuperGrok monthly credits",
+							scope: { provider: "grok-build", windowId: "7d" },
+							window: { id: "7d", label: "Monthly credits", resetsAt: now + 20 * 86400_000 },
+							amount: { used: 25, usedFraction: 0.25, unit: "percent" },
+						},
+						{
+							id: "grok-build:weekly",
+							label: "SuperGrok weekly credits",
+							scope: { provider: "grok-build", windowId: "weekly" },
+							window: { id: "weekly", label: "Weekly", resetsAt: now + 6 * 86400_000 },
+							amount: { used: 6, usedFraction: 0.06, unit: "percent" },
+						},
+					],
+					metadata: {},
+				},
+				fetchedAt: now,
+				freshUntil: now + 60_000,
+				retainUntil: now + 86_400_000,
+				freshness: "fresh",
 			},
-		];
+		);
 
 		await expect(executeAcpBuiltinSlashCommand("/usage", runtime)).resolves.toEqual({ consumed: true });
 
-		expect(output[0]?.match(/account 1:/g)).toHaveLength(2);
-		expect(output[0]).not.toContain("account 2:");
+		expect(output[0]?.match(/account 1/g)).toHaveLength(1);
+		expect(output[0]).toContain("SuperGrok monthly credits");
+		expect(output[0]).toContain("SuperGrok weekly credits");
 	});
 
 	it("returns false for unknown commands", async () => {
@@ -1413,26 +1477,43 @@ describe("wave 5 — adapters and polish", () => {
 
 	// /usage bar character
 	it("/usage: includes bar character when usedFraction is 0.5", async () => {
-		const { output, runtime } = createRuntime();
-		runtime.session.fetchUsageReports = async () => [
+		const { output, runtime, setAccountUsage } = createRuntime();
+		const now = Date.now();
+		setAccountUsage(
+			[
+				{
+					id: 1,
+					provider: "test-provider",
+					credentialKind: "oauth",
+					identityLabel: null,
+					disabled: false,
+					disabledCause: null,
+				},
+			],
 			{
-				provider: "test-provider",
-				fetchedAt: Date.now(),
-				limits: [
-					{
-						id: "test-limit",
-						label: "Monthly",
-						scope: { provider: "test-provider", tier: "pro", accountId: "acct-1" },
-						window: { id: "monthly", label: "monthly", resetsAt: Date.now() + 30 * 86400_000 },
-						amount: { used: 50, usedFraction: 0.5, unit: "requests" },
-					},
-				],
-				metadata: {},
+				report: {
+					provider: "test-provider",
+					fetchedAt: now,
+					limits: [
+						{
+							id: "test-limit",
+							label: "Monthly",
+							scope: { provider: "test-provider", tier: "pro", accountId: "acct-1" },
+							window: { id: "monthly", label: "monthly", resetsAt: now + 30 * 86400_000 },
+							amount: { used: 50, usedFraction: 0.5, unit: "requests" },
+						},
+					],
+					metadata: {},
+				},
+				fetchedAt: now,
+				freshUntil: now + 60_000,
+				retainUntil: now + 86_400_000,
+				freshness: "fresh",
 			},
-		];
+		);
 		const result = await executeAcpBuiltinSlashCommand("/usage", runtime);
 		expect(result).toEqual({ consumed: true });
-		expect(output[0]).toContain("█");
+		expect(output[0]).toContain("Monthly: 50.00 requests used (50.0% left)");
 	});
 
 	// /context breakdown

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -16,6 +16,7 @@ interface FakeAcpBuiltinSession {
 	isStreaming: boolean;
 	sessionFile: string | undefined;
 	sessionId: string;
+	credentialSessionId: string;
 	sessionName: string;
 	_todoPhases: Array<{ name: string; tasks: Array<{ content: string; status: string }> }>;
 	thinkingLevel: ThinkingLevel | undefined;
@@ -99,7 +100,8 @@ function createRuntime() {
 		getGeneration: () => 0,
 		getCachedCredentialHealth: () => ({ status: "unknown", reason: null }),
 		getCachedUsageReport: (_provider: string, credentialId: number) => cachedUsage.get(credentialId),
-		getSessionCredentialRowId: (provider: string) => activeCredentialRows.get(provider),
+		getSessionCredentialRowId: (provider: string, sessionId?: string) =>
+			activeCredentialRows.get(`${sessionId ?? ""}\u0000${provider}`),
 		hasRuntimeApiKey: () => false,
 		hasConfigApiKey: () => false,
 		getEffectiveCredentialType: () => undefined,
@@ -113,6 +115,7 @@ function createRuntime() {
 		isStreaming: false,
 		sessionFile: undefined,
 		sessionId: "fake-session-id",
+		credentialSessionId: "fake-credential-session-id",
 		sessionName: "Fake Session",
 		_todoPhases: [],
 		thinkingLevel: ThinkingLevel.Low,
@@ -266,7 +269,8 @@ function createRuntime() {
 			cachedUsage.clear();
 			for (const [credentialId, usage] of usageByCredentialId) cachedUsage.set(credentialId, usage);
 			activeCredentialRows.clear();
-			for (const [provider, credentialId] of activeRows) activeCredentialRows.set(provider, credentialId);
+			for (const [scopeAndProvider, credentialId] of activeRows)
+				activeCredentialRows.set(scopeAndProvider, credentialId);
 		},
 		runtime: {
 			session: typedSession,
@@ -422,7 +426,7 @@ describe("ACP builtin slash commands", () => {
 					},
 				],
 			]),
-			new Map([["openai-codex", 2]]),
+			new Map([["fake-credential-session-id\u0000openai-codex", 2]]),
 		);
 
 		const result = await executeAcpBuiltinSlashCommand("/usage", runtime);
@@ -434,6 +438,41 @@ describe("ACP builtin slash commands", () => {
 		expect(output[0]).toContain("openai-codex:stored:2");
 		expect(output[0]).toContain("selected@example.com [active]");
 		expect(output[0]).toContain("Weekly: 2.00 requests used (98.0% left)");
+	});
+
+	it("does not cross-label active accounts between credential sessions or providers", async () => {
+		const { output, runtime, session, setAccountInventory } = createRuntime();
+		setAccountInventory(
+			[
+				{
+					id: 1,
+					provider: "openai-codex",
+					credentialKind: "oauth",
+					identityLabel: "codex@example.com",
+					disabled: false,
+					disabledCause: null,
+				},
+				{
+					id: 2,
+					provider: "anthropic",
+					credentialKind: "oauth",
+					identityLabel: "claude@example.com",
+					disabled: false,
+					disabledCause: null,
+				},
+			],
+			new Map(),
+			new Map([
+				["other-session\u0000openai-codex", 1],
+				["fake-credential-session-id\u0000anthropic", 2],
+			]),
+		);
+
+		await expect(executeAcpBuiltinSlashCommand("/usage", runtime)).resolves.toEqual({ consumed: true });
+
+		expect(session.credentialSessionId).toBe("fake-credential-session-id");
+		expect(output[0]).not.toContain("codex@example.com [active]");
+		expect(output[0]).toContain("claude@example.com [active]");
 	});
 
 	it("renders the deterministic empty stored-account inventory without probing", async () => {

--- a/packages/coding-agent/test/login-preset-recommendation.test.ts
+++ b/packages/coding-agent/test/login-preset-recommendation.test.ts
@@ -83,6 +83,8 @@ function createControllerContext(
 			refresh: vi.fn(async () => {}),
 			authStorage: {
 				login: vi.fn(async () => {}),
+				listCredentialInventory: vi.fn(() => []),
+				listCredentialRemovalTargets: vi.fn(() => []),
 			},
 			getModelProfiles: () => new Map(profiles),
 			getModelProfile: (name: string) => profiles.get(name),

--- a/packages/coding-agent/test/login-preset-recommendation.test.ts
+++ b/packages/coding-agent/test/login-preset-recommendation.test.ts
@@ -5,6 +5,7 @@ import type { ModelProfileDefinition } from "@gajae-code/coding-agent/config/mod
 import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { SelectorController } from "@gajae-code/coding-agent/modes/controllers/selector-controller";
 import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
 
 const model = (provider: string, id: string): Model =>
 	({
@@ -109,12 +110,12 @@ function createControllerContext(
 		showStatus: vi.fn(),
 		showError: vi.fn(),
 	};
-	return { ctx, settings, session, setCalls };
+	return { ctx: ctx as unknown as InteractiveModeContext, settings, session, setCalls };
 }
 
-async function login(ctx: ReturnType<typeof createControllerContext>["ctx"], providerId: string): Promise<void> {
+async function login(ctx: InteractiveModeContext, providerId: string): Promise<void> {
 	installTestTheme();
-	const controller = new SelectorController(ctx as never);
+	const controller = new SelectorController(ctx);
 	await controller.showOAuthSelector("login", providerId);
 }
 

--- a/packages/coding-agent/test/sdk-operation-inventory.test.ts
+++ b/packages/coding-agent/test/sdk-operation-inventory.test.ts
@@ -93,6 +93,14 @@ describe("SDK operation inventory", () => {
 
 		const expected = new Map([
 			[
+				"agent_session:setCredentialPin",
+				"interactive session-scoped OAuth account selector mutation behind the locked /credential and OAuth selector surfaces; the public SDK has no credential-selection operation and must not gain credential authority implicitly",
+			],
+			[
+				"agent_session:setCredentialAuto",
+				"interactive session-scoped OAuth AUTO-ranking mutation behind the locked /credential and OAuth selector surfaces; the public SDK has no credential-selection operation and must not gain credential authority implicitly",
+			],
+			[
 				"agent_session:runMidRunMaintenanceForTests",
 				"test-only maintenance seam, not a user-facing SDK control seam",
 			],


### PR DESCRIPTION
## Summary
- lock session-only credential pin/AUTO seams out of the public SDK inventory and regenerate it
- provide ACP `/usage` with deterministic cache-only, non-probing, row-specific, session-scoped multi-account AuthStorage authority
- provide login preset recommendation with deterministic empty credential/removal inventories

## Current evidence
- current dev: `099ca7ec19654b2863f0a113ed569c8e7e96b9f5`
- Dev CI run 31758358584, shard-3 job 94640153622: exact #4518 failures
- dependent PR #4524 run 31758733081, shard-3 job 94641991570: same failures
- exact repair head: `65130ce03cfa3bbad2e8e89dcdcf418b5609a748`
- exact binary diff SHA-256: `9bfe2142a980c544a430003ec4c3f0bacfc14dd5e827f34e86e91db95c6d934b`

## Verification
- focused inventory, ACP builtins, login preset, and credential/account selectors: 113 pass / 599 assertions
- exact shard 3 before final assertion-only fix: 174/174 files pass
- `bun --cwd=packages/coding-agent run check`: pass
- explicit throwing provider-probe sentinel proves plain `/usage` remains cache-only

Closes #4518

gajae.pr-review-verdict.v1 merge-approved sha256:9bfe2142a980c544a430003ec4c3f0bacfc14dd5e827f34e86e91db95c6d934b reviewer:human reviewer-id:probepark evidence:local-worktree-base-vs-head bun test 92pass/11fail@099ca7ec1 -> 105pass/0fail@65130ce03 + CI jobs 94649573175,94649573194,94649573188

<!-- gaebal-gajae: GJC -->
