### PR TITLE
fix(provider): restrict keyless vLLM discovery to loopback

### DIFF
--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2767,12 +2767,17 @@ export class ModelRegistry {
 		for (let i = 0; i < standardProviderDescriptors.length; i++) {
 			const descriptor = standardProviderDescriptors[i];
 			const { apiKey, authGeneration } = standardProviderCredentials[i];
+			const baseUrl = this.#getProviderBaseUrlForDiscovery(descriptor.providerId);
+			const allowsKeylessDiscovery =
+				descriptor.allowUnauthenticated &&
+				(descriptor.providerId !== "vllm" ||
+					baseUrl === undefined ||
+					resolveLoopbackOpenAIBaseUrl(baseUrl, "") === baseUrl);
 			if (
 				authGeneration !== undefined &&
 				authGeneration === this.#getProviderEvidenceGeneration(descriptor.providerId, apiKey) &&
-				(isAuthenticated(apiKey) || descriptor.allowUnauthenticated)
+				(isAuthenticated(apiKey) || allowsKeylessDiscovery)
 			) {
-				const baseUrl = this.#getProviderBaseUrlForDiscovery(descriptor.providerId);
 				options.push({
 					options: descriptor.createModelManagerOptions({
 						apiKey: isAuthenticated(apiKey) ? apiKey : undefined,

--- a/packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts
+++ b/packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts
@@ -200,6 +200,31 @@ describe("issue #970 custom provider discovery", () => {
 		}
 	});
 
+	test("does not discover a configured remote vLLM endpoint without credentials", async () => {
+		const previousApiKey = Bun.env.VLLM_API_KEY;
+		const previousBaseUrl = Bun.env.VLLM_BASE_URL;
+		delete Bun.env.VLLM_API_KEY;
+		Bun.env.VLLM_BASE_URL = "https://vllm.example.test/v1";
+		try {
+			using _hook = hookFetch(input => {
+				if (String(input) === "https://vllm.example.test/v1/models") {
+					throw new Error("credentialless discovery must not probe a remote vLLM endpoint");
+				}
+				return new Response(null, { status: 404 });
+			});
+
+			const registry = new ModelRegistryImpl(authStorage, modelsPath);
+			await registry.refresh();
+
+			expect(registry.find("vllm", "remote-vllm-model")).toBeUndefined();
+		} finally {
+			if (previousApiKey === undefined) delete Bun.env.VLLM_API_KEY;
+			else Bun.env.VLLM_API_KEY = previousApiKey;
+			if (previousBaseUrl === undefined) delete Bun.env.VLLM_BASE_URL;
+			else Bun.env.VLLM_BASE_URL = previousBaseUrl;
+		}
+	});
+
 	test("shows a provider-tab hint when discovery succeeds but returns zero models", async () => {
 		installTestTheme();
 		const selector = await createSelector({


### PR DESCRIPTION
## What

Restrict credentialless vLLM discovery to default or explicitly configured loopback endpoints.

## Why

The descriptor flag fixed by #4895 enabled the intended local no-auth path, but a credentialless remote `VLLM_BASE_URL` could also be probed. This change keeps remote vLLM discovery authenticated while preserving local development behavior.

## Testing

- `bun test packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts` → 5 pass.
- Covers default local keyless discovery, configured authenticated discovery with a bearer token, and a configured remote endpoint that must not be probed without credentials.

## Risk classification

- [x] `low-risk` — endpoint admission guard and regression test.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:fb795dd7a335ecf4818122624dbe4c32ae8cf3d5b64b7c74df2b7e35c002ff5d reviewer:human reviewer-id:Yeachan-Heo evidence:focused vLLM local, authenticated, and remote-negative regression
```