### PR TITLE
fix(coding-agent): validate blob names before filesystem reads

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - An install with no configured model no longer starts on a model its provider has already withdrawn. The startup fallback now applies the configured provider-priority policy, skips bundled defaults disproved by fresh provider discovery, and only then preserves catalog order for remaining candidates. Explicit model and profile selections, enabled-model allowlists, credential selectors, disabled providers, and provider/id collision-safe candidate membership remain unchanged.
 
+### Fixed
+
+- Blob references and filesystem-backed blob reads now accept only exact lowercase SHA-256 names before resolving a disk path; canonical references and valid missing-blob behavior are unchanged.
+
 ## [0.15.6] - 2026-08-30
 
 - Auth metadata remains session-only when a compatibility registry has auth storage but no owner accessor, preventing an unscoped OAuth account lookup from attributing a registry-scoped API-key request to the wrong account.

--- a/packages/coding-agent/src/session/blob-store.ts
+++ b/packages/coding-agent/src/session/blob-store.ts
@@ -6,7 +6,12 @@ import { exactUnlink } from "@gajae-code/natives";
 import { isEnoent, logger, postmortem } from "@gajae-code/utils";
 
 const BLOB_PREFIX = "blob:sha256:";
+const CANONICAL_BLOB_NAME = /^[0-9a-f]{64}$/;
 const TAKE_BLOB_BUFFER_OWNERSHIP = Symbol("takeBlobBufferOwnership");
+
+function isCanonicalBlobHash(hash: string): boolean {
+	return hash.length === 64 && CANONICAL_BLOB_NAME.test(hash);
+}
 
 /**
  * Owner-only permissions for on-disk blob directories and files.
@@ -1126,6 +1131,7 @@ export class BlobStore {
 
 	/** Read blob by hash, returns Buffer or null if not found. */
 	async get(hash: string): Promise<Buffer | null> {
+		if (!isCanonicalBlobHash(hash)) return null;
 		const blobPath = path.join(this.dir, hash);
 		try {
 			const file = Bun.file(blobPath);
@@ -1139,6 +1145,7 @@ export class BlobStore {
 
 	/** Synchronously read blob by hash, returns Buffer or null if not found. */
 	getSync(hash: string): Buffer | null {
+		if (!isCanonicalBlobHash(hash)) return null;
 		const blobPath = path.join(this.dir, hash);
 		try {
 			return fs.readFileSync(blobPath);
@@ -1155,6 +1162,7 @@ export class BlobStore {
 
 	/** Synchronously read blob by hash and verify its content hash; returns null if not found. */
 	getCheckedSync(hash: string): Buffer | null {
+		if (!isCanonicalBlobHash(hash)) return null;
 		const blobPath = path.join(this.dir, hash);
 		try {
 			return verifyBlobFileSync(hash, blobPath);
@@ -1166,6 +1174,7 @@ export class BlobStore {
 
 	/** Check if a blob exists. */
 	async has(hash: string): Promise<boolean> {
+		if (!isCanonicalBlobHash(hash)) return false;
 		try {
 			await fsp.access(path.join(this.dir, hash));
 			return true;
@@ -1321,6 +1330,7 @@ export class EphemeralBlobStore extends BlobStore {
 	}
 
 	getSync(hash: string): Buffer | null {
+		if (!isCanonicalBlobHash(hash)) return null;
 		const cached = this.#bufferCache.get(hash);
 		if (cached) {
 			const blobPath = path.join(this.dir, hash);
@@ -1374,7 +1384,7 @@ export class EphemeralBlobStore extends BlobStore {
 				const blobPath = path.join(this.dir, entry);
 				const stat = fs.lstatSync(blobPath);
 				if (
-					!/^[a-f0-9]{64}$/.test(entry) ||
+					!isCanonicalBlobHash(entry) ||
 					!stat.isFile() ||
 					stat.isSymbolicLink() ||
 					stat.uid !== uid ||
@@ -1534,13 +1544,14 @@ export class ResidentBlobMissingError extends Error {
 
 /** Check if a data string is a blob reference. */
 export function isBlobRef(data: string): boolean {
-	return data.startsWith(BLOB_PREFIX);
+	return parseBlobRef(data) !== null;
 }
 
 /** Extract the SHA-256 hash from a blob reference string. */
 export function parseBlobRef(data: string): string | null {
 	if (!data.startsWith(BLOB_PREFIX)) return null;
-	return data.slice(BLOB_PREFIX.length);
+	const hash = data.slice(BLOB_PREFIX.length);
+	return isCanonicalBlobHash(hash) ? hash : null;
 }
 
 /** Identify provider transport image data URLs so persistence can externalize and restore them losslessly. */
@@ -1731,7 +1742,6 @@ export interface CanonicalBlobEntry {
 	readonly nlink: bigint;
 }
 
-const CANONICAL_BLOB_NAME = /^[0-9a-f]{64}$/;
 const BLOB_REFERENCE = /blob:sha256:([0-9a-f]{64})/g;
 
 /** Longest possible `blob:sha256:<hash>` reference, used to bound chunked scans. */
@@ -1758,7 +1768,7 @@ export async function listCanonicalBlobs(dir: string): Promise<CanonicalBlobEntr
 
 	const entries: CanonicalBlobEntry[] = [];
 	for (const name of names) {
-		if (!CANONICAL_BLOB_NAME.test(name)) continue;
+		if (!isCanonicalBlobHash(name)) continue;
 		const blobPath = path.join(dir, name);
 		let stat: fs.BigIntStats;
 		try {

--- a/packages/coding-agent/test/blob-reference-boundary.test.ts
+++ b/packages/coding-agent/test/blob-reference-boundary.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { BlobStore, EphemeralBlobStore, isBlobRef, parseBlobRef } from "../src/session/blob-store";
+
+const roots: string[] = [];
+const CANONICAL_HASH = "a".repeat(64);
+
+function makeStore(): { root: string; store: BlobStore } {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-blob-ref-boundary-"));
+	roots.push(root);
+	return { root, store: new BlobStore(path.join(root, "blobs")) };
+}
+
+afterEach(() => {
+	for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("canonical blob reference boundary", () => {
+	test("accepts only an exact lowercase SHA-256 reference", () => {
+		const validRef = `blob:sha256:${CANONICAL_HASH}`;
+		expect(isBlobRef(validRef)).toBe(true);
+		expect(parseBlobRef(validRef)).toBe(CANONICAL_HASH);
+
+		for (const invalidRef of [
+			"blob:sha256:",
+			"blob:sha256:abc",
+			`blob:sha256:${"A".repeat(64)}`,
+			`blob:sha256:${CANONICAL_HASH}\n`,
+			`blob:sha256:${CANONICAL_HASH}/child`,
+			"blob:sha256:../sentinel.txt",
+			"blob:sha256:..\\sentinel.txt",
+		]) {
+			expect(isBlobRef(invalidRef)).toBe(false);
+			expect(parseBlobRef(invalidRef)).toBeNull();
+		}
+	});
+
+	test("valid missing hashes retain null and false degradation", async () => {
+		const { store } = makeStore();
+		await expect(store.get(CANONICAL_HASH)).resolves.toBeNull();
+		expect(store.getSync(CANONICAL_HASH)).toBeNull();
+		expect(store.getCheckedSync(CANONICAL_HASH)).toBeNull();
+		await expect(store.has(CANONICAL_HASH)).resolves.toBe(false);
+	});
+
+	test("disk-backed lookups reject noncanonical names before resolving a path", async () => {
+		const { root, store } = makeStore();
+		fs.writeFileSync(path.join(root, "sentinel.txt"), "outside");
+
+		await expect(store.get("../sentinel.txt")).resolves.toBeNull();
+		expect(store.getSync("../sentinel.txt")).toBeNull();
+		expect(store.getCheckedSync("../sentinel.txt")).toBeNull();
+		await expect(store.has("../sentinel.txt")).resolves.toBe(false);
+	});
+
+	test("ephemeral disk-backed lookup rejects noncanonical cache keys", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-blob-ref-ephemeral-"));
+		roots.push(root);
+		const store = new EphemeralBlobStore(path.join(root, "blobs"));
+		fs.writeFileSync(path.join(root, "sentinel.txt"), "outside");
+
+		expect(store.getSync("../sentinel.txt")).toBeNull();
+	});
+});


### PR DESCRIPTION
## What

Require canonical lowercase SHA-256 blob names before parsing references or resolving filesystem-backed blob lookups. Valid references and missing-blob behavior remain unchanged.

## Why

Blob-reference handling should enforce the same canonical filename invariant at every disk-backed read boundary. This keeps malformed names out of path resolution while preserving existing storage and resume contracts.

## Testing

- `bun test packages/coding-agent/test/blob-reference-boundary.test.ts` — 4 passed, 25 assertions
- Related blob/resident suites — 38 passed, 217 assertions
- Changed-file Biome and `git diff --check`
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run build`
- `bun --cwd=packages/natives run build`

## Risk classification

- [ ] `low-risk`
- [ ] `regression-risk`
- [x] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:ac72a434d79b6fb657dc1a93115c1ba5d932fb7314939c99387a6ca003e964a1 reviewer:human reviewer-id:probepark evidence:exact-head-5c3f2bc4-blob-names-validated-before-filesystem-access
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
