### PR TITLE
fix(session): make escaped non-ASCII exhaustion terminal in managed fallback (#4880)

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -18183,6 +18183,7 @@ export class AgentSession {
 	#isRetryableError(message: AssistantMessage): boolean {
 		if (this.#isTerminalProviderFirstEventTimeout(message)) return false;
 		if (message.errorMessage?.startsWith("Model fallback chain exhausted;")) return false;
+		if (message.errorMessage?.startsWith("Managed fallback retried the escaped non-ASCII")) return false;
 		const transportFailure = message.transportFailure;
 		// Transport facts normally bypass typed classification in managed fallback.
 		// A provider safety stop must still remain terminal on that path.
@@ -18314,6 +18315,7 @@ export class AgentSession {
 	 * except canonical idle-stream stalls bounded downstream) -> unknown (bounded retry).
 	 */
 	#classifyErrorForRetry(message: AssistantMessage): RetryErrorClassification {
+		if (message.errorMessage?.startsWith("Managed fallback retried the escaped non-ASCII")) return "terminal";
 		if (message.stopReason !== "error") return "none";
 		if (message.errorKind === "provider_safety_stop") return "terminal";
 		if (message.errorKind === "local_snapshot_failure") return "local_snapshot";
@@ -18692,6 +18694,7 @@ export class AgentSession {
 		// result is returned verbatim below. Narrowing it away here would silently
 		// disable the terminal-403 guard in `#markFailedCredential`.
 	): { class: FallbackTriggerClass; retryAfterMs?: number; authDisposition?: AuthDisposition } | undefined {
+		if (message.errorMessage?.startsWith("Managed fallback retried the escaped non-ASCII")) return undefined;
 		if (message.stopReason === "error" && message.errorKind === "provider_safety_stop") return undefined;
 		if (classifyContextOverflow(message, transportFailure, this.model?.contextWindow ?? 0)) return undefined;
 		const transport = classifyFallbackTrigger(transportFailure ?? { status: message.errorStatus });

--- a/packages/coding-agent/test/agent-session-escaped-nonascii-fallback-terminal.test.ts
+++ b/packages/coding-agent/test/agent-session-escaped-nonascii-fallback-terminal.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent, type AgentMessage, type AgentTool } from "@gajae-code/agent-core";
+import { ESCAPED_NONASCII_RECOVERY_PROMPT } from "@gajae-code/agent-core/agent-loop";
+import { getBundledModel, type Message, type Model } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { AgentSession } from "@gajae-code/coding-agent/session/agent-session";
+import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
+import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
+import { TempDir } from "@gajae-code/utils";
+import * as z from "zod/v4";
+
+const QUESTION = "C:\\Users\\최재필\\.gjc\\session.json";
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(
+		message => message.role === "user" || message.role === "assistant" || message.role === "toolResult",
+	) as Message[];
+}
+
+function escapedTurn(id: string) {
+	return {
+		content: [
+			{
+				type: "toolCall" as const,
+				id,
+				name: "ask",
+				arguments: { question: QUESTION },
+				escapedNonAsciiArguments: true,
+			},
+		],
+	};
+}
+
+const schema = z.object({ question: z.string() });
+
+function askTool(executed: Array<Record<string, unknown>>): AgentTool<typeof schema, Record<string, never>> {
+	return {
+		name: "ask",
+		label: "Ask",
+		description: "Ask",
+		parameters: schema,
+		async execute(_id, params) {
+			executed.push(params as Record<string, unknown>);
+			return { content: [{ type: "text", text: "answered" }], details: {} };
+		},
+	};
+}
+
+function selector(model: Model): string {
+	return `${model.provider}/${model.id}`;
+}
+
+function hasUserText(messages: AgentMessage[], text: string): boolean {
+	return messages.some(message => {
+		if (message.role !== "user") return false;
+		const content = message.content;
+		if (typeof content === "string") return content === text;
+		if (!Array.isArray(content)) return false;
+		return content.some(block => block?.type === "text" && block.text === text);
+	});
+}
+
+describe("AgentSession escaped non-ASCII fallback terminal (#4880)", () => {
+	let tempDir: TempDir | undefined;
+	let authStorage: AuthStorage | undefined;
+	let session: AgentSession | undefined;
+
+	afterEach(async () => {
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+	});
+
+	it("fails closed without fallback re-entry on deterministic escaped non-ASCII exhaustion", async () => {
+		tempDir = TempDir.createSync("@gjc-escaped-fallback-terminal-4880-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+
+		const primary = getBundledModel("anthropic", "claude-opus-5");
+		const fallback = getBundledModel("anthropic", "claude-opus-4-6");
+		if (!primary || !fallback) throw new Error("Expected bundled opus models");
+
+		const modelRegistry = new ModelRegistry(authStorage);
+		const manager = SessionManager.create(tempDir.path(), tempDir.path());
+		const executed: Array<Record<string, unknown>> = [];
+
+		// Deterministic escaper: every wire attempt escapes, forever.
+		// This reproduces the v0.15.0 fallback-exhaustion defect without Windows.
+		const mock = createMockModel({
+			handler: () => escapedTurn(`tc-esc-${mock.model.calls.length}`),
+		});
+
+		const agent = new Agent({
+			initialState: { model: primary, systemPrompt: ["test"], tools: [askTool(executed)], messages: [] },
+			convertToLlm: identityConverter,
+			streamFn: (model, context, options) => mock.stream(model, context, options),
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"fallback.maxAttempts": 3,
+			"retry.baseDelayMs": 10,
+		});
+		settings.setModelRole("default", selector(primary));
+		session = new AgentSession({
+			agent,
+			sessionManager: manager,
+			settings,
+			modelRegistry,
+		});
+		session.setConfiguredModelChain("default", [selector(primary), selector(fallback)], "test");
+
+		const events: Array<{ type: string; from?: string; to?: string; reason?: string; attemptsUsed?: number }> = [];
+		session.subscribe(event => {
+			if (event.type === "model_fallback_switched") {
+				events.push({
+					type: event.type,
+					from: (event as { from: string }).from,
+					to: (event as { to: string }).to,
+					reason: (event as { reason: string }).reason,
+					attemptsUsed: (event as { attemptsUsed: number }).attemptsUsed,
+				});
+			}
+		});
+
+		await session.prompt("ask me");
+		await manager.flush();
+
+		// No decode-and-execute: tool never ran.
+		expect(executed).toEqual([]);
+
+		// Durable history stays clean: no defective tool calls persisted.
+		const durable = manager.buildSessionContext().messages;
+		const persistedToolCallIds = durable.flatMap(message =>
+			message.role === "assistant"
+				? message.content.flatMap(block => (block.type === "toolCall" ? [block.id] : []))
+				: [],
+		);
+		// None of the deterministic escaped ids should appear.
+		for (const call of mock.model.calls) {
+			const ids = call.context.messages.flatMap(m =>
+				Array.isArray((m as { content?: unknown }).content)
+					? ((m as { content: unknown[] }).content as { type: string; id?: string }[])
+							.filter(b => b.type === "toolCall")
+							.map(b => b.id)
+					: [],
+			);
+			// no assertion on wire ids — durable history is the contract
+			void ids;
+		}
+		expect(persistedToolCallIds.length).toBe(0);
+
+		// Terminal error still names escaped non-ASCII, retains original cause.
+		const last = durable.findLast(message => message.role === "assistant") as
+			| { stopReason?: string; errorMessage?: string }
+			| undefined;
+		expect(last?.stopReason === "error" || last?.stopReason === "exhausted").toBe(true);
+		expect(last?.errorMessage ?? "").toContain("escaped non-ASCII");
+
+		// Steering instruction is transient: at most one steered request, never durable.
+		expect(hasUserText(durable, ESCAPED_NONASCII_RECOVERY_PROMPT)).toBe(false);
+		const steeredRequests = mock.model.calls.filter(request =>
+			hasUserText(request.context.messages, ESCAPED_NONASCII_RECOVERY_PROMPT),
+		);
+		expect(steeredRequests.length).toBeLessThanOrEqual(1);
+
+		// Bounded provider calls: initial + bounded managed retries (steered + blind).
+		// Must NOT burn the full fallback chain (2 resamples × 2 models × 3 attempts).
+		expect(mock.model.calls.length).toBeLessThanOrEqual(4);
+		expect(mock.model.calls.length).toBeGreaterThanOrEqual(2);
+
+		// No same-model duplicate re-entry: the chain never re-charged the same model.
+		// With fallback.maxAttempts=3 the old bug re-charged opus-4-6 three times and
+		// emitted model_fallback_switched with reason unknown and attemptsUsed 3.
+		expect(events).toEqual([]);
+	});
+});


### PR DESCRIPTION
Fixes #4880

## What

Managed fallback treated the deterministic escaped-non-ASCII exhaustion terminal (`Managed fallback retried the escaped non-ASCII ...`) as retryable `unknown`. It re-charged the same model up to `fallback.maxAttempts` (3), then advanced the chain and emitted `model_fallback_switched` with `reason: unknown`.

Distinct from #4881: this changes no detector or decoder behavior; it corrects only managed-fallback terminal classification.

## Why

Escaped-argument resample exhaustion is model-independent. A different model cannot make an already exhausted wire turn safe, so fallback must not retry, advance, decode, or execute it.

## Change

- `#classifyErrorForRetry` recognizes the stable exhaustion prefix as `terminal` before the `stopReason` check, including the `exhausted` terminal.
- `#isRetryableError` and `#fallbackTriggerFor` reject the same prefix, preventing post-terminal fallback re-entry.
- Original escaped non-ASCII error text is retained. Existing one-time transient steering, resample bounds, and new-turn reset remain unchanged.

## Testing

- `bun test packages/coding-agent/test/agent-session-escaped-nonascii-fallback-terminal.test.ts packages/coding-agent/test/agent-session-escaped-nonascii-managed-steering.test.ts packages/coding-agent/test/agent-session-escaped-nonascii-metadata.test.ts` — 4 pass: deterministic two-model Hangul-path escaper; no tool execution or decoding; no fallback switch; original terminal error; bounded calls; clean durable history; transient steering at most once.
- `bun --cwd packages/coding-agent tsc --noEmit --skipLibCheck` — pass.
- `bunx --bun @biomejs/biome check packages/coding-agent/src/session/agent-session.ts packages/coding-agent/test/agent-session-escaped-nonascii-fallback-terminal.test.ts` — pass.

## Risk classification

- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:d730e6831d250f9e228fa1631a1973adf9b8b90224cd609eaa4d1c252aa0e829 reviewer:human reviewer-id:Yeachan-Heo evidence:bun targeted adversarial fallback suites 4 pass; coding-agent TypeScript and Biome checks pass; Dev CI exact-head affected tests/native-build/check pass
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing) — behavior correction is covered by the package changelog convention; no release section edit required for this narrow unreleased fix
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
