### PR TITLE
fix(coordinator-mcp): mark unregistered sessions in list_sessions

### DIFF
--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -888,6 +888,17 @@ function toolSchema(name: CoordinatorToolName): {
 			},
 		};
 	}
+	if (name === "gjc_coordinator_list_sessions") {
+		return {
+			name,
+			description:
+				"Enumerate GJC sessions discovered on the broker under the allowed roots. Each entry reports " +
+				"`registered`: only sessions with `registered: true` can be used with the other coordinator " +
+				"tools. Calling read_status, read_tail, send_prompt, or stop_session on an entry with " +
+				"`registered: false` returns not_found; register it with gjc_coordinator_register_session first.",
+			inputSchema: common,
+		};
+	}
 	return { name, description: "List known scoped GJC coordinator bridge sessions.", inputSchema: common };
 }
 
@@ -5341,6 +5352,21 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 	function sessionFile(sessionId: unknown): string {
 		return path.join(namespaceDir, "sessions", `${safeExternalId("session", sessionId)}.json`);
 	}
+	/**
+	 * True when the session has a durable coordinator projection, i.e. when tools
+	 * other than list_sessions can resolve it. A broker session that was never
+	 * registered answers false instead of throwing, so listing stays total.
+	 */
+	async function isRegisteredSession(sessionId: unknown): Promise<boolean> {
+		if (typeof sessionId !== "string" || sessionId.length === 0) return false;
+		let file: string;
+		try {
+			file = sessionFile(sessionId);
+		} catch {
+			return false;
+		}
+		return asRecord(await readJsonFile(file)) !== null;
+	}
 	async function removeReapedProjection(
 		sessionId: string,
 		turnIds: readonly string[],
@@ -7088,8 +7114,20 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 
 	async function callTool(name: string, args: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
 		try {
-			if (name === "gjc_coordinator_list_sessions")
-				return { ok: true, sessions: (await listSessions()).map(publicBrokerSession) };
+			if (name === "gjc_coordinator_list_sessions") {
+				// listSessions() enumerates the broker across allowed roots, but every other
+				// coordinator tool resolves a session through its durable projection. Without
+				// an explicit marker a controller cannot tell the two apart and burns a
+				// not_found round-trip per unregistered session, which trips client-side
+				// consecutive-failure breakers. Publish registration as first-class state.
+				const sessions = await Promise.all(
+					(await listSessions()).map(async session => {
+						const view = publicBrokerSession(session);
+						return { ...view, registered: await isRegisteredSession(view.session_id) };
+					}),
+				);
+				return { ok: true, sessions };
+			}
 			if (name === "gjc_coordinator_register_session") {
 				requireCoordinatorMutation(config, "sessions", args);
 				const idempotencyKey = requiredIdempotencyKey(args);

--- a/packages/coding-agent/test/coordinator-mcp/list-sessions.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp/list-sessions.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { createCoordinatorMcpServer } from "../../src/coordinator-mcp/server";
+import { writeBrokerDiscovery } from "../../src/sdk/broker/discovery";
+import type { SdkClient } from "../../src/sdk/client/client";
+import {
+	coordinatorFixtureRoot,
+	fixtureBrokerRows,
+	writeDurableCoordinatorSession,
+} from "../helpers/coordinator-session-fixture";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+const REGISTERED_ID = "11111111-1111-4111-8111-111111111111";
+const BROKER_ONLY_ID = "22222222-2222-4222-8222-222222222222";
+
+/**
+ * A coordinator whose broker reports two sessions under the allowed root. Only
+ * one of them has a durable projection, which is the split real controllers
+ * hit: the broker index is workspace-wide while projections are not.
+ */
+async function createServer(root: string, options: { registerFirst?: boolean } = {}) {
+	const agentDir = path.join(root, "agent-global");
+	const env: NodeJS.ProcessEnv = {
+		GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
+		GJC_COORDINATOR_MCP_STATE_ROOT: path.join(root, ".gjc", "coordinator-state"),
+		GJC_COORDINATOR_MCP_MUTATIONS: "sessions",
+		GJC_COORDINATOR_MCP_PROFILE: "local",
+		GJC_COORDINATOR_MCP_REPO: "repo",
+	};
+	await writeBrokerDiscovery(agentDir, {
+		version: 1,
+		protocolVersion: 3,
+		packageGeneration: "test",
+		ownerId: "test",
+		pid: process.pid,
+		host: "127.0.0.1",
+		port: 1,
+		url: "ws://sdk.example.test",
+		token: "test-token",
+		startedAt: Date.now(),
+		heartbeatAt: Date.now(),
+	});
+	const brokerSessions = [fixtureBrokerRows(root, REGISTERED_ID).live, fixtureBrokerRows(root, BROKER_ONLY_ID).live];
+	const server = createCoordinatorMcpServer({
+		env,
+		services: {
+			getAgentDir: () => agentDir,
+			connectBroker: async () =>
+				({
+					global: async (operation: string, input: Record<string, unknown>) => {
+						if (operation === "session.list") return { ok: true, result: { sessions: brokerSessions } };
+						return { ok: true, result: { sessionId: input.sessionId } };
+					},
+					close: async () => {},
+				}) as unknown as SdkClient,
+		},
+	});
+	if (options.registerFirst !== false)
+		await writeDurableCoordinatorSession({ sessionId: REGISTERED_ID, cwd: root, env });
+	return server;
+}
+
+describe("gjc_coordinator_list_sessions registration marker", () => {
+	it("reports registered for projected sessions and unregistered for broker-only ones", async () => {
+		const root = await coordinatorFixtureRoot(tempDirs);
+		const server = await createServer(root);
+
+		const listed = (await server.callTool("gjc_coordinator_list_sessions", {})) as {
+			ok: boolean;
+			sessions: Array<{ session_id?: string; registered?: boolean }>;
+		};
+
+		expect(listed.ok).toBe(true);
+		const byId = new Map(listed.sessions.map(session => [session.session_id, session]));
+		expect(byId.get(REGISTERED_ID)?.registered).toBe(true);
+		expect(byId.get(BROKER_ONLY_ID)?.registered).toBe(false);
+	});
+
+	it("predicts not_found: session-scoped tools reject exactly the unregistered entries", async () => {
+		const root = await coordinatorFixtureRoot(tempDirs);
+		const server = await createServer(root);
+
+		// The marker is only useful if it is the same condition other tools
+		// enforce, so assert it against real tool behavior rather than against
+		// the projection file it is derived from.
+		for (const tool of ["gjc_coordinator_read_status", "gjc_coordinator_read_tail"]) {
+			expect(await server.callTool(tool, { session_id: BROKER_ONLY_ID })).toMatchObject({
+				ok: false,
+				error: { code: "not_found" },
+			});
+		}
+	});
+
+	it("marks every session unregistered when no projection exists", async () => {
+		const root = await coordinatorFixtureRoot(tempDirs);
+		const server = await createServer(root, { registerFirst: false });
+
+		const listed = (await server.callTool("gjc_coordinator_list_sessions", {})) as {
+			sessions: Array<{ registered?: boolean }>;
+		};
+
+		expect(listed.sessions).toHaveLength(2);
+		expect(listed.sessions.every(session => session.registered === false)).toBe(true);
+	});
+
+	it("advertises the registered contract in the tool description", async () => {
+		const root = await coordinatorFixtureRoot(tempDirs);
+		const server = await createServer(root);
+
+		const response = (await server.handleJsonRpc({ jsonrpc: "2.0", id: 1, method: "tools/list" })) as {
+			result?: { tools?: Array<{ name: string; description: string }> };
+		};
+		const listSessions = response.result?.tools?.find(tool => tool.name === "gjc_coordinator_list_sessions");
+
+		expect(listSessions?.description).toContain("registered");
+		expect(listSessions?.description).toContain("not_found");
+	});
+});


### PR DESCRIPTION
## Problem

`gjc_coordinator_list_sessions` enumerates the **broker** across the allowed roots:

```ts
if (name === "gjc_coordinator_list_sessions")
    return { ok: true, sessions: (await listSessions()).map(publicBrokerSession) };
```

Every other coordinator tool resolves a session through its **durable projection** (`sessionFile(sessionId)`), and returns `not_found` when there is none. `publicBrokerSession` emits only `session_id`, `live`, and `terminal_uncertain`, so a listed entry carries nothing that distinguishes the two sets.

The result is a tool that advertises session ids no other tool accepts.

## Impact observed

On a workspace driven by an external coordinator (Hermes) over this bridge:

| | count |
|---|---|
| sessions in the broker index | 350 |
| sessions with a coordinator projection | 24 |
| ids returned by one `list_sessions` call | 9 |
| of those, addressable | **0** |

The controller called `read_status` on ids it had just received from `list_sessions`, got `Coordinator session not found` three times in a row, and its consecutive-failure breaker opened:

```
MCP server 'gjc_coordinator' is unreachable after 3 consecutive failures.
Auto-retry available in ~48s.
```

Every subsequent coordinator call in that turn was rejected client-side. Across that controller's history this was the single most frequent coordinator error, and it is reachable purely by enumerating state — no mutation required.

The existing remedy (`gjc_coordinator_register_session`) is correct but undiscoverable: nothing in the listing says which entries need it.

## Change

- `list_sessions` reports `registered: boolean` on every entry.
- `isRegisteredSession` answers `false` for ids that cannot form a projection path instead of throwing, so listing stays total even with malformed broker rows.
- The tool description states the contract. The previous text — `"List known scoped GJC coordinator bridge sessions."` — described sessions it does not return.

No behavior change for already-registered sessions; this is an additive field plus documentation.

## Tests

`packages/coding-agent/test/coordinator-mcp/list-sessions.test.ts` (4 cases):

- registered vs broker-only entries are marked correctly
- **the flag predicts real tool behavior** — asserted against `read_status`/`read_tail` returning `not_found`, not against the projection file the flag is derived from
- everything is unregistered before any registration
- the description advertises the contract

Durable sessions come from the existing `coordinator-session-fixture` helper (`writeDurableCoordinatorSession` / `fixtureBrokerRows`), so the test uses the same canonical layout as the rest of the coordinator suite rather than hand-writing projection files.

```
bun test packages/coding-agent/test/coordinator-mcp/   →  46 pass / 0 fail
tsc --noEmit -p packages/coding-agent                  →  clean
biome check                                            →  clean (3 pre-existing warnings, server.ts:2530/2552)
bun scripts/verify-gjc-state-writers.ts --fail         →  0 unsanctioned write sites
```

Rebased onto `dev`; `git merge-base --is-ancestor upstream/dev HEAD` passes.
