### PR TITLE
fix(tui): retire working indicator at terminal boundary

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 
+
 ### Added
 
 - Added an SDK `automationTools` option for host-owned `browser` and `computer` implementations. External automation retains built-in activation and provenance, receives the normal abort signal, works independently of the default browser/platform gates, and fails closed on custom, extension, or MCP name collisions (#4809).
@@ -18,6 +19,7 @@
 
 ### Fixed
 
+- Terminal `agent_end` now retires the foreground `Working…` indicator even when the mutable session streaming flag settles late. The terminal event remains authoritative across later background-task refreshes, while the next `agent_start` re-enables normal streaming activity.
 - Bash tool globs with a trailing separator (`pattern*/`) now match directories only, and literal components after a glob (`*/name`) now require the resulting path to exist, matching bash/POSIX pathname expansion. The vendored shell's expander appended post-glob literal components (including the empty component a trailing `/` splits into) without any filesystem check, so `LICENSE*/` matched the plain file `LICENSE`, `ls -d */` received file arguments and exited 1, `for d in */` iterated over files, and `*/absent` fabricated paths that were never on disk. Directory checks follow symlinks (matching bash `*/` semantics) while literal-suffix existence uses lstat (dangling symlinks still match); patterns whose last component is itself a glob are unchanged since their matches come from directory reads.
 - Workflow handoffs out of autoresearch now transit properly: `/skill:deep-interview`, `/skill:ralplan`, and `/skill:ultragoal` chain from any live autoresearch phase (`intake`/`research`/`verdict`), and ralplan's `final` phase chains via its manifest terminal states; ralplan/ultragoal live phases still require the explicit write-to-handoff step. `gjc autoresearch clear` remains the finalize-only exit.
 - The coordinator idle reaper now judges idle eligibility against the durable WAL's turn activity watermark (`recovery.prompt_watermark_at`, falling back to the session's creation stamp for turn-less sessions) instead of the projection session-state stamp. Projection repair (and any failed close admission) rewrites that state file with a fresh `now` stamp, which reset the idle clock after every failed `session.close` and deferred the reaper's same-key retry by a full idle TTL. The reaper retry contract (`coordinator-reap:<session>:<incarnation>` key reuse) holds again, and an ephemeral session older than the TTL whose last turn completed recently is no longer reapable between turns; the projection stamp remains the fallback only for sessions whose WAL cannot be read. The `stop-session` and `send-prompt-concurrency` lifecycle suites were also re-based onto the post-#4731 durable layout (canonical WAL + namespaced projections; broker `session.create` mocks echo `coordinatorSidecarKeyId`), restoring them to the required CI set (#4835).

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1031,7 +1031,7 @@ export class CommandController {
 		if (this.ctx.isStopped?.()) return false;
 		clearInteractiveActivityLoaders(this.ctx);
 
-		stopInteractiveActivityIndicator(this.ctx);
+		stopInteractiveActivityIndicator(this.ctx, { foregroundSettled: true });
 		this.ctx.resetIrcSidebarSession();
 		this.ctx.resetObserverRegistry();
 		setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
@@ -1064,7 +1064,7 @@ export class CommandController {
 	async handleContextClearCommand(): Promise<void> {
 		if (this.ctx.isStopped?.()) return;
 		clearInteractiveActivityLoaders(this.ctx);
-		stopInteractiveActivityIndicator(this.ctx);
+		stopInteractiveActivityIndicator(this.ctx, { foregroundSettled: true });
 		if (this.ctx.session.isCompacting) {
 			this.ctx.session.abortCompaction();
 			while (this.ctx.session.isCompacting) {
@@ -1119,7 +1119,7 @@ export class CommandController {
 			return;
 		}
 		clearInteractiveActivityLoaders(this.ctx);
-		stopInteractiveActivityIndicator(this.ctx);
+		stopInteractiveActivityIndicator(this.ctx, { foregroundSettled: true });
 		this.ctx.resetIrcSidebarSession();
 
 		this.ctx.statusLine.invalidate();

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -941,7 +941,7 @@ export class EventController {
 		this.ctx.editor.onEscape = () => {
 			this.ctx.session.abortCompaction();
 		};
-		stopInteractiveActivityIndicator(this.ctx, { restoreBackground: false });
+		stopInteractiveActivityIndicator(this.ctx, { restoreBackground: false, foregroundSettled: true });
 		const reasonText =
 			event.reason === "overflow" ? "Context overflow detected, " : event.reason === "idle" ? "Idle " : "";
 		const actionLabel = event.action === "handoff" ? "Auto-handoff" : "Auto context-full maintenance";
@@ -1042,7 +1042,7 @@ export class EventController {
 				this.ctx.session.abortRetry();
 			}
 		};
-		stopInteractiveActivityIndicator(this.ctx, { restoreBackground: false });
+		stopInteractiveActivityIndicator(this.ctx, { restoreBackground: false, foregroundSettled: true });
 		// Stop any prior retry loader/timer before installing a new one.
 		this.ctx.retryLoader?.stop();
 		this.#clearRetryCountdown();

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -905,7 +905,7 @@ export class EventController {
 
 	async #handleAgentEnd(_event: Extract<AgentSessionEvent, { type: "agent_end" }>): Promise<void> {
 		this.ctx.setWorkingMessage(undefined);
-		stopInteractiveActivityIndicator(this.ctx);
+		stopInteractiveActivityIndicator(this.ctx, { foregroundSettled: true });
 		if (this.ctx.streamingComponent) {
 			this.ctx.chatContainer.removeChild(this.ctx.streamingComponent);
 			this.ctx.streamingComponent = undefined;

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -383,7 +383,7 @@ export class InputController {
 			// Stop the stale indicator so completed work clears the busy state and
 			// keep evaluating the remaining states; when none match, the key falls
 			// through to idle semantics instead of a no-op abort that swallows it.
-			stopInteractiveActivityIndicator(this.ctx);
+			stopInteractiveActivityIndicator(this.ctx, { foregroundSettled: true });
 		}
 		if (options.processes && this.ctx.session.isBashRunning) {
 			this.ctx.session.abortBash();

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -3097,7 +3097,10 @@ export class SelectorController {
 
 	#clearTransientSessionUi(options?: { restoreBackground?: boolean; clearSpecializedLoaders?: boolean }): void {
 		if (options?.clearSpecializedLoaders) clearInteractiveActivityLoaders(this.ctx);
-		stopInteractiveActivityIndicator(this.ctx, { restoreBackground: options?.restoreBackground });
+		stopInteractiveActivityIndicator(this.ctx, {
+			restoreBackground: options?.restoreBackground,
+			foregroundSettled: true,
+		});
 		this.ctx.pendingMessagesContainer.clear();
 		this.ctx.compactionQueuedMessages = [];
 		this.ctx.streamingComponent = undefined;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -114,6 +114,7 @@ import type { Theme } from "./theme/theme";
 import { getEditorTheme, getSymbolTheme, onTerminalAppearanceChange, onThemeChange, theme } from "./theme/theme";
 import { type RegisterTranscriptItem, TranscriptItemRegistry, transcriptItemId } from "./transcript-item-registry";
 import {
+	type ActivityIndicatorStopOptions,
 	type CompactionQueuedMessage,
 	type ComposerSubmissionOptions,
 	canApplyComposerSubmission,
@@ -496,6 +497,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	#jobsObserver?: JobsObserver;
 	#tasksAggregator?: TasksAggregator;
 	#foregroundActivity = false;
+	#foregroundTurnSettled = false;
 	#activityIndicatorSuspensions = 0;
 	#suspendedActivityIndicator?: Loader;
 	#stopped = false;
@@ -1841,13 +1843,13 @@ export class InteractiveMode implements InteractiveModeContext {
 	syncActivityIndicator(): void {
 		if (this.#stopped || this.#activityIndicatorSuspensions > 0 || this.autoCompactionLoader || this.retryLoader)
 			return;
-		const foregroundActive = this.#foregroundActivity || this.session.isStreaming;
+		const foregroundActive = this.#foregroundActivity || (!this.#foregroundTurnSettled && this.session.isStreaming);
 		if (!this.isInitialized && !foregroundActive) {
 			this.#stopLoadingAnimation();
 			return;
 		}
 		const message = resolveActivityIndicatorMessage(
-			this.#foregroundActivity || this.session.isStreaming,
+			foregroundActive,
 			this.#activeBackgroundTaskCount(),
 			this.#pendingWorkingMessage ?? this.#defaultWorkingMessage,
 		);
@@ -1874,12 +1876,14 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	ensureLoadingAnimation(): void {
+		this.#foregroundTurnSettled = false;
 		this.#foregroundActivity = true;
 		this.syncActivityIndicator();
 	}
 
-	stopLoadingAnimation(options?: { restoreBackground?: boolean }): void {
+	stopLoadingAnimation(options?: ActivityIndicatorStopOptions): void {
 		this.#foregroundActivity = false;
+		if (options?.foregroundSettled) this.#foregroundTurnSettled = true;
 		if (options?.restoreBackground === false) {
 			this.#stopLoadingAnimation();
 			return;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -66,13 +66,19 @@ export function canApplyComposerSubmission(
 
 type PartialActivityStatusContainer = Partial<Pick<Container, "children" | "clear" | "detachChild" | "addChild">>;
 
+export type ActivityIndicatorStopOptions = Readonly<{
+	restoreBackground?: boolean;
+	/** The terminal event is authoritative even if the session's streaming flag has not settled yet. */
+	foregroundSettled?: boolean;
+}>;
+
 export function stopInteractiveActivityIndicator(
 	ctx: {
 		loadingAnimation?: Loader;
 		statusContainer?: PartialActivityStatusContainer;
-		stopLoadingAnimation?: (options?: { restoreBackground?: boolean }) => void;
+		stopLoadingAnimation?: (options?: ActivityIndicatorStopOptions) => void;
 	},
-	options?: { restoreBackground?: boolean },
+	options?: ActivityIndicatorStopOptions,
 ): void {
 	if (ctx.stopLoadingAnimation) {
 		ctx.stopLoadingAnimation(options);
@@ -111,7 +117,7 @@ export function clearInteractiveActivityLoaders(
 export function suspendInteractiveActivityIndicator(ctx: {
 	loadingAnimation?: Loader;
 	statusContainer?: PartialActivityStatusContainer;
-	stopLoadingAnimation?: (options?: { restoreBackground?: boolean }) => void;
+	stopLoadingAnimation?: (options?: ActivityIndicatorStopOptions) => void;
 	syncActivityIndicator?: () => void;
 	suspendActivityIndicator?: () => () => void;
 }): () => void {
@@ -276,7 +282,7 @@ export interface InteractiveModeContext {
 	ensureLoadingAnimation(): void;
 	syncActivityIndicator(): void;
 	suspendActivityIndicator(): () => void;
-	stopLoadingAnimation(options?: { restoreBackground?: boolean }): void;
+	stopLoadingAnimation(options?: ActivityIndicatorStopOptions): void;
 	/**
 	 * Commit a pet mode through the shared result-returning policy: capability
 	 * is rechecked immediately before mutation and the preference persists only

--- a/packages/coding-agent/test/interactive-mode-background-activity.test.ts
+++ b/packages/coding-agent/test/interactive-mode-background-activity.test.ts
@@ -109,6 +109,56 @@ describe("interactive background activity indicator", () => {
 		expect(renderStatus(mode)).toBe("");
 	});
 
+	it("preserves background activity and re-arms after settled terminal cleanup", async () => {
+		const ownerId = session.getAgentId();
+		if (!ownerId) throw new Error("Expected an owner id");
+		const background = Promise.withResolvers<string>();
+		pendingJobs.push(background);
+		const jobId = manager.register("task", "terminal-boundary activity", () => background.promise, { ownerId });
+		manager.registerSubagentRecord({
+			subagentId: "terminal-boundary-subagent",
+			ownerId,
+			currentJobId: jobId,
+			historicalJobIds: [],
+			status: "running",
+			sessionFile: null,
+			resumable: false,
+		});
+		await waitFor(() => mode.loadingAnimation !== undefined);
+
+		mode.ensureLoadingAnimation();
+		Object.defineProperty(session, "isStreaming", { configurable: true, get: () => true });
+		const controller = new EventController(mode);
+		await controller.handleEvent({ type: "agent_end", messages: [] });
+		mode.syncActivityIndicator();
+		const backgroundLoader = mode.loadingAnimation;
+		if (!backgroundLoader) throw new Error("Expected background loader after agent_end");
+		expect(renderStatus(mode)).toContain("Background: 1 task…");
+
+		await controller.handleEvent({ type: "agent_end", messages: [] });
+		mode.syncActivityIndicator();
+		expect(mode.loadingAnimation).toBe(backgroundLoader);
+		expect(renderStatus(mode)).toContain("Background: 1 task…");
+
+		const releaseSuspension = mode.suspendActivityIndicator();
+		expect(renderStatus(mode)).toBe("");
+		await controller.handleEvent({ type: "agent_end", messages: [] });
+		releaseSuspension();
+		expect(mode.loadingAnimation).toBe(backgroundLoader);
+		expect(renderStatus(mode)).toContain("Background: 1 task…");
+
+		await controller.handleEvent({ type: "agent_start" });
+		expect(renderStatus(mode)).toContain("Working…");
+		expect(renderStatus(mode)).toContain("1 background task");
+
+		background.resolve("done");
+		pendingJobs.pop();
+		await waitFor(() => manager.getAllJobs({ ownerId }).find(job => job.id === jobId)?.status === "completed");
+		Object.defineProperty(session, "isStreaming", { configurable: true, get: () => false });
+		await controller.handleEvent({ type: "agent_end", messages: [] });
+		await waitFor(() => mode.loadingAnimation === undefined);
+	});
+
 	it("schedules the startup crash relay hook from trusted global settings", async () => {
 		const debug = vi.spyOn(logger, "debug");
 		Settings.instance.set("crashReport.upstream", "sentry");

--- a/packages/coding-agent/test/interactive-mode-background-activity.test.ts
+++ b/packages/coding-agent/test/interactive-mode-background-activity.test.ts
@@ -94,6 +94,21 @@ describe("interactive background activity indicator", () => {
 		expect(renderStatus(mode)).toBe("");
 	});
 
+	it("retires stale foreground activity across maintenance stop boundaries", async () => {
+		mode.ensureLoadingAnimation();
+		Object.defineProperty(session, "isStreaming", { configurable: true, get: () => true });
+		const controller = new EventController(mode);
+
+		await controller.handleEvent({ type: "auto_compaction_start", reason: "threshold", action: "context-full" });
+		mode.autoCompactionLoader?.stop();
+		mode.autoCompactionLoader = undefined;
+		mode.statusContainer.clear();
+		mode.syncActivityIndicator();
+
+		expect(mode.loadingAnimation).toBeUndefined();
+		expect(renderStatus(mode)).toBe("");
+	});
+
 	it("schedules the startup crash relay hook from trusted global settings", async () => {
 		const debug = vi.spyOn(logger, "debug");
 		Settings.instance.set("crashReport.upstream", "sentry");

--- a/packages/coding-agent/test/interactive-mode-background-activity.test.ts
+++ b/packages/coding-agent/test/interactive-mode-background-activity.test.ts
@@ -5,6 +5,7 @@ import { Agent } from "@gajae-code/agent-core";
 import { AsyncJobManager } from "@gajae-code/coding-agent/async/job-manager";
 import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
+import { EventController } from "@gajae-code/coding-agent/modes/controllers/event-controller";
 import { InteractiveMode, resolveActivityIndicatorMessage } from "@gajae-code/coding-agent/modes/interactive-mode";
 import { initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
 import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
@@ -80,6 +81,19 @@ describe("interactive background activity indicator", () => {
 		expect(resolveActivityIndicatorMessage(false, 2, "Working…")).toBe("Background: 2 tasks…");
 		expect(resolveActivityIndicatorMessage(true, 2, "Working…")).toBe("Working… · 2 background tasks");
 	});
+
+	it("retires the foreground indicator when agent_end races stale streaming state", async () => {
+		mode.ensureLoadingAnimation();
+		Object.defineProperty(session, "isStreaming", { configurable: true, get: () => true });
+		const controller = new EventController(mode);
+
+		await controller.handleEvent({ type: "agent_end", messages: [] });
+		mode.syncActivityIndicator();
+
+		expect(mode.loadingAnimation).toBeUndefined();
+		expect(renderStatus(mode)).toBe("");
+	});
+
 	it("schedules the startup crash relay hook from trusted global settings", async () => {
 		const debug = vi.spyOn(logger, "debug");
 		Settings.instance.set("crashReport.upstream", "sentry");

--- a/packages/coding-agent/test/modes/controllers/selector-controller-resume-model.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-resume-model.test.ts
@@ -105,7 +105,10 @@ describe("SelectorController resume model choice", () => {
 		// Only the (no-op) editor restore path runs — no confirm dialog mounted.
 		expect(ctx.editorContainer.children).toHaveLength(0);
 		expect(setModel).not.toHaveBeenCalled();
-		expect(ctx.stopLoadingAnimation).toHaveBeenCalledWith({ restoreBackground: false });
+		expect(ctx.stopLoadingAnimation).toHaveBeenCalledWith({
+			foregroundSettled: true,
+			restoreBackground: false,
+		});
 		expect(ctx.syncActivityIndicator).toHaveBeenCalledTimes(1);
 	});
 


### PR DESCRIPTION
## What

Retire the interactive foreground `Working…` indicator at the authoritative `agent_end` boundary, even when `session.isStreaming` is a stale `true` snapshot. Preserve detached background-task status and re-arm normal streaming display on the next foreground start. Alternate maintenance, cancellation, session-transition, and selector cleanup stops now mark their own terminal boundary authoritative too, preventing stale streaming reactivation.

## Why

The v0.15.0 #4741 fix repaired Esc/Ctrl+C recovery after a loader became stale, but did not fix the source. `stopLoadingAnimation()` still re-read the lagging streaming flag during terminal handling and retained the foreground spinner indefinitely. The same stale-state hazard existed in alternate cleanup paths, so those paths now settle the foreground turn explicitly.

## Testing

- `bun test packages/coding-agent/test/interactive-mode-background-activity.test.ts` (12 passed)
- `bun test packages/coding-agent/test/modes/controllers/event-controller-completion-viewport.test.ts` (1 passed)
- `bun test packages/coding-agent/test/modes/controllers/selector-controller-resume-model.test.ts packages/coding-agent/test/input-controller-escape.test.ts packages/coding-agent/test/modes/controllers/event-controller-auto-compaction.test.ts packages/coding-agent/test/modes/controllers/event-controller-abort-guard.test.ts` (98 passed)
- `bun --cwd=packages/coding-agent run check` (passes with 11 pre-existing warnings)
- `bunx biome check` on all changed coding-agent source and test files
- `bun --cwd=packages/natives run build` to provide the local native addon required by the focused suites

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:1ccede3397cb2b5e3e0ea33e434660efc879f193eb2ae5a589588185cd03ff65 reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/pull/4842#pullrequestreview-5001782622
```

---

- [x] Target branch is `dev`
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
