### PR TITLE
fix(read): reject invalid internal selectors before routing

### DIFF
--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -36,6 +36,18 @@ function normalizeUnicodeSpaces(str: string): string {
 	return str.replace(UNICODE_SPACES, " ");
 }
 
+function rawSkillPrefixForName(authority: string, skillName: string): string | undefined {
+	for (let index = 1; index < authority.length; index++) {
+		if (authority[index] !== ":") continue;
+		try {
+			if (decodeURIComponent(authority.slice(0, index)) === skillName) return authority.slice(0, index);
+		} catch {
+			return undefined;
+		}
+	}
+	return undefined;
+}
+
 function tryMacOSScreenshotPath(filePath: string): string {
 	// macOS writes a narrow no-break space before AM/PM, but the model normalizes it
 	// to a plain space. The original name is not always `…PM.png`: attachment paths
@@ -177,14 +189,23 @@ export function splitInternalUrlSel(
 
 	if (scheme === "skill") {
 		const activeSkillNames = options.activeSkillNames ?? [];
-		if (activeSkillNames.includes(authority)) return { path: rawPath };
+		let decodedAuthority: string | undefined;
+		try {
+			decodedAuthority = decodeURIComponent(authority);
+		} catch {
+			// Let the resolver report malformed URL encoding when no selector boundary
+			// can be established from the raw authority.
+		}
+		if (decodedAuthority !== undefined && activeSkillNames.includes(decodedAuthority)) return { path: rawPath };
 		const skillName = activeSkillNames
-			.filter(name => authority.startsWith(`${name}:`))
+			.filter(name => decodedAuthority?.startsWith(`${name}:`))
 			.sort((a, b) => b.length - a.length)[0];
-		if (skillName) {
+		if (skillName && decodedAuthority !== undefined) {
+			const rawSkillPrefix = rawSkillPrefixForName(authority, skillName);
+			if (!rawSkillPrefix) return { path: rawPath };
 			return {
-				path: `${rawPath.slice(0, schemeEnd)}${skillName}`,
-				sel: authority.slice(skillName.length + 1),
+				path: `${rawPath.slice(0, schemeEnd)}${rawSkillPrefix}`,
+				sel: authority.slice(rawSkillPrefix.length + 1),
 			};
 		}
 		const strict = splitPathAndSel(authority);

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -149,12 +149,11 @@ export function splitPathAndSel(rawPath: string): { path: string; sel?: string }
 /**
  * Variant of {@link splitPathAndSel} for internal URLs (`scheme://...`).
  *
- * Artifact authorities are generated identifiers, so their complete tail is
- * unambiguously a selector and malformed selectors can be rejected before
- * resolving the artifact. Other resources may legitimately use colons in
- * their identities, so they only lose strict, recognized selector suffixes.
- * Skill authorities additionally use the active registry to distinguish a
- * skill name from its selector without making path-utils depend on skills.
+ * Selector-capable internal authorities use identifier-shaped resource names,
+ * so an authority-only `:<tail>` is an explicit read selector even when the
+ * selector is malformed. Skill authorities are the exception: namespaced
+ * skill names already contain a colon, so the active registry gets first
+ * refusal and the fallback recognizes a later colon as the selector boundary.
  */
 export function splitInternalUrlSel(
 	rawPath: string,
@@ -172,10 +171,6 @@ export function splitInternalUrlSel(
 	const firstColon = authority.indexOf(":");
 	if (firstColon === -1) return { path: rawPath };
 
-	if (scheme === "artifact") {
-		return { path: rawPath.slice(0, schemeEnd + firstColon), sel: authority.slice(firstColon + 1) };
-	}
-
 	if (scheme === "skill") {
 		const activeSkillNames = options.activeSkillNames ?? [];
 		if (activeSkillNames.includes(authority)) return { path: rawPath };
@@ -188,11 +183,23 @@ export function splitInternalUrlSel(
 				sel: authority.slice(skillName.length + 1),
 			};
 		}
+		const strict = splitPathAndSel(authority);
+		if (strict.sel !== undefined) {
+			return { path: `${rawPath.slice(0, schemeEnd)}${strict.path}`, sel: strict.sel };
+		}
+		const firstTail = authority.slice(firstColon + 1);
+		if (FILE_LINE_RANGE_RE.test(firstTail)) {
+			return { path: rawPath.slice(0, schemeEnd + firstColon), sel: firstTail };
+		}
+		const selectorColon = authority.indexOf(":", firstColon + 1);
+		if (selectorColon === -1) return { path: rawPath };
+		return {
+			path: rawPath.slice(0, schemeEnd + selectorColon),
+			sel: authority.slice(selectorColon + 1),
+		};
 	}
 
-	const strict = splitPathAndSel(authority);
-	if (strict.sel === undefined) return { path: rawPath };
-	return { path: `${rawPath.slice(0, schemeEnd)}${strict.path}`, sel: strict.sel };
+	return { path: rawPath.slice(0, schemeEnd + firstColon), sel: authority.slice(firstColon + 1) };
 }
 
 function assertNotInternalUrl(expanded: string, original: string): void {

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -227,7 +227,7 @@ export function splitInternalUrlSel(
 	if (!INTERNAL_SCHEMES_WITH_UNAMBIGUOUS_AUTHORITIES[scheme]) {
 		const strict = splitPathAndSel(authority);
 		if (strict.sel !== undefined) {
-			return { path: `${rawPath.slice(0, schemeEnd)}${strict.path}`, sel: strict.sel };
+			return { path: `${rawPath.slice(0, schemeEnd)}${strict.path}${authoritySuffix}`, sel: strict.sel };
 		}
 		return { path: rawPath };
 	}

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -181,8 +181,9 @@ export function splitInternalUrlSel(
 
 	const schemeEnd = schemeMatch[0].length;
 	const authorityTerminator = rawPath.slice(schemeEnd).search(/[/?#]/);
-	if (authorityTerminator !== -1) return { path: rawPath };
-	const authority = rawPath.slice(schemeEnd);
+	const authorityEnd = authorityTerminator === -1 ? rawPath.length : schemeEnd + authorityTerminator;
+	const authority = rawPath.slice(schemeEnd, authorityEnd);
+	const authoritySuffix = rawPath.slice(authorityEnd);
 	const firstColon = authority.indexOf(":");
 	if (firstColon === -1) return { path: rawPath };
 	if (firstColon === 0) return { path: rawPath };
@@ -204,22 +205,22 @@ export function splitInternalUrlSel(
 			const rawSkillPrefix = rawSkillPrefixForName(authority, skillName);
 			if (!rawSkillPrefix) return { path: rawPath };
 			return {
-				path: `${rawPath.slice(0, schemeEnd)}${rawSkillPrefix}`,
+				path: `${rawPath.slice(0, schemeEnd)}${rawSkillPrefix}${authoritySuffix}`,
 				sel: authority.slice(rawSkillPrefix.length + 1),
 			};
 		}
 		const strict = splitPathAndSel(authority);
 		if (strict.sel !== undefined) {
-			return { path: `${rawPath.slice(0, schemeEnd)}${strict.path}`, sel: strict.sel };
+			return { path: `${rawPath.slice(0, schemeEnd)}${strict.path}${authoritySuffix}`, sel: strict.sel };
 		}
 		const firstTail = authority.slice(firstColon + 1);
 		if (FILE_LINE_RANGE_RE.test(firstTail)) {
-			return { path: rawPath.slice(0, schemeEnd + firstColon), sel: firstTail };
+			return { path: `${rawPath.slice(0, schemeEnd + firstColon)}${authoritySuffix}`, sel: firstTail };
 		}
 		const selectorColon = authority.indexOf(":", firstColon + 1);
 		if (selectorColon === -1) return { path: rawPath };
 		return {
-			path: rawPath.slice(0, schemeEnd + selectorColon),
+			path: `${rawPath.slice(0, schemeEnd + selectorColon)}${authoritySuffix}`,
 			sel: authority.slice(selectorColon + 1),
 		};
 	}
@@ -232,7 +233,10 @@ export function splitInternalUrlSel(
 		return { path: rawPath };
 	}
 
-	return { path: rawPath.slice(0, schemeEnd + firstColon), sel: authority.slice(firstColon + 1) };
+	return {
+		path: `${rawPath.slice(0, schemeEnd + firstColon)}${authoritySuffix}`,
+		sel: authority.slice(firstColon + 1),
+	};
 }
 
 function assertNotInternalUrl(expanded: string, original: string): void {

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -198,12 +198,11 @@ export function splitInternalUrlSel(
 			// can be established from the raw authority.
 		}
 		if (decodedAuthority !== undefined && activeSkillNames.includes(decodedAuthority)) return { path: rawPath };
-		const skillName = activeSkillNames
-			.filter(name => decodedAuthority?.startsWith(`${name}:`))
-			.sort((a, b) => b.length - a.length)[0];
-		if (skillName && decodedAuthority !== undefined) {
-			const rawSkillPrefix = rawSkillPrefixForName(authority, skillName);
-			if (!rawSkillPrefix) return { path: rawPath };
+		const rawSkillPrefix = activeSkillNames
+			.map(name => ({ name, prefix: rawSkillPrefixForName(authority, name) }))
+			.filter(item => item.prefix !== undefined)
+			.sort((a, b) => b.name.length - a.name.length)[0]?.prefix;
+		if (rawSkillPrefix) {
 			return {
 				path: `${rawPath.slice(0, schemeEnd)}${rawSkillPrefix}${authoritySuffix}`,
 				sel: authority.slice(rawSkillPrefix.length + 1),

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -225,9 +225,14 @@ export function splitInternalUrlSel(
 	}
 
 	if (!INTERNAL_SCHEMES_WITH_UNAMBIGUOUS_AUTHORITIES[scheme]) {
+		// A path/query/fragment after a path-like authority makes a colon-bearing
+		// resource identity indistinguishable from an authority selector. Preserve
+		// the complete URL; path-like selectors are accepted only on authority-only
+		// URLs, where the existing strict grammar is the sole interpretation.
+		if (authoritySuffix !== "") return { path: rawPath };
 		const strict = splitPathAndSel(authority);
 		if (strict.sel !== undefined) {
-			return { path: `${rawPath.slice(0, schemeEnd)}${strict.path}${authoritySuffix}`, sel: strict.sel };
+			return { path: `${rawPath.slice(0, schemeEnd)}${strict.path}`, sel: strict.sel };
 		}
 		return { path: rawPath };
 	}

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -11,17 +11,20 @@ const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
 const FILE_LINE_RANGE_RE = /^(?:L?\d+(?:[-+]L?\d+|-)?(?:,L?\d+(?:[-+]L?\d+|-)?)*|raw|conflicts)$/i;
 const FILE_LINE_RANGE_ONLY_RE = /^L?\d+(?:[-+]L?\d+|-)?(?:,L?\d+(?:[-+]L?\d+|-)?)*$/i;
 const FILE_RAW_ONLY_RE = /^raw$/i;
-// Schemes whose authority grammar is identifier-shaped and may therefore carry
-// a read selector immediately after the authority. Colons in a path, query, or
-// fragment remain part of the URL and are never considered selectors.
-const INTERNAL_SCHEMES_WITH_SELECTORS: Record<string, true> = {
+// Schemes whose authority grammar is identifier-shaped and cannot contain a
+// literal colon. Colons in a path, query, or fragment remain part of the URL
+// and are never considered selectors.
+const INTERNAL_SCHEMES_WITH_UNAMBIGUOUS_AUTHORITIES: Record<string, true> = {
 	agent: true,
 	artifact: true,
-	issue: true,
-	local: true,
 	memory: true,
-	gjc: true,
+	issue: true,
 	pr: true,
+};
+const INTERNAL_SCHEMES_WITH_SELECTORS: Record<string, true> = {
+	...INTERNAL_SCHEMES_WITH_UNAMBIGUOUS_AUTHORITIES,
+	gjc: true,
+	local: true,
 	rule: true,
 	skill: true,
 };
@@ -170,6 +173,7 @@ export function splitInternalUrlSel(
 	const authority = rawPath.slice(schemeEnd);
 	const firstColon = authority.indexOf(":");
 	if (firstColon === -1) return { path: rawPath };
+	if (firstColon === 0) return { path: rawPath };
 
 	if (scheme === "skill") {
 		const activeSkillNames = options.activeSkillNames ?? [];
@@ -197,6 +201,14 @@ export function splitInternalUrlSel(
 			path: rawPath.slice(0, schemeEnd + selectorColon),
 			sel: authority.slice(selectorColon + 1),
 		};
+	}
+
+	if (!INTERNAL_SCHEMES_WITH_UNAMBIGUOUS_AUTHORITIES[scheme]) {
+		const strict = splitPathAndSel(authority);
+		if (strict.sel !== undefined) {
+			return { path: `${rawPath.slice(0, schemeEnd)}${strict.path}`, sel: strict.sel };
+		}
+		return { path: rawPath };
 	}
 
 	return { path: rawPath.slice(0, schemeEnd + firstColon), sel: authority.slice(firstColon + 1) };

--- a/packages/coding-agent/test/autorouting-boundary-redteam.test.ts
+++ b/packages/coding-agent/test/autorouting-boundary-redteam.test.ts
@@ -2177,7 +2177,7 @@ describe("autorouting boundary red-team generation 4 delta re-attacks", () => {
 			parserObserved["artifact://3:bogus"]?.sel === "bogus" &&
 			parserObserved["artifact://3:-100"]?.sel === "-100" &&
 			parserObserved["agent://3:raw:1-100"]?.sel === "raw:1-100" &&
-			parserObserved["agent://3:bogus"]?.sel === undefined;
+			parserObserved["agent://3:bogus"]?.sel === "bogus";
 		const cyclePass =
 			JSON.stringify(remappedCycle?.nested) ===
 				JSON.stringify({

--- a/packages/coding-agent/test/read-acp-fs.test.ts
+++ b/packages/coding-agent/test/read-acp-fs.test.ts
@@ -198,6 +198,9 @@ describe("read tool ACP fs routing", () => {
 		]);
 
 		try {
+			await expect(tool.execute("agent-unknown", { path: "agent://0:bogus" })).rejects.toThrow(
+				'Invalid internal URL selector "bogus".',
+			);
 			await expect(tool.execute("empty", { path: "artifact://3:" })).rejects.toThrow(
 				'Invalid internal URL selector "".',
 			);

--- a/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
+++ b/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
@@ -14,8 +14,8 @@ describe("splitInternalUrlSel", () => {
 		}
 	});
 
-	it("peels explicit authority selectors before resolving every internal resource", () => {
-		for (const scheme of ["agent", "local", "memory", "rule", "gjc", "issue", "pr"]) {
+	it("peels explicit authority selectors for identifier-shaped resources", () => {
+		for (const scheme of ["agent", "artifact", "memory", "issue", "pr"]) {
 			expect(splitInternalUrlSel(`${scheme}://namespace:raw:bogus`)).toEqual({
 				path: `${scheme}://namespace`,
 				sel: "raw:bogus",
@@ -28,6 +28,20 @@ describe("splitInternalUrlSel", () => {
 				path: `${scheme}://namespace`,
 				sel: "raw:1-5",
 			});
+		}
+	});
+
+	it("preserves literal-colon authorities for path-like resources", () => {
+		for (const scheme of ["local", "rule", "gjc"]) {
+			expect(splitInternalUrlSel(`${scheme}://report:raw.txt`)).toEqual({
+				path: `${scheme}://report:raw.txt`,
+			});
+		}
+	});
+
+	it("does not turn empty authorities into selector-bearing root reads", () => {
+		for (const scheme of ["agent", "artifact", "memory", "issue", "pr"]) {
+			expect(splitInternalUrlSel(`${scheme}://:raw`)).toEqual({ path: `${scheme}://:raw` });
 		}
 	});
 

--- a/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
+++ b/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
@@ -76,6 +76,14 @@ describe("splitInternalUrlSel", () => {
 			path: "skill://superpowers:brainstorming",
 			sel: "",
 		});
+		expect(splitInternalUrlSel("skill://superpowers%3Abrainstorming:bogus", { activeSkillNames })).toEqual({
+			path: "skill://superpowers%3Abrainstorming",
+			sel: "bogus",
+		});
+		expect(splitInternalUrlSel("skill://superpowers%3Abrainstorming:raw:bogus", { activeSkillNames })).toEqual({
+			path: "skill://superpowers%3Abrainstorming",
+			sel: "raw:bogus",
+		});
 	});
 
 	it("falls back to ordinary strict skill selectors without a registry", () => {

--- a/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
+++ b/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
@@ -58,6 +58,14 @@ describe("splitInternalUrlSel", () => {
 		expect(splitInternalUrlSel("pr://owner/repo?author=team:runtime")).toEqual({
 			path: "pr://owner/repo?author=team:runtime",
 		});
+		expect(splitInternalUrlSel("agent://reviewer_0:bogus/result")).toEqual({
+			path: "agent://reviewer_0/result",
+			sel: "bogus",
+		});
+		expect(splitInternalUrlSel("artifact://3:bogus?range=1-2")).toEqual({
+			path: "artifact://3?range=1-2",
+			sel: "bogus",
+		});
 	});
 
 	it("uses active skill names before interpreting selectors", () => {

--- a/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
+++ b/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
@@ -39,11 +39,10 @@ describe("splitInternalUrlSel", () => {
 		}
 	});
 
-	it("preserves path-like URL suffixes after strict selectors", () => {
+	it("preserves ambiguous path-like authorities with URL suffixes", () => {
 		for (const suffix of ["/nested.txt", "?query=value", "#fragment"]) {
 			expect(splitInternalUrlSel(`local://report:raw${suffix}`)).toEqual({
-				path: `local://report${suffix}`,
-				sel: "raw",
+				path: `local://report:raw${suffix}`,
 			});
 		}
 	});

--- a/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
+++ b/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
@@ -14,10 +14,11 @@ describe("splitInternalUrlSel", () => {
 		}
 	});
 
-	it("only peels strict selectors from ambiguous resource identities", () => {
+	it("peels explicit authority selectors before resolving every internal resource", () => {
 		for (const scheme of ["agent", "local", "memory", "rule", "gjc", "issue", "pr"]) {
 			expect(splitInternalUrlSel(`${scheme}://namespace:raw:bogus`)).toEqual({
-				path: `${scheme}://namespace:raw:bogus`,
+				path: `${scheme}://namespace`,
+				sel: "raw:bogus",
 			});
 			expect(splitInternalUrlSel(`${scheme}://namespace:raw`)).toEqual({
 				path: `${scheme}://namespace`,

--- a/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
+++ b/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
@@ -39,6 +39,15 @@ describe("splitInternalUrlSel", () => {
 		}
 	});
 
+	it("preserves path-like URL suffixes after strict selectors", () => {
+		for (const suffix of ["/nested.txt", "?query=value", "#fragment"]) {
+			expect(splitInternalUrlSel(`local://report:raw${suffix}`)).toEqual({
+				path: `local://report${suffix}`,
+				sel: "raw",
+			});
+		}
+	});
+
 	it("does not turn empty authorities into selector-bearing root reads", () => {
 		for (const scheme of ["agent", "artifact", "memory", "issue", "pr"]) {
 			expect(splitInternalUrlSel(`${scheme}://:raw`)).toEqual({ path: `${scheme}://:raw` });

--- a/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
+++ b/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
@@ -92,6 +92,10 @@ describe("splitInternalUrlSel", () => {
 			path: "skill://superpowers%3Abrainstorming",
 			sel: "raw:bogus",
 		});
+		expect(splitInternalUrlSel("skill://superpowers%3Abrainstorming:%ZZ", { activeSkillNames })).toEqual({
+			path: "skill://superpowers%3Abrainstorming",
+			sel: "%ZZ",
+		});
 	});
 
 	it("falls back to ordinary strict skill selectors without a registry", () => {


### PR DESCRIPTION
## What

Restore fail-closed rejection of malformed and unknown selectors on authority-only internal URLs before protocol routing.

## Why

Issue #5036: internal resource handlers could reinterpret malformed selector tails instead of rejecting them. This preserves registered namespaced skill identities while validating explicit authority selectors first. Fixes #5036.

## Testing

- Base: `1606c2190efb2cb72780b37b2c4292f48de46cd5`
- Head: `e7e0c28e76e8041ed0cc2de1c8541a31a319e07f`
- Diff digest: `sha256:3e269cad9519eb50c16a5666529f034d19ad8a1ffc32b3d7ef9322d58cddc918`
- `bun test packages/coding-agent/test/read-acp-fs.test.ts packages/coding-agent/test/tools/split-internal-url-sel.test.ts` — 16 pass, 0 fail
- Related read suites — 56 pass, 0 fail
- Related internal URL/tool suites — 53 pass, 0 fail
- Read red-team suites — 149 pass, 0 fail
- `bun --cwd=packages/coding-agent run check:types` — passed
- Hosted PR contract runs failed only because the original PR body lacked the required risk/verdict contract; the body and signed exact-head evidence are now corrected.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:3e269cad9519eb50c16a5666529f034d19ad8a1ffc32b3d7ef9322d58cddc918 reviewer:human reviewer-id:Yeachan-Heo evidence:focused tests and exact-head signed risk record
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (not user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken