### PR TITLE
fix(coding-agent): interrupt active work on Ctrl+C

### DIFF
--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -331,12 +331,25 @@ export class InputController {
 		);
 	}
 
+	#handlePendingSteerInterrupt(): boolean {
+		if (!this.#steerConsumePending) return false;
+		this.#resetEscapeGestures();
+		if (!this.ctx.session.hasQueuedSteering) {
+			this.#steerConsumePending = false;
+			return false;
+		}
+
+		this.#steerConsumePending = false;
+		this.restoreQueuedMessagesToEditor({ abort: true });
+		return true;
+	}
+
 	#handleCancellableWorkEscape(options: {
 		loading?: boolean;
 		processes?: boolean;
 		modes?: boolean;
 		maintenance?: boolean;
-		retry?: boolean;
+		retry?: "escape" | "clear";
 		streaming?: boolean;
 	}): boolean {
 		if (options.loading && this.ctx.loadingAnimation) {
@@ -380,7 +393,7 @@ export class InputController {
 		}
 		if (options.retry) {
 			if (this.#isRetryBackoffActive()) {
-				if (this.ctx.retryEscapePrimed) {
+				if (options.retry === "clear" || this.ctx.retryEscapePrimed) {
 					this.ctx.session.abortRetry();
 				} else {
 					this.ctx.retryEscapePrimed = true;
@@ -416,14 +429,23 @@ export class InputController {
 			if (!isInterruptKey && !isClearKey) {
 				return undefined;
 			}
+			if (isClearKey && !isInterruptKey && this.ctx.hasActiveBtw() && this.ctx.handleBtwEscape()) {
+				this.#resetEscapeGestures();
+				return { consume: true };
+			}
+			if (isClearKey && !isInterruptKey && this.ctx.hookSelector?.hasActiveInlineInput?.() === true) {
+				this.#resetEscapeGestures();
+				return undefined;
+			}
 			if (isClearKey && !isInterruptKey) {
+				if (this.#handlePendingSteerInterrupt()) return { consume: true };
 				if (
 					!this.#handleCancellableWorkEscape({
 						loading: true,
 						processes: true,
 						modes: true,
 						maintenance: true,
-						retry: true,
+						retry: "clear",
 						streaming: true,
 					})
 				) {
@@ -450,7 +472,7 @@ export class InputController {
 					processes: hookDialogActive,
 					modes: false,
 					maintenance: true,
-					retry: true,
+					retry: "escape",
 					streaming: hookDialogActive,
 				})
 			) {
@@ -514,19 +536,8 @@ export class InputController {
 				this.#resetEscapeGestures();
 				return;
 			}
-			if (this.#steerConsumePending) {
-				this.#resetEscapeGestures();
-				if (this.ctx.session.hasQueuedSteering) {
-					// Second Esc before the scheduled steer continuation drains the
-					// queue: restore/drop the queued steer and perform a real abort,
-					// even if abort cleanup already made the session look idle.
-					this.#steerConsumePending = false;
-					this.restoreQueuedMessagesToEditor({ abort: true });
-					return;
-				}
-				this.#steerConsumePending = false;
-			}
-			if (this.#handleCancellableWorkEscape({ maintenance: true, retry: true })) {
+			if (this.#handlePendingSteerInterrupt()) return;
+			if (this.#handleCancellableWorkEscape({ maintenance: true, retry: "escape" })) {
 				this.#resetEscapeGestures();
 				return;
 			}
@@ -536,7 +547,7 @@ export class InputController {
 					processes: true,
 					modes: true,
 					maintenance: true,
-					retry: true,
+					retry: "escape",
 					streaming: true,
 				})
 			) {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -315,6 +315,10 @@ export class InputController {
 		return this.ctx.keybindings.getKeys("app.interrupt").some(key => matchesKey(data, key));
 	}
 
+	#matchesClearKey(data: string): boolean {
+		return this.ctx.keybindings.getKeys("app.clear").some(key => matchesKey(data, key));
+	}
+
 	#hasHookDialog(): boolean {
 		return Boolean(this.ctx.hookSelector || this.ctx.hookInput || this.ctx.hookEditor);
 	}
@@ -407,8 +411,26 @@ export class InputController {
 		}
 		this.#globalInterruptUnsubscribe?.();
 		this.#globalInterruptUnsubscribe = this.ctx.ui.addInputListener(data => {
-			if (!this.#matchesInterruptKey(data)) {
+			const isInterruptKey = this.#matchesInterruptKey(data);
+			const isClearKey = this.#matchesClearKey(data);
+			if (!isInterruptKey && !isClearKey) {
 				return undefined;
+			}
+			if (isClearKey && !isInterruptKey) {
+				if (
+					!this.#handleCancellableWorkEscape({
+						loading: true,
+						processes: true,
+						modes: true,
+						maintenance: true,
+						retry: true,
+						streaming: true,
+					})
+				) {
+					return undefined;
+				}
+				this.#resetEscapeGestures();
+				return { consume: true };
 			}
 			if (this.ctx.hasActiveBtw() && this.ctx.handleBtwEscape()) {
 				this.#resetEscapeGestures();

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -69,7 +69,7 @@ function createSubmission(input: {
 	};
 }
 
-function createContext(): {
+function createContext(options: { interruptKeys?: string[]; clearKeys?: string[] } = {}): {
 	ctx: InteractiveModeContext;
 	editor: FakeEditor;
 	inputListeners: FakeInputListener[];
@@ -89,6 +89,7 @@ function createContext(): {
 		requestRender: ReturnType<typeof vi.fn>;
 		startPendingSubmission: ReturnType<typeof vi.fn>;
 		clearEditor: ReturnType<typeof vi.fn>;
+		shutdown: ReturnType<typeof vi.fn>;
 		abortCompaction: ReturnType<typeof vi.fn>;
 		abortHandoff: ReturnType<typeof vi.fn>;
 		abortRetry: ReturnType<typeof vi.fn>;
@@ -158,6 +159,7 @@ function createContext(): {
 		editor.setText("");
 		ctx.pendingImages = [];
 	});
+	const shutdown = vi.fn(() => Promise.resolve());
 	const ensureLoadingAnimation = vi.fn(() => {
 		ctx.loadingAnimation = {} as InteractiveModeContext["loadingAnimation"];
 	});
@@ -198,13 +200,18 @@ function createContext(): {
 		} as unknown as InteractiveModeContext["sessionManager"],
 		keybindings: {
 			getKeys: (action: string) =>
-				action === "app.interrupt" ? ["escape"] : action === "app.clear" ? ["ctrl+c"] : [],
+				action === "app.interrupt"
+					? (options.interruptKeys ?? ["escape"])
+					: action === "app.clear"
+						? (options.clearKeys ?? ["ctrl+c"])
+						: [],
 			getDisplayString: () => "",
 		} as unknown as InteractiveModeContext["keybindings"],
 		pendingImages: [],
 		lastEscapeTime: 0,
 		lastComposerClearEscapeTime: 0,
 		clearEditor,
+		shutdown,
 		isBashMode: false,
 		isPythonMode: false,
 		optimisticUserMessageSignature: undefined,
@@ -256,6 +263,7 @@ function createContext(): {
 			requestRender,
 			startPendingSubmission,
 			clearEditor,
+			shutdown,
 			showStatus,
 		},
 	};
@@ -529,6 +537,105 @@ describe("InputController escape behavior", () => {
 		expect(spies.abort).toHaveBeenCalledWith(expect.objectContaining({ cause: "user_interrupt" }));
 		expect(spies.clearEditor).not.toHaveBeenCalled();
 		expect(editor.getText()).toBe("draft message");
+	});
+	it("falls through to the editor for idle Ctrl+C clear and double-press shutdown", async () => {
+		const { ctx, editor, inputListeners, spies } = createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.setText("draft message");
+		const first = inputListeners[0]?.("\x03");
+		if (!first?.consume) editor.onClear?.();
+		await Bun.sleep(0);
+		expect(first).toBeUndefined();
+		expect(spies.clearEditor).toHaveBeenCalledTimes(1);
+		expect(spies.shutdown).not.toHaveBeenCalled();
+
+		const second = inputListeners[0]?.("\x03");
+		if (!second?.consume) editor.onClear?.();
+		await Bun.sleep(0);
+		expect(second).toBeUndefined();
+		expect(spies.shutdown).toHaveBeenCalledTimes(1);
+	});
+	it("honors remapped and multiple clear bindings at the listener boundary", () => {
+		const { ctx, inputListeners, spies } = createContext({ clearKeys: ["ctrl+x", "ctrl+c"] });
+		(ctx.session as { isStreaming: boolean }).isStreaming = true;
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		expect(inputListeners[0]?.("\x18")).toEqual({ consume: true });
+		expect(spies.abort).toHaveBeenCalledTimes(1);
+	});
+	it("uses clear cancellation for loading, process, mode, maintenance, and retry states", () => {
+		const cases = [
+			{
+				name: "loading",
+				setup: (ctx: InteractiveModeContext) => {
+					ctx.loadingAnimation = {} as InteractiveModeContext["loadingAnimation"];
+				},
+				assert: (spies: ReturnType<typeof createContext>["spies"]) => expect(spies.clearQueue).toHaveBeenCalled(),
+			},
+			{
+				name: "bash process",
+				setup: (ctx: InteractiveModeContext) => {
+					(ctx.session as { isBashRunning: boolean }).isBashRunning = true;
+				},
+				assert: (spies: ReturnType<typeof createContext>["spies"]) =>
+					expect(spies.abortBash).toHaveBeenCalledTimes(1),
+			},
+			{
+				name: "bash mode",
+				setup: (ctx: InteractiveModeContext) => {
+					ctx.isBashMode = true;
+				},
+				assert: (spies: ReturnType<typeof createContext>["spies"]) =>
+					expect(spies.clearEditor).not.toHaveBeenCalled(),
+			},
+			{
+				name: "maintenance",
+				setup: (ctx: InteractiveModeContext) => {
+					(ctx.session as { isCompacting: boolean }).isCompacting = true;
+				},
+				assert: (spies: ReturnType<typeof createContext>["spies"]) =>
+					expect(spies.abortCompaction).toHaveBeenCalledTimes(1),
+			},
+			{
+				name: "retry",
+				setup: (ctx: InteractiveModeContext) => {
+					ctx.retryLoader = {} as InteractiveModeContext["retryLoader"];
+				},
+				assert: (spies: ReturnType<typeof createContext>["spies"]) => {
+					expect(spies.abortRetry).toHaveBeenCalledTimes(1);
+					expect(spies.retryNow).not.toHaveBeenCalled();
+				},
+			},
+		] as const;
+
+		for (const testCase of cases) {
+			const { ctx, inputListeners, spies } = createContext();
+			testCase.setup(ctx);
+			new InputController(ctx).setupKeyHandlers();
+			expect(inputListeners[0]?.("\x03"), testCase.name).toEqual({ consume: true });
+			testCase.assert(spies);
+		}
+	});
+	it("preserves BTW precedence and queued-steer first/second Ctrl+C semantics", () => {
+		const overlay = createContext();
+		overlay.spies.hasActiveBtw.mockReturnValue(true);
+		new InputController(overlay.ctx).setupKeyHandlers();
+		expect(overlay.inputListeners[0]?.("\x03")).toEqual({ consume: true });
+		expect(overlay.spies.handleBtwEscape).toHaveBeenCalledTimes(1);
+		expect(overlay.spies.abort).not.toHaveBeenCalled();
+
+		const queued = createContext();
+		(queued.ctx.session as { isStreaming: boolean; hasQueuedSteering: boolean }).isStreaming = true;
+		(queued.ctx.session as { hasQueuedSteering: boolean }).hasQueuedSteering = true;
+		new InputController(queued.ctx).setupKeyHandlers();
+		expect(queued.inputListeners[0]?.("\x03")).toEqual({ consume: true });
+		expect(queued.spies.abort).toHaveBeenCalledWith(expect.objectContaining({ silent: true }));
+		expect(queued.inputListeners[0]?.("\x03")).toEqual({ consume: true });
+		expect(queued.spies.clearQueue).toHaveBeenCalledTimes(1);
+		expect(queued.spies.abort).toHaveBeenCalledTimes(2);
 	});
 	it("lets hook selector inline input handle Esc locally during a workflow stream", () => {
 		const { ctx, inputListeners, spies } = createContext();

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -197,7 +197,8 @@ function createContext(): {
 			getSessionName: () => "existing session",
 		} as unknown as InteractiveModeContext["sessionManager"],
 		keybindings: {
-			getKeys: (action: string) => (action === "app.interrupt" ? ["escape"] : []),
+			getKeys: (action: string) =>
+				action === "app.interrupt" ? ["escape"] : action === "app.clear" ? ["ctrl+c"] : [],
 			getDisplayString: () => "",
 		} as unknown as InteractiveModeContext["keybindings"],
 		pendingImages: [],
@@ -513,6 +514,21 @@ describe("InputController escape behavior", () => {
 		expect(result).toEqual({ consume: true });
 		expect(spies.abort).toHaveBeenCalledTimes(1);
 		expect(spies.abort).toHaveBeenCalledWith(expect.objectContaining({ cause: "user_interrupt" }));
+	});
+	it("globally aborts an active workflow stream on Ctrl+C without clearing the composer", () => {
+		const { ctx, editor, inputListeners, spies } = createContext();
+		(ctx.session as { isStreaming: boolean }).isStreaming = true;
+		editor.setText("draft message");
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		const result = inputListeners[0]?.("\x03");
+
+		expect(result).toEqual({ consume: true });
+		expect(spies.abort).toHaveBeenCalledTimes(1);
+		expect(spies.abort).toHaveBeenCalledWith(expect.objectContaining({ cause: "user_interrupt" }));
+		expect(spies.clearEditor).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("draft message");
 	});
 	it("lets hook selector inline input handle Esc locally during a workflow stream", () => {
 		const { ctx, inputListeners, spies } = createContext();


### PR DESCRIPTION
## What

Fix active-task terminal interruption for #4671. The global input listener now shares the pending-steer prelude with Escape and app.clear, preserves focused overlay/dialog precedence, and uses clear-specific retry cancellation without retryNow.

## Why

Fixes #4671. On `gjc/0.14.0` under WSL, the report reproduced in Zed and the default terminal: `Esc` and `Ctrl+C` failed to interrupt an active task inspecting `history.md` and `D:\agent_project\PNU\apps`.

## Testing

- `bun --cwd=packages/coding-agent run check` — passed.
- `bun test packages/coding-agent/test/input-controller-escape.test.ts packages/tui/test/keys.test.ts packages/tui/test/stdin-buffer.test.ts scripts/verify-pr-verdict.test.ts` — 247 passed, 0 failed.
- Added listener-to-editor coverage for idle first-clear/double-press exit, remapped and multiple clear bindings, loading/process/mode/maintenance/retry paths, BTW precedence, and first/second queued-steer Ctrl+C.
- Changed paths are limited to `packages/coding-agent/src/modes/controllers/input-controller.ts` and `packages/coding-agent/test/input-controller-escape.test.ts`.
- `packages/natives/native/index.d.ts` is excluded; unrelated generated drift was restored.
- Live WSL terminal capture is unavailable in this Linux runner; no live WSL claim is made.

## Exact-head receipt

- Repository: `Yeachan-Heo/gajae-code`
- Target: `dev`
- Exact base: `2bd7b4a48cd4eb196388744bf0f17f466bd4afa5`
- Exact head: `c9c7bfae6cfb8288c1bf9b2df20d05b64e116362`
- Exact base-to-head diff digest: `sha256:24cea4101eabe4c891511a1b32d99c17b74d0593c455785372f22203b474d399`
- Native key tables are unchanged; existing `matchesKey` normalization covers Escape and Ctrl+C.

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:24cea4101eabe4c891511a1b32d99c17b74d0593c455785372f22203b474d399 reviewer:human reviewer-id:probepark evidence:bun test packages/coding-agent/test/input-controller-escape.test.ts packages/tui/test/keys.test.ts packages/tui/test/stdin-buffer.test.ts scripts/verify-pr-verdict.test.ts
```

A fresh non-author exact-head approval is required before changing this verdict to `merge-approved`. Self-approval is invalid.

---

- [x] Target branch is `dev`
- [x] `bun check` passes (targeted coding-agent check)
- [x] Tested locally
- [ ] CHANGELOG updated (not needed for this narrow fix)
- [ ] Verdict changes to `merge-approved` only after independent exact-head approval

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*