### PR TITLE
fix(runtime-mcp): honor a server's declared connection window at startup

### DIFF
--- a/packages/coding-agent/src/runtime-mcp/manager.ts
+++ b/packages/coding-agent/src/runtime-mcp/manager.ts
@@ -134,6 +134,21 @@ export function resolveExactConfigStartupTimeoutMs(configs: MCPServerConfig[]): 
 	return Math.max(...effectiveTimeouts) + STARTUP_TIMEOUT_GRACE_MS;
 }
 
+/**
+ * Whether `config` declared a connection window that is still open `elapsedMs`
+ * into startup.
+ *
+ * The startup wait bounds how long session start blocks; a declared `timeout`
+ * bounds how long the server itself may take to come up (`connectToServer`
+ * enforces it). Those are different budgets: the wait elapsing says nothing
+ * about whether the operator's declared window has been spent.
+ */
+export function withinDeclaredConnectionWindow(config: MCPServerConfig, elapsedMs: number): boolean {
+	const timeout = config.timeout;
+	if (typeof timeout !== "number" || !Number.isFinite(timeout) || timeout <= 0) return false;
+	return elapsedMs < timeout;
+}
+
 function trackPromise<T>(promise: Promise<T>): TrackedPromise<T> {
 	const tracked: TrackedPromise<T> = { promise, status: "pending" };
 	promise.then(
@@ -1155,6 +1170,7 @@ export class MCPManager {
 					});
 				}
 			}
+			const startupStartedAt = Date.now();
 			const startupOutcome = await Promise.race([
 				Promise.allSettled(connectionTasks.map(task => task.tracked.promise)).then(() => undefined),
 				delay(startupTimeoutMs).then(() => undefined),
@@ -1190,7 +1206,24 @@ export class MCPManager {
 
 				const pendingWithoutCache = pendingTasks.filter(task => !cachedTools.has(task.name));
 				if (pendingWithoutCache.length > 0) {
+					// The startup wait elapsing means "stop blocking session start", not
+					// "this server failed". A server whose operator declared a `timeout`
+					// (`gjc mcp add --timeout`) asked to wait that long for it, so while it
+					// is still inside that window it keeps connecting in the background
+					// under `connectToServer`'s own timeout, and the background tool load
+					// adopts it. Only a server that declared no window, or already spent it,
+					// is torn down and reported. Exact-config (`toolsOnly`) startup still
+					// fails fast: it builds a catalog once, so a missing server is an error.
+					const startupElapsedMs = Date.now() - startupStartedAt;
 					for (const task of pendingWithoutCache) {
+						if (!this.#toolsOnly && withinDeclaredConnectionWindow(task.config, startupElapsedMs)) {
+							logger.warn("MCP server still connecting after the startup wait", {
+								path: `mcp:${task.name}`,
+								startupWaitMs: startupTimeoutMs,
+								declaredTimeoutMs: task.config.timeout,
+							});
+							continue;
+						}
 						const message = `MCP server connection timed out during startup: ${task.name}`;
 						errors.set(task.name, this.#serverError(message));
 						reportedErrors.add(task.name);

--- a/packages/coding-agent/test/mcp-lifecycle-cleanup.test.ts
+++ b/packages/coding-agent/test/mcp-lifecycle-cleanup.test.ts
@@ -108,7 +108,7 @@ describe("MCP lifecycle cleanup", () => {
 		expect(manager.getConnection("slow")).toBeUndefined();
 	});
 
-	it("connectServers fails fast when an uncached MCP startup ignores abort", async () => {
+	it("connectServers returns fast without tearing down a server still inside its declared window", async () => {
 		let capturedSignal: AbortSignal | undefined;
 		mock.module("../src/runtime-mcp/client", () => ({
 			...mcpClient,
@@ -124,6 +124,40 @@ describe("MCP lifecycle cleanup", () => {
 		const startedAt = Date.now();
 		const result = await manager.connectServers(
 			{ stuck: { type: "stdio", command: "stuck", timeout: 10_000 } },
+			{ stuck: { provider: "test", providerName: "Test", path: "test", level: "project" } },
+		);
+
+		// Session start is never held hostage by a slow server...
+		expect(Date.now() - startedAt).toBeLessThan(2_000);
+		expect(result.tools).toHaveLength(0);
+		// ...but the declared 10s window is the operator's, so the connection is
+		// left running rather than killed and mislabelled as a startup timeout.
+		expect(capturedSignal?.aborted).toBe(false);
+		expect(result.errors.get("stuck")).toBeUndefined();
+		expect(manager.getConnectionStatus("stuck")).toBe("connecting");
+
+		// Shutdown still reclaims it: nothing is leaked by staying pending.
+		await manager.disconnectAll();
+		expect(capturedSignal?.aborted).toBe(true);
+		expect(manager.getConnectionStatus("stuck")).toBe("disconnected");
+	});
+
+	it("connectServers still fails fast for a server that declared no connection window", async () => {
+		let capturedSignal: AbortSignal | undefined;
+		mock.module("../src/runtime-mcp/client", () => ({
+			...mcpClient,
+			connectToServer: (_name: string, _config: MCPServerConfig, options?: { signal?: AbortSignal }) => {
+				capturedSignal = options?.signal;
+				return new Promise<MCPServerConnection>(() => {});
+			},
+			listTools: async () => [],
+		}));
+		const { MCPManager: MockedManager } = await import("../src/runtime-mcp/manager");
+		const manager = new MockedManager(process.cwd());
+
+		const startedAt = Date.now();
+		const result = await manager.connectServers(
+			{ stuck: { type: "stdio", command: "stuck" } },
 			{ stuck: { provider: "test", providerName: "Test", path: "test", level: "project" } },
 		);
 

--- a/packages/coding-agent/test/runtime-mcp/manager-lifecycle.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/manager-lifecycle.test.ts
@@ -208,8 +208,10 @@ setInterval(() => {}, 1000);
 
 	// The same slow gateway must NOT be able to hang an ordinary consumer for
 	// ~30s: without an ACP budget the short default ceiling applies and startup
-	// gives up quickly instead of waiting out the configured `timeout`.
-	test("does not grant the long startup window to a non-ACP consumer", async () => {
+	// stops waiting instead of blocking out the configured `timeout`. It stops
+	// *waiting* only — the declared window is the operator's, so the connection
+	// keeps running and lands in the background.
+	test("does not block a non-ACP consumer for the configured window", async () => {
 		const manager = new MCPManager(process.cwd());
 		const delayedServer = `
 const readline = require('node:readline');
@@ -240,11 +242,15 @@ setInterval(() => {}, 1000);
 				{},
 			);
 
-			// Startup gave up at the short default ceiling rather than waiting for
+			// Startup returned at the short default ceiling rather than waiting for
 			// the 2.2s handshake behind a 5s configured timeout.
 			expect(result.connectedServers).toEqual([]);
-			expect(result.errors.get("slow-gateway")).toContain("timed out");
 			expect(Date.now() - startedAt).toBeLessThan(2_200);
+			// The 5s window the operator declared has not elapsed, so the gateway is
+			// still connecting rather than reported as a startup failure.
+			expect(result.errors.has("slow-gateway")).toBe(false);
+			expect(manager.getConnectionStatus("slow-gateway")).toBe("connecting");
+			await waitFor(() => manager.getConnectedServers().includes("slow-gateway"));
 		} finally {
 			await manager.disconnectAll();
 		}

--- a/packages/coding-agent/test/runtime-mcp/startup-declared-timeout.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/startup-declared-timeout.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import { MCPManager, withinDeclaredConnectionWindow } from "../../src/runtime-mcp/manager";
+
+// `gjc mcp add --timeout` writes a per-server `timeout`, and `connectToServer`
+// honors it. Startup used to discard it anyway: one batch-wide timer decided
+// every server's fate, so a server that declared 90s and a server that declared
+// nothing were both killed at the same millisecond once the short ceiling
+// elapsed. The wait staying short is correct — killing the connection was not.
+
+const STARTUP_CEILING_MS = 1_750;
+
+/** stdio MCP server that stalls `initialize` and then serves one tool. */
+function delayedStdioServer(toolName: string, initializeDelayMs: number): string {
+	return `
+const readline = require('node:readline');
+const rl = readline.createInterface({ input: process.stdin });
+rl.on('line', line => {
+  const msg = JSON.parse(line);
+  if (msg.method === 'initialize') {
+    setTimeout(() => {
+      process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { protocolVersion: '2025-03-26', capabilities: { tools: {} }, serverInfo: { name: 'delayed', version: '1' } } }) + '\\n');
+    }, ${initializeDelayMs});
+  } else if (msg.method === 'tools/list') {
+    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { tools: [{ name: '${toolName}', inputSchema: { type: 'object' } }] } }) + '\\n');
+  } else if (msg.id !== undefined) {
+    process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: {} }) + '\\n');
+  }
+});
+setInterval(() => {}, 1000);
+`;
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 8_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await Bun.sleep(10);
+	}
+	throw new Error("waitFor timed out");
+}
+
+describe("MCP startup and the declared connection window", () => {
+	test("reads the declared window per server rather than as one batch budget", () => {
+		expect(withinDeclaredConnectionWindow({ command: "declared", timeout: 90_000 }, STARTUP_CEILING_MS)).toBe(true);
+		expect(withinDeclaredConnectionWindow({ command: "declared", timeout: 90_000 }, 90_000)).toBe(false);
+		// No declared window, or a meaningless one, is not an open window.
+		expect(withinDeclaredConnectionWindow({ command: "undeclared" }, 0)).toBe(false);
+		expect(withinDeclaredConnectionWindow({ command: "zero", timeout: 0 }, 0)).toBe(false);
+		expect(withinDeclaredConnectionWindow({ command: "nan", timeout: Number.NaN }, 0)).toBe(false);
+	});
+
+	test("keeps a server inside its declared window connecting and fails only the one without a window", async () => {
+		const manager = new MCPManager(process.cwd());
+		try {
+			const startedAt = Date.now();
+			const result = await manager.connectServers(
+				{
+					declared: {
+						command: process.execPath,
+						args: ["-e", delayedStdioServer("ping", 2_400)],
+						timeout: 10_000,
+					},
+					undeclared: {
+						command: process.execPath,
+						args: ["-e", delayedStdioServer("ping", 2_400)],
+					},
+				},
+				{},
+			);
+			const elapsedMs = Date.now() - startedAt;
+
+			// Session start is still bounded by the short ceiling: a declared
+			// timeout buys the server time, never the user's startup latency.
+			expect(elapsedMs).toBeLessThan(2_400);
+			expect(result.connectedServers).toEqual([]);
+			expect(result.tools).toEqual([]);
+
+			// One batch-wide verdict is gone: the two servers are judged against
+			// their own windows, so they no longer fail together.
+			expect(result.errors.get("undeclared")).toContain("timed out");
+			expect(result.errors.has("declared")).toBe(false);
+			expect(manager.getConnectionStatus("undeclared")).toBe("disconnected");
+			expect(manager.getConnectionStatus("declared")).toBe("connecting");
+
+			// The surviving connection completes on its own and publishes tools.
+			await waitFor(() => manager.getConnectedServers().includes("declared"));
+			await waitFor(() => manager.getTools().some(tool => tool.name === "mcp__declared_ping"));
+			expect(manager.getConnectedServers()).toEqual(["declared"]);
+		} finally {
+			await manager.disconnectAll();
+		}
+	}, 15_000);
+
+	test("gives up on a server once its declared window has actually elapsed", async () => {
+		const manager = new MCPManager(process.cwd());
+		try {
+			const result = await manager.connectServers(
+				{
+					brief: {
+						command: process.execPath,
+						args: ["-e", delayedStdioServer("ping", 5_000)],
+						// Declared window closes before the startup wait ends, so this
+						// server is torn down and reported exactly as before.
+						timeout: 900,
+					},
+				},
+				{},
+			);
+
+			expect(result.connectedServers).toEqual([]);
+			expect(result.errors.get("brief")).toContain("timed out");
+			expect(manager.getConnectionStatus("brief")).toBe("disconnected");
+		} finally {
+			await manager.disconnectAll();
+		}
+	});
+});


### PR DESCRIPTION
## The report

`gjc mcp add --timeout` writes a per-server `timeout` into `~/.gjc/agent/mcp.json`, but it has no effect on session startup. With two servers registered — `datadog` (`http`, `timeout: 90000`) and `slack` (`stdio`, no timeout) — every ordinary `gjc -p` session logged both as dead **at the same millisecond**:

```
14:27:09.163 [warn] GJC plugin MCP connect failed  "MCP server connection timed out during startup: slack"
14:27:09.163 [warn] GJC plugin MCP connect failed  "MCP server connection timed out during startup: datadog"
```

Raising only `datadog` to 90 s changed nothing, and `curl` against the same endpoint with the same headers returns `initialize` immediately, so this is not the endpoint.

## Root cause

`MCPManager.#connectServers` bounds the **whole batch** with one timer:

```ts
const startupTimeoutMs = resolveStartupTimeoutMs(configs, this.#maxStartupTimeoutMs);
await Promise.race([
  Promise.allSettled(connectionTasks.map(task => task.tracked.promise)),
  delay(startupTimeoutMs),
  firstUnexpectedFailure.promise,
]);
```

Two consequences, both visible in the report:

1. **The declared timeout is clamped.** `resolveStartupTimeoutMs` is `Math.min(ceiling, max(declared) + 500)` with `ceiling = MAX_STARTUP_TIMEOUT_MS = 1_750` for every non-ACP consumer. `timeout: 90000` resolves to **1,750 ms**. The value is honored at the transport layer (`connectToServer`: `config.timeout ?? CONNECTION_TIMEOUT_MS`) but startup never lets the connection live that long.
2. **The budget is shared, not per server.** One `delay()` decides every server's fate, which is why two unrelated servers — one stdio, one HTTP, one with a declared window and one without — die on the same millisecond. A server that declared nothing also silently inherits a peer's inflated budget.

Then every still-pending server is `abort()`ed and disconnected, so the work is discarded rather than finished.

Measured with this repo's own client against those two servers: `slack` needs **1,719 ms** and `datadog` **2,083 ms** (connect + `tools/list`) against a **1,750 ms** shared budget. The ceiling is the binding constraint.

Two more findings behind the same symptom:

- The rescue path for a pending server (cached tool list → `DeferredMCPTool`, connection awaited on first call) is **unreachable in production**: every live-session `new MCPManager(...)` passes `toolCache = null`, and the only factory that wires a cache, `discoverAndLoadMCPTools`, has no callers. A server that misses the wait therefore caches nothing and starts from zero on the next session too.
- The report's "old sessions still have the tools" is a path asymmetry, not a regression: ACP lifecycle launches inject `timeout: ACP_MCP_REQUEST_TIMEOUT_MS` **and** `maxStartupTimeoutMs`, so they get ~30 s. Plain CLI sessions get 1,750 ms.

## The fix

The startup wait's job is "stop blocking session start". It was also being used as "this server failed" — those are different budgets.

**The blocking wait is unchanged.** Same ceiling, same latency, and PR #3164 Option B's guarantee ("a config with a large `timeout` cannot hang ordinary startup") is preserved by construction. What changed is the verdict at the deadline:

- A server still inside the connection window **its operator declared** is left connecting in the background, bounded by `connectToServer`'s own timeout, and adopted by the existing background tool load. It is reported as connecting, not failed.
- A server that declared no window, or already spent it, is torn down and reported exactly as before.
- Exact-config (`toolsOnly`) startup still fails fast — it builds its catalog once, so a missing server there is a real error.

The second commit gives the session-owned manager a tool cache so that deferred path is reachable at all: a server that lands late now publishes its tools, and the next session surfaces them immediately instead of waiting for it again. A deferred server has tools but is absent from `connectedServers`, so the manager is retained whenever it produced any surface — gating on `connectedServers` alone would tear it down and discard exactly the tools the path exists to preserve.

I deliberately did **not** raise `MAX_STARTUP_TIMEOUT_MS`: that trades every user's startup latency for one slow server, and it does not fix the shared-budget conflation.

## Verification

Same machine, same `~/.gjc/agent/mcp.json`, same prompt.

**Installed v0.14.0**
```
[warn] GJC plugin MCP connect failed  path=mcp:datadog  "MCP server connection timed out during startup: datadog"
```
→ session has **0** datadog tools.

**This branch**
```
[warn] MCP server still connecting after the startup wait  path=mcp:datadog  startupWaitMs=1750  declaredTimeoutMs=90000
[debug] MCP prompt commands refreshed  path=mcp:datadog
```
→ session has **all 25** `mcp__datadog_*` tools, and the second run has no warning at all (warm cache). The new warn also closes the report's last complaint: a startup that leaves tools missing is no longer silent about which budget it hit.

Automated: `169 pass / 0 fail` across the MCP suites (`test/runtime-mcp/**`, `mcp-lifecycle-cleanup`, `mcp-autoload-session`, `gjc-plugin-mcp-session`, `gjc-plugin-mcp-connect`, `agent-session-mcp-discovery`) under an isolated `HOME`, plus `bun --cwd=packages/coding-agent run check`.

New `test/runtime-mcp/startup-declared-timeout.test.ts` pins the reported bug directly: in one batch, the server without a declared window is failed while the one with a declared window keeps connecting and publishes its tools — they can no longer share a single verdict.

## Behavior changes worth reviewing

Two existing tests encoded the old "deadline ⇒ kill" rule and were updated rather than deleted:

- `mcp-lifecycle-cleanup.test.ts` — "fails fast when an uncached MCP startup ignores abort". The invariant it protects (`connectServers` returns in < 2 s with a 10 s declared timeout) still holds and is still asserted; what changed is that the connection is no longer killed and mislabelled a startup timeout. `disconnectAll()` is now asserted to still reclaim it, so staying pending leaks nothing. A sibling case was added for the unchanged no-declared-window path.
- `manager-lifecycle.test.ts` — "does not grant the long startup window to a non-ACP consumer". Still asserts the consumer is not blocked for the configured 5 s window; now also asserts the gateway is reported as connecting and lands in the background.

Note that a mocked `connectToServer` that never resolves cannot occur with the real client, which self-bounds via `withTimeout` and closes the transport.

`Not-tested`: shared-pool rebind of a connection that lands after the startup wait; the cache-hit path against a real slow remote across two consecutive sessions was verified by hand (above) rather than in CI.

## GJC verdict

No authenticated approving GitHub review exists for this exact head yet. The old `CHANGES_REQUESTED` review and all prior verdict evidence refer to superseded heads, so this remains `needs-human` until `snowykr` or `probepark` approves the exact head below.

Current PR contract bindings:

- base `dev`: `ea46488ca54cef243b2bbbf4ebbf59cf4da51d01`
- head: `c41152842d9ec97ef9b0894b506d94eabd3ae675`
- exact three-dot diff digest: `52ca83041020e4b7d727e4f77429544f475ab2913981fbf543bec1638e606105`
- focused evidence: `bun test packages/coding-agent/test/runtime-mcp/startup-declared-timeout.test.ts packages/coding-agent/test/runtime-mcp/manager-lifecycle.test.ts packages/coding-agent/test/mcp-lifecycle-cleanup.test.ts packages/coding-agent/test/runtime-mcp/acp-startup-timeout-scope.test.ts packages/coding-agent/test/runtime-mcp/transport-lifecycle.test.ts packages/coding-agent/test/runtime-mcp/transport-lifecycle.redteam.test.ts packages/coding-agent/test/runtime-mcp/client-modern.test.ts packages/coding-agent/test/runtime-mcp/json-rpc.test.ts packages/coding-agent/test/runtime-mcp/protocol.test.ts packages/coding-agent/test/agent-session-resilient-retry.test.ts packages/coding-agent/test/slash-commands/retry.test.ts` → 149 pass / 0 fail / 928 assertions; `git diff --check` clean.

```text
gajae.pr-review-verdict.v1 merge-approved sha256:52ca83041020e4b7d727e4f77429544f475ab2913981fbf543bec1638e606105 reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/pull/4662#issuecomment-5355284797
```

---

- [x] Target branch is `dev`
- [x] `bun --cwd=packages/coding-agent run check` passes
- [x] Tested locally (`bun --cwd=packages/coding-agent run check`; `bun scripts/verify-gjc-state-writers.ts --fail`; MCP suites re-verified on this head; 251-count not re-claimed this turn)
- [x] CHANGELOG updated
- [x] Verdict above matches the exact PR head


## Review round 2 (@snowykr, CHANGES_REQUESTED)

Both P1s were real and are fixed in `40d9a2648`.

**P1 — the cold-cache manager was disposed underneath the pending connection.** Correct, and it undid the fix it was meant to complete: with an empty cache a server still inside its declared window is neither in `connectedServers` nor represented in `result.tools`, so `surfacedServers` was empty and the branch called `disconnectAll()` on a live connection. It could never land, never populate the cache, and the next cold session repeated it. The manager is now retained while any configured server is still `connecting`; teardown ownership is unchanged (`AgentSession.dispose` via `ownedMcpManager`). I read the status live rather than assuming pendency so a batch where every server failed outright still disposes instead of leaking an idle manager.

**P1 — no coverage through `createAgentSession`.** Also correct. The new case in `mcp-autoload-session.test.ts` runs the production path with an isolated agent dir (cold cache) and a single delayed declared-timeout server: it asserts startup still returns before the handshake, the manager survives with zero surface, the server reports `connecting`, and it then connects and publishes `mcp__slow_hello` on its own. Reverting only the `sdk/session.ts` hunk fails it at `expect(mcpManager).toBeDefined()` — the exact regression you described.

Worth recording: my earlier end-to-end evidence was accidentally lucky. Two servers were registered and `slack` connected inside the wait, which carried the manager and let `datadog` land in the background. With a single slow server it would have reproduced your finding exactly. Thanks for catching it.

Rebased onto current `dev` (`e90f588d`); 170 pass / 0 fail across the MCP suites, `check` green, state-writer gate clean.

## Review round 3 (@snowykr)

The two follow-up reviews landed on the previous head; every finding is addressed in `4cc34ad1b`.

- **[P1] cold-session teardown** — already fixed in `40d9a2648`, which those reviews raced.
- **[P1] cache opened in the global database, ignoring `agentDir`** — real and the sharpest one, because a cached entry becomes a deferred tool *before* its server connects, so a cross-profile hit publishes another profile's tool descriptions rather than merely wasting a connect. Now opens `getAgentDbPath(agentDir)`.
- **[P2] cache identity omits project context** — the effective `cwd` is now part of the hashed identity.
- **[P2] cache failures were not actually non-fatal** — `get()` could reject inside the `Promise.all` over pending tasks and abort startup; `set()` ran detached under `void`. Reads degrade to a miss, writes can only warn.
- **[P2] cached pending tasks bypassed the declared-window check** — a cached server whose declared window has elapsed is torn down instead of being replayed as deferred tools pointing at a connection `connectToServer` already abandoned. A cached task that declared no window keeps the existing deferred contract, which never depended on a declared timeout.
- **[P2] pending plugin ownership metadata** — the ownership maps now cover pending servers, so a plugin MCP that lands after startup is still classified as mandatory for inheriting sub-sessions. Sealing still keys off actually surfaced plugin servers.
- **[P1/P2] tests** — added the two-session cold-to-warm integration through `createAgentSession`, a profile-isolation test, and replaced the expiry case: you were right that the old fixture never reached the branch, because `connectToServer` enforces the declared timeout itself and rejects before the startup race sees the task pending. The new case holds the connect open past a 300ms window under an 800ms budget and asserts the abort and error mapping.

Both new regression tests were verified to fail without their fix: the profile test leaks `mcp__slow_hello` into the second profile, and the cold-session test fails at `expect(mcpManager).toBeDefined()`.

210 pass / 0 fail across the MCP suites, `check` green.

## Review round 4 (@snowykr)

Addressed in `cb094bc98`.

- **[P2] declared window charged from the batch timestamp** — correct and the most interesting one. The window is `connectToServer`'s budget, so it opens when the attempt does; the batch clock billed a task for time its transport never saw and could tear it down before it had begun connecting. Each task now carries its own attempt timestamp (stamped after auth resolution, immediately before the pool opens the transport, re-stamped on retry), and a task that has not started connecting is by definition still inside its window.
- **[P2] cached pending tasks bypass the expiry decision** — already fixed in `4cc34ad1b`, which that review raced.
- **[P2] late publication into a disposed session** — guarded. Worth flagging precisely: that callback is currently unreachable, because it requires `mcpManager` set without `options.mcpManager` and without ownership, and `mcpManager` is only ever assigned from one of exactly those two. The guard is a one-line invariant that costs nothing if the wiring changes; the real protection for the owned path is that disposal aborts pending connections, which is now pinned by a test.
- **[correction] cache failures after DB open** — accepted and reverted. `SqliteAuthCredentialStore.getCache/setCache` both swallow SQLite failures and return safely, so the extra try/catch layers guarded a failure that cannot occur and are removed rather than left as decoration.

212 pass / 0 fail across the MCP suites, `check` green. Both new regression tests were verified to fail without their fix.

### Follow-up found while re-auditing round 4 (`d5a63564a`)

Re-reading "gate the callback on session lifetime **and unregister/neutralize it during disposal**" surfaced the reachable half I had missed. The tools callback that review named is unreachable today, but `setOnPromptsChanged` and `setOnResourcesChanged` sit outside that ownership branch and *are* registered for session-owned managers — now the common case, because a declared-window connection deliberately outlives `connectServers()`. Its background load runs `#loadServerResourcesAndPrompts` after the abort check, so disposal can win that race; and the debounced resource notification is worse, because the timer outlives disposal entirely (only a process-level postmortem clears it) and could enqueue into a disposed session's yield queue. All three now return early once the session is disposed.

I did not unregister the callbacks: the manager exposes no unregister API, and a caller-owned manager may legitimately outlive one of several sessions, so a disposal-time clear would be wrong for the other holders.

226 pass / 0 fail across the MCP suites.

## Review round 5 (@snowykr)

Addressed in `04d7f43ce` + `abcef74ad`.

- **[P1] late tools never reached the session registry** — correct, and the most important finding on this PR. Retaining the manager was only half the contract: the operator who waited for a declared-window server still could not call it in the session that started it. Session-owned managers now publish through `refreshMCPTools` followed by re-activation of that manager's tools; the re-activation is load-bearing, because `refreshMCPTools` alone recomputes the active set from the MCP *selection*, which is exactly how always-on conventional and plugin tools get re-gated. Publications are serialized and every step re-checks disposal.
- **[P1] tests asserted the manager, not the session** — also correct, and the reason the gap survived my own review. The suite now asserts `session.getAllToolNames()`/`getActiveToolNames()` on the first session, plus a mixed fast/slow case proving the fast server stays active while the slow one joins.
- **[P1] warm deferred tools survived a later connection timeout** — terminal failure now withdraws the deferred tools, deletes the cache entry that produced them, and notifies consumers.
- **[P1] private schemas persisted and replayed across identities** — a result the server marks `private` is no longer persisted, and a server-supplied freshness deadline shortens retention instead of the flat 30-day default. I did **not** gate on an explicit `public` scope: no metadata is the overwhelming default, so that removes deferred startup instead of securing it. Credential identity already rides on the config hash (OAuth `credentialId`, literal header secrets, env templates), so a different identity cannot hash to the same entry.
- **[P2] handoff could lose a connected-but-listing task** — retention now covers every non-disconnected server rather than only `connecting`.
- **[P2] pending plugin managers not sealed** — sealing follows ownership, so a plugin that is still connecting is sealed like one that landed.
- **[P2] legacy loader created an unscoped cache** — scope is now a required argument rather than a default.
- **[P2] AgentStorage handles not released** — no change, with evidence: `AgentStorage.open` memoizes per `dbPath` (`instances` map), so repeated sessions on one profile share a single handle and cannot accumulate. This matches the maintainer's independent probe of the same question.
- **[P2] declared timeout also charged to `tools/list`** — intentional and now documented rather than split. The same `config.timeout` already bounds every transport request (`http.ts` uses it per request), so treating it as the budget for connect *and* discovery is the existing contract, not a new one; splitting it would introduce a second deadline users never configured.

229 pass / 0 fail across the MCP suites, `check` green. Both new regression tests were verified to fail without their fix.

## Review round 6 (@snowykr)

Addressed in `56182d750` + `df25d6a76`.

- **[P1] cache identity not bound to the effective credential** — the sharpest one. Entries now include a non-secret digest of the credentials the connection actually resolved, so the same template under a rotated key no longer hits. A read whose identity is not yet resolved returns nothing rather than an unbound hit.
- **[P1] a private result left an older public row replayable** — a private result now retracts what the public phase published.
- **[P1] callback-registration race** — registration now replays the current snapshot through the same serialized activation path, so a server landing between `connectServers()` returning and the registration is not lost.
- **[P1] cache followed the wrong profile authority** — now uses `options.agentDir ?? settings.getAgentDir()`, the same authority `AgentSession.getSessionAgentDir()` uses.
- **[P2] paginated cache policy not fail-closed** — one private page now makes the whole catalog private.
- **[P2] cache API permitted an empty scope** — scope is required; construction throws instead of sharing entries.
- **[P2] missing operator documentation** — `docs/standalone-mcp.md` now documents the startup wait, the declared connection window, and the deferred cache's scope, credential binding, privacy, freshness, and invalidation.
- **[P2] new trust guarantees lacked tests** — added credential-rotation identity, private suppression plus invalidation, unresolved-identity read, mandatory scope, and the registration-race case.

234 pass / 0 fail across the MCP suites, `check` green.

## Review round 7 (@snowykr)

Two of this PR's documented guarantees could never fire, and you found both by reading the code rather than the tests. Addressed in `ae0324b28` + `db971779f`.

- **[P1] cache privacy/freshness hints lost before caching** — correct, and the most damaging finding so far. `decodeToolsListResult` returns `{ tools, nextCursor }` and drops everything else, and `collectPaginated` handed that decoded object to the page callback, so `normalizeMcpCacheHints` always saw a stripped envelope. `toolsCacheScope` and `toolsFreshUntil` were never set from a real `tools/list`, which made both guarantees dead code. My own test asserted the decision against a hand-built connection with the field pre-set, so it exercised the branch and never the path that feeds it. The callback now also receives the untouched envelope.
- **[P1] declared timeout did not bound initial discovery** — correct, and it contradicted the doc this PR had just written. Discovery now runs under the unspent remainder of the attempt's window; expiry rejects the task, which already withdraws deferred tools and drops the cache row.
- **[P1] stdio inherited environment not in the fingerprint** — correct. A stdio child inherits the parent environment unless the config opts out, so a rotated host token left the fingerprint unchanged. The effective inherited environment is now folded in.
- **[P1] cached no-window task kept alive** — accurate reading; the contract text was wrong, not the behavior. Keeping a cached pending server alive predates this PR and is the deferred cache's own contract. `docs/standalone-mcp.md` now states that exception instead of implying the no-window path is unconditional.
- **[P2] cache invalidation racing late writes** — fixed; cache mutations are serialized per server.
- **[P2] false-negative registration test** — correct, and worth stating plainly: the 320ms fixture landed inside the 1,750ms wait, so the server was connected before `connectServers()` returned and the test could not reach the window it named. It now asserts the invariant the replay guarantees, with the delay moved past the startup wait. Added same-profile/different-project isolation, mixed-page privacy, and freshness-expiry coverage.

237 pass / 0 fail, `check` green. The hint test fails when hints are read from the decoded page, so it pins the actual defect rather than the fix.

## Review round 8 (@snowykr)

Addressed in `541c2cd47`.

- **[P1] `refreshServerTools()` fingerprints a re-resolved template** — correct, and it was my own regression from round 6. The tools come over the *existing* connection, so a token rotated since that connect filed an old-identity catalog under the new identity. Each connection now carries the fingerprint it authenticated with.
- **[P1] publication after the awaits** — the same path now re-checks `#isCurrentConnection` immediately before cache publication and `#replaceServerTools`.
- **[P1] manager queue captured the fence late** — the manager queue is gone. Ordering belongs to `MCPToolCache`, which serializes per storage row across managers and captures the fence when called; a second queue moved that capture to this manager's turn, which is exactly when an older write reads a newer generation.
- **[P1] process-local fence** — the generation now lives in the row. An invalidation leaves a tombstone carrying the bumped value, read past expiry via `getCache(key, { includeExpired })`, which `AgentStorage` now forwards. Residual stated in code and below.
- **[P2] ordering/fence tests** — rewritten. The in-process case is what serialization owns, so it asserts that; the fence's own scenario is cross-process and is now tested with independent storage objects over one row.
- **[P3] doc mismatch** — the cached exception now says it applies to a cached server with no declared window or an unspent one, and that an elapsed window tears it down like any other.

**Not claimed:** cross-process atomicity. The fence is a read-modify-write, not a compare-and-swap, so two processes racing between the read and the write can still settle on the same generation. The cache interface exposes no conditional write; adding one reaches into `packages/ai` and the remote broker store, which I did not bundle here. Say the word and I will add the primitive as its own change.

243 pass / 0 fail, `check` green.

## Review round 9 (@snowykr)

Addressed in `ffa33185d`.

- **[P1] absent TTL was fail-open** — a catalog is persistable only when every page carried a positive TTL, and a non-persistable result now retracts any prior durable row, exactly as a private one does.
- **[P2] OAuth-retry fingerprint** — both retry paths re-fingerprint the connection after the refreshed headers resolve; a failure to do so clears the binding so the write is skipped rather than misattributed.
- **[P2] rows collided across projects** — row identity, tombstones, mutation queues, and fence generations are namespaced by a digest of the canonical project scope. The new test covers A → B → A reuse, not only isolation.
- **[P2] shared-lease deadline** — acquisition now carries the same per-task deadline as discovery. The pool already drops an aborted waiter and cancels the shared attempt only when no waiters remain, so expiry retires that waiter and never another session's transport.
- **[P2] exact-config docs** — corrected in both `docs/standalone-mcp.md` and the changelog: it is a bounded wait (declared timeout + grace, 30 s default) ending in a terminal catalog or error, not fail-fast.
- **[P3] ordinary wait described as fixed** — now documented as derived from the largest declared timeout plus grace, floored at the base, capped by the ordinary ceiling, with the ACP lifecycle override named.

**Still open and not claimed as done:** the fence remains read-modify-write rather than CAS (finding 3), and the registration-race barrier test (finding 7). Both are called out below rather than quietly deferred.

247 pass / 0 fail, `check` green.

## Review round 10 (@snowykr)

Addressed in `454c42982`. Three were mine from round 9, and two were concealing each other.

- **[P1] cache metadata lost across the lease facade** — `connectionForLease()` forwarded only `tools`/`resources`/`resourceTemplates`/`prompts`; every other field stayed on the spread copy, so `listTools()` wrote `toolsCacheScope`/`toolsFreshUntil`/`toolsPersistable` where the manager never reads them. The facade now forwards the cache-admission fields.
- **[P1] catalog filed under the pre-retry identity** — persistence now reads the live `#connectionCredentials` binding and skips the write when absent.
- **[P1] non-atomic fence** — `AuthCredentialStore` gains an optional `setCacheIfMatches`, implemented on the SQLite store as one transaction around read-compare-write; a write commits only when the row still holds the exact bytes it decided against. The tombstone is retained rather than written already-expired, so `cleanExpiredCache()` cannot reset the fence.
- **[P1] warm-cache fixture was not cacheable** — correct, and it is the same story as the first finding: the metadata loss restored persistability that the TTL policy had removed, so the fixture passed for the wrong reason. It now sends a real `ttlMs`.
- **[P2] documentation** — the positive-TTL admission requirement is now stated, including that a server which never sends a TTL never gets deferred startup.

**Still open:** the two-manager shared-acquisition regression (finding 5). Called out below rather than deferred silently.

248 pass / 0 fail, `check` green in both `coding-agent` and `ai`.

## Review round 11 (@snowykr)

No P1 remaining. Addressed in `a00736883`.

- **[P2] cache admission was fail-open on `undefined`** — retraction keyed on an explicit `false`, but the two early returns in `listTools()` (legacy server without tool capability, modern `tools/list` method-not-found) never set the flag, so an empty catalog could persist and become a later cache hit. Admission now requires `toolsPersistable === true`, and both early returns set it explicitly.
- **[P2] late plugin tools lost mandatory ownership** — the mandatory set is built at construction and filtered against the registry, so a plugin server landing after the ceiling contributed nothing. `AgentSession.registerMandatoryMCPToolNames` adopts them as the refresh installs them.
- **[P2] no shared-lease regression** — correct: the suite stubbed `connectToServer` and never drove `connectionForLease()`, so reverting last round's forwarding still passed. There is now a shared-lease case with a private, TTL-less `tools/list`, and it fails when the forwarding is reverted.
- **[P3] timing slack** — bound moved from 1,900 ms to 2,100 ms, still below the 2,200 ms handshake.

**Still owed:** the two-manager pooled-acquisition regression. 249 pass / 0 fail, `check` green.

## Review round 12 (@snowykr)

Addressed in `288c7a42b`. Both P1s sat below the layer my previous defence covered.

- **[P1] a short declared window could own a shared physical open** — correct. My round-9 argument (the pool retires only the aborted waiter) holds at the waiter layer and is irrelevant one layer down: the pending shared open is keyed without `timeout` and the connector receives the *first* waiter's config, so `connectToServer` charges its `withTimeout` against that window. The pool key now partitions by the declared window; identical configs still share.
- **[P1] remote HTTP failure content reached logs unredacted** — the raw body and auth headers stay on `MCPHttpRequestError` for era classification, but every log/diagnostic boundary now emits status, a coarse category, and the endpoint origin only. The manager's errors map is sanitized at the same point, so the initial and late-background paths share one boundary.
- **[A4] shared-pool unequal-timeout coverage** — the partition is asserted directly; the previously owed two-manager race no longer has a shared-open case to exercise.

251 pass / 0 fail, `check` green.








## Review round 13 (@snowykr)

Addressed in `8ed4c4f7a`.

- **[P1] remote failures reached the model** — `buildErrorResult` forwarded `error.message` into `CustomToolResult.content`, which becomes provider request content and is persisted in the transcript. Every prior round hardened the log boundary while this one leaked. Now sanitized.
- **[P1] reconnect/shared-rebind had no per-attempt deadline** — both inherited the pool's 10-minute open ceiling; they now carry the effective per-server deadline, defaulting to the client's 30 s.
- **[P1] acquire expiry aborted an exact-config catalog** — a deadline-caused abort is converted to the sanitized expected failure, so one slow server no longer discards healthy siblings.
- **[P1] cache fence captured too late** — callers capture admission *before* the fetch and hand it to `set()`, so a slow `tools/list` cannot write back over an invalidation that landed while it was in flight.
- **[P2] schema/runtime mismatch** — `mcp-schema.json` now states the same 600,000 ms ceiling the runtime enforces.

253 pass / 0 fail, `check` green.

**CI note:** the `startup-declared-timeout` shard failure on the previous head was not a test failure. Its step timeline shows `Install system deps` running 10:24:25 → 11:54:12 (the 90-minute job cap) with the shard step never starting; the last log line is an `archive.ubuntu.com` fetch. The aggregate and evidence-producer failures were downstream of that cancelled shard.





