### PR TITLE
fix(ci): restore SDK closure checks

### DIFF
--- a/packages/coding-agent/test/manifests/telegram-baseline-v1.json
+++ b/packages/coding-agent/test/manifests/telegram-baseline-v1.json
@@ -110,6 +110,27 @@
 			"argv": [
 				"bun",
 				"test",
+				"packages/coding-agent/test/notifications-inbound-acceptance.test.ts"
+			]
+		},
+		{
+			"argv": [
+				"bun",
+				"test",
+				"packages/coding-agent/test/notifications-inbound-production-path.test.ts"
+			]
+		},
+		{
+			"argv": [
+				"bun",
+				"test",
+				"packages/coding-agent/test/notifications-inbound-reaction-ordering.test.ts"
+			]
+		},
+		{
+			"argv": [
+				"bun",
+				"test",
 				"packages/coding-agent/test/notifications-lifecycle-command-routing.test.ts"
 			]
 		},

--- a/scripts/telegram-daemon-generation-guard.test.ts
+++ b/scripts/telegram-daemon-generation-guard.test.ts
@@ -32,6 +32,7 @@ import {
 const guardScript = "scripts/telegram-daemon-generation-guard.ts";
 const manifestScript = "scripts/telegram-daemon-generation-manifest.json";
 const topicRegistryFixture = "packages/coding-agent/test/notifications-topic-registry.test.ts";
+const repositoryRoot = path.resolve(import.meta.dir, "..");
 const stableEntries = (value: Record<string, string>) => JSON.stringify(Object.entries(value).sort());
 
 const telegramContract = "packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts";
@@ -1416,8 +1417,8 @@ test("publishes exact durable authority generation 167 at serving epoch 87", () 
 	});
 
 	test("the committed topic-registry fixture tracks the canonical Telegram generation", async () => {
-		const fixture = await Bun.file(topicRegistryFixture).text();
-		const contract = await Bun.file(telegramContract).text();
+		const fixture = await Bun.file(path.join(repositoryRoot, topicRegistryFixture)).text();
+		const contract = await Bun.file(path.join(repositoryRoot, telegramContract)).text();
 		const declared = declaration(contract, "DAEMON_GENERATION");
 		expect(declared).toBeDefined();
 		const canonical = Number(/DAEMON_GENERATION\s*=\s*(\d+)/.exec(declared!)?.[1]);


### PR DESCRIPTION
## Summary

- Resolve Telegram daemon guard fixtures from the repository root so the guard suite works from both the root and package working directories.
- Refresh the generated Telegram baseline manifest with the three discovered inbound notification suites, moving the baseline from 54 to 57 commands.

## Root cause

The package-level `check:sdk-closure` command invokes the root guard test while the working directory is `packages/coding-agent`. Two fixture reads used cwd-relative paths, which incorrectly resolved beneath a duplicated `packages/coding-agent` segment.

The committed Telegram baseline had also drifted from generator discovery and omitted three existing inbound notification test files.

## Commit structure

Each modified file has its own commit as required:

- `a82b61d43` — `scripts/telegram-daemon-generation-guard.test.ts`
- `749111d0c` — `packages/coding-agent/test/manifests/telegram-baseline-v1.json`

## Validation

- Guard suite from repository root: 75 passed
- Guard suite from `packages/coding-agent`: 75 passed
- Three newly registered inbound notification suites: 17 passed
- Telegram baseline generator `--check`: passed
- Coding-agent package check: passed with 11 pre-existing lint warnings
- SDK adapter parity manifest: all 582 row receipts passed
- Telegram baseline manifest: all 57 command receipts passed
- SDK downgrade and rollback tests: 4 passed

The full `check:sdk-closure` run reaches the final canonicalization gate, which fails with 27 existing `mcp-serve.ts` dependency violations. The same gate was run against `upstream/dev`; exit status, violation count, and complete output are identical, so this branch does not introduce that failure.

## Review status

- Independent architecture review: `CLEAR`
- Additional reviewer: no severity-rated code findings
- Required `code-reviewer` lane: unavailable because this deployment rejects that operation

This PR remains draft because the required independent review lane could not return evidence.