### PR TITLE
fix(test): make case-distinct lock key coverage platform-honest

### DIFF
--- a/packages/coding-agent/test/file-lock-gc-toctou.test.ts
+++ b/packages/coding-agent/test/file-lock-gc-toctou.test.ts
@@ -893,8 +893,29 @@ describe("file lock cleanup failure handling (#2478)", () => {
 		expect(await fs.exists(`${realFile}.lock`)).toBe(false);
 	});
 
-	test("keeps case-distinct lock keys independent", async () => {
+	/**
+	 * Case-distinct keys carry the semantics 581960b079 documents: distinct
+	 * authorities on case-SENSITIVE directories, converged aliases elsewhere.
+	 * The two halves need different assertions — on a case-insensitive volume
+	 * (default macOS APFS, Windows NTFS) both spellings publish one on-disk
+	 * `.lock` directory, so a NESTED acquire of the alias would wait on its own
+	 * live owner. The suite previously asserted only the case-sensitive half,
+	 * unconditionally, and CI's ubuntu-only test shards never executed it on a
+	 * case-insensitive filesystem (#5082).
+	 */
+	async function directoryIsCaseInsensitive(base: string): Promise<boolean> {
+		const probe = path.join(base, "CaseProbe.tmp");
+		await fs.writeFile(probe, "", "utf8");
+		try {
+			return await fs.exists(path.join(base, "caseprobe.tmp"));
+		} finally {
+			await fs.rm(probe, { force: true });
+		}
+	}
+
+	test("keeps case-distinct lock keys independent on case-sensitive volumes", async () => {
 		const base = await makeTemp();
+		if (await directoryIsCaseInsensitive(base)) return;
 		const upper = path.join(base, "State.json");
 		const lower = path.join(base, "state.json");
 		let upperEntered = false;
@@ -907,6 +928,40 @@ describe("file lock cleanup failure handling (#2478)", () => {
 		});
 		expect(upperEntered).toBe(true);
 		expect(lowerEntered).toBe(true);
+		expect(await fs.exists(`${upper}.lock`)).toBe(false);
+		expect(await fs.exists(`${lower}.lock`)).toBe(false);
+	});
+
+	test("converges case-aliased lock keys on case-insensitive volumes", async () => {
+		const base = await makeTemp();
+		if (!(await directoryIsCaseInsensitive(base))) return;
+		const upper = path.join(base, "State.json");
+		const lower = path.join(base, "state.json");
+
+		// Sequential acquires of both spellings share one converged authority.
+		let upperEntered = false;
+		let lowerEntered = false;
+		await withFileLock(upper, async () => {
+			upperEntered = true;
+		});
+		await withFileLock(lower, async () => {
+			lowerEntered = true;
+		});
+		expect(upperEntered).toBe(true);
+		expect(lowerEntered).toBe(true);
+
+		// Concurrent, independent acquires serialize on the converged key
+		// instead of corrupting ownership; both critical sections complete.
+		let inside = 0;
+		let maxInside = 0;
+		const enter = async (): Promise<void> => {
+			inside += 1;
+			maxInside = Math.max(maxInside, inside);
+			await Bun.sleep(25);
+			inside -= 1;
+		};
+		await Promise.all([withFileLock(upper, enter), withFileLock(lower, enter)]);
+		expect(maxInside).toBe(1);
 		expect(await fs.exists(`${upper}.lock`)).toBe(false);
 		expect(await fs.exists(`${lower}.lock`)).toBe(false);
 	});


### PR DESCRIPTION
Fixes #5082.

The `keeps case-distinct lock keys independent` test deadlocked deterministically (4/4, exact 5s timeout) on case-insensitive volumes — default macOS APFS and Windows NTFS — because both spellings publish one on-disk `.lock` directory and the nested alias acquire waits on its own live owner. CI's ubuntu-only test shards never ran it on such a volume.

This splits the coverage per the semantics `581960b079` documents:
- **case-sensitive volumes**: original nested-independence assertions, unchanged;
- **case-insensitive volumes**: converged-alias contract — sequential acquires of both spellings succeed, and concurrent non-nested acquires serialize with proven mutual exclusion (`maxInside === 1`) and clean release.

Verified: 48/48 on macOS APFS (previously 47 pass / 1 deterministic timeout). The case-sensitive branch continues to run on ubuntu shards.

Deliberately out of scope: the in-process converged-key **nested** acquire still self-waits on case-insensitive volumes (product behavior, pre-existing; tracked in #5082's follow-up direction), and adding a macOS/windows test-shard lane.