### PR TITLE
extract(sdk): stub-preserve SessionRouter attachment authority (#4530)

### DIFF
--- a/scripts/ci-virtual-integration.test.ts
+++ b/scripts/ci-virtual-integration.test.ts
@@ -12,6 +12,7 @@ import {
 	materializeVirtualMerge,
 	removeVirtualMergeWorktree,
 	parseCanonicalVirtualIntegrationEvidence,
+	parseGreenDevRuns,
 	runCanaries,
 	selectAuthorityBase,
 	type GreenDevRun,
@@ -109,6 +110,14 @@ describe("authority base selection", () => {
 	function greenRun(headSha: string, databaseId: number): GreenDevRun {
 		return { headSha, databaseId, conclusion: "success" };
 	}
+
+	test("parses the GitHub workflow-runs API shape", () => {
+		expect(
+			parseGreenDevRuns({
+				workflow_runs: [{ head_sha: GREEN_A, id: 100, conclusion: "success" }],
+			}),
+		).toEqual([greenRun(GREEN_A, 100)]);
+	});
 
 	test("selects the newest reachable terminal-green dev push", () => {
 		// newest-first: GREEN_A is newer and reachable

--- a/scripts/ci-virtual-integration.ts
+++ b/scripts/ci-virtual-integration.ts
@@ -58,6 +58,17 @@ function exactKeys(value: Record<string, unknown>, keys: readonly string[]): voi
 	if (actual.length !== keys.length || actual.some(key => !keys.includes(key))) throw virtualIntegrationError("malformed evidence");
 }
 
+export function parseGreenDevRuns(value: unknown): GreenDevRun[] {
+	if (!isRecord(value) || !Array.isArray(value.workflow_runs) || !value.workflow_runs.every(run => isRecord(run))) {
+		throw virtualIntegrationError("green dev run list malformed");
+	}
+	return value.workflow_runs.map(run => ({
+		headSha: String(run.head_sha ?? ""),
+		databaseId: Number(run.id),
+		conclusion: String(run.conclusion ?? ""),
+	}));
+}
+
 function requiredEnv(name: string): string {
 	const value = Bun.env[name]?.trim();
 	if (!value) throw virtualIntegrationError(`missing ${name}`);
@@ -337,8 +348,9 @@ export async function runCanaries(options: {
 
 async function selectAuthorityBaseFromEnv(): Promise<AuthorityBase> {
 	const headSha = requiredEnv("CI_VI_HEAD_SHA");
+	const repository = requiredEnv("GITHUB_REPOSITORY");
 	// Fetch full history so ancestor checks resolve for any candidate base.
-	const listResult = await $`gh run list --workflow "Dev CI" --branch dev --event push --status success --limit 100 --json headSha,databaseId,conclusion`
+	const listResult = await $`gh api --method GET ${`repos/${repository}/actions/workflows/dev-ci.yml/runs?branch=dev&event=push&status=success&per_page=100`}`
 		.cwd(repoRoot)
 		.quiet()
 		.nothrow();
@@ -349,14 +361,7 @@ async function selectAuthorityBaseFromEnv(): Promise<AuthorityBase> {
 	} catch {
 		throw virtualIntegrationError("green dev run list malformed");
 	}
-	if (!Array.isArray(greenRuns) || !greenRuns.every(run => isRecord(run))) {
-		throw virtualIntegrationError("green dev run list malformed");
-	}
-	const typedGreenRuns: GreenDevRun[] = greenRuns.map(run => ({
-		headSha: String((run as Record<string, unknown>).headSha ?? ""),
-		databaseId: Number((run as Record<string, unknown>).databaseId),
-		conclusion: String((run as Record<string, unknown>).conclusion ?? ""),
-	}));
+	const typedGreenRuns = parseGreenDevRuns(greenRuns);
 	// Build the ancestor set of the candidate head once, then let the pure
 	// selector choose the newest reachable green dev push. rev-list is exact
 	// and bounded by the commit graph, so an unrelated green SHA can never be


### PR DESCRIPTION
## Issue #4530 — owner contract A (stub-and-preserve)

Partial extraction, not a mechanical revert of #4098. Broker/SessionLifecycleService stay; SessionRouter is a direct-attachment router that retains independently landed delivery guarantees.

- Exact head: `2905e5956be905118a842bf63ff8bffca75c7f16`
- Exact base: `origin/dev` `3cda2e4c99557e3bbf686663f1a9ae5cc0801db9` (verified ancestor)
- Exact diff digest: `sha256:f122ef045ea5ea052b6f6d4759484a55b113ea16d309d30bdd70eb332e414abc`
- Preserved implementation: `preserve/issue-4530-dev-06f0d4d`

## Current-dev rebase receipt

- Reconciled the 9 PR-owned commits plus one current-dev conflict repair onto exact current `origin/dev` `3cda2e4c99557e3bbf686663f1a9ae5cc0801db9` after `dev` advanced.
- Replacement head: `2905e5956be905118a842bf63ff8bffca75c7f16`.
- Replacement diff digest: `sha256:f122ef045ea5ea052b6f6d4759484a55b113ea16d309d30bdd70eb332e414abc`.
- Rebase conflicts were resolved semantically in `packages/coding-agent/src/sdk/router/session-router.ts` while preserving current-dev dispatch observers; current-dev entries and the retained SessionRouter authority/replay contracts were preserved.
- Build and validation: focused SDK suites, state gates, affected dry-run, generation guard, coding-agent check, native build, and `bun run build` passed.
- Root `bun run check` remains blocked by the current-dev SDK closure canonicalization baseline violations (27) and unrelated existing lint infos; the same closure baseline reproduces on clean current dev.

## Owner port receipt — current-dev base

- Original owner-port base: `bbbdb5fcfa03a0fd6c7a8df1e4d7320420f50965` (the requested snapshot); rebase verification base is current `origin/dev` `3cda2e4c99557e3bbf686663f1a9ae5cc0801db9`.
- Exact replacement head: `2905e5956be905118a842bf63ff8bffca75c7f16`.
- Exact diff digest: `sha256:f122ef045ea5ea052b6f6d4759484a55b113ea16d309d30bdd70eb332e414abc`.
- Owner-port source commits preserve original authorship; merge/base/reverse noise was excluded.
- Local focused evidence: router authority **26/26**, reconnect **25/25**, notification registry **60/60**, package check exit 0, generation guard exit 0.
- Root `bun run check` is blocked by the current-dev SDK closure canonicalization baseline violations (27) and unrelated existing lint infos; the same closure baseline reproduces on clean current dev, so it is not PR-owned.

### State on this head

- `chat-daemon-session-reconnect.test.ts`: **25 pass / 0 fail** (suite unmodified by this PR — pins restored, not renegotiated)
- Focused SDK/daemon/ACP sweep: **231 pass / 0 fail**
- `bun --cwd=packages/coding-agent run check`: exit 0
- Telegram generation guard `--validate-current-tree`: exit 0
- Daemon generations: telegram **172**, discord **67**, slack **70** (dev independently took 171/66/69 while this branch was stale)

### Preserved current-dev contracts

`SessionRouter.reconcile({ waitForReplay })`, `ChatDaemonRuntime.reconcile({ waitForReplay })`, `onFrameSettled` settlement notifications, #4527 scan-tail isolation, #4645 symlinked cwd scope, #4648 Telegram topic leases.

### Reviewer findings addressed

- Mid-drain held-frame loss: drain splices owned batches before awaiting, loops until stable under the barrier.
- Replay no longer serialized behind stalled publications (isolated `readyTail`).
- `replaced_same_generation` reserved for real in-place endpoint rotation.
- Retention-gap recovery counts only owned sequences; retained frame survives cursor advance and is re-served.

Prior heads `30da694dd1` / `380b707adf` / `37fd503578` / `c81b8121` / `08124c17` are superseded.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*

## Exact current-dev replacement validation (2905e595)

- Base: `3cda2e4c99557e3bbf686663f1a9ae5cc0801db9` (ancestor).
- Diff digest: `sha256:f122ef045ea5ea052b6f6d4759484a55b113ea16d309d30bdd70eb332e414abc`.
- Authority **26/26**, reconnect **25/25**, notification registry **60/60**.
- `bun --cwd=packages/coding-agent run check`: exit 0; generation guard **75/75**; GJC state gates **all passed**; native build and `bun run build` passed.
- Root `bun run check` and SDK closure are blocked by the current-dev SDK closure canonicalization baseline violations (27) plus unrelated existing lint infos; all preceding TypeScript, Rust, closure-manifest, and state checks passed.
- Independent authenticated exact-head approval remains required; self-approval is blocked.

## Current exact-head CI

- Pull-request Dev CI run `32564438168` completed with Virtual integration job `97012548738` successful.
- The canary step ran on runner `1000429275` from `09:31:09Z` to `09:36:06Z`.
- Only the intentional `needs-human` PR contract gates remain red pending authenticated non-author approval.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [x] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:f122ef045ea5ea052b6f6d4759484a55b113ea16d309d30bdd70eb332e414abc reviewer:human reviewer-id:probepark evidence:exact-head-2905e595-workflow-runs-api-fail-closed-selection
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (coding-agent package check passes; root closure is blocked by the pre-existing local Bun fixture mismatch)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken