### PR TITLE
fix(ask): bound empty custom-answer retries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- The `ask` tool now rejects empty or whitespace-only custom answers on every local and remote input path. Remote invalid answers receive a visible explanation and are retried at most four times with an event-loop yield between attempts before the ask is cancelled; local empty custom input is never returned as a valid answer. (#5001)
+- The `ask` tool now rejects empty or whitespace-only custom answers on every local and remote input path. Remote invalid answers receive a visible explanation and are retried at most three times with an event-loop yield between attempts before the ask is cancelled; local empty custom input is never returned as a valid answer. (#5001)
 
 ## [0.15.3] - 2026-08-27
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- The `ask` tool now rejects empty or whitespace-only custom answers on every local and remote input path. Remote invalid answers receive a visible explanation and are retried at most four times with an event-loop yield between attempts before the ask is cancelled; local empty custom input is never returned as a valid answer. (#5001)
+
 ## [0.15.3] - 2026-08-27
 
 ### Added

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -155,6 +155,8 @@ export interface ExtensionUIDialogOptions {
 	customInput?: {
 		optionLabel: string;
 		onSubmit: (text: string) => void;
+		/** Empty/whitespace-only submissions may be rejected by the selector. */
+		allowEmpty?: boolean;
 	};
 	/**
 	 * Inline free-text input for a non-answer clarification action. It is

--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -72,6 +72,7 @@ export interface HookSelectorOptions {
 	customInput?: {
 		optionLabel: string;
 		onSubmit: (text: string) => void;
+		allowEmpty?: boolean;
 	};
 	clarificationInput?: {
 		optionLabel: string;
@@ -390,7 +391,7 @@ export class HookSelectorComponent extends Container {
 	#outline: boolean;
 	#scrollTitleRows: number | undefined;
 	#inlineEditorMaxHeight: number | undefined;
-	#customInput: { optionLabel: string; onSubmit: (text: string) => void } | undefined;
+	#customInput: { optionLabel: string; onSubmit: (text: string) => void; allowEmpty?: boolean } | undefined;
 	#clarificationInput: { optionLabel: string; onSubmit: (text: string) => void; allowEmpty?: boolean } | undefined;
 	#activeInput: { onSubmit: (text: string) => void; allowEmpty?: boolean } | undefined;
 	#inputArea: Container;

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -1154,6 +1154,7 @@ export class ExtensionUiController {
 				customInput: dialogOptions?.customInput
 					? {
 							optionLabel: dialogOptions.customInput.optionLabel,
+							allowEmpty: (dialogOptions.customInput as { allowEmpty?: boolean }).allowEmpty,
 							onSubmit: text => {
 								const optionLabel = dialogOptions.customInput?.optionLabel;
 								this.hideHookSelector();

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -114,9 +114,15 @@ const HEADLESS_CHECKBOX_CHECKED = "[x]";
 const HEADLESS_CHECKBOX_UNCHECKED = "[ ]";
 const DEEP_INTERVIEW_SELECTOR_SCROLL_TITLE_ROWS = Number.MAX_SAFE_INTEGER;
 const DEEP_INTERVIEW_RECORDER_AWAIT_TIMEOUT_MS = 250;
+export const MAX_EMPTY_CUSTOM_RETRIES = 3;
+const EMPTY_CUSTOM_RETRY_MESSAGE = "Custom input cannot be empty. Enter text or cancel the ask.";
 
 function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
+}
+
+function nonEmptyCustomInput(value: string | undefined): string | undefined {
+	return value !== undefined && value.trim().length > 0 ? value : undefined;
 }
 
 function isAskTimeoutError(error: unknown): boolean {
@@ -541,7 +547,9 @@ async function askSingleQuestion(
 					timedOut = true;
 					break;
 				}
-				const input = inlineInput !== undefined ? inlineInput : (await promptForCustomInput()).input;
+				const input = nonEmptyCustomInput(
+					inlineInput !== undefined ? inlineInput : (await promptForCustomInput()).input,
+				);
 				if (input === undefined) {
 					break;
 				}
@@ -642,7 +650,9 @@ async function askSingleQuestion(
 			}
 		} else if (choice === otherOptionLabel) {
 			if (!selectTimedOut) {
-				const input = inlineInput !== undefined ? inlineInput : (await promptForCustomInput()).input;
+				const input = nonEmptyCustomInput(
+					inlineInput !== undefined ? inlineInput : (await promptForCustomInput()).input,
+				);
 				if (input !== undefined) {
 					customInput = input;
 					selectedOptions = [];
@@ -1100,10 +1110,15 @@ export class AskTool implements AgentTool<AskParametersSchema, AskToolDetails> {
 
 		const askQuestion = async (
 			q: AskParams["questions"][number],
-			options?: { previous?: QuestionResult; navigation?: NavigationControls },
+			options?: {
+				previous?: QuestionResult;
+				navigation?: NavigationControls;
+				emptyCustomRetryCount?: number;
+			},
 		) => {
 			const rawOptionLabels = q.options.map(o => o.label);
 			const questionIndex = params.questions.indexOf(q);
+			const emptyCustomRetryCount = options?.emptyCustomRetryCount ?? 0;
 			// Route headless asks through the SDK workflow-gate emitter; a connected
 			// SDK responder supplies the durable answer instead of an interactive UI.
 			if (gateEmitter && canUseWorkflowGate) {
@@ -1133,7 +1148,11 @@ export class AskTool implements AgentTool<AskParametersSchema, AskToolDetails> {
 			try {
 				const deepInterviewPrompt = formatDeepInterviewSelectorPrompt(q.question);
 				const isDeepInterviewQuestion = deepInterviewPrompt !== null || q.deepInterview !== undefined;
-				const displayQuestion = deepInterviewPrompt ?? q.question;
+				const baseDisplayQuestion = deepInterviewPrompt ?? q.question;
+				const displayQuestion =
+					emptyCustomRetryCount > 0
+						? `${baseDisplayQuestion}\n\n${EMPTY_CUSTOM_RETRY_MESSAGE} (attempt ${emptyCustomRetryCount + 1} of ${MAX_EMPTY_CUSTOM_RETRIES + 1})`
+						: baseDisplayQuestion;
 				const shouldNumberOptions = isDeepInterviewQuestion || isDeepInterviewAskQuestion(q.question);
 				const optionLabels = shouldNumberOptions ? numberOptionLabels(rawOptionLabels) : rawOptionLabels;
 				const clarificationOptionLabel = shouldNumberOptions
@@ -1256,7 +1275,22 @@ export class AskTool implements AgentTool<AskParametersSchema, AskToolDetails> {
 													: { kind: "resolve_without_commit", reason: "cancelled" };
 					await settleActiveRemote(settlement);
 					activeRemoteRequest = undefined;
-					if (settlement.kind === "invalid") return askQuestion(q, options);
+					if (settlement.kind === "invalid") {
+						if (emptyCustomRetryCount >= MAX_EMPTY_CUSTOM_RETRIES) {
+							context?.abort();
+							throw new ToolAbortError(
+								`${EMPTY_CUSTOM_RETRY_MESSAGE} Ask cancelled after ${MAX_EMPTY_CUSTOM_RETRIES + 1} attempts.`,
+							);
+						}
+						// A remote source may resolve synchronously. Yield to a timer queue
+						// between retries so repeated invalid answers cannot starve the
+						// event loop indefinitely.
+						await Bun.sleep(0);
+						return askQuestion(q, {
+							...options,
+							emptyCustomRetryCount: emptyCustomRetryCount + 1,
+						});
+					}
 				}
 				activeRemoteRequest = undefined;
 				return {

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -114,7 +114,7 @@ const HEADLESS_CHECKBOX_CHECKED = "[x]";
 const HEADLESS_CHECKBOX_UNCHECKED = "[ ]";
 const DEEP_INTERVIEW_SELECTOR_SCROLL_TITLE_ROWS = Number.MAX_SAFE_INTEGER;
 const DEEP_INTERVIEW_RECORDER_AWAIT_TIMEOUT_MS = 250;
-export const MAX_EMPTY_CUSTOM_RETRIES = 3;
+export const MAX_EMPTY_CUSTOM_ATTEMPTS = 3;
 const EMPTY_CUSTOM_RETRY_MESSAGE = "Custom input cannot be empty. Enter text or cancel the ask.";
 
 function errorMessage(error: unknown): string {
@@ -330,7 +330,7 @@ interface UIContext {
 			onLeft?: () => void;
 			onRight?: () => void;
 			helpText?: string;
-			customInput?: { optionLabel: string; onSubmit: (text: string) => void };
+			customInput?: { optionLabel: string; onSubmit: (text: string) => void; allowEmpty?: boolean };
 			clarificationInput?: { optionLabel: string; onSubmit: (text: string) => void; allowEmpty?: boolean };
 		},
 	): Promise<string | undefined>;
@@ -406,6 +406,7 @@ async function askSingleQuestion(
 			helpText,
 			customInput: {
 				optionLabel: otherOptionLabel,
+				allowEmpty: false,
 				onSubmit: (text: string) => {
 					inlineInput = text;
 				},
@@ -1113,12 +1114,12 @@ export class AskTool implements AgentTool<AskParametersSchema, AskToolDetails> {
 			options?: {
 				previous?: QuestionResult;
 				navigation?: NavigationControls;
-				emptyCustomRetryCount?: number;
+				emptyCustomAttempt?: number;
 			},
 		) => {
 			const rawOptionLabels = q.options.map(o => o.label);
 			const questionIndex = params.questions.indexOf(q);
-			const emptyCustomRetryCount = options?.emptyCustomRetryCount ?? 0;
+			const emptyCustomAttempt = options?.emptyCustomAttempt ?? 0;
 			// Route headless asks through the SDK workflow-gate emitter; a connected
 			// SDK responder supplies the durable answer instead of an interactive UI.
 			if (gateEmitter && canUseWorkflowGate) {
@@ -1150,8 +1151,8 @@ export class AskTool implements AgentTool<AskParametersSchema, AskToolDetails> {
 				const isDeepInterviewQuestion = deepInterviewPrompt !== null || q.deepInterview !== undefined;
 				const baseDisplayQuestion = deepInterviewPrompt ?? q.question;
 				const displayQuestion =
-					emptyCustomRetryCount > 0
-						? `${baseDisplayQuestion}\n\n${EMPTY_CUSTOM_RETRY_MESSAGE} (attempt ${emptyCustomRetryCount + 1} of ${MAX_EMPTY_CUSTOM_RETRIES + 1})`
+					emptyCustomAttempt > 0
+						? `${baseDisplayQuestion}\n\n${EMPTY_CUSTOM_RETRY_MESSAGE} (attempt ${emptyCustomAttempt + 1} of ${MAX_EMPTY_CUSTOM_ATTEMPTS})`
 						: baseDisplayQuestion;
 				const shouldNumberOptions = isDeepInterviewQuestion || isDeepInterviewAskQuestion(q.question);
 				const optionLabels = shouldNumberOptions ? numberOptionLabels(rawOptionLabels) : rawOptionLabels;
@@ -1276,19 +1277,24 @@ export class AskTool implements AgentTool<AskParametersSchema, AskToolDetails> {
 					await settleActiveRemote(settlement);
 					activeRemoteRequest = undefined;
 					if (settlement.kind === "invalid") {
-						if (emptyCustomRetryCount >= MAX_EMPTY_CUSTOM_RETRIES) {
-							context?.abort();
-							throw new ToolAbortError(
-								`${EMPTY_CUSTOM_RETRY_MESSAGE} Ask cancelled after ${MAX_EMPTY_CUSTOM_RETRIES + 1} attempts.`,
-							);
+						if (emptyCustomAttempt + 1 >= MAX_EMPTY_CUSTOM_ATTEMPTS) {
+							return {
+								optionLabels: rawOptionLabels,
+								selectedOptions: [] as string[],
+								customInput: undefined,
+								clarificationQuestion: undefined,
+								navigation: undefined,
+								cancelled: true,
+								timedOut: false,
+							};
 						}
 						// A remote source may resolve synchronously. Yield to a timer queue
 						// between retries so repeated invalid answers cannot starve the
 						// event loop indefinitely.
-						await Bun.sleep(0);
+						await Bun.sleep(1);
 						return askQuestion(q, {
 							...options,
-							emptyCustomRetryCount: emptyCustomRetryCount + 1,
+							emptyCustomAttempt: emptyCustomAttempt + 1,
 						});
 					}
 				}

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -6,7 +6,13 @@ import type { AppendOrMergeResult } from "@gajae-code/coding-agent/gjc-runtime/d
 import * as deepInterviewRecorder from "@gajae-code/coding-agent/gjc-runtime/deep-interview-recorder";
 import { deepInterviewCharacterCount } from "@gajae-code/coding-agent/gjc-runtime/deep-interview-state";
 import { getThemeByName, initTheme } from "@gajae-code/coding-agent/modes/theme/theme";
-import type { AskAnswerRequest, AskAnswerSource, AskRemoteReceipt, ToolSession } from "@gajae-code/coding-agent/tools";
+import type {
+	AskAnswerRequest,
+	AskAnswerSource,
+	AskRemoteReceipt,
+	AskSettlement,
+	ToolSession,
+} from "@gajae-code/coding-agent/tools";
 import { AskTool, askSchema, askToolRenderer } from "@gajae-code/coding-agent/tools/ask";
 import { ToolAbortError } from "@gajae-code/coding-agent/tools/tool-errors";
 import { logger } from "@gajae-code/utils";
@@ -688,7 +694,7 @@ describe("AskTool cancellation", () => {
 });
 
 describe("AskTool remote semantic settlements", () => {
-	const abortableUi = () =>
+	const abortableUi = (abort?: () => void) =>
 		createContext({
 			select: (_prompt, _options, dialogOptions) =>
 				new Promise<string | undefined>(resolve => {
@@ -698,7 +704,83 @@ describe("AskTool remote semantic settlements", () => {
 				new Promise<string | undefined>(resolve => {
 					dialogOptions?.signal?.addEventListener("abort", () => resolve(undefined), { once: true });
 				}),
+			abort,
 		});
+
+	it("bounds repeated remote whitespace custom answers and explains the retry", async () => {
+		const requests: AskAnswerRequest[] = [];
+		const settlements: AskSettlement[] = [];
+		let remoteCalls = 0;
+		const source: AskAnswerSource = {
+			awaitAnswer: async () => undefined,
+			awaitAnswerRequest: request => {
+				requests.push(request);
+				remoteCalls++;
+				return Promise.resolve({
+					source: "remote" as const,
+					interaction: { kind: "value" as const, value: " \t" },
+					settle: async (settlement: AskSettlement) => {
+						settlements.push(settlement);
+						return { kind: "invalid_closed" as const };
+					},
+				});
+			},
+		};
+		const abort = vi.fn();
+		const tool = new AskTool(createSession({ getAskAnswerSource: () => source }));
+
+		await expect(
+			tool.execute(
+				"remote-whitespace-loop",
+				{ questions: [{ id: "choice", question: "Choose", options: [{ label: "yes" }] }] },
+				undefined,
+				undefined,
+				abortableUi(abort),
+			),
+		).rejects.toThrow("Ask cancelled after 4 attempts");
+
+		expect(remoteCalls).toBe(4);
+		expect(settlements).toHaveLength(4);
+		expect(settlements).toEqual([
+			{ kind: "invalid", reason: "empty_custom" },
+			{ kind: "invalid", reason: "empty_custom" },
+			{ kind: "invalid", reason: "empty_custom" },
+			{ kind: "invalid", reason: "empty_custom" },
+		]);
+		expect(requests.slice(1).every(request => request.question.includes("Custom input cannot be empty"))).toBe(true);
+	});
+
+	it("yields between synchronous invalid remote answers so timers are not starved", async () => {
+		let timerRan = false;
+		const timer = setTimeout(() => {
+			timerRan = true;
+		}, 0);
+		let remoteCalls = 0;
+		const source: AskAnswerSource = {
+			awaitAnswer: async () => undefined,
+			awaitAnswerRequest: () => {
+				remoteCalls++;
+				return Promise.resolve({
+					source: "remote" as const,
+					interaction: { kind: "value" as const, value: "   " },
+					settle: async () => ({ kind: "invalid_closed" as const }),
+				});
+			},
+		};
+
+		await expect(
+			new AskTool(createSession({ getAskAnswerSource: () => source })).execute(
+				"remote-whitespace-yield",
+				{ questions: [{ id: "choice", question: "Choose", options: [{ label: "yes" }] }] },
+				undefined,
+				undefined,
+				abortableUi(),
+			),
+		).rejects.toThrow("Ask cancelled after 4 attempts");
+		clearTimeout(timer);
+		expect(timerRan).toBe(true);
+		expect(remoteCalls).toBe(4);
+	});
 
 	it("awaits a committed visible acknowledgement before returning the answer", async () => {
 		const settlementStarted = Promise.withResolvers<void>();
@@ -1378,7 +1460,7 @@ describe("AskTool custom input", () => {
 		expect(abort).not.toHaveBeenCalled();
 	});
 
-	it("treats explicit empty-string custom input as submitted input", async () => {
+	it("cancels when the editor submits empty custom input", async () => {
 		const tool = new AskTool(createSession());
 		const abort = vi.fn();
 		const editor = vi.fn(async () => "");
@@ -1388,31 +1470,51 @@ describe("AskTool custom input", () => {
 			abort,
 		});
 
-		const result = await tool.execute(
-			"call-empty-custom",
-			{
-				questions: [
-					{
-						id: "details",
-						question: "Share details",
-						options: [{ label: "yes" }, { label: "no" }],
-					},
-				],
-			},
-			undefined,
-			undefined,
-			context,
-		);
-
-		expect(result.content[0]?.type).toBe("text");
-		if (result.content[0]?.type !== "text") {
-			throw new Error("Expected text result");
-		}
-		expect(result.content[0].text).toContain("User provided custom input:");
-		expect(result.details?.customInput).toBe("");
-		expect(result.details?.selectedOptions).toEqual([]);
+		await expect(
+			tool.execute(
+				"call-empty-custom",
+				{
+					questions: [
+						{
+							id: "details",
+							question: "Share details",
+							options: [{ label: "yes" }, { label: "no" }],
+						},
+					],
+				},
+				undefined,
+				undefined,
+				context,
+			),
+		).rejects.toBeInstanceOf(ToolAbortError);
 		expect(editor).toHaveBeenCalledTimes(1);
-		expect(abort).not.toHaveBeenCalled();
+		expect(abort).toHaveBeenCalledTimes(1);
+	});
+
+	it("cancels when inline Other input is only whitespace", async () => {
+		const tool = new AskTool(createSession());
+		const abort = vi.fn();
+		const editor = vi.fn(async () => "editor fallback");
+		const context = createContext({
+			select: async (_prompt, _options, dialogOptions) => {
+				dialogOptions?.customInput?.onSubmit(" \t\n ");
+				return "Other (type your own)";
+			},
+			editor,
+			abort,
+		});
+
+		await expect(
+			tool.execute(
+				"call-inline-empty-custom",
+				{ questions: [{ id: "details", question: "Share details", options: [{ label: "yes" }] }] },
+				undefined,
+				undefined,
+				context,
+			),
+		).rejects.toBeInstanceOf(ToolAbortError);
+		expect(editor).not.toHaveBeenCalled();
+		expect(abort).toHaveBeenCalledTimes(1);
 	});
 
 	it("renders checked options together with custom text in multi-select answers", async () => {

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -737,12 +737,11 @@ describe("AskTool remote semantic settlements", () => {
 				undefined,
 				abortableUi(abort),
 			),
-		).rejects.toThrow("Ask cancelled after 4 attempts");
+		).rejects.toThrow("Ask tool was cancelled by the user");
 
-		expect(remoteCalls).toBe(4);
-		expect(settlements).toHaveLength(4);
+		expect(remoteCalls).toBe(3);
+		expect(settlements).toHaveLength(3);
 		expect(settlements).toEqual([
-			{ kind: "invalid", reason: "empty_custom" },
 			{ kind: "invalid", reason: "empty_custom" },
 			{ kind: "invalid", reason: "empty_custom" },
 			{ kind: "invalid", reason: "empty_custom" },
@@ -776,10 +775,10 @@ describe("AskTool remote semantic settlements", () => {
 				undefined,
 				abortableUi(),
 			),
-		).rejects.toThrow("Ask cancelled after 4 attempts");
+		).rejects.toThrow("Ask tool was cancelled by the user");
 		clearTimeout(timer);
 		expect(timerRan).toBe(true);
-		expect(remoteCalls).toBe(4);
+		expect(remoteCalls).toBe(3);
 	});
 
 	it("awaits a committed visible acknowledgement before returning the answer", async () => {


### PR DESCRIPTION
## What
Bound empty and whitespace-only custom answers in the ask tool across remote races and local TUI selectors.

## Why
Issue #5001: repeated empty remote custom answers could re-enter the same question indefinitely, while local inline/editor paths could return empty custom input as an answer.

## Testing
- `bun test packages/coding-agent/test/tools/ask.test.ts` — 99 pass, 0 fail, 424 expect() calls
- `bun --cwd=packages/coding-agent run check:types` — passed
- `bunx biome check packages/coding-agent/src/tools/ask.ts packages/coding-agent/src/modes/components/hook-selector.ts packages/coding-agent/src/modes/controllers/extension-ui-controller.ts packages/coding-agent/src/extensibility/extensions/types.ts packages/coding-agent/test/tools/ask.test.ts` — passed

## Risk classification
- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

gajae.pr-review-verdict.v1 merge-self-approved sha256:bfae523e346f8386ae73f778c3c5cf1171833fc3b579930bf7ab821815debfc2 reviewer:human reviewer-id:Yeachan-Heo evidence:Signed exact-head fix-forward commits; local regression and type checks passed; #5003 allowEmpty and three-attempt behavior compared and reimplemented

- [x] Target branch is `dev`
- [x] Tested locally
- [x] CHANGELOG updated
- [x] Verdict is bound to exact head `fbb6537feff61d5b21f2f7df836639f1e4ae2560`

Closes #5001
Excludes #5002