### PR TITLE
test(models): budget exhaustive secret-header matrix

### DIFF
--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -6868,7 +6868,7 @@ describe("ModelRegistry", () => {
 				await changedSecretRegistry.refreshProvider("discovery-provider", "online-if-uncached");
 				expect(requests).toBeGreaterThan(requestsBeforeChange);
 			}
-		});
+		}, 60_000);
 		test("does not expose a prior non-secret cache after switching to secret headers offline", async () => {
 			const config = (headers: Record<string, string>) => ({
 				"discovery-provider": {


### PR DESCRIPTION
## What

Increase the exhaustive model-registry secret-header provenance test's per-test timeout from Bun's 5s default to a measured 60s budget. The source diff remains exactly one timeout argument in `packages/coding-agent/test/model-registry.test.ts`.

## Why

The current canonical dev baseline completes the 19-variant matrix's 152 security assertions in about 33s wall-clock but fails Bun's default 5s test timeout. The bounded 60s allowance is below the observed latest-head sample (33.96s, 35.65s, 35.91s) with an external 90s kill guard; repeated runs complete and exit rather than masking a hang. Cache non-persistence, cache non-reuse, secret-header provenance rejection, and changed-secret refetch assertions are unchanged byte-for-byte.

## Testing

- Canonical dev `64ff42bc288e753034d92cf7c51b90410f5ad23d` baseline: focused test failed only because the unchanged 5s default fired after 33.27s wall-clock; it still reached all 152 assertions.
- Exact PR head `0dcbd143e53b32e5387d1f536700e752e575a3bd`: focused matrix passed 3/3 times in 33.96s, 35.65s, and 35.91s, with 152 expect() calls each, under a 90s external kill guard.
- Exact PR head full `model-registry.test.ts`: 295 pass, 0 fail, 12,198 expect() calls. Whole-file wall time was 204.12s; the 60s value is intentionally the single slow test's budget, not a claimed whole-file process cap.
- Exact affected plan for `64ff42bc288e753034d92cf7c51b90410f5ad23d...0dcbd143e53b32e5387d1f536700e752e575a3bd`: direct model-registry test, `native-linux-x64`, and coding-agent TypeScript build. The direct affected test command passed with the same 295/12,198 result on the exact head.
- Exact shard-1 harness replay on canonical dev and exact head both completed 183/185 before the same two unrelated failures: `settings-selector-status-line-custom.test.ts` and `runtime-mcp/mcp-autoload-redteam.test.ts`. The deterministic harness enumeration places `model-registry.test.ts` in shard 6/8 (90th of 184), so the shard-1 failures do not exercise this timeout. Both named failures reproduce on canonical dev without this PR.
- `bun --cwd=packages/coding-agent run check:types` passed.
- Fresh exact-head contract receipt: `https://github.com/Yeachan-Heo/gajae-code/runs/98030726292` passed for head `0dcbd143e53b32e5387d1f536700e752e575a3bd`.
- `bun scripts/verify-gjc-state-writers.ts --fail` passed.
- `bun test scripts/ci-dev-affected.test.ts scripts/run-bun-test-files.test.ts` passed (117 tests, 811 expect() calls).

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:c20b40b6e1b672b211affe43035a32fdc03544acf77f906a9769196efec3d2ac reviewer:human reviewer-id:Yeachan-Heo evidence:MERGE_READY exact-head focused matrix, full suite, affected plan, and checks passed
```

- [x] Target branch is `dev`
- [ ] `bun check` passes (the exact affected package type check and CI harness checks pass; full root check is outside this one-test PR scope)
- [x] Tested locally
- [ ] CHANGELOG updated (test-only change; no user-facing behavior)
- [x] Verdict above matches exact PR head `0dcbd143e53b32e5387d1f536700e752e575a3bd` and base `64ff42bc288e753034d92cf7c51b90410f5ad23d`
