### PR TITLE
fix(ai/openai-completions): retry transient finish_reason=network_error stream failures

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Direct model selections now retry zero-token empty OpenAI-compatible responses.
+- OpenAI-compatible chat streams now replay an exact `finish_reason: "network_error"` only when no text, reasoning, refusal, or tool-call delta has been exposed. Retries honor `streamMaxRetries`, exponential backoff, caller cancellation, and managed-fallback ownership; failed-attempt usage, cost, response IDs, and partial chunks are discarded while terminal error wording remains compatible (#4918).
 
 - Cursor `requestContext` rules now forward normalized system prompts, Cursor HTTP/2 transport honors standard proxy environment variables, and GPT effort siblings are sent as their base model with the corresponding reasoning parameter.
 - `AuthStorage.getEarliestUnblockAt(provider)` now exposes the earliest stored credential `blockedUntil` instant so quota exhaustion can report when a row becomes usable again without waiting for it (#4908).

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1,3 +1,4 @@
+import { scheduler } from "node:timers/promises";
 import { $credentialEnv, $env, extractHttpStatusFromError, logger } from "@gajae-code/utils";
 import OpenAI, { APIConnectionTimeoutError } from "openai";
 import type {
@@ -515,6 +516,26 @@ function getTrailingPartialDeepseekToken(text: string): string {
 const OPENAI_COMPLETIONS_FIRST_EVENT_TIMEOUT_MESSAGE =
 	"OpenAI completions stream timed out while waiting for the first event";
 const OPENAI_COMPLETIONS_EMPTY_RESPONSE_MESSAGE = "Provider returned an empty response with zero token usage";
+const OPENAI_COMPLETIONS_NETWORK_ERROR_RETRY_MAX_RETRIES = 3;
+const OPENAI_COMPLETIONS_NETWORK_ERROR_RETRY_BASE_DELAY_MS = 2000;
+
+function hasReplayUnsafeOpenAICompletionsDelta(chunk: ChatCompletionChunk): boolean {
+	const choice = Array.isArray(chunk.choices) ? chunk.choices[0] : undefined;
+	const delta = choice?.delta;
+	if (!delta) return false;
+	if (typeof delta.refusal === "string" && delta.refusal.length > 0) return true;
+	if (normalizeStreamingContentText(delta.content).length > 0) return true;
+	if (Array.isArray(delta.tool_calls) && delta.tool_calls.length > 0) return true;
+	return ["reasoning_content", "reasoning", "reasoning_text"].some(field => {
+		const value = (delta as Record<string, unknown>)[field];
+		return typeof value === "string" && value.length > 0;
+	});
+}
+
+function hasNetworkErrorFinishReason(chunk: ChatCompletionChunk): boolean {
+	const choice = Array.isArray(chunk.choices) ? chunk.choices[0] : undefined;
+	return (choice?.finish_reason as string | null | undefined) === "network_error";
+}
 
 function isEmptyOpenAICompletionsResponse(
 	output: AssistantMessage,
@@ -678,6 +699,63 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				output.usage.premiumRequests = premiumRequestsTotal;
 			}
 			stream.push({ type: "start", partial: output });
+			const iterateAttempt = (attemptStream: AsyncIterable<ChatCompletionChunk>) =>
+				iterateWithIdleTimeout(attemptStream, {
+					firstItemTimeoutMs: firstEventTimeoutMs,
+					firstItemErrorMessage: OPENAI_COMPLETIONS_FIRST_EVENT_TIMEOUT_MESSAGE,
+					idleTimeoutMs,
+					errorMessage: "OpenAI completions stream stalled while waiting for the next event",
+					onIdle: () => requestAbortController.abort(),
+					onFirstItemTimeout: () => requestAbortController.abort(),
+					abortSignal: options?.signal,
+					isProgressItem: isOpenAICompletionsProgressChunk,
+				});
+			const iterateWithNetworkErrorRetry = async function* (): AsyncGenerator<ChatCompletionChunk> {
+				let attemptStream = openaiStream;
+				let retryAttempt = 0;
+				while (true) {
+					const replaySafeChunks: ChatCompletionChunk[] = [];
+					let replayUnsafe = false;
+					let retryNetworkError = false;
+					for await (const chunk of iterateAttempt(attemptStream)) {
+						if (!replayUnsafe && hasReplayUnsafeOpenAICompletionsDelta(chunk)) {
+							replayUnsafe = true;
+							for (const bufferedChunk of replaySafeChunks) yield bufferedChunk;
+							replaySafeChunks.length = 0;
+						}
+						if (replayUnsafe) {
+							yield chunk;
+							continue;
+						}
+						replaySafeChunks.push(chunk);
+						if (hasNetworkErrorFinishReason(chunk) && !options?.fallbackManaged) {
+							retryNetworkError = true;
+							break;
+						}
+					}
+
+					if (
+						!retryNetworkError ||
+						abortTracker.wasCallerAbort() ||
+						retryAttempt >=
+							resolveRetryBudget(options?.streamMaxRetries, OPENAI_COMPLETIONS_NETWORK_ERROR_RETRY_MAX_RETRIES)
+					) {
+						for (const bufferedChunk of replaySafeChunks) yield bufferedChunk;
+						return;
+					}
+
+					retryAttempt += 1;
+					const delayMs = OPENAI_COMPLETIONS_NETWORK_ERROR_RETRY_BASE_DELAY_MS * 2 ** (retryAttempt - 1);
+					if (options?.providerRetryWait) {
+						await options.providerRetryWait(delayMs, options.signal);
+					} else {
+						await scheduler.wait(delayMs, { signal: options?.signal });
+					}
+					if (abortTracker.wasCallerAbort()) throw new Error("Request was aborted");
+					attemptStream = await createCompletionsStream();
+					streamConnected = true;
+				}
+			};
 
 			const parseMiniMaxThinkTags = model.provider === "minimax-code" || model.provider === "minimax-code-cn";
 			// Some OpenAI-compatible DeepSeek hosts (including NVIDIA NIM and DeepSeek's
@@ -886,16 +964,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				if (errorMessage) output.errorMessage = errorMessage;
 			};
 
-			for await (const chunk of iterateWithIdleTimeout(openaiStream, {
-				firstItemTimeoutMs: firstEventTimeoutMs,
-				firstItemErrorMessage: OPENAI_COMPLETIONS_FIRST_EVENT_TIMEOUT_MESSAGE,
-				idleTimeoutMs,
-				errorMessage: "OpenAI completions stream stalled while waiting for the next event",
-				onIdle: () => requestAbortController.abort(),
-				onFirstItemTimeout: () => requestAbortController.abort(),
-				abortSignal: options?.signal,
-				isProgressItem: isOpenAICompletionsProgressChunk,
-			})) {
+			for await (const chunk of iterateWithNetworkErrorRetry()) {
 				if (!chunk || typeof chunk !== "object") continue;
 
 				// OpenAI documents ChatCompletionChunk.id as the unique chat completion identifier,
@@ -2152,7 +2221,6 @@ function shouldRetryWithoutStrictTools(
 		.join("\n");
 	return /wrong_api_format|mixed values for 'strict'|tool[s]?\b.*strict|\bstrict\b.*tool/i.test(messageParts);
 }
-
 function mapStopReason(reason: ChatCompletionChunk.Choice["finish_reason"] | string): {
 	stopReason: StopReason;
 	errorMessage?: string;

--- a/packages/ai/test/openai-completions-network-error-retry.test.ts
+++ b/packages/ai/test/openai-completions-network-error-retry.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "bun:test";
+import { getBundledModel } from "../src/models";
+import { streamOpenAICompletions } from "../src/providers/openai-completions";
+import type { AssistantMessageEvent, Context, FetchImpl, Model } from "../src/types";
+
+const model = getBundledModel("openai", "gpt-4o-mini") as Model<"openai-completions">;
+const context: Context = {
+	messages: [{ role: "user", content: "hello", timestamp: 1 }],
+};
+
+function chunk(
+	finishReason: string | null,
+	delta: Record<string, unknown> = {},
+	usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number },
+): Record<string, unknown> {
+	return {
+		id: `chatcmpl-${finishReason ?? "delta"}`,
+		object: "chat.completion.chunk",
+		created: 1,
+		model: model.id,
+		choices: [{ index: 0, delta, finish_reason: finishReason }],
+		...(usage ? { usage } : {}),
+	};
+}
+
+function sse(events: Array<Record<string, unknown> | "[DONE]">): Response {
+	return new Response(
+		`${events.map(event => `data: ${typeof event === "string" ? event : JSON.stringify(event)}`).join("\n\n")}\n\n`,
+		{
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		},
+	);
+}
+
+function sequenceFetch(
+	attempts: Array<Array<Record<string, unknown> | "[DONE]">>,
+	calls: { count: number },
+): FetchImpl {
+	const fetchImpl = async (): Promise<Response> => {
+		const events = attempts[calls.count];
+		calls.count += 1;
+		if (!events) throw new Error("Unexpected extra request");
+		return sse(events);
+	};
+	return Object.assign(fetchImpl, { preconnect: fetch.preconnect });
+}
+
+async function drainEvents(options: Parameters<typeof streamOpenAICompletions>[2]): Promise<{
+	events: AssistantMessageEvent[];
+	result: Awaited<ReturnType<ReturnType<typeof streamOpenAICompletions>["result"]>>;
+}> {
+	const stream = streamOpenAICompletions(model, context, options);
+	const events: AssistantMessageEvent[] = [];
+	for await (const event of stream) events.push(event);
+	return { events, result: await stream.result() };
+}
+
+describe("OpenAI completions finish_reason=network_error replay", () => {
+	it("retries a replay-safe first chunk and publishes only the successful attempt", async () => {
+		const calls = { count: 0 };
+		const waits: number[] = [];
+		const { events, result } = await drainEvents({
+			apiKey: "test-key",
+			requestMaxRetries: 0,
+			streamMaxRetries: 2,
+			providerRetryWait: async delayMs => {
+				waits.push(delayMs);
+			},
+			fetch: sequenceFetch(
+				[
+					[chunk("network_error", {}, { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 }), "[DONE]"],
+					[
+						chunk(null, { role: "assistant", content: "ok" }),
+						chunk("stop", {}, { prompt_tokens: 2, completion_tokens: 1, total_tokens: 3 }),
+						"[DONE]",
+					],
+				],
+				calls,
+			),
+		});
+
+		expect(calls.count).toBe(2);
+		expect(waits).toEqual([2000]);
+		expect(events.filter(event => event.type === "start")).toHaveLength(1);
+		expect(
+			events.filter(event => event.type === "text_delta").map(event => event.type === "text_delta" && event.delta),
+		).toEqual(["ok"]);
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toEqual([{ type: "text", text: "ok" }]);
+		expect(result.usage.input).toBe(2);
+		expect(result.usage.output).toBe(1);
+		expect(result.usage.totalTokens).toBe(3);
+		expect(result.usage.cost.input).toBeCloseTo((model.cost.input / 1_000_000) * 2);
+		expect(result.usage.cost.output).toBeCloseTo(model.cost.output / 1_000_000);
+		expect(result.responseId).toBe("chatcmpl-delta");
+	});
+
+	it("does not retry after visible text has been emitted", async () => {
+		const calls = { count: 0 };
+		const { events, result } = await drainEvents({
+			apiKey: "test-key",
+			requestMaxRetries: 0,
+			streamMaxRetries: 3,
+			providerRetryWait: async () => {
+				throw new Error("retry wait must not run");
+			},
+			fetch: sequenceFetch([[chunk(null, { content: "partial" }), chunk("network_error"), "[DONE]"]], calls),
+		});
+
+		expect(calls.count).toBe(1);
+		expect(events.some(event => event.type === "text_delta")).toBe(true);
+		expect(result.stopReason).toBe("error");
+		expect(result.content).toEqual([{ type: "text", text: "partial" }]);
+		expect(result.errorMessage).toContain("Provider finish_reason: network_error");
+	});
+
+	it("does not retry after a tool-call delta has been emitted", async () => {
+		const calls = { count: 0 };
+		const { result } = await drainEvents({
+			apiKey: "test-key",
+			requestMaxRetries: 0,
+			streamMaxRetries: 3,
+			providerRetryWait: async () => {
+				throw new Error("retry wait must not run");
+			},
+			fetch: sequenceFetch(
+				[
+					[
+						chunk(null, {
+							tool_calls: [
+								{ index: 0, id: "call-1", type: "function", function: { name: "read", arguments: "{" } },
+							],
+						}),
+						chunk("network_error"),
+						"[DONE]",
+					],
+				],
+				calls,
+			),
+		});
+
+		expect(calls.count).toBe(1);
+		expect(result.stopReason).toBe("error");
+		expect(result.content[0]).toMatchObject({ type: "toolCall", id: "call-1", name: "read" });
+	});
+
+	it("stops after the configured retry budget is exhausted", async () => {
+		const calls = { count: 0 };
+		const waits: number[] = [];
+		const failure = [chunk("network_error"), "[DONE]"] as Array<Record<string, unknown> | "[DONE]">;
+		const { result } = await drainEvents({
+			apiKey: "test-key",
+			requestMaxRetries: 0,
+			streamMaxRetries: 2,
+			providerRetryWait: async delayMs => {
+				waits.push(delayMs);
+			},
+			fetch: sequenceFetch([failure, failure, failure], calls),
+		});
+
+		expect(calls.count).toBe(3);
+		expect(waits).toEqual([2000, 4000]);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("Provider finish_reason: network_error");
+	});
+
+	it("honors caller cancellation during retry backoff", async () => {
+		const calls = { count: 0 };
+		const controller = new AbortController();
+		const { result } = await drainEvents({
+			apiKey: "test-key",
+			requestMaxRetries: 0,
+			streamMaxRetries: 3,
+			signal: controller.signal,
+			providerRetryWait: async (_delayMs, signal) => {
+				expect(signal).toBe(controller.signal);
+				controller.abort();
+			},
+			fetch: sequenceFetch([[chunk("network_error"), "[DONE]"]], calls),
+		});
+
+		expect(calls.count).toBe(1);
+		expect(result.stopReason).toBe("aborted");
+		expect(result.errorMessage).toContain("Request was aborted");
+	});
+
+	it("leaves replay and exact error reporting to managed fallback", async () => {
+		const calls = { count: 0 };
+		const { result } = await drainEvents({
+			apiKey: "test-key",
+			requestMaxRetries: 0,
+			streamMaxRetries: 3,
+			fallbackManaged: true,
+			providerRetryWait: async () => {
+				throw new Error("retry wait must not run");
+			},
+			fetch: sequenceFetch([[chunk("network_error"), "[DONE]"]], calls),
+		});
+
+		expect(calls.count).toBe(1);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("Provider finish_reason: network_error");
+	});
+
+	it("does not broaden retry classification to provider-specific finish reason variants", async () => {
+		const calls = { count: 0 };
+		const { result } = await drainEvents({
+			apiKey: "test-key",
+			requestMaxRetries: 0,
+			streamMaxRetries: 3,
+			providerRetryWait: async () => {
+				throw new Error("retry wait must not run");
+			},
+			fetch: sequenceFetch([[chunk("network-error"), "[DONE]"]], calls),
+		});
+
+		expect(calls.count).toBe(1);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("Provider finish_reason: network-error");
+	});
+});


### PR DESCRIPTION
## What

Retry an exact OpenAI-compatible `finish_reason: "network_error"` only while the attempt remains replay-safe. Pre-output chunks are buffered and discarded on retry, so failed-attempt response IDs, usage, and cost never reach the result. Retries honor `streamMaxRetries`, 2-second exponential backoff, cancellation, and managed-fallback ownership.

## Why

The original patch caught only request-setup failures, so it never observed a streamed finish reason. Its `firstTokenTime` guard was also unsafe for tool calls, the shared transient matcher was broader than this provider contract, the new branch was not bounded by `streamMaxRetries`, and it changed the existing terminal error text.

## Testing

- `bun test packages/ai/test/openai-completions-network-error-retry.test.ts` — 7 pass
- OpenAI completions regression set — 45 pass
- `bun --cwd=packages/ai run check` — pass (2 pre-existing informational lint notices)

Deterministic cases cover first-chunk network error then success, text/tool-call no-retry boundaries, retry exhaustion and backoff, cancellation, managed fallback, exact provider-variation matching, and usage/cost isolation.

Rebased from contributor head `8b887701f6d471755e7dc4773f2199331683d53b` onto `dev@83c7df05701951c5a997fdaed3d4a6d6d45cc312`. Reviewed head: `a1c6a97f30ea166f4060a3432b2e13e66033f6ed`.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:4b737533b4d35b212e2a0e3dabb86c8d6c6d75338f69f0e24ced334a0221e429 reviewer:human reviewer-id:Yeachan-Heo evidence:bun test packages/ai/test/openai-completions-network-error-retry.test.ts and openai-completions regression set; packages/ai check
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken