### PR TITLE
fix(agent): convert zod tool schemas to wire form on subagent paths (#4837)

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- `normalizeTools` now converts every Zod-authored tool schema to the wire JSON schema even when intent tracing is off. Previously the conversion ran only inside the `_i` intent-injection branch, so canonical sub-sessions (role agents spawned via `task`, where `resolveIntentTracingEnabled` forces `_i` off) sent a live `ZodObject` across the provider boundary. On append-only context providers (`anthropic`, `deepseek`; auto-enabled) the stable-prefix clone JSON-round-trips tools, and a `ZodObject` without `toJSON` reduces to a bare `{def, type}` object with no `properties`/`required` — the model is then advertised a tool with no parameters and omits required arguments. This is the root cause of issue #4837: every subagent `bash` call failing with `command: Invalid input: expected string, received undefined` while the parent session's identical call worked. Tool argument validation itself is unchanged: executors still validate against the original Zod schema.
 - Managed fallback now transfers safety-stop authority only to the adjudicated final assistant shell; intermediate partial snapshots and hostile accessor-backed final messages cannot retain or bypass the provenance boundary (#4777 review).
 
 - Managed assistant reconstruction now copies provider metadata through guarded property reads instead of an unguarded spread, so accessor-trapped metadata degrades without aborting the attempt or creating managed retry authority (#4777 review).

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -3005,13 +3005,22 @@ export function normalizeTools(tools: AgentContext["tools"], injectIntent: boole
 	return tools?.map(t => {
 		const intentMode = resolveIntentMode(t.intent);
 		let parameters: TSchema = t.parameters;
-		if (injectIntent && intentMode !== "omit") {
-			if (isZodSchema(parameters)) {
-				const wired = zodToWireSchema(parameters);
-				parameters = injectIntentIntoSchema(wired, intentMode) as TSchema;
-			} else {
-				parameters = injectIntentIntoSchema(parameters, intentMode) as TSchema;
-			}
+		if (isZodSchema(parameters)) {
+			// Zod instances must never cross the provider boundary as-is: any
+			// downstream JSON round-trip (append-only stable-prefix cloning, fork
+			// seed snapshots) reduces a live ZodObject to a bare `{def, type}`
+			// object with no `properties`/`required`, so providers advertise a
+			// tool with no parameters and the model omits required arguments
+			// (issue #4837: subagent-only bash "command: expected string,
+			// received undefined"). Intent injection forced the conversion on
+			// operator-facing sessions; canonical sub-sessions run it too.
+			const wired = zodToWireSchema(parameters);
+			parameters =
+				injectIntent && intentMode !== "omit"
+					? (injectIntentIntoSchema(wired, intentMode) as TSchema)
+					: (wired as TSchema);
+		} else if (injectIntent && intentMode !== "omit") {
+			parameters = injectIntentIntoSchema(parameters, intentMode) as TSchema;
 		}
 		const description = t.description ?? "";
 		return { ...t, parameters, description };

--- a/packages/agent/test/normalize-tools-subagent-wire-schema.test.ts
+++ b/packages/agent/test/normalize-tools-subagent-wire-schema.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "bun:test";
+import { AppendOnlyContextManager } from "@gajae-code/agent-core/append-only-context";
+import * as z from "zod/v4";
+import { toolWireSchema } from "../../ai/src/utils/schema/wire";
+import { normalizeTools } from "../src/agent-loop";
+import type { AgentContext, AgentTool } from "../src/types";
+
+// Issue #4837: canonical sub-sessions run with intent tracing off
+// (`resolveIntentTracingEnabled` forces `_i` omission for task-spawned role
+// agents). `normalizeTools` used to leave a live ZodObject as
+// `tool.parameters` whenever no intent injection was needed, so any JSON
+// round-trip downstream (append-only stable-prefix cloning, fork-seed
+// snapshots) reduced the schema to a bare `{def, type}` object with no
+// `properties`/`required`. Providers then advertised tools with no parameters
+// and the model omitted required arguments — every subagent `bash` call failed
+// with `command: Invalid input: expected string, received undefined` while the
+// parent session's identical call worked (its intent injection converted Zod
+// to the wire schema first).
+//
+// The regression contract: whatever the intent-tracing mode, a Zod-authored
+// tool must reach the provider boundary as a wire JSON schema whose declared
+// parameters survive a JSON round-trip.
+
+const bashLikeSchema = z.object({
+	command: z.string().describe("command to execute"),
+	timeout: z.number().default(300).describe("timeout in seconds").optional(),
+});
+
+function makeBashLikeTool(): AgentTool {
+	return {
+		name: "bash",
+		description: "bash tool",
+		parameters: bashLikeSchema,
+		async execute() {
+			return { content: [{ type: "text", text: "ok" }] };
+		},
+	} as unknown as AgentTool;
+}
+
+function makeContext(tools: AgentTool[]): AgentContext {
+	return { systemPrompt: ["sys"], messages: [], tools };
+}
+
+/** Wire conversion the provider layer performs on whatever it receives. */
+function providerViewOfParameters(parameters: unknown): { properties?: Record<string, unknown>; required?: string[] } {
+	return toolWireSchema({ name: "bash", description: "", parameters } as never);
+}
+
+describe("normalizeTools preserves zod parameter contracts on subagent paths (#4837)", () => {
+	it("converts zod parameters to a wire schema even when intent injection is off", () => {
+		const tools = normalizeTools([makeBashLikeTool()], false)!;
+		const parameters = tools[0]!.parameters as Record<string, unknown>;
+
+		// No live Zod instance may reach the provider boundary: it has no
+		// JSON-serializable parameter contract.
+		expect(typeof (parameters as { parse?: unknown }).parse).not.toBe("function");
+		const view = providerViewOfParameters(parameters);
+		expect(Object.keys(view.properties ?? {})).toContain("command");
+		expect(view.required).toContain("command");
+	});
+
+	it("keeps declared parameters after an append-only stable-prefix round-trip (subagent intent mode)", () => {
+		const context = makeContext([makeBashLikeTool()]);
+		const manager = new AppendOnlyContextManager();
+		const built = manager.build(context, { intentTracing: false });
+
+		const tool = built.tools![0]!;
+		const view = providerViewOfParameters(tool.parameters);
+		expect(Object.keys(view.properties ?? {})).toContain("command");
+		expect(view.required).toContain("command");
+		// No `_i` leaks into a subagent schema: intent tracing stays off.
+		expect(Object.keys(view.properties ?? {})).not.toContain("_i");
+	});
+
+	it("keeps declared parameters after an append-only stable-prefix round-trip (parent intent mode)", () => {
+		const context = makeContext([makeBashLikeTool()]);
+		const manager = new AppendOnlyContextManager();
+		const built = manager.build(context, { intentTracing: true });
+
+		const tool = built.tools![0]!;
+		const view = providerViewOfParameters(tool.parameters);
+		expect(Object.keys(view.properties ?? {})).toContain("command");
+		expect(view.required).toContain("command");
+		// Parent mode still injects the intent field.
+		expect(Object.keys(view.properties ?? {})).toContain("_i");
+	});
+
+	it("still injects the intent field when intent tracing is on", () => {
+		const tools = normalizeTools([makeBashLikeTool()], true)!;
+		const view = providerViewOfParameters(tools[0]!.parameters);
+		expect(Object.keys(view.properties ?? {})).toContain("_i");
+		expect(Object.keys(view.properties ?? {})).toContain("command");
+	});
+
+	it("leaves non-zod (plain JSON schema) parameters untouched when intent injection is off", () => {
+		const plainSchema = {
+			type: "object",
+			properties: { command: { type: "string" } },
+			required: ["command"],
+		};
+		const tool = {
+			name: "bash",
+			description: "bash tool",
+			parameters: plainSchema,
+			async execute() {
+				return { content: [] };
+			},
+		} as unknown as AgentTool;
+		const tools = normalizeTools([tool], false)!;
+		expect(tools[0]!.parameters).toBe(plainSchema);
+	});
+
+	it("does not inject intent for tools that omit it (function intent policy)", () => {
+		const tool = makeBashLikeTool();
+		(tool as { intent?: unknown }).intent = (args: { command?: string }) => `Run ${args.command ?? "command"}`;
+		const tools = normalizeTools([tool], true)!;
+		const view = providerViewOfParameters(tools[0]!.parameters);
+		expect(Object.keys(view.properties ?? {})).not.toContain("_i");
+		expect(Object.keys(view.properties ?? {})).toContain("command");
+	});
+});


### PR DESCRIPTION
## What

Fixes #4837 — subagent-only `bash` tool argument loss (`Validation failed for tool "bash": command: Invalid input: expected string, received undefined`) while the parent session's bash works.

`normalizeTools` (packages/agent/src/agent-loop.ts) now converts Zod-authored tool schemas to the provider wire JSON Schema unconditionally; previously the conversion ran only inside the `_i` intent-injection branch. Intent injection into the converted wire schema stays gated on `injectIntent && intentMode !== "omit"`.

## Why

Canonical sub-sessions (role agents spawned via `task`) run with intent tracing forced off (`resolveIntentTracingEnabled` → false for `taskDepth > 0` / `parentTaskPrefix` / `currentAgentType`), so they shipped live `ZodObject` instances across the provider boundary. On append-only context providers (`anthropic`, `deepseek` — auto-enabled), `StablePrefix.toContext()` JSON-round-trips tools via `cloneJson`; a `ZodObject` has no `toJSON`, so the clone degenerates to a bare `{def, type}` object with no `properties`/`required`. `toolWireSchema` at the provider passes that through unchanged: the model is advertised a parameterless `bash` tool, omits `command`, and the untouched executor-side Zod validation fails with exactly the reported signature. Parent sessions converted Zod first (intent injection required it) — matching the reported parent/subagent asymmetry. Converting at the `normalizeTools` boundary also repairs the fork-seed `exportSnapshot` round-trip.

Deterministic harness (real `BashTool` schema through the real agent-loop boundary + append-only prefix + provider `toolWireSchema`):

| Path | intentTracing | append-only | properties | required |
|---|---|---|---|---|
| parent-style | true | on | `_i, command, env, …` | `[command]` |
| subagent-style | false | on | **none** | **undefined** |

Executor-side validation is unchanged: tool calls still validate against the **original** tool's Zod schema (`runTool` dispatches from `currentContext.tools`, never the provider-facing clone). No reporter-suggested logging/canary additions; no #4836 scope.

## Testing

- `bun test packages/agent/test/normalize-tools-subagent-wire-schema.test.ts` — new deterministic regression suite, 6 pass (2 verified failing pre-fix via `git stash` of the fix)
- `bun test packages/agent/test/` — 834 pass, 0 fail
- `bun test packages/coding-agent/test/task/` — 326 pass, 0 fail
- `bun test packages/coding-agent/test/sdk-intent-tracing-surface.test.ts` — 2 pass
- `bun test packages/coding-agent/src/tools/descriptors.test.ts` — 22 pass
- `bun --cwd=packages/agent run check` (biome + tsc) and `bun --cwd=packages/coding-agent run check:types` — clean
- Red-team probes (run and deleted): executor defaults still materialize against the original tool; plain-JSON schema identity preserved (`===`); function-intent tools get wire schema without `_i`; `AppendOnlyContextManager.build` twice keeps fingerprint/version stable; `PI_NO_INTENT=1` still converts; shared-schema cross-intent use cannot leak `_i`; no downstream consumer relied on live Zod from the intent-off path.
- `packages/ai` has pre-existing failures verified identical on the unmodified tree (auth-broker/gateway fixtures, fake-timer tests) — out of scope.

CHANGELOG: `packages/agent/CHANGELOG.md` under `[Unreleased]`.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:90f3c006404a9db1097000b4d94af3c52cfd7ba431eb202bc1f28abee2ef8e02 reviewer:human reviewer-id:Yeachan-Heo evidence:local - bun test packages/agent/test/ 834 pass (regression suite fails pre-fix); boundary cohort architect APPROVE + executor red-team passed; agent + coding-agent typechecks clean
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken