### PR TITLE
feat(coding-agent): add /aside composer command for Aside CLI

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -293,7 +293,7 @@ endpoint records or credentials under .gjc/state/sdk, never open a raw session W
 1 セッションずつではなく多くのワークツリーへイベント駆動で展開する必要がある場合、ネイティブの
 [Coordinator MCP ブリッジ](docs/hermes-mcp-bridge.md)（`gjc mcp-serve coordinator`、`gjc setup hermes` でインストール）が、その形の委任ツールを提供します。
 
-- [外部コントローラ / bot 統合ガイド](docs/bot-integration.md) — プロバイダ非依存のスモーク。[`docs/aside-integration.md`](docs/aside-integration.md) はオプトインの検索/コンテキストサイドカーを扱います
+- [外部コントローラ / bot 統合ガイド](docs/bot-integration.md) — プロバイダ非依存のスモーク。[`docs/aside-integration.md`](docs/aside-integration.md) はオプトインの検索/コンテキストサイドカーと `/aside` コンポーザーコマンドを扱います
 - [SDK session CLI](docs/sdk-session-cli.md) · [SDK とワイヤプロトコル](docs/sdk.md) · [SDK アプリガイド](docs/sdk-app-guide.md) · [外部制御レディネス](docs/external-control-readiness.md)
 
 ---

--- a/README.ko.md
+++ b/README.ko.md
@@ -302,7 +302,7 @@ endpoint records or credentials under .gjc/state/sdk, never open a raw session W
 [Coordinator MCP 브리지](docs/hermes-mcp-bridge.md)(`gjc mcp-serve coordinator`, `gjc setup hermes`로 설치)가
 그 형태의 위임 도구를 제공한다.
 
-- [외부 컨트롤러 / 봇 통합 가이드](docs/bot-integration.md) — 프로바이더 독립 스모크; [`docs/aside-integration.md`](docs/aside-integration.md)는 옵트인 검색/컨텍스트 사이드카를 다룬다
+- [외부 컨트롤러 / 봇 통합 가이드](docs/bot-integration.md) — 프로바이더 독립 스모크; [`docs/aside-integration.md`](docs/aside-integration.md)는 옵트인 검색/컨텍스트 사이드카와 `/aside` 컴포저 명령을 다룬다
 - [SDK 세션 CLI](docs/sdk-session-cli.md) · [SDK & 와이어 프로토콜](docs/sdk.md) · [SDK 앱 가이드](docs/sdk-app-guide.md) · [외부 제어 준비도](docs/external-control-readiness.md)
 
 ---

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Need event-driven fan-out across many worktrees instead of one session at a time
 [Coordinator MCP bridge](docs/hermes-mcp-bridge.md) (`gjc mcp-serve coordinator`, installed by
 `gjc setup hermes`) exposes the delegation tools for that shape.
 
-- [External controller / bot integration guide](docs/bot-integration.md) — provider-independent smokes; [`docs/aside-integration.md`](docs/aside-integration.md) covers the opt-in search/context sidecar
+- [External controller / bot integration guide](docs/bot-integration.md) — provider-independent smokes; [`docs/aside-integration.md`](docs/aside-integration.md) covers the opt-in search/context sidecar and the `/aside` composer command
 - [SDK session CLI](docs/sdk-session-cli.md) · [SDK & wire protocol](docs/sdk.md) · [SDK app guide](docs/sdk-app-guide.md) · [External-control readiness](docs/external-control-readiness.md)
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -244,7 +244,7 @@ The session command selector accepts only "gjc" or "gjc --worktree [name]".
 若控制器要直接驱动单个在线会话，每个会话还暴露回环 **SDK WebSocket** 端点、`gjc sdk session` CLI（`list|inspect|send|status|tail`）以及内置 `sdk-skills/`（`gjc-sdk-discover` · `gjc-sdk-operate` · `gjc-sdk-author`）— 任何控制器托管的代理都能遵循的、经过审阅且带审批门的流程。
 
 - [外部控制器集成指南](docs/bot-integration.md) · [Coordinator MCP 桥](docs/hermes-mcp-bridge.md)
-- [外部控制器 / 机器人](docs/bot-integration.md) — 提供商无关冒烟测试；[`docs/aside-integration.md`](docs/aside-integration.md) 涵盖可选的搜索/上下文边车
+- [外部控制器 / 机器人](docs/bot-integration.md) — 提供商无关冒烟测试；[`docs/aside-integration.md`](docs/aside-integration.md) 涵盖可选的搜索/上下文边车和 `/aside` 编辑器命令
 - [SDK 与线协议](docs/sdk.md) · [SDK 会话 CLI](docs/sdk-session-cli.md) · [外部控制就绪度](docs/external-control-readiness.md)
 
 ---

--- a/docs/aside-integration.md
+++ b/docs/aside-integration.md
@@ -1,6 +1,8 @@
 # Aside sidecar evaluation
 
-This note records the safe first-step boundary for evaluating [Aside](https://aside.com/) with Gajae-Code (`gjc`). It is intentionally docs-only: GJC does not ship an Aside adapter, does not auto-discover Aside, and does not enable browser-control behavior by default.
+This note records the safe first-step boundary for evaluating [Aside](https://aside.com/) with Gajae-Code (`gjc`). The search/context sidecar path is intentionally docs-only: GJC does not ship an Aside adapter, does not auto-discover Aside, and does not enable browser-control behavior by default.
+
+The one in-tree CLI ergonomics surface is the explicit `/aside` composer slash command. It probes a user-installed Aside CLI and can run `aside exec` / `aside account` when the operator types it. That command does not restore a GJC browser-tool backend and does not turn Aside on for ordinary browser or search tools.
 
 ## Current public surface
 
@@ -58,7 +60,31 @@ Recommended prompt boundary for evaluation:
 Use the Aside sidecar only for read-only search/context retrieval. Do not click, submit, sign in, autofill credentials, use payment or billing flows, post messages, write files, or operate internal tools. Return a short answer with source titles/URLs only.
 ```
 
-## Option B: future HTTP/SSE MCP endpoint
+## Option B: `/aside` composer command
+
+Type `/aside` in the GJC composer to probe and use a locally installed Aside CLI. This is operator-initiated and does not enable GJC browser-control by default.
+
+```text
+/aside
+/aside Summarize the current page
+/aside exec --session <id> Continue
+/aside mcp
+/aside account list
+```
+
+Behavior:
+
+- Bare `/aside` prints the resolved CLI path, `aside --version` when available, and usage.
+- `/aside <prompt>` and `/aside exec …` spawn `aside exec` with argv (no shell).
+- `/aside mcp` prints `gjc mcp add aside <resolved-cli> mcp --project`. It does not start `aside mcp` inside GJC, because that command is a stdio server.
+- `/aside repl` is refused inside GJC. Run `aside repl` in a real terminal TTY.
+- If the CLI is missing, GJC prints the searched paths and `curl -fsSL https://releases.aside.com/install.sh | bash`. It never runs the installer.
+
+Probe order: `~/.local/bin/aside`, then `~/.aside/cli/Aside CLI.app/Contents/MacOS/aside`, then `PATH`.
+
+Keep the same payload boundary as the MCP path: do not paste cookies, screenshots, task transcripts, or private Aside profile paths into issues or PRs.
+
+## Option C: future HTTP/SSE MCP endpoint
 
 If Aside or a wrapper later exposes a narrow search/context MCP endpoint, keep endpoint and credentials user-owned:
 
@@ -101,7 +127,9 @@ gjc mcp remove aside-search --project
 
 | Symptom | Check |
 | --- | --- |
-| `aside` command not found | Install the Aside CLI from Aside developer settings, then use the concrete CLI path as the MCP `command` if needed. |
+| `aside` command not found | Run `/aside` in the GJC composer, or install the Aside CLI from Aside developer settings, then use the concrete CLI path as the MCP `command` if needed. |
+| `/aside` says the CLI was not found | Confirm the installer symlink (`~/.local/bin/aside`) or the `Aside CLI.app` bundle exists and is executable. `/aside` never runs the installer. |
+| `/aside repl` is refused | Expected. GJC cannot attach a TTY to `aside repl`; run that command in a terminal. |
 | MCP server does not appear in `gjc mcp list` | Re-run `gjc mcp list --json`; confirm whether the registration was user-scoped or project-scoped. |
 | Aside tools do not appear in a normal GJC session | Check `gjc mcp list --json`: the server must be `autoload` status (not `enabled: false`, not in `disabledServers`, not `autoload: false`), project scope must not be disabled by an explicit `mcp.enableProjectConfig: false` setting, and the session must not have passed `--no-mcp`. |
 | Auth failure | Rotate or re-enter the Aside-side token/API key. Do not paste it into GJC prompts or issue comments. |
@@ -111,4 +139,4 @@ gjc mcp remove aside-search --project
 
 ## Decision
 
-Docs-only is the smallest safe outcome for issue #1097. Existing GJC MCP registration can store a user-provided Aside MCP server definition for redacted inspection, and Aside already documents `aside mcp`; no GJC adapter glue is required. The future-safe boundary is to keep Aside external and opt-in, document read/search/context-only use, and require a separate design before GJC claims runtime support for browser actions, login, payment, internal-tool, or private browser-session workflows.
+Docs-only remains the smallest safe outcome for the search/context sidecar in issue #1097: existing GJC MCP registration can store a user-provided Aside MCP server definition for redacted inspection, and Aside already documents `aside mcp`. `/aside` is the separate CLI-ergonomics path: an explicit composer command that probes and optionally execs the user-installed binary, without adapter glue and without restoring the reverted Aside browser-tool backend. The future-safe boundary is to keep Aside external and opt-in, document read/search/context-only use, and require a separate design before GJC claims runtime support for browser actions, login, payment, internal-tool, or private browser-session workflows.

--- a/docs/aside-integration.md
+++ b/docs/aside-integration.md
@@ -79,6 +79,7 @@ Behavior:
 - `/aside mcp` prints `gjc mcp add aside <resolved-cli> mcp --project`. It does not start `aside mcp` inside GJC, because that command is a stdio server.
 - `/aside repl` is refused inside GJC. Run `aside repl` in a real terminal TTY.
 - If the CLI is missing, GJC prints the searched paths and `curl -fsSL https://releases.aside.com/install.sh | bash`. It never runs the installer.
+- On native Windows, the printed MCP and REPL commands use PowerShell quoting; the documented installer command is for WSL or Git Bash, not PowerShell itself.
 
 Probe order: `~/.local/bin/aside`, then `~/.aside/cli/Aside CLI.app/Contents/MacOS/aside`, then `PATH`.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added Japanese (`ja`) to the persisted `ui.language` response-language surface: the `/language` command and the Settings → Appearance selector. Accepted input spellings include `ja`, `ja-JP`, `japanese`, `jp`, `jpn`, and `日本語`. English and Korean behavior, defaults, and onboarding language ranking are unchanged. (#4947)
+- Added `/aside`, a composer slash command that probes a user-installed Aside CLI (`~/.local/bin/aside`, the macOS `Aside CLI.app` bundle, then `PATH`) and runs explicit `exec` / `account` invocations from GJC. Bare `/aside` prints the resolved path and version; `/aside mcp` prints `gjc mcp add aside <cli> mcp --project` with a quoted concrete binary instead of starting a stdio server; `/aside repl` stays terminal-only because the GJC host cannot attach a TTY. Missing-binary output includes the official install command. This does not restore the reverted Aside browser-tool backend and does not enable browser-control by default.
 
 ### Fixed
 

--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -43,8 +43,7 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 	"slash_command:exit": "visual/local-only command, not a user-facing SDK control seam",
 	"slash_command:notify":
 		"interactive diagnostics command; session on/off delegate to the notifications extension, not an SDK ingress seam",
-	"slash_command:aside":
-		"explicit user-owned external CLI process launcher; not a credential-free SDK control seam",
+	"slash_command:aside": "explicit user-owned external CLI process launcher; not a credential-free SDK control seam",
 	"slash_command:extensions":
 		"interactive local customization dashboard mutates trusted local skill, hook, and MCP configuration (including filesystem import/removal); ACP and local headless cannot dispatch it, while SDK extension list/enable operations do not expose this dashboard authority",
 	"slash_command:credential":

--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -43,6 +43,8 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 	"slash_command:exit": "visual/local-only command, not a user-facing SDK control seam",
 	"slash_command:notify":
 		"interactive diagnostics command; session on/off delegate to the notifications extension, not an SDK ingress seam",
+	"slash_command:aside":
+		"explicit user-owned external CLI process launcher; not a credential-free SDK control seam",
 	"slash_command:extensions":
 		"interactive local customization dashboard mutates trusted local skill, hook, and MCP configuration (including filesystem import/removal); ACP and local headless cannot dispatch it, while SDK extension list/enable operations do not expose this dashboard authority",
 	"slash_command:credential":

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -1728,6 +1728,17 @@
 		]
 	},
 	{
+		"sourceId": "slash_command:aside",
+		"sourceFile": "packages/coding-agent/src/slash-commands/builtin-registry.ts",
+		"sourceKind": "slash_command",
+		"decision": "exclude",
+		"rationale": "explicit user-owned external CLI process launcher; not a credential-free SDK control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
 		"sourceId": "slash_command:import-session",
 		"sourceFile": "packages/coding-agent/src/slash-commands/builtin-registry.ts",
 		"sourceKind": "slash_command",

--- a/packages/coding-agent/src/slash-commands/aside-command.test.ts
+++ b/packages/coding-agent/src/slash-commands/aside-command.test.ts
@@ -5,6 +5,7 @@ import {
 	asideCliCandidates,
 	createAsideHandler,
 	formatAsideMcpRegistration,
+	parseAsideArgv,
 	posixQuote,
 	probeAsideCli,
 	resolveAsideCliPath,
@@ -80,6 +81,31 @@ describe("posixQuote", () => {
 		);
 		expect(windowsPowerShellQuote("C:\\Users\\O'Brien\\aside.exe")).toBe("'C:\\Users\\O''Brien\\aside.exe'");
 	});
+
+	test("selects PowerShell quoting for native Windows MCP commands", () => {
+		const cliPath = "C:\\Users\\demo\\Aside CLI\\aside.exe";
+		expect(formatAsideMcpRegistration(cliPath, "win32")).toContain(
+			`gjc mcp add aside ${windowsPowerShellQuote(cliPath)} mcp --project`,
+		);
+	});
+});
+
+describe("parseAsideArgv", () => {
+	test("preserves empty quoted arguments and escaped quotes", () => {
+		expect(parseAsideArgv('exec --message "" it\\\'s')).toEqual({
+			ok: true,
+			args: ["exec", "--message", "", "it's"],
+		});
+		expect(parseAsideArgv('exec "say \\"hello\\""')).toEqual({
+			ok: true,
+			args: ["exec", 'say "hello"'],
+		});
+	});
+
+	test("rejects unterminated quotes and escapes", () => {
+		expect(parseAsideArgv('exec "unterminated')).toEqual({ ok: false, error: "unterminated quote" });
+		expect(parseAsideArgv("exec trailing\\")).toEqual({ ok: false, error: "unfinished escape" });
+	});
 });
 
 describe("/aside slash command", () => {
@@ -130,6 +156,19 @@ describe("/aside slash command", () => {
 		expect(output[0]).toContain("Aside CLI: /Users/demo/.local/bin/aside");
 		expect(output[0]).toContain("Version: 1.26.810");
 		expect(output[0]).toContain(ASIDE_USAGE);
+	});
+
+	test("sanitizes version output before rendering status", async () => {
+		const handle = createAsideHandler({
+			homedir: () => "/Users/demo",
+			isExecutable: filePath => filePath === "/Users/demo/.local/bin/aside",
+			which: () => null,
+			exec: async () => ({ stdout: "\x1b]0;pwned\x071.26.810\n", stderr: "", code: 0, killed: false }),
+		});
+		const { runtime, output } = runtimeHarness();
+		await handle({ name: "aside", args: "", text: "/aside" }, runtime);
+		expect(output[0]).toContain("Version: 1.26.810");
+		expect(output[0]).not.toContain("pwned");
 	});
 
 	test("freeform prompts run aside exec with a single prompt argument", async () => {
@@ -262,6 +301,21 @@ describe("/aside slash command", () => {
 			exitCode: 1,
 		});
 		expect(output).toEqual(["no daemon\n(exit 1)"]);
+	});
+
+	test("timeout results are consumed with a non-zero status", async () => {
+		const handle = createAsideHandler({
+			homedir: () => "/Users/demo",
+			isExecutable: filePath => filePath === "/Users/demo/.local/bin/aside",
+			which: () => null,
+			exec: async () => ({ stdout: "partial", stderr: "", code: 0, killed: true }),
+		});
+		const { runtime, output } = runtimeHarness();
+		expect(await handle({ name: "aside", args: "exec Continue", text: "/aside exec Continue" }, runtime)).toEqual({
+			consumed: true,
+			exitCode: 1,
+		});
+		expect(output).toEqual(["partial\nAside CLI timed out or was cancelled."]);
 	});
 
 	test("sanitizes CLI control sequences before rendering output", async () => {

--- a/packages/coding-agent/src/slash-commands/aside-command.test.ts
+++ b/packages/coding-agent/src/slash-commands/aside-command.test.ts
@@ -1,6 +1,4 @@
 import { describe, expect, test } from "bun:test";
-import { ACP_BUILTIN_SLASH_COMMANDS } from "./acp-builtins";
-import { lookupBuiltinSlashCommand } from "./builtin-registry";
 import {
 	ASIDE_INSTALL_COMMAND,
 	ASIDE_USAGE,
@@ -10,6 +8,7 @@ import {
 	posixQuote,
 	probeAsideCli,
 	resolveAsideCliPath,
+	windowsPowerShellQuote,
 } from "./helpers/aside";
 
 function runtimeHarness() {
@@ -73,6 +72,13 @@ describe("posixQuote", () => {
 
 	test("leaves simple paths unquoted", () => {
 		expect(posixQuote("/Users/demo/.local/bin/aside")).toBe("/Users/demo/.local/bin/aside");
+	});
+
+	test("quotes native Windows paths for PowerShell", () => {
+		expect(windowsPowerShellQuote("C:\\Users\\demo\\Aside CLI\\aside.exe")).toBe(
+			"'C:\\Users\\demo\\Aside CLI\\aside.exe'",
+		);
+		expect(windowsPowerShellQuote("C:\\Users\\O'Brien\\aside.exe")).toBe("'C:\\Users\\O''Brien\\aside.exe'");
 	});
 });
 
@@ -164,7 +170,11 @@ describe("/aside slash command", () => {
 		const { runtime, output } = runtimeHarness();
 		expect(
 			await handle(
-				{ name: "aside", args: 'exec --session abc "Continue later"', text: '/aside exec --session abc "Continue later"' },
+				{
+					name: "aside",
+					args: 'exec --session abc "Continue later"',
+					text: '/aside exec --session abc "Continue later"',
+				},
 				runtime,
 			),
 		).toEqual({ consumed: true });
@@ -252,5 +262,17 @@ describe("/aside slash command", () => {
 			exitCode: 1,
 		});
 		expect(output).toEqual(["no daemon\n(exit 1)"]);
+	});
+
+	test("sanitizes CLI control sequences before rendering output", async () => {
+		const handle = createAsideHandler({
+			homedir: () => "/Users/demo",
+			isExecutable: filePath => filePath === "/Users/demo/.local/bin/aside",
+			which: () => null,
+			exec: async () => ({ stdout: "\x1b]0;pwned\x07safe", stderr: "", code: 0, killed: false }),
+		});
+		const { runtime, output } = runtimeHarness();
+		await handle({ name: "aside", args: "account status", text: "/aside account status" }, runtime);
+		expect(output).toEqual(["safe"]);
 	});
 });

--- a/packages/coding-agent/src/slash-commands/aside-command.test.ts
+++ b/packages/coding-agent/src/slash-commands/aside-command.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, test } from "bun:test";
+import { ACP_BUILTIN_SLASH_COMMANDS } from "./acp-builtins";
+import { lookupBuiltinSlashCommand } from "./builtin-registry";
+import {
+	ASIDE_INSTALL_COMMAND,
+	ASIDE_USAGE,
+	asideCliCandidates,
+	createAsideHandler,
+	formatAsideMcpRegistration,
+	posixQuote,
+	probeAsideCli,
+	resolveAsideCliPath,
+} from "./helpers/aside";
+
+function runtimeHarness() {
+	const output: string[] = [];
+	return {
+		runtime: {
+			session: {},
+			settings: {},
+			cwd: "/tmp",
+			output: async (message: string) => {
+				output.push(message);
+			},
+		} as never,
+		output,
+	};
+}
+
+describe("Aside CLI probe", () => {
+	test("lists installer symlink then the macOS app bundle", () => {
+		expect(asideCliCandidates("/Users/demo")).toEqual([
+			"/Users/demo/.local/bin/aside",
+			"/Users/demo/.aside/cli/Aside CLI.app/Contents/MacOS/aside",
+		]);
+	});
+
+	test("prefers the installer symlink over PATH", () => {
+		const path = resolveAsideCliPath("/Users/demo", {
+			isExecutable: filePath => filePath === "/Users/demo/.local/bin/aside",
+			which: () => "/opt/homebrew/bin/aside",
+		});
+		expect(path).toBe("/Users/demo/.local/bin/aside");
+	});
+
+	test("falls back to PATH when local candidates are missing", () => {
+		const probe = probeAsideCli("/Users/demo", {
+			isExecutable: filePath => filePath === "/opt/homebrew/bin/aside",
+			which: command => (command === "aside" ? "/opt/homebrew/bin/aside" : null),
+		});
+		expect(probe).toEqual({ ok: true, path: "/opt/homebrew/bin/aside" });
+	});
+
+	test("reports searched locations when nothing is executable", () => {
+		const probe = probeAsideCli("/Users/demo", {
+			isExecutable: () => false,
+			which: () => null,
+		});
+		expect(probe.ok).toBe(false);
+		if (probe.ok) throw new Error("expected a miss");
+		expect(probe.searched).toContain("/Users/demo/.local/bin/aside");
+		expect(probe.searched).toContain("PATH (aside)");
+		expect(probe.manualInstallCommand).toBe(ASIDE_INSTALL_COMMAND);
+	});
+});
+
+describe("posixQuote", () => {
+	test("quotes paths that contain spaces", () => {
+		expect(posixQuote("/Users/demo/.aside/cli/Aside CLI.app/Contents/MacOS/aside")).toBe(
+			"'/Users/demo/.aside/cli/Aside CLI.app/Contents/MacOS/aside'",
+		);
+	});
+
+	test("leaves simple paths unquoted", () => {
+		expect(posixQuote("/Users/demo/.local/bin/aside")).toBe("/Users/demo/.local/bin/aside");
+	});
+});
+
+describe("/aside slash command", () => {
+	test("prints usage for help verbs without probing", async () => {
+		const handle = createAsideHandler({
+			homedir: () => "/missing",
+			isExecutable: () => false,
+			which: () => null,
+			exec: async () => {
+				throw new Error("exec should not run for /aside help");
+			},
+		});
+		const { runtime, output } = runtimeHarness();
+		expect(await handle({ name: "aside", args: "help", text: "/aside help" }, runtime)).toEqual({ consumed: true });
+		expect(output).toEqual([ASIDE_USAGE]);
+	});
+
+	test("guides installation when the CLI is missing", async () => {
+		const handle = createAsideHandler({
+			homedir: () => "/Users/demo",
+			isExecutable: () => false,
+			which: () => null,
+			exec: async () => {
+				throw new Error("exec should not run when CLI is missing");
+			},
+		});
+		const { runtime, output } = runtimeHarness();
+		expect(await handle({ name: "aside", args: "", text: "/aside" }, runtime)).toEqual({ consumed: true });
+		expect(output[0]).toContain("Aside CLI was not found.");
+		expect(output[0]).toContain(ASIDE_INSTALL_COMMAND);
+		expect(output[0]).toContain(ASIDE_USAGE);
+	});
+
+	test("status prints the resolved path and version", async () => {
+		const execCalls: string[][] = [];
+		const handle = createAsideHandler({
+			homedir: () => "/Users/demo",
+			isExecutable: filePath => filePath === "/Users/demo/.local/bin/aside",
+			which: () => null,
+			exec: async (_command, args) => {
+				execCalls.push(args);
+				return { stdout: "1.26.810\n", stderr: "", code: 0, killed: false };
+			},
+		});
+		const { runtime, output } = runtimeHarness();
+		expect(await handle({ name: "aside", args: "", text: "/aside" }, runtime)).toEqual({ consumed: true });
+		expect(execCalls).toEqual([["--version"]]);
+		expect(output[0]).toContain("Aside CLI: /Users/demo/.local/bin/aside");
+		expect(output[0]).toContain("Version: 1.26.810");
+		expect(output[0]).toContain(ASIDE_USAGE);
+	});
+
+	test("freeform prompts run aside exec with a single prompt argument", async () => {
+		const execCalls: Array<{ command: string; args: string[] }> = [];
+		const handle = createAsideHandler({
+			homedir: () => "/Users/demo",
+			isExecutable: filePath => filePath === "/Users/demo/.local/bin/aside",
+			which: () => null,
+			exec: async (command, args) => {
+				execCalls.push({ command, args });
+				return { stdout: "ok", stderr: "", code: 0, killed: false };
+			},
+		});
+		const { runtime, output } = runtimeHarness();
+		expect(
+			await handle(
+				{ name: "aside", args: "Summarize the current page", text: "/aside Summarize the current page" },
+				runtime,
+			),
+		).toEqual({ consumed: true });
+		expect(execCalls).toEqual([
+			{ command: "/Users/demo/.local/bin/aside", args: ["exec", "Summarize the current page"] },
+		]);
+		expect(output).toEqual(["ok"]);
+	});
+
+	test("exec passes quoted argv through without a shell", async () => {
+		const execCalls: string[][] = [];
+		const handle = createAsideHandler({
+			homedir: () => "/Users/demo",
+			isExecutable: filePath => filePath === "/Users/demo/.local/bin/aside",
+			which: () => null,
+			exec: async (_command, args) => {
+				execCalls.push(args);
+				return { stdout: "", stderr: "", code: 0, killed: false };
+			},
+		});
+		const { runtime, output } = runtimeHarness();
+		expect(
+			await handle(
+				{ name: "aside", args: 'exec --session abc "Continue later"', text: '/aside exec --session abc "Continue later"' },
+				runtime,
+			),
+		).toEqual({ consumed: true });
+		expect(execCalls).toEqual([["exec", "--session", "abc", "Continue later"]]);
+		expect(output).toEqual(["Aside CLI exited 0 with no output."]);
+	});
+
+	test("leading flags are forwarded to aside exec", async () => {
+		const execCalls: string[][] = [];
+		const handle = createAsideHandler({
+			homedir: () => "/Users/demo",
+			isExecutable: filePath => filePath === "/Users/demo/.local/bin/aside",
+			which: () => null,
+			exec: async (_command, args) => {
+				execCalls.push(args);
+				return { stdout: "continued", stderr: "", code: 0, killed: false };
+			},
+		});
+		const { runtime } = runtimeHarness();
+		await handle({ name: "aside", args: "--session abc Continue", text: "/aside --session abc Continue" }, runtime);
+		expect(execCalls).toEqual([["exec", "--session", "abc", "Continue"]]);
+	});
+
+	test("mcp prints a quoted registration command and does not spawn stdio", async () => {
+		const handle = createAsideHandler({
+			homedir: () => "/Users/demo",
+			isExecutable: filePath => filePath.includes("Aside CLI.app"),
+			which: () => null,
+			exec: async () => {
+				throw new Error("mcp must not spawn aside mcp");
+			},
+		});
+		const { runtime, output } = runtimeHarness();
+		const cliPath = "/Users/demo/.aside/cli/Aside CLI.app/Contents/MacOS/aside";
+		expect(await handle({ name: "aside", args: "mcp", text: "/aside mcp" }, runtime)).toEqual({ consumed: true });
+		expect(output).toEqual([formatAsideMcpRegistration(cliPath)]);
+		expect(output[0]).toContain(`gjc mcp add aside ${posixQuote(cliPath)} mcp --project`);
+		expect(output[0]).not.toContain("aside mcp\n");
+	});
+
+	test("repl refuses to run inside GJC", async () => {
+		const handle = createAsideHandler({
+			homedir: () => "/Users/demo",
+			isExecutable: filePath => filePath === "/Users/demo/.local/bin/aside",
+			which: () => null,
+			exec: async () => {
+				throw new Error("repl must not spawn");
+			},
+		});
+		const { runtime, output } = runtimeHarness();
+		expect(await handle({ name: "aside", args: "repl", text: "/aside repl" }, runtime)).toEqual({ consumed: true });
+		expect(output[0]).toContain("needs a real terminal TTY");
+		expect(output[0]).toContain("/Users/demo/.local/bin/aside repl");
+	});
+
+	test("account forwards subcommands", async () => {
+		const execCalls: string[][] = [];
+		const handle = createAsideHandler({
+			homedir: () => "/Users/demo",
+			isExecutable: filePath => filePath === "/Users/demo/.local/bin/aside",
+			which: () => null,
+			exec: async (_command, args) => {
+				execCalls.push(args);
+				return { stdout: "u0", stderr: "", code: 0, killed: false };
+			},
+		});
+		const { runtime, output } = runtimeHarness();
+		expect(await handle({ name: "aside", args: "account list", text: "/aside account list" }, runtime)).toEqual({
+			consumed: true,
+		});
+		expect(execCalls).toEqual([["account", "list"]]);
+		expect(output).toEqual(["u0"]);
+	});
+
+	test("nonzero CLI exit is consumed with a non-zero status", async () => {
+		const handle = createAsideHandler({
+			homedir: () => "/Users/demo",
+			isExecutable: filePath => filePath === "/Users/demo/.local/bin/aside",
+			which: () => null,
+			exec: async () => ({ stdout: "no daemon", stderr: "", code: 1, killed: false }),
+		});
+		const { runtime, output } = runtimeHarness();
+		expect(await handle({ name: "aside", args: "account status", text: "/aside account status" }, runtime)).toEqual({
+			consumed: true,
+			exitCode: 1,
+		});
+		expect(output).toEqual(["no daemon\n(exit 1)"]);
+	});
+});

--- a/packages/coding-agent/src/slash-commands/aside-command.test.ts
+++ b/packages/coding-agent/src/slash-commands/aside-command.test.ts
@@ -254,6 +254,22 @@ describe("/aside slash command", () => {
 		expect(output[0]).not.toContain("aside mcp\n");
 	});
 
+	test("rejects unexpected MCP arguments without probing or spawning", async () => {
+		const handle = createAsideHandler({
+			homedir: () => "/missing",
+			isExecutable: () => false,
+			which: () => null,
+			exec: async () => {
+				throw new Error("mcp must not spawn");
+			},
+		});
+		const { runtime, output } = runtimeHarness();
+		expect(await handle({ name: "aside", args: "mcp unexpected", text: "/aside mcp unexpected" }, runtime)).toEqual({
+			consumed: true,
+		});
+		expect(output).toEqual(["Usage: /aside mcp"]);
+	});
+
 	test("repl refuses to run inside GJC", async () => {
 		const handle = createAsideHandler({
 			homedir: () => "/Users/demo",
@@ -267,6 +283,24 @@ describe("/aside slash command", () => {
 		expect(await handle({ name: "aside", args: "repl", text: "/aside repl" }, runtime)).toEqual({ consumed: true });
 		expect(output[0]).toContain("needs a real terminal TTY");
 		expect(output[0]).toContain("/Users/demo/.local/bin/aside repl");
+	});
+
+	test("rejects unexpected REPL arguments without probing or spawning", async () => {
+		const handle = createAsideHandler({
+			homedir: () => "/missing",
+			isExecutable: () => false,
+			which: () => null,
+			exec: async () => {
+				throw new Error("repl must not spawn");
+			},
+		});
+		const { runtime, output } = runtimeHarness();
+		expect(await handle({ name: "aside", args: "repl unexpected", text: "/aside repl unexpected" }, runtime)).toEqual(
+			{
+				consumed: true,
+			},
+		);
+		expect(output).toEqual(["Usage: /aside repl"]);
 	});
 
 	test("account forwards subcommands", async () => {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -45,6 +45,7 @@ import {
 } from "../setup/provider-onboarding";
 import { parseThinkingLevel } from "../thinking";
 import { getDisplayChangelogEntries } from "../utils/changelog";
+import { handleAsideAcp } from "./helpers/aside";
 import { buildAutoroutingStatusReport } from "./helpers/autorouting-status";
 import { buildContextReportText } from "./helpers/context-report";
 import { switchSessionCredentialCommand } from "./helpers/credential-switch";
@@ -609,6 +610,24 @@ const shutdownHandlerTui = (_command: ParsedSlashCommand, runtime: TuiSlashComma
 const IMPORT_SESSION_RETAINED_DESCRIPTOR_AUTHORITY_AVAILABLE = process.platform === "linux";
 
 const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
+	{
+		name: "aside",
+		priority: 32,
+		description: "Run the Aside CLI from the composer",
+		acpDescription: "Run the Aside CLI",
+		subcommands: [
+			{ name: "exec", description: "Run Aside with a prompt", usage: "[args] <prompt>" },
+			{ name: "repl", description: "Aside REPL is terminal-only; prints the outside command" },
+			{ name: "mcp", description: "Print MCP registration using the resolved CLI path" },
+			{ name: "account", description: "Inspect or select Aside CLI accounts", usage: "[list|status|use]" },
+			{ name: "help", description: "Show /aside usage" },
+		],
+		inlineHint: "[exec|repl|mcp|account|help|<prompt>]",
+		acpInputHint: "[exec|repl|mcp|account|help|<prompt>]",
+		allowArgs: true,
+		localHeadless: true,
+		handle: handleAsideAcp,
+	},
 	{
 		name: "import-session",
 		priority: 29,

--- a/packages/coding-agent/src/slash-commands/helpers/aside.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/aside.ts
@@ -1,0 +1,225 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type ExecOptions, type ExecResult, execCommand } from "../../exec/exec";
+import { parseCommandArgs } from "../../utils/command-args";
+import type { ParsedSlashCommand, SlashCommandResult, SlashCommandRuntime } from "../types";
+import { commandConsumed, errorMessage, parseSubcommand, usage } from "./parse";
+
+/**
+ * Aside CLI discovery and `/aside` dispatch.
+ *
+ * Probe-only: never runs the installer. Missing-CLI handling is the caller's
+ * decision. This is an explicit composer frontend, not a GJC browser backend.
+ */
+
+export const ASIDE_INSTALL_URL = "https://releases.aside.com/install.sh";
+export const ASIDE_INSTALL_COMMAND = "curl -fsSL https://releases.aside.com/install.sh | bash";
+
+const ASIDE_HELP_VERBS = new Set(["help", "-h", "--help"]);
+
+const ASIDE_STATUS_TIMEOUT_MS = 15_000;
+const ASIDE_EXEC_TIMEOUT_MS = 10 * 60 * 1000;
+
+export const ASIDE_USAGE = [
+	"Aside CLI (explicit opt-in; does not enable GJC browser-control by default)",
+	"  /aside                         Show CLI path and usage",
+	"  /aside <prompt>                Run `aside exec <prompt>`",
+	"  /aside exec [args]             Pass argv through to `aside exec`",
+	"  /aside repl                    Not available inside GJC; run `aside repl` in a terminal",
+	"  /aside mcp                     Print MCP registration using the resolved CLI path",
+	"  /aside account [args]          Run `aside account` (list/status/use)",
+	"  /aside help                    Show this help",
+].join("\n");
+
+export type AsideCliProbe =
+	| { ok: true; path: string }
+	| { ok: false; searched: string[]; manualInstallCommand: string; url: string };
+
+export type AsideWhich = (command: string) => string | null | undefined;
+export type AsideIsExecutable = (filePath: string) => boolean;
+export type AsideExec = (
+	command: string,
+	args: string[],
+	cwd: string,
+	options?: ExecOptions,
+) => Promise<ExecResult>;
+
+export interface AsideHandlerOptions {
+	homedir?: () => string;
+	which?: AsideWhich;
+	isExecutable?: AsideIsExecutable;
+	exec?: AsideExec;
+}
+
+/** Candidate absolute paths for the `aside` CLI, in priority order. */
+export function asideCliCandidates(home = os.homedir()): string[] {
+	return [
+		path.join(home, ".local", "bin", "aside"),
+		path.join(home, ".aside", "cli", "Aside CLI.app", "Contents", "MacOS", "aside"),
+	];
+}
+
+function defaultIsExecutable(filePath: string): boolean {
+	try {
+		const st = fs.statSync(filePath);
+		if (!st.isFile()) return false;
+		fs.accessSync(filePath, fs.constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function defaultWhich(command: string): string | null {
+	return Bun.which(command) ?? null;
+}
+
+/** Resolve the first executable Aside CLI path, or null when none is found. */
+export function resolveAsideCliPath(
+	home = os.homedir(),
+	options: Pick<AsideHandlerOptions, "which" | "isExecutable"> = {},
+): string | null {
+	const isExecutable = options.isExecutable ?? defaultIsExecutable;
+	const which = options.which ?? defaultWhich;
+	for (const candidate of asideCliCandidates(home)) {
+		if (isExecutable(candidate)) return candidate;
+	}
+	const fromPath = which("aside");
+	if (fromPath && isExecutable(fromPath)) return fromPath;
+	return null;
+}
+
+/** Structured probe result for callers that need to guide installation. */
+export function probeAsideCli(
+	home = os.homedir(),
+	options: Pick<AsideHandlerOptions, "which" | "isExecutable"> = {},
+): AsideCliProbe {
+	const searched = [...asideCliCandidates(home), "PATH (aside)"];
+	const found = resolveAsideCliPath(home, options);
+	if (found) return { ok: true, path: found };
+	return { ok: false, searched, manualInstallCommand: ASIDE_INSTALL_COMMAND, url: ASIDE_INSTALL_URL };
+}
+
+export function posixQuote(value: string): string {
+	if (value.length === 0) return "''";
+	if (/^[A-Za-z0-9_./:-]+$/.test(value)) return value;
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function formatAsideMissingCli(probe: Extract<AsideCliProbe, { ok: false }>): string {
+	return [
+		"Aside CLI was not found.",
+		"Looked in:",
+		...probe.searched.map(entry => `  - ${entry}`),
+		"Install with:",
+		`  ${probe.manualInstallCommand}`,
+		`Docs: ${probe.url}`,
+		"Then retry /aside, or register MCP with the concrete binary path.",
+	].join("\n");
+}
+
+export function formatAsideMcpRegistration(cliPath: string): string {
+	return [
+		`Aside CLI: ${cliPath}`,
+		"`/aside mcp` does not start a stdio server inside GJC.",
+		"Register the user-owned MCP definition with the resolved binary:",
+		`  gjc mcp add aside ${posixQuote(cliPath)} mcp --project`,
+		"Inspect the redacted record with `gjc mcp list --json`.",
+		"Do not paste cookies, screenshots, or private Aside profile paths into issues or PRs.",
+	].join("\n");
+}
+
+function formatExecOutput(result: ExecResult): string {
+	const body = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join("\n");
+	if (result.killed) {
+		return body ? `${body}\nAside CLI timed out or was cancelled.` : "Aside CLI timed out or was cancelled.";
+	}
+	if (!body) {
+		return result.code === 0 ? "Aside CLI exited 0 with no output." : `Aside CLI exited ${result.code} with no output.`;
+	}
+	if (result.code !== 0) return `${body}\n(exit ${result.code})`;
+	return body;
+}
+
+export function createAsideHandler(options: AsideHandlerOptions = {}) {
+	const homedir = options.homedir ?? os.homedir;
+	const exec = options.exec ?? execCommand;
+	const probeOptions = { which: options.which, isExecutable: options.isExecutable };
+
+	async function runCli(
+		runtime: SlashCommandRuntime,
+		cliPath: string,
+		args: string[],
+		timeout: number,
+	): Promise<SlashCommandResult> {
+		try {
+			const result = await exec(cliPath, args, runtime.cwd, { timeout });
+			await runtime.output(formatExecOutput(result));
+			return result.code === 0 && !result.killed ? commandConsumed() : { consumed: true, exitCode: result.code || 1 };
+		} catch (error) {
+			return usage(`Aside CLI failed: ${errorMessage(error)}`, runtime);
+		}
+	}
+
+	return async function handleAsideAcp(
+		command: ParsedSlashCommand,
+		runtime: SlashCommandRuntime,
+	): Promise<SlashCommandResult> {
+		const { verb, rest } = parseSubcommand(command.args);
+		if (ASIDE_HELP_VERBS.has(verb)) return usage(ASIDE_USAGE, runtime);
+
+		const probe = probeAsideCli(homedir(), probeOptions);
+
+		if (verb === "mcp") {
+			if (!probe.ok) return usage(formatAsideMissingCli(probe), runtime);
+			return usage(formatAsideMcpRegistration(probe.path), runtime);
+		}
+
+		if (verb === "repl") {
+			if (!probe.ok) return usage(formatAsideMissingCli(probe), runtime);
+			return usage(
+				[
+					"`/aside repl` needs a real terminal TTY.",
+					`Run this outside GJC: ${posixQuote(probe.path)} repl`,
+				].join("\n"),
+				runtime,
+			);
+		}
+
+		if (!verb) {
+			if (!probe.ok) return usage(`${formatAsideMissingCli(probe)}\n\n${ASIDE_USAGE}`, runtime);
+			const lines = [`Aside CLI: ${probe.path}`];
+			try {
+				const version = await exec(probe.path, ["--version"], runtime.cwd, { timeout: ASIDE_STATUS_TIMEOUT_MS });
+				const label = version.stdout.trim() || version.stderr.trim();
+				if (version.code === 0 && label) lines.push(`Version: ${label.split("\n")[0]}`);
+			} catch {
+				// Status should still print when `--version` is unavailable.
+			}
+			lines.push(ASIDE_USAGE);
+			await runtime.output(lines.join("\n"));
+			return commandConsumed();
+		}
+
+		if (!probe.ok) return usage(formatAsideMissingCli(probe), runtime);
+
+		if (verb === "account") {
+			return runCli(runtime, probe.path, ["account", ...parseCommandArgs(rest)], ASIDE_STATUS_TIMEOUT_MS);
+		}
+
+		if (verb === "exec") {
+			const argv = parseCommandArgs(rest);
+			if (argv.length === 0) return usage("Usage: /aside exec [args] <prompt>", runtime);
+			return runCli(runtime, probe.path, ["exec", ...argv], ASIDE_EXEC_TIMEOUT_MS);
+		}
+
+		if (verb.startsWith("-")) {
+			return runCli(runtime, probe.path, ["exec", ...parseCommandArgs(command.args)], ASIDE_EXEC_TIMEOUT_MS);
+		}
+
+		return runCli(runtime, probe.path, ["exec", command.args.trim()], ASIDE_EXEC_TIMEOUT_MS);
+	};
+}
+
+export const handleAsideAcp = createAsideHandler();

--- a/packages/coding-agent/src/slash-commands/helpers/aside.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/aside.ts
@@ -1,9 +1,8 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { sanitizeText } from "@gajae-code/utils";
+import { sanitizeDisplayLine, sanitizeText } from "@gajae-code/utils";
 import { type ExecOptions, type ExecResult, execCommand } from "../../exec/exec";
-import { parseCommandArgs } from "../../utils/command-args";
 import type { ParsedSlashCommand, SlashCommandResult, SlashCommandRuntime } from "../types";
 import { commandConsumed, errorMessage, parseSubcommand, usage } from "./parse";
 
@@ -112,8 +111,59 @@ export function windowsPowerShellQuote(value: string): string {
 	return `'${value.replace(/'/g, "''")}'`;
 }
 
-function quoteAsidePath(value: string): string {
-	return process.platform === "win32" ? windowsPowerShellQuote(value) : posixQuote(value);
+function quoteAsidePath(value: string, platform = process.platform): string {
+	return platform === "win32" ? windowsPowerShellQuote(value) : posixQuote(value);
+}
+
+type AsideArgvResult = { ok: true; args: string[] } | { ok: false; error: string };
+
+/** Parse user-provided Aside argv without silently accepting malformed quoting. */
+export function parseAsideArgv(input: string): AsideArgvResult {
+	const args: string[] = [];
+	let current = "";
+	let tokenStarted = false;
+	let quote: "'" | '"' | null = null;
+	let escaped = false;
+
+	for (const char of input) {
+		if (escaped) {
+			current += char;
+			tokenStarted = true;
+			escaped = false;
+			continue;
+		}
+		if (quote) {
+			if (char === quote) {
+				quote = null;
+			} else if (char === "\\" && quote === '"') {
+				escaped = true;
+			} else {
+				current += char;
+			}
+			continue;
+		}
+		if (char === "'" || char === '"') {
+			quote = char;
+			tokenStarted = true;
+		} else if (char === "\\") {
+			escaped = true;
+			tokenStarted = true;
+		} else if (char === " " || char === "\t") {
+			if (tokenStarted) {
+				args.push(current);
+				current = "";
+				tokenStarted = false;
+			}
+		} else {
+			current += char;
+			tokenStarted = true;
+		}
+	}
+
+	if (escaped) return { ok: false, error: "unfinished escape" };
+	if (quote) return { ok: false, error: "unterminated quote" };
+	if (tokenStarted) args.push(current);
+	return { ok: true, args };
 }
 
 export function formatAsideMissingCli(probe: Extract<AsideCliProbe, { ok: false }>): string {
@@ -129,9 +179,9 @@ export function formatAsideMissingCli(probe: Extract<AsideCliProbe, { ok: false 
 	].join("\n");
 }
 
-export function formatAsideMcpRegistration(cliPath: string): string {
+export function formatAsideMcpRegistration(cliPath: string, platform = process.platform): string {
 	const safeCliPath = sanitizeText(cliPath).replace(/[\r\n]/gu, " ");
-	const quotedCliPath = quoteAsidePath(safeCliPath);
+	const quotedCliPath = quoteAsidePath(safeCliPath, platform);
 	return [
 		`Aside CLI: ${safeCliPath}`,
 		"`/aside mcp` does not start a stdio server inside GJC.",
@@ -208,7 +258,7 @@ export function createAsideHandler(options: AsideHandlerOptions = {}) {
 			const lines = [`Aside CLI: ${probe.path}`];
 			try {
 				const version = await exec(probe.path, ["--version"], runtime.cwd, { timeout: ASIDE_STATUS_TIMEOUT_MS });
-				const label = version.stdout.trim() || version.stderr.trim();
+				const label = sanitizeDisplayLine(version.stdout).trim() || sanitizeDisplayLine(version.stderr).trim();
 				if (version.code === 0 && label) lines.push(`Version: ${label.split("\n")[0]}`);
 			} catch {
 				// Status should still print when `--version` is unavailable.
@@ -221,17 +271,23 @@ export function createAsideHandler(options: AsideHandlerOptions = {}) {
 		if (!probe.ok) return usage(formatAsideMissingCli(probe), runtime);
 
 		if (verb === "account") {
-			return runCli(runtime, probe.path, ["account", ...parseCommandArgs(rest)], ASIDE_STATUS_TIMEOUT_MS);
+			const parsed = parseAsideArgv(rest);
+			if (!parsed.ok) return usage(`Invalid Aside arguments: ${parsed.error}.`, runtime);
+			return runCli(runtime, probe.path, ["account", ...parsed.args], ASIDE_STATUS_TIMEOUT_MS);
 		}
 
 		if (verb === "exec") {
-			const argv = parseCommandArgs(rest);
+			const parsed = parseAsideArgv(rest);
+			if (!parsed.ok) return usage(`Invalid Aside arguments: ${parsed.error}.`, runtime);
+			const argv = parsed.args;
 			if (argv.length === 0) return usage("Usage: /aside exec [args] <prompt>", runtime);
 			return runCli(runtime, probe.path, ["exec", ...argv], ASIDE_EXEC_TIMEOUT_MS);
 		}
 
 		if (verb.startsWith("-")) {
-			return runCli(runtime, probe.path, ["exec", ...parseCommandArgs(command.args)], ASIDE_EXEC_TIMEOUT_MS);
+			const parsed = parseAsideArgv(command.args);
+			if (!parsed.ok) return usage(`Invalid Aside arguments: ${parsed.error}.`, runtime);
+			return runCli(runtime, probe.path, ["exec", ...parsed.args], ASIDE_EXEC_TIMEOUT_MS);
 		}
 
 		return runCli(runtime, probe.path, ["exec", command.args.trim()], ASIDE_EXEC_TIMEOUT_MS);

--- a/packages/coding-agent/src/slash-commands/helpers/aside.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/aside.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { sanitizeText } from "@gajae-code/utils";
 import { type ExecOptions, type ExecResult, execCommand } from "../../exec/exec";
 import { parseCommandArgs } from "../../utils/command-args";
 import type { ParsedSlashCommand, SlashCommandResult, SlashCommandRuntime } from "../types";
@@ -38,12 +39,7 @@ export type AsideCliProbe =
 
 export type AsideWhich = (command: string) => string | null | undefined;
 export type AsideIsExecutable = (filePath: string) => boolean;
-export type AsideExec = (
-	command: string,
-	args: string[],
-	cwd: string,
-	options?: ExecOptions,
-) => Promise<ExecResult>;
+export type AsideExec = (command: string, args: string[], cwd: string, options?: ExecOptions) => Promise<ExecResult>;
 
 export interface AsideHandlerOptions {
 	homedir?: () => string;
@@ -75,6 +71,10 @@ function defaultWhich(command: string): string | null {
 	return Bun.which(command) ?? null;
 }
 
+function isSafeAsideCliPath(value: string): boolean {
+	return sanitizeText(value) === value && !/[\r\n]/u.test(value);
+}
+
 /** Resolve the first executable Aside CLI path, or null when none is found. */
 export function resolveAsideCliPath(
 	home = os.homedir(),
@@ -83,10 +83,10 @@ export function resolveAsideCliPath(
 	const isExecutable = options.isExecutable ?? defaultIsExecutable;
 	const which = options.which ?? defaultWhich;
 	for (const candidate of asideCliCandidates(home)) {
-		if (isExecutable(candidate)) return candidate;
+		if (isExecutable(candidate) && isSafeAsideCliPath(candidate)) return candidate;
 	}
 	const fromPath = which("aside");
-	if (fromPath && isExecutable(fromPath)) return fromPath;
+	if (fromPath && isExecutable(fromPath) && isSafeAsideCliPath(fromPath)) return fromPath;
 	return null;
 }
 
@@ -107,12 +107,22 @@ export function posixQuote(value: string): string {
 	return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
+/** Quote a path for the PowerShell command shown on native Windows. */
+export function windowsPowerShellQuote(value: string): string {
+	return `'${value.replace(/'/g, "''")}'`;
+}
+
+function quoteAsidePath(value: string): string {
+	return process.platform === "win32" ? windowsPowerShellQuote(value) : posixQuote(value);
+}
+
 export function formatAsideMissingCli(probe: Extract<AsideCliProbe, { ok: false }>): string {
+	const installLabel = process.platform === "win32" ? "Install with in WSL or Git Bash:" : "Install with:";
 	return [
 		"Aside CLI was not found.",
 		"Looked in:",
 		...probe.searched.map(entry => `  - ${entry}`),
-		"Install with:",
+		installLabel,
 		`  ${probe.manualInstallCommand}`,
 		`Docs: ${probe.url}`,
 		"Then retry /aside, or register MCP with the concrete binary path.",
@@ -120,23 +130,27 @@ export function formatAsideMissingCli(probe: Extract<AsideCliProbe, { ok: false 
 }
 
 export function formatAsideMcpRegistration(cliPath: string): string {
+	const safeCliPath = sanitizeText(cliPath).replace(/[\r\n]/gu, " ");
+	const quotedCliPath = quoteAsidePath(safeCliPath);
 	return [
-		`Aside CLI: ${cliPath}`,
+		`Aside CLI: ${safeCliPath}`,
 		"`/aside mcp` does not start a stdio server inside GJC.",
 		"Register the user-owned MCP definition with the resolved binary:",
-		`  gjc mcp add aside ${posixQuote(cliPath)} mcp --project`,
+		`  gjc mcp add aside ${quotedCliPath} mcp --project`,
 		"Inspect the redacted record with `gjc mcp list --json`.",
 		"Do not paste cookies, screenshots, or private Aside profile paths into issues or PRs.",
 	].join("\n");
 }
 
 function formatExecOutput(result: ExecResult): string {
-	const body = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join("\n");
+	const body = [sanitizeText(result.stdout).trim(), sanitizeText(result.stderr).trim()].filter(Boolean).join("\n");
 	if (result.killed) {
 		return body ? `${body}\nAside CLI timed out or was cancelled.` : "Aside CLI timed out or was cancelled.";
 	}
 	if (!body) {
-		return result.code === 0 ? "Aside CLI exited 0 with no output." : `Aside CLI exited ${result.code} with no output.`;
+		return result.code === 0
+			? "Aside CLI exited 0 with no output."
+			: `Aside CLI exited ${result.code} with no output.`;
 	}
 	if (result.code !== 0) return `${body}\n(exit ${result.code})`;
 	return body;
@@ -156,7 +170,9 @@ export function createAsideHandler(options: AsideHandlerOptions = {}) {
 		try {
 			const result = await exec(cliPath, args, runtime.cwd, { timeout });
 			await runtime.output(formatExecOutput(result));
-			return result.code === 0 && !result.killed ? commandConsumed() : { consumed: true, exitCode: result.code || 1 };
+			return result.code === 0 && !result.killed
+				? commandConsumed()
+				: { consumed: true, exitCode: result.code || 1 };
 		} catch (error) {
 			return usage(`Aside CLI failed: ${errorMessage(error)}`, runtime);
 		}
@@ -181,7 +197,7 @@ export function createAsideHandler(options: AsideHandlerOptions = {}) {
 			return usage(
 				[
 					"`/aside repl` needs a real terminal TTY.",
-					`Run this outside GJC: ${posixQuote(probe.path)} repl`,
+					`Run this outside GJC: ${quoteAsidePath(probe.path)} repl`,
 				].join("\n"),
 				runtime,
 			);

--- a/packages/coding-agent/src/slash-commands/helpers/aside.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/aside.ts
@@ -238,11 +238,13 @@ export function createAsideHandler(options: AsideHandlerOptions = {}) {
 		const probe = probeAsideCli(homedir(), probeOptions);
 
 		if (verb === "mcp") {
+			if (rest) return usage("Usage: /aside mcp", runtime);
 			if (!probe.ok) return usage(formatAsideMissingCli(probe), runtime);
 			return usage(formatAsideMcpRegistration(probe.path), runtime);
 		}
 
 		if (verb === "repl") {
+			if (rest) return usage("Usage: /aside repl", runtime);
 			if (!probe.ok) return usage(formatAsideMissingCli(probe), runtime);
 			return usage(
 				[

--- a/packages/coding-agent/test/bot-integration-docs.test.ts
+++ b/packages/coding-agent/test/bot-integration-docs.test.ts
@@ -87,6 +87,8 @@ describe("external controller integration docs", () => {
 		expect(guide).toContain("docs-only");
 		expect(guide).toContain("aside mcp");
 		expect(guide).toContain("gjc mcp add aside aside mcp --project");
+		expect(guide).toContain("/aside");
+		expect(guide).toContain("composer slash command");
 		expect(guide).toContain("browser actions and form submissions");
 		expect(guide).toContain("login flows, credential autofill, MFA");
 		expect(guide).toContain("payments, purchases, subscriptions, billing changes");

--- a/packages/coding-agent/test/slash-command-builtin-registry.test.ts
+++ b/packages/coding-agent/test/slash-command-builtin-registry.test.ts
@@ -6,6 +6,7 @@ import { Settings } from "@gajae-code/coding-agent/config/settings";
 import { BUILTIN_SLASH_COMMANDS } from "@gajae-code/coding-agent/extensibility/slash-commands";
 import { getCurrentThemeName, initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+import { ACP_BUILTIN_SLASH_COMMANDS } from "@gajae-code/coding-agent/slash-commands/acp-builtins";
 import {
 	BUILTIN_SLASH_COMMAND_DEFS,
 	BUILTIN_SLASH_COMMANDS_INTERNAL,
@@ -613,5 +614,24 @@ describe("builtin /routing slash command", () => {
 
 		expect(fastLine).toBeDefined();
 		expect(fastLine?.length).toBeLessThanOrEqual(220);
+	});
+});
+
+describe("builtin /aside slash command", () => {
+	it("is discoverable with Aside CLI completion metadata", () => {
+		const asideCommand = BUILTIN_SLASH_COMMAND_DEFS.find(command => command.name === "aside");
+
+		expect(asideCommand).toBeDefined();
+		expect(asideCommand?.description).toContain("Aside CLI");
+		expect(asideCommand?.inlineHint).toBe("[exec|repl|mcp|account|help|<prompt>]");
+		expect(asideCommand?.subcommands?.map(command => command.name)).toEqual([
+			"exec",
+			"repl",
+			"mcp",
+			"account",
+			"help",
+		]);
+		expect(lookupBuiltinSlashCommand("aside")?.allowArgs).toBe(true);
+		expect(ACP_BUILTIN_SLASH_COMMANDS.some(command => command.name === "aside")).toBe(true);
 	});
 });


### PR DESCRIPTION
## Maintainer fix-forward for external PR #4955

This existing source PR by @twoimo carries the valuable implementation and now includes the maintainer fix-forward hardening on the same PR path. No duplicate merge candidate was created.

### Review scope

- `/aside` value and explicit opt-in behavior
- no-shell argv forwarding and command parsing
- process timeout / non-zero exit lifecycle
- TUI and ACP registry integration
- native Windows PowerShell quoting and WSL/Git Bash installer guidance
- external output sanitization to prevent terminal-control injection
- docs, changelog, and targeted tests

### Exact source and owner head

- Source PR: #4955
- Source head: `6b45eaf4eb00c8dbd22dea2d85cf9f66e0874f19`
- Owner fix-forward head: `d92cfe0646b66ecd8338996772345c81ea0c6b3f`
- Immutable base: `354c13c57e9ed29e5aa5708ceb5f79b2017d9acf`

### Verification

- `bun test packages/coding-agent/src/slash-commands/aside-command.test.ts packages/coding-agent/test/slash-command-builtin-registry.test.ts packages/coding-agent/test/bot-integration-docs.test.ts packages/coding-agent/test/sdk-operation-inventory.test.ts` — 80 pass / 0 fail
- `bun test packages/coding-agent/src/slash-commands/aside-command.test.ts` after blocker hardening — 23 pass / 0 fail
- `bun --cwd=packages/coding-agent run check` — exit 0
- `bun run check:ts` — exit 0
- `bunx biome check` on affected coding-agent files — exit 0
- `bun scripts/verify-gjc-state-writers.ts --fail --root .` — 0 violations
- Native addon rebuilt with `bun --cwd=packages/natives run build`

## GJC verdict

gajae.pr-review-verdict.v1 merge-approved sha256:363d3387883b16f959e0267791efcf4a19b385cfcda994d106f3d0c7a397067a reviewer:human reviewer-id:Yeachan-Heo evidence:strict utility-subcommand validation plus retained malformed argv rejection, version-output sanitization, Windows branch coverage, and timeout coverage on dev 354c13c57e9ed29e5aa5708ceb5f79b2017d9acf

## Risk classification

- [ ] `low-risk`
- [ ] `regression-risk`
- [x] `high-risk`

- [x] Target branch is `dev`
- [x] Exact owner head is `d92cfe0646b66ecd8338996772345c81ea0c6b3f`
- [x] Targeted and affected package checks pass
- [x] High-risk process-execution surface reviewed independently by the repository maintainer