### PR TITLE
test(sdk): classify PR #5093 rescope regression seams

### DIFF
--- a/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
+++ b/packages/coding-agent/scripts/generate-sdk-operation-inventory.ts
@@ -107,6 +107,12 @@ const LOCKED_EXCLUSIONS: Readonly<Record<string, string>> = {
 	"agent_session:activeMidRunBarrierCountForTests": "read-only test seam, not a user-facing SDK control seam",
 	"agent_session:activeMidRunMaintenanceCountForTests": "read-only test seam, not a user-facing SDK control seam",
 	"agent_session:getPendingNextTurnMessagesForTests": "read-only test seam, not a user-facing SDK control seam",
+	"agent_session:queueCoordinatorRuntimeStatePersistForTests":
+		"test-only coordinator persistence ordering seam, not a user-facing SDK control seam",
+	"agent_session:parkAgentEndForCoordinatorPersistForTests":
+		"test-only parked terminal persistence seam, not a user-facing SDK control seam",
+	"agent_session:flushParkedAgentEndForCoordinatorPersistForTests":
+		"test-only parked terminal flush seam, not a user-facing SDK control seam",
 	"agent_session:setCancelAndSubmitAbortOutcomeProviderForTests":
 		"test-only cancellation seam, not a user-facing SDK control seam",
 	"agent_session:getAgentId": "internal accessor/plumbing, not a user-facing control seam",

--- a/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
+++ b/packages/coding-agent/src/sdk/protocol/operation-inventory.generated.json
@@ -2846,6 +2846,39 @@
 		}
 	},
 	{
+		"sourceId": "agent_session:queueCoordinatorRuntimeStatePersistForTests",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "test-only coordinator persistence ordering seam, not a user-facing SDK control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
+		"sourceId": "agent_session:parkAgentEndForCoordinatorPersistForTests",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "test-only parked terminal persistence seam, not a user-facing SDK control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
+		"sourceId": "agent_session:flushParkedAgentEndForCoordinatorPersistForTests",
+		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
+		"sourceKind": "agent_session",
+		"decision": "exclude",
+		"rationale": "test-only parked terminal flush seam, not a user-facing SDK control seam",
+		"exclusionMetadata": {
+			"adapterMappings": "not_applicable",
+			"testIds": "not_applicable"
+		}
+	},
+	{
 		"sourceId": "agent_session:drainAsyncJobDeliveriesForAcp",
 		"sourceFile": "packages/coding-agent/src/session/agent-session.ts",
 		"sourceKind": "agent_session",


### PR DESCRIPTION
## Summary

- lock three PR #5093 test-only AgentSession persistence seams out of the public SDK inventory
- regenerate the canonical operation inventory
- repair the actionable successor-dev CI failure from merged PR #5093

## Verification

- `bun test packages/coding-agent/test/sdk-operation-inventory.test.ts` (19 pass)
- `bun packages/coding-agent/scripts/generate-sdk-operation-inventory.ts --check`

## Risk classification

- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-approved sha256:cb93176f648de6a7a3be2060ff467c2323e82f31243000ac471e731080a38875 reviewer:human reviewer-id:probepark evidence:exact-head-4733389a-rescope-test-seams-correctly-excluded-from-sdk
```

- [x] Target branch is `dev`
- [x] Tested locally
- [x] Verdict matches exact head