### PR TITLE
test(model-registry): hermeticize ambient-credential-sensitive fixtures

### DIFF
--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1319,6 +1319,13 @@ describe("ModelRegistry", () => {
 		});
 	});
 
+	/** Hermetic candidate set for fixture providers only (excludes ambient host providers). */
+	function fixtureCandidates(registry: ModelRegistry, providers: readonly string[], modelId: string): Model<Api>[] {
+		return providers
+			.map(provider => registry.find(provider, modelId))
+			.filter((model): model is NonNullable<typeof model> => model !== undefined);
+	}
+
 	describe("provider selection policy and alias resolution", () => {
 		test("dedupes explicit provider order and assigns disjoint rank bands", () => {
 			const policy = createProviderSelectionPolicy({
@@ -1391,9 +1398,15 @@ describe("ModelRegistry", () => {
 			});
 
 			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			// Pin candidates to the demo fixture plus the bundled anthropic exact-id
+			// variant (hermetic pattern from #3207) so ambient host credentials (e.g.
+			// GH_TOKEN/GITHUB_TOKEN enabling other bundled providers) cannot change
+			// alias or canonical resolution in this test.
+			const demoVariants = fixtureCandidates(registry, ["demo"], "anthropic/claude-sonnet-4.5");
+			const candidates = [...demoVariants, ...fixtureCandidates(registry, ["anthropic"], "claude-sonnet-4-5")];
 			const resolved = registry.resolveModelByLookupAlias("claude-sonnet-4.5", {
 				availableOnly: false,
-				candidates: registry.getAll(),
+				candidates,
 			});
 
 			expect(resolved?.provider).toBe("demo");
@@ -1407,13 +1420,13 @@ describe("ModelRegistry", () => {
 			expect(
 				registry.resolveCanonicalModel("claude-sonnet-4-5", {
 					availableOnly: false,
-					candidates: registry.getAll(),
+					candidates,
 				}),
 			).toMatchObject({ id: "claude-sonnet-4-5" });
 			expect(
 				registry.resolveCanonicalModel("claude-sonnet-4.5", {
 					availableOnly: false,
-					candidates: registry.getAll(),
+					candidates,
 				}),
 			).toBeUndefined();
 		});
@@ -1488,9 +1501,12 @@ describe("ModelRegistry", () => {
 			});
 
 			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			// Pin candidates to the demo fixture (hermetic pattern from #3207): the
+			// fixture's inline wire id must survive alias resolution regardless of
+			// ambient host credentials enabling other bundled providers.
 			const resolved = registry.resolveModelByLookupAlias("claude-sonnet-4.5", {
 				availableOnly: false,
-				candidates: registry.getAll(),
+				candidates: fixtureCandidates(registry, ["demo"], "anthropic/claude-sonnet-4.5"),
 			});
 
 			expect(resolved?.provider).toBe("demo");
@@ -1510,19 +1526,24 @@ describe("ModelRegistry", () => {
 			});
 
 			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			// Pin candidates to the demo fixture (hermetic pattern from #3207): the
+			// alias must fail closed because the only fixture variant is
+			// credential-less, regardless of ambient host credentials enabling other
+			// bundled providers' claude-sonnet-4.5 variants.
+			const fixtureModel = registry.find("demo", "anthropic/claude-sonnet-4.5")!;
 			expect(registry.lookupAliasExists("claude-sonnet-4.5")).toBe(true);
 			// Canonical-id access stays alias-unaware.
 			expect(registry.getCanonicalVariants("claude-sonnet-4.5")).toEqual([]);
 			expect(
 				registry.resolveModelByLookupAlias("claude-sonnet-4.5", {
 					availableOnly: true,
-					candidates: registry.getAll(),
+					candidates: [fixtureModel],
 				}),
 			).toBeUndefined();
 			expect(
 				registry.resolveModelByLookupAlias("claude-sonnet-4.5", {
 					availableOnly: false,
-					candidates: registry.getAll(),
+					candidates: [fixtureModel],
 				}),
 			).toBeUndefined();
 		});
@@ -1797,6 +1818,11 @@ describe("ModelRegistry", () => {
 		});
 
 		test("ranks expired OAuth ahead of an environment key because requests refresh OAuth first", async () => {
+			// Pin the anthropic env surface before writing the fixture value: the
+			// credential env resolver prefers an ambient ANTHROPIC_OAUTH_TOKEN from
+			// the launching shell over any in-process ANTHROPIC_API_KEY write, so
+			// unset it to keep the fixture key the effective environment key.
+			const restoreAnthropicOAuthToken = unsetEnvForTest("ANTHROPIC_OAUTH_TOKEN");
 			const restoreAnthropicKey = setEnvForTest("ANTHROPIC_API_KEY", "environment-anthropic-key");
 			try {
 				await authStorage.set("anthropic", [
@@ -1813,6 +1839,7 @@ describe("ModelRegistry", () => {
 				expect(registry.getEffectiveProviderAuth("anthropic")).toBe("oauth");
 			} finally {
 				restoreAnthropicKey();
+				restoreAnthropicOAuthToken();
 			}
 		});
 		test("ranks a mixed manual+OAuth provider in the non-OAuth band by default", async () => {
@@ -2065,18 +2092,20 @@ describe("ModelRegistry", () => {
 			expect(registry.lookupAliasExists("claude-sonnet-4.5")).toBe(true);
 			expect(registry.lookupAliasExists("claude-sonnet-45")).toBe(true);
 
-			// Alias `claude-sonnet-4.5` resolves only the dotted variant.
+			// Alias `claude-sonnet-4.5` resolves only the dotted variant. Candidates
+			// are pinned to the demo fixture (hermetic pattern from #3207) so ambient
+			// host credentials cannot inject sibling variants from other providers.
 			expect(
 				registry.resolveModelByLookupAlias("claude-sonnet-4.5", {
 					availableOnly: true,
-					candidates: registry.getAll(),
+					candidates: [dotVariant, compactVariant],
 				}),
 			).toBe(dotVariant);
 			// Alias `claude-sonnet-45` resolves only the compact variant.
 			expect(
 				registry.resolveModelByLookupAlias("claude-sonnet-45", {
 					availableOnly: true,
-					candidates: registry.getAll(),
+					candidates: [dotVariant, compactVariant],
 				}),
 			).toBe(compactVariant);
 			// Supplying only the compact variant cannot satisfy the dotted alias.
@@ -5792,19 +5821,23 @@ describe("ModelRegistry", () => {
 			const registry = new ModelRegistry(authStorage, modelsJsonPath);
 			await registry.refresh();
 
-			expect(registry.getActiveProviders()).toEqual([{ provider: "local", connectionKind: "credential" }]);
+			// Rows are scoped to the local fixture (hermetic pattern from #3207) so
+			// ambient host credentials (e.g. OPENAI_API_KEY) enabling unrelated bundled
+			// providers cannot change this provider's credential/discovery activity.
+			expect(activeRowsFor(registry, ["local"])).toEqual([{ provider: "local", connectionKind: "credential" }]);
 			expect(await registry.getApiKeyForProvider("local")).toBe("STORED_TEST_KEY");
 			await authStorage.set("local", []);
 
 			expect(registry.find("local", "local-model")).toBeDefined();
-			expect(registry.getActiveProviders()).toEqual([]);
+			expect(activeRowsFor(registry, ["local"])).toEqual([]);
 		});
 	});
+	/** Active-provider rows scoped to fixture providers only (excludes ambient host providers). */
+	const activeRowsFor = (registry: ModelRegistry, providerIds: readonly string[]) => {
+		const selected = new Set(providerIds);
+		return registry.getActiveProviders().filter(provider => selected.has(provider.provider));
+	};
 	describe("active provider resolution", () => {
-		const activeRowsFor = (registry: ModelRegistry, providerIds: readonly string[]) => {
-			const selected = new Set(providerIds);
-			return registry.getActiveProviders().filter(provider => selected.has(provider.provider));
-		};
 		test("rechecks non-fingerprinted environment credentials for active providers", () => {
 			const previous = process.env.GITLAB_TOKEN;
 			delete process.env.GITLAB_TOKEN;
@@ -5896,7 +5929,10 @@ describe("ModelRegistry", () => {
 			await registry.refreshProvider("credentialless-provider", "online");
 			await authStorage.set("credentialless-provider", []);
 
-			expect(registry.getActiveProviders()).toEqual([
+			// Rows are scoped to the fixture provider (hermetic pattern from #3207)
+			// so ambient host credentials enabling unrelated bundled providers cannot
+			// affect this provider's credentialless discovery activity.
+			expect(activeRowsFor(registry, ["credentialless-provider"])).toEqual([
 				{ provider: "credentialless-provider", connectionKind: "credentialless" },
 			]);
 			expect(registry.getAvailable().some(model => model.provider === "credentialless-provider")).toBe(true);
@@ -5956,18 +5992,24 @@ describe("ModelRegistry", () => {
 		});
 		test("excludes bundled providers when the selected stored key resolver returns undefined", async () => {
 			authStorage.close();
+			const restoreAnthropicKey = unsetEnvForTest("ANTHROPIC_API_KEY");
+			const restoreAnthropicToken = unsetEnvForTest("ANTHROPIC_OAUTH_TOKEN");
 			authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"), {
 				configValueResolver: async () => undefined,
 			});
 			await authStorage.set("anthropic", [{ type: "api_key", key: "!missing-anthropic-key" }]);
 
-			const registry = new ModelRegistry(authStorage, modelsJsonPath);
-			await registry.refresh();
+			try {
+				const registry = new ModelRegistry(authStorage, modelsJsonPath);
+				await registry.refresh();
 
-			expect(registry.getAll().some(model => model.provider === "anthropic")).toBe(true);
-			expect(activeRowsFor(registry, ["anthropic"])).toEqual([]);
+				expect(registry.getAll().some(model => model.provider === "anthropic")).toBe(true);
+				expect(activeRowsFor(registry, ["anthropic"])).toEqual([]);
+			} finally {
+				restoreAnthropicKey();
+				restoreAnthropicToken();
+			}
 		});
-
 		test("tracks credential addition, replacement, removal, dedupe, and registry-only exclusions", async () => {
 			writeRawModelsJson({
 				"tracked-provider": {


### PR DESCRIPTION
Fixes #4582

## Summary

All six reported failures in `packages/coding-agent/test/model-registry.test.ts` are **fixture non-hermeticity, not a product regression**: the six tests read ambient host credentials through `registry.getAll()` / `registry.getActiveProviders()`, so provider credentials exported by the launching shell (`OPENAI_API_KEY`, `GH_TOKEN`/`GITHUB_TOKEN`, `ANTHROPIC_OAUTH_TOKEN`) change which bundled providers are credential-active and change the resolution outcome. In a clean credential environment all 269 tests in the file pass on exact `dev` (`45885ea287` then `804314081f`), and CI's shard harness scrubs credential env — which is why the failures reproduce on a developer checkout but not in CI.

Exact reproduction of the reported six on unmodified dev `804314081f` (fresh `HOME`, scrubbed env, plus only `OPENAI_API_KEY` + `GH_TOKEN`):

```
(fail) keeps credentialless discovery active with an irrelevant dangling selector
(fail) uses stored credentials for OpenAI-compatible providers without inline auth
(fail) alias A cannot select a sibling variant that only has alias B in the same record
(fail) fails closed for known aliases with no eligible variants
(fail) preserves full model and wire ids when resolving via alias
(fail) resolves final-slash-segment aliases through canonical records
```

Mechanism, per pair:

- **Four alias/provider-selection tests** — `GH_TOKEN`/`GITHUB_TOKEN` makes bundled `github-copilot` models available; `resolveModelByLookupAlias("claude-sonnet-4.5", { candidates: registry.getAll() })` then legitimately ranks the copilot variant ahead of the `demo` fixture (sample failure: expected `demo`, received `github-copilot`). The fail-closed test stops failing closed for the same reason — an *unrelated* provider's variant becomes eligible through `getAll()`.
- **Two credential/discovery tests** — ambient `OPENAI_API_KEY` makes bundled `openai` credential-active, so `getActiveProviders()` returns an extra `{ provider: "openai", connectionKind: "credential" }` row and the exact `toEqual` assertions break.

This is the same defect class #3207 fixed for the canonical-equivalence cases ("host provider credentials … cannot change sticky/bound/child resolution").

## Change

Test-only, in `packages/coding-agent/test/model-registry.test.ts` (+63/−21):

- Add `fixtureCandidates()` helper (the #3207 pattern) and pin alias/canonical candidate sets to the fixture providers in the four alias tests, keeping one exact-id bundled anthropic variant where the canonical exactness axis needs it.
- Hoist `activeRowsFor()` and scope the two active-provider row assertions to the fixture provider.
- Unset `ANTHROPIC_API_KEY`/`ANTHROPIC_OAUTH_TOKEN` in the two tests whose fixture keys otherwise race ambient anthropic credentials.

**No assertion is deleted or weakened.** Fail-closed alias behavior, alias isolation, canonical/wire-id preservation, final-slash-segment aliases, stored credentials for OpenAI-compatible providers, and credentialless discovery under an irrelevant dangling selector all keep their original contract strength — they now assert it against a pinned fixture universe instead of the host's ambient credential state.

Known residual (documented in the commit, not worked around): an ambient `ANTHROPIC_API_KEY` cannot be suppressed in-process because `$inheritedEnv` pins the launch-time value; `ranks expired OAuth ahead of an environment key` still depends on a clean `ANTHROPIC_API_KEY`. The CI harness scrubs `*_API_KEY`, so CI is unaffected; a subprocess-based fixture would be needed to cover that locally.

## Reproduction before/after (exact heads, base `804314081f` → head `a2f3ac3b3e`)

| Environment (fresh `HOME`, `env -i`) | Base `804314081f` (before) | Head `a2f3ac3b3e` (after) |
|---|---|---|
| Clean | 269 pass / 0 fail | 269 pass / 0 fail |
| + `OPENAI_API_KEY` + `GH_TOKEN` | **6 fail (the reported six)** | 269 pass / 0 fail |
| + `GH_TOKEN` alone | 6 fail (the same six) | 269 pass / 0 fail |
| + each of `GITHUB_TOKEN`, `ANTHROPIC_OAUTH_TOKEN`, `GEMINI_API_KEY`, `XAI_API_KEY`, `OPENAI_API_KEY` alone | 2–12 fails incl. the six | 269 pass / 0 fail |

## Verification (head `a2f3ac3b3e`, base `804314081f`)

- `bun test packages/coding-agent/test/model-registry.test.ts` — 269 pass clean; 269 pass under the reporter's pollution signature; 269 pass under each individual polluter
- Adversarial mask-check on the polluted matrices: base failures change exactly as the mechanism predicts per polluter (e.g. `GH_TOKEN` alone → the six; `ANTHROPIC_OAUTH_TOKEN` alone → the six minus the alias quartet plus `excludes bundled providers…` and `ranks expired OAuth…`), and the head is 0-fail in every matrix — the pinning repairs the fixtures without deleting or weakening any assertion (diff is test-file-only, +63/−21, `model-registry.ts` untouched)
- Adjacent suites on head, clean **and** polluted: model-registry-runtime-provider 20/0, model-resolver 9/0, provider-ranking 10/0, provider-ranking-surfaces 5/0, provider-auth-health 8/0, model-selector-profiles 11/0, provider-onboarding 28/0, oauth-discovery 6/0, startup-auth-config 13/0
- `bun --cwd=packages/coding-agent run check` (biome + tsc) — clean
- `bun run --cwd=packages/coding-agent build` — clean; worktree contains only the intended file
- `bun scripts/verify-gjc-state-writers.ts --fail --root .` — 0 violations
- Remaining operator-shell sensitivity (two `OPENAI_BASE_URL` tests + `keeps signed models.dev descriptor rows out of the model cache`) is **identical on base and head** and caused by deliberate product behavior: `$inheritedEnv` pins launch-time credential/base-url values (`packages/utils/src/env.ts`), and `~/.gjc/agent/models.yml` provider overrides legitimately win for `baseUrl` — host-config artifacts, out of scope for the reported six, not masked by this PR

## merge-approved verdict/digest (promoted from needs-human)

**Canonical question for the reviewer (probepark / HaD0Yun):** the fix reclassifies the six failures as environment-dependent fixture sensitivity (ambient credential env vars) rather than a provider-selection implementation regression, and repairs them by pinning fixtures per the #3207 precedent — **without** changing `model-registry.ts` product code and **without** weakening any assertion. If the intended contract was instead that these resolutions must be invariant even against the *ambient* credential universe (i.e. alias resolution should never see host-enabled providers), that is a product-behavior change and this PR should be rejected in favor of one; the test-side pinning here matches the repo's existing precedent.

**Promotion provenance:** `needs-human` → `merge-approved` at 2026-08-15T13:01:03Z from [@probepark](https://github.com/probepark)'s exact-head APPROVED review of `a2f3ac3b3e5e23e8bb5107e144426590ac3ed997` (repository write authority, non-author; review verifies the fail-today/green matrices and the unset/restore scoping, and corrects the original issue's diagnosis on the record). Digest unchanged — head and diff identical since the `needs-human` line was recorded. Product CI run 31884312121 terminal green.

gajae.pr-review-verdict.v1 merge-approved sha256:87748eacd90810a4e8299eb5bee4a7fef364df6ea03eebec15bd4436cf480e8a reviewer:human reviewer-id:probepark evidence:https://github.com/Yeachan-Heo/gajae-code/pull/4584#pullrequestreview-4943889042

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*