### PR TITLE
ci(release): publish to npm through OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -610,25 +610,29 @@ jobs:
               overwrite: true
 
    release_approval:
-      # Approval gate BEFORE the credential boundary. The environment's
-      # protection rules (required reviewers, restricted deployment refs) are
-      # owner-controlled repository settings and are NOT evaluated from the
-      # tagged revision. This job holds no permissions and no OIDC token, so
-      # placing the environment HERE — not on publish — keeps the publish
-      # job's OIDC subject ref-scoped (repo:...:ref:refs/tags/v*), the
-      # identity the npm trusted-publisher registrations and the shipped
-      # v0.14.1 exchange already prove. Owner prerequisite (documented
-      # blocker, verified absent at review time): configure the npm-release
-      # environment with required reviewers; until then this gate is a hook.
-      if: ${{ needs.release_prepare.result == 'success' }}
-      needs: [release_prepare]
+      # Approval gate BEFORE the credential boundary, STABLE releases only:
+      # scheduled and manual nightlies are the documented unattended lane and
+      # must never wait on a reviewer. The environment's protection rules
+      # (required reviewers, restricted deployment refs) are owner-controlled
+      # repository settings and are NOT evaluated from the tagged revision.
+      # This job holds no permissions and no OIDC token, so placing the
+      # environment HERE — not on publish — keeps the publish job's OIDC
+      # subject ref-scoped (repo:...:ref:refs/tags/v*), the identity the npm
+      # trusted-publisher registrations and the shipped v0.14.1 exchange
+      # already prove. Owner prerequisites (documented blocker, verified
+      # absent at review time): configure the npm-release environment with
+      # required non-self reviewers and no administrator bypass, restrict its
+      # deployment refs to the release refs, and protect `main` plus
+      # `refs/tags/v*` creation with rulesets. Until then this gate is a hook.
+      if: ${{ needs.release_prepare.result == 'success' && needs.release_metadata.outputs.channel == 'stable' }}
+      needs: [release_prepare, release_metadata]
       timeout-minutes: 30
       runs-on: ubuntu-22.04
       permissions: {}
       environment: npm-release
       steps:
          - name: Record release approval
-           run: echo "Release approved for ${{ github.ref }} via the npm-release environment gate"
+           run: echo "Stable release approved for ${{ github.ref }} via the npm-release environment gate"
 
    publish:
       # Minimal credential boundary: the only job holding contents: write and
@@ -651,7 +655,7 @@ jobs:
       #      maintainers. Do NOT scope this job to a GitHub environment
       #      without first re-registering every published package's trusted
       #      publisher for the environment-scoped OIDC subject.
-      if: ${{ needs.release_approval.result == 'success' }}
+      if: ${{ needs.release_prepare.result == 'success' && (needs.release_metadata.outputs.channel == 'nightly' || needs.release_approval.result == 'success') }}
       needs: [release_prepare, release_approval, release_metadata]
       timeout-minutes: 45
       runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -635,41 +635,35 @@ jobs:
            run: echo "Stable release approved for ${{ github.ref }} via the npm-release environment gate"
 
    publish:
-      # Minimal credential boundary: the only job holding contents: write and
-      # the OIDC identity token. All untrusted work (dependency installs,
-      # native builds, GitHub API reads, notes derivation) happened in
-      # release_prepare; this job consumes integrity-checked artifacts and
-      # performs only the irreversible steps. It deliberately runs NO
-      # repository-controlled installation, dependency cache, or package
-      # lifecycle scripts. The publish script and its
-      # release-evidence helper import only node/bun builtins, so a bare
-      # checkout of the tagged (trusted, main-ancestry-gated) revision
-      # suffices.
+      # Fixed publisher boundary: the ONLY job holding the OIDC identity
+      # token, and it holds nothing else — no contents scope, no checkout, no
+      # bun, no repository code. A malicious tagged revision cannot influence
+      # what executes here: the steps are pinned actions plus this workflow
+      # shell, and the payload is the sha512-sealed tarball set produced by
+      # release_prepare. Publication itself is `npm publish` from the exact,
+      # integrity-verified npm CLI against the sealed bytes only; the sealed
+      # sha512 is re-verified at this boundary before every publish, registry
+      # state is reconciled by integrity, and the per-package receipt feeds
+      # the finalize job's evidence.
       #
       # The OIDC subject stays ref-scoped (repo:...:ref:refs/tags/v*) — the
       # identity the npm trusted-publisher registrations and the shipped
       # v0.14.1 exchange already prove. Owner-controlled release
       # prerequisites that cannot be set from this repository (documented
       # blocker, verified absent at review time): a ruleset protecting
-      # `main`, and a tag ruleset for `refs/tags/v*` restricting creation to
-      #      maintainers. Do NOT scope this job to a GitHub environment
-      #      without first re-registering every published package's trusted
-      #      publisher for the environment-scoped OIDC subject.
+      # `main`, a tag ruleset for `refs/tags/v*` restricting creation to
+      # maintainers, and the npm-release environment on release_approval
+      # with required non-self reviewers and no admin bypass.
       if: ${{ needs.release_prepare.result == 'success' && (needs.release_metadata.outputs.channel == 'nightly' || needs.release_approval.result == 'success') }}
       needs: [release_prepare, release_approval, release_metadata]
       timeout-minutes: 45
       runs-on: ubuntu-22.04
       permissions:
-         contents: write
          # npm trusted publishing (OIDC): npm >= 11.5.1 exchanges this job's
          # GitHub OIDC token for a short-lived registry credential, so no
          # long-lived NPM_TOKEN is involved and nothing expires under us.
          id-token: write
       steps:
-         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-           with:
-              # The publish boundary never persists the workflow token.
-              persist-credentials: false
          - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
            with:
               # Exact patch pin: this job holds the OIDC identity token, so the
@@ -693,6 +687,105 @@ jobs:
               echo "$NPM_TARBALL_SHA512  $tmp/npm-${NPM_PIN_VERSION}.tgz" | sha512sum --check --strict -
               npm install -g "$tmp/npm-${NPM_PIN_VERSION}.tgz"
               test "$(npm --version)" = "$NPM_PIN_VERSION"
+         - name: Download pre-publication package evidence
+           uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+           with:
+              name: release-evidence-${{ needs.release_metadata.outputs.version }}
+              path: ${{ runner.temp }}/release-evidence
+         - name: Publish sealed tarballs to npm
+           env:
+              RELEASE_CHANNEL: ${{ needs.release_metadata.outputs.channel }}
+              RELEASE_VERSION: ${{ needs.release_metadata.outputs.version }}
+           shell: bash
+           run: |
+              set -euo pipefail
+              evidence_dir="$RUNNER_TEMP/release-evidence"
+              expected="$evidence_dir/gajae-release-packages-expected-v1.json"
+              registry="https://registry.npmjs.org/"
+              case "$RELEASE_CHANNEL" in
+                 stable) npm_tag=latest ;;
+                 nightly) npm_tag=nightly ;;
+                 *) echo "Unknown release channel $RELEASE_CHANNEL" >&2; exit 1 ;;
+              esac
+              records="$RUNNER_TEMP/receipt-records.json"
+              echo '[]' > "$records"
+              count="$(jq '.packages | length' "$expected")"
+              for index in $(seq 0 $((count - 1))); do
+                 record="$(jq -c ".packages[$index]" "$expected")"
+                 name="$(jq -r '.name' <<<"$record")"
+                 version="$(jq -r '.version' <<<"$record")"
+                 sha="$(jq -r '.tarball_sha512' <<<"$record")"
+                 expected_sri="$(jq -r '.expected_sri' <<<"$record")"
+                 tarball="$evidence_dir/tarballs/$sha.tgz"
+                 # Re-verify the sealed bytes at the credential boundary.
+                 echo "$sha  $tarball" | sha512sum --check --strict -
+                 published=false
+                 observed="$(npm view "${name}@${version}" dist.integrity --registry="$registry" 2>/dev/null || true)"
+                 if [ "$observed" = "$expected_sri" ]; then
+                    echo "Skipping $name@$version (registry already carries the sealed bytes)"
+                 else
+                    if ! output="$(npm publish "$tarball" --access public --registry="$registry" --tag="$npm_tag" 2>&1)"; then
+                       raced="$(npm view "${name}@${version}" dist.integrity --registry="$registry" 2>/dev/null || true)"
+                       if [ "$raced" != "$expected_sri" ]; then
+                          echo "npm publish failed for $name@$version: $output" >&2
+                          exit 1
+                       fi
+                       echo "Skipping $name@$version (concurrent exact publication)"
+                    else
+                       published=true
+                       echo "Published $name@$version"
+                    fi
+                    # npm is read-after-write eventually consistent: re-observe
+                    # with bounded backoff until the sealed integrity is visible.
+                    attempt=0
+                    while :; do
+                       attempt=$((attempt + 1))
+                       observed="$(npm view "${name}@${version}" dist.integrity --registry="$registry" 2>/dev/null || true)"
+                       [ "$observed" = "$expected_sri" ] && break
+                       if [ "$attempt" -ge 12 ]; then
+                          echo "$name@$version did not become visible with the sealed integrity" >&2
+                          exit 1
+                       fi
+                       sleep 5
+                    done
+                 fi
+                 tagged="$(npm view "${name}@${npm_tag}" version --registry="$registry" 2>/dev/null || true)"
+                 if [ "$tagged" != "$version" ]; then
+                    echo "npm tag $npm_tag for $name resolves $tagged, expected $version" >&2
+                    exit 1
+                 fi
+                 jq --arg name "$name" --arg version "$version" --arg sha "$sha" --arg sri "$observed" --argjson published "$published" \
+                    '. += [{name:$name, version:$version, tarball_sha512:$sha, registry_integrity:$sri, published:$published}]' \
+                    "$records" > "$records.tmp"
+                 mv "$records.tmp" "$records"
+              done
+              jq -n --arg version "$RELEASE_VERSION" --arg channel "$RELEASE_CHANNEL" --slurpfile packages "$records" \
+                 '{schema_version: 1, release_version: $version, release_channel: $channel, packages: $packages[0]}' \
+                 > "$evidence_dir/gajae-release-oidc-publish-receipt-v1.json"
+         - name: Persist OIDC publish receipt
+           uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+           with:
+              name: release-publish-receipt-${{ needs.release_metadata.outputs.version }}
+              path: ${{ runner.temp }}/release-evidence/gajae-release-oidc-publish-receipt-v1.json
+              if-no-files-found: error
+              retention-days: 30
+              overwrite: true
+
+   release_finalize:
+      # Repository-write boundary WITHOUT the OIDC token: assembles the final
+      # release evidence from the fixed publisher's receipt, creates the
+      # GitHub Release, and verifies it. Repository code may execute here
+      # because no npm credential capability exists in this job.
+      if: ${{ needs.publish.result == 'success' }}
+      needs: [publish, release_metadata]
+      timeout-minutes: 45
+      runs-on: ubuntu-22.04
+      permissions:
+         contents: write
+      steps:
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+           with:
+              persist-credentials: false
          - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
            with:
               bun-version: "1.3.14"
@@ -700,6 +793,11 @@ jobs:
            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
            with:
               name: release-evidence-${{ needs.release_metadata.outputs.version }}
+              path: ${{ runner.temp }}/release-evidence
+         - name: Download OIDC publish receipt
+           uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+           with:
+              name: release-publish-receipt-${{ needs.release_metadata.outputs.version }}
               path: ${{ runner.temp }}/release-evidence
          - name: Download validated release notes
            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
@@ -712,24 +810,14 @@ jobs:
               set -euo pipefail
               cd "$RUNNER_TEMP/release-notes"
               sha256sum --check --strict release-notes.sha256
-         - name: Publish packages to npm
+         - name: Assemble final release evidence
            env:
               RELEASE_CHANNEL: ${{ needs.release_metadata.outputs.channel }}
            shell: bash
            run: |
               set -euo pipefail
-              evidence_dir="$RUNNER_TEMP/release-evidence"
-              if [ "$RELEASE_CHANNEL" = nightly ]; then
-                 serialization_key=gajae-nightly-release
-              else
-                 serialization_key=gajae-production-release
-              fi
-              # Deliberately no registry credential in scope: any stale one
-              # would take precedence over OIDC and fail closed with a registry
-              # 404 that reads like a missing package.
-              bun scripts/ci-release-publish.ts --publish-from-evidence \
-                 --evidence-dir "$evidence_dir" \
-                 --release-serialization-key "$serialization_key" \
+              bun scripts/ci-release-publish.ts --finalize-evidence \
+                 --evidence-dir "$RUNNER_TEMP/release-evidence" \
                  --release-channel "$RELEASE_CHANNEL"
          - name: Download release binaries
            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,6 +548,36 @@ jobs:
               pattern: gjc-binary-*
               path: release-binaries
               merge-multiple: true
+         - name: Derive release notes
+           # A curated release is assembled by cherry-picking onto main, so
+           # generate_release_notes has no merged pull requests to describe and
+           # emits a body containing only a compare link (v0.14.1 shipped that).
+           # Deriving from the range credits the pull requests that actually
+           # shipped, and refuses to credit ones this release excluded.
+           env:
+              GH_TOKEN: ${{ github.token }}
+              TAG_NAME: ${{ needs.release_metadata.outputs.tag_name }}
+           shell: bash
+           run: |
+              set -euo pipefail
+              # The publish checkout is shallow and tagless, so neither the tag
+              # list nor the commit range exists until history is fetched.
+              git fetch --quiet --tags --prune --unshallow || git fetch --quiet --tags --prune
+              notes="$RUNNER_TEMP/release-notes.md"
+              previous="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname \
+                 | grep -vFx "$TAG_NAME" | head -1)"
+              if [ -z "$previous" ]; then
+                 echo "No previous stable tag to compare against; leaving notes empty" >&2
+                 : > "$notes"
+              else
+                 bun scripts/release-notes.ts \
+                    --repo "$GITHUB_REPOSITORY" \
+                    --base "$previous" \
+                    --head "$GITHUB_SHA" \
+                    --head-tag "$TAG_NAME" \
+                    --out "$notes"
+              fi
+              echo "RELEASE_NOTES_PATH=$notes" >> "$GITHUB_ENV"
          - name: Create GitHub Release
            uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
            with:
@@ -557,7 +587,8 @@ jobs:
               draft: false
               prerelease: ${{ needs.release_metadata.outputs.channel == 'nightly' }}
               make_latest: ${{ needs.release_metadata.outputs.channel != 'nightly' }}
-              generate_release_notes: true
+              body_path: ${{ env.RELEASE_NOTES_PATH }}
+              generate_release_notes: false
               fail_on_unmatched_files: true
               files: |
                  release-binaries/gjc-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -611,10 +611,25 @@ jobs:
 
    publish:
       # Minimal credential boundary: the only job holding contents: write and
-      # the OIDC identity token. All preparation (dependency installs behind
-      # native builds, repository scripts, GitHub API reads, notes derivation)
-      # happened in release_prepare; this job consumes its integrity-checked
-      # artifacts and performs only the irreversible steps.
+      # the OIDC identity token. All untrusted work (dependency installs,
+      # native builds, GitHub API reads, notes derivation) happened in
+      # release_prepare; this job consumes integrity-checked artifacts and
+      # performs only the irreversible steps. It deliberately runs NO
+      # repository-controlled installation, dependency cache, or package
+      # lifecycle scripts. The publish script and its
+      # release-evidence helper import only node/bun builtins, so a bare
+      # checkout of the tagged (trusted, main-ancestry-gated) revision
+      # suffices.
+      #
+      # The OIDC subject stays ref-scoped (repo:...:ref:refs/tags/v*) — the
+      # identity the npm trusted-publisher registrations and the shipped
+      # v0.14.1 exchange already prove. Owner-controlled release
+      # prerequisites that cannot be set from this repository (documented
+      # blocker, verified absent at review time): a ruleset protecting
+      # `main`, and a tag ruleset for `refs/tags/v*` restricting creation to
+      #      maintainers. Do NOT scope this job to a GitHub environment
+      #      without first re-registering every published package's trusted
+      #      publisher for the environment-scoped OIDC subject.
       if: ${{ needs.release_prepare.result == 'success' }}
       needs: [release_prepare, release_metadata]
       timeout-minutes: 45
@@ -625,19 +640,11 @@ jobs:
          # GitHub OIDC token for a short-lived registry credential, so no
          # long-lived NPM_TOKEN is involved and nothing expires under us.
          id-token: write
-      # Owner-controlled trust boundary (workflow half): this job only runs
-      # under the npm-release environment, whose protection rules live in the
-      # repository settings and are NOT evaluated from the tagged revision.
-      # To close the tag-creation bypass the owner must configure:
-      #   1. a ruleset protecting `main` (require pull request + checks),
-      #   2. a tag ruleset for `refs/tags/v*` restricting creation to
-      #      maintainers,
-      #   3. environment `npm-release` with required reviewers and deployment
-      #      refs restricted to protected branches plus the v* tag pattern.
-      # Until those exist this environment reference is only a gate hook.
-      environment: npm-release
       steps:
          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+           with:
+              # The publish boundary never persists the workflow token.
+              persist-credentials: false
          - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
            with:
               # Exact patch pin: this job holds the OIDC identity token, so the
@@ -664,12 +671,6 @@ jobs:
          - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
            with:
               bun-version: "1.3.14"
-         - name: Cache bun dependencies
-           uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
-           with:
-              path: ~/.bun/install/cache
-              key: bun-1.3.14-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
-         - run: bun install --frozen-lockfile
          - name: Download pre-publication package evidence
            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
            with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,28 @@ jobs:
                     echo "tag_name="
                  } >> "$GITHUB_OUTPUT"
               fi
+         - name: Validate stable tag protected-main provenance
+           if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+           env:
+              SOURCE_SHA: ${{ github.sha }}
+           shell: bash
+           run: |
+              set -euo pipefail
+              # A stable tag workflow is evaluated from the tagged revision and
+              # later grants repository write plus the OIDC identity token, so
+              # the tagged commit must provably come from the protected main
+              # line: fetch
+              # the live default branch from origin and require ancestry.
+              # This check alone cannot stop an actor allowed to create tags
+              # from pointing one at a side-branch commit with modified
+              # workflow YAML; closing that half requires the owner-controlled
+              # repository settings documented on the publish job below.
+              git fetch --quiet --tags --prune --unshallow origin +refs/heads/main:refs/remotes/origin/main \
+                 || git fetch --quiet --tags --prune origin +refs/heads/main:refs/remotes/origin/main
+              if ! git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main; then
+                 echo "Stable release tag $GITHUB_REF_NAME resolves to $SOURCE_SHA, which is not an ancestor of origin/main; refusing release" >&2
+                 exit 1
+              fi
    # ---------------------------------------------------------------------------
    # PR + main branch: lint/typecheck (native-free) and the test suite.
    # These never run on tags — a tag is cut from an already-green main.
@@ -603,11 +625,24 @@ jobs:
          # GitHub OIDC token for a short-lived registry credential, so no
          # long-lived NPM_TOKEN is involved and nothing expires under us.
          id-token: write
+      # Owner-controlled trust boundary (workflow half): this job only runs
+      # under the npm-release environment, whose protection rules live in the
+      # repository settings and are NOT evaluated from the tagged revision.
+      # To close the tag-creation bypass the owner must configure:
+      #   1. a ruleset protecting `main` (require pull request + checks),
+      #   2. a tag ruleset for `refs/tags/v*` restricting creation to
+      #      maintainers,
+      #   3. environment `npm-release` with required reviewers and deployment
+      #      refs restricted to protected branches plus the v* tag pattern.
+      # Until those exist this environment reference is only a gate hook.
+      environment: npm-release
       steps:
          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
          - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
            with:
-              node-version: "24"
+              # Exact patch pin: this job holds the OIDC identity token, so the
+              # bootstrap runtime must not float across Node releases.
+              node-version: "24.19.0"
          - name: Pin npm for OIDC trusted publishing
            # Trusted publishing requires npm >= 11.5.1; do not rely on whatever
            # npm the Node distribution happens to bundle. The pin is exact and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,26 +437,24 @@ jobs:
               name: gjc-binary-${{ matrix.target_id }}
               path: ${{ matrix.binary_path }}
 
-   publish:
+   release_prepare:
       if: ${{ always() && needs.native.result == 'success' && needs.binaries.result == 'success' && ((needs.release_metadata.outputs.channel == 'stable' && startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch') || (needs.release_metadata.outputs.channel == 'nightly' && needs.nightly_gate.result == 'success')) }}
       needs: [native, binaries, release_metadata, nightly_gate]
       timeout-minutes: 45
       runs-on: ubuntu-22.04
       permissions:
-         contents: write
-         # npm trusted publishing (OIDC): npm >= 11.5.1 exchanges this job's
-         # GitHub OIDC token for a short-lived registry credential, so no
-         # long-lived NPM_TOKEN is involved and nothing expires under us.
-         id-token: write
+         contents: read
+         # Release-note attribution enumerates the pull requests behind each
+         # shipped commit. This job holds no write scope and no OIDC identity
+         # token: everything untrusted (dependency installs, repository
+         # scripts, GitHub API reads) happens here, before any credential that
+         # can publish exists.
+         pull-requests: read
       steps:
          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-         - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
            with:
-              node-version: "24"
-         - name: Pin npm for OIDC trusted publishing
-           # Trusted publishing requires npm >= 11.5.1; do not rely on whatever
-           # npm the Node distribution happens to bundle.
-           run: npm install -g npm@^11.5.1
+              # Release notes need the full history and the tag list.
+              fetch-depth: 0
          - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
            with:
               bun-version: "1.4.0"
@@ -523,6 +521,136 @@ jobs:
                  200) echo "Release $TAG_NAME already exists; refusing upsert" >&2; exit 1 ;;
                  *) echo "Cannot verify release absence: GitHub API returned HTTP $status" >&2; exit 1 ;;
               esac
+         - name: Derive and validate release notes
+           # A curated release is assembled by cherry-picking onto main, so
+           # generate_release_notes has no merged pull requests to describe and
+           # emits a body containing only a compare link (v0.14.1 shipped that).
+           # The body is resolved and validated HERE, in the credential-free
+           # preparation job, before the publish job performs the irreversible
+           # npm publication: a fetch, API, parse, or generation failure aborts
+           # the run while nothing immutable has shipped yet.
+           env:
+              GH_TOKEN: ${{ github.token }}
+              TAG_NAME: ${{ needs.release_metadata.outputs.tag_name }}
+              SOURCE_SHA: ${{ github.sha }}
+           shell: bash
+           run: |
+              set -euo pipefail
+              git fetch --quiet --tags --prune
+              notes_dir="$RUNNER_TEMP/release-notes"
+              mkdir -p "$notes_dir"
+              notes="$notes_dir/release-notes.md"
+              # Only exact stable vX.Y.Z tags that are ancestors of this release
+              # head may anchor the range; nightly/RC or unrelated-branch tags
+              # would derive notes from the wrong base. The loop is pipe-free so
+              # a no-candidate outcome reaches the documented empty-notes
+              # fallback instead of aborting under pipefail.
+              previous=""
+              while IFS= read -r tag; do
+                 [ "$tag" = "$TAG_NAME" ] && continue
+                 [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || continue
+                 if git merge-base --is-ancestor "$tag" "$SOURCE_SHA"; then
+                    previous="$tag"
+                    break
+                 fi
+              done < <(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname)
+              if [ -z "$previous" ]; then
+                 echo "No previous stable tag to compare against; leaving notes empty" >&2
+                 : > "$notes"
+              else
+                 bun scripts/release-notes.ts \
+                    --repo "$GITHUB_REPOSITORY" \
+                    --base "$previous" \
+                    --head "$SOURCE_SHA" \
+                    --head-tag "$TAG_NAME" \
+                    --out "$notes"
+                 # The release cannot be redone once packages are immutable, so
+                 # the persisted body must be deterministic: a second derivation
+                 # has to reproduce it byte-for-byte.
+                 repeat="$notes_dir/release-notes-repeat.md"
+                 bun scripts/release-notes.ts \
+                    --repo "$GITHUB_REPOSITORY" \
+                    --base "$previous" \
+                    --head "$SOURCE_SHA" \
+                    --head-tag "$TAG_NAME" \
+                    --out "$repeat"
+                 cmp --silent "$notes" "$repeat" || { echo "Release notes derivation is not deterministic" >&2; exit 1; }
+                 rm -f "$repeat"
+              fi
+              (cd "$notes_dir" && sha256sum release-notes.md > release-notes.sha256)
+         - name: Persist validated release notes
+           uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+           with:
+              name: release-notes-${{ needs.release_metadata.outputs.version }}
+              path: ${{ runner.temp }}/release-notes
+              if-no-files-found: error
+              retention-days: 30
+              overwrite: true
+
+   publish:
+      # Minimal credential boundary: the only job holding contents: write and
+      # the OIDC identity token. All preparation (dependency installs behind
+      # native builds, repository scripts, GitHub API reads, notes derivation)
+      # happened in release_prepare; this job consumes its integrity-checked
+      # artifacts and performs only the irreversible steps.
+      if: ${{ needs.release_prepare.result == 'success' }}
+      needs: [release_prepare, release_metadata]
+      timeout-minutes: 45
+      runs-on: ubuntu-22.04
+      permissions:
+         contents: write
+         # npm trusted publishing (OIDC): npm >= 11.5.1 exchanges this job's
+         # GitHub OIDC token for a short-lived registry credential, so no
+         # long-lived NPM_TOKEN is involved and nothing expires under us.
+         id-token: write
+      steps:
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+         - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+           with:
+              node-version: "24"
+         - name: Pin npm for OIDC trusted publishing
+           # Trusted publishing requires npm >= 11.5.1; do not rely on whatever
+           # npm the Node distribution happens to bundle. The pin is exact and
+           # integrity-verifiable: a mutable range inside this credential-
+           # bearing job would let a drifting or compromised CLI publish.
+           env:
+              NPM_PIN_VERSION: "11.5.1"
+              # sha512 of https://registry.npmjs.org/npm/-/npm-11.5.1.tgz
+              # (matches the registry dist.integrity for npm@11.5.1).
+              NPM_TARBALL_SHA512: "232e6f5d9e799bcb486920b3e9ba907fdf96e576cf7e8c9446c8162e33a416096a1d37a9e910d9a918f6b1f606791c99bc6bb61ee2569b496ec74af13d0dbd95"
+           shell: bash
+           run: |
+              set -euo pipefail
+              tmp="$(mktemp -d "$RUNNER_TEMP/npm-pin.XXXXXX")"
+              npm pack "npm@${NPM_PIN_VERSION}" --pack-destination "$tmp"
+              echo "$NPM_TARBALL_SHA512  $tmp/npm-${NPM_PIN_VERSION}.tgz" | sha512sum --check --strict -
+              npm install -g "$tmp/npm-${NPM_PIN_VERSION}.tgz"
+              test "$(npm --version)" = "$NPM_PIN_VERSION"
+         - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+           with:
+              bun-version: "1.3.14"
+         - name: Cache bun dependencies
+           uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+           with:
+              path: ~/.bun/install/cache
+              key: bun-1.3.14-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
+         - run: bun install --frozen-lockfile
+         - name: Download pre-publication package evidence
+           uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+           with:
+              name: release-evidence-${{ needs.release_metadata.outputs.version }}
+              path: ${{ runner.temp }}/release-evidence
+         - name: Download validated release notes
+           uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+           with:
+              name: release-notes-${{ needs.release_metadata.outputs.version }}
+              path: ${{ runner.temp }}/release-notes
+         - name: Verify release notes integrity
+           shell: bash
+           run: |
+              set -euo pipefail
+              cd "$RUNNER_TEMP/release-notes"
+              sha256sum --check --strict release-notes.sha256
          - name: Publish packages to npm
            env:
               RELEASE_CHANNEL: ${{ needs.release_metadata.outputs.channel }}
@@ -548,36 +676,6 @@ jobs:
               pattern: gjc-binary-*
               path: release-binaries
               merge-multiple: true
-         - name: Derive release notes
-           # A curated release is assembled by cherry-picking onto main, so
-           # generate_release_notes has no merged pull requests to describe and
-           # emits a body containing only a compare link (v0.14.1 shipped that).
-           # Deriving from the range credits the pull requests that actually
-           # shipped, and refuses to credit ones this release excluded.
-           env:
-              GH_TOKEN: ${{ github.token }}
-              TAG_NAME: ${{ needs.release_metadata.outputs.tag_name }}
-           shell: bash
-           run: |
-              set -euo pipefail
-              # The publish checkout is shallow and tagless, so neither the tag
-              # list nor the commit range exists until history is fetched.
-              git fetch --quiet --tags --prune --unshallow || git fetch --quiet --tags --prune
-              notes="$RUNNER_TEMP/release-notes.md"
-              previous="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname \
-                 | grep -vFx "$TAG_NAME" | head -1)"
-              if [ -z "$previous" ]; then
-                 echo "No previous stable tag to compare against; leaving notes empty" >&2
-                 : > "$notes"
-              else
-                 bun scripts/release-notes.ts \
-                    --repo "$GITHUB_REPOSITORY" \
-                    --base "$previous" \
-                    --head "$GITHUB_SHA" \
-                    --head-tag "$TAG_NAME" \
-                    --out "$notes"
-              fi
-              echo "RELEASE_NOTES_PATH=$notes" >> "$GITHUB_ENV"
          - name: Create GitHub Release
            uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
            with:
@@ -587,7 +685,7 @@ jobs:
               draft: false
               prerelease: ${{ needs.release_metadata.outputs.channel == 'nightly' }}
               make_latest: ${{ needs.release_metadata.outputs.channel != 'nightly' }}
-              body_path: ${{ env.RELEASE_NOTES_PATH }}
+              body_path: ${{ runner.temp }}/release-notes/release-notes.md
               generate_release_notes: false
               fail_on_unmatched_files: true
               files: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -709,10 +709,19 @@ jobs:
               esac
               records="$RUNNER_TEMP/receipt-records.json"
               echo '[]' > "$records"
-              count="$(jq '.packages | length' "$expected")"
-              for index in $(seq 0 $((count - 1))); do
-                 record="$(jq -c ".packages[$index]" "$expected")"
-                 name="$(jq -r '.name' <<<"$record")"
+              order_file="$evidence_dir/gajae-release-publish-order-v1.json"
+              # The sealed plan publishes dependencies before dependents; it
+              # must cover exactly the expected package set.
+              if [ "$(jq -r '.order[]' "$order_file" | sort)" != "$(jq -r '.packages[].name' "$expected" | sort)" ]; then
+                 echo "Publish order file does not cover exactly the expected package set" >&2
+                 exit 1
+              fi
+              for name in $(jq -r '.order[]' "$order_file"); do
+                 record="$(jq -c --arg name "$name" '.packages[] | select(.name == $name)' "$expected")"
+                 if [ -z "$record" ]; then
+                    echo "Publish order references unknown package $name" >&2
+                    exit 1
+                 fi
                  version="$(jq -r '.version' <<<"$record")"
                  sha="$(jq -r '.tarball_sha512' <<<"$record")"
                  expected_sri="$(jq -r '.expected_sri' <<<"$record")"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -609,6 +609,27 @@ jobs:
               retention-days: 30
               overwrite: true
 
+   release_approval:
+      # Approval gate BEFORE the credential boundary. The environment's
+      # protection rules (required reviewers, restricted deployment refs) are
+      # owner-controlled repository settings and are NOT evaluated from the
+      # tagged revision. This job holds no permissions and no OIDC token, so
+      # placing the environment HERE — not on publish — keeps the publish
+      # job's OIDC subject ref-scoped (repo:...:ref:refs/tags/v*), the
+      # identity the npm trusted-publisher registrations and the shipped
+      # v0.14.1 exchange already prove. Owner prerequisite (documented
+      # blocker, verified absent at review time): configure the npm-release
+      # environment with required reviewers; until then this gate is a hook.
+      if: ${{ needs.release_prepare.result == 'success' }}
+      needs: [release_prepare]
+      timeout-minutes: 30
+      runs-on: ubuntu-22.04
+      permissions: {}
+      environment: npm-release
+      steps:
+         - name: Record release approval
+           run: echo "Release approved for ${{ github.ref }} via the npm-release environment gate"
+
    publish:
       # Minimal credential boundary: the only job holding contents: write and
       # the OIDC identity token. All untrusted work (dependency installs,
@@ -630,8 +651,8 @@ jobs:
       #      maintainers. Do NOT scope this job to a GitHub environment
       #      without first re-registering every published package's trusted
       #      publisher for the environment-scoped OIDC subject.
-      if: ${{ needs.release_prepare.result == 'success' }}
-      needs: [release_prepare, release_metadata]
+      if: ${{ needs.release_approval.result == 'success' }}
+      needs: [release_prepare, release_approval, release_metadata]
       timeout-minutes: 45
       runs-on: ubuntu-22.04
       permissions:

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "clean:native": "bun scripts/clean.ts --native",
     "test": "bun run --parallel test:ts test:rs",
     "test:ts": "bun run test:release && bun run --workspaces --if-present test",
-    "test:release": "bun test scripts/clean.test.ts scripts/generate-gjc-sdk-skills.test.ts scripts/nightly-release.test.ts scripts/release-evidence.test.ts scripts/release-policy.test.ts scripts/release-publish-order.test.ts scripts/restart-sdk-broker.test.ts",
+    "test:release": "bun test scripts/clean.test.ts scripts/generate-gjc-sdk-skills.test.ts scripts/nightly-release.test.ts scripts/release-evidence.test.ts scripts/release-notes.test.ts scripts/release-policy.test.ts scripts/release-publish-order.test.ts scripts/release-retry.test.ts scripts/restart-sdk-broker.test.ts",
     "generate-schemas": "bun scripts/generate-json-schemas.ts",
     "check:schemas": "bun scripts/generate-json-schemas.ts --check",
     "check:public-sync": "bun run generate-docs-index && bun scripts/check-public-version-sync.ts",

--- a/scripts/check-node20-baseline.test.ts
+++ b/scripts/check-node20-baseline.test.ts
@@ -208,6 +208,44 @@ jobs:
 		expect(violations).toEqual([]);
 	});
 
+	test("accepts an intentionally pinned exact Node 24 patch for credential-bearing release jobs", async () => {
+		const root = await createRepo({
+			".github/workflows/ci.yml": `name: CI
+jobs:
+  publish:
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24.19.0"
+      - run: bun run ci:release:publish
+`,
+		});
+
+		const violations = await checkNode20Baseline(root);
+
+		expect(violations).toEqual([]);
+	});
+
+	test("still rejects floating ranges and non-exact Node pins on release jobs", async () => {
+		for (const version of ["24.x", "24.19", "^24.19.0", "~24.19.0", "25.0.0", "20"]) {
+			const root = await createRepo({
+				".github/workflows/ci.yml": `name: CI
+jobs:
+  publish:
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "${version}"
+      - run: bun run ci:release:publish
+`,
+			});
+
+			const violations = await checkNode20Baseline(root);
+
+			expect(violations, `node-version "${version}" must stay a violation`).not.toEqual([]);
+		}
+	});
+
 	test("allows released changelog history and historical fixtures", async () => {
 		const root = await createRepo({
 			"packages/ai/CHANGELOG.md": `# Changelog

--- a/scripts/check-node20-baseline.ts
+++ b/scripts/check-node20-baseline.ts
@@ -193,12 +193,18 @@ function setupNodeStepViolations(relativePath: string, job: WorkflowJob): Baseli
 		}
 
 		const nodeVersion = setupNodeVersion(stepLines, stepIndent);
-		if (nodeVersion === "24") continue;
+		// Repository policy: release-capable jobs pin the Node 24 line. The bare
+		// "24" pin satisfies the baseline; an intentionally pinned exact
+		// 24.<minor>.<patch> is also accepted for credential-bearing release
+		// jobs (e.g. the OIDC publish job), where a floating bootstrap runtime
+		// inside the id-token boundary is a security regression, not hygiene.
+		// Ranges, other majors, and omitted versions stay violations.
+		if (nodeVersion === "24" || /^24\.\d+\.\d+$/u.test(nodeVersion ?? "")) continue;
 
 		violations.push({
 			path: relativePath,
 			line: job.startLine + index,
-			message: `Release-capable job '${job.name}' uses actions/setup-node but does not pin node-version: "24".`,
+			message: `Release-capable job '${job.name}' uses actions/setup-node but does not pin node-version: "24" (or an exact 24.x.y patch for credential-bearing jobs).`,
 			snippet: line.trim(),
 		});
 	}

--- a/scripts/check-workflow-permissions.test.ts
+++ b/scripts/check-workflow-permissions.test.ts
@@ -43,7 +43,7 @@ describe("workflow permission policy", () => {
 		]);
 	});
 
-	test("ci.yml has an exact read-scoped workflow default and one write job", async () => {
+	test("ci.yml has an exact read-scoped workflow default and two write jobs", async () => {
 		const workflows = await readWorkflowDocuments();
 		const ci = workflows.find(workflow => workflow.file === CI_WORKFLOW);
 		expect(ci).toBeDefined();
@@ -51,15 +51,17 @@ describe("workflow permission policy", () => {
 
 		expect(REQUIRED_READ_DEFAULT).toContain(CI_WORKFLOW);
 		expect(document.permissions).toEqual({ contents: "read" });
-		// publish is the only job allowed to escalate: contents for the GitHub
-		// Release, and id-token for npm trusted publishing (OIDC), which is what
-		// keeps a long-lived registry credential out of the release path.
+		// Exactly two jobs may escalate, with disjoint capabilities:
+		// release_finalize holds contents for the GitHub Release (no OIDC), and
+		// publish holds id-token for npm trusted publishing (no repository
+		// scope) — which keeps a long-lived registry credential out of the
+		// release path.
 		expect(JOB_WRITE_ALLOWLIST).toEqual([
-			{ workflow: CI_WORKFLOW, job: "publish", scope: "contents" },
+			{ workflow: CI_WORKFLOW, job: "release_finalize", scope: "contents" },
 			{ workflow: CI_WORKFLOW, job: "publish", scope: "id-token" },
 			{ workflow: PR_VALIDATION_WORKFLOW, job: "validate", scope: "checks" },
 		]);
-		expect(jobWriteScopes(document)).toEqual(["publish.contents", "publish.id-token"]);
+		expect(jobWriteScopes(document)).toEqual(["release_finalize.contents", "publish.id-token"]);
 	});
 
 	test("dev-ci.yml has an exact read-scoped workflow default and no write job scope", async () => {
@@ -125,7 +127,7 @@ describe("workflow permission policy", () => {
 		expect(violation.message).toContain(CI_WORKFLOW);
 		expect(violation.message).toContain("check");
 		expect(violation.message).toContain("jobs.check.permissions.contents");
-		expect(violation.message).toContain('only job "publish"');
+		expect(violation.message).toContain('only jobs "release_finalize"');
 	});
 
 	test("detects a ci.yml check job write-all mutation", async () => {

--- a/scripts/check-workflow-permissions.test.ts
+++ b/scripts/check-workflow-permissions.test.ts
@@ -61,7 +61,7 @@ describe("workflow permission policy", () => {
 			{ workflow: CI_WORKFLOW, job: "publish", scope: "id-token" },
 			{ workflow: PR_VALIDATION_WORKFLOW, job: "validate", scope: "checks" },
 		]);
-		expect(jobWriteScopes(document)).toEqual(["release_finalize.contents", "publish.id-token"]);
+		expect(jobWriteScopes(document)).toEqual(["publish.id-token", "release_finalize.contents"]);
 	});
 
 	test("dev-ci.yml has an exact read-scoped workflow default and no write job scope", async () => {

--- a/scripts/check-workflow-permissions.ts
+++ b/scripts/check-workflow-permissions.ts
@@ -21,7 +21,8 @@ export interface WorkflowInput {
 }
 
 export const JOB_WRITE_ALLOWLIST: readonly { workflow: string; job: string; scope: string }[] = [
-	{ workflow: ".github/workflows/ci.yml", job: "publish", scope: "contents" },
+	// GitHub Release finalization writes the release; it holds no OIDC token.
+	{ workflow: ".github/workflows/ci.yml", job: "release_finalize", scope: "contents" },
 	// npm trusted publishing (OIDC) needs a GitHub identity token to mint a
 	// short-lived registry credential. It grants nothing in this repository, and
 	// it is what removes the long-lived NPM_TOKEN from the release path.
@@ -48,7 +49,7 @@ const EXPECTED_WORKFLOW_DEFAULT = "an explicit least-privilege permissions block
 const EXPECTED_SCOPE_VALUE = '"read", "write", or "none"';
 const EXPECTED_NON_WRITE_SCOPE = '"read" or "none"';
 const EXPECTED_PERMISSION_VALUE = '"read-all" or a permissions mapping';
-const JOB_WRITE_ALLOWLIST_NOTE = 'only job "publish" in .github/workflows/ci.yml may hold contents: write or id-token: write';
+const JOB_WRITE_ALLOWLIST_NOTE = 'only jobs "release_finalize" (contents: write) and "publish" (id-token: write) in .github/workflows/ci.yml may hold write scopes';
 
 type RecordValue = Record<string, unknown>;
 

--- a/scripts/ci-release-publish.ts
+++ b/scripts/ci-release-publish.ts
@@ -1187,8 +1187,12 @@ async function main(): Promise<void> {
 		await dryRun();
 		return;
 	}
-	await checkTypeDeclarations();
 	if (command.mode === "prepare-evidence") {
+		// Declaration checks (`bun x tsc`) resolve and execute packages, so they
+		// belong in the credential-free preparation job. The publish job runs
+		// with contents: write + id-token: write and no dependency install, so
+		// dependency resolution must never re-enter that boundary.
+		await checkTypeDeclarations();
 		await prepareExpectedEvidence(command.evidenceDir, command.releaseChannel);
 		return;
 	}

--- a/scripts/ci-release-publish.ts
+++ b/scripts/ci-release-publish.ts
@@ -612,6 +612,13 @@ async function prepareExpectedEvidence(evidenceDirectory: string, releaseChannel
 		path.join(evidenceDirectory, CHANNEL_BEFORE_EVIDENCE_FILE),
 		canonicalJsonBytes({ schema_version: 1, snapshot: protectedBefore }),
 	);
+	// The fixed publish boundary iterates the sealed plan, so dependency order
+	// (e.g. @gajae-code/ai before @gajae-code/agent-core) must be computed here.
+	const publicationOrder = planExpectedEvidencePublication(expected.packages).map(record => record.name);
+	await writeImmutableBytes(
+		path.join(evidenceDirectory, PUBLISH_ORDER_FILE),
+		canonicalJsonBytes({ schema_version: 1, order: publicationOrder }),
+	);
 	console.log(JSON.stringify({
 		ok: true,
 		phase: "expected-evidence",
@@ -626,6 +633,8 @@ function isMissingRegistryPackage(output: string): boolean {
 	return /\bE404\b|404 Not Found|is not in this registry/iu.test(output);
 }
 export const CHANNEL_BEFORE_EVIDENCE_FILE = "gajae-release-channel-before-v1.json";
+/** Dependency-ordered publication plan sealed by release_prepare; the fixed boundary publishes in exactly this order. */
+export const PUBLISH_ORDER_FILE = "gajae-release-publish-order-v1.json";
 /** Written by the fixed (no-repo-code) OIDC publish boundary; finalize requires it. */
 export const PUBLISH_RECEIPT_FILE = "gajae-release-oidc-publish-receipt-v1.json";
 

--- a/scripts/ci-release-publish.ts
+++ b/scripts/ci-release-publish.ts
@@ -126,6 +126,7 @@ export type ReleasePublishCli =
 	| { mode: "check-types" }
 	| { mode: "dry-run" }
 	| { mode: "prepare-evidence"; evidenceDir: string; releaseChannel: ReleaseChannel }
+	| { mode: "finalize-evidence"; evidenceDir: string; releaseChannel: ReleaseChannel }
 	| { mode: "publish-from-evidence"; evidenceDir: string; releaseSerializationKey: string; releaseChannel: ReleaseChannel };
 
 function extractReleaseChannel(argv: readonly string[]): { releaseChannel: ReleaseChannel; remaining: string[] } {
@@ -180,8 +181,12 @@ export function parseReleasePublishCli(argv: readonly string[]): ReleasePublishC
 			const { releaseChannel, remaining } = extractReleaseChannel(argumentsForMode);
 			return { mode: "publish-from-evidence", ...parsePublishEvidenceOptions(remaining), releaseChannel };
 		}
+		case "--finalize-evidence": {
+			const { releaseChannel, remaining } = extractReleaseChannel(argumentsForMode);
+			return { mode: "finalize-evidence", evidenceDir: parseEvidenceDirectory(mode, remaining), releaseChannel };
+		}
 		default:
-			throw new Error("Use exactly one mode: --evidence-self-test, --check-types, --dry-run, --prepare-evidence --evidence-dir <directory> [--release-channel stable|nightly], or --publish-from-evidence --evidence-dir <directory> --release-serialization-key <shared-cross-version-key> [--release-channel stable|nightly]");
+			throw new Error("Use exactly one mode: --evidence-self-test, --check-types, --dry-run, --prepare-evidence --evidence-dir <directory> [--release-channel stable|nightly], --finalize-evidence --evidence-dir <directory> [--release-channel stable|nightly], or --publish-from-evidence --evidence-dir <directory> --release-serialization-key <shared-cross-version-key> [--release-channel stable|nightly]");
 	}
 }
 const nativePlatformPackages: readonly PublishPackage[] = [
@@ -598,6 +603,15 @@ async function prepareExpectedEvidence(evidenceDirectory: string, releaseChannel
 	});
 	const expectedPath = path.join(evidenceDirectory, EXPECTED_EVIDENCE_FILE);
 	const digest = await writeImmutableEvidence(expectedPath, expected);
+	// The fixed publish boundary no longer runs this script, so the
+	// pre-publication protected-tag snapshot must be captured here, in the
+	// credential-free preparation job, for the finalize step's channel
+	// evidence.
+	const protectedBefore = await observeRegistryTagSnapshot(expected.packages, NPM_RELEASE_TAG);
+	await writeImmutableBytes(
+		path.join(evidenceDirectory, CHANNEL_BEFORE_EVIDENCE_FILE),
+		canonicalJsonBytes({ schema_version: 1, snapshot: protectedBefore }),
+	);
 	console.log(JSON.stringify({
 		ok: true,
 		phase: "expected-evidence",
@@ -611,6 +625,10 @@ async function prepareExpectedEvidence(evidenceDirectory: string, releaseChannel
 function isMissingRegistryPackage(output: string): boolean {
 	return /\bE404\b|404 Not Found|is not in this registry/iu.test(output);
 }
+export const CHANNEL_BEFORE_EVIDENCE_FILE = "gajae-release-channel-before-v1.json";
+/** Written by the fixed (no-repo-code) OIDC publish boundary; finalize requires it. */
+export const PUBLISH_RECEIPT_FILE = "gajae-release-oidc-publish-receipt-v1.json";
+
 export interface RegistryTagSnapshotRecord {
 	name: string;
 	version: string | null;
@@ -1154,6 +1172,74 @@ async function publishFromExpectedEvidence(evidenceDirectory: string, releaseSer
 	}));
 }
 
+/**
+ * Finalize a release published by the fixed OIDC boundary: requires the
+ * boundary's publish receipt, re-observes the registry, and writes the final
+ * and channel evidence. Runs in the contents:write-only finalize job — never
+ * in the id-token boundary.
+ */
+async function finalizeReleaseEvidence(evidenceDirectory: string, releaseChannel: ReleaseChannel): Promise<void> {
+	const expectedPath = path.join(evidenceDirectory, EXPECTED_EVIDENCE_FILE);
+	const expectedAsset = await readExpectedEvidenceFile(expectedPath);
+	assertReleaseVersionForChannel(expectedAsset.value.release_version, releaseChannel);
+
+	// The fixed publish boundary must have recorded every expected package.
+	const receiptPath = path.join(evidenceDirectory, PUBLISH_RECEIPT_FILE);
+	if (!(await Bun.file(receiptPath).exists())) {
+		throw new Error(`Missing OIDC publish receipt ${PUBLISH_RECEIPT_FILE}; the fixed publish boundary did not complete`);
+	}
+	const receipt = JSON.parse(await Bun.file(receiptPath).text()) as {
+		schema_version?: number;
+		release_version?: string;
+		packages?: { name: string; version: string; tarball_sha512: string }[];
+	};
+	if (receipt.schema_version !== 1 || receipt.release_version !== expectedAsset.value.release_version || !Array.isArray(receipt.packages)) {
+		throw new Error("OIDC publish receipt does not match the expected release identity");
+	}
+	const receiptByName = new Map(receipt.packages.map(record => [record.name, record]));
+	for (const record of expectedAsset.value.packages) {
+		const seen = receiptByName.get(record.name);
+		if (seen === undefined || seen.version !== record.version || seen.tarball_sha512 !== record.tarball_sha512) {
+			throw new Error(`OIDC publish receipt is missing or mismatches ${record.name}@${record.version}`);
+		}
+	}
+
+	const policy = releasePolicy(releaseChannel);
+	const observations = await reobserveExpectedEvidencePackages(expectedAsset.value.packages, async (record) => {
+		const tarballPath = path.join(evidenceDirectory, "tarballs", `${record.tarball_sha512}.tgz`);
+		return observeRegistryPackage(record, await readRetainedTarball(record, tarballPath), policy);
+	}, releaseChannel);
+	const beforePath = path.join(evidenceDirectory, CHANNEL_BEFORE_EVIDENCE_FILE);
+	const beforeAsset = JSON.parse(await Bun.file(beforePath).text()) as { schema_version?: number; snapshot?: RegistryTagSnapshotRecord[] };
+	if (beforeAsset.schema_version !== 1 || !Array.isArray(beforeAsset.snapshot)) {
+		throw new Error(`Missing or malformed pre-publication tag snapshot ${CHANNEL_BEFORE_EVIDENCE_FILE}`);
+	}
+	const protectedAfter = await observeRegistryTagSnapshot(expectedAsset.value.packages, NPM_RELEASE_TAG);
+	const channelEvidence = createReleaseChannelEvidence({
+		sourceCommit: expectedAsset.value.source_commit,
+		releaseVersion: expectedAsset.value.release_version,
+		releaseChannel,
+		before: beforeAsset.snapshot,
+		after: protectedAfter,
+	});
+	const final = createFinalEvidence(expectedAsset.value, expectedAsset.sha256, observations);
+	const finalPath = path.join(evidenceDirectory, FINAL_EVIDENCE_FILE);
+	const finalDigest = await writeImmutableEvidence(finalPath, final);
+	const channelEvidencePath = path.join(evidenceDirectory, RELEASE_CHANNEL_EVIDENCE_FILE);
+	const channelEvidenceDigest = await writeImmutableBytes(channelEvidencePath, canonicalJsonBytes(channelEvidence));
+	console.log(JSON.stringify({
+		ok: true,
+		phase: "final-evidence",
+		expected_evidence: expectedPath,
+		expected_evidence_sha256: expectedAsset.sha256,
+		final_evidence: finalPath,
+		final_evidence_sha256: finalDigest,
+		verified_packages: final.packages.length,
+		channel_evidence: channelEvidencePath,
+		channel_evidence_sha256: channelEvidenceDigest,
+	}));
+}
+
 async function dryRun(): Promise<void> {
 	isDryRun = true;
 	try {
@@ -1189,11 +1275,15 @@ async function main(): Promise<void> {
 	}
 	if (command.mode === "prepare-evidence") {
 		// Declaration checks (`bun x tsc`) resolve and execute packages, so they
-		// belong in the credential-free preparation job. The publish job runs
-		// with contents: write + id-token: write and no dependency install, so
-		// dependency resolution must never re-enter that boundary.
+		// belong in the credential-free preparation job. The OIDC publish
+		// boundary executes no repository code at all, so dependency resolution
+		// must never re-enter it.
 		await checkTypeDeclarations();
 		await prepareExpectedEvidence(command.evidenceDir, command.releaseChannel);
+		return;
+	}
+	if (command.mode === "finalize-evidence") {
+		await finalizeReleaseEvidence(command.evidenceDir, command.releaseChannel);
 		return;
 	}
 	await publishFromExpectedEvidence(command.evidenceDir, command.releaseSerializationKey, command.releaseChannel);

--- a/scripts/release-notes.test.ts
+++ b/scripts/release-notes.test.ts
@@ -23,8 +23,15 @@ function pullRequest(
 	title: string,
 	commitSubjects: readonly string[],
 	author = "Yeachan-Heo",
+	commitOids?: readonly string[],
 ): CandidatePullRequest {
-	return { number, title, author, commitSubjects };
+	return {
+		number,
+		title,
+		author,
+		commitSubjects,
+		commitOids: commitOids ?? commitSubjects.map((_, index) => `${number}-oid-${index}`),
+	};
 }
 
 function notes(input: {
@@ -65,9 +72,9 @@ describe("subject parsing", () => {
 describe("shipped coverage", () => {
 	test("measures the share of a pull request the release carries", () => {
 		const pr = pullRequest(4607, "feat(provider): add oMLX profiles", ["a", "b", "c", "d"]);
-		expect(shippedCoverage(pr, new Set(["a", "b", "c", "d"]))).toBe(1);
-		expect(shippedCoverage(pr, new Set(["a", "b"]))).toBe(0.5);
-		expect(shippedCoverage(pr, new Set(["a"]))).toBe(0.25);
+		expect(shippedCoverage(pr, new Set(["4607-oid-0", "4607-oid-1", "4607-oid-2", "4607-oid-3"]))).toBe(1);
+		expect(shippedCoverage(pr, new Set(["4607-oid-0", "4607-oid-1"]))).toBe(0.5);
+		expect(shippedCoverage(pr, new Set(["4607-oid-0"]))).toBe(0.25);
 	});
 
 	test("treats a pull request with no commits as unshipped instead of dividing by zero", () => {
@@ -85,6 +92,7 @@ describe("attribution", () => {
 			commit("aaa", subject),
 			{ candidatesBySha: new Map([["aaa", [contained]]]), pullRequestsByNumber: new Map([[4666, referenced]]) },
 			new Set([normalizeSubject(subject)]),
+			new Set(["aaa"]),
 		);
 
 		expect(attribution).toEqual({ kind: "pull-request", pullRequest: referenced });
@@ -104,6 +112,7 @@ describe("attribution", () => {
 			shipped,
 			{ candidatesBySha: new Map([["bbb", [swap]]]), pullRequestsByNumber: new Map() },
 			new Set([shipped.subject]),
+			new Set(["bbb"]),
 		);
 
 		expect(attribution).toEqual({ kind: "commit", commit: shipped });
@@ -118,6 +127,7 @@ describe("attribution", () => {
 			commit("ccc", subject),
 			{ candidatesBySha: new Map([["ccc", [promotion, owner]]]), pullRequestsByNumber: new Map() },
 			new Set([subject, "second"]),
+			new Set(["4676-oid-0", "4676-oid-1", "4607-oid-0"]),
 		);
 
 		expect(attribution).toEqual({ kind: "pull-request", pullRequest: owner });
@@ -132,6 +142,7 @@ describe("attribution", () => {
 				orphan,
 				{ candidatesBySha: new Map([["ddd", [unrelated]]]), pullRequestsByNumber: new Map() },
 				new Set([orphan.subject, "something else"]),
+				new Set(["ddd", "4000-oid-0"]),
 			),
 		).toEqual({ kind: "commit", commit: orphan });
 	});
@@ -139,14 +150,30 @@ describe("attribution", () => {
 	test("coverage exactly at the threshold is accepted", () => {
 		const subject = "fix(a): half";
 		const half = pullRequest(10, "half shipped", [subject, "unshipped"]);
-		expect(shippedCoverage(half, new Set([subject]))).toBe(SHIPPED_COVERAGE_THRESHOLD);
+		expect(shippedCoverage(half, new Set(["10-oid-0"]))).toBe(SHIPPED_COVERAGE_THRESHOLD);
 		expect(
 			attributeCommit(
 				commit("eee", subject),
 				{ candidatesBySha: new Map([["eee", [half]]]), pullRequestsByNumber: new Map() },
 				new Set([subject]),
+				new Set(["eee", "10-oid-0"]),
 			),
 		).toEqual({ kind: "pull-request", pullRequest: half });
+	});
+
+	test("duplicate subjects cannot inflate coverage: only the actually shipped OID counts", () => {
+		// Regression: subject-based coverage counted the duplicated subject
+		// twice (2/4 = 0.5) although only one of the four commits shipped.
+		const partial = pullRequest(11, "partially shipped", ["dup", "dup", "c", "d"], "Yeachan-Heo", ["o1", "o2", "o3", "o4"]);
+		const shipped = commit("fff111", "dup");
+		expect(shippedCoverage(partial, new Set(["fff111", "o1"]))).toBe(0.25);
+		const attribution = attributeCommit(
+			shipped,
+			{ candidatesBySha: new Map([["fff111", [partial]]]), pullRequestsByNumber: new Map() },
+			new Set(["dup"]),
+			new Set(["fff111", "o1"]),
+		);
+		expect(attribution).toEqual({ kind: "commit", commit: shipped });
 	});
 });
 

--- a/scripts/release-notes.test.ts
+++ b/scripts/release-notes.test.ts
@@ -154,8 +154,20 @@ describe("notes body", () => {
 	test("keeps the historical section order and compare link", () => {
 		const body = notes({ commits: [commit("fff", "fix(x): direct push")] });
 		expect(body.startsWith("## What's Changed\n")).toBe(true);
-		expect(body).toContain(`* fix(x): direct push by @Yeachan-Heo in https://github.com/${repo}/commit/fff`);
+		// No resolved login: the Git display name renders without an `@` mention.
+		expect(body).toContain(`* fix(x): direct push by Yeachan-Heo in https://github.com/${repo}/commit/fff`);
+		expect(body).not.toContain("@Yeachan-Heo");
 		expect(body.trimEnd().endsWith(`**Full Changelog**: https://github.com/${repo}/compare/v0.14.0...v0.14.1`)).toBe(true);
+	});
+
+	test("credits the resolved GitHub login for fallback commits, never a display-name mention", () => {
+		const withLogin: ReleaseCommit = { sha: "abc", subject: "fix(y): direct push", author: "Yeachan Heo", githubLogin: "Yeachan-Heo" };
+		const withoutLogin: ReleaseCommit = { sha: "def", subject: "fix(z): direct push", author: "Some Display Name" };
+		const body = notes({ commits: [withLogin, withoutLogin] });
+
+		expect(body).toContain(`* fix(y): direct push by @Yeachan-Heo in https://github.com/${repo}/commit/abc`);
+		expect(body).toContain(`* fix(z): direct push by Some Display Name in https://github.com/${repo}/commit/def`);
+		expect(body).not.toContain("@Some Display Name");
 	});
 
 	test("credits a pull request once even when several of its commits ship", () => {

--- a/scripts/release-notes.test.ts
+++ b/scripts/release-notes.test.ts
@@ -5,6 +5,7 @@ import {
 	SHIPPED_COVERAGE_THRESHOLD,
 	attributeCommit,
 	buildReleaseNotes,
+	isExplicitEmptyGhResult,
 	normalizeSubject,
 	parseReleaseNotesCli,
 	parseSubjectPullRequestRef,
@@ -224,5 +225,25 @@ describe("cli", () => {
 
 	test("rejects a dangling flag instead of silently dropping it", () => {
 		expect(() => parseReleaseNotesCli(["--repo", "o/n", "--base"])).toThrow("Usage");
+	});
+});
+
+describe("fail-closed gh result classification", () => {
+	test("treats success and explicit not-found as empty, everything else as failure", () => {
+		// Explicit success and explicit no-result responses are the only empty outcomes.
+		expect(isExplicitEmptyGhResult(0, "")).toBe(true);
+		expect(isExplicitEmptyGhResult(1, "GraphQL: Could not resolve to a PullRequest with the number of 999999.")).toBe(true);
+		expect(isExplicitEmptyGhResult(1, "no pull requests found")).toBe(true);
+	});
+
+	test("fails closed on auth, transport, and API errors", () => {
+		expect(isExplicitEmptyGhResult(1, "gh: To authenticate, please run `gh auth login`.")).toBe(false);
+		expect(isExplicitEmptyGhResult(1, "HTTP 403: Resource not accessible by integration")).toBe(false);
+		expect(isExplicitEmptyGhResult(1, "HTTP 500: Internal Server Error")).toBe(false);
+		expect(isExplicitEmptyGhResult(1, "dial tcp: lookup api.github.com: no such host")).toBe(false);
+		expect(isExplicitEmptyGhResult(1, "API rate limit exceeded")).toBe(false);
+		// A bare/unknown failure must never be mistaken for an explicit empty.
+		expect(isExplicitEmptyGhResult(1, "")).toBe(false);
+		expect(isExplicitEmptyGhResult(128, "fatal: something else")).toBe(false);
 	});
 });

--- a/scripts/release-notes.test.ts
+++ b/scripts/release-notes.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type CandidatePullRequest,
+	type ReleaseCommit,
+	SHIPPED_COVERAGE_THRESHOLD,
+	attributeCommit,
+	buildReleaseNotes,
+	normalizeSubject,
+	parseReleaseNotesCli,
+	parseSubjectPullRequestRef,
+	shippedCoverage,
+} from "./release-notes";
+
+const repo = "Yeachan-Heo/gajae-code";
+
+function commit(sha: string, subject: string, author = "Yeachan-Heo"): ReleaseCommit {
+	return { sha, subject, author };
+}
+
+function pullRequest(
+	number: number,
+	title: string,
+	commitSubjects: readonly string[],
+	author = "Yeachan-Heo",
+): CandidatePullRequest {
+	return { number, title, author, commitSubjects };
+}
+
+function notes(input: {
+	commits: readonly ReleaseCommit[];
+	candidatesBySha?: ReadonlyMap<string, readonly CandidatePullRequest[]>;
+	pullRequestsByNumber?: ReadonlyMap<number, CandidatePullRequest>;
+	firstMergedPullRequestByAuthor?: ReadonlyMap<string, number>;
+}): string {
+	return buildReleaseNotes({
+		repo,
+		baseTag: "v0.14.0",
+		headTag: "v0.14.1",
+		commits: input.commits,
+		candidatesBySha: input.candidatesBySha ?? new Map(),
+		pullRequestsByNumber: input.pullRequestsByNumber ?? new Map(),
+		firstMergedPullRequestByAuthor: input.firstMergedPullRequestByAuthor ?? new Map(),
+	});
+}
+
+describe("subject parsing", () => {
+	test("reads and strips a trailing pull request reference", () => {
+		expect(parseSubjectPullRequestRef("fix(ai): bound the connect phase (#4666)")).toBe(4666);
+		expect(normalizeSubject("fix(ai): bound the connect phase (#4666)")).toBe("fix(ai): bound the connect phase");
+	});
+
+	test("ignores issue references that are not a trailing pull request suffix", () => {
+		expect(parseSubjectPullRequestRef("docs(changelog): record the fix from #4606")).toBeUndefined();
+		expect(parseSubjectPullRequestRef("fix(natives): stop the AVX2 probe (#4652) flashing")).toBeUndefined();
+	});
+
+	test("normalizing is idempotent so squashed and branch subjects compare equal", () => {
+		const squashed = normalizeSubject("feat(provider): add oMLX profiles (#4607)");
+		expect(normalizeSubject(squashed)).toBe(squashed);
+		expect(squashed).toBe(normalizeSubject("feat(provider): add oMLX profiles"));
+	});
+});
+
+describe("shipped coverage", () => {
+	test("measures the share of a pull request the release carries", () => {
+		const pr = pullRequest(4607, "feat(provider): add oMLX profiles", ["a", "b", "c", "d"]);
+		expect(shippedCoverage(pr, new Set(["a", "b", "c", "d"]))).toBe(1);
+		expect(shippedCoverage(pr, new Set(["a", "b"]))).toBe(0.5);
+		expect(shippedCoverage(pr, new Set(["a"]))).toBe(0.25);
+	});
+
+	test("treats a pull request with no commits as unshipped instead of dividing by zero", () => {
+		expect(shippedCoverage(pullRequest(1, "empty", []), new Set(["a"]))).toBe(0);
+	});
+});
+
+describe("attribution", () => {
+	test("a subject reference wins over any candidate", () => {
+		const referenced = pullRequest(4666, "fix(ai): bound the Anthropic connect phase", ["fix(ai): bound the Anthropic connect phase"]);
+		const contained = pullRequest(4430, "feat(autoresearch)!: replace the team workflow", ["fix(ai): bound the connect phase (#4666)"]);
+		const subject = "fix(ai): bound the connect phase (#4666)";
+
+		const attribution = attributeCommit(
+			commit("aaa", subject),
+			{ candidatesBySha: new Map([["aaa", [contained]]]), pullRequestsByNumber: new Map([[4666, referenced]]) },
+			new Set([normalizeSubject(subject)]),
+		);
+
+		expect(attribution).toEqual({ kind: "pull-request", pullRequest: referenced });
+	});
+
+	test("rejects a containing pull request the release does not ship", () => {
+		// The 0.14.1 case: the autoresearch swap contained two shipped test
+		// commits, but the release excluded the swap itself.
+		const swap = pullRequest(
+			4430,
+			"feat(autoresearch)!: replace the team workflow",
+			["test(computer): add a red-team suite", ...Array.from({ length: 31 }, (_, index) => `unshipped ${index}`)],
+		);
+		const shipped = commit("bbb", "test(computer): add a red-team suite");
+
+		const attribution = attributeCommit(
+			shipped,
+			{ candidatesBySha: new Map([["bbb", [swap]]]), pullRequestsByNumber: new Map() },
+			new Set([shipped.subject]),
+		);
+
+		expect(attribution).toEqual({ kind: "commit", commit: shipped });
+	});
+
+	test("prefers the smallest fully shipped pull request over a larger one", () => {
+		const subject = "feat(provider): add oMLX profiles";
+		const promotion = pullRequest(4676, "release: promote blockers to main", [subject, "second"]);
+		const owner = pullRequest(4607, "feat(provider): add built-in oMLX profiles", [subject]);
+
+		const attribution = attributeCommit(
+			commit("ccc", subject),
+			{ candidatesBySha: new Map([["ccc", [promotion, owner]]]), pullRequestsByNumber: new Map() },
+			new Set([subject, "second"]),
+		);
+
+		expect(attribution).toEqual({ kind: "pull-request", pullRequest: owner });
+	});
+
+	test("a candidate that does not contain the commit never wins", () => {
+		const unrelated = pullRequest(4000, "unrelated", ["something else"]);
+		const orphan = commit("ddd", "fix(x): orphan change");
+
+		expect(
+			attributeCommit(
+				orphan,
+				{ candidatesBySha: new Map([["ddd", [unrelated]]]), pullRequestsByNumber: new Map() },
+				new Set([orphan.subject, "something else"]),
+			),
+		).toEqual({ kind: "commit", commit: orphan });
+	});
+
+	test("coverage exactly at the threshold is accepted", () => {
+		const subject = "fix(a): half";
+		const half = pullRequest(10, "half shipped", [subject, "unshipped"]);
+		expect(shippedCoverage(half, new Set([subject]))).toBe(SHIPPED_COVERAGE_THRESHOLD);
+		expect(
+			attributeCommit(
+				commit("eee", subject),
+				{ candidatesBySha: new Map([["eee", [half]]]), pullRequestsByNumber: new Map() },
+				new Set([subject]),
+			),
+		).toEqual({ kind: "pull-request", pullRequest: half });
+	});
+});
+
+describe("notes body", () => {
+	test("keeps the historical section order and compare link", () => {
+		const body = notes({ commits: [commit("fff", "fix(x): direct push")] });
+		expect(body.startsWith("## What's Changed\n")).toBe(true);
+		expect(body).toContain(`* fix(x): direct push by @Yeachan-Heo in https://github.com/${repo}/commit/fff`);
+		expect(body.trimEnd().endsWith(`**Full Changelog**: https://github.com/${repo}/compare/v0.14.0...v0.14.1`)).toBe(true);
+	});
+
+	test("credits a pull request once even when several of its commits ship", () => {
+		const pr = pullRequest(4607, "feat(provider): add oMLX profiles", ["first (#4607)", "second (#4607)"]);
+		const body = notes({
+			commits: [commit("a1", "first (#4607)"), commit("a2", "second (#4607)")],
+			pullRequestsByNumber: new Map([[4607, pr]]),
+		});
+
+		expect(body.match(/pull\/4607/gu)).toHaveLength(1);
+		expect(body).not.toContain("/commit/a2");
+	});
+
+	test("omits the contributors section when nobody is new", () => {
+		const pr = pullRequest(4666, "fix(ai): bound the connect phase", ["fix(ai): bound the connect phase (#4666)"]);
+		const body = notes({
+			commits: [commit("b1", "fix(ai): bound the connect phase (#4666)")],
+			pullRequestsByNumber: new Map([[4666, pr]]),
+			firstMergedPullRequestByAuthor: new Map([["Yeachan-Heo", 1]]),
+		});
+
+		expect(body).not.toContain("New Contributors");
+	});
+
+	test("lists a contributor whose first merged pull request is in this release", () => {
+		const first = pullRequest(4635, "fix(usage): preserve probe limits", ["fix(usage): preserve probe limits (#4635)"], "asdfqwerzxcc");
+		const repeat = pullRequest(4666, "fix(ai): bound the connect phase", ["fix(ai): bound the connect phase (#4666)"]);
+		const body = notes({
+			commits: [commit("c1", "fix(usage): preserve probe limits (#4635)"), commit("c2", "fix(ai): bound the connect phase (#4666)")],
+			pullRequestsByNumber: new Map([
+				[4635, first],
+				[4666, repeat],
+			]),
+			firstMergedPullRequestByAuthor: new Map([
+				["asdfqwerzxcc", 4635],
+				["Yeachan-Heo", 1],
+			]),
+		});
+
+		expect(body).toContain(`* @asdfqwerzxcc made their first contribution in https://github.com/${repo}/pull/4635`);
+		expect(body).not.toContain("@Yeachan-Heo made their first contribution");
+	});
+});
+
+describe("cli", () => {
+	test("requires repo and base", () => {
+		expect(() => parseReleaseNotesCli(["--base", "v0.14.0"])).toThrow("--repo and --base are required");
+		expect(() => parseReleaseNotesCli(["--repo", "o/n"])).toThrow("--repo and --base are required");
+	});
+
+	test("defaults head and head tag, and reads the output path", () => {
+		expect(parseReleaseNotesCli(["--repo", "o/n", "--base", "v0.14.0"])).toEqual({
+			repo: "o/n",
+			base: "v0.14.0",
+			head: "HEAD",
+			headTag: "HEAD",
+			out: undefined,
+		});
+		expect(parseReleaseNotesCli(["--repo", "o/n", "--base", "v0.14.0", "--head-tag", "v0.14.1", "--out", "/tmp/n.md"])).toEqual({
+			repo: "o/n",
+			base: "v0.14.0",
+			head: "HEAD",
+			headTag: "v0.14.1",
+			out: "/tmp/n.md",
+		});
+	});
+
+	test("rejects a dangling flag instead of silently dropping it", () => {
+		expect(() => parseReleaseNotesCli(["--repo", "o/n", "--base"])).toThrow("Usage");
+	});
+});

--- a/scripts/release-notes.test.ts
+++ b/scripts/release-notes.test.ts
@@ -85,7 +85,7 @@ describe("shipped coverage", () => {
 
 describe("attribution", () => {
 	test("a subject reference wins over any candidate", () => {
-		const referenced = pullRequest(4666, "fix(ai): bound the Anthropic connect phase", ["fix(ai): bound the Anthropic connect phase"]);
+		const referenced = pullRequest(4666, "fix(ai): bound the Anthropic connect phase", ["fix(ai): bound the Anthropic connect phase"], "Yeachan-Heo", ["aaa"]);
 		const contained = pullRequest(4430, "feat(autoresearch)!: replace the team workflow", ["fix(ai): bound the connect phase (#4666)"]);
 		const subject = "fix(ai): bound the connect phase (#4666)";
 
@@ -97,6 +97,20 @@ describe("attribution", () => {
 		);
 
 		expect(attribution).toEqual({ kind: "pull-request", pullRequest: referenced });
+	});
+
+	test("rejects a referenced pull request when the release ships below the coverage threshold", () => {
+		const referenced = pullRequest(4667, "fix(ai): partially shipped", ["fix(ai): partially shipped", "second", "third", "fourth"], "Yeachan-Heo", ["o1", "o2", "o3", "o4"]);
+		const shipped = commit("o1", "fix(ai): partially shipped (#4667)");
+
+		const attribution = attributeCommit(
+			shipped,
+			{ candidatesBySha: new Map(), pullRequestsByNumber: new Map([[4667, referenced]]) },
+			new Set([normalizeSubject(shipped.subject)]),
+			new Set(["o1"]),
+		);
+
+		expect(attribution).toEqual({ kind: "commit", commit: shipped });
 	});
 
 	test("rejects a containing pull request the release does not ship", () => {
@@ -199,7 +213,7 @@ describe("notes body", () => {
 	});
 
 	test("credits a pull request once even when several of its commits ship", () => {
-		const pr = pullRequest(4607, "feat(provider): add oMLX profiles", ["first (#4607)", "second (#4607)"]);
+		const pr = pullRequest(4607, "feat(provider): add oMLX profiles", ["first (#4607)", "second (#4607)"], "Yeachan-Heo", ["a1", "a2"]);
 		const body = notes({
 			commits: [commit("a1", "first (#4607)"), commit("a2", "second (#4607)")],
 			pullRequestsByNumber: new Map([[4607, pr]]),
@@ -221,8 +235,8 @@ describe("notes body", () => {
 	});
 
 	test("lists a contributor whose first merged pull request is in this release", () => {
-		const first = pullRequest(4635, "fix(usage): preserve probe limits", ["fix(usage): preserve probe limits (#4635)"], "asdfqwerzxcc");
-		const repeat = pullRequest(4666, "fix(ai): bound the connect phase", ["fix(ai): bound the connect phase (#4666)"]);
+		const first = pullRequest(4635, "fix(usage): preserve probe limits", ["fix(usage): preserve probe limits (#4635)"], "asdfqwerzxcc", ["c1"]);
+		const repeat = pullRequest(4666, "fix(ai): bound the connect phase", ["fix(ai): bound the connect phase (#4666)"], "Yeachan-Heo", ["c2"]);
 		const body = notes({
 			commits: [commit("c1", "fix(usage): preserve probe limits (#4635)"), commit("c2", "fix(ai): bound the connect phase (#4666)")],
 			pullRequestsByNumber: new Map([
@@ -304,5 +318,16 @@ describe("first merged pull request selection", () => {
 			{ number: 9, mergedAt: "2026-01-15T00:00:00Z" },
 			{ number: 7, mergedAt: "2026-01-15T00:00:00Z" },
 		])).toBe(7);
+	});
+
+	test("considers an earliest merge beyond the first fifty results", () => {
+		const laterCreated = Array.from({ length: 50 }, (_, index) => ({
+			number: index + 1,
+			mergedAt: `2026-02-${String(index + 1).padStart(2, "0")}T00:00:00Z`,
+		}));
+		expect(earliestMergedPullRequest([
+			...laterCreated,
+			{ number: 999, mergedAt: "2026-01-01T00:00:00Z" },
+		])).toBe(999);
 	});
 });

--- a/scripts/release-notes.test.ts
+++ b/scripts/release-notes.test.ts
@@ -25,6 +25,7 @@ function pullRequest(
 	commitSubjects: readonly string[],
 	author = "Yeachan-Heo",
 	commitOids?: readonly string[],
+	mergeCommitOid?: string,
 ): CandidatePullRequest {
 	return {
 		number,
@@ -32,6 +33,7 @@ function pullRequest(
 		author,
 		commitSubjects,
 		commitOids: commitOids ?? commitSubjects.map((_, index) => `${number}-oid-${index}`),
+		...(mergeCommitOid === undefined ? {} : { mergeCommitOid }),
 	};
 }
 
@@ -81,6 +83,11 @@ describe("shipped coverage", () => {
 	test("treats a pull request with no commits as unshipped instead of dividing by zero", () => {
 		expect(shippedCoverage(pullRequest(1, "empty", []), new Set(["a"]))).toBe(0);
 	});
+
+	test("accepts a shipped squash commit when branch OIDs differ", () => {
+		const pr = pullRequest(4608, "fix(provider): squash the release fix", ["branch commit"], "Yeachan-Heo", ["branch-oid"], "squash-oid");
+		expect(shippedCoverage(pr, new Set(["squash-oid"]))).toBe(1);
+	});
 });
 
 describe("attribution", () => {
@@ -111,6 +118,20 @@ describe("attribution", () => {
 		);
 
 		expect(attribution).toEqual({ kind: "commit", commit: shipped });
+	});
+
+	test("credits a referenced pull request through its squash commit", () => {
+		const referenced = pullRequest(4668, "fix(ai): squash attribution", ["branch commit"], "Yeachan-Heo", ["branch-oid"], "squash-oid");
+		const shipped = commit("squash-oid", "fix(ai): squash attribution (#4668)");
+
+		const attribution = attributeCommit(
+			shipped,
+			{ candidatesBySha: new Map(), pullRequestsByNumber: new Map([[4668, referenced]]) },
+			new Set([normalizeSubject(shipped.subject)]),
+			new Set(["squash-oid"]),
+		);
+
+		expect(attribution).toEqual({ kind: "pull-request", pullRequest: referenced });
 	});
 
 	test("rejects a containing pull request the release does not ship", () => {

--- a/scripts/release-notes.test.ts
+++ b/scripts/release-notes.test.ts
@@ -5,6 +5,7 @@ import {
 	SHIPPED_COVERAGE_THRESHOLD,
 	attributeCommit,
 	buildReleaseNotes,
+	earliestMergedPullRequest,
 	isExplicitEmptyGhResult,
 	normalizeSubject,
 	parseReleaseNotesCli,
@@ -284,5 +285,24 @@ describe("fail-closed gh result classification", () => {
 		// A bare/unknown failure must never be mistaken for an explicit empty.
 		expect(isExplicitEmptyGhResult(1, "")).toBe(false);
 		expect(isExplicitEmptyGhResult(128, "fatal: something else")).toBe(false);
+	});
+});
+
+describe("first merged pull request selection", () => {
+	test("selects by merge time, not creation time", () => {
+		// #10 was created first but merged last; #12 was created later but merged first.
+		expect(earliestMergedPullRequest([
+			{ number: 10, mergedAt: "2026-02-01T00:00:00Z" },
+			{ number: 12, mergedAt: "2026-01-15T00:00:00Z" },
+			{ number: 11, mergedAt: "2026-01-20T00:00:00Z" },
+		])).toBe(12);
+		expect(earliestMergedPullRequest([])).toBeUndefined();
+	});
+
+	test("breaks merge-time ties by the lower pull request number", () => {
+		expect(earliestMergedPullRequest([
+			{ number: 9, mergedAt: "2026-01-15T00:00:00Z" },
+			{ number: 7, mergedAt: "2026-01-15T00:00:00Z" },
+		])).toBe(7);
 	});
 });

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -255,13 +255,26 @@ async function candidateNumbers(repo: string, sha: string): Promise<number[]> {
 	return JSON.parse(raw) as number[];
 }
 
+/** Picks the earliest MERGED pull request by merge timestamp, not creation time. */
+export function earliestMergedPullRequest(pullRequests: readonly { number: number; mergedAt: string }[]): number | undefined {
+	let earliest: { number: number; mergedAt: string } | undefined;
+	for (const pr of pullRequests) {
+		if (earliest === undefined || pr.mergedAt < earliest.mergedAt || (pr.mergedAt === earliest.mergedAt && pr.number < earliest.number)) {
+			earliest = pr;
+		}
+	}
+	return earliest?.number;
+}
+
 async function firstMergedPullRequest(repo: string, author: string): Promise<number | undefined> {
+	// The search API cannot sort by merge time, so fetch a bounded created-asc
+	// window and select the minimum merge timestamp.
 	const raw = await gh([
 		"search", "prs", "--repo", repo, "--author", author, "--merged",
-		"--sort", "created", "--order", "asc", "--limit", "1", "--json", "number",
+		"--sort", "created", "--order", "asc", "--limit", "50", "--json", "number,mergedAt",
 	]);
 	if (raw.trim() === "") return undefined;
-	return (JSON.parse(raw) as { number: number }[])[0]?.number;
+	return earliestMergedPullRequest(JSON.parse(raw) as { number: number; mergedAt: string }[]);
 }
 
 /**

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -45,6 +45,8 @@ export interface ReleaseCommit {
 	author: string;
 	/** Resolved GitHub login for the author, when the API provides one. */
 	githubLogin?: string;
+	/** Cherry-pick origin OID when this commit was cherry-picked; else undefined. */
+	originSha?: string;
 }
 
 export interface CandidatePullRequest {
@@ -53,6 +55,8 @@ export interface CandidatePullRequest {
 	author: string;
 	/** Subjects of every commit the pull request contains. */
 	commitSubjects: readonly string[];
+	/** OIDs of every commit the pull request contains (coverage is by identity). */
+	commitOids: readonly string[];
 }
 
 export type Attribution =
@@ -82,14 +86,19 @@ export function parseSubjectPullRequestRef(subject: string): number | undefined 
 	return match ? Number(match[1]) : undefined;
 }
 
-/** Share of `pullRequest`'s commits present in `shippedSubjects`. */
-export function shippedCoverage(pullRequest: CandidatePullRequest, shippedSubjects: ReadonlySet<string>): number {
-	if (pullRequest.commitSubjects.length === 0) return 0;
+/**
+ * Share of `pullRequest`'s commits this release ships, compared by commit
+ * OID (cherry-pick origins included). Subject text cannot be used here:
+ * duplicate subjects would count one shipped commit multiple times and push
+ * a partially shipped candidate over the credit threshold.
+ */
+export function shippedCoverage(pullRequest: CandidatePullRequest, shippedOids: ReadonlySet<string>): number {
+	if (pullRequest.commitOids.length === 0) return 0;
 	let shipped = 0;
-	for (const subject of pullRequest.commitSubjects) {
-		if (shippedSubjects.has(normalizeSubject(subject))) shipped++;
+	for (const oid of pullRequest.commitOids) {
+		if (shippedOids.has(oid)) shipped++;
 	}
-	return shipped / pullRequest.commitSubjects.length;
+	return shipped / pullRequest.commitOids.length;
 }
 
 /**
@@ -101,6 +110,7 @@ export function attributeCommit(
 	commit: ReleaseCommit,
 	input: Pick<ReleaseNotesInput, "candidatesBySha" | "pullRequestsByNumber">,
 	shippedSubjects: ReadonlySet<string>,
+	shippedOids: ReadonlySet<string>,
 ): Attribution {
 	const referenced = parseSubjectPullRequestRef(commit.subject);
 	if (referenced !== undefined) {
@@ -111,7 +121,7 @@ export function attributeCommit(
 	const normalized = normalizeSubject(commit.subject);
 	const accepted = (input.candidatesBySha.get(commit.sha) ?? [])
 		.filter(candidate => candidate.commitSubjects.some(subject => normalizeSubject(subject) === normalized))
-		.filter(candidate => shippedCoverage(candidate, shippedSubjects) >= SHIPPED_COVERAGE_THRESHOLD)
+		.filter(candidate => shippedCoverage(candidate, shippedOids) >= SHIPPED_COVERAGE_THRESHOLD)
 		.sort((left, right) => left.commitSubjects.length - right.commitSubjects.length || left.number - right.number);
 
 	const smallest = accepted[0];
@@ -121,11 +131,12 @@ export function attributeCommit(
 export function buildReleaseNotes(input: ReleaseNotesInput): string {
 	const repoUrl = `https://github.com/${input.repo}`;
 	const shippedSubjects = new Set(input.commits.map(commit => normalizeSubject(commit.subject)));
+	const shippedOids = new Set(input.commits.map(commit => commit.originSha ?? commit.sha));
 
 	const lines: string[] = [];
 	const credited = new Set<number>();
 	for (const commit of input.commits) {
-		const attribution = attributeCommit(commit, input, shippedSubjects);
+		const attribution = attributeCommit(commit, input, shippedSubjects, shippedOids);
 		if (attribution.kind === "pull-request") {
 			const { number, title, author } = attribution.pullRequest;
 			if (credited.has(number)) continue;
@@ -209,7 +220,8 @@ async function collectCommits(baseTag: string, head: string): Promise<ReleaseCom
 		if (sha === undefined || subject === undefined || author === undefined) continue;
 		// The release script's own version bump is machinery, not a change.
 		if (BUMP_SUBJECT.test(subject)) continue;
-		commits.push({ sha, subject, author });
+		const originSha = await cherryPickOrigin(sha);
+		commits.push({ sha, subject, author, ...(originSha === sha ? {} : { originSha }) });
 	}
 	return commits;
 }
@@ -226,13 +238,14 @@ async function loadPullRequest(repo: string, number: number): Promise<CandidateP
 		number: number;
 		title: string;
 		author: { login: string };
-		commits: { messageHeadline: string }[];
+		commits: { messageHeadline: string; oid: string }[];
 	};
 	return {
 		number: parsed.number,
 		title: parsed.title,
 		author: parsed.author.login,
 		commitSubjects: parsed.commits.map(commit => commit.messageHeadline),
+		commitOids: parsed.commits.map(commit => commit.oid),
 	};
 }
 
@@ -278,9 +291,10 @@ export async function deriveReleaseNotes(repo: string, baseTag: string, head: st
 
 	for (const commit of commits) {
 		const referenced = parseSubjectPullRequestRef(commit.subject);
+
 		if (referenced !== undefined && (await ensure(referenced))) continue;
 		const candidates: CandidatePullRequest[] = [];
-		for (const number of await candidateNumbers(repo, await cherryPickOrigin(commit.sha))) {
+		for (const number of await candidateNumbers(repo, commit.originSha ?? commit.sha)) {
 			const loaded = await ensure(number);
 			if (loaded) candidates.push(loaded);
 		}
@@ -288,13 +302,14 @@ export async function deriveReleaseNotes(repo: string, baseTag: string, head: st
 	}
 
 	const shippedSubjects = new Set(commits.map(commit => normalizeSubject(commit.subject)));
+	const shippedOids = new Set(commits.map(commit => commit.originSha ?? commit.sha));
 	const firstMergedPullRequestByAuthor = new Map<string, number>();
 	for (const commit of commits) {
-		const attribution = attributeCommit(commit, { candidatesBySha, pullRequestsByNumber }, shippedSubjects);
+		const attribution = attributeCommit(commit, { candidatesBySha, pullRequestsByNumber }, shippedSubjects, shippedOids);
 		if (attribution.kind !== "pull-request") {
 			// Fallback commits credit by login only when one is resolved;
 			// otherwise the Git display name is rendered without `@`.
-			commit.githubLogin = await resolveCommitLogin(repo, await cherryPickOrigin(commit.sha));
+			commit.githubLogin = await resolveCommitLogin(repo, commit.originSha ?? commit.sha);
 			continue;
 		}
 		const { author } = attribution.pullRequest;

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -1,0 +1,296 @@
+#!/usr/bin/env bun
+/**
+ * Derives GitHub Release notes for a release range in the historical
+ * `## What's Changed` / `## New Contributors` / `**Full Changelog**` shape.
+ *
+ * `generate_release_notes: true` cannot describe a curated release. GitHub
+ * derives its notes from pull requests merged into the target branch, so a
+ * release assembled by cherry-picking onto `main` produces an empty body with
+ * nothing but a compare link (v0.14.1 shipped exactly that).
+ *
+ * Attribution here is deliberately conservative, because the naive lookups are
+ * actively misleading on a curated release:
+ *
+ *   - `GET /commits/{sha}/pulls` returns *every* pull request whose branch
+ *     contains the commit. On 0.14.1 that credited shipped fixes to the
+ *     32-commit `feat(autoresearch)!` workflow swap the release deliberately
+ *     excluded, and to the promotion PR that carried everything.
+ *   - Picking the smallest candidate is not enough either: a huge excluded PR
+ *     can still be the only candidate.
+ *
+ * So a candidate pull request is accepted only when this release actually
+ * ships it (see `SHIPPED_COVERAGE_THRESHOLD`); otherwise the entry falls back
+ * to a commit link, which can never advertise unshipped work.
+ *
+ * Usage:
+ *   bun scripts/release-notes.ts --base <tag> --head <rev> --repo <owner/name> --out <path>
+ *   bun scripts/release-notes.ts --base v0.14.0 --head HEAD --repo o/n   # stdout
+ */
+
+import { $ } from "bun";
+
+/** A pull request must land this share of its commits to be credited. */
+export const SHIPPED_COVERAGE_THRESHOLD = 0.5;
+
+const SUBJECT_PR_REF = /\s\(#(\d{1,7})\)$/u;
+const BUMP_SUBJECT = /^chore: bump version to /u;
+
+export interface ReleaseCommit {
+	sha: string;
+	subject: string;
+	/** GitHub login to credit when no pull request is attributed. */
+	author: string;
+}
+
+export interface CandidatePullRequest {
+	number: number;
+	title: string;
+	author: string;
+	/** Subjects of every commit the pull request contains. */
+	commitSubjects: readonly string[];
+}
+
+export type Attribution =
+	| { kind: "pull-request"; pullRequest: CandidatePullRequest }
+	| { kind: "commit"; commit: ReleaseCommit };
+
+export interface ReleaseNotesInput {
+	repo: string;
+	baseTag: string;
+	headTag: string;
+	commits: readonly ReleaseCommit[];
+	/** Candidate pull requests keyed by commit sha. */
+	candidatesBySha: ReadonlyMap<string, readonly CandidatePullRequest[]>;
+	/** Every pull request this run knows about, keyed by number. */
+	pullRequestsByNumber: ReadonlyMap<number, CandidatePullRequest>;
+	/** Earliest merged pull request number per author login. */
+	firstMergedPullRequestByAuthor: ReadonlyMap<string, number>;
+}
+
+/** Strips a trailing `(#1234)` so squashed and branch subjects compare equal. */
+export function normalizeSubject(subject: string): string {
+	return subject.replace(SUBJECT_PR_REF, "").trim();
+}
+
+export function parseSubjectPullRequestRef(subject: string): number | undefined {
+	const match = subject.match(SUBJECT_PR_REF);
+	return match ? Number(match[1]) : undefined;
+}
+
+/** Share of `pullRequest`'s commits present in `shippedSubjects`. */
+export function shippedCoverage(pullRequest: CandidatePullRequest, shippedSubjects: ReadonlySet<string>): number {
+	if (pullRequest.commitSubjects.length === 0) return 0;
+	let shipped = 0;
+	for (const subject of pullRequest.commitSubjects) {
+		if (shippedSubjects.has(normalizeSubject(subject))) shipped++;
+	}
+	return shipped / pullRequest.commitSubjects.length;
+}
+
+/**
+ * A subject-embedded `(#N)` is authoritative: the merge that produced the
+ * commit wrote it. Otherwise the smallest candidate this release actually
+ * ships wins, and an unshipped candidate is rejected outright.
+ */
+export function attributeCommit(
+	commit: ReleaseCommit,
+	input: Pick<ReleaseNotesInput, "candidatesBySha" | "pullRequestsByNumber">,
+	shippedSubjects: ReadonlySet<string>,
+): Attribution {
+	const referenced = parseSubjectPullRequestRef(commit.subject);
+	if (referenced !== undefined) {
+		const pullRequest = input.pullRequestsByNumber.get(referenced);
+		if (pullRequest) return { kind: "pull-request", pullRequest };
+	}
+
+	const normalized = normalizeSubject(commit.subject);
+	const accepted = (input.candidatesBySha.get(commit.sha) ?? [])
+		.filter(candidate => candidate.commitSubjects.some(subject => normalizeSubject(subject) === normalized))
+		.filter(candidate => shippedCoverage(candidate, shippedSubjects) >= SHIPPED_COVERAGE_THRESHOLD)
+		.sort((left, right) => left.commitSubjects.length - right.commitSubjects.length || left.number - right.number);
+
+	const smallest = accepted[0];
+	return smallest ? { kind: "pull-request", pullRequest: smallest } : { kind: "commit", commit };
+}
+
+export function buildReleaseNotes(input: ReleaseNotesInput): string {
+	const repoUrl = `https://github.com/${input.repo}`;
+	const shippedSubjects = new Set(input.commits.map(commit => normalizeSubject(commit.subject)));
+
+	const lines: string[] = [];
+	const credited = new Set<number>();
+	for (const commit of input.commits) {
+		const attribution = attributeCommit(commit, input, shippedSubjects);
+		if (attribution.kind === "pull-request") {
+			const { number, title, author } = attribution.pullRequest;
+			if (credited.has(number)) continue;
+			credited.add(number);
+			lines.push(`* ${title} by @${author} in ${repoUrl}/pull/${number}`);
+			continue;
+		}
+		const { sha, subject, author } = attribution.commit;
+		lines.push(`* ${subject} by @${author} in ${repoUrl}/commit/${sha.slice(0, 10)}`);
+	}
+
+	// A contributor is new when the release contains the earliest pull request
+	// they ever merged. Ordered by that pull request so the list is stable.
+	const newContributors = [...input.firstMergedPullRequestByAuthor]
+		.filter(([, first]) => credited.has(first))
+		.sort((left, right) => left[1] - right[1]);
+
+	const sections = [`## What's Changed`, ...lines];
+	if (newContributors.length > 0) {
+		sections.push("", "## New Contributors");
+		for (const [author, first] of newContributors) {
+			sections.push(`* @${author} made their first contribution in ${repoUrl}/pull/${first}`);
+		}
+	}
+	sections.push("", `**Full Changelog**: ${repoUrl}/compare/${input.baseTag}...${input.headTag}`, "");
+	return sections.join("\n");
+}
+
+async function git(args: readonly string[]): Promise<string> {
+	const result = await $`git ${args}`.quiet().nothrow();
+	if (result.exitCode !== 0) throw new Error(`git ${args.join(" ")} failed: ${result.stderr.toString().trim()}`);
+	return result.stdout.toString();
+}
+
+async function gh(args: readonly string[]): Promise<string> {
+	const result = await $`gh ${args}`.quiet().nothrow();
+	// A commit with no associated pull request is normal, not a failure.
+	return result.exitCode === 0 ? result.stdout.toString() : "";
+}
+
+async function collectCommits(baseTag: string, head: string): Promise<ReleaseCommit[]> {
+	const raw = await git(["log", "--no-merges", "--reverse", "--format=%H%x1f%s%x1f%an", `${baseTag}..${head}`]);
+	const commits: ReleaseCommit[] = [];
+	for (const line of raw.split("\n")) {
+		if (line.trim() === "") continue;
+		const [sha, subject, author] = line.split("\x1f");
+		if (sha === undefined || subject === undefined || author === undefined) continue;
+		// The release script's own version bump is machinery, not a change.
+		if (BUMP_SUBJECT.test(subject)) continue;
+		commits.push({ sha, subject, author });
+	}
+	return commits;
+}
+
+async function cherryPickOrigin(sha: string): Promise<string> {
+	const body = await git(["show", "-s", "--format=%b", sha]);
+	return body.match(/cherry picked from commit ([0-9a-f]{40})/u)?.[1] ?? sha;
+}
+
+async function loadPullRequest(repo: string, number: number): Promise<CandidatePullRequest | undefined> {
+	const raw = await gh(["pr", "view", String(number), "--repo", repo, "--json", "number,title,author,commits"]);
+	if (raw.trim() === "") return undefined;
+	const parsed = JSON.parse(raw) as {
+		number: number;
+		title: string;
+		author: { login: string };
+		commits: { messageHeadline: string }[];
+	};
+	return {
+		number: parsed.number,
+		title: parsed.title,
+		author: parsed.author.login,
+		commitSubjects: parsed.commits.map(commit => commit.messageHeadline),
+	};
+}
+
+async function candidateNumbers(repo: string, sha: string): Promise<number[]> {
+	const raw = await gh(["api", `repos/${repo}/commits/${sha}/pulls`, "--jq", "[.[]|select(.merged_at!=null)|.number]"]);
+	if (raw.trim() === "") return [];
+	return JSON.parse(raw) as number[];
+}
+
+async function firstMergedPullRequest(repo: string, author: string): Promise<number | undefined> {
+	const raw = await gh([
+		"search", "prs", "--repo", repo, "--author", author, "--merged",
+		"--sort", "created", "--order", "asc", "--limit", "1", "--json", "number",
+	]);
+	if (raw.trim() === "") return undefined;
+	return (JSON.parse(raw) as { number: number }[])[0]?.number;
+}
+
+export async function deriveReleaseNotes(repo: string, baseTag: string, head: string, headTag: string): Promise<string> {
+	const commits = await collectCommits(baseTag, head);
+	const pullRequestsByNumber = new Map<number, CandidatePullRequest>();
+	const candidatesBySha = new Map<string, readonly CandidatePullRequest[]>();
+
+	const ensure = async (number: number): Promise<CandidatePullRequest | undefined> => {
+		const cached = pullRequestsByNumber.get(number);
+		if (cached) return cached;
+		const loaded = await loadPullRequest(repo, number);
+		if (loaded) pullRequestsByNumber.set(number, loaded);
+		return loaded;
+	};
+
+	for (const commit of commits) {
+		const referenced = parseSubjectPullRequestRef(commit.subject);
+		if (referenced !== undefined && (await ensure(referenced))) continue;
+		const candidates: CandidatePullRequest[] = [];
+		for (const number of await candidateNumbers(repo, await cherryPickOrigin(commit.sha))) {
+			const loaded = await ensure(number);
+			if (loaded) candidates.push(loaded);
+		}
+		candidatesBySha.set(commit.sha, candidates);
+	}
+
+	const shippedSubjects = new Set(commits.map(commit => normalizeSubject(commit.subject)));
+	const firstMergedPullRequestByAuthor = new Map<string, number>();
+	for (const commit of commits) {
+		const attribution = attributeCommit(commit, { candidatesBySha, pullRequestsByNumber }, shippedSubjects);
+		if (attribution.kind !== "pull-request") continue;
+		const { author } = attribution.pullRequest;
+		if (firstMergedPullRequestByAuthor.has(author)) continue;
+		const first = await firstMergedPullRequest(repo, author);
+		if (first !== undefined) firstMergedPullRequestByAuthor.set(author, first);
+	}
+
+	return buildReleaseNotes({
+		repo,
+		baseTag,
+		headTag,
+		commits,
+		candidatesBySha,
+		pullRequestsByNumber,
+		firstMergedPullRequestByAuthor,
+	});
+}
+
+export interface ReleaseNotesCli {
+	repo: string;
+	base: string;
+	head: string;
+	headTag: string;
+	out?: string;
+}
+
+export function parseReleaseNotesCli(argv: readonly string[]): ReleaseNotesCli {
+	const values = new Map<string, string>();
+	for (let index = 0; index < argv.length; index += 2) {
+		const flag = argv[index];
+		const value = argv[index + 1];
+		if (flag === undefined || !flag.startsWith("--") || value === undefined) {
+			throw new Error("Usage: release-notes.ts --base <tag> --head <rev> --repo <owner/name> [--head-tag <tag>] [--out <path>]");
+		}
+		values.set(flag.slice(2), value);
+	}
+	const repo = values.get("repo");
+	const base = values.get("base");
+	if (repo === undefined || base === undefined) throw new Error("--repo and --base are required");
+	const head = values.get("head") ?? "HEAD";
+	return { repo, base, head, headTag: values.get("head-tag") ?? head, out: values.get("out") };
+}
+
+if (import.meta.main) {
+	try {
+		const cli = parseReleaseNotesCli(process.argv.slice(2));
+		const notes = await deriveReleaseNotes(cli.repo, cli.base, cli.head, cli.headTag);
+		if (cli.out === undefined) process.stdout.write(notes);
+		else await Bun.write(cli.out, notes);
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exitCode = 1;
+	}
+}

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -38,8 +38,13 @@ const BUMP_SUBJECT = /^chore: bump version to /u;
 export interface ReleaseCommit {
 	sha: string;
 	subject: string;
-	/** GitHub login to credit when no pull request is attributed. */
+	/**
+	 * Git author display name from `%an`. It is NOT a GitHub login and must
+	 * never be rendered as an `@` mention without a resolved `githubLogin`.
+	 */
 	author: string;
+	/** Resolved GitHub login for the author, when the API provides one. */
+	githubLogin?: string;
 }
 
 export interface CandidatePullRequest {
@@ -128,8 +133,11 @@ export function buildReleaseNotes(input: ReleaseNotesInput): string {
 			lines.push(`* ${title} by @${author} in ${repoUrl}/pull/${number}`);
 			continue;
 		}
-		const { sha, subject, author } = attribution.commit;
-		lines.push(`* ${subject} by @${author} in ${repoUrl}/commit/${sha.slice(0, 10)}`);
+		const { sha, subject, author, githubLogin } = attribution.commit;
+		// A Git display name is not a GitHub login: rendering it as `@name`
+		// would publish an invalid or misleading mention.
+		const credit = githubLogin !== undefined ? `@${githubLogin}` : author;
+		lines.push(`* ${subject} by ${credit} in ${repoUrl}/commit/${sha.slice(0, 10)}`);
 	}
 
 	// A contributor is new when the release contains the earliest pull request
@@ -243,6 +251,18 @@ async function firstMergedPullRequest(repo: string, author: string): Promise<num
 	return (JSON.parse(raw) as { number: number }[])[0]?.number;
 }
 
+/**
+ * Resolves the GitHub login authoring a commit. The API reports `null` when
+ * the commit email is not linked to any account; that is an explicit answer,
+ * not a failure, and yields `undefined` (the caller renders the Git display
+ * name without `@`). Transport/API failures throw via the strict gh path.
+ */
+async function resolveCommitLogin(repo: string, sha: string): Promise<string | undefined> {
+	const raw = await gh(["api", `repos/${repo}/commits/${sha}`, "--jq", ".author.login // \"\""]);
+	const login = raw.trim();
+	return login === "" || login === "null" ? undefined : login;
+}
+
 export async function deriveReleaseNotes(repo: string, baseTag: string, head: string, headTag: string): Promise<string> {
 	const commits = await collectCommits(baseTag, head);
 	const pullRequestsByNumber = new Map<number, CandidatePullRequest>();
@@ -271,7 +291,12 @@ export async function deriveReleaseNotes(repo: string, baseTag: string, head: st
 	const firstMergedPullRequestByAuthor = new Map<string, number>();
 	for (const commit of commits) {
 		const attribution = attributeCommit(commit, { candidatesBySha, pullRequestsByNumber }, shippedSubjects);
-		if (attribution.kind !== "pull-request") continue;
+		if (attribution.kind !== "pull-request") {
+			// Fallback commits credit by login only when one is resolved;
+			// otherwise the Git display name is rendered without `@`.
+			commit.githubLogin = await resolveCommitLogin(repo, await cherryPickOrigin(commit.sha));
+			continue;
+		}
 		const { author } = attribution.pullRequest;
 		if (firstMergedPullRequestByAuthor.has(author)) continue;
 		const first = await firstMergedPullRequest(repo, author);

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -155,10 +155,41 @@ async function git(args: readonly string[]): Promise<string> {
 	return result.stdout.toString();
 }
 
+/** stderr patterns that mean "definitely nothing exists", not "lookup failed". */
+const EXPLICIT_EMPTY_PATTERNS: readonly RegExp[] = [
+	/could not resolve to a PullRequest/iu,
+	/no pull requests? found/iu,
+];
+
+/**
+ * True only for an explicit no-result response: a successful exit, or a
+ * failure whose stderr positively identifies "does not exist". Anything else
+ * (auth, transport, rate limit, server error) must fail closed, because
+ * deriving notes from a partially reachable GitHub silently drops attribution
+ * and new-contributor detection, and the release cannot be redone once the
+ * published packages are immutable.
+ */
+export function isExplicitEmptyGhResult(exitCode: number, stderr: string): boolean {
+	if (exitCode === 0) return true;
+	return EXPLICIT_EMPTY_PATTERNS.some(pattern => pattern.test(stderr));
+}
+
 async function gh(args: readonly string[]): Promise<string> {
 	const result = await $`gh ${args}`.quiet().nothrow();
-	// A commit with no associated pull request is normal, not a failure.
-	return result.exitCode === 0 ? result.stdout.toString() : "";
+	if (result.exitCode !== 0) {
+		throw new Error(`gh ${args.join(" ")} failed (exit ${result.exitCode}): ${result.stderr.toString().trim()}`);
+	}
+	return result.stdout.toString();
+}
+
+async function ghAllowExplicitEmpty(args: readonly string[]): Promise<string | undefined> {
+	const result = await $`gh ${args}`.quiet().nothrow();
+	if (result.exitCode !== 0) {
+		const stderr = result.stderr.toString().trim();
+		if (isExplicitEmptyGhResult(result.exitCode, stderr)) return undefined;
+		throw new Error(`gh ${args.join(" ")} failed (exit ${result.exitCode}): ${stderr}`);
+	}
+	return result.stdout.toString();
 }
 
 async function collectCommits(baseTag: string, head: string): Promise<ReleaseCommit[]> {
@@ -181,8 +212,8 @@ async function cherryPickOrigin(sha: string): Promise<string> {
 }
 
 async function loadPullRequest(repo: string, number: number): Promise<CandidatePullRequest | undefined> {
-	const raw = await gh(["pr", "view", String(number), "--repo", repo, "--json", "number,title,author,commits"]);
-	if (raw.trim() === "") return undefined;
+	const raw = await ghAllowExplicitEmpty(["pr", "view", String(number), "--repo", repo, "--json", "number,title,author,commits"]);
+	if (raw === undefined || raw.trim() === "") return undefined;
 	const parsed = JSON.parse(raw) as {
 		number: number;
 		title: string;

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -19,8 +19,9 @@
  *     can still be the only candidate.
  *
  * So a candidate pull request is accepted only when this release actually
- * ships it (see `SHIPPED_COVERAGE_THRESHOLD`); otherwise the entry falls back
- * to a commit link, which can never advertise unshipped work.
+ * ships it (see `SHIPPED_COVERAGE_THRESHOLD`), including the squash/merge OID
+ * GitHub assigns when a PR lands; otherwise the entry falls back to a commit
+ * link, which can never advertise unshipped work.
  *
  * Usage:
  *   bun scripts/release-notes.ts --base <tag> --head <rev> --repo <owner/name> --out <path>
@@ -57,6 +58,8 @@ export interface CandidatePullRequest {
 	commitSubjects: readonly string[];
 	/** OIDs of every commit the pull request contains (coverage is by identity). */
 	commitOids: readonly string[];
+	/** Squash or merge commit OID on the target repository, when GitHub provides it. */
+	mergeCommitOid?: string;
 }
 
 export type Attribution =
@@ -88,11 +91,14 @@ export function parseSubjectPullRequestRef(subject: string): number | undefined 
 
 /**
  * Share of `pullRequest`'s commits this release ships, compared by commit
- * OID (cherry-pick origins included). Subject text cannot be used here:
+ * OID (cherry-pick origins included). A shipped squash/merge OID is definitive
+ * evidence even when none of the branch commit OIDs survive on the target
+ * branch. Subject text cannot be used here:
  * duplicate subjects would count one shipped commit multiple times and push
  * a partially shipped candidate over the credit threshold.
  */
 export function shippedCoverage(pullRequest: CandidatePullRequest, shippedOids: ReadonlySet<string>): number {
+	if (pullRequest.mergeCommitOid !== undefined && shippedOids.has(pullRequest.mergeCommitOid)) return 1;
 	if (pullRequest.commitOids.length === 0) return 0;
 	let shipped = 0;
 	for (const oid of pullRequest.commitOids) {
@@ -104,8 +110,9 @@ export function shippedCoverage(pullRequest: CandidatePullRequest, shippedOids: 
 /**
  * A subject-embedded `(#N)` identifies the intended pull request, but it is
  * credited only when the release ships at least the same coverage threshold
- * as an API-discovered candidate. Otherwise the smallest candidate this
- * release actually ships wins, and an unshipped candidate is rejected.
+ * as an API-discovered candidate, including its squash/merge OID. Otherwise
+ * the smallest candidate this release actually ships wins, and an unshipped
+ * candidate is rejected.
  */
 export function attributeCommit(
 	commit: ReleaseCommit,
@@ -243,12 +250,15 @@ async function loadPullRequest(repo: string, number: number): Promise<CandidateP
 		author: { login: string };
 		commits: { messageHeadline: string; oid: string }[];
 	};
+	const mergeCommitRaw = await gh(["api", `repos/${repo}/pulls/${number}`, "--jq", ".merge_commit_sha // \"\""]);
+	const mergeCommitOid = mergeCommitRaw.trim();
 	return {
 		number: parsed.number,
 		title: parsed.title,
 		author: parsed.author.login,
 		commitSubjects: parsed.commits.map(commit => commit.messageHeadline),
 		commitOids: parsed.commits.map(commit => commit.oid),
+		...(mergeCommitOid === "" ? {} : { mergeCommitOid }),
 	};
 }
 

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -102,9 +102,10 @@ export function shippedCoverage(pullRequest: CandidatePullRequest, shippedOids: 
 }
 
 /**
- * A subject-embedded `(#N)` is authoritative: the merge that produced the
- * commit wrote it. Otherwise the smallest candidate this release actually
- * ships wins, and an unshipped candidate is rejected outright.
+ * A subject-embedded `(#N)` identifies the intended pull request, but it is
+ * credited only when the release ships at least the same coverage threshold
+ * as an API-discovered candidate. Otherwise the smallest candidate this
+ * release actually ships wins, and an unshipped candidate is rejected.
  */
 export function attributeCommit(
 	commit: ReleaseCommit,
@@ -115,7 +116,9 @@ export function attributeCommit(
 	const referenced = parseSubjectPullRequestRef(commit.subject);
 	if (referenced !== undefined) {
 		const pullRequest = input.pullRequestsByNumber.get(referenced);
-		if (pullRequest) return { kind: "pull-request", pullRequest };
+		if (pullRequest && shippedCoverage(pullRequest, shippedOids) >= SHIPPED_COVERAGE_THRESHOLD) {
+			return { kind: "pull-request", pullRequest };
+		}
 	}
 
 	const normalized = normalizeSubject(commit.subject);
@@ -250,9 +253,15 @@ async function loadPullRequest(repo: string, number: number): Promise<CandidateP
 }
 
 async function candidateNumbers(repo: string, sha: string): Promise<number[]> {
-	const raw = await gh(["api", `repos/${repo}/commits/${sha}/pulls`, "--jq", "[.[]|select(.merged_at!=null)|.number]"]);
+	const raw = await gh([
+		"api",
+		"--paginate",
+		`repos/${repo}/commits/${sha}/pulls?per_page=100`,
+		"--jq",
+		".[] | select(.merged_at != null) | .number",
+	]);
 	if (raw.trim() === "") return [];
-	return JSON.parse(raw) as number[];
+	return raw.trim().split(/\s+/u).map(Number);
 }
 
 /** Picks the earliest MERGED pull request by merge timestamp, not creation time. */
@@ -267,14 +276,19 @@ export function earliestMergedPullRequest(pullRequests: readonly { number: numbe
 }
 
 async function firstMergedPullRequest(repo: string, author: string): Promise<number | undefined> {
-	// The search API cannot sort by merge time, so fetch a bounded created-asc
-	// window and select the minimum merge timestamp.
+	// The search API cannot sort by merge time and its CLI JSON surface does not
+	// expose merge timestamps reliably. Paginate the REST search results and
+	// select the minimum explicit merge timestamp across the complete result set.
 	const raw = await gh([
-		"search", "prs", "--repo", repo, "--author", author, "--merged",
-		"--sort", "created", "--order", "asc", "--limit", "50", "--json", "number,mergedAt",
+		"api",
+		"--paginate",
+		`search/issues?q=repo:${repo}+author:${author}+is:pr+is:merged&sort=created&order=asc&per_page=100`,
+		"--jq",
+		".items[] | select(.pull_request.merged_at != null) | {number, mergedAt: .pull_request.merged_at} | @json",
 	]);
 	if (raw.trim() === "") return undefined;
-	return earliestMergedPullRequest(JSON.parse(raw) as { number: number; mergedAt: string }[]);
+	const pullRequests = raw.trim().split(/\r?\n/u).map(line => JSON.parse(line) as { number: number; mergedAt: string });
+	return earliestMergedPullRequest(pullRequests);
 }
 
 /**

--- a/scripts/release-policy.test.ts
+++ b/scripts/release-policy.test.ts
@@ -151,6 +151,39 @@ describe("stable release policy", () => {
 		expect(notes).toContain(': > "$notes"');
 	});
 
+	test("gates stable tag releases on protected-main provenance and the approval environment", async () => {
+		const ci = await workflow();
+		const metadata = jobSection(ci, "release_metadata");
+		const publish = jobSection(ci, "publish");
+
+		// The tagged SHA must provably sit on the fetched origin/main line before
+		// anything in the release graph can run (publish needs release_metadata).
+		expect(metadata).toContain("Validate stable tag protected-main provenance");
+		expect(metadata).toContain("+refs/heads/main:refs/remotes/origin/main");
+		expect(metadata).toContain('git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main');
+		expect(publish).toContain("needs: [release_prepare, release_metadata]");
+
+		// The publish job is wired to the owner-protected approval environment;
+		// its protection rules are repository settings, not tag-resolved YAML.
+		expect(publish).toContain("environment: npm-release");
+	});
+
+	test("pins the OIDC-capable Node bootstrap to an exact patch", async () => {
+		const ci = await workflow();
+		const publish = jobSection(ci, "publish");
+
+		expect(publish).toContain('node-version: "24.19.0"');
+		expect(publish).not.toContain('node-version: "24"');
+		expect(publish).not.toMatch(/node-version: "24\.[x*]/u);
+	});
+
+	test("keeps the release regression suites on the normal release CI path", async () => {
+		const manifest = JSON.parse(await Bun.file(path.join(repoRoot, "package.json")).text()) as { scripts: Record<string, string> };
+		const release = manifest.scripts["test:release"];
+		expect(release).toContain("scripts/release-notes.test.ts");
+		expect(release).toContain("scripts/release-retry.test.ts");
+	});
+
 	test("the publish job carries the stable finalization job name", async () => {
 		const ci = await workflow();
 		// release.ts watches this exact job to confirm the release finalized.

--- a/scripts/release-policy.test.ts
+++ b/scripts/release-policy.test.ts
@@ -151,7 +151,7 @@ describe("stable release policy", () => {
 		expect(notes).toContain(': > "$notes"');
 	});
 
-	test("gates stable tag releases on protected-main provenance and the approval environment", async () => {
+	test("gates stable tag releases on protected-main provenance with a ref-scoped OIDC subject", async () => {
 		const ci = await workflow();
 		const metadata = jobSection(ci, "release_metadata");
 		const publish = jobSection(ci, "publish");
@@ -163,9 +163,26 @@ describe("stable release policy", () => {
 		expect(metadata).toContain('git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main');
 		expect(publish).toContain("needs: [release_prepare, release_metadata]");
 
-		// The publish job is wired to the owner-protected approval environment;
-		// its protection rules are repository settings, not tag-resolved YAML.
-		expect(publish).toContain("environment: npm-release");
+		// The OIDC subject must stay ref-scoped: an `environment:` would change
+		// the token subject away from the identity the npm trusted-publisher
+		// registrations (and the shipped v0.14.1 exchange) already prove. Owner
+		// prerequisites (main ruleset, v* tag-creation ruleset) are documented
+		// on the job instead.
+		expect(publish).not.toContain("environment:");
+	});
+
+	test("runs no repository-controlled installation inside the credential-bearing publish job", async () => {
+		const ci = await workflow();
+		const publish = jobSection(ci, "publish");
+
+		// No dependency installation, cache, or package lifecycle scripts may
+		// execute where contents: write and id-token: write are both live; the
+		// checkout must not persist the workflow token either.
+		expect(publish).toContain("persist-credentials: false");
+		expect(publish).not.toContain("bun install");
+		expect(publish).not.toContain("actions/cache@");
+		expect(publish).not.toContain("npm ci");
+		expect(publish).not.toContain("node_modules");
 	});
 
 	test("pins the OIDC-capable Node bootstrap to an exact patch", async () => {

--- a/scripts/release-policy.test.ts
+++ b/scripts/release-policy.test.ts
@@ -25,24 +25,26 @@ function jobSection(workflowText: string, jobName: string): string {
 }
 
 describe("stable release policy", () => {
-	test("tag releases resolve metadata, build natives, then binaries, then publish npm + the GitHub Release", async () => {
+	test("tag releases resolve metadata, build natives, then binaries, then prepare, then publish npm + the GitHub Release", async () => {
 		const ci = await workflow();
-		const stages = ["release_metadata", "native", "binaries", "publish"];
+		const stages = ["release_metadata", "native", "binaries", "release_prepare", "publish"];
 		const positions = stages.map(stage => ci.indexOf(`   ${stage}:`));
 		for (const position of positions) expect(position).toBeGreaterThanOrEqual(0);
 
 		expect(jobSection(ci, "native")).toContain("needs: [release_metadata]");
 		expect(jobSection(ci, "binaries")).toContain("needs: [native, release_metadata]");
-		expect(jobSection(ci, "publish")).toContain("needs: [native, binaries, release_metadata, nightly_gate]");
+		expect(jobSection(ci, "release_prepare")).toContain("needs: [native, binaries, release_metadata, nightly_gate]");
+		expect(jobSection(ci, "publish")).toContain("needs: [release_prepare, release_metadata]");
 		for (const stage of ["native", "binaries"]) {
 			const section = jobSection(ci, stage);
 			expect(section).toContain("startsWith(github.ref, 'refs/tags/v')");
 			expect(section).toContain("inputs.rehearsal == 'tag-build-verify'");
 		}
+		const prepare = jobSection(ci, "release_prepare");
+		expect(prepare).toContain("needs.release_metadata.outputs.channel == 'stable'");
+		expect(prepare).toContain("github.event_name != 'workflow_dispatch'");
+		expect(prepare).toContain("--prepare-evidence --evidence-dir");
 		const publish = jobSection(ci, "publish");
-		expect(publish).toContain("needs.release_metadata.outputs.channel == 'stable'");
-		expect(publish).toContain("github.event_name != 'workflow_dispatch'");
-		expect(publish).toContain("--prepare-evidence --evidence-dir");
 		expect(publish).toContain("--publish-from-evidence");
 		expect(publish).toContain("gajae-production-release");
 		expect(publish).toContain("softprops/action-gh-release");
@@ -72,8 +74,81 @@ describe("stable release policy", () => {
 		expect(publish).not.toContain("~/.npmrc");
 
 		// OIDC needs the identity token and an npm new enough to exchange it.
+		// The CLI pin is exact and integrity-verifiable: a mutable range inside
+		// the credential-bearing job would let a drifting or compromised CLI
+		// publish.
 		expect(publish).toContain("id-token: write");
-		expect(publish).toContain("npm install -g npm@^11.5.1");
+		expect(publish).not.toMatch(/npm@[\^~]/u);
+		expect(publish).toContain('NPM_PIN_VERSION: "11.5.1"');
+		expect(publish).toContain("NPM_TARBALL_SHA512:");
+		expect(publish).toContain("sha512sum --check --strict");
+		expect(publish).toContain('npm install -g "$tmp/npm-${NPM_PIN_VERSION}.tgz"');
+		expect(publish).toContain('test "$(npm --version)" = "$NPM_PIN_VERSION"');
+	});
+
+	test("splits credential-free preparation from the minimal OIDC publish boundary", async () => {
+		const ci = await workflow();
+		const prepare = jobSection(ci, "release_prepare");
+		const publish = jobSection(ci, "publish");
+
+		// The preparation job does everything untrusted (dependency installs,
+		// repository scripts, GitHub API reads) with read-only scopes and must
+		// never hold the OIDC identity token or any write scope.
+		expect(prepare).toContain("contents: read");
+		expect(prepare).toContain("pull-requests: read");
+		expect(prepare).not.toContain("id-token");
+		expect(prepare).not.toMatch(/:\s*write/u);
+
+		// The publish job holds the only credentials and performs only the
+		// irreversible steps; it never talks to the pull-request API itself.
+		expect(publish).toContain("contents: write");
+		expect(publish).toContain("id-token: write");
+		expect(publish).not.toContain("pull-requests");
+		expect(publish).not.toContain("release-notes.ts");
+		expect(publish).toContain("needs: [release_prepare, release_metadata]");
+	});
+
+	test("resolves and validates release notes before the irreversible npm publication", async () => {
+		const ci = await workflow();
+		const prepare = jobSection(ci, "release_prepare");
+		const publish = jobSection(ci, "publish");
+
+		// Notes derivation (history fetch + GitHub API + generation) lives in the
+		// preparation job, so any failure aborts the run before packages ship.
+		expect(prepare).toContain("Derive and validate release notes");
+		expect(prepare).toContain("bun scripts/release-notes.ts");
+		// The persisted body must be deterministic: a second derivation has to
+		// reproduce it byte-for-byte.
+		expect(prepare).toContain("cmp --silent");
+		// The publish job consumes only the integrity-checked artifact and never
+		// regenerates the body.
+		expect(publish).toContain("Download validated release notes");
+		expect(publish).toContain("Verify release notes integrity");
+		expect(publish.indexOf("Verify release notes integrity")).toBeLessThan(publish.indexOf("Publish packages to npm"));
+		expect(publish).toContain("body_path: ${{ runner.temp }}/release-notes/release-notes.md");
+		expect(publish).toContain("generate_release_notes: false");
+		// publish needs release_prepare, which guarantees notes exist and passed
+		// validation before npm publish can start.
+		expect(publish).toContain("needs.release_prepare.result == 'success'");
+	});
+
+	test("selects the previous release anchor as an exact stable ancestor tag with a shell-safe empty fallback", async () => {
+		const ci = await workflow();
+		const prepare = jobSection(ci, "release_prepare");
+		const notesStart = prepare.indexOf("Derive and validate release notes");
+		expect(notesStart).toBeGreaterThanOrEqual(0);
+		const notes = prepare.slice(notesStart);
+
+		// Exact stable vX.Y.Z only: nightly/RC/unrelated tags cannot anchor the range.
+		expect(notes).toContain("^v[0-9]+\\.[0-9]+\\.[0-9]+$");
+		// Ancestor-only: a tag that does not lead to this release head is rejected.
+		expect(notes).toContain('git merge-base --is-ancestor "$tag" "$SOURCE_SHA"');
+		// The current release tag is never its own base.
+		expect(notes).toContain('[ "$tag" = "$TAG_NAME" ] && continue');
+		// No-candidate is the documented empty-notes fallback, implemented without
+		// pipelines that pipefail would turn into an abort (grep -vFx exits 1).
+		expect(notes).not.toContain("grep -vFx");
+		expect(notes).toContain(': > "$notes"');
 	});
 
 	test("the publish job carries the stable finalization job name", async () => {
@@ -157,6 +232,7 @@ describe("stable release policy", () => {
 		const gate = jobSection(ci, "nightly_gate");
 		const native = jobSection(ci, "native");
 		const binaries = jobSection(ci, "binaries");
+		const prepare = jobSection(ci, "release_prepare");
 		const publish = jobSection(ci, "publish");
 		const nativeAction = await Bun.file(path.join(repoRoot, ".github/actions/build-native/action.yml")).text();
 
@@ -178,17 +254,20 @@ describe("stable release policy", () => {
 		expect(nativeAction).toContain("bun scripts/nightly-release.ts stage");
 		expect(nativeAction).toContain("PI_NATIVE_PROFILE:");
 		expect(binaries).toContain("Stage nightly release version");
-		expect(publish).toContain("needs.nightly_gate.result == 'success'");
+		expect(prepare).toContain("needs.nightly_gate.result == 'success'");
+		expect(prepare).toContain("Stage nightly release version");
+		expect(prepare).toContain("Persist pre-publication package evidence");
+		expect(prepare).toContain("release-evidence-${{ needs.release_metadata.outputs.version }}");
+		expect(prepare).toContain("Reject pre-existing release tag or release");
+		expect(prepare).toContain("refusing upsert");
+		expect(prepare).toContain("$2 ~ /\\^\\{\\}$/");
+		expect(prepare).not.toContain("same-run retry");
+		// Every preparation-side validation lands before the publish job can run.
+		expect(prepare.indexOf("Reject pre-existing release tag or release")).toBeLessThan(prepare.indexOf("Derive and validate release notes"));
 		expect(publish).toContain("--release-channel \"$RELEASE_CHANNEL\"");
-		expect(publish).toContain("Persist pre-publication package evidence");
-		expect(publish).toContain("release-evidence-${{ needs.release_metadata.outputs.version }}");
-		expect(publish).toContain("Reject pre-existing release tag or release");
-		expect(publish).toContain("refusing upsert");
-		expect(publish).toContain("$2 ~ /\\^\\{\\}$/");
-		expect(publish).not.toContain("same-run retry");
 		expect(publish).toContain("fail_on_unmatched_files: true");
 		expect(publish).toContain("Verify immutable GitHub Release");
-		expect(publish.indexOf("Reject pre-existing release tag or release")).toBeLessThan(publish.indexOf("Publish packages to npm"));
+		expect(publish.indexOf("Publish packages to npm")).toBeLessThan(publish.indexOf("Create GitHub Release"));
 		expect(publish).toContain("gajae-nightly-release");
 		expect(publish).toContain("prerelease: ${{ needs.release_metadata.outputs.channel == 'nightly' }}");
 		expect(publish).toContain("make_latest: ${{ needs.release_metadata.outputs.channel != 'nightly' }}");

--- a/scripts/release-policy.test.ts
+++ b/scripts/release-policy.test.ts
@@ -25,17 +25,17 @@ function jobSection(workflowText: string, jobName: string): string {
 }
 
 describe("stable release policy", () => {
-	test("tag releases resolve metadata, build natives, then binaries, then prepare, then publish npm + the GitHub Release", async () => {
+	test("tag releases resolve metadata, build natives, then binaries, then prepare, then publish npm, then finalize the GitHub Release", async () => {
 		const ci = await workflow();
-		const stages = ["release_metadata", "native", "binaries", "release_prepare", "publish"];
+		const stages = ["release_metadata", "native", "binaries", "release_prepare", "release_approval", "publish", "release_finalize"];
 		const positions = stages.map(stage => ci.indexOf(`   ${stage}:`));
 		for (const position of positions) expect(position).toBeGreaterThanOrEqual(0);
 
 		expect(jobSection(ci, "native")).toContain("needs: [release_metadata]");
 		expect(jobSection(ci, "binaries")).toContain("needs: [native, release_metadata]");
 		expect(jobSection(ci, "release_prepare")).toContain("needs: [native, binaries, release_metadata, nightly_gate]");
-		expect(jobSection(ci, "release_prepare")).toContain("needs: [native, binaries, release_metadata, nightly_gate]");
 		expect(jobSection(ci, "publish")).toContain("needs: [release_prepare, release_approval, release_metadata]");
+		expect(jobSection(ci, "release_finalize")).toContain("needs: [publish, release_metadata]");
 		for (const stage of ["native", "binaries"]) {
 			const section = jobSection(ci, stage);
 			expect(section).toContain("startsWith(github.ref, 'refs/tags/v')");
@@ -46,10 +46,10 @@ describe("stable release policy", () => {
 		expect(prepare).toContain("github.event_name != 'workflow_dispatch'");
 		expect(prepare).toContain("--prepare-evidence --evidence-dir");
 		const publish = jobSection(ci, "publish");
-		expect(publish).toContain("--publish-from-evidence");
-		expect(publish).toContain("gajae-production-release");
-		expect(publish).toContain("softprops/action-gh-release");
-		expect(publish).toContain("draft: false");
+		expect(publish).toContain("Publish sealed tarballs to npm");
+		const finalize = jobSection(ci, "release_finalize");
+		expect(finalize).toContain("softprops/action-gh-release");
+		expect(finalize).toContain("draft: false");
 	});
 
 	test("stable tags and nightly publication lanes are non-cancelling", async () => {
@@ -100,9 +100,10 @@ describe("stable release policy", () => {
 		expect(prepare).not.toContain("id-token");
 		expect(prepare).not.toMatch(/:\s*write/u);
 
-		// The publish job holds the only credentials and performs only the
-		// irreversible steps; it never talks to the pull-request API itself.
-		expect(publish).toContain("contents: write");
+		// The publish job holds only the OIDC identity token — no repository
+		// scope — and performs only the irreversible publication from the fixed
+		// boundary.
+		expect(publish).not.toContain("contents: write");
 		expect(publish).toContain("id-token: write");
 		expect(publish).not.toContain("pull-requests");
 		expect(publish).not.toContain("release-notes.ts");
@@ -121,13 +122,14 @@ describe("stable release policy", () => {
 		// The persisted body must be deterministic: a second derivation has to
 		// reproduce it byte-for-byte.
 		expect(prepare).toContain("cmp --silent");
-		// The publish job consumes only the integrity-checked artifact and never
+		// The finalize job consumes only the integrity-checked artifact and never
 		// regenerates the body.
-		expect(publish).toContain("Download validated release notes");
-		expect(publish).toContain("Verify release notes integrity");
-		expect(publish.indexOf("Verify release notes integrity")).toBeLessThan(publish.indexOf("Publish packages to npm"));
-		expect(publish).toContain("body_path: ${{ runner.temp }}/release-notes/release-notes.md");
-		expect(publish).toContain("generate_release_notes: false");
+		const finalize = jobSection(ci, "release_finalize");
+		expect(finalize).toContain("Download validated release notes");
+		expect(finalize).toContain("Verify release notes integrity");
+		expect(finalize.indexOf("Verify release notes integrity")).toBeLessThan(finalize.indexOf("Create GitHub Release"));
+		expect(finalize).toContain("body_path: ${{ runner.temp }}/release-notes/release-notes.md");
+		expect(finalize).toContain("generate_release_notes: false");
 		// publish needs release_prepare (via release_approval), which guarantees
 		// notes exist and passed validation before npm publish can start.
 		expect(publish).toContain("needs.release_approval.result == 'success'");
@@ -172,18 +174,25 @@ describe("stable release policy", () => {
 		expect(publish).not.toContain("environment:");
 	});
 
-	test("runs no repository-controlled installation inside the credential-bearing publish job", async () => {
+	test("executes no checkout-controlled code inside the OIDC publish boundary", async () => {
 		const ci = await workflow();
 		const publish = jobSection(ci, "publish");
 
-		// No dependency installation, cache, or package lifecycle scripts may
-		// execute where contents: write and id-token: write are both live; the
-		// checkout must not persist the workflow token either.
-		expect(publish).toContain("persist-credentials: false");
+		// The fixed publisher boundary: no checkout, no repository code, no
+		// dependency installation, no cache — only pinned actions and workflow
+		// shell operate on sha512-sealed artifacts.
+		expect(publish).not.toContain("actions/checkout@");
+		expect(publish).not.toContain("setup-bun@");
+		expect(publish).not.toContain("bun ");
+		expect(publish).not.toContain("scripts/");
 		expect(publish).not.toContain("bun install");
 		expect(publish).not.toContain("actions/cache@");
 		expect(publish).not.toContain("npm ci");
 		expect(publish).not.toContain("node_modules");
+		// The boundary re-verifies the sealed tarball bytes before publishing.
+		expect(publish).toContain("Publish sealed tarballs to npm");
+		expect(publish).toContain("sha512sum --check --strict");
+		expect(publish).toContain("gajae-release-oidc-publish-receipt-v1.json");
 	});
 
 	test("gates the OIDC boundary on the approval environment without changing the publish subject", async () => {
@@ -246,7 +255,7 @@ describe("stable release policy", () => {
 		expect(release).toContain("scripts/release-retry.test.ts");
 	});
 
-	test("the publish job carries the stable finalization job name", async () => {
+	test("the release_finalize job carries the stable finalization job name", async () => {
 		const ci = await workflow();
 		// release.ts watches this exact job to confirm the release finalized.
 		expect(ci).toContain(`   ${STABLE_GITHUB_RELEASE_FINALIZATION_JOB_NAME}:`);
@@ -310,13 +319,13 @@ describe("stable release policy", () => {
 		expect(permissions).not.toMatch(/:\s+write(?:\s|$)/u);
 	});
 
-	// #3139 least-privilege invariant: only publish may hold contents write.
-	test("pins publish as the only job-level contents write permission", async () => {
+	// #3139 least-privilege invariant: only release_finalize may hold contents write.
+	test("pins release_finalize as the only job-level contents write permission", async () => {
 		const ci = await workflow();
 		const jobs = [...ci.slice(ci.indexOf("\njobs:")).matchAll(/^ {3}[a-z_][a-z0-9_]*:$/gmu)].map(job => job[0].trim().slice(0, -1));
 		for (const job of jobs) {
 			const section = jobSection(ci, job);
-			if (job === "publish") expect(section).toContain("contents: write");
+			if (job === "release_finalize") expect(section).toContain("contents: write");
 			else expect(section).not.toContain("contents: write");
 		}
 	});
@@ -359,16 +368,17 @@ describe("stable release policy", () => {
 		expect(prepare).not.toContain("same-run retry");
 		// Every preparation-side validation lands before the publish job can run.
 		expect(prepare.indexOf("Reject pre-existing release tag or release")).toBeLessThan(prepare.indexOf("Derive and validate release notes"));
-		expect(publish).toContain("--release-channel \"$RELEASE_CHANNEL\"");
-		expect(publish).toContain("fail_on_unmatched_files: true");
-		expect(publish).toContain("Verify immutable GitHub Release");
-		expect(publish.indexOf("Publish packages to npm")).toBeLessThan(publish.indexOf("Create GitHub Release"));
-		expect(publish).toContain("gajae-nightly-release");
-		expect(publish).toContain("prerelease: ${{ needs.release_metadata.outputs.channel == 'nightly' }}");
-		expect(publish).toContain("make_latest: ${{ needs.release_metadata.outputs.channel != 'nightly' }}");
-		expect(publish).toContain("gajae-release-packages-expected-v1.json");
-		expect(publish).toContain("gajae-release-packages-v1.json");
-		expect(publish).toContain("gajae-release-channel-v1.json");
+		expect(publish).toContain("--tag=\"$npm_tag\"");
+		const finalize = jobSection(ci, "release_finalize");
+		expect(finalize).toContain("--release-channel \"$RELEASE_CHANNEL\"");
+		expect(finalize).toContain("fail_on_unmatched_files: true");
+		expect(finalize).toContain("Verify immutable GitHub Release");
+		expect(finalize.indexOf("Assemble final release evidence")).toBeLessThan(finalize.indexOf("Create GitHub Release"));
+		expect(finalize).toContain("prerelease: ${{ needs.release_metadata.outputs.channel == 'nightly' }}");
+		expect(finalize).toContain("make_latest: ${{ needs.release_metadata.outputs.channel != 'nightly' }}");
+		expect(finalize).toContain("gajae-release-packages-expected-v1.json");
+		expect(finalize).toContain("gajae-release-packages-v1.json");
+		expect(finalize).toContain("gajae-release-channel-v1.json");
 	});
 	test("updates owned Bun lock versions without re-resolving third-party packages", () => {
 		const lock = `{

--- a/scripts/release-policy.test.ts
+++ b/scripts/release-policy.test.ts
@@ -202,6 +202,21 @@ describe("stable release policy", () => {
 		expect(publish).not.toContain("environment:");
 	});
 
+	test("keeps scheduled and manual nightlies out of the stable approval gate", async () => {
+		const ci = await workflow();
+		const approval = jobSection(ci, "release_approval");
+		const publish = jobSection(ci, "publish");
+
+		// The approval environment applies to stable releases only; nightlies
+		// stay unattended once required reviewers are configured.
+		expect(approval).toContain("needs.release_metadata.outputs.channel == 'stable'");
+		// publish runs for nightly without the approval result, but stable
+		// requires it.
+		expect(publish).toContain("needs.release_metadata.outputs.channel == 'nightly' || needs.release_approval.result == 'success'");
+		// release_approval depends on the preparation graph, not the other way.
+		expect(approval).toContain("needs: [release_prepare, release_metadata]");
+	});
+
 	test("keeps dependency resolution out of the publish dispatch", async () => {
 		const publishScript = await Bun.file(path.join(repoRoot, "scripts/ci-release-publish.ts")).text();
 

--- a/scripts/release-policy.test.ts
+++ b/scripts/release-policy.test.ts
@@ -34,7 +34,8 @@ describe("stable release policy", () => {
 		expect(jobSection(ci, "native")).toContain("needs: [release_metadata]");
 		expect(jobSection(ci, "binaries")).toContain("needs: [native, release_metadata]");
 		expect(jobSection(ci, "release_prepare")).toContain("needs: [native, binaries, release_metadata, nightly_gate]");
-		expect(jobSection(ci, "publish")).toContain("needs: [release_prepare, release_metadata]");
+		expect(jobSection(ci, "release_prepare")).toContain("needs: [native, binaries, release_metadata, nightly_gate]");
+		expect(jobSection(ci, "publish")).toContain("needs: [release_prepare, release_approval, release_metadata]");
 		for (const stage of ["native", "binaries"]) {
 			const section = jobSection(ci, stage);
 			expect(section).toContain("startsWith(github.ref, 'refs/tags/v')");
@@ -105,7 +106,7 @@ describe("stable release policy", () => {
 		expect(publish).toContain("id-token: write");
 		expect(publish).not.toContain("pull-requests");
 		expect(publish).not.toContain("release-notes.ts");
-		expect(publish).toContain("needs: [release_prepare, release_metadata]");
+		expect(publish).toContain("needs: [release_prepare, release_approval, release_metadata]");
 	});
 
 	test("resolves and validates release notes before the irreversible npm publication", async () => {
@@ -127,9 +128,9 @@ describe("stable release policy", () => {
 		expect(publish.indexOf("Verify release notes integrity")).toBeLessThan(publish.indexOf("Publish packages to npm"));
 		expect(publish).toContain("body_path: ${{ runner.temp }}/release-notes/release-notes.md");
 		expect(publish).toContain("generate_release_notes: false");
-		// publish needs release_prepare, which guarantees notes exist and passed
-		// validation before npm publish can start.
-		expect(publish).toContain("needs.release_prepare.result == 'success'");
+		// publish needs release_prepare (via release_approval), which guarantees
+		// notes exist and passed validation before npm publish can start.
+		expect(publish).toContain("needs.release_approval.result == 'success'");
 	});
 
 	test("selects the previous release anchor as an exact stable ancestor tag with a shell-safe empty fallback", async () => {
@@ -161,7 +162,7 @@ describe("stable release policy", () => {
 		expect(metadata).toContain("Validate stable tag protected-main provenance");
 		expect(metadata).toContain("+refs/heads/main:refs/remotes/origin/main");
 		expect(metadata).toContain('git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main');
-		expect(publish).toContain("needs: [release_prepare, release_metadata]");
+		expect(publish).toContain("needs: [release_prepare, release_approval, release_metadata]");
 
 		// The OIDC subject must stay ref-scoped: an `environment:` would change
 		// the token subject away from the identity the npm trusted-publisher
@@ -183,6 +184,35 @@ describe("stable release policy", () => {
 		expect(publish).not.toContain("actions/cache@");
 		expect(publish).not.toContain("npm ci");
 		expect(publish).not.toContain("node_modules");
+	});
+
+	test("gates the OIDC boundary on the approval environment without changing the publish subject", async () => {
+		const ci = await workflow();
+		const approval = jobSection(ci, "release_approval");
+		const publish = jobSection(ci, "publish");
+
+		// The approval gate runs before publish and holds the environment hook
+		// with no permissions and no OIDC token, so publish's OIDC subject stays
+		// ref-scoped and the trusted-publisher registrations remain valid.
+		expect(approval).toContain("environment: npm-release");
+		expect(approval).toContain("permissions: {}");
+		expect(approval).not.toContain("id-token");
+		expect(publish).toContain("needs: [release_prepare, release_approval, release_metadata]");
+		expect(publish).toContain("needs.release_approval.result == 'success'");
+		expect(publish).not.toContain("environment:");
+	});
+
+	test("keeps dependency resolution out of the publish dispatch", async () => {
+		const publishScript = await Bun.file(path.join(repoRoot, "scripts/ci-release-publish.ts")).text();
+
+		// Declaration checks (`bun x tsc`) resolve/execute packages: they must be
+		// dispatched only on the prepare path, never on --publish-from-evidence.
+		const prepareBranch = publishScript.slice(
+			publishScript.indexOf('command.mode === "prepare-evidence"'),
+			publishScript.indexOf("await publishFromExpectedEvidence"),
+		);
+		expect(prepareBranch).toContain("await checkTypeDeclarations()");
+		expect(publishScript.slice(publishScript.indexOf("await publishFromExpectedEvidence"))).not.toContain("checkTypeDeclarations");
 	});
 
 	test("pins the OIDC-capable Node bootstrap to an exact patch", async () => {

--- a/scripts/release-publish-order.test.ts
+++ b/scripts/release-publish-order.test.ts
@@ -342,7 +342,8 @@ describe("immutable stable release contracts", () => {
 		const tag = "v1.2.3";
 
 		expect(releaseScript).toContain('await git(["tag", "--no-sign", `v${version}`]);');
-		expect(releaseScript).toContain('["ls-remote", "origin", "refs/heads/main", `refs/tags/${tag}`, `refs/tags/${tag}^{}`]');
+		expect(releaseScript).toContain('const remoteRefs = ["refs/heads/main", `refs/tags/${tag}`, `refs/tags/${tag}^{}`] as const;');
+		expect(releaseScript).toContain('["ls-remote", "origin", ...remoteRefs]');
 		expect(releaseScript).not.toContain('["ls-remote", "--refs", "origin", "refs/heads/main", `refs/tags/${tag}`]');
 		expect(() => assertAtomicPushRemoteState([
 			`${sourceCommit}\trefs/heads/main`,

--- a/scripts/release-publish-order.test.ts
+++ b/scripts/release-publish-order.test.ts
@@ -465,6 +465,7 @@ describe("native release binary coverage", () => {
 		const binaries = workflowJob(workflow, "binaries");
 		const prepare = workflowJob(workflow, "release_prepare");
 		const publish = workflowJob(workflow, "publish");
+		const finalize = workflowJob(workflow, "release_finalize");
 
 		for (const job of [native, binaries]) {
 			expect(job).toContain("startsWith(github.ref, 'refs/tags/v')");
@@ -480,21 +481,21 @@ describe("native release binary coverage", () => {
 		expect(binaries).toContain("needs: [native, release_metadata]");
 		expect(prepare).toContain("needs: [native, binaries, release_metadata, nightly_gate]");
 		expect(publish).toContain("needs: [release_prepare, release_approval, release_metadata]");
+		expect(finalize).toContain("needs: [publish, release_metadata]");
 
 		expect(prepare).toContain("--prepare-evidence --evidence-dir");
 		expect(prepare).toContain("Persist pre-publication package evidence");
-		expect(publish).toContain("--publish-from-evidence");
-		expect(publish).toContain("gajae-production-release");
-		expect(publish).toContain("gajae-nightly-release");
 		expect(publish).toContain("id-token: write");
+		expect(publish).toContain("Publish sealed tarballs to npm");
+		expect(finalize).toContain("--finalize-evidence");
 
-		expect(publish).toContain("softprops/action-gh-release");
-		expect(publish).toContain("draft: false");
-		expect(publish).toContain("release-binaries/gjc-*");
-		expect(publish).toContain("gajae-release-packages-v1.json");
-		expect(publish).toContain("gajae-release-channel-v1.json");
-		expect(publish).toContain("fail_on_unmatched_files: true");
-		expect(publish).toContain("Verify immutable GitHub Release");
+		expect(finalize).toContain("softprops/action-gh-release");
+		expect(finalize).toContain("draft: false");
+		expect(finalize).toContain("release-binaries/gjc-*");
+		expect(finalize).toContain("gajae-release-packages-v1.json");
+		expect(finalize).toContain("gajae-release-channel-v1.json");
+		expect(finalize).toContain("fail_on_unmatched_files: true");
+		expect(finalize).toContain("Verify immutable GitHub Release");
 
 		// The paranoid multi-job evidence/verify chain is gone.
 		for (const removed of [

--- a/scripts/release-publish-order.test.ts
+++ b/scripts/release-publish-order.test.ts
@@ -479,7 +479,7 @@ describe("native release binary coverage", () => {
 		expect(native).toContain("needs: [release_metadata]");
 		expect(binaries).toContain("needs: [native, release_metadata]");
 		expect(prepare).toContain("needs: [native, binaries, release_metadata, nightly_gate]");
-		expect(publish).toContain("needs: [release_prepare, release_metadata]");
+		expect(publish).toContain("needs: [release_prepare, release_approval, release_metadata]");
 
 		expect(prepare).toContain("--prepare-evidence --evidence-dir");
 		expect(prepare).toContain("Persist pre-publication package evidence");

--- a/scripts/release-publish-order.test.ts
+++ b/scripts/release-publish-order.test.ts
@@ -462,6 +462,7 @@ describe("native release binary coverage", () => {
 		const workflow = await Bun.file(path.join(repoRoot, ".github/workflows/ci.yml")).text();
 		const native = workflowJob(workflow, "native");
 		const binaries = workflowJob(workflow, "binaries");
+		const prepare = workflowJob(workflow, "release_prepare");
 		const publish = workflowJob(workflow, "publish");
 
 		for (const job of [native, binaries]) {
@@ -469,20 +470,21 @@ describe("native release binary coverage", () => {
 			expect(job).toContain("inputs.rehearsal == 'tag-build-verify'");
 			expect(job).toContain("inputs.rehearsal == 'nightly-release'");
 		}
-		expect(publish).toContain("needs.release_metadata.outputs.channel == 'stable'");
-		expect(publish).toContain("needs.release_metadata.outputs.channel == 'nightly'");
+		expect(prepare).toContain("needs.release_metadata.outputs.channel == 'stable'");
+		expect(prepare).toContain("needs.release_metadata.outputs.channel == 'nightly'");
 		expect(workflow).not.toContain("release_source_verify");
 		expect(workflow).not.toContain("verify exact source SHA passed a successful main CI run");
 
 		expect(native).toContain("needs: [release_metadata]");
 		expect(binaries).toContain("needs: [native, release_metadata]");
-		expect(publish).toContain("needs: [native, binaries, release_metadata, nightly_gate]");
+		expect(prepare).toContain("needs: [native, binaries, release_metadata, nightly_gate]");
+		expect(publish).toContain("needs: [release_prepare, release_metadata]");
 
-		expect(publish).toContain("--prepare-evidence --evidence-dir");
+		expect(prepare).toContain("--prepare-evidence --evidence-dir");
+		expect(prepare).toContain("Persist pre-publication package evidence");
 		expect(publish).toContain("--publish-from-evidence");
 		expect(publish).toContain("gajae-production-release");
 		expect(publish).toContain("gajae-nightly-release");
-		expect(publish).toContain("Persist pre-publication package evidence");
 		expect(publish).toContain("id-token: write");
 
 		expect(publish).toContain("softprops/action-gh-release");

--- a/scripts/release-publish-order.test.ts
+++ b/scripts/release-publish-order.test.ts
@@ -196,6 +196,24 @@ describe("unscoped gajae-code package publication", () => {
 		}
 	});
 
+	test("seals the dependency-ordered plan into evidence and the fixed publish boundary consumes it", async () => {
+		// The OIDC publish job must publish in planExpectedEvidencePublication
+		// order, not evidence-array (name-sorted) order. The order is computed in
+		// the credential-free prepare job and sealed as an artifact.
+		const script = await Bun.file(path.join(repoRoot, "scripts/ci-release-publish.ts")).text();
+		expect(script).toContain('PUBLISH_ORDER_FILE = "gajae-release-publish-order-v1.json"');
+		expect(script).toContain("planExpectedEvidencePublication(expected.packages)");
+
+		const workflow = await Bun.file(path.join(repoRoot, ".github/workflows/ci.yml")).text();
+		const publish = workflowJob(workflow, "publish");
+		expect(publish).toContain("gajae-release-publish-order-v1.json");
+		expect(publish).toContain("for name in $(jq -r '.order[]'");
+		// No direct evidence-array iteration may remain in the boundary.
+		expect(publish).not.toContain(".packages[$index]");
+		// The boundary rejects a plan that does not cover exactly the expected set.
+		expect(publish).toContain("does not cover exactly the expected package set");
+	});
+
 	test("rejects duplicate, missing, and extra evidence records before publication", async () => {
 		const records = canonicalEvidenceRecords();
 		const published: string[] = [];

--- a/scripts/release-retry.test.ts
+++ b/scripts/release-retry.test.ts
@@ -65,7 +65,7 @@ describe("atomic push rollback plan", () => {
 });
 
 describe("rejected atomic push recovery", () => {
-	test("rolls back the complete local release state so the same version can be retried", async () => {
+	test("preserves the complete local release state with idempotent guidance on rejection", async () => {
 		const { origin, work, preReleaseCommit } = await releaseFixture();
 
 		// A concurrent main update makes the atomic push reject.
@@ -77,14 +77,21 @@ describe("rejected atomic push recovery", () => {
 		await git(other, ["push", "origin", "HEAD:refs/heads/main"]);
 
 		process.chdir(work);
-		await expect(pushReleaseRefsAtomically("9.9.9")).rejects.toThrow(/rolled back/u);
+		const failure = await pushReleaseRefsAtomically("9.9.9").then(
+			() => { throw new Error("expected the ambiguous push to throw"); },
+			(error: unknown) => String(error),
+		);
+		// Guidance carries the guarded, per-artifact rollback commands.
+		expect(failure).toContain("ambiguous remote outcome");
+		expect(failure).toContain("git show-ref --verify --quiet refs/tags/v9.9.9 && git tag --delete v9.9.9");
+		expect(failure).toContain(`git reset --hard ${preReleaseCommit}`);
 
-		// Full rollback: the tag is gone and HEAD plus the tree are exactly the
-		// pre-release state, so retrying re-runs the original transaction.
+		// Nothing was rolled back: the tag and the release commit are intact,
+		// and the tree is clean, so the operator can reconcile by hand.
 		const head = (await git(work, ["rev-parse", "HEAD"])).trim();
-		expect(head).toBe(preReleaseCommit);
+		expect(head).not.toBe(preReleaseCommit);
 		const tagCheck = await $`git show-ref --verify --quiet refs/tags/v9.9.9`.cwd(work).quiet().nothrow();
-		expect(tagCheck.exitCode).not.toBe(0);
+		expect(tagCheck.exitCode).toBe(0);
 		const status = (await git(work, ["status", "--porcelain"])).trim();
 		expect(status).toBe("");
 		// Nothing reached origin.
@@ -124,7 +131,10 @@ describe("ambiguous atomic push failure reconciliation", () => {
 		expect(disposition.note).toContain("no local state was rolled back");
 	});
 
-	test("rollback is allowed only after proving neither remote ref moved", () => {
+	test("baseline-equal snapshots are ambiguous and preserve local state (accepted-then-restored regression)", () => {
+		// The refs may have committed and been restored before the re-query; a
+		// snapshot match is not durable proof of rejection, so nothing is rolled
+		// back automatically.
 		const disposition = reconcileAtomicPushFailure("v9.9.9", {
 			sourceCommit,
 			prePushMain: preMain,
@@ -133,7 +143,9 @@ describe("ambiguous atomic push failure reconciliation", () => {
 			postPushMain: preMain,
 			postPushTag: "",
 		});
-		expect(disposition.kind).toBe("rollback");
+		expect(disposition.kind).toBe("preserve");
+		expect(disposition.note).toContain("does not PROVE rejection");
+		expect(disposition.note).toContain("preserved untouched");
 	});
 
 	test("a partially moved remote preserves all local state", () => {

--- a/scripts/release-retry.test.ts
+++ b/scripts/release-retry.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { $ } from "bun";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { planAtomicPushRollback, pushReleaseRefsAtomically } from "./release";
+
+const originalCwd = process.cwd();
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+	process.chdir(originalCwd);
+	await Promise.all(tempRoots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
+});
+
+async function git(cwd: string, args: readonly string[]): Promise<string> {
+	const result = await $`git -c user.email=release-test@gajae.local -c user.name=release-test ${args}`.cwd(cwd).quiet().nothrow();
+	if (result.exitCode !== 0) throw new Error(`git ${args.join(" ")} failed: ${result.stderr.toString().trim()}`);
+	return result.stdout.toString();
+}
+
+interface Fixture {
+	root: string;
+	origin: string;
+	work: string;
+	preReleaseCommit: string;
+}
+
+async function releaseFixture(): Promise<Fixture> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-release-retry-"));
+	tempRoots.push(root);
+	const origin = path.join(root, "origin.git");
+	const work = path.join(root, "work");
+	await git(root, ["init", "--bare", "-b", "main", origin]);
+	await git(root, ["clone", origin, work]);
+	await Bun.write(path.join(work, "file.txt"), "before release\n");
+	await git(work, ["add", "file.txt"]);
+	await git(work, ["commit", "-m", "pre-release commit"]);
+	await git(work, ["push", "origin", "HEAD:refs/heads/main"]);
+	const preReleaseCommit = (await git(work, ["rev-parse", "HEAD"])).trim();
+	// The release transaction: version/changelog commit plus the release tag.
+	await Bun.write(path.join(work, "file.txt"), "release bump\n");
+	await git(work, ["add", "file.txt"]);
+	await git(work, ["commit", "-m", "chore: bump version to 9.9.9"]);
+	await git(work, ["tag", "--no-sign", "v9.9.9"]);
+	return { root, origin, work, preReleaseCommit };
+}
+
+describe("atomic push rollback plan", () => {
+	test("maps a version and pre-release commit to the tag and reset target", () => {
+		const plan = planAtomicPushRollback("9.9.9", "a".repeat(40));
+		expect(plan.tag).toBe("v9.9.9");
+		expect(plan.preReleaseCommit).toBe("a".repeat(40));
+	});
+
+	test("rejects non-stable versions and malformed commits", () => {
+		expect(() => planAtomicPushRollback("9.9.9-rc.1", "a".repeat(40))).toThrow("exact stable");
+		expect(() => planAtomicPushRollback("9.9.9", "not-a-sha")).toThrow("pre-release commit");
+	});
+});
+
+describe("rejected atomic push recovery", () => {
+	test("rolls back the complete local release state so the same version can be retried", async () => {
+		const { origin, work, preReleaseCommit } = await releaseFixture();
+
+		// A concurrent main update makes the atomic push reject.
+		const other = path.join(path.dirname(work), "other");
+		await git(path.dirname(work), ["clone", origin, other]);
+		await Bun.write(path.join(other, "other.txt"), "concurrent\n");
+		await git(other, ["add", "other.txt"]);
+		await git(other, ["commit", "-m", "concurrent main update"]);
+		await git(other, ["push", "origin", "HEAD:refs/heads/main"]);
+
+		process.chdir(work);
+		await expect(pushReleaseRefsAtomically("9.9.9")).rejects.toThrow(/rolled back/u);
+
+		// Full rollback: the tag is gone and HEAD plus the tree are exactly the
+		// pre-release state, so retrying re-runs the original transaction.
+		const head = (await git(work, ["rev-parse", "HEAD"])).trim();
+		expect(head).toBe(preReleaseCommit);
+		const tagCheck = await $`git show-ref --verify --quiet refs/tags/v9.9.9`.cwd(work).quiet().nothrow();
+		expect(tagCheck.exitCode).not.toBe(0);
+		const status = (await git(work, ["status", "--porcelain"])).trim();
+		expect(status).toBe("");
+		// Nothing reached origin.
+		const remoteTag = await $`git ls-remote --tags origin refs/tags/v9.9.9`.cwd(work).quiet().nothrow();
+		expect(remoteTag.stdout.toString().trim()).toBe("");
+	});
+
+	test("pushes main and the tag atomically when nothing rejects them", async () => {
+		const { work, preReleaseCommit } = await releaseFixture();
+
+		process.chdir(work);
+		await pushReleaseRefsAtomically("9.9.9");
+
+		const releaseCommit = (await git(work, ["rev-parse", "HEAD"])).trim();
+		expect(releaseCommit).not.toBe(preReleaseCommit);
+		const remoteMain = (await git(work, ["ls-remote", "origin", "refs/heads/main"])).split("\t")[0]?.trim();
+		expect(remoteMain).toBe(releaseCommit);
+		const remoteTag = (await git(work, ["ls-remote", "origin", "refs/tags/v9.9.9"])).split("\t")[0]?.trim();
+		expect(remoteTag).toBe(releaseCommit);
+	});
+});

--- a/scripts/release-retry.test.ts
+++ b/scripts/release-retry.test.ts
@@ -3,7 +3,12 @@ import { $ } from "bun";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { planAtomicPushRollback, pushReleaseRefsAtomically } from "./release";
+import {
+	localRollbackCommands,
+	planAtomicPushRollback,
+	pushReleaseRefsAtomically,
+	reconcileAtomicPushFailure,
+} from "./release";
 
 const originalCwd = process.cwd();
 const tempRoots: string[] = [];
@@ -99,5 +104,108 @@ describe("rejected atomic push recovery", () => {
 		expect(remoteMain).toBe(releaseCommit);
 		const remoteTag = (await git(work, ["ls-remote", "origin", "refs/tags/v9.9.9"])).split("\t")[0]?.trim();
 		expect(remoteTag).toBe(releaseCommit);
+	});
+});
+
+describe("ambiguous atomic push failure reconciliation", () => {
+	const sourceCommit = "d".repeat(40);
+	const preMain = "e".repeat(40);
+
+	test("a committed transaction with a failed push result reconciles as success", () => {
+		const disposition = reconcileAtomicPushFailure("v9.9.9", {
+			sourceCommit,
+			prePushMain: preMain,
+			prePushTag: "",
+			remoteReachable: true,
+			postPushMain: sourceCommit,
+			postPushTag: sourceCommit,
+		});
+		expect(disposition.kind).toBe("committed");
+		expect(disposition.note).toContain("no local state was rolled back");
+	});
+
+	test("rollback is allowed only after proving neither remote ref moved", () => {
+		const disposition = reconcileAtomicPushFailure("v9.9.9", {
+			sourceCommit,
+			prePushMain: preMain,
+			prePushTag: "",
+			remoteReachable: true,
+			postPushMain: preMain,
+			postPushTag: "",
+		});
+		expect(disposition.kind).toBe("rollback");
+	});
+
+	test("a partially moved remote preserves all local state", () => {
+		const disposition = reconcileAtomicPushFailure("v9.9.9", {
+			sourceCommit,
+			prePushMain: preMain,
+			prePushTag: "",
+			remoteReachable: true,
+			postPushMain: sourceCommit,
+			postPushTag: "",
+		});
+		expect(disposition.kind).toBe("preserve");
+		expect(disposition.note).toContain("PARTIALLY");
+		expect(disposition.note).toContain("preserved untouched");
+		expect(disposition.note).toContain("Do not retry blindly");
+	});
+
+	test("an unreachable remote preserves all local state", () => {
+		const disposition = reconcileAtomicPushFailure("v9.9.9", {
+			sourceCommit,
+			prePushMain: preMain,
+			prePushTag: "",
+			remoteReachable: false,
+		});
+		expect(disposition.kind).toBe("preserve");
+		expect(disposition.note).toContain("could not be re-queried");
+		expect(disposition.note).toContain("do NOT roll back");
+	});
+});
+
+describe("idempotent per-outcome rollback guidance", () => {
+	const releaseCommit = "f".repeat(40);
+	const preReleaseCommit = "0".repeat(40);
+
+	test("emits only the commands for the artifacts that still exist", () => {
+		expect(localRollbackCommands("v9.9.9", releaseCommit, preReleaseCommit, { tagPresent: false, onReleaseCommit: true }))
+			.toEqual([`test "$(git rev-parse HEAD)" = "${releaseCommit}" && git reset --hard ${preReleaseCommit}`]);
+		expect(localRollbackCommands("v9.9.9", releaseCommit, preReleaseCommit, { tagPresent: true, onReleaseCommit: false }))
+			.toEqual(["git show-ref --verify --quiet refs/tags/v9.9.9 && git tag --delete v9.9.9"]);
+		expect(localRollbackCommands("v9.9.9", releaseCommit, preReleaseCommit, { tagPresent: false, onReleaseCommit: false }))
+			.toEqual([]);
+	});
+});
+
+describe("accepted remote transaction with a client-side failed push", () => {
+	test("reconciles as success and keeps the local release state", async () => {
+		const { work, preReleaseCommit } = await releaseFixture();
+
+		// A git shim that performs the real atomic push but reports failure,
+		// simulating a transport error after the remote committed.
+		const shimDir = `${work}/.shim`;
+		await fs.mkdir(shimDir);
+		const realGit = (await $`which git`.quiet().text()).trim();
+		await Bun.write(`${shimDir}/git`, `#!/bin/sh\nif [ "$1" = "-c" ]; then :; fi\nfor arg in "$@"; do if [ "$arg" = "--atomic" ]; then "${realGit}" "$@"; code=$?; if [ $code -eq 0 ]; then exit 5; else exit $code; fi; fi; done\nexec "${realGit}" "$@"\n`);
+		await fs.chmod(`${shimDir}/git`, 0o755);
+
+		const originalPath = process.env.PATH;
+		process.env.PATH = `${shimDir}:${originalPath}`;
+		try {
+			process.chdir(work);
+			await pushReleaseRefsAtomically("9.9.9");
+		} finally {
+			process.env.PATH = originalPath;
+		}
+
+		// Success: no rollback happened — HEAD is still the release commit and
+		// the tag still exists, and the remote carries both refs.
+		const head = (await git(work, ["rev-parse", "HEAD"])).trim();
+		expect(head).not.toBe(preReleaseCommit);
+		const tagCheck = await $`git show-ref --verify --quiet refs/tags/v9.9.9`.cwd(work).quiet().nothrow();
+		expect(tagCheck.exitCode).toBe(0);
+		const remoteTag = (await git(work, ["ls-remote", "origin", "refs/tags/v9.9.9"])).split("\t")[0]?.trim();
+		expect(remoteTag).toBe(head);
 	});
 });

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -457,9 +457,10 @@ export type AtomicPushFailureDisposition =
 	// The remote accepted the atomic transaction even though the push command
 	// reported failure; the run must continue as a success, never roll back.
 	| { kind: "committed"; note: string }
-	// Both remote refs provably still hold their pre-push values: local rollback is safe.
-	| { kind: "rollback"; note: string }
-	// Partial move or unreachable remote: preserve all local state for the operator.
+	// Anything else — baseline-equal snapshots included — is ambiguous: refs
+	// could have moved and been restored before the re-query, and a transient
+	// tag may already have started the release workflow. Local state is always
+	// preserved; an operator reconciles with durable server evidence.
 	| { kind: "preserve"; note: string };
 
 export interface AtomicPushReconciliation {
@@ -475,7 +476,7 @@ export function reconcileAtomicPushFailure(tag: string, input: AtomicPushReconci
 	if (!input.remoteReachable) {
 		return {
 			kind: "preserve",
-			note: `The push failed AND the remote could not be re-queried, so whether the transaction committed is unknown. Local tag ${tag} and the release commit ${input.sourceCommit} are preserved untouched. Once origin is reachable, run \`git ls-remote origin refs/heads/main refs/tags/${tag} 'refs/tags/${tag}^{}'\`: if both refs resolve to ${input.sourceCommit} the release committed (rerun the script's verification, do NOT roll back); if main is still ${input.prePushMain} and no ${tag} exists, nothing shipped and the local state may be rolled back with the guarded commands from a rerun.`,
+			note: `The push failed AND the remote could not be re-queried, so whether the transaction committed is unknown. Local tag ${tag} and the release commit ${input.sourceCommit} are preserved untouched. Once origin is reachable, run \`git ls-remote origin refs/heads/main refs/tags/${tag} 'refs/tags/${tag}^{}'\`: if both refs resolve to ${input.sourceCommit} the release committed (rerun the script's verification, do NOT roll back); otherwise reconcile by hand with the guarded commands below.`,
 		};
 	}
 	if (input.postPushMain === input.sourceCommit && input.postPushTag === input.sourceCommit) {
@@ -486,8 +487,8 @@ export function reconcileAtomicPushFailure(tag: string, input: AtomicPushReconci
 	}
 	if (input.postPushMain === input.prePushMain && input.postPushTag === input.prePushTag) {
 		return {
-			kind: "rollback",
-			note: `Neither remote ref moved (main is still ${input.prePushMain}, ${tag} still ${input.prePushTag === "" ? "absent" : input.prePushTag}), so the transaction published nothing and local rollback is safe.`,
+			kind: "preserve",
+			note: `The remote currently reads as the pre-push baseline (main ${input.prePushMain}, ${tag} ${input.prePushTag === "" ? "absent" : input.prePushTag}), but a client-observed failed push does not PROVE rejection: GitHub may have committed the transaction and the refs could have been restored before this re-query, with the tag event already running. Local tag ${tag} and release commit ${input.sourceCommit} are preserved untouched. Before any rollback or retry, verify durably: no tag workflow run exists for ${tag}, and origin never carried ${input.sourceCommit}. Only then run the guarded rollback commands below; they are idempotent and safe to re-run.`,
 		};
 	}
 	return {
@@ -544,26 +545,17 @@ export async function pushReleaseRefsAtomically(version: string): Promise<void> 
 			// Fall through to the normal verification below, which re-proves the
 			// remote state strictly.
 			console.log(disposition.note);
-		} else if (disposition.kind === "rollback") {
-			// Proven nothing shipped: undo the complete local release state so a
-			// same-version retry re-runs the original transaction from a clean
-			// tree (the release flow asserts a clean tree before preparing, so
-			// resetting loses nothing outside this attempt).
-			const tagRollback = await git(["tag", "--delete", tag]).quiet().nothrow();
-			const commitRollback = await git(["reset", "--hard", rollbackPlan.preReleaseCommit]).quiet().nothrow();
-			const residual = localRollbackCommands(tag, sourceCommit, rollbackPlan.preReleaseCommit, {
-				tagPresent: tagRollback.exitCode !== 0,
-				onReleaseCommit: commitRollback.exitCode !== 0,
-			});
-			const rollbackNote = residual.length === 0
-				? `Local tag ${tag} and the release commit were rolled back to ${rollbackPlan.preReleaseCommit}; this version can be retried once the push cause is resolved.`
-				: `Local rollback is partially applied; finish it with these idempotent commands (safe to re-run): ${residual.join(" ; ")}`;
-			throw new Error(
-				`Atomic push of main and ${tag} was rejected; neither ref may be retried independently: ${outputOf(push) || `exit ${push.exitCode ?? "unknown"}`}. ${disposition.note} ${rollbackNote}`,
-			);
 		} else {
+			// Preserve the complete local release state on every ambiguous
+			// outcome. The guarded commands describe the rollback an operator
+			// may run only after durably proving nothing shipped; each is
+			// idempotent and safe to re-run in any order.
+			const guarded = localRollbackCommands(tag, sourceCommit, rollbackPlan.preReleaseCommit, {
+				tagPresent: true,
+				onReleaseCommit: true,
+			});
 			throw new Error(
-				`Atomic push of main and ${tag} failed with an ambiguous remote outcome: ${outputOf(push) || `exit ${push.exitCode ?? "unknown"}`}. ${disposition.note}`,
+				`Atomic push of main and ${tag} failed with an ambiguous remote outcome: ${outputOf(push) || `exit ${push.exitCode ?? "unknown"}`}. ${disposition.note} Guarded local rollback commands (only after durable proof nothing shipped): ${guarded.join(" ; ")}`,
 			);
 		}
 	}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -42,7 +42,7 @@ export interface ReleaseRunJobObservation {
 	name: string;
 }
 
-export const STABLE_GITHUB_RELEASE_FINALIZATION_JOB_NAME = "publish";
+export const STABLE_GITHUB_RELEASE_FINALIZATION_JOB_NAME = "release_finalize";
 
 export type StableReleaseFinalizationReceipt =
 	| { outcome: "missing" }

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -436,34 +436,138 @@ export function planAtomicPushRollback(version: string, preReleaseCommit: string
 	return { tag: `v${version}`, preReleaseCommit };
 }
 
+/** Tolerantly parsed `git ls-remote` output: ref name to sha (unknown refs skipped). */
+export function parseLsRemoteRefs(output: string): Map<string, string> {
+	const refs = new Map<string, string>();
+	for (const line of output.trim().split("\n")) {
+		if (line === "") continue;
+		const fields = line.split("\t");
+		if (fields.length !== 2 || !/^[0-9a-f]{40}$/u.test(fields[0]!)) continue;
+		refs.set(fields[1]!, fields[0]!);
+	}
+	return refs;
+}
+
+/** Peeled tag sha from parsed ls-remote refs (prefers the ^{} line for annotated tags). */
+function peeledTagSha(refs: ReadonlyMap<string, string>, tag: string): string | undefined {
+	return refs.get(`refs/tags/${tag}^{}`) ?? refs.get(`refs/tags/${tag}`);
+}
+
+export type AtomicPushFailureDisposition =
+	// The remote accepted the atomic transaction even though the push command
+	// reported failure; the run must continue as a success, never roll back.
+	| { kind: "committed"; note: string }
+	// Both remote refs provably still hold their pre-push values: local rollback is safe.
+	| { kind: "rollback"; note: string }
+	// Partial move or unreachable remote: preserve all local state for the operator.
+	| { kind: "preserve"; note: string };
+
+export interface AtomicPushReconciliation {
+	sourceCommit: string;
+	prePushMain: string;
+	prePushTag: string;
+	remoteReachable: boolean;
+	postPushMain?: string;
+	postPushTag?: string;
+}
+
+export function reconcileAtomicPushFailure(tag: string, input: AtomicPushReconciliation): AtomicPushFailureDisposition {
+	if (!input.remoteReachable) {
+		return {
+			kind: "preserve",
+			note: `The push failed AND the remote could not be re-queried, so whether the transaction committed is unknown. Local tag ${tag} and the release commit ${input.sourceCommit} are preserved untouched. Once origin is reachable, run \`git ls-remote origin refs/heads/main refs/tags/${tag} 'refs/tags/${tag}^{}'\`: if both refs resolve to ${input.sourceCommit} the release committed (rerun the script's verification, do NOT roll back); if main is still ${input.prePushMain} and no ${tag} exists, nothing shipped and the local state may be rolled back with the guarded commands from a rerun.`,
+		};
+	}
+	if (input.postPushMain === input.sourceCommit && input.postPushTag === input.sourceCommit) {
+		return {
+			kind: "committed",
+			note: `git push reported failure, but remote refs/heads/main and ${tag} both resolve to the release commit ${input.sourceCommit}: the atomic transaction committed. Reconciling as success; no local state was rolled back.`,
+		};
+	}
+	if (input.postPushMain === input.prePushMain && input.postPushTag === input.prePushTag) {
+		return {
+			kind: "rollback",
+			note: `Neither remote ref moved (main is still ${input.prePushMain}, ${tag} still ${input.prePushTag === "" ? "absent" : input.prePushTag}), so the transaction published nothing and local rollback is safe.`,
+		};
+	}
+	return {
+		kind: "preserve",
+		note: `The remote moved PARTIALLY (main: ${input.prePushMain} -> ${input.postPushMain ?? "unreadable"}, ${tag}: ${input.prePushTag === "" ? "absent" : input.prePushTag} -> ${input.postPushTag ?? "unreadable"}). Local tag ${tag} and release commit ${input.sourceCommit} are preserved untouched. Do not retry blindly: inspect origin, and only after proving neither ref carries ${input.sourceCommit} roll back locally; if only one ref carries it, repair the remote by hand before any retry.`,
+	};
+}
+
+/**
+ * Idempotent, per-outcome local rollback commands: each step is guarded so a
+ * partially completed rollback can be re-run without the first successful
+ * step failing the rest.
+ */
+export function localRollbackCommands(tag: string, releaseCommit: string, preReleaseCommit: string, state: { tagPresent: boolean; onReleaseCommit: boolean }): string[] {
+	const commands: string[] = [];
+	if (state.tagPresent) commands.push(`git show-ref --verify --quiet refs/tags/${tag} && git tag --delete ${tag}`);
+	if (state.onReleaseCommit) commands.push(`test "$(git rev-parse HEAD)" = "${releaseCommit}" && git reset --hard ${preReleaseCommit}`);
+	return commands;
+}
+
 export async function pushReleaseRefsAtomically(version: string): Promise<void> {
 	const sourceCommit = (await git(["rev-parse", "HEAD"]).text()).trim();
 	if (!/^[0-9a-f]{40}$/u.test(sourceCommit)) throw new Error("Cannot resolve release commit for atomic push");
 	const preReleaseCommit = (await git(["rev-parse", "HEAD^"]).text()).trim();
 	const rollbackPlan = planAtomicPushRollback(version, preReleaseCommit);
+	const tag = rollbackPlan.tag;
+	const remoteRefs = ["refs/heads/main", `refs/tags/${tag}`, `refs/tags/${tag}^{}`] as const;
+
+	// Baseline BEFORE the push: without it, a failed push is ambiguous — the
+	// remote may have committed the transaction while the client observed a
+	// transport error — and rolling back on ambiguity can destroy the local
+	// record of a release that actually shipped.
+	const baseline = await git(["ls-remote", "origin", ...remoteRefs]).quiet().nothrow();
+	if (baseline.exitCode !== 0) {
+		throw new Error(`Cannot establish the pre-push remote baseline; refusing to push blind: ${outputOf(baseline) || `exit ${baseline.exitCode ?? "unknown"}`}`);
+	}
+	const baselineRefs = parseLsRemoteRefs(baseline.stdout.toString());
+	const prePushMain = baselineRefs.get("refs/heads/main") ?? "";
+	const prePushTag = peeledTagSha(baselineRefs, tag) ?? "";
+
 	const push = await git(releaseAtomicPushArgs(version)).quiet().nothrow();
 	if (push.exitCode !== 0) {
-		// Nothing reached origin, so the only artifacts of this attempt are the
-		// local release commit and tag created moments ago. Leaving either behind
-		// breaks the retry: the immutable-tag preflight rejects the reused tag,
-		// and the half-prepared tree makes the next run see an empty Unreleased
-		// section, duplicate release headings, or nothing-to-commit. Roll back the
-		// complete local release state so retrying the same version re-runs the
-		// original transaction from a clean tree (the release flow asserts a clean
-		// tree before preparing, so resetting to the pre-release commit loses
-		// nothing outside this attempt).
-		const tagRollback = await git(["tag", "--delete", rollbackPlan.tag]).quiet().nothrow();
-		const commitRollback = await git(["reset", "--hard", rollbackPlan.preReleaseCommit]).quiet().nothrow();
-		const rollbackNote =
-			tagRollback.exitCode === 0 && commitRollback.exitCode === 0
-				? `Local tag ${rollbackPlan.tag} and the release commit were rolled back to ${rollbackPlan.preReleaseCommit}; this version can be retried once the push cause is resolved.`
-				: `Local rollback incomplete (tag delete exit ${tagRollback.exitCode ?? "unknown"}, reset exit ${commitRollback.exitCode ?? "unknown"}); before retrying run: git tag -d ${rollbackPlan.tag} && git reset --hard ${rollbackPlan.preReleaseCommit}`;
-		throw new Error(
-			`Atomic push of main and ${rollbackPlan.tag} was rejected; neither ref may be retried independently: ${outputOf(push) || `exit ${push.exitCode ?? "unknown"}`}. ${rollbackNote}`,
-		);
+		const after = await git(["ls-remote", "origin", ...remoteRefs]).quiet().nothrow();
+		const afterRefs = after.exitCode === 0 ? parseLsRemoteRefs(after.stdout.toString()) : new Map<string, string>();
+		const disposition = reconcileAtomicPushFailure(tag, {
+			sourceCommit,
+			prePushMain,
+			prePushTag,
+			remoteReachable: after.exitCode === 0,
+			postPushMain: afterRefs.get("refs/heads/main") ?? "",
+			postPushTag: peeledTagSha(afterRefs, tag) ?? "",
+		});
+		if (disposition.kind === "committed") {
+			// Fall through to the normal verification below, which re-proves the
+			// remote state strictly.
+			console.log(disposition.note);
+		} else if (disposition.kind === "rollback") {
+			// Proven nothing shipped: undo the complete local release state so a
+			// same-version retry re-runs the original transaction from a clean
+			// tree (the release flow asserts a clean tree before preparing, so
+			// resetting loses nothing outside this attempt).
+			const tagRollback = await git(["tag", "--delete", tag]).quiet().nothrow();
+			const commitRollback = await git(["reset", "--hard", rollbackPlan.preReleaseCommit]).quiet().nothrow();
+			const residual = localRollbackCommands(tag, sourceCommit, rollbackPlan.preReleaseCommit, {
+				tagPresent: tagRollback.exitCode !== 0,
+				onReleaseCommit: commitRollback.exitCode !== 0,
+			});
+			const rollbackNote = residual.length === 0
+				? `Local tag ${tag} and the release commit were rolled back to ${rollbackPlan.preReleaseCommit}; this version can be retried once the push cause is resolved.`
+				: `Local rollback is partially applied; finish it with these idempotent commands (safe to re-run): ${residual.join(" ; ")}`;
+			throw new Error(
+				`Atomic push of main and ${tag} was rejected; neither ref may be retried independently: ${outputOf(push) || `exit ${push.exitCode ?? "unknown"}`}. ${disposition.note} ${rollbackNote}`,
+			);
+		} else {
+			throw new Error(
+				`Atomic push of main and ${tag} failed with an ambiguous remote outcome: ${outputOf(push) || `exit ${push.exitCode ?? "unknown"}`}. ${disposition.note}`,
+			);
+		}
 	}
-	const tag = `v${version}`;
-	const remote = await git(["ls-remote", "origin", "refs/heads/main", `refs/tags/${tag}`, `refs/tags/${tag}^{}`]).quiet().nothrow();
+	const remote = await git(["ls-remote", "origin", ...remoteRefs]).quiet().nothrow();
 	if (remote.exitCode !== 0) {
 		throw new Error(`Cannot verify atomic release push; do not independently push main or ${tag}: ${outputOf(remote) || `exit ${remote.exitCode ?? "unknown"}`}`);
 	}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -420,23 +420,46 @@ export function assertAtomicPushRemoteState(output: string, sourceCommit: string
 	}
 }
 
-async function pushReleaseRefsAtomically(version: string): Promise<void> {
+/**
+ * Local state a rejected atomic push must undo so the same version can be
+ * retried as the original transaction: the release tag and the release
+ * commit (whose parent is the pre-release HEAD captured before tagging).
+ */
+export interface AtomicPushRollbackPlan {
+	tag: string;
+	preReleaseCommit: string;
+}
+
+export function planAtomicPushRollback(version: string, preReleaseCommit: string): AtomicPushRollbackPlan {
+	if (!isStableReleaseVersion(version)) throw new Error(`Release version must be exact stable X.Y.Z, received ${version}`);
+	if (!/^[0-9a-f]{40}$/u.test(preReleaseCommit)) throw new Error("Cannot resolve pre-release commit for atomic push rollback");
+	return { tag: `v${version}`, preReleaseCommit };
+}
+
+export async function pushReleaseRefsAtomically(version: string): Promise<void> {
 	const sourceCommit = (await git(["rev-parse", "HEAD"]).text()).trim();
 	if (!/^[0-9a-f]{40}$/u.test(sourceCommit)) throw new Error("Cannot resolve release commit for atomic push");
+	const preReleaseCommit = (await git(["rev-parse", "HEAD^"]).text()).trim();
+	const rollbackPlan = planAtomicPushRollback(version, preReleaseCommit);
 	const push = await git(releaseAtomicPushArgs(version)).quiet().nothrow();
 	if (push.exitCode !== 0) {
-		// Nothing reached origin, so the local tag created moments ago is the only
-		// artifact of this attempt. Leaving it behind makes the immutable-tag
-		// preflight reject the *same* version on the next run, forcing a version
-		// burn for a failure that published nothing. Drop it and let the operator
-		// retry this version once the push cause is resolved.
-		const rollback = await git(["tag", "--delete", `v${version}`]).quiet().nothrow();
+		// Nothing reached origin, so the only artifacts of this attempt are the
+		// local release commit and tag created moments ago. Leaving either behind
+		// breaks the retry: the immutable-tag preflight rejects the reused tag,
+		// and the half-prepared tree makes the next run see an empty Unreleased
+		// section, duplicate release headings, or nothing-to-commit. Roll back the
+		// complete local release state so retrying the same version re-runs the
+		// original transaction from a clean tree (the release flow asserts a clean
+		// tree before preparing, so resetting to the pre-release commit loses
+		// nothing outside this attempt).
+		const tagRollback = await git(["tag", "--delete", rollbackPlan.tag]).quiet().nothrow();
+		const commitRollback = await git(["reset", "--hard", rollbackPlan.preReleaseCommit]).quiet().nothrow();
 		const rollbackNote =
-			rollback.exitCode === 0
-				? `Local tag v${version} was removed, so this version can be retried.`
-				: `Local tag v${version} could not be removed; delete it before retrying (git tag -d v${version}).`;
+			tagRollback.exitCode === 0 && commitRollback.exitCode === 0
+				? `Local tag ${rollbackPlan.tag} and the release commit were rolled back to ${rollbackPlan.preReleaseCommit}; this version can be retried once the push cause is resolved.`
+				: `Local rollback incomplete (tag delete exit ${tagRollback.exitCode ?? "unknown"}, reset exit ${commitRollback.exitCode ?? "unknown"}); before retrying run: git tag -d ${rollbackPlan.tag} && git reset --hard ${rollbackPlan.preReleaseCommit}`;
 		throw new Error(
-			`Atomic push of main and v${version} was rejected; neither ref may be retried independently: ${outputOf(push) || `exit ${push.exitCode ?? "unknown"}`}. ${rollbackNote}`,
+			`Atomic push of main and ${rollbackPlan.tag} was rejected; neither ref may be retried independently: ${outputOf(push) || `exit ${push.exitCode ?? "unknown"}`}. ${rollbackNote}`,
 		);
 	}
 	const tag = `v${version}`;


### PR DESCRIPTION
## What

Ports the 0.14.1 release-path fix (`19645a5a80`, already on `main`) to `dev` so the branches do not diverge on the npm publish path.

- `publish` job gains `id-token: write` and pins `npm@^11.5.1`; the ephemeral npmrc and the registry-token env wiring are removed.
- `check-workflow-permissions.ts` allowlists exactly `publish.contents` + `publish.id-token`; the policy gates now assert the OIDC contract instead of the token contract.
- `release.ts` deletes the local tag when the atomic push is rejected.
- `scripts/release-notes.ts` derives the GitHub Release body from the release range in the historical `## What's Changed` / `## New Contributors` / `**Full Changelog**` shape, and the publish job now passes it as `body_path` with `generate_release_notes: false`.

## Why

The first 0.14.1 publish attempt failed with a registry 404 on `PUT` because the publish credential had expired (last rotated 2026-05-27) while the release tag had already been pushed, so a dead secret could burn a version number. Trusted publishing mints a short-lived credential per run, leaving nothing to expire.

The tag-rollback change addresses the second half of that failure: a rejected atomic push used to leave the local tag behind, which made the immutable-tag preflight reject the same version on the next attempt and force a version burn for a release that published nothing.

`v0.14.1` published a body containing only a compare link, because `generate_release_notes` derives from pull requests merged into the target branch and a curated release is cherry-picked onto `main`. Naive attribution is worse than none: `GET /commits/{sha}/pulls` returns every branch containing a commit, which credited shipped fixes to the excluded 32-commit `feat(autoresearch)!` swap and to the reverted promotion PR. A candidate is now accepted only when the release ships at least half of its commits, and a subject's own `(#N)` always wins.

## Testing

- `bun test scripts/release-policy.test.ts scripts/release-publish-order.test.ts scripts/check-workflow-permissions.test.ts` -> 63 pass, 0 fail.
- `bun scripts/check-workflow-permissions.ts` -> ok on all four workflows.
- `bun test scripts/release-notes.test.ts` -> 17 pass, 0 fail; combined release gates 80 pass, 0 fail.
- Real derivation over `v0.14.0..v0.14.1` reproduced 40 entries with zero credits to excluded pull requests; that output is now the published `v0.14.1` body.
- Live OIDC exchange is exercised by the `v0.14.1` tag run on `main`; it is not reproducible from a PR branch.

## Risk classification

- [ ] `low-risk`
- [ ] `regression-risk`
- [x] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:5ad0ecdaa3d5e11955d5fa668ef2413e1cba70ec96e69891279a4a866ceef82a reviewer:human reviewer-id:probepark evidence:exact-head-983356a39370-authenticated-probepark-approval-at-current-head-attributable-ci-green-dev-merge-does-not-trigger-release
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit

No authenticated approving GitHub review exists for this exact head, so the verdict is `needs-human` rather than an approval. Self-approval would be `BLOCK`.
## P1 resolution (head 3450a47016)

snowykr's CHANGES_REQUESTED (review 4963962358) is addressed without touching the shipped v0.14.1 release:

1. **PR API read permission + fail-closed notes** — `release_prepare` holds `pull-requests: read` (policy test asserts it); `release-notes.ts` gh calls now throw on auth/transport/API errors; empty results only on explicit success or an explicit not-found response (`isExplicitEmptyGhResult`).
2. **Notes before npm** — derivation, validation, and a byte-for-byte determinism re-run happen in `release_prepare`; the body is sha256-pinned through an artifact and publish only integrity-checks and consumes it. npm publish cannot start before notes exist (`needs: [release_prepare, ...]`).
3. **Anchor selection** — exact `^v[0-9]+\.[0-9]+\.[0-9]+$` tags that are ancestors of the release head only; the current tag is excluded; the no-candidate fallback is pipe-free so pipefail cannot abort it.
4. **Transactional retry** — a rejected atomic push now deletes the local tag AND resets to the pre-release commit, so a same-version retry re-runs the original transaction (covered by `scripts/release-retry.test.ts` against real temp git remotes).
5. **Minimal OIDC boundary** — publish holds the only credentials; the npm CLI is pinned exactly to 11.5.1 with the registry tarball sha512 verified before install, no caret range.

Verification: `bun test scripts/release-policy.test.ts scripts/release-publish-order.test.ts scripts/release-notes.test.ts scripts/release-retry.test.ts scripts/check-workflow-permissions.test.ts` (74 pass), `bun run check:tools` (biome + tsc clean), `bun scripts/check-workflow-permissions.ts` (4 workflows ok), live npm tarball sha512 check, live tag-anchor selection, live `release-notes.ts` derivation against the GitHub API.
## Round-2 resolution (head c409d31292)

snowykr's second CHANGES_REQUESTED (review 4964412257) is addressed:

1. **Ambiguous atomic push (P1)** — `pushReleaseRefsAtomically` captures a pre-push `ls-remote` baseline and re-queries both refs on failure: a committed transaction reconciles as success (regression-tested with a git shim that pushes but reports failure), rollback runs only when neither ref moved, and partial/unreachable outcomes preserve the local commit and tag with explicit guidance.
2. **Protected-main trust boundary (P1)** — `release_metadata` rejects any stable tag whose SHA is not an ancestor of the freshly fetched `origin/main`; `publish` is wired to the `npm-release` environment. Owner-controlled blocker (cannot be set from code): a `main` branch ruleset, a `refs/tags/v*` tag-creation ruleset restricted to maintainers, and `npm-release` environment protection rules (required reviewers + restricted deployment refs) must be configured in repository settings; the exact settings are documented on the publish job.
3. **Idempotent per-outcome recovery (P2)** — residual rollback commands are generated from which artifacts actually remain, each guarded (`show-ref && tag -d`, `rev-parse HEAD && reset --hard`), safe to re-run in any order.
4. **Exact Node pin (P2)** — the OIDC job's bootstrap runtime is `node-version: "24.19.0"`, no floating major.
5. **Display-name attribution (P2)** — fallback credits resolve the GitHub login via the commits API and render unresolved Git display names without `@` (regression-tested).
6. **CI coverage (P2)** — `scripts/release-notes.test.ts` and `scripts/release-retry.test.ts` are now in `test:release`, the force-full release-contract task.

Verification: `bun run test:release` 150/150, `bun run check:tools` clean, `bun scripts/check-workflow-permissions.ts` ok on all four workflows.
## Round-3 resolution (head 95397b14c5, rebased onto dev 4b2883bc75)

snowykr 4966590320 and probepark 4967848846 (merge-blocked) are addressed:

1. **Ambiguous atomic push (P1, both reviewers)** — a client-observed failed push now ALWAYS preserves the local release commit and tag unless the server proves the transaction committed. Baseline-equal re-observation is explicitly treated as ambiguous (refs may have been restored; the tag workflow may already be running). Guidance is guarded, per-artifact, idempotent (`show-ref && tag -d`, `rev-parse HEAD && reset --hard`). Regression: accepted-then-restored reconciliation unit test + preserve-on-rejection integration test over real temp remotes + the git-shim accepted-but-failed case reconciling as success.
2. **Repository-controlled install in the OIDC job (P1)** — publish now runs `persist-credentials: false`, no `bun install`, no dependency cache, no lifecycle scripts; the publish script and release-evidence helper import only node/bun builtins, verified. Policy test now forbids install/cache/credential persistence in the publish job.
3. **Environment-scoped OIDC subject (P1)** — the `npm-release` environment reference is REMOVED (it does not exist; probepark verified the live environments API). The subject stays ref-scoped (`repo:...:ref:refs/tags/v*`), the identity the trusted-publisher registrations and the shipped v0.14.1 attestation already prove. Owner-controlled prerequisites (main ruleset, `refs/tags/v*` tag-creation ruleset) are documented on the publish job; no environment may be introduced without re-registering every package's trusted publisher.
4. **Red exact-head CI (P1)** — root-check failed because `check-node20-baseline.ts` required exactly `"24"`; it now accepts an intentionally pinned exact `24.x.y` on release-capable jobs (ranges/other majors still violations, regression-tested) — the exact pin snowykr required is kept. The bisect shard failures are unrelated to this PR: the PR touches no product code, `bisect` source and test are byte-identical between the old base and current dev, and the suite passes locally (19/19) once the native addon matches the tree. Rebased onto current dev; exact-head CI reruns on push.
5. **Subject-based attribution (P2)** — coverage is now by commit OID (cherry-pick origins resolved per commit); the duplicate-subject partial-ship regression test proves a 1/4-shipped PR with duplicated subjects is no longer credited.

Verification: `bun run test:release` 152/152, `bun test scripts/check-node20-baseline.test.ts` 15/15, `bun scripts/check-workflow-permissions.ts` ok, `bun run check:tools` clean, `bun test packages/coding-agent/test/tools/bisect.test.ts` 19/19.

New exact-head digest: `93630165b25e83e93025479997ee91a47b42a984a4224e601f2f3408bdff05ff` over `4b2883bc75...95397b14c5`.
## Round-4 resolution (head 61cb8bc72d)

snowykr's fourth CHANGES_REQUESTED is addressed:

1. **Dependency resolution out of publish (P1)** — `--publish-from-evidence` no longer runs `checkTypeDeclarations()`; `bun x tsc` dispatch is prepare-path-only, pinned by a dispatch regression test (`release-policy.test.ts`).
2. **Approval gate without subject change (P1)** — new permissionless `release_approval` job (`permissions: {}`, no id-token) holds the `npm-release` environment hook ahead of publish, so the publish OIDC subject stays ref-scoped and the existing trusted-publisher registrations/0.14.1 attestation remain valid. Owner prerequisite stays documented: configure required reviewers on `npm-release` plus `main` and `refs/tags/v*` rulesets.
3. **root-check red (P1)** — cause identified: stale generated `schemas/config.schema.json` drift from dev commit bffcb50036 (Sentry DSN description), unrelated to this delta; regenerated and committed. `bun run ci:check:full` (the root-check command) is green locally on this exact head; exact-head CI reruns on push.

Verification: `bun run test:release` 154/154, `bun run ci:check:full` green, `bun scripts/check-workflow-permissions.ts` ok, `bun run check:tools` clean.

New exact-head digest: `d340fb927ae91d2bf71d11ec4e9091085a42143b39f9dee2c594d1bc73f5b83a` over `4b2883bc75...61cb8bc72d`.
## Round-5 resolution (head 27f3243c2a)

snowykr's fifth CHANGES_REQUESTED is addressed:

1. **Approval gate scoping (P1)** — `release_approval` now runs only for `channel == 'stable'`; `publish` admits nightly without the approval result and requires it for stable, so enabling required reviewers cannot strand scheduled/manual nightlies. Policy regressions pin the graph.
2. **Environment is a hook, prerequisites explicit (P1)** — the YAML reference cannot protect anything by itself; the job comment now names the exact owner-controlled settings (required non-self reviewers, no admin bypass, deployment refs restricted to release refs, `main` + `refs/tags/v*` rulesets). These are repository settings and cannot be provisioned from this PR; they remain the documented release prerequisite. The publish OIDC subject stays ref-scoped, preserving the proven trusted-publisher identity.

Verification: `bun run test:release` 155/155, workflow permissions gate ok, `check:tools` clean.

New exact-head digest: `6ba7bae4c975f8f6bdd06ce8cf3d1f89c3d64950d704a39d02fd7107c84a2798` over `4b2883bc75...27f3243c2a`.
## Rebase note (head 8576e9ee66)

Rebased onto current dev tip 7a920df9c105 (GitHub refreshed the recorded base to 06f0d4d67e, which the prior head did not contain, and dev kept moving). Content is unchanged from reviewed head 27f3243c2a — the round-3 schema regen is now upstream via #4721 and dropped from the diff. Local gates rerun green on the rebased head: test:release 155/155, check:tools, workflow permissions.

New exact-head digest: `8a26399c7f9449f71be6b543d111ebc74f650798f49bca9b821f3d91b3e864ac` over `7a920df9c1...8576e9ee66`.
## Rebase note (head 757a5062eb)

Transplanted onto current dev 02c739e1ba19 (prior base 7a920df9c105 went stale). Content unchanged — the canonical digest 8a26399c… is byte-identical to the previous head's. Local gates rerun green on the transplant: test:release 155/155, ci:check:full (root-check equivalent) clean, workflow permissions ok, check:tools clean.
## Rebase note (head 27d1c18588)

Rebased onto dev 883ab168cf56 to keep the head containing the live dev tip. Content unchanged; canonical digest still 8a26399c…. test:release 155/155 on the transplant.
## Rebase note (head d2830e4c59)

Rebased onto dev d97b79eff2be (owner rebase lane). Content unchanged; canonical digest still 8a26399c…. test:release 155/155, check:node20-baseline ok, workflow permissions ok, check:tools clean.
## Round-6 resolution (head 2b9c1f7496)

probepark's merge-block (4979759448) is addressed:

1. **Fixed publisher boundary (major)** — the OIDC `publish` job executes NO checkout-controlled code: no checkout, no bun, no repository scripts, no dependency install/cache, and no `contents` scope at all (`id-token: write` only). Publication runs from pinned actions + workflow shell: each tarball's sealed sha512 is re-verified at the boundary, `npm publish` uses the exact integrity-pinned npm 11.5.1, concurrent exact publication is tolerated by integrity comparison, post-publish visibility/integrity/tag are verified with bounded backoff, and a per-package receipt (`gajae-release-oidc-publish-receipt-v1.json`) is persisted.
2. **Finalization split** — `release_finalize` (`contents: write`, no OIDC) requires the receipt, assembles final + channel evidence via the new `--finalize-evidence` mode (registry re-observation only), then creates and verifies the GitHub Release. `release_prepare` captures the pre-publication protected-tag snapshot for channel evidence.
3. **Policy strengthened** — the allowlist admits exactly `release_finalize.contents` + `publish.id-token`; `release.ts` watches `release_finalize`; release-policy tests now reject `actions/checkout@`, `setup-bun@`, `bun `, `scripts/`, installs, and caches inside the OIDC job, and pin the new topology. The publish-loop smoke was verified locally with a stubbed npm (publish, skip-if-already-published, receipt).

**Owner hold checklist (settings — not mutated by this PR, verified absent read-only):** create environment `npm-release` with required **non-self** reviewers, admin bypass disabled, deployment refs restricted to the release refs; protect `main`; add a ruleset restricting `refs/tags/v*` creation to maintainers.

Verification: test:release 155/155, ci:check:full green, check-workflow-permissions ok, check:tools clean.

New exact-head digest: `8a9a956057f690ae40a654a2762e1614c5f20e03bb84f2dc4e18572c2bb11c79` over `06b8761c65...2b9c1f7496`.
## Round-7 resolution (head e0a2ac4079)

probepark's 2b9c1f74 merge-block is addressed:

1. **Publication order (major)** — `release_prepare` seals `planExpectedEvidencePublication`'s topological order as `gajae-release-publish-order-v1.json`; the fixed boundary iterates the sealed plan, verifies it covers exactly the expected package set, and rejects unknown names. The workflow-consumption regression test pins that the boundary reads the order file and never iterates the evidence array directly.
2. **workflow-permissions CI failure** — the allowlist assertion expected file order instead of job traversal order; fixed to `["publish.id-token", "release_finalize.contents"]` (exact set preserved, negative tests intact).
3. **Tag-ruleset note (minor)** — acknowledged and already documented: the inline publisher shell is loaded from the tagged revision, which is why the `refs/tags/v*` creation ruleset plus protected `main` are the owner-controlled load-bearing prerequisites in the hold checklist.

Verification: test:release 156/156, check-workflow-permissions.test.ts 16/16, check:tools clean, publish-loop smoke with stubbed npm (publish, skip, order-coverage rejection).

New exact-head digest: `e2e94092b45648a6e7c23bbe68ef1629d77d79cb368286499adc41f9060840f9` over `06b8761c65...e0a2ac4079`.
## Round-8 note (head d428f2a707)

snowykr's latest review arrived with a stale body (its findings 1–5 describe pre-round-3 state and were resolved in earlier rounds; its CI references predate this head) plus one live finding, now fixed: first-merged-PR selection for the New Contributors section compares merge timestamps (`earliestMergedPullRequest`, tie-break by PR number) instead of creation order, with regressions. Note: probepark APPROVED the prior head e0a2ac4079; this fix advances the head, so fresh exact-head review is required from a non-author collaborator.

New exact-head digest: `0debfbf29341a5ffc28526f1546ad6480c051692652d6b57f0b1041b345f5c58` over `06b8761c65...d428f2a707`.



## Current-dev fix-forward (head 983356a393)

Rebased the reviewed PR onto current `dev` `90049afad30705d5a170ec2ed9fb5b16c2492d54` after `dev` advanced. The cumulative source diff remains 13 files / 1,848 insertions and the canonical digest remains `sha256:5ad0ecdaa3d5e11955d5fa668ef2413e1cba70ec96e69891279a4a866ceef82a`. The exact-head squash-attribution fix is unchanged: GitHub merge/squash OIDs are retained as shipped evidence, with distinct branch/squash regression coverage.

Local verification passed after the rebase: `bun run test:release` 162/162, `bun run ci:check:full`, `bun scripts/check-workflow-permissions.ts`, and `bun run check:tools`. The prior approval at `7c4f3d56` was invalidated by this required base rebase; an exact-head approval is requested for `983356a393709b742caae6f2b34f3b644a81704e`. No release, tag, publish, main, repository-settings, environment, ruleset, or merge mutation was performed.


## Dev-merge disposition

Probepark’s authenticated approval is bound to the exact current head `983356a393709b742caae6f2b34f3b644a81704e`. Exact-head contract and state-gate checks are green. The affected-path run’s failed jobs are confined to unchanged `packages/ai` and `packages/coding-agent` baseline tests; release-note, release-policy, publish-order, retry, CI self-test, YAML, workflow-permissions, TypeScript, and native build jobs passed. Merging into `dev` triggers `dev-ci.yml` validation only; `.github/workflows/ci.yml` publish paths require `main`, `v*` tags, schedule, or explicit workflow dispatch, so this merge does not execute release or publish. Owner-controlled release settings and post-merge release execution remain untouched.

