### PR TITLE
fix(tui): match decomposed file names in path autocomplete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,6 +2484,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+ "unicode-normalization",
  "unicode-segmentation",
  "unicode-width",
  "windows-sys 0.61.2",
@@ -3353,6 +3354,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4130,6 +4146,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,6 +215,7 @@ clap = { version = "4", features = ["derive"] }
 # ──────────────────────────────────────────────────────────────────────────────
 regex = "1"
 similar = "3.1.0"
+unicode-normalization = "0.1"
 unicode-segmentation = "1.13"
 unicode-width = "0.2"
 

--- a/crates/pi-natives/Cargo.toml
+++ b/crates/pi-natives/Cargo.toml
@@ -48,6 +48,7 @@ syntect.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 toml.workspace = true
+unicode-normalization.workspace = true
 unicode-segmentation.workspace = true
 unicode-width.workspace = true
 xxhash-rust.workspace = true

--- a/crates/pi-natives/src/fd.rs
+++ b/crates/pi-natives/src/fd.rs
@@ -3,10 +3,11 @@
 //! Searches for files and directories whose paths match a query string via
 //! subsequence scoring. Uses the shared [`fs_cache`] for directory scanning.
 
-use std::path::Path;
+use std::{borrow::Cow, path::Path};
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
+use unicode_normalization::{IsNormalized, UnicodeNormalization, is_nfc_quick};
 
 use crate::{fs_cache, task};
 
@@ -51,8 +52,17 @@ pub struct FuzzyFindResult {
 	pub total_matches: u32,
 }
 
+/// Composes decomposed (NFD) file names, e.g. from macOS APFS/HFS+ volumes, so
+/// they match composed (NFC) queries typed in the composer.
+fn nfc_normalize(value: &str) -> Cow<'_, str> {
+	match is_nfc_quick(value.chars()) {
+		IsNormalized::Yes => Cow::Borrowed(value),
+		_ => Cow::Owned(value.nfc().collect()),
+	}
+}
+
 fn normalize_fuzzy_text(value: &str) -> String {
-	value
+	nfc_normalize(value)
 		.chars()
 		.filter(|ch| !ch.is_whitespace() && !matches!(ch, '/' | '\\' | '.' | '_' | '-'))
 		.flat_map(|ch| ch.to_lowercase())
@@ -107,7 +117,7 @@ fn score_fuzzy_path(
 		.file_name()
 		.and_then(|name| name.to_str())
 		.unwrap_or(path);
-	let lower_file_name = file_name.to_lowercase();
+	let lower_file_name = nfc_normalize(file_name).to_lowercase();
 
 	let mut score = if lower_file_name == query_lower {
 		120
@@ -124,7 +134,7 @@ fn score_fuzzy_path(
 			0
 		}
 	} else {
-		let lower_path = path.to_lowercase();
+		let lower_path = nfc_normalize(path).to_lowercase();
 		if lower_path.contains(query_lower) {
 			60
 		} else {
@@ -199,7 +209,7 @@ fn fuzzy_find_sync(config: FuzzyFindConfig, ct: task::CancelToken) -> Result<Fuz
 		return Ok(FuzzyFindResult { matches: Vec::new(), total_matches: 0 });
 	}
 
-	let query_lower = config.query.trim().to_lowercase();
+	let query_lower = nfc_normalize(config.query.trim()).to_lowercase();
 	let normalized_query = normalize_fuzzy_text(&query_lower);
 	let query_chars: Vec<char> = normalized_query.chars().collect();
 	if !query_lower.is_empty() && normalized_query.is_empty() {
@@ -245,4 +255,46 @@ pub fn fuzzy_find(options: FuzzyFindOptions<'_>) -> task::Promise<FuzzyFindResul
 	let ct = task::CancelToken::new(timeout_ms, signal);
 	let config = FuzzyFindConfig { query, path, hidden, gitignore, max_results, cache };
 	task::blocking("fuzzy_find", ct, move |ct| fuzzy_find_sync(config, ct))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn score(path: &str, query: &str) -> u32 {
+		let query_lower = nfc_normalize(query.trim()).to_lowercase();
+		let normalized_query = normalize_fuzzy_text(&query_lower);
+		let query_chars: Vec<char> = normalized_query.chars().collect();
+		score_fuzzy_path(path, false, &query_lower, &normalized_query, &query_chars)
+	}
+
+	#[test]
+	fn nfc_query_matches_nfd_file_name() {
+		let nfd = "\u{1112}\u{1161}\u{11AB}\u{1100}\u{1173}\u{11AF}.txt";
+		assert!(score(nfd, "\u{D55C}") > 0);
+		assert!(score(nfd, "\u{D55C}\u{AE00}") > 0);
+	}
+
+	#[test]
+	fn nfd_query_matches_nfc_file_name() {
+		assert!(score("\u{D55C}\u{AE00}.txt", "\u{1112}\u{1161}\u{11AB}") > 0);
+	}
+
+	#[test]
+	fn nfc_query_matches_nfd_path_segment() {
+		let nfd_dir = "\u{1103}\u{1169}\u{11A8}\u{1109}\u{1165}/readme.md";
+		assert!(score(nfd_dir, "\u{B3C5}\u{C11C}/read") > 0);
+	}
+
+	#[test]
+	fn ascii_scoring_is_unchanged() {
+		assert_eq!(score("readme.md", "readme.md"), 120);
+		assert_eq!(score("readme.md", "read"), 100);
+		assert_eq!(score("readme.md", "zzz"), 0);
+	}
+
+	#[test]
+	fn nfc_normalize_borrows_composed_text() {
+		assert!(matches!(nfc_normalize("plain/ascii.txt"), Cow::Borrowed(_)));
+	}
 }

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `fuzzyFind` NFC-normalizes queries and candidate paths before scoring so composed (NFC) queries match decomposed (NFD) file names as returned by macOS volumes.
+
 ## [0.15.3] - 2026-08-27
 
 ### Fixed

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Path autocomplete matches decomposed (NFD) file names against composed (NFC) input. Composer keystrokes are NFC-normalized while macOS volumes commonly return Hangul and other composed scripts in NFD, so `@한` found nothing even though `한글.txt` existed; both the directory-listing prefix match and the fuzzy filter now compare NFC forms while completion values keep the on-disk name. The native fuzzy finder applies the same normalization to queries and candidates.
+
 ## [0.15.3] - 2026-08-27
 
 ### Fixed

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -708,9 +708,10 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 
 			const entries = await this.#getCachedDirEntries(searchDir);
 			const suggestions: AutocompleteItem[] = [];
+			const lowerSearchPrefix = searchPrefix.normalize("NFC").toLowerCase();
 
 			for (const entry of entries) {
-				if (!entry.name.toLowerCase().startsWith(searchPrefix.toLowerCase())) {
+				if (!entry.name.normalize("NFC").toLowerCase().startsWith(lowerSearchPrefix)) {
 					continue;
 				}
 				// Skip .git directory
@@ -801,14 +802,14 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			const searchPath = scopedQuery?.baseDir ?? this.#basePath;
 			const fuzzyQuery = scopedQuery?.query ?? query;
 			const result = await (await fuzzyFindNative())(buildAutocompleteFuzzyDiscoveryProfile(fuzzyQuery, searchPath));
-			const lowerQuery = fuzzyQuery.toLowerCase();
+			const lowerQuery = fuzzyQuery.normalize("NFC").toLowerCase();
 			const filteredMatches = result.matches.filter(entry => {
 				const p = entry.path.endsWith("/") ? entry.path.slice(0, -1) : entry.path;
 				const normalized = p.replaceAll("\\", "/");
 				if (/(^|\/)\.git(\/|$)/.test(normalized)) {
 					return false;
 				}
-				return lowerQuery.length === 0 || fuzzyMatch(lowerQuery, normalized.toLowerCase());
+				return lowerQuery.length === 0 || fuzzyMatch(lowerQuery, normalized.normalize("NFC").toLowerCase());
 			});
 			const topEntries = filteredMatches.slice(0, 20);
 			const suggestions: AutocompleteItem[] = [];

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -310,7 +310,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	// Intentionally separate from pi-natives cache: this cache is a local,
 	// per-directory readdir fast-path for prefix completions. Global fuzzy
 	// discovery continues to use native fuzzyFind + shared scan cache.
-	#dirCache: Map<string, { entries: fs.Dirent[]; timestamp: number }> = new Map();
+	#dirCache: Map<string, { entries: fs.Dirent[]; resolvedDir: string; timestamp: number }> = new Map();
 	readonly #DIR_CACHE_TTL = 2000; // 2 seconds
 
 	constructor(commands: (SlashCommand | AutocompleteItem)[] = [], basePath: string = getProjectDir()) {
@@ -624,16 +624,32 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		return `${displayBase}${relativePath}`;
 	}
 
-	async #getCachedDirEntries(searchDir: string): Promise<fs.Dirent[]> {
+	async #getCachedDirEntries(searchDir: string): Promise<{ entries: fs.Dirent[]; resolvedDir: string }> {
 		const now = Date.now();
 		const cached = this.#dirCache.get(searchDir);
 
 		if (cached && now - cached.timestamp < this.#DIR_CACHE_TTL) {
-			return cached.entries;
+			return { entries: cached.entries, resolvedDir: cached.resolvedDir };
 		}
 
-		const entries = await fs.promises.readdir(searchDir, { withFileTypes: true });
-		this.#dirCache.set(searchDir, { entries, timestamp: now });
+		const searchDirs = [...new Set([searchDir, searchDir.normalize("NFD"), searchDir.normalize("NFC")])];
+		let entries: fs.Dirent[] | undefined;
+		let resolvedDir: string | undefined;
+		for (const candidate of searchDirs) {
+			try {
+				entries = await fs.promises.readdir(candidate, { withFileTypes: true });
+				resolvedDir = candidate;
+				break;
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+					throw error;
+				}
+			}
+		}
+		if (!entries || !resolvedDir) {
+			throw new Error(`Directory not found: ${searchDir}`);
+		}
+		this.#dirCache.set(searchDir, { entries, resolvedDir, timestamp: now });
 
 		if (this.#dirCache.size > 100) {
 			const sortedKeys = [...this.#dirCache.entries()]
@@ -645,7 +661,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			}
 		}
 
-		return entries;
+		return { entries, resolvedDir };
 	}
 
 	invalidateDirCache(dir?: string): void {
@@ -706,9 +722,27 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				searchPrefix = file;
 			}
 
-			const entries = await this.#getCachedDirEntries(searchDir);
+			const { entries, resolvedDir } = await this.#getCachedDirEntries(searchDir);
 			const suggestions: AutocompleteItem[] = [];
 			const lowerSearchPrefix = searchPrefix.normalize("NFC").toLowerCase();
+			const resolvedDirectoryPrefix = (() => {
+				if (resolvedDir === searchDir) return rawPrefix.endsWith("/") ? rawPrefix : path.dirname(rawPrefix);
+
+				const normalizedResolvedDir = resolvedDir.replaceAll(path.sep, "/");
+				let prefix: string;
+				if (rawPrefix.startsWith("~")) {
+					const homeRelative = path.relative(this.#expandHomePath("~"), resolvedDir).replaceAll(path.sep, "/");
+					prefix = homeRelative ? `~/${homeRelative}` : "~";
+				} else if (path.isAbsolute(expandedPrefix)) {
+					prefix = normalizedResolvedDir;
+				} else {
+					const relative = path.relative(this.#basePath, resolvedDir).replaceAll(path.sep, "/");
+					prefix = rawPrefix.startsWith("./") && relative ? `./${relative}` : relative;
+				}
+				return prefix ? `${prefix}/` : prefix;
+			})();
+			const resolvedDisplayPrefix =
+				resolvedDir === searchDir ? rawPrefix : `${resolvedDirectoryPrefix}${searchPrefix}`;
 
 			for (const entry of entries) {
 				if (!entry.name.normalize("NFC").toLowerCase().startsWith(lowerSearchPrefix)) {
@@ -733,7 +767,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 
 				let relativePath: string;
 				const name = entry.name;
-				const displayPrefix = rawPrefix;
+				const displayPrefix = resolvedDisplayPrefix;
 
 				if (displayPrefix.endsWith("/")) {
 					// If prefix ends with /, append entry to the prefix

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -179,6 +179,7 @@ describe("CombinedAutocompleteProvider", () => {
 
 	describe("unicode-normalized path matching", () => {
 		let baseDir: string;
+		const nfdDirectory = "\u1112\u1161\u11AB";
 		const nfdName = "\u1112\u1161\u11AB\u1100\u1173\u11AF.txt";
 
 		beforeEach(() => {
@@ -206,6 +207,16 @@ describe("CombinedAutocompleteProvider", () => {
 			const result = await provider.getSuggestions([line], 0, line.length);
 			const values = result?.items.map(item => item.value) ?? [];
 			expect(values).toContain(`@${nfdName}`);
+		});
+
+		it("traverses an NFD directory from an NFC path prefix", async () => {
+			fs.mkdirSync(path.join(baseDir, nfdDirectory));
+			fs.writeFileSync(path.join(baseDir, nfdDirectory, nfdName), "content\n");
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = "./\uD55C/";
+			const result = await provider.getForceFileSuggestions([line], 0, line.length);
+			const values = result?.items.map(item => item.value) ?? [];
+			expect(values).toContain(`./${nfdDirectory}/${nfdName}`);
 		});
 	});
 });

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -176,6 +176,38 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(values).toContain("./src/");
 		});
 	});
+
+	describe("unicode-normalized path matching", () => {
+		let baseDir: string;
+		const nfdName = "\u1112\u1161\u11AB\u1100\u1173\u11AF.txt";
+
+		beforeEach(() => {
+			baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "autocomplete-nfc-test-"));
+		});
+
+		afterEach(() => {
+			fs.rmSync(baseDir, { recursive: true, force: true });
+		});
+
+		it("matches NFD directory entries against an NFC prefix", async () => {
+			fs.writeFileSync(path.join(baseDir, nfdName), "content\n");
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = "./\uD55C";
+			const result = await provider.getForceFileSuggestions([line], 0, line.length);
+			expect(result).not.toBeNull();
+			const values = result?.items.map(item => item.value) ?? [];
+			expect(values).toContain(`./${nfdName}`);
+		});
+
+		it("matches NFD entries in the @ fuzzy lane against an NFC query", async () => {
+			fs.writeFileSync(path.join(baseDir, nfdName), "content\n");
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = "@\uD55C\uAE00";
+			const result = await provider.getSuggestions([line], 0, line.length);
+			const values = result?.items.map(item => item.value) ?? [];
+			expect(values).toContain(`@${nfdName}`);
+		});
+	});
 });
 
 describe("slash command token classification", () => {


### PR DESCRIPTION
## What

Fix NFD/NFC matching for path autocomplete in the TUI directory-prefix lane and pi-natives fuzzy finder. Completion values preserve the exact on-disk entry names, including decomposed Unicode.

## Why

macOS commonly stores filenames and parent directories in NFD while composer input is NFC. Matching now normalizes comparison text without rewriting returned filesystem names; parent-directory fallback also reconstructs the resolved on-disk path.

## Testing

- `bun test packages/tui/test/autocomplete.test.ts`
- `cargo test -p pi-natives fd::tests`
- `bun --cwd=packages/tui run check`
- `cargo check -p pi-natives`
- `cargo fmt --all -- --check`
- Fresh exact-head CI for base `1735fddf7413d831b4fdd81f8a1bb24826504e26` and head `bd4d5663c9460ddbc7f1951a604ad5e7d645219b`

## Risk classification

- [x] `low-risk` — ordinary bug fix; maintainer self-review path
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:dc088ff0f9eec087ffbf1388567fc13b58680419cedbaa0b54dad4cbdb7fb57f reviewer:human reviewer-id:Yeachan-Heo evidence:fresh local TUI autocomplete test, pi-natives NFD test, cargo check, cargo fmt check, and fresh exact-head CI
```

- [x] Target branch is `dev`
- [x] Tested locally
- [x] CHANGELOG updated
- [x] Verdict is bound to the exact PR head and current dev base