### PR TITLE
feat(sdk): add scoped session listing

### DIFF
--- a/docs/sdk-session-cli.md
+++ b/docs/sdk-session-cli.md
@@ -32,6 +32,34 @@ directory).
 every indexed session into the versioned row DTO (`SESSION_ROWS_VERSION`). Each
 row is credential-free and carries:
 
+The list is fully paginated before scope filtering. By default its effective
+scope is `repo`. Select a scope with:
+
+```sh
+gjc sdk session list --scope repo|cwd|worktree|all [--repo <path>]
+```
+
+`--repo` is the selected workspace path and defaults to the process cwd. The
+result reports the effective `scope` and a bounded credential-free `selection`
+descriptor containing the canonical selected path and, for Git selections,
+the canonical worktree root and Git common directory.
+
+- `repo` matches the canonical Git common directory, so the main checkout and
+  linked worktrees are included while another repository is excluded.
+- `worktree` matches only the selected path's canonical containing worktree.
+- `cwd` matches only the exact canonical selected workspace; nested directories
+  do not match.
+- `all` preserves the complete unfiltered Broker listing.
+
+For a path outside Git, `repo` and `worktree` fail with the typed
+`not_a_repository` operational error and an actionable suggestion to use
+`cwd` or `all`; they never broaden the result. `cwd` remains available for an
+exact canonical path match. Unreadable or removed row workspaces are excluded
+from Git scopes deterministically and reported in `warnings`.
+
+The raw global `session.list` route remains unfiltered, and `inspect`, `send`,
+`status`, `tail`, `retire`, and raw control/query behavior is unchanged.
+
 - `sessionId` and the `locator` (`repo`, `stateRoot`);
 - `endpointGeneration`, `pid`, `live`, `deleted` (tombstone), `indexSeq`;
 - `hostIncarnation` and `identityProvenance` (`composite` | `legacy`);

--- a/packages/coding-agent/src/commands/sdk.ts
+++ b/packages/coding-agent/src/commands/sdk.ts
@@ -838,6 +838,10 @@ class SdkSessionHelp extends Command {
 			description: "Workspace directory for saved-session resolution (default: current directory)",
 		}),
 		op: Flags.string({ description: "Raw control or global operation" }),
+		scope: Flags.string({
+			description: "list scope: repo (default), cwd, worktree, or all",
+			options: ["repo", "cwd", "worktree", "all"],
+		}),
 		query: Flags.string({ description: "Raw query name" }),
 		"json-input": Flags.string({ description: "SDK request JSON object" }),
 		"json-input-file": Flags.string({ description: "Read SDK request JSON from a 0600 file" }),
@@ -894,6 +898,7 @@ class SdkSessionCommand extends Command {
 			allEvents: Boolean(flagRec["all-events"]),
 			agentDir: flagRec["agent-dir"] as string | undefined,
 			repo: flagRec.repo as string | undefined,
+			scope: flagRec.scope as string | undefined,
 		});
 	}
 }

--- a/packages/coding-agent/src/sdk/cli/session-cli.ts
+++ b/packages/coding-agent/src/sdk/cli/session-cli.ts
@@ -1,7 +1,9 @@
 import { randomBytes } from "node:crypto";
 import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import { getAgentDir } from "@gajae-code/utils";
+import { repo as resolveGitRepository } from "../../utils/git";
 import { ensureBroker } from "../broker/ensure";
 import { lifecycleRequestTimeoutMs } from "../broker/startup-budget";
 import { SdkClientError } from "../client";
@@ -38,10 +40,12 @@ export type SdkSessionCliAction =
 	| "status"
 	| "tail"
 	| "retire"
+	| "global"
 	| "raw"
 	| "control"
 	| "query"
 	| "global";
+export type SdkSessionListScope = "repo" | "cwd" | "worktree" | "all";
 export type SdkSessionCliRawKind = "control" | "query" | "global";
 
 export interface SdkSessionCliArgs {
@@ -56,6 +60,7 @@ export interface SdkSessionCliArgs {
 	jsonInputFile?: string;
 	jsonInputStdin?: boolean;
 	idempotencyKey?: string;
+	scope?: string;
 	confirm?: boolean;
 	cursor?: string;
 	wait?: boolean;
@@ -358,16 +363,142 @@ async function sessionRows(agentDir: string): Promise<SessionRows> {
 	});
 }
 
-async function runList(agentDir: string): Promise<unknown> {
+const SESSION_LIST_SCOPES: readonly SdkSessionListScope[] = ["repo", "cwd", "worktree", "all"];
+/** Row workspaces whose locator cannot be canonicalized still get one deterministic identity. */
+const WORKSPACE_IDENTITY_CACHE_LIMIT = 4096;
+
+interface WorkspaceIdentity {
+	/** Canonical workspace path (realpath when it exists, lexical resolve otherwise). */
+	canonicalPath: string;
+	/** Canonical containing worktree root; null outside a Git checkout. */
+	repoRoot: string | null;
+	/** Canonical Git common dir; shared by the main checkout and linked worktrees. */
+	commonDir: string | null;
+}
+
+export interface SdkSessionListSelection {
+	scope: SdkSessionListScope;
+	selection: WorkspaceIdentity;
+	/** Bounded, credential-free descriptor included in list output. */
+	descriptor: {
+		scope: SdkSessionListScope;
+		path: string;
+		worktreeRoot?: string;
+		commonDir?: string;
+	};
+}
+
+/** Parses `--scope`; missing means `repo`, anything else invalid is a usage error. */
+export function parseSessionListScope(value: string | undefined): SdkSessionListScope {
+	if (value === undefined) return "repo";
+	if ((SESSION_LIST_SCOPES as readonly string[]).includes(value)) return value as SdkSessionListScope;
+	throw new SdkSessionCliError(
+		"usage",
+		`Invalid scope "${value}". Expected one of: ${SESSION_LIST_SCOPES.join(", ")}.`,
+		2,
+	);
+}
+
+async function canonicalWorkspacePath(target: string): Promise<string> {
+	try {
+		return await fs.realpath(target);
+	} catch {
+		// A removed or unreadable workspace keeps a deterministic lexical identity
+		// instead of guessing a broader or narrower one.
+		return path.resolve(target);
+	}
+}
+
+const workspaceIdentityCache = new Map<string, WorkspaceIdentity>();
+
+/** Resolves (and caches) the Git identity of one workspace locator. */
+async function workspaceIdentity(target: string): Promise<WorkspaceIdentity> {
+	const canonicalPath = await canonicalWorkspacePath(target);
+	const cached = workspaceIdentityCache.get(canonicalPath);
+	if (cached) return cached;
+	const repository = await resolveGitRepository.resolve(canonicalPath);
+	const identity: WorkspaceIdentity = repository
+		? {
+				canonicalPath,
+				repoRoot: await canonicalWorkspacePath(repository.repoRoot),
+				commonDir: await canonicalWorkspacePath(repository.commonDir),
+			}
+		: { canonicalPath, repoRoot: null, commonDir: null };
+	if (workspaceIdentityCache.size >= WORKSPACE_IDENTITY_CACHE_LIMIT) workspaceIdentityCache.clear();
+	workspaceIdentityCache.set(canonicalPath, identity);
+	return identity;
+}
+
+/**
+ * Resolves the list selection from `--repo` (default: process cwd) under the
+ * effective scope. Outside Git, `repo`/`worktree` fail typed and actionable —
+ * they never broaden to `all`; `cwd` remains an exact canonical match.
+ */
+export async function resolveSessionListSelection(
+	scope: SdkSessionListScope,
+	repoArg: string | undefined,
+): Promise<SdkSessionListSelection> {
+	const selection = await workspaceIdentity(repoArg ?? process.cwd());
+	if (scope !== "cwd" && !selection.repoRoot)
+		throw new SdkSessionCliError(
+			"not_a_repository",
+			`--scope ${scope} requires a Git repository, but "${selection.canonicalPath}" is outside any Git checkout. ` +
+				"Use --scope cwd for an exact workspace match or --scope all for the full broker listing.",
+			1,
+		);
+	const descriptor: SdkSessionListSelection["descriptor"] = {
+		scope,
+		path: selection.canonicalPath,
+		...(selection.repoRoot ? { worktreeRoot: selection.repoRoot, commonDir: selection.commonDir! } : {}),
+	};
+	return { scope, selection, descriptor };
+}
+
+/**
+ * Filters fully traversed broker rows by the selection scope. Row workspaces
+ * are canonicalized and cached per distinct locator; `repo` matches the shared
+ * common dir across the main checkout and linked worktrees, `worktree` the
+ * containing worktree only, and `cwd` the exact canonical workspace.
+ */
+export async function filterSessionRowsByScope(
+	rows: readonly SdkSessionRowV1[],
+	scope: SdkSessionListScope,
+	selection: SdkSessionListSelection,
+): Promise<{ sessions: SdkSessionRowV1[]; warnings: string[] }> {
+	if (scope === "all") return { sessions: [...rows], warnings: [] };
+	const warnings: string[] = [];
+	const sessions: SdkSessionRowV1[] = [];
+	for (const row of rows) {
+		const identity = await workspaceIdentity(row.locator.repo);
+		let keep: boolean;
+		if (scope === "cwd") keep = identity.canonicalPath === selection.selection.canonicalPath;
+		else if (scope === "worktree")
+			keep = identity.repoRoot !== null && identity.repoRoot === selection.selection.repoRoot;
+		else keep = identity.commonDir !== null && identity.commonDir === selection.selection.commonDir;
+		if (keep) sessions.push(row);
+		else if (identity.repoRoot === null && identity.commonDir === null)
+			warnings.push(
+				`Session ${row.sessionId} workspace "${row.locator.repo}" is outside Git; excluded by scope ${scope}.`,
+			);
+	}
+	return { sessions, warnings };
+}
+
+async function runList(agentDir: string, args: SdkSessionCliArgs): Promise<unknown> {
+	const scope = parseSessionListScope(args.scope);
+	const { selection, descriptor } = await resolveSessionListSelection(scope, args.repo);
 	const listing = await sessionRows(agentDir);
+	const filtered = await filterSessionRowsByScope(listing.sessions, scope, { scope, selection, descriptor });
 	return {
 		ok: true,
 		result: {
 			version: SESSION_ROWS_VERSION,
 			source: "broker",
+			scope,
+			selection: descriptor,
 			...(listing.indexSeq === undefined ? {} : { indexSeq: listing.indexSeq }),
-			sessions: listing.sessions,
-			warnings: listing.warnings,
+			sessions: filtered.sessions,
+			warnings: [...listing.warnings, ...filtered.warnings],
 		},
 	};
 }
@@ -1367,7 +1498,7 @@ export async function runSdkSessionCli(
 			);
 		const agentDir = args.agentDir ?? getAgentDir();
 		if (action === "list") {
-			writeOutput(stripSecretFields(await runList(agentDir)));
+			writeOutput(stripSecretFields(await runList(agentDir, args)));
 			return;
 		}
 		if (action === "inspect") {

--- a/packages/coding-agent/src/sdk/cli/session-cli.ts
+++ b/packages/coding-agent/src/sdk/cli/session-cli.ts
@@ -416,6 +416,11 @@ async function workspaceIdentity(target: string): Promise<WorkspaceIdentity> {
 	const canonicalPath = await canonicalWorkspacePath(target);
 	const cached = workspaceIdentityCache.get(canonicalPath);
 	if (cached) return cached;
+	if (target === "unknown") {
+		const unavailable = { canonicalPath, repoRoot: null, commonDir: null };
+		workspaceIdentityCache.set(canonicalPath, unavailable);
+		return unavailable;
+	}
 	try {
 		if (!(await fs.stat(target)).isDirectory()) throw new Error("workspace is not a directory");
 	} catch {

--- a/packages/coding-agent/src/sdk/cli/session-cli.ts
+++ b/packages/coding-agent/src/sdk/cli/session-cli.ts
@@ -416,6 +416,15 @@ async function workspaceIdentity(target: string): Promise<WorkspaceIdentity> {
 	const canonicalPath = await canonicalWorkspacePath(target);
 	const cached = workspaceIdentityCache.get(canonicalPath);
 	if (cached) return cached;
+	try {
+		if (!(await fs.stat(target)).isDirectory()) throw new Error("workspace is not a directory");
+	} catch {
+		// A removed or unreadable locator cannot prove Git membership. Keeping it
+		// outside every identity is the narrowest safe result for row filtering.
+		const unavailable = { canonicalPath, repoRoot: null, commonDir: null };
+		workspaceIdentityCache.set(canonicalPath, unavailable);
+		return unavailable;
+	}
 	const repository = await resolveGitRepository.resolve(canonicalPath);
 	const identity: WorkspaceIdentity = repository
 		? {

--- a/packages/coding-agent/test/sdk-session-cli-list-scope.test.ts
+++ b/packages/coding-agent/test/sdk-session-cli-list-scope.test.ts
@@ -191,6 +191,17 @@ describe("sdk session list scope filtering", () => {
 		expect(filtered.warnings.join("\n")).toContain("s-gone");
 	});
 
+	test("unknown projected locators never resolve relative to the process cwd", async () => {
+		const repo = await makeRepo("unknown-locator");
+		const selection = await resolveSessionListSelection("repo", repo);
+		const filtered = await filterSessionRowsByScope(
+			[row("s-unknown", "unknown"), row("s-repo", repo)],
+			"repo",
+			selection,
+		);
+		expect(filtered.sessions.map(candidate => candidate.sessionId)).toEqual(["s-repo"]);
+	});
+
 	test("matching rows are retained regardless of their position in the fully traversed listing", async () => {
 		const main = await makeRepo("pager");
 		const other = await makeRepo("pagerother");

--- a/packages/coding-agent/test/sdk-session-cli-list-scope.test.ts
+++ b/packages/coding-agent/test/sdk-session-cli-list-scope.test.ts
@@ -1,0 +1,202 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { SdkSessionRowV1 } from "../src/sdk/cli/rows";
+import {
+	filterSessionRowsByScope,
+	parseSessionListScope,
+	resolveSessionListSelection,
+	runSdkSessionCli,
+	type SdkSessionCliArgs,
+} from "../src/sdk/cli/session-cli";
+
+const tempRoot = await mkdtemp(path.join(os.tmpdir(), "gjc-sdk-session-scope-"));
+
+async function git(cwd: string, ...args: string[]): Promise<void> {
+	const proc = Bun.spawn(["git", ...args], { cwd, stdout: "ignore", stderr: "pipe" });
+	const code = await proc.exited;
+	if (code !== 0) throw new Error(`git ${args.join(" ")} failed: ${await new Response(proc.stderr).text()}`);
+}
+
+async function makeRepo(name: string): Promise<string> {
+	const repoPath = path.join(tempRoot, name);
+	await mkdir(repoPath, { recursive: true });
+	await git(repoPath, "init", "-q");
+	await git(repoPath, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init");
+	return repoPath;
+}
+
+function row(sessionId: string, repoLocator: string): SdkSessionRowV1 {
+	return {
+		sessionId,
+		locator: { repo: repoLocator, stateRoot: `${repoLocator}/.gjc/state` },
+		endpointGeneration: 1,
+		pid: 100,
+		live: false,
+		deleted: false,
+		indexSeq: 0,
+	};
+}
+
+afterAll(async () => {
+	await rm(tempRoot, { recursive: true, force: true });
+});
+
+describe("sdk session list scope parsing", () => {
+	test("missing scope defaults to repo", () => {
+		expect(parseSessionListScope(undefined)).toBe("repo");
+	});
+
+	test("accepts every documented scope", () => {
+		for (const scope of ["repo", "cwd", "worktree", "all"] as const) {
+			expect(parseSessionListScope(scope)).toBe(scope);
+		}
+	});
+
+	test("invalid scope fails usage with exit 2", () => {
+		try {
+			parseSessionListScope("bogus");
+			throw new Error("expected usage failure");
+		} catch (error) {
+			expect((error as { code: string; exitCode: number }).code).toBe("usage");
+			expect((error as { exitCode: number }).exitCode).toBe(2);
+		}
+	});
+
+	test("runSdkSessionCli exits 2 on an invalid scope before broker contact", async () => {
+		const outputs: unknown[] = [];
+		let exitCode: number | undefined;
+		const args: SdkSessionCliArgs = { action: "list", scope: "bogus", agentDir: path.join(tempRoot, "unused") };
+		await runSdkSessionCli(
+			args,
+			value => outputs.push(value),
+			code => {
+				exitCode = code;
+			},
+		);
+		expect(exitCode).toBe(2);
+		const record = outputs[0] as { ok: boolean; error: { code: string } };
+		expect(record.ok).toBe(false);
+		expect(record.error.code).toBe("usage");
+	});
+});
+
+describe("sdk session list scope filtering", () => {
+	test("repo scope spans the main checkout and linked worktrees and excludes another repo", async () => {
+		const main = await makeRepo("main");
+		const worktree = path.join(tempRoot, "wt");
+		await git(main, "worktree", "add", "-b", "feature", worktree);
+		const other = await makeRepo("other");
+		const scope = "repo";
+		const { selection } = await resolveSessionListSelection(scope, main);
+		const filtered = await filterSessionRowsByScope(
+			[row("s-main", main), row("s-wt", worktree), row("s-other", other)],
+			scope,
+			{ scope, selection, descriptor: { scope, path: main } },
+		);
+		expect(filtered.sessions.map(candidate => candidate.sessionId).sort()).toEqual(["s-main", "s-wt"]);
+	});
+
+	test("worktree scope distinguishes checkouts of the same repository", async () => {
+		const main = await makeRepo("main2");
+		const worktree = path.join(tempRoot, "wt2");
+		await git(main, "worktree", "add", "-b", "feature2", worktree);
+		const worktreeSelection = await resolveSessionListSelection("worktree", worktree);
+		const filtered = await filterSessionRowsByScope(
+			[row("s-main", main), row("s-wt", worktree)],
+			"worktree",
+			worktreeSelection,
+		);
+		expect(filtered.sessions.map(candidate => candidate.sessionId)).toEqual(["s-wt"]);
+		expect(worktreeSelection.descriptor.worktreeRoot).toBe(worktree);
+		const mainSelection = await resolveSessionListSelection("worktree", main);
+		expect(mainSelection.descriptor.worktreeRoot).toBe(main);
+	});
+
+	test("cwd scope is an exact canonical match and excludes nested workspaces", async () => {
+		const repo = await makeRepo("cwdrepo");
+		const nested = path.join(repo, "packages", "app");
+		await mkdir(nested, { recursive: true });
+		const { selection } = await resolveSessionListSelection("cwd", repo);
+		const filtered = await filterSessionRowsByScope(
+			[row("s-exact", repo), row("s-nested", nested), row("s-elsewhere", tempRoot)],
+			"cwd",
+			{ scope: "cwd", selection, descriptor: { scope: "cwd", path: repo } },
+		);
+		expect(filtered.sessions.map(candidate => candidate.sessionId)).toEqual(["s-exact"]);
+	});
+
+	test("all scope returns the full unfiltered listing", async () => {
+		const main = await makeRepo("allrepo");
+		const other = await makeRepo("allother");
+		const rows = [row("s-a", main), row("s-b", other), row("s-c", tempRoot)];
+		const { selection } = await resolveSessionListSelection("all", main);
+		const filtered = await filterSessionRowsByScope(rows, "all", {
+			scope: "all",
+			selection,
+			descriptor: { scope: "all", path: main },
+		});
+		expect(filtered.sessions).toHaveLength(3);
+		expect(filtered.warnings).toEqual([]);
+	});
+
+	test("symlinked selection and row workspaces canonicalize to the same identity", async () => {
+		const repo = await makeRepo("symrepo");
+		const link = path.join(tempRoot, "symrepo-link");
+		await symlink(repo, link, "dir");
+		const selection = await resolveSessionListSelection("cwd", link);
+		expect(selection.selection.canonicalPath).toBe(repo);
+		const filtered = await filterSessionRowsByScope(
+			[row("s-via-link", link), row("s-direct", repo)],
+			"cwd",
+			selection,
+		);
+		expect(filtered.sessions.map(candidate => candidate.sessionId).sort()).toEqual(["s-direct", "s-via-link"]);
+	});
+
+	test("non-Git selection: repo/worktree fail typed without broadening, cwd still matches", async () => {
+		const plain = path.join(tempRoot, "plain");
+		await mkdir(plain, { recursive: true });
+		for (const scope of ["repo", "worktree"] as const) {
+			try {
+				await resolveSessionListSelection(scope, plain);
+				throw new Error("expected not_a_repository");
+			} catch (error) {
+				expect((error as { code: string; exitCode: number }).code).toBe("not_a_repository");
+				expect((error as { exitCode: number }).exitCode).toBe(1);
+			}
+		}
+		const cwdSelection = await resolveSessionListSelection("cwd", plain);
+		const filtered = await filterSessionRowsByScope(
+			[row("s-plain", plain), row("s-git", tempRoot)],
+			"cwd",
+			cwdSelection,
+		);
+		expect(filtered.sessions.map(candidate => candidate.sessionId)).toEqual(["s-plain"]);
+	});
+
+	test("removed row workspaces are excluded deterministically with a warning", async () => {
+		const repo = await makeRepo("gonerepo");
+		const gone = path.join(repo, "removed-workspace");
+		await mkdir(gone, { recursive: true });
+		const { selection } = await resolveSessionListSelection("repo", repo);
+		await rm(gone, { recursive: true, force: true });
+		const filtered = await filterSessionRowsByScope([row("s-gone", gone), row("s-here", repo)], "repo", {
+			scope: "repo",
+			selection,
+			descriptor: { scope: "repo", path: repo },
+		});
+		expect(filtered.sessions.map(candidate => candidate.sessionId)).toEqual(["s-here"]);
+		expect(filtered.warnings.join("\n")).toContain("s-gone");
+	});
+
+	test("matching rows are retained regardless of their position in the fully traversed listing", async () => {
+		const main = await makeRepo("pager");
+		const other = await makeRepo("pagerother");
+		const rows = [row("p1", other), row("p2", other), row("p-late", main), row("p3", other)];
+		const selection = await resolveSessionListSelection("repo", main);
+		const filtered = await filterSessionRowsByScope(rows, "repo", selection);
+		expect(filtered.sessions.map(candidate => candidate.sessionId)).toEqual(["p-late"]);
+	});
+});


### PR DESCRIPTION
Closes #5029

Adds repository, worktree, cwd, and all scopes to `gjc sdk session list`, defaulting to repository identity. Git common-dir identity spans linked worktrees; list traversal completes before filtering; rows remain credential-free and raw global listing is unchanged. Includes focused tests and documentation.

Verification: `bun test packages/coding-agent/test/sdk-session-cli-list-scope.test.ts`; `bun --cwd=packages/coding-agent run check`; `bun --cwd=packages/coding-agent run build`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*