### PR TITLE
fix(autoresearch)!: proper workflow handoff transitions and spec-intake verb disambiguation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+
+### Changed
+
+- Workflow handoffs out of autoresearch now transit properly: `/skill:deep-interview`, `/skill:ralplan`, and `/skill:ultragoal` chain from any live autoresearch phase (`intake`/`research`/`verdict`), and ralplan's `final` phase chains via its manifest terminal states; ralplan/ultragoal live phases still require the explicit write-to-handoff step. `gjc autoresearch clear` remains the finalize-only exit.
+- Breaking: autoresearch spec intake is now the explicit `intake` verb (`gjc autoresearch intake --spec <path>`; the bare `--spec` flag form still works). The ambiguous `handoff` verb token is rejected with disambiguation hints instead of silently becoming a cold-intake goal — workflow handoff lives at `/skill:<callee>` (or `gjc state autoresearch handoff --to <callee>`).
 - Queued SDK prompts now retain their dispatch-time ownership across selection fences instead of reclassifying from a contradictory later streaming snapshot. Fresh promotion, earlier follow-up ordering, and terminal-abort cancellation are reachable again, while `/btw` test fixtures now model the user-drainable queue count required by the current empty-submit contract.
 - Coordinator stop and idle-reap now initialize canonical namespace state before reading durable deletion recovery. Fresh or upgraded projection-only sessions were misreported as `state_corrupt` before the broker close was attempted, and completed deletion receipts were excluded from the idempotent missing-session lookup; both paths now preserve strict malformed-state rejection while allowing safe cleanup and replay.
 - Fixed provider safety-stop classification being lost before session persistence (#4777). The managed provider-envelope boundary now preserves only the allowlisted `provider_safety_stop` kind, typed safety stops remain terminal even with transport facts on a multi-model fallback chain, and the regression e2e test is selected both by the focused affected-path route and exactly one normal coding-agent shard.

--- a/packages/coding-agent/src/commands/autoresearch.ts
+++ b/packages/coding-agent/src/commands/autoresearch.ts
@@ -6,6 +6,7 @@ export default class Autoresearch extends Command {
 	static description = "Run native GJC Autoresearch workflow commands";
 	static strict = false;
 	static examples = [
+		"$ gjc autoresearch intake --spec <deep-interview-spec.md> --json",
 		"$ gjc autoresearch --spec <deep-interview-spec.md> --json",
 		'$ gjc autoresearch "<goal>"',
 		"$ gjc autoresearch",

--- a/packages/coding-agent/src/defaults/gjc/skills/autoresearch/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/autoresearch/SKILL.md
@@ -36,7 +36,7 @@ gjc autoresearch read --json
 gjc autoresearch clear
 ```
 
-- `--spec <path>` — handoff intake from a persisted deep-interview spec; asks zero questions.
+- `intake --spec <path>` (or the bare `--spec` flag) — spec intake from a persisted deep-interview spec; asks zero questions.
 - `"<goal>"` or bare invocation — cold intake; goal, constraints, and deliverables must be clarified before research begins.
 - `read --json` — current mission artifact plus the append-only ledger snapshot.
 - `clear` — retire the mission artifact and its working set, recording `mission_cleared` in the ledger. This never touches the session `python` REPL kernel; reset that with the `python` tool's own `clear` action.
@@ -55,9 +55,9 @@ gjc autoresearch clear
 
 Both intakes write the same mission artifact (`objective`, `mode`, `deliverables`, `constraints`, `slug`).
 
-### Handoff intake
+### Spec intake
 
-`gjc autoresearch --spec <path>` reads a persisted deep-interview spec and starts the mission with **zero clarification questions**. The spec MUST declare its mission mode explicitly (a line like `autoresearch-mode: web`); a missing or invalid declaration is a hard fail. The consumed spec path and handoff time are recorded on the mission artifact.
+`gjc autoresearch intake --spec <path>` (or the bare `--spec` flag) reads a persisted deep-interview spec and starts the mission with **zero clarification questions**. The spec MUST declare its mission mode explicitly (a line like `autoresearch-mode: web`); a missing or invalid declaration is a hard fail. The consumed spec path and handoff time are recorded on the mission artifact.
 
 ### Cold intake
 

--- a/packages/coding-agent/src/defaults/gjc/skills/autoresearch/SKILL.md
+++ b/packages/coding-agent/src/defaults/gjc/skills/autoresearch/SKILL.md
@@ -107,3 +107,10 @@ The mission ends on one mission-level structured verdict: `status` (structured d
 ## Boundary
 
 Autoresearch produces research findings and a verdict; it never implements. Downstream implementation goes through the normal approval-gated path (planning → pending approval → explicitly approved execution).
+
+## Ending a mission
+
+Two exits, both one step:
+
+- **Hand off to planning/clarification**: invoke `/skill:ralplan`, `/skill:deep-interview`, or `/skill:ultragoal` directly — autoresearch is handoff-ready at any phase (`intake`/`research`/`verdict`), and the skill tool performs the atomic state handoff itself. No `gjc state` preparation is needed.
+- **Finalize only**: `gjc autoresearch clear` retires the mission artifact and its working set, appends `mission_cleared` to the ledger, and marks the workflow complete — no handoff target required.

--- a/packages/coding-agent/src/gjc-runtime/autoresearch-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/autoresearch-runtime.ts
@@ -11,7 +11,7 @@
  * refuse targets outside the project `.gjc/` tree.
  *
  * Intake contract (AC-14..AC-16): two entrypoints write the one mission
- * artifact. Handoff intake (`--spec <path>`) consumes a persisted deep-interview
+ * artifact. Spec intake (`intake --spec <path>`, or the bare `--spec` flag) consumes a persisted deep-interview
  * spec and asks zero clarification questions; cold intake (positional goal or
  * bare invocation) signals that goal/constraints/deliverables clarification must
  * run before research begins and writes nothing. The mission mode is one of
@@ -82,7 +82,7 @@ export interface AutoresearchMission {
 	intake: AutoresearchIntakeKind;
 	createdAt: string;
 	updatedAt: string;
-	/** Absolute path of the deep-interview spec consumed by handoff intake. */
+	/** Absolute path of the deep-interview spec consumed by spec intake. */
 	specPath?: string;
 	handedOffAt?: string;
 	/**
@@ -174,7 +174,7 @@ export interface AutoresearchClearReceipt {
 	retiredTo?: string;
 }
 
-export interface AutoresearchHandoffReceipt extends AutoresearchWriteReceipt {
+export interface AutoresearchIntakeReceipt extends AutoresearchWriteReceipt {
 	specPath: string;
 }
 
@@ -562,7 +562,7 @@ async function moveIfPresent(from: string, to: string): Promise<void> {
 	}
 }
 
-/* --------------------------- handoff intake --------------------------- */
+/* ---------------------------- spec intake ---------------------------- */
 
 const AUTORESEARCH_MODE_DECLARATION_RE = /^(?:[-*]\s+)?autoresearch-mode\s*:\s*(web|mixed|data)\s*$/i;
 const AUTORESEARCH_METRIC_DECLARATION_RE = /^(?:[-*]\s+)?autoresearch-metric\s*:\s*(.+?)\s*$/i;
@@ -611,10 +611,7 @@ function sanitizeSpecSlug(value: string): string {
 		.replace(/[^a-z0-9._-]+/g, "-")
 		.replace(/^-+|-+$/g, "");
 	if (normalized === "") {
-		throw new AutoresearchCommandError(
-			2,
-			"autoresearch handoff intake could not derive a mission slug from the spec",
-		);
+		throw new AutoresearchCommandError(2, "autoresearch spec intake could not derive a mission slug from the spec");
 	}
 	return normalized;
 }
@@ -638,7 +635,7 @@ function parseAutoresearchSpec(specText: string, specPath: string): ParsedAutore
 	if (!mode) {
 		throw new AutoresearchCommandError(
 			2,
-			`autoresearch handoff intake requires the spec to declare its mission mode explicitly with a line like "autoresearch-mode: web" (one of web, mixed, data) at ${specPath}. ` +
+			`autoresearch spec intake requires the spec to declare its mission mode explicitly with a line like "autoresearch-mode: web" (one of web, mixed, data) at ${specPath}. ` +
 				"Mode is never inferred from the presence of a data file.",
 		);
 	}
@@ -657,7 +654,7 @@ function parseAutoresearchSpec(specText: string, specPath: string): ParsedAutore
 			metricUnit: firstMatch(AUTORESEARCH_METRIC_UNIT_DECLARATION_RE),
 			metricDirection: firstMatch(AUTORESEARCH_METRIC_DIRECTION_DECLARATION_RE),
 		},
-		`autoresearch handoff intake at ${specPath}`,
+		`autoresearch spec intake at ${specPath}`,
 	);
 
 	const h1 = lines.find(line => /^#\s+\S/.test(line.trim()));
@@ -683,12 +680,12 @@ function parseAutoresearchSpec(specText: string, specPath: string): ParsedAutore
 	};
 }
 
-/** handoff verb: `--spec` intake — read the spec, write the mission, ask zero questions. */
-export async function autoresearchHandoff(input: {
+/** Spec intake (`intake --spec <path>` or bare `--spec`): read the spec, write the mission, ask zero questions. The persisted intake kind stays "handoff" (seeded by a deep-interview handoff). */
+export async function autoresearchIntake(input: {
 	cwd: string;
 	specPath: string;
 	sessionId?: string | null;
-}): Promise<AutoresearchHandoffReceipt> {
+}): Promise<AutoresearchIntakeReceipt> {
 	const resolvedSpecPath = path.resolve(input.cwd, input.specPath);
 	let specText: string;
 	try {
@@ -696,7 +693,7 @@ export async function autoresearchHandoff(input: {
 	} catch (error) {
 		throw new AutoresearchCommandError(
 			2,
-			`autoresearch handoff intake could not read spec at ${resolvedSpecPath}: ${error instanceof Error ? error.message : String(error)}`,
+			`autoresearch spec intake could not read spec at ${resolvedSpecPath}: ${error instanceof Error ? error.message : String(error)}`,
 		);
 	}
 	const parsed = parseAutoresearchSpec(specText, resolvedSpecPath);
@@ -899,6 +896,7 @@ function renderAutoresearchHelp(): string {
 		"",
 		"USAGE",
 		"  $ gjc autoresearch [--spec <path>] [--json] [goal...]",
+		"  $ gjc autoresearch intake --spec <path> [--json]",
 		"  $ gjc autoresearch read [--json]",
 		"  $ gjc autoresearch clear [--json]",
 		"  $ gjc autoresearch write --goal <goal> --mode <web|mixed|data> --slug <slug> [--deliverable <text>] [--constraint <text>] [--json]",
@@ -907,7 +905,7 @@ function renderAutoresearchHelp(): string {
 		"  $ gjc autoresearch critic --status-json <object> --evidence <text> --evaluator <id> [--caveat <text>] [--json]",
 		"",
 		"INTAKE",
-		"  --spec=<path>    Handoff intake: read a persisted deep-interview spec and start research",
+		"  intake --spec    Spec intake: read a persisted deep-interview spec and start research",
 		"                   with zero clarification questions. The spec must declare its mission",
 		"                   mode explicitly (a line like `autoresearch-mode: web`).",
 		"  positional goal  Cold intake: signals that goal/constraints/deliverables clarification",
@@ -993,7 +991,7 @@ function extractPositionalGoal(args: readonly string[]): string {
 	return parts.join(" ").trim();
 }
 
-function renderHandoffIntakeText(receipt: AutoresearchHandoffReceipt): string {
+function renderSpecIntakeText(receipt: AutoresearchIntakeReceipt): string {
 	return [
 		`autoresearch intake=handoff slug=${receipt.mission.slug}`,
 		`mode=${receipt.mission.mode}`,
@@ -1190,13 +1188,20 @@ export async function runNativeAutoresearchCommand(
 				'unknown verb "report" — the report verb was removed; missions end at verdict and the ledger is the record',
 			);
 		}
-		const specPath = flagValue(args, "--spec");
-		if (specPath !== undefined) {
-			if (specPath.trim() === "") {
+		if (verb === "handoff") {
+			throw new AutoresearchCommandError(
+				2,
+				'unknown verb "handoff" — for spec intake use `gjc autoresearch intake --spec <path>`; for workflow handoff invoke the next skill directly (/skill:<callee>) or run `gjc state autoresearch handoff --to <callee>`',
+			);
+		}
+		if (verb === "intake") {
+			assertOnlyAutoresearchFlags(args.slice(1), ["--spec", "--json"]);
+			const intakeSpecPath = requiredFlagValue(args, "--spec").trim();
+			if (intakeSpecPath === "") {
 				return { status: 2, stderr: "--spec requires a non-empty path\n" };
 			}
 			const json = hasFlag(args, "--json");
-			const receipt = await autoresearchHandoff({ cwd, specPath: specPath.trim() });
+			const receipt = await autoresearchIntake({ cwd, specPath: intakeSpecPath });
 			await reconcileAutoresearchState(cwd, receipt.mission);
 			return {
 				status: 0,
@@ -1211,7 +1216,31 @@ export async function runNativeAutoresearchCommand(
 							spec_path: receipt.specPath,
 							ledger_event: receipt.ledgerEvent?.event,
 						})
-					: renderHandoffIntakeText(receipt),
+					: renderSpecIntakeText(receipt),
+			};
+		}
+		const specPath = flagValue(args, "--spec");
+		if (specPath !== undefined) {
+			if (specPath.trim() === "") {
+				return { status: 2, stderr: "--spec requires a non-empty path\n" };
+			}
+			const json = hasFlag(args, "--json");
+			const receipt = await autoresearchIntake({ cwd, specPath: specPath.trim() });
+			await reconcileAutoresearchState(cwd, receipt.mission);
+			return {
+				status: 0,
+				intake: "handoff",
+				missionCreated: true,
+				stdout: json
+					? renderCliWriteReceipt({
+							ok: true,
+							intake: "handoff",
+							mission: receipt.mission,
+							mission_path: receipt.missionPath,
+							spec_path: receipt.specPath,
+							ledger_event: receipt.ledgerEvent?.event,
+						})
+					: renderSpecIntakeText(receipt),
 			};
 		}
 		const goal = extractPositionalGoal(args);

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.generated.json
@@ -252,9 +252,10 @@
       },
       {
         "appliesToVerbs": [
-          "handoff"
+          "intake"
         ],
         "name": "spec",
+        "required": true,
         "type": "string"
       },
       {
@@ -282,6 +283,7 @@
           "read",
           "write",
           "clear",
+          "intake",
           "handoff"
         ],
         "name": "json",
@@ -322,6 +324,10 @@
       {
         "name": "doctor",
         "surface": "state-action"
+      },
+      {
+        "name": "intake",
+        "surface": "command-positional"
       },
       {
         "name": "graph",

--- a/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
+++ b/packages/coding-agent/src/gjc-runtime/workflow-manifest.ts
@@ -439,9 +439,9 @@ export const WORKFLOW_MANIFEST: Record<CanonicalGjcWorkflowSkill, SkillManifest>
 			{ from: "research", to: "handoff", verb: "handoff" },
 			{ from: "verdict", to: "handoff", verb: "handoff" },
 		],
-		verbs: [...stateVerbs(), ...plannedVerbs(PLANNED_ADMIN_VERBS)],
+		verbs: [...stateVerbs(), ...positionalVerbs(["intake"]), ...plannedVerbs(PLANNED_ADMIN_VERBS)],
 		typedArgs: [
-			{ name: "spec", type: "string", appliesToVerbs: ["handoff"] },
+			{ name: "spec", type: "string", required: true, appliesToVerbs: ["intake"] },
 			{ name: "goal", type: "string", appliesToVerbs: ["write"] },
 			{
 				name: "mode",
@@ -453,7 +453,7 @@ export const WORKFLOW_MANIFEST: Record<CanonicalGjcWorkflowSkill, SkillManifest>
 			{
 				name: "json",
 				type: "boolean",
-				appliesToVerbs: ["read", "write", "clear", "handoff"],
+				appliesToVerbs: ["read", "write", "clear", "intake", "handoff"],
 			},
 			{ name: "args", type: "string", planned: true },
 			{ name: "metadata-json", type: "string", planned: true },

--- a/packages/coding-agent/src/prompts/tools/skill.md
+++ b/packages/coding-agent/src/prompts/tools/skill.md
@@ -9,7 +9,7 @@ Invoke another available skill in the current turn.
 - `name` is the skill name as it appears in `/skill:<name>` (e.g. `ralplan`, `ultragoal`, `autoresearch`, `deep-interview`)
 - `args` is the free-form argument string the skill would receive after `/skill:<name>` on the command line
 - The tool loads the callee's SKILL.md into the current turn and handles native workflow caller→callee state handoff when the caller is one of the built-in GJC workflows.
-- The chain is refused while a native workflow caller is still active. If your current skill is one of `deep-interview`, `ralplan`, `ultragoal`, or `autoresearch` and has not yet reached a terminal phase, prepare it first with `gjc state <skill> write --input '{"current_phase":"handoff"}' --json`; no other handoff command is needed. Runtime project/user skills do not use `gjc state <skill>`.
+- The chain is refused while a native workflow caller is still mid-flight. `autoresearch` chains from any of its phases (`intake`/`research`/`verdict`) — a research mission is always handoff-ready. `deep-interview` chains once its final spec is persisted (phase `handoff`), and `ralplan` chains from `final` or `handoff`. Only a mid-flight `ralplan` or `ultragoal` needs preparation first: `gjc state <skill> write --input '{"current_phase":"handoff"}' --json`; no other handoff command is needed. Runtime project/user skills do not use `gjc state <skill>`.
 - Call once per chain step. To chain `A → B → C`, A calls `skill(B)`; B's next agent turn calls `skill(C)`.
 </instruction>
 

--- a/packages/coding-agent/src/tools/skill.ts
+++ b/packages/coding-agent/src/tools/skill.ts
@@ -10,10 +10,15 @@
  * project/user skills have no native workflow mode-state, so they are dispatched
  * directly and tracked by the prompt observer instead.
  *
- * Canonical workflow chaining is refused unless the caller's `current_phase` is
- * in `{complete, completed, handoff, failed, cancelled, canceled, inactive}`.
- * The agent declares readiness either by writing `current_phase: "handoff"` to
- * its mode-state or by running the handoff verb directly.
+ * Canonical workflow chaining is refused unless the caller's phase permits it:
+ * the generic terminal set `{complete, completed, handoff, failed, cancelled,
+ * canceled, inactive}`, the caller's manifest-declared terminal states (e.g.
+ * ralplan `final`), or — for autoresearch only — any phase with a declared
+ * handoff edge (`intake`/`research`/`verdict`): a research mission never
+ * mutates and guards no approval gate, its mission state is durable, so an
+ * ongoing or verdict-complete mission may hand off to planning at any point.
+ * ralplan/ultragoal keep the explicit write-to-handoff step for live phases:
+ * their mid-flight chaining is exactly what the approval-gate guard blocks.
  */
 
 import type { AgentTool, AgentToolResult } from "@gajae-code/agent-core";
@@ -23,6 +28,7 @@ import { resolveSubskillActivationForSkillInvocation } from "../extensibility/gj
 import { findRuntimeSkillByName } from "../extensibility/runtime-skill-discovery";
 import { buildSkillPromptMessage } from "../extensibility/skills";
 import { runNativeStateCommand } from "../gjc-runtime/state-runtime";
+import { getSkillManifest } from "../gjc-runtime/workflow-manifest";
 import skillDescription from "../prompts/tools/skill.md" with { type: "text" };
 import { SKILL_PROMPT_MESSAGE_TYPE } from "../session/messages";
 import { isCanonicalGjcWorkflowSkill } from "../skill-state/active-state";
@@ -30,6 +36,25 @@ import type { ToolSession } from ".";
 import { ToolError } from "./tool-errors";
 
 const TERMINAL_PHASES = new Set(["complete", "completed", "handoff", "failed", "cancelled", "canceled", "inactive"]);
+
+/**
+ * Whether the active canonical workflow's phase permits chaining into another
+ * skill. Generic terminal phases always chain; manifest terminal states cover
+ * skill-specific termini the generic set misses (ralplan "final"); and
+ * autoresearch chains from any phase with a manifest handoff edge because a
+ * research mission is safely abandonable mid-flight (read-only, durable
+ * mission state, no approval gate). ralplan/ultragoal deliberately stay
+ * blocked in live phases so mid-consensus or mid-execution chaining still
+ * requires the explicit write-to-handoff step.
+ */
+function phasePermitsChain(skill: string, phase: string): boolean {
+	if (TERMINAL_PHASES.has(phase)) return true;
+	if (!isCanonicalGjcWorkflowSkill(skill)) return false;
+	const manifest = getSkillManifest(skill);
+	if (manifest.terminalStates.includes(phase)) return true;
+	if (skill !== "autoresearch") return false;
+	return manifest.transitions.some(transition => transition.from === phase && transition.to === "handoff");
+}
 
 const skillSchema = z.object({
 	name: z.string().describe("skill name as it appears in /skill:<name>"),
@@ -137,9 +162,9 @@ export class SkillTool implements AgentTool<typeof skillSchema, SkillToolDetails
 			// so there is no `gjc state <skill>` command to run for them.
 			if (activeSkill && isCanonicalGjcWorkflowSkill(activeSkill)) {
 				const phase = (this.#session.getActiveSkillPhase?.() ?? "running").trim().toLowerCase();
-				if (!TERMINAL_PHASES.has(phase)) {
+				if (!phasePermitsChain(activeSkill, phase)) {
 					throw new ToolError(
-						`skill tool: refusing to chain from "${activeSkill}" (phase=${phase}) into "${requestedName}". Finalize the current skill (gjc state ${activeSkill} write --input '{"current_phase":"handoff"}' --json) or run gjc state ${activeSkill} handoff --to ${requestedName} --json directly before chaining.`,
+						`skill tool: refusing to chain from "${activeSkill}" (phase=${phase}) into "${requestedName}". Run gjc state ${activeSkill} handoff --to ${requestedName} --json directly, or finalize the current skill first (gjc state ${activeSkill} write --input '{"current_phase":"handoff"}' --json) before chaining.`,
 					);
 				}
 				const cwd = this.#session.cwd;

--- a/packages/coding-agent/test/gjc-runtime/autoresearch-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/autoresearch-runtime.test.ts
@@ -7,7 +7,7 @@ import {
 	type AutoresearchMode,
 	autoresearchClear,
 	autoresearchDashboardText,
-	autoresearchHandoff,
+	autoresearchIntake,
 	autoresearchIssueVerdict,
 	autoresearchLogRun,
 	autoresearchRead,
@@ -375,7 +375,7 @@ describe("autoresearch ledger", () => {
 			"utf-8",
 		);
 
-		const receipt = await autoresearchHandoff({ cwd: root, specPath });
+		const receipt = await autoresearchIntake({ cwd: root, specPath });
 
 		expect(receipt.mission.primaryMetric).toBe("decode_tokens_per_second");
 		expect(receipt.mission.metricUnit).toBe("tok/s");
@@ -391,7 +391,7 @@ describe("autoresearch ledger", () => {
 			"utf-8",
 		);
 
-		await expect(autoresearchHandoff({ cwd: root, specPath })).rejects.toThrow(
+		await expect(autoresearchIntake({ cwd: root, specPath })).rejects.toThrow(
 			/metric direction must be "higher" or "lower"/,
 		);
 	});
@@ -674,9 +674,41 @@ describe("autoresearch intake (AC-14..AC-15)", () => {
 		const result = await runNativeAutoresearchCommand(["--help"], root);
 		expect(result.status).toBe(0);
 		expect(result.stdout).toContain("--spec");
-		expect(result.stdout).toContain("Handoff intake");
+		expect(result.stdout).toContain("Spec intake");
+		expect(result.stdout).toContain("intake --spec");
 		expect(result.stdout).toContain("Cold intake");
 		expect(result.stdout).not.toContain("report");
+		expect((await autoresearchRead(root, TEST_SESSION_ID)).exists).toBe(false);
+	});
+
+	it("intake verb consumes a spec exactly like the bare --spec flag", async () => {
+		const root = await tempDir();
+		const specPath = path.join(root, "deep-interview-intake-verb.md");
+		await Bun.write(
+			specPath,
+			"# Deep Interview Spec: Intake Verb\n\nautoresearch-mode: web\n\n## Goal\nProbe the intake verb.\n",
+		);
+		const result = await runNativeAutoresearchCommand(["intake", "--spec", specPath, "--json"], root);
+		expect(result.status).toBe(0);
+		expect(result.intake).toBe("handoff");
+		const payload = JSON.parse(result.stdout ?? "") as { ok: boolean; intake: string; mission: { slug: string } };
+		expect(payload.ok).toBe(true);
+		expect(payload.intake).toBe("handoff");
+		const receipt = await autoresearchRead(root, TEST_SESSION_ID);
+		expect(receipt.exists).toBe(true);
+		expect(receipt.mission?.intake).toBe("handoff");
+	});
+
+	it("rejects the ambiguous handoff verb with both disambiguation hints", async () => {
+		const root = await tempDir();
+		for (const args of [["handoff"], ["handoff", "--spec", "x.md"], ["handoff", "--json"]]) {
+			const result = await runNativeAutoresearchCommand(args, root);
+			expect(result.status).toBe(2);
+			expect(result.stderr).toContain('unknown verb "handoff"');
+			expect(result.stderr).toContain("gjc autoresearch intake --spec");
+			expect(result.stderr).toContain("gjc state autoresearch handoff --to");
+		}
+		// The rejected verb must never fall through to cold intake or create a mission.
 		expect((await autoresearchRead(root, TEST_SESSION_ID)).exists).toBe(false);
 	});
 
@@ -688,11 +720,11 @@ describe("autoresearch intake (AC-14..AC-15)", () => {
 		// data file sits right next to it: mode is never inferred (AC-16).
 		await fs.writeFile(path.join(root, "DATA.md"), "# dataset\n", "utf-8");
 		await fs.writeFile(specPath, "# Spec\n\n## Goal\n\nMeasure throughput.\n", "utf-8");
-		await expect(autoresearchHandoff({ cwd: root, specPath })).rejects.toThrow(/mission mode explicitly/);
+		await expect(autoresearchIntake({ cwd: root, specPath })).rejects.toThrow(/mission mode explicitly/);
 
 		// With the mode declared, handoff intake succeeds and asks zero questions.
 		await fs.writeFile(specPath, "# Spec\n\nautoresearch-mode: data\n\n## Goal\n\nMeasure throughput.\n", "utf-8");
-		const receipt = await autoresearchHandoff({ cwd: root, specPath });
+		const receipt = await autoresearchIntake({ cwd: root, specPath });
 
 		expect(receipt.mission.mode).toBe("data");
 		expect(receipt.specPath).toBe(specPath);
@@ -703,7 +735,7 @@ describe("autoresearch intake (AC-14..AC-15)", () => {
 
 	it("handoff intake fails closed when the spec path does not exist", async () => {
 		const root = await tempDir();
-		await expect(autoresearchHandoff({ cwd: root, specPath: path.join(root, "missing-spec.md") })).rejects.toThrow(
+		await expect(autoresearchIntake({ cwd: root, specPath: path.join(root, "missing-spec.md") })).rejects.toThrow(
 			/could not read spec/,
 		);
 	});

--- a/packages/coding-agent/test/tools/skill.test.ts
+++ b/packages/coding-agent/test/tools/skill.test.ts
@@ -715,6 +715,81 @@ describe("SkillTool", () => {
 		});
 	}
 
+	// Manifest-driven chain permissions (autoresearch handoff-ready at any live
+	// phase; ralplan "final" is a manifest terminal state the generic set misses;
+	// ralplan/ultragoal live phases stay blocked).
+	for (const [phase, callee] of [
+		["research", "deep-interview"],
+		["verdict", "ralplan"],
+		["intake", "ralplan"],
+	] as const) {
+		it(`allows autoresearch (phase=${phase}) to chain into ${callee} without a pre-write`, async () => {
+			const cwd = await makeTempCwd();
+			await writeCallerModeState(cwd, "autoresearch", phase, "s1");
+			const autoresearch = await makeSkill("autoresearch", "---\nname: autoresearch\n---\nResearch");
+			const target = await makeSkill(callee, `---\nname: ${callee}\n---\nBody`);
+			const captured: CapturedSend[] = [];
+			const session = createSession(cwd, [autoresearch, target], captured, {
+				getActiveSkillState: () => ({ skill: "autoresearch", session_id: "s1" }),
+				getActiveSkillPhase: () => phase,
+			});
+			const tool = SkillTool.createIf(session)!;
+
+			const result = await tool.execute("call-1", { name: callee });
+			expect(result.details?.name).toBe(callee);
+			expect(captured).toHaveLength(1);
+			const ar = await readModeState(cwd, "autoresearch", "s1");
+			expect(ar?.active).toBe(false);
+			expect(ar?.current_phase).toBe("handoff");
+			expect(ar?.handoff_to).toBe(callee);
+			const promoted = await readModeState(cwd, callee, "s1");
+			expect(promoted?.active).toBe(true);
+			expect(promoted?.handoff_from).toBe("autoresearch");
+		});
+	}
+
+	it("allows ralplan (phase=final, manifest terminal) to chain into ultragoal", async () => {
+		const cwd = await makeTempCwd();
+		await writeCallerModeState(cwd, "ralplan", "final", "s1");
+		const ralplan = await makeSkill("ralplan", "---\nname: ralplan\n---\nPlan");
+		const ultragoal = await makeSkill("ultragoal", "---\nname: ultragoal\n---\nGo");
+		const captured: CapturedSend[] = [];
+		const session = createSession(cwd, [ralplan, ultragoal], captured, {
+			getActiveSkillState: () => ({ skill: "ralplan", session_id: "s1" }),
+			getActiveSkillPhase: () => "final",
+		});
+		const tool = SkillTool.createIf(session)!;
+
+		const result = await tool.execute("call-1", { name: "ultragoal" });
+		expect(result.details?.name).toBe("ultragoal");
+		const rp = await readModeState(cwd, "ralplan", "s1");
+		expect(rp?.active).toBe(false);
+		expect(rp?.handoff_to).toBe("ultragoal");
+		const ug = await readModeState(cwd, "ultragoal", "s1");
+		expect(ug?.active).toBe(true);
+	});
+
+	for (const [caller, phase, callee] of [
+		["ralplan", "planner", "ultragoal"],
+		["ultragoal", "active", "ralplan"],
+	] as const) {
+		it(`still refuses ${caller} mid-flight chaining (phase=${phase})`, async () => {
+			const cwd = await makeTempCwd();
+			await writeCallerModeState(cwd, caller, phase, "s1");
+			const callerSkill = await makeSkill(caller, `---\nname: ${caller}\n---\nBody`);
+			const target = await makeSkill(callee, `---\nname: ${callee}\n---\nBody`);
+			const captured: CapturedSend[] = [];
+			const session = createSession(cwd, [callerSkill, target], captured, {
+				getActiveSkillState: () => ({ skill: caller, session_id: "s1" }),
+				getActiveSkillPhase: () => phase,
+			});
+			const tool = SkillTool.createIf(session)!;
+
+			await expect(tool.execute("call-1", { name: callee })).rejects.toThrow(/refusing to chain/);
+			expect(captured).toHaveLength(0);
+		});
+	}
+
 	it("calls handoff CLI before dispatching the chained skill (ordering)", async () => {
 		const cwd = await makeTempCwd();
 		await writeCallerModeState(cwd, "deep-interview", "handoff", "s1");


### PR DESCRIPTION
## What

Two related handoff-semantics fixes for the autoresearch workflow:

**1. Manifest-driven skill-tool chain guard** (`src/tools/skill.ts`)
- autoresearch chains into `/skill:deep-interview` / `/skill:ralplan` / `/skill:ultragoal` from **any** live phase (`intake`/`research`/`verdict`) — the manifest declares handoff edges from all three, and a research mission is read-only with durable state and no approval gate. Previously refused by a hardcoded terminal set (a done mission parks at `verdict` forever since the report-verb removal).
- ralplan `final` now chains via manifest `terminalStates` (previously refused, with a suggested remediation write the manifest itself rejects).
- ralplan/ultragoal **live** phases stay refused (approval-gate defense, test-pinned); refusal message now leads with the always-valid `gjc state <skill> handoff --to` command.

**2. Spec intake disambiguated from workflow handoff** (`gjc-runtime/autoresearch-runtime.ts`, breaking)
- `gjc autoresearch handoff --spec` meant spec *intake* while `gjc state autoresearch handoff --to` means workflow handoff — same word, opposite directions; a bare `handoff` token silently became a cold-intake research goal.
- Spec intake is now the explicit `intake` verb (`gjc autoresearch intake --spec <path>`; the documented bare `--spec` flag form stays). The `handoff` verb token is rejected with status 2 carrying both disambiguation hints, before cold-intake parsing. `autoresearchHandoff`/`AutoresearchHandoffReceipt` renamed to `autoresearchIntake`/`AutoresearchIntakeReceipt`; the persisted mission intake-kind literal stays `"handoff"` for artifact compatibility. Help surfaces + SKILL.md updated.

## Why

With the goal-based autoresearch skill, `deep-interview → autoresearch → ralplan/deep-interview` must transit cleanly (verified live at the state layer: atomic demote/promote through every hop), and `gjc autoresearch clear` remains the solely-finalize exit. The chain guard and the verb collision were the two rough edges.

## Testing

- 9 new tests: autoresearch `intake`/`research`/`verdict` chain with atomic demote/promote; ralplan `final` chains; ralplan `planner` + ultragoal `active` still refused; `intake --spec` creates the mission identically to bare `--spec`; `handoff`/`handoff --spec`/`handoff --json` reject with both hints and create no state; help pins `Spec intake`.
- `autoresearch-runtime.test.ts` 39 pass, `skill.test.ts` 30 pass (2 pre-existing env-dependent discovery failures reproduce without these changes), autoresearch suite + default-surface gates green, biome/types clean.

## Risk classification

- [ ] `low-risk`
- [x] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:d6b059479c936cd3e8815403308fbb3de9f6ceb1ce007f3cd6f4c0ae0d333caa reviewer:critic reviewer-id:gjc-leader-review evidence:local autoresearch-runtime.test.ts 39 pass + skill.test.ts 30 pass incl. 9 new cases + default-surface gates on head ea7b5ea653dbd4b751945646853ddd0c93b9cfca; no authenticated independent GitHub approval exists for this head
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes (touched files clean; pre-existing cross-worktree tsc duplication unrelated)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit



