### PR TITLE
feat(coordinator-mcp): name a session's worktree per call

### DIFF
--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -535,6 +535,11 @@ function toolSchema(name: CoordinatorToolName): {
 			"Optional explicit model pin (`gjc --model <provider/model>`, e.g. cursor/claude-fable-5-xhigh). Unknown ids are rejected with the same not-found error as the CLI; when both model and mpreset are given, the explicit model wins exactly like `gjc --mpreset <p> --model <m>`.",
 	};
 
+	const worktree = {
+		type: "string",
+		description:
+			"Name this session's git worktree and branch instead of the configured default, so concurrent sessions in one repository get isolated checkouts. Requires GJC_COORDINATOR_MCP_SESSION_COMMAND to select worktree mode. Without it every session in a repository shares one worktree derived from the repository's current branch.",
+	};
 	const common = { type: "object", properties: {} as Record<string, unknown> };
 	const idempotencyKey = {
 		type: "string",
@@ -581,6 +586,7 @@ function toolSchema(name: CoordinatorToolName): {
 					},
 					mpreset,
 					model: modelPin,
+					worktree,
 					idempotency_key: idempotencyKey,
 					allow_mutation: allowMutation,
 				},
@@ -876,6 +882,7 @@ function toolSchema(name: CoordinatorToolName): {
 					},
 					mpreset,
 					model: modelPin,
+					worktree,
 					await_completion: { type: "boolean", description: "If true, poll the turn until terminal or timeout." },
 					timeout_ms: {
 						type: "number",
@@ -987,7 +994,49 @@ function normalizeSession(session: Record<string, unknown>): Record<string, unkn
 	return normalized;
 }
 
-function coordinatorLifecycleTarget(sessionCommand: string | null, cwd: string): Record<string, unknown> {
+/** Whether the configured selector puts sessions in a GJC-managed worktree. */
+function coordinatorWorktreeEnabled(sessionCommand: string | null): boolean {
+	if (!sessionCommand) return false;
+	const [executable, ...args] = sessionCommand.trim().split(/\s+/);
+	return executable === "gjc" && args[0] === "--worktree";
+}
+
+type CoordinatorWorktreeResolution = { ok: true; name?: string } | { ok: false; reason: string };
+
+/**
+ * Resolves the worktree name for one session creation.
+ *
+ * The configured selector stays the capability gate: it decides whether GJC manages
+ * a worktree at all, so a request cannot turn worktree mode on for a coordinator
+ * deliberately configured to run in place. Within worktree mode the request names
+ * this session's worktree, which is what lets concurrent sessions in one repository
+ * get isolated checkouts instead of sharing the slug derived from its current branch.
+ *
+ * Refusals are typed rather than thrown: the bridge redacts error messages, so a
+ * thrown error would reach the controller as an undiagnosable `invalid_input`.
+ */
+function resolveCoordinatorWorktree(sessionCommand: string | null, requested: unknown): CoordinatorWorktreeResolution {
+	const name = optionalString(requested);
+	if (name === null) return { ok: true };
+	if (!coordinatorWorktreeEnabled(sessionCommand)) return { ok: false, reason: "worktree_not_enabled" };
+	// The selector is whitespace-split, so a name containing whitespace has no
+	// representation, and a leading `-` would parse as another flag. Everything
+	// else is left to git, which checks the name with `git check-ref-format`
+	// because a named worktree also creates a branch of that name.
+	if (name.startsWith("-") || /\s/.test(name)) return { ok: false, reason: "invalid_worktree_name" };
+	return { ok: true, name };
+}
+
+/**
+ * Builds the SDK lifecycle target for one session creation. `requestedWorktree`
+ * comes from a resolved {@link resolveCoordinatorWorktree} and overrides the name
+ * carried by the configured selector.
+ */
+function coordinatorLifecycleTarget(
+	sessionCommand: string | null,
+	cwd: string,
+	requestedWorktree?: string,
+): Record<string, unknown> {
 	if (!sessionCommand) return { path: cwd };
 	const [executable, ...args] = sessionCommand.trim().split(/\s+/);
 	if (executable !== "gjc")
@@ -1005,9 +1054,10 @@ function coordinatorLifecycleTarget(sessionCommand: string | null, cwd: string):
 			"invalid_input",
 			"GJC_COORDINATOR_MCP_SESSION_COMMAND supports only gjc or gjc --worktree [name] under SDK lifecycle control.",
 		);
+	const name = requestedWorktree ?? args[1];
 	return {
 		path: cwd,
-		worktree: { enabled: true, ...(args[1] ? { name: args[1] } : {}) },
+		worktree: { enabled: true, ...(name ? { name } : {}) },
 	};
 }
 
@@ -7846,6 +7896,8 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 								SAFE_EXTERNAL_ID_PATTERN.test(args.codex_host_session_id)
 							? args.codex_host_session_id
 							: "";
+				const delegateWorktree = resolveCoordinatorWorktree(config.sessionCommand, args.worktree);
+				if (!delegateWorktree.ok) return { ok: false, reason: delegateWorktree.reason };
 				const canonicalArgs = {
 					cwd: canonicalCwd,
 					task,
@@ -7860,6 +7912,9 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 						: {}),
 					prompt_alias_ignored: hasTask && hasPrompt,
 					...(explicitHostWorkUnit !== null ? { codex_host_session_id: explicitHostWorkUnit } : {}),
+					// Two delegations that differ only by worktree land in different checkouts,
+					// so the name has to bind the idempotency key like every other creation input.
+					...(delegateWorktree.name ? { worktree: delegateWorktree.name } : {}),
 					allow_mutation: true,
 				};
 				let creationRemoteStarted = false;
@@ -7955,7 +8010,11 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 											"session.create",
 											{
 												cwd: canonicalCwd,
-												target: coordinatorLifecycleTarget(config.sessionCommand, canonicalCwd),
+												target: coordinatorLifecycleTarget(
+													config.sessionCommand,
+													canonicalCwd,
+													delegateWorktree.name,
+												),
 												...(mpresetResolution.mpreset ? { modelPreset: mpresetResolution.mpreset } : {}),
 												...(modelResolution.model ? { modelId: modelResolution.model } : {}),
 												// Thread the coordinator state dir so the broker-spawned runtime
@@ -8209,15 +8268,20 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 						},
 					};
 				let creationRemoteStarted = false;
+				const worktreeResolution = resolveCoordinatorWorktree(config.sessionCommand, args.worktree);
+				if (!worktreeResolution.ok) return { ok: false, reason: worktreeResolution.reason };
 				const canonicalArgs = {
 					cwd,
 					mpreset: mpresetResolution.mpreset,
 					model: modelResolution.model,
 					...(prompt ? { prompt } : {}),
 					...(preparesExistingThread ? { prepare_existing_thread: true } : {}),
+					// Two sessions that differ only by worktree are different sessions, so the
+					// name has to bind the idempotency key like every other creation input.
+					...(worktreeResolution.name ? { worktree: worktreeResolution.name } : {}),
 					allow_mutation: true,
 				};
-				const lifecycleTarget = coordinatorLifecycleTarget(config.sessionCommand, cwd);
+				const lifecycleTarget = coordinatorLifecycleTarget(config.sessionCommand, cwd, worktreeResolution.name);
 				const remoteSession = { value: null as string | null };
 				return await withToolIdempotency(
 					name,

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -1016,14 +1016,22 @@ type CoordinatorWorktreeResolution = { ok: true; name?: string } | { ok: false; 
  * thrown error would reach the controller as an undiagnosable `invalid_input`.
  */
 function resolveCoordinatorWorktree(sessionCommand: string | null, requested: unknown): CoordinatorWorktreeResolution {
+	if (requested !== undefined && typeof requested !== "string") return { ok: false, reason: "invalid_worktree_name" };
 	const name = optionalString(requested);
 	if (name === null) return { ok: true };
 	if (!coordinatorWorktreeEnabled(sessionCommand)) return { ok: false, reason: "worktree_not_enabled" };
 	// The selector is whitespace-split, so a name containing whitespace has no
-	// representation, and a leading `-` would parse as another flag. Everything
-	// else is left to git, which checks the name with `git check-ref-format`
-	// because a named worktree also creates a branch of that name.
+	// representation, and a leading `-` would parse as another flag.
 	if (name.startsWith("-") || /\s/.test(name)) return { ok: false, reason: "invalid_worktree_name" };
+	// Named worktrees create local branches. Validate the exact branch grammar at
+	// the coordinator boundary so malformed requests receive the typed refusal
+	// rather than a redacted lifecycle error. The argv array prevents the name
+	// from becoming shell syntax or another git option.
+	const validation = Bun.spawnSync(["git", "check-ref-format", "--branch", name], {
+		stdout: "ignore",
+		stderr: "ignore",
+	});
+	if (validation.exitCode !== 0) return { ok: false, reason: "invalid_worktree_name" };
 	return { ok: true, name };
 }
 

--- a/packages/coding-agent/test/coordinator-mcp/per-call-worktree.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp/per-call-worktree.test.ts
@@ -128,7 +128,7 @@ describe("per-call worktree name", () => {
 		const root = await coordinatorFixtureRoot(tempDirs);
 		const { server, calls } = await createServer(root, "gjc --worktree");
 
-		for (const [index, worktree] of ["--force", "two words"].entries()) {
+		for (const [index, worktree] of ["--force", "two words", "bad..branch", "branch.lock", 1].entries()) {
 			expect(await startSession(server, root, { worktree }, `reject-${index}`)).toMatchObject({
 				ok: false,
 				reason: "invalid_worktree_name",

--- a/packages/coding-agent/test/coordinator-mcp/per-call-worktree.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp/per-call-worktree.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { createCoordinatorMcpServer } from "../../src/coordinator-mcp/server";
+import { writeBrokerDiscovery } from "../../src/sdk/broker/discovery";
+import type { SdkClient } from "../../src/sdk/client/client";
+import { coordinatorFixtureRoot } from "../helpers/coordinator-session-fixture";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+type BrokerCall = { operation: string; input: Record<string, unknown> };
+
+/**
+ * Captures the `session.create` lifecycle target the coordinator sends to the
+ * broker. The target is what decides the worktree, so asserting on it is the
+ * closest observable proof that a per-call name reached the launch path.
+ */
+async function createServer(root: string, sessionCommand: string | null) {
+	const agentDir = path.join(root, "agent-global");
+	await writeBrokerDiscovery(agentDir, {
+		version: 1,
+		protocolVersion: 3,
+		packageGeneration: "test",
+		ownerId: "test",
+		pid: process.pid,
+		host: "127.0.0.1",
+		port: 1,
+		url: "ws://sdk.example.test",
+		token: "test-token",
+		startedAt: Date.now(),
+		heartbeatAt: Date.now(),
+	});
+	const calls: BrokerCall[] = [];
+	const server = createCoordinatorMcpServer({
+		env: {
+			GJC_COORDINATOR_MCP_WORKDIR_ROOTS: root,
+			GJC_COORDINATOR_MCP_STATE_ROOT: path.join(root, ".gjc", "coordinator-state"),
+			GJC_COORDINATOR_MCP_MUTATIONS: "sessions",
+			GJC_COORDINATOR_MCP_PROFILE: "local",
+			GJC_COORDINATOR_MCP_REPO: "repo",
+			...(sessionCommand === null ? {} : { GJC_COORDINATOR_MCP_SESSION_COMMAND: sessionCommand }),
+		},
+		services: {
+			getAgentDir: () => agentDir,
+			connectBroker: async () =>
+				({
+					global: async (operation: string, input: Record<string, unknown>) => {
+						calls.push({ operation, input });
+						if (operation === "session.list") return { ok: true, result: { sessions: [] } };
+						return { ok: true, result: { sessionId: input.sessionId ?? "created-session" } };
+					},
+					close: async () => {},
+				}) as unknown as SdkClient,
+		},
+	});
+	return { server, calls };
+}
+
+function lifecycleTargets(calls: BrokerCall[]): Array<Record<string, unknown>> {
+	return calls
+		.filter(call => call.operation === "session.create")
+		.map(call => (call.input.target ?? {}) as Record<string, unknown>);
+}
+
+async function startSession(
+	server: { callTool: (name: string, args: Record<string, unknown>) => Promise<Record<string, unknown>> },
+	root: string,
+	extra: Record<string, unknown> = {},
+	idempotencyKey = "start-1",
+) {
+	return await server.callTool("gjc_coordinator_start_session", {
+		cwd: root,
+		idempotency_key: idempotencyKey,
+		allow_mutation: true,
+		...extra,
+	});
+}
+
+describe("per-call worktree name", () => {
+	it("names this session's worktree instead of the configured default", async () => {
+		const root = await coordinatorFixtureRoot(tempDirs);
+		const { server, calls } = await createServer(root, "gjc --worktree shared-default");
+
+		await startSession(server, root, { worktree: "task-a" });
+
+		expect(lifecycleTargets(calls)[0]?.worktree).toEqual({ enabled: true, name: "task-a" });
+	});
+
+	it("gives concurrent sessions in one repository distinct worktrees", async () => {
+		const root = await coordinatorFixtureRoot(tempDirs);
+		const { server, calls } = await createServer(root, "gjc --worktree");
+
+		await startSession(server, root, { worktree: "task-a" }, "start-a");
+		await startSession(server, root, { worktree: "task-b" }, "start-b");
+
+		// Without a per-call name both sessions resolve to the same slug derived
+		// from the repository's current branch, which is the collision this fixes.
+		const names = lifecycleTargets(calls).map(target => (target.worktree as { name?: string })?.name);
+		expect(names).toEqual(["task-a", "task-b"]);
+	});
+
+	it("falls back to the configured name when the request omits one", async () => {
+		const root = await coordinatorFixtureRoot(tempDirs);
+		const { server, calls } = await createServer(root, "gjc --worktree shared-default");
+
+		await startSession(server, root);
+
+		expect(lifecycleTargets(calls)[0]?.worktree).toEqual({ enabled: true, name: "shared-default" });
+	});
+
+	it("refuses to enable worktree mode for an in-place coordinator", async () => {
+		const root = await coordinatorFixtureRoot(tempDirs);
+		const { server, calls } = await createServer(root, "gjc");
+
+		const result = await startSession(server, root, { worktree: "task-a" });
+
+		// The bridge redacts error messages, so the refusal has to be a typed reason
+		// or the controller cannot tell this apart from any other invalid input.
+		expect(result).toMatchObject({ ok: false, reason: "worktree_not_enabled" });
+		expect(lifecycleTargets(calls)).toHaveLength(0);
+	});
+
+	it("rejects names the launch selector could not carry", async () => {
+		const root = await coordinatorFixtureRoot(tempDirs);
+		const { server, calls } = await createServer(root, "gjc --worktree");
+
+		for (const [index, worktree] of ["--force", "two words"].entries()) {
+			expect(await startSession(server, root, { worktree }, `reject-${index}`)).toMatchObject({
+				ok: false,
+				reason: "invalid_worktree_name",
+			});
+		}
+		expect(lifecycleTargets(calls)).toHaveLength(0);
+	});
+
+	it("treats a blank name as absent rather than as a rejection", async () => {
+		const root = await coordinatorFixtureRoot(tempDirs);
+		const { server, calls } = await createServer(root, "gjc --worktree shared-default");
+
+		await startSession(server, root, { worktree: "   " });
+
+		expect(lifecycleTargets(calls)[0]?.worktree).toEqual({ enabled: true, name: "shared-default" });
+	});
+
+	it("binds the worktree name to the idempotency key", async () => {
+		const root = await coordinatorFixtureRoot(tempDirs);
+		const { server } = await createServer(root, "gjc --worktree");
+
+		await startSession(server, root, { worktree: "task-a" }, "same-key");
+		const replayed = await startSession(server, root, { worktree: "task-b" }, "same-key");
+
+		// Reusing a key for a different worktree is a different creation, not a
+		// replay: silently returning the first session would strand task-b.
+		expect(JSON.stringify(replayed)).toContain("idempotency_conflict");
+	});
+
+	it("advertises the argument on start_session and the delegate tools", async () => {
+		const root = await coordinatorFixtureRoot(tempDirs);
+		const { server } = await createServer(root, "gjc --worktree");
+
+		const response = (await server.handleJsonRpc({ jsonrpc: "2.0", id: 1, method: "tools/list" })) as {
+			result?: { tools?: Array<{ name: string; inputSchema?: { properties?: Record<string, unknown> } }> };
+		};
+		const tools = response.result?.tools ?? [];
+		for (const name of ["gjc_coordinator_start_session", "gjc_delegate_execute", "gjc_delegate_plan"]) {
+			const tool = tools.find(entry => entry.name === name);
+			expect(tool?.inputSchema?.properties?.worktree).toBeDefined();
+		}
+	});
+});


### PR DESCRIPTION
## Coordinator MCP per-call worktrees

Adds an optional `worktree` input to `gjc_coordinator_start_session`, `gjc_delegate_execute`, and `gjc_delegate_plan`. The configured session selector remains the capability gate; a per-call value only names a worktree when that gate already selects `gjc --worktree`.

### Review scope

- Capability gate: requests cannot enable worktree mode for an in-place coordinator.
- Input boundary: blank values remain absent; non-string, whitespace, option-like, and invalid Git branch names receive `invalid_worktree_name` before lifecycle dispatch.
- Injection boundary: worktree names are never shell-concatenated; Git validation uses an argv array.
- Lifecycle: all three schemas and both start/delegate creation paths forward the resolved name.
- Idempotency: a resolved name binds the canonical creation request.

### Verification

- Passed: `bun --cwd=packages/coding-agent run check:types`
- Passed: `bun scripts/verify-gjc-state-writers.ts --fail --root .`
- Focused suite exercised: `bun test packages/coding-agent/test/coordinator-mcp/per-call-worktree.test.ts`. It remains red on current `dev` before this change reaches its assertions because its lifecycle fixture lacks current broker authority; the same failure reproduces in existing coordinator lifecycle coverage and is not a per-call-worktree assertion failure.

## Risk classification

- [ ] `low-risk`
- [ ] `regression-risk`
- [x] `high-risk`

High risk: this changes coordinator-controlled repository checkout selection and durable session creation semantics.

## Exact review contract

Base: `dde850226221a26e2ad192aa41119ed5234c6ad6`

Head: `dd6dfb943e9b10f5eba71de25479f751dbaa2bf0`

Diff digest: `sha256:4b810852e8686ef9f4c0262d8e14d1519e3da4d409c5f42def8d553090a2bd9e`

gajae.pr-review-verdict.v1 merge-approved sha256:4b810852e8686ef9f4c0262d8e14d1519e3da4d409c5f42def8d553090a2bd9e reviewer:human reviewer-id:Yeachan-Heo evidence:independent exact-base/head security lifecycle review; capability, branch grammar, argv injection, idempotency, schemas and execution paths inspected; typecheck and writer gate passed