### PR TITLE
fix(tui): resolve skill HUD review findings

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/autoresearch-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/autoresearch-runtime.ts
@@ -41,6 +41,7 @@ import {
 	type MetricDirection,
 } from "../autoresearch/runs";
 import { syncSkillActiveState } from "../skill-state/active-state";
+import { buildAutoresearchHudSummary } from "../skill-state/workflow-hud";
 import { renderCliWriteReceipt } from "./cli-write-receipt";
 import { sessionAutoresearchDir } from "./session-layout";
 import {
@@ -794,7 +795,7 @@ export async function autoresearchLogRun(input: {
 		description,
 		...(input.metric === undefined ? {} : { metric: input.metric }),
 	});
-	return await appendAutoresearchLedger(
+	const ledgerEvent = await appendAutoresearchLedger(
 		input.cwd,
 		{
 			event: "run_logged",
@@ -806,6 +807,9 @@ export async function autoresearchLogRun(input: {
 		},
 		sessionId,
 	);
+	const mission = await readAutoresearchMission(input.cwd, sessionId);
+	if (mission) await reconcileAutoresearchState(input.cwd, mission, sessionId, { phase: "research" });
+	return ledgerEvent;
 }
 
 /** Record the optional per-mission critic pass; its evaluator is distinct from the mission agent. */
@@ -1027,6 +1031,32 @@ async function reconcileAutoresearchState(
 	const resolvedSessionId =
 		sessionId?.trim() || resolveGjcSessionForWrite(cwd, { envSessionId: process.env.GJC_SESSION_ID }).gjcSessionId;
 	try {
+		const ledger = await readAutoresearchLedger(cwd, resolvedSessionId);
+		const store = await AutoresearchRunsStore.open(cwd, resolvedSessionId);
+		const latestVerdict = [...ledger]
+			.reverse()
+			.find(event => event.event === "verdict_issued" && event.verdictReceipt);
+		const verdictReceipt = latestVerdict?.verdictReceipt as AutoresearchVerdictReceipt | undefined;
+		const verdictStatus = verdictReceipt?.status;
+		const verdict = verdictStatus
+			? typeof verdictStatus.verdict === "string"
+				? verdictStatus.verdict
+				: typeof verdictStatus.status === "string"
+					? verdictStatus.status
+					: undefined
+			: undefined;
+		const hud = mission
+			? buildAutoresearchHudSummary({
+					phase: options.phase ?? "research",
+					mode: mission.mode,
+					intake: mission.intake,
+					slug: mission.slug,
+					specPath: mission.specPath,
+					verdict,
+					experimentStatuses: store.listLoggedRuns().flatMap(run => (run.status ? [run.status] : [])),
+					updatedAt: new Date().toISOString(),
+				})
+			: undefined;
 		await syncSkillActiveState({
 			cwd,
 			skill: "autoresearch",
@@ -1034,13 +1064,10 @@ async function reconcileAutoresearchState(
 			phase: options.phase ?? "research",
 			sessionId: resolvedSessionId,
 			source: "gjc-autoresearch-native",
-			hud: {
+			hud: hud ?? {
 				version: 1,
-				summary: mission ? `autoresearch mission ${mission.slug}` : "autoresearch mission cleared",
-				chips: [
-					...(mission ? [{ label: "mode", value: mission.mode }] : []),
-					...(mission ? [{ label: "intake", value: mission.intake }] : []),
-				],
+				summary: "autoresearch mission cleared",
+				chips: [],
 				updated_at: new Date().toISOString(),
 			},
 		});

--- a/packages/coding-agent/src/modes/components/skill-hud/render.ts
+++ b/packages/coding-agent/src/modes/components/skill-hud/render.ts
@@ -1,3 +1,4 @@
+import { truncateToWidth, visibleWidth } from "@gajae-code/tui";
 import {
 	collapsePlanningPipeline,
 	type SkillActiveEntry,
@@ -8,25 +9,14 @@ import { theme } from "../../theme/theme";
 
 const ANSI_PATTERN = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
 
+type WidthTier = "wide" | "medium" | "tight";
+
 function color(role: "border" | "accent" | "dim" | "muted" | "warning" | "error", text: string): string {
 	return theme?.fg(role, text) ?? text;
 }
 
 function statusSymbol(kind: "warning" | "error"): string {
 	return theme?.status[kind] ?? (kind === "error" ? "[!!]" : "[!]");
-}
-
-type WidthTier = "wide" | "medium" | "tight";
-
-function visibleWidth(text: string): number {
-	return text.replace(ANSI_PATTERN, "").length;
-}
-
-function truncateToWidth(text: string, maxWidth: number): string {
-	if (maxWidth <= 0) return "";
-	if (visibleWidth(text) <= maxWidth) return text;
-	const plain = text.replace(ANSI_PATTERN, "");
-	return maxWidth === 1 ? "…" : `${plain.slice(0, maxWidth - 1)}…`;
 }
 
 function sanitizeHudPart(value: string | undefined): string {
@@ -71,58 +61,99 @@ function formatChip(chip: WorkflowHudChip): string | null {
 	return role ? color(role, body) : color("dim", body);
 }
 
-function formatEntry(entry: SkillActiveEntry, tier: WidthTier): string {
+function keyMetricChip(skill: string, chips: readonly WorkflowHudChip[]): WorkflowHudChip | undefined {
+	const preferredBySkill: Record<string, readonly string[]> = {
+		"deep-interview": ["ambiguity"],
+		ralplan: ["iter", "round", "stage"],
+		ultragoal: ["goals", "current"],
+		autoresearch: ["exp", "experiments"],
+	};
+	const preferred = preferredBySkill[skill] ?? [];
+	return (
+		preferred.map(label => chips.find(chip => chip.label === label && !severityOf(chip))).find(Boolean) ??
+		chips.find(chip => !severityOf(chip))
+	);
+}
+
+function fitWithSuffix(prefix: string, suffix: string, width: number): string {
+	if (width <= 0) return "";
+	if (!suffix) return truncateToWidth(prefix, width);
+	const suffixWidth = visibleWidth(suffix);
+	if (suffixWidth >= width) return truncateToWidth(suffix, width);
+	return `${truncateToWidth(prefix, width - suffixWidth)}${suffix}`;
+}
+
+function formatEntry(entry: SkillActiveEntry, tier: WidthTier, width: number): string {
 	const skill = sanitizeHudPart(entry.skill);
 	const phase = sanitizeHudPart(entry.phase);
 	const base = phase ? `${skill}:${phase}` : skill;
 	const chips = [...(entry.hud?.chips ?? [])].sort(compareChips);
 	if (entry.stale === true) chips.unshift({ label: "stale", priority: 0, severity: "warning" });
-	if (workflowReceiptStatus(entry.receipt) === "stale")
+	if (workflowReceiptStatus(entry.receipt) === "stale") {
 		chips.unshift({ label: "receipt", value: "stale", priority: 1, severity: "warning" });
+	}
 
 	const severity =
 		chips.find(chip => chip.severity === "error" || chip.severity === "blocked")?.severity ??
 		chips.find(chip => chip.severity === "warning")?.severity;
-	if (tier === "tight") return `${color("accent", skill)}${severityGlyph(severity)}`;
-	const metric = chips.find(chip => !severityOf(chip));
+	const suffix = severity ? ` ${severityGlyph(severity)}` : "";
+	if (tier === "tight") return fitWithSuffix(color("accent", skill), suffix, width);
+
+	const metric = keyMetricChip(skill, chips);
 	if (tier === "medium") {
-		const metricText = metric ? formatChip(metric) : "";
-		return [color("accent", base), metricText, severityGlyph(severity)].filter(Boolean).join(" ");
+		const prefix = [color("accent", base), metric ? formatChip(metric) : ""].filter(Boolean).join(" ");
+		return fitWithSuffix(prefix, suffix, width);
 	}
+
 	const summary = sanitizeHudPart(entry.hud?.summary);
 	const details = chips.map(formatChip).filter((chip): chip is string => Boolean(chip));
-	return [color("accent", base), summary ? color("muted", summary) : "", ...details, severityGlyph(severity)]
-		.filter(Boolean)
-		.join(" ");
+	const prefix = [color("accent", base), summary ? color("muted", summary) : "", ...details].filter(Boolean).join(" ");
+	return fitWithSuffix(prefix, suffix, width);
 }
 
 export function renderSkillHudBar(entries: readonly SkillActiveEntry[], width: number): string | null {
 	const visible = collapsePlanningPipeline(entries.filter(entry => entry.active !== false));
 	const active = visible.filter(entry => sanitizeHudPart(entry.skill)).sort(compareEntries);
 	if (active.length === 0 || width <= 0) return null;
+
 	const tier = tierForWidth(width);
 	const rail = color("border", "◆");
 	const separator = color("dim", " + ");
-	const lines: string[] = [];
-	let current = rail;
+	const railPrefix = visibleWidth(rail) + 1 <= width ? `${rail} ` : "";
+	const rows: string[] = [];
+	let row = railPrefix;
+	let hasEntry = false;
+	let omitted = false;
+
 	for (const entry of active) {
-		const rendered = formatEntry(entry, tier);
-		const candidate = current === rail ? `${current} ${rendered}` : `${current}${separator}${rendered}`;
-		if (visibleWidth(candidate) <= width) {
-			current = candidate;
-		} else if (lines.length === 0) {
-			lines.push(truncateToWidth(current, width));
-			current = `${rail} ${rendered}`;
-		} else {
-			lines.push(truncateToWidth(`${current}…`, width));
-			current = "";
-			break;
+		const joiner = hasEntry ? separator : "";
+		const budget = Math.max(0, width - visibleWidth(row) - visibleWidth(joiner));
+		const fullRendered = formatEntry(entry, tier, 4096);
+		let rendered = visibleWidth(fullRendered) <= budget ? fullRendered : "";
+		if (!rendered) {
+			if (!hasEntry) {
+				row = "";
+				rendered = formatEntry(entry, tier, width);
+			} else if (rows.length === 0) {
+				rows.push(truncateToWidth(row, width));
+				row = railPrefix;
+				hasEntry = false;
+				const firstRowBudget = Math.max(0, width - visibleWidth(row));
+				rendered = visibleWidth(fullRendered) <= firstRowBudget ? fullRendered : formatEntry(entry, tier, width);
+			} else {
+				omitted = true;
+				break;
+			}
 		}
+		if (!rendered) continue;
+		row = `${row}${hasEntry ? separator : ""}${rendered}`;
+		hasEntry = true;
 	}
-	if (current.trim()) lines.push(truncateToWidth(current, width));
-	if (lines.length > 2) {
-		lines.length = 2;
-		lines[1] = truncateToWidth(lines[1] ?? "", width);
+
+	if (hasEntry) rows.push(truncateToWidth(row, width));
+	if (omitted && rows.length > 0) {
+		const last = rows.length - 1;
+		rows[last] = truncateToWidth(`${rows[last]}…`, width);
 	}
-	return lines.join("\n");
+	return rows.slice(0, 2).join("\n") || null;
 }

--- a/packages/coding-agent/src/modes/components/tool-status-header.ts
+++ b/packages/coding-agent/src/modes/components/tool-status-header.ts
@@ -1050,7 +1050,9 @@ export class StatusLineComponent implements Component {
 		this.#refreshSkillHudInBackground();
 		const skillHud = this.#settings.showSkillHud === false ? null : renderSkillHudBar(this.#skillHudEntries, width);
 		if (skillHud) {
-			lines.push(skillHud);
+			for (const skillHudRow of skillHud.split("\n")) {
+				if (skillHudRow) lines.push(truncateToWidth(skillHudRow, width));
+			}
 		}
 
 		const statusRows = this.#buildStatusRows(width, this.#resolveMaxRows());

--- a/packages/coding-agent/src/skill-state/workflow-hud.ts
+++ b/packages/coding-agent/src/skill-state/workflow-hud.ts
@@ -254,7 +254,6 @@ export interface AutoresearchHudState extends WorkflowGateHudState {
 	intake?: string;
 	slug?: string;
 	specPath?: string;
-
 	verdict?: string;
 	experimentCount?: number;
 	experimentStatuses?: string[];
@@ -263,25 +262,29 @@ export interface AutoresearchHudState extends WorkflowGateHudState {
 
 export function buildAutoresearchHudSummary(state: AutoresearchHudState): WorkflowHudSummary {
 	const statuses = state.experimentStatuses ?? [];
-	const experimentCount = state.experimentCount ?? statuses.length;
-	const failures = statuses.filter(status => status === "crash" || status === "checks_failed").length;
+	const total = Math.max(state.experimentCount ?? statuses.length, statuses.length);
+	const kept = statuses.filter(status => status === "keep").length;
+	const crash = statuses.filter(status => status === "crash").length;
+	const checksFailed = statuses.filter(status => status === "checks_failed").length;
 	const chips: Array<WorkflowHudChip | null> = [
-		...gateChips(state, 50),
-		state.phase === "verdict" ? chip("verdict", state.verdict ?? "issued", 5, "success") : null,
+		...(state.phase === "verdict" ? [chip("verdict", state.verdict ?? "issued", 5)] : []),
 		chip("phase", state.phase, 10),
-		chip("mode", state.mode, 20),
-		...(experimentCount > 0
-			? [chip("experiments", `${experimentCount}/${statuses.filter(status => status === "keep").length}`, 30)]
-			: []),
-		failures > 0 ? { label: "failed", value: String(failures), priority: 4, severity: "warning" } : null,
+		...(total > 0 ? [chip("exp", `${kept}/${total}`, 20)] : []),
+		crash > 0 ? { label: "crash", value: String(crash), priority: 4, severity: "warning" } : null,
+		checksFailed > 0
+			? { label: "checks_failed", value: String(checksFailed), priority: 5, severity: "warning" }
+			: null,
+		chip("mode", state.mode, 30),
 		chip("intake", state.intake, 40),
 		chip("spec", state.specPath, 45),
+		...gateChips(state, 50),
 	];
-
+	const visibleChips =
+		total === 0 && state.phase !== "verdict" ? compactChips([chip("phase", state.phase, 10)]) : compactChips(chips);
 	return {
 		version: 1,
 		...(state.slug ? { summary: `autoresearch mission ${state.slug}` } : {}),
-		chips: compactChips(chips),
+		chips: visibleChips,
 		...(state.updatedAt ? { updated_at: state.updatedAt } : {}),
 	};
 }

--- a/packages/coding-agent/test/gjc-runtime/autoresearch-runtime.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/autoresearch-runtime.test.ts
@@ -18,6 +18,7 @@ import {
 	runNativeAutoresearchCommand,
 } from "@gajae-code/coding-agent/gjc-runtime/autoresearch-runtime";
 import {
+	activeSnapshotPath,
 	autoresearchRlmArtifactRoot,
 	sessionAutoresearchDir,
 	sessionAutoresearchRunsDir,
@@ -602,6 +603,13 @@ describe("autoresearch intake (AC-14..AC-15)", () => {
 			root,
 		);
 		expect(run.status).toBe(0);
+		const activeState = JSON.parse(await fs.readFile(activeSnapshotPath(root, TEST_SESSION_ID), "utf-8")) as {
+			active_skills?: Array<{ skill?: string; hud?: { chips?: Array<{ label?: string; value?: string }> } }>;
+		};
+		const autoresearchEntry = activeState.active_skills?.find(entry => entry.skill === "autoresearch");
+		expect(autoresearchEntry?.hud?.chips).toEqual(
+			expect.arrayContaining([expect.objectContaining({ label: "exp", value: "1/1" })]),
+		);
 		const critic = await runNativeAutoresearchCommand(
 			["critic", "--status-json", '{"verdict":"OKAY"}', "--evidence", "reviewed", "--evaluator", "critic"],
 			root,

--- a/packages/coding-agent/test/skill-hud-bar.test.ts
+++ b/packages/coding-agent/test/skill-hud-bar.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { renderSkillHudBar } from "../src/modes/components/skill-hud/render";
 import { STATUS_LINE_PRESETS } from "../src/modes/components/status-line/presets";
+import { theme } from "../src/modes/theme/theme";
 
 function visibleWidth(text: string): number {
 	return Bun.stripANSI(text).length;
@@ -36,7 +37,7 @@ describe("skill HUD bar renderer", () => {
 		expect(medium).toContain("experiments=2/4");
 		expect(medium).not.toContain("failed=1");
 		expect(tight).toContain("autoresearch");
-		expect(tight).toContain("[!");
+		expect(tight).toContain(theme?.status.warning ?? "[!]");
 	});
 
 	it("caps the HUD at two lines", () => {
@@ -44,6 +45,25 @@ describe("skill HUD bar renderer", () => {
 		const rendered = renderSkillHudBar(entries, 20);
 		expect(rendered).not.toBeNull();
 		expect(rendered?.split("\n").length).toBeLessThanOrEqual(2);
+	});
+
+	it("uses terminal-cell widths and keeps severity beside narrow content", () => {
+		const rendered = renderSkillHudBar(
+			[
+				{
+					skill: "가나다라마",
+					phase: "研究",
+					hud: { version: 1, chips: [{ label: "blocked", value: "yes", severity: "blocked" }] },
+				},
+			],
+			10,
+		);
+		expect(rendered).not.toBeNull();
+		const rows = (rendered ?? "").split("\n");
+		expect(rows.every(row => Bun.stringWidth(Bun.stripANSI(row)) > 0)).toBe(true);
+		expect(rows.every(row => Bun.stringWidth(Bun.stripANSI(row)) <= 10)).toBe(true);
+		expect(rows[0]).not.toBe("◆");
+		expect(rendered).toContain(theme?.status.error ?? "[!!]");
 	});
 
 	it("sanitizes dynamic text and truncates to width", () => {
@@ -90,7 +110,7 @@ describe("skill HUD bar renderer", () => {
 		expect(rendered).toContain("ralplan:planning consensus");
 		expect(rendered).toContain("stage=critic");
 		expect(rendered).toContain("verdict=ITERATE");
-		expect(rendered).toContain("[!");
+		expect(rendered).toContain(theme?.status.warning ?? "[!]");
 	});
 
 	it("sanitizes HUD chips and keeps constrained rendering within width", () => {
@@ -147,7 +167,7 @@ describe("skill HUD bar renderer", () => {
 		);
 		expect(rendered).toContain("deep-interview:interviewing");
 		expect(rendered).toContain("next=ask user for approval");
-		expect(rendered).toContain("[!!]");
+		expect(rendered).toContain(theme?.status.error ?? "[!!]");
 		expect(rendered).not.toContain("receipt=fresh");
 	});
 

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -411,6 +411,19 @@ describe("status line multi-row wrapping (statusLine.maxRows)", () => {
 		expect(wrapped.some(row => strip(row).includes(LONG_NAME))).toBe(true);
 	});
 
+	it("accounts for wrapped skill HUD rows as separate status rows", () => {
+		const component = buildComponent(2);
+		component.updateSettings({ showSkillHud: true });
+		component.setSkillHudEntriesForTest([
+			{ skill: "deep-interview", phase: "interviewing" },
+			{ skill: "autoresearch", phase: "research" },
+		]);
+		const rows = component.render(20);
+		const hudRows = rows.filter(row => strip(row).includes("◆"));
+		expect(hudRows.length).toBe(2);
+		expect(hudRows.every(row => visibleWidth(row) <= 20)).toBe(true);
+	});
+
 	it("caps wrapping at maxRows", () => {
 		const wrapped = buildComponent(2).render(8);
 		expect(wrapped.length).toBeLessThanOrEqual(2);

--- a/packages/coding-agent/test/workflow-hud-autoresearch.test.ts
+++ b/packages/coding-agent/test/workflow-hud-autoresearch.test.ts
@@ -14,8 +14,9 @@ describe("autoresearch HUD summary", () => {
 		});
 		expect(summary.chips).toEqual(
 			expect.arrayContaining([
-				expect.objectContaining({ label: "experiments", value: "4/1" }),
-				expect.objectContaining({ label: "failed", value: "2", severity: "warning" }),
+				expect.objectContaining({ label: "exp", value: "1/4" }),
+				expect.objectContaining({ label: "crash", value: "1", severity: "warning" }),
+				expect.objectContaining({ label: "checks_failed", value: "1", severity: "warning" }),
 			]),
 		);
 	});


### PR DESCRIPTION
## What

Resolve the review findings from PR #4806 for the merged Skill-HUD redesign.

## Why

The original review identified four concrete regressions: wrapped HUD rows were counted as one status row, width calculations used UTF-16 length instead of terminal cells, severity could be truncated away, and native autoresearch updates did not publish experiment/verdict data to the HUD.

## Testing

- `bun test packages/coding-agent/test/skill-hud-bar.test.ts packages/coding-agent/test/workflow-hud-autoresearch.test.ts packages/coding-agent/test/status-line-overflow.test.ts packages/coding-agent/test/gjc-runtime/autoresearch-runtime.test.ts` (80 passed)
- `git diff --check`
- `bun --cwd=packages/coding-agent run check` — Biome passes; typecheck is blocked only by pre-existing missing generated `docs-index.generated` modules.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:cf435b5c7cb30c1cfb691865c0c862fe79198d0dfb569672a0b46f215700dcd5 reviewer:human reviewer-id:pending evidence:focused-regression-tests-pass-independent-exact-head-review-required
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (follow-up to merged user-facing change)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
