### PR TITLE
fix(session): stop absent-staging cleanup from masking the primary fork failure

### DIFF
--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -10249,7 +10249,7 @@ export class SessionManager {
 					parentStore.removeTreeExpected(stagingName, stagingSnapshot);
 			} catch (cleanupError) {
 				const cleanupMessage = toError(cleanupError).message;
-				if (cleanupMessage !== "cleanup_pending") {
+				if (cleanupMessage !== "cleanup_pending" && cleanupMessage !== "not_found") {
 					throw new Error(`Failed to clean up managed fork artifacts: ${cleanupMessage}`, {
 						cause: toError(error),
 					});


### PR DESCRIPTION
## What

One-line fix for the fork-failure masking bug that has made `session-id.test.ts > rejects an artifact identity mismatch during retained tree fsync` fail on **main and dev** on Darwin through every recent run.

Sequence (traced with store-method instrumentation at exact head):

1. Managed fork artifact publication stages entries into `.fork-staging` and snapshots them
2. `moveTreeNoReplace` fails with the primary error (here: injected `identity_mismatch`), having **already disposed of the staging tree**
3. The catch-block cleanup calls `removeTreeExpected(stagingName, …)` on the now-absent directory → native exact-remove reports `not_found`
4. The wrapper treated `not_found` as an independently real cleanup failure and superseded the primary with `Failed to clean up managed fork artifacts: not_found` (primary demoted to `cause`)

Per the precedent established by `f6fb5c812c` — *"only a cleanup failure that can leave a live artifact behind supersedes the primary"* — a `not_found` on the staging tree is the strongest evidence that nothing is left to clean. It is now classified with `cleanup_pending` as authorized cleanup, and the primary error reaches the caller verbatim.

Stacked on #4583 (`fix/darwin-nested-managed-reads`): both changes are needed for the Darwin fork battery to go green — #4583 restores the nested reads, this restores primary-error fidelity when the move boundary fails.

## Evidence (darwin-arm64, exact head `87bee519ff`)

- Target test: **pass** (was: fail with the masking message, identical on main and dev)
- Negative control: reverting only this line reproduces `Received message: "Failed to clean up managed fork artifacts: not_found"`
- Discrimination preserved: `escalates a real fork publication cleanup failure` (real cleanup `identity_mismatch` still supersedes, cause preserved) — pass; `preserves the primary fork failure when publication cleanup only reports an authorized POSIX quarantine` (`cleanup_pending`) — pass
- `session-id.test.ts` 20/20; `session-manager/` (24 files) + `session-resident-transition-seam` 316 pass / 0 fail
- `bun --cwd=packages/coding-agent run check` (biome + tsc): clean

Lore-id: fork-staging-notfound-masking
Constraint: only cleanup failures that can leave a live artifact behind may supersede the primary error
Confidence: high
Scope-risk: narrow
Reversibility: trivial
Tested: session-id 20/20 with negative control; session-manager/ + transition-seam 316/0; biome + tsc
Not-tested: Windows exact-remove code paths

gajae.pr-review-verdict.v1 merge-approved sha256:b815bb90386b5631dd5b7d8ab6fbc135ab29ed043f7f70b544065bb0e004d900 reviewer:human reviewer-id:probepark evidence:exact-head-5178ae8a0d-replacement-ci-full-green-run-31936628692-verified-green-base-52dad45852-approval-was-probepark-review-4945341593-submitted-03-53-58Z-at-3059adb527-identical-digest-b815bb90-re-associated-by-github-at-force-push-fresh-exact-head-approval-term-unmet-correction-posted-5306690568

<!-- retrigger -->