### PR TITLE
fix(worktree): use repo-local directory

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -506,9 +506,9 @@ LSP project configuration may control declarative matching, activation, and capa
 | `GJC_CONFIG_DIR`       | Config root dirname under home (default `.gjc`)                               |
 | `GJC_CODING_AGENT_DIR` | Full override for agent directory (default `~/<GJC_CONFIG_DIR or .gjc>/agent`). `gjc setup hermes --coding-agent-dir <abs-path>` renders it into the coordinator server env so bridge-spawned sessions share that broker; it is distinct from `GJC_COORDINATOR_MCP_STATE_ROOT`, which never selects the agent directory. |
 | `PWD`                 | Used when matching canonical current working directory in path helpers        |
-| `GJC_WORKTREE_DIR`     | Directory holding `--worktree` launch worktrees (default `{repo}.gajae-code-worktrees`) |
+| `GJC_WORKTREE_DIR`     | Directory holding `--worktree` launch worktrees (default `{repo}/.worktrees`) |
 
-`GJC_WORKTREE_DIR` is a path template. `{repo}` expands to the repository directory name, which keeps one exported value repo-scoped so two repositories that share a branch name never resolve to the same worktree. A relative value resolves against the repository's parent directory — the default's own shape — so `{repo}.worktrees` adopts an existing sibling bucket and `.worktrees` parks a hidden bucket beside the repository; an absolute value (or a leading `~/`) is used as given. An unset or blank value keeps the default bucket.
+`GJC_WORKTREE_DIR` is a path template. `{repo}` expands to the repository directory name, which keeps one exported value repo-scoped so two repositories that share a branch name never resolve to the same worktree. The default `{repo}/.worktrees` places managed worktrees inside the repository; the bucket must already be ignored by Git. A relative override resolves against the repository's parent directory, so `{repo}.worktrees` adopts an existing sibling bucket and `.worktrees` parks a hidden bucket beside the repository; an absolute value (or a leading `~/`) is used as given. An unset or blank value keeps the default bucket.
 
 ```sh
 # Reuse an existing <repo>.worktrees convention instead of a second bucket

--- a/docs/streamdeck-integration-guide-with-cmux.md
+++ b/docs/streamdeck-integration-guide-with-cmux.md
@@ -181,7 +181,7 @@ Do not prompt for a model profile here. Apply the profile after the GJC session 
 
 #### Frequent GJC project controls
 
-Bind the first two project keys from GJC session history, not operator-specific absolute paths. Merge `gjc sdk session list` with saved top-level session headers under the agent session store, canonicalize managed worktree paths such as `<repo>.gajae-code-worktrees/<name>` back to `<repo>`, discard non-existent and non-Git directories outside the user's home, count sessions per canonical repository, and display the top two repositories. The third key always opens `$HOME`.
+Bind the first two project keys from GJC session history, not operator-specific absolute paths. Merge `gjc sdk session list` with saved top-level session headers under the agent session store, canonicalize managed worktree paths such as `<repo>/.worktrees/<name>` (and legacy `<repo>.gajae-code-worktrees/<name>`) back to `<repo>`, discard non-existent and non-Git directories outside the user's home, count sessions per canonical repository, and display the top two repositories. The third key always opens `$HOME`.
 
 Each project key shows the repository basename and session count. Pressing it creates a terminal surface in that repository. The `HOME` key creates a terminal surface in the user's home directory. Leave the cmux tab name automatic so a later `gjc` launch can publish its authoritative `GJC:` title.
 
@@ -326,7 +326,7 @@ Every top-level GJC session publishes a loopback SDK discovery file:
 
 The file contains the session WebSocket URL and token. Connect with the token as a query parameter and never persist or log it elsewhere.
 
-Do not assume repositories are only one directory below a fixed workspace root. Resolve each live `gjc` process PID to its TTY and current working directory, then inspect that exact `<cwd>/.gjc/state/sdk/` directory. This includes managed `.gajae-code-worktrees` sessions.
+Do not assume repositories are only one directory below a fixed workspace root. Resolve each live `gjc` process PID to its TTY and current working directory, then inspect that exact `<cwd>/.gjc/state/sdk/` directory. This includes managed `.worktrees` sessions and legacy `.gajae-code-worktrees` sessions.
 
 When the focused session emits:
 

--- a/integrations/streamdeck-cmux/plugin/plugin.js
+++ b/integrations/streamdeck-cmux/plugin/plugin.js
@@ -130,7 +130,7 @@ async function discoverEndpoints() {
 }
 
 function canonicalProjectPath(value) {
-  return String(value || "").replace(/\.gajae-code-worktrees\/[^/]+$/, "");
+  return String(value || "").replace(/(?:\.gajae-code-worktrees|\.worktrees)\/[^/]+$/, "");
 }
 
 async function discoverFrequentProjects() {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `gjc update` now recognizes an already verified standalone binary during package-manager shim migration, avoiding repeated downloads and post-update work while clearly explaining the required PATH ordering.
 
 - The `ask` tool now rejects empty or whitespace-only custom answers on every local and remote input path. Remote invalid answers receive a visible explanation and are retried at most three times with an event-loop yield between attempts before the ask is cancelled; local empty custom input is never returned as a valid answer. (#5001)
+- GJC-managed launch worktrees now default to `<repo>/.worktrees/<slug>` instead of a `<repo>.gajae-code-worktrees` sibling beside the checkout, keeping each repository's isolated branches in one predictable local folder. Launch fails with an actionable diagnostic unless an in-repository bucket is ignored by Git, preventing nested worktrees from polluting the source checkout; external `GJC_WORKTREE_DIR` buckets and already registered sibling worktrees are unchanged.
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - The `ask` tool now rejects empty or whitespace-only custom answers on every local and remote input path. Remote invalid answers receive a visible explanation and are retried at most three times with an event-loop yield between attempts before the ask is cancelled; local empty custom input is never returned as a valid answer. (#5001)
 - GJC-managed launch worktrees now default to `<repo>/.worktrees/<slug>` instead of a `<repo>.gajae-code-worktrees` sibling beside the checkout, keeping each repository's isolated branches in one predictable local folder. Launch fails with an actionable diagnostic unless an in-repository bucket is ignored by Git, preventing nested worktrees from polluting the source checkout; external `GJC_WORKTREE_DIR` buckets and already registered sibling worktrees are unchanged.
+- Launch worktree reuse now revalidates Git-registered paths before adoption and reports locked or replaced stale entries instead of running Git commands in an unavailable or occupied directory; coordinator policy and Stream Deck project grouping use the repository-local default while retaining legacy sibling-path recognition.
 
 ### Fixed
 

--- a/packages/coding-agent/src/coordinator-mcp/policy.ts
+++ b/packages/coding-agent/src/coordinator-mcp/policy.ts
@@ -112,7 +112,7 @@ function parseRootList(value: string | undefined): string[] {
 }
 
 function resolveManagedWorktreeRoot(root: string, configured: string | undefined): string {
-	const template = (configured?.trim() || "{repo}.gajae-code-worktrees").replace(/^~(?=\/|$)/, os.homedir());
+	const template = (configured?.trim() || "{repo}/.worktrees").replace(/^~(?=\/|$)/, os.homedir());
 	const resolved = template.replaceAll("{repo}", path.basename(root));
 	return path.resolve(path.isAbsolute(resolved) ? resolved : path.join(path.dirname(root), resolved));
 }

--- a/packages/coding-agent/src/gjc-runtime/launch-worktree.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-worktree.ts
@@ -78,7 +78,7 @@ const WORKTREE_BUCKET_ENV = "GJC_WORKTREE_DIR";
  * what keeps two repositories that share a branch name from resolving to one worktree.
  */
 const REPO_NAME_PLACEHOLDER = "{repo}";
-const DEFAULT_WORKTREE_BUCKET = `${REPO_NAME_PLACEHOLDER}.gajae-code-worktrees`;
+const DEFAULT_WORKTREE_BUCKET = `${REPO_NAME_PLACEHOLDER}/.worktrees`;
 
 function expandHomePrefix(value: string, home: string, pathApi: typeof path.posix): string {
 	if (value === "~") return home;
@@ -108,12 +108,34 @@ export function resolveWorktreeBucketForPath(
 /**
  * Directory that holds this repository's launch worktrees.
  *
- * A relative override resolves against the repository's PARENT directory, matching the
- * default's own shape, so `{repo}.worktrees` adopts an existing sibling bucket and
- * `.worktrees` parks a hidden bucket beside the repository. An absolute override is used verbatim.
+ * A relative override resolves against the repository's parent directory. The default
+ * `{repo}/.worktrees` template places managed worktrees inside the repository, while
+ * `{repo}.worktrees` adopts an existing sibling bucket. An absolute override is used verbatim.
  */
 function resolveWorktreeBucket(repoRoot: string): string {
 	return resolveWorktreeBucketForPath(repoRoot, process.env[WORKTREE_BUCKET_ENV], os.homedir(), path);
+}
+
+function ensureRepositoryBucketIgnored(repoRoot: string, bucketPath: string): void {
+	const relativeBucket = path.relative(repoRoot, bucketPath);
+	if (relativeBucket.startsWith(`..${path.sep}`) || relativeBucket === ".." || path.isAbsolute(relativeBucket)) return;
+	const ignoreProbe = path.join(relativeBucket, ".gjc-worktree-probe");
+	for (const candidate of [relativeBucket, ignoreProbe]) {
+		const result = Bun.spawnSync(["git", "check-ignore", "--quiet", "--", candidate], {
+			cwd: repoRoot,
+			stdout: "ignore",
+			stderr: "pipe",
+		});
+		if (result.exitCode === 0) return;
+	}
+	throw new Error(
+		[
+			"worktree_bucket_not_ignored",
+			"The GJC launch worktree bucket is inside the repository but is not ignored by Git.",
+			`Path: ${formatBucketPath(bucketPath)}`,
+			`Safe remediation: add /${relativeBucket.replaceAll(path.sep, "/")} to ${path.join(repoRoot, ".gitignore")}, then relaunch.`,
+		].join("\n"),
+	);
 }
 
 function resolveSourceBranchSlug(repoRoot: string, baseRef: string): string {
@@ -301,6 +323,7 @@ function pruneStaleWorktreePath(repoRoot: string): void {
 
 function readWorktreeEntryFromPath(repoRoot: string, worktreePath: string): GitWorktreeEntry | null {
 	if (!fs.existsSync(worktreePath)) return null;
+	if (!fs.existsSync(path.join(worktreePath, ".git"))) return null;
 	const repoCommonDir = tryRunGit(repoRoot, ["rev-parse", "--git-common-dir"]);
 	const worktreeCommonDir = tryRunGit(worktreePath, ["rev-parse", "--git-common-dir"]);
 	if (!repoCommonDir || !worktreeCommonDir) return null;
@@ -386,6 +409,9 @@ export function ensureLaunchWorktree(
 	plan: GjcLaunchWorktreePlan | { enabled: false },
 ): GjcLaunchWorktreeResult | { enabled: false } {
 	if (!plan.enabled) return { enabled: false };
+	const bucketPath = path.dirname(plan.worktreePath);
+	inspectBucketDir(bucketPath);
+	ensureRepositoryBucketIgnored(plan.repoRoot, bucketPath);
 	let allWorktrees = listWorktrees(plan.repoRoot);
 	const staleAtPath = findWorktreeByPath(allWorktrees, plan.worktreePath);
 	if (staleAtPath && !fs.existsSync(staleAtPath.path)) {

--- a/packages/coding-agent/src/gjc-runtime/launch-worktree.ts
+++ b/packages/coding-agent/src/gjc-runtime/launch-worktree.ts
@@ -402,6 +402,7 @@ export function planLaunchWorktree(
 	if (branchName) validateBranchName(repoRoot, branchName);
 	const worktreeSlug = mode.detached ? resolveSourceBranchSlug(repoRoot, baseRef) : sanitizePathToken(mode.name);
 	const worktreePath = path.join(resolveWorktreeBucket(repoRoot), worktreeSlug);
+	if (path.resolve(worktreePath) === path.resolve(repoRoot)) throw new Error(`worktree_path_conflict:${worktreePath}`);
 	return { enabled: true, repoRoot, worktreePath, detached: mode.detached, baseRef, branchName };
 }
 
@@ -419,9 +420,19 @@ export function ensureLaunchWorktree(
 		allWorktrees = listWorktrees(plan.repoRoot);
 	}
 
-	const existingAtPath =
-		findWorktreeByPath(allWorktrees, plan.worktreePath) ??
-		readWorktreeEntryFromPath(plan.repoRoot, plan.worktreePath);
+	const listedAtPath = findWorktreeByPath(allWorktrees, plan.worktreePath);
+	const existingAtPath = readWorktreeEntryFromPath(plan.repoRoot, plan.worktreePath);
+	if (listedAtPath && !existingAtPath) {
+		if (fs.existsSync(plan.worktreePath)) throw new Error(`worktree_path_conflict:${plan.worktreePath}`);
+		throw new Error(
+			[
+				"worktree_path_unavailable",
+				"The requested launch worktree is still registered by Git but its directory is unavailable or locked.",
+				`Path: ${formatBucketPath(plan.worktreePath)}`,
+				"Safe remediation: inspect the worktree lock and remove or repair it with git worktree remove/prune when it is no longer needed, then relaunch. GJC did not delete or replace the entry.",
+			].join("\n"),
+		);
+	}
 	const expectedBranchRef = plan.branchName ? `refs/heads/${plan.branchName}` : null;
 
 	if (existingAtPath) {

--- a/packages/coding-agent/test/coordinator-mcp-policy.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-policy.test.ts
@@ -76,9 +76,9 @@ describe("Hermes MCP safety policy", () => {
 		);
 	});
 
-	it("authorizes GJC-managed sibling worktrees under the repository bucket", async () => {
+	it("authorizes GJC-managed repository-local worktrees under the repository bucket", async () => {
 		const root = await tempRoot();
-		const bucket = `${root}.gajae-code-worktrees`;
+		const bucket = path.join(root, ".worktrees");
 		const worktree = path.join(bucket, "feature-session");
 		await fs.mkdir(worktree, { recursive: true });
 		const config = buildCoordinatorMcpConfig({

--- a/packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts
@@ -461,6 +461,21 @@ describe("default launch worktrees", () => {
 		expect(() => ensureLaunchWorktree(planned)).toThrow(/worktree_path_conflict/);
 	});
 
+	it("rejects a missing locked worktree instead of running status in its absent path", async () => {
+		const repo = await createRepo("gjc-launch-locked-worktree-");
+		const planned = planLaunchWorktree(repo, { enabled: true, detached: false, name: "feature/demo" });
+		const ensured = ensureLaunchWorktree(planned);
+		if (!ensured.enabled) throw new Error("expected enabled worktree");
+
+		run("git", ["worktree", "lock", "--reason", "regression test", ensured.worktreePath], repo);
+		await fs.rm(ensured.worktreePath, { recursive: true, force: true });
+
+		expect(() => ensureLaunchWorktree(planned)).toThrow(
+			/worktree_path_unavailable[\s\S]*still registered by Git[\s\S]*inspect the worktree lock/,
+		);
+		run("git", ["worktree", "unlock", ensured.worktreePath], repo);
+	});
+
 	it("keeps launch worktree slugs collision-resistant for similar branch names", async () => {
 		const repo = await createRepo("gjc-launch-collision-worktree-");
 		const slashPlan = planLaunchWorktree(repo, { enabled: true, detached: false, name: "feature/demo" });

--- a/packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts
@@ -55,14 +55,15 @@ async function createRepo(prefix: string): Promise<string> {
 	run("git", ["config", "user.email", "test@example.com"], root);
 	run("git", ["config", "user.name", "Test User"], root);
 	await Bun.write(path.join(root, "README.md"), "hello\n");
-	run("git", ["add", "README.md"], root);
+	await Bun.write(path.join(root, ".gitignore"), "/.worktrees\n");
+	run("git", ["add", "README.md", ".gitignore"], root);
 	run("git", ["commit", "-m", "init"], root);
 	return root;
 }
 
 afterEach(async () => {
 	for (const root of cleanupRoots.splice(0)) {
-		const bucket = path.join(path.dirname(root), `${path.basename(root)}.gajae-code-worktrees`);
+		const bucket = path.join(root, ".worktrees");
 		const branchSlug = testSlug(run("git", ["branch", "--show-current"], root));
 		Bun.spawnSync(["git", "worktree", "remove", "--force", path.join(bucket, branchSlug)], {
 			cwd: root,
@@ -75,7 +76,6 @@ afterEach(async () => {
 			stderr: "ignore",
 		});
 		await fs.rm(root, { recursive: true, force: true });
-		await fs.rm(bucket, { recursive: true, force: true });
 	}
 	for (const cleanupPath of cleanupPaths.splice(0)) await fs.rm(cleanupPath, { recursive: true, force: true });
 });
@@ -117,13 +117,13 @@ describe("default launch worktrees", () => {
 		});
 	});
 
-	it("creates and reuses a detached launch worktree beside the source repo", async () => {
+	it("creates and reuses a detached launch worktree inside the source repo", async () => {
 		const repo = await createRepo("gjc-launch-worktree-");
 		await fs.mkdir(path.join(repo, "node_modules"));
 
 		const first = prepareLaunchWorktree(repo, ["--worktree", "--", "hello"]);
 		const branchSlug = testSlug(run("git", ["branch", "--show-current"], repo));
-		const expectedPath = path.join(path.dirname(repo), `${path.basename(repo)}.gajae-code-worktrees`, branchSlug);
+		const expectedPath = path.join(repo, ".worktrees", branchSlug);
 
 		expect(await fs.realpath(first.cwd)).toBe(await fs.realpath(expectedPath));
 		expect(first.args).toEqual(["--", "hello"]);
@@ -226,22 +226,18 @@ describe("default launch worktrees", () => {
 		expect(await fs.realpath(target)).toBe(externalModules);
 	});
 
-	it("creates launch worktrees beside the canonical source repo when launched from an existing worktree", async () => {
+	it("creates launch worktrees under the canonical source repo when launched from an existing worktree", async () => {
 		const repo = await fs.realpath(await createRepo("gjc-launch-nested-source-worktree-"));
 		const first = prepareLaunchWorktree(repo, ["--worktree"]);
 		expect(first.worktree.enabled && first.worktree.created).toBe(true);
 
 		const second = prepareLaunchWorktree(first.cwd, ["--worktree", "feature/nested"]);
-		const expectedPath = path.join(
-			path.dirname(repo),
-			`${path.basename(repo)}.gajae-code-worktrees`,
-			testSlug("feature/nested"),
-		);
+		const expectedPath = path.join(repo, ".worktrees", testSlug("feature/nested"));
 
 		expect(second.worktree.enabled && second.worktree.repoRoot).toBe(repo);
 		expect(await fs.realpath(second.cwd)).toBe(await fs.realpath(expectedPath));
 		expect(
-			second.cwd.includes(`.gajae-code-worktrees${path.sep}${path.basename(first.cwd)}.gajae-code-worktrees`),
+			second.cwd.includes(`${path.sep}.worktrees${path.sep}${path.basename(first.cwd)}${path.sep}.worktrees`),
 		).toBe(false);
 	});
 
@@ -291,11 +287,7 @@ describe("default launch worktrees", () => {
 		await Bun.write(path.join(detached.cwd, "dirty.txt"), "dirty\n");
 
 		const named = prepareLaunchWorktree(repo, ["--worktree", "feat/hud-ui-alignment"]);
-		const expectedPath = path.join(
-			path.dirname(repo),
-			`${path.basename(repo)}.gajae-code-worktrees`,
-			testSlug("feat/hud-ui-alignment"),
-		);
+		const expectedPath = path.join(repo, ".worktrees", testSlug("feat/hud-ui-alignment"));
 
 		expect(await fs.realpath(named.cwd)).toBe(await fs.realpath(expectedPath));
 		expect(named.worktree.enabled && named.worktree.branchName).toBe("feat/hud-ui-alignment");
@@ -304,7 +296,7 @@ describe("default launch worktrees", () => {
 
 	it("reports a private, platform-neutral error for a broken bucket symlink without deleting it", async () => {
 		const repo = await createRepo("gjc launch 'broken-bucket-symlink-");
-		const bucket = path.join(path.dirname(repo), `${path.basename(repo)}.gajae-code-worktrees`);
+		const bucket = path.join(repo, ".worktrees");
 		const missingTarget = path.join(path.dirname(repo), "private-missing-cold-storage-target");
 		await fs.symlink(missingTarget, bucket, process.platform === "win32" ? "junction" : "dir");
 
@@ -324,7 +316,7 @@ describe("default launch worktrees", () => {
 
 	it("reclassifies a broken symlink racing the bucket mkdir instead of leaking raw EEXIST", async () => {
 		const repo = await createRepo("gjc-launch-bucket-mkdir-race-");
-		const bucket = path.join(path.dirname(repo), `${path.basename(repo)}.gajae-code-worktrees`);
+		const bucket = path.join(repo, ".worktrees");
 		const missingTarget = path.join(path.dirname(repo), "racing-missing-bucket-target");
 		const mkdirSpy = spyOn(fsSync, "mkdirSync").mockImplementationOnce((targetPath: fsSync.PathLike) => {
 			expect(path.resolve(String(targetPath))).toBe(path.resolve(bucket));
@@ -344,7 +336,7 @@ describe("default launch worktrees", () => {
 
 	it("does not treat non-ENOENT bucket inspection failures as a missing directory", async () => {
 		const repo = await createRepo("gjc-launch-bucket-inspection-failure-");
-		const bucket = path.join(path.dirname(repo), `${path.basename(repo)}.gajae-code-worktrees`);
+		const bucket = path.join(repo, ".worktrees");
 		const lstatSpy = spyOn(fsSync, "lstatSync").mockImplementationOnce(() => {
 			throw Object.assign(new Error("permission denied"), { code: "EACCES" });
 		});
@@ -361,7 +353,7 @@ describe("default launch worktrees", () => {
 
 	it("allows a valid directory symlink or Windows junction as the worktree bucket", async () => {
 		const repo = await createRepo("gjc-launch-valid-bucket-symlink-");
-		const bucket = path.join(path.dirname(repo), `${path.basename(repo)}.gajae-code-worktrees`);
+		const bucket = path.join(repo, ".worktrees");
 		const target = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-launch-bucket-target-"));
 		cleanupPaths.push(target);
 		await fs.symlink(target, bucket, process.platform === "win32" ? "junction" : "dir");
@@ -378,7 +370,7 @@ describe("default launch worktrees", () => {
 
 	it("reports a symlink to a non-directory target without disclosing or deleting the target", async () => {
 		const repo = await createRepo("gjc-launch-bucket-file-symlink-");
-		const bucket = path.join(path.dirname(repo), `${path.basename(repo)}.gajae-code-worktrees`);
+		const bucket = path.join(repo, ".worktrees");
 		const target = path.join(path.dirname(repo), "private-bucket-target-file");
 		cleanupPaths.push(target);
 		await Bun.write(target, "preserve-me\n");
@@ -398,7 +390,7 @@ describe("default launch worktrees", () => {
 
 	it("reports a regular-file bucket without shell text or deletion side effects", async () => {
 		const repo = await createRepo("gjc-launch-bucket-not-directory-");
-		const bucket = path.join(path.dirname(repo), `${path.basename(repo)}.gajae-code-worktrees`);
+		const bucket = path.join(repo, ".worktrees");
 		await Bun.write(bucket, "not-a-directory\n");
 
 		let message = "";
@@ -416,7 +408,7 @@ describe("default launch worktrees", () => {
 	if (process.platform !== "win32") {
 		it("reports a FIFO bucket as a non-directory without deleting it", async () => {
 			const repo = await createRepo("gjc-launch-bucket-fifo-");
-			const bucket = path.join(path.dirname(repo), `${path.basename(repo)}.gajae-code-worktrees`);
+			const bucket = path.join(repo, ".worktrees");
 			const created = Bun.spawnSync(["mkfifo", bucket], { stdout: "pipe", stderr: "pipe" });
 			expect(created.exitCode).toBe(0);
 
@@ -428,7 +420,7 @@ describe("default launch worktrees", () => {
 
 		it("reports a Unix socket bucket as a non-directory without deleting it", async () => {
 			const repo = await createRepo("gjc-launch-bucket-socket-");
-			const bucket = path.join(path.dirname(repo), `${path.basename(repo)}.gajae-code-worktrees`);
+			const bucket = path.join(repo, ".worktrees");
 			const server = net.createServer();
 			const ready = Promise.withResolvers<void>();
 			server.once("error", ready.reject);
@@ -452,15 +444,21 @@ describe("default launch worktrees", () => {
 		const repo = await createRepo("gjc-launch-named-worktree-");
 		const planned = planLaunchWorktree(repo, { enabled: true, detached: false, name: "feature/demo" });
 		const ensured = ensureLaunchWorktree(planned);
-		const expectedPath = path.join(
-			path.dirname(repo),
-			`${path.basename(repo)}.gajae-code-worktrees`,
-			testSlug("feature/demo"),
-		);
+		const expectedPath = path.join(repo, ".worktrees", testSlug("feature/demo"));
 
 		expect(ensured.enabled && (await fs.realpath(ensured.worktreePath))).toBe(await fs.realpath(expectedPath));
 		expect(ensured.enabled && ensured.branchName).toBe("feature/demo");
 		expect(run("git", ["branch", "--show-current"], expectedPath)).toBe("feature/demo");
+	});
+
+	it("rejects an occupied nested path instead of adopting the source repository", async () => {
+		const repo = await createRepo("gjc-launch-occupied-worktree-");
+		const planned = planLaunchWorktree(repo, { enabled: true, detached: false, name: "feature/demo" });
+		if (!planned.enabled) throw new Error("expected enabled worktree plan");
+		await fs.mkdir(planned.worktreePath, { recursive: true });
+		await Bun.write(path.join(planned.worktreePath, "occupied"), "conflict\n");
+
+		expect(() => ensureLaunchWorktree(planned)).toThrow(/worktree_path_conflict/);
 	});
 
 	it("keeps launch worktree slugs collision-resistant for similar branch names", async () => {
@@ -500,9 +498,7 @@ describe("default launch worktrees", () => {
 		expect(run("git", ["branch", "--show-current"], path.join(bucket, testSlug("feature/demo")))).toBe(
 			"feature/demo",
 		);
-		expect(fsSync.existsSync(path.join(path.dirname(repo), `${path.basename(repo)}.gajae-code-worktrees`))).toBe(
-			false,
-		);
+		expect(fsSync.existsSync(path.join(repo, ".worktrees"))).toBe(false);
 	});
 
 	it("keeps the template repo-scoped so two repos never share one worktree path", async () => {
@@ -530,9 +526,19 @@ describe("default launch worktrees", () => {
 		);
 
 		expect(homePlan.enabled && path.dirname(homePlan.worktreePath)).toBe(path.join(os.homedir(), "gjc-worktrees"));
-		expect(blankPlan.enabled && path.dirname(blankPlan.worktreePath)).toBe(
-			path.join(path.dirname(repo), `${path.basename(repo)}.gajae-code-worktrees`),
+		expect(blankPlan.enabled && path.dirname(blankPlan.worktreePath)).toBe(path.join(repo, ".worktrees"));
+	});
+
+	it("rejects the repository-local bucket when Git does not ignore it", async () => {
+		const repo = await createRepo("gjc-launch-bucket-unignored-");
+		await fs.rm(path.join(repo, ".gitignore"));
+		run("git", ["add", ".gitignore"], repo);
+		run("git", ["commit", "-m", "remove ignore"], repo);
+
+		expect(() => prepareLaunchWorktree(repo, ["--worktree", "feature/demo"])).toThrow(
+			/worktree_bucket_not_ignored[\s\S]*add \/.worktrees/,
 		);
+		expect(await Bun.file(path.join(repo, ".worktrees")).exists()).toBe(false);
 	});
 
 	it("uses the launch worktree as the generated tmux cwd", async () => {
@@ -657,7 +663,7 @@ describe("resolveWorktreeBucketForPath Windows semantics", () => {
 	it("keeps UNC repos on their share for the default and relative templates", () => {
 		const uncRepo = "\\\\server\\share\\app";
 		expect(resolveWorktreeBucketForPath(uncRepo, undefined, home, path.win32)).toBe(
-			"\\\\server\\share\\app.gajae-code-worktrees",
+			"\\\\server\\share\\app\\.worktrees",
 		);
 		expect(resolveWorktreeBucketForPath(uncRepo, "{repo}.worktrees", home, path.win32)).toBe(
 			"\\\\server\\share\\app.worktrees",
@@ -668,6 +674,6 @@ describe("resolveWorktreeBucketForPath Windows semantics", () => {
 		expect(resolveWorktreeBucketForPath("C:\\repos\\App", "{repo}.worktrees", home, path.win32)).toBe(
 			"C:\\repos\\App.worktrees",
 		);
-		expect(resolveWorktreeBucketForPath(repo, "   ", home, path.win32)).toBe("C:\\repos\\app.gajae-code-worktrees");
+		expect(resolveWorktreeBucketForPath(repo, "   ", home, path.win32)).toBe("C:\\repos\\app\\.worktrees");
 	});
 });

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -2952,7 +2952,12 @@ test("broker records the resolved worktree state root and preserves pre-child pr
 			if (result.exitCode !== 0) throw new Error(result.stderr.toString());
 		}
 		await fs.writeFile(path.join(repo, "README"), "fixture\n");
-		const committed = Bun.spawnSync(["git", "add", "README"], { cwd: repo, stdout: "pipe", stderr: "pipe" });
+		await fs.writeFile(path.join(repo, ".gitignore"), "/.worktrees\n");
+		const committed = Bun.spawnSync(["git", "add", "README", ".gitignore"], {
+			cwd: repo,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
 		if (committed.exitCode !== 0) throw new Error(committed.stderr.toString());
 		const commit = Bun.spawnSync(["git", "commit", "-m", "fixture"], { cwd: repo, stdout: "pipe", stderr: "pipe" });
 		if (commit.exitCode !== 0) throw new Error(commit.stderr.toString());


### PR DESCRIPTION
## Problem

Running `gjc --worktree feature/demo` creates the managed checkout beside the repository:

```text
<repo-parent>/<repo>.gajae-code-worktrees/<slug>
```

This scatters repository-specific working state across the parent directory instead of keeping it under the project. The requested and now tested default is:

```text
<repo>/.worktrees/<slug>
```

Reproduction on `upstream/dev` at `a05ecaf4a05c2e5b7767e516fb75187edb527bed`:

```sh
gjc --worktree feature/demo
git worktree list
```

The listed managed path uses the sibling `.gajae-code-worktrees` bucket.

## Root cause

`packages/coding-agent/src/gjc-runtime/launch-worktree.ts` defines `DEFAULT_WORKTREE_BUCKET` as `{repo}.gajae-code-worktrees`, and relative bucket templates resolve against the repository parent. The canonical-root resolver correctly prevents nested launches from deriving a second project identity, but the default template still selects a sibling path.

Moving the bucket inside the repository adds two boundaries that the sibling layout did not need:

1. Git must ignore the bucket, or the nested checkout can pollute source status.
2. A plain occupied directory under the repository must not be mistaken for the source repository merely because `git` walks upward to the parent's `.git` directory.

## Fix

- `launch-worktree.ts`: change the default template to `{repo}/.worktrees`, require every in-repository bucket to be ignored by Git, and emit an actionable `.gitignore` diagnostic before creating or reusing it. External `GJC_WORKTREE_DIR` buckets keep their existing resolution.
- `launch-worktree.ts`: require a candidate reusable worktree path to contain its own `.git` marker before inspecting its Git common directory. This preserves `worktree_path_conflict` for occupied nested paths.
- `launch-worktree.test.ts`: move default path, cleanup, symlink, nested-launch, named-worktree, and Windows/UNC assertions to the repository-local bucket. Add explicit unignored-bucket and occupied-nested-path cases.
- `sdk-broker-lifecycle-e2e.test.ts`: make the lifecycle worktree fixture satisfy the new ignore contract so it continues testing the intended pre-child path conflict.
- `CHANGELOG.md`: document the new default, ignore requirement, and unaffected external/previously registered buckets.

GJC does not edit `.gitignore`, migrate or delete existing sibling worktrees, or add another configuration switch.

## Tests

New or changed regression coverage includes:

- detached worktrees resolve to `<repo>/.worktrees/<slug>`
- named and nested launches retain the canonical source repository
- unignored in-repository buckets fail before creation
- occupied nested paths remain `worktree_path_conflict`
- symlink and invalid-node safety diagnostics remain intact
- Windows drive and UNC defaults resolve under `<repo>/.worktrees`
- SDK lifecycle preparation preserves its intended pre-child conflict

**15 of the 35 focused tests fail with the source reverted to unmodified `dev`; 20 pass as unchanged regression guards.**

Commands run:

```text
bun test packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts
35 pass, 0 fail, 112 expectations

# source reverted, changed tests retained
bun test packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts
20 pass, 15 fail, 75 expectations

bun test packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts --test-name-pattern 'broker records the resolved worktree state root'
1 pass, 0 fail, 95 filtered, 2 expectations

bunx biome check packages/coding-agent/src/gjc-runtime/launch-worktree.ts packages/coding-agent/test/gjc-runtime/launch-worktree.test.ts packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
3 files checked, no errors

bun --cwd=packages/coding-agent run check
passed TypeScript checking; Biome reported 14 existing warnings outside the changed files

bun test packages/coding-agent/test/
did not complete within 1800 seconds; the run observed an unrelated session-state-lock test failure before timeout
```

## Risk classification

- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

gajae.pr-review-verdict.v1 merge-approved sha256:be729221620d6ffe527e108220e30bf631b34870222b810e988b42c814391e03 reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/pull/5012#pullrequestreview-5049042027


Current exact-head reconciliation: origin\/dev 7674034f949f254ec494802a19a178fe2e235314; salvage head 9a379d1bb4b1fc65e7a6a25c49b2fd7ed05327d; fresh local verification 44 worktree\/coordinator-policy tests, 95 SDK lifecycle tests, coding-agent TypeScript check, and changed-file Biome check passed.

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken