### PR TITLE
fix(coordinator): reconcile durable runtime events

### DIFF
--- a/packages/coding-agent/src/coordinator-mcp/question-state.ts
+++ b/packages/coding-agent/src/coordinator-mcp/question-state.ts
@@ -349,7 +349,8 @@ async function readJson<T>(file: string): Promise<T | null> {
 		return JSON.parse(await fs.readFile(file, "utf8")) as T;
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
-		throw new Error("state_corrupt");
+		if (error instanceof SyntaxError) throw new Error("state_corrupt");
+		throw error;
 	}
 }
 function assertTransaction(transaction: CoordinatorSessionTransactionV1, namespaceId: string, sessionId: string): void {

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -6055,6 +6055,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 						const reportPath = path.join(namespaceDir, "reports", `${reportId}.json`);
 						await writeJsonFile(reportPath, report);
 						await appendCoordinatorEvent(namespaceDir, {
+							...(sessionId == null ? { stableId: `report-written:${reportId}` } : {}),
 							kind: "report.written",
 							sessionId,
 							turnId: typeof args.turn_id === "string" ? args.turn_id : null,

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -1756,6 +1756,10 @@ console.log(JSON.stringify(await appendCoordinatorEventForTest(${JSON.stringify(
 		await expect(server.callTool("gjc_coordinator_read_coordination_status")).resolves.toMatchObject({
 			summary: { reports: 1 },
 		});
+		const events = await server.callTool("gjc_coordinator_watch_events", { after_seq: 0 });
+		expect(
+			(events.events as Array<Record<string, unknown>>).filter(event => event.kind === "report.written"),
+		).toHaveLength(1);
 	});
 	it("fails closed when a same-generation successor has a different endpoint incarnation", async () => {
 		const root = await tempRoot();


### PR DESCRIPTION
## What

Coordinator MCP now reconciles runtime terminal receipts and structured workflow blockers into its durable long-poll event journal. The branch also hardens retained-delivery ordering, runtime provenance, public error mapping, queue/report transitions, answer validation, status scope, and controller documentation.

## Why

Hermes and other controllers could drive GJC turns but could not reliably observe runtime completion or a newly opened structured blocker through `watch_events` alone. The previous recovery and public response paths also left correctness and public-contract gaps under audit.

## Behavior and recovery

- `gjc_coordinator_watch_events` projects terminal, waiting, and question transitions as bounded public journal events.
- Controllers resume from safe event cursors, read details through existing turn/question/artifact APIs, and never receive raw SDK endpoint/token errors.
- Failed/restarted delivery claims are reconciled through retained public-delivery state; non-active turn reports preserve an unrelated active turn.
- No webhook, raw endpoint access, terminal scraping, new MCP tool, or SDK protocol change is introduced.

## Related context

- Replaces the prior incomplete long-poll-only controller behavior discussed during Coordinator/Hermes integration review.
- Complements the existing Coordinator MCP bridge and `gjc setup hermes` integration; it is not a separate Hermes-only transport.

## Testing

- `bun test packages/coding-agent/test/coordinator-mcp-server.test.ts packages/coding-agent/test/bot-integration-docs.test.ts packages/coding-agent/test/coordinator-mcp-policy.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `bun scripts/verify-gjc-state-writers.ts --fail`

## Environment

Verified on macOS arm64 with Bun workspace tooling. The change is API/state-machine focused; no platform-specific external transport is added.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:ea89cbfd31bfa67b89cbd8b2f6fc43c2a07f1ed3c1310158ea4144112a9cf479 reviewer:human reviewer-id:probepark evidence:exact-head-1d90fd39-reaffirmation-after-dismissal-all-three-approved-hunks-verified-present-unchanged
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes for `packages/coding-agent`
- [x] Focused tests run locally
- [ ] CHANGELOG updated (not added: no packaged release-note decision was made)
- [x] Verdict above matches exact head 6be3768ac4544bd9d39bd79df7e7b56ce735d929 over base 06b8761c652d8f6713836937ecfcb43ead686539

Delta audit: 6fffff366dd58c498354a14e263595ee1325a139..6be3768ac4544bd9d39bd79df7e7b56ce735d929 only normalizes three auth-account files to the base versions (CHANGELOG and accounts-cli hashes equal base; accounts-cli-errors.test.ts is restored from base). The Coordinator functional diff and digest are unchanged: sha256:1e450202240cd544ea400fe5687a1e264cd779bbf691f2a80bea897c2b3c8ed7.

Human GitHub approval is required again because the branch was rebased onto live dev 012f62b52c2489e096a436c65a3fe732b3e250cd.

<!-- exact-head CI refresh -->