### PR TITLE
fix(ask): bound the empty free-text re-ask loop and reject empty custom submits

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -155,6 +155,11 @@ export interface ExtensionUIDialogOptions {
 	customInput?: {
 		optionLabel: string;
 		onSubmit: (text: string) => void;
+		/**
+		 * When false, the selector refuses an empty/whitespace-only submit instead
+		 * of forwarding it, so a stray Enter cannot answer the question with "".
+		 */
+		allowEmpty?: boolean;
 	};
 	/**
 	 * Inline free-text input for a non-answer clarification action. It is

--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -72,6 +72,7 @@ export interface HookSelectorOptions {
 	customInput?: {
 		optionLabel: string;
 		onSubmit: (text: string) => void;
+		allowEmpty?: boolean;
 	};
 	clarificationInput?: {
 		optionLabel: string;
@@ -390,7 +391,7 @@ export class HookSelectorComponent extends Container {
 	#outline: boolean;
 	#scrollTitleRows: number | undefined;
 	#inlineEditorMaxHeight: number | undefined;
-	#customInput: { optionLabel: string; onSubmit: (text: string) => void } | undefined;
+	#customInput: { optionLabel: string; onSubmit: (text: string) => void; allowEmpty?: boolean } | undefined;
 	#clarificationInput: { optionLabel: string; onSubmit: (text: string) => void; allowEmpty?: boolean } | undefined;
 	#activeInput: { onSubmit: (text: string) => void; allowEmpty?: boolean } | undefined;
 	#inputArea: Container;

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -1154,6 +1154,7 @@ export class ExtensionUiController {
 				customInput: dialogOptions?.customInput
 					? {
 							optionLabel: dialogOptions.customInput.optionLabel,
+							allowEmpty: dialogOptions.customInput.allowEmpty,
 							onSubmit: text => {
 								const optionLabel = dialogOptions.customInput?.optionLabel;
 								this.hideHookSelector();

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -76,6 +76,14 @@ import { formatErrorMessage, formatMeta, formatTitle } from "./render-utils";
 import { ToolAbortError } from "./tool-errors";
 import { assertUltragoalAskAllowed } from "./ultragoal-ask-guard";
 
+/**
+ * How many times one question may be re-asked after an empty/whitespace-only
+ * free-text answer before the ask settles as cancelled. Without a bound, an
+ * answering surface that keeps submitting "" re-asks the identical question
+ * forever (gajae-code#5001).
+ */
+const MAX_EMPTY_CUSTOM_ATTEMPTS = 3;
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -324,7 +332,7 @@ interface UIContext {
 			onLeft?: () => void;
 			onRight?: () => void;
 			helpText?: string;
-			customInput?: { optionLabel: string; onSubmit: (text: string) => void };
+			customInput?: { optionLabel: string; onSubmit: (text: string) => void; allowEmpty?: boolean };
 			clarificationInput?: { optionLabel: string; onSubmit: (text: string) => void; allowEmpty?: boolean };
 		},
 	): Promise<string | undefined>;
@@ -400,6 +408,7 @@ async function askSingleQuestion(
 			helpText,
 			customInput: {
 				optionLabel: otherOptionLabel,
+				allowEmpty: false,
 				onSubmit: (text: string) => {
 					inlineInput = text;
 				},
@@ -1100,7 +1109,7 @@ export class AskTool implements AgentTool<AskParametersSchema, AskToolDetails> {
 
 		const askQuestion = async (
 			q: AskParams["questions"][number],
-			options?: { previous?: QuestionResult; navigation?: NavigationControls },
+			options?: { previous?: QuestionResult; navigation?: NavigationControls; emptyCustomAttempt?: number },
 		) => {
 			const rawOptionLabels = q.options.map(o => o.label);
 			const questionIndex = params.questions.indexOf(q);
@@ -1256,7 +1265,23 @@ export class AskTool implements AgentTool<AskParametersSchema, AskToolDetails> {
 													: { kind: "resolve_without_commit", reason: "cancelled" };
 					await settleActiveRemote(settlement);
 					activeRemoteRequest = undefined;
-					if (settlement.kind === "invalid") return askQuestion(q, options);
+					if (settlement.kind === "invalid") {
+						// An answering surface that keeps producing empty free text used to spin
+						// this question forever. Bound the re-asks and then let the ask settle as
+						// cancelled so the caller sees a terminal outcome instead of a live lock.
+						const attempt = (options?.emptyCustomAttempt ?? 0) + 1;
+						if (attempt >= MAX_EMPTY_CUSTOM_ATTEMPTS)
+							return {
+								optionLabels: rawOptionLabels,
+								selectedOptions: [] as string[],
+								customInput: undefined,
+								clarificationQuestion: undefined,
+								navigation: undefined,
+								cancelled: true,
+								timedOut: false,
+							};
+						return askQuestion(q, { ...options, emptyCustomAttempt: attempt });
+					}
 				}
 				activeRemoteRequest = undefined;
 				return {

--- a/packages/coding-agent/test/tools/ask-empty-custom-loop.test.ts
+++ b/packages/coding-agent/test/tools/ask-empty-custom-loop.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression coverage for gajae-code#5001: an answering surface that keeps
+ * submitting an empty/whitespace-only free-text answer used to make the ask
+ * tool re-ask the identical question forever. The re-asks are now bounded and
+ * the ask settles instead of spinning.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { Settings } from "@gajae-code/coding-agent/config/settings";
+import type { AskAnswerRequest, AskAnswerSource, ToolSession } from "@gajae-code/coding-agent/tools";
+import { AskTool } from "@gajae-code/coding-agent/tools/ask";
+
+function createSession(overrides: Partial<ToolSession> = {}): ToolSession {
+	return {
+		cwd: "/tmp/test",
+		hasUI: true,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings: Settings.isolated(),
+		...overrides,
+	};
+}
+
+function neverResolvingContext() {
+	return {
+		select: (_prompt: string, _options: string[], dialogOptions?: { signal?: AbortSignal }) =>
+			new Promise<string | undefined>(resolve => {
+				dialogOptions?.signal?.addEventListener("abort", () => resolve(undefined), { once: true });
+			}),
+		editor: (_title: string, _prefill: string, dialogOptions?: { signal?: AbortSignal }) =>
+			new Promise<string | undefined>(resolve => {
+				dialogOptions?.signal?.addEventListener("abort", () => resolve(undefined), { once: true });
+			}),
+		abort: () => {},
+	};
+}
+
+describe("AskTool empty free-text answers", () => {
+	it("bounds the re-ask loop instead of repeating one question forever", async () => {
+		const questions: string[] = [];
+		const settlements: unknown[] = [];
+		const source: AskAnswerSource = {
+			awaitAnswer: async () => undefined,
+			awaitAnswerRequest: (request: AskAnswerRequest) => {
+				questions.push(request.question);
+				// A surface stuck on whitespace-only free text. Before the fix this
+				// branch was re-entered without any bound.
+				if (questions.length > 25) throw new Error(`LOOP_UNBOUNDED_${questions.length}`);
+				return Promise.resolve({
+					source: "remote" as const,
+					interaction: { kind: "value" as const, value: "   " },
+					settle: async (settlement: unknown) => {
+						settlements.push(settlement);
+						return { kind: "resolved_without_commit" as const };
+					},
+				});
+			},
+		};
+		const tool = new AskTool(createSession({ getAskAnswerSource: () => source }));
+
+		// The bounded path ends on the existing terminal outcome for an answerless
+		// ask rather than looping: ToolAbortError instead of a live lock.
+		await expect(
+			tool.execute(
+				"empty-custom-loop",
+				{ questions: [{ id: "only", question: "Which one?", options: [{ label: "a" }, { label: "b" }] }] },
+				undefined,
+				undefined,
+				neverResolvingContext() as never,
+			),
+		).rejects.toThrow("Ask tool was cancelled by the user");
+
+		// Bounded: the same question is asked a small, fixed number of times.
+		expect(questions.length).toBeLessThanOrEqual(3);
+		expect(new Set(questions).size).toBe(1);
+		expect(settlements.every(s => (s as { kind?: string }).kind === "invalid")).toBe(true);
+	});
+});


### PR DESCRIPTION
Closes #5001.

## Problem

An `ask` free-text ("Other (type your own)") answer that arrives empty or whitespace-only re-asks the identical question **forever**, with no message explaining why. In deep-interview it reads as "I answered, but it keeps asking the same question".

Reporter reproduced on `dev @ cb1d1f827` (= v0.15.3 content); I reproduced the unbounded spin in a test before fixing.

## Root cause (two independent holes)

1. **The re-ask had no bound.** `ask.ts` did `if (settlement.kind === "invalid") return askQuestion(q, options)` — no attempt counter, no backoff, no user-visible reason. Any answering surface that keeps producing empty text spins on one question.
2. **The inline "Other" editor allowed an empty submit.** `customInput` never carried `allowEmpty`, while `clarificationInput` explicitly passes `allowEmpty: false`. The selector already enforces `allowEmpty === false` on `#activeInput`, so the capability existed and only the custom path failed to opt in — a stray/second Enter submitted `""`.

## Fix

- Thread `allowEmpty` through the `customInput` option: extension types → hook selector option + `#customInput` field → extension UI controller passthrough → `ask.ts` interface, and pass `allowEmpty: false` from the ask tool. The selector's existing empty-submit guard now covers the custom editor exactly as it covers the clarification editor.
- Bound the empty-custom re-ask with `MAX_EMPTY_CUSTOM_ATTEMPTS = 3`, carried on `askQuestion`'s options. On exhaustion the ask returns through the **existing** answerless terminal path (`ToolAbortError: Ask tool was cancelled by the user`) rather than looping — deterministic, already-handled behavior instead of a live lock.

Deliberately minimal: no new user-facing copy, no change to the settlement kinds, no behavior change for non-empty answers.

## Verification

- New `packages/coding-agent/test/tools/ask-empty-custom-loop.test.ts`: a source that always answers `"   "` throws `LOOP_UNBOUNDED_26` before the bound; after the fix the same question is asked ≤3 times and the ask settles. **1 pass.**
- Existing `packages/coding-agent/test/tools/ask.test.ts`: **96 pass / 0 fail.**
- `tsc --noEmit` on `packages/coding-agent`: clean for all touched files. The only two remaining project errors are the pre-existing missing `docs-index.generated` in a fresh worktree, unrelated to this change.
- `biome check`: clean on all five touched files.

## Not covered

The issue also notes that when the inline editor never opens and the fallback `ui.editor(...)` is dismissed, the ask dies with `ToolAbortError` and the user only sees "do nothing". That is the pre-existing dismissal path and is untouched here; it deserves its own decision about user-facing copy.

/cc @Yeachan-Heo — merge is yours.

## Risk classification

- [ ] `low-risk`
- [x] `regression-risk` — changes TUI custom-input submit semantics and the ask turn-abort path; independent review flagged answer loss in the multi-question exhaustion path.
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 needs-human sha256:c14b62827b08c8dbfb6522c6c7863075acca14cde712933e0462f1ea78183756 reviewer:architect reviewer-id:way-gajae evidence:independent review blockers all addressed at exact head da92a87b45; author cannot self-approve so an independent reviewer identity is still required
```

**Author note (superseded):** the independent review found this PR closes only about half of #5001. Fixes for B1/B2/B3 are in progress; do not merge at this head.

---

## Review round 2 — blockers addressed at `da92a87b45`

Every blocker from the independent review is fixed and pushed. Verdict line above is rebound to this exact head. Still `needs-human`: policy forbids the author reaching `merge-approved`, so an independent reviewer identity is required.