### PR TITLE
fix(tui): stop stale g003 context mock from emitting a leading palette error

### DIFF
--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -345,7 +345,7 @@ export class InputController {
 	}
 
 	#installOAuthCopyListener(): void {
-		if (typeof this.ctx.ui.addInputListener !== "function") return;
+		if (typeof this.ctx.ui?.addInputListener !== "function") return;
 		this.#oauthCopyUnsubscribe?.();
 		this.#oauthCopyUnsubscribe = this.ctx.ui.addInputListener(data => {
 			if (this.ctx.hasOAuthUrlForCopy?.() !== true) return;

--- a/packages/coding-agent/test/g003-ws2-redteam.test.ts
+++ b/packages/coding-agent/test/g003-ws2-redteam.test.ts
@@ -38,6 +38,9 @@ function createControllerContext(overrides: Partial<InteractiveModeContext> = {}
 		todoPhases: [],
 		showError: () => {},
 		showStatus: () => {},
+		beginOAuthUrlForCopy: () => () => {},
+		hasOAuthUrlForCopy: () => false,
+		copyOAuthUrl: async () => {},
 		historyStorage: { getRecent: () => [] },
 		skillCommands: new Map(),
 		...overrides,
@@ -174,6 +177,49 @@ describe("G003 WS2 red-team: command palette", () => {
 		palette?.handleInput("\n");
 		await Promise.resolve();
 		expect(order).toEqual(["hide", "focus", "execute", "error"]);
+	});
+
+	it("emits no error events while building the palette and gates the OAuth URL-copy entry on lease availability", async () => {
+		const order: string[] = [];
+		let leaseActive = false;
+		let palette: CommandPalette | undefined;
+		const ctx = createControllerContext({
+			hasOAuthUrlForCopy: () => leaseActive,
+			copyOAuthUrl: async () => {
+				order.push("copy");
+				throw new Error("clipboard failed");
+			},
+			showError: (message: string) => order.push(`error:${message}`),
+			ui: {
+				showOverlay(component: CommandPalette) {
+					palette = component;
+					return { hide: () => order.push("hide") };
+				},
+				setFocus: () => {},
+				requestRender: () => {},
+			} as never,
+		});
+		const controller = new InputController(ctx);
+		controller.openCommandPalette();
+		expect(palette?.getEntries().some(entry => entry.id === "action:app.clipboard.copyOAuthUrl")).toBe(false);
+		expect(order).toEqual([]);
+
+		leaseActive = true;
+		await Promise.resolve();
+		controller.openCommandPalette();
+		const oauthEntry = palette?.getEntries().find(entry => entry.id === "action:app.clipboard.copyOAuthUrl");
+		expect(oauthEntry?.handler).toBeDefined();
+		expect(order).toEqual([]);
+
+		leaseActive = false;
+		await oauthEntry?.handler?.();
+		await Promise.resolve();
+		expect(order).toEqual([]);
+
+		leaseActive = true;
+		await oauthEntry?.handler?.();
+		await Promise.resolve();
+		expect(order).toEqual(["copy", "error:Action app.clipboard.copyOAuthUrl execution failed: clipboard failed"]);
 	});
 
 	it("does not expose idle queue submission through the draft palette", () => {


### PR DESCRIPTION
Fixes #4988

## What

Two-file fix for the extra leading `error` event in `packages/coding-agent/test/g003-ws2-redteam.test.ts`:

1. `packages/coding-agent/test/g003-ws2-redteam.test.ts` — teach the suite's hand-rolled `createControllerContext` mock the post-#4981 `InteractiveModeContext` members (`beginOAuthUrlForCopy`/`hasOAuthUrlForCopy`/`copyOAuthUrl`), and add a focused regression test pinning zero-error palette construction, lease-gated OAuth entry, `executeFresh` stale-entry no-op, and execution-failure error visibility.
2. `packages/coding-agent/src/modes/controllers/input-controller.ts` — one-line optional-chain guard (`ctx.ui?.addInputListener`) in `#installOAuthCopyListener`, fixing a pre-existing constructor crash for hosts embedding `InputController` with a minimal UI stub (red `background-fold.test.ts` on dev HEAD).

## Why

The leading `error` was a **stale test mock**, not a production lifecycle bug. PR #4981 added three required `InteractiveModeContext` members and registered `app.clipboard.copyOAuthUrl` as an availability-gated palette action whose predicate calls `this.ctx.hasOAuthUrlForCopy()` (`input-controller.ts:227-228`). The g003 suite's mock predates that change and lacks the member, so `openCommandPalette()`'s availability sweep (`action-registry.ts` `#evaluateAvailability` → `#reportError` → `ctx.showError`) fires an error event **before** the overlay is built:

```
Action app.clipboard.copyOAuthUrl availability failed: this.ctx.hasOAuthUrlForCopy is not a function.
```

Production is sound: `InteractiveMode` implements all three members (`interactive-mode.ts:1842-1876`) and the lease list is begin/release balanced. `ActionRegistry`'s availability-error visibility is intentional pre-existing behavior (`50f9a9a54`) and is **not** weakened by this fix.

## Testing

- **Reproduction at base `975f043e9`:** `bun test packages/coding-agent/test/g003-ws2-redteam.test.ts` → 1 fail, received `[error, hide, focus, execute, error]`.
- **At head `d4e39d96c`:** same command → **10 pass / 0 fail**.
- **Red-green proof:** stashing only the test-file change at head reproduces the base red (`8 pass / 1 fail`, same leading `error`); restoring returns green.
- **Adjacent:** 348 pass / 0 fail across 21 suites (all palette/OAuth/input-controller/action-registry/red-team suites incl. `background-fold`, `g002-ws1`, `g004-ws3`).
- **Gate/build/smoke:** `bun scripts/verify-gjc-state-writers.ts --fail` exit 0; `bun --cwd=packages/coding-agent run check` exit 0; `build` exit 0; `gjc --version` → `gjc/0.15.2`; `--smoke-test` → `smoke-test: ok`.
- **Non-regression verified:** OAuth URL-copy availability gating and `executeFresh` recheck, palette `hide → focus → execute → error` ordering, Escape/cancellation (25 open/escape cycles), Ctrl+C/Escape remap guard while a lease is active, and `showError` visibility for both availability and execution failures.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:d1c6e368741ed0f71a77bb30ae01fa61b899d804db67703761dae786c4f1d2e4 reviewer:human reviewer-id:Yeachan-Heo evidence:local: bun test packages/coding-agent/test/g003-ws2-redteam.test.ts 10/10 pass at exact head d4e39d96c; 348 pass across 21 adjacent suites; fast gate + coding-agent check/build/CLI smoke exit 0
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing) — not user-facing; no changelog entry required
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
