### PR TITLE
test(update): derive checksum asset from host platform

### DIFF
--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -590,11 +590,13 @@ describe("update-cli managed notification recovery", () => {
 					path: runtimePath,
 				}),
 			});
-			const osName = process.platform === "darwin" ? "darwin" : "linux";
-			const arch = process.arch === "arm64" ? "arm64" : "x64";
-			expect(checksumCalls).toEqual([
-				{ tag: release.tag, assetName: `gjc-${osName}-${arch}`, filePath: target.path },
-			]);
+			// Derive the expected asset from the production platform mapping so the
+			// assertion stays host-faithful (including the Windows `.exe` name) and
+			// fails loudly through the same unsupported-platform errors.
+			const assetName = path.posix.basename(
+				buildReleaseBinaryUrlForTest(release.version, process.platform, process.arch),
+			);
+			expect(checksumCalls).toEqual([{ tag: release.tag, assetName, filePath: target.path }]);
 			expect(result).toEqual({ ok: true, actual: release.version, path: target.path });
 		});
 

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -590,7 +590,11 @@ describe("update-cli managed notification recovery", () => {
 					path: runtimePath,
 				}),
 			});
-			expect(checksumCalls).toEqual([{ tag: release.tag, assetName: "gjc-linux-x64", filePath: target.path }]);
+			const osName = process.platform === "darwin" ? "darwin" : "linux";
+			const arch = process.arch === "arm64" ? "arm64" : "x64";
+			expect(checksumCalls).toEqual([
+				{ tag: release.tag, assetName: `gjc-${osName}-${arch}`, filePath: target.path },
+			]);
 			expect(result).toEqual({ ok: true, actual: release.version, path: target.path });
 		});
 


### PR DESCRIPTION
## What

Make the migration checksum adapter regression test derive the expected release asset from the host operating system and architecture instead of hard-coding `gjc-linux-x64`.

## Why

PR #5019 added concrete checksum-wiring coverage. The assertion passed on Linux CI but failed on macOS arm64 because production correctly selected `gjc-darwin-arm64` while the test always expected `gjc-linux-x64`:

```diff
- expected: gjc-linux-x64
+ received: gjc-darwin-arm64
```

The test should validate the production platform mapping on every supported test host rather than encode one CI platform.

A maintainer fix-forward (4035596f9a, authorship-preserving; sj00c's original commit remains byte-identical upstream) strengthens the same assertion further: instead of re-deriving the platform string by hand (`darwin ? "darwin" : "linux"`), the expected asset now comes from the production mapping itself via the exported `buildReleaseBinaryUrlForTest`, so the test stays host-faithful for every supported OS/arch including the Windows `.exe` asset name and fails loudly through the same unsupported-platform errors production raises.

## Testing

```sh
bun test packages/coding-agent/test/update-cli.test.ts
bun --cwd=packages/coding-agent run check
```

Results at exact head 4035596f9aca44316851a23178e86bee04002e01:

```text
88 pass
0 fail
241 assertions
```

Verified locally on Linux x64; the derivation table (linux/darwin/win32 × x64/arm64 plus unsupported throws) matches production `getBinaryName` exactly. Pre-fix assertion reproduced the failure on macOS arm64 (author-verified upstream).

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`; the token alone never suffices).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:97214d55d8ae255413c2e908ea9d1afc3202fa6b8b533a90b630f4e06d775dfd reviewer:architect reviewer-id:Yeachan-Heo evidence:independent latest-head review; host mapping through production buildReleaseBinaryUrlForTest, unsupported-platform fail-closed, checksum verification unweakened
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing) — not user-facing
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
