### PR TITLE
docs(readme): replace expired community Discord invite with permanent invite

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -18,7 +18,7 @@
   <a href="https://gajae-code.com"><img alt="Website" src="https://img.shields.io/badge/website-gajae--code.com-ff4d4f?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/gajae-code"><img alt="npm package" src="https://img.shields.io/npm/v/gajae-code?style=flat-square"></a>
   <a href="LICENSE"><img alt="MIT license" src="https://img.shields.io/badge/license-MIT-green?style=flat-square"></a>
-  <a href="https://discord.gg/EFedyMMbcF"><img alt="Discord" src="https://img.shields.io/badge/Discord-join-5865F2?style=flat-square&logo=discord&logoColor=white"></a>
+  <a href="https://discord.gg/wSyUQYfhAw"><img alt="Discord" src="https://img.shields.io/badge/Discord-join-5865F2?style=flat-square&logo=discord&logoColor=white"></a>
 </p>
 
 <p align="center">

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
   <a href="https://gajae-code.com"><img alt="Website" src="https://img.shields.io/badge/website-gajae--code.com-ff4d4f?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/gajae-code"><img alt="npm package" src="https://img.shields.io/npm/v/gajae-code?style=flat-square"></a>
   <a href="LICENSE"><img alt="MIT license" src="https://img.shields.io/badge/license-MIT-green?style=flat-square"></a>
-  <a href="https://discord.gg/EFedyMMbcF"><img alt="Discord" src="https://img.shields.io/badge/Discord-join-5865F2?style=flat-square&logo=discord&logoColor=white"></a>
+  <a href="https://discord.gg/wSyUQYfhAw"><img alt="Discord" src="https://img.shields.io/badge/Discord-join-5865F2?style=flat-square&logo=discord&logoColor=white"></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <a href="https://gajae-code.com"><img alt="Website" src="https://img.shields.io/badge/website-gajae--code.com-ff4d4f?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/gajae-code"><img alt="npm package" src="https://img.shields.io/npm/v/gajae-code?style=flat-square"></a>
   <a href="LICENSE"><img alt="MIT license" src="https://img.shields.io/badge/license-MIT-green?style=flat-square"></a>
-  <a href="https://discord.gg/EFedyMMbcF"><img alt="Discord" src="https://img.shields.io/badge/Discord-join-5865F2?style=flat-square&logo=discord&logoColor=white"></a>
+  <a href="https://discord.gg/wSyUQYfhAw"><img alt="Discord" src="https://img.shields.io/badge/Discord-join-5865F2?style=flat-square&logo=discord&logoColor=white"></a>
 </p>
 
 <p align="center">
@@ -396,6 +396,7 @@ For evaluating Aside as an opt-in search/context retrieval sidecar, see [`docs/a
 
 - [gjc-remote](https://github.com/kogangdon/gjc-remote) — a real-world SDK extension for controlling allowlisted GJC sessions on remote hosts from Discord.
 - [oh-my-gajae-code](https://github.com/devswha/oh-my-gajae-code) — a community plugin marketplace for installing additional workflow skills and slash commands.
+- [gjc-agy-skill](https://github.com/jkf87/gjc-agy-skill) — a third-party community GJC skill integrating Antigravity CLI for vision/OCR, image generation, and Gemini print-mode one-shot workflows.
 - [GJC multivendor setup guide](https://github.com/project820/gjc-multivendor-setup-guide) — role-based provider profiles and installable model bundles for multivendor GJC setups.
 
 ## Configuration

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,7 +18,7 @@
   <a href="https://gajae-code.com"><img alt="Website" src="https://img.shields.io/badge/website-gajae--code.com-ff4d4f?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/gajae-code"><img alt="npm package" src="https://img.shields.io/npm/v/gajae-code?style=flat-square"></a>
   <a href="LICENSE"><img alt="MIT license" src="https://img.shields.io/badge/license-MIT-green?style=flat-square"></a>
-  <a href="https://discord.gg/EFedyMMbcF"><img alt="Discord" src="https://img.shields.io/badge/Discord-join-5865F2?style=flat-square&logo=discord&logoColor=white"></a>
+  <a href="https://discord.gg/wSyUQYfhAw"><img alt="Discord" src="https://img.shields.io/badge/Discord-join-5865F2?style=flat-square&logo=discord&logoColor=white"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Replaces the expired project community Discord invite (`discord.gg/EFedyMMbcF`) with the confirmed permanent invite **https://discord.gg/wSyUQYfhAw** on all four public README surfaces (`README.md`, `README.ko.md`, `README.ja.md`, `README.zh-CN.md`), badge markup unchanged.
- Adds one third-party community bullet to the root English README `## SDK Extensions` list: [`gjc-agy-skill`](https://github.com/jkf87/gjc-agy-skill) — Antigravity CLI integration for vision/OCR, image generation, and Gemini print-mode one-shot workflows. Explicitly third-party; no bundled/official/security claim. Localized READMEs intentionally not broadened (they do not mirror this section).
- Vendored brush crate READMEs (`crates/brush-core-vendored`, `crates/brush-builtins-vendored`) keep their upstream `discord.gg/kPRgC9j3Tj` links untouched.
- Root README already carried a Discord badge, so no addition was needed.

## Risk classification
- [x] `low-risk` — ordinary docs maintenance; owner self-review path (no independent human review; the verdict name itself records this) with a risk-record comment bound to this exact head.
- [ ] `regression-risk`
- [ ] `high-risk`

## Validation (exact head `e81248ec`)
- `git grep EFedyMMbcF HEAD` → 0 hits; `grep -c wSyUQYfhAw` → exactly 1 per README.
- `bun run check:public-sync` → pass (`Public docs/site/version surfaces are in sync.`).
- `bun test scripts/check-public-version-sync.test.ts` → 22 pass / 0 fail.
- `bun scripts/verify-gjc-state-writers.ts --fail --root .` → 0 write sites outside the sanctioned allowlist.
- Link resolution: `https://github.com/jkf87/gjc-agy-skill` HTTP 200 (resolved URL unchanged); `https://discord.gg/wSyUQYfhAw` GET/HEAD 200 → `https://discord.com/invite/wSyUQYfhAw`.
- markdownlint head-vs-base parity: 219/169/85/70 diagnostics identical; zero new findings.

gajae.pr-review-verdict.v1 merge-self-approved sha256:50964b6298f17b8edd163d66475b18beaa72005152f8109bf614686c8727fb80 reviewer:human reviewer-id:Yeachan-Heo evidence:README-only exact-head validation; public-sync and targeted tests passed; signed self-review risk record posted for this head

Authorized docs maintenance per owner request (Discord message 1541067796203704341).

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*