### PR TITLE
fix(update): preserve version verification diagnostics

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Fixed
 
+- Post-install update verification now preserves a bounded, secret-redacted stderr/stdout cause when the newly installed `gjc --version` exits unsuccessfully, so runtime guards such as Bun version incompatibilities remain actionable instead of collapsing to a generic verification failure. (#5108)
+
 - Managed-session file identities now use one canonical unsigned 64-bit representation across stat/native boundaries and replacement cleanup receipts. Native Windows file IDs surfaced as signed negative bigints no longer create double-hyphen receipt names that block persistence or reopen; already-written signed receipt names and interrupted pending receipts are recovered only through the existing identity-bound, fail-closed reconciliation paths. (#5095)
 
 - Confirmed operator `turn.abort` requests now travel through a dedicated local Broker route instead of trusting caller-supplied `operator:true` and `confirm:true` on ordinary SDK frames. The Broker revalidates the exact live endpoint identity, injects a process-bound private capability, preserves post-send uncertainty, and the host uses one capability-free canonical identity for dispatch idempotency, durable admission, and delivery receipts, so forged, stale, dropped, and replayed requests fail closed consistently across restart boundaries.

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -9,7 +9,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { pipeline } from "node:stream/promises";
-import { $which, APP_NAME, isCompiledBinary, isEnoent, VERSION } from "@gajae-code/utils";
+import { $which, APP_NAME, isCompiledBinary, isEnoent, redactCrashSecrets, VERSION } from "@gajae-code/utils";
 import { $ } from "bun";
 import chalk from "chalk";
 import { Settings } from "../config/settings";
@@ -55,6 +55,7 @@ export interface InstalledVersionVerification {
 	ok: boolean;
 	actual?: string;
 	path?: string;
+	versionOutput?: string;
 	smokeTestFailed?: boolean;
 	smokeTestOutput?: string;
 	cleanupWarning?: string;
@@ -462,6 +463,71 @@ export function parseReportedVersionForTest(output: string): string | undefined 
 	return parseReportedVersion(output);
 }
 
+const VERIFICATION_OUTPUT_MAX_LENGTH = 512;
+const ANSI_ESCAPE = /\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))/gu;
+const UNSAFE_CONTROL = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/gu;
+
+function sanitizeVerificationOutput(...streams: Array<string | undefined>): string | undefined {
+	const output = streams
+		.map(stream => stream?.replace(ANSI_ESCAPE, "").replace(UNSAFE_CONTROL, " ").replace(/\s+/g, " ").trim() ?? "")
+		.filter(Boolean)
+		.filter((stream, index, all) => all.indexOf(stream) === index)
+		.join(" ");
+	if (!output) return undefined;
+	const redacted = redactCrashSecrets(output);
+	if (redacted.length <= VERIFICATION_OUTPUT_MAX_LENGTH) return redacted;
+	return `${redacted.slice(0, VERIFICATION_OUTPUT_MAX_LENGTH - 3)}...`;
+}
+
+export function sanitizeVerificationOutputForTest(
+	stderr: string | undefined,
+	stdout: string | undefined,
+): string | undefined {
+	return sanitizeVerificationOutput(stderr, stdout);
+}
+
+interface InstalledVersionCommandResult {
+	exitCode: number | null;
+	stdout: string;
+	stderr: string;
+}
+
+type InstalledVersionCommandRunner = (runtimePath: string) => Promise<InstalledVersionCommandResult>;
+
+async function verifyInstalledVersionWith(
+	expectedVersion: string,
+	runtimePath: string | undefined,
+	runVersion: InstalledVersionCommandRunner,
+): Promise<InstalledVersionVerification> {
+	if (!runtimePath) return { ok: false };
+	try {
+		const result = await runVersion(runtimePath);
+		if (result.exitCode !== 0) {
+			return {
+				ok: false,
+				path: runtimePath,
+				versionOutput: sanitizeVerificationOutput(result.stderr, result.stdout),
+			};
+		}
+		const actual = parseReportedVersion(result.stdout);
+		return { ok: actual === expectedVersion, actual, path: runtimePath };
+	} catch (error) {
+		return {
+			ok: false,
+			path: runtimePath,
+			versionOutput: sanitizeVerificationOutput(error instanceof Error ? error.message : String(error)),
+		};
+	}
+}
+
+export async function verifyInstalledVersionForTest(options: {
+	expectedVersion: string;
+	runtimePath: string | undefined;
+	runVersion: InstalledVersionCommandRunner;
+}): Promise<InstalledVersionVerification> {
+	return await verifyInstalledVersionWith(options.expectedVersion, options.runtimePath, options.runVersion);
+}
+
 /**
  * Run the resolved gjc binary and check if it reports the expected version.
  */
@@ -469,15 +535,14 @@ async function verifyInstalledVersion(
 	expectedVersion: string,
 	runtimePath: string | undefined = resolveGjcPath(),
 ): Promise<InstalledVersionVerification> {
-	if (!runtimePath) return { ok: false };
-	try {
-		const result = await $`${runtimePath} --version`.quiet().nothrow();
-		if (result.exitCode !== 0) return { ok: false, path: runtimePath };
-		const actual = parseReportedVersion(result.text());
-		return { ok: actual === expectedVersion, actual, path: runtimePath };
-	} catch {
-		return { ok: false, path: runtimePath };
-	}
+	return await verifyInstalledVersionWith(expectedVersion, runtimePath, async resolvedPath => {
+		const result = await $`${resolvedPath} --version`.quiet().nothrow();
+		return {
+			exitCode: result.exitCode,
+			stdout: result.stdout.toString(),
+			stderr: result.stderr.toString(),
+		};
+	});
 }
 
 async function verifyInstalledRuntime(
@@ -665,7 +730,8 @@ function formatVerificationFailure(result: InstalledVersionVerification, expecte
 	if (result.actual) {
 		return `${APP_NAME} at ${result.path} still reports ${result.actual} (expected ${expectedVersion})`;
 	}
-	return `could not verify updated version${result.path ? ` at ${result.path}` : ""}`;
+	const outputSuffix = result.versionOutput ? `: ${result.versionOutput}` : "";
+	return `could not verify updated version${result.path ? ` at ${result.path}` : ""}${outputSuffix}`;
 }
 
 export function formatVerificationFailureForTest(

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -28,6 +28,8 @@ import {
 	runPackageManagerUpdateForTest,
 	runPostUpdateRecoveryForTest,
 	runUpdateCommand,
+	sanitizeVerificationOutputForTest,
+	verifyInstalledVersionForTest,
 	verifyMigrationTargetAdapterForTest,
 	verifyMigrationTargetForTest,
 } from "../src/cli/update-cli";
@@ -228,6 +230,76 @@ describe("update-cli binary release assets", () => {
 		expect(message).toContain("stale or partial update");
 		expect(message).toContain("native addon release mismatch");
 		expect(message).not.toContain("undefined");
+	});
+
+	it("preserves Bun version guard stderr when installed version verification fails", async () => {
+		const verification = await verifyInstalledVersionForTest({
+			expectedVersion: "0.15.6",
+			runtimePath: "/Users/test/.bun/bin/gjc",
+			runVersion: async () => ({
+				exitCode: 1,
+				stderr:
+					"error: gjc requires Bun >= 1.4.0, but the running Bun is v1.3.14.\n  detected Bun runtime: /Users/test/.bun/bin/bun\n",
+				stdout: "",
+			}),
+		});
+		const message = formatVerificationFailureForTest(verification, "0.15.6");
+
+		expect(message).toContain("requires Bun >= 1.4.0");
+		expect(message).toContain("running Bun is v1.3.14");
+		expect(message).toContain("at /Users/test/.bun/bin/gjc");
+	});
+
+	it("uses stdout when failed installed version verification has no stderr", async () => {
+		const verification = await verifyInstalledVersionForTest({
+			expectedVersion: "0.15.6",
+			runtimePath: "/opt/gjc",
+			runVersion: async () => ({ exitCode: 1, stderr: "", stdout: "runtime bootstrap failed on stdout\n" }),
+		});
+
+		expect(formatVerificationFailureForTest(verification, "0.15.6")).toContain("runtime bootstrap failed on stdout");
+	});
+
+	it("still parses successful installed version output", async () => {
+		const verification = await verifyInstalledVersionForTest({
+			expectedVersion: "0.15.6",
+			runtimePath: "C:\\Tools\\gjc.exe",
+			runVersion: async runtimePath => {
+				expect(runtimePath).toBe("C:\\Tools\\gjc.exe");
+				return { exitCode: 0, stderr: "", stdout: "gjc/0.15.6\n" };
+			},
+		});
+
+		expect(verification).toEqual({
+			ok: true,
+			actual: "0.15.6",
+			path: "C:\\Tools\\gjc.exe",
+		});
+	});
+
+	it("keeps the generic fallback when failed installed version verification has no output", () => {
+		const output = sanitizeVerificationOutputForTest("  \n\t", "");
+
+		expect(
+			formatVerificationFailureForTest({ ok: false, path: "C:\\Tools\\gjc.exe", versionOutput: output }, "0.15.6"),
+		).toBe("could not verify updated version at C:\\Tools\\gjc.exe");
+	});
+
+	it("bounds failed installed version verification output", () => {
+		const output = sanitizeVerificationOutputForTest("x".repeat(1_000), undefined);
+
+		expect(output).toHaveLength(512);
+		expect(output).toEndWith("...");
+	});
+
+	it("redacts secrets before reporting failed installed version verification output", () => {
+		const output = sanitizeVerificationOutputForTest(
+			"Authorization: Bearer abcdefghijklmnopqrstuvwxyz api_key=sk-abcdefghijklmnopqrstuvwxyz012345",
+			undefined,
+		);
+
+		expect(output).not.toContain("abcdefghijklmnopqrstuvwxyz");
+		expect(output).toContain("redacted");
 	});
 
 	it("includes actionable guidance when a release asset download fails", () => {


### PR DESCRIPTION
## Summary
- capture failed post-install `gjc --version` stderr and stdout
- strip terminal controls, redact credential shapes, and cap the displayed cause at 512 characters
- preserve successful version parsing and cross-platform runtime paths

## Verification
- `bun test packages/coding-agent/test/update-cli.test.ts` (94 pass)
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run build`

## Risk
- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

gajae.pr-review-verdict.v1 merge-self-approved sha256:9cacde338870c011241932e3f4b127fe53657480250c58599be4f9d853c2b711 reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head-focused-tests-types-build-and-independent-frozen-review-pass

Closes #5108