### PR TITLE
fix(tui): stabilize long skill HUD wrapping

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Fixed
 
+- Fixed long skill-HUD entries corrupting bottom-pinned TUI row accounting by emitting at most two independent width-bounded rows and preserving severity glyphs through narrow truncation.
+
 - SDK `goal.list/get` no longer reports `resource_gone` when an in-flight session's live goal projection is temporarily unavailable. It recovers the latest authoritative goal mode state from the current session branch after runtime recreation or session replacement, while goal-less sessions return an explicit `no_active_goal` diagnostic instead of being confused with snapshot-store loss (#4824).
 
 - `/logout` (and `gjc accounts logout`) now remove stored API-key credentials, not just OAuth rows. The interactive logout and the CLI only enumerated `oauth` inventory, so API-key logins (OpenCode Go/Zen, Cursor, Venice, DeepSeek, …) were rejected with `API-key credentials are not managed here`; both paths now remove stored credentials of either kind.

--- a/packages/coding-agent/src/modes/components/skill-hud/render.ts
+++ b/packages/coding-agent/src/modes/components/skill-hud/render.ts
@@ -95,7 +95,6 @@ function buildEntryTokens(entry: SkillActiveEntry, tier: WidthTier, width: numbe
 	if (
 		tier === "tight" &&
 		glyph &&
-		visibleWidth(glyph) > 1 &&
 		visibleWidth(glyph) <= width &&
 		visibleWidth(baseText) + 1 + visibleWidth(glyph) > width
 	) {

--- a/packages/coding-agent/src/modes/components/skill-hud/render.ts
+++ b/packages/coding-agent/src/modes/components/skill-hud/render.ts
@@ -77,7 +77,7 @@ function keyMetricChip(skill: string, chips: readonly WorkflowHudChip[]): Workfl
 	);
 }
 
-function buildEntryTokens(entry: SkillActiveEntry, tier: WidthTier): HudToken[] {
+function buildEntryTokens(entry: SkillActiveEntry, tier: WidthTier, width: number): HudToken[] {
 	const skill = sanitizeHudPart(entry.skill);
 	const phase = sanitizeHudPart(entry.phase);
 	const base = phase ? `${skill}:${phase}` : skill;
@@ -91,15 +91,24 @@ function buildEntryTokens(entry: SkillActiveEntry, tier: WidthTier): HudToken[] 
 		chips.find(chip => chip.severity === "error" || chip.severity === "blocked")?.severity ??
 		chips.find(chip => chip.severity === "warning")?.severity;
 	const glyph = severityGlyph(severity);
+	const baseText = color("accent", tier === "tight" ? skill : base);
+	if (
+		tier === "tight" &&
+		glyph &&
+		visibleWidth(glyph) > 1 &&
+		visibleWidth(glyph) <= width &&
+		visibleWidth(baseText) + 1 + visibleWidth(glyph) > width
+	) {
+		return [{ text: glyph, mandatory: true, startsEntry: true }];
+	}
 	const tokens: HudToken[] = [
 		{
-			text: color("accent", tier === "tight" ? skill : base),
+			text: baseText,
 			mandatory: true,
 			startsEntry: true,
 			reserveAfter: glyph ? visibleWidth(` ${glyph}`) : 0,
 		},
 	];
-
 	if (glyph) tokens.push({ text: glyph, mandatory: true });
 
 	if (tier === "medium") {
@@ -188,7 +197,7 @@ export function renderSkillHudBar(entries: readonly SkillActiveEntry[], width: n
 	};
 
 	for (const entry of active) {
-		for (const token of buildEntryTokens(entry, tier)) {
+		for (const token of buildEntryTokens(entry, tier, width)) {
 			const append = (allowTruncate: boolean): boolean => {
 				const appended = tryAppend(token, allowTruncate);
 				if (appended && token.mandatory && !token.startsEntry) lastSeverityToken = token.text;

--- a/packages/coding-agent/src/modes/components/skill-hud/render.ts
+++ b/packages/coding-agent/src/modes/components/skill-hud/render.ts
@@ -11,7 +11,7 @@ const ANSI_PATTERN = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
 const MAX_HUD_ROWS = 2;
 
 type WidthTier = "wide" | "medium" | "tight";
-type HudToken = { text: string; mandatory: boolean; startsEntry?: boolean };
+type HudToken = { text: string; mandatory: boolean; startsEntry?: boolean; reserveAfter?: number };
 
 function color(role: "border" | "accent" | "dim" | "muted" | "warning" | "error", text: string): string {
 	return theme?.fg(role, text) ?? text;
@@ -90,11 +90,16 @@ function buildEntryTokens(entry: SkillActiveEntry, tier: WidthTier): HudToken[] 
 	const severity =
 		chips.find(chip => chip.severity === "error" || chip.severity === "blocked")?.severity ??
 		chips.find(chip => chip.severity === "warning")?.severity;
+	const glyph = severityGlyph(severity);
 	const tokens: HudToken[] = [
-		{ text: color("accent", tier === "tight" ? skill : base), mandatory: true, startsEntry: true },
+		{
+			text: color("accent", tier === "tight" ? skill : base),
+			mandatory: true,
+			startsEntry: true,
+			reserveAfter: glyph ? visibleWidth(` ${glyph}`) : 0,
+		},
 	];
 
-	const glyph = severityGlyph(severity);
 	if (glyph) tokens.push({ text: glyph, mandatory: true });
 
 	if (tier === "medium") {
@@ -113,8 +118,19 @@ function buildEntryTokens(entry: SkillActiveEntry, tier: WidthTier): HudToken[] 
 	return tokens;
 }
 
-function appendOverflowMarker(row: string, width: number): string {
+function appendOverflowMarker(row: string, width: number, protectedToken?: string): string {
 	if (!row || width <= 0) return row;
+	if (protectedToken) {
+		const tokenIndex = row.lastIndexOf(protectedToken);
+		if (tokenIndex >= 0) {
+			const prefix = row.slice(0, tokenIndex);
+			const tokenWidth = visibleWidth(protectedToken);
+			const plainPrefix = Bun.stripANSI(prefix).trimEnd();
+			const needsMarker = !plainPrefix.endsWith("…");
+			const prefixWidth = Math.max(0, width - tokenWidth - (needsMarker ? 1 : 0));
+			return `${truncateToWidth(prefix, prefixWidth)}${needsMarker ? "…" : ""}${protectedToken}`;
+		}
+	}
 	return truncateToWidth(`${row}…`, width);
 }
 
@@ -138,6 +154,7 @@ export function renderSkillHudBar(entries: readonly SkillActiveEntry[], width: n
 	let rowIndex = 0;
 	let hasToken = false;
 	let omitted = false;
+	let lastSeverityToken: string | undefined;
 
 	const tryAppend = (token: HudToken, allowTruncate: boolean): boolean => {
 		let joiner = hasToken ? (token.startsEntry ? separator : " ") : "";
@@ -148,11 +165,12 @@ export function renderSkillHudBar(entries: readonly SkillActiveEntry[], width: n
 			available = width;
 		}
 		if (available <= 0) return false;
+		const textAvailable = Math.max(0, available - (allowTruncate ? (token.reserveAfter ?? 0) : 0));
 		const text =
-			visibleWidth(token.text) <= available
+			visibleWidth(token.text) <= textAvailable
 				? token.text
 				: allowTruncate
-					? truncateToWidth(token.text, available)
+					? truncateToWidth(token.text, textAvailable)
 					: "";
 		if (!text || visibleWidth(text) <= 0) return false;
 		row = `${row}${joiner}${text}`;
@@ -171,10 +189,15 @@ export function renderSkillHudBar(entries: readonly SkillActiveEntry[], width: n
 
 	for (const entry of active) {
 		for (const token of buildEntryTokens(entry, tier)) {
-			if (tryAppend(token, false)) continue;
-			if (startNextRow() && tryAppend(token, false)) continue;
-			if (tryAppend(token, true)) continue;
-			if (token.mandatory && startNextRow() && tryAppend(token, true)) continue;
+			const append = (allowTruncate: boolean): boolean => {
+				const appended = tryAppend(token, allowTruncate);
+				if (appended && token.mandatory && !token.startsEntry) lastSeverityToken = token.text;
+				return appended;
+			};
+			if (append(false)) continue;
+			if (startNextRow() && append(false)) continue;
+			if (append(true)) continue;
+			if (token.mandatory && startNextRow() && append(true)) continue;
 			omitted = true;
 			break;
 		}
@@ -184,7 +207,7 @@ export function renderSkillHudBar(entries: readonly SkillActiveEntry[], width: n
 	if (hasToken) rows.push(truncateToWidth(row, width));
 	if (omitted && rows.length > 0) {
 		const last = rows.length - 1;
-		rows[last] = appendOverflowMarker(rows[last] ?? "", width);
+		rows[last] = appendOverflowMarker(rows[last] ?? "", width, lastSeverityToken);
 	}
 	return rows.length > 0 ? rows.slice(0, MAX_HUD_ROWS) : null;
 }

--- a/packages/coding-agent/src/modes/components/skill-hud/render.ts
+++ b/packages/coding-agent/src/modes/components/skill-hud/render.ts
@@ -8,8 +8,10 @@ import { workflowReceiptStatus } from "../../../skill-state/workflow-state-contr
 import { theme } from "../../theme/theme";
 
 const ANSI_PATTERN = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
+const MAX_HUD_ROWS = 2;
 
 type WidthTier = "wide" | "medium" | "tight";
+type HudToken = { text: string; mandatory: boolean; startsEntry?: boolean };
 
 function color(role: "border" | "accent" | "dim" | "muted" | "warning" | "error", text: string): string {
 	return theme?.fg(role, text) ?? text;
@@ -75,15 +77,7 @@ function keyMetricChip(skill: string, chips: readonly WorkflowHudChip[]): Workfl
 	);
 }
 
-function fitWithSuffix(prefix: string, suffix: string, width: number): string {
-	if (width <= 0) return "";
-	if (!suffix) return truncateToWidth(prefix, width);
-	const suffixWidth = visibleWidth(suffix);
-	if (suffixWidth >= width) return truncateToWidth(suffix, width);
-	return `${truncateToWidth(prefix, width - suffixWidth)}${suffix}`;
-}
-
-function formatEntry(entry: SkillActiveEntry, tier: WidthTier, width: number): string {
+function buildEntryTokens(entry: SkillActiveEntry, tier: WidthTier): HudToken[] {
 	const skill = sanitizeHudPart(entry.skill);
 	const phase = sanitizeHudPart(entry.phase);
 	const base = phase ? `${skill}:${phase}` : skill;
@@ -96,22 +90,40 @@ function formatEntry(entry: SkillActiveEntry, tier: WidthTier, width: number): s
 	const severity =
 		chips.find(chip => chip.severity === "error" || chip.severity === "blocked")?.severity ??
 		chips.find(chip => chip.severity === "warning")?.severity;
-	const suffix = severity ? ` ${severityGlyph(severity)}` : "";
-	if (tier === "tight") return fitWithSuffix(color("accent", skill), suffix, width);
+	const tokens: HudToken[] = [
+		{ text: color("accent", tier === "tight" ? skill : base), mandatory: true, startsEntry: true },
+	];
 
-	const metric = keyMetricChip(skill, chips);
+	const glyph = severityGlyph(severity);
+	if (glyph) tokens.push({ text: glyph, mandatory: true });
+
 	if (tier === "medium") {
-		const prefix = [color("accent", base), metric ? formatChip(metric) : ""].filter(Boolean).join(" ");
-		return fitWithSuffix(prefix, suffix, width);
+		const metric = keyMetricChip(skill, chips);
+		const metricText = metric ? formatChip(metric) : null;
+		if (metricText) tokens.push({ text: metricText, mandatory: false });
+		return tokens;
 	}
 
 	const summary = sanitizeHudPart(entry.hud?.summary);
-	const details = chips.map(formatChip).filter((chip): chip is string => Boolean(chip));
-	const prefix = [color("accent", base), summary ? color("muted", summary) : "", ...details].filter(Boolean).join(" ");
-	return fitWithSuffix(prefix, suffix, width);
+	if (summary) tokens.push({ text: color("muted", summary), mandatory: false });
+	for (const chip of chips) {
+		const formatted = formatChip(chip);
+		if (formatted) tokens.push({ text: formatted, mandatory: false });
+	}
+	return tokens;
 }
 
-export function renderSkillHudBar(entries: readonly SkillActiveEntry[], width: number): string | null {
+function appendOverflowMarker(row: string, width: number): string {
+	if (!row || width <= 0) return row;
+	return truncateToWidth(`${row}…`, width);
+}
+
+/**
+ * Render the HUD as physical rows rather than embedding a newline in one row.
+ * The bottom-pinned TUI layout counts array elements as rows; a newline inside
+ * one element corrupts that accounting and can overwrite the editor.
+ */
+export function renderSkillHudBar(entries: readonly SkillActiveEntry[], width: number): string[] | null {
 	const visible = collapsePlanningPipeline(entries.filter(entry => entry.active !== false));
 	const active = visible.filter(entry => sanitizeHudPart(entry.skill)).sort(compareEntries);
 	if (active.length === 0 || width <= 0) return null;
@@ -119,41 +131,60 @@ export function renderSkillHudBar(entries: readonly SkillActiveEntry[], width: n
 	const tier = tierForWidth(width);
 	const rail = color("border", "◆");
 	const separator = color("dim", " + ");
-	const railPrefix = visibleWidth(rail) + 1 <= width ? `${rail} ` : "";
+	const firstPrefix = visibleWidth(rail) + 1 <= width ? `${rail} ` : "";
+	const continuationPrefix = firstPrefix ? " ".repeat(visibleWidth(firstPrefix)) : "";
 	const rows: string[] = [];
-	let row = railPrefix;
-	let hasEntry = false;
+	let row = firstPrefix;
+	let rowIndex = 0;
+	let hasToken = false;
 	let omitted = false;
 
-	for (const entry of active) {
-		const joiner = hasEntry ? separator : "";
-		const budget = Math.max(0, width - visibleWidth(row) - visibleWidth(joiner));
-		const fullRendered = formatEntry(entry, tier, 4096);
-		let rendered = visibleWidth(fullRendered) <= budget ? fullRendered : "";
-		if (!rendered) {
-			if (!hasEntry) {
-				row = "";
-				rendered = formatEntry(entry, tier, width);
-			} else if (rows.length === 0) {
-				rows.push(truncateToWidth(row, width));
-				row = railPrefix;
-				hasEntry = false;
-				const firstRowBudget = Math.max(0, width - visibleWidth(row));
-				rendered = visibleWidth(fullRendered) <= firstRowBudget ? fullRendered : formatEntry(entry, tier, width);
-			} else {
-				omitted = true;
-				break;
-			}
+	const tryAppend = (token: HudToken, allowTruncate: boolean): boolean => {
+		let joiner = hasToken ? (token.startsEntry ? separator : " ") : "";
+		let available = width - visibleWidth(row) - visibleWidth(joiner);
+		if (!hasToken && visibleWidth(row) > 0 && visibleWidth(token.text) > available) {
+			row = "";
+			joiner = "";
+			available = width;
 		}
-		if (!rendered) continue;
-		row = `${row}${hasEntry ? separator : ""}${rendered}`;
-		hasEntry = true;
+		if (available <= 0) return false;
+		const text =
+			visibleWidth(token.text) <= available
+				? token.text
+				: allowTruncate
+					? truncateToWidth(token.text, available)
+					: "";
+		if (!text || visibleWidth(text) <= 0) return false;
+		row = `${row}${joiner}${text}`;
+		hasToken = true;
+		return true;
+	};
+
+	const startNextRow = (): boolean => {
+		if (rowIndex >= MAX_HUD_ROWS - 1) return false;
+		if (hasToken) rows.push(truncateToWidth(row, width));
+		rowIndex += 1;
+		row = continuationPrefix;
+		hasToken = false;
+		return true;
+	};
+
+	for (const entry of active) {
+		for (const token of buildEntryTokens(entry, tier)) {
+			if (tryAppend(token, false)) continue;
+			if (startNextRow() && tryAppend(token, false)) continue;
+			if (tryAppend(token, true)) continue;
+			if (token.mandatory && startNextRow() && tryAppend(token, true)) continue;
+			omitted = true;
+			break;
+		}
+		if (omitted) break;
 	}
 
-	if (hasEntry) rows.push(truncateToWidth(row, width));
+	if (hasToken) rows.push(truncateToWidth(row, width));
 	if (omitted && rows.length > 0) {
 		const last = rows.length - 1;
-		rows[last] = truncateToWidth(`${rows[last]}…`, width);
+		rows[last] = appendOverflowMarker(rows[last] ?? "", width);
 	}
-	return rows.slice(0, 2).join("\n") || null;
+	return rows.length > 0 ? rows.slice(0, MAX_HUD_ROWS) : null;
 }

--- a/packages/coding-agent/src/modes/components/tool-status-header.ts
+++ b/packages/coding-agent/src/modes/components/tool-status-header.ts
@@ -1048,9 +1048,10 @@ export class StatusLineComponent implements Component {
 	render(width: number): string[] {
 		const lines: string[] = [];
 		this.#refreshSkillHudInBackground();
-		const skillHud = this.#settings.showSkillHud === false ? null : renderSkillHudBar(this.#skillHudEntries, width);
-		if (skillHud) {
-			for (const skillHudRow of skillHud.split("\n")) {
+		const skillHudRows =
+			this.#settings.showSkillHud === false ? null : renderSkillHudBar(this.#skillHudEntries, width);
+		if (skillHudRows) {
+			for (const skillHudRow of skillHudRows) {
 				if (skillHudRow) lines.push(truncateToWidth(skillHudRow, width));
 			}
 		}

--- a/packages/coding-agent/test/skill-hud-bar.test.ts
+++ b/packages/coding-agent/test/skill-hud-bar.test.ts
@@ -98,6 +98,16 @@ describe("skill HUD bar renderer", () => {
 		expect(rows.every(row => Bun.stringWidth(Bun.stripANSI(row)) <= 10)).toBe(true);
 		expect(rows[0]).not.toBe("◆");
 		expect(text).toContain(theme?.status.error ?? "[!!]");
+		const longSkillRows = renderSkillHudBar(
+			[
+				{
+					skill: "averyverylongskillname",
+					hud: { version: 1, chips: [{ label: "blocked", value: "yes", severity: "blocked" }] },
+				},
+			],
+			10,
+		);
+		expect(longSkillRows?.join("\n")).toContain(theme?.status.error ?? "[!!]");
 	});
 
 	it("sanitizes dynamic text and truncates to width", () => {

--- a/packages/coding-agent/test/skill-hud-bar.test.ts
+++ b/packages/coding-agent/test/skill-hud-bar.test.ts
@@ -2,9 +2,14 @@ import { describe, expect, it } from "bun:test";
 import { renderSkillHudBar } from "../src/modes/components/skill-hud/render";
 import { STATUS_LINE_PRESETS } from "../src/modes/components/status-line/presets";
 import { theme } from "../src/modes/theme/theme";
+import type { SkillActiveEntry } from "../src/skill-state/active-state";
+
+function renderHudText(entries: readonly SkillActiveEntry[], width: number): string {
+	return Bun.stripANSI(renderSkillHudBar(entries, width)?.join("\n") ?? "");
+}
 
 function visibleWidth(text: string): number {
-	return Bun.stripANSI(text).length;
+	return Bun.stringWidth(Bun.stripANSI(text));
 }
 
 describe("skill HUD bar renderer", () => {
@@ -13,7 +18,8 @@ describe("skill HUD bar renderer", () => {
 	});
 
 	it("renders active skill and phase compactly", () => {
-		const rendered = Bun.stripANSI(renderSkillHudBar([{ skill: "deep-interview", phase: "intent-first" }], 80) ?? "");
+		const rendered = renderHudText([{ skill: "deep-interview", phase: "intent-first" }], 80);
+
 		expect(rendered).not.toContain("hud");
 		expect(rendered).toContain("deep-interview:intent-first");
 	});
@@ -30,9 +36,10 @@ describe("skill HUD bar renderer", () => {
 				],
 			},
 		};
-		const wide = Bun.stripANSI(renderSkillHudBar([entry], 100) ?? "");
-		const medium = Bun.stripANSI(renderSkillHudBar([entry], 80) ?? "");
-		const tight = Bun.stripANSI(renderSkillHudBar([entry], 40) ?? "");
+		const wide = renderHudText([entry], 100);
+		const medium = renderHudText([entry], 80);
+		const tight = renderHudText([entry], 40);
+
 		expect(wide).toContain("experiments=2/4");
 		expect(medium).toContain("experiments=2/4");
 		expect(medium).not.toContain("failed=1");
@@ -44,7 +51,33 @@ describe("skill HUD bar renderer", () => {
 		const entries = Array.from({ length: 8 }, (_, index) => ({ skill: `skill-${index}`, phase: "running" }));
 		const rendered = renderSkillHudBar(entries, 20);
 		expect(rendered).not.toBeNull();
-		expect(rendered?.split("\n").length).toBeLessThanOrEqual(2);
+		expect(rendered?.length).toBeLessThanOrEqual(2);
+	});
+
+	it("wraps long wide content into physical rows without embedded newlines", () => {
+		const rows = renderSkillHudBar(
+			[
+				{
+					skill: "ultragoal",
+					phase: "executing",
+					hud: {
+						version: 1,
+						summary: "long-running aggregate execution",
+						chips: [
+							{ label: "goals", value: "1/2", priority: 10 },
+							{ label: "current", value: "G002:Stabilize long HUD wrapping", priority: 20 },
+							{ label: "ledger", value: "goal_started:2026-08-22T02:27:00.000Z", priority: 30 },
+							{ label: "status", value: "active", priority: 40 },
+						],
+					},
+				},
+			],
+			100,
+		);
+		expect(rows).not.toBeNull();
+		expect(rows).toHaveLength(2);
+		expect(rows?.every(row => !row.includes("\n") && visibleWidth(row) <= 100)).toBe(true);
+		expect(rows?.join("\n")).toContain("ultragoal:executing");
 	});
 
 	it("uses terminal-cell widths and keeps severity beside narrow content", () => {
@@ -59,11 +92,12 @@ describe("skill HUD bar renderer", () => {
 			10,
 		);
 		expect(rendered).not.toBeNull();
-		const rows = (rendered ?? "").split("\n");
+		const rows = rendered ?? [];
+		const text = rows.join("\n");
 		expect(rows.every(row => Bun.stringWidth(Bun.stripANSI(row)) > 0)).toBe(true);
 		expect(rows.every(row => Bun.stringWidth(Bun.stripANSI(row)) <= 10)).toBe(true);
 		expect(rows[0]).not.toBe("◆");
-		expect(rendered).toContain(theme?.status.error ?? "[!!]");
+		expect(text).toContain(theme?.status.error ?? "[!!]");
 	});
 
 	it("sanitizes dynamic text and truncates to width", () => {
@@ -72,14 +106,13 @@ describe("skill HUD bar renderer", () => {
 			30,
 		);
 		expect(rendered).not.toBeNull();
-		expect(Bun.stripANSI(rendered ?? "")).not.toContain("\n");
-		expect(Bun.stripANSI(rendered ?? "")).not.toContain("\t");
-		expect(visibleWidth(rendered ?? "")).toBeLessThanOrEqual(30);
+		expect(rendered?.every(row => !row.includes("\n") && !row.includes("\t"))).toBe(true);
+		expect(visibleWidth((rendered ?? []).join("\n"))).toBeLessThanOrEqual(30);
 	});
 
 	it("is included as a native status-line rail without changing preset segments", () => {
 		expect(STATUS_LINE_PRESETS.default.leftSegments).toEqual(["model", "mode", "git", "pr", "path"]);
-		const rendered = Bun.stripANSI(renderSkillHudBar([{ skill: "team", phase: "running" }], 100) ?? "");
+		const rendered = renderHudText([{ skill: "team", phase: "running" }], 100);
 		expect(rendered).toContain("◆ team:running");
 	});
 
@@ -87,27 +120,26 @@ describe("skill HUD bar renderer", () => {
 		expect(renderSkillHudBar([{ skill: "team", phase: "running", active: false }], 100)).toBeNull();
 	});
 	it("renders normalized HUD chips in priority order with stale warning", () => {
-		const rendered = Bun.stripANSI(
-			renderSkillHudBar(
-				[
-					{
-						skill: "ralplan",
-						phase: "planning",
-						stale: true,
-						hud: {
-							version: 1,
-							summary: "consensus",
-							chips: [
-								{ label: "verdict", value: "ITERATE", priority: 40, severity: "warning" },
-								{ label: "stage", value: "critic", priority: 10 },
-							],
-						},
+		const rendered = renderHudText(
+			[
+				{
+					skill: "ralplan",
+					phase: "planning",
+					stale: true,
+					hud: {
+						version: 1,
+						summary: "consensus",
+						chips: [
+							{ label: "verdict", value: "ITERATE", priority: 40, severity: "warning" },
+							{ label: "stage", value: "critic", priority: 10 },
+						],
 					},
-				],
-				120,
-			) ?? "",
+				},
+			],
+			120,
 		);
-		expect(rendered).toContain("ralplan:planning consensus");
+		expect(rendered).toContain("ralplan:planning");
+		expect(rendered).toContain("consensus");
 		expect(rendered).toContain("stage=critic");
 		expect(rendered).toContain("verdict=ITERATE");
 		expect(rendered).toContain(theme?.status.warning ?? "[!]");
@@ -117,8 +149,8 @@ describe("skill HUD bar renderer", () => {
 		const rendered = renderSkillHudBar(
 			[
 				{
-					skill: "team",
-					phase: "running",
+					skill: "team\n\u001b[31mred",
+					phase: "running\twith-a-very-long-phase-name",
 					hud: {
 						version: 1,
 						summary: "workers\nok",
@@ -129,41 +161,38 @@ describe("skill HUD bar renderer", () => {
 			35,
 		);
 		expect(rendered).not.toBeNull();
-		expect(Bun.stripANSI(rendered ?? "")).not.toContain("\n");
-		expect(Bun.stripANSI(rendered ?? "")).not.toContain("\t");
-		expect(visibleWidth(rendered ?? "")).toBeLessThanOrEqual(35);
+		expect(rendered?.every(row => !row.includes("\n") && !row.includes("\t"))).toBe(true);
+		expect(rendered?.every(row => visibleWidth(row) <= 35)).toBe(true);
 	});
 	it("renders gate and receipt status from canonical state entries", () => {
-		const rendered = Bun.stripANSI(
-			renderSkillHudBar(
-				[
-					{
-						skill: "deep-interview",
-						phase: "interviewing",
-						hud: {
-							version: 1,
-							chips: [
-								{ label: "gate", value: "approval-required", priority: 5, severity: "warning" },
-								{ label: "blocked", value: "execution approval missing", priority: 10, severity: "blocked" },
-								{ label: "next", value: "ask user for approval", priority: 20 },
-							],
-						},
-						receipt: {
-							version: 1,
-							skill: "deep-interview",
-							owner: "gjc-state-cli",
-							command: "gjc state deep-interview write",
-							state_path: ".gjc/state/skill-active-state.json",
-							storage_path: ".gjc/state/deep-interview-state.json",
-							mutated_at: new Date().toISOString(),
-							fresh_until: new Date(Date.now() + 60_000).toISOString(),
-							status: "fresh",
-							mutation_id: "test",
-						},
+		const rendered = renderHudText(
+			[
+				{
+					skill: "deep-interview",
+					phase: "interviewing",
+					hud: {
+						version: 1,
+						chips: [
+							{ label: "gate", value: "approval-required", priority: 5, severity: "warning" },
+							{ label: "blocked", value: "execution approval missing", priority: 10, severity: "blocked" },
+							{ label: "next", value: "ask user for approval", priority: 20 },
+						],
 					},
-				],
-				160,
-			) ?? "",
+					receipt: {
+						version: 1,
+						skill: "deep-interview",
+						owner: "gjc-state-cli",
+						command: "gjc state deep-interview write",
+						state_path: ".gjc/state/skill-active-state.json",
+						storage_path: ".gjc/state/deep-interview-state.json",
+						mutated_at: new Date().toISOString(),
+						fresh_until: new Date(Date.now() + 60_000).toISOString(),
+						status: "fresh",
+						mutation_id: "test",
+					},
+				},
+			],
+			160,
 		);
 		expect(rendered).toContain("deep-interview:interviewing");
 		expect(rendered).toContain("next=ask user for approval");
@@ -176,19 +205,21 @@ describe("skill HUD bar renderer", () => {
 		// entry is preserved in active_skills with active:false and handoff_to
 		// lineage for audit; the HUD filters on active!==false so only ralplan
 		// appears in the rendered bar.
-		const rendered = Bun.stripANSI(renderSkillHudBar([{ skill: "ralplan", phase: "planning" }], 80) ?? "");
+		const rendered = renderHudText([{ skill: "ralplan", phase: "planning" }], 80);
+
 		expect(rendered).toContain("ralplan:planning");
 		expect(rendered).not.toContain("deep-interview");
 	});
 
 	it("shows only the callee after an R->U handoff", () => {
-		const rendered = Bun.stripANSI(renderSkillHudBar([{ skill: "ultragoal", phase: "goal-planning" }], 80) ?? "");
+		const rendered = renderHudText([{ skill: "ultragoal", phase: "goal-planning" }], 80);
+
 		expect(rendered).toContain("ultragoal:goal-planning");
 		expect(rendered).not.toContain("ralplan");
 	});
 
 	it("shows only the callee after a backward U->R handoff", () => {
-		const rendered = Bun.stripANSI(renderSkillHudBar([{ skill: "ralplan", phase: "planning" }], 80) ?? "");
+		const rendered = renderHudText([{ skill: "ralplan", phase: "planning" }], 80);
 		expect(rendered).toContain("ralplan:planning");
 		expect(rendered).not.toContain("ultragoal");
 	});
@@ -197,29 +228,27 @@ describe("skill HUD bar renderer", () => {
 		// `gjc ralplan` then `gjc ultragoal` activate their own rows without
 		// running the handoff verb, so both arrive at the HUD active. Only the
 		// current (newest) stage should render.
-		const rendered = Bun.stripANSI(
-			renderSkillHudBar(
-				[
-					{ skill: "ralplan", phase: "final", active: true, updated_at: "2026-01-01T00:00:00.000Z" },
-					{ skill: "ultragoal", phase: "executing", active: true, updated_at: "2026-01-01T00:05:00.000Z" },
-				],
-				80,
-			) ?? "",
+		const rendered = renderHudText(
+			[
+				{ skill: "ralplan", phase: "final", active: true, updated_at: "2026-01-01T00:00:00.000Z" },
+				{ skill: "ultragoal", phase: "executing", active: true, updated_at: "2026-01-01T00:05:00.000Z" },
+			],
+			80,
 		);
+
 		expect(rendered).toContain("ultragoal:executing");
 		expect(rendered).not.toContain("ralplan");
 	});
 
 	it("keeps team alongside ultragoal since team is not part of the planning pipeline", () => {
-		const rendered = Bun.stripANSI(
-			renderSkillHudBar(
-				[
-					{ skill: "ultragoal", phase: "executing", active: true, updated_at: "2026-01-01T00:00:00.000Z" },
-					{ skill: "team", phase: "running", active: true, updated_at: "2026-01-01T00:05:00.000Z" },
-				],
-				80,
-			) ?? "",
+		const rendered = renderHudText(
+			[
+				{ skill: "ultragoal", phase: "executing", active: true, updated_at: "2026-01-01T00:00:00.000Z" },
+				{ skill: "team", phase: "running", active: true, updated_at: "2026-01-01T00:05:00.000Z" },
+			],
+			80,
 		);
+
 		expect(rendered).toContain("ultragoal:executing");
 		expect(rendered).toContain("team:running");
 	});
@@ -229,8 +258,9 @@ describe("skill HUD bar renderer", () => {
 			{ skill: "ralplan", phase: "final", active: true },
 			{ skill: "ultragoal", phase: "executing", active: true, updated_at: "2026-01-01T00:05:00.000Z" },
 		];
-		const forward = Bun.stripANSI(renderSkillHudBar(entries, 80) ?? "");
-		const reversed = Bun.stripANSI(renderSkillHudBar([...entries].reverse(), 80) ?? "");
+		const forward = renderHudText(entries, 80);
+		const reversed = renderHudText([...entries].reverse(), 80);
+
 		expect(forward).toContain("ultragoal:executing");
 		expect(forward).not.toContain("ralplan");
 		expect(reversed).toContain("ultragoal:executing");
@@ -238,15 +268,14 @@ describe("skill HUD bar renderer", () => {
 	});
 
 	it("renders a single deterministic pipeline stage when no entry has a timestamp", () => {
-		const rendered = Bun.stripANSI(
-			renderSkillHudBar(
-				[
-					{ skill: "ralplan", phase: "final", active: true },
-					{ skill: "ultragoal", phase: "executing", active: true },
-				],
-				80,
-			) ?? "",
+		const rendered = renderHudText(
+			[
+				{ skill: "ralplan", phase: "final", active: true },
+				{ skill: "ultragoal", phase: "executing", active: true },
+			],
+			80,
 		);
+
 		// Exactly one planning-pipeline entry survives the collapse.
 		expect(rendered).toContain("ultragoal:executing");
 		expect(rendered).not.toContain("ralplan:final");
@@ -255,9 +284,7 @@ describe("skill HUD bar renderer", () => {
 	it("does not emit warn:stale for an entry without explicit stale flag (no 24h derivation)", () => {
 		// Pre-G003 the renderer relied on withDerivedStale to flag aged entries.
 		// Post-G003, only explicit `entry.stale === true` produces the chip.
-		const rendered = Bun.stripANSI(
-			renderSkillHudBar([{ skill: "team", phase: "running", updated_at: "2000-01-01T00:00:00.000Z" }], 80) ?? "",
-		);
+		const rendered = renderHudText([{ skill: "team", phase: "running", updated_at: "2000-01-01T00:00:00.000Z" }], 80);
 		expect(rendered).toContain("team:running");
 		expect(rendered).not.toContain("warn:stale");
 	});

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -419,9 +419,33 @@ describe("status line multi-row wrapping (statusLine.maxRows)", () => {
 			{ skill: "autoresearch", phase: "research" },
 		]);
 		const rows = component.render(20);
-		const hudRows = rows.filter(row => strip(row).includes("◆"));
+		const hudRows = rows.filter(row => /deep-interview|autoresearch/.test(strip(row)));
 		expect(hudRows.length).toBe(2);
-		expect(hudRows.every(row => visibleWidth(row) <= 20)).toBe(true);
+		expect(hudRows.every(row => !row.includes("\n") && visibleWidth(row) <= 20)).toBe(true);
+	});
+
+	it("keeps a long single HUD entry as separate pinned rows", () => {
+		const component = buildComponent(2);
+		component.updateSettings({ showSkillHud: true });
+		component.setSkillHudEntriesForTest([
+			{
+				skill: "ultragoal",
+				phase: "executing",
+				hud: {
+					version: 1,
+					summary: "long-running aggregate execution",
+					chips: [
+						{ label: "goals", value: "1/2", priority: 10 },
+						{ label: "current", value: "G002:Stabilize long HUD wrapping", priority: 20 },
+						{ label: "ledger", value: "goal_started:2026-08-22T02:27:00.000Z", priority: 30 },
+					],
+				},
+			},
+		]);
+		const rows = component.render(100);
+		const hudRows = rows.filter(row => /ultragoal|long-running|current=|ledger=/.test(strip(row)));
+		expect(hudRows).toHaveLength(2);
+		expect(hudRows.every(row => !row.includes("\n") && visibleWidth(row) <= 100)).toBe(true);
 	});
 
 	it("caps wrapping at maxRows", () => {


### PR DESCRIPTION
## What

Fix long skill-HUD content so it renders as independent, bounded terminal rows without corrupting the bottom-pinned TUI.

## Why

Long HUD entries previously crossed the status-line row contract and could overwrite/corrupt the composer. The renderer now keeps the full row lifecycle newline-free and preserves severity symbols at narrow widths.

## Testing

- `bun test packages/coding-agent/test/skill-hud-bar.test.ts packages/coding-agent/test/status-line-overflow.test.ts packages/coding-agent/test/status-line-cache.test.ts packages/coding-agent/test/status-line-cache-redteam.test.ts packages/coding-agent/test/workflow-hud-autoresearch.test.ts packages/coding-agent/test/workflow-hud-summary.test.ts packages/coding-agent/test/gjc-runtime/autoresearch-runtime.test.ts packages/tui/test/bottom-pinned-layout.test.ts packages/tui/test/render-loop-resilience.test.ts` — 111 passed.
- Biome check and `git diff --check` passed.
- Direct ASCII fallback and initialized-theme severity sweeps passed at widths 1–8.
- `bun --cwd=packages/coding-agent run check:types` remains blocked by the pre-existing missing `docs-index.generated` modules.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:6657c1592846886e251ed94edc3c0320ede1c56829bfaed195b7cd92269cdf07 reviewer:human reviewer-id:Yeachan-Heo evidence:owner-reviewed exact-head regression fix; focused tests and TUI probes pass
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (blocked by the pre-existing missing generated docs-index modules)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

## Self-review record

The exact-head owner risk record is posted as a separate signed PR comment for the `merge-self-approved` path.