### PR TITLE
feat(sdk): inject external automation tools

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an SDK `automationTools` option for host-owned `browser` and `computer` implementations. External automation retains built-in activation and provenance, receives the normal abort signal, works independently of the default browser/platform gates, and fails closed on custom, extension, or MCP name collisions (#4809).
+
 ### Changed
 
 - Workflow handoffs out of autoresearch now transit properly: `/skill:deep-interview`, `/skill:ralplan`, and `/skill:ultragoal` chain from any live autoresearch phase (`intake`/`research`/`verdict`), and ralplan's `final` phase chains via its manifest terminal states; ralplan/ultragoal live phases still require the explicit write-to-handoff step. `gjc autoresearch clear` remains the finalize-only exit.

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -163,6 +163,8 @@ import { AgentOutputManager } from "../task/output-manager";
 import { parseThinkingLevel, resolveThinkingLevelForModel, toReasoningEffort } from "../thinking";
 import { isMCPBridgeTool, selectRestorableDiscoveredBuiltinToolNames } from "../tool-discovery/tool-index";
 import {
+	type AutomationToolName,
+	type AutomationTools,
 	BUILTIN_TOOL_DESCRIPTORS,
 	BUILTIN_TOOLS,
 	computeEssentialBuiltinNames,
@@ -184,6 +186,8 @@ import {
 	lifecycleStartupCapabilityOption,
 	type SdkStartupCapability,
 } from "./startup-capability";
+
+export type { AutomationToolName, AutomationTools } from "../tools";
 
 type AsyncResultEntry = {
 	jobId: string;
@@ -450,6 +454,13 @@ export interface CreateAgentSessionOptions {
 
 	/** Custom tools to register (in addition to built-in tools). Accepts both CustomTool and ToolDefinition. */
 	customTools?: (CustomTool | ToolDefinition)[];
+	/**
+	 * Host-owned implementations for the built-in `browser` and `computer`
+	 * surfaces. These are materialized as built-ins, retain built-in provenance
+	 * and activation behavior, and receive cancellation through AgentTool's
+	 * AbortSignal. A matching custom or extension tool is rejected.
+	 */
+	automationTools?: AutomationTools;
 	/** Explicit parent/phase used to load active GJC sub-skill tools for this session. */
 	gjcSubskillToolContext?: { parent: string; phase: string; sessionId?: string; cwd?: string };
 	/** Inline extensions (merged with discovery). */
@@ -1256,7 +1267,31 @@ function findDeferredExactMcpToolNameCollisions(
 	return [...collisions];
 }
 
+const AUTOMATION_TOOL_NAMES = new Set<AutomationToolName>(["browser", "computer"]);
+
+function validateAutomationTools(options: CreateAgentSessionOptions): AutomationTools {
+	const automationTools = options.automationTools ?? {};
+	const entries = Object.entries(automationTools);
+	for (const [name, tool] of entries) {
+		if (!AUTOMATION_TOOL_NAMES.has(name as AutomationToolName)) {
+			throw new Error(`Unsupported SDK automation tool name: ${name}`);
+		}
+		if (!tool || tool.name !== name) {
+			throw new Error(`SDK automation tool ${name} must expose the built-in name ${JSON.stringify(name)}`);
+		}
+	}
+	const externalNames = new Set(entries.map(([name]) => name));
+	const collisions = [
+		...new Set((options.customTools ?? []).map(tool => tool.name).filter(name => externalNames.has(name))),
+	];
+	if (collisions.length > 0) {
+		throw new Error(`SDK automation tools cannot collide with custom tools: ${collisions.join(", ")}`);
+	}
+	return automationTools;
+}
+
 export async function createAgentSession(options: CreateAgentSessionOptions = {}): Promise<CreateAgentSessionResult> {
+	const automationTools = validateAutomationTools(options);
 	const lifecycleStartupCapability = (
 		options as CreateAgentSessionOptions & { [lifecycleStartupCapabilityOption]?: SdkStartupCapability }
 	)[lifecycleStartupCapabilityOption];
@@ -2174,7 +2209,13 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		);
 
 		// Create built-in tools (already wrapped with meta notice formatting)
-		const builtinTools = await logger.time("createAllTools", createTools, toolSession, options.toolNames);
+		const builtinTools = await logger.time(
+			"createAllTools",
+			createTools,
+			toolSession,
+			options.toolNames,
+			automationTools,
+		);
 
 		// A top-level session loads MCP tools from three bounded surfaces: a
 		// caller-supplied exact config (`--mcp-config`), conventional native
@@ -2895,6 +2936,15 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			wrappedExtensionTools = (options.customTools ?? [])
 				.filter(isCustomTool)
 				.map(tool => CustomToolAdapter.wrap(tool, customToolContext));
+		}
+		const automationToolNames = new Set(Object.keys(automationTools));
+		const automationToolCollisions = [
+			...new Set(wrappedExtensionTools.map(tool => tool.name).filter(name => automationToolNames.has(name))),
+		];
+		if (automationToolCollisions.length > 0) {
+			throw new Error(
+				`SDK automation tools cannot collide with extension or MCP tools: ${automationToolCollisions.join(", ")}`,
+			);
 		}
 
 		// All built-in tools are active (conditional tools like git/ask return null from factory if disabled)

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -32,6 +32,7 @@ import {
 	BUILTIN_TOOLS,
 	HIDDEN_TOOL_DESCRIPTORS,
 	LazyAgentTool,
+	PLATFORM_EXCLUDED_TOOL_DESCRIPTORS,
 	resolveEffectiveDiscoveryMode,
 	type ToolAvailabilityContext,
 } from "./descriptors";
@@ -49,6 +50,18 @@ export type { WriteToolDetails, WriteToolInput } from "./write";
 
 /** Tool type (AgentTool from pi-ai) */
 export type Tool = AgentTool<any, any, any>;
+
+/** Built-in automation surfaces that an SDK host may back with its own transport. */
+export type AutomationToolName = "browser" | "computer";
+
+/**
+ * Host-owned implementations for the built-in automation surfaces.
+ *
+ * Each implementation must use the matching built-in name. The normal
+ * AgentTool execute signature carries cancellation through its AbortSignal,
+ * while the implementation owns the model-facing schema and description.
+ */
+export type AutomationTools = Partial<Record<AutomationToolName, Tool>>;
 
 export type ContextFileEntry = {
 	path: string;
@@ -543,7 +556,11 @@ export function resolveEvalBackends(session: ToolSession): EvalBackendsAllowance
 /**
  * Create tools from the descriptor registry.
  */
-export async function createTools(session: ToolSession, toolNames?: string[]): Promise<Tool[]> {
+export async function createTools(
+	session: ToolSession,
+	toolNames?: string[],
+	automationTools: AutomationTools = {},
+): Promise<Tool[]> {
 	const includeYield = session.requireYieldTool === true;
 	const enableLsp = session.enableLsp ?? true;
 	let requestedTools =
@@ -624,8 +641,14 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		allowEval,
 		discoveryActive,
 	};
-	const allToolDescriptors: Record<string, (typeof BUILTIN_TOOL_DESCRIPTORS)[string]> = {
+	const builtinToolDescriptors: Record<string, (typeof BUILTIN_TOOL_DESCRIPTORS)[string]> = {
 		...BUILTIN_TOOL_DESCRIPTORS,
+		...(automationTools.computer && !BUILTIN_TOOL_DESCRIPTORS.computer
+			? { computer: PLATFORM_EXCLUDED_TOOL_DESCRIPTORS.computer }
+			: {}),
+	};
+	const allToolDescriptors: Record<string, (typeof BUILTIN_TOOL_DESCRIPTORS)[string]> = {
+		...builtinToolDescriptors,
 		...HIDDEN_TOOL_DESCRIPTORS,
 	};
 	const allToolDescriptorEntries = Object.entries(allToolDescriptors) as Array<
@@ -650,13 +673,21 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 	const filteredRequestedTools = requestedTools
 		?.map(name => allToolsByRequestName.get(name))
 		.filter((entry): entry is [string, (typeof BUILTIN_TOOL_DESCRIPTORS)[string]] => entry !== undefined)
-		.filter(([, descriptor]) => descriptor.isAvailable(session, availabilityContext));
+		.filter(
+			([name, descriptor]) =>
+				automationTools[name as AutomationToolName] !== undefined ||
+				descriptor.isAvailable(session, availabilityContext),
+		);
 	const baseEntries =
 		filteredRequestedTools !== undefined
 			? filteredRequestedTools.filter(([name]) => name !== "resolve")
 			: [
-					...Object.entries(BUILTIN_TOOL_DESCRIPTORS)
-						.filter(([, descriptor]) => descriptor.isAvailable(session, availabilityContext))
+					...Object.entries(builtinToolDescriptors)
+						.filter(
+							([name, descriptor]) =>
+								automationTools[name as AutomationToolName] !== undefined ||
+								descriptor.isAvailable(session, availabilityContext),
+						)
 						.map(([name, descriptor]) => [name, descriptor] as const),
 					...(includeYield ? ([["yield", HIDDEN_TOOL_DESCRIPTORS.yield]] as const) : []),
 				];
@@ -667,6 +698,10 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		),
 	);
 	const materialize = async ([name, descriptor]: readonly [string, (typeof BUILTIN_TOOL_DESCRIPTORS)[string]]) => {
+		const externalAutomationTool = automationTools[name as AutomationToolName];
+		if (externalAutomationTool) {
+			return wrapToolWithMetaNotice(new LazyAgentTool(descriptor, externalAutomationTool, undefined, session));
+		}
 		const defer =
 			effectiveDiscoveryMode !== "off" &&
 			descriptor.metadata.loadMode === "discoverable" &&

--- a/packages/coding-agent/test/sdk-automation-tools.test.ts
+++ b/packages/coding-agent/test/sdk-automation-tools.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentTool } from "@gajae-code/agent-core";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import type { CustomTool } from "@gajae-code/coding-agent/extensibility/custom-tools/types";
+import { type AutomationTools, createAgentSession } from "@gajae-code/coding-agent/sdk";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { z } from "zod/v4";
+
+const automationSchema = z.object({
+	action: z.enum(["ping", "wait"]),
+});
+
+function externalTool(name: "browser" | "computer", calls: string[]): AgentTool<typeof automationSchema> {
+	return {
+		name,
+		label: `External ${name}`,
+		description: `Host-owned ${name} transport`,
+		parameters: automationSchema,
+		strict: true,
+		async execute(_toolCallId, params, signal) {
+			calls.push(`${name}:${params.action}`);
+			if (signal?.aborted) throw new Error(`${name} transport aborted`);
+			if (params.action === "wait") {
+				const pending = Promise.withResolvers<void>();
+				const abort = () => pending.reject(new Error(`${name} transport aborted`));
+				signal?.addEventListener("abort", abort, { once: true });
+				try {
+					await pending.promise;
+				} finally {
+					signal?.removeEventListener("abort", abort);
+				}
+			}
+			return { content: [{ type: "text", text: `${name} external result` }] };
+		},
+	};
+}
+
+describe("createAgentSession external automation tools", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	function sessionOptions() {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-automation-"));
+		tempDirs.push(tempDir);
+		return {
+			cwd: tempDir,
+			agentDir: tempDir,
+			sessionManager: SessionManager.inMemory(tempDir),
+			settings: Settings.isolated({ "browser.enabled": false, "computer.alwaysOn": false }),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			toolNames: ["browser", "computer"],
+		};
+	}
+
+	it("materializes host browser and computer backends as built-ins and forwards cancellation", async () => {
+		const calls: string[] = [];
+		const browser = externalTool("browser", calls);
+		const computer = externalTool("computer", calls);
+		const automationTools: AutomationTools = { browser, computer };
+		const { session } = await createAgentSession({
+			...sessionOptions(),
+			automationTools,
+		});
+
+		try {
+			const materializedBrowser = session.getToolByName("browser");
+			const materializedComputer = session.getToolByName("computer");
+			expect(materializedBrowser?.label).toBe("External browser");
+			expect(materializedBrowser?.description).toBe("Host-owned browser transport");
+			expect(materializedBrowser?.parameters).toBe(automationSchema);
+			expect(materializedBrowser?.loadMode).toBe("discoverable");
+			expect(materializedComputer?.label).toBe("External computer");
+
+			const browserResult = await materializedBrowser!.execute("browser-ping", { action: "ping" });
+			const computerResult = await materializedComputer!.execute("computer-ping", { action: "ping" });
+			expect(browserResult.content).toEqual([{ type: "text", text: "browser external result" }]);
+			expect(computerResult.content).toEqual([{ type: "text", text: "computer external result" }]);
+
+			const controller = new AbortController();
+			const pending = materializedBrowser!.execute("browser-wait", { action: "wait" }, controller.signal);
+			controller.abort();
+			await expect(pending).rejects.toThrow("browser transport aborted");
+			expect(calls).toEqual(["browser:ping", "computer:ping", "browser:wait"]);
+		} finally {
+			await session.dispose();
+		}
+	}, 60_000);
+
+	it("keeps host automation in built-in discovery and activation", async () => {
+		const calls: string[] = [];
+		const { session } = await createAgentSession({
+			...sessionOptions(),
+			settings: Settings.isolated({
+				"browser.enabled": false,
+				"computer.alwaysOn": false,
+				"tools.discoveryMode": "all",
+			}),
+			toolNames: undefined,
+			automationTools: {
+				browser: externalTool("browser", calls),
+				computer: externalTool("computer", calls),
+			},
+		});
+
+		try {
+			expect(session.getActiveToolNames()).not.toContain("browser");
+			expect(session.getActiveToolNames()).not.toContain("computer");
+			const discoverable = session.getDiscoverableTools({ source: "builtin" });
+			expect(discoverable).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ name: "browser", source: "builtin" }),
+					expect.objectContaining({ name: "computer", source: "builtin" }),
+				]),
+			);
+
+			expect(await session.activateDiscoveredTools(["browser", "computer"])).toEqual(["browser", "computer"]);
+			await session.getToolByName("computer")!.execute("computer-after-activation", { action: "ping" });
+			expect(calls).toEqual(["computer:ping"]);
+		} finally {
+			await session.dispose();
+		}
+	}, 60_000);
+
+	it("rejects a same-name custom tool before session construction", async () => {
+		const calls: string[] = [];
+		const customBrowser: CustomTool<typeof automationSchema> = {
+			name: "browser",
+			label: "Custom browser",
+			description: "Must not overwrite the external built-in",
+			parameters: automationSchema,
+			async execute() {
+				return { content: [{ type: "text", text: "custom" }] };
+			},
+		};
+
+		await expect(
+			createAgentSession({
+				...sessionOptions(),
+				automationTools: { browser: externalTool("browser", calls) },
+				customTools: [customBrowser],
+			}),
+		).rejects.toThrow("SDK automation tools cannot collide with custom tools: browser");
+		expect(calls).toEqual([]);
+	});
+});


### PR DESCRIPTION
## What

- Add an SDK `automationTools` option for host-owned `browser` and `computer` implementations.
- Materialize injected tools through the built-in descriptors so discovery, labels, provenance, and provider schemas remain canonical.
- Forward the standard tool abort signal and fail closed on custom, extension, or MCP name collisions.
- Cover direct execution, disabled-tool discovery activation, unsupported-platform computer injection, and collision rejection.

## Why

Desktop hosts such as Gajae Code App need the model-facing built-in `browser` and `computer` contracts to delegate to a shared Chromium/CDP session and a native CUA transport without patching `node_modules` or shadowing built-ins with same-name custom tools.

Closes #4809.

Downstream integration: https://github.com/devswha/gajae-code-app

## Testing

- `bun test packages/coding-agent/test/sdk-automation-tools.test.ts` — 3 pass.
- Related coding-agent SDK/tool tests — 80 pass.
- `bun --cwd=packages/coding-agent run check` — pass.
- `bun scripts/verify-gjc-state-writers.ts --fail` — pass.
- Root `bun run check` on Bun 1.4.0 reaches and passes the 582-row SDK adapter manifest. The unrelated Bun 1.4/rollback-manifest baseline mismatch has a minimal fix in #4812; with that applied, the executable rollback proof passes and the root check proceeds to the separate pre-existing SDK canonicalization failure tracked in #4813.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance.
- [ ] `regression-risk` — fix with material regression risk.
- [x] `high-risk` — public SDK API and host automation architecture change; independent maintainer review required.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:f4218732daa5761e41a63c4077bb6b679adcfaa1252672e8f887e11dbc615334 reviewer:human reviewer-id:Yeachan-Heo evidence:independent-exact-head-adversarial-review-approve-probes-and-package-checks-green
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes — blocked by the unrelated `dev` baseline failures tracked in #4812 and #4813.
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

