### PR TITLE
test(sdk): repair chat daemon reconnect regressions

### DIFF
--- a/packages/coding-agent/test/chat-daemon-session-reconnect.test.ts
+++ b/packages/coding-agent/test/chat-daemon-session-reconnect.test.ts
@@ -14,6 +14,7 @@ import { ACP_SESSION_RECONNECT } from "../src/sdk/session-reconnect";
 import {
 	drainReconnects,
 	expectedBackoffs,
+	flush,
 	type FakeClock,
 	FakeWebSocket,
 	withFakeTransport,
@@ -639,9 +640,11 @@ async function awaitSocket(count: number): Promise<FakeWebSocket> {
  */
 async function awaitPosts(provider: FakeSlackProvider, count: number, clock?: FakeClock): Promise<void> {
 	for (let attempt = 0; attempt < 5_000 && provider.posts.length < count; attempt++) {
+		await flush();
 		if (clock) {
 			const pending = clock.pendingDelays();
-			if (pending.length > 0) clock.advanceBy(Math.min(...pending));
+			const backoffs = pending.filter(delay => delay <= 2_000);
+			if (backoffs.length > 0) clock.advanceBy(Math.min(...backoffs));
 		}
 		await Bun.sleep(1);
 	}
@@ -686,6 +689,7 @@ async function awaitRefusals(provider: FakeSlackProvider, count: number): Promis
 /** The replay rides the socket, so settle on the request the host itself observed. */
 async function awaitReplayRequests(host: FakeSessionHost, count: number, clock?: FakeClock): Promise<void> {
 	for (let attempt = 0; attempt < 5_000 && host.replayRequests.length < count; attempt++) {
+		await flush();
 		if (clock) {
 			const pending = clock.pendingDelays();
 			if (pending.length > 0) clock.advanceBy(Math.min(...pending));

--- a/packages/coding-agent/test/chat-daemon-session-reconnect.test.ts
+++ b/packages/coding-agent/test/chat-daemon-session-reconnect.test.ts
@@ -11,7 +11,13 @@ import type { DiscordMessageComponent, DiscordProvider, DiscordThread } from "..
 import { SlackProviderError } from "../src/sdk/bus/slack-live-provider";
 import type { SlackProviderClient } from "../src/sdk/bus/slack-provider";
 import { ACP_SESSION_RECONNECT } from "../src/sdk/session-reconnect";
-import { drainReconnects, expectedBackoffs, FakeWebSocket, withFakeTransport } from "./helpers/fake-sdk-transport";
+import {
+	drainReconnects,
+	expectedBackoffs,
+	type FakeClock,
+	FakeWebSocket,
+	withFakeTransport,
+} from "./helpers/fake-sdk-transport";
 
 const SESSION_ID = "chat-reconnect-session";
 const GENERATION = 4;
@@ -631,8 +637,14 @@ async function awaitSocket(count: number): Promise<FakeWebSocket> {
  * a test that drops the socket the instant a post appears would otherwise be racing a
  * cursor the runtime has not moved yet.
  */
-async function awaitPosts(provider: FakeSlackProvider, count: number): Promise<void> {
-	for (let attempt = 0; attempt < 5_000 && provider.posts.length < count; attempt++) await Bun.sleep(1);
+async function awaitPosts(provider: FakeSlackProvider, count: number, clock?: FakeClock): Promise<void> {
+	for (let attempt = 0; attempt < 5_000 && provider.posts.length < count; attempt++) {
+		if (clock) {
+			const pending = clock.pendingDelays();
+			if (pending.length > 0) clock.advanceBy(Math.min(...pending));
+		}
+		await Bun.sleep(1);
+	}
 	expect(provider.posts).toHaveLength(count);
 	await Bun.sleep(25);
 }
@@ -672,8 +684,14 @@ async function awaitRefusals(provider: FakeSlackProvider, count: number): Promis
 }
 
 /** The replay rides the socket, so settle on the request the host itself observed. */
-async function awaitReplayRequests(host: FakeSessionHost, count: number): Promise<void> {
-	for (let attempt = 0; attempt < 5_000 && host.replayRequests.length < count; attempt++) await Bun.sleep(1);
+async function awaitReplayRequests(host: FakeSessionHost, count: number, clock?: FakeClock): Promise<void> {
+	for (let attempt = 0; attempt < 5_000 && host.replayRequests.length < count; attempt++) {
+		if (clock) {
+			const pending = clock.pendingDelays();
+			if (pending.length > 0) clock.advanceBy(Math.min(...pending));
+		}
+		await Bun.sleep(1);
+	}
 	expect(host.replayRequests).toHaveLength(count);
 }
 
@@ -994,7 +1012,7 @@ test("a supersession while a replay is pending discards it instead of replaying 
 
 test("a replay refused on a live socket loses no event and leaves the cursor below the gap", async () => {
 	await withAttachedSessionRuntime(async ({ runtime, provider, reconcile }) => {
-		await withSerializedFakeTransport(async () => {
+		await withSerializedFakeTransport(async clock => {
 			const host = new FakeSessionHost();
 			const starting = runtime.start();
 			host.accept(await awaitSocket(1));
@@ -1012,11 +1030,11 @@ test("a replay refused on a live socket loses no event and leaves the cursor bel
 
 			reconcile();
 			host.accept(await awaitSocket(2));
-			await awaitReplayRequests(host, 2);
+			await awaitReplayRequests(host, 2, clock);
 			// Delivered on the live socket after the refusal, while the gap is still open.
 			host.emit("three");
 
-			await awaitPosts(provider, 3);
+			await awaitPosts(provider, 3, clock);
 			await Bun.sleep(20);
 			// The refusal costs the stream nothing: every sequence, exactly once, in order.
 			expect(provider.posts.map(post => post.text)).toEqual([
@@ -1039,7 +1057,7 @@ test("a replay refused on a live socket loses no event and leaves the cursor bel
 
 test("a replay refused past its retry budget rebuilds the attachment from its cursor", async () => {
 	await withAttachedSessionRuntime(async ({ runtime, provider, reconcile, awaitFrameSettlement }) => {
-		await withSerializedFakeTransport(async () => {
+		await withSerializedFakeTransport(async clock => {
 			const host = new FakeSessionHost();
 			const starting = runtime.start();
 			host.accept(await awaitSocket(1));
@@ -1057,14 +1075,14 @@ test("a replay refused past its retry budget rebuilds the attachment from its cu
 
 			reconcile();
 			host.accept(await awaitSocket(2));
-			await awaitReplayRequests(host, 5);
+			await awaitReplayRequests(host, 5, clock);
 			// The barrier has failed by now, so this frame is not published on the fenced
 			// attachment — but it is in the host log, so the rebuild owes it too.
 			host.emit("three");
 
 			reconcile();
 			host.accept(await awaitSocket(3));
-			await awaitPosts(provider, 3);
+			await awaitPosts(provider, 3, clock);
 			await Bun.sleep(20);
 			// The rebuild resumes the same stream instead of restarting it: nothing above the
 			// cursor is skipped, and nothing at or below it is published twice.

--- a/packages/coding-agent/test/chat-daemon-session-reconnect.test.ts
+++ b/packages/coding-agent/test/chat-daemon-session-reconnect.test.ts
@@ -491,6 +491,7 @@ async function withAttachedSessionRuntime(run: (harness: AttachedRuntimeHarness)
 					clearInterval: (() => undefined) as unknown as typeof clearInterval,
 					setTimeout: inertAttachmentTimeout,
 					clearTimeout: clearInertAttachmentTimeout,
+					startupAttachBudgetMs: 50,
 				},
 			},
 		);
@@ -692,7 +693,8 @@ async function awaitReplayRequests(host: FakeSessionHost, count: number, clock?:
 		await flush();
 		if (clock) {
 			const pending = clock.pendingDelays();
-			if (pending.length > 0) clock.advanceBy(Math.min(...pending));
+			const backoffs = pending.filter(delay => delay <= 2_000);
+			if (backoffs.length > 0) clock.advanceBy(Math.min(...backoffs));
 		}
 		await Bun.sleep(1);
 	}
@@ -785,8 +787,14 @@ test("an unreachable attached chat session exhausts its long-lived reconnect bud
 		await withSerializedFakeTransport(async clock => {
 			const starting = runtime.start();
 			await awaitSocket(1);
-			const observed = await drainReconnects(clock);
+			// Startup owns a short independent cutoff. Advancing only that cutoff proves
+			// the caller is released while the first long-lived transport backoff remains
+			// pending; draining the reconnect budget below is a separate assertion.
+			clock.advanceBy(50);
+			await flush();
 			await expect(starting).resolves.toBeUndefined();
+			expect(FakeWebSocket.instances).toHaveLength(1);
+			const observed = await drainReconnects(clock);
 
 			// The attached-session client must follow the shared long-lived schedule,
 			// not the transport's one-shot defaults (3 attempts, 25/50/100ms = 175ms).
@@ -968,6 +976,7 @@ test("stopping the runtime while a replay is pending neither hangs nor publishes
 			await runtime.stop();
 			await Bun.sleep(20);
 			expect(provider.posts.map(post => post.text)).toEqual(["GJC notice\none"]);
+			expect(FakeWebSocket.instances.every(socket => socket.readyState === FakeWebSocket.CLOSED)).toBe(true);
 		});
 	});
 }, 20_000);

--- a/packages/coding-agent/test/helpers/fake-sdk-transport.ts
+++ b/packages/coding-agent/test/helpers/fake-sdk-transport.ts
@@ -165,10 +165,17 @@ export async function drainReconnects(clock: FakeClock, attempt = 0): Promise<nu
 		for (let tick = 0; tick < 4; tick++) await flush();
 		const pending = clock.pendingDelays();
 		if (pending.length === 0) break;
-		// The failed incarnation clears its open timer, so only the backoff sleep is pending.
-		expect(pending).toHaveLength(1);
-		observed.push(pending[0]);
-		clock.advanceBy(pending[0]);
+		// The startup budget may still be pending while the long-lived reconnect
+		// cycle drains. Select the transport backoff; the open timer is cleared by
+		// the failed incarnation and the startup cutoff is independent of it.
+		const backoffs = pending.filter(delay => delay <= 2_000);
+		expect(backoffs.length).toBeGreaterThan(0);
+		// A startup cutoff can be shorter than the current backoff near the end of
+		// the budget. The transport backoff is the largest short timer; the cutoff
+		// is allowed to remain pending until startup observes it.
+		const backoff = Math.max(...backoffs);
+		observed.push(backoff);
+		clock.advanceBy(backoff);
 		for (let tick = 0; tick < 4; tick++) await flush();
 	}
 	return observed;

--- a/packages/coding-agent/test/helpers/fake-sdk-transport.ts
+++ b/packages/coding-agent/test/helpers/fake-sdk-transport.ts
@@ -140,7 +140,7 @@ export async function withFakeTransport(run: (clock: FakeClock) => Promise<void>
 	}
 }
 
-const flush = (): Promise<void> => new Promise<void>(resolve => queueMicrotask(resolve));
+export const flush = (): Promise<void> => new Promise<void>(resolve => queueMicrotask(resolve));
 
 export type SessionReconnectBudget = Readonly<{
 	reconnectAttempts: number;


### PR DESCRIPTION
## What

Make the chat reconnect regression suite deterministic without changing production reconnect behavior. Fake-clock waits flush queued replay responses before advancing time and only advance transport backoff timers; startup cutoff and stalled-replay cleanup are asserted directly.

## Why

Fixes #5035. The prior helper could advance unrelated startup/publication timers, causing retry-budget rebuild assertions to race or fail while the real SessionRouter path was otherwise correct. Review findings also required observing startup release before retry exhaustion and verifying stalled replay sockets close.

## Testing

- `bun test packages/coding-agent/test/chat-daemon-session-reconnect.test.ts` — 25 pass, 254 expect calls.
- Startup/cleanup selectors — 2 pass.
- Retry-budget rebuild scenario repeated 5 times — 5 pass.
- Exact reproduction: prior helper advanced the minimum pending timer; after repair, microtask flush precedes fake-clock advancement and only <=2000ms transport backoffs are advanced.
- Hosted affected CI: trigger refreshed after exact-head verdict correction; latest dispatch was not a PR event and is recorded only as supplemental evidence.

## Risk classification

- [x] `low-risk` — test-only deterministic scheduling and assertion repair; no product source changed.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:7b96c58b7ffe18c2084f2885506313f9f6222c21414ae45ad5ce16456eb61df5 reviewer:architect reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/actions/runs/33156567740
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (not user-facing)
- [x] Verdict above matches exact PR head 19078926184b64ba32af18bce6e5d9a727d0e450
- [x] Risk classification matches test-only change and solo merge path