### PR TITLE
fix(coordinator): clear coding-agent Biome blockers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Coordinator event watchers now advertise the exact supported event-kind enum, while outbox entity validation and durable WAL/active-turn cleanup reuse their existing authority helpers instead of leaving those checks disconnected. (#5115)
 - Post-install update verification now preserves a bounded, secret-redacted stderr/stdout cause when the newly installed `gjc --version` exits unsuccessfully, so runtime guards such as Bun version incompatibilities remain actionable instead of collapsing to a generic verification failure. (#5108)
 - Concurrent coordinator mutations sharing one idempotency key now join the same in-process flight before taking the durable key lock, so a slow accepted prompt cannot make its retry time out as unavailable. Conflicting in-flight requests still fail closed, completed responses remain durably replayable, and different keys remain isolated. (#5110)
 

--- a/packages/coding-agent/src/coordinator-mcp/question-state.ts
+++ b/packages/coding-agent/src/coordinator-mcp/question-state.ts
@@ -1029,7 +1029,7 @@ function assertTransaction(transaction: CoordinatorSessionTransactionV1, namespa
 		const rejectedHistorical = request.phase === "rejected";
 		if (
 			rejectedHistorical
-				? !request.safe_receipt || request.safe_receipt.status !== "rejected"
+				? request.safe_receipt?.status !== "rejected"
 				: question.answer_request_id !== request.request_id ||
 					question.claim_fence_epoch !== request.claim_fence_epoch
 		)
@@ -1083,7 +1083,7 @@ function assertTransaction(transaction: CoordinatorSessionTransactionV1, namespa
 			event.transaction_revision > transaction.revision ||
 			typeof event.kind !== "string" ||
 			event.kind.length === 0 ||
-			!["turn", "question", "report", "session", "deletion"].includes(event.entity) ||
+			!isOutboxEntity(event.entity) ||
 			typeof event.entity_id !== "string" ||
 			event.entity_id.length === 0 ||
 			!isRecord(event.payload) ||
@@ -1296,7 +1296,7 @@ export async function listCanonicalActiveSessions(
 		paths.registryLock,
 		async () => {
 			const registry = await readJson<NamespaceRegistryV1>(paths.registry);
-			if (!registry || registry.schema_version !== 1 || registry.namespace_id !== path.basename(paths.root))
+			if (registry?.schema_version !== 1 || registry.namespace_id !== path.basename(paths.root))
 				throw new Error("state_corrupt");
 			return Object.values(registry.roster ?? {})
 				.filter(entry => entry.active || entry.dirty)
@@ -1333,7 +1333,7 @@ export async function readDeliveryDiscoveryCursor(
 		paths.registryLock,
 		async () => {
 			const registry = await readJson<NamespaceRegistryV1>(paths.registry);
-			if (!registry || registry.schema_version !== 1 || registry.namespace_id !== path.basename(paths.root))
+			if (registry?.schema_version !== 1 || registry.namespace_id !== path.basename(paths.root))
 				throw new Error("state_corrupt");
 			return registry.delivery_discovery_cursor ?? "";
 		},
@@ -1660,7 +1660,7 @@ export async function startCreationRemote(
 ): Promise<CreationRequestV1> {
 	return await withNamespaceRegistry(paths, async registry => {
 		const request = registry.creations[keyDigest];
-		if (!request || !request.sidecar_verifier) throw new Error("state_corrupt");
+		if (!request?.sidecar_verifier) throw new Error("state_corrupt");
 		if (
 			request.phase === "claimed" &&
 			(request.sidecar_verifier.key_id !== expectedVerifier.key_id ||
@@ -1687,8 +1687,7 @@ export async function reconcileCreationRemoteVerifier(
 ): Promise<CreationRequestV1> {
 	return await withNamespaceRegistry(paths, async registry => {
 		const request = registry.creations[keyDigest];
-		if (!request || !request.sidecar_verifier || request.phase !== "remote_started")
-			throw new Error("terminal_uncertain");
+		if (!request?.sidecar_verifier || request.phase !== "remote_started") throw new Error("terminal_uncertain");
 		if (!/^[a-f0-9]{64}$/.test(usedKeyId)) throw new Error("terminal_uncertain");
 		if (usedKeyId === candidate.key_id) request.sidecar_verifier = candidate;
 		else if (usedKeyId !== request.sidecar_verifier.key_id) throw new Error("terminal_uncertain");
@@ -2241,7 +2240,7 @@ export async function enumeratePublicDeliveries(
 		paths.registryLock,
 		async () => {
 			const registry = await readJson<NamespaceRegistryV1>(paths.registry);
-			if (!registry || registry.schema_version !== 1 || registry.namespace_id !== path.basename(paths.root))
+			if (registry?.schema_version !== 1 || registry.namespace_id !== path.basename(paths.root))
 				throw new Error("state_corrupt");
 			return [...new Set([...Object.keys(registry.roster ?? {}), ...Object.keys(registry.retained_sessions ?? {})])]
 				.filter(name => COORDINATOR_SESSION_ID_PATTERN.test(name))
@@ -2526,7 +2525,7 @@ export async function replaceCreationRetirementIntent(
 		if (request.phase !== "remote_started" && request.phase !== "uncertain" && request.phase !== "retired")
 			throw new Error("retire_not_allowed");
 		const staged = request.retirement_intent;
-		if (!staged || staged.phase !== "intent" || staged.broker_proof) throw new Error("state_corrupt");
+		if (staged?.phase !== "intent" || staged.broker_proof) throw new Error("state_corrupt");
 		if (staged.retirement_key_digest !== retirementKeyDigest) throw new Error("idempotency_conflict");
 		assertCreationRetirementProofMatches(request, proof, false);
 		staged.phase = "pre_effect_rejected";
@@ -2716,8 +2715,7 @@ export async function removeSessionTransaction(
 				// exporter lease expires instead of deleting an undelivered event.
 				if (Object.values(transaction.outbox).some(event => event.public_delivery.state !== "acknowledged"))
 					return false;
-				await fs.rm(file, { force: true });
-				await syncCoordinatorDirectory(path.dirname(file));
+				await removeCoordinatorStateFile(file);
 				delete registry.roster?.[sessionId];
 				delete registry.retained_sessions?.[sessionId];
 				return true;

--- a/packages/coding-agent/src/coordinator-mcp/server.ts
+++ b/packages/coding-agent/src/coordinator-mcp/server.ts
@@ -835,7 +835,7 @@ function toolSchema(name: CoordinatorToolName): {
 				properties: {
 					after_seq: { type: "integer", minimum: 0 },
 					session_id: sessionId,
-					event_types: { type: "array", items: { type: "string" } },
+					event_types: { type: "array", items: { type: "string", enum: [...COORDINATOR_EVENT_KINDS] } },
 					timeout_ms: {
 						type: "number",
 						description: "Bounded event long-poll timeout in milliseconds, capped at 30 seconds.",
@@ -2637,11 +2637,6 @@ async function writeActiveTurn(namespaceDir: string, turn: TurnRecord): Promise<
 	});
 }
 
-async function clearActiveTurn(namespaceDir: string, turn: TurnRecord): Promise<void> {
-	const active = asRecord(await readJsonFile(activeTurnFile(namespaceDir, turn.session_id)));
-	if (active?.turn_id === turn.turn_id) await removeCoordinatorFile(activeTurnFile(namespaceDir, turn.session_id));
-}
-
 async function readSessionState(namespaceDir: string, sessionId: string): Promise<CoordinatorSessionState | null> {
 	return (await readJsonFile(sessionStateFile(namespaceDir, sessionId))) as CoordinatorSessionState | null;
 }
@@ -2661,9 +2656,6 @@ async function writeSessionStateUnlocked(
 	} = {},
 ): Promise<CoordinatorSessionState> {
 	const persisted = await readSessionState(namespaceDir, sessionId);
-	const session = asRecord(
-		await readJsonFile(path.join(namespaceDir, "sessions", `${safeExternalId("session", sessionId)}.json`)),
-	);
 	// An overwrite is a canonical lifecycle repair, not proof that tool activity ended.
 	const previous = options.overwrite ? null : persisted;
 	const hasCurrentTurn = Object.hasOwn(options, "currentTurnId");
@@ -6773,7 +6765,7 @@ export function createCoordinatorMcpServer(options: CoordinatorMcpServerOptions 
 					// any stale pointer directly: once the turn projection is rewritten
 					// terminal, readActiveTurn() intentionally rejects it and cannot
 					// discover the legacy active-turn file to clear.
-					await fs.rm(activeTurnFile(namespaceDir, sessionId), { force: true });
+					await removeCoordinatorFile(activeTurnFile(namespaceDir, sessionId));
 				}
 				// A runtime sidecar can advance a live session while the canonical WAL still
 				// needs projection repair. Preserve that observed lifecycle state (and its

--- a/packages/coding-agent/src/sdk/host/host.ts
+++ b/packages/coding-agent/src/sdk/host/host.ts
@@ -637,7 +637,11 @@ export class SessionSdkHost {
 	}
 	#observeRequest(kind: "control" | "query", connectionId: string, frame: SdkFrame): void {
 		try {
-			this.#options.onRequest?.(kind, connectionId, redactObservedRequestContent(redactBrokerRuntimeCapabilities(frame)));
+			this.#options.onRequest?.(
+				kind,
+				connectionId,
+				redactObservedRequestContent(redactBrokerRuntimeCapabilities(frame)),
+			);
 		} catch {
 			// Diagnostic observers must not change request handling.
 		}


### PR DESCRIPTION
## Summary
- reconnect outbox entity validation and durable coordinator WAL removal helpers
- expose the existing coordinator event-kind authority in the watch-events schema
- remove only obsolete active-turn/session projection declarations
- apply pinned Biome formatting to the post-master-mode SDK host merge line
- record the public schema correction in the coding-agent Unreleased changelog

## Attribution
Inspected the pre-existing `fix/dev-ci-biome-format` branch and commit `fd7587fda9` by Yeachan-Heo as required. That branch is 4,674 commits behind current `dev` and only formats obsolete ultragoal surfaces, so no hunks were copied or misattributed; its original commit remains intact.

## Risk classification
- [x] `low-risk` — narrow CI/validation wiring cleanup with no public behavior expansion
- [ ] `regression-risk`
- [ ] `high-risk`

## Exact-head CI
- Rerun attempt 2 passed coding-agent check, affected tests, state gates, evidence aggregation, and virtual integration at `46983220aaefa5dc4072c0c1786c7e5e18a18cbe`.

## Verification
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent run check:types`
- `bun test packages/coding-agent/test/coordinator-mcp-server.test.ts packages/coding-agent/test/coordinator-durability.test.ts packages/coding-agent/test/coordinator-durability-masking.test.ts packages/coding-agent/test/coordinator-mcp/session-reaper.test.ts` (260 pass)

gajae.pr-review-verdict.v1 merge-approved sha256:9599decf5cf7bf86df8da0b383ea3c0e55419b27c6851e0e8380f8d553ac72d8 reviewer:human reviewer-id:probepark evidence:exact-head-46983220-coordinator-biome-cleanup-preserves-contracts

Closes #5115