### PR TITLE
fix(ai): let stored login credentials outrank env-sourced models.yml apiKeyEnv overrides

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -732,10 +732,14 @@ Extensions can register providers at runtime (`pi.registerProvider(...)`), inclu
 When requesting a key for a provider, effective order is:
 
 1. Runtime override (CLI `--api-key`)
-2. Stored API key credential in `agent.db`
-3. Stored OAuth credential in `agent.db` (with refresh)
-4. Environment variable mapping (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.)
-5. ModelRegistry fallback resolver (provider `apiKey` from `models.yml`, env-name-or-literal semantics)
+2. `models.yml` `providers.<name>.apiKey` literal pin
+3. Stored API key credential in `agent.db` (written by `auth login`)
+4. `models.yml` `providers.<name>.apiKeyEnv` indirection — a pointer to a key,
+   not a pinned value, so a stored login credential outranks it; it still
+   outranks stored OAuth credentials
+5. Stored OAuth credential in `agent.db` (with refresh)
+6. Environment variable mapping (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.)
+7. ModelRegistry fallback resolver (provider `apiKey` from `models.yml`, env-name-or-literal semantics)
 
 `models.yml` `apiKey` behavior:
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1231,6 +1231,14 @@ export class AuthStorage {
 	#data: Map<string, StoredCredential[]> = new Map();
 	#runtimeOverrides: Map<string, string> = new Map();
 	#configOverrides: Map<string, string> = new Map();
+	/**
+	 * Providers whose config override was resolved from a models.yml `apiKeyEnv`
+	 * indirection rather than a literal `apiKey` pin. An env pointer is not a
+	 * pinned secret: the pointed-to value (shell env, trusted env files) can go
+	 * stale silently, and the 401 rotation machinery cannot repair it. A stored
+	 * api_key credential from `auth login` therefore outranks it.
+	 */
+	#configOverrideEnvSourced: Set<string> = new Set();
 	#runtimeCredentialSelectors: Map<string, AuthCredentialSelector> = new Map();
 	/** Soft runtime credential preference per provider; quota failures may rotate away from it. */
 	#runtimePreferredCredentialSelectors: Map<string, AuthCredentialSelector> = new Map();
@@ -1926,10 +1934,22 @@ export class AuthStorage {
 	 *
 	 * Lower priority than {@link setRuntimeApiKey} so a CLI `--api-key`
 	 * still wins for the duration of a single invocation.
+	 *
+	 * `options.envSourced` marks the value as resolved from a models.yml
+	 * `apiKeyEnv` indirection. Unlike a literal pin, an env pointer only says
+	 * where to look for a key; when the user has since run `auth login`, the
+	 * stored api_key credential is the fresher, actively-managed secret and
+	 * wins over the indirection (stored OAuth credentials still yield, so a
+	 * custom-endpoint bearer is never replaced by an upstream OAuth token).
 	 */
-	setConfigApiKey(provider: string, apiKey: string): void {
+	setConfigApiKey(provider: string, apiKey: string, options: { envSourced?: boolean } = {}): void {
 		const storageProvider = resolveOAuthStorageProvider(provider);
 		this.#configOverrides.set(storageProvider, apiKey);
+		if (options.envSourced) {
+			this.#configOverrideEnvSourced.add(storageProvider);
+		} else {
+			this.#configOverrideEnvSourced.delete(storageProvider);
+		}
 		this.#bumpGeneration("set-config-api-key", storageProvider);
 	}
 
@@ -1938,6 +1958,7 @@ export class AuthStorage {
 	 */
 	removeConfigApiKey(provider: string): void {
 		const storageProvider = resolveOAuthStorageProvider(provider);
+		this.#configOverrideEnvSourced.delete(storageProvider);
 		if (this.#configOverrides.delete(storageProvider)) this.#bumpGeneration("remove-config-api-key", storageProvider);
 	}
 
@@ -1947,6 +1968,7 @@ export class AuthStorage {
 	 */
 	clearConfigApiKeys(): void {
 		const providers = [...this.#configOverrides.keys()];
+		this.#configOverrideEnvSourced.clear();
 		if (providers.length === 0) return;
 		this.#configOverrides.clear();
 		for (const provider of providers) this.#bumpGeneration("clear-config-api-keys", provider);
@@ -5165,9 +5187,16 @@ export class AuthStorage {
 		if (runtimeKey) return runtimeKey;
 
 		const configKey = this.#configOverrides.get(provider);
-		if (configKey) return configKey;
+		if (configKey && !this.#configOverrideEnvSourced.has(provider)) return configKey;
 
 		const selectedCredential = this.#resolveSelectedStoredCredential(provider, undefined, undefined);
+		if (configKey) {
+			// Env-sourced (`apiKeyEnv`) override: same precedence as getApiKey —
+			// a stored api_key credential from `auth login` wins, stored OAuth
+			// still yields to the indirection.
+			const storedApiKey = await this.#resolveStoredApiKeyOverEnvConfig(provider, selectedCredential, undefined);
+			return storedApiKey ?? configKey;
+		}
 		if (selectedCredential?.credential.type === "api_key") {
 			return this.#resolveStoredApiKey(provider, selectedCredential.credential.key);
 		}
@@ -5217,13 +5246,16 @@ export class AuthStorage {
 	 * Get API key for a provider.
 	 * Priority:
 	 * 1. Runtime override (CLI --api-key)
-	 * 2. Config override (models.yml `providers.<name>.apiKey`)
-	 * 3. Session-selected OAuth credential, when present
-	 * 4. Usable or unresolved API key from storage
-	 * 5. OAuth token from storage (auto-refreshed)
-	 * 6. Previously unusable command-backed API key retry
-	 * 7. Environment variable
-	 * 8. Fallback resolver (models.yml custom providers, last-resort)
+	 * 2. Config override (models.yml `providers.<name>.apiKey` literal pin)
+	 * 3. Stored api_key credential from `auth login`, when the config override
+	 *    is only an `apiKeyEnv` indirection
+	 * 4. Config override sourced from models.yml `providers.<name>.apiKeyEnv`
+	 * 5. Session-selected OAuth credential, when present
+	 * 6. Usable or unresolved API key from storage
+	 * 7. OAuth token from storage (auto-refreshed)
+	 * 8. Previously unusable command-backed API key retry
+	 * 9. Environment variable
+	 * 10. Fallback resolver (models.yml custom providers, last-resort)
 	 */
 	async getApiKey(provider: string, sessionId?: string, options?: AuthApiKeyOptions): Promise<string | undefined> {
 		provider = resolveOAuthStorageProvider(provider);
@@ -5239,7 +5271,17 @@ export class AuthStorage {
 		// honor it instead of forwarding an upstream OAuth token that the proxy
 		// won't accept.
 		const configKey = this.#configOverrides.get(provider);
-		if (configKey) return configKey;
+		if (configKey) {
+			if (!this.#configOverrideEnvSourced.has(provider)) return configKey;
+			// The override is an `apiKeyEnv` indirection, not a pinned value. A
+			// stored api_key credential from `auth login` is actively managed
+			// (validated at login, rotated on 401), while the pointed-to env
+			// value can go stale with no recovery path — prefer the stored
+			// credential. Stored OAuth credentials still yield to the override.
+			const storedApiKey = await this.#resolveStoredApiKeyOverEnvConfig(provider, selectedCredential, sessionId);
+			if (storedApiKey) return storedApiKey;
+			return configKey;
+		}
 
 		if (selectedCredential?.credential.type === "api_key") {
 			this.#recordSessionCredential(provider, sessionId, "api_key", selectedCredential.index);
@@ -5293,6 +5335,38 @@ export class AuthStorage {
 		const envKey = getEnvApiKey(provider);
 		if (envKey) return envKey;
 		return this.#fallbackResolver?.(provider) ?? undefined;
+	}
+
+	/**
+	 * Resolve a stored api_key credential that outranks an env-sourced config
+	 * override (`apiKeyEnv`). Mirrors the api_key branches of {@link getApiKey}:
+	 * the selector-pinned credential first, then the round-robin/session pool.
+	 * Returns undefined when no stored api_key credential resolves, leaving the
+	 * env-sourced override in effect.
+	 */
+	async #resolveStoredApiKeyOverEnvConfig(
+		provider: string,
+		selectedCredential: ({ index: number } & StoredCredential) | undefined,
+		sessionId?: string,
+	): Promise<string | undefined> {
+		if (selectedCredential?.credential.type === "api_key") {
+			const resolved = await this.#resolveStoredApiKey(provider, selectedCredential.credential.key);
+			if (resolved) {
+				this.#recordSessionCredential(provider, sessionId, "api_key", selectedCredential.index);
+				return resolved;
+			}
+		}
+		const attemptedApiKeyIndices = new Set<number>();
+		for (;;) {
+			const apiKeySelection = this.#selectApiKeyCredential(provider, sessionId, attemptedApiKeyIndices);
+			if (!apiKeySelection) return undefined;
+			attemptedApiKeyIndices.add(apiKeySelection.index);
+			const resolved = await this.#resolveStoredApiKey(provider, apiKeySelection.credential.key);
+			if (resolved) {
+				this.#recordSessionCredential(provider, sessionId, "api_key", apiKeySelection.index);
+				return resolved;
+			}
+		}
 	}
 
 	/**
@@ -5621,7 +5695,9 @@ export class AuthStorage {
 	 *
 	 * Surfaces four layers, highest precedence first:
 	 *   1. Runtime override (`--api-key`).
-	 *   2. Config override (`models.yml` `providers.<name>.apiKey`).
+	 *   2. Config override (`models.yml` `providers.<name>.apiKey` literal pin,
+	 *      or an `apiKeyEnv` indirection when no stored api_key credential
+	 *      outranks it).
 	 *   3. Stored credential (the one this session is currently sticky to, or the
 	 *      one round-robin would pick next when no session id is supplied).
 	 *   4. Env var / fallback resolver — when no stored credential exists.
@@ -5633,7 +5709,12 @@ export class AuthStorage {
 			return "runtime override (--api-key)";
 		}
 		if (this.#configOverrides.has(provider)) {
-			return "config override (models.yml)";
+			// An `apiKeyEnv` indirection loses to a stored api_key credential
+			// (see getApiKey); describe the credential that actually wins.
+			const shadowed = this.#getStoredCredentials(provider).some(entry => entry.credential.type === "api_key");
+			if (!this.#configOverrideEnvSourced.has(provider) || !shadowed) {
+				return "config override (models.yml)";
+			}
 		}
 
 		const baseLabel = this.#sourceLabel ?? "local store";

--- a/packages/ai/test/auth-storage-config-override.test.ts
+++ b/packages/ai/test/auth-storage-config-override.test.ts
@@ -122,4 +122,68 @@ describe("AuthStorage config-override apiKey", () => {
 			expect(authStorage.describeCredentialSource("anthropic")).toBe("config override (models.yml)");
 		});
 	});
+	test("env-sourced override yields to a stored login api_key", async () => {
+		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
+			if (!authStorage) throw new Error("test setup failed");
+			await authStorage.set("anthropic", [{ type: "api_key", key: "stored-login-key" }]);
+			authStorage.setConfigApiKey("anthropic", "stale-env-key", { envSourced: true });
+
+			expect(await authStorage.getApiKey("anthropic")).toBe("stored-login-key");
+			expect(await authStorage.peekApiKey("anthropic")).toBe("stored-login-key");
+		});
+	});
+
+	test("env-sourced override applies when no stored credential exists", async () => {
+		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
+			if (!authStorage) throw new Error("test setup failed");
+			authStorage.setConfigApiKey("anthropic", "env-key", { envSourced: true });
+
+			expect(await authStorage.getApiKey("anthropic")).toBe("env-key");
+			expect(await authStorage.peekApiKey("anthropic")).toBe("env-key");
+		});
+	});
+
+	test("env-sourced override still beats a stored OAuth credential", async () => {
+		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
+			if (!authStorage) throw new Error("test setup failed");
+			await seedOAuth("anthropic", "oauth-from-broker");
+			authStorage.setConfigApiKey("anthropic", "gateway-bearer-from-env", { envSourced: true });
+
+			expect(await authStorage.getApiKey("anthropic")).toBe("gateway-bearer-from-env");
+			expect(await authStorage.peekApiKey("anthropic")).toBe("gateway-bearer-from-env");
+		});
+	});
+
+	test("literal config override still beats a stored login api_key", async () => {
+		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
+			if (!authStorage) throw new Error("test setup failed");
+			await authStorage.set("anthropic", [{ type: "api_key", key: "stored-login-key" }]);
+			authStorage.setConfigApiKey("anthropic", "literal-pin");
+
+			expect(await authStorage.getApiKey("anthropic")).toBe("literal-pin");
+			expect(await authStorage.peekApiKey("anthropic")).toBe("literal-pin");
+		});
+	});
+
+	test("re-pinning a literal key after an env-sourced override restores top priority", async () => {
+		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
+			if (!authStorage) throw new Error("test setup failed");
+			await authStorage.set("anthropic", [{ type: "api_key", key: "stored-login-key" }]);
+			authStorage.setConfigApiKey("anthropic", "stale-env-key", { envSourced: true });
+			expect(await authStorage.getApiKey("anthropic")).toBe("stored-login-key");
+
+			authStorage.setConfigApiKey("anthropic", "literal-pin");
+			expect(await authStorage.getApiKey("anthropic")).toBe("literal-pin");
+		});
+	});
+
+	test("describeCredentialSource reports the stored credential that shadows an env-sourced override", async () => {
+		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
+			if (!authStorage) throw new Error("test setup failed");
+			await authStorage.set("anthropic", [{ type: "api_key", key: "stored-login-key" }]);
+			authStorage.setConfigApiKey("anthropic", "stale-env-key", { envSourced: true });
+
+			expect(authStorage.describeCredentialSource("anthropic")).toContain("api_key");
+		});
+	});
 });

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2154,7 +2154,9 @@ export class ModelRegistry {
 				});
 				if (localCompatResolvedKey) {
 					this.#customProviderApiKeys.set(providerName, localCompatResolvedKey);
-					this.authStorage.setConfigApiKey(providerName, localCompatResolvedKey);
+					this.authStorage.setConfigApiKey(providerName, localCompatResolvedKey, {
+						envSourced: !localOpenAICompat.apiKey,
+					});
 				} else {
 					keylessProviders.add(providerName);
 					this.#optionalAuthProviders.add(providerName);
@@ -2216,7 +2218,9 @@ export class ModelRegistry {
 						? resolveApiKeyEnvConfig(providerConfig.apiKeyEnv)
 						: undefined;
 				if (resolved) this.#customProviderApiKeys.set(providerName, resolved);
-				if (resolved) this.authStorage.setConfigApiKey(providerName, resolved);
+				if (resolved) {
+					this.authStorage.setConfigApiKey(providerName, resolved, { envSourced: !providerConfig.apiKey });
+				}
 			}
 
 			// Parse per-model overrides
@@ -3806,7 +3810,9 @@ export class ModelRegistry {
 						? resolveApiKeyEnvConfig(providerConfig.apiKeyEnv)
 						: undefined;
 				if (resolved) this.#customProviderApiKeys.set(providerName, resolved);
-				if (resolved) this.authStorage.setConfigApiKey(providerName, resolved);
+				if (resolved) {
+					this.authStorage.setConfigApiKey(providerName, resolved, { envSourced: !providerConfig.apiKey });
+				}
 			}
 			for (const modelDef of modelDefs) {
 				const providerCompat = providerConfig.disableStrictTools
@@ -4547,7 +4553,7 @@ export class ModelRegistry {
 			return;
 		}
 		this.#customProviderApiKeys.set(provider, resolved);
-		this.authStorage.setConfigApiKey(provider, resolved);
+		this.authStorage.setConfigApiKey(provider, resolved, { envSourced: true });
 	}
 
 	async #peekApiKeyForProvider(


### PR DESCRIPTION
## Problem

A `models.yml` `providers.<name>.apiKeyEnv` entry is an **indirection** — a pointer to a key living in the process env or trusted env files (`~/.gjc/agent/.env`, etc.) — not a pinned secret. Today that indirection is registered via `setConfigApiKey` and beats *everything* in `AuthStorage.getApiKey`, including credentials stored by a successful interactive `auth login`.

When the pointed-to value goes stale, the failure is unrecoverable from the user's side:

1. User runs `auth login alibaba-token-plan` → key validated against the live endpoint → stored in `agent.db` → UI reports success.
2. Every actual request still sends the stale env-file value → `401 Invalid API-key provided`.
3. The 401 credential-invalidation/rotation path can only disable *stored* rows — it cannot repair an env file, so the retry fails identically, forever.

Reproduced live: a valid login credential (verified against `token-plan.ap-southeast-1.maas.aliyuncs.com`) sat in `agent.db` while a revoked key from a July-dated `~/.gjc/agent/.env` line — referenced by an old-onboarding `apiKeyEnv: ALIBABA_TOKEN_PLAN_API_KEY` models.yml entry — shadowed it. Removing the stale line instantly fixed requests; with this patch, the stored credential wins even while the stale env value is still present.

## Change

`AuthStorage` now tracks whether a config override came from an `apiKeyEnv` indirection (`setConfigApiKey(provider, key, { envSourced: true })`, wired at the three models.yml load sites and the rotating-env refresh in `ModelRegistry`).

New precedence in `getApiKey`/`peekApiKey`:

1. Runtime override (CLI `--api-key`)
2. Literal `models.yml` `apiKey` pin *(unchanged — still beats everything)*
3. **Stored api_key credential from `auth login`** *(new: outranks apiKeyEnv)*
4. Env-sourced `apiKeyEnv` indirection *(still outranks stored OAuth, so a custom-endpoint bearer is never replaced by an upstream OAuth token — the documented auth-gateway case)*
5. Stored OAuth → unusable-retry → env mapping → fallback resolver *(unchanged)*

An env-sourced override also becomes self-healing: if the stored login credential is itself wrong, the existing 401 rotation disables it and the next attempt falls through to the env value.

`describeCredentialSource` reports the credential that actually wins, and `docs/models.md` gains the previously undocumented config-override layers in the resolution-order list.

## Tests

`packages/ai/test/auth-storage-config-override.test.ts` — 6 new cases: env-sourced yields to stored login key (getApiKey + peekApiKey), env-sourced applies with no stored credential, env-sourced still beats stored OAuth, literal pin still beats stored login key, literal re-pin after env-sourced restores top priority, describeCredentialSource reports the shadowing stored credential.

- `bun test test/auth-storage-*.test.ts` — 186 pass / 0 fail
- `tsc --noEmit` clean for `@gajae-code/ai` and `@gajae-code/coding-agent`
- `biome check` clean on all changed files
- End-to-end: `ModelRegistry` over a real user `models.yml` + stale env value + stored login credential now resolves the stored credential (was: stale env key)



- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

gajae.pr-review-verdict.v1 merge-approved sha256:fe24104c8d8ccf5cf798ef1ea47230977ce0548e15e920ab37f864f9bbfa5560 reviewer:architect reviewer-id:Yeachan-Heo evidence:rebased contributor patch validated against origin/dev; focused auth-storage tests pass; exact-head review pending

<!-- exact-head contract refresh -->