### PR TITLE
docs(readme): sync Korean and Japanese translations

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -28,7 +28,8 @@
   <a href="#スマホで答える">スマホ</a> ·
   <a href="#変更の前に計画">ワークフロー</a> ·
   <a href="#トークンを節約">トークン節約</a> ·
-  <a href="#openclaw--hermes-に-gjc-を操縦させる">コントローラ</a> ·
+  <a href="#openclaw--hermes--grokbot--自分の-bot-に-gjc-を動かさせる">コントローラ</a> ·
+  <a href="#paseoorcat3-code-の中で-gjc-を動かす">エージェントシェル</a> ·
   <a href="#ドキュメント">ドキュメント</a>
 </p>
 
@@ -65,7 +66,11 @@ sh gjc-install.sh
 gjc
 ```
 
-`main` をパイプすると可変のインストーラが実行されます。最新インストーラが必要なときだけ使ってください。
+`main` をパイプすると可変のインストーラが実行されます。最新インストーラが必要なときだけ使ってください:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts/install.sh | sh
+```
 
 Windows（PowerShell、タグ固定）:
 
@@ -182,6 +187,24 @@ deep-interview -> ralplan -> ultragoal
 
 オプトインで利用可能: **`computer-use`**（実験的なデスクトップ制御）。[Python REPL](docs/python-repl.md) と [docs/tools/computer.md](docs/tools/computer.md) を参照。
 
+## カスタムスキル
+
+GJC はカスタムスキルに Claude Code / Codex のファイル規約を採用しています。文書化された場所に `SKILL.md` を置くだけで、**設定なしに**通常のセッションから検出できます:
+
+```sh
+# プロジェクトローカル（以下のどれでも可）:
+cp -r my-skill .gjc/skills/          # または .claude/skills/ または .codex/skills/
+
+# すべてのプロジェクトで使えるユーザー全体の場所:
+mkdir -p ~/.gjc/agent/skills && cp -r my-skill ~/.gjc/agent/skills/
+```
+
+セッションで `/skill:my-skill` として呼び出します。スコープの信頼は `skills.trustProjectSkills` / `skills.trustUserSkills` で明示され（どちらもデフォルトで有効）、`skills.enabled` がマスタースイッチです。検出可能な項目は `gjc skills discover` で確認できます。上記の同梱ワークフロースキル 4 つはディスク上のスキルで置き換えられません。場所、優先順位、診断については [docs/skills.md](docs/skills.md) を参照してください。
+
+## デフォルトテーマ
+
+デフォルトのダーク TUI アイデンティティは GJC red-claw テーマで、ライト外観のターミナルは同梱の blue-crab テーマがデフォルトです。明示的なテーマ設定が常に優先されます。
+
 ---
 
 ## トークンを節約
@@ -195,57 +218,138 @@ GJC はトークン請求の両側を最適化します:
 
 ---
 
-## OpenClaw / Hermes に GJC を操縦させる
+デフォルトのダーク TUI アイデンティティは GJC red-claw テーマで、ライト外観のターミナルは同梱の blue-crab テーマがデフォルトです。カタログ全体と `theme.dark` / `theme.light` の設定は [docs/theme.md](docs/theme.md) を参照してください。
 
-GJC はネイティブの Coordinator MCP ブリッジを同梱しており、OpenClaw や Hermes のような外部コントローラが durable turn を通じて本物の GJC セッションをオーケストレーションします — ターミナルスクレイピングは一切なし。
+## OpenClaw / Hermes / Grokbot / 自分の bot に GJC を動かさせる
 
-ガイドを読む必要はありません — このプロンプトを OpenClaw/Hermes コントローラに貼り付ければ、自分で配線します:
+OpenClaw、Hermes、Grokbot、Discord bot、cron スクリプトなど、どのような外部コントローラでも、ブローカーにバインドされた **SDK session CLI** と同梱の
+[`sdk-skills/`](https://github.com/Yeachan-Heo/gajae-code/tree/main/sdk-skills) 手順
+（`gjc-sdk-discover` · `gjc-sdk-operate` · `gjc-sdk-author`）を通じて本物の GJC セッションを動かせます。永続的な turn と資格情報を含まない JSON を使い、ターミナルスクレイピングは行いません。
+
+ガイドを読む必要はありません。次のプロンプトをコントローラに貼り付ければ、自分で接続を構成します:
 
 <details>
-<summary><strong>コピペ用コントローラセットアッププロンプト</strong></summary>
+<summary><strong>コピペ用コントローラ設定プロンプト</strong></summary>
 
 ```text
-Set up Gajae-Code (gjc) as your coding-agent backend on this machine. gjc is already installed.
+Use Gajae-Code (gjc) as your coding-agent backend on this machine. gjc is already installed.
+Your interface is the broker-bound SDK session CLI. Never scrape terminal output, never read
+endpoint records or credentials under .gjc/state/sdk, never open a raw session WebSocket.
 
-1. Render and install the coordinator MCP setup package (replace the paths):
-   gjc setup hermes --root <ABS_REPO_PATH> --profile <PROFILE_NAME> --repo <REPO_NAME> \
-     --mutation sessions,questions,reports --profile-dir <YOUR_PROFILE_DIR> --install
-   Without --install the command is render-only; re-run with --install to write files.
+1. Load the shipped procedures before acting. Read these skill files from the gjc checkout or
+   from https://github.com/Yeachan-Heo/gajae-code/tree/main/sdk-skills (bundle root
+   `sdk-skills/`, manifest.json formatVersion 1 — if it is missing, malformed, or a different
+   version, stop and report instead of guessing):
+     sdk-skills/gjc-sdk-discover/SKILL.md   -- find and inspect sessions
+     sdk-skills/gjc-sdk-operate/SKILL.md    -- the allowlisted control/lifecycle operations
+     sdk-skills/gjc-sdk-author/SKILL.md     -- TypeScript/Python templates for scripted flows
+   Follow their allowlists exactly. Pass every value as an argv item, never as a shell string.
 
-2. Verify the contract (non-mutating, no LLM call). Both must report ok:
-   gjc setup hermes --root <ABS_REPO_PATH> --smoke
-   gjc mcp-serve coordinator --check --json
+2. Prove the surface works (read-only). Run from inside the target repository:
+     gjc --version
+     gjc sdk session list
+   `list` returns a credential-free JSON DTO of indexed sessions. Fail closed on missing,
+   unavailable, stale, dead, unknown, or ambiguous rows. Exit 2 = usage error, exit 1 =
+   operational failure (broker unavailable, session unavailable, retention gap, wait timeout).
 
-3. Register the MCP server from the installed config. It is equivalent to:
-   command: gjc, args: ["mcp-serve", "coordinator"]
-   env: GJC_COORDINATOR_MCP_WORKDIR_ROOTS=<ABS_REPO_PATH>,
-        GJC_COORDINATOR_MCP_PROFILE=<PROFILE_NAME>,
-        GJC_COORDINATOR_MCP_REPO=<REPO_NAME>,
-        GJC_COORDINATOR_MCP_SESSION_COMMAND="gjc --worktree",
-        GJC_COORDINATOR_MCP_MUTATIONS=sessions,questions,reports
+3. Understand a session before touching it:
+     gjc sdk session inspect <sessionId>
+     gjc sdk session raw query <sessionId> --query session.metadata
+     ... then context.get, goal.list, todo.list, workflow.gates.list, session.stats
+   These reads are not an atomic snapshot: label every reported field confirmed / inferred /
+   stale / unavailable / unknown. Never invent a missing value.
 
-4. To delegate coding work, prefer one call per workflow:
-   gjc_delegate_plan / gjc_delegate_execute
-   with { cwd, task, allow_mutation: true, idempotency_key: <fresh-uuid> }.
-   Each starts an isolated worktree session and returns a durable turn_id and artifacts.
+4. Start work in an isolated session:
+     gjc sdk session raw global --op session.create \
+       --idempotency-key <fresh-uuid> --json-input '{"cwd":"/abs/path/to/repo"}'
+   Lifecycle ops allowed: session.create, session.fork, session.resume, session.close.
+   session.delete is NOT allowed. session.get_endpoint is refused unconditionally.
 
-5. For finer control: gjc_coordinator_start_session -> gjc_coordinator_send_prompt ->
-   poll gjc_coordinator_read_turn or bounded gjc_coordinator_await_turn ->
-   answer gjc_coordinator_list_questions rows via gjc_coordinator_submit_question_answer ->
-   close with gjc_coordinator_report_status.
+5. Drive a turn and reconcile it:
+     gjc sdk session send <sessionId> --text "<task>" --op-ref <fresh-ulid>
+     gjc sdk session status <sessionId> <opRef>        # lossless turn.result lookup
+     gjc sdk session tail <sessionId> --until-idle     # replay + live follow
+   Use `send --wait --timeout-ms <ms>` for a bounded wait; a wait window that elapses reports
+   wait_timeout and never cancels the running turn. One fresh op-ref per logical prompt --
+   `unknown` means uncertainty, never proof of non-execution, so reconcile with `status`
+   instead of replaying a prompt.
 
-Rules: every mutating call needs allow_mutation: true plus a fresh idempotency_key.
-Treat durable turn state as authoritative; never scrape terminal output.
-The session command selector accepts only "gjc" or "gjc --worktree [name]".
+6. Answer what the agent asks you:
+     gjc sdk session raw control <sessionId> --op ask.answer --json-input '{...}'
+     gjc sdk session raw control <sessionId> --op workflow.gate_answer --json-input '{...}'
+   For gate answers use the durable workflow gate ID plus expectedSessionId; a transient
+   action_needed.id is never durable authority. Other allowed per-session controls:
+   turn.prompt, turn.steer, turn.follow_up, todo.replace, session.switch, session.rename.
+
+7. Show the human the exact operation and target before any mutating call, and treat the
+   approval as single-use: if the operation, input, or target changes, ask again.
 ```
 
 </details>
 
-ライブセッション 1 つを直接操作するコントローラ向けに、各セッションはループバックの **SDK WebSocket** エンドポイント、`gjc sdk session` CLI（`list|inspect|send|status|tail`）、同梱の `sdk-skills/`（`gjc-sdk-discover` · `gjc-sdk-operate` · `gjc-sdk-author`）も公開します — コントローラ上のどんなエージェントでも従える、レビュー済みで承認ゲート付きの手順です。
+長いプロンプトを残したままにしても安全です。SDK プロンプトのデッドラインは進捗を反映する無操作リース
+（`sdk.promptDeadlineMs`、デフォルト 30 分）で、`sdk.promptMaxRuntimeMs`（デフォルト 6 時間）により上限が定められます。更新されるのは受理された turn に帰属するツール実行だけであり、ハートビートやストリーミングテキストでは更新されません。
 
-- [外部コントローラ統合ガイド](docs/bot-integration.md) · [Coordinator MCP ブリッジ](docs/hermes-mcp-bridge.md)
-- [外部コントローラ / ボット](docs/bot-integration.md) — プロバイダ非依存スモーク；[`docs/aside-integration.md`](docs/aside-integration.md) はオプトインの検索/コンテキストサイドカーを扱います
-- [SDK とワイヤプロトコル](docs/sdk.md) · [SDK セッション CLI](docs/sdk-session-cli.md) · [外部制御レディネス](docs/external-control-readiness.md)
+1 セッションずつではなく多くのワークツリーへイベント駆動で展開する必要がある場合、ネイティブの
+[Coordinator MCP ブリッジ](docs/hermes-mcp-bridge.md)（`gjc mcp-serve coordinator`、`gjc setup hermes` でインストール）が、その形の委任ツールを提供します。
+
+- [外部コントローラ / bot 統合ガイド](docs/bot-integration.md) — プロバイダ非依存のスモーク。[`docs/aside-integration.md`](docs/aside-integration.md) はオプトインの検索/コンテキストサイドカーを扱います
+- [SDK session CLI](docs/sdk-session-cli.md) · [SDK とワイヤプロトコル](docs/sdk.md) · [SDK アプリガイド](docs/sdk-app-guide.md) · [外部制御レディネス](docs/external-control-readiness.md)
+
+---
+
+## Paseo・Orca・T3 Code の中で GJC を動かす
+
+むき出しのターミナルではなくデスクトップ/モバイルのエージェントシェルを使いたい場合、GJC は代表的な 3 つに接続できます。ただしサポートの水準は率直に異なります。
+
+<table>
+<tr>
+<th width="120">ホスト</th><th width="110">サポート</th><th>利用できること</th><th>設定</th>
+</tr>
+<tr>
+<td align="center">
+  <a href="https://paseo.sh"><img src="https://www.google.com/s2/favicons?domain=paseo.sh&sz=64" width="28" alt="Paseo ロゴ" /><br/><strong>Paseo</strong></a><br/>
+  <sub><a href="https://github.com/getpaseo/paseo">リポジトリ</a></sub>
+</td>
+<td align="center">★★★★★<br/><sub>ファーストクラス</sub></td>
+<td>GJC 自身がインストールするネイティブ ACP プロバイダ。モデルカタログ、Default/Plan モード、thinking レベル、実際の権限プロンプト、所有するサブエージェントも停止できるキャンセル、モバイル制御。</td>
+<td><code>gjc setup paseo</code><br/><sub>その後 <code>paseo daemon restart</code></sub></td>
+</tr>
+<tr>
+<td align="center">
+  <a href="https://onorca.dev"><img src="https://www.google.com/s2/favicons?domain=onorca.dev&sz=64" width="28" alt="Orca ロゴ" /><br/><strong>Orca</strong></a><br/>
+  <sub><a href="https://github.com/stablyai/orca">リポジトリ</a></sub>
+</td>
+<td align="center">★★★★☆<br/><sub>1 フィールドで動作</sub></td>
+<td>GJC はカスタム CLI エージェントとして動作し、セッションごとにワークツリーを分けます。Orca の差分レビュー、ターミナル分割、SSH ワークツリー、モバイルコンパニオンを使えます。使用量追跡とアカウントのホットスワップはまだありません。</td>
+<td><strong>Settings → Agents</strong><br/>コマンドに <code>gjc</code> を追加</td>
+</tr>
+<tr>
+<td align="center">
+  <a href="https://t3.codes"><img src="https://www.google.com/s2/favicons?domain=t3.codes&sz=64" width="28" alt="T3 Code ロゴ" /><br/><strong>T3 Code</strong></a><br/>
+  <sub><a href="https://github.com/pingdotgg/t3code">リポジトリ</a></sub>
+</td>
+<td align="center">★★★☆☆<br/><sub>実験的</sub></td>
+<td>T3 Code は現在 Codex・Claude・Cursor・Grok・OpenCode のハーネスだけを提供しており、GJC ハーネスはまだ upstream にありません。現時点では横に並べて実行し、ネイティブプロバイダは <a href="https://github.com/pingdotgg/t3code/discussions/7290">upstream に提案</a>済みです。</td>
+<td><sub>まだワンコマンドではありません — ガイドを参照</sub></td>
+</tr>
+</table>
+
+Paseo は次をそのまま貼り付けます:
+
+```sh
+gjc setup paseo            # ACP プロバイダエントリを書き込み、バックアップするが、デーモンは決して再起動しない
+paseo daemon restart
+paseo provider ls          # gjc が `available` と表示される必要がある
+paseo run --provider gjc --cwd /path/to/repo "your prompt"
+
+gjc setup paseo --check    # pass / stale / drift。機械可読な --json も利用可能
+gjc setup paseo --remove   # GJC 自身が作成したキーだけをロールバック
+```
+
+Orca は 1 フィールドだけです。GJC をインストールして（[docs/install.md](docs/install.md) を参照）、引数なしのコマンド `gjc` を持つカスタムエージェントを追加します。Orca は権限バイパスフラグを公開するエージェントにそのフラグを事前入力しますが、GJC には設計上そのようなフラグはありません。引数は空のままにして、GJC 自身の承認ゲートを維持してください。
+
+**[統合ガイド全文 → docs/terminal-app-integrations.md](docs/terminal-app-integrations.md)** — ホストごとの設定、検証、キャンセルの意味、トラブルシューティング表、各ホストがまだ到達できない範囲を説明します。
 
 ---
 
@@ -253,9 +357,11 @@ The session command selector accepts only "gjc" or "gjc --worktree [name]".
 
 **[gajae-code.com](https://gajae-code.com)** または `docs/` から:
 
-- [インストールと更新](docs/install.md) · [環境変数](docs/environment-variables.md) · [キーバインド](docs/keybindings.md) · [テーマ](docs/theme.md)
+- [インストールと更新](docs/install.md) · [環境変数](docs/environment-variables.md) · [キーバインド](docs/keybindings.md) · [テーマ](docs/theme.md) · [UI 言語](docs/ui-language.md)
 - [モデルとプロバイダ](docs/models.md) · [カスタムプロバイダとマルチアカウントルーティング](docs/custom-providers-and-multi-account.md) · [マルチベンダープロファイル](docs/multi-vendor-profiles.md) · [Auth ブローカー](docs/auth-broker-gateway.md)
-- [Telegram](docs/telegram-onboarding.md) · [Bot 統合](docs/bot-integration.md) · [SDK](docs/sdk.md) · [SDK セッション CLI](docs/sdk-session-cli.md)
+- [カスタマイズの権限・インポート・信頼](docs/customization.md) · [スキル](docs/skills.md) · [フック](docs/hooks.md) · [スタンドアロン MCP](docs/standalone-mcp.md) · [プラグインバンドル](docs/gjc-plugins.md)
+- [ターミナルアプリ統合: Paseo・Orca・T3 Code](docs/terminal-app-integrations.md)
+- [Telegram](docs/telegram-onboarding.md) · [Bot 統合](docs/bot-integration.md) · [SDK](docs/sdk.md) · [SDK session CLI](docs/sdk-session-cli.md)
 - [セッション](docs/session.md) · [コンパクション](docs/compaction.md) · [メモリ](docs/memory.md) · [シークレット](docs/secrets.md)
 - [コードベース概要](docs/codebase-overview.md) · [コントリビュート / 開発環境](CONTRIBUTING.md)
 - [macOS Option/Alt キー設定（iTerm2）](docs/macos-option-key.md) · [GEO 可視性ベンチマーク](docs/geobench.md)
@@ -264,9 +370,94 @@ The session command selector accepts only "gjc" or "gjc --worktree [name]".
 
 ## SDK 拡張
 
-- [gjc-remote](https://github.com/kogangdon/gjc-remote) — Discord からリモートホスト上の許可リスト済み GJC セッションを制御。
-- [oh-my-gajae-code](https://github.com/devswha/oh-my-gajae-code) — 追加スキルとスラッシュコマンドのコミュニティプラグインマーケットプレイス。
-- [GJC マルチベンダーセットアップガイド](https://github.com/project820/gjc-multivendor-setup-guide) — マルチベンダー構成のためのロールベースのプロバイダプロファイル。
+### ローカルカスタマイズ: `/extensions`
+
+対話セッションでは、`/extensions` が主要なカスタマイズ設定画面です。プロジェクト（`<project>/.gjc/`）とユーザー全体（`~/.gjc/agent/`）のスコープにわたるスキル、フック、MCP を設定し、状態/出所の診断、有効化/無効化/削除、Claude Code/Codex からのガイド付きインポート（正規化プレビュー、明示的な確認、衝突時のスキップ/リネーム/上書きポリシー、ロールバック可能な原子的書き込み）を提供します。非対話的な設定では、MCP サーバーに `gjc mcp`、Claude Code/Codex のインポートに `gjc migrate` を使います。
+
+### スキルの移行と同梱スキルの検査
+
+ワークフローを GJC に移す場合は、インストールまたは上書きする前に同梱のデフォルトを検査してください:
+
+```sh
+gjc skills list
+gjc skills read ralplan
+gjc setup defaults --check
+```
+
+`gjc setup defaults` は同梱の GJC ワークフロースキル 4 つをユーザーの `.gjc` ディレクトリにインストールし、デフォルトでは既存のローカルファイルを保持します。`--check` が欠落または差異のあるファイルを報告したら、まず `gjc skills read <name>` で埋め込みコピーと比較してください。ローカルのデフォルトワークフロースキルファイルを意図して置き換える場合にだけ `gjc setup defaults --force` を使います。
+
+## 既存のエージェントや bot と併用する
+
+| ツールまたは bot | 推奨する GJC コマンド | 境界 |
+| --- | --- | --- |
+| Codex CLI | `gjc --tmux --worktree <name>` または `gjc` | `--worktree` は GJC 管理の隣接ワークツリーに名前を付けます。既存のパスでは先にそこへ `cd` してください。 |
+| Claude Code | `gjc --tmux` または `gjc --tmux --worktree <name>` | GJC は Claude Code の拡張にはなりません。 |
+| OpenCode | `gjc` または `gjc --tmux` | 現時点では外部ランナーのワークフローのみです。 |
+| Claw Code | `gjc --tmux --worktree <name>` | GJC は Claw Code にインストールされたり、置き換えたりしません。 |
+| [Paseo](https://paseo.sh) | `gjc setup paseo` | GJC は自身を ACP プロバイダとして登録し、`--remove` で自身の変更だけを戻します。Paseo 自身の設定ファイルは Paseo が所有します。 |
+| [Orca](https://onorca.dev) | カスタムエージェントコマンドとして `gjc` | Orca は自身のワークツリーターミナルで GJC を起動し、GJC は自身の承認ゲートを維持します。 |
+| [T3 Code](https://t3.codes) | まだなし — 実験的 | upstream に GJC ハーネスはありません（[提案](https://github.com/pingdotgg/t3code/discussions/7290)）。ドライバーが届くまで GJC を横に並べて実行してください。 |
+| 外部コントローラ / bot | Coordinator MCP、`gjc sdk session`、または構成済みのマネージドアダプタ | 外部コントローラは、スクロールバックや直接エンドポイント転送ではなく、ブローカーにバインドされ資格情報を含まない表面を使います。ホスト中立の `gjc-sdk-*` スキルは `gjc sdk session` を組み合わせ、Coordinator 統合をインストールしません。 |
+
+オプトインの検索/コンテキスト取得サイドカーとして Aside を評価する場合は [`docs/aside-integration.md`](docs/aside-integration.md) を参照してください。汎用のサードパーティ bot 設定とプロバイダ非依存のスモークについては [`docs/bot-integration.md`](docs/bot-integration.md)、外部制御の準備状況については [`docs/external-control-readiness.md`](docs/external-control-readiness.md)、ワイヤプロトコルとマシンインターフェースについては [`docs/sdk.md`](docs/sdk.md) を参照してください。
+
+## SDK 拡張機能
+
+- [gjc-remote](https://github.com/kogangdon/gjc-remote) — Discord からリモートホスト上の許可リスト済み GJC セッションを制御する実運用の SDK 拡張です。
+- [oh-my-gajae-code](https://github.com/devswha/oh-my-gajae-code) — 追加のワークフロースキルとスラッシュコマンドをインストールするコミュニティプラグインマーケットプレイスです。
+- [gjc-agy-skill](https://github.com/jkf87/gjc-agy-skill) — Antigravity CLI を通じたビジョン/OCR、画像生成、Gemini print-mode のワンショットワークフローを統合するサードパーティのコミュニティ GJC スキルです。
+- [GJC マルチベンダーセットアップガイド](https://github.com/project820/gjc-multivendor-setup-guide) — マルチベンダー GJC 環境向けのロールベースプロバイダプロファイルとインストール可能なモデルバンドルです。
+
+## 設定
+
+プロバイダの再試行予算は `~/.gjc/config.yml` にあります:
+
+```yaml
+retry:
+  requestMaxRetries: 4
+  streamMaxRetries: 100
+  maxRetries: 3
+  maxDelayMs: 300000
+```
+
+`requestMaxRetries` はストリーム確立前に適用されます。`streamMaxRetries` は再生しても安全な一時的ストリーム失敗にだけ適用されます。無効な認証、未対応のモデル/プロバイダ、不正なリクエスト、コンテキスト超過、ユーザーによる中断、恒久的なクォータ失敗は引き続き即時に失敗します。
+
+### 起動時の更新
+
+対話的な起動では、デフォルトでバックグラウンドから新しい GJC バージョンを GitHub Releases で確認します。この確認は通知専用で変更を加えません。GJC が起動中に自分自身をインストールまたは置き換えることはありません。対応プラットフォームでは `gjc update` が一致する GitHub リリースバイナリをダウンロードして原子的に置き換えます（パッケージマネージャの shim は上書きしません）。ソースチェックアウトと `dev:link` 実行ファイルはそのチェックアウト経由で更新する必要があり、`gjc update` はそれらの自己上書きを拒否します。未対応プラットフォームでは文書化されたインストーラを再実行してください。
+
+起動時の確認を無効にするには `gjc config set startup.checkUpdate false` を実行します。ネットワーク障害は起動を妨げないよう無視されます。
+
+### あわせて読む資料
+
+- [GJC マルチベンダーセットアップガイド](https://github.com/project820/gjc-multivendor-setup-guide) — Anthropic、OpenAI/Codex、Google/Gemini、xAI/Grok、opencode-go にわたるロール別のプロバイダ/プロファイル選択のためのコミュニティガイドです。そのプリセットは同梱のデフォルトではなくユーザーレベルの設定ガイダンスとして扱い、導入前に自分の環境でモデルの可用性とプロバイダ認証を確認してください。
+
+## TUI アイデンティティ
+
+デフォルトのダーク TUI アイデンティティは GJC red-claw テーマで、ライト外観のターミナルは同梱の blue-crab テーマがデフォルトです。追加の同梱移行テーマ `claude-code`、`codex`、`opencode` はそれらのツールの見た目を再現しており、目が慣れた環境へ移りやすくするため Settings または `/theme` から選べます。明示的なユーザーテーマ設定が常に優先されます。
+
+### 同梱テーマ一覧
+
+Settings（`Appearance -> Dark theme` / `Light theme`）または `/theme` から選びます。
+
+| テーマ | 見た目 | 向いている用途 |
+| --- | --- | --- |
+| `red-claw` | 温かい red-claw のアクセントと強い状態コントラストを持つダーク GJC デフォルト。 | ダークターミナルでの GJC 固有のアイデンティティ。 |
+| `blue-crab` | 明るい領域で読みやすいよう調整した、明るいターミナル向けの青いパレット。 | ライトターミナルまたは OS の外観。 |
+| `claude-code` | テラコッタとピンクのハイライトを備えた Claude Code 風ダークパレット。 | GJC 内で維持する Claude Code の慣れ。 |
+| `codex` | コーディングセッションのコントラストを明瞭にした、シャープなダークブルーグレーのパレット。 | Codex らしいダークワークスペース。 |
+| `opencode` | より強いターミナルアクセントを備えた OpenCode 風ダークパレット。 | 同梱ピッカーで使う OpenCode の慣れ。 |
+
+## トラブルシューティング
+
+ツール、スキル、フック、拡張、スラッシュコマンド、MCP サーバー、プラグインバンドルが期待どおりに表示されない場合は、ここから始めてください:
+
+```sh
+gjc customize doctor         # 人間が読める出所と対処方法
+gjc customize doctor --json # CI/設定ツール向けの安定した JSON
+```
+
+`gjc customize doctor` は唯一の読み取り専用トラブルシューティング表面です。検出されたすべてのカスタマイズ、出所の規約とスコープ（`gjc`、Claude プロジェクト、Codex プロジェクト、プラグイン、明示的な設定）、実効優先順位とシャドーイング、loaded/enabled/disabled/quarantined/rejected/stored-only の状態、制限された理由コード、修復コマンド、信頼要件、再起動/新規セッションが必要かどうかを報告します。資格情報、エンドポイントトークン、認証ヘッダ、安全でない生の設定ダンプは決して表示しません。
 
 ## 開発
 
@@ -281,7 +472,7 @@ bun run dev:doctor     # リンクを検証
 
 ## コントリビュータと系譜
 
-[Yeachan-Heo](https://github.com/Yeachan-Heo)、[IYENTeam](https://github.com/IYENTeam)、[HaD0Yun](https://github.com/HaD0Yun)、[probepark](https://github.com/probepark) に感謝します。GJC はエージェントハーネスの小さな系譜から得た教訓の上に築かれています。歴史的なアトリビューションは [NOTICE.md](NOTICE.md) にあります。
+[Yeachan-Heo](https://github.com/Yeachan-Heo)、[IYENTeam](https://github.com/IYENTeam)、[HaD0Yun](https://github.com/HaD0Yun)、[probepark](https://github.com/probepark)、[snowykr](https://github.com/snowykr) に感謝します。リポジトリのメンテナーと GitHub アクセスは [MAINTAINERS.md](MAINTAINERS.md) に記載されています。GJC はエージェントハーネスの小さな系譜から得た教訓の上に築かれています。歴史的なアトリビューションは [NOTICE.md](NOTICE.md) にあります。
 
 ## ライセンス
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -193,7 +193,7 @@ GJC は Claude Code / Codex の `SKILL.md` ファイル規約を使いますが�
 
 ```sh
 # プロジェクトローカル、リポジトリごと:
-cp -r my-skill .gjc/skills/
+mkdir -p .gjc/skills && cp -r my-skill .gjc/skills/
 
 # すべてのプロジェクトで使えるユーザー全体の場所:
 mkdir -p ~/.gjc/agent/skills && cp -r my-skill ~/.gjc/agent/skills/

--- a/README.ja.md
+++ b/README.ja.md
@@ -189,17 +189,17 @@ deep-interview -> ralplan -> ultragoal
 
 ## カスタムスキル
 
-GJC はカスタムスキルに Claude Code / Codex のファイル規約を採用しています。文書化された場所に `SKILL.md` を置くだけで、**設定なしに**通常のセッションから検出できます:
+GJC は Claude Code / Codex の `SKILL.md` ファイル規約を使いますが、ランタイムスキルを直接読み込むのは正規の GJC 場所だけです。設定は不要です:
 
 ```sh
-# プロジェクトローカル（以下のどれでも可）:
-cp -r my-skill .gjc/skills/          # または .claude/skills/ または .codex/skills/
+# プロジェクトローカル、リポジトリごと:
+cp -r my-skill .gjc/skills/
 
 # すべてのプロジェクトで使えるユーザー全体の場所:
 mkdir -p ~/.gjc/agent/skills && cp -r my-skill ~/.gjc/agent/skills/
 ```
 
-セッションで `/skill:my-skill` として呼び出します。スコープの信頼は `skills.trustProjectSkills` / `skills.trustUserSkills` で明示され（どちらもデフォルトで有効）、`skills.enabled` がマスタースイッチです。検出可能な項目は `gjc skills discover` で確認できます。上記の同梱ワークフロースキル 4 つはディスク上のスキルで置き換えられません。場所、優先順位、診断については [docs/skills.md](docs/skills.md) を参照してください。
+Claude Code と Codex のスキルディレクトリはインポートソースに過ぎません。`gjc skills discover` が正確なコピーコマンドとともに表示するため、スキルを正規の `.gjc` 場所へコピーしてから、セッションで `/skill:my-skill` として呼び出してください。スコープの信頼は `skills.trustProjectSkills` / `skills.trustUserSkills` で明示され（どちらもデフォルトで有効）、`skills.enabled` がマスタースイッチです。上記の同梱ワークフロースキル 4 つはディスク上のスキルで置き換えられません。場所、優先順位、診断については [docs/skills.md](docs/skills.md) を参照してください。
 
 ## デフォルトテーマ
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -28,7 +28,7 @@
   <a href="#휴대폰으로-답하기">휴대폰</a> ·
   <a href="#변경-전에-계획">워크플로</a> ·
   <a href="#토큰을-덜-쓰기">토큰 다이어트</a> ·
-  <a href="#openclaw--hermes가-gjc를-부리게-하기">컨트롤러</a> ·
+  <a href="#openclaw--hermes--grokbot--내가-만든-봇이-gjc를-부리게-하기">컨트롤러</a> ·
   <a href="#paseo--orca--t3-code-안에서-gjc-돌리기">에이전트 셸</a> ·
   <a href="#문서">문서</a>
 </p>
@@ -66,7 +66,11 @@ sh gjc-install.sh
 gjc
 ```
 
-`main`을 파이프하면 변경 가능한 설치 스크립트가 실행됩니다. 최신 설치기가 필요할 때만 사용하세요.
+`main`을 파이프하면 변경 가능한 설치 스크립트가 실행됩니다. 최신 설치기가 필요할 때만 사용하세요:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts/install.sh | sh
+```
 
 Windows (PowerShell, 태그 고정):
 
@@ -189,6 +193,24 @@ deep-interview -> ralplan -> ultragoal
 
 옵트인 기능: **`computer-use`** (실험적 데스크톱 제어). [Python REPL](docs/python-repl.md), [docs/tools/computer.md](docs/tools/computer.md) 참고.
 
+## 사용자 스킬
+
+GJC는 사용자 스킬에 Claude Code / Codex 파일 규약을 따릅니다. 문서화된 경로에 `SKILL.md`를 넣기만 하면 **별도 설정 없이** 일반 세션에서 발견됩니다:
+
+```sh
+# 프로젝트 로컬(아래 중 아무 곳):
+cp -r my-skill .gjc/skills/          # 또는 .claude/skills/ 또는 .codex/skills/
+
+# 모든 프로젝트에서 쓸 사용자 전역 경로:
+mkdir -p ~/.gjc/agent/skills && cp -r my-skill ~/.gjc/agent/skills/
+```
+
+세션에서 `/skill:my-skill`로 실행합니다. 범위 신뢰는 `skills.trustProjectSkills` / `skills.trustUserSkills`로 명시하며(둘 다 기본 활성화), `skills.enabled`가 전체 스위치입니다. `gjc skills discover`로 발견 가능한 항목을 확인할 수 있습니다. 위의 번들 워크플로 스킬 4개는 디스크 스킬로 교체할 수 없습니다. 위치, 우선순위, 진단은 [docs/skills.md](docs/skills.md)를 참고하세요.
+
+## 기본 테마
+
+기본 다크 TUI 아이덴티티는 GJC red-claw 테마이며, 라이트 외관 터미널은 번들된 blue-crab 테마가 기본입니다. 명시적으로 설정한 테마가 항상 우선합니다.
+
 ---
 
 ## 토큰을 덜 쓰기
@@ -201,6 +223,8 @@ GJC는 토큰 비용의 양쪽을 모두 최적화합니다:
 [캐시 유지 & 프로바이더 호환](docs/models.md) · [컴팩션 & 브랜치 요약](docs/compaction.md)
 
 ---
+
+기본 다크 TUI 아이덴티티는 GJC red-claw 테마이며, 라이트 외관 터미널은 번들된 blue-crab 테마가 기본입니다. 전체 카탈로그와 `theme.dark` / `theme.light` 설정은 [docs/theme.md](docs/theme.md)를 참고하세요.
 
 ## OpenClaw / Hermes / Grokbot / 내가 만든 봇이 GJC를 부리게 하기
 
@@ -345,8 +369,10 @@ Orca는 필드 하나다: GJC를 설치([docs/install.md](docs/install.md))하�
 
 **[gajae-code.com](https://gajae-code.com)** 또는 `docs/`에서 시작하세요:
 
-- [설치 & 업데이트](docs/install.md) · [환경 변수](docs/environment-variables.md) · [키바인딩](docs/keybindings.md) · [테마](docs/theme.md)
+- [설치 & 업데이트](docs/install.md) · [환경 변수](docs/environment-variables.md) · [키바인딩](docs/keybindings.md) · [테마](docs/theme.md) · [UI 언어](docs/ui-language.md)
 - [모델 & 프로바이더](docs/models.md) · [커스텀 프로바이더 & 멀티 계정 라우팅](docs/custom-providers-and-multi-account.md) · [멀티 벤더 프로필](docs/multi-vendor-profiles.md) · [Auth 브로커](docs/auth-broker-gateway.md)
+- [커스터마이징 권한·가져오기·신뢰](docs/customization.md) · [스킬](docs/skills.md) · [훅](docs/hooks.md) · [독립 MCP](docs/standalone-mcp.md) · [플러그인 번들](docs/gjc-plugins.md)
+- [터미널 앱 통합: Paseo · Orca · T3 Code](docs/terminal-app-integrations.md)
 - [텔레그램](docs/telegram-onboarding.md) · [봇 통합](docs/bot-integration.md) · [SDK](docs/sdk.md) · [SDK 세션 CLI](docs/sdk-session-cli.md)
 - [세션](docs/session.md) · [컴팩션](docs/compaction.md) · [메모리](docs/memory.md) · [시크릿](docs/secrets.md)
 - [코드베이스 개요](docs/codebase-overview.md) · [기여 / 개발 환경](CONTRIBUTING.md)
@@ -356,9 +382,94 @@ Orca는 필드 하나다: GJC를 설치([docs/install.md](docs/install.md))하�
 
 ## SDK 확장
 
-- [gjc-remote](https://github.com/kogangdon/gjc-remote) — Discord에서 원격 호스트의 allowlist된 GJC 세션 제어.
-- [oh-my-gajae-code](https://github.com/devswha/oh-my-gajae-code) — 추가 스킬과 슬래시 커맨드를 위한 커뮤니티 플러그인 마켓플레이스.
-- [GJC 멀티벤더 설정 가이드](https://github.com/project820/gjc-multivendor-setup-guide) — 멀티벤더 설정을 위한 역할 기반 프로바이더 프로필.
+### 로컬 커스터마이징: `/extensions`
+
+대화형 세션에서 `/extensions`는 기본 커스터마이징 설정 화면입니다. 프로젝트(`<project>/.gjc/`)와 사용자 전역(`~/.gjc/agent/`) 범위의 스킬·훅·MCP를 구성하고, 상태·출처 진단, 활성화·비활성화·제거, Claude Code/Codex에서 가져오는 안내형 흐름(정규화된 미리보기, 명시적 확인, 충돌 시 건너뛰기·이름 변경·덮어쓰기 정책, 롤백 가능한 원자적 쓰기)을 제공합니다. 비대화형 설정에서는 MCP 서버에 `gjc mcp`, Claude Code/Codex 가져오기에 `gjc migrate`를 사용하세요.
+
+### 스킬 마이그레이션 및 번들 스킬 검사
+
+워크플로를 GJC로 옮길 때는 설치하거나 덮어쓰기 전에 번들 기본값을 먼저 검사하세요:
+
+```sh
+gjc skills list
+gjc skills read ralplan
+gjc setup defaults --check
+```
+
+`gjc setup defaults`는 번들된 GJC 워크플로 스킬 4개를 사용자 `.gjc` 디렉터리에 설치하며, 기본적으로 기존 로컬 파일을 보존합니다. `--check`가 누락되었거나 다른 파일을 보고하면 먼저 `gjc skills read <name>`으로 내장 사본과 비교하세요. 로컬 기본 워크플로 스킬 파일을 의도적으로 교체할 때만 `gjc setup defaults --force`를 사용하세요.
+
+## 기존 에이전트·봇과 함께 쓰기
+
+| 도구 또는 봇 | 권장 GJC 명령 | 경계 |
+| --- | --- | --- |
+| Codex CLI | `gjc --tmux --worktree <name>` 또는 `gjc` | `--worktree`는 GJC가 관리하는 인접 워크트리에 이름을 붙입니다. 기존 경로에서는 먼저 그곳으로 `cd`하세요. |
+| Claude Code | `gjc --tmux` 또는 `gjc --tmux --worktree <name>` | GJC는 Claude Code 확장이 되지 않습니다. |
+| OpenCode | `gjc` 또는 `gjc --tmux` | 현재는 외부 러너 워크플로만 지원합니다. |
+| Claw Code | `gjc --tmux --worktree <name>` | GJC는 Claw Code에 설치되거나 이를 대체하지 않습니다. |
+| [Paseo](https://paseo.sh) | `gjc setup paseo` | GJC가 ACP 프로바이더로 자신을 등록하고 `--remove`로 되돌립니다. Paseo 자체 설정 파일은 Paseo가 소유합니다. |
+| [Orca](https://onorca.dev) | 커스텀 에이전트 명령으로 `gjc` | Orca가 자체 워크트리 터미널에서 GJC를 실행하고, GJC는 자체 승인 게이트를 유지합니다. |
+| [T3 Code](https://t3.codes) | 아직 없음 — 실험적 | 업스트림에 GJC 하네스가 없습니다([제안](https://github.com/pingdotgg/t3code/discussions/7290)). 드라이버가 나올 때까지 GJC를 나란히 실행하세요. |
+| 외부 컨트롤러 / 봇 | Coordinator MCP, `gjc sdk session`, 또는 구성된 관리형 어댑터 | 외부 컨트롤러는 스크롤백이나 직접 엔드포인트 전송 대신 브로커 바인딩·크리덴셜 없는 표면을 사용합니다. 호스트 중립적인 `gjc-sdk-*` 스킬은 `gjc sdk session`을 조합하며 Coordinator 통합을 설치하지 않습니다. |
+
+옵트인 검색/컨텍스트 검색 사이드카로 Aside를 평가하려면 [`docs/aside-integration.md`](docs/aside-integration.md)를 참고하세요. 일반적인 서드파티 봇 설정과 프로바이더 독립 스모크는 [`docs/bot-integration.md`](docs/bot-integration.md), 외부 제어 준비도는 [`docs/external-control-readiness.md`](docs/external-control-readiness.md), 와이어 프로토콜 및 머신 인터페이스는 [`docs/sdk.md`](docs/sdk.md)를 참고하세요.
+
+## SDK 확장 프로그램
+
+- [gjc-remote](https://github.com/kogangdon/gjc-remote) — Discord에서 원격 호스트의 허용 목록 GJC 세션을 제어하는 실사용 SDK 확장입니다.
+- [oh-my-gajae-code](https://github.com/devswha/oh-my-gajae-code) — 추가 워크플로 스킬과 슬래시 명령을 설치하는 커뮤니티 플러그인 마켓플레이스입니다.
+- [gjc-agy-skill](https://github.com/jkf87/gjc-agy-skill) — Antigravity CLI를 통한 비전/OCR, 이미지 생성, Gemini print-mode 원샷 워크플로를 통합하는 서드파티 커뮤니티 GJC 스킬입니다.
+- [GJC 멀티벤더 설정 가이드](https://github.com/project820/gjc-multivendor-setup-guide) — 멀티벤더 GJC 환경을 위한 역할 기반 프로바이더 프로필과 설치 가능한 모델 번들입니다.
+
+## 설정
+
+프로바이더 재시도 예산은 `~/.gjc/config.yml`에 있습니다:
+
+```yaml
+retry:
+  requestMaxRetries: 4
+  streamMaxRetries: 100
+  maxRetries: 3
+  maxDelayMs: 300000
+```
+
+`requestMaxRetries`는 스트림이 수립되기 전에 적용됩니다. `streamMaxRetries`는 재생 안전한 일시적 스트림 실패에만 적용됩니다. 잘못된 인증, 지원하지 않는 모델/프로바이더, 잘못된 요청, 컨텍스트 초과, 사용자 중단, 영구적인 할당량 실패는 계속 즉시 실패합니다.
+
+### 시작 시 업데이트
+
+대화형 시작은 기본적으로 백그라운드에서 더 새 GJC 버전이 있는지 GitHub 릴리스를 확인합니다. 이 검사는 알림 전용이며 변경하지 않습니다. GJC는 시작 중 스스로를 설치하거나 교체하지 않습니다. 지원 플랫폼에서는 `gjc update`가 일치하는 GitHub 릴리스 바이너리를 내려받아 원자적으로 교체합니다(패키지 매니저 shim은 덮어쓰지 않습니다). 소스 체크아웃과 `dev:link` 실행 파일은 해당 체크아웃을 통해 업데이트해야 하며, `gjc update`는 이를 스스로 덮어쓰지 않습니다. 지원하지 않는 플랫폼에서는 문서화된 설치기를 다시 실행하세요.
+
+시작 시 확인을 끄려면 `gjc config set startup.checkUpdate false`를 실행하세요. 네트워크 실패는 시작을 막지 않도록 무시됩니다.
+
+### 함께 읽으면 좋은 자료
+
+- [GJC 멀티벤더 설정 가이드](https://github.com/project820/gjc-multivendor-setup-guide) — Anthropic, OpenAI/Codex, Google/Gemini, xAI/Grok, opencode-go 전반에서 역할별 프로바이더/프로필을 선택하는 커뮤니티 가이드입니다. 프리셋은 번들 기본값이 아니라 사용자 수준 설정 지침으로 취급하고, 도입 전에는 환경에서 모델 가용성과 프로바이더 인증을 확인하세요.
+
+## TUI 아이덴티티
+
+기본 다크 TUI 아이덴티티는 GJC red-claw 테마이고, 라이트 외관 터미널은 번들된 blue-crab 테마가 기본입니다. 추가 번들 마이그레이션 테마 `claude-code`, `codex`, `opencode`는 해당 도구의 외관을 따라가 눈에 익은 환경으로 쉽게 옮길 수 있으며 Settings 또는 `/theme`에서 선택합니다. 명시적인 사용자 테마 설정이 항상 우선합니다.
+
+### 번들 테마 표
+
+Settings(`Appearance -> Dark theme` / `Light theme`) 또는 `/theme`에서 고르세요.
+
+| 테마 | 시각적 인상 | 적합한 경우 |
+| --- | --- | --- |
+| `red-claw` | 따뜻한 red-claw 포인트와 강한 상태 대비를 갖춘 다크 GJC 기본 테마. | 다크 터미널의 GJC 고유 아이덴티티. |
+| `blue-crab` | 밝은 슬롯에서 읽기 좋도록 조정한 밝은 터미널용 블루 팔레트. | 라이트 터미널 또는 OS 외관. |
+| `claude-code` | 테라코타·핑크 하이라이트를 갖춘 Claude Code 풍 다크 팔레트. | GJC 안에서 유지하는 Claude Code의 익숙함. |
+| `codex` | 코딩 세션 대비를 또렷하게 한 선명한 다크 블루그레이 팔레트. | Codex 같은 다크 작업 공간. |
+| `opencode` | 더 강한 터미널 포인트를 갖춘 OpenCode 풍 다크 팔레트. | 번들 피커에서 쓰는 OpenCode의 익숙함. |
+
+## 문제 해결
+
+도구, 스킬, 훅, 확장, 슬래시 명령, MCP 서버, 플러그인 번들이 예상대로 보이지 않으면 여기서 시작하세요:
+
+```sh
+gjc customize doctor         # 사람이 읽는 출처와 해결책
+gjc customize doctor --json # CI/설정 도구용 안정적인 JSON
+```
+
+`gjc customize doctor`는 유일한 읽기 전용 문제 해결 표면입니다. 발견한 모든 커스터마이징, 출처 규약과 범위(`gjc`, Claude 프로젝트, Codex 프로젝트, 플러그인, 명시적 설정), 실제 우선순위 및 섀도잉, loaded/enabled/disabled/quarantined/rejected/stored-only 상태, 제한된 이유 코드, 해결 명령, 신뢰 요구사항, 재시작/새 세션 필요 여부를 보고합니다. 크리덴셜, 엔드포인트 토큰, 인증 헤더, 안전하지 않은 원시 설정 덤프는 절대 출력하지 않습니다.
 
 ## 개발
 
@@ -373,7 +484,7 @@ bun run dev:doctor     # 링크 검증
 
 ## 기여자 & 계보
 
-[Yeachan-Heo](https://github.com/Yeachan-Heo), [IYENTeam](https://github.com/IYENTeam), [HaD0Yun](https://github.com/HaD0Yun), [probepark](https://github.com/probepark)에게 감사드립니다. GJC는 여러 에이전트 하네스에서 얻은 교훈 위에 세워졌으며, 역사적 어트리뷰션은 [NOTICE.md](NOTICE.md)에 있습니다.
+[Yeachan-Heo](https://github.com/Yeachan-Heo), [IYENTeam](https://github.com/IYENTeam), [HaD0Yun](https://github.com/HaD0Yun), [probepark](https://github.com/probepark), [snowykr](https://github.com/snowykr)에게 감사드립니다. 저장소 유지관리자와 GitHub 접근 권한은 [MAINTAINERS.md](MAINTAINERS.md)에 정리되어 있습니다. GJC는 작은 에이전트 하네스 계보에서 얻은 교훈 위에 세워졌으며, 역사적 어트리뷰션은 [NOTICE.md](NOTICE.md)에 있습니다.
 
 ## 라이선스
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -199,7 +199,7 @@ GJC는 Claude Code / Codex의 `SKILL.md` 파일 규약을 사용하지만, 런�
 
 ```sh
 # 프로젝트 로컬, 저장소별:
-cp -r my-skill .gjc/skills/
+mkdir -p .gjc/skills && cp -r my-skill .gjc/skills/
 
 # 모든 프로젝트에서 쓸 사용자 전역 경로:
 mkdir -p ~/.gjc/agent/skills && cp -r my-skill ~/.gjc/agent/skills/

--- a/README.ko.md
+++ b/README.ko.md
@@ -195,17 +195,17 @@ deep-interview -> ralplan -> ultragoal
 
 ## 사용자 스킬
 
-GJC는 사용자 스킬에 Claude Code / Codex 파일 규약을 따릅니다. 문서화된 경로에 `SKILL.md`를 넣기만 하면 **별도 설정 없이** 일반 세션에서 발견됩니다:
+GJC는 Claude Code / Codex의 `SKILL.md` 파일 규약을 사용하지만, 런타임 스킬은 정식 GJC 경로에서만 직접 로드합니다. 별도 설정은 필요 없습니다:
 
 ```sh
-# 프로젝트 로컬(아래 중 아무 곳):
-cp -r my-skill .gjc/skills/          # 또는 .claude/skills/ 또는 .codex/skills/
+# 프로젝트 로컬, 저장소별:
+cp -r my-skill .gjc/skills/
 
 # 모든 프로젝트에서 쓸 사용자 전역 경로:
 mkdir -p ~/.gjc/agent/skills && cp -r my-skill ~/.gjc/agent/skills/
 ```
 
-세션에서 `/skill:my-skill`로 실행합니다. 범위 신뢰는 `skills.trustProjectSkills` / `skills.trustUserSkills`로 명시하며(둘 다 기본 활성화), `skills.enabled`가 전체 스위치입니다. `gjc skills discover`로 발견 가능한 항목을 확인할 수 있습니다. 위의 번들 워크플로 스킬 4개는 디스크 스킬로 교체할 수 없습니다. 위치, 우선순위, 진단은 [docs/skills.md](docs/skills.md)를 참고하세요.
+Claude Code와 Codex 스킬 디렉터리는 가져오기 소스일 뿐입니다. `gjc skills discover`가 정확한 복사 명령과 함께 이를 알려 주므로, 스킬을 정식 `.gjc` 경로로 복사한 뒤 세션에서 `/skill:my-skill`로 실행하세요. 범위 신뢰는 `skills.trustProjectSkills` / `skills.trustUserSkills`로 명시하며(둘 다 기본 활성화), `skills.enabled`가 전체 스위치입니다. 위의 번들 워크플로 스킬 4개는 디스크 스킬로 교체할 수 없습니다. 위치, 우선순위, 진단은 [docs/skills.md](docs/skills.md)를 참고하세요.
 
 ## 기본 테마
 

--- a/README.md
+++ b/README.md
@@ -187,17 +187,17 @@ Also included, opt-in: **`computer-use`** (experimental desktop control). See [P
 
 ## Custom skills
 
-GJC follows the Claude Code / Codex file convention for custom skills — drop a `SKILL.md` into a documented location and it is discoverable in a normal session with **no configuration**:
+GJC uses the Claude Code / Codex `SKILL.md` file convention, but loads runtime skills directly only from canonical GJC locations — no configuration required:
 
 ```sh
-# project-local (any of these):
-cp -r my-skill .gjc/skills/          # or .claude/skills/ or .codex/skills/
+# project-local, per repository:
+cp -r my-skill .gjc/skills/
 
 # user-wide, available in every project:
 mkdir -p ~/.gjc/agent/skills && cp -r my-skill ~/.gjc/agent/skills/
 ```
 
-Then invoke it with `/skill:my-skill` in a session. Scope trust is explicit via `skills.trustProjectSkills` / `skills.trustUserSkills` (both default on), with `skills.enabled` as the master switch; inspect what is discoverable with `gjc skills discover`. The four bundled workflow skills above can never be replaced by disk skills. See [docs/skills.md](docs/skills.md) for locations, precedence, and diagnostics.
+Claude Code and Codex skill directories are import sources only. `gjc skills discover` reports them with the exact copy command; copy a skill into a canonical `.gjc` location before invoking it with `/skill:my-skill`. Scope trust is explicit via `skills.trustProjectSkills` / `skills.trustUserSkills` (both default on), with `skills.enabled` as the master switch. The four bundled workflow skills above can never be replaced by disk skills. See [docs/skills.md](docs/skills.md) for locations, precedence, and diagnostics.
 ## Theme defaults
 
 The default dark TUI identity is the GJC red-claw theme; light-appearance terminals default to the bundled blue-crab theme. Explicit theme settings still take precedence.

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ GJC uses the Claude Code / Codex `SKILL.md` file convention, but loads runtime s
 
 ```sh
 # project-local, per repository:
-cp -r my-skill .gjc/skills/
+mkdir -p .gjc/skills && cp -r my-skill .gjc/skills/
 
 # user-wide, available in every project:
 mkdir -p ~/.gjc/agent/skills && cp -r my-skill ~/.gjc/agent/skills/


### PR DESCRIPTION
## What

Synchronizes `README.ko.md` and `README.ja.md` with the current English README, and corrects all three READMEs to document canonical runtime locations and a working setup command for custom skills.

## Why

The localized READMEs had fallen behind the English source and omitted current skills, controller, terminal-integration, customization, configuration, theme, and troubleshooting guidance. Review found two correctness issues in the custom-skill section: Claude Code/Codex directories are import sources only, and a fresh project needs `.gjc/skills` created before copying. The READMEs now state the canonical runtime rule and create the destination directory first.

## Testing

- Fresh-project scenario: executed the documented command in a temporary directory and verified `.gjc/skills/my-skill/SKILL.md` exists — passed
- Localized README structural, link, navigation, controller-prompt, and canonical skill-guidance validation — passed
- `bun scripts/verify-gjc-state-writers.ts --fail` — passed
- `git diff --check` — passed
- `bun run check` — failed outside this documentation-only diff: `packages/coding-agent/test/sdk-adapter-dispositions-acp.test.ts` timed out while starting its production SDK host, causing all 97 manifest cases to fail. CI is pending on this exact head.

No changelog entry: this is a documentation-only synchronization and correction; it does not change product behavior.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:e150bfe299aa5ff29524d0e86d10dd3c55a381a52c009bb2eee0d751b8caa790 reviewer:human reviewer-id:Yeachan-Heo evidence:epoch-transition review after rebase onto dev 10d038710f8a6cc3b73ade35362b7be0ee53f460 at head 2602ac458a3a62a780a8ef97348403c9dd9eff01
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes — prior exact-head run exposed an SDK-host timeout outside this three-README diff; fresh exact-head CI is running
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing; not applicable for documentation-only synchronization)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken\n\nFresh exact-head approval ids: 5022196327, 5022571552, 5022585618; all are authenticated Yeachan-Heo approvals bound by the current PR contract validator.