### PR TITLE
feat(safety): fail-closed recursive-deletion boundary for test processes (real-HOME guard)

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "test:rs": "bun scripts/run-rs-task.ts test:rs",
     "check": "bun run --parallel check:ts check:rs",
     "check:ts": "bun run check:tools && bun run check:publish-types && bun run check:node20-baseline && bun run check:public-sync && bun run check:schemas && bun run check:sdk-closure && bun run check:docker-context && bun run check:gjc-ui && bun run --workspaces --if-present check",
-    "check:tools": "biome check . --no-errors-on-unmatched && tsc -p tsconfig.tools.json --noEmit",
+    "check:tools": "biome check . --no-errors-on-unmatched && tsc -p tsconfig.tools.json --noEmit && bun scripts/check-unsafe-rmrf.ts",
     "check:publish-types": "bun scripts/ci-release-publish.ts --check-types",
     "check:node20-baseline": "bun scripts/check-node20-baseline.ts",
     "check:rs": "bun scripts/run-rs-task.ts check:rs",

--- a/packages/coding-agent/scripts/generate-tool-catalog.ts
+++ b/packages/coding-agent/scripts/generate-tool-catalog.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { toolWireSchema } from "@gajae-code/ai/utils/schema";
+import { safeRm } from "../../../scripts/safe-cleanup";
 import { TaskTool } from "../src/task";
 import { TOOL_CATALOG } from "../src/tools/tool-catalog.generated";
 
@@ -496,7 +497,7 @@ export async function generateToolCatalogData(
 		else process.env.GJC_CODING_AGENT_DIR = previousGjcCodingAgentDir;
 		if (previousPiCodingAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 		else process.env.PI_CODING_AGENT_DIR = previousPiCodingAgentDir;
-		await fs.rm(isolatedRoot, { recursive: true, force: true });
+		await safeRm(isolatedRoot, { recursive: true, force: true });
 	}
 }
 

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -14,6 +14,7 @@ import { DEFAULT_MAX_BYTES } from "@gajae-code/coding-agent/session/streaming-ou
 import * as shellSnapshot from "@gajae-code/coding-agent/utils/shell-snapshot";
 import type { Shell } from "@gajae-code/natives";
 import * as piNatives from "@gajae-code/natives";
+import { safeRmSync } from "../../../scripts/safe-cleanup";
 
 const BACKGROUND_COMPLETION_RACE_MS = 750;
 // Direct executor callers retain the shared 20 KiB head alongside the 50 KiB tail.
@@ -38,7 +39,7 @@ describe("executeBash", () => {
 		resetSettingsForTest();
 		vi.restoreAllMocks();
 		if (fs.existsSync(tempDir)) {
-			fs.rmSync(tempDir, { recursive: true });
+			safeRmSync(tempDir, { recursive: true });
 		}
 	});
 

--- a/packages/coding-agent/test/default-gjc-definitions.test.ts
+++ b/packages/coding-agent/test/default-gjc-definitions.test.ts
@@ -25,6 +25,7 @@ import { getBundledAgent } from "@gajae-code/coding-agent/task/agents";
 import { discoverAgents } from "@gajae-code/coding-agent/task/discovery";
 import { checkBashAllowedPrefixes } from "@gajae-code/coding-agent/tools/bash-allowed-prefixes";
 import { prompt } from "@gajae-code/utils";
+import { safeRm } from "../../../scripts/safe-cleanup";
 
 const tempRoots: string[] = [];
 const roleAgentNames = ["architect", "critic", "executor", "planner"] as const;
@@ -66,7 +67,7 @@ async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
 
 afterEach(async () => {
 	resetActiveSkillsForTests();
-	await Promise.all(tempRoots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
+	await Promise.all(tempRoots.splice(0).map(root => safeRm(root, { recursive: true, force: true })));
 });
 
 describe("default GJC definitions", () => {

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -10,6 +10,7 @@ import {
 	parseClaudePluginsRegistry,
 } from "@gajae-code/coding-agent/discovery/helpers";
 import { discoverAgents } from "@gajae-code/coding-agent/task/discovery";
+import { safeRm } from "../../../../scripts/safe-cleanup";
 import "@gajae-code/coding-agent/discovery/claude-plugins";
 import type { Skill } from "@gajae-code/coding-agent/capability/skill";
 import type { SlashCommand } from "@gajae-code/coding-agent/capability/slash-command";
@@ -79,7 +80,7 @@ describe("listClaudePluginRoots", () => {
 		} else {
 			process.env.HOME = originalHome;
 		}
-		await fs.rm(tempDir, { recursive: true, force: true });
+		await safeRm(tempDir, { recursive: true, force: true });
 	});
 
 	test("returns empty roots when no registry file exists", async () => {
@@ -561,7 +562,7 @@ describe("discoverAgents plugin precedence", () => {
 
 	afterEach(async () => {
 		clearClaudePluginRootsCache();
-		await fs.rm(tempDir, { recursive: true, force: true });
+		await safeRm(tempDir, { recursive: true, force: true });
 	});
 
 	test("prefers project-scoped plugin agent over user-scoped plugin agent", async () => {

--- a/packages/coding-agent/test/discovery/disabled-extensions.test.ts
+++ b/packages/coding-agent/test/discovery/disabled-extensions.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { type ContextFile, contextFileCapability } from "@gajae-code/coding-agent/capability/context-file";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { initializeWithSettings, loadCapability } from "@gajae-code/coding-agent/discovery";
+import { safeRm } from "../../../../scripts/safe-cleanup";
 
 describe("disabledExtensions runtime filtering", () => {
 	let tempDir = "";
@@ -39,8 +40,8 @@ describe("disabledExtensions runtime filtering", () => {
 		} else {
 			process.env.HOME = originalHome;
 		}
-		await fs.rm(tempHomeDir, { recursive: true, force: true });
-		await fs.rm(tempDir, { recursive: true, force: true });
+		await safeRm(tempHomeDir, { recursive: true, force: true });
+		await safeRm(tempDir, { recursive: true, force: true });
 	});
 
 	test("hides disabled context files from runtime loads by default", async () => {

--- a/packages/coding-agent/test/gjc-plugin-no-surface.test.ts
+++ b/packages/coding-agent/test/gjc-plugin-no-surface.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getAgentDir, setAgentDir } from "@gajae-code/utils";
+import { safeRm } from "../../../scripts/safe-cleanup";
 import { loadCapability } from "../src/capability";
 import { clearCache as clearFsCache } from "../src/capability/fs";
 import { hookCapability } from "../src/capability/hook";
@@ -86,9 +87,9 @@ afterEach(async () => {
 	} else {
 		process.env.HOME = originalHome;
 	}
-	await fs.rm(tempHome, { recursive: true, force: true });
-	await fs.rm(tempCwd, { recursive: true, force: true });
-	await fs.rm(agentDir, { recursive: true, force: true });
+	await safeRm(tempHome, { recursive: true, force: true });
+	await safeRm(tempCwd, { recursive: true, force: true });
+	await safeRm(agentDir, { recursive: true, force: true });
 });
 
 describe("GJC plugin roots never surface through legacy claude plugin providers", () => {

--- a/packages/coding-agent/test/helpers/temp-home-cleanup.ts
+++ b/packages/coding-agent/test/helpers/temp-home-cleanup.ts
@@ -1,4 +1,4 @@
-import * as fs from "node:fs";
+import { safeRmSync } from "../../../../scripts/safe-cleanup";
 
 export interface TempHomeState {
 	tempDir: string;
@@ -9,12 +9,12 @@ export interface TempHomeState {
 export function cleanupTempHome(getState: () => TempHomeState): () => void {
 	return () => {
 		const { tempDir, tempHomeDir, originalHome } = getState();
-		if (tempDir) {
-			fs.rmSync(tempDir, { recursive: true, force: true });
-		}
-		if (tempHomeDir) {
-			fs.rmSync(tempHomeDir, { recursive: true, force: true });
-		}
+		// Fail-closed cleanup (issue #4794): the safe contract refuses the real
+		// home, its ancestors, out-of-root aliases, symlink escapes, and
+		// unowned paths instead of recursively deleting whatever the variable
+		// happens to hold. A truthiness check alone never proved ownership.
+		if (tempDir) safeRmSync(tempDir, { recursive: true, force: true });
+		if (tempHomeDir) safeRmSync(tempHomeDir, { recursive: true, force: true });
 		if (originalHome === undefined) {
 			delete process.env.HOME;
 		} else {

--- a/packages/coding-agent/test/helpers/temp-home.test.ts
+++ b/packages/coding-agent/test/helpers/temp-home.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { withTempHome } from "./temp-home";
+
+const originalHome = process.env.HOME;
+
+afterEach(() => {
+	if (originalHome === undefined) delete process.env.HOME;
+	else process.env.HOME = originalHome;
+	vi.restoreAllMocks();
+});
+
+describe("withTempHome", () => {
+	test("overrides HOME and os.homedir inside fn, restores and cleans up after", async () => {
+		let seenHome = "";
+		let seenRoot = "";
+		await withTempHome(async home => {
+			seenHome = home;
+			seenRoot = path.dirname(home);
+			expect(process.env.HOME).toBe(home);
+			expect(os.homedir()).toBe(home);
+			// The override is asserted in-effect: strictly inside the canonical temp root.
+			expect(fs.realpathSync(home).startsWith(fs.realpathSync(os.tmpdir()))).toBe(true);
+			fs.mkdirSync(path.join(home, ".gjc", "skills"), { recursive: true });
+		});
+		expect(process.env.HOME).toBe(originalHome);
+		expect(os.homedir()).toBe(originalHome ?? os.homedir());
+		expect(seenHome).not.toBe(originalHome);
+		// Cleanup removed the whole owning root.
+		expect(fs.existsSync(seenRoot)).toBe(false);
+	});
+
+	test("cleans up and restores even when fn throws", async () => {
+		let seenRoot = "";
+		await expect(
+			withTempHome(async home => {
+				seenRoot = path.dirname(home);
+				throw new Error("boom");
+			}),
+		).rejects.toThrow("boom");
+		expect(process.env.HOME).toBe(originalHome);
+		expect(fs.existsSync(seenRoot)).toBe(false);
+	});
+
+	test("restores HOME when it was previously unset", async () => {
+		delete process.env.HOME;
+		await withTempHome(async () => {
+			expect(process.env.HOME).toBeDefined();
+		});
+		expect(process.env.HOME).toBeUndefined();
+	});
+
+	test("leaves os.homedir untouched when mockHomedir is disabled", async () => {
+		const realHomedir = os.homedir();
+		await withTempHome(
+			async home => {
+				expect(process.env.HOME).toBe(home);
+				expect(os.homedir()).toBe(realHomedir);
+			},
+			{ mockHomedir: false },
+		);
+	});
+});

--- a/packages/coding-agent/test/helpers/temp-home.ts
+++ b/packages/coding-agent/test/helpers/temp-home.ts
@@ -1,0 +1,51 @@
+import { vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { assertSafeDeletion, safeRmSync } from "../../../../scripts/safe-cleanup";
+
+export interface WithTempHomeOptions {
+	/**
+	 * Also mock `os.homedir()` to return the temp home (default: true). The
+	 * mock is restored before cleanup runs.
+	 */
+	mockHomedir?: boolean;
+}
+
+/**
+ * Atomically run `fn` with `process.env.HOME` (and by default `os.homedir()`)
+ * pointed at a fresh, owned temporary home, then restore the previous
+ * environment and delete the temporary tree through the fail-closed cleanup
+ * contract (issue #4794).
+ *
+ * Fail-closed by construction:
+ * - The override is asserted to be in effect (`assertSafeDeletion`) — the temp
+ *   home must be strictly inside the canonical OS temp root — BEFORE `fn`
+ *   runs, so a test can never exercise home-derived paths against the real
+ *   home by accident.
+ * - Restore happens before removal, and removal targets the owning `mkdtemp`
+ *   root captured at creation, never a value derived from `HOME` afterwards.
+ * - Cleanup goes through `safeRmSync`, which refuses real-home/ancestor/
+ *   out-of-root/unowned targets instead of blindly recursing.
+ */
+export async function withTempHome<T>(fn: (home: string) => Promise<T>, options: WithTempHomeOptions = {}): Promise<T> {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-temp-home-"));
+	const home = path.join(root, "home");
+	fs.mkdirSync(home, { recursive: true });
+	assertSafeDeletion(home);
+
+	const originalHome = process.env.HOME;
+	const homedirSpy = options.mockHomedir === false ? undefined : vi.spyOn(os, "homedir").mockReturnValue(home);
+	process.env.HOME = home;
+	try {
+		return await fn(home);
+	} finally {
+		if (originalHome === undefined) {
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = originalHome;
+		}
+		homedirSpy?.mockRestore();
+		safeRmSync(root, { recursive: true, force: true });
+	}
+}

--- a/packages/coding-agent/test/issue-4508-cross-convention-fixture.test.ts
+++ b/packages/coding-agent/test/issue-4508-cross-convention-fixture.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getAgentDir, setAgentDir } from "@gajae-code/utils";
+import { safeRm } from "../../../scripts/safe-cleanup";
 import { Settings } from "../src/config/settings";
 import { applyImport, type BuildImportPreviewOptions, buildImportPreview } from "../src/customization/import";
 import { discoverRuntimeSkills } from "../src/extensibility/runtime-skill-discovery";
@@ -297,7 +298,7 @@ afterEach(async () => {
 	resetActiveSkillsForTests();
 	setAgentDir(originalAgentDir);
 	await expect(fs.readdir(homeDir)).resolves.toEqual(homeBefore);
-	await fs.rm(root, { recursive: true, force: true });
+	await safeRm(root, { recursive: true, force: true });
 });
 
 describe("issue #4508 cross-convention canonical fixture", () => {
@@ -322,7 +323,7 @@ describe("issue #4508 cross-convention canonical fixture", () => {
 					"collision-hook-ran",
 				);
 				expect(await fs.readFile(path.join(projectDir, ".gjc", "mcp.json"), "utf8")).toContain("native-collision");
-				await fs.rm(path.join(projectDir, ".gjc"), { recursive: true, force: true });
+				await safeRm(path.join(projectDir, ".gjc"), { recursive: true, force: true });
 				const plan = await buildImportPreview(previewOptions(convention));
 				const previewJson = JSON.stringify(plan.preview);
 				await expect(fs.stat(path.join(projectDir, ".gjc"))).rejects.toMatchObject({ code: "ENOENT" });

--- a/packages/coding-agent/test/issue-851-repro.test.ts
+++ b/packages/coding-agent/test/issue-851-repro.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { loadCapability } from "@gajae-code/coding-agent/capability";
 import { clearCache as clearFsCache } from "@gajae-code/coding-agent/capability/fs";
 import { clearClaudePluginRootsCache } from "@gajae-code/coding-agent/discovery/helpers";
+import { safeRm } from "../../../scripts/safe-cleanup";
 import "@gajae-code/coding-agent/discovery/claude-plugins";
 import type { MCPServer } from "../src/capability/mcp";
 
@@ -27,7 +28,7 @@ describe("issue-851: marketplace plugins load flat .mcp.json shape", () => {
 		vi.restoreAllMocks();
 		if (originalHome === undefined) delete process.env.HOME;
 		else process.env.HOME = originalHome;
-		await fs.rm(tempDir, { recursive: true, force: true });
+		await safeRm(tempDir, { recursive: true, force: true });
 	});
 
 	async function setupPlugin(pluginId: string, mcpJson: unknown): Promise<void> {

--- a/packages/coding-agent/test/lsp/lsp-command-trust.test.ts
+++ b/packages/coding-agent/test/lsp/lsp-command-trust.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as piUtils from "@gajae-code/utils";
 import { TempDir } from "@gajae-code/utils";
+import { registerOwnedDeletionRoot, safeRm, safeRmSync } from "../../../../scripts/safe-cleanup";
 import * as discoveryHelpers from "../../src/discovery/helpers";
 import { createLspWritethrough, LspTool } from "../../src/lsp";
 import { shutdownAll } from "../../src/lsp/client";
@@ -252,7 +253,13 @@ describe("LSP repository command trust", () => {
 	it("wraps supported servers with an external lspmux and honors both disable variables", async () => {
 		using tempDir = TempDir.createSync("@gjc-lspmux-external-");
 		const cwd = path.join(tempDir.path(), "repo");
+		// Issue #4794: trusted user-scope resolution only honors the REAL home
+		// (resolvers capture os.homedir at import time, so a mock cannot
+		// redirect it). This test therefore still creates its fixture under the
+		// real home, but the deletion is explicitly granted for exactly this
+		// process-created directory and still refuses the home itself.
 		const externalBinDir = path.join(os.homedir(), `.gjc-lspmux-external-${process.pid}-${Date.now()}`);
+		const forgetGrant = registerOwnedDeletionRoot(externalBinDir);
 		await fs.promises.mkdir(cwd, { recursive: true });
 		await fs.promises.mkdir(externalBinDir, { recursive: true });
 		try {
@@ -275,7 +282,8 @@ describe("LSP repository command trust", () => {
 			Bun.env.PI_DISABLE_LSPMUX = "1";
 			expect((await detectLspmux(cwd)).available).toBe(false);
 		} finally {
-			await fs.promises.rm(externalBinDir, { recursive: true, force: true });
+			await safeRm(externalBinDir, { recursive: true, force: true });
+			forgetGrant();
 		}
 	});
 
@@ -523,10 +531,15 @@ describe("LSP repository command trust", () => {
 		using tempDir = TempDir.createSync("@gjc-lsp-command-fields-");
 		const cwd = tempDir.path();
 		const configDirName = `.gjc-lsp-command-trust-${process.pid}-${Date.now()}`;
+		// Issue #4794: user-scope config resolution goes through the trusted
+		// home resolver, which only honors the REAL home (the os.homedir
+		// binding is captured at import time and cannot be redirected by a
+		// mock). The fixture stays under the real home, but its recursive
+		// deletion is granted for exactly this process-created directory.
 		const userConfigDir = path.join(os.homedir(), configDirName);
+		const forgetGrant = registerOwnedDeletionRoot(userConfigDir);
 		const userAgentDir = path.join(userConfigDir, "agent");
 		const trustedServer = path.join(userConfigDir, "typescript-language-server");
-
 		fs.mkdirSync(userAgentDir, { recursive: true });
 		fs.writeFileSync(trustedServer, "#!/bin/sh\nexit 0\n");
 		fs.chmodSync(trustedServer, 0o755);
@@ -570,7 +583,8 @@ describe("LSP repository command trust", () => {
 			expect(server?.initOptions).toEqual({ trustedInitialization: true });
 			expect(server?.settings).toEqual({ trustedSettings: true });
 		} finally {
-			fs.rmSync(userConfigDir, { recursive: true, force: true });
+			safeRmSync(userConfigDir, { recursive: true, force: true });
+			forgetGrant();
 		}
 	});
 });

--- a/packages/coding-agent/test/marketplace/project-scope.test.ts
+++ b/packages/coding-agent/test/marketplace/project-scope.test.ts
@@ -8,6 +8,7 @@
  * This file imports from helpers.ts directly — the native addon IS present in the
  * test environment (verified: `bun run import-helpers.ts` succeeds).
  */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -19,6 +20,7 @@ import {
 	readInstalledPluginsRegistry,
 	writeInstalledPluginsRegistry,
 } from "@gajae-code/coding-agent/extensibility/plugins/marketplace";
+import { safeRm, safeRmSync } from "../../../../scripts/safe-cleanup";
 import {
 	clearClaudePluginRootsCache,
 	listClaudePluginRoots,
@@ -47,7 +49,7 @@ describe("resolveActiveProjectRegistryPath", () => {
 	});
 
 	afterEach(() => {
-		fs.rmSync(tmpDir, { recursive: true, force: true });
+		safeRmSync(tmpDir, { recursive: true, force: true });
 	});
 
 	it("walk-up finds nearest .gjc/ directory", async () => {
@@ -121,7 +123,7 @@ describe("resolveActiveProjectRegistryPath", () => {
 			const homeGjcPath = path.join(homeDir, ".gjc", "plugins", "installed_plugins.json");
 			expect(result).not.toBe(homeGjcPath);
 		} finally {
-			if (!hadGit) await fs.promises.rm(fakeHomeGit, { recursive: true, force: true });
+			if (!hadGit) await safeRm(fakeHomeGit, { recursive: true, force: true });
 		}
 	});
 
@@ -165,8 +167,8 @@ describe("listClaudePluginRoots — project shadows user", () => {
 	afterEach(() => {
 		// Cache is keyed by home:projectPath — must clear between tests.
 		clearClaudePluginRootsCache();
-		fs.rmSync(tmpHome, { recursive: true, force: true });
-		fs.rmSync(tmpProject, { recursive: true, force: true });
+		safeRmSync(tmpHome, { recursive: true, force: true });
+		safeRmSync(tmpProject, { recursive: true, force: true });
 	});
 
 	it("project entry shadows user entry when plugin IDs match", async () => {

--- a/packages/coding-agent/test/mcp-autoload-session.test.ts
+++ b/packages/coding-agent/test/mcp-autoload-session.test.ts
@@ -2,6 +2,7 @@
  * Conventional MCP autoload: ordinary top-level standalone sessions consume
  * `gjc mcp add` registrations (issue #4284).
  */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -12,6 +13,7 @@ import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { createAgentSession } from "@gajae-code/coding-agent/sdk";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
 import { getAgentDir, setAgentDir } from "@gajae-code/utils";
+import { safeRm } from "../../../scripts/safe-cleanup";
 import { runMCPCommand } from "../src/cli/mcp-cli";
 import { MCPManager } from "../src/runtime-mcp";
 
@@ -59,9 +61,9 @@ describe("conventional MCP autoload in standalone sessions", () => {
 	afterEach(async () => {
 		vi.restoreAllMocks();
 		setAgentDir(originalAgentDir);
-		await fs.promises.rm(projectDir, { recursive: true, force: true });
-		await fs.promises.rm(agentDir, { recursive: true, force: true });
-		await fs.promises.rm(tempHome, { recursive: true, force: true });
+		await safeRm(projectDir, { recursive: true, force: true });
+		await safeRm(agentDir, { recursive: true, force: true });
+		await safeRm(tempHome, { recursive: true, force: true });
 	});
 
 	function isolatedSessionOptions() {

--- a/packages/coding-agent/test/runtime-mcp/mcp-autoload-precedence.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/mcp-autoload-precedence.test.ts
@@ -7,11 +7,13 @@
  * through the bounded mcp-compat layer; they are never implicit competing
  * runtime authorities, and foreign user-home configuration is never read.
  */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getMCPConfigPath, setAgentDir } from "@gajae-code/utils";
+import { safeRm } from "../../../../scripts/safe-cleanup";
 import type { MCPServer } from "../../src/capability/mcp";
 import { normalizeClaudeMcpJson, normalizeCodexMcpToml, validateMCPCompatServer } from "../../src/discovery/mcp-compat";
 import { loadAllMCPConfigs } from "../../src/runtime-mcp/config";
@@ -45,8 +47,8 @@ afterEach(async () => {
 	vi.restoreAllMocks();
 	if (originalAgentDir) setAgentDir(originalAgentDir);
 	else delete process.env.GJC_CODING_AGENT_DIR;
-	await fs.rm(projectDir, { recursive: true, force: true });
-	await fs.rm(tempHome, { recursive: true, force: true });
+	await safeRm(projectDir, { recursive: true, force: true });
+	await safeRm(tempHome, { recursive: true, force: true });
 });
 
 describe("conventional MCP precedence", () => {

--- a/packages/coding-agent/test/runtime-mcp/mcp-autoload-redteam.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/mcp-autoload-redteam.test.ts
@@ -6,6 +6,7 @@
  * interplay with plugin-bundle MCPs, disabledServers bypass via explicit
  * connect, sealed-manager re-discovery, and native file precedence.
  */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -16,6 +17,7 @@ import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { createAgentSession } from "@gajae-code/coding-agent/sdk";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
 import { getAgentDir, setAgentDir } from "@gajae-code/utils";
+import { safeRm } from "../../../../scripts/safe-cleanup";
 import { runMCPCommand } from "../../src/cli/mcp-cli";
 import { installGjcBundle } from "../../src/extensibility/gjc-plugins";
 import { MCPManager } from "../../src/runtime-mcp";
@@ -76,9 +78,9 @@ describe("red-team: conventional MCP autoload", () => {
 	afterEach(async () => {
 		vi.restoreAllMocks();
 		setAgentDir(originalAgentDir);
-		await fs.promises.rm(projectDir, { recursive: true, force: true });
-		await fs.promises.rm(agentDir, { recursive: true, force: true });
-		await fs.promises.rm(tempHome, { recursive: true, force: true });
+		await safeRm(projectDir, { recursive: true, force: true });
+		await safeRm(agentDir, { recursive: true, force: true });
+		await safeRm(tempHome, { recursive: true, force: true });
 	});
 
 	async function writeProjectConfig(relPath: string, content: string | unknown): Promise<void> {

--- a/packages/coding-agent/test/sdk-skills.test.ts
+++ b/packages/coding-agent/test/sdk-skills.test.ts
@@ -7,6 +7,7 @@ import { DEFAULT_GJC_DEFINITION_NAMES } from "@gajae-code/coding-agent/defaults/
 import type { Skill } from "@gajae-code/coding-agent/sdk";
 import { createAgentSession } from "@gajae-code/coding-agent/sdk";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { safeRmSync } from "../../../scripts/safe-cleanup";
 import { cleanupTempHome } from "./helpers/temp-home-cleanup";
 
 function createIsolatedSkillsSettings(): Settings {
@@ -71,7 +72,7 @@ Loaded via symbolic link.
 	afterEach(cleanupTempHome(() => ({ tempDir, tempHomeDir, originalHome })));
 
 	it("loads embedded default GJC workflow skills even when .gjc is absent and arbitrary skill discovery is disabled", async () => {
-		fs.rmSync(path.join(tempDir, ".gjc"), { recursive: true, force: true });
+		safeRmSync(path.join(tempDir, ".gjc"), { recursive: true, force: true });
 		const { session } = await createAgentSession({
 			cwd: tempDir,
 			agentDir: tempDir,
@@ -110,7 +111,7 @@ Loaded via symbolic link.
 
 	it("should still discover project skills when user skills directory is missing", async () => {
 		const userAgentDir = path.join(tempHomeDir, ".gjc", "agent");
-		fs.rmSync(path.join(userAgentDir, "skills"), { recursive: true, force: true });
+		safeRmSync(path.join(userAgentDir, "skills"), { recursive: true, force: true });
 		fs.writeFileSync(path.join(userAgentDir, "placeholder.txt"), "placeholder");
 
 		const { session } = await createAgentSession({

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -11,6 +11,7 @@ import {
 	parseSkillInvocations,
 	type Skill,
 } from "@gajae-code/coding-agent/extensibility/skills";
+import { safeRm } from "../../../scripts/safe-cleanup";
 
 const fixturesDir = path.resolve(import.meta.dirname, "fixtures/skills");
 const collisionFixturesDir = path.resolve(import.meta.dirname, "fixtures/skills-collision");
@@ -258,8 +259,8 @@ describe("skills", () => {
 				expect(skills.map(skill => skill.name)).toEqual(["native-project-skill"]);
 				expect(skills[0]?.source).toBe("native:project");
 			} finally {
-				await fs.rm(tempProjectDir, { recursive: true, force: true });
-				await fs.rm(tempHomeDir, { recursive: true, force: true });
+				await safeRm(tempProjectDir, { recursive: true, force: true });
+				await safeRm(tempHomeDir, { recursive: true, force: true });
 			}
 		});
 
@@ -325,7 +326,7 @@ enabled: false
 				});
 				expect(skills.some(s => s.name === "disabled-skill")).toBe(false);
 			} finally {
-				await fs.rm(tempDir, { recursive: true, force: true });
+				await safeRm(tempDir, { recursive: true, force: true });
 			}
 		});
 
@@ -385,7 +386,7 @@ description: Skill loaded from a tilde-expanded custom directory.
 				expect(withTilde.length).toBe(withoutTilde.length);
 				expect(withTilde.some(skill => skill.name === "tilde-skill")).toBe(true);
 			} finally {
-				await fs.rm(tempHome, { recursive: true, force: true });
+				await safeRm(tempHome, { recursive: true, force: true });
 			}
 		});
 
@@ -423,8 +424,8 @@ description: Skill loaded from a tilde-expanded custom directory.
 				const { skills } = await loadSkills({ cwd: tempDir, home: tempHome });
 				expect(skills.map(skill => skill.name).sort()).toEqual(["project-skill", "user-skill"]);
 			} finally {
-				await fs.rm(tempDir, { recursive: true, force: true });
-				await fs.rm(tempHome, { recursive: true, force: true });
+				await safeRm(tempDir, { recursive: true, force: true });
+				await safeRm(tempHome, { recursive: true, force: true });
 			}
 		});
 
@@ -456,21 +457,21 @@ description: Skill loaded from a tilde-expanded custom directory.
 				expect(warnings.filter(w => w.message.includes("name collision")).length).toBe(2);
 
 				// Drop the nested copy: the repo-root project copy still beats user.
-				await fs.rm(path.join(nested, ".gjc"), { recursive: true, force: true });
+				await safeRm(path.join(nested, ".gjc"), { recursive: true, force: true });
 				const { skills: next } = await loadSkills({ cwd: nested, home: tempHome });
 				expect(next.find(skill => skill.name === "shared")?.filePath).toContain(
 					path.join(tempDir, ".gjc", "skills", "shared"),
 				);
 
 				// Drop all project copies: the user copy finally wins.
-				await fs.rm(path.join(tempDir, ".gjc"), { recursive: true, force: true });
+				await safeRm(path.join(tempDir, ".gjc"), { recursive: true, force: true });
 				const { skills: userWins } = await loadSkills({ cwd: nested, home: tempHome });
 				expect(userWins.find(skill => skill.name === "shared")?.filePath).toContain(
 					path.join(tempHome, ".gjc", "agent", "skills", "shared"),
 				);
 			} finally {
-				await fs.rm(tempDir, { recursive: true, force: true });
-				await fs.rm(tempHome, { recursive: true, force: true });
+				await safeRm(tempDir, { recursive: true, force: true });
+				await safeRm(tempHome, { recursive: true, force: true });
 			}
 		});
 
@@ -497,8 +498,8 @@ description: Skill loaded from a tilde-expanded custom directory.
 				const legacyDisabled = await loadSkills({ cwd: tempDir, home: tempHome, enablePiProject: false });
 				expect(legacyDisabled.skills).toHaveLength(0);
 			} finally {
-				await fs.rm(tempDir, { recursive: true, force: true });
-				await fs.rm(tempHome, { recursive: true, force: true });
+				await safeRm(tempDir, { recursive: true, force: true });
+				await safeRm(tempHome, { recursive: true, force: true });
 			}
 		});
 
@@ -533,8 +534,8 @@ description: Skill loaded from a tilde-expanded custom directory.
 				const masterOff = await loadSkills({ cwd: tempDir, home: tempHome, enabled: false });
 				expect(masterOff.skills).toHaveLength(0);
 			} finally {
-				await fs.rm(tempDir, { recursive: true, force: true });
-				await fs.rm(tempHome, { recursive: true, force: true });
+				await safeRm(tempDir, { recursive: true, force: true });
+				await safeRm(tempHome, { recursive: true, force: true });
 			}
 		});
 		it("should filter skills with includeSkills glob patterns", async () => {

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -13,6 +13,7 @@ import {
 import * as git from "@gajae-code/coding-agent/utils/git";
 import { getAgentDir, hashPath, setAgentDir } from "@gajae-code/utils";
 import * as z from "zod/v4";
+import { safeRm } from "../../../../scripts/safe-cleanup";
 
 // Isolate every `git` invocation in this file from the developer's host
 // configuration. The fixture spawns dozens of git subprocesses against tiny
@@ -166,7 +167,7 @@ async function setupTempHome(): Promise<{ home: string; cleanup: () => Promise<v
 		home,
 		cleanup: async () => {
 			setAgentDir(originalAgentDir);
-			await fs.rm(home, { recursive: true, force: true });
+			await safeRm(home, { recursive: true, force: true });
 		},
 	};
 }
@@ -1091,7 +1092,7 @@ describe("github tool", () => {
 			expect(runGit(worktreePath, ["branch", "--show-current"])).toBe("pr-123");
 		} finally {
 			await tempHome.cleanup();
-			await fs.rm(fixture.baseDir, { recursive: true, force: true });
+			await safeRm(fixture.baseDir, { recursive: true, force: true });
 		}
 	});
 
@@ -1103,7 +1104,7 @@ describe("github tool", () => {
 		});
 
 		afterAll(async () => {
-			await fs.rm(fixture.baseDir, { recursive: true, force: true });
+			await safeRm(fixture.baseDir, { recursive: true, force: true });
 		});
 
 		it("treats git.remote.add as a no-op when the remote already exists with the same URL", async () => {
@@ -1138,7 +1139,7 @@ describe("github tool", () => {
 				expect(runGit(fixture.repoRoot, ["config", "--get", `branch.race-test.key${idx}`])).toBe(`value-${idx}`);
 			}
 		} finally {
-			await fs.rm(fixture.baseDir, { recursive: true, force: true });
+			await safeRm(fixture.baseDir, { recursive: true, force: true });
 		}
 	});
 
@@ -1209,7 +1210,7 @@ describe("github tool", () => {
 			expect(summaries?.every(s => s.reused === false)).toBe(true);
 		} finally {
 			await tempHome.cleanup();
-			await fs.rm(fixture.baseDir, { recursive: true, force: true });
+			await safeRm(fixture.baseDir, { recursive: true, force: true });
 		}
 	}, 30_000);
 
@@ -1236,7 +1237,7 @@ describe("github tool", () => {
 				originMainBefore,
 			);
 		} finally {
-			await fs.rm(fixture.baseDir, { recursive: true, force: true });
+			await safeRm(fixture.baseDir, { recursive: true, force: true });
 		}
 	});
 
@@ -1267,7 +1268,7 @@ describe("github tool", () => {
 				}),
 			);
 		} finally {
-			await fs.rm(fixture.baseDir, { recursive: true, force: true });
+			await safeRm(fixture.baseDir, { recursive: true, force: true });
 		}
 	});
 
@@ -1359,7 +1360,7 @@ describe("github tool", () => {
 			expect(artifactText).toContain("epsilon");
 			expect(artifactText).toContain("zeta");
 		} finally {
-			await fs.rm(artifactsDir, { recursive: true, force: true });
+			await safeRm(artifactsDir, { recursive: true, force: true });
 		}
 	});
 });

--- a/packages/coding-agent/test/tools/skill-discovery.test.ts
+++ b/packages/coding-agent/test/tools/skill-discovery.test.ts
@@ -9,6 +9,7 @@ import { buildSystemPrompt } from "@gajae-code/coding-agent/system-prompt";
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
 import { SkillTool } from "@gajae-code/coding-agent/tools/skill";
 import { SkillDiscoveryTool } from "@gajae-code/coding-agent/tools/skill-discovery";
+import { safeRm } from "../../../../scripts/safe-cleanup";
 
 async function makeSkill(
 	root: string,
@@ -356,8 +357,8 @@ describe("SkillDiscoveryTool", () => {
 			else process.env.PI_CODING_AGENT_DIR = originalPiCodingAgentDir;
 			if (originalXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
 			else process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
-			await fs.rm(cwd, { recursive: true, force: true });
-			await fs.rm(home, { recursive: true, force: true });
+			await safeRm(cwd, { recursive: true, force: true });
+			await safeRm(home, { recursive: true, force: true });
 		}
 	});
 
@@ -401,8 +402,8 @@ describe("SkillDiscoveryTool", () => {
 			else process.env.GJC_CONFIG_DIR = originalGjcConfigDir;
 			if (originalPiConfigDir === undefined) delete process.env.PI_CONFIG_DIR;
 			else process.env.PI_CONFIG_DIR = originalPiConfigDir;
-			await fs.rm(cwd, { recursive: true, force: true });
-			await fs.rm(home, { recursive: true, force: true });
+			await safeRm(cwd, { recursive: true, force: true });
+			await safeRm(home, { recursive: true, force: true });
 		}
 	});
 
@@ -451,7 +452,7 @@ describe("SkillDiscoveryTool", () => {
 				}).map(command => command.name),
 			).not.toContain("skill:hidden-helper");
 		} finally {
-			await fs.rm(cwd, { recursive: true, force: true });
+			await safeRm(cwd, { recursive: true, force: true });
 		}
 	});
 
@@ -490,8 +491,8 @@ describe("SkillDiscoveryTool", () => {
 				expect.objectContaining({ name: "alpha", description: "Sort alpha", path: alphaPath, source: "project" }),
 			]);
 		} finally {
-			await fs.rm(cwd, { recursive: true, force: true });
-			await fs.rm(home, { recursive: true, force: true });
+			await safeRm(cwd, { recursive: true, force: true });
+			await safeRm(home, { recursive: true, force: true });
 		}
 	});
 
@@ -595,7 +596,7 @@ describe("SkillDiscoveryTool", () => {
 
 			// Drop the native copy: the user-scope copy wins at runtime while the
 			// convention copies remain import candidates with enablement guidance.
-			await fs.rm(path.join(cwd, ".gjc"), { recursive: true, force: true });
+			await safeRm(path.join(cwd, ".gjc"), { recursive: true, force: true });
 			const userWins = await new SkillDiscoveryTool(
 				createSession(cwd, { settings: runtimeSkillSettings(), home }),
 			).execute("call", { query: "shared" });

--- a/packages/coding-agent/test/tools/skill.test.ts
+++ b/packages/coding-agent/test/tools/skill.test.ts
@@ -10,6 +10,7 @@ import { SKILL_PROMPT_MESSAGE_TYPE } from "@gajae-code/coding-agent/session/mess
 import type { ToolSession } from "@gajae-code/coding-agent/tools";
 import { SkillTool } from "@gajae-code/coding-agent/tools/skill";
 import { ToolError } from "@gajae-code/coding-agent/tools/tool-errors";
+import { safeRm } from "../../../../scripts/safe-cleanup";
 
 async function makeSkill(name: string, content: string): Promise<Skill> {
 	const dir = await mkdtemp(path.join(os.tmpdir(), `skill-tool-${name}-`));
@@ -253,10 +254,10 @@ describe("SkillTool", () => {
 			else process.env.GJC_CONFIG_DIR = originalGjcConfigDir;
 			if (originalPiConfigDir === undefined) delete process.env.PI_CONFIG_DIR;
 			else process.env.PI_CONFIG_DIR = originalPiConfigDir;
-			if (unrelated) await fs.rm(unrelated.baseDir, { recursive: true, force: true });
-			if (preloaded) await fs.rm(preloaded.baseDir, { recursive: true, force: true });
-			await fs.rm(cwd, { recursive: true, force: true });
-			await fs.rm(home, { recursive: true, force: true });
+			if (unrelated) await safeRm(unrelated.baseDir, { recursive: true, force: true });
+			if (preloaded) await safeRm(preloaded.baseDir, { recursive: true, force: true });
+			await safeRm(cwd, { recursive: true, force: true });
+			await safeRm(home, { recursive: true, force: true });
 		}
 	});
 
@@ -415,9 +416,9 @@ describe("SkillTool", () => {
 			else process.env.PI_CODING_AGENT_DIR = originalPiCodingAgentDir;
 			if (originalXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
 			else process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
-			if (loaded) await fs.rm(loaded.baseDir, { recursive: true, force: true });
-			await fs.rm(cwd, { recursive: true, force: true });
-			await fs.rm(home, { recursive: true, force: true });
+			if (loaded) await safeRm(loaded.baseDir, { recursive: true, force: true });
+			await safeRm(cwd, { recursive: true, force: true });
+			await safeRm(home, { recursive: true, force: true });
 		}
 	});
 

--- a/packages/utils/test/account-home-nss.test.ts
+++ b/packages/utils/test/account-home-nss.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { safeRm } from "../../../scripts/safe-cleanup";
 
 /**
  * The account home is the evidence that lets the resolver reject a home the
@@ -32,7 +33,7 @@ async function tempDir(): Promise<string> {
 }
 
 afterEach(async () => {
-	await Promise.all(scratch.splice(0).map(entry => fs.rm(entry, { recursive: true, force: true })));
+	await Promise.all(scratch.splice(0).map(entry => safeRm(entry, { recursive: true, force: true })));
 });
 
 /** Resolve the trusted home in a child process under a controlled environment. */
@@ -197,7 +198,7 @@ describe("account home is resolved through the OS account database", () => {
 			// variable must never select the home on Linux.
 			expect(await resolveWith({ HOME: undefined, USERPROFILE: hostile })).toBe(account);
 		} finally {
-			await fs.rm(hostile, { recursive: true, force: true });
+			await safeRm(hostile, { recursive: true, force: true });
 		}
 	});
 
@@ -262,7 +263,7 @@ describe("account home is resolved through the OS account database", () => {
 			expect(first).toBe("REFUSED");
 			expect(second).toBe("REFUSED");
 		} finally {
-			await Promise.all([attacker, project].map(dir => fs.rm(dir, { recursive: true, force: true })));
+			await Promise.all([attacker, project].map(dir => safeRm(dir, { recursive: true, force: true })));
 		}
 	});
 
@@ -303,9 +304,9 @@ describe("account home is resolved through the OS account database", () => {
 			const resolved = stdout.trim().split("\n").at(-1) ?? "";
 			expect(resolved).toBe(home);
 			expect(path.isAbsolute(resolved)).toBe(true);
-			await fs.rm(home, { recursive: true, force: true });
+			await safeRm(home, { recursive: true, force: true });
 		} finally {
-			await fs.rm(work, { recursive: true, force: true });
+			await safeRm(work, { recursive: true, force: true });
 		}
 	});
 
@@ -325,7 +326,7 @@ describe("account home is resolved through the OS account database", () => {
 			const resolved = await resolveWith({ HOME: account, GJC_TEST_DYNAMIC: account }, project);
 			expect(resolved).toBe(account);
 		} finally {
-			await fs.rm(project, { recursive: true, force: true });
+			await safeRm(project, { recursive: true, force: true });
 		}
 	});
 
@@ -344,7 +345,7 @@ describe("account home is resolved through the OS account database", () => {
 			expect(resolved).not.toBe(aliased);
 			expect(resolved).not.toBe(real);
 		} finally {
-			await Promise.all([base, project].map(dir => fs.rm(dir, { recursive: true, force: true })));
+			await Promise.all([base, project].map(dir => safeRm(dir, { recursive: true, force: true })));
 		}
 	});
 });

--- a/packages/utils/test/trusted-home-resolution.test.ts
+++ b/packages/utils/test/trusted-home-resolution.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { safeRm } from "../../../scripts/safe-cleanup";
 import {
 	CONFIG_DIR_NAME,
 	getAgentDir,
@@ -95,7 +96,7 @@ async function tempDir(): Promise<string> {
 
 afterEach(async () => {
 	vi.restoreAllMocks();
-	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+	await Promise.all(tempDirs.splice(0).map(dir => safeRm(dir, { recursive: true, force: true })));
 });
 
 describe("authoritative home resolution", () => {

--- a/scripts/check-unsafe-rmrf.test.ts
+++ b/scripts/check-unsafe-rmrf.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
+import { isFixturePath, scanRepository, scanUnsafeRecursiveRemovals } from "./check-unsafe-rmrf";
+
+function violationsOf(text: string, filePath = "packages/coding-agent/test/example.test.ts") {
+	return scanUnsafeRecursiveRemovals([{ path: filePath, text }]);
+}
+
+describe("check-unsafe-rmrf scanner", () => {
+	test("flags a HOME-seam file with a raw recursive rmSync", () => {
+		const violations = violationsOf(
+			[
+				'import * as os from "node:os";',
+				"process.env.HOME = tempHome;",
+				"afterEach(() => {",
+				"	fs.rmSync(tempHome, { recursive: true, force: true });",
+				"});",
+			].join("\n"),
+		);
+		expect(violations).toHaveLength(1);
+		expect(violations[0]?.line).toBe(4);
+		expect(violations[0]?.message).toContain("safeRm");
+	});
+
+	test("flags a HOME-seam file with raw fs.rm and fs.promises.rm", () => {
+		for (const call of [
+			"await fs.rm(tempDir, { recursive: true, force: true });",
+			"await fs.promises.rm(tempDir, { recursive: true, force: true });",
+			"fs.rmdirSync(tempDir, { recursive: true });",
+		]) {
+			const violations = violationsOf(['process.env.HOME = home;', call].join("\n"));
+			expect(violations).toHaveLength(1);
+		}
+	});
+
+	test("flags an os.homedir spy seam", () => {
+		const violations = violationsOf(
+			['vi.spyOn(os, "homedir").mockReturnValue(home);', "await fs.rm(home, { recursive: true, force: true });"].join(
+				"\n",
+			),
+		);
+		expect(violations).toHaveLength(1);
+	});
+
+	test("does not flag files without a HOME seam", () => {
+		expect(
+			violationsOf(["await fs.rm(tempDir, { recursive: true, force: true });"].join("\n")),
+		).toEqual([]);
+	});
+
+	test("does not flag migrated safe-contract calls", () => {
+		expect(
+			violationsOf(
+				[
+					'import { safeRm } from "../../../scripts/safe-cleanup";',
+					"process.env.HOME = home;",
+					"await safeRm(home, { recursive: true, force: true });",
+				].join("\n"),
+			),
+		).toEqual([]);
+	});
+
+	test("does not flag non-removal recursive calls such as mkdir", () => {
+		expect(
+			violationsOf(["process.env.HOME = home;", "fs.mkdirSync(dir, { recursive: true });"].join("\n")),
+		).toEqual([]);
+	});
+
+	test("does not flag non-recursive removals", () => {
+		expect(
+			violationsOf(["process.env.HOME = home;", "await fs.rm(file, { force: true });"].join("\n")),
+		).toEqual([]);
+	});
+
+	test("flags shell template and spawn-array force-recursive rm", () => {
+		expect(violationsOf(["process.env.HOME = home;", "await $`rm -rf ${dir}`;"].join("\n"))).toHaveLength(1);
+		expect(
+			violationsOf(['process.env.HOME = home;', 'Bun.spawn(["rm", "-rf", dir]);'].join("\n")),
+		).toHaveLength(1);
+	});
+
+	test("does not flag bare blocked-command fixture strings", () => {
+		expect(
+			violationsOf(['process.env.HOME = home;', 'const blocked = ["rm -rf .gjc", "echo verdict"];'].join("\n")),
+		).toEqual([]);
+	});
+
+	test("flags multi-line rm calls within the recursive window", () => {
+		const violations = violationsOf(
+			["process.env.HOME = home;", "await fs.rm(", "\ttempDir,", "\t{ recursive: true, force: true },", ");"].join(
+				"\n",
+			),
+		);
+		expect(violations).toHaveLength(1);
+		expect(violations[0]?.line).toBe(2);
+	});
+
+	test("excludes fixture paths from scanning", () => {
+		const text = 'process.env.HOME = home;\nfs.rmSync(home, { recursive: true, force: true });';
+		expect(violationsOf(text, "packages/coding-agent/test/test-fixtures/guard-violation.ts")).toEqual([]);
+		expect(violationsOf(text, "scripts/test-fixtures/guard-violation.ts")).toEqual([]);
+	});
+
+	test("isFixturePath recognizes fixture locations", () => {
+		expect(isFixturePath("a/fixtures/x.ts")).toBe(true);
+		expect(isFixturePath("a/test-fixtures/x.ts")).toBe(true);
+		expect(isFixturePath("packages/coding-agent/test/example.test.ts")).toBe(false);
+	});
+});
+
+describe("check-unsafe-rmrf repository scan", () => {
+	test("the repository is clean", async () => {
+		const violations = await scanRepository(path.join(import.meta.dir, ".."));
+		expect(violations).toEqual([]);
+	}, 60_000);
+});

--- a/scripts/check-unsafe-rmrf.ts
+++ b/scripts/check-unsafe-rmrf.ts
@@ -1,0 +1,141 @@
+#!/usr/bin/env bun
+/**
+ * Static guard for issue #4794: repository test code must not combine HOME-seam
+ * mutation (`process.env.HOME = …` / `vi.spyOn(os, "homedir")`) with raw
+ * recursive removals (`fs.rm*`/`fs.rmdir*` with `recursive: true`, or a real
+ * shell force-recursive `rm` invocation). That combination is exactly how an
+ * operator's real home was destroyed: a cleanup path that deletes a variable
+ * bug (or a lazily-captured consumer) resolved back to the real home.
+ *
+ * Files that need both must route deletions through the fail-closed contract
+ * (`safeRm`/`safeRmSync` from `scripts/safe-cleanup.ts`) or the
+ * `withTempHome()`/`temp-home-cleanup` helpers. The runtime guard in
+ * `scripts/test-preload.ts` cannot intercept ESM top-level `fs.rmSync`
+ * bindings in Bun 1.4.0, so this check is the deterministic enforcement layer
+ * for repository source.
+ *
+ * Deliberate raw recursive removals inside test INPUT fixtures live under
+ * `test-fixtures/` directories and are excluded: fixtures are data exercised
+ * by tests, not test cleanup code.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+export interface UnsafeRemovalViolation {
+	path: string;
+	line: number;
+	snippet: string;
+	message: string;
+}
+
+export interface UnsafeRemovalFile {
+	/** Repository-relative path, used for reporting. */
+	path: string;
+	text: string;
+}
+
+const HOME_SEAM_PATTERN = /process\.env\.HOME\s*=|vi\.spyOn\(os,\s*["']homedir["']/;
+const RM_CALL_PATTERN = /\.(rmSync|rmdirSync|rm|rmdir)\s*\(/g;
+// A real shell force-recursive rm invocation: either a Bun-shell tagged
+// template containing `rm` with recursive+force flags, or a spawn-style
+// string array whose command element is `rm` followed by recursive+force
+// flags. Bare strings on their own line (blocked-command fixtures) are not
+// invocations.
+const SHELL_TEMPLATE_RM_PATTERN = /\$`[^`]*\brm\s+(-[A-Za-z]*r[A-Za-z]*f|-[A-Za-z]*f[A-Za-z]*r)/g;
+const SHELL_ARRAY_RM_PATTERN = /["'`]rm["'`]\s*,\s*["'`]-[A-Za-z]*r[A-Za-z]*f/g;
+const RECURSIVE_WINDOW = 400;
+const SCAN_ROOTS = ["packages", "scripts"];
+const SKIP_DIRS = new Set(["node_modules", "fixtures", "test-fixtures", "dist", "native", ".git"]);
+// The scanner's own test file is fixture data by construction — it embeds the
+// exact patterns the scanner must flag. The exemption does not weaken
+// coverage of real test code.
+const EXEMPT_FILES = new Set(["scripts/check-unsafe-rmrf.test.ts"]);
+export function isFixturePath(relativePath: string): boolean {
+	return /(^|\/)(test-)?fixtures\//.test(relativePath);
+}
+
+export function scanUnsafeRecursiveRemovals(files: readonly UnsafeRemovalFile[]): UnsafeRemovalViolation[] {
+	const violations: UnsafeRemovalViolation[] = [];
+	for (const file of files) {
+		if (isFixturePath(file.path) || EXEMPT_FILES.has(file.path)) continue;
+		if (!file.text.match(HOME_SEAM_PATTERN)) continue;
+		const lines = file.text.split("\n");
+		for (const match of file.text.matchAll(RM_CALL_PATTERN)) {
+			const call = match[1];
+			const start = match.index ?? 0;
+			const window = file.text.slice(start, start + RECURSIVE_WINDOW);
+			if (!/recursive\s*:\s*true/.test(window)) continue;
+			const line = file.text.slice(0, start).split("\n").length;
+			violations.push({
+				path: file.path,
+				line,
+				snippet: lines[line - 1]?.trim() ?? "",
+				message: `${file.path}:${line}: raw recursive removal \`.${call}(…, { recursive: true … })\` in a HOME-seam test file — use safeRm/safeRmSync from scripts/safe-cleanup.ts (or the temp-home helpers) instead`,
+			});
+		}
+		for (const shellMatch of [
+			...file.text.matchAll(SHELL_TEMPLATE_RM_PATTERN),
+			...file.text.matchAll(SHELL_ARRAY_RM_PATTERN),
+		]) {
+			const start = shellMatch.index ?? 0;
+			const line = file.text.slice(0, start).split("\n").length;
+			violations.push({
+				path: file.path,
+				line,
+				snippet: lines[line - 1]?.trim() ?? "",
+				message: `${file.path}:${line}: shell force-recursive rm in a HOME-seam test file — route deletion through the safe-cleanup contract`,
+			});
+		}
+	}
+	return violations;
+}
+
+async function collectFiles(root: string, dir = root, out: string[] = []): Promise<string[]> {
+	let entries;
+	try {
+		entries = await fs.readdir(dir, { withFileTypes: true });
+	} catch {
+		return out;
+	}
+	for (const entry of entries) {
+		const fullPath = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (SKIP_DIRS.has(entry.name)) continue;
+			await collectFiles(root, fullPath, out);
+		} else if (entry.isFile() && entry.name.endsWith(".ts")) {
+			out.push(fullPath);
+		}
+	}
+	return out;
+}
+
+export async function scanRepository(root: string): Promise<UnsafeRemovalViolation[]> {
+	const files: UnsafeRemovalFile[] = [];
+	for (const scanRoot of SCAN_ROOTS) {
+		const base = path.join(root, scanRoot);
+		for (const filePath of await collectFiles(base)) {
+			files.push({
+				path: path.relative(root, filePath).split(path.sep).join("/"),
+				text: await fs.readFile(filePath, "utf8"),
+			});
+		}
+	}
+	return scanUnsafeRecursiveRemovals(files);
+}
+
+async function main(): Promise<void> {
+	const root = path.join(import.meta.dir, "..");
+	const violations = await scanRepository(root);
+	if (violations.length > 0) {
+		for (const violation of violations) {
+			process.stderr.write(`${violation.message}\n    ${violation.snippet}\n`);
+		}
+		process.stderr.write(
+			`\ncheck-unsafe-rmrf: ${violations.length} unsafe recursive removal(s) in HOME-seam test files (issue #4794)\n`,
+		);
+		process.exit(1);
+	}
+	console.log("check-unsafe-rmrf: no raw recursive removals in HOME-seam test files");
+}
+
+if (import.meta.main) await main();

--- a/scripts/safe-cleanup-guard.test.ts
+++ b/scripts/safe-cleanup-guard.test.ts
@@ -1,0 +1,238 @@
+// Verifies the runtime recursive-deletion guard: which surfaces Bun 1.4.0
+// actually lets us intercept, that refusals never fall through to the real
+// deletion, and that the real preload wiring aborts a violating `bun test`
+// child without deleting anything. The Bun interception matrix is pinned here
+// on purpose: if a future Bun makes more surfaces interceptable (or breaks
+// one), these tests fail and the guard must be updated.
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+import {
+	__uninstallRuntimeDeletionGuardForTests,
+	installRuntimeDeletionGuard,
+	type DeletionRefusal,
+	type DeletionRefusalReason,
+	type SafeCleanupWorld,
+} from "./safe-cleanup";
+
+const require = createRequire(import.meta.url);
+
+function sandboxWorld(sandboxRoot: string): SafeCleanupWorld {
+	return {
+		pathModule: path,
+		homeAliases: ["/home/guard-probe-op"],
+		allowedRoots: [sandboxRoot],
+		realpathSync: (target: string) => fs.realpathSync(target),
+		existsSync: (target: string) => fs.existsSync(target),
+		statUid: (target: string) => fs.statSync(target).uid,
+		uid: process.getuid?.(),
+		caseInsensitive: false,
+	};
+}
+
+function tempDir(prefix: string): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+const recorded: Array<{ reason: DeletionRefusalReason; target: string }> = [];
+let sandbox = "";
+
+afterEach(() => {
+	__uninstallRuntimeDeletionGuardForTests();
+	// Restore the production posture the preload installed, so later test
+	// files in this process keep the default-world guard.
+	installRuntimeDeletionGuard({ label: "test-preload" });
+	recorded.length = 0;
+	if (sandbox && fs.existsSync(sandbox)) {
+		fs.rmSync(sandbox, { recursive: true, force: true });
+		sandbox = "";
+	}
+});
+
+function install(world: SafeCleanupWorld): void {
+	// The preload already installed the default-world guard in this process;
+	// swap it for the scenario world under test.
+	__uninstallRuntimeDeletionGuardForTests();
+	installRuntimeDeletionGuard({
+		world,
+		label: "guard-test",
+		onViolation: (refusal: DeletionRefusal, target: string) => {
+			recorded.push({ reason: refusal.reason, target });
+		},
+	});
+}
+
+describe("runtime deletion guard: interceptable surfaces", () => {
+	test("fs.promises.rm refusal blocks the deletion and records the reason", async () => {
+		sandbox = tempDir("gjc-guard-sbx-");
+		const outside = tempDir("gjc-guard-outside-"); // inside os.tmpdir(), outside the guard's allowed root
+		fs.mkdirSync(path.join(outside, "child"), { recursive: true });
+		install(sandboxWorld(sandbox));
+		await expect(fs.promises.rm(outside, { recursive: true, force: true })).rejects.toThrow(
+			"refusing to delete",
+		);
+		expect(recorded.map((entry) => entry.reason)).toEqual(["outside-allowed-roots"]);
+		// Fail-closed proof: the refused tree is untouched.
+		expect(fs.existsSync(path.join(outside, "child"))).toBe(true);
+		fs.rmSync(outside, { recursive: true, force: true });
+	});
+
+	test("fs.promises.rm approves and completes inside the allowed root", async () => {
+		sandbox = tempDir("gjc-guard-sbx-");
+		const victim = path.join(sandbox, "victim");
+		fs.mkdirSync(victim, { recursive: true });
+		install(sandboxWorld(sandbox));
+		await fs.promises.rm(victim, { recursive: true, force: true });
+		expect(fs.existsSync(victim)).toBe(false);
+		expect(recorded).toEqual([]);
+	});
+
+	test("CJS require('node:fs').rmSync refusal blocks the deletion", () => {
+		sandbox = tempDir("gjc-guard-sbx-");
+		const outside = tempDir("gjc-guard-outside-");
+		fs.mkdirSync(path.join(outside, "child"), { recursive: true });
+		install(sandboxWorld(sandbox));
+		expect(() => require("node:fs").rmSync(outside, { recursive: true, force: true })).toThrow(
+			"refusing to delete",
+		);
+		expect(recorded.map((entry) => entry.reason)).toEqual(["outside-allowed-roots"]);
+		expect(fs.existsSync(path.join(outside, "child"))).toBe(true);
+		fs.rmSync(outside, { recursive: true, force: true });
+	});
+
+	test("CJS require('node:fs/promises').rm refusal blocks the deletion", async () => {
+		sandbox = tempDir("gjc-guard-sbx-");
+		const outside = tempDir("gjc-guard-outside-");
+		fs.mkdirSync(path.join(outside, "child"), { recursive: true });
+		install(sandboxWorld(sandbox));
+		await expect(require("node:fs/promises").rm(outside, { recursive: true, force: true })).rejects.toThrow(
+			"refusing to delete",
+		);
+		expect(recorded.map((entry) => entry.reason)).toEqual(["outside-allowed-roots"]);
+		fs.rmSync(outside, { recursive: true, force: true });
+	});
+
+	test("non-recursive removals pass through unassessed", async () => {
+		sandbox = tempDir("gjc-guard-sbx-");
+		const outside = tempDir("gjc-guard-outside-");
+		const file = path.join(outside, "single.txt");
+		fs.writeFileSync(file, "x");
+		install(sandboxWorld(sandbox));
+		await fs.promises.rm(file, { force: true });
+		expect(fs.existsSync(file)).toBe(false);
+		expect(recorded).toEqual([]);
+		fs.rmSync(outside, { recursive: true, force: true });
+	});
+
+	test("a second install in the same process is a no-op (preload idempotence)", () => {
+		sandbox = tempDir("gjc-guard-sbx-");
+		const world = sandboxWorld(sandbox);
+		// Install directly (the helper swaps by design) to observe idempotence.
+		__uninstallRuntimeDeletionGuardForTests();
+		installRuntimeDeletionGuard({ world, label: "guard-test" });
+		const first = require("node:fs").rmSync;
+		installRuntimeDeletionGuard({ world, label: "guard-test-again" });
+		expect(require("node:fs").rmSync).toBe(first);
+	});
+
+	test.skip("KNOWN GAP (Bun 1.4.0): ESM top-level fs.rmSync is a snapshot binding and is NOT intercepted — the static guard (check-unsafe-rmrf) covers repository source for this surface", () => {
+		// Intentionally skipped: this documents the boundary. If Bun ever makes
+		// namespace bindings live, move this to a real assertion and extend the
+		// guard to patch them.
+	});
+
+	test("uninstall removes the guard wrapping and is idempotent", () => {
+		sandbox = tempDir("gjc-guard-sbx-");
+		install(sandboxWorld(sandbox));
+		const wrapped = require("node:fs").rmSync;
+		expect(String(wrapped)).toContain("refusalFor");
+		__uninstallRuntimeDeletionGuardForTests();
+		const restored = require("node:fs").rmSync;
+		expect(String(restored)).not.toContain("refusalFor");
+		__uninstallRuntimeDeletionGuardForTests();
+		expect(require("node:fs").rmSync).toBe(restored);
+	});
+});
+
+describe("runtime deletion guard: real preload wiring (subprocess)", () => {
+	const repoRoot = path.join(import.meta.dir, "..");
+	const fixturesDir = path.join(repoRoot, "scripts", "test-fixtures");
+
+	function runFixture(name: string, env: Record<string, string>): { exitCode: number; stderr: string } {
+		const proc = Bun.spawnSync({
+			cmd: [process.execPath, "test", path.join(fixturesDir, name)],
+			cwd: repoRoot,
+			env: { ...process.env, ...env },
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		return {
+			exitCode: proc.exitCode,
+			stderr: new TextDecoder().decode(proc.stderr),
+		};
+	}
+
+	/** Removal outside any guarded surface: a plain `bun -e` process has no preload. */
+	function unguardedRm(target: string): void {
+		const proc = Bun.spawnSync({
+			cmd: [process.execPath, "-e", "require('node:fs').rmSync(process.argv[1], { recursive: true, force: true })", target],
+			cwd: repoRoot,
+			env: process.env,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		if (proc.exitCode !== 0) throw new Error(`unguarded cleanup failed for ${target}`);
+	}
+
+	test.skipIf(!isWritable("/var/tmp"))(
+		"bun test child aborts (exit 70) on an out-of-root recursive rm and deletes nothing",
+		() => {
+			const probe = fs.mkdtempSync("/var/tmp/gjc-guard-e2e-");
+			fs.mkdirSync(path.join(probe, "precious"), { recursive: true });
+			const result = runFixture("guard-violation-fixture.ts", { GJC_GUARD_PROBE_DIR: probe });
+			expect(result.exitCode).toBe(70);
+			expect(result.stderr).toContain("[safe-cleanup:test-preload]");
+			expect(result.stderr).toContain("REFUSED recursive deletion");
+			// The refused tree must still exist.
+			expect(fs.existsSync(path.join(probe, "precious"))).toBe(true);
+			unguardedRm(probe);
+		},
+	);
+
+	test("bun test child completes normally for owned in-root cleanup", () => {
+		const probe = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-guard-pass-"));
+		fs.mkdirSync(path.join(probe, "child"), { recursive: true });
+		const result = runFixture("guard-pass-fixture.ts", { GJC_GUARD_PROBE_DIR: probe });
+		expect(result.exitCode).toBe(0);
+		expect(fs.existsSync(probe)).toBe(false);
+	});
+
+	test.skipIf(process.platform === "win32")(
+		"the child refuses the HOME it inherited at preload time (fake home under tmp; the real HOME is never touched)",
+		() => {
+			const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-guard-fakehome-"));
+			fs.mkdirSync(path.join(fakeHome, "identity"), { recursive: true });
+			// The fake home sits INSIDE the allowed tmp root, so only the
+			// captured home alias — not containment — can refuse it.
+			const result = runFixture("guard-env-home-fixture.ts", {
+				HOME: fakeHome,
+				GJC_GUARD_PROBE_DIR: fakeHome,
+			});
+			expect(result.exitCode).toBe(70);
+			expect(result.stderr).toContain("real-home");
+			expect(fs.existsSync(path.join(fakeHome, "identity"))).toBe(true);
+			fs.rmSync(fakeHome, { recursive: true, force: true });
+		},
+	);
+});
+
+function isWritable(dir: string): boolean {
+	try {
+		fs.accessSync(dir, fs.constants.W_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/scripts/safe-cleanup.test.ts
+++ b/scripts/safe-cleanup.test.ts
@@ -1,0 +1,390 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { PlatformPath } from "./safe-cleanup";
+
+import {
+	assessDeletionTarget,
+	assertSafeDeletion,
+	getDefaultSafeCleanupWorld,
+	registerOwnedDeletionRoot,
+	SafeCleanupRefusalError,
+	safeRm,
+	safeRmSync,
+	type DeletionRefusal,
+	type DeletionRefusalReason,
+	type SafeCleanupWorld,
+} from "./safe-cleanup";
+
+interface FakeFs {
+	exists: Set<string>;
+	realpaths: Map<string, string>;
+	owners: Map<string, number>;
+}
+
+function makeWorld(
+	fake: FakeFs,
+	overrides?: {
+		pathModule?: PlatformPath;
+		homeAliases?: string[];
+		allowedRoots?: string[];
+		uid?: number | undefined;
+		caseInsensitive?: boolean;
+	},
+): SafeCleanupWorld {
+	return {
+		pathModule: overrides?.pathModule ?? path.posix,
+		homeAliases: overrides?.homeAliases ?? ["/home/op"],
+		allowedRoots: overrides?.allowedRoots ?? ["/tmp", "/repo"],
+		realpathSync: (target: string): string => {
+			const mapped = fake.realpaths.get(target);
+			if (mapped !== undefined) return mapped;
+			if (fake.exists.has(target)) return target;
+			throw new Error(`ENOENT: ${target}`);
+		},
+		existsSync: (target: string): boolean => fake.exists.has(target) || fake.realpaths.has(target),
+		statUid: (target: string): number => fake.owners.get(target) ?? 1000,
+		uid: overrides && "uid" in overrides ? overrides.uid : 1000,
+		caseInsensitive: overrides?.caseInsensitive ?? false,
+	};
+}
+
+function baseFake(): FakeFs {
+	return {
+		exists: new Set([
+			"/home/op",
+			"/home/op/sub",
+			"/home/op/.config",
+			"/tmp/owned/child",
+			"/tmp/root-owned/child",
+			"/repo/checked-out",
+			"/opt/elsewhere/thing",
+		]),
+		realpaths: new Map(),
+		owners: new Map([["/tmp/root-owned", 0], ["/tmp/root-owned/child", 0]]),
+	};
+}
+
+function refusalFor(target: string, world: SafeCleanupWorld): DeletionRefusalReason {
+	const verdict = assessDeletionTarget(target, world);
+	expect(verdict.ok).toBe(false);
+	return (verdict as DeletionRefusal).reason;
+}
+
+function approvalFor(target: string, world: SafeCleanupWorld): { canonicalTarget: string; containedRoot: string } {
+	const verdict = assessDeletionTarget(target, world);
+	expect(verdict.ok).toBe(true);
+	if (!verdict.ok) throw new Error("unreachable");
+	return { canonicalTarget: verdict.canonicalTarget, containedRoot: verdict.containedRoot };
+}
+
+describe("safe-cleanup verdict: lexical refusals (posix)", () => {
+	const world = makeWorld(baseFake());
+
+	test("refuses empty and blank targets", () => {
+		expect(refusalFor("", world)).toBe("empty-target");
+		expect(refusalFor("   ", world)).toBe("empty-target");
+	});
+
+	test("refuses relative and dot targets", () => {
+		expect(refusalFor("relative/dir", world)).toBe("relative-target");
+		expect(refusalFor(".", world)).toBe("relative-target");
+		expect(refusalFor("..", world)).toBe("relative-target");
+	});
+
+	test("refuses the filesystem root", () => {
+		expect(refusalFor("/", world)).toBe("filesystem-root");
+		expect(refusalFor("////", world)).toBe("filesystem-root");
+	});
+
+	test("refuses single-segment paths as too shallow", () => {
+		expect(refusalFor("/x", world)).toBe("too-shallow");
+	});
+
+	test("refuses the real home exactly", () => {
+		expect(refusalFor("/home/op", world)).toBe("real-home");
+		expect(refusalFor("/home/op/", world)).toBe("real-home");
+	});
+
+	test("refuses ancestors of the real home", () => {
+		expect(refusalFor("/home", world)).toBe("real-home-ancestor");
+		expect(refusalFor("/home/", world)).toBe("real-home-ancestor");
+	});
+
+	test("refuses dot-dot aliases that resolve into the home", () => {
+		expect(refusalFor("/tmp/../../home/op", world)).toBe("real-home");
+		expect(refusalFor("/tmp/../..", world)).toBe("filesystem-root");
+	});
+
+	test("refuses paths inside the home that are outside the allowed roots", () => {
+		expect(refusalFor("/home/op/.config", world)).toBe("outside-allowed-roots");
+	});
+
+	test("refuses the allowed roots themselves", () => {
+		const deepRootWorld = makeWorld(baseFake(), { allowedRoots: ["/tmp", "/repo/work-tree"] });
+		expect(refusalFor("/repo/work-tree", deepRootWorld)).toBe("outside-allowed-roots");
+	});
+
+	test("refuses whole single-segment roots as too shallow to ever be deletion targets", () => {
+		expect(refusalFor("/tmp", world)).toBe("too-shallow");
+		expect(refusalFor("/repo", world)).toBe("too-shallow");
+	});
+});
+
+describe("safe-cleanup verdict: filesystem-aware refusals (posix)", () => {
+	test("refuses a symlink that resolves to the real home", () => {
+		const fake = baseFake();
+		fake.realpaths.set("/tmp/home-link", "/home/op");
+		const world = makeWorld(fake);
+		expect(refusalFor("/tmp/home-link", world)).toBe("real-home");
+	});
+
+	test("refuses a symlink that resolves to an ancestor of the real home", () => {
+		const fake = baseFake();
+		fake.realpaths.set("/tmp/home-parent-link", "/home");
+		const world = makeWorld(fake);
+		expect(refusalFor("/tmp/home-parent-link", world)).toBe("real-home-ancestor");
+	});
+
+	test("refuses a symlink that escapes the allowed roots", () => {
+		const fake = baseFake();
+		fake.realpaths.set("/tmp/escape-link", "/opt/elsewhere/thing");
+		const world = makeWorld(fake);
+		expect(refusalFor("/tmp/escape-link", world)).toBe("symlink-escape");
+	});
+
+	test("refuses unowned components below the allowed root", () => {
+		const world = makeWorld(baseFake());
+		expect(refusalFor("/tmp/root-owned/child", world)).toBe("unowned-path");
+	});
+
+	test("refuses components whose ownership cannot be verified", () => {
+		const fake = baseFake();
+		fake.owners.set("/tmp/owned", 42); // mismatch
+		const world = makeWorld(fake);
+		expect(refusalFor("/tmp/owned/child", world)).toBe("unowned-path");
+	});
+
+	test("skips the ownership check when uid is unavailable (win32-style world)", () => {
+		const world = makeWorld(baseFake(), { uid: undefined });
+		expect(approvalFor("/tmp/root-owned/child", world).containedRoot).toBe("/tmp");
+	});
+});
+
+describe("safe-cleanup verdict: approvals (posix)", () => {
+	const world = makeWorld(baseFake());
+
+	test("approves an owned path strictly inside the temp root", () => {
+		const approval = approvalFor("/tmp/owned/child", world);
+		expect(approval.canonicalTarget).toBe("/tmp/owned/child");
+		expect(approval.containedRoot).toBe("/tmp");
+	});
+
+	test("approves a deeper owned path inside the repository worktree", () => {
+		expect(approvalFor("/repo/checked-out/nested/dir", world).containedRoot).toBe("/repo");
+	});
+
+	test("approves a missing path strictly inside an allowed root (force no-op)", () => {
+		expect(approvalFor("/tmp/owned/gone-already", world).containedRoot).toBe("/tmp");
+	});
+
+	test("refuses a missing path outside the allowed roots", () => {
+		expect(refusalFor("/var/missing/thing", world)).toBe("outside-allowed-roots");
+	});
+
+	test("follows symlinks that stay inside the allowed roots", () => {
+		const fake = baseFake();
+		fake.realpaths.set("/tmp/link", "/tmp/owned/child");
+		const world = makeWorld(fake);
+		expect(approvalFor("/tmp/link", world).canonicalTarget).toBe("/tmp/owned/child");
+	});
+});
+
+describe("safe-cleanup verdict: win32 normalization", () => {
+	const fake: FakeFs = {
+		exists: new Set([
+			"C:\\Users\\Op",
+			"C:\\Users\\Op\\AppData\\Local\\Temp\\gjc-home\\agent",
+			"D:\\repo\\sub",
+			"D:\\other",
+		]),
+		realpaths: new Map([["C:\\Users\\Op\\AppData\\Local\\Temp\\home-link", "C:\\Users\\Op"]]),
+		owners: new Map(),
+	};
+	const world = makeWorld(fake, {
+		pathModule: path.win32,
+		homeAliases: ["C:\\Users\\Op"],
+		allowedRoots: ["C:\\Users\\Op\\AppData\\Local\\Temp", "D:\\repo"],
+		caseInsensitive: true,
+	});
+
+	test("refuses the home regardless of case and separator style", () => {
+		expect(refusalFor("c:\\users\\op", world)).toBe("real-home");
+		expect(refusalFor("C:/Users/Op", world)).toBe("real-home");
+		expect(refusalFor("C:\\USERS\\OP\\", world)).toBe("real-home");
+	});
+
+	test("refuses win32 ancestors, root, and shallow paths", () => {
+		expect(refusalFor("C:\\Users", world)).toBe("real-home-ancestor");
+		expect(refusalFor("C:\\", world)).toBe("filesystem-root");
+		expect(refusalFor("C:\\x", world)).toBe("too-shallow");
+	});
+
+	test("approves owned temp paths case-insensitively", () => {
+		expect(approvalFor("c:\\users\\op\\appdata\\local\\temp\\GJC-HOME\\agent", world).containedRoot).toBe(
+			"C:\\Users\\Op\\AppData\\Local\\Temp",
+		);
+	});
+
+	test("refuses other drives outside the allowed roots", () => {
+		expect(refusalFor("D:\\other\\thing", world)).toBe("outside-allowed-roots");
+		// A single segment below another drive's root is refused by the
+		// shallow rule, which fires before containment.
+		expect(refusalFor("E:\\anywhere", world)).toBe("too-shallow");
+	});
+
+	test("refuses a win32 symlink resolving to the home", () => {
+		expect(refusalFor("C:\\Users\\Op\\AppData\\Local\\Temp\\home-link", world)).toBe("real-home");
+	});
+});
+
+describe("safe-cleanup verdict: darwin case-insensitive home", () => {
+	const fake = baseFake();
+	fake.exists.add("/Users/Op");
+	const world = makeWorld(fake, { homeAliases: ["/Users/Op"], allowedRoots: ["/tmp"], caseInsensitive: true });
+
+	test("refuses the home regardless of case", () => {
+		expect(refusalFor("/users/op", world)).toBe("real-home");
+		expect(refusalFor("/Users/op/", world)).toBe("real-home");
+	});
+});
+
+describe("safe-cleanup against the live filesystem", () => {
+	test.skipIf(process.platform === "win32")(
+		"safeRmSync removes an owned temp tree and its nested children",
+		async () => {
+			const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-safe-cleanup-pos-"));
+			fs.mkdirSync(path.join(root, "a", "b"), { recursive: true });
+			fs.writeFileSync(path.join(root, "a", "b", "file.txt"), "x");
+			safeRmSync(path.join(root, "a"), { recursive: true, force: true });
+			expect(fs.existsSync(path.join(root, "a"))).toBe(false);
+			await safeRm(root, { recursive: true, force: true });
+			expect(fs.existsSync(root)).toBe(false);
+		},
+	);
+
+	test.skipIf(process.platform === "win32")("safeRm refuses the real home without touching it", () => {
+		const home = os.homedir();
+		expect(() => safeRmSync(home, { recursive: true, force: true })).toThrow(SafeCleanupRefusalError);
+		// Non-destructive proof: the home directory still exists after the refusal.
+		expect(fs.existsSync(home)).toBe(true);
+	});
+
+	test.skipIf(process.platform === "win32")("safeRm refuses a symlink that resolves to the real home", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-safe-cleanup-link-"));
+		const link = path.join(root, "home-link");
+		fs.symlinkSync(os.homedir(), link, "dir");
+		try {
+			expect(() => safeRmSync(link, { recursive: true, force: true })).toThrow(SafeCleanupRefusalError);
+			// Read-only probe only: the real home is intact.
+			expect(fs.existsSync(os.homedir())).toBe(true);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test.skipIf(process.platform === "win32")("safeRm refuses the repository worktree root itself", () => {
+		const repoRoot = path.join(import.meta.dir, "..");
+		expect(() => assertSafeDeletion(repoRoot)).toThrow(SafeCleanupRefusalError);
+	});
+
+	test.skipIf(process.platform === "win32" || !isWritable("/var/tmp"))(
+		"safeRm refuses a symlink that escapes the allowed roots",
+		() => {
+			const escapeRoot = fs.mkdtempSync("/var/tmp/gjc-safe-cleanup-escape-");
+			const escapeTarget = path.join(escapeRoot, "precious");
+			fs.mkdirSync(escapeTarget);
+			const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-safe-cleanup-wrap-"));
+			const link = path.join(tmpRoot, "escape-link");
+			fs.symlinkSync(escapeTarget, link, "dir");
+			try {
+				expect(() => safeRmSync(link, { recursive: true, force: true })).toThrow(SafeCleanupRefusalError);
+				expect(fs.existsSync(escapeTarget)).toBe(true);
+			} finally {
+				fs.rmSync(escapeRoot, { recursive: true, force: true });
+				fs.rmSync(tmpRoot, { recursive: true, force: true });
+			}
+		},
+	);
+
+	test("refusal error carries the machine-readable reason", () => {
+		try {
+			assertSafeDeletion("");
+			throw new Error("expected refusal");
+		} catch (error) {
+			expect(error).toBeInstanceOf(SafeCleanupRefusalError);
+			expect((error as SafeCleanupRefusalError).refusal.reason).toBe("empty-target");
+		}
+	});
+});
+
+describe("registerOwnedDeletionRoot grants", () => {
+	test.skipIf(process.platform === "win32")("permits exactly the granted process-created directory", () => {
+		const dir = path.join(os.homedir(), `.gjc-grant-test-${process.pid}-${Date.now()}`);
+		const forget = registerOwnedDeletionRoot(dir);
+		fs.mkdirSync(path.join(dir, "agent"), { recursive: true });
+		try {
+			const verdict = assessDeletionTarget(dir, getDefaultSafeCleanupWorld());
+			expect(verdict.ok).toBe(true);
+			safeRmSync(dir, { recursive: true, force: true });
+			expect(fs.existsSync(dir)).toBe(false);
+		} finally {
+			forget();
+		}
+	});
+
+	test.skipIf(process.platform === "win32")("never permits the home or ancestors even when granted", () => {
+		expect(() => registerOwnedDeletionRoot(os.homedir())).toThrow("real home");
+		expect(() => registerOwnedDeletionRoot(path.dirname(os.homedir()))).toThrow("real home");
+		expect(() => registerOwnedDeletionRoot("/")).toThrow();
+		expect(() => registerOwnedDeletionRoot("relative/path")).toThrow("relative");
+	});
+
+	test.skipIf(process.platform === "win32")("refuses an existing directory (grant-before-create only)", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-grant-existing-"));
+		try {
+			expect(() => registerOwnedDeletionRoot(dir)).toThrow("already exists");
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test.skipIf(process.platform === "win32")("sibling and parent paths stay refused while a grant is active", () => {
+		const granted = path.join(os.homedir(), `.gjc-grant-scope-${process.pid}-${Date.now()}`);
+		const forget = registerOwnedDeletionRoot(granted);
+		try {
+			expect(refusalFor(path.dirname(granted), getDefaultSafeCleanupWorld())).toBe("real-home");
+			const sibling = path.join(path.dirname(granted), ".gjc-sibling-never-granted");
+			expect(refusalFor(sibling, getDefaultSafeCleanupWorld())).toBe("outside-allowed-roots");
+		} finally {
+			forget();
+		}
+	});
+
+	test.skipIf(process.platform === "win32")("the grant is forgotten after disposal", () => {
+		const granted = path.join(os.homedir(), `.gjc-grant-dispose-${process.pid}-${Date.now()}`);
+		const forget = registerOwnedDeletionRoot(granted);
+		forget();
+		expect(refusalFor(granted, getDefaultSafeCleanupWorld())).toBe("outside-allowed-roots");
+	});
+});
+
+function isWritable(dir: string): boolean {
+	try {
+		fs.accessSync(dir, fs.constants.W_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/scripts/safe-cleanup.ts
+++ b/scripts/safe-cleanup.ts
@@ -1,0 +1,556 @@
+/**
+ * Fail-closed recursive-deletion boundary for test processes (issue #4794).
+ *
+ * An operator's real `$HOME` was destroyed by test cleanup activity. The
+ * structural fix is a single verdict function every deletion path consults:
+ * a recursive removal is permitted ONLY when the target is a strictly-nested,
+ * process-owned path inside an explicitly allowed root (the canonical OS temp
+ * root or this repository worktree), and is NEVER the real home, an ancestor
+ * of it, the filesystem root, a shallow path, or a symlink-resolved escape.
+ *
+ * Enforcement layers (they complement each other; none is sufficient alone):
+ *
+ * 1. `safeRm`/`safeRmSync` — the explicit contract. Migrated cleanup code
+ *    calls these; a refusal throws `SafeCleanupRefusalError` so the failure is
+ *    a normal, attributable test error.
+ * 2. `installRuntimeDeletionGuard()` — a last-resort runtime backstop for the
+ *    surfaces Bun 1.4.0 actually allows intercepting: the shared `fs.promises`
+ *    object (`fs.promises.rm`/`rmdir` and `import { promises }`) and the CJS
+ *    `require("node:fs")`/`require("node:fs/promises")` exports objects.
+ *    ESM namespace bindings (`import * as fs` top-level `rmSync`/`rm`) are
+ *    immutable snapshots in Bun and CANNOT be intercepted at runtime — that
+ *    gap is closed by layer 3, and the interception matrix is pinned by
+ *    `safe-cleanup-guard.test.ts` so a future runtime change is detected.
+ * 3. `scripts/check-unsafe-rmrf.ts` — the static guard that bans raw
+ *    recursive `fs.rm*`/`fs.rmdir*` calls in HOME-seam test files, making the
+ *    un-interceptable sync surface deterministic at check time.
+ *
+ * The guard is test-process-scoped on purpose: it is installed only from
+ * `scripts/test-preload.ts` (bunfig `[test] preload`). Product runtime and
+ * non-test tooling never load it, so third-party and production behavior is
+ * untouched. Within a test process, a third-party dependency that recursively
+ * deletes inside the allowed roots keeps working; anything else aborts the
+ * process — that is the intended fail-closed behavior.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+import type * as fsTypes from "node:fs";
+
+/** Either platform flavor of the node:path API (posix or win32 semantics). */
+export type PlatformPath = typeof path.posix | typeof path.win32;
+
+export type DeletionRefusalReason =
+	| "empty-target"
+	| "relative-target"
+	| "filesystem-root"
+	| "too-shallow"
+	| "real-home"
+	| "real-home-ancestor"
+	| "outside-allowed-roots"
+	| "symlink-escape"
+	| "unowned-path";
+
+export interface DeletionRefusal {
+	ok: false;
+	reason: DeletionRefusalReason;
+	message: string;
+	target: string;
+}
+
+export interface DeletionApproval {
+	ok: true;
+	target: string;
+	/** Symlink-resolved absolute path (equals `target` resolution when absent on disk). */
+	canonicalTarget: string;
+	/** The allowed root the canonical target is strictly nested inside. */
+	containedRoot: string;
+}
+
+export type DeletionVerdict = DeletionApproval | DeletionRefusal;
+
+/**
+ * Everything the verdict needs, injectable so the decision table is
+ * unit-testable on any platform (posix semantics via `path.win32`, synthetic
+ * filesystems via fake `realpathSync`/`statUid`).
+ */
+export interface SafeCleanupWorld {
+	pathModule: PlatformPath;
+	/** Absolute home paths that must never be deleted (real home + its realpath). */
+	homeAliases: readonly string[];
+	/** Canonical roots; deletion targets must be strictly nested inside one. */
+	allowedRoots: readonly string[];
+	realpathSync: (target: string) => string;
+	existsSync: (target: string) => boolean;
+	statUid: (target: string) => number;
+	/** Current process uid; `undefined` (win32) skips the ownership check. */
+	uid: number | undefined;
+	caseInsensitive: boolean;
+}
+
+function pathKit(pathModule: PlatformPath, caseInsensitive: boolean) {
+	const norm = (value: string): string => {
+		const normalized = pathModule.normalize(value);
+		return caseInsensitive ? normalized.toLowerCase() : normalized;
+	};
+	const withSeparator = (value: string): string =>
+		value.endsWith(pathModule.sep) ? value : value + pathModule.sep;
+	return {
+		equal: (a: string, b: string): boolean => norm(a) === norm(b),
+		/** `ancestor` is `descendant` itself or a path-segment prefix of it. */
+		isAncestorOrEqual: (ancestor: string, descendant: string): boolean => {
+			const a = norm(ancestor);
+			const d = norm(descendant);
+			return a === d || d.startsWith(withSeparator(a));
+		},
+		/** `child` is strictly below `root` (never the root itself). */
+		strictlyInside: (child: string, root: string): boolean => {
+			const c = norm(child);
+			const r = norm(root);
+			return c !== r && c.startsWith(withSeparator(r));
+		},
+		segments: (value: string): string[] => {
+			const root = pathModule.parse(pathModule.normalize(value)).root;
+			const relative = pathModule.relative(root, pathModule.normalize(value));
+			return relative === "" ? [] : relative.split(pathModule.sep).filter((part: string) => part !== "");
+		},
+		/** Every existing component strictly below `root`, deepest last. */
+		componentsBetween: (root: string, target: string): string[] => {
+			const parts = pathModule
+				.relative(pathModule.normalize(root), pathModule.normalize(target))
+				.split(pathModule.sep)
+			.filter((part: string) => part !== "" && part !== ".");
+			const components: string[] = [];
+			let current = pathModule.normalize(root);
+			for (const part of parts) {
+				current = pathModule.join(current, part);
+				components.push(current);
+			}
+			return components;
+		},
+	};
+}
+
+function tryRun<T>(fn: () => T): T | undefined {
+	try {
+		return fn();
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * The single verdict every recursive deletion must pass.
+ *
+ * Ordering is fail-closed: purely lexical refusals (empty/relative/root/
+ * shallow/home) fire before any filesystem access, so even an unreadable or
+ * racing path can never slip through on a technicality.
+ */
+export function assessDeletionTarget(target: string, world: SafeCleanupWorld): DeletionVerdict {
+	const kit = pathKit(world.pathModule, world.caseInsensitive);
+	const refuse = (reason: DeletionRefusalReason, message: string): DeletionRefusal => ({
+		ok: false,
+		reason,
+		message,
+		target,
+	});
+
+	if (typeof target !== "string" || target.trim() === "") {
+		return refuse("empty-target", "refusing to delete: target is empty or blank");
+	}
+	if (!world.pathModule.isAbsolute(target)) {
+		return refuse(
+			"relative-target",
+			`refusing to delete relative target ${JSON.stringify(target)}: relative paths are ambiguous under process.cwd()`,
+		);
+	}
+	const resolved = world.pathModule.resolve(target);
+	if (kit.equal(resolved, world.pathModule.parse(resolved).root)) {
+		return refuse("filesystem-root", `refusing to delete the filesystem root (${resolved})`);
+	}
+	// Home checks precede the shallow check on purpose: `/home` (or `C:\Users`)
+	// is both a one-segment path and an ancestor of the real home, and the
+	// home-specific reason is the actionable one.
+	for (const home of world.homeAliases) {
+		if (kit.equal(resolved, home)) {
+			return refuse("real-home", `refusing to delete the real home directory (${home})`);
+		}
+		if (kit.isAncestorOrEqual(resolved, home)) {
+			return refuse(
+				"real-home-ancestor",
+				`refusing to delete ${resolved}: it contains the real home directory (${home})`,
+			);
+		}
+	}
+	if (kit.segments(resolved).length < 2) {
+		return refuse(
+			"too-shallow",
+			`refusing to delete ${resolved}: fewer than 2 path segments below the filesystem root`,
+		);
+	}
+
+	const exists = (() => {
+		try {
+			return world.existsSync(resolved);
+		} catch {
+			return true; // unreadable → treat as existing so the strict path runs
+		}
+	})();
+	let canonical: string;
+	if (exists) {
+		const real = tryRun(() => world.realpathSync(resolved));
+		if (real === undefined) {
+			return refuse(
+				"symlink-escape",
+				`refusing to delete ${resolved}: it exists but its real path could not be resolved`,
+			);
+		}
+		canonical = real;
+	} else {
+		// Absent targets are a no-op for `force` removals; the lexical checks
+		// above have already run, which is all that can be checked offline.
+		canonical = resolved;
+	}
+
+	if (exists) {
+		for (const home of world.homeAliases) {
+			if (kit.equal(canonical, home)) {
+				return refuse(
+					"real-home",
+					`refusing to delete ${resolved}: it resolves to the real home directory (${home})`,
+				);
+			}
+			if (kit.isAncestorOrEqual(canonical, home)) {
+				return refuse(
+					"real-home-ancestor",
+					`refusing to delete ${resolved}: it resolves to ${canonical}, which contains the real home directory (${home})`,
+				);
+			}
+		}
+		if (kit.equal(canonical, world.pathModule.parse(canonical).root)) {
+			return refuse("filesystem-root", `refusing to delete ${resolved}: it resolves to the filesystem root`);
+		}
+		if (kit.segments(canonical).length < 2) {
+			return refuse(
+				"too-shallow",
+				`refusing to delete ${resolved}: it resolves to a path with fewer than 2 segments below the root`,
+			);
+		}
+	}
+
+	const lexicalRoot = world.allowedRoots.find((root) => kit.strictlyInside(resolved, root));
+	if (exists) {
+		const canonicalRoot = world.allowedRoots.find((root) => kit.strictlyInside(canonical, root));
+		// An explicitly registered, process-created fixture root outside the
+		// standard roots (see registerOwnedDeletionRoot) is the only additional
+		// permission surface; it never relaxes the home/ancestor/root/shallow
+		// checks above and still requires process ownership below.
+		const grantedRoot = canonicalRoot ? undefined : grantedRootFor(resolved, canonical);
+		const effectiveRoot = canonicalRoot ?? grantedRoot;
+		if (!effectiveRoot) {
+			return lexicalRoot
+				? refuse(
+						"symlink-escape",
+						`refusing to delete ${resolved}: it resolves to ${canonical}, outside every allowed root (${world.allowedRoots.join(", ")})`,
+					)
+				: refuse(
+						"outside-allowed-roots",
+						`refusing to delete ${resolved}: it is not strictly inside any allowed root (${world.allowedRoots.join(", ")})`,
+					);
+		}
+		if (world.uid !== undefined) {
+			for (const component of kit.componentsBetween(effectiveRoot, canonical)) {
+				const owner = tryRun(() => world.statUid(component));
+				if (owner === undefined) {
+					return refuse(
+						"unowned-path",
+						`refusing to delete ${canonical}: ownership of ${component} could not be verified`,
+					);
+				}
+				if (owner !== world.uid) {
+					return refuse(
+						"unowned-path",
+						`refusing to delete ${canonical}: ${component} is owned by uid ${owner}, not the test process uid ${world.uid}`,
+					);
+				}
+			}
+		}
+		return { ok: true, target, canonicalTarget: canonical, containedRoot: effectiveRoot };
+	}
+	if (!lexicalRoot) {
+		return refuse(
+			"outside-allowed-roots",
+			`refusing to delete ${resolved}: it is not strictly inside any allowed root (${world.allowedRoots.join(", ")})`,
+		);
+	}
+	return { ok: true, target, canonicalTarget: canonical, containedRoot: lexicalRoot };
+}
+
+function homeAliasesFor(home: string): string[] {
+	const aliases = new Set<string>([path.normalize(home)]);
+	const real = tryRun(() => fs.realpathSync(home));
+	if (real !== undefined) aliases.add(real);
+	return [...aliases];
+}
+
+/**
+ * The default world. Built eagerly at module load — before any test or script
+ * mutates `process.env.HOME` — so `homeAliases` always names the REAL
+ * operator home, never a temporary one a test installed later. Bun resolves
+ * `os.homedir()` from `HOME`/`USERPROFILE`, so capturing at import time is the
+ * earliest trustworthy point.
+ */
+const defaultWorld: SafeCleanupWorld = (() => {
+	const aliases = new Set<string>();
+	const envHome = process.env.HOME ?? process.env.USERPROFILE;
+	if (envHome && path.isAbsolute(envHome)) {
+		for (const alias of homeAliasesFor(path.resolve(envHome))) aliases.add(alias);
+	}
+	const osHome = tryRun(() => os.homedir());
+	if (osHome && path.isAbsolute(osHome)) {
+		for (const alias of homeAliasesFor(path.resolve(osHome))) aliases.add(alias);
+	}
+	const canonicalTmp = tryRun(() => fs.realpathSync(os.tmpdir())) ?? path.resolve(os.tmpdir());
+	const repoRoot = tryRun(() => fs.realpathSync(path.join(import.meta.dir, ".."))) ?? path.resolve(
+		import.meta.dir,
+		"..",
+	);
+	return {
+		pathModule: path,
+		homeAliases: [...aliases],
+		allowedRoots: [canonicalTmp, repoRoot],
+		realpathSync: (target) => fs.realpathSync(target),
+		existsSync: (target) => fs.existsSync(target),
+		statUid: (target) => fs.statSync(target).uid,
+		uid: process.platform === "win32" ? undefined : process.getuid?.(),
+		caseInsensitive: process.platform === "win32" || process.platform === "darwin",
+	};
+})();
+
+export function getDefaultSafeCleanupWorld(): SafeCleanupWorld {
+	return defaultWorld;
+}
+
+// --- Explicitly granted test-owned deletion roots ---------------------------------
+//
+// A small class of tests must create fixtures under the REAL home (trusted
+// user-scope resolution only honors the real home — mocking os.homedir cannot
+// redirect it, because resolvers capture the binding at import time). Those
+// tests still must not get blanket permission to recursively delete anything
+// under the home: they register the exact directory they are about to create,
+// the verdict accepts only that directory (and its nested contents), and the
+// home itself, its ancestors, and every unregistered sibling stay refused.
+
+const grantedOwnedRoots = new Map<string, number>();
+
+/**
+ * Grant this test process permission to recursively delete exactly `dir`
+ * (and its contents). Must be called BEFORE the directory is created; the
+ * registration is refused for the real home, an ancestor of it, relative
+ * paths, and paths that already exist (a fresh, process-owned fixture).
+ * Returns a disposer that forgets the grant.
+ */
+export function registerOwnedDeletionRoot(dir: string): () => void {
+	const kit = pathKit(path, process.platform === "win32" || process.platform === "darwin");
+	const resolved = path.resolve(dir);
+	if (!path.isAbsolute(dir)) throw new Error(`registerOwnedDeletionRoot: relative path ${JSON.stringify(dir)}`);
+	for (const home of defaultWorld.homeAliases) {
+		if (kit.equal(resolved, home) || kit.isAncestorOrEqual(resolved, home)) {
+			throw new Error(`registerOwnedDeletionRoot: ${resolved} is the real home or an ancestor of it`);
+		}
+	}
+	if (fs.existsSync(resolved)) {
+		throw new Error(`registerOwnedDeletionRoot: ${resolved} already exists; grant before creating`);
+	}
+	grantedOwnedRoots.set(resolved, Date.now());
+	return () => {
+		grantedOwnedRoots.delete(resolved);
+	};
+}
+
+function grantedRootFor(resolved: string, canonical: string): string | undefined {
+	if (grantedOwnedRoots.size === 0) return undefined;
+	const kit = pathKit(path, process.platform === "win32" || process.platform === "darwin");
+	for (const granted of grantedOwnedRoots.keys()) {
+		// The granted root itself and everything strictly below it are deletable;
+		// every other path — siblings, parents, the home — stays refused.
+		const covered = (candidate: string): boolean =>
+			kit.equal(candidate, granted) || kit.strictlyInside(candidate, granted);
+		if (covered(resolved) || covered(canonical)) return granted;
+	}
+	return undefined;
+}
+
+/** Thrown by `safeRm*`/`assertSafeDeletion` so refusals surface as test errors. */
+export class SafeCleanupRefusalError extends Error {
+	public readonly refusal: DeletionRefusal;
+	constructor(refusal: DeletionRefusal) {
+		super(refusal.message);
+		this.name = "SafeCleanupRefusalError";
+		this.refusal = refusal;
+	}
+}
+
+export function assertSafeDeletion(target: string, world: SafeCleanupWorld = defaultWorld): DeletionApproval {
+	const verdict = assessDeletionTarget(target, world);
+	if (!verdict.ok) throw new SafeCleanupRefusalError(verdict);
+	return verdict;
+}
+
+// Pristine function references, captured at module load. `safeRm*` must not be
+// affected by (or re-enter) the runtime guard installed below.
+const originalRmSync = fs.rmSync.bind(fs);
+const originalRm = fs.promises.rm.bind(fs.promises);
+
+/**
+ * Safe recursive cleanup. Identical semantics to
+ * `fs.rmSync(target, options)` for permitted targets; refuses (throws) when the
+ * verdict fails. Works in any process — no preload required.
+ */
+export function safeRmSync(target: string, options?: fsTypes.RmOptions): void {
+	assertSafeDeletion(target);
+	originalRmSync(target, options);
+}
+
+/** Promise variant of {@link safeRmSync} (`fs.promises.rm`). */
+export async function safeRm(target: string, options?: fsTypes.RmOptions): Promise<void> {
+	assertSafeDeletion(target);
+	await originalRm(target, options);
+}
+
+export interface DeletionGuardOptions {
+	world?: SafeCleanupWorld;
+	/** Default: print to stderr and abort the process (exit 70). */
+	onViolation?: (refusal: DeletionRefusal, target: string) => void;
+	label?: string;
+}
+
+function coerceTarget(target: unknown): string | null {
+	if (typeof target === "string") return target;
+	if (Buffer.isBuffer(target)) return target.toString("utf8");
+	if (target instanceof URL) {
+		try {
+			return decodeURIComponent(target.pathname);
+		} catch {
+			return null;
+		}
+	}
+	return null;
+}
+
+const GUARD_INSTALLED = Symbol.for("gajae-code.safe-cleanup.deletion-guard");
+
+type SyncRmLike = (target: unknown, options?: fsTypes.RmOptions) => unknown;
+type AsyncRmLike = (target: unknown, options?: fsTypes.RmOptions) => Promise<unknown>;
+
+/**
+ * Install the runtime recursive-deletion guard in this test process.
+ *
+ * Intercepted (verified against Bun 1.4.0, pinned by tests):
+ * - `fs.promises.rm` / `fs.promises.rmdir` — the `promises` object is shared
+ *   by reference across every import style, including `import * as fs`.
+ * - `require("node:fs")` and `require("node:fs/promises")` exports (CJS
+ *   consumers, including third-party dependencies).
+ *
+ * NOT interceptable in Bun 1.4.0: top-level `fs.rmSync`/`fs.rm`/
+ * `fs.rmdirSync`/`fs.rmdir` reached through ESM namespace or named imports —
+ * those bindings are immutable snapshots. `scripts/check-unsafe-rmrf.ts`
+ * closes that gap statically for repository test code.
+ */
+export function installRuntimeDeletionGuard(options: DeletionGuardOptions = {}): void {
+	const registry = globalThis as Record<symbol, unknown>;
+	if (registry[GUARD_INSTALLED]) return;
+	registry[GUARD_INSTALLED] = true;
+
+	const world = options.world ?? defaultWorld;
+	const label = options.label ?? "bun-test";
+	const onViolation =
+		options.onViolation ??
+		((refusal: DeletionRefusal, target: string): void => {
+			process.stderr.write(
+				[
+					`[safe-cleanup:${label}] REFUSED recursive deletion of ${target} (${refusal.reason})`,
+					`[safe-cleanup:${label}] ${refusal.message}`,
+					`[safe-cleanup:${label}] aborting process: recursive test cleanup must never leave the allowed roots (issue #4794)`,
+					"",
+				].join("\n"),
+			);
+			process.exit(70);
+		});
+
+	const refusalFor = (target: unknown): DeletionRefusal | null => {
+		const asString = coerceTarget(target);
+		if (asString === null) return null;
+		const verdict = assessDeletionTarget(asString, world);
+		return verdict.ok ? null : verdict;
+	};
+	const guardSync =
+		(original: SyncRmLike) =>
+		(target: unknown, options?: fsTypes.RmOptions): unknown => {
+			if (options?.recursive === true) {
+				const refusal = refusalFor(target);
+				if (refusal) {
+					onViolation(refusal, refusal.target);
+					// Fail closed even when a custom handler returns: never fall
+					// through to the original deletion after a refusal.
+					throw new SafeCleanupRefusalError(refusal);
+				}
+			}
+			return original(target, options);
+		};
+	const guardAsync =
+		(original: AsyncRmLike) =>
+		async (target: unknown, options?: fsTypes.RmOptions): Promise<unknown> => {
+			if (options?.recursive === true) {
+				const refusal = refusalFor(target);
+				if (refusal) {
+					onViolation(refusal, refusal.target);
+					throw new SafeCleanupRefusalError(refusal);
+				}
+			}
+			return original(target, options);
+		};
+
+	// Shared `fs.promises` object — reachable from every import style.
+	const promises = fs.promises as unknown as Record<string, AsyncRmLike>;
+	const patches: GuardPatch[] = [
+		{ holder: promises, name: "rm", original: promises.rm, wrapped: guardAsync(promises.rm.bind(promises)) },
+		{
+			holder: promises,
+			name: "rmdir",
+			original: promises.rmdir,
+			wrapped: guardAsync(promises.rmdir.bind(promises)),
+		},
+	];
+
+	// CJS export objects — mutable, and what `require()` hands to consumers.
+	const require = createRequire(import.meta.url);
+	const cfs = require("node:fs") as Record<string, SyncRmLike>;
+	for (const name of ["rmSync", "rm", "rmdirSync", "rmdir"] as const) {
+		patches.push({ holder: cfs, name, original: cfs[name], wrapped: guardSync(cfs[name].bind(cfs)) });
+	}
+	const cfp = require("node:fs/promises") as Record<string, AsyncRmLike>;
+	patches.push({ holder: cfp, name: "rm", original: cfp.rm, wrapped: guardAsync(cfp.rm.bind(cfp)) });
+	patches.push({ holder: cfp, name: "rmdir", original: cfp.rmdir, wrapped: guardAsync(cfp.rmdir.bind(cfp)) });
+
+	for (const patch of patches) patch.holder[patch.name] = patch.wrapped;
+	installedPatches = patches;
+}
+
+interface GuardPatch {
+	holder: Record<string, unknown>;
+	name: string;
+	original: unknown;
+	wrapped: unknown;
+}
+
+let installedPatches: GuardPatch[] = [];
+
+/** Test-only: restore the pristine deletion functions and allow reinstall. */
+export function __uninstallRuntimeDeletionGuardForTests(): void {
+	const registry = globalThis as Record<symbol, unknown>;
+	registry[GUARD_INSTALLED] = undefined;
+	for (const patch of installedPatches) patch.holder[patch.name] = patch.original;
+	installedPatches = [];
+}

--- a/scripts/test-fixtures/guard-env-home-fixture.ts
+++ b/scripts/test-fixtures/guard-env-home-fixture.ts
@@ -1,0 +1,15 @@
+// Issue #4794 e2e fixture: the parent sets HOME to a fake home it owns under
+// the OS temp root and points GJC_GUARD_PROBE_DIR at it. The child test
+// process inherits that HOME, so its preload captures it as the real-home
+// alias, and a recursive removal of it must be refused with `real-home` even
+// though it is inside the allowed temp root. The operator's actual HOME is
+// never involved. Run only via scripts/safe-cleanup-guard.test.ts.
+import { expect, test } from "bun:test";
+import * as fs from "node:fs";
+
+const probe = process.env.GJC_GUARD_PROBE_DIR;
+test("guard refuses the home captured at preload time", async () => {
+	if (!probe) throw new Error("GJC_GUARD_PROBE_DIR is required");
+	await fs.promises.rm(probe, { recursive: true, force: true });
+	expect(fs.existsSync(probe)).toBe(false); // must never be reached
+});

--- a/scripts/test-fixtures/guard-pass-fixture.ts
+++ b/scripts/test-fixtures/guard-pass-fixture.ts
@@ -1,0 +1,12 @@
+// Issue #4794 e2e fixture: recursive force removal of an owned temporary
+// directory inside the allowed temp root. The test preload's deletion guard
+// must let this pass. Run only via scripts/safe-cleanup-guard.test.ts.
+import { expect, test } from "bun:test";
+import * as fs from "node:fs";
+
+const probe = process.env.GJC_GUARD_PROBE_DIR;
+test("guard allows owned in-root recursive removal", async () => {
+	if (!probe) throw new Error("GJC_GUARD_PROBE_DIR is required");
+	await fs.promises.rm(probe, { recursive: true, force: true });
+	expect(fs.existsSync(probe)).toBe(false);
+});

--- a/scripts/test-fixtures/guard-violation-fixture.ts
+++ b/scripts/test-fixtures/guard-violation-fixture.ts
@@ -1,0 +1,15 @@
+// Issue #4794 e2e fixture: attempts a recursive force removal of a directory
+// OUTSIDE the allowed roots. Run only via scripts/safe-cleanup-guard.test.ts,
+// which creates the probe directory under /var/tmp first. The test preload's
+// deletion guard must abort this process (exit 70) before anything is deleted.
+import { expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const probe = process.env.GJC_GUARD_PROBE_DIR;
+test("guard aborts out-of-root recursive removal", async () => {
+	if (!probe) throw new Error("GJC_GUARD_PROBE_DIR is required");
+	// fs.promises.rm is an interceptable surface (shared promises object).
+	await fs.promises.rm(path.join(probe), { recursive: true, force: true });
+	expect(fs.existsSync(probe)).toBe(false); // must never be reached
+});

--- a/scripts/test-preload.ts
+++ b/scripts/test-preload.ts
@@ -1,3 +1,4 @@
+import { installRuntimeDeletionGuard } from "./safe-cleanup";
 import { decideAgentDirIsolation, readProjectEnvFile, stripAmbientProviderEnvironment } from "./test-agent-dir-isolation";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -70,3 +71,17 @@ if (isolation.action === "isolate") {
 	process.env.GJC_CODING_AGENT_DIR = agentDir;
 	process.env.PI_CODING_AGENT_DIR = agentDir;
 }
+//
+// Recursive-deletion boundary (issue #4794). An operator's real home was
+// destroyed by test cleanup activity; this preload now installs a
+// fail-closed runtime guard over the deletion surfaces Bun 1.4.0 allows
+// intercepting (`fs.promises.rm/rmdir` — shared by reference across every
+// import style — plus the CJS `require("node:fs")` exports). ESM top-level
+// `fs.rmSync` bindings are immutable snapshots in Bun and cannot be patched;
+// repository test source is covered instead by `scripts/check-unsafe-rmrf.ts`
+// (run in `check:tools`), and the interception matrix is pinned by
+// scripts/safe-cleanup-guard.test.ts. The safe world captures the REAL home at
+// module-load time — before any test mutates process.env.HOME — so a cleanup
+// bug that resolves back to the operator home aborts this process instead of
+// deleting it. A refusal exits 70 by default.
+installRuntimeDeletionGuard({ label: "test-preload" });


### PR DESCRIPTION
## Summary

Fail-closed recursive-deletion boundary for `bun test` processes, closing the hazard class behind the operator HOME destruction incident (#4794).

An operator's real `$HOME` was destroyed while only gajae-code agent/test activity was running. The audit found no smoking gun but a real structural hazard: tests mutate `process.env.HOME` directly, and nothing at the deletion layer prevented a recursive `fs.rm(..., {recursive: true, force: true})` from receiving the real home (or `/home/<user>` via an empty/undefined join, or a capture/restore ordering bug).

This PR implements the smallest robust boundary: **one verdict function every recursive deletion must pass**, enforced in three complementary layers because no single layer closes the gap alone.

### Layer 1 — the contract (`scripts/safe-cleanup.ts`)
`assessDeletionTarget()` refuses, in fail-closed order:
- `empty-target` / `relative-target` (empty-string and cwd-relative ambiguity)
- `filesystem-root` (`/`, `//`, `C:\`)
- `real-home` / `real-home-ancestor` — the real home captured at **module load**, before any test mutates `HOME`, plus its realpath alias; checked both lexically and on the symlink-resolved canonical path
- `too-shallow` (fewer than 2 segments below the root)
- `symlink-escape` (target resolves outside the allowed roots)
- `outside-allowed-roots` — deletion is permitted **only strictly inside** the canonical `os.tmpdir()` or this repository worktree (the roots themselves are refused)
- `unowned-path` (every existing component below the containing root must be owned by the test process uid)

Platform normalization is first-class: win32 (`C:\Users\OP` ≡ `c:/users/op`, drive roots) and darwin case-insensitivity are covered by an injectable path module, so the verdict logic is unit-testable on any platform.

`safeRm`/`safeRmSync` wrap the primitives; refusals throw `SafeCleanupRefusalError` carrying the machine-readable reason.

### Layer 2 — runtime guard (`installRuntimeDeletionGuard`)
Installed by `scripts/test-preload.ts` (already loaded by both root and package-cwd test shards). It patches only the surfaces Bun 1.4.0 actually allows intercepting — verified by probing, and pinned by tests so a runtime change is detected:
- the shared `fs.promises` object (`fs.promises.rm`/`rmdir`, visible through every import style including `import * as fs`)
- the CJS `require("node:fs")` / `require("node:fs/promises")` exports (third-party dependencies)

A refusal prints the reason and **aborts the process (exit 70)**. Even a custom `onViolation` that returns cannot fall through to the deletion.

**Known gap, deliberately documented:** ESM top-level `fs.rmSync`/`fs.rm` bindings are immutable snapshots in Bun 1.4.0 and cannot be patched at runtime. `Bun.plugin` cannot intercept builtins either. That gap is closed by layer 3, and `scripts/safe-cleanup-guard.test.ts` carries a skipped test documenting the boundary.

The guard is test-process-scoped only — it never loads in product runtime or non-test tooling, so no third-party or production behavior changes (per the issue's constraint).

### Layer 3 — static guard (`scripts/check-unsafe-rmrf.ts`)
Bans raw recursive `fs.rm*`/`fs.rmdir*` and shell `rm -rf` invocations in **HOME-seam files** (files mutating `process.env.HOME` or mocking `os.homedir`). Wired into `check:tools`, so CI fails closed on regressions. Blocked-command fixture strings and `test-fixtures/` are excluded.

### `withTempHome` + migrations
- `packages/coding-agent/test/helpers/temp-home.ts` — atomic HOME override (including the `os.homedir` spy) with an in-effect assertion before `fn` runs, restore-before-cleanup in `finally`, and deletion of the owning `mkdtemp` root through the safe contract.
- `temp-home-cleanup.ts` now routes both removals through `safeRmSync` (a truthiness check never proved ownership).
- All 21 HOME-seam files with raw recursive removals migrated to `safeRm`/`safeRmSync` (mechanical, no behavior change).
- **Two tests that wrote and recursively deleted under the REAL home are fixed:**
  - `skills.test.ts` "~ expansion" created/deleted `~/.pi-skills-test-*` → now a mocked temp home. (The guard caught this one live during verification.)
  - `lsp-command-trust.test.ts` external-lspmux / trusted-user-config fixtures genuinely require real-home resolution semantics (trusted-home resolvers capture `os.homedir` at import time; a mock cannot redirect them). They keep real-home fixtures but call `registerOwnedDeletionRoot()` **before creating** the directory — an explicit grant that permits exactly that process-created directory, while the home itself, its ancestors, and every sibling stay refused.

## Verification
- 66 new tests across 4 suites, all green: verdict decision table (posix/win32/darwin, every refusal class, dot-dot/trailing-slash/symlink aliases), runtime-guard interception matrix + idempotence, **subprocess e2e** proving a violating `bun test` child exits 70 *without deleting anything* (out-of-root probe under `/var/tmp`; inherited-fake-HOME probe under tmpdir), scanner behavior, `withTempHome` atomicity.
- Every negative test uses an injected fake home or an out-of-root probe; the real HOME was never targeted destructively (only `existsSync` assertions).
- All migrated suites green; `skill-discovery`/`skill` failures verified **identical to the pristine base commit** (pre-existing at `89d1b7c`, fixed by later commits already on dev).
- `check:tools` (biome + tsc + new guard), and package-level `check` for coding-agent/utils/agent/ai/tui/natives all green.

## Pre-existing failures at this base (not from this PR, documented for reviewers)
- `packages/coding-agent/test/manifests/sdk-pretrain-binary.json` pins toolchain `1.3.14` while base `89d1b7c` bumped the Bun pin to 1.4.0 → `sdk-downgrade-rollback.test.ts` fails identically on a pristine checkout of the base.
- `issue-4508-cross-convention-fixture`, `skill-discovery`, `skill`, and the runtime-mcp cross-file combination fail identically at the base commit (fixes live in later dev commits).

Closes #4794

---
🤖 Generated with [GJC](https://github.com/Yeachan-Heo/gajae-code)
