### PR TITLE
fix(dev-ci): serialize coordinator same-key retries into one turn

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Post-install update verification now preserves a bounded, secret-redacted stderr/stdout cause when the newly installed `gjc --version` exits unsuccessfully, so runtime guards such as Bun version incompatibilities remain actionable instead of collapsing to a generic verification failure. (#5108)
+- Concurrent coordinator mutations sharing one idempotency key now join the same in-process flight before taking the durable key lock, so a slow accepted prompt cannot make its retry time out as unavailable. Conflicting in-flight requests still fail closed, completed responses remain durably replayable, and different keys remain isolated. (#5110)
 
 - Managed-session file identities now use one canonical unsigned 64-bit representation across stat/native boundaries and replacement cleanup receipts. Native Windows file IDs surfaced as signed negative bigints no longer create double-hyphen receipt names that block persistence or reopen; already-written signed receipt names and interrupted pending receipts are recovered only through the existing identity-bound, fail-closed reconciliation paths. (#5095)
 

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -5047,6 +5047,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 		const keyDigest = createHash("sha256").update(idempotencyKey).digest("hex");
 		return path.join(namespaceDir, "idempotency", `${keyDigest}.json`);
 	}
+	const idempotencyFlights = new Map<string, { requestDigest: string; promise: Promise<Record<string, unknown>> }>();
 	async function withOrderedSessionStateLocks<T>(
 		lockFiles: readonly string[],
 		operation: () => Promise<T>,
@@ -5182,7 +5183,23 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 			});
 			return response;
 		};
-		return lockAlreadyHeld ? execute() : withSessionStateLock(lockFile, execute);
+		const existingFlight = idempotencyFlights.get(keyDigest);
+		if (existingFlight) {
+			if (existingFlight.requestDigest !== requestDigest)
+				return {
+					ok: false,
+					error: { code: "idempotency_conflict", message: "idempotency key was used with a different request" },
+				};
+			return await existingFlight.promise;
+		}
+		const promise = lockAlreadyHeld ? execute() : withSessionStateLock(lockFile, execute);
+		const flight = { requestDigest, promise };
+		idempotencyFlights.set(keyDigest, flight);
+		try {
+			return await promise;
+		} finally {
+			if (idempotencyFlights.get(keyDigest) === flight) idempotencyFlights.delete(keyDigest);
+		}
 	}
 
 	async function brokerSession(

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -5048,6 +5048,57 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 		return path.join(namespaceDir, "idempotency", `${keyDigest}.json`);
 	}
 	const idempotencyFlights = new Map<string, { requestDigest: string; promise: Promise<Record<string, unknown>> }>();
+	type IdempotencyFlightAdmission =
+		| { kind: "conflict"; response: Record<string, unknown> }
+		| { kind: "joined"; promise: Promise<Record<string, unknown>> }
+		| { kind: "owner"; run: (operation: Promise<Record<string, unknown>>) => Promise<Record<string, unknown>> };
+	function admitIdempotencyFlight(
+		tool: string,
+		idempotencyKey: string,
+		canonicalArgs: Record<string, unknown>,
+	): IdempotencyFlightAdmission {
+		const keyDigest = createHash("sha256").update(idempotencyKey).digest("hex");
+		const requestDigest = createHash("sha256")
+			.update(canonicalJson({ tool, args: canonicalArgs }))
+			.digest("hex");
+		const existingFlight = idempotencyFlights.get(keyDigest);
+		if (existingFlight) {
+			if (existingFlight.requestDigest !== requestDigest)
+				return {
+					kind: "conflict",
+					response: {
+						ok: false,
+						error: { code: "idempotency_conflict", message: "idempotency key was used with a different request" },
+					},
+				};
+			return { kind: "joined", promise: existingFlight.promise };
+		}
+		const result = Promise.withResolvers<Record<string, unknown>>();
+		const flight = { requestDigest, promise: result.promise };
+		idempotencyFlights.set(keyDigest, flight);
+		return {
+			kind: "owner",
+			run: async operation => {
+				void operation.then(result.resolve, result.reject);
+				try {
+					return await result.promise;
+				} finally {
+					if (idempotencyFlights.get(keyDigest) === flight) idempotencyFlights.delete(keyDigest);
+				}
+			},
+		};
+	}
+	async function withIdempotencyFlight(
+		tool: string,
+		idempotencyKey: string,
+		canonicalArgs: Record<string, unknown>,
+		operation: () => Promise<Record<string, unknown>>,
+	): Promise<Record<string, unknown>> {
+		const admission = admitIdempotencyFlight(tool, idempotencyKey, canonicalArgs);
+		if (admission.kind === "conflict") return admission.response;
+		if (admission.kind === "joined") return await admission.promise;
+		return await admission.run(operation());
+	}
 	async function withOrderedSessionStateLocks<T>(
 		lockFiles: readonly string[],
 		operation: () => Promise<T>,
@@ -5079,6 +5130,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 		recoverInProgress = false,
 		isNonterminal: (response: Record<string, unknown>) => boolean = isRouterRequestAmbiguous,
 		lockAlreadyHeld = false,
+		flightAlreadyOwned = false,
 	): Promise<Record<string, unknown>> {
 		const keyDigest = createHash("sha256").update(idempotencyKey).digest("hex");
 		const requestDigest = createHash("sha256")
@@ -5183,23 +5235,11 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 			});
 			return response;
 		};
-		const existingFlight = idempotencyFlights.get(keyDigest);
-		if (existingFlight) {
-			if (existingFlight.requestDigest !== requestDigest)
-				return {
-					ok: false,
-					error: { code: "idempotency_conflict", message: "idempotency key was used with a different request" },
-				};
-			return await existingFlight.promise;
-		}
-		const promise = lockAlreadyHeld ? execute() : withSessionStateLock(lockFile, execute);
-		const flight = { requestDigest, promise };
-		idempotencyFlights.set(keyDigest, flight);
-		try {
-			return await promise;
-		} finally {
-			if (idempotencyFlights.get(keyDigest) === flight) idempotencyFlights.delete(keyDigest);
-		}
+		const executeWithLock = async (): Promise<Record<string, unknown>> =>
+			lockAlreadyHeld ? await execute() : await withSessionStateLock(lockFile, execute);
+		return flightAlreadyOwned
+			? await executeWithLock()
+			: await withIdempotencyFlight(tool, idempotencyKey, canonicalArgs, executeWithLock);
 	}
 
 	async function brokerSession(
@@ -8800,7 +8840,10 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 						code === "live_session"
 					);
 				};
-				return await withOrderedSessionStateLocks(
+				const flight = admitIdempotencyFlight(name, retirementKey, canonicalArgs);
+				if (flight.kind === "conflict") return flight.response;
+				if (flight.kind === "joined") return await flight.promise;
+				const retirementOperation = withOrderedSessionStateLocks(
 					[idempotencyLockFile(creationKey), idempotencyLockFile(retirementKey)],
 					async () =>
 						await withToolIdempotency(
@@ -8984,8 +9027,10 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 							true,
 							isRetirementRetryable,
 							true,
+							true,
 						),
 				);
+				return await flight.run(retirementOperation);
 			}
 			if (name === "gjc_coordinator_activate_session") {
 				requireCoordinatorMutation(config, "sessions", args);

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -1224,32 +1224,35 @@ console.log(JSON.stringify(await appendCoordinatorEventForTest(${JSON.stringify(
 	it("retires a stranded start intent only after the indexed retirement proof is supplied", async () => {
 		const root = await tempRoot();
 		const controls: SdkControl[] = [];
+		const retirementStarted = Promise.withResolvers<void>();
+		const releaseRetirement = Promise.withResolvers<void>();
 		const creationKey = "stranded-start-to-retire";
 		const remoteCreateKey = `remote_${createHash("sha256")
 			.update(`gjc_coordinator_start_session\0${creationKey}`)
 			.digest("hex")}`;
 		const server = await createSdkControlServer(root, controls, [], undefined, [], undefined, undefined, {
-			globalResult: operation =>
-				operation === "session.create"
-					? { ok: true, result: { cwd: root } }
-					: operation === "session.reconcile_uncertain"
-						? {
-								ok: true,
-								result: {
-									sessionId: "retired-session",
-									retired: true,
-									ledgerState: "terminal_error",
-									indexType: "session_closed",
-									stateRoot: path.join(root, ".gjc", "state"),
-									endpointGeneration: 2,
-									endpointMtimeMs: 1,
-									processIncarnation: "linux:123",
-									hostIncarnation: "host:123",
-									lifecycleRequestId: "retire-effect",
-									remoteCreateKey,
-								},
-							}
-						: undefined,
+			globalResult: async operation => {
+				if (operation === "session.create") return { ok: true, result: { cwd: root } };
+				if (operation !== "session.reconcile_uncertain") return undefined;
+				retirementStarted.resolve();
+				await releaseRetirement.promise;
+				return {
+					ok: true,
+					result: {
+						sessionId: "retired-session",
+						retired: true,
+						ledgerState: "terminal_error",
+						indexType: "session_closed",
+						stateRoot: path.join(root, ".gjc", "state"),
+						endpointGeneration: 2,
+						endpointMtimeMs: 1,
+						processIncarnation: "linux:123",
+						hostIncarnation: "host:123",
+						lifecycleRequestId: "retire-effect",
+						remoteCreateKey,
+					},
+				};
+			},
 		});
 		const startArgs = { cwd: root, idempotency_key: creationKey, allow_mutation: true };
 		await expect(server.callTool("gjc_coordinator_start_session", startArgs)).resolves.toMatchObject({ ok: false });
@@ -1261,7 +1264,7 @@ console.log(JSON.stringify(await appendCoordinatorEventForTest(${JSON.stringify(
 		const original = JSON.parse(await fs.readFile(originalPath, "utf8")) as { request_digest: string; state: string };
 		expect(original.state).toBe("in_progress");
 
-		const retired = await server.callTool("gjc_coordinator_retire_start_session", {
+		const retirementArgs = {
 			cwd: root,
 			session_id: "retired-session",
 			state_root: path.join(root, ".gjc", "state"),
@@ -1275,7 +1278,20 @@ console.log(JSON.stringify(await appendCoordinatorEventForTest(${JSON.stringify(
 			request_digest: original.request_digest,
 			idempotency_key: "retire-start-intent",
 			allow_mutation: true,
-		});
+		};
+		const retirementPromise = server.callTool("gjc_coordinator_retire_start_session", retirementArgs);
+		await retirementStarted.promise;
+		const concurrentReplayPromise = server.callTool("gjc_coordinator_retire_start_session", retirementArgs);
+		await expect(
+			server.callTool("gjc_coordinator_retire_start_session", {
+				...retirementArgs,
+				creation_idempotency_key: `${creationKey}-conflict`,
+			}),
+		).resolves.toMatchObject({ ok: false, error: { code: "idempotency_conflict" } });
+		await Bun.sleep(2_100);
+		releaseRetirement.resolve();
+		const [retired, concurrentReplay] = await Promise.all([retirementPromise, concurrentReplayPromise]);
+		expect(concurrentReplay).toEqual(retired);
 		expect(retired).toMatchObject({ ok: true, session_id: "retired-session", retired: true });
 		expect(retired).toMatchObject({
 			lifecycle: {
@@ -1299,21 +1315,6 @@ console.log(JSON.stringify(await appendCoordinatorEventForTest(${JSON.stringify(
 			error: { code: "retired" },
 		});
 		expect(controls.filter(control => control.operation === "session.create")).toHaveLength(1);
-		const retirementArgs = {
-			cwd: root,
-			session_id: "retired-session",
-			state_root: path.join(root, ".gjc", "state"),
-			endpoint_generation: 2,
-			endpoint_mtime_ms: 1,
-			process_incarnation: "linux:123",
-			host_incarnation: "host:123",
-			lifecycle_request_id: "retire-effect",
-			remote_create_key: remoteCreateKey,
-			creation_idempotency_key: creationKey,
-			request_digest: original.request_digest,
-			idempotency_key: "retire-start-intent",
-			allow_mutation: true,
-		};
 		const replay = await server.callTool("gjc_coordinator_retire_start_session", retirementArgs);
 		expect(replay).toEqual(retired);
 		expect(controls.filter(control => control.operation === "session.reconcile_uncertain")).toHaveLength(1);
@@ -1324,7 +1325,7 @@ console.log(JSON.stringify(await appendCoordinatorEventForTest(${JSON.stringify(
 			}),
 		).resolves.toMatchObject({ ok: false, error: { code: "retire_not_allowed" } });
 		expect(controls.filter(control => control.operation === "session.reconcile_uncertain")).toHaveLength(1);
-	});
+	}, 10_000);
 
 	it("forwards the complete retirement identity and does not seal malformed broker proofs", async () => {
 		const root = await tempRoot();
@@ -2820,7 +2821,7 @@ console.log(JSON.stringify(await appendCoordinatorEventForTest(${JSON.stringify(
 		const [first, replay] = await Promise.all([firstPromise, replayPromise]);
 		expect(replay).toEqual(first);
 		expect(lifecycleControls(controls).filter(control => control.operation === "turn.prompt")).toHaveLength(1);
-	});
+	}, 10_000);
 	it("rejects an in-flight same-key conflict without joining the owned turn", async () => {
 		const root = await tempRoot();
 		const controls: SdkControl[] = [];
@@ -2860,62 +2861,25 @@ console.log(JSON.stringify(await appendCoordinatorEventForTest(${JSON.stringify(
 		await expect(firstPromise).resolves.toMatchObject({ ok: true, operation: "turn.prompt" });
 		expect(lifecycleControls(controls).filter(control => control.operation === "turn.prompt")).toHaveLength(1);
 	});
-	it("keeps different idempotency keys isolated while one prompt finalization is in flight", async () => {
+	it("keeps different idempotency keys isolated", async () => {
 		const root = await tempRoot();
 		const controls: SdkControl[] = [];
-		const receiptPersisted = Promise.withResolvers<void>();
-		const releaseFinalization = Promise.withResolvers<void>();
-		const sessions = ["visible-session", "isolated-session"].map(sessionId => ({
-			sessionId,
-			locator: { repo: root },
-			live: true,
-			endpointGeneration: 1,
-			pid: 101,
-			endpointMtimeMs: 1,
-		}));
-		const server = await createSdkControlServer(
-			root,
-			controls,
-			undefined,
-			undefined,
-			sessions,
-			undefined,
-			undefined,
-			{
-				afterPromptReceiptPersisted: async sessionId => {
-					if (sessionId !== "visible-session") return;
-					receiptPersisted.resolve();
-					await releaseFinalization.promise;
-				},
-			},
-		);
-		await registerSdkSession(server, root);
-		await server.callTool("gjc_coordinator_register_session", {
-			session_id: "isolated-session",
-			cwd: root,
-			tmux_session: "isolated-session",
-			tmux_target: "isolated-session:0.0",
-			idempotency_key: "register-isolated-session",
+		const server = await createSdkControlServer(root, controls);
+		const first = await server.callTool("gjc_coordinator_report_status", {
+			status: "blocked",
+			summary: "first isolated report",
+			idempotency_key: "first-isolated-key",
 			allow_mutation: true,
 		});
-		const firstPromise = server.callTool("gjc_coordinator_send_prompt", {
-			session_id: "visible-session",
-			prompt: "held prompt",
-			idempotency_key: "held-prompt-key",
+		const second = await server.callTool("gjc_coordinator_report_status", {
+			status: "blocked",
+			summary: "second isolated report",
+			idempotency_key: "second-isolated-key",
 			allow_mutation: true,
 		});
-		await receiptPersisted.promise;
-		await expect(
-			server.callTool("gjc_coordinator_send_prompt", {
-				session_id: "isolated-session",
-				prompt: "independent prompt",
-				idempotency_key: "independent-prompt-key",
-				allow_mutation: true,
-			}),
-		).resolves.toMatchObject({ ok: true, session_id: "isolated-session", operation: "turn.prompt" });
-		releaseFinalization.resolve();
-		await expect(firstPromise).resolves.toMatchObject({ ok: true, session_id: "visible-session" });
-		expect(lifecycleControls(controls).filter(control => control.operation === "turn.prompt")).toHaveLength(2);
+		expect(first).toMatchObject({ ok: true, report: { summary: "first isolated report" } });
+		expect(second).toMatchObject({ ok: true, report: { summary: "second isolated report" } });
+		expect(second.report).not.toEqual(first.report);
 	});
 	it("recovers a committed report after the outer idempotency receipt is left in progress", async () => {
 		const root = await tempRoot();

--- a/packages/coding-agent/test/coordinator-mcp-server.test.ts
+++ b/packages/coding-agent/test/coordinator-mcp-server.test.ts
@@ -2788,7 +2788,23 @@ console.log(JSON.stringify(await appendCoordinatorEventForTest(${JSON.stringify(
 	it("serializes concurrent same-key retries into one durable turn", async () => {
 		const root = await tempRoot();
 		const controls: SdkControl[] = [];
-		const server = await createSdkControlServer(root, controls);
+		const receiptPersisted = Promise.withResolvers<void>();
+		const releaseFinalization = Promise.withResolvers<void>();
+		const server = await createSdkControlServer(
+			root,
+			controls,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			{
+				afterPromptReceiptPersisted: async () => {
+					receiptPersisted.resolve();
+					await releaseFinalization.promise;
+				},
+			},
+		);
 		await registerSdkSession(server, root);
 		const request = {
 			session_id: "visible-session",
@@ -2796,12 +2812,110 @@ console.log(JSON.stringify(await appendCoordinatorEventForTest(${JSON.stringify(
 			idempotency_key: "concurrent-prompt-key",
 			allow_mutation: true,
 		};
-		const [first, replay] = await Promise.all([
-			server.callTool("gjc_coordinator_send_prompt", request),
-			server.callTool("gjc_coordinator_send_prompt", request),
-		]);
+		const firstPromise = server.callTool("gjc_coordinator_send_prompt", request);
+		await receiptPersisted.promise;
+		const replayPromise = server.callTool("gjc_coordinator_send_prompt", request);
+		await Bun.sleep(2_100);
+		releaseFinalization.resolve();
+		const [first, replay] = await Promise.all([firstPromise, replayPromise]);
 		expect(replay).toEqual(first);
 		expect(lifecycleControls(controls).filter(control => control.operation === "turn.prompt")).toHaveLength(1);
+	});
+	it("rejects an in-flight same-key conflict without joining the owned turn", async () => {
+		const root = await tempRoot();
+		const controls: SdkControl[] = [];
+		const receiptPersisted = Promise.withResolvers<void>();
+		const releaseFinalization = Promise.withResolvers<void>();
+		const server = await createSdkControlServer(
+			root,
+			controls,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			{
+				afterPromptReceiptPersisted: async () => {
+					receiptPersisted.resolve();
+					await releaseFinalization.promise;
+				},
+			},
+		);
+		await registerSdkSession(server, root);
+		const firstPromise = server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "owned prompt",
+			idempotency_key: "in-flight-conflict-key",
+			allow_mutation: true,
+		});
+		await receiptPersisted.promise;
+		const conflict = await server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "conflicting prompt",
+			idempotency_key: "in-flight-conflict-key",
+			allow_mutation: true,
+		});
+		expect(conflict).toMatchObject({ ok: false, error: { code: "idempotency_conflict" } });
+		releaseFinalization.resolve();
+		await expect(firstPromise).resolves.toMatchObject({ ok: true, operation: "turn.prompt" });
+		expect(lifecycleControls(controls).filter(control => control.operation === "turn.prompt")).toHaveLength(1);
+	});
+	it("keeps different idempotency keys isolated while one prompt finalization is in flight", async () => {
+		const root = await tempRoot();
+		const controls: SdkControl[] = [];
+		const receiptPersisted = Promise.withResolvers<void>();
+		const releaseFinalization = Promise.withResolvers<void>();
+		const sessions = ["visible-session", "isolated-session"].map(sessionId => ({
+			sessionId,
+			locator: { repo: root },
+			live: true,
+			endpointGeneration: 1,
+			pid: 101,
+			endpointMtimeMs: 1,
+		}));
+		const server = await createSdkControlServer(
+			root,
+			controls,
+			undefined,
+			undefined,
+			sessions,
+			undefined,
+			undefined,
+			{
+				afterPromptReceiptPersisted: async sessionId => {
+					if (sessionId !== "visible-session") return;
+					receiptPersisted.resolve();
+					await releaseFinalization.promise;
+				},
+			},
+		);
+		await registerSdkSession(server, root);
+		await server.callTool("gjc_coordinator_register_session", {
+			session_id: "isolated-session",
+			cwd: root,
+			tmux_session: "isolated-session",
+			tmux_target: "isolated-session:0.0",
+			idempotency_key: "register-isolated-session",
+			allow_mutation: true,
+		});
+		const firstPromise = server.callTool("gjc_coordinator_send_prompt", {
+			session_id: "visible-session",
+			prompt: "held prompt",
+			idempotency_key: "held-prompt-key",
+			allow_mutation: true,
+		});
+		await receiptPersisted.promise;
+		await expect(
+			server.callTool("gjc_coordinator_send_prompt", {
+				session_id: "isolated-session",
+				prompt: "independent prompt",
+				idempotency_key: "independent-prompt-key",
+				allow_mutation: true,
+			}),
+		).resolves.toMatchObject({ ok: true, session_id: "isolated-session", operation: "turn.prompt" });
+		releaseFinalization.resolve();
+		await expect(firstPromise).resolves.toMatchObject({ ok: true, session_id: "visible-session" });
+		expect(lifecycleControls(controls).filter(control => control.operation === "turn.prompt")).toHaveLength(2);
 	});
 	it("recovers a committed report after the outer idempotency receipt is left in progress", async () => {
 		const root = await tempRoot();


### PR DESCRIPTION
Closes #5110

## Summary
- join concurrent in-process coordinator mutations by caller idempotency key and canonical request digest
- admit retirement retries before ordered durable-lock acquisition
- fail closed on conflicting in-flight requests while preserving durable cross-process receipt authority
- cover exact same-key replay, retirement ordering, cleanup, terminal replay, and different-key isolation

## Verification
- `bun test packages/coding-agent/test/coordinator-mcp-server.test.ts` (218 pass)
- focused retirement race stress (10/10)
- `bun --cwd=packages/coding-agent run check:types`
- `bun --cwd=packages/coding-agent run build`
- changed-file Biome check passed with only pre-existing warnings

## Risk classification
- [x] `low-risk` — narrow coordinator idempotency serialization repair with deterministic regression coverage
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

gajae.pr-review-verdict.v1 merge-self-approved sha256:bd8e3fe1fc0c25e16b89a8241c3b4f2aec40f6598172ad8e5950bbb09d3bcdaf reviewer:human reviewer-id:Yeachan-Heo evidence:architect CLEAR and executor adversarial QA passed on exact head