### PR TITLE
fix(provider): require auth for configured remote vLLM

### DIFF
--- a/packages/ai/src/utils/discovery/openai-compatible.ts
+++ b/packages/ai/src/utils/discovery/openai-compatible.ts
@@ -122,7 +122,7 @@ export function resolveLoopbackOpenAIBaseUrl(value: string | undefined, fallback
 	if (!candidate) return fallback;
 	try {
 		const parsed = new URL(candidate);
-		const host = parsed.hostname.toLowerCase();
+		const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
 		const isLoopback = host === "localhost" || host === "::1" || /^127(?:\.\d{1,3}){3}$/.test(host);
 		if ((parsed.protocol === "http:" || parsed.protocol === "https:") && isLoopback) {
 			return candidate;

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2522,6 +2522,11 @@ export class ModelRegistry {
 		}
 		const effectiveProviderConfig = this.#effectiveDiscoveryProviderConfig(providerConfig);
 		const endpoint = this.#normalizeDiscoveryEvidenceEndpoint(effectiveProviderConfig.baseUrl ?? "");
+		const allowsKeylessVllmDiscovery =
+			provider !== "vllm" ||
+			isAuthenticated(preflightApiKey) ||
+			effectiveProviderConfig.baseUrl === undefined ||
+			resolveLoopbackOpenAIBaseUrl(effectiveProviderConfig.baseUrl, "") === effectiveProviderConfig.baseUrl;
 		if (!isCurrentPreflight() || preflightStale) {
 			return {
 				provider: effectiveProviderConfig.provider,
@@ -2537,6 +2542,17 @@ export class ModelRegistry {
 			return {
 				provider: effectiveProviderConfig.provider,
 				current: false,
+				models: [],
+				authGeneration: this.#getProviderEvidenceGeneration(provider, preflightApiKey),
+				configurationGeneration: preflightAuthConfigurationGeneration,
+				endpoint,
+				fetched: false,
+			};
+		}
+		if (!allowsKeylessVllmDiscovery) {
+			return {
+				provider: effectiveProviderConfig.provider,
+				current: true,
 				models: [],
 				authGeneration: this.#getProviderEvidenceGeneration(provider, preflightApiKey),
 				configurationGeneration: preflightAuthConfigurationGeneration,

--- a/packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts
+++ b/packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts
@@ -225,6 +225,32 @@ describe("issue #970 custom provider discovery", () => {
 		}
 	});
 
+	test("does not discover a remote configured vLLM provider without credentials", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					vllm: {
+						baseUrl: "https://vllm.example.test/v1",
+						api: "openai-completions",
+						auth: "none",
+						discovery: { type: "openai-models-list" },
+					},
+				},
+			}),
+		);
+		let requestedRemote = false;
+		using _hook = hookFetch(input => {
+			if (String(input) === "https://vllm.example.test/v1/models") requestedRemote = true;
+			return new Response(null, { status: 404 });
+		});
+
+		const registry = new ModelRegistryImpl(authStorage, modelsPath);
+		await registry.refresh();
+
+		expect(requestedRemote).toBe(false);
+	});
+
 	test("shows a provider-tab hint when discovery succeeds but returns zero models", async () => {
 		installTestTheme();
 		const selector = await createSelector({


### PR DESCRIPTION
## What

Require authentication for configured remote vLLM discovery and recognize IPv6 loopback endpoints.

## Risk classification

- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:7ec151d72f12892c9535505f6229515a18ae08ae58ec796b25caf9301f90599a reviewer:human reviewer-id:Yeachan-Heo evidence:focused configured-vLLM regression
```