### PR TITLE
fix(session): cancel pending retries during disposal

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8469,7 +8469,6 @@ export class AgentSession {
 		await this.#agentEndPublicationPromise;
 		await this.#queuedExtensionEvents;
 		await this.#agentEndHandlingPromise;
-		await this.#waitForSessionSettlement();
 		// Drain the sidecar write order for the same reason the two queues above are
 		// drained: each entry writes under the native identity-bound state-file lock, so a
 		// still-queued write would run after the session that owns it is gone — releasing

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8388,16 +8388,22 @@ export class AgentSession {
 		if (this.#disposePromise) return this.#disposePromise;
 		this.#abortAdmissionEpoch++;
 		this.#isDisposed = true;
+		this.abortRetry();
+		this.#quarantineAgentRunResources();
 		const { promise, resolve, reject } = Promise.withResolvers<void>();
 		this.#disposePromise = promise;
 		void this.#dispose().then(resolve, reject);
 		return promise;
 	}
 
+	/** Cancel the active logical run domain, including managed continuations detached from Agent's active attempt. */
+	#quarantineAgentRunResources(): void {
+		const resourceRunId = this.agent.currentManagedLogicalRunId ?? this.agent.activeResourceRunId;
+		if (resourceRunId !== undefined) this.agent.resourceLedger.quarantine(String(resourceRunId));
+	}
+
 	async #dispose(): Promise<void> {
 		await this.sessionManager.joinCwdTransition();
-		const managedLogicalRunId = this.agent.currentManagedLogicalRunId;
-		const activeResourceRunId = this.agent.activeResourceRunId;
 		const admissionClosed = this.#closeSessionAdmission();
 		// Reject new direct Python starts as soon as disposal begins (synchronously,
 		// before any await) so callers cannot race a start against teardown.
@@ -8409,11 +8415,7 @@ export class AgentSession {
 		// #waitForPostPromptRecovery can keep its admission lease forever while
 		// teardown waits for that same lease to settle.
 		this.abortRetry();
-		// A managed attempt clears Agent's active run before invoking its continuation.
-		// Quarantine that logical resource domain as well, so a continuation that is
-		// already between attempts observes disposal through its ownership signal.
-		const teardownResourceRunId = managedLogicalRunId ?? activeResourceRunId;
-		if (teardownResourceRunId !== undefined) this.agent.resourceLedger.quarantine(String(teardownResourceRunId));
+		this.#quarantineAgentRunResources();
 		this.agent.abort();
 		this.agent.setMainAttemptScopeObserver(undefined);
 		// Disconnect the Agent event bridge NOW — before the maintenance join and the
@@ -20619,8 +20621,9 @@ export class AgentSession {
 
 			if (managedOutcome) {
 				try {
+					if (retryCancelled() || ownershipCancelled()) return;
 					await this.#checkEstimatedContextBeforePrompt();
-					if (ownershipCancelled()) {
+					if (retryCancelled() || ownershipCancelled()) {
 						const attempt = this.#retryAttempt;
 						this.#retryAttempt = 0;
 						await this.#emitSessionEvent({

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -12284,7 +12284,7 @@ export class AgentSession {
 				try {
 					await this.#promptQueuedHiddenNextTurnMessages(signal);
 				} catch {
-					if (signal.aborted || this.#isDisposed || this.#sessionAdmissionClosing) {
+					if (this.#isDisposed || this.#sessionAdmissionClosing || this.#disposeAbortController.signal.aborted) {
 						this.#pendingNextTurnMessages = [];
 						return;
 					}
@@ -12332,8 +12332,12 @@ export class AgentSession {
 		if (reclassified.length === 0) {
 			return;
 		}
-		if (signal?.aborted || this.#isDisposed || this.#sessionAdmissionClosing) {
+		if (this.#isDisposed || this.#sessionAdmissionClosing || this.#disposeAbortController.signal.aborted) {
 			this.#settleDeliveredOwnedRegistrations(reclassified.map(entry => entry.message));
+			return;
+		}
+		if (signal?.aborted) {
+			this.#pendingNextTurnMessages = [...reclassified, ...this.#pendingNextTurnMessages];
 			return;
 		}
 		// Allocate a fresh root-turn lineage when the drained batch contains a
@@ -12357,8 +12361,12 @@ export class AgentSession {
 		const textContent = this.#getCustomMessageTextContent(message);
 		await this.#syncSkillPromptActiveStateSafely(message, true);
 		try {
-			if (signal?.aborted || this.#isDisposed || this.#sessionAdmissionClosing) {
+			if (this.#isDisposed || this.#sessionAdmissionClosing || this.#disposeAbortController.signal.aborted) {
 				this.#settleDeliveredOwnedRegistrations(reclassified.map(entry => entry.message));
+				return;
+			}
+			if (signal?.aborted) {
+				this.#pendingNextTurnMessages = [...reclassified, ...this.#pendingNextTurnMessages];
 				return;
 			}
 			await this.#promptWithMessage(message, textContent, {
@@ -12367,7 +12375,7 @@ export class AgentSession {
 				preflightSignal: signal,
 			});
 		} catch (error) {
-			if (signal?.aborted || this.#isDisposed || this.#sessionAdmissionClosing) {
+			if (this.#isDisposed || this.#sessionAdmissionClosing || this.#disposeAbortController.signal.aborted) {
 				this.#settleDeliveredOwnedRegistrations(reclassified.map(entry => entry.message));
 				return;
 			}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8386,6 +8386,8 @@ export class AgentSession {
 	dispose(): Promise<void> {
 		this.#evalExecutionDisposing = true;
 		if (this.#disposePromise) return this.#disposePromise;
+		this.#abortAdmissionEpoch++;
+		this.#isDisposed = true;
 		const { promise, resolve, reject } = Promise.withResolvers<void>();
 		this.#disposePromise = promise;
 		void this.#dispose().then(resolve, reject);
@@ -8394,8 +8396,9 @@ export class AgentSession {
 
 	async #dispose(): Promise<void> {
 		await this.sessionManager.joinCwdTransition();
+		const managedLogicalRunId = this.agent.currentManagedLogicalRunId;
+		const activeResourceRunId = this.agent.activeResourceRunId;
 		const admissionClosed = this.#closeSessionAdmission();
-		this.#isDisposed = true;
 		// Reject new direct Python starts as soon as disposal begins (synchronously,
 		// before any await) so callers cannot race a start against teardown.
 		this.#evalExecutionDisposing = true;
@@ -8406,6 +8409,11 @@ export class AgentSession {
 		// #waitForPostPromptRecovery can keep its admission lease forever while
 		// teardown waits for that same lease to settle.
 		this.abortRetry();
+		// A managed attempt clears Agent's active run before invoking its continuation.
+		// Quarantine that logical resource domain as well, so a continuation that is
+		// already between attempts observes disposal through its ownership signal.
+		const teardownResourceRunId = managedLogicalRunId ?? activeResourceRunId;
+		if (teardownResourceRunId !== undefined) this.agent.resourceLedger.quarantine(String(teardownResourceRunId));
 		this.agent.abort();
 		this.agent.setMainAttemptScopeObserver(undefined);
 		// Disconnect the Agent event bridge NOW — before the maintenance join and the
@@ -19498,11 +19506,15 @@ export class AgentSession {
 	}
 
 	async #handleManagedAttemptOutcome(outcome: ManagedAttemptOutcome): Promise<ManagedAttemptDecision> {
+		const attemptAbortEpoch = this.#abortAdmissionEpoch;
+		const attemptCancelled = () =>
+			this.#isDisposed || this.#sessionAdmissionClosing || this.#abortAdmissionEpoch !== attemptAbortEpoch;
 		const activePromptHandle = this.activePromptHandle;
 		const cancellationSignal = activePromptHandle
 			? this.#runCancellationDomains.lookup(activePromptHandle)?.signal
 			: undefined;
-		if (cancellationSignal?.aborted) return { type: "terminal", terminal: { stopReason: "cancelled" } };
+		if (attemptCancelled() || cancellationSignal?.aborted)
+			return { type: "terminal", terminal: { stopReason: "cancelled" } };
 		if (outcome.type === "run_terminal") {
 			this.#defaultFallbackChain().resetAttemptBudget();
 			return { type: "terminal", terminal: { stopReason: outcome.reason } };
@@ -19538,7 +19550,6 @@ export class AgentSession {
 				const controllerStateBeforeFailure = controller.snapshotRuntimeState();
 				const advanced = controller.recordEscapedArgumentsFailure(errorMessage, false);
 				this.#escapedNonAsciiManagedRetries = 0;
-				const abortEpoch = this.#abortAdmissionEpoch;
 				if (advanced) {
 					const transitionGeneration = ++this.#fallbackTransitionGeneration;
 					return {
@@ -19559,7 +19570,9 @@ export class AgentSession {
 								!ownership.isCurrent() ||
 								ownership.lease.signal.aborted ||
 								cancellationSignal?.aborted ||
-								this.#abortAdmissionEpoch !== abortEpoch ||
+								this.#isDisposed ||
+								this.#sessionAdmissionClosing ||
+								this.#abortAdmissionEpoch !== attemptAbortEpoch ||
 								this.#fallbackTransitionGeneration !== transitionGeneration;
 							if (continuationCancelled) {
 								await restoreOwnedTransition();
@@ -19584,7 +19597,7 @@ export class AgentSession {
 								"escaped_non_ascii",
 								1,
 								cancellationSignal,
-								abortEpoch,
+								attemptAbortEpoch,
 								controllerStateBeforeFailure,
 								previousModel,
 								previousThinkingLevel,
@@ -19593,7 +19606,9 @@ export class AgentSession {
 							);
 							if (!switched) {
 								if (
-									this.#abortAdmissionEpoch !== abortEpoch ||
+									this.#isDisposed ||
+									this.#sessionAdmissionClosing ||
+									this.#abortAdmissionEpoch !== attemptAbortEpoch ||
 									cancellationSignal?.aborted ||
 									this.#fallbackTransitionGeneration !== transitionGeneration
 								) {
@@ -19622,7 +19637,9 @@ export class AgentSession {
 							});
 							if (
 								cancellationSignal?.aborted ||
-								this.#abortAdmissionEpoch !== abortEpoch ||
+								this.#isDisposed ||
+								this.#sessionAdmissionClosing ||
+								this.#abortAdmissionEpoch !== attemptAbortEpoch ||
 								this.#fallbackTransitionGeneration !== transitionGeneration
 							) {
 								await restoreOwnedTransition();
@@ -19641,7 +19658,7 @@ export class AgentSession {
 					};
 				}
 				controller.advance();
-				if (this.#abortAdmissionEpoch !== abortEpoch || cancellationSignal?.aborted)
+				if (attemptCancelled() || cancellationSignal?.aborted)
 					return { type: "terminal", terminal: { stopReason: "cancelled" } };
 				this.#defaultFallbackExhaustedLastTurn = true;
 				return this.#managedFallbackExhaustionDecision(
@@ -19653,7 +19670,7 @@ export class AgentSession {
 			return {
 				type: "retry",
 				continuation: async ownership => {
-					if (!ownership.isCurrent() || ownership.lease.signal.aborted) return;
+					if (attemptCancelled() || !ownership.isCurrent() || ownership.lease.signal.aborted) return;
 					await this.agent.continue({
 						...this.#managedFallbackPromptOptions(),
 						transientRecoveryMessage: this.#escapedNonAsciiRecoveryMessage(),
@@ -19672,7 +19689,7 @@ export class AgentSession {
 			return {
 				type: "maintenance",
 				continuation: async ownership => {
-					if (!ownership.isCurrent() || ownership.lease.signal.aborted) return;
+					if (attemptCancelled() || !ownership.isCurrent() || ownership.lease.signal.aborted) return;
 					const resourceRunId = String(ownership.logicalRunId);
 					const previousLease = this.#postPromptLeases.get(resourceRunId);
 					this.#postPromptLeases.set(resourceRunId, ownership.lease);
@@ -19691,7 +19708,13 @@ export class AgentSession {
 							resourceRunId,
 							ownership.lease.signal,
 						);
-						if (terminalized || successorScheduled || !ownership.isCurrent() || ownership.lease.signal.aborted)
+						if (
+							terminalized ||
+							successorScheduled ||
+							attemptCancelled() ||
+							!ownership.isCurrent() ||
+							ownership.lease.signal.aborted
+						)
 							return;
 						this.agent.requestRunTerminal(ownership.handle.logicalRunId, {
 							stopReason: "error",
@@ -20134,6 +20157,9 @@ export class AgentSession {
 		scope?: AttemptScope,
 		scopeWasClean = this.#isRetryScopeClean(scope),
 	): Promise<boolean | ManagedAttemptDecision> {
+		const retryAbortEpoch = this.#abortAdmissionEpoch;
+		const retryCancelled = () =>
+			this.#isDisposed || this.#sessionAdmissionClosing || this.#abortAdmissionEpoch !== retryAbortEpoch;
 		const controller = this.#defaultFallbackChain();
 		const managedFallback = controller.chain.entries.length > 1;
 		const retrySettings = this.settings.getGroup("retry");
@@ -20145,6 +20171,9 @@ export class AgentSession {
 		const classification = this.#classifyErrorForRetry(message);
 		const localSnapshot = classification === "local_snapshot";
 		const localBufferOverflow = classification === "local_buffer_overflow";
+		if (retryCancelled()) {
+			return managedOutcome ? { type: "terminal", terminal: { stopReason: "cancelled" } } : false;
+		}
 		// A local machinery failure must never stay charged against the provider
 		// fallback budget, no matter which local exit follows (disabled retry,
 		// visible-content surface, bounded retry, exhaustion, or the immediate
@@ -20407,7 +20436,7 @@ export class AgentSession {
 				ownership?.domain.signal ??
 				(activePromptHandle ? this.#runCancellationDomains.lookup(activePromptHandle)?.signal : undefined);
 			if (ownership && (!ownership.isCurrent() || cancellationSignal?.aborted)) return;
-			const abortEpoch = this.#abortAdmissionEpoch;
+			if (retryCancelled()) return;
 			let quotaPoolExhausted = false;
 			if (managedFallback && !credentialRotated && !providerRetryCeilingReached) {
 				const mark = await this.#markFailedCredential(trigger);
@@ -20441,7 +20470,7 @@ export class AgentSession {
 						trigger.class,
 						attemptsUsed,
 						cancellationSignal,
-						abortEpoch,
+						retryAbortEpoch,
 						controllerStateBeforeAdvance,
 						previousModel,
 						previousThinkingLevel,
@@ -20451,7 +20480,7 @@ export class AgentSession {
 				}
 			}
 			if (ownership && (!ownership.isCurrent() || cancellationSignal?.aborted)) {
-				if (this.#abortAdmissionEpoch === abortEpoch) {
+				if (!retryCancelled()) {
 					await this.#restoreDefaultFallbackTransition(
 						controller,
 						controllerStateBeforeAdvance,
@@ -20461,7 +20490,7 @@ export class AgentSession {
 				}
 				return;
 			}
-			if (this.#abortAdmissionEpoch !== abortEpoch) {
+			if (retryCancelled()) {
 				controller.resetForNewTurn();
 				return;
 			}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8477,14 +8477,7 @@ export class AgentSession {
 		// is already failure-absorbing, so this only waits.
 		await this.#coordinatorPersistQueue;
 		this.#pendingBackgroundExchanges = [];
-		this.yieldQueue.clear((kind, entries) => {
-			if (kind !== "async-result") return;
-			for (const entry of entries) {
-				if (typeof entry !== "object" || entry === null) continue;
-				const envelope = (entry as { ownedCompletion?: unknown }).ownedCompletion;
-				if (isOwnedCompletionEnvelope(envelope)) this.#settleOwnedCompletionEnvelope(envelope);
-			}
-		});
+		this.#drainTerminalOwnedYieldEntries();
 
 		this.agent.setOnBeforeYield(undefined);
 		try {
@@ -8504,6 +8497,15 @@ export class AgentSession {
 		// the session that owns the manager goes on to dispose it (which itself
 		// nukes any leftover jobs and pending deliveries).
 		this.#cancelOwnAsyncJobs();
+		// Final drain (Codex review P2 on #5088): an async-job completion that
+		// enqueued during the awaited session_shutdown window above survived the
+		// first drain with a retained delivery claim, and the already-aborted
+		// disposal signal makes its idle-flush task exit before YieldQueue.flush
+		// can run. Producers are now cancelled, so drain once more to settle any
+		// straggler envelope and release its claim before owned-manager teardown
+		// — a shared manager would otherwise keep the claim past this session's
+		// disposal.
+		this.#drainTerminalOwnedYieldEntries();
 		await Promise.allSettled(this.#deferredOwnerShutdownFinalizations);
 		const ownedAsyncManager = this.#ownedAsyncJobManager;
 		if (ownedAsyncManager && this.#disposeAsyncJobManager) {
@@ -12437,6 +12439,40 @@ export class AgentSession {
 		if (job === undefined || status === "completed" || status === "cancelled" || status === "failed") {
 			unregisterOwnedRegistration(envelope.registration);
 		}
+	}
+
+	/**
+	 * Drop every queued yield entry, releasing its retained delivery claim and
+	 * settling terminal owned-completion envelopes so neither outlives this
+	 * session's disposal. Claims resolve to the manager that actually retained
+	 * them: owned entries via their registration endpoint (subagents inherit a
+	 * parent's manager, and the process-global instance may belong to a
+	 * different concurrent session), ordinary entries only on the session-OWNED
+	 * manager. Disposal runs this twice: before the awaited session_shutdown
+	 * emit, and again after producer cancellation — a completion enqueued
+	 * inside that window would otherwise survive disposal, its claim retained
+	 * on a shared manager and interfering with later delivery teardown (Codex
+	 * review P2 on #5088).
+	 */
+	#drainTerminalOwnedYieldEntries(): void {
+		this.yieldQueue.clear((kind, entries) => {
+			if (kind !== "async-result") return;
+			const ownedManager = this.#ownedAsyncJobManager;
+			for (const entry of entries) {
+				if (typeof entry !== "object" || entry === null) continue;
+				const record = entry as { generation?: unknown; ownedCompletion?: unknown };
+				if (typeof record.generation === "string" && record.generation !== "") {
+					const envelope = isOwnedCompletionEnvelope(record.ownedCompletion) ? record.ownedCompletion : undefined;
+					const endpointId = envelope?.registration.endpointId;
+					const manager =
+						(endpointId !== undefined ? AsyncJobManager.forEndpoint(endpointId) : undefined) ?? ownedManager;
+					manager?.releaseDeliveryClaim(record.generation);
+				}
+				if (isOwnedCompletionEnvelope(record.ownedCompletion)) {
+					this.#settleOwnedCompletionEnvelope(record.ownedCompletion);
+				}
+			}
+		});
 	}
 
 	#getCustomMessageTextContent(message: Pick<CustomMessage, "content">): string {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8401,6 +8401,11 @@ export class AgentSession {
 		this.#evalExecutionDisposing = true;
 		this.#abortActiveMidRunBarriers();
 		this.abortCompaction();
+		// Disposal does not use the public abort unwind, so cancel any pending
+		// retry before closing admission. Otherwise a prompt waiting on
+		// #waitForPostPromptRecovery can keep its admission lease forever while
+		// teardown waits for that same lease to settle.
+		this.abortRetry();
 		this.agent.abort();
 		this.agent.setMainAttemptScopeObserver(undefined);
 		// Disconnect the Agent event bridge NOW — before the maintenance join and the

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8390,6 +8390,8 @@ export class AgentSession {
 	dispose(): Promise<void> {
 		this.#evalExecutionDisposing = true;
 		if (this.#disposePromise) return this.#disposePromise;
+		const { promise, resolve, reject } = Promise.withResolvers<void>();
+		this.#disposePromise = promise;
 		this.#abortAdmissionEpoch++;
 		this.#isDisposed = true;
 		this.#disposeAdmissionClosed = this.#closeSessionAdmission();
@@ -8401,8 +8403,6 @@ export class AgentSession {
 		this.agent.abort();
 		this.agent.setMainAttemptScopeObserver(undefined);
 		this.#disconnectFromAgent();
-		const { promise, resolve, reject } = Promise.withResolvers<void>();
-		this.#disposePromise = promise;
 		void this.#dispose().then(resolve, reject);
 		return promise;
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2848,6 +2848,8 @@ export class AgentSession {
 	readonly #asyncJobProviderSessionId: string | undefined;
 	#isDisposed = false;
 	#disposePromise: Promise<void> | undefined;
+	#disposeAdmissionClosed: Promise<void> | undefined;
+	#disposePostPromptDrain: Promise<void> | undefined;
 	readonly #toolSessionCleanups = new Set<() => Promise<void> | void>();
 	readonly #toolSessionTransitionCleanups = new Set<() => Promise<void> | void>();
 	readonly #deferredOwnerShutdownFinalizations = new Set<Promise<void>>();
@@ -6530,9 +6532,11 @@ export class AgentSession {
 				});
 			}
 			this.#resolveRetry();
+			if (this.#isDisposed || this.#sessionAdmissionClosing) return;
 
 			const compactionTask = this.#schedulePostPromptTask(
 				async () => {
+					if (this.#isDisposed || this.#sessionAdmissionClosing) return;
 					await this.#checkCompaction(msg, true, undefined, activePromptHandle);
 				},
 				{ resourceRunId: activePromptHandle },
@@ -8388,8 +8392,15 @@ export class AgentSession {
 		if (this.#disposePromise) return this.#disposePromise;
 		this.#abortAdmissionEpoch++;
 		this.#isDisposed = true;
+		this.#disposeAdmissionClosed = this.#closeSessionAdmission();
+		this.#disposePostPromptDrain = this.#cancelPostPromptTasks();
+		this.#abortActiveMidRunBarriers();
+		this.abortCompaction();
 		this.abortRetry();
 		this.#quarantineAgentRunResources();
+		this.agent.abort();
+		this.agent.setMainAttemptScopeObserver(undefined);
+		this.#disconnectFromAgent();
 		const { promise, resolve, reject } = Promise.withResolvers<void>();
 		this.#disposePromise = promise;
 		void this.#dispose().then(resolve, reject);
@@ -8404,26 +8415,7 @@ export class AgentSession {
 
 	async #dispose(): Promise<void> {
 		await this.sessionManager.joinCwdTransition();
-		const admissionClosed = this.#closeSessionAdmission();
-		// Reject new direct Python starts as soon as disposal begins (synchronously,
-		// before any await) so callers cannot race a start against teardown.
-		this.#evalExecutionDisposing = true;
-		this.#abortActiveMidRunBarriers();
-		this.abortCompaction();
-		// Disposal does not use the public abort unwind, so cancel any pending
-		// retry before closing admission. Otherwise a prompt waiting on
-		// #waitForPostPromptRecovery can keep its admission lease forever while
-		// teardown waits for that same lease to settle.
-		this.abortRetry();
-		this.#quarantineAgentRunResources();
-		this.agent.abort();
-		this.agent.setMainAttemptScopeObserver(undefined);
-		// Disconnect the Agent event bridge NOW — before the maintenance join and the
-		// bounded idle / forceAbort below — so no agent_end emitted during teardown
-		// (including the one forceAbort emits) can re-enter #handleAgentEvent and start
-		// fresh post-turn maintenance or mutate the closing session. Maintenance promises
-		// are joined directly (not via events), so this does not affect the join.
-		this.#disconnectFromAgent();
+		const admissionClosed = this.#disposeAdmissionClosed ?? this.#closeSessionAdmission();
 		// R2-5: join any in-flight mid-run maintenance invocation before teardown so the
 		// abort-aware maintenance promise (already aborted above) settles and cannot touch
 		// torn-down state afterward.
@@ -8472,7 +8464,7 @@ export class AgentSession {
 		this.#workflowGateEmitter = undefined;
 		this.#notifyWorkflowGateEmitterChanged(this.sessionId, undefined);
 		await this.#flushWorkerIntegrationAttempt();
-		await this.#cancelPostPromptTasks();
+		await (this.#disposePostPromptDrain ?? this.#cancelPostPromptTasks());
 		// Cancel jobs this agent registered so a subagent's teardown doesn't
 		// leak its background bash/task work into the parent's manager. Only
 		// the session that owns the manager goes on to dispose it (which itself
@@ -19628,6 +19620,15 @@ export class AgentSession {
 										),
 									],
 								});
+								return;
+							}
+							if (
+								attemptCancelled() ||
+								!ownership.isCurrent() ||
+								ownership.lease.signal.aborted ||
+								this.#fallbackTransitionGeneration !== transitionGeneration
+							) {
+								await restoreOwnedTransition();
 								return;
 							}
 							const continuation = this.agent.continue({

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2848,6 +2848,7 @@ export class AgentSession {
 	readonly #asyncJobProviderSessionId: string | undefined;
 	#isDisposed = false;
 	#disposePromise: Promise<void> | undefined;
+	readonly #disposeAbortController = new AbortController();
 	#disposeAdmissionClosed: Promise<void> | undefined;
 	#disposePostPromptDrain: Promise<void> | undefined;
 	readonly #toolSessionCleanups = new Set<() => Promise<void> | void>();
@@ -3244,10 +3245,10 @@ export class AgentSession {
 		return { entry, capability: entry.continuationCapability };
 	}
 
-	async #awaitStartupTurnBarrier(): Promise<void> {
+	async #awaitStartupTurnBarrier(signal?: AbortSignal): Promise<void> {
 		const barrier = this.#startupTurnBarrier;
 		if (!barrier) return;
-		await barrier;
+		await awaitPromptInvocationPreflight(barrier, signal);
 		if (this.#startupTurnBarrier === barrier) this.#startupTurnBarrier = undefined;
 	}
 	extendStartupTurnBarrier(barrier: Promise<void>): void {
@@ -4155,8 +4156,20 @@ export class AgentSession {
 				if (dropped.length > 0) this.#settleDeliveredOwnedRegistrations(dropped);
 				const first = survivors[0];
 				if (!first) return;
-				await this.#awaitStartupTurnBarrier();
-				if (this.#isDisposed) return;
+				const settleIfDisposing = (): boolean => {
+					if (!this.#isDisposed && !this.#sessionAdmissionClosing && !this.#disposeAbortController.signal.aborted)
+						return false;
+					this.#settleDeliveredOwnedRegistrations(survivors);
+					return true;
+				};
+				if (settleIfDisposing()) return;
+				try {
+					await this.#awaitStartupTurnBarrier(this.#disposeAbortController.signal);
+				} catch {
+					settleIfDisposing();
+					return;
+				}
+				if (settleIfDisposing()) return;
 				// A user prompt may have started during the barrier/scheduling
 				// delay: if the session is now streaming, mutating the epoch and
 				// lineage here would corrupt the ACTIVE user turn (and
@@ -6822,7 +6835,7 @@ export class AgentSession {
 									settleLease();
 									return;
 								}
-								await this.#awaitStartupTurnBarrier();
+								await this.#awaitStartupTurnBarrier(scheduledSignal);
 								if (!canContinue()) {
 									settleLease();
 									return;
@@ -8394,8 +8407,12 @@ export class AgentSession {
 		this.#disposePromise = promise;
 		this.#abortAdmissionEpoch++;
 		this.#isDisposed = true;
+		this.#disposeAbortController.abort();
 		this.#disposeAdmissionClosed = this.#closeSessionAdmission();
 		this.#disposePostPromptDrain = this.#cancelPostPromptTasks();
+		this.#settleDeliveredOwnedRegistrations(this.#pendingNextTurnMessages.map(entry => entry.message));
+		this.#pendingNextTurnMessages = [];
+		this.#scheduledHiddenNextTurnGeneration = undefined;
 		this.#abortActiveMidRunBarriers();
 		this.abortCompaction();
 		this.abortRetry();
@@ -12227,7 +12244,16 @@ export class AgentSession {
 		}
 		this.#scheduledHiddenNextTurnGeneration = generation;
 		this.#schedulePostPromptTask(
-			async () => {
+			async signal => {
+				if (signal.aborted || this.#isDisposed || this.#sessionAdmissionClosing) return;
+				if (this.#startupTurnBarrier) {
+					try {
+						await this.#awaitStartupTurnBarrier(signal);
+					} catch {
+						return;
+					}
+				}
+				if (signal.aborted || this.#isDisposed || this.#sessionAdmissionClosing) return;
 				if (this.#scheduledHiddenNextTurnGeneration === generation) {
 					this.#scheduledHiddenNextTurnGeneration = undefined;
 				}
@@ -12256,8 +12282,12 @@ export class AgentSession {
 					return;
 				}
 				try {
-					await this.#promptQueuedHiddenNextTurnMessages();
+					await this.#promptQueuedHiddenNextTurnMessages(signal);
 				} catch {
+					if (signal.aborted || this.#isDisposed || this.#sessionAdmissionClosing) {
+						this.#pendingNextTurnMessages = [];
+						return;
+					}
 					// Leave the hidden next-turn messages queued for the next explicit prompt.
 				}
 			},
@@ -12272,7 +12302,7 @@ export class AgentSession {
 		);
 	}
 
-	async #promptQueuedHiddenNextTurnMessages(): Promise<void> {
+	async #promptQueuedHiddenNextTurnMessages(signal?: AbortSignal): Promise<void> {
 		if (this.#pendingNextTurnMessages.length === 0) {
 			return;
 		}
@@ -12302,6 +12332,10 @@ export class AgentSession {
 		if (reclassified.length === 0) {
 			return;
 		}
+		if (signal?.aborted || this.#isDisposed || this.#sessionAdmissionClosing) {
+			this.#settleDeliveredOwnedRegistrations(reclassified.map(entry => entry.message));
+			return;
+		}
 		// Allocate a fresh root-turn lineage when the drained batch contains a
 		// fresh owned envelope OR an EXTERNAL hidden trigger: an external
 		// nextTurn message has no owned envelope, so without this it would
@@ -12323,11 +12357,20 @@ export class AgentSession {
 		const textContent = this.#getCustomMessageTextContent(message);
 		await this.#syncSkillPromptActiveStateSafely(message, true);
 		try {
+			if (signal?.aborted || this.#isDisposed || this.#sessionAdmissionClosing) {
+				this.#settleDeliveredOwnedRegistrations(reclassified.map(entry => entry.message));
+				return;
+			}
 			await this.#promptWithMessage(message, textContent, {
 				prependMessages,
 				skipPostPromptRecoveryWait: true,
+				preflightSignal: signal,
 			});
 		} catch (error) {
+			if (signal?.aborted || this.#isDisposed || this.#sessionAdmissionClosing) {
+				this.#settleDeliveredOwnedRegistrations(reclassified.map(entry => entry.message));
+				return;
+			}
 			// Requeue only the SURVIVING reclassified entries: a completion
 			// denied by scope:"owned" was settled (dropped) above and must
 			// never reach a later prompt — once its scope and now-unoccupied

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3280,7 +3280,12 @@ export class AgentSession {
 			}
 			throw this.#sessionAdmissionBusyError();
 		}
-		if (kind === "prompt") await awaitPromptInvocationPreflight(this.#awaitStartupTurnBarrier(), signal);
+		if (kind === "prompt") {
+			const startupSignal = signal
+				? AbortSignal.any([signal, this.#disposeAbortController.signal])
+				: this.#disposeAbortController.signal;
+			await awaitPromptInvocationPreflight(this.#awaitStartupTurnBarrier(startupSignal), startupSignal);
+		}
 		const bypassesSelectionFence =
 			options?.bypassSelectionFenceGeneration !== undefined &&
 			options.bypassSelectionFenceGeneration < this.#selectionFenceGeneration;
@@ -6674,7 +6679,11 @@ export class AgentSession {
 			options?.onSkip?.();
 			return Promise.resolve();
 		}
-		const signal = reservation?.ok ? reservation.lease.signal : this.#postPromptTasksAbortController.signal;
+		const taskSignal = reservation?.ok ? reservation.lease.signal : this.#postPromptTasksAbortController.signal;
+		// Disposal is a session-wide terminal fence. Compose it with the selected
+		// logical-resource signal so stale leases from earlier runs cannot keep a
+		// post-prompt task alive after the current run was quarantined.
+		const signal = AbortSignal.any([taskSignal, this.#disposeAbortController.signal]);
 		const runScheduled = async () => {
 			if (delayMs > 0) {
 				try {
@@ -8459,6 +8468,8 @@ export class AgentSession {
 		await admissionClosed;
 		await this.#agentEndPublicationPromise;
 		await this.#queuedExtensionEvents;
+		await this.#agentEndHandlingPromise;
+		await this.#waitForSessionSettlement();
 		// Drain the sidecar write order for the same reason the two queues above are
 		// drained: each entry writes under the native identity-bound state-file lock, so a
 		// still-queued write would run after the session that owns it is gone — releasing
@@ -8467,7 +8478,14 @@ export class AgentSession {
 		// is already failure-absorbing, so this only waits.
 		await this.#coordinatorPersistQueue;
 		this.#pendingBackgroundExchanges = [];
-		this.yieldQueue.clear();
+		this.yieldQueue.clear((kind, entries) => {
+			if (kind !== "async-result") return;
+			for (const entry of entries) {
+				if (typeof entry !== "object" || entry === null) continue;
+				const envelope = (entry as { ownedCompletion?: unknown }).ownedCompletion;
+				if (isOwnedCompletionEnvelope(envelope)) this.#settleOwnedCompletionEnvelope(envelope);
+			}
+		});
 
 		this.agent.setOnBeforeYield(undefined);
 		try {
@@ -12405,18 +12423,20 @@ export class AgentSession {
 		// another session's manager (which lacks the same local job id) would
 		// see job === undefined and remove a still-live registration (review
 		// thread P1).
-		const manager = this.#ownedAsyncJobManager ?? AsyncJobManager.instance();
 		for (const message of messages) {
 			const details = (message as { details?: { ownedCompletions?: OwnedCompletionEnvelope[] } }).details;
-			for (const envelope of details?.ownedCompletions ?? []) {
-				const job = manager?.getJob(envelope.registration.jobId);
-				const status = job?.generation === envelope.registration.jobGeneration ? job?.status : undefined;
-				// Evicted jobs have no live record (job === undefined); terminal
-				// statuses settle the registration.
-				if (job === undefined || status === "completed" || status === "cancelled" || status === "failed") {
-					unregisterOwnedRegistration(envelope.registration);
-				}
-			}
+			for (const envelope of details?.ownedCompletions ?? []) this.#settleOwnedCompletionEnvelope(envelope);
+		}
+	}
+
+	#settleOwnedCompletionEnvelope(envelope: OwnedCompletionEnvelope): void {
+		const manager = this.#ownedAsyncJobManager ?? AsyncJobManager.instance();
+		const job = manager?.getJob(envelope.registration.jobId);
+		const status = job?.generation === envelope.registration.jobGeneration ? job?.status : undefined;
+		// Evicted jobs have no live record (job === undefined); terminal statuses
+		// settle the registration.
+		if (job === undefined || status === "completed" || status === "cancelled" || status === "failed") {
+			unregisterOwnedRegistration(envelope.registration);
 		}
 	}
 

--- a/packages/coding-agent/src/session/yield-queue.ts
+++ b/packages/coding-agent/src/session/yield-queue.ts
@@ -112,7 +112,10 @@ export class YieldQueue {
 		}
 	}
 
-	clear(): void {
+	clear(onDrop?: (kind: string, entries: readonly unknown[]) => void): void {
+		if (onDrop) {
+			for (const [kind, entries] of this.#entries) onDrop(kind, entries);
+		}
 		this.#entries.clear();
 		this.#idleFlushPending = false;
 	}

--- a/packages/coding-agent/test/agent-session-fallback-cancel-idle.test.ts
+++ b/packages/coding-agent/test/agent-session-fallback-cancel-idle.test.ts
@@ -261,6 +261,33 @@ describe("AgentSession managed fallback cancellation completion", () => {
 		markUsageLimitReached.mockRestore();
 	});
 
+	it("cancels a hidden next-turn continuation waiting behind startup", async () => {
+		const calls: string[] = [];
+		createSession((model, context, options) => {
+			calls.push(selector(model));
+			return createMockModel({ responses: [{ content: ["must not run"] }] }).stream(model, context, options);
+		});
+		const startupBarrier = Promise.withResolvers<void>();
+		session!.extendStartupTurnBarrier(startupBarrier.promise);
+		session!.queueDeferredMessageForTests(
+			{
+				role: "custom",
+				customType: "test-hidden-disposal",
+				content: [{ type: "text", text: "hidden successor" }],
+				display: false,
+				details: {},
+				timestamp: Date.now(),
+			},
+			true,
+		);
+		await Bun.sleep(10);
+
+		await session!.dispose();
+
+		expect(calls).toHaveLength(0);
+		expect(session!.getPendingNextTurnMessagesForTests()).toHaveLength(0);
+	});
+
 	it("abandons the overflow-maintenance handoff before any continuation provider call", async () => {
 		const calls: string[] = [];
 		createSession((model, _context, _options) => {

--- a/packages/coding-agent/test/agent-session-fallback-cancel-idle.test.ts
+++ b/packages/coding-agent/test/agent-session-fallback-cancel-idle.test.ts
@@ -227,6 +227,40 @@ describe("AgentSession managed fallback cancellation completion", () => {
 		expect(events.find(event => event.type === "agent_end")).toMatchObject({ stopReason: "cancelled" });
 	});
 
+	it("fences managed fallback retry preparation when disposal wins before allocation", async () => {
+		const primary = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!primary) throw new Error("Expected bundled primary model");
+		const calls: string[] = [];
+		authStorage.removeRuntimeApiKey("anthropic");
+		await authStorage.set("anthropic", { type: "api_key", key: "stored-key" });
+		createSession(model => {
+			calls.push(selector(model));
+			return failingStream(model);
+		});
+		const markStarted = Promise.withResolvers<void>();
+		const releaseMark = Promise.withResolvers<void>();
+		const markUsageLimitReached = vi.spyOn(authStorage, "markUsageLimitReached").mockImplementation(async () => {
+			markStarted.resolve();
+			await releaseMark.promise;
+			return false;
+		});
+		const events: AgentSessionEvent[] = [];
+		session!.subscribe(event => events.push(event));
+
+		const run = session!.prompt("dispose during managed credential preparation");
+		await markStarted.promise;
+		const dispose = session!.dispose();
+		releaseMark.resolve();
+		await dispose;
+		await run;
+
+		expect(calls).toEqual([selector(primary)]);
+		expect(events.filter(event => event.type === "auto_retry_start")).toHaveLength(0);
+		expect(session!.isRetrying).toBe(false);
+		expect(session!.isStreaming).toBe(false);
+		markUsageLimitReached.mockRestore();
+	});
+
 	it("abandons the overflow-maintenance handoff before any continuation provider call", async () => {
 		const calls: string[] = [];
 		createSession((model, _context, _options) => {

--- a/packages/coding-agent/test/agent-session-fallback-cancel-idle.test.ts
+++ b/packages/coding-agent/test/agent-session-fallback-cancel-idle.test.ts
@@ -288,6 +288,24 @@ describe("AgentSession managed fallback cancellation completion", () => {
 		expect(session!.getPendingNextTurnMessagesForTests()).toHaveLength(0);
 	});
 
+	it("cancels an ordinary prompt waiting behind startup during disposal", async () => {
+		const calls: string[] = [];
+		createSession((model, context, options) => {
+			calls.push(selector(model));
+			return createMockModel({ responses: [{ content: ["must not run"] }] }).stream(model, context, options);
+		});
+		const startupBarrier = Promise.withResolvers<void>();
+		session!.extendStartupTurnBarrier(startupBarrier.promise);
+		const prompt = session!.prompt("ordinary prompt behind startup");
+		await Bun.sleep(10);
+
+		const dispose = session!.dispose();
+		await expect(prompt).rejects.toMatchObject({ code: "busy" });
+		await dispose;
+
+		expect(calls).toHaveLength(0);
+	});
+
 	it("abandons the overflow-maintenance handoff before any continuation provider call", async () => {
 		const calls: string[] = [];
 		createSession((model, _context, _options) => {

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
 import { Agent, type AgentTool, type StreamFn } from "@gajae-code/agent-core";
@@ -20,6 +20,8 @@ import {
 	PROVIDER_SAFETY_STOP_ADAPTER_CAPABILITY,
 	PROVIDER_SAFETY_STOP_ADAPTER_INVOCATION,
 } from "../../ai/src/adapter-internals/provider-safety-stop";
+
+const it = test.serial;
 
 /**
  * Anthropic's statusless capacity-overload envelope exactly as observed in a
@@ -102,12 +104,13 @@ describe("AgentSession resilient retry", () => {
 		// Teardown uses real timer/deadline state. Restore test clocks and scheduler
 		// hooks before disposing so a mocked Date.now cannot wedge cleanup.
 		vi.restoreAllMocks();
-		if (session) {
-			await session.dispose();
-			session = undefined;
-		}
-		authStorage.close();
-		tempDir.removeSync();
+		const currentSession = session;
+		const currentAuthStorage = authStorage;
+		const currentTempDir = tempDir;
+		session = undefined;
+		if (currentSession) await currentSession.dispose();
+		currentAuthStorage.close();
+		currentTempDir.removeSync();
 	});
 
 	function buildSession(options: {

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -112,7 +112,7 @@ describe.serial("AgentSession resilient retry", () => {
 		if (currentSession) await currentSession.dispose();
 		currentAuthStorage.close();
 		currentTempDir.removeSync();
-	});
+	}, 30_000);
 
 	function buildSession(options: {
 		responses: Array<{ throw: string } | { content: string[] }>;
@@ -1005,7 +1005,7 @@ describe.serial("AgentSession resilient retry", () => {
 			session = undefined;
 			waitSpy.mockClear();
 		}
-	});
+	}, 60_000);
 
 	it("uses failed AssistantMessage identity rather than the active model for Alibaba timeout policy", async () => {
 		const alibabaModel = getBundledModel("alibaba-token-plan", "qwen3.8-max-preview");
@@ -1056,7 +1056,7 @@ describe.serial("AgentSession resilient retry", () => {
 			model: alibabaModel.id,
 			errorMessage: timeoutMessage,
 		});
-	});
+	}, 60_000);
 
 	it("keeps Alibaba near misses, cross-API text, and unrelated transient failures retryable", async () => {
 		const responsesModel = getBundledModel("alibaba-token-plan", "qwen3.8-max-preview");

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -2509,6 +2509,27 @@ describe("AgentSession resilient retry", () => {
 		expect(retryEndEvents[0]).toMatchObject({ success: true });
 		expect(lastAssistant(session).stopReason).toBe("stop");
 	});
+	it("disposal cancels a pending idle-stall retry before closing admission", async () => {
+		const retryStarted = Promise.withResolvers<void>();
+		session = buildSession({
+			responses: [{ throw: "Anthropic stream stalled while waiting for the next event" }],
+			settingsOverrides: {
+				"retry.baseDelayMs": 60_000,
+				"retry.maxDelayMs": 60_000,
+				"retry.maxRetries": 2,
+			},
+		});
+		session.subscribe(event => {
+			if (event.type === "auto_retry_start") retryStarted.resolve();
+		});
+		const prompt = session.prompt("dispose while idle-stall retry is waiting");
+		await retryStarted.promise;
+
+		const disposed = await Promise.race([session.dispose().then(() => true), Bun.sleep(1_000).then(() => false)]);
+		expect(disposed).toBe(true);
+		await prompt;
+		session = undefined;
+	});
 	it("bounds repeated provider stream idle stalls by retry.maxRetries", async () => {
 		const requestedModels: string[] = [];
 		session = buildSession({

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -21,6 +21,8 @@ import {
 	PROVIDER_SAFETY_STOP_ADAPTER_INVOCATION,
 } from "../../ai/src/adapter-internals/provider-safety-stop";
 
+const REAL_DATE_NOW = Date.now;
+
 /**
  * Anthropic's statusless capacity-overload envelope exactly as observed in a
  * live session, including the trailing padding the provider sends.
@@ -102,6 +104,7 @@ describe.serial("AgentSession resilient retry", () => {
 		// Teardown uses real timer/deadline state. Restore test clocks and scheduler
 		// hooks before disposing so a mocked Date.now cannot wedge cleanup.
 		vi.restoreAllMocks();
+		Date.now = REAL_DATE_NOW;
 		const currentSession = session;
 		const currentAuthStorage = authStorage;
 		const currentTempDir = tempDir;

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -112,7 +112,7 @@ describe.serial("AgentSession resilient retry", () => {
 		if (currentSession) await currentSession.dispose();
 		currentAuthStorage.close();
 		currentTempDir.removeSync();
-	}, 30_000);
+	}, 300_000);
 
 	function buildSession(options: {
 		responses: Array<{ throw: string } | { content: string[] }>;

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
 import { Agent, type AgentTool, type StreamFn } from "@gajae-code/agent-core";
@@ -20,8 +20,6 @@ import {
 	PROVIDER_SAFETY_STOP_ADAPTER_CAPABILITY,
 	PROVIDER_SAFETY_STOP_ADAPTER_INVOCATION,
 } from "../../ai/src/adapter-internals/provider-safety-stop";
-
-const it = test.serial.bind(test);
 
 /**
  * Anthropic's statusless capacity-overload envelope exactly as observed in a
@@ -87,7 +85,7 @@ function assistantMessage(
  *  - retry.enabled=false surfaces immediately;
  *  - first Esc (retryNow) skips the backoff; abortRetry cancels.
  */
-describe("AgentSession resilient retry", () => {
+describe.serial("AgentSession resilient retry", () => {
 	let tempDir: TempDir;
 	let authStorage: AuthStorage;
 	let modelRegistry: ModelRegistry;
@@ -858,6 +856,7 @@ describe("AgentSession resilient retry", () => {
 	});
 
 	it("does not terminalize retryable explicit HTTP statuses", async () => {
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
 		for (const [status, message] of [
 			[408, "HTTP 408 request timeout"],
 			[425, "HTTP 425 too early retry your request"],
@@ -869,7 +868,6 @@ describe("AgentSession resilient retry", () => {
 				session = undefined;
 			}
 			session = buildSession({ responses: [{ throw: message }, { content: [`recovered ${status}`] }] });
-			vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
 			const { retryStartEvents } = track(session);
 
 			await session.prompt(`trigger retryable HTTP ${status}`);

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -21,7 +21,7 @@ import {
 	PROVIDER_SAFETY_STOP_ADAPTER_INVOCATION,
 } from "../../ai/src/adapter-internals/provider-safety-stop";
 
-const it = test.serial;
+const it = test.serial.bind(test);
 
 /**
  * Anthropic's statusless capacity-overload envelope exactly as observed in a

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -2180,7 +2180,7 @@ describe.serial("AgentSession resilient retry", () => {
 			expect.objectContaining({ attempt: 1, maxAttempts: 2, errorMessage, unbounded: false }),
 		]);
 		expect(lastAssistant(session).errorMessage).toContain("exhausted after 2 attempts");
-	}, 60000);
+	}, 60_000);
 	it("reseeds first-event timeout accounting at the first retryable failure", async () => {
 		let now = 10;
 		vi.spyOn(Date, "now").mockImplementation(() => now);
@@ -2869,7 +2869,7 @@ describe.serial("AgentSession resilient retry", () => {
 			false,
 		);
 		expect(lastAssistant(session).content).toEqual([{ type: "text", text: "replacement recovered" }]);
-	});
+	}, 60_000);
 	it("fails closed on non-canonical watchdog prose under bare defaults", async () => {
 		const nearMisses = [
 			"stream timed out while waiting for the first event",

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -99,13 +99,15 @@ describe("AgentSession resilient retry", () => {
 	});
 
 	afterEach(async () => {
+		// Teardown uses real timer/deadline state. Restore test clocks and scheduler
+		// hooks before disposing so a mocked Date.now cannot wedge cleanup.
+		vi.restoreAllMocks();
 		if (session) {
 			await session.dispose();
 			session = undefined;
 		}
 		authStorage.close();
 		tempDir.removeSync();
-		vi.restoreAllMocks();
 	});
 
 	function buildSession(options: {

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -1170,7 +1170,7 @@ describe.serial("AgentSession resilient retry", () => {
 			session = undefined;
 			waitSpy.mockClear();
 		}
-	});
+	}, 300000);
 
 	it("keeps first-party first-event timeout retries unbounded (#713 scope guard)", async () => {
 		// The fix is scoped to ollama-cloud: first-party providers keep their
@@ -1198,7 +1198,7 @@ describe.serial("AgentSession resilient retry", () => {
 		expect(retryEndEvents).toHaveLength(1);
 		expect(retryEndEvents[0]).toMatchObject({ success: true });
 		expect(lastAssistant(session).stopReason).toBe("stop");
-	});
+	}, 300000);
 	it("retries provider stream first-event timeouts under a bare default config (single model)", async () => {
 		// Regression: with a single default model and NO explicit retry.* keys,
 		// a provider stream timeout used to fail the turn without retrying and
@@ -2135,7 +2135,7 @@ describe.serial("AgentSession resilient retry", () => {
 			stopReason: "stop",
 			content: [{ type: "text", text: "recovered" }],
 		});
-	});
+	}, 300000);
 
 	it("bounds canonical wrapped first-event timeout exhaustion with exact diagnostics", async () => {
 		const errorMessage = "Error: Provider stream timed out while waiting for the first event";
@@ -2158,7 +2158,7 @@ describe.serial("AgentSession resilient retry", () => {
 		expect(lastAssistant(session).errorMessage).toMatch(
 			/^First-event stream timeout exhausted after 3 attempts; waited \d+ms total: Error: Provider stream timed out while waiting for the first event$/,
 		);
-	});
+	}, 300000);
 
 	it("bounds the exact no-the first-event compatibility message under explicit retry policy", async () => {
 		const errorMessage = "Provider stream timed out while waiting for first event";

--- a/packages/coding-agent/test/agent-session-resilient-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-resilient-retry.test.ts
@@ -2511,6 +2511,7 @@ describe("AgentSession resilient retry", () => {
 	});
 	it("disposal cancels a pending idle-stall retry before closing admission", async () => {
 		const retryStarted = Promise.withResolvers<void>();
+		const requestedModels: string[] = [];
 		session = buildSession({
 			responses: [{ throw: "Anthropic stream stalled while waiting for the next event" }],
 			settingsOverrides: {
@@ -2518,7 +2519,9 @@ describe("AgentSession resilient retry", () => {
 				"retry.maxDelayMs": 60_000,
 				"retry.maxRetries": 2,
 			},
+			requestedModels,
 		});
+		const { retryStartEvents, retryEndEvents } = track(session);
 		session.subscribe(event => {
 			if (event.type === "auto_retry_start") retryStarted.resolve();
 		});
@@ -2528,6 +2531,11 @@ describe("AgentSession resilient retry", () => {
 		const disposed = await Promise.race([session.dispose().then(() => true), Bun.sleep(1_000).then(() => false)]);
 		expect(disposed).toBe(true);
 		await prompt;
+		expect(requestedModels).toHaveLength(1);
+		expect(retryStartEvents).toHaveLength(1);
+		expect(retryEndEvents).toEqual([expect.objectContaining({ success: false, attempt: 1 })]);
+		expect(session.isRetrying).toBe(false);
+		expect(session.isStreaming).toBe(false);
 		session = undefined;
 	});
 	it("bounds repeated provider stream idle stalls by retry.maxRetries", async () => {


### PR DESCRIPTION
## What

Cancel pending session retries before `AgentSession.dispose()` closes session admission, and fence managed fallback preparation/continuations against teardown. Regression coverage covers idle-stall backoff disposal, credential/fallback preparation before retry allocation, ordinary and hidden prompts behind startup barriers, yield-queue owned-delivery cleanup, and deterministic resilient-retry teardown under mocked clocks and shared fixtures.

## Why

`dispose()` did not use the public abort unwind, so it skipped `abortRetry()`. A prompt waiting in `#waitForPostPromptRecovery()` could retain the active admission lease while disposal waited for that lease to settle. Managed fallback retries had a second race: Agent detaches its active attempt before invoking a managed continuation, so disposal could otherwise miss the logical run and allow fallback preparation or direct continuation work to re-arm after teardown.

The bounded successor-Dev fix-forward for #5075 now publishes the shared disposal promise before synchronous hooks, closes session admission, cancels post-prompt work and ordinary retry gates, invalidates the retry admission epoch, quarantines the managed logical resource domain, and checks disposal before retry allocation and every managed continuation. The terminal disposal signal is composed into pre-admission and resource-bound post-prompt waits, drains the in-flight agent-end handler boundary before session close, and settles terminal owned envelopes before clearing the yield queue. Ordinary post-prompt cancellation still preserves hidden-message requeue semantics. The resilient-retry fixture restores the original `Date.now` before disposal, marks the whole shared-fixture suite serial, consolidates loop scheduler spies, and gives multi-session policy cases explicit bounded test budgets so loaded CI cannot start afterEach while a test body still owns its shared session. Normal retry policy is unchanged outside disposal. The original unused `findInitialModel` import repair is already integrated by #5076; this PR does not duplicate that patch.

## Testing

- `bun test packages/coding-agent/test/agent-session-resilient-retry.test.ts` (79 passed locally)
- `bun test packages/coding-agent/test/agent-session-fallback-cancel-idle.test.ts` (8 passed)
- `bun test packages/coding-agent/test/agent-session-terminal-abort-chain.test.ts --test-name-pattern 'hidden next-turn|owned completion|continuation'` (4 passed)
- `bun test packages/coding-agent/test/session/yield-queue.test.ts` (6 passed)
- `bun test packages/coding-agent/test/async-yield-queue.test.ts` (6 passed)
- `bun test packages/coding-agent/test/agent-session-skill-reroute-cancellation.test.ts` (9 passed)
- `bun test packages/coding-agent/test/agent-session-auto-compaction-continue.test.ts --test-name-pattern 'startup barrier|dispose|continuation'` (27 passed, 1 skipped)
- `bun --cwd=packages/coding-agent run check`
- `bun run build`

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict.
- [ ] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer.
- [x] `high-risk` — lifecycle teardown behavior requires an authenticated exact-head independent review.

## GJC verdict

gajae.pr-review-verdict.v1 merge-approved sha256:cd5de0b6bb3f4663f20c3a3a13653b76a7d8dc00084e3ff18428f1a971b861bd reviewer:human reviewer-id:snowykr evidence:https://github.com/Yeachan-Heo/gajae-code/pull/5088/checks

---

- [x] Target branch is `dev` at `002e6e5f2c911d02633d30d14ae28a35eacc9d22`
- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (not user-facing)
- [x] Verdict above matches the exact PR head
- [x] Risk classification matches the actual review path

Refs #5075


