### PR TITLE
fix(tui): align Hangul fuzzy filtering and scoring

### DIFF
--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -324,7 +324,10 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 		if (!prefix) return null;
 		const query = prefix.slice(1).toLowerCase();
 		if (query.length === 0 && !options.includeEmpty) return null;
-		const normalizedQuery = query.startsWith("skill-") ? `skill:${query.slice("skill-".length)}` : query;
+		const normalizedQuery = normalizeFuzzyText(
+			query.startsWith("skill-") ? `skill:${query.slice("skill-".length)}` : query,
+		);
+		if (query.length > 0 && normalizedQuery.length === 0) return null;
 		const exactNonSkillCommand = this.#commands.some(
 			command => command.name === query && !command.name.startsWith("skill:"),
 		);
@@ -338,7 +341,7 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 					`skill-${skillName}`,
 					...(exactNonSkillCommand ? [] : [skillName]),
 					command.description ?? "",
-				].map(target => target.toLowerCase());
+				].map(target => normalizeFuzzyText(target));
 				if (
 					!searchTargets.some(
 						target => autocompleteFuzzyMatch(normalizedQuery, target) || target.includes(normalizedQuery),

--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -1,9 +1,12 @@
 import {
 	type AutocompleteItem,
 	type AutocompleteProvider,
+	autocompleteFuzzyMatch,
+	autocompleteFuzzyScore,
 	CombinedAutocompleteProvider,
 	extractSlashCommandTokenPrefix,
 	getSlashCommandMatchRank,
+	normalizeFuzzyText,
 	type SlashCommand,
 } from "@gajae-code/tui";
 import type { KeybindingsManager } from "../config/keybindings";
@@ -50,43 +53,6 @@ interface PromptActionAutocompleteOptions {
 	getPromptSuggestion?: () => string | null;
 }
 
-function fuzzyMatch(query: string, target: string): boolean {
-	if (query.length === 0) return true;
-	if (query.length > target.length) return false;
-
-	let queryIndex = 0;
-	for (let targetIndex = 0; targetIndex < target.length && queryIndex < query.length; targetIndex += 1) {
-		if (query[queryIndex] === target[targetIndex]) {
-			queryIndex += 1;
-		}
-	}
-
-	return queryIndex === query.length;
-}
-
-function fuzzyScore(query: string, target: string): number {
-	if (query.length === 0) return 1;
-	if (target === query) return 100;
-	if (target.startsWith(query)) return 80;
-	if (target.includes(query)) return 60;
-
-	let queryIndex = 0;
-	let gaps = 0;
-	let lastMatchIndex = -1;
-	for (let targetIndex = 0; targetIndex < target.length && queryIndex < query.length; targetIndex += 1) {
-		if (query[queryIndex] === target[targetIndex]) {
-			if (lastMatchIndex >= 0 && targetIndex - lastMatchIndex > 1) {
-				gaps += 1;
-			}
-			lastMatchIndex = targetIndex;
-			queryIndex += 1;
-		}
-	}
-
-	if (queryIndex !== query.length) return 0;
-	return Math.max(1, 40 - gaps * 5);
-}
-
 function isPromptActionItem(item: AutocompleteItem): item is PromptActionAutocompleteItem {
 	return "actionId" in item && "execute" in item && typeof item.execute === "function";
 }
@@ -127,6 +93,7 @@ function sortSlashCommandSuggestions(
 ): { items: AutocompleteItem[]; prefix: string } | null {
 	if (!suggestions) return null;
 	const query = suggestions.prefix.slice(1).toLowerCase();
+	const normalizedQuery = normalizeFuzzyText(query);
 	const commandIndexes = new Map(commands.map((command, index) => [command.name, index]));
 	const commandByName = new Map(commands.map(command => [command.name, command]));
 	const items = suggestions.items
@@ -135,13 +102,20 @@ function sortSlashCommandSuggestions(
 			const commandIndex = commandIndexes.get(item.value) ?? index;
 			const lowerName = item.value.toLowerCase();
 			const lowerDesc = command?.description?.toLowerCase() ?? item.description?.toLowerCase() ?? "";
-			const nameScore = fuzzyMatch(query, lowerName) ? fuzzyScore(query, lowerName) : 0;
-			const descScore = fuzzyMatch(query, lowerDesc) ? fuzzyScore(query, lowerDesc) * 0.5 : 0;
+			const normalizedName = normalizeFuzzyText(item.value);
+			const normalizedDesc = normalizeFuzzyText(lowerDesc);
+			const nameScore = autocompleteFuzzyMatch(normalizedQuery, normalizedName)
+				? autocompleteFuzzyScore(normalizedQuery, normalizedName)
+				: 0;
+			const descScore = autocompleteFuzzyMatch(normalizedQuery, normalizedDesc)
+				? autocompleteFuzzyScore(normalizedQuery, normalizedDesc) * 0.5
+				: 0;
+			const isAscii = /^[\x00-\x7F]*$/.test(`${query}${item.value}`);
 			return {
 				item,
 				index,
 				commandIndex,
-				matchRank: getSlashCommandMatchRank(query, lowerName),
+				matchRank: isAscii ? getSlashCommandMatchRank(query, lowerName) : 4,
 				priority: getSlashCommandPriority(command, item),
 				score: Math.max(nameScore, descScore),
 			};
@@ -219,14 +193,14 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 					const searchable = [action.id, action.label, action.description, ...action.keywords]
 						.join(" ")
 						.toLowerCase();
-					if (!fuzzyMatch(query, searchable)) return null;
+					if (!autocompleteFuzzyMatch(query, searchable)) return null;
 					return {
 						value: action.label,
 						label: action.label,
 						description: action.description,
 						actionId: action.id,
 						execute: action.execute,
-						score: fuzzyScore(query, searchable),
+						score: autocompleteFuzzyScore(query, searchable),
 					} satisfies PromptActionAutocompleteItem & { score: number };
 				})
 				.filter(item => item !== null)
@@ -366,14 +340,16 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 					command.description ?? "",
 				].map(target => target.toLowerCase());
 				if (
-					!searchTargets.some(target => fuzzyMatch(normalizedQuery, target) || target.includes(normalizedQuery))
+					!searchTargets.some(
+						target => autocompleteFuzzyMatch(normalizedQuery, target) || target.includes(normalizedQuery),
+					)
 				) {
 					return null;
 				}
 				const bestScore = Math.max(
 					...searchTargets.map(target =>
-						fuzzyMatch(normalizedQuery, target)
-							? fuzzyScore(normalizedQuery, target)
+						autocompleteFuzzyMatch(normalizedQuery, target)
+							? autocompleteFuzzyScore(normalizedQuery, target)
 							: target.includes(normalizedQuery)
 								? 60
 								: 0,

--- a/packages/coding-agent/test/prompt-action-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-autocomplete.test.ts
@@ -416,6 +416,15 @@ describe("prompt action autocomplete", () => {
 		expect(result?.items.map(item => item.value)).toEqual(["한글", "한모글"]);
 	});
 
+	it("rejects separator-only slash queries and normalizes skill Hangul queries", () => {
+		expect(
+			createNoopProvider([{ name: "model", description: "Switch model" }]).trySyncSlashCompletion("/-"),
+		).toBeNull();
+
+		const provider = createNoopProvider([{ name: "skill:한글", description: "Korean skill" }]);
+		expect(provider.trySyncSlashCompletion("/ㅎ-ㄱ")?.items.map(item => item.value)).toEqual(["skill:한글"]);
+	});
+
 	it("returns null from trySyncSlashCompletion for non-slash text", () => {
 		const provider = createPromptActionAutocompleteProvider({
 			commands: [{ name: "model", description: "Switch AI model" }],

--- a/packages/coding-agent/test/prompt-action-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-autocomplete.test.ts
@@ -406,6 +406,16 @@ describe("prompt action autocomplete", () => {
 		expect(result!.items.map(i => i.value)).toContain("model");
 	});
 
+	it("preserves Hangul chosung ordering through the product wrapper", () => {
+		const provider = createNoopProvider([
+			{ name: "한모글", description: "Gapped Korean command" },
+			{ name: "한글", description: "Adjacent Korean command" },
+		]);
+
+		const result = provider.trySyncSlashCompletion("/ㅎㄱ");
+		expect(result?.items.map(item => item.value)).toEqual(["한글", "한모글"]);
+	});
+
 	it("returns null from trySyncSlashCompletion for non-slash text", () => {
 		const provider = createPromptActionAutocompleteProvider({
 			commands: [{ name: "model", description: "Switch AI model" }],

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -352,6 +352,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	#getSlashCommandNameSuggestions(prefix: string): AutocompleteItem[] {
 		const lowerPrefix = prefix.toLowerCase();
 		const normalizedPrefix = normalizeFuzzyText(prefix);
+		if (prefix.length > 0 && normalizedPrefix.length === 0) return [];
 
 		return this.#commands
 			.filter(cmd => {

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -129,6 +129,17 @@ function hangulInitialJamo(char: string): string | undefined {
 	return HANGUL_INITIAL_COMPAT_JAMO[Math.floor(offset / 588)];
 }
 
+function fuzzyCharMatches(queryChar: string, targetChar: string): boolean {
+	return queryChar === targetChar || hangulInitialJamo(targetChar) === queryChar;
+}
+
+function normalizeFuzzyText(value: string): string {
+	return value
+		.normalize("NFC")
+		.toLowerCase()
+		.replace(/[\s/\\._-]+/g, "");
+}
+
 /**
  * Check if query is a subsequence of target (fuzzy match).
  * "wig" matches "skill:wig" because w-i-g appear in order.
@@ -141,9 +152,7 @@ function fuzzyMatch(query: string, target: string): boolean {
 
 	let qi = 0;
 	for (let ti = 0; ti < target.length && qi < query.length; ti++) {
-		const queryChar = query[qi] as string;
-		const targetChar = target[ti] as string;
-		if (queryChar === targetChar || hangulInitialJamo(targetChar) === queryChar) qi++;
+		if (fuzzyCharMatches(query[qi] as string, target[ti] as string)) qi++;
 	}
 	return qi === query.length;
 }
@@ -164,7 +173,7 @@ function fuzzyScore(query: string, target: string): number {
 	let gaps = 0;
 	let lastMatchIdx = -1;
 	for (let ti = 0; ti < target.length && qi < query.length; ti++) {
-		if (query[qi] === target[ti]) {
+		if (fuzzyCharMatches(query[qi] as string, target[ti] as string)) {
 			if (lastMatchIdx >= 0 && ti - lastMatchIdx > 1) gaps++;
 			lastMatchIdx = ti;
 			qi++;
@@ -849,14 +858,14 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			const searchPath = scopedQuery?.baseDir ?? this.#basePath;
 			const fuzzyQuery = scopedQuery?.query ?? query;
 			const result = await (await fuzzyFindNative())(buildAutocompleteFuzzyDiscoveryProfile(fuzzyQuery, searchPath));
-			const lowerQuery = fuzzyQuery.normalize("NFC").toLowerCase();
+			const normalizedQuery = normalizeFuzzyText(fuzzyQuery);
 			const filteredMatches = result.matches.filter(entry => {
 				const p = entry.path.endsWith("/") ? entry.path.slice(0, -1) : entry.path;
 				const normalized = p.replaceAll("\\", "/");
 				if (/(^|\/)\.git(\/|$)/.test(normalized)) {
 					return false;
 				}
-				return lowerQuery.length === 0 || fuzzyMatch(lowerQuery, normalized.normalize("NFC").toLowerCase());
+				return normalizedQuery.length === 0 || fuzzyMatch(normalizedQuery, normalizeFuzzyText(normalized));
 			});
 			const topEntries = filteredMatches.slice(0, 20);
 			const suggestions: AutocompleteItem[] = [];

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -349,22 +349,31 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 
 	#getSlashCommandNameSuggestions(prefix: string): AutocompleteItem[] {
 		const lowerPrefix = prefix.toLowerCase();
+		const normalizedPrefix = normalizeFuzzyText(prefix);
 
 		return this.#commands
 			.filter(cmd => {
 				const name = this.#getCommandName(cmd);
 				if (!name) return false;
-				if (fuzzyMatch(lowerPrefix, name.toLowerCase())) return true;
-				if (getSlashCommandMatchRank(lowerPrefix, name.toLowerCase()) < 4) return true;
-				const desc = cmd.description?.toLowerCase();
-				return desc ? fuzzyMatch(lowerPrefix, desc) : false;
+				const lowerName = name.toLowerCase();
+				if (fuzzyMatch(normalizedPrefix, normalizeFuzzyText(name))) return true;
+				const isAscii = /^[\x00-\x7F]*$/.test(`${prefix}${name}`);
+				if (isAscii && getSlashCommandMatchRank(lowerPrefix, lowerName) < 4) return true;
+				const desc = cmd.description;
+				return desc ? fuzzyMatch(normalizedPrefix, normalizeFuzzyText(desc)) : false;
 			})
 			.map((cmd, index) => {
 				const name = this.#getCommandName(cmd);
 				const lowerName = name?.toLowerCase() ?? "";
-				const lowerDesc = cmd.description?.toLowerCase() ?? "";
-				const nameScore = fuzzyMatch(lowerPrefix, lowerName) ? fuzzyScore(lowerPrefix, lowerName) : 0;
-				const descScore = fuzzyMatch(lowerPrefix, lowerDesc) ? fuzzyScore(lowerPrefix, lowerDesc) * 0.5 : 0;
+				const lowerDesc = cmd.description ?? "";
+				const normalizedName = normalizeFuzzyText(name);
+				const normalizedDesc = normalizeFuzzyText(lowerDesc);
+				const nameScore = fuzzyMatch(normalizedPrefix, normalizedName)
+					? fuzzyScore(normalizedPrefix, normalizedName)
+					: 0;
+				const descScore = fuzzyMatch(normalizedPrefix, normalizedDesc)
+					? fuzzyScore(normalizedPrefix, normalizedDesc) * 0.5
+					: 0;
 				const hint = "argumentHint" in cmd && cmd.argumentHint ? cmd.argumentHint : undefined;
 				const desc = cmd.description ?? "";
 				const fullDesc = hint ? (desc ? `${hint} — ${desc}` : hint) : desc;
@@ -374,7 +383,9 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 					label: "name" in cmd ? cmd.name : cmd.label,
 					score: Math.max(nameScore, descScore),
 					priority,
-					matchRank: getSlashCommandMatchRank(lowerPrefix, lowerName),
+					matchRank: /^[\x00-\x7F]*$/.test(`${prefix}${name}`)
+						? getSlashCommandMatchRank(lowerPrefix, lowerName)
+						: 4,
 					index,
 					...(fullDesc && { description: fullDesc }),
 				} as AutocompleteItem & { score: number; priority: number; matchRank: number; index: number };

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -133,7 +133,7 @@ function fuzzyCharMatches(queryChar: string, targetChar: string): boolean {
 	return queryChar === targetChar || hangulInitialJamo(targetChar) === queryChar;
 }
 
-function normalizeFuzzyText(value: string): string {
+export function normalizeFuzzyText(value: string): string {
 	return value
 		.normalize("NFC")
 		.toLowerCase()
@@ -184,6 +184,8 @@ function fuzzyScore(query: string, target: string): number {
 	// Base score 40 for subsequence, minus penalty for gaps
 	return Math.max(1, 40 - gaps * 5);
 }
+
+export { fuzzyMatch as autocompleteFuzzyMatch, fuzzyScore as autocompleteFuzzyScore };
 export function getSlashCommandMatchRank(query: string, commandName: string): number {
 	const normalizedQuery = normalizeSlashCommandText(query);
 	if (normalizedQuery.length === 0) return 4;

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -357,6 +357,15 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(values).toContain("@history-search.ts");
 			expect(values).not.toContain(`@${hangulName}`);
 		});
+
+		it("keeps separator-bearing chosung queries accepted by native fuzzy search", async () => {
+			fs.writeFileSync(path.join(baseDir, hangulName), "content\n");
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = "@ㅎ-ㄱ";
+			const result = await provider.getSuggestions([line], 0, line.length);
+			const values = result?.items.map(item => item.value) ?? [];
+			expect(values).toContain(`@${hangulName}`);
+		});
 	});
 });
 
@@ -518,6 +527,15 @@ describe("trySyncSlashCompletion", () => {
 		// Both should be present; order depends on fuzzyScore internals
 		expect(modelIdx).not.toBe(-1);
 		expect(modeIdx).not.toBe(-1);
+	});
+
+	it("scores Hangul chosung slash-command matches", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[{ name: "한글명령", description: "Korean command", value: "한글명령" }],
+			"/tmp",
+		);
+		const result = provider.trySyncSlashCompletion("/ㅎㄱ");
+		expect(result?.items.map(item => item.value)).toEqual(["한글명령"]);
 	});
 
 	it("matches case-insensitively", () => {

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -538,6 +538,19 @@ describe("trySyncSlashCompletion", () => {
 		expect(result?.items.map(item => item.value)).toEqual(["한글명령"]);
 	});
 
+	it("normalizes separators and rejects unrelated commands for mixed Hangul queries", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[
+				{ name: "한글명령", description: "Korean command", value: "한글명령" },
+				{ name: "model", description: "Switch model", value: "model" },
+			],
+			"/tmp",
+		);
+
+		expect(provider.trySyncSlashCompletion("/ㅎ-ㄱ")?.items.map(item => item.value)).toEqual(["한글명령"]);
+		expect(provider.trySyncSlashCompletion("/ㅎㄱ-model")).toBeNull();
+	});
+
 	it("matches case-insensitively", () => {
 		const provider = new CombinedAutocompleteProvider(
 			[{ name: "Model", description: "Switch AI model", value: "Model" }],


### PR DESCRIPTION
Follow-up fix for merged PR #5008 (feat(tui): add Hangul chosung matching to fuzzy file search).

## What
- Apply the Hangul-aware predicate to TUI fuzzy scoring as well as acceptance filtering.
- Match the native fuzzy normalization contract in the TUI post-filter so separator-bearing queries are not discarded.
- Add slash-command and separator-bearing Hangul regression tests.

## Attribution
This fix-forward preserves the original PR #5008 contributor attribution and addresses post-merge adversarial review findings.

## Validation
- bun test packages/tui/test/autocomplete.test.ts (56/56)
- bun --cwd=packages/tui run check

Related: #5008

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*

## Risk classification

- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:b503e66fe05693ba1afef5fc11c7fb696de9db96ac6f8cd8d833e22660fe9a37 reviewer:human reviewer-id:Yeachan-Heo evidence:local focused TUI tests and package check
```


Exact-head contract refresh: a1bd4abef5d31f71e7e45ae029aafb8a6539f525.

Wrapper parity fix: the product autocomplete wrapper now reuses the TUI Hangul-aware scorer and has a regression test for adjacent versus gapped chosung ranking.
Punctuation-only slash queries are rejected, and skill command filtering now uses shared normalization.