### PR TITLE
fix(ai): prevent LM Studio first-event stream timeouts

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -369,7 +369,7 @@ OAuth host chain: `KIMI_CODE_OAUTH_HOST` → `KIMI_OAUTH_HOST` → `https://auth
 | `GJC_OPENAI_CODE_WEBSOCKET_IDLE_TIMEOUT_MS` | Positive integer override (default 300000)           |
 | `GJC_OPENAI_CODE_WEBSOCKET_RETRY_BUDGET`    | Non-negative integer override (default 5)            |
 | `GJC_OPENAI_CODE_WEBSOCKET_RETRY_DELAY_MS`  | Positive integer base backoff override (default 500) |
-| `GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS`   | Positive integer OpenAI stream idle timeout override. Unset: 120s, except xAI Grok / Grok Build providers and Grok model ids on any OpenAI-compatible host use 300s (same floor as Anthropic long-reasoning). `0` disables. |
+| `GJC_OPENAI_STREAM_IDLE_TIMEOUT_MS`   | Positive integer OpenAI stream idle timeout override. Unset: 120s, except xAI Grok / Grok Build providers and Grok model ids on any OpenAI-compatible host use 300s (same floor as Anthropic long-reasoning). `0` disables. LM Studio keeps the shared idle timeout, but its first-event window is 300s by default to allow local model loading/prefill; `PI_STREAM_FIRST_EVENT_TIMEOUT_MS` overrides that window. |
 
 ### Cursor provider debug
 

--- a/packages/ai/src/utils/idle-iterator.ts
+++ b/packages/ai/src/utils/idle-iterator.ts
@@ -5,6 +5,11 @@ const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 120_000;
 const DEFAULT_STREAM_FIRST_EVENT_TIMEOUT_MS = 100_000;
 const ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS = 600_000;
 const KIMI_CODE_FIRST_EVENT_TIMEOUT_MS = 300_000;
+// Local LM Studio models can spend several minutes loading weights and filling
+// the prompt before emitting their first SSE event. Keep the shared default
+// for other OpenAI-compatible providers, but avoid aborting legitimate local
+// inference during that startup window.
+const LM_STUDIO_FIRST_EVENT_TIMEOUT_MS = 300_000;
 // Ollama Cloud is a hosted proxy where queueing/cold-start plus long prefill
 // (thinking-mode requests over 1M-context sessions) routinely exceeds 120s before
 // the first streamed token; 300s matches kimi-code's floor for long-reasoning silence.
@@ -34,6 +39,7 @@ export function isGrokModelId(modelId: string | undefined): boolean {
 
 export function getProviderFirstEventTimeoutFallbackMs(provider: string): number | undefined {
 	if (provider === "alibaba-token-plan") return ALIBABA_TOKEN_PLAN_FIRST_EVENT_TIMEOUT_MS;
+	if (provider === "lm-studio") return LM_STUDIO_FIRST_EVENT_TIMEOUT_MS;
 	if (provider === "ollama-cloud") return OLLAMA_CLOUD_FIRST_EVENT_TIMEOUT_MS;
 	return provider === "kimi-code" ? KIMI_CODE_FIRST_EVENT_TIMEOUT_MS : undefined;
 }

--- a/packages/ai/test/openai-first-event-timeout.test.ts
+++ b/packages/ai/test/openai-first-event-timeout.test.ts
@@ -21,6 +21,18 @@ const alibabaOpenAICompletionsModel = getBundledModel(
 	"alibaba-token-plan",
 	"deepseek-v4-pro",
 ) as Model<"openai-completions">;
+const lmStudioCompletionsModel: Model<"openai-completions"> = {
+	id: "local-model",
+	name: "LM Studio Local Model",
+	api: "openai-completions",
+	provider: "lm-studio",
+	baseUrl: "http://127.0.0.1:1234/v1",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 32768,
+	maxTokens: 4096,
+};
 const azureOpenAIResponsesModel: Model<"azure-openai-responses"> = {
 	id: "gpt-5-mini",
 	name: "GPT-5 Mini",
@@ -530,6 +542,37 @@ describe("OpenAI-family first-event timeouts", () => {
 			}).result();
 			await flushMicrotasks();
 			expect(fetchAttempts).toBe(1);
+
+			vi.advanceTimersByTime(120_000);
+			await flushMicrotasks();
+			let settled = false;
+			void pending.then(() => {
+				settled = true;
+			});
+			await flushMicrotasks();
+			expect(settled).toBe(false);
+
+			vi.advanceTimersByTime(30_000);
+			await flushMicrotasks();
+			const result = await pending;
+			expect(result.stopReason).toBe("stop");
+			expect(getFirstTextContent(result)).toMatchObject({ type: "text", text: "Hello delayed" });
+		});
+	});
+
+	it("lets LM Studio completions wait past the shared 120s SDK timeout for local model startup", async () => {
+		vi.useFakeTimers();
+		await withEnv({ PI_STREAM_FIRST_EVENT_TIMEOUT_MS: undefined }, async () => {
+			const delayedFetch = createDelayedFetch(150_000, () =>
+				createOpenAICompletionsSuccessResponse(lmStudioCompletionsModel.id),
+			);
+			global.fetch = Object.assign(delayedFetch, { preconnect: originalFetch.preconnect });
+
+			const pending = streamOpenAICompletions(lmStudioCompletionsModel, baseContext(), {
+				apiKey: "test-key",
+				requestMaxRetries: 0,
+			}).result();
+			await flushMicrotasks();
 
 			vi.advanceTimersByTime(120_000);
 			await flushMicrotasks();

--- a/packages/ai/test/register-builtins.test.ts
+++ b/packages/ai/test/register-builtins.test.ts
@@ -235,6 +235,7 @@ describe("register-builtins lazy streams", () => {
 describe("resolveLazyStreamFirstEventFallbackMs", () => {
 	it("returns each slow provider's centralized first-event fallback", () => {
 		expect(resolveLazyStreamFirstEventFallbackMs("alibaba-token-plan")).toBe(600_000);
+		expect(resolveLazyStreamFirstEventFallbackMs("lm-studio")).toBe(300_000);
 		expect(resolveLazyStreamFirstEventFallbackMs("kimi-code")).toBe(300_000);
 	});
 	it("returns undefined for unrelated providers", () => {

--- a/packages/ai/test/stream-timeout-defaults.test.ts
+++ b/packages/ai/test/stream-timeout-defaults.test.ts
@@ -73,6 +73,10 @@ describe("getProviderFirstEventTimeoutFallbackMs(provider)", () => {
 		expect(getProviderFirstEventTimeoutFallbackMs("ollama-cloud")).toBe(300_000);
 	});
 
+	it("gives LM Studio a 300-second first-event window for local model startup", () => {
+		expect(getProviderFirstEventTimeoutFallbackMs("lm-studio")).toBe(300_000);
+	});
+
 	it("does not widen unrelated providers", () => {
 		expect(getProviderFirstEventTimeoutFallbackMs("anthropic")).toBeUndefined();
 	});
@@ -159,6 +163,10 @@ describe("getStreamFirstEventTimeoutMs(idleTimeoutMs, fallbackMs)", () => {
 describe("resolveOpenAISdkRequestTimeoutMs(provider, override)", () => {
 	it("uses the Alibaba 600s fallback when neither env nor caller pins a value", () => {
 		expect(resolveOpenAISdkRequestTimeoutMs("alibaba-token-plan")).toBe(600_000);
+	});
+
+	it("uses the LM Studio 300s fallback for slow local request setup", () => {
+		expect(resolveOpenAISdkRequestTimeoutMs("lm-studio")).toBe(300_000);
 	});
 
 	it("honors an explicit shorter Alibaba override for pre-headers setup", () => {


### PR DESCRIPTION
## What

Extend the LM Studio local-model first-event timeout to 300 seconds while preserving the shared idle timeout and existing override semantics.

## Why

LM Studio can spend several minutes loading local model weights and filling the prompt before emitting the first streaming event. The previous 120-second SDK/request boundary could abort legitimate local inference with `OpenAI completions stream timed out while waiting for the first event`.

## Testing

- `bun test packages/ai/test/openai-first-event-timeout.test.ts packages/ai/test/stream-timeout-defaults.test.ts packages/ai/test/register-builtins.test.ts packages/ai/test/openai-completions-progress-chunk.test.ts` — 90 passed, 0 failed
- `bun run --cwd packages/ai check:types`
- Focused Biome checks passed
- Local LM Studio `GET /v1/models` returned five models

## Risk classification

- [ ] `low-risk`
- [x] `regression-risk` — timeout behavior changes for the LM Studio provider and has exact-head maintainer approval.
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:1cc9b9a25a04a8338178e098c6e2ba483082afc0af1fa4e655089760aedefc4c reviewer:architect reviewer-id:Yeachan-Heo evidence:exact-head review of dev-based head 65c401714f6bc84118bfad2d6790129d5c6326ce; focused suites 90/90 pass, packages/ai typecheck clean, biome clean, idle-timeout precedence verified
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (intentionally omitted; focused runtime fix)
- [x] Verdict above matches the exact PR head
- [x] Risk classification above matches the actual review path taken