### PR TITLE
feat(onboarding): add frictionless guided setup

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added frictionless interactive onboarding for unresolved users and `/tutorial`. GJC now performs bounded, local metadata discovery across known coding-agent roots, requires corroborating activity within 90 days before inferring a workflow, falls back to manual guidance when evidence is insufficient, persists only a derived profile and completion decision, discloses unavailable sources, and previews the guided migration result before a single explicit apply or experienced-user skip.
+
 ### Changed
 
 - The five `macOS Local (oMLX)` presets are retuned from same-machine throughput measurements (#4871). All presets now use one role-effort ladder — critic and architect `high`, planner `medium`, executor and default `low` — and pick each preset's model by measured local throughput: `fast` keeps the 4-bit and `balanced` the 8-bit Qwen 3.6 35B A3B MoE quants (93.5 / 71.1 tok/s measured), `quality` keeps the 8-bit MoE for default/executor/planner/architect and routes only the critic to the official dense `Qwen3.8-27B-8bit` checkpoint (public SWE-bench/agent scores still favor dense for criticism), and both `abliterated` presets move to the faster `Qwen3.8-27B-Uncensored-MLX-4bit` (19.8 tok/s measured, ahead of the Abliterated 4-bit/6-bit quants on every measured axis). Preset display names now state the measured throughput instead of the memory-tier hints.

--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -46,6 +46,7 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 	"slash_command:credential":
 		"interactive session credential selector; not a credential-free public SDK operation or independent control seam",
 	"slash_command:pet": "visual/local-only command, not a user-facing SDK control seam",
+	"slash_command:tutorial": "visual/local-only onboarding selector, not a user-facing SDK control seam",
 	"slash_command:transcript": "visual/local-only transcript viewer, not a user-facing SDK control seam",
 	"slash_command:sessions": "visual/local-only sessions dashboard, not a user-facing SDK control seam",
 	"agent_session:constructor": "internal accessor/plumbing, not a user-facing control seam",

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -71,6 +71,11 @@ import {
 	type StrictSessionOpenResult,
 } from "./session/session-manager";
 import { runStartupCredentialAutoImportIfNeeded } from "./setup/credential-auto-import";
+import {
+	readOnboardingState,
+	shouldOfferAutomaticOnboarding,
+	shouldOfferOnboarding,
+} from "./setup/frictionless-onboarding";
 import { formatModelOnboardingGuidance } from "./setup/model-onboarding-guidance";
 import { executeBuiltinSlashCommand } from "./slash-commands/builtin-registry";
 import { resolvePromptInput } from "./system-prompt";
@@ -716,6 +721,21 @@ export async function runInteractiveMode(
 		throw error;
 	}
 
+	if (
+		shouldOfferAutomaticOnboarding({
+			normalInteractive: true,
+			initialMessage,
+			initialMessages,
+			initialImages,
+			resumeAction,
+		})
+	) {
+		const agentDir = session.getSessionAgentDir?.() ?? session.settings?.getAgentDir?.();
+		if (agentDir) {
+			const onboardingState = await readOnboardingState(agentDir);
+			if (shouldOfferOnboarding(onboardingState)) await mode.showFrictionlessOnboarding();
+		}
+	}
 	mode.renderInitialMessages(undefined, { preserveExistingChat: true });
 
 	for (const notify of notifs) {

--- a/packages/coding-agent/src/modes/components/frictionless-onboarding-selector.ts
+++ b/packages/coding-agent/src/modes/components/frictionless-onboarding-selector.ts
@@ -1,0 +1,268 @@
+import { Container, matchesKey, Spacer, TruncatedText } from "@gajae-code/tui";
+import type { OnboardingProfile } from "../../setup/frictionless-onboarding";
+import { theme } from "../theme/theme";
+import { matchesSelectCancel } from "../utils/keybinding-matchers";
+import { DynamicBorder } from "./dynamic-border";
+
+export type FrictionlessOnboardingAction =
+	| "analyze"
+	| "apply"
+	| "skip"
+	| "later"
+	| "manual"
+	| "manual-migration"
+	| "manual-learn";
+export type FrictionlessOnboardingStage = "disclosure" | "manual" | "preview";
+
+export interface FrictionlessOnboardingCopy {
+	title: string;
+	disclosure: string;
+	analyze: string;
+	manual: string;
+	skip: string;
+	later: string;
+	apply: string;
+	preview: string;
+	migration: string;
+	learn: string;
+	noChanges: string;
+	controls: string;
+	confirmTitle: string;
+	completed: string;
+	skipped: string;
+	persistFailed: string;
+}
+
+const TEXT: Record<string, FrictionlessOnboardingCopy> = {
+	en: {
+		title: "Frictionless onboarding",
+		disclosure:
+			"GJC checks Codex, Claude, OpenCode, OMP, and OMO directory metadata. Supported session content is analyzed only after Analyze; only the derived profile and completion state are retained.",
+		analyze: "Analyze supported local evidence",
+		manual: "Which GJC workflow do you want help with?",
+		skip: "I'm experienced with GJC",
+		later: "Later",
+		apply: "Confirm this guided action",
+		preview: "Preview — nothing has been applied",
+		migration: "Map my existing workflow to GJC",
+		learn: "Open the GJC command guide",
+		noChanges: "No configuration changes selected",
+		controls: "↑/↓ select · Enter choose · Esc cancel",
+		confirmTitle: "Apply the previewed onboarding action?",
+		completed: "Onboarding action completed",
+		skipped: "Onboarding skipped",
+		persistFailed: "Onboarding state could not be saved; onboarding remains unresolved.",
+	},
+	ko: {
+		title: "간편 온보딩",
+		disclosure:
+			"GJC는 Codex, Claude, OpenCode, OMP, OMO 디렉터리 메타데이터를 확인합니다. 지원되는 세션 내용은 분석을 선택한 뒤에만 처리하며, 파생된 프로필과 완료 상태만 저장합니다.",
+		analyze: "지원되는 로컬 증거 분석",
+		manual: "어떤 GJC 워크플로에 도움이 필요하신가요?",
+		skip: "GJC에 익숙합니다",
+		later: "나중에",
+		apply: "이 안내 작업 확인",
+		preview: "미리보기 — 아직 적용되지 않음",
+		migration: "기존 워크플로를 GJC에 매핑",
+		learn: "GJC 명령 안내 열기",
+		noChanges: "선택된 설정 변경 없음",
+		controls: "↑/↓ 선택 · Enter 확인 · Esc 취소",
+		confirmTitle: "미리 본 온보딩 작업을 적용할까요?",
+		completed: "온보딩 작업 완료",
+		skipped: "온보딩 건너뜀",
+		persistFailed: "온보딩 상태를 저장하지 못했습니다. 온보딩은 미완료 상태로 유지됩니다.",
+	},
+	ja: {
+		title: "簡単オンボーディング",
+		disclosure:
+			"GJCはCodex、Claude、OpenCode、OMP、OMOのディレクトリメタデータを確認します。対応セッションの内容は分析を選んだ後だけ処理し、派生プロフィールと完了状態だけを保存します。",
+		analyze: "対応するローカル情報を分析",
+		manual: "どのGJCワークフローを案内しますか？",
+		skip: "GJCを使い慣れています",
+		later: "後で",
+		apply: "この案内操作を確認",
+		preview: "プレビュー — まだ適用されていません",
+		migration: "既存ワークフローをGJCに対応付ける",
+		learn: "GJCコマンドガイドを開く",
+		noChanges: "選択された設定変更はありません",
+		controls: "↑/↓選択 · Enter決定 · Escキャンセル",
+		confirmTitle: "プレビューしたオンボーディング操作を適用しますか？",
+		completed: "オンボーディング操作が完了しました",
+		skipped: "オンボーディングをスキップしました",
+		persistFailed: "オンボーディング状態を保存できませんでした。未完了のままです。",
+	},
+	zh: {
+		title: "轻松入门",
+		disclosure:
+			"GJC 会检查 Codex、Claude、OpenCode、OMP 和 OMO 的目录元数据。仅在选择分析后处理受支持的会话内容，并且只保留派生配置和完成状态。",
+		analyze: "分析支持的本地信息",
+		manual: "您希望获得哪种 GJC 工作流帮助？",
+		skip: "我熟悉 GJC",
+		later: "稍后",
+		apply: "确认此引导操作",
+		preview: "预览 — 尚未应用",
+		migration: "将现有工作流映射到 GJC",
+		learn: "打开 GJC 命令指南",
+		noChanges: "未选择配置更改",
+		controls: "↑/↓选择 · Enter确认 · Esc取消",
+		confirmTitle: "应用预览的入门操作？",
+		completed: "入门操作已完成",
+		skipped: "已跳过入门",
+		persistFailed: "无法保存入门状态；入门仍未完成。",
+	},
+	es: {
+		title: "Incorporación sencilla",
+		disclosure:
+			"GJC revisa metadatos de directorios de Codex, Claude, OpenCode, OMP y OMO. Solo analiza sesiones compatibles después de elegir Analizar y conserva únicamente el perfil derivado y el estado de finalización.",
+		analyze: "Analizar evidencia local compatible",
+		manual: "¿Con qué flujo de GJC necesitas ayuda?",
+		skip: "Tengo experiencia con GJC",
+		later: "Más tarde",
+		apply: "Confirmar esta acción guiada",
+		preview: "Vista previa — aún no aplicada",
+		migration: "Adaptar mi flujo existente a GJC",
+		learn: "Abrir la guía de comandos de GJC",
+		noChanges: "No hay cambios de configuración seleccionados",
+		controls: "↑/↓ elegir · Enter confirmar · Esc cancelar",
+		confirmTitle: "¿Aplicar la acción de incorporación mostrada?",
+		completed: "Acción de incorporación completada",
+		skipped: "Incorporación omitida",
+		persistFailed: "No se pudo guardar el estado; la incorporación sigue pendiente.",
+	},
+	fr: {
+		title: "Configuration rapide",
+		disclosure:
+			"GJC vérifie les métadonnées des répertoires Codex, Claude, OpenCode, OMP et OMO. Le contenu des sessions compatibles n'est analysé qu'après votre choix, et seuls le profil dérivé et l'état d'achèvement sont conservés.",
+		analyze: "Analyser les éléments locaux compatibles",
+		manual: "Pour quel workflow GJC souhaitez-vous de l'aide ?",
+		skip: "Je connais GJC",
+		later: "Plus tard",
+		apply: "Confirmer cette action guidée",
+		preview: "Aperçu — rien n'est encore appliqué",
+		migration: "Adapter mon workflow existant à GJC",
+		learn: "Ouvrir le guide des commandes GJC",
+		noChanges: "Aucune modification sélectionnée",
+		controls: "↑/↓ choisir · Enter confirmer · Esc annuler",
+		confirmTitle: "Appliquer l'action d'accueil affichée ?",
+		completed: "Action d'accueil terminée",
+		skipped: "Accueil ignoré",
+		persistFailed: "Impossible d'enregistrer l'état ; l'accueil reste inachevé.",
+	},
+	de: {
+		title: "Reibungsloser Einstieg",
+		disclosure:
+			"GJC prüft Verzeichnismetadaten von Codex, Claude, OpenCode, OMP und OMO. Unterstützte Sitzungsinhalte werden erst nach Analysieren verarbeitet; gespeichert werden nur das abgeleitete Profil und der Abschlussstatus.",
+		analyze: "Unterstützte lokale Hinweise analysieren",
+		manual: "Bei welchem GJC-Workflow benötigen Sie Hilfe?",
+		skip: "Ich kenne GJC",
+		later: "Später",
+		apply: "Diese geführte Aktion bestätigen",
+		preview: "Vorschau — noch nichts angewendet",
+		migration: "Meinen bestehenden Workflow auf GJC abbilden",
+		learn: "GJC-Befehlsübersicht öffnen",
+		noChanges: "Keine Konfigurationsänderungen ausgewählt",
+		controls: "↑/↓ wählen · Enter bestätigen · Esc abbrechen",
+		confirmTitle: "Die angezeigte Onboarding-Aktion anwenden?",
+		completed: "Onboarding-Aktion abgeschlossen",
+		skipped: "Onboarding übersprungen",
+		persistFailed: "Onboarding-Status konnte nicht gespeichert werden; er bleibt offen.",
+	},
+};
+
+export function getFrictionlessOnboardingCopy(language: string): FrictionlessOnboardingCopy {
+	return TEXT[language] ?? TEXT.en!;
+}
+
+export class FrictionlessOnboardingSelectorComponent extends Container {
+	#selectedIndex = 0;
+	#list: Container;
+	#options: Array<{ label: string; description: string; action: FrictionlessOnboardingAction }>;
+
+	constructor(
+		profile: OnboardingProfile,
+		onSelect: (action: FrictionlessOnboardingAction) => void,
+		onCancel: () => void,
+		language = "en",
+		stage: FrictionlessOnboardingStage = "disclosure",
+	) {
+		super();
+		const text = getFrictionlessOnboardingCopy(language);
+		this.#options =
+			stage === "disclosure"
+				? [
+						{ label: text.analyze, description: text.disclosure, action: "analyze" },
+						{ label: text.manual, description: "", action: "manual" },
+						{ label: text.skip, description: "", action: "skip" },
+						{ label: text.later, description: "", action: "later" },
+					]
+				: stage === "manual"
+					? [
+							{ label: text.migration, description: "", action: "manual-migration" },
+							{ label: text.learn, description: "", action: "manual-learn" },
+							{ label: text.later, description: "", action: "later" },
+						]
+					: [
+							{ label: text.apply, description: text.preview, action: "apply" },
+							{ label: text.manual, description: "", action: "manual" },
+							{ label: text.skip, description: "", action: "skip" },
+							{ label: text.later, description: "", action: "later" },
+						];
+
+		this.addChild(new DynamicBorder());
+		this.addChild(new Spacer(1));
+		this.addChild(new TruncatedText(theme.bold(text.title)));
+		const summary =
+			stage === "disclosure"
+				? text.disclosure
+				: stage === "manual"
+					? text.manual
+					: `${text.preview}: ${profile.migrationMap.join(", ") || text.noChanges}`;
+		this.addChild(new TruncatedText(theme.fg("muted", summary), 0, 0));
+		for (const omission of stage === "disclosure" ? [] : profile.omissions) {
+			this.addChild(new TruncatedText(theme.fg("warning", `  ${omission}`), 0, 0));
+		}
+		this.addChild(new Spacer(1));
+		this.#list = new Container();
+		this.addChild(this.#list);
+		this.addChild(new Spacer(1));
+		this.addChild(new TruncatedText(theme.fg("dim", text.controls), 0, 0));
+		this.addChild(new DynamicBorder());
+		this.#updateList();
+		this.#onSelect = onSelect;
+		this.#onCancel = onCancel;
+	}
+
+	#onSelect: (action: FrictionlessOnboardingAction) => void;
+	#onCancel: () => void;
+
+	#updateList(): void {
+		this.#list.clear();
+		this.#options.forEach((option, index) => {
+			const selected = index === this.#selectedIndex;
+			const prefix = selected ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
+			const label = selected ? theme.fg("accent", option.label) : option.label;
+			this.#list.addChild(new TruncatedText(`${prefix}${label}`, 0, 0));
+			if (option.description)
+				this.#list.addChild(new TruncatedText(theme.fg("muted", `    ${option.description}`), 0, 0));
+		});
+	}
+
+	handleInput(keyData: string): void {
+		if (matchesKey(keyData, "up")) {
+			this.#selectedIndex = (this.#selectedIndex + this.#options.length - 1) % this.#options.length;
+			this.#updateList();
+			return;
+		}
+		if (matchesKey(keyData, "down")) {
+			this.#selectedIndex = (this.#selectedIndex + 1) % this.#options.length;
+			this.#updateList();
+			return;
+		}
+		if (matchesKey(keyData, "enter")) {
+			const option = this.#options[this.#selectedIndex];
+			if (option) this.#onSelect(option.action);
+			return;
+		}
+		if (matchesSelectCancel(keyData)) this.#onCancel();
+	}
+}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -131,6 +131,15 @@ import {
 	type ImportableCredential,
 } from "../../setup/credential-import";
 import {
+	analyzeOnboardingEvidence,
+	createManualOnboardingProfile,
+	deriveOnboardingProfile,
+	discoverOnboardingRootPresence,
+	type OnboardingProfile,
+	shouldPersistCompletion,
+	writeOnboardingState,
+} from "../../setup/frictionless-onboarding";
+import {
 	MODEL_ONBOARDING_API_PROVIDER_COMMAND,
 	MODEL_ONBOARDING_PROVIDER_PRESET_COMMAND,
 	MODEL_ONBOARDING_SETUP_COMMAND,
@@ -159,6 +168,11 @@ import {
 import { CustomProviderWizardComponent, type CustomProviderWizardSubmit } from "../components/custom-provider-wizard";
 import { CustomizationDashboard } from "../components/customization";
 import { ExtensionDashboard } from "../components/extensions";
+import {
+	FrictionlessOnboardingSelectorComponent,
+	type FrictionlessOnboardingStage,
+	getFrictionlessOnboardingCopy,
+} from "../components/frictionless-onboarding-selector";
 import type { PetMode } from "../components/gajae-pet-widget";
 import { HistorySearchComponent } from "../components/history-search";
 import { HookSelectorComponent } from "../components/hook-selector";
@@ -1438,15 +1452,10 @@ export class SelectorController {
 			const selector = new ProviderOnboardingSelectorComponent(
 				(action: ProviderOnboardingAction) => {
 					done();
-					if (action === "custom-provider-wizard") {
-						this.showCustomProviderWizard();
-					} else if (action === "oauth-login") {
-						void this.showOAuthSelector("login");
-					} else if (action === "import-credentials") {
-						void this.#handleCredentialImport();
-					} else {
-						this.ctx.showStatus(formatProviderOnboardingCommandGuide());
-					}
+					if (action === "custom-provider-wizard") this.showCustomProviderWizard();
+					else if (action === "oauth-login") void this.showOAuthSelector("login");
+					else if (action === "import-credentials") void this.#handleCredentialImport();
+					else this.ctx.showStatus(formatProviderOnboardingCommandGuide());
 				},
 				() => {
 					done();
@@ -1455,6 +1464,81 @@ export class SelectorController {
 			);
 			return { component: selector, focus: selector };
 		});
+	}
+
+	async showFrictionlessOnboarding(): Promise<void> {
+		const agentDir = this.ctx.session.getSessionAgentDir();
+		const presence = await discoverOnboardingRootPresence();
+		const initialProfile = deriveOnboardingProfile([], {
+			osLocale: Intl.DateTimeFormat().resolvedOptions().locale,
+		});
+
+		const open = (profile: OnboardingProfile, stage: FrictionlessOnboardingStage): void => {
+			const text = getFrictionlessOnboardingCopy(profile.language);
+			this.showSelector(done => {
+				const selector = new FrictionlessOnboardingSelectorComponent(
+					profile,
+					async action => {
+						if (action === "analyze") {
+							const evidence = await analyzeOnboardingEvidence(presence);
+							const analyzed = deriveOnboardingProfile(evidence, {
+								osLocale: Intl.DateTimeFormat().resolvedOptions().locale,
+							});
+							done();
+							open(analyzed, analyzed.operations?.length ? "preview" : "manual");
+							return;
+						}
+						if (action === "manual") {
+							done();
+							open(profile, "manual");
+							return;
+						}
+						const manualIntent =
+							action === "manual-migration" ? "migration" : action === "manual-learn" ? "commands" : undefined;
+						if (manualIntent) {
+							done();
+							open(createManualOnboardingProfile(profile.language, manualIntent), "preview");
+							return;
+						}
+						if (action === "apply") {
+							const operation = profile.operations?.[0];
+							const confirmed = await this.ctx.showHookConfirm(
+								text.confirmTitle,
+								profile.migrationMap.join("\n") || text.noChanges,
+							);
+							done();
+							if (!shouldPersistCompletion(operation, confirmed)) {
+								open(profile, "preview");
+								return;
+							}
+							this.ctx.handleHelpCommand();
+							const saved = await writeOnboardingState({ version: 1, decision: "completed", profile }, agentDir);
+							if (!saved) {
+								this.ctx.showError(text.persistFailed);
+								return;
+							}
+							this.ctx.showStatus(text.completed);
+							return;
+						}
+						if (action === "skip") {
+							const saved = await writeOnboardingState({ version: 1, decision: "skipped" }, agentDir);
+							if (saved) {
+								done();
+								this.ctx.showStatus(text.skipped);
+							} else this.ctx.showError(text.persistFailed);
+							return;
+						}
+						done();
+					},
+					done,
+					profile.language,
+					stage,
+				);
+				return { component: selector, focus: selector };
+			});
+		};
+
+		open(initialProfile, "disclosure");
 	}
 
 	async #handleCredentialImport(): Promise<void> {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2366,6 +2366,9 @@ export class InteractiveMode implements InteractiveModeContext {
 	showProviderOnboarding(): void {
 		this.#selectorController.showProviderOnboarding();
 	}
+	showFrictionlessOnboarding(): Promise<void> {
+		return this.#selectorController.showFrictionlessOnboarding();
+	}
 
 	showPluginSelector(mode?: "install" | "uninstall"): void {
 		void this.#selectorController.showPluginSelector(mode);

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -421,6 +421,7 @@ export interface InteractiveModeContext {
 	setAutoroutingEnabled(enabled: boolean): Promise<void>;
 	showEffortSelector(): void;
 	showProviderOnboarding(): void;
+	showFrictionlessOnboarding(): Promise<void>;
 	showPluginSelector(mode?: "install" | "uninstall"): void;
 	showUserMessageSelector(): void;
 	showTreeSelector(): void;

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -2018,6 +2018,17 @@
 		}
 	},
 	{
+		"sourceId": "slash_command:tutorial",
+		"sourceFile": "packages/coding-agent/src/slash-commands/builtin-registry.ts",
+		"sourceKind": "slash_command",
+		"decision": "exclude",
+		"rationale": "visual/local-only onboarding selector, not a user-facing SDK control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
 		"sourceId": "slash_command:help",
 		"sourceFile": "packages/coding-agent/src/slash-commands/builtin-registry.ts",
 		"sourceKind": "slash_command",

--- a/packages/coding-agent/src/session-import/provider-service.ts
+++ b/packages/coding-agent/src/session-import/provider-service.ts
@@ -55,8 +55,19 @@ interface ParsedSource {
 	redactionKinds: string[];
 }
 
+export interface SessionImportSourceIdentity {
+	dev: bigint;
+	ino: bigint;
+	size: bigint;
+	mtimeNs: bigint;
+	ctimeNs: bigint;
+}
+
 /** Read the explicit source file with fixed bounds. The source is never written. */
-async function readImportSource(sourcePath: string): Promise<{ text: string; bytes: number; sha256: string }> {
+async function readImportSource(
+	sourcePath: string,
+	expectedIdentity?: SessionImportSourceIdentity,
+): Promise<{ text: string; bytes: number; sha256: string }> {
 	const resolved = path.resolve(sourcePath);
 	const displayPath = redactImportedText(sourcePath).value;
 	let handle: fsp.FileHandle;
@@ -76,6 +87,21 @@ async function readImportSource(sourcePath: string): Promise<{ text: string; byt
 	}
 	try {
 		const initial = await handle.stat({ bigint: true });
+		if (
+			expectedIdentity &&
+			(initial.dev !== expectedIdentity.dev ||
+				initial.ino !== expectedIdentity.ino ||
+				initial.size !== expectedIdentity.size ||
+				initial.mtimeNs !== expectedIdentity.mtimeNs ||
+				initial.ctimeNs !== expectedIdentity.ctimeNs)
+		) {
+			throw new SessionImportError(
+				"source_changed",
+				"read",
+				"The transcript path no longer identifies the disclosed source file.",
+				{ retryable: true },
+			);
+		}
 		if (!initial.isFile()) {
 			throw new SessionImportError(
 				"invalid_request",
@@ -266,7 +292,9 @@ function renderImportContext(conversation: ImportedConversation): {
  * session mutation; safe to run before any session transition.
  */
 export async function prepareExternalSessionImport(
-	request: Pick<ExternalSessionImportRequest, "sourcePath" | "provider">,
+	request: Pick<ExternalSessionImportRequest, "sourcePath" | "provider"> & {
+		expectedIdentity?: SessionImportSourceIdentity;
+	},
 ): Promise<PreparedSessionImport> {
 	if (typeof request.sourcePath !== "string" || request.sourcePath.trim().length === 0) {
 		throw new SessionImportError(
@@ -282,7 +310,7 @@ export async function prepareExternalSessionImport(
 			`Unsupported provider "${String(request.provider)}"; expected codex or claude.`,
 		);
 	}
-	const source = await readImportSource(request.sourcePath);
+	const source = await readImportSource(request.sourcePath, request.expectedIdentity);
 	const detection = detectSessionImportFormat(source.text, request.provider);
 	const parsed = parseDetectedFormat(detection, source.text);
 	assertValidTimestamps(parsed.conversation);

--- a/packages/coding-agent/src/setup/frictionless-onboarding.ts
+++ b/packages/coding-agent/src/setup/frictionless-onboarding.ts
@@ -1,0 +1,699 @@
+import type * as nodeFs from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getAgentDir } from "@gajae-code/utils";
+import { withFileLock } from "../config/file-lock";
+import { prepareExternalSessionImport, type SessionImportSourceIdentity } from "../session-import/provider-service";
+
+export type OnboardingDecision = "completed" | "skipped";
+export type OnboardingOperation = "learn-commands";
+
+export interface OnboardingProfile {
+	language: string;
+	sources: string[];
+	workflow: string[];
+	migrationMap: string[];
+	omissions: string[];
+	evidenceCount: number;
+	operations?: OnboardingOperation[];
+}
+
+export interface FrictionlessOnboardingState {
+	version: 1;
+	decision?: OnboardingDecision;
+	profile?: OnboardingProfile;
+}
+
+export interface OnboardingRootPresence {
+	provider: string;
+	present: boolean;
+	unsupported: boolean;
+	activityAt: number;
+	rootPath?: string;
+	rootRealPath?: string;
+	installedCliActivityAt: number;
+	rootIdentity?: SessionImportSourceIdentity;
+}
+
+export interface OnboardingEvidence {
+	provider: string;
+	activityAt: number;
+	signals: string[];
+	userMessages?: string[];
+	sessionCount?: number;
+	omittedSessions?: number;
+	workflowCategories?: string[];
+}
+
+const ROOTS = ["codex", "claude", "opencode", "omp", "omo"] as const;
+export const NINETY_DAYS = 90 * 24 * 60 * 60 * 1000;
+const MAX_ARRAY_ITEMS = 16;
+const MAX_STATE_BYTES = 64 * 1024;
+const MAX_DISCOVERY_ENTRIES = 512;
+const MAX_SESSION_CANDIDATES = 4;
+const MAX_STRING_LENGTH = 500;
+const LANGUAGES: Record<string, string[]> = {
+	en: ["the", "and", "please", "file", "change", "help"],
+	ko: ["을", "를", "그리고", "파일", "변경", "도와"],
+	ja: ["を", "そして", "ファイル", "変更", "お願い"],
+	zh: ["请", "文件", "修改", "帮助"],
+	es: ["el", "la", "por", "favor", "archivo", "cambio"],
+	fr: ["le", "la", "fichier", "merci", "modifier"],
+	de: ["der", "die", "datei", "bitte", "ändern"],
+};
+
+export function onboardingStatePath(agentDir = getAgentDir()): string {
+	return path.join(agentDir, "onboarding", "frictionless.json");
+}
+
+function boundedStringArray(value: unknown): string[] | undefined {
+	if (!Array.isArray(value) || value.length > MAX_ARRAY_ITEMS) return undefined;
+	if (!value.every(item => typeof item === "string" && item.length <= MAX_STRING_LENGTH)) return undefined;
+	return [...value];
+}
+
+function validProfile(value: unknown): value is OnboardingProfile {
+	if (!value || typeof value !== "object") return false;
+	const profile = value as Record<string, unknown>;
+	const sources = boundedStringArray(profile.sources);
+	const workflow = boundedStringArray(profile.workflow);
+	const migrationMap = boundedStringArray(profile.migrationMap);
+	const omissions = boundedStringArray(profile.omissions);
+	const operations = boundedStringArray(profile.operations);
+	return (
+		typeof profile.language === "string" &&
+		profile.language.length <= 16 &&
+		sources !== undefined &&
+		workflow !== undefined &&
+		migrationMap !== undefined &&
+		omissions !== undefined &&
+		(typeof profile.operations === "undefined" ||
+			operations?.every(operation => operation === "learn-commands") === true) &&
+		typeof profile.evidenceCount === "number" &&
+		Number.isInteger(profile.evidenceCount) &&
+		profile.evidenceCount >= 0 &&
+		profile.evidenceCount <= MAX_ARRAY_ITEMS
+	);
+}
+
+export function projectOnboardingState(value: unknown): FrictionlessOnboardingState {
+	if (!value || typeof value !== "object") return { version: 1 };
+	const input = value as Record<string, unknown>;
+	const decision = input.decision === "completed" || input.decision === "skipped" ? input.decision : undefined;
+	if (!validProfile(input.profile)) return { version: 1, ...(decision ? { decision } : {}) };
+	const profile = input.profile;
+	return {
+		version: 1,
+		...(decision ? { decision } : {}),
+		profile: {
+			language: profile.language,
+			sources: [...profile.sources],
+			workflow: [...profile.workflow],
+			migrationMap: [...profile.migrationMap],
+			omissions: [...profile.omissions],
+			evidenceCount: profile.evidenceCount,
+			...(profile.operations ? { operations: [...profile.operations] } : {}),
+		},
+	};
+}
+
+export async function readOnboardingState(agentDir = getAgentDir()): Promise<FrictionlessOnboardingState> {
+	try {
+		const statePath = onboardingStatePath(agentDir);
+		const stat = await fs.lstat(statePath);
+		if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_STATE_BYTES) return { version: 1 };
+		return projectOnboardingState(JSON.parse(await Bun.file(statePath).text()));
+	} catch {
+		return { version: 1 };
+	}
+}
+
+export async function writeOnboardingState(value: unknown, agentDir = getAgentDir()): Promise<boolean> {
+	const target = onboardingStatePath(agentDir);
+	const temporary = `${target}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
+	try {
+		await fs.mkdir(path.dirname(target), { recursive: true, mode: 0o700 });
+		await withFileLock(target, async () => {
+			const handle = await fs.open(temporary, "wx", 0o600);
+			try {
+				await handle.close();
+				await Bun.write(temporary, `${JSON.stringify(projectOnboardingState(value))}\n`);
+				await fs.chmod(temporary, 0o600);
+				await fs.rename(temporary, target);
+				await fs.chmod(target, 0o600);
+			} finally {
+				try {
+					await handle.close();
+				} catch {
+					// The descriptor is already closed in the normal path.
+				}
+			}
+		});
+		return true;
+	} catch {
+		try {
+			await fs.unlink(temporary);
+		} catch {
+			// Best-effort cleanup only.
+		}
+		return false;
+	}
+}
+
+function localeLanguage(locale = Intl.DateTimeFormat().resolvedOptions().locale): string {
+	const code = locale.split(/[-_]/)[0]?.toLowerCase();
+	return code && Object.hasOwn(LANGUAGES, code) ? code : "en";
+}
+
+export function detectOnboardingLanguage(messages: readonly string[], osLocale?: string): string {
+	const counts = new Map<string, number>();
+	for (const message of messages.slice(-MAX_ARRAY_ITEMS)) {
+		const normalized = message.toLowerCase();
+		for (const [language, words] of Object.entries(LANGUAGES)) {
+			const score = words.reduce((sum, word) => sum + (normalized.includes(word) ? 1 : 0), 0);
+			if (score) counts.set(language, (counts.get(language) ?? 0) + score);
+		}
+	}
+	const winner = [...counts.entries()].sort((left, right) => right[1] - left[1])[0];
+	return winner && winner[1] >= 2 ? winner[0] : localeLanguage(osLocale);
+}
+
+function sourceIdentity(stat: nodeFs.BigIntStats): SessionImportSourceIdentity {
+	return { dev: stat.dev, ino: stat.ino, size: stat.size, mtimeNs: stat.mtimeNs, ctimeNs: stat.ctimeNs };
+}
+
+function sameSourceIdentity(left: SessionImportSourceIdentity, right: SessionImportSourceIdentity): boolean {
+	return (
+		left.dev === right.dev &&
+		left.ino === right.ino &&
+		left.size === right.size &&
+		left.mtimeNs === right.mtimeNs &&
+		left.ctimeNs === right.ctimeNs
+	);
+}
+
+async function collectSessionCandidates(
+	rootPath: string,
+	rootRealPath: string,
+	provider: "codex" | "claude",
+	openDirectory: typeof fs.opendir,
+): Promise<{ candidates: Array<{ path: string; identity: SessionImportSourceIdentity }>; omittedEntries: number }> {
+	const start = path.join(rootPath, provider === "codex" ? "sessions" : "projects");
+	const maxDepth = provider === "codex" ? 5 : 3;
+	const queue: Array<{ directory: string; depth: number }> = [{ directory: start, depth: 0 }];
+	const candidates: Array<{ path: string; mtimeMs: number; identity: SessionImportSourceIdentity }> = [];
+	let inspected = 0;
+	let omittedEntries = 0;
+
+	while (queue.length > 0 && inspected < MAX_DISCOVERY_ENTRIES) {
+		const current = queue.shift()!;
+		let directory: nodeFs.Dir;
+		try {
+			const identityBefore = await fs.lstat(current.directory, { bigint: true });
+			const realPath = await fs.realpath(current.directory);
+			const identityAfter = await fs.lstat(current.directory, { bigint: true });
+			if (
+				!identityBefore.isDirectory() ||
+				identityBefore.isSymbolicLink() ||
+				!sameSourceIdentity(identityBefore, identityAfter) ||
+				!isWithinRoot(realPath, rootRealPath)
+			) {
+				omittedEntries++;
+				continue;
+			}
+			directory = await openDirectory(current.directory);
+		} catch (error) {
+			if (shouldCountOnboardingDirectoryFailure(error, current.depth)) omittedEntries++;
+			continue;
+		}
+		try {
+			for await (const entry of directory) {
+				if (++inspected > MAX_DISCOVERY_ENTRIES) {
+					omittedEntries++;
+					break;
+				}
+				const entryPath = path.join(current.directory, entry.name);
+				try {
+					const identityBefore = await fs.lstat(entryPath, { bigint: true });
+					const realPath = await fs.realpath(entryPath);
+					const identityAfter = await fs.lstat(entryPath, { bigint: true });
+					if (
+						identityBefore.isSymbolicLink() ||
+						!sameSourceIdentity(identityBefore, identityAfter) ||
+						!isWithinRoot(realPath, rootRealPath)
+					) {
+						omittedEntries++;
+						continue;
+					}
+					if (identityAfter.isDirectory() && current.depth < maxDepth) {
+						queue.push({ directory: entryPath, depth: current.depth + 1 });
+					} else if (identityAfter.isFile() && entry.name.endsWith(".jsonl")) {
+						candidates.push({
+							path: entryPath,
+							mtimeMs: Number(identityAfter.mtimeMs),
+							identity: sourceIdentity(identityAfter),
+						});
+					}
+				} catch {
+					omittedEntries++;
+				}
+			}
+		} catch {
+			omittedEntries++;
+		} finally {
+			await directory.close().catch(() => {});
+		}
+	}
+
+	return {
+		candidates: candidates
+			.sort((left, right) => right.mtimeMs - left.mtimeMs)
+			.slice(0, MAX_SESSION_CANDIDATES)
+			.map(candidate => ({ path: candidate.path, identity: candidate.identity })),
+		omittedEntries,
+	};
+}
+
+function isWithinRoot(candidate: string, root: string): boolean {
+	const relative = path.relative(root, candidate);
+	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+export function shouldCountOnboardingDirectoryFailure(error: unknown, depth: number): boolean {
+	return depth > 0 || (error as NodeJS.ErrnoException).code !== "ENOENT";
+}
+
+async function installedCliActivityAt(provider: string): Promise<number> {
+	const executablePath = Bun.which(provider);
+	if (!executablePath) return 0;
+	try {
+		return (await fs.stat(executablePath)).mtimeMs;
+	} catch {
+		return 0;
+	}
+}
+
+export async function discoverOnboardingRootPresence(
+	options: { home?: string } = {},
+): Promise<OnboardingRootPresence[]> {
+	const home = options.home ?? os.homedir();
+	const result: OnboardingRootPresence[] = [];
+	for (const provider of ROOTS) {
+		const rootPath = path.join(home, `.${provider}`);
+		const cliActivityAt = await installedCliActivityAt(provider);
+		try {
+			const identityBefore = await fs.lstat(rootPath, { bigint: true });
+			const rootRealPath = await fs.realpath(rootPath);
+			const identityAfter = await fs.lstat(rootPath, { bigint: true });
+			const safeDirectory =
+				identityBefore.isDirectory() &&
+				!identityBefore.isSymbolicLink() &&
+				sameSourceIdentity(identityBefore, identityAfter);
+			result.push({
+				provider,
+				present: safeDirectory,
+				unsupported: safeDirectory && provider !== "codex" && provider !== "claude",
+				activityAt: safeDirectory ? Number(identityAfter.mtimeMs) : 0,
+				installedCliActivityAt: cliActivityAt,
+				...(safeDirectory ? { rootPath, rootRealPath, rootIdentity: sourceIdentity(identityAfter) } : {}),
+			});
+		} catch {
+			result.push({
+				provider,
+				present: false,
+				unsupported: false,
+				activityAt: 0,
+				installedCliActivityAt: cliActivityAt,
+			});
+		}
+	}
+	return result;
+}
+
+function classifyWorkflow(text: string): string[] {
+	const normalized = text.toLowerCase();
+	const categories: string[] = [];
+	if (/\b(test|tests|spec|coverage|verify|qa)\b/u.test(normalized)) categories.push("testing");
+	if (/\b(bug|fix|error|failure|debug|crash)\b/u.test(normalized)) categories.push("debugging");
+	if (/\b(refactor|cleanup|simplify|rename|extract)\b/u.test(normalized)) categories.push("refactoring");
+	if (/\b(git|commit|branch|pull request|pr|review)\b/u.test(normalized)) categories.push("version-control");
+	if (/\b(doc|docs|readme|documentation)\b/u.test(normalized)) categories.push("documentation");
+	if (/\b(model|provider|config|configure|setup|install)\b/u.test(normalized)) categories.push("configuration");
+	return categories;
+}
+
+export interface AnalyzeOnboardingEvidenceOptions {
+	now?: number;
+	openDirectory?: typeof fs.opendir;
+}
+
+export async function analyzeOnboardingEvidence(
+	presence: readonly OnboardingRootPresence[],
+	options: AnalyzeOnboardingEvidenceOptions = {},
+): Promise<OnboardingEvidence[]> {
+	const now = options.now ?? Date.now();
+	const openDirectory = options.openDirectory ?? fs.opendir;
+	const evidence: OnboardingEvidence[] = [];
+	for (const root of presence) {
+		if (!root.present) {
+			evidence.push({ provider: root.provider, activityAt: 0, signals: ["missing"] });
+			continue;
+		}
+		if (root.unsupported) {
+			evidence.push({ provider: root.provider, activityAt: root.activityAt, signals: ["unsupported"] });
+			continue;
+		}
+		if (!root.rootPath || !root.rootRealPath || !root.rootIdentity) {
+			evidence.push({ provider: root.provider, activityAt: root.activityAt, signals: ["unavailable"] });
+			continue;
+		}
+		try {
+			const identityBefore = await fs.lstat(root.rootPath, { bigint: true });
+			const currentRealPath = await fs.realpath(root.rootPath);
+			const identityAfter = await fs.lstat(root.rootPath, { bigint: true });
+			if (
+				!identityBefore.isDirectory() ||
+				identityBefore.isSymbolicLink() ||
+				!sameSourceIdentity(identityBefore, identityAfter) ||
+				!sameSourceIdentity(identityAfter, root.rootIdentity) ||
+				currentRealPath !== root.rootRealPath
+			) {
+				evidence.push({ provider: root.provider, activityAt: root.activityAt, signals: ["unavailable"] });
+				continue;
+			}
+		} catch {
+			evidence.push({ provider: root.provider, activityAt: root.activityAt, signals: ["unavailable"] });
+			continue;
+		}
+
+		const provider = root.provider as "codex" | "claude";
+		const discovery = await collectSessionCandidates(root.rootPath, root.rootRealPath, provider, openDirectory);
+		const candidates = discovery.candidates;
+		const userMessages: string[] = [];
+		const workflowCategories = new Set<string>();
+		let sessionCount = 0;
+		let omittedSessions = discovery.omittedEntries;
+		let activityAt = 0;
+		for (const candidate of candidates) {
+			try {
+				const prepared = await prepareExternalSessionImport({
+					sourcePath: candidate.path,
+					provider,
+					expectedIdentity: candidate.identity,
+				});
+				sessionCount++;
+				activityAt = Math.max(activityAt, Date.parse(prepared.conversation.messages.at(-1)?.timestamp ?? "") || 0);
+				for (let index = prepared.conversation.messages.length - 1; index >= 0; index--) {
+					const message = prepared.conversation.messages[index]!;
+					if (message.role !== "user") continue;
+					for (const category of classifyWorkflow(message.text)) workflowCategories.add(category);
+					const messageAge = now - Date.parse(message.timestamp ?? "");
+					if (messageAge >= 0 && messageAge <= NINETY_DAYS && userMessages.length < MAX_ARRAY_ITEMS) {
+						userMessages.unshift(message.text.slice(0, MAX_STRING_LENGTH));
+					}
+				}
+			} catch {
+				omittedSessions++;
+			}
+		}
+		if (sessionCount > 0) {
+			evidence.push({
+				provider,
+				activityAt,
+				signals: ["supported-session"],
+				sessionCount,
+				...(omittedSessions > 0 ? { omittedSessions } : {}),
+				...(workflowCategories.size > 0
+					? { workflowCategories: [...workflowCategories].slice(0, MAX_ARRAY_ITEMS) }
+					: {}),
+				...(userMessages.length > 0 ? { userMessages } : {}),
+			});
+		} else if (candidates.length > 0 || omittedSessions > 0) {
+			evidence.push({ provider, activityAt: root.activityAt, signals: ["unavailable"], omittedSessions });
+		} else {
+			const rootAge = now - root.activityAt;
+			const cliAge = now - root.installedCliActivityAt;
+			if (rootAge >= 0 && rootAge <= NINETY_DAYS) {
+				evidence.push({
+					provider,
+					activityAt: root.activityAt,
+					signals: ["agent-root", ...(cliAge >= 0 && cliAge <= NINETY_DAYS ? ["installed-cli"] : [])],
+				});
+			} else evidence.push({ provider, activityAt: root.activityAt, signals: ["stale"] });
+		}
+	}
+	return evidence;
+}
+
+export interface DeriveOnboardingProfileOptions {
+	now?: number;
+	osLocale?: string;
+}
+
+interface OnboardingProfileText {
+	categories: Record<string, string>;
+	mapping: string;
+	missing: string;
+	unsupported: string;
+	stale: string;
+	unavailable: string;
+	partial: string;
+	manualMigration: string;
+	manualCommands: string;
+}
+
+const PROFILE_TEXT: Record<string, OnboardingProfileText> = {
+	en: {
+		categories: {
+			testing: "Testing and verification",
+			debugging: "Debugging and fixes",
+			refactoring: "Refactoring and cleanup",
+			"version-control": "Git and code review",
+			documentation: "Documentation",
+			configuration: "Provider and project configuration",
+			general: "General coding assistance",
+		},
+		mapping: "use GJC's matching commands, tools, and review flow",
+		missing: "source unavailable",
+		unsupported: "source is present but unsupported",
+		stale: "source is stale",
+		unavailable: "analysis unavailable",
+		partial: "session files were safely omitted",
+		manualMigration: "Map my existing workflow to GJC",
+		manualCommands: "Open the GJC command guide",
+	},
+	ko: {
+		categories: {
+			testing: "테스트 및 검증",
+			debugging: "디버깅 및 수정",
+			refactoring: "리팩터링 및 정리",
+			"version-control": "Git 및 코드 리뷰",
+			documentation: "문서화",
+			configuration: "프로바이더 및 프로젝트 설정",
+			general: "일반 코딩 지원",
+		},
+		mapping: "GJC의 관련 명령, 도구 및 리뷰 흐름 사용",
+		missing: "소스를 찾을 수 없음",
+		unsupported: "소스가 있지만 지원되지 않음",
+		stale: "소스가 오래됨",
+		unavailable: "분석할 수 없음",
+		partial: "세션 파일을 안전하게 제외함",
+		manualMigration: "기존 워크플로를 GJC에 매핑",
+		manualCommands: "GJC 명령 안내 열기",
+	},
+	ja: {
+		categories: {
+			testing: "テストと検証",
+			debugging: "デバッグと修正",
+			refactoring: "リファクタリングと整理",
+			"version-control": "Gitとコードレビュー",
+			documentation: "ドキュメント",
+			configuration: "プロバイダーとプロジェクト設定",
+			general: "一般的なコーディング支援",
+		},
+		mapping: "対応するGJCコマンド、ツール、レビューフローを使う",
+		missing: "ソースがありません",
+		unsupported: "ソースは存在しますが未対応です",
+		stale: "ソースが古すぎます",
+		unavailable: "分析できません",
+		partial: "セッションファイルを安全に除外しました",
+		manualMigration: "既存ワークフローをGJCに対応付ける",
+		manualCommands: "GJCコマンドガイドを開く",
+	},
+	zh: {
+		categories: {
+			testing: "测试与验证",
+			debugging: "调试与修复",
+			refactoring: "重构与清理",
+			"version-control": "Git 与代码审查",
+			documentation: "文档",
+			configuration: "提供商与项目配置",
+			general: "通用编码协助",
+		},
+		mapping: "使用 GJC 中对应的命令、工具和审查流程",
+		missing: "来源不可用",
+		unsupported: "来源存在但不受支持",
+		stale: "来源已过期",
+		unavailable: "无法分析",
+		partial: "已安全省略会话文件",
+		manualMigration: "将现有工作流映射到 GJC",
+		manualCommands: "打开 GJC 命令指南",
+	},
+	es: {
+		categories: {
+			testing: "Pruebas y verificación",
+			debugging: "Depuración y correcciones",
+			refactoring: "Refactorización y limpieza",
+			"version-control": "Git y revisión de código",
+			documentation: "Documentación",
+			configuration: "Configuración de proveedores y proyectos",
+			general: "Asistencia general de código",
+		},
+		mapping: "usar los comandos, herramientas y revisiones equivalentes de GJC",
+		missing: "fuente no disponible",
+		unsupported: "fuente presente pero no compatible",
+		stale: "fuente obsoleta",
+		unavailable: "análisis no disponible",
+		partial: "archivos de sesión omitidos de forma segura",
+		manualMigration: "Adaptar mi flujo existente a GJC",
+		manualCommands: "Abrir la guía de comandos de GJC",
+	},
+	fr: {
+		categories: {
+			testing: "Tests et vérification",
+			debugging: "Débogage et corrections",
+			refactoring: "Refactorisation et nettoyage",
+			"version-control": "Git et revue de code",
+			documentation: "Documentation",
+			configuration: "Configuration des fournisseurs et projets",
+			general: "Assistance générale au code",
+		},
+		mapping: "utiliser les commandes, outils et revues GJC correspondants",
+		missing: "source indisponible",
+		unsupported: "source présente mais non prise en charge",
+		stale: "source trop ancienne",
+		unavailable: "analyse indisponible",
+		partial: "fichiers de session omis en toute sécurité",
+		manualMigration: "Adapter mon workflow existant à GJC",
+		manualCommands: "Ouvrir le guide des commandes GJC",
+	},
+	de: {
+		categories: {
+			testing: "Tests und Verifikation",
+			debugging: "Debugging und Fehlerbehebung",
+			refactoring: "Refactoring und Bereinigung",
+			"version-control": "Git und Code-Review",
+			documentation: "Dokumentation",
+			configuration: "Provider- und Projektkonfiguration",
+			general: "Allgemeine Coding-Unterstützung",
+		},
+		mapping: "passende GJC-Befehle, Werkzeuge und Review-Abläufe nutzen",
+		missing: "Quelle nicht verfügbar",
+		unsupported: "Quelle vorhanden, aber nicht unterstützt",
+		stale: "Quelle ist veraltet",
+		unavailable: "Analyse nicht verfügbar",
+		partial: "Sitzungsdateien sicher ausgelassen",
+		manualMigration: "Meinen bestehenden Workflow auf GJC abbilden",
+		manualCommands: "GJC-Befehlsübersicht öffnen",
+	},
+};
+
+export function deriveOnboardingProfile(
+	evidence: readonly OnboardingEvidence[],
+	options: DeriveOnboardingProfileOptions = {},
+): OnboardingProfile {
+	const now = options.now ?? Date.now();
+	const sessionEvidence = evidence.filter(item => item.signals.includes("supported-session"));
+	const fallbackEvidence = evidence.filter(item => {
+		const age = now - item.activityAt;
+		return age >= 0 && age <= NINETY_DAYS && item.signals.includes("agent-root");
+	});
+	const usable =
+		sessionEvidence.length > 0
+			? sessionEvidence
+			: hasCorroboratedRecentEvidence(evidence, now)
+				? fallbackEvidence
+				: [];
+	const language = detectOnboardingLanguage(
+		sessionEvidence.flatMap(item => item.userMessages ?? []),
+		options.osLocale,
+	);
+	const text = PROFILE_TEXT[language] ?? PROFILE_TEXT.en!;
+	const omissions = evidence
+		.filter(item => !usable.includes(item))
+		.map(item => {
+			if (item.signals.includes("missing")) return `${item.provider}: ${text.missing}.`;
+			if (item.signals.includes("unsupported")) return `${item.provider}: ${text.unsupported}.`;
+			if (item.signals.includes("stale")) return `${item.provider}: ${text.stale}.`;
+			return `${item.provider}: ${text.unavailable}.`;
+		});
+	for (const item of usable) {
+		if (item.omittedSessions) omissions.push(`${item.provider}: ${item.omittedSessions} ${text.partial}.`);
+	}
+	const sources = usable.map(item => item.provider);
+	const categories = [...new Set(usable.flatMap(item => item.workflowCategories ?? []))];
+	if (sources.length > 0 && categories.length === 0) categories.push("general");
+	const workflow = categories.map(category => text.categories[category] ?? text.categories.general!);
+	return {
+		language,
+		sources,
+		workflow,
+		migrationMap: sources
+			.flatMap(source => workflow.map(item => `${source}: ${item} → ${text.mapping}`))
+			.slice(0, MAX_ARRAY_ITEMS),
+		omissions,
+		evidenceCount: sources.length,
+		operations: sources.length ? ["learn-commands"] : [],
+	};
+}
+
+export function createManualOnboardingProfile(language: string, intent: "migration" | "commands"): OnboardingProfile {
+	const text = PROFILE_TEXT[language] ?? PROFILE_TEXT.en!;
+	const label = intent === "migration" ? text.manualMigration : text.manualCommands;
+	return {
+		language,
+		sources: ["manual"],
+		workflow: [label],
+		migrationMap: [`manual → ${label}`],
+		omissions: [],
+		evidenceCount: 1,
+		operations: ["learn-commands"],
+	};
+}
+
+export function hasCorroboratedRecentEvidence(evidence: readonly OnboardingEvidence[], now = Date.now()): boolean {
+	const recent = evidence.filter(item => {
+		const age = now - item.activityAt;
+		return age >= 0 && age <= NINETY_DAYS && item.signals.includes("agent-root");
+	});
+	const providers = new Set(recent.map(item => item.provider));
+	const signalFamilies = new Set(recent.flatMap(item => item.signals));
+	return providers.size >= 2 && signalFamilies.has("agent-root") && signalFamilies.has("installed-cli");
+}
+
+export function shouldOfferOnboarding(state: FrictionlessOnboardingState): boolean {
+	return state.decision === undefined;
+}
+
+export interface AutomaticOnboardingInput {
+	normalInteractive: boolean;
+	initialMessage?: string;
+	initialMessages: readonly string[];
+	initialImages?: readonly unknown[];
+	resumeAction?: string;
+}
+
+export function shouldOfferAutomaticOnboarding(input: AutomaticOnboardingInput): boolean {
+	return (
+		input.normalInteractive &&
+		!input.initialMessage &&
+		input.initialMessages.length === 0 &&
+		(input.initialImages?.length ?? 0) === 0 &&
+		input.resumeAction === undefined
+	);
+}
+
+export function shouldPersistCompletion(operation: OnboardingOperation | undefined, confirmed: boolean): boolean {
+	return confirmed && operation !== undefined;
+}

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1482,6 +1482,15 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "tutorial",
+		priority: 99,
+		description: "Open frictionless onboarding",
+		handleTui: (_command, runtime) => {
+			void runtime.ctx.showFrictionlessOnboarding();
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
 		name: "help",
 		priority: 100,
 		description: "Learn commands and beginner workflows",

--- a/packages/coding-agent/test/frictionless-onboarding.test.ts
+++ b/packages/coding-agent/test/frictionless-onboarding.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getFrictionlessOnboardingCopy } from "../src/modes/components/frictionless-onboarding-selector";
+import {
+	analyzeOnboardingEvidence,
+	createManualOnboardingProfile,
+	deriveOnboardingProfile,
+	detectOnboardingLanguage,
+	discoverOnboardingRootPresence,
+	hasCorroboratedRecentEvidence,
+	NINETY_DAYS,
+	projectOnboardingState,
+	readOnboardingState,
+	shouldCountOnboardingDirectoryFailure,
+	shouldOfferAutomaticOnboarding,
+	shouldPersistCompletion,
+	writeOnboardingState,
+} from "../src/setup/frictionless-onboarding";
+import { executeBuiltinSlashCommand, lookupBuiltinSlashCommand } from "../src/slash-commands/builtin-registry";
+
+describe("frictionless onboarding", () => {
+	test("projects only validated state fields", () => {
+		const state = projectOnboardingState({
+			version: 99,
+			decision: "bad",
+			roots: ["/private"],
+			profile: {
+				language: "en",
+				sources: ["codex"],
+				workflow: [],
+				migrationMap: [],
+				omissions: [],
+				evidenceCount: 1,
+				messages: ["secret"],
+			},
+		});
+		expect(state.decision).toBeUndefined();
+		expect(state.profile).toBeDefined();
+		expect(JSON.stringify(state)).not.toContain("secret");
+	});
+
+	test("writes readable state and survives malformed input", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-onboarding-"));
+		expect(
+			await writeOnboardingState(
+				{
+					version: 1,
+					decision: "completed",
+					profile: {
+						language: "en",
+						sources: [],
+						workflow: [],
+						migrationMap: [],
+						omissions: [],
+						evidenceCount: 0,
+					},
+				},
+				dir,
+			),
+		).toBe(true);
+		expect((await readOnboardingState(dir)).decision).toBe("completed");
+		await fs.rm(dir, { recursive: true, force: true });
+	});
+
+	test("requires two providers and two signal families", () => {
+		const now = 1_000_000;
+		const evidence = [
+			{ provider: "codex", activityAt: now, signals: ["agent-root", "installed-cli"] },
+			{ provider: "claude", activityAt: now, signals: ["agent-root"] },
+		];
+		expect(hasCorroboratedRecentEvidence(evidence, now)).toBe(true);
+		expect(hasCorroboratedRecentEvidence([evidence[0]], now)).toBe(false);
+		expect(
+			hasCorroboratedRecentEvidence(
+				evidence.map(item => ({ ...item, activityAt: now - NINETY_DAYS - 1 })),
+				now,
+			),
+		).toBe(false);
+		expect(
+			hasCorroboratedRecentEvidence(
+				evidence.map(item => ({ ...item, activityAt: now + 1 })),
+				now,
+			),
+		).toBe(false);
+		expect(
+			hasCorroboratedRecentEvidence(
+				evidence.map(item => ({ ...item, signals: ["agent-root"] })),
+				now,
+			),
+		).toBe(false);
+	});
+
+	test("language prefers dominant messages then locale", () => {
+		expect(detectOnboardingLanguage(["파일 변경을 도와주세요", "파일을 변경해주세요"], "en-US")).toBe("ko");
+		expect(detectOnboardingLanguage([], "fr-FR")).toBe("fr");
+	});
+
+	test("profile derivation accepts injected time", () => {
+		const profile = deriveOnboardingProfile(
+			[
+				{ provider: "codex", activityAt: 1000, signals: ["supported-session"], sessionCount: 1 },
+				{ provider: "claude", activityAt: 1000, signals: ["supported-session"], sessionCount: 1 },
+			],
+			{ now: 1000, osLocale: "en-US" },
+		);
+		expect(profile.sources).toEqual(["codex", "claude"]);
+	});
+
+	test("uses one safely parsed supported session without fallback corroboration", async () => {
+		const home = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-onboarding-session-"));
+		const sessions = path.join(home, ".codex", "sessions", "2026");
+		await fs.mkdir(sessions, { recursive: true });
+		const transcript = [
+			JSON.stringify({
+				timestamp: "2026-08-22T10:00:00.000Z",
+				type: "session_meta",
+				payload: { id: "session-1", cwd: home, timestamp: "2026-08-22T10:00:00.000Z" },
+			}),
+			JSON.stringify({
+				timestamp: "2026-08-22T10:00:30.000Z",
+				type: "response_item",
+				payload: {
+					type: "message",
+					role: "user",
+					content: [{ type: "input_text", text: "Please fix this bug and add tests" }],
+				},
+			}),
+			JSON.stringify({
+				timestamp: "2026-08-22T10:01:00.000Z",
+				type: "response_item",
+				payload: {
+					type: "message",
+					role: "user",
+					content: [{ type: "input_text", text: "파일 변경을 도와주세요" }],
+				},
+			}),
+		].join("\n");
+		await Bun.write(path.join(sessions, "session-1.jsonl"), `${transcript}\n`);
+		await Bun.write(path.join(sessions, "malformed.jsonl"), "not-json\n");
+		const presence = await discoverOnboardingRootPresence({ home });
+		const evidence = await analyzeOnboardingEvidence(presence, { now: Date.parse("2026-08-23T00:00:00.000Z") });
+		const codex = evidence.find(item => item.provider === "codex");
+		expect(codex).toMatchObject({
+			signals: ["supported-session"],
+			sessionCount: 1,
+			omittedSessions: 1,
+			workflowCategories: ["testing", "debugging"],
+		});
+		const profile = deriveOnboardingProfile(evidence, {
+			now: Date.parse("2026-08-23T00:00:00.000Z"),
+			osLocale: "en-US",
+		});
+		expect(profile.sources).toEqual(["codex"]);
+		expect(profile.language).toBe("ko");
+		expect(profile.workflow).toEqual(["테스트 및 검증", "디버깅 및 수정"]);
+		expect(profile.omissions.some(item => item.includes("1 세션 파일을 안전하게 제외함"))).toBe(true);
+		await fs.rm(home, { recursive: true, force: true });
+	});
+
+	test("startup gate excludes input, images, and resume", () => {
+		expect(
+			shouldOfferAutomaticOnboarding({
+				normalInteractive: true,
+				initialMessage: undefined,
+				initialMessages: [],
+				resumeAction: undefined,
+			}),
+		).toBe(true);
+		expect(
+			shouldOfferAutomaticOnboarding({
+				normalInteractive: true,
+				initialMessage: "hi",
+				initialMessages: [],
+				resumeAction: undefined,
+			}),
+		).toBe(false);
+		expect(
+			shouldOfferAutomaticOnboarding({
+				normalInteractive: true,
+				initialMessage: undefined,
+				initialMessages: [],
+				initialImages: [{}],
+				resumeAction: undefined,
+			}),
+		).toBe(false);
+	});
+
+	test("rejects oversized persisted arrays", () => {
+		const state = projectOnboardingState({
+			version: 1,
+			decision: "completed",
+			profile: {
+				language: "en",
+				sources: Array.from({ length: 17 }, (_, index) => `source-${index}`),
+				workflow: [],
+				migrationMap: [],
+				omissions: [],
+				evidenceCount: 17,
+			},
+		});
+		expect(state.profile).toBeUndefined();
+	});
+
+	test("rejects symlinked roots and marks unsupported real roots", async () => {
+		const home = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-onboarding-home-"));
+		const external = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-onboarding-external-"));
+		await fs.symlink(external, path.join(home, ".codex"));
+		await fs.mkdir(path.join(home, ".claude"));
+		await fs.mkdir(path.join(home, ".opencode"));
+		const presence = await discoverOnboardingRootPresence({ home });
+		expect(presence.find(item => item.provider === "codex")?.present).toBe(false);
+		expect(presence.find(item => item.provider === "claude")).toMatchObject({ present: true, unsupported: false });
+		expect(presence.find(item => item.provider === "opencode")).toMatchObject({ present: true, unsupported: true });
+		await fs.rm(home, { recursive: true, force: true });
+		await fs.rm(external, { recursive: true, force: true });
+	});
+
+	test("rejects a provider root replaced after disclosure", async () => {
+		const home = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-onboarding-root-swap-"));
+		const original = path.join(home, ".codex");
+		const outside = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-onboarding-root-outside-"));
+		await fs.mkdir(original);
+		const presence = await discoverOnboardingRootPresence({ home });
+		await fs.rename(original, path.join(home, ".codex-original"));
+		await fs.symlink(outside, original);
+		const evidence = await analyzeOnboardingEvidence(presence);
+		expect(evidence.find(item => item.provider === "codex")?.signals).toEqual(["unavailable"]);
+		await fs.rm(home, { recursive: true, force: true });
+		await fs.rm(outside, { recursive: true, force: true });
+	});
+
+	test("treats depth-zero EACCES as unavailable instead of metadata fallback", async () => {
+		const home = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-onboarding-eacces-"));
+		const sessions = path.join(home, ".codex", "sessions");
+		await fs.mkdir(sessions, { recursive: true });
+		const presence = await discoverOnboardingRootPresence({ home });
+		const permissionError = Object.assign(new Error("permission denied"), { code: "EACCES" });
+		const evidence = await analyzeOnboardingEvidence(presence, {
+			openDirectory: async directoryPath => {
+				if (path.resolve(directoryPath.toString()) === path.resolve(sessions)) throw permissionError;
+				return fs.opendir(directoryPath);
+			},
+		});
+		expect(shouldCountOnboardingDirectoryFailure(permissionError, 0)).toBe(true);
+		expect(shouldCountOnboardingDirectoryFailure(Object.assign(new Error(), { code: "ENOENT" }), 0)).toBe(false);
+		expect(evidence.find(item => item.provider === "codex")).toMatchObject({
+			signals: ["unavailable"],
+			omittedSessions: 1,
+		});
+		await fs.rm(home, { recursive: true, force: true });
+	});
+
+	test("falls back to English and presents a direct privacy-bounded question", () => {
+		expect(detectOnboardingLanguage([], "xx-YY")).toBe("en");
+		const copy = getFrictionlessOnboardingCopy("xx");
+		expect(copy.title).toBe("Frictionless onboarding");
+		expect(copy.manual.endsWith("?")).toBe(true);
+		expect(copy.disclosure).toContain("only the derived profile and completion state are retained");
+	});
+
+	test("builds each manual answer as previewable command guidance", () => {
+		expect(createManualOnboardingProfile("en", "migration")).toMatchObject({
+			workflow: ["Map my existing workflow to GJC"],
+			operations: ["learn-commands"],
+		});
+		expect(createManualOnboardingProfile("en", "commands").operations).toEqual(["learn-commands"]);
+	});
+
+	test("requires a selected operation and confirmation before completion", () => {
+		expect(shouldPersistCompletion(undefined, true)).toBe(false);
+		expect(shouldPersistCompletion("learn-commands", false)).toBe(false);
+		expect(shouldPersistCompletion("learn-commands", true)).toBe(true);
+	});
+
+	test("fails soft when the onboarding state path is unwritable", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-onboarding-write-failure-"));
+		await Bun.write(path.join(root, "onboarding"), "not a directory");
+		expect(await writeOnboardingState({ version: 1, decision: "skipped" }, root)).toBe(false);
+		await fs.rm(root, { recursive: true, force: true });
+	});
+
+	test("tutorial is registered and dispatches", async () => {
+		expect(lookupBuiltinSlashCommand("tutorial")?.name).toBe("tutorial");
+		let shown = false;
+		const ctx = {
+			editor: { setText: () => undefined },
+			showFrictionlessOnboarding: async () => {
+				shown = true;
+			},
+		} as never;
+		await executeBuiltinSlashCommand("/tutorial", { ctx } as never);
+		expect(shown).toBe(true);
+	});
+});


### PR DESCRIPTION
## What

- Add automatic frictionless onboarding that repeats until completed or explicitly skipped.
- Add `/tutorial` to reopen onboarding at any time.
- Analyze bounded Codex and Claude session evidence only after localized disclosure, with identity-pinned reads and derived-profile-only retention.
- Provide best-effort omissions, corroborated metadata fallback, localized personalized workflow guidance, a complete preview, and one explicit confirmation.

## Why

New users previously entered GJC without contextual guidance or a privacy-safe way to translate existing coding-agent workflows into GJC.

## Testing

- `bun --cwd=packages/coding-agent run check:types`
- changed-file Biome check
- `git diff --check origin/dev...HEAD`
- focused onboarding/startup/slash/session-import suites: 84 passed, 28 skipped, 0 failed, 342 assertions
- deterministic injected EACCES and ENOENT discovery-classification coverage
- exact-source live ANSI PTY captures for shared preview/confirmation/applied guidance, cancellation with no persistence, experienced-user skip, submitted `/tutorial` reopening, and persisted-state readback
- final exact-source Ultragoal architect, cleaner, QA, and terminal critic gates passed

A broader aggregate run including `session-import-command-policy.test.ts` encounters the current SDK broker trusted-root fixture error on this workstation; the directly affected suites pass independently.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [x] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:00a15c56425d7a8f81e4033e20227d73b3fb63b1e23a3cc1aa087e8b68240adb reviewer:human reviewer-id:probepark evidence:exact-source-typecheck-biome-focused-tests-pty-red-team-and-terminal-gates
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken