### PR TITLE
fix(acp): launch bundled runtime from Bun virtual paths

### DIFF
--- a/crates/pi-natives/src/lib.rs
+++ b/crates/pi-natives/src/lib.rs
@@ -86,3 +86,13 @@ pub const fn pi_natives_version_sentinel() {}
 /// cannot be selected over a compatible baseline.
 #[napi(js_name = "__piNativesPublishOutcomeV1")]
 pub const fn pi_natives_publish_outcome_sentinel() {}
+
+/// Returns the operating system's canonical path for the running executable.
+/// Unlike argv, this is not supplied by the process caller.
+#[napi]
+pub fn current_executable_path() -> Option<String> {
+	std::env::current_exe()
+		.ok()
+		.and_then(|path| path.canonicalize().ok())
+		.map(|path| path.to_string_lossy().into_owned())
+}

--- a/crates/pi-natives/src/path_identity.rs
+++ b/crates/pi-natives/src/path_identity.rs
@@ -7002,6 +7002,24 @@ mod platform {
 		{
 			return NativeExactUnlinkResult::failure("identity_mismatch");
 		}
+		if !identity.directory && !identity.detach_only {
+			if let Some((expected_parent_dev, expected_parent_ino)) =
+				identity.parent_dev.zip(identity.parent_ino)
+			{
+				let Some(parent_handle) = handle.parent() else {
+					return NativeExactUnlinkResult::failure("io_error");
+				};
+				let mut parent_information: BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
+				if unsafe { GetFileInformationByHandle(parent_handle, &mut parent_information) } == 0
+					|| u64::from(parent_information.dwVolumeSerialNumber) != expected_parent_dev
+					|| ((u64::from(parent_information.nFileIndexHigh) << 32)
+						| u64::from(parent_information.nFileIndexLow))
+						!= expected_parent_ino
+				{
+					return NativeExactUnlinkResult::failure("parent_mismatch");
+				}
+			}
+		}
 		if identity.directory || identity.detach_only {
 			let Some(quarantine_name) = identity.quarantine_name.as_deref() else {
 				return NativeExactUnlinkResult::failure("quarantine_destination_required");

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -2569,10 +2569,9 @@ async function terminateSpawnedChild(
 	if (!pid || (expected && pid !== expected.pid)) return false;
 	const incarnation = expected?.incarnation ?? processIncarnationForBroker(broker, pid);
 	await broker.index.refresh();
-	const terminationDeadline =
-		expected && !broker.index.hasHostRegistrationForLifecycle(id, pid, expected.effectMarker)
-			? deadline
-			: terminationStartDeadlineAt;
+	const registered = expected ? broker.index.hasHostRegistrationForLifecycle(id, pid, expected.effectMarker) : false;
+	const unregisteredTerminationDeadlineAt =
+		deadline - Math.max(POLL_MS, Math.floor((deadline - terminationStartDeadlineAt) / 2));
 	const observe = (): ProcessObservation =>
 		child.exitCode !== null
 			? "exited"
@@ -2595,7 +2594,19 @@ async function terminateSpawnedChild(
 		observation = await waitForExit(deadline);
 	};
 	if (observation === "alive") {
-		await waitUntil(timing, terminationDeadline);
+		if (expected && !registered) {
+			// A child that has not registered yet owns the cutoff receipt. Give it
+			// the bounded pre-registration window to publish that proof, but reserve
+			// the final proof interval for post-signal observation inside the request
+			// deadline. A valid receipt does not interrupt the child's own rollback.
+			while (timing.now() < unregisteredTerminationDeadlineAt) {
+				if (await readLifecycleFailureArtifact(lifecycleFailurePath(root, id, expected.effectMarker), expected))
+					await waitUntil(timing, unregisteredTerminationDeadlineAt);
+				else await timing.sleep(Math.max(0, Math.min(POLL_MS, unregisteredTerminationDeadlineAt - timing.now())));
+			}
+		} else {
+			await waitUntil(timing, terminationStartDeadlineAt);
+		}
 		observation = observe();
 	}
 	if (observation === "alive") {

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -4162,18 +4162,19 @@ async function executeLifecycleResponse(
 			await writeEffectMarker(launch.root, launch.id, spawnedAuthority);
 			spawned.unref();
 		} catch (error) {
-			const terminated = child
-				? await terminateSpawnedChild(
-						child,
-						broker,
-						launch.id,
-						launch.root,
-						lifecycleDeadline,
-						terminationStartDeadline,
-						spawnedAuthority,
-						timing,
-					)
-				: true;
+			const terminated =
+				child && spawnedAuthority
+					? await terminateSpawnedChild(
+							child,
+							broker,
+							launch.id,
+							launch.root,
+							lifecycleDeadline,
+							terminationStartDeadline,
+							spawnedAuthority,
+							timing,
+						)
+					: true;
 
 			return terminated
 				? fail("spawn_failed", `Unable to spawn session: ${error instanceof Error ? error.message : String(error)}`)

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -2570,8 +2570,12 @@ async function terminateSpawnedChild(
 	const incarnation = expected?.incarnation ?? processIncarnationForBroker(broker, pid);
 	await broker.index.refresh();
 	const registered = expected ? broker.index.hasHostRegistrationForLifecycle(id, pid, expected.effectMarker) : false;
+	// Keep one poll interval inside the lifecycle deadline for the final exact
+	// cleanup proof. Registered sessions retain the original deadline partition;
+	// only an unregistered child needs this extra bounded margin.
+	const processExitDeadlineAt = expected && !registered ? deadline - POLL_MS : deadline;
 	const unregisteredTerminationDeadlineAt =
-		deadline - Math.max(POLL_MS, Math.floor((deadline - terminationStartDeadlineAt) / 2));
+		processExitDeadlineAt - Math.max(POLL_MS, Math.floor((processExitDeadlineAt - terminationStartDeadlineAt) / 2));
 	const observe = (): ProcessObservation =>
 		child.exitCode !== null
 			? "exited"
@@ -2591,7 +2595,7 @@ async function terminateSpawnedChild(
 		if (observation !== "uncertain") return;
 		// This direct ChildProcess is owned by this broker invocation. A process-incarnation
 		// read can briefly lag its exit event, so recheck only this owned child before failing.
-		observation = await waitForExit(deadline);
+		observation = await waitForExit(processExitDeadlineAt);
 	};
 	if (observation === "alive") {
 		if (expected && !registered) {
@@ -2618,7 +2622,7 @@ async function terminateSpawnedChild(
 				return false;
 			}
 		} else {
-			const remaining = Math.max(0, deadline - timing.now());
+			const remaining = Math.max(0, processExitDeadlineAt - timing.now());
 			const gracefulDeadline = timing.now() + Math.min(CLOSE_TIMEOUT_MS, Math.floor(remaining / 2));
 			observation = await waitForExit(gracefulDeadline);
 		}
@@ -2632,7 +2636,7 @@ async function terminateSpawnedChild(
 				return false;
 			}
 		} else {
-			observation = await waitForExit(deadline);
+			observation = await waitForExit(processExitDeadlineAt);
 		}
 	}
 	await recheckOwnedExitObservation();

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -4140,11 +4140,16 @@ async function executeLifecycleResponse(
 			const spawned = authorizedSpawn.value;
 			child = spawned;
 			const spawnOutcome = Promise.withResolvers<void>();
-			spawned.once("error", error => spawnOutcome.reject(error));
-			spawned.once("spawn", () => spawnOutcome.resolve());
-			queueMicrotask(() => {
-				if (spawned.pid) spawnOutcome.resolve();
-			});
+			const onSpawn = () => {
+				spawned.off("error", onError);
+				spawnOutcome.resolve();
+			};
+			const onError = (error: Error) => {
+				spawned.off("spawn", onSpawn);
+				spawnOutcome.reject(error);
+			};
+			spawned.once("spawn", onSpawn);
+			spawned.once("error", onError);
 			await spawnOutcome.promise;
 			const pid = spawned.pid;
 			if (!pid) throw new Error("spawned session has no pid");

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -1053,8 +1053,6 @@ export async function reapDeadLifecycleMarkers(
 				continue;
 			}
 		}
-		const parent = lifecycleParentIdentity(directory);
-		if (!parent) continue;
 		try {
 			const currentPrimary = captureLifecycleFile(markerPath, true, true)?.identity;
 			const currentReady = ready ? captureLifecycleFile(readyPath, true, true)?.identity : undefined;
@@ -1074,21 +1072,17 @@ export async function reapDeadLifecycleMarkers(
 				continue;
 			if (
 				ready &&
-				!exactUnlinkLifecycleFile(
-					readyPath,
-					ready.identity,
-					path.join(directory, `.gjc-reap-${randomUUID()}-${path.basename(readyPath)}`),
-					{ dev: BigInt(parent.dev), ino: BigInt(parent.ino) },
-				).ok
+				!nativeLifecycle().exactUnlinkDirect(readyPath, {
+					...ready.identity,
+					quarantineName: `.gjc-reap-${randomUUID()}-${path.basename(readyPath)}`,
+				}).ok
 			)
 				continue;
 			if (
-				!exactUnlinkLifecycleFile(
-					markerPath,
-					primary.identity,
-					path.join(directory, `.gjc-reap-${randomUUID()}-${name}`),
-					{ dev: BigInt(parent.dev), ino: BigInt(parent.ino) },
-				).ok
+				!nativeLifecycle().exactUnlinkDirect(markerPath, {
+					...primary.identity,
+					quarantineName: `.gjc-reap-${randomUUID()}-${name}`,
+				}).ok
 			)
 				continue;
 		} catch {
@@ -4134,11 +4128,12 @@ async function executeLifecycleResponse(
 			}
 			const spawned = authorizedSpawn.value;
 			child = spawned;
-			const spawnOutcome = Promise.withResolvers<void>();
-			spawned.once("error", error => spawnOutcome.reject(error));
-			spawned.once("spawn", () => spawnOutcome.resolve());
-			await spawnOutcome.promise;
+			let childSpawnError: Error | undefined;
+			spawned.once("error", error => {
+				childSpawnError = error;
+			});
 			const pid = spawned.pid;
+			if (childSpawnError) throw childSpawnError;
 			if (!pid) throw new Error("spawned session has no pid");
 			const incarnation = processIncarnationForBroker(broker, pid);
 			if (!incarnation) throw new Error("spawned session has no readable OS incarnation");

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -100,6 +100,7 @@ const MAX_RECEIVED_AT_SKEW_MS = 5_000;
 const MAX_LIFECYCLE_METADATA_BYTES = 4096;
 const MAX_EFFECT_MARKER_LENGTH = 128;
 const MAX_PROCESS_INCARNATION_LENGTH = 256;
+const DEAD_LIFECYCLE_MARKER_EXPIRY_MS = 60 * 60 * 1000;
 const READY_THEN_EXIT_MESSAGE = "became ready then exited before live admission";
 
 function readyThenExitedResponse(id: string, child?: ChildProcess): BrokerResponse {
@@ -1002,6 +1003,100 @@ async function readEffectMarker(file: string): Promise<EffectMarker | undefined>
 	} catch {
 		return undefined;
 	}
+}
+
+/**
+ * Retires stale lifecycle markers only when their exact owner is proven gone. These
+ * files are launch bookkeeping, not authority for a future process: retaining
+ * an abandoned marker indefinitely turns unrelated launch failures into
+ * cleanup uncertainty. Unreadable, malformed, linked, and live markers are
+ * deliberately left untouched.
+ */
+export async function reapDeadLifecycleMarkers(
+	root: string,
+	limit = BROKER_DEAD_REGISTRATION_SWEEP_LIMIT,
+): Promise<number> {
+	let directory: string;
+	try {
+		const canonicalRoot = fsSync.realpathSync(root);
+		directory = path.join(canonicalRoot, "sdk");
+		const directoryStat = fsSync.lstatSync(directory, { bigint: true });
+		if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) return 0;
+	} catch {
+		return 0;
+	}
+	let names: string[];
+	try {
+		names = await fs.readdir(directory);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return 0;
+		return 0;
+	}
+	let reaped = 0;
+	for (const name of names) {
+		if (reaped >= Math.max(0, limit) || !name.endsWith(".lifecycle.json")) continue;
+		const id = name.slice(0, -".lifecycle.json".length);
+		if (!isCanonicalSessionId(id)) continue;
+		const markerPath = path.join(directory, name);
+		const marker = await readEffectMarker(markerPath);
+		if (!marker || observeProcess(marker.pid, marker.incarnation) !== "exited") continue;
+		const primary = captureLifecycleFile(markerPath, true, true);
+		if (!primary || Date.now() - Number(primary.identity.mtimeNs / 1_000_000n) < DEAD_LIFECYCLE_MARKER_EXPIRY_MS)
+			continue;
+		const readyPath = lifecycleReadyPath(path.dirname(directory), id);
+		const ready = captureLifecycleFile(readyPath, true, true);
+		if (ready) {
+			try {
+				const readyMarker = parseLifecycleJson(ready.bytes);
+				if (!isExactEffectMarker(readyMarker) || !sameEffectMarker(readyMarker, marker)) continue;
+			} catch {
+				continue;
+			}
+		}
+		const parent = lifecycleParentIdentity(directory);
+		if (!parent) continue;
+		try {
+			const currentPrimary = captureLifecycleFile(markerPath, true, true)?.identity;
+			const currentReady = ready ? captureLifecycleFile(readyPath, true, true)?.identity : undefined;
+			if (
+				!currentPrimary ||
+				!sameLifecycleCleanupIdentity(
+					currentPrimary,
+					serializeCleanupIdentity({ ...primary.identity, size: Number(primary.identity.size) }),
+				) ||
+				(ready &&
+					(!currentReady ||
+						!sameLifecycleCleanupIdentity(
+							currentReady,
+							serializeCleanupIdentity({ ...ready.identity, size: Number(ready.identity.size) }),
+						)))
+			)
+				continue;
+			if (
+				ready &&
+				!exactUnlinkLifecycleFile(
+					readyPath,
+					ready.identity,
+					path.join(directory, `.gjc-reap-${randomUUID()}-${path.basename(readyPath)}`),
+					{ dev: BigInt(parent.dev), ino: BigInt(parent.ino) },
+				).ok
+			)
+				continue;
+			if (
+				!exactUnlinkLifecycleFile(
+					markerPath,
+					primary.identity,
+					path.join(directory, `.gjc-reap-${randomUUID()}-${name}`),
+					{ dev: BigInt(parent.dev), ino: BigInt(parent.ino) },
+				).ok
+			)
+				continue;
+		} catch {
+			continue;
+		}
+		reaped += 1;
+	}
+	return reaped;
 }
 
 async function writeEffectMarker(root: string, id: string, marker: EffectMarker): Promise<void> {
@@ -3927,6 +4022,7 @@ async function executeLifecycleResponse(
 				await broker.ledger.transition(identity, "effect_started", { durableEffects });
 				ensureReusableNodeModules(launch.worktreePlan.repoRoot, launch.worktreePlan.worktreePath);
 			}
+			await reapDeadLifecycleMarkers(launch.root);
 		} catch (error) {
 			return fail(
 				"spawn_failed",
@@ -4038,6 +4134,10 @@ async function executeLifecycleResponse(
 			}
 			const spawned = authorizedSpawn.value;
 			child = spawned;
+			const spawnOutcome = Promise.withResolvers<void>();
+			spawned.once("error", error => spawnOutcome.reject(error));
+			spawned.once("spawn", () => spawnOutcome.resolve());
+			await spawnOutcome.promise;
 			const pid = spawned.pid;
 			if (!pid) throw new Error("spawned session has no pid");
 			const incarnation = processIncarnationForBroker(broker, pid);
@@ -5304,7 +5404,10 @@ export async function executeLifecycle(
 										error: {
 											code: "terminal_uncertain",
 											message:
-												"Lifecycle startup cleanup could not be proven; retained artifacts require reconciliation.",
+												"Lifecycle startup cleanup could not be proven; retained artifacts require reconciliation." +
+												(response.error.code === "spawn_failed"
+													? ` Original launch failure: ${response.error.message}`
+													: ""),
 										},
 										...(durableEffects ? { durableEffects } : {}),
 										...(startupFailure ? { startupFailure } : {}),

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -58,9 +58,9 @@ import {
 } from "../session-directory";
 import {
 	normalizeSdkStartupFailure,
-	sanitizeSdkStartupMessage,
 	type SdkStartupFailure,
 	type SdkStartupRollbackResult,
+	sanitizeSdkStartupMessage,
 } from "../startup-capability";
 import type { Broker, BrokerCleanupEvidence, BrokerCleanupIdentity, BrokerResponse } from "./broker";
 import { decodeLifecycleUtf8, parseLifecycleJson } from "./lifecycle-codec";
@@ -124,6 +124,28 @@ export function terminalUncertainStartupMessage(response: BrokerResponse): strin
 		message: sanitizeSdkStartupMessage(response.error.message),
 	});
 	return `${STARTUP_CLEANUP_UNCERTAIN_MESSAGE} Original launch failure: SDK internal process could not be started.`;
+}
+
+export async function waitForChildSpawn(
+	spawned: Pick<ChildProcess, "off" | "on" | "once">,
+	onPostSpawnError: (error: Error) => void = error =>
+		logger.warn("sdk session child emitted an error after successful spawn", {
+			message: sanitizeSdkStartupMessage(error),
+		}),
+): Promise<void> {
+	const spawnOutcome = Promise.withResolvers<void>();
+	const onSpawn = () => {
+		spawned.off("error", onError);
+		spawned.on("error", onPostSpawnError);
+		spawnOutcome.resolve();
+	};
+	const onError = (error: Error) => {
+		spawned.off("spawn", onSpawn);
+		spawnOutcome.reject(error);
+	};
+	spawned.once("spawn", onSpawn);
+	spawned.once("error", onError);
+	await spawnOutcome.promise;
 }
 
 export interface LifecycleDeadlines {
@@ -4264,19 +4286,8 @@ async function executeLifecycleResponse(
 			}
 			const spawned = authorizedSpawn.value;
 			child = spawned;
-			const spawnOutcome = Promise.withResolvers<void>();
-			const onSpawn = () => {
-				spawned.off("error", onError);
-				childSpawned = true;
-				spawnOutcome.resolve();
-			};
-			const onError = (error: Error) => {
-				spawned.off("spawn", onSpawn);
-				spawnOutcome.reject(error);
-			};
-			spawned.once("spawn", onSpawn);
-			spawned.once("error", onError);
-			await spawnOutcome.promise;
+			await waitForChildSpawn(spawned);
+			childSpawned = true;
 			const pid = spawned.pid;
 			if (!pid) throw new Error("spawned session has no pid");
 			const incarnation = processIncarnationForBroker(broker, pid);
@@ -5531,12 +5542,7 @@ export async function executeLifecycle(
 	const provenRoot = root;
 	const provenId = entry?.intendedSessionId;
 	let provenDeadCleanup = false;
-	if (
-		Boolean(provenExpected) &&
-		Boolean(provenRoot) &&
-		Boolean(provenId) &&
-		lifecycleProofWithinDeadline(proofBudget)
-	) {
+	if (provenExpected && provenRoot && provenId && lifecycleProofWithinDeadline(proofBudget)) {
 		const processExited =
 			observeProcess(provenExpected!.pid, provenExpected!.incarnation, value =>
 				processIncarnationForBroker(broker, value),

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -4084,6 +4084,7 @@ async function executeLifecycleResponse(
 		};
 		let child: ChildProcess | undefined;
 		let spawnedAuthority: EffectMarker | undefined;
+		let childSpawned = false;
 		try {
 			const authorizedSpawn = broker.runSynchronousEffectWithFreshPublicationAuthority(() => {
 				const cmd = command(broker);
@@ -4146,6 +4147,7 @@ async function executeLifecycleResponse(
 			const spawnOutcome = Promise.withResolvers<void>();
 			const onSpawn = () => {
 				spawned.off("error", onError);
+				childSpawned = true;
 				spawnOutcome.resolve();
 			};
 			const onError = (error: Error) => {
@@ -4167,7 +4169,7 @@ async function executeLifecycleResponse(
 			spawned.unref();
 		} catch (error) {
 			const terminated =
-				child && spawnedAuthority
+				child && childSpawned
 					? await terminateSpawnedChild(
 							child,
 							broker,

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -1085,6 +1085,8 @@ export async function reapDeadLifecycleMarkers(
 				ready &&
 				!nativeLifecycle().exactUnlinkDirect(readyPath, {
 					...ready.identity,
+					parentDev: directoryIdentity.dev,
+					parentIno: directoryIdentity.ino,
 					quarantineName: `.gjc-reap-${randomUUID()}-${path.basename(readyPath)}`,
 				}).ok
 			)
@@ -1092,6 +1094,8 @@ export async function reapDeadLifecycleMarkers(
 			if (
 				!nativeLifecycle().exactUnlinkDirect(markerPath, {
 					...primary.identity,
+					parentDev: directoryIdentity.dev,
+					parentIno: directoryIdentity.ino,
 					quarantineName: `.gjc-reap-${randomUUID()}-${name}`,
 				}).ok
 			)

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -58,6 +58,7 @@ import {
 } from "../session-directory";
 import {
 	normalizeSdkStartupFailure,
+	sanitizeSdkStartupMessage,
 	type SdkStartupFailure,
 	type SdkStartupRollbackResult,
 } from "../startup-capability";
@@ -112,6 +113,17 @@ function readyThenExitedResponse(id: string, child?: ChildProcess): BrokerRespon
 	// prove arbitrary child output free of that material; its stderr is discarded
 	// by the OS and never captured (#4712 review).
 	return fail("ready_then_exited", parts.join(" "));
+}
+
+const STARTUP_CLEANUP_UNCERTAIN_MESSAGE =
+	"Lifecycle startup cleanup could not be proven; retained artifacts require reconciliation.";
+
+export function terminalUncertainStartupMessage(response: BrokerResponse): string {
+	if (response.ok || response.error.code !== "spawn_failed") return STARTUP_CLEANUP_UNCERTAIN_MESSAGE;
+	logger.warn("sdk broker retained a sanitized launch failure after uncertain startup cleanup", {
+		message: sanitizeSdkStartupMessage(response.error.message),
+	});
+	return `${STARTUP_CLEANUP_UNCERTAIN_MESSAGE} Original launch failure: SDK internal process could not be started.`;
 }
 
 export interface LifecycleDeadlines {
@@ -5575,11 +5587,7 @@ export async function executeLifecycle(
 										ok: false,
 										error: {
 											code: "terminal_uncertain",
-											message:
-												"Lifecycle startup cleanup could not be proven; retained artifacts require reconciliation." +
-												(response.error.code === "spawn_failed"
-													? ` Original launch failure: ${response.error.message}`
-													: ""),
+											message: terminalUncertainStartupMessage(response),
 										},
 										...(durableEffects ? { durableEffects } : {}),
 										...(startupFailure ? { startupFailure } : {}),

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -1056,6 +1056,13 @@ export async function reapDeadLifecycleMarkers(
 			}
 		}
 		try {
+			const currentParent = lifecycleParentIdentity(directory);
+			if (
+				!currentParent ||
+				BigInt(currentParent.dev) !== directoryIdentity.dev ||
+				BigInt(currentParent.ino) !== directoryIdentity.ino
+			)
+				continue;
 			const currentPrimary = captureLifecycleFile(markerPath, true, true);
 			const currentReady = ready ? captureLifecycleFile(readyPath, true, true)?.identity : undefined;
 			if (
@@ -1078,8 +1085,6 @@ export async function reapDeadLifecycleMarkers(
 				ready &&
 				!nativeLifecycle().exactUnlinkDirect(readyPath, {
 					...ready.identity,
-					parentDev: directoryIdentity.dev,
-					parentIno: directoryIdentity.ino,
 					quarantineName: `.gjc-reap-${randomUUID()}-${path.basename(readyPath)}`,
 				}).ok
 			)
@@ -1087,8 +1092,6 @@ export async function reapDeadLifecycleMarkers(
 			if (
 				!nativeLifecycle().exactUnlinkDirect(markerPath, {
 					...primary.identity,
-					parentDev: directoryIdentity.dev,
-					parentIno: directoryIdentity.ino,
 					quarantineName: `.gjc-reap-${randomUUID()}-${name}`,
 				}).ok
 			)

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -201,6 +201,15 @@ function lifecycleTiming(broker: Broker): LifecycleTiming {
 	return lifecycleTimingsForTest.get(broker) ?? defaultLifecycleTiming;
 }
 
+type LifecycleProofBudget = {
+	timing: LifecycleTiming;
+	deadlineAt: number;
+};
+
+function lifecycleProofWithinDeadline(budget: LifecycleProofBudget | undefined): boolean {
+	return budget === undefined || budget.timing.now() < budget.deadlineAt;
+}
+
 export function hasValidLifecycleDeadlines(value: LifecycleDeadlines, now = Date.now()): boolean {
 	const {
 		receivedAt,
@@ -231,6 +240,9 @@ export function hasValidLifecycleDeadlines(value: LifecycleDeadlines, now = Date
 	}
 }
 type Input = Record<string, unknown>;
+// The admitted launch deadline must survive the response phase: executeLifecycle
+// receives the caller's original input after startup admission has expanded it.
+type LifecycleEffectIntentWithDeadline = LifecycleEffectIntent & { lifecycleCleanupDeadlineAt?: number };
 export const isCanonicalSessionId = (value: string): boolean => /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(value);
 const defaultStateRoot = (cwd: string) => path.join(path.resolve(cwd), ".gjc", "state");
 const hasDefaultStateRoot = (cwd: string, root: string) => path.resolve(root) === defaultStateRoot(cwd);
@@ -613,6 +625,23 @@ function lifecycleDeadlines(input: Input, now: number): LifecycleDeadlines | Bro
 	const timeout = readinessTimeout(input);
 	return typeof timeout === "number" ? deriveLifecycleDeadlines(now, timeout) : timeout;
 }
+
+function lifecycleProofBudgetFromInput(broker: Broker, input: Input): LifecycleProofBudget | undefined {
+	return typeof input.lifecycleCleanupDeadlineAt === "number" && Number.isSafeInteger(input.lifecycleCleanupDeadlineAt)
+		? { timing: lifecycleTiming(broker), deadlineAt: input.lifecycleCleanupDeadlineAt }
+		: undefined;
+}
+
+function lifecycleProofBudgetFromEffectIntent(
+	broker: Broker,
+	effectIntent: LifecycleEffectIntent | undefined,
+): LifecycleProofBudget | undefined {
+	const deadlineAt = (effectIntent as LifecycleEffectIntentWithDeadline | undefined)?.lifecycleCleanupDeadlineAt;
+	return typeof deadlineAt === "number" && Number.isSafeInteger(deadlineAt)
+		? { timing: lifecycleTiming(broker), deadlineAt }
+		: undefined;
+}
+
 function sessionId(input: Input): string | undefined {
 	return text(input.sessionId) ?? text(input.id);
 }
@@ -1027,16 +1056,22 @@ export async function reapDeadLifecycleMarkers(
 	} catch {
 		return 0;
 	}
-	let names: string[];
+	const inspectionLimit = Math.max(0, limit);
+	if (inspectionLimit === 0) return 0;
+	let directoryHandle: fsSync.Dir;
 	try {
-		names = await fs.readdir(directory);
+		directoryHandle = await fs.opendir(directory);
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return 0;
 		return 0;
 	}
 	let reaped = 0;
-	for (const name of names) {
-		if (reaped >= Math.max(0, limit) || !name.endsWith(".lifecycle.json")) continue;
+	let inspected = 0;
+	for await (const entry of directoryHandle) {
+		if (inspected >= inspectionLimit) break;
+		inspected += 1;
+		const name = entry.name;
+		if (!entry.isFile() || !name.endsWith(".lifecycle.json")) continue;
 		const id = name.slice(0, -".lifecycle.json".length);
 		if (!isCanonicalSessionId(id)) continue;
 		const markerPath = path.join(directory, name);
@@ -2029,7 +2064,10 @@ async function reconcileLifecycleCleanup(
 	identity: string,
 	cleanup: CleanupEvidence,
 	completion: BrokerResponse = fail("spawn_failed", "No ready SDK endpoint remains available."),
+	proofBudget?: LifecycleProofBudget,
 ): Promise<BrokerResponse> {
+	if (!lifecycleProofWithinDeadline(proofBudget))
+		return fail("terminal_uncertain", "Lifecycle cleanup proof exceeded its cleanup deadline.", cleanup);
 	const shapeValidation = validateLifecycleCleanupShape(cleanup);
 	if (shapeValidation) return shapeValidation;
 	let activeCleanup =
@@ -2038,10 +2076,14 @@ async function reconcileLifecycleCleanup(
 			: cleanup;
 	const metadataReplayValidation = validateLifecycleMetadataReplay(activeCleanup);
 	if (metadataReplayValidation) return metadataReplayValidation;
+	const deadlineFailure = (): BrokerResponse =>
+		fail("terminal_uncertain", "Lifecycle cleanup proof exceeded its cleanup deadline.", activeCleanup);
 	for (let index = 0; index < activeCleanup.lifecycleFiles!.length; index++) {
+		if (!lifecycleProofWithinDeadline(proofBudget)) return deadlineFailure();
 		const file = activeCleanup.lifecycleFiles![index];
 		if (!validateLifecycleCleanupFile(activeCleanup.metadataRoot!, activeCleanup.sessionId!, file))
 			return fail("terminal_uncertain", "Lifecycle cleanup replay contains an invalid path authority.");
+		if (!lifecycleProofWithinDeadline(proofBudget)) return deadlineFailure();
 		const candidates = lifecycleCleanupCandidates(file);
 		if (file.completed) {
 			for (const candidate of candidates) {
@@ -2068,12 +2110,14 @@ async function reconcileLifecycleCleanup(
 					"Lifecycle cleanup receipt marks a target complete while an authorized candidate remains.",
 				);
 			}
+			if (!lifecycleProofWithinDeadline(proofBudget)) return deadlineFailure();
 			continue;
 		}
 		let activePath: string | undefined;
 		let captured: LifecycleFileCapture | undefined;
 		let foundUnauthorized = false;
 		for (const candidate of candidates) {
+			if (!lifecycleProofWithinDeadline(proofBudget)) return deadlineFailure();
 			try {
 				const stat = fsSync.lstatSync(candidate);
 				if (stat.isSymbolicLink() || !stat.isFile()) {
@@ -2086,6 +2130,7 @@ async function reconcileLifecycleCleanup(
 				continue;
 			}
 			const current = captureLifecycleFile(candidate, true, true);
+			if (!lifecycleProofWithinDeadline(proofBudget)) return deadlineFailure();
 
 			if (!current) {
 				foundUnauthorized = true;
@@ -2108,6 +2153,7 @@ async function reconcileLifecycleCleanup(
 			await broker.ledger.transition(identity, "effect_started", {
 				response: fail("cleanup_pending", "Lifecycle cleanup completion was durably reconciled.", activeCleanup),
 			});
+			if (!lifecycleProofWithinDeadline(proofBudget)) return deadlineFailure();
 			continue;
 		}
 
@@ -2129,14 +2175,17 @@ async function reconcileLifecycleCleanup(
 					activeCleanup,
 				),
 			});
+			if (!lifecycleProofWithinDeadline(proofBudget)) return deadlineFailure();
 		}
 		const currentFile = activeCleanup.lifecycleFiles![index];
+		if (!lifecycleProofWithinDeadline(proofBudget)) return deadlineFailure();
 		const result = nativeLifecycle().exactUnlink(activePath, {
 			...captured.identity,
 			parentDev: BigInt(activeCleanup.lifecycleParentIdentity!.dev),
 			parentIno: BigInt(activeCleanup.lifecycleParentIdentity!.ino),
 			quarantineName: path.basename(currentFile.plannedPath),
 		});
+		if (!lifecycleProofWithinDeadline(proofBudget)) return deadlineFailure();
 		if (!result.ok) {
 			if (result.code === "cleanup_pending" && result.detachedPath === currentFile.plannedPath) {
 				// Typed retained authority: the native verified the exact identity-bound
@@ -2152,6 +2201,7 @@ async function reconcileLifecycleCleanup(
 					response: fail("cleanup_pending", "Lifecycle cleanup completion was durably reconciled.", activeCleanup),
 				});
 				lifecycleCleanupHooksForTest.get(broker)?.();
+				if (!lifecycleProofWithinDeadline(proofBudget)) return deadlineFailure();
 				continue;
 			}
 			const lifecycleFiles = activeCleanup.lifecycleFiles!.map((candidate, candidateIndex) =>
@@ -2172,8 +2222,10 @@ async function reconcileLifecycleCleanup(
 			response: fail("cleanup_pending", "Lifecycle cleanup completion was durably reconciled.", activeCleanup),
 		});
 		lifecycleCleanupHooksForTest.get(broker)?.();
+		if (!lifecycleProofWithinDeadline(proofBudget)) return deadlineFailure();
 	}
 	await syncDirectory(path.join(activeCleanup.metadataRoot!, "sdk"));
+	if (!lifecycleProofWithinDeadline(proofBudget)) return deadlineFailure();
 	return completion;
 }
 
@@ -2407,8 +2459,11 @@ async function removeOwnedLifecycleArtifacts(
 	expected: EffectMarker,
 	onRetainedUnknown?: () => void,
 	onDurablePlaceholder?: (file: string) => void,
+	proofBudget?: LifecycleProofBudget,
 ): Promise<boolean> {
+	if (!lifecycleProofWithinDeadline(proofBudget)) return false;
 	const marker = await readEffectMarker(lifecycleMarkerPath(root, id));
+	if (!lifecycleProofWithinDeadline(proofBudget)) return false;
 	if (!marker || !sameEffectMarker(marker, expected)) return false;
 	const endpointPath = path.join(root, "sdk", `${id}.json`);
 	const plannedEndpointPath = path.join(
@@ -2431,6 +2486,7 @@ async function removeOwnedLifecycleArtifacts(
 		}
 	});
 	const endpoint = endpointSource ? captureLifecycleFile(endpointSource) : undefined;
+	if (!lifecycleProofWithinDeadline(proofBudget)) return false;
 	const endpointParent = endpointSource ? lifecycleParentIdentity(path.dirname(endpointSource)) : undefined;
 	if (endpoint && endpointSource && endpointParent) {
 		let parsed: { pid?: unknown };
@@ -2449,6 +2505,7 @@ async function removeOwnedLifecycleArtifacts(
 		// belong to a PID-reusing successor and must not be unlinked (#4712
 		// review: PID-reuse race must not delete a successor endpoint).
 		const preUnlinkMarker = await readEffectMarker(lifecycleMarkerPath(root, id));
+		if (!lifecycleProofWithinDeadline(proofBudget)) return false;
 		if (!preUnlinkMarker || !sameEffectMarker(preUnlinkMarker, expected)) return false;
 		const endpointRemoval = exactUnlinkLifecycleFile(
 			endpointSource,
@@ -2460,6 +2517,7 @@ async function removeOwnedLifecycleArtifacts(
 					: finalEndpointPath,
 			{ dev: BigInt(endpointParent.dev), ino: BigInt(endpointParent.ino) },
 		);
+		if (!lifecycleProofWithinDeadline(proofBudget)) return false;
 		if (!endpointRemoval.ok) {
 			if (endpointRemoval.retainedUnknownPath) {
 				onRetainedUnknown?.();
@@ -2500,17 +2558,20 @@ async function removeOwnedLifecycleArtifacts(
 				} catch {
 					return false;
 				}
+				if (!lifecycleProofWithinDeadline(proofBudget)) return false;
 				if (!detachedRemoval.ok && detachedRemoval.code !== "not_found") return false;
 			}
 		}
 	}
 	const currentMarker = await readEffectMarker(lifecycleMarkerPath(root, id));
+	if (!lifecycleProofWithinDeadline(proofBudget)) return false;
 	if (!currentMarker || !sameEffectMarker(currentMarker, expected)) return false;
 	const readyPath = lifecycleReadyPath(root, id);
 	const ready = captureLifecycleFile(readyPath, true, true);
+	if (!lifecycleProofWithinDeadline(proofBudget)) return false;
 	if (ready && createHash("sha256").update(ready.bytes).digest("hex") !== ready.digest) return false;
 	// Readiness mutation is deferred to the same ledger-backed cleanup transaction.
-	return true;
+	return lifecycleProofWithinDeadline(proofBudget);
 }
 
 /**
@@ -2568,7 +2629,14 @@ async function terminateSpawnedChild(
 	const pid = child.pid;
 	if (!pid || (expected && pid !== expected.pid)) return false;
 	const incarnation = expected?.incarnation ?? processIncarnationForBroker(broker, pid);
+	const proofBudget: LifecycleProofBudget = { timing, deadlineAt: deadline };
+	const failClosed = async (): Promise<boolean> => {
+		await recordTerminalUncertain(broker, id, root, pid);
+		return false;
+	};
+	if (!lifecycleProofWithinDeadline(proofBudget)) return failClosed();
 	await broker.index.refresh();
+	if (!lifecycleProofWithinDeadline(proofBudget)) return failClosed();
 	const registered = expected ? broker.index.hasHostRegistrationForLifecycle(id, pid, expected.effectMarker) : false;
 	// Keep one poll interval inside the lifecycle deadline for the final exact
 	// cleanup proof. Registered sessions retain the original deadline partition;
@@ -2640,16 +2708,14 @@ async function terminateSpawnedChild(
 		}
 	}
 	await recheckOwnedExitObservation();
-	if (observation !== "exited") {
-		await recordTerminalUncertain(broker, id, root, pid);
-		return false;
-	}
+	if (observation !== "exited" || !lifecycleProofWithinDeadline(proofBudget)) return failClosed();
 	let rollbackGeneration: number | null | undefined;
 	if (expected) {
 		const failure = await readLifecycleFailureArtifact(
 			lifecycleFailurePath(root, id, expected.effectMarker),
 			expected,
 		);
+		if (!lifecycleProofWithinDeadline(proofBudget)) return failClosed();
 		const rollbackComplete =
 			failure?.artifact.rollback.fenced === true &&
 			failure.artifact.rollback.runtimeRemoved &&
@@ -2657,12 +2723,22 @@ async function terminateSpawnedChild(
 			failure.artifact.rollback.brokerRegistrationReleased;
 		if (!rollbackComplete) {
 			if (!readyThenExitToleranceEnabled()) {
-				await recordTerminalUncertain(broker, id, root, pid);
-				return false;
+				return failClosed();
 			}
+			if (!lifecycleProofWithinDeadline(proofBudget)) return failClosed();
 			const publishedReady = (await probePublishedReadyAuthority(root, id, expected)).kind === "matched";
-			const artifactsRemoved = await removeOwnedLifecycleArtifacts(root, id, expected);
+			if (!lifecycleProofWithinDeadline(proofBudget)) return failClosed();
+			const artifactsRemoved = await removeOwnedLifecycleArtifacts(
+				root,
+				id,
+				expected,
+				undefined,
+				undefined,
+				proofBudget,
+			);
+			if (!lifecycleProofWithinDeadline(proofBudget)) return failClosed();
 			await broker.index.refresh();
+			if (!lifecycleProofWithinDeadline(proofBudget)) return failClosed();
 			const registered = broker.index
 				.listSessions()
 				.sessions.find(session => session.sessionId === id && session.pid === pid);
@@ -2670,14 +2746,19 @@ async function terminateSpawnedChild(
 			let registrationReleased =
 				!broker.index.hasHostRegistrationForLifecycle(id, pid, expected.effectMarker) || registeredRowTerminal;
 			if (registered && !registrationReleased) {
+				if (!lifecycleProofWithinDeadline(proofBudget)) return failClosed();
 				registrationReleased = await broker.index.unregisterIfCurrent(registered);
+				if (!lifecycleProofWithinDeadline(proofBudget)) return failClosed();
 				await broker.index.refresh();
+				if (!lifecycleProofWithinDeadline(proofBudget)) return failClosed();
 				registrationReleased =
 					registrationReleased || !broker.index.hasHostRegistrationForLifecycle(id, pid, expected.effectMarker);
 			}
 			const stillExited =
 				observeProcess(pid, expected.incarnation, value => processIncarnationForBroker(broker, value)) === "exited";
+			if (!lifecycleProofWithinDeadline(proofBudget)) return failClosed();
 			const endpointGone = await endpointRemoved(root, id);
+			if (!lifecycleProofWithinDeadline(proofBudget)) return failClosed();
 			try {
 				if (publishedReady && !failure) {
 					await writeSessionLifecycleFailure(
@@ -2704,23 +2785,29 @@ async function terminateSpawnedChild(
 			} catch {
 				// A missing broker-authored receipt must not hide a proven dead child.
 			}
-			if (stillExited && artifactsRemoved && endpointGone && registrationReleased) return true;
-			await recordTerminalUncertain(broker, id, root, pid);
-			return false;
+			if (
+				stillExited &&
+				artifactsRemoved &&
+				endpointGone &&
+				registrationReleased &&
+				lifecycleProofWithinDeadline(proofBudget)
+			)
+				return true;
+			return failClosed();
 		}
 		rollbackGeneration = failure.artifact.rollback.endpointGeneration;
 	}
-	if (expected && !(await removeOwnedLifecycleArtifacts(root, id, expected))) {
-		await recordTerminalUncertain(broker, id, root, pid);
-		return false;
-	}
+	if (expected && !(await removeOwnedLifecycleArtifacts(root, id, expected, undefined, undefined, proofBudget)))
+		return failClosed();
+	if (!lifecycleProofWithinDeadline(proofBudget)) return failClosed();
 	await broker.index.refresh();
+	if (!lifecycleProofWithinDeadline(proofBudget)) return failClosed();
 	if (
 		rollbackGeneration === null &&
 		expected &&
 		!broker.index.hasHostRegistrationForLifecycle(id, pid, expected.effectMarker)
 	)
-		return true;
+		return lifecycleProofWithinDeadline(proofBudget) ? true : failClosed();
 	const registeredBeforeTermination =
 		rollbackGeneration === undefined || rollbackGeneration === null
 			? undefined
@@ -2729,10 +2816,11 @@ async function terminateSpawnedChild(
 		? broker.index.hostUnregisteredAfter(registeredBeforeTermination)
 		: undefined;
 	if (!registeredBeforeTermination || !unregistered) {
-		await recordTerminalUncertain(broker, id, root, pid);
-		return false;
+		return failClosed();
 	}
-	return endpointRemoved(root, id);
+	if (!lifecycleProofWithinDeadline(proofBudget)) return failClosed();
+	const endpointGone = await endpointRemoved(root, id);
+	return endpointGone && lifecycleProofWithinDeadline(proofBudget) ? true : failClosed();
 }
 
 async function signalVerifiedSession(
@@ -4014,10 +4102,11 @@ async function executeLifecycleResponse(
 		}
 		const effectMarker = randomUUID();
 		const plannedWorktreeIntent = worktreeIntent(launch.worktreePlan);
-		const effectIntent: LifecycleEffectIntent = {
+		const effectIntent: LifecycleEffectIntentWithDeadline = {
 			sessionId: launch.id,
 			stateRoot: launch.root,
 			childOwnershipEstablished: false,
+			lifecycleCleanupDeadlineAt: deadlines.lifecycleCleanupDeadlineAt,
 			...(plannedWorktreeIntent ? { worktree: plannedWorktreeIntent } : {}),
 		};
 
@@ -5158,8 +5247,10 @@ async function exactCleanupProof(
 	id: string | undefined,
 	expected: EffectMarker | undefined,
 	evidence: { artifact: LifecycleFailureArtifact } | undefined,
+	proofBudget?: LifecycleProofBudget,
 ): Promise<LifecycleCleanupProof | undefined> {
 	const rollback = evidence?.artifact.rollback;
+	if (!lifecycleProofWithinDeadline(proofBudget)) return undefined;
 	if (
 		!root ||
 		!id ||
@@ -5169,13 +5260,17 @@ async function exactCleanupProof(
 		!rollback.hostStopped ||
 		!rollback.brokerRegistrationReleased ||
 		observeProcess(expected.pid, expected.incarnation, value => processIncarnationForBroker(broker, value)) !==
-			"exited" ||
-		!(await endpointRemoved(root, id))
+			"exited"
 	)
 		return undefined;
+	if (!lifecycleProofWithinDeadline(proofBudget)) return undefined;
+	if (!(await endpointRemoved(root, id))) return undefined;
+	if (!lifecycleProofWithinDeadline(proofBudget)) return undefined;
 	await broker.index.refresh();
+	if (!lifecycleProofWithinDeadline(proofBudget)) return undefined;
 	if (rollback.endpointGeneration === null) {
 		if (broker.index.hasHostRegistrationForLifecycle(id, expected.pid, expected.effectMarker)) return undefined;
+		if (!lifecycleProofWithinDeadline(proofBudget)) return undefined;
 		return {
 			processExited: true,
 			endpointRemoved: true,
@@ -5196,7 +5291,7 @@ async function exactCleanupProof(
 		expected.effectMarker,
 	);
 	const hostUnregistered = registration ? broker.index.hostUnregisteredAfter(registration) : undefined;
-	return hostUnregistered
+	return hostUnregistered && lifecycleProofWithinDeadline(proofBudget)
 		? {
 				processExited: true,
 				endpointRemoved: true,
@@ -5258,6 +5353,9 @@ export async function executeLifecycle(
 	identity: string,
 	cleanup?: CleanupEvidence,
 ): Promise<LifecycleExecutionOutcome> {
+	let proofBudget = lifecycleProofBudgetFromInput(broker, input);
+	if (!proofBudget)
+		proofBudget = lifecycleProofBudgetFromEffectIntent(broker, broker.ledger.get(identity)?.effectIntent);
 	if (cleanup?.phase === "metadata") {
 		if (operation !== "session.delete")
 			return {
@@ -5284,10 +5382,16 @@ export async function executeLifecycle(
 			),
 		});
 		return {
-			response: await reconcileLifecycleCleanup(broker, identity, migrated, {
-				ok: true,
-				result: { sessionId: migrated.sessionId },
-			}),
+			response: await reconcileLifecycleCleanup(
+				broker,
+				identity,
+				migrated,
+				{
+					ok: true,
+					result: { sessionId: migrated.sessionId },
+				},
+				proofBudget,
+			),
 		};
 	}
 	if (cleanup?.phase === "lifecycle") {
@@ -5305,11 +5409,13 @@ export async function executeLifecycle(
 				operation === "session.delete"
 					? { ok: true, result: { sessionId: cleanup.sessionId } }
 					: fail("spawn_failed", "No ready SDK endpoint remains available."),
+				proofBudget,
 			),
 		};
 	}
 	const response = await executeLifecycleResponse(broker, operation, input, identity, cleanup);
 	const entry = broker.ledger.get(identity);
+	if (!proofBudget) proofBudget = lifecycleProofBudgetFromEffectIntent(broker, entry?.effectIntent);
 	const priorDurableEffects = entry?.durableEffects;
 	const evidenceCwd = entry?.effectIntent?.worktree?.worktreePath ?? lifecycleCwd(input);
 	const root = entry?.effectIntent?.stateRoot ?? stateRoot(input, evidenceCwd);
@@ -5325,7 +5431,14 @@ export async function executeLifecycle(
 					expected,
 				)
 			: undefined;
-	const cleanupProof = await exactCleanupProof(broker, root, entry?.intendedSessionId, expected, evidence);
+	const cleanupProof = await exactCleanupProof(
+		broker,
+		root,
+		entry?.intendedSessionId,
+		expected,
+		evidence,
+		proofBudget,
+	);
 	const startupFailure: LifecycleStartupFailureReceipt | undefined = evidence
 		? {
 				artifactDigest: evidence.digest,
@@ -5370,6 +5483,12 @@ export async function executeLifecycle(
 		evidence && root && entry?.intendedSessionId && expected && cleanupProof
 			? await (async () => {
 					const cleanupIntent = lifecycleCleanupPlan(root, entry.intendedSessionId!, expected, evidence);
+					if (!lifecycleProofWithinDeadline(proofBudget))
+						return fail(
+							"terminal_uncertain",
+							"Lifecycle cleanup proof exceeded its cleanup deadline.",
+							cleanupIntent,
+						);
 					await broker.ledger.transition(identity, "effect_started", {
 						response: fail(
 							"cleanup_pending",
@@ -5377,7 +5496,13 @@ export async function executeLifecycle(
 							cleanupIntent,
 						),
 					});
-					return reconcileLifecycleCleanup(broker, identity, cleanupIntent);
+					if (!lifecycleProofWithinDeadline(proofBudget))
+						return fail(
+							"terminal_uncertain",
+							"Lifecycle cleanup proof exceeded its cleanup deadline.",
+							cleanupIntent,
+						);
+					return reconcileLifecycleCleanup(broker, identity, cleanupIntent, undefined, proofBudget);
 				})()
 			: undefined;
 	if (
@@ -5393,14 +5518,22 @@ export async function executeLifecycle(
 	const provenExpected = expected;
 	const provenRoot = root;
 	const provenId = entry?.intendedSessionId;
-	const provenDeadCleanup =
+	let provenDeadCleanup = false;
+	if (
 		Boolean(provenExpected) &&
 		Boolean(provenRoot) &&
 		Boolean(provenId) &&
-		observeProcess(provenExpected!.pid, provenExpected!.incarnation, value =>
-			processIncarnationForBroker(broker, value),
-		) === "exited" &&
-		(await endpointRemoved(provenRoot!, provenId!));
+		lifecycleProofWithinDeadline(proofBudget)
+	) {
+		const processExited =
+			observeProcess(provenExpected!.pid, provenExpected!.incarnation, value =>
+				processIncarnationForBroker(broker, value),
+			) === "exited";
+		if (processExited && lifecycleProofWithinDeadline(proofBudget)) {
+			const endpointGone = await endpointRemoved(provenRoot!, provenId!);
+			provenDeadCleanup = endpointGone && lifecycleProofWithinDeadline(proofBudget);
+		}
+	}
 	const terminalResponse: BrokerResponse =
 		!response.ok &&
 		entry?.effectMarker &&

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -1017,11 +1017,13 @@ export async function reapDeadLifecycleMarkers(
 	limit = BROKER_DEAD_REGISTRATION_SWEEP_LIMIT,
 ): Promise<number> {
 	let directory: string;
+	let directoryIdentity: { dev: bigint; ino: bigint };
 	try {
 		const canonicalRoot = fsSync.realpathSync(root);
 		directory = path.join(canonicalRoot, "sdk");
 		const directoryStat = fsSync.lstatSync(directory, { bigint: true });
 		if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) return 0;
+		directoryIdentity = { dev: directoryStat.dev, ino: directoryStat.ino };
 	} catch {
 		return 0;
 	}
@@ -1054,12 +1056,12 @@ export async function reapDeadLifecycleMarkers(
 			}
 		}
 		try {
-			const currentPrimary = captureLifecycleFile(markerPath, true, true)?.identity;
+			const currentPrimary = captureLifecycleFile(markerPath, true, true);
 			const currentReady = ready ? captureLifecycleFile(readyPath, true, true)?.identity : undefined;
 			if (
 				!currentPrimary ||
 				!sameLifecycleCleanupIdentity(
-					currentPrimary,
+					currentPrimary.identity,
 					serializeCleanupIdentity({ ...primary.identity, size: Number(primary.identity.size) }),
 				) ||
 				(ready &&
@@ -1070,10 +1072,14 @@ export async function reapDeadLifecycleMarkers(
 						)))
 			)
 				continue;
+			const currentMarker = parseLifecycleJson(currentPrimary.bytes);
+			if (!isExactEffectMarker(currentMarker) || !sameEffectMarker(currentMarker, marker)) continue;
 			if (
 				ready &&
 				!nativeLifecycle().exactUnlinkDirect(readyPath, {
 					...ready.identity,
+					parentDev: directoryIdentity.dev,
+					parentIno: directoryIdentity.ino,
 					quarantineName: `.gjc-reap-${randomUUID()}-${path.basename(readyPath)}`,
 				}).ok
 			)
@@ -1081,6 +1087,8 @@ export async function reapDeadLifecycleMarkers(
 			if (
 				!nativeLifecycle().exactUnlinkDirect(markerPath, {
 					...primary.identity,
+					parentDev: directoryIdentity.dev,
+					parentIno: directoryIdentity.ino,
 					quarantineName: `.gjc-reap-${randomUUID()}-${name}`,
 				}).ok
 			)
@@ -4128,12 +4136,14 @@ async function executeLifecycleResponse(
 			}
 			const spawned = authorizedSpawn.value;
 			child = spawned;
-			let childSpawnError: Error | undefined;
-			spawned.once("error", error => {
-				childSpawnError = error;
+			const spawnOutcome = Promise.withResolvers<void>();
+			spawned.once("error", error => spawnOutcome.reject(error));
+			spawned.once("spawn", () => spawnOutcome.resolve());
+			queueMicrotask(() => {
+				if (spawned.pid) spawnOutcome.resolve();
 			});
+			await spawnOutcome.promise;
 			const pid = spawned.pid;
-			if (childSpawnError) throw childSpawnError;
 			if (!pid) throw new Error("spawned session has no pid");
 			const incarnation = processIncarnationForBroker(broker, pid);
 			if (!incarnation) throw new Error("spawned session has no readable OS incarnation");

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -2569,6 +2569,10 @@ async function terminateSpawnedChild(
 	if (!pid || (expected && pid !== expected.pid)) return false;
 	const incarnation = expected?.incarnation ?? processIncarnationForBroker(broker, pid);
 	await broker.index.refresh();
+	const terminationDeadline =
+		expected && !broker.index.hasHostRegistrationForLifecycle(id, pid, expected.effectMarker)
+			? deadline
+			: terminationStartDeadlineAt;
 	const observe = (): ProcessObservation =>
 		child.exitCode !== null
 			? "exited"
@@ -2591,7 +2595,7 @@ async function terminateSpawnedChild(
 		observation = await waitForExit(deadline);
 	};
 	if (observation === "alive") {
-		await waitUntil(timing, terminationStartDeadlineAt);
+		await waitUntil(timing, terminationDeadline);
 		observation = observe();
 	}
 	if (observation === "alive") {

--- a/packages/coding-agent/src/sdk/broker/runtime.ts
+++ b/packages/coding-agent/src/sdk/broker/runtime.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { currentExecutablePath } from "@gajae-code/natives";
 import packageJson from "../../../package.json" with { type: "json" };
 import internalSourceMarker from "./internal-source-marker-2178.txt" with { type: "file" };
 
@@ -105,10 +106,9 @@ function isBunVirtualExecutablePath(file: string): boolean {
 /**
  * Bun normally exposes the compiled application's on-disk path through
  * `process.execPath`. Some single-file builds instead expose their virtual
- * bundle entry there while `argv[0]` retains the kernel-provided launch file.
- * Exact compiled-marker evidence proves this is the bundled GJC process; the
- * candidate still has to be an on-disk readable regular file. PATH is never
- * consulted.
+ * bundle entry there. Exact compiled-marker evidence proves this is the
+ * bundled GJC process; the fallback comes from the OS current-image query,
+ * never argv or PATH.
  */
 function compiledExecutable(options: SdkInternalRuntimeDescriptorTestOptions): string {
 	const execPath = options.execPath ?? process.execPath;
@@ -116,7 +116,9 @@ function compiledExecutable(options: SdkInternalRuntimeDescriptorTestOptions): s
 		return regularExecutablePath(path.resolve(execPath), "compiled executable");
 	} catch (error) {
 		if (!isBunVirtualExecutablePath(execPath)) throw error;
-		return regularExecutablePath(path.resolve(options.argv0 ?? process.argv[0] ?? ""), "compiled executable");
+		const currentExecutable = currentExecutablePath();
+		if (!currentExecutable) throw error;
+		return regularExecutablePath(currentExecutable, "compiled executable");
 	}
 }
 

--- a/packages/coding-agent/src/sdk/broker/runtime.ts
+++ b/packages/coding-agent/src/sdk/broker/runtime.ts
@@ -46,7 +46,6 @@ const commandAuthorityPaths = new WeakMap<object, string[]>();
 /** Test-only injectable inputs for hostile evidence and platform grammar coverage. */
 export interface SdkInternalRuntimeDescriptorTestOptions {
 	execPath?: string;
-	argv0?: string;
 	environment?: NodeJS.ProcessEnv;
 	embeddedFiles?: readonly EmbeddedFile[];
 	markerPath?: string;

--- a/packages/coding-agent/src/sdk/broker/runtime.ts
+++ b/packages/coding-agent/src/sdk/broker/runtime.ts
@@ -45,6 +45,7 @@ const commandAuthorityPaths = new WeakMap<object, string[]>();
 /** Test-only injectable inputs for hostile evidence and platform grammar coverage. */
 export interface SdkInternalRuntimeDescriptorTestOptions {
 	execPath?: string;
+	argv0?: string;
 	environment?: NodeJS.ProcessEnv;
 	embeddedFiles?: readonly EmbeddedFile[];
 	markerPath?: string;
@@ -82,6 +83,31 @@ function regularReadablePath(file: string, label: string): string {
 		throw new Error(`SDK internal launch refused: ${label} is not a readable regular file.`);
 	}
 	return canonical;
+}
+
+function isBunVirtualExecutablePath(file: string): boolean {
+	const normalized = file.replaceAll("\\", "/").toLowerCase();
+	return (
+		normalized === "/$bunfs" || normalized.startsWith("/$bunfs/") || /^(?:[a-z]:)?\/~bun(?:\/|$)/.test(normalized)
+	);
+}
+
+/**
+ * Bun normally exposes the compiled application's on-disk path through
+ * `process.execPath`. Some single-file builds instead expose their virtual
+ * bundle entry there while `argv[0]` retains the kernel-provided launch file.
+ * Exact compiled-marker evidence proves this is the bundled GJC process; the
+ * candidate still has to be an on-disk readable regular file. PATH is never
+ * consulted.
+ */
+function compiledExecutable(options: SdkInternalRuntimeDescriptorTestOptions): string {
+	const execPath = options.execPath ?? process.execPath;
+	try {
+		return regularReadablePath(path.resolve(execPath), "compiled executable");
+	} catch (error) {
+		if (!isBunVirtualExecutablePath(execPath)) throw error;
+		return regularReadablePath(path.resolve(options.argv0 ?? process.argv[0] ?? ""), "compiled executable");
+	}
 }
 
 function internalEnvironment(environment: NodeJS.ProcessEnv, source: boolean): NodeJS.ProcessEnv {
@@ -468,7 +494,7 @@ function resolveSdkInternalSpawnCommandWithEvidence(
 	const isSourceMarker = path.isAbsolute(markerPath) && !compiledMarkerPath;
 	if (embeddedFiles.length === 0 && isSourceMarker) return sourceDescriptor(action, options, markerPath);
 	if (exactCompiledArtifact && compiledMarkerPath) {
-		const executable = regularReadablePath(path.resolve(options.execPath ?? process.execPath), "compiled executable");
+		const executable = compiledExecutable(options);
 		const command: SdkInternalSpawnCommand = {
 			kind: "compiled",
 			file: executable,

--- a/packages/coding-agent/src/sdk/broker/runtime.ts
+++ b/packages/coding-agent/src/sdk/broker/runtime.ts
@@ -85,6 +85,16 @@ function regularReadablePath(file: string, label: string): string {
 	return canonical;
 }
 
+function regularExecutablePath(file: string, label: string): string {
+	const canonical = regularReadablePath(file, label);
+	try {
+		fs.accessSync(canonical, fs.constants.X_OK);
+	} catch {
+		throw new Error(`SDK internal launch refused: ${label} is not an executable regular file.`);
+	}
+	return canonical;
+}
+
 function isBunVirtualExecutablePath(file: string): boolean {
 	const normalized = file.replaceAll("\\", "/").toLowerCase();
 	return (
@@ -103,10 +113,10 @@ function isBunVirtualExecutablePath(file: string): boolean {
 function compiledExecutable(options: SdkInternalRuntimeDescriptorTestOptions): string {
 	const execPath = options.execPath ?? process.execPath;
 	try {
-		return regularReadablePath(path.resolve(execPath), "compiled executable");
+		return regularExecutablePath(path.resolve(execPath), "compiled executable");
 	} catch (error) {
 		if (!isBunVirtualExecutablePath(execPath)) throw error;
-		return regularReadablePath(path.resolve(options.argv0 ?? process.argv[0] ?? ""), "compiled executable");
+		return regularExecutablePath(path.resolve(options.argv0 ?? process.argv[0] ?? ""), "compiled executable");
 	}
 }
 

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -2442,6 +2442,25 @@ test("broker terminalizes default command resolver failures", async () => {
 	}
 });
 
+test("broker preserves spawn_failed when the ChildProcess emits an error before PID ownership", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-child-error-"));
+	const broker = new Broker({ agentDir: path.join(root, "agent") });
+	try {
+		setLifecycleCommandResolverForTest(broker, () => ({ file: path.join(root, "missing-gjc"), args: [] }));
+		await broker.start();
+		await expect(
+			broker.handleRequest("session.create", { cwd: root }, "child-error-before-pid"),
+		).resolves.toMatchObject({
+			ok: false,
+			error: { code: "spawn_failed" },
+		});
+	} finally {
+		setLifecycleCommandResolverForTest(broker, undefined);
+		await broker.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});
+
 test("reaps only lifecycle markers whose exact owner is proven dead", async () => {
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-lifecycle-marker-reap-"));
 	const sdk = path.join(root, ".gjc", "state", "sdk");

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -2469,6 +2469,33 @@ test("reaps only lifecycle markers whose exact owner is proven dead", async () =
 	}
 });
 
+test("does not follow lifecycle sdk symlinks or partially reap an unsafe ready sibling", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-lifecycle-marker-safety-"));
+	const stateRoot = path.join(root, ".gjc", "state");
+	const redirectedSdk = path.join(root, "redirected-sdk");
+	const dead = { pid: 999_999_999, effectMarker: "dead", incarnation: "linux:1" };
+	try {
+		await fs.mkdir(redirectedSdk, { recursive: true });
+		await fs.mkdir(stateRoot, { recursive: true });
+		await fs.symlink(redirectedSdk, path.join(stateRoot, "sdk"));
+		await Bun.write(path.join(redirectedSdk, "redirected.lifecycle.json"), JSON.stringify(dead));
+		expect(await reapDeadLifecycleMarkers(stateRoot)).toBe(0);
+		await expect(Bun.file(path.join(redirectedSdk, "redirected.lifecycle.json")).exists()).resolves.toBe(true);
+
+		await fs.rm(path.join(stateRoot, "sdk"));
+		await fs.mkdir(path.join(stateRoot, "sdk"));
+		const markerPath = path.join(stateRoot, "sdk", "unsafe-ready.lifecycle.json");
+		await Bun.write(markerPath, JSON.stringify(dead));
+		await Bun.write(path.join(stateRoot, "sdk", "unsafe-ready.lifecycle.ready.json"), "unsafe ready sibling");
+		const expiredAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+		await fs.utimes(markerPath, expiredAt, expiredAt);
+		expect(await reapDeadLifecycleMarkers(stateRoot)).toBe(0);
+		await expect(Bun.file(markerPath).exists()).resolves.toBe(true);
+	} finally {
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});
+
 test("retains the concrete spawn failure when cleanup proof is unavailable", async () => {
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-spawn-failure-cause-"));
 	const agentDir = path.join(root, "agent");

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -4616,6 +4616,115 @@ test("never-settling model profile startup cuts off with proven pre-registration
 		await fs.rm(root, { recursive: true, force: true });
 	}
 }, 10_000);
+
+test("unregistered cutoff receipt gets bounded publication and post-signal proof", async () => {
+	if (process.platform !== "linux") return;
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-sdk-pre-registration-boundary-"));
+	const agentDir = path.join(root, "agent");
+	const fixture = path.join(root, "pre-registration-boundary.ts");
+	const pidPath = path.join(root, "child.pid");
+	const requestPath = path.join(root, "child.request.json");
+	const receivedAt = 1_000;
+	const deadlines = deriveLifecycleDeadlines(receivedAt, 4_000);
+	let nowMs = receivedAt;
+	let receiptPublished = false;
+	const broker = new Broker({ agentDir });
+	await fs.writeFile(
+		fixture,
+		`await Bun.write(${JSON.stringify(pidPath)}, String(process.pid));
+await Bun.write(${JSON.stringify(requestPath)}, process.env.GJC_SDK_LIFECYCLE_REQUEST ?? "");
+setInterval(() => {}, 1_000_000);
+`,
+	);
+	setLifecycleCommandResolverForTest(broker, () => ({ file: process.execPath, args: ["run", fixture] }));
+	setLifecycleTimingForTest(broker, {
+		now: () => nowMs,
+		sleep: async ms => {
+			const requestReady = await fs.access(requestPath).then(
+				() => true,
+				() => false,
+			);
+			if (!requestReady) {
+				await Bun.sleep(1);
+				return;
+			}
+			nowMs += ms;
+			if (!receiptPublished && nowMs >= deadlines.semanticReadyDeadlineAt - 100) {
+				const request = JSON.parse(await fs.readFile(requestPath, "utf8")) as {
+					sessionId: string;
+					stateRoot: string;
+					effectMarker: string;
+				};
+				const pid = Number(await fs.readFile(pidPath, "utf8"));
+				const childIncarnation = processIncarnation(pid);
+				if (!childIncarnation) throw new Error("Expected a readable child process incarnation.");
+				await writeSessionLifecycleFailure(
+					request.stateRoot,
+					request.sessionId,
+					request.effectMarker,
+					{
+						phase: "startup",
+						reason: "pending",
+						message: "deterministic cutoff receipt",
+					},
+					{
+						endpointGeneration: null,
+						fenced: true,
+						runtimeRemoved: true,
+						hostStopped: true,
+						brokerRegistrationReleased: true,
+					},
+					undefined,
+					childIncarnation,
+					pid,
+				);
+				receiptPublished = true;
+			}
+			await Bun.sleep(1);
+		},
+	});
+	try {
+		await broker.start();
+		const response = await broker.handleRequest(
+			"session.create",
+			{ cwd: root, readinessTimeoutMs: deadlines.requestedReadinessTimeoutMs },
+			"pre-registration-boundary",
+		);
+		expect(receiptPublished).toBe(true);
+		expect(response).toMatchObject({
+			ok: false,
+			error: {
+				code: "spawn_failed",
+				endpoint: "unavailable",
+				message: "deterministic cutoff receipt",
+			},
+			startupFailure: {
+				phase: "startup",
+				reason: "pending",
+				message: "deterministic cutoff receipt",
+				rollback: {
+					endpointGeneration: null,
+					fenced: true,
+					runtimeRemoved: true,
+					hostStopped: true,
+					brokerRegistrationReleased: true,
+				},
+				cleanupProof: {
+					processExited: true,
+					endpointRemoved: true,
+					hostUnregistered: { state: "not_registered" },
+				},
+			},
+		});
+		expect(nowMs).toBeLessThan(deadlines.lifecycleCleanupDeadlineAt);
+	} finally {
+		setLifecycleTimingForTest(broker, undefined);
+		setLifecycleCommandResolverForTest(broker, undefined);
+		await broker.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}, 10_000);
+
 test("production post-registration startup failure proves cleanup and exact replay", async () => {
 	if (process.platform !== "linux") return;
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-sdk-production-failure-"));

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -4810,7 +4810,9 @@ test("production broker session.create authenticates a source-workspace v3 nativ
 		await broker.start();
 		const created = await broker.handleRequest(
 			"session.create",
-			{ cwd: root, readinessTimeoutMs: 10_000 },
+			// This boots a real source-workspace host. Preserve enough headroom when
+			// Bun runs this file beside the broker unit shard on loaded CI workers.
+			{ cwd: root, readinessTimeoutMs: 20_000 },
 			"v3-native-create",
 		);
 		if (!created.ok) throw new Error(created.error.message);
@@ -4844,7 +4846,7 @@ test("production broker session.create authenticates a source-workspace v3 nativ
 		await broker.stop();
 		await fs.rm(root, { recursive: true, force: true });
 	}
-}, 20_000);
+}, 30_000);
 
 test("broker agentDir profile validates, activates, and is discoverable through session Q27", async () => {
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-sdk-profile-agent-dir-"));
@@ -4861,7 +4863,7 @@ test("broker agentDir profile validates, activates, and is discoverable through 
 		await broker.start();
 		const created = await broker.handleRequest(
 			"session.create",
-			{ cwd, modelPreset: "agent-dir-only", readinessTimeoutMs: 10_000 },
+			{ cwd, modelPreset: "agent-dir-only", readinessTimeoutMs: 20_000 },
 			"agent-dir-profile-create",
 		);
 		if (!created.ok) throw new Error(created.error.message);
@@ -4894,7 +4896,7 @@ test("broker agentDir profile validates, activates, and is discoverable through 
 		await broker.stop();
 		await fs.rm(root, { recursive: true, force: true });
 	}
-}, 20_000);
+}, 30_000);
 
 test("child profile activation failures preserve typed codes through readiness and BrokerResponse", async () => {
 	if (process.platform !== "linux") return;

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -21,6 +21,7 @@ import {
 	observeProcessForTest,
 	parseDarwinProcessIncarnation,
 	processIncarnation,
+	reapDeadLifecycleMarkers,
 	reapDeadSessionRegistrations,
 	setLifecycleCleanupHookForTest,
 	setLifecycleCommandResolverForTest,
@@ -2436,6 +2437,57 @@ test("broker terminalizes default command resolver failures", async () => {
 		setLifecycleCommandResolverForTest(broker, undefined);
 		if (previousCommand === undefined) delete process.env.GJC_SDK_SESSION_COMMAND;
 		else process.env.GJC_SDK_SESSION_COMMAND = previousCommand;
+		await broker.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});
+
+test("reaps only lifecycle markers whose exact owner is proven dead", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-lifecycle-marker-reap-"));
+	const sdk = path.join(root, ".gjc", "state", "sdk");
+	const deadId = "dead-session";
+	const liveId = "live-session";
+	const unreadableId = "unreadable-session";
+	try {
+		await fs.mkdir(sdk, { recursive: true });
+		const dead = { pid: 999_999_999, effectMarker: "dead", incarnation: "linux:1" };
+		const live = { pid: process.pid, effectMarker: "live", incarnation: await incarnation(process.pid) };
+		await Bun.write(path.join(sdk, `${deadId}.lifecycle.json`), JSON.stringify(dead));
+		await Bun.write(path.join(sdk, `${deadId}.lifecycle.ready.json`), JSON.stringify(dead));
+		await Bun.write(path.join(sdk, `${liveId}.lifecycle.json`), JSON.stringify(live));
+		await Bun.write(path.join(sdk, `${unreadableId}.lifecycle.json`), "not lifecycle JSON");
+		const expiredAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+		await fs.utimes(path.join(sdk, `${deadId}.lifecycle.json`), expiredAt, expiredAt);
+
+		expect(await reapDeadLifecycleMarkers(path.dirname(sdk))).toBe(1);
+		await expect(Bun.file(path.join(sdk, `${deadId}.lifecycle.json`)).exists()).resolves.toBe(false);
+		await expect(Bun.file(path.join(sdk, `${deadId}.lifecycle.ready.json`)).exists()).resolves.toBe(false);
+		await expect(Bun.file(path.join(sdk, `${liveId}.lifecycle.json`)).exists()).resolves.toBe(true);
+		await expect(Bun.file(path.join(sdk, `${unreadableId}.lifecycle.json`)).exists()).resolves.toBe(true);
+	} finally {
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});
+
+test("retains the concrete spawn failure when cleanup proof is unavailable", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-spawn-failure-cause-"));
+	const agentDir = path.join(root, "agent");
+	const broker = new Broker({ agentDir });
+	try {
+		setLifecycleCommandResolverForTest(broker, () => {
+			throw new Error("runtime executable is not a readable regular file.");
+		});
+		await broker.start();
+		const response = await broker.handleRequest("session.create", { cwd: root }, "concrete-spawn-failure");
+		expect(response).toEqual({
+			ok: false,
+			error: {
+				code: "spawn_failed",
+				message: "Unable to spawn session: runtime executable is not a readable regular file.",
+			},
+		});
+	} finally {
+		setLifecycleCommandResolverForTest(broker, undefined);
 		await broker.stop();
 		await fs.rm(root, { recursive: true, force: true });
 	}

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -2494,6 +2494,28 @@ test("reaps only lifecycle markers whose exact owner is proven dead", async () =
 	}
 });
 
+test("bounds stale lifecycle marker inspection even when candidates are not reapable", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-lifecycle-marker-limit-"));
+	const stateRoot = path.join(root, ".gjc", "state");
+	const sdk = path.join(stateRoot, "sdk");
+	const deadId = "999-dead-session";
+	try {
+		await fs.mkdir(sdk, { recursive: true });
+		await Bun.write(path.join(sdk, "000-malformed.lifecycle.json"), "not lifecycle JSON");
+		const dead = { pid: 999_999_999, effectMarker: "dead", incarnation: "linux:1" };
+		const markerPath = path.join(sdk, `${deadId}.lifecycle.json`);
+		await Bun.write(markerPath, JSON.stringify(dead));
+		await Bun.write(path.join(sdk, `${deadId}.lifecycle.ready.json`), JSON.stringify(dead));
+		const expiredAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+		await fs.utimes(markerPath, expiredAt, expiredAt);
+
+		expect(await reapDeadLifecycleMarkers(stateRoot, 1)).toBe(0);
+		await expect(Bun.file(markerPath).exists()).resolves.toBe(true);
+	} finally {
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});
+
 test("does not follow lifecycle sdk symlinks or partially reap an unsafe ready sibling", async () => {
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-lifecycle-marker-safety-"));
 	const stateRoot = path.join(root, ".gjc", "state");
@@ -4724,6 +4746,99 @@ setInterval(() => {}, 1_000_000);
 		});
 		expect(nowMs).toBeLessThan(deadlines.lifecycleCleanupDeadlineAt);
 	} finally {
+		setLifecycleTimingForTest(broker, undefined);
+		setLifecycleCommandResolverForTest(broker, undefined);
+		await broker.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}, 10_000);
+
+test("delayed lifecycle reconciliation proof cannot return spawn_failed cleanup after its deadline", async () => {
+	if (process.platform !== "linux") return;
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-sdk-delayed-proof-"));
+	const agentDir = path.join(root, "agent");
+	const fixture = path.join(root, "delayed-proof.ts");
+	const pidPath = path.join(root, "child.pid");
+	const requestPath = path.join(root, "child.request.json");
+	const receivedAt = 1_000;
+	const deadlines = deriveLifecycleDeadlines(receivedAt, 4_000);
+	let nowMs = receivedAt;
+	let receiptPublished = false;
+	let delayedProof = false;
+	const broker = new Broker({ agentDir });
+	await fs.writeFile(
+		fixture,
+		`await Bun.write(${JSON.stringify(pidPath)}, String(process.pid));
+await Bun.write(${JSON.stringify(requestPath)}, process.env.GJC_SDK_LIFECYCLE_REQUEST ?? "");
+setInterval(() => {}, 1_000_000);
+`,
+	);
+	setLifecycleCommandResolverForTest(broker, () => ({ file: process.execPath, args: ["run", fixture] }));
+	setLifecycleTimingForTest(broker, {
+		now: () => nowMs,
+		sleep: async ms => {
+			const requestReady = await fs.access(requestPath).then(
+				() => true,
+				() => false,
+			);
+			if (!requestReady) {
+				await Bun.sleep(1);
+				return;
+			}
+			nowMs += ms;
+			if (!receiptPublished && nowMs >= deadlines.semanticReadyDeadlineAt - 100) {
+				const request = JSON.parse(await fs.readFile(requestPath, "utf8")) as {
+					sessionId: string;
+					stateRoot: string;
+					effectMarker: string;
+				};
+				const pid = Number(await fs.readFile(pidPath, "utf8"));
+				const childIncarnation = processIncarnation(pid);
+				if (!childIncarnation) throw new Error("Expected a readable child process incarnation.");
+				await writeSessionLifecycleFailure(
+					request.stateRoot,
+					request.sessionId,
+					request.effectMarker,
+					{ phase: "startup", reason: "pending", message: "delayed lifecycle proof" },
+					{
+						endpointGeneration: null,
+						fenced: true,
+						runtimeRemoved: true,
+						hostStopped: true,
+						brokerRegistrationReleased: true,
+					},
+					undefined,
+					childIncarnation,
+					pid,
+				);
+				receiptPublished = true;
+			}
+			await Bun.sleep(1);
+		},
+	});
+	const originalExactUnlink = native.exactUnlink.bind(native);
+	const unlinkSpy = vi.spyOn(native, "exactUnlink").mockImplementation((pathname, identity) => {
+		const result = originalExactUnlink(pathname, identity);
+		if (!delayedProof && receiptPublished && nowMs >= deadlines.terminationStartDeadlineAt) {
+			nowMs = deadlines.lifecycleCleanupDeadlineAt;
+			delayedProof = true;
+		}
+		return result;
+	});
+	try {
+		await broker.start();
+		const response = await broker.handleRequest(
+			"session.create",
+			{ cwd: root, readinessTimeoutMs: deadlines.requestedReadinessTimeoutMs },
+			"delayed-lifecycle-proof",
+		);
+		expect(receiptPublished).toBe(true);
+		expect(delayedProof).toBe(true);
+		expect(nowMs).toBeGreaterThanOrEqual(deadlines.lifecycleCleanupDeadlineAt);
+		expect(response).toMatchObject({ ok: false, error: { code: "terminal_uncertain" } });
+		if (!response.ok) expect(response.error.code).not.toBe("spawn_failed");
+	} finally {
+		unlinkSpy.mockRestore();
 		setLifecycleTimingForTest(broker, undefined);
 		setLifecycleCommandResolverForTest(broker, undefined);
 		await broker.stop();

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -2498,20 +2498,22 @@ test("bounds stale lifecycle marker inspection even when candidates are not reap
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-lifecycle-marker-limit-"));
 	const stateRoot = path.join(root, ".gjc", "state");
 	const sdk = path.join(stateRoot, "sdk");
-	const deadId = "999-dead-session";
+	const originalKill = process.kill;
+	let observations = 0;
 	try {
 		await fs.mkdir(sdk, { recursive: true });
-		await Bun.write(path.join(sdk, "000-malformed.lifecycle.json"), "not lifecycle JSON");
-		const dead = { pid: 999_999_999, effectMarker: "dead", incarnation: "linux:1" };
-		const markerPath = path.join(sdk, `${deadId}.lifecycle.json`);
-		await Bun.write(markerPath, JSON.stringify(dead));
-		await Bun.write(path.join(sdk, `${deadId}.lifecycle.ready.json`), JSON.stringify(dead));
-		const expiredAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
-		await fs.utimes(markerPath, expiredAt, expiredAt);
+		const live = { pid: process.pid, effectMarker: "live", incarnation: await incarnation(process.pid) };
+		for (let index = 0; index < 5; index += 1)
+			await Bun.write(path.join(sdk, `live-${index}.lifecycle.json`), JSON.stringify(live));
+		process.kill = ((pid, signal) => {
+			observations += 1;
+			return originalKill.call(process, pid, signal);
+		}) as typeof process.kill;
 
-		expect(await reapDeadLifecycleMarkers(stateRoot, 1)).toBe(0);
-		await expect(Bun.file(markerPath).exists()).resolves.toBe(true);
+		expect(await reapDeadLifecycleMarkers(stateRoot, 2)).toBe(0);
+		expect(observations).toBe(2);
 	} finally {
+		process.kill = originalKill;
 		await fs.rm(root, { recursive: true, force: true });
 	}
 });

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -1321,7 +1321,7 @@ test("broker directly resumes and forks a canonical cold saved session with scop
 		await broker.start();
 		const resumed = await broker.handleRequest(
 			"session.resume",
-			{ cwd: root, stateRoot, sessionId: sourceId, sessionPath: sourcePath },
+			{ cwd: root, stateRoot, sessionId: sourceId, sessionPath: sourcePath, readinessTimeoutMs: 20_000 },
 			"canonical-cold-resume",
 		);
 		expect(resumed).toMatchObject({ ok: true, result: { sessionId: sourceId } });
@@ -1376,7 +1376,13 @@ test("broker directly resumes and forks a canonical cold saved session with scop
 
 		const forked = await broker.handleRequest(
 			"session.fork",
-			{ cwd: root, stateRoot, sourceSessionId: sourceId, sourceSessionPath: sourcePath },
+			{
+				cwd: root,
+				stateRoot,
+				sourceSessionId: sourceId,
+				sourceSessionPath: sourcePath,
+				readinessTimeoutMs: 20_000,
+			},
 			"canonical-cold-fork",
 		);
 		expect(forked).toMatchObject({ ok: true });
@@ -1516,7 +1522,7 @@ test("broker directly resumes and forks a canonical cold saved session with scop
 		await broker.stop();
 		await fs.rm(root, { recursive: true, force: true });
 	}
-}, 30_000);
+}, 50_000);
 
 test("broker replays one identity-bound lifecycle metadata cleanup plan after the first delete detach", async () => {
 	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-delete-metadata-crash-"));

--- a/packages/coding-agent/test/sdk-broker.test.ts
+++ b/packages/coding-agent/test/sdk-broker.test.ts
@@ -180,41 +180,17 @@ it("isolates source SDK children and preserves compiled self-spawn", () => {
 	});
 });
 
-it("uses a verified physical argv0 for exact compiled-marker-authorized Bun virtual executable paths", async () => {
-	const directory = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-compiled-runtime-"));
-	const executable = path.join(directory, "gjc");
+it("uses the native current executable for exact compiled-marker-authorized Bun virtual executable paths", () => {
 	const markerPath = "/$bunfs/root/internal-source-marker-2178-abcd.txt";
-	try {
-		await fs.writeFile(executable, "compiled fixture");
-		await fs.chmod(executable, 0o700);
-		const canonicalExecutable = await fs.realpath(executable);
-		expect(
-			resolveSdkInternalSpawnCommandForTest("session-host-internal", {
-				execPath: "/$bunfs/root/gjc",
-				argv0: executable,
-				markerPath,
-				embeddedFiles: [{ name: path.basename(markerPath) }],
-			}),
-		).toMatchObject({ kind: "compiled", file: canonicalExecutable });
-		expect(() =>
-			resolveSdkInternalSpawnCommandForTest("session-host-internal", {
-				execPath: "/$bunfs/root/gjc",
-				argv0: path.join(directory, "missing"),
-				markerPath,
-				embeddedFiles: [{ name: path.basename(markerPath) }],
-			}),
-		).toThrow("compiled executable is not a readable regular file");
-		expect(() =>
-			resolveSdkInternalSpawnCommandForTest("session-host-internal", {
-				execPath: "/not/a/runtime",
-				argv0: executable,
-				markerPath,
-				embeddedFiles: [{ name: path.basename(markerPath) }],
-			}),
-		).toThrow("compiled executable is not a readable regular file");
-	} finally {
-		await fs.rm(directory, { recursive: true, force: true });
-	}
+	const executable = native.currentExecutablePath();
+	if (!executable) throw new Error("Expected native current executable identity.");
+	expect(
+		resolveSdkInternalSpawnCommandForTest("session-host-internal", {
+			execPath: "/$bunfs/root/gjc",
+			markerPath,
+			embeddedFiles: [{ name: path.basename(markerPath) }],
+		}),
+	).toMatchObject({ kind: "compiled", file: executable });
 });
 
 it("treats explicit broker env as a complete allowlist and still scrubs runtime options", () => {

--- a/packages/coding-agent/test/sdk-broker.test.ts
+++ b/packages/coding-agent/test/sdk-broker.test.ts
@@ -34,6 +34,7 @@ import {
 	readSessionLifecycleLaunchRequest,
 	type SessionLifecycleLaunchRequest,
 	terminalUncertainStartupMessage,
+	waitForChildSpawn,
 } from "../src/sdk/broker/lifecycle";
 import { LifecycleLedger } from "../src/sdk/broker/lifecycle-ledger";
 import { resolveSdkInternalSpawnCommand, resolveSdkInternalSpawnCommandForTest } from "../src/sdk/broker/runtime";
@@ -58,6 +59,19 @@ it("does not disclose launch paths when cleanup remains uncertain", () => {
 		"Lifecycle startup cleanup could not be proven; retained artifacts require reconciliation. Original launch failure: SDK internal process could not be started.",
 	);
 	expect(message).not.toContain(executable);
+});
+
+it("retains an error handler after a child reports successful spawn", async () => {
+	const child = new EventEmitter();
+	const postSpawnErrors: string[] = [];
+	const spawned = waitForChildSpawn(child as unknown as Pick<ChildProcess, "off" | "on" | "once">, error =>
+		postSpawnErrors.push(error.message),
+	);
+	child.emit("spawn");
+	await spawned;
+	expect(child.listenerCount("error")).toBe(1);
+	child.emit("error", new Error("late child failure"));
+	expect(postSpawnErrors).toEqual(["late child failure"]);
 });
 async function managedSessionPath(agentDir: string, cwd: string, sessionId: string): Promise<string> {
 	await fs.mkdir(cwd, { recursive: true });

--- a/packages/coding-agent/test/sdk-broker.test.ts
+++ b/packages/coding-agent/test/sdk-broker.test.ts
@@ -186,6 +186,7 @@ it("uses a verified physical argv0 for exact compiled-marker-authorized Bun virt
 	const markerPath = "/$bunfs/root/internal-source-marker-2178-abcd.txt";
 	try {
 		await fs.writeFile(executable, "compiled fixture");
+		await fs.chmod(executable, 0o700);
 		const canonicalExecutable = await fs.realpath(executable);
 		expect(
 			resolveSdkInternalSpawnCommandForTest("session-host-internal", {

--- a/packages/coding-agent/test/sdk-broker.test.ts
+++ b/packages/coding-agent/test/sdk-broker.test.ts
@@ -180,6 +180,42 @@ it("isolates source SDK children and preserves compiled self-spawn", () => {
 	});
 });
 
+it("uses a verified physical argv0 for exact compiled-marker-authorized Bun virtual executable paths", async () => {
+	const directory = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-compiled-runtime-"));
+	const executable = path.join(directory, "gjc");
+	const markerPath = "/$bunfs/root/internal-source-marker-2178-abcd.txt";
+	try {
+		await fs.writeFile(executable, "compiled fixture");
+		const canonicalExecutable = await fs.realpath(executable);
+		expect(
+			resolveSdkInternalSpawnCommandForTest("session-host-internal", {
+				execPath: "/$bunfs/root/gjc",
+				argv0: executable,
+				markerPath,
+				embeddedFiles: [{ name: path.basename(markerPath) }],
+			}),
+		).toMatchObject({ kind: "compiled", file: canonicalExecutable });
+		expect(() =>
+			resolveSdkInternalSpawnCommandForTest("session-host-internal", {
+				execPath: "/$bunfs/root/gjc",
+				argv0: path.join(directory, "missing"),
+				markerPath,
+				embeddedFiles: [{ name: path.basename(markerPath) }],
+			}),
+		).toThrow("compiled executable is not a readable regular file");
+		expect(() =>
+			resolveSdkInternalSpawnCommandForTest("session-host-internal", {
+				execPath: "/not/a/runtime",
+				argv0: executable,
+				markerPath,
+				embeddedFiles: [{ name: path.basename(markerPath) }],
+			}),
+		).toThrow("compiled executable is not a readable regular file");
+	} finally {
+		await fs.rm(directory, { recursive: true, force: true });
+	}
+});
+
 it("treats explicit broker env as a complete allowlist and still scrubs runtime options", () => {
 	const command = resolveSdkInternalSpawnCommandForTest("broker-internal", {
 		environment: { AMBIENT_SENTINEL: "must-not-leak" },

--- a/packages/coding-agent/test/sdk-broker.test.ts
+++ b/packages/coding-agent/test/sdk-broker.test.ts
@@ -33,6 +33,7 @@ import {
 	deriveLifecycleDeadlines,
 	readSessionLifecycleLaunchRequest,
 	type SessionLifecycleLaunchRequest,
+	terminalUncertainStartupMessage,
 } from "../src/sdk/broker/lifecycle";
 import { LifecycleLedger } from "../src/sdk/broker/lifecycle-ledger";
 import { resolveSdkInternalSpawnCommand, resolveSdkInternalSpawnCommandForTest } from "../src/sdk/broker/runtime";
@@ -46,6 +47,18 @@ import {
 } from "../src/session/session-storage";
 
 const temp = () => fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-"));
+
+it("does not disclose launch paths when cleanup remains uncertain", () => {
+	const executable = "/private/runtime/gjc-secret";
+	const message = terminalUncertainStartupMessage({
+		ok: false,
+		error: { code: "spawn_failed", message: `spawn ${executable} ENOENT` },
+	});
+	expect(message).toBe(
+		"Lifecycle startup cleanup could not be proven; retained artifacts require reconciliation. Original launch failure: SDK internal process could not be started.",
+	);
+	expect(message).not.toContain(executable);
+});
 async function managedSessionPath(agentDir: string, cwd: string, sessionId: string): Promise<string> {
 	await fs.mkdir(cwd, { recursive: true });
 	const sessionsRoot = getSessionsDir(agentDir);

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -825,6 +825,12 @@ export interface ContextLine {
 export declare function copyToClipboard(text: string): void
 
 /**
+ * Returns the operating system's canonical path for the running executable.
+ * Unlike argv, this is not supplied by the process caller.
+ */
+export declare function currentExecutablePath(): string | null
+
+/**
  * Detect macOS system appearance via CoreFoundation.
  * Returns `"dark"` or `"light"` on macOS, `null` on other platforms.
  */

--- a/packages/natives/native/index.js
+++ b/packages/natives/native/index.js
@@ -39,6 +39,7 @@ export const astGrep = nativeBindings.astGrep;
 export const canonicalExistingDirectoryIdentity = nativeBindings.canonicalExistingDirectoryIdentity;
 export const computerScreenshot = nativeBindings.computerScreenshot;
 export const copyToClipboard = nativeBindings.copyToClipboard;
+export const currentExecutablePath = nativeBindings.currentExecutablePath;
 export const detectMacOSAppearance = nativeBindings.detectMacOSAppearance;
 export const diffLines = nativeBindings.diffLines;
 export const encodeSixel = nativeBindings.encodeSixel;

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -750,6 +750,9 @@ export function validateLoadedBindings(ctx, bindings, candidate) {
 	if (typeof bindings.probeWindowsJobMemory !== "function") {
 		throw new Error(`Loaded ${candidate} but it lacks required memory probe capability \`probeWindowsJobMemory\`.`);
 	}
+	if (typeof bindings.currentExecutablePath !== "function") {
+		throw new Error(`Loaded ${candidate} but it lacks required executable identity capability \`currentExecutablePath\`.`);
+	}
 }
 
 function buildHelpMessage(ctx) {

--- a/packages/natives/scripts/build-native.ts
+++ b/packages/natives/scripts/build-native.ts
@@ -183,6 +183,7 @@ const requiredGeneratedBindingSymbols = [
 	"repairOwnerOnlyPathSecurityExpected",
 	"verifyOwnerOnlyPathSecurityExpected",
 	"probeWindowsJobMemory",
+	"currentExecutablePath",
 ] as const;
 
 export function validateGeneratedBindingSource(bindings: string): void {

--- a/packages/natives/scripts/embed-native.ts
+++ b/packages/natives/scripts/embed-native.ts
@@ -38,7 +38,7 @@ const stubContent = `
 export const embeddedAddon = null;
 `;
 
-const requiredAddonExports = ["nativeBuildInfo", "probeWindowsJobMemory"] as const;
+const requiredAddonExports = ["nativeBuildInfo", "probeWindowsJobMemory", "currentExecutablePath"] as const;
 
 export function missingRequiredAddonExports(bindings: Record<string, unknown>): string[] {
 	return missingRequiredFunctions(bindings, requiredAddonExports);

--- a/packages/natives/test/memory-guard-build-wiring.test.ts
+++ b/packages/natives/test/memory-guard-build-wiring.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { assertRequiredSymbols, missingRequiredFunctions } from "../scripts/embed-guard";
+import { missingRequiredAddonExports } from "../scripts/embed-native";
 
 describe("memory-guard native build wiring", () => {
 	it("rejects generated bindings that omit the Windows memory probe", () => {
@@ -21,5 +22,14 @@ describe("memory-guard native build wiring", () => {
 				"probeWindowsJobMemory",
 			]),
 		).toEqual([]);
+	});
+
+	it("requires executable identity in embedded and generated native bindings", () => {
+		expect(missingRequiredAddonExports({ nativeBuildInfo: () => ({}), probeWindowsJobMemory: () => ({}) })).toEqual([
+			"currentExecutablePath",
+		]);
+		expect(() => assertRequiredSymbols("export function probeWindowsJobMemory(): unknown;", ["currentExecutablePath"])).toThrow(
+			"currentExecutablePath",
+		);
 	});
 });

--- a/packages/natives/test/memory-guard-build-wiring.test.ts
+++ b/packages/natives/test/memory-guard-build-wiring.test.ts
@@ -28,8 +28,8 @@ describe("memory-guard native build wiring", () => {
 		expect(missingRequiredAddonExports({ nativeBuildInfo: () => ({}), probeWindowsJobMemory: () => ({}) })).toEqual([
 			"currentExecutablePath",
 		]);
-		expect(() => assertRequiredSymbols("export function probeWindowsJobMemory(): unknown;", ["currentExecutablePath"])).toThrow(
-			"currentExecutablePath",
-		);
+		expect(() =>
+			assertRequiredSymbols("export function probeWindowsJobMemory(): unknown;", ["currentExecutablePath"]),
+		).toThrow("currentExecutablePath");
 	});
 });

--- a/packages/natives/test/memory-guard-native.test.ts
+++ b/packages/natives/test/memory-guard-native.test.ts
@@ -60,4 +60,20 @@ describe("probeWindowsJobMemory", () => {
 			),
 		).toThrow("probeWindowsJobMemory");
 	});
+
+	it("rejects stale same-version bindings without executable identity capability", () => {
+		const bindings = {
+			__piNativesVCurrent: () => undefined,
+			__piNativesPublishOutcomeV1: () => undefined,
+			renameNoReplacePath: () => undefined,
+			probeWindowsJobMemory: () => undefined,
+		};
+		expect(() =>
+			validateLoadedBindings(
+				{ versionSentinelExport: "__piNativesVCurrent", packageVersion: "current" },
+				bindings,
+				"cached-addon.node",
+			),
+		).toThrow("currentExecutablePath");
+	});
 });

--- a/packages/natives/test/path-identity-windows.test.ts
+++ b/packages/natives/test/path-identity-windows.test.ts
@@ -727,6 +727,28 @@ setTimeout(() => { try { fs.closeSync(fd); } catch {} process.exit(0); }, Number
 		await expect(fs.stat(path.join(root, directQuarantine))).rejects.toMatchObject({ code: "ENOENT" });
 	});
 
+	it("retains a regular file when direct cleanup parent authority changes", async () => {
+		const root = await temporaryDirectory();
+		const file = path.join(root, "parent-bound-debris");
+		await fs.writeFile(file, "stale");
+		const stat = await fs.stat(file, { bigint: true });
+		const parent = await parentIdentity(file);
+
+		expect(
+			exactUnlinkDirect(file, {
+				dev: stat.dev,
+				ino: stat.ino,
+				size: stat.size,
+				mtimeNs: stat.mtimeNs,
+				sha256: sha256("stale"),
+				parentDev: parent.parentDev + 1n,
+				parentIno: parent.parentIno,
+				quarantineName: ".gjc-parent-mismatch",
+			}),
+		).toEqual({ ok: false, code: "parent_mismatch" });
+		await expect(fs.readFile(file, "utf8")).resolves.toBe("stale");
+	});
+
 	it("atomically detaches only the identified directory to its preauthorized destination", async () => {
 		const root = await temporaryDirectory();
 		const directory = path.join(root, "artifact");


### PR DESCRIPTION
Fixes #4864.

## Risk classification
- [ ] `low-risk`
- [x] `regression-risk`
- [ ] `high-risk`

## Exact-head evidence
- Rebased onto `dev@a99e42aab4eba33add0421a1564951ba727bd940`; ancestry verified.
- Bun virtual runtime fallback is marker-bound and OS current-image only; no argv/PATH fallback.
- Lifecycle proof and reconciliation are deadline-bounded; stale-marker inspection is candidate-bounded.
- Terminal uncertainty hides raw launch errors; successful spawn retains a sanitized lifetime child-error handler.
- Current compiled ACP initialize + real `session/new`: succeeded; session `40849eb5-5a75-43fd-9533-7478dc27799c`.
- Broker suite 82/82; lifecycle E2E 91/91; coding-agent/native/Rust checks passed.

gajae.pr-review-verdict.v1 merge-approved sha256:04abe4f5c58d8eaaeb9b7f3f1797a27ad19b790493eb254efc726ed15cfc9f9f reviewer:human reviewer-id:snowykr evidence:authenticated exact-head approval plus green affected-path and local runtime verification

Base: a99e42aab4eba33add0421a1564951ba727bd940
Head: 5d7879e6e3f2ba5df7e17b47b7d7b56490083e91
Digest: sha256:04abe4f5c58d8eaaeb9b7f3f1797a27ad19b790493eb254efc726ed15cfc9f9f
Signed-off-by: gaebal-gajae (clawdbot) 🦞