### PR TITLE
fix(ai): validate AWS region credential destinations

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Fixed
 
+- Bedrock and both Kiro credential transports now reject malformed project-aware AWS regions before interpolating them into authenticated service authorities. Valid lowercase ASCII region labels and explicit Kiro model `baseUrl` overrides are unchanged.
 - Cursor HTTP/2 streams now drain admitted exec responses before normal teardown and centralize terminal failures, preventing delayed handlers and retained shell callbacks from writing after the request has ended.
 - Auth-gateway boot and dispatch are now provider-scoped: model catalogs reject cross-provider id ambiguity, Codex rows retain `openai-codex-responses`, and requests cannot borrow credentials from another provider.
 - Broker-backed gateway dispatch leases now remain held until the provider's transport-admission boundary, preventing lazy stream construction from releasing authority before outbound dispatch.

--- a/packages/ai/src/adapter-internals/aws-region.ts
+++ b/packages/ai/src/adapter-internals/aws-region.ts
@@ -1,0 +1,13 @@
+const AWS_REGION_LABEL = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+
+/**
+ * Fail closed before an AWS region is interpolated into a credential-bearing
+ * service authority. Region names are one lowercase ASCII DNS label; dots,
+ * URL delimiters, Unicode, whitespace, and controls must never reach URL
+ * parsing as part of that label.
+ */
+export function assertAwsRegionLabel(region: unknown): asserts region is string {
+	if (typeof region !== "string" || !AWS_REGION_LABEL.test(region)) {
+		throw new Error("Invalid AWS region: expected a lowercase ASCII DNS label.");
+	}
+}

--- a/packages/ai/src/adapter-internals/aws-region.ts
+++ b/packages/ai/src/adapter-internals/aws-region.ts
@@ -7,7 +7,8 @@ const AWS_REGION_LABEL = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
  * parsing as part of that label.
  */
 export function assertAwsRegionLabel(region: unknown): asserts region is string {
-	if (typeof region !== "string" || !AWS_REGION_LABEL.test(region)) {
+	const match = typeof region === "string" ? AWS_REGION_LABEL.exec(region) : undefined;
+	if (!match || match[0] !== region) {
 		throw new Error("Invalid AWS region: expected a lowercase ASCII DNS label.");
 	}
 }

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -8,6 +8,7 @@
  */
 
 import { $credentialEnv, $env, $flag, extractHttpStatusFromError, fetchWithRetry } from "@gajae-code/utils";
+import { assertAwsRegionLabel } from "../adapter-internals/aws-region";
 import type { Effort } from "../model-thinking";
 import {
 	mapEffortToAnthropicAdaptiveEffort,
@@ -202,9 +203,10 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 
 		const blocks = output.content as Block[];
 		let rawRequestDump: RawHttpRequestDump | undefined;
-		const region = options.region || $env.AWS_REGION || $env.AWS_DEFAULT_REGION || "us-east-1";
+		const region = options.region ?? $env.AWS_REGION ?? $env.AWS_DEFAULT_REGION ?? "us-east-1";
 
 		try {
+			assertAwsRegionLabel(region);
 			const cacheRetention = resolveCacheRetention(options.cacheRetention);
 			const resolvedToolChoice = resolveToolChoice(model, options.toolChoice);
 			const toolConfig = convertToolConfig(context.tools, resolvedToolChoice.resolvedChoice);
@@ -303,6 +305,7 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 					method: "POST",
 					headers: await buildRequestHeaders(retryBody),
 					body: retryBody,
+					redirect: "error",
 					signal: options.signal,
 					maxAttempts: 1,
 				});
@@ -312,6 +315,7 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 				method: "POST",
 				headers: requestHeaders,
 				body,
+				redirect: "error",
 				signal: options.signal,
 				maxAttempts: resolveRetryBudget(options.requestMaxRetries, 4) + 1,
 			});

--- a/packages/ai/src/providers/aws-credentials.ts
+++ b/packages/ai/src/providers/aws-credentials.ts
@@ -414,6 +414,7 @@ async function readImdsCredentials(parentSignal: AbortSignal | undefined): Promi
 		const tokenRes = await fetch(`http://${IMDS_HOST}/latest/api/token`, {
 			method: "PUT",
 			headers: { "x-aws-ec2-metadata-token-ttl-seconds": "21600" },
+			redirect: "error",
 			signal,
 		});
 		if (!tokenRes.ok) return undefined;
@@ -421,6 +422,7 @@ async function readImdsCredentials(parentSignal: AbortSignal | undefined): Promi
 
 		const roleRes = await fetch(`http://${IMDS_HOST}/latest/meta-data/iam/security-credentials/`, {
 			headers: { "x-aws-ec2-metadata-token": token },
+			redirect: "error",
 			signal,
 		});
 		if (!roleRes.ok) return undefined;
@@ -431,6 +433,7 @@ async function readImdsCredentials(parentSignal: AbortSignal | undefined): Promi
 			`http://${IMDS_HOST}/latest/meta-data/iam/security-credentials/${encodeURIComponent(role)}`,
 			{
 				headers: { "x-aws-ec2-metadata-token": token },
+				redirect: "error",
 				signal,
 			},
 		);

--- a/packages/ai/src/providers/aws-credentials.ts
+++ b/packages/ai/src/providers/aws-credentials.ts
@@ -22,6 +22,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { $env, getTrustedHomeDir, isEnoent, logger } from "@gajae-code/utils";
+import { assertAwsRegionLabel } from "../adapter-internals/aws-region";
 import {
 	type AwsIniFile,
 	classifyAwsProfileCapability,
@@ -155,6 +156,7 @@ async function readSsoCredentials(
 		}
 	}
 	if (!startUrl || !ssoRegion) return undefined;
+	assertAwsRegionLabel(ssoRegion);
 
 	const token = await loadSsoCachedToken(startUrl, sessionName);
 	if (!token?.accessToken) {
@@ -172,6 +174,7 @@ async function readSsoCredentials(
 	const response = await fetch(url, {
 		method: "GET",
 		headers: { "x-amz-sso_bearer_token": token.accessToken },
+		redirect: "error",
 		signal,
 	});
 	if (!response.ok) {

--- a/packages/ai/src/providers/kiro-api-key.ts
+++ b/packages/ai/src/providers/kiro-api-key.ts
@@ -6,6 +6,7 @@
  * AWS SSO OIDC / CodeWhisperer streaming path used by `gjc auth-broker login kiro`.
  */
 import { $env } from "@gajae-code/utils";
+import { assertAwsRegionLabel } from "../adapter-internals/aws-region";
 import { Effort } from "../model-thinking";
 import type {
 	Api,
@@ -53,17 +54,38 @@ export function isKiroApiKey(value: string | undefined): value is string {
 
 export function kiroApiRegion(options?: { region?: string }): string {
 	return (
-		options?.region ||
-		$env.KIRO_API_REGION ||
-		$env.KIRO_REGION ||
-		$env.AWS_REGION ||
-		$env.AWS_DEFAULT_REGION ||
+		options?.region ??
+		$env.KIRO_API_REGION ??
+		$env.KIRO_REGION ??
+		$env.AWS_REGION ??
+		$env.AWS_DEFAULT_REGION ??
 		DEFAULT_REGION
 	);
 }
 
 export function kiroApiBaseUrl(region: string): string {
+	assertAwsRegionLabel(region);
 	return `https://q.${region}.amazonaws.com/`;
+}
+
+function isRegionDerivedKiroApiBaseUrl(baseUrl: string): boolean {
+	try {
+		const url = new URL(baseUrl);
+		const match = /^q\.([a-z0-9-]+)\.amazonaws\.com$/.exec(url.hostname);
+		if (!match) return false;
+		assertAwsRegionLabel(match[1]);
+		return (
+			url.protocol === "https:" &&
+			url.username === "" &&
+			url.password === "" &&
+			url.port === "" &&
+			url.pathname === "/" &&
+			url.search === "" &&
+			url.hash === ""
+		);
+	} catch {
+		return false;
+	}
 }
 
 export function toKiroModelId(modelId: string): string {
@@ -279,12 +301,13 @@ export async function fetchKiroApiModels(
 	apiKey: string,
 	region?: string,
 ): Promise<Model<"kiro-codewhisperer-stream">[]> {
-	const resolvedRegion = region || kiroApiRegion();
+	const resolvedRegion = region ?? kiroApiRegion();
 	const baseUrl = kiroApiBaseUrl(resolvedRegion);
 	const response = await fetch(baseUrl, {
 		method: "POST",
 		headers: kiroApiHeaders(apiKey, LIST_TARGET),
 		body: JSON.stringify({ origin: KIRO_ORIGIN }),
+		redirect: "error",
 		signal: AbortSignal.timeout(15_000),
 	});
 	if (!response.ok) {
@@ -585,8 +608,9 @@ export const streamKiroApiKey: StreamFunction<"kiro-codewhisperer-stream"> = (
 					"Kiro API key missing. Set KIRO_API_KEY to a ksk_ key from https://app.kiro.dev/settings/api-keys.",
 				);
 			}
-			const region = kiroApiRegion(options);
-			const endpoint = model.baseUrl || kiroApiBaseUrl(region);
+			const configuredBaseUrl = model.baseUrl;
+			const usesExplicitBaseUrl = Boolean(configuredBaseUrl) && !isRegionDerivedKiroApiBaseUrl(configuredBaseUrl);
+			const endpoint = configuredBaseUrl || kiroApiBaseUrl(kiroApiRegion(options));
 			const request = buildApiKeyRequest(model, context, options);
 			options?.onPayload?.(request, model, options?.attemptScope);
 
@@ -594,6 +618,7 @@ export const streamKiroApiKey: StreamFunction<"kiro-codewhisperer-stream"> = (
 				method: "POST",
 				headers: { ...kiroApiHeaders(apiKey, CHAT_TARGET), ...(options.headers ?? {}) },
 				body: JSON.stringify(request),
+				...(usesExplicitBaseUrl ? {} : { redirect: "error" as const }),
 				signal: options.signal,
 			});
 			if (!response.ok) {

--- a/packages/ai/src/providers/kiro-codewhisperer.ts
+++ b/packages/ai/src/providers/kiro-codewhisperer.ts
@@ -11,6 +11,7 @@
  * not from any AGPL reference implementation.
  */
 import { $credentialEnv, $env, extractHttpStatusFromError } from "@gajae-code/utils";
+import { assertAwsRegionLabel } from "../adapter-internals/aws-region";
 import type { Effort } from "../model-thinking";
 import type {
 	Api,
@@ -178,9 +179,10 @@ export const streamKiroCodeWhisperer: StreamFunction<"kiro-codewhisperer-stream"
 		};
 
 		const blocks = output.content as Block[];
-		const region = options.region || $env.KIRO_REGION || $env.AWS_REGION || $env.AWS_DEFAULT_REGION || DEFAULT_REGION;
+		const region = options.region ?? $env.KIRO_REGION ?? $env.AWS_REGION ?? $env.AWS_DEFAULT_REGION ?? DEFAULT_REGION;
 
 		try {
+			assertAwsRegionLabel(region);
 			// Resolve bearer token
 			const bearerToken = resolveBearerToken(options.apiKey);
 			if (!bearerToken) {
@@ -222,6 +224,7 @@ export const streamKiroCodeWhisperer: StreamFunction<"kiro-codewhisperer-stream"
 				method: "POST",
 				headers: requestHeaders,
 				body,
+				redirect: "error",
 				signal: options.signal,
 			});
 

--- a/packages/ai/src/utils/oauth/kiro.ts
+++ b/packages/ai/src/utils/oauth/kiro.ts
@@ -493,7 +493,7 @@ function oidcRequestFailure(url: string, response: Response): string {
  * Non-2xx responses without an `error` field still fail closed.
  */
 async function createTokenOnce(url: string, init: RequestInit & { signal?: AbortSignal }): Promise<CreateTokenResult> {
-	const response = await fetch(url, init);
+	const response = await fetch(url, { ...init, redirect: "error" });
 	const rawBody = await response.text();
 	let data: CreateTokenSuccess | CreateTokenError;
 	try {

--- a/packages/ai/src/utils/oauth/kiro.ts
+++ b/packages/ai/src/utils/oauth/kiro.ts
@@ -8,6 +8,7 @@
  * and AWS public documentation, not from any third-party reference.
  */
 import { scheduler } from "node:timers/promises";
+import { assertAwsRegionLabel } from "../../adapter-internals/aws-region";
 import type { OAuthCredentials } from "./types";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -148,6 +149,7 @@ export async function registerClient(
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify(body),
+		redirect: "error",
 		signal,
 	});
 
@@ -195,6 +197,7 @@ export async function startDeviceAuthorization(
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify(body),
+		redirect: "error",
 		signal,
 	});
 
@@ -328,6 +331,7 @@ export async function refreshKiroToken(credentials: OAuthCredentials): Promise<O
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify(body),
+		redirect: "error",
 	});
 
 	const data = (await response.json()) as CreateTokenSuccess | CreateTokenError;
@@ -466,11 +470,12 @@ export function importSsoCacheToken(): OAuthCredentials | undefined {
 // ─────────────────────────────────────────────────────────────────────────────
 
 function ssoOidcEndpoint(region: string, pathSuffix: string): string {
+	assertAwsRegionLabel(region);
 	return `https://oidc.${region}.amazonaws.com${pathSuffix}`;
 }
 
 async function fetchOidc(url: string, init: RequestInit & { signal?: AbortSignal }): Promise<Response> {
-	const response = await fetch(url, init);
+	const response = await fetch(url, { ...init, redirect: "error" });
 	if (!response.ok) {
 		throw new Error(oidcRequestFailure(url, response));
 	}

--- a/packages/ai/test/aws-region-credential-destination.test.ts
+++ b/packages/ai/test/aws-region-credential-destination.test.ts
@@ -9,6 +9,7 @@ const sourceRoot = path.resolve(import.meta.dir, "../src/providers");
 
 type Scenario =
 	| "aws-sso"
+	| "aws-imds"
 	| "bedrock-bearer"
 	| "bedrock-sigv4"
 	| "codewhisperer"
@@ -149,6 +150,23 @@ async function childMain(): Promise<void> {
 			if (forcedToolChoiceProbe && captures.length === 1) {
 				return new Response("validationException: This model does not support forced toolChoice", { status: 400 });
 			}
+			if (!redirectServer && scenario === "aws-imds" && captures.length === 1) {
+				return new Response("imds-test-token", { status: 200 });
+			}
+			if (!redirectServer && scenario === "aws-imds" && captures.length === 2) {
+				return new Response("test-role\n", { status: 200 });
+			}
+			if (!redirectServer && scenario === "aws-imds" && captures.length === 3) {
+				return new Response(
+					JSON.stringify({
+						AccessKeyId: "imds-access-key",
+						SecretAccessKey: "imds-secret-key",
+						Token: "imds-session-token",
+						Expiration: "2099-01-01T00:00:00Z",
+					}),
+					{ status: 200 },
+				);
+			}
 			if (scenario === "kiro-discovered-stream" && captures.length === 1) {
 				return new Response(JSON.stringify({ models: [{ modelId: "test-model" }] }), { status: 200 });
 			}
@@ -205,6 +223,13 @@ async function childMain(): Promise<void> {
 		const { resolveAwsCredentials } = await import(pathToFileURL(path.join(sourceRoot, "aws-credentials.ts")).href);
 		try {
 			await resolveAwsCredentials({ profile: "test-sso", region: "us-east-1" });
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		}
+	} else if (scenario === "aws-imds") {
+		const { resolveAwsCredentials } = await import(pathToFileURL(path.join(sourceRoot, "aws-credentials.ts")).href);
+		try {
+			await resolveAwsCredentials({ profile: "missing", region: "us-east-1" });
 		} catch (cause) {
 			error = cause instanceof Error ? cause.message : String(cause);
 		}
@@ -389,6 +414,7 @@ if (process.argv[2] === CHILD_FLAG) {
 			AWS_SESSION_TOKEN: scenario === "bedrock-sigv4" ? "test-session-token" : "",
 			KIRO_API_KEY: scenario.startsWith("kiro-") ? "ksk_test-secret" : "",
 		};
+		if (scenario === "aws-imds") env.AWS_EC2_METADATA_DISABLED = "false";
 		if (options.source !== "project") env.AWS_REGION = region;
 		const proc = Bun.spawn(
 			[
@@ -422,6 +448,7 @@ if (process.argv[2] === CHILD_FLAG) {
 	describe("AWS region credential destination", () => {
 		test.each([
 			"aws-sso",
+			"aws-imds",
 			"bedrock-bearer",
 			"bedrock-sigv4",
 			"codewhisperer",
@@ -545,6 +572,17 @@ if (process.argv[2] === CHILD_FLAG) {
 			"-us-east-1",
 			"us-east-1-",
 		])("rejects malformed region %p before Kiro API-key discovery", async region => {
+			const result = await probe("kiro-discovery", region);
+			expect(result.fetches).toHaveLength(0);
+			expect(result.error).toBe("Invalid AWS region: expected a lowercase ASCII DNS label.");
+		});
+
+		test.each([
+			"us-east-1\n",
+			"us-east-1\r",
+			"us-east-1\u2028",
+			"us-east-1\u2029",
+		])("rejects a trailing line terminator before Kiro API-key discovery", async region => {
 			const result = await probe("kiro-discovery", region);
 			expect(result.fetches).toHaveLength(0);
 			expect(result.error).toBe("Invalid AWS region: expected a lowercase ASCII DNS label.");

--- a/packages/ai/test/aws-region-credential-destination.test.ts
+++ b/packages/ai/test/aws-region-credential-destination.test.ts
@@ -1,0 +1,624 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const CHILD_FLAG = "--aws-region-credential-destination-probe";
+const sourceRoot = path.resolve(import.meta.dir, "../src/providers");
+
+type Scenario =
+	| "aws-sso"
+	| "bedrock-bearer"
+	| "bedrock-sigv4"
+	| "codewhisperer"
+	| "kiro-discovered-stream"
+	| "kiro-discovery"
+	| "kiro-oidc-device"
+	| "kiro-oidc-poll"
+	| "kiro-oidc-refresh"
+	| "kiro-static-stream"
+	| "kiro-stream";
+
+interface ProbeResult {
+	fetches: Array<{
+		url: string;
+		host: string;
+		authorization: "bearer" | "sigv4" | "none";
+		ssoBearerToken: boolean;
+		target: string | null;
+	}>;
+	error: string | null;
+	redirect?: {
+		initialRequests: number;
+		targetRequests: Array<{
+			authorization: string | null;
+			securityToken: string | null;
+			ssoBearerToken: string | null;
+			target: string | null;
+			body: string;
+		}>;
+	};
+}
+
+const tempDirs: string[] = [];
+
+function model(api: "bedrock-converse-stream" | "kiro-codewhisperer-stream", baseUrl?: string) {
+	return {
+		id: "test-model",
+		name: "Test model",
+		api,
+		provider: api === "bedrock-converse-stream" ? "amazon-bedrock" : "kiro",
+		...(baseUrl ? { baseUrl } : {}),
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8_192,
+		maxTokens: 1_024,
+	};
+}
+
+const context = {
+	messages: [{ role: "user", content: "hello", timestamp: 1 }],
+};
+
+async function consume(
+	stream: AsyncIterable<{ type: string; error?: { errorMessage?: string } }>,
+): Promise<string | null> {
+	let error: string | null = null;
+	for await (const event of stream) {
+		if (event.type === "error") error = event.error?.errorMessage ?? "unknown stream error";
+	}
+	return error;
+}
+
+async function childMain(): Promise<void> {
+	const scenario = process.argv[3] as Scenario;
+	const explicitBaseUrl = process.argv[4] || undefined;
+	const redirectProbe = process.argv[6] === "redirect";
+	const forcedToolChoiceProbe = process.argv[7] === "forced-tool-choice";
+	const probeRegion = process.argv[8] || "us-east-1";
+	let statefulRegionRead = 0;
+	const explicitRegion =
+		process.argv[5] === "explicit-empty"
+			? ""
+			: process.argv[5] === "explicit-stateful"
+				? ({
+						toString: () => (statefulRegionRead++ === 0 ? "us-east-1" : "amazonaws.com@attacker.example/"),
+					} as unknown as string)
+				: undefined;
+	const captures: ProbeResult["fetches"] = [];
+	const nativeFetch = globalThis.fetch;
+	let initialRequests = 0;
+	const targetRequests: NonNullable<ProbeResult["redirect"]>["targetRequests"] = [];
+	const targetServer = redirectProbe
+		? Bun.serve({
+				hostname: "127.0.0.1",
+				port: 0,
+				async fetch(request) {
+					targetRequests.push({
+						authorization: request.headers.get("authorization"),
+						securityToken: request.headers.get("x-amz-security-token"),
+						ssoBearerToken: request.headers.get("x-amz-sso_bearer_token"),
+						target: request.headers.get("x-amz-target") ?? request.headers.get("amzn-x-amz-target"),
+						body: await request.text(),
+					});
+					return scenario === "kiro-stream"
+						? new Response('{"content":"ok"}', { status: 200 })
+						: scenario === "kiro-oidc-poll"
+							? new Response(
+									JSON.stringify({
+										accessToken: "redirect-target-access-token",
+										refreshToken: "redirect-target-refresh-token",
+										expiresIn: 3600,
+										tokenType: "Bearer",
+									}),
+									{ status: 200, headers: { "Content-Type": "application/json" } },
+								)
+							: new Response(JSON.stringify({ models: [{ modelId: "test-model" }] }), { status: 200 });
+				},
+			})
+		: undefined;
+	const redirectServer = redirectProbe
+		? Bun.serve({
+				hostname: "127.0.0.1",
+				port: 0,
+				fetch() {
+					initialRequests++;
+					return Response.redirect(`http://127.0.0.1:${targetServer?.port}/capture`, 307);
+				},
+			})
+		: undefined;
+	globalThis.fetch = Object.assign(
+		async (input: string | URL | Request, init?: RequestInit) => {
+			const url = String(input);
+			const parsed = new URL(url);
+			const headers = new Headers(init?.headers);
+			const authorization = headers.get("authorization") ?? "";
+			captures.push({
+				url,
+				host: parsed.host,
+				authorization: authorization.startsWith("Bearer ")
+					? "bearer"
+					: authorization.startsWith("AWS4-HMAC-SHA256 ")
+						? "sigv4"
+						: "none",
+				ssoBearerToken: headers.has("x-amz-sso_bearer_token"),
+				target: headers.get("x-amz-target") ?? headers.get("amzn-x-amz-target"),
+			});
+			if (forcedToolChoiceProbe && captures.length === 1) {
+				return new Response("validationException: This model does not support forced toolChoice", { status: 400 });
+			}
+			if (scenario === "kiro-discovered-stream" && captures.length === 1) {
+				return new Response(JSON.stringify({ models: [{ modelId: "test-model" }] }), { status: 200 });
+			}
+			if (scenario === "kiro-oidc-refresh" && captures.length === 1) {
+				return new Response(
+					JSON.stringify({
+						clientId: "oidc-client-id",
+						clientSecret: "oidc-client-secret",
+						clientIdIssuedAt: Math.floor(Date.now() / 1000),
+						clientSecretExpiresAt: Math.floor(Date.now() / 1000) + 86_400,
+					}),
+					{ status: 200 },
+				);
+			}
+			if (redirectServer) {
+				return nativeFetch(`http://127.0.0.1:${redirectServer.port}/start`, init);
+			}
+			if (scenario === "kiro-discovery") {
+				return new Response(JSON.stringify({ models: [{ modelId: "test-model" }] }), { status: 200 });
+			}
+			if (scenario === "aws-sso") {
+				return new Response(
+					JSON.stringify({
+						roleCredentials: {
+							accessKeyId: "sso-access-key",
+							secretAccessKey: "sso-secret-key",
+							sessionToken: "sso-session-token",
+							expiration: Date.now() + 60_000,
+						},
+					}),
+					{ status: 200 },
+				);
+			}
+			if (scenario === "kiro-oidc-device") {
+				return new Response(
+					JSON.stringify({
+						deviceCode: "oidc-device-code",
+						userCode: "ABCD-EFGH",
+						verificationUri: "https://example.invalid/verify",
+						interval: 1,
+						expiresIn: 600,
+					}),
+					{ status: 200 },
+				);
+			}
+			if (scenario === "kiro-stream") return new Response('{"content":"ok"}', { status: 200 });
+			return new Response(new Uint8Array(), { status: 200 });
+		},
+		{ preconnect: globalThis.fetch.preconnect },
+	) as typeof globalThis.fetch;
+
+	let error: string | null = null;
+	if (scenario === "aws-sso") {
+		const { resolveAwsCredentials } = await import(pathToFileURL(path.join(sourceRoot, "aws-credentials.ts")).href);
+		try {
+			await resolveAwsCredentials({ profile: "test-sso", region: "us-east-1" });
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		}
+	} else if (scenario === "bedrock-bearer" || scenario === "bedrock-sigv4") {
+		const { streamBedrock } = await import(pathToFileURL(path.join(sourceRoot, "amazon-bedrock.ts")).href);
+		error = await consume(
+			streamBedrock(
+				model("bedrock-converse-stream") as never,
+				(forcedToolChoiceProbe
+					? {
+							...context,
+							tools: [
+								{
+									name: "read",
+									description: "Read",
+									parameters: { type: "object", properties: {}, additionalProperties: false },
+								},
+							],
+						}
+					: context) as never,
+				{
+					maxTokens: 32,
+					region: explicitRegion,
+					requestMaxRetries: 0,
+					...(forcedToolChoiceProbe ? { toolChoice: "required" } : {}),
+				} as never,
+			),
+		);
+	} else if (scenario === "codewhisperer") {
+		const { streamKiroCodeWhisperer } = await import(
+			pathToFileURL(path.join(sourceRoot, "kiro-codewhisperer.ts")).href
+		);
+		error = await consume(
+			streamKiroCodeWhisperer(
+				model("kiro-codewhisperer-stream") as never,
+				context as never,
+				{ apiKey: "oauth-test-secret", region: explicitRegion } as never,
+			),
+		);
+	} else if (scenario === "kiro-discovery") {
+		const { fetchKiroApiModels } = await import(pathToFileURL(path.join(sourceRoot, "kiro-api-key.ts")).href);
+		try {
+			await fetchKiroApiModels("ksk_test-secret", explicitRegion);
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		}
+	} else if (scenario === "kiro-discovered-stream" || scenario === "kiro-static-stream") {
+		const { fetchKiroApiModels, kiroApiStaticModels, streamKiroApiKey } = await import(
+			pathToFileURL(path.join(sourceRoot, "kiro-api-key.ts")).href
+		);
+		try {
+			const catalog =
+				scenario === "kiro-discovered-stream"
+					? await fetchKiroApiModels("ksk_test-secret", "us-east-1")
+					: kiroApiStaticModels();
+			const selected = catalog.find((candidate: { id: string }) => candidate.id === "test-model") ?? catalog[0];
+			error = await consume(
+				streamKiroApiKey(selected as never, context as never, { apiKey: "ksk_test-secret" } as never),
+			);
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		}
+	} else if (scenario === "kiro-oidc-device") {
+		const { startDeviceAuthorization } = await import(
+			pathToFileURL(path.resolve(sourceRoot, "../utils/oauth/kiro.ts")).href
+		);
+		try {
+			await startDeviceAuthorization(probeRegion, "https://view.awsapps.com/start", {
+				clientId: "oidc-client-id",
+				clientSecret: "oidc-client-secret",
+				expiresAt: Date.now() + 60_000,
+			});
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		}
+	} else if (scenario === "kiro-oidc-poll") {
+		const { pollForToken } = await import(pathToFileURL(path.resolve(sourceRoot, "../utils/oauth/kiro.ts")).href);
+		try {
+			await pollForToken(
+				probeRegion,
+				{
+					clientId: "oidc-client-id",
+					clientSecret: "oidc-client-secret",
+					expiresAt: Date.now() + 60_000,
+				},
+				"oidc-device-code",
+				0,
+				2,
+			);
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		}
+	} else if (scenario === "kiro-oidc-refresh") {
+		const { refreshKiroToken, registerClient } = await import(
+			pathToFileURL(path.resolve(sourceRoot, "../utils/oauth/kiro.ts")).href
+		);
+		try {
+			await registerClient("us-east-1", "https://view.awsapps.com/start");
+			await refreshKiroToken({
+				access: "old-access-token",
+				refresh: "oidc-refresh-token",
+				expires: Date.now() - 1,
+			});
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		}
+	} else {
+		const { streamKiroApiKey } = await import(pathToFileURL(path.join(sourceRoot, "kiro-api-key.ts")).href);
+		error = await consume(
+			streamKiroApiKey(
+				model("kiro-codewhisperer-stream", explicitBaseUrl) as never,
+				context as never,
+				{ apiKey: "ksk_test-secret", region: explicitRegion } as never,
+			),
+		);
+	}
+	redirectServer?.stop(true);
+	targetServer?.stop(true);
+	process.stdout.write(
+		`${JSON.stringify({
+			fetches: captures,
+			error,
+			...(redirectProbe ? { redirect: { initialRequests, targetRequests } } : {}),
+		} satisfies ProbeResult)}\n`,
+	);
+}
+
+if (process.argv[2] === CHILD_FLAG) {
+	await childMain();
+} else {
+	afterEach(async () => {
+		await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+	});
+
+	async function probe(
+		scenario: Scenario,
+		region: string,
+		options: {
+			source?: "environment" | "project" | "explicit";
+			explicitBaseUrl?: string;
+			explicitRegionKind?: "empty" | "stateful";
+			redirect?: boolean;
+			forcedToolChoice?: boolean;
+		} = {},
+	): Promise<ProbeResult> {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-aws-region-destination-"));
+		tempDirs.push(cwd);
+		if (options.source === "project") await fs.writeFile(path.join(cwd, ".env"), `AWS_REGION=${region}\n`);
+		const home = path.join(cwd, "home");
+		await fs.mkdir(home);
+		const configPath = path.join(cwd, "aws-config");
+		const credentialsPath = path.join(cwd, "aws-credentials");
+		await fs.writeFile(credentialsPath, "");
+		if (scenario === "aws-sso") {
+			await fs.writeFile(
+				configPath,
+				`[profile test-sso]\nsso_start_url = https://example.awsapps.com/start\nsso_region = ${region}\nsso_account_id = 123456789012\nsso_role_name = TestRole\n`,
+			);
+			const cacheDir = path.join(home, ".aws", "sso", "cache");
+			await fs.mkdir(cacheDir, { recursive: true });
+			await fs.writeFile(
+				path.join(cacheDir, "token.json"),
+				JSON.stringify({
+					startUrl: "https://example.awsapps.com/start",
+					accessToken: "sso-test-bearer-token",
+					expiresAt: "2099-01-01T00:00:00Z",
+				}),
+			);
+		}
+		const env: Record<string, string> = {
+			PATH: process.env.PATH ?? "",
+			HOME: home,
+			USERPROFILE: home,
+			GJC_CONFIG_DIR: path.join(cwd, "config"),
+			GJC_CODING_AGENT_DIR: path.join(cwd, "agent"),
+			AWS_EC2_METADATA_DISABLED: "true",
+			AWS_CONFIG_FILE: configPath,
+			AWS_SHARED_CREDENTIALS_FILE: credentialsPath,
+			AWS_BEARER_TOKEN_BEDROCK: scenario === "bedrock-bearer" ? "bedrock-test-secret" : "",
+			AWS_ACCESS_KEY_ID: scenario === "bedrock-sigv4" ? "test-access-key" : "",
+			AWS_SECRET_ACCESS_KEY: scenario === "bedrock-sigv4" ? "test-secret-key" : "",
+			AWS_SESSION_TOKEN: scenario === "bedrock-sigv4" ? "test-session-token" : "",
+			KIRO_API_KEY: scenario.startsWith("kiro-") ? "ksk_test-secret" : "",
+		};
+		if (options.source !== "project") env.AWS_REGION = region;
+		const proc = Bun.spawn(
+			[
+				process.execPath,
+				import.meta.path,
+				CHILD_FLAG,
+				scenario,
+				options.explicitBaseUrl ?? "",
+				options.explicitRegionKind === "stateful"
+					? "explicit-stateful"
+					: options.source === "explicit"
+						? "explicit-empty"
+						: "",
+				options.redirect ? "redirect" : "",
+				options.forcedToolChoice ? "forced-tool-choice" : "",
+				region,
+			],
+			{ cwd, env, stdout: "pipe", stderr: "pipe" },
+		);
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+		expect(exitCode, stderr).toBe(0);
+		return JSON.parse(stdout.trim()) as ProbeResult;
+	}
+
+	const attackerRegion = "amazonaws.com@attacker.example/";
+
+	describe("AWS region credential destination", () => {
+		test.each([
+			"aws-sso",
+			"bedrock-bearer",
+			"bedrock-sigv4",
+			"codewhisperer",
+			"kiro-discovery",
+			"kiro-stream",
+		] as const)("fails closed instead of following a credential-bearing %s redirect", async scenario => {
+			const result = await probe(scenario, "us-east-1", { redirect: true });
+			expect(result.redirect?.initialRequests).toBeGreaterThan(0);
+			expect(result.redirect?.targetRequests).toHaveLength(0);
+			expect(result.error).not.toBeNull();
+		});
+
+		test("rejects an OIDC authority injection before sending a registered client secret", async () => {
+			const result = await probe("kiro-oidc-device", attackerRegion);
+			expect(result.fetches).toHaveLength(0);
+			expect(result.error).toBe("Invalid AWS region: expected a lowercase ASCII DNS label.");
+		});
+
+		test.each([
+			"kiro-oidc-device",
+			"kiro-oidc-refresh",
+		] as const)("fails closed instead of forwarding %s credentials across a redirect", async scenario => {
+			const result = await probe(scenario, "us-east-1", { redirect: true });
+			expect(result.redirect?.initialRequests).toBe(1);
+			expect(result.redirect?.targetRequests).toHaveLength(0);
+			expect(result.error).not.toBeNull();
+		});
+
+		test("fails closed instead of forwarding pollForToken credentials across a redirect", async () => {
+			const result = await probe("kiro-oidc-poll", "us-east-1", { redirect: true });
+			expect(result.redirect?.initialRequests).toBe(1);
+			expect(result.redirect?.targetRequests).toHaveLength(0);
+			expect(result.error).not.toBeNull();
+		});
+
+		test("rejects an SSO profile authority injection before sending its cached bearer token", async () => {
+			const result = await probe("aws-sso", attackerRegion);
+			expect(result.fetches).toHaveLength(0);
+			expect(result.error).toBe("Invalid AWS region: expected a lowercase ASCII DNS label.");
+		});
+
+		test.each([
+			"kiro-static-stream",
+			"kiro-discovered-stream",
+		] as const)("fails closed when a region-derived %s catalog model receives a redirect", async scenario => {
+			const result = await probe(scenario, "us-east-1", { redirect: true });
+			expect(result.redirect?.initialRequests).toBe(1);
+			expect(result.redirect?.targetRequests).toHaveLength(0);
+			expect(result.error).not.toBeNull();
+		});
+
+		test("fails closed when Bedrock's forced-tool-choice fallback receives a redirect", async () => {
+			const result = await probe("bedrock-sigv4", "us-east-1", {
+				redirect: true,
+				forcedToolChoice: true,
+			});
+			expect(result.fetches).toHaveLength(2);
+			expect(result.redirect?.initialRequests).toBe(1);
+			expect(result.redirect?.targetRequests).toHaveLength(0);
+			expect(result.error).not.toBeNull();
+		});
+
+		test.each([
+			"bedrock-bearer",
+			"bedrock-sigv4",
+			"codewhisperer",
+			"kiro-discovery",
+			"kiro-stream",
+		] as const)("rejects a project-aware authority injection before %s sends credentials", async scenario => {
+			const result = await probe(scenario, attackerRegion, { source: "project" });
+			expect(result.fetches).toHaveLength(0);
+			expect(result.error).toBe("Invalid AWS region: expected a lowercase ASCII DNS label.");
+		});
+
+		test.each([
+			["project", "bedrock-bearer"],
+			["project", "bedrock-sigv4"],
+			["project", "codewhisperer"],
+			["project", "kiro-discovery"],
+			["project", "kiro-stream"],
+			["environment", "bedrock-bearer"],
+			["environment", "bedrock-sigv4"],
+			["environment", "codewhisperer"],
+			["environment", "kiro-discovery"],
+			["environment", "kiro-stream"],
+			["explicit", "bedrock-bearer"],
+			["explicit", "bedrock-sigv4"],
+			["explicit", "codewhisperer"],
+			["explicit", "kiro-discovery"],
+			["explicit", "kiro-stream"],
+		] as const)("rejects an empty %s region before %s sends credentials", async (source, scenario) => {
+			const result = await probe(scenario, "", { source });
+			expect(result.fetches).toHaveLength(0);
+			expect(result.error).toBe("Invalid AWS region: expected a lowercase ASCII DNS label.");
+		});
+
+		test.each([
+			"bedrock-bearer",
+			"bedrock-sigv4",
+			"codewhisperer",
+			"kiro-discovery",
+			"kiro-stream",
+		] as const)("rejects a stateful non-string region before %s sends credentials", async scenario => {
+			const result = await probe(scenario, "us-east-1", {
+				source: "explicit",
+				explicitRegionKind: "stateful",
+			});
+			expect(result.fetches).toHaveLength(0);
+			expect(result.error).toBe("Invalid AWS region: expected a lowercase ASCII DNS label.");
+		});
+
+		test.each([
+			"us-east-1.attacker.example",
+			"us-east-1%2eattacker",
+			"us-east-1/../attacker",
+			"us-east-1@attacker",
+			"US-EAST-1",
+			"us-east-1 ",
+			"us-east-1\t",
+			"us-éast-1",
+			"-us-east-1",
+			"us-east-1-",
+		])("rejects malformed region %p before Kiro API-key discovery", async region => {
+			const result = await probe("kiro-discovery", region);
+			expect(result.fetches).toHaveLength(0);
+			expect(result.error).toBe("Invalid AWS region: expected a lowercase ASCII DNS label.");
+		});
+
+		test.each([
+			[
+				"aws-sso",
+				"us-east-1",
+				"https://portal.sso.us-east-1.amazonaws.com/federation/credentials?account_id=123456789012&role_name=TestRole",
+				"none",
+				null,
+			],
+			[
+				"bedrock-bearer",
+				"us-east-1",
+				"https://bedrock-runtime.us-east-1.amazonaws.com/model/test-model/converse-stream",
+				"bearer",
+				null,
+			],
+			[
+				"bedrock-sigv4",
+				"us-gov-west-1",
+				"https://bedrock-runtime.us-gov-west-1.amazonaws.com/model/test-model/converse-stream",
+				"sigv4",
+				null,
+			],
+			[
+				"codewhisperer",
+				"us-iso-east-1",
+				"https://amazoncodewhispererstreamingservice.us-iso-east-1.amazonaws.com/",
+				"bearer",
+				"AmazonCodeWhispererService.GenerateAssistantResponse",
+			],
+			[
+				"kiro-discovery",
+				"cn-north-1",
+				"https://q.cn-north-1.amazonaws.com/",
+				"bearer",
+				"AmazonCodeWhispererService.ListAvailableModels",
+			],
+			[
+				"kiro-stream",
+				"eu-isoe-west-1",
+				"https://q.eu-isoe-west-1.amazonaws.com/",
+				"bearer",
+				"AmazonCodeWhispererStreamingService.GenerateAssistantResponse",
+			],
+		] as const)("preserves %s credential routing for region %s", async (scenario, region, url, authorization, target) => {
+			const result = await probe(scenario, region);
+			expect(result.error).toBeNull();
+			expect(result.fetches).toHaveLength(1);
+			expect(result.fetches[0]).toMatchObject({ url, authorization, target });
+			if (scenario === "aws-sso") expect(result.fetches[0]?.ssoBearerToken).toBe(true);
+		});
+
+		test("preserves an explicit Kiro model baseUrl without consulting the implicit region", async () => {
+			const result = await probe("kiro-stream", attackerRegion, {
+				explicitBaseUrl: "https://trusted.gateway.example/kiro",
+			});
+			expect(result.error).toBeNull();
+			expect(result.fetches).toEqual([
+				expect.objectContaining({ host: "trusted.gateway.example", authorization: "bearer" }),
+			]);
+		});
+
+		test("preserves redirect handling for an explicitly trusted Kiro model baseUrl", async () => {
+			const result = await probe("kiro-stream", attackerRegion, {
+				explicitBaseUrl: "https://trusted.gateway.example/kiro",
+				redirect: true,
+			});
+			expect(result.redirect?.initialRequests).toBe(1);
+			expect(result.redirect?.targetRequests).toHaveLength(1);
+			expect(result.error).toBeNull();
+		});
+	});
+}


### PR DESCRIPTION
## Finding / reproduction

AWS/Kiro region values can reach authenticated service-authority construction without one shared DNS-label invariant. On current `dev`, malformed, empty, and stateful non-string region values reach multiple Bedrock/Kiro runtime paths, and implicit credential-bearing requests accept redirects.

- Current base: `34ae26f0d74ffc31840e98178672aaaddc663fc2`
- Runtime-equivalent base replay: **8 pass / 49 fail**
- Boundary: untrusted region label → credential-bearing AWS/Kiro network destination and redirect handling

## Root cause

Region validation was distributed or absent at the actual transport consumers. The same value was interpolated independently into Bedrock, AWS SSO, Kiro CodeWhisperer, Kiro API-key, and Kiro OIDC authorities, while fetch redirect policy was not consistently fail-closed.

## Change

- Add one internal ASCII DNS-label validator shared by every region-derived AWS/Kiro consumer.
- Validate before credential resolution, signing, or authenticated dispatch.
- Reject redirects for implicit region-derived credential destinations, including Bedrock retry/fallback and Kiro OAuth polling/refresh.
- Preserve explicitly configured Kiro `model.baseUrl` behavior; it remains outside the implicit region-derived trust boundary.

Each production file is atomic to this finding:

- `adapter-internals/aws-region.ts`: one classifier for every consumer.
- `amazon-bedrock.ts`: bearer/SigV4 authority construction and retry transport.
- `aws-credentials.ts`: SSO federation token destination.
- `kiro-codewhisperer.ts`: OAuth bearer streaming destination.
- `kiro-api-key.ts`: API-key discovery and implicit streaming destination while preserving explicit custom endpoints.
- `utils/oauth/kiro.ts`: OIDC registration, start, poll, and refresh transport.

## Scope

- Changed files: **8**
- Production: **65 additions / 11 deletions** across one package and one trust boundary
- Tests: **624 additions / 0 deletions**
- Generated/docs/changelog: **1 changelog addition; no generated or public-schema edits**
- Total: **690 additions / 11 deletions**

The size warning is test-dominated. Splitting consumers would reopen the same region-to-credential-destination invariant in the intermediate state.

## Contract

Preserved:

- Valid AWS region labels and existing provider selection.
- Explicit Kiro custom `baseUrl` behavior, including its existing redirect semantics.
- Public APIs, configuration keys, storage formats, schemas, and model output shapes.

Intentionally changed:

- Malformed, empty, Unicode, dotted, delimiter-bearing, oversized, or non-string implicit region values fail closed before authenticated transport.
- Implicit region-derived credential requests reject redirects.

No product capability decision is hidden in this patch. Repository policy still requires an authenticated independent exact-head approval before merge.

## Verification

- Base SHA: `34ae26f0d74ffc31840e98178672aaaddc663fc2`
- Head SHA: `4aadc2eee935eb2448cc5726a933a5bacfc1f4bb`
- Exact diff digest: `b062364618bffc32ec3e60f6ffdbc8078ac7ad6fd72677f2eff4b496a5626097`
- Red-on-base: region/destination regression **8 pass / 49 fail**
- Focused exact-head: **82 pass / 0 fail / 246 assertions**
- Affected package paths: **101 pass / 0 fail / 314 assertions**
- Current #5072 integration: tree `a74921f4e088cb38a9d86466d759a6ce4f1aedbd`; **103 pass / 0 fail / 317 assertions**
- Type/lint/check: `bun --cwd=packages/ai run check` passed; two unrelated informational Biome notices in `openai-codex-responses.ts`
- Build/binary/Rust: `bun run build` passed, including Rust/N-API and compiled `dist/gjc`
- Generated/public gates: publish types, public sync, and schemas passed
- `git diff --check`: passed
- Independent review: prior approvals were stale after rebase; fresh exact-head owner review is being recorded for `4aadc2eee935eb2448cc5726a933a5bacfc1f4bb`

Full-suite differential, reported rather than hidden:

- Head full AI suite terminated at **3063 pass / 337 skip / 12 fail**.
- Exact-base full AI suite was nonterminal twice at the same pre-existing tool-choice cache boundary (5+ minutes and 180 seconds), so no base total is claimed.
- Equivalent targeted replay of the four implicated files was **30 pass / 1 fail** on both exact base and exact head.
- The shared failure is the same pre-existing Anthropic cache artifact identity mismatch; the other 11 head-full failures pass in isolated base and head runs. None of the implicated files is in this diff.

## Overlap and integration

- Reviewed current open heads for #4784, #4834, #5027, #5049, #5051, #5071, #5072, #5074, #5087, #5088, #5089, and #5090.
- Attribute-safe merge-tree is clean with #4784, #5049, #5051, #5072, #5087, #5088, #5089, and #5090.
- #5027/#5071 conflicts already exist against current base and are unrelated to this AI-package diff.
- #4834/#5074 add changelog-only overlap introduced by this patch; their production invariants are independent. If either advances first, refresh only the changelog against current `dev` and rerun exact-head evidence.
- #5072 is the adjacent Kiro OAuth overlap. A real combined worktree passed the redirect regression, affected suites, AI check, and full build.

## Known limits / non-goals

- The exact-base full AI suite has no terminal total because it independently hangs; the bounded attempts and targeted base/head differential are recorded above.
- IMDSv2 token, role, and credential requests now reject redirects as part of the credential-destination boundary.
- This PR does not redesign provider configuration, remove custom endpoints, change credential storage, or alter generated/public surfaces.

## Risk classification

- [ ] `low-risk`
- [ ] `regression-risk`
- [x] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:b062364618bffc32ec3e60f6ffdbc8078ac7ad6fd72677f2eff4b496a5626097 reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head-39c0dac6-aws-region-authorities-and-imds-redirects-validated
```

---

- [x] Target branch is `dev`
- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken