### PR TITLE
fix(sdk): skip reconciliation persist on startup when no steers need settlement

### DIFF
--- a/packages/coding-agent/src/sdk/bus/kind-aware-reconciliation.ts
+++ b/packages/coding-agent/src/sdk/bus/kind-aware-reconciliation.ts
@@ -523,7 +523,13 @@ export function createKindAwareReconciliation(
 				}),
 			);
 			const candidateIndex = indexRecords(candidate);
-			await store.transact(() => [...candidate.values()].map(record => ({ ...record })));
+			// Persist only when hydration settled accepted steers to uncertain: an
+			// unconditional transact emits a rename on every startup even for empty
+			// stores, which a test pause hook or slow fs can intercept before any
+			// prompt/skill admission — stalling reconciliationReady so a concurrent
+			// abort misses the not-yet-registered pending preflight entry (#4522).
+			const settledSteers = loaded.some(record => record.kind === "steer" && record.status === "accepted");
+			if (settledSteers) await store.transact(() => [...candidate.values()].map(record => ({ ...record })));
 			records = candidate;
 			clientRefIndex = candidateIndex;
 		};


### PR DESCRIPTION
## Summary

Fixes #4522

`hydrateFromStore` unconditionally called `store.transact()` on every startup, even for empty stores with no accepted steers needing settlement. This emitted an atomic rename to the reconciliation store path indistinguishable from a durable prompt/skill acceptance commit.

## Root cause

The flaky timeout in `SDK host waits for durable skill acceptance before completing concurrent cancellation` (~10–20% fresh process flake) came from the test `pauseNextReconciliationCommit` hook intercepting the **hydration** rename instead of the skill `noteAccepted` rename:

1. `hydrateFromStore` → `store.transact()` → `rename(temp, storePath)` — paused by the test hook
2. `reconciliationReady` stalls before the skill invoke registers its `pendingPreflightCancellations` entry
3. Concurrent `turn.abort` finds no pending preflight entry → falls through to `abortOwnedPrompt` → returns `{ disposition: "idle" }` (no submission registered)
4. Preflight controller signal never aborts → `abortObserved.promise` never resolves → test hangs past 60s

## Fix

Guard the redundant persist in `hydrateFromStore`:

```diff
+const settledSteers = loaded.some(record => record.kind === "steer" && record.status === "accepted");
-await store.transact(() => [...candidate.values()].map(record => ({ ...record })));
+if (settledSteers) await store.transact(() => [...candidate.values()].map(record => ({ ...record })));
```

Records still load and hydrate in memory. Only the unnecessary durable rewrite is removed.

## Validation

| Configuration | Pass | Timeout | Runs |
|---|---|---|---|
| Baseline (no fix) | 29 | **1** | 30 |
| With fix | **50** | **0** | 50 |

### Suites
- `sdk-host-wiring.test.ts`: 104/104
- `sdk-kind-aware-reconciliation`, `sdk-reconciliation-recovery`, `sdk-steer-reconciliation`, `agent-session-skill-reroute-cancellation`, `session-runtime`: 71/71
- `agent-session-terminal-abort-chain`, `abort-message`, `cancel-and-submit`, `agent-session-silent-abort`, `sdk-acp-production-path`, `sdk-lifecycle-idempotency-restart`, `sdk-prompt-terminal-diagnostics`: 128/128 (3 skip)
- `bun --cwd=packages/coding-agent run check`: clean
- Prompt sibling: 20/20

### Provenance
- Head: `63011373ddf2c25f6594e329a24a9aa8d123c11a`
- Base: `4906d0e29c18d137d15c19af11a2bb0864f017ad` (exact origin/dev)
- File SHA-256 (`kind-aware-reconciliation.ts`): `b32eccaa5c2bef3cc984d2cced06eb7682fd9731aa917368e3d4d89311709dd4`
- Evidence comment: https://github.com/Yeachan-Heo/gajae-code/issues/4522#issuecomment-5289327058

### Invariants preserved
- Concurrent cancellation cannot complete before durable skill acceptance (both settle after acceptance)
- No timeout increase, retry, skip, or arbitrary yield
- No leaked authority or duplicate terminal publication
- No broad lifecycle redesign — 7 added lines, 1 removed

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:99286178a66286fc8ae631b6e1c8c33a5dbc6fb828369ebca455db7cc3e90212 reviewer:human reviewer-id:probepark evidence:local-worktree-base-vs-head bun test 29pass/1timeout@4906d0e29c -> 50pass/0timeout@63011373dd; rebased 5587ec29fd 20pass/0timeout vs f0453b6ab1 19pass/1timeout; Dev CI run 31770851066
```

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG not required (test-infrastructure race, no user-facing behavior change)
- [x] Verdict above matches the exact PR head `5587ec29fd`, not an earlier commit