### PR TITLE
fix(defaults): retire leftover team definitions and sweep translated READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -159,7 +159,7 @@ API キーのプロバイダ、ローカルランタイム（Ollama、LM Studio�
 
 ```text
 deep-interview -> ralplan -> ultragoal
-                         └─ 並列 tmux ワーカーが有効な場合のみ任意の team 実行
+               └─ リサーチが計画を裏付ける必要がある場合の任意の autoresearch ミッション
 ```
 
 | 表面 | 役割 |
@@ -167,10 +167,10 @@ deep-interview -> ralplan -> ultragoal
 | `deep-interview` | 曖昧な依頼を具体的な要件に変える。 |
 | `ralplan` | コード変更の前に実装計画を立てて批評する。 |
 | `ultragoal` | 実行・修正・検証・証拠まで目標を追跡する。 |
-| `team` | 並列化に価値があるとき tmux ワーカーを調整する。 |
+| `autoresearch` | 目標指向のリサーチミッションを実行し、構造化された判定で締めくくる。 |
 | `executor` / `architect` / `planner` / `critic` | 実装と読み取り専用レビューのための同梱ロールエージェント。 |
 
-オプトインで利用可能: **`gjc rlm`**（ノートブックとレポートを合成する Jupyter スタイルのリサーチ/REPL モード）と **`computer-use`**（実験的なデスクトップ制御）。[Python REPL](docs/python-repl.md) と [docs/tools/computer.md](docs/tools/computer.md) を参照。
+オプトインで利用可能: **`computer-use`**（実験的なデスクトップ制御）。[Python REPL](docs/python-repl.md) と [docs/tools/computer.md](docs/tools/computer.md) を参照。
 
 ---
 
@@ -215,7 +215,7 @@ Set up Gajae-Code (gjc) as your coding-agent backend on this machine. gjc is alr
         GJC_COORDINATOR_MCP_MUTATIONS=sessions,questions,reports
 
 4. To delegate coding work, prefer one call per workflow:
-   gjc_delegate_plan / gjc_delegate_execute / gjc_delegate_team
+   gjc_delegate_plan / gjc_delegate_execute
    with { cwd, task, allow_mutation: true, idempotency_key: <fresh-uuid> }.
    Each starts an isolated worktree session and returns a durable turn_id and artifacts.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -167,7 +167,7 @@ API 키 프로바이더, 로컬 런타임(Ollama, LM Studio, vLLM), 게이트웨
 
 ```text
 deep-interview -> ralplan -> ultragoal
-                         └─ 병렬 tmux 워커가 도움이 될 때만 선택적 team 실행
+               └─ 리서치가 계획을 뒷받침해야 할 때 선택적 autoresearch 미션
 ```
 
 | 표면 | 역할 |
@@ -175,10 +175,10 @@ deep-interview -> ralplan -> ultragoal
 | `deep-interview` | 모호한 요청을 구체적인 요구사항으로 바꿉니다. |
 | `ralplan` | 코드 변경 전에 구현 계획을 세우고 비평합니다. |
 | `ultragoal` | 실행·수정·검증·증거까지 목표를 추적합니다. |
-| `team` | 병렬화가 가치 있을 때 tmux 기반 워커를 조율합니다. |
+| `autoresearch` | 목표 지향 리서치 미션을 수행하고 구조화된 판정으로 마무리합니다. |
 | `executor` / `architect` / `planner` / `critic` | 구현 및 읽기 전용 리뷰 레인을 위한 번들 역할 에이전트. |
 
-옵트인 기능: **`gjc rlm`** (노트북과 리포트를 합성하는 Jupyter 스타일 리서치/REPL 모드), **`computer-use`** (실험적 데스크톱 제어). [Python REPL](docs/python-repl.md), [docs/tools/computer.md](docs/tools/computer.md) 참고.
+옵트인 기능: **`computer-use`** (실험적 데스크톱 제어). [Python REPL](docs/python-repl.md), [docs/tools/computer.md](docs/tools/computer.md) 참고.
 
 ---
 
@@ -223,7 +223,7 @@ Set up Gajae-Code (gjc) as your coding-agent backend on this machine. gjc is alr
         GJC_COORDINATOR_MCP_MUTATIONS=sessions,questions,reports
 
 4. To delegate coding work, prefer one call per workflow:
-   gjc_delegate_plan / gjc_delegate_execute / gjc_delegate_team
+   gjc_delegate_plan / gjc_delegate_execute
    with { cwd, task, allow_mutation: true, idempotency_key: <fresh-uuid> }.
    Each starts an isolated worktree session and returns a durable turn_id and artifacts.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -159,7 +159,7 @@ API key 提供商、本地运行时（Ollama、LM Studio、vLLM）与网关（Cl
 
 ```text
 deep-interview -> ralplan -> ultragoal
-                         └─ 并行 tmux worker 有价值时可选 team 执行
+               └─ 研究必须为计划奠基时可选 autoresearch 任务
 ```
 
 | 表面 | 作用 |
@@ -167,10 +167,10 @@ deep-interview -> ralplan -> ultragoal
 | `deep-interview` | 把模糊请求变成具体需求。 |
 | `ralplan` | 在改代码之前制定并评审实现计划。 |
 | `ultragoal` | 跟踪目标贯穿执行、修订、验证与证据。 |
-| `team` | 并行值得时协调 tmux worker。 |
+| `autoresearch` | 执行目标导向的研究任务，并以结构化结论收尾。 |
 | `executor` / `architect` / `planner` / `critic` | 内置角色代理，覆盖实现与只读评审通道。 |
 
-可选启用：**`gjc rlm`**（合成 notebook 与报告的 Jupyter 风格研究/REPL 模式）与 **`computer-use`**（实验性桌面控制）。见 [Python REPL](docs/python-repl.md) 与 [docs/tools/computer.md](docs/tools/computer.md)。
+可选启用：**`computer-use`**（实验性桌面控制）。见 [Python REPL](docs/python-repl.md) 与 [docs/tools/computer.md](docs/tools/computer.md)。
 
 ---
 
@@ -215,7 +215,7 @@ Set up Gajae-Code (gjc) as your coding-agent backend on this machine. gjc is alr
         GJC_COORDINATOR_MCP_MUTATIONS=sessions,questions,reports
 
 4. To delegate coding work, prefer one call per workflow:
-   gjc_delegate_plan / gjc_delegate_execute / gjc_delegate_team
+   gjc_delegate_plan / gjc_delegate_execute
    with { cwd, task, allow_mutation: true, idempotency_key: <fresh-uuid> }.
    Each starts an isolated worktree session and returns a durable turn_id and artifacts.
 

--- a/packages/coding-agent/src/cli/setup-cli.ts
+++ b/packages/coding-agent/src/cli/setup-cli.ts
@@ -596,6 +596,14 @@ async function handleDefaultsSetup(flags: { json?: boolean; check?: boolean; for
 	console.log(chalk.dim(`Target: ${result.targetRoot}`));
 	console.log(chalk.dim(`Written: ${result.written}; skipped: ${result.skipped}`));
 	console.log(chalk.dim(inspectGuidance));
+	const quarantined = result.retired.filter(entry => entry.status === "quarantined");
+	for (const entry of quarantined) {
+		console.log(
+			chalk.dim(
+				`Retired: \`${entry.name}\` is no longer a bundled workflow skill; moved to ${entry.quarantinedTo} so it is no longer discoverable.`,
+			),
+		);
+	}
 	if (result.skipped > 0 && !flags.force) {
 		console.log(
 			chalk.dim(

--- a/packages/coding-agent/src/defaults/gjc-defaults.ts
+++ b/packages/coding-agent/src/defaults/gjc-defaults.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getAgentDir, isEnoent } from "@gajae-code/utils";
 import { BUNDLED_GJC_SKILL_CATALOG, type BundledGjcSkillCatalogEntry } from "./gjc-skills.generated";
@@ -64,6 +65,32 @@ export type DefaultGjcDefinitionInstallFile =
 			status: DefaultGjcInstallStatus;
 	  };
 
+/**
+ * Bundled workflow definitions that GJC used to ship and no longer does.
+ *
+ * Installing defaults only ever wrote the CURRENT set, so a definition dropped
+ * from the bundle stayed on disk under the agent dir forever — where
+ * filesystem skill discovery still found it and `/skill:<name>` still resolved.
+ * `team` was the first removal, so it was the first to expose that gap.
+ *
+ * Retirement QUARANTINES rather than deletes: the directory is moved aside to
+ * `<targetRoot>/retired/<name>.<timestamp>/`. A user who customized the skill
+ * keeps their content, and nothing is destroyed to satisfy a rename.
+ */
+export const RETIRED_GJC_DEFINITION_NAMES = ["team"] as const;
+export type RetiredGjcDefinitionName = (typeof RETIRED_GJC_DEFINITION_NAMES)[number];
+
+export type RetiredGjcDefinitionStatus = "absent" | "quarantined";
+
+export interface RetiredGjcDefinitionFile {
+	name: RetiredGjcDefinitionName;
+	/** Directory that held the retired definition. */
+	path: string;
+	/** Where it was moved, when quarantined. */
+	quarantinedTo?: string;
+	status: RetiredGjcDefinitionStatus;
+}
+
 export interface DefaultGjcDefinitionInstallResult {
 	targetRoot: string;
 	total: number;
@@ -73,6 +100,8 @@ export interface DefaultGjcDefinitionInstallResult {
 	missing: number;
 	different: number;
 	files: DefaultGjcDefinitionInstallFile[];
+	/** Retired bundled definitions found under `targetRoot`, and what happened to them. */
+	retired: RetiredGjcDefinitionFile[];
 }
 function sourcePathForBundledEntry(entry: BundledGjcSkillCatalogEntry): string {
 	const relative = entry.kind === "skill" ? entry.relativePath : entry.relativePath.replace(/^skill-fragments\//, "");
@@ -236,7 +265,49 @@ export async function installDefaultGjcDefinitions(
 		}
 	}
 
-	return summarizeInstallResult(targetRoot, files);
+	const retired = await retireRemovedGjcDefinitions(targetRoot, { check: options.check === true });
+	return summarizeInstallResult(targetRoot, files, retired);
+}
+
+/**
+ * Quarantine any retired bundled definition still present under `targetRoot`.
+ *
+ * `check` reports what WOULD move without touching the filesystem, so
+ * `--check` callers stay read-only.
+ */
+export async function retireRemovedGjcDefinitions(
+	targetRoot: string,
+	options: { check?: boolean } = {},
+): Promise<RetiredGjcDefinitionFile[]> {
+	const results: RetiredGjcDefinitionFile[] = [];
+	for (const name of RETIRED_GJC_DEFINITION_NAMES) {
+		const directory = path.join(targetRoot, "skills", name);
+		if (!(await directoryExists(directory))) {
+			results.push({ name, path: directory, status: "absent" });
+			continue;
+		}
+		if (options.check) {
+			results.push({ name, path: directory, status: "quarantined" });
+			continue;
+		}
+		// Timestamped so repeated retirements never collide and never overwrite an
+		// earlier quarantine.
+		const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+		const quarantinedTo = path.join(targetRoot, "retired", `${name}.${stamp}`);
+		await fs.mkdir(path.dirname(quarantinedTo), { recursive: true });
+		await fs.rename(directory, quarantinedTo);
+		results.push({ name, path: directory, quarantinedTo, status: "quarantined" });
+	}
+	return results;
+}
+
+async function directoryExists(candidate: string): Promise<boolean> {
+	try {
+		return (await fs.stat(candidate)).isDirectory();
+	} catch (error) {
+		if (isEnoent(error)) return false;
+		throw error;
+	}
 }
 
 async function readExistingText(filePath: string): Promise<string | undefined> {
@@ -251,6 +322,7 @@ async function readExistingText(filePath: string): Promise<string | undefined> {
 function summarizeInstallResult(
 	targetRoot: string,
 	files: DefaultGjcDefinitionInstallFile[],
+	retired: RetiredGjcDefinitionFile[],
 ): DefaultGjcDefinitionInstallResult {
 	return {
 		targetRoot,
@@ -261,6 +333,7 @@ function summarizeInstallResult(
 		missing: countStatus(files, "missing"),
 		different: countStatus(files, "different"),
 		files,
+		retired,
 	};
 }
 

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -698,6 +698,66 @@ Project executor override body.
 		).toBe(true);
 	});
 
+	it("quarantines a retired bundled skill left on disk instead of leaving it discoverable", async () => {
+		const targetRoot = await makeTempRoot();
+		const retiredSkill = path.join(targetRoot, "skills", "team", "SKILL.md");
+		await Bun.write(retiredSkill, "---\nname: team\n---\n\nstale bundled team skill\n");
+
+		const result = await installDefaultGjcDefinitions({ targetRoot });
+
+		// The retired directory is gone from the discoverable skills root...
+		expect(await Bun.file(retiredSkill).exists()).toBe(false);
+		const row = result.retired.find(entry => entry.name === "team");
+		expect(row?.status).toBe("quarantined");
+		// ...but the content survives under retired/, so a customized copy is not destroyed.
+		expect(row?.quarantinedTo).toBeDefined();
+		expect(await Bun.file(path.join(row!.quarantinedTo!, "SKILL.md")).text()).toContain("stale bundled team skill");
+		// Retiring team must not disturb the four current skills.
+		expect(await Bun.file(path.join(targetRoot, "skills", "autoresearch", "SKILL.md")).exists()).toBe(true);
+	});
+
+	it("reports a retired skill under check without touching the filesystem", async () => {
+		const targetRoot = await makeTempRoot();
+		const retiredSkill = path.join(targetRoot, "skills", "team", "SKILL.md");
+		await Bun.write(retiredSkill, "stale\n");
+
+		const checked = await installDefaultGjcDefinitions({ targetRoot, check: true });
+
+		expect(checked.retired.find(entry => entry.name === "team")?.status).toBe("quarantined");
+		// --check is read-only: the file is still exactly where it was.
+		expect(await Bun.file(retiredSkill).exists()).toBe(true);
+		expect(await Bun.file(retiredSkill).text()).toBe("stale\n");
+	});
+
+	it("reports retired definitions as absent when none are on disk and never creates retired/", async () => {
+		const targetRoot = await makeTempRoot();
+
+		const result = await installDefaultGjcDefinitions({ targetRoot });
+
+		expect(result.retired.map(entry => entry.name)).toEqual(["team"]);
+		expect(result.retired.every(entry => entry.status === "absent")).toBe(true);
+		expect(await Bun.file(path.join(targetRoot, "retired")).exists()).toBe(false);
+	});
+
+	it("does not collide when the same retired skill is quarantined twice", async () => {
+		const targetRoot = await makeTempRoot();
+		const retiredSkill = path.join(targetRoot, "skills", "team", "SKILL.md");
+
+		await Bun.write(retiredSkill, "first\n");
+		const first = await installDefaultGjcDefinitions({ targetRoot });
+		await Bun.write(retiredSkill, "second\n");
+		const second = await installDefaultGjcDefinitions({ targetRoot });
+
+		const firstTo = first.retired.find(entry => entry.name === "team")?.quarantinedTo;
+		const secondTo = second.retired.find(entry => entry.name === "team")?.quarantinedTo;
+		expect(firstTo).toBeDefined();
+		expect(secondTo).toBeDefined();
+		expect(secondTo).not.toBe(firstTo);
+		// Neither quarantine overwrote the other.
+		expect(await Bun.file(path.join(firstTo!, "SKILL.md")).text()).toBe("first\n");
+		expect(await Bun.file(path.join(secondTo!, "SKILL.md")).text()).toBe("second\n");
+	});
+
 	it("refreshOnly rewrites stale local copies but never materializes missing ones", async () => {
 		const targetRoot = await makeTempRoot();
 		const deepInterviewSkillPath = path.join(targetRoot, "skills", "deep-interview", "SKILL.md");


### PR DESCRIPTION
## Summary

Follow-up cleanup for the `team` → `autoresearch` retirement. Two leftovers reported after building the base branch:

1. **`/skill:team` was still discoverable** even after the skill was removed from the bundle.
2. **The translated READMEs still documented `team`, `gjc rlm`, and `gjc_delegate_team`.**

> **Base note:** this targets `feat/deprecate-team-skill-and-add-autoresearch-goal-skill`, not `dev`, because **#4430 is currently closed and unmerged** — `dev` still has `team` as the fourth canonical skill and no `autoresearch`. This cleanup only makes sense on top of that work. If #4430 is reopened and merged, I'll retarget this to `dev`.

## 1. Retiring bundled definitions that are no longer shipped

**Root cause:** `installDefaultGjcDefinitions` iterates only the *current* `DEFAULT_GJC_DEFINITIONS` and writes them. It had no notion of a definition that used to exist. So dropping `team` from the bundle left `~/.gjc/agent/skills/team/SKILL.md` on disk permanently, where filesystem skill discovery still found it and `/skill:team` still resolved — pointing at a workflow whose command, runtime, and prompt had all been deleted.

`team` is the first bundled default GJC has ever removed, which is why nothing caught this earlier.

**Fix:** a `RETIRED_GJC_DEFINITION_NAMES` list plus a retirement pass that **quarantines rather than deletes**:

- the directory moves to `<targetRoot>/retired/<name>.<timestamp>/`
- a user who customized the skill keeps their content — nothing is destroyed to satisfy a rename
- the timestamp means repeated retirements never overwrite an earlier quarantine
- `--check` reports what *would* move and touches nothing
- `setup defaults` prints where each retired skill went

Reproduced end to end against a real installed layout:

```
BEFORE: skills/team
retired: [{"name":"team","status":"quarantined"}]
AFTER skills:  autoresearch deep-interview ralplan ultragoal
AFTER retired/: team.2026-08-14T01-39-57-007Z
content preserved: stale team skill
```

### Why quarantine instead of delete

| Option | Verdict |
| :--- | :--- |
| Delete the directory outright | Rejected — destroys a customized local skill with no recovery |
| Delete only if content matches the old bundled copy | Rejected — we no longer ship that content, so there's nothing to compare against |
| **Move aside and report** | Chosen — removes it from discovery, loses nothing |

## 2. Translated READMEs

The original change swept `README.md` but not the translations. All three still advertised the retired surfaces:

| File | Leftovers |
| :--- | :--- |
| `README.ko.md` | workflow diagram, `team` skill row, `gjc rlm` opt-in, `gjc_delegate_team` |
| `README.ja.md` | same |
| `README.zh-CN.md` | same |

Each now carries an idiomatic `autoresearch` row in its own language rather than English text spliced into a translated table:

- ko — 목표 지향 리서치 미션을 수행하고 구조화된 판정으로 마무리합니다.
- ja — 目標指向のリサーチミッションを実行し、構造化された判定で締めくくる。
- zh-CN — 执行目标导向的研究任务，并以结构化结论收尾。

All three back-translate to "runs goal-directed research missions and ends on a structured verdict", matching the English row.

The only remaining `team` match in those files is the `IYENTeam` contributor handle.

## Verification

- `default-gjc-definitions` **33/33**, including four new cases: quarantine leaves the four current skills intact; `--check` stays read-only; absent retirees create no `retired/` dir; a second quarantine doesn't collide with the first.
- **All four proven fail-today** by disabling the retirement call — 4 fail, then pass once restored.
- `cli-command-surface` green; `check:types` clean; `check:tools`, `check-visible-definitions`, `verify-gjc-skill-docs`, `verify-gjc-plugins`, `ci-gjc-state-gates`, `rebrand-inventory --strict` all pass.
- Acceptance greps for `gjc team` / `/skill:team` / `gjc rlm` / `gjc_delegate_team` return nothing across the three translations.

## Directive for future removals

Dropping a bundled default now requires adding it to `RETIRED_GJC_DEFINITION_NAMES`, or it lingers as a discoverable ghost skill. That's captured in the commit trailer and in the constant's doc comment.
