### PR TITLE
feat(setup): render and preserve GJC_CODING_AGENT_DIR in gjc setup hermes

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -316,7 +316,7 @@ Coordinator MCP currently exposes durable polling/await tools, not push subscrip
 | `GJC_COORDINATOR_MCP_WORKDIR_ROOTS` | Required allowlist for workdir and artifact paths. `gjc setup hermes` renders absolute normalized paths joined with the platform path delimiter (`:` on POSIX, `;` on Windows). The bridge parser also accepts commas, semicolons, and newlines for legacy manual configs. |
 | `GJC_COORDINATOR_MCP_MUTATIONS` | Enables mutating tool classes as a comma-separated list (`sessions`, `questions`, `reports`) or `all`. `sessions` covers session startup, prompt delivery, durable turn journal updates, queue, and force operations. Per-call `allow_mutation: true` is still required. |
 | `GJC_COORDINATOR_MCP_ARTIFACT_BYTE_CAP` | Max bytes returned by Linux-only artifact reads (default `65536`, capped at `1048576`). On macOS and Windows, artifact reads fail closed with generic `artifact_unavailable`; detect support through MCP `tools/list`; use the controller's approved repository/worktree reader and report bounded results instead. |
-| `GJC_COORDINATOR_MCP_STATE_ROOT` | Bridge coordination state root (default `<cwd>/.gjc/state/coordinator-mcp`). |
+| `GJC_COORDINATOR_MCP_STATE_ROOT` | Bridge coordination state root (default `<cwd>/.gjc/state/coordinator-mcp`). Coordinator durable state only — it does **not** select the broker agent directory; that is `GJC_CODING_AGENT_DIR`, rendered by `gjc setup hermes --coding-agent-dir <abs-path>` (absolute path required; home/filesystem-root refused; preserved across managed re-installs unless the flag overrides it). |
 | `GJC_COORDINATOR_MCP_CODEX_TOKEN_ROOT` | Root for managed Codex handoff token files (default `<state-root>/codex-tokens`). Registered files must be owner-only regular non-symlink files beneath this root. Authenticated token-file handoff is unavailable on native Windows unless an equivalent secure ACL proof is provided; registration fails closed with `codex_authenticated_handoff_unavailable_windows`. |
 | `GJC_COORDINATOR_MCP_PROFILE` | Optional profile namespace for session/question/report state. Missing scope never widens to global session enumeration. |
 | `GJC_COORDINATOR_MCP_REPO` | Optional repo namespace for session/question/report state. Missing scope never widens to global session enumeration. |
@@ -499,7 +499,7 @@ LSP project configuration may control declarative matching, activation, and capa
 | Variable              | Default / behavior                                                            |
 | --------------------- | ----------------------------------------------------------------------------- |
 | `GJC_CONFIG_DIR`       | Config root dirname under home (default `.gjc`)                               |
-| `GJC_CODING_AGENT_DIR` | Full override for agent directory (default `~/<GJC_CONFIG_DIR or .gjc>/agent`) |
+| `GJC_CODING_AGENT_DIR` | Full override for agent directory (default `~/<GJC_CONFIG_DIR or .gjc>/agent`). `gjc setup hermes --coding-agent-dir <abs-path>` renders it into the coordinator server env so bridge-spawned sessions share that broker; it is distinct from `GJC_COORDINATOR_MCP_STATE_ROOT`, which never selects the agent directory. |
 | `PWD`                 | Used when matching canonical current working directory in path helpers        |
 | `GJC_WORKTREE_DIR`     | Directory holding `--worktree` launch worktrees (default `{repo}.gajae-code-worktrees`) |
 

--- a/docs/hermes-mcp-bridge.md
+++ b/docs/hermes-mcp-bridge.md
@@ -51,6 +51,28 @@ gjc setup hermes \
 
 The runtime accepts only the literal selectors `gjc` and `gjc --worktree [name]`. It rejects local wrappers, shell syntax, tmux flags, and model/provider flags before creating a session. Existing setup configs that contain a legacy explicit `--session-command` must be changed to one of those selectors; provider and model resolution remains normal GJC configuration, not coordinator command injection.
 
+## Agent directory override
+
+`GJC_COORDINATOR_MCP_STATE_ROOT` selects coordinator durable state (session/turn/question journals, projections). It is **not** the broker selector: sessions started by the bridge use the GJC agent directory (`GJC_CODING_AGENT_DIR`; broker, lifecycle ledger, session index, `config.yml` / `models.yml`), and the spawned `gjc` process inherits it from the MCP server env. Pointing only `STATE_ROOT` at a separate directory leaves sessions on the default `~/.gjc/agent` broker.
+
+Render the agent-directory override next to the state root with an absolute path:
+
+```bash
+gjc setup hermes \
+  --root /path/to/repo \
+  --state-root /var/lib/gjc/hermes-state \
+  --coding-agent-dir /var/lib/gjc/hermes-agent
+```
+
+The rendered block then carries both keys as independent values:
+
+```bash
+export GJC_COORDINATOR_MCP_STATE_ROOT="/var/lib/gjc/hermes-state"
+export GJC_CODING_AGENT_DIR="/var/lib/gjc/hermes-agent"
+```
+
+`--coding-agent-dir` requires an absolute path (Windows accepts `C:\...` and UNC `\\server\share\...`) and refuses the home directory, the account home, and the filesystem root, the same way `--root` does. On `--install` of a GJC-managed block, an existing `GJC_CODING_AGENT_DIR` is preserved unless `--coding-agent-dir` is passed, which overrides it explicitly; the value participates in the managed setup signature, so `--check` detects drift.
+
 Run a non-mutating setup smoke check with:
 
 ```bash

--- a/packages/coding-agent/src/cli/setup-cli.ts
+++ b/packages/coding-agent/src/cli/setup-cli.ts
@@ -82,6 +82,7 @@ export interface SetupCommandArgs {
 		worktreeName?: string;
 		requireWorktree?: boolean;
 		stateRoot?: string;
+		codingAgentDir?: string;
 		mutation?: string[];
 		artifactByteCap?: string;
 		serverKey?: string;
@@ -123,6 +124,7 @@ const HERMES_ONLY_FLAGS: readonly (keyof SetupCommandArgs["flags"])[] = [
 	"worktreeName",
 	"requireWorktree",
 	"stateRoot",
+	"codingAgentDir",
 	"mutation",
 	"artifactByteCap",
 	"serverKey",
@@ -225,6 +227,8 @@ export function parseSetupArgs(args: string[]): SetupCommandArgs | undefined {
 			flags.requireWorktree = true;
 		} else if (arg === "--state-root") {
 			flags.stateRoot = args[++i];
+		} else if (arg === "--coding-agent-dir") {
+			flags.codingAgentDir = args[++i];
 		} else if (arg === "--mutation") {
 			flags.mutation = [...(flags.mutation ?? []), args[++i] ?? ""];
 		} else if (arg === "--artifact-byte-cap") {
@@ -927,6 +931,7 @@ ${chalk.bold("Hermes example:")}
   ${APP_NAME} setup hermes --root /path/to/repo --worktree-name hermes-gajae-code
   ${APP_NAME} setup hermes --root /path/to/repo --session-command "gjc --worktree hermes-custom"
   ${APP_NAME} setup hermes --root /path/to/repo --session-command gjc
+  ${APP_NAME} setup hermes --root /path/to/repo --coding-agent-dir /var/lib/gjc/hermes-agent
 
 ${chalk.bold("Options:")}
   -c, --check       Check if dependencies are installed without installing
@@ -948,6 +953,7 @@ ${chalk.bold("Options:")}
   --no-worktree     Disable default GJC --worktree isolation for Hermes sessions
   --worktree-name   Named GJC --worktree branch for Hermes sessions
   --mutation        Hermes MCP mutation classes: sessions,questions,reports,all
+  --coding-agent-dir GJC agent-directory override (GJC_CODING_AGENT_DIR, absolute path); distinct from --state-root
   --target          Hermes config file target for config-only install
   --profile-dir     Hermes profile directory for full setup install
   --dry-run         Preview discovered credentials without importing (credentials)

--- a/packages/coding-agent/src/commands/setup.ts
+++ b/packages/coding-agent/src/commands/setup.ts
@@ -45,6 +45,9 @@ export default class Setup extends Command {
 			description: "Refuse Hermes session creation that did not name its own worktree",
 		}),
 		"state-root": Flags.string({ description: "Hermes MCP coordination state root" }),
+		"coding-agent-dir": Flags.string({
+			description: "GJC agent-directory override rendered as GJC_CODING_AGENT_DIR (distinct from --state-root)",
+		}),
 		mutation: Flags.string({
 			description: "Hermes MCP mutation classes: sessions,questions,reports,all",
 			multiple: true,
@@ -94,6 +97,7 @@ export default class Setup extends Command {
 				worktreeName: flags["worktree-name"],
 				requireWorktree: flags["require-worktree"],
 				stateRoot: flags["state-root"],
+				codingAgentDir: flags["coding-agent-dir"],
 				mutation: flags.mutation,
 				artifactByteCap: flags["artifact-byte-cap"],
 				serverKey: flags["server-key"],

--- a/packages/coding-agent/src/setup/hermes-setup.ts
+++ b/packages/coding-agent/src/setup/hermes-setup.ts
@@ -444,7 +444,12 @@ function mergeHermesConfig(
 	// An operator-set GJC_CODING_AGENT_DIR in a managed block survives re-install
 	// unless --coding-agent-dir explicitly overrides it (issue #4879). The value
 	// stays out of the spec so the rendered signature remains flags-derived.
-	const preservedCodingAgentDir = spec.codingAgentDir ? undefined : readManagedCodingAgentDir(existingBlock);
+	// Preserve is scoped to GJC-managed blocks: a value we signed ourselves. An
+	// unmanaged block (--force) or a tampered one re-renders from flags alone.
+	const preservedCodingAgentDir =
+		spec.codingAgentDir || !serverBlockIsManaged(existingBlock)
+			? undefined
+			: readManagedCodingAgentDir(existingBlock);
 	return {
 		...existing,
 		mcp_servers: {
@@ -457,9 +462,9 @@ function mergeHermesConfig(
 }
 
 /**
- * Read the GJC_CODING_AGENT_DIR an earlier managed install rendered. Only a
- * managed block can carry one: unmanaged blocks already fail above unless
- * --force, and --force re-renders from flags alone.
+ * Read the GJC_CODING_AGENT_DIR a managed block carries. Callers gate on
+ * serverBlockIsManaged first, so only values GJC itself signed can be
+ * preserved; unmanaged or tampered blocks re-render from flags alone.
  */
 function readManagedCodingAgentDir(existingBlock: unknown): string | undefined {
 	if (!isRecord(existingBlock) || !isRecord(existingBlock.env)) return undefined;

--- a/packages/coding-agent/src/setup/hermes-setup.ts
+++ b/packages/coding-agent/src/setup/hermes-setup.ts
@@ -28,6 +28,7 @@ export interface HermesSetupFlags {
 	worktreeName?: string;
 	requireWorktree?: boolean;
 	stateRoot?: string;
+	codingAgentDir?: string;
 	mutation?: string[];
 	artifactByteCap?: string;
 	serverKey?: string;
@@ -58,6 +59,8 @@ export interface CoordinatorSetupSpec {
 		required: boolean;
 	};
 	stateRoot?: string;
+	/** Agent-directory override (GJC_CODING_AGENT_DIR). Distinct from the coordinator state root. */
+	codingAgentDir?: string;
 	mutationPolicy: {
 		classes: HermesMutationClass[];
 		perCallConsentRequired: true;
@@ -138,6 +141,27 @@ function normalizeRoots(roots: string[] | undefined): string[] {
 		}
 	}
 	return normalized;
+}
+/**
+ * Validate --coding-agent-dir with the same guard normalizeRoots applies to
+ * --root: absolute (path.isAbsolute covers POSIX and Windows drive/UNC), never
+ * the filesystem root, /home, or the account home.
+ */
+function normalizeCodingAgentDir(value: string | undefined): string | undefined {
+	const trimmed = optionalTrim(value);
+	if (!trimmed) return undefined;
+	if (!path.isAbsolute(trimmed)) {
+		throw new HermesSetupError(`--coding-agent-dir must be an absolute path; got: ${trimmed}`, 2);
+	}
+	const resolved = path.resolve(trimmed);
+	if (
+		resolved === path.parse(resolved).root ||
+		resolved === path.resolve("/home") ||
+		resolved === path.resolve(os.homedir())
+	) {
+		throw new HermesSetupError(`Refusing broad Hermes coding agent dir: ${resolved}`, 2);
+	}
+	return resolved;
 }
 
 function parseMutationClasses(values: string[] | undefined): HermesMutationClass[] {
@@ -271,6 +295,11 @@ export function buildHermesSetupSpec(flags: HermesSetupFlags): CoordinatorSetupS
 		sessionCommandSource: flags.sessionCommand !== undefined ? "explicit" : "default",
 		sessionCommand,
 		...(optionalTrim(flags.stateRoot) ? { stateRoot: path.resolve(flags.stateRoot!) } : {}),
+		// Preserved/overridden at install time from the managed block, so the
+		// spec field only reflects an explicit --coding-agent-dir.
+		...(normalizeCodingAgentDir(flags.codingAgentDir)
+			? { codingAgentDir: normalizeCodingAgentDir(flags.codingAgentDir) }
+			: {}),
 		mutationPolicy: {
 			classes: parseMutationClasses(flags.mutation),
 			perCallConsentRequired: true,
@@ -319,6 +348,7 @@ function renderHermesServerBlockWithoutSignature(spec: CoordinatorSetupSpec): Re
 	if (spec.namespace.profile) env.GJC_COORDINATOR_MCP_PROFILE = spec.namespace.profile;
 	if (spec.namespace.repo) env.GJC_COORDINATOR_MCP_REPO = spec.namespace.repo;
 	if (spec.stateRoot) env.GJC_COORDINATOR_MCP_STATE_ROOT = spec.stateRoot;
+	if (spec.codingAgentDir) env.GJC_CODING_AGENT_DIR = spec.codingAgentDir;
 	if (spec.mutationPolicy.classes.length > 0)
 		env.GJC_COORDINATOR_MCP_MUTATIONS = spec.mutationPolicy.classes.join(",");
 	if (spec.artifactByteCap !== undefined) env.GJC_COORDINATOR_MCP_ARTIFACT_BYTE_CAP = String(spec.artifactByteCap);
@@ -411,13 +441,31 @@ function mergeHermesConfig(
 	if (existingBlock !== undefined && !serverBlockIsManaged(existingBlock) && !force) {
 		throw new HermesSetupError(`Hermes MCP server '${spec.serverKey}' already exists and is not managed by GJC.`, 3);
 	}
+	// An operator-set GJC_CODING_AGENT_DIR in a managed block survives re-install
+	// unless --coding-agent-dir explicitly overrides it (issue #4879). The value
+	// stays out of the spec so the rendered signature remains flags-derived.
+	const preservedCodingAgentDir = spec.codingAgentDir ? undefined : readManagedCodingAgentDir(existingBlock);
 	return {
 		...existing,
 		mcp_servers: {
 			...currentServers,
-			[spec.serverKey]: renderHermesServerBlock(spec),
+			[spec.serverKey]: renderHermesServerBlock(
+				preservedCodingAgentDir ? { ...spec, codingAgentDir: preservedCodingAgentDir } : spec,
+			),
 		},
 	};
+}
+
+/**
+ * Read the GJC_CODING_AGENT_DIR an earlier managed install rendered. Only a
+ * managed block can carry one: unmanaged blocks already fail above unless
+ * --force, and --force re-renders from flags alone.
+ */
+function readManagedCodingAgentDir(existingBlock: unknown): string | undefined {
+	if (!isRecord(existingBlock) || !isRecord(existingBlock.env)) return undefined;
+	const value = existingBlock.env.GJC_CODING_AGENT_DIR;
+	if (typeof value !== "string" || !value.trim()) return undefined;
+	return value;
 }
 
 function configPathForTarget(spec: CoordinatorSetupSpec): string | null {

--- a/packages/coding-agent/test/hermes-setup-coding-agent-dir.test.ts
+++ b/packages/coding-agent/test/hermes-setup-coding-agent-dir.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as nodePath from "node:path";
+import { YAML } from "bun";
+import { buildHermesSetupSpec, runHermesSetup } from "../src/setup/hermes-setup";
+
+let tempRoot: string | undefined;
+
+async function freshRoot(): Promise<string> {
+	tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-hermes-agent-dir-"));
+	return tempRoot;
+}
+
+describe("gjc setup hermes --coding-agent-dir", () => {
+	afterEach(cleanup);
+	async function cleanup(): Promise<void> {
+		if (tempRoot) {
+			await fs.rm(tempRoot, { recursive: true, force: true });
+			tempRoot = undefined;
+		}
+	}
+
+	it("renders GJC_CODING_AGENT_DIR next to GJC_COORDINATOR_MCP_STATE_ROOT when set", async () => {
+		const root = await freshRoot();
+		const agentDir = path.join(root, "agent-home");
+		const stateRoot = path.join(root, "state");
+		const result = await runHermesSetup({
+			json: true,
+			root: [root],
+			stateRoot,
+			codingAgentDir: agentDir,
+		});
+
+		const preview = result.previews.find(entry => entry.path.endsWith(".yaml"))?.content ?? "";
+		expect(preview).toContain(`GJC_COORDINATOR_MCP_STATE_ROOT: ${stateRoot}`);
+		expect(preview).toContain(`GJC_CODING_AGENT_DIR: ${agentDir}`);
+	});
+
+	it("omits GJC_CODING_AGENT_DIR when the flag is unset", async () => {
+		const root = await freshRoot();
+		const result = await runHermesSetup({ json: true, root: [root] });
+
+		const preview = result.previews.find(entry => entry.path.endsWith(".yaml"))?.content ?? "";
+		expect(preview).not.toContain("GJC_CODING_AGENT_DIR");
+		expect(preview).not.toContain("GJC_COORDINATOR_MCP_STATE_ROOT");
+	});
+
+	it("keeps the two variables independent: setting one never renders the other", async () => {
+		const root = await freshRoot();
+		const agentOnly = await runHermesSetup({
+			json: true,
+			root: [root],
+			codingAgentDir: path.join(root, "agent-home"),
+		});
+		const agentOnlyPreview = agentOnly.previews.find(entry => entry.path.endsWith(".yaml"))?.content ?? "";
+		expect(agentOnlyPreview).toContain("GJC_CODING_AGENT_DIR");
+		expect(agentOnlyPreview).not.toContain("GJC_COORDINATOR_MCP_STATE_ROOT");
+
+		const stateOnly = await runHermesSetup({
+			json: true,
+			root: [root],
+			stateRoot: path.join(root, "state"),
+		});
+		const stateOnlyPreview = stateOnly.previews.find(entry => entry.path.endsWith(".yaml"))?.content ?? "";
+		expect(stateOnlyPreview).toContain("GJC_COORDINATOR_MCP_STATE_ROOT");
+		expect(stateOnlyPreview).not.toContain("GJC_CODING_AGENT_DIR");
+	});
+
+	it("participates in the setup signature so --check detects drift", async () => {
+		const root = await freshRoot();
+		const profileDir = path.join(root, "profile");
+		await runHermesSetup({
+			install: true,
+			root: [root],
+			profileDir,
+			codingAgentDir: path.join(root, "agent-a"),
+		});
+		expect(
+			await runHermesSetup({
+				check: true,
+				root: [root],
+				profileDir,
+				codingAgentDir: path.join(root, "agent-a"),
+			}),
+		).toMatchObject({ ok: true, check: { mismatches: [] } });
+
+		// Same flags but a different agent dir is a different managed signature.
+		const drifted = await runHermesSetup({
+			check: true,
+			root: [root],
+			profileDir,
+			codingAgentDir: path.join(root, "agent-b"),
+		});
+		expect(drifted.ok).toBe(false);
+	});
+
+	it("preserves an existing GJC_CODING_AGENT_DIR on install when the flag is omitted", async () => {
+		const root = await freshRoot();
+		const profileDir = path.join(root, "profile");
+		const operatorDir = path.join(root, "operator-agent");
+		await runHermesSetup({ install: true, root: [root], profileDir, codingAgentDir: operatorDir });
+
+		// Re-install without the flag: the managed value must survive.
+		await runHermesSetup({ install: true, root: [root], profileDir });
+		const preserved = await readServerEnv(profileDir);
+		expect(preserved.GJC_CODING_AGENT_DIR).toBe(operatorDir);
+
+		// Idempotent: a third install without the flag still keeps it.
+		await runHermesSetup({ install: true, root: [root], profileDir });
+		expect((await readServerEnv(profileDir)).GJC_CODING_AGENT_DIR).toBe(operatorDir);
+	});
+
+	it("overrides the managed value when --coding-agent-dir is provided", async () => {
+		const root = await freshRoot();
+		const profileDir = path.join(root, "profile");
+		await runHermesSetup({
+			install: true,
+			root: [root],
+			profileDir,
+			codingAgentDir: path.join(root, "agent-old"),
+		});
+		const agentNew = path.join(root, "agent-new");
+		await runHermesSetup({ install: true, root: [root], profileDir, codingAgentDir: agentNew });
+
+		expect((await readServerEnv(profileDir)).GJC_CODING_AGENT_DIR).toBe(agentNew);
+		// The overridden value itself survives a later flag-less re-install.
+		await runHermesSetup({ install: true, root: [root], profileDir });
+		expect((await readServerEnv(profileDir)).GJC_CODING_AGENT_DIR).toBe(agentNew);
+	});
+
+	it("normalizes the rendered value to an absolute resolved path", () => {
+		const root = "/tmp/gjc-hermes-abs";
+		const spec = buildHermesSetupSpec({
+			root: ["/tmp/gjc-hermes-roots"],
+			codingAgentDir: path.join(root, "nested", ".."),
+		});
+		expect(spec.codingAgentDir).toBe("/tmp/gjc-hermes-abs");
+	});
+
+	it("rejects relative paths", () => {
+		const root = "/tmp/gjc-hermes-roots";
+		expect(() => buildHermesSetupSpec({ root: [root], codingAgentDir: "relative/agent" })).toThrow(
+			/--coding-agent-dir must be an absolute path/,
+		);
+		expect(() => buildHermesSetupSpec({ root: [root], codingAgentDir: "~/gjc-agent" })).toThrow(
+			/--coding-agent-dir must be an absolute path/,
+		);
+	});
+
+	it("refuses home, filesystem root, and /home like --root does", () => {
+		const root = "/tmp/gjc-hermes-roots";
+		const home = path.resolve(os.homedir());
+		const cases = ["/", "/home", home, `${path.sep}`];
+		for (const value of cases) {
+			expect(() => buildHermesSetupSpec({ root: [root], codingAgentDir: value }), `value=${value}`).toThrow(
+				/Refusing broad Hermes coding agent dir/,
+			);
+		}
+	});
+
+	it("accepts Windows drive and UNC spellings as absolute on win32 path rules", () => {
+		const root = "/tmp/gjc-hermes-roots";
+		// path.isAbsolute is the platform gate; on POSIX hosts the win32 check is
+		// asserted directly against the same predicate the validator uses.
+		const winDrive = "C:\\gjc\\agent";
+		const winUnc = "\\\\server\\share\\gjc-agent";
+		expect(nodePath.win32.isAbsolute(winDrive)).toBe(true);
+		expect(nodePath.win32.isAbsolute(winUnc)).toBe(true);
+		// A POSIX host still rejects them because they are not absolute here.
+		if (process.platform !== "win32") {
+			expect(() => buildHermesSetupSpec({ root: [root], codingAgentDir: winDrive })).toThrow(
+				/--coding-agent-dir must be an absolute path/,
+			);
+		}
+	});
+
+	async function readServerEnv(profileDir: string): Promise<Record<string, string>> {
+		const configPath = path.join(profileDir, "config.yaml");
+		const parsed = YAML.parse(await Bun.file(configPath).text()) as {
+			mcp_servers: Record<string, { env?: Record<string, string> }>;
+		};
+		return parsed.mcp_servers.gjc_coordinator?.env ?? {};
+	}
+});

--- a/packages/coding-agent/test/hermes-setup-coding-agent-dir.test.ts
+++ b/packages/coding-agent/test/hermes-setup-coding-agent-dir.test.ts
@@ -129,6 +129,55 @@ describe("gjc setup hermes --coding-agent-dir", () => {
 		await runHermesSetup({ install: true, root: [root], profileDir });
 		expect((await readServerEnv(profileDir)).GJC_CODING_AGENT_DIR).toBe(agentNew);
 	});
+	it("does not preserve a foreign GJC_CODING_AGENT_DIR from an unmanaged block under --force", async () => {
+		const root = await freshRoot();
+		const configPath = path.join(root, "config.yaml");
+		await Bun.write(
+			configPath,
+			YAML.stringify({
+				mcp_servers: {
+					gjc_coordinator: {
+						command: "custom",
+						env: { GJC_CODING_AGENT_DIR: path.join(root, "foreign-agent") },
+					},
+				},
+			}),
+		);
+
+		await runHermesSetup({ install: true, force: true, root: [root], target: configPath });
+
+		const parsed = YAML.parse(await Bun.file(configPath).text()) as {
+			mcp_servers: Record<string, { env?: Record<string, string> }>;
+		};
+		// Preserve is scoped to blocks GJC signed itself; --force re-renders from
+		// flags alone instead of adopting an untrusted env value.
+		expect(parsed.mcp_servers.gjc_coordinator?.env?.GJC_CODING_AGENT_DIR).toBeUndefined();
+	});
+
+	it("refuses a tampered managed block instead of preserving the edited value", async () => {
+		const root = await freshRoot();
+		const profileDir = path.join(root, "profile");
+		await runHermesSetup({
+			install: true,
+			root: [root],
+			profileDir,
+			codingAgentDir: path.join(root, "agent-a"),
+		});
+		const configPath = path.join(profileDir, "config.yaml");
+		await Bun.write(
+			configPath,
+			(await Bun.file(configPath).text()).replace(
+				`GJC_CODING_AGENT_DIR: ${path.join(root, "agent-a")}`,
+				"GJC_CODING_AGENT_DIR: relative-injection",
+			),
+		);
+
+		await expect(runHermesSetup({ install: true, root: [root], profileDir })).rejects.toThrow(
+			"already exists and is not managed by GJC",
+		);
+		// Fail-closed: the refused install leaves the tampered bytes untouched.
+		expect(await Bun.file(configPath).text()).toContain("relative-injection");
+	});
 
 	it("normalizes the rendered value to an absolute resolved path", () => {
 		const root = "/tmp/gjc-hermes-abs";

--- a/packages/coding-agent/test/setup-cli.test.ts
+++ b/packages/coding-agent/test/setup-cli.test.ts
@@ -206,6 +206,43 @@ describe("setup CLI parsing", () => {
 				},
 			});
 		});
+		it("parses --coding-agent-dir as a Hermes-only flag", () => {
+			expect(
+				parseSetupArgs([
+					"setup",
+					"hermes",
+					"--root",
+					"/tmp/repo",
+					"--state-root",
+					"/tmp/state",
+					"--coding-agent-dir",
+					"/tmp/agent-home",
+				]),
+			).toEqual({
+				component: "hermes",
+				flags: {
+					root: ["/tmp/repo"],
+					stateRoot: "/tmp/state",
+					codingAgentDir: "/tmp/agent-home",
+				},
+			});
+		});
+
+		it("rejects --coding-agent-dir outside the Hermes component", async () => {
+			const proc = Bun.spawn({
+				cmd: [
+					process.execPath,
+					"-e",
+					`import { parseSetupArgs } from "./src/cli/setup-cli"; parseSetupArgs(["setup", "defaults", "--coding-agent-dir", "/tmp/agent"]);`,
+				],
+				cwd: path.join(import.meta.dir, ".."),
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
+			expect(exitCode).toBe(1);
+			expect(stderr).toContain("--coding-agent-dir require the explicit `hermes` component");
+		});
 
 		it("renders Hermes setup with a model-agnostic usable GJC session command", async () => {
 			tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-coordinator-setup-"));


### PR DESCRIPTION
Closes #4879

## Problem

`gjc setup hermes` could render `GJC_COORDINATOR_MCP_STATE_ROOT` via `--state-root` but had no surface for `GJC_CODING_AGENT_DIR`. Those are different variables: the agent-directory override selects the broker / lifecycle ledger / session index / `config.yml`/`models.yml` (resolved through `getAgentDir()`), while `STATE_ROOT` is coordinator durable state. Worse, `--install` of a managed block **dropped** a pre-existing `GJC_CODING_AGENT_DIR` because `renderHermesServerBlock` never wrote the key and `mergeHermesConfig` replaced the whole server env.

## Change

- New `gjc setup hermes --coding-agent-dir <abs-path>`:
  - renders `GJC_CODING_AGENT_DIR` next to `GJC_COORDINATOR_MCP_STATE_ROOT`, only when set
  - participates in `computeHermesSetupSignature` so `--check`/reconciliation detect drift
  - on `--install` of a GJC-managed block, preserves the existing `GJC_CODING_AGENT_DIR` when the flag is omitted; an explicit flag overrides it
  - validation mirrors `--root`: absolute path (`path.isAbsolute`, so Windows drive/UNC accepted on win32), refusing the filesystem root, `/home`, and the account home
- Plumb through `parseSetupArgs` + `HERMES_ONLY_FLAGS`, the oclif `setup` command flags, and `printSetupHelp`
- Docs: `docs/hermes-mcp-bridge.md` (new "Agent directory override" section) and `docs/environment-variables.md` now state explicitly that `STATE_ROOT` does **not** select the broker

Non-goals from the issue respected: runtime resolution of `GJC_CODING_AGENT_DIR` is unchanged, and the two directories are not merged.

## Tests

- New `hermes-setup-coding-agent-dir.test.ts` (10 tests): render when set / omit when unset; independence of the two env keys; signature drift via `--check`; install preserve without the flag; explicit override; idempotent reinstall; POSIX normalization; relative-path rejection; home/`/`/`/home` refusal; Windows drive/UNC absoluteness assertions
- `setup-cli.test.ts`: parses the flag; rejects it outside the `hermes` component
- Targeted: 52/52 across hermes + setup-cli suites; `bun --cwd=packages/coding-agent run check` exit 0
- Live CLI probes: rendered YAML carries both keys; relative/home values refused; non-hermes component rejected

Note: `check:schemas` reports `schemas/config.schema.json` out of date on a clean `origin/dev` checkout too (verified in a separate worktree) — pre-existing, unrelated to this PR.

<!-- contract recheck 2 -->

## Risk classification

- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

gajae.pr-review-verdict.v1 merge-self-approved sha256:c69e81450dbfe5a82fce24704b1518690b66473b3c67ce8b02f6dae68fc1bd3c reviewer:human reviewer-id:Yeachan-Heo evidence:54/54 targeted tests; package check exit 0; live CLI adversarial matrix; architect + QA red-team lanes clean on sourceHash 1b1fe75a

- [x] Target branch is `dev`
- [x] `bun check` passes (coding-agent package check; root schema drift pre-exists on clean dev, verified in separate worktree)
- [x] Tested locally
- [ ] CHANGELOG updated (setup adapter flag; in-repo docs updated instead)
- [x] Verdict above matches the exact PR head
- [x] Risk classification above matches the actual review path

<!-- recheck 3 -->