### PR TITLE
fix(update): make standalone migration converge

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -61,7 +61,7 @@ Gajae-Code（`gjc`）は外付けのコーディングエージェントハー�
 **インストール** — Linux（x64/arm64）、macOS（arm64/x64）、Windows（x64）向けビルド済みバイナリ。Bun は不要です:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.0/scripts/install.sh -o gjc-install.sh
+curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.3/scripts/install.sh -o gjc-install.sh
 sh gjc-install.sh
 gjc
 ```
@@ -75,7 +75,7 @@ curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts
 Windows（PowerShell、タグ固定）:
 
 ```powershell
-Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.0/scripts/install.ps1 -OutFile gjc-install.ps1
+Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.3/scripts/install.ps1 -OutFile gjc-install.ps1
 powershell -File gjc-install.ps1
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -61,7 +61,7 @@ Gajae-Code(`gjc`)는 외부 코딩 에이전트 하네스입니다. 아무 저�
 **설치** — Linux(x64/arm64), macOS(arm64/x64), Windows(x64) 프리빌드 바이너리. Bun은 필요 없습니다:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.0/scripts/install.sh -o gjc-install.sh
+curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.3/scripts/install.sh -o gjc-install.sh
 sh gjc-install.sh
 gjc
 ```
@@ -75,7 +75,7 @@ curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts
 Windows (PowerShell, 태그 고정):
 
 ```powershell
-Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.0/scripts/install.ps1 -OutFile gjc-install.ps1
+Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.3/scripts/install.ps1 -OutFile gjc-install.ps1
 powershell -File gjc-install.ps1
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Most coding agents fail on three fronts: they bill you twice, they mutate before
 **Install** — prebuilt binaries for Linux (x64/arm64), macOS (arm64/x64), and Windows (x64). Bun is not required:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.0/scripts/install.sh -o gjc-install.sh
+curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.3/scripts/install.sh -o gjc-install.sh
 sh gjc-install.sh
 gjc
 ```
@@ -73,7 +73,7 @@ curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts
 Windows (PowerShell), tagged:
 
 ```powershell
-Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.0/scripts/install.ps1 -OutFile gjc-install.ps1
+Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.3/scripts/install.ps1 -OutFile gjc-install.ps1
 powershell -File gjc-install.ps1
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,7 +60,7 @@ Gajae-Code（`gjc`）是一个外置编码代理 harness：丢进任意仓库或
 **安装** — 提供 Linux（x64/arm64）、macOS（arm64/x64）、Windows（x64）预编译二进制。不需要 Bun：
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.0/scripts/install.sh -o gjc-install.sh
+curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.3/scripts/install.sh -o gjc-install.sh
 sh gjc-install.sh
 gjc
 ```
@@ -70,7 +70,7 @@ gjc
 Windows（PowerShell，固定标签）：
 
 ```powershell
-Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.0/scripts/install.ps1 -OutFile gjc-install.ps1
+Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.3/scripts/install.ps1 -OutFile gjc-install.ps1
 powershell -File gjc-install.ps1
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,7 +6,7 @@ Prebuilt standalone binaries are the supported end-user install. Bun is not requ
 
 ```sh
 # Tagged installer (recommended): pin the ref, then run locally.
-curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.0/scripts/install.sh -o gjc-install.sh
+curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.3/scripts/install.sh -o gjc-install.sh
 sh gjc-install.sh
 gjc --version
 gjc --smoke-test
@@ -21,7 +21,7 @@ curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/main/scripts
 Windows (PowerShell), tagged:
 
 ```powershell
-Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.0/scripts/install.ps1 -OutFile gjc-install.ps1
+Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.3/scripts/install.ps1 -OutFile gjc-install.ps1
 powershell -File gjc-install.ps1
 ```
 

--- a/docs/terminal-app-integrations.md
+++ b/docs/terminal-app-integrations.md
@@ -120,12 +120,12 @@ agent below.
 1. Install and authenticate GJC on the machine Orca runs agents on:
 
    ```sh
-   curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.0/scripts/install.sh -o gjc-install.sh
+   curl -fsSL https://raw.githubusercontent.com/Yeachan-Heo/gajae-code/v0.15.3/scripts/install.sh -o gjc-install.sh
    sh gjc-install.sh
    gjc auth
    ```
 
-   To pick a newer installer, change `v0.15.0` to the release tag you want (see [docs/install.md](install.md)).
+   To pick a newer installer, change `v0.15.3` to the release tag you want (see [docs/install.md](install.md)).
 
 2. In Orca, open **Settings → Agents** and add a custom agent:
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- `gjc update` now recognizes an already verified standalone binary during package-manager shim migration, avoiding repeated downloads and post-update work while clearly explaining the required PATH ordering.
+
 - The `ask` tool now rejects empty or whitespace-only custom answers on every local and remote input path. Remote invalid answers receive a visible explanation and are retried at most three times with an event-loop yield between attempts before the ask is cancelled; local empty custom input is never returned as a valid answer. (#5001)
 
 ## [0.15.3] - 2026-08-27

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -1382,10 +1382,15 @@ export async function runUpdateCommand(
 	});
 
 	if (target.method === "migrate" && decision.install && !opts.force) {
-		const verification = await verifyTarget(release, target.path);
-		if (verification.ok) {
-			printVerifiedMigrationTarget(target, release.version);
-			return;
+		const releaseLock = await acquireBinaryUpdateLock(target.path);
+		try {
+			const verification = await verifyTarget(release, target.path);
+			if (verification.ok) {
+				printVerifiedMigrationTarget(target, release.version);
+				return;
+			}
+		} finally {
+			await releaseLock();
 		}
 	}
 

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -163,11 +163,12 @@ function isPathInDirectory(filePath: string, directoryPath: string): boolean {
 }
 
 export type PackageManagerTarget = { manager: "npm"; packageName: string };
+type MigrationUpdateTarget = { method: "migrate"; path: string; previousPath?: string };
 export type UpdateTarget =
 	| { method: "bun" }
 	| { method: "npm"; packageName: string }
 	| { method: "binary"; path: string }
-	| { method: "migrate"; path: string; previousPath?: string };
+	| MigrationUpdateTarget;
 
 type PathPlatform = NodeJS.Platform;
 type PackageExists = (packageName: string, packageRoot: string) => boolean;
@@ -504,6 +505,43 @@ async function verifyInstalledRuntime(
 			smokeTestOutput: error instanceof Error ? error.message : String(error),
 		};
 	}
+}
+
+interface MigrationTargetVerificationOptions {
+	runtimePath: string;
+	verifyChecksum: () => Promise<void>;
+	verifyRuntime: () => Promise<InstalledVersionVerification>;
+}
+
+async function verifyMigrationTargetWith(
+	options: MigrationTargetVerificationOptions,
+): Promise<InstalledVersionVerification> {
+	try {
+		await options.verifyChecksum();
+	} catch {
+		return { ok: false, path: options.runtimePath };
+	}
+	return await options.verifyRuntime();
+}
+
+async function verifyMigrationTarget(release: ReleaseInfo, runtimePath: string): Promise<InstalledVersionVerification> {
+	return await verifyMigrationTargetWith({
+		runtimePath,
+		verifyChecksum: async () => {
+			await verifyDownloadedBinaryChecksum({
+				tag: release.tag,
+				assetName: getBinaryName(),
+				filePath: runtimePath,
+			});
+		},
+		verifyRuntime: async () => await verifyInstalledRuntime(release.version, runtimePath),
+	});
+}
+
+export async function verifyMigrationTargetForTest(
+	options: MigrationTargetVerificationOptions,
+): Promise<InstalledVersionVerification> {
+	return await verifyMigrationTargetWith(options);
 }
 
 function printRestartGuidance(): void {
@@ -1062,6 +1100,7 @@ async function updateViaBinaryAt(
 export interface UpdateCommandDependencies {
 	getLatestRelease?: (options?: LatestReleaseLookupOptions) => Promise<ReleaseInfo>;
 	resolveUpdateTarget?: () => Promise<UpdateTarget>;
+	verifyMigrationTarget?: (release: ReleaseInfo, runtimePath: string) => Promise<InstalledVersionVerification>;
 	performUpdate?: (
 		target: UpdateTarget,
 		expectedVersion: string,
@@ -1265,6 +1304,24 @@ export function resolveUpdateDecision(options: {
 	return { install: true, kind: options.comparison > 0 ? "new-version" : "force" };
 }
 
+function printVerifiedMigrationTarget(target: MigrationUpdateTarget, version: string): void {
+	console.log(
+		chalk.green(
+			`${theme.status.success} Standalone ${APP_NAME} ${version} is already installed and verified at ${target.path}`,
+		),
+	);
+	if (target.previousPath) {
+		console.log(chalk.yellow(`${target.previousPath} shadows it on PATH.`));
+		console.log(
+			chalk.cyan(
+				`The standalone directory ${path.dirname(target.path)} must precede the shim directory ${path.dirname(target.previousPath)} on PATH.`,
+			),
+		);
+		return;
+	}
+	console.log(chalk.cyan(`Ensure the standalone directory ${path.dirname(target.path)} is on PATH.`));
+}
+
 export async function runUpdateCommand(
 	opts: UpdateCommandOptions,
 	deps: UpdateCommandDependencies = {},
@@ -1272,6 +1329,7 @@ export async function runUpdateCommand(
 	const channel = opts.channel ?? "stable";
 	const lookupRelease = deps.getLatestRelease ?? getLatestRelease;
 	const resolveTarget = deps.resolveUpdateTarget ?? resolveUpdateTarget;
+	const verifyTarget = deps.verifyMigrationTarget ?? verifyMigrationTarget;
 	const update = deps.performUpdate ?? performUpdate;
 	const refreshDefaults = deps.refreshInstalledDefaultSkills ?? refreshInstalledDefaultSkills;
 	const exit = deps.exit ?? process.exit;
@@ -1322,6 +1380,14 @@ export async function runUpdateCommand(
 		currentVersion: VERSION,
 		migrate: target?.method === "migrate",
 	});
+
+	if (target.method === "migrate" && decision.install && !opts.force) {
+		const verification = await verifyTarget(release, target.path);
+		if (verification.ok) {
+			printVerifiedMigrationTarget(target, release.version);
+			return;
+		}
+	}
 
 	if (!decision.install) {
 		console.log(chalk.green(`${theme.status.success} Already up to date`));

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -513,6 +513,14 @@ interface MigrationTargetVerificationOptions {
 	verifyRuntime: () => Promise<InstalledVersionVerification>;
 }
 
+interface MigrationChecksumOptions {
+	tag: string;
+	assetName: string;
+	filePath: string;
+}
+
+type MigrationChecksumVerifier = (options: MigrationChecksumOptions) => Promise<unknown>;
+
 async function verifyMigrationTargetWith(
 	options: MigrationTargetVerificationOptions,
 ): Promise<InstalledVersionVerification> {
@@ -524,17 +532,25 @@ async function verifyMigrationTargetWith(
 	return await options.verifyRuntime();
 }
 
-async function verifyMigrationTarget(release: ReleaseInfo, runtimePath: string): Promise<InstalledVersionVerification> {
+async function verifyMigrationTarget(
+	release: Pick<ReleaseInfo, "tag" | "version">,
+	runtimePath: string,
+	verifyChecksum: MigrationChecksumVerifier = verifyDownloadedBinaryChecksum,
+	verifyRuntime: (
+		expectedVersion: string,
+		runtimePath: string,
+	) => Promise<InstalledVersionVerification> = verifyInstalledRuntime,
+): Promise<InstalledVersionVerification> {
 	return await verifyMigrationTargetWith({
 		runtimePath,
 		verifyChecksum: async () => {
-			await verifyDownloadedBinaryChecksum({
+			await verifyChecksum({
 				tag: release.tag,
 				assetName: getBinaryName(),
 				filePath: runtimePath,
 			});
 		},
-		verifyRuntime: async () => await verifyInstalledRuntime(release.version, runtimePath),
+		verifyRuntime: async () => await verifyRuntime(release.version, runtimePath),
 	});
 }
 
@@ -542,6 +558,20 @@ export async function verifyMigrationTargetForTest(
 	options: MigrationTargetVerificationOptions,
 ): Promise<InstalledVersionVerification> {
 	return await verifyMigrationTargetWith(options);
+}
+
+export async function verifyMigrationTargetAdapterForTest(options: {
+	release: Pick<ReleaseInfo, "tag" | "version">;
+	runtimePath: string;
+	verifyChecksum: MigrationChecksumVerifier;
+	verifyRuntime: (expectedVersion: string, runtimePath: string) => Promise<InstalledVersionVerification>;
+}): Promise<InstalledVersionVerification> {
+	return await verifyMigrationTarget(
+		options.release,
+		options.runtimePath,
+		options.verifyChecksum,
+		options.verifyRuntime,
+	);
 }
 
 function printRestartGuidance(): void {

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -28,6 +28,7 @@ import {
 	runPackageManagerUpdateForTest,
 	runPostUpdateRecoveryForTest,
 	runUpdateCommand,
+	verifyMigrationTargetAdapterForTest,
 	verifyMigrationTargetForTest,
 } from "../src/cli/update-cli";
 import { Settings } from "../src/config/settings";
@@ -573,6 +574,24 @@ describe("update-cli managed notification recovery", () => {
 			});
 			expect(calls).toEqual(["checksum"]);
 			expect(result).toEqual({ ok: false, path: target.path });
+		});
+
+		it("passes the release tag, binary asset, and target path to checksum verification", async () => {
+			const checksumCalls: Array<{ tag: string; assetName: string; filePath: string }> = [];
+			const result = await verifyMigrationTargetAdapterForTest({
+				release,
+				runtimePath: target.path,
+				verifyChecksum: async options => {
+					checksumCalls.push(options);
+				},
+				verifyRuntime: async (expectedVersion, runtimePath) => ({
+					ok: true,
+					actual: expectedVersion,
+					path: runtimePath,
+				}),
+			});
+			expect(checksumCalls).toEqual([{ tag: release.tag, assetName: "gjc-linux-x64", filePath: target.path }]);
+			expect(result).toEqual({ ok: true, actual: release.version, path: target.path });
 		});
 
 		it("keeps a checksum-valid but stale or smoke-failing target on the migration path", async () => {

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -28,6 +28,7 @@ import {
 	runPackageManagerUpdateForTest,
 	runPostUpdateRecoveryForTest,
 	runUpdateCommand,
+	verifyMigrationTargetForTest,
 } from "../src/cli/update-cli";
 import { Settings } from "../src/config/settings";
 import { distTagForChannel, isUpdateChannel } from "../src/config/update-channel";
@@ -519,6 +520,258 @@ describe("update-cli managed notification recovery", () => {
 		registry: DEFAULT_NPM_REGISTRY,
 		warnings: [],
 	};
+
+	describe("standalone migration preflight", () => {
+		const target = { method: "migrate" as const, path: "/standalone/gjc", previousPath: "/shim/gjc" };
+
+		it("verifies the release checksum before executing the migration target", async () => {
+			const calls: string[] = [];
+			const result = await verifyMigrationTargetForTest({
+				runtimePath: target.path,
+				verifyChecksum: async () => {
+					calls.push("checksum");
+				},
+				verifyRuntime: async () => {
+					calls.push("runtime");
+					return { ok: true, actual: release.version, path: target.path };
+				},
+			});
+			expect(calls).toEqual(["checksum", "runtime"]);
+			expect(result).toEqual({ ok: true, actual: release.version, path: target.path });
+		});
+
+		it("does not execute a missing or tampered migration target when checksum verification fails", async () => {
+			const calls: string[] = [];
+			const result = await verifyMigrationTargetForTest({
+				runtimePath: target.path,
+				verifyChecksum: async () => {
+					calls.push("checksum");
+					throw new Error("checksum mismatch");
+				},
+				verifyRuntime: async () => {
+					calls.push("runtime");
+					return { ok: true, actual: release.version, path: target.path };
+				},
+			});
+			expect(calls).toEqual(["checksum"]);
+			expect(result).toEqual({ ok: false, path: target.path });
+		});
+
+		it("keeps a checksum-valid but stale or smoke-failing target on the migration path", async () => {
+			const calls: string[] = [];
+			const result = await verifyMigrationTargetForTest({
+				runtimePath: target.path,
+				verifyChecksum: async () => {
+					calls.push("checksum");
+				},
+				verifyRuntime: async () => {
+					calls.push("runtime");
+					return {
+						ok: false,
+						actual: release.version,
+						path: target.path,
+						smokeTestFailed: true,
+					};
+				},
+			});
+			expect(calls).toEqual(["checksum", "runtime"]);
+			expect(result).toEqual({
+				ok: false,
+				actual: release.version,
+				path: target.path,
+				smokeTestFailed: true,
+			});
+		});
+
+		it("skips update recovery and defaults refresh when the standalone target already verifies", async () => {
+			const calls: string[] = [];
+			const output: string[] = [];
+			const logSpy = vi.spyOn(console, "log").mockImplementation(message => output.push(String(message)));
+			try {
+				await runUpdateCommand(
+					{ force: false, check: false },
+					{
+						getLatestRelease: async () => release,
+						resolveUpdateTarget: async () => target,
+						verifyMigrationTarget: async (expectedRelease, runtimePath) => {
+							expect(expectedRelease).toEqual(release);
+							expect(runtimePath).toBe(target.path);
+							return { ok: true, actual: expectedRelease.version, path: runtimePath };
+						},
+						performUpdate: async () => {
+							calls.push("update");
+							return { ok: true, path: target.path };
+						},
+						runPostUpdateRecovery: async () => {
+							calls.push("recovery");
+						},
+						refreshInstalledDefaultSkills: async () => {
+							calls.push("refresh");
+						},
+					},
+				);
+				expect(calls).toEqual([]);
+				expect(output.join("\n")).toContain(
+					`Standalone gjc ${release.version} is already installed and verified at ${target.path}`,
+				);
+				expect(output.join("\n")).toContain(`${target.previousPath} shadows it on PATH.`);
+				expect(output.join("\n")).toContain("must precede the shim directory");
+			} finally {
+				logSpy.mockRestore();
+			}
+		});
+
+		it("leaves a shim-first repeated invocation non-mutating after standalone verification", async () => {
+			const calls: string[] = [];
+			for (let attempt = 0; attempt < 2; attempt++) {
+				await runUpdateCommand(
+					{ force: false, check: false },
+					{
+						getLatestRelease: async () => release,
+						resolveUpdateTarget: async () => target,
+						verifyMigrationTarget: async () => {
+							calls.push("verify standalone");
+							return { ok: true, actual: release.version, path: target.path };
+						},
+						performUpdate: async () => {
+							calls.push("update");
+							return { ok: true, path: target.path };
+						},
+						runPostUpdateRecovery: async () => {
+							calls.push("recovery");
+						},
+						refreshInstalledDefaultSkills: async () => {
+							calls.push("refresh");
+						},
+					},
+				);
+			}
+			expect(calls).toEqual(["verify standalone", "verify standalone"]);
+		});
+
+		it("reports a verified shadowed target in check mode without performing an update", async () => {
+			const calls: string[] = [];
+			await runUpdateCommand(
+				{ force: false, check: true },
+				{
+					getLatestRelease: async () => release,
+					resolveUpdateTarget: async () => target,
+					verifyMigrationTarget: async () => {
+						calls.push("verify");
+						return { ok: true, actual: release.version, path: target.path };
+					},
+					performUpdate: async () => {
+						calls.push("update");
+						return { ok: true, path: target.path };
+					},
+				},
+			);
+			expect(calls).toEqual(["verify"]);
+		});
+
+		it("skips an already verified nightly migration target", async () => {
+			const calls: string[] = [];
+			const nightlyRelease = {
+				...release,
+				tag: "v999.0.0-nightly.20260828000000.1.gabcdef123456",
+				version: "999.0.0-nightly.20260828000000.1.gabcdef123456",
+			};
+			await runUpdateCommand(
+				{ force: false, check: false, channel: "nightly" },
+				{
+					getLatestRelease: async options => {
+						expect(options?.channel).toBe("nightly");
+						return nightlyRelease;
+					},
+					resolveUpdateTarget: async () => target,
+					verifyMigrationTarget: async expectedRelease => {
+						calls.push("verify");
+						expect(expectedRelease).toEqual(nightlyRelease);
+						return { ok: true, actual: nightlyRelease.version, path: target.path };
+					},
+					performUpdate: async () => {
+						calls.push("update");
+						return { ok: true, path: target.path };
+					},
+				},
+			);
+			expect(calls).toEqual(["verify"]);
+		});
+
+		it("migrates when the standalone target is stale or fails its smoke test", async () => {
+			const calls: string[] = [];
+			await runUpdateCommand(
+				{ force: false, check: false },
+				{
+					getLatestRelease: async () => release,
+					resolveUpdateTarget: async () => target,
+					verifyMigrationTarget: async () => ({
+						ok: false,
+						actual: release.version,
+						path: target.path,
+						smokeTestFailed: true,
+					}),
+					performUpdate: async () => {
+						calls.push("update");
+						return { ok: true, path: target.path };
+					},
+					runPostUpdateRecovery: async () => {
+						calls.push("recovery");
+					},
+					refreshInstalledDefaultSkills: async () => {
+						calls.push("refresh");
+					},
+				},
+			);
+			expect(calls).toEqual(["update", "recovery", "refresh"]);
+		});
+
+		it("does not preflight a migration target when the release decision is already up to date", async () => {
+			const calls: string[] = [];
+			await runUpdateCommand(
+				{ force: false, check: false },
+				{
+					getLatestRelease: async () => ({ ...release, version: "0.0.1" }),
+					resolveUpdateTarget: async () => target,
+					verifyMigrationTarget: async () => {
+						calls.push("verify");
+						return { ok: true, path: target.path };
+					},
+					performUpdate: async () => {
+						calls.push("update");
+						return { ok: true, path: target.path };
+					},
+				},
+			);
+			expect(calls).toEqual([]);
+		});
+
+		it("bypasses migration preflight when force is set", async () => {
+			const calls: string[] = [];
+			await runUpdateCommand(
+				{ force: true, check: false },
+				{
+					getLatestRelease: async () => release,
+					resolveUpdateTarget: async () => target,
+					verifyMigrationTarget: async () => {
+						calls.push("verify");
+						return { ok: true, path: target.path };
+					},
+					performUpdate: async () => {
+						calls.push("update");
+						return { ok: true, path: target.path };
+					},
+					runPostUpdateRecovery: async () => {
+						calls.push("recovery");
+					},
+					refreshInstalledDefaultSkills: async () => {
+						calls.push("refresh");
+					},
+				},
+			);
+			expect(calls).toEqual(["update", "recovery", "refresh"]);
+		});
+	});
 
 	function configuredSettings(overrides: Record<string, unknown> = {}): Settings {
 		return Settings.isolated({

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -540,6 +540,24 @@ describe("update-cli managed notification recovery", () => {
 			expect(result).toEqual({ ok: true, actual: release.version, path: target.path });
 		});
 
+		it("holds the binary update lock across migration preflight", async () => {
+			const root = await makeTempDir();
+			const runtimePath = path.join(root, "gjc");
+			const lockPath = path.join(root, ".gjc-install.lock");
+			await runUpdateCommand(
+				{ force: false, check: false },
+				{
+					getLatestRelease: async () => release,
+					resolveUpdateTarget: async () => ({ method: "migrate", path: runtimePath }),
+					verifyMigrationTarget: async () => {
+						expect(fsNode.existsSync(lockPath)).toBe(true);
+						return { ok: true, actual: release.version, path: runtimePath };
+					},
+				},
+			);
+			expect(fsNode.existsSync(lockPath)).toBe(false);
+		});
+
 		it("does not execute a missing or tampered migration target when checksum verification fails", async () => {
 			const calls: string[] = [];
 			const result = await verifyMigrationTargetForTest({

--- a/scripts/install-tests/install-docs-contract.test.ts
+++ b/scripts/install-tests/install-docs-contract.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
+
+const repoRoot = path.join(import.meta.dir, "..", "..");
+const BINARY_FIRST_INSTALLER_REF = "v0.15.3";
+const TAGGED_INSTALLER_URL = /https:\/\/raw\.githubusercontent\.com\/Yeachan-Heo\/gajae-code\/(v[^/]+)\/scripts\/install\.(?:sh|ps1)/g;
+const STALE_INSTALLER_URL = "/v0.15.0/scripts/install.";
+
+const coreInstallerDocs = [
+	"README.md",
+	"docs/install.md",
+	"docs/terminal-app-integrations.md",
+] as const;
+const expectedLocalizedInstallerDocs = ["README.ko.md", "README.ja.md", "README.zh-CN.md"] as const;
+const installerDocs = [...coreInstallerDocs, ...expectedLocalizedInstallerDocs];
+
+describe("installer documentation contract", () => {
+	test("uses the approved immutable installer release in every core and localized guide", async () => {
+		for (const documentPath of installerDocs) {
+			const content = await Bun.file(path.join(repoRoot, documentPath)).text();
+			const taggedUrls = [...content.matchAll(TAGGED_INSTALLER_URL)];
+
+			expect(content).not.toContain(STALE_INSTALLER_URL);
+			expect(taggedUrls.length).toBeGreaterThan(0);
+			for (const taggedUrl of taggedUrls) {
+				expect(taggedUrl[1]).toBe(BINARY_FIRST_INSTALLER_REF);
+			}
+		}
+	});
+});


### PR DESCRIPTION
## What

Make package-manager-shim migration idempotent and align the documented tagged installer with GJC's binary-first install policy.

For shim migrations, `gjc update` now verifies an existing standalone target before replacing it:

1. verify the target against the published release checksum;
2. only then run version and smoke verification;
3. skip download, replacement, recovery, and defaults refresh when it is already valid;
4. report the shim that still shadows it on `PATH`.

Missing, stale, tampered, or smoke-failing targets continue through the existing verified migration flow. `--force` continues to reinstall.

Installation guides now pin the immutable v0.15.3 binary-first installer instead of the pre-binary-first v0.15.0 bootstrap. A no-network documentation contract prevents those references from drifting back.

## Why

A package-manager shim that remained first on `PATH` caused every invocation to classify the install as `migrate`, even when the standalone target already contained the same verified release.

Reproduced before this change on v0.15.3:

```text
$HOME/.bun/bin/gjc update --check
Current version: 0.15.3
Migrating to a standalone GitHub binary: 0.15.3

$HOME/.local/bin/gjc update --check
Current version: 0.15.3
Already up to date
```

Both binaries reported 0.15.3 and passed `--smoke-test`. The difference was solely which executable won `PATH` resolution.

The documentation also described standalone installation while downloading v0.15.0's installer. In a deterministic stub-Bun reproduction, that installer selected:

```text
bun install -g @gajae-code/coding-agent
```

and did not create the standalone target. These two behaviors could recreate and then repeatedly migrate the same package-manager installation.

The latest `origin/dev` was fetched before submission and still contained both defects: all six install guides pinned v0.15.0, active package-manager shims were classified as `migrate` without inspecting the destination, and equal-version migration remained forced.

## Testing

```sh
bun test packages/coding-agent/test/update-cli.test.ts \
  scripts/install-tests/install-docs-contract.test.ts \
  scripts/install-tests/install-sh-binary-upgrade.test.ts \
  packages/coding-agent/test/notifications-service.test.ts

bunx biome check \
  packages/coding-agent/src/cli/update-cli.ts \
  packages/coding-agent/test/update-cli.test.ts \
  scripts/install-tests/install-docs-contract.test.ts

bun --cwd=packages/coding-agent run check:types
bun run check
```

Results:

```text
109 pass
0 fail
346 assertions

Full repository check passed on the exact submitted head.
```

Coverage includes checksum-before-execution ordering, checksum rejection without target execution, missing/stale/smoke-failing fallthrough, repeat invocation, `--check`, nightly, older-release no-op, `--force`, recovery/default-refresh suppression, and the existing stable switch-back decision matrix.

A read-only architecture review initially requested the checksum/channel boundary coverage above; after it was added, the scoped runtime and documentation reviews both returned APPROVE. A new authenticated GitHub exact-head review is still required by the repository gate.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [x] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:96d23a76b0494af34d54e748fd60d0d5f283286a075efe7f793e41ab7f129b45 reviewer:architect reviewer-id:Yeachan-Heo evidence:independent latest-head review; lock serialization and concrete checksum wiring verified
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken






