### PR TITLE
fix(workflows): reject deep-interview placeholder questions

### DIFF
--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -871,7 +871,7 @@ export type TSchema = ZodType | TJsonSchema;
 export type Static<S> = S extends ZodType ? z.infer<S> : S extends { static: infer T } ? T : unknown;
 
 export type RawArgumentRejectionCode =
-	| "deep-interview-question-body-placeholder"
+	| "ask-deep-interview-question-body-required"
 	| "ask-intent-review-requires-positive-round"
 	| "ask-intent-contract-requires-non-empty-authority"
 	| "ask-deep-interview-metadata-requires-deep-interview-gate"

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -871,6 +871,7 @@ export type TSchema = ZodType | TJsonSchema;
 export type Static<S> = S extends ZodType ? z.infer<S> : S extends { static: infer T } ? T : unknown;
 
 export type RawArgumentRejectionCode =
+	| "deep-interview-question-body-placeholder"
 	| "ask-intent-review-requires-positive-round"
 	| "ask-intent-contract-requires-non-empty-authority"
 	| "ask-deep-interview-metadata-requires-deep-interview-gate"

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -959,6 +959,8 @@ export function validateToolCall(tools: Tool[], toolCall: ToolCall): ToolCall["a
 }
 
 const RAW_ARGUMENT_REJECTION_MESSAGES: Record<RawArgumentRejectionCode, string> = {
+	"deep-interview-question-body-placeholder":
+		"deep-interview question bodies must contain a specific question, not a placeholder",
 	"ask-intent-review-requires-positive-round":
 		"deepInterview.intent_review is post-Round-0 only and requires a positive round",
 	"ask-intent-contract-requires-non-empty-authority":

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -959,7 +959,7 @@ export function validateToolCall(tools: Tool[], toolCall: ToolCall): ToolCall["a
 }
 
 const RAW_ARGUMENT_REJECTION_MESSAGES: Record<RawArgumentRejectionCode, string> = {
-	"deep-interview-question-body-placeholder":
+	"ask-deep-interview-question-body-required":
 		"deep-interview question bodies must contain a specific question, not a placeholder",
 	"ask-intent-review-requires-positive-round":
 		"deepInterview.intent_review is post-Round-0 only and requires a positive round",

--- a/packages/coding-agent/src/deep-interview/render-middleware.ts
+++ b/packages/coding-agent/src/deep-interview/render-middleware.ts
@@ -10,6 +10,7 @@ import {
 	type ViewportAnchorSource,
 	type ViewportAnchorSourceRenderer,
 } from "@gajae-code/tui";
+import { isWorkflowPlaceholderText } from "../gjc-runtime/workflow-placeholder";
 import { getMarkdownTheme, type Theme } from "../modes/theme/theme";
 
 interface RoundQuestionModel {
@@ -132,7 +133,7 @@ function parseRoundQuestion(text: string): RoundQuestionModel | null {
 		.slice(headerIndex + 1)
 		.join("\n")
 		.trim();
-	if (!body) return null;
+	if (isWorkflowPlaceholderText(body)) return null;
 
 	const componentMatch =
 		/^Round\s+(\d+)\s+\|\s+Component:\s*(.*?)\s+\|\s+Targeting:\s*(.*?)\s+\|\s+Why now:\s*(.*?)\s+\|\s+Ambiguity:\s*(.+?)%?\s*$/i.exec(

--- a/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
+++ b/packages/coding-agent/src/gjc-runtime/ultragoal-runtime.ts
@@ -86,6 +86,7 @@ import {
 	type UltragoalValidationLaneSelection,
 	validationLaneSelectionFor,
 } from "./ultragoal-validation-policy";
+import { isWorkflowPlaceholderText, WORKFLOW_PLACEHOLDER_CORRECTION } from "./workflow-placeholder";
 import { resolveWorkflowSetting } from "./workflow-settings";
 
 export {
@@ -1166,6 +1167,9 @@ function parseGoalsFromBrief(brief: string): ParsedGoal[] {
 		if (!title && !body) {
 			throw new Error(`ultragoal @goal block ${index + 1} has no title or objective`);
 		}
+		if (isWorkflowPlaceholderText(body || title)) {
+			throw new Error(`ultragoal @goal block ${index + 1} requires ${WORKFLOW_PLACEHOLDER_CORRECTION}`);
+		}
 		return { title: clampTitle(title), objective: body || title };
 	});
 }
@@ -1180,6 +1184,7 @@ export async function createUltragoalPlan(input: {
 }): Promise<UltragoalPlan> {
 	const brief = input.brief.trim();
 	if (!brief) throw new Error("ultragoal brief is required");
+	if (isWorkflowPlaceholderText(brief)) throw new Error(`ultragoal brief requires ${WORKFLOW_PLACEHOLDER_CORRECTION}`);
 	const now = new Date().toISOString();
 	// Parse the untrimmed brief so the raw-line delimiter contract holds: a
 	// leading-indented `@goal` on the first line must stay objective text rather

--- a/packages/coding-agent/src/gjc-runtime/workflow-placeholder.ts
+++ b/packages/coding-agent/src/gjc-runtime/workflow-placeholder.ts
@@ -1,0 +1,24 @@
+/** Shared placeholder semantics for model-authored workflow content. */
+
+const WORKFLOW_PLACEHOLDER_TOKENS = new Set([
+	"empty",
+	"n/a",
+	"n-a",
+	"na",
+	"none",
+	"placeholder",
+	"stub",
+	"tbd",
+	"todo",
+	"unused",
+]);
+
+export const WORKFLOW_PLACEHOLDER_CORRECTION =
+	"provide a specific, non-placeholder question or objective instead of empty, whitespace, unused, TODO, TBD, N/A, none, placeholder, or stub";
+
+/** Exact, case-insensitive placeholder detection; meaningful sentences remain valid. */
+export function isWorkflowPlaceholderText(value: unknown): boolean {
+	if (typeof value !== "string") return false;
+	const normalized = value.trim().toLowerCase();
+	return normalized.length === 0 || WORKFLOW_PLACEHOLDER_TOKENS.has(normalized);
+}

--- a/packages/coding-agent/src/tools/ask-contract.ts
+++ b/packages/coding-agent/src/tools/ask-contract.ts
@@ -7,6 +7,7 @@ import { INTENT_FIELD } from "@gajae-code/agent-core";
 import type { RawArgumentValidationResult } from "@gajae-code/ai/types";
 import * as z from "zod/v4";
 import { deepInterviewCharacterCount } from "../gjc-runtime/deep-interview-state";
+import { isWorkflowPlaceholderText, WORKFLOW_PLACEHOLDER_CORRECTION } from "../gjc-runtime/workflow-placeholder";
 
 function deepInterviewBoundedString(maximum: number) {
 	return z.string().superRefine((value, context) => {
@@ -146,6 +147,13 @@ function createQuestionItemSchema(deepInterviewSchema: z.ZodType<DeepInterviewMe
 			workflowGate: WorkflowGateMeta.describe("optional workflow gate stage/kind override").optional(),
 		})
 		.superRefine((value, context) => {
+			if (isWorkflowPlaceholderText(value.question)) {
+				context.addIssue({
+					code: "custom",
+					message: `deep-interview question body must ${WORKFLOW_PLACEHOLDER_CORRECTION}`,
+					path: ["question"],
+				});
+			}
 			const labels = new Set(value.options.map(option => option.label));
 			const contract = intentContract(value.deepInterview);
 			const review = intentReview(value.deepInterview);
@@ -459,10 +467,33 @@ function knownIntentRejection(arguments_: Record<string, unknown>): RawArgumentV
 		return { outcome: "reject", code: "ask-intent-contract-requires-non-empty-authority" };
 	return undefined;
 }
+
+function deepInterviewPlaceholderRejection(
+	arguments_: Record<string, unknown>,
+): RawArgumentValidationResult | undefined {
+	if (!isPlainRecord(arguments_) || !Array.isArray(arguments_.questions)) return undefined;
+	for (const [index, rawQuestion] of arguments_.questions.entries()) {
+		if (!isPlainRecord(rawQuestion) || !Object.hasOwn(rawQuestion, "deepInterview")) continue;
+		if (isWorkflowPlaceholderText(rawQuestion.question)) {
+			return {
+				outcome: "reject",
+				code: "deep-interview-question-body-placeholder",
+				detail: {
+					rejectedKeys: [`questions[${index}].question`],
+					hint: WORKFLOW_PLACEHOLDER_CORRECTION,
+				},
+			};
+		}
+	}
+	return undefined;
+}
+
 export function recoverRoundZeroIntentContract(
 	arguments_: Record<string, unknown>,
 	stage?: "topology" | "post-topology",
 ): RawArgumentValidationResult {
+	const placeholderRejection = deepInterviewPlaceholderRejection(arguments_);
+	if (placeholderRejection) return placeholderRejection;
 	// #4649: an incomplete Round-0 topology object (deepInterview present,
 	// required fields omitted) is NOT a retired-pair recovery candidate, so it
 	// would passthrough into generic Zod validation whose error names no contract

--- a/packages/coding-agent/src/tools/ask-contract.ts
+++ b/packages/coding-agent/src/tools/ask-contract.ts
@@ -477,7 +477,7 @@ function deepInterviewPlaceholderRejection(
 		if (isWorkflowPlaceholderText(rawQuestion.question)) {
 			return {
 				outcome: "reject",
-				code: "deep-interview-question-body-placeholder",
+				code: "ask-deep-interview-question-body-required",
 				detail: {
 					rejectedKeys: [`questions[${index}].question`],
 					hint: WORKFLOW_PLACEHOLDER_CORRECTION,

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-placeholder.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-placeholder.test.ts
@@ -9,7 +9,20 @@ import {
 } from "@gajae-code/coding-agent/gjc-runtime/workflow-placeholder";
 import { askSchema, recoverRoundZeroIntentContract } from "@gajae-code/coding-agent/tools/ask-contract";
 
-const PLACEHOLDERS = ["", "   \n\t", "unused", "TODO", "tbd", "n-a", "none", "placeholder", "empty", "stub"];
+const PLACEHOLDERS = [
+	"",
+	"   \n\t",
+	"unused",
+	"TODO",
+	"tbd",
+	"n-a",
+	"n/a",
+	"N/A",
+	"none",
+	"placeholder",
+	"empty",
+	"stub",
+];
 
 function roundQuestion(question: string): Record<string, unknown> {
 	return {
@@ -41,7 +54,7 @@ describe("shared workflow placeholder semantics", () => {
 			const result = recoverRoundZeroIntentContract(roundQuestion(question));
 			expect(result).toMatchObject({
 				outcome: "reject",
-				code: "deep-interview-question-body-placeholder",
+				code: "ask-deep-interview-question-body-required",
 				detail: {
 					rejectedKeys: ["questions[0].question"],
 					hint: WORKFLOW_PLACEHOLDER_CORRECTION,

--- a/packages/coding-agent/test/gjc-runtime/deep-interview-placeholder.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/deep-interview-placeholder.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import {
+	formatDeepInterviewSelectorPrompt,
+	renderDeepInterviewAskQuestion,
+} from "@gajae-code/coding-agent/deep-interview/render-middleware";
+import {
+	isWorkflowPlaceholderText,
+	WORKFLOW_PLACEHOLDER_CORRECTION,
+} from "@gajae-code/coding-agent/gjc-runtime/workflow-placeholder";
+import { askSchema, recoverRoundZeroIntentContract } from "@gajae-code/coding-agent/tools/ask-contract";
+
+const PLACEHOLDERS = ["", "   \n\t", "unused", "TODO", "tbd", "n-a", "none", "placeholder", "empty", "stub"];
+
+function roundQuestion(question: string): Record<string, unknown> {
+	return {
+		questions: [
+			{
+				id: "q1",
+				question,
+				options: [{ label: "Continue" }],
+				deepInterview: {
+					round: 1,
+					component: "scope",
+					dimension: "constraints",
+					ambiguity: 0.4,
+				},
+			},
+		],
+	};
+}
+
+describe("shared workflow placeholder semantics", () => {
+	it("recognizes empty and exact placeholder bodies while preserving meaningful questions", () => {
+		for (const value of PLACEHOLDERS) expect(isWorkflowPlaceholderText(value)).toBe(true);
+		expect(isWorkflowPlaceholderText("Should exports preserve ordering?")).toBe(false);
+		expect(isWorkflowPlaceholderText("TODO items are displayed in the review panel")).toBe(false);
+	});
+
+	it("rejects every placeholder through the named raw deep-interview contract", () => {
+		for (const question of PLACEHOLDERS) {
+			const result = recoverRoundZeroIntentContract(roundQuestion(question));
+			expect(result).toMatchObject({
+				outcome: "reject",
+				code: "deep-interview-question-body-placeholder",
+				detail: {
+					rejectedKeys: ["questions[0].question"],
+					hint: WORKFLOW_PLACEHOLDER_CORRECTION,
+				},
+			});
+		}
+	});
+
+	it("rejects placeholders in the schema and accepts valid deep-interview questions", () => {
+		for (const question of PLACEHOLDERS) expect(askSchema.safeParse(roundQuestion(question)).success).toBe(false);
+		expect(askSchema.safeParse(roundQuestion("Which export behavior is required?")).success).toBe(true);
+	});
+});
+
+describe("deep-interview placeholder rendering", () => {
+	it("does not render a placeholder round body or selector prompt", () => {
+		const raw = "Round 2 | Targeting: scope | Why now: needed | Ambiguity: 40%\n\nTODO";
+		expect(formatDeepInterviewSelectorPrompt(raw)).toBeNull();
+		// @ts-expect-error test intentionally supplies an uninitialized theme
+		expect(renderDeepInterviewAskQuestion(raw, undefined)).toBeNull();
+	});
+});


### PR DESCRIPTION
Closes #5002

## Summary
- centralize exact workflow placeholder semantics and share them with deep-interview and ultragoal
- reject placeholder deep-interview question bodies before coercion with correction code `ask-deep-interview-question-body-required`
- keep meaningful text and existing round-header parsing backward-compatible

## Risk classification
- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict
```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:2024848d8851c9a9e08d5f0b28df0db4395f70b87723d4c8097f5d79007e905a reviewer:human reviewer-id:Yeachan-Heo evidence:bun test focused workflow suites; signed exact-head commit
```

## Verification
- `bun test packages/coding-agent/test/gjc-runtime/deep-interview-placeholder.test.ts packages/coding-agent/test/modes/components/deep-interview-render-middleware.test.ts packages/coding-agent/test/tools/ask.test.ts` (107 pass)
- `bun run --cwd=packages/coding-agent check:types`
- signed commits: e49712876d8e2b16a99feb7bf96ef79dc02277ad, 126709825
- exact diff SHA-256: 

No #5001 changes included.