### PR TITLE
fix(contribution-prep): redact all GitHub token prefixes

### DIFF
--- a/packages/coding-agent/src/session/contribution-prep.ts
+++ b/packages/coding-agent/src/session/contribution-prep.ts
@@ -87,7 +87,7 @@ export function redactContributionPrepText(
 	);
 	redacted = replaceRegex(
 		redacted,
-		/\b(?:ghp_[A-Za-z0-9_]{12,}|gho_[A-Za-z0-9_]{12,}|github_pat_[A-Za-z0-9_]{12,})\b/g,
+		/\b(?:gh[opsur]_[A-Za-z0-9_]{12,}|github_pat_[A-Za-z0-9_]{12,})\b/g,
 		"[REDACTED_TOKEN]",
 		state,
 		"tokens",
@@ -273,7 +273,7 @@ export async function prepareContributionPrep(
 		created_at: createdAt,
 		cwd: redact(context.cwd),
 		git_head: gitHead,
-		changed_files: files,
+		changed_files: files.map(redact),
 		artifacts,
 		redactions: [...redactions.labels].sort(),
 		recommended_output: [

--- a/packages/coding-agent/test/contribution-prep.test.ts
+++ b/packages/coding-agent/test/contribution-prep.test.ts
@@ -36,6 +36,29 @@ describe("contribution prep", () => {
 		expect(redacted).not.toContain(process.env.HOME ?? "__missing_home__");
 	});
 
+	it("redacts every supported GitHub token prefix without changing near-misses", () => {
+		const tokens = [
+			"ghp_abcdefghijklmnopqrstuvwxyz123456",
+			"gho_abcdefghijklmnopqrstuvwxyz123456",
+			"ghs_abcdefghijklmnopqrstuvwxyz123456",
+			"ghu_abcdefghijklmnopqrstuvwxyz123456",
+			"ghr_abcdefghijklmnopqrstuvwxyz123456",
+			"github_pat_11ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz1234567890",
+		];
+		const nearMisses = [
+			"ghx_abcdefghijklmnopqrstuvwxyz123456",
+			"ghs_abcdefghijk",
+			"prefixghu_abcdefghijklmnopqrstuvwxyz123456",
+			"ordinary prose remains visible",
+		];
+		const redacted = redactContributionPrepText([...tokens, ...nearMisses].join("\n"), process.cwd());
+
+		expect(redacted).toBe([...tokens.map(() => "[REDACTED_TOKEN]"), ...nearMisses].join("\n"));
+		expect(redactContributionPrepText("before (ghs_abcdefghijkl), after", process.cwd())).toBe(
+			"before ([REDACTED_TOKEN]), after",
+		);
+	});
+
 	it("writes a manifest with redacted file-pointer artifacts", async () => {
 		const tempDir = TempDir.createSync("@gjc-contribution-prep-");
 		try {
@@ -43,10 +66,14 @@ describe("contribution prep", () => {
 			await $`git init`.cwd(tempDir.path()).quiet();
 			await $`git add tracked.txt`.cwd(tempDir.path()).quiet();
 			await $`git -c user.email=test@example.com -c user.name=Test commit -m initial`.cwd(tempDir.path()).quiet();
+			const tokenFilename = "ghs_abcdefghijklmnopqrstuvwxyz123456.txt";
+			const transcriptToken = "ghu_abcdefghijklmnopqrstuvwxyz123456";
+			const instructionsToken = "ghr_abcdefghijklmnopqrstuvwxyz123456";
 			await Bun.write(
 				path.join(tempDir.path(), "tracked.txt"),
-				"changed ghp_abcdefghijklmnopqrstuvwxyz123456 github_pat_11ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz1234567890\n",
+				"changed ghs_abcdefghijklmnopqrstuvwxyz123456 github_pat_11ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz1234567890\n",
 			);
+			await Bun.write(path.join(tempDir.path(), tokenFilename), "untracked");
 			const messages: AgentMessage[] = [
 				{ role: "user", content: "Failure uses Authorization: Bearer ghp_secretsecretsecret", timestamp: 1 },
 				{
@@ -55,7 +82,7 @@ describe("contribution prep", () => {
 					provider: "anthropic",
 					model: "claude-sonnet-test",
 					timestamp: 2,
-					content: [{ type: "text", text: "Check http://192.168.0.10:3000/private" }],
+					content: [{ type: "text", text: `Check http://192.168.0.10:3000/private with ${transcriptToken}` }],
 					usage: {
 						input: 1,
 						output: 1,
@@ -75,7 +102,11 @@ describe("contribution prep", () => {
 					messages,
 					sessionFile: path.join(tempDir.path(), "session.jsonl"),
 				},
-				{ artifactRoot: path.join(tempDir.path(), "artifacts"), now: new Date("2026-05-31T00:00:00.000Z") },
+				{
+					artifactRoot: path.join(tempDir.path(), "artifacts"),
+					customInstructions: `Include ${instructionsToken}`,
+					now: new Date("2026-05-31T00:00:00.000Z"),
+				},
 			);
 
 			const manifest = JSON.parse(await Bun.file(result.manifestPath).text()) as {
@@ -85,6 +116,7 @@ describe("contribution prep", () => {
 				redactions: string[];
 				recommended_output: string[];
 				worker_prompt_path: string;
+				changed_files: string[];
 			};
 			const transcriptPath = manifest.artifacts.find(artifact => artifact.path.endsWith("transcript.md"))?.path;
 			expect(manifest.schema_version).toBe(1);
@@ -93,15 +125,22 @@ describe("contribution prep", () => {
 			expect(manifest.recommended_output).toContain("uncertainty / remaining risks");
 			expect(manifest.redactions).toContain("auth_headers");
 			expect(manifest.redactions).toContain("private_endpoints");
+			expect(manifest.changed_files).toContain("[REDACTED_TOKEN].txt");
+			expect(manifest.changed_files).not.toContain(tokenFilename);
 			expect(transcriptPath).toBeTruthy();
 			const transcript = await Bun.file(transcriptPath ?? "").text();
 			expect(transcript).toContain("[REDACTED_AUTH_HEADER]");
 			expect(transcript).toContain("[REDACTED_PRIVATE_ENDPOINT]");
+			expect(transcript).not.toContain(transcriptToken);
+			const summaryPath = manifest.artifacts.find(artifact => artifact.path.endsWith("summary.md"))?.path;
+			expect(summaryPath).toBeTruthy();
+			const summary = await Bun.file(summaryPath ?? "").text();
+			expect(summary).not.toContain(instructionsToken);
 			const diffPath = manifest.artifacts.find(artifact => artifact.path.endsWith("git-diff.patch"))?.path;
 			expect(diffPath).toBeTruthy();
 			const gitDiff = await Bun.file(diffPath ?? "").text();
 			expect(gitDiff).toContain("[REDACTED_TOKEN]");
-			expect(gitDiff).not.toContain("ghp_abcdefghijklmnopqrstuvwxyz123456");
+			expect(gitDiff).not.toContain("ghs_abcdefghijklmnopqrstuvwxyz123456");
 			expect(gitDiff).not.toContain("github_pat_11ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz1234567890");
 		} finally {
 			tempDir.remove();


### PR DESCRIPTION
## What
- Redact all supported GitHub token prefixes from outbound contribution-prep text.
- Redact token-shaped changed-file names before they enter the outbound manifest.
- Add focused token boundary and generated-artifact regressions.

## Why
Contribution prep previously left synthetic `ghs_`, `ghu_`, and `ghr_` values visible. This preserves the established sibling `gh[opsur]` matching contract and fixes the same redaction boundary in `manifest.json`. Fixes #4894.

## Testing
- `bun test packages/coding-agent/test/contribution-prep.test.ts` (7 pass, 45 assertions)
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/session/contribution-prep.ts packages/coding-agent/test/contribution-prep.test.ts`
- `bun --cwd=packages/coding-agent run build`

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:cf5f6159719cf7a0b362b7c0c76c999ce76d758e5914b23d05c3f3ec1e7cf0c3 reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head local QA artifact artifacts/issue-4894-redaction-qa.json
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (not user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken