### PR TITLE
fix(sdk): restore Telegram->session frame token; auto-reap pre-registry stray daemons

### DIFF
--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -7091,7 +7091,18 @@ export function createNotificationsExtension(
 			// thread (forwarded by the daemon over the WS, fail-closed at the daemon).
 			server.onInbound((err, inbound) => {
 				if (err || !inbound) return;
-				if (initializedRuntime.inboundFenced) return;
+				if (initializedRuntime.inboundFenced) {
+					// A fenced predecessor keeps its native server alive for the terminal
+					// response, so the daemon can still deliver here after it has already
+					// ACKed the user's Telegram message. Dropping without a diagnostic
+					// made that loss undiscoverable (2026-08-14 incident).
+					logger.warn(
+						`notifications: inbound ${inbound.kind} dropped: runtime is inbound-fenced (updateId=${String(
+							(inbound as { updateId?: unknown }).updateId ?? "none",
+						)})`,
+					);
+					return;
+				}
 				const authenticatedInbound = inbound as typeof inbound & {
 					connectionId: string;
 					messageId?: number;
@@ -7115,6 +7126,12 @@ export function createNotificationsExtension(
 							});
 						}
 					}
+					if (inbound.kind !== "control_command")
+						logger.warn(
+							`notifications: inbound ${inbound.kind} dropped: notification policy is suspended (updateId=${String(
+								(inbound as { updateId?: unknown }).updateId ?? "none",
+							)})`,
+						);
 					return;
 				}
 				if (inbound.kind === "control_command") {

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts
@@ -266,7 +266,7 @@ export const SDK_LIFECYCLE_ROUTER_PROTOCOL_VERSION = 1;
  * in the daemon run loop, pre-poll stale-poller fencing, and fail-closed
  * watchdog behavior when stable identity authority is unavailable (#4403).
  */
-export const DAEMON_GENERATION = 166;
+export const DAEMON_GENERATION = 167;
 
 /**
  * Serving-compatibility boundary for daemon lifecycle requests. Epoch 7

--- a/packages/coding-agent/src/sdk/bus/telegram-daemon-orphan-reap.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon-orphan-reap.ts
@@ -1,4 +1,6 @@
 import * as path from "node:path";
+import { nativeProcessBindings } from "@gajae-code/utils/native-process";
+import { $ } from "bun";
 import { isProcessIncarnation } from "../broker/process-incarnation";
 import type { TelegramDaemonFs } from "./telegram-daemon";
 import {
@@ -27,6 +29,17 @@ export interface TelegramOrphanProcessRef {
 	terminateTree(signal?: NodeJS.Signals): boolean;
 }
 
+/**
+ * A pinned reference that can additionally prove the process's kernel-derived
+ * launch arguments. Used only by the legacy-stray sweep: candidate PIDs come
+ * from an untrusted enumeration, but every authorization fact (incarnation,
+ * argv) is read from this pinned reference, never from the enumeration.
+ */
+export interface TelegramStrayProcessRef extends TelegramOrphanProcessRef {
+	/** Launch arguments reported by the kernel for the pinned incarnation. */
+	args(): string[];
+}
+
 export interface TelegramOrphanReapDeps {
 	fs?: TelegramDaemonFs;
 	now?: () => number;
@@ -39,6 +52,21 @@ export interface TelegramOrphanReapDeps {
 	 */
 	processReference?: (pid: number) => TelegramOrphanProcessRef | undefined;
 	platform?: NodeJS.Platform;
+	/**
+	 * Enumerates candidate PIDs for the legacy-stray sweep. The list is
+	 * untrusted discovery input only; authorization derives exclusively from
+	 * the pinned {@link TelegramStrayProcessRef}. Defaults to a bounded POSIX
+	 * `ps` listing; returns nothing on Windows or enumeration failure.
+	 */
+	listCandidatePids?: () => Promise<number[]>;
+	/** Opens a pinned argv-capable reference for stray verification. */
+	strayReference?: (pid: number) => TelegramStrayProcessRef | undefined;
+	/**
+	 * First-sighting ledger for stray confirmation, keyed by
+	 * `pid|incarnation` with the first-seen timestamp. Injectable for tests;
+	 * defaults to a process-lifetime module ledger.
+	 */
+	straySightings?: Map<string, number>;
 }
 
 export interface TelegramOrphanCandidate {
@@ -78,6 +106,88 @@ const MAX_REAP_CANDIDATES = 64;
 const TERM_GRACE_MS = 2_000;
 /** Bounded hard-kill wait before declaring termination failed (ms). */
 const KILL_WAIT_MS = 1_500;
+
+/** Maximum PIDs the legacy-stray enumeration will inspect per sweep. */
+const MAX_STRAY_SCAN_PIDS = 4096;
+/** Maximum stray terminations per sweep; the rest wait for the next cadence. */
+const MAX_STRAY_TERMINATIONS = 8;
+/**
+ * A stray must be sighted twice with the same pinned incarnation at least this
+ * far apart before it may be terminated. A legitimate successor daemon reaches
+ * ownership (and writes its marker) within seconds of spawning, so it can
+ * never accumulate a confirmed unmarked sighting; a pre-registry zombie
+ * persists across sweeps and is confirmed on the second one.
+ */
+const STRAY_CONFIRMATION_MS = 45_000;
+/** Bounded size of the first-sighting ledger. */
+const MAX_STRAY_SIGHTINGS = 256;
+
+/** Process-lifetime default first-sighting ledger for the stray sweep. */
+const moduleStraySightings = new Map<string, number>();
+
+/**
+ * Exact invocation-signature test for a legacy Telegram daemon owner:
+ * a `notify daemon-internal` subcommand bound to exactly this agent dir.
+ * This is deliberately an exact-token match on kernel-reported argv from a
+ * pinned reference — never a substring similarity over an untrusted dump.
+ */
+export function isLegacyStrayDaemonArgs(args: readonly string[], agentDir: string): boolean {
+	const resolvedAgentDir = path.resolve(agentDir);
+	let hasSubcommand = false;
+	let agentDirMatches = false;
+	for (let i = 0; i < args.length; i++) {
+		if (args[i] === "notify" && args[i + 1] === "daemon-internal") hasSubcommand = true;
+		if (args[i] === "--agent-dir") {
+			const value = args[i + 1];
+			if (typeof value === "string" && path.resolve(value) === resolvedAgentDir) agentDirMatches = true;
+		}
+	}
+	return hasSubcommand && agentDirMatches;
+}
+
+/** Bounded POSIX PID enumeration; empty on Windows or on any failure. */
+async function defaultListCandidatePids(platform: NodeJS.Platform): Promise<number[]> {
+	if (platform === "win32") return [];
+	try {
+		const out = await $`ps -axo pid=`.quiet().text();
+		const pids: number[] = [];
+		for (const line of out.split("\n")) {
+			const pid = Number.parseInt(line.trim(), 10);
+			if (Number.isSafeInteger(pid) && pid > 0) pids.push(pid);
+			if (pids.length >= MAX_STRAY_SCAN_PIDS) break;
+		}
+		return pids;
+	} catch {
+		return [];
+	}
+}
+
+/** Default pinned argv-capable reference over the native process bindings. */
+function defaultStrayReference(pid: number): TelegramStrayProcessRef | undefined {
+	try {
+		const ref = nativeProcessBindings().Process.fromPid(pid);
+		if (!ref || !isProcessIncarnation(ref.incarnation)) return undefined;
+		return {
+			incarnation: ref.incarnation,
+			args: () => {
+				try {
+					return ref.args();
+				} catch {
+					return [];
+				}
+			},
+			terminateTree: (signal?: NodeJS.Signals) => {
+				try {
+					return ref.killTree(signal === "SIGKILL" ? 9 : 15) > 0;
+				} catch {
+					return false;
+				}
+			},
+		};
+	} catch {
+		return undefined;
+	}
+}
 
 /**
  * Identity-bound, process-group-aware termination.
@@ -287,6 +397,65 @@ export async function reapTelegramDaemonOrphans(input: {
 			refused += 1;
 			reasons.termination_failed = (reasons.termination_failed ?? 0) + 1;
 		}
+	}
+
+	// Legacy-stray sweep: daemons spawned by builds that predate the marker
+	// registry never registered a marker and may not own the state file, so the
+	// marker sweep above cannot see them — they keep polling getUpdates and
+	// 409-starve every fresh owner. Candidate PIDs come from an untrusted
+	// enumeration; ALL authorization facts (incarnation, argv) come from the
+	// pinned native reference. Termination additionally requires a confirmed
+	// second sighting of the same pinned incarnation, so a legitimate successor
+	// mid-handoff (which reaches ownership and writes its marker within
+	// seconds) can never be killed.
+	try {
+		const markerPids = new Set<number>();
+		for (const entry of candidates) if (entry.marker) markerPids.add(entry.marker.pid);
+		const clock = deps.now ?? Date.now;
+		const sightings = deps.straySightings ?? moduleStraySightings;
+		const listPids = deps.listCandidatePids ?? (() => defaultListCandidatePids(deps.platform ?? process.platform));
+		const strayRef = deps.strayReference ?? defaultStrayReference;
+		const liveKeys = new Set<string>();
+		let strayTerminations = 0;
+		for (const pid of (await listPids()).slice(0, MAX_STRAY_SCAN_PIDS)) {
+			if (pid === input.currentPid || pid === process.pid || markerPids.has(pid)) continue;
+			const ref = strayRef(pid);
+			if (!ref || !isProcessIncarnation(ref.incarnation)) continue;
+			if (ref.incarnation === input.currentIncarnation) continue;
+			if (!isLegacyStrayDaemonArgs(ref.args(), input.agentDir)) continue;
+			const key = `${pid}|${ref.incarnation}`;
+			liveKeys.add(key);
+			const firstSeenAt = sightings.get(key);
+			if (firstSeenAt === undefined) {
+				if (sightings.size < MAX_STRAY_SIGHTINGS) sightings.set(key, clock());
+				reasons.legacy_stray_pending_confirmation = (reasons.legacy_stray_pending_confirmation ?? 0) + 1;
+				continue;
+			}
+			if (clock() - firstSeenAt < STRAY_CONFIRMATION_MS) {
+				reasons.legacy_stray_pending_confirmation = (reasons.legacy_stray_pending_confirmation ?? 0) + 1;
+				continue;
+			}
+			if (strayTerminations >= MAX_STRAY_TERMINATIONS) break;
+			const acquisitionId = `legacy-stray:${pid}`;
+			const exited = await terminateOwnedProcessTree(pid, ref, deps);
+			if (exited || !deps.pidAlive(pid)) {
+				decisions.push({ kind: "reaped", pid, acquisitionId });
+				terminated += 1;
+				strayTerminations += 1;
+				sightings.delete(key);
+				liveKeys.delete(key);
+				reasons.legacy_stray_reaped = (reasons.legacy_stray_reaped ?? 0) + 1;
+			} else {
+				decisions.push({ kind: "refused", pid, acquisitionId, reason: "termination_failed" });
+				refused += 1;
+				reasons.legacy_stray_termination_failed = (reasons.legacy_stray_termination_failed ?? 0) + 1;
+			}
+		}
+		// Drop ledger entries whose process no longer matched this sweep, so the
+		// bounded ledger cannot fill with dead incarnations.
+		for (const key of [...sightings.keys()]) if (!liveKeys.has(key)) sightings.delete(key);
+	} catch {
+		reasons.legacy_stray_scan_failed = (reasons.legacy_stray_scan_failed ?? 0) + 1;
 	}
 
 	// If the registry exceeded the bound, record the overflow.

--- a/packages/coding-agent/src/sdk/router/session-router.ts
+++ b/packages/coding-agent/src/sdk/router/session-router.ts
@@ -527,9 +527,7 @@ export class SessionRouter {
 		// omitting it made every daemon-origin injection (Telegram → session)
 		// vanish after the daemon had already ACKed the user's message.
 		const withToken =
-			typeof frame.type === "string" &&
-			TOKEN_AUTHORIZED_FRAME_TYPES.has(frame.type) &&
-			frame.token === undefined
+			typeof frame.type === "string" && TOKEN_AUTHORIZED_FRAME_TYPES.has(frame.type) && frame.token === undefined
 				? { ...frame, token: attached.endpoint.token }
 				: frame;
 		const connectionId = attached.client.connectionId;

--- a/packages/coding-agent/src/sdk/router/session-router.ts
+++ b/packages/coding-agent/src/sdk/router/session-router.ts
@@ -219,6 +219,19 @@ const ATTACH_CONCURRENCY = 4;
 const ATTACH_CONNECT_TIMEOUT_MS = 10_000;
 const NOTIFICATION_WORK_TIMEOUT_MS = 5_000;
 const NOTIFICATION_WORK_TIMEOUT = Symbol("notification_work_timeout");
+/**
+ * Client-message types the native session server authorizes with the
+ * per-session endpoint token (`tokens_match` in crates/gjc-sdk server.rs).
+ * Frames of these types without a matching `token` are dropped silently.
+ */
+const TOKEN_AUTHORIZED_FRAME_TYPES = new Set([
+	"user_message",
+	"reply",
+	"ephemeral_turn",
+	"ephemeral_turn_cancel",
+	"config_command",
+	"control_command",
+]);
 
 function readGeneration(value: unknown): number | undefined {
 	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
@@ -507,11 +520,23 @@ export class SessionRouter {
 		return attached.capability;
 	}
 	#prepareFrame(attached: AttachedSession, frame: Record<string, unknown>): Record<string, unknown> {
+		// The native session server authorizes these client-message types with
+		// the per-session endpoint token and silently drops frames whose token
+		// is missing or wrong. Providers only hold opaque capabilities (the
+		// endpoint record lives here), so the router must stamp the token —
+		// omitting it made every daemon-origin injection (Telegram → session)
+		// vanish after the daemon had already ACKed the user's message.
+		const withToken =
+			typeof frame.type === "string" &&
+			TOKEN_AUTHORIZED_FRAME_TYPES.has(frame.type) &&
+			frame.token === undefined
+				? { ...frame, token: attached.endpoint.token }
+				: frame;
 		const connectionId = attached.client.connectionId;
-		if (connectionId === undefined) return frame;
-		if (frame.connectionId !== undefined && frame.connectionId !== connectionId)
+		if (connectionId === undefined) return withToken;
+		if (withToken.connectionId !== undefined && withToken.connectionId !== connectionId)
 			throw new SessionRouterError("pre_send", "SDK session transport identity changed before command dispatch.");
-		return { ...frame, connectionId };
+		return { ...withToken, connectionId };
 	}
 
 	/** Sends an SDK command through the current attachment without exposing its client. */

--- a/packages/coding-agent/test/sdk-session-router-authority.test.ts
+++ b/packages/coding-agent/test/sdk-session-router-authority.test.ts
@@ -1517,4 +1517,33 @@ describe("SessionRouter dispatch authority", () => {
 			await fixture.router.stop();
 		}
 	});
+	test("stamps the endpoint token onto token-authorized inbound frames", async () => {
+		// The native session server silently drops user_message/reply/control
+		// frames whose embedded token is missing or wrong; providers never see
+		// the endpoint record, so the router must stamp the token itself.
+		const subscriptions: NotificationSubscription[] = [];
+		const fixture = await routerFixture({
+			onNotificationSubscription: subscription => {
+				subscriptions.push(subscription);
+			},
+		});
+		try {
+			expect(subscriptions.length).toBe(1);
+			const [client] = fixture.clients;
+			const subscription = subscriptions[0]!;
+			subscription.send({ type: "user_message", sessionId: fixture.sessionId, text: "hi" });
+			subscription.send({ type: "reply", id: "a1", answer: "yes" });
+			subscription.send({ type: "user_message", sessionId: fixture.sessionId, text: "x", token: "preset" });
+			subscription.send({ type: "session_frame_ack", seq: 1 });
+			const byType = (type: string) => client!.sent.filter(frame => frame.type === type);
+			expect(byType("user_message")[0]?.token).toBe("secret");
+			expect(byType("reply")[0]?.token).toBe("secret");
+			// A caller-provided token is never overwritten.
+			expect(byType("user_message")[1]?.token).toBe("preset");
+			// Non-authorized frame types stay untouched.
+			expect(byType("session_frame_ack")[0]?.token).toBeUndefined();
+		} finally {
+			await fixture.router.stop();
+		}
+	});
 });

--- a/packages/coding-agent/test/telegram-daemon-legacy-stray-reap.test.ts
+++ b/packages/coding-agent/test/telegram-daemon-legacy-stray-reap.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { TelegramDaemonFs } from "../src/sdk/bus/telegram-daemon";
+import {
+	isLegacyStrayDaemonArgs,
+	reapTelegramDaemonOrphans,
+	type TelegramStrayProcessRef,
+} from "../src/sdk/bus/telegram-daemon-orphan-reap";
+
+function tempAgentDir(): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), "gjc-legacy-stray-test-"));
+}
+
+const AGENT_DIR_ARGS = (agentDir: string) => [
+	"/old/workspace/dist/gjc",
+	"notify",
+	"daemon-internal",
+	"--owner-id",
+	"5513-msr3xott-bbdihsv4vin",
+	"--agent-dir",
+	agentDir,
+];
+
+describe("legacy stray daemon argv signature", () => {
+	const agentDir = "/home/u/.gjc/agent";
+
+	test("matches the exact daemon-internal invocation for this agent dir", () => {
+		expect(isLegacyStrayDaemonArgs(AGENT_DIR_ARGS(agentDir), agentDir)).toBe(true);
+	});
+
+	test("rejects near-miss invocations", () => {
+		// Different agent dir.
+		expect(isLegacyStrayDaemonArgs(AGENT_DIR_ARGS("/home/u/.gjc/other"), agentDir)).toBe(false);
+		// Subcommand tokens not adjacent.
+		expect(
+			isLegacyStrayDaemonArgs(["gjc", "notify", "health", "daemon-internal", "--agent-dir", agentDir], agentDir),
+		).toBe(false);
+		// Substring lookalikes are not token matches.
+		expect(isLegacyStrayDaemonArgs(["gjc", "notify-daemon-internal", "--agent-dir", agentDir], agentDir)).toBe(false);
+		// Missing --agent-dir binding.
+		expect(isLegacyStrayDaemonArgs(["gjc", "notify", "daemon-internal"], agentDir)).toBe(false);
+	});
+});
+
+interface FakeStray {
+	pid: number;
+	incarnation: string;
+	args: string[];
+	alive: boolean;
+	terminations: NodeJS.Signals[];
+}
+
+function strayDeps(input: {
+	agentDir: string;
+	strays: FakeStray[];
+	sightings: Map<string, number>;
+	now: () => number;
+}) {
+	const byPid = new Map(input.strays.map(stray => [stray.pid, stray]));
+	return {
+		pidAlive: (pid: number) => byPid.get(pid)?.alive ?? false,
+		pidIncarnation: (pid: number) => byPid.get(pid)?.incarnation,
+		now: input.now,
+		listCandidatePids: async () => input.strays.map(stray => stray.pid),
+		strayReference: (pid: number): TelegramStrayProcessRef | undefined => {
+			const stray = byPid.get(pid);
+			if (!stray?.alive) return undefined;
+			return {
+				incarnation: stray.incarnation,
+				args: () => stray.args,
+				terminateTree: (signal?: NodeJS.Signals) => {
+					stray.terminations.push(signal ?? "SIGTERM");
+					stray.alive = false;
+					return true;
+				},
+			};
+		},
+		straySightings: input.sightings,
+	};
+}
+
+async function sweep(agentDir: string, deps: ReturnType<typeof strayDeps>) {
+	return await reapTelegramDaemonOrphans({
+		agentDir,
+		currentOwnerId: "cur",
+		currentAcquisitionId: "cur-acq",
+		currentPid: 99999,
+		currentIncarnation: "linux:99999:1",
+		fsImpl: fs.promises as unknown as TelegramDaemonFs,
+		deps,
+	});
+}
+
+describe("legacy stray daemon sweep", () => {
+	test("terminates a confirmed pre-registry stray on the second sighting", async () => {
+		const agentDir = tempAgentDir();
+		try {
+			let clock = 1_000_000;
+			const stray: FakeStray = {
+				pid: 31056,
+				incarnation: "darwin:31056:7",
+				args: AGENT_DIR_ARGS(agentDir),
+				alive: true,
+				terminations: [],
+			};
+			const sightings = new Map<string, number>();
+			const deps = strayDeps({ agentDir, strays: [stray], sightings, now: () => clock });
+
+			// First sighting: recorded, never signaled.
+			const first = await sweep(agentDir, deps);
+			expect(stray.alive).toBe(true);
+			expect(first.receipt.terminated).toBe(0);
+			expect(first.receipt.reasons.legacy_stray_pending_confirmation).toBe(1);
+			expect(sightings.size).toBe(1);
+
+			// Second sighting before the confirmation window: still not signaled.
+			clock += 10_000;
+			const early = await sweep(agentDir, deps);
+			expect(stray.alive).toBe(true);
+			expect(early.receipt.reasons.legacy_stray_pending_confirmation).toBe(1);
+
+			// Confirmed sighting after the window: terminated.
+			clock += 60_000;
+			const confirmed = await sweep(agentDir, deps);
+			expect(stray.alive).toBe(false);
+			expect(stray.terminations.length).toBeGreaterThan(0);
+			expect(confirmed.receipt.terminated).toBe(1);
+			expect(confirmed.receipt.reasons.legacy_stray_reaped).toBe(1);
+			expect(confirmed.decisions.some(d => d.kind === "reaped" && d.pid === stray.pid)).toBe(true);
+			expect(sightings.size).toBe(0);
+		} finally {
+			fs.rmSync(agentDir, { recursive: true, force: true });
+		}
+	});
+
+	test("never signals non-matching processes and prunes their ledger entries", async () => {
+		const agentDir = tempAgentDir();
+		try {
+			let clock = 1_000_000;
+			const unrelated: FakeStray = {
+				pid: 555,
+				incarnation: "darwin:555:1",
+				args: ["/usr/bin/some-tool", "--agent-dir", agentDir],
+				alive: true,
+				terminations: [],
+			};
+			const otherAgentDir: FakeStray = {
+				pid: 556,
+				incarnation: "darwin:556:1",
+				args: AGENT_DIR_ARGS(path.join(agentDir, "elsewhere")),
+				alive: true,
+				terminations: [],
+			};
+			const sightings = new Map<string, number>();
+			const deps = strayDeps({ agentDir, strays: [unrelated, otherAgentDir], sightings, now: () => clock });
+
+			await sweep(agentDir, deps);
+			clock += 60_000;
+			const result = await sweep(agentDir, deps);
+			expect(unrelated.alive).toBe(true);
+			expect(otherAgentDir.alive).toBe(true);
+			expect(result.receipt.terminated).toBe(0);
+			expect(result.receipt.reasons.legacy_stray_reaped).toBeUndefined();
+			expect(sightings.size).toBe(0);
+		} finally {
+			fs.rmSync(agentDir, { recursive: true, force: true });
+		}
+	});
+
+	test("an incarnation change resets confirmation (PID reuse is never inherited)", async () => {
+		const agentDir = tempAgentDir();
+		try {
+			let clock = 1_000_000;
+			const stray: FakeStray = {
+				pid: 777,
+				incarnation: "darwin:777:1",
+				args: AGENT_DIR_ARGS(agentDir),
+				alive: true,
+				terminations: [],
+			};
+			const sightings = new Map<string, number>();
+			const deps = strayDeps({ agentDir, strays: [stray], sightings, now: () => clock });
+
+			await sweep(agentDir, deps);
+			// PID reused by a different process incarnation with the same argv shape.
+			stray.incarnation = "darwin:777:2";
+			clock += 60_000;
+			const result = await sweep(agentDir, deps);
+			expect(stray.alive).toBe(true);
+			expect(result.receipt.terminated).toBe(0);
+			expect(result.receipt.reasons.legacy_stray_pending_confirmation).toBe(1);
+		} finally {
+			fs.rmSync(agentDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/scripts/telegram-daemon-generation-guard.test.ts
+++ b/scripts/telegram-daemon-generation-guard.test.ts
@@ -9,6 +9,7 @@ import {
 	currentTreeDigests,
 	declaration,
 	evaluate,
+	fixGenerations,
 	FIX_GENERATIONS_REMEDIATION,
 	GUARD_CONTRACT_VERSION,
 	isLegacyBootstrapBase,
@@ -21,6 +22,7 @@ import {
 	validateCurrentTreeManifest,
 	validateInventory,
 	validateManifest,
+	validateRegeneratedManifest,
 	validateSha,
 	writeManifest,
 } from "./telegram-daemon-generation-guard";
@@ -1082,6 +1084,42 @@ test("fails closed when a protected native authority declaration is missing or m
 			await rm(directory, { recursive: true, force: true });
 		}
 	}, 60000);
+
+	test("stale declaration digests fail strict validation but a regenerated manifest passes (fail-before / pass-after)", async () => {
+		// fail-before: a manifest whose semantic digests do not byte-match the current
+		// tree must be rejected by the strict current-tree comparison that normal/CI
+		// guard runs use, so a pre-repair stale manifest can never quietly pass.
+		const stale = {
+			...manifest,
+			digests: {
+				...manifest.digests,
+				"telegram:packages/coding-agent/src/sdk/bus/index.ts:createNotificationsExtension": "0".repeat(64),
+			},
+		};
+		await expect(
+			validateRegeneratedManifest(JSON.stringify(stale), GUARD_CONTRACT_VERSION),
+		).rejects.toThrow("post-fix manifest digests do not byte-match the current tree");
+		// pass-after: the manifest regenerated from the current tree (the exact output the
+		// local --fix-generations bootstrap writes to disk) must pass the same strict check.
+		const regenerated = await manifestForCurrentTree();
+		await expect(
+			validateRegeneratedManifest(JSON.stringify(regenerated), GUARD_CONTRACT_VERSION),
+		).resolves.toBeUndefined();
+		expect(regenerated.digests).toEqual(await currentTreeDigests());
+	}, 60000);
+
+	test("CI/guard environments reject the explicit local --fix-generations mutation path", async () => {
+		const previousCi = process.env.CI;
+		process.env.CI = "true";
+		try {
+			await expect(fixGenerations(undefined, {})).rejects.toThrow(
+				"explicit local developer command and must not run under CI or guard-event environments",
+			);
+		} finally {
+			if (previousCi === undefined) delete process.env.CI;
+			else process.env.CI = previousCi;
+		}
+	});
 
 	test("guard authority proves immutable event objects without pinning the mutable base ref", () => {
 		const head = "a".repeat(40);

--- a/scripts/telegram-daemon-generation-guard.ts
+++ b/scripts/telegram-daemon-generation-guard.ts
@@ -8,7 +8,7 @@ import * as path from "node:path";
 
 const root = path.join(import.meta.dir, "..");
 const SHA = /^[0-9a-f]{40}$/i;
-export const GUARD_CONTRACT_VERSION = 49;
+export const GUARD_CONTRACT_VERSION = 50;
 const telegramContract = "packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts";
 const telegramDaemon = "packages/coding-agent/src/sdk/bus/telegram-daemon.ts";
 const telegramControl = "packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts";
@@ -1260,20 +1260,20 @@ export async function fixGenerations(baseInput: string | undefined, options: { f
 		} finally {
 			await fs.rm(manifestTemp, { force: true });
 		}
-		// Validate the current-tree manifest byte-matches the updated tree.
-		if (hasGuardContractBump && plan.guardContractEdit) {
-			// The in-memory validateCurrentTreeManifest uses the pre-bump
-			// GUARD_CONTRACT_VERSION import, so validate the disk manifest directly.
-			const diskManifest = JSON.parse(await Bun.file(manifestTarget).text()) as GuardManifest;
-			const diskGuardVersion = guardContractVersion(await Bun.file(path.join(root, guardScript)).text());
-			if (diskGuardVersion === undefined || diskManifest.contractVersion !== diskGuardVersion)
-				throw new Error("telegram-daemon-generation-guard: post-fix manifest contract version does not match the guard script");
-			const expected = JSON.stringify(Object.entries(await currentTreeDigests()).sort());
-			const actual = JSON.stringify(Object.entries(diskManifest.digests).sort());
-			if (expected !== actual) throw new Error("telegram-daemon-generation-guard: post-fix manifest digests do not byte-match the current tree");
-		} else {
-			await validateCurrentTreeManifest();
-		}
+		// Validate the regenerated disk manifest byte-matches the current tree.
+		// validateCurrentTreeManifest() validates against the module-level `manifest`
+		// import, which is stale on a bootstrap where the committed digests do not yet
+		// match the tree. Always validate the manifest we just wrote to disk, so a local
+		// --fix-generations bootstrap that regenerates stale semantic digests can pass its
+		// own strict current-tree check, while validateCurrentTreeManifest() (normal/CI
+		// guard) stays fail-closed against the pre-repair committed manifest.
+		const diskManifest = JSON.parse(await Bun.file(manifestTarget).text()) as GuardManifest;
+		const diskGuardVersion = guardContractVersion(await Bun.file(path.join(root, guardScript)).text());
+		if (diskGuardVersion === undefined || diskManifest.contractVersion !== diskGuardVersion)
+			throw new Error("telegram-daemon-generation-guard: post-fix manifest contract version does not match the guard script");
+		const expected = JSON.stringify(Object.entries(await currentTreeDigests()).sort());
+		const actual = JSON.stringify(Object.entries(diskManifest.digests).sort());
+		if (expected !== actual) throw new Error("telegram-daemon-generation-guard: post-fix manifest digests do not byte-match the current tree");
 		// Re-evaluate base→updated-tree to confirm the normal guard would pass.
 		const updatedHead: Array<readonly [string, string | undefined]> = [];
 		for (const file of filePaths) updatedHead.push([file, await Bun.file(path.join(root, file)).text().catch(() => undefined)]);

--- a/scripts/telegram-daemon-generation-guard.ts
+++ b/scripts/telegram-daemon-generation-guard.ts
@@ -470,6 +470,24 @@ export async function validateCurrentTreeManifest(): Promise<void> {
 		throw new Error("telegram-daemon-generation-guard: native authority digests do not byte-match the current tree");
 }
 
+/**
+ * Fail-closed current-tree validation for a manifest that was just regenerated and
+ * written to disk by the local {@link fixGenerations} bootstrap. Unlike
+ * `validateCurrentTreeManifest()` — which compares against the module-level
+ * `manifest` import and is stale until a repair commits — this byte-compares the
+ * provided on-disk manifest source against the current tree so a fresh digest
+ * bootstrap can pass its own strict check. It is only invoked from the explicit
+ * local developer fix path and must never gate normal/CI guard runs.
+ */
+export async function validateRegeneratedManifest(manifestSource: string, guardVersion: number | undefined): Promise<void> {
+	const diskManifest = JSON.parse(manifestSource) as GuardManifest;
+	if (guardVersion === undefined || diskManifest.contractVersion !== guardVersion)
+		throw new Error("telegram-daemon-generation-guard: post-fix manifest contract version does not match the guard script");
+	const expected = JSON.stringify(Object.entries(await currentTreeDigests()).sort());
+	const actual = JSON.stringify(Object.entries(diskManifest.digests).sort());
+	if (expected !== actual) throw new Error("telegram-daemon-generation-guard: post-fix manifest digests do not byte-match the current tree");
+}
+
 function bootstrapGuardContract(): void {
 	validateInventory();
 	validateManifest();
@@ -1267,13 +1285,10 @@ export async function fixGenerations(baseInput: string | undefined, options: { f
 		// --fix-generations bootstrap that regenerates stale semantic digests can pass its
 		// own strict current-tree check, while validateCurrentTreeManifest() (normal/CI
 		// guard) stays fail-closed against the pre-repair committed manifest.
-		const diskManifest = JSON.parse(await Bun.file(manifestTarget).text()) as GuardManifest;
-		const diskGuardVersion = guardContractVersion(await Bun.file(path.join(root, guardScript)).text());
-		if (diskGuardVersion === undefined || diskManifest.contractVersion !== diskGuardVersion)
-			throw new Error("telegram-daemon-generation-guard: post-fix manifest contract version does not match the guard script");
-		const expected = JSON.stringify(Object.entries(await currentTreeDigests()).sort());
-		const actual = JSON.stringify(Object.entries(diskManifest.digests).sort());
-		if (expected !== actual) throw new Error("telegram-daemon-generation-guard: post-fix manifest digests do not byte-match the current tree");
+		await validateRegeneratedManifest(
+			await Bun.file(manifestTarget).text(),
+			guardContractVersion(await Bun.file(path.join(root, guardScript)).text()),
+		);
 		// Re-evaluate base→updated-tree to confirm the normal guard would pass.
 		const updatedHead: Array<readonly [string, string | undefined]> = [];
 		for (const file of filePaths) updatedHead.push([file, await Bun.file(path.join(root, file)).text().catch(() => undefined)]);

--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -1,5 +1,5 @@
 {
-  "contractVersion": 49,
+  "contractVersion": 50,
   "inventory": {
     "telegram": {
       "packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts": [
@@ -526,7 +526,7 @@
     "telegram:packages/coding-agent/src/sdk/bus/daemon-paths.ts:HEARTBEAT_TTL_MS": "62255b5467995d21d3f929c863278ca3e815102001c51ca6d66840e1522ff990",
     "telegram:packages/coding-agent/src/sdk/bus/daemon-paths.ts:daemonPaths": "1bd6ae51096fedb95d47149b977f8a40e7f814a774ecfce21e027aac268b0379",
     "telegram:packages/coding-agent/src/sdk/bus/index.ts:buildIdentity": "246ad10dd6341037a20379a8544736039584d36482f6b2d44e3054f5e7f87724",
-    "telegram:packages/coding-agent/src/sdk/bus/index.ts:createNotificationsExtension": "ff153c2302edd2a56e16f18ec1fe8712b7c0e6f056d9dd46f8a31f65fef6d5cf",
+    "telegram:packages/coding-agent/src/sdk/bus/index.ts:createNotificationsExtension": "afcd50ce4ba8c88bc28c8821002d4a387fcdfca1a92af140ad149a66f1558d51",
     "telegram:packages/coding-agent/src/sdk/bus/notification-service.ts:DaemonTransitionLock": "0fb018a6384bff312aab0345012936f7e0609e4691c841919426ad3d75841dcb",
     "telegram:packages/coding-agent/src/sdk/bus/notification-service.ts:NATIVE_PATH_IDENTITY_CONTRACT_VERSION": "ec669ef396909ce429e08ce4fa9a78b5f0106d8cedf967e634c6ae6974830b8a",
     "telegram:packages/coding-agent/src/sdk/bus/notification-service.ts:acquireDaemonTransitionLock": "0115500fcb5c5797008d607bd69694579c5b372420310f265d33a4759364decc",
@@ -545,7 +545,7 @@
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:ownerPidFromOwnerId": "46691373b2bee01f28f3817a6aa6a7efffe880c2cea337c89155582c98d952bf",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:runDaemonInternal": "3a65a0c0631214cc41679d379399c96c15bd9ed16802f772c031d35ae207d82a",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:runDaemonSmoke": "6f085a667aa5c83de46d2d8945fb845c355fcbb43c46872342a44489203a5830",
-    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:DAEMON_GENERATION": "b3b312e7fd2d6e685ecf748265f3c4642a6ce06cd21d2f21e7a4efd53953ae67",
+    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:DAEMON_GENERATION": "d31b5c22e723b92e650faaa120a700c482e73266b31cfbd37e5abc281ba616fb",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:NOTIFICATION_PROTOCOL_VERSION": "b99289f651fedcf020d28dbaf6f07dd37e7e4a5f6dc1f5118b872112325f1e81",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts:DaemonProcessReference": "c3d13e3670a6245a1250c4ebfcd80a36dd8fc96c67ab64d9f979182bd117bc4e",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts:TelegramDaemonController": "166b909a9073e4d1052b245152789cfb7a272cbf5fe3075e9e651766e68d0b1e",


### PR DESCRIPTION
## Summary
Companion to #4526 (registry heal). Three independent fixes for the 2026-08-14 Telegram incident chain; each was repeatedly dropped from #4526 by branch-rewrite automation, so they ship here.

1. **Restore the per-session frame token** (`SessionRouter#prepareFrame`): the authority-containment refactor dropped `token: session.token` from daemon-injected frames; the native server (`tokens_match`) silently discards tokenless `user_message`/`reply`/`ephemeral_turn`/`ephemeral_turn_cancel`/`config_command`/`control_command` frames. Result: every Telegram→session message was ACKed (QUEUED reaction) then dropped. The router now stamps `attached.endpoint.token` for exactly those types — the secret stays inside the router.
2. **Diagnostics for silent inbound drops**: warn when a session host discards inbound frames because the runtime is inbound-fenced or its notification policy is suspended (previously invisible; see #4528).
3. **Auto-reap pre-registry legacy stray daemons**: bounded sweep in the orphan reaper (startup + 60s watchdog). Untrusted `ps` enumeration supplies candidate PIDs only; authorization requires a pinned native reference proving kernel incarnation + exact `notify daemon-internal --agent-dir <this agent dir>` argv, plus a second sighting of the same incarnation ≥45s later so a legitimate successor mid-handoff can never be killed. Closes the last manual step (`kill <pid>`) in the `gjc update` recovery story; see #4527/#4528 context.

## Verification
- `bun test packages/coding-agent/test/sdk-session-router-authority.test.ts` (39 pass, incl. new token-stamp regression test)
- `bun test packages/coding-agent/test/telegram-daemon-legacy-stray-reap.test.ts` (5 pass)
- `bun test packages/coding-agent/test/telegram-daemon-auto-reap.test.ts packages/coding-agent/test/telegram-daemon-orphan-reap-acceptance.test.ts` (pass)
- biome clean on touched files; live end-to-end verified this morning by running the daemon from this source (token fix) against real Telegram traffic

## Note
Full-package `tsc` in the shared worktree currently fails on ~100 pre-existing errors from unrelated surfaces (auth/accounts/pet-widget) plus a sibling-worktree path leaking into the program — present without these commits; my touched files contribute zero errors.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:ca8f5846f7af593f2100c3510632f936bf84c794a617e8e0f34c5b55d5e8118e reviewer:human reviewer-id:probepark evidence:base-vs-head router test 38pass-1fail@4906d0e29 -> 109pass-0fail@a8d78799d + check exit0
```


## CI
Requested a fresh authoritative Dev CI run at the current exact head; the earlier review-triggered run only tripped the shared guard input-validation gap on pull_request_review events (empty base SHA), which is resolved here by a pull_request event.
