### PR TITLE
fix(tui): open command palette over composer drafts

### DIFF
--- a/packages/coding-agent/src/modes/action-registry.ts
+++ b/packages/coding-agent/src/modes/action-registry.ts
@@ -164,4 +164,9 @@ export class ActionRegistry<Context> {
 			if (group) this.#busyGroups.delete(group);
 		}
 	}
+
+	async executeFresh(id: AppKeybinding): Promise<boolean> {
+		this.#availability.delete(id);
+		return this.execute(id);
+	}
 }

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -184,7 +184,7 @@ export class InputController {
 			case "app.thinking.toggle":
 				return Boolean(this.ctx.session.model?.reasoning);
 			case "app.commandPalette.open":
-				return this.ctx.editor.getText().trim().length === 0;
+				return true;
 			case "app.model.cycleForward":
 			case "app.model.cycleBackward":
 				return this.ctx.session.getRoleModelCycleCandidateCount() > 1;

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -745,7 +745,7 @@ export class InputController {
 		const queue = () => this.handleQueueSubmit();
 		this.ctx.editor.setActionKeys("app.message.queue", this.ctx.keybindings.getKeys("app.message.queue"));
 		this.ctx.editor.onQueue = () => this.#executeAction("app.message.queue");
-		this.#registerCommandPaletteAction("app.message.queue", queue);
+		this.#registerCommandPaletteAction("app.message.queue", queue, true);
 
 		this.ctx.editor.onViewportPageScroll = direction => this.ctx.ui.scrollViewportPages(direction);
 		this.ctx.editor.onViewportFollowLive = () => {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -742,7 +742,7 @@ export class InputController {
 		this.ctx.editor.setActionKeys("app.message.dequeue", this.ctx.keybindings.getKeys("app.message.dequeue"));
 		this.ctx.editor.onDequeue = () => this.#executeAction("app.message.dequeue");
 		this.#registerCommandPaletteAction("app.message.dequeue", dequeue);
-		const queue = () => this.handleQueueSubmit();
+		const queue = () => this.#executeAction("app.message.queue");
 		this.ctx.editor.setActionKeys("app.message.queue", this.ctx.keybindings.getKeys("app.message.queue"));
 		this.ctx.editor.onQueue = () => this.#executeAction("app.message.queue");
 		this.#registerCommandPaletteAction("app.message.queue", queue, true);

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -254,7 +254,7 @@ export class InputController {
 	}
 
 	#executeAction(id: (typeof APP_ACTION_METADATA)[number]["id"]): void {
-		void this.actionRegistry.execute(id);
+		void this.actionRegistry.executeFresh(id);
 	}
 
 	#transcriptTurnAnchorIds: readonly string[] = [];
@@ -2189,7 +2189,7 @@ export class InputController {
 						keybinding: action.bindingId
 							? this.ctx.keybindings.getKeys(action.bindingId).join(", ") || undefined
 							: undefined,
-						handler: () => this.actionRegistry.execute(action.id),
+						handler: () => this.actionRegistry.executeFresh(action.id),
 					})),
 				...slashCommands.map(command => ({
 					id: `slash:/${command.name}`,

--- a/packages/coding-agent/test/action-registry.test.ts
+++ b/packages/coding-agent/test/action-registry.test.ts
@@ -54,6 +54,27 @@ describe("ActionRegistry", () => {
 		expect(await registry.execute("app.suspend")).toBe(false);
 		expect(errors).toEqual(["Action app.suspend execution failed: failure"]);
 	});
+	it("rechecks availability for explicit fresh execution", async () => {
+		let available = true;
+		let calls = 0;
+		const registry = new ActionRegistry({ context: undefined, showError: () => {} });
+		registry.register({
+			id: "app.clear",
+			title: "Clear",
+			category: "Test",
+			bindingId: "app.clear",
+			domains: ["global"],
+			availability: () => available,
+			execute: () => {
+				calls += 1;
+			},
+		});
+
+		expect(registry.isAvailable("app.clear")).toBe(true);
+		available = false;
+		expect(await registry.executeFresh("app.clear")).toBe(false);
+		expect(calls).toBe(0);
+	});
 	it("contains reporter failures when availability or execution fails", async () => {
 		const registry = new ActionRegistry({
 			context: undefined,

--- a/packages/coding-agent/test/command-palette-interactive-host.test.ts
+++ b/packages/coding-agent/test/command-palette-interactive-host.test.ts
@@ -271,8 +271,8 @@ async function createHost(): Promise<InteractivePaletteHost> {
 	}
 }
 
-async function openPalette(host: InteractivePaletteHost): Promise<CommandPaletteComponent> {
-	host.mode.editor.handleInput("\u0010");
+async function openPalette(host: InteractivePaletteHost, key = "\u0010"): Promise<CommandPaletteComponent> {
+	host.mode.editor.handleInput(key);
 	let palette: CommandPaletteComponent | undefined;
 	await waitFor(() => {
 		const component = host.mode.editorContainer.children[0];
@@ -430,6 +430,26 @@ describe("command palette InteractiveMode host", () => {
 			const palette = await openPalette(host);
 			palette.handleInput("\u001b");
 			expect(host.mode.editorContainer.children).toEqual([host.mode.editor]);
+		}
+	});
+
+	it("preserves whitespace and Unicode multiline drafts across repeated palette cycles", async () => {
+		const host = await createHost();
+		const editor = host.mode.editor;
+
+		for (const draft of ["   ", "한글\nsecond line\n終わり"]) {
+			editor.setText(draft);
+			const cursor = editor.getCursor();
+			for (let cycle = 0; cycle < 3; cycle += 1) {
+				const palette = await openPalette(host);
+				expect(host.mode.editor).toBe(editor);
+				expect(editor.getText()).toBe(draft);
+				expect(editor.getCursor()).toEqual(cursor);
+				palette.handleInput("\u001b");
+				expect(host.mode.editorContainer.children).toEqual([editor]);
+				expect(host.mode.editor.getText()).toBe(draft);
+				expect(host.mode.editor.getCursor()).toEqual(cursor);
+			}
 		}
 	});
 

--- a/packages/coding-agent/test/command-palette-interactive-host.test.ts
+++ b/packages/coding-agent/test/command-palette-interactive-host.test.ts
@@ -408,14 +408,21 @@ describe("command palette InteractiveMode host", () => {
 		expect(host.dispatches.extensionError).not.toHaveBeenCalled();
 	});
 
-	it("keeps a draft when the palette action is unavailable and does not leak palette components", async () => {
+	it("opens over a draft, preserves its cursor, and does not leak palette components", async () => {
 		const host = await createHost();
 		host.mode.editor.setText("keep this draft");
+		host.mode.editor.handleInput("\u001b[D");
+		host.mode.editor.handleInput("\u001b[D");
+		const draftCursor = host.mode.editor.getCursor();
 
-		host.mode.editor.handleInput("\u0010");
+		const palette = await openPalette(host);
 
+		expect(host.mode.editor.getText()).toBe("keep this draft");
+		expect(host.mode.editor.getCursor()).toEqual(draftCursor);
+		palette.handleInput("\u001b");
 		expect(host.mode.editorContainer.children).toEqual([host.mode.editor]);
 		expect(host.mode.editor.getText()).toBe("keep this draft");
+		expect(host.mode.editor.getCursor()).toEqual(draftCursor);
 
 		host.mode.editor.setText("");
 		await Promise.resolve();
@@ -426,16 +433,17 @@ describe("command palette InteractiveMode host", () => {
 		}
 	});
 
-	it("blocks the palette while a draft or palette command is active without leaking a modal", async () => {
+	it("allows a draft palette and blocks overlapping palette commands without leaking a modal", async () => {
 		const host = await createHost();
 		const status = vi.spyOn(host.mode, "showStatus");
 		host.mode.editor.setText("unsent draft");
 
-		host.mode.editor.handleInput("\u0010");
-
+		const draftPalette = await openPalette(host);
+		draftPalette.handleInput("\u001b");
 		expect(host.dispatches.builtin).toHaveBeenCalledTimes(0);
 		expect(host.mode.editor.getText()).toBe("unsent draft");
 		expect(host.mode.editorContainer.children).toEqual([host.mode.editor]);
+		expect(status).not.toHaveBeenCalled();
 		host.mode.editor.setText("");
 		await Promise.resolve();
 		const pending = Promise.withResolvers<void>();

--- a/packages/coding-agent/test/command-palette-interactive-host.test.ts
+++ b/packages/coding-agent/test/command-palette-interactive-host.test.ts
@@ -453,6 +453,31 @@ describe("command palette InteractiveMode host", () => {
 		}
 	});
 
+	it("restores a nonempty draft before a selected action reports an error", async () => {
+		const host = await createHost();
+		const editor = host.mode.editor;
+		editor.setText("preserve this action draft");
+		editor.handleInput("\u001b[D");
+		const cursor = editor.getCursor();
+		const failure = new Error("dashboard action failed");
+		vi.spyOn(host.mode, "showSessionsDashboard").mockImplementation(() => {
+			throw failure;
+		});
+		const showError = vi.spyOn(host.mode, "showError");
+
+		const palette = await openPalette(host);
+		expect(palette.getEntries().some(entry => entry.id === "action:app.session.dashboard")).toBe(true);
+		select(palette, "sessions dashboard");
+		await waitFor(() => showError.mock.calls.length === 1, "the dashboard action error");
+
+		expect(host.mode.editor).toBe(editor);
+		expect(editor.getText()).toBe("preserve this action draft");
+		expect(editor.getCursor()).toEqual(cursor);
+		expect(host.mode.editorContainer.children).toEqual([editor]);
+		expect(host.focus).toHaveBeenLastCalledWith(editor);
+		expect(showError).toHaveBeenCalledWith(expect.stringContaining("dashboard action failed"));
+	});
+
 	it("allows a draft palette and blocks overlapping palette commands without leaking a modal", async () => {
 		const host = await createHost();
 		const status = vi.spyOn(host.mode, "showStatus");

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -16,6 +16,8 @@ function inputForKey(key: string): string {
 	switch (key) {
 		case "alt+q":
 			return "\x1bq";
+		case "alt+p":
+			return "\x1bp";
 		case "alt+enter":
 			return "\x1b\r";
 		default:
@@ -44,6 +46,17 @@ describe("CustomEditor command palette keybinding", () => {
 
 		expect(onOpenCommandPalette).toHaveBeenCalledTimes(1);
 		expect(onCycleModelForward).not.toHaveBeenCalled();
+	});
+
+	it("routes a remapped palette binding through the same editor action", () => {
+		const editor = createEditor();
+		const onOpenCommandPalette = vi.fn();
+		editor.onOpenCommandPalette = onOpenCommandPalette;
+		editor.setActionKeys("app.commandPalette.open", ["alt+p"]);
+
+		editor.handleInput(inputForKey("alt+p"));
+
+		expect(onOpenCommandPalette).toHaveBeenCalledTimes(1);
 	});
 
 	it("moves model cycling to Alt+N by default", () => {

--- a/packages/coding-agent/test/g003-ws2-redteam.test.ts
+++ b/packages/coding-agent/test/g003-ws2-redteam.test.ts
@@ -204,6 +204,50 @@ describe("G003 WS2 red-team: command palette", () => {
 		expect(busy.actionRegistry.isAvailable("app.message.queue")).toBe(true);
 	});
 
+	it("rechecks queue availability when streaming ends after palette open", async () => {
+		let text = "draft";
+		let submitted = 0;
+		let palette: CommandPalette | undefined;
+		const session = {
+			messages: [],
+			isStreaming: true,
+			getQueuedMessageEntries: () => [],
+			getRoleModelCycleCandidateCount: () => 0,
+			hasForegroundBashBackgroundRequestHandler: () => false,
+			prompt: async () => {
+				submitted += 1;
+			},
+		};
+		const controller = new InputController(
+			createControllerContext({
+				editor: {
+					getText: () => text,
+					setText: (value: string) => {
+						text = value;
+					},
+					onSubmit: async () => {},
+				} as never,
+				session: session as never,
+				ui: {
+					showOverlay(component: CommandPalette) {
+						palette = component;
+						return { hide: () => {} };
+					},
+					setFocus: () => {},
+					requestRender: () => {},
+				} as never,
+			}) as never,
+		);
+		controller.openCommandPalette();
+		for (const key of "queue message") palette?.handleInput(key);
+		session.isStreaming = false;
+		palette?.handleInput("\n");
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(submitted).toBe(0);
+		expect(text).toBe("draft");
+	});
+
 	it("does not open a palette over an active transcript overlay", () => {
 		let overlays = 0;
 		const ctx = createControllerContext({

--- a/packages/coding-agent/test/g003-ws2-redteam.test.ts
+++ b/packages/coding-agent/test/g003-ws2-redteam.test.ts
@@ -35,6 +35,7 @@ function createControllerContext(overrides: Partial<InteractiveModeContext> = {}
 		chatContainer: { children: [] },
 		goalModeController: { enabled: false, paused: false, handleCommand: () => {} },
 		planModeController: { enabled: true, paused: false, handleCommand: () => {} },
+		todoPhases: [],
 		showError: () => {},
 		showStatus: () => {},
 		historyStorage: { getRecent: () => [] },
@@ -140,7 +141,9 @@ describe("G003 WS2 red-team: command palette", () => {
 			editor: { getText: () => "draft", setText: () => {}, onSubmit: async () => {} } as never,
 			showStatus: status => statuses.push(status),
 		});
-		new InputController(nonempty).openCommandPalette();
+		const nonemptyController = new InputController(nonempty);
+		expect(nonemptyController.actionRegistry.isAvailable("app.commandPalette.open")).toBe(true);
+		nonemptyController.openCommandPalette();
 		expect(statuses).toEqual([]);
 
 		const order: string[] = [];

--- a/packages/coding-agent/test/g003-ws2-redteam.test.ts
+++ b/packages/coding-agent/test/g003-ws2-redteam.test.ts
@@ -225,9 +225,13 @@ describe("G003 WS2 red-team: command palette", () => {
 					setText: (value: string) => {
 						text = value;
 					},
+					addToHistory: () => {},
 					onSubmit: async () => {},
 				} as never,
 				session: session as never,
+				hasActiveBtw: () => false,
+				withLocalSubmission: async <T>(_value: string, action: () => Promise<T>) => action(),
+				updatePendingMessagesDisplay: () => {},
 				ui: {
 					showOverlay(component: CommandPalette) {
 						palette = component;
@@ -239,10 +243,10 @@ describe("G003 WS2 red-team: command palette", () => {
 			}) as never,
 		);
 		controller.openCommandPalette();
-		for (const key of "queue message") palette?.handleInput(key);
+		const queueEntry = palette?.getEntries().find(entry => entry.id === "action:app.message.queue");
+		expect(queueEntry?.handler).toBeDefined();
 		session.isStreaming = false;
-		palette?.handleInput("\n");
-		await Promise.resolve();
+		await queueEntry?.handler?.();
 		await Promise.resolve();
 		expect(submitted).toBe(0);
 		expect(text).toBe("draft");

--- a/packages/coding-agent/test/g003-ws2-redteam.test.ts
+++ b/packages/coding-agent/test/g003-ws2-redteam.test.ts
@@ -176,6 +176,34 @@ describe("G003 WS2 red-team: command palette", () => {
 		expect(order).toEqual(["hide", "focus", "execute", "error"]);
 	});
 
+	it("does not expose idle queue submission through the draft palette", () => {
+		let idlePalette: CommandPalette | undefined;
+		const idle = new InputController(
+			createControllerContext({
+				editor: { getText: () => "draft", setText: () => {}, onSubmit: async () => {} } as never,
+				ui: {
+					showOverlay(component: CommandPalette) {
+						idlePalette = component;
+						return { hide: () => {} };
+					},
+					setFocus: () => {},
+					requestRender: () => {},
+				} as never,
+			}) as never,
+		);
+		expect(idle.actionRegistry.isAvailable("app.message.queue")).toBe(false);
+		idle.openCommandPalette();
+		expect(idlePalette?.getEntries().some(entry => entry.id === "action:app.message.queue")).toBe(false);
+
+		const busy = new InputController(
+			createControllerContext({
+				editor: { getText: () => "draft", setText: () => {}, onSubmit: async () => {} } as never,
+				session: { isStreaming: true } as never,
+			}) as never,
+		);
+		expect(busy.actionRegistry.isAvailable("app.message.queue")).toBe(true);
+	});
+
 	it("does not open a palette over an active transcript overlay", () => {
 		let overlays = 0;
 		const ctx = createControllerContext({

--- a/packages/coding-agent/test/modes/controllers/selector-controller-command-palette.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-command-palette.test.ts
@@ -69,6 +69,38 @@ describe("SelectorController command palette", () => {
 
 		expect(showError).toHaveBeenCalledWith("external editor failed");
 	});
+	it("restores composer before executing and reporting a throwing action", async () => {
+		const order: string[] = [];
+		const component = { clear: vi.fn(), detachChild: vi.fn(), addChild: vi.fn() };
+		const ctx = {
+			editorContainer: component,
+			editor: {},
+			restoreComposer: vi.fn(() => order.push("focus")),
+			keybindings: { getDisplayString: () => "" },
+			ui: { setFocus: vi.fn(), requestRender: vi.fn() },
+			showError: vi.fn(() => order.push("error")),
+		} as unknown as InteractiveModeContext;
+		const controller = new SelectorController(ctx);
+
+		controller.showCommandPalette(
+			[],
+			[
+				{
+					id: "app.editor.external",
+					label: "External editor",
+					handler: async () => {
+						order.push("execute");
+						throw new Error("external editor failed");
+					},
+				},
+			],
+			async () => {},
+		);
+		const palette = component.addChild.mock.calls[0]?.[0] as CommandPaletteComponent;
+		palette.handleInput("\r");
+		await new Promise<void>(resolve => setImmediate(resolve));
+		expect(order).toEqual(["focus", "execute", "error"]);
+	});
 	it("uses effective display strings and omits unbound action shortcuts", () => {
 		const component = { clear: vi.fn(), detachChild: vi.fn(), addChild: vi.fn() };
 		const keybindings = {


### PR DESCRIPTION
## Summary
- make `app.commandPalette.open` available while the composer contains a draft
- preserve the existing editor instance, draft bytes, cursor, and focus across palette open/cancel and selected action teardown
- keep throwing-action teardown ordered as close, focus restore, execute, error
- keep curated action availability authoritative, including fresh selection-time checks for stale palette rows

## Scope
PR #4971 only. Issue #4969 has a separate closure-only owner. The shard-1 red-team failure is explicitly excluded.

Base/head are fixed to `b9df59e78e8f6a19132ac51d770c9508a3c2a3d5` / `d04948c6d2af0dbcfecd169db73aa364e5348796`.

## Verification
- `bun test ./packages/coding-agent/test/action-registry.test.ts ./packages/coding-agent/test/command-palette-interactive-host.test.ts ./packages/coding-agent/test/g003-ws2-redteam.test.ts ./packages/coding-agent/test/modes/components/command-palette.test.ts ./packages/coding-agent/test/modes/controllers/selector-controller-command-palette.test.ts ./packages/coding-agent/test/input-controller-keybindings.test.ts ./packages/coding-agent/test/input-controller-escape.test.ts ./packages/coding-agent/test/custom-editor-keybindings.test.ts ./packages/coding-agent/test/g004-ws3-redteam.test.ts ./packages/coding-agent/test/interactive-mode-editor-component.test.ts ./packages/coding-agent/test/main-interactive-input.test.ts`
- `bun test ./packages/tui/test/editor.test.ts ./packages/tui/test/editor-autocomplete-actions.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check packages/coding-agent/src/modes/action-registry.ts packages/coding-agent/src/modes/controllers/input-controller.ts packages/coding-agent/test/action-registry.test.ts packages/coding-agent/test/command-palette-interactive-host.test.ts packages/coding-agent/test/g003-ws2-redteam.test.ts packages/coding-agent/test/custom-editor-keybindings.test.ts packages/coding-agent/test/modes/controllers/selector-controller-command-palette.test.ts`
- `bun run build:native`
- `bun --cwd=packages/coding-agent run build`
- `bun run dev -- --smoke-test`

The full coding-agent suite was attempted and timed out in unrelated `sdk-downgrade-rollback.test.ts`; the complete affected suite passed after final host coverage (270 tests, 1247 assertions) and the TUI editor suite passed (185 tests, 530 assertions).

## Risk classification

- [x] `low-risk` — narrow command-palette availability/filtering/dispatch change and regression coverage; no API, persistence, or migration changes.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:53568fab1c18347f28b1629dda17deadd124b0bb9fd48e0acc0dd454d6cad33e reviewer:architect reviewer-id:Yeachan-Heo evidence:exact-head CI, affected-suite, fresh-authority red-team, mounted-host teardown, selector, remapped-key, type, build, smoke, and TUI evidence
```

---

- [x] Target branch is `dev`
- [x] Tested locally
- [x] Verdict above matches the exact PR head
