### PR TITLE
fix(sdk): reject empty prompt terminal success

### DIFF
--- a/packages/coding-agent/src/sdk/bus/kind-aware-reconciliation.ts
+++ b/packages/coding-agent/src/sdk/bus/kind-aware-reconciliation.ts
@@ -21,6 +21,8 @@ import type {
 	ReconciliationStore,
 } from "./reconciliation-store";
 
+const EMPTY_PROMPT_FAILURE = { code: "prompt_failed", message: "Prompt submission failed." } as const;
+
 export type { ReconciliationKind };
 
 export interface KindCorrelation extends PromptCorrelation {
@@ -51,8 +53,13 @@ export interface KindAwareReconciliation {
 		kind: ReconciliationKind,
 		correlation: PromptCorrelation | undefined,
 		frame:
-			| { type: "agent_start" | "agent_end"; content?: TurnResultContent }
-			| { type: "agent_failed"; error: unknown; content?: TurnResultContent },
+			| {
+					type: "agent_start" | "agent_end";
+					content?: TurnResultContent;
+					hasActivity?: boolean;
+					outcome?: SdkPromptTerminalOutcome;
+			  }
+			| { type: "agent_failed"; error: unknown; content?: TurnResultContent; hasActivity?: boolean },
 	): Promise<void>;
 	claimPendingOutcome(
 		kind: ReconciliationKind,
@@ -340,8 +347,13 @@ export function createKindAwareReconciliation(
 		kind: ReconciliationKind,
 		correlation: PromptCorrelation | undefined,
 		frame:
-			| { type: "agent_start" | "agent_end"; content?: TurnResultContent }
-			| { type: "agent_failed"; error: unknown; content?: TurnResultContent },
+			| {
+					type: "agent_start" | "agent_end";
+					content?: TurnResultContent;
+					hasActivity?: boolean;
+					outcome?: SdkPromptTerminalOutcome;
+			  }
+			| { type: "agent_failed"; error: unknown; content?: TurnResultContent; hasActivity?: boolean },
 	) => {
 		if (!correlation) return;
 		await queueMutation(candidate => {
@@ -412,7 +424,17 @@ export function createKindAwareReconciliation(
 				record.receiptState = record.pendingReceiptState ?? "missing";
 				record.pendingReceiptState = undefined;
 			} else {
-				record.status = record.error === undefined ? "terminal_ok" : "failed";
+				if (
+					kind === "prompt" &&
+					record.error === undefined &&
+					frame.type === "agent_end" &&
+					frame.outcome?.kind !== "stopped" &&
+					!frame.content?.text.trim() &&
+					!frame.hasActivity
+				) {
+					record.status = "failed";
+					record.error = EMPTY_PROMPT_FAILURE;
+				} else record.status = record.error === undefined ? "terminal_ok" : "failed";
 				record.receiptState = frame.content?.text?.trim() ? "present" : "missing";
 			}
 			cleanupRecords(candidate);
@@ -453,6 +475,7 @@ export function createKindAwareReconciliation(
 					: undefined;
 		const content =
 			typeof arg4 === "function" ? arg6 : typeof arg5 === "object" && arg5 !== null && "code" in arg5 ? arg6 : arg5;
+		const sanitizedContent = sanitizeTurnResultContent(content);
 		await queueMutation(candidate => {
 			if (isCurrent !== undefined && !isCurrent()) return { value: undefined, changed: false };
 			const record = candidate.get(keyOf(kind, correlation));
@@ -463,8 +486,15 @@ export function createKindAwareReconciliation(
 			if (finalOutcome?.kind === "failed") {
 				record.status = "failed";
 				record.error = recordError ?? { code: finalOutcome.code, message: finalOutcome.message };
+			} else if (
+				kind === "prompt" &&
+				((finalOutcome === undefined && !sanitizedContent?.text.trim()) ||
+					(finalOutcome?.kind !== "stopped" && content !== undefined && !sanitizedContent?.text.trim()))
+			) {
+				record.status = "failed";
+				record.error = EMPTY_PROMPT_FAILURE;
 			} else record.status = "terminal_ok";
-			record.content = sanitizeTurnResultContent(content);
+			record.content = sanitizedContent;
 			record.outcome = finalOutcome;
 			record.receiptState = record.pendingReceiptState ?? "unknown";
 			record.pendingOutcome = undefined;

--- a/packages/coding-agent/src/sdk/bus/prompt-reconciliation.ts
+++ b/packages/coding-agent/src/sdk/bus/prompt-reconciliation.ts
@@ -23,11 +23,13 @@
  */
 
 import { PROMPT_FAILURE_CODE_MAX, sanitizePromptFailure } from "../prompt-failure";
+import type { SdkPromptTerminalOutcome } from "../prompt-status";
 import type { ReceiptState } from "../receipt-state";
 
 export { PROMPT_FAILURE_CODE_MAX, sanitizePromptFailure };
 export const PROMPT_RECONCILIATION_ACTIVE_CAPACITY = 128;
 export const PROMPT_RECONCILIATION_TERMINAL_CAPACITY = 256;
+const EMPTY_PROMPT_FAILURE = { code: "prompt_failed", message: "Prompt submission failed." } as const;
 
 export type PromptReconciliationStatus = "accepted" | "in_flight" | "terminal_ok" | "failed";
 
@@ -101,8 +103,13 @@ export interface PromptReconciliation {
 		correlation: PromptCorrelation | undefined,
 		frame:
 			| { type: "agent_start" }
-			| { type: "agent_end"; finalText?: string }
-			| { type: "agent_failed"; error: unknown; finalText?: string },
+			| {
+					type: "agent_end";
+					finalText?: string;
+					hasActivity?: boolean;
+					outcome?: SdkPromptTerminalOutcome;
+			  }
+			| { type: "agent_failed"; error: unknown; finalText?: string; hasActivity?: boolean },
 	): void;
 	lookup(selector: { commandId?: string; turnId?: string; clientRef?: string }): TurnPromptReconciliation;
 	cleanup(): void;
@@ -190,8 +197,13 @@ export function createPromptReconciliation(options: { now?: () => number } = {})
 		correlation: PromptCorrelation | undefined,
 		frame:
 			| { type: "agent_start" }
-			| { type: "agent_end"; finalText?: string }
-			| { type: "agent_failed"; error: unknown; finalText?: string },
+			| {
+					type: "agent_end";
+					finalText?: string;
+					hasActivity?: boolean;
+					outcome?: SdkPromptTerminalOutcome;
+			  }
+			| { type: "agent_failed"; error: unknown; finalText?: string; hasActivity?: boolean },
 	) => {
 		if (!correlation) return;
 		const record = records.get(keyOf(correlation));
@@ -221,6 +233,18 @@ export function createPromptReconciliation(options: { now?: () => number } = {})
 		if (frame.type === "agent_failed") {
 			record.status = "failed";
 			record.error = sanitizePromptFailure(frame.error);
+		} else if (record.error !== undefined) {
+			// Preserve an actionable provider failure already recorded before a late
+			// empty agent_end; the empty frame cannot downgrade or replace its cause.
+			record.status = "failed";
+		} else if (frame.type === "agent_end" && frame.outcome?.kind === "stopped") {
+			record.status = "terminal_ok";
+		} else if (!frame.finalText?.trim() && !frame.hasActivity) {
+			// A prompt cannot claim successful completion without assistant content.
+			// Keep the terminal transition first-wins, but fail closed instead of
+			// exposing an empty zero-token turn as terminal_ok.
+			record.status = "failed";
+			record.error = EMPTY_PROMPT_FAILURE;
 		} else {
 			record.status = "terminal_ok";
 		}

--- a/packages/coding-agent/src/sdk/host/session-runtime.test.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.test.ts
@@ -13,6 +13,8 @@ import {
 	unregisterOwnedRegistration,
 } from "../../session/terminal-abort";
 import { Broker } from "../broker/broker";
+import { createKindAwareReconciliation } from "../bus/kind-aware-reconciliation";
+import { createPromptReconciliation } from "../bus/prompt-reconciliation";
 import { createReconciliationStore } from "../bus/reconciliation-store";
 import { CursorRegistry, QueryHandlers, RevisionStore } from "./query";
 import {
@@ -145,6 +147,76 @@ async function queryGoalState(
 	if (!response.ok) throw new Error(`goal query failed: ${JSON.stringify(response)}`);
 	return response.page?.items[0];
 }
+
+test("native prompt reconciliation fails closed for an explicitly empty assistant result", () => {
+	const reconciliation = createPromptReconciliation();
+	const correlation = { commandId: "native-empty-command", turnId: "native-empty-turn" };
+	reconciliation.admit("native-empty-ref");
+	reconciliation.noteAccepted(correlation, "native-empty-ref");
+	reconciliation.noteTransition(correlation, { type: "agent_end", finalText: "" });
+	expect(reconciliation.lookup({ clientRef: "native-empty-ref" })).toMatchObject({
+		status: "failed",
+		error: { code: "prompt_failed" },
+		receiptState: "missing",
+	});
+	reconciliation.noteTransition(correlation, { type: "agent_end", finalText: "late text" });
+	expect(reconciliation.lookup({ clientRef: "native-empty-ref" })).toMatchObject({ status: "failed" });
+});
+
+test("broker reconciliation fails closed for an empty prompt and persists the first terminal result", async () => {
+	let records: unknown[] = [];
+	const store = {
+		load: async () => records,
+		transact: async (mutator: (current: never[]) => never[]) => {
+			records = mutator(records as never);
+		},
+	} as never;
+	const reconciliation = createKindAwareReconciliation({ store });
+	const correlation = { commandId: "broker-empty-command", turnId: "broker-empty-turn" };
+	await reconciliation.noteAccepted("prompt", correlation, "broker-empty-ref");
+	await reconciliation.noteTransition("prompt", correlation, {
+		type: "agent_end",
+		content: { version: 1, type: "text", text: "", byteLength: 0, truncated: false },
+	});
+	const settled = reconciliation.lookupResult("prompt", { clientRef: "broker-empty-ref" });
+	expect(settled).toMatchObject({ status: "failed", error: { code: "prompt_failed" } });
+	await reconciliation.noteTransition("prompt", correlation, {
+		type: "agent_end",
+		content: { version: 1, type: "text", text: "late text", byteLength: 9, truncated: false },
+	});
+	const reloaded = createKindAwareReconciliation({ store });
+	await reloaded.hydrateFromStore();
+	expect(reloaded.lookupResult("prompt", { clientRef: "broker-empty-ref" })).toMatchObject({
+		status: "failed",
+		error: { code: "prompt_failed" },
+	});
+	const noOpCorrelation = { commandId: "broker-noop-command", turnId: "broker-noop-turn" };
+	await reconciliation.noteAccepted("prompt", noOpCorrelation, "broker-noop-ref");
+	await reconciliation.finalizeOutcome(
+		"prompt",
+		noOpCorrelation,
+		{ kind: "stopped", reason: "cancelled", provenance: "client_cancel" },
+		undefined,
+		"",
+	);
+	expect(reconciliation.lookupResult("prompt", { clientRef: "broker-noop-ref" })).toMatchObject({
+		status: "terminal_ok",
+	});
+});
+
+test("session-host prompt reconciliation fails closed when the accepted result is empty", async () => {
+	const reconciliation = createInvocationReconciliation();
+	const correlation = { commandId: "host-empty-command", turnId: "host-empty-turn" };
+	await reconciliation.noteAccepted("prompt", correlation, "host-empty-ref");
+	await reconciliation.noteTransition("prompt", correlation, {
+		type: "agent_end",
+		content: { version: 1, type: "text", text: "", byteLength: 0, truncated: false },
+	});
+	expect(reconciliation.lookup("prompt", { clientRef: "host-empty-ref" })).toMatchObject({
+		status: "failed",
+		error: { code: "prompt_failed" },
+	});
+});
 
 describe("SDK goal snapshot lifecycle", () => {
 	test("recovers an active nonzero-activity goal from the durable session projection", async () => {
@@ -405,7 +477,10 @@ test("durable reload keeps agent_end terminal across a paused successor transiti
 	const correlation = { commandId: "durable-race-command", turnId: "durable-race-turn" };
 	await reconciliation.noteAccepted("prompt", correlation, "durable-race-ref");
 	pauseWrites = 2;
-	const terminal = reconciliation.noteTransition("prompt", correlation, { type: "agent_end" });
+	const terminal = reconciliation.noteTransition("prompt", correlation, {
+		type: "agent_end",
+		content: { version: 1, type: "text", text: "completed", byteLength: 9, truncated: false },
+	});
 	await writeStarted[0]!.promise;
 	// A successor lifecycle event arrives while the terminal write is held. It
 	// must observe the staged terminal record and never resurrect in_flight state.
@@ -455,7 +530,10 @@ test("agent_end is not swallowed when deadline persistence fails", async () => {
 		message: "deadline",
 	});
 	await persistStarted.promise;
-	const terminal = reconciliation.noteTransition("prompt", correlation, { type: "agent_end" });
+	const terminal = reconciliation.noteTransition("prompt", correlation, {
+		type: "agent_end",
+		content: { version: 1, type: "text", text: "completed", byteLength: 9, truncated: false },
+	});
 	releasePersist.resolve();
 	await expect(deadline).rejects.toThrow("held store failed");
 	await terminal;
@@ -523,13 +601,86 @@ test("agent_end upgrades a durable deadline terminal when it races a successful 
 		code: "prompt_deadline_exceeded",
 		message: "deadline",
 	});
-	await reconciliation.noteTransition("prompt", correlation, { type: "agent_end" });
+	await reconciliation.noteTransition("prompt", correlation, {
+		type: "agent_end",
+		content: { version: 1, type: "text", text: "completed", byteLength: 9, truncated: false },
+	});
 	const reloaded = createInvocationReconciliation({ store });
 	await reloaded.hydrate();
 	expect(reloaded.lookup("prompt", { clientRef: "upgrade-race-ref" })).toMatchObject({ status: "terminal_ok" });
 });
 
-test("failed agent_end upgrade persistence retains the deadline record for retry", async () => {
+test("an empty late agent_end cannot upgrade a durable prompt deadline failure", async () => {
+	let records: unknown[] = [];
+	const store = {
+		path: null,
+		load: async () => records,
+		transact: async (mutator: (current: never[]) => never[]) => {
+			records = mutator(records as never);
+		},
+	} as never;
+	const reconciliation = createInvocationReconciliation({ store });
+	const correlation = { commandId: "empty-deadline-command", turnId: "empty-deadline-turn" };
+	await reconciliation.noteAccepted("prompt", correlation, "empty-deadline-ref");
+	await reconciliation.finalizeOutcome("prompt", correlation, {
+		kind: "failed",
+		code: "prompt_deadline_exceeded",
+		message: "deadline",
+	});
+	await reconciliation.noteTransition("prompt", correlation, {
+		type: "agent_end",
+		content: { version: 1, type: "text", text: "", byteLength: 0, truncated: false },
+	});
+	expect(reconciliation.lookup("prompt", { clientRef: "empty-deadline-ref" })).toMatchObject({
+		status: "failed",
+		error: { code: "prompt_deadline_exceeded" },
+	});
+	const reloaded = createInvocationReconciliation({ store });
+	await reloaded.hydrate();
+	expect(reloaded.lookup("prompt", { clientRef: "empty-deadline-ref" })).toMatchObject({
+		status: "failed",
+		error: { code: "prompt_deadline_exceeded" },
+	});
+});
+
+test("whitespace and provider failures stay actionable across a late empty agent_end", async () => {
+	let records: unknown[] = [];
+	const store = {
+		path: null,
+		load: async () => records,
+		transact: async (mutator: (current: never[]) => never[]) => {
+			records = mutator(records as never);
+		},
+	} as never;
+	const reconciliation = createInvocationReconciliation({ store });
+	const whitespace = { commandId: "whitespace-command", turnId: "whitespace-turn" };
+	await reconciliation.noteAccepted("prompt", whitespace, "whitespace-ref");
+	await reconciliation.noteTransition("prompt", whitespace, {
+		type: "agent_end",
+		content: { version: 1, type: "text", text: " \t\n ", byteLength: 4, truncated: false },
+	});
+	expect(reconciliation.lookup("prompt", { clientRef: "whitespace-ref" })).toMatchObject({
+		status: "failed",
+		error: { code: "prompt_failed", message: "Prompt submission failed." },
+	});
+
+	const providerFailure = { commandId: "provider-command", turnId: "provider-turn" };
+	await reconciliation.noteAccepted("prompt", providerFailure, "provider-ref");
+	await reconciliation.noteTransition("prompt", providerFailure, {
+		type: "agent_failed",
+		error: Object.assign(new Error("provider leaked detail"), { code: "provider_unavailable" }),
+	});
+	await reconciliation.noteTransition("prompt", providerFailure, {
+		type: "agent_end",
+		content: { version: 1, type: "text", text: "", byteLength: 0, truncated: false },
+	});
+	expect(reconciliation.lookup("prompt", { clientRef: "provider-ref" })).toMatchObject({
+		status: "failed",
+		error: { code: "provider_unavailable", message: "Prompt submission failed." },
+	});
+});
+
+test("an empty prompt terminal remains failed after a late real failure", async () => {
 	let records: unknown[] = [];
 	let writes = 0;
 	const store = {
@@ -550,9 +701,12 @@ test("failed agent_end upgrade persistence retains the deadline record for retry
 		code: "prompt_deadline_exceeded",
 		message: "deadline",
 	});
-	await expect(reconciliation.noteTransition("prompt", correlation, { type: "agent_end" })).rejects.toThrow(
-		"upgrade persist failed",
-	);
+	await expect(
+		reconciliation.noteTransition("prompt", correlation, {
+			type: "agent_end",
+			content: { version: 1, type: "text", text: "completed", byteLength: 9, truncated: false },
+		}),
+	).rejects.toThrow("upgrade persist failed");
 	expect(reconciliation.lookup("prompt", { clientRef: "upgrade-failure-ref" })).toMatchObject({
 		status: "failed",
 		error: { code: "prompt_deadline_exceeded" },
@@ -563,17 +717,132 @@ test("failed agent_end upgrade persistence retains the deadline record for retry
 		status: "failed",
 		error: { code: "prompt_deadline_exceeded" },
 	});
-	await reconciliation.noteTransition("prompt", correlation, { type: "agent_end" });
+	await reconciliation.noteTransition("prompt", correlation, {
+		type: "agent_end",
+		content: { version: 1, type: "text", text: "completed", byteLength: 9, truncated: false },
+	});
 	const reloaded = createInvocationReconciliation({ store });
 	await reloaded.hydrate();
 	expect(reloaded.lookup("prompt", { clientRef: "upgrade-failure-ref" })).toMatchObject({ status: "terminal_ok" });
+});
+
+test("late cancellation and non-text activity upgrade deadline terminals", async () => {
+	const makeStore = () => {
+		let records: unknown[] = [];
+		return {
+			path: null,
+			load: async () => records,
+			transact: async (mutator: (current: never[]) => never[]) => {
+				records = mutator(records as never);
+			},
+		} as never;
+	};
+	const cancelled = createInvocationReconciliation({ store: makeStore() });
+	const cancelledCorrelation = { commandId: "late-cancel-command", turnId: "late-cancel-turn" };
+	await cancelled.noteAccepted("prompt", cancelledCorrelation, "late-cancel-ref");
+	await cancelled.finalizeOutcome("prompt", cancelledCorrelation, {
+		kind: "failed",
+		code: "prompt_deadline_exceeded",
+		message: "deadline",
+	});
+	await cancelled.noteTransition("prompt", cancelledCorrelation, {
+		type: "agent_end",
+		outcome: { kind: "stopped", reason: "cancelled", provenance: "client_cancel" },
+	});
+	expect(cancelled.lookup("prompt", { clientRef: "late-cancel-ref" })).toMatchObject({ status: "terminal_ok" });
+
+	const activity = createInvocationReconciliation({ store: makeStore() });
+	const activityCorrelation = { commandId: "late-activity-command", turnId: "late-activity-turn" };
+	await activity.noteAccepted("prompt", activityCorrelation, "late-activity-ref");
+	await activity.finalizeOutcome("prompt", activityCorrelation, {
+		kind: "failed",
+		code: "prompt_deadline_exceeded",
+		message: "deadline",
+	});
+	await activity.noteTransition("prompt", activityCorrelation, { type: "agent_end", hasActivity: true });
+	expect(activity.lookup("prompt", { clientRef: "late-activity-ref" })).toMatchObject({ status: "terminal_ok" });
+});
+test("finalization without an explicit outcome follows the noteTransition evidence predicate", async () => {
+	const makeLocalStore = () => {
+		let records: unknown[] = [];
+		return {
+			path: null,
+			load: async () => records,
+			transact: async (mutator: (current: never[]) => never[]) => {
+				records = mutator(records as never);
+			},
+		} as never;
+	};
+	const contentBearing = createInvocationReconciliation({ store: makeLocalStore() });
+	const contentCorrelation = { commandId: "final-content-command", turnId: "final-content-turn" };
+	await contentBearing.noteAccepted("prompt", contentCorrelation, "final-content-ref");
+	await contentBearing.finalizeOutcome("prompt", contentCorrelation, undefined, undefined, undefined, {
+		content: { version: 1, type: "text", text: "completed", byteLength: 9, truncated: false },
+	});
+	expect(contentBearing.lookup("prompt", { clientRef: "final-content-ref" })).toMatchObject({
+		status: "terminal_ok",
+	});
+
+	const activityBearing = createInvocationReconciliation({ store: makeLocalStore() });
+	const activityCorrelation = { commandId: "final-activity-command", turnId: "final-activity-turn" };
+	await activityBearing.noteAccepted("prompt", activityCorrelation, "final-activity-ref");
+	await activityBearing.finalizeOutcome("prompt", activityCorrelation, undefined, undefined, undefined, {
+		hasActivity: true,
+	});
+	expect(activityBearing.lookup("prompt", { clientRef: "final-activity-ref" })).toMatchObject({
+		status: "terminal_ok",
+	});
+
+	const stoppedOutcome = createInvocationReconciliation({ store: makeLocalStore() });
+	const stoppedCorrelation = { commandId: "final-stopped-command", turnId: "final-stopped-turn" };
+	await stoppedOutcome.noteAccepted("prompt", stoppedCorrelation, "final-stopped-ref");
+	await stoppedOutcome.finalizeOutcome("prompt", stoppedCorrelation, undefined, undefined, undefined, {
+		outcomeKind: "stopped",
+	});
+	expect(stoppedOutcome.lookup("prompt", { clientRef: "final-stopped-ref" })).toMatchObject({
+		status: "terminal_ok",
+	});
+
+	const evidenceFree = createInvocationReconciliation({ store: makeLocalStore() });
+	const emptyCorrelation = { commandId: "final-empty-command", turnId: "final-empty-turn" };
+	await evidenceFree.noteAccepted("prompt", emptyCorrelation, "final-empty-ref");
+	await evidenceFree.finalizeOutcome("prompt", emptyCorrelation);
+	expect(evidenceFree.lookup("prompt", { clientRef: "final-empty-ref" })).toMatchObject({
+		status: "failed",
+		error: { code: "prompt_failed" },
+	});
+	const legacyArg5 = createInvocationReconciliation({ store: makeLocalStore() });
+	const legacyCorrelation = { commandId: "final-legacy-command", turnId: "final-legacy-turn" };
+	await legacyArg5.noteAccepted("prompt", legacyCorrelation, "final-legacy-ref");
+	await legacyArg5.finalizeOutcome("prompt", legacyCorrelation, undefined, undefined, {
+		content: { version: 1, type: "text", text: "legacy", byteLength: 6, truncated: false },
+	});
+	expect(legacyArg5.lookup("prompt", { clientRef: "final-legacy-ref" })).toMatchObject({
+		status: "terminal_ok",
+	});
+
+	const explicitFailure = createInvocationReconciliation({ store: makeLocalStore() });
+	const failureCorrelation = { commandId: "final-failure-command", turnId: "final-failure-turn" };
+	await explicitFailure.noteAccepted("prompt", failureCorrelation, "final-failure-ref");
+	await explicitFailure.finalizeOutcome("prompt", failureCorrelation, {
+		kind: "failed",
+		code: "provider_rejected",
+		message: "provider rejected",
+	});
+	expect(explicitFailure.lookup("prompt", { clientRef: "final-failure-ref" })).toMatchObject({
+		status: "failed",
+		error: { code: "provider_rejected" },
+	});
 });
 
 test("a reason attached after a prompt settled is never replaced by a later failure", async () => {
 	const reconciliation = createInvocationReconciliation();
 	const correlation = { commandId: "late-reason-command", turnId: "late-reason-turn" };
 	await reconciliation.noteAccepted("prompt", correlation, "late-reason-ref");
-	await reconciliation.noteTransition("prompt", correlation, { type: "agent_end" });
+	await reconciliation.noteTransition("prompt", correlation, {
+		type: "agent_end",
+		content: { version: 1, type: "text", text: "completed", byteLength: 9, truncated: false },
+	});
 	const claimed = reconciliation.lookup("prompt", { clientRef: "late-reason-ref" }) as Record<string, unknown>;
 	expect(claimed).toEqual({
 		status: "terminal_ok",
@@ -649,7 +918,10 @@ test("retains terminal host reconciliation records past the 15-minute window", a
 		reconciliation.admit("skill", "aged-skill-ref");
 		await reconciliation.noteAccepted("prompt", promptCorrelation, "aged-ref");
 		await reconciliation.noteAccepted("skill", skillCorrelation, "aged-skill-ref");
-		await reconciliation.noteTransition("prompt", promptCorrelation, { type: "agent_end" });
+		await reconciliation.noteTransition("prompt", promptCorrelation, {
+			type: "agent_end",
+			content: { version: 1, type: "text", text: "completed", byteLength: 9, truncated: false },
+		});
 		await reconciliation.noteTransition("skill", skillCorrelation, { type: "agent_end" });
 
 		clock += 15 * 60_000 + 1;
@@ -679,7 +951,10 @@ test("capacity eviction still releases the clientRef and reports honest unknown"
 		const correlation = { commandId: `capacity-command-${index}`, turnId: `capacity-turn-${index}` };
 		reconciliation.admit("prompt", `capacity-ref-${index}`);
 		await reconciliation.noteAccepted("prompt", correlation, `capacity-ref-${index}`);
-		await reconciliation.noteTransition("prompt", correlation, { type: "agent_end" });
+		await reconciliation.noteTransition("prompt", correlation, {
+			type: "agent_end",
+			content: { version: 1, type: "text", text: "completed", byteLength: 9, truncated: false },
+		});
 	}
 	expect(reconciliation.lookup("prompt", { clientRef: "capacity-ref-1" })).toEqual({
 		status: "unknown",
@@ -1870,10 +2145,10 @@ describe("SessionSdkSessionRuntime", () => {
 			prompt("conn-b", "stale-b");
 			await waitResponse("stale-b");
 			// A later AGENT-INITIATED turn starts: the pending queue is empty, so
-			// the owner stays conn-a (B's stale connection is not associated).
+			// the predecessor's conn-a owner is cleared and no SDK client owns it.
 			await handlers.get("agent_start")?.({ type: "agent_start" }, ctx);
-			// B's abort must NOT stop the agent-initiated turn.
-			transport.feed("conn-b", {
+			// A's stale owner must NOT stop the agent-initiated turn.
+			transport.feed("conn-a", {
 				type: "control_request",
 				id: "stale-owner-abort",
 				operation: "turn.abort",
@@ -1983,6 +2258,40 @@ describe("SessionSdkSessionRuntime", () => {
 			expect(seamCalls).toHaveLength(0);
 		} finally {
 			await handlers.get("session_shutdown")?.({}, ctx);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("agent-initiated successor activity cannot renew a stale predecessor deadline", async () => {
+		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-sdk-stale-deadline-owner-"));
+		try {
+			const harness = await invocationHarness("stale-deadline-owner", cwd, {
+				settings: {
+					get: (key: string) =>
+						key === "sdk.promptDeadlineMs" ? 25 : key === "sdk.promptMaxRuntimeMs" ? 60_000 : undefined,
+				} as unknown as Settings,
+				sendUserMessage: async (_content, options) => {
+					await options?.onPreflightAcceptCommit?.();
+					await neverSettlingPromise();
+				},
+			});
+			const prompt = await harness.control("turn.prompt", { text: "predecessor" });
+			expect(prompt.ok).toBe(true);
+			const ids = { commandId: prompt.result?.commandId, turnId: prompt.result?.turnId };
+			await harness.emit("agent_start");
+			// Empty drain represents an agent-initiated successor with no SDK owner.
+			await harness.emit("agent_start");
+			for (let i = 0; i < 3; i += 1) {
+				await harness.emit("tool_execution_start");
+				await Bun.sleep(15);
+			}
+			expect(await settledStatus(harness, "turn.prompt_status", ids)).toMatchObject({
+				status: "failed",
+				error: { code: "prompt_deadline_exceeded" },
+			});
+			await harness.stop();
+		} finally {
+			await Bun.sleep(50);
 			await rm(cwd, { recursive: true, force: true });
 		}
 	});
@@ -2985,7 +3294,7 @@ async function invocationHarness(
 	sessionId: string,
 	cwd: string,
 	hooks: {
-		sendUserMessage?: (content: unknown, options?: PreflightHooks & { deliverAs?: string }) => Promise<void>;
+		sendUserMessage?: (content: unknown, options?: PreflightHooks & { deliverAs?: string }) => Promise<unknown>;
 		invokeSkill?: (name: string, args?: string, options?: PreflightHooks) => Promise<unknown>;
 		abort?: () => void;
 		isIdle?: () => boolean;
@@ -3010,7 +3319,10 @@ async function invocationHarness(
 		on(event: string, handler: (event: unknown, ctx: unknown) => Promise<void> | void) {
 			handlers.set(event, handler);
 		},
-		sendUserMessage: hooks.sendUserMessage ?? (async () => {}),
+		sendUserMessage: async (content: unknown, options?: PreflightHooks & { deliverAs?: string }) => {
+			const result = await hooks.sendUserMessage?.(content, options);
+			return result === undefined ? "completed" : result;
+		},
 	} as unknown as ExtensionAPI;
 	const interceptorStore = hooks.persistInterceptor
 		? createInterceptorReconciliationStore(
@@ -3202,13 +3514,19 @@ async function settledStatus(
 	name: string,
 	input: Record<string, unknown>,
 ): Promise<NonNullable<ResponseFrame["result"]>> {
-	for (let attempt = 0; attempt < 200; attempt += 1) {
+	// Wall-clock budget instead of a fixed poll count: CI runners can starve the
+	// event loop long enough to exhaust 200 ~1ms polls before a 25ms deadline
+	// timer is dispatched, failing a correct implementation on timing alone.
+	// The contract is unchanged — the status must still reach a terminal
+	// reconciliation state with the asserted shape within a bounded horizon.
+	const budgetEndsAt = Date.now() + 10_000;
+	for (;;) {
 		const frame = await harness.query(name, input);
 		const result = frame.result;
 		if (result && (result.status === "failed" || result.status === "terminal_ok")) return result;
+		if (Date.now() > budgetEndsAt) throw new Error(`${name} never reported a terminal reconciliation status`);
 		await Bun.sleep(1);
 	}
-	throw new Error(`${name} never reported a terminal reconciliation status`);
 }
 
 function neverSettlingPromise(): Promise<void> {
@@ -3429,7 +3747,10 @@ describe("post-acceptance invocation terminalization", () => {
 					},
 				],
 			});
-			expect(await settledStatus(harness, "turn.prompt_status", ids)).toMatchObject({ status: "terminal_ok" });
+			expect(await settledStatus(harness, "turn.prompt_status", ids)).toMatchObject({
+				status: "failed",
+				error: { code: "prompt_failed" },
+			});
 			await harness.stop();
 		} finally {
 			await Bun.sleep(50);
@@ -3460,7 +3781,10 @@ describe("post-acceptance invocation terminalization", () => {
 					},
 				],
 			});
-			expect(await settledStatus(harness, "turn.prompt_status", ids)).toMatchObject({ status: "terminal_ok" });
+			expect(await settledStatus(harness, "turn.prompt_status", ids)).toMatchObject({
+				status: "failed",
+				error: { code: "prompt_failed" },
+			});
 			await harness.stop();
 		} finally {
 			await Bun.sleep(50);
@@ -3489,7 +3813,8 @@ describe("post-acceptance invocation terminalization", () => {
 			});
 			await harness.emit("agent_end", event);
 			expect(await settledStatus(harness, "turn.prompt_status", ids)).toMatchObject({
-				status: "terminal_ok",
+				status: "failed",
+				error: { code: "prompt_failed" },
 			});
 			await harness.stop();
 		} finally {
@@ -3530,7 +3855,9 @@ describe("post-acceptance invocation terminalization", () => {
 				error: { code: "provider_http_402" },
 			});
 			expect((await harness.query("turn.prompt_status", replacementIds)).result?.status).toBe("in_flight");
-			await harness.emit("agent_end", { messages: [{ role: "assistant", stopReason: "stop" }] });
+			await harness.emit("agent_end", {
+				messages: [{ role: "assistant", stopReason: "stop", content: "completed" }],
+			});
 			expect(await settledStatus(harness, "turn.prompt_status", replacementIds)).toMatchObject({
 				status: "terminal_ok",
 			});
@@ -3656,7 +3983,9 @@ describe("post-acceptance invocation terminalization", () => {
 				expect(successor.ok).toBe(true);
 				const successorIds = { commandId: successor.result?.commandId, turnId: successor.result?.turnId };
 				await harness.emit("agent_start");
-				await harness.emit("agent_end", { messages: [{ role: "assistant", stopReason: "stop" }] });
+				await harness.emit("agent_end", {
+					messages: [{ role: "assistant", stopReason: "stop", content: "completed" }],
+				});
 				secondInflight.resolve();
 				expect(await settledStatus(harness, "turn.prompt_status", successorIds)).toMatchObject({
 					status: "terminal_ok",
@@ -3789,7 +4118,9 @@ describe("post-acceptance invocation terminalization", () => {
 			expect(successor.ok).toBe(true);
 			const successorIds = { commandId: successor.result?.commandId, turnId: successor.result?.turnId };
 			await harness.emit("agent_start");
-			await harness.emit("agent_end", { messages: [{ role: "assistant", stopReason: "stop" }] });
+			await harness.emit("agent_end", {
+				messages: [{ role: "assistant", stopReason: "stop", content: "completed" }],
+			});
 			secondInflight.resolve();
 			expect(await settledStatus(harness, "turn.prompt_status", successorIds)).toMatchObject({
 				status: "terminal_ok",
@@ -3938,7 +4269,7 @@ describe("post-acceptance invocation terminalization", () => {
 				status: "failed",
 				error: { code: "aborted" },
 			});
-			await harness.emit("agent_end");
+			await harness.emit("agent_end", { messages: [{ role: "assistant", content: "completed" }] });
 			expect(await settledStatus(harness, "turn.prompt_status", secondIds)).toMatchObject({
 				status: "terminal_ok",
 			});
@@ -3989,8 +4320,8 @@ describe("post-acceptance invocation terminalization", () => {
 			expect(await harness.query("turn.prompt_status", successorIds)).toMatchObject({
 				result: { status: expect.stringMatching(/accepted|in_flight/) },
 			});
-			await harness.emit("agent_end");
-			await harness.emit("agent_end");
+			await harness.emit("agent_end", { messages: [{ role: "assistant", content: "completed" }] });
+			await harness.emit("agent_end", { messages: [{ role: "assistant", content: "completed" }] });
 			expect(await settledStatus(harness, "turn.prompt_status", successorIds)).toMatchObject({
 				status: "terminal_ok",
 			});
@@ -4078,7 +4409,7 @@ describe("post-acceptance invocation terminalization", () => {
 			expect(accepted.ok).toBe(true);
 			const successorIds = { commandId: accepted.result?.commandId, turnId: accepted.result?.turnId };
 			await harness.emit("agent_start");
-			await harness.emit("agent_end");
+			await harness.emit("agent_end", { messages: [{ role: "assistant", content: "completed" }] });
 			expect(await settledStatus(harness, "turn.prompt_status", successorIds)).toMatchObject({
 				status: "terminal_ok",
 			});
@@ -4277,7 +4608,7 @@ describe("post-acceptance invocation terminalization", () => {
 			const accepted = await harness.control("turn.prompt", { text: "hello" });
 			const { commandId, turnId } = accepted.result ?? {};
 			await harness.emit("agent_start");
-			await harness.emit("agent_end");
+			await harness.emit("agent_end", { messages: [{ role: "assistant", content: "completed" }] });
 			const claimed = await settledStatus(harness, "turn.prompt_status", { commandId, turnId });
 			expect(claimed).toMatchObject({ status: "terminal_ok" });
 			inflight.reject(Object.assign(new Error("late provider failure"), { code: "upstream_error" }));
@@ -4445,7 +4776,7 @@ describe("accepted-control zero-execution bound (#4668)", () => {
 			const first = await harness.control("turn.prompt", { text: "first" });
 			expect(first.ok).toBe(true);
 			await harness.emit("agent_start");
-			await harness.emit("agent_end");
+			await harness.emit("agent_end", { messages: [{ role: "assistant", content: "completed" }] });
 			const followUpB = await harness.control("turn.follow_up", { text: "b" });
 			const followUpC = await harness.control("turn.follow_up", { text: "c" });
 			promoted[0]?.({ startsOwnRun: true });
@@ -4593,7 +4924,7 @@ describe("accepted-control zero-execution bound (#4668)", () => {
 			}
 			const midRun = await harness.query("turn.prompt_status", ids);
 			expect(midRun.result?.status).not.toBe("failed");
-			await harness.emit("agent_end");
+			await harness.emit("agent_end", { messages: [{ role: "assistant", content: "completed" }] });
 			const final = await harness.query("turn.prompt_status", ids);
 			expect(final.result?.status).toBe("terminal_ok");
 			await harness.stop();
@@ -4688,7 +5019,7 @@ describe("accepted-control zero-execution bound (#4668)", () => {
 			// The consuming run ends. The consumed submission must terminalize
 			// WITH it (terminal_ok, never a fabricated prompt_deadline_exceeded):
 			// with the bug it would still be parked in pending as merely accepted.
-			await handlers.get("agent_end")?.({}, ctx);
+			await handlers.get("agent_end")?.({ messages: [{ role: "assistant", content: "completed" }] }, ctx);
 			const statusOf = async (ids: { commandId?: string; turnId?: string }, frameId: string) => {
 				transport.feed("conn-a", {
 					type: "query_request",
@@ -4766,7 +5097,7 @@ describe("accepted-control zero-execution bound (#4668)", () => {
 			expect(midRun.result?.status).not.toBe("terminal_ok");
 			expect(midRun.result?.status).not.toBe("failed");
 			// The in-flight run ends: the diverted correlation terminalizes with it.
-			await harness.emit("agent_end");
+			await harness.emit("agent_end", { messages: [{ role: "assistant", content: "completed" }] });
 			expect(await settledStatus(harness, "turn.prompt_status", idsRaced)).toMatchObject({
 				status: "terminal_ok",
 			});
@@ -4825,7 +5156,7 @@ describe("accepted-control zero-execution bound (#4668)", () => {
 			expect(queued.result?.status).not.toBe("failed");
 			// Real consumption re-leases and attaches to the in-flight run.
 			consumed?.({ startsOwnRun: false });
-			await harness.emit("agent_end");
+			await harness.emit("agent_end", { messages: [{ role: "assistant", content: "completed" }] });
 			expect(await settledStatus(harness, "turn.prompt_status", idsRaced)).toMatchObject({
 				status: "terminal_ok",
 			});
@@ -5265,6 +5596,7 @@ describe("accepted-control zero-execution bound (#4668)", () => {
 			const acceptedA = (await waitFrame("settle-early-a")) as { result?: { commandId?: string; turnId?: string } };
 			const idsA = { commandId: acceptedA.result?.commandId, turnId: acceptedA.result?.turnId };
 			const statusDeadline = Date.now() + 15_000;
+			let settledStatus: string | undefined;
 			for (;;) {
 				transport.feed("conn-a", {
 					type: "query_request",
@@ -5276,10 +5608,12 @@ describe("accepted-control zero-execution bound (#4668)", () => {
 					result?: { status?: string };
 				};
 				transport.sent.splice(transport.sent.indexOf(statusFrame), 1);
-				if (statusFrame.result?.status === "terminal_ok") break;
+				settledStatus = statusFrame.result?.status;
+				if (statusFrame.result?.status === "terminal_ok" || statusFrame.result?.status === "failed") break;
 				if (Date.now() > statusDeadline) throw new Error("settled prompt never reported terminal_ok");
 				await Bun.sleep(20);
 			}
+			expect(settledStatus).toBe("failed");
 			// conn-b's prompt is accepted and hangs; its run then starts.
 			transport.feed("conn-b", {
 				type: "control_request",
@@ -5954,7 +6288,7 @@ test("SDK-only host lets every connection whose follow-up was promoted abort the
 			Promise.resolve(options?.onPreflightAcceptCommit?.()).then(() => {
 				if (options?.onQueuedPromoted) promoted.push(options.onQueuedPromoted);
 				options?.onPreflightAccepted?.();
-				return {};
+				return "completed";
 			}),
 	} as unknown as ExtensionAPI;
 	const transport = memoryTransport();
@@ -6042,7 +6376,7 @@ test("SDK-only host lets every connection whose follow-up was promoted abort the
 		// invocation left the remaining follow-ups durably accepted — their
 		// result lookups would never complete and a restart would report them
 		// failed even though they ran in the shared turn.
-		await handlers.get("agent_end")?.({ type: "agent_end" }, ctx);
+		await handlers.get("agent_end")?.({ type: "agent_end", stopReason: "cancelled", messages: [] }, ctx);
 		{
 			const terminalDeadline = Date.now() + 15_000;
 			const promptStatuses = () =>

--- a/packages/coding-agent/src/sdk/host/session-runtime.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.ts
@@ -34,7 +34,7 @@ import {
 	syntheticNamespaceCollision,
 } from "../model-profile-model";
 import { projectQ10Models } from "../models.js";
-import { PromptDeadlineManager } from "../prompt-deadline-manager";
+import { PromptDeadlineManager, type PromptTerminalTransitionEvidence } from "../prompt-deadline-manager";
 import { formatPromptFailureForLocalLog, sanitizePromptFailure } from "../prompt-failure";
 import { OPERATIONS } from "../protocol/operation-registry";
 import {
@@ -43,6 +43,7 @@ import {
 	type KindAwareReconciliation,
 	resolveReconciliationSessionFile,
 } from "../reconciliation-extensions";
+import { sanitizeTurnResultContent, type TurnResultContent } from "../turn-result";
 import { type ControlSurface, controlRequestFromFrame, dispatchControl } from "./control";
 import { BROKER_RUNTIME_CLOSE_CAPABILITY_FIELD } from "./control/runtime-gate";
 import { SessionSdkHost, type SessionSdkHostOptions } from "./host";
@@ -420,6 +421,7 @@ export interface InvocationCorrelation {
 
 export type InvocationKind = "prompt" | "skill" | "steer";
 type InvocationStatus = "accepted" | "in_flight" | "terminal_ok" | "failed" | "uncertain";
+const EMPTY_PROMPT_FAILURE = { code: "prompt_failed", message: "Prompt submission failed." } as const;
 interface InvocationRecord extends InvocationCorrelation {
 	kind: InvocationKind;
 	revision: number;
@@ -440,7 +442,14 @@ export interface InvocationReconciliation {
 	noteTransition(
 		kind: InvocationKind,
 		correlation: InvocationCorrelation | undefined,
-		frame: { type: "agent_start" | "agent_end" } | { type: "agent_failed"; error: unknown },
+		frame:
+			| {
+					type: "agent_start" | "agent_end";
+					content?: TurnResultContent;
+					hasActivity?: boolean;
+					outcome?: { kind: "stopped"; reason: "cancelled"; provenance: "client_cancel" };
+			  }
+			| { type: "agent_failed"; error: unknown; content?: TurnResultContent; hasActivity?: boolean },
 	): Promise<void>;
 	lookup(kind: InvocationKind, selector: { commandId?: string; turnId?: string; clientRef?: string }): unknown;
 	lookupResult(kind: InvocationKind, selector: { commandId?: string; turnId?: string; clientRef?: string }): unknown;
@@ -464,7 +473,13 @@ export interface InvocationReconciliation {
 		correlation: InvocationCorrelation,
 		outcome?: { kind: string; code: string; message: string; provenance?: string },
 		arg4?: (() => boolean) | { code: string; message: string },
+		// Terminal evidence accepted by finalizeOutcome (exact-head review P1/P2):
+		// when an explicit outcome is absent, a content-bearing, activity-bearing,
+		// or explicitly stopped finalization is still a successful terminal; only a
+		// genuinely empty, no-activity completion fails closed with the sanitized
+		// empty-prompt failure. Mirrors the noteTransition evidence predicate.
 		arg5?: unknown,
+		arg6?: { content?: TurnResultContent; hasActivity?: boolean; outcomeKind?: string },
 	): Promise<void>;
 	markUncertain(
 		kind: InvocationKind,
@@ -699,7 +714,14 @@ export function createInvocationReconciliation(
 						// so a real lifecycle event is never swallowed.
 					}
 					const current = records.get(recordKey);
-					if (frame.type === "agent_end" && current === pending.finalizedRecord) {
+					if (
+						frame.type === "agent_end" &&
+						current === pending.finalizedRecord &&
+						(kind !== "prompt" ||
+							frame.outcome?.kind === "stopped" ||
+							frame.hasActivity === true ||
+							frame.content?.text.trim())
+					) {
 						// A real lifecycle end that arrived during deadline finalization is
 						// stronger evidence than the synthetic deadline outcome. Upgrade the
 						// durable terminal instead of treating the event as a duplicate.
@@ -734,7 +756,14 @@ export function createInvocationReconciliation(
 				}
 			}
 			if (record.terminalAt !== undefined) {
-				if (frame.type === "agent_end" && record.error?.code === "prompt_deadline_exceeded") {
+				if (
+					frame.type === "agent_end" &&
+					record.error?.code === "prompt_deadline_exceeded" &&
+					(kind !== "prompt" ||
+						frame.outcome?.kind === "stopped" ||
+						frame.hasActivity === true ||
+						frame.content?.text.trim())
+				) {
 					const upgraded = { ...record, revision: ++mutationRevision, status: "terminal_ok" as const };
 					// The synthetic deadline error is superseded evidence; terminal_ok must not
 					// surface a deadline failure for a prompt that actually completed.
@@ -795,7 +824,17 @@ export function createInvocationReconciliation(
 				if (next.error === undefined || (next.error.code === "agent_failed" && failure.code !== "agent_failed"))
 					next.error = failure;
 			} else {
-				next.status = next.error === undefined ? "terminal_ok" : "failed";
+				if (
+					kind === "prompt" &&
+					next.error === undefined &&
+					frame.type === "agent_end" &&
+					frame.outcome?.kind !== "stopped" &&
+					!frame.content?.text.trim() &&
+					!frame.hasActivity
+				) {
+					next.status = "failed";
+					next.error = EMPTY_PROMPT_FAILURE;
+				} else next.status = next.error === undefined ? "terminal_ok" : "failed";
 				next.terminalAt = Date.now();
 			}
 			records.set(recordKey, next);
@@ -868,6 +907,7 @@ export function createInvocationReconciliation(
 			outcome,
 			arg4?: (() => boolean) | { code: string; message: string },
 			arg5?: unknown,
+			arg6?: { content?: TurnResultContent; hasActivity?: boolean; outcomeKind?: string },
 		) {
 			// Normalize every supported positional form (exact-head review P1):
 			//   (…, isCurrent) | (…, recordError) | (…, undefined, recordError) |
@@ -880,6 +920,14 @@ export function createInvocationReconciliation(
 						? (arg5 as { code: string; message: string })
 						: undefined;
 			const recordError = recordErrorCandidate;
+			// Terminal evidence may also arrive positionally through arg5 (legacy
+			// callers) when it does not carry a recordError shape; normalize it so
+			// the empty predicate below sees every evidence channel consistently.
+			const legacyEvidenceCandidate =
+				typeof arg5 === "object" && arg5 !== null && !("code" in arg5)
+					? (arg5 as { content?: TurnResultContent; hasActivity?: boolean; outcomeKind?: string })
+					: undefined;
+			const evidence = arg6 ?? legacyEvidenceCandidate;
 			const recordKey = key(kind, correlation);
 			const record = records.get(recordKey);
 			if (!record || record.terminalAt !== undefined || record.kind !== kind) return;
@@ -896,6 +944,19 @@ export function createInvocationReconciliation(
 					recordError !== undefined
 						? { code: recordError.code, message: recordError.message }
 						: { code: finalOutcome.code, message: finalOutcome.message };
+			} else if (kind === "prompt" && finalOutcome === undefined) {
+				// Evidence-based empty predicate (exact-head review P1/P2): the same
+				// semantics as the noteTransition agent_end classifier. A
+				// content-bearing, activity-bearing, or explicitly stopped
+				// finalization without an explicit outcome is a successful terminal;
+				// only a genuinely empty, no-activity completion fails closed.
+				const terminalText = evidence?.content?.text.trim() ?? "";
+				if (terminalText === "" && !evidence?.hasActivity && evidence?.outcomeKind !== "stopped") {
+					finalizedRecord.status = "failed";
+					finalizedRecord.error = EMPTY_PROMPT_FAILURE;
+				} else {
+					finalizedRecord.status = "terminal_ok";
+				}
 			} else {
 				finalizedRecord.status = "terminal_ok";
 			}
@@ -1597,6 +1658,55 @@ function providerFailureFromAgentEnd(event: unknown): { code: string; message: s
 		// Provider metadata is untrusted: an SDK/provider adapter may expose a
 		// throwing getter while the lifecycle boundary still needs to terminalize.
 		return undefined;
+	}
+}
+
+interface PromptTerminalEvidence {
+	content?: TurnResultContent;
+	hasActivity: boolean;
+}
+
+function promptTerminalEvidenceFromAgentEnd(event: unknown): PromptTerminalEvidence {
+	try {
+		if (!event || typeof event !== "object") return { hasActivity: false };
+		const messages = (event as { messages?: unknown }).messages;
+		if (!Array.isArray(messages)) return { hasActivity: false };
+		const assistant = [...messages]
+			.reverse()
+			.find(
+				message => message && typeof message === "object" && (message as { role?: unknown }).role === "assistant",
+			);
+		if (!assistant || typeof assistant !== "object") return { hasActivity: false };
+		const content = (assistant as { content?: unknown }).content;
+		if (typeof content === "string") {
+			const bounded = sanitizeTurnResultContent(content);
+			return { content: bounded, hasActivity: content.trim().length > 0 };
+		}
+		if (Array.isArray(content)) {
+			const hasActivity = content.some(block => {
+				if (block === null || typeof block !== "object") return false;
+				const type = (block as { type?: unknown }).type;
+				if (type === "text") {
+					const text = (block as { text?: unknown }).text;
+					return typeof text === "string" && text.trim().length > 0;
+				}
+				return typeof type === "string" && type.length > 0;
+			});
+			const text = content
+				.filter(
+					(block): block is { type: "text"; text: string } =>
+						block !== null &&
+						typeof block === "object" &&
+						(block as { type?: unknown }).type === "text" &&
+						typeof (block as { text?: unknown }).text === "string",
+				)
+				.map(block => block.text)
+				.join("");
+			return { content: sanitizeTurnResultContent(text), hasActivity };
+		}
+		return { content: sanitizeTurnResultContent(""), hasActivity: false };
+	} catch {
+		return { hasActivity: false };
 	}
 }
 
@@ -3374,6 +3484,9 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 		failureCause?: unknown,
 		maintenanceOutcome?: string,
 		lifecycleOwner?: LifecycleOwner,
+		terminalContent?: TurnResultContent,
+		terminalHasActivity = false,
+		terminalOutcome?: { kind: "stopped"; reason: "cancelled"; provenance: "client_cancel" },
 	): Promise<void> => {
 		const current = lifecycleOwner?.state ?? active;
 		if (!current) return;
@@ -3461,6 +3574,11 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 				if (current.activeInvocation?.kind === "prompt") {
 					current.deadlineManager.onAccepted(current.activeInvocation.correlation);
 				}
+			} else {
+				// An empty drain is an agent-initiated successor run. Clear the
+				// predecessor's SDK owner and active invocation so abort ownership and
+				// tool-progress renewal cannot leak into the successor.
+				adoptLifecycleBatch(undefined);
 			}
 			transitions = drained.map(({ kind, correlation }) => ({ kind, correlation }));
 		} else {
@@ -3626,7 +3744,17 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 					const reasonKey = `${invocation.correlation.commandId}:${invocation.correlation.turnId}`;
 					const unrecorded = type === "agent_end" ? current.unrecordedFailureReasons?.get(reasonKey) : undefined;
 					if (type === "agent_end" && invocation.kind === "prompt")
-						current.deadlineManager.noteTerminalTransition(invocation.correlation, unrecorded);
+						current.deadlineManager.noteTerminalTransition(
+							invocation.correlation,
+							unrecorded,
+							terminalContent !== undefined || terminalHasActivity || terminalOutcome !== undefined
+								? ({
+										content: terminalContent,
+										hasActivity: terminalHasActivity,
+										outcome: terminalOutcome,
+									} satisfies PromptTerminalTransitionEvidence)
+								: undefined,
+						);
 					if (type === "agent_end") {
 						// Compound recovery (exact-head review P1): if this run's
 						// agent_failed write failed, re-record the sanitized reason
@@ -3650,7 +3778,16 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 									error:
 										failureCause ?? Object.assign(new Error("agent run failed"), { code: "agent_failed" }),
 								}
-							: { type };
+							: {
+									type,
+									...(type === "agent_end" && terminalContent !== undefined
+										? { content: terminalContent }
+										: {}),
+									...(type === "agent_end" && terminalHasActivity ? { hasActivity: true } : {}),
+									...(type === "agent_end" && terminalOutcome !== undefined
+										? { outcome: terminalOutcome }
+										: {}),
+								};
 					await current.reconciliation.noteTransition(invocation.kind, invocation.correlation, frame as never);
 					if ((type as string) === "agent_end") {
 						if (invocation.kind === "prompt") current.deadlineManager.clear(invocation.correlation);
@@ -3814,6 +3951,11 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 			owner?.failureDiagnosticKeys.has(lifecycleCorrelationKey(correlation)),
 		);
 		const failureAlreadyPublished = failure === undefined || (hasExistingFailure && genericFailureKeys.length === 0);
+		const terminalEvidence = promptTerminalEvidenceFromAgentEnd(event);
+		const terminalOutcome =
+			event.stopReason === "cancelled"
+				? ({ kind: "stopped", reason: "cancelled", provenance: "client_cancel" } as const)
+				: undefined;
 		return trackLifecycle(async () => {
 			if (failure && !failureAlreadyPublished) {
 				for (const key of genericFailureKeys) owner?.failureDiagnosticKeys.delete(key);
@@ -3825,6 +3967,9 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 				undefined,
 				event.stopReason === "maintenance" ? event.maintenanceOutcome : undefined,
 				lifecycleOwner,
+				terminalEvidence.content,
+				terminalEvidence.hasActivity,
+				terminalOutcome,
 			);
 		}, owner).finally(() => {
 			if (typeof event.sdkRunToken === "string" && lifecycleRunOwners.get(event.sdkRunToken)?.state === owner)

--- a/packages/coding-agent/src/sdk/prompt-deadline-manager.ts
+++ b/packages/coding-agent/src/sdk/prompt-deadline-manager.ts
@@ -7,6 +7,7 @@ import {
 	promptDeadlineAt,
 	recordAttributableProgress,
 } from "./prompt-deadline-lease";
+import type { TurnResultContent } from "./turn-result";
 
 const MAX_EXPIRY_RETRIES = 5;
 const MAX_UNCERTAINTY_RETRIES = 3;
@@ -21,6 +22,12 @@ export type PromptDeadlineOutcome = {
 	message: string;
 	provenance: "deadline";
 };
+
+export interface PromptTerminalTransitionEvidence {
+	content?: TurnResultContent;
+	hasActivity?: boolean;
+	outcome?: { kind: "stopped"; reason: "cancelled"; provenance: "client_cancel" };
+}
 
 function leaseKey(correlation: InvocationCorrelation): string {
 	return `${correlation.commandId}:${correlation.turnId}`;
@@ -37,6 +44,7 @@ export class PromptDeadlineManager {
 	readonly #expiring = new Set<string>();
 	readonly #pendingTerminalTransitions = new Set<string>();
 	readonly #pendingTerminalFailureReasons = new Map<string, { code: string; message: string }>();
+	readonly #pendingTerminalEvidence = new Map<string, PromptTerminalTransitionEvidence>();
 	readonly #getLeaseMs: () => number;
 	readonly #getMaxMs: () => number;
 	readonly #now: () => number;
@@ -102,7 +110,10 @@ export class PromptDeadlineManager {
 						error: Object.assign(new Error(failureReason.message), { code: failureReason.code }),
 					} as never);
 				}
-				await this.#reconciliation.noteTransition("prompt", correlation, { type: "agent_end" });
+				await this.#reconciliation.noteTransition("prompt", correlation, {
+					type: "agent_end",
+					...this.#pendingTerminalEvidence.get(key),
+				});
 				// Supersession check before retiring ownership (exact-head review P1):
 				// attributable progress during the awaited writes renews the lease
 				// past its deadline, so this replay instance must back off and
@@ -367,6 +378,7 @@ export class PromptDeadlineManager {
 	noteTerminalTransition(
 		correlation: InvocationCorrelation,
 		pendingFailure?: { code: string; message: string },
+		evidence?: PromptTerminalTransitionEvidence,
 	): void {
 		const key = leaseKey(correlation);
 		if (!this.#leases.has(key)) {
@@ -377,6 +389,7 @@ export class PromptDeadlineManager {
 			this.onAccepted(correlation);
 		}
 		this.#pendingTerminalTransitions.add(key);
+		if (evidence !== undefined) this.#pendingTerminalEvidence.set(key, evidence);
 		// Compound failure-plus-terminal recovery intent (exact-head review HIGH):
 		// when expiry replays this real terminal transition after a failed write, it
 		// must re-record the failure reason BEFORE agent_end, or the abandoned or
@@ -395,6 +408,7 @@ export class PromptDeadlineManager {
 		this.#expiring.delete(key);
 		this.#pendingTerminalTransitions.delete(key);
 		this.#pendingTerminalFailureReasons.delete(key);
+		this.#pendingTerminalEvidence.delete(key);
 	}
 
 	clearAll(): void {
@@ -407,6 +421,7 @@ export class PromptDeadlineManager {
 		this.#expiring.clear();
 		this.#pendingTerminalTransitions.clear();
 		this.#pendingTerminalFailureReasons.clear();
+		this.#pendingTerminalEvidence.clear();
 	}
 
 	/** For tests: current deadline or undefined if no lease. */

--- a/packages/coding-agent/test/sdk-prompt-deadline-manager.test.ts
+++ b/packages/coding-agent/test/sdk-prompt-deadline-manager.test.ts
@@ -21,6 +21,7 @@ interface FakeReconciliation {
 	noteTransitionFailures: number;
 	uncertainCalls: number;
 	noteTransitionFrames: string[];
+	lastNoteTransitionFrame?: { type?: string; content?: unknown; hasActivity?: boolean; outcome?: unknown };
 	finalizeCodes: string[];
 	uncertainFailures: number;
 	uncertainStarted?: () => void;
@@ -60,9 +61,14 @@ function fakeReconciliation(): {
 		state,
 		reconciliation: {
 			lookup: () => ({ status: state.status, ...(state.error === undefined ? {} : { error: state.error }) }),
-			noteTransition: async (_kind: string, _correlation: unknown, frame?: { type?: string }) => {
+			noteTransition: async (
+				_kind: string,
+				_correlation: unknown,
+				frame?: { type?: string; content?: unknown; hasActivity?: boolean; outcome?: unknown },
+			) => {
 				state.noteTransitionCalls += 1;
 				state.noteTransitionFrames.push(frame?.type ?? "unknown");
+				state.lastNoteTransitionFrame = frame;
 				if (state.noteTransitionCalls <= state.noteTransitionFailures) throw new Error("terminal replay failed");
 				state.status = state.error === undefined ? "terminal_ok" : "failed";
 			},
@@ -187,6 +193,30 @@ describe("PromptDeadlineManager expiry reconciliation (#4668)", () => {
 		expect(manager.has(correlation)).toBe(true);
 		await Bun.sleep(2_300);
 		expect(state.noteTransitionCalls).toBeGreaterThanOrEqual(2);
+		expect(manager.has(correlation)).toBe(false);
+	});
+
+	test("retries preserve terminal content and cancellation evidence", async () => {
+		const { reconciliation, state } = fakeReconciliation();
+		state.noteTransitionFailures = 1;
+		const manager = new PromptDeadlineManager({
+			reconciliation: reconciliation as never,
+			getLeaseMs: () => 20,
+			getMaxMs: () => 60_000,
+		});
+		const correlation = { commandId: "cmd-evidence-retry", turnId: "turn-evidence-retry" };
+		manager.noteTerminalTransition(correlation, undefined, {
+			content: { version: 1, type: "text", text: "completed", byteLength: 9, truncated: false },
+			hasActivity: true,
+			outcome: { kind: "stopped", reason: "cancelled", provenance: "client_cancel" },
+		});
+		await Bun.sleep(2_300);
+		expect(state.lastNoteTransitionFrame).toMatchObject({
+			type: "agent_end",
+			content: { text: "completed" },
+			hasActivity: true,
+			outcome: { kind: "stopped", reason: "cancelled" },
+		});
 		expect(manager.has(correlation)).toBe(false);
 	});
 

--- a/packages/coding-agent/test/sdk-q26-prompt-status.test.ts
+++ b/packages/coding-agent/test/sdk-q26-prompt-status.test.ts
@@ -43,10 +43,10 @@ describe("prompt reconciliation record", () => {
 			acceptedAt: clock.now(),
 			startedAt: clock.now(),
 		});
-		rec.noteTransition(correlation(), { type: "agent_end" });
+		rec.noteTransition(correlation(), { type: "agent_end", finalText: "completed" });
 		expect(rec.lookup({ commandId: "command-1", turnId: "turn-1" })).toEqual({
 			status: "terminal_ok",
-			receiptState: "missing",
+			receiptState: "present",
 			commandId: "command-1",
 			turnId: "turn-1",
 			clientRef: "ref-1",
@@ -72,6 +72,26 @@ describe("prompt reconciliation record", () => {
 		expect(result.error.message).not.toMatch(/[\t\r\n]/);
 		expect(result.error.message.length).toBeLessThanOrEqual(512);
 		expect(result.terminalAt).toBeGreaterThan(0);
+	});
+
+	it("accepts explicit cancellation and non-text activity without a visible receipt", () => {
+		const rec = createPromptReconciliation();
+		rec.noteAccepted(correlation(4), "ref-cancelled");
+		rec.noteTransition(correlation(4), {
+			type: "agent_end",
+			outcome: { kind: "stopped", reason: "cancelled", provenance: "client_cancel" },
+		});
+		expect(rec.lookup({ clientRef: "ref-cancelled" })).toMatchObject({
+			status: "terminal_ok",
+			receiptState: "missing",
+		});
+
+		rec.noteAccepted(correlation(5), "ref-activity");
+		rec.noteTransition(correlation(5), { type: "agent_end", hasActivity: true });
+		expect(rec.lookup({ clientRef: "ref-activity" })).toMatchObject({
+			status: "terminal_ok",
+			receiptState: "missing",
+		});
 	});
 
 	it("retains only a safe-token code and never exposes arbitrary failure text", () => {
@@ -137,7 +157,7 @@ describe("prompt reconciliation record", () => {
 		const rec = createPromptReconciliation({ now: clock.now });
 		rec.noteAccepted(correlation(), "ref-1");
 		rec.noteTransition(correlation(), { type: "agent_start" });
-		rec.noteTransition(correlation(), { type: "agent_end" });
+		rec.noteTransition(correlation(), { type: "agent_end", finalText: "completed" });
 		expect(rec.lookup({ clientRef: "ref-1" })).toMatchObject({ status: "terminal_ok" });
 		clock.advance(24 * 60 * 60_000);
 		expect(() => rec.admit("ref-1")).toThrowError(/never reuse a clientRef/);
@@ -146,7 +166,7 @@ describe("prompt reconciliation record", () => {
 
 		for (let n = 2; n <= PROMPT_RECONCILIATION_TERMINAL_CAPACITY + 1; n++) {
 			rec.noteAccepted(correlation(n), `ref-${n}`);
-			rec.noteTransition(correlation(n), { type: "agent_end" });
+			rec.noteTransition(correlation(n), { type: "agent_end", finalText: "completed" });
 			clock.advance(1);
 		}
 		expect(rec.lookup({ clientRef: "ref-1" })).toEqual({ status: "unknown", receiptState: "unknown" });
@@ -187,7 +207,7 @@ describe("prompt reconciliation record", () => {
 		const rec = createPromptReconciliation({ now: clock.now });
 		for (let n = 1; n <= PROMPT_RECONCILIATION_TERMINAL_CAPACITY + 1; n++) {
 			rec.noteAccepted(correlation(n));
-			rec.noteTransition(correlation(n), { type: "agent_end" });
+			rec.noteTransition(correlation(n), { type: "agent_end", finalText: "completed" });
 			clock.advance(1);
 		}
 		expect(rec.lookup({ commandId: "command-1", turnId: "turn-1" })).toEqual({
@@ -214,7 +234,10 @@ describe("prompt reconciliation record", () => {
 		}
 		// The early record terminates LAST (newest terminalAt), so capacity eviction
 		// must drop the oldest terminal record, not the newly terminal one.
-		rec.noteTransition({ commandId: "command-early", turnId: "turn-early" }, { type: "agent_end" });
+		rec.noteTransition(
+			{ commandId: "command-early", turnId: "turn-early" },
+			{ type: "agent_end", finalText: "completed" },
+		);
 		expect(rec.lookup({ clientRef: "ref-early" })).toMatchObject({ status: "terminal_ok" });
 		expect(rec.lookup({ commandId: "command-1", turnId: "turn-1" })).toEqual({
 			status: "unknown",
@@ -281,7 +304,7 @@ describe("prompt reconciliation record", () => {
 		const rec = createPromptReconciliation({ now: clock.now });
 		rec.noteAccepted(correlation(), "ref-late");
 		rec.noteTransition(correlation(), { type: "agent_start" });
-		rec.noteTransition(correlation(), { type: "agent_end" });
+		rec.noteTransition(correlation(), { type: "agent_end", finalText: "completed" });
 		const settled = rec.lookup({ clientRef: "ref-late" });
 		if (settled.status !== "terminal_ok") throw new Error("expected terminal_ok");
 		expect(settled.error).toBeUndefined();
@@ -304,7 +327,7 @@ describe("prompt reconciliation record", () => {
 	it("keeps the first recorded reason when later agent_failed frames disagree", () => {
 		const rec = createPromptReconciliation();
 		rec.noteAccepted(correlation(1), "ref-first");
-		rec.noteTransition(correlation(1), { type: "agent_end" });
+		rec.noteTransition(correlation(1), { type: "agent_end", finalText: "completed" });
 		rec.noteTransition(correlation(1), {
 			type: "agent_failed",
 			error: Object.assign(new Error("first"), { code: "transport_reset" }),
@@ -338,7 +361,7 @@ describe("prompt reconciliation record", () => {
 		rec.noteTransition(correlation(3), { type: "agent_start" });
 		const startedAt = clock.now();
 		clock.advance(10);
-		rec.noteTransition(correlation(3), { type: "agent_end" });
+		rec.noteTransition(correlation(3), { type: "agent_end", finalText: "completed" });
 		const terminalAt = clock.now();
 		rec.noteTransition(correlation(3), {
 			type: "agent_failed",
@@ -346,7 +369,7 @@ describe("prompt reconciliation record", () => {
 		});
 		clock.advance(60_000);
 		rec.noteTransition(correlation(3), { type: "agent_start" });
-		rec.noteTransition(correlation(3), { type: "agent_end" });
+		rec.noteTransition(correlation(3), { type: "agent_end", finalText: "completed" });
 		expect(rec.lookup({ clientRef: "ref-frozen" })).toEqual({
 			status: "terminal_ok",
 			commandId: "command-3",
@@ -355,7 +378,7 @@ describe("prompt reconciliation record", () => {
 			acceptedAt: startedAt,
 			startedAt,
 			terminalAt,
-			receiptState: "missing",
+			receiptState: "present",
 			error: { code: "transport_reset", message: "Prompt submission failed." },
 		});
 		expect(rec.activeCount()).toBe(0);


### PR DESCRIPTION
## Summary

Closes #5015. Empty or absent zero-token prompt completions now reconcile as sanitized terminal failures instead of `terminal_ok`; explicit client cancellation outcomes remain successful no-ops. The change covers native prompt reconciliation, broker durable reconciliation, and SDK session-host reconciliation, including deadline-recovery races. Outcome-free prompt finalizations now follow the same evidence predicate as `noteTransition`: content-bearing, activity-bearing, or explicitly stopped finalizations stay successful; only genuinely empty ones fail closed.

## Risk classification

- [ ] `low-risk`
- [x] `regression-risk`
- [ ] `high-risk`

## Verification

- `bun test packages/coding-agent/src/sdk/host/session-runtime.test.ts` — 115 passed (includes the new evidence-predicate regression for `finalizeOutcome`)
- `bun test packages/coding-agent/test/sdk-prompt-deadline-manager.test.ts packages/coding-agent/test/sdk-q26-prompt-status.test.ts packages/coding-agent/test/sdk-kind-aware-reconciliation.test.ts` — 52 passed
- Deterministic stale-owner/shared-run races and deadline/activity/failure matrix covered by the session-runtime and focused suites
- `bun test packages/coding-agent/test/sdk-kind-aware-reconciliation.test.ts` — 5 passed
- `bun test packages/coding-agent/src/sdk/host/sdk-surface-parity.test.ts packages/coding-agent/src/sdk/host/websocket-transport.lifecycle.test.ts` — 14 passed
- `bun --cwd=packages/coding-agent run check:types` — passed
- `bun --cwd=packages/coding-agent run build` — passed
- `bun --cwd=packages/coding-agent run check` — exit 0 (14 pre-existing warnings outside this PR scope)
- Exact reproduction: finalized `prompt_deadline_exceeded` followed by empty `agent_end` remains `failed` with `prompt_deadline_exceeded` after reload
- Exact base: `4ddbdc48515ad329177e73e735787b4bc3ed7e3a` (current `origin/dev` after PR #5045)
- Exact head: `961aa5a2dc6c8ce6c6658dcfb2f13b41da7705dd`
- Exact diff digest: `sha256:fa78740e7729e50a3e0fb0bac699389a2329117f42322ef0445667a50a9f8afe`
- Reconstruction lineage: byte-identical patch and commit message to prior head `956e944957e9ca5439574727c82c71ade3ea4f35` (which was byte-identical to `5310198232ac4c2c05ae67f58b9aceacaafbb03e`), plus the snowykr exact-head review P1/P2 remediation on `createInvocationReconciliation.finalizeOutcome`

Preserves first-terminal-wins and durable reload semantics. Deadline upgrades require validated non-empty assistant content; explicit `stopped` client-cancel outcomes remain valid.

gajae.pr-review-verdict.v1 merge-approved sha256:fa78740e7729e50a3e0fb0bac699389a2329117f42322ef0445667a50a9f8afe reviewer:human reviewer-id:snowykr evidence:authenticated exact-head APPROVED review by snowykr at 961aa5a2dc6c8ce6c6658dcfb2f13b41da7705dd (16:03:11Z); exact-head CI 33185002141 fully green (session-runtime, shard-1, check, evidence producer, aggregator, state gates all success; sole red = the prior intentional hold)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
