### PR TITLE
fix(config): fail closed on retargeted CLI persistence

### DIFF
--- a/packages/coding-agent/src/cli/config-cli.ts
+++ b/packages/coding-agent/src/cli/config-cli.ts
@@ -10,6 +10,7 @@ import type * as path from "node:path";
 import { APP_NAME, getAgentDir } from "@gajae-code/utils";
 import { YAML } from "bun";
 import chalk from "chalk";
+import { AtomicYamlReplaceError, AtomicYamlRetargetError } from "../config/atomic-yaml-patch";
 import { resolveModelProfileName } from "../config/model-profile-contract";
 import { mergeModelProfiles } from "../config/model-profiles";
 import { ModelsConfigFile } from "../config/model-registry";
@@ -397,11 +398,55 @@ function handleGet(key: string | undefined, flags: { json?: boolean; showSecrets
  * exited 0 -- the setting silently reverts on the next process. Await the durable save and
  * fail loudly instead.
  */
+const SAFE_NESTED_DIAGNOSTIC_PATTERN =
+	/\b(?:atomic_[a-z0-9_]+|destination_[a-z0-9_]+|source_[a-z0-9_]+|cleanup_[a-z0-9_]+|E[A-Z0-9_]+)\b/i;
+
+function errorCode(error: unknown): string | undefined {
+	if (typeof error !== "object" || error === null || !("code" in error)) return undefined;
+	const code = (error as { code?: unknown }).code;
+	return typeof code === "string" && code.length > 0 ? code : undefined;
+}
+
+function errorCause(error: unknown): unknown {
+	if (typeof error !== "object" || error === null || !("cause" in error)) return undefined;
+	return (error as { cause?: unknown }).cause;
+}
+
+function nestedCauseDiagnostic(cause: unknown): string | undefined {
+	const code = errorCode(cause);
+	if (code && /^[A-Z][A-Z0-9_]{1,63}$/.test(code)) return code;
+	const message = cause instanceof Error ? cause.message : typeof cause === "string" ? cause : undefined;
+	const match = message?.match(SAFE_NESTED_DIAGNOSTIC_PATTERN);
+	return match?.[0]?.slice(0, 64);
+}
+
+function persistenceDiagnostic(error: unknown): string {
+	if (error instanceof AtomicYamlRetargetError) {
+		return "config target changed during save; retry after restoring the original target";
+	}
+	const code = errorCode(error);
+	const cause = errorCause(error);
+	if (error instanceof AtomicYamlReplaceError) {
+		const detail = nestedCauseDiagnostic(cause);
+		return detail ? `atomic replacement failed (${detail})` : "atomic replacement failed";
+	}
+	if (code) {
+		if (cause !== undefined) {
+			const nested = nestedCauseDiagnostic(cause);
+			return nested ? `${code}: ${nested}` : code;
+		}
+		return code;
+	}
+	const nested = nestedCauseDiagnostic(error);
+	if (nested) return nested;
+	return "unknown persistence failure";
+}
+
 async function persistOrExit(): Promise<void> {
 	try {
 		await settings.flushOrThrow();
 	} catch (err) {
-		console.error(chalk.red(`Failed to persist setting: ${err instanceof Error ? err.message : String(err)}`));
+		console.error(chalk.red(`Failed to persist setting: ${persistenceDiagnostic(err)}`));
 		process.exit(1);
 	}
 }

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -46,6 +46,7 @@ import {
 	type AtomicYamlConfigTransaction,
 	AtomicYamlConflictError,
 	type AtomicYamlPatch,
+	AtomicYamlRetargetError,
 	applyAtomicYamlPatches,
 	applyAtomicYamlPatchesWithCurrent,
 	atomicYamlPathHash,
@@ -1041,6 +1042,7 @@ export class Settings implements NotificationSettingsReader {
 			saveError = error;
 		}
 		await this.#refreshDurableSettings();
+		if (saveError instanceof AtomicYamlRetargetError) throw saveError;
 		if (this.#modified.size > 0 && !this.#pendingSaveSlot) {
 			this.#queueSave();
 			this.#releasePendingSaveSlot();

--- a/packages/coding-agent/test/config-cli.test.ts
+++ b/packages/coding-agent/test/config-cli.test.ts
@@ -3,7 +3,9 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getConfigRootDir, setAgentDir } from "@gajae-code/utils";
+import { YAML } from "bun";
 import { inspectConfigFile, runConfigCommand } from "../src/cli/config-cli";
+import { FileLockTestHooks } from "../src/config/file-lock";
 import { resetSettingsForTest } from "../src/config/settings";
 
 let testAgentDir = "";
@@ -379,6 +381,10 @@ describe("config CLI durable persistence", () => {
 		expect(exitSpy).toHaveBeenCalledWith(1);
 		const errors = errorSpy.mock.calls.map(call => Bun.stripANSI(String(call[0] ?? "")));
 		expect(errors.some(line => line.includes("Failed to persist setting"))).toBe(true);
+		const diagnostic = errors.join("\n");
+		expect(diagnostic).toMatch(/EACCES|atomic replacement failed|atomic_unavailable/);
+		expect(diagnostic).not.toContain(testAgentDir);
+		expect(diagnostic).not.toContain("true");
 		const logs = logSpy.mock.calls.map(call => Bun.stripANSI(String(call[0] ?? "")));
 		expect(logs.some(line => line.includes('"value": true') || line.includes('"value":true'))).toBe(false);
 	});
@@ -392,5 +398,87 @@ describe("config CLI durable persistence", () => {
 		expect(contents).toContain("colorBlindMode");
 		const logs = logSpy.mock.calls.map(call => String(call[0] ?? ""));
 		expect(logs.some(line => line.includes('"colorBlindMode"'))).toBe(true);
+	});
+
+	it("durably saves reset before reporting success", async () => {
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await runConfigCommand({ action: "set", key: "colorBlindMode", value: "true", flags: { json: true } });
+		logSpy.mockClear();
+		await runConfigCommand({ action: "reset", key: "colorBlindMode", flags: { json: true } });
+
+		const payload = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0])) as { key: string; value: unknown };
+		expect(payload).toEqual({ key: "colorBlindMode", value: false });
+		const persisted = YAML.parse(await fs.readFile(path.join(testAgentDir, "config.yml"), "utf8")) as {
+			colorBlindMode?: unknown;
+		};
+		expect(persisted.colorBlindMode).toBe(false);
+	});
+
+	it("fails reset without success output when the durable save is denied", async () => {
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation(((): never => {
+			throw new Error("process.exit");
+		}) as never);
+
+		await runConfigCommand({ action: "set", key: "colorBlindMode", value: "true", flags: { json: true } });
+		logSpy.mockClear();
+		await fs.chmod(testAgentDir, 0o500);
+
+		try {
+			await expect(
+				runConfigCommand({ action: "reset", key: "colorBlindMode", flags: { json: true } }),
+			).rejects.toThrow("process.exit");
+		} finally {
+			await fs.chmod(testAgentDir, 0o700);
+		}
+
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(logSpy).not.toHaveBeenCalled();
+		expect(errorSpy.mock.calls.map(call => String(call[0] ?? "")).join("\n")).toContain("Failed to persist setting");
+	});
+
+	it("does not retry a retargeted config save onto the new symlink target", async () => {
+		const realTarget = path.join(testAgentDir, "real-config.yml");
+		const otherTarget = path.join(testAgentDir, "other-config.yml");
+		const configPath = path.join(testAgentDir, "config.yml");
+		const initialConfig = "configSchemaVersion: 1\ncolorBlindMode: false\n";
+		await fs.writeFile(realTarget, initialConfig, "utf8");
+		await fs.writeFile(otherTarget, initialConfig, "utf8");
+		await fs.symlink(realTarget, configPath);
+		resetSettingsForTest();
+
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		await runConfigCommand({ action: "get", key: "colorBlindMode", flags: { json: true } });
+		logSpy.mockClear();
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation(((): never => {
+			throw new Error("process.exit");
+		}) as never);
+		const originalHook = FileLockTestHooks.afterParentMkdir;
+		let retargeted = false;
+		FileLockTestHooks.afterParentMkdir = async lockPath => {
+			if (retargeted || !lockPath.endsWith("real-config.yml.lock")) return;
+			retargeted = true;
+			await fs.rm(configPath, { force: true });
+			await fs.symlink(otherTarget, configPath);
+		};
+
+		try {
+			await expect(
+				runConfigCommand({ action: "set", key: "colorBlindMode", value: "true", flags: { json: true } }),
+			).rejects.toThrow("process.exit");
+		} finally {
+			FileLockTestHooks.afterParentMkdir = originalHook;
+		}
+
+		expect(retargeted).toBe(true);
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(await fs.readFile(realTarget, "utf8")).toBe(initialConfig);
+		expect(await fs.readFile(otherTarget, "utf8")).toBe(initialConfig);
+		const diagnostic = errorSpy.mock.calls.map(call => Bun.stripANSI(String(call[0] ?? ""))).join("\n");
+		expect(diagnostic).toContain("config target changed during save");
+		expect(diagnostic).not.toContain(testAgentDir);
 	});
 });


### PR DESCRIPTION
## What

Fix the three non-merge-blocking findings from #4681 review `4962582700` in the config CLI's durable-save path:

- reject `AtomicYamlRetargetError` without retrying after refresh, so `gjc config set` or `gjc config reset` cannot follow a newly retargeted `config.yml` symlink;
- include only bounded atomic failure reason codes in persistence diagnostics, never setting values or uncontrolled paths;
- add durable-reset success/denied-write coverage and a symlink-retarget regression proving neither target changes.

## Why

#4681 made mutating config commands wait for persistence before reporting success, but its review identified a fail-closed retarget gap and missing reset coverage. A retarget during the retry path could otherwise apply a setting to a different config target. This PR complements, rather than duplicates, #4681; GitHub issue/PR searches found no existing substantive follow-up.

User-visible behavior: a retargeted configuration save exits nonzero without changing either target; persistence errors expose safe reason codes such as `atomic_unavailable` rather than opaque top-level messages.

## Failure handling and platforms

Retarget failures are terminal for the current command. No fallback write is introduced. The focused suite runs with the Linux native addon; NFS `atomic_unavailable` is covered at the atomic-writer/error-mapping level, not against a live NFS mount.

## Testing

- `bun test packages/coding-agent/test/config-cli.test.ts packages/coding-agent/test/config/atomic-yaml-patch.test.ts` — 54 passed, 0 failed
- `bun --cwd=packages/coding-agent run check` — passed
- `bun scripts/verify-gjc-state-writers.ts --fail` — passed
- `git diff --check` — passed

No project-wide test, lint, check, or formatter gate was run.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:8f1ba296e3bff9a1b67fe643502a9409b5fa8e4992cc0feafb2ebef336f3643f reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head-approved-review-749f564-plus-bun-test-config-cli-atomic-yaml-patch-54-pass-coding-agent-check-writer-gate
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (targeted package check passed; full repository check was not run)
- [x] Tested locally
- [ ] CHANGELOG updated (not appropriate for this narrowly scoped follow-up; #4681 provides the parent user-facing change)
- [x] Verdict above matches the exact PR head, not an earlier commit