### PR TITLE
fix(provider): allow unauthenticated vLLM runtime discovery

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Cursor `requestContext` rules now forward normalized system prompts, Cursor HTTP/2 transport honors standard proxy environment variables, and GPT effort siblings are sent as their base model with the corresponding reasoning parameter.
+- vLLM's `allowUnauthenticated: true` now lives on the descriptor itself, not only inside its `catalogDiscovery` config. The runtime discovery gate in `packages/coding-agent/src/config/model-registry.ts` checks `isAuthenticated(apiKey) || descriptor.allowUnauthenticated`, so a local no-auth vLLM server previously needed a credential (`VLLM_API_KEY` or `/login vllm`) before its models would be discovered — unlike lm-studio/omlx, which already carry the descriptor-level flag. Catalog-generation behavior is unchanged.
 
 ## [0.15.0] - 2026-08-22
 - A failed dynamic-model refresh no longer blanks a legacy cache row in an unbound provider context. `resolveProviderModels` only reused the last-known rows when the latest cache row was provenance-bound to the current discovery context, so a provider that supplies no `cacheDynamicModelProvenance` (e.g. the Codex family) lost every cached model on a refresh failure AND had its row overwritten with an empty snapshot — the stale-while-error fallback the surrounding code documents never applied to it. Legacy rows now serve through a failed refresh whenever the request context is unbound; bound contexts still fail closed on foreign rows.

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -278,6 +278,7 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 		"gpt-oss-20b",
 		config => vllmModelManagerOptions(config),
 		catalog("vLLM", ["VLLM_API_KEY"], { allowUnauthenticated: true }),
+		{ allowUnauthenticated: true },
 	),
 	catalogDescriptor(
 		"moonshot",

--- a/packages/ai/test/vllm-allow-unauthenticated.test.ts
+++ b/packages/ai/test/vllm-allow-unauthenticated.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { PROVIDER_DESCRIPTORS } from "../src/provider-models/descriptors";
+
+function requireDescriptor(providerId: string) {
+	const descriptor = PROVIDER_DESCRIPTORS.find(d => d.providerId === providerId);
+	if (!descriptor) throw new Error(`descriptor not found for providerId "${providerId}"`);
+	return descriptor;
+}
+
+describe("vllm descriptor allowUnauthenticated", () => {
+	test("vllm descriptor allows unauthenticated runtime discovery", () => {
+		const vllm = requireDescriptor("vllm");
+
+		expect(vllm.allowUnauthenticated).toBe(true);
+	});
+
+	test("vllm descriptor matches lm-studio's local-provider allowUnauthenticated intent", () => {
+		const vllm = requireDescriptor("vllm");
+		const lmStudio = requireDescriptor("lm-studio");
+
+		expect(vllm.allowUnauthenticated).toBe(lmStudio.allowUnauthenticated);
+		expect(lmStudio.allowUnauthenticated).toBe(true);
+	});
+
+	test("vllm catalog discovery remains unauthenticated-friendly", () => {
+		const vllm = requireDescriptor("vllm");
+
+		expect(vllm.catalogDiscovery?.allowUnauthenticated).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts
+++ b/packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts
@@ -167,6 +167,39 @@ describe("issue #970 custom provider discovery", () => {
 		expect(uncatalogued?.maxTokens).toBe(UNK_MAX_TOKENS);
 	});
 
+	test("discovers a default vLLM endpoint without credentials", async () => {
+		const previousApiKey = Bun.env.VLLM_API_KEY;
+		const previousBaseUrl = Bun.env.VLLM_BASE_URL;
+		delete Bun.env.VLLM_API_KEY;
+		delete Bun.env.VLLM_BASE_URL;
+		try {
+			const requestedUrls: string[] = [];
+			using _hook = hookFetch((input, init) => {
+				const url = String(input);
+				requestedUrls.push(url);
+				if (url !== "http://127.0.0.1:8000/v1/models") return new Response(null, { status: 404 });
+				const headers = init?.headers as Headers | Record<string, string> | undefined;
+				const authHeader = headers instanceof Headers ? headers.get("Authorization") : headers?.Authorization;
+				expect(authHeader).toBeUndefined();
+				return new Response(JSON.stringify({ data: [{ id: "credentialless-vllm-model" }] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			});
+
+			const registry = new ModelRegistryImpl(authStorage, modelsPath);
+			await registry.refresh();
+
+			expect(requestedUrls).toContain("http://127.0.0.1:8000/v1/models");
+			expect(registry.find("vllm", "credentialless-vllm-model")?.provider).toBe("vllm");
+		} finally {
+			if (previousApiKey === undefined) delete Bun.env.VLLM_API_KEY;
+			else Bun.env.VLLM_API_KEY = previousApiKey;
+			if (previousBaseUrl === undefined) delete Bun.env.VLLM_BASE_URL;
+			else Bun.env.VLLM_BASE_URL = previousBaseUrl;
+		}
+	});
+
 	test("shows a provider-tab hint when discovery succeeds but returns zero models", async () => {
 		installTestTheme();
 		const selector = await createSelector({


### PR DESCRIPTION
## What

Add the descriptor-level `{ allowUnauthenticated: true }` option to the `vllm` `catalogDescriptor`, plus descriptor and runtime-discovery regression coverage and a changelog entry.

## Why

vLLM's `allowUnauthenticated: true` lived only inside its catalog-discovery config (`catalog(...)`), not on the descriptor itself. The runtime discovery gate in `packages/coding-agent/src/config/model-registry.ts` checks `isAuthenticated(apiKey) || descriptor.allowUnauthenticated`, so a local no-auth vLLM server needed a credential (`VLLM_API_KEY` or `/login vllm`) before its models would be discovered — unlike lm-studio/omlx, which already carry the descriptor-level flag. Catalog-generation behavior is unchanged.

LiteLLM deliberately remains catalog-only: its descriptor still has `runtime=false`, `catalog=true`; no shared runtime invariant warrants widening its behavior in this vLLM-only fix.

## Testing

- `bun test packages/ai/test/vllm-allow-unauthenticated.test.ts` → 3 pass.
- `bun test packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts` → 4 pass, including default credentialless vLLM discovery with no `Authorization` header; the existing configured vLLM case continues to require `Bearer sk-1234`.
- `bun test packages/coding-agent/test/model-registry.test.ts` → 289 pass, covering cached discovery and evidence gating.
- `bun --cwd=packages/ai run check` and `bun --cwd=packages/coding-agent run check` → pass (pre-existing informational diagnostics only).
- `bun --cwd=packages/natives run build` → pass, used to synchronize the local native addon.
- `bun --cwd=packages/ai test` is currently red outside this diff: 39 unrelated failures in auth-broker/auth-gateway and fixture provenance suites.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; reviewed by the repository owner on the exact head.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:9fa334eedbc907df25e36810741f9daf4ca06d99ba7a2b563d9a55770fd2dffd reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head owner review; focused vLLM and model-registry regressions passed
```

---

- [x] Target branch is `dev`
- [x] Focused verification passed
- [x] CHANGELOG updated
- [x] Verdict matches the exact PR head
- [x] Risk classification matches the review path