### PR TITLE
fix(sdk): recover in-flight goal snapshots across runtime replacement

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Fixed
 
+- SDK `goal.list/get` no longer reports `resource_gone` when an in-flight session's live goal projection is temporarily unavailable. It recovers the latest authoritative goal mode state from the current session branch after runtime recreation or session replacement, while goal-less sessions return an explicit `no_active_goal` diagnostic instead of being confused with snapshot-store loss (#4824).
+
 - `/logout` (and `gjc accounts logout`) now remove stored API-key credentials, not just OAuth rows. The interactive logout and the CLI only enumerated `oauth` inventory, so API-key logins (OpenCode Go/Zen, Cursor, Venice, DeepSeek, …) were rejected with `API-key credentials are not managed here`; both paths now remove stored credentials of either kind.
 - Queued SDK prompts now retain their dispatch-time ownership across selection fences instead of reclassifying from a contradictory later streaming snapshot. Fresh promotion, earlier follow-up ordering, and terminal-abort cancellation are reachable again, while `/btw` test fixtures now model the user-drainable queue count required by the current empty-submit contract.
 - Coordinator stop and idle-reap now initialize canonical namespace state before reading durable deletion recovery. Fresh or upgraded projection-only sessions were misreported as `state_corrupt` before the broker close was attempted, and completed deletion receipts were excluded from the idempotent missing-session lookup; both paths now preserve strict malformed-state rejection while allowing safe cleanup and replay.

--- a/packages/coding-agent/src/sdk/host/session-runtime.test.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.test.ts
@@ -13,9 +13,11 @@ import {
 } from "../../session/terminal-abort";
 import { Broker } from "../broker/broker";
 import { createReconciliationStore } from "../bus/reconciliation-store";
+import { CursorRegistry, QueryHandlers, RevisionStore } from "./query";
 import {
 	createInvocationReconciliation,
 	createSdkSessionRuntimeExtension,
+	createSdkSurfaceFactory,
 	SessionSdkSessionRuntime,
 	type SessionSdkTransport,
 } from "./session-runtime";
@@ -76,7 +78,11 @@ function admissionBarrier(target: number) {
 	};
 }
 
-function extensionContext(sessionId: string, cwd: string): ExtensionContext {
+function extensionContext(
+	sessionId: string,
+	cwd: string,
+	options: { goalState?: unknown; branch?: unknown[] } = {},
+): ExtensionContext {
 	return {
 		cwd,
 		workflowGate: undefined,
@@ -85,9 +91,122 @@ function extensionContext(sessionId: string, cwd: string): ExtensionContext {
 			getSessionId: () => sessionId,
 			getSessionFile: () => path.join(cwd, `${sessionId}.json`),
 			getSessionName: () => undefined,
+			getBranch: () => options.branch ?? [],
 		},
+		getGoalState: () => options.goalState,
 	} as unknown as ExtensionContext;
 }
+
+function goalModeEntry(sessionId: string, tokensUsed: number): Record<string, unknown> {
+	return {
+		type: "mode_change",
+		id: `goal-${sessionId}`,
+		parentId: null,
+		timestamp: new Date(1_000).toISOString(),
+		mode: "goal",
+		data: {
+			goal: {
+				id: `goal-${sessionId}`,
+				objective: "Preserve the active SDK goal",
+				status: "active",
+				tokensUsed,
+				timeUsedSeconds: 2,
+				createdAt: 1_000,
+				updatedAt: 2_000,
+			},
+		},
+	};
+}
+
+async function queryGoalState(ctx: ExtensionContext, sessionId: string): Promise<unknown> {
+	const surface = createSdkSurfaceFactory({ ctx, id: sessionId, api: {} as ExtensionAPI }).query;
+	const store = new RevisionStore(sessionId);
+	const cursors = new CursorRegistry("goal-test-token", store);
+	const response = await new QueryHandlers(surface, sessionId, store, cursors).dispatch({
+		query: "goal.list/get",
+		connectionId: "goal-test-connection",
+	});
+	if (!response.ok) throw new Error(`goal query failed: ${JSON.stringify(response)}`);
+	return response.page?.items[0];
+}
+
+describe("SDK goal snapshot lifecycle", () => {
+	test("recovers an active nonzero-activity goal from the durable session projection", async () => {
+		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-sdk-goal-recovery-"));
+		try {
+			const sessionId = "runtime-recreated";
+			const branch = [goalModeEntry(sessionId, 17)];
+			const liveGoal = {
+				enabled: true,
+				mode: "active",
+				goal: { ...(branch[0] as { data: { goal: Record<string, unknown> } }).data.goal },
+			};
+			const live = await queryGoalState(
+				extensionContext(sessionId, cwd, { goalState: liveGoal, branch }),
+				sessionId,
+			);
+			const recreated = await queryGoalState(extensionContext(sessionId, cwd, { branch }), sessionId);
+
+			expect(live).toMatchObject({ enabled: true, goal: { status: "active", tokensUsed: 17 } });
+			expect(recreated).toEqual(live);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("keeps fresh session/worktree projections isolated while an active turn has activity", async () => {
+		const root = await mkdtemp(path.join(os.tmpdir(), "gjc-sdk-goal-isolation-"));
+		try {
+			const first = await queryGoalState(
+				extensionContext("fresh-session-a", path.join(root, "a"), {
+					branch: [goalModeEntry("fresh-session-a", 11)],
+				}),
+				"fresh-session-a",
+			);
+			const second = await queryGoalState(
+				extensionContext("fresh-session-b", path.join(root, "b"), {
+					branch: [goalModeEntry("fresh-session-b", 23)],
+				}),
+				"fresh-session-b",
+			);
+
+			expect(first).toMatchObject({ goal: { id: "goal-fresh-session-a", tokensUsed: 11 } });
+			expect(second).toMatchObject({ goal: { id: "goal-fresh-session-b", tokensUsed: 23 } });
+			expect(first).not.toEqual(second);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	test("returns an explicit no-active-goal diagnostic for the zero-activity control", async () => {
+		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-sdk-goal-empty-"));
+		try {
+			const result = await queryGoalState(extensionContext("zero-activity", cwd), "zero-activity");
+			expect(result).toMatchObject({ enabled: false, goal: null, reason: "no_active_goal" });
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("returns a recoverable diagnostic when durable active-goal state is malformed", async () => {
+		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-sdk-goal-corrupt-"));
+		try {
+			const result = await queryGoalState(
+				extensionContext("corrupt-goal", cwd, {
+					branch: [{ ...goalModeEntry("corrupt-goal", 19), data: { goal: { status: "active" } } }],
+				}),
+				"corrupt-goal",
+			);
+			expect(result).toMatchObject({
+				reason: "goal_state_unavailable",
+				recoverable: true,
+				goal: null,
+			});
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+});
 
 test("preserves an agent failure code in host prompt reconciliation", async () => {
 	const reconciliation = createInvocationReconciliation();

--- a/packages/coding-agent/src/sdk/host/session-runtime.test.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.test.ts
@@ -81,7 +81,11 @@ function admissionBarrier(target: number) {
 function extensionContext(
 	sessionId: string,
 	cwd: string,
-	options: { goalState?: unknown; branch?: unknown[] } = {},
+	options: {
+		goalState?: unknown;
+		branch?: unknown[];
+		liveState?: { isStreaming: boolean; steeringQueueDepth: number; followupQueueDepth: number };
+	} = {},
 ): ExtensionContext {
 	return {
 		cwd,
@@ -118,8 +122,17 @@ function goalModeEntry(sessionId: string, tokensUsed: number): Record<string, un
 	};
 }
 
-async function queryGoalState(ctx: ExtensionContext, sessionId: string): Promise<unknown> {
-	const surface = createSdkSurfaceFactory({ ctx, id: sessionId, api: {} as ExtensionAPI }).query;
+async function queryGoalState(
+	ctx: ExtensionContext,
+	sessionId: string,
+	liveState?: { isStreaming: boolean; steeringQueueDepth: number; followupQueueDepth: number },
+): Promise<unknown> {
+	const surface = createSdkSurfaceFactory({
+		ctx,
+		id: sessionId,
+		api: {} as ExtensionAPI,
+		getLiveState: () => liveState ?? { isStreaming: false, steeringQueueDepth: 0, followupQueueDepth: 0 },
+	}).query;
 	const store = new RevisionStore(sessionId);
 	const cursors = new CursorRegistry("goal-test-token", store);
 	const response = await new QueryHandlers(surface, sessionId, store, cursors).dispatch({
@@ -144,6 +157,7 @@ describe("SDK goal snapshot lifecycle", () => {
 			const live = await queryGoalState(
 				extensionContext(sessionId, cwd, { goalState: liveGoal, branch }),
 				sessionId,
+				{ isStreaming: true, steeringQueueDepth: 1, followupQueueDepth: 0 },
 			);
 			const recreated = await queryGoalState(extensionContext(sessionId, cwd, { branch }), sessionId);
 

--- a/packages/coding-agent/src/sdk/host/session-runtime.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.ts
@@ -14,6 +14,7 @@ import { resolveModelChainWithAuth, splitSelectorThinkingSuffix } from "../../co
 import { type ModelSelectorValue, normalizeModelSelectorValue } from "../../config/model-selector-value";
 import { type Settings, validateSettingPatch } from "../../config/settings";
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "../../extensibility/extensions";
+import { normalizeGoal } from "../../goals/state";
 import {
 	boundTerminalRetentionState,
 	findOwnedRegistrationsForTurn,
@@ -869,6 +870,48 @@ function createQuerySurface(
 			throw error;
 		}
 	};
+	const getDurableGoalState = (): { kind: "state"; state: unknown } | { kind: "empty" } | { kind: "unavailable" } => {
+		// A recreated SDK host can observe the session before its in-memory goal
+		// projection is hydrated. The latest mode_change is the durable authority;
+		// never borrow a goal from another session or an older branch.
+		let branch: ReturnType<ExtensionContext["sessionManager"]["getBranch"]>;
+		try {
+			branch = ctx.sessionManager.getBranch();
+		} catch {
+			return { kind: "unavailable" };
+		}
+		for (const entry of branch.toReversed()) {
+			if (entry.type !== "mode_change") continue;
+			if (entry.mode !== "goal" && entry.mode !== "goal_paused") return { kind: "empty" };
+			const goal = normalizeGoal(entry.data?.goal);
+			if (!goal) return { kind: "unavailable" };
+			return { kind: "state", state: { enabled: entry.mode === "goal", mode: "active", goal } };
+		}
+		return { kind: "empty" };
+	};
+	const getGoalState = (): unknown => {
+		const liveState =
+			typeof (ctx as Partial<ExtensionContext>).getGoalState === "function" ? ctx.getGoalState() : undefined;
+		if (liveState !== undefined) return liveState;
+		const durableState = getDurableGoalState();
+		if (durableState.kind === "state") return durableState.state;
+		if (durableState.kind === "unavailable")
+			return {
+				enabled: false,
+				goal: null,
+				reason: "goal_state_unavailable",
+				recoverable: true,
+				message:
+					"The authoritative goal state could not be recovered from this session. Reconnect or resume the session before retrying.",
+			};
+		return {
+			enabled: false,
+			goal: null,
+			reason: "no_active_goal",
+			message:
+				"No goal is active in this session: goal mode has not created or resumed a goal, so no goal snapshot exists yet.",
+		};
+	};
 	return {
 		getTranscriptEntries: () =>
 			typeof (ctx as Partial<ExtensionContext>).getTranscript === "function" ? ctx.getTranscript() : [],
@@ -877,8 +920,7 @@ function createQuerySurface(
 			systemPrompt: ctx.getSystemPrompt(),
 			...getLiveState(),
 		}),
-		getGoalState: () =>
-			typeof (ctx as Partial<ExtensionContext>).getGoalState === "function" ? ctx.getGoalState() : undefined,
+		getGoalState,
 		getTodoState: () =>
 			typeof (ctx as Partial<ExtensionContext>).getTodoState === "function" ? ctx.getTodoState() : [],
 		getDiff,

--- a/packages/coding-agent/test/helpers/sdk-adapter-dispositions-shared.ts
+++ b/packages/coding-agent/test/helpers/sdk-adapter-dispositions-shared.ts
@@ -111,7 +111,6 @@ export const expectedDomainErrors: Readonly<Record<string, string>> = {
 	"queue.message.move": "invalid_position",
 	"queue.message.update": "invalid_message",
 	"transcript.body": "resource_gone",
-	"goal.list/get": "resource_gone",
 	"session.last_assistant": "resource_gone",
 	"resource.body": "resource_gone",
 	"artifact.read": "resource_gone",


### PR DESCRIPTION
## What

Recover authoritative SDK goal snapshots across runtime recreation and session replacement.

## Why

An accepted in-flight turn with real model activity could make `goal.list/get` return `resource_gone` because the live projection was temporarily absent. The current session branch is the durable authority; a goal-less session must be distinguishable from snapshot loss. Fixes #4824.

## Testing

- `bun test packages/coding-agent/src/sdk/host/session-runtime.test.ts`
- focused goal lifecycle, goal-mode request, SDK host wiring, and adapter Q04 tests
- `bun --cwd=packages/coding-agent run check`
- `bun run check:publish-types`
- `bun run check:rs`
- GitHub CI run 32525337796

## Risk classification

- [x] `low-risk` — narrow SDK query projection repair with current-session isolation and explicit fail-closed diagnostics.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

gajae.pr-review-verdict.v1 merge-self-approved sha256:dff8b9edb7e3fc190e461fc0b75ff801b30436919cd569f27cbfe57fac10d078 reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/actions/runs/32525337796

---

- [x] Target branch is `dev`
- [ ] `bun check` passes locally; the full root TypeScript manifest exceeded the bounded local window after emitting passing receipts
- [x] Tested locally
- [x] CHANGELOG updated
- [x] Verdict above matches exact head `a998667c42652e8ed4d78baceb5a49960ff2d197`
- [x] Risk classification matches the solo low-risk path
