### PR TITLE
fix(session): track terminal assistant before admission wait

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4762,6 +4762,14 @@ export class AgentSession {
 			this.#silentAbortPending = false;
 		}
 
+		// Track the terminal assistant synchronously, before any admission wait:
+		// the agent_end handler for an externally emitted terminal can otherwise
+		// read a stale #lastAssistantMessage (missing the just-emitted stop) and
+		// run post-turn continuation logic against the previous turn.
+		if (event.type === "message_end" && event.message.role === "assistant") {
+			this.#lastAssistantMessage = event.message;
+		}
+
 		// Canonical persistence follows synchronous message_end reservation order.
 		// Only the admission predecessor and this event's own pre-admission work are
 		// inside the lane; release before extension delivery and unrelated post-work.
@@ -5082,9 +5090,9 @@ export class AgentSession {
 				this.#markTtsrInjected(this.#extractTtsrRuleNames(event.message.details));
 			}
 
-			// Track assistant message for auto-compaction (checked on agent_end)
+			// (#lastAssistantMessage is captured synchronously before the
+			// admission wait above.)
 			if (event.message.role === "assistant") {
-				this.#lastAssistantMessage = event.message;
 				const assistantMsg = event.message as AssistantMessage;
 				const currentGrantsAnthropicPriority =
 					this.serviceTier === "priority" || this.serviceTier === "claude-only";

--- a/packages/coding-agent/test/agent-session-midrun-maintenance.test.ts
+++ b/packages/coding-agent/test/agent-session-midrun-maintenance.test.ts
@@ -521,13 +521,16 @@ describe("AgentSession mid-run maintenance outcomes", () => {
 			{ role: "user", content: "second distinct steering", timestamp: Date.now() },
 		]);
 
-		// With protectRecentTurns: 2 (default), the session manager's canonical
-		// entry ordering places the large orphan tool results inside the fence
-		// window, so they are not eligible for pruning — maintenance falls
-		// through to compaction. The short-circuit extension produces a
-		// compaction entry that preserves the recent paired result and steering.
+		// Canonical message admission is chronological, so the branch persists
+		// exactly the seeded order: the three orphan tool results land BEFORE the
+		// two trailing steering turns. With protectRecentTurns: 2 (default) the
+		// fence starts at the first steering message, so the oldest orphan output
+		// falls outside the 40k-token protect window and is prunable — maintenance
+		// prunes instead of compacting. The rewrite must still preserve the recent
+		// paired result, both steering messages, and replace the pruned output with
+		// a canonical truncate notice.
 		const outcome = await session.runMidRunMaintenanceForTests(contextOf(session));
-		expect(outcome).toBe("compacted");
+		expect(outcome).toBe("pruned");
 		const persisted = session.sessionManager
 			.getBranch()
 			.flatMap(entry =>
@@ -543,6 +546,10 @@ describe("AgentSession mid-run maintenance outcomes", () => {
 			persisted.filter(message => message.role === "user" && message.content === "second distinct steering"),
 		).toHaveLength(1);
 		expect(closed).toBeGreaterThanOrEqual(1);
+		const prunedOldest = persisted.find(message => message.toolCallId === "old-output-1");
+		expect(prunedOldest).toBeDefined();
+		expect(JSON.stringify(prunedOldest?.content)).toContain("[Output truncated");
+		expect(getLatestCompactionEntry(session.sessionManager.getBranch())).toBeNull();
 	});
 
 	it("fails closed when tool-output artifact persistence is unavailable", async () => {


### PR DESCRIPTION
## Summary

Post-merge repair for the #4521 canonical admission serialization fallout on `dev`:

- `#lastAssistantMessage` is captured synchronously in the `message_end` handler, before the canonical-admission wait. Externally emitted terminals (host bridges/replays/tests) dispatch `agent_end` immediately after `message_end`; with serialized admission the `agent_end` handler could otherwise read the previous turn's assistant and run post-turn continuation logic (deep-interview stop handling) against the wrong turn — double-processing one stop and skipping another.
- T2 mid-run maintenance is updated to the chronological persistence contract: canonical admission now persists the seeded order, so the oldest orphan tool result falls outside the `protectRecentTurns` fence and maintenance prunes (canonical truncate notice) instead of compacting. The paired result, both steering messages, the codex provider close, and the absence of a compaction entry are still asserted.

## Verification

- `agent-session-deep-interview-continuation.test.ts`: 22/22 (was 4 fails on merged dev)
- `agent-session-midrun-maintenance.test.ts`: 19/19 (was 1 fail on merged dev)
- `agent-session-midrun-compaction.test.ts` 18/18; spill suite 5/5; cursor-exec + concurrent 58/58
- `bun --cwd=packages/coding-agent run check`: green
- exact head: `47f0c30816`
- exact base: `9d2a2d2f2d8f074333bba92fe1fc4d6902f5b2df`

Pre-existing local-env red (sixel pet-mode, sdk-workflow-gate-emitter) reproduces identically on the pre-merge base and is not touched here.

Follow-up to #4521. Fixes the post-merge shard-4 red introduced by 65128cc1a8/e1dd34d3dd.

gajae.pr-review-verdict.v1 needs-human sha256:580168f60d58748845c9160b370591c28d1bbf3b0516b5eab20c1ea3a31b61b0 reviewer:human reviewer-id:pending-independent-review evidence:awaiting-authenticated-exact-head-review-47f0c30816