### PR TITLE
fix(release): survive transient failures while watching release CI

### DIFF
--- a/scripts/release-retry.test.ts
+++ b/scripts/release-retry.test.ts
@@ -4,9 +4,14 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
+	decideObservationRetry,
 	localRollbackCommands,
+	observeWithRetry,
 	planAtomicPushRollback,
 	pushReleaseRefsAtomically,
+	ReleaseObservationError,
+	RELEASE_OBSERVATION_ATTEMPTS,
+	releaseObservationRetryDelayMs,
 	reconcileAtomicPushFailure,
 } from "./release";
 
@@ -219,5 +224,97 @@ describe("accepted remote transaction with a client-side failed push", () => {
 		expect(tagCheck.exitCode).toBe(0);
 		const remoteTag = (await git(work, ["ls-remote", "origin", "refs/tags/v9.9.9"])).split("\t")[0]?.trim();
 		expect(remoteTag).toBe(head);
+	});
+});
+
+describe("post-push CI observation retry policy", () => {
+	test("backs off exponentially from 2s and holds a 30s ceiling", () => {
+		expect([1, 2, 3, 4, 5, 6].map(releaseObservationRetryDelayMs)).toEqual([2_000, 4_000, 8_000, 16_000, 30_000, 30_000]);
+	});
+
+	test("rejects a non-positive or fractional attempt instead of inventing a delay", () => {
+		expect(() => releaseObservationRetryDelayMs(0)).toThrow("positive integer");
+		expect(() => releaseObservationRetryDelayMs(-1)).toThrow("positive integer");
+		expect(() => releaseObservationRetryDelayMs(1.5)).toThrow("positive integer");
+		expect(() => decideObservationRetry(0)).toThrow("positive integer");
+	});
+
+	test("retries every attempt before the budget and fails only on exhaustion", () => {
+		for (let attempt = 1; attempt < RELEASE_OBSERVATION_ATTEMPTS; attempt++) {
+			expect(decideObservationRetry(attempt)).toEqual({ action: "retry", delayMs: releaseObservationRetryDelayMs(attempt) });
+		}
+		expect(decideObservationRetry(RELEASE_OBSERVATION_ATTEMPTS)).toEqual({ action: "fail" });
+		expect(decideObservationRetry(RELEASE_OBSERVATION_ATTEMPTS + 1)).toEqual({ action: "fail" });
+	});
+
+	test("spends a bounded wall-clock budget so a broken watch still terminates", () => {
+		let total = 0;
+		for (let attempt = 1; attempt < RELEASE_OBSERVATION_ATTEMPTS; attempt++) {
+			const decision = decideObservationRetry(attempt);
+			if (decision.action === "retry") total += decision.delayMs;
+		}
+		expect(total).toBeGreaterThanOrEqual(60_000);
+		expect(total).toBeLessThanOrEqual(300_000);
+	});
+});
+
+describe("observation command classification", () => {
+	const noSleep = () => Promise.resolve();
+	const zeroExitCommand = () => Promise.resolve({ exitCode: 0, stdout: Buffer.alloc(0), stderr: Buffer.alloc(0) });
+
+	test("classifies a zero exit with unusable output as an observation failure, not a verdict", async () => {
+		let attempts = 0;
+		let caught: unknown;
+		try {
+			await observeWithRetry(
+				"probe",
+				zeroExitCommand,
+				() => {
+					attempts++;
+					throw new Error("Unexpected end of JSON input");
+				},
+				noSleep,
+			);
+		} catch (error) {
+			caught = error;
+		}
+		expect(caught).toBeInstanceOf(ReleaseObservationError);
+		expect(attempts).toBe(RELEASE_OBSERVATION_ATTEMPTS);
+		expect((caught as ReleaseObservationError).message).toContain("failed 8 times: unusable response: Unexpected end of JSON input");
+	});
+
+	test("retries a truncated response within the same bounded budget and recovers", async () => {
+		let attempts = 0;
+		const command = () => Promise.resolve({ exitCode: 0, stdout: Buffer.from("[]"), stderr: Buffer.alloc(0) });
+		const delays: number[] = [];
+		const result = await observeWithRetry(
+			"probe",
+			command,
+			stdout => {
+				attempts++;
+				if (attempts === 1) throw new Error("Cannot parse CI run query");
+				return JSON.parse(stdout) as unknown[];
+			},
+			ms => {
+				delays.push(ms);
+				return Promise.resolve();
+			},
+		);
+		expect(result).toEqual([]);
+		expect(attempts).toBe(2);
+		expect(delays).toEqual([releaseObservationRetryDelayMs(1)]);
+	});
+
+	test("reports the malformed-output reason, not a silent success or failure", async () => {
+		const command = () => Promise.resolve({ exitCode: 0, stdout: Buffer.from("not json"), stderr: Buffer.alloc(0) });
+		try {
+			await observeWithRetry("probe", command, () => {
+				throw new Error("did not return an array");
+			}, noSleep);
+			throw new Error("expected rejection");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ReleaseObservationError);
+			expect((error as ReleaseObservationError).message).toContain("unusable response: did not return an array");
+		}
 	});
 });

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -147,29 +147,115 @@ function parseReleaseRunJobs(output: string, runId: number): ReleaseRunJobObserv
 	});
 }
 
+/**
+ * A read-only CI observation could not be completed.
+ *
+ * Distinct from a CI verdict: the release refs may already be published and the
+ * workflow may be perfectly healthy. Only the observer failed, so the operator
+ * must re-observe rather than cut a new version.
+ */
+export class ReleaseObservationError extends Error {
+	override readonly name = "ReleaseObservationError";
+}
+
+/** Bounded attempt budget for a single read-only CI observation command. */
+export const RELEASE_OBSERVATION_ATTEMPTS = 8;
+
+/**
+ * Backoff before re-attempting a failed observation: 2s doubling to a 30s ceiling.
+ *
+ * The whole budget spans roughly four minutes, which outlasts an ordinary network
+ * blip or GitHub API hiccup without stalling a genuinely broken watch for long.
+ */
+export function releaseObservationRetryDelayMs(attempt: number): number {
+	if (!Number.isInteger(attempt) || attempt < 1) throw new Error(`Observation attempt must be a positive integer, received ${attempt}`);
+	return Math.min(30_000, 2_000 * 2 ** (attempt - 1));
+}
+
+/** Whether a failed observation attempt gets another try, and how long to wait first. */
+export type ObservationRetryDecision = { action: "retry"; delayMs: number } | { action: "fail" };
+
+/**
+ * Decide what follows a failed observation attempt.
+ *
+ * Split from the command runner so the budget and backoff are provable without
+ * spending the real wall-clock delays.
+ */
+export function decideObservationRetry(attempt: number): ObservationRetryDecision {
+	if (!Number.isInteger(attempt) || attempt < 1) throw new Error(`Observation attempt must be a positive integer, received ${attempt}`);
+	if (attempt >= RELEASE_OBSERVATION_ATTEMPTS) return { action: "fail" };
+	return { action: "retry", delayMs: releaseObservationRetryDelayMs(attempt) };
+}
+
+/**
+ * Run a read-only observation command, retrying every non-zero exit.
+ *
+ * The observation phase runs after the release refs are pushed, so a transient
+ * `gh`/network failure must never be reported as a release failure. Retrying every
+ * failure keeps the decision off brittle error-message matching; only exhausting
+ * the budget is authoritative.
+ */
+export async function observeWithRetry<T>(
+	description: string,
+	run: () => Promise<{ exitCode: number | null; stdout: Uint8Array; stderr: Uint8Array }>,
+	parse: (stdout: string) => T,
+	sleep: (ms: number) => Promise<void> = ms => Bun.sleep(ms),
+): Promise<T> {
+	let lastFailure = "";
+	for (let attempt = 1; attempt <= RELEASE_OBSERVATION_ATTEMPTS; attempt++) {
+		const result = await run();
+		if (result.exitCode === 0) {
+			try {
+				return parse(result.stdout.toString());
+			} catch (error) {
+				// A zero exit with unusable output is still an observation failure:
+				// truncated or mis-shaped responses are as transient as any network
+				// error, and only a trustworthy verdict may leave this loop.
+				lastFailure = `unusable response: ${error instanceof Error ? error.message : String(error)}`;
+			}
+		} else {
+			lastFailure = outputOf(result) || `exit ${result.exitCode ?? "unknown"}`;
+		}
+		const decision = decideObservationRetry(attempt);
+		if (decision.action === "fail") break;
+		console.log(`  ${description} failed (attempt ${attempt}/${RELEASE_OBSERVATION_ATTEMPTS}), retrying in ${Math.round(decision.delayMs / 1000)}s: ${lastFailure}`);
+		await sleep(decision.delayMs);
+	}
+	throw new ReleaseObservationError(`${description} failed ${RELEASE_OBSERVATION_ATTEMPTS} times: ${lastFailure}`);
+}
+
 async function queryReleaseRuns(commitSha: string, expectedTag?: string): Promise<ReleaseRunObservation[]> {
-	const result = expectedTag === undefined
-		? await $`gh run list --workflow ci.yml --commit ${commitSha} --json databaseId,status,conclusion,name,headSha,headBranch,event`.quiet().nothrow()
-		: await $`gh run list --workflow ci.yml --branch ${expectedTag} --commit ${commitSha} --json databaseId,status,conclusion,name,headSha,headBranch,event`.quiet().nothrow();
-	if (result.exitCode !== 0) throw new Error(`Cannot query CI runs for ${commitSha}: ${outputOf(result) || `exit ${result.exitCode ?? "unknown"}`}`);
-	return parseReleaseRuns(result.stdout.toString(), commitSha, expectedTag);
+	return observeWithRetry(`Querying CI runs for ${commitSha.slice(0, 8)}`, () =>
+		expectedTag === undefined
+			? $`gh run list --workflow ci.yml --commit ${commitSha} --json databaseId,status,conclusion,name,headSha,headBranch,event`.quiet().nothrow()
+			: $`gh run list --workflow ci.yml --branch ${expectedTag} --commit ${commitSha} --json databaseId,status,conclusion,name,headSha,headBranch,event`.quiet().nothrow(),
+		stdout => parseReleaseRuns(stdout, commitSha, expectedTag),
+	);
 }
 
 async function queryReleaseRunJobs(runId: number): Promise<ReleaseRunJobObservation[]> {
-	const result = await $`gh run view ${runId} --json jobs`.quiet().nothrow();
-	if (result.exitCode !== 0) throw new Error(`Cannot query jobs for CI run ${runId}: ${outputOf(result) || `exit ${result.exitCode ?? "unknown"}`}`);
-	return parseReleaseRunJobs(result.stdout.toString(), runId);
+	return observeWithRetry(`Querying jobs for CI run ${runId}`, () => $`gh run view ${runId} --json jobs`.quiet().nothrow(), stdout => parseReleaseRunJobs(stdout, runId));
 }
 
 async function failedJobLog(jobId: number): Promise<string> {
 	const result = await $`gh run view --job ${jobId} --log-failed`.quiet().nothrow();
-	if (result.exitCode !== 0) throw new Error(`Cannot query failed log for CI job ${jobId}: ${outputOf(result) || `exit ${result.exitCode ?? "unknown"}`}`);
+	if (result.exitCode !== 0) return "";
 	return result.stdout.toString().trim();
 }
 
+/**
+ * Print the tail of a failed job's log, best effort.
+ *
+ * The log is diagnostic context for a verdict that has already been decided, and
+ * GitHub drops job logs on its own retention schedule (an expired log answers with
+ * `BlobNotFound`). An unavailable log must never mask the failure it explains.
+ */
 async function printFailedJobLog(job: ReleaseRunJobObservation): Promise<void> {
 	const log = await failedJobLog(job.databaseId);
-	if (!log) return;
+	if (!log) {
+		console.error(`  (no log available for ${job.name}; job ${job.databaseId})`);
+		return;
+	}
 	const tail = log.split("\n").slice(-20).join("\n");
 	console.error(`\n--- Last 20 lines of ${job.name} ---\n${tail}\n`);
 }
@@ -347,8 +433,15 @@ export function releasedBunLockContent(content: string, previousVersion: string,
 
 async function cmdWatch(): Promise<void> {
 	console.log("\n=== Watching CI ===\n");
-	const success = await watchCI();
-	process.exit(success ? 0 : 1);
+	try {
+		const success = await watchCI();
+		process.exit(success ? 0 : 1);
+	} catch (error) {
+		if (!(error instanceof ReleaseObservationError)) throw error;
+		console.error(`\nCI observation unavailable: ${error.message}`);
+		console.error("  No CI verdict was observed. Retry once connectivity returns.");
+		process.exit(1);
+	}
 }
 
 export function isStableReleaseVersion(version: string): boolean {
@@ -805,9 +898,22 @@ async function cmdRelease(version: string): Promise<void> {
 	await pushReleaseRefsAtomically(version);
 	console.log();
 
-	// 9. Watch CI
+	// 9. Watch CI. The refs are published from here on, so an observer that cannot
+	// reach GitHub is reported as an observation gap — never as a CI verdict, and
+	// never as a reason to cut another version.
 	console.log("Watching CI...");
-	const success = await watchCI(`v${version}`);
+	let success: boolean;
+	try {
+		success = await watchCI(`v${version}`);
+	} catch (error) {
+		if (!(error instanceof ReleaseObservationError)) throw error;
+		console.error(`\nCI observation unavailable: ${error.message}`);
+		console.error(`  v${version} and its release commit are already pushed; this reports the observer, not the release.`);
+		console.error("  Keep the published tag immutable; do not retag, delete, or force-push it.");
+		console.error("  Do not cut a newer version for this failure. Re-observe once connectivity returns:");
+		console.error("  bun scripts/release.ts watch");
+		process.exit(1);
+	}
 
 	if (success) {
 		console.log(`=== Released v${version} ===`);


### PR DESCRIPTION
## Why

The v0.15.3 release completed successfully — tag pushed, CI green, npm `latest` at 0.15.3, GitHub release finalized — but `bun run release` still exited 1. The post-push watcher hit a single network read timeout:

```
error: Cannot query CI runs for 103659a2eb…: read tcp 172.20.10.4:54545->20.200.245.245:443: read: operation timed out
      at queryReleaseRuns (scripts/release.ts:154:39)
      at async watchCI (scripts/release.ts:213:22)
```

Every observation helper turned any `gh` non-zero exit into a throw. That throw escapes `cmdRelease` entirely, so the operator gets a stack trace minutes after the refs are already published, with nothing saying that re-cutting the version is the wrong response.

## What changed

- Read-only observations (`gh run list`, `gh run view --json jobs`) retry every non-zero exit on a bounded 2s→30s backoff, 8 attempts (~2 min). Retrying unconditionally keeps the decision off brittle error-message matching; only exhausting the budget is authoritative.
- Exhaustion raises `ReleaseObservationError`, reported as an observation gap that names the published tag, forbids retag/force-push, and points at `bun scripts/release.ts watch` — explicitly *not* at a newer version.
- Job-log fetches are best effort. GitHub expires job logs on its own schedule (`BlobNotFound`), and an unavailable log must never mask the failure it was fetched to explain.
- Retry policy is split into pure `releaseObservationRetryDelayMs` / `decideObservationRetry` so the budget and backoff are provable without spending real wall-clock delays.

## Verification

- `bun test scripts/release-retry.test.ts` — 14 pass (4 new)
- `bun test scripts/release-policy.test.ts scripts/release-publish-order.test.ts scripts/release-notes.test.ts` — 88 pass
- `bun run check:tools` — exit 0
- `gh`-shim smoke, both paths:
  - two transient failures absorbed, verdict observed on attempt 3 → exit 0 in 8s
  - permanently failing `gh` → exit 1 after 8 attempts with the observation-gap message and no CI verdict claim

Not tested: a live release run through the amended watcher.

## Risk classification
- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

gajae.pr-review-verdict.v1 merge-self-approved sha256:411b7c57c840452816d79708ed40fc223f21ef8a368cedf3cb2f8186207316e8 reviewer:human reviewer-id:Yeachan-Heo evidence:Rebased onto latest dev@001d24c3d8 as 915948dbf3; focused release retry tests and release policy suites pass; check:tools passes

- [x] Target branch is `dev`
- [x] Tested locally
- [x] Verdict is bound to exact head `915948dbf399da8e4687b4b66da900d4a28254cc`



Current-head contract refresh: exact head `915948dbf399da8e4687b4b66da900d4a28254cc`, base `001d24c3d881d16ccdb93fca4580f65720b9f62d`.


Bootstrap revalidation evidence refreshed for exact head `915948dbf399da8e4687b4b66da900d4a28254cc`.


Self-review integrity corrected for the exact current head.
