### PR TITLE
fix(ask): avoid numeric enum in round-zero schema for Cloud Code Assist

### DIFF
--- a/packages/coding-agent/src/tools/ask-contract.ts
+++ b/packages/coding-agent/src/tools/ask-contract.ts
@@ -99,7 +99,7 @@ const DeepInterviewMetadata = z.object({
 });
 
 const DeepInterviewTopologyMeta = DeepInterviewMetadata.extend({
-	round: z.literal(0).describe("Round 0 topology confirmation"),
+	round: z.number().int().min(0).max(0).describe("Round 0 topology confirmation"),
 	component: z.literal("review-topology"),
 	dimension: z.literal("topology"),
 	intent_contract: DeepInterviewIntentContract.describe("required Round 0 locked-intent contract"),


### PR DESCRIPTION
## Problem

The `ask` tool's deep-interview round-zero schema uses `z.literal(0)`:

```ts
round: z.literal(0).describe("Round 0 topology confirmation"),
```

When serialized to JSON Schema this emits `{"type": "number", "enum": [0]}`. The Cloud Code Assist API (google-antigravity provider) rejects numeric enum values with:

```
Cloud Code Assist API error (400): Invalid value at
'request.tools[0].function_declarations[...].parameters...
enum[0]' (TYPE_STRING), 0
```

Any session on the `google-antigravity` provider that activates the deep-interview skill prompt fails with HTTP 400 before the first assistant turn.

## Fix

Replace `z.literal(0)` with an integer range pinned to zero:

```ts
round: z.number().int().min(0).max(0).describe("Round 0 topology confirmation"),
```

This keeps the runtime contract identical (only `0` is accepted — verified by schema tests) while avoiding the numeric `enum` that Cloud Code Assist rejects. String literals elsewhere (`component`, `dimension`) are unaffected because their enums are already strings.

## Verification

- `bun test packages/coding-agent/test/deep-interview-*` and `sdk-ask-*`: 76 pass / 0 fail
- Schema probe: round accepts `0`, rejects `1` and `-1` (same contract as `z.literal(0)`)
- Repro: deep-interview session on `google-antigravity` previously 400'd; with this change the schema no longer contains a numeric enum