### PR TITLE
fix(ci): drop unsupported concurrency queue key from virtual integration lane

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -1004,8 +1004,9 @@ jobs:
   # selected risk canaries. A dispatch remains available for exact-head bootstrap
   # evidence. Every merge candidate shares one non-cancelling lane: a candidate
   # selects and materializes against dev, so overlapping candidates could otherwise
-  # validate against incompatible integration state. Keep up to 100 candidates
-  # pending instead of replacing an older pending validation.
+  # validate against incompatible integration state. GitHub's queue depth is fixed
+  # by capacity; candidates without a free slot wait pending instead of replacing
+  # an older pending validation.
   virtual-integration:
     name: Virtual integration validation
     needs: [affected-plan, affected]
@@ -1013,7 +1014,6 @@ jobs:
     concurrency:
       group: dev-ci-virtual-integration
       cancel-in-progress: false
-      queue: max
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     permissions:

--- a/scripts/dev-ci-guard-topology.test.ts
+++ b/scripts/dev-ci-guard-topology.test.ts
@@ -19,7 +19,7 @@ interface WorkflowJob {
 	needs?: string[];
 	if?: string;
 	env?: Record<string, string>;
-	concurrency?: { group: string; "cancel-in-progress"?: string | boolean; queue?: string };
+	concurrency?: { group: string; "cancel-in-progress"?: string | boolean };
 	steps: WorkflowStep[];
 }
 
@@ -187,7 +187,11 @@ describe("dev-ci Telegram daemon generation guard topology", () => {
 		const source = await Bun.file(".github/workflows/dev-ci.yml").text();
 		// Every candidate must serialize: each one selects a dev base and materializes
 		// a merge, so concurrent runs could validate incompatible integration states.
-		expect(source).toContain("group: dev-ci-virtual-integration\n      cancel-in-progress: false\n      queue: max");
+		// Candidates must serialize on one non-cancelling lane with schema-valid keys
+		// only: GitHub Actions concurrency has exactly `group` and
+		// `cancel-in-progress`; unknown keys make the workflow fail actionlint.
+		expect(source).toContain("group: dev-ci-virtual-integration\n      cancel-in-progress: false");
+		expect(source).not.toMatch(/^\s+queue:/m);
 		expect(source).toContain("Select authoritative terminal-green dev base");
 		expect(source).toContain("bun scripts/ci-virtual-integration.ts --select-base");
 		expect(source).toContain("CI_VI_BASE_SHA: ${{ steps.green-dev.outputs.base_sha }}");
@@ -244,6 +248,12 @@ describe("dev-ci Telegram daemon generation guard topology", () => {
 		expect(raw).toBeDefined();
 		expect(raw!.group).toBe("dev-ci-virtual-integration");
 		expect(raw!["cancel-in-progress"]).toBe(false);
-		expect(raw!.queue).toBe("max");
+		// Regression for the dev workflow_dispatch zero-step "Virtual integration
+		// validation" terminal-red incident burst (runs 33025650533..33038420275):
+		// the job block previously carried an unsupported `queue: max` key that is
+		// outside GitHub Actions' documented concurrency schema and made every
+		// static workflow gate fail. Concurrency admits only group +
+		// cancel-in-progress; queue depth is platform-controlled.
+		expect(Object.keys(raw!).sort()).toEqual(["cancel-in-progress", "group"]);
 	});
 });


### PR DESCRIPTION
Summary: Removes the schema-invalid queue key from the virtual-integration job concurrency block and pins the corrected topology in the guard tests. GitHub Actions documented job-level concurrency admits exactly group and cancel-in-progress; queue: max (added in 54c6c84d0) is not part of the schema, fails actionlint every scan, and leaves the dispatch-materialized lane's admission to undefined parser behavior. The issue-3350 invariant is preserved: one shared non-cancelling group still serializes every merge candidate. Evidence: workflow_dispatch Dev CI runs terminalize within seconds; all jobs skipped except Virtual integration validation = failure with 0 steps, runner_name null, no annotations, log blob BlobNotFound. Same-head push runs succeed with full step execution. 24+ failures across heads d6e62f0/82b4d23/213baf8/bd81be7/ea32bea/13450e5/975f043/08535da/103659a/ea18bcf incl. runs 33025650533, 33029010663, 33029486831, 33031378971, 33031546040, 33033325146, 33038420275. GitHub statuspage documented the same failure class on 2026-08-26 (Incident with Actions: jobs failed to start; Actions and Pull Requests incident 22:56Z-00:26Z). Validation: bun test scripts/dev-ci-guard-topology.test.ts 8 pass (pins now assert exactly cancel-in-progress and group keys); bun scripts/check-workflow-yaml.ts all 4 workflows parse; actionlint clean (previously unexpected key queue at 1016:7); bun test scripts/check-workflow-permissions.test.ts 16 pass. Risks: none beyond scope, one key deletion plus comment truthing plus test pins, serialization semantics unchanged.


## Risk classification

- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

gajae.pr-review-verdict.v1 merge-self-approved sha256:9061d2af37e8d8ea611bb10d87139d80aa7d529d86d52658ab0ef956694a0289 reviewer:human reviewer-id:Yeachan-Heo evidence:workflow-only key deletion; bun test scripts/dev-ci-guard-topology.test.ts 8 pass; check-workflow-yaml 4 workflows parse; actionlint clean; check-workflow-permissions 16 pass

Contract refresh: verdict and risk record re-bound to current dev base 1f4e4d0 after #5007 merge.
