### PR TITLE
fix(gh): decode quoted diff paths as UTF-8 bytes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - Managed-session file identities now use one canonical unsigned 64-bit representation across stat/native boundaries and replacement cleanup receipts. Native Windows file IDs surfaced as signed negative bigints no longer create double-hyphen receipt names that block persistence or reopen; already-written signed receipt names and interrupted pending receipts are recovered only through the existing identity-bound, fail-closed reconciliation paths. (#5095)
 
+- `gh` PR diffs decode git's C-style quoted paths as UTF-8 bytes instead of Latin-1 code points, so non-ASCII file names (`docs/\355\225\234\352\270\200.md`) no longer surface as mojibake in the file list, and quoted `rename from`/`rename to` lines are unquoted the same way instead of keeping their literal quotes and escapes.
 - Confirmed operator `turn.abort` requests now travel through a dedicated local Broker route instead of trusting caller-supplied `operator:true` and `confirm:true` on ordinary SDK frames. The Broker revalidates the exact live endpoint identity, injects a process-bound private capability, preserves post-send uncertainty, and the host uses one capability-free canonical identity for dispatch idempotency, durable admission, and delivery receipts, so forged, stale, dropped, and replayed requests fail closed consistently across restart boundaries.
 
 - Blob references and filesystem-backed blob reads now accept only exact lowercase SHA-256 names before resolving a disk path; canonical references and valid missing-blob behavior are unchanged.

--- a/packages/coding-agent/src/internal-urls/issue-pr-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/issue-pr-protocol.ts
@@ -375,8 +375,10 @@ function buildSingleResource({
 
 function formatFileLine(idx: number, file: PrDiffFile, repo: string, prNumber: number): string {
 	const stats = file.changeType === "binary" ? "(binary)" : `+${file.additions} -${file.deletions}`;
-	const rename = file.oldPath ? `  (renamed from ${file.oldPath})` : "";
-	return `${idx}. ${file.path}  ${stats}  [${file.changeType}]${rename}\n   pr://${repo}/${prNumber}/diff/${idx}`;
+	const escapedNote = file.pathEscaped ? " (escaped non-UTF-8 name)" : "";
+	const renameNote = file.oldPathEscaped ? " (escaped non-UTF-8 name)" : "";
+	const rename = file.oldPath ? `  (renamed from ${file.oldPath}${renameNote})` : "";
+	return `${idx}. ${file.path}${escapedNote}  ${stats}  [${file.changeType}]${rename}\n   pr://${repo}/${prNumber}/diff/${idx}`;
 }
 
 async function fetchAndRenderPrDiff(

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -2870,12 +2870,12 @@ function skipDiffHeaderSpaces(text: string, index: number): number {
 }
 
 interface ParsedDiffQuotedEscape {
-	bytes: number[];
+	byte: number;
 	nextIndex: number;
 }
 
 const DIFF_PATH_ENCODER = new TextEncoder();
-const DIFF_PATH_DECODER = new TextDecoder();
+const DIFF_PATH_DECODER = new TextDecoder("utf-8", { fatal: true });
 
 const DIFF_NAMED_ESCAPE_BYTES: Record<string, number> = {
 	a: 0x07,
@@ -2885,47 +2885,60 @@ const DIFF_NAMED_ESCAPE_BYTES: Record<string, number> = {
 	r: 0x0d,
 	t: 0x09,
 	v: 0x0b,
+	"\\": 0x5c,
+	'"': 0x22,
 };
 
 /**
- * Git quotes paths C-style and escapes every byte outside printable ASCII as
- * octal, so a multi-byte UTF-8 character arrives as consecutive octal escapes.
- * Escapes therefore yield bytes, and the whole token is decoded once.
+ * Git quotes paths C-style: its named escapes plus exactly three octal digits
+ * per byte (leading digit 0-3), so a multi-byte UTF-8 character arrives as
+ * consecutive octal escapes. Anything else is malformed for this grammar.
  */
-function parseDiffQuotedEscape(text: string, slashIndex: number): ParsedDiffQuotedEscape {
-	const codePoint = text.codePointAt(slashIndex + 1);
-	if (codePoint === undefined) return { bytes: [0x5c], nextIndex: slashIndex + 1 };
-	const next = String.fromCodePoint(codePoint);
-
-	if (next >= "0" && next <= "7") {
-		let end = slashIndex + 1;
-		while (end < text.length && end < slashIndex + 4) {
-			const digit = text.charAt(end);
-			if (digit < "0" || digit > "7") break;
-			end += 1;
-		}
-		return { bytes: [Number.parseInt(text.slice(slashIndex + 1, end), 8) & 0xff], nextIndex: end };
+function parseDiffQuotedEscape(text: string, slashIndex: number): ParsedDiffQuotedEscape | undefined {
+	const first = text.charAt(slashIndex + 1);
+	if (first >= "0" && first <= "3") {
+		const second = text.charAt(slashIndex + 2);
+		const third = text.charAt(slashIndex + 3);
+		if (second < "0" || second > "7" || third < "0" || third > "7") return undefined;
+		return { byte: Number.parseInt(text.slice(slashIndex + 1, slashIndex + 4), 8), nextIndex: slashIndex + 4 };
 	}
-
-	const named = DIFF_NAMED_ESCAPE_BYTES[next];
-	if (named !== undefined) return { bytes: [named], nextIndex: slashIndex + 2 };
-	return { bytes: Array.from(DIFF_PATH_ENCODER.encode(next)), nextIndex: slashIndex + 1 + next.length };
+	const named = DIFF_NAMED_ESCAPE_BYTES[first];
+	if (named === undefined) return undefined;
+	return { byte: named, nextIndex: slashIndex + 2 };
 }
 
+/**
+ * Escaped bytes are decoded as strict UTF-8. A token holding invalid UTF-8 or
+ * a malformed escape keeps its escaped source form, so distinct non-UTF-8
+ * byte sequences never collapse into one replacement-character path.
+ */
 function parseDiffQuotedToken(text: string, startIndex: number): ParsedDiffHeaderToken | undefined {
 	if (text.charAt(startIndex) !== '"') return undefined;
 	const bytes: number[] = [];
+	let malformed = false;
 	for (let i = startIndex + 1; i < text.length; ) {
 		const codePoint = text.codePointAt(i) as number;
 		const ch = String.fromCodePoint(codePoint);
-		if (ch === '"') return { value: DIFF_PATH_DECODER.decode(Uint8Array.from(bytes)), nextIndex: i + 1 };
+		if (ch === '"') {
+			if (!malformed) {
+				try {
+					return { value: DIFF_PATH_DECODER.decode(Uint8Array.from(bytes)), nextIndex: i + 1 };
+				} catch {}
+			}
+			return { value: text.slice(startIndex + 1, i), nextIndex: i + 1 };
+		}
 		if (ch !== "\\") {
 			bytes.push(...DIFF_PATH_ENCODER.encode(ch));
 			i += ch.length;
 			continue;
 		}
 		const escaped = parseDiffQuotedEscape(text, i);
-		bytes.push(...escaped.bytes);
+		if (escaped === undefined) {
+			malformed = true;
+			i += 2;
+			continue;
+		}
+		bytes.push(escaped.byte);
 		i = escaped.nextIndex;
 	}
 	return undefined;

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -2806,6 +2806,14 @@ export interface PrDiffFile {
 	changeType: "modified" | "added" | "deleted" | "renamed" | "binary";
 	/** Pre-image path for renames/deletes; same as `path` otherwise. */
 	oldPath?: string;
+	/**
+	 * Set when `path` kept its C-style escaped source form because the quoted
+	 * token held invalid UTF-8 or a malformed escape; distinguishes it from a
+	 * valid path whose decoded text looks identical.
+	 */
+	pathEscaped?: boolean;
+	/** Same as {@link PrDiffFile.pathEscaped}, for `oldPath`. */
+	oldPathEscaped?: boolean;
 	/** Byte offset of the section's `diff --git` line in the unified diff. */
 	startOffset: number;
 	/** Byte offset of the next section (or end-of-text). */
@@ -2861,6 +2869,8 @@ export function parsePrUnifiedDiff(text: string): PrDiffPayload {
 interface ParsedDiffHeaderToken {
 	value: string;
 	nextIndex: number;
+	/** Set when the token kept its C-style escaped source form. */
+	escaped?: boolean;
 }
 
 function skipDiffHeaderSpaces(text: string, index: number): number {
@@ -2925,7 +2935,7 @@ function parseDiffQuotedToken(text: string, startIndex: number): ParsedDiffHeade
 					return { value: DIFF_PATH_DECODER.decode(Uint8Array.from(bytes)), nextIndex: i + 1 };
 				} catch {}
 			}
-			return { value: text.slice(startIndex + 1, i), nextIndex: i + 1 };
+			return { value: text.slice(startIndex + 1, i), nextIndex: i + 1, escaped: true };
 		}
 		if (ch !== "\\") {
 			bytes.push(...DIFF_PATH_ENCODER.encode(ch));
@@ -2944,9 +2954,10 @@ function parseDiffQuotedToken(text: string, startIndex: number): ParsedDiffHeade
 	return undefined;
 }
 
-function parseDiffPathLine(line: string, prefix: string): string {
+function parseDiffPathLine(line: string, prefix: string): { value: string; escaped?: boolean } {
 	const rest = line.slice(prefix.length);
-	return parseDiffQuotedToken(rest, 0)?.value ?? rest;
+	const token = parseDiffQuotedToken(rest, 0);
+	return token ? { value: token.value, escaped: token.escaped } : { value: rest };
 }
 
 function parseDiffHeaderToken(text: string, startIndex: number): ParsedDiffHeaderToken | undefined {
@@ -2963,7 +2974,14 @@ function stripPrDiffPathPrefix(value: string, prefix: "a/" | "b/"): string | und
 	return value.startsWith(prefix) ? value.slice(prefix.length) : undefined;
 }
 
-function parsePrDiffHeaderPaths(header: string): { oldPath?: string; newPath?: string } {
+interface PrDiffHeaderPaths {
+	oldPath?: string;
+	newPath?: string;
+	oldPathEscaped?: boolean;
+	newPathEscaped?: boolean;
+}
+
+function parsePrDiffHeaderPaths(header: string): PrDiffHeaderPaths {
 	const trail = header.slice("diff --git ".length);
 	if (trail.startsWith('"')) {
 		const oldToken = parseDiffQuotedToken(trail, 0);
@@ -2973,6 +2991,8 @@ function parsePrDiffHeaderPaths(header: string): { oldPath?: string; newPath?: s
 		return {
 			oldPath: stripPrDiffPathPrefix(oldToken.value, "a/"),
 			newPath: stripPrDiffPathPrefix(newToken.value, "b/"),
+			oldPathEscaped: oldToken.escaped,
+			newPathEscaped: newToken.escaped,
 		};
 	}
 
@@ -3003,6 +3023,8 @@ function parsePrDiffSection(section: string, startOffset: number, endOffset: num
 	const headerPaths = parsePrDiffHeaderPaths(header);
 	let oldPath = headerPaths.oldPath;
 	let newPath = headerPaths.newPath;
+	let oldPathEscaped = headerPaths.oldPathEscaped;
+	let newPathEscaped = headerPaths.newPathEscaped;
 
 	let changeType: PrDiffFile["changeType"] = "modified";
 	let isBinary = false;
@@ -3022,11 +3044,11 @@ function parsePrDiffSection(section: string, startOffset: number, endOffset: num
 		}
 		if (line.startsWith("rename from ")) {
 			changeType = "renamed";
-			oldPath = parseDiffPathLine(line, "rename from ");
+			({ value: oldPath, escaped: oldPathEscaped } = parseDiffPathLine(line, "rename from "));
 			continue;
 		}
 		if (line.startsWith("rename to ")) {
-			newPath = parseDiffPathLine(line, "rename to ");
+			({ value: newPath, escaped: newPathEscaped } = parseDiffPathLine(line, "rename to "));
 			continue;
 		}
 		if (line.startsWith("Binary files ") && line.endsWith(" differ")) {
@@ -3051,8 +3073,9 @@ function parsePrDiffSection(section: string, startOffset: number, endOffset: num
 		deletions = 0;
 	}
 
-	const displayPath =
-		changeType === "deleted" ? (oldPath ?? newPath ?? "(unknown)") : (newPath ?? oldPath ?? "(unknown)");
+	const preferOld = changeType === "deleted";
+	const displayPath = preferOld ? (oldPath ?? newPath ?? "(unknown)") : (newPath ?? oldPath ?? "(unknown)");
+	const displayEscaped = (preferOld ? oldPath !== undefined : newPath === undefined) ? oldPathEscaped : newPathEscaped;
 	const file: PrDiffFile = {
 		path: displayPath,
 		additions,
@@ -3061,8 +3084,12 @@ function parsePrDiffSection(section: string, startOffset: number, endOffset: num
 		startOffset,
 		endOffset,
 	};
+	if (displayEscaped) {
+		file.pathEscaped = true;
+	}
 	if (oldPath && oldPath !== displayPath) {
 		file.oldPath = oldPath;
+		if (oldPathEscaped) file.oldPathEscaped = true;
 	}
 	return file;
 }

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -2869,9 +2869,33 @@ function skipDiffHeaderSpaces(text: string, index: number): number {
 	return i;
 }
 
-function parseDiffQuotedEscape(text: string, slashIndex: number): ParsedDiffHeaderToken {
-	const next = text.charAt(slashIndex + 1);
-	if (next === "") return { value: "\\", nextIndex: slashIndex + 1 };
+interface ParsedDiffQuotedEscape {
+	bytes: number[];
+	nextIndex: number;
+}
+
+const DIFF_PATH_ENCODER = new TextEncoder();
+const DIFF_PATH_DECODER = new TextDecoder();
+
+const DIFF_NAMED_ESCAPE_BYTES: Record<string, number> = {
+	a: 0x07,
+	b: 0x08,
+	f: 0x0c,
+	n: 0x0a,
+	r: 0x0d,
+	t: 0x09,
+	v: 0x0b,
+};
+
+/**
+ * Git quotes paths C-style and escapes every byte outside printable ASCII as
+ * octal, so a multi-byte UTF-8 character arrives as consecutive octal escapes.
+ * Escapes therefore yield bytes, and the whole token is decoded once.
+ */
+function parseDiffQuotedEscape(text: string, slashIndex: number): ParsedDiffQuotedEscape {
+	const codePoint = text.codePointAt(slashIndex + 1);
+	if (codePoint === undefined) return { bytes: [0x5c], nextIndex: slashIndex + 1 };
+	const next = String.fromCodePoint(codePoint);
 
 	if (next >= "0" && next <= "7") {
 		let end = slashIndex + 1;
@@ -2880,50 +2904,36 @@ function parseDiffQuotedEscape(text: string, slashIndex: number): ParsedDiffHead
 			if (digit < "0" || digit > "7") break;
 			end += 1;
 		}
-		return {
-			value: String.fromCharCode(Number.parseInt(text.slice(slashIndex + 1, end), 8)),
-			nextIndex: end,
-		};
+		return { bytes: [Number.parseInt(text.slice(slashIndex + 1, end), 8) & 0xff], nextIndex: end };
 	}
 
-	switch (next) {
-		case "a":
-			return { value: "\x07", nextIndex: slashIndex + 2 };
-		case "b":
-			return { value: "\b", nextIndex: slashIndex + 2 };
-		case "f":
-			return { value: "\f", nextIndex: slashIndex + 2 };
-		case "n":
-			return { value: "\n", nextIndex: slashIndex + 2 };
-		case "r":
-			return { value: "\r", nextIndex: slashIndex + 2 };
-		case "t":
-			return { value: "\t", nextIndex: slashIndex + 2 };
-		case "v":
-			return { value: "\v", nextIndex: slashIndex + 2 };
-		case "\\":
-		case '"':
-			return { value: next, nextIndex: slashIndex + 2 };
-		default:
-			return { value: next, nextIndex: slashIndex + 2 };
-	}
+	const named = DIFF_NAMED_ESCAPE_BYTES[next];
+	if (named !== undefined) return { bytes: [named], nextIndex: slashIndex + 2 };
+	return { bytes: Array.from(DIFF_PATH_ENCODER.encode(next)), nextIndex: slashIndex + 1 + next.length };
 }
 
 function parseDiffQuotedToken(text: string, startIndex: number): ParsedDiffHeaderToken | undefined {
 	if (text.charAt(startIndex) !== '"') return undefined;
-	let value = "";
-	for (let i = startIndex + 1; i < text.length; i += 1) {
-		const ch = text.charAt(i);
-		if (ch === '"') return { value, nextIndex: i + 1 };
+	const bytes: number[] = [];
+	for (let i = startIndex + 1; i < text.length; ) {
+		const codePoint = text.codePointAt(i) as number;
+		const ch = String.fromCodePoint(codePoint);
+		if (ch === '"') return { value: DIFF_PATH_DECODER.decode(Uint8Array.from(bytes)), nextIndex: i + 1 };
 		if (ch !== "\\") {
-			value += ch;
+			bytes.push(...DIFF_PATH_ENCODER.encode(ch));
+			i += ch.length;
 			continue;
 		}
 		const escaped = parseDiffQuotedEscape(text, i);
-		value += escaped.value;
-		i = escaped.nextIndex - 1;
+		bytes.push(...escaped.bytes);
+		i = escaped.nextIndex;
 	}
 	return undefined;
+}
+
+function parseDiffPathLine(line: string, prefix: string): string {
+	const rest = line.slice(prefix.length);
+	return parseDiffQuotedToken(rest, 0)?.value ?? rest;
 }
 
 function parseDiffHeaderToken(text: string, startIndex: number): ParsedDiffHeaderToken | undefined {
@@ -2999,11 +3009,11 @@ function parsePrDiffSection(section: string, startOffset: number, endOffset: num
 		}
 		if (line.startsWith("rename from ")) {
 			changeType = "renamed";
-			oldPath = line.slice("rename from ".length);
+			oldPath = parseDiffPathLine(line, "rename from ");
 			continue;
 		}
 		if (line.startsWith("rename to ")) {
-			newPath = line.slice("rename to ".length);
+			newPath = parseDiffPathLine(line, "rename to ");
 			continue;
 		}
 		if (line.startsWith("Binary files ") && line.endsWith(" differ")) {

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -3075,7 +3075,13 @@ function parsePrDiffSection(section: string, startOffset: number, endOffset: num
 
 	const preferOld = changeType === "deleted";
 	const displayPath = preferOld ? (oldPath ?? newPath ?? "(unknown)") : (newPath ?? oldPath ?? "(unknown)");
-	const displayEscaped = (preferOld ? oldPath !== undefined : newPath === undefined) ? oldPathEscaped : newPathEscaped;
+	const displayEscaped = preferOld
+		? oldPath !== undefined
+			? oldPathEscaped
+			: newPathEscaped
+		: newPath !== undefined
+			? newPathEscaped
+			: oldPathEscaped;
 	const file: PrDiffFile = {
 		path: displayPath,
 		additions,
@@ -3087,7 +3093,7 @@ function parsePrDiffSection(section: string, startOffset: number, endOffset: num
 	if (displayEscaped) {
 		file.pathEscaped = true;
 	}
-	if (oldPath && oldPath !== displayPath) {
+	if (oldPath && (oldPath !== displayPath || oldPathEscaped !== displayEscaped)) {
 		file.oldPath = oldPath;
 		if (oldPathEscaped) file.oldPathEscaped = true;
 	}

--- a/packages/coding-agent/src/tools/github-cache.ts
+++ b/packages/coding-agent/src/tools/github-cache.ts
@@ -103,7 +103,7 @@ export function openDb(): Database | null {
 		// than running an in-place ALTER dance.
 		const userVersion = (db.prepare("PRAGMA user_version").get() as { user_version?: number } | undefined)
 			?.user_version;
-		if (userVersion !== undefined && userVersion < 3) {
+		if (userVersion !== undefined && userVersion < 4) {
 			db.run("DROP TABLE IF EXISTS github_view_cache");
 		}
 		db.run(`
@@ -120,7 +120,7 @@ export function openDb(): Database | null {
 				PRIMARY KEY (auth_key, repo, kind, number, include_comments)
 			);
 			CREATE INDEX IF NOT EXISTS idx_github_view_cache_fetched ON github_view_cache(fetched_at);
-			PRAGMA user_version = 3;
+			PRAGMA user_version = 4;
 		`);
 		protectDbFiles(dbPath);
 		cachedDb = db;

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -283,13 +283,52 @@ describe("parsePrUnifiedDiff", () => {
 		const diffFor = (quoted: string) =>
 			[`diff --git "a/${quoted}" "b/${quoted}"`, "index 0000000..1111111 100644", "@@ -1 +1 @@", "+new"].join("\n");
 
-		const first = parsePrUnifiedDiff(diffFor("x\\303y.md")).files[0]?.path;
-		const second = parsePrUnifiedDiff(diffFor("x\\304y.md")).files[0]?.path;
+		const first = parsePrUnifiedDiff(diffFor("x\\303y.md")).files[0];
+		const second = parsePrUnifiedDiff(diffFor("x\\304y.md")).files[0];
 
-		expect(first).toBe("x\\303y.md");
-		expect(second).toBe("x\\304y.md");
-		expect(first).not.toBe(second);
-		expect(first).not.toContain("\uFFFD");
+		expect(first).toMatchObject({ path: "x\\303y.md", pathEscaped: true });
+		expect(second).toMatchObject({ path: "x\\304y.md", pathEscaped: true });
+		expect(first?.path).not.toBe(second?.path);
+		expect(first?.path).not.toContain("\uFFFD");
+	});
+
+	it.each([
+		["an invalid byte", "x\\303y.md", "x\\\\303y.md"],
+		["a malformed escape", "x\\qy.md", "x\\\\qy.md"],
+	])("separates %s fallback from a valid literal-backslash path", (_label, invalidQuoted, validQuoted) => {
+		const diffFor = (quoted: string) =>
+			[`diff --git "a/${quoted}" "b/${quoted}"`, "index 0000000..1111111 100644", "@@ -1 +1 @@", "+new"].join("\n");
+
+		const invalid = parsePrUnifiedDiff(diffFor(invalidQuoted)).files[0];
+		const valid = parsePrUnifiedDiff(diffFor(validQuoted)).files[0];
+
+		expect(invalid?.path).toBe(valid?.path);
+		expect(invalid?.pathEscaped).toBe(true);
+		expect(valid?.pathEscaped).toBeUndefined();
+	});
+
+	it("separates invalid and valid literal-backslash rename metadata", () => {
+		const diffFor = (oldQuoted: string, newQuoted: string) =>
+			[
+				`diff --git "a/${oldQuoted}" "b/${newQuoted}"`,
+				"similarity index 100%",
+				`rename from "${oldQuoted}"`,
+				`rename to "${newQuoted}"`,
+			].join("\n");
+
+		const invalid = parsePrUnifiedDiff(diffFor("old \\303.md", "new \\304.md")).files[0];
+		const valid = parsePrUnifiedDiff(diffFor("old \\\\303.md", "new \\\\304.md")).files[0];
+
+		expect(invalid).toMatchObject({
+			changeType: "renamed",
+			oldPath: "old \\303.md",
+			oldPathEscaped: true,
+			path: "new \\304.md",
+			pathEscaped: true,
+		});
+		expect(valid).toMatchObject({ changeType: "renamed", oldPath: "old \\303.md", path: "new \\304.md" });
+		expect(valid?.pathEscaped).toBeUndefined();
+		expect(valid?.oldPathEscaped).toBeUndefined();
 	});
 
 	it.each([

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -228,6 +228,69 @@ describe("parsePrUnifiedDiff", () => {
 			changeType: "modified",
 		});
 	});
+
+	it("decodes octal-escaped UTF-8 bytes in quoted diff headers", () => {
+		const diff = [
+			'diff --git "a/docs/\\355\\225\\234\\352\\270\\200.md" "b/docs/\\355\\225\\234\\352\\270\\200.md"',
+			"index 0000000..1111111 100644",
+			'--- "a/docs/\\355\\225\\234\\352\\270\\200.md"',
+			'+++ "b/docs/\\355\\225\\234\\352\\270\\200.md"',
+			"@@ -1 +1 @@",
+			"-old",
+			"+new",
+		].join("\n");
+
+		const parsed = parsePrUnifiedDiff(diff);
+
+		expect(parsed.files[0]?.path).toBe("docs/\uD55C\uAE00.md");
+	});
+
+	it.each([
+		["two-byte sequence", "caf\\303\\251.md", "caf\u00E9.md"],
+		["four-byte sequence", "\\360\\237\\232\\200.md", "\u{1F680}.md"],
+		["octal bytes beside named escapes and spaces", "na\\tme \\303\\251.md", "na\tme \u00E9.md"],
+		["escaped quote and backslash", 'q\\"b\\\\.md', 'q"b\\.md'],
+		["truncated multi-byte sequence", "x\\303y.md", "x\uFFFDy.md"],
+	])("decodes a quoted header path with a %s", (_label, quoted, expected) => {
+		const diff = [
+			`diff --git "a/${quoted}" "b/${quoted}"`,
+			"index 0000000..1111111 100644",
+			"@@ -1 +1 @@",
+			"+new",
+		].join("\n");
+
+		expect(parsePrUnifiedDiff(diff).files[0]?.path).toBe(expected);
+	});
+
+	it("decodes quoted rename lines", () => {
+		const diff = [
+			'diff --git "a/old \\355\\225\\234.md" "b/new \\352\\270\\200.md"',
+			"similarity index 100%",
+			'rename from "old \\355\\225\\234.md"',
+			'rename to "new \\352\\270\\200.md"',
+		].join("\n");
+
+		const parsed = parsePrUnifiedDiff(diff);
+
+		expect(parsed.files[0]).toMatchObject({
+			changeType: "renamed",
+			oldPath: "old \uD55C.md",
+			path: "new \uAE00.md",
+		});
+	});
+
+	it("keeps unquoted rename lines verbatim", () => {
+		const diff = [
+			"diff --git a/old.md b/new.md",
+			"similarity index 100%",
+			"rename from old.md",
+			"rename to new.md",
+		].join("\n");
+
+		const parsed = parsePrUnifiedDiff(diff);
+
+		expect(parsed.files[0]).toMatchObject({ changeType: "renamed", oldPath: "old.md", path: "new.md" });
+	});
 });
 
 describe("github tool", () => {

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -250,7 +250,7 @@ describe("parsePrUnifiedDiff", () => {
 		["four-byte sequence", "\\360\\237\\232\\200.md", "\u{1F680}.md"],
 		["octal bytes beside named escapes and spaces", "na\\tme \\303\\251.md", "na\tme \u00E9.md"],
 		["escaped quote and backslash", 'q\\"b\\\\.md', 'q"b\\.md'],
-		["truncated multi-byte sequence", "x\\303y.md", "x\uFFFDy.md"],
+		["truncated multi-byte sequence kept in escaped form", "x\\303y.md", "x\\303y.md"],
 	])("decodes a quoted header path with a %s", (_label, quoted, expected) => {
 		const diff = [
 			`diff --git "a/${quoted}" "b/${quoted}"`,
@@ -276,6 +276,51 @@ describe("parsePrUnifiedDiff", () => {
 			changeType: "renamed",
 			oldPath: "old \uD55C.md",
 			path: "new \uAE00.md",
+		});
+	});
+
+	it("keeps distinct invalid-UTF-8 byte sequences distinct", () => {
+		const diffFor = (quoted: string) =>
+			[`diff --git "a/${quoted}" "b/${quoted}"`, "index 0000000..1111111 100644", "@@ -1 +1 @@", "+new"].join("\n");
+
+		const first = parsePrUnifiedDiff(diffFor("x\\303y.md")).files[0]?.path;
+		const second = parsePrUnifiedDiff(diffFor("x\\304y.md")).files[0]?.path;
+
+		expect(first).toBe("x\\303y.md");
+		expect(second).toBe("x\\304y.md");
+		expect(first).not.toBe(second);
+		expect(first).not.toContain("\uFFFD");
+	});
+
+	it.each([
+		["two-digit octal", "x\\77y.md"],
+		["octal above \\377", "x\\455y.md"],
+		["unknown escape", "x\\qy.md"],
+	])("keeps a %s escape in its source form", (_label, quoted) => {
+		const diff = [
+			`diff --git "a/${quoted}" "b/${quoted}"`,
+			"index 0000000..1111111 100644",
+			"@@ -1 +1 @@",
+			"+new",
+		].join("\n");
+
+		expect(parsePrUnifiedDiff(diff).files[0]?.path).toBe(quoted);
+	});
+
+	it("preserves invalid-UTF-8 rename metadata in escaped form", () => {
+		const diff = [
+			'diff --git "a/old \\303.md" "b/new \\304.md"',
+			"similarity index 100%",
+			'rename from "old \\303.md"',
+			'rename to "new \\304.md"',
+		].join("\n");
+
+		const parsed = parsePrUnifiedDiff(diff);
+
+		expect(parsed.files[0]).toMatchObject({
+			changeType: "renamed",
+			oldPath: "old \\303.md",
+			path: "new \\304.md",
 		});
 	});
 

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -375,6 +375,24 @@ describe("parsePrUnifiedDiff", () => {
 
 		expect(parsed.files[0]).toMatchObject({ changeType: "renamed", oldPath: "old.md", path: "new.md" });
 	});
+
+	it("retains old-path identity when opposite encoding tags share the same display text", () => {
+		const diff = [
+			'diff --git "a/old \\303.md" "b/new \\\\303.md"',
+			"similarity index 100%",
+			'rename from "old \\303.md"',
+			'rename to "new \\\\303.md"',
+		].join("\n");
+
+		const file = parsePrUnifiedDiff(diff).files[0];
+		expect(file).toMatchObject({
+			changeType: "renamed",
+			path: "new \\303.md",
+			oldPath: "old \\303.md",
+			oldPathEscaped: true,
+		});
+		expect(file?.pathEscaped).toBeUndefined();
+	});
 });
 
 describe("github tool", () => {


### PR DESCRIPTION
## What

`gh` PR diff parsing decodes git's C-style quoted paths as UTF-8 bytes instead of Latin-1 code points, and unquotes `rename from` / `rename to` lines with the same rule.

## Why

Git (`core.quotePath` default) escapes every non-ASCII byte of a path as octal, so `docs/한글.md` arrives as `"a/docs/\355\225\234\352\270\200.md"`. `parseDiffQuotedEscape` turned each escape into `String.fromCharCode(byte)`, which treats UTF-8 bytes as Latin-1 characters: `café.md` became `cafÃ©.md`, and every CJK or emoji path in a PR file list was mojibake. The token parser now accumulates bytes (octal escapes, named escapes, and literal characters) and decodes the token once with `TextDecoder`, so multi-byte sequences spanning several escapes reassemble correctly. Decoding is strict UTF-8: a token holding invalid UTF-8 or an escape outside git's quoting grammar (named escapes plus exactly three octal digits with a 0-3 lead) keeps its escaped source form and sets `pathEscaped`/`oldPathEscaped` on the `PrDiffFile`, so distinct non-UTF-8 byte sequences never collapse into one replacement-character path and an escaped fallback is structurally distinct from a valid path whose decoded text looks identical; rendered file listings annotate escaped names. `rename from` / `rename to` lines are quoted by git under the same rule but were sliced verbatim, keeping their literal quotes and escapes; they now go through the same decoder while unquoted lines stay untouched.

## Testing

- `packages/coding-agent/test/tools/gh.test.ts`: 8 new `parsePrUnifiedDiff` cases — Korean path, two-byte and four-byte sequences, octal bytes beside named escapes and spaces, escaped quote/backslash, truncated multi-byte and malformed escapes kept in escaped source form, distinct invalid-UTF-8 sequences staying distinct, invalid-UTF-8 rename metadata, quoted rename lines, unquoted rename lines, and paired invalid-versus-valid literal-backslash collisions across headers and rename metadata (18 parser cases). Non-ASCII expectations are pinned as `\uXXXX` escapes. `bun test test/tools/gh.test.ts -t parsePrUnifiedDiff`: 18 pass.
- `bun --cwd=packages/coding-agent run check:types`, biome on touched files: pass.
- Full `gh.test.ts` is 49/51 locally; the two failures are pre-existing `git remote add` cases that assert English git messages on a Korean-locale git and are unrelated to this change.

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:ca975bc1458ecd930a263ab416c35879b08f696c783974471f52775f77785c66 reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head-50eb891268-maintainer-review
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken


