### PR TITLE
feat(ai): add Ox Alpha and recover empty streams

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Kilo's `stealth/ox-alpha` model with its reviewed 1,048,576-token context, 131,072-token output ceiling, text/image input, and low/high/max reasoning-effort contract.
+
 ### Fixed
 
 - Direct model selections now retry zero-token empty OpenAI-compatible responses.

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Direct model selections now retry zero-token empty OpenAI-compatible responses.
+
 - Cursor `requestContext` rules now forward normalized system prompts, Cursor HTTP/2 transport honors standard proxy environment variables, and GPT effort siblings are sent as their base model with the corresponding reasoning parameter.
 - vLLM's `allowUnauthenticated: true` now lives on the descriptor itself, not only inside its `catalogDiscovery` config. The runtime discovery gate in `packages/coding-agent/src/config/model-registry.ts` checks `isAuthenticated(apiKey) || descriptor.allowUnauthenticated`, so a local no-auth vLLM server previously needed a credential (`VLLM_API_KEY` or `/login vllm`) before its models would be discovered — unlike lm-studio/omlx, which already carry the descriptor-level flag. Catalog-generation behavior is unchanged.
 

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -153,6 +153,10 @@ export const CLOUDFLARE_FALLBACK_MODEL: ApiModel<"anthropic-messages"> = {
 const kEnrichedModel = Symbol("model-thinking.enrichedModel");
 type ModelWithEnriched = ApiModel<Api> & { [kEnrichedModel]?: ApiModel<Api> };
 
+export function isGroqCompoundReasoningUnsupported(model: Pick<ApiModel<Api>, "provider" | "id">): boolean {
+	return model.provider === "groq" && (model.id === "groq/compound" || model.id === "groq/compound-mini");
+}
+
 /**
  * Returns a copy of the model with canonical thinking metadata attached.
  *
@@ -167,7 +171,12 @@ export function enrichModelThinking<TApi extends Api>(model: ApiModel<TApi>): Ap
 	}
 	const normalizedThinking = normalizeThinkingConfig(model.thinking);
 	let result: ApiModel<TApi>;
-	if (!model.reasoning) {
+	if (isGroqCompoundReasoningUnsupported(model)) {
+		result =
+			!model.reasoning && normalizedThinking === undefined
+				? model
+				: { ...model, reasoning: false, thinking: undefined };
+	} else if (!model.reasoning) {
 		result =
 			normalizedThinking === undefined && model.thinking === undefined ? model : { ...model, thinking: undefined };
 	} else {
@@ -193,6 +202,11 @@ export function enrichModelThinking<TApi extends Api>(model: ApiModel<TApi>): Ap
  * canonical rules, replacing any existing `thinking`.
  */
 export function refreshModelThinking<TApi extends Api>(model: ApiModel<TApi>): ApiModel<TApi> {
+	if (isGroqCompoundReasoningUnsupported(model)) {
+		return !model.reasoning && model.thinking === undefined
+			? model
+			: { ...model, reasoning: false, thinking: undefined };
+	}
 	if (!model.reasoning) {
 		const normalizedThinking = normalizeThinkingConfig(model.thinking);
 		return normalizedThinking === undefined && model.thinking === undefined
@@ -499,16 +513,19 @@ function applyGeneratedModelPolicy(model: ApiModel<Api>): void {
 	// (400 "`reasoning_effort` is not supported with this model", verified
 	// 2026-08-23), yet models.dev advertises them as reasoning models. Drop the
 	// thinking config so GJC never sends the field.
-	if (model.provider === "groq" && (model.id === "groq/compound" || model.id === "groq/compound-mini")) {
+	if (isGroqCompoundReasoningUnsupported(model)) {
 		model.reasoning = false;
 		delete model.thinking;
 	}
-	// Ox Alpha (OpenRouter stealth preview) always thinks and exposes only
-	// low/high/max reasoning_effort. Measured against the live endpoint on
-	// 2026-08-23: every effort value returns 200, but only `max` (or omitting
-	// `reasoning`) emits reasoning content — the generated minimal..high range
-	// silently disabled thinking because `max` was unreachable.
-	if (model.id === "stealth/ox-alpha" && model.reasoning) {
+	// Kilo's Ox Alpha catalog row advertises reasoning, vision, a 1,048,576-token
+	// context, a 131,072-token output ceiling, and low/high/max variants. Its
+	// OpenAI-compatible `/models` shape exposes those fields outside the generic
+	// discovery parser, so pin the reviewed provider-specific contract here.
+	if (model.provider === "kilo" && model.id === "stealth/ox-alpha") {
+		model.reasoning = true;
+		model.input = ["text", "image"];
+		model.contextWindow = 1_048_576;
+		model.maxTokens = 131_072;
 		model.thinking = {
 			mode: "effort",
 			minLevel: Effort.Low,

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -495,6 +495,20 @@ function applyGeneratedModelPolicy(model: ApiModel<Api>): void {
 			levels: [Effort.Low, Effort.High, Effort.Max],
 		};
 	}
+	// Ox Alpha (OpenRouter stealth preview) always thinks and exposes only
+	// low/high/max reasoning_effort. Measured against the live endpoint on
+	// 2026-08-23: every effort value returns 200, but only `max` (or omitting
+	// `reasoning`) emits reasoning content — the generated minimal..high range
+	// silently disabled thinking because `max` was unreachable.
+	if (model.id === "stealth/ox-alpha" && model.reasoning) {
+		model.thinking = {
+			mode: "effort",
+			minLevel: Effort.Low,
+			maxLevel: Effort.Max,
+			defaultLevel: Effort.Max,
+			levels: [Effort.Low, Effort.High, Effort.Max],
+		};
+	}
 	if (model.provider === "alibaba-token-plan" && model.id === "deepseek-v4-flash-0731") {
 		model.contextWindow = 1_000_000;
 		model.maxTokens = 384_000;

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -495,6 +495,14 @@ function applyGeneratedModelPolicy(model: ApiModel<Api>): void {
 			levels: [Effort.Low, Effort.High, Effort.Max],
 		};
 	}
+	// Groq's agentic `compound` systems reject `reasoning_effort` outright
+	// (400 "`reasoning_effort` is not supported with this model", verified
+	// 2026-08-23), yet models.dev advertises them as reasoning models. Drop the
+	// thinking config so GJC never sends the field.
+	if (model.provider === "groq" && (model.id === "groq/compound" || model.id === "groq/compound-mini")) {
+		model.reasoning = false;
+		delete model.thinking;
+	}
 	// Ox Alpha (OpenRouter stealth preview) always thinks and exposes only
 	// low/high/max reasoning_effort. Measured against the live endpoint on
 	// 2026-08-23: every effort value returns 200, but only `max` (or omitting

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -116,33 +116,6 @@
 				"maxLevel": "xhigh"
 			}
 		},
-		"deepseek-v4-pro-0813": {
-			"id": "deepseek-v4-pro-0813",
-			"name": "DeepSeek V4 Pro 0813",
-			"api": "openai-completions",
-			"provider": "alibaba-token-plan",
-			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 384000,
-			"compat": {
-				"supportsDeveloperRole": false
-			},
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
 		"glm-5": {
 			"id": "glm-5",
 			"name": "GLM-5",
@@ -1258,10 +1231,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 11,
-				"output": 55,
-				"cacheRead": 1.1,
-				"cacheWrite": 13.75
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -1283,10 +1256,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
-				"output": 5,
-				"cacheRead": 0.1,
-				"cacheWrite": 1.25
+				"input": 1.1,
+				"output": 5.5,
+				"cacheRead": 0.11,
+				"cacheWrite": 1.375
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
@@ -1415,10 +1388,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 5,
-				"output": 25,
-				"cacheRead": 0.5,
-				"cacheWrite": 6.25
+				"input": 5.5,
+				"output": 27.5,
+				"cacheRead": 0.55,
+				"cacheWrite": 6.875
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -1651,7 +1624,7 @@
 		},
 		"global.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
-			"name": "Anthropic Haiku 4.5",
+			"name": "Anthropic Haiku 4.5 (Global)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1676,7 +1649,7 @@
 		},
 		"global.anthropic.claude-opus-4-5-20251101-v1:0": {
 			"id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
-			"name": "Anthropic Opus 4.5 (Global)",
+			"name": "Anthropic Opus 4.5",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1879,7 +1852,7 @@
 		},
 		"global.anthropic.claude-sonnet-4-6": {
 			"id": "global.anthropic.claude-sonnet-4-6",
-			"name": "Anthropic Sonnet 4.6 (Global)",
+			"name": "Anthropic Sonnet 4.6",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1925,81 +1898,6 @@
 				"mode": "anthropic-budget-effort",
 				"minLevel": "minimal",
 				"maxLevel": "high"
-			}
-		},
-		"global.openai.gpt-5.6-luna": {
-			"id": "global.openai.gpt-5.6-luna",
-			"name": "GPT-5.6 Luna (Global)",
-			"api": "bedrock-converse-stream",
-			"provider": "amazon-bedrock",
-			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.22,
-				"output": 1.32,
-				"cacheRead": 0.022,
-				"cacheWrite": 0.275
-			},
-			"contextWindow": 1050000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "low",
-				"maxLevel": "max"
-			}
-		},
-		"global.openai.gpt-5.6-sol": {
-			"id": "global.openai.gpt-5.6-sol",
-			"name": "GPT-5.6 Sol (Global)",
-			"api": "bedrock-converse-stream",
-			"provider": "amazon-bedrock",
-			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 5.5,
-				"output": 33,
-				"cacheRead": 0.55,
-				"cacheWrite": 6.875
-			},
-			"contextWindow": 1050000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "low",
-				"maxLevel": "max"
-			}
-		},
-		"global.openai.gpt-5.6-terra": {
-			"id": "global.openai.gpt-5.6-terra",
-			"name": "GPT-5.6 Terra (Global)",
-			"api": "bedrock-converse-stream",
-			"provider": "amazon-bedrock",
-			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 2.2,
-				"output": 13.2,
-				"cacheRead": 0.22,
-				"cacheWrite": 2.75
-			},
-			"contextWindow": 1050000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "low",
-				"maxLevel": "max"
 			}
 		},
 		"google.gemma-3-27b-it": {
@@ -3261,7 +3159,7 @@
 		},
 		"us.anthropic.claude-opus-4-1-20250805-v1:0": {
 			"id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
-			"name": "Anthropic Opus 4.1 (US)",
+			"name": "Anthropic Opus 4.1",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -3790,31 +3688,6 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "high"
-			}
-		},
-		"xai.grok-4.6": {
-			"id": "xai.grok-4.6",
-			"name": "Grok 4.6",
-			"api": "bedrock-converse-stream",
-			"provider": "amazon-bedrock",
-			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 2.2,
-				"output": 6.6,
-				"cacheRead": 0.55,
-				"cacheWrite": 0
-			},
-			"contextWindow": 500000,
-			"maxTokens": 500000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -4552,7 +4425,7 @@
 	"bizrouter": {
 		"anthropic/claude-sonnet-4.5": {
 			"id": "anthropic/claude-sonnet-4.5",
-			"name": "Anthropic Sonnet 4.5 (latest)",
+			"name": "Anthropic Sonnet 4.5",
 			"api": "openai-completions",
 			"provider": "bizrouter",
 			"baseUrl": "https://api.bizrouter.ai/v1",
@@ -4943,31 +4816,6 @@
 				"maxLevel": "xhigh"
 			}
 		},
-		"anthropic/claude-haiku-4.5": {
-			"id": "anthropic/claude-haiku-4.5",
-			"name": "Anthropic Haiku 4.5 (latest)",
-			"api": "anthropic-messages",
-			"provider": "cloudflare-ai-gateway",
-			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 1,
-				"output": 5,
-				"cacheRead": 0.1,
-				"cacheWrite": 1.25
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
 		"anthropic/claude-opus-4": {
 			"id": "anthropic/claude-opus-4",
 			"name": "Anthropic Opus 4",
@@ -5125,113 +4973,6 @@
 				"maxLevel": "max"
 			}
 		},
-		"anthropic/claude-opus-4.5": {
-			"id": "anthropic/claude-opus-4.5",
-			"name": "Anthropic Opus 4.5 (latest)",
-			"api": "anthropic-messages",
-			"provider": "cloudflare-ai-gateway",
-			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 5,
-				"output": 25,
-				"cacheRead": 0.5,
-				"cacheWrite": 6.25
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"thinking": {
-				"mode": "anthropic-budget-effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"anthropic/claude-opus-4.6": {
-			"id": "anthropic/claude-opus-4.6",
-			"name": "Anthropic Opus 4.6",
-			"api": "anthropic-messages",
-			"provider": "cloudflare-ai-gateway",
-			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 5,
-				"output": 25,
-				"cacheRead": 0.5,
-				"cacheWrite": 6.25
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "anthropic-adaptive",
-				"minLevel": "minimal",
-				"maxLevel": "max",
-				"levels": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"max"
-				]
-			}
-		},
-		"anthropic/claude-opus-4.7": {
-			"id": "anthropic/claude-opus-4.7",
-			"name": "Anthropic Opus 4.7",
-			"api": "anthropic-messages",
-			"provider": "cloudflare-ai-gateway",
-			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 5,
-				"output": 25,
-				"cacheRead": 0.5,
-				"cacheWrite": 6.25
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "anthropic-adaptive",
-				"minLevel": "minimal",
-				"maxLevel": "max"
-			}
-		},
-		"anthropic/claude-opus-4.8": {
-			"id": "anthropic/claude-opus-4.8",
-			"name": "Anthropic Opus 4.8",
-			"api": "anthropic-messages",
-			"provider": "cloudflare-ai-gateway",
-			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 5,
-				"output": 25,
-				"cacheRead": 0.5,
-				"cacheWrite": 6.25
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "anthropic-adaptive",
-				"minLevel": "minimal",
-				"maxLevel": "max"
-			}
-		},
 		"anthropic/claude-opus-5": {
 			"id": "anthropic/claude-opus-5",
 			"name": "Anthropic Opus 5",
@@ -5309,56 +5050,6 @@
 		},
 		"anthropic/claude-sonnet-4-6": {
 			"id": "anthropic/claude-sonnet-4-6",
-			"name": "Anthropic Sonnet 4.6",
-			"api": "anthropic-messages",
-			"provider": "cloudflare-ai-gateway",
-			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 3,
-				"output": 15,
-				"cacheRead": 0.3,
-				"cacheWrite": 3.75
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "anthropic-adaptive",
-				"minLevel": "minimal",
-				"maxLevel": "high"
-			}
-		},
-		"anthropic/claude-sonnet-4.5": {
-			"id": "anthropic/claude-sonnet-4.5",
-			"name": "Anthropic Sonnet 4.5 (latest)",
-			"api": "anthropic-messages",
-			"provider": "cloudflare-ai-gateway",
-			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 3,
-				"output": 15,
-				"cacheRead": 0.3,
-				"cacheWrite": 3.75
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
-			"thinking": {
-				"mode": "anthropic-budget-effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"anthropic/claude-sonnet-4.6": {
-			"id": "anthropic/claude-sonnet-4.6",
 			"name": "Anthropic Sonnet 4.6",
 			"api": "anthropic-messages",
 			"provider": "cloudflare-ai-gateway",
@@ -5568,9 +5259,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 1.25,
-				"output": 5,
-				"cacheRead": 0.625,
+				"input": 2.5,
+				"output": 10,
+				"cacheRead": 1.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -5588,9 +5279,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.075,
-				"output": 0.3,
-				"cacheRead": 0.0375,
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.075,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -8887,66 +8578,28 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000
 		},
-		"gemini-3.6-flash-low": {
-			"id": "gemini-3.6-flash-low",
-			"name": "Gemini 3.6 Flash Low",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000
-		},
-		"gemini-3.6-flash-medium": {
-			"id": "gemini-3.6-flash-medium",
-			"name": "Gemini 3.6 Flash Medium",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000
-		},
-		"gemini-3.6-flash-minimal": {
-			"id": "gemini-3.6-flash-minimal",
-			"name": "Gemini 3.6 Flash Minimal",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000
-		},
 		"gemini-3.7-flash-high": {
 			"id": "gemini-3.7-flash-high",
 			"name": "Gemini 3.7 Flash",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000
+		},
+		"gemini-3.6-flash-low": {
+			"id": "gemini-3.6-flash-low",
+			"name": "Gemini 3.6 Flash Low",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -8982,9 +8635,47 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000
 		},
+		"gemini-3.6-flash-medium": {
+			"id": "gemini-3.6-flash-medium",
+			"name": "Gemini 3.6 Flash Medium",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000
+		},
 		"gemini-3.7-flash-medium": {
 			"id": "gemini-3.7-flash-medium",
 			"name": "Gemini 3.7 Flash Medium",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000
+		},
+		"gemini-3.6-flash-minimal": {
+			"id": "gemini-3.6-flash-minimal",
+			"name": "Gemini 3.6 Flash Minimal",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -11277,56 +10968,6 @@
 				"maxLevel": "xhigh"
 			}
 		},
-		"ByteDance/Seed-2.0-mini": {
-			"id": "ByteDance/Seed-2.0-mini",
-			"name": "Seed 2.0 Mini",
-			"api": "openai-completions",
-			"provider": "deepinfra",
-			"baseUrl": "https://api.deepinfra.com/v1/openai",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.1,
-				"output": 0.4,
-				"cacheRead": 0.02,
-				"cacheWrite": 0
-			},
-			"contextWindow": 256000,
-			"maxTokens": 32000,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"ByteDance/Seed-2.0-pro": {
-			"id": "ByteDance/Seed-2.0-pro",
-			"name": "Seed 2.0 Pro",
-			"api": "openai-completions",
-			"provider": "deepinfra",
-			"baseUrl": "https://api.deepinfra.com/v1/openai",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.5,
-				"output": 3,
-				"cacheRead": 0.1,
-				"cacheWrite": 0
-			},
-			"contextWindow": 256000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
 		"deepseek-ai/DeepSeek-R1-0528": {
 			"id": "deepseek-ai/DeepSeek-R1-0528",
 			"name": "DeepSeek-R1-0528",
@@ -11503,30 +11144,6 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 16384,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"deepseek-ai/DeepSeek-V4-Pro-0813": {
-			"id": "deepseek-ai/DeepSeek-V4-Pro-0813",
-			"name": "DeepSeek V4 Pro 0813",
-			"api": "openai-completions",
-			"provider": "deepinfra",
-			"baseUrl": "https://api.deepinfra.com/v1/openai",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 1.3,
-				"output": 2.6,
-				"cacheRead": 0.1,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 384000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -12065,26 +11682,6 @@
 			"contextWindow": 262144,
 			"maxTokens": 32768
 		},
-		"Qwen/Qwen3-VL-235B-A22B-Instruct": {
-			"id": "Qwen/Qwen3-VL-235B-A22B-Instruct",
-			"name": "Qwen3 VL 235B A22B Instruct",
-			"api": "openai-completions",
-			"provider": "deepinfra",
-			"baseUrl": "https://api.deepinfra.com/v1/openai",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.2,
-				"output": 0.88,
-				"cacheRead": 0.11,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262144,
-			"maxTokens": 32768
-		},
 		"Qwen/Qwen3.5-122B-A10B": {
 			"id": "Qwen/Qwen3.5-122B-A10B",
 			"name": "Qwen3.5 122B-A10B",
@@ -12278,55 +11875,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536
-		},
-		"Qwen/Qwen3.8-2.4T-A95B": {
-			"id": "Qwen/Qwen3.8-2.4T-A95B",
-			"name": "Qwen3.8 2.4T A95B",
-			"api": "openai-completions",
-			"provider": "deepinfra",
-			"baseUrl": "https://api.deepinfra.com/v1/openai",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 2,
-				"output": 6,
-				"cacheRead": 0.2,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262144,
-			"maxTokens": 131072,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "high"
-			}
-		},
-		"Qwen/Qwen3.8-27B": {
-			"id": "Qwen/Qwen3.8-27B",
-			"name": "Qwen3.8 27B",
-			"api": "openai-completions",
-			"provider": "deepinfra",
-			"baseUrl": "https://api.deepinfra.com/v1/openai",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.4,
-				"output": 3,
-				"cacheRead": 0.04,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262144,
-			"maxTokens": 32768,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "high"
-			}
 		},
 		"Qwen/Qwen3.8-Max": {
 			"id": "Qwen/Qwen3.8-Max",
@@ -12651,53 +12199,6 @@
 			"reasoning": true,
 			"input": [
 				"text"
-			],
-			"cost": {
-				"input": 0.14,
-				"output": 0.28,
-				"cacheRead": 0.0028,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 384000,
-			"compat": {
-				"supportsDeveloperRole": false,
-				"supportsReasoningEffort": true,
-				"reasoningEffortMap": {
-					"minimal": "high",
-					"low": "high",
-					"medium": "high",
-					"high": "high",
-					"xhigh": "max",
-					"max": "max"
-				},
-				"maxTokensField": "max_tokens",
-				"supportsToolChoice": false,
-				"extraBody": {
-					"thinking": {
-						"type": "enabled"
-					}
-				},
-				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": true,
-				"requiresAssistantContentForToolCalls": true
-			},
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"deepseek-v4-flash-vision-exp": {
-			"id": "deepseek-v4-flash-vision-exp",
-			"name": "DeepSeek V4 Flash Vision Exp",
-			"api": "openai-completions",
-			"provider": "deepseek",
-			"baseUrl": "https://api.deepseek.com",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
 			],
 			"cost": {
 				"input": 0.14,
@@ -14092,10 +13593,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 15,
-				"cacheRead": 0.25,
-				"cacheWrite": 3.125
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -14139,39 +13640,6 @@
 		"grok-4.5": {
 			"id": "grok-4.5",
 			"name": "Grok 4.5",
-			"api": "openai-completions",
-			"provider": "github-copilot",
-			"baseUrl": "https://api.githubcopilot.com",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 2,
-				"output": 6,
-				"cacheRead": 0.5,
-				"cacheWrite": 0
-			},
-			"contextWindow": 500000,
-			"maxTokens": 128000,
-			"headers": {
-				"User-Agent": "opencode/1.3.15"
-			},
-			"compat": {
-				"supportsStore": false,
-				"supportsDeveloperRole": false,
-				"supportsReasoningEffort": false
-			},
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "high"
-			}
-		},
-		"grok-4.6": {
-			"id": "grok-4.6",
-			"name": "Grok 4.6",
 			"api": "openai-completions",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -15502,9 +14970,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.75,
-				"output": 3.75,
-				"cacheRead": 0.075,
+				"input": 1.5,
+				"output": 7.5,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -15552,9 +15020,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.75,
-				"output": 3.75,
-				"cacheRead": 0.075,
+				"input": 1.5,
+				"output": 9,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -15577,9 +15045,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 2.5,
-				"cacheRead": 0.03,
+				"input": 0.25,
+				"output": 1.5,
+				"cacheRead": 0.025,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -16317,81 +15785,6 @@
 				"maxLevel": "high"
 			}
 		},
-		"gemini-3.6-flash-low": {
-			"id": "gemini-3.6-flash-low",
-			"name": "Gemini 3.6 Flash (Low) (Antigravity)",
-			"api": "google-gemini-cli",
-			"provider": "google-antigravity",
-			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 65536,
-			"thinking": {
-				"mode": "google-level",
-				"minLevel": "minimal",
-				"maxLevel": "high"
-			}
-		},
-		"gemini-3.6-flash-medium": {
-			"id": "gemini-3.6-flash-medium",
-			"name": "Gemini 3.6 Flash (Medium) (Antigravity)",
-			"api": "google-gemini-cli",
-			"provider": "google-antigravity",
-			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 65536,
-			"thinking": {
-				"mode": "google-level",
-				"minLevel": "minimal",
-				"maxLevel": "high"
-			}
-		},
-		"gemini-3.6-flash-tiered": {
-			"id": "gemini-3.6-flash-tiered",
-			"name": "gemini-3.6-flash-tiered",
-			"api": "google-gemini-cli",
-			"provider": "google-antigravity",
-			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 65536,
-			"thinking": {
-				"mode": "google-level",
-				"minLevel": "minimal",
-				"maxLevel": "high"
-			}
-		},
 		"gemini-3.7-flash-high": {
 			"id": "gemini-3.7-flash-high",
 			"name": "Gemini 3.7 Flash (High) (Antigravity)",
@@ -16414,6 +15807,31 @@
 			"thinking": {
 				"mode": "google-level",
 				"minLevel": "low",
+				"maxLevel": "high"
+			}
+		},
+		"gemini-3.6-flash-low": {
+			"id": "gemini-3.6-flash-low",
+			"name": "Gemini 3.6 Flash (Low) (Antigravity)",
+			"api": "google-gemini-cli",
+			"provider": "google-antigravity",
+			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "google-level",
+				"minLevel": "minimal",
 				"maxLevel": "high"
 			}
 		},
@@ -16442,6 +15860,31 @@
 				"maxLevel": "high"
 			}
 		},
+		"gemini-3.6-flash-medium": {
+			"id": "gemini-3.6-flash-medium",
+			"name": "Gemini 3.6 Flash (Medium) (Antigravity)",
+			"api": "google-gemini-cli",
+			"provider": "google-antigravity",
+			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "google-level",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"gemini-3.7-flash-medium": {
 			"id": "gemini-3.7-flash-medium",
 			"name": "Gemini 3.7 Flash (Medium) (Antigravity)",
@@ -16464,6 +15907,31 @@
 			"thinking": {
 				"mode": "google-level",
 				"minLevel": "low",
+				"maxLevel": "high"
+			}
+		},
+		"gemini-3.6-flash-tiered": {
+			"id": "gemini-3.6-flash-tiered",
+			"name": "gemini-3.6-flash-tiered",
+			"api": "google-gemini-cli",
+			"provider": "google-antigravity",
+			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "google-level",
+				"minLevel": "minimal",
 				"maxLevel": "high"
 			}
 		},
@@ -17174,7 +16642,7 @@
 			"api": "openai-completions",
 			"provider": "groq",
 			"baseUrl": "https://api.groq.com/openai/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -17185,7 +16653,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 8192
+			"maxTokens": 8192,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"groq/compound-mini": {
 			"id": "groq/compound-mini",
@@ -17193,7 +16666,7 @@
 			"api": "openai-completions",
 			"provider": "groq",
 			"baseUrl": "https://api.groq.com/openai/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -17204,7 +16677,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 8192
+			"maxTokens": 8192,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"llama-3.1-8b-instant": {
 			"id": "llama-3.1-8b-instant",
@@ -18079,7 +17557,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"~anthropic/claude-haiku-latest": {
@@ -18098,7 +17576,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"~anthropic/claude-opus-latest": {
@@ -18117,7 +17595,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"~anthropic/claude-sonnet-latest": {
@@ -18136,7 +17614,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"~deepseek/deepseek-v4-flash-latest": {
@@ -18155,7 +17633,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1310720,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"~google/gemini-flash-latest": {
@@ -18174,7 +17652,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"~google/gemini-pro-latest": {
@@ -18193,7 +17671,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"~moonshotai/kimi-latest": {
@@ -18212,7 +17690,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"~openai/gpt-latest": {
@@ -18231,7 +17709,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"~openai/gpt-mini-latest": {
@@ -18250,7 +17728,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 400000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"~x-ai/grok-latest": {
@@ -18269,26 +17747,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 500000,
-			"maxTokens": 8888
-		},
-		"~z-ai/glm-latest": {
-			"id": "~z-ai/glm-latest",
-			"name": "Z.ai: GLM Latest",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"ai21/jamba-large-1.7": {
@@ -18364,7 +17823,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"aion-labs/aion-3.0": {
@@ -18383,7 +17842,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"aion-labs/aion-3.0-mini": {
@@ -18402,7 +17861,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"aion-labs/aion-rp-llama-3.1-8b": {
@@ -18421,7 +17880,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"alfredpros/codellama-7b-instruct-solidity": {
@@ -18516,7 +17975,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 65536,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"allenai/olmo-3-7b-instruct": {
@@ -18630,7 +18089,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"amazon/nova-lite-v1": {
@@ -18649,7 +18108,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 300000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"amazon/nova-micro-v1": {
@@ -18668,7 +18127,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"amazon/nova-premier-v1": {
@@ -18687,7 +18146,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"amazon/nova-pro-v1": {
@@ -18706,7 +18165,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 300000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"anthracite-org/magnum-v4-72b": {
@@ -18725,7 +18184,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"anthropic/claude-3-haiku": {
@@ -18745,7 +18204,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"anthropic/claude-3.5-haiku": {
@@ -18859,11 +18318,11 @@
 		},
 		"anthropic/claude-haiku-4.5": {
 			"id": "anthropic/claude-haiku-4.5",
-			"name": "Anthropic Haiku 4.5 (latest)",
+			"name": "Anthropic Haiku 4.5",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
 				"text",
 				"image"
@@ -18875,12 +18334,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
+			"maxTokens": 64000
 		},
 		"anthropic/claude-opus-4": {
 			"id": "anthropic/claude-opus-4",
@@ -18934,7 +18388,7 @@
 		},
 		"anthropic/claude-opus-4.5": {
 			"id": "anthropic/claude-opus-4.5",
-			"name": "Anthropic Opus 4.5 (latest)",
+			"name": "Anthropic Opus 4.5",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -19042,7 +18496,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"anthropic/claude-opus-4.8": {
@@ -19087,7 +18541,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"anthropic/claude-opus-5": {
@@ -19132,7 +18586,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"anthropic/claude-sonnet-4": {
@@ -19162,7 +18616,7 @@
 		},
 		"anthropic/claude-sonnet-4.5": {
 			"id": "anthropic/claude-sonnet-4.5",
-			"name": "Anthropic Sonnet 4.5 (latest)",
+			"name": "Anthropic Sonnet 4.5",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -19203,7 +18657,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
-			"maxTokens": 128000,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -19346,7 +18800,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"arcee-ai/trinity-large-thinking:free": {
@@ -19403,7 +18857,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"baidu/cobuddy:free": {
@@ -19517,7 +18971,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 123000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"baidu/qianfan-ocr-fast": {
@@ -19593,7 +19047,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"bytedance-seed/seed-1.6-flash": {
@@ -19612,7 +19066,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"bytedance-seed/seed-2-1-turbo": {
@@ -19631,7 +19085,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"bytedance-seed/seed-2.0-code": {
@@ -19650,7 +19104,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"bytedance-seed/seed-2.0-lite": {
@@ -19669,7 +19123,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"bytedance-seed/seed-2.0-mini": {
@@ -19688,7 +19142,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"bytedance/ui-tars-1.5-7b": {
@@ -19707,7 +19161,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"cognitivecomputations/dolphin-mistral-24b-venice-edition": {
@@ -19726,7 +19180,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"cohere/command-a": {
@@ -19745,7 +19199,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"cohere/command-r-08-2024": {
@@ -19764,7 +19218,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"cohere/command-r-plus-08-2024": {
@@ -19783,7 +19237,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"cohere/command-r7b-12-2024": {
@@ -19802,7 +19256,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"cohere/north-mini-code:free": {
@@ -19821,7 +19275,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"corethink:free": {
@@ -19878,7 +19332,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 163840,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"deepseek/deepseek-chat-v3-0324": {
@@ -19897,7 +19351,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 163840,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"deepseek/deepseek-chat-v3.1": {
@@ -19916,7 +19370,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 163840,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"deepseek/deepseek-r1": {
@@ -19935,7 +19389,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 64000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"deepseek/deepseek-r1-0528": {
@@ -19954,7 +19408,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 163840,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"deepseek/deepseek-r1-distill-llama-70b": {
@@ -19973,7 +19427,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 8192,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"deepseek/deepseek-r1-distill-qwen-32b": {
@@ -20011,7 +19465,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 163840,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"deepseek/deepseek-v3.1-terminus:exacto": {
@@ -20049,7 +19503,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 163840,
+			"contextWindow": 128000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -20073,7 +19527,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 163840,
+			"contextWindow": 163000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -20116,7 +19570,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1000000,
 			"maxTokens": 384000,
 			"thinking": {
 				"mode": "effort",
@@ -20140,26 +19594,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1310720,
-			"maxTokens": 8888
-		},
-		"deepseek/deepseek-v4-flash-vision-exp": {
-			"id": "deepseek/deepseek-v4-flash-vision-exp",
-			"name": "DeepSeek: DeepSeek V4 Flash Vision Exp",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"deepseek/deepseek-v4-flash:discounted": {
@@ -20216,7 +19651,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1000000,
 			"maxTokens": 384000,
 			"thinking": {
 				"mode": "effort",
@@ -20240,7 +19675,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"deepseek/deepseek-v4-pro:discounted": {
@@ -20260,25 +19695,6 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 222222,
-			"maxTokens": 8888
-		},
-		"dots-studio/dots-3-note-preview:free": {
-			"id": "dots-studio/dots-3-note-preview:free",
-			"name": "Dots Studio: Dots3-Note Preview (free)",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 512000,
 			"maxTokens": 8888
 		},
 		"eleutherai/llemma_7b": {
@@ -20412,7 +19828,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1048000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -20436,7 +19852,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"google/gemini-2.5-flash-lite": {
@@ -20456,7 +19872,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1048000,
 			"maxTokens": 64000
 		},
 		"google/gemini-2.5-flash-lite-preview-09-2025": {
@@ -20495,7 +19911,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1048000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -20519,7 +19935,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"google/gemini-2.5-pro-preview-05-06": {
@@ -20538,7 +19954,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"google/gemini-3-flash-preview": {
@@ -20558,7 +19974,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1048000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -20582,7 +19998,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"google/gemini-3-pro-image-preview": {
@@ -20602,7 +20018,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 65536,
+			"contextWindow": 222222,
 			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
@@ -20659,7 +20075,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"google/gemini-3.1-flash-image-preview": {
@@ -20678,7 +20094,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 65536,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"google/gemini-3.1-flash-lite": {
@@ -20722,7 +20138,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 65536,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"google/gemini-3.1-flash-lite-preview": {
@@ -20742,7 +20158,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1050000,
 			"maxTokens": 65530
 		},
 		"google/gemini-3.1-pro-preview": {
@@ -20762,7 +20178,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1048000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -20790,7 +20206,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"google/gemini-3.5-flash": {
@@ -20834,7 +20250,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"google/gemini-3.6-flash": {
@@ -20853,7 +20269,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"google/gemini-3.7-flash": {
@@ -20872,7 +20288,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"google/gemma-2-27b-it": {
@@ -20891,7 +20307,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 8192,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"google/gemma-2-9b-it": {
@@ -20950,7 +20366,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
@@ -20995,7 +20411,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
+			"contextWindow": 128000,
 			"maxTokens": 4096
 		},
 		"google/gemma-4-26b-a4b-it": {
@@ -21014,7 +20430,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"google/gemma-4-31b-it": {
@@ -21034,7 +20450,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 256000,
 			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
@@ -21058,7 +20474,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"google/lyria-3-pro-preview": {
@@ -21077,7 +20493,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"gryphe/mythomax-l2-13b": {
@@ -21096,7 +20512,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 8192,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"ibm-granite/granite-4.0-h-micro": {
@@ -21115,7 +20531,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"ibm-granite/granite-4.1-8b": {
@@ -21134,7 +20550,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"inception/mercury": {
@@ -21172,7 +20588,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"inception/mercury-coder": {
@@ -21196,7 +20612,7 @@
 		},
 		"inclusionai/ling-2.6-1t": {
 			"id": "inclusionai/ling-2.6-1t",
-			"name": "inclusionAI: Ling-2.6-1T (retires Aug 24)",
+			"name": "inclusionAI: Ling-2.6-1T",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -21210,7 +20626,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"inclusionai/ling-2.6-1t:free": {
@@ -21234,7 +20650,7 @@
 		},
 		"inclusionai/ling-2.6-flash": {
 			"id": "inclusionai/ling-2.6-flash",
-			"name": "inclusionAI: Ling-2.6-flash (retires Aug 24)",
+			"name": "inclusionAI: Ling-2.6-flash",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -21248,7 +20664,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"inclusionai/ling-2.6-flash:free": {
@@ -21286,7 +20702,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"inclusionai/ling-3.0-tiny:free": {
@@ -21324,7 +20740,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 262000,
 			"maxTokens": 65000,
 			"thinking": {
 				"mode": "effort",
@@ -21405,7 +20821,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"kilo-auto/efficient": {
@@ -21424,7 +20840,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"kilo-auto/free": {
@@ -21443,7 +20859,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"kilo-auto/frontier": {
@@ -21462,7 +20878,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"kilo-auto/small": {
@@ -21481,7 +20897,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"kilo/auto": {
@@ -21557,7 +20973,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"kwaipilot/kat-coder-pro": {
@@ -21595,7 +21011,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"kwaipilot/kat-coder-pro-v2.5": {
@@ -21614,7 +21030,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"kwaipilot/kat-coder-pro-v2.5:free": {
@@ -21690,7 +21106,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 65536,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"liquid/lfm2-8b-a1b": {
@@ -21728,7 +21144,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 8000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"meituan/longcat-2.0": {
@@ -21747,26 +21163,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048756,
-			"maxTokens": 8888
-		},
-		"meituan/longcat-2.0-free": {
-			"id": "meituan/longcat-2.0-free",
-			"name": "Meituan: LongCat 2.0 (free)",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048756,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"meituan/longcat-flash-chat": {
@@ -21880,7 +21277,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"meta-llama/llama-3.1-8b-instruct": {
@@ -21899,7 +21296,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"meta-llama/llama-3.2-11b-vision-instruct": {
@@ -21937,7 +21334,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 60000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"meta-llama/llama-3.2-3b-instruct": {
@@ -21956,7 +21353,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"meta-llama/llama-3.3-70b-instruct": {
@@ -21975,7 +21372,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"meta-llama/llama-4-maverick": {
@@ -21994,7 +21391,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"meta-llama/llama-4-scout": {
@@ -22013,7 +21410,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1310720,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"meta-llama/llama-guard-2-8b": {
@@ -22070,7 +21467,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"meta-llama/llama-guard-4-12b:free": {
@@ -22094,14 +21491,13 @@
 		},
 		"meta/muse-glimmer-30b": {
 			"id": "meta/muse-glimmer-30b",
-			"name": "Muse Glimmer 30B",
+			"name": "Meta: Muse Glimmer 30B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 0,
@@ -22109,13 +21505,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 131072,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
+			"contextWindow": 222222,
+			"maxTokens": 8888
 		},
 		"meta/muse-spark-1.1": {
 			"id": "meta/muse-spark-1.1",
@@ -22133,7 +21524,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"meta/muse-spark-1.2": {
@@ -22152,32 +21543,13 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 222222,
 			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
-		},
-		"meta/muse-spark-1.2-contributor": {
-			"id": "meta/muse-spark-1.2-contributor",
-			"name": "Meta: Muse Spark 1.2 Contributor",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 8888
 		},
 		"microsoft/phi-4": {
 			"id": "microsoft/phi-4",
@@ -22195,7 +21567,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 16384,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"microsoft/phi-4-mini-instruct": {
@@ -22233,7 +21605,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 65535,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"minimax/minimax-01": {
@@ -22252,7 +21624,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000192,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"minimax/minimax-m1": {
@@ -22271,7 +21643,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"minimax/minimax-m2": {
@@ -22290,7 +21662,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204800,
+			"contextWindow": 204000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -22314,7 +21686,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 65536,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"minimax/minimax-m2.1": {
@@ -22333,7 +21705,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204800,
+			"contextWindow": 204000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -22425,7 +21797,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 512000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -22449,7 +21821,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"mistralai/devstral-2512": {
@@ -22525,7 +21897,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"mistralai/ministral-3b-2512": {
@@ -22544,26 +21916,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 8888
-		},
-		"mistralai/ministral-8b": {
-			"id": "mistralai/ministral-8b",
-			"name": "Mistral: Ministral 8B",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"mistralai/ministral-8b-2512": {
@@ -22582,7 +21935,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-7b-instruct": {
@@ -22658,7 +22011,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-large-2407": {
@@ -22677,7 +22030,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-large-2411": {
@@ -22715,7 +22068,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-medium-3": {
@@ -22734,7 +22087,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-medium-3-5": {
@@ -22753,7 +22106,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-medium-3.1": {
@@ -22772,7 +22125,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-nemo": {
@@ -22791,7 +22144,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-saba": {
@@ -22810,7 +22163,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-small-24b-instruct-2501": {
@@ -22829,7 +22182,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-small-2603": {
@@ -22848,7 +22201,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-small-3.1-24b-instruct": {
@@ -22867,7 +22220,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-small-3.2-24b-instruct": {
@@ -22886,7 +22239,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-small-creative": {
@@ -22981,7 +22334,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"moonshotai/kimi-k2": {
@@ -23000,7 +22353,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"moonshotai/kimi-k2-0905": {
@@ -23019,7 +22372,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"moonshotai/kimi-k2-0905:exacto": {
@@ -23057,7 +22410,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
@@ -23082,7 +22435,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 262000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -23238,7 +22591,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 81920,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"morph/morph-v3-large": {
@@ -23257,7 +22610,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"neversleep/llama-3.1-lumimaid-8b": {
@@ -23333,7 +22686,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"nex-agi/nex-n2-pro": {
@@ -23352,7 +22705,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"nex-agi/nex-n2-pro:free": {
@@ -23409,7 +22762,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"nousresearch/hermes-3-llama-3.1-70b": {
@@ -23428,7 +22781,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"nousresearch/hermes-4-405b": {
@@ -23447,7 +22800,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"nousresearch/hermes-4-70b": {
@@ -23466,7 +22819,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"nvidia/llama-3.1-nemotron-70b-instruct": {
@@ -23552,7 +22905,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 131072,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -23576,7 +22929,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"nvidia/nemotron-3-super-120b-a12b": {
@@ -23595,7 +22948,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 262144,
 			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
@@ -23619,7 +22972,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"nvidia/nemotron-3-ultra-550b-a55b": {
@@ -23638,7 +22991,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 512288,
+			"contextWindow": 1000000,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -23662,7 +23015,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"nvidia/nemotron-3.5-content-safety:free": {
@@ -23681,7 +23034,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"nvidia/nemotron-3.5-lightning": {
@@ -23700,7 +23053,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"nvidia/nemotron-3.5-lightning:free": {
@@ -23719,7 +23072,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"nvidia/nemotron-nano-12b-v2-vl": {
@@ -23782,7 +23135,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 16385,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openai/gpt-3.5-turbo-0613": {
@@ -23801,7 +23154,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 4095,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openai/gpt-3.5-turbo-16k": {
@@ -23820,7 +23173,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 16385,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openai/gpt-3.5-turbo-instruct": {
@@ -23839,7 +23192,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 4095,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openai/gpt-4": {
@@ -23858,7 +23211,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 8191,
+			"contextWindow": 8192,
 			"maxTokens": 8192
 		},
 		"openai/gpt-4-0314": {
@@ -23935,7 +23288,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openai/gpt-4.1": {
@@ -24034,7 +23387,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openai/gpt-4o-2024-08-06": {
@@ -24053,7 +23406,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openai/gpt-4o-2024-11-20": {
@@ -24072,7 +23425,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openai/gpt-4o-audio-preview": {
@@ -24130,7 +23483,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openai/gpt-4o-mini-search-preview": {
@@ -24275,7 +23628,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 400000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openai/gpt-5-image-mini": {
@@ -24294,7 +23647,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 400000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openai/gpt-5-mini": {
@@ -24527,7 +23880,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openai/gpt-5.2-codex": {
@@ -24665,7 +24018,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 272000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openai/gpt-5.4-mini": {
@@ -24834,7 +24187,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openai/gpt-5.6-sol": {
@@ -24862,25 +24215,6 @@
 				"maxLevel": "max"
 			}
 		},
-		"openai/gpt-5.6-sol-discounted": {
-			"id": "openai/gpt-5.6-sol-discounted",
-			"name": "OpenAI: GPT-5.6 Sol (50% off)",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1050000,
-			"maxTokens": 8888
-		},
 		"openai/gpt-5.6-sol-pro": {
 			"id": "openai/gpt-5.6-sol-pro",
 			"name": "OpenAI: GPT-5.6 Sol Pro",
@@ -24897,7 +24231,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openai/gpt-5.6-terra": {
@@ -24941,7 +24275,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openai/gpt-audio": {
@@ -24960,7 +24294,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openai/gpt-audio-mini": {
@@ -24979,7 +24313,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openai/gpt-chat-latest": {
@@ -24998,7 +24332,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 400000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openai/gpt-oss-120b": {
@@ -25226,7 +24560,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openai/o3-pro": {
@@ -25314,7 +24648,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"opengvlab/internvl3-78b": {
@@ -25352,7 +24686,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 2000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openrouter/auto-beta": {
@@ -25371,7 +24705,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 2000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openrouter/bodybuilder": {
@@ -25390,7 +24724,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openrouter/elephant-alpha": {
@@ -25428,7 +24762,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openrouter/fusion": {
@@ -25447,7 +24781,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"openrouter/healer-alpha": {
@@ -25523,7 +24857,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 2000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"perceptron/perceptron-mk1": {
@@ -25542,7 +24876,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"perplexity/sonar": {
@@ -25561,7 +24895,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 127072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"perplexity/sonar-deep-research": {
@@ -25580,7 +24914,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"perplexity/sonar-pro": {
@@ -25599,7 +24933,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"perplexity/sonar-pro-search": {
@@ -25618,7 +24952,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"perplexity/sonar-reasoning-pro": {
@@ -25637,7 +24971,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"poolside/laguna-m.1": {
@@ -25694,7 +25028,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"poolside/laguna-s-2.1:free": {
@@ -25713,7 +25047,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"poolside/laguna-xs-2.1": {
@@ -25756,7 +25090,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"poolside/laguna-xs.2": {
@@ -25832,7 +25166,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen-2.5-7b-instruct": {
@@ -25851,7 +25185,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen-2.5-coder-32b-instruct": {
@@ -25870,7 +25204,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen-2.5-vl-7b-instruct": {
@@ -25927,7 +25261,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen-plus-2025-07-28": {
@@ -25946,7 +25280,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen-plus-2025-07-28:thinking": {
@@ -25965,7 +25299,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen-turbo": {
@@ -26079,7 +25413,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-14b": {
@@ -26098,7 +25432,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-235b-a22b": {
@@ -26117,7 +25451,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
@@ -26141,7 +25475,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-235b-a22b-thinking-2507": {
@@ -26160,7 +25494,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-30b-a3b": {
@@ -26179,7 +25513,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-30b-a3b-instruct-2507": {
@@ -26198,7 +25532,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-30b-a3b-thinking-2507": {
@@ -26217,7 +25551,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 81920,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-32b": {
@@ -26236,7 +25570,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
@@ -26260,7 +25594,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-coder": {
@@ -26279,7 +25613,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-coder-30b-a3b-instruct": {
@@ -26298,7 +25632,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-coder-flash": {
@@ -26317,7 +25651,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-coder-next": {
@@ -26336,7 +25670,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-coder-plus": {
@@ -26393,7 +25727,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 256000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -26417,7 +25751,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-next-80b-a3b-instruct": {
@@ -26455,7 +25789,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
@@ -26479,7 +25813,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-vl-235b-a22b-thinking": {
@@ -26498,7 +25832,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-vl-30b-a3b-instruct": {
@@ -26517,7 +25851,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-vl-30b-a3b-thinking": {
@@ -26536,7 +25870,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-vl-32b-instruct": {
@@ -26555,7 +25889,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-vl-8b-instruct": {
@@ -26574,7 +25908,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-vl-8b-thinking": {
@@ -26593,7 +25927,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.5-122b-a10b": {
@@ -26637,7 +25971,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.5-35b-a3b": {
@@ -26656,7 +25990,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.5-397b-a17b": {
@@ -26700,7 +26034,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.5-flash-02-23": {
@@ -26719,7 +26053,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.5-plus-02-15": {
@@ -26738,7 +26072,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.5-plus-20260420": {
@@ -26757,7 +26091,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.6-27b": {
@@ -26777,7 +26111,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 131072,
 			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
@@ -26801,7 +26135,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.6-flash": {
@@ -26820,7 +26154,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.6-max-preview": {
@@ -26839,7 +26173,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.6-plus": {
@@ -26920,7 +26254,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.7-max": {
@@ -26988,26 +26322,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
-			"maxTokens": 8888
-		},
-		"qwen/qwen3.8-27b": {
-			"id": "qwen/qwen3.8-27b",
-			"name": "Qwen: Qwen3.8 27B",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.8-max": {
@@ -27026,7 +26341,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"qwen/qwq-32b": {
@@ -27102,7 +26417,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 16384,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"rekaai/reka-flash-3": {
@@ -27121,7 +26436,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 65536,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"relace/relace-apply-3": {
@@ -27140,7 +26455,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"relace/relace-search": {
@@ -27159,7 +26474,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"sakana/fugu-ultra": {
@@ -27178,7 +26493,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"sakana/sakana-namazu": {
@@ -27197,7 +26512,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"sao10k/l3-euryale-70b": {
@@ -27235,7 +26550,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 8192,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"sao10k/l3.1-70b-hanami-x1": {
@@ -27273,7 +26588,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"sao10k/l3.3-euryale-70b": {
@@ -27292,7 +26607,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"stealth/claude-opus-4.6": {
@@ -27311,7 +26626,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"stealth/claude-opus-4.7": {
@@ -27330,7 +26645,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"stealth/claude-opus-4.8": {
@@ -27350,7 +26665,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"stealth/claude-sonnet-4.6": {
@@ -27369,7 +26684,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"stealth/gpt-5.6-sol": {
@@ -27397,9 +26712,10 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -27408,7 +26724,18 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 8888
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "max",
+				"defaultLevel": "max",
+				"levels": [
+					"low",
+					"high",
+					"max"
+				]
+			}
 		},
 		"stealth/qwen3.6-plus": {
 			"id": "stealth/qwen3.6-plus",
@@ -27426,7 +26753,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"stepfun/step-3.5-flash": {
@@ -27445,7 +26772,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 256000,
 			"maxTokens": 64000
 		},
 		"stepfun/step-3.5-flash:free": {
@@ -27484,7 +26811,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 256000,
 			"maxTokens": 256000,
 			"thinking": {
 				"mode": "effort",
@@ -27508,7 +26835,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"switchpoint/router": {
@@ -27546,64 +26873,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 8888
-		},
-		"tencent/hy-mt2-1.8b": {
-			"id": "tencent/hy-mt2-1.8b",
-			"name": "Tencent: Hy-MT2-1.8B",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 8192,
-			"maxTokens": 8888
-		},
-		"tencent/hy-mt2-30b-a3b": {
-			"id": "tencent/hy-mt2-30b-a3b",
-			"name": "Tencent: Hy-MT2-30B-A3B",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 8192,
-			"maxTokens": 8888
-		},
-		"tencent/hy-mt2-7b": {
-			"id": "tencent/hy-mt2-7b",
-			"name": "Tencent: Hy-MT2-7B",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 8192,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"tencent/hy3": {
@@ -27622,7 +26892,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"tencent/hy3-preview": {
@@ -27641,7 +26911,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 256000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -27684,7 +26954,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"thedrummer/cydonia-24b-v4.1": {
@@ -27703,7 +26973,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"thedrummer/rocinante-12b": {
@@ -27722,7 +26992,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 65536,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"thedrummer/skyfall-36b-v2": {
@@ -27741,7 +27011,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"thedrummer/unslopnemo-12b": {
@@ -27760,7 +27030,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1024000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"thinkingmachines/inkling": {
@@ -27804,45 +27074,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
-			"maxTokens": 8888
-		},
-		"thinkingmachines/inkling-small:free": {
-			"id": "thinkingmachines/inkling-small:free",
-			"name": "Thinking Machines: Inkling Small (free)",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262144,
-			"maxTokens": 8888
-		},
-		"thinkingmachines/inkling:free": {
-			"id": "thinkingmachines/inkling:free",
-			"name": "Thinking Machines: Inkling (free)",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"tngtech/deepseek-r1t2-chimera": {
@@ -27880,7 +27112,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 6144,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"upstage/solar-pro-3": {
@@ -27899,7 +27131,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"upstage/solar-pro4": {
@@ -27918,7 +27150,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 524288,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"writer/palmyra-x5": {
@@ -27937,7 +27169,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1040000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"x-ai/grok-3": {
@@ -28107,7 +27339,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 2000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"x-ai/grok-4.20-beta": {
@@ -28145,7 +27377,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 2000000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"x-ai/grok-4.20-multi-agent-beta": {
@@ -28233,7 +27465,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 500000,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"x-ai/grok-build-0.1": {
@@ -28432,7 +27664,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 1048576,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -28456,7 +27688,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 1048576,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -28499,7 +27731,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 128000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -28523,7 +27755,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 128000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -28547,7 +27779,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 65536,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"z-ai/glm-4.6": {
@@ -28566,7 +27798,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204800,
+			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -28610,7 +27842,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -28634,7 +27866,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204800,
+			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -28658,7 +27890,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 202752,
+			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
 		"z-ai/glm-5": {
@@ -28677,7 +27909,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204800,
+			"contextWindow": 200000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -28701,7 +27933,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 202752,
+			"contextWindow": 200000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -28725,7 +27957,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204800,
+			"contextWindow": 200000,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -28749,32 +27981,13 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1000000,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
-		},
-		"z-ai/glm-5.3": {
-			"id": "z-ai/glm-5.3",
-			"name": "Z.ai: GLM 5.3 (new)",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 8888
 		},
 		"z-ai/glm-5v-turbo": {
 			"id": "z-ai/glm-5v-turbo",
@@ -28793,7 +28006,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 202752,
+			"contextWindow": 200000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -29432,11 +28645,11 @@
 		},
 		"anthropic/claude-haiku-4.5": {
 			"id": "anthropic/claude-haiku-4.5",
-			"name": "Anthropic Haiku 4.5 (latest)",
+			"name": "Anthropic Haiku 4.5",
 			"api": "openai-completions",
 			"provider": "litellm",
 			"baseUrl": "http://localhost:4000/v1",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
 				"text",
 				"image"
@@ -29448,12 +28661,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
+			"maxTokens": 64000
 		},
 		"anthropic/claude-haiku-latest": {
 			"id": "anthropic/claude-haiku-latest",
@@ -29526,7 +28734,7 @@
 		},
 		"anthropic/claude-opus-4.5": {
 			"id": "anthropic/claude-opus-4.5",
-			"name": "Anthropic Opus 4.5 (latest)",
+			"name": "Anthropic Opus 4.5",
 			"api": "openai-completions",
 			"provider": "litellm",
 			"baseUrl": "http://localhost:4000/v1",
@@ -29645,7 +28853,7 @@
 		},
 		"anthropic/claude-sonnet-4.5": {
 			"id": "anthropic/claude-sonnet-4.5",
-			"name": "Anthropic Sonnet 4.5 (latest)",
+			"name": "Anthropic Sonnet 4.5",
 			"api": "openai-completions",
 			"provider": "litellm",
 			"baseUrl": "http://localhost:4000/v1",
@@ -41058,14 +40266,13 @@
 		},
 		"Qwen/Qwen3-VL-235B-A22B-Instruct": {
 			"id": "Qwen/Qwen3-VL-235B-A22B-Instruct",
-			"name": "Qwen3 VL 235B A22B Instruct",
+			"name": "Qwen/Qwen3-VL-235B-A22B-Instruct",
 			"api": "openai-completions",
 			"provider": "litellm",
 			"baseUrl": "http://localhost:4000/v1",
 			"reasoning": false,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 0,
@@ -41073,8 +40280,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 32768
+			"contextWindow": 222222,
+			"maxTokens": 8888
 		},
 		"qwen/qwen3-vl-plus": {
 			"id": "qwen/qwen3-vl-plus",
@@ -57181,14 +56388,13 @@
 		},
 		"Qwen/Qwen3-VL-235B-A22B-Instruct": {
 			"id": "Qwen/Qwen3-VL-235B-A22B-Instruct",
-			"name": "Qwen3 VL 235B A22B Instruct",
+			"name": "Qwen/Qwen3-VL-235B-A22B-Instruct",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
 			"reasoning": false,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 0,
@@ -57196,8 +56402,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 32768
+			"contextWindow": 222222,
+			"maxTokens": 8888
 		},
 		"qwen/qwen3.5-397b-a17b": {
 			"id": "qwen/qwen3.5-397b-a17b",
@@ -61346,30 +60552,6 @@
 				"maxLevel": "xhigh"
 			}
 		},
-		"deepseek-ai/deepseek-v4-flash-0731": {
-			"id": "deepseek-ai/deepseek-v4-flash-0731",
-			"name": "DeepSeek V4 Flash 0731",
-			"api": "openai-completions",
-			"provider": "nvidia",
-			"baseUrl": "https://integrate.api.nvidia.com/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 384000,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
 		"deepseek-ai/deepseek-v4-pro": {
 			"id": "deepseek-ai/deepseek-v4-pro",
 			"name": "DeepSeek V4 Pro",
@@ -61794,31 +60976,6 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096
-		},
-		"meta/muse-glimmer-30b": {
-			"id": "meta/muse-glimmer-30b",
-			"name": "Muse Glimmer 30B",
-			"api": "openai-completions",
-			"provider": "nvidia",
-			"baseUrl": "https://integrate.api.nvidia.com/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 131072,
-			"maxTokens": 131072,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
 		},
 		"microsoft/phi-3-medium-128k-instruct": {
 			"id": "microsoft/phi-3-medium-128k-instruct",
@@ -62476,31 +61633,6 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"moonshotai/kimi-k3": {
-			"id": "moonshotai/kimi-k3",
-			"name": "Kimi K3",
-			"api": "openai-completions",
-			"provider": "nvidia",
-			"baseUrl": "https://integrate.api.nvidia.com/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -65562,31 +64694,6 @@
 				"requiresReasoningContentForToolCalls": true
 			}
 		},
-		"deepseek-v4-flash-vision-exp": {
-			"id": "deepseek-v4-flash-vision-exp",
-			"name": "DeepSeek V4 Flash Vision Exp",
-			"api": "openai-completions",
-			"provider": "opencode-go",
-			"baseUrl": "https://opencode.ai/zen/go/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.22,
-				"output": 0.66,
-				"cacheRead": 0.007,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 384000,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
 		"deepseek-v4-pro": {
 			"id": "deepseek-v4-pro",
 			"name": "DeepSeek V4 Pro",
@@ -65714,7 +64821,7 @@
 		},
 		"gpt-5.6-luna": {
 			"id": "gpt-5.6-luna",
-			"name": "GPT-5.6 Luna",
+			"name": "GPT-5.6 Luna (2x usage)",
 			"api": "openai-responses",
 			"provider": "opencode-go",
 			"baseUrl": "https://opencode.ai/zen/go/v1",
@@ -65724,10 +64831,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.2,
-				"output": 1.2,
-				"cacheRead": 0.02,
-				"cacheWrite": 0.25
+				"input": 0.1,
+				"output": 0.6,
+				"cacheRead": 0.01,
+				"cacheWrite": 0.125
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -65764,7 +64871,7 @@
 		},
 		"hy3": {
 			"id": "hy3",
-			"name": "Hy3 (8x usage)",
+			"name": "Hy3",
 			"api": "openai-completions",
 			"provider": "opencode-go",
 			"baseUrl": "https://opencode.ai/zen/go/v1",
@@ -65773,9 +64880,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.0175,
-				"output": 0.0725,
-				"cacheRead": 0.004375,
+				"input": 0.14,
+				"output": 0.58,
+				"cacheRead": 0.035,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -66081,56 +65188,6 @@
 				"maxLevel": "xhigh"
 			}
 		},
-		"muse-spark-1.2-contributor": {
-			"id": "muse-spark-1.2-contributor",
-			"name": "Muse Spark 1.2 Contributor",
-			"api": "openai-responses",
-			"provider": "opencode-go",
-			"baseUrl": "https://opencode.ai/zen/go/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.1,
-				"output": 0.2,
-				"cacheRead": 0.002,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 131072,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"ox-alpha-free": {
-			"id": "ox-alpha-free",
-			"name": "Ox Alpha Free (Unlimited)",
-			"api": "openai-completions",
-			"provider": "opencode-go",
-			"baseUrl": "https://opencode.ai/zen/go/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 131072,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
 		"qwen3.5-plus": {
 			"id": "qwen3.5-plus",
 			"name": "Qwen3.5 Plus",
@@ -66233,9 +65290,9 @@
 		"qwen3.8-max": {
 			"id": "qwen3.8-max",
 			"name": "Qwen3.8 Max",
-			"api": "openai-completions",
+			"api": "anthropic-messages",
 			"provider": "opencode-go",
-			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"baseUrl": "https://opencode.ai/zen/go",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -66250,9 +65307,9 @@
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
 			"thinking": {
-				"mode": "effort",
+				"mode": "budget",
 				"minLevel": "minimal",
-				"maxLevel": "high"
+				"maxLevel": "xhigh"
 			}
 		}
 	},
@@ -67435,7 +66492,7 @@
 		},
 		"gpt-5.6-sol": {
 			"id": "gpt-5.6-sol",
-			"name": "GPT-5.6 Sol (50% Off)",
+			"name": "GPT-5.6 Sol",
 			"api": "openai-responses",
 			"provider": "opencode-zen",
 			"baseUrl": "https://opencode.ai/zen/v1",
@@ -67445,10 +66502,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 10,
-				"cacheRead": 0.2,
-				"cacheWrite": 2.5
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -68060,31 +67117,6 @@
 				"maxLevel": "xhigh"
 			}
 		},
-		"muse-spark-1.2-contributor-free": {
-			"id": "muse-spark-1.2-contributor-free",
-			"name": "Muse Spark 1.2 Free",
-			"api": "openai-responses",
-			"provider": "opencode-zen",
-			"baseUrl": "https://opencode.ai/zen/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 131072,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
 		"nemotron-3-super-free": {
 			"id": "nemotron-3-super-free",
 			"name": "Nemotron 3 Super Free",
@@ -68297,31 +67329,6 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072
-		},
-		"x-preview-f-free": {
-			"id": "x-preview-f-free",
-			"name": "Ox Alpha Free (Unlimited)",
-			"api": "openai-completions",
-			"provider": "opencode-zen",
-			"baseUrl": "https://opencode.ai/zen/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 131072,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
 		}
 	},
 	"opengateway": {
@@ -68508,13 +67515,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.04,
-				"output": 0.13,
-				"cacheRead": 0.01,
+				"input": 0.079996,
+				"output": 0.252,
+				"cacheRead": 0.0252,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1310720,
-			"maxTokens": 262144,
+			"contextWindow": 1048576,
+			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -68583,13 +67590,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.6,
-				"output": 13,
+				"input": 2.8,
+				"output": 14,
 				"cacheRead": 0.29,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 974842,
+			"maxTokens": 1048576,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -68608,10 +67615,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 10,
-				"cacheRead": 0.19999999999999998,
-				"cacheWrite": 2.5
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -68665,30 +67672,6 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 8888,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "high"
-			}
-		},
-		"~z-ai/glm-latest": {
-			"id": "~z-ai/glm-latest",
-			"name": "Z.ai: GLM Latest",
-			"api": "openai-completions",
-			"provider": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 1.4,
-				"output": 4.4,
-				"cacheRead": 0.26,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -69107,11 +68090,11 @@
 		},
 		"anthropic/claude-haiku-4.5": {
 			"id": "anthropic/claude-haiku-4.5",
-			"name": "Anthropic Haiku 4.5 (latest)",
+			"name": "Anthropic Haiku 4.5",
 			"api": "openai-completions",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
 				"text",
 				"image"
@@ -69123,12 +68106,7 @@
 				"cacheWrite": 1.25
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "high"
-			}
+			"maxTokens": 64000
 		},
 		"anthropic/claude-haiku-4.5:batch": {
 			"id": "anthropic/claude-haiku-4.5:batch",
@@ -69232,7 +68210,7 @@
 		},
 		"anthropic/claude-opus-4.5": {
 			"id": "anthropic/claude-opus-4.5",
-			"name": "Anthropic Opus 4.5 (latest)",
+			"name": "Anthropic Opus 4.5",
 			"api": "openai-completions",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -69607,7 +68585,7 @@
 		},
 		"anthropic/claude-sonnet-4.5": {
 			"id": "anthropic/claude-sonnet-4.5",
-			"name": "Anthropic Sonnet 4.5 (latest)",
+			"name": "Anthropic Sonnet 4.5",
 			"api": "openai-completions",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -70252,13 +69230,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 1,
+				"input": 0.27,
+				"output": 1.12,
 				"cacheRead": 0.135,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
-			"maxTokens": 163840,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -70276,13 +69254,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.55,
-				"output": 1.6500000000000001,
-				"cacheRead": 0.55,
+				"input": 0.25,
+				"output": 0.95,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
-			"maxTokens": 161000,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -70349,8 +69327,8 @@
 			],
 			"cost": {
 				"input": 0.27,
-				"output": 1,
-				"cacheRead": 0.135,
+				"output": 0.95,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
@@ -70396,13 +69374,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.26,
-				"output": 0.38,
-				"cacheRead": 0.13,
+				"input": 0.26899999999999996,
+				"output": 0.39999999999999997,
+				"cacheRead": 0.13449999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
-			"maxTokens": 163840,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -70444,13 +69422,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.05166,
-				"output": 0.10332,
-				"cacheRead": 0.010332,
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 384000,
+			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -70468,38 +69446,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.08,
-				"output": 0.18,
-				"cacheRead": 0.016,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1310720,
-			"maxTokens": 384000,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "high"
-			}
-		},
-		"deepseek/deepseek-v4-flash-vision-exp": {
-			"id": "deepseek/deepseek-v4-flash-vision-exp",
-			"name": "DeepSeek: DeepSeek V4 Flash Vision Exp",
-			"api": "openai-completions",
-			"provider": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.22,
-				"output": 0.66,
-				"cacheRead": 0.007,
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 384000,
+			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -70541,13 +69494,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.396894,
-				"output": 0.793788,
-				"cacheRead": 0.0330745,
+				"input": 1.1680000000000001,
+				"output": 2.3360000000000003,
+				"cacheRead": 0.09855000000000001,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 384000,
+			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -70565,38 +69518,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.122,
-				"output": 3.366,
-				"cacheRead": 0.037399999999999996,
+				"input": 0.435,
+				"output": 0.87,
+				"cacheRead": 0.003625,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 8888,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "high"
-			}
-		},
-		"dots-studio/dots-3-note-preview:free": {
-			"id": "dots-studio/dots-3-note-preview:free",
-			"name": "Dots Studio: Dots3-Note Preview (free)",
-			"api": "openai-completions",
-			"provider": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 512000,
-			"maxTokens": 512000,
+			"maxTokens": 384000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -71449,13 +70377,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.07,
-				"output": 0.33999999999999997,
+				"input": 0.12,
+				"output": 0.39999999999999997,
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 16384,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -71464,7 +70392,7 @@
 		},
 		"google/gemma-4-26b-a4b-it:free": {
 			"id": "google/gemma-4-26b-a4b-it:free",
-			"name": "Google: Gemma 4 26B A4B (free)",
+			"name": "Google: Gemma 4 26B A4B  (free)",
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -71906,7 +70834,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 65536,
+			"contextWindow": 128000,
 			"maxTokens": 8192,
 			"thinking": {
 				"mode": "effort",
@@ -72084,12 +71012,12 @@
 			],
 			"cost": {
 				"input": 0.19999999999999998,
-				"output": 0.7999999999999999,
+				"output": 0.696,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 16384
+			"maxTokens": 8888
 		},
 		"meta-llama/llama-4-scout": {
 			"id": "meta-llama/llama-4-scout",
@@ -72113,7 +71041,7 @@
 		},
 		"meta/muse-glimmer-30b": {
 			"id": "meta/muse-glimmer-30b",
-			"name": "Muse Glimmer 30B",
+			"name": "Meta: Muse Glimmer 30B",
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -72129,7 +71057,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 131072,
+			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -72184,31 +71112,6 @@
 				"mode": "effort",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
-			}
-		},
-		"meta/muse-spark-1.2-contributor": {
-			"id": "meta/muse-spark-1.2-contributor",
-			"name": "Meta: Muse Spark 1.2 Contributor",
-			"api": "openai-completions",
-			"provider": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.09999999999999999,
-				"output": 0.19999999999999998,
-				"cacheRead": 0.002,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 8888,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "high"
 			}
 		},
 		"minimax/minimax-m1": {
@@ -72294,13 +71197,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.27,
-				"output": 1.08,
-				"cacheRead": 0.027,
+				"input": 0.22,
+				"output": 0.8999999999999999,
+				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
-			"maxTokens": 128000,
+			"maxTokens": 196608,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -72395,9 +71298,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 1.2,
-				"cacheRead": 0.06,
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 524288,
@@ -72820,12 +71723,12 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.075,
-				"output": 0.19999999999999998,
+				"input": 0.09375,
+				"output": 0.25,
 				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 256000,
 			"maxTokens": 16384
 		},
 		"mistralai/mistral-small-creative": {
@@ -73017,9 +71920,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.44999999999999996,
-				"output": 2.25,
-				"cacheRead": 0.07,
+				"input": 0.5700000000000001,
+				"output": 2.8499999999999996,
+				"cacheRead": 0.095,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -73094,7 +71997,7 @@
 			"cost": {
 				"input": 0.67,
 				"output": 3.4,
-				"cacheRead": 0.16999999999999998,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -73117,9 +72020,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.95,
-				"output": 4,
-				"cacheRead": 0.19,
+				"input": 0.475,
+				"output": 2,
+				"cacheRead": 0.095,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -73353,11 +72256,11 @@
 			"cost": {
 				"input": 0.049999999999999996,
 				"output": 0.19999999999999998,
-				"cacheRead": 0.03,
+				"cacheRead": 0.024999999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 228000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -73496,9 +72399,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.6,
-				"output": 3.5999999999999996,
-				"cacheRead": 0.19999999999999998,
+				"input": 0.3,
+				"output": 1.7999999999999998,
+				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 0
 			},
 			"contextWindow": 512288,
@@ -73544,13 +72447,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.08,
-				"output": 0.19999999999999998,
-				"cacheRead": 0.04,
+				"input": 0.09999999999999999,
+				"output": 0.25,
+				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 131072,
+			"contextWindow": 1000000,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -75111,10 +74014,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.19999999999999998,
-				"output": 1.2,
-				"cacheRead": 0.02,
-				"cacheWrite": 0.25
+				"input": 0.09999999999999999,
+				"output": 0.6,
+				"cacheRead": 0.01,
+				"cacheWrite": 0.125
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -75136,10 +74039,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.19999999999999998,
-				"output": 1.2,
-				"cacheRead": 0.02,
-				"cacheWrite": 0.25
+				"input": 0.09999999999999999,
+				"output": 0.6,
+				"cacheRead": 0.01,
+				"cacheWrite": 0.125
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -75211,10 +74114,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 10,
-				"cacheRead": 0.19999999999999998,
-				"cacheWrite": 2.5
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -75236,10 +74139,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 10,
-				"cacheRead": 0.19999999999999998,
-				"cacheWrite": 2.5
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -75261,10 +74164,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
-				"output": 5,
-				"cacheRead": 0.09999999999999999,
-				"cacheWrite": 1.25
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
+				"cacheWrite": 0
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -75286,10 +74189,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
-				"output": 5,
-				"cacheRead": 0.09999999999999999,
-				"cacheWrite": 1.25
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
+				"cacheWrite": 0
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -75311,10 +74214,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 12,
-				"cacheRead": 0.19999999999999998,
-				"cacheWrite": 2.5
+				"input": 1,
+				"output": 6,
+				"cacheRead": 0.09999999999999999,
+				"cacheWrite": 1.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -75336,10 +74239,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 12,
-				"cacheRead": 0.19999999999999998,
-				"cacheWrite": 2.5
+				"input": 1,
+				"output": 6,
+				"cacheRead": 0.09999999999999999,
+				"cacheWrite": 1.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -75468,7 +74371,7 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.037,
+				"input": 0.03,
 				"output": 0.16999999999999998,
 				"cacheRead": 0.03,
 				"cacheWrite": 0
@@ -76508,8 +75411,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.26,
-				"output": 0.78,
+				"input": 0.39999999999999997,
+				"output": 1.2,
 				"cacheRead": 0,
 				"cacheWrite": 0.5
 			},
@@ -77074,8 +75977,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.21,
-				"output": 1.9,
+				"input": 0.26,
+				"output": 1.04,
 				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 0
 			},
@@ -77229,13 +76132,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.26,
-				"output": 2.08,
+				"input": 0.29,
+				"output": 2.4,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 81920,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -77304,13 +76207,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.39,
-				"output": 2.34,
+				"input": 0.5,
+				"output": 3.5999999999999996,
 				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -77454,7 +76357,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.14,
+				"input": 0.15,
 				"output": 1,
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
@@ -77679,33 +76582,8 @@
 				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
-			"maxTokens": 131072,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "high"
-			}
-		},
-		"qwen/qwen3.8-27b": {
-			"id": "qwen/qwen3.8-27b",
-			"name": "Qwen: Qwen3.8 27B",
-			"api": "openai-completions",
-			"provider": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.39999999999999997,
-				"output": 3,
-				"cacheRead": 0.049999999999999996,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 131072,
+			"contextWindow": 1010000,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -77908,37 +76786,6 @@
 			"contextWindow": 131072,
 			"maxTokens": 16384
 		},
-		"stealth/ox-alpha": {
-			"id": "stealth/ox-alpha",
-			"name": "Ox Alpha",
-			"api": "openai-completions",
-			"provider": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 131072,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "low",
-				"maxLevel": "max",
-				"defaultLevel": "max",
-				"levels": [
-					"low",
-					"high",
-					"max"
-				]
-			}
-		},
 		"stepfun/step-3.5-flash": {
 			"id": "stepfun/step-3.5-flash",
 			"name": "Step 3.5 Flash",
@@ -78051,9 +76898,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.18,
-				"output": 0.6,
-				"cacheRead": 0.06,
+				"input": 0.063,
+				"output": 0.21,
+				"cacheRead": 0.020999999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -78138,13 +76985,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
+				"input": 0.95,
 				"output": 4.05,
-				"cacheRead": 0.16999999999999998,
+				"cacheRead": 0.16,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 16384,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -78168,36 +77015,8 @@
 				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 524288,
 			"maxTokens": 262144,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "high"
-			}
-		},
-		"thinkingmachines/inkling-small:free": {
-			"id": "thinkingmachines/inkling-small:free",
-			"name": "Thinking Machines: Inkling Small (free)",
-			"api": "openai-completions",
-			"provider": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262144,
-			"maxTokens": 262144,
-			"compat": {
-				"supportsToolChoice": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -78216,41 +77035,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
-				"output": 4.05,
-				"cacheRead": 0.16999999999999998,
+				"input": 0.5,
+				"output": 2.025,
+				"cacheRead": 0.08499999999999999,
 				"cacheWrite": 0
 			},
 			"contextWindow": 524288,
 			"maxTokens": 8888,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "high"
-			}
-		},
-		"thinkingmachines/inkling:free": {
-			"id": "thinkingmachines/inkling:free",
-			"name": "Thinking Machines: Inkling (free)",
-			"api": "openai-completions",
-			"provider": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262144,
-			"maxTokens": 262144,
-			"compat": {
-				"supportsToolChoice": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -79082,13 +77873,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.6,
-				"output": 1.92,
-				"cacheRead": 0.12,
+				"input": 0.95,
+				"output": 2.5500000000000003,
+				"cacheRead": 0.19999999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
-			"maxTokens": 128000,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -79130,13 +77921,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.966,
-				"output": 3.036,
-				"cacheRead": 0.1794,
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0.26,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
-			"maxTokens": 128000,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -79154,9 +77945,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.966,
-				"output": 3.036,
-				"cacheRead": 0.1932,
+				"input": 0.63,
+				"output": 1.9800000000000002,
+				"cacheRead": 0.0945,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -79178,61 +77969,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.4,
-				"output": 4.4,
-				"cacheRead": 0.26,
+				"input": 0.7,
+				"output": 2.2,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048575,
+			"contextWindow": 512000,
 			"maxTokens": 8888,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "high"
-			}
-		},
-		"z-ai/glm-5.2:free": {
-			"id": "z-ai/glm-5.2:free",
-			"name": "Z.ai: GLM 5.2 (free)",
-			"api": "openai-completions",
-			"provider": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 256000,
-			"maxTokens": 256000,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "high"
-			}
-		},
-		"z-ai/glm-5.3": {
-			"id": "z-ai/glm-5.3",
-			"name": "Z.ai: GLM 5.3",
-			"api": "openai-completions",
-			"provider": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 1.4,
-				"output": 4.4,
-				"cacheRead": 0.26,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -80551,11 +79294,11 @@
 		},
 		"deepseek-v4-pro-0813": {
 			"id": "deepseek-v4-pro-0813",
-			"name": "DeepSeek V4 Pro 0813",
+			"name": "deepseek-v4-pro-0813",
 			"api": "openai-completions",
 			"provider": "venice",
 			"baseUrl": "https://api.venice.ai/api/v1",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
 				"text"
 			],
@@ -80565,15 +79308,10 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
-			"maxTokens": 384000,
+			"contextWindow": 222222,
+			"maxTokens": 8888,
 			"compat": {
 				"supportsUsageInStreaming": false
-			},
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
 			}
 		},
 		"e2ee-deepseek-v4-flash": {
@@ -82574,28 +81312,6 @@
 				"supportsUsageInStreaming": false
 			}
 		},
-		"qwen-3-8-27b": {
-			"id": "qwen-3-8-27b",
-			"name": "qwen-3-8-27b",
-			"api": "openai-completions",
-			"provider": "venice",
-			"baseUrl": "https://api.venice.ai/api/v1",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262144,
-			"maxTokens": 8888,
-			"compat": {
-				"supportsUsageInStreaming": false
-			}
-		},
 		"qwen-3-8-max": {
 			"id": "qwen-3-8-max",
 			"name": "qwen-3-8-max",
@@ -82915,28 +81631,6 @@
 				"supportsUsageInStreaming": false
 			}
 		},
-		"stealth-ox-alpha": {
-			"id": "stealth-ox-alpha",
-			"name": "stealth-ox-alpha",
-			"api": "openai-completions",
-			"provider": "venice",
-			"baseUrl": "https://api.venice.ai/api/v1",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 8888,
-			"compat": {
-				"supportsUsageInStreaming": false
-			}
-		},
 		"venice-uncensored": {
 			"id": "venice-uncensored",
 			"name": "Venice Uncensored 1.1",
@@ -83006,28 +81700,6 @@
 		"xiaomi-mimo-v2-5": {
 			"id": "xiaomi-mimo-v2-5",
 			"name": "xiaomi-mimo-v2-5",
-			"api": "openai-completions",
-			"provider": "venice",
-			"baseUrl": "https://api.venice.ai/api/v1",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 8888,
-			"compat": {
-				"supportsUsageInStreaming": false
-			}
-		},
-		"z-ai-glm-5-3": {
-			"id": "z-ai-glm-5-3",
-			"name": "z-ai-glm-5-3",
 			"api": "openai-completions",
 			"provider": "venice",
 			"baseUrl": "https://api.venice.ai/api/v1",
@@ -83830,41 +82502,15 @@
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"reasoning": true,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 2,
 				"output": 6,
-				"cacheRead": 0.19999999999999998,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 131072,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"alibaba/qwen3.8-27b": {
-			"id": "alibaba/qwen3.8-27b",
-			"name": "Qwen3.8 27B",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.55,
-				"output": 3.3000000000000003,
-				"cacheRead": 0.11,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "budget",
@@ -84113,11 +82759,11 @@
 		},
 		"anthropic/claude-haiku-4.5": {
 			"id": "anthropic/claude-haiku-4.5",
-			"name": "Anthropic Haiku 4.5 (latest)",
+			"name": "Anthropic Haiku 4.5",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
 				"text",
 				"image"
@@ -84129,12 +82775,7 @@
 				"cacheWrite": 1.25
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
+			"maxTokens": 64000
 		},
 		"anthropic/claude-opus-4": {
 			"id": "anthropic/claude-opus-4",
@@ -84188,7 +82829,7 @@
 		},
 		"anthropic/claude-opus-4.5": {
 			"id": "anthropic/claude-opus-4.5",
-			"name": "Anthropic Opus 4.5 (latest)",
+			"name": "Anthropic Opus 4.5",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -84420,7 +83061,7 @@
 		},
 		"anthropic/claude-sonnet-4.5": {
 			"id": "anthropic/claude-sonnet-4.5",
-			"name": "Anthropic Sonnet 4.5 (latest)",
+			"name": "Anthropic Sonnet 4.5",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -84775,9 +83416,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.13,
-				"output": 0.26,
-				"cacheRead": 0.028,
+				"input": 0.19999999999999998,
+				"output": 0.39999999999999997,
+				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -84799,34 +83440,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.07600000000000001,
-				"output": 0.153,
-				"cacheRead": 0.014,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 384000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"deepseek/deepseek-v4-flash-vision-exp": {
-			"id": "deepseek/deepseek-v4-flash-vision-exp",
-			"name": "DeepSeek V4 Flash Vision Exp",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.22,
-				"output": 0.66,
-				"cacheRead": 0.007,
+				"input": 0.19999999999999998,
+				"output": 0.39999999999999997,
+				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -85235,9 +83851,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.75,
-				"output": 3.75,
-				"cacheRead": 0.075,
+				"input": 1.5,
+				"output": 7.5,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -86664,54 +85280,6 @@
 				"maxLevel": "xhigh"
 			}
 		},
-		"nvidia/nemotron-3.5-lightning": {
-			"id": "nvidia/nemotron-3.5-lightning",
-			"name": "Nemotron 3.5 Lightning 30B",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 32768,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"nvidia/nemotron-3.5-lightning-free": {
-			"id": "nvidia/nemotron-3.5-lightning-free",
-			"name": "Nemotron 3.5 Lightning 30B (Free)",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 32768,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
 		"nvidia/nemotron-nano-12b-v2-vl": {
 			"id": "nvidia/nemotron-nano-12b-v2-vl",
 			"name": "Nemotron Nano 12B v2 VL",
@@ -86845,26 +85413,6 @@
 			"contextWindow": 1047576,
 			"maxTokens": 32768
 		},
-		"openai/gpt-4.1-fast": {
-			"id": "openai/gpt-4.1-fast",
-			"name": "GPT-4.1 (Fast)",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 3.5,
-				"output": 14,
-				"cacheRead": 0.875,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1047576,
-			"maxTokens": 32768
-		},
 		"openai/gpt-4.1-mini": {
 			"id": "openai/gpt-4.1-mini",
 			"name": "GPT-4.1 mini",
@@ -86880,26 +85428,6 @@
 				"input": 0.39999999999999997,
 				"output": 1.5999999999999999,
 				"cacheRead": 0.09999999999999999,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1047576,
-			"maxTokens": 32768
-		},
-		"openai/gpt-4.1-mini-fast": {
-			"id": "openai/gpt-4.1-mini-fast",
-			"name": "GPT-4.1 mini (Fast)",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.7,
-				"output": 2.8,
-				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1047576,
@@ -86925,26 +85453,6 @@
 			"contextWindow": 1047576,
 			"maxTokens": 32768
 		},
-		"openai/gpt-4.1-nano-fast": {
-			"id": "openai/gpt-4.1-nano-fast",
-			"name": "GPT-4.1 nano (Fast)",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.19999999999999998,
-				"output": 0.7999999999999999,
-				"cacheRead": 0.049999999999999996,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1047576,
-			"maxTokens": 32768
-		},
 		"openai/gpt-4o": {
 			"id": "openai/gpt-4o",
 			"name": "GPT-4o",
@@ -86965,26 +85473,6 @@
 			"contextWindow": 128000,
 			"maxTokens": 16384
 		},
-		"openai/gpt-4o-fast": {
-			"id": "openai/gpt-4o-fast",
-			"name": "GPT-4o (Fast)",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 4.25,
-				"output": 17,
-				"cacheRead": 2.125,
-				"cacheWrite": 0
-			},
-			"contextWindow": 128000,
-			"maxTokens": 16384
-		},
 		"openai/gpt-4o-mini": {
 			"id": "openai/gpt-4o-mini",
 			"name": "GPT-4o mini",
@@ -87000,26 +85488,6 @@
 				"input": 0.15,
 				"output": 0.6,
 				"cacheRead": 0.075,
-				"cacheWrite": 0
-			},
-			"contextWindow": 128000,
-			"maxTokens": 16384
-		},
-		"openai/gpt-4o-mini-fast": {
-			"id": "openai/gpt-4o-mini-fast",
-			"name": "GPT-4o mini (Fast)",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.25,
-				"output": 1,
-				"cacheRead": 0.125,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -87100,31 +85568,6 @@
 				"maxLevel": "high"
 			}
 		},
-		"openai/gpt-5-fast": {
-			"id": "openai/gpt-5-fast",
-			"name": "GPT-5 (Fast)",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 2.5,
-				"output": 20,
-				"cacheRead": 0.25,
-				"cacheWrite": 0
-			},
-			"contextWindow": 400000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
 		"openai/gpt-5-mini": {
 			"id": "openai/gpt-5-mini",
 			"name": "GPT-5 Mini",
@@ -87148,31 +85591,6 @@
 				"mode": "budget",
 				"minLevel": "minimal",
 				"maxLevel": "high"
-			}
-		},
-		"openai/gpt-5-mini-fast": {
-			"id": "openai/gpt-5-mini-fast",
-			"name": "GPT-5 mini (Fast)",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.44999999999999996,
-				"output": 3.5999999999999996,
-				"cacheRead": 0.045,
-				"cacheWrite": 0
-			},
-			"contextWindow": 400000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
 			}
 		},
 		"openai/gpt-5-nano": {
@@ -87350,31 +85768,6 @@
 				"maxLevel": "xhigh"
 			}
 		},
-		"openai/gpt-5.1-thinking-fast": {
-			"id": "openai/gpt-5.1-thinking-fast",
-			"name": "GPT 5.1 Thinking (Fast)",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 2.5,
-				"output": 20,
-				"cacheRead": 0.25,
-				"cacheWrite": 0
-			},
-			"contextWindow": 400000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
 		"openai/gpt-5.2": {
 			"id": "openai/gpt-5.2",
 			"name": "GPT-5.2",
@@ -87450,31 +85843,6 @@
 				"maxLevel": "xhigh"
 			}
 		},
-		"openai/gpt-5.2-fast": {
-			"id": "openai/gpt-5.2-fast",
-			"name": "GPT 5.2 (Fast)",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 3.5,
-				"output": 28,
-				"cacheRead": 0.35,
-				"cacheWrite": 0
-			},
-			"contextWindow": 400000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
 		"openai/gpt-5.2-pro": {
 			"id": "openai/gpt-5.2-pro",
 			"name": "GPT-5.2 Pro",
@@ -87544,31 +85912,6 @@
 				"maxLevel": "xhigh"
 			}
 		},
-		"openai/gpt-5.3-codex-fast": {
-			"id": "openai/gpt-5.3-codex-fast",
-			"name": "GPT 5.3 OpenAI code (Fast)",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 3.5,
-				"output": 28,
-				"cacheRead": 0.35,
-				"cacheWrite": 0
-			},
-			"contextWindow": 400000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
 		"openai/gpt-5.4": {
 			"id": "openai/gpt-5.4",
 			"name": "GPT-5.4",
@@ -87594,31 +85937,6 @@
 				"maxLevel": "xhigh"
 			}
 		},
-		"openai/gpt-5.4-fast": {
-			"id": "openai/gpt-5.4-fast",
-			"name": "GPT 5.4 (Fast)",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 5,
-				"output": 30,
-				"cacheRead": 0.5,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1050000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
 		"openai/gpt-5.4-mini": {
 			"id": "openai/gpt-5.4-mini",
 			"name": "GPT-5.4 mini",
@@ -87641,31 +85959,6 @@
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "low",
-				"maxLevel": "xhigh"
-			}
-		},
-		"openai/gpt-5.4-mini-fast": {
-			"id": "openai/gpt-5.4-mini-fast",
-			"name": "GPT 5.4 Mini (Fast)",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 1.5,
-				"output": 9,
-				"cacheRead": 0.15,
-				"cacheWrite": 0
-			},
-			"contextWindow": 400000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
 		},
@@ -87744,31 +86037,6 @@
 				"maxLevel": "xhigh"
 			}
 		},
-		"openai/gpt-5.5-fast": {
-			"id": "openai/gpt-5.5-fast",
-			"name": "GPT 5.5 (Fast)",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 12.5,
-				"output": 75,
-				"cacheRead": 1.25,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
 		"openai/gpt-5.5-pro": {
 			"id": "openai/gpt-5.5-pro",
 			"name": "GPT-5.5 Pro",
@@ -87819,31 +86087,6 @@
 				"maxLevel": "max"
 			}
 		},
-		"openai/gpt-5.6-luna-fast": {
-			"id": "openai/gpt-5.6-luna-fast",
-			"name": "GPT 5.6 Luna (Fast)",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.39999999999999997,
-				"output": 2.4,
-				"cacheRead": 0.04,
-				"cacheWrite": 0.25
-			},
-			"contextWindow": 1050000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
 		"openai/gpt-5.6-sol": {
 			"id": "openai/gpt-5.6-sol",
 			"name": "GPT-5.6 Sol",
@@ -87856,10 +86099,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 10,
-				"cacheRead": 0.19999999999999998,
-				"cacheWrite": 2.5
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -87867,31 +86110,6 @@
 				"mode": "budget",
 				"minLevel": "low",
 				"maxLevel": "max"
-			}
-		},
-		"openai/gpt-5.6-sol-fast": {
-			"id": "openai/gpt-5.6-sol-fast",
-			"name": "GPT 5.6 Sol (Fast)",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 4,
-				"output": 20,
-				"cacheRead": 0.39999999999999997,
-				"cacheWrite": 2.5
-			},
-			"contextWindow": 1050000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
 			}
 		},
 		"openai/gpt-5.6-terra": {
@@ -87917,31 +86135,6 @@
 				"mode": "budget",
 				"minLevel": "low",
 				"maxLevel": "max"
-			}
-		},
-		"openai/gpt-5.6-terra-fast": {
-			"id": "openai/gpt-5.6-terra-fast",
-			"name": "GPT 5.6 Terra (Fast)",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 4,
-				"output": 24,
-				"cacheRead": 0.39999999999999997,
-				"cacheWrite": 2.5
-			},
-			"contextWindow": 1050000,
-			"maxTokens": 128000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
 			}
 		},
 		"openai/gpt-oss-120b": {
@@ -88091,31 +86284,6 @@
 				"maxLevel": "xhigh"
 			}
 		},
-		"openai/o3-fast": {
-			"id": "openai/o3-fast",
-			"name": "o3 (Fast)",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 3.5,
-				"output": 14,
-				"cacheRead": 0.875,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 100000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
 		"openai/o3-mini": {
 			"id": "openai/o3-mini",
 			"name": "o3-mini",
@@ -88180,31 +86348,6 @@
 				"input": 1.1,
 				"output": 4.4,
 				"cacheRead": 0.275,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 100000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"openai/o4-mini-fast": {
-			"id": "openai/o4-mini-fast",
-			"name": "o4-mini (Fast)",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 2,
-				"output": 8,
-				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -88377,291 +86520,6 @@
 				"maxLevel": "xhigh"
 			}
 		},
-		"spacexai/grok-4.1-fast-non-reasoning": {
-			"id": "spacexai/grok-4.1-fast-non-reasoning",
-			"name": "Grok 4.1 Fast Non-Reasoning",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.19999999999999998,
-				"output": 0.5,
-				"cacheRead": 0.049999999999999996,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 1000000
-		},
-		"spacexai/grok-4.1-fast-reasoning": {
-			"id": "spacexai/grok-4.1-fast-reasoning",
-			"name": "Grok 4.1 Fast Reasoning",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.19999999999999998,
-				"output": 0.5,
-				"cacheRead": 0.049999999999999996,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 1000000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"spacexai/grok-4.20-multi-agent": {
-			"id": "spacexai/grok-4.20-multi-agent",
-			"name": "Grok 4.20 Multi-Agent",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 1.25,
-				"output": 2.5,
-				"cacheRead": 0.19999999999999998,
-				"cacheWrite": 0
-			},
-			"contextWindow": 2000000,
-			"maxTokens": 2000000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"spacexai/grok-4.20-multi-agent-beta": {
-			"id": "spacexai/grok-4.20-multi-agent-beta",
-			"name": "Grok 4.20 Multi Agent Beta",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 1.25,
-				"output": 2.5,
-				"cacheRead": 0.19999999999999998,
-				"cacheWrite": 0
-			},
-			"contextWindow": 2000000,
-			"maxTokens": 2000000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"spacexai/grok-4.20-non-reasoning": {
-			"id": "spacexai/grok-4.20-non-reasoning",
-			"name": "Grok 4.20 Non-Reasoning",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 1.25,
-				"output": 2.5,
-				"cacheRead": 0.19999999999999998,
-				"cacheWrite": 0
-			},
-			"contextWindow": 2000000,
-			"maxTokens": 2000000
-		},
-		"spacexai/grok-4.20-non-reasoning-beta": {
-			"id": "spacexai/grok-4.20-non-reasoning-beta",
-			"name": "Grok 4.20 Beta Non-Reasoning",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": false,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 1.25,
-				"output": 2.5,
-				"cacheRead": 0.19999999999999998,
-				"cacheWrite": 0
-			},
-			"contextWindow": 2000000,
-			"maxTokens": 2000000
-		},
-		"spacexai/grok-4.20-reasoning": {
-			"id": "spacexai/grok-4.20-reasoning",
-			"name": "Grok 4.20 Reasoning",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 1.25,
-				"output": 2.5,
-				"cacheRead": 0.19999999999999998,
-				"cacheWrite": 0
-			},
-			"contextWindow": 2000000,
-			"maxTokens": 2000000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"spacexai/grok-4.20-reasoning-beta": {
-			"id": "spacexai/grok-4.20-reasoning-beta",
-			"name": "Grok 4.20 Beta Reasoning",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 1.25,
-				"output": 2.5,
-				"cacheRead": 0.19999999999999998,
-				"cacheWrite": 0
-			},
-			"contextWindow": 2000000,
-			"maxTokens": 2000000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"spacexai/grok-4.3": {
-			"id": "spacexai/grok-4.3",
-			"name": "Grok 4.3",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 1.25,
-				"output": 2.5,
-				"cacheRead": 0.19999999999999998,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 1000000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"spacexai/grok-4.5": {
-			"id": "spacexai/grok-4.5",
-			"name": "Grok 4.5",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 2,
-				"output": 6,
-				"cacheRead": 0.3,
-				"cacheWrite": 0
-			},
-			"contextWindow": 500000,
-			"maxTokens": 500000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"spacexai/grok-4.6": {
-			"id": "spacexai/grok-4.6",
-			"name": "Grok 4.6",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 2,
-				"output": 6,
-				"cacheRead": 0.5,
-				"cacheWrite": 0
-			},
-			"contextWindow": 500000,
-			"maxTokens": 500000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"spacexai/grok-build-0.1": {
-			"id": "spacexai/grok-build-0.1",
-			"name": "Grok Build 0.1",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 1,
-				"output": 2,
-				"cacheRead": 0.19999999999999998,
-				"cacheWrite": 0
-			},
-			"contextWindow": 256000,
-			"maxTokens": 256000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
 		"stepfun/step-3.5-flash": {
 			"id": "stepfun/step-3.5-flash",
 			"name": "Step 3.5 Flash",
@@ -88717,13 +86575,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.13199999999999998,
-				"output": 0.5279999999999999,
-				"cacheRead": 0.032999999999999995,
+				"input": 0.14,
+				"output": 0.58,
+				"cacheRead": 0.035,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 128000,
+			"contextWindow": 262144,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -89694,9 +87552,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.7999999999999999,
-				"output": 2.5500000000000003,
-				"cacheRead": 0.16,
+				"input": 1.1,
+				"output": 3.851,
+				"cacheRead": 0.275,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -89725,30 +87583,6 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"thinking": {
-				"mode": "budget",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"zai/glm-5.3": {
-			"id": "zai/glm-5.3",
-			"name": "GLM 5.3",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 1.4,
-				"output": 4.4,
-				"cacheRead": 0.26,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 12800,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -77939,8 +77939,14 @@
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "high"
+				"minLevel": "low",
+				"maxLevel": "max",
+				"defaultLevel": "max",
+				"levels": [
+					"low",
+					"high",
+					"max"
+				]
 			}
 		},
 		"stepfun/step-3.5-flash": {

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -17174,7 +17174,7 @@
 			"api": "openai-completions",
 			"provider": "groq",
 			"baseUrl": "https://api.groq.com/openai/v1",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
 				"text"
 			],
@@ -17185,12 +17185,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 8192,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
+			"maxTokens": 8192
 		},
 		"groq/compound-mini": {
 			"id": "groq/compound-mini",
@@ -17198,7 +17193,7 @@
 			"api": "openai-completions",
 			"provider": "groq",
 			"baseUrl": "https://api.groq.com/openai/v1",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
 				"text"
 			],
@@ -17209,12 +17204,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 8192,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
+			"maxTokens": 8192
 		},
 		"llama-3.1-8b-instant": {
 			"id": "llama-3.1-8b-instant",

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -116,6 +116,33 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"deepseek-v4-pro-0813": {
+			"id": "deepseek-v4-pro-0813",
+			"name": "DeepSeek V4 Pro 0813",
+			"api": "openai-completions",
+			"provider": "alibaba-token-plan",
+			"baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"compat": {
+				"supportsDeveloperRole": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"glm-5": {
 			"id": "glm-5",
 			"name": "GLM-5",
@@ -1231,10 +1258,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 10,
-				"output": 50,
-				"cacheRead": 1,
-				"cacheWrite": 12.5
+				"input": 11,
+				"output": 55,
+				"cacheRead": 1.1,
+				"cacheWrite": 13.75
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -1256,10 +1283,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1.1,
-				"output": 5.5,
-				"cacheRead": 0.11,
-				"cacheWrite": 1.375
+				"input": 1,
+				"output": 5,
+				"cacheRead": 0.1,
+				"cacheWrite": 1.25
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
@@ -1388,10 +1415,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 5.5,
-				"output": 27.5,
-				"cacheRead": 0.55,
-				"cacheWrite": 6.875
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -1624,7 +1651,7 @@
 		},
 		"global.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
-			"name": "Anthropic Haiku 4.5 (Global)",
+			"name": "Anthropic Haiku 4.5",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1649,7 +1676,7 @@
 		},
 		"global.anthropic.claude-opus-4-5-20251101-v1:0": {
 			"id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
-			"name": "Anthropic Opus 4.5",
+			"name": "Anthropic Opus 4.5 (Global)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1852,7 +1879,7 @@
 		},
 		"global.anthropic.claude-sonnet-4-6": {
 			"id": "global.anthropic.claude-sonnet-4-6",
-			"name": "Anthropic Sonnet 4.6",
+			"name": "Anthropic Sonnet 4.6 (Global)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1898,6 +1925,81 @@
 				"mode": "anthropic-budget-effort",
 				"minLevel": "minimal",
 				"maxLevel": "high"
+			}
+		},
+		"global.openai.gpt-5.6-luna": {
+			"id": "global.openai.gpt-5.6-luna",
+			"name": "GPT-5.6 Luna (Global)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.22,
+				"output": 1.32,
+				"cacheRead": 0.022,
+				"cacheWrite": 0.275
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "low",
+				"maxLevel": "max"
+			}
+		},
+		"global.openai.gpt-5.6-sol": {
+			"id": "global.openai.gpt-5.6-sol",
+			"name": "GPT-5.6 Sol (Global)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5.5,
+				"output": 33,
+				"cacheRead": 0.55,
+				"cacheWrite": 6.875
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "low",
+				"maxLevel": "max"
+			}
+		},
+		"global.openai.gpt-5.6-terra": {
+			"id": "global.openai.gpt-5.6-terra",
+			"name": "GPT-5.6 Terra (Global)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.2,
+				"output": 13.2,
+				"cacheRead": 0.22,
+				"cacheWrite": 2.75
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "low",
+				"maxLevel": "max"
 			}
 		},
 		"google.gemma-3-27b-it": {
@@ -3159,7 +3261,7 @@
 		},
 		"us.anthropic.claude-opus-4-1-20250805-v1:0": {
 			"id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
-			"name": "Anthropic Opus 4.1",
+			"name": "Anthropic Opus 4.1 (US)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -3688,6 +3790,31 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"xai.grok-4.6": {
+			"id": "xai.grok-4.6",
+			"name": "Grok 4.6",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.2,
+				"output": 6.6,
+				"cacheRead": 0.55,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -4425,7 +4552,7 @@
 	"bizrouter": {
 		"anthropic/claude-sonnet-4.5": {
 			"id": "anthropic/claude-sonnet-4.5",
-			"name": "Anthropic Sonnet 4.5",
+			"name": "Anthropic Sonnet 4.5 (latest)",
 			"api": "openai-completions",
 			"provider": "bizrouter",
 			"baseUrl": "https://api.bizrouter.ai/v1",
@@ -4816,6 +4943,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"anthropic/claude-haiku-4.5": {
+			"id": "anthropic/claude-haiku-4.5",
+			"name": "Anthropic Haiku 4.5 (latest)",
+			"api": "anthropic-messages",
+			"provider": "cloudflare-ai-gateway",
+			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 5,
+				"cacheRead": 0.1,
+				"cacheWrite": 1.25
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"anthropic/claude-opus-4": {
 			"id": "anthropic/claude-opus-4",
 			"name": "Anthropic Opus 4",
@@ -4973,6 +5125,113 @@
 				"maxLevel": "max"
 			}
 		},
+		"anthropic/claude-opus-4.5": {
+			"id": "anthropic/claude-opus-4.5",
+			"name": "Anthropic Opus 4.5 (latest)",
+			"api": "anthropic-messages",
+			"provider": "cloudflare-ai-gateway",
+			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "anthropic-budget-effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"anthropic/claude-opus-4.6": {
+			"id": "anthropic/claude-opus-4.6",
+			"name": "Anthropic Opus 4.6",
+			"api": "anthropic-messages",
+			"provider": "cloudflare-ai-gateway",
+			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "max",
+				"levels": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
+			}
+		},
+		"anthropic/claude-opus-4.7": {
+			"id": "anthropic/claude-opus-4.7",
+			"name": "Anthropic Opus 4.7",
+			"api": "anthropic-messages",
+			"provider": "cloudflare-ai-gateway",
+			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "max"
+			}
+		},
+		"anthropic/claude-opus-4.8": {
+			"id": "anthropic/claude-opus-4.8",
+			"name": "Anthropic Opus 4.8",
+			"api": "anthropic-messages",
+			"provider": "cloudflare-ai-gateway",
+			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "max"
+			}
+		},
 		"anthropic/claude-opus-5": {
 			"id": "anthropic/claude-opus-5",
 			"name": "Anthropic Opus 5",
@@ -5050,6 +5309,56 @@
 		},
 		"anthropic/claude-sonnet-4-6": {
 			"id": "anthropic/claude-sonnet-4-6",
+			"name": "Anthropic Sonnet 4.6",
+			"api": "anthropic-messages",
+			"provider": "cloudflare-ai-gateway",
+			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"anthropic/claude-sonnet-4.5": {
+			"id": "anthropic/claude-sonnet-4.5",
+			"name": "Anthropic Sonnet 4.5 (latest)",
+			"api": "anthropic-messages",
+			"provider": "cloudflare-ai-gateway",
+			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "anthropic-budget-effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"anthropic/claude-sonnet-4.6": {
+			"id": "anthropic/claude-sonnet-4.6",
 			"name": "Anthropic Sonnet 4.6",
 			"api": "anthropic-messages",
 			"provider": "cloudflare-ai-gateway",
@@ -5259,9 +5568,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 10,
-				"cacheRead": 1.25,
+				"input": 1.25,
+				"output": 5,
+				"cacheRead": 0.625,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -5279,9 +5588,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.15,
-				"output": 0.6,
-				"cacheRead": 0.075,
+				"input": 0.075,
+				"output": 0.3,
+				"cacheRead": 0.0375,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -8578,47 +8887,9 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000
 		},
-		"gemini-3.7-flash-high": {
-			"id": "gemini-3.7-flash-high",
-			"name": "Gemini 3.7 Flash",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000
-		},
 		"gemini-3.6-flash-low": {
 			"id": "gemini-3.6-flash-low",
 			"name": "Gemini 3.6 Flash Low",
-			"api": "cursor-agent",
-			"provider": "cursor",
-			"baseUrl": "https://api2.cursor.sh",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000
-		},
-		"gemini-3.7-flash-low": {
-			"id": "gemini-3.7-flash-low",
-			"name": "Gemini 3.7 Flash Low",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -8654,9 +8925,9 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000
 		},
-		"gemini-3.7-flash-medium": {
-			"id": "gemini-3.7-flash-medium",
-			"name": "Gemini 3.7 Flash Medium",
+		"gemini-3.6-flash-minimal": {
+			"id": "gemini-3.6-flash-minimal",
+			"name": "Gemini 3.6 Flash Minimal",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -8673,9 +8944,47 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000
 		},
-		"gemini-3.6-flash-minimal": {
-			"id": "gemini-3.6-flash-minimal",
-			"name": "Gemini 3.6 Flash Minimal",
+		"gemini-3.7-flash-high": {
+			"id": "gemini-3.7-flash-high",
+			"name": "Gemini 3.7 Flash",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000
+		},
+		"gemini-3.7-flash-low": {
+			"id": "gemini-3.7-flash-low",
+			"name": "Gemini 3.7 Flash Low",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000
+		},
+		"gemini-3.7-flash-medium": {
+			"id": "gemini-3.7-flash-medium",
+			"name": "Gemini 3.7 Flash Medium",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -10968,6 +11277,56 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"ByteDance/Seed-2.0-mini": {
+			"id": "ByteDance/Seed-2.0-mini",
+			"name": "Seed 2.0 Mini",
+			"api": "openai-completions",
+			"provider": "deepinfra",
+			"baseUrl": "https://api.deepinfra.com/v1/openai",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.4,
+				"cacheRead": 0.02,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 32000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"ByteDance/Seed-2.0-pro": {
+			"id": "ByteDance/Seed-2.0-pro",
+			"name": "Seed 2.0 Pro",
+			"api": "openai-completions",
+			"provider": "deepinfra",
+			"baseUrl": "https://api.deepinfra.com/v1/openai",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.5,
+				"output": 3,
+				"cacheRead": 0.1,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"deepseek-ai/DeepSeek-R1-0528": {
 			"id": "deepseek-ai/DeepSeek-R1-0528",
 			"name": "DeepSeek-R1-0528",
@@ -11144,6 +11503,30 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"deepseek-ai/DeepSeek-V4-Pro-0813": {
+			"id": "deepseek-ai/DeepSeek-V4-Pro-0813",
+			"name": "DeepSeek V4 Pro 0813",
+			"api": "openai-completions",
+			"provider": "deepinfra",
+			"baseUrl": "https://api.deepinfra.com/v1/openai",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.3,
+				"output": 2.6,
+				"cacheRead": 0.1,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 384000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -11682,6 +12065,26 @@
 			"contextWindow": 262144,
 			"maxTokens": 32768
 		},
+		"Qwen/Qwen3-VL-235B-A22B-Instruct": {
+			"id": "Qwen/Qwen3-VL-235B-A22B-Instruct",
+			"name": "Qwen3 VL 235B A22B Instruct",
+			"api": "openai-completions",
+			"provider": "deepinfra",
+			"baseUrl": "https://api.deepinfra.com/v1/openai",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.2,
+				"output": 0.88,
+				"cacheRead": 0.11,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768
+		},
 		"Qwen/Qwen3.5-122B-A10B": {
 			"id": "Qwen/Qwen3.5-122B-A10B",
 			"name": "Qwen3.5 122B-A10B",
@@ -11875,6 +12278,55 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536
+		},
+		"Qwen/Qwen3.8-2.4T-A95B": {
+			"id": "Qwen/Qwen3.8-2.4T-A95B",
+			"name": "Qwen3.8 2.4T A95B",
+			"api": "openai-completions",
+			"provider": "deepinfra",
+			"baseUrl": "https://api.deepinfra.com/v1/openai",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"Qwen/Qwen3.8-27B": {
+			"id": "Qwen/Qwen3.8-27B",
+			"name": "Qwen3.8 27B",
+			"api": "openai-completions",
+			"provider": "deepinfra",
+			"baseUrl": "https://api.deepinfra.com/v1/openai",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.4,
+				"output": 3,
+				"cacheRead": 0.04,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		},
 		"Qwen/Qwen3.8-Max": {
 			"id": "Qwen/Qwen3.8-Max",
@@ -12199,6 +12651,53 @@
 			"reasoning": true,
 			"input": [
 				"text"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.0028,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"compat": {
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": true,
+				"reasoningEffortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max",
+					"max": "max"
+				},
+				"maxTokensField": "max_tokens",
+				"supportsToolChoice": false,
+				"extraBody": {
+					"thinking": {
+						"type": "enabled"
+					}
+				},
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"requiresAssistantContentForToolCalls": true
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"deepseek-v4-flash-vision-exp": {
+			"id": "deepseek-v4-flash-vision-exp",
+			"name": "DeepSeek V4 Flash Vision Exp",
+			"api": "openai-completions",
+			"provider": "deepseek",
+			"baseUrl": "https://api.deepseek.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.14,
@@ -13593,10 +14092,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 5,
-				"output": 30,
-				"cacheRead": 0.5,
-				"cacheWrite": 6.25
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
+				"cacheWrite": 3.125
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -13640,6 +14139,39 @@
 		"grok-4.5": {
 			"id": "grok-4.5",
 			"name": "Grok 4.5",
+			"api": "openai-completions",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 128000,
+			"headers": {
+				"User-Agent": "opencode/1.3.15"
+			},
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"grok-4.6": {
+			"id": "grok-4.6",
+			"name": "Grok 4.6",
 			"api": "openai-completions",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -14970,9 +15502,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 1.5,
-				"output": 7.5,
-				"cacheRead": 0.15,
+				"input": 0.75,
+				"output": 3.75,
+				"cacheRead": 0.075,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -15020,9 +15552,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 1.5,
-				"output": 9,
-				"cacheRead": 0.15,
+				"input": 0.75,
+				"output": 3.75,
+				"cacheRead": 0.075,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -15045,9 +15577,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 1.5,
-				"cacheRead": 0.025,
+				"input": 0.3,
+				"output": 2.5,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -15785,31 +16317,6 @@
 				"maxLevel": "high"
 			}
 		},
-		"gemini-3.7-flash-high": {
-			"id": "gemini-3.7-flash-high",
-			"name": "Gemini 3.7 Flash (High) (Antigravity)",
-			"api": "google-gemini-cli",
-			"provider": "google-antigravity",
-			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 65536,
-			"thinking": {
-				"mode": "google-level",
-				"minLevel": "low",
-				"maxLevel": "high"
-			}
-		},
 		"gemini-3.6-flash-low": {
 			"id": "gemini-3.6-flash-low",
 			"name": "Gemini 3.6 Flash (Low) (Antigravity)",
@@ -15832,31 +16339,6 @@
 			"thinking": {
 				"mode": "google-level",
 				"minLevel": "minimal",
-				"maxLevel": "high"
-			}
-		},
-		"gemini-3.7-flash-low": {
-			"id": "gemini-3.7-flash-low",
-			"name": "Gemini 3.7 Flash (Low) (Antigravity)",
-			"api": "google-gemini-cli",
-			"provider": "google-antigravity",
-			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 65536,
-			"thinking": {
-				"mode": "google-level",
-				"minLevel": "low",
 				"maxLevel": "high"
 			}
 		},
@@ -15885,31 +16367,6 @@
 				"maxLevel": "high"
 			}
 		},
-		"gemini-3.7-flash-medium": {
-			"id": "gemini-3.7-flash-medium",
-			"name": "Gemini 3.7 Flash (Medium) (Antigravity)",
-			"api": "google-gemini-cli",
-			"provider": "google-antigravity",
-			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 65536,
-			"thinking": {
-				"mode": "google-level",
-				"minLevel": "low",
-				"maxLevel": "high"
-			}
-		},
 		"gemini-3.6-flash-tiered": {
 			"id": "gemini-3.6-flash-tiered",
 			"name": "gemini-3.6-flash-tiered",
@@ -15932,6 +16389,81 @@
 			"thinking": {
 				"mode": "google-level",
 				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"gemini-3.7-flash-high": {
+			"id": "gemini-3.7-flash-high",
+			"name": "Gemini 3.7 Flash (High) (Antigravity)",
+			"api": "google-gemini-cli",
+			"provider": "google-antigravity",
+			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "google-level",
+				"minLevel": "low",
+				"maxLevel": "high"
+			}
+		},
+		"gemini-3.7-flash-low": {
+			"id": "gemini-3.7-flash-low",
+			"name": "Gemini 3.7 Flash (Low) (Antigravity)",
+			"api": "google-gemini-cli",
+			"provider": "google-antigravity",
+			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "google-level",
+				"minLevel": "low",
+				"maxLevel": "high"
+			}
+		},
+		"gemini-3.7-flash-medium": {
+			"id": "gemini-3.7-flash-medium",
+			"name": "Gemini 3.7 Flash (Medium) (Antigravity)",
+			"api": "google-gemini-cli",
+			"provider": "google-antigravity",
+			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "google-level",
+				"minLevel": "low",
 				"maxLevel": "high"
 			}
 		},
@@ -17557,7 +18089,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"~anthropic/claude-haiku-latest": {
@@ -17576,7 +18108,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 200000,
 			"maxTokens": 8888
 		},
 		"~anthropic/claude-opus-latest": {
@@ -17595,7 +18127,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"~anthropic/claude-sonnet-latest": {
@@ -17614,7 +18146,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"~deepseek/deepseek-v4-flash-latest": {
@@ -17633,7 +18165,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1310720,
 			"maxTokens": 8888
 		},
 		"~google/gemini-flash-latest": {
@@ -17652,7 +18184,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1048576,
 			"maxTokens": 8888
 		},
 		"~google/gemini-pro-latest": {
@@ -17671,7 +18203,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1048576,
 			"maxTokens": 8888
 		},
 		"~moonshotai/kimi-latest": {
@@ -17690,7 +18222,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1048576,
 			"maxTokens": 8888
 		},
 		"~openai/gpt-latest": {
@@ -17709,7 +18241,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1050000,
 			"maxTokens": 8888
 		},
 		"~openai/gpt-mini-latest": {
@@ -17728,7 +18260,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 400000,
 			"maxTokens": 8888
 		},
 		"~x-ai/grok-latest": {
@@ -17747,7 +18279,26 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 500000,
+			"maxTokens": 8888
+		},
+		"~z-ai/glm-latest": {
+			"id": "~z-ai/glm-latest",
+			"name": "Z.ai: GLM Latest",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
 			"maxTokens": 8888
 		},
 		"ai21/jamba-large-1.7": {
@@ -17823,7 +18374,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"aion-labs/aion-3.0": {
@@ -17842,7 +18393,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"aion-labs/aion-3.0-mini": {
@@ -17861,7 +18412,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"aion-labs/aion-rp-llama-3.1-8b": {
@@ -17880,7 +18431,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 32768,
 			"maxTokens": 8888
 		},
 		"alfredpros/codellama-7b-instruct-solidity": {
@@ -17975,7 +18526,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 65536,
 			"maxTokens": 8888
 		},
 		"allenai/olmo-3-7b-instruct": {
@@ -18089,7 +18640,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"amazon/nova-lite-v1": {
@@ -18108,7 +18659,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 300000,
 			"maxTokens": 8888
 		},
 		"amazon/nova-micro-v1": {
@@ -18127,7 +18678,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"amazon/nova-premier-v1": {
@@ -18146,7 +18697,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"amazon/nova-pro-v1": {
@@ -18165,7 +18716,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 300000,
 			"maxTokens": 8888
 		},
 		"anthracite-org/magnum-v4-72b": {
@@ -18184,7 +18735,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 32768,
 			"maxTokens": 8888
 		},
 		"anthropic/claude-3-haiku": {
@@ -18204,7 +18755,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 200000,
 			"maxTokens": 8888
 		},
 		"anthropic/claude-3.5-haiku": {
@@ -18318,11 +18869,11 @@
 		},
 		"anthropic/claude-haiku-4.5": {
 			"id": "anthropic/claude-haiku-4.5",
-			"name": "Anthropic Haiku 4.5",
+			"name": "Anthropic Haiku 4.5 (latest)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
@@ -18334,7 +18885,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"anthropic/claude-opus-4": {
 			"id": "anthropic/claude-opus-4",
@@ -18388,7 +18944,7 @@
 		},
 		"anthropic/claude-opus-4.5": {
 			"id": "anthropic/claude-opus-4.5",
-			"name": "Anthropic Opus 4.5",
+			"name": "Anthropic Opus 4.5 (latest)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -18496,7 +19052,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"anthropic/claude-opus-4.8": {
@@ -18541,7 +19097,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"anthropic/claude-opus-5": {
@@ -18586,7 +19142,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"anthropic/claude-sonnet-4": {
@@ -18616,7 +19172,7 @@
 		},
 		"anthropic/claude-sonnet-4.5": {
 			"id": "anthropic/claude-sonnet-4.5",
-			"name": "Anthropic Sonnet 4.5",
+			"name": "Anthropic Sonnet 4.5 (latest)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -18657,7 +19213,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
-			"maxTokens": 64000,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -18800,7 +19356,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"arcee-ai/trinity-large-thinking:free": {
@@ -18857,7 +19413,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"baidu/cobuddy:free": {
@@ -18971,7 +19527,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 123000,
 			"maxTokens": 8888
 		},
 		"baidu/qianfan-ocr-fast": {
@@ -19047,7 +19603,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"bytedance-seed/seed-1.6-flash": {
@@ -19066,7 +19622,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"bytedance-seed/seed-2-1-turbo": {
@@ -19085,7 +19641,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"bytedance-seed/seed-2.0-code": {
@@ -19104,7 +19660,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"bytedance-seed/seed-2.0-lite": {
@@ -19123,7 +19679,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"bytedance-seed/seed-2.0-mini": {
@@ -19142,7 +19698,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"bytedance/ui-tars-1.5-7b": {
@@ -19161,7 +19717,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"cognitivecomputations/dolphin-mistral-24b-venice-edition": {
@@ -19180,7 +19736,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"cohere/command-a": {
@@ -19199,7 +19755,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 256000,
 			"maxTokens": 8888
 		},
 		"cohere/command-r-08-2024": {
@@ -19218,7 +19774,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"cohere/command-r-plus-08-2024": {
@@ -19237,7 +19793,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"cohere/command-r7b-12-2024": {
@@ -19256,7 +19812,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"cohere/north-mini-code:free": {
@@ -19275,7 +19831,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 256000,
 			"maxTokens": 8888
 		},
 		"corethink:free": {
@@ -19332,7 +19888,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 163840,
 			"maxTokens": 8888
 		},
 		"deepseek/deepseek-chat-v3-0324": {
@@ -19351,7 +19907,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 163840,
 			"maxTokens": 8888
 		},
 		"deepseek/deepseek-chat-v3.1": {
@@ -19370,7 +19926,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 163840,
 			"maxTokens": 8888
 		},
 		"deepseek/deepseek-r1": {
@@ -19389,7 +19945,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 64000,
 			"maxTokens": 8888
 		},
 		"deepseek/deepseek-r1-0528": {
@@ -19408,7 +19964,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 163840,
 			"maxTokens": 8888
 		},
 		"deepseek/deepseek-r1-distill-llama-70b": {
@@ -19427,7 +19983,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 8192,
 			"maxTokens": 8888
 		},
 		"deepseek/deepseek-r1-distill-qwen-32b": {
@@ -19465,7 +20021,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 163840,
 			"maxTokens": 8888
 		},
 		"deepseek/deepseek-v3.1-terminus:exacto": {
@@ -19503,7 +20059,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 163840,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -19527,7 +20083,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 163000,
+			"contextWindow": 163840,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -19570,7 +20126,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 1048576,
 			"maxTokens": 384000,
 			"thinking": {
 				"mode": "effort",
@@ -19594,7 +20150,26 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1310720,
+			"maxTokens": 8888
+		},
+		"deepseek/deepseek-v4-flash-vision-exp": {
+			"id": "deepseek/deepseek-v4-flash-vision-exp",
+			"name": "DeepSeek: DeepSeek V4 Flash Vision Exp",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
 			"maxTokens": 8888
 		},
 		"deepseek/deepseek-v4-flash:discounted": {
@@ -19651,7 +20226,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 1048576,
 			"maxTokens": 384000,
 			"thinking": {
 				"mode": "effort",
@@ -19675,7 +20250,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1048576,
 			"maxTokens": 8888
 		},
 		"deepseek/deepseek-v4-pro:discounted": {
@@ -19695,6 +20270,25 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"dots-studio/dots-3-note-preview:free": {
+			"id": "dots-studio/dots-3-note-preview:free",
+			"name": "Dots Studio: Dots3-Note Preview (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
 			"maxTokens": 8888
 		},
 		"eleutherai/llemma_7b": {
@@ -19828,7 +20422,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048000,
+			"contextWindow": 1048576,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -19852,7 +20446,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 32768,
 			"maxTokens": 8888
 		},
 		"google/gemini-2.5-flash-lite": {
@@ -19872,7 +20466,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048000,
+			"contextWindow": 1048576,
 			"maxTokens": 64000
 		},
 		"google/gemini-2.5-flash-lite-preview-09-2025": {
@@ -19911,7 +20505,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048000,
+			"contextWindow": 1048576,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -19935,7 +20529,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1048576,
 			"maxTokens": 8888
 		},
 		"google/gemini-2.5-pro-preview-05-06": {
@@ -19954,7 +20548,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1048576,
 			"maxTokens": 8888
 		},
 		"google/gemini-3-flash-preview": {
@@ -19974,7 +20568,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048000,
+			"contextWindow": 1048576,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -19998,7 +20592,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"google/gemini-3-pro-image-preview": {
@@ -20018,7 +20612,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 65536,
 			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
@@ -20075,7 +20669,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"google/gemini-3.1-flash-image-preview": {
@@ -20094,7 +20688,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 65536,
 			"maxTokens": 8888
 		},
 		"google/gemini-3.1-flash-lite": {
@@ -20138,7 +20732,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 65536,
 			"maxTokens": 8888
 		},
 		"google/gemini-3.1-flash-lite-preview": {
@@ -20158,7 +20752,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1050000,
+			"contextWindow": 1048576,
 			"maxTokens": 65530
 		},
 		"google/gemini-3.1-pro-preview": {
@@ -20178,7 +20772,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048000,
+			"contextWindow": 1048576,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -20206,7 +20800,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1048576,
 			"maxTokens": 8888
 		},
 		"google/gemini-3.5-flash": {
@@ -20250,7 +20844,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1048576,
 			"maxTokens": 8888
 		},
 		"google/gemini-3.6-flash": {
@@ -20269,7 +20863,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1048576,
 			"maxTokens": 8888
 		},
 		"google/gemini-3.7-flash": {
@@ -20288,7 +20882,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1048576,
 			"maxTokens": 8888
 		},
 		"google/gemma-2-27b-it": {
@@ -20307,7 +20901,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 8192,
 			"maxTokens": 8888
 		},
 		"google/gemma-2-9b-it": {
@@ -20366,7 +20960,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
@@ -20411,7 +21005,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 32768,
 			"maxTokens": 4096
 		},
 		"google/gemma-4-26b-a4b-it": {
@@ -20430,7 +21024,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"google/gemma-4-31b-it": {
@@ -20450,7 +21044,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
+			"contextWindow": 262144,
 			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
@@ -20474,7 +21068,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1048576,
 			"maxTokens": 8888
 		},
 		"google/lyria-3-pro-preview": {
@@ -20493,7 +21087,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1048576,
 			"maxTokens": 8888
 		},
 		"gryphe/mythomax-l2-13b": {
@@ -20512,7 +21106,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 8192,
 			"maxTokens": 8888
 		},
 		"ibm-granite/granite-4.0-h-micro": {
@@ -20531,7 +21125,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131000,
 			"maxTokens": 8888
 		},
 		"ibm-granite/granite-4.1-8b": {
@@ -20550,7 +21144,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"inception/mercury": {
@@ -20588,7 +21182,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"inception/mercury-coder": {
@@ -20612,7 +21206,7 @@
 		},
 		"inclusionai/ling-2.6-1t": {
 			"id": "inclusionai/ling-2.6-1t",
-			"name": "inclusionAI: Ling-2.6-1T",
+			"name": "inclusionAI: Ling-2.6-1T (retires Aug 24)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -20626,7 +21220,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"inclusionai/ling-2.6-1t:free": {
@@ -20650,7 +21244,7 @@
 		},
 		"inclusionai/ling-2.6-flash": {
 			"id": "inclusionai/ling-2.6-flash",
-			"name": "inclusionAI: Ling-2.6-flash",
+			"name": "inclusionAI: Ling-2.6-flash (retires Aug 24)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -20664,7 +21258,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"inclusionai/ling-2.6-flash:free": {
@@ -20702,7 +21296,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"inclusionai/ling-3.0-tiny:free": {
@@ -20740,7 +21334,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262000,
+			"contextWindow": 262144,
 			"maxTokens": 65000,
 			"thinking": {
 				"mode": "effort",
@@ -20821,7 +21415,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"kilo-auto/efficient": {
@@ -20840,7 +21434,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"kilo-auto/free": {
@@ -20859,7 +21453,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 256000,
 			"maxTokens": 8888
 		},
 		"kilo-auto/frontier": {
@@ -20878,7 +21472,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"kilo-auto/small": {
@@ -20897,7 +21491,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"kilo/auto": {
@@ -20973,7 +21567,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 256000,
 			"maxTokens": 8888
 		},
 		"kwaipilot/kat-coder-pro": {
@@ -21011,7 +21605,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"kwaipilot/kat-coder-pro-v2.5": {
@@ -21030,7 +21624,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 256000,
 			"maxTokens": 8888
 		},
 		"kwaipilot/kat-coder-pro-v2.5:free": {
@@ -21106,7 +21700,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 65536,
 			"maxTokens": 8888
 		},
 		"liquid/lfm2-8b-a1b": {
@@ -21144,7 +21738,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 8000,
 			"maxTokens": 8888
 		},
 		"meituan/longcat-2.0": {
@@ -21163,7 +21757,26 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1048756,
+			"maxTokens": 8888
+		},
+		"meituan/longcat-2.0-free": {
+			"id": "meituan/longcat-2.0-free",
+			"name": "Meituan: LongCat 2.0 (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048756,
 			"maxTokens": 8888
 		},
 		"meituan/longcat-flash-chat": {
@@ -21277,7 +21890,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"meta-llama/llama-3.1-8b-instruct": {
@@ -21296,7 +21909,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"meta-llama/llama-3.2-11b-vision-instruct": {
@@ -21334,7 +21947,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 60000,
 			"maxTokens": 8888
 		},
 		"meta-llama/llama-3.2-3b-instruct": {
@@ -21353,7 +21966,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"meta-llama/llama-3.3-70b-instruct": {
@@ -21372,7 +21985,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"meta-llama/llama-4-maverick": {
@@ -21391,7 +22004,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1048576,
 			"maxTokens": 8888
 		},
 		"meta-llama/llama-4-scout": {
@@ -21410,7 +22023,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1310720,
 			"maxTokens": 8888
 		},
 		"meta-llama/llama-guard-2-8b": {
@@ -21467,7 +22080,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1048576,
 			"maxTokens": 8888
 		},
 		"meta-llama/llama-guard-4-12b:free": {
@@ -21491,13 +22104,14 @@
 		},
 		"meta/muse-glimmer-30b": {
 			"id": "meta/muse-glimmer-30b",
-			"name": "Meta: Muse Glimmer 30B",
+			"name": "Muse Glimmer 30B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -21505,8 +22119,13 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 131072,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"meta/muse-spark-1.1": {
 			"id": "meta/muse-spark-1.1",
@@ -21524,7 +22143,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1048576,
 			"maxTokens": 8888
 		},
 		"meta/muse-spark-1.2": {
@@ -21543,13 +22162,32 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1048576,
 			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
+		},
+		"meta/muse-spark-1.2-contributor": {
+			"id": "meta/muse-spark-1.2-contributor",
+			"name": "Meta: Muse Spark 1.2 Contributor",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 8888
 		},
 		"microsoft/phi-4": {
 			"id": "microsoft/phi-4",
@@ -21567,7 +22205,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 16384,
 			"maxTokens": 8888
 		},
 		"microsoft/phi-4-mini-instruct": {
@@ -21605,7 +22243,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 65535,
 			"maxTokens": 8888
 		},
 		"minimax/minimax-01": {
@@ -21624,7 +22262,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000192,
 			"maxTokens": 8888
 		},
 		"minimax/minimax-m1": {
@@ -21643,7 +22281,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"minimax/minimax-m2": {
@@ -21662,7 +22300,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204000,
+			"contextWindow": 204800,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -21686,7 +22324,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 65536,
 			"maxTokens": 8888
 		},
 		"minimax/minimax-m2.1": {
@@ -21705,7 +22343,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204000,
+			"contextWindow": 204800,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -21797,7 +22435,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 512000,
+			"contextWindow": 1048576,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -21821,7 +22459,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 256000,
 			"maxTokens": 8888
 		},
 		"mistralai/devstral-2512": {
@@ -21897,7 +22535,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"mistralai/ministral-3b-2512": {
@@ -21916,7 +22554,26 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
+			"maxTokens": 8888
+		},
+		"mistralai/ministral-8b": {
+			"id": "mistralai/ministral-8b",
+			"name": "Mistral: Ministral 8B",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"mistralai/ministral-8b-2512": {
@@ -21935,7 +22592,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-7b-instruct": {
@@ -22011,7 +22668,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-large-2407": {
@@ -22030,7 +22687,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-large-2411": {
@@ -22068,7 +22725,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-medium-3": {
@@ -22087,7 +22744,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-medium-3-5": {
@@ -22106,7 +22763,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-medium-3.1": {
@@ -22125,7 +22782,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-nemo": {
@@ -22144,7 +22801,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-saba": {
@@ -22163,7 +22820,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 32768,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-small-24b-instruct-2501": {
@@ -22182,7 +22839,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 32768,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-small-2603": {
@@ -22201,7 +22858,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-small-3.1-24b-instruct": {
@@ -22220,7 +22877,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-small-3.2-24b-instruct": {
@@ -22239,7 +22896,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"mistralai/mistral-small-creative": {
@@ -22334,7 +22991,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 32000,
 			"maxTokens": 8888
 		},
 		"moonshotai/kimi-k2": {
@@ -22353,7 +23010,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"moonshotai/kimi-k2-0905": {
@@ -22372,7 +23029,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"moonshotai/kimi-k2-0905:exacto": {
@@ -22410,7 +23067,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
@@ -22435,7 +23092,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262000,
+			"contextWindow": 262144,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -22591,7 +23248,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 81920,
 			"maxTokens": 8888
 		},
 		"morph/morph-v3-large": {
@@ -22610,7 +23267,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"neversleep/llama-3.1-lumimaid-8b": {
@@ -22686,7 +23343,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"nex-agi/nex-n2-pro": {
@@ -22705,7 +23362,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"nex-agi/nex-n2-pro:free": {
@@ -22762,7 +23419,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"nousresearch/hermes-3-llama-3.1-70b": {
@@ -22781,7 +23438,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"nousresearch/hermes-4-405b": {
@@ -22800,7 +23457,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"nousresearch/hermes-4-70b": {
@@ -22819,7 +23476,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"nvidia/llama-3.1-nemotron-70b-instruct": {
@@ -22905,7 +23562,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 262144,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -22929,7 +23586,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 256000,
 			"maxTokens": 8888
 		},
 		"nvidia/nemotron-3-super-120b-a12b": {
@@ -22948,7 +23605,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 1000000,
 			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
@@ -22972,7 +23629,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"nvidia/nemotron-3-ultra-550b-a55b": {
@@ -22991,7 +23648,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 512288,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -23015,7 +23672,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"nvidia/nemotron-3.5-content-safety:free": {
@@ -23034,7 +23691,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"nvidia/nemotron-3.5-lightning": {
@@ -23053,7 +23710,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"nvidia/nemotron-3.5-lightning:free": {
@@ -23072,7 +23729,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"nvidia/nemotron-nano-12b-v2-vl": {
@@ -23135,7 +23792,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 16385,
 			"maxTokens": 8888
 		},
 		"openai/gpt-3.5-turbo-0613": {
@@ -23154,7 +23811,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 4095,
 			"maxTokens": 8888
 		},
 		"openai/gpt-3.5-turbo-16k": {
@@ -23173,7 +23830,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 16385,
 			"maxTokens": 8888
 		},
 		"openai/gpt-3.5-turbo-instruct": {
@@ -23192,7 +23849,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 4095,
 			"maxTokens": 8888
 		},
 		"openai/gpt-4": {
@@ -23211,7 +23868,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 8192,
+			"contextWindow": 8191,
 			"maxTokens": 8192
 		},
 		"openai/gpt-4-0314": {
@@ -23288,7 +23945,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"openai/gpt-4.1": {
@@ -23387,7 +24044,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"openai/gpt-4o-2024-08-06": {
@@ -23406,7 +24063,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"openai/gpt-4o-2024-11-20": {
@@ -23425,7 +24082,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"openai/gpt-4o-audio-preview": {
@@ -23483,7 +24140,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"openai/gpt-4o-mini-search-preview": {
@@ -23628,7 +24285,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 400000,
 			"maxTokens": 8888
 		},
 		"openai/gpt-5-image-mini": {
@@ -23647,7 +24304,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 400000,
 			"maxTokens": 8888
 		},
 		"openai/gpt-5-mini": {
@@ -23880,7 +24537,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"openai/gpt-5.2-codex": {
@@ -24018,7 +24675,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 272000,
 			"maxTokens": 8888
 		},
 		"openai/gpt-5.4-mini": {
@@ -24187,7 +24844,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1050000,
 			"maxTokens": 8888
 		},
 		"openai/gpt-5.6-sol": {
@@ -24215,6 +24872,25 @@
 				"maxLevel": "max"
 			}
 		},
+		"openai/gpt-5.6-sol-discounted": {
+			"id": "openai/gpt-5.6-sol-discounted",
+			"name": "OpenAI: GPT-5.6 Sol (50% off)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 8888
+		},
 		"openai/gpt-5.6-sol-pro": {
 			"id": "openai/gpt-5.6-sol-pro",
 			"name": "OpenAI: GPT-5.6 Sol Pro",
@@ -24231,7 +24907,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1050000,
 			"maxTokens": 8888
 		},
 		"openai/gpt-5.6-terra": {
@@ -24275,7 +24951,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1050000,
 			"maxTokens": 8888
 		},
 		"openai/gpt-audio": {
@@ -24294,7 +24970,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"openai/gpt-audio-mini": {
@@ -24313,7 +24989,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"openai/gpt-chat-latest": {
@@ -24332,7 +25008,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 400000,
 			"maxTokens": 8888
 		},
 		"openai/gpt-oss-120b": {
@@ -24560,7 +25236,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 200000,
 			"maxTokens": 8888
 		},
 		"openai/o3-pro": {
@@ -24648,7 +25324,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 200000,
 			"maxTokens": 8888
 		},
 		"opengvlab/internvl3-78b": {
@@ -24686,7 +25362,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 2000000,
 			"maxTokens": 8888
 		},
 		"openrouter/auto-beta": {
@@ -24705,7 +25381,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 2000000,
 			"maxTokens": 8888
 		},
 		"openrouter/bodybuilder": {
@@ -24724,7 +25400,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"openrouter/elephant-alpha": {
@@ -24762,7 +25438,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 200000,
 			"maxTokens": 8888
 		},
 		"openrouter/fusion": {
@@ -24781,7 +25457,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"openrouter/healer-alpha": {
@@ -24857,7 +25533,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 2000000,
 			"maxTokens": 8888
 		},
 		"perceptron/perceptron-mk1": {
@@ -24876,7 +25552,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 32768,
 			"maxTokens": 8888
 		},
 		"perplexity/sonar": {
@@ -24895,7 +25571,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 127072,
 			"maxTokens": 8888
 		},
 		"perplexity/sonar-deep-research": {
@@ -24914,7 +25590,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"perplexity/sonar-pro": {
@@ -24933,7 +25609,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 200000,
 			"maxTokens": 8888
 		},
 		"perplexity/sonar-pro-search": {
@@ -24952,7 +25628,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 200000,
 			"maxTokens": 8888
 		},
 		"perplexity/sonar-reasoning-pro": {
@@ -24971,7 +25647,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"poolside/laguna-m.1": {
@@ -25028,7 +25704,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1048576,
 			"maxTokens": 8888
 		},
 		"poolside/laguna-s-2.1:free": {
@@ -25047,7 +25723,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"poolside/laguna-xs-2.1": {
@@ -25090,7 +25766,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"poolside/laguna-xs.2": {
@@ -25166,7 +25842,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 32768,
 			"maxTokens": 8888
 		},
 		"qwen/qwen-2.5-7b-instruct": {
@@ -25185,7 +25861,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 32768,
 			"maxTokens": 8888
 		},
 		"qwen/qwen-2.5-coder-32b-instruct": {
@@ -25204,7 +25880,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 32768,
 			"maxTokens": 8888
 		},
 		"qwen/qwen-2.5-vl-7b-instruct": {
@@ -25261,7 +25937,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"qwen/qwen-plus-2025-07-28": {
@@ -25280,7 +25956,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"qwen/qwen-plus-2025-07-28:thinking": {
@@ -25299,7 +25975,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"qwen/qwen-turbo": {
@@ -25413,7 +26089,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-14b": {
@@ -25432,7 +26108,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-235b-a22b": {
@@ -25451,7 +26127,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
@@ -25475,7 +26151,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-235b-a22b-thinking-2507": {
@@ -25494,7 +26170,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-30b-a3b": {
@@ -25513,7 +26189,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-30b-a3b-instruct-2507": {
@@ -25532,7 +26208,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-30b-a3b-thinking-2507": {
@@ -25551,7 +26227,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 81920,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-32b": {
@@ -25570,7 +26246,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
@@ -25594,7 +26270,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-coder": {
@@ -25613,7 +26289,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-coder-30b-a3b-instruct": {
@@ -25632,7 +26308,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-coder-flash": {
@@ -25651,7 +26327,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-coder-next": {
@@ -25670,7 +26346,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-coder-plus": {
@@ -25727,7 +26403,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
+			"contextWindow": 262144,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -25751,7 +26427,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-next-80b-a3b-instruct": {
@@ -25789,7 +26465,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
@@ -25813,7 +26489,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-vl-235b-a22b-thinking": {
@@ -25832,7 +26508,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-vl-30b-a3b-instruct": {
@@ -25851,7 +26527,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-vl-30b-a3b-thinking": {
@@ -25870,7 +26546,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-vl-32b-instruct": {
@@ -25889,7 +26565,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-vl-8b-instruct": {
@@ -25908,7 +26584,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3-vl-8b-thinking": {
@@ -25927,7 +26603,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.5-122b-a10b": {
@@ -25971,7 +26647,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.5-35b-a3b": {
@@ -25990,7 +26666,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.5-397b-a17b": {
@@ -26034,7 +26710,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.5-flash-02-23": {
@@ -26053,7 +26729,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.5-plus-02-15": {
@@ -26072,7 +26748,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.5-plus-20260420": {
@@ -26091,7 +26767,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.6-27b": {
@@ -26111,7 +26787,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 262144,
 			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
@@ -26135,7 +26811,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.6-flash": {
@@ -26154,7 +26830,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.6-max-preview": {
@@ -26173,7 +26849,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.6-plus": {
@@ -26254,7 +26930,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.7-max": {
@@ -26322,7 +26998,26 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1048576,
+			"maxTokens": 8888
+		},
+		"qwen/qwen3.8-27b": {
+			"id": "qwen/qwen3.8-27b",
+			"name": "Qwen: Qwen3.8 27B",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"qwen/qwen3.8-max": {
@@ -26341,7 +27036,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"qwen/qwq-32b": {
@@ -26417,7 +27112,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 16384,
 			"maxTokens": 8888
 		},
 		"rekaai/reka-flash-3": {
@@ -26436,7 +27131,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 65536,
 			"maxTokens": 8888
 		},
 		"relace/relace-apply-3": {
@@ -26455,7 +27150,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 256000,
 			"maxTokens": 8888
 		},
 		"relace/relace-search": {
@@ -26474,7 +27169,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 256000,
 			"maxTokens": 8888
 		},
 		"sakana/fugu-ultra": {
@@ -26493,7 +27188,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"sakana/sakana-namazu": {
@@ -26512,7 +27207,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"sao10k/l3-euryale-70b": {
@@ -26550,7 +27245,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 8192,
 			"maxTokens": 8888
 		},
 		"sao10k/l3.1-70b-hanami-x1": {
@@ -26588,7 +27283,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"sao10k/l3.3-euryale-70b": {
@@ -26607,7 +27302,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"stealth/claude-opus-4.6": {
@@ -26626,7 +27321,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"stealth/claude-opus-4.7": {
@@ -26645,7 +27340,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"stealth/claude-opus-4.8": {
@@ -26665,7 +27360,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"stealth/claude-sonnet-4.6": {
@@ -26684,7 +27379,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"stealth/gpt-5.6-sol": {
@@ -26706,6 +27401,25 @@
 			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
+		"stealth/ox-alpha": {
+			"id": "stealth/ox-alpha",
+			"name": "Ox Alpha",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 8888
+		},
 		"stealth/qwen3.6-plus": {
 			"id": "stealth/qwen3.6-plus",
 			"name": "Stealth: Qwen3.6 Plus (50% off)",
@@ -26722,7 +27436,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888
 		},
 		"stepfun/step-3.5-flash": {
@@ -26741,7 +27455,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
+			"contextWindow": 262144,
 			"maxTokens": 64000
 		},
 		"stepfun/step-3.5-flash:free": {
@@ -26780,7 +27494,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
+			"contextWindow": 262144,
 			"maxTokens": 256000,
 			"thinking": {
 				"mode": "effort",
@@ -26804,7 +27518,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"switchpoint/router": {
@@ -26842,7 +27556,64 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
+			"maxTokens": 8888
+		},
+		"tencent/hy-mt2-1.8b": {
+			"id": "tencent/hy-mt2-1.8b",
+			"name": "Tencent: Hy-MT2-1.8B",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 8192,
+			"maxTokens": 8888
+		},
+		"tencent/hy-mt2-30b-a3b": {
+			"id": "tencent/hy-mt2-30b-a3b",
+			"name": "Tencent: Hy-MT2-30B-A3B",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 8192,
+			"maxTokens": 8888
+		},
+		"tencent/hy-mt2-7b": {
+			"id": "tencent/hy-mt2-7b",
+			"name": "Tencent: Hy-MT2-7B",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 8192,
 			"maxTokens": 8888
 		},
 		"tencent/hy3": {
@@ -26861,7 +27632,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"tencent/hy3-preview": {
@@ -26880,7 +27651,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
+			"contextWindow": 262144,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -26923,7 +27694,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"thedrummer/cydonia-24b-v4.1": {
@@ -26942,7 +27713,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"thedrummer/rocinante-12b": {
@@ -26961,7 +27732,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 65536,
 			"maxTokens": 8888
 		},
 		"thedrummer/skyfall-36b-v2": {
@@ -26980,7 +27751,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 32768,
 			"maxTokens": 8888
 		},
 		"thedrummer/unslopnemo-12b": {
@@ -26999,7 +27770,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1024000,
 			"maxTokens": 8888
 		},
 		"thinkingmachines/inkling": {
@@ -27043,7 +27814,45 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1048576,
+			"maxTokens": 8888
+		},
+		"thinkingmachines/inkling-small:free": {
+			"id": "thinkingmachines/inkling-small:free",
+			"name": "Thinking Machines: Inkling Small (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 8888
+		},
+		"thinkingmachines/inkling:free": {
+			"id": "thinkingmachines/inkling:free",
+			"name": "Thinking Machines: Inkling (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
 			"maxTokens": 8888
 		},
 		"tngtech/deepseek-r1t2-chimera": {
@@ -27081,7 +27890,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 6144,
 			"maxTokens": 8888
 		},
 		"upstage/solar-pro-3": {
@@ -27100,7 +27909,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"upstage/solar-pro4": {
@@ -27119,7 +27928,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 524288,
 			"maxTokens": 8888
 		},
 		"writer/palmyra-x5": {
@@ -27138,7 +27947,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1040000,
 			"maxTokens": 8888
 		},
 		"x-ai/grok-3": {
@@ -27308,7 +28117,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 2000000,
 			"maxTokens": 8888
 		},
 		"x-ai/grok-4.20-beta": {
@@ -27346,7 +28155,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 2000000,
 			"maxTokens": 8888
 		},
 		"x-ai/grok-4.20-multi-agent-beta": {
@@ -27434,7 +28243,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 500000,
 			"maxTokens": 8888
 		},
 		"x-ai/grok-build-0.1": {
@@ -27633,7 +28442,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1050000,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -27657,7 +28466,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1050000,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -27700,7 +28509,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 131072,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -27724,7 +28533,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 131072,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -27748,7 +28557,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 65536,
 			"maxTokens": 8888
 		},
 		"z-ai/glm-4.6": {
@@ -27767,7 +28576,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 204800,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -27811,7 +28620,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 131072,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -27835,7 +28644,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 204800,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
@@ -27859,7 +28668,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 202752,
 			"maxTokens": 8888
 		},
 		"z-ai/glm-5": {
@@ -27878,7 +28687,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 204800,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -27902,7 +28711,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 202752,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -27926,7 +28735,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 204800,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -27950,13 +28759,32 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 1048576,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
+		},
+		"z-ai/glm-5.3": {
+			"id": "z-ai/glm-5.3",
+			"name": "Z.ai: GLM 5.3 (new)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 8888
 		},
 		"z-ai/glm-5v-turbo": {
 			"id": "z-ai/glm-5v-turbo",
@@ -27975,7 +28803,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 202752,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
@@ -28614,11 +29442,11 @@
 		},
 		"anthropic/claude-haiku-4.5": {
 			"id": "anthropic/claude-haiku-4.5",
-			"name": "Anthropic Haiku 4.5",
+			"name": "Anthropic Haiku 4.5 (latest)",
 			"api": "openai-completions",
 			"provider": "litellm",
 			"baseUrl": "http://localhost:4000/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
@@ -28630,7 +29458,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"anthropic/claude-haiku-latest": {
 			"id": "anthropic/claude-haiku-latest",
@@ -28703,7 +29536,7 @@
 		},
 		"anthropic/claude-opus-4.5": {
 			"id": "anthropic/claude-opus-4.5",
-			"name": "Anthropic Opus 4.5",
+			"name": "Anthropic Opus 4.5 (latest)",
 			"api": "openai-completions",
 			"provider": "litellm",
 			"baseUrl": "http://localhost:4000/v1",
@@ -28822,7 +29655,7 @@
 		},
 		"anthropic/claude-sonnet-4.5": {
 			"id": "anthropic/claude-sonnet-4.5",
-			"name": "Anthropic Sonnet 4.5",
+			"name": "Anthropic Sonnet 4.5 (latest)",
 			"api": "openai-completions",
 			"provider": "litellm",
 			"baseUrl": "http://localhost:4000/v1",
@@ -40235,13 +41068,14 @@
 		},
 		"Qwen/Qwen3-VL-235B-A22B-Instruct": {
 			"id": "Qwen/Qwen3-VL-235B-A22B-Instruct",
-			"name": "Qwen/Qwen3-VL-235B-A22B-Instruct",
+			"name": "Qwen3 VL 235B A22B Instruct",
 			"api": "openai-completions",
 			"provider": "litellm",
 			"baseUrl": "http://localhost:4000/v1",
 			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -40249,8 +41083,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 262144,
+			"maxTokens": 32768
 		},
 		"qwen/qwen3-vl-plus": {
 			"id": "qwen/qwen3-vl-plus",
@@ -56357,13 +57191,14 @@
 		},
 		"Qwen/Qwen3-VL-235B-A22B-Instruct": {
 			"id": "Qwen/Qwen3-VL-235B-A22B-Instruct",
-			"name": "Qwen/Qwen3-VL-235B-A22B-Instruct",
+			"name": "Qwen3 VL 235B A22B Instruct",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
 			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -56371,8 +57206,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 262144,
+			"maxTokens": 32768
 		},
 		"qwen/qwen3.5-397b-a17b": {
 			"id": "qwen/qwen3.5-397b-a17b",
@@ -60521,6 +61356,30 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"deepseek-ai/deepseek-v4-flash-0731": {
+			"id": "deepseek-ai/deepseek-v4-flash-0731",
+			"name": "DeepSeek V4 Flash 0731",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"deepseek-ai/deepseek-v4-pro": {
 			"id": "deepseek-ai/deepseek-v4-pro",
 			"name": "DeepSeek V4 Pro",
@@ -60945,6 +61804,31 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096
+		},
+		"meta/muse-glimmer-30b": {
+			"id": "meta/muse-glimmer-30b",
+			"name": "Muse Glimmer 30B",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"microsoft/phi-3-medium-128k-instruct": {
 			"id": "microsoft/phi-3-medium-128k-instruct",
@@ -61602,6 +62486,31 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"moonshotai/kimi-k3": {
+			"id": "moonshotai/kimi-k3",
+			"name": "Kimi K3",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -64663,6 +65572,31 @@
 				"requiresReasoningContentForToolCalls": true
 			}
 		},
+		"deepseek-v4-flash-vision-exp": {
+			"id": "deepseek-v4-flash-vision-exp",
+			"name": "DeepSeek V4 Flash Vision Exp",
+			"api": "openai-completions",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.22,
+				"output": 0.66,
+				"cacheRead": 0.007,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"deepseek-v4-pro": {
 			"id": "deepseek-v4-pro",
 			"name": "DeepSeek V4 Pro",
@@ -64790,7 +65724,7 @@
 		},
 		"gpt-5.6-luna": {
 			"id": "gpt-5.6-luna",
-			"name": "GPT-5.6 Luna (2x usage)",
+			"name": "GPT-5.6 Luna",
 			"api": "openai-responses",
 			"provider": "opencode-go",
 			"baseUrl": "https://opencode.ai/zen/go/v1",
@@ -64800,10 +65734,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.1,
-				"output": 0.6,
-				"cacheRead": 0.01,
-				"cacheWrite": 0.125
+				"input": 0.2,
+				"output": 1.2,
+				"cacheRead": 0.02,
+				"cacheWrite": 0.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -64840,7 +65774,7 @@
 		},
 		"hy3": {
 			"id": "hy3",
-			"name": "Hy3",
+			"name": "Hy3 (8x usage)",
 			"api": "openai-completions",
 			"provider": "opencode-go",
 			"baseUrl": "https://opencode.ai/zen/go/v1",
@@ -64849,9 +65783,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.58,
-				"cacheRead": 0.035,
+				"input": 0.0175,
+				"output": 0.0725,
+				"cacheRead": 0.004375,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -65157,6 +66091,56 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"muse-spark-1.2-contributor": {
+			"id": "muse-spark-1.2-contributor",
+			"name": "Muse Spark 1.2 Contributor",
+			"api": "openai-responses",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.2,
+				"cacheRead": 0.002,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"ox-alpha-free": {
+			"id": "ox-alpha-free",
+			"name": "Ox Alpha Free (Unlimited)",
+			"api": "openai-completions",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"qwen3.5-plus": {
 			"id": "qwen3.5-plus",
 			"name": "Qwen3.5 Plus",
@@ -65259,9 +66243,9 @@
 		"qwen3.8-max": {
 			"id": "qwen3.8-max",
 			"name": "Qwen3.8 Max",
-			"api": "anthropic-messages",
+			"api": "openai-completions",
 			"provider": "opencode-go",
-			"baseUrl": "https://opencode.ai/zen/go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -65276,9 +66260,9 @@
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
 			"thinking": {
-				"mode": "budget",
+				"mode": "effort",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "high"
 			}
 		}
 	},
@@ -66461,7 +67445,7 @@
 		},
 		"gpt-5.6-sol": {
 			"id": "gpt-5.6-sol",
-			"name": "GPT-5.6 Sol",
+			"name": "GPT-5.6 Sol (50% Off)",
 			"api": "openai-responses",
 			"provider": "opencode-zen",
 			"baseUrl": "https://opencode.ai/zen/v1",
@@ -66471,10 +67455,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 5,
-				"output": 30,
-				"cacheRead": 0.5,
-				"cacheWrite": 6.25
+				"input": 2,
+				"output": 10,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -67086,6 +68070,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"muse-spark-1.2-contributor-free": {
+			"id": "muse-spark-1.2-contributor-free",
+			"name": "Muse Spark 1.2 Free",
+			"api": "openai-responses",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"nemotron-3-super-free": {
 			"id": "nemotron-3-super-free",
 			"name": "Nemotron 3 Super Free",
@@ -67298,6 +68307,31 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072
+		},
+		"x-preview-f-free": {
+			"id": "x-preview-f-free",
+			"name": "Ox Alpha Free (Unlimited)",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		}
 	},
 	"opengateway": {
@@ -67484,13 +68518,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.079996,
-				"output": 0.252,
-				"cacheRead": 0.0252,
+				"input": 0.04,
+				"output": 0.13,
+				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
-			"maxTokens": 8888,
+			"contextWindow": 1310720,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -67559,13 +68593,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.8,
-				"output": 14,
+				"input": 2.6,
+				"output": 13,
 				"cacheRead": 0.29,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 1048576,
+			"maxTokens": 974842,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -67584,10 +68618,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 5,
-				"output": 30,
-				"cacheRead": 0.5,
-				"cacheWrite": 6.25
+				"input": 2,
+				"output": 10,
+				"cacheRead": 0.19999999999999998,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -67641,6 +68675,30 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 8888,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"~z-ai/glm-latest": {
+			"id": "~z-ai/glm-latest",
+			"name": "Z.ai: GLM Latest",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0.26,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -68059,11 +69117,11 @@
 		},
 		"anthropic/claude-haiku-4.5": {
 			"id": "anthropic/claude-haiku-4.5",
-			"name": "Anthropic Haiku 4.5",
+			"name": "Anthropic Haiku 4.5 (latest)",
 			"api": "openai-completions",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
@@ -68075,7 +69133,12 @@
 				"cacheWrite": 1.25
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		},
 		"anthropic/claude-haiku-4.5:batch": {
 			"id": "anthropic/claude-haiku-4.5:batch",
@@ -68179,7 +69242,7 @@
 		},
 		"anthropic/claude-opus-4.5": {
 			"id": "anthropic/claude-opus-4.5",
-			"name": "Anthropic Opus 4.5",
+			"name": "Anthropic Opus 4.5 (latest)",
 			"api": "openai-completions",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -68554,7 +69617,7 @@
 		},
 		"anthropic/claude-sonnet-4.5": {
 			"id": "anthropic/claude-sonnet-4.5",
-			"name": "Anthropic Sonnet 4.5",
+			"name": "Anthropic Sonnet 4.5 (latest)",
 			"api": "openai-completions",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -69199,13 +70262,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.27,
-				"output": 1.12,
+				"input": 0.25,
+				"output": 1,
 				"cacheRead": 0.135,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
-			"maxTokens": 65536,
+			"maxTokens": 163840,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -69223,13 +70286,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 0.95,
-				"cacheRead": 0.13,
+				"input": 0.55,
+				"output": 1.6500000000000001,
+				"cacheRead": 0.55,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
-			"maxTokens": 32768,
+			"maxTokens": 161000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -69296,8 +70359,8 @@
 			],
 			"cost": {
 				"input": 0.27,
-				"output": 0.95,
-				"cacheRead": 0.13,
+				"output": 1,
+				"cacheRead": 0.135,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
@@ -69343,13 +70406,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.26899999999999996,
-				"output": 0.39999999999999997,
-				"cacheRead": 0.13449999999999998,
+				"input": 0.26,
+				"output": 0.38,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
-			"maxTokens": 65536,
+			"maxTokens": 163840,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -69391,13 +70454,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.28,
-				"cacheRead": 0.028,
+				"input": 0.05166,
+				"output": 0.10332,
+				"cacheRead": 0.010332,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 393216,
+			"maxTokens": 384000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -69415,13 +70478,38 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.28,
-				"cacheRead": 0.028,
+				"input": 0.08,
+				"output": 0.18,
+				"cacheRead": 0.016,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1310720,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"deepseek/deepseek-v4-flash-vision-exp": {
+			"id": "deepseek/deepseek-v4-flash-vision-exp",
+			"name": "DeepSeek: DeepSeek V4 Flash Vision Exp",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.22,
+				"output": 0.66,
+				"cacheRead": 0.007,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 393216,
+			"maxTokens": 384000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -69463,13 +70551,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.1680000000000001,
-				"output": 2.3360000000000003,
-				"cacheRead": 0.09855000000000001,
+				"input": 0.396894,
+				"output": 0.793788,
+				"cacheRead": 0.0330745,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 393216,
+			"maxTokens": 384000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -69487,13 +70575,38 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.435,
-				"output": 0.87,
-				"cacheRead": 0.003625,
+				"input": 1.122,
+				"output": 3.366,
+				"cacheRead": 0.037399999999999996,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 384000,
+			"maxTokens": 8888,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"dots-studio/dots-3-note-preview:free": {
+			"id": "dots-studio/dots-3-note-preview:free",
+			"name": "Dots Studio: Dots3-Note Preview (free)",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 512000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -70346,13 +71459,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.12,
-				"output": 0.39999999999999997,
+				"input": 0.07,
+				"output": 0.33999999999999997,
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -70361,7 +71474,7 @@
 		},
 		"google/gemma-4-26b-a4b-it:free": {
 			"id": "google/gemma-4-26b-a4b-it:free",
-			"name": "Google: Gemma 4 26B A4B  (free)",
+			"name": "Google: Gemma 4 26B A4B (free)",
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -70803,7 +71916,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 65536,
 			"maxTokens": 8192,
 			"thinking": {
 				"mode": "effort",
@@ -70981,12 +72094,12 @@
 			],
 			"cost": {
 				"input": 0.19999999999999998,
-				"output": 0.696,
+				"output": 0.7999999999999999,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 8888
+			"maxTokens": 16384
 		},
 		"meta-llama/llama-4-scout": {
 			"id": "meta-llama/llama-4-scout",
@@ -71010,7 +72123,7 @@
 		},
 		"meta/muse-glimmer-30b": {
 			"id": "meta/muse-glimmer-30b",
-			"name": "Meta: Muse Glimmer 30B",
+			"name": "Muse Glimmer 30B",
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -71026,7 +72139,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 8888,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -71081,6 +72194,31 @@
 				"mode": "effort",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
+			}
+		},
+		"meta/muse-spark-1.2-contributor": {
+			"id": "meta/muse-spark-1.2-contributor",
+			"name": "Meta: Muse Spark 1.2 Contributor",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.09999999999999999,
+				"output": 0.19999999999999998,
+				"cacheRead": 0.002,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 8888,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
 			}
 		},
 		"minimax/minimax-m1": {
@@ -71166,13 +72304,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.22,
-				"output": 0.8999999999999999,
-				"cacheRead": 0.049999999999999996,
+				"input": 0.27,
+				"output": 1.08,
+				"cacheRead": 0.027,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
-			"maxTokens": 196608,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -71267,9 +72405,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.15,
-				"output": 0.6,
-				"cacheRead": 0.03,
+				"input": 0.3,
+				"output": 1.2,
+				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
 			"contextWindow": 524288,
@@ -71692,12 +72830,12 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.09375,
-				"output": 0.25,
+				"input": 0.075,
+				"output": 0.19999999999999998,
 				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
+			"contextWindow": 131072,
 			"maxTokens": 16384
 		},
 		"mistralai/mistral-small-creative": {
@@ -71889,9 +73027,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.5700000000000001,
-				"output": 2.8499999999999996,
-				"cacheRead": 0.095,
+				"input": 0.44999999999999996,
+				"output": 2.25,
+				"cacheRead": 0.07,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -71966,7 +73104,7 @@
 			"cost": {
 				"input": 0.67,
 				"output": 3.4,
-				"cacheRead": 0.15,
+				"cacheRead": 0.16999999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -71989,9 +73127,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.475,
-				"output": 2,
-				"cacheRead": 0.095,
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.19,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -72225,11 +73363,11 @@
 			"cost": {
 				"input": 0.049999999999999996,
 				"output": 0.19999999999999998,
-				"cacheRead": 0.024999999999999998,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 228000,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -72368,9 +73506,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 1.7999999999999998,
-				"cacheRead": 0.09999999999999999,
+				"input": 0.6,
+				"output": 3.5999999999999996,
+				"cacheRead": 0.19999999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 512288,
@@ -72416,13 +73554,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
-				"output": 0.25,
-				"cacheRead": 0.049999999999999996,
+				"input": 0.08,
+				"output": 0.19999999999999998,
+				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
-			"maxTokens": 262144,
+			"contextWindow": 262144,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -73983,10 +75121,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
-				"output": 0.6,
-				"cacheRead": 0.01,
-				"cacheWrite": 0.125
+				"input": 0.19999999999999998,
+				"output": 1.2,
+				"cacheRead": 0.02,
+				"cacheWrite": 0.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -74008,10 +75146,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
-				"output": 0.6,
-				"cacheRead": 0.01,
-				"cacheWrite": 0.125
+				"input": 0.19999999999999998,
+				"output": 1.2,
+				"cacheRead": 0.02,
+				"cacheWrite": 0.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -74083,10 +75221,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 5,
-				"output": 30,
-				"cacheRead": 0.5,
-				"cacheWrite": 6.25
+				"input": 2,
+				"output": 10,
+				"cacheRead": 0.19999999999999998,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -74108,10 +75246,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 5,
-				"output": 30,
-				"cacheRead": 0.5,
-				"cacheWrite": 6.25
+				"input": 2,
+				"output": 10,
+				"cacheRead": 0.19999999999999998,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -74133,10 +75271,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 15,
-				"cacheRead": 0.25,
-				"cacheWrite": 0
+				"input": 1,
+				"output": 5,
+				"cacheRead": 0.09999999999999999,
+				"cacheWrite": 1.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -74158,10 +75296,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 15,
-				"cacheRead": 0.25,
-				"cacheWrite": 0
+				"input": 1,
+				"output": 5,
+				"cacheRead": 0.09999999999999999,
+				"cacheWrite": 1.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -74183,10 +75321,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
-				"output": 6,
-				"cacheRead": 0.09999999999999999,
-				"cacheWrite": 1.25
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.19999999999999998,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -74208,10 +75346,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
-				"output": 6,
-				"cacheRead": 0.09999999999999999,
-				"cacheWrite": 1.25
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.19999999999999998,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -74340,7 +75478,7 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.03,
+				"input": 0.037,
 				"output": 0.16999999999999998,
 				"cacheRead": 0.03,
 				"cacheWrite": 0
@@ -75380,8 +76518,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.39999999999999997,
-				"output": 1.2,
+				"input": 0.26,
+				"output": 0.78,
 				"cacheRead": 0,
 				"cacheWrite": 0.5
 			},
@@ -75946,8 +77084,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.26,
-				"output": 1.04,
+				"input": 0.21,
+				"output": 1.9,
 				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 0
 			},
@@ -76101,13 +77239,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.29,
-				"output": 2.4,
+				"input": 0.26,
+				"output": 2.08,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 81920,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -76176,13 +77314,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.5,
-				"output": 3.5999999999999996,
+				"input": 0.39,
+				"output": 2.34,
 				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -76326,7 +77464,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.15,
+				"input": 0.14,
 				"output": 1,
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
@@ -76551,8 +77689,33 @@
 				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1010000,
-			"maxTokens": 262144,
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"qwen/qwen3.8-27b": {
+			"id": "qwen/qwen3.8-27b",
+			"name": "Qwen: Qwen3.8 27B",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.39999999999999997,
+				"output": 3,
+				"cacheRead": 0.049999999999999996,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -76755,6 +77918,31 @@
 			"contextWindow": 131072,
 			"maxTokens": 16384
 		},
+		"stealth/ox-alpha": {
+			"id": "stealth/ox-alpha",
+			"name": "Ox Alpha",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"stepfun/step-3.5-flash": {
 			"id": "stepfun/step-3.5-flash",
 			"name": "Step 3.5 Flash",
@@ -76867,9 +78055,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.063,
-				"output": 0.21,
-				"cacheRead": 0.020999999999999998,
+				"input": 0.18,
+				"output": 0.6,
+				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -76954,13 +78142,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.95,
+				"input": 1,
 				"output": 4.05,
-				"cacheRead": 0.16,
+				"cacheRead": 0.16999999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 262144,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -76984,8 +78172,36 @@
 				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 0
 			},
-			"contextWindow": 524288,
+			"contextWindow": 1048576,
 			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"thinkingmachines/inkling-small:free": {
+			"id": "thinkingmachines/inkling-small:free",
+			"name": "Thinking Machines: Inkling Small (free)",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"compat": {
+				"supportsToolChoice": false
+			},
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -77004,13 +78220,41 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.5,
-				"output": 2.025,
-				"cacheRead": 0.08499999999999999,
+				"input": 1,
+				"output": 4.05,
+				"cacheRead": 0.16999999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 524288,
 			"maxTokens": 8888,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"thinkingmachines/inkling:free": {
+			"id": "thinkingmachines/inkling:free",
+			"name": "Thinking Machines: Inkling (free)",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"compat": {
+				"supportsToolChoice": false
+			},
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -77842,13 +79086,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.95,
-				"output": 2.5500000000000003,
-				"cacheRead": 0.19999999999999998,
+				"input": 0.6,
+				"output": 1.92,
+				"cacheRead": 0.12,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
-			"maxTokens": 131072,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -77890,13 +79134,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.4,
-				"output": 4.4,
-				"cacheRead": 0.26,
+				"input": 0.966,
+				"output": 3.036,
+				"cacheRead": 0.1794,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
-			"maxTokens": 131072,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -77914,9 +79158,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.63,
-				"output": 1.9800000000000002,
-				"cacheRead": 0.0945,
+				"input": 0.966,
+				"output": 3.036,
+				"cacheRead": 0.1932,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -77938,13 +79182,61 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.7,
-				"output": 2.2,
-				"cacheRead": 0.13,
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0.26,
 				"cacheWrite": 0
 			},
-			"contextWindow": 512000,
+			"contextWindow": 1048575,
 			"maxTokens": 8888,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"z-ai/glm-5.2:free": {
+			"id": "z-ai/glm-5.2:free",
+			"name": "Z.ai: GLM 5.2 (free)",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 256000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"z-ai/glm-5.3": {
+			"id": "z-ai/glm-5.3",
+			"name": "Z.ai: GLM 5.3",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0.26,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -79263,11 +80555,11 @@
 		},
 		"deepseek-v4-pro-0813": {
 			"id": "deepseek-v4-pro-0813",
-			"name": "deepseek-v4-pro-0813",
+			"name": "DeepSeek V4 Pro 0813",
 			"api": "openai-completions",
 			"provider": "venice",
 			"baseUrl": "https://api.venice.ai/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -79277,10 +80569,15 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888,
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
 			"compat": {
 				"supportsUsageInStreaming": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
 			}
 		},
 		"e2ee-deepseek-v4-flash": {
@@ -81281,6 +82578,28 @@
 				"supportsUsageInStreaming": false
 			}
 		},
+		"qwen-3-8-27b": {
+			"id": "qwen-3-8-27b",
+			"name": "qwen-3-8-27b",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
 		"qwen-3-8-max": {
 			"id": "qwen-3-8-max",
 			"name": "qwen-3-8-max",
@@ -81600,6 +82919,28 @@
 				"supportsUsageInStreaming": false
 			}
 		},
+		"stealth-ox-alpha": {
+			"id": "stealth-ox-alpha",
+			"name": "stealth-ox-alpha",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
 		"venice-uncensored": {
 			"id": "venice-uncensored",
 			"name": "Venice Uncensored 1.1",
@@ -81669,6 +83010,28 @@
 		"xiaomi-mimo-v2-5": {
 			"id": "xiaomi-mimo-v2-5",
 			"name": "xiaomi-mimo-v2-5",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"z-ai-glm-5-3": {
+			"id": "z-ai-glm-5-3",
+			"name": "z-ai-glm-5-3",
 			"api": "openai-completions",
 			"provider": "venice",
 			"baseUrl": "https://api.venice.ai/api/v1",
@@ -82471,15 +83834,41 @@
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 2,
 				"output": 6,
-				"cacheRead": 0.25,
+				"cacheRead": 0.19999999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"alibaba/qwen3.8-27b": {
+			"id": "alibaba/qwen3.8-27b",
+			"name": "Qwen3.8 27B",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.55,
+				"output": 3.3000000000000003,
+				"cacheRead": 0.11,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "budget",
@@ -82728,11 +84117,11 @@
 		},
 		"anthropic/claude-haiku-4.5": {
 			"id": "anthropic/claude-haiku-4.5",
-			"name": "Anthropic Haiku 4.5",
+			"name": "Anthropic Haiku 4.5 (latest)",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
@@ -82744,7 +84133,12 @@
 				"cacheWrite": 1.25
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"anthropic/claude-opus-4": {
 			"id": "anthropic/claude-opus-4",
@@ -82798,7 +84192,7 @@
 		},
 		"anthropic/claude-opus-4.5": {
 			"id": "anthropic/claude-opus-4.5",
-			"name": "Anthropic Opus 4.5",
+			"name": "Anthropic Opus 4.5 (latest)",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -83030,7 +84424,7 @@
 		},
 		"anthropic/claude-sonnet-4.5": {
 			"id": "anthropic/claude-sonnet-4.5",
-			"name": "Anthropic Sonnet 4.5",
+			"name": "Anthropic Sonnet 4.5 (latest)",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -83385,9 +84779,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.19999999999999998,
-				"output": 0.39999999999999997,
-				"cacheRead": 0.04,
+				"input": 0.13,
+				"output": 0.26,
+				"cacheRead": 0.028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -83409,9 +84803,34 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.19999999999999998,
-				"output": 0.39999999999999997,
-				"cacheRead": 0.04,
+				"input": 0.07600000000000001,
+				"output": 0.153,
+				"cacheRead": 0.014,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"deepseek/deepseek-v4-flash-vision-exp": {
+			"id": "deepseek/deepseek-v4-flash-vision-exp",
+			"name": "DeepSeek V4 Flash Vision Exp",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.22,
+				"output": 0.66,
+				"cacheRead": 0.007,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -83820,9 +85239,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 1.5,
-				"output": 7.5,
-				"cacheRead": 0.15,
+				"input": 0.75,
+				"output": 3.75,
+				"cacheRead": 0.075,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -85249,6 +86668,54 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"nvidia/nemotron-3.5-lightning": {
+			"id": "nvidia/nemotron-3.5-lightning",
+			"name": "Nemotron 3.5 Lightning 30B",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"nvidia/nemotron-3.5-lightning-free": {
+			"id": "nvidia/nemotron-3.5-lightning-free",
+			"name": "Nemotron 3.5 Lightning 30B (Free)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"nvidia/nemotron-nano-12b-v2-vl": {
 			"id": "nvidia/nemotron-nano-12b-v2-vl",
 			"name": "Nemotron Nano 12B v2 VL",
@@ -85382,6 +86849,26 @@
 			"contextWindow": 1047576,
 			"maxTokens": 32768
 		},
+		"openai/gpt-4.1-fast": {
+			"id": "openai/gpt-4.1-fast",
+			"name": "GPT-4.1 (Fast)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 3.5,
+				"output": 14,
+				"cacheRead": 0.875,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1047576,
+			"maxTokens": 32768
+		},
 		"openai/gpt-4.1-mini": {
 			"id": "openai/gpt-4.1-mini",
 			"name": "GPT-4.1 mini",
@@ -85397,6 +86884,26 @@
 				"input": 0.39999999999999997,
 				"output": 1.5999999999999999,
 				"cacheRead": 0.09999999999999999,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1047576,
+			"maxTokens": 32768
+		},
+		"openai/gpt-4.1-mini-fast": {
+			"id": "openai/gpt-4.1-mini-fast",
+			"name": "GPT-4.1 mini (Fast)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.7,
+				"output": 2.8,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1047576,
@@ -85422,6 +86929,26 @@
 			"contextWindow": 1047576,
 			"maxTokens": 32768
 		},
+		"openai/gpt-4.1-nano-fast": {
+			"id": "openai/gpt-4.1-nano-fast",
+			"name": "GPT-4.1 nano (Fast)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.19999999999999998,
+				"output": 0.7999999999999999,
+				"cacheRead": 0.049999999999999996,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1047576,
+			"maxTokens": 32768
+		},
 		"openai/gpt-4o": {
 			"id": "openai/gpt-4o",
 			"name": "GPT-4o",
@@ -85442,6 +86969,26 @@
 			"contextWindow": 128000,
 			"maxTokens": 16384
 		},
+		"openai/gpt-4o-fast": {
+			"id": "openai/gpt-4o-fast",
+			"name": "GPT-4o (Fast)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 4.25,
+				"output": 17,
+				"cacheRead": 2.125,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384
+		},
 		"openai/gpt-4o-mini": {
 			"id": "openai/gpt-4o-mini",
 			"name": "GPT-4o mini",
@@ -85457,6 +87004,26 @@
 				"input": 0.15,
 				"output": 0.6,
 				"cacheRead": 0.075,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384
+		},
+		"openai/gpt-4o-mini-fast": {
+			"id": "openai/gpt-4o-mini-fast",
+			"name": "GPT-4o mini (Fast)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.25,
+				"output": 1,
+				"cacheRead": 0.125,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -85537,6 +87104,31 @@
 				"maxLevel": "high"
 			}
 		},
+		"openai/gpt-5-fast": {
+			"id": "openai/gpt-5-fast",
+			"name": "GPT-5 (Fast)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 20,
+				"cacheRead": 0.25,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"openai/gpt-5-mini": {
 			"id": "openai/gpt-5-mini",
 			"name": "GPT-5 Mini",
@@ -85560,6 +87152,31 @@
 				"mode": "budget",
 				"minLevel": "minimal",
 				"maxLevel": "high"
+			}
+		},
+		"openai/gpt-5-mini-fast": {
+			"id": "openai/gpt-5-mini-fast",
+			"name": "GPT-5 mini (Fast)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.44999999999999996,
+				"output": 3.5999999999999996,
+				"cacheRead": 0.045,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
 			}
 		},
 		"openai/gpt-5-nano": {
@@ -85737,6 +87354,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"openai/gpt-5.1-thinking-fast": {
+			"id": "openai/gpt-5.1-thinking-fast",
+			"name": "GPT 5.1 Thinking (Fast)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 20,
+				"cacheRead": 0.25,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"openai/gpt-5.2": {
 			"id": "openai/gpt-5.2",
 			"name": "GPT-5.2",
@@ -85812,6 +87454,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"openai/gpt-5.2-fast": {
+			"id": "openai/gpt-5.2-fast",
+			"name": "GPT 5.2 (Fast)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 3.5,
+				"output": 28,
+				"cacheRead": 0.35,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"openai/gpt-5.2-pro": {
 			"id": "openai/gpt-5.2-pro",
 			"name": "GPT-5.2 Pro",
@@ -85881,6 +87548,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"openai/gpt-5.3-codex-fast": {
+			"id": "openai/gpt-5.3-codex-fast",
+			"name": "GPT 5.3 OpenAI code (Fast)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 3.5,
+				"output": 28,
+				"cacheRead": 0.35,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"openai/gpt-5.4": {
 			"id": "openai/gpt-5.4",
 			"name": "GPT-5.4",
@@ -85906,6 +87598,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"openai/gpt-5.4-fast": {
+			"id": "openai/gpt-5.4-fast",
+			"name": "GPT 5.4 (Fast)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"openai/gpt-5.4-mini": {
 			"id": "openai/gpt-5.4-mini",
 			"name": "GPT-5.4 mini",
@@ -85928,6 +87645,31 @@
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "low",
+				"maxLevel": "xhigh"
+			}
+		},
+		"openai/gpt-5.4-mini-fast": {
+			"id": "openai/gpt-5.4-mini-fast",
+			"name": "GPT 5.4 Mini (Fast)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.5,
+				"output": 9,
+				"cacheRead": 0.15,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
 		},
@@ -86006,6 +87748,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"openai/gpt-5.5-fast": {
+			"id": "openai/gpt-5.5-fast",
+			"name": "GPT 5.5 (Fast)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 12.5,
+				"output": 75,
+				"cacheRead": 1.25,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"openai/gpt-5.5-pro": {
 			"id": "openai/gpt-5.5-pro",
 			"name": "GPT-5.5 Pro",
@@ -86056,6 +87823,31 @@
 				"maxLevel": "max"
 			}
 		},
+		"openai/gpt-5.6-luna-fast": {
+			"id": "openai/gpt-5.6-luna-fast",
+			"name": "GPT 5.6 Luna (Fast)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.39999999999999997,
+				"output": 2.4,
+				"cacheRead": 0.04,
+				"cacheWrite": 0.25
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"openai/gpt-5.6-sol": {
 			"id": "openai/gpt-5.6-sol",
 			"name": "GPT-5.6 Sol",
@@ -86068,10 +87860,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 5,
-				"output": 30,
-				"cacheRead": 0.5,
-				"cacheWrite": 6.25
+				"input": 2,
+				"output": 10,
+				"cacheRead": 0.19999999999999998,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -86079,6 +87871,31 @@
 				"mode": "budget",
 				"minLevel": "low",
 				"maxLevel": "max"
+			}
+		},
+		"openai/gpt-5.6-sol-fast": {
+			"id": "openai/gpt-5.6-sol-fast",
+			"name": "GPT 5.6 Sol (Fast)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 4,
+				"output": 20,
+				"cacheRead": 0.39999999999999997,
+				"cacheWrite": 2.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
 			}
 		},
 		"openai/gpt-5.6-terra": {
@@ -86104,6 +87921,31 @@
 				"mode": "budget",
 				"minLevel": "low",
 				"maxLevel": "max"
+			}
+		},
+		"openai/gpt-5.6-terra-fast": {
+			"id": "openai/gpt-5.6-terra-fast",
+			"name": "GPT 5.6 Terra (Fast)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 4,
+				"output": 24,
+				"cacheRead": 0.39999999999999997,
+				"cacheWrite": 2.5
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
 			}
 		},
 		"openai/gpt-oss-120b": {
@@ -86253,6 +88095,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"openai/o3-fast": {
+			"id": "openai/o3-fast",
+			"name": "o3 (Fast)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 3.5,
+				"output": 14,
+				"cacheRead": 0.875,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 100000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"openai/o3-mini": {
 			"id": "openai/o3-mini",
 			"name": "o3-mini",
@@ -86317,6 +88184,31 @@
 				"input": 1.1,
 				"output": 4.4,
 				"cacheRead": 0.275,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 100000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"openai/o4-mini-fast": {
+			"id": "openai/o4-mini-fast",
+			"name": "o4-mini (Fast)",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 8,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -86489,6 +88381,291 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"spacexai/grok-4.1-fast-non-reasoning": {
+			"id": "spacexai/grok-4.1-fast-non-reasoning",
+			"name": "Grok 4.1 Fast Non-Reasoning",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.19999999999999998,
+				"output": 0.5,
+				"cacheRead": 0.049999999999999996,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 1000000
+		},
+		"spacexai/grok-4.1-fast-reasoning": {
+			"id": "spacexai/grok-4.1-fast-reasoning",
+			"name": "Grok 4.1 Fast Reasoning",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.19999999999999998,
+				"output": 0.5,
+				"cacheRead": 0.049999999999999996,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 1000000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"spacexai/grok-4.20-multi-agent": {
+			"id": "spacexai/grok-4.20-multi-agent",
+			"name": "Grok 4.20 Multi-Agent",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 2.5,
+				"cacheRead": 0.19999999999999998,
+				"cacheWrite": 0
+			},
+			"contextWindow": 2000000,
+			"maxTokens": 2000000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"spacexai/grok-4.20-multi-agent-beta": {
+			"id": "spacexai/grok-4.20-multi-agent-beta",
+			"name": "Grok 4.20 Multi Agent Beta",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 2.5,
+				"cacheRead": 0.19999999999999998,
+				"cacheWrite": 0
+			},
+			"contextWindow": 2000000,
+			"maxTokens": 2000000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"spacexai/grok-4.20-non-reasoning": {
+			"id": "spacexai/grok-4.20-non-reasoning",
+			"name": "Grok 4.20 Non-Reasoning",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 2.5,
+				"cacheRead": 0.19999999999999998,
+				"cacheWrite": 0
+			},
+			"contextWindow": 2000000,
+			"maxTokens": 2000000
+		},
+		"spacexai/grok-4.20-non-reasoning-beta": {
+			"id": "spacexai/grok-4.20-non-reasoning-beta",
+			"name": "Grok 4.20 Beta Non-Reasoning",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 2.5,
+				"cacheRead": 0.19999999999999998,
+				"cacheWrite": 0
+			},
+			"contextWindow": 2000000,
+			"maxTokens": 2000000
+		},
+		"spacexai/grok-4.20-reasoning": {
+			"id": "spacexai/grok-4.20-reasoning",
+			"name": "Grok 4.20 Reasoning",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 2.5,
+				"cacheRead": 0.19999999999999998,
+				"cacheWrite": 0
+			},
+			"contextWindow": 2000000,
+			"maxTokens": 2000000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"spacexai/grok-4.20-reasoning-beta": {
+			"id": "spacexai/grok-4.20-reasoning-beta",
+			"name": "Grok 4.20 Beta Reasoning",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 2.5,
+				"cacheRead": 0.19999999999999998,
+				"cacheWrite": 0
+			},
+			"contextWindow": 2000000,
+			"maxTokens": 2000000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"spacexai/grok-4.3": {
+			"id": "spacexai/grok-4.3",
+			"name": "Grok 4.3",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 2.5,
+				"cacheRead": 0.19999999999999998,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 1000000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"spacexai/grok-4.5": {
+			"id": "spacexai/grok-4.5",
+			"name": "Grok 4.5",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.3,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"spacexai/grok-4.6": {
+			"id": "spacexai/grok-4.6",
+			"name": "Grok 4.6",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"spacexai/grok-build-0.1": {
+			"id": "spacexai/grok-build-0.1",
+			"name": "Grok Build 0.1",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 2,
+				"cacheRead": 0.19999999999999998,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 256000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"stepfun/step-3.5-flash": {
 			"id": "stepfun/step-3.5-flash",
 			"name": "Step 3.5 Flash",
@@ -86544,13 +88721,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.58,
-				"cacheRead": 0.035,
+				"input": 0.13199999999999998,
+				"output": 0.5279999999999999,
+				"cacheRead": 0.032999999999999995,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"contextWindow": 256000,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -87521,9 +89698,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.1,
-				"output": 3.851,
-				"cacheRead": 0.275,
+				"input": 0.7999999999999999,
+				"output": 2.5500000000000003,
+				"cacheRead": 0.16,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -87552,6 +89729,30 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"zai/glm-5.3": {
+			"id": "zai/glm-5.3",
+			"name": "GLM 5.3",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0.26,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 12800,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -43,7 +43,7 @@ import {
 import { normalizeSystemPrompts, sanitizeJsonStrings } from "../utils";
 import { createAbortSourceTracker } from "../utils/abort";
 import { AssistantMessageEventStream } from "../utils/event-stream";
-import { transportFailureFacts } from "../utils/fallback-transport";
+import { EMPTY_RESPONSE_PROVIDER_CODE, transportFailureFacts } from "../utils/fallback-transport";
 import { toFirepassWireModelId, toFireworksWireModelId } from "../utils/fireworks-model-id";
 import {
 	type CapturedHttpErrorResponse,
@@ -509,6 +509,19 @@ function getTrailingPartialDeepseekToken(text: string): string {
 
 const OPENAI_COMPLETIONS_FIRST_EVENT_TIMEOUT_MESSAGE =
 	"OpenAI completions stream timed out while waiting for the first event";
+const OPENAI_COMPLETIONS_EMPTY_RESPONSE_MESSAGE = "Provider returned an empty response with zero token usage";
+
+function isEmptyOpenAICompletionsResponse(output: AssistantMessage): boolean {
+	return (
+		output.stopReason === "stop" &&
+		output.content.length === 0 &&
+		output.usage.input === 0 &&
+		output.usage.output === 0 &&
+		output.usage.cacheRead === 0 &&
+		output.usage.cacheWrite === 0 &&
+		output.usage.totalTokens === 0
+	);
+}
 
 export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 	model: Model<"openai-completions">,
@@ -1060,9 +1073,21 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 			}
 
 			output.errorMessage = strictFallbackErrorMessage;
+			if (isEmptyOpenAICompletionsResponse(output)) {
+				output.stopReason = "error";
+				output.errorMessage = OPENAI_COMPLETIONS_EMPTY_RESPONSE_MESSAGE;
+				output.transportFailure = {
+					kind: "transport",
+					providerCode: EMPTY_RESPONSE_PROVIDER_CODE,
+				};
+			}
 			output.duration = Date.now() - startTime;
 			if (firstTokenTime) output.ttft = firstTokenTime - startTime;
-			stream.push({ type: "done", reason: output.stopReason, message: output });
+			if (output.stopReason === "error") {
+				stream.push({ type: "error", reason: "error", error: output });
+			} else {
+				stream.push({ type: "done", reason: output.stopReason, message: output });
+			}
 			stream.end();
 		} catch (error) {
 			for (const block of output.content) delete (block as any).index;

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -15,7 +15,7 @@ import {
 	mintProviderSafetyStop,
 	PROVIDER_SAFETY_STOP_ADAPTER_CAPABILITY,
 } from "../adapter-internals/provider-safety-stop";
-import { type Effort, getSupportedEfforts } from "../model-thinking";
+import { type Effort, getSupportedEfforts, isGroqCompoundReasoningUnsupported } from "../model-thinking";
 import { calculateCost } from "../models";
 import { getEnvApiKey } from "../stream";
 import {
@@ -511,8 +511,14 @@ const OPENAI_COMPLETIONS_FIRST_EVENT_TIMEOUT_MESSAGE =
 	"OpenAI completions stream timed out while waiting for the first event";
 const OPENAI_COMPLETIONS_EMPTY_RESPONSE_MESSAGE = "Provider returned an empty response with zero token usage";
 
-function isEmptyOpenAICompletionsResponse(output: AssistantMessage): boolean {
+function isEmptyOpenAICompletionsResponse(
+	output: AssistantMessage,
+	hasExplicitUsageReport: boolean,
+	hasNonzeroUsageEvidence: boolean,
+): boolean {
 	return (
+		hasExplicitUsageReport &&
+		!hasNonzeroUsageEvidence &&
 		output.stopReason === "stop" &&
 		output.content.length === 0 &&
 		output.usage.input === 0 &&
@@ -845,6 +851,20 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				for (const call of calls) emitHealedToolCall(call);
 			};
 			let providerSafetyStop = false;
+			let hasExplicitUsageReport = false;
+			let hasNonzeroUsageEvidence = false;
+			const applyUsage = (rawUsage: object): void => {
+				const usage = parseChunkUsage(rawUsage, model, premiumRequestsTotal);
+				const hasExplicitTotal = getOptionalNumberProperty(rawUsage, "total_tokens") !== undefined;
+				const hasExplicitComponents =
+					getOptionalNumberProperty(rawUsage, "prompt_tokens") !== undefined &&
+					getOptionalNumberProperty(rawUsage, "completion_tokens") !== undefined;
+				hasExplicitUsageReport ||= hasExplicitTotal || hasExplicitComponents;
+				hasNonzeroUsageEvidence ||= usage.totalTokens > 0;
+				if (usage.totalTokens >= output.usage.totalTokens) {
+					output.usage = usage;
+				}
+			};
 			const markProviderSafetyStop = (errorMessage?: string): void => {
 				providerSafetyStop = true;
 				output.stopReason = "error";
@@ -878,7 +898,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				output.responseId ||= chunk.id;
 
 				if (chunk.usage) {
-					output.usage = parseChunkUsage(chunk.usage, model, premiumRequestsTotal);
+					applyUsage(chunk.usage);
 				}
 
 				const choice = Array.isArray(chunk.choices) ? chunk.choices[0] : undefined;
@@ -887,7 +907,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				if (!chunk.usage) {
 					const choiceUsage = getChoiceUsage(choice);
 					if (choiceUsage) {
-						output.usage = parseChunkUsage(choiceUsage, model, premiumRequestsTotal);
+						applyUsage(choiceUsage);
 					}
 				}
 
@@ -1073,7 +1093,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 			}
 
 			output.errorMessage = strictFallbackErrorMessage;
-			if (isEmptyOpenAICompletionsResponse(output)) {
+			if (isEmptyOpenAICompletionsResponse(output, hasExplicitUsageReport, hasNonzeroUsageEvidence)) {
 				output.stopReason = "error";
 				output.errorMessage = OPENAI_COMPLETIONS_EMPTY_RESPONSE_MESSAGE;
 				output.transportFailure = {
@@ -1320,7 +1340,7 @@ function buildParams(
 	const compat = getCompat(model, resolvedBaseUrl);
 	const messages = convertMessages(model, context, compat);
 	maybeAddOpenRouterAnthropicCacheControl(model, messages);
-	const supportsReasoningParams = model.provider !== "github-copilot";
+	const supportsReasoningParams = model.provider !== "github-copilot" && !isGroqCompoundReasoningUnsupported(model);
 
 	// Kimi (including via OpenRouter and Fireworks router-form IDs such as
 	// `accounts/fireworks/routers/kimi-*`) calculates TPM rate limits based on
@@ -1580,12 +1600,14 @@ export function parseChunkUsage(
 	// `completion_tokens` (which is the total billed output). Adding them would
 	// double-count.
 	const outputTokens = getOptionalNumberProperty(rawUsage, "completion_tokens") ?? 0;
+	const reportedTotalTokens = getOptionalNumberProperty(rawUsage, "total_tokens") ?? 0;
+	const componentTotalTokens = input + outputTokens + cachedTokens + cacheWriteTokens;
 	const usage: AssistantMessage["usage"] = {
 		input,
 		output: outputTokens,
 		cacheRead: cachedTokens,
 		cacheWrite: cacheWriteTokens,
-		totalTokens: input + outputTokens + cachedTokens + cacheWriteTokens,
+		totalTokens: Math.max(componentTotalTokens, reportedTotalTokens),
 		...(reasoningTokens > 0 ? { reasoningTokens } : {}),
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		...(premiumRequests !== undefined ? { premiumRequests } : {}),

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -329,6 +329,53 @@ describe("generated model policies", () => {
 		});
 	});
 
+	it("pins Kilo Ox Alpha capabilities when generic discovery omits them", () => {
+		const models: Model<Api>[] = [
+			createModel({
+				id: "stealth/ox-alpha",
+				api: "openai-completions",
+				provider: "kilo",
+				reasoning: false,
+			}),
+		];
+		models[0]!.input = ["text"];
+		models[0]!.contextWindow = 222_222;
+		models[0]!.maxTokens = 8_888;
+
+		applyGeneratedModelPolicies(models);
+
+		expect(models[0]).toMatchObject({
+			reasoning: true,
+			input: ["text", "image"],
+			contextWindow: 1_048_576,
+			maxTokens: 131_072,
+			thinking: {
+				mode: "effort",
+				minLevel: Effort.Low,
+				maxLevel: Effort.Max,
+				defaultLevel: Effort.Max,
+				levels: [Effort.Low, Effort.High, Effort.Max],
+			},
+		});
+	});
+
+	it("removes unsupported reasoning controls only from Groq compound systems", () => {
+		const models = [
+			createModel({ id: "groq/compound", api: "openai-completions", provider: "groq" }),
+			createModel({ id: "groq/compound-mini", api: "openai-completions", provider: "groq" }),
+			createModel({ id: "groq/compound", api: "openai-completions", provider: "openrouter" }),
+		];
+
+		applyGeneratedModelPolicies(models);
+
+		expect(models[0]?.reasoning).toBe(false);
+		expect(models[0]?.thinking).toBeUndefined();
+		expect(models[1]?.reasoning).toBe(false);
+		expect(models[1]?.thinking).toBeUndefined();
+		expect(models[2]?.reasoning).toBe(true);
+		expect(models[2]?.thinking).toBeDefined();
+	});
+
 	it("maps only first-class MiniMax M3 routes to the official 1M context (issue #3896)", () => {
 		const models = [
 			createModel({ id: "MiniMax-M3", api: "anthropic-messages", provider: "minimax" }),

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import * as z from "zod/v4";
+import { Effort } from "../src/model-thinking";
 import { getBundledModel } from "../src/models";
 import { convertMessages, detectCompat, streamOpenAICompletions } from "../src/providers/openai-completions";
 import { resolveOpenAICompat } from "../src/providers/openai-completions-compat";
@@ -70,6 +71,20 @@ function createSuccessfulCompletionResponse(): Response {
 	]);
 }
 
+function createEmptyResponseModel(
+	cost: Model<"openai-completions">["cost"] = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+): Model<"openai-completions"> {
+	return {
+		...getBundledModel("openai", "gpt-4o-mini"),
+		api: "openai-completions",
+		provider: "kilo",
+		id: "stealth/ox-alpha",
+		name: "Ox Alpha",
+		baseUrl: "https://api.kilo.ai/api/gateway",
+		cost,
+	};
+}
+
 function baseContext(): Context {
 	return {
 		messages: [
@@ -83,6 +98,38 @@ function baseContext(): Context {
 }
 
 describe("openai-completions compatibility", () => {
+	it("never sends reasoning controls to Groq compound systems after late metadata overrides", async () => {
+		for (const id of ["groq/compound", "groq/compound-mini"] as const) {
+			const model: Model<"openai-completions"> = {
+				id,
+				name: id,
+				api: "openai-completions",
+				provider: "groq",
+				baseUrl: "https://api.groq.com/openai/v1",
+				reasoning: true,
+				thinking: { mode: "effort", minLevel: Effort.Low, maxLevel: Effort.High },
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 131_072,
+				maxTokens: 8_192,
+				compat: { supportsReasoningEffort: true },
+			};
+			const { promise, resolve } = Promise.withResolvers<Record<string, unknown>>();
+			streamOpenAICompletions(model, baseContext(), {
+				apiKey: "test-key",
+				reasoning: "high",
+				signal: createAbortedSignal(),
+				onPayload: payload => resolve(payload as Record<string, unknown>),
+			});
+
+			const payload = await promise;
+			expect(payload.reasoning_effort).toBeUndefined();
+			expect(payload.reasoning).toBeUndefined();
+			expect(payload.enable_thinking).toBeUndefined();
+			expect(payload.chat_template_kwargs).toBeUndefined();
+		}
+	});
+
 	it("serializes direct xAI Grok 4.5 and 4.6 reasoning efforts without changing other Grok routes", async () => {
 		async function captureXaiPayload(modelId: "grok-4.5" | "grok-4.6", reasoning: "low" | "xhigh") {
 			const model: Model<"openai-completions"> = {
@@ -431,7 +478,7 @@ describe("openai-completions compatibility", () => {
 	});
 
 	it("types an empty zero-usage completion as a retryable transport failure", async () => {
-		const model = getBundledModel("kilo", "stealth/ox-alpha") as Model<"openai-completions">;
+		const model = createEmptyResponseModel();
 		global.fetch = createMockFetch([
 			{
 				id: "chatcmpl-empty",
@@ -460,7 +507,7 @@ describe("openai-completions compatibility", () => {
 	});
 
 	it("leaves low nonzero empty completion usage untyped for overflow recovery", async () => {
-		const model = getBundledModel("kilo", "stealth/ox-alpha") as Model<"openai-completions">;
+		const model = createEmptyResponseModel({ input: 2, output: 4, cacheRead: 1, cacheWrite: 3 });
 		global.fetch = createMockFetch([
 			{
 				id: "chatcmpl-low-usage-empty",
@@ -481,9 +528,87 @@ describe("openai-completions compatibility", () => {
 		expect(result.stopReason).toBe("stop");
 		expect(result.content).toEqual([]);
 		expect(result.usage).toMatchObject({ input: 1, output: 1 });
+		expect(result.usage.cost).toEqual({
+			input: 0.000002,
+			output: 0.000004,
+			cacheRead: 0,
+			cacheWrite: 0,
+			total: 0.000006,
+		});
 		expect(result.transportFailure).toBeUndefined();
 		expect(events.filter(event => event.type === "error")).toHaveLength(0);
 		expect(events.filter(event => event.type === "done")).toHaveLength(1);
+	});
+
+	it("leaves empty completions without explicit usage on overflow recovery", async () => {
+		const model = createEmptyResponseModel();
+		global.fetch = createMockFetch([
+			{
+				id: "chatcmpl-usage-absent",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+			},
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(model, baseContext(), { apiKey: "test-key" }).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toEqual([]);
+		expect(result.usage.totalTokens).toBe(0);
+		expect(result.transportFailure).toBeUndefined();
+	});
+
+	it("preserves total-token-only evidence on empty completions", async () => {
+		const model = createEmptyResponseModel();
+		global.fetch = createMockFetch([
+			{
+				id: "chatcmpl-total-only",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+				usage: { total_tokens: 2 },
+			},
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(model, baseContext(), { apiKey: "test-key" }).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.usage.totalTokens).toBe(2);
+		expect(result.transportFailure).toBeUndefined();
+	});
+
+	it("does not let duplicate zero usage erase earlier nonzero evidence", async () => {
+		const model = createEmptyResponseModel();
+		global.fetch = createMockFetch([
+			{
+				id: "chatcmpl-nonzero-first",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [],
+				usage: { prompt_tokens: 1, completion_tokens: 1 },
+			},
+			{
+				id: "chatcmpl-zero-last",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+				usage: { prompt_tokens: 0, completion_tokens: 0 },
+			},
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(model, baseContext(), { apiKey: "test-key" }).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.usage).toMatchObject({ input: 1, output: 1, totalTokens: 2 });
+		expect(result.transportFailure).toBeUndefined();
 	});
 
 	it("maps qwen chat template reasoning into chat_template_kwargs", async () => {

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -3,7 +3,8 @@ import * as z from "zod/v4";
 import { getBundledModel } from "../src/models";
 import { convertMessages, detectCompat, streamOpenAICompletions } from "../src/providers/openai-completions";
 import { resolveOpenAICompat } from "../src/providers/openai-completions-compat";
-import type { AssistantMessage, Context, Model, OpenAICompat, Tool } from "../src/types";
+import type { AssistantMessage, AssistantMessageEvent, Context, Model, OpenAICompat, Tool } from "../src/types";
+import { EMPTY_RESPONSE_PROVIDER_CODE } from "../src/utils/fallback-transport";
 
 const originalFetch = global.fetch;
 
@@ -54,6 +55,19 @@ function createMockFetch(events: unknown[]): typeof fetch {
 	}
 
 	return Object.assign(mockFetch, { preconnect: originalFetch.preconnect });
+}
+
+function createSuccessfulCompletionResponse(): Response {
+	return createSseResponse([
+		{
+			id: "chatcmpl-success",
+			object: "chat.completion.chunk",
+			created: 0,
+			model: "gpt-4o-mini",
+			choices: [{ index: 0, delta: { content: "ok" }, finish_reason: "stop" }],
+		},
+		"[DONE]",
+	]);
 }
 
 function baseContext(): Context {
@@ -416,6 +430,62 @@ describe("openai-completions compatibility", () => {
 		expect(result.usage.totalTokens).toBe(15);
 	});
 
+	it("types an empty zero-usage completion as a retryable transport failure", async () => {
+		const model = getBundledModel("kilo", "stealth/ox-alpha") as Model<"openai-completions">;
+		global.fetch = createMockFetch([
+			{
+				id: "chatcmpl-empty",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+				usage: { prompt_tokens: 0, completion_tokens: 0 },
+			},
+			"[DONE]",
+		]);
+
+		const stream = streamOpenAICompletions(model, baseContext(), { apiKey: "test-key" });
+		const events: AssistantMessageEvent[] = [];
+		for await (const event of stream) events.push(event);
+		const result = await stream.result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("Provider returned an empty response with zero token usage");
+		expect(result.transportFailure).toEqual({
+			kind: "transport",
+			providerCode: EMPTY_RESPONSE_PROVIDER_CODE,
+		});
+		expect(events.filter(event => event.type === "error")).toHaveLength(1);
+		expect(events.filter(event => event.type === "done")).toHaveLength(0);
+	});
+
+	it("leaves low nonzero empty completion usage untyped for overflow recovery", async () => {
+		const model = getBundledModel("kilo", "stealth/ox-alpha") as Model<"openai-completions">;
+		global.fetch = createMockFetch([
+			{
+				id: "chatcmpl-low-usage-empty",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+				usage: { prompt_tokens: 1, completion_tokens: 1 },
+			},
+			"[DONE]",
+		]);
+
+		const stream = streamOpenAICompletions(model, baseContext(), { apiKey: "test-key" });
+		const events: AssistantMessageEvent[] = [];
+		for await (const event of stream) events.push(event);
+		const result = await stream.result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toEqual([]);
+		expect(result.usage).toMatchObject({ input: 1, output: 1 });
+		expect(result.transportFailure).toBeUndefined();
+		expect(events.filter(event => event.type === "error")).toHaveLength(0);
+		expect(events.filter(event => event.type === "done")).toHaveLength(1);
+	});
+
 	it("maps qwen chat template reasoning into chat_template_kwargs", async () => {
 		const model: Model<"openai-completions"> = {
 			...getBundledModel("openai", "gpt-4o-mini"),
@@ -578,7 +648,7 @@ describe("openai-completions compatibility", () => {
 				if (attempt === 1) {
 					return new Response("retry", { status: 500, headers: { "retry-after-ms": "0" } });
 				}
-				return createSseResponse(["[DONE]"]);
+				return createSuccessfulCompletionResponse();
 			},
 			{ preconnect: originalFetch.preconnect },
 		);
@@ -607,7 +677,7 @@ describe("openai-completions compatibility", () => {
 		const fetch = Object.assign(
 			async (input: string | URL | Request): Promise<Response> => {
 				requests.push(input instanceof Request ? input.url : String(input));
-				return createSseResponse(["[DONE]"]);
+				return createSuccessfulCompletionResponse();
 			},
 			{ preconnect: originalFetch.preconnect },
 		);
@@ -630,7 +700,7 @@ describe("openai-completions compatibility", () => {
 		const fetch = Object.assign(
 			async (input: string | URL | Request): Promise<Response> => {
 				requests.push(input instanceof Request ? input.url : String(input));
-				return createSseResponse(["[DONE]"]);
+				return createSuccessfulCompletionResponse();
 			},
 			{ preconnect: originalFetch.preconnect },
 		);

--- a/packages/ai/test/preset-catalog-models.test.ts
+++ b/packages/ai/test/preset-catalog-models.test.ts
@@ -8,6 +8,34 @@ function gemini37SiblingId(modelId: string): string {
 }
 
 describe("preset catalog model entries", () => {
+	test("bundles Kilo Ox Alpha with its reviewed capability contract", () => {
+		const model = getBundledModel("kilo", "stealth/ox-alpha");
+
+		expect(model.id).toBe("stealth/ox-alpha");
+		expect(model.provider).toBe("kilo");
+		expect(model.name).toBe("Ox Alpha");
+		expect(model.reasoning).toBe(true);
+		expect(model.input).toEqual(["text", "image"]);
+		expect(model.contextWindow).toBe(1_048_576);
+		expect(model.maxTokens).toBe(131_072);
+		expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+		expect(model.thinking).toEqual({
+			mode: "effort",
+			minLevel: Effort.Low,
+			maxLevel: Effort.Max,
+			defaultLevel: Effort.Max,
+			levels: [Effort.Low, Effort.High, Effort.Max],
+		});
+	});
+
+	test("keeps Groq compound systems reasoning-control free", () => {
+		for (const id of ["groq/compound", "groq/compound-mini"] as const) {
+			const model = getBundledModel("groq", id);
+			expect(model.reasoning).toBe(false);
+			expect(model.thinking).toBeUndefined();
+		}
+	});
+
 	test("bundles kimi-code/kimi-k2.7-code", () => {
 		const model = getBundledModel("kimi-code", "kimi-k2.7-code");
 


### PR DESCRIPTION
## Summary
- add Kilo `stealth/ox-alpha` with reviewed text/image, 1,048,576-context, 131,072-output, and low/high/max reasoning metadata
- recover explicitly zero-token empty OpenAI-compatible streams through the bounded retry path
- preserve absent, partial, low-nonzero, and earlier nonzero usage evidence for context-overflow recovery and accounting
- hard-disable unsupported reasoning controls for Groq compound systems at metadata and outbound request boundaries
- remove the unrelated live catalog regeneration churn from the original external head

## Adversarial review findings resolved
- generated catalog provenance/diff explosion: reduced from +2,799/-602 catalog lines to the single reviewed Kilo model entry
- Ox Alpha capability truth: pinned provider identity, reasoning, input, context, output, cost, and exact low/high/max/default-max ladder
- Groq exclusions: exact provider-and-ID boundary survives late model overrides and suppresses outbound reasoning controls
- empty stream semantics: requires explicit complete zero-usage wire evidence; absent/partial/nonzero evidence remains on overflow recovery
- duplicate usage/events: nonzero usage cannot be erased by a later duplicate zero frame; terminal stream emits exactly one error or done event
- retry/backoff/cancellation: existing bounded resilient retry policy remains authoritative; caller abort is checked before empty-response typing

## Verification
- `bun test packages/ai/test/openai-completions-compat.test.ts packages/ai/test/model-thinking.test.ts packages/ai/test/preset-catalog-models.test.ts packages/ai/test/generate-models.test.ts packages/ai/test/models-lazy.test.ts packages/ai/test/models-cost.test.ts packages/agent/test/agent-loop.test.ts` (146 pass)
- `bun test packages/coding-agent/test/agent-session-resilient-retry.test.ts packages/coding-agent/test/agent-session-fallback-attempt-transaction.test.ts packages/coding-agent/test/agent-session-context-promotion.test.ts` (100 pass)
- `bun scripts/run-bun-test-files.ts --root=packages/ai --timeout=30000 --file-timeout=300000 --concurrency=1` (284 files pass in fresh processes)
- `bun --cwd=packages/ai run check`
- `bun --cwd=packages/agent run check && bun --cwd=packages/agent run test` (840 pass)
- `bun --cwd=packages/coding-agent run check`
- `bun scripts/verify-gjc-state-writers.ts --fail --root .`
- `bun test scripts/ci-dev-affected.test.ts scripts/verify-pr-verdict.test.ts` (145 pass)
- CLI dogfood resolved `kilo/stealth/ox-alpha` and reached the expected credential boundary; no `KILO_API_KEY` is configured on this host, so live authenticated generation was not claimed

## Risk classification
- [ ] `low-risk`
- [x] `regression-risk`
- [ ] `high-risk`

## Exact-head verdict
gajae.pr-review-verdict.v1 merge-approved sha256:a46faaec367287d16b789b4ea00e484dc959192e655f31e081875b4c026c807f reviewer:human reviewer-id:Yeachan-Heo evidence:adversarial review resolved catalog provenance capability request-boundary usage-accounting retry and finalization findings; focused impacted and exact affected AI CI commands passed on head e9637c743ce1e0a66c81f0ebbc1629835aa5938f