### PR TITLE
fix(sdk): prefer a curated provider default when no model is configured

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- An install with no configured model no longer starts on a model its provider has already withdrawn. The startup fallback now applies the configured provider-priority policy, skips bundled defaults disproved by fresh provider discovery, and only then preserves catalog order for remaining candidates. Explicit model and profile selections, enabled-model allowlists, credential selectors, disabled providers, and provider/id collision-safe candidate membership remain unchanged.
+
 ## [0.15.6] - 2026-08-30
 
 - Auth metadata remains session-only when a compatibility registry has auth storage but no owner accessor, preventing an unscoped OAuth account lookup from attributing a registry-scoped API-key request to the wrong account.

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -4584,6 +4584,22 @@ export class ModelRegistry {
 	autoroutingProviderOrder(): readonly string[] {
 		return projectCatalogProviderOrder(getConfiguredProviderOrderFromSettings(), this.#models);
 	}
+
+	/**
+	 * Provider priority for automatic model selection. Explicit provider order
+	 * wins first, followed by omitted OAuth providers, then other providers;
+	 * catalog order breaks ties within each policy band.
+	 */
+	automaticProviderOrder(sessionId?: string): readonly string[] {
+		const policy = this.#buildProviderSelectionPolicy(sessionId);
+		return [...policy.orderedProviders()].sort((left, right) => {
+			const rankDifference = policy.rank(left) - policy.rank(right);
+			return rankDifference !== 0
+				? rankDifference
+				: policy.providerCatalogIndex(left) - policy.providerCatalogIndex(right);
+		});
+	}
+
 	#providerRankMap(policy: ProviderSelectionPolicy): Map<string, number> {
 		const providerRank = new Map<string, number>();
 		for (const provider of policy.orderedProviders()) {

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -17,6 +17,8 @@ import {
 	type AuthCredentialSelector,
 	type CredentialDisabledEvent,
 	codexToolWireName,
+	DEFAULT_MODEL_PER_PROVIDER,
+	type KnownProvider,
 	type Message,
 	type Model,
 	type ProviderSessionState,
@@ -1280,6 +1282,38 @@ function findDeferredExactMcpToolNameCollisions(
 		seen.add(toolName);
 	}
 	return [...collisions];
+}
+
+/**
+ * Order candidates so each known provider's curated default model is tried
+ * before the rest of the catalog.
+ *
+ * Provider catalogs are not ranked by fitness — a withdrawn model whose ID
+ * carries an older date suffix sorts ahead of its current replacement — so
+ * picking the first credentialed entry can start an unconfigured install on a
+ * model the provider no longer serves. `DEFAULT_MODEL_PER_PROVIDER` is the
+ * curated table `findInitialModel` already sweeps for the same purpose;
+ * reusing it keeps both unconfigured paths on one source of truth. Candidates
+ * that are not a provider default keep their original relative order.
+ */
+export function orderByProviderDefaultFirst(candidates: readonly Model[]): Model[] {
+	const preferred: Model[] = [];
+	const rest: Model[] = [];
+	const preferredKeys = new Set<string>();
+	for (const provider of Object.keys(DEFAULT_MODEL_PER_PROVIDER) as KnownProvider[]) {
+		const defaultId = DEFAULT_MODEL_PER_PROVIDER[provider];
+		for (const candidate of candidates) {
+			if (candidate.provider === provider && candidate.id === defaultId) {
+				preferred.push(candidate);
+				preferredKeys.add(`${candidate.provider}/${candidate.id}`);
+			}
+		}
+	}
+	if (preferred.length === 0) return [...candidates];
+	for (const candidate of candidates) {
+		if (!preferredKeys.has(`${candidate.provider}/${candidate.id}`)) rest.push(candidate);
+	}
+	return [...preferred, ...rest];
 }
 
 const AUTOMATION_TOOL_NAMES = new Set<AutomationToolName>(["browser", "computer"]);
@@ -3423,7 +3457,13 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			// Re-resolve the allowed set: extension factories above may have
 			// registered providers/models that weren't visible at startup.
 			const fallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
-			for (const candidate of fallbackCandidates) {
+			// Candidate order is not a quality signal: catalogs sort retired models
+			// ahead of current ones whenever their IDs carry older date suffixes, so
+			// an unconfigured install would otherwise start on a model its provider
+			// has already withdrawn. Sweep each known provider's curated default
+			// first — the same table `findInitialModel` consults — and only then fall
+			// back to catalog order.
+			for (const candidate of orderByProviderDefaultFirst(fallbackCandidates)) {
 				if (await hasModelApiKey(candidate)) {
 					model = candidate;
 					break;

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -1296,14 +1296,21 @@ function findDeferredExactMcpToolNameCollisions(
  * reusing it keeps both unconfigured paths on one source of truth. Candidates
  * that are not a provider default keep their original relative order.
  */
-export function orderByProviderDefaultFirst(candidates: readonly Model[]): Model[] {
+export function orderByProviderDefaultFirst(
+	candidates: readonly Model[],
+	providerOrder: readonly string[] = Object.keys(DEFAULT_MODEL_PER_PROVIDER),
+): Model[] {
 	const preferred: Model[] = [];
 	const rest: Model[] = [];
 	const preferredCandidates = new Set<Model>();
-	for (const provider of Object.keys(DEFAULT_MODEL_PER_PROVIDER) as KnownProvider[]) {
-		const defaultId = DEFAULT_MODEL_PER_PROVIDER[provider];
+	const seenProviders = new Set<string>();
+	for (const rawProvider of [...providerOrder, ...Object.keys(DEFAULT_MODEL_PER_PROVIDER)]) {
+		const provider = rawProvider.trim().toLowerCase();
+		if (!provider || seenProviders.has(provider) || !(provider in DEFAULT_MODEL_PER_PROVIDER)) continue;
+		seenProviders.add(provider);
+		const defaultId = DEFAULT_MODEL_PER_PROVIDER[provider as KnownProvider];
 		for (const candidate of candidates) {
-			if (candidate.provider === provider && candidate.id === defaultId) {
+			if (candidate.provider.trim().toLowerCase() === provider && candidate.id === defaultId) {
 				preferred.push(candidate);
 				preferredCandidates.add(candidate);
 			}
@@ -3456,14 +3463,30 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		if (!model && !options.modelPattern && !startupCredentialModelRejected) {
 			// Re-resolve the allowed set: extension factories above may have
 			// registered providers/models that weren't visible at startup.
-			const fallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
+			const allowedFallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
+			// A fresh provider discovery can disprove a bundled model while the
+			// general available catalog retains it for offline/profile compatibility.
+			// Exclude only those positively disproved bundled entries from the
+			// unconfigured startup path; explicit model/profile resolution above keeps
+			// its existing precedence and semantics.
+			const profileAvailableKeys = new Set(
+				modelRegistry
+					.getAvailableForProfileActivation()
+					.map(candidate => `${candidate.provider}\u0000${candidate.id}`),
+			);
+			const fallbackCandidates = allowedFallbackCandidates.filter(candidate =>
+				profileAvailableKeys.has(`${candidate.provider}\u0000${candidate.id}`),
+			);
 			// Candidate order is not a quality signal: catalogs sort retired models
 			// ahead of current ones whenever their IDs carry older date suffixes, so
 			// an unconfigured install would otherwise start on a model its provider
 			// has already withdrawn. Sweep each known provider's curated default
 			// first — the same table `findInitialModel` consults — and only then fall
 			// back to catalog order.
-			for (const candidate of orderByProviderDefaultFirst(fallbackCandidates)) {
+			for (const candidate of orderByProviderDefaultFirst(
+				fallbackCandidates,
+				modelRegistry.automaticProviderOrder(credentialSessionId),
+			)) {
 				if (await hasModelApiKey(candidate)) {
 					model = candidate;
 					break;

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -1299,19 +1299,19 @@ function findDeferredExactMcpToolNameCollisions(
 export function orderByProviderDefaultFirst(candidates: readonly Model[]): Model[] {
 	const preferred: Model[] = [];
 	const rest: Model[] = [];
-	const preferredKeys = new Set<string>();
+	const preferredCandidates = new Set<Model>();
 	for (const provider of Object.keys(DEFAULT_MODEL_PER_PROVIDER) as KnownProvider[]) {
 		const defaultId = DEFAULT_MODEL_PER_PROVIDER[provider];
 		for (const candidate of candidates) {
 			if (candidate.provider === provider && candidate.id === defaultId) {
 				preferred.push(candidate);
-				preferredKeys.add(`${candidate.provider}/${candidate.id}`);
+				preferredCandidates.add(candidate);
 			}
 		}
 	}
 	if (preferred.length === 0) return [...candidates];
 	for (const candidate of candidates) {
-		if (!preferredKeys.has(`${candidate.provider}/${candidate.id}`)) rest.push(candidate);
+		if (!preferredCandidates.has(candidate)) rest.push(candidate);
 	}
 	return [...preferred, ...rest];
 }

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1620,6 +1620,31 @@ describe("ModelRegistry", () => {
 			expect(policy.providerCatalogIndex("zeta")).toBe(Number.MAX_SAFE_INTEGER);
 		});
 
+		test("automatic provider order keeps explicit priority ahead of OAuth bands", async () => {
+			await authStorage.set("anthropic", [
+				{
+					type: "oauth",
+					access: "anthropic-policy-access",
+					refresh: "anthropic-policy-refresh",
+					expires: Date.now() + 60 * 60_000,
+					email: "anthropic-policy@example.test",
+				},
+			]);
+			authStorage.setRuntimeApiKey("amazon-bedrock", "bedrock-policy-key");
+			const registrySettings = Settings.isolated();
+			const registry = new ModelRegistry(authStorage, modelsJsonPath, registrySettings, { automaticRefresh: false });
+			try {
+				const explicitOrder = registry.automaticProviderOrder();
+				expect(explicitOrder.indexOf("anthropic")).toBeLessThan(explicitOrder.indexOf("amazon-bedrock"));
+
+				registrySettings.set("modelProviderOrder", ["amazon-bedrock"]);
+				const configuredOrder = registry.automaticProviderOrder();
+				expect(configuredOrder.indexOf("amazon-bedrock")).toBeLessThan(configuredOrder.indexOf("anthropic"));
+			} finally {
+				await registry.dispose();
+			}
+		});
+
 		test("builds stable catalog tie data from registry model order", () => {
 			const makeCatalogModel = (provider: string, id: string): Model<Api> =>
 				({

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, setDefaultTimeout, test, vi } 
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { closeModelCache, Effort, getBundledModel, type Model } from "@gajae-code/ai";
+import { closeModelCache, DEFAULT_MODEL_PER_PROVIDER, Effort, getBundledModel, type Model } from "@gajae-code/ai";
 import { ModelRegistry, ModelsConfigFile } from "@gajae-code/coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings } from "@gajae-code/coding-agent/config/settings";
 import { createAgentSession } from "@gajae-code/coding-agent/sdk";
@@ -1004,6 +1004,78 @@ describe("createAgentSession deferred model pattern resolution", () => {
 			expect(authStorage.hasRuntimePreferredCredentialSelector("runtime-provider")).toBe(false);
 		} finally {
 			await session.dispose();
+		}
+	});
+
+	test("honors explicit provider priority when selecting curated startup defaults", async () => {
+		const anthropicDefault = getBundledModel("anthropic", DEFAULT_MODEL_PER_PROVIDER.anthropic);
+		const bedrockDefault = getBundledModel("amazon-bedrock", DEFAULT_MODEL_PER_PROVIDER["amazon-bedrock"]);
+		if (!anthropicDefault || !bedrockDefault) throw new Error("Expected bundled Anthropic and Bedrock defaults");
+
+		authStorage.setRuntimeApiKey("anthropic", "anthropic-test-key");
+		authStorage.setRuntimeApiKey("amazon-bedrock", "bedrock-test-key");
+		const settings = Settings.isolated({ modelProviderOrder: ["amazon-bedrock", "anthropic"] });
+		const { session } = await createAgentSession({
+			...buildSessionOptions(),
+			settings,
+		});
+
+		try {
+			expect(session.model).toMatchObject({ provider: bedrockDefault.provider, id: bedrockDefault.id });
+			expect(session.model?.id).not.toBe(anthropicDefault.id);
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	test("skips a curated default disproved by fresh provider discovery", async () => {
+		const staleAuth = await AuthStorage.create(path.join(tempDir, `stale-default-${Snowflake.next()}.db`));
+		const staleRegistry = new ModelRegistry(
+			staleAuth,
+			path.join(tempDir, `stale-default-${Snowflake.next()}.yml`),
+			undefined,
+			{ automaticRefresh: false },
+		);
+		const currentModelId = "claude-opus-4-6";
+		try {
+			staleAuth.setRuntimeApiKey("anthropic", "anthropic-test-key");
+			using _hook = hookFetch(input => {
+				const url = String(input);
+				if (url === "https://models.dev/api.json") {
+					return new Response(JSON.stringify({ anthropic: { models: {} } }), {
+						headers: { "Content-Type": "application/json" },
+					});
+				}
+				if (!url.endsWith("/models")) throw new Error(`Unexpected model discovery request: ${input}`);
+				return new Response(JSON.stringify({ data: [{ id: currentModelId }] }), {
+					headers: { "Content-Type": "application/json" },
+				});
+			});
+			await staleRegistry.refreshProvider("anthropic", "online");
+
+			const curatedDefault = DEFAULT_MODEL_PER_PROVIDER.anthropic;
+			expect(staleRegistry.getAvailable().some(model => model.id === curatedDefault)).toBe(true);
+			expect(staleRegistry.getAvailableForProfileActivation().some(model => model.id === curatedDefault)).toBe(
+				false,
+			);
+
+			const settings = Settings.isolated({
+				enabledModels: [`anthropic/${curatedDefault}`, `anthropic/${currentModelId}`],
+			});
+			const { session } = await createAgentSession({
+				...buildSessionOptions(),
+				authStorage: staleAuth,
+				modelRegistry: staleRegistry,
+				settings,
+			});
+			try {
+				expect(session.model).toMatchObject({ provider: "anthropic", id: currentModelId });
+			} finally {
+				await session.dispose();
+			}
+		} finally {
+			staleRegistry.dispose();
+			staleAuth.close();
 		}
 	});
 

--- a/packages/coding-agent/test/unconfigured-startup-model-provider-default.test.ts
+++ b/packages/coding-agent/test/unconfigured-startup-model-provider-default.test.ts
@@ -59,6 +59,17 @@ describe("unconfigured startup model prefers a curated provider default", () => 
 		);
 	});
 
+	test("preserves a custom provider when its flattened key collides with a provider default", () => {
+		const candidates = [
+			model("openrouter/openai", "gpt-5.4"),
+			model("openrouter", DEFAULT_MODEL_PER_PROVIDER.openrouter),
+		];
+
+		const ordered = orderByProviderDefaultFirst(candidates);
+
+		expect(ordered).toEqual([candidates[1], candidates[0]]);
+	});
+
 	test("keeps catalog order when no candidate is a curated provider default", () => {
 		const candidates = [
 			model("anthropic", "claude-3-5-sonnet-20240620"),

--- a/packages/coding-agent/test/unconfigured-startup-model-provider-default.test.ts
+++ b/packages/coding-agent/test/unconfigured-startup-model-provider-default.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_MODEL_PER_PROVIDER, type Model } from "@gajae-code/ai/core";
+import { orderByProviderDefaultFirst } from "@gajae-code/coding-agent/sdk/session";
+
+function model(provider: string, id: string): Model {
+	return {
+		provider,
+		id,
+		name: `${provider}/${id}`,
+		api: "anthropic-messages",
+		baseUrl: `https://${provider}.example.com`,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 8192,
+	} as Model;
+}
+
+const anthropicDefault = DEFAULT_MODEL_PER_PROVIDER.anthropic;
+
+describe("unconfigured startup model prefers a curated provider default", () => {
+	test("hoists the provider default ahead of an earlier retired catalog entry", () => {
+		// A withdrawn model sorts first because its ID carries an older date
+		// suffix. Picking the first credentialed candidate would start the
+		// session on a model the provider no longer serves.
+		const candidates = [model("anthropic", "claude-3-5-sonnet-20240620"), model("anthropic", anthropicDefault)];
+
+		const ordered = orderByProviderDefaultFirst(candidates);
+
+		expect(ordered[0]?.provider).toBe("anthropic");
+		expect(ordered[0]?.id).toBe(anthropicDefault);
+	});
+
+	test("hoists across providers when the first entry belongs to another provider", () => {
+		const candidates = [
+			model("amazon-bedrock", "anthropic.claude-3-5-haiku-20241022-v1:0"),
+			model("anthropic", anthropicDefault),
+		];
+
+		const ordered = orderByProviderDefaultFirst(candidates);
+
+		expect(ordered[0]?.provider).toBe("anthropic");
+		expect(ordered[0]?.id).toBe(anthropicDefault);
+	});
+
+	test("preserves every candidate so credential scanning still sees the full set", () => {
+		const candidates = [
+			model("anthropic", "claude-3-5-sonnet-20240620"),
+			model("anthropic", anthropicDefault),
+			model("amazon-bedrock", "anthropic.claude-3-5-haiku-20241022-v1:0"),
+		];
+
+		const ordered = orderByProviderDefaultFirst(candidates);
+
+		expect(ordered).toHaveLength(candidates.length);
+		expect(new Set(ordered.map(m => `${m.provider}/${m.id}`))).toEqual(
+			new Set(candidates.map(m => `${m.provider}/${m.id}`)),
+		);
+	});
+
+	test("keeps catalog order when no candidate is a curated provider default", () => {
+		const candidates = [
+			model("anthropic", "claude-3-5-sonnet-20240620"),
+			model("anthropic", "claude-3-5-sonnet-20241022"),
+		];
+
+		const ordered = orderByProviderDefaultFirst(candidates);
+
+		expect(ordered.map(m => m.id)).toEqual(["claude-3-5-sonnet-20240620", "claude-3-5-sonnet-20241022"]);
+	});
+
+	test("returns an empty list unchanged", () => {
+		expect(orderByProviderDefaultFirst([])).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/unconfigured-startup-model-provider-default.test.ts
+++ b/packages/coding-agent/test/unconfigured-startup-model-provider-default.test.ts
@@ -44,6 +44,17 @@ describe("unconfigured startup model prefers a curated provider default", () => 
 		expect(ordered[0]?.id).toBe(anthropicDefault);
 	});
 
+	test("uses explicit provider priority before curated default table order", () => {
+		const candidates = [
+			model("anthropic", anthropicDefault),
+			model("amazon-bedrock", DEFAULT_MODEL_PER_PROVIDER["amazon-bedrock"]),
+		];
+
+		const ordered = orderByProviderDefaultFirst(candidates, ["amazon-bedrock", "anthropic"]);
+
+		expect(ordered).toEqual([candidates[1], candidates[0]]);
+	});
+
 	test("preserves every candidate so credential scanning still sees the full set", () => {
 		const candidates = [
 			model("anthropic", "claude-3-5-sonnet-20240620"),


### PR DESCRIPTION
## What

Make the unconfigured startup fallback in `createAgentSession` sweep each known provider's curated `DEFAULT_MODEL_PER_PROVIDER` entry before falling back to catalog order.

## Why

Fixes #5079.

The fallback took the first credentialed entry in catalog order:

```ts
for (const candidate of fallbackCandidates) {
    if (await hasModelApiKey(candidate)) {
        model = candidate;
        break;
    }
}
```

Catalog order is not a fitness ranking. A retired model whose ID carries an older date suffix sorts ahead of its current replacement, so an install with no `modelRoles`/`modelProfile.default` started every session on a withdrawn model and 404'd before the user could type anything — `anthropic/claude-3-5-sonnet-20240620` with Anthropic auth alone, or `amazon-bedrock/anthropic.claude-3-5-haiku-20241022-v1:0` when AWS credentials on disk also enabled Bedrock discovery.

`findInitialModel` already sweeps `DEFAULT_MODEL_PER_PROVIDER` for exactly this reason. This change puts the `createAgentSession` path on the same table rather than introducing a second notion of a sensible default. Every candidate is still credential-scanned, and catalog order is preserved when no candidate is a provider default.

## Testing

`packages/coding-agent/test/unconfigured-startup-model-provider-default.test.ts` — 5 new cases covering hoisting within a provider, hoisting across providers, candidate-set preservation, order preservation when no curated default is present, and the empty input. Verified the tests fail without the fix (2 fail when `orderByProviderDefaultFirst` is reverted to returning input order) so they bind the behavior rather than restating it.

```
bun test packages/coding-agent/test/unconfigured-startup-model-provider-default.test.ts   # 5 pass
bun test packages/coding-agent/test/*model*.test.ts                                       # 1093 pass, 4 skip, 0 fail (60 files)
bun test .../sdk-model-selection .../sdk-default-model-selection-e2e \
         .../sdk-model-profile-model .../issue-980-bedrock-priority                       # 47 pass, 0 fail
bun --cwd=packages/coding-agent run check:types                                           # pass
bunx biome check <changed files>                                                          # pass
bun scripts/verify-gjc-state-writers.ts --fail                                            # 0 sites outside sanctioned writer
bun scripts/changelog-history-guard.ts                                                    # no released sections removed
```

End-to-end against a binary built from this branch, using a config with no model settings:

```
printf 'configSchemaVersion: 1\n' > /tmp/fresh/agent/config.yml

# before (installed 0.15.3)
GJC_CODING_AGENT_DIR=/tmp/fresh/agent gjc -p "say OK" --no-session
  -> Bedrock HTTP 404: This model version has reached the end of its life

# after (this branch)
GJC_CODING_AGENT_DIR=/tmp/fresh/agent ./dist/gjc -p "say OK" --no-session
  -> OK
```

Confirmed with AWS credentials both present and hidden (`AWS_SHARED_CREDENTIALS_FILE` pointed at an empty file); both return `OK` after the fix and both 404 before it.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records this) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:188201493fcef72d5e9f1afbd420d8215155c48714384733723f877d05ad6971 reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head-4e6d37b3835a-current-dev-7d23ed3d9e8c-salvage-tests
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken


---

Maintainer salvage update:

The successor is rebased onto current `dev` at `7d23ed3d9e8cb6e5062ba2840462d59fe18eb784` with contributor-authored commits preserved and maintainer salvage commit `4e6d37b3835add863618a6c1c71859ab063695e4` at the exact head.

Focused verification passed: `bun test packages/coding-agent/test/unconfigured-startup-model-provider-default.test.ts`, `bun test packages/coding-agent/test/sdk-model-selection.test.ts`, `bun test packages/coding-agent/test/sdk-default-model-selection-e2e.test.ts`, `bun test packages/coding-agent/test/model-registry.test.ts`, `bun test packages/coding-agent/test/model-profile-activation.test.ts`, coding-agent package check, and required definition/rebrand gates. Root `bun run check` is not checked because the current-dev baseline scanner still reports pre-existing tmux canonicalization violations in `packages/coding-agent/src/tools/tmux-self-injection-guard.ts`; the PR change does not touch that file.