### PR TITLE
fix(tui): keep fuzzy composer autocomplete reachable

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,15 +2,16 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Composer file autocomplete now keeps the `@` fuzzy/chosung path reachable from explicit Tab and while Korean query characters are typed, without changing ordinary path-prefix completion.
+
 ## [0.15.5] - 2026-08-29
 
 ### Added
 
 - `@` fuzzy file search supports Hangul chosung (초성) matching: a bare consonant matches any syllable with that initial, so `@ㅎㄱ` finds `한글.txt`. Literal and full-syllable matches keep ranking above chosung matches.
 
-### Fixed
-
-- Composer file autocomplete now keeps the `@` fuzzy/chosung path reachable from explicit Tab and while Korean query characters are typed, without changing ordinary path-prefix completion.
 ## [0.15.4] - 2026-08-29
 
 ### Fixed

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -7,6 +7,10 @@
 ### Added
 
 - `@` fuzzy file search supports Hangul chosung (초성) matching: a bare consonant matches any syllable with that initial, so `@ㅎㄱ` finds `한글.txt`. Literal and full-syllable matches keep ranking above chosung matches.
+
+### Fixed
+
+- Composer file autocomplete now keeps the `@` fuzzy/chosung path reachable from explicit Tab and while Korean query characters are typed, without changing ordinary path-prefix completion.
 ## [0.15.4] - 2026-08-29
 
 ### Fixed

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -904,10 +904,10 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		if (rawPrefix.length === 0) return prefixSuggestions;
 
 		const fuzzySuggestions = await this.#getFuzzyFileSuggestions(rawPrefix, { isQuotedPrefix });
-		const seen = new Set(prefixSuggestions.map(item => item.value));
+		const seen = new Set(fuzzySuggestions.map(item => item.value));
 		return [
-			...prefixSuggestions,
-			...fuzzySuggestions.filter(item => {
+			...fuzzySuggestions,
+			...prefixSuggestions.filter(item => {
 				if (seen.has(item.value)) return false;
 				seen.add(item.value);
 				return true;

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -17,6 +17,7 @@ async function fuzzyFindNative(): Promise<NativeFuzzyFind> {
 }
 
 const PATH_DELIMITERS = new Set([" ", "\t", '"', "'", "="]);
+const MAX_AUTOCOMPLETE_SUGGESTIONS = 100;
 
 function isAbsolutePathLike(value: string): boolean {
 	return path.isAbsolute(value) || path.win32.isAbsolute(value);
@@ -912,7 +913,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				seen.add(item.value);
 				return true;
 			}),
-		];
+		].slice(0, MAX_AUTOCOMPLETE_SUGGESTIONS);
 	}
 
 	// Force file completion (called on Tab key) - always returns suggestions

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -902,7 +902,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	async #getAtFileSuggestions(atPrefix: string): Promise<AutocompleteItem[]> {
 		const prefixSuggestions = await this.#getFileSuggestions(atPrefix);
 		const { rawPrefix, isQuotedPrefix } = parsePathPrefix(atPrefix);
-		if (rawPrefix.length === 0) return prefixSuggestions;
+		if (rawPrefix.length === 0) return prefixSuggestions.slice(0, MAX_AUTOCOMPLETE_SUGGESTIONS);
 
 		const fuzzySuggestions = await this.#getFuzzyFileSuggestions(rawPrefix, { isQuotedPrefix });
 		const seen = new Set(fuzzySuggestions.map(item => item.value));

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -928,7 +928,12 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			const suggestions =
 				rawPrefix.length > 0
 					? await this.#getFuzzyFileSuggestions(rawPrefix, { isQuotedPrefix })
-					: await this.#getFileSuggestions("@");
+					: await this.#getFileSuggestions(atPrefix);
+			if (suggestions.length === 0 && rawPrefix.length > 0) {
+				const fallback = await this.#getFileSuggestions(atPrefix);
+				if (fallback.length === 0) return null;
+				return { items: fallback, prefix: atPrefix };
+			}
 			if (suggestions.length === 0) return null;
 
 			return { items: suggestions, prefix: atPrefix };

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -922,6 +922,18 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		}
 
 		// Force extract path prefix - this will always return something
+		const atPrefix = this.#extractAtPrefix(textBeforeCursor);
+		if (atPrefix !== null) {
+			const { rawPrefix, isQuotedPrefix } = parsePathPrefix(atPrefix);
+			const suggestions =
+				rawPrefix.length > 0
+					? await this.#getFuzzyFileSuggestions(rawPrefix, { isQuotedPrefix })
+					: await this.#getFileSuggestions("@");
+			if (suggestions.length === 0) return null;
+
+			return { items: suggestions, prefix: atPrefix };
+		}
+
 		const pathMatch = this.#extractPathPrefix(textBeforeCursor, true);
 		if (pathMatch !== null) {
 			const suggestions = await this.#getFileSuggestions(pathMatch);

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -408,16 +408,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		// Check for @ file reference (fuzzy search) - must be after a delimiter or at start
 		const atPrefix = this.#extractAtPrefix(textBeforeCursor);
 		if (atPrefix) {
-			const { rawPrefix, isQuotedPrefix } = parsePathPrefix(atPrefix);
-			const suggestions =
-				rawPrefix.length > 0
-					? await this.#getFuzzyFileSuggestions(rawPrefix, { isQuotedPrefix })
-					: await this.#getFileSuggestions("@");
-			if (suggestions.length === 0 && rawPrefix.length > 0) {
-				const fallback = await this.#getFileSuggestions(atPrefix);
-				if (fallback.length === 0) return null;
-				return { items: fallback, prefix: atPrefix };
-			}
+			const suggestions = await this.#getAtFileSuggestions(atPrefix);
 			if (suggestions.length === 0) return null;
 
 			return {
@@ -907,6 +898,23 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		}
 	}
 
+	async #getAtFileSuggestions(atPrefix: string): Promise<AutocompleteItem[]> {
+		const prefixSuggestions = await this.#getFileSuggestions(atPrefix);
+		const { rawPrefix, isQuotedPrefix } = parsePathPrefix(atPrefix);
+		if (rawPrefix.length === 0) return prefixSuggestions;
+
+		const fuzzySuggestions = await this.#getFuzzyFileSuggestions(rawPrefix, { isQuotedPrefix });
+		const seen = new Set(prefixSuggestions.map(item => item.value));
+		return [
+			...prefixSuggestions,
+			...fuzzySuggestions.filter(item => {
+				if (seen.has(item.value)) return false;
+				seen.add(item.value);
+				return true;
+			}),
+		];
+	}
+
 	// Force file completion (called on Tab key) - always returns suggestions
 	async getForceFileSuggestions(
 		lines: string[],
@@ -924,16 +932,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		// Force extract path prefix - this will always return something
 		const atPrefix = this.#extractAtPrefix(textBeforeCursor);
 		if (atPrefix !== null) {
-			const { rawPrefix, isQuotedPrefix } = parsePathPrefix(atPrefix);
-			const suggestions =
-				rawPrefix.length > 0
-					? await this.#getFuzzyFileSuggestions(rawPrefix, { isQuotedPrefix })
-					: await this.#getFileSuggestions(atPrefix);
-			if (suggestions.length === 0 && rawPrefix.length > 0) {
-				const fallback = await this.#getFileSuggestions(atPrefix);
-				if (fallback.length === 0) return null;
-				return { items: fallback, prefix: atPrefix };
-			}
+			const suggestions = await this.#getAtFileSuggestions(atPrefix);
 			if (suggestions.length === 0) return null;
 
 			return { items: suggestions, prefix: atPrefix };

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1994,7 +1994,7 @@ export class Editor implements Component, Focusable {
 				this.#tryTriggerAutocomplete();
 			}
 			// Also auto-trigger when typing letters/path chars in a completable context
-			else if (/[a-zA-Z0-9.\-_/]/.test(char)) {
+			else if (/[\p{L}0-9.\-_/]/u.test(char)) {
 				const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 				const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
 				// Check if we're in a slash command or inline slash token

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -109,7 +109,7 @@ describe("CombinedAutocompleteProvider", () => {
 		});
 
 		it("preserves quoted @ metadata for explicit Tab", async () => {
-			fs.writeFileSync(path.join(baseDir, "file name.md"), "content\n");
+			await Bun.write(path.join(baseDir, "file name.md"), "content\n");
 			const provider = new CombinedAutocompleteProvider([], baseDir);
 			const result = await provider.getForceFileSuggestions(['@"'], 0, 2);
 
@@ -317,7 +317,7 @@ describe("CombinedAutocompleteProvider", () => {
 		});
 
 		it("uses the same chosung fuzzy lane for explicit Tab", async () => {
-			fs.writeFileSync(path.join(baseDir, hangulName), "content\n");
+			await Bun.write(path.join(baseDir, hangulName), "content\n");
 			const provider = new CombinedAutocompleteProvider([], baseDir);
 			const line = "@\u314E\u3131";
 			const result = await provider.getForceFileSuggestions([line], 0, line.length);
@@ -328,7 +328,7 @@ describe("CombinedAutocompleteProvider", () => {
 
 		it("uses fuzzy contains matching for explicit Tab", async () => {
 			const filename = "project-story.md";
-			fs.writeFileSync(path.join(baseDir, filename), "content\n");
+			await Bun.write(path.join(baseDir, filename), "content\n");
 			const provider = new CombinedAutocompleteProvider([], baseDir);
 			const line = "@story";
 			const result = await provider.getForceFileSuggestions([line], 0, line.length);
@@ -338,9 +338,9 @@ describe("CombinedAutocompleteProvider", () => {
 		});
 
 		it("merges ignored prefix matches with fuzzy tracked siblings", async () => {
-			fs.writeFileSync(path.join(baseDir, ".gitignore"), "story-ignored.md\nnode_modules/\n");
-			fs.writeFileSync(path.join(baseDir, "story-ignored.md"), "ignored\n");
-			fs.writeFileSync(path.join(baseDir, "story-tracked.md"), "tracked\n");
+			await Bun.write(path.join(baseDir, ".gitignore"), "story-ignored.md\nnode_modules/\n");
+			await Bun.write(path.join(baseDir, "story-ignored.md"), "ignored\n");
+			await Bun.write(path.join(baseDir, "story-tracked.md"), "tracked\n");
 			const provider = new CombinedAutocompleteProvider([], baseDir);
 			const result = await provider.getForceFileSuggestions(["@story"], 0, 6);
 
@@ -348,8 +348,8 @@ describe("CombinedAutocompleteProvider", () => {
 		});
 
 		it("keeps node_modules exact prefix matches reachable from explicit Tab", async () => {
-			fs.mkdirSync(path.join(baseDir, "node_modules"), { recursive: true });
-			fs.writeFileSync(path.join(baseDir, "node_modules", "package.json"), "{}\n");
+			await fs.promises.mkdir(path.join(baseDir, "node_modules"), { recursive: true });
+			await Bun.write(path.join(baseDir, "node_modules", "package.json"), "{}\n");
 			const provider = new CombinedAutocompleteProvider([], baseDir);
 			const line = "@node_modules/pac";
 			const result = await provider.getForceFileSuggestions([line], 0, line.length);

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -107,6 +107,15 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(values).toContain("@.github/");
 			expect(values.some(value => value === "@.git" || value.startsWith("@.git/"))).toBe(false);
 		});
+
+		it("preserves quoted @ metadata for explicit Tab", async () => {
+			fs.writeFileSync(path.join(baseDir, "file name.md"), "content\n");
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const result = await provider.getForceFileSuggestions(['@"'], 0, 2);
+
+			expect(result?.prefix).toBe('@"');
+			expect(result?.items.map(item => item.value)).toContain('@"file name.md"');
+		});
 	});
 
 	describe("@ fuzzy search scoped paths", () => {

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
+import * as fsPromises from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
@@ -350,7 +351,7 @@ describe("CombinedAutocompleteProvider", () => {
 
 		it("keeps an exact file ahead of a fuzzy directory match", async () => {
 			await Bun.write(path.join(baseDir, "target"), "file\n");
-			await fs.promises.mkdir(path.join(baseDir, "target-dir"));
+			await fsPromises.mkdir(path.join(baseDir, "target-dir"));
 			const provider = new CombinedAutocompleteProvider([], baseDir);
 			const values =
 				(await provider.getForceFileSuggestions(["@target"], 0, 7))?.items.map(item => item.value) ?? [];
@@ -361,7 +362,7 @@ describe("CombinedAutocompleteProvider", () => {
 		});
 
 		it("keeps node_modules exact prefix matches reachable from explicit Tab", async () => {
-			await fs.promises.mkdir(path.join(baseDir, "node_modules"), { recursive: true });
+			await fsPromises.mkdir(path.join(baseDir, "node_modules"), { recursive: true });
 			await Bun.write(path.join(baseDir, "node_modules", "package.json"), "{}\n");
 			const provider = new CombinedAutocompleteProvider([], baseDir);
 			const line = "@node_modules/pac";

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -341,10 +341,23 @@ describe("CombinedAutocompleteProvider", () => {
 			await Bun.write(path.join(baseDir, ".gitignore"), "story-ignored.md\nnode_modules/\n");
 			await Bun.write(path.join(baseDir, "story-ignored.md"), "ignored\n");
 			await Bun.write(path.join(baseDir, "story-tracked.md"), "tracked\n");
+			await Bun.$`git -C ${baseDir} init`.quiet();
 			const provider = new CombinedAutocompleteProvider([], baseDir);
 			const result = await provider.getForceFileSuggestions(["@story"], 0, 6);
 
-			expect(result?.items.map(item => item.value)).toEqual(["@story-ignored.md", "@story-tracked.md"]);
+			expect(result?.items.map(item => item.value)).toEqual(["@story-tracked.md", "@story-ignored.md"]);
+		});
+
+		it("keeps an exact file ahead of a fuzzy directory match", async () => {
+			await Bun.write(path.join(baseDir, "target"), "file\n");
+			await fs.promises.mkdir(path.join(baseDir, "target-dir"));
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const values =
+				(await provider.getForceFileSuggestions(["@target"], 0, 7))?.items.map(item => item.value) ?? [];
+
+			expect(values.indexOf("@target")).toBeGreaterThanOrEqual(0);
+			expect(values.indexOf("@target-dir/")).toBeGreaterThanOrEqual(0);
+			expect(values.indexOf("@target")).toBeLessThan(values.indexOf("@target-dir/"));
 		});
 
 		it("keeps node_modules exact prefix matches reachable from explicit Tab", async () => {

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -307,6 +307,27 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(values).toContain(`@${hangulName}`);
 		});
 
+		it("uses the same chosung fuzzy lane for explicit Tab", async () => {
+			fs.writeFileSync(path.join(baseDir, hangulName), "content\n");
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = "@\u314E\u3131";
+			const result = await provider.getForceFileSuggestions([line], 0, line.length);
+
+			expect(result?.prefix).toBe(line);
+			expect(result?.items.map(item => item.value)).toContain(`@${hangulName}`);
+		});
+
+		it("uses fuzzy contains matching for explicit Tab", async () => {
+			const filename = "project-story.md";
+			fs.writeFileSync(path.join(baseDir, filename), "content\n");
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = "@story";
+			const result = await provider.getForceFileSuggestions([line], 0, line.length);
+
+			expect(result?.prefix).toBe(line);
+			expect(result?.items.map(item => item.value)).toContain(`@${filename}`);
+		});
+
 		it("matches chosung against NFD-stored file names", async () => {
 			const nfdName = "\u1112\u1161\u11AB\u1100\u1173\u11AF.txt";
 			fs.writeFileSync(path.join(baseDir, nfdName), "content\n");

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -337,6 +337,26 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(result?.items.map(item => item.value)).toContain(`@${filename}`);
 		});
 
+		it("merges ignored prefix matches with fuzzy tracked siblings", async () => {
+			fs.writeFileSync(path.join(baseDir, ".gitignore"), "story-ignored.md\nnode_modules/\n");
+			fs.writeFileSync(path.join(baseDir, "story-ignored.md"), "ignored\n");
+			fs.writeFileSync(path.join(baseDir, "story-tracked.md"), "tracked\n");
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const result = await provider.getForceFileSuggestions(["@story"], 0, 6);
+
+			expect(result?.items.map(item => item.value)).toEqual(["@story-ignored.md", "@story-tracked.md"]);
+		});
+
+		it("keeps node_modules exact prefix matches reachable from explicit Tab", async () => {
+			fs.mkdirSync(path.join(baseDir, "node_modules"), { recursive: true });
+			fs.writeFileSync(path.join(baseDir, "node_modules", "package.json"), "{}\n");
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = "@node_modules/pac";
+			const result = await provider.getForceFileSuggestions([line], 0, line.length);
+
+			expect(result?.items.map(item => item.value)).toContain("@node_modules/package.json");
+		});
+
 		it("matches chosung against NFD-stored file names", async () => {
 			const nfdName = "\u1112\u1161\u11AB\u1100\u1173\u11AF.txt";
 			fs.writeFileSync(path.join(baseDir, nfdName), "content\n");

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -625,4 +625,21 @@ describe("Editor Enter handler sync slash completion", () => {
 		expect(submitted).toBe("/model");
 		expect(suggestionsCallCount).toBeGreaterThan(0);
 	});
+
+	it("updates fuzzy suggestions for Korean characters typed after @", async () => {
+		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "editor-korean-autocomplete-"));
+		try {
+			fs.writeFileSync(path.join(baseDir, "한글.txt"), "content\n");
+			const editor = new Editor(defaultEditorTheme);
+			editor.setAutocompleteProvider(new CombinedAutocompleteProvider([], baseDir));
+
+			editor.handleInput("@");
+			editor.handleInput("ㅎㄱ");
+			await Bun.sleep(100);
+
+			expect(editor.isShowingAutocomplete()).toBe(true);
+		} finally {
+			fs.rmSync(baseDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -627,9 +627,9 @@ describe("Editor Enter handler sync slash completion", () => {
 	});
 
 	it("updates fuzzy suggestions for Korean characters typed after @", async () => {
-		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "editor-korean-autocomplete-"));
+		const baseDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "editor-korean-autocomplete-"));
 		try {
-			fs.writeFileSync(path.join(baseDir, "한글.txt"), "content\n");
+			await Bun.write(path.join(baseDir, "한글.txt"), "content\n");
 			const editor = new Editor(defaultEditorTheme);
 			editor.setAutocompleteProvider(new CombinedAutocompleteProvider([], baseDir));
 
@@ -639,14 +639,14 @@ describe("Editor Enter handler sync slash completion", () => {
 
 			expect(editor.isShowingAutocomplete()).toBe(true);
 		} finally {
-			fs.rmSync(baseDir, { recursive: true, force: true });
+			await fs.promises.rm(baseDir, { recursive: true, force: true });
 		}
 	});
 
 	it("applies a fuzzy @ completion from explicit Tab", async () => {
-		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "editor-tab-fuzzy-autocomplete-"));
+		const baseDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "editor-tab-fuzzy-autocomplete-"));
 		try {
-			fs.writeFileSync(path.join(baseDir, "한글.txt"), "content\n");
+			await Bun.write(path.join(baseDir, "한글.txt"), "content\n");
 			const editor = new Editor(defaultEditorTheme);
 			editor.setAutocompleteProvider(new CombinedAutocompleteProvider([], baseDir));
 			editor.setText("@ㅎㄱ");
@@ -656,7 +656,7 @@ describe("Editor Enter handler sync slash completion", () => {
 
 			expect(editor.getText()).toBe("@한글.txt ");
 		} finally {
-			fs.rmSync(baseDir, { recursive: true, force: true });
+			await fs.promises.rm(baseDir, { recursive: true, force: true });
 		}
 	});
 });

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -256,7 +256,7 @@ describe("Editor Enter handler sync slash completion", () => {
 			editor.setText("please read `src");
 
 			editor.handleInput("/");
-			await Bun.sleep(20);
+			await Bun.sleep(500);
 
 			expect(editor.isShowingAutocomplete()).toBe(true);
 			editor.handleInput("\r");
@@ -280,7 +280,7 @@ describe("Editor Enter handler sync slash completion", () => {
 			editor.setText(`please read \`${baseDir}`);
 
 			editor.handleInput("/");
-			await Bun.sleep(20);
+			await Bun.sleep(500);
 			expect(editor.isShowingAutocomplete()).toBe(true);
 			editor.handleInput("\r");
 
@@ -306,7 +306,7 @@ describe("Editor Enter handler sync slash completion", () => {
 			editor.setText(`please read \`${baseDir}`);
 
 			editor.handleInput("/");
-			await Bun.sleep(20);
+			await Bun.sleep(500);
 			expect(editor.isShowingAutocomplete()).toBe(true);
 			editor.moveToLineStart();
 			editor.handleInput("\r");
@@ -635,7 +635,7 @@ describe("Editor Enter handler sync slash completion", () => {
 
 			editor.handleInput("@");
 			editor.handleInput("ㅎㄱ");
-			await Bun.sleep(100);
+			await Bun.sleep(500);
 
 			expect(editor.isShowingAutocomplete()).toBe(true);
 		} finally {
@@ -652,7 +652,7 @@ describe("Editor Enter handler sync slash completion", () => {
 			editor.setText("@ㅎㄱ");
 
 			editor.handleInput("\t");
-			await Bun.sleep(100);
+			await Bun.sleep(500);
 
 			expect(editor.getText()).toBe("@한글.txt ");
 		} finally {

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -642,4 +642,21 @@ describe("Editor Enter handler sync slash completion", () => {
 			fs.rmSync(baseDir, { recursive: true, force: true });
 		}
 	});
+
+	it("applies a fuzzy @ completion from explicit Tab", async () => {
+		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "editor-tab-fuzzy-autocomplete-"));
+		try {
+			fs.writeFileSync(path.join(baseDir, "한글.txt"), "content\n");
+			const editor = new Editor(defaultEditorTheme);
+			editor.setAutocompleteProvider(new CombinedAutocompleteProvider([], baseDir));
+			editor.setText("@ㅎㄱ");
+
+			editor.handleInput("\t");
+			await Bun.sleep(100);
+
+			expect(editor.getText()).toBe("@한글.txt ");
+		} finally {
+			fs.rmSync(baseDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
+import * as fsPromises from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
@@ -627,7 +628,7 @@ describe("Editor Enter handler sync slash completion", () => {
 	});
 
 	it("updates fuzzy suggestions for Korean characters typed after @", async () => {
-		const baseDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "editor-korean-autocomplete-"));
+		const baseDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "editor-korean-autocomplete-"));
 		try {
 			await Bun.write(path.join(baseDir, "한글.txt"), "content\n");
 			const editor = new Editor(defaultEditorTheme);
@@ -639,12 +640,12 @@ describe("Editor Enter handler sync slash completion", () => {
 
 			expect(editor.isShowingAutocomplete()).toBe(true);
 		} finally {
-			await fs.promises.rm(baseDir, { recursive: true, force: true });
+			await fsPromises.rm(baseDir, { recursive: true, force: true });
 		}
 	});
 
 	it("applies a fuzzy @ completion from explicit Tab", async () => {
-		const baseDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "editor-tab-fuzzy-autocomplete-"));
+		const baseDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "editor-tab-fuzzy-autocomplete-"));
 		try {
 			await Bun.write(path.join(baseDir, "한글.txt"), "content\n");
 			const editor = new Editor(defaultEditorTheme);
@@ -656,7 +657,7 @@ describe("Editor Enter handler sync slash completion", () => {
 
 			expect(editor.getText()).toBe("@한글.txt ");
 		} finally {
-			await fs.promises.rm(baseDir, { recursive: true, force: true });
+			await fsPromises.rm(baseDir, { recursive: true, force: true });
 		}
 	});
 });


### PR DESCRIPTION
## What

- Keep explicit Tab `@` completion aligned with incremental fuzzy/chosung suggestions.
- Merge legacy prefix-provider authority with fuzzy results so ignored and `node_modules` paths remain reachable.
- Refresh suggestions for typed Korean characters and preserve quoting/path insertion.

## Why

Fixes #5056. The fuzzy discovery lane intentionally honors ignore rules, but composer completion must retain exact/prefix reachability and popup parity.

## Testing

- `bun test packages/tui/test/autocomplete.test.ts` — 63 pass
- `bun test packages/tui/test/editor-autocomplete-actions.test.ts` — 27 pass
- `bun test packages/tui/test/editor.test.ts` — 160 pass
- `bun --cwd=packages/tui run check` — pass

## Risk classification

- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:4ef1d377d1b9d8accfbe71e8987c42e36bda3a5e763c1efb1621730481338e2e reviewer:critic reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/pull/5057#issuecomment-5461040238
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*