### PR TITLE
fix(lsp,dap,mcp): await backpressured protocol writes to stop EPIPE crashes

### DIFF
--- a/packages/coding-agent/src/dap/client.ts
+++ b/packages/coding-agent/src/dap/client.ts
@@ -104,6 +104,7 @@ export class DapClient {
 	#isReading = false;
 	#disposed = false;
 	#lastActivity = Date.now();
+	#writeQueue = Promise.resolve();
 	#capabilities?: DapCapabilities;
 	#eventHandlers = new Map<string, Set<DapEventHandler>>();
 	#anyEventHandlers = new Set<DapEventHandler>();
@@ -417,7 +418,7 @@ export class DapClient {
 		});
 		this.#lastActivity = Date.now();
 		try {
-			await writeMessage(this.#writeSink, request);
+			await this.#queueWrite(request);
 		} catch (error) {
 			this.#pendingRequests.delete(requestSeq);
 			cleanup();
@@ -436,7 +437,13 @@ export class DapClient {
 			...(message ? { message } : {}),
 			...(body !== undefined ? { body } : {}),
 		};
-		await writeMessage(this.#writeSink, response);
+		await this.#queueWrite(response);
+	}
+
+	#queueWrite(message: DapRequestMessage | DapResponseMessage): Promise<void> {
+		const write = this.#writeQueue.catch(() => {}).then(() => writeMessage(this.#writeSink, message));
+		this.#writeQueue = write.catch(() => {});
+		return write;
 	}
 
 	async dispose(): Promise<void> {

--- a/packages/coding-agent/src/dap/client.ts
+++ b/packages/coding-agent/src/dap/client.ts
@@ -62,8 +62,13 @@ function parseMessage(
 
 async function writeMessage(sink: DapWriteSink, message: DapRequestMessage | DapResponseMessage): Promise<void> {
 	const content = JSON.stringify(message);
-	sink.write(`Content-Length: ${Buffer.byteLength(content, "utf-8")}\r\n\r\n`);
-	sink.write(content);
+	// DapWriteSink.write() returns `number | Promise<number>`: under
+	// backpressure it returns a promise whose rejection (e.g. EPIPE when the
+	// adapter dies mid-write) would otherwise be discarded here and surface as
+	// an unhandled rejection. Await both writes so failures reach the callers
+	// that already handle flush() errors.
+	await sink.write(`Content-Length: ${Buffer.byteLength(content, "utf-8")}\r\n\r\n`);
+	await sink.write(content);
 	await sink.flush();
 }
 

--- a/packages/coding-agent/src/dap/client.ts
+++ b/packages/coding-agent/src/dap/client.ts
@@ -334,6 +334,7 @@ export class DapClient {
 			throw signal.reason instanceof Error ? signal.reason : new ToolAbortError();
 		}
 		const { promise, resolve, reject } = Promise.withResolvers<TBody>();
+		void promise.catch(() => {});
 		let timeout: NodeJS.Timeout | undefined;
 		const cleanup = () => {
 			unsubscribe();
@@ -417,13 +418,11 @@ export class DapClient {
 			},
 		});
 		this.#lastActivity = Date.now();
-		try {
-			await this.#queueWrite(request);
-		} catch (error) {
+		void this.#queueWrite(request).catch(error => {
 			this.#pendingRequests.delete(requestSeq);
 			cleanup();
-			throw error;
-		}
+			reject(error);
+		});
 		return promise;
 	}
 

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -23,6 +23,8 @@ const clients = new Map<string, LspClient>();
 const killedClients = new WeakSet<LspClient>();
 const clientLocks = new Map<string, Promise<LspClient>>();
 const fileOperationLocks = new Map<string, Promise<void>>();
+const initializingClients = new Set<LspClient>();
+let shutdownGeneration = 0;
 const transportClosedErrors = new WeakMap<LspClient, Error>();
 const LSP_TRANSPORT_CLOSED_MESSAGE = "LSP transport closed";
 let lspCleanupOwner: (() => void) | undefined;
@@ -515,6 +517,7 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 	// Create new client with lock
 	let clientPromise!: Promise<LspClient>;
 	clientPromise = (async () => {
+		const creationGeneration = shutdownGeneration;
 		const baseCommand = config.resolvedCommand ?? config.command;
 		const baseArgs = config.args ?? [];
 
@@ -522,6 +525,9 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 		const { command, args, env } = isLspmuxSupported(baseCommand)
 			? await getLspmuxCommand(baseCommand, baseArgs, cwd)
 			: { command: baseCommand, args: baseArgs };
+		if (creationGeneration !== shutdownGeneration) {
+			throw new Error("LSP client shutdown");
+		}
 
 		const owner = spawnOwnedProcess([command, ...args], {
 			cwd,
@@ -567,6 +573,12 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 			killedClients.add(client);
 			return originalKill(...args);
 		};
+		initializingClients.add(client);
+		if (creationGeneration !== shutdownGeneration) {
+			initializingClients.delete(client);
+			await shutdownClientInstance(client);
+			throw new Error("LSP client shutdown");
+		}
 
 		// Register crash recovery - remove client on process exit
 		proc.exited.then(async () => {
@@ -641,6 +653,9 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 			ensureLspCleanup();
 			const terminalError = transportClosedErrors.get(client);
 			if (terminalError) throw terminalError;
+			if (creationGeneration !== shutdownGeneration) {
+				throw new Error("LSP client shutdown");
+			}
 
 			// Publish to the cache only after the handshake completes: callers that
 			// hit the `clients` map must never observe a client whose initialize is
@@ -657,6 +672,7 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 			await shutdownClientInstance(client);
 			throw err;
 		} finally {
+			initializingClients.delete(client);
 			deleteClientLock(key, clientPromise);
 		}
 	})();
@@ -1011,11 +1027,18 @@ export async function sendNotification(client: LspClient, method: string, params
  */
 export async function shutdownAll(): Promise<void> {
 	stopIdleChecker();
+	shutdownGeneration += 1;
+	const inFlightPromises = Array.from(clientLocks.values());
+	const initializingToShutdown = Array.from(initializingClients);
 	clientLocks.clear();
 	fileOperationLocks.clear();
 	const clientsToShutdown = Array.from(clients.values());
 	clients.clear();
-	await Promise.allSettled(clientsToShutdown.map(client => shutdownClientInstance(client)));
+	await Promise.allSettled([
+		...clientsToShutdown.map(client => shutdownClientInstance(client)),
+		...initializingToShutdown.map(client => shutdownClientInstance(client)),
+		...inFlightPromises,
+	]);
 }
 
 /** Status of an LSP server */

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -280,7 +280,13 @@ async function writeMessage(
 	if (terminalError) throw terminalError;
 
 	try {
-		client.proc.stdin.write(`Content-Length: ${Buffer.byteLength(content, "utf-8")}\r\n\r\n${content}`);
+		// FileSink.write() returns `number | Promise<number>`: under backpressure
+		// (e.g. a large didOpen/didChange payload) it returns a promise whose
+		// rejection — typically EPIPE when the server dies mid-write — would
+		// otherwise be discarded here and surface as an unhandled rejection that
+		// takes down the whole process. Await it so every failure mode reaches
+		// the transport-closed mapping below.
+		await client.proc.stdin.write(`Content-Length: ${Buffer.byteLength(content, "utf-8")}\r\n\r\n${content}`);
 		await client.proc.stdin.flush();
 	} catch (error) {
 		if (isKnownSinkPeerClosedError(error)) {

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -567,7 +567,6 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 			killedClients.add(client);
 			return originalKill(...args);
 		};
-		clients.set(key, client);
 
 		// Register crash recovery - remove client on process exit
 		proc.exited.then(async () => {
@@ -643,10 +642,17 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 			const terminalError = transportClosedErrors.get(client);
 			if (terminalError) throw terminalError;
 
+			// Publish to the cache only after the handshake completes: callers that
+			// hit the `clients` map must never observe a client whose initialize is
+			// still in flight. Concurrent callers instead share `clientLocks` and
+			// wait for initialization, so a server that dies mid-handshake rejects
+			// every waiter instead of handing them a transport that is about to
+			// break underneath them.
+			clients.set(key, client);
+
 			return client;
 		} catch (err) {
 			// Clean up on initialization failure
-			deleteCachedClient(key, client);
 			deleteClientLock(key, clientPromise);
 			await shutdownClientInstance(client);
 			throw err;

--- a/packages/coding-agent/src/runtime-mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/runtime-mcp/transports/stdio.ts
@@ -283,6 +283,7 @@ export class StdioTransport implements MCPTransport {
 		}
 
 		const { promise, resolve, reject } = Promise.withResolvers<T>();
+		void promise.catch(() => {});
 		let timer: NodeJS.Timeout | undefined;
 		let settled = false;
 
@@ -326,16 +327,18 @@ export class StdioTransport implements MCPTransport {
 		}, timeout);
 
 		const message = `${JSON.stringify(request)}\n`;
-		try {
-			// Bun's FileSink has write() method directly. Await both write and
-			// flush: under backpressure write() returns a promise, and either
-			// call can fail with EPIPE when the server dies mid-write.
-			await stdin.write(message);
-			await stdin.flush();
-		} catch (error: unknown) {
-			cleanup();
-			reject(new MCPExpectedFailure(error));
-		}
+		void (async () => {
+			try {
+				// Bun's FileSink has write() method directly. Await both write and
+				// flush: under backpressure write() returns a promise, and either
+				// call can fail with EPIPE when the server dies mid-write.
+				await stdin.write(message);
+				await stdin.flush();
+			} catch (error: unknown) {
+				cleanup();
+				reject(new MCPExpectedFailure(error));
+			}
+		})();
 
 		return promise;
 	}

--- a/packages/coding-agent/src/runtime-mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/runtime-mcp/transports/stdio.ts
@@ -239,8 +239,15 @@ export class StdioTransport implements MCPTransport {
 		const response = error
 			? { jsonrpc: "2.0" as const, id, error }
 			: { jsonrpc: "2.0" as const, id, result: result ?? {} };
-		stdin.write(`${JSON.stringify(response)}\n`);
-		stdin.flush();
+		// FileSink.write()/flush() return `number | Promise<number>` (flush may
+		// also return undefined): under backpressure a write returns a promise
+		// whose rejection — e.g. EPIPE when the server dies mid-write — must
+		// not escape as an unhandled rejection. Best-effort, like the caller.
+		Promise.resolve(stdin.write(`${JSON.stringify(response)}\n`))
+			.then(() => stdin.flush())
+			.catch(() => {
+				// Best-effort — process may have exited
+			});
 	}
 
 	#handleClose(failure?: MCPExpectedFailure): void {
@@ -320,9 +327,11 @@ export class StdioTransport implements MCPTransport {
 
 		const message = `${JSON.stringify(request)}\n`;
 		try {
-			// Bun's FileSink has write() method directly
-			stdin.write(message);
-			stdin.flush();
+			// Bun's FileSink has write() method directly. Await both write and
+			// flush: under backpressure write() returns a promise, and either
+			// call can fail with EPIPE when the server dies mid-write.
+			await stdin.write(message);
+			await stdin.flush();
 		} catch (error: unknown) {
 			cleanup();
 			reject(new MCPExpectedFailure(error));
@@ -345,9 +354,11 @@ export class StdioTransport implements MCPTransport {
 
 		const message = `${JSON.stringify(notification)}\n`;
 		try {
-			// Bun's FileSink has write() method directly
-			stdin.write(message);
-			stdin.flush();
+			// Bun's FileSink has write() method directly. Await both write and
+			// flush: under backpressure write() returns a promise, and either
+			// call can fail with EPIPE when the server dies mid-write.
+			await stdin.write(message);
+			await stdin.flush();
 		} catch (error) {
 			throw new MCPExpectedFailure(error);
 		}

--- a/packages/coding-agent/test/dap/dap-lifecycle.test.ts
+++ b/packages/coding-agent/test/dap/dap-lifecycle.test.ts
@@ -180,6 +180,31 @@ describe("DAP lifecycle behavior", () => {
 		await second;
 	});
 
+	it("delivers request timeouts while a write remains backpressured", async () => {
+		const sink = {
+			write(): Promise<number> {
+				return new Promise(() => {});
+			},
+			flush(): number {
+				return 0;
+			},
+		};
+		const owner = {
+			child: { stdin: sink, stdout: new ReadableStream<Uint8Array>() },
+			dispose: async () => {},
+			awaitExit: async () => {},
+			disposed: false,
+		};
+		const client = new DapClient(STDIO_ADAPTER, ".", owner as never, {
+			readable: new ReadableStream<Uint8Array>(),
+			writeSink: sink,
+		});
+
+		await expect(client.sendRequest("blocked", undefined, undefined, 10)).rejects.toThrow(
+			"DAP request blocked timed out after 10ms",
+		);
+	});
+
 	it("socket-mode startup timeout disposes the adapter process", async () => {
 		const cwd = await tempDir("gjc-dap-socket-timeout-");
 		try {

--- a/packages/coding-agent/test/dap/dap-lifecycle.test.ts
+++ b/packages/coding-agent/test/dap/dap-lifecycle.test.ts
@@ -131,6 +131,55 @@ afterEach(async () => {
 });
 
 describe("DAP lifecycle behavior", () => {
+	it("serializes concurrent backpressured protocol frames", async () => {
+		const calls: string[] = [];
+		const resolvers: Array<() => void> = [];
+		const sink = {
+			write(data: string | Uint8Array): Promise<number> {
+				calls.push(typeof data === "string" ? data : new TextDecoder().decode(data));
+				return new Promise(resolve =>
+					resolvers.push(() => resolve(typeof data === "string" ? data.length : data.byteLength)),
+				);
+			},
+			flush(): number {
+				calls.push("flush");
+				return 0;
+			},
+		};
+		const owner = {
+			child: { stdin: sink, stdout: new ReadableStream<Uint8Array>() },
+			dispose: async () => {},
+			awaitExit: async () => {},
+			disposed: false,
+		};
+		const client = new DapClient(STDIO_ADAPTER, ".", owner as never, {
+			readable: new ReadableStream<Uint8Array>(),
+			writeSink: sink,
+		});
+
+		const first = client.sendResponse({ seq: 1, type: "request", command: "first" }, true);
+		await Bun.sleep(0);
+		const second = client.sendResponse({ seq: 2, type: "request", command: "second" }, true);
+		await Bun.sleep(0);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]).toBe("Content-Length: 76\r\n\r\n");
+
+		resolvers.shift()?.();
+		await Bun.sleep(0);
+		expect(calls[1]).toContain('"first"');
+		resolvers.shift()?.();
+		await first;
+		await Bun.sleep(0);
+		expect(calls[2]).toBe("flush");
+		expect(calls[3]).toBe("Content-Length: 77\r\n\r\n");
+
+		resolvers.shift()?.();
+		await Bun.sleep(0);
+		expect(calls[4]).toContain('"second"');
+		resolvers.shift()?.();
+		await second;
+	});
+
 	it("socket-mode startup timeout disposes the adapter process", async () => {
 		const cwd = await tempDir("gjc-dap-socket-timeout-");
 		try {

--- a/packages/coding-agent/test/lsp/lsp-lifecycle.test.ts
+++ b/packages/coding-agent/test/lsp/lsp-lifecycle.test.ts
@@ -39,11 +39,11 @@ function serverConfig(command: string, args: string[] = []): ServerConfig {
 	};
 }
 
-async function writeFakeLspServer(dir: string): Promise<string> {
+async function writeFakeLspServer(dir: string, options?: { initDelayMs?: number }): Promise<string> {
 	const script = path.join(dir, "fake-lsp.ts");
 	await Bun.write(
 		script,
-		`let buffer = Buffer.alloc(0);\nfunction write(message) {\n  const body = JSON.stringify(message);\n  process.stdout.write(\`Content-Length: \${Buffer.byteLength(body, "utf8")}\\r\\n\\r\\n\${body}\`);\n}\nfunction handle(message) {\n  if (message.method === "initialize") {\n    write({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });\n    return;\n  }\n  if (message.method === "shutdown") {\n    write({ jsonrpc: "2.0", id: message.id, result: null });\n    process.exit(0);\n    return;\n  }\n}\nprocess.stdin.on("data", chunk => {\n  buffer = Buffer.concat([buffer, chunk]);\n  for (;;) {\n    const headerEnd = buffer.indexOf("\\r\\n\\r\\n");\n    if (headerEnd === -1) return;\n    const header = buffer.subarray(0, headerEnd).toString();\n    const match = /Content-Length: (\\d+)/i.exec(header);\n    if (!match) return;\n    const length = Number(match[1]);\n    const start = headerEnd + 4;\n    const end = start + length;\n    if (buffer.length < end) return;\n    const message = JSON.parse(buffer.subarray(start, end).toString());\n    buffer = buffer.subarray(end);\n    handle(message);\n  }\n});\nsetInterval(() => {}, 1000);\n`,
+		`let buffer = Buffer.alloc(0);\nfunction write(message) {\n  const body = JSON.stringify(message);\n  process.stdout.write(\`Content-Length: \${Buffer.byteLength(body, "utf8")}\\r\\n\\r\\n\${body}\`);\n}\nfunction handle(message) {\n  if (message.method === "initialize") {\n    setTimeout(() => {\n      write({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });\n    }, ${options?.initDelayMs ?? 0});\n    return;\n  }\n  if (message.method === "shutdown") {\n    write({ jsonrpc: "2.0", id: message.id, result: null });\n    process.exit(0);\n    return;\n  }\n}\nprocess.stdin.on("data", chunk => {\n  buffer = Buffer.concat([buffer, chunk]);\n  for (;;) {\n    const headerEnd = buffer.indexOf("\\r\\n\\r\\n");\n    if (headerEnd === -1) return;\n    const header = buffer.subarray(0, headerEnd).toString();\n    const match = /Content-Length: (\\d+)/i.exec(header);\n    if (!match) return;\n    const length = Number(match[1]);\n    const start = headerEnd + 4;\n    const end = start + length;\n    if (buffer.length < end) return;\n    const message = JSON.parse(buffer.subarray(start, end).toString());\n    buffer = buffer.subarray(end);\n    handle(message);\n  }\n});\nsetInterval(() => {}, 1000);\n`,
 	);
 	return script;
 }
@@ -228,4 +228,98 @@ describe("LSP lifecycle behavior", () => {
 			await fs.rm(cwd, { recursive: true, force: true });
 		}
 	}, 3_000);
+});
+
+async function writeBusyThenDyingLspServer(dir: string): Promise<string> {
+	// Answers `initialize`, then blocks its event loop without consuming stdin
+	// (like a server busy analyzing a large file), then exits while the client
+	// still has a large in-flight write queued in the socket buffer.
+	const script = path.join(dir, "busy-lsp.ts");
+	await Bun.write(
+		script,
+		`let buffer = Buffer.alloc(0);\nfunction write(message) {\n  const body = JSON.stringify(message);\n  process.stdout.write(\`Content-Length: \${Buffer.byteLength(body, "utf8")}\\r\\n\\r\\n\${body}\`);\n}\nprocess.stdin.on("data", chunk => {\n  buffer = Buffer.concat([buffer, chunk]);\n  for (;;) {\n    const headerEnd = buffer.indexOf("\\r\\n\\r\\n");\n    if (headerEnd === -1) return;\n    const header = buffer.subarray(0, headerEnd).toString();\n    const match = /Content-Length: (\\d+)/i.exec(header);\n    if (!match) return;\n    const length = Number(match[1]);\n    const start = headerEnd + 4;\n    const end = start + length;\n    if (buffer.length < end) return;\n    const message = JSON.parse(buffer.subarray(start, end).toString());\n    buffer = buffer.subarray(end);\n    if (message.method === "initialize") {\n      write({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });\n      // Immediately simulate a server that stops servicing stdin (like one\n      // busy analyzing a large file): the reply is already in the kernel pipe\n      // buffer, so blocking the event loop keeps stdin unconsumed and the\n      // client's next large write stays pending in the kernel socket buffer.\n      const until = Date.now() + 3000;\n      while (Date.now() < until) {}\n      process.exit(1);\n    }\n  }\n});\nsetInterval(() => {}, 1000);\n`,
+	);
+	return script;
+}
+
+describe("LSP transport write failures", () => {
+	it("a large pending write to a dying server is terminalized, not an unhandled rejection", async () => {
+		const cwd = await tempDir("gjc-lsp-epipe-");
+		const unhandled: unknown[] = [];
+		const onUnhandledRejection = (reason: unknown) => {
+			unhandled.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandledRejection);
+		try {
+			const script = await writeBusyThenDyingLspServer(cwd);
+			const config = serverConfig(BUN, [script]);
+			const client = await getOrCreateClient(config, cwd, 5_000);
+
+			// Larger than the kernel socket buffer so FileSink.write() returns a
+			// promise (backpressure) that stays pending while the server is busy.
+			const largeParams = { text: "x".repeat(512 * 1024) };
+			const largeWrite = sendNotification(client, "textDocument/didChange", largeParams);
+			await Bun.sleep(100);
+
+			// Kill the server while the write is still pending, exactly like a
+			// language server that crashes mid-analysis with a large didOpen or
+			// didChange queued: the pending write fails with EPIPE.
+			client.proc.kill();
+			await largeWrite;
+			await Bun.sleep(200);
+
+			expect(unhandled).toEqual([]);
+
+			// The transport must be terminalized: notifications resolve quietly
+			// and later requests reject with the mapped error, not the raw one.
+			await sendNotification(client, "test/afterExit", {});
+			const staleRequestError = await captureError(sendRequest(client, "test/stale", null));
+			expect(staleRequestError.message).toBe("LSP transport closed");
+		} finally {
+			process.off("unhandledRejection", onUnhandledRejection);
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	}, 10_000);
+
+	it("concurrent callers during a slow initialize share the initialized client, never an uninitialized one", async () => {
+		const cwd = await tempDir("gjc-lsp-slow-init-");
+		try {
+			const script = await writeFakeLspServer(cwd, { initDelayMs: 150 });
+			const config = serverConfig(BUN, [script]);
+
+			const firstPromise = getOrCreateClient(config, cwd, 5_000);
+			let secondResolvedBeforeHandshake = false;
+			const secondPromise = getOrCreateClient(config, cwd, 5_000).then(client => {
+				secondResolvedBeforeHandshake = client.serverCapabilities === undefined;
+				return client;
+			});
+			const [first, second] = await Promise.all([firstPromise, secondPromise]);
+
+			expect(second).toBe(first);
+			expect(secondResolvedBeforeHandshake).toBe(false);
+			expect(second.serverCapabilities).toBeDefined();
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	}, 10_000);
+
+	it("concurrent callers observe the same failure when the server dies during initialize", async () => {
+		const cwd = await tempDir("gjc-lsp-dying-init-");
+		try {
+			// A server that exits immediately, like a broken launcher on PATH
+			// (e.g. a Python LSP stub whose interpreter can no longer import it).
+			const script = path.join(cwd, "dying-lsp.ts");
+			await Bun.write(script, "console.error(\"No module named 'fake-lsp'\");\nprocess.exit(1);\n");
+			const config = serverConfig(BUN, [script]);
+
+			const firstPromise = getOrCreateClient(config, cwd, 5_000).catch(error => error);
+			const secondPromise = getOrCreateClient(config, cwd, 5_000).catch(error => error);
+			const [first, second] = await Promise.all([firstPromise, secondPromise]);
+
+			expect(first).toBeInstanceOf(Error);
+			expect(second).toBe(first);
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	}, 10_000);
 });

--- a/packages/coding-agent/test/lsp/lsp-lifecycle.test.ts
+++ b/packages/coding-agent/test/lsp/lsp-lifecycle.test.ts
@@ -10,7 +10,7 @@ import {
 	waitForProjectLoaded,
 } from "../../src/lsp/client";
 import type { ServerConfig } from "../../src/lsp/types";
-import { disposeAllOwnedProcesses } from "../../src/runtime/process-lifecycle";
+import { disposeAllOwnedProcesses, liveOwnedProcessCount } from "../../src/runtime/process-lifecycle";
 
 const BUN = process.execPath;
 const ORIGINAL_PATH = Bun.env.PATH;
@@ -322,4 +322,24 @@ describe("LSP transport write failures", () => {
 			await fs.rm(cwd, { recursive: true, force: true });
 		}
 	}, 10_000);
+
+	it("shutdownAll disposes an in-flight initializer and prevents cache resurrection", async () => {
+		const cwd = await tempDir("gjc-lsp-shutdown-init-");
+		try {
+			const script = await writeFakeLspServer(cwd, { initDelayMs: 500 });
+			const config = serverConfig(BUN, [script]);
+			const before = liveOwnedProcessCount();
+			const initializing = getOrCreateClient(config, cwd, 5_000);
+			await Bun.sleep(50);
+			await shutdownAll();
+			await expect(initializing).rejects.toThrow("LSP client shutdown");
+			await Bun.sleep(100);
+			expect(liveOwnedProcessCount()).toBe(before);
+
+			const retry = await getOrCreateClient(config, cwd, 5_000);
+			expect(retry.proc.exitCode).toBeNull();
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/coding-agent/test/runtime-mcp/transport-lifecycle.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/transport-lifecycle.test.ts
@@ -133,6 +133,22 @@ describe("MCP stdio transport lifecycle", () => {
 		}
 	}, 10_000);
 
+	test("delivers request timeouts while a write remains backpressured", async () => {
+		const transport = new StdioTransport({
+			command: process.execPath,
+			args: ["-e", "setInterval(() => {}, 1000)"],
+			timeout: 25,
+		});
+		try {
+			await transport.connect();
+			await expect(transport.request("tools/list", { text: "x".repeat(64 * 1024 * 1024) })).rejects.toThrow(
+				"Request timeout after 25ms",
+			);
+		} finally {
+			await transport.close().catch(() => {});
+		}
+	}, 10_000);
+
 	test("close and reconnect dispose the old owned child tree", async () => {
 		vi.restoreAllMocks();
 		if (process.env[STDIO_LIFECYCLE_ISOLATION] !== "1") {

--- a/packages/coding-agent/test/runtime-mcp/transport-lifecycle.test.ts
+++ b/packages/coding-agent/test/runtime-mcp/transport-lifecycle.test.ts
@@ -5,6 +5,7 @@ import { logger } from "@gajae-code/utils";
 import { disposeAllOwnedProcesses, liveOwnedProcessCount } from "../../src/runtime/process-lifecycle";
 import { HttpTransport } from "../../src/runtime-mcp/transports/http";
 import { StdioTransport } from "../../src/runtime-mcp/transports/stdio";
+import { MCPExpectedFailure } from "../../src/runtime-mcp/types";
 
 async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 10_000): Promise<void> {
 	const deadline = Date.now() + timeoutMs;
@@ -111,6 +112,27 @@ afterEach(async () => {
 });
 
 describe("MCP stdio transport lifecycle", () => {
+	test("propagates backpressured write failures without unhandled rejection", async () => {
+		const transport = new StdioTransport({
+			command: process.execPath,
+			args: ["-e", "setTimeout(() => process.exit(1), 100)"],
+			timeout: 1_000,
+		});
+		const unhandled: unknown[] = [];
+		const onUnhandled = (reason: unknown) => unhandled.push(reason);
+		process.on("unhandledRejection", onUnhandled);
+		try {
+			await transport.connect();
+			await expect(
+				transport.notify("notifications/large", { text: "x".repeat(64 * 1024 * 1024) }),
+			).rejects.toBeInstanceOf(MCPExpectedFailure);
+			expect(unhandled).toEqual([]);
+		} finally {
+			process.off("unhandledRejection", onUnhandled);
+			await transport.close().catch(() => {});
+		}
+	}, 10_000);
+
 	test("close and reconnect dispose the old owned child tree", async () => {
 		vi.restoreAllMocks();
 		if (process.env[STDIO_LIFECYCLE_ISOLATION] !== "1") {


### PR DESCRIPTION
## Summary

Every protocol writer (`lsp/client.ts`, `dap/client.ts`, `runtime-mcp/transports/stdio.ts`) discarded the return value of `FileSink.write()` and only awaited `flush()`. Bun's `FileSink.write()` returns `number | Promise<number>` — under backpressure (a large `didOpen`/`didChange` payload, a big MCP tool result) it returns a **promise**. When the child process died while such a write was pending, the rejected promise surfaced as an **unhandled rejection** that took down the whole process:

```
[Unhandled Rejection] Error: EPIPE: broken pipe, send
    at write (unknown)
    at writeMessage (...)
    at processTicksAndRejections (native:7:39)
{"code":"EPIPE","syscall":"send","errno":-32}
```

Reproduced end to end: a pending backpressured write + child death rejects with exactly this error (Bun's subprocess stdin pipe reports `send`/`EPIPE`). This is the signature of real-world crashes where a language server or MCP server dies mid-analysis while a large document sync is in flight.

### Changes

- **LSP** (`writeMessage`): await the write alongside the flush, so every failure mode (sync throw, async write rejection, flush failure) reaches the existing `isKnownSinkPeerClosedError` → `terminalizeTransport` mapping instead of escaping to the process-level crash handler.
- **DAP** (`writeMessage`): same treatment; surfaced failures flow into the existing catch blocks around request/response dispatch.
- **MCP stdio transport** (`request`, `notify`, `#sendResponse`): same treatment; `#sendResponse` now chains write→flush with a best-effort catch, matching its fire-and-forget contract.
- **LSP cache race**: `getOrCreateClient` published the client to the `clients` map *before* sending `initialize`, so a concurrent caller could receive an uninitialized client and start writing document payloads mid-handshake (against a server that may be about to die — the exact shape of a broken launcher on PATH that exits on startup). The cache insert now happens only after the handshake completes; concurrent callers wait on the existing `clientLocks` promise and either share the initialized client or observe the same initialization failure. The now-dead `deleteCachedClient` in the failure path was removed.

## Tests

Three regression tests in `test/lsp/lsp-lifecycle.test.ts`:

1. **EPIPE terminalization** — a server that blocks its event loop after `initialize` (never reads stdin) keeps a 512 KB `didChange` write pending; the test kills the server mid-write and asserts no `unhandledRejection` fires, the notification resolves quietly, and later requests reject with the mapped `"LSP transport closed"` error.
2. **Slow-initialize race** — concurrent `getOrCreateClient` callers during a 150 ms delayed handshake share the same client and never observe it before `serverCapabilities` is set.
3. **Dying-initialize race** — when the server exits during `initialize` (broken-launcher shape), concurrent callers observe the same rejection instead of one of them receiving a doomed client.

Verified red on `upstream/dev` (tests 1 and 3 fail without the fixes) and green with them. Full local runs: `test/lsp/`, `test/dap/`, `test/runtime-mcp/` (130 pass), `test/lsp-lifecycle-cleanup.test.ts`, `test/lsp-diagnostics-freshness.test.ts`, `tsc -p tsconfig.json --noEmit`, and `biome check` on the touched files.



## Risk classification

- [ ] `low-risk`
- [x] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:570699b80a6f70a16e8214aed93108e6b9924aad88c774272f7599febeb266c0 reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/actions/runs/32930196922n-Heo/gajae-code/actions/runs/32928451713
```
