### PR TITLE
fix(sdk): drain durable reconciliation before session teardown completes

### DIFF
--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -219,6 +219,29 @@ const sdkReconciliationDrainTimeoutMs = (): number => {
 	const override = Number(process.env.GJC_SDK_RECONCILIATION_DRAIN_TIMEOUT_MS);
 	return override > 0 ? override : 5_000;
 };
+/**
+ * #4743: the two reconciliation failure codes that mean durable state may be
+ * lost. Both must reach the teardown owner; every other owner-release failure
+ * stays retryable through the retained `cleanupRetries` entry.
+ */
+const RECONCILIATION_DURABILITY_FAILURE_CODES: ReadonlySet<string> = new Set([
+	"reconciliation_persist_failed",
+	"reconciliation_drain_timeout",
+]);
+function reconciliationFailureCode(value: unknown): string | undefined {
+	if (typeof value !== "object" || value === null) return undefined;
+	const code = (value as { code?: unknown }).code;
+	return typeof code === "string" && RECONCILIATION_DURABILITY_FAILURE_CODES.has(code) ? code : undefined;
+}
+/**
+ * Flatten an owner-release failure to its durability-failure members. Aggregates
+ * nest (the store batches a drained window's failures, and owner release batches
+ * every release failure), so recursion is required to reach the coded leaves.
+ */
+function reconciliationDurabilityFailures(error: unknown): unknown[] {
+	if (error instanceof AggregateError) return error.errors.flatMap(member => reconciliationDurabilityFailures(member));
+	return reconciliationFailureCode(error) === undefined ? [] : [error];
+}
 type PromptTerminalDiagnostic = {
 	reason?: unknown;
 	loopStopReason?: string;
@@ -1197,9 +1220,10 @@ interface SessionRuntime {
 	disableEphemeralTurns: () => void;
 	waitForGateResolutionQuiescence: () => Promise<void>;
 	/** Awaits durable quiescence of every reconciliation transaction this runtime
-	 *  admitted, joining their producers first; resolves `{ timedOut: true }` at
-	 *  the bounded deadline so expiry stays observable (#4743). */
-	drainDurableReconciliation: () => Promise<{ timedOut: boolean }>;
+	 *  admitted, joining their producers first. Never swallows evidence: producer
+	 *  and store rejections are returned in `failures`, and a bounded-deadline
+	 *  expiry is returned as `timedOut` (#4743). */
+	drainDurableReconciliation: () => Promise<{ timedOut: boolean; failures: unknown[] }>;
 	trackGateResolution: <T>(resolution: Promise<T>) => Promise<T>;
 	workflowGate?: WorkflowGateEmitter;
 	gatePresentations?: PresentationArbiter;
@@ -4393,6 +4417,10 @@ export function createNotificationsExtension(
 		// never silently treated as drained).
 		try {
 			const drained = await rt.drainDurableReconciliation();
+			for (const failure of drained.failures) {
+				ownerReleaseFailures.push(failure);
+				logger.warn(`sdk reconciliation publication failed during teardown: ${String(failure)}`);
+			}
 			if (drained.timedOut) {
 				const timeoutError = Object.assign(
 					new Error(
@@ -4760,9 +4788,16 @@ export function createNotificationsExtension(
 		const reconciliationProducers = new Set<Promise<unknown>>();
 		const trackReconciliationProducer = (producer: Promise<unknown>): void => {
 			reconciliationProducers.add(producer);
-			void producer.finally(() => {
+			// Deliberately a two-arm handler, NOT `finally`: `finally` returns a derived
+			// promise that re-rejects when the producer rejects, and nothing observes
+			// that derived promise — a failed durable write would become an unhandled
+			// rejection and kill the resident process. The two-arm form always resolves,
+			// while the ORIGINAL producer keeps its rejection for the teardown drain to
+			// inspect (#4743).
+			const forget = (): void => {
 				reconciliationProducers.delete(producer);
-			});
+			};
+			void producer.then(forget, forget);
 		};
 		// Restart recovery must commit before any prompt is admitted; otherwise a new
 		// admission can race the hydrated full-state replacement.
@@ -6831,24 +6866,54 @@ export function createNotificationsExtension(
 			// finite deadline whose expiry is reported as a NON-QUIESCENT result so
 			// the caller records an owner-release failure instead of silently
 			// treating a hung write as drained.
-			drainDurableReconciliation: async (): Promise<{ timedOut: boolean }> => {
+			drainDurableReconciliation: async (): Promise<{ timedOut: boolean; failures: unknown[] }> => {
+				// One failed write surfaces twice by design — once as the producer's
+				// rejection and once through the store's failure window — and both carry
+				// the same coded error object, so identity dedupe keeps the reported
+				// evidence at one entry per real failure without dropping distinct ones.
+				const seen = new Set<unknown>();
+				const failures: unknown[] = [];
+				const record = (failure: unknown): void => {
+					if (seen.has(failure)) return;
+					seen.add(failure);
+					failures.push(failure);
+				};
 				const quiescent = (async () => {
 					while (true) {
 						const producers = [...reconciliationProducers];
-						await Promise.allSettled(producers);
-						await kindReconciliation.drain();
+						// `allSettled` joins ALL producers even when one rejects, but its
+						// results are INSPECTED: a rejected terminal publication is evidence
+						// the caller must see, not something the join consumes before the
+						// store's own failure window opens (#4743).
+						for (const settled of await Promise.allSettled(producers))
+							if (settled.status === "rejected") record(settled.reason);
+						// Both drains below surface store-recorded persistence failures by
+						// rejecting; collect and keep draining so one failed write cannot
+						// hide a later producer's work from the join.
+						try {
+							await kindReconciliation.drain();
+						} catch (e) {
+							record(e);
+						}
 						// Direct store writes (terminal-scope response-state advance) bypass
 						// the kind-aware chain; join them too.
-						await durableStore?.drain?.();
+						try {
+							await durableStore?.drain?.();
+						} catch (e) {
+							record(e);
+						}
 						await Bun.sleep(0);
 						if ([...reconciliationProducers].every(producer => producers.includes(producer))) {
-							return { timedOut: false };
+							return { timedOut: false, failures };
 						}
 					}
 				})();
 				return await Promise.race([
 					quiescent,
-					Bun.sleep(sdkReconciliationDrainTimeoutMs()).then(() => ({ timedOut: true })),
+					// A deadline expiry reports the failures observed SO FAR alongside the
+					// timeout: evidence already collected must not be dropped because the
+					// remaining wait ran out.
+					Bun.sleep(sdkReconciliationDrainTimeoutMs()).then(() => ({ timedOut: true, failures })),
 				]);
 			},
 			disposeGateEmitterListener: () => {},
@@ -8998,6 +9063,11 @@ export function createNotificationsExtension(
 			return false;
 		});
 		if (startupWasPending) void settledControllerStop;
+		// #4743: a durability failure has no later retry cycle at terminal quit, so it
+		// must reach the teardown owner instead of being logged into silence. Held
+		// until the controller queue below is joined so the failure never truncates
+		// the rest of teardown.
+		let reconciliationTeardownFailure: Error | undefined;
 		try {
 			await stopSession(id);
 		} catch (error) {
@@ -9007,11 +9077,27 @@ export function createNotificationsExtension(
 			// shutdown. On terminal quit there is no later retry cycle, so log at
 			// error severity (matching the postmortem cleanup precedent).
 			logger.error(`notifications: SDK notification runtime cleanup failed: ${String(error)}`);
+			// Endpoint-release failures (host/server stop) stay swallowed: they are
+			// retryable through the retained cleanupRetries entry and observable in
+			// lifecycle rollback proof. Reconciliation durability failures are not —
+			// a committed publication that never reached disk, or a drain whose
+			// deadline expired, is state loss the owner must be told about.
+			const durable = reconciliationDurabilityFailures(error);
+			if (durable.length > 0)
+				reconciliationTeardownFailure = Object.assign(
+					new Error(
+						`SDK reconciliation teardown failed for session ${id}: ${durable
+							.map(failure => reconciliationFailureCode(failure) ?? "unknown")
+							.join(", ")}.`,
+					),
+					{ code: "sdk_reconciliation_teardown_failed", failures: durable },
+				);
 		}
 		// Keep shutdown nonblocking only while native startup is genuinely
 		// pending (the `/notify on` path); otherwise await the controller queue so
 		// completed-start reconciliation and its replacement-token cleanup are
 		// joined before lifecycle shutdown returns.
 		if (!startupWasPending) await settledControllerStop;
+		if (reconciliationTeardownFailure) throw reconciliationTeardownFailure;
 	});
 }

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -1186,6 +1186,9 @@ interface SessionRuntime {
 	/** Aborts and fences side turns while notification delivery is disabled. */
 	disableEphemeralTurns: () => void;
 	waitForGateResolutionQuiescence: () => Promise<void>;
+	/** Awaits durable quiescence of every reconciliation transaction this runtime
+	 *  admitted, so teardown owners observe a settled store (#4743). */
+	drainDurableReconciliation: () => Promise<void>;
 	trackGateResolution: <T>(resolution: Promise<T>) => Promise<T>;
 	workflowGate?: WorkflowGateEmitter;
 	gatePresentations?: PresentationArbiter;
@@ -4343,6 +4346,18 @@ export function createNotificationsExtension(
 				logger.warn(`notifications: stop failed: ${String(e)}`);
 			}
 		}
+		// #4743: terminal release must not be reported while a fire-and-forget
+		// reconciliation publication this runtime admitted is still between its temp
+		// write and atomic rename — an owner removing the state tree at that instant
+		// fails the rename with ENOENT/reconciliation_persist_failed. Observe durable
+		// quiescence AFTER the endpoint stopped serving (no new admissions) and
+		// BEFORE the terminal release is recorded.
+		try {
+			await rt.drainDurableReconciliation();
+		} catch (e) {
+			ownerReleaseFailures.push(e);
+			logger.warn(`sdk reconciliation drain failed: ${String(e)}`);
+		}
 		lifecycleStartupCapability?.rollback?.recordStop(rt.host.generation, {
 			runtimeRemoved: true,
 			hostStopped: rt.hostStopped && rt.serverStopped,
@@ -6742,6 +6757,17 @@ export function createNotificationsExtension(
 			enableNotifications: () => {},
 			disposeGateTerminalController: () => {},
 			disposeAckRecoveryParticipant: () => {},
+			// #4743: session teardown must observe durable quiescence of every
+			// reconciliation transaction this runtime admitted. Fire-and-forget
+			// post-response publications (agent_end/agent_failed transitions) are
+			// enqueued on the store chain, not awaited by their callers; without this
+			// drain an external teardown owner removing the state tree the moment
+			// session_shutdown resolves can delete the .sdk-reconciliation directory
+			// between a publication's temp write and its atomic rename (ENOENT,
+			// reconciliation_persist_failed).
+			drainDurableReconciliation: async () => {
+				await durableStore?.drain?.();
+			},
 			disposeGateEmitterListener: () => {},
 			trackGateResolution,
 			waitForGateResolutionQuiescence: async () => {

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -209,6 +209,16 @@ const PROMPT_SETTLEMENT_DIAGNOSTIC_MAX_AGE_MS = 86_400_000;
  * provider error cannot flood the log file.
  */
 const PROMPT_TERMINAL_FAILURE_REASON_LOG_MAX = 512;
+/**
+ * #4743: bounded wait for durable reconciliation quiescence during session
+ * teardown. Expiry is OBSERVABLE (owner-release failure), never silently
+ * treated as drained. Read per drain so the env override is effective for
+ * deterministic tests.
+ */
+const sdkReconciliationDrainTimeoutMs = (): number => {
+	const override = Number(process.env.GJC_SDK_RECONCILIATION_DRAIN_TIMEOUT_MS);
+	return override > 0 ? override : 5_000;
+};
 type PromptTerminalDiagnostic = {
 	reason?: unknown;
 	loopStopReason?: string;
@@ -1187,8 +1197,9 @@ interface SessionRuntime {
 	disableEphemeralTurns: () => void;
 	waitForGateResolutionQuiescence: () => Promise<void>;
 	/** Awaits durable quiescence of every reconciliation transaction this runtime
-	 *  admitted, so teardown owners observe a settled store (#4743). */
-	drainDurableReconciliation: () => Promise<void>;
+	 *  admitted, joining their producers first; resolves `{ timedOut: true }` at
+	 *  the bounded deadline so expiry stays observable (#4743). */
+	drainDurableReconciliation: () => Promise<{ timedOut: boolean }>;
 	trackGateResolution: <T>(resolution: Promise<T>) => Promise<T>;
 	workflowGate?: WorkflowGateEmitter;
 	gatePresentations?: PresentationArbiter;
@@ -2479,6 +2490,10 @@ function sdkControlSurface(
 		discardTerminalAbortSteeringSnapshot?: (token: number) => void;
 		rebindTerminalAbortSteeringSnapshot?: (token: number) => void;
 	},
+	// #4743: registers fire-and-forget reconciliation producers (accepted
+	// executions and post-response publications) so session teardown can join
+	// them before reporting durable quiescence.
+	trackReconciliationProducer?: (producer: Promise<unknown>) => void,
 ): ControlSurface & {
 	cancelPendingPreflights(): Promise<void>;
 	cancelPendingPreflightsForConnection(connectionId: string): Promise<void>;
@@ -2753,6 +2768,10 @@ function sdkControlSurface(
 			}
 			accepting = false;
 			accepted = true;
+			// #4743: an accepted run owns a durable terminal publication when it
+			// settles; teardown joins it via this latch (never-accepted preflights
+			// produce no durable write and stay unjoined by design).
+			trackReconciliationProducer?.(submissionSettled.promise);
 			pendingPreflightCancellations.delete(key);
 			settlePreflight({ status: "accepted" });
 			if (preflightController.signal.aborted) throw cancellationError;
@@ -2778,10 +2797,14 @@ function sdkControlSurface(
 			);
 		} catch (error) {
 			submissionSettled.resolve();
-			if (accepted && !preflightController.signal.aborted) void onPromptFailed(correlation, error);
+			if (accepted && !preflightController.signal.aborted)
+				trackReconciliationProducer?.(Promise.resolve(onPromptFailed(correlation, error)));
 			else settlePreflight({ status: "rejected", error });
 		}
 		if (submission) {
+			// #4743: the continuation may settle long after teardown (a cancelled
+			// preflight stays pending forever by design), so the EXECUTION is never
+			// joined — only its reconciliation publications are tracked below.
 			void submission.then(
 				() => {
 					if (!accepted)
@@ -2794,7 +2817,8 @@ function sdkControlSurface(
 					submissionSettled.resolve();
 				},
 				error => {
-					if (accepted && !preflightController.signal.aborted) void onPromptFailed(correlation, error);
+					if (accepted && !preflightController.signal.aborted)
+						trackReconciliationProducer?.(Promise.resolve(onPromptFailed(correlation, error)));
 					else settlePreflight({ status: "rejected", error });
 					submissionSettled.resolve();
 				},
@@ -3290,6 +3314,10 @@ function sdkControlSurface(
 								if (skillRecon) {
 									await skillRecon.noteAccepted(correlation, trimmedClientRef, { skillName: meta.name });
 									durableSkillAccepted = true;
+									// #4743: a durably accepted skill owns a terminal
+									// publication; teardown joins this latch (bounded by the
+									// drain deadline).
+									trackReconciliationProducer?.(executionSettled.promise);
 								}
 							} catch (error) {
 								onPromptAcceptFailed(correlation);
@@ -3308,6 +3336,11 @@ function sdkControlSurface(
 				settleReject(error);
 				run = Promise.reject(error);
 			}
+			// #4743: the skill execution itself may outlive teardown (a cancelled
+			// preflight never settles by design), so only its reconciliation
+			// PUBLICATIONS are tracked — created synchronously the moment the
+			// execution settles, so a publication fired during teardown is always
+			// joined before the drain reports quiescence.
 			void run.then(
 				result => {
 					if (phase === "pending") {
@@ -3320,12 +3353,14 @@ function sdkControlSurface(
 							...(trimmedClientRef ? { clientRef: trimmedClientRef } : {}),
 						});
 					} else if (durableSkillAccepted && skillRecon) {
-						void skillRecon.noteTransition(correlation, {
-							type: "agent_end",
-							...(typeof result === "string"
-								? { content: { version: 1, type: "text", text: result, byteLength: 0, truncated: false } }
-								: {}),
-						});
+						trackReconciliationProducer?.(
+							skillRecon.noteTransition(correlation, {
+								type: "agent_end",
+								...(typeof result === "string"
+									? { content: { version: 1, type: "text", text: result, byteLength: 0, truncated: false } }
+									: {}),
+							}),
+						);
 					}
 					executionSettled.resolve();
 				},
@@ -3334,10 +3369,12 @@ function sdkControlSurface(
 						releaseAdmission();
 						settleReject(error);
 					} else if (phase === "accepted" && promptOwned && !preflightController.signal.aborted) {
-						void onPromptFailed(correlation, error);
+						trackReconciliationProducer?.(Promise.resolve(onPromptFailed(correlation, error)));
 					}
 					if (durableSkillAccepted && skillRecon && !preflightController.signal.aborted)
-						void skillRecon.noteTransition(correlation, { type: "agent_failed", error });
+						trackReconciliationProducer?.(
+							skillRecon.noteTransition(correlation, { type: "agent_failed", error }),
+						);
 					executionSettled.resolve();
 				},
 			);
@@ -4346,14 +4383,26 @@ export function createNotificationsExtension(
 				logger.warn(`notifications: stop failed: ${String(e)}`);
 			}
 		}
-		// #4743: terminal release must not be reported while a fire-and-forget
-		// reconciliation publication this runtime admitted is still between its temp
-		// write and atomic rename — an owner removing the state tree at that instant
-		// fails the rename with ENOENT/reconciliation_persist_failed. Observe durable
-		// quiescence AFTER the endpoint stopped serving (no new admissions) and
-		// BEFORE the terminal release is recorded.
+		// #4743: terminal release must not be reported while a reconciliation
+		// publication this runtime admitted — or the execution that will produce it —
+		// is still in flight. Observe durable quiescence AFTER the endpoint stopped
+		// serving (no new admissions) and BEFORE the terminal release is recorded.
+		// Both failure shapes stay observable as owner-release failures: a drained
+		// window containing a failed write (reconciliation_persist_failed evidence
+		// preserved through the store drain) and a deadline expiry (non-quiescent,
+		// never silently treated as drained).
 		try {
-			await rt.drainDurableReconciliation();
+			const drained = await rt.drainDurableReconciliation();
+			if (drained.timedOut) {
+				const timeoutError = Object.assign(
+					new Error(
+						`SDK reconciliation drain timed out after ${sdkReconciliationDrainTimeoutMs()}ms; reconciliation state may be non-quiescent.`,
+					),
+					{ code: "reconciliation_drain_timeout" },
+				);
+				ownerReleaseFailures.push(timeoutError);
+				logger.warn("sdk reconciliation drain timed out; proceeding with non-quiescent state");
+			}
 		} catch (e) {
 			ownerReleaseFailures.push(e);
 			logger.warn(`sdk reconciliation drain failed: ${String(e)}`);
@@ -4702,6 +4751,19 @@ export function createNotificationsExtension(
 				? createReconciliationStore({ sessionFile, sessionId: String(reconciliationSessionId) })
 				: null;
 		const kindReconciliation = createKindAwareReconciliation({ store: durableStore });
+		// #4743: reconciliation publications and the executions that produce them
+		// are fire-and-forget at their call sites; without joining the PRODUCERS a
+		// drain can observe an empty queue and return just before a still-running
+		// skill enqueues its terminal publication — the teardown race again, by
+		// another route. Every void-ed producer registers here and the teardown
+		// drain joins the set before awaiting store quiescence.
+		const reconciliationProducers = new Set<Promise<unknown>>();
+		const trackReconciliationProducer = (producer: Promise<unknown>): void => {
+			reconciliationProducers.add(producer);
+			void producer.finally(() => {
+				reconciliationProducers.delete(producer);
+			});
+		};
 		// Restart recovery must commit before any prompt is admitted; otherwise a new
 		// admission can race the hydrated full-state replacement.
 		let reconciliationReady: Promise<void> = durableStore ? kindReconciliation.hydrateFromStore() : Promise.resolve();
@@ -6331,6 +6393,8 @@ export function createNotificationsExtension(
 				settleSteer: kindReconciliation.settleSteer,
 			},
 			terminalAbortSeams,
+			// #4743: join fire-and-forget reconciliation producers at teardown.
+			trackReconciliationProducer,
 		);
 		cancelPreflightsForConnection = controlSurface.cancelPendingPreflightsForConnection;
 		const abandonPromptResponse = (connectionId: string, frame: Record<string, unknown>) => {
@@ -6758,15 +6822,34 @@ export function createNotificationsExtension(
 			disposeGateTerminalController: () => {},
 			disposeAckRecoveryParticipant: () => {},
 			// #4743: session teardown must observe durable quiescence of every
-			// reconciliation transaction this runtime admitted. Fire-and-forget
-			// post-response publications (agent_end/agent_failed transitions) are
-			// enqueued on the store chain, not awaited by their callers; without this
-			// drain an external teardown owner removing the state tree the moment
-			// session_shutdown resolves can delete the .sdk-reconciliation directory
-			// between a publication's temp write and its atomic rename (ENOENT,
-			// reconciliation_persist_failed).
-			drainDurableReconciliation: async () => {
-				await durableStore?.drain?.();
+			// reconciliation transaction this runtime admitted, INCLUDING the ones
+			// whose producers (accepted skill/prompt executions and their post-
+			// response publications) are still running when teardown starts — an
+			// empty queue proves nothing about work that has not been enqueued yet.
+			// Order: join producers → join kind-aware mutations → join the store
+			// chain (which also surfaces persistence-failure evidence). All under a
+			// finite deadline whose expiry is reported as a NON-QUIESCENT result so
+			// the caller records an owner-release failure instead of silently
+			// treating a hung write as drained.
+			drainDurableReconciliation: async (): Promise<{ timedOut: boolean }> => {
+				const quiescent = (async () => {
+					while (true) {
+						const producers = [...reconciliationProducers];
+						await Promise.allSettled(producers);
+						await kindReconciliation.drain();
+						// Direct store writes (terminal-scope response-state advance) bypass
+						// the kind-aware chain; join them too.
+						await durableStore?.drain?.();
+						await Bun.sleep(0);
+						if ([...reconciliationProducers].every(producer => producers.includes(producer))) {
+							return { timedOut: false };
+						}
+					}
+				})();
+				return await Promise.race([
+					quiescent,
+					Bun.sleep(sdkReconciliationDrainTimeoutMs()).then(() => ({ timedOut: true })),
+				]);
 			},
 			disposeGateEmitterListener: () => {},
 			trackGateResolution,

--- a/packages/coding-agent/src/sdk/bus/kind-aware-reconciliation.ts
+++ b/packages/coding-agent/src/sdk/bus/kind-aware-reconciliation.ts
@@ -89,6 +89,8 @@ export interface KindAwareReconciliation {
 	activeCount(kind: ReconciliationKind): number;
 	/** Hydrate from durable store (call once at session host start). */
 	hydrateFromStore(): Promise<void>;
+	/** Await quiescence of every admitted mutation and the durable store (#4743). */
+	drain(): Promise<void>;
 }
 
 export function createKindAwareReconciliation(
@@ -534,6 +536,19 @@ export function createKindAwareReconciliation(
 		);
 		await pending;
 	};
+	const drain = async (): Promise<void> => {
+		while (true) {
+			const observed = mutationChain;
+			await observed;
+			// A noteTransition/noteAccepted admitted in a later microtask must still
+			// be joined before teardown reports durable quiescence (#4743).
+			await Bun.sleep(0);
+			if (mutationChain === observed) {
+				await store?.drain?.();
+				return;
+			}
+		}
+	};
 
 	return {
 		admit,
@@ -551,6 +566,7 @@ export function createKindAwareReconciliation(
 		reserveSteer,
 		settleSteer,
 		lookupSteer,
+		drain,
 	};
 }
 

--- a/packages/coding-agent/src/sdk/bus/reconciliation-store.ts
+++ b/packages/coding-agent/src/sdk/bus/reconciliation-store.ts
@@ -625,13 +625,20 @@ export function createReconciliationStore(options: {
 	let terminalMemory: DurableTerminalScopeRecord[] = [];
 	let terminalKeyMemory: EvictedTerminalKeyEntry[] = [];
 	let chain: Promise<void> = Promise.resolve();
+	// #4743: transaction tails neutralize rejection on the serialization chain, so
+	// a failed publication is invisible to a plain tail await. Record the failure
+	// sequence here so drain() can surface evidence for exactly the window it
+	// awaited instead of reporting a failed write as drained.
+	let persistFailureCount = 0;
+	let lastPersistFailure: unknown;
 
 	const writeAtomic = async (document: ReconciliationStoreDocument): Promise<void> => {
 		if (!filePath) return;
 		const directory = path.dirname(filePath);
-		await fileFs.mkdir(directory, { recursive: true, mode: 0o700 });
-		const temporary = `${filePath}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`;
+		let temporary: string | undefined;
 		try {
+			await fileFs.mkdir(directory, { recursive: true, mode: 0o700 });
+			temporary = `${filePath}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`;
 			await fileFs.writeFile(temporary, `${JSON.stringify(document)}\n`, { mode: 0o600 });
 			try {
 				const handle = await fileFs.open(temporary, "r+");
@@ -645,10 +652,15 @@ export function createReconciliationStore(options: {
 			}
 			await fileFs.rename(temporary, filePath);
 		} catch (error) {
-			await fileFs.unlink(temporary).catch(() => {});
-			throw Object.assign(error instanceof Error ? error : new Error("reconciliation persist failed"), {
+			// Every persistence-path failure (mkdir included) is evidence a drained
+			// window must surface, never silently treat as quiescent (#4743).
+			if (temporary !== undefined) await fileFs.unlink(temporary).catch(() => {});
+			const coded = Object.assign(error instanceof Error ? error : new Error("reconciliation persist failed"), {
 				code: "reconciliation_persist_failed",
 			});
+			persistFailureCount += 1;
+			lastPersistFailure = coded;
+			throw coded;
 		}
 	};
 
@@ -827,6 +839,9 @@ export function createReconciliationStore(options: {
 		transactTerminalState,
 		transactTerminalKeys,
 		drain: async () => {
+			// Snapshot the failure sequence first: only failures recorded after this
+			// point belong to the window this drain awaits (#4743).
+			const observedFailures = persistFailureCount;
 			while (true) {
 				const observed = chain;
 				await observed;
@@ -834,7 +849,14 @@ export function createReconciliationStore(options: {
 				// a later microtask. Yield once and require the queue tail to remain
 				// stable before reporting durable quiescence.
 				await Bun.sleep(0);
-				if (chain === observed) return;
+				if (chain === observed) {
+					// Transaction tails neutralize rejections on `chain`, so a failed
+					// publication would otherwise be indistinguishable from a completed
+					// one: surface the recorded failure instead of claiming quiescence
+					// (#4743).
+					if (persistFailureCount > observedFailures) throw lastPersistFailure;
+					return;
+				}
 			}
 		},
 		loadTerminalScopes: async () => {

--- a/packages/coding-agent/src/sdk/bus/reconciliation-store.ts
+++ b/packages/coding-agent/src/sdk/bus/reconciliation-store.ts
@@ -625,12 +625,13 @@ export function createReconciliationStore(options: {
 	let terminalMemory: DurableTerminalScopeRecord[] = [];
 	let terminalKeyMemory: EvictedTerminalKeyEntry[] = [];
 	let chain: Promise<void> = Promise.resolve();
-	// #4743: transaction tails neutralize rejection on the serialization chain, so
-	// a failed publication is invisible to a plain tail await. Record the failure
-	// sequence here so drain() can surface evidence for exactly the window it
-	// awaited instead of reporting a failed write as drained.
-	let persistFailureCount = 0;
-	let lastPersistFailure: unknown;
+	// #4743: transaction tails neutralize rejection on the serialization chain and
+	// publications are enqueued fire-and-forget, so a failed write has no observer
+	// at all. Retain every persistence failure until a drain reports it, then clear
+	// it: surface-once means no failure is lost (even one that landed before
+	// teardown began) and no later drain is permanently poisoned by a failure an
+	// owner has already been told about.
+	let unreportedPersistFailures: unknown[] = [];
 
 	const writeAtomic = async (document: ReconciliationStoreDocument): Promise<void> => {
 		if (!filePath) return;
@@ -658,8 +659,7 @@ export function createReconciliationStore(options: {
 			const coded = Object.assign(error instanceof Error ? error : new Error("reconciliation persist failed"), {
 				code: "reconciliation_persist_failed",
 			});
-			persistFailureCount += 1;
-			lastPersistFailure = coded;
+			unreportedPersistFailures.push(coded);
 			throw coded;
 		}
 	};
@@ -839,9 +839,6 @@ export function createReconciliationStore(options: {
 		transactTerminalState,
 		transactTerminalKeys,
 		drain: async () => {
-			// Snapshot the failure sequence first: only failures recorded after this
-			// point belong to the window this drain awaits (#4743).
-			const observedFailures = persistFailureCount;
 			while (true) {
 				const observed = chain;
 				await observed;
@@ -852,10 +849,13 @@ export function createReconciliationStore(options: {
 				if (chain === observed) {
 					// Transaction tails neutralize rejections on `chain`, so a failed
 					// publication would otherwise be indistinguishable from a completed
-					// one: surface the recorded failure instead of claiming quiescence
-					// (#4743).
-					if (persistFailureCount > observedFailures) throw lastPersistFailure;
-					return;
+					// one. Claim the retained evidence (clearing it so exactly one drain
+					// reports each failure) and reject instead of claiming quiescence.
+					if (unreportedPersistFailures.length === 0) return;
+					const claimed = unreportedPersistFailures;
+					unreportedPersistFailures = [];
+					if (claimed.length === 1) throw claimed[0];
+					throw new AggregateError(claimed, "Reconciliation persistence failed during the drained window.");
 				}
 			}
 		},

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -3025,6 +3025,164 @@ test("session_shutdown awaits a late reconciliation publication before teardown 
 	expect(persisted.records.some(record => record.kind === "skill")).toBe(true);
 	pausedCommit.restore();
 }, 60_000);
+test("session_shutdown joins a still-executing skill before teardown can race its publication (#4743)", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-skill-teardown-join-"));
+	dirs.push(cwd);
+	const sessionId = `sdk-skill-teardown-join-${Date.now()}`;
+	const sessionFile = path.join(cwd, "session.jsonl");
+	const sessionContext = context(cwd, sessionId);
+	const sessionManager = sessionContext.sessionManager as Record<string, unknown>;
+	sessionContext.sessionManager = {
+		...sessionManager,
+		getSessionFile: () => sessionFile,
+	};
+	const baseBindings = sessionContext.sdkBindings as () => string[];
+	sessionContext.sdkBindings = () => [...baseBindings(), "invokeSkill"];
+	// The skill is ACCEPTED and still executing when shutdown begins; nothing has
+	// been resolved yet, so an empty-queue drain would return immediately and the
+	// late agent_end publication would race teardown (#4743 major 1).
+	const resumeExecution = Promise.withResolvers<void>();
+	sessionContext.invokeSkill = async (
+		_name: string,
+		args: string | undefined,
+		options?: {
+			onSkillPrepared?: (meta: { name: string; path: string; cleanedArgs?: string }) => void;
+			onPreflightAcceptCommit?: () => void | Promise<void>;
+		},
+	) => {
+		options?.onSkillPrepared?.({ name: "fixture-skill", path: "/fixture/SKILL.md", cleanedArgs: args });
+		await options?.onPreflightAcceptCommit?.();
+		await resumeExecution.promise;
+		return { name: "fixture-skill", path: "/fixture/SKILL.md", args };
+	};
+	const storePath = reconciliationStorePath(sessionFile, sessionId);
+	const handlers = start(sessionContext, undefined, () => {}, false, new Map(), undefined, false);
+	await handlers.get("session_start")?.({ type: "session_start" }, sessionContext);
+	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+	const frames: Record<string, unknown>[] = [];
+	const socket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	sockets.push(socket);
+	socket.addEventListener("message", event => frames.push(JSON.parse(String(event.data))));
+	await new Promise<void>((resolve, reject) => {
+		socket.addEventListener("open", () => resolve(), { once: true });
+		socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+	});
+	socket.send(
+		JSON.stringify({
+			type: "control_request",
+			id: "skill-teardown-join",
+			operation: "skill.invoke",
+			input: { name: "fixture-skill", args: "hold", clientRef: "skill-teardown-join-ref" },
+		}),
+	);
+	await waitFor(
+		() => frames.some(frame => frame.type === "control_response" && frame.id === "skill-teardown-join"),
+		"accepted skill response",
+	);
+	expect(frames.find(frame => frame.type === "control_response" && frame.id === "skill-teardown-join")).toMatchObject({
+		ok: true,
+		result: { accepted: true },
+	});
+	// Shutdown begins while the execution is still pending: it must NOT settle
+	// before the skill (and its terminal publication) settles.
+	let shutdownSettled = false;
+	const shutdown = Promise.resolve(
+		handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext),
+	).finally(() => {
+		shutdownSettled = true;
+	});
+	await Bun.sleep(500);
+	expect(shutdownSettled).toBe(false);
+	resumeExecution.resolve();
+	await shutdown;
+	expect(shutdownSettled).toBe(true);
+	// The terminal publication won the race: the durable document carries the
+	// skill record, and teardown never removed the publication's destination.
+	const persisted = JSON.parse(fs.readFileSync(storePath, "utf8")) as {
+		records: Array<{ kind: string; status?: string }>;
+	};
+	expect(persisted.records.some(record => record.kind === "skill")).toBe(true);
+}, 60_000);
+test("session_shutdown bounds a hung reconciliation publication and reports the drain timeout (#4743)", async () => {
+	process.env.GJC_SDK_RECONCILIATION_DRAIN_TIMEOUT_MS = "250";
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-drain-deadline-"));
+	dirs.push(cwd);
+	const sessionId = `sdk-drain-deadline-${Date.now()}`;
+	const sessionFile = path.join(cwd, "session.jsonl");
+	const sessionContext = context(cwd, sessionId);
+	const sessionManager = sessionContext.sessionManager as Record<string, unknown>;
+	sessionContext.sessionManager = {
+		...sessionManager,
+		getSessionFile: () => sessionFile,
+	};
+	const baseBindings = sessionContext.sdkBindings as () => string[];
+	sessionContext.sdkBindings = () => [...baseBindings(), "invokeSkill"];
+	const resumeExecution = Promise.withResolvers<void>();
+	sessionContext.invokeSkill = async (
+		_name: string,
+		args: string | undefined,
+		options?: {
+			onSkillPrepared?: (meta: { name: string; path: string; cleanedArgs?: string }) => void;
+			onPreflightAcceptCommit?: () => void | Promise<void>;
+		},
+	) => {
+		options?.onSkillPrepared?.({ name: "fixture-skill", path: "/fixture/SKILL.md", cleanedArgs: args });
+		await options?.onPreflightAcceptCommit?.();
+		await resumeExecution.promise;
+		return { name: "fixture-skill", path: "/fixture/SKILL.md", args };
+	};
+	// Hold the terminal publication's rename FOREVER: an unbounded drain would
+	// hang session_shutdown indefinitely (#4743 major 2).
+	const pausedCommit = pauseNextReconciliationCommit(sessionFile, sessionId);
+	const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+	try {
+		const handlers = start(sessionContext, undefined, () => {}, false, new Map(), undefined, false);
+		await handlers.get("session_start")?.({ type: "session_start" }, sessionContext);
+		const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+		await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+		const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+		const frames: Record<string, unknown>[] = [];
+		const socket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+		sockets.push(socket);
+		socket.addEventListener("message", event => frames.push(JSON.parse(String(event.data))));
+		await new Promise<void>((resolve, reject) => {
+			socket.addEventListener("open", () => resolve(), { once: true });
+			socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+		});
+		socket.send(
+			JSON.stringify({
+				type: "control_request",
+				id: "skill-drain-deadline",
+				operation: "skill.invoke",
+				input: { name: "fixture-skill", args: "hold", clientRef: "skill-drain-deadline-ref" },
+			}),
+		);
+		await waitFor(
+			() => frames.some(frame => frame.type === "control_response" && frame.id === "skill-drain-deadline"),
+			"accepted skill response",
+		);
+		// The publication is armed and held mid-rename; shutdown begins with the
+		// rename still never released.
+		pausedCommit.arm();
+		resumeExecution.resolve();
+		await pausedCommit.started;
+		const shutdownStarted = Date.now();
+		await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
+		const elapsed = Date.now() - shutdownStarted;
+		// Bounded: the 250ms deadline (not an infinite hang) released teardown.
+		expect(elapsed).toBeLessThan(5_000);
+		// Observable: the expiry surfaced as a drain-timeout warning rather than a
+		// silent pretend-drain.
+		expect(warnSpy.mock.calls.some(call => String(call[0]).includes("reconciliation drain timed out"))).toBe(true);
+	} finally {
+		warnSpy.mockRestore();
+		pausedCommit.release();
+		pausedCommit.restore();
+		delete process.env.GJC_SDK_RECONCILIATION_DRAIN_TIMEOUT_MS;
+	}
+}, 60_000);
 
 test("SDK host terminalizes a never-resolving preflight on abort and fences late acceptance", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-prompt-preflight-never-"));

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -132,6 +132,54 @@ function pauseNextReconciliationCommit(
 	};
 }
 
+/**
+ * Fail the next durable reconciliation commit to `sessionFile`/`sessionId` at its
+ * atomic rename, i.e. after the temp write succeeded. This is the shape of a real
+ * persistence failure (#4743): the publication's promise rejects and the store
+ * records the failure, so a teardown drain that consumes either one silently
+ * reports a lost write as cleanly drained.
+ */
+function failNextReconciliationCommit(
+	sessionFile: string,
+	sessionId: string,
+): { failed: Promise<void>; restore: () => void; arm: () => void } {
+	const target = reconciliationStorePath(sessionFile, sessionId);
+	const failed = Promise.withResolvers<void>();
+	const realRename = fsPromises.rename.bind(fsPromises);
+	let armed = false;
+	let thrown = false;
+	const rename = spyOn(fsPromises, "rename").mockImplementation(async (from, to) => {
+		if (armed && !thrown && String(to) === target) {
+			thrown = true;
+			failed.resolve();
+			throw Object.assign(new Error("injected reconciliation rename failure"), { code: "EACCES" });
+		}
+		await realRename(from, to);
+	});
+	return {
+		failed: failed.promise,
+		restore: () => rename.mockRestore(),
+		arm: () => {
+			armed = true;
+		},
+	};
+}
+
+/**
+ * Capture process-level unhandled rejections for the duration of a teardown
+ * assertion. The repo treats an unhandled rejection as process-killing
+ * (`src/modes/components/session-selector.ts`), so a durable-write failure must
+ * never produce one.
+ */
+function captureUnhandledRejections(): { seen: unknown[]; restore: () => void } {
+	const seen: unknown[] = [];
+	const listener = (reason: unknown): void => {
+		seen.push(reason);
+	};
+	process.on("unhandledRejection", listener);
+	return { seen, restore: () => void process.off("unhandledRejection", listener) };
+}
+
 async function closeSocket(socket: WebSocket): Promise<void> {
 	if (socket.readyState === WebSocket.CLOSED) return;
 	const { promise, resolve } = Promise.withResolvers<void>();
@@ -3169,10 +3217,24 @@ test("session_shutdown bounds a hung reconciliation publication and reports the 
 		resumeExecution.resolve();
 		await pausedCommit.started;
 		const shutdownStarted = Date.now();
-		await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
+		// The deadline expiry is CALLER-VISIBLE, not merely logged: teardown rejects
+		// with the coded reconciliation failure so the lifecycle owner is never told
+		// the session shut down cleanly over a non-quiescent store (#4743).
+		const shutdownFailure = await Promise.resolve(
+			handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext),
+		).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
 		const elapsed = Date.now() - shutdownStarted;
 		// Bounded: the 250ms deadline (not an infinite hang) released teardown.
 		expect(elapsed).toBeLessThan(5_000);
+		expect((shutdownFailure as { code?: string } | undefined)?.code).toBe("sdk_reconciliation_teardown_failed");
+		expect(
+			((shutdownFailure as { failures?: unknown[] } | undefined)?.failures ?? []).map(
+				failure => (failure as { code?: string }).code,
+			),
+		).toContain("reconciliation_drain_timeout");
 		// Observable: the expiry surfaced as a drain-timeout warning rather than a
 		// silent pretend-drain.
 		expect(warnSpy.mock.calls.some(call => String(call[0]).includes("reconciliation drain timed out"))).toBe(true);
@@ -3184,6 +3246,205 @@ test("session_shutdown bounds a hung reconciliation publication and reports the 
 	}
 }, 60_000);
 
+test("session_shutdown propagates a rejected reconciliation publication without an unhandled rejection (#4743)", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-drain-publish-failure-"));
+	dirs.push(cwd);
+	const sessionId = `sdk-drain-publish-failure-${Date.now()}`;
+	const sessionFile = path.join(cwd, "session.jsonl");
+	const sessionContext = context(cwd, sessionId);
+	const sessionManager = sessionContext.sessionManager as Record<string, unknown>;
+	sessionContext.sessionManager = { ...sessionManager, getSessionFile: () => sessionFile };
+	const baseBindings = sessionContext.sdkBindings as () => string[];
+	sessionContext.sdkBindings = () => [...baseBindings(), "invokeSkill"];
+	const resumeExecution = Promise.withResolvers<void>();
+	sessionContext.invokeSkill = async (
+		_name: string,
+		args: string | undefined,
+		options?: {
+			onSkillPrepared?: (meta: { name: string; path: string; cleanedArgs?: string }) => void;
+			onPreflightAcceptCommit?: () => void | Promise<void>;
+		},
+	) => {
+		options?.onSkillPrepared?.({ name: "fixture-skill", path: "/fixture/SKILL.md", cleanedArgs: args });
+		await options?.onPreflightAcceptCommit?.();
+		await resumeExecution.promise;
+		return { name: "fixture-skill", path: "/fixture/SKILL.md", args };
+	};
+	const failedCommit = failNextReconciliationCommit(sessionFile, sessionId);
+	const unhandled = captureUnhandledRejections();
+	const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+	const errorSpy = spyOn(logger, "error").mockImplementation(() => {});
+	try {
+		const handlers = start(sessionContext, undefined, () => {}, false, new Map(), undefined, false);
+		await handlers.get("session_start")?.({ type: "session_start" }, sessionContext);
+		const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+		await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+		const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+		const frames: Record<string, unknown>[] = [];
+		const socket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+		sockets.push(socket);
+		socket.addEventListener("message", event => frames.push(JSON.parse(String(event.data))));
+		await new Promise<void>((resolve, reject) => {
+			socket.addEventListener("open", () => resolve(), { once: true });
+			socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+		});
+		socket.send(
+			JSON.stringify({
+				type: "control_request",
+				id: "skill-publish-failure",
+				operation: "skill.invoke",
+				input: { name: "fixture-skill", args: "hold", clientRef: "skill-publish-failure-ref" },
+			}),
+		);
+		await waitFor(
+			() => frames.some(frame => frame.type === "control_response" && frame.id === "skill-publish-failure"),
+			"accepted skill response",
+		);
+		// The acceptance write has committed; the NEXT commit is the terminal
+		// agent_end publication, and it is made to fail at its atomic rename.
+		failedCommit.arm();
+		resumeExecution.resolve();
+		await failedCommit.failed;
+		const shutdownFailure = await Promise.resolve(
+			handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext),
+		).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		// A committed publication that never reached disk is state loss: teardown
+		// must report it instead of resolving as cleanly drained.
+		expect((shutdownFailure as { code?: string } | undefined)?.code).toBe("sdk_reconciliation_teardown_failed");
+		expect(
+			((shutdownFailure as { failures?: unknown[] } | undefined)?.failures ?? []).map(
+				failure => (failure as { code?: string }).code,
+			),
+		).toContain("reconciliation_persist_failed");
+		// The producer rejection is reported exactly once even though the store's
+		// failure window observes the same coded error.
+		expect(
+			((shutdownFailure as { failures?: unknown[] } | undefined)?.failures ?? []).filter(
+				failure => (failure as { code?: string }).code === "reconciliation_persist_failed",
+			),
+		).toHaveLength(1);
+		// The tracking handler must not leave a derived rejected promise behind: an
+		// unhandled rejection is process-killing in this repo.
+		await Bun.sleep(50);
+		expect(unhandled.seen).toEqual([]);
+	} finally {
+		errorSpy.mockRestore();
+		warnSpy.mockRestore();
+		unhandled.restore();
+		failedCommit.restore();
+	}
+}, 60_000);
+test("a recovered reconciliation publication lets a later teardown drain report success (#4743)", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-drain-recovery-"));
+	dirs.push(cwd);
+	const sessionId = `sdk-drain-recovery-${Date.now()}`;
+	const sessionFile = path.join(cwd, "session.jsonl");
+	const sessionContext = context(cwd, sessionId);
+	const sessionManager = sessionContext.sessionManager as Record<string, unknown>;
+	sessionContext.sessionManager = { ...sessionManager, getSessionFile: () => sessionFile };
+	const baseBindings = sessionContext.sdkBindings as () => string[];
+	sessionContext.sdkBindings = () => [...baseBindings(), "invokeSkill"];
+	const resumeFirst = Promise.withResolvers<void>();
+	let invocations = 0;
+	sessionContext.invokeSkill = async (
+		_name: string,
+		args: string | undefined,
+		options?: {
+			onSkillPrepared?: (meta: { name: string; path: string; cleanedArgs?: string }) => void;
+			onPreflightAcceptCommit?: () => void | Promise<void>;
+		},
+	) => {
+		invocations++;
+		options?.onSkillPrepared?.({ name: "fixture-skill", path: "/fixture/SKILL.md", cleanedArgs: args });
+		await options?.onPreflightAcceptCommit?.();
+		if (invocations === 1) await resumeFirst.promise;
+		return { name: "fixture-skill", path: "/fixture/SKILL.md", args };
+	};
+	const failedCommit = failNextReconciliationCommit(sessionFile, sessionId);
+	const unhandled = captureUnhandledRejections();
+	const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+	const errorSpy = spyOn(logger, "error").mockImplementation(() => {});
+	try {
+		const handlers = start(sessionContext, undefined, () => {}, false, new Map(), undefined, false);
+		await handlers.get("session_start")?.({ type: "session_start" }, sessionContext);
+		const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+		await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+		const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+		const frames: Record<string, unknown>[] = [];
+		const socket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+		sockets.push(socket);
+		socket.addEventListener("message", event => frames.push(JSON.parse(String(event.data))));
+		await new Promise<void>((resolve, reject) => {
+			socket.addEventListener("open", () => resolve(), { once: true });
+			socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+		});
+		socket.send(
+			JSON.stringify({
+				type: "control_request",
+				id: "skill-recovery-first",
+				operation: "skill.invoke",
+				input: { name: "fixture-skill", args: "first", clientRef: "skill-recovery-first-ref" },
+			}),
+		);
+		await waitFor(
+			() => frames.some(frame => frame.type === "control_response" && frame.id === "skill-recovery-first"),
+			"first accepted skill response",
+		);
+		failedCommit.arm();
+		resumeFirst.resolve();
+		await failedCommit.failed;
+		// The failure window closes with the failing publication; the store is
+		// writable again, so a subsequent publication persists and the teardown
+		// drain reports quiescence rather than staying poisoned by the past failure.
+		socket.send(
+			JSON.stringify({
+				type: "control_request",
+				id: "skill-recovery-second",
+				operation: "skill.invoke",
+				input: { name: "fixture-skill", args: "second", clientRef: "skill-recovery-second-ref" },
+			}),
+		);
+		await waitFor(
+			() => frames.some(frame => frame.type === "control_response" && frame.id === "skill-recovery-second"),
+			"second accepted skill response",
+		);
+		// The first teardown still reports the earlier lost write: a publication that
+		// never reached disk is state loss even though a later one succeeded, and
+		// evidence is retained until an owner is actually told about it.
+		const firstShutdown = await Promise.resolve(
+			handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext),
+		).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		expect((firstShutdown as { code?: string } | undefined)?.code).toBe("sdk_reconciliation_teardown_failed");
+		// Recovery: the store kept working after the failure, so the later
+		// publication is durably on disk.
+		const persisted = JSON.parse(fs.readFileSync(reconciliationStorePath(sessionFile, sessionId), "utf8")) as {
+			records: Array<{ kind: string; clientRef?: string; status?: string }>;
+		};
+		expect(
+			persisted.records.some(
+				record => record.clientRef === "skill-recovery-second-ref" && record.status === "terminal_ok",
+			),
+		).toBe(true);
+		// The retained-runtime retry drains clean: reported evidence is not replayed,
+		// so teardown converges instead of failing forever.
+		await expect(
+			Promise.resolve(handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext)),
+		).resolves.toBeUndefined();
+		await Bun.sleep(50);
+		expect(unhandled.seen).toEqual([]);
+	} finally {
+		errorSpy.mockRestore();
+		warnSpy.mockRestore();
+		unhandled.restore();
+		failedCommit.restore();
+	}
+}, 60_000);
 test("SDK host terminalizes a never-resolving preflight on abort and fences late acceptance", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-prompt-preflight-never-"));
 	dirs.push(cwd);

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -2930,6 +2930,101 @@ test("SDK host rolls back canonical skill ownership when durable acceptance fail
 	expect(executionCount).toBe(1);
 	await handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext);
 });
+test("session_shutdown awaits a late reconciliation publication before teardown can remove it", async () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-skill-late-publication-"));
+	dirs.push(cwd);
+	const sessionId = `sdk-skill-late-publication-${Date.now()}`;
+	const sessionFile = path.join(cwd, "session.jsonl");
+	const sessionContext = context(cwd, sessionId);
+	const sessionManager = sessionContext.sessionManager as Record<string, unknown>;
+	sessionContext.sessionManager = {
+		...sessionManager,
+		getSessionFile: () => sessionFile,
+	};
+	const baseBindings = sessionContext.sdkBindings as () => string[];
+	sessionContext.sdkBindings = () => [...baseBindings(), "invokeSkill"];
+	// Hold the skill run open after its durable acceptance: the harness controls
+	// exactly when the fire-and-forget agent_end reconciliation publication is
+	// enqueued, so the paused rename below is provably that late publication.
+	const resumeExecution = Promise.withResolvers<void>();
+	let executionCount = 0;
+	sessionContext.invokeSkill = async (
+		_name: string,
+		args: string | undefined,
+		options?: {
+			onSkillPrepared?: (meta: { name: string; path: string; cleanedArgs?: string }) => void;
+			onPreflightAcceptCommit?: () => void | Promise<void>;
+		},
+	) => {
+		options?.onSkillPrepared?.({ name: "fixture-skill", path: "/fixture/SKILL.md", cleanedArgs: args });
+		await options?.onPreflightAcceptCommit?.();
+		await resumeExecution.promise;
+		executionCount++;
+		return { name: "fixture-skill", path: "/fixture/SKILL.md", args };
+	};
+	const storePath = reconciliationStorePath(sessionFile, sessionId);
+	const pausedCommit = pauseNextReconciliationCommit(sessionFile, sessionId);
+	const handlers = start(sessionContext, undefined, () => {}, false, new Map(), undefined, false);
+	await handlers.get("session_start")?.({ type: "session_start" }, sessionContext);
+	const endpointFile = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
+	await waitFor(() => fs.existsSync(endpointFile), "SDK endpoint");
+	const endpoint = JSON.parse(fs.readFileSync(endpointFile, "utf8")) as { url: string; token: string };
+	const frames: Record<string, unknown>[] = [];
+	const socket = new WebSocket(`${endpoint.url}/?token=${encodeURIComponent(endpoint.token)}`);
+	sockets.push(socket);
+	socket.addEventListener("message", event => frames.push(JSON.parse(String(event.data))));
+	await new Promise<void>((resolve, reject) => {
+		socket.addEventListener("open", () => resolve(), { once: true });
+		socket.addEventListener("error", () => reject(new Error("WS error")), { once: true });
+	});
+	socket.send(
+		JSON.stringify({
+			type: "control_request",
+			id: "skill-late-publication",
+			operation: "skill.invoke",
+			input: { name: "fixture-skill", args: "hold", clientRef: "skill-late-publication-ref" },
+		}),
+	);
+	await waitFor(
+		() => frames.some(frame => frame.type === "control_response" && frame.id === "skill-late-publication"),
+		"accepted skill response",
+	);
+	expect(
+		frames.find(frame => frame.type === "control_response" && frame.id === "skill-late-publication"),
+	).toMatchObject({ ok: true, result: { accepted: true } });
+	// The acceptance publication has settled; the next commit to this store file
+	// is the late fire-and-forget agent_end transition. Arm the pause, then let
+	// the run resolve so that publication starts and is held mid-rename.
+	pausedCommit.arm();
+	resumeExecution.resolve();
+	await pausedCommit.started;
+	// Teardown must not report the session stopped while a durable publication it
+	// admitted is still between its temp write and atomic rename: an external
+	// cleanup owner removing the state tree at that instant fails the rename with
+	// ENOENT (#4743).
+	let shutdownSettled = false;
+	const shutdown = Promise.resolve(
+		handlers.get("session_shutdown")?.({ type: "session_shutdown" }, sessionContext),
+	).then(
+		() => {
+			shutdownSettled = true;
+		},
+		() => {
+			shutdownSettled = true;
+		},
+	);
+	await Bun.sleep(300);
+	expect(shutdownSettled).toBe(false);
+	pausedCommit.release();
+	await shutdown;
+	expect(shutdownSettled).toBe(true);
+	expect(executionCount).toBe(1);
+	const persisted = JSON.parse(fs.readFileSync(storePath, "utf8")) as {
+		records: Array<{ kind: string; status?: string }>;
+	};
+	expect(persisted.records.some(record => record.kind === "skill")).toBe(true);
+	pausedCommit.restore();
+}, 60_000);
 
 test("SDK host terminalizes a never-resolving preflight on abort and fences late acceptance", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-prompt-preflight-never-"));

--- a/packages/coding-agent/test/sdk-reconciliation-store.test.ts
+++ b/packages/coding-agent/test/sdk-reconciliation-store.test.ts
@@ -1066,3 +1066,59 @@ test("drain surfaces a failed publication in its awaited window instead of repor
 		await fs.rm(root, { recursive: true, force: true });
 	}
 });
+test("concurrent drains report every publication failure exactly once (#4743)", async () => {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "recon-drain-concurrent-"));
+	try {
+		const sessionFile = path.join(root, "session.jsonl");
+		const sessionId = "drain-concurrent";
+		const store = createReconciliationStore({ sessionFile, sessionId });
+		await store.load();
+		const storeDirectory = path.dirname(reconciliationStorePath(sessionFile, sessionId));
+		await fs.writeFile(storeDirectory, "block reconciliation persistence");
+		const record = (suffix: string) => ({
+			kind: "prompt" as const,
+			commandId: `command-${suffix}`,
+			turnId: `turn-${suffix}`,
+			createdAt: 1,
+			acceptedAt: 1,
+			status: "terminal_ok" as const,
+			terminalAt: 2,
+			terminalOutcome: { kind: "success" as const },
+		});
+		const failures = [
+			store.transact(() => [record("concurrent-a")]).catch((error: NodeJS.ErrnoException) => error),
+			store.transact(() => [record("concurrent-b")]).catch((error: NodeJS.ErrnoException) => error),
+		];
+		// Two teardown owners drain the same store at once. Evidence is retained
+		// until claimed, so neither drain can be starved into reporting quiescence
+		// while a failure is still unreported, exactly one of them carries each
+		// failure, and the serialized chain deadlocks neither.
+		const reported = await Promise.all([
+			store.drain?.().then(
+				() => undefined,
+				(error: unknown) => error,
+			),
+			store.drain?.().then(
+				() => undefined,
+				(error: unknown) => error,
+			),
+		]);
+		const reportedCodes = reported.flatMap(error =>
+			error instanceof AggregateError
+				? error.errors.map(member => (member as NodeJS.ErrnoException).code)
+				: error === undefined
+					? []
+					: [(error as NodeJS.ErrnoException).code],
+		);
+		expect(reportedCodes).toEqual(["reconciliation_persist_failed", "reconciliation_persist_failed"]);
+		expect((await Promise.all(failures)).map(error => (error as NodeJS.ErrnoException).code)).toEqual([
+			"reconciliation_persist_failed",
+			"reconciliation_persist_failed",
+		]);
+		// Both failures have been claimed, so a drain opened after them is clean:
+		// reported evidence never permanently poisons the store.
+		await store.drain?.();
+	} finally {
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});

--- a/packages/coding-agent/test/sdk-reconciliation-store.test.ts
+++ b/packages/coding-agent/test/sdk-reconciliation-store.test.ts
@@ -1021,3 +1021,48 @@ test("drain resolves only after an in-flight publication's atomic rename settles
 		await fs.rm(root, { recursive: true, force: true });
 	}
 });
+test("drain surfaces a failed publication in its awaited window instead of reporting drained (#4743)", async () => {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "recon-drain-failure-"));
+	try {
+		const sessionFile = path.join(root, "session.jsonl");
+		const sessionId = "drain-failure";
+		const store = createReconciliationStore({ sessionFile, sessionId });
+		await store.load();
+		// Block persistence exactly like the wiring failure harness: a FILE sits at
+		// the .sdk-reconciliation directory path, so mkdir/write/rename cannot
+		// succeed.
+		const storeDirectory = path.dirname(reconciliationStorePath(sessionFile, sessionId));
+		await fs.writeFile(storeDirectory, "block reconciliation persistence");
+		// A first drain with NO failure in its window must still resolve cleanly.
+		await store.drain?.();
+		const transactionFailure = store
+			.transact(() => [
+				{
+					kind: "prompt",
+					commandId: "command-drain-failure",
+					turnId: "turn-drain-failure",
+					createdAt: 1,
+					acceptedAt: 1,
+					status: "terminal_ok",
+					terminalAt: 2,
+					terminalOutcome: { kind: "success" },
+				},
+			])
+			.then(
+				() => undefined,
+				(error: NodeJS.ErrnoException) => error,
+			);
+		// Drain while the failing transaction is still in its window (teardown
+		// shape): the neutralized chain tail must not hide the failure evidence.
+		const drainedFailure = await store.drain?.().then(
+			() => undefined,
+			(error: NodeJS.ErrnoException) => error,
+		);
+		expect(drainedFailure?.code).toBe("reconciliation_persist_failed");
+		expect((await transactionFailure)?.code).toBe("reconciliation_persist_failed");
+		// A later clean window is not poisoned by the already-surfaced failure.
+		await store.drain?.();
+	} finally {
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});

--- a/packages/coding-agent/test/sdk-reconciliation-store.test.ts
+++ b/packages/coding-agent/test/sdk-reconciliation-store.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import * as crypto from "node:crypto";
 import * as fs from "node:fs/promises";
+import * as fsPromises from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
@@ -974,4 +975,49 @@ test("empty-store reload clears retained evicted-terminal keys on every empty-lo
 	await pathless.load();
 	expect(pathless.snapshotTerminalKeys()).toEqual([]);
 	await fs.rm(root, { recursive: true, force: true });
+});
+
+test("drain resolves only after an in-flight publication's atomic rename settles (#4743)", async () => {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "recon-drain-"));
+	const sessionFile = path.join(root, "session.jsonl");
+	const sessionId = "drain-race";
+	const store = createReconciliationStore({ sessionFile, sessionId });
+	await store.load();
+	const target = reconciliationStorePath(sessionFile, sessionId);
+	const gate = Promise.withResolvers<void>();
+	const realRename = fsPromises.rename.bind(fsPromises);
+	const rename = spyOn(fsPromises, "rename").mockImplementation(async (from: unknown, to: unknown) => {
+		if (String(to) === target) await gate.promise;
+		return await realRename(from as string, to as string);
+	});
+	try {
+		const publication = store.transact(() => [
+			{
+				kind: "prompt",
+				commandId: "command-drain",
+				turnId: "turn-drain",
+				createdAt: 1,
+				acceptedAt: 1,
+				status: "terminal_ok",
+				terminalAt: 2,
+				terminalOutcome: { kind: "success" },
+			},
+		]);
+		// The publication's rename is held by the gate; drain must observe it.
+		await Bun.sleep(50);
+		let drained = false;
+		const drain = (store.drain?.() ?? Promise.resolve()).then(() => {
+			drained = true;
+		});
+		await Bun.sleep(100);
+		expect(drained).toBe(false);
+		gate.resolve();
+		await publication;
+		await drain;
+		expect(drained).toBe(true);
+		expect(await fs.readFile(target, "utf8")).toContain("command-drain");
+	} finally {
+		rename.mockRestore();
+		await fs.rm(root, { recursive: true, force: true });
+	}
 });


### PR DESCRIPTION
## What

Session teardown observes **durable** reconciliation quiescence: it joins reconciliation producers, bounds the wait with an observable deadline, and now propagates publication-persistence failure to the teardown owner instead of reporting a lost write as drained.

## Why

`#4743`: teardown deleted `.sdk-reconciliation` between a publication's temp write and its atomic rename, producing ENOENT. Awaiting a drain was not enough — the drain proved nothing about work not yet enqueued, had no deadline, and could not distinguish a failed write from a completed one.

## Response to @probepark's exact-head review of `40346183`

**major — `Promise.allSettled` discarded the publication rejection.** The join now *inspects* settled results and records every rejection, so the store's failure window is not robbed of its evidence before it opens. `allSettled` is retained deliberately: rethrowing mid-loop would abandon the remaining producers.

**major — the cleanup `finally` created a process-killing rejection.** `producer.finally(...)` returns a derived promise that re-rejects and was left unobserved (`void`), which this repo treats as fatal. Replaced with a two-arm `producer.then(forget, forget)` whose derived promise always resolves, while the **original** producer keeps its rejection for the drain to inspect.

**major — shutdown resolved success over a failed release.** `session_shutdown` now classifies `stopSession`'s `AggregateError`: `reconciliation_persist_failed` and `reconciliation_drain_timeout` propagate as a coded `sdk_reconciliation_teardown_failed` failure, while retryable endpoint-release failures stay swallowed (they are recoverable through the retained `cleanupRetries` entry and already visible in lifecycle rollback proof). The existing lifecycle tests that assert host/server-stop failures are swallowed therefore remain correct and unchanged.

**Store evidence is retained, not window-snapshotted.** The previous failure-count snapshot could not see a failure that landed *before* the drain opened. Failures are now retained until a drain actually reports them, then cleared — surface-once: no failure is lost, and a reported failure never poisons a later teardown retry.

## Coverage

New adversarial pins, each verified to fail when its fix is reverted:

- publication rejection propagates out of `session_shutdown` as `sdk_reconciliation_teardown_failed` carrying `reconciliation_persist_failed`, reported exactly once despite surfacing on two paths
- **no unhandled rejection** is produced by a failed durable write (restoring `finally` fails this test)
- drain-deadline expiry is now asserted **caller-visible**, not merely logged
- retry/recovery: a later publication persists and the retained-runtime retry drains clean
- concurrent drains report every failure exactly once without deadlocking the serialized chain

Verified on this exact head: `check:types` clean, biome clean, `sdk-reconciliation-store` 33/33, `sdk-kind-aware-reconciliation` green, `sdk-host-wiring` 110/110 across 3 consecutive runs.

Closes #4743

gajae.pr-review-verdict.v1 needs-human sha256:0c59218e72089ec816e7445d8d9f3855d7cdf409961eecce1aa10aba10d422f5 reviewer:human reviewer-id:probepark evidence:exact-head-b869610f-rebased-onto-dev-d9fabc8f-allsettled-rejections-inspected-two-arm-producer-handler-replaces-derived-finally-store-failures-retained-surface-once-and-shutdown-propagates-coded-durability-failure
