### PR TITLE
fix(session): restore Darwin nested managed reads in readExpected

### DIFF
--- a/packages/coding-agent/src/session/internal/managed-session-storage.ts
+++ b/packages/coding-agent/src/session/internal/managed-session-storage.ts
@@ -2113,7 +2113,6 @@ export class ManagedSessionDescendantStore {
 	}
 	/** Read an exact managed file without exposing its pathname as authority. */
 	readExpected(relativePath: string): ManagedFileSnapshot | null {
-		this.#assertPathBackedReadRelative(relativePath);
 		this.#assertBound();
 		const resolved = this.#resolve(relativePath);
 		const relative = this.#relative(resolved);

--- a/packages/coding-agent/test/session-import.test.ts
+++ b/packages/coding-agent/test/session-import.test.ts
@@ -696,7 +696,7 @@ describe("/import-session command surface", () => {
 		expect(parseImportSessionArgs("/tmp/a.jsonl /tmp/b.jsonl").kind).toBe("error");
 	});
 
-	it("is registered for trusted local dispatch and excluded from ACP", () => {
+	it.skipIf(process.platform !== "linux")("is registered for trusted local dispatch and excluded from ACP", () => {
 		const spec = lookupBuiltinSlashCommand("import-session");
 		expect(spec).toBeDefined();
 		expect(spec?.handle).toBeDefined();


### PR DESCRIPTION
## What

`23261d448f` added `#assertPathBackedReadRelative` to `ManagedSessionDescendantStore.readExpected()`, which throws `managed_nested_path_unsupported` for every nested relative path when retained descriptor authority is absent — always the case on Darwin. That broke `/fork`, `--fork`, `moveTo`, and session-import verification for all macOS users (15 test failures across session-manager + transition-seam suites). CI never saw it: dev-ci runs ubuntu-only, and Linux retains root authority so the guard never fires there.

`readExpected` already verifies nested paths on the no-authority path via `#assertPathBackedDirectoryChain` (per-component lstat, symlink rejection, same-device check) — exactly the main behavior. The guard stays in `descriptorExpected` and range reads, where it is the only defense.

Also gates the `import-session` registry test to Linux like its sibling policy test: the command is deliberately Linux-only since `9154f2c3fb` and the ungated assertion failed on every Darwin run, masking real signal.

## Evidence (darwin-arm64, clean env, exact head `bb0fa99be1` (rebased onto dev `87b540d2`; diff digest `24d5f33e…` — same 2-file patch, byte-identical; prior heads `e4824ff758` (darwin-verified) and `f87f4b8d41` (probepark-approved, invalidated by head change)))

- session-manager/ (24 files) + session-resident-transition-seam + session-import + session-import-command-policy: 373 pass / 1 fail — the single failure (`rejects an artifact identity mismatch during retained tree fsync`) fails identically on `main`; pre-existing, cleanup error masks the injected primary on Darwin
- without this fix, pristine dev fails 12 of the same suites (fork cluster × 7, moveTo × 4, seam × 2 …)
- `bun --cwd=packages/coding-agent run check`, `--cwd=packages/ai`, `--cwd=packages/agent`: clean

Found during the 1131-commit dev→main rollout risk review; PR #4515 verified in parallel.

Lore-id: 4ea1286f-followup
Constraint: authority-absent nested reads must still verify intermediate components (directory-chain check retained)
Confidence: high
Scope-risk: targeted
Reversibility: clean
Tested: session-manager/ + transition-seam + session-import suites on darwin (373 pass)
Not-tested: Linux retained-authority path (CI covers); Windows

gajae.pr-review-verdict.v1 merge-approved sha256:24d5f33e4880e237ce4f08e8726902b94ec34218771f97522831b73b78792578 reviewer:human reviewer-id:probepark evidence:exact-head-bb0fa99be1-probepark-write-permission-APPROVED-review-4943897802-github-current-at-exact-head-byte-identical-patch-approved-at-f87f4b8d41-replacement-CI-product-green




