### PR TITLE
fix(autorouting): classify Ox Alpha as uncurated

### DIFF
--- a/packages/coding-agent/src/config/autorouting-tier-map.ts
+++ b/packages/coding-agent/src/config/autorouting-tier-map.ts
@@ -335,6 +335,7 @@ export const TIER_MAP_SKIP_LIST = {
 	"kilo/qwen/qwen3.8-max": { rationale: "post-rebase catalog addition from dev; not yet curated" },
 	"kilo/sakana/fugu-ultra": { rationale: "post-rebase catalog addition from dev; not yet curated" },
 	"kilo/sakana/sakana-namazu": { rationale: "post-rebase catalog addition from dev; not yet curated" },
+	"kilo/stealth/ox-alpha": { rationale: "newly pinned preview model; latency and quality rank are not yet curated" },
 	"kilo/tencent/hy3:free": { rationale: "post-rebase catalog addition from dev; not yet curated" },
 	"kilo/thinkingmachines/inkling-small": { rationale: "post-rebase catalog addition from dev; not yet curated" },
 	"kilo/upstage/solar-pro4": { rationale: "post-rebase catalog addition from dev; not yet curated" },


### PR DESCRIPTION
## What

Classify `kilo/stealth/ox-alpha` in the autorouting tier-map skip inventory.

## Why

The reviewed Ox Alpha catalog pin landed on `dev` without a tier-map disposition, so the repository root check fails with `Offending provider/model-id keys: kilo/stealth/ox-alpha`. This preview model has no reviewed latency or quality rank; an explicit skip is safer than guessing a tier.

## Testing

- `bun packages/coding-agent/scripts/check-autorouting-tier-map.ts`
- `bun test packages/coding-agent/test/autorouting-tier-map-gate.test.ts packages/coding-agent/test/autorouting-tier-map.test.ts` — 13 passed

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:07cc62f6abd8ee7867a6a047dc09d8c3ca68438172da9823a8e8d894d775e9be reviewer:human reviewer-id:Yeachan-Heo evidence:autorouting tier-map gate and 13 focused tests
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (not user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
