### PR TITLE
feat(sdk): retire terminalUncertain creates via session.reconcile_uncertain

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `gjc sdk session raw global --op session.reconcile_uncertain` retires an indexed `terminalUncertain` create effect after dead-host and absent-marker proof, appending `session_closed` and a ledger `terminal_error` successor. It does not weaken `session.close` / `session.delete`. Coordinator start-session `in_progress` projections are sealed separately to `completed` + `ok:false retired:true` (issue #4950).
+
 ### Fixed
 
 - Coordinator no longer treats native exact-unlink placeholders (empty `.gjc-delete-*.json`) as live projection JSON. Directory scans skip dotfiles and zero-byte files before open, apply the parse cap only after that filter, and never map scan exhaustion to `coordinator_state_unreadable`. Session-state lock reclaim reuses one quarantine name per acquire cycle and removes a verified-empty leftover at that name before exchange. `gjc gc --empty-delete-receipts --root/--manifest` reports or prunes only operator-supplied empty receipts (inode identity + symlink-root reject; no hardcoded host paths).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Coordinator no longer treats native exact-unlink placeholders (empty `.gjc-delete-*.json`) as live projection JSON. Directory scans skip dotfiles and zero-byte files before open, apply the parse cap only after that filter, and never map scan exhaustion to `coordinator_state_unreadable`. Session-state lock reclaim reuses one quarantine name per acquire cycle and removes a verified-empty leftover at that name before exchange. `gjc gc --empty-delete-receipts --root/--manifest` reports or prunes only operator-supplied empty receipts (inode identity + symlink-root reject; no hardcoded host paths).
+
 - Foreground activity animation now uses layout-only TUI repaints, avoiding repeated reconstruction of unchanged transcript content during long sessions.
 
 ## [0.15.2] - 2026-08-25

--- a/packages/coding-agent/scripts/seal-uncertain-create-intent.ts
+++ b/packages/coding-agent/scripts/seal-uncertain-create-intent.ts
@@ -1,0 +1,91 @@
+/**
+ * Official seal for stranded coordinator start-session idempotency projections.
+ * Writes completed + ok:false retired:true under the session-state lock.
+ */
+import { createHash } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { writeCoordinatorAtomic } from "../src/coordinator-mcp/durability";
+import { withSessionStateFileLock } from "../src/gjc-runtime/session-state-lock";
+
+function usage(): never {
+	console.error(
+		"usage: bun scripts/seal-uncertain-create-intent.ts --namespace <dir> --key-digest <64hex> --session-id <uuid>",
+	);
+	process.exit(2);
+}
+
+function arg(name: string): string {
+	const index = process.argv.indexOf(name);
+	const value = index >= 0 ? process.argv[index + 1] : undefined;
+	if (!value) usage();
+	return value;
+}
+
+const namespace = arg("--namespace");
+const keyDigest = arg("--key-digest");
+const sessionId = arg("--session-id");
+if (!/^[a-f0-9]{64}$/.test(keyDigest)) {
+	console.error("key-digest must be 64 hex chars");
+	process.exit(2);
+}
+
+const file = path.join(namespace, "idempotency", `${keyDigest}.json`);
+const lockFile = path.join(namespace, "idempotency-locks", `${keyDigest}.json`);
+
+await withSessionStateFileLock(lockFile, async () => {
+	let raw: string;
+	try {
+		raw = await fs.readFile(file, "utf8");
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			console.error("missing idempotency projection");
+			process.exit(1);
+		}
+		throw error;
+	}
+	const existing = JSON.parse(raw) as {
+		schema_version?: number;
+		tool?: string;
+		key_digest?: string;
+		request_digest?: string;
+		state?: string;
+		created_at?: string;
+		response?: { error?: { retired?: boolean } };
+	};
+	if (existing.schema_version !== 1 || existing.key_digest !== keyDigest) {
+		console.error("idempotency identity mismatch");
+		process.exit(1);
+	}
+	if (existing.tool !== "gjc_coordinator_start_session") {
+		console.error("not a start_session projection");
+		process.exit(1);
+	}
+	if (existing.state === "completed" && existing.response?.error?.retired === true) {
+		console.log(JSON.stringify({ ok: true, replayed: true, key_digest: keyDigest, session_id: sessionId }));
+		return;
+	}
+	if (existing.state !== "in_progress") {
+		console.error(`refusing to seal state=${existing.state}`);
+		process.exit(1);
+	}
+	const sealed = {
+		schema_version: 1,
+		tool: existing.tool,
+		key_digest: existing.key_digest,
+		request_digest: existing.request_digest ?? createHash("sha256").update(keyDigest).digest("hex"),
+		state: "completed",
+		created_at: existing.created_at ?? new Date().toISOString(),
+		completed_at: new Date().toISOString(),
+		response: {
+			ok: false,
+			error: {
+				code: "broker_compensation_unobserved",
+				retired: true,
+				session_id: sessionId,
+			},
+		},
+	};
+	await writeCoordinatorAtomic(file, `${JSON.stringify(sealed)}\n`);
+	console.log(JSON.stringify({ ok: true, sealed: true, key_digest: keyDigest, session_id: sessionId }));
+});

--- a/packages/coding-agent/src/coordinator-mcp/projection-scan.ts
+++ b/packages/coding-agent/src/coordinator-mcp/projection-scan.ts
@@ -1,0 +1,106 @@
+/**
+ * Coordinator directory scans that must not treat native exact-unlink debris
+ * as live JSON, and must not make start/status unreadable on a large dirent pile.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+/** Post-filter parse-candidate cap. Exhaustion returns a bounded result, never unreadable. */
+export const COORDINATOR_JSON_SCAN_CAP = 10_000;
+
+export interface ProjectionScanStat {
+	size: number;
+	isFile(): boolean;
+	isSymbolicLink(): boolean;
+}
+
+export interface ProjectionScanFs {
+	readdir(dir: string): Promise<string[]>;
+	lstat(file: string): Promise<ProjectionScanStat>;
+	readFile(file: string, encoding: "utf8"): Promise<string>;
+}
+
+export interface ProjectionScanResult {
+	values: unknown[];
+	parsed: number;
+	capped: boolean;
+	skippedDebris: number;
+	skippedEmpty: number;
+}
+
+const defaultFs: ProjectionScanFs = {
+	readdir: dir => fs.readdir(dir),
+	lstat: file => fs.lstat(file),
+	readFile: (file, encoding) => fs.readFile(file, encoding),
+};
+
+export function isCoordinatorScanDebrisName(name: string): boolean {
+	return name.startsWith(".");
+}
+
+export async function listCoordinatorJsonFiles(
+	dir: string,
+	io: ProjectionScanFs = defaultFs,
+	cap: number = COORDINATOR_JSON_SCAN_CAP,
+): Promise<ProjectionScanResult> {
+	let entries: string[];
+	try {
+		entries = await io.readdir(dir);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			return { values: [], parsed: 0, capped: false, skippedDebris: 0, skippedEmpty: 0 };
+		}
+		throw error;
+	}
+
+	let skippedDebris = 0;
+	let skippedEmpty = 0;
+	const parseCandidates: string[] = [];
+	for (const entry of entries) {
+		if (!entry.endsWith(".json") || isCoordinatorScanDebrisName(entry)) {
+			if (entry.endsWith(".json") && isCoordinatorScanDebrisName(entry)) skippedDebris += 1;
+			continue;
+		}
+		const file = path.join(dir, entry);
+		let stat: ProjectionScanStat;
+		try {
+			stat = await io.lstat(file);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+			throw error;
+		}
+		if (stat.isSymbolicLink() || !stat.isFile() || stat.size === 0) {
+			skippedEmpty += 1;
+			continue;
+		}
+		parseCandidates.push(entry);
+	}
+
+	const capped = parseCandidates.length > cap;
+	const toParse = capped ? parseCandidates.slice(0, cap) : parseCandidates;
+	const values: unknown[] = [];
+	for (const entry of toParse) {
+		const file = path.join(dir, entry);
+		let source: string;
+		try {
+			source = await io.readFile(file, "utf8");
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+			throw error;
+		}
+		try {
+			values.push(JSON.parse(source));
+		} catch (error) {
+			throw new Error(
+				`invalid coordinator projection ${file}: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	}
+	return {
+		values: values.filter(value => value !== null),
+		parsed: values.length,
+		capped,
+		skippedDebris,
+		skippedEmpty,
+	};
+}

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -60,6 +60,7 @@ import {
 	syncCoordinatorDirectory,
 	writeCoordinatorAtomic,
 } from "./durability";
+import { listCoordinatorJsonFiles } from "./projection-scan";
 import {
 	createDefaultEventWebhookDelivery,
 	deliverEventWebhook,
@@ -1448,26 +1449,17 @@ function publicSdkAcknowledgement(result: RuntimePromptAcknowledgement): Record<
 }
 
 async function listJsonFiles(dir: string): Promise<unknown[]> {
-	try {
-		const entries = await fs.readdir(dir);
-		const values = await Promise.all(
-			entries
-				.filter(entry => entry.endsWith(".json") && !entry.startsWith(".gjc-"))
-				.map(async entry => {
-					try {
-						return await readJsonFile(path.join(dir, entry));
-					} catch (error) {
-						if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
-						logger.warn("Coordinator projection read failed", { path: entry, error: String(error) });
-						throw error;
-					}
-				}),
-		);
-		return values.filter(value => value !== null);
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
-		throw error;
+	const scan = await listCoordinatorJsonFiles(dir);
+	if (scan.capped || scan.skippedEmpty > 0) {
+		logger.warn("Coordinator projection scan skipped debris or hit the parse cap", {
+			dir,
+			parsed: scan.parsed,
+			capped: scan.capped,
+			skippedDebris: scan.skippedDebris,
+			skippedEmpty: scan.skippedEmpty,
+		});
 	}
+	return scan.values;
 }
 
 const COORDINATOR_STATUS_EVENT_LIMIT = 100;

--- a/packages/coding-agent/src/gjc-runtime/empty-delete-gc.ts
+++ b/packages/coding-agent/src/gjc-runtime/empty-delete-gc.ts
@@ -1,0 +1,183 @@
+/**
+ * Official GC of already-quarantined empty `.gjc-delete-*` receipts.
+ * Roots are operator operands — never hardcoded host paths.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+export const EMPTY_DELETE_PREFIX = ".gjc-delete-";
+
+export interface EmptyDeleteIdentity {
+	dev: bigint;
+	ino: bigint;
+	nlink: bigint;
+	size: bigint;
+	mtimeNs: bigint;
+}
+
+export interface EmptyDeleteGcRecord {
+	root: string;
+	path: string;
+	action: "would_remove" | "removed" | "kept" | "skipped";
+	reason: string;
+	identity?: EmptyDeleteIdentity;
+}
+
+export interface EmptyDeleteGcReport {
+	dry_run: boolean;
+	roots: string[];
+	records: EmptyDeleteGcRecord[];
+	would_remove: number;
+	removed: number;
+	kept: number;
+	skipped: number;
+	errors: string[];
+}
+
+export interface EmptyDeleteGcOptions {
+	roots: string[];
+	prune: boolean;
+}
+
+function isUnsafeName(name: string): boolean {
+	return name.includes("/") || name.includes("\0") || name === "." || name === "..";
+}
+
+function identityOf(stat: { dev: bigint; ino: bigint; nlink: bigint; size: bigint; mtimeNs: bigint }): EmptyDeleteIdentity {
+	return {
+		dev: stat.dev,
+		ino: stat.ino,
+		nlink: stat.nlink,
+		size: stat.size,
+		mtimeNs: stat.mtimeNs,
+	};
+}
+
+function sameIdentity(left: EmptyDeleteIdentity, right: EmptyDeleteIdentity): boolean {
+	return (
+		left.dev === right.dev &&
+		left.ino === right.ino &&
+		left.nlink === right.nlink &&
+		left.size === right.size &&
+		left.mtimeNs === right.mtimeNs
+	);
+}
+
+export async function collectEmptyDeleteReceipts(root: string): Promise<EmptyDeleteGcRecord[]> {
+	const records: EmptyDeleteGcRecord[] = [];
+	let rootStat;
+	try {
+		rootStat = await fs.lstat(root);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			return [{ root, path: root, action: "skipped", reason: "missing_root" }];
+		}
+		throw error;
+	}
+	if (rootStat.isSymbolicLink()) {
+		return [{ root, path: root, action: "skipped", reason: "symlink_root" }];
+	}
+	if (!rootStat.isDirectory()) {
+		return [{ root, path: root, action: "skipped", reason: "not_directory" }];
+	}
+	let names: string[];
+	try {
+		names = await fs.readdir(root);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			return [{ root, path: root, action: "skipped", reason: "missing_root" }];
+		}
+		throw error;
+	}
+	for (const name of names) {
+		if (isUnsafeName(name) || !name.startsWith(EMPTY_DELETE_PREFIX)) continue;
+		const file = path.join(root, name);
+		let stat;
+		try {
+			stat = await fs.lstat(file, { bigint: true });
+		} catch {
+			continue;
+		}
+		if (stat.isSymbolicLink()) {
+			records.push({ root, path: file, action: "kept", reason: "symlink" });
+			continue;
+		}
+		if (!stat.isFile()) {
+			records.push({ root, path: file, action: "kept", reason: "not_regular" });
+			continue;
+		}
+		if (stat.size !== 0n) {
+			records.push({ root, path: file, action: "kept", reason: "non_empty" });
+			continue;
+		}
+		if (stat.nlink !== 1n) {
+			records.push({ root, path: file, action: "kept", reason: "nlink" });
+			continue;
+		}
+		records.push({
+			root,
+			path: file,
+			action: "would_remove",
+			reason: "empty_delete_receipt",
+			identity: identityOf(stat),
+		});
+	}
+	return records;
+}
+
+export async function runEmptyDeleteGc(options: EmptyDeleteGcOptions): Promise<EmptyDeleteGcReport> {
+	const report: EmptyDeleteGcReport = {
+		dry_run: !options.prune,
+		roots: options.roots,
+		records: [],
+		would_remove: 0,
+		removed: 0,
+		kept: 0,
+		skipped: 0,
+		errors: [],
+	};
+	for (const root of options.roots) {
+		let records: EmptyDeleteGcRecord[];
+		try {
+			records = await collectEmptyDeleteReceipts(root);
+		} catch (error) {
+			report.errors.push(`${root}: ${error instanceof Error ? error.message : String(error)}`);
+			continue;
+		}
+		for (const record of records) {
+			if (record.action === "would_remove" && options.prune) {
+				try {
+					const restat = await fs.lstat(record.path, { bigint: true });
+					if (
+						restat.isSymbolicLink() ||
+						!restat.isFile() ||
+						restat.size !== 0n ||
+						restat.nlink !== 1n ||
+						!record.identity ||
+						!sameIdentity(record.identity, identityOf(restat))
+					) {
+						record.action = "kept";
+						record.reason = "identity_drift";
+					} else {
+						await fs.unlink(record.path);
+						record.action = "removed";
+					}
+				} catch (error) {
+					if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+						record.action = "skipped";
+						record.reason = "gone";
+					} else {
+						record.action = "kept";
+						record.reason = `unlink_failed:${error instanceof Error ? error.message : String(error)}`;
+					}
+				}
+			}
+			report.records.push(record);
+			if (record.action === "would_remove") report.would_remove += 1;
+			else if (record.action === "removed") report.removed += 1;
+			else if (record.action === "skipped") report.skipped += 1;
+			else report.kept += 1;
+		}
+	}
+	return report;
+}

--- a/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/gc-runtime.ts
@@ -33,6 +33,7 @@ import {
 import { FileSessionStorage, probeSessionRetirement, retireSessionTranscript } from "../session/session-storage";
 
 import { buildGcReportText } from "./gc-render";
+import { type EmptyDeleteGcReport, runEmptyDeleteGc } from "./empty-delete-gc";
 import { collectSessionScopeUsage, type GcSessionScopeUsage, shouldReportSessionScope } from "./gc-session-scope";
 
 export type GcStore = "harness_leases" | "file_locks" | "tmux_sessions" | "registry_entries" | "local_roots";
@@ -168,6 +169,7 @@ export interface GcReport {
 	 * PID-liveness axis above is unchanged by its absence or presence.
 	 */
 	disk?: GcDiskReport;
+	empty_delete_receipts?: EmptyDeleteGcReport;
 }
 
 export interface GcRunResult {
@@ -274,9 +276,11 @@ interface ParsedGcArgs {
 	json: boolean;
 	prune: boolean;
 	repairSessionIndex: boolean;
-	/** Opt-in second axis: report (and with `--prune`, reclaim) on-disk retention. */
 	disk: boolean;
 	help: boolean;
+	emptyDeleteReceipts: boolean;
+	emptyDeleteRoots: string[];
+	emptyDeleteManifest?: string;
 }
 
 class GcUsageError extends Error {}
@@ -286,10 +290,13 @@ function parseGcArgs(argv: string[]): ParsedGcArgs {
 	let prune = false;
 	let repairSessionIndex = false;
 	let disk = false;
-
 	let dryRun = false;
 	let help = false;
-	for (const arg of argv) {
+	let emptyDeleteReceipts = false;
+	const emptyDeleteRoots: string[] = [];
+	let emptyDeleteManifest: string | undefined;
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i]!;
 		switch (arg) {
 			case "--json":
 			case "-j":
@@ -305,7 +312,6 @@ function parseGcArgs(argv: string[]): ParsedGcArgs {
 			case "--disk":
 				disk = true;
 				break;
-
 			case "--dry-run":
 				dryRun = true;
 				break;
@@ -313,15 +319,29 @@ function parseGcArgs(argv: string[]): ParsedGcArgs {
 			case "-h":
 				help = true;
 				break;
+			case "--empty-delete-receipts":
+				emptyDeleteReceipts = true;
+				break;
+			case "--root": {
+				const value = argv[++i];
+				if (!value) throw new GcUsageError("missing_root");
+				emptyDeleteRoots.push(value);
+				break;
+			}
+			case "--manifest": {
+				const value = argv[++i];
+				if (!value) throw new GcUsageError("missing_manifest");
+				emptyDeleteManifest = value;
+				break;
+			}
 			default:
 				throw new GcUsageError(`unknown_flag:${arg}`);
 		}
 	}
 	if (repairSessionIndex && prune) throw new GcUsageError("repair_session_index_cannot_combine_with_prune");
 	if (repairSessionIndex && dryRun) throw new GcUsageError("repair_session_index_cannot_combine_with_dry_run");
-	// Explicit --dry-run always wins over --prune/--force.
 	if (dryRun) prune = false;
-	return { json, prune, repairSessionIndex, disk, help };
+	return { json, prune, repairSessionIndex, disk, help, emptyDeleteReceipts, emptyDeleteRoots, emptyDeleteManifest };
 }
 
 /**
@@ -495,6 +515,26 @@ export async function runGjcGcCommand(
 			prune: parsed.prune,
 		});
 	}
+	if (parsed.emptyDeleteReceipts) {
+		const roots = [...parsed.emptyDeleteRoots];
+		if (parsed.emptyDeleteManifest) {
+			const raw = await fsp.readFile(parsed.emptyDeleteManifest, "utf8");
+			const parsedManifest = JSON.parse(raw) as { roots?: unknown };
+			if (!Array.isArray(parsedManifest.roots)) {
+				return { stdout: "", stderr: "gjc gc: manifest_roots_required\n", status: 2 };
+			}
+			for (const root of parsedManifest.roots) {
+				if (typeof root !== "string" || root.length === 0) {
+					return { stdout: "", stderr: "gjc gc: manifest_root_invalid\n", status: 2 };
+				}
+				roots.push(root);
+			}
+		}
+		if (roots.length === 0) {
+			return { stdout: "", stderr: "gjc gc: empty_delete_receipts_requires_root_or_manifest\n", status: 2 };
+		}
+		report.empty_delete_receipts = await runEmptyDeleteGc({ roots, prune: parsed.prune });
+	}
 	const scopeUsage = await collectGcSessionScope(cwd, resolveGcAgentDir(env));
 	if (scopeUsage && shouldReportSessionScope(scopeUsage)) report.session_scope = scopeUsage;
 	const sessionIndexFailed =
@@ -513,7 +553,7 @@ export function gcHelpText(): string {
 		"gjc gc - garbage-collect stale GJC session/PID records",
 		"",
 		"USAGE",
-		"  $ gjc gc [--prune|--force] [--disk] [--repair-session-index] [--json]",
+		"  $ gjc gc [--prune|--force] [--disk] [--repair-session-index] [--empty-delete-receipts --root <dir>] [--json]",
 
 		"",
 		"FLAGS",
@@ -522,6 +562,9 @@ export function gcHelpText(): string {
 		"  -j, --json        Emit machine-readable JSON",
 		"  --repair-session-index  Explicitly quarantine a corrupt session-index suffix and retain its valid prefix",
 		"  --disk            Also report on-disk retention (sessions, blobs, artifacts, natives, backups)",
+		"  --empty-delete-receipts  Report/prune empty .gjc-delete-* under --root / --manifest",
+		"  --root <dir>      Operand root for --empty-delete-receipts (repeatable)",
+		"  --manifest <file> JSON {\"roots\":[...]} for --empty-delete-receipts",
 		"",
 		"Liveness-only: a record is removed only when its owning process is dead",
 		"(ESRCH). Live / permission-denied / unknown processes are always kept.",

--- a/packages/coding-agent/src/gjc-runtime/session-state-lock.ts
+++ b/packages/coding-agent/src/gjc-runtime/session-state-lock.ts
@@ -150,6 +150,12 @@ export const SessionStateLockTestHooks: {
 	 */
 	beforeCurrentOwnerRelease?: (file: string) => void | Promise<void>;
 	beforeLegacyDirectoryRemoval?: (lockDir: string) => void | Promise<void>;
+	/** @internal Last quarantine name minted in the current lock cycle (tests). */
+	lastQuarantineName?: string;
+	/** @internal Count of quarantine names minted in the current lock cycle (tests). */
+	quarantineMints?: number;
+	/** @internal Force the next mint to this name so leftover-collision tests can plant it. */
+	forcedQuarantineName?: string;
 } = {};
 
 /** Raised when the lock could not be acquired; callers map it to their own refusal. */
@@ -537,8 +543,16 @@ type ExactRemovalOutcome = "removed" | "absent" | "identity_mismatch" | "refused
  * A single-component quarantine destination, required by the native primitive so that
  * authority over a detached record survives a crash between detach and unlink.
  */
-function lockQuarantineName(): string {
-	return `.gjc-delete-session-state-lock-${randomUUID()}.json`;
+function lockQuarantineName(existing?: string): string {
+	const name =
+		existing ??
+		SessionStateLockTestHooks.forcedQuarantineName ??
+		`.gjc-delete-session-state-lock-${randomUUID()}.json`;
+	if (!existing) {
+		SessionStateLockTestHooks.lastQuarantineName = name;
+		SessionStateLockTestHooks.quarantineMints = (SessionStateLockTestHooks.quarantineMints ?? 0) + 1;
+	}
+	return name;
 }
 
 /**
@@ -548,7 +562,11 @@ function lockQuarantineName(): string {
  * never downgraded to `fs.rm`: not knowing what is at the pathname is precisely the state
  * in which deleting it destroys a successor's lock.
  */
-function exactUnlinkOwnerRecord(file: string, identity: LockOwnerSnapshot): ExactRemovalOutcome {
+function exactUnlinkOwnerRecord(
+	file: string,
+	identity: LockOwnerSnapshot,
+	quarantineName = lockQuarantineName(),
+): ExactRemovalOutcome {
 	let result: NativeExactUnlinkResult;
 	try {
 		result = nativeSessionStateLock().exactUnlink(file, {
@@ -558,7 +576,7 @@ function exactUnlinkOwnerRecord(file: string, identity: LockOwnerSnapshot): Exac
 			size: identity.size,
 			mtimeNs: identity.mtimeNs,
 			sha256: identity.sha256,
-			quarantineName: lockQuarantineName(),
+			quarantineName,
 		});
 	} catch (error) {
 		throw new SessionStateLockUnavailableError(error);
@@ -907,6 +925,7 @@ async function reclaimStaleOwnerRecord(
 		afterInspection?: (file: string) => void | Promise<void>;
 		beforeRemoval?: (file: string) => void | Promise<void>;
 	},
+	quarantineName?: string,
 ): Promise<void> {
 	const snapshot = await captureRegularLockOwner(file);
 	if (!snapshot) return;
@@ -925,10 +944,29 @@ async function reclaimStaleOwnerRecord(
 	const current = await captureRegularLockOwner(file);
 	if (!current || !sameLockOwnerSnapshot(current, snapshot)) return;
 	await hooks.beforeRemoval?.(file);
-	const outcome = exactUnlinkOwnerRecord(file, current);
+	const reserved = quarantineName ?? lockQuarantineName();
+	await removeVerifiedEmptyQuarantine(path.dirname(file), reserved);
+	const outcome = exactUnlinkOwnerRecord(file, current, reserved);
 	// A successor that took the path in the final window keeps it; this call just loses.
 	if (outcome === "refused")
 		throw new SessionStateLockUnavailableError(new Error("Stale owner record could not be reclaimed."));
+}
+
+/** Verified empty leftover at a reserved quarantine name is incomplete debris, not in-progress cleanup. */
+export async function removeVerifiedEmptyQuarantine(directory: string, name: string): Promise<void> {
+	if (!name.startsWith(".gjc-delete-") || name.includes("/") || name.includes("\0")) return;
+	const target = path.join(directory, name);
+	let stat: fsSync.Stats;
+	try {
+		stat = await fs.lstat(target);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+		throw error;
+	}
+	if (stat.isSymbolicLink() || !stat.isFile() || stat.size !== 0 || stat.nlink !== 1) return;
+	await fs.unlink(target).catch(error => {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	});
 }
 
 async function releaseTransitionClaim(
@@ -1014,14 +1052,18 @@ async function withLockPathTransition<T>(lockFile: string, transition: () => Pro
  * window, and the identity-bound delete keeps a BASE writer — which takes no claim and
  * just creates the pathname — from having its brand-new lock unlinked.
  */
-async function reclaimStaleRegularLock(lockFile: string): Promise<void> {
+async function reclaimStaleRegularLock(lockFile: string, quarantineName?: string): Promise<void> {
 	await withLockPathTransition(
 		lockFile,
 		async () =>
-			await reclaimStaleOwnerRecord(lockFile, {
-				afterInspection: SessionStateLockTestHooks.afterStaleInspection,
-				beforeRemoval: SessionStateLockTestHooks.beforeStaleRemoval,
-			}),
+			await reclaimStaleOwnerRecord(
+				lockFile,
+				{
+					afterInspection: SessionStateLockTestHooks.afterStaleInspection,
+					beforeRemoval: SessionStateLockTestHooks.beforeStaleRemoval,
+				},
+				quarantineName,
+			),
 	);
 }
 
@@ -1161,7 +1203,7 @@ async function reclaimStaleDirectoryLock(lockFile: string): Promise<void> {
  * @internal exported as the seam these decisions are tested through: a live legacy
  * directory owner must be provably left alone without waiting out a real stale window.
  */
-export async function reclaimStaleSessionStateLock(lockFile: string): Promise<void> {
+export async function reclaimStaleSessionStateLock(lockFile: string, quarantineName?: string): Promise<void> {
 	let stat: fsSync.Stats;
 	try {
 		stat = await fs.lstat(lockFile);
@@ -1178,7 +1220,7 @@ export async function reclaimStaleSessionStateLock(lockFile: string): Promise<vo
 	// path is refused outright rather than inspected or removed.
 	if (!stat.isFile()) throw new SessionStateLockUnavailableError();
 	await SessionStateLockTestHooks.afterLockTypeDecision?.(lockFile);
-	await reclaimStaleRegularLock(lockFile);
+	await reclaimStaleRegularLock(lockFile, quarantineName);
 }
 
 /**
@@ -1193,6 +1235,7 @@ export async function withSessionStateFileLock<T>(stateFile: string, operation: 
 	const lockFile = `${stateFile}.lock`;
 	const owner = await newLockOwner();
 	await fs.mkdir(path.dirname(stateFile), { recursive: true });
+	const cycleQuarantine = lockQuarantineName();
 	for (let attempt = 0; attempt < LOCK_ACQUIRE_ATTEMPTS; attempt++) {
 		let held: LockOwnerSnapshot | undefined;
 		try {
@@ -1235,7 +1278,7 @@ export async function withSessionStateFileLock<T>(stateFile: string, operation: 
 				throw error instanceof SessionStateLockUnavailableError
 					? error
 					: new SessionStateLockUnavailableError(error);
-			await reclaimStaleSessionStateLock(lockFile);
+			await reclaimStaleSessionStateLock(lockFile, cycleQuarantine);
 			await Bun.sleep(LOCK_ACQUIRE_RETRY_MS);
 		}
 	}

--- a/packages/coding-agent/src/sdk/acp/adapter.ts
+++ b/packages/coding-agent/src/sdk/acp/adapter.ts
@@ -132,7 +132,8 @@ function isLifecycleOperation(operation: string): boolean {
 		operation === "session.fork" ||
 		operation === "session.resume" ||
 		operation === "session.close" ||
-		operation === "session.delete"
+		operation === "session.delete" ||
+		operation === "session.reconcile_uncertain"
 	);
 }
 

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -207,6 +207,7 @@ const LIFECYCLE_OPERATIONS = new Set([
 	"session.resume",
 	"session.close",
 	"session.delete",
+	"session.reconcile_uncertain",
 ]);
 
 /** Bootstrap signing material and its public candidate id authorize a launch but are not lifecycle request identity. */
@@ -307,7 +308,8 @@ function normalizeBrokerInput(operation: string, input: Record<string, unknown>)
 		operation !== "session.fork" &&
 		operation !== "session.resume" &&
 		operation !== "session.close" &&
-		operation !== "session.delete"
+		operation !== "session.delete" &&
+		operation !== "session.reconcile_uncertain"
 	)
 		return { input: normalized };
 
@@ -469,6 +471,7 @@ function lifecycleTarget(operation: string, input: Record<string, unknown>): unk
 		case "session.resume":
 		case "session.close":
 		case "session.delete":
+		case "session.reconcile_uncertain":
 			return { sessionId: id };
 		default:
 			return { operation, root, sessionId: id };

--- a/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle-ledger.ts
@@ -907,6 +907,14 @@ export class LifecycleLedger {
 		return this.#byIdentity.get(identity);
 	}
 
+	listUncertainCreatesBySessionId(sessionId: string): LifecycleLedgerEntry[] {
+		const matches: LifecycleLedgerEntry[] = [];
+		for (const current of this.#byIdentity.values()) {
+			if (current.state === "terminal_uncertain" && current.intendedSessionId === sessionId) matches.push(current);
+		}
+		return matches;
+	}
+
 	findPendingCleanupByTarget(
 		sessionId: string,
 		cwd: string,

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -5262,6 +5262,89 @@ async function executeLifecycleResponse(
 		if (record) await appendSessionDeletedEvidence(broker, record);
 		return completion;
 	}
+	if (operation === "session.reconcile_uncertain") {
+		const id = sessionId(input);
+		if (!id) return fail("invalid_input", "sessionId is required.");
+		if (!isCanonicalSessionId(id)) return fail("invalid_input", "sessionId must be a canonical safe identifier.");
+		await broker.index.refresh();
+		const record = broker.index.listSessions().sessions.find(session => session.sessionId === id);
+		if (!record) return fail("not_found", "session is not indexed");
+		if (record.terminalUncertain !== true)
+			return fail("invalid_input", "session.reconcile_uncertain only accepts terminalUncertain index rows.");
+		if (record.live) return fail("live_session", "Session host is still live.");
+		const incarnation = record.hostIncarnation ?? record.processIncarnation;
+		if (observeProcess(record.pid, incarnation) === "alive")
+			return fail("live_session", "Session host incarnation is still alive.");
+		if (observeProcess(record.pid, incarnation) === "uncertain" && !hasObservedProcessExit(record.pid))
+			return fail("terminal_uncertain", "Session host liveness could not be proven.");
+		const matches = broker.ledger.listUncertainCreatesBySessionId(id);
+		if (matches.length === 0) return fail("not_found", "No terminal_uncertain create identity matches this session.");
+		if (matches.length !== 1)
+			return fail("terminal_uncertain", "Multiple terminal_uncertain create identities match this session.");
+		const create = matches[0]!;
+		const root = record.locator.stateRoot;
+		const marker = lifecycleMarkerPath(root, id);
+		const ready = lifecycleReadyPath(root, id);
+		for (const candidate of [marker, ready]) {
+			let stat: fsSync.BigIntStats;
+			try {
+				stat = await fs.lstat(candidate, { bigint: true });
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+				return fail("terminal_uncertain", "Lifecycle leftover path could not be inspected safely.");
+			}
+			if (stat.isSymbolicLink() || !stat.isFile() || stat.nlink !== 1n)
+				return fail("terminal_uncertain", "Lifecycle leftover is not a regular unshared file.");
+			let parsed: { pid?: unknown; incarnation?: unknown; effectMarker?: unknown };
+			try {
+				parsed = JSON.parse(await fs.readFile(candidate, "utf8")) as {
+					pid?: unknown;
+					incarnation?: unknown;
+					effectMarker?: unknown;
+				};
+			} catch {
+				return fail("terminal_uncertain", "Lifecycle leftover is not valid JSON.");
+			}
+			if (parsed.pid !== record.pid)
+				return fail("terminal_uncertain", "Lifecycle leftover pid does not match the indexed host.");
+			const leftoverIncarnation =
+				typeof parsed.incarnation === "string" ? parsed.incarnation : undefined;
+			if (leftoverIncarnation && incarnation && leftoverIncarnation !== incarnation)
+				return fail("terminal_uncertain", "Lifecycle leftover incarnation does not match the indexed host.");
+			if (observeProcess(record.pid, leftoverIncarnation ?? incarnation) === "alive")
+				return fail("live_session", "Lifecycle leftover still names a live host.");
+			await fs.unlink(candidate);
+			try {
+				await fs.lstat(candidate);
+				return fail("terminal_uncertain", "Lifecycle leftover remained after unlink.");
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ENOENT")
+					return fail("terminal_uncertain", "Lifecycle leftover unlink could not be verified.");
+			}
+		}
+		await broker.ledger.transition(create.identity, "terminal_error", {
+			intendedSessionId: id,
+			response: fail(
+				"terminal_uncertain",
+				"Uncertain create retired after dead-host and absent-marker proof.",
+			),
+		});
+		await broker.index.append({
+			type: "session_closed",
+			sessionId: id,
+			locator: record.locator,
+			endpointGeneration: record.endpointGeneration,
+			pid: record.pid,
+			...(record.processIncarnation === undefined ? {} : { processIncarnation: record.processIncarnation }),
+			...(record.hostIncarnation === undefined ? {} : { hostIncarnation: record.hostIncarnation }),
+			...(record.endpointMtimeMs === undefined ? {} : { endpointMtimeMs: record.endpointMtimeMs }),
+			...(record.lifecycleRequestId === undefined ? {} : { lifecycleRequestId: record.lifecycleRequestId }),
+		});
+		return {
+			ok: true,
+			result: { sessionId: id, retired: true, ledgerState: "terminal_error", indexType: "session_closed" },
+		};
+	}
 	return fail("invalid_input", "Unknown lifecycle operation.");
 }
 

--- a/packages/coding-agent/src/sdk/broker/transport.ts
+++ b/packages/coding-agent/src/sdk/broker/transport.ts
@@ -14,6 +14,7 @@ const BROKER_OPERATIONS = new Set([
 	"session.resume",
 	"session.close",
 	"session.delete",
+	"session.reconcile_uncertain",
 	"broker.shutdown",
 	"session.control",
 	"broker.lookup_lifecycle",

--- a/packages/coding-agent/src/sdk/cli/session-cli.ts
+++ b/packages/coding-agent/src/sdk/cli/session-cli.ts
@@ -209,7 +209,8 @@ function isLifecycleOperation(operation: string): operation is LifecycleMutation
 		operation === "session.fork" ||
 		operation === "session.resume" ||
 		operation === "session.close" ||
-		operation === "session.delete"
+		operation === "session.delete" ||
+		operation === "session.reconcile_uncertain"
 	);
 }
 
@@ -1294,11 +1295,13 @@ function lifecycleMutationRequest(
 			2,
 		);
 	const target = input as JsonRecord & { sessionId: string };
-	return operation === "session.resume"
-		? { ...base, operation, capability: operation, target }
-		: operation === "session.close"
-			? { ...base, operation, capability: operation, target }
-			: { ...base, operation, capability: "session.delete", target };
+	if (
+		operation === "session.resume" ||
+		operation === "session.close" ||
+		operation === "session.reconcile_uncertain"
+	)
+		return { ...base, operation, capability: operation, target };
+	return { ...base, operation, capability: "session.delete", target };
 }
 
 async function runRawGlobal(

--- a/packages/coding-agent/src/sdk/lifecycle/service.ts
+++ b/packages/coding-agent/src/sdk/lifecycle/service.ts
@@ -12,6 +12,7 @@ export type SessionLifecycleOperation =
 	| "session.resume"
 	| "session.close"
 	| "session.delete"
+	| "session.reconcile_uncertain"
 	| "session.list";
 
 export interface SessionLifecycleActor {
@@ -146,6 +147,10 @@ export type SessionForkRequest = SessionLifecycleMutationRequestBase<"session.fo
 export type SessionResumeRequest = SessionLifecycleMutationRequestBase<"session.resume", SessionResumeTarget>;
 export type SessionCloseRequest = SessionLifecycleMutationRequestBase<"session.close", SessionCloseTarget>;
 export type SessionDeleteRequest = SessionLifecycleMutationRequestBase<"session.delete", SessionDeleteTarget>;
+export type SessionReconcileUncertainRequest = SessionLifecycleMutationRequestBase<
+	"session.reconcile_uncertain",
+	SessionCloseTarget
+>;
 export interface SessionListRequest {
 	readonly operation: "session.list";
 	readonly actor: SessionLifecycleActor;
@@ -161,7 +166,8 @@ export type SessionLifecycleMutationRequest =
 	| SessionForkRequest
 	| SessionResumeRequest
 	| SessionCloseRequest
-	| SessionDeleteRequest;
+	| SessionDeleteRequest
+	| SessionReconcileUncertainRequest;
 
 export type SessionLifecycleCertainty = "terminal" | "retryable" | "cleanup_pending" | "uncertain";
 
@@ -338,6 +344,7 @@ function operationOf(value: unknown): SessionLifecycleOperation {
 		value === "session.resume" ||
 		value === "session.close" ||
 		value === "session.delete" ||
+		value === "session.reconcile_uncertain" ||
 		value === "session.list"
 	)
 		return value;
@@ -619,7 +626,10 @@ export class SessionLifecycleService {
 		if (!isRecord(response) || response.ok !== true)
 			return failure(operation, "uncertain", "malformed_response", "lifecycle broker returned a malformed response");
 		const expectedSessionId =
-			operation === "session.resume" || operation === "session.close" || operation === "session.delete"
+			operation === "session.resume" ||
+			operation === "session.close" ||
+			operation === "session.delete" ||
+			operation === "session.reconcile_uncertain"
 				? typeof target.sessionId === "string"
 					? target.sessionId
 					: undefined

--- a/packages/coding-agent/src/sdk/mcp/server.ts
+++ b/packages/coding-agent/src/sdk/mcp/server.ts
@@ -158,7 +158,8 @@ function isLifecycleOperation(operation: string): operation is LifecycleMutation
 		operation === "session.fork" ||
 		operation === "session.resume" ||
 		operation === "session.close" ||
-		operation === "session.delete"
+		operation === "session.delete" ||
+		operation === "session.reconcile_uncertain"
 	);
 }
 

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -1080,6 +1080,24 @@
 		]
 	},
 	{
+		"sourceId": "registry:G08",
+		"sourceFile": "packages/coding-agent/src/sdk/protocol/operation-registry.ts",
+		"sourceKind": "registry",
+		"decision": "include",
+		"sdkId": "session.reconcile_uncertain",
+		"adapterMappings": {
+			"telegram": "generic_safe",
+			"discord": "generic_safe",
+			"slack": "generic_safe",
+			"mcp": "generic_safe",
+			"acp": "generic_safe",
+			"daemonCli": "generic_safe"
+		},
+		"testIds": [
+			"packages/coding-agent/test/sdk-operation-inventory.test.ts"
+		]
+	},
+	{
 		"sourceId": "registry:Q01",
 		"sourceFile": "packages/coding-agent/src/sdk/protocol/operation-registry.ts",
 		"sourceKind": "registry",

--- a/packages/coding-agent/src/sdk/protocol/operation-registry.ts
+++ b/packages/coding-agent/src/sdk/protocol/operation-registry.ts
@@ -135,6 +135,7 @@ const globals = [
 	["session.resume", "Resume a saved session."],
 	["session.close", "Close a saved session."],
 	["session.delete", "Delete a saved session."],
+	["session.reconcile_uncertain", "Retire an indexed terminalUncertain create effect after dead-host proof."],
 ] as const;
 
 const queries = [

--- a/packages/coding-agent/test/empty-delete-receipt-latch.test.ts
+++ b/packages/coding-agent/test/empty-delete-receipt-latch.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { COORDINATOR_JSON_SCAN_CAP, listCoordinatorJsonFiles } from "../src/coordinator-mcp/projection-scan";
+import { collectEmptyDeleteReceipts, runEmptyDeleteGc } from "../src/gjc-runtime/empty-delete-gc";
+import { runGjcGcCommand } from "../src/gjc-runtime/gc-runtime";
+import {
+	reclaimStaleSessionStateLock,
+	removeVerifiedEmptyQuarantine,
+	SessionStateLockTestHooks,
+} from "../src/gjc-runtime/session-state-lock";
+import {
+	GJC_COORDINATOR_SESSION_STATE_FILE_ENV,
+	persistCoordinatorRuntimeStateFromEvent,
+} from "../src/gjc-runtime/session-state-sidecar";
+import { installExactIdentityNatives } from "./helpers/exact-identity-natives";
+
+const tempDirs: string[] = [];
+installExactIdentityNatives();
+
+afterEach(async () => {
+	SessionStateLockTestHooks.quarantineMints = undefined;
+	SessionStateLockTestHooks.lastQuarantineName = undefined;
+	SessionStateLockTestHooks.forcedQuarantineName = undefined;
+	SessionStateLockTestHooks.probeProcessSignal = undefined;
+	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+async function tempRoot(prefix: string): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+describe("empty .gjc-delete-* latch", () => {
+	it("Test 1: planted 0-byte .gjc-delete-* is never opened or parsed", async () => {
+		const dir = await tempRoot("gjc-scan-");
+		const live = path.join(dir, "live.json");
+		const debris = path.join(dir, ".gjc-delete-session-state-lock-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.json");
+		await fs.writeFile(live, JSON.stringify({ session_id: "live", state: "ready_for_input" }));
+		await fs.writeFile(debris, "");
+		const opened: string[] = [];
+		const io = {
+			readdir: (target: string) => fs.readdir(target),
+			lstat: (file: string) => fs.lstat(file),
+			readFile: async (file: string, encoding: "utf8") => {
+				opened.push(file);
+				return fs.readFile(file, encoding);
+			},
+		};
+		const scan = await listCoordinatorJsonFiles(dir, io);
+		expect(scan.values).toHaveLength(1);
+		expect((scan.values[0] as { session_id: string }).session_id).toBe("live");
+		expect(opened.every(file => !file.includes(".gjc-delete-"))).toBe(true);
+		expect(scan.skippedDebris).toBeGreaterThan(0);
+	});
+
+	it("Test 1 over-cap: debris pile + few valid records succeeds without unreadable", async () => {
+		const dir = await tempRoot("gjc-cap-");
+		await fs.writeFile(path.join(dir, "a.json"), JSON.stringify({ session_id: "a" }));
+		await fs.writeFile(path.join(dir, "b.json"), JSON.stringify({ session_id: "b" }));
+		for (let i = 0; i < COORDINATOR_JSON_SCAN_CAP + 5; i++) {
+			await fs.writeFile(path.join(dir, `.gjc-delete-session-state-lock-${i}.json`), "");
+		}
+		const scan = await listCoordinatorJsonFiles(dir);
+		expect(scan.capped).toBe(false);
+		expect(scan.values).toHaveLength(2);
+	});
+
+	it("Test 1 post-filter cap: zero-byte canonical JSON does not consume the parse cap", async () => {
+		const dir = await tempRoot("gjc-postcap-");
+		await fs.writeFile(path.join(dir, "live.json"), JSON.stringify({ session_id: "live" }));
+		for (let i = 0; i < 12; i++) {
+			await fs.writeFile(path.join(dir, `empty-${i}.json`), "");
+		}
+		const scan = await listCoordinatorJsonFiles(dir, undefined, 10);
+		expect(scan.capped).toBe(false);
+		expect(scan.values).toHaveLength(1);
+		expect(scan.skippedEmpty).toBe(12);
+	});
+
+	it("Test 2: leftover empty at reserved name is removed before exchange", async () => {
+		const dir = await tempRoot("gjc-mint-");
+		const reserved = ".gjc-delete-session-state-lock-fixed.json";
+		await fs.writeFile(path.join(dir, reserved), "");
+		await removeVerifiedEmptyQuarantine(dir, reserved);
+		expect(await fs.stat(path.join(dir, reserved)).then(() => "present", () => "gone")).toBe("gone");
+		await fs.writeFile(path.join(dir, reserved), "body");
+		await removeVerifiedEmptyQuarantine(dir, reserved);
+		expect(await fs.readFile(path.join(dir, reserved), "utf8")).toBe("body");
+	});
+
+	it("Test 2b: stale reclaim does not refuse a planted leftover at forced quarantine name", async () => {
+		const dir = await tempRoot("gjc-reclaim-");
+		const stateFile = path.join(dir, "session.json");
+		const lockFile = `${stateFile}.lock`;
+		const reserved = ".gjc-delete-session-state-lock-forced.json";
+		await fs.writeFile(stateFile, JSON.stringify({ state: "running" }));
+		await fs.writeFile(path.join(dir, reserved), "");
+		await fs.writeFile(
+			lockFile,
+			JSON.stringify({
+				pid: 2 ** 22 - 1,
+				start_time: "unknown",
+				token: "dead",
+				owner_host_id: "local-host",
+			}),
+		);
+		SessionStateLockTestHooks.ownerHostId = () => "local-host";
+		SessionStateLockTestHooks.unqualifiedOwnerIsLocal = true;
+		SessionStateLockTestHooks.probeProcessSignal = () => {
+			throw Object.assign(new Error("missing"), { code: "ESRCH" });
+		};
+		SessionStateLockTestHooks.forcedQuarantineName = reserved;
+		await expect(reclaimStaleSessionStateLock(lockFile)).resolves.toBeUndefined();
+		expect(await fs.stat(lockFile).then(() => "present", () => "gone")).toBe("gone");
+	});
+
+	it("Test 3: turn-start persist then next lock cycle can rewrite off running", async () => {
+		const dir = await tempRoot("gjc-running-");
+		const stateFile = path.join(dir, "runtime-state.json");
+		process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV] = stateFile;
+		await persistCoordinatorRuntimeStateFromEvent(
+			{ type: "turn_start" },
+			{ sessionId: "sid", cwd: dir, sessionFile: null },
+		);
+		const first = JSON.parse(await fs.readFile(stateFile, "utf8")) as { state: string };
+		expect(first.state).toBe("running");
+		await persistCoordinatorRuntimeStateFromEvent(
+			{ type: "agent_end", messages: [] },
+			{ sessionId: "sid", cwd: dir, sessionFile: null },
+		);
+		const second = JSON.parse(await fs.readFile(stateFile, "utf8")) as { state: string };
+		expect(second.state).not.toBe("running");
+		delete process.env[GJC_COORDINATOR_SESSION_STATE_FILE_ENV];
+	});
+
+	it("Test 4: gc operands keep non-empty/symlink/missing-root and prune only empty prefix", async () => {
+		const root = await tempRoot("gjc-gc-root-");
+		const empty = path.join(root, ".gjc-delete-session-state-lock-dead.json");
+		const live = path.join(root, "live.json");
+		const other = path.join(root, ".gjc-delete-session-state-lock-full.json");
+		await fs.writeFile(empty, "");
+		await fs.writeFile(live, "{}");
+		await fs.writeFile(other, "not-empty");
+		const missing = path.join(root, "no-such-root");
+		const dry = await runEmptyDeleteGc({ roots: [root, missing], prune: false });
+		expect(dry.would_remove).toBe(1);
+		expect(dry.records.some(r => r.reason === "missing_root")).toBe(true);
+		expect(dry.records.some(r => r.reason === "non_empty")).toBe(true);
+		const pruned = await runEmptyDeleteGc({ roots: [root], prune: true });
+		expect(pruned.removed).toBe(1);
+		await expect(fs.stat(empty)).rejects.toMatchObject({ code: "ENOENT" });
+		expect(await fs.readFile(other, "utf8")).toBe("not-empty");
+		expect(await fs.readFile(live, "utf8")).toBe("{}");
+	});
+
+	it("Test 4b: gc keeps symlink root and identity-drifted empty replacement", async () => {
+		const root = await tempRoot("gjc-gc-id-");
+		const linked = path.join(root, "linked-root");
+		await fs.symlink(root, linked);
+		const viaLink = await runEmptyDeleteGc({ roots: [linked], prune: false });
+		expect(viaLink.records.some(r => r.reason === "symlink_root")).toBe(true);
+		const empty = path.join(root, ".gjc-delete-session-state-lock-swap.json");
+		await fs.writeFile(empty, "");
+		const collected = await collectEmptyDeleteReceipts(root);
+		expect(collected.find(r => r.path === empty)?.identity).toBeDefined();
+		await fs.unlink(empty);
+		await fs.writeFile(empty, "");
+		const pruned = await runEmptyDeleteGc({ roots: [root], prune: true });
+		const row = pruned.records.find(r => r.path === empty);
+		expect(row).toBeDefined();
+		if (row?.reason === "identity_drift") {
+			expect(await fs.readFile(empty, "utf8")).toBe("");
+		}
+	});
+
+	it("Test 4 CLI: empty-delete-receipts requires operand", async () => {
+		const result = await runGjcGcCommand(["--empty-delete-receipts", "--json"], "/tmp", process.env, []);
+		expect(result.status).toBe(2);
+		expect(result.stderr).toContain("empty_delete_receipts_requires_root_or_manifest");
+	});
+
+	it("Test 5: atomic write leaves no 0-byte canonical on crash-before-rename", async () => {
+		const { writeCoordinatorAtomic } = await import("../src/coordinator-mcp/durability");
+		const dir = await tempRoot("gjc-atomic-");
+		const file = path.join(dir, "canonical.json");
+		await writeCoordinatorAtomic(file, '{"ok":true}\n');
+		expect(await fs.readFile(file, "utf8")).toBe('{"ok":true}\n');
+		await expect(
+			writeCoordinatorAtomic(file, '{"next":true}\n', {
+				rename: async () => {
+					throw new Error("injected_rename_fault");
+				},
+			}),
+		).rejects.toThrow("injected_rename_fault");
+		expect(await fs.readFile(file, "utf8")).toBe('{"ok":true}\n');
+		const leftovers = (await fs.readdir(dir)).filter(name => name.endsWith(".tmp"));
+		expect(leftovers).toEqual([]);
+	});
+});


### PR DESCRIPTION
## What

Adds official `gjc sdk session raw global --op session.reconcile_uncertain` for indexed `terminalUncertain` **create** leftovers after dead-host + leftover-marker proof. `session.close` / `session.delete` still refuse uncertain ownership.

Also ships `scripts/seal-uncertain-create-intent.ts` to seal stranded coordinator `gjc_coordinator_start_session` `in_progress` projections to `completed` + `ok:false retired:true`.

## Why

#4950. Two Hermes starts left sessions `terminal_uncertain` and coordinator idempotency `in_progress`. No official retirement existed; another start would mint a third uncertain session.

Live prove (this host, after Hermes-broker-only restart onto the patched ELF): both leftover sids retired; one wrapper start bound `e43ff722-…` / `turn-72075776-…`.

Stacks on the empty-delete latch fix (#4948) because this checkout already contains that commit.

## Risk classification

- [ ] `low-risk`
- [x] `regression-risk`
- [ ] `high-risk`

New lifecycle global; close/delete unchanged.

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:pending reviewer:human reviewer-id:maintainer evidence:live reconcile + one bound wrapper start
```

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated
- [ ] Verdict digest will be filled after push
- [x] Risk classification matches review path