### PR TITLE
feat(ai): parse contextWindow and maxTokens in openai-compatible discovery

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Generic OpenAI-compatible `/v1/models` discovery now reads served context-window and output-limit metadata instead of defaulting every dynamically listed model to the unknown-window sentinel. `max_model_len` (vLLM/SGLang/oMLX), `context_length`, `context_window`, `max_context_length` (LM Studio), and `max_position_embeddings` populate `contextWindow` in that precedence order, while `max_tokens`/`max_output_tokens` populate `maxTokens`; total-window fields never leak into the output-token ceiling. Malformed values (non-finite, zero, negative, non-numeric) are rejected per-field with fallback to the next candidate, so a `1e400`-style catalog entry can no longer poison compaction thresholds or compact-input budgets.
 - Refreshed the bundled ZAI catalog with GLM-5.3 and made it the provider's default model.
 - Added the typed `local_snapshot_failure` and `local_buffer_overflow` assistant error kinds so downstream retry policy can distinguish local event-snapshot and staging-buffer failures from provider failures.
 - Defense-in-depth: a completed Anthropic stream whose assembled assistant content carries directly adjacent `thinking`/`redacted_thinking` blocks now emits a bounded diagnostic per stream invocation naming only the envelope shape (block count, adjacency presence, model, provider), never raw thinking text, signatures, or redacted payloads. The send-boundary collapse remains the wire source of truth; this is a read-only observation that helps surface upstream producers of the rejected shape (#4443).

--- a/packages/ai/src/utils/discovery/openai-compatible.ts
+++ b/packages/ai/src/utils/discovery/openai-compatible.ts
@@ -1,6 +1,7 @@
 import { UNK_CONTEXT_WINDOW, UNK_MAX_TOKENS } from "@gajae-code/ai";
 import * as z from "zod/v4";
 import type { Api, FetchImpl, Model, Provider } from "../../types";
+import { toNumber } from "../../utils";
 
 const MODELS_PATH = "/models";
 
@@ -162,25 +163,16 @@ export async function fetchOpenAICompatibleModels<TApi extends Api>(
 
 	const deduped = new Map<string, Model<TApi>>();
 	for (const entry of entries) {
-		const rawContextWindow =
-			typeof entry.max_model_len === "number" && entry.max_model_len > 0
-				? entry.max_model_len
-				: typeof entry.context_length === "number" && entry.context_length > 0
-					? entry.context_length
-					: typeof entry.context_window === "number" && entry.context_window > 0
-						? entry.context_window
-						: typeof entry.max_context_length === "number" && entry.max_context_length > 0
-							? entry.max_context_length
-							: typeof entry.max_position_embeddings === "number" && entry.max_position_embeddings > 0
-								? entry.max_position_embeddings
-								: UNK_CONTEXT_WINDOW;
+		const rawContextWindow = firstPositiveModelNumber(
+			UNK_CONTEXT_WINDOW,
+			entry.max_model_len,
+			entry.context_length,
+			entry.context_window,
+			entry.max_context_length,
+			entry.max_position_embeddings,
+		);
 
-		const rawMaxTokens =
-			typeof entry.max_tokens === "number" && entry.max_tokens > 0
-				? entry.max_tokens
-				: typeof entry.max_output_tokens === "number" && entry.max_output_tokens > 0
-					? entry.max_output_tokens
-					: UNK_MAX_TOKENS;
+		const rawMaxTokens = firstPositiveModelNumber(UNK_MAX_TOKENS, entry.max_tokens, entry.max_output_tokens);
 
 		const defaults: Model<TApi> = {
 			id: entry.id,
@@ -263,4 +255,21 @@ function extractModelEntriesFromNode(node: unknown): ParsedOpenAICompatibleModel
 	}
 
 	return null;
+}
+
+/**
+ * First finite positive number among candidates, else the fallback.
+ *
+ * Rejects non-numbers, non-finite values (JSON `1e400` parses to
+ * `Infinity`), zero, and negatives so a malformed catalog field can never
+ * poison compaction thresholds or output budgets with `Infinity`.
+ */
+function firstPositiveModelNumber(fallback: number, ...candidates: readonly unknown[]): number {
+	for (const candidate of candidates) {
+		const value = toNumber(candidate);
+		if (value !== undefined && value > 0 && Number.isFinite(value)) {
+			return value;
+		}
+	}
+	return fallback;
 }

--- a/packages/ai/src/utils/discovery/openai-compatible.ts
+++ b/packages/ai/src/utils/discovery/openai-compatible.ts
@@ -162,6 +162,26 @@ export async function fetchOpenAICompatibleModels<TApi extends Api>(
 
 	const deduped = new Map<string, Model<TApi>>();
 	for (const entry of entries) {
+		const rawContextWindow =
+			typeof entry.max_model_len === "number" && entry.max_model_len > 0
+				? entry.max_model_len
+				: typeof entry.context_length === "number" && entry.context_length > 0
+					? entry.context_length
+					: typeof entry.context_window === "number" && entry.context_window > 0
+						? entry.context_window
+						: typeof entry.max_context_length === "number" && entry.max_context_length > 0
+							? entry.max_context_length
+							: typeof entry.max_position_embeddings === "number" && entry.max_position_embeddings > 0
+								? entry.max_position_embeddings
+								: UNK_CONTEXT_WINDOW;
+
+		const rawMaxTokens =
+			typeof entry.max_tokens === "number" && entry.max_tokens > 0
+				? entry.max_tokens
+				: typeof entry.max_output_tokens === "number" && entry.max_output_tokens > 0
+					? entry.max_output_tokens
+					: UNK_MAX_TOKENS;
+
 		const defaults: Model<TApi> = {
 			id: entry.id,
 			name: typeof entry.name === "string" && entry.name.length > 0 ? entry.name : entry.id,
@@ -171,8 +191,8 @@ export async function fetchOpenAICompatibleModels<TApi extends Api>(
 			reasoning: false,
 			input: ["text"],
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: UNK_CONTEXT_WINDOW,
-			maxTokens: UNK_MAX_TOKENS,
+			contextWindow: rawContextWindow,
+			maxTokens: rawMaxTokens,
 		};
 
 		const mapped = options.mapModel?.(entry, defaults, context) ?? defaults;

--- a/packages/ai/test/openai-compatible-discovery.test.ts
+++ b/packages/ai/test/openai-compatible-discovery.test.ts
@@ -127,7 +127,7 @@ describe("fetchOpenAICompatibleModels contextWindow & maxTokens discovery", () =
 		// thresholds and collapse compact-input budgets to zero.
 		const body =
 			'{"object":"list","data":[{"id":"bad-limits","max_model_len":1e400,"context_length":1e400,"context_window":1e400,"max_context_length":1e400,"max_tokens":1e400}]}';
-		global.fetch = (async () =>
+		global.fetch = (async (_url: string | URL | Request) =>
 			new Response(body, { status: 200, headers: { "content-type": "application/json" } })) as typeof fetch;
 
 		const models = await fetchOpenAICompatibleModels(options);
@@ -152,7 +152,7 @@ describe("fetchOpenAICompatibleModels contextWindow & maxTokens discovery", () =
 	it("skips a malformed field and takes the next positive candidate", async () => {
 		const body =
 			'{"object":"list","data":[{"id":"mixed-model","max_model_len":1e400,"context_length":131072,"max_tokens":0}]}';
-		global.fetch = (async () =>
+		global.fetch = (async (_url: string | URL | Request) =>
 			new Response(body, { status: 200, headers: { "content-type": "application/json" } })) as typeof fetch;
 
 		const models = await fetchOpenAICompatibleModels(options);
@@ -168,7 +168,7 @@ describe("fetchOpenAICompatibleModels contextWindow & maxTokens discovery", () =
 			'{"id":"healthy","max_model_len":65536,"max_tokens":8192},' +
 			'{"id":"malformed","max_model_len":1e400,"max_tokens":-1},' +
 			'{"id":"bare"}]}';
-		global.fetch = (async () =>
+		global.fetch = (async (_url: string | URL | Request) =>
 			new Response(body, { status: 200, headers: { "content-type": "application/json" } })) as typeof fetch;
 
 		const models = await fetchOpenAICompatibleModels(options);

--- a/packages/ai/test/openai-compatible-discovery.test.ts
+++ b/packages/ai/test/openai-compatible-discovery.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import { UNK_CONTEXT_WINDOW, UNK_MAX_TOKENS } from "@gajae-code/ai";
 import { fetchOpenAICompatibleModels } from "../src/utils/discovery/openai-compatible";
 
 const originalFetch = global.fetch;
@@ -7,33 +8,36 @@ afterEach(() => {
 	global.fetch = originalFetch;
 });
 
+function respondWithModels(models: unknown): void {
+	global.fetch = (async (url: string | URL | Request) => {
+		if (String(url).endsWith("/models")) {
+			return new Response(JSON.stringify({ object: "list", data: models }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}
+		return new Response("Not found", { status: 404 });
+	}) as typeof fetch;
+}
+
+const options = {
+	api: "openai-completions" as const,
+	provider: "custom",
+	baseUrl: "http://127.0.0.1:8000/v1",
+};
+
 describe("fetchOpenAICompatibleModels contextWindow & maxTokens discovery", () => {
 	it("parses max_model_len for contextWindow from OpenAI-compatible /v1/models response", async () => {
-		global.fetch = (async (url: string | URL | Request) => {
-			if (String(url).endsWith("/models")) {
-				return new Response(
-					JSON.stringify({
-						object: "list",
-						data: [
-							{
-								id: "Qwen3.6-35B-A3B-8bit",
-								object: "model",
-								max_model_len: 262144,
-								max_tokens: 16384,
-							},
-						],
-					}),
-					{ status: 200, headers: { "content-type": "application/json" } },
-				);
-			}
-			return new Response("Not found", { status: 404 });
-		}) as typeof fetch;
+		respondWithModels([
+			{
+				id: "Qwen3.6-35B-A3B-8bit",
+				object: "model",
+				max_model_len: 262144,
+				max_tokens: 16384,
+			},
+		]);
 
-		const models = await fetchOpenAICompatibleModels({
-			api: "openai-completions",
-			provider: "omlx",
-			baseUrl: "http://127.0.0.1:8000/v1",
-		});
+		const models = await fetchOpenAICompatibleModels(options);
 
 		expect(models).not.toBeNull();
 		expect(models!.length).toBe(1);
@@ -43,30 +47,154 @@ describe("fetchOpenAICompatibleModels contextWindow & maxTokens discovery", () =
 	});
 
 	it("parses context_length as fallback when max_model_len is not present", async () => {
-		global.fetch = (async (url: string | URL | Request) => {
-			if (String(url).endsWith("/models")) {
-				return new Response(
-					JSON.stringify({
-						data: [
-							{
-								id: "custom-local-model",
-								context_length: 131072,
-							},
-						],
-					}),
-					{ status: 200, headers: { "content-type": "application/json" } },
-				);
-			}
-			return new Response("Not found", { status: 404 });
-		}) as typeof fetch;
+		respondWithModels([{ id: "custom-local-model", context_length: 131072 }]);
 
-		const models = await fetchOpenAICompatibleModels({
-			api: "openai-completions",
-			provider: "custom",
-			baseUrl: "http://localhost:8080/v1",
-		});
+		const models = await fetchOpenAICompatibleModels(options);
 
 		expect(models).not.toBeNull();
 		expect(models![0].contextWindow).toBe(131072);
+	});
+
+	it("parses context_window and max_context_length (LM Studio / gateways)", async () => {
+		respondWithModels([
+			{ id: "lm-studio-model", max_context_length: 32768 },
+			{ id: "groq-model", context_window: 131072 },
+		]);
+
+		const models = await fetchOpenAICompatibleModels(options);
+
+		expect(models).not.toBeNull();
+		const byId = new Map(models!.map(model => [model.id, model]));
+		expect(byId.get("lm-studio-model")?.contextWindow).toBe(32768);
+		expect(byId.get("groq-model")?.contextWindow).toBe(131072);
+	});
+
+	it("falls back to max_position_embeddings only when no served context field exists", async () => {
+		respondWithModels([{ id: "hf-adapter-model", max_position_embeddings: 4096 }]);
+
+		const models = await fetchOpenAICompatibleModels(options);
+
+		expect(models).not.toBeNull();
+		expect(models![0].contextWindow).toBe(4096);
+	});
+
+	it("prefers served context fields over max_position_embeddings when both are present", async () => {
+		// max_position_embeddings is the training ceiling; the served window is authoritative.
+		respondWithModels([{ id: "quantized-model", max_model_len: 32768, max_position_embeddings: 262144 }]);
+
+		const models = await fetchOpenAICompatibleModels(options);
+
+		expect(models).not.toBeNull();
+		expect(models![0].contextWindow).toBe(32768);
+	});
+
+	it("keeps the UNK sentinel when the record carries no limit fields at all", async () => {
+		respondWithModels([{ id: "bare-model", object: "model" }]);
+
+		const models = await fetchOpenAICompatibleModels(options);
+
+		expect(models).not.toBeNull();
+		expect(models![0].contextWindow).toBe(UNK_CONTEXT_WINDOW);
+		expect(models![0].maxTokens).toBe(UNK_MAX_TOKENS);
+	});
+
+	it("never assigns a context-window field to maxTokens", async () => {
+		// Adversarial isolation: total-window fields must not leak into the
+		// output-token ceiling (which drives request max_tokens budgets).
+		respondWithModels([
+			{
+				id: "isolated-model",
+				max_model_len: 262144,
+				context_length: 262144,
+				context_window: 262144,
+				max_context_length: 262144,
+				max_position_embeddings: 262144,
+			},
+		]);
+
+		const models = await fetchOpenAICompatibleModels(options);
+
+		expect(models).not.toBeNull();
+		expect(models![0].contextWindow).toBe(262144);
+		expect(models![0].maxTokens).toBe(UNK_MAX_TOKENS);
+	});
+
+	it("rejects non-finite limits and never lets them reach model records", async () => {
+		// A gateway can emit a raw `1e400` literal; JSON.parse yields Infinity
+		// client-side (JSON.stringify of Infinity would produce null, so the
+		// body must be handed to the parser verbatim). Infinity must never
+		// reach contextWindow/maxTokens: it would disable compaction
+		// thresholds and collapse compact-input budgets to zero.
+		const body =
+			'{"object":"list","data":[{"id":"bad-limits","max_model_len":1e400,"context_length":1e400,"context_window":1e400,"max_context_length":1e400,"max_tokens":1e400}]}';
+		global.fetch = (async () =>
+			new Response(body, { status: 200, headers: { "content-type": "application/json" } })) as typeof fetch;
+
+		const models = await fetchOpenAICompatibleModels(options);
+
+		expect(models).not.toBeNull();
+		expect(models![0].contextWindow).toBe(UNK_CONTEXT_WINDOW);
+		expect(models![0].maxTokens).toBe(UNK_MAX_TOKENS);
+	});
+
+	it("rejects zero and negative limits", async () => {
+		respondWithModels([
+			{ id: "zero-negative", max_model_len: 0, context_length: -8, context_window: -1, max_tokens: -1 },
+		]);
+
+		const models = await fetchOpenAICompatibleModels(options);
+
+		expect(models).not.toBeNull();
+		expect(models![0].contextWindow).toBe(UNK_CONTEXT_WINDOW);
+		expect(models![0].maxTokens).toBe(UNK_MAX_TOKENS);
+	});
+
+	it("skips a malformed field and takes the next positive candidate", async () => {
+		const body =
+			'{"object":"list","data":[{"id":"mixed-model","max_model_len":1e400,"context_length":131072,"max_tokens":0}]}';
+		global.fetch = (async () =>
+			new Response(body, { status: 200, headers: { "content-type": "application/json" } })) as typeof fetch;
+
+		const models = await fetchOpenAICompatibleModels(options);
+
+		expect(models).not.toBeNull();
+		expect(models![0].contextWindow).toBe(131072);
+		expect(models![0].maxTokens).toBe(UNK_MAX_TOKENS);
+	});
+
+	it("preserves mixed-record behavior: healthy and malformed entries in one catalog", async () => {
+		const body =
+			'{"object":"list","data":[' +
+			'{"id":"healthy","max_model_len":65536,"max_tokens":8192},' +
+			'{"id":"malformed","max_model_len":1e400,"max_tokens":-1},' +
+			'{"id":"bare"}]}';
+		global.fetch = (async () =>
+			new Response(body, { status: 200, headers: { "content-type": "application/json" } })) as typeof fetch;
+
+		const models = await fetchOpenAICompatibleModels(options);
+
+		expect(models).not.toBeNull();
+		const byId = new Map(models!.map(model => [model.id, model]));
+		expect(byId.get("healthy")?.contextWindow).toBe(65536);
+		expect(byId.get("healthy")?.maxTokens).toBe(8192);
+		expect(byId.get("malformed")?.contextWindow).toBe(UNK_CONTEXT_WINDOW);
+		expect(byId.get("malformed")?.maxTokens).toBe(UNK_MAX_TOKENS);
+		expect(byId.get("bare")?.contextWindow).toBe(UNK_CONTEXT_WINDOW);
+	});
+
+	it("still passes parsed limits through mapModel overrides", async () => {
+		respondWithModels([{ id: "mapped-model", max_model_len: 131072, max_tokens: 4096 }]);
+
+		const models = await fetchOpenAICompatibleModels({
+			...options,
+			mapModel: (entry, defaults) => ({
+				...defaults,
+				contextWindow: typeof entry.max_model_len === "number" ? entry.max_model_len * 2 : defaults.contextWindow,
+			}),
+		});
+
+		expect(models).not.toBeNull();
+		expect(models![0].contextWindow).toBe(262144);
+		expect(models![0].maxTokens).toBe(4096);
 	});
 });

--- a/packages/ai/test/openai-compatible-discovery.test.ts
+++ b/packages/ai/test/openai-compatible-discovery.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { fetchOpenAICompatibleModels } from "../src/utils/discovery/openai-compatible";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+	global.fetch = originalFetch;
+});
+
+describe("fetchOpenAICompatibleModels contextWindow & maxTokens discovery", () => {
+	it("parses max_model_len for contextWindow from OpenAI-compatible /v1/models response", async () => {
+		global.fetch = (async (url: string | URL | Request) => {
+			if (String(url).endsWith("/models")) {
+				return new Response(
+					JSON.stringify({
+						object: "list",
+						data: [
+							{
+								id: "Qwen3.6-35B-A3B-8bit",
+								object: "model",
+								max_model_len: 262144,
+								max_tokens: 16384,
+							},
+						],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			}
+			return new Response("Not found", { status: 404 });
+		}) as typeof fetch;
+
+		const models = await fetchOpenAICompatibleModels({
+			api: "openai-completions",
+			provider: "omlx",
+			baseUrl: "http://127.0.0.1:8000/v1",
+		});
+
+		expect(models).not.toBeNull();
+		expect(models!.length).toBe(1);
+		expect(models![0].id).toBe("Qwen3.6-35B-A3B-8bit");
+		expect(models![0].contextWindow).toBe(262144);
+		expect(models![0].maxTokens).toBe(16384);
+	});
+
+	it("parses context_length as fallback when max_model_len is not present", async () => {
+		global.fetch = (async (url: string | URL | Request) => {
+			if (String(url).endsWith("/models")) {
+				return new Response(
+					JSON.stringify({
+						data: [
+							{
+								id: "custom-local-model",
+								context_length: 131072,
+							},
+						],
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			}
+			return new Response("Not found", { status: 404 });
+		}) as typeof fetch;
+
+		const models = await fetchOpenAICompatibleModels({
+			api: "openai-completions",
+			provider: "custom",
+			baseUrl: "http://localhost:8080/v1",
+		});
+
+		expect(models).not.toBeNull();
+		expect(models![0].contextWindow).toBe(131072);
+	});
+});


### PR DESCRIPTION
## Summary
When discovering models from OpenAI-compatible endpoints (`/v1/models`), OpenAI-compatible local/custom servers (such as oMLX, vLLM, SGLang, LiteLLM, Ollama, LMStudio) often return context length and token limit fields such as `max_model_len`, `context_length`, `context_window`, `max_context_length`, or `max_position_embeddings`.

Previously, `fetchOpenAICompatibleModels` defaulted `contextWindow` and `maxTokens` to `UNK_CONTEXT_WINDOW` and `UNK_MAX_TOKENS`.

This PR updates `fetchOpenAICompatibleModels` to extract these fields from the model records if present, enabling accurate 256k+ context window auto-detection for local and custom OpenAI-compatible providers.

Maintainer hardening follow-up (same branch): all candidate fields now go through a finite-positive first-match helper, so non-finite values (a raw `1e400` JSON literal parses to `Infinity` client-side) can never reach `contextWindow`/`maxTokens`, the suite grew from 2 happy paths to 12 contract cases (field precedence, sentinel preservation, window/output isolation, malformed and mixed records, `mapModel` pass-through), and the behavior change is recorded in `packages/ai/CHANGELOG.md`.

## Testing
Added unit tests in `packages/ai/test/openai-compatible-discovery.test.ts` verifying context window & max tokens extraction from `/v1/models` responses. All tests pass (12/12). `bun --cwd=packages/ai run check` clean; full AI suite failure set byte-identical to base.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:61f0eb7219b944dbd1b9ad4a67a2c8a17ade093765a70fd1d3711d820909fb54 reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head Dev CI 31816434801 all product checks green; adversarial semantic verification + maintainer fix-forward 8b9af4df06
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit