### PR TITLE
feat(tui): add Hangul chosung matching to fuzzy file search

### DIFF
--- a/crates/pi-natives/src/fd.rs
+++ b/crates/pi-natives/src/fd.rs
@@ -69,6 +69,37 @@ fn normalize_fuzzy_text(value: &str) -> String {
 		.collect()
 }
 
+const HANGUL_SYLLABLE_BASE: u32 = 0xac00;
+const HANGUL_SYLLABLE_COUNT: u32 = 11_172;
+const SYLLABLES_PER_INITIAL: u32 = 588;
+
+/// Keyboard-typed compatibility jamo (U+3131 block) for each of the 19
+/// Hangul initial consonants, indexed by a syllable's initial-consonant index.
+const INITIAL_COMPAT_JAMO: [char; 19] = [
+	'ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ',
+	'ㅌ', 'ㅍ', 'ㅎ',
+];
+
+fn hangul_initial_jamo(ch: char) -> Option<char> {
+	let offset = (ch as u32).checked_sub(HANGUL_SYLLABLE_BASE)?;
+	if offset >= HANGUL_SYLLABLE_COUNT {
+		return None;
+	}
+	Some(INITIAL_COMPAT_JAMO[(offset / SYLLABLES_PER_INITIAL) as usize])
+}
+
+/// A query char matches a target char literally, or — when the query char is a
+/// bare consonant jamo — by the target syllable's initial consonant (초성
+/// 검색).
+#[allow(
+	clippy::suspicious_operation_groupings,
+	reason = "the asymmetry is intended: a bare jamo query char matches the target syllable's \
+	          initial"
+)]
+fn fuzzy_char_matches(query_ch: char, target_ch: char) -> bool {
+	query_ch == target_ch || hangul_initial_jamo(target_ch) == Some(query_ch)
+}
+
 fn fuzzy_subsequence_score(query_chars: &[char], target: &str) -> u32 {
 	if query_chars.is_empty() {
 		return 1;
@@ -80,7 +111,7 @@ fn fuzzy_subsequence_score(query_chars: &[char], target: &str) -> u32 {
 		if query_index >= query_chars.len() {
 			break;
 		}
-		if query_chars[query_index] == target_ch {
+		if fuzzy_char_matches(query_chars[query_index], target_ch) {
 			if let Some(last_index) = last_match_index
 				&& target_index > last_index + 1
 			{
@@ -296,5 +327,84 @@ mod tests {
 	#[test]
 	fn nfc_normalize_borrows_composed_text() {
 		assert!(matches!(nfc_normalize("plain/ascii.txt"), Cow::Borrowed(_)));
+	}
+
+	#[test]
+	fn chosung_query_matches_syllable_initials() {
+		assert_eq!(score("\u{D55C}\u{AE00}.txt", "\u{314E}\u{3131}"), 90);
+	}
+
+	#[test]
+	fn chosung_query_matches_nfd_file_name() {
+		let nfd = "\u{1112}\u{1161}\u{11AB}\u{1100}\u{1173}\u{11AF}.txt";
+		assert_eq!(score(nfd, "\u{314E}\u{3131}"), 90);
+	}
+
+	#[test]
+	fn chosung_mixed_with_full_syllables() {
+		assert_eq!(score("\u{D55C}\u{AE00}.txt", "\u{314E}\u{AE00}"), 90);
+		assert_eq!(score("\u{D55C}\u{AE00}.txt", "\u{D55C}\u{3131}"), 90);
+	}
+
+	#[test]
+	fn chosung_double_consonants() {
+		assert!(score("\u{B538}\u{AE30}.txt", "\u{3138}\u{3131}") > 0);
+		assert!(score("\u{C4F0}\u{AE30}.md", "\u{3146}") > 0);
+	}
+
+	#[test]
+	fn chosung_requires_subsequence_order() {
+		assert_eq!(score("\u{D55C}\u{AE00}.txt", "\u{3131}\u{314E}"), 0);
+	}
+
+	#[test]
+	fn chosung_rejects_absent_initials() {
+		assert_eq!(score("\u{D55C}\u{AE00}.txt", "\u{3134}"), 0);
+	}
+
+	#[test]
+	fn chosung_covers_syllable_block_boundaries() {
+		assert!(score("\u{AC00}.txt", "\u{3131}") > 0);
+		assert!(score("\u{D7A3}.txt", "\u{314E}") > 0);
+	}
+
+	#[test]
+	fn vowel_jamo_only_matches_literally() {
+		assert_eq!(score("\u{D55C}\u{AE00}.txt", "\u{314F}"), 0);
+		assert!(score("\u{314F}note.txt", "\u{314F}") > 0);
+	}
+
+	#[test]
+	fn literal_jamo_file_name_outranks_chosung_match() {
+		let literal = score("\u{314E}\u{3131}.txt", "\u{314E}\u{3131}");
+		let chosung = score("\u{D55C}\u{AE00}.txt", "\u{314E}\u{3131}");
+		assert_eq!(literal, 100);
+		assert!(literal > chosung);
+	}
+
+	#[test]
+	fn chosung_matches_path_segments_for_path_queries() {
+		assert!(score("\u{D55C}\u{AE00}/readme.md", "\u{314E}\u{3131}/read") > 0);
+		assert_eq!(score("\u{D55C}\u{AE00}/readme.md", "\u{314E}\u{3131}"), 0);
+	}
+
+	#[test]
+	fn chosung_gap_penalty_prefers_adjacent_matches() {
+		let adjacent = score("\u{D55C}\u{AE00}\u{BAA8}\u{C74C}.txt", "\u{314E}\u{3131}");
+		let gapped = score("\u{D55C}\u{AE00}\u{BAA8}\u{C74C}.txt", "\u{314E}\u{BAA8}");
+		assert!(adjacent > gapped);
+		assert!(gapped > 0);
+	}
+
+	#[test]
+	fn hangul_initial_jamo_maps_all_nineteen_initials() {
+		for (index, jamo) in INITIAL_COMPAT_JAMO.iter().enumerate() {
+			let syllable =
+				char::from_u32(HANGUL_SYLLABLE_BASE + index as u32 * SYLLABLES_PER_INITIAL).unwrap();
+			assert_eq!(hangul_initial_jamo(syllable), Some(*jamo));
+		}
+		assert_eq!(hangul_initial_jamo('a'), None);
+		assert_eq!(hangul_initial_jamo('\u{314E}'), None);
+		assert_eq!(hangul_initial_jamo('\u{1112}'), None);
 	}
 }

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `fuzzyFind` subsequence scoring supports Hangul chosung (초성) matching: a bare consonant jamo in the query matches any syllable with that initial consonant. Exact, prefix, and contains tiers are unchanged, so literal matches keep outranking chosung matches.
+
 ### Fixed
 
 - `fuzzyFind` NFC-normalizes queries and candidate paths before scoring so composed (NFC) queries match decomposed (NFD) file names as returned by macOS volumes.

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `@` fuzzy file search supports Hangul chosung (초성) matching: a bare consonant matches any syllable with that initial, so `@ㅎㄱ` finds `한글.txt`. Literal and full-syllable matches keep ranking above chosung matches.
+
 ### Fixed
 
 - Path autocomplete matches decomposed (NFD) file names against composed (NFC) input. Composer keystrokes are NFC-normalized while macOS volumes commonly return Hangul and other composed scripts in NFD, so `@한` found nothing even though `한글.txt` existed; both the directory-listing prefix match and the fuzzy filter now compare NFC forms while completion values keep the on-disk name. The native fuzzy finder applies the same normalization to queries and candidates.

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -117,9 +117,19 @@ function buildCompletionValue(
 	return `${openQuote}${path}${closeQuote}`;
 }
 
+const HANGUL_INITIAL_COMPAT_JAMO = "ㄱㄲㄴㄷㄸㄹㅁㅂㅃㅅㅆㅇㅈㅉㅊㅋㅌㅍㅎ";
+
+function hangulInitialJamo(char: string): string | undefined {
+	const offset = char.charCodeAt(0) - 0xac00;
+	if (offset < 0 || offset >= 11172) return undefined;
+	return HANGUL_INITIAL_COMPAT_JAMO[Math.floor(offset / 588)];
+}
+
 /**
  * Check if query is a subsequence of target (fuzzy match).
  * "wig" matches "skill:wig" because w-i-g appear in order.
+ * A bare Hangul consonant also matches a syllable's initial (초성 검색),
+ * so "ㅎㄱ" matches "한글".
  */
 function fuzzyMatch(query: string, target: string): boolean {
 	if (query.length === 0) return true;
@@ -127,7 +137,9 @@ function fuzzyMatch(query: string, target: string): boolean {
 
 	let qi = 0;
 	for (let ti = 0; ti < target.length && qi < query.length; ti++) {
-		if (query[qi] === target[ti]) qi++;
+		const queryChar = query[qi] as string;
+		const targetChar = target[ti] as string;
+		if (queryChar === targetChar || hangulInitialJamo(targetChar) === queryChar) qi++;
 	}
 	return qi === query.length;
 }

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -219,6 +219,79 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(values).toContain(`./${nfdDirectory}/${nfdName}`);
 		});
 	});
+
+	describe("hangul chosung fuzzy matching", () => {
+		let baseDir: string;
+		const hangulName = "\uD55C\uAE00.txt";
+
+		beforeEach(() => {
+			baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "autocomplete-chosung-test-"));
+		});
+
+		afterEach(() => {
+			fs.rmSync(baseDir, { recursive: true, force: true });
+		});
+
+		it("matches syllable initials from a bare-consonant @ query", async () => {
+			fs.writeFileSync(path.join(baseDir, hangulName), "content\n");
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = "@\u314E\u3131";
+			const result = await provider.getSuggestions([line], 0, line.length);
+			const values = result?.items.map(item => item.value) ?? [];
+			expect(values).toContain(`@${hangulName}`);
+		});
+
+		it("matches chosung against NFD-stored file names", async () => {
+			const nfdName = "\u1112\u1161\u11AB\u1100\u1173\u11AF.txt";
+			fs.writeFileSync(path.join(baseDir, nfdName), "content\n");
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = "@\u314E\u3131";
+			const result = await provider.getSuggestions([line], 0, line.length);
+			const values = result?.items.map(item => item.value) ?? [];
+			expect(values).toContain(`@${nfdName}`);
+		});
+
+		it("mixes chosung with full syllables in one query", async () => {
+			fs.writeFileSync(path.join(baseDir, hangulName), "content\n");
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = "@\u314E\uAE00";
+			const result = await provider.getSuggestions([line], 0, line.length);
+			const values = result?.items.map(item => item.value) ?? [];
+			expect(values).toContain(`@${hangulName}`);
+		});
+
+		it("does not match syllables whose initials differ", async () => {
+			fs.writeFileSync(path.join(baseDir, hangulName), "content\n");
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = "@\u3134\u3137";
+			const result = await provider.getSuggestions([line], 0, line.length);
+			const values = result?.items.map(item => item.value) ?? [];
+			expect(values).not.toContain(`@${hangulName}`);
+		});
+
+		it("ranks a literal jamo file name above a chosung match", async () => {
+			const literalName = "\u314E\u3131.txt";
+			fs.writeFileSync(path.join(baseDir, hangulName), "content\n");
+			fs.writeFileSync(path.join(baseDir, literalName), "content\n");
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = "@\u314E\u3131";
+			const result = await provider.getSuggestions([line], 0, line.length);
+			const values = result?.items.map(item => item.value) ?? [];
+			expect(values.indexOf(`@${literalName}`)).toBeGreaterThanOrEqual(0);
+			expect(values.indexOf(`@${hangulName}`)).toBeGreaterThan(values.indexOf(`@${literalName}`));
+		});
+
+		it("keeps ascii fuzzy queries unaffected", async () => {
+			fs.writeFileSync(path.join(baseDir, "history-search.ts"), "content\n");
+			fs.writeFileSync(path.join(baseDir, hangulName), "content\n");
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = "@histsr";
+			const result = await provider.getSuggestions([line], 0, line.length);
+			const values = result?.items.map(item => item.value) ?? [];
+			expect(values).toContain("@history-search.ts");
+			expect(values).not.toContain(`@${hangulName}`);
+		});
+	});
 });
 
 describe("slash command token classification", () => {


### PR DESCRIPTION
## What

`@` fuzzy file search supports Hangul chosung (초성) matching: a bare consonant jamo matches any syllable with that initial consonant, so `@ㅎㄱ` finds `한글.txt`. Implemented in the native scorer (`crates/pi-natives/src/fd.rs`) and mirrored in the TUI-side fuzzy filter (`packages/tui/src/autocomplete.ts`), the same two-lane structure as #4997.

## Why

Chosung search is the standard Korean fast-filter idiom (fzf plugins, editor extensions): typing initials is far faster than composing full syllables through an IME. The #4997 NFC normalization made syllables reach the scorer in composed form, which is exactly what the decomposition arithmetic needs — a syllable's initial is `(cp - 0xAC00) / 588` into a 19-entry compatibility-jamo table. The match extension lives only in the subsequence tier, so exact (120), prefix (100), and contains (80) keep outranking chosung matches (90 when adjacent), and ASCII queries never take the jamo branch. Mixed queries (`ㅎ글`, `한ㄱ`) work per-character; vowel jamo and non-initial consonants only match literally.

## Testing

- `crates/pi-natives/src/fd.rs`: 12 new unit tests — exact-score assertions for the chosung tier (90), NFD file names, mixed jamo/syllable queries, double consonants, subsequence order, absent-initial rejection, syllable block boundaries (`가`/`힣`), vowel-jamo literal-only matching, literal-jamo ranking above chosung, path-segment queries, gap penalty, and full 19-initial table coverage. `cargo test -p pi-natives fd::` 17 pass.
- `packages/tui/test/autocomplete.test.ts`: 6 new end-to-end cases through the built native (darwin-arm64) — chosung query, NFD-stored fixture, mixed query, negative match, literal-above-chosung ordering, ASCII regression. All literals pinned as `\uXXXX` escapes so normalization survives re-encoding.
- `cargo fmt --check`, `cargo clippy -p pi-natives --all-targets` (one reasoned `#[allow]` for a nursery false positive), `bun --cwd=packages/tui run check`, `bun --cwd=packages/natives test` (216 pass): all pass.
- Local file run is 49/50: the one failure is the pre-existing `traverses an NFD directory from an NFC path prefix` case, which fails identically on pristine `dev` on this macOS host and is unrelated to this change.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:fa5c9ade1845374eb664a1c2fd23a88ce6476033185c415919f44547e187888a reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/actions/runs/33038801087 + local cargo test -p pi-natives fd:: (17/17) and bun test packages/tui/test/autocomplete.test.ts (50/50)
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

