### PR TITLE
test(notifications): sync durable-authority generation pin to 167 and bind it to the generator

### DIFF
--- a/packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts
@@ -265,6 +265,10 @@ export const SDK_LIFECYCLE_ROUTER_PROTOCOL_VERSION = 1;
  * instead of root-only signalRoot), identity-fenced orphan-owner reconciliation
  * in the daemon run loop, pre-poll stale-poller fencing, and fail-closed
  * watchdog behavior when stable identity authority is unavailable (#4403).
+ * Generation 167 repairs the telegram daemon generation guard bootstrap so the
+ * generator's post-fix manifest check always byte-compares the regenerated disk
+ * manifest against the current tree, and auto-reaps pre-registry legacy stray
+ * Telegram daemons (#4533).
  */
 export const DAEMON_GENERATION = 167;
 

--- a/packages/coding-agent/test/notifications-topic-registry.test.ts
+++ b/packages/coding-agent/test/notifications-topic-registry.test.ts
@@ -756,7 +756,7 @@ test("preserves a no-provenance endpoint claim before a held create can stage it
 	await creating;
 	expect(reg.endpointAuthority(binding)).toEqual({ state: "unique", sessionId: "B" });
 });
-test("publishes exact durable authority generation 166 at serving epoch 87", () => {
+test("publishes exact durable authority generation 167 at serving epoch 87", () => {
 	// Generation 58: parser-valid durable-fence promotion and rollback.
 	// Generation 152: a thrown steady heartbeat renewal in the run loop is
 	// contained instead of terminating the daemon (#4200).
@@ -779,7 +779,11 @@ test("publishes exact durable authority generation 166 at serving epoch 87", () 
 	// Generation 165: bounded lean settlement windows preserve user receipts.
 	// Generation 166: complete owned process-group cleanup, fail-closed watchdog,
 	// and daemon-internal orphan-owner reconciliation (#4403).
-	expect(DAEMON_GENERATION).toBe(166);
+	// Generation 167: repairs the telegram daemon generation guard bootstrap so
+	// the generator's post-fix manifest check byte-compares the regenerated disk
+	// manifest against the current tree, and pre-registry legacy stray Telegram
+	// daemons are auto-reaped (#4533).
+	expect(DAEMON_GENERATION).toBe(167);
 	expect(SERVING_EPOCH).toBe(87);
 });
 test("archives pending topics into retained inactive records", async () => {

--- a/scripts/telegram-daemon-generation-guard.test.ts
+++ b/scripts/telegram-daemon-generation-guard.test.ts
@@ -16,8 +16,10 @@ import {
 	manifestForCurrentTree,
 	protectedInventory,
 	replaceNumericLiteral,
+	replaceTopicRegistryGenerationPin,
 	TELEGRAM_LIFECYCLE_PROTECTED_DECLARATIONS,
 	TELEGRAM_SHUTDOWN_DRAIN_PROTECTED_DECLARATIONS,
+	topicRegistryGenerationPin,
 	validateCiInputs,
 	validateCurrentTreeManifest,
 	validateInventory,
@@ -29,6 +31,7 @@ import {
 
 const guardScript = "scripts/telegram-daemon-generation-guard.ts";
 const manifestScript = "scripts/telegram-daemon-generation-manifest.json";
+const topicRegistryFixture = "packages/coding-agent/test/notifications-topic-registry.test.ts";
 const stableEntries = (value: Record<string, string>) => JSON.stringify(Object.entries(value).sort());
 
 const telegramContract = "packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts";
@@ -1303,5 +1306,123 @@ describe("fix-generations auto-repair", () => {
 		const remediationMessage = `protected Telegram lifecycle change requires a strictly higher DAEMON_GENERATION: ${telegramChanges.join(", ")}\n${FIX_GENERATIONS_REMEDIATION}`;
 		expect(remediationMessage).toContain("--fix-generations");
 		expect(FIX_GENERATIONS_REMEDIATION).toContain("base-sha");
+	});
+
+	test("topicRegistryGenerationPin extracts the pinned durable-authority generation", () => {
+		const source = `test("publishes exact durable authority generation 166 at serving epoch 87", () => {
+	// Generation 58: parser-valid durable-fence promotion and rollback.
+	expect(DAEMON_GENERATION).toBe(166);
+	expect(SERVING_EPOCH).toBe(87);
+});`;
+		expect(topicRegistryGenerationPin(source)).toBe(166);
+		expect(topicRegistryGenerationPin('test("unrelated", () => { expect(DAEMON_GENERATION).toBe(5); });')).toBeUndefined();
+	});
+
+	test("replaceTopicRegistryGenerationPin rewrites title and assertion preserving formatting", () => {
+		const source = `import { DAEMON_GENERATION } from "../src/telegram-daemon-contract";
+
+test("publishes exact durable authority generation 166 at serving epoch 87", () => {
+	// Generation 166: complete owned process-group cleanup (#4403).
+	expect(DAEMON_GENERATION).toBe(166);
+	expect(SERVING_EPOCH).toBe(87);
+});`;
+		expect(replaceTopicRegistryGenerationPin(source, 167)).toBe(`import { DAEMON_GENERATION } from "../src/telegram-daemon-contract";
+
+test("publishes exact durable authority generation 167 at serving epoch 87", () => {
+	// Generation 166: complete owned process-group cleanup (#4403).
+	expect(DAEMON_GENERATION).toBe(167);
+	expect(SERVING_EPOCH).toBe(87);
+});`);
+	});
+
+	test("replaceTopicRegistryGenerationPin fails closed on a missing or malformed pin test", () => {
+		expect(() => replaceTopicRegistryGenerationPin('test("unrelated", () => {});', 167)).toThrow("must be present and unique to sync");
+		expect(() => replaceTopicRegistryGenerationPin('test("publishes exact durable authority generation 166 at serving epoch 87", () => { expect(DAEMON_GENERATION).toBe("stale"); });', 167)).toThrow("must be present and unique to sync");
+	});
+
+	test("computeRepairPlan syncs the fixture pin when the Telegram generation already moved in head", () => {
+		const base = repairFiles({ telegramGeneration: 166, discordGeneration: 63, slackGeneration: 66, telegramOwnership: "return true;" });
+		const head = repairFiles({ telegramGeneration: 167, discordGeneration: 63, slackGeneration: 66, telegramOwnership: "return true;" });
+		const fixtureSource = (generation: number) =>
+			`test("publishes exact durable authority generation ${generation} at serving epoch 87", () => {\n\texpect(DAEMON_GENERATION).toBe(${generation});\n});`;
+		base.set(topicRegistryFixture, fixtureSource(166));
+		head.set(topicRegistryFixture, fixtureSource(166));
+		const plan = computeRepairPlan(base, head, inventory);
+		// The author already bumped the contract; only the stale fixture needs syncing.
+		expect(plan.generationEdits).toEqual([]);
+		expect(plan.fixtureEdits).toEqual([{ kind: "telegram", file: topicRegistryFixture, from: 166, to: 167 }]);
+	});
+
+	test("computeRepairPlan emits the fixture edit alongside a forced contract bump", () => {
+		const base = repairFiles({ telegramGeneration: 166, discordGeneration: 63, slackGeneration: 66, telegramOwnership: "return true;" });
+		const head = repairFiles({ telegramGeneration: 166, discordGeneration: 63, slackGeneration: 66, telegramOwnership: "return false;" });
+		const fixtureSource = (generation: number) =>
+			`test("publishes exact durable authority generation ${generation} at serving epoch 87", () => {\n\texpect(DAEMON_GENERATION).toBe(${generation});\n});`;
+		base.set(topicRegistryFixture, fixtureSource(166));
+		head.set(topicRegistryFixture, fixtureSource(166));
+		const plan = computeRepairPlan(base, head, inventory);
+		expect(plan.generationEdits).toEqual([{ kind: "telegram", file: contractFile, from: 166, to: 167 }]);
+		expect(plan.fixtureEdits).toEqual([{ kind: "telegram", file: topicRegistryFixture, from: 166, to: 167 }]);
+	});
+
+	test("computeRepairPlan leaves the fixture untouched when the Telegram generation is unchanged", () => {
+		const base = repairFiles({ telegramGeneration: 166, discordGeneration: 63, slackGeneration: 66, telegramOwnership: "return true;" });
+		const head = repairFiles({ telegramGeneration: 166, discordGeneration: 64, slackGeneration: 67, telegramOwnership: "return true;" });
+		head.set(chatControl, (head.get(chatControl) ?? "").replace("return value !== null", "return Boolean(value)"));
+		const fixtureSource = (generation: number) =>
+			`test("publishes exact durable authority generation ${generation} at serving epoch 87", () => {\n\texpect(DAEMON_GENERATION).toBe(${generation});\n});`;
+		base.set(topicRegistryFixture, fixtureSource(166));
+		head.set(topicRegistryFixture, fixtureSource(166));
+		const plan = computeRepairPlan(base, head, inventory);
+		expect(plan.fixtureEdits).toEqual([]);
+	});
+
+	test("computeRepairPlan fails closed on a malformed fixture pin when Telegram changes", () => {
+		const base = repairFiles({ telegramGeneration: 166, discordGeneration: 63, slackGeneration: 66, telegramOwnership: "return true;" });
+		const head = repairFiles({ telegramGeneration: 167, discordGeneration: 63, slackGeneration: 66, telegramOwnership: "return true;" });
+		base.set(topicRegistryFixture, `test("publishes exact durable authority generation 166 at serving epoch 87", () => {});`);
+		head.set(topicRegistryFixture, `test("publishes exact durable authority generation 166 at serving epoch 87", () => {});`);
+		const plan = computeRepairPlan(base, head, inventory);
+		expect(plan.malformedDeclarations).toContain(`telegram:${topicRegistryFixture}:durable-authority-generation-pin`);
+		expect(plan.fixtureEdits).toEqual([]);
+	});
+
+	test("computeRepairPlan reconciles a fixture stale against the already-current generation", () => {
+		// The exact composition that left dev red: the canonical generation moved
+		// earlier (already merged) but the snapshot pin was never synced. There is
+		// no transition to detect, so the fixture is reconciled with the canonical
+		// head generation directly.
+		const base = repairFiles({ telegramGeneration: 167, discordGeneration: 63, slackGeneration: 66, telegramOwnership: "return true;" });
+		const head = repairFiles({ telegramGeneration: 167, discordGeneration: 63, slackGeneration: 66, telegramOwnership: "return true;" });
+		const fixtureSource = (generation: number) =>
+			`test("publishes exact durable authority generation ${generation} at serving epoch 87", () => {\n\texpect(DAEMON_GENERATION).toBe(${generation});\n});`;
+		base.set(topicRegistryFixture, fixtureSource(166));
+		head.set(topicRegistryFixture, fixtureSource(166));
+		const plan = computeRepairPlan(base, head, inventory);
+		expect(plan.noProtectedChanges).toBe(true);
+		expect(plan.generationEdits).toEqual([]);
+		expect(plan.fixtureEdits).toEqual([{ kind: "telegram", file: topicRegistryFixture, from: 166, to: 167 }]);
+	});
+
+	test("computeRepairPlan leaves an already-synced fixture untouched", () => {
+		const base = repairFiles({ telegramGeneration: 167, discordGeneration: 63, slackGeneration: 66, telegramOwnership: "return true;" });
+		const head = repairFiles({ telegramGeneration: 167, discordGeneration: 63, slackGeneration: 66, telegramOwnership: "return true;" });
+		const fixtureSource = (generation: number) =>
+			`test("publishes exact durable authority generation ${generation} at serving epoch 87", () => {\n\texpect(DAEMON_GENERATION).toBe(${generation});\n});`;
+		base.set(topicRegistryFixture, fixtureSource(167));
+		head.set(topicRegistryFixture, fixtureSource(167));
+		const plan = computeRepairPlan(base, head, inventory);
+		expect(plan.fixtureEdits).toEqual([]);
+	});
+
+	test("the committed topic-registry fixture tracks the canonical Telegram generation", async () => {
+		const fixture = await Bun.file(topicRegistryFixture).text();
+		const contract = await Bun.file(telegramContract).text();
+		const declared = declaration(contract, "DAEMON_GENERATION");
+		expect(declared).toBeDefined();
+		const canonical = Number(/DAEMON_GENERATION\s*=\s*(\d+)/.exec(declared!)?.[1]);
+		expect(Number.isInteger(canonical)).toBe(true);
+		const pinned = topicRegistryGenerationPin(fixture);
+		expect(pinned).toBe(canonical);
 	});
 });

--- a/scripts/telegram-daemon-generation-guard.ts
+++ b/scripts/telegram-daemon-generation-guard.ts
@@ -8,7 +8,7 @@ import * as path from "node:path";
 
 const root = path.join(import.meta.dir, "..");
 const SHA = /^[0-9a-f]{40}$/i;
-export const GUARD_CONTRACT_VERSION = 50;
+export const GUARD_CONTRACT_VERSION = 51;
 const telegramContract = "packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts";
 const telegramDaemon = "packages/coding-agent/src/sdk/bus/telegram-daemon.ts";
 const telegramControl = "packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts";
@@ -24,6 +24,14 @@ const config = "packages/coding-agent/src/sdk/bus/config.ts";
 const busIndex = "packages/coding-agent/src/sdk/bus/index.ts";
 const guardScript = "scripts/telegram-daemon-generation-guard.ts";
 const manifestScript = "scripts/telegram-daemon-generation-manifest.json";
+
+/**
+ * The topic-registry durable-authority snapshot. The guard's deterministic
+ * repair path syncs this fixture's generation pin whenever the Telegram
+ * generation changes, so a valid bump can never leave the assertion stale
+ * while the exact pin still fails closed on accidental drift.
+ */
+const topicRegistryFixture = "packages/coding-agent/test/notifications-topic-registry.test.ts";
 const nativeAuthorityDeclarations = {
 	"crates/pi-natives/src/path_identity.rs": [
 		"retain_broker_publication",
@@ -1148,12 +1156,122 @@ export function replaceNumericLiteral(source: string, name: string, newValue: nu
 	return `${source.slice(0, location.start)}${String(newValue)}${source.slice(location.end)}`;
 }
 
+/**
+ * The exact title of the topic-registry durable-authority snapshot test. Its
+ * generation number must track DAEMON_GENERATION so behavior pinned to the
+ * registry contract is always acknowledged at each generation bump.
+ */
+const TOPIC_REGISTRY_GENERATION_PIN_TITLE = /^publishes exact durable authority generation \d+ at serving epoch \d+$/;
+
+function topicRegistryToBeLiteral(node: unknown): { start: number; end: number } | undefined {
+	if (!node || typeof node !== "object") return undefined;
+	const candidate = node as { type?: string; start?: number; end?: number; callee?: unknown; property?: unknown; object?: unknown; arguments?: unknown[]; [key: string]: unknown };
+	if (
+		candidate.type === "CallExpression" &&
+		candidate.callee &&
+		typeof candidate.callee === "object" &&
+		(candidate.callee as { type?: string; object?: unknown; property?: unknown }).type === "MemberExpression" &&
+		(candidate.callee as { property?: unknown }).property &&
+		typeof (candidate.callee as { property?: unknown }).property === "object" &&
+		(candidate.callee as { property: { type?: string; name?: string } }).property.type === "Identifier" &&
+		(candidate.callee as { property: { name?: string } }).property.name === "toBe" &&
+		(candidate.callee as { object?: unknown }).object &&
+		typeof (candidate.callee as { object?: unknown }).object === "object" &&
+		(candidate.callee as { object: { type?: string; callee?: unknown; arguments?: unknown[] } }).object.type === "CallExpression" &&
+		(candidate.callee as { object: { callee?: unknown } }).object.callee &&
+		typeof (candidate.callee as { object: { callee?: unknown } }).object.callee === "object" &&
+		(candidate.callee as { object: { callee: { type?: string; name?: string } } }).object.callee.type === "Identifier" &&
+		(candidate.callee as { object: { callee: { name?: string } } }).object.callee.name === "expect" &&
+		Array.isArray((candidate.callee as { object: { arguments?: unknown[] } }).object.arguments) &&
+		(candidate.callee as { object: { arguments: unknown[] } }).object.arguments[0] &&
+		typeof (candidate.callee as { object: { arguments: unknown[] } }).object.arguments[0] === "object" &&
+		(candidate.callee as { object: { arguments: Array<{ type?: string; name?: string }> } }).object.arguments[0].type === "Identifier" &&
+		(candidate.callee as { object: { arguments: Array<{ name?: string }> } }).object.arguments[0].name === "DAEMON_GENERATION" &&
+		Array.isArray(candidate.arguments) &&
+		candidate.arguments[0] &&
+		typeof candidate.arguments[0] === "object" &&
+		(candidate.arguments[0] as { type?: string }).type === "NumericLiteral" &&
+		typeof (candidate.arguments[0] as { start?: number }).start === "number" &&
+		typeof (candidate.arguments[0] as { end?: number }).end === "number"
+	) {
+		return { start: (candidate.arguments[0] as { start: number }).start, end: (candidate.arguments[0] as { end: number }).end };
+	}
+	for (const [key, child] of Object.entries(candidate)) {
+		if (key === "loc" || key === "extra") continue;
+		if (Array.isArray(child)) {
+			for (const item of child) {
+				const found = topicRegistryToBeLiteral(item);
+				if (found) return found;
+			}
+		} else {
+			const found = topicRegistryToBeLiteral(child);
+			if (found) return found;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Locate the source spans of the topic-registry durable-authority generation
+ * pin: the generation digits inside the test title and the numeric literal of
+ * the `expect(DAEMON_GENERATION).toBe(...)` assertion inside that test. Uses the
+ * same AST-backed extraction as the guard so comments and similarly named text
+ * cannot match. Returns undefined when the pin test is missing or ambiguous.
+ */
+function topicRegistryGenerationPinLocation(source: string): { titleDigitsStart: number; titleDigitsEnd: number; toBeStart: number; toBeEnd: number } | undefined {
+	try {
+		const ast = parse(source, { sourceType: "module", plugins: ["typescript"] });
+		for (const statement of ast.program.body) {
+			if (statement.type !== "ExpressionStatement" || statement.expression.type !== "CallExpression") continue;
+			const call = statement.expression;
+			if (call.callee.type !== "Identifier" || call.callee.name !== "test" || call.arguments.length < 2) continue;
+			const title = call.arguments[0];
+			if (!title || title.type !== "StringLiteral") continue;
+			const raw = title.extra?.raw;
+			if (typeof raw !== "string" || typeof title.start !== "number" || !TOPIC_REGISTRY_GENERATION_PIN_TITLE.test(title.value)) continue;
+			const digits = /generation (\d+)/.exec(raw);
+			if (!digits) continue;
+			const titleDigitsStart = title.start + digits.index + "generation ".length;
+			const titleDigitsEnd = titleDigitsStart + digits[1]!.length;
+			const callback = call.arguments[1];
+			if (!callback || (callback.type !== "ArrowFunctionExpression" && callback.type !== "FunctionExpression")) continue;
+			const toBe = topicRegistryToBeLiteral(callback.body);
+			if (!toBe) continue;
+			return { titleDigitsStart, titleDigitsEnd, toBeStart: toBe.start, toBeEnd: toBe.end };
+		}
+		return undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/** The pinned generation number the topic-registry durable-authority snapshot asserts. */
+export function topicRegistryGenerationPin(source: string): number | undefined {
+	const location = topicRegistryGenerationPinLocation(source);
+	if (!location) return undefined;
+	return Number(source.slice(location.toBeStart, location.toBeEnd));
+}
+
+/**
+ * Rewrite the topic-registry durable-authority generation pin (the test title
+ * digits and the `expect(DAEMON_GENERATION).toBe(...)` assertion) to a new
+ * integer, preserving all surrounding source formatting. Throws if the pin test
+ * is missing, ambiguous, or non-numeric — never silently writes a malformed edit.
+ */
+export function replaceTopicRegistryGenerationPin(source: string, newValue: number): string {
+	const location = topicRegistryGenerationPinLocation(source);
+	if (!location) throw new Error("telegram-daemon-generation-guard: the topic-registry durable-authority generation pin test must be present and unique to sync");
+	return `${source.slice(0, location.titleDigitsStart)}${String(newValue)}${source.slice(location.titleDigitsEnd, location.toBeStart)}${String(newValue)}${source.slice(location.toBeEnd)}`;
+}
+
 /** A single generation-constant repair edit. */
 export type GenerationEdit = { kind: "telegram" | "discord" | "slack"; file: string; from: number; to: number };
 
 /** The complete repair plan for one `--fix-generations` invocation. */
 export type RepairPlan = {
 	generationEdits: GenerationEdit[];
+	/** Deterministic sync of the topic-registry durable-authority snapshot pin. */
+	fixtureEdits: GenerationEdit[];
 	needsGuardPolicyAuthority: boolean;
 	guardContractEdit: { from: number; to: number } | undefined;
 	malformedDeclarations: string[];
@@ -1173,17 +1291,39 @@ export function computeRepairPlan(
 	baseInventory: Inventory = inventory,
 ): RepairPlan {
 	const decision = evaluate(base, head, inventory, baseInventory);
-	if (decision.malformedDeclarations.length > 0)
-		return { generationEdits: [], needsGuardPolicyAuthority: false, guardContractEdit: undefined, malformedDeclarations: decision.malformedDeclarations, noProtectedChanges: false };
+	const malformedDeclarations = [...decision.malformedDeclarations];
 	const generationEdits: GenerationEdit[] = [];
-	const telegramAffected = decision.protectedChanges.some(change => change.startsWith("telegram:"));
-	if (telegramAffected) {
-		const baseGen = generation(base.get(telegramContract));
-		const headGen = generation(head.get(telegramContract));
-		if (baseGen === undefined || headGen === undefined)
-			throw new Error("telegram-daemon-generation-guard: DAEMON_GENERATION is missing or non-numeric in base or head");
-		if (headGen <= baseGen) generationEdits.push({ kind: "telegram", file: telegramContract, from: headGen, to: baseGen + 1 });
+	const fixtureEdits: GenerationEdit[] = [];
+	let telegramTargetGeneration: number | undefined;
+	if (decision.malformedDeclarations.length === 0) {
+		const telegramAffected = decision.protectedChanges.some(change => change.startsWith("telegram:"));
+		if (telegramAffected) {
+			const baseGen = generation(base.get(telegramContract));
+			const headGen = generation(head.get(telegramContract));
+			if (baseGen === undefined || headGen === undefined)
+				throw new Error("telegram-daemon-generation-guard: DAEMON_GENERATION is missing or non-numeric in base or head");
+			if (headGen <= baseGen) generationEdits.push({ kind: "telegram", file: telegramContract, from: headGen, to: baseGen + 1 });
+			telegramTargetGeneration = headGen > baseGen ? headGen : baseGen + 1;
+		} else {
+			telegramTargetGeneration = generation(head.get(telegramContract));
+		}
+		// Deterministically reconcile the topic-registry durable-authority snapshot
+		// with the canonical head generation — whether the generation moved in this
+		// transition or is already current — so a valid bump can never leave the
+		// hard-coded pin stale. A present-but-malformed pin fails closed.
+		const baseFixture = base.get(topicRegistryFixture);
+		const headFixture = head.get(topicRegistryFixture);
+		if (telegramTargetGeneration !== undefined && baseFixture !== undefined && headFixture !== undefined) {
+			const headPin = topicRegistryGenerationPin(headFixture);
+			if (headPin === undefined) {
+				malformedDeclarations.push(`telegram:${topicRegistryFixture}:durable-authority-generation-pin`);
+			} else if (headPin !== telegramTargetGeneration) {
+				fixtureEdits.push({ kind: "telegram", file: topicRegistryFixture, from: headPin, to: telegramTargetGeneration });
+			}
+		}
 	}
+	if (malformedDeclarations.length > 0)
+		return { generationEdits: [], fixtureEdits: [], needsGuardPolicyAuthority: false, guardContractEdit: undefined, malformedDeclarations, noProtectedChanges: false };
 	for (const kind of ["discord", "slack"] as const) {
 		const affected = decision.protectedChanges.some(change => change.startsWith(`${kind}:`));
 		if (!affected) continue;
@@ -1201,7 +1341,7 @@ export function computeRepairPlan(
 			throw new Error("telegram-daemon-generation-guard: GUARD_CONTRACT_VERSION is missing or non-numeric in base");
 		guardContractEdit = { from: baseVersion, to: baseVersion + 1 };
 	}
-	return { generationEdits, needsGuardPolicyAuthority, guardContractEdit, malformedDeclarations: [], noProtectedChanges: decision.protectedChanges.length === 0 };
+	return { generationEdits, fixtureEdits, needsGuardPolicyAuthority, guardContractEdit, malformedDeclarations: [], noProtectedChanges: decision.protectedChanges.length === 0 };
 }
 
 /**
@@ -1222,6 +1362,7 @@ export async function fixGenerations(baseInput: string | undefined, options: { f
 	const filePaths = [
 		guardScript,
 		manifestScript,
+		topicRegistryFixture,
 		...new Set([
 			...Object.values(baseInventory).flatMap(inv => Object.keys(inv)),
 			...Object.values(protectedInventory).flatMap(inv => Object.keys(inv)),
@@ -1240,13 +1381,14 @@ export async function fixGenerations(baseInput: string | undefined, options: { f
 	if (plan.needsGuardPolicyAuthority && !options.fixGuardPolicy)
 		throw new Error("telegram-daemon-generation-guard: guard policy change requires a strictly higher GUARD_CONTRACT_VERSION; rerun with --fix-guard-policy to bump it automatically");
 	const hasGuardContractBump = plan.needsGuardPolicyAuthority && options.fixGuardPolicy === true && plan.guardContractEdit !== undefined;
-	if (plan.generationEdits.length === 0 && !hasGuardContractBump) {
+	if (plan.generationEdits.length === 0 && plan.fixtureEdits.length === 0 && !hasGuardContractBump) {
 		console.log(`telegram-daemon-generation-guard: v${GUARD_CONTRACT_VERSION} no generation bumps required`);
 		return;
 	}
 	// Snapshot every file that may be mutated so rollback restores the exact prior state.
 	const editFiles = new Set<string>();
 	for (const edit of plan.generationEdits) editFiles.add(edit.file);
+	for (const edit of plan.fixtureEdits) editFiles.add(edit.file);
 	if (hasGuardContractBump) editFiles.add(guardScript);
 	editFiles.add(manifestScript);
 	const snapshots = new Map<string, string | undefined>();
@@ -1259,6 +1401,11 @@ export async function fixGenerations(baseInput: string | undefined, options: { f
 				? replaceNumericLiteral(current, "DAEMON_GENERATION", edit.to)
 				: replaceNumericLiteral(current, "CHAT_DAEMON_GENERATIONS", edit.to, edit.kind);
 			await Bun.write(filePath, updated);
+		}
+		for (const edit of plan.fixtureEdits) {
+			const filePath = path.join(root, edit.file);
+			const current = await Bun.file(filePath).text();
+			await Bun.write(filePath, replaceTopicRegistryGenerationPin(current, edit.to));
 		}
 		if (hasGuardContractBump && plan.guardContractEdit) {
 			const guardPath = path.join(root, guardScript);
@@ -1305,6 +1452,7 @@ export async function fixGenerations(baseInput: string | undefined, options: { f
 		}
 		// Print a bounded, secret-free summary.
 		const parts: string[] = plan.generationEdits.map(edit => `${edit.kind} ${edit.from}→${edit.to}`);
+		for (const edit of plan.fixtureEdits) parts.push(`fixture ${edit.from}→${edit.to}`);
 		if (hasGuardContractBump && plan.guardContractEdit) parts.push(`guard-contract ${plan.guardContractEdit.from}→${plan.guardContractEdit.to}`);
 		console.log(`telegram-daemon-generation-guard: v${GUARD_CONTRACT_VERSION} applied ${parts.join(", ")}`);
 	} catch (error) {

--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -1,5 +1,5 @@
 {
-  "contractVersion": 50,
+  "contractVersion": 51,
   "inventory": {
     "telegram": {
       "packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts": [


### PR DESCRIPTION
Closes #4553

## Summary

Deterministic stale-fixture repair that restores `dev` green. `packages/coding-agent/test/notifications-topic-registry.test.ts` pinned `DAEMON_GENERATION === 166` while the canonical runtime generation became **167** through the already-merged Telegram generation guard-bootstrap repair (PR #4533, commit `c734e53d59`). PR #4550's merge is the current dev head where that stale composition is terminal red (shard 1 job `94732792508`, Dev CI run `31789008766`).

The fixture duplicated a manual sync step the generation generator never covered, so any future valid generation bump left the assertion stale the same way. This PR fixes the fixture **and** binds it to the deterministic generator authority so future bumps cannot leave it stale while accidental drift still fails closed.

## Exact fail-before evidence (clean dev `8e0c0c14`)

```
packages/coding-agent/test/notifications-topic-registry.test.ts:
782 |  expect(DAEMON_GENERATION).toBe(166);
error: expect(received).toBe(expected)
Expected: 166
Received: 167
(fail) publishes exact durable authority generation 166 at serving epoch 87
59 pass / 1 fail
```

Guard baseline on clean dev: `--validate-current-tree` passes (manifest was in sync; only the test fixture was stale).

## Fix

1. **Fixture sync** — pin/title/comment moved to generation 167; generation 167 documented in the contract's canonical history log (`telegram-daemon-contract.ts`, comment-only, digest-neutral — verified `--validate-current-tree` stays green).
2. **Deterministic binding** (`scripts/telegram-daemon-generation-guard.ts`) — `computeRepairPlan`/`fixGenerations` now reconcile the topic-registry durable-authority pin whenever the Telegram generation changes **or** is already current but the fixture drifted, so `--fix-generations` atomically syncs the fixture together with the contract constant and the regenerated manifest. The exact pin remains, preserving drift detection; a malformed pin fails closed. `GUARD_CONTRACT_VERSION` 50→51 + manifest `contractVersion` 51 regenerated by the generator (no hand-edited digests; manifest diff is exactly the version field).
3. **Deterministic coverage** (`telegram-daemon-generation-guard.test.ts`, 10 new tests) — pin extraction/rewrite, transition sync, no-transition reconciliation (the exact dev-stale composition), untouched-when-synced, malformed fail-closed, and a current-tree test proving the committed fixture tracks the canonical generation.

## Exact pass-after evidence

| Check | Result |
|---|---|
| `bun test packages/coding-agent/test/notifications-topic-registry.test.ts` | 60 pass / 0 fail |
| `bun test scripts/telegram-daemon-generation-guard.test.ts` | 75 pass / 0 fail |
| notification suites (daemon-control, notifications-telegram-daemon, notifications-service, notifications-orchestration, notifications-config) | 384 pass / 0 fail |
| `bun scripts/telegram-daemon-generation-guard.ts --validate-current-tree` | exit 0 (manifest byte-matches tree) |
| CI-equivalent guard `run()` base `8e0c0c14` → head `99669a8b4c` | `v51 no protected changes`, exit 0 |
| `bun --cwd=packages/coding-agent run check` (biome + tsc) | exit 0 |
| biome check on changed files | OK |
| E2E `--fix-generations` in isolated worktree reproducing the stale composition (contract 167 / fixture 166, no transition) | `applied fixture 166→167, guard-contract 50→51`; fixture, guard, manifest all reconciled; focused test green |

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:27ec8ded8a061b6b02424080e36d5b47b06bc2d9addb97a10620259e44fc2086 reviewer:human reviewer-id:probepark evidence:fresh worktree 135pass-0fail; base cannot load new export; check exit0
```

Exact-head CI and an independent authenticated review are required before merge; verdict will be updated to `merge-approved` only after an authenticated APPROVED review of this exact head and terminal green CI.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*

