### PR TITLE
chore(schemas): regenerate config schema after global-only crash relay settings

### DIFF
--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -1232,12 +1232,12 @@
 						"off",
 						"sentry"
 					],
-					"description": "Opt in to transmit sanitized crash signatures to an aggregation service for cross-install counting. Off sends nothing. Only fields approved by `sanitizeExternalCrashV1` are sent; prompt text, source code, file contents, and credentials are excluded.",
+					"description": "Global-only opt-in to transmit sanitized crash signatures to an aggregation service for cross-install counting. Off sends nothing. Only fields approved by `sanitizeExternalCrashV1` are sent; prompt text, source code, file contents, and credentials are excluded.",
 					"default": "off"
 				},
 				"upstreamDsn": {
 					"type": "string",
-					"description": "Sentry DSN for the opted-in upstream; ignored while Crash Report Upstream is off, and no default destination exists. Only fields approved by `sanitizeExternalCrashV1` are sent; prompt text, source code, file contents, and credentials are excluded.",
+					"description": "Global-only Sentry DSN for the opted-in upstream; ignored while Crash Report Upstream is off, and no default destination exists. Only fields approved by `sanitizeExternalCrashV1` are sent; prompt text, source code, file contents, and credentials are excluded.",
 					"default": ""
 				}
 			},


### PR DESCRIPTION
## What

Regenerate `schemas/config.schema.json`. Two description strings, no shape change.

## Why

#4698 made `crashReport.upstream` and `crashReport.upstreamDsn` global-only, which changed their descriptions in `settings-schema.ts`, but the generated schema was not regenerated alongside it. Since that merged, `check:schemas` fails on `dev`:

```
Generated JSON Schemas are out of date: schemas/config.schema.json
Run `bun run generate-schemas` and commit the updated files.
```

`check:schemas` runs inside `ci:check:full`, so **root-check is red for every open PR** until this lands. I introduced it in #4698, so I am fixing it rather than leaving it for whoever hits it next.

## Testing

`bun run generate-schemas` then `bun run check:schemas` — passes. Output is exactly the two descriptions already present in `settings-schema.ts:1623,1633`.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:082f419f91261b39922f1bb18f78fd1c48c572e5cb64b87e92c43425e410dc26 reviewer:human reviewer-id:snowykr evidence:authenticated-APPROVED-review-4970547189-by-snowykr-at-exact-head-79f1491256bbafb498668055f75c743ebea5a8b2
```

---

- [x] Target branch is `dev`
- [x] `bun run check:schemas` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing) — not user-facing, generated artifact sync
- [x] Verdict above matches the exact PR head

<!-- gaebal-gajae -->