### PR TITLE
fix(ai): avoid Bun 1.4.0 Windows Codex WebSocket crash

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- OpenAI Codex WebSockets are now opt-in on Windows. Bun 1.4.0 can segfault in its Windows TLS WebSocket handshake, so the automatic model preference uses SSE on Windows while the explicit WebSocket setting remains available for operators who have a newer safe runtime.
 - MCP dispatcher tools now preserve dynamic nested `args` and `params` objects when a server declares them as propertyless JSON Schema objects. `normalizeSchemaForMCP` makes the implicit open-map semantics explicit with `additionalProperties: true` without loosening objects that declare properties or an explicit closure, so provider tool schemas no longer collapse valid nested arguments to `{}`.
 - Schema normalization now copies `default`, `const`, `enum`, and `examples` payloads verbatim. These keywords carry instance data, not subschemas, so the previous recursive walk rewrote user payloads as if they were schemas (a `default` of `{"type":"object","nullable":true}` lost `nullable`, and literal `anyOf`/`const` branches collapsed into `enum`).
 - Schema copies now write property names as own data properties. A `JSON.parse`d tool schema carries `__proto__` as an ordinary key, and plain assignment routed it to `Object.prototype`'s `__proto__` setter, dropping that valid property from the normalized schema.

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -2307,6 +2307,15 @@ function recordCodexWebSocketFailure(state: CodexWebSocketSessionState, activate
 	}
 }
 
+/**
+ * Bun 1.4.0's Windows WebSocket client can segfault during TLS handshakes.
+ * Keep the model's websocket preference available on other platforms, while
+ * requiring an explicit opt-in on Windows until the bundled runtime is fixed.
+ */
+export function isCodexWebSocketSafeByDefault(platform: NodeJS.Platform = process.platform): boolean {
+	return platform !== "win32";
+}
+
 function shouldUseCodexWebSocket(
 	model: Model<"openai-codex-responses">,
 	state: CodexWebSocketSessionState | undefined,
@@ -2314,7 +2323,11 @@ function shouldUseCodexWebSocket(
 ): boolean {
 	if (!state || state.disableWebsocket) return false;
 	if (preferWebsockets === false) return false;
-	return isCodexWebSocketEnvEnabled() || preferWebsockets === true || model.preferWebsockets === true;
+	return (
+		isCodexWebSocketEnvEnabled() ||
+		preferWebsockets === true ||
+		(isCodexWebSocketSafeByDefault() && model.preferWebsockets === true)
+	);
 }
 
 export interface OpenAICodexTransportDetails {
@@ -2372,7 +2385,9 @@ export function getOpenAICodexTransportDetails(
 	const websocketPreferred =
 		options?.preferWebsockets === false
 			? false
-			: isCodexWebSocketEnvEnabled() || options?.preferWebsockets === true || model.preferWebsockets === true;
+			: isCodexWebSocketEnvEnabled() ||
+				options?.preferWebsockets === true ||
+				(isCodexWebSocketSafeByDefault() && model.preferWebsockets === true);
 	const state = getCodexWebSocketStateForPublicSession(model, options);
 
 	return {

--- a/packages/ai/test/openai-codex.test.ts
+++ b/packages/ai/test/openai-codex.test.ts
@@ -6,6 +6,7 @@ import {
 	codexToolWireName,
 	convertOpenAICodexResponsesTools,
 	formatCodexUserAgent,
+	isCodexWebSocketSafeByDefault,
 	normalizeCodexToolChoice,
 } from "@gajae-code/ai/providers/openai-codex-responses";
 import type { Tool } from "@gajae-code/ai/types";
@@ -26,6 +27,17 @@ describe("openai-codex user agent", () => {
 		const userAgent = formatCodexUserAgent("linux\n", "6.8.0\t-generic", "arm64\r");
 
 		expect(userAgent).toMatch(/^pi\/[^ ]+ \(linux 6\.8\.0-generic; arm64\)$/);
+	});
+});
+
+describe("openai-codex websocket platform policy", () => {
+	it("requires explicit opt-in on Windows", () => {
+		expect(isCodexWebSocketSafeByDefault("win32")).toBe(false);
+	});
+
+	it("keeps model websocket defaults enabled off Windows", () => {
+		expect(isCodexWebSocketSafeByDefault("linux")).toBe(true);
+		expect(isCodexWebSocketSafeByDefault("darwin")).toBe(true);
 	});
 });
 


### PR DESCRIPTION
The reported Bun crash trace terminates in Bun 1.4.0 Windows TLS WebSocket handshake code. SSE is the smallest maintained safe automatic transport; explicit WebSocket opt-in remains. Rebased onto successor dev 1ee8c19a20dcbf51d74144a5f5bf95f086c7a81e.

## Risk classification
- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

## Validation
- focused Codex transport tests: 100 passed
- resume/orchestration tests: 26 passed
- AI package check passed
- native build completed

Fixes #5103

gajae.pr-review-verdict.v1 merge-self-approved sha256:ecac0077327f4dd78efbca68a7293076e82587c58c2fec5d1e5c7c1efdeb8c6b reviewer:human reviewer-id:Yeachan-Heo evidence:Signed exact-head owner self-review; Windows WebSocket TLS handshake is disabled by default under bundled Bun 1.4.0 and focused transport/resume validation passed on the maintained branch.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*  