### PR TITLE
fix(tui): publish terminal completion before sidecar latency

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - Gajae Pet now treats forwarded `LC_TERMINAL=iTerm2` and `TERM_PROGRAM=iTerm.app` values as probe hints over SSH, enabling iTerm2 only after an active OSC 1337 File-capability reply. Generic SSH, spoofed/noninteractive/CI environments, and unmanaged tmux/screen/zellij nesting remain on the text fallback; verified Kitty and Sixel keep precedence. (#4911)
+- Interactive terminal completion now publishes the local `agent_end` boundary before waiting for the ordered coordinator sidecar write, so slow or lock-hostile WSL drvfs mounts cannot leave the foreground activity indicator and composer busy after a turn has completed. Coordinator persistence ordering and extension delivery remain unchanged. (#4741)
 
 - Telegram polling no longer wedges behind a deleted private-chat `forum_topic_created` update. Definitive missing-topic `400` responses from the adoption picker now consume the stale update, remove only its matching pending-topic sidecar, and let the ordered poll offset advance; rate limits, network/server failures, authentication failures, and ambiguous responses remain retryable. (#4904)
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3528,21 +3528,21 @@ export class AgentSession {
 		};
 		const publish = async () => {
 			// Worker integration is first-party lifecycle persistence, not an extension
-			// hook. Make it durable before publishing the terminal boundary while user
-			// extension delivery remains asynchronous.
+			// hook. Settle it before publishing the terminal boundary while user extension
+			// delivery and coordinator sidecar persistence remain asynchronous.
 			await this.#flushWorkerIntegrationForAgentEnd();
-			// Persist before notifying synchronous subscribers: a subscriber may start a
-			// successor prompt from agent_end, whose running state must serialize after
-			// this terminal boundary rather than be overwritten by it.
+			// Reserve persistence before notifying synchronous subscribers: a subscriber
+			// may start a successor prompt from agent_end, whose running state must
+			// serialize after this terminal boundary rather than be overwritten by it.
 			//
-			// Awaited, not fire-and-forget: this is the terminal boundary, and the write
-			// runs under the native identity-bound state-file lock. A detached write
-			// outlives the session that owns it — under `bun test --isolate` the pending
-			// unlink lands after the runtime has torn down the context it was scheduled in
-			// and segfaults the process, and in production it lets a settled session's
-			// last write race whatever reclaims its lock next.
-			await this.#queueCoordinatorRuntimeStatePersist(pending);
+			// Reserve the write before notifying subscribers so a successor still queues
+			// behind this terminal transition, but do not make the interactive terminal
+			// wait for the filesystem-backed lock/write to settle. On slow or lock-hostile
+			// mounts such as WSL drvfs, waiting here leaves the foreground activity loader
+			// and busy input state visible after the model has already finished.
+			const terminalPersistence = this.#queueCoordinatorRuntimeStatePersist(pending);
 			this.#emit(pending);
+			await terminalPersistence;
 			extensionDelivery = this.#queueExtensionEvent(
 				pending,
 				undefined,

--- a/packages/coding-agent/test/interactive-mode-background-activity.test.ts
+++ b/packages/coding-agent/test/interactive-mode-background-activity.test.ts
@@ -13,6 +13,7 @@ import { AuthStorage } from "@gajae-code/coding-agent/session/auth-storage";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
 import { Container, Loader } from "@gajae-code/tui";
 import { logger, TempDir } from "@gajae-code/utils";
+import { FileLockTestHooks } from "../src/config/file-lock";
 import { ExtensionUiController } from "../src/modes/controllers/extension-ui-controller";
 import { SelectorController } from "../src/modes/controllers/selector-controller";
 
@@ -92,6 +93,29 @@ describe("interactive background activity indicator", () => {
 
 		expect(mode.loadingAnimation).toBeUndefined();
 		expect(renderStatus(mode)).toBe("");
+	});
+
+	it("publishes terminal activity cleanup before a slow coordinator sidecar write", async () => {
+		mode.ensureLoadingAnimation();
+		const lockEntered = Promise.withResolvers<void>();
+		const releaseLock = Promise.withResolvers<void>();
+		let gated = true;
+		const previousHook = FileLockTestHooks.afterParentMkdir;
+		FileLockTestHooks.afterParentMkdir = async lockPath => {
+			if (!gated || !lockPath.endsWith("mutation.lock.lock")) return;
+			gated = false;
+			lockEntered.resolve();
+			await releaseLock.promise;
+		};
+
+		try {
+			session.agent.emitExternalEvent({ type: "agent_end", messages: [] });
+			await lockEntered.promise;
+			await waitFor(() => mode.loadingAnimation === undefined);
+		} finally {
+			releaseLock.resolve();
+			FileLockTestHooks.afterParentMkdir = previousHook;
+		}
 	});
 
 	it("retires stale foreground activity across maintenance stop boundaries", async () => {


### PR DESCRIPTION
## Summary

Fixes the reopened #4741 regression where a completed turn can leave the interactive composer in `Working…` / busy state when the coordinator runtime sidecar write is slow on a filesystem boundary such as WSL drvfs.

This is independent of merged #4750 and #4842:

- #4750 fixed stale-loader input consumption after `agent_end` had already reached the TUI.
- #4842 fixed stale `session.isStreaming` snapshots at the TUI terminal boundary.
- This change covers the earlier publication boundary: `AgentSession` previously awaited the filesystem-backed coordinator sidecar lock/write before emitting `agent_end`, so the TUI never received the terminal event while that write was delayed.

The ordered sidecar write is still reserved before local subscribers run, so successor lifecycle writes remain serialized. Only the local terminal notification is decoupled from filesystem latency; worker integration remains settled before `agent_end`, and extension delivery remains ordered after persistence.

## Reproduction boundary

Live WSL/DRVFS is unavailable in this Linux runner (`/mnt/c` is absent; the checkout reports `ext2/ext3`). The maintainer-owned deterministic simulation gates the coordinator transaction lock (`mutation.lock.lock`) while emitting `agent_end`. On the unfixed source, the foreground loader remains mounted until the gated write is released. With this fix, `agent_end` reaches the interactive controller and clears the foreground loader while the same ordered write remains blocked. This isolates filesystem-backed terminal publication latency from generic WSL/input handling and does not claim a live drvfs run.

The regression is in `packages/coding-agent/test/interactive-mode-background-activity.test.ts` and fails on the unfixed source before this commit, then passes with the fix. The test waits on the observable loader-clear condition while the coordinator lock remains held; it does not use a fixed sleep.

## Validation

- `bun test packages/coding-agent/test/interactive-mode-background-activity.test.ts` — 13 passed
- `bun test packages/coding-agent/test/interactive-*.test.ts packages/coding-agent/test/input-controller-*.test.ts` — 281 passed
- `bun test packages/coding-agent/test/agent-session-concurrent.test.ts packages/coding-agent/test/session-state-sidecar.test.ts` — 159 passed
- `bunx biome check` on changed files — passed
- `bun --cwd=packages/coding-agent run check` — passed with 12 pre-existing warnings
- `bun --cwd=packages/coding-agent run build` — passed

The broad `agent-session-*.test.ts` sweep earlier reached 933 passed / 20 skipped but exposed four unrelated failures/timeouts in `agent-session-openai-responses-replay.test.ts`; no issue-owned test failed. The focused suites above pass at this current head.

## Risk classification

- [ ] `low-risk`
- [x] `regression-risk`
- [ ] `high-risk`

## Exact-head receipt

- Base: `a99e42aab4eba33add0421a1564951ba727bd940`
- Head: `70d3e04c451a057dd68691430f1c81671418796e`
- Exact base-to-head diff digest: `sha256:57f4868dab615086b4bab11a15124f01ac1feb339bdd8bdc1cbb6d83ee68c859`
- Changed paths: `packages/coding-agent/CHANGELOG.md`, `packages/coding-agent/src/session/agent-session.ts`, `packages/coding-agent/test/interactive-mode-background-activity.test.ts`
- Live WSL/DRVFS: not available in this runner; bounded blocker is explicit above

gajae.pr-review-verdict.v1 merge-approved sha256:57f4868dab615086b4bab11a15124f01ac1feb339bdd8bdc1cbb6d83ee68c859 reviewer:human reviewer-id:snowykr evidence:https://github.com/Yeachan-Heo/gajae-code/pull/4915#pullrequestreview-5006831761

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*