### PR TITLE
fix(ralplan): avoid caret in Windows git validation argv

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ralplan-runtime.ts
@@ -747,7 +747,12 @@ export async function resolveRalplanTargetRoot(
 	if (!repository) {
 		throw new RalplanCommandError(2, `ralplan --worktree-root is not inside a git repository: ${canonical}`);
 	}
-	const verified = Bun.spawn(["git", "-C", canonical, "rev-parse", "--verify", "HEAD^{commit}"], {
+	// Do not pass the caret-containing `HEAD^{commit}` revision here. On Windows,
+	// Bun may dispatch git through a `.cmd` shim, where `^` is interpreted by the
+	// command shell before git receives the argument. HEAD is sufficient after
+	// resolving a repository root: an unborn or non-commit HEAD still fails the
+	// same validation, while the argv remains shell-safe on every platform.
+	const verified = Bun.spawn(["git", "-C", canonical, "rev-parse", "--verify", "HEAD"], {
 		stdout: "pipe",
 		stderr: "pipe",
 	});

--- a/packages/coding-agent/test/gjc-runtime/ralplan-worktree-root.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/ralplan-worktree-root.test.ts
@@ -244,6 +244,25 @@ describe("ralplan --worktree-root explicit target binding (#4693)", () => {
 		expect(await pathExists(path.join(dispatcher, ".gjc"))).toBe(false);
 	});
 
+	it("validates a committed target with Windows-safe git argv", async () => {
+		const session = "wt-windows-safe-head";
+		const target = await initRepo("gjc-ralplan-target-");
+		const dispatcher = await initRepo("gjc-ralplan-dispatcher-");
+
+		const seed = await runNativeRalplanCommand(
+			["--worktree-root", target, "--session-id", session, "--json", "windows-safe target task"],
+			dispatcher,
+		);
+
+		expect(seed.status).toBe(0);
+		expect(JSON.parse(seed.stdout ?? "{}")).toMatchObject({
+			ok: true,
+			repository_binding: { worktreeRoot: await realpath(target) },
+		});
+		expect(await pathExists(path.join(target, ".gjc"))).toBe(true);
+		expect(await pathExists(path.join(dispatcher, ".gjc"))).toBe(false);
+	});
+
 	it("supports resume/restart: re-seed and later writes keep the same bound target run", async () => {
 		const session = "wt-resume";
 		const target = await initRepo("gjc-ralplan-target-");


### PR DESCRIPTION
## What

Fix Windows `.cmd` spawn rejection in `resolveRalplanTargetRoot` by removing the caret-containing git revision from the validation argv.

## Why

Fixes #4998. Bun/Windows `.cmd` dispatch can interpret `^` before git receives `HEAD^{commit}`.

## Testing

- `bun test packages/coding-agent/test/gjc-runtime/ralplan-worktree-root.test.ts` — 22 pass, 0 fail.
- `bun --cwd=packages/coding-agent run check` — typecheck reached completion; repository lint reported unrelated pre-existing findings.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; exact-head owner authorization is recorded below after independent architect review.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:05e042c1e91314ef514e7d524a5e052c00c14d8b1abdc5ac82797711b002b6d6 reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head owner authorization; independent architect review and CI evidence posted in PR comments
```

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (not user-facing)
- [x] Verdict above matches the exact PR head
- [x] Risk classification matches the actual review path

Exact evidence:
- Base: `103659a2ebf6e698140c021981d47508389a2897`
- Head: `51a2bc9ca460cdcc7ff49935e79609c820e43dfb`
- Diff SHA-256: `05e042c1e91314ef514e7d524a5e052c00c14d8b1abdc5ac82797711b002b6d6`
- Windows reproduction: `Bun.spawn(["git", "-C", canonical, "rev-parse", "--verify", "HEAD^{commit}"])` at the `.cmd` boundary.
- Signed record: `gajae.pr-self-review.v1` comment bound to the exact base/head/digest.
<!-- exact-head contract refreshed -->
<!-- CI retriggered after signed exact-head record correction -->