### PR TITLE
fix(cursor): sync upstream request and transport contracts

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+
+### Fixed
+
+- Cursor `requestContext` rules now forward normalized system prompts, Cursor HTTP/2 transport honors standard proxy environment variables, and GPT effort siblings are sent as their base model with the corresponding reasoning parameter.
+
 - A failed dynamic-model refresh no longer blanks a legacy cache row in an unbound provider context. `resolveProviderModels` only reused the last-known rows when the latest cache row was provenance-bound to the current discovery context, so a provider that supplies no `cacheDynamicModelProvenance` (e.g. the Codex family) lost every cached model on a refresh failure AND had its row overwritten with an empty snapshot — the stale-while-error fallback the surrounding code documents never applied to it. Legacy rows now serve through a failed refresh whenever the request context is unbound; bound contexts still fail closed on foreign rows.
 - Added OpenRouter as an API-key login provider in `/login` (`openrouter`). Pasting an `sk-or-v1-...` key validates against `https://openrouter.ai/api/v1` (`openrouter/auto` chat completion probe) and stores a reusable `OPENROUTER_API_KEY` credential, closing the gap where OpenRouter had catalog/env support but no interactive login entry point.
 - Fixed `/logout` (and `gjc accounts logout`) silently ignoring stored API-key credentials. Removal-target enumeration and hard removal were both scoped to `credential_type = 'oauth'` rows, so API-key logins (OpenCode Go/Zen, Cursor, Venice, DeepSeek, …) could never be removed and the flow answered `API-key credentials are not managed here`. Removal targets now include every stored row, `removeAuthCredentialsHard` accepts non-OAuth rows, and the interactive/CLI logout removes stored credentials of either kind.

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -29,6 +29,7 @@ import { normalizeSystemPrompts } from "../utils";
 import { kCursorExecResolved } from "../utils/block-symbols";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { findUnnecessaryUnicodeEscape, parseStreamingJson } from "../utils/json-parse";
+import { connectProxiedSocket, getProxyForUrl } from "../utils/proxy";
 import { formatErrorMessageWithRetryAfter } from "../utils/retry-after";
 import { flattenToolRootCombinators, toolWireSchema } from "../utils/schema";
 import { CURSOR_COMPOSER_EDIT_DISCIPLINE_PROMPT, isComposerHarnessModel } from "./composer-discipline";
@@ -59,7 +60,7 @@ import {
 	piReadDisplayPath,
 	piTimeout,
 } from "./cursor/exec-modern";
-import type { McpToolDefinition } from "./cursor/gen/agent_pb";
+import type { CursorRule, McpToolDefinition, RequestedModel_ModelParameterbytes } from "./cursor/gen/agent_pb";
 import {
 	AgentClientMessageSchema,
 	AgentConversationTurnStructureSchema,
@@ -75,6 +76,10 @@ import {
 	ConversationStateStructureSchema,
 	ConversationStepSchema,
 	ConversationTurnStructureSchema,
+	CursorRuleSchema,
+	CursorRuleSource,
+	CursorRuleTypeGlobalSchema,
+	CursorRuleTypeSchema,
 	DeleteErrorSchema,
 	DeleteRejectedSchema,
 	DeleteResultSchema,
@@ -134,6 +139,8 @@ import {
 	RequestContextResultSchema,
 	RequestContextSchema,
 	RequestContextSuccessSchema,
+	RequestedModel_ModelParameterbytesSchema,
+	RequestedModelSchema,
 	ResumeActionSchema,
 	SelectedContextSchema,
 	SelectedImageSchema,
@@ -364,12 +371,82 @@ function omitTypeName(record: Record<string, unknown>): Record<string, unknown> 
 	return rest;
 }
 
+const CURSOR_MODEL_EFFORT_RE = /^(.*)-(minimal|low|medium|high|xhigh|max)(-fast)?$/;
+const CURSOR_GPT_MODEL_RE =
+	/^gpt-\d+(?:\.\d+){0,2}(?:-(?:codex-spark|codex-mini|codex-max|codex|luna|mini|max|nano|sol|terra))?$/;
+// `codex-max` is itself an intrinsic Cursor model, not an effort suffix. Keep
+// its canonical and canonical-fast forms intact before parsing effort aliases.
+const CURSOR_INTRINSIC_CODEX_MAX_RE = /^gpt-\d+(?:\.\d+){0,2}-codex-max(?:-fast)?$/;
+
+/** Build the ordered global USER rules Cursor expects for the current system prompt. */
+export function buildCursorRequestContextRules(systemPrompt: readonly string[] | undefined): CursorRule[] {
+	return normalizeSystemPrompts(systemPrompt).map((content, index) =>
+		create(CursorRuleSchema, {
+			fullPath: `/gjc/system-prompt/${index}.mdc`,
+			content,
+			type: create(CursorRuleTypeSchema, {
+				type: {
+					case: "global",
+					value: create(CursorRuleTypeGlobalSchema, {}),
+				},
+			}),
+			source: CursorRuleSource.USER,
+		}),
+	);
+}
+
+export interface CursorWireModelResolution {
+	modelId: string;
+	parameters: RequestedModel_ModelParameterbytes[];
+	translated: boolean;
+}
+
+/** Resolve a Cursor model's GPT effort suffix into its wire model and parameter. */
+export function resolveCursorWireModelForTest(
+	model: Pick<Model<"cursor-agent">, "id" | "wireModelId">,
+): CursorWireModelResolution {
+	const wireModelId = model.wireModelId ?? model.id;
+	if (CURSOR_INTRINSIC_CODEX_MAX_RE.test(wireModelId)) {
+		return { modelId: wireModelId, parameters: [], translated: false };
+	}
+	const match = CURSOR_MODEL_EFFORT_RE.exec(wireModelId);
+	if (!match || !CURSOR_GPT_MODEL_RE.test(match[1])) {
+		return { modelId: wireModelId, parameters: [], translated: false };
+	}
+
+	const [, baseModelId, effort, fastSuffix] = match;
+	const modelId = `${baseModelId}${fastSuffix ?? ""}`;
+	return {
+		modelId,
+		parameters: [
+			create(RequestedModel_ModelParameterbytesSchema, {
+				id: "reasoning",
+				value: effort,
+			}),
+		],
+		translated: true,
+	};
+}
+
+/** Turn Cursor's opaque HTTP/2 failure into a useful transport diagnosis. */
+export function mapH2TransportError(error: unknown, baseUrl: string): unknown {
+	if (!error || typeof error !== "object") return error;
+	const candidate = error as { code?: unknown; message?: unknown };
+	if (candidate.code !== "ERR_HTTP2_ERROR" || typeof candidate.message !== "string") return error;
+	if (!/h2 is not supported/i.test(candidate.message)) return error;
+	return new Error(
+		`Cursor HTTP/2 is not supported by ${baseUrl}. Use an HTTP/2-capable endpoint, configure a proxy tunnel that preserves ALPN h2, or set providers.cursor.baseUrl to an HTTP/2 endpoint.`,
+		{ cause: error },
+	);
+}
+
 export const streamCursor: StreamFunction<"cursor-agent"> = (
 	model: Model<"cursor-agent">,
 	context: Context,
 	options?: CursorOptions,
 ): AssistantMessageEventStream => {
 	const stream = new AssistantMessageEventStream();
+	const requestContextRules = buildCursorRequestContextRules(context.systemPrompt);
 
 	(async () => {
 		const startTime = Date.now();
@@ -395,12 +472,50 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 
 		let h2Client: http2.ClientHttp2Session | null = null;
 		let h2Request: http2.ClientHttp2Stream | null = null;
+		let proxiedSocket: Awaited<ReturnType<typeof connectProxiedSocket>> | null = null;
 		let heartbeatTimer: NodeJS.Timeout | null = null;
+		let h2ClientErrorHandler: ((error: Error) => void) | undefined;
+		let h2RequestErrorHandler: ((error: Error) => void) | undefined;
+		let onAbort: (() => void) | undefined;
+		const baseUrl = model.baseUrl || CURSOR_API_URL;
+		const h2Completion = Promise.withResolvers<void>();
+		h2Completion.promise.catch(() => {});
+		let h2Settled = false;
+		let h2Failure: unknown;
+		let sawTurnEnded = false;
+		let responseEnded = false;
+		let queueDrained = false;
+		let endStreamError: Error | null = null;
+		const settleH2 = (error?: unknown): void => {
+			if (h2Settled) return;
+			h2Settled = true;
+			if (error !== undefined) {
+				h2Failure = mapH2TransportError(error, baseUrl);
+				h2Completion.reject(h2Failure);
+			} else {
+				h2Completion.resolve();
+			}
+		};
+		const settleH2WhenReady = (): void => {
+			if (!queueDrained) return;
+			if (endStreamError) {
+				settleH2(endStreamError);
+			} else if (sawTurnEnded) {
+				// A drained turnEnded is the successful terminal condition; Cursor
+				// may leave the HTTP/2 response open after sending it.
+				settleH2();
+			} else if (responseEnded) {
+				settleH2(new Error("Cursor HTTP/2 stream ended before turnEnded"));
+			}
+		};
 
 		try {
 			const apiKey = options?.apiKey;
 			if (!apiKey) {
 				throw new Error("Cursor API key (access token) is required");
+			}
+			if (options?.signal?.aborted) {
+				throw new Error("Request was aborted");
 			}
 
 			const conversationId = options?.conversationId ?? options?.sessionId ?? crypto.randomUUID();
@@ -415,9 +530,22 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			conversationStateCache.set(conversationId, conversationState);
 			touchCursorConversation(conversationId);
 			const requestContextTools = buildMcpToolDefinitions(context.tools);
-
-			const baseUrl = model.baseUrl || CURSOR_API_URL;
-			h2Client = http2.connect(baseUrl);
+			const targetUrl = new URL(baseUrl);
+			const proxyUrl = getProxyForUrl(model.provider, targetUrl);
+			if (options?.signal?.aborted) {
+				throw new Error("Request was aborted");
+			}
+			if (proxyUrl) {
+				proxiedSocket = await connectProxiedSocket(proxyUrl, baseUrl, {
+					signal: options?.signal,
+					timeoutMs: 30_000,
+				});
+				h2Client = http2.connect(baseUrl, { createConnection: () => proxiedSocket! });
+			} else {
+				h2Client = http2.connect(baseUrl);
+			}
+			h2ClientErrorHandler = error => settleH2(error);
+			h2Client.on("error", h2ClientErrorHandler);
 
 			h2Request = h2Client.request({
 				":method": "POST",
@@ -431,11 +559,12 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 				"x-cursor-client-type": "cli",
 				"x-request-id": crypto.randomUUID(),
 			});
+			h2RequestErrorHandler = error => settleH2(error);
+			h2Request.on("error", h2RequestErrorHandler);
 
 			stream.push({ type: "start", partial: output });
 
 			let pendingBuffer = Buffer.alloc(0);
-			let endStreamError: Error | null = null;
 			let currentTextBlock: (TextContent & { index: number }) | null = null;
 			let currentThinkingBlock: (ThinkingContent & { index: number }) | null = null;
 			let currentToolCall: ToolCallState | null = null;
@@ -473,11 +602,43 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 				touchCursorConversation(conversationId);
 			};
 
-			let resolveH2: (() => void) | undefined;
-			let rejectH2: ((error: unknown) => void) | undefined;
 			const messageQueue = createCursorMessageQueueForTest(error => {
 				log("error", "handleServerMessage", { error: String(error) });
 			});
+			const drainMessageQueue = (): void => {
+				void messageQueue.drain().then(
+					() => {
+						queueDrained = true;
+						settleH2WhenReady();
+					},
+					error => {
+						queueDrained = true;
+						settleH2(error);
+					},
+				);
+			};
+
+			h2Request.on("trailers", trailers => {
+				const status = trailers["grpc-status"];
+				const msg = trailers["grpc-message"];
+				if (status && status !== "0") {
+					settleH2(new Error(`gRPC error ${status}: ${decodeURIComponent(String(msg || ""))}`));
+				}
+			});
+			h2Request.on("end", () => {
+				responseEnded = true;
+				drainMessageQueue();
+			});
+			onAbort = () => {
+				h2Request?.close();
+				h2Client?.close();
+				proxiedSocket?.destroy();
+				settleH2(new Error("Request was aborted"));
+			};
+			if (options?.signal) {
+				options.signal.addEventListener("abort", onAbort, { once: true });
+				if (options.signal.aborted) onAbort();
+			}
 
 			h2Request.on("data", (chunk: Buffer) => {
 				pendingBuffer = Buffer.concat([pendingBuffer, chunk]);
@@ -491,10 +652,14 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 					pendingBuffer = pendingBuffer.subarray(5 + msgLen);
 
 					if (flags & CONNECT_END_STREAM_FLAG) {
+						responseEnded = true;
 						const endError = parseConnectEndStream(messageBytes);
 						if (endError) {
 							endStreamError = endError;
+							settleH2(endError);
 							h2Request?.close();
+						} else {
+							drainMessageQueue();
 						}
 						continue;
 					}
@@ -519,20 +684,13 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 								usageState,
 								requestContextTools,
 								onConversationCheckpoint,
+								requestContextRules,
 							),
 						);
 
-						// Resolve only on explicit turnEnded. stopReason defaults to "stop"
-						// and is not a reliable signal for stream completion.
 						if (isTurnEnded) {
-							messageQueue.drain().then(() => {
-								if (resolveH2) {
-									const r = resolveH2;
-									resolveH2 = undefined;
-									rejectH2 = undefined;
-									r();
-								}
-							});
+							sawTurnEnded = true;
+							drainMessageQueue();
 						}
 					} catch (e) {
 						log("error", "parseServerMessage", { error: String(e) });
@@ -540,6 +698,9 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 				}
 			});
 
+			if (h2Settled) {
+				await h2Completion.promise;
+			}
 			h2Request.write(frameConnectMessage(requestBytes));
 
 			const sendHeartbeat = () => {
@@ -554,39 +715,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			};
 
 			heartbeatTimer = setInterval(sendHeartbeat, 5000);
-
-			await new Promise<void>((resolve, reject) => {
-				resolveH2 = resolve;
-				rejectH2 = reject;
-
-				h2Request!.on("trailers", trailers => {
-					const status = trailers["grpc-status"];
-					const msg = trailers["grpc-message"];
-					if (status && status !== "0") {
-						reject(new Error(`gRPC error ${status}: ${decodeURIComponent(String(msg || ""))}`));
-					}
-				});
-
-				h2Request!.on("end", () => {
-					messageQueue.drain().then(() => {
-						resolveH2 = undefined;
-						rejectH2 = undefined;
-						if (endStreamError) reject(endStreamError);
-						else resolve();
-					});
-				});
-
-				h2Request!.on("error", error => {
-					if (rejectH2) rejectH2(error);
-				});
-
-				if (options?.signal) {
-					options.signal.addEventListener("abort", () => {
-						h2Request?.close();
-						reject(new Error("Request was aborted"));
-					});
-				}
-			});
+			await h2Completion.promise;
 
 			if (state.currentTextBlock) {
 				const idx = output.content.indexOf(state.currentTextBlock);
@@ -633,9 +762,13 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			});
 			stream.end();
 		} catch (error) {
+			// Keep the completion promise terminal even for synchronous setup/write
+			// failures that may not emit a separate HTTP/2 error event.
+			if (!h2Settled) settleH2(error);
+			const mappedError = h2Failure ?? error;
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorStatus = extractHttpStatusFromError(error);
-			output.errorMessage = formatErrorMessageWithRetryAfter(error);
+			output.errorStatus = extractHttpStatusFromError(mappedError);
+			output.errorMessage = formatErrorMessageWithRetryAfter(mappedError);
 			output.duration = Date.now() - startTime;
 			if (firstTokenTime) output.ttft = firstTokenTime - startTime;
 			stream.push({ type: "error", reason: output.stopReason, error: output });
@@ -645,8 +778,18 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 				clearInterval(heartbeatTimer);
 				heartbeatTimer = null;
 			}
+			if (options?.signal && onAbort) {
+				options.signal.removeEventListener("abort", onAbort);
+			}
+			if (h2Request && h2RequestErrorHandler) {
+				h2Request.removeListener("error", h2RequestErrorHandler);
+			}
+			if (h2Client && h2ClientErrorHandler) {
+				h2Client.removeListener("error", h2ClientErrorHandler);
+			}
 			h2Request?.close();
 			h2Client?.close();
+			proxiedSocket?.destroy();
 		}
 	})();
 
@@ -687,6 +830,7 @@ async function handleServerMessage(
 	usageState: UsageState,
 	requestContextTools: McpToolDefinition[],
 	onConversationCheckpoint?: (checkpoint: ConversationStateStructure) => void,
+	requestContextRules: CursorRule[] = [],
 ): Promise<void> {
 	const msgCase = msg.message.case;
 
@@ -705,6 +849,7 @@ async function handleServerMessage(
 			requestContextTools,
 			output,
 			stream,
+			requestContextRules,
 		);
 	} else if (msgCase === "conversationCheckpointUpdate") {
 		handleConversationCheckpointUpdate(msg.message.value, output, usageState, onConversationCheckpoint);
@@ -1063,12 +1208,13 @@ async function handleExecServerMessage(
 	requestContextTools: McpToolDefinition[],
 	output: AssistantMessage,
 	stream: AssistantMessageEventStream,
+	requestContextRules: CursorRule[] = [],
 ): Promise<void> {
 	const execCase = execMsg.message.case;
 	log("exec", "dispatch", { execCase, execId: execMsg.execId, hasHandlers: !!execHandlers });
 	if (execCase === "requestContextArgs") {
 		const requestContext = create(RequestContextSchema, {
-			rules: [],
+			rules: requestContextRules,
 			repositoryInfo: [],
 			tools: requestContextTools,
 			gitRepos: [],
@@ -3034,8 +3180,9 @@ function buildGrpcRequest(
 		turns,
 	});
 
+	const resolvedModel = resolveCursorWireModelForTest(model);
 	const modelDetails = create(ModelDetailsSchema, {
-		modelId: model.id,
+		modelId: resolvedModel.modelId,
 		displayModelId: model.id,
 		displayName: model.name,
 	});
@@ -3045,6 +3192,14 @@ function buildGrpcRequest(
 		action,
 		modelDetails,
 		conversationId: state.conversationId,
+		...(resolvedModel.translated
+			? {
+					requestedModel: create(RequestedModelSchema, {
+						modelId: resolvedModel.modelId,
+						parameters: resolvedModel.parameters,
+					}),
+				}
+			: {}),
 	});
 
 	options?.onPayload?.(runRequest, model, options?.attemptScope);

--- a/packages/ai/src/utils/proxy.ts
+++ b/packages/ai/src/utils/proxy.ts
@@ -1,0 +1,652 @@
+import * as net from "node:net";
+import * as tls from "node:tls";
+
+export interface ProxyConnectOptions {
+	signal?: AbortSignal;
+	timeoutMs?: number;
+}
+
+const CONNECT_HEADER_LIMIT = 64 * 1024;
+const CLOUD_METADATA_HOSTS: Record<string, true> = {
+	metadata: true,
+	"metadata.aws": true,
+	"metadata.aws.internal": true,
+	"metadata.azure": true,
+	"metadata.azure.com": true,
+	"metadata.azure.internal": true,
+	"metadata.google": true,
+	"metadata.google.internal": true,
+	"metadata.oraclecloud.com": true,
+	"instance-data": true,
+	"instance-data.ec2.internal": true,
+	"100.100.100.100": true,
+	"100.100.100.200": true,
+	"169.254.169.254": true,
+};
+
+class ProxyTransportError extends Error {
+	readonly name = "ProxyTransportError";
+}
+
+function transportError(message: string): ProxyTransportError {
+	return new ProxyTransportError(message);
+}
+
+function normalizeProvider(provider: string): string {
+	return provider
+		.trim()
+		.toUpperCase()
+		.replace(/[^A-Z0-9]+/g, "_")
+		.replace(/^_+|_+$/g, "");
+}
+
+function firstEnvValue(...names: string[]): string | undefined {
+	for (const name of names) {
+		const value = process.env[name];
+		if (value?.trim()) return value.trim();
+	}
+	return undefined;
+}
+
+function normalizeHost(hostname: string): string {
+	return hostname
+		.trim()
+		.replace(/^\[|\]$/g, "")
+		.replace(/\.$/, "")
+		.toLowerCase();
+}
+
+function defaultPortForProtocol(protocol: string): number | undefined {
+	if (protocol === "https:") return 443;
+	if (protocol === "http:") return 80;
+	return undefined;
+}
+
+function effectiveUrlPort(url: URL): number | undefined {
+	if (url.port) {
+		const port = Number(url.port);
+		return Number.isInteger(port) && port >= 1 && port <= 65_535 ? port : undefined;
+	}
+	return defaultPortForProtocol(url.protocol);
+}
+
+function parseIPv4(host: string): [number, number, number, number] | undefined {
+	if (net.isIP(host) !== 4) return undefined;
+	const parts = host.split(".");
+	if (parts.length !== 4) return undefined;
+	const numbers = parts.map(part => Number(part));
+	if (numbers.some(part => !Number.isInteger(part) || part < 0 || part > 255)) return undefined;
+	return numbers as [number, number, number, number];
+}
+
+function parseIPv6(host: string): Uint8Array | undefined {
+	if (net.isIP(host) !== 6) return undefined;
+	const withoutZone = host.split("%", 1)[0] ?? host;
+	let value = withoutZone;
+
+	// IPv4 tails are represented by the final two IPv6 hextets.
+	const lastColon = value.lastIndexOf(":");
+	const lastDot = value.lastIndexOf(".");
+	if (lastDot > lastColon) {
+		const ipv4 = value.slice(lastColon + 1);
+		const parsed = parseIPv4(ipv4);
+		if (!parsed) return undefined;
+		const [a, b, c, d] = parsed;
+		value = `${value.slice(0, lastColon + 1)}${((a << 8) | b).toString(16)}:${((c << 8) | d).toString(16)}`;
+	}
+
+	const doubleColon = value.indexOf("::");
+	if (doubleColon !== value.lastIndexOf("::")) return undefined;
+
+	const parseHextets = (part: string): number[] => {
+		if (!part) return [];
+		const hextets = part.split(":");
+		if (hextets.some(hextet => !/^[0-9a-f]{1,4}$/i.test(hextet))) return [];
+		return hextets.map(hextet => Number.parseInt(hextet, 16));
+	};
+
+	let hextets: number[];
+	if (doubleColon >= 0) {
+		const left = parseHextets(value.slice(0, doubleColon));
+		const right = parseHextets(value.slice(doubleColon + 2));
+		if (
+			(!left.length && value.slice(0, doubleColon) !== "") ||
+			(!right.length && value.slice(doubleColon + 2) !== "")
+		) {
+			return undefined;
+		}
+		const missing = 8 - left.length - right.length;
+		if (missing < 1) return undefined;
+		hextets = [...left, ...new Array<number>(missing).fill(0), ...right];
+	} else {
+		hextets = parseHextets(value);
+		if (hextets.length !== 8) return undefined;
+	}
+	if (hextets.length !== 8) return undefined;
+
+	const bytes = new Uint8Array(16);
+	for (let index = 0; index < hextets.length; index++) {
+		bytes[index * 2] = hextets[index]! >> 8;
+		bytes[index * 2 + 1] = hextets[index]! & 0xff;
+	}
+	return bytes;
+}
+
+function isPrivateOrLocalHost(hostname: string): boolean {
+	const host = normalizeHost(hostname);
+	if (!host) return false;
+	if (
+		host === "localhost" ||
+		host.endsWith(".localhost") ||
+		host === "localhost.localdomain" ||
+		host.endsWith(".localhost.localdomain")
+	)
+		return true;
+	if (Object.hasOwn(CLOUD_METADATA_HOSTS, host)) return true;
+
+	const ipv4 = parseIPv4(host);
+	if (ipv4) {
+		const [first, second] = ipv4;
+		return (
+			first === 0 ||
+			first === 10 ||
+			(first === 172 && second >= 16 && second <= 31) ||
+			(first === 192 && second === 168) ||
+			first === 127 ||
+			(first === 169 && second === 254)
+		);
+	}
+
+	const ipv6 = parseIPv6(host);
+	if (!ipv6) return false;
+
+	// IPv4-mapped IPv6 addresses retain the local/private classification of IPv4.
+	const isMapped = ipv6.slice(0, 10).every(byte => byte === 0) && ipv6[10] === 0xff && ipv6[11] === 0xff;
+	if (isMapped) {
+		const mapped = `${ipv6[12]}.${ipv6[13]}.${ipv6[14]}.${ipv6[15]}`;
+		return isPrivateOrLocalHost(mapped);
+	}
+
+	const isUnspecified = ipv6.every(byte => byte === 0);
+	const isLoopback = ipv6.slice(0, 15).every(byte => byte === 0) && ipv6[15] === 1;
+	const isLinkLocal = ipv6[0] === 0xfe && (ipv6[1]! & 0xc0) === 0x80;
+	const isUniqueLocal = (ipv6[0]! & 0xfe) === 0xfc;
+	return isUnspecified || isLoopback || isLinkLocal || isUniqueLocal;
+}
+
+interface NoProxyRule {
+	host: string;
+	port?: number;
+	wildcard: boolean;
+}
+
+function parseNoProxyRule(rawRule: string): NoProxyRule | undefined {
+	const rule = rawRule.trim().toLowerCase();
+	if (!rule) return undefined;
+
+	let host: string;
+	let portText: string | undefined;
+	if (rule.startsWith("[")) {
+		const closingBracket = rule.indexOf("]");
+		if (closingBracket < 0) return undefined;
+		host = rule.slice(1, closingBracket);
+		const suffix = rule.slice(closingBracket + 1);
+		if (suffix) {
+			if (!suffix.startsWith(":")) return undefined;
+			portText = suffix.slice(1);
+		}
+	} else {
+		const colon = rule.lastIndexOf(":");
+		if (colon >= 0 && rule.indexOf(":") === colon) {
+			const possiblePort = rule.slice(colon + 1);
+			if (/^\d+$/.test(possiblePort) || possiblePort === "*") {
+				host = rule.slice(0, colon);
+				portText = possiblePort;
+			} else {
+				host = rule;
+			}
+		} else {
+			host = rule;
+		}
+	}
+
+	const wildcard = host === "*" || host === "*.";
+	if (wildcard) {
+		if (portText && portText !== "*" && !/^\d+$/.test(portText)) return undefined;
+		const port = portText && portText !== "*" ? Number(portText) : undefined;
+		if (port !== undefined && (!Number.isInteger(port) || port < 1 || port > 65_535)) return undefined;
+		return { host: "*", port, wildcard: true };
+	}
+
+	if (host.startsWith("*.")) host = host.slice(1);
+	if (host.startsWith(".")) host = host.slice(1);
+	host = normalizeHost(host);
+	if (!host) return undefined;
+
+	let port: number | undefined;
+	if (portText && portText !== "*") {
+		if (!/^\d+$/.test(portText)) return undefined;
+		port = Number(portText);
+		if (!Number.isInteger(port) || port < 1 || port > 65_535) return undefined;
+	}
+	return { host, port, wildcard: false };
+}
+
+function matchesNoProxy(hostname: string, port: number | undefined): boolean {
+	const noProxy = firstEnvValue("NO_PROXY", "no_proxy");
+	if (!noProxy) return false;
+	const host = normalizeHost(hostname);
+
+	for (const rawRule of noProxy.split(",")) {
+		const rule = parseNoProxyRule(rawRule);
+		if (!rule) continue;
+		if (rule.port !== undefined && rule.port !== port) continue;
+		if (rule.wildcard) return true;
+		if (host === rule.host || host.endsWith(`.${rule.host}`)) return true;
+	}
+	return false;
+}
+
+export function getProxyForUrl(provider: string, url: URL): string | undefined {
+	const hostname = normalizeHost(url.hostname);
+	if (!hostname || isPrivateOrLocalHost(hostname) || matchesNoProxy(hostname, effectiveUrlPort(url))) return undefined;
+
+	const normalizedProvider = normalizeProvider(provider);
+	const protocolProxy =
+		url.protocol === "https:"
+			? firstEnvValue("HTTPS_PROXY", "https_proxy")
+			: url.protocol === "http:"
+				? firstEnvValue("HTTP_PROXY", "http_proxy")
+				: undefined;
+	const candidates = [
+		normalizedProvider ? process.env[`PI_PROXY_${normalizedProvider}`] : undefined,
+		process.env.PI_PROXY,
+		protocolProxy,
+		firstEnvValue("ALL_PROXY", "all_proxy"),
+	];
+	for (const candidate of candidates) {
+		if (candidate?.trim()) return candidate.trim();
+	}
+	return undefined;
+}
+
+function formatAuthority(hostname: string, port: number): string {
+	const host = normalizeHost(hostname);
+	return net.isIP(host) === 6 ? `[${host}]:${port}` : `${host}:${port}`;
+}
+
+function tlsServerName(hostname: string): string | undefined {
+	const host = normalizeHost(hostname);
+	return host && net.isIP(host) === 0 ? host : undefined;
+}
+
+interface ParsedProxyUrl {
+	protocol: "http:" | "https:";
+	hostname: string;
+	port: number;
+	username: string;
+	password: string;
+}
+
+function parseProxyUrl(value: string): ParsedProxyUrl {
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		throw transportError("Invalid proxy URL");
+	}
+	if (url.protocol !== "http:" && url.protocol !== "https:") throw transportError("Unsupported proxy protocol");
+	const hostname = normalizeHost(url.hostname);
+	const port = url.port ? Number(url.port) : url.protocol === "https:" ? 443 : 80;
+	if (!hostname || !Number.isInteger(port) || port < 1 || port > 65_535) throw transportError("Invalid proxy address");
+	return { protocol: url.protocol, hostname, port, username: url.username, password: url.password };
+}
+
+interface ParsedTargetUrl {
+	hostname: string;
+	port: number;
+	authority: string;
+	servername?: string;
+}
+
+function parseTargetUrl(value: string): ParsedTargetUrl {
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		throw transportError("Invalid target URL");
+	}
+	const hostname = normalizeHost(url.hostname);
+	const port = url.port ? Number(url.port) : defaultPortForProtocol(url.protocol);
+	if (!hostname || port === undefined || !Number.isInteger(port) || port < 1 || port > 65_535) {
+		throw transportError("Invalid target address");
+	}
+	return { hostname, port, authority: formatAuthority(hostname, port), servername: tlsServerName(hostname) };
+}
+
+function decodeProxyCredential(value: string): string {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		throw transportError("Invalid proxy credentials");
+	}
+}
+
+function proxyAuthorization(proxy: ParsedProxyUrl): string | undefined {
+	if (!proxy.username && !proxy.password) return undefined;
+	const username = decodeProxyCredential(proxy.username);
+	const password = decodeProxyCredential(proxy.password);
+	return `Basic ${Buffer.from(`${username}:${password}`, "utf8").toString("base64")}`;
+}
+
+function waitForSocketConnect(socket: net.Socket, signal: AbortSignal): Promise<void> {
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
+	let settled = false;
+	const cleanup = () => {
+		socket.removeListener("connect", onConnect);
+		socket.removeListener("error", onError);
+		socket.removeListener("close", onClose);
+		signal.removeEventListener("abort", onAbort);
+	};
+	const succeed = () => {
+		if (settled) return;
+		settled = true;
+		cleanup();
+		resolve();
+	};
+	const fail = (error: ProxyTransportError) => {
+		if (settled) return;
+		settled = true;
+		cleanup();
+		reject(error);
+	};
+	const onConnect = () => succeed();
+	const onError = () => fail(transportError("Proxy TCP connection failed"));
+	const onClose = () => fail(transportError("Proxy TCP connection closed"));
+	const onAbort = () => {
+		cleanup();
+		if (!settled) {
+			settled = true;
+			reject(transportError("Proxy connection aborted"));
+		}
+	};
+
+	socket.once("connect", onConnect);
+	socket.once("error", onError);
+	socket.once("close", onClose);
+	signal.addEventListener("abort", onAbort, { once: true });
+	if (signal.aborted) onAbort();
+	return promise;
+}
+
+function openTcpSocket(
+	hostname: string,
+	port: number,
+	signal: AbortSignal,
+	addSocket: (socket: net.Socket) => void,
+): Promise<net.Socket> {
+	let socket: net.Socket;
+	try {
+		socket = net.connect({ host: hostname, port });
+	} catch {
+		return Promise.reject(transportError("Proxy TCP connection failed"));
+	}
+	addSocket(socket);
+	return waitForSocketConnect(socket, signal).then(() => socket);
+}
+
+function waitForTlsHandshake(socket: tls.TLSSocket, signal: AbortSignal): Promise<tls.TLSSocket> {
+	const { promise, resolve, reject } = Promise.withResolvers<tls.TLSSocket>();
+	let settled = false;
+	const cleanup = () => {
+		socket.removeListener("secureConnect", onSecureConnect);
+		socket.removeListener("error", onError);
+		socket.removeListener("close", onClose);
+		signal.removeEventListener("abort", onAbort);
+	};
+	const succeed = () => {
+		if (settled) return;
+		settled = true;
+		cleanup();
+		resolve(socket);
+	};
+	const fail = (error: ProxyTransportError) => {
+		if (settled) return;
+		settled = true;
+		cleanup();
+		reject(error);
+	};
+	const onSecureConnect = () => succeed();
+	const onError = () => fail(transportError("Proxy TLS handshake failed"));
+	const onClose = () => fail(transportError("Proxy TLS connection closed"));
+	const onAbort = () => {
+		cleanup();
+		if (!settled) {
+			settled = true;
+			reject(transportError("Proxy connection aborted"));
+		}
+	};
+
+	socket.once("secureConnect", onSecureConnect);
+	socket.once("error", onError);
+	socket.once("close", onClose);
+	signal.addEventListener("abort", onAbort, { once: true });
+	if (signal.aborted) onAbort();
+	return promise;
+}
+
+function wrapProxyTls(
+	socket: net.Socket,
+	servername: string | undefined,
+	signal: AbortSignal,
+	addSocket: (socket: net.Socket) => void,
+	alpnProtocols?: string[],
+): Promise<tls.TLSSocket> {
+	let tlsSocket: tls.TLSSocket;
+	try {
+		const options: tls.ConnectionOptions = { socket };
+		if (servername) options.servername = servername;
+		if (alpnProtocols) options.ALPNProtocols = alpnProtocols;
+		tlsSocket = tls.connect(options);
+	} catch {
+		return Promise.reject(transportError("Proxy TLS handshake failed"));
+	}
+	addSocket(tlsSocket);
+	const handshake = waitForTlsHandshake(tlsSocket, signal);
+	// CONNECT parsing pauses the socket before handing it to TLS so buffered bytes are not lost.
+	socket.resume();
+	return handshake;
+}
+
+function issueConnectRequest(
+	socket: net.Socket,
+	target: ParsedTargetUrl,
+	proxy: ParsedProxyUrl,
+	signal: AbortSignal,
+): Promise<void> {
+	const authorization = proxyAuthorization(proxy);
+	const request = [
+		`CONNECT ${target.authority} HTTP/1.1`,
+		`Host: ${target.authority}`,
+		authorization ? `Proxy-Authorization: ${authorization}` : undefined,
+		"Connection: Keep-Alive",
+		"",
+		"",
+	]
+		.filter((line): line is string => line !== undefined)
+		.join("\r\n");
+
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
+	let settled = false;
+	const response = Buffer.allocUnsafe(CONNECT_HEADER_LIMIT);
+	let responseLength = 0;
+	let headerMatchLength = 0;
+	const cleanup = () => {
+		socket.removeListener("data", onData);
+		socket.removeListener("error", onError);
+		socket.removeListener("close", onClose);
+		signal.removeEventListener("abort", onAbort);
+	};
+	const succeed = () => {
+		if (settled) return;
+		settled = true;
+		cleanup();
+		resolve();
+	};
+	const fail = (error: ProxyTransportError) => {
+		if (settled) return;
+		settled = true;
+		cleanup();
+		reject(error);
+	};
+	const onData = (bytes: Buffer) => {
+		const capacity = CONNECT_HEADER_LIMIT - responseLength;
+		const scanLength = Math.min(bytes.length, capacity);
+		let headerLength = -1;
+
+		for (let index = 0; index < scanLength; index++) {
+			const byte = bytes[index];
+			if (headerMatchLength === 0) {
+				if (byte === 0x0d) headerMatchLength = 1;
+			} else if (headerMatchLength === 1) {
+				if (byte === 0x0a) headerMatchLength = 2;
+				else if (byte !== 0x0d) headerMatchLength = 0;
+			} else if (headerMatchLength === 2) {
+				if (byte === 0x0d) headerMatchLength = 3;
+				else headerMatchLength = 0;
+			} else {
+				if (byte === 0x0a) {
+					headerLength = index + 1;
+					break;
+				}
+				if (byte === 0x0d) headerMatchLength = 1;
+				else headerMatchLength = 0;
+			}
+		}
+
+		if (headerLength < 0) {
+			if (bytes.length > capacity) {
+				fail(transportError("Proxy CONNECT response headers too large"));
+				return;
+			}
+			bytes.copy(response, responseLength);
+			responseLength += bytes.length;
+			return;
+		}
+
+		bytes.copy(response, responseLength, 0, headerLength);
+		responseLength += headerLength;
+		const headerEnd = responseLength - 4;
+		const header = response.subarray(0, responseLength);
+		const firstLineEnd = header.indexOf("\r\n");
+		const firstLine = header.subarray(0, firstLineEnd < 0 ? headerEnd : firstLineEnd).toString("latin1");
+		const statusMatch = /^HTTP\/\d(?:\.\d)?\s+(\d{3})(?:\s|$)/i.exec(firstLine);
+		if (!statusMatch) {
+			fail(transportError("Invalid proxy CONNECT response"));
+			return;
+		}
+		const status = Number(statusMatch[1]);
+		if (status !== 200) {
+			fail(transportError(`Proxy CONNECT failed with status ${status}`));
+			return;
+		}
+		socket.pause();
+		const remaining = bytes.subarray(headerLength);
+		if (remaining.length > 0) socket.unshift(remaining);
+		succeed();
+	};
+	const onError = () => fail(transportError("Proxy CONNECT failed"));
+	const onClose = () => fail(transportError("Proxy CONNECT connection closed"));
+	const onAbort = () => {
+		cleanup();
+		if (!settled) {
+			settled = true;
+			reject(transportError("Proxy connection aborted"));
+		}
+	};
+
+	socket.on("data", onData);
+	socket.once("error", onError);
+	socket.once("close", onClose);
+	signal.addEventListener("abort", onAbort, { once: true });
+	if (signal.aborted) {
+		onAbort();
+		return promise;
+	}
+	try {
+		socket.write(request);
+	} catch {
+		onError();
+	}
+	return promise;
+}
+
+export function connectProxiedSocket(
+	proxyUrl: string,
+	targetUrl: string,
+	options: ProxyConnectOptions = {},
+): Promise<tls.TLSSocket> {
+	const { promise, resolve, reject } = Promise.withResolvers<tls.TLSSocket>();
+	const sockets = new Set<net.Socket>();
+	const abortController = new AbortController();
+	const signal = abortController.signal;
+	let settled = false;
+	let timeout: NodeJS.Timeout | undefined;
+
+	const addSocket = (socket: net.Socket) => sockets.add(socket);
+	const cleanup = () => {
+		if (options.signal) options.signal.removeEventListener("abort", onAbort);
+		if (timeout !== undefined) clearTimeout(timeout);
+	};
+	const destroySockets = () => {
+		for (const socket of sockets) socket.destroy();
+		sockets.clear();
+	};
+	const fail = (message: string) => {
+		if (settled) return;
+		settled = true;
+		cleanup();
+		abortController.abort();
+		destroySockets();
+		reject(transportError(message));
+	};
+	const succeed = (socket: tls.TLSSocket) => {
+		if (settled) {
+			socket.destroy();
+			return;
+		}
+		settled = true;
+		cleanup();
+		sockets.clear();
+		resolve(socket);
+	};
+	const onAbort = () => fail("Proxy connection aborted");
+	if (options.signal?.aborted) {
+		fail("Proxy connection aborted");
+		return promise;
+	}
+	if (options.signal) options.signal.addEventListener("abort", onAbort, { once: true });
+	if (options.timeoutMs !== undefined && Number.isFinite(options.timeoutMs) && options.timeoutMs > 0) {
+		timeout = setTimeout(() => fail("Proxy connection timed out"), options.timeoutMs);
+	}
+
+	void (async () => {
+		try {
+			if (settled) return;
+			const proxy = parseProxyUrl(proxyUrl);
+			const target = parseTargetUrl(targetUrl);
+			let proxySocket: net.Socket = await openTcpSocket(proxy.hostname, proxy.port, signal, addSocket);
+			if (proxy.protocol === "https:") {
+				proxySocket = await wrapProxyTls(proxySocket, tlsServerName(proxy.hostname), signal, addSocket);
+			}
+			await issueConnectRequest(proxySocket, target, proxy, signal);
+			const targetTls = await wrapProxyTls(proxySocket, target.servername, signal, addSocket, ["h2"]);
+			succeed(targetTls);
+		} catch (error) {
+			if (settled) return;
+			const message = error instanceof ProxyTransportError ? error.message : "Proxy connection failed";
+			fail(message);
+		}
+	})();
+	return promise;
+}

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
 	buildCursorHistoryForTest,
+	buildCursorRequestContextRules,
 	buildCursorSystemPromptJsons,
 	createCursorMessageQueueForTest,
 	resolveExecHandler,
@@ -164,6 +165,38 @@ describe("Cursor server message ordering", () => {
 });
 
 describe("Cursor system prompt encoding", () => {
+	it("maps normalized prompts to ordered USER/global Cursor rules", () => {
+		const rules = buildCursorRequestContextRules(["Primary instructions.", "", "Developer constraints."]);
+
+		expect(rules).toHaveLength(2);
+		expect(
+			rules.map(rule => ({
+				fullPath: rule.fullPath,
+				content: rule.content,
+				source: rule.source,
+				type: rule.type?.type.case,
+			})),
+		).toEqual([
+			{
+				fullPath: "/gjc/system-prompt/0.mdc",
+				content: "Primary instructions.",
+				source: 2,
+				type: "global",
+			},
+			{
+				fullPath: "/gjc/system-prompt/1.mdc",
+				content: "Developer constraints.",
+				source: 2,
+				type: "global",
+			},
+		]);
+	});
+
+	it("does not emit rules for missing or empty system prompts", () => {
+		expect(buildCursorRequestContextRules(undefined)).toEqual([]);
+		expect(buildCursorRequestContextRules(["", ""])).toEqual([]);
+	});
+
 	it("emits one Cursor system blob per ordered prompt", () => {
 		const jsons = buildCursorSystemPromptJsons(["Primary instructions.", "Developer constraints."]);
 		expect(jsons).toHaveLength(2);

--- a/packages/ai/test/cursor-proxy.test.ts
+++ b/packages/ai/test/cursor-proxy.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { mapH2TransportError } from "../src/providers/cursor";
+import { getProxyForUrl } from "../src/utils/proxy";
+
+const PROXY_ENV_KEYS = [
+	"PI_PROXY_CURSOR",
+	"PI_PROXY",
+	"HTTP_PROXY",
+	"http_proxy",
+	"HTTPS_PROXY",
+	"https_proxy",
+	"ALL_PROXY",
+	"all_proxy",
+	"NO_PROXY",
+	"no_proxy",
+] as const;
+
+type ProxyEnvKey = (typeof PROXY_ENV_KEYS)[number];
+
+function withProxyEnv<T>(values: Partial<Record<ProxyEnvKey, string | undefined>>, fn: () => T): T {
+	const previous: Partial<Record<ProxyEnvKey, string | undefined>> = {};
+	for (const key of PROXY_ENV_KEYS) previous[key] = process.env[key];
+
+	try {
+		for (const key of PROXY_ENV_KEYS) delete process.env[key];
+		for (const [key, value] of Object.entries(values) as [ProxyEnvKey, string | undefined][]) {
+			if (value !== undefined) process.env[key] = value;
+		}
+		return fn();
+	} finally {
+		for (const key of PROXY_ENV_KEYS) {
+			const value = previous[key];
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	}
+}
+
+type ProxyFixtureResult = {
+	mode?: string;
+	proxyUrl: string;
+	connectTarget: string | null;
+	targetTlsBytes?: number;
+	transportError?: string;
+	timeoutError?: string;
+	abortError?: string;
+	openSocketsAfterCleanup?: number;
+	fixtureError?: string;
+};
+
+async function runProxyFixture(mode?: "fragmented" | "oversized" | "held"): Promise<ProxyFixtureResult> {
+	const fixture = path.join(import.meta.dir, "fixtures", "cursor-proxy-env.ts");
+	const env: Record<string, string> = {};
+	for (const [key, value] of Object.entries(process.env)) {
+		if (value !== undefined) env[key] = value;
+	}
+
+	const args = mode ? [process.execPath, fixture, mode] : [process.execPath, fixture];
+	const proc = Bun.spawn(args, {
+		cwd: path.resolve(import.meta.dir, ".."),
+		env,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+	const exitCode = await proc.exited;
+	if (exitCode !== 0) throw new Error(`Cursor proxy fixture failed (${exitCode}): ${stderr}`);
+	return JSON.parse(stdout.trim()) as ProxyFixtureResult;
+}
+
+describe("Cursor proxy environment resolution", () => {
+	it("uses provider, global, protocol, and ALL_PROXY precedence in order", () => {
+		const httpsUrl = new URL("https://api.example.com/v1");
+		const httpUrl = new URL("http://api.example.com/v1");
+
+		expect(
+			withProxyEnv(
+				{
+					PI_PROXY_CURSOR: "http://provider.proxy:8080",
+					PI_PROXY: "http://global.proxy:8080",
+					HTTPS_PROXY: "http://https.proxy:8080",
+					ALL_PROXY: "http://all.proxy:8080",
+				},
+				() => getProxyForUrl("cursor", httpsUrl),
+			),
+		).toBe("http://provider.proxy:8080");
+
+		expect(
+			withProxyEnv(
+				{
+					PI_PROXY: "http://global.proxy:8080",
+					HTTPS_PROXY: "http://https.proxy:8080",
+					ALL_PROXY: "http://all.proxy:8080",
+				},
+				() => getProxyForUrl("cursor", httpsUrl),
+			),
+		).toBe("http://global.proxy:8080");
+
+		expect(
+			withProxyEnv(
+				{
+					HTTPS_PROXY: "http://https.proxy:8080",
+					ALL_PROXY: "http://all.proxy:8080",
+				},
+				() => getProxyForUrl("cursor", httpsUrl),
+			),
+		).toBe("http://https.proxy:8080");
+
+		expect(withProxyEnv({ ALL_PROXY: "http://all.proxy:8080" }, () => getProxyForUrl("cursor", httpsUrl))).toBe(
+			"http://all.proxy:8080",
+		);
+
+		expect(
+			withProxyEnv({ HTTP_PROXY: "http://http.proxy:8080", ALL_PROXY: "http://all.proxy:8080" }, () =>
+				getProxyForUrl("cursor", httpUrl),
+			),
+		).toBe("http://http.proxy:8080");
+
+		expect(
+			withProxyEnv({ https_proxy: "http://lowercase.proxy:8080" }, () => getProxyForUrl("cursor", httpsUrl)),
+		).toBe("http://lowercase.proxy:8080");
+	});
+
+	it("bypasses proxies for NO_PROXY hosts and local/private targets", () => {
+		expect(
+			withProxyEnv({ PI_PROXY_CURSOR: "http://proxy.example:8080", NO_PROXY: "api.example.com" }, () =>
+				getProxyForUrl("cursor", new URL("https://api.example.com/v1")),
+			),
+		).toBeUndefined();
+
+		expect(
+			withProxyEnv({ PI_PROXY_CURSOR: "http://proxy.example:8080", NO_PROXY: "*" }, () =>
+				getProxyForUrl("cursor", new URL("https://anywhere.example/v1")),
+			),
+		).toBeUndefined();
+
+		expect(
+			withProxyEnv({ PI_PROXY_CURSOR: "http://proxy.example:8080" }, () =>
+				getProxyForUrl("cursor", new URL("https://localhost:8443/v1")),
+			),
+		).toBeUndefined();
+
+		expect(
+			withProxyEnv({ PI_PROXY_CURSOR: "http://proxy.example:8080" }, () =>
+				getProxyForUrl("cursor", new URL("https://192.168.1.20:8443/v1")),
+			),
+		).toBeUndefined();
+
+		for (const target of [
+			"https://0.0.0.0:8443/v1",
+			"https://0.255.255.255:8443/v1",
+			"https://[::]:8443/v1",
+			"https://localhost.localdomain:8443/v1",
+		]) {
+			expect(
+				withProxyEnv({ PI_PROXY_CURSOR: "http://proxy.example:8080" }, () =>
+					getProxyForUrl("cursor", new URL(target)),
+				),
+			).toBeUndefined();
+		}
+	});
+
+	it("returns undefined when no proxy environment is configured", () => {
+		expect(withProxyEnv({}, () => getProxyForUrl("cursor", new URL("https://api.example.com/v1")))).toBeUndefined();
+	});
+});
+
+describe("Cursor HTTP/2 transport error mapping", () => {
+	it("maps the unsupported-HTTP/2 proxy failure with actionable transport context", () => {
+		const original = Object.assign(new Error("H2 is not supported by this proxy"), {
+			code: "ERR_HTTP2_ERROR",
+		});
+		const baseUrl = "https://api2.cursor.sh";
+		const mapped = mapH2TransportError(original, baseUrl) as Error & { cause?: unknown };
+
+		expect(mapped).not.toBe(original);
+		expect(mapped).toBeInstanceOf(Error);
+		expect(mapped.cause).toBe(original);
+		expect(String(mapped)).toContain(baseUrl);
+		expect(String(mapped)).toMatch(/ALPN/i);
+		expect(String(mapped)).toContain("providers.cursor.baseUrl");
+	});
+
+	it("passes through unrelated HTTP/2 and non-HTTP/2 errors unchanged", () => {
+		const unrelatedHttp2 = Object.assign(new Error("HTTP/2 protocol error"), { code: "ERR_HTTP2_ERROR" });
+		const unrelatedTransport = Object.assign(new Error("H2 is not supported"), { code: "ECONNRESET" });
+
+		expect(mapH2TransportError(unrelatedHttp2, "https://api2.cursor.sh")).toBe(unrelatedHttp2);
+		expect(mapH2TransportError(unrelatedTransport, "https://api2.cursor.sh")).toBe(unrelatedTransport);
+	});
+});
+
+describe("Cursor HTTPS proxy CONNECT transport", () => {
+	it("uses HTTPS_PROXY-only through a fake CONNECT proxy instead of direct-connect", async () => {
+		const result = await runProxyFixture();
+		expect(result.proxyUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+		expect(result.connectTarget).toBe("198.51.100.7:8443");
+		expect(result.transportError).toMatch(/403|proxy|connect/i);
+	});
+
+	it("parses fragmented bounded CONNECT headers and reaches target TLS", async () => {
+		const result = await runProxyFixture("fragmented");
+		expect(result.proxyUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+		expect(result.connectTarget).toBe("198.51.100.7:8443");
+		expect(result.targetTlsBytes ?? 0).toBeGreaterThan(0);
+		expect(result.transportError).toMatch(/TLS|handshake|closed/i);
+	});
+
+	it("rejects oversized CONNECT headers before the held-response timeout", async () => {
+		const result = await runProxyFixture("oversized");
+		expect(result.proxyUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+		expect(result.connectTarget).toBe("198.51.100.7:8443");
+		expect(result.transportError).toMatch(/headers too large/i);
+	});
+
+	it("cleans up held CONNECT sockets on timeout and abort", async () => {
+		const result = await runProxyFixture("held");
+		expect(result.proxyUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+		expect(result.connectTarget).toBe("198.51.100.7:8443");
+		expect(result.timeoutError).toMatch(/timed out/i);
+		expect(result.abortError).toMatch(/aborted/i);
+		expect(result.openSocketsAfterCleanup).toBe(0);
+	});
+});

--- a/packages/ai/test/cursor-requested-model.test.ts
+++ b/packages/ai/test/cursor-requested-model.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "bun:test";
+import { resolveCursorWireModelForTest, streamCursor } from "../src/providers/cursor";
+import type { AgentRunRequest } from "../src/providers/cursor/gen/agent_pb";
+import type { Context, Model } from "../src/types";
+
+const baseCursorModel: Model<"cursor-agent"> = {
+	id: "cursor-composer-2.5",
+	name: "Cursor Composer 2.5",
+	api: "cursor-agent",
+	provider: "cursor",
+	baseUrl: "https://api2.cursor.sh",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 1,
+	maxTokens: 1,
+};
+
+function cursorModel(id: string): Model<"cursor-agent"> {
+	return { ...baseCursorModel, id, name: id };
+}
+
+function captureCursorRequest(model: Model<"cursor-agent">): Promise<AgentRunRequest> {
+	const { promise, resolve, reject } = Promise.withResolvers<AgentRunRequest>();
+	streamCursor(
+		model,
+		{
+			messages: [{ role: "user", content: "capture this request", timestamp: 0 }],
+		} satisfies Context,
+		{
+			apiKey: "test-token",
+			onPayload: payload => {
+				if (payload && typeof payload === "object" && "$typeName" in payload) {
+					resolve(payload as AgentRunRequest);
+				} else {
+					reject(new Error("Cursor payload was not an AgentRunRequest"));
+				}
+				// The payload callback runs before any transport is opened, so the
+				// request contract can be captured without a network connection.
+				throw new Error("stop after capturing Cursor payload");
+			},
+		},
+	);
+	return promise;
+}
+
+describe("Cursor requested model wire translation", () => {
+	it.each([
+		[
+			"gpt-5.4-mini-low",
+			{ modelId: "gpt-5.4-mini", parameters: [{ id: "reasoning", value: "low" }], translated: true },
+		],
+		[
+			"gpt-5.6-sol-high",
+			{ modelId: "gpt-5.6-sol", parameters: [{ id: "reasoning", value: "high" }], translated: true },
+		],
+		[
+			"gpt-5.6-sol-xhigh-fast",
+			{
+				modelId: "gpt-5.6-sol-fast",
+				parameters: [{ id: "reasoning", value: "xhigh" }],
+				translated: true,
+			},
+		],
+		[
+			"gpt-5.1-codex-max-high",
+			{ modelId: "gpt-5.1-codex-max", parameters: [{ id: "reasoning", value: "high" }], translated: true },
+		],
+	])("translates %s to Cursor requestedModel fields", (id, expected) => {
+		const resolved = resolveCursorWireModelForTest(cursorModel(id));
+		expect({
+			modelId: resolved.modelId,
+			parameters: resolved.parameters.map(parameter => ({ id: parameter.id, value: parameter.value })),
+			translated: resolved.translated,
+		}).toEqual(expected);
+	});
+
+	it.each([
+		"gpt-5.6-sol-fast",
+		"gpt-5.6-sol",
+		"gpt-5.6-sol-none",
+		"gpt-5.6-sol-none-fast",
+		"gpt-5.1-codex-max",
+		"gpt-5.1-codex-max-fast",
+		"native",
+		"claude-sonnet-4-5",
+	])("passes through %s without a requested model translation", id => {
+		const resolved = resolveCursorWireModelForTest(cursorModel(id));
+		expect({
+			modelId: resolved.modelId,
+			parameters: resolved.parameters.map(parameter => ({ id: parameter.id, value: parameter.value })),
+			translated: resolved.translated,
+		}).toEqual({
+			modelId: id,
+			parameters: [],
+			translated: false,
+		});
+	});
+
+	it.each([
+		"gpt-5.6-sol-fast",
+		"gpt-5.6-sol",
+		"gpt-5.6-sol-none",
+		"gpt-5.1-codex-max",
+		"native",
+		"claude-sonnet-4-5",
+	])("omits requestedModel from the captured AgentRunRequest for native/pass-through %s", async id => {
+		const payload = await captureCursorRequest(cursorModel(id));
+		expect(payload.modelDetails?.modelId).toBe(id);
+		expect(payload.requestedModel).toBeUndefined();
+	});
+});

--- a/packages/ai/test/fixtures/cursor-proxy-env.ts
+++ b/packages/ai/test/fixtures/cursor-proxy-env.ts
@@ -1,0 +1,178 @@
+import { type AddressInfo, createServer, type Socket } from "node:net";
+import { connectProxiedSocket, getProxyForUrl } from "../../src/utils/proxy";
+
+const PROXY_ENV_KEYS = [
+	"PI_PROXY_CURSOR",
+	"PI_PROXY",
+	"HTTP_PROXY",
+	"http_proxy",
+	"HTTPS_PROXY",
+	"https_proxy",
+	"ALL_PROXY",
+	"all_proxy",
+	"NO_PROXY",
+	"no_proxy",
+] as const;
+
+type ProxyEnvKey = (typeof PROXY_ENV_KEYS)[number];
+type FixtureMode = "forbidden" | "fragmented" | "oversized" | "held";
+
+const mode = (process.argv[2] as FixtureMode | undefined) ?? "forbidden";
+const targetUrl = "https://198.51.100.7:8443";
+const openSockets = new Set<Socket>();
+let connectTarget: string | null = null;
+let targetTlsBytes = 0;
+
+const previousProxyEnv: Partial<Record<ProxyEnvKey, string | undefined>> = {};
+for (const key of PROXY_ENV_KEYS) previousProxyEnv[key] = process.env[key];
+
+function clearProxyEnv(): void {
+	for (const key of PROXY_ENV_KEYS) delete process.env[key];
+}
+
+function restoreProxyEnv(): void {
+	for (const key of PROXY_ENV_KEYS) {
+		const value = previousProxyEnv[key];
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+}
+
+async function sendFragments(socket: Socket, response: Buffer, fragmentSize: number): Promise<void> {
+	for (let offset = 0; offset < response.length && !socket.destroyed; offset += fragmentSize) {
+		socket.write(response.subarray(offset, offset + fragmentSize));
+		const { promise, resolve } = Promise.withResolvers<void>();
+		setImmediate(resolve);
+		await promise;
+	}
+}
+
+const proxyServer = createServer(socket => {
+	openSockets.add(socket);
+	let request = "";
+	let responded = false;
+
+	const respondForbidden = () => {
+		if (responded || socket.destroyed) return;
+		responded = true;
+		socket.end("HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+	};
+
+	const respondFragmented = async () => {
+		if (responded || socket.destroyed) return;
+		responded = true;
+		const response = Buffer.from(
+			"HTTP/1.1 200 Connection Established\r\nProxy-Agent: local-fixture\r\n\r\n",
+			"latin1",
+		);
+		await sendFragments(socket, response, 3);
+		// The client must cross the fragmented CONNECT response before it can send
+		// its target TLS ClientHello. Close that local tunnel to force a deterministic
+		// target-TLS failure without requiring a brittle certificate fixture.
+		if (!socket.destroyed) socket.setTimeout(1_500, () => socket.destroy());
+	};
+
+	const respondOversized = async () => {
+		if (responded || socket.destroyed) return;
+		responded = true;
+		const prefix = Buffer.from("HTTP/1.1 200 Connection Established\r\nX-Padding: ", "latin1");
+		const padding = Buffer.alloc(64 * 1024, 0x78);
+		await sendFragments(socket, Buffer.concat([prefix, padding]), 1_024);
+		if (!socket.destroyed) socket.setTimeout(1_500, () => socket.destroy());
+	};
+
+	socket.on("error", () => {});
+	socket.on("data", chunk => {
+		if (responded) {
+			if (mode === "fragmented" && targetTlsBytes === 0 && chunk.length > 0) {
+				targetTlsBytes = chunk.length;
+				socket.destroy();
+			}
+			return;
+		}
+		request += chunk.toString("latin1");
+		const headerEnd = request.indexOf("\r\n\r\n");
+		if (headerEnd < 0) return;
+		const firstLine = request.slice(0, headerEnd).split("\r\n", 1)[0] ?? "";
+		const [method, authority] = firstLine.split(" ");
+		if (method === "CONNECT") connectTarget = authority ?? null;
+
+		if (mode === "fragmented") void respondFragmented();
+		else if (mode === "oversized") void respondOversized();
+		else if (mode === "held") responded = true;
+		else respondForbidden();
+	});
+	socket.on("close", () => openSockets.delete(socket));
+});
+
+const { promise: listening, resolve: resolveListening, reject: rejectListening } = Promise.withResolvers<void>();
+proxyServer.once("error", rejectListening);
+proxyServer.listen({ host: "127.0.0.1", port: 0 }, () => resolveListening());
+await listening;
+
+const address = proxyServer.address();
+if (!address || typeof address === "string") throw new Error("fake proxy did not expose an address");
+const proxyUrl = `http://127.0.0.1:${(address as AddressInfo).port}`;
+
+async function closeProxyServer(): Promise<void> {
+	for (const socket of openSockets) socket.destroy();
+	if (!proxyServer.listening) return;
+	const { promise, resolve } = Promise.withResolvers<void>();
+	proxyServer.close(() => resolve());
+	await promise;
+}
+
+async function connectError(options: { signal?: AbortSignal; timeoutMs?: number }): Promise<string> {
+	try {
+		const socket = await connectProxiedSocket(proxyUrl, targetUrl, options);
+		socket.destroy();
+		return "resolved unexpectedly";
+	} catch (error) {
+		return String(error);
+	}
+}
+
+async function waitForSocketCleanup(): Promise<number> {
+	const deadline = Date.now() + 500;
+	while (openSockets.size > 0 && Date.now() < deadline) {
+		const { promise, resolve } = Promise.withResolvers<void>();
+		setTimeout(() => resolve(), 5);
+		await promise;
+	}
+	return openSockets.size;
+}
+
+clearProxyEnv();
+process.env.HTTPS_PROXY = proxyUrl;
+let result: Record<string, unknown>;
+try {
+	const selectedProxy = getProxyForUrl("cursor", new URL(targetUrl));
+	if (selectedProxy !== proxyUrl)
+		throw new Error(`expected HTTPS_PROXY to be selected, got ${selectedProxy ?? "none"}`);
+
+	if (mode === "fragmented") {
+		const transportError = await connectError({ timeoutMs: 1_000 });
+		result = { mode, proxyUrl, connectTarget, targetTlsBytes, transportError };
+	} else if (mode === "oversized") {
+		const transportError = await connectError({ timeoutMs: 1_000 });
+		result = { mode, proxyUrl, connectTarget, transportError };
+	} else if (mode === "held") {
+		const timeoutError = await connectError({ timeoutMs: 150 });
+		const abortController = new AbortController();
+		const abortPromise = connectError({ signal: abortController.signal });
+		setTimeout(() => abortController.abort(), 50);
+		const abortError = await abortPromise;
+		const openSocketsAfterCleanup = await waitForSocketCleanup();
+		result = { mode, proxyUrl, connectTarget, timeoutError, abortError, openSocketsAfterCleanup };
+	} else {
+		const transportError = await connectError({ timeoutMs: 500 });
+		result = { proxyUrl, connectTarget, transportError };
+	}
+} catch (error) {
+	result = { mode, proxyUrl, connectTarget, fixtureError: String(error) };
+} finally {
+	restoreProxyEnv();
+	await closeProxyServer();
+}
+
+console.log(JSON.stringify(result));


### PR DESCRIPTION
## Problem

Cursor's current AgentService contract exposed three gaps in Gajae Code:

- the service reconstructs prompts from `requestContext.rules`, but GJC answered that handshake with an empty rule list;
- the HTTP/2 Run transport ignored standard proxy environment variables;
- GPT reasoning sibling IDs must be sent as a base model ID plus a `reasoning` parameter, while non-GPT/native IDs must retain the existing modelDetails-only contract.

## Changes

- map normalized GJC system-prompt entries to ordered global `CursorRule`s and return them on `requestContextArgs`;
- add bounded HTTP/HTTPS CONNECT proxy transport with provider/env precedence, `NO_PROXY` and local/special-address bypass, proxy auth, IPv6 authority support, HTTPS-proxy SNI, target SNI, and ALPN `h2`;
- map ALPN-stripping failures to an actionable `providers.cursor.baseUrl` error;
- split supported GPT effort siblings into base IDs plus `{ id: "reasoning", value: effort }`, preserving the `-fast` lane and intrinsic `codex-max` identities;
- emit `requestedModel` only for translated GPT siblings, preserving Claude/native/unknown behavior;
- harden Cursor HTTP/2 terminal settlement so drained `turnEnded` completes and premature EOF fails explicitly;
- add focused rule, wire-model, proxy parsing, header-cap, timeout, abort, and socket-cleanup regressions.

The existing protobuf schema/generated bindings already contain `CursorRule`, `RequestContext.rules`, and `RequestedModel.parameters`; this PR intentionally leaves generated files unchanged.

## Verification

- `bun --cwd=packages/ai test test/cursor-exec-handlers.test.ts test/cursor-requested-model.test.ts test/cursor-proxy.test.ts` — 40 pass
- `bun run check` in `packages/ai` — pass
- `bun --cwd=packages/coding-agent test test/cursor-exec-handlers.test.ts` — 17 pass
- `git diff --check` — pass

## Risk

- [ ] `low-risk`
- [x] `regression-risk`
- [ ] `high-risk`


gajae.pr-review-verdict.v1 merge-approved sha256:6ab1a6a0bfa96036e25b6bb94a16b3c63b173b55874f149d262f525e59b7139c reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/actions/runs/32591359517 frozen:sha256:79aa21aad183ee5f54ada2ac2c198ed99534cd3cb3b2e6f3ab0bc76a9d763651 57-pass strict-cohort-CLEAR
