### PR TITLE
test(coding-agent): repair issue 4959 regression fixtures

### DIFF
--- a/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
@@ -853,6 +853,7 @@ describe("AgentSession MCP discovery", () => {
 		const reasoningModel: Model<"openai-responses"> = {
 			...createModel(),
 			reasoning: true,
+			compat: { supportsReasoningEffort: true },
 			thinking: { mode: "effort", minLevel: Effort.Medium, maxLevel: Effort.Medium },
 		};
 

--- a/packages/coding-agent/test/changelog.test.ts
+++ b/packages/coding-agent/test/changelog.test.ts
@@ -56,6 +56,27 @@ describe("parseChangelogContent", () => {
 
 		expect(parseChangelogContent(fixture)).toEqual([]);
 	});
+
+	it("keeps inline backticked heading references inside the owning entry", () => {
+		const fixture = [
+			"# Changelog",
+			"",
+			"## [0.15.2] - 2026-08-25",
+			"",
+			"- Everything listed under `## [0.15.1]` below ships in this release.",
+			"",
+			"## [0.15.1] - 2026-08-25",
+			"",
+			"- older entry",
+			"",
+		].join("\n");
+
+		const entries = parseChangelogContent(fixture);
+
+		expect(entries).toHaveLength(2);
+		expect(entries[0]?.content).toContain("`## [0.15.1]`");
+		expect(entries[0]?.content.split("\n")).not.toContain("## [0.15.1]");
+	});
 });
 
 describe("getDisplayChangelogEntries", () => {
@@ -118,8 +139,7 @@ describe("first-run changelog display", () => {
 		expect(olderVersion).toBeDefined();
 
 		expect(firstRunEntry!.content).toContain(`## [${VERSION}]`);
-		expect(firstRunEntry!.content).not.toContain(
-			`## [${olderVersion!.major}.${olderVersion!.minor}.${olderVersion!.patch}]`,
-		);
+		const olderHeading = `## [${olderVersion!.major}.${olderVersion!.minor}.${olderVersion!.patch}]`;
+		expect(firstRunEntry!.content.split("\n")).not.toContain(olderHeading);
 	});
 });

--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -66,6 +66,7 @@ function createReasoningModel(): Model<"openai-responses"> {
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 8192,
 		maxTokens: 2048,
+		compat: { supportsReasoningEffort: true },
 	};
 }
 

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -57,6 +57,7 @@ describe("createAgentSession deferred model pattern resolution", () => {
 					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 					contextWindow: 128000,
 					maxTokens: 8192,
+					compat: { supportsReasoningEffort: true },
 					thinking: {
 						minLevel: Effort.Minimal,
 						maxLevel: Effort.High,
@@ -72,6 +73,7 @@ describe("createAgentSession deferred model pattern resolution", () => {
 					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 					contextWindow: 128000,
 					maxTokens: 8192,
+					compat: { supportsReasoningEffort: true },
 					thinking: {
 						minLevel: Effort.Minimal,
 						maxLevel: Effort.High,
@@ -87,6 +89,7 @@ describe("createAgentSession deferred model pattern resolution", () => {
 					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 					contextWindow: 128000,
 					maxTokens: 8192,
+					compat: { supportsReasoningEffort: true },
 					thinking: {
 						minLevel: Effort.Minimal,
 						maxLevel: Effort.High,


### PR DESCRIPTION
## Summary

Closes #4959. Repairs the three red focused surfaces without weakening assertions or changing product behavior:

- Anchors the first-run changelog check to complete heading lines, and adds a deterministic fixture proving inline backticked ``## [0.15.1]`` prose remains content.
- Declares explicit reasoning support on the custom OpenAI-completions test models so model metadata normalization cannot erase the effective high/low/default thinking contract.
- Declares explicit reasoning support on the custom OpenAI-responses MCP switch model so session restoration tests exercise Medium rather than an unsupported transport.

## Root attribution

The changelog failure is a test assertion false positive: inline Markdown is not a heading. The thinking failures are latent test-fixture capability omissions exposed by the current model-selector epoch and restoration contract; the selector resolves the model correctly, while capability normalization correctly returns undefined for an unaudited custom reasoning transport. The fix makes the fixtures truthful and preserves the existing assertions for global, project, resume, model-default, explicit-default, and session-switch paths.

## Risk classification

- [ ] `low-risk`
- [ ] `regression-risk`
- [x] `high-risk`

## Evidence

- Base: `dev@6e68fafa240b8d3636b47e095e81f5ab924137c3`
- Required red CI attribution: `32905012488` (terminal-red; exact failures owned here are the three fixture/test files below)
- Exact head: `7cd3e98c79d87d26080ac3668809e6b356e009e0` (reconciled from source `13069ccdf8a54b47777ecba5134ea2d403838bf3`)
- Focused exact-head: `packages/coding-agent/test/changelog.test.ts` (6 pass), `packages/coding-agent/test/sdk-model-selection.test.ts` (31 pass), `packages/coding-agent/test/agent-session-mcp-discovery.test.ts` (22 pass)
- Related: `bun test packages/coding-agent/test/model-resolver.test.ts packages/coding-agent/test/agent-session-resume-model-behavior.test.ts` (85 pass)
- Affected package check: `bun --cwd=packages/coding-agent run check` completed type-checking; existing repository Biome warnings remain outside this change.
- Full package test command was attempted and timed out in unrelated long-running broker coverage; no test result was suppressed.
- Contract: custom OpenAI-compatible reasoning fixtures must explicitly opt in to reasoning-effort support; no source fallback, compatibility shim, or weakened assertion was added.

High-risk review: independent exact-head approval requested from `probepark`.

gajae.pr-review-verdict.v1 merge-approved sha256:b467f1b40fcd12c82e931751c2b9dd918e53b75ba805e48a1a020013affe994f reviewer:human reviewer-id:probepark evidence:exact-head-7cd3e98c-run-32905012488-three-fixture-files

