### PR TITLE
fix(notifications): heal legacy closed-endpoint bindings

### DIFF
--- a/packages/coding-agent/src/sdk/bus/topic-registry.ts
+++ b/packages/coding-agent/src/sdk/bus/topic-registry.ts
@@ -308,6 +308,33 @@ export function parseTopicRegistryState(value: unknown): TopicRegistryState | un
 								: records,
 						]),
 					),
+		// Pre-#4401 writers persisted closed-endpoint bindings without the
+		// `transport` discriminator. Rejecting them would permanently brick an
+		// otherwise-healthy shared registry (the same class as the
+		// disconnectGraceExpiresAt artifact below): the CAS authority refuses
+		// every read and write forever. The transport can only be "telegram" in
+		// those snapshots, so heal the in-memory record; the serializer no
+		// longer persists closed endpoints at all. Only heal records that match
+		// the complete pre-#4401 shape (chatId + endpointKey + endpointDigest +
+		// endpointGeneration): partial records are corruption, not legacy data.
+		closedEndpoints:
+			state.closedEndpoints === undefined
+				? undefined
+				: isObject(state.closedEndpoints)
+					? Object.fromEntries(
+							Object.entries(state.closedEndpoints).map(([sessionId, binding]) => [
+								sessionId,
+								isObject(binding) &&
+								binding.transport === undefined &&
+								isValidBindingString(binding.chatId) &&
+								isValidBindingString(binding.endpointKey) &&
+								isValidBindingString(binding.endpointDigest) &&
+								isValidBindingGeneration(binding.endpointGeneration)
+									? ({ chatId: binding.chatId, transport: "telegram" } as TelegramTopicBinding)
+									: binding,
+							]),
+						)
+					: state.closedEndpoints,
 	};
 	state.topics = Object.fromEntries(
 		Object.entries(state.topics).map(([sessionId, record]) => [

--- a/packages/coding-agent/test/notifications-topic-registry.test.ts
+++ b/packages/coding-agent/test/notifications-topic-registry.test.ts
@@ -493,6 +493,63 @@ describe("TopicRegistry", () => {
 		);
 	});
 
+	test("heals legacy closed-endpoint bindings persisted without a transport discriminator", () => {
+		// Pre-#4401 writers stored closedEndpoints as bare
+		// { chatId, endpointKey, endpointDigest, endpointGeneration } records.
+		// Rejecting them bricked the shared CAS authority on every read.
+		const stateWithClosed = (binding: object) =>
+			({
+				version: 2,
+				registryGeneration: 1,
+				topics: {},
+				closedEndpoints: { s1: binding },
+			}) as unknown as TopicRegistryState;
+
+		const legacy = {
+			chatId: "1824716193",
+			endpointKey: "c367bef42406c4b5ab90f21f9e1634a49d6ca3fd8ec66f5cb14f2bd69a551034",
+			endpointDigest: "c367bef42406c4b5ab90f21f9e1634a49d6ca3fd8ec66f5cb14f2bd69a551034",
+			endpointGeneration: 1,
+		};
+		const state = parseTopicRegistryState(stateWithClosed(legacy));
+		expect(state?.closedEndpoints?.s1).toMatchObject({ chatId: "1824716193", transport: "telegram" });
+		// The input snapshot is never mutated; healing is in-memory only.
+		expect("transport" in legacy).toBe(false);
+		// Healed records are stripped to the durable Telegram binding shape:
+		// no SDK endpoint identity (endpointKey/digest/generation) leaks
+		// into the healed in-memory record.
+		const healed = state?.closedEndpoints?.s1 as unknown as Record<string, unknown>;
+		expect(healed.endpointKey).toBeUndefined();
+		expect(healed.endpointDigest).toBeUndefined();
+		expect(healed.endpointGeneration).toBeUndefined();
+
+		// Partial legacy records (missing endpointDigest/generation) are
+		// corruption, not pre-#4401 legacy data, and must stay rejected.
+		expect(() => parseTopicRegistryState(stateWithClosed({ chatId: "1", endpointKey: "key" }))).toThrow(
+			"malformed Telegram topic state",
+		);
+
+		// Truly malformed entries remain rejected.
+		expect(() => parseTopicRegistryState(stateWithClosed({ endpointGeneration: 1 }))).toThrow(
+			"malformed Telegram topic state",
+		);
+		expect(() => parseTopicRegistryState(stateWithClosed({ chatId: "1", transport: "discord" }))).toThrow(
+			"malformed Telegram topic state",
+		);
+		// Non-object closedEndpoints (scalar/bool/array) stays rejected: the
+		// healing path must not coerce it to {} and bypass fail-closed.
+		for (const malformed of [1, true, []]) {
+			expect(() =>
+				parseTopicRegistryState({
+					version: 2,
+					registryGeneration: 1,
+					topics: {},
+					closedEndpoints: malformed,
+				} as unknown as TopicRegistryState),
+			).toThrow("malformed Telegram topic state");
+		}
+	});
+
 	test("restores the exact disconnect grace deadline after archive publication fails", async () => {
 		const reg = new TopicRegistry();
 		await reg.getOrCreateTopic("s1", async () => "1");


### PR DESCRIPTION
## Summary
- normalize legacy `closedEndpoints` records that lack `transport` while parsing the Telegram topic registry
- preserve rejection of malformed or non-Telegram endpoint bindings
- cover the upgrade path without mutating caller-owned snapshots

## Why
Pre-#4401 registry writers persisted closed endpoint bindings without `transport`. The stricter parser then rejected the entire registry, leaving the Telegram daemon unable to load topic authority or attach sessions.

## Verification
- `bun test packages/coding-agent/test/notifications-topic-registry.test.ts`
- `bun test packages/coding-agent/test/sdk-telegram-fault-containment.test.ts`
- `bun --cwd=packages/coding-agent run check`

gajae.pr-review-verdict.v1 merge-approved sha256:386bf910032148705b55863927b7f93e546543aff440e3726ce138cdb6cb9df5 reviewer:human reviewer-id:probepark evidence:re-verified at head f6fd94e93; patch identical to approved 6a8a90e89; new-base 59pass-1fail -> head 60pass-0fail
