### PR TITLE
fix(pet): detect iTerm2 over SSH without manual env setup

### DIFF
--- a/packages/coding-agent/src/modes/components/iterm-pet-transport.ts
+++ b/packages/coding-agent/src/modes/components/iterm-pet-transport.ts
@@ -120,8 +120,13 @@ export function isItermCandidate(
 	env: NodeJS.ProcessEnv = Bun.env,
 	tty = Boolean(process.stdin.isTTY && process.stdout.isTTY),
 ): boolean {
+	if (!tty) return false;
+	// OpenSSH forwards TERM automatically, but TERM_PROGRAM is not normally
+	// forwarded. iTerm2's LC_TERMINAL marker is part of the locale environment
+	// and is forwarded by the standard LANG/LC_* SSH rules.
+	if (env.LC_TERMINAL === "iTerm2") return true;
 	const v = env.TERM_PROGRAM_VERSION?.split(".").map(Number);
-	return env.TERM_PROGRAM === "iTerm.app" && tty && !!v && v[0] >= 3 && (v[0] > 3 || (v[1] ?? 0) >= 5);
+	return env.TERM_PROGRAM === "iTerm.app" && !!v && v[0] >= 3 && (v[0] > 3 || (v[1] ?? 0) >= 5);
 }
 export function createNativePetTransport(o: {
 	ui: NativePetUi;

--- a/packages/coding-agent/test/modes/components/iterm-pet-transport.test.ts
+++ b/packages/coding-agent/test/modes/components/iterm-pet-transport.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
 	consumeCapabilityInput,
+	isItermCandidate,
 	ItermPetTransport,
 	type PetTransportClock,
 } from "@gajae-code/coding-agent/modes/components/iterm-pet-transport";
@@ -134,5 +135,17 @@ describe("capability input fragmentation", () => {
 		const consume = consumeCapabilityInput(data => captured.push(String(data)));
 		expect(consume("\x1b]1337;Capabilities=F\x07xy\x1b]1337;Capabilities=x\x07")?.data).toBe("xy");
 		expect(captured).toEqual(["\x1b]1337;Capabilities=F\x07", "\x1b]1337;Capabilities=x\x07"]);
+	});
+});
+
+
+describe("iTerm2 SSH candidate detection", () => {
+	it("accepts the forwarded LC_TERMINAL marker without manual TERM_PROGRAM forwarding", () => {
+		expect(isItermCandidate({ LC_TERMINAL: "iTerm2" }, true)).toBe(true);
+	});
+
+	it("still rejects non-iTerm2 terminals and non-TTY sessions", () => {
+		expect(isItermCandidate({ TERM: "xterm-256color" }, true)).toBe(false);
+		expect(isItermCandidate({ LC_TERMINAL: "iTerm2" }, false)).toBe(false);
 	});
 });


### PR DESCRIPTION
## What

Make iTerm2 pet transport detection work over SSH without requiring manual environment exports.

## Why

OpenSSH forwards `TERM` automatically and commonly forwards `LC_*`, but `TERM_PROGRAM` is not normally forwarded. The existing transport candidate check therefore missed iTerm2 sessions over SSH.

## Testing

- Added candidate detection coverage for `LC_TERMINAL=iTerm2`, generic terminals, and non-TTY sessions.
- Existing iTerm2 capability probing remains authoritative before rendering.

## Risk classification

- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:cbbac5b52344bad39e7fd81155b5b3c2a2486cb460fe6d342df12e25920c2dbb reviewer:human reviewer-id:thegreatesthoneybee evidence:CI and independent maintainer review required before merge
```

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (not needed for this internal bug fix)
- [x] Verdict above matches the exact PR head
- [x] Risk classification matches the review path