### PR TITLE
test(coding-agent): stop the composer-detach suite aborting the test process

### DIFF
--- a/packages/coding-agent/test/composer-detach-overlay-paths.test.ts
+++ b/packages/coding-agent/test/composer-detach-overlay-paths.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, vi } from "bun:test";
 import { randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
@@ -191,15 +191,27 @@ function restoreEnvVar(name: string, original: string | undefined): void {
  * agent directory gets its own mkdtemp root. The resolved config root is
  * asserted to sit inside the exclusive name before anything is seeded, so a
  * resolver that refuses the override (e.g. a project-env provenance clash)
- * fails the test loudly instead of touching the real `~/.gjc`. The returned
- * restore closure puts the exact prior environment and agent directory back
- * and removes both exclusive trees.
+ * fails the test loudly instead of touching the real `~/.gjc`.
+ *
+ * The config root is derived from the home directory, so the home is first
+ * redirected to an owned temp tree. Anchoring the exclusive name under the
+ * real home instead put the tree outside every allowed cleanup root, and the
+ * fail-closed test cleanup contract (#4794) aborted the whole test process
+ * rather than recursing there — taking every later file in the run with it and
+ * leaving the directory behind in the developer's home.
+ *
+ * The returned restore closure puts the exact prior environment, home, and
+ * agent directory back and removes both exclusive trees.
  */
 async function pinExclusiveDirState(): Promise<{ restore: () => Promise<void> }> {
 	const originalAgentDir = getAgentDir();
 	const originalConfigDir = process.env.PI_CONFIG_DIR;
 	const originalGjcConfigDir = process.env.GJC_CONFIG_DIR;
 	const originalCodingAgentDir = process.env.GJC_CODING_AGENT_DIR;
+	const originalHome = process.env.HOME;
+	const homeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-composer-detach-home-"));
+	const homedirSpy = vi.spyOn(os, "homedir").mockReturnValue(homeRoot);
+	process.env.HOME = homeRoot;
 	const agentRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-composer-detach-agent-"));
 	const configName = `gjc-composer-detach-${randomUUID()}`;
 	process.env.GJC_CONFIG_DIR = configName;
@@ -217,8 +229,10 @@ async function pinExclusiveDirState(): Promise<{ restore: () => Promise<void> }>
 			// setAgentDir re-exports GJC_CODING_AGENT_DIR, so restore it after.
 			setAgentDir(originalAgentDir);
 			restoreEnvVar("GJC_CODING_AGENT_DIR", originalCodingAgentDir);
+			restoreEnvVar("HOME", originalHome);
+			homedirSpy.mockRestore();
 			await fs.rm(agentRoot, { recursive: true, force: true });
-			await fs.rm(configRoot, { recursive: true, force: true });
+			await fs.rm(homeRoot, { recursive: true, force: true });
 		},
 	};
 }


### PR DESCRIPTION
## What

`packages/coding-agent/test/composer-detach-overlay-paths.test.ts` aborts the entire test process and leaves a directory behind in the developer's home.

`pinExclusiveDirState` derived its exclusive config root from the real home (`path.join(os.homedir(), configName)`). That tree sits outside every allowed cleanup root, so the fail-closed test cleanup contract (#4794) refused to recurse there and killed the process:

```
[safe-cleanup:test-preload] REFUSED recursive deletion of /Users/<user>/gjc-composer-detach-<uuid> (outside-allowed-roots)
[safe-cleanup:test-preload] aborting process: recursive test cleanup must never leave the allowed roots (issue #4794)
```

`bun test packages/coding-agent/test/composer-detach-overlay-paths.test.ts` exits **70** on `dev` today.

The fix redirects `HOME` and `os.homedir()` to an owned `mkdtemp` root before deriving anything, matching what the existing `withTempHome` helper already does, and removes that captured root on restore instead of a path re-derived from `HOME` afterwards.

Deliberately not done: widening the safe-cleanup allowlist to cover home-anchored test trees. That weakens the exact guard the abort exists to enforce.

## Why

This is worse than an ordinary test failure. `bun test packages/coding-agent/test` dies at this file, so every test file after it never runs — the local suite silently reports far less than it appears to, and each run deposits another `~/gjc-composer-detach-<uuid>` in the developer's home.

## Testing

- `bun test packages/coding-agent/test/composer-detach-overlay-paths.test.ts` — 9 pass, 0 fail, exit 0 (was exit 70, 0 tests reported).
- Confirmed no `~/gjc-composer-detach-*` directory is created by the run.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:5dabaeca0cfa253ca1f6cafee5472180eb20eea8957e3a5a49eb249c566ed542 reviewer:human reviewer-id:Yeachan-Heo evidence:bun test composer-detach-overlay-paths 9 pass exit=0 (was exit 70) + no ~/gjc-composer-detach-* left behind
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
