### PR TITLE
fix(pet): detect iTerm2 capability over SSH

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Fixed
 
+- Gajae Pet now treats forwarded `LC_TERMINAL=iTerm2` and `TERM_PROGRAM=iTerm.app` values as probe hints over SSH, enabling iTerm2 only after an active OSC 1337 File-capability reply. Generic SSH, spoofed/noninteractive/CI environments, and unmanaged tmux/screen/zellij nesting remain on the text fallback; verified Kitty and Sixel keep precedence. (#4911)
+
 - Telegram polling no longer wedges behind a deleted private-chat `forum_topic_created` update. Definitive missing-topic `400` responses from the adoption picker now consume the stale update, remove only its matching pending-topic sidecar, and let the ordered poll offset advance; rate limits, network/server failures, authentication failures, and ambiguous responses remain retryable. (#4904)
 
 - `gjc --worktree` now runs the declared Bun, npm, or pnpm frozen install in workspace launch worktrees instead of linking the origin checkout's `node_modules`. Workspace imports and install mutations are bound to the worktree's own lockfile and checkout, including reuse of worktrees carrying the legacy source-tree link (#4620).

--- a/packages/coding-agent/src/modes/components/iterm-pet-transport.ts
+++ b/packages/coding-agent/src/modes/components/iterm-pet-transport.ts
@@ -120,12 +120,18 @@ export function isItermCandidate(
 	env: NodeJS.ProcessEnv = Bun.env,
 	tty = Boolean(process.stdin.isTTY && process.stdout.isTTY),
 ): boolean {
-	const v = env.TERM_PROGRAM_VERSION?.split(".").map(Number);
-	return env.TERM_PROGRAM === "iTerm.app" && tty && !!v && v[0] >= 3 && (v[0] > 3 || (v[1] ?? 0) >= 5);
+	if (!tty) return false;
+	const ci = env.CI?.trim().toLowerCase();
+	if (ci && ci !== "0" && ci !== "false") return false;
+	// These variables are untrusted hints, especially when forwarded over SSH.
+	// They may start the capability probe, but only an OSC 1337 reply containing
+	// the File capability can make the transport available.
+	return env.LC_TERMINAL === "iTerm2" || env.TERM_PROGRAM === "iTerm.app";
 }
 export function createNativePetTransport(o: {
 	ui: NativePetUi;
 	env?: NodeJS.ProcessEnv;
+	tty?: boolean;
 	topology?: () => Promise<PetTmuxTopology>;
 }): ItermPetTransport | undefined {
 	const env = o.env ?? Bun.env;
@@ -133,7 +139,7 @@ export function createNativePetTransport(o: {
 		env.GJC_TMUX_ACTIVE_SESSION?.trim() && env.TMUX_PANE?.trim() && env.GJC_MANAGED_OWNER_RUN_ID?.trim(),
 	);
 	if (isUnderTerminalMultiplexer(env) && !managed) return undefined;
-	if (!isItermCandidate(env, true)) return undefined;
+	if (!isItermCandidate(env, o.tty)) return undefined;
 	const clock: PetTransportClock = { now: Date.now, setTimeout, clearTimeout };
 	const input: PetTransportInput = {
 		drain: (a, b) => o.ui.drainPetProbeInput?.(a, b) ?? o.ui.drainInput(a, b),

--- a/packages/coding-agent/test/modes/components/iterm-pet-transport.test.ts
+++ b/packages/coding-agent/test/modes/components/iterm-pet-transport.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import {
 	consumeCapabilityInput,
+	createNativePetTransport,
 	ItermPetTransport,
+	isItermCandidate,
+	type NativePetUi,
 	type PetTransportClock,
 } from "@gajae-code/coding-agent/modes/components/iterm-pet-transport";
 
@@ -54,6 +57,46 @@ async function waitFor(predicate: () => boolean): Promise<void> {
 	}
 	throw new Error("condition did not become true within 200 microtasks");
 }
+
+const nativeUi = {
+	drainInput: async () => {},
+	addInputListener: () => () => {},
+	submitTerminalOutput: async () => ({ status: "written" }),
+	notifyTerminalLifecycle: async () => {},
+	terminalGeneration: 1,
+} satisfies NativePetUi;
+
+describe("iTerm Pet candidate detection", () => {
+	it.each([
+		["forwarded LC_TERMINAL", { SSH_CONNECTION: "client server", LC_TERMINAL: "iTerm2" }],
+		["forwarded TERM_PROGRAM", { SSH_TTY: "/dev/pts/1", TERM_PROGRAM: "iTerm.app" }],
+		["local iTerm2", { TERM_PROGRAM: "iTerm.app", TERM_PROGRAM_VERSION: "3.6.11" }],
+	] as const)("probes %s without treating the environment marker as proof", (_label, env) => {
+		expect(isItermCandidate(env, true)).toBe(true);
+		const transport = createNativePetTransport({ ui: nativeUi, env, tty: true });
+		expect(transport).toBeDefined();
+		expect(transport?.availability.available).toBe(false);
+		transport?.dispose();
+	});
+
+	it.each([
+		["generic SSH", { SSH_CONNECTION: "client server", TERM: "xterm-256color" }, true],
+		["spoofed noninteractive marker", { SSH_CONNECTION: "client server", LC_TERMINAL: "iTerm2" }, false],
+		["CI with a forwarded marker", { CI: "true", SSH_CONNECTION: "client server", LC_TERMINAL: "iTerm2" }, true],
+	] as const)("does not probe %s", (_label, env, tty) => {
+		expect(isItermCandidate(env, tty)).toBe(false);
+		expect(createNativePetTransport({ ui: nativeUi, env, tty })).toBeUndefined();
+	});
+
+	it.each([
+		["tmux", { TMUX: "/tmp/tmux-1/default,1,0" }],
+		["screen", { STY: "screen.1" }],
+		["zellij", { ZELLIJ: "1" }],
+	] as const)("blocks unverified iTerm graphics inside %s", (_label, nesting) => {
+		const env = { SSH_CONNECTION: "client server", LC_TERMINAL: "iTerm2", ...nesting };
+		expect(createNativePetTransport({ ui: nativeUi, env, tty: true })).toBeUndefined();
+	});
+});
 
 describe("managed iTerm Pet topology revocation", () => {
 	it.each([

--- a/packages/coding-agent/test/modes/components/pet-capability.test.ts
+++ b/packages/coding-agent/test/modes/components/pet-capability.test.ts
@@ -3,6 +3,7 @@ import {
 	getPetPixelProtocol,
 	getPetRenderProtocol,
 	PET_CAPABILITY_SETTLE_MS,
+	setVerifiedItermPetAvailability,
 	warnWhenPetCapabilitySettled,
 } from "@gajae-code/coding-agent/modes/components/pet-capability";
 import { ImageProtocol, setTerminalImageProtocol, TERMINAL } from "@gajae-code/tui";
@@ -34,6 +35,7 @@ function setForcedProtocol(protocol: "kitty" | "sixel", multiplexerEnv: Readonly
 }
 
 afterEach(() => {
+	setVerifiedItermPetAvailability(undefined);
 	setTerminalImageProtocol(originalProtocol);
 	for (const key of multiplexerEnvKeys) {
 		const value = originalMultiplexerEnv.get(key);
@@ -45,6 +47,31 @@ afterEach(() => {
 });
 
 describe("getPetPixelProtocol", () => {
+	it("requires an active iTerm capability reply instead of trusting direct or forwarded markers", () => {
+		setTerminalImageProtocol(ImageProtocol.Iterm2);
+
+		expect(getPetPixelProtocol()).toBeNull();
+		expect(getPetRenderProtocol()).toBe("text");
+
+		setVerifiedItermPetAvailability({ available: false, mode: "direct", reason: "probe-timeout", epoch: 1 });
+		expect(getPetPixelProtocol()).toBeNull();
+
+		setVerifiedItermPetAvailability({ available: true, mode: "direct", epoch: 2 });
+		expect(getPetPixelProtocol()).toBe("iterm");
+		expect(getPetRenderProtocol()).toBe("iterm");
+	});
+
+	it.each([
+		[ImageProtocol.Kitty, "kitty"],
+		[ImageProtocol.Sixel, "sixel"],
+	] as const)("keeps %s precedence over verified iTerm", (imageProtocol, expected) => {
+		for (const key of multiplexerEnvKeys) delete Bun.env[key];
+		setVerifiedItermPetAvailability({ available: true, mode: "direct", epoch: 1 });
+		setTerminalImageProtocol(imageProtocol);
+
+		expect(getPetPixelProtocol()).toBe(expected);
+	});
+
 	for (const [name, multiplexerEnv] of multiplexerCases) {
 		it(`uses text cells for forced Kitty inside ${name}`, () => {
 			setForcedProtocol("kitty", multiplexerEnv);


### PR DESCRIPTION
## What

Make iTerm2 pet transport discovery work over SSH without requiring manual environment exports, while requiring an actual iTerm2 capability probe before enabling image rendering.

## Why

Forwarded terminal markers are discovery hints, not proof that OSC 1337 image escapes reach the client. The transport now probes the capability and preserves safe fallback behavior.

## Testing

- Rebased exact-head adversarial review: 128 passed, 0 failed
- Coding-agent check passed with 12 unrelated existing warnings
- Changed-file Biome check passed

## Risk classification

- [ ] `low-risk`
- [x] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:bf3e75c4803edfaff80b01e646e77ca4a3f9ec8815e27028bea4377a2d0be88b reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head owner adversarial review approved at c37a36ac8c31aa7596ccb196d9637596918359e1
```

- [x] Target branch is `dev`
- [x] Tested locally
- [x] Exact-head verdict matches the reviewed commit
- [x] Independent maintainer approval exists