### PR TITLE
fix(tui): close normalized autocomplete path regressions

### DIFF
--- a/crates/pi-natives/src/fd.rs
+++ b/crates/pi-natives/src/fd.rs
@@ -109,9 +109,10 @@ fn score_fuzzy_path(
 	}
 
 	// Match against the full relative path only when the user typed a path-style
-	// query (contains '/'). Plain queries should match by basename only, otherwise
-	// '@plan' surfaces every file whose ancestor directories contain 'plan'.
-	let query_has_slash = query_lower.contains('/');
+	// query (contains a path separator). Plain queries should match by basename
+	// only, otherwise '@plan' surfaces every file whose ancestor directories
+	// contain 'plan'.
+	let query_has_slash = query_lower.contains('/') || query_lower.contains('\\');
 
 	let file_name = Path::new(path)
 		.file_name()
@@ -209,7 +210,9 @@ fn fuzzy_find_sync(config: FuzzyFindConfig, ct: task::CancelToken) -> Result<Fuz
 		return Ok(FuzzyFindResult { matches: Vec::new(), total_matches: 0 });
 	}
 
-	let query_lower = nfc_normalize(config.query.trim()).to_lowercase();
+	let query_lower = nfc_normalize(config.query.trim())
+		.to_lowercase()
+		.replace('\\', "/");
 	let normalized_query = normalize_fuzzy_text(&query_lower);
 	let query_chars: Vec<char> = normalized_query.chars().collect();
 	if !query_lower.is_empty() && normalized_query.is_empty() {
@@ -262,7 +265,9 @@ mod tests {
 	use super::*;
 
 	fn score(path: &str, query: &str) -> u32 {
-		let query_lower = nfc_normalize(query.trim()).to_lowercase();
+		let query_lower = nfc_normalize(query.trim())
+			.to_lowercase()
+			.replace('\\', "/");
 		let normalized_query = normalize_fuzzy_text(&query_lower);
 		let query_chars: Vec<char> = normalized_query.chars().collect();
 		score_fuzzy_path(path, false, &query_lower, &normalized_query, &query_chars)
@@ -284,6 +289,11 @@ mod tests {
 	fn nfc_query_matches_nfd_path_segment() {
 		let nfd_dir = "\u{1103}\u{1169}\u{11A8}\u{1109}\u{1165}/readme.md";
 		assert!(score(nfd_dir, "\u{B3C5}\u{C11C}/read") > 0);
+	}
+
+	#[test]
+	fn windows_separator_query_matches_forward_slash_path() {
+		assert!(score("src/readme.md", "src\\read") > 0);
 	}
 
 	#[test]

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -18,6 +18,10 @@ async function fuzzyFindNative(): Promise<NativeFuzzyFind> {
 
 const PATH_DELIMITERS = new Set([" ", "\t", '"', "'", "="]);
 
+function isAbsolutePathLike(value: string): boolean {
+	return path.isAbsolute(value) || path.win32.isAbsolute(value);
+}
+
 function buildAutocompleteFuzzyDiscoveryProfile(
 	query: string,
 	basePath: string,
@@ -589,7 +593,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	async #resolveScopedFuzzyQuery(
 		rawQuery: string,
 	): Promise<{ baseDir: string; query: string; displayBase: string } | null> {
-		const slashIndex = rawQuery.lastIndexOf("/");
+		const slashIndex = Math.max(rawQuery.lastIndexOf("/"), rawQuery.lastIndexOf("\\"));
 		if (slashIndex === -1) {
 			return null;
 		}
@@ -669,7 +673,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			const homeRelative = path.relative(path.resolve(os.homedir()), resolvedDir).replaceAll(path.sep, "/");
 			return homeRelative ? `~/${homeRelative}/` : "~/";
 		}
-		if (path.isAbsolute(rawPrefix)) {
+		if (isAbsolutePathLike(rawPrefix)) {
 			return normalizedResolvedDir === "/" ? "/" : `${normalizedResolvedDir}/`;
 		}
 
@@ -740,7 +744,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 
 			if (isRootPrefix) {
 				// Complete from specified position
-				if (rawPrefix.startsWith("~") || expandedPrefix.startsWith("/")) {
+				if (rawPrefix.startsWith("~") || isAbsolutePathLike(expandedPrefix)) {
 					searchDir = expandedPrefix;
 				} else {
 					searchDir = path.join(this.#basePath, expandedPrefix);
@@ -748,7 +752,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				searchPrefix = "";
 			} else if (rawPrefix.endsWith("/")) {
 				// If prefix ends with /, show contents of that directory
-				if (rawPrefix.startsWith("~") || expandedPrefix.startsWith("/")) {
+				if (rawPrefix.startsWith("~") || isAbsolutePathLike(expandedPrefix)) {
 					searchDir = expandedPrefix;
 				} else {
 					searchDir = path.join(this.#basePath, expandedPrefix);
@@ -758,7 +762,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				// Split into directory and file prefix
 				const dir = path.dirname(expandedPrefix);
 				const file = path.basename(expandedPrefix);
-				if (rawPrefix.startsWith("~") || expandedPrefix.startsWith("/")) {
+				if (rawPrefix.startsWith("~") || isAbsolutePathLike(expandedPrefix)) {
 					searchDir = dir;
 				} else {
 					searchDir = path.join(this.#basePath, dir);

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -606,15 +606,16 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			baseDir = path.join(this.#basePath, displayBase);
 		}
 
-		try {
-			if (!(await fs.promises.stat(baseDir)).isDirectory()) {
-				return null;
-			}
-		} catch {
+		const resolvedDir = await this.#resolveDirectoryPath(baseDir);
+		if (!resolvedDir) {
 			return null;
 		}
 
-		return { baseDir, query, displayBase };
+		return {
+			baseDir: resolvedDir,
+			query,
+			displayBase: this.#formatResolvedDirectoryPrefix(displayBase, resolvedDir),
+		};
 	}
 
 	#scopedPathForDisplay(displayBase: string, relativePath: string): string {
@@ -622,6 +623,61 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			return `/${relativePath}`;
 		}
 		return `${displayBase}${relativePath}`;
+	}
+
+	async #resolveDirectoryPath(candidate: string): Promise<string | null> {
+		const absoluteCandidate = path.resolve(candidate);
+		const root = path.parse(absoluteCandidate).root;
+		const relativePath = path.relative(root, absoluteCandidate);
+		const components = relativePath ? relativePath.split(path.sep).filter(Boolean) : [];
+		let resolvedPath = root;
+
+		for (const component of components) {
+			let entries: fs.Dirent[];
+			try {
+				entries = await fs.promises.readdir(resolvedPath, { withFileTypes: true });
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+				throw error;
+			}
+
+			const exactEntry = entries.find(entry => entry.name === component);
+			const matchingEntries = exactEntry
+				? [exactEntry]
+				: entries.filter(entry => entry.name.normalize("NFC") === component.normalize("NFC"));
+			// An exact spelling is unambiguous even when a Linux directory contains
+			// both NFC and NFD variants. A normalized-only match must not guess
+			// between siblings, since doing so can expose the wrong subtree.
+			if (matchingEntries.length !== 1) return null;
+
+			const entry = matchingEntries[0];
+			if (!entry) return null;
+			let isDirectory = entry.isDirectory();
+			if (!isDirectory && entry.isSymbolicLink()) {
+				isDirectory = (await fs.promises.stat(path.join(resolvedPath, entry.name))).isDirectory();
+			}
+			if (!isDirectory) return null;
+			resolvedPath = path.join(resolvedPath, entry.name);
+		}
+
+		return resolvedPath;
+	}
+
+	#formatResolvedDirectoryPrefix(rawPrefix: string, resolvedDir: string): string {
+		const normalizedResolvedDir = resolvedDir.replaceAll(path.sep, "/");
+		if (rawPrefix === "~" || rawPrefix.startsWith("~/")) {
+			const homeRelative = path.relative(path.resolve(os.homedir()), resolvedDir).replaceAll(path.sep, "/");
+			return homeRelative ? `~/${homeRelative}/` : "~/";
+		}
+		if (path.isAbsolute(rawPrefix)) {
+			return normalizedResolvedDir === "/" ? "/" : `${normalizedResolvedDir}/`;
+		}
+
+		const relative = path.relative(path.resolve(this.#basePath), resolvedDir).replaceAll(path.sep, "/");
+		if (rawPrefix.startsWith("./")) {
+			return relative ? `./${relative}/` : "./";
+		}
+		return relative ? `${relative}/` : "";
 	}
 
 	async #getCachedDirEntries(searchDir: string): Promise<{ entries: fs.Dirent[]; resolvedDir: string }> {
@@ -632,23 +688,11 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			return { entries: cached.entries, resolvedDir: cached.resolvedDir };
 		}
 
-		const searchDirs = [...new Set([searchDir, searchDir.normalize("NFD"), searchDir.normalize("NFC")])];
-		let entries: fs.Dirent[] | undefined;
-		let resolvedDir: string | undefined;
-		for (const candidate of searchDirs) {
-			try {
-				entries = await fs.promises.readdir(candidate, { withFileTypes: true });
-				resolvedDir = candidate;
-				break;
-			} catch (error) {
-				if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-					throw error;
-				}
-			}
-		}
-		if (!entries || !resolvedDir) {
+		const resolvedDir = await this.#resolveDirectoryPath(searchDir);
+		if (!resolvedDir) {
 			throw new Error(`Directory not found: ${searchDir}`);
 		}
+		const entries = await fs.promises.readdir(resolvedDir, { withFileTypes: true });
 		this.#dirCache.set(searchDir, { entries, resolvedDir, timestamp: now });
 
 		if (this.#dirCache.size > 100) {
@@ -725,24 +769,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			const { entries, resolvedDir } = await this.#getCachedDirEntries(searchDir);
 			const suggestions: AutocompleteItem[] = [];
 			const lowerSearchPrefix = searchPrefix.normalize("NFC").toLowerCase();
-			const resolvedDirectoryPrefix = (() => {
-				if (resolvedDir === searchDir) return rawPrefix.endsWith("/") ? rawPrefix : path.dirname(rawPrefix);
-
-				const normalizedResolvedDir = resolvedDir.replaceAll(path.sep, "/");
-				let prefix: string;
-				if (rawPrefix.startsWith("~")) {
-					const homeRelative = path.relative(this.#expandHomePath("~"), resolvedDir).replaceAll(path.sep, "/");
-					prefix = homeRelative ? `~/${homeRelative}` : "~";
-				} else if (path.isAbsolute(expandedPrefix)) {
-					prefix = normalizedResolvedDir;
-				} else {
-					const relative = path.relative(this.#basePath, resolvedDir).replaceAll(path.sep, "/");
-					prefix = rawPrefix.startsWith("./") && relative ? `./${relative}` : relative;
-				}
-				return prefix ? `${prefix}/` : prefix;
-			})();
-			const resolvedDisplayPrefix =
-				resolvedDir === searchDir ? rawPrefix : `${resolvedDirectoryPrefix}${searchPrefix}`;
+			const displayDirectoryPrefix = this.#formatResolvedDirectoryPrefix(rawPrefix, resolvedDir);
 
 			for (const entry of entries) {
 				if (!entry.name.normalize("NFC").toLowerCase().startsWith(lowerSearchPrefix)) {
@@ -757,7 +784,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				let isDirectory = entry.isDirectory();
 				if (!isDirectory && entry.isSymbolicLink()) {
 					try {
-						const fullPath = path.join(searchDir, entry.name);
+						const fullPath = path.join(resolvedDir, entry.name);
 						isDirectory = (await fs.promises.stat(fullPath)).isDirectory();
 					} catch {
 						// Broken symlink, file deleted between readdir and stat, or permission error
@@ -765,41 +792,8 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 					}
 				}
 
-				let relativePath: string;
 				const name = entry.name;
-				const displayPrefix = resolvedDisplayPrefix;
-
-				if (displayPrefix.endsWith("/")) {
-					// If prefix ends with /, append entry to the prefix
-					relativePath = displayPrefix + name;
-				} else if (displayPrefix.includes("/")) {
-					// Preserve ~/ format for home directory paths
-					if (displayPrefix.startsWith("~/")) {
-						const homeRelativeDir = displayPrefix.slice(2); // Remove ~/
-						const dir = path.dirname(homeRelativeDir);
-						relativePath = `~/${dir === "." ? name : path.join(dir, name)}`;
-					} else if (displayPrefix.startsWith("/")) {
-						// Absolute path - construct properly
-						const dir = path.dirname(displayPrefix);
-						if (dir === "/") {
-							relativePath = `/${name}`;
-						} else {
-							relativePath = `${dir}/${name}`;
-						}
-					} else {
-						relativePath = path.join(path.dirname(displayPrefix), name);
-						if (displayPrefix.startsWith("./") && !relativePath.startsWith("./")) {
-							relativePath = `./${relativePath}`;
-						}
-					}
-				} else {
-					// For standalone entries, preserve ~/ if original prefix was ~/
-					if (displayPrefix.startsWith("~")) {
-						relativePath = `~/${name}`;
-					} else {
-						relativePath = name;
-					}
-				}
+				const relativePath = `${displayDirectoryPrefix}${name}`;
 
 				const pathValue = isDirectory ? `${relativePath}/` : relativePath;
 				const value = buildCompletionValue(pathValue, {
@@ -833,6 +827,9 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	async #getFuzzyFileSuggestions(query: string, options: { isQuotedPrefix: boolean }): Promise<AutocompleteItem[]> {
 		try {
 			const scopedQuery = await this.#resolveScopedFuzzyQuery(query);
+			if (query.includes("/") && !scopedQuery) {
+				return [];
+			}
 			const searchPath = scopedQuery?.baseDir ?? this.#basePath;
 			const fuzzyQuery = scopedQuery?.query ?? query;
 			const result = await (await fuzzyFindNative())(buildAutocompleteFuzzyDiscoveryProfile(fuzzyQuery, searchPath));

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -143,6 +143,22 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(values).not.toContain("@../outside/nested/deeper/zzz.ts");
 			expect(values.some(value => value.includes("alpha-local.ts"))).toBe(false);
 		});
+
+		it("resolves an NFC parent component without falling back to sibling directories", async () => {
+			const nfdParent = "\u1112\u1161\u11AB";
+			const nfcParent = nfdParent.normalize("NFC");
+			const decoyParent = `${nfcParent}-decoy`;
+			fs.mkdirSync(path.join(baseDir, nfdParent));
+			fs.mkdirSync(path.join(baseDir, decoyParent));
+			fs.writeFileSync(path.join(baseDir, nfdParent, "target.ts"), "export const target = 1;\n");
+			fs.writeFileSync(path.join(baseDir, decoyParent, "target.ts"), "export const decoy = 1;\n");
+
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = `@${nfcParent}/target`;
+			const result = await provider.getSuggestions([line], 0, line.length);
+
+			expect(result?.items.map(item => item.value)).toEqual([`@${nfdParent}/target.ts`]);
+		});
 	});
 	describe("dot-slash path completion", () => {
 		let baseDir: string;
@@ -217,6 +233,56 @@ describe("CombinedAutocompleteProvider", () => {
 			const result = await provider.getForceFileSuggestions([line], 0, line.length);
 			const values = result?.items.map(item => item.value) ?? [];
 			expect(values).toContain(`./${nfdDirectory}/${nfdName}`);
+		});
+
+		it("keeps normalized directory completions stable across the directory cache", async () => {
+			fs.mkdirSync(path.join(baseDir, nfdDirectory));
+			fs.writeFileSync(path.join(baseDir, nfdDirectory, nfdName), "content\n");
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = `./${nfdDirectory.normalize("NFC")}/`;
+
+			const first = await provider.getForceFileSuggestions([line], 0, line.length);
+			const second = await provider.getForceFileSuggestions([line], 0, line.length);
+
+			expect(first?.items.map(item => item.value)).toEqual([`./${nfdDirectory}/${nfdName}`]);
+			expect(second?.items.map(item => item.value)).toEqual([`./${nfdDirectory}/${nfdName}`]);
+		});
+
+		it("preserves exact on-disk spelling across mixed NFC/NFD parent components", async () => {
+			const outerNfd = nfdDirectory;
+			const innerNfd = nfdName.slice(0, -4);
+			const childNfd = `${nfdDirectory}${innerNfd}.txt`;
+			const outerNfc = outerNfd.normalize("NFC");
+			const innerNfc = innerNfd.normalize("NFC");
+			const childNfc = childNfd.normalize("NFC");
+			fs.mkdirSync(path.join(baseDir, outerNfd, innerNfd), { recursive: true });
+			fs.writeFileSync(path.join(baseDir, outerNfd, innerNfd, childNfd), "content\n");
+
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = `./${outerNfc}/${innerNfc}/${childNfc}`;
+			const result = await provider.getForceFileSuggestions([line], 0, line.length);
+
+			expect(result?.items.map(item => item.value)).toEqual([`./${outerNfd}/${innerNfd}/${childNfd}`]);
+		});
+
+		it("stats symlink children relative to the resolved normalized parent", async () => {
+			const nfcParent = nfdDirectory.normalize("NFC");
+			const parentPath = path.join(baseDir, nfdDirectory);
+			const targetPath = path.join(baseDir, "symlink-target");
+			fs.mkdirSync(parentPath);
+			fs.mkdirSync(targetPath);
+			fs.writeFileSync(path.join(targetPath, "child.txt"), "content\n");
+			try {
+				fs.symlinkSync(targetPath, path.join(parentPath, "linked"), "dir");
+			} catch {
+				return;
+			}
+
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = `./${nfcParent}/lin`;
+			const result = await provider.getForceFileSuggestions([line], 0, line.length);
+
+			expect(result?.items.map(item => item.value)).toContain(`./${nfdDirectory}/linked/`);
 		});
 	});
 });


### PR DESCRIPTION
## What

Fix the post-merge PR #4997 autocomplete blockers with bounded component-wise NFC/NFD parent resolution.

- Preserve exact on-disk parent and child spellings.
- Keep `./`, `../`, `~/`, absolute, nested relative, Windows drive, UNC, and separator forms intact.
- Resolve scoped `@` parents without root fallback or sibling leakage.
- Stat symlink children against resolved directories.
- Cover mixed normalization and exact completion regressions.

## Testing

- `bun test packages/tui/test/autocomplete.test.ts` — 48 passed
- `bun --cwd=packages/tui run check` — passed
- `cargo test -p pi-natives fd::tests -- --nocapture` — 6 passed
- `cargo check -p pi-natives` — passed
- `cargo fmt --all -- --check` — passed

## Risk classification

- [x] `low-risk` — narrow fix-forward with focused regression coverage
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:7e48df4adf62d0e03da59b3ee216c839209f153b18b5ed2a64ed1a8b0d6734b9 reviewer:human reviewer-id:Yeachan-Heo evidence:glm-gpt-compatible review evidence, focused TUI and native regression suites, exact-head CI
```

- [x] Target branch is `dev`
- [x] Tested locally
- [x] Verdict is bound to exact base `ea18bcf1a8c1720753fcd73a6c565fc8d3351c38` and exact head `b0769ec26acb7038d858c1b18def6df645f88236`\n