### PR TITLE
fix(pet): render text fallback without image protocols

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Gajae Pet now stays reachable in tmux and image-protocol-free SSH clients through a bounded two-row text-cell rendering. The fallback derives conservative Block Elements from the active skin, uses truecolor when available and ANSI-256 otherwise, reserves no extra transcript rows, and retains the pixel renderer unchanged for supported Kitty, Sixel, and iTerm2 terminals (#4867).
+
 - Python kernel reuse is once again keyed on the settings values that shape a kernel, not on `Settings` object identity. Binding built-in executors to session settings (#4826) made `scopedSessionId` suffix each kernel key with a per-instance counter, so two logical sessions in one process — which resolve the same shell configuration and therefore spawn byte-identical kernels — each started their own kernel, and disposing one shut down a kernel the other still owned. The scope is now a fingerprint of the resolved shell config (shell, args, environment), so equivalent settings share one retained kernel while genuinely different shell environments stay isolated.
 
 ## [0.15.0] - 2026-08-22

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -885,7 +885,7 @@ export const SETTINGS_SCHEMA = {
 		ui: {
 			tab: "appearance",
 			label: "Gajae Pet",
-			description: "Real-pixel pet living beside the composer (sixel/kitty terminals)",
+			description: "Animated pet beside the composer (pixel graphics where supported; text cells elsewhere)",
 			options: [
 				{ value: "off", label: "Off", description: "No pet" },
 				...PET_SKIN_IDS.map(id => ({

--- a/packages/coding-agent/src/modes/components/gajae-pet-widget.ts
+++ b/packages/coding-agent/src/modes/components/gajae-pet-widget.ts
@@ -349,8 +349,13 @@ export class GajaePetWidget {
 	#applyMode(mode: PetMode, mountComposer: boolean): void {
 		if (this.#disposed) return;
 		if (mode === this.#mode) {
-			if (mode !== "off" && this.#framedEditor.canFit(this.#ui.terminal.columns)) this.#mountEditor(true);
-			return;
+			if (mode === "off") return;
+			const nextProtocol = this.#forcedProtocol ?? GajaePetWidget.pixelProtocol();
+			const currentProtocol = this.#itermProtocol ? "iterm" : (this.#pixel?.protocol ?? "text");
+			if (nextProtocol === currentProtocol) {
+				if (this.#framedEditor.canFit(this.#ui.terminal.columns)) this.#mountEditor(true);
+				return;
+			}
 		}
 		if (mode === "off") {
 			if (!this.#canMutateSharedUi()) return;

--- a/packages/coding-agent/src/modes/components/gajae-pet-widget.ts
+++ b/packages/coding-agent/src/modes/components/gajae-pet-widget.ts
@@ -4,6 +4,7 @@ import {
 	type CellRect,
 	type Component,
 	type Container,
+	CURSOR_MARKER,
 	type GajaeGifFrame,
 	type GajaeGifTimeline,
 	type GajaePixelFrames,
@@ -14,15 +15,18 @@ import {
 	type PetFrameName,
 	type PetMode,
 	type PetSkinId,
+	padding,
 	petBurstDurationMs,
 	petBurstFrame,
 	type RasterLeaseToken,
 	registerAnimationCallback,
+	TERMINAL,
 	type TUI,
+	visibleWidth,
 	wrapITerm2RecordForTmux,
 } from "@gajae-code/tui";
 import type { CustomEditor } from "./custom-editor";
-import { getItermPetUnavailableReason, getPetPixelProtocol, getVerifiedItermPetAvailability } from "./pet-capability";
+import { getItermPetUnavailableReason, getPetRenderProtocol, getVerifiedItermPetAvailability } from "./pet-capability";
 
 /** Re-exported from the tui skin registry so widget-relative imports stay valid. */
 export type { PetMode, PetSkinId };
@@ -145,11 +149,62 @@ const OUROBOROS_WORK_BURST_MAX_GAP_MS = 30_000;
 
 /** Selector preview: fire the first burst this soon after a skin is previewed. */
 const PREVIEW_INTRO_MS = 2300;
+const TEXT_PET_COLUMNS = 8;
+
+function nearestAnsi256([red, green, blue]: readonly [number, number, number]): number {
+	if (red === green && green === blue)
+		return red < 8 ? 16 : red > 248 ? 231 : 232 + Math.round(((red - 8) / 247) * 23);
+	return 16 + 36 * Math.round((red / 255) * 5) + 6 * Math.round((green / 255) * 5) + Math.round((blue / 255) * 5);
+}
+
+function sgr(color: readonly [number, number, number], background: boolean): string {
+	const channel = background ? 48 : 38;
+	return TERMINAL.trueColor
+		? `\x1b[${channel};2;${color[0]};${color[1]};${color[2]}m`
+		: `\x1b[${channel};5;${nearestAnsi256(color)}m`;
+}
+
+function dominantColor(
+	grid: readonly string[],
+	palette: Readonly<Record<string, readonly [number, number, number] | null>>,
+	x: number,
+	y: number,
+): readonly [number, number, number] | null {
+	const counts = new Map<string, number>();
+	for (let row = y; row < y + 4; row++)
+		for (let column = x; column < x + 2; column++) {
+			const key = grid[row]?.[column] ?? ".";
+			if (palette[key]) counts.set(key, (counts.get(key) ?? 0) + 1);
+		}
+	let selected: string | undefined;
+	let count = 0;
+	for (const [key, nextCount] of counts) if (nextCount > count) [selected, count] = [key, nextCount];
+	return selected ? (palette[selected] ?? null) : null;
+}
+
+/** A two-row, eight-cell composition that never emits terminal graphics escapes. */
+function textPetFrame(mode: PetSkinId, frame: PetFrameName): string[] {
+	const skin = PET_SKINS[mode];
+	const grid = skin.frames[frame] ?? skin.frames[skin.baseFrame]!;
+	return [0, 8].map(y => {
+		let line = "";
+		for (let x = 0; x < 16; x += 2) {
+			const upper = dominantColor(grid, skin.palette, x, y);
+			const lower = dominantColor(grid, skin.palette, x, y + 4);
+			if (!upper && !lower) line += " ";
+			else if (upper && lower) line += `${sgr(upper, false)}${sgr(lower, true)}▀`;
+			else if (upper) line += `${sgr(upper, false)}▀`;
+			else if (lower) line += `${sgr(lower, false)}▄`;
+		}
+		return `${line}\x1b[0m`;
+	});
+}
 
 /** Reserve a right-side area beside the composer where the pixel pet is drawn. */
 export class PetFramedEditor implements Component {
 	#editor: CustomEditor;
 	#reserve = 0;
+	#textArt: (() => string[]) | undefined;
 
 	constructor(editor: CustomEditor) {
 		this.#editor = editor;
@@ -157,6 +212,10 @@ export class PetFramedEditor implements Component {
 
 	setReserve(columns: number): void {
 		this.#reserve = columns;
+	}
+
+	setTextArt(textArt: (() => string[]) | undefined): void {
+		this.#textArt = textArt;
 	}
 
 	canFit(width: number): boolean {
@@ -169,7 +228,17 @@ export class PetFramedEditor implements Component {
 
 	render(width: number): string[] {
 		if (!this.canFit(width)) return this.#editor.render(width);
-		return this.#editor.render(width - this.#reserve);
+		const lines = this.#editor.render(width - this.#reserve);
+		const art = this.#textArt?.();
+		if (!art) return lines;
+		const start = Math.max(0, lines.length - art.length);
+		return lines.map((line, index) => {
+			if (index < start) return line;
+			// The APC cursor marker is zero-width but native width calculation sees
+			// it before TUI strips it. Keep the reserved art from shifting the cursor.
+			const lineWidth = visibleWidth(line.replace(CURSOR_MARKER, ""));
+			return `${line}${padding(Math.max(0, width - this.#reserve - lineWidth))}${art[index - start]}`;
+		});
 	}
 }
 
@@ -240,8 +309,8 @@ export class GajaePetWidget {
 			options.autoFlexGapMs === undefined ? [AUTO_FLEX_MIN_GAP_MS, AUTO_FLEX_MAX_GAP_MS] : options.autoFlexGapMs;
 	}
 
-	static pixelProtocol(): "sixel" | "kitty" | "iterm" | null {
-		return getPetPixelProtocol();
+	static pixelProtocol(): "sixel" | "kitty" | "iterm" | "text" | null {
+		return getPetRenderProtocol();
 	}
 
 	get mode(): PetMode {
@@ -278,7 +347,11 @@ export class GajaePetWidget {
 	}
 
 	#applyMode(mode: PetMode, mountComposer: boolean): void {
-		if (this.#disposed || mode === this.#mode) return;
+		if (this.#disposed) return;
+		if (mode === this.#mode) {
+			if (mode !== "off" && this.#framedEditor.canFit(this.#ui.terminal.columns)) this.#mountEditor(true);
+			return;
+		}
 		if (mode === "off") {
 			if (!this.#canMutateSharedUi()) return;
 			this.#itermGeneration++;
@@ -299,6 +372,7 @@ export class GajaePetWidget {
 			this.#workTransition = undefined;
 			this.#nextWorkBurstAt = 0;
 			this.#framedEditor.setReserve(0);
+			this.#framedEditor.setTextArt(undefined);
 			if (mountComposer) this.#mountEditor(false);
 			this.#ui.requestRender(true);
 			return;
@@ -359,11 +433,19 @@ export class GajaePetWidget {
 		this.dispose();
 	}
 
-	#buildPixel(protocol: "sixel" | "kitty" | "iterm"): void {
+	#buildPixel(protocol: "sixel" | "kitty" | "iterm" | "text"): void {
 		const cell = getCellDimensions();
 		this.#builtCellW = cell.widthPx;
 		this.#builtCellH = cell.heightPx;
 		const skin: PetSkinId = this.#mode === "off" ? "red" : this.#mode;
+		if (protocol === "text") {
+			this.#itermProtocol = false;
+			this.#pixel = undefined;
+			this.#framedEditor.setReserve(TEXT_PET_COLUMNS + PET_SIDE_MARGIN);
+			this.#framedEditor.setTextArt(() => textPetFrame(skin, this.#frame));
+			return;
+		}
+		this.#framedEditor.setTextArt(undefined);
 		if (protocol === "kitty") {
 			this.#kittyImageId ??= allocatePetKittyImageId();
 			this.#kittyCleanupGeneration++;
@@ -781,7 +863,15 @@ export class GajaePetWidget {
 			this.#tickIterm(now);
 			return;
 		}
-		if (this.#mode === "off" || !this.#pixel) return;
+		if (this.#mode === "off") return;
+		if (!this.#pixel) {
+			const frame = this.#pickFrame(now);
+			if (frame !== this.#frame) {
+				this.#frame = frame;
+				this.#ui.requestRender();
+			}
+			return;
+		}
 		const cell = getCellDimensions();
 		if (cell.widthPx !== this.#builtCellW || cell.heightPx !== this.#builtCellH) {
 			const protocol = this.#forcedProtocol ?? GajaePetWidget.pixelProtocol();

--- a/packages/coding-agent/src/modes/components/pet-capability.ts
+++ b/packages/coding-agent/src/modes/components/pet-capability.ts
@@ -9,8 +9,9 @@ import {
 import type { PetTransportAvailability } from "./iterm-pet-transport";
 
 export type PetPixelProtocol = "sixel" | "kitty" | "iterm";
+export type PetRenderProtocol = PetPixelProtocol | "text";
 
-export const PET_UNAVAILABLE_DESCRIPTION = "Unavailable: requires compatible Kitty or Sixel overlay rendering";
+export const PET_UNAVAILABLE_DESCRIPTION = "Unavailable";
 export const PET_SAVED_UNAVAILABLE_DESCRIPTION =
 	"Saved, unavailable — requires compatible Kitty or Sixel overlay rendering";
 export const PET_UNAVAILABLE_WARNING =
@@ -54,7 +55,12 @@ export function getPetPixelProtocol(): PetPixelProtocol | null {
 }
 
 export function isPetAvailable(): boolean {
-	return getPetPixelProtocol() !== null;
+	return true;
+}
+
+/** Every terminal can render the conservative text-cell pet; pixels are optional. */
+export function getPetRenderProtocol(): PetRenderProtocol {
+	return getPetPixelProtocol() ?? "text";
 }
 
 export function createPetSelectItems(

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -647,8 +647,9 @@ export class InteractiveMode implements InteractiveModeContext {
 				if (!availability.available) void this.petWidget?.suspendItermCapability();
 				setVerifiedItermPetAvailability(availability);
 				if (availability.available && availability.mode === "managed") this.ui.refreshImageCellSize();
-				const saved = settings.get("pet.mode");
-				if (saved !== "off" && this.petWidget) this.petWidget.setMode(saved);
+				const petWidget = this.petWidget;
+				const active = petWidget?.mode;
+				if (active && active !== "off") petWidget.setMode(active);
 			});
 		}
 		this.ui.setClearOnShrink(settings.get("clearOnShrink"));

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -839,10 +839,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.petWidget = this.#createPetWidget(this.editor);
 		const configuredPetMode = settings.get("pet.mode");
 		this.petWidget.setMode(configuredPetMode);
-		// The async sixel capability probe can enable graphics after the saved
-		// pet mode was applied and dropped (no protocol yet at startup).
-		// Re-apply the configured mode when capability arrives so the pet
-		// appears without the user re-running /pet.
+		// The text-cell fallback renders immediately. Re-apply a saved mode if an
+		// asynchronous graphics probe later upgrades it to pixel rendering.
 		this.#petProtocolUnsubscribe?.();
 		this.#petProtocolUnsubscribe = onImageProtocolChanged(protocol => {
 			if (!protocol) {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -646,11 +646,9 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.#petTransportAvailabilityUnsubscribe = this.#itermPetTransport.subscribe(availability => {
 				if (!availability.available) void this.petWidget?.suspendItermCapability();
 				setVerifiedItermPetAvailability(availability);
-				if (availability.available) {
-					if (availability.mode === "managed") this.ui.refreshImageCellSize();
-					const saved = settings.get("pet.mode");
-					if (saved !== "off" && this.petWidget && this.petWidget.mode === "off") this.petWidget.setMode(saved);
-				}
+				if (availability.available && availability.mode === "managed") this.ui.refreshImageCellSize();
+				const saved = settings.get("pet.mode");
+				if (saved !== "off" && this.petWidget) this.petWidget.setMode(saved);
 			});
 		}
 		this.ui.setClearOnShrink(settings.get("clearOnShrink"));

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -845,10 +845,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#petProtocolUnsubscribe = onImageProtocolChanged(protocol => {
 			if (!protocol) {
 				void this.petWidget?.suspendItermCapability();
-				return;
 			}
 			const saved = settings.get("pet.mode");
-			if (saved !== "off" && this.petWidget && this.petWidget.mode === "off") {
+			if (saved !== "off" && this.petWidget) {
 				this.petWidget.setMode(saved);
 			}
 		});

--- a/packages/coding-agent/test/gajae-pet-widget.test.ts
+++ b/packages/coding-agent/test/gajae-pet-widget.test.ts
@@ -234,6 +234,38 @@ describe("GajaePetWidget", () => {
 		}
 	});
 
+	it("renders a bounded text-cell fallback without terminal image escapes", () => {
+		const { widget, editorContainer, getEmitter } = makeWidget(80, 30, { protocol: null });
+		const protocol = vi.spyOn(GajaePetWidget, "pixelProtocol").mockReturnValue("text");
+		try {
+			widget.setMode("red");
+			const lines = editorContainer.render(80);
+			expect(lines).toHaveLength(2);
+			expect(lines.join("\n")).toContain("▀");
+			expect(getEmitter()?.()).toBeNull();
+			expect(lines.join("")).not.toContain("\x1bP");
+			expect(lines.join("")).not.toContain("\x1b_G");
+		} finally {
+			protocol.mockRestore();
+			widget.dispose();
+		}
+	});
+
+	it("drops text art rather than widening or adding rows on narrow terminals", () => {
+		const { widget, editorContainer } = makeWidget(17, 30, { protocol: null });
+		const protocol = vi.spyOn(GajaePetWidget, "pixelProtocol").mockReturnValue("text");
+		try {
+			widget.setMode("blue");
+			const lines = editorContainer.render(17);
+			expect(lines).toHaveLength(2);
+			expect(lines.every(line => tui.visibleWidth(line) <= 17)).toBe(true);
+			expect(lines.join("\n")).not.toContain("▀");
+		} finally {
+			protocol.mockRestore();
+			widget.dispose();
+		}
+	});
+
 	it("owns and deletes a distinct Kitty image ID per widget", () => {
 		const first = makeWidget(80, 30, { protocol: "kitty" });
 		const second = makeWidget(80, 30, { protocol: "kitty" });

--- a/packages/coding-agent/test/gajae-pet-widget.test.ts
+++ b/packages/coding-agent/test/gajae-pet-widget.test.ts
@@ -266,6 +266,35 @@ describe("GajaePetWidget", () => {
 		}
 	});
 
+	it("upgrades a text fallback to pixels when its protocol becomes available", () => {
+		const { widget, getEmitter } = makeWidget(80, 30, { protocol: null });
+		const protocol = vi.spyOn(GajaePetWidget, "pixelProtocol").mockReturnValue("text");
+		try {
+			widget.setMode("red");
+			protocol.mockReturnValue("sixel");
+			widget.setMode("red");
+			expect(getEmitter()?.()).toContain("\x1bP0;1;0q");
+		} finally {
+			protocol.mockRestore();
+			widget.dispose();
+		}
+	});
+
+	it("replaces an active pixel pet with text cells when graphics disappear", () => {
+		const { widget, editorContainer, getEmitter } = makeWidget(80, 30, { protocol: null });
+		const protocol = vi.spyOn(GajaePetWidget, "pixelProtocol").mockReturnValue("sixel");
+		try {
+			widget.setMode("red");
+			protocol.mockReturnValue("text");
+			widget.setMode("red");
+			expect(getEmitter()?.()).toBeNull();
+			expect(editorContainer.render(80).join("\n")).toContain("▀");
+		} finally {
+			protocol.mockRestore();
+			widget.dispose();
+		}
+	});
+
 	it("owns and deletes a distinct Kitty image ID per widget", () => {
 		const first = makeWidget(80, 30, { protocol: "kitty" });
 		const second = makeWidget(80, 30, { protocol: "kitty" });

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -164,9 +164,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 			vi.advanceTimersByTime(PET_CAPABILITY_SETTLE_MS - 1);
 			expect(showStatus).not.toHaveBeenCalled();
 			vi.advanceTimersByTime(1);
-			expect(showStatus).toHaveBeenCalledTimes(1);
-			expect(showStatus.mock.calls[0]?.[0]).toContain("Pets aren’t available");
-			expect(showStatus.mock.calls[0]?.[0]).not.toContain("(unknown)");
+			expect(showStatus).not.toHaveBeenCalled();
 		} finally {
 			mode.stop();
 			setVerifiedItermPetAvailability(undefined);
@@ -211,17 +209,11 @@ describe("InteractiveMode.setEditorComponent", () => {
 			await mode.init();
 			vi.advanceTimersByTime(PET_CAPABILITY_SETTLE_MS * 2);
 
-			expect(showStatus).toHaveBeenCalledTimes(1);
-			const startupWarning = showStatus.mock.calls[0]?.[0] ?? "";
-			expect(startupWarning).toContain("Pets aren’t available");
-			expect(startupWarning).not.toContain("(");
+			expect(showStatus).not.toHaveBeenCalled();
 
 			showStatus.mockClear();
-			expect(mode.setPetMode("red")).toBe(false);
-			expect(showStatus).toHaveBeenCalledTimes(1);
-			const refusal = showStatus.mock.calls[0]?.[0] ?? "";
-			expect(refusal).toContain("Pets aren’t available");
-			expect(refusal).not.toContain("(");
+			expect(mode.setPetMode("red")).toBe(true);
+			expect(showStatus).not.toHaveBeenCalled();
 		} finally {
 			mode.stop();
 			setVerifiedItermPetAvailability(undefined);
@@ -268,15 +260,11 @@ describe("InteractiveMode.setEditorComponent", () => {
 			setVerifiedItermPetAvailability({ available: false, mode: "direct", reason: "probe-timeout", epoch: 1 });
 			vi.advanceTimersByTime(PET_CAPABILITY_SETTLE_MS * 2);
 
-			expect(showStatus).toHaveBeenCalledTimes(1);
-			const startupWarning = showStatus.mock.calls[0]?.[0] ?? "";
-			expect(startupWarning).toContain("Pets aren’t available");
-			expect(startupWarning).toContain("(probe-timeout)");
+			expect(showStatus).not.toHaveBeenCalled();
 
 			showStatus.mockClear();
-			expect(mode.setPetMode("red")).toBe(false);
-			expect(showStatus).toHaveBeenCalledTimes(1);
-			expect(showStatus.mock.calls[0]?.[0] ?? "").toContain("(probe-timeout)");
+			expect(mode.setPetMode("red")).toBe(true);
+			expect(showStatus).not.toHaveBeenCalled();
 		} finally {
 			mode.stop();
 			setVerifiedItermPetAvailability(undefined);
@@ -943,10 +931,10 @@ describe("InteractiveMode.setEditorComponent", () => {
 			setTerminalImageProtocol(null);
 			settings.set("pet.mode", "red");
 			mode.setEditorComponent((_tui, editorTheme) => new TestModalEditor(editorTheme));
-			expect(mode.petWidget?.mode).toBe("off");
+			expect(mode.petWidget?.mode).toBe("red");
 
 			mode.setEditorComponent((_tui, editorTheme) => new TestModalEditor(editorTheme));
-			expect(mode.petWidget?.mode).toBe("off");
+			expect(mode.petWidget?.mode).toBe("red");
 
 			expect(settings.get("pet.mode")).toBe("red");
 			setTerminalImageProtocol(ImageProtocol.Sixel);
@@ -972,7 +960,7 @@ describe("InteractiveMode.setEditorComponent", () => {
 
 			expect(dispose).toHaveBeenCalledTimes(1);
 			expect(mode.petWidget).not.toBe(preInitWidget);
-			expect(mode.petWidget?.mode).toBe("off");
+			expect(mode.petWidget?.mode).toBe("red");
 
 			setTerminalImageProtocol(ImageProtocol.Sixel);
 			expect(mode.petWidget?.mode).toBe("red");
@@ -988,21 +976,16 @@ describe("InteractiveMode.setEditorComponent", () => {
 			settings.set("pet.mode", "off");
 			const showStatus = vi.spyOn(mode, "showStatus").mockImplementation(() => {});
 
-			// Capability is rechecked immediately before mutation: a rejected
-			// commit surfaces the warning and never persists.
+			// Text cells make the pet reachable even without an image protocol.
 			setTerminalImageProtocol(null);
-			expect(mode.setPetMode("red")).toBe(false);
-			expect(settings.get("pet.mode")).toBe("off");
+			expect(mode.setPetMode("red")).toBe(true);
+			expect(settings.get("pet.mode")).toBe("red");
 			expect(mode.petWidget?.mode ?? "off").toBe("off");
-			expect(showStatus).toHaveBeenCalledTimes(1);
+			expect(showStatus).not.toHaveBeenCalled();
 
-			expect(mode.commitPetPreviewMode("red")).toBe(false);
-			expect(settings.get("pet.mode")).toBe("off");
-			expect(showStatus).toHaveBeenCalledTimes(2);
-			for (const call of showStatus.mock.calls) {
-				expect(String(call[0])).toContain("Gajae Pet");
-				expect(String(call[0])).not.toContain("(unknown)");
-			}
+			expect(mode.commitPetPreviewMode("red")).toBe(true);
+			expect(settings.get("pet.mode")).toBe("red");
+			expect(showStatus).not.toHaveBeenCalled();
 
 			// An accepted commit persists only after the widget mutation applies.
 			setTerminalImageProtocol(ImageProtocol.Sixel);

--- a/packages/coding-agent/test/modes/components/pet-capability.test.ts
+++ b/packages/coding-agent/test/modes/components/pet-capability.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import {
 	getPetPixelProtocol,
+	getPetRenderProtocol,
 	PET_CAPABILITY_SETTLE_MS,
 	warnWhenPetCapabilitySettled,
 } from "@gajae-code/coding-agent/modes/components/pet-capability";
@@ -45,16 +46,18 @@ afterEach(() => {
 
 describe("getPetPixelProtocol", () => {
 	for (const [name, multiplexerEnv] of multiplexerCases) {
-		it(`keeps forced Kitty unavailable inside ${name}`, () => {
+		it(`uses text cells for forced Kitty inside ${name}`, () => {
 			setForcedProtocol("kitty", multiplexerEnv);
 
 			expect(getPetPixelProtocol()).toBeNull();
+			expect(getPetRenderProtocol()).toBe("text");
 		});
 
 		it(`keeps forced Sixel available inside ${name}`, () => {
 			setForcedProtocol("sixel", multiplexerEnv);
 
 			expect(getPetPixelProtocol()).toBe("sixel");
+			expect(getPetRenderProtocol()).toBe("sixel");
 		});
 	}
 });
@@ -88,7 +91,7 @@ describe("warnWhenPetCapabilitySettled", () => {
 		}
 	});
 
-	it("warns exactly once when the settle deadline passes with the terminal still unavailable", () => {
+	it("does not warn when the settle deadline selects the text-cell fallback", () => {
 		vi.useFakeTimers();
 		setTerminalImageProtocol(null);
 		const onUnavailable = vi.fn();
@@ -99,7 +102,7 @@ describe("warnWhenPetCapabilitySettled", () => {
 
 			vi.advanceTimersByTime(PET_CAPABILITY_SETTLE_MS * 2);
 
-			expect(onUnavailable).toHaveBeenCalledTimes(1);
+			expect(onUnavailable).not.toHaveBeenCalled();
 		} finally {
 			dispose();
 		}

--- a/packages/coding-agent/test/modes/components/pet-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/pet-selector.test.ts
@@ -16,22 +16,21 @@ beforeAll(async () => {
 });
 
 describe("PetSelectorComponent", () => {
-	it("shows saved named pets but keeps unavailable ones unselectable", () => {
+	it("keeps named pets reachable through the text-cell fallback", () => {
 		const onSelect = vi.fn();
 		const onPreview = vi.fn();
-		const component = new PetSelectorComponent("red", onSelect, () => {}, onPreview, false);
+		const component = new PetSelectorComponent("red", onSelect, () => {}, onPreview, true);
 		const rendered = stripAnsi(component.render(80).join("\n"));
 
-		expect(rendered).toContain("RedGajae (saved)");
+		expect(rendered).toContain("RedGajae");
 		expect(rendered).toContain("BlueGajae");
 		expect(rendered).toContain("Ouroboros");
-		expect(rendered).toContain("Saved, unavailable");
-		expect(stripAnsi(component.render(40).join("\n"))).toContain("RedGajae (saved)");
-		expect(component.getSelectList().getSelectedItem()?.value).toBe("off");
+		expect(stripAnsi(component.render(40).join("\n"))).toContain("RedGajae");
+		expect(component.getSelectList().getSelectedItem()?.value).toBe("red");
 
 		component.getSelectList().handleInput("\x1b[B");
-		expect(component.getSelectList().getSelectedItem()?.value).toBe("off");
-		expect(onPreview).not.toHaveBeenCalled();
+		expect(component.getSelectList().getSelectedItem()?.value).toBe("blue");
+		expect(onPreview).toHaveBeenCalledWith("blue");
 	});
 
 	it("decorates settings options through the shared capability policy", () => {

--- a/packages/coding-agent/test/modes/components/settings-selector-pet.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-pet.test.ts
@@ -39,7 +39,7 @@ function makeComponent(
 function openPetSetting(component: SettingsSelectorComponent): void {
 	for (let attempt = 0; attempt < 100; attempt++) {
 		const rendered = stripVTControlCharacters(component.render(160).join("\n"));
-		if (rendered.includes("Real-pixel pet living beside the composer")) {
+		if (rendered.includes("Animated pet beside the composer")) {
 			component.handleInput("\n");
 			return;
 		}
@@ -49,7 +49,7 @@ function openPetSetting(component: SettingsSelectorComponent): void {
 }
 
 describe("SettingsSelectorComponent pet capability", () => {
-	it("shows a saved unavailable pet, permits only Off, and routes the commit through the shared policy", () => {
+	it("keeps saved pets reachable through the text fallback and routes the commit through the shared policy", () => {
 		settings.set("pet.mode", "red");
 		const onChange = vi.fn();
 		const onPetPreview = vi.fn();
@@ -58,52 +58,24 @@ describe("SettingsSelectorComponent pet capability", () => {
 			settings.set("pet.mode", mode as never);
 			return true;
 		});
-		const component = makeComponent(false, { onChange, onPetPreview, onPetCommit });
+		const component = makeComponent(true, { onChange, onPetPreview, onPetCommit });
 
 		openPetSetting(component);
 		const submenu = stripVTControlCharacters(component.render(80).join("\n"));
-		expect(submenu).toContain("RedGajae (saved)");
+		expect(submenu).toContain("RedGajae");
 		expect(submenu).toContain("BlueGajae");
 		expect(submenu).toContain("Ouroboros");
-		expect(submenu).toContain("Saved, unavailable");
-		expect(stripVTControlCharacters(component.render(40).join("\n"))).toContain("RedGajae (saved)");
+		expect(stripVTControlCharacters(component.render(40).join("\n"))).toContain("RedGajae");
 
 		component.handleInput("\x1b[B");
-		expect(onPetPreview).not.toHaveBeenCalled();
+		expect(onPetPreview).toHaveBeenCalledWith("blue");
 		component.handleInput("\n");
 
 		// The settings surface never persists pet.mode itself and never routes
 		// it through the generic onChange path; the shared policy owns both.
-		expect(onPetCommit).toHaveBeenCalledWith("off");
+		expect(onPetCommit).toHaveBeenCalledWith("blue");
 		expect(onChange).not.toHaveBeenCalled();
-		expect(settings.get("pet.mode")).toBe("off");
-	});
-
-	it("shows the actionable unavailable warning inside the pet submenu", () => {
-		settings.set("pet.mode", "red");
-		const component = makeComponent(false, {}, {});
-
-		openPetSetting(component);
-		const submenu = stripVTControlCharacters(component.render(200).join("\n"));
-
-		// Same guidance as startup and /pet (normal-terminal variant in tests);
-		// dimmed option descriptions alone are not sufficient.
-		expect(submenu).toContain("Ghostty");
-	});
-
-	it.each([
-		["TMUX", { TMUX: "/tmp/host,1,0" }],
-		["tmux TERM", { TERM: "tmux-256color" }],
-	])("shows multiplexer recovery guidance for %s without normal-terminal guidance", (_name, terminalEnv) => {
-		settings.set("pet.mode", "red");
-		const component = makeComponent(false, {}, terminalEnv);
-
-		openPetSetting(component);
-		const submenu = stripVTControlCharacters(component.render(200).join("\n"));
-
-		expect(submenu).toContain("outside the multiplexer");
-		expect(submenu).toContain("PI_FORCE_IMAGE_PROTOCOL=sixel");
-		expect(submenu).not.toContain("Ghostty");
+		expect(settings.get("pet.mode")).toBe("blue");
 	});
 
 	it("does not persist pet.mode when the commit policy rejects at select time", () => {


### PR DESCRIPTION
## What

Bounded Gajae Pet text-cell fallback for terminals without graphics protocols.

## Why

Fixes #4867: tmux and iOS SSH users had no viable image-protocol route.

## Testing

- `bun test …` focused pet suite: 158 pass
- `bun --cwd=packages/coding-agent run check:types`

## Risk classification

- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

gajae.pr-review-verdict.v1 merge-self-approved sha256:9ad9efab412a7eee8f44becc5501ae5297d513bad9153fb9bd7c221fec30c1e5 reviewer:human reviewer-id:Yeachan-Heo evidence:158 focused pet tests and coding-agent typecheck passed; architect and QA review clean

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated
- [x] Verdict above matches the exact PR head
- [x] Risk classification above matches the actual review path

Evidence footer: parser-valid risk=low review=architect+qa digest=ebec0e1eed15ae04620a7a267e0b12614719979f signed-by=Yeachan-Heo