### PR TITLE
fix(browser): stabilize Chrome default-root refusal

### DIFF
--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -7,7 +7,7 @@ import browserDescription from "../prompts/tools/browser.md" with { type: "text"
 import type { ToolSession } from "../sdk";
 import { type BrowserActionStep, compileActionSteps } from "./browser/actions";
 import { isChromeProfileExecutableForLaunch, isEdgeExecutable, resolveSystemChromeForProfile } from "./browser/launch";
-import { chromeUserDataRoots, defaultDiscoveryEnv } from "./browser/profile-discovery";
+import { chromeUserDataRoots, type DiscoveryEnv, defaultDiscoveryEnv } from "./browser/profile-discovery";
 import { acquireBrowser, type BrowserHandle, type BrowserKind, type BrowserKindTag } from "./browser/registry";
 import type { Observation, ScreenshotResult } from "./browser/tab-protocol";
 import { acquireTab, dropHeadlessTabs, getTab, releaseAllTabs, releaseTab, runInTab } from "./browser/tab-supervisor";
@@ -130,8 +130,9 @@ export function resolveBrowserKindForTest(
 	params: BrowserParams,
 	session: ToolSession,
 	signal?: AbortSignal,
+	discoveryEnv?: DiscoveryEnv,
 ): Promise<BrowserKind> {
-	return resolveBrowserKind(params, session, signal);
+	return resolveBrowserKind(params, session, signal, discoveryEnv);
 }
 
 /**
@@ -144,6 +145,7 @@ async function resolveChromeProfileKind(
 	app: NonNullable<BrowserParams["app"]>,
 	session: ToolSession,
 	signal?: AbortSignal,
+	discoveryEnv?: DiscoveryEnv,
 ): Promise<BrowserKind> {
 	const profileDirectory = app.profile_directory ?? "Default";
 	const exe = app.path ? resolveToCwd(app.path, session.cwd) : resolveSystemChromeForProfile();
@@ -165,8 +167,8 @@ async function resolveChromeProfileKind(
 			'app.user_data_dir is required for app.browser "chrome". Chrome 136+ disables remote debugging for the default Chrome data directory; pass a separate non-default user data directory, or attach to an already-authorized browser with app.cdp_url.',
 		);
 	}
-	const userDataDir = resolveToCwd(app.user_data_dir, session.cwd);
-	if (await isDefaultChromeUserDataDir(userDataDir, signal)) {
+	const userDataDir = resolveChromeProfileUserDataDir(app.user_data_dir, session.cwd, discoveryEnv?.platform);
+	if (await isDefaultChromeUserDataDir(userDataDir, signal, discoveryEnv)) {
 		throw new ToolError(
 			`Refusing Chrome's default user data directory ${JSON.stringify(userDataDir)}. Chrome 136+ disables remote debugging there; pass a separate non-default app.user_data_dir, or use app.cdp_url for an already-authorized browser.`,
 		);
@@ -187,7 +189,8 @@ async function canonicalPath(
 	platform: NodeJS.Platform = process.platform,
 	signal?: AbortSignal,
 ): Promise<string> {
-	let resolved = platform === "win32" ? path.win32.resolve(candidate) : path.resolve(candidate);
+	const platformPath = platform === "win32" ? path.win32 : path.posix;
+	let resolved = platformPath.resolve(candidate);
 	if (platform === process.platform) {
 		throwIfAborted(signal);
 		try {
@@ -198,13 +201,27 @@ async function canonicalPath(
 	return platform === "win32" ? resolved.toLowerCase() : resolved;
 }
 
-function isDefaultChromeUserDataDir(candidate: string, signal?: AbortSignal): Promise<boolean> {
+function isDefaultChromeUserDataDir(
+	candidate: string,
+	signal?: AbortSignal,
+	discoveryEnv: DiscoveryEnv = defaultDiscoveryEnv(() => false),
+): Promise<boolean> {
 	return isDefaultChromeUserDataDirForTest(
 		candidate,
-		chromeUserDataRoots(defaultDiscoveryEnv(() => false)),
-		process.platform,
+		chromeUserDataRoots(discoveryEnv),
+		discoveryEnv.platform,
 		signal,
 	);
+}
+
+function resolveChromeProfileUserDataDir(
+	candidate: string,
+	cwd: string,
+	platform: NodeJS.Platform = process.platform,
+): string {
+	if (platform === process.platform) return resolveToCwd(candidate, cwd);
+	const platformPath = platform === "win32" ? path.win32 : path.posix;
+	return platformPath.isAbsolute(candidate) ? platformPath.resolve(candidate) : platformPath.resolve(cwd, candidate);
 }
 
 export async function isDefaultChromeUserDataDirForTest(
@@ -224,13 +241,14 @@ async function resolveBrowserKind(
 	params: BrowserParams,
 	session: ToolSession,
 	signal?: AbortSignal,
+	discoveryEnv?: DiscoveryEnv,
 ): Promise<BrowserKind> {
 	const app = params.app;
 	if (app?.cdp_url) {
 		return { kind: "connected", cdpUrl: app.cdp_url.replace(/\/+$/, "") };
 	}
 	if (app?.browser === "chrome") {
-		return resolveChromeProfileKind(app, session, signal);
+		return resolveChromeProfileKind(app, session, signal, discoveryEnv);
 	}
 	if (app?.path) {
 		const exe = resolveToCwd(app.path, session.cwd);

--- a/packages/coding-agent/test/tools/browser-chrome-profile.test.ts
+++ b/packages/coding-agent/test/tools/browser-chrome-profile.test.ts
@@ -19,7 +19,7 @@ import {
 	isSafeCdpAddressForTest,
 } from "../../src/tools/browser/attach";
 import * as launch from "../../src/tools/browser/launch";
-import { chromeUserDataRoots } from "../../src/tools/browser/profile-discovery";
+import { chromeUserDataRoots, type DiscoveryEnv, defaultDiscoveryEnv } from "../../src/tools/browser/profile-discovery";
 import {
 	type AcquireBrowserOptions,
 	type BrowserHandle,
@@ -253,10 +253,9 @@ describe("Chrome profile browser mode (#809)", () => {
 	});
 
 	it("rejects an explicit default Chrome user data directory on every platform", async () => {
-		// Drive the refusal through the injectable seam with explicit platforms and
-		// homes: ambient `os.homedir()` on the host only proves the host's own
-		// default root (the darwin branch never lists `~/.config/google-chrome`,
-		// so the old form failed on macOS while the guard was correct).
+		// The resolver must use the same injected discovery environment to resolve
+		// and compare the path. The live environment may override a platform's
+		// conventional root through CHROME_USER_DATA_DIR or XDG_CONFIG_HOME.
 		const matrix: Array<{ platform: NodeJS.Platform; home: string; defaultRoot: string }> = [
 			{
 				platform: "darwin",
@@ -274,15 +273,39 @@ describe("Chrome profile browser mode (#809)", () => {
 				defaultRoot: path.posix.join("/home/u", ".config", "google-chrome"),
 			},
 		];
-		for (const entry of matrix) {
-			expect(await isDefaultChromeUserDataDirForTest(entry.defaultRoot, [entry.defaultRoot], entry.platform)).toBe(
-				true,
-			);
-		}
-		// End-to-end refusal keeps exercising the live resolution path, but with the
-		// host's actual platform default root instead of a Linux-only spelling.
-		const hostRoot = chromeUserDataRoots({ platform: process.platform, home: os.homedir(), exists: () => false })[0]!;
 		vi.spyOn(launch, "resolveSystemChromeForProfile").mockReturnValue("/usr/bin/google-chrome");
+		for (const entry of matrix) {
+			const discoveryEnv: DiscoveryEnv = {
+				platform: entry.platform,
+				home: entry.home,
+				exists: () => false,
+			};
+			expect(
+				await isDefaultChromeUserDataDirForTest(
+					entry.defaultRoot,
+					chromeUserDataRoots(discoveryEnv),
+					entry.platform,
+				),
+			).toBe(true);
+			await expect(
+				resolveBrowserKindForTest(
+					{ action: "open", app: { browser: "chrome", user_data_dir: entry.defaultRoot } },
+					makeSession("/work"),
+					undefined,
+					discoveryEnv,
+				),
+			).rejects.toThrow(/Refusing Chrome's default user data directory/);
+			const customRoot = entry.platform === "win32" ? "D:\\automation\\chrome" : "/tmp/automation-chrome";
+			await expect(
+				resolveBrowserKindForTest(
+					{ action: "open", app: { browser: "chrome", user_data_dir: customRoot } },
+					makeSession("/work"),
+					undefined,
+					discoveryEnv,
+				),
+			).resolves.toMatchObject({ kind: "chrome-profile", userDataDir: customRoot });
+		}
+		const hostRoot = chromeUserDataRoots(defaultDiscoveryEnv(() => false))[0]!;
 		await expect(
 			resolveBrowserKindForTest(
 				{


### PR DESCRIPTION
## What

Makes Chrome-profile default-root rejection use one injected discovery environment for both path normalization and root comparison in the test seam. Production continues to construct its discovery environment from live `LOCALAPPDATA`, `CHROME_USER_DATA_DIR`, `CHROME_CONFIG_HOME`, and `XDG_CONFIG_HOME`.

## Why

Fixes #4574. Current dev reproduces the Chrome-profile default-root refusal regression in fresh-process shard 3; this PR restores the Chrome 136+ safety guard.

## Testing

- exact former failing test: 1 passing
- full browser Chrome-profile file: 31 passing
- fresh-process coding-agent shard 3/8: 175 files passing
- `bun --cwd=packages/coding-agent run check`
- affected planner, package build, and CLI smoke

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:0598848bca5b1e35e8000e51b6efa2088c72c42a541e00db71231e4740ddc069 reviewer:human reviewer-id:probepark evidence:https://github.com/Yeachan-Heo/gajae-code/pull/4575#pullrequestreview-4943274747
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (not user-facing)
- [x] Verdict above matches exact head `52e1107678aec352560624e9e97a616312f345d8`