### PR TITLE
fix(sdk): restore Windows ACP session-host liveness

### DIFF
--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -827,6 +827,18 @@ function observeProcess(
 	expectedIncarnation: string | undefined,
 	readIncarnation: (pid: number) => string | undefined = processIncarnation,
 ): ProcessObservation {
+	if (process.platform === "win32") {
+		try {
+			const reference = nativeLifecycle().Process.fromPid(pid);
+			if (reference?.status() !== "running") return "exited";
+		} catch {
+			return "uncertain";
+		}
+		if (!expectedIncarnation) return "uncertain";
+		const actualIncarnation = readIncarnation(pid);
+		if (!actualIncarnation) return "uncertain";
+		return actualIncarnation === expectedIncarnation ? "alive" : "exited";
+	}
 	try {
 		process.kill(pid, 0);
 	} catch (error) {
@@ -841,6 +853,15 @@ function observeProcess(
 	const actualIncarnation = readIncarnation(pid);
 	if (!actualIncarnation) return "uncertain";
 	return actualIncarnation === expectedIncarnation ? "alive" : "exited";
+}
+
+/** Test seam for the lifecycle-owned process observation boundary. */
+export function observeProcessForTest(
+	pid: number,
+	expectedIncarnation: string | undefined,
+	readIncarnation: (pid: number) => string | undefined = processIncarnation,
+): ProcessObservation {
+	return observeProcess(pid, expectedIncarnation, readIncarnation);
 }
 
 function hasObservedProcessExit(pid: number): boolean {

--- a/packages/coding-agent/src/sdk/broker/session-index.ts
+++ b/packages/coding-agent/src/sdk/broker/session-index.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import path from "node:path";
 import { logger, resolveEquivalentPath } from "@gajae-code/utils";
+import { nativeProcessBindings } from "@gajae-code/utils/native-process";
 import { withFileLock } from "../../config/file-lock";
 import { processIncarnation } from "./process-incarnation";
 import {
@@ -754,6 +755,18 @@ async function replaceAtomically(file: string, contents: Buffer | string): Promi
 }
 
 function alive(pid: number): boolean {
+	if (process.platform === "win32") {
+		try {
+			// Bun's signal-0 probe is not a reliable Windows liveness authority for a
+			// detached child: it can report a non-live process even while the child
+			// has already published its endpoint. Use the native process handle, which
+			// is also the source of the process-incarnation fence, and fail closed when
+			// the handle cannot be opened.
+			return nativeProcessBindings().Process.fromPid(pid)?.status() === "running";
+		} catch {
+			return false;
+		}
+	}
 	try {
 		process.kill(pid, 0);
 		return true;

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -18,6 +18,7 @@ import {
 	deriveLifecycleDeadlines,
 	executeLifecycle,
 	hasValidLifecycleDeadlines,
+	observeProcessForTest,
 	parseDarwinProcessIncarnation,
 	processIncarnation,
 	reapDeadSessionRegistrations,
@@ -829,6 +830,30 @@ test("broker reads Windows process incarnations as canonical FILETIME ticks with
 			runCommand: () => ({ exitCode: 0, stdout: "4242\t133830291061234568\n" }),
 		}),
 	).toBe("windows:133830291061234568");
+});
+test("Windows lifecycle readiness uses the native process handle instead of signal-zero", () => {
+	const originalPlatform = process.platform;
+	const originalKill = process.kill;
+	const processRef = {
+		incarnation: "windows:133830291061234567",
+		status: () => "running" as const,
+	};
+	const fromPid = vi.spyOn(native.Process, "fromPid").mockReturnValue(processRef as never);
+	process.kill = (() => {
+		throw Object.assign(new Error("signal zero unavailable"), { code: "EINVAL" });
+	}) as typeof process.kill;
+	Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+	try {
+		expect(observeProcessForTest(4_242, processRef.incarnation, () => processRef.incarnation)).toBe("alive");
+		fromPid.mockReturnValue(null);
+		expect(observeProcessForTest(4_242, processRef.incarnation, () => processRef.incarnation)).toBe("exited");
+		fromPid.mockReturnValue({ ...processRef, status: () => "exited" as const } as never);
+		expect(observeProcessForTest(4_242, processRef.incarnation, () => processRef.incarnation)).toBe("exited");
+	} finally {
+		Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+		process.kill = originalKill;
+		fromPid.mockRestore();
+	}
 });
 test("native absent-process null skips PowerShell on native Windows without repeated spawns (#4362, #4367)", () => {
 	// The native binding returns null as the authoritative absent-process result.

--- a/packages/coding-agent/test/sdk-session-index.test.ts
+++ b/packages/coding-agent/test/sdk-session-index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import path from "node:path";
+import * as native from "@gajae-code/natives";
 import { SessionIndex, type SessionIndexEvent, sessionIndexChecksum } from "../src/sdk/broker/session-index";
 import { SDK_STATE_VERSION } from "../src/sdk/broker/state-version";
 
@@ -97,6 +98,36 @@ describe("SDK session index", () => {
 			await first;
 		} finally {
 			spy.mockRestore();
+		}
+	});
+	it("uses the native Windows process handle when signal-zero misreports a detached host", async () => {
+		const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-index-windows-live-"));
+		const originalPlatform = process.platform;
+		const originalKill = process.kill;
+		const processRef = {
+			incarnation: "windows:133830291061234567",
+			status: () => "running" as const,
+		};
+		const fromPid = vi.spyOn(native.Process, "fromPid").mockReturnValue(processRef as never);
+		process.kill = (() => {
+			throw Object.assign(new Error("signal zero unavailable"), { code: "EINVAL" });
+		}) as typeof process.kill;
+		Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+		try {
+			const index = await new SessionIndex(dir).open();
+			await index.append({
+				...event("windows-detached"),
+				hostIncarnation: processRef.incarnation,
+			});
+			expect(index.listSessions().sessions).toMatchObject([
+				{ sessionId: "windows-detached", live: true, identityProvenance: "composite" },
+			]);
+			expect(fromPid).toHaveBeenCalled();
+		} finally {
+			Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+			process.kill = originalKill;
+			fromPid.mockRestore();
+			await fs.rm(dir, { recursive: true, force: true });
 		}
 	});
 	it("replays only rows after the snapshotted prefix", async () => {


### PR DESCRIPTION
## What
Restore Windows detached SDK session-host liveness at both lifecycle boundaries: the broker session-index `live` projection and the pre-readiness process observation used by `currentReadyAuthority`/`waitForReady`. Add deterministic regressions for the Windows signal-zero gap and fail-closed native authority cases.

## Why
On Windows, Bun's `process.kill(pid, 0)` can report a detached lifecycle child as unavailable after it has published its endpoint and indexed registration. The initial index-only fix was insufficient because lifecycle readiness still called signal-zero observation first, so `currentReadyAuthority` could never reach the native index liveness proof. The native process handle is the same OS authority used for process incarnation. An unavailable or non-running handle remains non-live/exited according to the existing fail-closed path; a ready file alone cannot authorize startup or cleanup. Fixes #4672.

## Testing
- `bun test packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts --timeout 30000` (83 passed on clean rerun; earlier runs exposed existing timing-sensitive startup assertions and were rerun)
- `bun test packages/coding-agent/test/sdk-session-index.test.ts --timeout 30000` (48 passed)
- `bun test packages/coding-agent/test/acp-session-reconnect.test.ts --timeout 30000` (2 passed)
- `bun --cwd=packages/coding-agent run check` passed

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:c57a509c8f737602392d5c7d94abda29c5c32422e3ecffc7d3ffbf460beb398d reviewer:architect reviewer-id:pending-independent-review evidence:independent exact-head review and Windows CI pending
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (internal lifecycle fix; no user-facing copy change)
- [ ] Verdict above matches the exact PR head, not an earlier commit