### PR TITLE
config: use 8-bit instead of BF16 for macos-omlx-quality profile

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Changed
 
+- `macos-omlx-quality` now routes every role through `omlx/Qwen3.6-35B-A3B-8bit` instead of the BF16 checkpoint, retaining the profile's higher reasoning-effort ladder while reducing the local model footprint and improving measured generation throughput on its M5 Max 128 GB target. The preset group label now uses the branded `macOS Local (oMLX)` casing throughout the public profile picker.
 - Upgrade note: restart the SDK broker after upgrading (`gjc sdk` callers pick this up automatically on the next launch; an already-running daemon does not). This release adds the `model.resolve` broker operation, and the broker discovery record carries no package-generation fence — a daemon left running from an earlier version keeps serving and answers the new operation with `unknown_operation`, so coordinator `model` pins (`gjc_coordinator_start_session`) fail until it is replaced. Verified against a live daemon: the failure is loud, no session is created, and one broker restart clears it.
 - Closed the remaining Sentry triage approval races: `gh` is resolved only from trusted system paths, acknowledgement rechecks and records under the creation lock, pending-create reconciliation uses a per-attempt nonce with compare-and-clear, and malformed timestamp suffixes fail ingestion before rendering. Regression coverage pins the retry/apply interleaving so a newer unresolved create cannot be cleared by an older `--retry-pending` request.
 

--- a/packages/coding-agent/src/config/model-profiles.ts
+++ b/packages/coding-agent/src/config/model-profiles.ts
@@ -593,22 +593,22 @@ const PROFILE_PRESENTATION: Record<string, ModelProfilePresentation> = {
 	"opus-codex": { displayName: "Opus + Codex", providerGroup: "COMBOS" },
 	"codex-opencodego": { displayName: "Codex + OpenCodeGo", providerGroup: "COMBOS" },
 	"fable-opus-codex": { displayName: "Fable + Opus + Codex", providerGroup: "COMBOS" },
-	"macos-omlx-fast": { displayName: "4-bit Fast (24GB~36GB+ / Default Ctx)", providerGroup: "MACOS LOCAL (OMLX)" },
+	"macos-omlx-fast": { displayName: "4-bit Fast (24GB~36GB+ / Default Ctx)", providerGroup: "macOS Local (oMLX)" },
 	"macos-omlx-balanced": {
 		displayName: "8-bit Balanced (64GB~128GB / Default Ctx)",
-		providerGroup: "MACOS LOCAL (OMLX)",
+		providerGroup: "macOS Local (oMLX)",
 	},
 	"macos-omlx-quality": {
 		displayName: "8-bit Max Quality (M5 Max 128GB / Default Ctx)",
-		providerGroup: "MACOS LOCAL (OMLX)",
+		providerGroup: "macOS Local (oMLX)",
 	},
 	"macos-omlx-abliterated-fast": {
 		displayName: "4-bit Abliterated Fast (Qwen3.8 27B / Default Ctx)",
-		providerGroup: "MACOS LOCAL (OMLX)",
+		providerGroup: "macOS Local (oMLX)",
 	},
 	"macos-omlx-abliterated-balanced": {
 		displayName: "6-bit Abliterated Balanced (Qwen3.8 27B / Default Ctx)",
-		providerGroup: "MACOS LOCAL (OMLX)",
+		providerGroup: "macOS Local (oMLX)",
 	},
 };
 
@@ -616,7 +616,7 @@ const PROFILE_GROUP_ORDER = [
 	"CODEX",
 	"OPENCODEGO",
 	"COMMAND CODE GOAT",
-	"MACOS LOCAL (OMLX)",
+	"macOS Local (oMLX)",
 	"OPEN WEIGHT MODELS (PROVIDER AGNOSTIC)",
 	"CLAUDE",
 	"GLM",
@@ -711,7 +711,7 @@ export function groupModelProfilesForPresetLanding(
 					(OPEN_WEIGHT_PROFILE_RANK.get(a.name) ?? Number.MAX_SAFE_INTEGER) -
 					(OPEN_WEIGHT_PROFILE_RANK.get(b.name) ?? Number.MAX_SAFE_INTEGER),
 			);
-		} else if (group === "MACOS LOCAL (OMLX)") {
+		} else if (group === "macOS Local (oMLX)") {
 			entries.sort(
 				(a, b) =>
 					(MACOS_OMLX_PROFILE_RANK.get(a.name) ?? Number.MAX_SAFE_INTEGER) -

--- a/packages/coding-agent/src/config/model-profiles.ts
+++ b/packages/coding-agent/src/config/model-profiles.ts
@@ -114,11 +114,11 @@ export const BUILTIN_MODEL_PROFILES: readonly ModelProfileDefinition[] = [
 		critic: "omlx/Qwen3.6-35B-A3B-8bit:medium",
 	}),
 	profile("macos-omlx-quality", ["omlx"], {
-		default: "omlx/Qwen3.6-35B-A3B-bf16:high",
-		executor: "omlx/Qwen3.6-35B-A3B-bf16:medium",
-		architect: "omlx/Qwen3.6-35B-A3B-bf16:high",
-		planner: "omlx/Qwen3.6-35B-A3B-bf16:high",
-		critic: "omlx/Qwen3.6-35B-A3B-bf16:high",
+		default: "omlx/Qwen3.6-35B-A3B-8bit:high",
+		executor: "omlx/Qwen3.6-35B-A3B-8bit:medium",
+		architect: "omlx/Qwen3.6-35B-A3B-8bit:high",
+		planner: "omlx/Qwen3.6-35B-A3B-8bit:high",
+		critic: "omlx/Qwen3.6-35B-A3B-8bit:high",
 	}),
 	profile("macos-omlx-abliterated-fast", ["omlx"], {
 		default: "omlx/Qwen3.8-27B-Abliterated-MLX-4bit:medium",
@@ -599,7 +599,7 @@ const PROFILE_PRESENTATION: Record<string, ModelProfilePresentation> = {
 		providerGroup: "MACOS LOCAL (OMLX)",
 	},
 	"macos-omlx-quality": {
-		displayName: "BF16 Max Quality (M5 Max 128GB / Default Ctx)",
+		displayName: "8-bit Max Quality (M5 Max 128GB / Default Ctx)",
 		providerGroup: "MACOS LOCAL (OMLX)",
 	},
 	"macos-omlx-abliterated-fast": {

--- a/packages/coding-agent/test/model-profiles-catalog.test.ts
+++ b/packages/coding-agent/test/model-profiles-catalog.test.ts
@@ -93,11 +93,11 @@ const expectedProfiles: Array<{
 		name: "macos-omlx-quality",
 		requiredProviders: ["omlx"],
 		mapping: {
-			default: "omlx/Qwen3.6-35B-A3B-bf16:high",
-			executor: "omlx/Qwen3.6-35B-A3B-bf16:medium",
-			architect: "omlx/Qwen3.6-35B-A3B-bf16:high",
-			planner: "omlx/Qwen3.6-35B-A3B-bf16:high",
-			critic: "omlx/Qwen3.6-35B-A3B-bf16:high",
+			default: "omlx/Qwen3.6-35B-A3B-8bit:high",
+			executor: "omlx/Qwen3.6-35B-A3B-8bit:medium",
+			architect: "omlx/Qwen3.6-35B-A3B-8bit:high",
+			planner: "omlx/Qwen3.6-35B-A3B-8bit:high",
+			critic: "omlx/Qwen3.6-35B-A3B-8bit:high",
 		},
 	},
 	{
@@ -688,7 +688,6 @@ const commandCodeGoatModels = new Set([
 const macosOmlxModels = new Set([
 	"Qwen3.6-35B-A3B-4bit",
 	"Qwen3.6-35B-A3B-8bit",
-	"Qwen3.6-35B-A3B-bf16",
 	"Qwen3.8-27B-Abliterated-MLX-4bit",
 	"Qwen3.8-27B-Abliterated-MLX-6bit",
 ]);
@@ -921,11 +920,11 @@ describe("built-in model profile catalog", () => {
 		for (const [name, displayName] of Object.entries({
 			"macos-omlx-fast": "4-bit Fast (24GB~36GB+ / Default Ctx)",
 			"macos-omlx-balanced": "8-bit Balanced (64GB~128GB / Default Ctx)",
-			"macos-omlx-quality": "BF16 Max Quality (M5 Max 128GB / Default Ctx)",
+			"macos-omlx-quality": "8-bit Max Quality (M5 Max 128GB / Default Ctx)",
 			"macos-omlx-abliterated-fast": "4-bit Abliterated Fast (Qwen3.8 27B / Default Ctx)",
 			"macos-omlx-abliterated-balanced": "6-bit Abliterated Balanced (Qwen3.8 27B / Default Ctx)",
 		})) {
-			expect(getModelProfilePresentation(name)).toEqual({ displayName, providerGroup: "MACOS LOCAL (OMLX)" });
+			expect(getModelProfilePresentation(name)).toEqual({ displayName, providerGroup: "macOS Local (oMLX)" });
 		}
 		for (const [name, displayName] of Object.entries({
 			"grok-45-eco": "Grok 4.5 Eco",
@@ -941,7 +940,7 @@ describe("built-in model profile catalog", () => {
 			"CODEX",
 			"OPENCODEGO",
 			"COMMAND CODE GOAT",
-			"MACOS LOCAL (OMLX)",
+			"macOS Local (oMLX)",
 			"OPEN WEIGHT MODELS (PROVIDER AGNOSTIC)",
 			"CLAUDE",
 			"GLM",
@@ -955,7 +954,7 @@ describe("built-in model profile catalog", () => {
 		]);
 		expect(
 			groupModelProfilesForPresetLanding(profiles)
-				.get("MACOS LOCAL (OMLX)")
+				.get("macOS Local (oMLX)")
 				?.map(profile => profile.name),
 		).toEqual([
 			"macos-omlx-fast",


### PR DESCRIPTION
## What

- Route all `macos-omlx-quality` roles from `omlx/Qwen3.6-35B-A3B-bf16` to `omlx/Qwen3.6-35B-A3B-8bit`.
- Preserve the profile ladder through thinking effort: fast uses 4-bit, balanced uses 8-bit with lower/medium role efforts, and quality uses the same 8-bit checkpoint with medium/high role efforts.
- Normalize the public profile group label to `macOS Local (oMLX)` and preserve its explicit group/profile sorting.
- Record the default-routing and picker-label change in the unreleased coding-agent changelog.

## Why

The oMLX leaderboard measurements supplied with this contribution show roughly 2× higher generation throughput and a substantially smaller weight footprint for the 8-bit checkpoint on the target M5 Max 128 GB class. The quality claim is bounded: public KLD evidence covers a dense sibling using the same quantization recipe, while no direct public 35B-A3B 8-bit-vs-BF16 KLD result was available. This change therefore treats 8-bit as the better default operational profile, not as proof of bit-identical BF16 quality.

The model ID is exercised by oMLX dynamic-discovery and compatibility tests; discovered oMLX models support low/medium/high reasoning effort through the Qwen chat template. No static provider catalog entry is required because oMLX resolves models dynamically from its local OpenAI-compatible endpoint.

## Testing

- `bun test packages/coding-agent/test/model-profiles-catalog.test.ts` — 16 pass
- `bun test packages/coding-agent/test/config-cli.test.ts packages/coding-agent/test/omlx-discovery.test.ts` — 27 pass
- `bun test packages/ai/test/openai-compatible-discovery.test.ts packages/ai/test/openai-completions-compat.test.ts` — 57 pass
- `bun --cwd=packages/coding-agent run check:types` — pass
- `bun run ci:test:smoke` — pass
- `bun --cwd=packages/coding-agent run build` — pass
- `bunx biome check packages/coding-agent/src/config/model-profiles.ts packages/coding-agent/test/model-profiles-catalog.test.ts` — pass

Hardware performance numbers were reviewed as contributor-supplied evidence; this Linux lane did not reproduce M5 Max inference benchmarks.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:721f22833035203e93417689770333e6df713d64992b72774d2ded812158c3fb reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/actions/runs/32635957845
```

---

- [x] Target branch is `dev`
- [x] `bun check` equivalent focused package checks pass
- [x] Tested locally
- [x] CHANGELOG updated (user-facing default routing and label)
- [x] Verdict above matches exact base `dde850226221a26e2ad192aa41119ed5234c6ad6`, head `37a12c34fdfd8825a33e54d36869ae3a0a2dee07`, and canonical diff digest
- [x] Risk classification matches the independent maintainer review path