### PR TITLE
perf(tui): scope activity loader repaints to layout

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Foreground activity animation now uses layout-only TUI repaints, avoiding repeated reconstruction of unchanged transcript content during long sessions.
+
 ## [0.15.2] - 2026-08-25
 
 ### Changed

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1864,7 +1864,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				workingMessage => renderWorkingMessage(workingMessage, this.#getWorkingMessageAccent()),
 				message,
 				getSymbolTheme().spinnerFrames,
-				{ timeDependentColor: true },
+				{ timeDependentColor: true, renderScope: "layout" },
 			);
 			this.statusContainer.addChild(this.loadingAnimation);
 		}

--- a/packages/coding-agent/test/interactive-mode-background-activity.test.ts
+++ b/packages/coding-agent/test/interactive-mode-background-activity.test.ts
@@ -83,6 +83,21 @@ describe("interactive background activity indicator", () => {
 		expect(resolveActivityIndicatorMessage(true, 2, "Working…")).toBe("Working… · 2 background tasks");
 	});
 
+	it("uses layout-only repaints for the foreground activity indicator", () => {
+		const layoutRender = vi.spyOn(mode.ui, "requestLayoutRender");
+		const fullRender = vi.spyOn(mode.ui, "requestRender");
+		try {
+			mode.ensureLoadingAnimation();
+
+			expect(layoutRender).toHaveBeenCalledWith("loader");
+			expect(fullRender.mock.calls.some(([, source]) => source === "loader")).toBe(false);
+		} finally {
+			mode.stopLoadingAnimation({ foregroundSettled: true });
+			layoutRender.mockRestore();
+			fullRender.mockRestore();
+		}
+	});
+
 	it("retires the foreground indicator when agent_end races stale streaming state", async () => {
 		mode.ensureLoadingAnimation();
 		Object.defineProperty(session, "isStreaming", { configurable: true, get: () => true });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Loader instances can opt into layout-only repaint requests so transient status animation does not force unchanged transcript subtree reconstruction.
+
 ## [0.15.2] - 2026-08-25
 
 ### Changed

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -17,6 +17,8 @@ const SPINNER_ADVANCE_MS = 80;
  */
 export interface LoaderOptions {
 	timeDependentColor?: boolean;
+	/** Request a layout-only repaint when the loader is outside the transcript anchor. */
+	renderScope?: "full" | "layout";
 }
 
 const SMOOTH_ANIMATION_MS = 16;
@@ -115,6 +117,7 @@ export class Loader extends Text {
 		this.#lastDisplayed = next;
 		this.setText(next);
 		__loaderPerfCounters.renderRequests += 1;
-		this.#ui?.requestRender(false, "loader");
+		if (this.options.renderScope === "layout") this.#ui?.requestLayoutRender("loader");
+		else this.#ui?.requestRender(false, "loader");
 	}
 }

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1172,6 +1172,7 @@ export class TUI extends Container {
 	}
 
 	#visibleWidthForDifferentialGuard(line: string): number {
+		if (line.length === 0) return 0;
 		const cached = this.#lineEmitWidthCache.get(line);
 		if (cached !== undefined) return cached;
 		TUI.#renderCounters.differentialGuardVisibleWidthCalls += 1;

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -1,9 +1,18 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import { TUI } from "@gajae-code/tui";
+import { Container, Text, TUI } from "@gajae-code/tui";
 import { __loaderPerfCounters, Loader } from "@gajae-code/tui/components/loader";
 import { visibleWidth } from "@gajae-code/tui/utils";
 import { __animationSchedulerTestHooks } from "../src/animation-scheduler";
 import { VirtualTerminal } from "./virtual-terminal";
+
+class CountingTranscript extends Container {
+	renderCount = 0;
+
+	override renderWithViewportAnchors(width: number) {
+		this.renderCount += 1;
+		return super.renderWithViewportAnchors(width);
+	}
+}
 
 const TERMINAL_TRANSPORT_ENV_KEYS = [
 	"SSH_CONNECTION",
@@ -125,6 +134,79 @@ describe("Loader component", () => {
 
 		loader.stop();
 		tui.stop();
+	});
+
+	it("routes layout-scoped updates through requestLayoutRender", () => {
+		const term = new VirtualTerminal(40, 4);
+		const tui = new TUI(term);
+		let fullRequests = 0;
+		let layoutRequests = 0;
+		const realRequestRender = tui.requestRender.bind(tui);
+		const realRequestLayoutRender = tui.requestLayoutRender.bind(tui);
+		tui.requestRender = ((force?: boolean, source?: string) => {
+			if (source === "loader") fullRequests += 1;
+			return realRequestRender(force, source);
+		}) as typeof tui.requestRender;
+		tui.requestLayoutRender = ((source?: string) => {
+			if (source === "loader") layoutRequests += 1;
+			return realRequestLayoutRender(source);
+		}) as typeof tui.requestLayoutRender;
+
+		const loader = new Loader(
+			tui,
+			text => text,
+			text => text,
+			"Working",
+			["|"],
+			{
+				renderScope: "layout",
+			},
+		);
+		expect(fullRequests).toBe(0);
+		expect(layoutRequests).toBe(1);
+
+		loader.setMessage("Still working");
+		expect(fullRequests).toBe(0);
+		expect(layoutRequests).toBe(2);
+
+		loader.stop();
+		tui.stop();
+	});
+
+	it("reuses an unchanged anchored transcript for a layout-scoped Loader update", async () => {
+		const term = new VirtualTerminal(80, 12);
+		const tui = new TUI(term, undefined, { widthSettleMs: 0 });
+		const transcript = new CountingTranscript();
+		for (let index = 0; index < 2_000; index++) transcript.addChild(new Text(`transcript-${index}`, 0, 0));
+		const status = new Container();
+		const loader = new Loader(
+			tui,
+			text => text,
+			text => text,
+			"Working",
+			["|"],
+			{ renderScope: "layout" },
+		);
+		status.addChild(loader);
+		tui.addChild(transcript);
+		tui.addChild(status);
+		tui.setViewportAnchorComponent(transcript);
+		tui.setViewportOutputSource({ identity: "session:test", revision: 0n });
+
+		try {
+			tui.start();
+			await term.waitForRender();
+			expect(transcript.renderCount).toBe(1);
+
+			loader.setMessage("Still working");
+			await term.waitForRender();
+
+			expect(transcript.renderCount).toBe(1);
+			expect(term.getViewport().join("\n")).toContain("Still working");
+		} finally {
+			loader.stop();
+			tui.stop();
+		}
 	});
 
 	it("still requests a render when a time-dependent colorizer changes the composed text", () => {

--- a/packages/tui/test/render-helper-counts.test.ts
+++ b/packages/tui/test/render-helper-counts.test.ts
@@ -105,4 +105,25 @@ describe("TUI render helper counters", () => {
 			tui.stop();
 		}
 	});
+
+	it("treats empty differential rows as zero-width without measuring them", async () => {
+		const term = new VirtualTerminal(12, 8);
+		const component = new MutableLinesComponent(["before", "", ""]);
+		const tui = new TUI(term);
+		tui.addChild(component);
+
+		try {
+			tui.start();
+			await settle(term);
+			TUI.resetRenderCountersForTest();
+
+			component.setLines(["after", "", ""]);
+			tui.requestRender(true, "empty-row-width-test");
+			await settle(term);
+
+			expect(TUI.getRenderCountersForTest().differentialGuardVisibleWidthCalls).toBe(0);
+		} finally {
+			tui.stop();
+		}
+	});
 });


### PR DESCRIPTION
## What

Add an opt-in layout-only repaint scope to `Loader` and use it only for the foreground activity indicator. The existing default remains a full repaint, so loaders mounted in transcript content retain conservative invalidation.

## Why

On Darwin arm64 source builds of `gjc/0.15.2`, resuming a large session while the foreground activity line shimmered could make input visibly buffer. Local dogfooding on this PR's source-linked CLI confirms that this change removes the observed freeze.

The causal path is now bounded more precisely:

1. `InteractiveMode.syncActivityIndicator()` mounts its Loader in `statusContainer`, a sibling *outside* the `ircSplitView` viewport-anchor subtree.
2. Its message uses `shimmerText()` / `shimmerSegments()`, which derives ANSI output from `Date.now()`. `timeDependentColor: true` therefore produces changed Loader text on the direct-local 16 ms animation bucket.
3. Before this change every changed frame called `requestRender("loader")`. That sets TUI render scope to `full`, conservatively re-entering the unchanged anchored `ircSplitView` and all of its transcript children.
4. The existing #4451 cache can reuse that subtree only for `requestLayoutRender()`, when the anchor component revision, output-source identity/revision, and width are unchanged. A status-only frame satisfies those invariants.
5. A concurrent ordinary/full request always wins over a pending layout request; transcript mutations therefore continue to bypass the cache.

The first focused 2,000-row fixture measured 20 changed Loader frames as follows on the local Apple M3 Pro:

| Scope | Anchored transcript renders | Mean frame time | p95 | `renderTree` total |
| --- | ---: | ---: | ---: | ---: |
| full | 20 | 12.17 ms | 25.58 ms | 77.09 ms |
| layout | 0 additional | 6.13 ms | 7.19 ms | 2.50 ms |

The layout path still performs the virtual viewport's raw-prefix equality scan (1,954 off-screen rows in this fixture) and normalizes the 48-row visible window. It does **not** claim to solve every transcript-scale cost. It removes the demonstrated avoidable subtree reconstruction that dogfooding identified as sufficient to stop the freeze.

Related work:

- [#4451](https://github.com/Yeachan-Heo/gajae-code/pull/4451) introduced the revision-checked layout cache. This PR supplies the missing safe caller; it is not a duplicate.
- [#257](https://github.com/Yeachan-Heo/gajae-code/pull/257) suppresses unchanged static Loader output. Shimmer produces changed text, so that suppression does not apply.
- [#4741](https://github.com/Yeachan-Heo/gajae-code/issues/4741) and [#4915](https://github.com/Yeachan-Heo/gajae-code/pull/4915) address lifecycle/completion wedges rather than this repaint path.

## Testing

Final-head local validation on Darwin arm64:

- `bun --cwd=packages/tui run check` — passed
- `bun --cwd=packages/coding-agent run check:types` — passed
- `bun test packages/tui/test/loader.test.ts packages/tui/test/animation-scheduler.test.ts packages/tui/test/render-regressions.test.ts packages/tui/test/revisioned-subtree-render-cache.test.ts packages/tui/test/viewport-virtualization.test.ts packages/tui/test/viewport-virtualization-redteam.test.ts` — 148 passed
- `bun test packages/coding-agent/test/interactive-mode-background-activity.test.ts packages/coding-agent/test/interactive-*.test.ts packages/coding-agent/test/input-controller-*.test.ts` — 282 passed

The Loader regression now proves the end-to-end cache boundary: a changed layout-scoped Loader updates the visible status line while a 2,000-row anchored transcript's `renderWithViewportAnchors()` count stays at one. The default Loader remains full-scoped and the TUI coalescer upgrades any frame containing an ordinary request to full scope.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; this is not the solo self-approval path.
- [x] `regression-risk` — the change crosses the shared TUI render-invalidation boundary and needs independent exact-head review.
- [ ] `high-risk` — large refactor, feature, or materially high-risk change.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:6d4ebab9ac0b3508f5c530c4bc2a3c1aa68758c18db698571f33fc7dc1fdfabc reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head-832ee0deb-approved-review-5020628807-admin-distinct-from-author-ci-rerun
```

---

- [x] Target branch is `dev`
- [x] Tested locally
- [x] CHANGELOG updated
- [x] Verdict matches the exact PR head, not an earlier commit
- [ ] `bun check` passes
- [ ] CI passes on the final head commit
- [x] Risk classification above matches the actual review path taken



