### PR TITLE
fix(sdk): enable confirmed operator terminal aborts

### DIFF
--- a/docs/sdk-session-cli.md
+++ b/docs/sdk-session-cli.md
@@ -186,10 +186,15 @@ gjc sdk session raw control <sessionId> \
 ```
 
 The JSON input accepts only operation fields (`mode`, `scope`, `operator`).
-`--confirm` and `--idempotency-key` are control-envelope flags, not JSON fields.
-Omitting confirmation, omitting the key, or supplying `operator:false` fails
-closed without invoking the terminal-abort surface. Non-operator terminal abort
-retains its existing connection-ownership semantics.
+`--confirm` and `--idempotency-key` are CLI authority inputs, not JSON fields.
+The exact `operator:true` shape is routed through the local Broker, which
+revalidates the current endpoint identity and injects a process-bound private
+capability before dispatch. MCP, ACP, notifications, and ordinary SDK endpoint
+requests cannot mint operator authority: copying `operator:true` and
+`confirm:true` into a public control frame is rejected. Omitting confirmation,
+omitting the key, or supplying `operator:false` fails closed without invoking
+the terminal-abort surface. Non-operator terminal abort retains its existing
+connection-ownership semantics.
 
 `session.get_endpoint` is refused unconditionally: endpoint credentials remain
 an SDK-core implementation detail. The raw hatch validates operation names and

--- a/docs/sdk-session-cli.md
+++ b/docs/sdk-session-cli.md
@@ -174,6 +174,23 @@ operation and returns the broker/host response:
   (`session.create`, `session.fork`, `session.resume`, `session.close`,
   `session.delete`, `session.reconcile_uncertain`) require `--idempotency-key`.
 
+A separately connected local controller can stop the active turn and its exact
+owned work with an explicitly confirmed operator abort:
+
+```sh
+gjc sdk session raw control <sessionId> \
+  --op turn.abort \
+  --json-input '{"mode":"terminal","scope":"owned","operator":true}' \
+  --idempotency-key '<unique-key>' \
+  --confirm
+```
+
+The JSON input accepts only operation fields (`mode`, `scope`, `operator`).
+`--confirm` and `--idempotency-key` are control-envelope flags, not JSON fields.
+Omitting confirmation, omitting the key, or supplying `operator:false` fails
+closed without invoking the terminal-abort surface. Non-operator terminal abort
+retains its existing connection-ownership semantics.
+
 `session.get_endpoint` is refused unconditionally: endpoint credentials remain
 an SDK-core implementation detail. The raw hatch validates operation names and
 adapter dispositions up front and never renders endpoint-disclosure results.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Confirmed operator `turn.abort` requests now travel through a dedicated local Broker route instead of trusting caller-supplied `operator:true` and `confirm:true` on ordinary SDK frames. The Broker revalidates the exact live endpoint identity, injects a process-bound private capability, preserves post-send uncertainty, and the host uses one capability-free canonical identity for dispatch idempotency, durable admission, and delivery receipts, so forged, stale, dropped, and replayed requests fail closed consistently across restart boundaries.
+
 - Blob references and filesystem-backed blob reads now accept only exact lowercase SHA-256 names before resolving a disk path; canonical references and valid missing-blob behavior are unchanged.
 
 ## [0.15.6] - 2026-08-30

--- a/packages/coding-agent/src/commands/sdk.ts
+++ b/packages/coding-agent/src/commands/sdk.ts
@@ -849,7 +849,7 @@ class SdkSessionHelp extends Command {
 		"idempotency-key": Flags.string({
 			description: "Caller idempotency key required for lifecycle globals and terminal abort controls",
 		}),
-		confirm: Flags.boolean({ description: "Confirm a destructive SDK control operation" }),
+		confirm: Flags.boolean({ description: "Confirm a destructive local CLI control operation" }),
 		cursor: Flags.string({
 			description: "Raw query continuation cursor, or a saved checkpoint token to resume tail from",
 		}),

--- a/packages/coding-agent/src/commands/sdk.ts
+++ b/packages/coding-agent/src/commands/sdk.ts
@@ -846,7 +846,9 @@ class SdkSessionHelp extends Command {
 		"json-input": Flags.string({ description: "SDK request JSON object" }),
 		"json-input-file": Flags.string({ description: "Read SDK request JSON from a 0600 file" }),
 		"json-input-stdin": Flags.boolean({ description: "Read SDK request JSON from standard input" }),
-		"idempotency-key": Flags.string({ description: "Caller idempotency key required for SDK lifecycle globals" }),
+		"idempotency-key": Flags.string({
+			description: "Caller idempotency key required for lifecycle globals and terminal abort controls",
+		}),
 		confirm: Flags.boolean({ description: "Confirm a destructive SDK control operation" }),
 		cursor: Flags.string({
 			description: "Raw query continuation cursor, or a saved checkpoint token to resume tail from",

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -7,6 +7,11 @@ import type { NativeDirectoryTreeSnapshot } from "@gajae-code/natives";
 import { logger } from "@gajae-code/utils";
 import type { ModelProfileErrorDetails } from "../../config/model-profile-contract";
 import { planLaunchWorktree } from "../../gjc-runtime/launch-worktree";
+import { SdkClient, SdkClientError } from "../client";
+import {
+	BROKER_RUNTIME_ABORT_CAPABILITY_FIELD,
+	BROKER_RUNTIME_CLOSE_CAPABILITY_FIELD,
+} from "../host/control/runtime-gate";
 import { createDefaultSdkHostModelResolver, type SdkHostModelResolver } from "../host/model-pin";
 import {
 	type DirectoryMigrationPolicy,
@@ -274,6 +279,12 @@ function isBrokerResponse(value: unknown): value is BrokerResponse {
 	return typeof value === "object" && value !== null && "ok" in value && typeof value.ok === "boolean";
 }
 
+function objectRecord(value: unknown): Record<string, unknown> | undefined {
+	return value !== null && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
 function normalizeAliasedString(
 	input: Record<string, unknown>,
 	canonical: string,
@@ -387,7 +398,13 @@ function credentialFreeLifecycleResponse(value: unknown): unknown {
 	if (value === null || typeof value !== "object") return value;
 	const output: Record<string, unknown> = {};
 	for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
-		if (key === "token" || key === "url" || (key === "endpoint" && nested !== null && typeof nested === "object"))
+		if (
+			key === BROKER_RUNTIME_ABORT_CAPABILITY_FIELD ||
+			key === BROKER_RUNTIME_CLOSE_CAPABILITY_FIELD ||
+			key === "token" ||
+			key === "url" ||
+			(key === "endpoint" && nested !== null && typeof nested === "object")
+		)
 			continue;
 		output[key] = credentialFreeLifecycleResponse(nested);
 	}
@@ -460,6 +477,90 @@ function sameEndpointRecord(expected: IndexedSession, current: IndexedSession): 
 		current.endpointMtimeMs === expected.endpointMtimeMs &&
 		path.resolve(current.locator.repo) === path.resolve(expected.locator.repo) &&
 		path.resolve(current.locator.stateRoot) === path.resolve(expected.locator.stateRoot)
+	);
+}
+
+const BROKER_SESSION_CONTROL_FIELDS = new Set(["sessionId", "operation", "input", "confirm"]);
+const BROKER_SESSION_CONTROL_ABORT_FIELDS = new Set(["mode", "scope", "operator"]);
+const BROKER_SESSION_CONTROL_TIMEOUT_MS = 10_000;
+
+type BrokerSessionControlRequest = {
+	sessionId: string;
+	abortInput: { mode: "terminal"; scope: "turn" | "owned"; operator: true };
+};
+
+type BrokerSessionControlAuthority = {
+	record: IndexedSession;
+	endpoint: Record<string, unknown>;
+	endpointIdentity: {
+		dev: bigint;
+		ino: bigint;
+		size: bigint;
+		mtimeNs: bigint;
+		ctimeNs: bigint;
+	};
+};
+
+function brokerSessionControlRequest(input: unknown): BrokerSessionControlRequest | BrokerResponse {
+	const frame = objectRecord(input);
+	if (!frame) return error("invalid_input", "session.control input must be an object");
+	for (const key of Object.keys(frame))
+		if (!BROKER_SESSION_CONTROL_FIELDS.has(key))
+			return error("invalid_input", `Unknown session.control field: ${key}`);
+	if (typeof frame.sessionId !== "string" || !isCanonicalSessionId(frame.sessionId))
+		return error("invalid_input", "sessionId must be a canonical safe identifier");
+	if (frame.operation !== "turn.abort") return error("invalid_input", "session.control only supports turn.abort");
+	if (frame.confirm !== true) return error("invalid_input", "session.control requires confirm:true");
+	const abortInput = objectRecord(frame.input);
+	if (!abortInput) return error("invalid_input", "session.control input must be an object");
+	for (const key of Object.keys(abortInput))
+		if (!BROKER_SESSION_CONTROL_ABORT_FIELDS.has(key))
+			return error("invalid_input", `Unknown turn.abort terminal field: ${key}`);
+	if (abortInput.mode !== "terminal") return error("invalid_input", 'turn.abort mode must be "terminal"');
+	const scope = abortInput.scope === undefined ? "turn" : abortInput.scope;
+	if (scope !== "turn" && scope !== "owned")
+		return error("invalid_input", 'turn.abort scope must be "turn" or "owned"');
+	if (abortInput.operator !== true) return error("invalid_input", "session.control requires operator:true");
+	return {
+		sessionId: frame.sessionId,
+		abortInput: { mode: "terminal", scope, operator: true },
+	};
+}
+
+function brokerControlResponse(value: unknown): BrokerResponse {
+	const response = objectRecord(value);
+	if (!response || typeof response.ok !== "boolean")
+		return error("unavailable", "session endpoint returned an invalid control response");
+	if (response.ok)
+		return response.result === undefined
+			? { ok: true }
+			: { ok: true, result: credentialFreeLifecycleResponse(response.result) };
+	const failure = objectRecord(response.error);
+	const code = typeof failure?.code === "string" ? failure.code : "unavailable";
+	const message = typeof failure?.message === "string" ? failure.message : "session endpoint control failed";
+	return { ok: false, error: { code, message } };
+}
+
+function sameSessionControlAuthority(
+	left: BrokerSessionControlAuthority,
+	right: BrokerSessionControlAuthority,
+): boolean {
+	return (
+		sameEndpointRecord(left.record, right.record) &&
+		left.record.processIncarnation === right.record.processIncarnation &&
+		left.record.hostIncarnation === right.record.hostIncarnation &&
+		left.record.lifecycleRequestId === right.record.lifecycleRequestId &&
+		endpointIncarnation(left.record, left.record.sessionId) ===
+			endpointIncarnation(right.record, right.record.sessionId) &&
+		left.endpoint.sessionId === right.endpoint.sessionId &&
+		left.endpoint.pid === right.endpoint.pid &&
+		left.endpoint.url === right.endpoint.url &&
+		left.endpoint.token === right.endpoint.token &&
+		left.endpointIdentity.dev === right.endpointIdentity.dev &&
+		left.endpointIdentity.ino === right.endpointIdentity.ino &&
+		left.endpointIdentity.size === right.endpointIdentity.size &&
+		left.endpointIdentity.mtimeNs === right.endpointIdentity.mtimeNs &&
+		left.endpointIdentity.ctimeNs === right.endpointIdentity.ctimeNs
 	);
 }
 
@@ -1465,6 +1566,139 @@ export class Broker {
 			throw e;
 		}
 	}
+	async #sessionControlAuthority(sessionId: string): Promise<BrokerSessionControlAuthority | BrokerResponse> {
+		await this.index.refresh();
+		const indexed = this.index.listSessions().sessions.find(session => session.sessionId === sessionId);
+		if (
+			!indexed ||
+			!isSessionAuthorityEligible(indexed) ||
+			!indexed.live ||
+			indexed.terminal ||
+			indexed.terminalUncertain
+		)
+			return error("resource_gone", "session endpoint record is gone");
+		if (
+			!Number.isSafeInteger(indexed.endpointGeneration) ||
+			indexed.endpointGeneration <= 0 ||
+			!Number.isSafeInteger(indexed.pid) ||
+			indexed.pid <= 0 ||
+			indexed.endpointMtimeMs === undefined ||
+			!Number.isFinite(indexed.endpointMtimeMs) ||
+			indexed.endpointMtimeMs <= 0 ||
+			typeof indexed.lifecycleRequestId !== "string" ||
+			indexed.lifecycleRequestId.length === 0 ||
+			indexed.lifecycleRequestId.length > 128 ||
+			!/^[A-Za-z0-9._-]+$/u.test(indexed.lifecycleRequestId) ||
+			endpointIncarnation(indexed, indexed.sessionId) === undefined
+		)
+			return error("endpoint_stale", "session endpoint authority is incomplete");
+		let endpointResponse: BrokerResponse;
+		try {
+			endpointResponse = await this.#readEndpoint(indexed, {});
+		} catch {
+			return error("endpoint_stale", "session endpoint is stale");
+		}
+		if (!endpointResponse.ok) return endpointResponse;
+		const endpoint = objectRecord(endpointResponse.result);
+		if (
+			!endpoint ||
+			endpoint.sessionId !== indexed.sessionId ||
+			endpoint.pid !== indexed.pid ||
+			typeof endpoint.url !== "string" ||
+			endpoint.url.length === 0 ||
+			typeof endpoint.token !== "string" ||
+			endpoint.token.length === 0
+		)
+			return error("endpoint_stale", "session endpoint is malformed");
+		try {
+			const endpointIdentity = await fs.lstat(
+				path.join(indexed.locator.stateRoot, "sdk", `${indexed.sessionId}.json`),
+				{ bigint: true },
+			);
+			if (!endpointIdentity.isFile()) return error("endpoint_stale", "session endpoint is not a regular file");
+			return {
+				record: indexed,
+				endpoint,
+				endpointIdentity: {
+					dev: endpointIdentity.dev,
+					ino: endpointIdentity.ino,
+					size: endpointIdentity.size,
+					mtimeNs: endpointIdentity.mtimeNs,
+					ctimeNs: endpointIdentity.ctimeNs,
+				},
+			};
+		} catch (caught) {
+			if ((caught as NodeJS.ErrnoException).code === "ENOENT")
+				return error("resource_gone", "session endpoint record is gone");
+			return error("endpoint_stale", "session endpoint is stale");
+		}
+	}
+	async #sessionControl(input: Record<string, unknown>, idempotencyKey?: string): Promise<BrokerResponse> {
+		if (
+			typeof idempotencyKey !== "string" ||
+			idempotencyKey.length === 0 ||
+			/[\u0000-\u001f\u007f]/u.test(idempotencyKey) ||
+			new TextEncoder().encode(idempotencyKey).length > 128
+		)
+			return error("invalid_input", "idempotencyKey must be a bounded non-empty string");
+		const request = brokerSessionControlRequest(input);
+		if (isBrokerResponse(request)) return request;
+		const target = `session.control\u0000${request.sessionId}`;
+		const previous = this.#chains.get(target) ?? Promise.resolve();
+		let release!: () => void;
+		const current = new Promise<void>(resolve => (release = resolve));
+		const chain = previous.then(() => current);
+		this.#chains.set(target, chain);
+		await previous;
+		try {
+			const authority = await this.#sessionControlAuthority(request.sessionId);
+			if (isBrokerResponse(authority)) return authority;
+			let client: SdkClient;
+			try {
+				client = await SdkClient.connect(authority.endpoint.url as string, authority.endpoint.token as string, {
+					timeoutMs: BROKER_SESSION_CONTROL_TIMEOUT_MS,
+					reconnectAttempts: 0,
+				});
+			} catch (caught) {
+				return caught instanceof SdkClientError
+					? error(caught.code, caught.message)
+					: error("unavailable", "session endpoint is unavailable");
+			}
+			try {
+				const currentAuthority = await this.#sessionControlAuthority(request.sessionId);
+				if (isBrokerResponse(currentAuthority)) return currentAuthority;
+				if (!sameSessionControlAuthority(authority, currentAuthority))
+					return error("endpoint_stale", "session endpoint changed before control dispatch");
+				const response = await client.control(
+					"turn.abort",
+					{
+						...request.abortInput,
+						[BROKER_RUNTIME_ABORT_CAPABILITY_FIELD]: authority.record.lifecycleRequestId,
+					},
+					{
+						confirm: true,
+						idempotencyKey,
+						beforeDispatch: () => {
+							if (!this.runSynchronousEffectWithFreshPublicationAuthority(() => undefined).authorized)
+								throw new SdkClientError("unavailable", "broker publication is unavailable");
+						},
+					},
+				);
+				return brokerControlResponse(response);
+			} catch (caught) {
+				return caught instanceof SdkClientError
+					? error(caught.code, caught.message)
+					: error("unavailable", "session endpoint control is unavailable");
+			} finally {
+				await client.close().catch(() => undefined);
+			}
+		} catch {
+			return error("unavailable", "session control is unavailable");
+		} finally {
+			release();
+			if (this.#chains.get(target) === chain) this.#chains.delete(target);
+		}
+	}
 	#storeSessionListCursor(cursor: SessionListCursor, replacingToken?: string): string | BrokerResponse {
 		const now = Date.now();
 		for (const [token, stored] of this.#sessionListCursors) {
@@ -1541,6 +1775,7 @@ export class Broker {
 		idempotencyKey?: string,
 	): Promise<BrokerResponse> {
 		if (this.#stopping) return error("broker_restarting", "broker is stopping");
+		if (operation === "session.control") return this.#sessionControl(input, idempotencyKey);
 		const fingerprint = lifecycleFingerprint(operation, input);
 		const normalization = normalizeBrokerInput(operation, input);
 		if (isBrokerResponse(normalization)) return normalization;

--- a/packages/coding-agent/src/sdk/cli/session-cli.ts
+++ b/packages/coding-agent/src/sdk/cli/session-cli.ts
@@ -6,7 +6,7 @@ import { getAgentDir } from "@gajae-code/utils";
 import { repo as resolveGitRepository } from "../../utils/git";
 import { ensureBroker } from "../broker/ensure";
 import { lifecycleRequestTimeoutMs } from "../broker/startup-budget";
-import { SdkClientError } from "../client";
+import { readSdkBrokerDiscovery, SdkClient, SdkClientError } from "../client";
 import { createBrokerSessionLifecycleService } from "../lifecycle/broker-client";
 import type {
 	SessionLifecycleMutationRequest,
@@ -24,6 +24,7 @@ import {
 import { adapterDispositionError, findOperation, type OperationKind } from "../protocol/operation-registry";
 import { type SessionAttachment, SessionRouter, SessionRouterError, type SessionRouterFrame } from "../router";
 import { SessionListTraversalError, sessionListPageFromResponse, traverseSessionList } from "../session-list";
+import { SESSION_REQUEST_TIMEOUT_MS } from "../session-reconnect";
 import {
 	type SdkCheckpointRecordV1,
 	type SdkRetentionGapV1,
@@ -585,6 +586,66 @@ export function controlRequestFrame(
 		confirm: args.confirm === true,
 		...(args.idempotencyKey ? { idempotencyKey: args.idempotencyKey } : {}),
 	};
+}
+
+const BROKER_OPERATOR_ABORT_FIELDS = new Set(["mode", "scope", "operator"]);
+
+export function operatorAbortBrokerRequest(
+	sessionId: string,
+	operation: string,
+	input: JsonRecord,
+	args: Pick<SdkSessionCliArgs, "confirm" | "idempotencyKey">,
+): JsonRecord | undefined {
+	if (!Object.hasOwn(input, "operator")) return undefined;
+	if (operation !== "turn.abort")
+		throw new SdkSessionCliError("invalid_input", "operator is only available for terminal turn.abort.", 2);
+	if (input.operator !== true)
+		throw new SdkSessionCliError("invalid_input", "turn.abort operator must be true when provided.", 2);
+	if (input.mode !== "terminal")
+		throw new SdkSessionCliError("invalid_input", 'operator turn.abort requires mode:"terminal".', 2);
+	for (const key of Object.keys(input))
+		if (!BROKER_OPERATOR_ABORT_FIELDS.has(key))
+			throw new SdkSessionCliError(`invalid_input`, `Unknown turn.abort terminal field: ${key}`, 2);
+	if (input.scope !== undefined && input.scope !== "turn" && input.scope !== "owned")
+		throw new SdkSessionCliError("invalid_input", 'operator turn.abort scope must be "turn" or "owned".', 2);
+	if (args.confirm !== true)
+		throw new SdkSessionCliError("invalid_input", "operator terminal abort requires --confirm.", 2);
+	if (!args.idempotencyKey)
+		throw new SdkSessionCliError("invalid_input", "operator terminal abort requires --idempotency-key.", 2);
+	return { sessionId, operation: "turn.abort", input, confirm: true };
+}
+
+async function requestBrokerOperatorAbort(
+	agentDir: string,
+	request: JsonRecord,
+	args: SdkSessionCliArgs,
+): Promise<JsonRecord> {
+	const idempotencyKey = args.idempotencyKey;
+	if (!idempotencyKey)
+		throw new SdkSessionCliError("invalid_input", "operator terminal abort requires --idempotency-key.", 2);
+	const discovery = await readSdkBrokerDiscovery(agentDir);
+	if (!discovery) throw new SdkSessionCliError("session_unavailable", "SDK broker discovery is unavailable.", 1);
+	const timeoutMs = args.timeoutMs ?? SESSION_REQUEST_TIMEOUT_MS;
+	const client = await SdkClient.connect(discovery.url, discovery.token, {
+		timeoutMs,
+		reconnectAttempts: 0,
+	});
+	try {
+		const response = await client.global("session.control", request, {
+			idempotencyKey,
+			timeoutMs,
+		});
+		const result = object(response);
+		if (!result) throw new SdkClientError("protocol_error", "SDK broker returned a malformed control response.");
+		throwResponseFailure(result);
+		return result;
+	} finally {
+		await client.close().catch(error => {
+			process.stderr.write(
+				`SDK broker control cleanup failed: ${error instanceof Error ? error.message : String(error)}\n`,
+			);
+		});
+	}
 }
 
 async function requestQuery(
@@ -1428,6 +1489,8 @@ async function runRawControl(
 	const invalid = validateAdapterControl(operation, input);
 	if (invalid) throw new SdkSessionCliError(invalid.code, invalid.message, 2);
 	await ensureBroker({ agentDir });
+	const operatorRequest = operatorAbortBrokerRequest(sessionId, operation, input, args);
+	if (operatorRequest) return await requestBrokerOperatorAbort(agentDir, operatorRequest, args);
 	return await withRouter(agentDir, async router => await requestControl(router, sessionId, operation, input, args));
 }
 

--- a/packages/coding-agent/src/sdk/cli/session-cli.ts
+++ b/packages/coding-agent/src/sdk/cli/session-cli.ts
@@ -563,13 +563,28 @@ async function requestControl(
 	const attachment = attachmentFor(router, sessionId);
 	const response = await router.request(
 		sessionId,
-		{ type: "control_request", operation, input, confirm: args.confirm === true },
+		controlRequestFrame(operation, input, args),
 		attachment.generation,
 		attachment,
 		args.timeoutMs === undefined ? undefined : { timeoutMs: args.timeoutMs },
 	);
 	throwResponseFailure(response);
 	return response;
+}
+
+/** Builds the public CLI control envelope without leaking envelope fields into operation input. */
+export function controlRequestFrame(
+	operation: string,
+	input: JsonRecord,
+	args: Pick<SdkSessionCliArgs, "confirm" | "idempotencyKey">,
+): JsonRecord {
+	return {
+		type: "control_request",
+		operation,
+		input,
+		confirm: args.confirm === true,
+		...(args.idempotencyKey ? { idempotencyKey: args.idempotencyKey } : {}),
+	};
 }
 
 async function requestQuery(

--- a/packages/coding-agent/src/sdk/host/control/dispatch.ts
+++ b/packages/coding-agent/src/sdk/host/control/dispatch.ts
@@ -164,14 +164,18 @@ function normalizeTerminalAbortInputForHash(input: unknown): unknown {
 	for (const key of Object.keys(record)) if (!TERMINAL_ABORT_FIELDS.has(key)) return input;
 	const scope = record.scope;
 	if (scope !== undefined && scope !== "turn" && scope !== "owned") return input;
-	return { mode: "terminal", scope: scope === undefined ? "turn" : scope };
+	return {
+		mode: "terminal",
+		scope: scope === undefined ? "turn" : scope,
+		...(record.operator === true ? { operator: true } : {}),
+	};
 }
 
 function text(input: ControlInput, key = "text"): string {
 	return input[key] as string;
 }
 
-const TERMINAL_ABORT_FIELDS = new Set(["mode", "scope"]);
+const TERMINAL_ABORT_FIELDS = new Set(["mode", "scope", "operator"]);
 
 function invalidInput(message: string): never {
 	throw new TypedControlError("invalid_input", message);
@@ -184,15 +188,22 @@ function invalidInput(message: string): never {
  * input is dropped and the ordinary argument-less `surface.abort()` runs.
  *
  * Terminal mode (`mode:"terminal"`) is validated strictly and side-effect-free
- * before any surface call: only `mode`/`scope` fields are accepted, `scope`
- * must be `"turn"` or `"owned"` (default `"turn"`), and a nonempty idempotency
- * key of at most 128 UTF-8 bytes is required on the request envelope. Terminal
- * semantics (see the approved plan): stop the root worker's current turn and
- * block only its own continuation routes; left-running owned work keeps
- * running and its completions are delivered normally so the root worker can
- * resume with a fresh attempt — owned delivery is NOT suppressed.
+ * before any surface call: only `mode`/`scope`/`operator` fields are accepted,
+ * `scope` must be `"turn"` or `"owned"` (default `"turn"`), and a nonempty
+ * idempotency key of at most 128 UTF-8 bytes is required on the request envelope.
+ * A cross-connection local operator must set `operator:true` and confirm the
+ * destructive control request explicitly. Terminal semantics (see the approved
+ * plan) always stop the root worker's current turn. `scope:"turn"` leaves owned
+ * work running so its completion can resume the root worker; `scope:"owned"`
+ * additionally requires exact causal proof and stops that owned work. Operator
+ * authority changes only connection ownership, never those settlement proofs.
  */
-function invokeAbort(surface: ControlSurface, input: ControlInput, idempotencyKey: string | undefined): ControlValue {
+function invokeAbort(
+	surface: ControlSurface,
+	input: ControlInput,
+	confirm: boolean | undefined,
+	idempotencyKey: string | undefined,
+): ControlValue {
 	const mode = input.mode === undefined ? "turn" : input.mode;
 	if (mode === "turn") return surface.abort();
 	if (mode !== "terminal") invalidInput('turn.abort mode must be "turn" or "terminal".');
@@ -200,12 +211,18 @@ function invokeAbort(surface: ControlSurface, input: ControlInput, idempotencyKe
 		if (!TERMINAL_ABORT_FIELDS.has(key)) invalidInput(`Unknown turn.abort terminal field: ${key}`);
 	const scope = input.scope === undefined ? "turn" : input.scope;
 	if (scope !== "turn" && scope !== "owned") invalidInput('turn.abort terminal scope must be "turn" or "owned".');
+	if (input.operator !== undefined && input.operator !== true)
+		invalidInput("turn.abort terminal operator must be true when provided.");
+	if (input.operator === true && confirm !== true) invalidInput("operator terminal abort requires confirm:true.");
 	if (typeof idempotencyKey !== "string" || idempotencyKey.length === 0)
 		invalidInput("terminal abort requires a nonempty idempotency key.");
 	if (new TextEncoder().encode(idempotencyKey).length > 128)
 		invalidInput("terminal abort idempotency key must be at most 128 UTF-8 bytes.");
 	if (!surface.abortTerminal) invalidInput("terminal abort is not supported by this surface.");
-	return surface.abortTerminal({ mode: "terminal", scope }, idempotencyKey);
+	return surface.abortTerminal(
+		{ mode: "terminal", scope, ...(input.operator === true ? { operator: true } : {}) },
+		idempotencyKey,
+	);
 }
 function invoke(
 	surface: ControlSurface,
@@ -222,7 +239,7 @@ function invoke(
 		case "turn.follow_up":
 			return surface.followUp(text(input));
 		case "turn.abort":
-			return invokeAbort(surface, input, idempotencyKey);
+			return invokeAbort(surface, input, confirm, idempotencyKey);
 		case "turn.abort_and_prompt":
 			return surface.abortAndPrompt(text(input));
 		case "ask.answer":

--- a/packages/coding-agent/src/sdk/host/control/dispatch.ts
+++ b/packages/coding-agent/src/sdk/host/control/dispatch.ts
@@ -6,7 +6,12 @@ import {
 import { validateRequiredPromptText } from "../../protocol/adapter-validation";
 import { OPERATIONS, type Operation } from "../../protocol/operation-registry";
 import type { ControlInput, ControlSurface, ControlValue } from "./operations";
-import { brokerRuntimeCloseCapability, hasBrokerRuntimeCloseCapability } from "./runtime-gate";
+import {
+	BROKER_RUNTIME_ABORT_CAPABILITY_FIELD,
+	brokerRuntimeCloseCapability,
+	hasBrokerRuntimeAbortCapability,
+	hasBrokerRuntimeCloseCapability,
+} from "./runtime-gate";
 
 export interface ControlRequest {
 	id: string;
@@ -149,26 +154,28 @@ function inputHash(input: unknown): string {
 		.update(JSON.stringify(canonicalize(input)))
 		.digest("hex");
 }
-/**
- * Normalize a WELL-FORMED terminal abort input for the idempotency hash:
- * omitted scope defaults to "turn", so `{mode:"terminal"}` and
- * `{mode:"terminal", scope:"turn"}` share one idempotency key (the durable
- * terminal-scope replay hashes the same normalized payload). Malformed
- * inputs (unknown fields, invalid mode/scope) are left raw so they are
- * rejected downstream and never collide with a valid input's key.
- */
-function normalizeTerminalAbortInputForHash(input: unknown): unknown {
-	if (typeof input !== "object" || input === null) return input;
-	const record = input as Record<string, unknown>;
-	if (record.mode !== "terminal") return input;
-	for (const key of Object.keys(record)) if (!TERMINAL_ABORT_FIELDS.has(key)) return input;
-	const scope = record.scope;
-	if (scope !== undefined && scope !== "turn" && scope !== "owned") return input;
-	return {
-		mode: "terminal",
-		scope: scope === undefined ? "turn" : scope,
-		...(record.operator === true ? { operator: true } : {}),
+
+export interface TerminalAbortIdentity {
+	input: { mode: "terminal"; scope: "turn" | "owned"; operator?: true };
+	inputHash: string;
+}
+
+/** One strict, capability-free identity shared by dispatch, durable admission, and delivery observation. */
+export function terminalAbortIdentity(input: unknown, operatorAuthorized: boolean): TerminalAbortIdentity | undefined {
+	if (!isInput(input) || input.mode !== "terminal") return undefined;
+	for (const key of Object.keys(input)) if (!TERMINAL_ABORT_FIELDS.has(key)) return undefined;
+	let scope: "turn" | "owned";
+	if (input.scope === undefined || input.scope === "turn") scope = "turn";
+	else if (input.scope === "owned") scope = "owned";
+	else return undefined;
+	if (input.operator !== undefined && input.operator !== true) return undefined;
+	if (input.operator === true && !operatorAuthorized) return undefined;
+	const normalized = {
+		mode: "terminal" as const,
+		scope,
+		...(input.operator === true ? { operator: true as const } : {}),
 	};
+	return { input: normalized, inputHash: inputHash(normalized) };
 }
 
 function text(input: ControlInput, key = "text"): string {
@@ -191,12 +198,13 @@ function invalidInput(message: string): never {
  * before any surface call: only `mode`/`scope`/`operator` fields are accepted,
  * `scope` must be `"turn"` or `"owned"` (default `"turn"`), and a nonempty
  * idempotency key of at most 128 UTF-8 bytes is required on the request envelope.
- * A cross-connection local operator must set `operator:true` and confirm the
- * destructive control request explicitly. Terminal semantics (see the approved
- * plan) always stop the root worker's current turn. `scope:"turn"` leaves owned
- * work running so its completion can resume the root worker; `scope:"owned"`
- * additionally requires exact causal proof and stops that owned work. Operator
- * authority changes only connection ownership, never those settlement proofs.
+ * A cross-connection local operator must arrive through the Broker route with a
+ * private lifecycle capability, set `operator:true`, and confirm the destructive
+ * control request explicitly. Terminal semantics (see the approved plan) always
+ * stop the root worker's current turn. `scope:"turn"` leaves owned work running
+ * so its completion can resume the root worker; `scope:"owned"` additionally
+ * requires exact causal proof and stops that owned work. Operator authority
+ * changes only connection ownership, never those settlement proofs.
  */
 function invokeAbort(
 	surface: ControlSurface,
@@ -421,11 +429,7 @@ function idempotent(
 	const now = Date.now();
 	for (const [key, entry] of requests) if (entry.expiresAt <= now) requests.delete(key);
 	const key = `${row.sdkId}\u0000${request.idempotencyKey}`;
-	// Terminal abort normalizes the omitted scope BEFORE hashing so the
-	// defaulted and explicit shapes share one idempotency key (and reach the
-	// durable terminal-scope replay on eviction); malformed inputs stay raw.
-	const hashInput = row.sdkId === "turn.abort" ? normalizeTerminalAbortInputForHash(request.input) : request.input;
-	const hash = inputHash(hashInput);
+	const hash = inputHash(request.input);
 	const existing = requests.get(key);
 	if (existing) {
 		requests.delete(key);
@@ -462,12 +466,30 @@ export function dispatchControl(
 			failure(request.id, "unknown_operation", `Unknown control operation: ${request.operation}.`),
 		);
 	const brokerCloseAuthorized = row.sdkId === "session.close" && hasBrokerRuntimeCloseCapability(request.input);
+	const brokerAbortInput = row.sdkId === "turn.abort" && isInput(request.input) ? request.input : undefined;
+	const brokerAbortFieldPresent =
+		brokerAbortInput !== undefined && Object.hasOwn(brokerAbortInput, BROKER_RUNTIME_ABORT_CAPABILITY_FIELD);
+	const brokerAbortAuthorized = row.sdkId === "turn.abort" && hasBrokerRuntimeAbortCapability(request.input);
 	if (BROKER_LIFECYCLE_CONTROL_OPERATIONS.has(row.sdkId) && !brokerCloseAuthorized)
 		return Promise.resolve(
 			failure(
 				request.id,
 				"operation_prohibited",
 				`${request.operation} is available only through the Broker lifecycle service.`,
+			),
+		);
+	if (!isInput(request.input))
+		return Promise.resolve(failure(request.id, "invalid_input", "Control input must be an object."));
+	if (
+		row.sdkId === "turn.abort" &&
+		((brokerAbortFieldPresent && !brokerAbortAuthorized) ||
+			(request.input.operator === true && !brokerAbortAuthorized))
+	)
+		return Promise.resolve(
+			failure(
+				request.id,
+				"operation_prohibited",
+				"Operator terminal aborts are available only through the Broker control route.",
 			),
 		);
 	if (
@@ -478,20 +500,42 @@ export function dispatchControl(
 		return Promise.resolve(
 			failure(request.id, "operation_not_session_owned", `${request.operation} is not installed for this session.`),
 		);
-	if (!isInput(request.input))
-		return Promise.resolve(failure(request.id, "invalid_input", "Control input must be an object."));
-	const promptError = validateRequiredPromptText(row.sdkId, request.input);
+	let dispatchRequest: ControlRequest = request;
+	if (row.sdkId === "turn.abort" && request.input.mode === "terminal") {
+		const publicInput = brokerAbortInput
+			? (() => {
+					const { [BROKER_RUNTIME_ABORT_CAPABILITY_FIELD]: _capability, ...input } = brokerAbortInput;
+					return input;
+				})()
+			: request.input;
+		const identity = terminalAbortIdentity(publicInput, brokerAbortAuthorized);
+		if (!identity)
+			return Promise.resolve(failure(request.id, "invalid_input", "Terminal turn.abort input is malformed."));
+		if (identity.input.operator === true && request.confirm !== true)
+			return Promise.resolve(failure(request.id, "invalid_input", "operator terminal abort requires confirm:true."));
+		if (typeof request.idempotencyKey !== "string" || request.idempotencyKey.length === 0)
+			return Promise.resolve(
+				failure(request.id, "invalid_input", "terminal abort requires a nonempty idempotency key."),
+			);
+		if (new TextEncoder().encode(request.idempotencyKey).length > 128)
+			return Promise.resolve(
+				failure(request.id, "invalid_input", "terminal abort idempotency key must be at most 128 UTF-8 bytes."),
+			);
+		dispatchRequest = { ...request, input: identity.input };
+	}
+	const promptError = validateRequiredPromptText(row.sdkId, dispatchRequest.input as ControlInput);
 	if (promptError) return Promise.resolve(failure(request.id, promptError.code, promptError.message));
 	if ((row.sdkId === "context.clear" || row.sdkId === "session.delete") && request.confirm !== true)
 		return Promise.resolve(
 			failure(request.id, "invalid_input", "confirm: true is required for this destructive operation."),
 		);
-	const work = () => execute(surface, row, request);
+	const work = () => execute(surface, row, dispatchRequest);
 	if (row.sdkId === "turn.abort_and_prompt") {
 		const cancellable = surface as PreflightCancellableSurface;
 		if (Object.hasOwn(cancellable, "cancelPendingPreflights")) cancellable.cancelPendingPreflights?.();
 		return serialize(surface, work);
 	}
-	if (row.idempotency === "idempotent" && request.idempotencyKey) return idempotent(surface, row, request, work);
+	if (row.idempotency === "idempotent" && dispatchRequest.idempotencyKey)
+		return idempotent(surface, row, dispatchRequest, work);
 	return row.idempotency === "ordered" && row.sdkId !== "retry.now" ? serialize(surface, work) : work();
 }

--- a/packages/coding-agent/src/sdk/host/control/index.ts
+++ b/packages/coding-agent/src/sdk/host/control/index.ts
@@ -6,6 +6,8 @@ export {
 	type ControlResponse,
 	controlRequestFromFrame,
 	dispatchControl,
+	type TerminalAbortIdentity,
 	TypedControlError,
+	terminalAbortIdentity,
 } from "./dispatch";
 export type { AbortScope, ControlInput, ControlSurface, ControlValue } from "./operations";

--- a/packages/coding-agent/src/sdk/host/control/operations.ts
+++ b/packages/coding-agent/src/sdk/host/control/operations.ts
@@ -11,7 +11,7 @@ export type AbortScope = "turn" | "owned";
 export interface TerminalAbortInput {
 	mode: "terminal";
 	scope?: AbortScope;
-	/** Confirmed local override for a turn owned by another SDK connection. */
+	/** Broker-authorized local override; public SDK callers cannot grant this authority. */
 	operator?: boolean;
 }
 export type ControlInput = Record<string, unknown>;

--- a/packages/coding-agent/src/sdk/host/control/operations.ts
+++ b/packages/coding-agent/src/sdk/host/control/operations.ts
@@ -11,6 +11,8 @@ export type AbortScope = "turn" | "owned";
 export interface TerminalAbortInput {
 	mode: "terminal";
 	scope?: AbortScope;
+	/** Confirmed local override for a turn owned by another SDK connection. */
+	operator?: boolean;
 }
 export type ControlInput = Record<string, unknown>;
 

--- a/packages/coding-agent/src/sdk/host/control/runtime-gate.ts
+++ b/packages/coding-agent/src/sdk/host/control/runtime-gate.ts
@@ -1,13 +1,17 @@
 /**
- * Private field carried only on the Broker's endpoint close request.
+ * Private fields carried only on Broker-authorized endpoint controls.
  *
- * The value is the lifecycle effect marker bound to the serving process. It is
- * never published in endpoint discovery or lifecycle service results; callers
- * that do not hold the Broker's indexed lifecycle record cannot satisfy this
- * gate.
+ * Their values are lifecycle effect markers bound to the serving process. They
+ * are never published in endpoint discovery or lifecycle service results;
+ * callers that do not hold the Broker's indexed lifecycle record cannot satisfy
+ * either gate.
  */
 export const BROKER_RUNTIME_CLOSE_CAPABILITY_FIELD = "__gjcBrokerCloseCapability";
+/** Private field carried only on the Broker-authorized terminal-abort request. */
+export const BROKER_RUNTIME_ABORT_CAPABILITY_FIELD = "__gjcBrokerAbortCapability";
 const EXPECTED_BROKER_RUNTIME_CLOSE_CAPABILITY = process.env.GJC_LIFECYCLE_REQUEST_ID;
+const EXPECTED_BROKER_RUNTIME_ABORT_CAPABILITY = process.env.GJC_LIFECYCLE_REQUEST_ID;
+let brokerRuntimeAbortCapabilityOverrideForTest: string | undefined;
 
 function record(value: unknown): Record<string, unknown> | undefined {
 	return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
@@ -18,13 +22,26 @@ export function brokerRuntimeCloseCapability(input: unknown): string | undefined
 	return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
-/** Remove the private close capability before a request is exposed to diagnostics. */
-export function redactBrokerRuntimeCloseCapability(frame: Record<string, unknown>): Record<string, unknown> {
-	if (frame.type !== "control_request" || frame.operation !== "session.close") return frame;
+export function brokerRuntimeAbortCapability(input: unknown): string | undefined {
+	const value = record(input)?.[BROKER_RUNTIME_ABORT_CAPABILITY_FIELD];
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/** Remove private Broker capabilities before a request is exposed to diagnostics. */
+export function redactBrokerRuntimeCapabilities(frame: Record<string, unknown>): Record<string, unknown> {
+	if (frame.type !== "control_request") return frame;
 	const input = record(frame.input);
-	if (!input || !Object.hasOwn(input, BROKER_RUNTIME_CLOSE_CAPABILITY_FIELD)) return frame;
-	const { [BROKER_RUNTIME_CLOSE_CAPABILITY_FIELD]: _capability, ...publicInput } = input;
-	return { ...frame, input: publicInput };
+	if (!input) return frame;
+	let redacted = false;
+	const publicInput: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(input)) {
+		if (key === BROKER_RUNTIME_CLOSE_CAPABILITY_FIELD || key === BROKER_RUNTIME_ABORT_CAPABILITY_FIELD) {
+			redacted = true;
+			continue;
+		}
+		publicInput[key] = value;
+	}
+	return redacted ? { ...frame, input: publicInput } : frame;
 }
 
 /**
@@ -36,5 +53,16 @@ export function redactBrokerRuntimeCloseCapability(frame: Record<string, unknown
 export function hasBrokerRuntimeCloseCapability(input: unknown): boolean {
 	const expected = EXPECTED_BROKER_RUNTIME_CLOSE_CAPABILITY;
 	const actual = brokerRuntimeCloseCapability(input);
+	return typeof expected === "string" && expected.length > 0 && actual === expected;
+}
+
+/** Test-only override for the abort gate; production authority remains process-local. */
+export function setBrokerRuntimeAbortCapabilityForTest(capability: string | undefined): void {
+	brokerRuntimeAbortCapabilityOverrideForTest = capability;
+}
+
+export function hasBrokerRuntimeAbortCapability(input: unknown): boolean {
+	const expected = brokerRuntimeAbortCapabilityOverrideForTest ?? EXPECTED_BROKER_RUNTIME_ABORT_CAPABILITY;
+	const actual = brokerRuntimeAbortCapability(input);
 	return typeof expected === "string" && expected.length > 0 && actual === expected;
 }

--- a/packages/coding-agent/src/sdk/host/host.ts
+++ b/packages/coding-agent/src/sdk/host/host.ts
@@ -1,6 +1,6 @@
 import { logger } from "@gajae-code/utils";
 import { AUTOROUTING_INACTIVE_WARNING } from "../../config/autorouting-contract";
-import { redactBrokerRuntimeCloseCapability } from "./control/runtime-gate";
+import { redactBrokerRuntimeCapabilities } from "./control/runtime-gate";
 import { type EventFrame, SessionEventStream } from "./events";
 import { isAutoroutingInactive } from "./internal-autorouting-state";
 import { type ProviderLease, ReverseLeaseError, ReverseLeaseRuntime } from "./reverse-leases";
@@ -616,7 +616,7 @@ export class SessionSdkHost {
 	}
 	#observeRequest(kind: "control" | "query", connectionId: string, frame: SdkFrame): void {
 		try {
-			this.#options.onRequest?.(kind, connectionId, redactBrokerRuntimeCloseCapability(frame));
+			this.#options.onRequest?.(kind, connectionId, redactBrokerRuntimeCapabilities(frame));
 		} catch {
 			// Diagnostic observers must not change request handling.
 		}

--- a/packages/coding-agent/src/sdk/host/session-runtime.test.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.test.ts
@@ -16,6 +16,7 @@ import { Broker } from "../broker/broker";
 import { createKindAwareReconciliation } from "../bus/kind-aware-reconciliation";
 import { createPromptReconciliation } from "../bus/prompt-reconciliation";
 import { createReconciliationStore } from "../bus/reconciliation-store";
+import { BROKER_RUNTIME_ABORT_CAPABILITY_FIELD, setBrokerRuntimeAbortCapabilityForTest } from "./control/runtime-gate";
 import { CursorRegistry, QueryHandlers, RevisionStore } from "./query";
 import {
 	createInvocationReconciliation,
@@ -1010,6 +1011,8 @@ describe("SessionSdkSessionRuntime", () => {
 	});
 	test("SDK-only host admits, replays, and conflicts terminal abort requests durably", async () => {
 		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-sdk-terminal-abort-"));
+		const operatorCapability = "runtime-terminal-abort-capability";
+		setBrokerRuntimeAbortCapabilityForTest(operatorCapability);
 		const handlers = new Map<string, (event: unknown, ctx: ExtensionContext) => Promise<void> | void>();
 		const api = {
 			on(event: string, handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void) {
@@ -1154,7 +1157,12 @@ describe("SessionSdkSessionRuntime", () => {
 				type: "control_request",
 				id: "terminal-operator-abort",
 				operation: "turn.abort",
-				input: { mode: "terminal", scope: "owned", operator: true },
+				input: {
+					mode: "terminal",
+					scope: "owned",
+					operator: true,
+					[BROKER_RUNTIME_ABORT_CAPABILITY_FIELD]: operatorCapability,
+				},
 				confirm: true,
 				idempotencyKey: "terminal-operator-key",
 			} as SdkFrame);
@@ -1167,7 +1175,17 @@ describe("SessionSdkSessionRuntime", () => {
 				ok: true,
 				result: expect.objectContaining({ turn: "stopped", ownedWork: "stopped" }),
 			});
+			const operatorKeyHash = createHash("sha256").update("terminal-operator-key").digest("hex");
+			const deliveryDeadline = Date.now() + 15_000;
+			while (
+				reconciliationStore.snapshotTerminalScopes().find(record => record.idempotencyKeyHash === operatorKeyHash)
+					?.responseState !== "sent"
+			) {
+				if (Date.now() > deliveryDeadline) throw new Error("Timed out waiting for operator delivery receipt");
+				await Bun.sleep(20);
+			}
 		} finally {
+			setBrokerRuntimeAbortCapabilityForTest(undefined);
 			await handlers.get("session_shutdown")?.({}, ctx);
 			await rm(cwd, { recursive: true, force: true });
 		}
@@ -1378,7 +1396,71 @@ describe("SessionSdkSessionRuntime", () => {
 		}
 	});
 
-	test("SDK-only host re-reads the active prompt AND its owner after an owner-mismatch reservation wins the race", async () => {
+	test("SDK-only operator abort never adopts a turn that starts after idle admission", async () => {
+		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-sdk-operator-idle-race-"));
+		const capability = "operator-idle-race-capability";
+		setBrokerRuntimeAbortCapabilityForTest(capability);
+		const handlers = new Map<string, (event: unknown, ctx: ExtensionContext) => Promise<void> | void>();
+		const api = {
+			on(event: string, handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void) {
+				handlers.set(event, handler);
+			},
+		} as unknown as ExtensionAPI;
+		const transport = memoryTransport();
+		const reconciliationStore = createReconciliationStore({
+			sessionFile: path.join(cwd, "session.json"),
+			sessionId: transport.sessionId,
+		});
+		const seamCalls: string[] = [];
+		let promptReads = 0;
+		createSdkSessionRuntimeExtension(api, {
+			agentDir: cwd,
+			createTransport: async () => transport,
+			terminalAbortSeams: {
+				getReconciliationStore: () => reconciliationStore,
+				getTerminalTurnEpoch: () => (promptReads++ === 0 ? undefined : 9),
+				getActivePromptHandle: () => (promptReads === 0 ? undefined : "successor-handle"),
+				getActivePromptOwnerConnectionId: () => "successor-owner",
+				cancelPendingPreflightForTerminalAbort: () => {},
+				abortPromptAndWaitWithTerminal: async handle => {
+					seamCalls.push(handle);
+					return { status: "settled", terminalScope: {} };
+				},
+			},
+		});
+		const ctx = extensionContext(transport.sessionId, cwd);
+		try {
+			await handlers.get("session_start")?.({}, ctx);
+			transport.feed("local-operator", {
+				type: "control_request",
+				id: "operator-idle-race",
+				operation: "turn.abort",
+				input: {
+					mode: "terminal",
+					operator: true,
+					[BROKER_RUNTIME_ABORT_CAPABILITY_FIELD]: capability,
+				},
+				confirm: true,
+				idempotencyKey: "operator-idle-race-key",
+			} as SdkFrame);
+			const deadline = Date.now() + 15_000;
+			while (!transport.sent.some(frame => frame.id === "operator-idle-race")) {
+				if (Date.now() > deadline) throw new Error("Timed out waiting for operator idle-race response");
+				await Bun.sleep(20);
+			}
+			expect(transport.sent.find(frame => frame.id === "operator-idle-race")).toMatchObject({
+				ok: true,
+				result: expect.objectContaining({ turn: "no_active_turn", terminal: "terminal_no_effect" }),
+			});
+			expect(seamCalls).toHaveLength(0);
+		} finally {
+			setBrokerRuntimeAbortCapabilityForTest(undefined);
+			await handlers.get("session_shutdown")?.({}, ctx);
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("SDK-only host re-reads the active prompt AND its owner after an owner-mismatch reservation race", async () => {
 		const cwd = await mkdtemp(path.join(os.tmpdir(), "gjc-sdk-terminal-owner-race-"));
 		const handlers = new Map<string, (event: unknown, ctx: ExtensionContext) => Promise<void> | void>();
 		const api = {

--- a/packages/coding-agent/src/sdk/host/session-runtime.test.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.test.ts
@@ -1045,7 +1045,13 @@ describe("SessionSdkSessionRuntime", () => {
 				},
 				abortPromptAndWaitWithTerminal: async (handle, options) => {
 					seamCalls.push({ handle, scope: options.terminal?.scope ?? "none" });
-					return { status: "settled", terminalScope: {} };
+					return {
+						status: "settled",
+						terminalScope: {
+							abortedAttemptEpoch: activeEpoch,
+							lineageIdHash: "runtime-test-lineage",
+						},
+					};
 				},
 			},
 		});
@@ -1140,6 +1146,27 @@ describe("SessionSdkSessionRuntime", () => {
 					}),
 				]),
 			);
+
+			// A separately connected, explicitly confirmed local operator may stop
+			// the active turn and its exact owned work without weakening ordinary
+			// connection ownership checks.
+			transport.feed("local-operator", {
+				type: "control_request",
+				id: "terminal-operator-abort",
+				operation: "turn.abort",
+				input: { mode: "terminal", scope: "owned", operator: true },
+				confirm: true,
+				idempotencyKey: "terminal-operator-key",
+			} as SdkFrame);
+			await waitForFrame("terminal-operator-abort");
+			expect(seamCalls).toEqual([
+				{ handle: "exact-run-handle", scope: "turn" },
+				{ handle: "later-run-handle", scope: "owned" },
+			]);
+			expect(transport.sent.find(frame => frame.id === "terminal-operator-abort")).toMatchObject({
+				ok: true,
+				result: expect.objectContaining({ turn: "stopped", ownedWork: "stopped" }),
+			});
 		} finally {
 			await handlers.get("session_shutdown")?.({}, ctx);
 			await rm(cwd, { recursive: true, force: true });

--- a/packages/coding-agent/src/sdk/host/session-runtime.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.ts
@@ -58,8 +58,12 @@ import {
 	resolveReconciliationSessionFile,
 } from "../reconciliation-extensions";
 import { sanitizeTurnResultContent, type TurnResultContent } from "../turn-result";
-import { type ControlSurface, controlRequestFromFrame, dispatchControl } from "./control";
-import { BROKER_RUNTIME_CLOSE_CAPABILITY_FIELD } from "./control/runtime-gate";
+import { type ControlSurface, controlRequestFromFrame, dispatchControl, terminalAbortIdentity } from "./control";
+import {
+	BROKER_RUNTIME_ABORT_CAPABILITY_FIELD,
+	BROKER_RUNTIME_CLOSE_CAPABILITY_FIELD,
+	hasBrokerRuntimeAbortCapability,
+} from "./control/runtime-gate";
 import { SessionSdkHost, type SessionSdkHostOptions } from "./host";
 import { clearAutoroutingInactive, isAutoroutingInactive, markAutoroutingInactive } from "./internal-autorouting-state";
 import { CursorRegistry, QueryHandlers, RevisionStore, type SessionSurface } from "./query";
@@ -2300,10 +2304,12 @@ function createControlSurface(
 				typeof idempotencyKey === "string"
 					? crypto.createHash("sha256").update(idempotencyKey).digest("hex")
 					: undefined;
-			const inputHash = crypto
-				.createHash("sha256")
-				.update(JSON.stringify({ mode: "terminal", scope, ...(input.operator === true ? { operator: true } : {}) }))
-				.digest("hex");
+			const abortIdentity = terminalAbortIdentity(
+				{ mode: "terminal", scope, ...(input.operator === true ? { operator: true } : {}) },
+				input.operator === true,
+			);
+			if (!abortIdentity) throw new Error("Terminal abort identity is invalid after dispatch validation.");
+			const inputHash = abortIdentity.inputHash;
 			const stored = (record: SdkOnlyTerminalScopeRecord | SdkOnlyEvictedTerminalKeyEntry) => ({
 				responseState: record.responseState ?? "pending",
 				responsePayloadHash: record.responsePayloadHash ?? inputHash,
@@ -2676,6 +2682,16 @@ function createControlSurface(
 						pendingPreflights.delete(requesterBucketKey);
 				}
 			};
+			const returnNoActiveTurn = async () => {
+				const result = {
+					ok: true,
+					selection: scope,
+					turn: "no_active_turn",
+					terminal: "terminal_no_effect",
+				};
+				await finalizeNoEffectReservation(result);
+				return result;
+			};
 			if (!handle || epoch === undefined) {
 				if ((await writeNoEffect()) === "conflict") {
 					throw Object.assign(new Error("Idempotency key was reused with different input."), {
@@ -2691,6 +2707,10 @@ function createControlSurface(
 					if (replayed !== undefined) return replayed;
 				}
 				cancelRequesterPreflights();
+				// Operator authority overrides connection ownership only for a turn
+				// observed at admission. It must never adopt a successor that starts
+				// while the durable no-effect reservation is being written.
+				if (input.operator === true) return await returnNoActiveTurn();
 				// A prompt for this requester may have become ACTIVE while the
 				// reservation awaited the filesystem transaction: its submit()
 				// cleanup already removed the preflight callback, so cancelling here
@@ -2706,14 +2726,7 @@ function createControlSurface(
 					// No prompt won the race: finalize the reserved row so a later
 					// same-key retry replays this deterministic no_active_turn result
 					// (review thread P2).
-					const noActiveTurnResult = {
-						ok: true,
-						selection: scope,
-						turn: "no_active_turn",
-						terminal: "terminal_no_effect",
-					};
-					await finalizeNoEffectReservation(noActiveTurnResult);
-					return noActiveTurnResult;
+					return await returnNoActiveTurn();
 				}
 				handle = recheckedHandle;
 				epoch = recheckedEpoch;
@@ -4780,21 +4793,13 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 					(request.input as { mode?: unknown }).mode !== "terminal"
 				)
 					return;
-				const input = request.input as Record<string, unknown>;
-				const mode = input.mode;
-				const rawScope = input.scope;
-				if (mode !== "terminal") return;
-				if (rawScope !== undefined && rawScope !== "turn" && rawScope !== "owned") return;
-				// A malformed retry (e.g. {mode:"terminal", scope:"turn", extra:true})
-				// rejected by dispatch must never hash as the valid turn input and
-				// advance the legitimate stored row (review thread P2).
-				for (const key of Object.keys(input)) if (key !== "mode" && key !== "scope") return;
-				const scopeInput = rawScope === "owned" ? "owned" : "turn";
+				const rawInput = request.input as Record<string, unknown>;
+				const operatorAuthorized = hasBrokerRuntimeAbortCapability(rawInput);
+				const { [BROKER_RUNTIME_ABORT_CAPABILITY_FIELD]: _capability, ...publicInput } = rawInput;
+				const abortIdentity = terminalAbortIdentity(publicInput, operatorAuthorized);
+				if (!abortIdentity) return;
 				const keyHash = crypto.createHash("sha256").update(String(request.idempotencyKey)).digest("hex");
-				const inputHash = crypto
-					.createHash("sha256")
-					.update(JSON.stringify({ mode: "terminal", scope: scopeInput }))
-					.digest("hex");
+				const inputHash = abortIdentity.inputHash;
 				// Hash the ACTUAL written response payload: the durable state may only
 				// advance when the written response corresponds to the row's payload.
 				// When more than 256 concurrent requests evict an in-flight abort from

--- a/packages/coding-agent/src/sdk/host/session-runtime.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.ts
@@ -2269,7 +2269,7 @@ function createControlSurface(
 		}
 	};
 	const terminalAbort = async (
-		input: { mode: "terminal"; scope?: "turn" | "owned" },
+		input: { mode: "terminal"; scope?: "turn" | "owned"; operator?: boolean },
 		idempotencyKey?: string,
 	): Promise<unknown> => {
 		const scope = input.scope === "owned" ? "owned" : "turn";
@@ -2302,7 +2302,7 @@ function createControlSurface(
 					: undefined;
 			const inputHash = crypto
 				.createHash("sha256")
-				.update(JSON.stringify({ mode: "terminal", scope }))
+				.update(JSON.stringify({ mode: "terminal", scope, ...(input.operator === true ? { operator: true } : {}) }))
 				.digest("hex");
 			const stored = (record: SdkOnlyTerminalScopeRecord | SdkOnlyEvictedTerminalKeyEntry) => ({
 				responseState: record.responseState ?? "pending",
@@ -2743,7 +2743,11 @@ function createControlSurface(
 			// cleared after a terminal lifecycle boundary) authorizes no client, and
 			// a stale prior owner authorizes only that old client — never a later
 			// turn it did not submit (review thread P1).
-			if (handle && (abortingConnectionId === undefined || !currentOwnerConnectionIds().has(abortingConnectionId))) {
+			if (
+				input.operator !== true &&
+				handle &&
+				(abortingConnectionId === undefined || !currentOwnerConnectionIds().has(abortingConnectionId))
+			) {
 				if ((await writeNoEffect()) === "conflict") {
 					throw Object.assign(new Error("Idempotency key was reused with different input."), {
 						code: "idempotency_conflict",

--- a/packages/coding-agent/test/sdk-broker.test.ts
+++ b/packages/coding-agent/test/sdk-broker.test.ts
@@ -39,6 +39,7 @@ import {
 import { LifecycleLedger } from "../src/sdk/broker/lifecycle-ledger";
 import { resolveSdkInternalSpawnCommand, resolveSdkInternalSpawnCommandForTest } from "../src/sdk/broker/runtime";
 import { readBrokerStartupFailureMarker, writeBrokerStartupFailureMarker } from "../src/sdk/broker/startup-failure";
+import { BROKER_RUNTIME_ABORT_CAPABILITY_FIELD } from "../src/sdk/host/control/runtime-gate";
 import { prepareManagedSessionScopeForWrite, resolveManagedScope } from "../src/session/internal/managed-session-scope";
 import { SessionManager } from "../src/session/session-manager";
 import {
@@ -3211,6 +3212,165 @@ describe("SDK broker identity and discovery", () => {
 			expect(await fs.readFile(sessionPath, "utf8")).toContain(sessionId);
 		} finally {
 			forged.mockRestore();
+			await broker.stop();
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("routes confirmed operator terminal aborts with the indexed private capability", async () => {
+		const dir = await temp();
+		const stateRoot = path.join(dir, ".gjc", "state");
+		const sessionId = "operator-abort";
+		const lifecycleRequestId = "operator-abort-capability";
+		const endpointPath = path.join(stateRoot, "sdk", `${sessionId}.json`);
+		const broker = new Broker({ agentDir: dir });
+		const requests: Array<Record<string, unknown>> = [];
+		let fenceOnNextOpen = false;
+		const server = Bun.serve({
+			hostname: "127.0.0.1",
+			port: 0,
+			fetch(request, httpServer) {
+				if (httpServer.upgrade(request)) return;
+				return new Response("WebSocket required", { status: 426 });
+			},
+			websocket: {
+				open(ws) {
+					if (fenceOnNextOpen) {
+						fenceOnNextOpen = false;
+						setPublicationObservationForTest(broker, "absent");
+					}
+					ws.send(JSON.stringify({ type: "hello" }));
+				},
+				message(ws, message) {
+					const frame = JSON.parse(String(message)) as Record<string, unknown>;
+					requests.push(frame);
+					if (typeof frame.id === "string")
+						ws.send(
+							JSON.stringify({
+								id: frame.id,
+								ok: true,
+								result: { turn: "stopped", ownedWork: "stopped" },
+							}),
+						);
+				},
+			},
+		});
+		await broker.start();
+		try {
+			await fs.mkdir(path.dirname(endpointPath), { recursive: true });
+			await fs.writeFile(
+				endpointPath,
+				JSON.stringify({
+					sessionId,
+					pid: process.pid,
+					url: `ws://127.0.0.1:${server.port}`,
+					token: "operator-token",
+				}),
+			);
+			await broker.index.append({
+				type: "host_registered",
+				sessionId,
+				locator: { repo: dir, stateRoot },
+				endpointGeneration: 1,
+				pid: process.pid,
+				endpointMtimeMs: (await fs.stat(endpointPath)).mtimeMs,
+				lifecycleRequestId,
+			});
+			await broker.index.append({
+				type: "host_heartbeat",
+				sessionId,
+				locator: { repo: dir, stateRoot },
+				endpointGeneration: 1,
+				pid: process.pid,
+			});
+			expect(
+				await broker.handleRequest(
+					"session.control",
+					{
+						sessionId,
+						operation: "turn.abort",
+						input: { mode: "terminal", scope: "owned", operator: true },
+						confirm: true,
+					},
+					"operator-abort-key",
+				),
+			).toEqual({ ok: true, result: { turn: "stopped", ownedWork: "stopped" } });
+			expect(requests).toHaveLength(1);
+			expect(requests[0]).toMatchObject({
+				type: "control_request",
+				operation: "turn.abort",
+				input: {
+					mode: "terminal",
+					scope: "owned",
+					operator: true,
+					[BROKER_RUNTIME_ABORT_CAPABILITY_FIELD]: lifecycleRequestId,
+				},
+				confirm: true,
+				idempotencyKey: "operator-abort-key",
+			});
+			await fs.writeFile(
+				endpointPath,
+				JSON.stringify({
+					sessionId,
+					pid: process.pid,
+					url: `ws://127.0.0.1:${server.port}`,
+					token: "replacement-token",
+				}),
+			);
+			await broker.index.append({
+				type: "host_registered",
+				sessionId,
+				locator: { repo: dir, stateRoot },
+				endpointGeneration: 2,
+				pid: process.pid,
+				endpointMtimeMs: (await fs.stat(endpointPath)).mtimeMs,
+			});
+			expect(
+				await broker.handleRequest(
+					"session.control",
+					{
+						sessionId,
+						operation: "turn.abort",
+						input: { mode: "terminal", operator: true },
+						confirm: true,
+					},
+					"replacement-abort-key",
+				),
+			).toEqual({
+				ok: false,
+				error: { code: "endpoint_stale", message: "session endpoint authority is incomplete" },
+			});
+			expect(requests).toHaveLength(1);
+
+			await broker.index.append({
+				type: "host_registered",
+				sessionId,
+				locator: { repo: dir, stateRoot },
+				endpointGeneration: 3,
+				pid: process.pid,
+				endpointMtimeMs: (await fs.stat(endpointPath)).mtimeMs,
+				lifecycleRequestId,
+			});
+			fenceOnNextOpen = true;
+			expect(
+				await broker.handleRequest(
+					"session.control",
+					{
+						sessionId,
+						operation: "turn.abort",
+						input: { mode: "terminal", operator: true },
+						confirm: true,
+					},
+					"stale-broker-abort-key",
+				),
+			).toEqual({
+				ok: false,
+				error: { code: "unavailable", message: "broker publication is unavailable" },
+			});
+			expect(requests).toHaveLength(1);
+		} finally {
+			setPublicationObservationForTest(broker, undefined);
+			server.stop(true);
 			await broker.stop();
 			await fs.rm(dir, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/sdk-control-dispatch.test.ts
+++ b/packages/coding-agent/test/sdk-control-dispatch.test.ts
@@ -663,6 +663,58 @@ test("turn.abort terminal mode validates strictly and forwards normalized input"
 	expect(replay).toEqual({ id: "t", ok: true, result: "terminal" });
 	expect(calls).toHaveLength(2);
 });
+test("turn.abort operator mode requires confirmation and preserves idempotency", async () => {
+	const abort = OPERATIONS.find(row => row.sdkId === "turn.abort")!;
+	const calls: Array<Record<string, unknown>> = [];
+	const surface = {
+		abort: () => "legacy",
+		abortTerminal: (input: unknown, idempotencyKey?: string) => {
+			calls.push({ ...(input as Record<string, unknown>), idempotencyKey });
+			return "operator";
+		},
+	} as unknown as ControlSurface;
+	const request = (input: Record<string, unknown>, idempotencyKey: string | undefined, confirm: boolean) =>
+		dispatchControl(surface, abort, {
+			id: "operator",
+			operation: abort.sdkId,
+			input,
+			idempotencyKey,
+			confirm,
+		});
+	const operatorInput = { mode: "terminal", scope: "owned", operator: true };
+
+	expect(await request(operatorInput, "operator-no-confirm", false)).toMatchObject({
+		ok: false,
+		error: { code: "invalid_input" },
+	});
+	expect(await request(operatorInput, undefined, true)).toMatchObject({
+		ok: false,
+		error: { code: "invalid_input" },
+	});
+	expect(await request({ ...operatorInput, operator: false }, "operator-false", true)).toMatchObject({
+		ok: false,
+		error: { code: "invalid_input" },
+	});
+	expect(await request(operatorInput, "operator-key", true)).toEqual({
+		id: "operator",
+		ok: true,
+		result: "operator",
+	});
+	expect(calls).toEqual([{ mode: "terminal", scope: "owned", operator: true, idempotencyKey: "operator-key" }]);
+
+	// Same-key/same-authority retries replay, while changing authority conflicts.
+	expect(await request(operatorInput, "operator-key", true)).toEqual({
+		id: "operator",
+		ok: true,
+		result: "operator",
+	});
+	expect(calls).toHaveLength(1);
+	expect(await request({ mode: "terminal", scope: "owned" }, "operator-key", true)).toMatchObject({
+		ok: false,
+		error: { code: "idempotency_conflict" },
+	});
+	expect(calls).toHaveLength(1);
+});
 test("turn.abort terminal normalizes omitted scope before idempotency hashing", async () => {
 	const abort = OPERATIONS.find(row => row.sdkId === "turn.abort")!;
 	let calls = 0;

--- a/packages/coding-agent/test/sdk-control-dispatch.test.ts
+++ b/packages/coding-agent/test/sdk-control-dispatch.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "bun:test";
 import { type ControlRequest, type ControlSurface, dispatchControl, TypedControlError } from "../src/sdk/host/control";
+import {
+	BROKER_RUNTIME_ABORT_CAPABILITY_FIELD,
+	redactBrokerRuntimeCapabilities,
+	setBrokerRuntimeAbortCapabilityForTest,
+} from "../src/sdk/host/control/runtime-gate";
 import { OPERATIONS } from "../src/sdk/protocol/operation-registry";
 
 const methodByOperation: Record<string, string> = {
@@ -663,8 +668,101 @@ test("turn.abort terminal mode validates strictly and forwards normalized input"
 	expect(replay).toEqual({ id: "t", ok: true, result: "terminal" });
 	expect(calls).toHaveLength(2);
 });
+
+test("turn.abort rejects forged public operator authority", async () => {
+	const abort = OPERATIONS.find(row => row.sdkId === "turn.abort")!;
+	let calls = 0;
+	const surface = {
+		abort: () => "legacy",
+		abortTerminal: () => {
+			calls++;
+			return "operator";
+		},
+	} as unknown as ControlSurface;
+
+	const response = await dispatchControl(surface, abort, {
+		id: "forged",
+		operation: abort.sdkId,
+		input: { mode: "terminal", scope: "owned", operator: true },
+		idempotencyKey: "forged-key",
+		confirm: true,
+	});
+
+	expect(response).toMatchObject({
+		ok: false,
+		error: { code: "operation_prohibited" },
+	});
+	expect(calls).toBe(0);
+});
+
+test("turn.abort private broker capability is removed from diagnostic frames", () => {
+	const frame = {
+		type: "control_request",
+		operation: "turn.abort",
+		input: {
+			mode: "terminal",
+			operator: true,
+			[BROKER_RUNTIME_ABORT_CAPABILITY_FIELD]: "secret-capability",
+		},
+	};
+	expect(redactBrokerRuntimeCapabilities(frame)).toEqual({
+		type: "control_request",
+		operation: "turn.abort",
+		input: { mode: "terminal", operator: true },
+	});
+	expect(frame.input[BROKER_RUNTIME_ABORT_CAPABILITY_FIELD]).toBe("secret-capability");
+});
+
+test("turn.abort accepts the verified private operator capability and hashes public input", async () => {
+	const abort = OPERATIONS.find(row => row.sdkId === "turn.abort")!;
+	const capability = "test-terminal-abort-capability";
+	const calls: Array<{ input: unknown; key?: string }> = [];
+	const surface = {
+		abort: () => "legacy",
+		abortTerminal: (input: unknown, key?: string) => {
+			calls.push({ input, key });
+			return "operator";
+		},
+	} as unknown as ControlSurface;
+	setBrokerRuntimeAbortCapabilityForTest(capability);
+	try {
+		const input = {
+			mode: "terminal",
+			scope: "owned",
+			operator: true,
+			[BROKER_RUNTIME_ABORT_CAPABILITY_FIELD]: capability,
+		};
+		const first = await dispatchControl(surface, abort, {
+			id: "verified-one",
+			operation: abort.sdkId,
+			input,
+			idempotencyKey: "verified-key",
+			confirm: true,
+		});
+		const replay = await dispatchControl(surface, abort, {
+			id: "verified-two",
+			operation: abort.sdkId,
+			input: {
+				[BROKER_RUNTIME_ABORT_CAPABILITY_FIELD]: capability,
+				operator: true,
+				scope: "owned",
+				mode: "terminal",
+			},
+			idempotencyKey: "verified-key",
+			confirm: true,
+		});
+
+		expect(first).toEqual({ id: "verified-one", ok: true, result: "operator" });
+		expect(replay).toEqual({ id: "verified-two", ok: true, result: "operator" });
+		expect(calls).toEqual([{ input: { mode: "terminal", scope: "owned", operator: true }, key: "verified-key" }]);
+	} finally {
+		setBrokerRuntimeAbortCapabilityForTest(undefined);
+	}
+});
+
 test("turn.abort operator mode requires confirmation and preserves idempotency", async () => {
 	const abort = OPERATIONS.find(row => row.sdkId === "turn.abort")!;
+	const capability = "test-operator-capability";
 	const calls: Array<Record<string, unknown>> = [];
 	const surface = {
 		abort: () => "legacy",
@@ -673,47 +771,76 @@ test("turn.abort operator mode requires confirmation and preserves idempotency",
 			return "operator";
 		},
 	} as unknown as ControlSurface;
-	const request = (input: Record<string, unknown>, idempotencyKey: string | undefined, confirm: boolean) =>
-		dispatchControl(surface, abort, {
-			id: "operator",
-			operation: abort.sdkId,
-			input,
-			idempotencyKey,
-			confirm,
+	setBrokerRuntimeAbortCapabilityForTest(capability);
+	try {
+		const request = (input: Record<string, unknown>, idempotencyKey: string | undefined, confirm: boolean) =>
+			dispatchControl(surface, abort, {
+				id: "operator",
+				operation: abort.sdkId,
+				input,
+				idempotencyKey,
+				confirm,
+			});
+		const operatorInput = {
+			mode: "terminal",
+			scope: "owned",
+			operator: true,
+			[BROKER_RUNTIME_ABORT_CAPABILITY_FIELD]: capability,
+		};
+
+		expect(await request(operatorInput, "operator-no-confirm", false)).toMatchObject({
+			ok: false,
+			error: { code: "invalid_input" },
 		});
-	const operatorInput = { mode: "terminal", scope: "owned", operator: true };
+		expect(await request(operatorInput, undefined, true)).toMatchObject({
+			ok: false,
+			error: { code: "invalid_input" },
+		});
+		expect(await request({ ...operatorInput, operator: false }, "operator-false", true)).toMatchObject({
+			ok: false,
+			error: { code: "invalid_input" },
+		});
+		expect(await request(operatorInput, "operator-key", true)).toEqual({
+			id: "operator",
+			ok: true,
+			result: "operator",
+		});
+		expect(calls).toEqual([{ mode: "terminal", scope: "owned", operator: true, idempotencyKey: "operator-key" }]);
 
-	expect(await request(operatorInput, "operator-no-confirm", false)).toMatchObject({
-		ok: false,
-		error: { code: "invalid_input" },
-	});
-	expect(await request(operatorInput, undefined, true)).toMatchObject({
-		ok: false,
-		error: { code: "invalid_input" },
-	});
-	expect(await request({ ...operatorInput, operator: false }, "operator-false", true)).toMatchObject({
-		ok: false,
-		error: { code: "invalid_input" },
-	});
-	expect(await request(operatorInput, "operator-key", true)).toEqual({
-		id: "operator",
-		ok: true,
-		result: "operator",
-	});
-	expect(calls).toEqual([{ mode: "terminal", scope: "owned", operator: true, idempotencyKey: "operator-key" }]);
-
-	// Same-key/same-authority retries replay, while changing authority conflicts.
-	expect(await request(operatorInput, "operator-key", true)).toEqual({
-		id: "operator",
-		ok: true,
-		result: "operator",
-	});
-	expect(calls).toHaveLength(1);
-	expect(await request({ mode: "terminal", scope: "owned" }, "operator-key", true)).toMatchObject({
-		ok: false,
-		error: { code: "idempotency_conflict" },
-	});
-	expect(calls).toHaveLength(1);
+		// Same-key/same-authority retries replay, while changing authority conflicts.
+		expect(await request(operatorInput, "operator-key", true)).toEqual({
+			id: "operator",
+			ok: true,
+			result: "operator",
+		});
+		expect(calls).toHaveLength(1);
+		expect(await request(operatorInput, "operator-key", false)).toMatchObject({
+			ok: false,
+			error: { code: "invalid_input" },
+		});
+		expect(await request({ ...operatorInput, operator: false }, "operator-key", true)).toMatchObject({
+			ok: false,
+			error: { code: "invalid_input" },
+		});
+		expect(await request({ mode: "terminal", scope: "owned", operator: true }, "operator-key", true)).toMatchObject({
+			ok: false,
+			error: { code: "operation_prohibited" },
+		});
+		expect(calls).toHaveLength(1);
+		expect(
+			await request(
+				{ mode: "terminal", scope: "owned", [BROKER_RUNTIME_ABORT_CAPABILITY_FIELD]: capability },
+				"operator-key",
+				true,
+			),
+		).toMatchObject({
+			ok: false,
+			error: { code: "idempotency_conflict" },
+		});
+		expect(calls).toHaveLength(1);
+	} finally {
+		setBrokerRuntimeAbortCapabilityForTest(undefined);
+	}
 });
 test("turn.abort terminal normalizes omitted scope before idempotency hashing", async () => {
 	const abort = OPERATIONS.find(row => row.sdkId === "turn.abort")!;

--- a/packages/coding-agent/test/sdk-session-cli-control-envelope.test.ts
+++ b/packages/coding-agent/test/sdk-session-cli-control-envelope.test.ts
@@ -1,22 +1,54 @@
 import { describe, expect, test } from "bun:test";
-import { controlRequestFrame } from "../src/sdk/cli/session-cli";
+import { controlRequestFrame, operatorAbortBrokerRequest } from "../src/sdk/cli/session-cli";
 
 describe("sdk session raw control envelope", () => {
-	test("forwards terminal abort authority as envelope flags, not input fields", () => {
+	test("routes confirmed operator terminal aborts through the dedicated broker envelope", () => {
 		const input = { mode: "terminal", scope: "owned", operator: true };
 		expect(
-			controlRequestFrame("turn.abort", input, {
+			operatorAbortBrokerRequest("session-1", "turn.abort", input, {
 				confirm: true,
 				idempotencyKey: "gajae-abort-test-key",
 			}),
 		).toEqual({
-			type: "control_request",
+			sessionId: "session-1",
 			operation: "turn.abort",
 			input,
 			confirm: true,
-			idempotencyKey: "gajae-abort-test-key",
 		});
 		expect(input).toEqual({ mode: "terminal", scope: "owned", operator: true });
+	});
+
+	test("does not route ordinary terminal aborts through broker operator authority", () => {
+		expect(
+			operatorAbortBrokerRequest(
+				"session-1",
+				"turn.abort",
+				{ mode: "terminal", scope: "turn" },
+				{
+					confirm: true,
+					idempotencyKey: "ordinary-key",
+				},
+			),
+		).toBeUndefined();
+	});
+
+	test("allows the terminal abort scope to default on the broker route", () => {
+		expect(
+			operatorAbortBrokerRequest(
+				"session-1",
+				"turn.abort",
+				{ mode: "terminal", operator: true },
+				{
+					confirm: true,
+					idempotencyKey: "default-scope-key",
+				},
+			),
+		).toEqual({
+			sessionId: "session-1",
+			operation: "turn.abort",
+			input: { mode: "terminal", operator: true },
+			confirm: true,
+		});
 	});
 
 	test("omits an absent idempotency key for ordinary controls", () => {

--- a/packages/coding-agent/test/sdk-session-cli-control-envelope.test.ts
+++ b/packages/coding-agent/test/sdk-session-cli-control-envelope.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { controlRequestFrame } from "../src/sdk/cli/session-cli";
+
+describe("sdk session raw control envelope", () => {
+	test("forwards terminal abort authority as envelope flags, not input fields", () => {
+		const input = { mode: "terminal", scope: "owned", operator: true };
+		expect(
+			controlRequestFrame("turn.abort", input, {
+				confirm: true,
+				idempotencyKey: "gajae-abort-test-key",
+			}),
+		).toEqual({
+			type: "control_request",
+			operation: "turn.abort",
+			input,
+			confirm: true,
+			idempotencyKey: "gajae-abort-test-key",
+		});
+		expect(input).toEqual({ mode: "terminal", scope: "owned", operator: true });
+	});
+
+	test("omits an absent idempotency key for ordinary controls", () => {
+		expect(controlRequestFrame("thinking.cycle", {}, { confirm: false })).toEqual({
+			type: "control_request",
+			operation: "thinking.cycle",
+			input: {},
+			confirm: false,
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- route confirmed operator terminal aborts through a dedicated local Broker `session.control` path instead of trusting caller-supplied SDK authority;
- bind Broker authority to the exact live endpoint lifecycle identity and re-prove publication ownership in `SdkClient.beforeDispatch` immediately before the WebSocket write;
- reject forged public `operator:true` or private-capability shapes before idempotency replay;
- use one capability-free `terminalAbortIdentity` for dispatch caching, durable admission/replay, and delivery observation;
- prevent an operator abort admitted while idle from adopting a successor turn;
- preserve ordinary connection-owner handle/epoch/lineage/owned-work behavior and document the CLI contract.

## Exact-head review disposition

Probepark's exact-head `CHANGES_REQUESTED` review `5061298820` at `7d17f9eed0b34f799afa99f3c2f13a639c968402` found two P1 blockers:

1. `operator:true` and `confirm:true` were caller-forgeable across MCP/ACP/direct SDK connections.
2. admission/idempotency included operator authority while delivery observation hashed the pre-operator schema, leaving completed destructive responses durably pending.

Both are resolved at repaired head `d8983deb9bfb0e86eb5df451dd22fdd206859726`. The stale review is dismissed and superseded by exact-head approval `5062063036` plus signed evidence comment `issuecomment-5471658992`.

## Verification

- `bun test packages/coding-agent/test/sdk-control-dispatch.test.ts packages/coding-agent/test/sdk-session-cli-control-envelope.test.ts packages/coding-agent/test/sdk-broker.test.ts packages/coding-agent/src/sdk/host/session-runtime.test.ts` — 233 passed, 0 failed, 909 assertions.
- `bun --cwd=packages/coding-agent run check:types` — passed.
- `bun run ci:test:smoke` — passed.
- changed-file Biome and `git diff --check` — passed.
- delegated architect generation 3 — `CLEAR/CLEAR/CLEAR`, `APPROVE`.
- delegated executor red-team QA — passed, including live CLI fail-closed probes.
- terminal critic — `OKAY`, no blockers.
- `bun run check:ts` attempted twice: earlier gates passed; the terminal failure is unchanged `origin/dev` canonicalization debt in `packages/coding-agent/src/tools/tmux-self-injection-guard.ts` (byte-identical to `origin/dev`, owner commit `93cb1ae3f9`). A transient SDK CLI test failure and its full file both passed on immediate rerun.

## Risk classification

- [ ] `low-risk`
- [ ] `regression-risk`
- [x] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:5999f3a14bea0889ac9d3f3ca198e831f1b2fd6680c6246bedcc81e50264cb8f reviewer:critic reviewer-id:Yeachan-Heo evidence:exact-head-d8983deb-broker-authorized-terminal-abort-architect-qa-critic-clean
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (blocked only by unchanged current-dev tmux canonicalization debt described above)
- [x] Tested locally
- [x] CHANGELOG updated
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken
- [x] No main/release/tag/publish action performed