### PR TITLE
fix(eval): repair python kernel reuse and session-settings test doubles (#4826)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Python kernel reuse is once again keyed on the settings values that shape a kernel, not on `Settings` object identity. Binding built-in executors to session settings (#4826) made `scopedSessionId` suffix each kernel key with a per-instance counter, so two logical sessions in one process — which resolve the same shell configuration and therefore spawn byte-identical kernels — each started their own kernel, and disposing one shut down a kernel the other still owned. The scope is now a fingerprint of the resolved shell config (shell, args, environment), so equivalent settings share one retained kernel while genuinely different shell environments stay isolated.
+
 ## [0.15.0] - 2026-08-22
 
 

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -133,8 +133,29 @@ function ensurePythonResourceCleanup(): void {
 }
 const sessions = new Map<string, PythonSession | InitializingPythonSession>();
 const retiringKernels = new Set<PythonKernel>();
-const settingsSessionIds = new WeakMap<Settings, number>();
-let nextSettingsSessionId = 1;
+const settingsScopes = new WeakMap<Settings, string>();
+
+/**
+ * Fingerprint the settings values that actually shape a spawned kernel process.
+ * `PythonKernel.start` derives the kernel environment solely from
+ * `settings.getShellConfig()`, so two Settings instances resolving to the same
+ * shell configuration produce byte-identical kernels and MUST share one
+ * retained kernel. Keying on Settings object identity instead partitions every
+ * logical session into its own kernel, which breaks cross-session reuse and
+ * lets one session's dispose shut down a kernel another session still owns.
+ */
+function settingsScope(activeSettings: Settings): string {
+	const cached = settingsScopes.get(activeSettings);
+	if (cached !== undefined) return cached;
+	const { shell, args, env } = activeSettings.getShellConfig();
+	const canonicalEnv = Object.keys(env)
+		.sort()
+		.map(key => [key, env[key]]);
+	const canonical = JSON.stringify([shell, args, canonicalEnv]);
+	const scope = new Bun.CryptoHasher("sha256").update(canonical).digest("hex").slice(0, 16);
+	settingsScopes.set(activeSettings, scope);
+	return scope;
+}
 
 function scopedSessionId(sessionId: string, activeSettings: Settings | undefined): string {
 	if (!activeSettings) {
@@ -144,13 +165,7 @@ function scopedSessionId(sessionId: string, activeSettings: Settings | undefined
 		}
 		return sessionId;
 	}
-	const existing = settingsSessionIds.get(activeSettings);
-	if (existing !== undefined) {
-		return `${sessionId}:settings-${existing}`;
-	}
-	const id = nextSettingsSessionId++;
-	settingsSessionIds.set(activeSettings, id);
-	return `${sessionId}:settings-${id}`;
+	return `${sessionId}:settings-${settingsScope(activeSettings)}`;
 }
 
 async function shutdownOrRetainKernel(kernel: PythonKernel): Promise<void> {

--- a/packages/coding-agent/test/bash-acp-terminal.test.ts
+++ b/packages/coding-agent/test/bash-acp-terminal.test.ts
@@ -3,6 +3,7 @@ import type { ClientBridge, ClientBridgeTerminalHandle } from "../src/session/cl
 import { truncateHeadBytes, truncateTailBytes } from "../src/session/streaming-output";
 import type { ToolSession } from "../src/tools";
 import { BashTool } from "../src/tools/bash";
+import { stubBashExecutorSettings } from "./helpers/tool-session-settings";
 
 interface SessionOptions {
 	tailKiB?: number;
@@ -38,6 +39,7 @@ function makeSession(bridge: ClientBridge, options: SessionOptions = {}): ToolSe
 			getBashInterceptorRules() {
 				return [];
 			},
+			...stubBashExecutorSettings,
 		},
 		getClientBridge: () => bridge,
 		getArtifactManager: options.saveArtifact ? () => ({ save: options.saveArtifact }) : undefined,
@@ -574,6 +576,7 @@ describe("BashTool ACP terminal routing", () => {
 				get: () => undefined,
 				has: () => false,
 				getAgentDir: () => "default-profile",
+				...stubBashExecutorSettings,
 			},
 			getSessionId: () => "test-session",
 			getSessionAgentDir: () => "tenant-profile",
@@ -592,6 +595,7 @@ describe("BashTool ACP terminal routing", () => {
 				get: () => undefined,
 				has: () => false,
 				getAgentDir: () => "default-profile",
+				...stubBashExecutorSettings,
 			},
 			getSessionId: () => "test-session",
 			getSessionAgentDir: () => "tenant-profile",

--- a/packages/coding-agent/test/helpers/tool-session-settings.ts
+++ b/packages/coding-agent/test/helpers/tool-session-settings.ts
@@ -1,0 +1,32 @@
+import { getShellConfig, type ShellConfig } from "@gajae-code/utils/shell-config";
+import type { ShellMinimizerSettings } from "../../src/config/settings-schema";
+
+/**
+ * The `Settings` surface `executeBash` requires from `ToolSession.settings`.
+ *
+ * `ToolSession.settings` is declared as a full `Settings`, and `BashTool`
+ * threads it straight into `executeBash`, which resolves the shell, its
+ * environment, and the configured prefix through `getShellConfig()` and reads
+ * the output minimizer through `getGroup("shellMinimizer")`. A hand-rolled stub
+ * that omits either member makes every real bash execution throw
+ * (`settings.getShellConfig is not a function`) before a process is ever
+ * spawned, so the test asserts nothing about the behavior it claims to cover.
+ *
+ * Spread this into a partial settings stub. `getShellConfig` mirrors
+ * `Settings.getShellConfig()` for a stub that declares no `shellPath`; the
+ * minimizer group is disabled, matching stubs whose `get()` returns `undefined`
+ * for every `shellMinimizer.*` key.
+ */
+export const stubBashExecutorSettings: {
+	getShellConfig: () => ShellConfig;
+	getGroup: (prefix: "shellMinimizer") => ShellMinimizerSettings;
+} = {
+	getShellConfig: () => getShellConfig(),
+	getGroup: () => ({
+		enabled: false,
+		settingsPath: undefined,
+		only: [],
+		except: [],
+		maxCaptureBytes: 0,
+	}),
+};

--- a/packages/coding-agent/test/sdk-credential-disabled-bridge.test.ts
+++ b/packages/coding-agent/test/sdk-credential-disabled-bridge.test.ts
@@ -426,7 +426,10 @@ describe("createAgentSession credential_disabled subscription", () => {
 				unsubscribe();
 			};
 		});
-		vi.spyOn(Settings, "init").mockRejectedValue(new Error("settings initialization failed"));
+		// createAgentSession loads scope-bound settings through `loadForScope`;
+		// `Settings.init` is the ambient-singleton path it deliberately no longer
+		// takes, so mocking that would exercise nothing.
+		vi.spyOn(Settings, "loadForScope").mockRejectedValue(new Error("settings initialization failed"));
 		const { settings: _settings, ...startupOptions } = baseOptions(dirs, authStorage);
 
 		await expect(createAgentSession(startupOptions)).rejects.toThrow(/settings initialization failed/);
@@ -440,7 +443,7 @@ describe("createAgentSession credential_disabled subscription", () => {
 		const storage = await createTestAuthStorage(path.join(dirs.agentDir, "agent.db"));
 		const close = vi.spyOn(storage, "close");
 		vi.spyOn(AuthStorage, "create").mockResolvedValue(storage);
-		vi.spyOn(Settings, "init").mockRejectedValue(new Error("settings initialization failed"));
+		vi.spyOn(Settings, "loadForScope").mockRejectedValue(new Error("settings initialization failed"));
 
 		await expect(createAgentSession({ cwd: dirs.cwd, agentDir: dirs.agentDir })).rejects.toThrow(
 			/settings initialization failed/,

--- a/packages/coding-agent/test/streaming-edit-abort.test.ts
+++ b/packages/coding-agent/test/streaming-edit-abort.test.ts
@@ -496,7 +496,10 @@ it("aborts auto-generated file edits as soon as the path is available", async ()
 		waitBeforeFirstDelta.resolve();
 		await promptPromise;
 
-		expect(checkSpy).toHaveBeenCalledWith(generatedPath, "generated.ts");
+		// The guard receives the resolved path, its display name, and the owning
+		// session's settings — built-in executors read session settings, never
+		// ambient role state (#4826).
+		expect(checkSpy).toHaveBeenCalledWith(generatedPath, "generated.ts", session.settings);
 		expect(abortSpy).toHaveBeenCalled();
 		expect(abortSignalRef.current?.aborted ?? false).toBe(true);
 		const lastAssistant = lastAssistantMessage(session.state.messages);

--- a/packages/coding-agent/test/tools/bash-interceptor.test.ts
+++ b/packages/coding-agent/test/tools/bash-interceptor.test.ts
@@ -10,6 +10,7 @@ import { disposeAllShellSessions, getShellSessionCount } from "../../src/exec/ba
 import type { ToolSession } from "../../src/tools";
 import { BashTool, type BashToolInput } from "../../src/tools/bash";
 import * as shellSnapshot from "../../src/utils/shell-snapshot";
+import { stubBashExecutorSettings } from "../helpers/tool-session-settings";
 
 afterEach(async () => {
 	vi.restoreAllMocks();
@@ -32,6 +33,7 @@ function createBashTool(rules: BashInterceptorRule[]): BashTool {
 			getBashInterceptorRules() {
 				return rules;
 			},
+			...stubBashExecutorSettings,
 		},
 	} as unknown as ToolSession;
 
@@ -109,6 +111,7 @@ describe("BashTool head/tail stripping", () => {
 				getBashInterceptorRules() {
 					return [];
 				},
+				...stubBashExecutorSettings,
 			},
 		} as unknown as ToolSession;
 		return new BashTool(session);
@@ -164,6 +167,7 @@ describe("BashTool restricted role-agent allowlist", () => {
 				getBashInterceptorRules() {
 					return [];
 				},
+				...stubBashExecutorSettings,
 			},
 		} as unknown as ToolSession;
 		return new BashTool(session);

--- a/packages/coding-agent/test/tools/bash-sleep-notice.test.ts
+++ b/packages/coding-agent/test/tools/bash-sleep-notice.test.ts
@@ -7,6 +7,7 @@ import { BashTool } from "@gajae-code/coding-agent/tools/bash";
 import { ToolError } from "@gajae-code/coding-agent/tools/tool-errors";
 import * as shellSnapshot from "@gajae-code/coding-agent/utils/shell-snapshot";
 import { resetShellConfigCache } from "@gajae-code/utils/shell-config";
+import { stubBashExecutorSettings } from "../helpers/tool-session-settings";
 
 /**
  * Observable BashTool integration for the sleep-advisory notice (#4465 review).
@@ -48,6 +49,7 @@ function createBashTool(cwd: string): BashTool {
 			getBashInterceptorRules() {
 				return [];
 			},
+			...stubBashExecutorSettings,
 		},
 	} as unknown as ToolSession;
 	return new BashTool(session);

--- a/packages/coding-agent/test/tools/bash-state-exploit.test.ts
+++ b/packages/coding-agent/test/tools/bash-state-exploit.test.ts
@@ -7,6 +7,7 @@ import type { ToolSession } from "@gajae-code/coding-agent/tools";
 import { BashTool } from "@gajae-code/coding-agent/tools/bash";
 import * as shellSnapshot from "@gajae-code/coding-agent/utils/shell-snapshot";
 import { resetShellConfigCache } from "@gajae-code/utils/shell-config";
+import { stubBashExecutorSettings } from "../helpers/tool-session-settings";
 
 const SEEDED_TREE_TIME = new Date("2020-01-01T00:00:00.000Z");
 
@@ -50,6 +51,7 @@ function createRestrictedBashTool(cwd: string, prefixes: string[] = ROLE_AGENT_P
 			getBashInterceptorRules() {
 				return [];
 			},
+			...stubBashExecutorSettings,
 		},
 	} as unknown as ToolSession;
 	return new BashTool(session);


### PR DESCRIPTION
## What

Repairs `dev`, which has been red on 5 of 8 `coding-agent` test shards since #4829 (issue #4826) landed.

Two independent defects, both introduced by binding built-in executors to session settings:

**1. Python kernel reuse broken (product bug, `src` fix).** `scopedSessionId` suffixed every kernel key with a per-`Settings`-instance counter from a `WeakMap`. Two logical sessions in one process resolve the same shell configuration and therefore spawn byte-identical kernels, so keying on object identity partitioned them anyway: each started its own kernel, and disposing one shut down a kernel the other still owned. The scope is now a fingerprint of the resolved shell config (shell, args, environment) — the only settings-derived input `PythonKernel.start` reads. Equivalent settings share one retained kernel; genuinely different shell environments stay isolated, preserving what the settings-scoping change wanted.

**2. Stale test doubles (test fix).** Three classes:

- Partial `ToolSession.settings` stubs omitted `getShellConfig` and `getGroup`. `BashTool` threads `session.settings` into `executeBash`, so every execution threw `settings.getShellConfig is not a function` before spawning a process — the suites named their behaviors and proved none of them. A shared helper (`test/helpers/tool-session-settings.ts`) now supplies exactly the surface `executeBash` consumes.
- `streaming-edit-abort` still asserted the two-argument `assertEditableFile` call; it now takes session settings as a third argument.
- Two SDK startup-failure tests mocked `Settings.init`, the ambient-singleton path `createAgentSession` deliberately no longer takes (it uses `Settings.loadForScope`), so their rejection paths were never entered.

Deliberately not done: making `executeBash` tolerate a settings object lacking `getShellConfig`. That is a fallback that hides broken callers in production.

## Why

`dev` CI has been failing since #4829. The most recent green `dev` run (`a61d643`) is vacuous — that commit only changed `assets/hero.png`, so affected-path detection ran no coding-agent tests. The three `dev` runs before it that did run tests all failed on the same 5 shards.

Beyond CI, defect 1 is a live cross-session Python kernel leak: one SDK session's dispose can shut down a kernel another session is actively using.

## Testing

- `bun test` on all 7 affected files — 103 pass, 0 fail (was 15 fail + 2 fail).
- `bun test` across all 32 python/eval test files — 170 pass, 0 fail.
- `bun --cwd=packages/coding-agent run check` — exit 0.

Root cause for defect 1 was confirmed by isolation, not inference: removing `settings: this.settings` from the `executePythonCommand` call turned the 2 failures green, pinning the regression to that argument before any fix was written.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:09e32b5e3fec903100964b8530e7fa896b3ef7cb7b15914daac938fd148046ae reviewer:human reviewer-id:Yeachan-Heo evidence:bun test (103 tests, 7 files) + 170 python/eval tests + bun --cwd=packages/coding-agent run check exit=0
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
