### PR TITLE
fix(sdk): restore master-mode endpoint authority

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Fixed
 
+- SDK lifecycle readiness now uses the same descriptor-bound endpoint identity tolerance as broker endpoint reads and selects owners by scoped state root, process incarnation, and lifecycle marker instead of bare session ID. This restores default source-host startup, shipped SDK lifecycle topology, shared-agent saved-source isolation, cold resume/fork cleanup, local SDK-only broker recovery, and generated operation-matrix closure after the master-mode merge. (#5114)
+
 - Coordinator event watchers now advertise the exact supported event-kind enum, while outbox entity validation and durable WAL/active-turn cleanup reuse their existing authority helpers instead of leaving those checks disconnected. (#5115)
 - Post-install update verification now preserves a bounded, secret-redacted stderr/stdout cause when the newly installed `gjc --version` exits unsuccessfully, so runtime guards such as Bun version incompatibilities remain actionable instead of collapsing to a generic verification failure. (#5108)
 - Concurrent coordinator mutations sharing one idempotency key now join the same in-process flight before taking the durable key lock, so a slow accepted prompt cannot make its retry time out as unavailable. Conflicting in-flight requests still fail closed, completed responses remain durably replayable, and different keys remain isolated. (#5110)

--- a/packages/coding-agent/src/commands/sdk.ts
+++ b/packages/coding-agent/src/commands/sdk.ts
@@ -583,6 +583,7 @@ export async function runSessionHost(
 				...(mcpStartupTimeoutMs !== undefined ? { mcpStartupTimeoutMs } : {}),
 				...(request.readiness ? { readiness: request.readiness } : {}),
 				...(request.modelId ? { modelId: request.modelId } : {}),
+				lifecycleRequestId: effectMarker,
 			});
 		} catch (error) {
 			throw await registrationFailure(error);

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -33,7 +33,7 @@ import {
 	readBrokerDiscovery,
 	redactBrokerDiscovery,
 } from "./discovery";
-import { readEndpointFile } from "./endpoint-authority";
+import { matchesIndexedEndpointFile, readEndpointFile } from "./endpoint-authority";
 import { deriveIdempotencyIdentity, getBrokerIdentityKey } from "./identity";
 import {
 	canonicalDeleteLocatorPath,
@@ -2868,9 +2868,7 @@ export class Broker {
 				endpoint.sessionId !== record.sessionId ||
 				endpoint.pid !== record.pid ||
 				endpoint.stale === true ||
-				record.endpointMtimeMs === undefined ||
-				Math.abs(file.mtimeMs - record.endpointMtimeMs) > 0.001 ||
-				(record.endpointFileId !== undefined && `${file.dev}:${file.ino}` !== record.endpointFileId)
+				!matchesIndexedEndpointFile(file, record)
 			)
 				return error("endpoint_stale", "session endpoint is stale");
 			await this.index.refresh();

--- a/packages/coding-agent/src/sdk/broker/endpoint-authority.ts
+++ b/packages/coding-agent/src/sdk/broker/endpoint-authority.ts
@@ -15,6 +15,11 @@ export type EndpointFileRead = {
 
 export type EndpointAuthorityFilesystem = Pick<typeof fs, "open">;
 
+export type IndexedEndpointAuthority = {
+	endpointMtimeMs?: number;
+	endpointFileId?: string;
+};
+
 function readFlags(): number {
 	return fsSync.constants.O_RDONLY | (fsSync.constants.O_NOFOLLOW ?? 0) | (fsSync.constants.O_NONBLOCK ?? 0);
 }
@@ -65,4 +70,17 @@ export async function readEndpointFile(
 	} finally {
 		await handle?.close().catch(() => undefined);
 	}
+}
+
+/** Match a descriptor-bound endpoint read to the index representation. */
+export function matchesIndexedEndpointFile(
+	file: Pick<EndpointFileRead, "dev" | "ino" | "mtimeMs">,
+	authority: IndexedEndpointAuthority,
+): boolean {
+	return (
+		authority.endpointMtimeMs !== undefined &&
+		Number.isFinite(authority.endpointMtimeMs) &&
+		Math.abs(file.mtimeMs - authority.endpointMtimeMs) <= 0.001 &&
+		(authority.endpointFileId === undefined || authority.endpointFileId === `${file.dev}:${file.ino}`)
+	);
 }

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -66,7 +66,7 @@ import {
 	sanitizeSdkStartupMessage,
 } from "../startup-capability";
 import type { Broker, BrokerCleanupEvidence, BrokerCleanupIdentity, BrokerResponse } from "./broker";
-import { readEndpointFile } from "./endpoint-authority";
+import { matchesIndexedEndpointFile, readEndpointFile } from "./endpoint-authority";
 import { decodeLifecycleUtf8, parseLifecycleJson } from "./lifecycle-codec";
 import type {
 	LifecycleCleanupProof,
@@ -919,10 +919,25 @@ async function validateLiveResumeScope(
 		sessionIdentity: session.identity,
 	};
 }
-async function reconcileReadyScope(broker: Broker, id: string, scope: string | undefined): Promise<void> {
+async function reconcileReadyScope(
+	broker: Broker,
+	id: string,
+	scope: string | undefined,
+	root: string,
+	expected: EffectMarker,
+): Promise<void> {
 	if (!scope) return;
 	await broker.index.refresh();
-	const record = broker.index.listSessions().sessions.find(session => session.sessionId === id);
+	const record = broker.index
+		.listSessions()
+		.sessions.find(
+			session =>
+				session.sessionId === id &&
+				resolveEquivalentPath(session.locator.stateRoot) === resolveEquivalentPath(root) &&
+				session.pid === expected.pid &&
+				(session.processIncarnation === undefined || session.processIncarnation === expected.incarnation) &&
+				session.lifecycleRequestId === expected.effectMarker,
+		);
 	if (!record) return;
 	const cwd = canonicalExistingPath(scope);
 	if (record.locator.cwd === cwd) return;
@@ -3938,16 +3953,24 @@ async function currentReadyAuthority(
 		// native-dead child; do not refuse a native-alive ready host for a stale live bit.
 		await broker.heartbeatSessions();
 		await broker.index.refresh();
-		const record = broker.index.listSessions().sessions.find(session => session.sessionId === id);
+		const record = broker.index
+			.listSessions()
+			.sessions.find(
+				session =>
+					session.sessionId === id &&
+					session.pid === expected.pid &&
+					resolveEquivalentPath(session.locator.stateRoot) === resolveEquivalentPath(root) &&
+					(session.processIncarnation === undefined || session.processIncarnation === expected.incarnation) &&
+					session.lifecycleRequestId === expected.effectMarker,
+			);
 		if (
 			!record ||
 			record.terminal ||
 			record.terminalUncertain ||
 			record.pid !== expected.pid ||
 			resolveEquivalentPath(record.locator.stateRoot) !== resolveEquivalentPath(root) ||
-			(record.endpointFileId !== undefined && record.endpointFileId !== `${endpointFile.dev}:${endpointFile.ino}`) ||
 			(record.processIncarnation !== undefined && record.processIncarnation !== expected.incarnation) ||
-			record.endpointMtimeMs !== endpointFile.mtimeMs ||
+			!matchesIndexedEndpointFile(endpointFile, record) ||
 			endpoint.pid !== expected.pid ||
 			endpoint.sessionId !== id ||
 			typeof endpoint.url !== "string" ||
@@ -3974,7 +3997,7 @@ async function currentReadyAuthority(
 function sameReadyAuthority(left: ReadyAuthority, right: ReadyAuthority): boolean {
 	return (
 		left.endpointSource === right.endpointSource &&
-		left.endpointMtimeMs === right.endpointMtimeMs &&
+		Math.abs(left.endpointMtimeMs - right.endpointMtimeMs) <= 0.001 &&
 		left.endpointFileId === right.endpointFileId &&
 		left.endpointGeneration === right.endpointGeneration
 	);
@@ -4808,13 +4831,18 @@ async function executeLifecycleResponse(
 	if (operation === "session.create" || operation === "session.fork" || operation === "session.resume") {
 		await broker.index.refresh();
 		await broker.heartbeatSessions();
+		await broker.index.refresh();
 		if (operation === "session.resume") {
 			const requestedSessionId = sessionId(input);
-			const existing = requestedSessionId
-				? broker.index.listSessions().sessions.find(session => session.sessionId === requestedSessionId)
-				: undefined;
-			if (existing && !isSessionAuthorityEligible(existing))
+			const indexedCandidates = requestedSessionId
+				? broker.index.listSessions().sessions.filter(session => session.sessionId === requestedSessionId)
+				: [];
+			if (indexedCandidates.some(session => !isSessionAuthorityEligible(session)))
 				return fail("endpoint_stale", "Session authority is ambiguous and cannot be resumed safely.");
+			const existingCandidates = indexedCandidates.filter(session => session.live);
+			if (existingCandidates.length > 1)
+				return fail("endpoint_stale", "Multiple live session owners claim this session id.");
+			const existing = existingCandidates[0];
 			if (existing?.live) {
 				const initialScope = await validateLiveResumeScope(broker, input, requestedSessionId!, existing);
 				if ("ok" in initialScope) return initialScope;
@@ -5175,7 +5203,7 @@ async function executeLifecycleResponse(
 									`Session ${launch.id} did not register an endpoint before the readiness timeout.`,
 								);
 		}
-		await reconcileReadyScope(broker, launch.id, launch.cwd);
+		await reconcileReadyScope(broker, launch.id, launch.cwd, launch.root, spawnedAuthority);
 		const verified = await currentReadyAuthority(broker, launch.id, launch.root, spawnedAuthority);
 		if (!verified || !sameReadyAuthority(readiness.authority, verified)) {
 			const exited =

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -745,6 +745,8 @@ type LiveResumeRecord = {
 	endpointGeneration: number;
 	pid: number;
 	endpointMtimeMs?: number;
+	processIncarnation?: string;
+	hostIncarnation?: string;
 	live: boolean;
 	ambiguous: boolean;
 };
@@ -785,6 +787,8 @@ function sameLiveResumeRecord(expected: LiveResumeRecord, current: LiveResumeRec
 		current.endpointGeneration === expected.endpointGeneration &&
 		current.pid === expected.pid &&
 		current.endpointMtimeMs === expected.endpointMtimeMs &&
+		(current.hostIncarnation ?? current.processIncarnation) ===
+			(expected.hostIncarnation ?? expected.processIncarnation) &&
 		sameResumeLocator(current, expected.locator.cwd, expected.locator.stateRoot)
 	);
 }
@@ -948,7 +952,7 @@ async function reconcileReadyScope(
 				session.sessionId === id &&
 				resolveEquivalentPath(session.locator.stateRoot) === resolveEquivalentPath(root) &&
 				session.pid === expected.pid &&
-				(session.processIncarnation === undefined || session.processIncarnation === expected.incarnation) &&
+				(session.hostIncarnation ?? session.processIncarnation) === expected.incarnation &&
 				session.lifecycleRequestId === expected.effectMarker,
 		);
 	if (!record) return;
@@ -3973,7 +3977,7 @@ async function currentReadyAuthority(
 					session.sessionId === id &&
 					session.pid === expected.pid &&
 					resolveEquivalentPath(session.locator.stateRoot) === resolveEquivalentPath(root) &&
-					(session.processIncarnation === undefined || session.processIncarnation === expected.incarnation) &&
+					(session.hostIncarnation ?? session.processIncarnation) === expected.incarnation &&
 					session.lifecycleRequestId === expected.effectMarker,
 			);
 		if (
@@ -3982,7 +3986,7 @@ async function currentReadyAuthority(
 			record.terminalUncertain ||
 			record.pid !== expected.pid ||
 			resolveEquivalentPath(record.locator.stateRoot) !== resolveEquivalentPath(root) ||
-			(record.processIncarnation !== undefined && record.processIncarnation !== expected.incarnation) ||
+			(record.hostIncarnation ?? record.processIncarnation) !== expected.incarnation ||
 			!matchesIndexedEndpointFile(endpointFile, record) ||
 			endpoint.pid !== expected.pid ||
 			endpoint.sessionId !== id ||
@@ -4869,6 +4873,10 @@ async function executeLifecycleResponse(
 						"live_session",
 						"Session is already live but its incarnation-bound endpoint is unavailable.",
 					);
+				const finalScope = await validateLiveResumeScope(broker, input, requestedSessionId!, existing);
+				if ("ok" in finalScope) return finalScope;
+				if (!sameResumeSessionIdentity(initialScope, finalScope))
+					return fail("endpoint_stale", "Saved session changed while its resume authority was being verified.");
 				await broker.index.refresh();
 				const finalAuthority = liveResumeAuthority(broker.index.listSessions().sessions, requestedSessionId!);
 				if (finalAuthority.kind === "ambiguous")
@@ -4876,10 +4884,6 @@ async function executeLifecycleResponse(
 				const current = finalAuthority.kind === "live" ? finalAuthority.record : undefined;
 				if (!current || !sameLiveResumeRecord(existing, current))
 					return fail("endpoint_stale", "Live session changed while its resume authority was being verified.");
-				const finalScope = await validateLiveResumeScope(broker, input, requestedSessionId!, current);
-				if ("ok" in finalScope) return finalScope;
-				if (!sameResumeSessionIdentity(initialScope, finalScope))
-					return fail("endpoint_stale", "Saved session changed while its resume authority was being verified.");
 				if (current.endpointMtimeMs === undefined)
 					return fail("endpoint_stale", "Live session endpoint authority is incomplete.");
 				return {

--- a/packages/coding-agent/src/sdk/broker/lifecycle.ts
+++ b/packages/coding-agent/src/sdk/broker/lifecycle.ts
@@ -740,6 +740,7 @@ function lifecycleWorktreeTarget(input: Input): SessionLifecycleWorktreeTarget |
 }
 
 type LiveResumeRecord = {
+	sessionId: string;
 	locator: SessionLocatorV2;
 	endpointGeneration: number;
 	pid: number;
@@ -786,6 +787,18 @@ function sameLiveResumeRecord(expected: LiveResumeRecord, current: LiveResumeRec
 		current.endpointMtimeMs === expected.endpointMtimeMs &&
 		sameResumeLocator(current, expected.locator.cwd, expected.locator.stateRoot)
 	);
+}
+
+function liveResumeAuthority(
+	sessions: readonly LiveResumeRecord[],
+	sessionId: string,
+): { kind: "none" } | { kind: "ambiguous" } | { kind: "live"; record: LiveResumeRecord } {
+	const indexedCandidates = sessions.filter(session => session.sessionId === sessionId);
+	if (indexedCandidates.some(session => !isSessionAuthorityEligible(session))) return { kind: "ambiguous" };
+	const liveCandidates = indexedCandidates.filter(session => session.live);
+	if (liveCandidates.length > 1) return { kind: "ambiguous" };
+	const record = liveCandidates[0];
+	return record ? { kind: "live", record } : { kind: "none" };
 }
 
 type ValidatedTranscript = {
@@ -4834,15 +4847,12 @@ async function executeLifecycleResponse(
 		await broker.index.refresh();
 		if (operation === "session.resume") {
 			const requestedSessionId = sessionId(input);
-			const indexedCandidates = requestedSessionId
-				? broker.index.listSessions().sessions.filter(session => session.sessionId === requestedSessionId)
-				: [];
-			if (indexedCandidates.some(session => !isSessionAuthorityEligible(session)))
+			const authority = requestedSessionId
+				? liveResumeAuthority(broker.index.listSessions().sessions, requestedSessionId)
+				: { kind: "none" as const };
+			if (authority.kind === "ambiguous")
 				return fail("endpoint_stale", "Session authority is ambiguous and cannot be resumed safely.");
-			const existingCandidates = indexedCandidates.filter(session => session.live);
-			if (existingCandidates.length > 1)
-				return fail("endpoint_stale", "Multiple live session owners claim this session id.");
-			const existing = existingCandidates[0];
+			const existing = authority.kind === "live" ? authority.record : undefined;
 			if (existing?.live) {
 				const initialScope = await validateLiveResumeScope(broker, input, requestedSessionId!, existing);
 				if ("ok" in initialScope) return initialScope;
@@ -4860,9 +4870,10 @@ async function executeLifecycleResponse(
 						"Session is already live but its incarnation-bound endpoint is unavailable.",
 					);
 				await broker.index.refresh();
-				const current = broker.index
-					.listSessions()
-					.sessions.find(session => session.sessionId === requestedSessionId);
+				const finalAuthority = liveResumeAuthority(broker.index.listSessions().sessions, requestedSessionId!);
+				if (finalAuthority.kind === "ambiguous")
+					return fail("endpoint_stale", "Session authority became ambiguous while it was being verified.");
+				const current = finalAuthority.kind === "live" ? finalAuthority.record : undefined;
 				if (!current || !sameLiveResumeRecord(existing, current))
 					return fail("endpoint_stale", "Live session changed while its resume authority was being verified.");
 				const finalScope = await validateLiveResumeScope(broker, input, requestedSessionId!, current);

--- a/packages/coding-agent/src/sdk/bus/index.ts
+++ b/packages/coding-agent/src/sdk/bus/index.ts
@@ -4499,12 +4499,14 @@ export function createNotificationsExtension(
 
 	async function startSession(ctx: ExtensionContext): Promise<SessionStartResult> {
 		const id = sessionId(ctx);
-		const lifecycleRequestId = safeLifecycleRequestId(process.env.GJC_LIFECYCLE_REQUEST_ID);
 		const { settings, cfg, settingsAvailable } = resolveSettings(options.settings);
 		const notificationsEnabledForSession = controller.query(ctx).genericSessionEnabled;
 		const sdkEnabledForSession =
 			(options.sdkHostModeSupported ?? true) && shouldHostSdk(settings, isNotificationEligibleContext(ctx));
 		const lifecycleRequired = lifecycleStartupCapability !== undefined;
+		const lifecycleRequestId = lifecycleRequired
+			? safeLifecycleRequestId(lifecycleStartupCapability.lifecycleRequestId)
+			: safeLifecycleRequestId(process.env.GJC_LIFECYCLE_REQUEST_ID);
 		/** The broker-issued readiness intent for this exact lifecycle-managed session. */
 		const lifecycleReadiness = lifecycleStartupCapability?.readiness ?? "immediate";
 		const failLifecycleStartup = (
@@ -7769,6 +7771,8 @@ export function createNotificationsExtension(
 			}
 			const agentDir = lifecycleAgentDir ?? settings?.getAgentDir?.();
 			if (lifecycleRequired && !agentDir) throw new Error("Lifecycle SDK host requires an agent directory.");
+			if (lifecycleRequired && !lifecycleRequestId)
+				throw new Error("Lifecycle SDK host requires a capability-bound request identity.");
 
 			if (agentDir) {
 				try {

--- a/packages/coding-agent/src/sdk/host/session-runtime.test.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.test.ts
@@ -3351,6 +3351,7 @@ describe("SessionSdkSessionRuntime", () => {
 		createSdkSessionRuntimeExtension(api, {
 			agentDir,
 			brokerRegistrationRequired: true,
+			lifecycleRequestId: "broker-required-marker",
 			createTransport: async ({ sessionId, stateRoot, token }) => ({
 				sessionId,
 				stateRoot,

--- a/packages/coding-agent/src/sdk/host/session-runtime.test.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.test.ts
@@ -3281,6 +3281,7 @@ describe("SessionSdkSessionRuntime", () => {
 			},
 		} as any;
 		const sessionId = "broker-recovery";
+		const endpointUrl = "ws://127.0.0.1:1";
 		createSdkSessionRuntimeExtension(api, {
 			agentDir,
 			createTransport: async ({ stateRoot, token }) => ({
@@ -3292,8 +3293,8 @@ describe("SessionSdkSessionRuntime", () => {
 				start: async () => {
 					const endpoint = path.join(stateRoot, "sdk", `${sessionId}.json`);
 					await mkdir(path.dirname(endpoint), { recursive: true });
-					await writeFile(endpoint, JSON.stringify({ sessionId, token, pid: process.pid }));
-					return { url: "ws://127.0.0.1:1" };
+					await writeFile(endpoint, JSON.stringify({ sessionId, token, pid: process.pid, url: endpointUrl }));
+					return { url: endpointUrl };
 				},
 				stop: async () => {},
 			}),

--- a/packages/coding-agent/src/sdk/host/session-runtime.ts
+++ b/packages/coding-agent/src/sdk/host/session-runtime.ts
@@ -472,6 +472,8 @@ export interface CreateSdkSessionRuntimeOptions {
 	agentDir: string;
 	/** Lifecycle-owned sessions require broker publication before they become usable. */
 	brokerRegistrationRequired?: boolean;
+	/** Trusted broker-issued lifecycle marker bound to lifecycle host index events. */
+	lifecycleRequestId?: string;
 	createTransport(input: {
 		sessionId: string;
 		stateRoot: string;
@@ -5043,6 +5045,8 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 		const registerBroker = async (): Promise<void> => {
 			if (brokerRegistered) return;
 			try {
+				if (options.brokerRegistrationRequired && !options.lifecycleRequestId)
+					throw new Error("Lifecycle broker registration requires a request identity.");
 				await ensureBroker({ agentDir: options.agentDir });
 				const index = await new SessionIndex(options.agentDir).open();
 				const locator = await resolveSessionLocator(ctx.cwd, stateRoot);
@@ -5090,11 +5094,18 @@ export function createSdkSessionRuntimeExtension(api: ExtensionAPI, options: Cre
 							pid: process.pid,
 							endpointMtimeMs,
 							endpointFileId,
+							...(options.lifecycleRequestId ? { lifecycleRequestId: options.lifecycleRequestId } : {}),
 							...(masterRole ? { masterRole } : {}),
 						});
 					},
 					unregister: async input => {
-						await index.append({ type: "host_unregistered", ...input, locator, pid: process.pid });
+						await index.append({
+							type: "host_unregistered",
+							...input,
+							locator,
+							pid: process.pid,
+							...(options.lifecycleRequestId ? { lifecycleRequestId: options.lifecycleRequestId } : {}),
+						});
 					},
 				});
 				brokerRegistered = true;

--- a/packages/coding-agent/src/sdk/lifecycle-session.ts
+++ b/packages/coding-agent/src/sdk/lifecycle-session.ts
@@ -55,6 +55,8 @@ export type CreateLifecycleAgentSessionOptions = Omit<CreateAgentSessionOptions,
 	 * a prepared signal instead of readiness until it is explicitly activated.
 	 */
 	readiness?: "immediate" | "deferred";
+	/** Broker-issued lifecycle request identity published with host registration. */
+	lifecycleRequestId?: string;
 };
 
 /** Internal lifecycle-only session construction with an owner-bound SDK startup result. */
@@ -62,9 +64,15 @@ export async function createLifecycleAgentSession(
 	options: CreateLifecycleAgentSessionOptions = {},
 ): Promise<CreateLifecycleAgentSessionResult> {
 	const rollback = new SdkStartupRollbackTracker();
-	const capability = new SdkStartupCapability(rollback, options.readiness ?? "immediate");
+	const capability = new SdkStartupCapability(rollback, options.readiness ?? "immediate", options.lifecycleRequestId);
 	try {
-		const { modelId, mcpStartupTimeoutMs, readiness: _readiness, ...sessionOptions } = options;
+		const {
+			modelId,
+			mcpStartupTimeoutMs,
+			readiness: _readiness,
+			lifecycleRequestId: _lifecycleRequestId,
+			...sessionOptions
+		} = options;
 		const internalOptions = {
 			...sessionOptions,
 			// Explicit model pin (#4707): resolve through the staged selector

--- a/packages/coding-agent/src/sdk/session.ts
+++ b/packages/coding-agent/src/sdk/session.ts
@@ -3330,6 +3330,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						createSdkSessionRuntimeExtension(api, {
 							agentDir,
 							brokerRegistrationRequired: lifecycleStartupCapability !== undefined,
+							...(lifecycleStartupCapability?.lifecycleRequestId
+								? { lifecycleRequestId: lifecycleStartupCapability.lifecycleRequestId }
+								: {}),
 							createTransport: input => createSdkWebSocketTransport(input),
 							settings,
 							configOverrides: new Map(),

--- a/packages/coding-agent/src/sdk/startup-capability.ts
+++ b/packages/coding-agent/src/sdk/startup-capability.ts
@@ -190,6 +190,7 @@ export class SdkStartupCapability {
 	constructor(
 		readonly rollback?: SdkStartupRollbackTracker,
 		readonly readiness: "immediate" | "deferred" = "immediate",
+		readonly lifecycleRequestId?: string,
 	) {}
 
 	normalizeFailure(phase: SdkStartupPhase, reason: SdkStartupReason, error?: unknown): SdkStartupFailure {

--- a/packages/coding-agent/test/notifications-config.test.ts
+++ b/packages/coding-agent/test/notifications-config.test.ts
@@ -1987,7 +1987,7 @@ describe("notifications config", () => {
 			let notify: { handler(args: string, ctx: ExtensionCommandContext): Promise<void> | void } | undefined;
 			let providerReady = false;
 			const rollback = new SdkStartupRollbackTracker();
-			const capability = new SdkStartupCapability(rollback);
+			const capability = new SdkStartupCapability(rollback, "immediate", "notifications-config-marker");
 			const api = {
 				on(event: string, handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void) {
 					handlers.set(event, handler);

--- a/packages/coding-agent/test/sdk-broker-host-integration.test.ts
+++ b/packages/coding-agent/test/sdk-broker-host-integration.test.ts
@@ -172,6 +172,7 @@ test("SDK-only runtime registers its broker endpoint and retracts it on shutdown
 	const agentDir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-sdk-only-broker-"));
 	const cwd = path.join(agentDir, "workspace");
 	const sessionId = "sdk-only-live";
+	const lifecycleRequestId = "sdk-only-live-marker";
 	const broker = new Broker({ agentDir });
 	await broker.start();
 	const handlers = new Map<string, (event: unknown, ctx: ExtensionContext) => void | Promise<void>>();
@@ -182,6 +183,8 @@ test("SDK-only runtime registers its broker endpoint and retracts it on shutdown
 	} as unknown as ExtensionAPI;
 	createSdkSessionRuntimeExtension(api, {
 		agentDir,
+		brokerRegistrationRequired: true,
+		lifecycleRequestId,
 		createTransport: input => createSdkWebSocketTransport(input),
 	});
 	const pendingGateIds = new Set(["gate-answer", "gate-approve", "gate-drain"]);
@@ -218,6 +221,10 @@ test("SDK-only runtime registers its broker endpoint and retracts it on shutdown
 		const start = handlers.get("session_start");
 		if (!start) throw new Error("SDK-only session_start handler was not registered.");
 		await start({}, context);
+		await broker.index.refresh();
+		expect(broker.index.listSessions().sessions.find(session => session.sessionId === sessionId)).toMatchObject({
+			lifecycleRequestId,
+		});
 		expect(await broker.handleRequest("session.get_endpoint", { sessionId, endpointGeneration: 1 })).toMatchObject({
 			ok: true,
 			result: { sessionId, pid: process.pid, url: expect.stringMatching(/^ws:\/\/127\.0\.0\.1:/) },
@@ -315,6 +322,7 @@ test("SDK-only runtime rejects an endpoint substituted before broker registratio
 	createSdkSessionRuntimeExtension(api, {
 		agentDir,
 		brokerRegistrationRequired: true,
+		lifecycleRequestId: "sdk-registration-authority-marker",
 		createTransport: async input => {
 			const transport = await createSdkWebSocketTransport(input);
 			const realStart = transport.start.bind(transport);

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -3201,6 +3201,50 @@ test("broker fences ambiguous state roots from checkpoint, endpoint, and resume 
 				endpoint: { token: "current-token" },
 			},
 		});
+
+		const originalHandleRequest = broker.handleRequest.bind(broker);
+		let racingOwner: Awaited<ReturnType<typeof broker.index.append>> | undefined;
+		broker.handleRequest = async (operation, input, idempotencyKey) => {
+			const response = await originalHandleRequest(operation, input, idempotencyKey);
+			if (operation === "session.get_endpoint" && input.sessionId === sessionId && racingOwner === undefined) {
+				racingOwner = await broker.index.append({
+					type: "host_registered",
+					sessionId,
+					locator: { cwd: root, worktreeRoot: null, stateRoot: alternateStateRoot },
+					endpointGeneration: alternate.endpointGeneration,
+					pid: process.pid,
+					endpointMtimeMs: 1,
+				});
+			}
+			return response;
+		};
+		expect(
+			await broker.handleRequest(
+				"session.resume",
+				{ cwd: root, stateRoot, sessionId, sessionPath },
+				"racing-owner-resume",
+			),
+		).toEqual({
+			ok: false,
+			error: {
+				code: "endpoint_stale",
+				message: "Session authority became ambiguous while it was being verified.",
+			},
+		});
+		broker.handleRequest = originalHandleRequest;
+		if (!racingOwner) throw new Error("Expected the competing live owner to be registered.");
+		await broker.index.append({
+			type: "host_unregistered",
+			sessionId,
+			locator: racingOwner.locator,
+			endpointGeneration: racingOwner.endpointGeneration,
+			pid: racingOwner.pid,
+			...(racingOwner.processIncarnation === undefined
+				? {}
+				: { processIncarnation: racingOwner.processIncarnation }),
+			...(racingOwner.hostIncarnation === undefined ? {} : { hostIncarnation: racingOwner.hostIncarnation }),
+		});
+
 		const replayAlternate = await broker.index.append({
 			type: "host_registered",
 			sessionId,

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -3716,6 +3716,51 @@ test("broker atomically reuses the indexed live owner for distinct resume keys",
 		await fs.rm(root, { recursive: true, force: true });
 	}
 });
+test("session.create rejects a forged effective host incarnation during readiness", async () => {
+	const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-forged-host-incarnation-"));
+	const workspace = path.join(root, "workspace");
+	const agentDir = path.join(root, "agent");
+	const stateRoot = path.join(workspace, ".gjc", "state");
+	const broker = new Broker({ agentDir });
+	try {
+		await fs.mkdir(workspace, { recursive: true });
+		await broker.start();
+		const index = await new SessionIndex(agentDir).open();
+		const forgeOwner = (async () => {
+			const row = await waitFor(async () => {
+				await index.refresh();
+				return index
+					.listSessionIdentities()
+					.find(session => session.endpointGeneration > 0 && session.lifecycleRequestId !== undefined);
+			}, "lifecycle host registration");
+			const actualIncarnation = row.hostIncarnation ?? row.processIncarnation;
+			if (!actualIncarnation) throw new Error("Expected lifecycle host incarnation.");
+			const forgedIncarnation = `${actualIncarnation}:forged`;
+			await index.append({
+				type: "host_registered",
+				sessionId: row.sessionId,
+				locator: row.locator,
+				endpointGeneration: row.endpointGeneration,
+				pid: row.pid,
+				endpointMtimeMs: row.endpointMtimeMs,
+				...(row.endpointFileId === undefined ? {} : { endpointFileId: row.endpointFileId }),
+				lifecycleRequestId: row.lifecycleRequestId,
+				processIncarnation: actualIncarnation,
+				hostIncarnation: forgedIncarnation,
+			});
+		})();
+		const response = await broker.handleRequest(
+			"session.create",
+			{ cwd: workspace, stateRoot, readinessTimeoutMs: 7_000 },
+			"forged-host-incarnation",
+		);
+		await forgeOwner;
+		expect(response).toMatchObject({ ok: false, error: { code: "terminal_uncertain" } });
+	} finally {
+		await broker.stop();
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}, 20_000);
 test("broker never signals a PID reused after its lifecycle marker was written", async () => {
 	const agentDir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "gjc-broker-reused-"));
 	const stateRoot = path.join(agentDir, "state");

--- a/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
+++ b/packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts
@@ -31,7 +31,7 @@ import {
 } from "../src/sdk/broker/lifecycle";
 import { parseLifecycleJson } from "../src/sdk/broker/lifecycle-codec";
 import { LifecycleLedger } from "../src/sdk/broker/lifecycle-ledger";
-import { SessionIndex } from "../src/sdk/broker/session-index";
+import { SessionIndex, type SessionIndexEvent } from "../src/sdk/broker/session-index";
 import { runSdkSessionCli } from "../src/sdk/cli";
 import { SdkClient } from "../src/sdk/client";
 import { readSdkBrokerDiscovery } from "../src/sdk/client/discovery";
@@ -3203,7 +3203,7 @@ test("broker fences ambiguous state roots from checkpoint, endpoint, and resume 
 		});
 
 		const originalHandleRequest = broker.handleRequest.bind(broker);
-		let racingOwner: Awaited<ReturnType<typeof broker.index.append>> | undefined;
+		let racingOwner: SessionIndexEvent | undefined;
 		broker.handleRequest = async (operation, input, idempotencyKey) => {
 			const response = await originalHandleRequest(operation, input, idempotencyKey);
 			if (operation === "session.get_endpoint" && input.sessionId === sessionId && racingOwner === undefined) {

--- a/packages/coding-agent/test/sdk-endpoint-authority.test.ts
+++ b/packages/coding-agent/test/sdk-endpoint-authority.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { matchesIndexedEndpointFile } from "../src/sdk/broker/endpoint-authority";
+
+describe("SDK endpoint index authority", () => {
+	test("accepts the index timestamp precision used by broker endpoint reads", () => {
+		const file = { dev: 7n, ino: 11n, mtimeMs: 1_000.123_456 };
+
+		expect(
+			matchesIndexedEndpointFile(file, {
+				endpointMtimeMs: 1_000.123,
+				endpointFileId: "7:11",
+			}),
+		).toBe(true);
+	});
+
+	test("rejects a changed endpoint file identity or material timestamp drift", () => {
+		const file = { dev: 7n, ino: 11n, mtimeMs: 1_000.123_456 };
+
+		expect(matchesIndexedEndpointFile(file, { endpointMtimeMs: file.mtimeMs, endpointFileId: "7:12" })).toBe(false);
+		expect(matchesIndexedEndpointFile(file, { endpointMtimeMs: file.mtimeMs + 0.002, endpointFileId: "7:11" })).toBe(
+			false,
+		);
+	});
+});

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -712,9 +712,12 @@ test("a blocked Telegram ownership race preserves the canonical endpoint and wit
 	);
 	const previousLifecycleRequestId = process.env.GJC_LIFECYCLE_REQUEST_ID;
 	process.env.GJC_LIFECYCLE_REQUEST_ID = "ambient-marker-must-not-win";
-	await handlers.get("session_start")!({ type: "session_start" }, sessionContext);
-	if (previousLifecycleRequestId === undefined) delete process.env.GJC_LIFECYCLE_REQUEST_ID;
-	else process.env.GJC_LIFECYCLE_REQUEST_ID = previousLifecycleRequestId;
+	try {
+		await handlers.get("session_start")!({ type: "session_start" }, sessionContext);
+	} finally {
+		if (previousLifecycleRequestId === undefined) delete process.env.GJC_LIFECYCLE_REQUEST_ID;
+		else process.env.GJC_LIFECYCLE_REQUEST_ID = previousLifecycleRequestId;
+	}
 	await expect(capability.promise).resolves.toEqual({ status: "started" });
 	const defaultEndpoint = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
 	const chatStateRoot = path.join(cwd, ".gjc", "state", "chat");

--- a/packages/coding-agent/test/sdk-host-wiring.test.ts
+++ b/packages/coding-agent/test/sdk-host-wiring.test.ts
@@ -539,7 +539,7 @@ test("lifecycle teardown swallows dual owner failures without surfacing an exten
 	dirs.push(cwd);
 	const sessionId = `cleanup-proof-${Date.now()}`;
 	const tracker = new SdkStartupRollbackTracker();
-	const capability = new SdkStartupCapability(tracker);
+	const capability = new SdkStartupCapability(tracker, "immediate", "cleanup-proof-marker");
 	const stop = spyOn(SessionSdkHost.prototype, "stop").mockRejectedValueOnce(new Error("host stop failed"));
 	const nativeStop = (NotificationServer.prototype as unknown as { stopAndWait: () => Promise<void> }).stopAndWait;
 	(NotificationServer.prototype as unknown as { stopAndWait: () => Promise<void> }).stopAndWait = async () => {
@@ -622,7 +622,7 @@ test("lifecycle cleanup fences same-id startup and preserves proven owner releas
 	dirs.push(cwd);
 	const sessionId = `cleanup-retry-${Date.now()}`;
 	const tracker = new SdkStartupRollbackTracker();
-	const capability = new SdkStartupCapability(tracker);
+	const capability = new SdkStartupCapability(tracker, "immediate", "cleanup-retry-marker");
 	const hostStop = spyOn(SessionSdkHost.prototype, "stop");
 	const serverStart = spyOn(NotificationServer.prototype, "start");
 	const nativeStop = (NotificationServer.prototype as unknown as { stopAndWait: () => Promise<void> }).stopAndWait;
@@ -695,7 +695,8 @@ test("a blocked Telegram ownership race preserves the canonical endpoint and wit
 			return typeof value === "function" ? value.bind(target) : value;
 		},
 	}) as Settings;
-	const capability = new SdkStartupCapability(new SdkStartupRollbackTracker());
+	const lifecycleRequestId = "telegram-sibling-capability-marker";
+	const capability = new SdkStartupCapability(new SdkStartupRollbackTracker(), "immediate", lifecycleRequestId);
 	const sessionContext = context(cwd, sessionId);
 	const handlers = start(
 		sessionContext,
@@ -709,7 +710,11 @@ test("a blocked Telegram ownership race preserves the canonical endpoint and wit
 		undefined,
 		async () => "attached",
 	);
+	const previousLifecycleRequestId = process.env.GJC_LIFECYCLE_REQUEST_ID;
+	process.env.GJC_LIFECYCLE_REQUEST_ID = "ambient-marker-must-not-win";
 	await handlers.get("session_start")!({ type: "session_start" }, sessionContext);
+	if (previousLifecycleRequestId === undefined) delete process.env.GJC_LIFECYCLE_REQUEST_ID;
+	else process.env.GJC_LIFECYCLE_REQUEST_ID = previousLifecycleRequestId;
 	await expect(capability.promise).resolves.toEqual({ status: "started" });
 	const defaultEndpoint = path.join(cwd, ".gjc", "state", "sdk", `${sessionId}.json`);
 	const chatStateRoot = path.join(cwd, ".gjc", "state", "chat");
@@ -727,9 +732,16 @@ test("a blocked Telegram ownership race preserves the canonical endpoint and wit
 			sessionId,
 			locator: { cwd: path.resolve(cwd), worktreeRoot: null, stateRoot },
 			endpointMtimeMs: fs.statSync(defaultEndpoint).mtimeMs,
+			lifecycleRequestId,
 		}),
 	);
 	await handlers.get("session_shutdown")!({ type: "session_shutdown" }, sessionContext);
+	const stoppedIndex = await new SessionIndex(agentDir).open();
+	await stoppedIndex.refresh();
+	expect(stoppedIndex.listSessions().sessions.find(session => session.sessionId === sessionId)).toMatchObject({
+		lifecycleRequestId,
+		terminal: true,
+	});
 }, 60_000);
 
 test("production SDK host starts exactly one instrumented server (no duplicate auto-host)", async () => {
@@ -758,7 +770,7 @@ test("lifecycle session shutdown disposes the exact endpoint once", async () => 
 	dirs.push(cwd);
 	const sessionId = `cleanup-once-${Date.now()}`;
 	const tracker = new SdkStartupRollbackTracker();
-	const capability = new SdkStartupCapability(tracker);
+	const capability = new SdkStartupCapability(tracker, "immediate", "cleanup-once-marker");
 	const stop = spyOn(SessionSdkHost.prototype, "stop");
 	try {
 		const sessionContext = context(cwd, sessionId);
@@ -801,7 +813,7 @@ test("lifecycle startup settles failure when native callback registration throws
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-prestart-failure-"));
 	dirs.push(cwd);
 	const sessionId = "prestart-failure";
-	const capability = new SdkStartupCapability();
+	const capability = new SdkStartupCapability(undefined, "immediate", "prestart-failure-marker");
 	const hook = spyOn(NotificationServer.prototype, "onSdkFrame").mockImplementation(() => {
 		throw new Error("token=prestart-secret");
 	});
@@ -908,7 +920,7 @@ test("session_start swallows startup plus owner-release failure without surfacin
 test("lifecycle startup reports an actionable error when native capability registration is missing", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-missing-capability-callback-"));
 	dirs.push(cwd);
-	const capability = new SdkStartupCapability();
+	const capability = new SdkStartupCapability(undefined, "immediate", "missing-capability-marker");
 	const prototype = NotificationServer.prototype as unknown as { onNegotiatedCapabilities?: unknown };
 	const original = prototype.onNegotiatedCapabilities;
 	try {
@@ -935,7 +947,7 @@ test("lifecycle startup reports an actionable error when native capability regis
 test("lifecycle startup settles native capability incompatibility before constructing the host", async () => {
 	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "gjc-sdk-native-incompatible-"));
 	dirs.push(cwd);
-	const capability = new SdkStartupCapability();
+	const capability = new SdkStartupCapability(undefined, "immediate", "native-incompatible-marker");
 	const original = (NotificationServer.prototype as unknown as { retireIfUnclaimed?: unknown }).retireIfUnclaimed;
 	try {
 		(NotificationServer.prototype as unknown as { retireIfUnclaimed?: unknown }).retireIfUnclaimed = undefined;
@@ -4330,7 +4342,7 @@ for (const eventType of ["session_switch", "session_branch"] as const) {
 		// throws the retained-retry AggregateError.
 		const stop = spyOn(SessionSdkHost.prototype, "stop").mockRejectedValueOnce(new Error("host stop failed"));
 		try {
-			const startupCapability = new SdkStartupCapability();
+			const startupCapability = new SdkStartupCapability(undefined, "immediate", "rotation-failure-marker");
 			const handlers = start(ctx, undefined, () => {}, false, new Map(), {
 				startupCapability,
 				lifecycleRequired: true,

--- a/packages/coding-agent/test/sdk-operation-matrix.test.ts
+++ b/packages/coding-agent/test/sdk-operation-matrix.test.ts
@@ -141,7 +141,7 @@ describe("SDK operation matrix", () => {
 		const registryById = new Map(OPERATIONS.map(operation => [operation.id, operation]));
 		const inventoryIds = registryInventory.map(row => row.sourceId.replace("registry:", ""));
 		expect(new Set(inventoryIds)).toEqual(new Set(registryById.keys()));
-		expect(registryInventory).toHaveLength(97);
+		expect(registryInventory).toHaveLength(OPERATIONS.length);
 
 		for (const row of registryInventory) {
 			const id = row.sourceId.startsWith("registry:") ? row.sourceId.slice("registry:".length) : row.sourceId;


### PR DESCRIPTION
## Summary
- bind lifecycle readiness and scope reconciliation to endpoint file identity, state root, process incarnation, and lifecycle marker
- tolerate the index timestamp precision already accepted by broker endpoint reads
- repair local SDK-only recovery fixture publication and derive generated operation-matrix cardinality from the registry

## Regression evidence
Exact `dev@59a856f63f1ac717c78190c6b14f39bd23d0b6e3` reproduced #5114 before the patch:
- default source host startup failed
- shipped SDK lifecycle topology failed (3 cases)
- shared-agent source isolation failed
- cold resume/fork cleanup failed
- local SDK-only broker recovery failed
- generated operation matrix expected 97 but contained 98 rows

## Verification
- `bun test packages/coding-agent/test/sdk-endpoint-authority.test.ts packages/coding-agent/test/sdk-broker-source-isolation.test.ts packages/coding-agent/test/sdk-broker-lifecycle-cleanup.test.ts packages/coding-agent/test/sdk-broker-lifecycle-e2e.test.ts packages/coding-agent/test/sdk-broker-host-integration.test.ts packages/coding-agent/src/sdk/host/session-runtime.test.ts packages/coding-agent/test/sdk-operation-matrix.test.ts` (239 pass)
- `bun test packages/coding-agent/test/sdk-machine-lifecycle-topology.test.ts` (7 pass)
- `bun --cwd=packages/coding-agent run check`
- `bun run check:tools`

Closes #5114

gajae.pr-review-verdict.v1 merge-approved sha256:67320daa275c1a2a2e62b06541859b8660a0ee99f39bc70995bcd253546d9fad reviewer:human reviewer-id:probepark evidence:exact-head-252f46fa-endpoint-followup-is-type-only
