### PR TITLE
fix(ask): reject escaped durable display fields

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 
+- `ask` question wording and option labels no longer use the post-resample U+2014 display-text exemption because accepted calls enter durable session history and deep-interview rounds; genuinely display-only tool fields retain the existing exemption (#4926).
 - Gajae Pet now treats forwarded `LC_TERMINAL=iTerm2` and `TERM_PROGRAM=iTerm.app` values as probe hints over SSH, enabling iTerm2 only after an active OSC 1337 File-capability reply. Generic SSH, spoofed/noninteractive/CI environments, and unmanaged tmux/screen/zellij nesting remain on the text fallback; verified Kitty and Sixel keep precedence. (#4911)
 - Interactive terminal completion now publishes the local `agent_end` boundary before waiting for the ordered coordinator sidecar write, so slow or lock-hostile WSL drvfs mounts cannot leave the foreground activity indicator and composer busy after a turn has completed. Coordinator persistence ordering and extension delivery remain unchanged. (#4741)
 

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -734,15 +734,6 @@ export class AskTool implements AgentTool<AskParametersSchema, AskToolDetails> {
 		recoverRoundZeroIntentContract(arguments_, this.session.getDeepInterviewAskStage?.());
 	readonly strict = true;
 	readonly loadMode = "discoverable";
-	/**
-	 * The only ask argument fields rendered to the user as display text: the
-	 * question wording and the option labels. Everything else — ids,
-	 * deep-interview metadata (intent contracts/reviews, references), workflow
-	 * gate metadata — is structured or durable and stays subject to the
-	 * fail-closed escaped-non-ASCII rejection even after the resample budget.
-	 */
-	readonly displaySafeEscapedArgFields = ["questions.question", "questions.options.label"] as const;
-
 	constructor(private readonly session: ToolSession) {
 		this.description = prompt.render(askDescription);
 	}

--- a/packages/coding-agent/test/tools/ask-escaped-durability.test.ts
+++ b/packages/coding-agent/test/tools/ask-escaped-durability.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { agentLoop } from "@gajae-code/agent-core/agent-loop";
+import type { AgentContext, AgentLoopConfig, AgentMessage, AgentToolContext } from "@gajae-code/agent-core/types";
+import type { Message } from "@gajae-code/ai";
+import { createMockModel } from "@gajae-code/ai/providers/mock";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import { readDeepInterviewStateCompact } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-recorder";
+import { deepInterviewStatePath } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-runtime";
+import { readWorkflowStateJson } from "@gajae-code/coding-agent/gjc-runtime/state-runtime";
+import type { ToolSession } from "@gajae-code/coding-agent/tools";
+import { AskTool } from "@gajae-code/coding-agent/tools/ask";
+import { TempDir } from "@gajae-code/utils";
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(
+		message => message.role === "user" || message.role === "assistant" || message.role === "toolResult",
+	) as Message[];
+}
+
+function createSession(cwd: string, sessionId: string): ToolSession {
+	return {
+		cwd,
+		hasUI: true,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		getSessionId: () => sessionId,
+		getDeepInterviewAskStage: () => "post-topology",
+		settings: Settings.isolated(),
+	};
+}
+
+function literalDeepInterviewArguments() {
+	return {
+		questions: [
+			{
+				id: "q-durable",
+				question: "Should sessions persist?",
+				options: [{ label: "Persist state" }, { label: "Display only" }],
+				deepInterview: {
+					round: 2,
+					component: "session-state",
+					dimension: "durability",
+					ambiguity: 0.25,
+				},
+			},
+		],
+	};
+}
+
+function answerFirstOptionContext(): AgentToolContext {
+	return {
+		hasUI: true,
+		ui: {
+			select: async (_prompt: string, options: string[]) => options[0],
+			editor: async () => undefined,
+		},
+		abort: () => {},
+	} as unknown as AgentToolContext;
+}
+
+function escapedDeepInterviewTurn(id: string, surface: "question" | "option") {
+	return {
+		content: [
+			{
+				type: "toolCall" as const,
+				id,
+				name: "ask",
+				arguments: {
+					questions: [
+						{
+							id: "q-durable",
+							question: surface === "question" ? "Should sessions — persist?" : "Should sessions persist?",
+							options: [
+								{ label: surface === "option" ? "Persist — state" : "Persist state" },
+								{ label: "Display only" },
+							],
+							deepInterview: {
+								round: 2,
+								component: "session-state",
+								dimension: "durability",
+								ambiguity: 0.25,
+							},
+						},
+					],
+				},
+				escapedNonAsciiArguments: true,
+			},
+		],
+	};
+}
+
+describe("AskTool escaped deep-interview durability (#4926)", () => {
+	let tempDir: TempDir | undefined;
+
+	afterEach(() => {
+		tempDir?.removeSync();
+	});
+
+	it("resamples terminally and leaves persistence, reload, and spec input clean", async () => {
+		tempDir = TempDir.createSync("@gjc-ask-escaped-durability-4926-");
+		for (const surface of ["question", "option"] as const) {
+			const cwd = `${tempDir.path()}/${surface}`;
+			const sessionId = `ask-escaped-${surface}`;
+			const tool = new AskTool(createSession(cwd, sessionId));
+			const literalResult = await tool.execute(
+				"literal-control",
+				literalDeepInterviewArguments(),
+				undefined,
+				undefined,
+				answerFirstOptionContext(),
+			);
+			expect(literalResult.details?.selectedOptions).toEqual(["Persist state"]);
+
+			const statePath = deepInterviewStatePath(cwd, sessionId);
+			expect(await Bun.file(statePath).exists()).toBe(true);
+			const persistedControl = await readWorkflowStateJson(cwd, "deep-interview", sessionId);
+			const persistedControlText = JSON.stringify(persistedControl);
+			expect(persistedControlText).toContain("Should sessions persist?");
+			expect(persistedControlText).toContain("Persist state");
+
+			const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+			const mock = createMockModel({
+				responses: [
+					escapedDeepInterviewTurn("tc-1", surface),
+					escapedDeepInterviewTurn("tc-2", surface),
+					escapedDeepInterviewTurn("tc-3", surface),
+					{ content: ["done"] },
+				],
+			});
+			const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+			const toolResults: Array<{ isError?: boolean; text: string }> = [];
+			const userMessage = { role: "user" as const, content: "Ask the durability question", timestamp: 1 };
+
+			const stream = agentLoop([userMessage], context, config, undefined, mock.stream);
+			for await (const event of stream) {
+				if (event.type === "tool_execution_end") {
+					const first = event.result.content?.[0];
+					toolResults.push({ isError: event.isError, text: first?.type === "text" ? first.text : "" });
+				}
+			}
+
+			expect(mock.calls).toHaveLength(4);
+			expect(toolResults).toHaveLength(1);
+			expect(toolResults[0].isError).toBe(true);
+			expect(toolResults[0].text).toContain("\\uXXXX");
+
+			const compact = await readDeepInterviewStateCompact(statePath);
+			expect(compact.pending_shells).toHaveLength(1);
+			expect(compact.recent_scored_rounds).toEqual([]);
+			expect(compact.pending_shells[0]?.question_text).toBe("Should sessions persist?");
+			expect(compact.pending_shells[0]?.selected_options).toEqual(["Persist state"]);
+
+			const specInput = await readWorkflowStateJson(cwd, "deep-interview", sessionId);
+			expect(specInput).toEqual(persistedControl);
+			expect(JSON.stringify(specInput)).not.toContain("Should sessions — persist?");
+			expect(JSON.stringify(specInput)).not.toContain("Persist — state");
+		}
+	});
+});


### PR DESCRIPTION
## What

Remove `AskTool`'s post-resample display-safe escaped-field opt-in. Add real-`AskTool` regressions for escaped question text and option labels across terminal rejection, accepted persistence control, reload, and downstream workflow/spec input.

## Why

Accepted Ask question text and option labels enter durable session history and deep-interview round state, violating the exemption contract that opted-in fields are never persisted. Sanitizing parsed text cannot recover raw-wire provenance. Fixes #4926.

## Testing

- `bun test packages/agent/test/agent-loop-escaped-nonascii-toolcall.test.ts packages/coding-agent/test/tools/ask-escaped-durability.test.ts packages/coding-agent/test/tools/ask.test.ts packages/coding-agent/test/gjc-runtime/deep-interview-recorder.test.ts packages/coding-agent/test/gjc-runtime/deep-interview-runtime.test.ts` — 180 pass, 0 fail, 866 assertions
- `bun --cwd=packages/agent run check` — pass
- `bun --cwd=packages/coding-agent run check` — pass with 13 pre-existing Biome warnings outside this change
- `bunx biome check packages/coding-agent/src/tools/ask.ts packages/coding-agent/test/tools/ask-escaped-durability.test.ts` — pass
- signed exact head `134a9403b1407ae2069f04896009b90488feb4fa`, GOOD EDDSA signature key `04D7A66ECE3B8013B060B8148817F4143F84F5E7`

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:7429e0d62015cae474f153385f15b2a5d910652b3adca202782cacbfa9fc5499 reviewer:human reviewer-id:Yeachan-Heo evidence:local-180-tests-signed-head-adversarial-fix
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

<!-- exact-head-ci-refresh: 134a9403b1407ae2069f04896009b90488feb4fa -->