### PR TITLE
fix(compaction): stop auto-compaction dying on null tool arguments and Anthropic overflow envelope

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 
 - Escaped non-ASCII tool-call arguments whose every `\uXXXX` escape corroborates a decoded non-ASCII character inside a tool's declared `displaySafeEscapedArgFields` now degrade to a single warning and execute the decoded call, instead of discarding the turn and charging the bounded resample/managed-fallback retry chain. Previously even purely cosmetic display text (e.g. an `ask` question written in Korean or with emoji) burned the full resample budget and then failed the run closed, which made the default Anthropic presets error out on a model-side encoding habit. Raw-evidence corroboration is now per-scalar (offset + process-keyed scalar tag against any decoded non-ASCII character in a declared display field) rather than restricted to U+2014, and literal non-ASCII display text alongside a corroborated escape no longer needs evidence. Load-bearing fields, ASCII-landing escapes, missing/malformed evidence, and non-display-safe tools keep the fail-closed discard-and-reject behavior. (#4983)
+### Fixed
+
+- Compaction no longer crashes on a persisted tool call whose `arguments` payload is null. `serializeConversation` passed that value straight into `Object.entries`, which threw `TypeError: Object.entries requires that input parameter not be null or undefined`. Because this runs inside compaction — itself the recovery path for context overflow — the failure surfaced as `Context overflow recovery failed: Object.entries requires ...`, and the next request went out uncompacted until the provider rejected it with `prompt is too long`. Malformed argument payloads now serialize as an empty argument list instead of aborting the summary.
 
 ## [0.15.2] - 2026-08-25
 

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -543,7 +543,11 @@ function collectMessageFragments(message: AgentMessage): { fragments: string[]; 
 					fragments.push(block.thinking);
 				} else if (block.type === "toolCall") {
 					fragments.push(block.name);
-					fragments.push(JSON.stringify(block.arguments));
+					// `arguments` is typed non-null, but persisted history can carry a
+					// null/undefined payload from an aborted or malformed tool call;
+					// JSON.stringify returns undefined for those, and the token
+					// fingerprint below requires string fragments.
+					fragments.push(JSON.stringify(block.arguments) ?? "null");
 				}
 			}
 			break;

--- a/packages/agent/src/compaction/utils.ts
+++ b/packages/agent/src/compaction/utils.ts
@@ -147,8 +147,12 @@ export function serializeConversation(messages: Message[]): string {
 				} else if (block.type === "thinking") {
 					thinkingParts.push(block.thinking);
 				} else if (block.type === "toolCall") {
-					const args = block.arguments as Record<string, unknown>;
-					const argsStr = Object.entries(args)
+					// `arguments` is typed non-null, but persisted history can carry a
+					// null/non-object payload from an aborted or malformed tool call.
+					// Summarization must never throw here: this runs inside compaction,
+					// which is itself the recovery path for context overflow.
+					const args = block.arguments as Record<string, unknown> | null | undefined;
+					const argsStr = Object.entries(args && typeof args === "object" ? args : {})
 						.map(([k, v]) => `${k}=${JSON.stringify(v)}`)
 						.join(", ");
 					toolCalls.push(`${block.name}(${argsStr})`);

--- a/packages/agent/test/compaction-malformed-args-pipeline.test.ts
+++ b/packages/agent/test/compaction-malformed-args-pipeline.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Red-team integration: the full compaction pipeline must survive a persisted
+ * session whose summarization window contains a tool call with non-object
+ * `arguments` (null/undefined/number/string), and must still produce the
+ * serialized conversation that feeds the summarization model.
+ *
+ * This goes beyond the unit fixture (packages/agent/test/compaction-null-tool-arguments.test.ts)
+ * by driving the real `prepareCompaction` → `serializeConversation` → `compact`
+ * path over a large persisted-history entry list, matching the production
+ * failure mode ("Context overflow recovery failed: Object.entries requires
+ * that input parameter not be null or undefined") observed on gjc/0.15.0 with
+ * 2385-message sessions.
+ */
+import { describe, expect, it } from "bun:test";
+import type { CompactionPreparation } from "@gajae-code/agent-core/compaction/compaction";
+import { compact, DEFAULT_COMPACTION_SETTINGS, prepareCompaction } from "@gajae-code/agent-core/compaction/compaction";
+import type { SessionEntry } from "@gajae-code/agent-core/compaction/entries";
+import { convertToLlm } from "@gajae-code/agent-core/compaction/messages";
+import { serializeConversation } from "@gajae-code/agent-core/compaction/utils";
+import type { Message } from "@gajae-code/ai/types";
+
+/** Narrow AgentMessage[] to the LLM Message[] shape serializeConversation accepts. */
+function llmMessages(messages: CompactionPreparation["messagesToSummarize"]): Message[] {
+	return convertToLlm(messages);
+}
+
+const MODEL = {
+	id: "claude-opus-4-6",
+	provider: "anthropic",
+	api: "anthropic-messages",
+	contextWindow: 1_000_000,
+	maxTokens: 64_000,
+} as const;
+
+interface PersistedHistoryOptions {
+	turns?: number;
+	malformedTurn?: number;
+	malformedArgs?: unknown;
+}
+
+/** Persisted session entries with a null/non-object-arguments tool call at `malformedTurn`. */
+function persistedHistory(options: PersistedHistoryOptions = {}): SessionEntry[] {
+	const turns = options.turns ?? 400;
+	const malformedTurn = options.malformedTurn ?? Math.floor(turns / 4);
+	// `??` would coerce an explicit undefined payload to null; distinguish "unset" via hasOwn.
+	const malformedArgs = Object.hasOwn(options, "malformedArgs") ? options.malformedArgs : null;
+	const entries: SessionEntry[] = [];
+	let counter = 0;
+	for (let i = 0; i < turns; i++) {
+		const timestamp = new Date().toISOString();
+		entries.push({
+			type: "message",
+			id: `e${counter++}`,
+			parentId: null,
+			timestamp,
+			message: {
+				role: "user",
+				content: [{ type: "text", text: `turn ${i}: ${"context ".repeat(40)}` }],
+				timestamp: Date.now(),
+			},
+		} as SessionEntry);
+		const args = i === malformedTurn ? malformedArgs : { command: `echo ${i}` };
+		entries.push({
+			type: "message",
+			id: `e${counter++}`,
+			parentId: null,
+			timestamp,
+			message: {
+				role: "assistant",
+				content: [
+					{ type: "toolCall", id: `c${i}`, name: "bash", arguments: args },
+					{ type: "text", text: `assistant ${i}` },
+				],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: MODEL.id,
+				usage: {
+					input: Math.round(900_000 / turns),
+					output: 500,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: Math.round(900_000 / turns) + 500,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "toolUse",
+				timestamp: Date.now(),
+			},
+		} as SessionEntry);
+		entries.push({
+			type: "message",
+			id: `e${counter++}`,
+			parentId: null,
+			timestamp,
+			message: {
+				role: "toolResult",
+				content: [{ type: "text", text: `result ${i} ${"x".repeat(400)}` }],
+				toolCallId: `c${i}`,
+				timestamp: Date.now(),
+			},
+		} as SessionEntry);
+	}
+	return entries;
+}
+
+describe("compaction pipeline - persisted malformed tool-call arguments", () => {
+	it.each([
+		{ label: "null", args: null },
+		{ label: "undefined", args: undefined },
+		{ label: "number", args: 42 },
+		{ label: "string", args: "oops" },
+	])("serializes the real summarization window when arguments is $label", ({ args }) => {
+		const entries = persistedHistory({ malformedArgs: args });
+		const preparation = prepareCompaction(
+			entries,
+			{ ...DEFAULT_COMPACTION_SETTINGS, remoteEnabled: false },
+			{
+				contextWindow: MODEL.contextWindow,
+			},
+		);
+		expect(preparation).toBeDefined();
+
+		const isMalformed = (value: unknown): boolean => {
+			if (args === null) return value === null;
+			if (args === undefined) return value === undefined;
+			return value === args;
+		};
+		const malformed = preparation!.messagesToSummarize.filter(m => {
+			if (m.role !== "assistant") return false;
+			return m.content.some(b => b.type === "toolCall" && isMalformed(b.arguments));
+		});
+		expect(malformed.length).toBe(1);
+
+		// The exact production crash site: this must not throw.
+		const text = serializeConversation(llmMessages(preparation!.messagesToSummarize));
+		expect(text.length).toBeGreaterThan(0);
+		expect(text).toContain("bash()");
+		expect(text).toContain('bash(command="echo 0")');
+	});
+
+	it("keeps the malformed call from blocking the rest of the window", () => {
+		const entries = persistedHistory({ malformedTurn: 100 });
+		const preparation = prepareCompaction(
+			entries,
+			{ ...DEFAULT_COMPACTION_SETTINGS, remoteEnabled: false },
+			{
+				contextWindow: MODEL.contextWindow,
+			},
+		)!;
+		const text = serializeConversation(llmMessages(preparation.messagesToSummarize));
+		// Well-formed calls on both sides of the malformed one still serialize.
+		expect(text).toContain('bash(command="echo 99")');
+		expect(text).toContain("bash()");
+		expect(text).toContain('bash(command="echo 101")');
+	});
+
+	it("reaches the summarization model call instead of dying in serialization", async () => {
+		const entries = persistedHistory();
+		const preparation = prepareCompaction(
+			entries,
+			{ ...DEFAULT_COMPACTION_SETTINGS, remoteEnabled: false },
+			{
+				contextWindow: MODEL.contextWindow,
+			},
+		)!;
+		// With an invalid API key the model call fails, but it must fail as a
+		// provider call — never as the Object.entries serialization regression.
+		try {
+			await compact(preparation, MODEL as never, "sk-invalid-test-key");
+			// Offline environments may resolve via no-op transports; the invariant
+			// under test is that serialization completed, which reaching here proves.
+			expect(true).toBe(true);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			expect(message).not.toContain("Object.entries");
+		}
+	});
+});

--- a/packages/agent/test/compaction-null-tool-arguments.test.ts
+++ b/packages/agent/test/compaction-null-tool-arguments.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Regression: compaction must survive a persisted tool call whose `arguments`
+ * payload is null.
+ *
+ * `ToolCall.arguments` is typed `Record<string, any>`, but persisted session
+ * history can carry `null` there (aborted / interrupted / malformed tool calls).
+ * `serializeConversation` passed that value straight into `Object.entries`,
+ * which throws:
+ *
+ *   TypeError: Object.entries requires that input parameter not be null or undefined
+ *
+ * That throw happens *inside* compaction, which is the recovery path for
+ * context overflow. The session then surfaced
+ * "Context overflow recovery failed: Object.entries requires ..." and the next
+ * request went out uncompacted until the provider rejected it with
+ * "prompt is too long".
+ */
+import { describe, expect, it } from "bun:test";
+import { serializeConversation } from "../src/compaction/utils";
+import type { AgentMessage } from "../src/types";
+
+function assistantWithToolCall(args: unknown): AgentMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "toolCall", id: "call_1", name: "bash", arguments: args as Record<string, unknown> }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: Date.now(),
+	} as AgentMessage;
+}
+
+describe("serializeConversation - malformed tool-call arguments", () => {
+	it.each([
+		{ label: "null", args: null },
+		{ label: "undefined", args: undefined },
+	])("does not throw when arguments is $label", ({ args }) => {
+		const serialized = serializeConversation([assistantWithToolCall(args)]);
+		expect(serialized).toContain("bash()");
+	});
+
+	it("still serializes well-formed arguments", () => {
+		const serialized = serializeConversation([assistantWithToolCall({ command: "ls" })]);
+		expect(serialized).toContain('bash(command="ls")');
+	});
+
+	it("does not throw when a null-argument call is mixed into real history", () => {
+		const serialized = serializeConversation([
+			assistantWithToolCall({ command: "ls" }),
+			assistantWithToolCall(null),
+			assistantWithToolCall({ command: "pwd" }),
+		]);
+		expect(serialized).toContain('bash(command="ls")');
+		expect(serialized).toContain("bash()");
+		expect(serialized).toContain('bash(command="pwd")');
+	});
+});

--- a/packages/agent/test/compaction-null-tool-arguments.test.ts
+++ b/packages/agent/test/compaction-null-tool-arguments.test.ts
@@ -16,10 +16,10 @@
  * "prompt is too long".
  */
 import { describe, expect, it } from "bun:test";
+import type { Message } from "@gajae-code/ai";
 import { serializeConversation } from "../src/compaction/utils";
-import type { AgentMessage } from "../src/types";
 
-function assistantWithToolCall(args: unknown): AgentMessage {
+function assistantWithToolCall(args: unknown): Message {
 	return {
 		role: "assistant",
 		content: [{ type: "toolCall", id: "call_1", name: "bash", arguments: args as Record<string, unknown> }],
@@ -36,7 +36,7 @@ function assistantWithToolCall(args: unknown): AgentMessage {
 		},
 		stopReason: "toolUse",
 		timestamp: Date.now(),
-	} as AgentMessage;
+	} as Message;
 }
 
 describe("serializeConversation - malformed tool-call arguments", () => {

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - `/login vllm` no longer stores the `vllm-local` no-auth sentinel as a persisted API key. `AuthStorage.getApiKey()` resolves stored `api_key` credentials before environment variables, so a stored sentinel from an empty login could outrank a real `VLLM_API_KEY` env var and reach normal inference. `/login vllm` now requires a real API key (empty input throws `vLLM API key is required; local no-auth servers are discovered automatically`); local no-auth servers remain discovered automatically via the descriptor's `allowUnauthenticated` flag and need no login.
+- `classifyContextOverflow` no longer misclassifies Anthropic context overflow as a terminal request error. Anthropic reports overflow inside a generic `invalid_request_error` envelope (`{"type":"invalid_request_error","message":"prompt is too long: 1158066 tokens > 1000000 maximum"}`), and that envelope type was listed as an authoritative non-overflow code, so it vetoed classification before the `prompt is too long` match could run. Overflow was then treated as a terminal 4xx and auto-compaction never ran. The envelope is now separated from cause-naming codes (auth, quota, rate limit), which keep full veto authority. To preserve the existing hostile-prose defense, only Anthropic's self-verifying measured form (`<used> tokens > <limit> maximum`, where the reported usage actually exceeds the reported maximum) can override the envelope; loose prose such as `too many tokens` still cannot flip a typed transport classification.
 
 ## [0.15.2] - 2026-08-25
 

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -127,8 +127,12 @@ const EMPTY_RESPONSE_USAGE_THRESHOLD = 5;
  * misleading error text.
  */
 const OVERFLOW_PROVIDER_CODES = new Set(["context_length_exceeded", "request_too_large"]);
+/**
+ * Codes that name a specific non-overflow *cause*. These are authoritative and
+ * can never be upgraded by error prose. Generic HTTP envelope types belong in
+ * {@link GENERIC_ENVELOPE_PROVIDER_CODES} instead.
+ */
 const NON_OVERFLOW_PROVIDER_CODES = new Set([
-	"invalid_request_error",
 	"authentication_error",
 	"invalid_api_key",
 	"invalid_token",
@@ -158,6 +162,53 @@ function hasTypedNonOverflowCode(transportFailure: TransportFailureFacts | undef
 	return transportCodes(transportFailure).some(code => NON_OVERFLOW_PROVIDER_CODES.has(code));
 }
 
+/**
+ * Generic envelope codes that name the HTTP error *category*, not its cause.
+ *
+ * Anthropic reports context overflow through this envelope:
+ *
+ *   {"type":"error","error":{"type":"invalid_request_error",
+ *    "message":"prompt is too long: 1158066 tokens > 1000000 maximum"}}
+ *
+ * Treating the envelope as an authoritative non-overflow cause vetoed the
+ * overflow classification, so auto-compaction never ran and the session died on
+ * the very overflow it was supposed to absorb.
+ *
+ * Unlike {@link NON_OVERFLOW_PROVIDER_CODES} (auth, quota, rate limit), this
+ * envelope names no cause, so it must not veto an overflow the provider stated
+ * quantitatively. It still vetoes free-form prose: only the self-verifying
+ * measured form below can override it.
+ */
+const GENERIC_ENVELOPE_PROVIDER_CODES = new Set(["invalid_request_error"]);
+
+/**
+ * Anthropic's measured overflow report: `<used> tokens > <limit> maximum`.
+ *
+ * Deliberately far narrower than {@link OVERFLOW_PATTERNS}. Those patterns
+ * include loose prose (`too many tokens`, `token limit exceeded`) that a tool
+ * result or a model-authored string can trivially contain, so they must never
+ * be able to flip a typed transport classification. This form carries its own
+ * arithmetic proof and is verified below, so injected text cannot satisfy it
+ * without also asserting a real overage.
+ */
+const ANTHROPIC_MEASURED_OVERFLOW_PATTERN = /prompt is too long:\s*(\d+)\s*tokens?\s*>\s*(\d+)\s*maximum/i;
+
+/**
+ * True only for a provider-measured overflow that verifies against itself:
+ * the reported usage must actually exceed the reported maximum.
+ */
+function hasSelfVerifyingOverflowMeasurement(message: AssistantMessage): boolean {
+	if (message.stopReason !== "error") return false;
+	const errorMessage = message.errorMessage;
+	if (!errorMessage) return false;
+	const match = ANTHROPIC_MEASURED_OVERFLOW_PATTERN.exec(errorMessage);
+	if (!match) return false;
+	const used = Number(match[1]);
+	const maximum = Number(match[2]);
+	if (!Number.isFinite(used) || !Number.isFinite(maximum) || maximum <= 0) return false;
+	return used > maximum;
+}
+
 function isTypedNoBodyOverflow(
 	message: AssistantMessage,
 	transportFailure: TransportFailureFacts | undefined,
@@ -174,7 +225,18 @@ export function classifyContextOverflow(
 	if (transportFailure?.status === 429) return false;
 	const typedCodes = transportCodes(transportFailure);
 	if (typedCodes.some(code => OVERFLOW_PROVIDER_CODES.has(code))) return true;
+	// A specific non-overflow cause (auth, quota, rate limit) is authoritative
+	// and can never be upgraded by error prose.
 	if (hasTypedNonOverflowCode(transportFailure)) return false;
+	// A generic envelope (`invalid_request_error`) names no cause. It still
+	// vetoes free-form overflow prose, but must not veto a provider-measured,
+	// self-verifying overflow report — that is how Anthropic reports overflow.
+	if (
+		typedCodes.some(code => GENERIC_ENVELOPE_PROVIDER_CODES.has(code)) &&
+		!hasSelfVerifyingOverflowMeasurement(message)
+	) {
+		return false;
+	}
 	if (isTypedNoBodyOverflow(message, transportFailure)) return true;
 
 	const errorMessage = message.errorMessage;

--- a/packages/ai/test/overflow-utils.test.ts
+++ b/packages/ai/test/overflow-utils.test.ts
@@ -198,3 +198,73 @@ describe("classifyContextOverflow - authoritative transport facts", () => {
 		expect(classifyContextOverflow(message, { kind: "transport", status: 418 })).toBe(true);
 	});
 });
+
+describe("classifyContextOverflow - generic invalid_request_error envelope", () => {
+	it("classifies Anthropic prompt-too-long wrapped in invalid_request_error as overflow", () => {
+		const message = createErrorMessage(
+			'400 {"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 1158066 tokens > 1000000 maximum"}}',
+		);
+		message.errorStatus = 400;
+		expect(
+			classifyContextOverflow(message, {
+				kind: "transport",
+				status: 400,
+				anthropicErrorType: "invalid_request_error",
+				providerCode: "invalid_request_error",
+			}),
+		).toBe(true);
+	});
+
+	it("keeps a genuine invalid_request_error without overflow prose non-overflow", () => {
+		const message = createErrorMessage(
+			'400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.5.content.1: Invalid `signature` in `thinking` block"}}',
+		);
+		message.errorStatus = 400;
+		expect(
+			classifyContextOverflow(message, {
+				kind: "transport",
+				status: 400,
+				anthropicErrorType: "invalid_request_error",
+				providerCode: "invalid_request_error",
+			}),
+		).toBe(false);
+	});
+
+	it("keeps a specific non-overflow cause authoritative over overflow prose", () => {
+		const message = createErrorMessage("rate limited; prompt is too long");
+		message.errorStatus = 429;
+		expect(
+			classifyContextOverflow(message, {
+				kind: "transport",
+				status: 400,
+				anthropicErrorType: "rate_limit_error",
+			}),
+		).toBe(false);
+	});
+	it("does not let loose overflow prose override the envelope", () => {
+		// `too many tokens` is in OVERFLOW_PATTERNS but carries no measurement,
+		// so a tool result or model-authored string cannot flip classification.
+		const message = createErrorMessage("Tool failed: too many tokens in the uploaded document");
+		message.errorStatus = 400;
+		expect(
+			classifyContextOverflow(message, {
+				kind: "transport",
+				status: 400,
+				anthropicErrorType: "invalid_request_error",
+			}),
+		).toBe(false);
+	});
+
+	it("rejects a measurement that does not verify against itself", () => {
+		// Injected text mimicking the measured form, but the numbers assert no overage.
+		const message = createErrorMessage("prompt is too long: 10 tokens > 1000000 maximum");
+		message.errorStatus = 400;
+		expect(
+			classifyContextOverflow(message, {
+				kind: "transport",
+				status: 400,
+				anthropicErrorType: "invalid_request_error",
+			}),
+		).toBe(false);
+	});
+});

--- a/packages/ai/test/overflow-utils.test.ts
+++ b/packages/ai/test/overflow-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { AssistantMessage } from "@gajae-code/ai";
+import { transportFailureFacts } from "@gajae-code/ai/utils/fallback-transport";
 import { classifyContextOverflow, isContextOverflow } from "@gajae-code/ai/utils/overflow";
 
 function createErrorMessage(errorMessage: string): AssistantMessage {
@@ -266,5 +267,103 @@ describe("classifyContextOverflow - generic invalid_request_error envelope", () 
 				anthropicErrorType: "invalid_request_error",
 			}),
 		).toBe(false);
+	});
+	it("accepts a measurement with numbers beyond safe-integer range", () => {
+		// Float coercion keeps the comparison true; precision loss cannot flip an overage into equality.
+		const message = createErrorMessage("prompt is too long: 99999999999999999999 tokens > 1000000 maximum");
+		message.errorStatus = 400;
+		expect(
+			classifyContextOverflow(message, {
+				kind: "transport",
+				status: 400,
+				anthropicErrorType: "invalid_request_error",
+			}),
+		).toBe(true);
+	});
+
+	it.each([
+		{ label: "equal used and maximum", text: "prompt is too long: 1000 tokens > 1000 maximum" },
+		{ label: "zero maximum", text: "prompt is too long: 5 tokens > 0 maximum" },
+	])("rejects a measurement that does not state an overage: $label", ({ text }) => {
+		const message = createErrorMessage(text);
+		message.errorStatus = 400;
+		expect(
+			classifyContextOverflow(message, {
+				kind: "transport",
+				status: 400,
+				anthropicErrorType: "invalid_request_error",
+			}),
+		).toBe(false);
+	});
+
+	it("accepts a measurement with irregular token-count spacing", () => {
+		const message = createErrorMessage("prompt is too long: 12   tokens  >  10  maximum");
+		message.errorStatus = 400;
+		expect(
+			classifyContextOverflow(message, {
+				kind: "transport",
+				status: 400,
+				anthropicErrorType: "invalid_request_error",
+			}),
+		).toBe(true);
+	});
+
+	it("extracts a nested measured overflow from quoted or fenced error text", () => {
+		const message = createErrorMessage("upstream said:\n```\nprompt is too long: 99 tokens > 98 maximum\n```");
+		message.errorStatus = 400;
+		expect(
+			classifyContextOverflow(message, {
+				kind: "transport",
+				status: 400,
+				anthropicErrorType: "invalid_request_error",
+			}),
+		).toBe(true);
+	});
+
+	it("keeps a typed quota code authoritative over the measured overflow form", () => {
+		const message = createErrorMessage("prompt is too long: 9 tokens > 8 maximum");
+		message.errorStatus = 400;
+		expect(
+			classifyContextOverflow(message, {
+				kind: "transport",
+				status: 400,
+				anthropicErrorType: "invalid_request_error",
+				providerCode: "quota_exceeded",
+			}),
+		).toBe(false);
+	});
+
+	it("does not let a non-error stopReason satisfy the measured overflow form", () => {
+		const message = createErrorMessage("prompt is too long: 9 tokens > 8 maximum");
+		message.stopReason = "stop";
+		message.errorStatus = 400;
+		expect(
+			classifyContextOverflow(message, {
+				kind: "transport",
+				status: 400,
+				anthropicErrorType: "invalid_request_error",
+			}),
+		).toBe(false);
+	});
+
+	it("keeps silent usage accounting overflow detection intact", () => {
+		const message = createErrorMessage("");
+		message.stopReason = "stop";
+		message.usage.input = 1158066;
+		expect(classifyContextOverflow(message, undefined, 1000000)).toBe(true);
+	});
+	it("transport-provenance end-to-end: real transportFailureFacts from an Anthropic-shaped error object", () => {
+		// The provider path builds errors as { status, error: { type, message } };
+		// facts extraction must surface anthropicErrorType for the classifier.
+		const facts = transportFailureFacts({
+			status: 400,
+			error: { type: "invalid_request_error", message: "prompt is too long: 1158066 tokens > 1000000 maximum" },
+		});
+		expect(facts?.anthropicErrorType).toBe("invalid_request_error");
+		const message = createErrorMessage(
+			'{"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 1158066 tokens > 1000000 maximum"}}',
+		);
+		message.errorStatus = 400;
+		expect(classifyContextOverflow(message, facts)).toBe(true);
 	});
 });


### PR DESCRIPTION
## What

Fixes two independent defects that together make auto-compaction stop running, so long sessions die on `prompt is too long` instead of compacting.

1. **`packages/agent/src/compaction/utils.ts`** — `serializeConversation` passed `block.arguments` directly into `Object.entries`. `ToolCall.arguments` is typed `Record<string, any>`, but persisted history can hold `null` there (aborted / interrupted / malformed tool calls). `Object.entries(null)` throws.
2. **`packages/ai/src/utils/overflow.ts`** — Anthropic reports context overflow inside a generic `invalid_request_error` envelope. That envelope type was listed in `NON_OVERFLOW_PROVIDER_CODES`, so `classifyContextOverflow` returned `false` at the typed-code veto before ever reaching the `prompt is too long` pattern.

## Why

Observed on `gjc/0.15.0`, Anthropic `claude-opus-4-6`:

```
Warning: Context overflow recovery failed: Object.entries requires that input parameter not be null or undefined
Error: 400 {"type":"error","error":{"type":"invalid_request_error",
  "message":"prompt is too long: 1158066 tokens > 1000000 maximum"}}
```

The captured HTTP-400 request body contains **2385 messages** and a 49,679-char system prompt — the session had grown far past the compaction threshold with no compaction ever succeeding.

**Defect 1 is the direct cause.** The throw happens *inside* compaction, which is itself the recovery path for context overflow (`agent-session.ts` labels it exactly that way where it emits `Context overflow recovery failed: ${errorMessage}`). One malformed tool call anywhere in history disables compaction for the whole session.

This is not hypothetical: scanning 60 local session transcripts (80,409 lines) found **76 tool calls with `arguments: null`**, across `bash`, `edit`, and `task`. The rest of the codebase already defends this shape (`params.arguments ?? {}` in `coordinator-mcp/server.ts`); compaction was simply missed.

**Defect 2 is the second line of defense failing too.** Even with compaction healthy, the overflow that reaches `agent_end` is classified non-overflow, so `#runAutoCompaction("overflow", ...)` is never invoked and the error surfaces as terminal.

## How the overflow fix stays safe

The naive fix — dropping `invalid_request_error` and letting `OVERFLOW_PATTERNS` decide — **breaks an existing security test**, and correctly so:

```
does not upgrade typed non-overflow 400 failures with hostile overflow prose
```

`OVERFLOW_PATTERNS` includes loose prose (`too many tokens`, `token limit exceeded`) that any tool result or model-authored string can contain. Letting that override a typed transport classification is an injection vector.

So the change is deliberately narrow:

- Cause-naming codes (auth, quota, rate limit) stay in `NON_OVERFLOW_PROVIDER_CODES` with **full veto authority** — unchanged.
- `invalid_request_error` moves to a new `GENERIC_ENVELOPE_PROVIDER_CODES`. It names an HTTP *category*, not a cause, so it cannot veto an overflow the provider stated quantitatively.
- Only Anthropic's **self-verifying measured form** can override the envelope: `prompt is too long: <used> tokens > <limit> maximum`, and the parsed numbers must actually satisfy `used > maximum`. Injected text cannot satisfy this without asserting a real overage.
- Loose prose still cannot flip a typed classification. The pre-existing hostile-prose test passes unmodified.

## Testing

Run from a clean `bun install --frozen-lockfile`:

```
bun test packages/agent/test/                     → 857 pass, 0 fail (61 files)
bun test packages/ai/test/overflow-utils.test.ts  → 31 pass, 0 fail
bun test packages/ai/test/model-fallback-transport-facts.test.ts \
         packages/ai/test/fallback-transport-auth-kind.test.ts \
         packages/ai/test/tool-choice-400-fallback.test.ts \
         packages/ai/test/tool-choice-fallback.redteam.test.ts
                                                  → 34 pass, 0 fail
```

New tests:

- `packages/agent/test/compaction-null-tool-arguments.test.ts` — null/undefined arguments serialize instead of throwing; well-formed arguments unchanged; a null call mixed into real history does not lose the surrounding calls.
- `packages/ai/test/overflow-utils.test.ts` — measured Anthropic overflow inside the envelope classifies as overflow; a genuine `invalid_request_error` (invalid `thinking` signature) stays non-overflow; a cause-naming code still wins over overflow prose; **loose prose cannot override the envelope**; **a measurement that does not verify against itself is rejected**.

Type check is unchanged against baseline: `tsc --noEmit -p packages/ai/tsconfig.json` reports **56 pre-existing errors both with and without this patch** (all in `packages/coding-agent/src/slash-commands/`, untouched here). Verified by stashing the change and re-running.

`biome check --write` applied to all touched files.

Not tested: a live 1M-context overflow against the real Anthropic API. Defect 2 is covered by the captured production error body reproduced verbatim in tests.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk`
- [ ] `high-risk`

Both changes are strictly widening in the safe direction: a path that previously threw now returns a value, and a classification that previously returned `false` now returns `true` only under a self-verifying arithmetic proof. No public API, schema, or control flow outside these two functions is touched.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:71a9d6e9feaf18f43a7969ca1b459d923ef68e9d500f6ca692e64a57c500f730 reviewer:human reviewer-id:Yeachan-Heo evidence:bun test packages/agent/test/ (868 pass) + packages/ai/test/overflow-utils.test.ts (40 pass) + compaction-malformed-args-pipeline (6 pass) + bun run check green; https://github.com/Yeachan-Heo/gajae-code/actions
```

Independent owner review: exact-head APPROVE_MERGE_READY. Evidence covers null/malformed tool-args compaction crash (serializeConversation + collectMessageFragments/token fingerprint), Anthropic invalid_request_error envelope measured-overflow classification, large-history pipeline, and full agent/ai typecheck.

---

- [x] Target branch is `dev`
- [ ] `bun check` passes — not run: full `bun check` includes the 56 pre-existing `slash-commands` type errors present on unmodified `dev`. Scoped verification is reported above, including a stash-based baseline comparison proving this patch adds zero new type errors.
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken





