### PR TITLE
fix(telegram): refresh daemon generation artifacts

### DIFF
--- a/packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts
+++ b/packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts
@@ -291,7 +291,7 @@ export const SDK_LIFECYCLE_ROUTER_PROTOCOL_VERSION = 1;
  * killing a session's mirroring after one transient rejection and must be
  * replaced across this upgrade.
  */
-export const DAEMON_GENERATION = 179;
+export const DAEMON_GENERATION = 180;
 
 /**
  * Serving-compatibility boundary for daemon lifecycle requests. Epoch 7

--- a/packages/coding-agent/test/notifications-topic-registry.test.ts
+++ b/packages/coding-agent/test/notifications-topic-registry.test.ts
@@ -756,7 +756,7 @@ test("preserves a no-provenance endpoint claim before a held create can stage it
 	await creating;
 	expect(reg.endpointAuthority(binding)).toEqual({ state: "unique", sessionId: "B" });
 });
-test("publishes exact durable authority generation 179 at serving epoch 88", () => {
+test("publishes exact durable authority generation 180 at serving epoch 88", () => {
 	// Generation 58: parser-valid durable-fence promotion and rollback.
 	// Generation 152: a thrown steady heartbeat renewal in the run loop is
 	// contained instead of terminating the daemon (#4200).
@@ -802,7 +802,7 @@ test("publishes exact durable authority generation 179 at serving epoch 88", () 
 	// notification publications instead of cancelling the subscription on the
 	// first refusal, so generation-178 owners that kill a session's mirroring
 	// after one transient rejection are replaced across this upgrade.
-	expect(DAEMON_GENERATION).toBe(179);
+	expect(DAEMON_GENERATION).toBe(180);
 	expect(SERVING_EPOCH).toBe(88);
 });
 test("archives pending topics into retained inactive records", async () => {

--- a/scripts/telegram-daemon-generation-manifest.json
+++ b/scripts/telegram-daemon-generation-manifest.json
@@ -545,7 +545,7 @@
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:ownerPidFromOwnerId": "46691373b2bee01f28f3817a6aa6a7efffe880c2cea337c89155582c98d952bf",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:runDaemonInternal": "db43a7e7a33d5891e6c200ebeb66ce56d47cf209caa3a2b27e6ac5f35640a574",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-cli.ts:runDaemonSmoke": "6f085a667aa5c83de46d2d8945fb845c355fcbb43c46872342a44489203a5830",
-    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:DAEMON_GENERATION": "ca43882948b4282dcaf580e92d6b0bc586f094bdd4297a0ebdc63e5d4a43aa2b",
+    "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:DAEMON_GENERATION": "17294c70aac51886e704044e06e84a193293058b66161ff083d6c2020a531115",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-contract.ts:NOTIFICATION_PROTOCOL_VERSION": "b99289f651fedcf020d28dbaf6f07dd37e7e4a5f6dc1f5118b872112325f1e81",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts:DaemonProcessReference": "c3d13e3670a6245a1250c4ebfcd80a36dd8fc96c67ab64d9f979182bd117bc4e",
     "telegram:packages/coding-agent/src/sdk/bus/telegram-daemon-control.ts:TelegramDaemonController": "166b909a9073e4d1052b245152789cfb7a272cbf5fe3075e9e651766e68d0b1e",


### PR DESCRIPTION
## Summary
- advance Telegram `DAEMON_GENERATION` from 179 to 180 for the protected `createNotificationsExtension` lifecycle change merged by #4934
- synchronize the exact durable-authority fixture pin
- regenerate the Telegram daemon semantic generation manifest

## Deterministic generation proof
- reproduced the original guard failure against base `18e69847ce4eb4d9eacfad2117bb418bb5494fef`
- ran `--fix-generations` on exact `dev@d07c48987b24b994c5ae118475f9df7b3ed113e2`
- regenerated docs index, SDK operation inventory, SDK adapter parity manifest, Telegram baseline manifest, and generation manifest
- second complete generator pass preserved identical diff hash `40a66e4820cfca014838da7a1f6b4911b26452f55dba1495f39182df51642603`
- only the three canonical generation closure files changed

## Verification
- exact semantic guard: passed (`v51 required generation bump verified`)
- current-tree manifest validation: passed
- Telegram generation guard tests: 75 passed
- durable authority generation pin: passed
- coding-agent TypeScript check: passed
- tool TypeScript and unsafe-rmrf checks: passed
- coding-agent binary build: passed after building the local native dependency
- SDK adapter parity and Telegram baseline manifests/tests passed; the aggregate closure command later reached an unrelated pre-existing SDK canonicalization violation in `tmux-self-injection-guard.ts`
- root `check:tools` remains blocked by an unrelated pre-existing formatter error in `sdk/host/host.ts`; changed-file Biome check passed

## Risk classification
- [x] `low-risk` — deterministic generated generation fence/fixture/manifest closure only
- [ ] `regression-risk`
- [ ] `high-risk`

gajae.pr-review-verdict.v1 merge-self-approved sha256:3106af047ae2e1e6a7c87fdf0d0d91c3925143d2ab4f89eb6c72d7291939c7cf reviewer:human reviewer-id:Yeachan-Heo evidence:canonical generator closure reproduced, regenerated, idempotence-proved, guard-tested, typechecked, and built

Closes #5113