### PR TITLE
fix(sdk): preserve continuation and injection boundaries

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -349,7 +349,9 @@ export async function submitInteractiveInput(
 		| "checkShutdownRequested"
 		| "waitForAgentEnd"
 	>,
-	session: Pick<AgentSession, "prompt" | "promptCustomMessage">,
+	session: Pick<AgentSession, "prompt" | "promptCustomMessage"> & {
+		continuePersistedHistory?: AgentSession["continuePersistedHistory"];
+	},
 	input: SubmittedUserInput,
 ): Promise<void> {
 	if (input.cancelled) {
@@ -357,8 +359,13 @@ export async function submitInteractiveInput(
 	}
 
 	try {
+		if (input.started) {
+			if (!session.continuePersistedHistory) throw new Error("Session continuation is unavailable.");
+			await session.continuePersistedHistory();
+			return;
+		}
 		// Continue shortcuts submit an already-started empty prompt with no optimistic user message.
-		if (!input.started && !mode.markPendingSubmissionStarted(input)) {
+		if (!mode.markPendingSubmissionStarted(input)) {
 			return;
 		}
 		const agentEnd = mode.waitForAgentEnd();

--- a/packages/coding-agent/src/modes/utils/injected-user-submission.ts
+++ b/packages/coding-agent/src/modes/utils/injected-user-submission.ts
@@ -17,7 +17,11 @@ import type { InteractiveModeContext } from "../types";
  * (unhandled rejection → resident crash).
  */
 export function extensionUserMessageContentError(content: string | (TextContent | ImageContent)[]): Error | undefined {
-	if (typeof content === "string") return undefined;
+	if (typeof content === "string") {
+		if (content.trim().length === 0)
+			return Object.assign(new Error("Prompt must not be empty."), { code: "invalid_input" });
+		return undefined;
+	}
 	if (!Array.isArray(content)) {
 		return Object.assign(new Error("sendUserMessage requires string or content-array content."), {
 			code: "invalid_input",
@@ -30,6 +34,16 @@ export function extensionUserMessageContentError(content: string | (TextContent 
 			});
 		}
 	}
+	const text = content
+		.filter((part): part is TextContent => part.type === "text")
+		.map(part => part.text)
+		.join("\n");
+	const hasUsableImage = content.some(
+		(part): part is ImageContent =>
+			part.type === "image" && typeof part.data === "string" && part.data.trim().length > 0,
+	);
+	if (text.trim().length === 0 && !hasUsableImage)
+		return Object.assign(new Error("Prompt must not be empty."), { code: "invalid_input" });
 	return undefined;
 }
 export function normalizeInjectedUserContent(content: string | (TextContent | ImageContent)[]): {

--- a/packages/coding-agent/test/empty-prompt-followup.test.ts
+++ b/packages/coding-agent/test/empty-prompt-followup.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test";
+import { extensionUserMessageContentError } from "../src/modes/utils/injected-user-submission";
+
+test("extension user message validation rejects empty text before optimistic UI bookkeeping", () => {
+	expect(extensionUserMessageContentError(" \n\t ")).toMatchObject({ code: "invalid_input" });
+	expect(extensionUserMessageContentError([{ type: "text", text: "\n" }])).toMatchObject({ code: "invalid_input" });
+	expect(
+		extensionUserMessageContentError([
+			{ type: "text", text: "" },
+			{ type: "image", data: "bytes", mimeType: "image/png" },
+		]),
+	).toBeUndefined();
+	expect(extensionUserMessageContentError("valid Unicode — multiline\ntext")).toBeUndefined();
+});

--- a/packages/coding-agent/test/main-interactive-input.test.ts
+++ b/packages/coding-agent/test/main-interactive-input.test.ts
@@ -47,16 +47,18 @@ describe("submitInteractiveInput", () => {
 		const session = {
 			prompt: vi.fn(async () => {}),
 			promptCustomMessage: vi.fn(async () => {}),
+			continuePersistedHistory: vi.fn(async () => {}),
 		};
 		const input = createInput({ text: "", started: true });
 
 		await submitInteractiveInput(mode, session, input);
 
 		expect(mode.markPendingSubmissionStarted).not.toHaveBeenCalled();
-		expect(session.prompt).toHaveBeenCalledWith("", { images: undefined });
+		expect(session.continuePersistedHistory).toHaveBeenCalledTimes(1);
+		expect(session.prompt).not.toHaveBeenCalled();
 		expect(mode.finishPendingSubmission).toHaveBeenCalledWith(input);
 		expect(mode.showError).not.toHaveBeenCalled();
-		expect(waiter.dispose).toHaveBeenCalledTimes(1);
+		expect(waiter.dispose).not.toHaveBeenCalled();
 	});
 
 	it("skips prompting when optimistic submission was cancelled before start", async () => {


### PR DESCRIPTION
## What

Follow up the merged #5059 fix by keeping interactive `.`/`c` continuation on the internal persisted-history path and validating extension-injected prompt semantics before optimistic UI/history bookkeeping.

## Why

The terminal critic found that continuation shortcuts still called `session.prompt("")`, and extension injection could record a phantom message before an empty prompt rejection was observed.

## Testing

- `bun test packages/coding-agent/test/main-interactive-input.test.ts packages/coding-agent/test/empty-prompt-followup.test.ts` — 14 pass, 0 fail
- `bun --cwd=packages/coding-agent run check` — passed with existing warnings
- signed commit: `f89db3bf3216ddc2e328c0bddffd635d9d760f14`
- exact diff digest: `sha256:c52b27170392a3d8157075d393ba91f49fbfa63597f2fd996e6384838b5123ca`
- base: `6c7632c16eb57be6f3fe032f885fe8b79dd95fe9`

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict with a risk-record comment bound to the exact head.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:c52b27170392a3d8157075d393ba91f49fbfa63597f2fd996e6384838b5123ca reviewer:critic reviewer-id:Yeachan-Heo evidence:exact-head critic follow-up and local tests
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] Verdict above matches the exact PR head
- [x] Risk classification matches the review path

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*