### PR TITLE
feat(tui): redesign skill HUD visualization

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/state-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/state-runtime.ts
@@ -14,7 +14,13 @@ import {
 	syncSkillActiveState,
 } from "../skill-state/active-state";
 import { initialPhaseForSkill } from "../skill-state/initial-phase";
-import { buildRalplanHudSummary, buildUltragoalHudSummary, deriveDeepInterviewHud } from "../skill-state/workflow-hud";
+import {
+	buildAutoresearchHudSummary,
+	buildRalplanHudSummary,
+	buildUltragoalHudSummary,
+	deriveDeepInterviewHud,
+} from "../skill-state/workflow-hud";
+
 import {
 	type AuditEntry,
 	buildWorkflowStateReceipt,
@@ -919,20 +925,20 @@ function buildHudForMode(
 			});
 		}
 		case "autoresearch": {
-			const missionPhase =
-				typeof payload.current_phase === "string" ? (payload.current_phase as string) : (phase ?? "intake");
-			const mode = typeof payload.mode === "string" ? (payload.mode as string) : undefined;
-			const intake = typeof payload.intake === "string" ? (payload.intake as string) : undefined;
-			const slug = typeof payload.slug === "string" ? (payload.slug as string) : undefined;
+			const missionPhase = typeof payload.current_phase === "string" ? payload.current_phase : (phase ?? "intake");
+			const mode = typeof payload.mode === "string" ? payload.mode : undefined;
+			const intake = typeof payload.intake === "string" ? payload.intake : undefined;
+			const slug = typeof payload.slug === "string" ? payload.slug : undefined;
 			const specPath =
 				typeof payload.spec_path === "string"
-					? (payload.spec_path as string)
+					? payload.spec_path
 					: typeof payload.specPath === "string"
-						? (payload.specPath as string)
+						? payload.specPath
 						: undefined;
+
 			const verdict =
 				payload.verdict && typeof payload.verdict === "object" && !Array.isArray(payload.verdict)
-					? (payload.verdict as { status?: unknown })
+					? (payload.verdict as Record<string, unknown>)
 					: undefined;
 			const verdictValue = verdict
 				? typeof verdict.status === "string"
@@ -941,21 +947,25 @@ function buildHudForMode(
 						? JSON.stringify(verdict.status).slice(0, 40)
 						: undefined
 				: undefined;
-			const chips: WorkflowHudSummary["chips"] = [
-				...(missionPhase === "verdict"
-					? [{ label: "verdict", value: verdictValue ?? "issued", priority: 5, severity: "success" as const }]
-					: []),
-				{ label: "phase", value: missionPhase, priority: 10 },
-				...(mode ? [{ label: "mode", value: mode, priority: 20 }] : []),
-				...(intake ? [{ label: "intake", value: intake, priority: 30 }] : []),
-				...(specPath ? [{ label: "spec", value: specPath, priority: 40 }] : []),
-			];
-			return {
-				version: 1,
-				...(slug ? { summary: `autoresearch mission ${slug}` } : {}),
-				chips,
-				updated_at: updatedAt,
-			};
+			const rawExperiments = Array.isArray(payload.experiments) ? payload.experiments : [];
+			const experimentStatuses = rawExperiments
+				.map(item =>
+					item && typeof item === "object" && typeof (item as Record<string, unknown>).status === "string"
+						? ((item as Record<string, unknown>).status as string)
+						: undefined,
+				)
+				.filter((status): status is string => Boolean(status));
+			return buildAutoresearchHudSummary({
+				phase: missionPhase,
+				mode,
+				intake,
+				slug,
+				verdict: verdictValue,
+				specPath,
+				experimentCount: experimentStatuses.length,
+				experimentStatuses,
+				updatedAt,
+			});
 		}
 		default:
 			return undefined;

--- a/packages/coding-agent/src/modes/components/skill-hud/render.ts
+++ b/packages/coding-agent/src/modes/components/skill-hud/render.ts
@@ -4,14 +4,19 @@ import {
 	type WorkflowHudChip,
 } from "../../../skill-state/active-state";
 import { workflowReceiptStatus } from "../../../skill-state/workflow-state-contract";
+import { theme } from "../../theme/theme";
 
-const ANSI_RESET_FG = "\x1b[39m";
-const ANSI_RESET_BOLD = "\x1b[22m";
-const ANSI_BORDER = "\x1b[90m";
-const ANSI_ACCENT = "\x1b[36m";
-const ANSI_DIM = "\x1b[2m";
-const ANSI_BOLD = "\x1b[1m";
 const ANSI_PATTERN = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
+
+function color(role: "border" | "accent" | "dim" | "muted" | "warning" | "error", text: string): string {
+	return theme?.fg(role, text) ?? text;
+}
+
+function statusSymbol(kind: "warning" | "error"): string {
+	return theme?.status[kind] ?? (kind === "error" ? "[!!]" : "[!]");
+}
+
+type WidthTier = "wide" | "medium" | "tight";
 
 function visibleWidth(text: string): number {
 	return text.replace(ANSI_PATTERN, "").length;
@@ -21,8 +26,7 @@ function truncateToWidth(text: string, maxWidth: number): string {
 	if (maxWidth <= 0) return "";
 	if (visibleWidth(text) <= maxWidth) return text;
 	const plain = text.replace(ANSI_PATTERN, "");
-	if (maxWidth === 1) return "…";
-	return `${plain.slice(0, maxWidth - 1)}…`;
+	return maxWidth === 1 ? "…" : `${plain.slice(0, maxWidth - 1)}…`;
 }
 
 function sanitizeHudPart(value: string | undefined): string {
@@ -40,10 +44,21 @@ function compareChips(a: WorkflowHudChip, b: WorkflowHudChip): number {
 	return (a.priority ?? 50) - (b.priority ?? 50) || a.label.localeCompare(b.label);
 }
 
-function chipPrefix(chip: WorkflowHudChip): string {
-	if (chip.severity === "error") return "!";
-	if (chip.severity === "blocked") return "block";
-	if (chip.severity === "warning") return "warn";
+function tierForWidth(width: number): WidthTier {
+	return width >= 100 ? "wide" : width >= 60 ? "medium" : "tight";
+}
+
+function severityOf(chip: WorkflowHudChip): "error" | "warning" | undefined {
+	return chip.severity === "error" || chip.severity === "blocked"
+		? "error"
+		: chip.severity === "warning"
+			? "warning"
+			: undefined;
+}
+
+function severityGlyph(severity: WorkflowHudChip["severity"]): string {
+	if (severity === "error" || severity === "blocked") return color("error", statusSymbol("error"));
+	if (severity === "warning") return color("warning", statusSymbol("warning"));
 	return "";
 }
 
@@ -52,32 +67,62 @@ function formatChip(chip: WorkflowHudChip): string | null {
 	const value = sanitizeHudPart(chip.value);
 	if (!label) return null;
 	const body = value ? `${label}=${value}` : label;
-	const prefix = chipPrefix(chip);
-	return prefix ? `${prefix}:${body}` : body;
+	const role = severityOf(chip);
+	return role ? color(role, body) : color("dim", body);
 }
 
-function formatEntry(entry: SkillActiveEntry): string {
+function formatEntry(entry: SkillActiveEntry, tier: WidthTier): string {
 	const skill = sanitizeHudPart(entry.skill);
 	const phase = sanitizeHudPart(entry.phase);
 	const base = phase ? `${skill}:${phase}` : skill;
-	const chips = [...(entry.hud?.chips ?? [])]
-		.sort(compareChips)
-		.map(formatChip)
-		.filter((chip): chip is string => Boolean(chip));
-	if (entry.stale === true) chips.unshift("warn:stale");
-	const receiptStatus = workflowReceiptStatus(entry.receipt);
-	if (receiptStatus === "stale") chips.unshift("warn:receipt=stale");
-	if (receiptStatus === "fresh") chips.push("receipt=fresh");
+	const chips = [...(entry.hud?.chips ?? [])].sort(compareChips);
+	if (entry.stale === true) chips.unshift({ label: "stale", priority: 0, severity: "warning" });
+	if (workflowReceiptStatus(entry.receipt) === "stale")
+		chips.unshift({ label: "receipt", value: "stale", priority: 1, severity: "warning" });
+
+	const severity =
+		chips.find(chip => chip.severity === "error" || chip.severity === "blocked")?.severity ??
+		chips.find(chip => chip.severity === "warning")?.severity;
+	if (tier === "tight") return `${color("accent", skill)}${severityGlyph(severity)}`;
+	const metric = chips.find(chip => !severityOf(chip));
+	if (tier === "medium") {
+		const metricText = metric ? formatChip(metric) : "";
+		return [color("accent", base), metricText, severityGlyph(severity)].filter(Boolean).join(" ");
+	}
 	const summary = sanitizeHudPart(entry.hud?.summary);
-	return [base, summary, ...chips].filter(Boolean).join(" ");
+	const details = chips.map(formatChip).filter((chip): chip is string => Boolean(chip));
+	return [color("accent", base), summary ? color("muted", summary) : "", ...details, severityGlyph(severity)]
+		.filter(Boolean)
+		.join(" ");
 }
 
 export function renderSkillHudBar(entries: readonly SkillActiveEntry[], width: number): string | null {
 	const visible = collapsePlanningPipeline(entries.filter(entry => entry.active !== false));
 	const active = visible.filter(entry => sanitizeHudPart(entry.skill)).sort(compareEntries);
 	if (active.length === 0 || width <= 0) return null;
-	const body = active.map(formatEntry).join(" + ");
-	const prefix = `${ANSI_BORDER}◆${ANSI_RESET_FG} ${ANSI_BOLD}${ANSI_ACCENT}hud${ANSI_RESET_FG}${ANSI_RESET_BOLD} `;
-	const budget = Math.max(1, width - visibleWidth(prefix));
-	return truncateToWidth(`${prefix}${ANSI_DIM}${truncateToWidth(body, budget)}${ANSI_RESET_BOLD}`, width);
+	const tier = tierForWidth(width);
+	const rail = color("border", "◆");
+	const separator = color("dim", " + ");
+	const lines: string[] = [];
+	let current = rail;
+	for (const entry of active) {
+		const rendered = formatEntry(entry, tier);
+		const candidate = current === rail ? `${current} ${rendered}` : `${current}${separator}${rendered}`;
+		if (visibleWidth(candidate) <= width) {
+			current = candidate;
+		} else if (lines.length === 0) {
+			lines.push(truncateToWidth(current, width));
+			current = `${rail} ${rendered}`;
+		} else {
+			lines.push(truncateToWidth(`${current}…`, width));
+			current = "";
+			break;
+		}
+	}
+	if (current.trim()) lines.push(truncateToWidth(current, width));
+	if (lines.length > 2) {
+		lines.length = 2;
+		lines[1] = truncateToWidth(lines[1] ?? "", width);
+	}
+	return lines.join("\n");
 }

--- a/packages/coding-agent/src/skill-state/workflow-hud.ts
+++ b/packages/coding-agent/src/skill-state/workflow-hud.ts
@@ -248,6 +248,44 @@ export function buildRalplanHudSummary(state: RalplanHudState): WorkflowHudSumma
 	};
 }
 
+export interface AutoresearchHudState extends WorkflowGateHudState {
+	phase: string;
+	mode?: string;
+	intake?: string;
+	slug?: string;
+	specPath?: string;
+
+	verdict?: string;
+	experimentCount?: number;
+	experimentStatuses?: string[];
+	updatedAt?: string;
+}
+
+export function buildAutoresearchHudSummary(state: AutoresearchHudState): WorkflowHudSummary {
+	const statuses = state.experimentStatuses ?? [];
+	const experimentCount = state.experimentCount ?? statuses.length;
+	const failures = statuses.filter(status => status === "crash" || status === "checks_failed").length;
+	const chips: Array<WorkflowHudChip | null> = [
+		...gateChips(state, 50),
+		state.phase === "verdict" ? chip("verdict", state.verdict ?? "issued", 5, "success") : null,
+		chip("phase", state.phase, 10),
+		chip("mode", state.mode, 20),
+		...(experimentCount > 0
+			? [chip("experiments", `${experimentCount}/${statuses.filter(status => status === "keep").length}`, 30)]
+			: []),
+		failures > 0 ? { label: "failed", value: String(failures), priority: 4, severity: "warning" } : null,
+		chip("intake", state.intake, 40),
+		chip("spec", state.specPath, 45),
+	];
+
+	return {
+		version: 1,
+		...(state.slug ? { summary: `autoresearch mission ${state.slug}` } : {}),
+		chips: compactChips(chips),
+		...(state.updatedAt ? { updated_at: state.updatedAt } : {}),
+	};
+}
+
 export function buildUltragoalHudSummary(state: UltragoalHudState): WorkflowHudSummary {
 	const total = state.goals.length;
 	const complete = state.counts.complete ?? 0;

--- a/packages/coding-agent/test/skill-hud-bar.test.ts
+++ b/packages/coding-agent/test/skill-hud-bar.test.ts
@@ -13,8 +13,37 @@ describe("skill HUD bar renderer", () => {
 
 	it("renders active skill and phase compactly", () => {
 		const rendered = Bun.stripANSI(renderSkillHudBar([{ skill: "deep-interview", phase: "intent-first" }], 80) ?? "");
-		expect(rendered).toContain("hud");
+		expect(rendered).not.toContain("hud");
 		expect(rendered).toContain("deep-interview:intent-first");
+	});
+
+	it("uses the three width tiers and preserves severity", () => {
+		const entry = {
+			skill: "autoresearch",
+			phase: "research",
+			hud: {
+				version: 1 as const,
+				chips: [
+					{ label: "experiments", value: "2/4", priority: 10 },
+					{ label: "failed", value: "1", priority: 1, severity: "warning" as const },
+				],
+			},
+		};
+		const wide = Bun.stripANSI(renderSkillHudBar([entry], 100) ?? "");
+		const medium = Bun.stripANSI(renderSkillHudBar([entry], 80) ?? "");
+		const tight = Bun.stripANSI(renderSkillHudBar([entry], 40) ?? "");
+		expect(wide).toContain("experiments=2/4");
+		expect(medium).toContain("experiments=2/4");
+		expect(medium).not.toContain("failed=1");
+		expect(tight).toContain("autoresearch");
+		expect(tight).toContain("[!");
+	});
+
+	it("caps the HUD at two lines", () => {
+		const entries = Array.from({ length: 8 }, (_, index) => ({ skill: `skill-${index}`, phase: "running" }));
+		const rendered = renderSkillHudBar(entries, 20);
+		expect(rendered).not.toBeNull();
+		expect(rendered?.split("\n").length).toBeLessThanOrEqual(2);
 	});
 
 	it("sanitizes dynamic text and truncates to width", () => {
@@ -31,7 +60,7 @@ describe("skill HUD bar renderer", () => {
 	it("is included as a native status-line rail without changing preset segments", () => {
 		expect(STATUS_LINE_PRESETS.default.leftSegments).toEqual(["model", "mode", "git", "pr", "path"]);
 		const rendered = Bun.stripANSI(renderSkillHudBar([{ skill: "team", phase: "running" }], 100) ?? "");
-		expect(rendered).toContain("hud team:running");
+		expect(rendered).toContain("◆ team:running");
 	});
 
 	it("omits inactive entries so statusLine.showSkillHud can gate the rail", () => {
@@ -58,7 +87,10 @@ describe("skill HUD bar renderer", () => {
 				120,
 			) ?? "",
 		);
-		expect(rendered).toContain("ralplan:planning consensus warn:stale stage=critic warn:verdict=ITERATE");
+		expect(rendered).toContain("ralplan:planning consensus");
+		expect(rendered).toContain("stage=critic");
+		expect(rendered).toContain("verdict=ITERATE");
+		expect(rendered).toContain("[!");
 	});
 
 	it("sanitizes HUD chips and keeps constrained rendering within width", () => {
@@ -114,10 +146,9 @@ describe("skill HUD bar renderer", () => {
 			) ?? "",
 		);
 		expect(rendered).toContain("deep-interview:interviewing");
-		expect(rendered).toContain("warn:gate=approval-required");
-		expect(rendered).toContain("block:blocked=execution approval missing");
 		expect(rendered).toContain("next=ask user for approval");
-		expect(rendered).toContain("receipt=fresh");
+		expect(rendered).toContain("[!!]");
+		expect(rendered).not.toContain("receipt=fresh");
 	});
 
 	it("shows only the callee after a D->R handoff (caller demoted to inactive entry, HUD filters it out)", () => {
@@ -196,9 +227,9 @@ describe("skill HUD bar renderer", () => {
 				80,
 			) ?? "",
 		);
-		// Exactly one planning-pipeline chip survives the collapse.
-		const chips = (rendered.split("hud")[1] ?? "").split("+").filter(part => /ralplan|ultragoal/.test(part));
-		expect(chips).toHaveLength(1);
+		// Exactly one planning-pipeline entry survives the collapse.
+		expect(rendered).toContain("ultragoal:executing");
+		expect(rendered).not.toContain("ralplan:final");
 	});
 
 	it("does not emit warn:stale for an entry without explicit stale flag (no 24h derivation)", () => {

--- a/packages/coding-agent/test/workflow-hud-autoresearch.test.ts
+++ b/packages/coding-agent/test/workflow-hud-autoresearch.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { buildAutoresearchHudSummary } from "../src/skill-state/workflow-hud";
+
+describe("autoresearch HUD summary", () => {
+	it("shows phase only for zero-experiment missions", () => {
+		const summary = buildAutoresearchHudSummary({ phase: "research" });
+		expect(summary.chips?.map(chip => chip.label)).toEqual(["phase"]);
+	});
+
+	it("shows tally and warning failures", () => {
+		const summary = buildAutoresearchHudSummary({
+			phase: "research",
+			experimentStatuses: ["keep", "discard", "crash", "checks_failed"],
+		});
+		expect(summary.chips).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ label: "experiments", value: "4/1" }),
+				expect.objectContaining({ label: "failed", value: "2", severity: "warning" }),
+			]),
+		);
+	});
+
+	it("renders verdict and preserves mission summary", () => {
+		const summary = buildAutoresearchHudSummary({ phase: "verdict", verdict: "keep", slug: "hud" });
+		expect(summary.summary).toBe("autoresearch mission hud");
+		expect(summary.chips).toEqual(
+			expect.arrayContaining([expect.objectContaining({ label: "verdict", value: "keep" })]),
+		);
+	});
+});


### PR DESCRIPTION
## What

Redesign the skill-HUD status bar with generic theme tokens, width-adaptive tiers, severity-preserving glyphs, and autoresearch coverage.

## Why

The existing HUD used hardcoded ANSI styling, noisy positive-status chips, and a single layout that degraded on narrow terminals. The new renderer keeps the workflow state legible across terminal widths and covers all bundled workflows.

## Testing

- `bun test packages/coding-agent/test/skill-hud-bar.test.ts packages/coding-agent/test/workflow-hud-autoresearch.test.ts packages/coding-agent/test/workflow-hud-summary.test.ts` (32 passed)
- `git diff --check`
- Package typecheck is currently blocked by pre-existing missing generated `docs-index.generated` modules.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [x] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-blocked sha256:f81cfb151f7e4961d0c3b677cb7723c0584dbab2345f301d99bb883f8de7384b reviewer:human reviewer-id:probepark evidence:exact-head-f1818fd6-embedded-newline-breaks-row-accounting-cjk-overflows-width-and-autoresearch-native-path-does-not-produce-advertised-data
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
