### PR TITLE
fix(tmux): retry on the default socket when an inherited $TMUX is unreachable

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
@@ -305,20 +305,54 @@ function parseSessionLine(line: string): GjcTmuxSessionStatus | null {
 	};
 }
 
+/** tmux failure shapes that mean "this socket has no server", not "tmux is broken". */
+function isMissingServerFailure(message: string): boolean {
+	return (
+		message.includes("no server running") ||
+		message.includes("failed to connect to server") ||
+		message.includes("error connecting to")
+	);
+}
+
+/**
+ * `$TMUX` is inherited from whatever launched gjc and names the socket tmux
+ * talks to. Terminal hosts that emulate tmux for their own agents can export a
+ * `$TMUX` pointing at a socket they never created, and tmux then fails with
+ * `error connecting to <socket>` — the same message shape as a legitimate
+ * "no server" miss. Returning the socket path lets callers tell the two apart
+ * instead of reporting zero sessions while sessions are live on the default
+ * socket.
+ */
+function inheritedTmuxSocketPath(env: NodeJS.ProcessEnv): string | null {
+	const socket = env.TMUX?.split(",")[0]?.trim();
+	return socket ? socket : null;
+}
+
+function envWithoutInheritedTmux(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+	const withoutTmux: NodeJS.ProcessEnv = { ...env };
+	delete withoutTmux.TMUX;
+	return withoutTmux;
+}
+
 function runListSessions(format: string, env: NodeJS.ProcessEnv = process.env): string[] {
 	let output = "";
 	try {
 		output = runTmux(["list-sessions", "-F", format], env);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
-		if (
-			message.includes("no server running") ||
-			message.includes("failed to connect to server") ||
-			message.includes("error connecting to")
-		) {
-			return [];
+		if (!isMissingServerFailure(message)) throw error;
+		const inheritedSocket = inheritedTmuxSocketPath(env);
+		// A miss on the default socket is a real empty list; only the inherited
+		// socket is suspect, so retry without it before concluding there is
+		// nothing to list.
+		if (!inheritedSocket || !message.includes(inheritedSocket)) return [];
+		try {
+			output = runTmux(["list-sessions", "-F", format], envWithoutInheritedTmux(env));
+		} catch (retryError) {
+			const retryMessage = retryError instanceof Error ? retryError.message : String(retryError);
+			if (isMissingServerFailure(retryMessage)) return [];
+			throw retryError;
 		}
-		throw error;
 	}
 	const lines = output
 		.split("\n")

--- a/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-sessions.test.ts
@@ -182,6 +182,58 @@ describe("GJC tmux session management", () => {
 		expect(listGjcTmuxSessions()).toEqual([]);
 	});
 
+	// A terminal host that emulates tmux for its own agents can export a `$TMUX`
+	// naming a socket it never created. tmux then fails with `error connecting
+	// to <socket>`, which shares its shape with a legitimate "no server" miss —
+	// so gjc used to report zero sessions while sessions were live on the
+	// default socket.
+	it("retries on the default socket when the inherited $TMUX socket is unreachable", () => {
+		const inheritedSocket = "/tmp/host-emulated/agent-team";
+		const sessionRow =
+			"gajae_code_abc\t1\t0\t1770000000\t1\troot\t2\t12345\tfeature/demo\tfeature-demo\t/repo-a\t\t\t\t\t\t$1";
+		const observedTmux: (string | undefined)[] = [];
+		spyOn(Bun, "spawnSync").mockImplementation(((command: unknown, options: unknown) => {
+			if (!spawnArgv(command).includes("list-sessions")) return spawnResult(0, "");
+			const inherited = (options as { env?: NodeJS.ProcessEnv } | undefined)?.env?.TMUX;
+			observedTmux.push(inherited);
+			if (inherited) return spawnResult(1, "", `error connecting to ${inheritedSocket} (No such file or directory)`);
+			return spawnResult(0, sessionRow);
+		}) as never);
+		clearPsmuxDetectionCache();
+
+		const sessions = listGjcTmuxSessions({ GJC_TMUX_COMMAND: "tmux-test", TMUX: `${inheritedSocket},0,1` });
+
+		expect(sessions.map(session => session.name)).toEqual(["gajae_code_abc"]);
+		expect(observedTmux[0]).toBe(`${inheritedSocket},0,1`);
+		expect(observedTmux).toContain(undefined);
+	});
+
+	it("still reports an empty list when the default socket has no server either", () => {
+		const inheritedSocket = "/tmp/host-emulated/agent-team";
+		spyOn(Bun, "spawnSync").mockImplementation(((command: unknown, options: unknown) => {
+			if (!spawnArgv(command).includes("list-sessions")) return spawnResult(0, "");
+			return (options as { env?: NodeJS.ProcessEnv } | undefined)?.env?.TMUX
+				? spawnResult(1, "", `error connecting to ${inheritedSocket} (No such file or directory)`)
+				: spawnResult(1, "", "no server running on /tmp/tmux-501/default");
+		}) as never);
+		clearPsmuxDetectionCache();
+
+		expect(listGjcTmuxSessions({ GJC_TMUX_COMMAND: "tmux-test", TMUX: `${inheritedSocket},0,1` })).toEqual([]);
+	});
+
+	it("does not retry when the failure does not name the inherited socket", () => {
+		let listCalls = 0;
+		spyOn(Bun, "spawnSync").mockImplementation(((command: unknown) => {
+			if (!spawnArgv(command).includes("list-sessions")) return spawnResult(0, "");
+			listCalls += 1;
+			return spawnResult(1, "", "no server running on /tmp/tmux-501/default");
+		}) as never);
+		clearPsmuxDetectionCache();
+
+		expect(listGjcTmuxSessions({ GJC_TMUX_COMMAND: "tmux-test" })).toEqual([]);
+		expect(listCalls).toBe(1);
+	});
+
 	it("reports provider-aware diagnostics before spawning when Windows has no multiplexer", async () => {
 		const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-tmux-sessions-test-"));
 		fixtureDirectories.push(stateDir);


### PR DESCRIPTION
## Problem

`runListSessions` treats three tmux stderr shapes as "there are no sessions":

```ts
message.includes("no server running") ||
message.includes("failed to connect to server") ||
message.includes("error connecting to")
```

The third one covers **two different states**:

1. the default socket has no server — a real empty list, and
2. the socket named by an inherited `$TMUX` does not exist — sessions may well be live on the default socket.

A terminal host that emulates tmux for its own agents (here: Orca's `agent-teams` feature) exports a `$TMUX` pointing at a socket it never created:

```
TMUX=/tmp/orca-claude-agent-teams/team-<uuid>,0,1     # no such file
```

Real tmux then answers:

```
$ tmux list-sessions
error connecting to /tmp/orca-claude-agent-teams/team-<uuid> (No such file or directory)
```

…which the allowlist swallows, so `gjc session list` reported **0 sessions while 5 were live** on the default socket:

```
$ env -u TMUX tmux list-sessions
gajae_code_main_mtazmfb6_k5itxyzs    1 windows (attached)
gajae_code_master_mtadeloa_brpnhdkp  1 windows (attached)
... 5 total
```

A silent wrong answer rather than an error, so nothing surfaces to the user.

## Fix

- Extract the allowlist into `isMissingServerFailure`.
- When the failure names the socket taken from `$TMUX` specifically, retry once with `$TMUX` removed before concluding the list is empty.
- A failure that names the default socket keeps the previous behaviour and spawns **no** second process.

This follows the precedent already in this file — the psmux `-F` fallback, whose comment notes that without it "gjc session list / status return an empty list on psmux even when sessions exist". The same class of problem, one case short: `$TMUX` inherited from a host that isn't the tmux we end up talking to.

## Tests

Three cases added to `test/gjc-runtime/tmux-sessions.test.ts`:

- retries on the default socket when the inherited `$TMUX` socket is unreachable, and asserts the second spawn carries no `TMUX`
- still reports an empty list when the default socket has no server either
- does not retry when the failure does not name the inherited socket (asserts exactly one `list-sessions` spawn)

```
bun test test/gjc-runtime/tmux-sessions.test.ts
 35 pass
 5 fail
```

The 5 failures are pre-existing on `upstream/main` in this environment (`Failed to load pi_natives native addon for darwin-arm64`); baseline on the same checkout without this change is **32 pass / 5 fail**, i.e. the same 5.

`bun run check:types` and `biome check` on both changed files are clean.

## Not in this PR

The same environment also crashes the process outright when the binary resolved as `tmux` is not tmux-class at all (a wrapper/shim that answers `tmux -V` but rejects real subcommands):

```
[Uncaught Exception] Error: tmux: unsupported command: list-sessions
    at run (/$bunfs/root/gjc-darwin-arm64:26238:1361)
```

That needs the capability probe in `psmux-detect.ts` strengthened past `-V`, plus classification instead of a raw rethrow in `runTmux`/`runListSessions`. Kept separate so this fix is not blocked on that design discussion. Happy to follow up.
