### PR TITLE
fix(sdk): release deferred MCP idle wakes at readiness

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Deferred MCP startup now releases queued idle yields as soon as readiness settles without bypassing prompt admission. Barrier extensions remain gated, rejected startup drops the wake without prompting, settled sessions retain the normal idle merge window, and readiness stays session-local. (#5085)
+
 - ACP deep-interview's real subprocess fixture now retires its owned lifecycle sessions before broker/root cleanup, preventing detached session hosts from recreating the fixture root after teardown. (#5086)
 - The ACP fixture tracks broker startup through its full producer deadline and tracks session creation before awaiting responses, keeps its independent broker fallback client available when runtime shutdown fails, and retires sessions first seen in either broker inventory phase directly through that fallback across cleanup retries. Verified broker-startup rejection no longer strands the root, while an unverified child-reap failure retains cleanup authority. Reconciliation recognizes the real ACP `terminal_uncertain` after-send wire envelope as transport uncertainty while preserving semantic close diagnostics, then accepts terminal races only after strict inventory proves unambiguous and certain retirement. A stalled broker-client transport close no longer blocks authoritative lease/root cleanup, and the child environment confines Windows profile and temporary paths to the fixture root. (#5086)
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2392,6 +2392,7 @@ export class AgentSession {
 	#preProfileModel: Model | undefined;
 	#sessionAdmissionQueue: SessionAdmissionEntry[] = [];
 	#activeSessionAdmission: SessionAdmissionEntry | undefined;
+	#startupPromptWaiters = new Set<Promise<void>>();
 	#sessionAdmissionClosing = false;
 	#sessionAdmissionClosed = false;
 	#sessionAdmissionContext = new AsyncLocalStorage<SessionAdmissionEntry>();
@@ -3050,6 +3051,7 @@ export class AgentSession {
 	#cancelAndSubmitAbortOutcomeProviderForTests: (() => Promise<AbortOutcome>) | undefined = undefined;
 	#postPromptTasks = new Set<Promise<void>>();
 	#postPromptTaskSelectionFenceGenerations = new Map<Promise<void>, number>();
+	#postPromptTaskRecoveryExcluded = new Set<Promise<void>>();
 	#postPromptTasksPromise: Promise<void> | undefined = undefined;
 	#postPromptTasksResolve: (() => void) | undefined = undefined;
 	#postPromptTasksAbortController = new AbortController();
@@ -3350,10 +3352,30 @@ export class AgentSession {
 			const barrier = this.#startupTurnBarrier;
 			if (!barrier) return;
 			await awaitPromptInvocationPreflight(barrier, signal);
+			// Let later reactions to the same readiness promise publish an
+			// extension before deciding the captured barrier is still current.
+			await Promise.resolve();
 			if (this.#startupTurnBarrier !== barrier) continue;
 			this.#setStartupTurnBarrier(undefined);
 			return;
 		}
+	}
+	async #awaitStartupPromptWaiters(signal?: AbortSignal): Promise<void> {
+		while (this.#startupPromptWaiters.size > 0) {
+			await awaitPromptInvocationPreflight(Promise.all([...this.#startupPromptWaiters]), signal);
+			await Promise.resolve();
+		}
+	}
+	#reserveStartupPromptWaiter(): () => void {
+		const waiter = Promise.withResolvers<void>();
+		this.#startupPromptWaiters.add(waiter.promise);
+		let released = false;
+		return () => {
+			if (released) return;
+			released = true;
+			this.#startupPromptWaiters.delete(waiter.promise);
+			waiter.resolve();
+		};
 	}
 	extendStartupTurnBarrier(barrier: Promise<void>): void {
 		const current = this.#startupTurnBarrier;
@@ -3370,6 +3392,8 @@ export class AgentSession {
 			allowDuringClosing?: boolean;
 			bypassSelectionFenceGeneration?: number;
 			allowPromptContinuationReentry?: boolean;
+			idleDelivery?: boolean;
+			startupPromptWaiterRelease?: () => void;
 		},
 	): Promise<T> {
 		const owner = this.#sessionAdmissionContext.getStore();
@@ -3384,11 +3408,20 @@ export class AgentSession {
 			}
 			throw this.#sessionAdmissionBusyError();
 		}
+		const releaseStartupPromptWaiter =
+			kind === "prompt" && options?.idleDelivery !== true
+				? (options?.startupPromptWaiterRelease ?? this.#reserveStartupPromptWaiter())
+				: undefined;
 		if (kind === "prompt") {
 			const startupSignal = signal
 				? AbortSignal.any([signal, this.#disposeAbortController.signal])
 				: this.#disposeAbortController.signal;
-			await awaitPromptInvocationPreflight(this.#awaitStartupTurnBarrier(startupSignal), startupSignal);
+			try {
+				await awaitPromptInvocationPreflight(this.#awaitStartupTurnBarrier(startupSignal), startupSignal);
+			} finally {
+				releaseStartupPromptWaiter?.();
+			}
+			if (options?.idleDelivery === true) await this.#awaitStartupPromptWaiters(startupSignal);
 		}
 		const bypassesSelectionFence =
 			options?.bypassSelectionFenceGeneration !== undefined &&
@@ -4369,43 +4402,33 @@ export class AgentSession {
 					this.#settleDeliveredOwnedRegistrations(survivors);
 					return true;
 				};
-				if (settleIfDisposing()) return;
 				try {
-					await this.#awaitStartupTurnBarrier(signal ?? this.#disposeAbortController.signal);
-				} catch {
-					settleIfDisposing();
-					return;
-				}
-				if (settleIfDisposing()) return;
-				// A user prompt may have started during the barrier/scheduling
-				// delay: if the session is now streaming, mutating the epoch and
-				// lineage here would corrupt the ACTIVE user turn (and
-				// agent.prompt would then reject as busy, losing the drained
-				// completion). Route the survivors through followUp — the
-				// streaming injector's path — which allocates the fresh resume
-				// lineage at actual admission (review thread P1).
-				if (this.isStreaming) {
-					for (const message of survivors) this.agent.followUp(message);
-					return;
-				}
-				if (survivors.some(message => ownedCompletionResumeAction(message) === "fresh"))
-					this.#resumeFromOwnedCompletion();
-				try {
-					if (survivors.length === 1) {
-						await this.agent.prompt(first, {
-							...this.#managedFallbackPromptOptions(),
-							onRunAccepted: (handle: AttemptRunHandle) => {
-								if (handle) this.#acceptSdkAttemptRun(handle);
-							},
-						});
-					} else {
-						await this.agent.prompt(survivors, {
-							...this.#managedFallbackPromptOptions(),
-							onRunAccepted: (handle: AttemptRunHandle) => {
-								if (handle) this.#acceptSdkAttemptRun(handle);
-							},
-						});
-					}
+					await this.#withSessionAdmission(
+						"prompt",
+						async () => {
+							if (settleIfDisposing()) return;
+							if (survivors.some(message => ownedCompletionResumeAction(message) === "fresh"))
+								this.#resumeFromOwnedCompletion();
+							if (survivors.length === 1) {
+								await this.agent.prompt(first, {
+									...this.#managedFallbackPromptOptions(),
+									onRunAccepted: (handle: AttemptRunHandle) => {
+										if (handle) this.#acceptSdkAttemptRun(handle);
+									},
+								});
+							} else {
+								await this.agent.prompt(survivors, {
+									...this.#managedFallbackPromptOptions(),
+									onRunAccepted: (handle: AttemptRunHandle) => {
+										if (handle) this.#acceptSdkAttemptRun(handle);
+									},
+								});
+							}
+						},
+						signal,
+						undefined,
+						{ idleDelivery: true },
+					);
 				} finally {
 					// The owned completions were delivered OR the prompt attempt
 					// failed (e.g. provider rejection): either way the yield
@@ -4426,7 +4449,7 @@ export class AgentSession {
 					async signal => {
 						await run(signal);
 					},
-					{ delayMs },
+					{ delayMs, excludeFromPostPromptRecovery: true },
 				);
 			},
 		});
@@ -6881,9 +6904,11 @@ export class AgentSession {
 		selectionFenceGeneration: number,
 		lease?: RunResourceProducerLease,
 		leaseTask: Promise<void> = task,
+		excludeFromRecovery = false,
 	): void {
 		this.#postPromptTasks.add(task);
 		this.#postPromptTaskSelectionFenceGenerations.set(task, selectionFenceGeneration);
+		if (excludeFromRecovery) this.#postPromptTaskRecoveryExcluded.add(task);
 		this.#ensurePostPromptTasksPromise();
 		if (lease) {
 			lease.track("post_prompt", "agent-session", leaseTask);
@@ -6894,6 +6919,7 @@ export class AgentSession {
 			.finally(() => {
 				this.#postPromptTasks.delete(task);
 				this.#postPromptTaskSelectionFenceGenerations.delete(task);
+				this.#postPromptTaskRecoveryExcluded.delete(task);
 				if (this.#postPromptTasks.size === 0) this.#resolvePostPromptTasks();
 			});
 	}
@@ -6907,6 +6933,7 @@ export class AgentSession {
 			resourceRunId?: string;
 			leaseTask?: Promise<void>;
 			selectionFenceGeneration?: number;
+			excludeFromPostPromptRecovery?: boolean;
 		},
 	): Promise<void> {
 		const selectionFenceGeneration =
@@ -6965,6 +6992,7 @@ export class AgentSession {
 			selectionFenceGeneration,
 			reservation?.ok ? reservation.lease : undefined,
 			options?.leaseTask,
+			options?.excludeFromPostPromptRecovery,
 		);
 		return scheduled;
 	}
@@ -7502,6 +7530,7 @@ export class AgentSession {
 		this.#postPromptTasksAbortController = new AbortController();
 		this.#postPromptTasks.clear();
 		this.#postPromptTaskSelectionFenceGenerations.clear();
+		this.#postPromptTaskRecoveryExcluded.clear();
 		this.#releaseDeferredAgentEndContinuations();
 		this.#resolveTtsrResume();
 		this.#resolvePostPromptTasks();
@@ -7523,8 +7552,11 @@ export class AgentSession {
 				await this.#ttsrResumePromise;
 				continue;
 			}
-			if (this.#postPromptTasksPromise) {
-				await this.#postPromptTasksPromise;
+			const recoveryTasks = [...this.#postPromptTasks].filter(
+				task => !this.#postPromptTaskRecoveryExcluded.has(task),
+			);
+			if (recoveryTasks.length > 0) {
+				await Promise.allSettled(recoveryTasks);
 				continue;
 			}
 			// Tracked post-prompt tasks cover deferred continuations scheduled from
@@ -7546,7 +7578,9 @@ export class AgentSession {
 	 */
 	async #waitForPostPromptTasksBeforeSelectionFence(selectionFenceGeneration: number): Promise<void> {
 		const precedingTasks = [...this.#postPromptTasks].filter(
-			task => (this.#postPromptTaskSelectionFenceGenerations.get(task) ?? 0) < selectionFenceGeneration,
+			task =>
+				!this.#postPromptTaskRecoveryExcluded.has(task) &&
+				(this.#postPromptTaskSelectionFenceGenerations.get(task) ?? 0) < selectionFenceGeneration,
 		);
 		if (precedingTasks.length > 0) await Promise.allSettled(precedingTasks);
 	}
@@ -11272,6 +11306,19 @@ export class AgentSession {
 	 * @throws Error if no model selected or no API key available (when not streaming)
 	 */
 	async prompt(text: string, options?: PromptOptions): Promise<void> {
+		const releaseStartupPromptWaiter = this.#reserveStartupPromptWaiter();
+		try {
+			await this.#promptInternal(text, options, releaseStartupPromptWaiter);
+		} finally {
+			releaseStartupPromptWaiter();
+		}
+	}
+
+	async #promptInternal(
+		text: string,
+		options: PromptOptions | undefined,
+		releaseStartupPromptWaiter: () => void,
+	): Promise<void> {
 		const hasUsableImage =
 			options?.images?.some(image => typeof image?.data === "string" && image.data.trim().length > 0) === true;
 		if (typeof text !== "string" || (text.trim().length === 0 && !hasUsableImage))
@@ -11417,7 +11464,12 @@ export class AgentSession {
 							attribution: promptAttribution,
 							timestamp: Date.now(),
 						}
-					: { role: "user" as const, content: userContent, attribution: promptAttribution, timestamp: Date.now() };
+					: {
+							role: "user" as const,
+							content: userContent,
+							attribution: promptAttribution,
+							timestamp: Date.now(),
+						};
 				if (deepInterviewUserIntentEpoch !== undefined)
 					this.#deepInterviewGenuineUserMessageEpochs.set(message, deepInterviewUserIntentEpoch);
 				await this.refreshGjcSubskillTools();
@@ -11445,6 +11497,8 @@ export class AgentSession {
 				}
 			},
 			options?.preflightSignal,
+			undefined,
+			{ startupPromptWaiterRelease: releaseStartupPromptWaiter },
 		);
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3352,9 +3352,13 @@ export class AgentSession {
 			const barrier = this.#startupTurnBarrier;
 			if (!barrier) return;
 			await awaitPromptInvocationPreflight(barrier, signal);
-			// Let later reactions to the same readiness promise publish an
-			// extension before deciding the captured barrier is still current.
-			await Promise.resolve();
+			// Drain chained readiness reactions before clearing the captured
+			// barrier. Extensions publish startup dependencies from promise
+			// reactions; re-reading across a bounded microtask drain preserves that
+			// ordering without introducing a timer into startup admission.
+			for (let reaction = 0; reaction < 16 && this.#startupTurnBarrier === barrier; reaction++) {
+				await Promise.resolve();
+			}
 			if (this.#startupTurnBarrier !== barrier) continue;
 			this.#setStartupTurnBarrier(undefined);
 			return;
@@ -4396,7 +4400,6 @@ export class AgentSession {
 				if (dropped.length > 0) this.#settleDeliveredOwnedRegistrations(dropped);
 				const first = survivors[0];
 				if (!first) return;
-				const handedOffToFollowUp = new Set<AgentMessage>();
 				const settleIfDisposing = (): boolean => {
 					if (!this.#isDisposed && !this.#sessionAdmissionClosing && !this.#disposeAbortController.signal.aborted)
 						return false;
@@ -4409,11 +4412,8 @@ export class AgentSession {
 						async () => {
 							if (settleIfDisposing()) return;
 							if (this.isStreaming) {
-								for (const message of survivors) {
-									this.agent.followUp(message);
-									handedOffToFollowUp.add(message);
-								}
-								return;
+								await awaitPromptInvocationPreflight(this.agent.waitForIdle(), signal);
+								if (settleIfDisposing()) return;
 							}
 							if (survivors.some(message => ownedCompletionResumeAction(message) === "fresh"))
 								this.#resumeFromOwnedCompletion();
@@ -4445,7 +4445,7 @@ export class AgentSession {
 					// failure, otherwise repeated failed idle resumptions leak
 					// terminal tuples into the global registries until capacity
 					// is exhausted (review thread P2).
-					this.#settleDeliveredOwnedRegistrations(survivors.filter(message => !handedOffToFollowUp.has(message)));
+					this.#settleDeliveredOwnedRegistrations(survivors);
 				}
 			},
 			scheduleIdleFlush: (run, onSkip) => {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4396,6 +4396,7 @@ export class AgentSession {
 				if (dropped.length > 0) this.#settleDeliveredOwnedRegistrations(dropped);
 				const first = survivors[0];
 				if (!first) return;
+				const handedOffToFollowUp = new Set<AgentMessage>();
 				const settleIfDisposing = (): boolean => {
 					if (!this.#isDisposed && !this.#sessionAdmissionClosing && !this.#disposeAbortController.signal.aborted)
 						return false;
@@ -4407,6 +4408,13 @@ export class AgentSession {
 						"prompt",
 						async () => {
 							if (settleIfDisposing()) return;
+							if (this.isStreaming) {
+								for (const message of survivors) {
+									this.agent.followUp(message);
+									handedOffToFollowUp.add(message);
+								}
+								return;
+							}
 							if (survivors.some(message => ownedCompletionResumeAction(message) === "fresh"))
 								this.#resumeFromOwnedCompletion();
 							if (survivors.length === 1) {
@@ -4437,7 +4445,7 @@ export class AgentSession {
 					// failure, otherwise repeated failed idle resumptions leak
 					// terminal tuples into the global registries until capacity
 					// is exhausted (review thread P2).
-					this.#settleDeliveredOwnedRegistrations(survivors);
+					this.#settleDeliveredOwnedRegistrations(survivors.filter(message => !handedOffToFollowUp.has(message)));
 				}
 			},
 			scheduleIdleFlush: run => {
@@ -9016,14 +9024,24 @@ export class AgentSession {
 				await this.#waitForPostPromptTasksBeforeSelectionFence(ignoreSelectionFenceGeneration);
 			}
 			await this.#waitForSessionSettlement(ignoreSelectionFenceGeneration);
+			const hasBlockingPostPromptTasks =
+				ignoreSelectionFenceGeneration === undefined
+					? this.#postPromptTasks.size > 0
+					: [...this.#postPromptTasks].some(
+							task =>
+								!this.#postPromptTaskRecoveryExcluded.has(task) &&
+								(this.#postPromptTaskSelectionFenceGenerations.get(task) ?? 0) < ignoreSelectionFenceGeneration,
+						);
 			if (
 				!this.agent.state.isStreaming &&
 				!this.#retryPromise &&
 				!this.#ttsrResumePromise &&
-				!this.#postPromptTasksPromise &&
+				!hasBlockingPostPromptTasks &&
 				!this.#isSessionSettlementPending(ignoreSelectionFenceGeneration)
 			)
 				return;
+			if (ignoreSelectionFenceGeneration === undefined && hasBlockingPostPromptTasks && this.#postPromptTasksPromise)
+				await this.#postPromptTasksPromise;
 		}
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4448,7 +4448,7 @@ export class AgentSession {
 					this.#settleDeliveredOwnedRegistrations(survivors.filter(message => !handedOffToFollowUp.has(message)));
 				}
 			},
-			scheduleIdleFlush: run => {
+			scheduleIdleFlush: (run, onSkip) => {
 				// The startup barrier already gates injectIdle, so begin waiting on a
 				// pending barrier immediately. Once readiness has settled, ordinary
 				// idle wakes retain the fixed merge window.
@@ -4457,9 +4457,10 @@ export class AgentSession {
 					async signal => {
 						await run(signal);
 					},
-					{ delayMs, excludeFromPostPromptRecovery: true },
+					{ delayMs, onSkip, excludeFromPostPromptRecovery: true },
 				);
 			},
+			getIdleFlushSignal: () => this.#postPromptTasksAbortController.signal,
 		});
 		this.agent.setOnBeforeYield(() => this.yieldQueue.flush("streaming"));
 		// Stop-after-result, never abort: a fold arms this once and the loop ends the

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2850,6 +2850,7 @@ export class AgentSession {
 	readonly #disposeAsyncJobManager: boolean;
 	#ownedMcpManager: MCPManager | undefined;
 	#startupTurnBarrier: Promise<void> | undefined;
+	#startupTurnBarrierPending = false;
 	#pendingPythonMessages: Array<{
 		message: PythonExecutionMessage;
 		onPersisted?: () => void;
@@ -3331,16 +3332,33 @@ export class AgentSession {
 		return { entry, capability: entry.continuationCapability };
 	}
 
-	async #awaitStartupTurnBarrier(signal?: AbortSignal): Promise<void> {
-		const barrier = this.#startupTurnBarrier;
+	#setStartupTurnBarrier(barrier: Promise<void> | undefined): void {
+		this.#startupTurnBarrier = barrier;
+		this.#startupTurnBarrierPending = barrier !== undefined;
 		if (!barrier) return;
-		await awaitPromptInvocationPreflight(barrier, signal);
-		if (this.#startupTurnBarrier === barrier) this.#startupTurnBarrier = undefined;
+		void barrier.then(
+			() => {
+				if (this.#startupTurnBarrier === barrier) this.#startupTurnBarrierPending = false;
+			},
+			() => {
+				if (this.#startupTurnBarrier === barrier) this.#startupTurnBarrierPending = false;
+			},
+		);
+	}
+	async #awaitStartupTurnBarrier(signal?: AbortSignal): Promise<void> {
+		while (true) {
+			const barrier = this.#startupTurnBarrier;
+			if (!barrier) return;
+			await awaitPromptInvocationPreflight(barrier, signal);
+			if (this.#startupTurnBarrier !== barrier) continue;
+			this.#setStartupTurnBarrier(undefined);
+			return;
+		}
 	}
 	extendStartupTurnBarrier(barrier: Promise<void>): void {
 		const current = this.#startupTurnBarrier;
-		this.#startupTurnBarrier = current ? Promise.all([current, barrier]).then(() => {}) : barrier;
-		void this.#startupTurnBarrier.catch(() => {});
+		this.#setStartupTurnBarrier(current ? Promise.all([current, barrier]).then(() => {}) : barrier);
+		void this.#startupTurnBarrier?.catch(() => {});
 	}
 
 	async #withSessionAdmission<T>(
@@ -4231,7 +4249,7 @@ export class AgentSession {
 		this.#disposeAsyncJobManager = config.disposeAsyncJobManager ?? true;
 		this.#retainedMemorySampler = config.retainedMemorySampler;
 		this.#ownedMcpManager = config.ownedMcpManager;
-		this.#startupTurnBarrier = config.startupTurnBarrier;
+		this.#setStartupTurnBarrier(config.startupTurnBarrier);
 		// Only arm the recovery barrier when a rescope journal is actually pending. Arming it
 		// unconditionally flips #startupTurnBarrier from absent to a (resolved) promise for
 		// every session, which makes barrier-gated post-turn work (e.g. the hidden-next-turn
@@ -4331,7 +4349,7 @@ export class AgentSession {
 				// agent.prompt directly, allocates right before admission.
 				this.agent.followUp(message);
 			},
-			injectIdle: async messages => {
+			injectIdle: async (messages, signal) => {
 				// Mandated boundary comment (corrected turn semantics): same origin
 				// split as the streaming injector — an allowed owned-completion
 				// delivery starts a fresh turn attempt/lineage and is not a
@@ -4353,7 +4371,7 @@ export class AgentSession {
 				};
 				if (settleIfDisposing()) return;
 				try {
-					await this.#awaitStartupTurnBarrier(this.#disposeAbortController.signal);
+					await this.#awaitStartupTurnBarrier(signal ?? this.#disposeAbortController.signal);
 				} catch {
 					settleIfDisposing();
 					return;
@@ -4400,13 +4418,15 @@ export class AgentSession {
 				}
 			},
 			scheduleIdleFlush: run => {
+				// The startup barrier already gates injectIdle, so begin waiting on a
+				// pending barrier immediately. Once readiness has settled, ordinary
+				// idle wakes retain the fixed merge window.
+				const delayMs = this.#startupTurnBarrierPending ? 0 : FOLD_WAKE_MERGE_WINDOW_MS;
 				this.#schedulePostPromptTask(
-					async () => {
-						await run();
+					async signal => {
+						await run(signal);
 					},
-					// One merge window, so staggered completions share a single wake
-					// turn instead of each buying its own.
-					{ delayMs: FOLD_WAKE_MERGE_WINDOW_MS },
+					{ delayMs },
 				);
 			},
 		});

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3352,12 +3352,16 @@ export class AgentSession {
 			const barrier = this.#startupTurnBarrier;
 			if (!barrier) return;
 			await awaitPromptInvocationPreflight(barrier, signal);
-			// Drain chained readiness reactions before clearing the captured
-			// barrier. Extensions publish startup dependencies from promise
-			// reactions; re-reading across a bounded microtask drain preserves that
-			// ordering without introducing a timer into startup admission.
-			for (let reaction = 0; reaction < 16 && this.#startupTurnBarrier === barrier; reaction++) {
-				await Promise.resolve();
+			// Cross one task boundary before clearing readiness. Promise reaction
+			// chains fully drain before timers, so every extension published by the
+			// captured barrier's settlement becomes visible without an arbitrary
+			// microtask-depth cap.
+			const publicationTurn = Promise.withResolvers<void>();
+			const timer = setTimeout(publicationTurn.resolve, 0);
+			try {
+				await awaitPromptInvocationPreflight(publicationTurn.promise, signal);
+			} finally {
+				clearTimeout(timer);
 			}
 			if (this.#startupTurnBarrier !== barrier) continue;
 			this.#setStartupTurnBarrier(undefined);
@@ -13906,12 +13910,14 @@ export class AgentSession {
 			this.#promptPreflightCancellationGeneration++;
 			this.#promptPreflightAbortController.abort();
 			this.#promptPreflightAbortController = new AbortController();
+			this.#drainTerminalOwnedYieldEntries();
+			const overlappingPostPromptDrain = this.#cancelPostPromptTasks();
 			// Abort visibility is per-request: a later real abort must not inherit an
 			// earlier silent abort's suppression and swallow the user-visible notice.
 			if (options?.silent !== true) this.#silentAbortPending = false;
 			// Capture the unwind: the field clears once the first abort settles, and
 			// the awaits below must keep watching THIS unwind, not a successor's.
-			const sharedUnwind = this.#abortUnwind;
+			const sharedUnwind = Promise.all([this.#abortUnwind, overlappingPostPromptDrain]).then(() => {});
 			if (options?.timeoutMs !== undefined) {
 				const timeoutMs = Math.max(0, options.timeoutMs);
 				const deadline = Date.now() + timeoutMs;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -13942,6 +13942,7 @@ export class AgentSession {
 		this.#abortUnwind = unwind.promise;
 		try {
 			this.#abortOptions(options);
+			this.#drainTerminalOwnedYieldEntries();
 			const postPromptDrain = this.#cancelPostPromptTasks();
 			const managedLogicalRunId =
 				this.#defaultFallbackChain().chain.entries.length > 1 ? this.agent.currentManagedLogicalRunId : undefined;

--- a/packages/coding-agent/src/session/yield-queue.ts
+++ b/packages/coding-agent/src/session/yield-queue.ts
@@ -40,6 +40,7 @@ export class YieldQueue {
 	readonly #dispatchers = new Map<string, StoredDispatcher>();
 	readonly #entries = new Map<string, unknown[]>();
 	#idleFlushPending = false;
+	#idleFlushPendingOwner: symbol | undefined;
 
 	constructor(options: YieldQueueOptions) {
 		this.#options = options;
@@ -86,6 +87,7 @@ export class YieldQueue {
 	async flush(mode: YieldFlushMode, signal?: AbortSignal): Promise<void> {
 		if (mode === "idle") {
 			this.#idleFlushPending = false;
+			this.#idleFlushPendingOwner = undefined;
 		}
 		const idleMessages: AgentMessage[] = [];
 		for (const [kind, dispatcher] of this.#dispatchers) {
@@ -119,6 +121,7 @@ export class YieldQueue {
 		}
 		this.#entries.clear();
 		this.#idleFlushPending = false;
+		this.#idleFlushPendingOwner = undefined;
 	}
 
 	/** Drop only the queued entries of a single kind, leaving other kinds intact. */
@@ -144,19 +147,21 @@ export class YieldQueue {
 	#scheduleIdleFlush(): void {
 		if (this.#idleFlushPending) return;
 		this.#idleFlushPending = true;
-		try {
-			this.#options.scheduleIdleFlush(
-				async signal => {
-					this.#idleFlushPending = false;
-					if (this.#options.isStreaming()) return;
-					await this.flush("idle", signal);
-				},
-				() => {
-					this.#idleFlushPending = false;
-				},
-			);
-		} catch (error) {
+		const owner = Symbol("idle-flush");
+		this.#idleFlushPendingOwner = owner;
+		const releaseOwner = () => {
+			if (this.#idleFlushPendingOwner !== owner) return;
+			this.#idleFlushPendingOwner = undefined;
 			this.#idleFlushPending = false;
+		};
+		try {
+			this.#options.scheduleIdleFlush(async signal => {
+				releaseOwner();
+				if (this.#options.isStreaming()) return;
+				await this.flush("idle", signal);
+			}, releaseOwner);
+		} catch (error) {
+			releaseOwner();
 			logger.warn("Yield queue idle flush scheduling failed", { error: formatError(error) });
 		}
 	}

--- a/packages/coding-agent/src/session/yield-queue.ts
+++ b/packages/coding-agent/src/session/yield-queue.ts
@@ -18,8 +18,8 @@ export interface YieldDispatcher<P> {
 export interface YieldQueueOptions {
 	isStreaming: () => boolean;
 	injectStreaming(msg: AgentMessage): void;
-	injectIdle(messages: AgentMessage[]): Promise<void>;
-	scheduleIdleFlush(run: () => Promise<void>): void;
+	injectIdle(messages: AgentMessage[], signal?: AbortSignal): Promise<void>;
+	scheduleIdleFlush(run: (signal?: AbortSignal) => Promise<void>): void;
 }
 
 type YieldFlushMode = "streaming" | "idle";
@@ -82,7 +82,7 @@ export class YieldQueue {
 		return false;
 	}
 
-	async flush(mode: YieldFlushMode): Promise<void> {
+	async flush(mode: YieldFlushMode, signal?: AbortSignal): Promise<void> {
 		if (mode === "idle") {
 			this.#idleFlushPending = false;
 		}
@@ -105,7 +105,7 @@ export class YieldQueue {
 		}
 		if (mode === "idle" && idleMessages.length > 0) {
 			try {
-				await this.#options.injectIdle(idleMessages);
+				await this.#options.injectIdle(idleMessages, signal);
 			} catch (error) {
 				logger.warn("Yield queue idle dispatch failed", { error: formatError(error) });
 			}
@@ -144,10 +144,10 @@ export class YieldQueue {
 		if (this.#idleFlushPending) return;
 		this.#idleFlushPending = true;
 		try {
-			this.#options.scheduleIdleFlush(async () => {
+			this.#options.scheduleIdleFlush(async signal => {
 				this.#idleFlushPending = false;
 				if (this.#options.isStreaming()) return;
-				await this.flush("idle");
+				await this.flush("idle", signal);
 			});
 		} catch (error) {
 			this.#idleFlushPending = false;

--- a/packages/coding-agent/src/session/yield-queue.ts
+++ b/packages/coding-agent/src/session/yield-queue.ts
@@ -19,7 +19,8 @@ export interface YieldQueueOptions {
 	isStreaming: () => boolean;
 	injectStreaming(msg: AgentMessage): void;
 	injectIdle(messages: AgentMessage[], signal?: AbortSignal): Promise<void>;
-	scheduleIdleFlush(run: (signal?: AbortSignal) => Promise<void>): void;
+	scheduleIdleFlush(run: (signal?: AbortSignal) => Promise<void>, onSkip: () => void): void;
+	getIdleFlushSignal?(): AbortSignal | undefined;
 }
 
 type YieldFlushMode = "streaming" | "idle";
@@ -105,7 +106,7 @@ export class YieldQueue {
 		}
 		if (mode === "idle" && idleMessages.length > 0) {
 			try {
-				await this.#options.injectIdle(idleMessages, signal);
+				await this.#options.injectIdle(idleMessages, signal ?? this.#options.getIdleFlushSignal?.());
 			} catch (error) {
 				logger.warn("Yield queue idle dispatch failed", { error: formatError(error) });
 			}
@@ -144,11 +145,16 @@ export class YieldQueue {
 		if (this.#idleFlushPending) return;
 		this.#idleFlushPending = true;
 		try {
-			this.#options.scheduleIdleFlush(async signal => {
-				this.#idleFlushPending = false;
-				if (this.#options.isStreaming()) return;
-				await this.flush("idle", signal);
-			});
+			this.#options.scheduleIdleFlush(
+				async signal => {
+					this.#idleFlushPending = false;
+					if (this.#options.isStreaming()) return;
+					await this.flush("idle", signal);
+				},
+				() => {
+					this.#idleFlushPending = false;
+				},
+			);
 		} catch (error) {
 			this.#idleFlushPending = false;
 			logger.warn("Yield queue idle flush scheduling failed", { error: formatError(error) });

--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -388,9 +388,16 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 	it("admits an explicit prompt before an idle wake released by startup", async () => {
 		authStorage.setRuntimeApiKey("openai", "test-key");
 		const barrier = Promise.withResolvers<void>();
+		const explicitRun = Promise.withResolvers<void>();
+		const promptAccepted = Promise.withResolvers<void>();
 		const { session } = await createAgentSession(createIsolatedSessionOptions());
 		try {
-			const agentPrompt = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+			const agentPrompt = vi.spyOn(session.agent, "prompt").mockImplementation(async (_message, promptOptions) => {
+				if (!Array.isArray(promptOptions)) promptOptions?.onRunAccepted?.(undefined as never, undefined as never);
+				promptAccepted.resolve();
+				await explicitRun.promise;
+			});
+			const followUp = vi.spyOn(session.agent, "followUp");
 			session.extendStartupTurnBarrier(barrier.promise);
 			session.yieldQueue.register<string>("startup-prompt-priority-test", {
 				build: entries => ({ role: "user", content: entries.join("\n"), timestamp: Date.now() }),
@@ -401,13 +408,17 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			expect(agentPrompt).not.toHaveBeenCalled();
 
 			barrier.resolve();
-			await explicit;
-			await session.waitForIdle();
-			expect(agentPrompt).toHaveBeenCalledTimes(2);
+			await promptAccepted.promise;
+			for (let i = 0; i < 10; i++) await Promise.resolve();
+			expect(agentPrompt).toHaveBeenCalledTimes(1);
 			expect(JSON.stringify(agentPrompt.mock.calls[0]?.[0])).toContain("explicit-before-idle");
-			expect(JSON.stringify(agentPrompt.mock.calls[1]?.[0])).toContain("idle-after-explicit");
+			expect(followUp).toHaveBeenCalledTimes(1);
+			expect(JSON.stringify(followUp.mock.calls[0]?.[0])).toContain("idle-after-explicit");
+			explicitRun.resolve();
+			await explicit;
 		} finally {
 			barrier.resolve();
+			explicitRun.resolve();
 			await session.dispose();
 		}
 	});
@@ -1559,60 +1570,64 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 		RESUME_SDK_TEST_TIMEOUT_MS,
 	);
 
-	it("restores fallback MCP, thinking, and service-tier state in memory without rewriting the session file", async () => {
-		const sessionManager = SessionManager.create(tempDir, tempDir);
-		sessionManager.appendMessage({
-			role: "user",
-			content: "resume me",
-			timestamp: Date.now(),
-		});
-		const sessionFile = sessionManager.getSessionFile();
-		expect(sessionFile).toBeDefined();
-		await sessionManager.rewriteEntries();
-		fs.utimesSync(sessionFile!, oldSessionMtime, oldSessionMtime);
-		const persistedBeforeResume = fs.readFileSync(sessionFile!, "utf8");
-		const persistedMtimeBeforeResume = fs.statSync(sessionFile!).mtimeMs;
-		const resumedManager = await SessionManager.open(sessionFile!, tempDir);
-		const { session } = await createAgentSession({
-			cwd: tempDir,
-			agentDir: tempDir,
-			modelRegistry,
-			sessionManager: resumedManager,
-			settings: Settings.isolated({
-				"mcp.discoveryMode": true,
-				"mcp.discoveryDefaultServers": ["github"],
-				defaultThinkingLevel: "high",
-				serviceTier: "priority",
-			}),
-			model: createReasoningModel(),
-			disableExtensionDiscovery: true,
-			skills: [],
-			contextFiles: [],
-			promptTemplates: [],
-			slashCommands: [],
-			enableMCP: false,
-			enableLsp: false,
-			toolNames: ["read", "search_tool_bm25"],
-			customTools: [
-				createMcpCustomTool("mcp__github_create_issue", "github", "create_issue"),
-				createMcpCustomTool("mcp__slack_post_message", "slack", "post_message"),
-			],
-		});
-		try {
-			expect(session.thinkingLevel).toBe(ThinkingLevel.High);
-			expect(session.serviceTier).toBe("priority");
-			expect(session.getSelectedMCPToolNames()).toEqual(["mcp__github_create_issue"]);
-			expect(session.getActiveToolNames()).toEqual(
-				expect.arrayContaining(["read", "search_tool_bm25", "mcp__github_create_issue"]),
-			);
-			expect(session.getActiveToolNames()).not.toContain("mcp__slack_post_message");
-			expect(session.sessionManager.buildSessionContext().hasPersistedMCPToolSelection).toBe(false);
-			expect(fs.readFileSync(sessionFile!, "utf8")).toBe(persistedBeforeResume);
-			expect(fs.statSync(sessionFile!).mtimeMs).toBe(persistedMtimeBeforeResume);
-		} finally {
-			await session.dispose();
-		}
-	}, RESUME_SDK_TEST_TIMEOUT_MS);
+	it(
+		"restores fallback MCP, thinking, and service-tier state in memory without rewriting the session file",
+		async () => {
+			const sessionManager = SessionManager.create(tempDir, tempDir);
+			sessionManager.appendMessage({
+				role: "user",
+				content: "resume me",
+				timestamp: Date.now(),
+			});
+			const sessionFile = sessionManager.getSessionFile();
+			expect(sessionFile).toBeDefined();
+			await sessionManager.rewriteEntries();
+			fs.utimesSync(sessionFile!, oldSessionMtime, oldSessionMtime);
+			const persistedBeforeResume = fs.readFileSync(sessionFile!, "utf8");
+			const persistedMtimeBeforeResume = fs.statSync(sessionFile!).mtimeMs;
+			const resumedManager = await SessionManager.open(sessionFile!, tempDir);
+			const { session } = await createAgentSession({
+				cwd: tempDir,
+				agentDir: tempDir,
+				modelRegistry,
+				sessionManager: resumedManager,
+				settings: Settings.isolated({
+					"mcp.discoveryMode": true,
+					"mcp.discoveryDefaultServers": ["github"],
+					defaultThinkingLevel: "high",
+					serviceTier: "priority",
+				}),
+				model: createReasoningModel(),
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+				toolNames: ["read", "search_tool_bm25"],
+				customTools: [
+					createMcpCustomTool("mcp__github_create_issue", "github", "create_issue"),
+					createMcpCustomTool("mcp__slack_post_message", "slack", "post_message"),
+				],
+			});
+			try {
+				expect(session.thinkingLevel).toBe(ThinkingLevel.High);
+				expect(session.serviceTier).toBe("priority");
+				expect(session.getSelectedMCPToolNames()).toEqual(["mcp__github_create_issue"]);
+				expect(session.getActiveToolNames()).toEqual(
+					expect.arrayContaining(["read", "search_tool_bm25", "mcp__github_create_issue"]),
+				);
+				expect(session.getActiveToolNames()).not.toContain("mcp__slack_post_message");
+				expect(session.sessionManager.buildSessionContext().hasPersistedMCPToolSelection).toBe(false);
+				expect(fs.readFileSync(sessionFile!, "utf8")).toBe(persistedBeforeResume);
+				expect(fs.statSync(sessionFile!).mtimeMs).toBe(persistedMtimeBeforeResume);
+			} finally {
+				await session.dispose();
+			}
+		},
+		RESUME_SDK_TEST_TIMEOUT_MS,
+	);
 
 	it(
 		"rebuilds explicit MCP custom-tool selections when resuming with requested MCP tools",

--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -73,7 +73,7 @@ function createReasoningModel(): Model<"openai-responses"> {
 
 const oldSessionMtime = new Date("2000-01-01T00:00:00.000Z");
 const SLOW_SDK_TEST_TIMEOUT_MS = 15_000;
-const RESUME_SDK_TEST_TIMEOUT_MS = 120_000;
+const FALLBACK_SDK_TEST_TIMEOUT_MS = 30_000;
 const validSixSurfacePluginBundle = path.join(import.meta.dir, "fixtures", "gjc-plugins", "valid-six-surface-bundle");
 const originalAgentDir = getAgentDir();
 
@@ -1598,7 +1598,7 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 				await resumedSession.dispose();
 			}
 		},
-		RESUME_SDK_TEST_TIMEOUT_MS,
+		SLOW_SDK_TEST_TIMEOUT_MS,
 	);
 
 	it(
@@ -1657,7 +1657,7 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 				await session.dispose();
 			}
 		},
-		RESUME_SDK_TEST_TIMEOUT_MS,
+		FALLBACK_SDK_TEST_TIMEOUT_MS,
 	);
 
 	it(
@@ -1721,6 +1721,6 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 				await resumedSession.dispose();
 			}
 		},
-		RESUME_SDK_TEST_TIMEOUT_MS,
+		SLOW_SDK_TEST_TIMEOUT_MS,
 	);
 });

--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -432,12 +432,14 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 				build: entries => ({ role: "user", content: entries.join("\n"), timestamp: Date.now() }),
 			});
 			session.yieldQueue.enqueue("startup-abort-race-test", "abort-race");
+			const directFlush = session.yieldQueue.flush("idle");
 			await Promise.resolve();
 
 			const abort = session.abort();
 			const abortedBeforeDeadline = await Promise.race([abort.then(() => true), Bun.sleep(1_000).then(() => false)]);
 			expect(abortedBeforeDeadline).toBe(true);
 			await abort;
+			await directFlush;
 			expect(agentPrompt).not.toHaveBeenCalled();
 		} finally {
 			barrier.resolve();

--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -73,6 +73,7 @@ function createReasoningModel(): Model<"openai-responses"> {
 
 const oldSessionMtime = new Date("2000-01-01T00:00:00.000Z");
 const SLOW_SDK_TEST_TIMEOUT_MS = 15_000;
+const RESUME_SDK_TEST_TIMEOUT_MS = 120_000;
 const validSixSurfacePluginBundle = path.join(import.meta.dir, "fixtures", "gjc-plugins", "valid-six-surface-bundle");
 const originalAgentDir = getAgentDir();
 
@@ -1555,7 +1556,7 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 				await resumedSession.dispose();
 			}
 		},
-		SLOW_SDK_TEST_TIMEOUT_MS,
+		RESUME_SDK_TEST_TIMEOUT_MS,
 	);
 
 	it("restores fallback MCP, thinking, and service-tier state in memory without rewriting the session file", async () => {
@@ -1611,7 +1612,7 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 		} finally {
 			await session.dispose();
 		}
-	}, 30_000);
+	}, RESUME_SDK_TEST_TIMEOUT_MS);
 
 	it(
 		"rebuilds explicit MCP custom-tool selections when resuming with requested MCP tools",
@@ -1674,6 +1675,6 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 				await resumedSession.dispose();
 			}
 		},
-		SLOW_SDK_TEST_TIMEOUT_MS,
+		RESUME_SDK_TEST_TIMEOUT_MS,
 	);
 });

--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -9,6 +9,7 @@ import { Settings } from "@gajae-code/coding-agent/config/settings";
 import type { CustomTool } from "@gajae-code/coding-agent/extensibility/custom-tools/types";
 import { createAgentSession, type ExtensionFactory } from "@gajae-code/coding-agent/sdk";
 import { ArtifactManager } from "@gajae-code/coding-agent/session/artifacts";
+import { FOLD_WAKE_MERGE_WINDOW_MS } from "@gajae-code/coding-agent/session/fold-coordinator";
 import { SessionManager } from "@gajae-code/coding-agent/session/session-manager";
 import { getAgentDir, logger, Snowflake, setAgentDir } from "@gajae-code/utils";
 import * as z from "zod/v4";
@@ -71,7 +72,7 @@ function createReasoningModel(): Model<"openai-responses"> {
 }
 
 const oldSessionMtime = new Date("2000-01-01T00:00:00.000Z");
-const SLOW_SDK_TEST_TIMEOUT_MS = 15_000;
+const SLOW_SDK_TEST_TIMEOUT_MS = 120_000;
 const validSixSurfacePluginBundle = path.join(import.meta.dir, "fixtures", "gjc-plugins", "valid-six-surface-bundle");
 const originalAgentDir = getAgentDir();
 
@@ -307,6 +308,7 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			mcpConfigPath: path.join(tempDir, "deferred-idle.json"),
 			deferMcpConfigStartup: true,
 		});
+		vi.useFakeTimers();
 		try {
 			const agentPrompt = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
 			session.yieldQueue.register<string>("deferred-mcp-test", {
@@ -314,15 +316,154 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			});
 			const startup = startDeferredMcpConfig!();
 			session.yieldQueue.enqueue("deferred-mcp-test", "background delivery");
-			await Bun.sleep(10);
+			vi.advanceTimersByTime(0);
+			await Promise.resolve();
 			expect(agentPrompt).not.toHaveBeenCalled();
 
 			discovery.resolve(createMcpLoadResult([createMcpCustomTool("mcp__exact_lookup", "exact", "lookup")]));
 			await startup;
-			await Bun.sleep(10);
+			vi.advanceTimersByTime(0);
+			for (let i = 0; i < 10; i++) await Promise.resolve();
 			expect(agentPrompt).toHaveBeenCalledTimes(1);
 		} finally {
+			vi.useRealTimers();
 			await session.dispose();
+		}
+	});
+	it("keeps idle delivery behind startup barriers added during readiness", async () => {
+		const firstBarrier = Promise.withResolvers<void>();
+		const secondBarrier = Promise.withResolvers<void>();
+		const { session } = await createAgentSession(createIsolatedSessionOptions());
+		vi.useFakeTimers();
+		try {
+			const agentPrompt = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+			session.extendStartupTurnBarrier(firstBarrier.promise);
+			session.yieldQueue.register<string>("startup-barrier-race-test", {
+				build: entries => ({ role: "user", content: entries.join("\n"), timestamp: Date.now() }),
+			});
+			session.yieldQueue.enqueue("startup-barrier-race-test", "barrier-race");
+			vi.advanceTimersByTime(0);
+			await Promise.resolve();
+
+			firstBarrier.resolve();
+			session.extendStartupTurnBarrier(secondBarrier.promise);
+			for (let i = 0; i < 5; i++) await Promise.resolve();
+			expect(agentPrompt).not.toHaveBeenCalled();
+
+			secondBarrier.resolve();
+			await session.waitForIdle();
+			expect(agentPrompt).toHaveBeenCalledTimes(1);
+		} finally {
+			firstBarrier.resolve();
+			secondBarrier.resolve();
+			vi.useRealTimers();
+			await session.dispose();
+		}
+	});
+	it("settles an idle wake without prompting when startup readiness rejects", async () => {
+		const barrier = Promise.withResolvers<void>();
+		const { session } = await createAgentSession(createIsolatedSessionOptions());
+		try {
+			const agentPrompt = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+			session.extendStartupTurnBarrier(barrier.promise);
+			session.yieldQueue.register<string>("startup-rejection-test", {
+				build: entries => ({ role: "user", content: entries.join("\n"), timestamp: Date.now() }),
+			});
+			session.yieldQueue.enqueue("startup-rejection-test", "rejected-startup");
+			await Promise.resolve();
+
+			barrier.reject(new Error("startup failed"));
+			await session.waitForIdle();
+			expect(agentPrompt).not.toHaveBeenCalled();
+			expect(session.yieldQueue.has()).toBe(false);
+		} finally {
+			barrier.resolve();
+			await session.dispose();
+		}
+	});
+	it("cancels an idle startup wait when abort is requested", async () => {
+		const barrier = Promise.withResolvers<void>();
+		const { session } = await createAgentSession(createIsolatedSessionOptions());
+		try {
+			const agentPrompt = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+			session.extendStartupTurnBarrier(barrier.promise);
+			session.yieldQueue.register<string>("startup-abort-race-test", {
+				build: entries => ({ role: "user", content: entries.join("\n"), timestamp: Date.now() }),
+			});
+			session.yieldQueue.enqueue("startup-abort-race-test", "abort-race");
+			await Promise.resolve();
+
+			const abort = session.abort();
+			const abortedBeforeDeadline = await Promise.race([abort.then(() => true), Bun.sleep(1_000).then(() => false)]);
+			expect(abortedBeforeDeadline).toBe(true);
+			await abort;
+			expect(agentPrompt).not.toHaveBeenCalled();
+		} finally {
+			barrier.resolve();
+			await session.dispose();
+		}
+	});
+	it("restores the merge window after readiness settles before the first idle wake", async () => {
+		const { session } = await createAgentSession(createIsolatedSessionOptions());
+		vi.useFakeTimers();
+		try {
+			const agentPrompt = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+			session.extendStartupTurnBarrier(Promise.resolve());
+			await Promise.resolve();
+			session.yieldQueue.register<string>("settled-startup-wake-test", {
+				build: entries => ({ role: "user", content: entries.join("\n"), timestamp: Date.now() }),
+			});
+			session.yieldQueue.enqueue("settled-startup-wake-test", "ordinary-wake");
+			await Promise.resolve();
+			expect(agentPrompt).not.toHaveBeenCalled();
+
+			vi.advanceTimersByTime(FOLD_WAKE_MERGE_WINDOW_MS - 1);
+			await Promise.resolve();
+			expect(agentPrompt).not.toHaveBeenCalled();
+			vi.advanceTimersByTime(1);
+			await session.waitForIdle();
+			expect(agentPrompt).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.useRealTimers();
+			await session.dispose();
+		}
+	});
+	it("isolates deferred idle readiness between sessions", async () => {
+		const firstBarrier = Promise.withResolvers<void>();
+		const secondBarrier = Promise.withResolvers<void>();
+		const { session: firstSession } = await createAgentSession(createIsolatedSessionOptions());
+		const { session: secondSession } = await createAgentSession(createIsolatedSessionOptions());
+		vi.useFakeTimers();
+		try {
+			const firstPrompt = vi.spyOn(firstSession.agent, "prompt").mockResolvedValue(undefined);
+			const secondPrompt = vi.spyOn(secondSession.agent, "prompt").mockResolvedValue(undefined);
+			firstSession.extendStartupTurnBarrier(firstBarrier.promise);
+			secondSession.extendStartupTurnBarrier(secondBarrier.promise);
+			for (const [session, kind] of [
+				[firstSession, "first-session-idle"],
+				[secondSession, "second-session-idle"],
+			] as const) {
+				session.yieldQueue.register<string>(kind, {
+					build: entries => ({ role: "user", content: entries.join("\n"), timestamp: Date.now() }),
+				});
+				session.yieldQueue.enqueue(kind, kind);
+			}
+			vi.advanceTimersByTime(0);
+			await Promise.resolve();
+
+			firstBarrier.resolve();
+			await firstSession.waitForIdle();
+			expect(firstPrompt).toHaveBeenCalledTimes(1);
+			expect(secondPrompt).not.toHaveBeenCalled();
+
+			secondBarrier.resolve();
+			await secondSession.waitForIdle();
+			expect(secondPrompt).toHaveBeenCalledTimes(1);
+		} finally {
+			firstBarrier.resolve();
+			secondBarrier.resolve();
+			vi.useRealTimers();
+			await Promise.all([firstSession.dispose(), secondSession.dispose()]);
 		}
 	});
 	it("preserves persisted MCP selections while the deferred catalog is pending", async () => {

--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -309,7 +309,6 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			mcpConfigPath: path.join(tempDir, "deferred-idle.json"),
 			deferMcpConfigStartup: true,
 		});
-		vi.useFakeTimers();
 		try {
 			const agentPrompt = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
 			session.yieldQueue.register<string>("deferred-mcp-test", {
@@ -317,20 +316,16 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			});
 			const startup = startDeferredMcpConfig!();
 			session.yieldQueue.enqueue("deferred-mcp-test", "background delivery");
-			vi.advanceTimersByTime(0);
-			await Promise.resolve();
+			const idleFlush = session.yieldQueue.flush("idle");
+			await Bun.sleep(10);
 			expect(agentPrompt).not.toHaveBeenCalled();
 
 			discovery.resolve(createMcpLoadResult([createMcpCustomTool("mcp__exact_lookup", "exact", "lookup")]));
 			await startup;
-			vi.advanceTimersByTime(0);
-			for (let i = 0; i < 30; i++) await Promise.resolve();
-			expect(agentPrompt).toHaveBeenCalledTimes(1);
-			vi.advanceTimersByTime(FOLD_WAKE_MERGE_WINDOW_MS);
-			await Promise.resolve();
+			await idleFlush;
+			await session.waitForIdle();
 			expect(agentPrompt).toHaveBeenCalledTimes(1);
 		} finally {
-			vi.useRealTimers();
 			await session.dispose();
 		}
 	});
@@ -338,7 +333,6 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 		const firstBarrier = Promise.withResolvers<void>();
 		const secondBarrier = Promise.withResolvers<void>();
 		const { session } = await createAgentSession(createIsolatedSessionOptions());
-		vi.useFakeTimers();
 		try {
 			const agentPrompt = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
 			session.extendStartupTurnBarrier(firstBarrier.promise);
@@ -346,8 +340,8 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 				build: entries => ({ role: "user", content: entries.join("\n"), timestamp: Date.now() }),
 			});
 			session.yieldQueue.enqueue("startup-barrier-race-test", "barrier-race");
-			vi.advanceTimersByTime(0);
-			await Promise.resolve();
+			const idleFlush = session.yieldQueue.flush("idle");
+			await Bun.sleep(10);
 
 			firstBarrier.resolve();
 			session.extendStartupTurnBarrier(secondBarrier.promise);
@@ -355,13 +349,12 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			expect(agentPrompt).not.toHaveBeenCalled();
 
 			secondBarrier.resolve();
-			vi.advanceTimersByTime(0);
+			await idleFlush;
 			await session.waitForIdle();
 			expect(agentPrompt).toHaveBeenCalledTimes(1);
 		} finally {
 			firstBarrier.resolve();
 			secondBarrier.resolve();
-			vi.useRealTimers();
 			await session.dispose();
 		}
 	});
@@ -448,15 +441,46 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			await session.dispose();
 		}
 	});
-	it("restores the merge window after readiness settles before the first idle wake", async () => {
+	it("keeps only post-overlap idle wakes across concurrent aborts", async () => {
+		const abortIdle = Promise.withResolvers<void>();
 		const { session } = await createAgentSession(createIsolatedSessionOptions());
 		vi.useFakeTimers();
 		try {
 			const agentPrompt = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+			vi.spyOn(session.agent, "waitForIdle").mockImplementation(async () => await abortIdle.promise);
+			session.yieldQueue.register<string>("overlapping-abort-idle-test", {
+				build: entries => ({ role: "user", content: entries.join("\n"), timestamp: Date.now() }),
+			});
+
+			session.yieldQueue.enqueue("overlapping-abort-idle-test", "before-first-abort");
+			const firstAbort = session.abort();
+			session.yieldQueue.enqueue("overlapping-abort-idle-test", "between-aborts");
+			const secondAbort = session.abort();
+			session.yieldQueue.enqueue("overlapping-abort-idle-test", "after-second-abort");
+
+			abortIdle.resolve();
+			await Promise.all([firstAbort, secondAbort]);
+			vi.advanceTimersByTime(FOLD_WAKE_MERGE_WINDOW_MS);
+			await session.waitForIdle();
+			expect(agentPrompt).toHaveBeenCalledTimes(1);
+			expect(JSON.stringify(agentPrompt.mock.calls[0]?.[0])).toContain("after-second-abort");
+			expect(JSON.stringify(agentPrompt.mock.calls[0]?.[0])).not.toContain("between-aborts");
+		} finally {
+			abortIdle.resolve();
+			vi.useRealTimers();
+			await session.dispose();
+		}
+	});
+	it("restores the merge window after readiness settles before the first idle wake", async () => {
+		authStorage.setRuntimeApiKey("openai", "test-key");
+		const { session } = await createAgentSession(createIsolatedSessionOptions());
+		try {
+			const agentPrompt = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
 			session.extendStartupTurnBarrier(Promise.resolve());
-			await Promise.resolve();
-			vi.advanceTimersByTime(0);
-			await Promise.resolve();
+			await session.prompt("settle startup readiness");
+			expect(agentPrompt).toHaveBeenCalledTimes(1);
+			agentPrompt.mockClear();
+			vi.useFakeTimers();
 			session.yieldQueue.register<string>("settled-startup-wake-test", {
 				build: entries => ({ role: "user", content: entries.join("\n"), timestamp: Date.now() }),
 			});
@@ -480,7 +504,6 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 		const secondBarrier = Promise.withResolvers<void>();
 		const { session: firstSession } = await createAgentSession(createIsolatedSessionOptions());
 		const { session: secondSession } = await createAgentSession(createIsolatedSessionOptions());
-		vi.useFakeTimers();
 		try {
 			const firstPrompt = vi.spyOn(firstSession.agent, "prompt").mockResolvedValue(undefined);
 			const secondPrompt = vi.spyOn(secondSession.agent, "prompt").mockResolvedValue(undefined);
@@ -495,23 +518,23 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 				});
 				session.yieldQueue.enqueue(kind, kind);
 			}
-			vi.advanceTimersByTime(0);
-			await Promise.resolve();
+			const firstFlush = firstSession.yieldQueue.flush("idle");
+			const secondFlush = secondSession.yieldQueue.flush("idle");
+			await Bun.sleep(10);
 
 			firstBarrier.resolve();
-			vi.advanceTimersByTime(0);
+			await firstFlush;
 			await firstSession.waitForIdle();
 			expect(firstPrompt).toHaveBeenCalledTimes(1);
 			expect(secondPrompt).not.toHaveBeenCalled();
 
 			secondBarrier.resolve();
-			vi.advanceTimersByTime(0);
+			await secondFlush;
 			await secondSession.waitForIdle();
 			expect(secondPrompt).toHaveBeenCalledTimes(1);
 		} finally {
 			firstBarrier.resolve();
 			secondBarrier.resolve();
-			vi.useRealTimers();
 			await Promise.all([firstSession.dispose(), secondSession.dispose()]);
 		}
 	});

--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -72,7 +72,7 @@ function createReasoningModel(): Model<"openai-responses"> {
 }
 
 const oldSessionMtime = new Date("2000-01-01T00:00:00.000Z");
-const SLOW_SDK_TEST_TIMEOUT_MS = 120_000;
+const SLOW_SDK_TEST_TIMEOUT_MS = 15_000;
 const validSixSurfacePluginBundle = path.join(import.meta.dir, "fixtures", "gjc-plugins", "valid-six-surface-bundle");
 const originalAgentDir = getAgentDir();
 
@@ -325,6 +325,9 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			vi.advanceTimersByTime(0);
 			for (let i = 0; i < 10; i++) await Promise.resolve();
 			expect(agentPrompt).toHaveBeenCalledTimes(1);
+			vi.advanceTimersByTime(FOLD_WAKE_MERGE_WINDOW_MS);
+			await Promise.resolve();
+			expect(agentPrompt).toHaveBeenCalledTimes(1);
 		} finally {
 			vi.useRealTimers();
 			await session.dispose();
@@ -376,6 +379,32 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			await session.waitForIdle();
 			expect(agentPrompt).not.toHaveBeenCalled();
 			expect(session.yieldQueue.has()).toBe(false);
+		} finally {
+			barrier.resolve();
+			await session.dispose();
+		}
+	});
+	it("admits an explicit prompt before an idle wake released by startup", async () => {
+		authStorage.setRuntimeApiKey("openai", "test-key");
+		const barrier = Promise.withResolvers<void>();
+		const { session } = await createAgentSession(createIsolatedSessionOptions());
+		try {
+			const agentPrompt = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+			session.extendStartupTurnBarrier(barrier.promise);
+			session.yieldQueue.register<string>("startup-prompt-priority-test", {
+				build: entries => ({ role: "user", content: entries.join("\n"), timestamp: Date.now() }),
+			});
+			session.yieldQueue.enqueue("startup-prompt-priority-test", "idle-after-explicit");
+			const explicit = session.prompt("explicit-before-idle");
+			await Promise.resolve();
+			expect(agentPrompt).not.toHaveBeenCalled();
+
+			barrier.resolve();
+			await explicit;
+			await session.waitForIdle();
+			expect(agentPrompt).toHaveBeenCalledTimes(2);
+			expect(JSON.stringify(agentPrompt.mock.calls[0]?.[0])).toContain("explicit-before-idle");
+			expect(JSON.stringify(agentPrompt.mock.calls[1]?.[0])).toContain("idle-after-explicit");
 		} finally {
 			barrier.resolve();
 			await session.dispose();

--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -324,7 +324,7 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			discovery.resolve(createMcpLoadResult([createMcpCustomTool("mcp__exact_lookup", "exact", "lookup")]));
 			await startup;
 			vi.advanceTimersByTime(0);
-			for (let i = 0; i < 10; i++) await Promise.resolve();
+			for (let i = 0; i < 30; i++) await Promise.resolve();
 			expect(agentPrompt).toHaveBeenCalledTimes(1);
 			vi.advanceTimersByTime(FOLD_WAKE_MERGE_WINDOW_MS);
 			await Promise.resolve();
@@ -355,6 +355,7 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			expect(agentPrompt).not.toHaveBeenCalled();
 
 			secondBarrier.resolve();
+			vi.advanceTimersByTime(0);
 			await session.waitForIdle();
 			expect(agentPrompt).toHaveBeenCalledTimes(1);
 		} finally {
@@ -397,7 +398,7 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 				promptAccepted.resolve();
 				await explicitRun.promise;
 			});
-			const followUp = vi.spyOn(session.agent, "followUp");
+			vi.spyOn(session.agent, "waitForIdle").mockImplementation(async () => await explicitRun.promise);
 			session.extendStartupTurnBarrier(barrier.promise);
 			session.yieldQueue.register<string>("startup-prompt-priority-test", {
 				build: entries => ({ role: "user", content: entries.join("\n"), timestamp: Date.now() }),
@@ -412,10 +413,11 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			for (let i = 0; i < 10; i++) await Promise.resolve();
 			expect(agentPrompt).toHaveBeenCalledTimes(1);
 			expect(JSON.stringify(agentPrompt.mock.calls[0]?.[0])).toContain("explicit-before-idle");
-			expect(followUp).toHaveBeenCalledTimes(1);
-			expect(JSON.stringify(followUp.mock.calls[0]?.[0])).toContain("idle-after-explicit");
 			explicitRun.resolve();
 			await explicit;
+			await session.waitForIdle();
+			expect(agentPrompt).toHaveBeenCalledTimes(2);
+			expect(JSON.stringify(agentPrompt.mock.calls[1]?.[0])).toContain("idle-after-explicit");
 		} finally {
 			barrier.resolve();
 			explicitRun.resolve();
@@ -452,6 +454,8 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 		try {
 			const agentPrompt = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
 			session.extendStartupTurnBarrier(Promise.resolve());
+			await Promise.resolve();
+			vi.advanceTimersByTime(0);
 			await Promise.resolve();
 			session.yieldQueue.register<string>("settled-startup-wake-test", {
 				build: entries => ({ role: "user", content: entries.join("\n"), timestamp: Date.now() }),
@@ -495,11 +499,13 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			await Promise.resolve();
 
 			firstBarrier.resolve();
+			vi.advanceTimersByTime(0);
 			await firstSession.waitForIdle();
 			expect(firstPrompt).toHaveBeenCalledTimes(1);
 			expect(secondPrompt).not.toHaveBeenCalled();
 
 			secondBarrier.resolve();
+			vi.advanceTimersByTime(0);
 			await secondSession.waitForIdle();
 			expect(secondPrompt).toHaveBeenCalledTimes(1);
 		} finally {

--- a/packages/coding-agent/test/session/yield-queue.test.ts
+++ b/packages/coding-agent/test/session/yield-queue.test.ts
@@ -25,7 +25,7 @@ function createHarness(initialStreaming: boolean) {
 	let streaming = initialStreaming;
 	const streamingMessages: AgentMessage[] = [];
 	const idleBatches: AgentMessage[][] = [];
-	const scheduledFlushes: Array<() => Promise<void>> = [];
+	const scheduledFlushes: Array<{ run: () => Promise<void>; onSkip: () => void }> = [];
 	const queue = new YieldQueue({
 		isStreaming: () => streaming,
 		injectStreaming: message => {
@@ -34,8 +34,8 @@ function createHarness(initialStreaming: boolean) {
 		injectIdle: async messages => {
 			idleBatches.push(messages);
 		},
-		scheduleIdleFlush: run => {
-			scheduledFlushes.push(run);
+		scheduleIdleFlush: (run, onSkip) => {
+			scheduledFlushes.push({ run, onSkip });
 		},
 	});
 	return {
@@ -80,10 +80,24 @@ describe("YieldQueue", () => {
 		expect(harness.scheduledFlushes).toHaveLength(1);
 		expect(harness.idleBatches).toHaveLength(0);
 
-		await harness.scheduledFlushes[0]!();
+		await harness.scheduledFlushes[0]!.run();
 
 		expect(harness.idleBatches).toHaveLength(1);
 		expect(harness.idleBatches[0]?.map(messageText)).toEqual(["a,b"]);
+	});
+
+	test("a skipped idle callback releases the debounce latch", () => {
+		const harness = createHarness(false);
+		harness.queue.register<Entry>("items", {
+			build: entries => userMessage(entries.map(entry => entry.id).join(",")),
+		});
+
+		harness.queue.enqueue("items", { id: "a" });
+		expect(harness.scheduledFlushes).toHaveLength(1);
+		harness.scheduledFlushes[0]!.onSkip();
+		harness.queue.enqueue("items", { id: "b" });
+
+		expect(harness.scheduledFlushes).toHaveLength(2);
 	});
 
 	test("isStale drops stale entries and keeps survivors", async () => {

--- a/packages/coding-agent/test/session/yield-queue.test.ts
+++ b/packages/coding-agent/test/session/yield-queue.test.ts
@@ -100,6 +100,26 @@ describe("YieldQueue", () => {
 		expect(harness.scheduledFlushes).toHaveLength(2);
 	});
 
+	test("a stale skipped callback cannot clear newer flush ownership", async () => {
+		const harness = createHarness(false);
+		harness.queue.register<Entry>("items", {
+			build: entries => userMessage(entries.map(entry => entry.id).join(",")),
+		});
+
+		harness.queue.enqueue("items", { id: "aborted" });
+		expect(harness.scheduledFlushes).toHaveLength(1);
+		harness.queue.clear();
+		harness.queue.enqueue("items", { id: "fresh" });
+		expect(harness.scheduledFlushes).toHaveLength(2);
+
+		harness.scheduledFlushes[0]!.onSkip();
+		harness.queue.enqueue("items", { id: "coalesced" });
+		expect(harness.scheduledFlushes).toHaveLength(2);
+
+		await harness.scheduledFlushes[1]!.run();
+		expect(harness.idleBatches[0]?.map(messageText)).toEqual(["fresh,coalesced"]);
+	});
+
 	test("isStale drops stale entries and keeps survivors", async () => {
 		const harness = createHarness(true);
 		let survivorIds: string[] = [];


### PR DESCRIPTION
## What

Repair the successor Dev deferred MCP idle-yield regression on exact `dev@7e1f9f2dcfe2cce1356a07564c9a4075267e7ea5`.

Idle wakes begin readiness immediately while delivery remains behind session admission. Ownership survives accepted prompts, rejection, abort/disposal, scheduler skips, abort-domain replacement, overlapping aborts, chained readiness reactions, and session boundaries.

## Contract preserved

- no callback before readiness; exactly-once delivery afterward
- readiness extensions remain gated through their settlement reaction turn
- rejection and every abort generation terminalize earlier wakes
- post-abort enqueues remain independently schedulable
- disposal cannot publish late tools or idle prompts
- settled readiness restores the 800 ms merge window
- explicit prompts retain admission priority
- sessions remain isolated

## Exact-head evidence

Head: `6ccb70e5c9e0aeabbafe3886d656fd9370873fc2`
Base: `7e1f9f2dcfe2cce1356a07564c9a4075267e7ea5`
Diff: `e881625e7f213458355c2b8493d12c94984aa6386c8de9f2c8f3831064a36079`

- successor shard failure test: 20/20 repeated passes
- sdk-mcp-discovery: 49 pass, 0 fail
- async-yield + yield-queue: 14 pass, 0 fail
- terminal-abort-chain: 39 pass, 0 fail
- fallback-cancel-idle: 8 pass, 0 fail
- coding-agent check: pass; existing repository warnings only
- git diff --check: pass

All prior-head approvals and CI evidence are stale.

## Risk classification

- [ ] `low-risk`
- [x] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:e881625e7f213458355c2b8493d12c94984aa6386c8de9f2c8f3831064a36079 reviewer:human reviewer-id:snowykr evidence:authenticated exact-head approval review 5071325633 plus clean architecture critic adversarial QA and CI
```

Closes #5085