### PR TITLE
fix(ai): preserve open MCP dispatcher argument maps

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 - MCP dispatcher tools now preserve dynamic nested `args` and `params` objects when a server declares them as propertyless JSON Schema objects. `normalizeSchemaForMCP` makes the implicit open-map semantics explicit with `additionalProperties: true` without loosening objects that declare properties or an explicit closure, so provider tool schemas no longer collapse valid nested arguments to `{}`.
+- Schema normalization now copies `default`, `const`, `enum`, and `examples` payloads verbatim. These keywords carry instance data, not subschemas, so the previous recursive walk rewrote user payloads as if they were schemas (a `default` of `{"type":"object","nullable":true}` lost `nullable`, and literal `anyOf`/`const` branches collapsed into `enum`).
+- Schema copies now write property names as own data properties. A `JSON.parse`d tool schema carries `__proto__` as an ordinary key, and plain assignment routed it to `Object.prototype`'s `__proto__` setter, dropping that valid property from the normalized schema.
 
 ## [0.15.6] - 2026-08-30
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -7,6 +7,7 @@
 - MCP dispatcher tools now preserve dynamic nested `args` and `params` objects when a server declares them as propertyless JSON Schema objects. `normalizeSchemaForMCP` makes the implicit open-map semantics explicit with `additionalProperties: true` without loosening objects that declare properties or an explicit closure, so provider tool schemas no longer collapse valid nested arguments to `{}`.
 - Schema normalization now copies `default`, `const`, `enum`, and `examples` payloads verbatim. These keywords carry instance data, not subschemas, so the previous recursive walk rewrote user payloads as if they were schemas (a `default` of `{"type":"object","nullable":true}` lost `nullable`, and literal `anyOf`/`const` branches collapsed into `enum`).
 - Schema copies now write property names as own data properties. A `JSON.parse`d tool schema carries `__proto__` as an ordinary key, and plain assignment routed it to `Object.prototype`'s `__proto__` setter, dropping that valid property from the normalized schema.
+- Schema-valued maps now remain maps even when dispatcher argument names collide with JSON Schema keywords (`type`, `default`, `const`, `enum`, or `examples`), and prototype-colliding names survive draft-upgrade, dereference, and Zod cleanup copies without polluting `Object.prototype`.
 
 ## [0.15.6] - 2026-08-30
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- MCP dispatcher tools now preserve dynamic nested `args` and `params` objects when a server declares them as propertyless JSON Schema objects. `normalizeSchemaForMCP` makes the implicit open-map semantics explicit with `additionalProperties: true` without loosening objects that declare properties or an explicit closure, so provider tool schemas no longer collapse valid nested arguments to `{}`.
+
 ## [0.15.6] - 2026-08-30
 
 ### Added

--- a/packages/ai/src/utils/schema/dereference.ts
+++ b/packages/ai/src/utils/schema/dereference.ts
@@ -11,6 +11,16 @@
  */
 import { isJsonObject, type JsonObject } from "./types";
 
+const JSON_SCHEMA_LITERAL_PAYLOAD_KEYS = new Set(["default", "const", "enum", "examples"]);
+
+function setOwnKey(target: JsonObject, key: string, value: unknown): void {
+	if (key === "__proto__") {
+		Object.defineProperty(target, key, { value, writable: true, enumerable: true, configurable: true });
+		return;
+	}
+	target[key] = value;
+}
+
 /**
  * Resolve a JSON-pointer-style `$ref` against the root schema's `$defs`
  * or `definitions` block. Returns `undefined` for external or unresolvable refs.
@@ -23,6 +33,7 @@ function resolveLocalRef(ref: string, root: JsonObject): JsonObject | undefined 
 	const [, defsKey, name] = match;
 	const defs = root[defsKey!];
 	if (!isJsonObject(defs)) return undefined;
+	if (!Object.hasOwn(defs, name!)) return undefined;
 
 	const resolved = defs[name!];
 	return isJsonObject(resolved) ? resolved : undefined;
@@ -49,6 +60,7 @@ function dereferenceNode(node: unknown, root: JsonObject, visiting: Set<string>)
 		// referencing node. In draft 2020-12 these are valid alongside $ref.
 		let hasSiblings = false;
 		for (const k in node) {
+			if (!Object.hasOwn(node, k)) continue;
 			if (k !== "$ref") {
 				hasSiblings = true;
 				break;
@@ -62,16 +74,27 @@ function dereferenceNode(node: unknown, root: JsonObject, visiting: Set<string>)
 
 	const result: JsonObject = {};
 	for (const key in node) {
+		if (!Object.hasOwn(node, key)) continue;
 		const value = node[key];
 		// Skip $defs/definitions — they get inlined into consumers
 		if (key === "$defs" || key === "definitions") continue;
+		// Literal instance data is not schema-shaped, even when it contains an
+		// object that happens to use schema-looking keys or a local `$ref`.
+		if (JSON_SCHEMA_LITERAL_PAYLOAD_KEYS.has(key)) {
+			setOwnKey(result, key, value);
+			continue;
+		}
 
 		if (Array.isArray(value)) {
-			result[key] = value.map(item => dereferenceNode(item, root, visiting));
+			setOwnKey(
+				result,
+				key,
+				value.map(item => dereferenceNode(item, root, visiting)),
+			);
 		} else if (isJsonObject(value)) {
-			result[key] = dereferenceNode(value, root, visiting);
+			setOwnKey(result, key, dereferenceNode(value, root, visiting));
 		} else {
-			result[key] = value;
+			setOwnKey(result, key, value);
 		}
 	}
 	return result;
@@ -91,7 +114,7 @@ export function dereferenceJsonSchema(schema: unknown): unknown {
 	if (!isJsonObject(schema)) return schema;
 
 	// Fast path: nothing to dereference
-	const hasDefs = schema.$defs !== undefined || schema.definitions !== undefined;
+	const hasDefs = Object.hasOwn(schema, "$defs") || Object.hasOwn(schema, "definitions");
 	if (!hasDefs) return schema;
 
 	return dereferenceNode(schema, schema, new Set());

--- a/packages/ai/src/utils/schema/dereference.ts
+++ b/packages/ai/src/utils/schema/dereference.ts
@@ -46,7 +46,7 @@ function dereferenceNode(node: unknown, root: JsonObject, visiting: Set<string>)
 	if (!isJsonObject(node)) return node;
 	if (Array.isArray(node)) return node.map(item => dereferenceNode(item, root, visiting));
 
-	const ref = node.$ref;
+	const ref = Object.hasOwn(node, "$ref") ? node.$ref : undefined;
 	if (typeof ref === "string") {
 		// Break circular references
 		if (visiting.has(ref)) return {};

--- a/packages/ai/src/utils/schema/dereference.ts
+++ b/packages/ai/src/utils/schema/dereference.ts
@@ -21,82 +21,137 @@ function setOwnKey(target: JsonObject, key: string, value: unknown): void {
 	target[key] = value;
 }
 
-/**
- * Resolve a JSON-pointer-style `$ref` against the root schema's `$defs`
- * or `definitions` block. Returns `undefined` for external or unresolvable refs.
- */
-function resolveLocalRef(ref: string, root: JsonObject): JsonObject | undefined {
-	// Only handle local refs: #/$defs/Name or #/definitions/Name
-	const match = /^#\/(\$defs|definitions)\/(.+)$/.exec(ref);
-	if (!match) return undefined;
+type DereferenceState = {
+	unresolvedRef: boolean;
+};
 
-	const [, defsKey, name] = match;
-	const defs = root[defsKey!];
-	if (!isJsonObject(defs)) return undefined;
-	if (!Object.hasOwn(defs, name!)) return undefined;
+/** Resolve any local JSON Pointer, including escaped names and boolean schemas. */
+function resolveLocalRef(ref: string, root: JsonObject): unknown | undefined {
+	if (!ref.startsWith("#")) return undefined;
+	let pointer: string;
+	try {
+		pointer = decodeURIComponent(ref.slice(1));
+	} catch {
+		return undefined;
+	}
+	if (pointer === "") return root;
+	if (!pointer.startsWith("/")) return undefined;
 
-	const resolved = defs[name!];
-	return isJsonObject(resolved) ? resolved : undefined;
+	let current: unknown = root;
+	for (const encodedSegment of pointer.slice(1).split("/")) {
+		const segment = encodedSegment.replaceAll("~1", "/").replaceAll("~0", "~");
+		if (Array.isArray(current)) {
+			if (!/^(0|[1-9]\d*)$/.test(segment) || !Object.hasOwn(current, segment)) return undefined;
+			current = current[Number(segment)];
+		} else if (isJsonObject(current)) {
+			if (!Object.hasOwn(current, segment)) return undefined;
+			current = current[segment];
+		} else {
+			return undefined;
+		}
+	}
+	return current;
+}
+
+/** Find definition maps anywhere in a schema graph, excluding literal instance data. */
+function hasDefinitionMapDeep(value: unknown, seen: Set<object>): boolean {
+	if (Array.isArray(value)) {
+		if (seen.has(value)) return false;
+		seen.add(value);
+		return value.some(entry => hasDefinitionMapDeep(entry, seen));
+	}
+	if (!isJsonObject(value) || seen.has(value)) return false;
+	seen.add(value);
+	for (const key in value) {
+		if (!Object.hasOwn(value, key)) continue;
+		if (key === "$defs" || key === "definitions") return true;
+		if (JSON_SCHEMA_LITERAL_PAYLOAD_KEYS.has(key)) continue;
+		if (hasDefinitionMapDeep(value[key], seen)) return true;
+	}
+	return false;
 }
 
 /**
  * Recursively dereference a JSON Schema node, inlining all local `$ref` pointers.
+ * Object and array path tracking preserves the existing `{}` cycle boundary.
  */
-function dereferenceNode(node: unknown, root: JsonObject, visiting: Set<string>): unknown {
-	if (!isJsonObject(node)) return node;
-	if (Array.isArray(node)) return node.map(item => dereferenceNode(item, root, visiting));
+function dereferenceNode(
+	node: unknown,
+	root: JsonObject,
+	visitingRefs: Set<string>,
+	visitingNodes: Set<object>,
+	state: DereferenceState,
+): unknown {
+	if (!node || typeof node !== "object") return node;
+	if (visitingNodes.has(node)) return {};
+	visitingNodes.add(node);
 
-	const ref = Object.hasOwn(node, "$ref") ? node.$ref : undefined;
+	if (Array.isArray(node)) {
+		const result = node.map(item => dereferenceNode(item, root, visitingRefs, visitingNodes, state));
+		visitingNodes.delete(node);
+		return result;
+	}
+
+	const schemaNode = node as JsonObject;
+	const ref = Object.hasOwn(schemaNode, "$ref") ? schemaNode.$ref : undefined;
 	if (typeof ref === "string") {
-		// Break circular references
-		if (visiting.has(ref)) return {};
-		const resolved = resolveLocalRef(ref, root);
-		if (!resolved) return node; // External ref — leave as-is
-		visiting.add(ref);
-		const inlined = dereferenceNode(resolved, root, visiting);
-		visiting.delete(ref);
-
-		// Merge sibling keywords (e.g. description, default) from the
-		// referencing node. In draft 2020-12 these are valid alongside $ref.
-		let hasSiblings = false;
-		for (const k in node) {
-			if (!Object.hasOwn(node, k)) continue;
-			if (k !== "$ref") {
-				hasSiblings = true;
-				break;
-			}
+		if (visitingRefs.has(ref)) {
+			visitingNodes.delete(node);
+			return {};
 		}
-		if (!hasSiblings || !isJsonObject(inlined)) return inlined;
-		const merged: JsonObject = { ...inlined, ...node };
-		delete merged.$ref;
-		return merged;
+		const resolved = resolveLocalRef(ref, root);
+		if (resolved !== undefined) {
+			visitingRefs.add(ref);
+			const inlined = dereferenceNode(resolved, root, visitingRefs, visitingNodes, state);
+			visitingRefs.delete(ref);
+
+			// Merge sibling keywords (e.g. description, default) from the
+			// referencing node. In draft 2020-12 these are valid alongside `$ref`.
+			let hasSiblings = false;
+			for (const key in schemaNode) {
+				if (Object.hasOwn(schemaNode, key) && key !== "$ref") {
+					hasSiblings = true;
+					break;
+				}
+			}
+			if (!hasSiblings || !isJsonObject(inlined)) {
+				visitingNodes.delete(node);
+				return inlined;
+			}
+			const merged: JsonObject = {};
+			for (const key in inlined) {
+				if (Object.hasOwn(inlined, key)) setOwnKey(merged, key, inlined[key]);
+			}
+			for (const key in schemaNode) {
+				if (Object.hasOwn(schemaNode, key) && key !== "$ref") setOwnKey(merged, key, schemaNode[key]);
+			}
+			if (!state.unresolvedRef) {
+				delete merged.$defs;
+				delete merged.definitions;
+			}
+			visitingNodes.delete(node);
+			return merged;
+		}
+		state.unresolvedRef = true;
 	}
 
 	const result: JsonObject = {};
-	for (const key in node) {
-		if (!Object.hasOwn(node, key)) continue;
-		const value = node[key];
-		// Skip $defs/definitions — they get inlined into consumers
-		if (key === "$defs" || key === "definitions") continue;
+	for (const key in schemaNode) {
+		if (!Object.hasOwn(schemaNode, key)) continue;
+		const value = schemaNode[key];
 		// Literal instance data is not schema-shaped, even when it contains an
 		// object that happens to use schema-looking keys or a local `$ref`.
 		if (JSON_SCHEMA_LITERAL_PAYLOAD_KEYS.has(key)) {
 			setOwnKey(result, key, value);
 			continue;
 		}
-
-		if (Array.isArray(value)) {
-			setOwnKey(
-				result,
-				key,
-				value.map(item => dereferenceNode(item, root, visiting)),
-			);
-		} else if (isJsonObject(value)) {
-			setOwnKey(result, key, dereferenceNode(value, root, visiting));
-		} else {
-			setOwnKey(result, key, value);
-		}
+		setOwnKey(result, key, dereferenceNode(value, root, visitingRefs, visitingNodes, state));
 	}
+	if (!state.unresolvedRef) {
+		delete result.$defs;
+		delete result.definitions;
+	}
+	visitingNodes.delete(node);
 	return result;
 }
 
@@ -113,9 +168,8 @@ function dereferenceNode(node: unknown, root: JsonObject, visiting: Set<string>)
 export function dereferenceJsonSchema(schema: unknown): unknown {
 	if (!isJsonObject(schema)) return schema;
 
-	// Fast path: nothing to dereference
-	const hasDefs = Object.hasOwn(schema, "$defs") || Object.hasOwn(schema, "definitions");
-	if (!hasDefs) return schema;
+	// Fast path: nothing to dereference anywhere in the schema graph
+	if (!hasDefinitionMapDeep(schema, new Set())) return schema;
 
-	return dereferenceNode(schema, schema, new Set());
+	return dereferenceNode(schema, schema, new Set(), new Set(), { unresolvedRef: false });
 }

--- a/packages/ai/src/utils/schema/dereference.ts
+++ b/packages/ai/src/utils/schema/dereference.ts
@@ -12,6 +12,14 @@
 import { isJsonObject, type JsonObject } from "./types";
 
 const JSON_SCHEMA_LITERAL_PAYLOAD_KEYS = new Set(["default", "const", "enum", "examples"]);
+const JSON_SCHEMA_MAP_KEYS = new Set([
+	"properties",
+	"patternProperties",
+	"dependencies",
+	"dependentSchemas",
+	"$defs",
+	"definitions",
+]);
 
 function setOwnKey(target: JsonObject, key: string, value: unknown): void {
 	if (key === "__proto__") {
@@ -54,21 +62,37 @@ function resolveLocalRef(ref: string, root: JsonObject): unknown | undefined {
 }
 
 /** Find definition maps anywhere in a schema graph, excluding literal instance data. */
-function hasDefinitionMapDeep(value: unknown, seen: Set<object>): boolean {
+function hasDefinitionMapDeep(value: unknown, seen: Set<object>, inSchemaMap = false): boolean {
 	if (Array.isArray(value)) {
 		if (seen.has(value)) return false;
 		seen.add(value);
-		return value.some(entry => hasDefinitionMapDeep(entry, seen));
+		return value.some(entry => hasDefinitionMapDeep(entry, seen, false));
 	}
 	if (!isJsonObject(value) || seen.has(value)) return false;
 	seen.add(value);
 	for (const key in value) {
 		if (!Object.hasOwn(value, key)) continue;
-		if (key === "$defs" || key === "definitions") return true;
-		if (JSON_SCHEMA_LITERAL_PAYLOAD_KEYS.has(key)) continue;
-		if (hasDefinitionMapDeep(value[key], seen)) return true;
+		if (!inSchemaMap && (key === "$defs" || key === "definitions")) return true;
+		if (!inSchemaMap && JSON_SCHEMA_LITERAL_PAYLOAD_KEYS.has(key)) continue;
+		const childInSchemaMap = !inSchemaMap && JSON_SCHEMA_MAP_KEYS.has(key);
+		if (hasDefinitionMapDeep(value[key], seen, childInSchemaMap)) return true;
 	}
 	return false;
+}
+
+function dereferenceSchemaMap(
+	schemaMap: JsonObject,
+	root: JsonObject,
+	visitingRefs: Set<string>,
+	visitingNodes: Set<object>,
+	state: DereferenceState,
+): JsonObject {
+	const result: JsonObject = {};
+	for (const key in schemaMap) {
+		if (!Object.hasOwn(schemaMap, key)) continue;
+		setOwnKey(result, key, dereferenceNode(schemaMap[key], root, visitingRefs, visitingNodes, state));
+	}
+	return result;
 }
 
 /**
@@ -81,6 +105,7 @@ function dereferenceNode(
 	visitingRefs: Set<string>,
 	visitingNodes: Set<object>,
 	state: DereferenceState,
+	inSchemaMap = false,
 ): unknown {
 	if (!node || typeof node !== "object") return node;
 	if (visitingNodes.has(node)) return {};
@@ -114,19 +139,29 @@ function dereferenceNode(
 					break;
 				}
 			}
-			if (!hasSiblings || !isJsonObject(inlined)) {
+			if (inlined === false) {
+				visitingNodes.delete(node);
+				return false;
+			}
+			if (!hasSiblings || (!isJsonObject(inlined) && inlined !== true)) {
 				visitingNodes.delete(node);
 				return inlined;
 			}
 			const merged: JsonObject = {};
-			for (const key in inlined) {
-				if (Object.hasOwn(inlined, key)) setOwnKey(merged, key, inlined[key]);
+			if (isJsonObject(inlined)) {
+				for (const key in inlined) {
+					if (Object.hasOwn(inlined, key)) setOwnKey(merged, key, inlined[key]);
+				}
 			}
 			for (const key in schemaNode) {
 				if (!Object.hasOwn(schemaNode, key) || key === "$ref") continue;
-				const sibling = JSON_SCHEMA_LITERAL_PAYLOAD_KEYS.has(key)
-					? schemaNode[key]
-					: dereferenceNode(schemaNode[key], root, visitingRefs, visitingNodes, state);
+				const siblingValue = schemaNode[key];
+				const sibling =
+					!inSchemaMap && JSON_SCHEMA_LITERAL_PAYLOAD_KEYS.has(key)
+						? schemaNode[key]
+						: !inSchemaMap && JSON_SCHEMA_MAP_KEYS.has(key) && isJsonObject(siblingValue)
+							? dereferenceSchemaMap(siblingValue, root, visitingRefs, visitingNodes, state)
+							: dereferenceNode(siblingValue, root, visitingRefs, visitingNodes, state);
 				setOwnKey(merged, key, sibling);
 			}
 			if (!state.unresolvedRef) {
@@ -145,8 +180,12 @@ function dereferenceNode(
 		const value = schemaNode[key];
 		// Literal instance data is not schema-shaped, even when it contains an
 		// object that happens to use schema-looking keys or a local `$ref`.
-		if (JSON_SCHEMA_LITERAL_PAYLOAD_KEYS.has(key)) {
+		if (!inSchemaMap && JSON_SCHEMA_LITERAL_PAYLOAD_KEYS.has(key)) {
 			setOwnKey(result, key, value);
+			continue;
+		}
+		if (!inSchemaMap && JSON_SCHEMA_MAP_KEYS.has(key) && isJsonObject(value)) {
+			setOwnKey(result, key, dereferenceSchemaMap(value, root, visitingRefs, visitingNodes, state));
 			continue;
 		}
 		setOwnKey(result, key, dereferenceNode(value, root, visitingRefs, visitingNodes, state));

--- a/packages/ai/src/utils/schema/dereference.ts
+++ b/packages/ai/src/utils/schema/dereference.ts
@@ -123,7 +123,11 @@ function dereferenceNode(
 				if (Object.hasOwn(inlined, key)) setOwnKey(merged, key, inlined[key]);
 			}
 			for (const key in schemaNode) {
-				if (Object.hasOwn(schemaNode, key) && key !== "$ref") setOwnKey(merged, key, schemaNode[key]);
+				if (!Object.hasOwn(schemaNode, key) || key === "$ref") continue;
+				const sibling = JSON_SCHEMA_LITERAL_PAYLOAD_KEYS.has(key)
+					? schemaNode[key]
+					: dereferenceNode(schemaNode[key], root, visitingRefs, visitingNodes, state);
+				setOwnKey(merged, key, sibling);
 			}
 			if (!state.unresolvedRef) {
 				delete merged.$defs;

--- a/packages/ai/src/utils/schema/draft.ts
+++ b/packages/ai/src/utils/schema/draft.ts
@@ -161,7 +161,9 @@ function hasNullType(type: unknown): boolean {
 
 /** True if any variant in `anyOf` declares (only) a null type. Used to avoid double-adding `{type:"null"}`. */
 function hasNullVariant(variants: unknown[]): boolean {
-	return variants.some(variant => isJsonObject(variant) && hasNullType(variant.type));
+	return variants.some(
+		variant => isJsonObject(variant) && Object.hasOwn(variant, "type") && hasNullType(variant.type),
+	);
 }
 
 /**

--- a/packages/ai/src/utils/schema/draft.ts
+++ b/packages/ai/src/utils/schema/draft.ts
@@ -140,7 +140,7 @@ function mergeDependentSchema(target: JsonObject, key: string, schema: unknown):
  *   - schema value → `dependentSchemas`
  */
 function convertDependencies(source: JsonObject, target: JsonObject, cache: WeakMap<object, unknown>): void {
-	const dependencies = source.dependencies;
+	const dependencies = Object.hasOwn(source, "dependencies") ? source.dependencies : undefined;
 	if (!isJsonObject(dependencies)) return;
 	for (const key in dependencies) {
 		if (!Object.hasOwn(dependencies, key)) continue;
@@ -311,10 +311,15 @@ function upgradeJsonSchemaTo202012Impl(value: unknown, cache: WeakMap<object, un
 
 	// Draft-07 tuple form: `items: [a, b]` (+ optional `additionalItems`) becomes
 	// draft 2020-12 `prefixItems: [a, b]` (+ optional `items` for the rest).
-	if (Array.isArray(value.items)) {
-		const convertedItems = upgradeJsonSchemaTo202012Impl(value.items, cache) as unknown[];
+	const tupleItems = Object.hasOwn(value, "items") && Array.isArray(value.items) ? value.items : undefined;
+	if (tupleItems !== undefined) {
+		const convertedItems = upgradeJsonSchemaTo202012Impl(tupleItems, cache) as unknown[];
 		result.prefixItems = mergePrefixItems(result.prefixItems, convertedItems);
-		if (value.additionalItems !== undefined && value.additionalItems !== true) {
+		if (
+			Object.hasOwn(value, "additionalItems") &&
+			value.additionalItems !== undefined &&
+			value.additionalItems !== true
+		) {
 			result.items = upgradeJsonSchemaTo202012Impl(value.additionalItems, cache);
 		} else {
 			// `additionalItems: true` (or absent) in draft-07 == no `items` in 2020-12.
@@ -327,7 +332,7 @@ function upgradeJsonSchemaTo202012Impl(value: unknown, cache: WeakMap<object, un
 	// OpenAPI 3.0 `nullable: true` → 2020-12 nullability. `makeNullable` may
 	// return a fresh wrapper object, in which case update the cache so callers
 	// referring to the same input see the wrapper instead of the inner result.
-	if (value.nullable === true) {
+	if (Object.hasOwn(value, "nullable") && value.nullable === true) {
 		const nullable = makeNullable(result);
 		if (nullable !== result) cache.set(value, nullable);
 		return nullable;

--- a/packages/ai/src/utils/schema/draft.ts
+++ b/packages/ai/src/utils/schema/draft.ts
@@ -17,7 +17,7 @@ const DRAFT_07_SCHEMA_URIS: Record<string, true> = {
  * entry rather than the map object itself so legacy `definitions`-style refs
  * inside property schemas get rewritten.
  */
-const SCHEMA_MAP_KEYS: Record<string, true> = { properties: true, patternProperties: true, dependentSchemas: true };
+const SCHEMA_MAP_KEYS = new Set(["properties", "patternProperties", "dependentSchemas"]);
 /**
  * Keys whose values are JSON-Schema *values*, not nested schemas. The upgrade
  * walker must NOT descend into these — `type: ["string","null"]` is not a
@@ -49,7 +49,7 @@ function convertRef(value: string): string {
 
 /** Get-or-create a child object map on `target[key]`. Used to lazily build up `$defs`/`dependentRequired`/`dependentSchemas` during conversion. */
 function getObjectMap(target: JsonObject, key: string): JsonObject {
-	const existing = target[key];
+	const existing = Object.hasOwn(target, key) ? target[key] : undefined;
 	if (isJsonObject(existing)) return existing;
 	const next: JsonObject = {};
 	setOwnKey(target, key, next);
@@ -116,7 +116,7 @@ function mergePrefixItems(existing: unknown, convertedItems: unknown[]): unknown
 /** Record `key → deps` in `dependentRequired`, unioning with any existing array. */
 function mergeDependentRequired(target: JsonObject, key: string, deps: unknown[]): void {
 	const dependentRequired = getObjectMap(target, "dependentRequired");
-	const existing = dependentRequired[key];
+	const existing = Object.hasOwn(dependentRequired, key) ? dependentRequired[key] : undefined;
 	if (existing === undefined) {
 		setOwnKey(dependentRequired, key, deps);
 		return;
@@ -129,7 +129,8 @@ function mergeDependentRequired(target: JsonObject, key: string, deps: unknown[]
 /** Record `key → schema` in `dependentSchemas`, intersecting with any existing entry. */
 function mergeDependentSchema(target: JsonObject, key: string, schema: unknown): void {
 	const dependentSchemas = getObjectMap(target, "dependentSchemas");
-	setOwnKey(dependentSchemas, key, combineSchemas(dependentSchemas[key], schema));
+	const existing = Object.hasOwn(dependentSchemas, key) ? dependentSchemas[key] : undefined;
+	setOwnKey(dependentSchemas, key, combineSchemas(existing, schema));
 }
 
 /**
@@ -216,7 +217,7 @@ function schemaNeedsDraft202012UpgradeImpl(value: unknown, epoch: number): boole
 		if (!Object.hasOwn(value, key)) continue;
 		const entry = value[key];
 		if (key === "$schema") {
-			if (typeof entry === "string" && entry in DRAFT_07_SCHEMA_URIS) return true;
+			if (typeof entry === "string" && Object.hasOwn(DRAFT_07_SCHEMA_URIS, entry)) return true;
 			continue;
 		}
 		if (key === "definitions" || key === "dependencies" || key === "additionalItems" || key === "nullable") {
@@ -227,11 +228,11 @@ function schemaNeedsDraft202012UpgradeImpl(value: unknown, epoch: number): boole
 			continue;
 		}
 		if (key === "items" && Array.isArray(entry)) return true;
-		if (key === "$defs" || key in SCHEMA_MAP_KEYS) {
+		if (key === "$defs" || SCHEMA_MAP_KEYS.has(key)) {
 			if (schemaMapNeedsDraft202012Upgrade(entry, epoch)) return true;
 			continue;
 		}
-		if (key in NON_SCHEMA_VALUE_KEYS) continue;
+		if (Object.hasOwn(NON_SCHEMA_VALUE_KEYS, key)) continue;
 		if (schemaNeedsDraft202012UpgradeImpl(entry, epoch)) return true;
 	}
 
@@ -273,12 +274,12 @@ function upgradeJsonSchemaTo202012Impl(value: unknown, cache: WeakMap<object, un
 			continue;
 		}
 		// Recurse into each entry; the map shape itself is preserved.
-		if (key in SCHEMA_MAP_KEYS) {
+		if (SCHEMA_MAP_KEYS.has(key)) {
 			copySchemaMap(result, key, entry, cache);
 			continue;
 		}
 		// JSON-Schema *value* keywords — copy verbatim.
-		if (key in NON_SCHEMA_VALUE_KEYS) {
+		if (Object.hasOwn(NON_SCHEMA_VALUE_KEYS, key)) {
 			setOwnKey(result, key, entry);
 			continue;
 		}
@@ -290,7 +291,9 @@ function upgradeJsonSchemaTo202012Impl(value: unknown, cache: WeakMap<object, un
 		// Rewrite `$schema` URI to the 2020-12 form; non-draft-07 URIs pass through.
 		if (key === "$schema") {
 			result.$schema =
-				typeof entry === "string" && entry in DRAFT_07_SCHEMA_URIS ? JSON_SCHEMA_DRAFT_2020_12_URI : entry;
+				typeof entry === "string" && Object.hasOwn(DRAFT_07_SCHEMA_URIS, entry)
+					? JSON_SCHEMA_DRAFT_2020_12_URI
+					: entry;
 			continue;
 		}
 		// `#/definitions/Foo` → `#/$defs/Foo`.

--- a/packages/ai/src/utils/schema/draft.ts
+++ b/packages/ai/src/utils/schema/draft.ts
@@ -193,6 +193,7 @@ function makeNullable(schema: JsonObject): JsonObject {
 function schemaMapNeedsDraft202012Upgrade(value: unknown, epoch: number): boolean {
 	if (!isJsonObject(value)) return false;
 	for (const k in value) {
+		if (!Object.hasOwn(value, k)) continue;
 		if (schemaNeedsDraft202012UpgradeImpl(value[k], epoch)) return true;
 	}
 	return false;

--- a/packages/ai/src/utils/schema/draft.ts
+++ b/packages/ai/src/utils/schema/draft.ts
@@ -34,6 +34,14 @@ const NON_SCHEMA_VALUE_KEYS: Record<string, true> = {
 	type: true,
 };
 
+function setOwnKey(target: JsonObject, key: string, value: unknown): void {
+	if (key === "__proto__") {
+		Object.defineProperty(target, key, { value, writable: true, enumerable: true, configurable: true });
+		return;
+	}
+	target[key] = value;
+}
+
 /** Rewrite draft-07's `#/definitions/Foo` ref form to draft 2020-12's `#/$defs/Foo`. External refs (`http://…`) pass through. */
 function convertRef(value: string): string {
 	return value.startsWith("#/definitions/") ? `#/$defs/${value.slice("#/definitions/".length)}` : value;
@@ -44,7 +52,7 @@ function getObjectMap(target: JsonObject, key: string): JsonObject {
 	const existing = target[key];
 	if (isJsonObject(existing)) return existing;
 	const next: JsonObject = {};
-	target[key] = next;
+	setOwnKey(target, key, next);
 	return next;
 }
 
@@ -52,13 +60,14 @@ function getObjectMap(target: JsonObject, key: string): JsonObject {
 function mergeSchemaMap(target: JsonObject, key: string, value: JsonObject, cache: WeakMap<object, unknown>): void {
 	const map = getObjectMap(target, key);
 	for (const name in value) {
-		map[name] = upgradeJsonSchemaTo202012Impl(value[name], cache);
+		if (!Object.hasOwn(value, name)) continue;
+		setOwnKey(map, name, upgradeJsonSchemaTo202012Impl(value[name], cache));
 	}
 }
 /** Copy a schema-map field with upgrade; non-object values are passed through verbatim. */
 function copySchemaMap(target: JsonObject, key: string, value: unknown, cache: WeakMap<object, unknown>): void {
 	if (!isJsonObject(value)) {
-		target[key] = value;
+		setOwnKey(target, key, value);
 		return;
 	}
 	mergeSchemaMap(target, key, value, cache);
@@ -109,18 +118,18 @@ function mergeDependentRequired(target: JsonObject, key: string, deps: unknown[]
 	const dependentRequired = getObjectMap(target, "dependentRequired");
 	const existing = dependentRequired[key];
 	if (existing === undefined) {
-		dependentRequired[key] = deps;
+		setOwnKey(dependentRequired, key, deps);
 		return;
 	}
 	if (Array.isArray(existing)) {
-		dependentRequired[key] = mergeArrayValues(existing, deps);
+		setOwnKey(dependentRequired, key, mergeArrayValues(existing, deps));
 	}
 }
 
 /** Record `key → schema` in `dependentSchemas`, intersecting with any existing entry. */
 function mergeDependentSchema(target: JsonObject, key: string, schema: unknown): void {
 	const dependentSchemas = getObjectMap(target, "dependentSchemas");
-	dependentSchemas[key] = combineSchemas(dependentSchemas[key], schema);
+	setOwnKey(dependentSchemas, key, combineSchemas(dependentSchemas[key], schema));
 }
 
 /**
@@ -133,6 +142,7 @@ function convertDependencies(source: JsonObject, target: JsonObject, cache: Weak
 	const dependencies = source.dependencies;
 	if (!isJsonObject(dependencies)) return;
 	for (const key in dependencies) {
+		if (!Object.hasOwn(dependencies, key)) continue;
 		const dependency = dependencies[key];
 		const converted = upgradeJsonSchemaTo202012Impl(dependency, cache);
 		if (Array.isArray(converted)) {
@@ -203,6 +213,7 @@ function schemaNeedsDraft202012UpgradeImpl(value: unknown, epoch: number): boole
 	if (!once(value, epoch)) return false;
 
 	for (const key in value) {
+		if (!Object.hasOwn(value, key)) continue;
 		const entry = value[key];
 		if (key === "$schema") {
 			if (typeof entry === "string" && entry in DRAFT_07_SCHEMA_URIS) return true;
@@ -253,6 +264,7 @@ function upgradeJsonSchemaTo202012Impl(value: unknown, cache: WeakMap<object, un
 	// Seed cache before recursion so back-edges in cyclic graphs resolve.
 	cache.set(value, result);
 	for (const key in value) {
+		if (!Object.hasOwn(value, key)) continue;
 		const entry = value[key];
 		// `definitions` is the draft-07 name; merge under the canonical `$defs`.
 		// `$defs` may appear pre-upgraded — still walk entries to upgrade their bodies.
@@ -267,7 +279,7 @@ function upgradeJsonSchemaTo202012Impl(value: unknown, cache: WeakMap<object, un
 		}
 		// JSON-Schema *value* keywords — copy verbatim.
 		if (key in NON_SCHEMA_VALUE_KEYS) {
-			result[key] = entry;
+			setOwnKey(result, key, entry);
 			continue;
 		}
 		// Draft-07-only keywords with no draft 2020-12 spelling — drop entirely.
@@ -290,7 +302,7 @@ function upgradeJsonSchemaTo202012Impl(value: unknown, cache: WeakMap<object, un
 		if (key === "items" && Array.isArray(entry)) {
 			continue;
 		}
-		result[key] = upgradeJsonSchemaTo202012Impl(entry, cache);
+		setOwnKey(result, key, upgradeJsonSchemaTo202012Impl(entry, cache));
 	}
 
 	// Draft-07 tuple form: `items: [a, b]` (+ optional `additionalItems`) becomes

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -146,7 +146,7 @@ function preHandleNullFields(obj: JsonObject): JsonObject {
 	let sawNull = false;
 	const kept: unknown[] = [];
 	for (const v of variants) {
-		if (isJsonObject(v) && v.type === "null") {
+		if (isJsonObject(v) && Object.hasOwn(v, "type") && v.type === "null") {
 			sawNull = true;
 			continue;
 		}
@@ -299,8 +299,9 @@ function normalizeSchemaNode(value: unknown, options: NormalizeSchemaWalkOptions
 	const result: JsonObject = {};
 	let spill: Array<[string, unknown]> | undefined;
 	for (const combiner of JSON_SCHEMA_COMBINERS) {
-		if (!Array.isArray(obj[combiner])) continue;
-		const variants = obj[combiner] as JsonObject[];
+		const variantsRaw = Object.hasOwn(obj, combiner) ? obj[combiner] : undefined;
+		if (!Array.isArray(variantsRaw)) continue;
+		const variants = variantsRaw as JsonObject[];
 		const allHaveConst = variants.every(v => isJsonObject(v) && Object.hasOwn(v, "const"));
 		if (!allHaveConst || variants.length === 0) continue;
 
@@ -311,7 +312,7 @@ function normalizeSchemaNode(value: unknown, options: NormalizeSchemaWalkOptions
 		result.enum = dedupedEnum;
 
 		const explicitTypes = variants
-			.map(variant => variant.type)
+			.map(variant => (Object.hasOwn(variant, "type") ? variant.type : undefined))
 			.filter((variantType): variantType is string => typeof variantType === "string");
 		const allHaveSameExplicitType =
 			explicitTypes.length === variants.length &&

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -132,7 +132,7 @@ function applySnakeCaseRenames(obj: JsonObject): JsonObject {
  * original reference otherwise (zero-allocation fast path).
  */
 function preHandleNullFields(obj: JsonObject): JsonObject {
-	if (obj.type === "null") {
+	if (Object.hasOwn(obj, "type") && obj.type === "null") {
 		const out: JsonObject = {};
 		for (const k in obj) {
 			if (!Object.hasOwn(obj, k) || k === "type") continue;
@@ -141,7 +141,7 @@ function preHandleNullFields(obj: JsonObject): JsonObject {
 		out.nullable = true;
 		return out;
 	}
-	if (!Array.isArray(obj.anyOf)) return obj;
+	if (!Object.hasOwn(obj, "anyOf") || !Array.isArray(obj.anyOf)) return obj;
 	const variants = obj.anyOf as unknown[];
 	let sawNull = false;
 	const kept: unknown[] = [];
@@ -450,7 +450,7 @@ export function copySchemaWithout(schema: JsonObject, combiner: string): JsonObj
 }
 
 function mergeObjectCombinerVariants(schema: JsonObject, combiner: "anyOf" | "oneOf"): JsonObject {
-	const variantsRaw = schema[combiner];
+	const variantsRaw = Object.hasOwn(schema, combiner) ? schema[combiner] : undefined;
 	if (!Array.isArray(variantsRaw) || variantsRaw.length === 0) {
 		return schema;
 	}
@@ -460,10 +460,10 @@ function mergeObjectCombinerVariants(schema: JsonObject, combiner: "anyOf" | "on
 		if (!isJsonObject(entry)) {
 			return schema;
 		}
-		const variantType = entry.type;
+		const variantType = Object.hasOwn(entry, "type") ? entry.type : undefined;
 		const hasObjectShape =
-			isJsonObject(entry.properties) ||
-			Array.isArray(entry.required) ||
+			(Object.hasOwn(entry, "properties") && isJsonObject(entry.properties)) ||
+			(Object.hasOwn(entry, "required") && Array.isArray(entry.required)) ||
 			Object.hasOwn(entry, "additionalProperties");
 		if (variantType === undefined && !hasObjectShape) {
 			return schema;
@@ -471,29 +471,34 @@ function mergeObjectCombinerVariants(schema: JsonObject, combiner: "anyOf" | "on
 		if (variantType !== undefined && variantType !== "object") {
 			return schema;
 		}
-		if (entry.properties !== undefined && !isJsonObject(entry.properties)) {
+		if (Object.hasOwn(entry, "properties") && !isJsonObject(entry.properties)) {
 			return schema;
 		}
-		if (entry.required !== undefined && !Array.isArray(entry.required)) {
+		if (Object.hasOwn(entry, "required") && !Array.isArray(entry.required)) {
 			return schema;
 		}
 		variants.push(entry);
 	}
 
 	const mergedProperties: JsonObject = {};
-	const ownProperties = isJsonObject(schema.properties) ? schema.properties : {};
+	const ownProperties =
+		Object.hasOwn(schema, "properties") && isJsonObject(schema.properties) ? schema.properties : {};
 	for (const name in ownProperties) {
-		if (Object.hasOwn(ownProperties, name)) mergedProperties[name] = ownProperties[name];
+		if (Object.hasOwn(ownProperties, name)) setOwnKey(mergedProperties, name, ownProperties[name]);
 	}
 
 	for (const variant of variants) {
-		const properties = isJsonObject(variant.properties) ? variant.properties : {};
+		const properties =
+			Object.hasOwn(variant, "properties") && isJsonObject(variant.properties) ? variant.properties : {};
 		for (const name in properties) {
 			if (!Object.hasOwn(properties, name)) continue;
 			const propertySchema = properties[name];
 			const existingSchema = mergedProperties[name];
-			mergedProperties[name] =
-				existingSchema === undefined ? propertySchema : mergePropertySchemas(existingSchema, propertySchema);
+			setOwnKey(
+				mergedProperties,
+				name,
+				existingSchema === undefined ? propertySchema : mergePropertySchemas(existingSchema, propertySchema),
+			);
 		}
 	}
 
@@ -503,9 +508,10 @@ function mergeObjectCombinerVariants(schema: JsonObject, combiner: "anyOf" | "on
 
 	let requiredIntersection: string[] | undefined;
 	for (const variant of variants) {
-		const variantRequired = Array.isArray(variant.required)
-			? variant.required.filter((r): r is string => typeof r === "string")
-			: [];
+		const variantRequired =
+			Object.hasOwn(variant, "required") && Array.isArray(variant.required)
+				? variant.required.filter((r): r is string => typeof r === "string")
+				: [];
 		if (requiredIntersection === undefined) {
 			requiredIntersection = [...variantRequired];
 		} else {
@@ -513,9 +519,10 @@ function mergeObjectCombinerVariants(schema: JsonObject, combiner: "anyOf" | "on
 			requiredIntersection = requiredIntersection.filter(r => reqSet.has(r));
 		}
 	}
-	const parentRequired = Array.isArray(schema.required)
-		? schema.required.filter((r): r is string => typeof r === "string")
-		: [];
+	const parentRequired =
+		Object.hasOwn(schema, "required") && Array.isArray(schema.required)
+			? schema.required.filter((r): r is string => typeof r === "string")
+			: [];
 	const safeRequired = new Set<string>();
 	for (const name of requiredIntersection ?? []) {
 		if (Object.hasOwn(mergedProperties, name)) safeRequired.add(name);
@@ -539,7 +546,7 @@ function mergeObjectCombinerVariants(schema: JsonObject, combiner: "anyOf" | "on
 }
 
 function collapseMixedTypeCombinerVariants(schema: JsonObject, combiner: "anyOf" | "oneOf"): JsonObject {
-	const variantsRaw = schema[combiner];
+	const variantsRaw = Object.hasOwn(schema, combiner) ? schema[combiner] : undefined;
 	if (!Array.isArray(variantsRaw) || variantsRaw.length === 0) {
 		return schema;
 	}
@@ -548,7 +555,7 @@ function collapseMixedTypeCombinerVariants(schema: JsonObject, combiner: "anyOf"
 	const variantTypes: string[] = [];
 	const mergedVariantFields: JsonObject = {};
 	for (const entry of variantsRaw) {
-		if (!isJsonObject(entry) || typeof entry.type !== "string") {
+		if (!isJsonObject(entry) || !Object.hasOwn(entry, "type") || typeof entry.type !== "string") {
 			return schema;
 		}
 
@@ -574,7 +581,7 @@ function collapseMixedTypeCombinerVariants(schema: JsonObject, combiner: "anyOf"
 			if (existingValue !== undefined && !areJsonValuesEqual(existingValue, variantValue)) {
 				return schema;
 			}
-			mergedVariantFields[key] = variantValue;
+			setOwnKey(mergedVariantFields, key, variantValue);
 		}
 
 		seenTypes.add(variantType);
@@ -596,19 +603,19 @@ function collapseMixedTypeCombinerVariants(schema: JsonObject, combiner: "anyOf"
 			return schema;
 		}
 		if (existingValue === undefined) {
-			nextSchema[key] = value;
+			setOwnKey(nextSchema, key, value);
 		}
 	}
 	return nextSchema;
 }
 
 function collapseSameTypeCombinerVariants(schema: JsonObject, combiner: "anyOf" | "oneOf"): JsonObject {
-	const variantsRaw = schema[combiner];
+	const variantsRaw = Object.hasOwn(schema, combiner) ? schema[combiner] : undefined;
 	if (!Array.isArray(variantsRaw) || variantsRaw.length === 0) return schema;
 	let commonType: string | undefined;
 	let firstEntry: JsonObject | undefined;
 	for (const entry of variantsRaw) {
-		if (!isJsonObject(entry) || typeof entry.type !== "string") return schema;
+		if (!isJsonObject(entry) || !Object.hasOwn(entry, "type") || typeof entry.type !== "string") return schema;
 		if (commonType === undefined) {
 			commonType = entry.type;
 			firstEntry = entry;
@@ -617,7 +624,7 @@ function collapseSameTypeCombinerVariants(schema: JsonObject, combiner: "anyOf" 
 	if (!firstEntry) return schema;
 	const nextSchema = copySchemaWithout(schema, combiner);
 	for (const key in firstEntry) {
-		if (Object.hasOwn(firstEntry, key) && !outHasOwn(nextSchema, key)) nextSchema[key] = firstEntry[key];
+		if (Object.hasOwn(firstEntry, key) && !outHasOwn(nextSchema, key)) setOwnKey(nextSchema, key, firstEntry[key]);
 	}
 	return nextSchema;
 }
@@ -636,7 +643,12 @@ export function stripResidualCombiners(value: unknown, epoch: number = epochNext
 	if (!once(value, epoch)) return {};
 	const result: JsonObject = {};
 	for (const key in value) {
-		if (Object.hasOwn(value, key)) result[key] = stripResidualCombiners(value[key], epoch);
+		if (!Object.hasOwn(value, key)) continue;
+		if (JSON_SCHEMA_LITERAL_PAYLOAD_KEYS.has(key)) {
+			setOwnKey(result, key, value[key]);
+			continue;
+		}
+		setOwnKey(result, key, stripResidualCombiners(value[key], epoch));
 	}
 	let current: JsonObject = result;
 	let changed = true;
@@ -668,13 +680,13 @@ function extractNullableUnionSchema(schema: unknown): NullableExtractionResult {
 		return { schema, nullable: false };
 	}
 
-	if (schema.nullable === true) {
+	if (Object.hasOwn(schema, "nullable") && schema.nullable === true) {
 		const nextSchema = { ...schema };
 		delete nextSchema.nullable;
 		return { schema: nextSchema, nullable: true };
 	}
 
-	if (Array.isArray(schema.type)) {
+	if (Object.hasOwn(schema, "type") && Array.isArray(schema.type)) {
 		const typeVariants = schema.type.filter((entry): entry is string => typeof entry === "string");
 		const nonNullTypes = typeVariants.filter(entry => entry !== "null");
 		if (typeVariants.includes("null") && nonNullTypes.length === 1) {
@@ -684,13 +696,13 @@ function extractNullableUnionSchema(schema: unknown): NullableExtractionResult {
 	}
 
 	for (const combiner of JSON_SCHEMA_COMBINERS) {
-		const variantsRaw = schema[combiner];
+		const variantsRaw = Object.hasOwn(schema, combiner) ? schema[combiner] : undefined;
 		if (!Array.isArray(variantsRaw)) continue;
 
 		let hasNullVariant = false;
 		const nonNullVariants: unknown[] = [];
 		for (const variant of variantsRaw) {
-			if (isJsonObject(variant) && variant.type === "null") {
+			if (isJsonObject(variant) && Object.hasOwn(variant, "type") && variant.type === "null") {
 				let keyCount = 0;
 				for (const k in variant) {
 					if (!Object.hasOwn(variant, k)) continue;
@@ -718,7 +730,7 @@ function extractNullableUnionSchema(schema: unknown): NullableExtractionResult {
 				return { schema, nullable: false };
 			}
 			if (existingValue === undefined) {
-				nextSchema[key] = value;
+				setOwnKey(nextSchema, key, value);
 			}
 		}
 		return { schema: nextSchema, nullable: true };
@@ -755,8 +767,12 @@ function normalizeNullablePropertiesForCloudCodeAssist(
 
 	const normalized: JsonObject = {};
 	for (const key in value) {
-		if (Object.hasOwn(value, key))
-			normalized[key] = normalizeNullablePropertiesForCloudCodeAssist(value[key], false, epoch).schema;
+		if (!Object.hasOwn(value, key)) continue;
+		if (JSON_SCHEMA_LITERAL_PAYLOAD_KEYS.has(key)) {
+			setOwnKey(normalized, key, value[key]);
+			continue;
+		}
+		setOwnKey(normalized, key, normalizeNullablePropertiesForCloudCodeAssist(value[key], false, epoch).schema);
 	}
 
 	if (isJsonObject(normalized.properties)) {
@@ -770,7 +786,7 @@ function normalizeNullablePropertiesForCloudCodeAssist(
 		for (const name in properties) {
 			if (!Object.hasOwn(properties, name)) continue;
 			const normalizedProperty = normalizeNullablePropertiesForCloudCodeAssist(properties[name], true, epoch);
-			nextProperties[name] = normalizedProperty.schema;
+			setOwnKey(nextProperties, name, normalizedProperty.schema);
 			if (normalizedProperty.nullable) {
 				required.delete(name);
 			}
@@ -833,16 +849,17 @@ function hasResidualSchemaIncompatibilities(
 		return false;
 	}
 
-	if (checks.typeArray && Array.isArray(value.type)) return true;
-	if (checks.typeNull && value.type === "null") return true;
+	if (checks.typeArray && Object.hasOwn(value, "type") && Array.isArray(value.type)) return true;
+	if (checks.typeNull && Object.hasOwn(value, "type") && value.type === "null") return true;
 	if (checks.nullable && Object.hasOwn(value, "nullable")) return true;
 	if (checks.combiners) {
 		for (const combiner of CCA_FORBIDDEN_COMBINERS) {
-			if (Array.isArray(value[combiner])) return true;
+			if (Object.hasOwn(value, combiner) && Array.isArray(value[combiner])) return true;
 		}
 	}
 	for (const k in value) {
 		if (!Object.hasOwn(value, k)) continue;
+		if (JSON_SCHEMA_LITERAL_PAYLOAD_KEYS.has(k)) continue;
 		if (hasResidualSchemaIncompatibilities(value[k], checks, epoch)) {
 			return true;
 		}
@@ -1130,7 +1147,7 @@ function normalizeOpenAIResponsesSchemaNode(value: unknown, cache: WeakMap<JsonO
 		}
 
 		if (next !== child) changed = true;
-		output[key] = next;
+		setOwnKey(output, key, next);
 	}
 
 	if (Array.isArray(value.oneOf)) {
@@ -1144,7 +1161,7 @@ function normalizeOpenAIResponsesSchemaNode(value: unknown, cache: WeakMap<JsonO
 	// Draft 2020-12 lets `type` be an array (e.g. `["object", "null"]`); treat
 	// any variant that includes "object" as an object position for the
 	// properties requirement.
-	if (declaresObjectType(value.type) && !Object.hasOwn(value, "properties")) {
+	if (Object.hasOwn(value, "type") && declaresObjectType(value.type) && !Object.hasOwn(value, "properties")) {
 		output.properties = {};
 		changed = true;
 	}
@@ -1185,7 +1202,7 @@ function normalizeOpenAIResponsesSchemaMap(schemaMap: JsonObject, cache: WeakMap
 		const child = schemaMap[key];
 		const next = normalizeOpenAIResponsesSchemaNode(child, cache);
 		if (next !== child) changed = true;
-		output[key] = next;
+		setOwnKey(output, key, next);
 	}
 	return changed ? output : schemaMap;
 }
@@ -1267,21 +1284,24 @@ function hasUnrepresentableStrictObjectMap(schema: Record<string, unknown>, epoc
 	if (!once(schema, epoch)) return false;
 
 	let hasPatternProperties = false;
-	if (isJsonObject(schema.patternProperties)) {
+	if (Object.hasOwn(schema, "patternProperties") && isJsonObject(schema.patternProperties)) {
 		for (const _ in schema.patternProperties) {
 			hasPatternProperties = true;
 			break;
 		}
 	}
-	const additionalPropertiesValue = schema.additionalProperties;
+	const additionalPropertiesValue = Object.hasOwn(schema, "additionalProperties")
+		? schema.additionalProperties
+		: undefined;
 	const hasSchemaAdditionalProperties = additionalPropertiesValue === true || isJsonObject(additionalPropertiesValue);
 	if (hasPatternProperties || hasSchemaAdditionalProperties) {
 		return true;
 	}
 
-	if (isJsonObject(schema.properties)) {
+	if (Object.hasOwn(schema, "properties") && isJsonObject(schema.properties)) {
 		const properties = schema.properties;
 		for (const k in properties) {
+			if (!Object.hasOwn(properties, k)) continue;
 			const propertySchema = properties[k];
 			if (isJsonObject(propertySchema) && hasUnrepresentableStrictObjectMap(propertySchema, epoch)) {
 				return true;
@@ -1289,18 +1309,18 @@ function hasUnrepresentableStrictObjectMap(schema: Record<string, unknown>, epoc
 		}
 	}
 
-	if (isJsonObject(schema.items)) {
+	if (Object.hasOwn(schema, "items") && isJsonObject(schema.items)) {
 		if (hasUnrepresentableStrictObjectMap(schema.items, epoch)) {
 			return true;
 		}
-	} else if (Array.isArray(schema.items)) {
+	} else if (Object.hasOwn(schema, "items") && Array.isArray(schema.items)) {
 		for (const itemSchema of schema.items) {
 			if (isJsonObject(itemSchema) && hasUnrepresentableStrictObjectMap(itemSchema, epoch)) {
 				return true;
 			}
 		}
 	}
-	if (Array.isArray(schema.prefixItems)) {
+	if (Object.hasOwn(schema, "prefixItems") && Array.isArray(schema.prefixItems)) {
 		for (const itemSchema of schema.prefixItems) {
 			if (isJsonObject(itemSchema) && hasUnrepresentableStrictObjectMap(itemSchema, epoch)) {
 				return true;
@@ -1309,7 +1329,7 @@ function hasUnrepresentableStrictObjectMap(schema: Record<string, unknown>, epoc
 	}
 
 	for (const key of COMBINATOR_KEYS) {
-		const variants = schema[key];
+		const variants = Object.hasOwn(schema, key) ? schema[key] : undefined;
 		if (!Array.isArray(variants)) continue;
 		for (const variant of variants) {
 			if (isJsonObject(variant) && hasUnrepresentableStrictObjectMap(variant, epoch)) {
@@ -1319,9 +1339,10 @@ function hasUnrepresentableStrictObjectMap(schema: Record<string, unknown>, epoc
 	}
 
 	for (const defsKey of ["$defs", "definitions"] as const) {
-		const defs = schema[defsKey];
+		const defs = Object.hasOwn(schema, defsKey) ? schema[defsKey] : undefined;
 		if (!isJsonObject(defs)) continue;
 		for (const k in defs) {
+			if (!Object.hasOwn(defs, k)) continue;
 			const defSchema = defs[k];
 			if (isJsonObject(defSchema) && hasUnrepresentableStrictObjectMap(defSchema, epoch)) {
 				return true;
@@ -1364,7 +1385,7 @@ export function sanitizeSchemaForStrictMode(
 	// OpenAI strict mode forbids `{$ref, description, ...}`; the SDK resolves
 	// and merges, with sibling keys taking precedence over the ref'd def.
 	// Cite: openai-python/src/openai/lib/_pydantic.py:96-110 (`_ensure_strict_json_schema`)
-	if (typeof schema.$ref === "string") {
+	if (Object.hasOwn(schema, "$ref") && typeof schema.$ref === "string") {
 		let hasSibling = false;
 		for (const k in schema) {
 			if (k !== "$ref" && Object.hasOwn(schema, k)) {
@@ -1379,7 +1400,7 @@ export function sanitizeSchemaForStrictMode(
 				const merged: Record<string, unknown> = { ...resolved };
 				for (const k in schema) {
 					if (k === "$ref" || !Object.hasOwn(schema, k)) continue;
-					merged[k] = schema[k];
+					setOwnKey(merged, k, schema[k]);
 				}
 				const result = sanitizeSchemaForStrictMode(merged, epoch, cache, root);
 				cache.set(schema, result);
@@ -1393,13 +1414,13 @@ export function sanitizeSchemaForStrictMode(
 	// entry's keys WIN over original sibling keys, then `allOf` is dropped.
 	// Cite: openai-python/src/openai/lib/_pydantic.py:79-83
 	{
-		const allOf = schema.allOf;
+		const allOf = Object.hasOwn(schema, "allOf") ? schema.allOf : undefined;
 		if (Array.isArray(allOf) && allOf.length === 1 && isJsonObject(allOf[0])) {
 			const merged: Record<string, unknown> = { ...schema };
 			delete merged.allOf;
 			const sole = allOf[0] as Record<string, unknown>;
 			for (const k in sole) {
-				if (Object.hasOwn(sole, k)) merged[k] = sole[k];
+				if (Object.hasOwn(sole, k)) setOwnKey(merged, k, sole[k]);
 			}
 			const result = sanitizeSchemaForStrictMode(merged, epoch, cache, root);
 			cache.set(schema, result);
@@ -1407,7 +1428,7 @@ export function sanitizeSchemaForStrictMode(
 		}
 	}
 
-	const typeValue = schema.type;
+	const typeValue = Object.hasOwn(schema, "type") ? schema.type : undefined;
 	if (Array.isArray(typeValue)) {
 		const typeVariants = typeValue.filter((entry): entry is string => typeof entry === "string");
 		const schemaWithoutType = { ...schema };
@@ -1460,8 +1481,9 @@ export function sanitizeSchemaForStrictMode(
 	const sanitized: Record<string, unknown> = {};
 	cache.set(schema, sanitized);
 	for (const key in schema) {
+		if (!Object.hasOwn(schema, key)) continue;
 		const value = schema[key];
-		if (key in NON_STRUCTURAL_SCHEMA_KEYS || key === "type" || key === "const" || key === "nullable") {
+		if (Object.hasOwn(NON_STRUCTURAL_SCHEMA_KEYS, key) || key === "type" || key === "const" || key === "nullable") {
 			continue;
 		}
 		// `properties` map — recurse into each property schema.
@@ -1469,10 +1491,15 @@ export function sanitizeSchemaForStrictMode(
 		if (key === "properties" && isJsonObject(value)) {
 			const properties: Record<string, unknown> = {};
 			for (const propertyName in value) {
+				if (!Object.hasOwn(value, propertyName)) continue;
 				const propertySchema = value[propertyName];
-				properties[propertyName] = isJsonObject(propertySchema)
-					? sanitizeSchemaForStrictMode(propertySchema, epoch, cache, root)
-					: propertySchema;
+				setOwnKey(
+					properties,
+					propertyName,
+					isJsonObject(propertySchema)
+						? sanitizeSchemaForStrictMode(propertySchema, epoch, cache, root)
+						: propertySchema,
+				);
 			}
 			sanitized.properties = properties;
 			continue;
@@ -1502,8 +1529,10 @@ export function sanitizeSchemaForStrictMode(
 		// `anyOf`/`oneOf`/`allOf` arrays — recurse into each branch.
 
 		if (COMBINATOR_KEYS.includes(key as (typeof COMBINATOR_KEYS)[number]) && Array.isArray(value)) {
-			sanitized[key] = value.map(entry =>
-				isJsonObject(entry) ? sanitizeSchemaForStrictMode(entry, epoch, cache, root) : entry,
+			setOwnKey(
+				sanitized,
+				key,
+				value.map(entry => (isJsonObject(entry) ? sanitizeSchemaForStrictMode(entry, epoch, cache, root) : entry)),
 			);
 			continue;
 		}
@@ -1512,12 +1541,17 @@ export function sanitizeSchemaForStrictMode(
 		if ((key === "$defs" || key === "definitions") && isJsonObject(value)) {
 			const defs: Record<string, unknown> = {};
 			for (const definitionName in value) {
+				if (!Object.hasOwn(value, definitionName)) continue;
 				const definitionSchema = value[definitionName];
-				defs[definitionName] = isJsonObject(definitionSchema)
-					? sanitizeSchemaForStrictMode(definitionSchema, epoch, cache, root)
-					: definitionSchema;
+				setOwnKey(
+					defs,
+					definitionName,
+					isJsonObject(definitionSchema)
+						? sanitizeSchemaForStrictMode(definitionSchema, epoch, cache, root)
+						: definitionSchema,
+				);
 			}
-			sanitized[key] = defs;
+			setOwnKey(sanitized, key, defs);
 			continue;
 		}
 		// `additionalProperties` is owned by `enforceStrictSchema`, which sets it to false.
@@ -1526,7 +1560,12 @@ export function sanitizeSchemaForStrictMode(
 			continue;
 		}
 
-		if (key === "description" && typeof value === "string" && schema.default !== undefined) {
+		if (
+			key === "description" &&
+			typeof value === "string" &&
+			Object.hasOwn(schema, "default") &&
+			schema.default !== undefined
+		) {
 			// Preserve `default:` info for strict-mode providers that strip the keyword.
 			// Inline as `(default: X)` text in the description, matching the convention for
 			// runtime-placeholder defaults (e.g. `cwd`) that cannot live in the keyword form.
@@ -1536,7 +1575,7 @@ export function sanitizeSchemaForStrictMode(
 			continue;
 		}
 
-		sanitized[key] = value;
+		setOwnKey(sanitized, key, value);
 	}
 	// Post-pass: re-derive `type` and turn dropped keywords into a representable shape.
 
@@ -1572,7 +1611,7 @@ export function sanitizeSchemaForStrictMode(
 	// `description` hoists to the wrapper so both branches share it without
 	// duplication — matches the optional-property wrap in `enforceStrictSchema`
 	// and the typical OpenAI strict-mode "description on the union" shape.
-	if (schema.nullable === true) {
+	if (Object.hasOwn(schema, "nullable") && schema.nullable === true) {
 		const { nullable: _, description, ...withoutNullable } = sanitized;
 		const wrapper: JsonObject = { anyOf: [withoutNullable, { type: "null" }] };
 		if (description !== undefined) wrapper.description = description;
@@ -1634,6 +1673,7 @@ function enforceStrictSchemaBody(
 		);
 		const strictProperties: Record<string, unknown> = {};
 		for (const key in props) {
+			if (!Object.hasOwn(props, key)) continue;
 			const value = props[key];
 			const processed =
 				value != null && typeof value === "object" && !Array.isArray(value)
@@ -1645,20 +1685,20 @@ function enforceStrictSchemaBody(
 				if (
 					isJsonObject(processed) &&
 					Array.isArray(processed.anyOf) &&
-					processed.anyOf.some(v => isJsonObject(v) && v.type === "null")
+					processed.anyOf.some(v => isJsonObject(v) && Object.hasOwn(v, "type") && v.type === "null")
 				) {
-					strictProperties[key] = processed;
+					setOwnKey(strictProperties, key, processed);
 					continue;
 				}
 				if (isJsonObject(processed) && typeof processed.description === "string") {
 					const { description, ...withoutDescription } = processed;
-					strictProperties[key] = { anyOf: [withoutDescription, { type: "null" }], description };
+					setOwnKey(strictProperties, key, { anyOf: [withoutDescription, { type: "null" }], description });
 					continue;
 				}
-				strictProperties[key] = { anyOf: [processed, { type: "null" }] };
+				setOwnKey(strictProperties, key, { anyOf: [processed, { type: "null" }] });
 				continue;
 			}
-			strictProperties[key] = processed;
+			setOwnKey(strictProperties, key, processed);
 		}
 		result.properties = strictProperties;
 		result.required = Object.keys(strictProperties);
@@ -1682,26 +1722,39 @@ function enforceStrictSchemaBody(
 		);
 	}
 	for (const key of COMBINATOR_KEYS) {
-		if (Array.isArray(result[key])) {
-			result[key] = (result[key] as unknown[]).map(entry =>
-				entry != null && typeof entry === "object" && !Array.isArray(entry)
-					? enforceStrictSchema(entry as Record<string, unknown>, cache)
-					: entry,
+		if (Object.hasOwn(result, key) && Array.isArray(result[key])) {
+			setOwnKey(
+				result,
+				key,
+				(result[key] as unknown[]).map(entry =>
+					entry != null && typeof entry === "object" && !Array.isArray(entry)
+						? enforceStrictSchema(entry as Record<string, unknown>, cache)
+						: entry,
+				),
 			);
 		}
 	}
 	for (const defsKey of ["$defs", "definitions"] as const) {
-		if (result[defsKey] != null && typeof result[defsKey] === "object" && !Array.isArray(result[defsKey])) {
+		if (
+			Object.hasOwn(result, defsKey) &&
+			result[defsKey] != null &&
+			typeof result[defsKey] === "object" &&
+			!Array.isArray(result[defsKey])
+		) {
 			const defs = result[defsKey] as Record<string, unknown>;
 			const nextDefs: Record<string, unknown> = {};
 			for (const name in defs) {
+				if (!Object.hasOwn(defs, name)) continue;
 				const def = defs[name];
-				nextDefs[name] =
+				setOwnKey(
+					nextDefs,
+					name,
 					def != null && typeof def === "object" && !Array.isArray(def)
 						? enforceStrictSchema(def as Record<string, unknown>, cache)
-						: def;
+						: def,
+				);
 			}
-			result[defsKey] = nextDefs;
+			setOwnKey(result, defsKey, nextDefs);
 		}
 	}
 	// Strict mode requires every schema node to declare a concrete type (or

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -301,7 +301,7 @@ function normalizeSchemaNode(value: unknown, options: NormalizeSchemaWalkOptions
 	for (const combiner of JSON_SCHEMA_COMBINERS) {
 		if (!Array.isArray(obj[combiner])) continue;
 		const variants = obj[combiner] as JsonObject[];
-		const allHaveConst = variants.every(v => isJsonObject(v) && "const" in v);
+		const allHaveConst = variants.every(v => isJsonObject(v) && Object.hasOwn(v, "const"));
 		if (!allHaveConst || variants.length === 0) continue;
 
 		const dedupedEnum: unknown[] = [];

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -70,6 +70,14 @@ const SNAKE_TO_CAMEL_RENAMES = new Map<string, string>([
 
 const JSON_SCHEMA_COMBINERS = ["anyOf", "oneOf"] as const;
 const CCA_FORBIDDEN_COMBINERS = new Set(["anyOf", "oneOf", "allOf"]);
+const JSON_SCHEMA_MAP_KEYS = new Set([
+	"properties",
+	"patternProperties",
+	"dependencies",
+	"dependentSchemas",
+	"$defs",
+	"definitions",
+]);
 
 const CLOUD_CODE_ASSIST_CLAUDE_FALLBACK_SCHEMA = {
 	type: "object",
@@ -269,6 +277,21 @@ function normalizeSchemaNode(value: unknown, options: NormalizeSchemaWalkOptions
 		return value;
 	}
 	if (!once(value, options.epoch)) return {};
+	if (options.insideProperties) {
+		let changed = false;
+		const result: JsonObject = {};
+		for (const key in value) {
+			if (!Object.hasOwn(value, key)) continue;
+			const child = value[key];
+			const next = normalizeSchemaNode(child, {
+				...options,
+				insideProperties: false,
+			});
+			if (next !== child) changed = true;
+			setOwnKey(result, key, next);
+		}
+		return changed ? result : value;
+	}
 	let obj = options.normalizeFieldNames && !options.insideProperties ? applySnakeCaseRenames(value) : value;
 	if (options.collapseNullFields && !options.insideProperties) {
 		obj = preHandleNullFields(obj);
@@ -331,7 +354,7 @@ function normalizeSchemaNode(value: unknown, options: NormalizeSchemaWalkOptions
 				key,
 				normalizeSchemaNode(entry, {
 					...options,
-					insideProperties: key === "properties",
+					insideProperties: JSON_SCHEMA_MAP_KEYS.has(key),
 				}),
 			);
 		}
@@ -361,7 +384,7 @@ function normalizeSchemaNode(value: unknown, options: NormalizeSchemaWalkOptions
 			key,
 			normalizeSchemaNode(entry, {
 				...options,
-				insideProperties: key === "properties",
+				insideProperties: JSON_SCHEMA_MAP_KEYS.has(key),
 			}),
 		);
 	}

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -832,8 +832,101 @@ export function normalizeSchemaForCCA(value: unknown): unknown {
 	});
 }
 
+const MCP_SCHEMA_ARRAY_KEYS = new Set(["anyOf", "oneOf", "allOf", "prefixItems"]);
+const MCP_SCHEMA_MAP_KEYS = new Set([
+	"properties",
+	"patternProperties",
+	"dependencies",
+	"dependentSchemas",
+	"$defs",
+	"definitions",
+]);
+const MCP_SCHEMA_VALUE_KEYS = new Set([
+	"items",
+	"additionalItems",
+	"contains",
+	"contentSchema",
+	"propertyNames",
+	"if",
+	"then",
+	"else",
+	"not",
+	"additionalProperties",
+	"unevaluatedItems",
+	"unevaluatedProperties",
+]);
+
+function makeImplicitMcpObjectMapsExplicit(value: unknown): unknown {
+	return normalizeMcpObjectMapNode(value, new WeakMap());
+}
+
+function normalizeMcpObjectMapNode(value: unknown, cache: WeakMap<JsonObject, JsonObject>): unknown {
+	if (!isJsonObject(value)) return value;
+	const cached = cache.get(value);
+	if (cached) return cached;
+
+	const output: JsonObject = {};
+	cache.set(value, output);
+	let changed = false;
+
+	for (const key in value) {
+		if (!Object.hasOwn(value, key)) continue;
+		const child = value[key];
+		let next: unknown = child;
+		if (MCP_SCHEMA_MAP_KEYS.has(key) && isJsonObject(child)) {
+			next = normalizeMcpObjectMap(child, cache);
+		} else if (MCP_SCHEMA_ARRAY_KEYS.has(key) && Array.isArray(child)) {
+			next = normalizeMcpObjectMapArray(child, cache);
+		} else if (MCP_SCHEMA_VALUE_KEYS.has(key)) {
+			next = Array.isArray(child)
+				? normalizeMcpObjectMapArray(child, cache)
+				: normalizeMcpObjectMapNode(child, cache);
+		}
+		if (next !== child) changed = true;
+		output[key] = next;
+	}
+
+	if (
+		declaresObjectType(value.type) &&
+		!Object.hasOwn(value, "properties") &&
+		!Object.hasOwn(value, "additionalProperties") &&
+		!Object.hasOwn(value, "patternProperties") &&
+		!Object.hasOwn(value, "unevaluatedProperties")
+	) {
+		output.additionalProperties = true;
+		changed = true;
+	}
+
+	const result = changed ? output : value;
+	cache.set(value, result);
+	return result;
+}
+
+function normalizeMcpObjectMapArray(value: unknown[], cache: WeakMap<JsonObject, JsonObject>): unknown[] {
+	let changed = false;
+	const output = value.map(item => {
+		const next = normalizeMcpObjectMapNode(item, cache);
+		if (next !== item) changed = true;
+		return next;
+	});
+	return changed ? output : value;
+}
+
+function normalizeMcpObjectMap(schemaMap: JsonObject, cache: WeakMap<JsonObject, JsonObject>): JsonObject {
+	let changed = false;
+	const output: JsonObject = {};
+	for (const key in schemaMap) {
+		if (!Object.hasOwn(schemaMap, key)) continue;
+		const child = schemaMap[key];
+		const next = normalizeMcpObjectMapNode(child, cache);
+		if (next !== child) changed = true;
+		output[key] = next;
+	}
+	return changed ? output : schemaMap;
+}
+
 export function normalizeSchemaForMCP(value: unknown): unknown {
-	return normalizeSchema(value, {
+	const normalized = normalizeSchema(value, {
 		unsupportedFields: isMcpUnsupportedSchemaField,
 		normalizeFieldNames: false,
 		collapseNullFields: false,
@@ -848,6 +941,7 @@ export function normalizeSchemaForMCP(value: unknown): unknown {
 		stripResidualCombinersFixpoint: false,
 		extractNullableFromUnions: false,
 	});
+	return makeImplicitMcpObjectMapsExplicit(normalized);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -969,8 +969,9 @@ function normalizeMcpObjectMapNode(value: unknown, cache: WeakMap<JsonObject, Js
 		setOwnKey(output, key, next);
 	}
 
+	const schemaType = Object.hasOwn(value, "type") ? value.type : undefined;
 	if (
-		declaresObjectType(value.type) &&
+		declaresObjectType(schemaType) &&
 		!Object.hasOwn(value, "properties") &&
 		!Object.hasOwn(value, "additionalProperties") &&
 		!Object.hasOwn(value, "patternProperties") &&

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -109,9 +109,9 @@ function applySnakeCaseRenames(obj: JsonObject): JsonObject {
 		if (!Object.hasOwn(obj, k)) continue;
 		const renamed = SNAKE_TO_CAMEL_RENAMES.get(k);
 		if (renamed !== undefined) {
-			out[renamed] = obj[k];
+			setOwnKey(out, renamed, obj[k]);
 		} else if (!outHasOwn(out, k)) {
-			out[k] = obj[k];
+			setOwnKey(out, k, obj[k]);
 		}
 	}
 	return out;
@@ -128,7 +128,7 @@ function preHandleNullFields(obj: JsonObject): JsonObject {
 		const out: JsonObject = {};
 		for (const k in obj) {
 			if (!Object.hasOwn(obj, k) || k === "type") continue;
-			out[k] = obj[k];
+			setOwnKey(out, k, obj[k]);
 		}
 		out.nullable = true;
 		return out;
@@ -147,7 +147,7 @@ function preHandleNullFields(obj: JsonObject): JsonObject {
 	if (!sawNull) return obj;
 	const out: JsonObject = {};
 	for (const k in obj) {
-		if (Object.hasOwn(obj, k)) out[k] = obj[k];
+		if (Object.hasOwn(obj, k)) setOwnKey(out, k, obj[k]);
 	}
 	out.nullable = true;
 	if (kept.length === 0) {
@@ -156,7 +156,7 @@ function preHandleNullFields(obj: JsonObject): JsonObject {
 		delete out.anyOf;
 		const only = kept[0];
 		for (const k in only) {
-			if (Object.hasOwn(only, k) && !outHasOwn(out, k)) out[k] = only[k];
+			if (Object.hasOwn(only, k) && !outHasOwn(out, k)) setOwnKey(out, k, only[k]);
 		}
 	} else {
 		out.anyOf = kept;
@@ -166,6 +166,50 @@ function preHandleNullFields(obj: JsonObject): JsonObject {
 
 function outHasOwn(obj: JsonObject, key: string): boolean {
 	return Object.hasOwn(obj, key);
+}
+
+/**
+ * Setter-independent own-data write. `JSON.parse` produces `__proto__` as an own
+ * data property, but plain-object assignment routes it to `Object.prototype`'s
+ * `__proto__` setter, so the key would be silently dropped from the copy (and a
+ * schema-shaped value would mutate the copy's prototype). Every schema copy site
+ * writes through this helper so arbitrary property names round-trip as data.
+ */
+function setOwnKey(target: JsonObject, key: string, value: unknown): void {
+	if (key === "__proto__") {
+		Object.defineProperty(target, key, { value, writable: true, enumerable: true, configurable: true });
+		return;
+	}
+	target[key] = value;
+}
+
+/**
+ * JSON Schema keywords whose values are literal instance data, not subschemas.
+ * The schema walkers must copy them verbatim: recursing into them rewrites user
+ * payloads (a `default` of `{type:"object",nullable:true}` is a default value,
+ * not a nullable object schema).
+ */
+const JSON_SCHEMA_LITERAL_PAYLOAD_KEYS = new Set(["default", "const", "enum", "examples"]);
+
+/** Deep copy of literal payload data; preserves arbitrary keys and breaks aliasing to the caller's input. */
+function cloneJsonLiteral(value: unknown, seen?: WeakMap<object, unknown>): unknown {
+	if (!value || typeof value !== "object") return value;
+	const cache = seen ?? new WeakMap<object, unknown>();
+	const cached = cache.get(value);
+	if (cached !== undefined) return cached;
+	if (Array.isArray(value)) {
+		const out: unknown[] = [];
+		cache.set(value, out);
+		for (const entry of value) out.push(cloneJsonLiteral(entry, cache));
+		return out;
+	}
+	const out: JsonObject = {};
+	cache.set(value, out);
+	for (const key in value as JsonObject) {
+		if (!Object.hasOwn(value, key)) continue;
+		setOwnKey(out, key, cloneJsonLiteral((value as JsonObject)[key], cache));
+	}
+	return out;
 }
 
 function inferJsonSchemaTypeFromValue(value: unknown): string | undefined {
@@ -239,7 +283,7 @@ function normalizeSchemaNode(value: unknown, options: NormalizeSchemaWalkOptions
 
 		const dedupedEnum: unknown[] = [];
 		for (const variant of variants) {
-			pushEnumValue(dedupedEnum, variant.const);
+			pushEnumValue(dedupedEnum, cloneJsonLiteral(variant.const));
 		}
 		result.enum = dedupedEnum;
 
@@ -278,10 +322,18 @@ function normalizeSchemaNode(value: unknown, options: NormalizeSchemaWalkOptions
 				continue;
 			}
 			if (options.stripNullableKeyword && key === "nullable") continue;
-			result[key] = normalizeSchemaNode(entry, {
-				...options,
-				insideProperties: key === "properties",
-			});
+			if (JSON_SCHEMA_LITERAL_PAYLOAD_KEYS.has(key)) {
+				setOwnKey(result, key, cloneJsonLiteral(entry));
+				continue;
+			}
+			setOwnKey(
+				result,
+				key,
+				normalizeSchemaNode(entry, {
+					...options,
+					insideProperties: key === "properties",
+				}),
+			);
 		}
 		applyDescriptionSpill(result, spill, options);
 		return applyNodePostProcessing(result, options);
@@ -297,13 +349,21 @@ function normalizeSchemaNode(value: unknown, options: NormalizeSchemaWalkOptions
 		}
 		if (options.stripNullableKeyword && key === "nullable") continue;
 		if (key === "const") {
-			constValue = entry;
+			constValue = cloneJsonLiteral(entry);
 			continue;
 		}
-		result[key] = normalizeSchemaNode(entry, {
-			...options,
-			insideProperties: key === "properties",
-		});
+		if (JSON_SCHEMA_LITERAL_PAYLOAD_KEYS.has(key)) {
+			setOwnKey(result, key, cloneJsonLiteral(entry));
+			continue;
+		}
+		setOwnKey(
+			result,
+			key,
+			normalizeSchemaNode(entry, {
+				...options,
+				insideProperties: key === "properties",
+			}),
+		);
 	}
 
 	if (options.normalizeTypeArrayToNullable && Array.isArray(result.type)) {
@@ -883,7 +943,7 @@ function normalizeMcpObjectMapNode(value: unknown, cache: WeakMap<JsonObject, Js
 				: normalizeMcpObjectMapNode(child, cache);
 		}
 		if (next !== child) changed = true;
-		output[key] = next;
+		setOwnKey(output, key, next);
 	}
 
 	if (
@@ -920,7 +980,7 @@ function normalizeMcpObjectMap(schemaMap: JsonObject, cache: WeakMap<JsonObject,
 		const child = schemaMap[key];
 		const next = normalizeMcpObjectMapNode(child, cache);
 		if (next !== child) changed = true;
-		output[key] = next;
+		setOwnKey(output, key, next);
 	}
 	return changed ? output : schemaMap;
 }

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -494,7 +494,7 @@ function mergeObjectCombinerVariants(schema: JsonObject, combiner: "anyOf" | "on
 		for (const name in properties) {
 			if (!Object.hasOwn(properties, name)) continue;
 			const propertySchema = properties[name];
-			const existingSchema = mergedProperties[name];
+			const existingSchema = Object.hasOwn(mergedProperties, name) ? mergedProperties[name] : undefined;
 			setOwnKey(
 				mergedProperties,
 				name,
@@ -578,7 +578,7 @@ function collapseMixedTypeCombinerVariants(schema: JsonObject, combiner: "anyOf"
 				return schema;
 			}
 
-			const existingValue = mergedVariantFields[key];
+			const existingValue = Object.hasOwn(mergedVariantFields, key) ? mergedVariantFields[key] : undefined;
 			if (existingValue !== undefined && !areJsonValuesEqual(existingValue, variantValue)) {
 				return schema;
 			}
@@ -599,7 +599,7 @@ function collapseMixedTypeCombinerVariants(schema: JsonObject, combiner: "anyOf"
 	for (const key in mergedVariantFields) {
 		if (!Object.hasOwn(mergedVariantFields, key)) continue;
 		const value = mergedVariantFields[key];
-		const existingValue = nextSchema[key];
+		const existingValue = Object.hasOwn(nextSchema, key) ? nextSchema[key] : undefined;
 		if (existingValue !== undefined && !areJsonValuesEqual(existingValue, value)) {
 			return schema;
 		}
@@ -635,6 +635,16 @@ function collapseSameTypeCombinerVariants(schema: JsonObject, combiner: "anyOf" 
  * collapse can handle. This is needed because object-combiner merging can
  * create new anyOf in merged subtrees after child normalization already ran.
  */
+function stripResidualCombinersMap(schemaMap: JsonObject, epoch: number): JsonObject {
+	if (!once(schemaMap, epoch)) return {};
+	const result: JsonObject = {};
+	for (const key in schemaMap) {
+		if (!Object.hasOwn(schemaMap, key)) continue;
+		setOwnKey(result, key, stripResidualCombiners(schemaMap[key], epoch));
+	}
+	return result;
+}
+
 export function stripResidualCombiners(value: unknown, epoch: number = epochNext()): unknown {
 	if (Array.isArray(value)) {
 		if (!once(value, epoch)) return [];
@@ -649,7 +659,14 @@ export function stripResidualCombiners(value: unknown, epoch: number = epochNext
 			setOwnKey(result, key, value[key]);
 			continue;
 		}
-		setOwnKey(result, key, stripResidualCombiners(value[key], epoch));
+		const child = value[key];
+		setOwnKey(
+			result,
+			key,
+			JSON_SCHEMA_MAP_KEYS.has(key) && isJsonObject(child)
+				? stripResidualCombinersMap(child, epoch)
+				: stripResidualCombiners(child, epoch),
+		);
 	}
 	let current: JsonObject = result;
 	let changed = true;
@@ -726,7 +743,7 @@ function extractNullableUnionSchema(schema: unknown): NullableExtractionResult {
 		for (const key in nonNullVariant) {
 			if (!Object.hasOwn(nonNullVariant, key)) continue;
 			const value = nonNullVariant[key];
-			const existingValue = nextSchema[key];
+			const existingValue = Object.hasOwn(nextSchema, key) ? nextSchema[key] : undefined;
 			if (existingValue !== undefined && !areJsonValuesEqual(existingValue, value)) {
 				return { schema, nullable: false };
 			}
@@ -743,6 +760,23 @@ function extractNullableUnionSchema(schema: unknown): NullableExtractionResult {
 interface NullableNormalizationResult {
 	schema: unknown;
 	nullable: boolean;
+}
+
+function normalizeNullableSchemaMapForCloudCodeAssist(
+	value: JsonObject,
+	propertyMap: boolean,
+	epoch: number,
+): { schema: JsonObject; nullableKeys: Set<string> } {
+	if (!once(value, epoch)) return { schema: {}, nullableKeys: new Set() };
+	const normalized: JsonObject = {};
+	const nullableKeys = new Set<string>();
+	for (const key in value) {
+		if (!Object.hasOwn(value, key)) continue;
+		const child = normalizeNullablePropertiesForCloudCodeAssist(value[key], propertyMap, epoch);
+		setOwnKey(normalized, key, child.schema);
+		if (child.nullable) nullableKeys.add(key);
+	}
+	return { schema: normalized, nullableKeys };
 }
 
 function normalizeNullablePropertiesForCloudCodeAssist(
@@ -767,33 +801,30 @@ function normalizeNullablePropertiesForCloudCodeAssist(
 	}
 
 	const normalized: JsonObject = {};
+	let nullablePropertyKeys: Set<string> | undefined;
 	for (const key in value) {
 		if (!Object.hasOwn(value, key)) continue;
 		if (JSON_SCHEMA_LITERAL_PAYLOAD_KEYS.has(key)) {
 			setOwnKey(normalized, key, value[key]);
 			continue;
 		}
+		if (JSON_SCHEMA_MAP_KEYS.has(key) && isJsonObject(value[key])) {
+			const mapped = normalizeNullableSchemaMapForCloudCodeAssist(value[key], key === "properties", epoch);
+			setOwnKey(normalized, key, mapped.schema);
+			if (key === "properties") nullablePropertyKeys = mapped.nullableKeys;
+			continue;
+		}
 		setOwnKey(normalized, key, normalizeNullablePropertiesForCloudCodeAssist(value[key], false, epoch).schema);
 	}
 
-	if (isJsonObject(normalized.properties)) {
-		const properties = normalized.properties;
+	if (nullablePropertyKeys && isJsonObject(normalized.properties)) {
 		const required = new Set(
 			Array.isArray(normalized.required)
 				? normalized.required.filter((entry): entry is string => typeof entry === "string")
 				: [],
 		);
-		const nextProperties: JsonObject = {};
-		for (const name in properties) {
-			if (!Object.hasOwn(properties, name)) continue;
-			const normalizedProperty = normalizeNullablePropertiesForCloudCodeAssist(properties[name], true, epoch);
-			setOwnKey(nextProperties, name, normalizedProperty.schema);
-			if (normalizedProperty.nullable) {
-				required.delete(name);
-			}
-		}
-		normalized.properties = nextProperties;
-		if (Array.isArray(normalized.required)) {
+		for (const key of nullablePropertyKeys) required.delete(key);
+		if (Object.hasOwn(normalized, "required") && Array.isArray(normalized.required)) {
 			normalized.required = Array.from(required);
 		}
 	}
@@ -861,9 +892,23 @@ function hasResidualSchemaIncompatibilities(
 	for (const k in value) {
 		if (!Object.hasOwn(value, k)) continue;
 		if (JSON_SCHEMA_LITERAL_PAYLOAD_KEYS.has(k)) continue;
-		if (hasResidualSchemaIncompatibilities(value[k], checks, epoch)) {
+		const child = value[k];
+		const hasResidual =
+			JSON_SCHEMA_MAP_KEYS.has(k) && isJsonObject(child)
+				? hasResidualSchemaMap(child, checks, epoch)
+				: hasResidualSchemaIncompatibilities(child, checks, epoch);
+		if (hasResidual) {
 			return true;
 		}
+	}
+	return false;
+}
+
+function hasResidualSchemaMap(value: JsonObject, checks: ResidualIncompatibilityChecks, epoch: number): boolean {
+	if (!once(value, epoch)) return false;
+	for (const key in value) {
+		if (!Object.hasOwn(value, key)) continue;
+		if (hasResidualSchemaIncompatibilities(value[key], checks, epoch)) return true;
 	}
 	return false;
 }

--- a/packages/ai/src/utils/schema/types.ts
+++ b/packages/ai/src/utils/schema/types.ts
@@ -6,6 +6,8 @@ export function isJsonObject(value: unknown): value is JsonObject {
 
 /** True when `value` is a plain JSON object with no own enumerable keys. */
 export function isJsonObjectEmpty(value: JsonObject): boolean {
-	for (const _ in value) return false;
+	for (const key in value) {
+		if (Object.hasOwn(value, key)) return false;
+	}
 	return true;
 }

--- a/packages/ai/src/utils/schema/zod-decontaminate.ts
+++ b/packages/ai/src/utils/schema/zod-decontaminate.ts
@@ -191,7 +191,8 @@ function rewriteZodNode(node: JsonObject, seen: WeakSet<object>): unknown {
 		}
 
 		case "literal": {
-			const values = Array.isArray(def.values) ? (def.values as unknown[]) : [];
+			const valuesValue = ownValue(def, "values");
+			const values = Array.isArray(valuesValue) ? valuesValue : [];
 			if (values.length === 1) {
 				return { const: values[0] };
 			}

--- a/packages/ai/src/utils/schema/zod-decontaminate.ts
+++ b/packages/ai/src/utils/schema/zod-decontaminate.ts
@@ -125,6 +125,7 @@ function setOwnKey(target: JsonObject, key: string, value: unknown): void {
 }
 
 function isZodLeak(node: JsonObject): boolean {
+	if (!Object.hasOwn(node, "def") || !Object.hasOwn(node, "type")) return false;
 	const def = node.def;
 	if (!isJsonObject(def)) return false;
 	const defType = def.type;

--- a/packages/ai/src/utils/schema/zod-decontaminate.ts
+++ b/packages/ai/src/utils/schema/zod-decontaminate.ts
@@ -114,6 +114,7 @@ const KEYS_THAT_ACCEPT_NULL: Record<string, true> = {
 	const: true,
 	examples: true,
 };
+const JSON_SCHEMA_LITERAL_PAYLOAD_KEYS = new Set(["default", "const", "enum", "examples"]);
 
 function setOwnKey(target: JsonObject, key: string, value: unknown): void {
 	if (key === "__proto__") {
@@ -334,6 +335,10 @@ function walk(value: unknown, seen: WeakSet<object>): unknown {
 	for (const key in value) {
 		if (!Object.hasOwn(value, key)) continue;
 		const child = value[key];
+		if (JSON_SCHEMA_LITERAL_PAYLOAD_KEYS.has(key)) {
+			setOwnKey(out, key, child);
+			continue;
+		}
 		const rewritten = walk(child, seen);
 		if (rewritten !== child) changed = true;
 		setOwnKey(out, key, rewritten);

--- a/packages/ai/src/utils/schema/zod-decontaminate.ts
+++ b/packages/ai/src/utils/schema/zod-decontaminate.ts
@@ -115,6 +115,14 @@ const KEYS_THAT_ACCEPT_NULL: Record<string, true> = {
 	examples: true,
 };
 
+function setOwnKey(target: JsonObject, key: string, value: unknown): void {
+	if (key === "__proto__") {
+		Object.defineProperty(target, key, { value, writable: true, enumerable: true, configurable: true });
+		return;
+	}
+	target[key] = value;
+}
+
 function isZodLeak(node: JsonObject): boolean {
 	const def = node.def;
 	if (!isJsonObject(def)) return false;
@@ -145,10 +153,11 @@ function unwrapInnerSchema(def: JsonObject): unknown {
 function copyWithoutNoise(node: JsonObject): JsonObject {
 	const out: JsonObject = {};
 	for (const key in node) {
+		if (!Object.hasOwn(node, key)) continue;
 		if (ZOD_NOISE_KEYS[key]) continue;
 		const value = node[key];
 		if (value === null && !KEYS_THAT_ACCEPT_NULL[key]) continue;
-		out[key] = value;
+		setOwnKey(out, key, value);
 	}
 	return out;
 }
@@ -222,8 +231,9 @@ function rewriteZodNode(node: JsonObject, seen: WeakSet<object>): unknown {
 			const properties: JsonObject = {};
 			const required: string[] = [];
 			for (const key in shape) {
+				if (!Object.hasOwn(shape, key)) continue;
 				const inner = walk(shape[key], seen);
-				properties[key] = inner;
+				setOwnKey(properties, key, inner);
 				if (!isOptionalEntry(shape[key])) required.push(key);
 			}
 			const out: JsonObject = { type: "object", properties };
@@ -322,10 +332,11 @@ function walk(value: unknown, seen: WeakSet<object>): unknown {
 	let changed = false;
 	const out: JsonObject = {};
 	for (const key in value) {
+		if (!Object.hasOwn(value, key)) continue;
 		const child = value[key];
 		const rewritten = walk(child, seen);
 		if (rewritten !== child) changed = true;
-		out[key] = rewritten;
+		setOwnKey(out, key, rewritten);
 	}
 	return changed ? out : value;
 }

--- a/packages/ai/src/utils/schema/zod-decontaminate.ts
+++ b/packages/ai/src/utils/schema/zod-decontaminate.ts
@@ -128,11 +128,16 @@ function isZodLeak(node: JsonObject): boolean {
 	if (!Object.hasOwn(node, "def") || !Object.hasOwn(node, "type")) return false;
 	const def = node.def;
 	if (!isJsonObject(def)) return false;
+	if (!Object.hasOwn(def, "type")) return false;
 	const defType = def.type;
 	if (typeof defType !== "string" || !Object.hasOwn(ZOD_KINDS, defType)) return false;
 	// Both surface and inner `.type` must agree — Zod always mirrors `_def.type`
 	// onto the instance, so this is a near-zero false-positive guard.
 	return node.type === defType;
+}
+
+function ownValue(object: JsonObject, key: string): unknown {
+	return Object.hasOwn(object, key) ? object[key] : undefined;
 }
 
 function inferTypeFromValues(values: readonly unknown[]): string {
@@ -149,7 +154,10 @@ function unwrapInnerSchema(def: JsonObject): unknown {
 	//   optional/nullable/readonly/brand/default → `innerType`
 	//   pipe → `in` (or `out`)
 	//   lazy → `getter` (a function — gone after JSON.stringify); fall back to {}
-	return def.innerType ?? def.in ?? def.out ?? def.schema ?? def.element ?? {};
+	for (const key of ["innerType", "in", "out", "schema", "element"]) {
+		if (Object.hasOwn(def, key) && def[key] !== undefined) return def[key];
+	}
+	return {};
 }
 
 function copyWithoutNoise(node: JsonObject): JsonObject {
@@ -172,9 +180,12 @@ function rewriteZodNode(node: JsonObject, seen: WeakSet<object>): unknown {
 		case "enum": {
 			// Prefer node.options (array form Zod exposes) → def.entries values →
 			// object-shaped node.enum values. All three carry the same data.
-			const optionsArray = Array.isArray(node.options) ? (node.options as unknown[]) : null;
-			const entries = isJsonObject(def.entries) ? Object.values(def.entries) : null;
-			const enumObj = isJsonObject(node.enum) ? Object.values(node.enum) : null;
+			const optionsValue = Object.hasOwn(node, "options") ? node.options : undefined;
+			const entriesValue = Object.hasOwn(def, "entries") ? def.entries : undefined;
+			const enumValue = Object.hasOwn(node, "enum") ? node.enum : undefined;
+			const optionsArray = Array.isArray(optionsValue) ? optionsValue : null;
+			const entries = isJsonObject(entriesValue) ? Object.values(entriesValue) : null;
+			const enumObj = isJsonObject(enumValue) ? Object.values(enumValue) : null;
 			const values = optionsArray ?? entries ?? enumObj ?? [];
 			return { type: inferTypeFromValues(values), enum: values };
 		}
@@ -192,44 +203,44 @@ function rewriteZodNode(node: JsonObject, seen: WeakSet<object>): unknown {
 
 		case "union":
 		case "discriminatedUnion": {
-			const arms = Array.isArray(def.options)
-				? (def.options as unknown[])
-				: Array.isArray(node.options)
-					? (node.options as unknown[])
-					: [];
+			const defOptions = Object.hasOwn(def, "options") ? def.options : undefined;
+			const nodeOptions = Object.hasOwn(node, "options") ? node.options : undefined;
+			const arms = Array.isArray(defOptions) ? defOptions : Array.isArray(nodeOptions) ? nodeOptions : [];
 			return { anyOf: arms.map(x => walk(x, seen)) };
 		}
 
 		case "intersection": {
 			return {
-				allOf: [walk(def.left, seen), walk(def.right, seen)],
+				allOf: [walk(ownValue(def, "left"), seen), walk(ownValue(def, "right"), seen)],
 			};
 		}
 
 		case "array": {
-			return { type: "array", items: walk(def.element, seen) };
+			return { type: "array", items: walk(ownValue(def, "element"), seen) };
 		}
 
 		case "set": {
-			const element = def.valueType ?? def.element;
+			const element = ownValue(def, "valueType") ?? ownValue(def, "element");
 			return { type: "array", uniqueItems: true, items: walk(element, seen) };
 		}
 
 		case "tuple": {
-			const items = Array.isArray(def.items) ? (def.items as unknown[]) : [];
+			const itemsValue = ownValue(def, "items");
+			const items = Array.isArray(itemsValue) ? itemsValue : [];
 			const out: JsonObject = { type: "array", prefixItems: items.map(x => walk(x, seen)) };
-			const rest = def.rest;
+			const rest = ownValue(def, "rest");
 			if (rest != null) out.items = walk(rest, seen);
 			return out;
 		}
 
 		case "record":
 		case "map": {
-			return { type: "object", additionalProperties: walk(def.valueType, seen) };
+			return { type: "object", additionalProperties: walk(ownValue(def, "valueType"), seen) };
 		}
 
 		case "object": {
-			const shape = isJsonObject(def.shape) ? def.shape : ({} as JsonObject);
+			const shapeValue = ownValue(def, "shape");
+			const shape = isJsonObject(shapeValue) ? shapeValue : ({} as JsonObject);
 			const properties: JsonObject = {};
 			const required: string[] = [];
 			for (const key in shape) {
@@ -256,10 +267,10 @@ function rewriteZodNode(node: JsonObject, seen: WeakSet<object>): unknown {
 		case "transform": {
 			const inner = walk(unwrapInnerSchema(def), seen);
 			if (kind === "nullable" && isJsonObject(inner)) {
-				if (typeof inner.type === "string") {
+				if (Object.hasOwn(inner, "type") && typeof inner.type === "string") {
 					return { ...inner, type: [inner.type, "null"] };
 				}
-				if (Array.isArray(inner.type)) {
+				if (Object.hasOwn(inner, "type") && Array.isArray(inner.type)) {
 					return (inner.type as string[]).includes("null")
 						? inner
 						: { ...inner, type: [...(inner.type as string[]), "null"] };
@@ -293,7 +304,8 @@ function rewriteZodNode(node: JsonObject, seen: WeakSet<object>): unknown {
 function isOptionalEntry(value: unknown): boolean {
 	if (!isJsonObject(value)) return false;
 	if (!isZodLeak(value)) return false;
-	const kind = (value.def as JsonObject).type;
+	const def = value.def as JsonObject;
+	const kind = Object.hasOwn(def, "type") ? def.type : undefined;
 	return kind === "optional" || kind === "default" || kind === "prefault";
 }
 

--- a/packages/ai/src/utils/schema/zod-decontaminate.ts
+++ b/packages/ai/src/utils/schema/zod-decontaminate.ts
@@ -127,7 +127,7 @@ function isZodLeak(node: JsonObject): boolean {
 	const def = node.def;
 	if (!isJsonObject(def)) return false;
 	const defType = def.type;
-	if (typeof defType !== "string" || !ZOD_KINDS[defType]) return false;
+	if (typeof defType !== "string" || !Object.hasOwn(ZOD_KINDS, defType)) return false;
 	// Both surface and inner `.type` must agree — Zod always mirrors `_def.type`
 	// onto the instance, so this is a near-zero false-positive guard.
 	return node.type === defType;
@@ -154,9 +154,9 @@ function copyWithoutNoise(node: JsonObject): JsonObject {
 	const out: JsonObject = {};
 	for (const key in node) {
 		if (!Object.hasOwn(node, key)) continue;
-		if (ZOD_NOISE_KEYS[key]) continue;
+		if (Object.hasOwn(ZOD_NOISE_KEYS, key)) continue;
 		const value = node[key];
-		if (value === null && !KEYS_THAT_ACCEPT_NULL[key]) continue;
+		if (value === null && !Object.hasOwn(KEYS_THAT_ACCEPT_NULL, key)) continue;
 		setOwnKey(out, key, value);
 	}
 	return out;
@@ -276,7 +276,7 @@ function rewriteZodNode(node: JsonObject, seen: WeakSet<object>): unknown {
 			const mapped = ZOD_SCALAR_TO_JSON_TYPE[kind];
 			if (mapped) {
 				cleaned.type = mapped;
-			} else if (typeof cleaned.type === "string" && !VALID_JSON_SCHEMA_TYPES[cleaned.type]) {
+			} else if (typeof cleaned.type === "string" && !Object.hasOwn(VALID_JSON_SCHEMA_TYPES, cleaned.type)) {
 				delete cleaned.type;
 			}
 			// Object-shaped `enum` survives as a noise field — remove if present.

--- a/packages/ai/src/utils/schema/zod-decontaminate.ts
+++ b/packages/ai/src/utils/schema/zod-decontaminate.ts
@@ -115,6 +115,14 @@ const KEYS_THAT_ACCEPT_NULL: Record<string, true> = {
 	examples: true,
 };
 const JSON_SCHEMA_LITERAL_PAYLOAD_KEYS = new Set(["default", "const", "enum", "examples"]);
+const JSON_SCHEMA_MAP_KEYS = new Set([
+	"properties",
+	"patternProperties",
+	"dependencies",
+	"dependentSchemas",
+	"$defs",
+	"definitions",
+]);
 
 function setOwnKey(target: JsonObject, key: string, value: unknown): void {
 	if (key === "__proto__") {
@@ -319,7 +327,20 @@ export function decontaminateZodInstance(value: unknown): unknown {
 	return walk(value, new WeakSet());
 }
 
-function walk(value: unknown, seen: WeakSet<object>): unknown {
+function walkSchemaMap(value: JsonObject, seen: WeakSet<object>): JsonObject {
+	let changed = false;
+	const out: JsonObject = {};
+	for (const key in value) {
+		if (!Object.hasOwn(value, key)) continue;
+		const child = value[key];
+		const rewritten = walk(child, seen);
+		if (rewritten !== child) changed = true;
+		setOwnKey(out, key, rewritten);
+	}
+	return changed ? out : value;
+}
+
+function walk(value: unknown, seen: WeakSet<object>, inSchemaMap = false): unknown {
 	if (Array.isArray(value)) {
 		if (seen.has(value)) return value;
 		seen.add(value);
@@ -349,11 +370,14 @@ function walk(value: unknown, seen: WeakSet<object>): unknown {
 	for (const key in value) {
 		if (!Object.hasOwn(value, key)) continue;
 		const child = value[key];
-		if (JSON_SCHEMA_LITERAL_PAYLOAD_KEYS.has(key)) {
+		if (!inSchemaMap && JSON_SCHEMA_LITERAL_PAYLOAD_KEYS.has(key)) {
 			setOwnKey(out, key, child);
 			continue;
 		}
-		const rewritten = walk(child, seen);
+		const rewritten =
+			!inSchemaMap && JSON_SCHEMA_MAP_KEYS.has(key) && isJsonObject(child)
+				? walkSchemaMap(child, seen)
+				: walk(child, seen);
 		if (rewritten !== child) changed = true;
 		setOwnKey(out, key, rewritten);
 	}

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -349,6 +349,32 @@ describe("normalizeSchemaForMCP", () => {
 		});
 	});
 
+	it("makes implicit propertyless MCP argument maps explicitly open without loosening declared objects", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				action: { type: "string" },
+				args: { type: "object", description: "Dispatcher arguments" },
+				explicitlyClosed: { type: "object", additionalProperties: false },
+				declared: { type: "object", properties: { path: { type: "string" } } },
+				literalCarrier: { type: "string", default: { type: "object" } },
+			},
+		};
+		const before = structuredClone(schema);
+
+		expect(normalizeSchemaForMCP(schema)).toEqual({
+			type: "object",
+			properties: {
+				action: { type: "string" },
+				args: { type: "object", description: "Dispatcher arguments", additionalProperties: true },
+				explicitlyClosed: { type: "object", additionalProperties: false },
+				declared: { type: "object", properties: { path: { type: "string" } } },
+				literalCarrier: { type: "string", default: { type: "object" } },
+			},
+		});
+		expect(schema).toEqual(before);
+	});
+
 	// Regression: issue #1101. Some MCP servers ship `JSON.stringify(zodSchema)`
 	// directly as a tool's `inputSchema`. Zod 4 surfaces `.type`, `.enum`,
 	// `.options`, and `.def` on every schema instance — those keys collide with

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -467,6 +467,54 @@ describe("normalizeSchemaForMCP", () => {
 		};
 		expect(normalizeSchemaForMCP(schema)).toEqual(schema);
 	});
+
+	// A tool schema arriving over the MCP wire is `JSON.parse`d, so `__proto__` is
+	// an ordinary own data property. Copying it with `out[key] = value` would hit
+	// `Object.prototype`'s `__proto__` setter and silently drop the property name.
+	it("preserves parsed `__proto__`, `constructor`, and `prototype` property names as own data", () => {
+		const parsed = JSON.parse(
+			'{"type":"object","properties":{"__proto__":{"type":"object","description":"open map"},"constructor":{"type":"string"},"prototype":{"type":"string"}},"required":["__proto__"]}',
+		);
+		const normalized = normalizeSchemaForMCP(parsed) as Record<string, Record<string, unknown>>;
+
+		expect(Object.keys(normalized.properties)).toEqual(["__proto__", "constructor", "prototype"]);
+		expect(Object.getOwnPropertyDescriptor(normalized.properties, "__proto__")?.value).toEqual({
+			type: "object",
+			description: "open map",
+			additionalProperties: true,
+		});
+		expect(Object.getPrototypeOf(normalized.properties)).toBe(Object.prototype);
+		expect(({} as Record<string, unknown>).description).toBeUndefined();
+	});
+
+	// `default`, `const`, `enum`, and `examples` carry instance data, not
+	// subschemas. The generic pre-walk used to recurse into them and rewrite user
+	// payloads as schemas; every value below changes visibly if that regresses.
+	it("copies literal payloads verbatim instead of normalizing them as schemas", () => {
+		const schema = {
+			type: "string",
+			default: { type: "object", nullable: true, format: null },
+			examples: [{ anyOf: [{ const: "a" }, { const: "b" }] }],
+		};
+		const before = structuredClone(schema);
+
+		expect(normalizeSchemaForMCP(schema)).toEqual({
+			type: "string",
+			default: { type: "object", nullable: true, format: null },
+			examples: [{ anyOf: [{ const: "a" }, { const: "b" }] }],
+		});
+		expect(schema).toEqual(before);
+	});
+
+	it("does not alias literal payloads back to the caller's input", () => {
+		const defaultValue = { nested: { keep: true } };
+		const schema = { type: "object", properties: {}, default: defaultValue };
+		const normalized = normalizeSchemaForMCP(schema) as { default: typeof defaultValue };
+
+		expect(normalized.default).toEqual(defaultValue);
+		expect(normalized.default).not.toBe(defaultValue);
+		expect(normalized.default.nested).not.toBe(defaultValue.nested);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -666,6 +666,48 @@ describe("normalizeSchemaForMCP", () => {
 		expect(isValidJsonSchema(normalized)).toBe(true);
 	});
 
+	it("dereferences refs in schema arrays, nested definitions, escaped names, and boolean definitions", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				nested: {
+					$defs: { Inner: { type: "string" } },
+					$ref: "#/properties/nested/$defs/Inner",
+				},
+			},
+			$defs: {
+				"Array/Definition": { type: "object" },
+				BooleanDefinition: false,
+			},
+			anyOf: [{ $ref: "#/$defs/Array~1Definition" }, { $ref: "#/$defs/BooleanDefinition" }],
+		};
+
+		const normalized = normalizeSchemaForMCP(schema) as Record<string, unknown>;
+		const properties = normalized.properties as Record<string, unknown>;
+		const alternatives = normalized.anyOf as Array<Record<string, unknown> | boolean>;
+
+		expect(properties.nested).toEqual({ type: "string" });
+		expect(alternatives).toEqual([{ type: "object", additionalProperties: true }, false]);
+		expect(normalized.$defs).toBeUndefined();
+		expect(isValidJsonSchema(normalized)).toBe(true);
+	});
+
+	it("terminates direct object cycles encountered while dereferencing definitions", () => {
+		const schema: Record<string, unknown> = {
+			$defs: { Node: { type: "object" } },
+			type: "object",
+			properties: {},
+		};
+		(schema.properties as Record<string, unknown>).self = schema;
+
+		const normalized = normalizeSchemaForMCP(schema) as Record<string, unknown>;
+		const properties = normalized.properties as Record<string, unknown>;
+
+		expect(properties.self).toEqual({});
+		expect(normalized.$defs).toBeUndefined();
+		expect(isValidJsonSchema(normalized)).toBe(true);
+	});
+
 	it("recurses nested additionalProperties, unions, arrays, and referenced definitions", () => {
 		const schema = {
 			type: "object",

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -705,6 +705,46 @@ describe("normalizeSchemaForMCP", () => {
 		expect(isValidJsonSchema(normalized)).toBe(true);
 	});
 
+	it("keeps reserved words as schema-map names through dereference and Zod cleanup", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				default: { $ref: "#/$defs/Value" },
+				const: {
+					type: "enum",
+					def: { type: "enum", entries: { enabled: "enabled" } },
+					enum: { enabled: "enabled" },
+				},
+			},
+			$defs: { Value: { type: "string" } },
+		};
+
+		const normalized = normalizeSchemaForMCP(schema) as Record<string, unknown>;
+		const properties = normalized.properties as Record<string, unknown>;
+
+		expect(properties.default).toEqual({ type: "string" });
+		expect(properties.const).toEqual({ type: "string", enum: ["enabled"] });
+		expect(normalized.$defs).toBeUndefined();
+		expect(isValidJsonSchema(normalized)).toBe(true);
+	});
+
+	it("applies sibling constraints when a local ref resolves to the boolean true schema", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				value: { $ref: "#/$defs/Any", type: "string" },
+			},
+			$defs: { Any: true },
+		};
+
+		const normalized = normalizeSchemaForMCP(schema) as Record<string, unknown>;
+		const properties = normalized.properties as Record<string, unknown>;
+
+		expect(properties.value).toEqual({ type: "string" });
+		expect(normalized.$defs).toBeUndefined();
+		expect(isValidJsonSchema(normalized)).toBe(true);
+	});
+
 	it("terminates direct object cycles encountered while dereferencing definitions", () => {
 		const schema: Record<string, unknown> = {
 			$defs: { Node: { type: "object" } },
@@ -1079,6 +1119,20 @@ describe("stripResidualCombiners", () => {
 // ---------------------------------------------------------------------------
 
 describe("normalizeSchemaForCCA", () => {
+	it("normalizes colliding property names as schema-map entries", () => {
+		const normalized = normalizeSchemaForCCA({
+			type: "object",
+			properties: {
+				default: { anyOf: [{ type: "string" }, { type: "null" }] },
+			},
+			required: ["default"],
+		}) as Record<string, unknown>;
+		const properties = normalized.properties as Record<string, unknown>;
+
+		expect(properties.default).toEqual({ type: "string" });
+		expect(normalized.required).toEqual(["default"]);
+	});
+
 	it("collapses same-type anyOf variants when mixed-type collapse bails out", () => {
 		const prepared = normalizeSchemaForCCA({
 			type: "object",

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -501,6 +501,12 @@ describe("normalizeSchemaForMCP", () => {
 				format: null,
 				$ref: "#/$defs/Literal",
 				$defs: { Literal: { type: "string" } },
+				nestedZodLookingData: {
+					def: { type: "enum", entries: { literal: "literal" } },
+					type: "enum",
+					enum: { literal: "literal" },
+					options: ["literal"],
+				},
 			},
 			examples: [{ anyOf: [{ const: "a" }, { const: "b" }] }],
 		};
@@ -514,6 +520,12 @@ describe("normalizeSchemaForMCP", () => {
 				format: null,
 				$ref: "#/$defs/Literal",
 				$defs: { Literal: { type: "string" } },
+				nestedZodLookingData: {
+					def: { type: "enum", entries: { literal: "literal" } },
+					type: "enum",
+					enum: { literal: "literal" },
+					options: ["literal"],
+				},
 			},
 			examples: [{ anyOf: [{ const: "a" }, { const: "b" }] }],
 		});

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -494,14 +494,27 @@ describe("normalizeSchemaForMCP", () => {
 	it("copies literal payloads verbatim instead of normalizing them as schemas", () => {
 		const schema = {
 			type: "string",
-			default: { type: "object", nullable: true, format: null },
+			$defs: { RootDefinition: { type: "number" } },
+			default: {
+				type: "object",
+				nullable: true,
+				format: null,
+				$ref: "#/$defs/Literal",
+				$defs: { Literal: { type: "string" } },
+			},
 			examples: [{ anyOf: [{ const: "a" }, { const: "b" }] }],
 		};
 		const before = structuredClone(schema);
 
 		expect(normalizeSchemaForMCP(schema)).toEqual({
 			type: "string",
-			default: { type: "object", nullable: true, format: null },
+			default: {
+				type: "object",
+				nullable: true,
+				format: null,
+				$ref: "#/$defs/Literal",
+				$defs: { Literal: { type: "string" } },
+			},
 			examples: [{ anyOf: [{ const: "a" }, { const: "b" }] }],
 		});
 		expect(schema).toEqual(before);
@@ -536,6 +549,20 @@ describe("normalizeSchemaForMCP", () => {
 		});
 		expect(Object.getPrototypeOf(properties)).toBe(Object.prototype);
 		expect(({} as Record<string, unknown>).additionalProperties).toBeUndefined();
+		expect(isValidJsonSchema(normalized)).toBe(true);
+	});
+
+	it("keeps a root prototype-colliding extension out of draft dispatch and Object.prototype", () => {
+		const parsed = JSON.parse(
+			'{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","__proto__":{"marker":"data"}}',
+		) as Record<string, unknown>;
+
+		const normalized = normalizeSchemaForMCP(parsed) as Record<string, unknown>;
+
+		expect(Object.hasOwn(normalized, "__proto__")).toBe(true);
+		expect(Object.getOwnPropertyDescriptor(normalized, "__proto__")?.value).toEqual({ marker: "data" });
+		expect(Object.getPrototypeOf(normalized)).toBe(Object.prototype);
+		expect(({} as Record<string, unknown>).marker).toBeUndefined();
 		expect(isValidJsonSchema(normalized)).toBe(true);
 	});
 
@@ -613,6 +640,18 @@ describe("normalizeSchemaForMCP", () => {
 		expect(Object.getPrototypeOf(properties)).toBe(Object.prototype);
 		expect(isValidJsonSchema(normalized)).toBe(true);
 		expect(({} as Record<string, unknown>).additionalProperties).toBeUndefined();
+	});
+
+	it("does not resolve an inherited prototype value for an unresolved local ref", () => {
+		const schema = {
+			$defs: { Safe: { type: "string" } },
+			$ref: "#/$defs/__proto__",
+		};
+
+		const normalized = normalizeSchemaForMCP(schema) as Record<string, unknown>;
+
+		expect(normalized).toEqual({ $defs: { Safe: { type: "string" } }, $ref: "#/$defs/__proto__" });
+		expect(isValidJsonSchema(normalized)).toBe(true);
 	});
 
 	it("recurses nested additionalProperties, unions, arrays, and referenced definitions", () => {

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -678,16 +678,29 @@ describe("normalizeSchemaForMCP", () => {
 			$defs: {
 				"Array/Definition": { type: "object" },
 				BooleanDefinition: false,
+				Base: { type: "string" },
+				Sibling: { type: "number" },
 			},
 			anyOf: [{ $ref: "#/$defs/Array~1Definition" }, { $ref: "#/$defs/BooleanDefinition" }],
+			additionalProperties: {
+				$ref: "#/$defs/Base",
+				anyOf: [{ $ref: "#/$defs/Sibling" }],
+				default: { $ref: "#/$defs/BooleanDefinition" },
+			},
 		};
 
 		const normalized = normalizeSchemaForMCP(schema) as Record<string, unknown>;
 		const properties = normalized.properties as Record<string, unknown>;
 		const alternatives = normalized.anyOf as Array<Record<string, unknown> | boolean>;
+		const additionalProperties = normalized.additionalProperties as Record<string, unknown>;
 
 		expect(properties.nested).toEqual({ type: "string" });
 		expect(alternatives).toEqual([{ type: "object", additionalProperties: true }, false]);
+		expect(additionalProperties).toEqual({
+			type: "string",
+			anyOf: [{ type: "number" }],
+			default: { $ref: "#/$defs/BooleanDefinition" },
+		});
 		expect(normalized.$defs).toBeUndefined();
 		expect(isValidJsonSchema(normalized)).toBe(true);
 	});

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -4,6 +4,7 @@ import { convertTools } from "@gajae-code/ai/providers/google-shared";
 import type { Context, Model, TJsonSchema, Tool } from "@gajae-code/ai/types";
 import {
 	enforceStrictSchema,
+	isValidJsonSchema,
 	mergeCompatibleEnumSchemas,
 	normalizeSchemaForCCA,
 	normalizeSchemaForGoogle,
@@ -514,6 +515,169 @@ describe("normalizeSchemaForMCP", () => {
 		expect(normalized.default).toEqual(defaultValue);
 		expect(normalized.default).not.toBe(defaultValue);
 		expect(normalized.default.nested).not.toBe(defaultValue.nested);
+	});
+
+	it("treats every properties key as data, including schema-key names and prototype keys", () => {
+		const parsed = JSON.parse(
+			'{"type":"object","properties":{"type":{"type":"object"},"default":{"type":"object"},"const":{"type":"object"},"enum":{"type":"object"},"examples":{"type":"object"},"__proto__":{"type":"object"},"constructor":{"type":"object"},"prototype":{"type":"object"}},"required":["type","default","const","enum","examples","__proto__","constructor","prototype"]}',
+		) as Record<string, unknown>;
+
+		const normalized = normalizeSchemaForMCP(parsed) as Record<string, unknown>;
+		const properties = normalized.properties as Record<string, unknown>;
+		const propertyNames = ["type", "default", "const", "enum", "examples", "__proto__", "constructor", "prototype"];
+
+		expect(Object.keys(properties)).toEqual(propertyNames);
+		for (const propertyName of propertyNames) {
+			expect(properties[propertyName]).toEqual({ type: "object", additionalProperties: true });
+		}
+		expect(Object.getOwnPropertyDescriptor(properties, "__proto__")?.value).toEqual({
+			type: "object",
+			additionalProperties: true,
+		});
+		expect(Object.getPrototypeOf(properties)).toBe(Object.prototype);
+		expect(({} as Record<string, unknown>).additionalProperties).toBeUndefined();
+		expect(isValidJsonSchema(normalized)).toBe(true);
+	});
+
+	it("keeps null-prototype and defineProperty-created maps safe during MCP copying", () => {
+		const properties = Object.create(null) as Record<string, unknown>;
+		Object.defineProperty(properties, "__proto__", {
+			value: Object.assign(Object.create(null), { type: "object" }),
+			configurable: true,
+			enumerable: true,
+			writable: true,
+		});
+		Object.defineProperty(properties, "constructor", {
+			value: { type: "string" },
+			configurable: true,
+			enumerable: true,
+			writable: true,
+		});
+		const schema = Object.create(null) as Record<string, unknown>;
+		Object.defineProperty(schema, "type", { value: "object", configurable: true, enumerable: true, writable: true });
+		Object.defineProperty(schema, "properties", {
+			value: properties,
+			configurable: true,
+			enumerable: true,
+			writable: true,
+		});
+
+		const normalized = normalizeSchemaForMCP(schema) as Record<string, unknown>;
+		const normalizedProperties = normalized.properties as Record<string, unknown>;
+
+		expect(Object.hasOwn(normalizedProperties, "__proto__")).toBe(true);
+		expect(Object.hasOwn(normalizedProperties, "constructor")).toBe(true);
+		expect(Object.getOwnPropertyDescriptor(normalizedProperties, "__proto__")?.value).toEqual({
+			type: "object",
+			additionalProperties: true,
+		});
+		expect(Object.getOwnPropertyDescriptor(normalizedProperties, "__proto__")?.enumerable).toBe(true);
+		expect(Object.getPrototypeOf(normalizedProperties)).toBe(Object.prototype);
+		expect(({} as Record<string, unknown>).additionalProperties).toBeUndefined();
+		expect(isValidJsonSchema(normalized)).toBe(true);
+	});
+
+	it("preserves dangerous keys when draft upgrade and definition dereferencing allocate copies", () => {
+		const parsed = JSON.parse(
+			'{"$schema":"http://json-schema.org/draft-07/schema#","nullable":true,"type":"object","properties":{"__proto__":{"type":"object"},"constructor":{"type":"object"},"prototype":{"type":"object"}},"items":[{"type":"object"}],"$defs":{"Definition":{"type":"object"}}}',
+		) as Record<string, unknown>;
+
+		const normalized = normalizeSchemaForMCP(parsed) as Record<string, unknown>;
+		const properties = normalized.properties as Record<string, unknown>;
+
+		expect(Object.keys(properties)).toEqual(["__proto__", "constructor", "prototype"]);
+		expect(Object.hasOwn(properties, "__proto__")).toBe(true);
+		expect(Object.getOwnPropertyDescriptor(properties, "__proto__")?.value).toEqual({
+			type: "object",
+			additionalProperties: true,
+		});
+		expect(normalized.prefixItems).toEqual([{ type: "object", additionalProperties: true }]);
+		expect(normalized.$defs).toBeUndefined();
+		expect(isValidJsonSchema(normalized)).toBe(true);
+		expect(({} as Record<string, unknown>).additionalProperties).toBeUndefined();
+	});
+
+	it("preserves dangerous keys while cleaning serialized Zod object schemas", () => {
+		const leaked = JSON.parse(
+			'{"type":"object","def":{"type":"object","shape":{"__proto__":{"type":"object"},"constructor":{"type":"string"},"prototype":{"type":"string"}}}}',
+		) as Record<string, unknown>;
+
+		const normalized = normalizeSchemaForMCP(leaked) as Record<string, unknown>;
+		const properties = normalized.properties as Record<string, unknown>;
+
+		expect(Object.keys(properties)).toEqual(["__proto__", "constructor", "prototype"]);
+		expect(Object.getOwnPropertyDescriptor(properties, "__proto__")?.value).toEqual({
+			type: "object",
+			additionalProperties: true,
+		});
+		expect(Object.getPrototypeOf(properties)).toBe(Object.prototype);
+		expect(isValidJsonSchema(normalized)).toBe(true);
+		expect(({} as Record<string, unknown>).additionalProperties).toBeUndefined();
+	});
+
+	it("recurses nested additionalProperties, unions, arrays, and referenced definitions", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				map: { type: "object", additionalProperties: { type: "object" } },
+				union: { anyOf: [{ type: "object" }, { type: "string" }] },
+				list: {
+					type: "array",
+					items: { type: "object" },
+					prefixItems: [{ type: "object" }],
+					contains: { type: "object" },
+				},
+				fromDefs: { $ref: "#/$defs/Definition" },
+			},
+			$defs: {
+				Definition: {
+					type: "object",
+					properties: { nested: { type: "object" } },
+				},
+			},
+		};
+
+		const normalized = normalizeSchemaForMCP(schema) as Record<string, unknown>;
+		const properties = normalized.properties as Record<string, Record<string, unknown>>;
+		const map = properties.map.additionalProperties as Record<string, unknown>;
+		const union = properties.union.anyOf as Array<Record<string, unknown>>;
+		const list = properties.list;
+		const definition = properties.fromDefs;
+
+		expect(map).toEqual({ type: "object", additionalProperties: true });
+		expect(union[0]).toEqual({ type: "object", additionalProperties: true });
+		expect(union[1]).toEqual({ type: "string" });
+		expect(list.items).toEqual({ type: "object", additionalProperties: true });
+		expect(list.prefixItems).toEqual([{ type: "object", additionalProperties: true }]);
+		expect(list.contains).toEqual({ type: "object", additionalProperties: true });
+		expect(definition).toEqual({
+			type: "object",
+			properties: { nested: { type: "object", additionalProperties: true } },
+		});
+		expect(normalized.$defs).toBeUndefined();
+		expect(isValidJsonSchema(normalized)).toBe(true);
+		expect(normalizeSchemaForMCP(normalized)).toEqual(normalized);
+	});
+
+	it("terminates cyclic schemas with the existing empty-schema cycle boundary", () => {
+		const schema: Record<string, unknown> = { type: "object", properties: {} };
+		(schema.properties as Record<string, unknown>).self = schema;
+
+		const normalized = normalizeSchemaForMCP(schema) as Record<string, unknown>;
+		const properties = normalized.properties as Record<string, unknown>;
+
+		expect(properties.self).toEqual({});
+		expect(normalizeSchemaForMCP(normalized)).toEqual(normalized);
+	});
+
+	it("does not turn malformed MCP schemas into valid JSON Schema", () => {
+		const malformed = {
+			type: "not-a-json-schema-type",
+			properties: [],
+		};
+
+		expect(isValidJsonSchema(malformed)).toBe(false);
+		expect(isValidJsonSchema(normalizeSchemaForMCP(malformed))).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## What

This change preserves JSON Schema's implicit open-object semantics for dynamic nested MCP dispatcher arguments.

- After `normalizeSchemaForMCP` finishes its existing normalization, recursively inspect only schema-valued positions.
- For a schema node that declares an object type but has no `properties`, `additionalProperties`, `patternProperties`, or `unevaluatedProperties`, emit `additionalProperties: true` explicitly.
- Preserve explicit `additionalProperties: false` and schema-valued `additionalProperties` contracts.
- Preserve object schemas that declare `properties`, `patternProperties`, or `unevaluatedProperties`.
- Do not traverse literal data under `default`, `const`, `enum`, or examples.
- Preserve identity for unchanged nodes and use a `WeakMap` while walking recursive schema graphs.
- Add regression coverage and an `@gajae-code/ai` changelog entry under `Unreleased`.

## Why

MCP servers commonly expose dispatcher tools with a concrete action plus an action-specific dynamic argument object:

```json
{
  "type": "object",
  "properties": {
    "action": { "type": "string" },
    "args": {
      "type": "object",
      "description": "Arguments for the selected action"
    }
  }
}
```

Under JSON Schema, `{ "type": "object" }` is open by default. The MCP bridge preserved that abbreviated shape, but downstream model-facing provider schema handling could interpret the propertyless nested object as a closed empty map. The model then emitted `args: {}` even when the selected action required fields such as `filepath`, `path`, `confirmed`, or `notes`.

The MCP server and transport were not dropping fields: a direct JSON-RPC `tools/call` carrying the same nested fields succeeded. The failure occurred before dispatch, in the model-facing schema path. Making the open-map contract explicit gives provider adapters an unambiguous schema while retaining the server's declared semantics.

### Observed reproduction

A registered FCPXML dispatcher exposes `validate_timeline` through an `action` plus dynamic `args` object.

Expected call:

```text
validate_timeline(args.filepath=/absolute/path/to/preflight-render.fcpxml)
```

Before this fix, the normal registered tool call reached the server with an empty `args` object and returned:

```text
Missing required argument: filepath
```

A direct MCP JSON-RPC call with `args.filepath` succeeded. With this patch compiled into GJC, a fresh process using only the normal registered MCP tool delivered the nested filepath and returned a 100% timeline health score.

### Behavioral boundaries

The regression test verifies all of the following in one representative dispatcher schema:

1. Propertyless nested `args` becomes explicitly open.
2. `additionalProperties: false` remains closed.
3. An object with declared `properties` remains unchanged.
4. A literal object under `default` is not interpreted as a schema node.
5. The caller's input object is not mutated.

The walker also handles schema maps (`properties`, definitions, dependent schemas), schema arrays (`anyOf`, `oneOf`, `allOf`, tuple prefixes), single schema-valued keywords (`items`, `contains`, conditionals, `not`, additional/unevaluated properties), nullable object type arrays, and recursive graph identity.

## Existing issue / PR search

No matching upstream issue or pull request was found after searching open and closed results for:

- `normalizeSchemaForMCP`
- `MCP additionalProperties`
- `propertyless MCP`
- `MCP empty object`
- `MCP nested`
- `MCP tool arguments`
- related schema/argument variants

Current `origin/dev` also has no changes to the affected normalizer or test since v0.15.6.

## Historical testing (superseded head `61b2c481`)

Passed on the superseded PR head:

- `bun test packages/ai/test/schema-normalization.test.ts packages/ai/test/schema-wire.test.ts packages/ai/test/anthropic-alignment.test.ts`
  - 118 tests passed
  - 0 failed
  - 266 assertions
- `bun --cwd=packages/ai run check`
  - Biome completed with only two existing informational `String.raw` notices
  - TypeScript `--noEmit` passed
- `bun run check:tools`
  - Passed with existing repository warnings/infos only
  - Unsafe recursive-removal gate passed
- `bun scripts/verify-gjc-state-writers.ts --fail`
  - 0 write sites outside the sanctioned writer / known allowlist
- `git diff --check origin/dev...HEAD`
  - Passed
- `bun --cwd=packages/coding-agent run build`
  - Compiled and ad-hoc signed the macOS arm64 binary successfully
- Fresh compiled-binary MCP regression
  - Used only the registered FCPXML MCP diagnose tool
  - Delivered nested `args.filepath` to the server
  - Returned 100% timeline health, 0 gaps, 0 flash frames, 0 duplicate-source findings
  - Left exactly one registered `fcp-mcp-server` and one `LogicProMCP` process; no orphan server remained
- Exact-head PR preflight
  - State-writer scan passed
  - Verdict/digest contract validated locally

### Full aggregate check status

`bun run check` was executed twice. Both runs progressed through the affected TypeScript/package checks and then failed outside this diff in the existing `check:sdk-closure` baseline:

```text
packages/coding-agent/src/tools/tmux-self-injection-guard.ts:10:
  tmux send-keys content injection is outside sanctioned process lifecycle (×2)
  tmux paste-buffer content injection is outside sanctioned process lifecycle (×2)
```

This branch does not modify that file or subsystem. The failure is recorded rather than suppressed or weakened.

## Historical REQUEST_CHANGES repair (superseded commit `61b2c481`)

Both blockers from the exact-head `REQUEST_CHANGES` review reproduced and are fixed.

**HIGH — parsed `__proto__` schema keys were dropped.** Every schema copy site wrote `out[key] = value` into a plain `{}`, so a `JSON.parse`d property named `__proto__` invoked `Object.prototype`'s `__proto__` setter instead of creating an own data property. Reproduced: `Object.hasOwn(normalized.properties, "__proto__") === false`, keys `["constructor", "prototype"]`. All copy sites in the shared pre-walk (`applySnakeCaseRenames`, `preHandleNullFields`, both `normalizeSchemaNode` loops) and the MCP walker now write through a setter-independent own-data helper. After the fix the key round-trips, the copy's prototype is still `Object.prototype`, and nothing lands on `Object.prototype`.

**HIGH — literal payloads were rewritten before the scoped MCP walk.** The generic `normalizeSchemaNode` pre-walk recursed into `default`, `const`, `enum`, and `examples`, treating instance data as subschemas. Reproduced: `default: {type:"object",nullable:true}` came back as `{type:"object"}`, and `examples: [{anyOf:[{const:"a"},{const:"b"}]}]` collapsed to `[{enum:["a","b"],type:"string"}]`. Those four keywords are now copied verbatim as deep clones, so payloads survive unchanged and the output never aliases the caller's input.

Regression coverage added to `packages/ai/test/schema-normalization.test.ts`:

- `JSON.parse` fixture asserting `__proto__`, `constructor`, and `prototype` survive as own data, the `__proto__` subschema still gets the open-map rule, and the prototype chain is clean.
- A visibly changing literal fixture (`nullable` under `default`, literal `anyOf`/`const` under `examples`).
- A non-aliasing assertion for nested literal payload data.

Both new fixtures were confirmed to fail against the pre-repair normalizer.

### Repair verification (exact head `61b2c481`)

- `bun test packages/ai/test/schema-normalization.test.ts packages/ai/test/schema-wire.test.ts packages/ai/test/anthropic-alignment.test.ts packages/ai/test/schema-compatibility.test.ts packages/ai/test/schema-strict-mode.test.ts packages/ai/test/google-tool-schema.test.ts packages/ai/test/anthropic-tool-schema.test.ts packages/ai/test/schema-dereference.test.ts packages/ai/test/schema-helpers.test.ts` — 274 passed, 0 failed, 650 assertions
- `bun test packages/ai/test/` — 3010 passed, 12 failed; every failure is in the pre-existing auth-broker / oauth-xai / anthropic-cache-eval cluster and reproduces identically with this diff stashed
- `bun test packages/agent/test/normalize-tools-subagent-wire-schema.test.ts packages/coding-agent/test/runtime-mcp packages/coding-agent/test/sdk-mcp-discovery.test.ts packages/coding-agent/test/runtime-mcp-sse-transport.test.ts` — 180 passed, 1 failed; the single failure (`blocks idle yield delivery until deferred MCP startup completes`) reproduces identically with this diff stashed
- `bun --cwd=packages/ai run check` — Biome clean apart from the two pre-existing `String.raw` infos; `tsc --noEmit` passed
- `bun run check:tools` — passed with existing repository warnings/infos only
- `bun scripts/verify-gjc-state-writers.ts --fail` — 0 write sites outside the sanctioned writer / allowlist
- `git diff --check origin/dev...HEAD` — passed; `git merge-base --is-ancestor origin/dev HEAD` — passed
- `git cat-file -s HEAD:packages/ai/CHANGELOG.md` — 307142 bytes (history intact across the rebase)

## Successor fix-forward (commits `3cb5fdbc11` through `836256e340`)

The follow-up repairs now cover the remaining pre-normalization blockers from the exact-head review:

- Schema-valued maps (`properties`, `patternProperties`, `dependentSchemas`, `$defs`, and definitions) are traversed as maps, so dispatcher names colliding with `type`, `default`, `const`, `enum`, or `examples` remain schema property names rather than being interpreted as keywords.
- Draft upgrade, dereference, and serialized-Zod cleanup copies use own-key checks and setter-independent writes, preserving parsed `__proto__`/`constructor`/`prototype` names and preventing inherited prototype values from changing dispatch or satisfying refs.
- Dereference and Zod cleanup leave `default`, `const`, `enum`, and `examples` instance data opaque, including nested schema-looking/Zod-looking values and refs.
- Regression coverage now includes null-prototype and `defineProperty` maps, root and nested prototype collisions, draft/definition paths, unresolved prototype refs, nested schema positions, cycles, idempotence, malformed validity, and MCP dispatcher compatibility.

### Frozen verification inputs

- Base: `bc7a9bdc30187190f638f10e9996154f2f0ed8d6` (`origin/dev`)
- Head: `836256e340d72fda3fc2622ff4305a815295c599`
- Binary diff SHA-256: `480665b5d83493454eee7d9d20ef1647b309a5f13497a894d80c2673a46d0d75`
- Ultragoal source hash: `sha256:91d243d0da774f10a57cfac416c518cee1d84f1b216e3f33241995721e64db08`
- Focused AI schema suite: `558 pass`, `0 fail`, `1359 expect() calls` across 18 files.
- `bun --cwd=packages/ai run check`: passed with two pre-existing informational `String.raw` diagnostics.
- `bun run check:tools`: passed with existing repository warnings/infos; unsafe recursive-removal scan passed.
- `bun scripts/verify-gjc-state-writers.ts --fail`: passed; no writes outside the sanctioned writer/allowlist.
- `bun run check`: reached the affected TypeScript/package checks, then failed outside this diff on existing `artifacts/base-wt` Rust-scope entries and the local `@gajae-code/natives` 0.15.6 addon mismatch in SDK closure tests.
- Native-dependent coding-agent MCP runtime tests remain environment-blocked by that addon mismatch; the package-level schema and agent compatibility tests passed.

## Exact branch identity

- Base: `bc7a9bdc30187190f638f10e9996154f2f0ed8d6` (`origin/dev`, rebased)
- Head: `61b2c4812464837d96b805b7bd7f355da73377f7`
- Binary diff SHA-256: `83bd72620db67e613027f2f3f9045da3644dfba2b0720d2c223bfc7a616e4953`

The prior head `87cec2d8` and its reviews are superseded by the REQUEST_CHANGES repair below.

## Risk classification

- [ ] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict (no independent human review; the verdict name itself records that) with a risk-record comment bound to the exact head.
- [x] `regression-risk` — fix with material regression risk; requires one assigned independent domain reviewer whose authenticated exact-head `APPROVED` review the gate verifies (`extra:independent:<login>`; the token alone never suffices).
- [ ] `high-risk` — large refactor, feature, or materially high-risk change (security/auth/install/remove/public API/destructive lifecycle/architecture); requires one assigned independent domain reviewer with an authenticated exact-head `APPROVED` review (`extra:independent:<login>`).

The change is classified as `regression-risk` because MCP schema normalization is provider-agnostic shared behavior, even though the implementation is narrowly bounded and regression-tested.

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:480665b5d83493454eee7d9d20ef1647b309a5f13497a894d80c2673a46d0d75 reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head-836256e340-architect-approve-executor-qa-passed-terminal-critic-okay
```

---

- [x] Target branch is `dev`
- [ ] `bun check` passes — blocked by unrelated `artifacts/base-wt` Rust-scope entries and the local `@gajae-code/natives` 0.15.6 addon mismatch documented above
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
- [x] Verdict above matches the exact PR head, not an earlier commit
- [x] Risk classification above matches the actual review path taken






