### PR TITLE
fix(provider): stop persisting the vLLM no-auth sentinel

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `/login vllm` no longer stores the `vllm-local` no-auth sentinel as a persisted API key. `AuthStorage.getApiKey()` resolves stored `api_key` credentials before environment variables, so a stored sentinel from an empty login could outrank a real `VLLM_API_KEY` env var and reach normal inference. `/login vllm` now requires a real API key (empty input throws `vLLM API key is required; local no-auth servers are discovered automatically`); local no-auth servers remain discovered automatically via the descriptor's `allowUnauthenticated` flag and need no login.
+
 ## [0.15.2] - 2026-08-25
 
 ### Changed

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -1074,7 +1074,7 @@ The quickest way to authenticate:
 ```bash
 bunx @gajae-code/ai login              # interactive provider selection
 bunx @gajae-code/ai login anthropic    # login to specific provider
-bunx @gajae-code/ai login vllm         # store vLLM API key (or placeholder for local no-auth)
+bunx @gajae-code/ai login vllm         # store vLLM API key (local no-auth servers are discovered automatically)
 bunx @gajae-code/ai login xai          # sign in with xAI/Grok OAuth
 bunx @gajae-code/ai list               # list available providers
 ```

--- a/packages/ai/src/utils/oauth/vllm.ts
+++ b/packages/ai/src/utils/oauth/vllm.ts
@@ -12,12 +12,11 @@ import type { OAuthController, OAuthProvider } from "./types";
 const PROVIDER_ID: OAuthProvider = "vllm";
 const AUTH_URL = "https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html";
 const DEFAULT_LOCAL_BASE_URL = "http://127.0.0.1:8000/v1";
-const DEFAULT_LOCAL_TOKEN = "vllm-local";
 /**
  * Login to vLLM.
  *
- * Opens vLLM OpenAI-compatible auth docs, prompts for an optional token,
- * and returns a stored key value.
+ * Opens vLLM OpenAI-compatible auth docs, prompts for a bearer token,
+ * and returns a stored key value. Local no-auth servers need no login.
  */
 export async function loginVllm(options: OAuthController): Promise<string> {
 	if (!options.onPrompt) {
@@ -25,16 +24,19 @@ export async function loginVllm(options: OAuthController): Promise<string> {
 	}
 	options.onAuth?.({
 		url: AUTH_URL,
-		instructions: `Paste your vLLM API key if your server requires auth. Leave empty for local no-auth mode (default base URL: ${DEFAULT_LOCAL_BASE_URL}).`,
+		instructions: `Paste the API key configured with vLLM's --api-key option. Local no-auth servers at ${DEFAULT_LOCAL_BASE_URL} are discovered automatically and do not need /login.`,
 	});
 	const apiKey = await options.onPrompt({
-		message: "Paste your vLLM API key (optional for local no-auth)",
-		placeholder: DEFAULT_LOCAL_TOKEN,
-		allowEmpty: true,
+		message: "Paste your vLLM API key",
+		placeholder: "vLLM API key",
+		allowEmpty: false,
 	});
 	if (options.signal?.aborted) {
 		throw new Error("Login cancelled");
 	}
 	const trimmed = apiKey.trim();
-	return trimmed || DEFAULT_LOCAL_TOKEN;
+	if (!trimmed) {
+		throw new Error("vLLM API key is required; local no-auth servers are discovered automatically");
+	}
+	return trimmed;
 }

--- a/packages/ai/test/vllm-login.test.ts
+++ b/packages/ai/test/vllm-login.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { loginVllm } from "../src/utils/oauth/vllm";
+
+describe("vLLM login", () => {
+	it("stores a trimmed API key and opens the current official server docs", async () => {
+		let authUrl = "";
+		let allowEmpty: boolean | undefined;
+		const apiKey = await loginVllm({
+			onAuth: info => {
+				authUrl = info.url;
+			},
+			onPrompt: async prompt => {
+				allowEmpty = prompt.allowEmpty;
+				return "  test-vllm-key  ";
+			},
+		});
+
+		expect(authUrl).toBe("https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html");
+		expect(allowEmpty).toBe(false);
+		expect(apiKey).toBe("test-vllm-key");
+	});
+
+	it("rejects an empty value instead of persisting a no-auth sentinel", async () => {
+		await expect(
+			loginVllm({
+				onAuth: () => {},
+				onPrompt: async () => "   ",
+			}),
+		).rejects.toThrow("vLLM API key is required");
+	});
+});

--- a/packages/ai/test/vllm-login.test.ts
+++ b/packages/ai/test/vllm-login.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { AuthStorage, SqliteAuthCredentialStore } from "../src/auth-storage";
 import { loginVllm } from "../src/utils/oauth/vllm";
 
 describe("vLLM login", () => {
@@ -27,5 +28,33 @@ describe("vLLM login", () => {
 				onPrompt: async () => "   ",
 			}),
 		).rejects.toThrow("vLLM API key is required");
+	});
+
+	it("does not replace a stored key on empty re-login and supports logout/re-login", async () => {
+		const store = await SqliteAuthCredentialStore.open(":memory:");
+		const authStorage = new AuthStorage(store);
+		let promptValue = "  first-vllm-key  ";
+		const controller = {
+			onAuth: () => {},
+			onPrompt: async () => promptValue,
+		};
+
+		try {
+			await authStorage.login("vllm", controller);
+			expect(store.getApiKey("vllm")).toBe("first-vllm-key");
+
+			promptValue = " \t ";
+			await expect(authStorage.login("vllm", controller)).rejects.toThrow("vLLM API key is required");
+			expect(store.getApiKey("vllm")).toBe("first-vllm-key");
+
+			await authStorage.logout("vllm");
+			expect(store.getApiKey("vllm")).toBeNull();
+
+			promptValue = "  second-vllm-key  ";
+			await authStorage.login("vllm", controller);
+			expect(store.getApiKey("vllm")).toBe("second-vllm-key");
+		} finally {
+			store.close();
+		}
 	});
 });

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -16,6 +16,7 @@ import {
 	enrichModelThinking,
 	getBundledModels,
 	getBundledProviders,
+	getEnvApiKey,
 	googleAntigravityModelManagerOptions,
 	googleGeminiCliModelManagerOptions,
 	isCodexGpt56Tier,
@@ -45,6 +46,10 @@ const VLLM_DEFAULT_LOCAL_TOKEN = "vllm-local";
 
 function isVllmNoAuthToken(provider: string, apiKey: string | undefined): boolean {
 	return provider === "vllm" && apiKey === VLLM_DEFAULT_LOCAL_TOKEN;
+}
+
+function normalizeVllmApiKey(provider: string, apiKey: string | undefined): string | undefined {
+	return isVllmNoAuthToken(provider, apiKey) ? getEnvApiKey(provider) : apiKey;
 }
 
 import { registerOAuthProvider, unregisterOAuthProviders } from "@gajae-code/ai/utils/oauth";
@@ -2585,11 +2590,14 @@ export class ModelRegistry {
 			if (optionalAuth && isCurrentPreflight()) this.#credentiallessAuthFallbackProviders.delete(provider);
 			let apiKey: string | undefined;
 			try {
-				apiKey = await this.#peekApiKeyForProvider(provider, {
-					ignoreCredentiallessFallback: optionalAuth,
-					refreshOAuth: true,
-					baseUrl: providerConfig.baseUrl,
-				});
+				apiKey = normalizeVllmApiKey(
+					provider,
+					await this.#peekApiKeyForProvider(provider, {
+						ignoreCredentiallessFallback: optionalAuth,
+						refreshOAuth: true,
+						baseUrl: providerConfig.baseUrl,
+					}),
+				);
 				const currentAuthConfigurationGeneration = this.authStorage.getProviderConfigurationGeneration(provider);
 				if (preflightAuthConfigurationGeneration !== currentAuthConfigurationGeneration) {
 					const currentOAuthRefreshGeneration = this.authStorage.getProviderOAuthRefreshGeneration(provider);
@@ -4457,9 +4465,11 @@ export class ModelRegistry {
 	}
 
 	async #getApiKeyOrNoAuth(provider: string, lookup: () => Promise<string | undefined>): Promise<string | undefined> {
-		if (!this.#isCredentiallessProvider(provider)) return lookup();
-		if (!this.#optionalAuthProviders.has(provider)) return kNoAuth;
+		const credentialless = this.#isCredentiallessProvider(provider);
+		if (credentialless && !this.#optionalAuthProviders.has(provider)) return kNoAuth;
 		const apiKey = await lookup();
+		if (isVllmNoAuthToken(provider, apiKey)) return normalizeVllmApiKey(provider, apiKey) ?? kNoAuth;
+		if (!credentialless) return apiKey;
 		if (apiKey !== undefined) {
 			this.#credentiallessAuthFallbackProviders.delete(provider);
 			return apiKey;

--- a/packages/coding-agent/test/vllm-discovery.test.ts
+++ b/packages/coding-agent/test/vllm-discovery.test.ts
@@ -178,7 +178,52 @@ describe("ModelRegistry vLLM Discovery", () => {
 		expect(registry.find("vllm", "sentinel-keyless-vllm-model")).toBeDefined();
 	});
 
-	test("does not let the empty-login sentinel authorize remote discovery", async () => {
+	test("neutralizes a stored legacy sentinel and preserves the environment key", async () => {
+		await authStorage.set("vllm", { type: "api_key", key: "vllm-local" });
+		Bun.env.VLLM_API_KEY = "env-vllm-key";
+
+		using _hook = hookFetch((input, init) => {
+			const url = String(input);
+			if (!url.includes(":8000/v1/models")) return new Response(null, { status: 404 });
+			const headers = init?.headers as Headers | Record<string, string> | undefined;
+			const authHeader = headers instanceof Headers ? headers.get("Authorization") : headers?.Authorization;
+			expect(authHeader).toBe("Bearer env-vllm-key");
+			return new Response(JSON.stringify({ data: [{ id: "legacy-sentinel-vllm-model" }] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+
+		// AuthStorage intentionally retains stored-credential precedence; the model
+		// registry must recognize this historical marker before it reaches inference.
+		expect(await authStorage.getApiKey("vllm")).toBe("vllm-local");
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		await registry.refreshProvider("vllm", "online");
+		const model = registry.find("vllm", "legacy-sentinel-vllm-model");
+		expect(model).toBeDefined();
+		expect(await registry.getApiKey(model!)).toBe("env-vllm-key");
+	});
+
+	test("maps a stored legacy sentinel to keyless auth when no environment key exists", async () => {
+		await authStorage.set("vllm", { type: "api_key", key: "vllm-local" });
+
+		using _hook = hookFetch(input => {
+			if (!String(input).includes(":8000/v1/models")) return new Response(null, { status: 404 });
+			return new Response(JSON.stringify({ data: [{ id: "legacy-keyless-vllm-model" }] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		await registry.refreshProvider("vllm", "online");
+		const model = registry.find("vllm", "legacy-keyless-vllm-model");
+		expect(model).toBeDefined();
+		expect(await registry.getApiKey(model!)).toBe(kNoAuth);
+	});
+
+	test("does not let the empty-login vLLM sentinel authorize remote discovery", async () => {
 		Bun.env.VLLM_BASE_URL = "https://vllm.example.test/v1";
 		authStorage.setRuntimeApiKey("vllm", "vllm-local");
 		let requestedRemote = false;


### PR DESCRIPTION
## What

`/login vllm` no longer persists the `vllm-local` no-auth sentinel as a stored API key. Empty input is rejected and the flow mirrors the hardened SGLang login landed in #4931.

Historical `vllm-local` credentials are also neutralized at the model boundary: a trusted `VLLM_API_KEY` regains precedence, while the absence of that key remains keyless for local loopback discovery and never sends the sentinel as a bearer token.

## Why

`AuthStorage.getApiKey()` resolves stored `api_key` credentials before environment variables, so a stored `vllm-local` from an earlier empty login could outrank a real `VLLM_API_KEY` and reach normal inference. Local no-auth servers remain covered by implicit loopback discovery and do not need `/login`.

## Testing

- `bun test packages/ai/test/vllm-login.test.ts`
- `bun test packages/coding-agent/test/vllm-discovery.test.ts`
- `bun test packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts packages/coding-agent/test/provider-auth-health-generation.redteam.test.ts packages/coding-agent/test/provider-auth-health.redteam.test.ts packages/coding-agent/test/oauth-selector-validation-race.redteam.test.ts packages/coding-agent/test/oauth-login-url-hyperlink.test.ts`
- `bunx biome check packages/ai/test/vllm-login.test.ts packages/coding-agent/src/config/model-registry.ts packages/coding-agent/test/vllm-discovery.test.ts`
- `bunx tsc -p packages/coding-agent/tsconfig.json --noEmit`

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:24efcd2ea2a511c42befe07b52736f63db84a3ede4ea83a446092dd336371af4 reviewer:architect reviewer-id:Yeachan-Heo evidence:exact-head review and focused auth/provider verification on rebased head 503fdcc817c79a06a185105a68ac4eff101c48c6
```

---

- [x] Target branch is `dev`
- [x] Rebased onto canonical dev `b02afe7318f0e60ff9d2c7c0786cc3c4d8c969d1`
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches exact PR head `503fdcc817c79a06a185105a68ac4eff101c48c6` and base `b02afe7318f0e60ff9d2c7c0786cc3c4d8c969d1`
- [x] Risk classification matches the actual reviewed path