### PR TITLE
test(ai): pin the escape detector on Windows non-ASCII home shapes (#4881)

### DIFF
--- a/packages/ai/test/json-parse-windows-home.test.ts
+++ b/packages/ai/test/json-parse-windows-home.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import { findUnnecessaryUnicodeEscape } from "@gajae-code/ai/utils/json-parse";
+
+// #4881: a Windows profile whose username is non-ASCII (C:\Users\최재필) puts
+// Hangul into the machine's shortest home path, so escaping fires on routine
+// tool calls that never chose non-ASCII content. These fixtures pin the
+// detector contract for the shapes that actually occur on such a host:
+// backslash drive paths, forward-slash variants, `ls -l` owner-column output,
+// and cp949 mojibake from tools that decoded the path with the wrong code page.
+
+const USER = "최재필";
+
+/** Escapes every non-ASCII character as `\uXXXX`, the wire defect under test. */
+function escapeAll(s: string): string {
+	return s.replace(/[^\x00-\x7F]/g, c => `\\u${c.charCodeAt(0).toString(16).padStart(4, "0")}`);
+}
+
+/** The exact username as it appears in `\uXXXX` form on the wire. */
+const USER_ESCAPED = escapeAll(USER);
+
+describe("findUnnecessaryUnicodeEscape — Windows non-ASCII home paths (#4881)", () => {
+	it("accepts every literal-UTF-8 Windows home shape the model should emit", () => {
+		// The detector must stay silent on the correct spelling: a non-ASCII
+		// home is not itself a defect, only its escaped serialization is.
+		const literalFixtures = [
+			JSON.stringify({ path: `C:\\Users\\${USER}\\.bun\\install\\cache\\x.tgz` }),
+			JSON.stringify({ path: `C:/Users/${USER}/AppData/Roaming/uv/cache` }),
+			JSON.stringify({ command: `ls -l "C:\\Users\\${USER}"` }),
+			JSON.stringify({ cwd: `D:\\DevProjects\\qlibx`, content: `const s = "${USER}";` }),
+		];
+		for (const payload of literalFixtures) {
+			expect(findUnnecessaryUnicodeEscape(payload)).toBeUndefined();
+		}
+	});
+
+	it("flags the escaped spelling of a backslash Windows home path", () => {
+		// Backslashes are JSON-escaped (`\\`) independently of the Hangul; the
+		// scanner must track both state machines at once and still name the
+		// first unnecessary escape — the first syllable of the username.
+		const payload = escapeAll(JSON.stringify({ path: `C:\\Users\\${USER}\\.bun\\x.ts` }));
+		expect(findUnnecessaryUnicodeEscape(payload)).toBe(USER_ESCAPED.slice(0, 6));
+	});
+
+	it("flags the escaped spelling of a forward-slash Windows home path", () => {
+		const payload = escapeAll(JSON.stringify({ path: `C:/Users/${USER}/.bun/x.ts` }));
+		expect(findUnnecessaryUnicodeEscape(payload)).toBe(USER_ESCAPED.slice(0, 6));
+	});
+
+	it("flags escaped Hangul arriving through `ls -l` owner-column output", () => {
+		// `ls -l` on this profile prints the username in every owner column,
+		// so the defect can ride a command's *output* path back into a later
+		// tool call even when the call's own arguments were ASCII.
+		const output = `-rw-r--r-- 1 ${USER} ${USER} 4096 Aug 20 23:17 qlibx`;
+		const payload = escapeAll(JSON.stringify({ command: `grep -l "sharpe" /tmp/out.txt`, content: output }));
+		expect(findUnnecessaryUnicodeEscape(payload)).toBe(USER_ESCAPED.slice(0, 6));
+	});
+
+	it("flags escaped cp949 mojibake bytes, and does not flag them when literal", () => {
+		// Python tracebacks on this host arrive as cp949-decoded mojibake
+		// (`?\x1a\AppData\Roaming\uv\...` style lead/trail bytes landing in
+		// Latin-1/PUA code points). Escaped, they are still an unnecessary
+		// escape of a printable non-ASCII character; literal, they pass.
+		const mojibake = "��\\AppData\\Roaming\\uv\\cache";
+		const escapedPayload = escapeAll(JSON.stringify({ content: mojibake }));
+		expect(findUnnecessaryUnicodeEscape(escapedPayload)).toBeDefined();
+		expect(findUnnecessaryUnicodeEscape(JSON.stringify({ content: mojibake }))).toBeUndefined();
+	});
+
+	it("never flags the `\\\\uXXXX` source syntax of code that intentionally escapes", () => {
+		// Writing an escaper that *should* emit `\uXXXX` (a code generator, a
+		// fixture builder) is correct spelling, not a defect: the backslash is
+		// itself escaped, so the scanner must not see an escape at all. This is
+		// the false-positive boundary that makes structural Windows-path
+		// triggering survivable rather than constant.
+		const payload = JSON.stringify({ content: `const USER_ESCAPED = "\\u${USER.charCodeAt(0).toString(16)}";` });
+		expect(findUnnecessaryUnicodeEscape(payload)).toBeUndefined();
+	});
+
+	it("flags an escaped Hangul payload only once — the reported span is the first escape", () => {
+		const payload = escapeAll(JSON.stringify({ path: `C:\\Users\\${USER}\\권한\\설정.json` }));
+		const hit = findUnnecessaryUnicodeEscape(payload);
+		expect(hit).toBe(USER_ESCAPED.slice(0, 6));
+		// The reported hit is a prefix of the full escaped username, and the
+		// full escaped username is present verbatim in the payload.
+		expect(payload).toContain(USER_ESCAPED);
+		expect(USER_ESCAPED.startsWith(hit ?? "")).toBe(true);
+	});
+});


### PR DESCRIPTION
## What

Pins the escaped-non-ASCII escape detector (findUnnecessaryUnicodeEscape) on the exact wire shapes a Windows non-ASCII home profile produces, which #4881 shows makes the guard fire structurally rather than per-turn-wire-luck:

- backslash drive paths (C:\Users\최재필\.bun\...) — the JSON string-escape state machine riding on top of the escape scanner, both flagged when escaped and clean when literal
- forward-slash variants (C:/Users/최재필/...)
- ls -l owner-column output (the username rides command output back into the next tool call's arguments)
- cp949-style mojibake (Python tracebacks decoding the path with the wrong code page)
- the \uXXXX intended-source-syntax control stays exempt (writing an escaper is correct output, not a defect)
- literal UTF-8 spellings of every shape stay clean — a non-ASCII home is not itself a defect, only its escaped serialization is

7 tests, all green on current dev; detector behavior is unchanged (this is coverage, not a fix).

## Why

#4881: on a Windows profile whose username is non-ASCII, the machine's shortest home path contains Hangul, so a large share of routine tool calls carry non-ASCII regardless of task content. The detector contract for those exact shapes was unpinned; this locks the boundary that keeps structural triggering precise (literal passes, source-syntax escapes pass, escaped spelling flags) while the fallback-side disposition is fixed separately under #4880.

Scope discipline: the session-level half of #4881 — escaped_arguments_discarded exhaustion advancing the fallback chain and silently downgrading opus-5 to opus-4-6 — is root-caused in both issues and owned by #4880's fallback fix. This PR deliberately does not touch agent-session.ts / agent-loop.ts / fallback-chain-controller.ts. The session-level regression repro that must turn green when #4880 lands is verified failing on dev exactly as reported (green half pinned: no decode-and-execute, nothing defective persisted, fail-closed, bounded; red half: a model_fallback_switched event from anthropic/claude-opus-5 to anthropic/claude-opus-4-6 with reason "unknown" and attemptsUsed 3) and ships as independent regression proof immediately after #4880 merges.

## Testing

- bun test packages/ai/test/json-parse-windows-home.test.ts — 7 pass
- bun test packages/ai/test/json-parse-windows-home.test.ts packages/coding-agent/test/agent-session-escaped-nonascii-managed-steering.test.ts packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts — 39 pass (no neighbor regression)
- bun --cwd=packages/ai run check — clean

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:39d15445b048af4e2e00c14870aa9fc96dcf63fdad3702011031618e4910abcd reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/actions/runs/32680038805 (Affected path validation: test:packages/ai/test/json-parse-windows-home.test.ts pass, native-build pass, ts-build pass)
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing) — test-only change, no user-facing behavior change, so no changelog entry per repo convention for test-only commits
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken