### PR TITLE
feat(ui-language): add Japanese to the supported ui.language surface

### DIFF
--- a/docs/ui-language.md
+++ b/docs/ui-language.md
@@ -1,6 +1,6 @@
 # UI language
 
-Human-facing interactive chrome can render in English or Korean. Canonical persisted values are only `en` and `ko`. Commands, flags, environment variables, JSON, and other protocol output stay in English.
+Human-facing interactive chrome can render in English, Korean, or Japanese. Canonical persisted values are only `en`, `ko`, and `ja`. Commands, flags, environment variables, JSON, and other protocol output stay in English.
 
 Primary implementation: `packages/coding-agent/src/modes/ui-language.ts`. Setting: `ui.language` in `packages/coding-agent/src/config/settings-schema.ts` (global-only; workspace config and runtime overrides cannot change it).
 
@@ -8,20 +8,20 @@ Primary implementation: `packages/coding-agent/src/modes/ui-language.ts`. Settin
 
 - `/language` with no arguments reports the current language and the available codes.
 - `/language <value>` persists `ui.language` and confirms in the selected language. Accepted spellings:
-  - canonical codes: `en`, `ko`
-  - locale tags whose language subtag is one of those codes: `en-US`, `ko-KR`
-  - English names: `english`, `korean`
-  - Korean endonym: `한국어`
-  - common aliases: `eng`, `kr`, `kor`
-- An unsupported value (`fr`, `ja`, …) is rejected with the available list and changes nothing.
+  - canonical codes: `en`, `ko`, `ja`
+  - locale tags whose language subtag is one of those codes: `en-US`, `ko-KR`, `ja-JP`
+  - English names: `english`, `korean`, `japanese`
+  - endonyms: `한국어`, `日本語`
+  - common aliases: `eng`, `kr`, `kor`, `jp`, `jpn`
+- An unsupported value (`fr`, `zh`, …) is rejected with the available list and changes nothing.
 - Durable-config failures use the same `config.yml` repair guidance as `/theme`.
 - `/language` is TUI-only (visual/local). It is not an SDK control seam.
 
-The settings Appearance tab exposes the same `en` / `ko` selector.
+The settings Appearance tab exposes the same `en` / `ko` / `ja` selector.
 
 ## Onboarding detection
 
-`/tutorial` and first-run onboarding may still choose copy from a larger catalog (`en`, `ko`, `ja`, `zh`, `es`, `fr`, `de`) based on transcript evidence and the OS locale. That catalog is display-only for onboarding and is not added to the persisted `ui.language` enum.
+`/tutorial` and first-run onboarding may still choose copy from a larger catalog (`en`, `ko`, `ja`, `zh`, `es`, `fr`, `de`) based on transcript evidence and the OS locale. An explicit `ui.language: ja` selection also pins onboarding copy to Japanese, like `en` and `ko`. The remaining catalog entries are display-only for onboarding and are not added to the persisted `ui.language` enum.
 
 Detection rules:
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Japanese (`ja`) to the persisted `ui.language` response-language surface: the `/language` command and the Settings → Appearance selector. Accepted input spellings include `ja`, `ja-JP`, `japanese`, `jp`, `jpn`, and `日本語`. English and Korean behavior, defaults, and onboarding language ranking are unchanged. (#4947)
+
 ### Fixed
 
 - Foreground activity animation now uses layout-only TUI repaints, avoiding repeated reconstruction of unchanged transcript content during long sessions.

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -745,7 +745,7 @@ export const SETTINGS_SCHEMA = {
 	// ────────────────────────────────────────────────────────────────────────
 	"ui.language": {
 		type: "enum",
-		values: ["en", "ko"] as const,
+		values: ["en", "ko", "ja"] as const,
 		default: "en",
 		ui: {
 			tab: "appearance",
@@ -754,6 +754,7 @@ export const SETTINGS_SCHEMA = {
 			options: [
 				{ value: "en", label: "English" },
 				{ value: "ko", label: "Korean (한국어)" },
+				{ value: "ja", label: "Japanese (日本語)" },
 			],
 		},
 	},

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -1009,6 +1009,7 @@ export class SettingsSelectorComponent extends Container {
 			options = [
 				{ value: "en", label: uiString(language, "settings.language.english") },
 				{ value: "ko", label: uiString(language, "settings.language.korean") },
+				{ value: "ja", label: uiString(language, "settings.language.japanese") },
 			];
 		}
 		if (def.path === "statusLine.preset") {

--- a/packages/coding-agent/src/modes/ui-language.ts
+++ b/packages/coding-agent/src/modes/ui-language.ts
@@ -1,4 +1,4 @@
-export const UI_LANGUAGES = ["en", "ko"] as const;
+export const UI_LANGUAGES = ["en", "ko", "ja"] as const;
 
 export type UiLanguage = (typeof UI_LANGUAGES)[number];
 
@@ -23,6 +23,7 @@ const ENGLISH_STRINGS = {
 	"settings.language.description": "Language for human-facing interactive UI text",
 	"settings.language.english": "English",
 	"settings.language.korean": "Korean (한국어)",
+	"settings.language.japanese": "Japanese (日本語)",
 	"language.current": "Current UI language:",
 	"language.changed": "UI language changed to",
 	"language.unknown": "Unknown language",
@@ -51,24 +52,59 @@ const KOREAN_STRINGS: Record<UiStringKey, string> = {
 	"settings.language.description": "사람이 읽는 대화형 UI 텍스트의 언어",
 	"settings.language.english": "English",
 	"settings.language.korean": "한국어",
+	"settings.language.japanese": "日本語",
 	"language.current": "현재 UI 언어:",
 	"language.changed": "UI 언어를 다음으로 변경했습니다:",
 	"language.unknown": "알 수 없는 언어",
 };
 
+const JAPANESE_STRINGS: Record<UiStringKey, string> = {
+	"settings.title": "設定",
+	"settings.navigationHint": "(Tab キーで切り替え)",
+	"settings.selectHint": "  Enter: 選択 · Esc: 戻る",
+	"settings.preview": "プレビュー:",
+	"settings.tab.appearance": "外観",
+	"settings.tab.model": "モデル",
+	"settings.tab.interaction": "操作",
+	"settings.tab.context": "コンテキスト",
+	"settings.tab.memory": "メモリ",
+	"settings.tab.editing": "編集",
+	"settings.tab.tools": "ツール",
+	"settings.tab.tasks": "タスク",
+	"settings.tab.providers": "プロバイダー",
+	"settings.tab.notifications": "通知",
+	"settings.tab.plugins": "プラグイン",
+	"settings.tab.gjcBundles": "GJC バンドル",
+	"settings.language.label": "言語",
+	"settings.language.description": "対話型 UI テキストに使う言語",
+	"settings.language.english": "English",
+	"settings.language.korean": "한국어",
+	"settings.language.japanese": "日本語",
+	"language.current": "現在の UI 言語:",
+	"language.changed": "UI 言語を次に変更しました:",
+	"language.unknown": "不明な言語",
+};
+
+const STRINGS: Record<UiLanguage, Record<UiStringKey, string>> = {
+	en: ENGLISH_STRINGS,
+	ko: KOREAN_STRINGS,
+	ja: JAPANESE_STRINGS,
+};
+
 /** User selection is authoritative; invalid or unavailable values deterministically fall back to English. */
 export function resolveUiLanguage(value: unknown): UiLanguage {
-	return value === "ko" ? "ko" : "en";
+	return value === "ko" || value === "ja" ? value : "en";
 }
 
 export function uiString(language: unknown, key: UiStringKey): string {
-	return resolveUiLanguage(language) === "ko" ? KOREAN_STRINGS[key] : ENGLISH_STRINGS[key];
+	return STRINGS[resolveUiLanguage(language)][key];
 }
 
 /** Endonym shown by `/language` and the language submenu. */
 export const UI_LANGUAGE_LABELS: Record<UiLanguage, string> = {
 	en: "English",
 	ko: "한국어",
+	ja: "日本語",
 };
 
 /** Spellings accepted by `/language`; the canonical codes stay authoritative. */
@@ -81,6 +117,11 @@ const UI_LANGUAGE_ALIASES: Readonly<Record<string, UiLanguage>> = {
 	kor: "ko",
 	korean: "ko",
 	한국어: "ko",
+	ja: "ja",
+	jp: "ja",
+	jpn: "ja",
+	japanese: "ja",
+	日本語: "ja",
 };
 
 export function parseUiLanguage(value: string): UiLanguage | undefined {

--- a/packages/coding-agent/test/config-cli.test.ts
+++ b/packages/coding-agent/test/config-cli.test.ts
@@ -43,6 +43,16 @@ describe("config CLI schema coverage", () => {
 			type: "enum",
 			description: "Language for human-facing interactive UI text",
 		});
+
+		await runConfigCommand({ action: "set", key: "ui.language", value: "ja", flags: { json: true } });
+		await runConfigCommand({ action: "get", key: "ui.language", flags: { json: true } });
+
+		expect(JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))).toEqual({
+			key: "ui.language",
+			value: "ja",
+			type: "enum",
+			description: "Language for human-facing interactive UI text",
+		});
 	});
 
 	it("renders record settings as JSON and with record type in text output", async () => {

--- a/packages/coding-agent/test/frictionless-onboarding.test.ts
+++ b/packages/coding-agent/test/frictionless-onboarding.test.ts
@@ -149,6 +149,7 @@ describe("frictionless onboarding", () => {
 
 	test("an explicit language preference outranks messages and locale", () => {
 		expect(detectOnboardingLanguage(["le fichier merci"], "fr-FR", "ko")).toBe("ko");
+		expect(detectOnboardingLanguage(["파일 변경해줘"], "ko-KR", "ja")).toBe("ja");
 		expect(
 			deriveOnboardingProfile(
 				[

--- a/packages/coding-agent/test/ui-language-selection.test.ts
+++ b/packages/coding-agent/test/ui-language-selection.test.ts
@@ -71,6 +71,29 @@ describe("interactive UI language selection", () => {
 		expect(submenu).toContain("한국어");
 	});
 
+	it("renders persisted Japanese settings chrome and offers it as a select option", () => {
+		settings.set("ui.language", "ja");
+		const selector = createSelector();
+		const rendered = selector.render(160).map(Bun.stripANSI).join("\n");
+
+		expect(rendered).toContain("設定:");
+		expect(rendered).toContain("外観");
+		expect(rendered).toContain("言語");
+		expect(settings.get("ui.language")).toBe("ja");
+
+		selector.handleInput("\x1b[B"); // Light Theme
+		selector.handleInput("\x1b[B"); // Language
+		selector.handleInput("\n");
+		const submenu = selector.render(160).map(Bun.stripANSI).join("\n");
+		expect(submenu).toContain("言語");
+		expect(submenu).toContain("対話型 UI テキストに使う言語");
+		expect(submenu).toContain("日本語");
+	});
+
+	it("validates Japanese in the settings enum patch surface", () => {
+		expect(validateSettingPatch({ "ui.language": "ja" })).toEqual([]);
+	});
+
 	it("keeps the operator language authoritative over runtime overrides", () => {
 		expect(
 			Settings.isolated({ "ui.language": "ko" }, { overrides: { "ui.language": "en" } }).get("ui.language"),
@@ -102,7 +125,7 @@ describe("/language slash command", () => {
 			settings: {
 				get: (path: "ui.language") => settings.get(path),
 				has: (path: "ui.language") => settings.has(path),
-				set: (path: "ui.language", value: "en" | "ko") => settings.set(path, value),
+				set: (path: "ui.language", value: "en" | "ko" | "ja") => settings.set(path, value),
 				canWriteDurableConfig: () => options.canWriteDurableConfig ?? settings.canWriteDurableConfig(),
 			},
 			editor: { setText: () => {} },
@@ -132,7 +155,22 @@ describe("/language slash command", () => {
 		expect(status[0]).toContain("한국어");
 	});
 
-	it("accepts endonym, English-name, ISO, and locale-tag spellings", async () => {
+	it("persists the Japanese canonical code and confirms in Japanese", async () => {
+		const { status, runtime } = harness();
+
+		expect(await executeBuiltinSlashCommand("/language ja", runtime as never)).toBe(true);
+
+		expect(settings.get("ui.language")).toBe("ja");
+		expect(status[0]).toContain("UI 言語を次に変更しました:");
+		expect(status[0]).toContain("日本語");
+	});
+
+	it("accepts Japanese endonym, English-name, ISO, and locale-tag spellings", async () => {
+		expect(parseUiLanguage("日本語")).toBe("ja");
+		expect(parseUiLanguage("Japanese")).toBe("ja");
+		expect(parseUiLanguage("jp")).toBe("ja");
+		expect(parseUiLanguage("jpn")).toBe("ja");
+		expect(parseUiLanguage("ja-JP")).toBe("ja");
 		expect(parseUiLanguage("한국어")).toBe("ko");
 		expect(parseUiLanguage("Korean")).toBe("ko");
 		expect(parseUiLanguage("kr")).toBe("ko");
@@ -170,6 +208,18 @@ describe("/language slash command", () => {
 		const english = harness();
 		await executeBuiltinSlashCommand("/language English", english.runtime as never);
 		expect(settings.get("ui.language")).toBe("en");
+	});
+
+	it("persists Japanese endonym and locale-tag spellings through the command", async () => {
+		const endonym = harness();
+		await executeBuiltinSlashCommand("/language 日本語", endonym.runtime as never);
+		expect(settings.get("ui.language")).toBe("ja");
+
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true });
+		const locale = harness();
+		await executeBuiltinSlashCommand("/language ja-JP", locale.runtime as never);
+		expect(settings.get("ui.language")).toBe("ja");
 	});
 
 	it("rejects an unsupported language and changes nothing", async () => {

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -535,7 +535,8 @@
 					"type": "string",
 					"enum": [
 						"en",
-						"ko"
+						"ko",
+						"ja"
 					],
 					"description": "Language for human-facing interactive UI text",
 					"default": "en"


### PR DESCRIPTION
Closes #4947.

## What

Adds Japanese (`ja`) as a third canonical persisted `ui.language` value, alongside `en` and `ko`, selectable through the two existing supported response-language surfaces:

- `/language` slash command: `ja`, `ja-JP`, `japanese`, `jp`, `jpn`, `日本語`
- Settings → Appearance → Language selector (`Japanese (日本語)`)

## Why

Community request (#4947, Discord `1541827645208268842`) for Japanese responses alongside the Korean localization work. The maintainer-defined scope is the smallest supported response-language configuration path: extend the existing persisted enum, not a new mechanism.

## Changes

- `packages/coding-agent/src/modes/ui-language.ts` — `UI_LANGUAGES` gains `ja`; independently authored `JAPANESE_STRINGS` catalog; `resolveUiLanguage` accepts `ja` (everything else still deterministically falls back to `en`); `UI_LANGUAGE_LABELS` and aliases extended
- `packages/coding-agent/src/config/settings-schema.ts` — enum values + UI options
- `packages/coding-agent/src/modes/components/settings-selector.ts` — submenu option
- `schemas/config.schema.json` — regenerated (`bun run generate-schemas`)
- `docs/ui-language.md` — supported spellings, selector, onboarding note
- `packages/coding-agent/CHANGELOG.md` — Unreleased entry

## Preserved behavior (regression-covered)

- `en`/`ko` resolution, defaults, and fallback unchanged
- Onboarding detection ranking untouched — explicit `ja` pins onboarding copy the same way `en`/`ko` already do (`detectOnboardingLanguage(["파일 변경해줘"], "ko-KR", "ja") === "ja"`)
- Machine-readable contracts stay English/codes-only: `gjc config set/get ui.language` JSON output canonical
- Hostile `/language` inputs (`__proto__`, `constructor`, …) still resolve to nothing
- Global-only ownership of `ui.language` unchanged

## Tests

- `bun test packages/coding-agent/test/ui-language-selection.test.ts` (15 pass)
- `bun test packages/coding-agent/test/config-cli.test.ts`
- `bun test packages/coding-agent/test/frictionless-onboarding.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun run check:schemas`
- `bun test packages/coding-agent/test/docs-index-lazy.test.ts` (after regenerating the docs index)
- `bun run ci:test:smoke`

The pre-existing `settings-selector-status-line-custom.test.ts` failures and 13 biome warnings reproduce identically on the clean base commit `07ebf245e` (verified by stashing this diff) and are unrelated to this change.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — persisted user-facing config/schema enum and response-language behavior; requires independent exact-head review.
- [ ] `high-risk` — large refactor, feature, or materially high-risk change.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:2a9ea453b2cea41654498dd5f7613792d37cc21b837edf072a4038722f6eea8c reviewer:human reviewer-id:snowykr evidence:https://github.com/Yeachan-Heo/gajae-code/pull/4949#pullrequestreview-5022751878
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken






