### PR TITLE
fix(ai): normalize Kiro OAuth wire model id and dedupe provider list

### DIFF
--- a/packages/ai/src/providers/kiro-codewhisperer.ts
+++ b/packages/ai/src/providers/kiro-codewhisperer.ts
@@ -29,7 +29,7 @@ import { transportFailureFacts } from "../utils/fallback-transport";
 import { withHttpStatus } from "../utils/http-inspector";
 import { captureUnicodeEscapeEvidence } from "../utils/json-parse";
 import { decodeEventStream } from "./aws-eventstream";
-import { isKiroApiKey, streamKiroApiKey } from "./kiro-api-key";
+import { isKiroApiKey, streamKiroApiKey, toKiroModelId } from "./kiro-api-key";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Provider options
@@ -362,7 +362,11 @@ function buildConversationState(
 		throw new Error("Kiro CodeWhisperer requires at least one message");
 	}
 
-	const modelId = model.wireModelId || model.id;
+	// Normalize the local dashed selector/wire id (e.g. "claude-haiku-4-5") to
+	// the canonical dotted upstream Kiro model id (e.g. "claude-haiku-4.5"),
+	// matching the sibling ksk_ API-key transport (kiro-api-key.ts) so both
+	// auth methods send the same wire form for the same catalog entry.
+	const modelId = toKiroModelId(model.wireModelId || model.id);
 
 	// Build history from all messages except the last
 	const history: WireHistoryMessage[] = [];

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -534,10 +534,19 @@ export function resolveOAuthStorageProvider(provider: OAuthProviderId): OAuthPro
  * Get list of OAuth providers.
  */
 export function getOAuthProviders(): OAuthProviderInfo[] {
-	const customProviders = Array.from(customOAuthProviders.values(), provider => ({
-		id: provider.id,
-		name: provider.name,
-		available: true,
-	}));
+	const builtInIds = new Set(builtInOAuthProviders.map(provider => provider.id));
+	// A custom provider colliding with a built-in id (e.g. an external
+	// integration mistakenly registering "kiro") must never produce a
+	// duplicate list entry: AuthStorage.login()'s switch statement always
+	// dispatches a matched built-in `case` before falling through to the
+	// custom-provider registry, so the built-in always wins the route and
+	// the advertised list must reflect that, not double-list the id.
+	const customProviders = Array.from(customOAuthProviders.values())
+		.filter(provider => !builtInIds.has(provider.id))
+		.map(provider => ({
+			id: provider.id,
+			name: provider.name,
+			available: true,
+		}));
 	return [...builtInOAuthProviders, ...customProviders];
 }

--- a/packages/ai/test/kiro-oauth-wiring.test.ts
+++ b/packages/ai/test/kiro-oauth-wiring.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test, vi } from "bun:test";
+import { afterEach, describe, expect, it, test, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -88,9 +88,15 @@ describe("Kiro OAuth provider advertisement is coherent with wiring", () => {
 	});
 
 	test("refreshOAuthToken keeps routing kiro through refreshKiroToken (unaffected by login fix)", async () => {
-		await expect(
-			refreshOAuthToken("kiro", { access: "a", refresh: "", expires: Date.now() - 1000 }),
-		).rejects.toThrow(); // no client registration cache / no network in test env — must fail via the kiro path, not "Unknown OAuth provider"
+		const refreshed = { access: "refreshed-access", refresh: "refreshed-refresh", expires: Date.now() + 3600_000 };
+		const refreshKiroTokenSpy = vi.spyOn(kiroOAuthModule, "refreshKiroToken").mockResolvedValue(refreshed);
+		try {
+			const result = await refreshOAuthToken("kiro", { access: "a", refresh: "r", expires: Date.now() - 1000 });
+			expect(refreshKiroTokenSpy).toHaveBeenCalledTimes(1);
+			expect(result).toEqual(refreshed);
+		} finally {
+			refreshKiroTokenSpy.mockRestore();
+		}
 	});
 });
 
@@ -125,6 +131,43 @@ describe("Kiro model catalog and default model", () => {
 		expect(descriptor).toBeDefined();
 		const staticCatalog = kiroApiStaticModels();
 		expect(staticCatalog.some(m => m.id === descriptor?.defaultModel)).toBe(true);
+	});
+});
+
+describe("OAuth CodeWhisperer transport normalizes the wire model id", () => {
+	const originalFetch = globalThis.fetch;
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	test("sends the canonical dotted Kiro model id, not the local dashed catalog alias", async () => {
+		const { streamKiroCodeWhisperer } = await import("../src/providers/kiro-codewhisperer");
+		// The dashed selector as published in models.json (kiroApiStaticModels()
+		// registers both the dotted upstream id and, when it differs, a dashed
+		// local alias like "claude-haiku-4-5").
+		const dashedModel = getBundledModel<"kiro-codewhisperer-stream">("kiro", "claude-haiku-4-5");
+		expect(dashedModel).toBeDefined();
+		if (!dashedModel) throw new Error("expected a dashed Kiro catalog alias for this regression test");
+
+		globalThis.fetch = (async () => new Response("", { status: 500 })) as unknown as typeof fetch;
+
+		let capturedPayload: unknown;
+		const context: Context = { messages: [{ role: "user", content: "hi", timestamp: Date.now() }] };
+		const stream = streamKiroCodeWhisperer(dashedModel, context, {
+			apiKey: "oauth-bearer-token",
+			onPayload: payload => {
+				capturedPayload = payload;
+			},
+		});
+		for await (const _event of stream) {
+			// drain to completion; only onPayload matters for this test
+		}
+
+		const payload = capturedPayload as {
+			conversationState: { currentMessage: { userInputMessage: { modelId?: string } } };
+		};
+		expect(payload.conversationState.currentMessage.userInputMessage.modelId).toBe("claude-haiku-4.5");
 	});
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #5067 (issue #5064). The Ultragoal completion cohort review (independent architect review + executor QA/red-team) found three real defects after #5067 merged, before the run could close:

1. **OAuth wire model id not normalized** — `packages/ai/src/providers/kiro-codewhisperer.ts` sent `model.wireModelId || model.id` verbatim as the CodeWhisperer wire `modelId`. Dashed catalog aliases (e.g. `claude-haiku-4-5`) were sent unnormalized to the upstream service, unlike the sibling `ksk_` API-key transport (`kiro-api-key.ts`), which already normalizes via `toKiroModelId()`. OAuth users picking a dashed alias from the model list would send a non-canonical id upstream.
2. **Non-hermetic refresh test** — `refreshOAuthToken("kiro")` test only asserted `.rejects.toThrow()`, which passes on unrelated sandbox network failure and doesn't prove the kiro route was actually taken.
3. **Pre-existing provider-list duplicate-id gap** — `getOAuthProviders()` concatenated built-in and custom provider lists without deduplication. A custom OAuth provider registered with an id colliding with a built-in id (found via adversarial testing of the `kiro` fix, but not specific to `kiro`) produced two list entries for the same id.

## Fix

- `kiro-codewhisperer.ts`: normalize via `toKiroModelId(model.wireModelId || model.id)`, matching the sibling transport.
- `kiro-oauth-wiring.test.ts`: made the refresh test hermetic (spy on `refreshKiroToken`, assert it was called and its result propagated); added a new regression test proving the OAuth transport sends the canonical dotted model id for a dashed catalog alias (captured via the existing `onPayload` hook, no network).
- `utils/oauth/index.ts`: `getOAuthProviders()` now filters custom providers whose id collides with a built-in id — built-in ids always win and are never duplicated, matching `AuthStorage.login()`'s actual dispatch order (built-in `case` always wins before falling through to the custom registry).

## Testing

```
bun test packages/ai/test/kiro-oauth-wiring.test.ts packages/ai/test/kiro-oauth.test.ts packages/ai/test/kiro-api-key.test.ts packages/coding-agent/test/kiro-oauth-provider-surface.test.ts
# 35 pass, 0 fail

bun test packages/ai/test/bizrouter-provider.test.ts packages/ai/test/fugu-provider.test.ts packages/ai/test/issue-1313-deepinfra.test.ts packages/ai/test/issue-830-repro.test.ts packages/ai/test/jetbrains-junie-provider.test.ts packages/ai/test/mara-provider.test.ts packages/ai/test/oauth-glm-zcode.test.ts packages/ai/test/oauth-xai.test.ts packages/ai/test/opengateway-provider.test.ts packages/ai/test/zenmux-provider.test.ts
# 85 pass, 0 fail (no getOAuthProviders() regression across every other provider)

bun test packages/ai/test/auth-storage-api-key-login.test.ts packages/ai/test/register-builtins.test.ts
# 25 pass, 0 fail

bun --cwd=packages/ai run check:types        # clean
bun --cwd=packages/coding-agent run check:types  # clean
```

Manual adversarial verification of the dedup fix:
```
bun -e '... registerOAuthProvider({id:"kiro", ...}); getOAuthProviders().filter(p=>p.id==="kiro").length'
# baseline: 1, after collision: 1, after cleanup: 1
```

No network secrets used anywhere — all tests mock `fetch`/spy, following the existing pattern.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:3c36fac21e90bfaef48c6e4c65300a50b897ecb831f4da32ec9f7c93db1e14fe reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/pull/5067
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes (targeted `check:types` for touched packages; ai/coding-agent packages clean)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing) — no additional CHANGELOG entry needed; this is a follow-up correction to the same #5067 CHANGELOG entry, not a new user-facing behavior change beyond what #5067 already documented.
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
