### PR TITLE
fix(tui): anchor the /login URL so narrow-pane fragments stay clickable

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- The `/login` URL row is now an OSC 8 anchor pointing at itself, so a login URL wider than the pane stays clickable on every wrapped fragment. A login URL is one unbreakable token, so a pane narrower than the URL splits it across rows; the row printed the bare URL, so the wrap layer had no link to carry (#4711) and every fragment rendered as dead text — in a 100-column tmux pane the Anthropic authorize URL broke into four unclickable rows. Bare URLs in Markdown prose already got this treatment; the login row did not.
 - Foreground activity animation now uses layout-only TUI repaints, avoiding repeated reconstruction of unchanged transcript content during long sessions.
 - Notification adapters can now opt into one live representation per native effect: adapters that accept a positioned event are excluded from its matching raw fan-out, while ordinary direct SDK and raw-only legacy subscribers retain their existing delivery. Telegram opts in, preventing turn output, tool activity, and reasoning summaries from rendering twice after #4570; acknowledged terminal shutdown delivery is unchanged.
 - Lean notifications no longer replay a retained completion receipt at idle when identical text was already delivered immediately before an autonomous `ask`; distinct receipts and other settlement windows remain preserved.

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -256,6 +256,19 @@ export function buildStatusLineSettings(settingsInstance: Settings): StatusLineS
 	};
 }
 
+/**
+ * Build the OSC 8 anchor emitted for an OAuth login URL row.
+ *
+ * The URL row is itself an anchor, not bare text: a login URL is a single
+ * unbreakable token, so any pane narrower than the URL splits it across rows.
+ * The wrap layer re-opens the identical link on every fragment (#4711), but
+ * only for text that carries an anchor to begin with — a bare URL wrapped into
+ * fragments leaves every fragment as dead, unclickable text.
+ */
+export function buildOAuthLoginAnchor(url: string, label: string = url): string {
+	return `\x1b]8;;${url}\x07${label}\x1b]8;;\x07`;
+}
+
 function formatProviderOnboardingCommandGuide(): string {
 	return [
 		"Provider preset setup:",
@@ -3484,8 +3497,8 @@ export class SelectorController {
 				{
 					onAuth: (info: { url: string; instructions?: string }) => {
 						this.ctx.chatContainer.addChild(new Spacer(1));
-						this.ctx.chatContainer.addChild(new Text(theme.fg("dim", info.url), 1, 0));
-						const hyperlink = `\x1b]8;;${info.url}\x07Click here to login\x1b]8;;\x07`;
+						this.ctx.chatContainer.addChild(new Text(theme.fg("dim", buildOAuthLoginAnchor(info.url)), 1, 0));
+						const hyperlink = buildOAuthLoginAnchor(info.url, "Click here to login");
 						this.ctx.chatContainer.addChild(new Text(theme.fg("accent", hyperlink), 1, 0));
 						if (info.instructions) {
 							this.ctx.chatContainer.addChild(new Spacer(1));

--- a/packages/coding-agent/test/oauth-login-url-hyperlink.test.ts
+++ b/packages/coding-agent/test/oauth-login-url-hyperlink.test.ts
@@ -1,0 +1,155 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import {
+	buildOAuthLoginAnchor,
+	SelectorController,
+} from "@gajae-code/coding-agent/modes/controllers/selector-controller";
+import { getThemeByName, setThemeInstance } from "@gajae-code/coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@gajae-code/coding-agent/modes/types";
+import { type Component, Text } from "@gajae-code/tui";
+
+// A login URL is a single unbreakable token, so any pane narrower than the URL
+// splits it across rows. The wrap layer re-opens the identical OSC 8 link on
+// every fragment (#4711), but only for text that carries an anchor: the login
+// row used to print the bare URL, so every wrapped fragment rendered as dead,
+// unclickable text and the visible URL was the only affordance left.
+
+const URL =
+	"https://claude.ai/oauth/authorize?code=true&client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e" +
+	"&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A54545%2Fcallback" +
+	"&scope=org%3Acreate_api_key+user%3Aprofile+user%3Ainference" +
+	"&code_challenge=VTR_ktTm5lthKdIfASwfdho91I8mCX4D_SLjbqnpSl4&code_challenge_method=S256" +
+	"&state=4b0a9aff661f8634cd253475142f70f2";
+
+/** Strip OSC and CSI escapes, leaving only visible text. */
+function plainText(line: string): string {
+	return line.replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/gu, "").replace(/\x1b\[[0-?]*[ -/]*[@-~]/gu, "");
+}
+
+/** Non-empty link targets opened on a row. */
+function urisIn(line: string): string[] {
+	return (line.match(/\x1b\]8;[^\x07\x1b]*(?:\x07|\x1b\\)/gu) ?? [])
+		.map(seq => seq.slice(5, seq.length - (seq.endsWith("\x07") ? 1 : 2)))
+		.filter(uri => uri.length > 0);
+}
+
+/**
+ * Rows a `Text` child produces at the given container width, dropping blank
+ * rows. `Text` pads each row with a one-column margin; a URL carries no spaces,
+ * so trimming the visible text recovers the fragment exactly.
+ */
+function rowsAt(content: string, width: number): string[] {
+	return new Text(content, 1, 0).render(width).filter(row => plainText(row).trim() !== "");
+}
+
+/** Visible fragment on a row, with the component's padding margins removed. */
+function fragment(row: string): string {
+	return plainText(row).trim();
+}
+
+describe("OAuth login URL hyperlink anchor", () => {
+	it("anchors the URL to itself so the visible text stays the URL", () => {
+		const anchor = buildOAuthLoginAnchor(URL);
+
+		expect(plainText(anchor)).toBe(URL);
+		expect(urisIn(anchor)).toEqual([URL]);
+	});
+
+	it("anchors a custom label to the same target", () => {
+		const anchor = buildOAuthLoginAnchor(URL, "Click here to login");
+
+		expect(plainText(anchor)).toBe("Click here to login");
+		expect(urisIn(anchor)).toEqual([URL]);
+	});
+
+	it("keeps every fragment of the wrapped URL row clickable in a narrow pane", () => {
+		// 100 columns is a routine tmux split; the URL is far longer than that.
+		const rows = rowsAt(buildOAuthLoginAnchor(URL), 100);
+
+		expect(rows.length).toBeGreaterThan(1);
+		for (const row of rows) expect(urisIn(row)).toEqual([URL]);
+		expect(rows.map(fragment).join("")).toBe(URL);
+	});
+
+	it("survives the SGR styling the login row applies around the anchor", () => {
+		const styled = `\x1b[2m${buildOAuthLoginAnchor(URL)}\x1b[0m`;
+
+		for (const width of [120, 100, 60, 40]) {
+			const rows = rowsAt(styled, width);
+			for (const row of rows) expect(urisIn(row)).toEqual([URL]);
+			expect(rows.map(fragment).join("")).toBe(URL);
+		}
+	});
+
+	it("leaves a URL that fits on one row as a single anchored fragment", () => {
+		const rows = rowsAt(buildOAuthLoginAnchor(URL), URL.length + 8);
+
+		expect(rows).toHaveLength(1);
+		expect(urisIn(rows[0]!)).toEqual([URL]);
+		expect(fragment(rows[0]!)).toBe(URL);
+	});
+});
+
+/** Drive the login flow far enough to capture what `onAuth` renders. */
+async function renderLoginRows(url: string): Promise<Component[]> {
+	const rendered: Component[] = [];
+	const authStorage = {
+		listCredentialInventory: () => [],
+		listCredentialRemovalTargets: () => [],
+		login: async (_provider: string, callbacks: { onAuth: (info: { url: string }) => void }) => {
+			callbacks.onAuth({ url });
+			// Abort after the URL is on screen; the rows under test are already
+			// rendered and the success path needs the full session/registry graph.
+			throw new Error("login aborted by test");
+		},
+	};
+	const ctx = {
+		ui: { requestRender: () => {}, setFocus: () => {} },
+		chatContainer: { addChild: (child: Component) => rendered.push(child) },
+		editorContainer: { clear: () => {}, detachChild: () => {}, addChild: () => {} },
+		editor: {},
+		showStatus: () => {},
+		showError: () => {},
+		openInBrowser: () => {},
+		oauthManualInput: { waitForInput: async () => "", clear: () => {} },
+		session: { modelRegistry: { authStorage, getModelProfiles: () => new Map() } },
+	} as unknown as InteractiveModeContext;
+
+	await new SelectorController(ctx).showOAuthSelector("login", "anthropic");
+	return rendered;
+}
+
+describe("OAuth login row emission", () => {
+	beforeAll(async () => {
+		const theme = await getThemeByName("red-claw");
+		if (!theme) throw new Error("Failed to load test theme");
+		setThemeInstance(theme);
+	});
+
+	it("renders the login URL as an anchored row whose every narrow-pane fragment is clickable", async () => {
+		const rendered = await renderLoginRows(URL);
+
+		const urlRow = rendered.find(child => child instanceof Text && plainText(child.getText()) === URL);
+		expect(urlRow).toBeDefined();
+
+		const rows = (urlRow as Text).render(100).filter(row => plainText(row).trim() !== "");
+		expect(rows.length).toBeGreaterThan(1);
+		for (const row of rows) expect(urisIn(row)).toEqual([URL]);
+		expect(rows.map(fragment).join("")).toBe(URL);
+	});
+
+	it("leaves the adjacent short-label link row pointing at the same target", async () => {
+		const rendered = await renderLoginRows(URL);
+
+		const labelRow = rendered.find(
+			child => child instanceof Text && plainText(child.getText()) === "Click here to login",
+		);
+		expect(labelRow).toBeDefined();
+		expect(urisIn((labelRow as Text).getText())).toEqual([URL]);
+
+		// The short label fits any sane pane, so it stays one row and keeps the
+		// click affordance the URL row cannot offer to a terminal without OSC 8.
+		const rows = (labelRow as Text).render(100).filter(row => plainText(row).trim() !== "");
+		expect(rows).toHaveLength(1);
+		expect(urisIn(rows[0]!)).toEqual([URL]);
+	});
+});


### PR DESCRIPTION
## What

Make the `/login` URL row an OSC 8 anchor pointing at itself, through one shared builder that the adjacent `Click here to login` row now uses as well.

One callsite, `packages/coding-agent/src/modes/controllers/selector-controller.ts`. No settings, no new policy, no behaviour change outside the login rows.

## Why

A login URL is a single unbreakable token, so a pane narrower than the URL splits it across rows. `#4711`/`#4771` made the wrap layer carry the identical OSC 8 open onto every fragment — but only for text that already carries an anchor. The `/login` row printed the bare URL, so there was no link to carry and every fragment rendered as dead text. The only clickable affordance was the separate short-label row below it.

Measured on tmux 3.5a in a 100-column pane, before this change. Each `$` is a real end of line, and `capture-pane -J` does not join them because they are application-emitted breaks, not terminal soft wrap:

```
 https://claude.ai/oauth/authorize?code=true&client_id=9d1c250a-...&respons$
 e_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A54545%2Fcallback&...user$
 %3Aprofile+user%3Ainference&code_challenge=VTR_...&code_challe$
 nge_method=S256&state=4b0a9aff661f8634cd253475142f70f2$
```

Per-row OSC 8 open count on those four rows: `0`. After the change: `1` on each, all with the identical target, and the fragments reassemble to the original URL byte for byte.

To be precise about what this rests on: I did not find an explicit statement that this particular row must be an anchor. The argument is consistency, and two things support it.

- Bare URLs elsewhere already get this treatment. `packages/tui/test/markdown.test.ts:1093` ("should keep every wrapped URL fragment clickable with the same OSC 8 target (#4711)") pins exactly that for a bare URL sitting in prose, with no caller-supplied anchor.
- This does not add clickability to a screen that had none. The login screen already offered a click, on the short-label row directly beneath. The URL row — the thing a user actually aims at — was the part that did not respond.

If keeping the `/login` URL plain is intentional, this is the wrong change and I would rather drop it than argue.

## Testing

`packages/coding-agent/test/oauth-login-url-hyperlink.test.ts`, 7 cases: anchor shape for self-label and custom label, fragment-level link retention at 100/120/60/40 columns, the SGR styling the row actually applies, the single-row case, plus two that drive `SelectorController.showOAuthSelector("login", …)` with a stub context and assert on what `onAuth` renders — the URL row and the adjacent short-label row.

- The callsite test is red on the parent commit and green here.
- `bun test` on the touched and adjacent suites: 122 pass (this file, `wrap-osc8-hyperlink`, `wrap-ansi`, `markdown`, `oauth-flow`, `oauth-selector-filter`, `oauth-manual-input`, `login-slash-command-manual`, `model-selector-controller-batch`).
- `bun --cwd=packages/coding-agent run check:types` clean; `biome check` clean on the touched files.
- Full `bun check` does not pass on my host, for reasons unrelated to this change. `sdk-adapter-dispositions-acp.test.ts` fails `0 pass / 97 fail` with `Timed out starting production SDK host` - identical counts on this branch and on clean `797f1a2b8`, so it is host capacity, not the diff. `telegram-daemon-generation-guard.test.ts` fails only under `bun check`'s parallel `check:ts`/`check:rs` and passes standalone on both (`75 pass / 0 fail`, 96.8s here vs 94.4s on clean dev). CI is the authority for the full gate.
- Live: built from this branch, `/login anthropic` in a 100-column tmux pane, escape-preserving `capture-pane`. Four URL rows, each with one identical OSC 8 open; reassembly matches the URL exactly.

## Out of scope

- **Copy is still broken and this does not fix it.** The rows are still hard-broken, so a copy still picks up newlines. Removing the hard wrap is a product decision about how the TUI renders an unbreakable token, not a defect fix, so it is filed separately with evidence and options rather than decided here.
- **Control bytes in the URL.** `info.url` is interpolated into the OSC 8 target without rejecting `BEL`/`ESC`, so a hostile URL could terminate the sequence early. This is pre-existing and unchanged: the adjacent row already did exactly this with the same value (`selector-controller.ts:3488` before this change). Tightening it means validating at the provider/`AuthStorage` boundary, which is a wider change than this fix.
- **`TERMINAL.hyperlinks` gating.** `/login` emits OSC 8 unconditionally, unlike `status-line/segments.ts`. Left as is: the capability is forced off under any multiplexer, but tmux 3.5a does store and render the link here, so gating would remove an affordance that currently works. That policy question is the owner's.
- **Other raw-URL surfaces.** The MCP server OAuth flow renders a bare `info.url` the same way, with no hyperlink row at all, under a `"Copy this exact URL in your browser:"` label (`runtime-mcp-command-controller.ts:608-610` and `:619-621`). Not touched here: different command and flow, and it is the copy problem rather than the click one, so it belongs to the separate issue. This PR's boundary is the `/login` rows, where the failure was measured.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:1453412ba5e5f608475c12d1785933fc04329ba6811c2fccc6f6e67b9b56cad5 reviewer:critic reviewer-id:yazzang-homelab evidence:local bun test (122 pass) + check:types clean + live 100-col tmux capture; no authenticated independent APPROVED review exists, and as the author I cannot reach merge-approved
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes - see Testing: the two failing suites fail identically on clean `dev` on my host (SDK production-host startup timeouts); TypeScript, lint, and all touched/adjacent suites pass
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
