### PR TITLE
fix(ai): bound unknown Ollama Cloud output limits

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Ollama Cloud discovery now keeps curated output limits authoritative and gives unknown models a bounded 32,000-token fallback capped by their discovered context window. This replaces the truncation-prone 8,192 fallback without treating the server context length as a verified 131,072-token output capability or sending unbounded `num_predict` requests (#4921).
+- Ollama Cloud discovery now keeps curated output limits authoritative and gives unknown models a bounded 32,000-token fallback capped by their discovered context window. This replaces the truncation-prone 8,192 fallback without treating the server context length as a verified 131,072-token output capability or sending unbounded `num_predict` requests. Hosted cold starts and long prefills also receive a 300-second first-event window while explicit timeout overrides keep precedence (#4921).
 - Direct model selections now retry zero-token empty OpenAI-compatible responses.
 - OpenAI-compatible chat streams now replay an exact `finish_reason: "network_error"` only when no text, reasoning, refusal, or tool-call delta has been exposed. Retries honor `streamMaxRetries`, exponential backoff, caller cancellation, and managed-fallback ownership; failed-attempt usage, cost, response IDs, and partial chunks are discarded while terminal error wording remains compatible (#4918).
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Ollama Cloud discovery now keeps curated output limits authoritative and gives unknown models a bounded 32,000-token fallback capped by their discovered context window. This replaces the truncation-prone 8,192 fallback without treating the server context length as a verified 131,072-token output capability or sending unbounded `num_predict` requests (#4921).
 - Direct model selections now retry zero-token empty OpenAI-compatible responses.
 - OpenAI-compatible chat streams now replay an exact `finish_reason: "network_error"` only when no text, reasoning, refusal, or tool-call delta has been exposed. Retries honor `streamMaxRetries`, exponential backoff, caller cancellation, and managed-fallback ownership; failed-attempt usage, cost, response IDs, and partial chunks are discarded while terminal error wording remains compatible (#4918).
 

--- a/packages/ai/src/provider-models/ollama.ts
+++ b/packages/ai/src/provider-models/ollama.ts
@@ -21,12 +21,11 @@ type OllamaShowResponse = {
 
 const OLLAMA_RETRY_DELAYS_MS = [2_000, 5_000, 10_000];
 
-// Ollama Cloud serves large hosted frontier models and its API exposes no per-model
-// output cap (/api/show reports context_length only). The previous 8192 fallback made
-// discovery report a tiny num_predict, so long generations were truncated server-side
-// (stop reason "length"), stalling agent loops mid-task. 128K matches the largest
-// max_output values already used by bundled reference catalogs.
-const OLLAMA_CLOUD_DEFAULT_MAX_TOKENS = 131_072;
+// /api/show exposes the context window, not a verified output ceiling. Keep curated
+// output limits authoritative; unknown cloud models use the same bounded default that
+// streamSimple would request for a model with a larger known limit. This avoids the old
+// 8192-token truncation without advertising or requesting an unverified 131K output.
+const OLLAMA_CLOUD_UNKNOWN_MAX_TOKENS = 32_000;
 
 function trimTrailingSlash(value: string): string {
 	return value.endsWith("/") ? value.slice(0, -1) : value;
@@ -148,7 +147,7 @@ export function ollamaCloudModelManagerOptions(
 						input,
 						cost: reference?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 						contextWindow,
-						maxTokens: reference?.maxTokens ?? Math.min(contextWindow, OLLAMA_CLOUD_DEFAULT_MAX_TOKENS),
+						maxTokens: reference?.maxTokens ?? Math.min(contextWindow, OLLAMA_CLOUD_UNKNOWN_MAX_TOKENS),
 					};
 				}),
 			);

--- a/packages/ai/src/provider-models/ollama.ts
+++ b/packages/ai/src/provider-models/ollama.ts
@@ -21,6 +21,13 @@ type OllamaShowResponse = {
 
 const OLLAMA_RETRY_DELAYS_MS = [2_000, 5_000, 10_000];
 
+// Ollama Cloud serves large hosted frontier models and its API exposes no per-model
+// output cap (/api/show reports context_length only). The previous 8192 fallback made
+// discovery report a tiny num_predict, so long generations were truncated server-side
+// (stop reason "length"), stalling agent loops mid-task. 128K matches the largest
+// max_output values already used by bundled reference catalogs.
+const OLLAMA_CLOUD_DEFAULT_MAX_TOKENS = 131_072;
+
 function trimTrailingSlash(value: string): string {
 	return value.endsWith("/") ? value.slice(0, -1) : value;
 }
@@ -141,7 +148,7 @@ export function ollamaCloudModelManagerOptions(
 						input,
 						cost: reference?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 						contextWindow,
-						maxTokens: reference?.maxTokens ?? Math.min(contextWindow, 8192),
+						maxTokens: reference?.maxTokens ?? Math.min(contextWindow, OLLAMA_CLOUD_DEFAULT_MAX_TOKENS),
 					};
 				}),
 			);

--- a/packages/ai/src/utils/idle-iterator.ts
+++ b/packages/ai/src/utils/idle-iterator.ts
@@ -5,6 +5,10 @@ const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 120_000;
 const DEFAULT_STREAM_FIRST_EVENT_TIMEOUT_MS = 100_000;
 const ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS = 600_000;
 const KIMI_CODE_FIRST_EVENT_TIMEOUT_MS = 300_000;
+// Ollama Cloud is a hosted proxy where queueing/cold-start plus long prefill
+// (thinking-mode requests over 1M-context sessions) routinely exceeds 120s before
+// the first streamed token; 300s matches kimi-code's floor for long-reasoning silence.
+const OLLAMA_CLOUD_FIRST_EVENT_TIMEOUT_MS = 300_000;
 
 const ANTHROPIC_STREAM_IDLE_TIMEOUT_MS = 300_000;
 
@@ -30,6 +34,7 @@ export function isGrokModelId(modelId: string | undefined): boolean {
 
 export function getProviderFirstEventTimeoutFallbackMs(provider: string): number | undefined {
 	if (provider === "alibaba-token-plan") return ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS;
+	if (provider === "ollama-cloud") return OLLAMA_CLOUD_FIRST_EVENT_TIMEOUT_MS;
 	return provider === "kimi-code" ? KIMI_CODE_FIRST_EVENT_TIMEOUT_MS : undefined;
 }
 

--- a/packages/ai/test/ollama-cloud-provider.test.ts
+++ b/packages/ai/test/ollama-cloud-provider.test.ts
@@ -105,6 +105,7 @@ describe("ollama-cloud provider support", () => {
 		expect(gpt?.baseUrl).toBe("https://ollama.com");
 		expect(gpt?.reasoning).toBe(true);
 		expect(gpt?.contextWindow).toBe(262144);
+		expect(gpt?.maxTokens).toBe(16384);
 		expect(gpt?.input).toEqual(["text", "image"]);
 		expect(qwen?.name).toBe("Qwen 3 32B");
 		expect(qwen?.input).toEqual(["text", "image"]);
@@ -112,6 +113,78 @@ describe("ollama-cloud provider support", () => {
 			"https://ollama.com/api/tags",
 			expect.objectContaining({ method: "GET" }),
 		);
+	});
+
+	test("bounds unknown model output limits by the discovered context window", async () => {
+		global.fetch = vi.fn(async (input, init) => {
+			const url = String(input);
+			if (url === "https://ollama.com/api/tags") {
+				return new Response(JSON.stringify({ models: [{ name: "unknown-large" }, { name: "unknown-small" }] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			if (url === "https://ollama.com/api/show") {
+				const body = JSON.parse(String(init?.body ?? "{}")) as { model?: string };
+				const contextLength = body.model === "unknown-small" ? 4096 : 1_048_576;
+				return new Response(JSON.stringify({ model_info: { "test.context_length": contextLength } }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		}) as unknown as typeof fetch;
+
+		const options = ollamaCloudModelManagerOptions({ apiKey: "cloud-test-key" });
+		const models = await options.fetchDynamicModels?.();
+
+		expect(models?.find(model => model.id === "unknown-large")).toMatchObject({
+			contextWindow: 1_048_576,
+			maxTokens: 32_000,
+		});
+		expect(models?.find(model => model.id === "unknown-small")).toMatchObject({
+			contextWindow: 4096,
+			maxTokens: 4096,
+		});
+	});
+
+	test("uses the bounded discovered limit for default requests and preserves explicit maxTokens", async () => {
+		const requestBodies: Array<Record<string, unknown>> = [];
+		global.fetch = vi.fn(async (input, init) => {
+			const url = String(input);
+			if (url === "https://ollama.com/api/tags") {
+				return new Response(JSON.stringify({ models: [{ name: "unknown-large" }] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			if (url === "https://ollama.com/api/show") {
+				return new Response(JSON.stringify({ model_info: { "test.context_length": 1_048_576 } }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			if (url === "https://ollama.com/api/chat") {
+				requestBodies.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+				return createNdjsonResponse([
+					{ model: "unknown-large", message: { role: "assistant", content: "ok" }, done: false },
+					{ model: "unknown-large", done: true, done_reason: "stop", prompt_eval_count: 1, eval_count: 1 },
+				]);
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		}) as unknown as typeof fetch;
+
+		const options = ollamaCloudModelManagerOptions({ apiKey: "cloud-test-key" });
+		const models = await options.fetchDynamicModels?.();
+		const model = models?.find(candidate => candidate.id === "unknown-large");
+		expect(model).toBeDefined();
+		if (!model) throw new Error("unknown-large was not discovered");
+
+		const context = { messages: [{ role: "user" as const, content: "hi", timestamp: Date.now() }] };
+		await streamSimple(model, context, { apiKey: "cloud-test-key" }).result();
+		await streamSimple(model, context, { apiKey: "cloud-test-key", maxTokens: 12_345 }).result();
+
+		expect(requestBodies.map(body => body.options)).toEqual([{ num_predict: 32_000 }, { num_predict: 12_345 }]);
 	});
 
 	test("tolerates individual /api/show failures during model discovery", async () => {

--- a/packages/ai/test/stream-timeout-defaults.test.ts
+++ b/packages/ai/test/stream-timeout-defaults.test.ts
@@ -69,6 +69,10 @@ describe("getProviderFirstEventTimeoutFallbackMs(provider)", () => {
 		expect(getProviderFirstEventTimeoutFallbackMs("kimi-code")).toBe(300_000);
 	});
 
+	it("gives Ollama Cloud a 300-second first-event window for hosted cold starts", () => {
+		expect(getProviderFirstEventTimeoutFallbackMs("ollama-cloud")).toBe(300_000);
+	});
+
 	it("does not widen unrelated providers", () => {
 		expect(getProviderFirstEventTimeoutFallbackMs("anthropic")).toBeUndefined();
 	});


### PR DESCRIPTION
## What

- Keep curated Ollama Cloud output limits authoritative.
- Use a bounded 32,000-token fallback for unknown cloud models.
- Cap unknown-model output by discovered small context windows.
- Preserve explicit request `maxTokens` as Ollama `num_predict`.
- Give hosted Ollama Cloud cold starts and long prefills a tested 300-second first-event window while preserving explicit overrides.

## Why

Ollama `/api/show` exposes context capacity, not a verified output ceiling. The old 8,192 fallback truncated long agent turns, but a universal 131,072 fallback would overstate unknown model capability and permit excessive latency, resource use, context reservation, and client-side buffering. The bounded policy raises the practical request ceiling without conflating server context with output capability.

## Testing

- `bun test packages/ai/test/ollama-cloud-provider.test.ts packages/ai/test/ollama-provider.test.ts packages/ai/test/ollama-tool-choice.test.ts packages/ai/test/ollama-truncated-toolcall.test.ts packages/ai/test/ollama-escaped-nonascii-toolcall.test.ts packages/ai/test/stream-timeout-defaults.test.ts` (72 pass)
- `bun --cwd=packages/ai run check` (passes; two pre-existing informational Biome diagnostics in `openai-codex-responses.ts`)

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:d545744f20c974436a457df78f41b44c93e7694e093fb07f017e7d4270c9ec27 reviewer:human reviewer-id:Yeachan-Heo evidence:bun test packages/ai/test/ollama-cloud-provider.test.ts packages/ai/test/ollama-provider.test.ts packages/ai/test/ollama-tool-choice.test.ts packages/ai/test/ollama-truncated-toolcall.test.ts packages/ai/test/ollama-escaped-nonascii-toolcall.test.ts packages/ai/test/stream-timeout-defaults.test.ts; bun --cwd=packages/ai run check
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
