### PR TITLE
test(coding-agent): drop unused findInitialModel import (fix #5075)

### DIFF
--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -17,7 +17,6 @@ import {
 import { streamOpenAICompletions } from "@gajae-code/ai/providers/openai-completions";
 import { kNoAuth, MODEL_ROLE_IDS, ModelRegistry } from "@gajae-code/coding-agent/config/model-registry";
 import {
-	findInitialModel,
 	type ModelLookupRegistry,
 	resolveModelFromString,
 	resolveModelOverride,


### PR DESCRIPTION
## Summary

Narrow repair for the deterministic post-#5050 Dev CI check failure (#5075).

- Dev CI run 33269722702, job 99146643154 (`Affected path validation / check:@gajae-code/coding-agent`) failed with exactly one biome error: `test/model-registry.test.ts:20:2 lint/correctness/noUnusedImports` on `findInitialModel`.
- The import rode in on PR #5050's Command Code regression test ("Command Code fresh descriptor routes Claude through Anthropic and others through OpenAI") but that test never uses it.
- This PR deletes that single import line. No test semantics, routing/auth coverage, or contributor attribution is changed.

## Independent verification of adjacent failures (run 33269722702)

| Job | Classification | Action here |
|---|---|---|
| `check:@gajae-code/coding-agent` (99146643154) | **The** source failure: unused `findInitialModel` import | Fixed by this PR |
| `test:...shard-1-of-8` | autorouting tier-map gate ×2 (`kiro/*` catalog keys unlabeled, introduced by #5067, ancestor of base) + MCP discovery gating timeout | Out of scope, separate lane |
| `test:...shard-2-of-8` | ACP deep-interview wire path (8.9s, flaky timing) | Out of scope, separate lane |
| `test:...shard-4-of-8` | watchdog retained publication (flaky timing) | Out of scope, separate lane |
| `test:...shard-7-of-8` | AgentSession resilient retry timeouts (238s/60s) + telemetry install-ID permission race | Out of scope, separate lane |
| `evidence producer` / `Affected path validation` aggregate | `required affected shards did not succeed` | Purely downstream; clears when shards go green |

## Verification run locally

- `bun test packages/coding-agent/test/model-registry.test.ts` — 306 pass / 0 fail (includes the Command Code routing test, untouched)
- `bun test packages/coding-agent/test/provider-onboarding.test.ts` — 28 pass / 0 fail (other #5050 coding-agent test surface)
- `bun test packages/ai/test/commandcode-login.test.ts packages/ai/test/commandcode-auth-storage-login.test.ts` — 12 pass / 0 fail
- `bun --cwd=packages/coding-agent run check` — exit 0 (0 errors; 17 warnings + 1 info are pre-existing at base and non-failing)
- `bun run --cwd=packages/coding-agent build` — binary builds; `gjc/0.15.5 --version` and `--help` render

## Non-goals

- The owner-only live provider credential smoke remains a non-blocking follow-up per #5075.
- The four flaky/environment-sensitive shard failures and the kiro tier-map gate failure (from #5067, not #5050) are separate repairs and are only classified here so the lane boundary is auditable.

Fixes #5075

gajae.pr-review-verdict.v1 merge-approved sha256:b1e154bd9bef9529c324e2b0b5038d2fec8a9d47ecd0da0c00a2298f66e7e9ad reviewer:human reviewer-id:probepark evidence:exact-head-18e3f8c1-unused-test-import-removal-is-semantic-noop
