### PR TITLE
fix(test): align rollback manifest with Bun 1.4

### DIFF
--- a/packages/coding-agent/test/manifests/sdk-pretrain-binary.json
+++ b/packages/coding-agent/test/manifests/sdk-pretrain-binary.json
@@ -22,7 +22,7 @@
   "supportedPlatforms": ["darwin", "linux", "win32"],
   "toolchain": {
     "runtime": "bun",
-    "version": "1.3.14",
+    "version": "1.4.0",
     "dependencyInstall": ["bun", "install", "--offline", "--frozen-lockfile"],
     "nativeBuild": ["bun", "--cwd=packages/natives", "run", "build"],
     "nativeEmbed": ["bun", "--cwd=packages/natives", "run", "embed:native"],


### PR DESCRIPTION
## What

Update the executable rollback proof's declared Bun toolchain from 1.3.14 to 1.4.0.

## Why

PR #4795 moved the repository package-manager pin, package engine floors, and CI runtime to Bun 1.4.0 but left `sdk-pretrain-binary.json` at 1.3.14. The rollback test intentionally asserts that its manifest describes the runtime that actually builds the pinned executable, so every Bun 1.4.0 root check now fails before exercising the proof. Running with Bun 1.3.14 is no longer an alternative because `@gajae-code/coding-agent` requires Bun >=1.4.0.

## Testing

- `bun test packages/coding-agent/test/sdk-downgrade-rollback.test.ts packages/coding-agent/test/sdk-downgrade-unknown-version.test.ts` under Bun 1.4.0 — 4 pass; the pinned pre-Phase-B source is checked out, installed offline, native-built, compiled, ad-hoc signed, executed, and removed.
- Root `bun run check` now passes the rollback proof. It continues farther and stops at pre-existing SDK canonicalization violations in `commands/mcp-serve.ts`; this one-line manifest change does not alter the source import graph.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance.
- [x] `regression-risk` — changes the toolchain recorded by the executable rollback proof and requires independent review.
- [ ] `high-risk` — large refactor, feature, or materially high-risk change.

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:3341ea5d7aa5006edefcd3d933bf4ded935a4e01dd54b04bdd32adaea28cd7ff reviewer:human reviewer-id:pending-maintainer evidence:bun-1.4-rollback-proof-4-pass
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes — rollback failure is fixed; the run stops later on documented pre-existing SDK canonicalization violations.
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing) — not user-facing; no changelog entry required.
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
