### PR TITLE
fix(utils): recognize exported dotenv assignments

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Fatal crash records now end with a machine-readable identity line (`gjc-crash-record.v1 fp:<32hex> fpv:1 id:<random>`) whose 128-bit fingerprint is computed from the already-captured diagnostic text with typed normalization (paths/home/uuid/hex/long-digit placeholders, `404` and `500` kept distinct, no line/column numbers in frames). The fatal path also appends one bounded (≤512 B) `O_APPEND` line to a new crash event journal beside the crash log; failures are swallowed and a latch makes a crash-during-crash skip journal work. New `getCrashEventsPath()` / `getCrashIndexPath()` resolvers, and `redactCrashSecrets` is now exported.
 
+### Fixed
+- Project `.env` trust guards now recognize `export NAME=value`, matching Bun's dotenv loader so exported directory overrides cannot redirect trusted configuration sources.
+
 ## [0.13.3] - 2026-08-15
 
 ### Fixed

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fatal crash records now end with a machine-readable identity line (`gjc-crash-record.v1 fp:<32hex> fpv:1 id:<random>`) whose 128-bit fingerprint is computed from the already-captured diagnostic text with typed normalization (paths/home/uuid/hex/long-digit placeholders, `404` and `500` kept distinct, no line/column numbers in frames). The fatal path also appends one bounded (≤512 B) `O_APPEND` line to a new crash event journal beside the crash log; failures are swallowed and a latch makes a crash-during-crash skip journal work. New `getCrashEventsPath()` / `getCrashIndexPath()` resolvers, and `redactCrashSecrets` is now exported.
 
 ### Fixed
-- Project `.env` trust guards now recognize `export NAME=value`, matching Bun's dotenv loader so exported directory overrides cannot redirect trusted configuration sources.
+- Project `.env` trust guards now recognize the full assignment syntax Bun's dotenv loader accepts: `export NAME=value`, whitespace around `=`, and unquoted trailing `#` comments (`NAME=value # note`), so exported or spaced directory overrides cannot redirect trusted configuration sources.
 
 ## [0.13.3] - 2026-08-15
 

--- a/packages/utils/src/env-file.ts
+++ b/packages/utils/src/env-file.ts
@@ -91,13 +91,13 @@ export function parseEnvFile(filePath: string): Record<string, string> {
 			// Skip comments and blank lines
 			if (!trimmed || trimmed.startsWith("#")) continue;
 
-			const eqIndex = trimmed.indexOf("=");
-			if (eqIndex === -1) continue;
+			const match = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(trimmed);
+			if (!match) continue;
 
-			const key = trimmed.slice(0, eqIndex).trim();
+			const key = match[1];
 			if (!isValidEnvName(key)) continue;
 
-			let value = trimmed.slice(eqIndex + 1).trim();
+			let value = (match[2] ?? "").trim();
 
 			// Remove surrounding quotes (" or ')
 			if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {

--- a/packages/utils/src/env-file.ts
+++ b/packages/utils/src/env-file.ts
@@ -39,6 +39,30 @@ function stripInlineShellComment(value: string): string {
 }
 
 /**
+ * Strips an unquoted trailing `# comment` from a dotenv value the way Bun's
+ * dotenv loader does: an unescaped `#` starts a comment regardless of the
+ * preceding character (`a#b` loads as `a`), while `#` inside quotes or after a
+ * backslash escape survives. Used only by `parseEnvFile`; shell files use
+ * `stripInlineShellComment`, whose POSIX rule requires whitespace before `#`.
+ */
+function stripInlineDotenvComment(value: string): string {
+	let quote: '"' | "'" | undefined;
+	for (let i = 0; i < value.length; i++) {
+		const char = value[i];
+		if (char === "\\") {
+			i++;
+			continue;
+		}
+		if ((char === '"' || char === "'") && (!quote || quote === char)) {
+			quote = quote ? undefined : char;
+			continue;
+		}
+		if (char === "#" && !quote) return value.slice(0, i).trimEnd();
+	}
+	return value.trimEnd();
+}
+
+/**
  * Parses simple POSIX shell environment assignments from files such as
  * ~/.zshrc without executing user shell code. Supports `export KEY=value` and
  * `KEY=value`, including single/double quoted literal values. Dynamic shell
@@ -81,6 +105,17 @@ export function parseShellEnvFile(filePath: string): Record<string, string> {
  * Ignores lines that are empty or start with '#'. Trims whitespace.
  * Allows values to be quoted with single or double quotes.
  * Returns an object of key-value pairs.
+ *
+ * The trust guards (`trustedAgentDirOverrideFor`, `trustedConfigDirName`,
+ * `filterCredentialInheritedEnv`) decide provenance by comparing
+ * `process.env` against this parse, so the accepted syntax must be a superset
+ * of what Bun's own dotenv loader honors in `cwd/.env`: `export KEY=value`,
+ * whitespace around `=`, and `#` comments after unquoted values (quotes keep
+ * their `#`). Values that Bun would expand (`$VAR`, `${VAR}`, backticks,
+ * command substitution) are kept as their literal text: the trust rule only
+ * needs the parser to see the key at all, and an operator environment value
+ * cannot equal attacker-written expansion text, so a literal parse stays
+ * conservative.
  */
 export function parseEnvFile(filePath: string): Record<string, string> {
 	const result: Record<string, string> = {};
@@ -91,13 +126,15 @@ export function parseEnvFile(filePath: string): Record<string, string> {
 			// Skip comments and blank lines
 			if (!trimmed || trimmed.startsWith("#")) continue;
 
-			const match = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(trimmed);
+			const match = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/.exec(trimmed);
 			if (!match) continue;
 
 			const key = match[1];
 			if (!isValidEnvName(key)) continue;
 
-			let value = (match[2] ?? "").trim();
+			// Strip an unquoted trailing `# comment` the way Bun's dotenv loader
+			// does (`KEY=v#note` loads as `v`); quoted `#` survives.
+			let value = stripInlineDotenvComment(match[2] ?? "").trim();
 
 			// Remove surrounding quotes (" or ')
 			if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {

--- a/packages/utils/test/agent-dir-trust.test.ts
+++ b/packages/utils/test/agent-dir-trust.test.ts
@@ -89,6 +89,13 @@ describe("agent directory trust boundary", () => {
 		expect(resolved.agentDir).not.toBe(agentDir);
 		expect(resolved.probeValue).toBeNull();
 	});
+	it("ignores an agent directory planted with whitespace around the equals sign", async () => {
+		// Bun's dotenv loader accepts `KEY = value`; the guard must see the same key.
+		const agentDir = agentDirWith("from-attacker-spaced-agent-env");
+		const resolved = await resolveIn(projectDir(`GJC_CODING_AGENT_DIR = ${agentDir}\n`));
+		expect(resolved.agentDir).not.toBe(agentDir);
+		expect(resolved.probeValue).toBeNull();
+	});
 
 	it("does not let the project .env redirect an inherited agent directory", async () => {
 		const operatorDir = agentDirWith("from-operator-agent-env");

--- a/packages/utils/test/agent-dir-trust.test.ts
+++ b/packages/utils/test/agent-dir-trust.test.ts
@@ -83,6 +83,13 @@ describe("agent directory trust boundary", () => {
 		expect(resolved.probeValue).toBeNull();
 	});
 
+	it("ignores an exported agent directory planted by the project .env", async () => {
+		const agentDir = agentDirWith("from-attacker-exported-agent-env");
+		const resolved = await resolveIn(projectDir(`export GJC_CODING_AGENT_DIR=${agentDir}\n`));
+		expect(resolved.agentDir).not.toBe(agentDir);
+		expect(resolved.probeValue).toBeNull();
+	});
+
 	it("does not let the project .env redirect an inherited agent directory", async () => {
 		const operatorDir = agentDirWith("from-operator-agent-env");
 		const attackerDir = agentDirWith("from-attacker-agent-env");

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -73,6 +73,33 @@ describe("parseEnvFile", () => {
 			GJC_FEATURE: "enabled",
 		});
 	});
+	it("accepts every assignment shape Bun's dotenv loader accepts", () => {
+		const filePath = writeTempEnv(
+			[
+				"PLAIN=value",
+				"export EXPORTED=exported-value",
+				"export\tTABBED=tabbed-value",
+				"SPACED_AROUND = spaced-value",
+				"export SPACED_EXPORT = spaced-export-value",
+				"INLINE_COMMENT=value # note",
+				"INLINE_COMMENT_TIGHT=value#note",
+				'QUOTED_HASH="value # kept"',
+				"MULTI_WORD=a b",
+			].join("\n"),
+		);
+
+		expect(parseEnvFile(filePath)).toEqual({
+			PLAIN: "value",
+			EXPORTED: "exported-value",
+			TABBED: "tabbed-value",
+			SPACED_AROUND: "spaced-value",
+			SPACED_EXPORT: "spaced-export-value",
+			INLINE_COMMENT: "value",
+			INLINE_COMMENT_TIGHT: "value",
+			QUOTED_HASH: "value # kept",
+			MULTI_WORD: "a b",
+		});
+	});
 });
 
 describe("parseShellEnvFile", () => {


### PR DESCRIPTION
## What changed

- recognize the full assignment syntax Bun's dotenv loader accepts in the shared dotenv parser: `export NAME=value`, whitespace around `=`, and unquoted trailing `#` comments
- add regressions proving exported and spaced project overrides cannot select the trusted agent directory, plus a Bun-parity parser matrix
- document the fix in the utils changelog

## Why

Bun loads `export NAME=value`, `NAME = value`, and `NAME=value # note` from `.env`, while `parseEnvFile()` ignored them. The directory trust guards use that parser to distinguish project-provided overrides from operator-provided environment values, so a project could bypass the guard with syntax Bun still honored — pointing `GJC_CODING_AGENT_DIR`/`PI_CODING_AGENT_DIR`/`GJC_CONFIG_DIR` at a directory it ships and having its own `.env` treated as a trusted credential source.

The original head's regex required `NAME` to touch `=`, which silently dropped `KEY = value` lines that Bun loads and that the legacy `indexOf("=")` parse caught — re-opening the very bypass this PR closes. Maintainer fix-forward `7bee069a` restores spaced-assignment coverage and aligns inline-comment stripping with Bun's dotenv semantics (`v#note` loads as `v`; quoted `#` survives), keeping `parseShellEnvFile` on POSIX whitespace-before-`#` rules.

## Impact

Project `.env` files can no longer redirect trusted configuration sources through export-prefixed or whitespace-spaced `GJC_CODING_AGENT_DIR` (and the `PI_` alias / config-dir equivalents). Normal dotenv assignments and shell-inherited overrides keep their existing behavior.

Known residual (pre-existing at base, out of scope here): Bun performs `$VAR`/backtick expansion when loading `.env`; the parser keeps those values literal, so an expansion-authored override can still slip past the value-equality check. Tracked for a follow-up.

## Validation

- `bun test packages/utils/test/` (342 pass — includes the trust-boundary suite)
- `bun --cwd=packages/utils run check`
- `bun scripts/verify-gjc-state-writers.ts --fail --root .`
- differential harness vs `bun --print process.env` across 10+ assignment forms (export, tab-separated export, spaced `=`, trailing `#` with and without space, quoted `#`, quotes, backtick/`$VAR` divergence, duplicate last-wins precedence, invalid names)
- `git diff --check`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:c6732b539098eb9333301e1bb1098172b15c684d9d4b0b2b919555aad97b0890 reviewer:human reviewer-id:Yeachan-Heo evidence:maintainer-exact-head-review-7bee069a-differential-bun-dotenv-matrix-plus-fix-forward
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit