### PR TITLE
fix(sdk): fall back when tmux spawn allocation fails

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/tmux-owner-isolation.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-owner-isolation.ts
@@ -249,7 +249,7 @@ export type TmuxOwnerIsolationExecutionResult = TmuxOwnerIsolationExecutionSucce
 /** Synchronous spawn boundary; callers pass argv and scoped stdin unchanged. */
 export interface TmuxOwnerIsolationExecutionDependencies {
 	socketKey: string;
-	spawn(argv: string[], stdinLine?: string): { exitCode: number | null; stdout?: string };
+	spawn(argv: string[], stdinLine?: string): { exitCode: number | null; stdout?: string; stderr?: string };
 	probeServer(socketKey: string): TmuxServerProof;
 	/** Reads the published owner generation immediately around direct execution. */
 	isCurrentGeneration?(): boolean;
@@ -493,7 +493,7 @@ export function executeTmuxOwnerIsolationPlanSync(
 			return {
 				ok: false,
 				code: "scope_bootstrap_failed",
-				diagnostic: "planned_spawn_failed",
+				diagnostic: safeDiagnostic(`planned_spawn_failed${result.stderr?.trim() ? `: ${result.stderr}` : ""}`),
 			};
 		if (execution.mode === "scoped" && !isExactScopedBootstrapSuccessReceipt(result.stdout ?? ""))
 			return {

--- a/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-sessions.ts
@@ -851,7 +851,7 @@ export function createGjcTmuxSession(
 							env: executionEnv,
 						})
 					: Bun.spawnSync(argv, { stdout: "pipe", stderr: "pipe", env: executionEnv });
-				return { exitCode: result.exitCode, stdout: result.stdout.toString() };
+				return { exitCode: result.exitCode, stdout: result.stdout.toString(), stderr: result.stderr.toString() };
 			} finally {
 				assertGjcTmuxStagedMutationAuthoritySync(authority);
 			}

--- a/packages/coding-agent/src/sdk/broker/broker.ts
+++ b/packages/coding-agent/src/sdk/broker/broker.ts
@@ -64,6 +64,7 @@ import {
 	type SpawnAuthorityV1,
 	type SpawnClaimDecision,
 	type SpawnClaimV2,
+	type SpawnSubstrateFailure,
 	type SpawnSubstrateProof,
 	type SpawnSubstrateProvider,
 } from "./spawn-authority";
@@ -224,7 +225,7 @@ export type BrokerResponse =
 			error: {
 				code: BrokerErrorCode;
 				message: string;
-				details?: ModelProfileErrorDetails;
+				details?: ModelProfileErrorDetails | SpawnSubstrateFailure;
 				endpoint?: "unavailable";
 				cleanup?: BrokerCleanupEvidence;
 			};
@@ -233,6 +234,14 @@ export type BrokerResponse =
 			startupFailure?: LifecycleStartupFailureReceipt;
 	  };
 const error = (code: BrokerErrorCode, message: string): BrokerResponse => ({ ok: false, error: { code, message } });
+const spawnFailureError = (failure: SpawnSubstrateFailure): BrokerResponse => ({
+	ok: false,
+	error: {
+		code: "spawn_failed",
+		message: `session.spawn substrate could not be safely established: ${failure.message}`,
+		details: failure,
+	},
+});
 
 function isCleanupPending(response: BrokerResponse): boolean {
 	if (response.ok) return false;
@@ -1496,7 +1505,9 @@ export class Broker {
 	#spawnTerminalResponse(claim: SpawnClaimV2): BrokerResponse {
 		if (claim.state === "accepted") return { ok: true, result: this.#spawnResult("spawn_replayed", claim) };
 		if (claim.state === "pre_send_rejected")
-			return error("spawn_failed", "session.spawn was rejected before seed handoff");
+			return claim.failure
+				? spawnFailureError(claim.failure)
+				: error("spawn_failed", "session.spawn was rejected before seed handoff");
 		return error("resource_gone", "session.spawn claim is closed");
 	}
 
@@ -1553,14 +1564,20 @@ export class Broker {
 				});
 				if (launched.ok) launchedProof = launched.proof;
 				if (!launched.ok) {
+					const failure: SpawnSubstrateFailure = {
+						substrateKind: launched.code === "substrate_unavailable" ? "headless" : "tmux",
+						code: launched.code,
+						message: launched.message,
+					};
 					current = (
 						await store.persistTransition(lifecycleIdentity, {
 							claimId: current.claimId,
 							from: "substrate_starting",
 							to: "pre_send_rejected",
+							failure,
 						})
 					).claim;
-					return error("spawn_failed", "session.spawn substrate could not be safely established");
+					return spawnFailureError(failure);
 				}
 				const registration = await this.#spawnPromptLayer.awaitRegistration({
 					childId: prep.childId,

--- a/packages/coding-agent/src/sdk/broker/spawn-authority.ts
+++ b/packages/coding-agent/src/sdk/broker/spawn-authority.ts
@@ -20,12 +20,19 @@ export type SpawnClaimV2 = {
 		| "pre_send_rejected"
 		| "uncertain"
 		| "closed";
+	failure?: SpawnSubstrateFailure;
 	preSendLease?: { epoch: string; status: "owned" | "consumed" };
 	childId?: string;
 	seed?: SeedDeliveryV2;
 	authorityRef?: string;
 	createdAt: number;
 	updatedAt: number;
+};
+
+export type SpawnSubstrateFailure = {
+	substrateKind: "tmux" | "psmux" | "headless";
+	code: string;
+	message: string;
 };
 
 export type SeedDeliveryV2 = {
@@ -134,6 +141,7 @@ export type SpawnClaimTransition = {
 	childId?: string;
 	/** Required for seed and terminal state transitions that carry Q26 facts. */
 	seed?: SeedDeliveryV2;
+	failure?: SpawnSubstrateFailure;
 	/** Required when exact substrate authority becomes active or closes. */
 	authority?: SpawnAuthorityV1;
 	/** Required to downgrade dispatching only when no frame was handed off. */
@@ -214,6 +222,7 @@ const CLAIM_KEYS = new Set([
 	"requestBindingMac",
 	"bindingMac",
 	"state",
+	"failure",
 	"preSendLease",
 	"childId",
 	"seed",
@@ -432,6 +441,18 @@ function hasClaimStateShape(claim: SpawnClaimV2): boolean {
 	}
 }
 
+function isSpawnSubstrateFailure(value: unknown): value is SpawnSubstrateFailure {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const failure = value as Record<string, unknown>;
+	return (
+		Object.keys(failure).every(key => key === "substrateKind" || key === "code" || key === "message") &&
+		SUBSTRATE_KINDS.has(failure.substrateKind as SpawnSubstrateProof["substrateKind"]) &&
+		isOpaque(failure.code) &&
+		isOpaque(failure.message) &&
+		failure.message.length <= 2048
+	);
+}
+
 export function isSpawnClaimV2(value: unknown): value is SpawnClaimV2 {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
 	const claim = value as Record<string, unknown>;
@@ -457,6 +478,7 @@ export function isSpawnClaimV2(value: unknown): value is SpawnClaimV2 {
 		(claim.childId === undefined || isOpaque(claim.childId)) &&
 		(claim.seed === undefined || isSeed(claim.seed)) &&
 		(claim.authorityRef === undefined || isOpaque(claim.authorityRef)) &&
+		(claim.failure === undefined || isSpawnSubstrateFailure(claim.failure)) &&
 		isTimestamp(claim.createdAt) &&
 		isTimestamp(claim.updatedAt) &&
 		claim.updatedAt >= claim.createdAt;
@@ -672,7 +694,12 @@ export class SpawnAuthorityStore {
 			let next: SpawnClaimV2;
 			switch (transition.to) {
 				case "substrate_starting": {
-					if (!isOpaque(transition.childId) || transition.seed !== undefined || transition.authority !== undefined)
+					if (
+						!isOpaque(transition.childId) ||
+						transition.seed !== undefined ||
+						transition.authority !== undefined ||
+						transition.failure !== undefined
+					)
 						throw new SpawnAuthorityTransitionError("invalid_transition");
 					next = { ...current, state: "substrate_starting", childId: transition.childId };
 					break;
@@ -752,7 +779,11 @@ export class SpawnAuthorityStore {
 				case "pre_send_rejected": {
 					if (current.state === "dispatching" && transition.provenNoHandoff !== true)
 						throw new SpawnAuthorityTransitionError("invalid_transition");
-					if (transition.childId !== undefined || transition.authority !== undefined)
+					if (
+						transition.childId !== undefined ||
+						transition.authority !== undefined ||
+						(transition.failure !== undefined && !isSpawnSubstrateFailure(transition.failure))
+					)
 						throw new SpawnAuthorityTransitionError("invalid_transition");
 					if (current.seed) {
 						if (
@@ -761,10 +792,14 @@ export class SpawnAuthorityStore {
 							!sameSeedIdentity(current.seed, transition.seed)
 						)
 							throw new SpawnAuthorityTransitionError("invalid_transition");
-						next = { ...current, state: "pre_send_rejected", seed: transition.seed };
+						next = { ...current, state: "pre_send_rejected", seed: transition.seed, failure: transition.failure };
 					} else {
 						if (transition.seed !== undefined) throw new SpawnAuthorityTransitionError("invalid_transition");
-						next = { ...current, state: "pre_send_rejected" };
+						next = {
+							...current,
+							state: "pre_send_rejected",
+							...(transition.failure === undefined ? {} : { failure: transition.failure }),
+						};
 					}
 					break;
 				}

--- a/packages/coding-agent/src/sdk/broker/spawn-substrate.ts
+++ b/packages/coding-agent/src/sdk/broker/spawn-substrate.ts
@@ -60,6 +60,8 @@ type HeadlessState = {
 	createdAt: number;
 };
 
+const MAX_SUBSTRATE_DIAGNOSTIC_LENGTH = 512;
+
 const HEADLESS_STATE_KEYS = new Set([
 	"version",
 	"pid",
@@ -77,6 +79,15 @@ function messageFor(code: "substrate_unavailable" | "substrate_proof_failed"): s
 	return code === "substrate_unavailable"
 		? "No safe spawn substrate is available."
 		: "The selected spawn substrate could not be proven exactly.";
+}
+
+function launchFailureMessage(selected: "tmux" | "psmux" | "headless", error: unknown): string {
+	const detail = error instanceof Error ? error.message : String(error);
+	const bounded = detail
+		.replace(/[\u0000-\u001f\u007f]/g, " ")
+		.trim()
+		.slice(0, MAX_SUBSTRATE_DIAGNOSTIC_LENGTH);
+	return `${selected} substrate launch failed${bounded ? `: ${bounded}` : ""}`;
 }
 
 function hasOnlyKeys(value: Record<string, unknown>, keys: Set<string>): boolean {
@@ -355,6 +366,57 @@ export function createSpawnSubstrateProvider(
 	const signalHeadless = dependencies.signalHeadless ?? signalExactHeadless;
 	const isGone = dependencies.isProcessGone ?? defaultIsProcessGone;
 	const sleep = dependencies.sleep ?? (milliseconds => Bun.sleep(milliseconds));
+	const launchHeadlessSubstrate = async (spec: SpawnSubstrateLaunchSpec, launchEnv: NodeJS.ProcessEnv) => {
+		let child: SpawnHeadlessProcess;
+		try {
+			child = launchHeadless(spec, launchEnv);
+		} catch {
+			return {
+				ok: false as const,
+				code: "substrate_unavailable" as const,
+				message: messageFor("substrate_unavailable"),
+			};
+		}
+		const incarnation = readIncarnation(child.pid);
+		if (!incarnation) {
+			child.terminate();
+			return {
+				ok: false as const,
+				code: "substrate_proof_failed" as const,
+				message: messageFor("substrate_proof_failed"),
+			};
+		}
+		const providerIdentity = crypto.randomUUID();
+		const state: HeadlessState = {
+			version: 1,
+			pid: child.pid,
+			processIncarnation: incarnation,
+			providerIdentity,
+			childSessionId: spec.childSessionId,
+			createdAt: Date.now(),
+		};
+		const stateFile = stateFileFor(spec, providerIdentity);
+		try {
+			await writeHeadlessState(stateFile, state);
+		} catch {
+			child.terminate();
+			return {
+				ok: false as const,
+				code: "substrate_proof_failed" as const,
+				message: messageFor("substrate_proof_failed"),
+			};
+		}
+		return {
+			ok: true as const,
+			proof: {
+				substrateKind: "headless" as const,
+				providerIdentity,
+				pid: child.pid,
+				processIncarnation: incarnation,
+				stateFileProof: { stateFile, childSessionId: spec.childSessionId },
+			},
+		};
+	};
 
 	const provider: SpawnSubstrateProvider = {
 		async launch(spec) {
@@ -376,8 +438,23 @@ export function createSpawnSubstrateProvider(
 				let managed: ManagedTmuxLaunchProof;
 				try {
 					managed = launchManaged(spec, launchEnv, platform);
-				} catch {
-					return { ok: false, code: "substrate_proof_failed", message: messageFor("substrate_proof_failed") };
+				} catch (error) {
+					const failure = launchFailureMessage(selected, error);
+					try {
+						const fallback = await launchHeadlessSubstrate(spec, launchEnv);
+						if (fallback.ok) return fallback;
+						return {
+							ok: false,
+							code: fallback.code,
+							message: `${failure}; headless substrate failed: ${fallback.message}`,
+						};
+					} catch (fallbackError) {
+						return {
+							ok: false,
+							code: "substrate_unavailable",
+							message: `${failure}; headless substrate failed: ${launchFailureMessage("headless", fallbackError)}`,
+						};
+					}
 				}
 				const incarnation = readIncarnation(managed.pid);
 				if (!incarnation || verifyManaged(managed, launchEnv) !== "verified") {
@@ -386,7 +463,14 @@ export function createSpawnSubstrateProvider(
 					} catch {
 						// The managed close primitive is already exact-proof fenced. Retain its result only in authority state.
 					}
-					return { ok: false, code: "substrate_proof_failed", message: messageFor("substrate_proof_failed") };
+					const failure = launchFailureMessage(selected, new Error("exact substrate proof failed"));
+					const fallback = await launchHeadlessSubstrate(spec, launchEnv);
+					if (fallback.ok) return fallback;
+					return {
+						ok: false,
+						code: fallback.code,
+						message: `${failure}; headless substrate failed: ${fallback.message}`,
+					};
 				}
 				return {
 					ok: true,
@@ -400,43 +484,7 @@ export function createSpawnSubstrateProvider(
 					},
 				};
 			}
-			let child: SpawnHeadlessProcess;
-			try {
-				child = launchHeadless(spec, launchEnv);
-			} catch {
-				return { ok: false, code: "substrate_unavailable", message: messageFor("substrate_unavailable") };
-			}
-			const incarnation = readIncarnation(child.pid);
-			if (!incarnation) {
-				child.terminate();
-				return { ok: false, code: "substrate_proof_failed", message: messageFor("substrate_proof_failed") };
-			}
-			const providerIdentity = crypto.randomUUID();
-			const state: HeadlessState = {
-				version: 1,
-				pid: child.pid,
-				processIncarnation: incarnation,
-				providerIdentity,
-				childSessionId: spec.childSessionId,
-				createdAt: Date.now(),
-			};
-			const stateFile = stateFileFor(spec, providerIdentity);
-			try {
-				await writeHeadlessState(stateFile, state);
-			} catch {
-				child.terminate();
-				return { ok: false, code: "substrate_proof_failed", message: messageFor("substrate_proof_failed") };
-			}
-			return {
-				ok: true,
-				proof: {
-					substrateKind: "headless",
-					providerIdentity,
-					pid: child.pid,
-					processIncarnation: incarnation,
-					stateFileProof: { stateFile, childSessionId: spec.childSessionId },
-				},
-			};
+			return launchHeadlessSubstrate(spec, launchEnv);
 		},
 		async verify(proof) {
 			const managed = managedProofFrom(proof);

--- a/packages/coding-agent/src/sdk/router/session-router.ts
+++ b/packages/coding-agent/src/sdk/router/session-router.ts
@@ -450,6 +450,10 @@ async function lstatEndpoint(file: string): Promise<SessionEndpointIdentity | un
 	};
 }
 
+function warningAffectsSession(warning: string, sessionId: string): boolean {
+	return !warning.startsWith("Session ") || warning.includes(`Session ${sessionId} `);
+}
+
 function sameEndpointIdentity(expected: SessionEndpointIdentity, current: SessionEndpointIdentity): boolean {
 	return (
 		expected.mtimeMs === current.mtimeMs &&
@@ -786,8 +790,9 @@ export class SessionRouter {
 		if (!attached || !current || !capability)
 			throw new SessionRouterError("pre_send", "Broker session endpoint could not be attached.");
 		const listing = this.#index.listSessions();
-		const indexedCurrent =
-			listing.warnings.length === 0 ? listing.sessions.find(item => item.sessionId === sessionId) : undefined;
+		const indexedCurrent = listing.warnings.some(warning => warningAffectsSession(warning, sessionId))
+			? undefined
+			: listing.sessions.find(item => item.sessionId === sessionId);
 		if (indexedCurrent && sameIndexedAuthority(indexed, indexedCurrent))
 			await this.#serialReconcile(this.#runEpoch, true, true);
 		return capability;
@@ -959,7 +964,7 @@ export class SessionRouter {
 		try {
 			await this.#index.refresh();
 			const listing = this.#index.listSessions();
-			if (listing.warnings.length > 0) return undefined;
+			if (listing.warnings.some(warning => warningAffectsSession(warning, sessionId))) return undefined;
 			indexed = listing.sessions.find(candidate => candidate.sessionId === sessionId);
 		} catch {
 			return undefined;
@@ -1031,7 +1036,7 @@ export class SessionRouter {
 			await this.#index.open();
 			await this.#index.refresh();
 			const listing = this.#index.listSessions();
-			if (listing.warnings.length > 0)
+			if (listing.warnings.some(warning => warningAffectsSession(warning, sessionId)))
 				throw new SessionActivationError(
 					"session_not_live",
 					"Session activation requires an intact session index.",
@@ -1209,54 +1214,51 @@ export class SessionRouter {
 			return;
 		}
 		const indexed = this.#index.listSessions();
-		const live =
-			indexed.warnings.length === 0
-				? indexed.sessions.filter(
-						session =>
-							session.live &&
-							isSessionAuthorityEligible(session) &&
-							!session.terminalUncertain &&
-							(this.#sessionIds === undefined || this.#sessionIds.has(session.sessionId)),
-					)
-				: [];
+		const live = indexed.sessions.filter(
+			session =>
+				!indexed.warnings.some(warning => warningAffectsSession(warning, session.sessionId)) &&
+				session.live &&
+				isSessionAuthorityEligible(session) &&
+				!session.terminalUncertain &&
+				(this.#sessionIds === undefined || this.#sessionIds.has(session.sessionId)),
+		);
 		const liveIds = new Set(live.map(session => session.sessionId));
 		const attachedIds = new Set<string>();
-		if (indexed.warnings.length === 0) {
-			for (const [sessionId, adopted] of [...this.#adopted]) {
-				const attached = this.#sessions.get(sessionId);
-				const indexedSession = indexed.sessions.find(session => session.sessionId === sessionId);
-				if (!attached || attached.capability !== adopted.attachment) {
+		for (const [sessionId, adopted] of [...this.#adopted]) {
+			if (indexed.warnings.some(warning => warningAffectsSession(warning, sessionId))) continue;
+			const attached = this.#sessions.get(sessionId);
+			const indexedSession = indexed.sessions.find(session => session.sessionId === sessionId);
+			if (!attached || attached.capability !== adopted.attachment) {
+				this.#adopted.delete(sessionId);
+				continue;
+			}
+			const exactIndex =
+				indexedSession?.live === true &&
+				isSessionAuthorityEligible(indexedSession) &&
+				!indexedSession.terminalUncertain &&
+				indexedSession.endpointGeneration === adopted.generation &&
+				indexedSession.pid === adopted.pid &&
+				indexedSession.endpointMtimeMs === adopted.endpointMtimeMs;
+			const endpoint = exactIndex ? await this.#readEndpoint(indexedSession).catch(() => null) : null;
+			if (
+				!exactIndex ||
+				!endpoint ||
+				endpoint.pid !== adopted.pid ||
+				endpoint.url !== attached.endpoint.url ||
+				endpoint.token !== attached.endpoint.token
+			) {
+				this.#adopted.delete(sessionId);
+				await this.#retireAttachment(attached);
+				continue;
+			}
+			try {
+				if (await this.#publishAttachment(attached, true)) {
 					this.#adopted.delete(sessionId);
-					continue;
+					attachedIds.add(sessionId);
 				}
-				const exactIndex =
-					indexedSession?.live === true &&
-					isSessionAuthorityEligible(indexedSession) &&
-					!indexedSession.terminalUncertain &&
-					indexedSession.endpointGeneration === adopted.generation &&
-					indexedSession.pid === adopted.pid &&
-					indexedSession.endpointMtimeMs === adopted.endpointMtimeMs;
-				const endpoint = exactIndex ? await this.#readEndpoint(indexedSession).catch(() => null) : null;
-				if (
-					!exactIndex ||
-					!endpoint ||
-					endpoint.pid !== adopted.pid ||
-					endpoint.url !== attached.endpoint.url ||
-					endpoint.token !== attached.endpoint.token
-				) {
-					this.#adopted.delete(sessionId);
-					await this.#retireAttachment(attached);
-					continue;
-				}
-				try {
-					if (await this.#publishAttachment(attached, true)) {
-						this.#adopted.delete(sessionId);
-						attachedIds.add(sessionId);
-					}
-				} catch {
-					this.#adopted.delete(sessionId);
-					await this.#retireAttachment(attached);
-				}
+			} catch {
+				this.#adopted.delete(sessionId);
+				await this.#retireAttachment(attached);
 			}
 		}
 		let nextAttachment = 0;
@@ -1419,7 +1421,7 @@ export class SessionRouter {
 			return null;
 		await this.#index.refresh();
 		const listing = this.#index.listSessions();
-		if (listing.warnings.length > 0) return null;
+		if (listing.warnings.some(warning => warningAffectsSession(warning, indexed.sessionId))) return null;
 		const current = listing.sessions.find(session => session.sessionId === indexed.sessionId);
 		if (!current || !sameIndexedAuthority(indexed, current)) return null;
 		return { endpoint, identity: provenIdentity };

--- a/packages/coding-agent/test/sdk-session-router-authority.test.ts
+++ b/packages/coding-agent/test/sdk-session-router-authority.test.ts
@@ -1527,6 +1527,24 @@ describe("SessionRouter dispatch authority", () => {
 		expect(fixture.clients[0]?.requests).toEqual([{ type: "event_replay", sinceSeq: 0, sinceGeneration: 1 }]);
 		await fixture.router.stop();
 	});
+	test("retains a proven attachment when warnings name another session", async () => {
+		const fixture = await routerFixture();
+		fixture.authority.warnings = ["Session another-session has a legacy locator row and must re-register."];
+
+		const response = await fixture.router.request(
+			fixture.sessionId,
+			{
+				type: "control_request",
+				id: "state",
+				operation: "session.state",
+				input: {},
+			},
+			1,
+		);
+		expect(response).toEqual({ events: [] });
+		expect(fixture.router.attachment(fixture.sessionId)).not.toBeNull();
+		await fixture.router.stop();
+	});
 	test("rejects activation when the exact endpoint rotates after connecting", async () => {
 		let fixture!: RouterFixture;
 		fixture = await routerFixture({

--- a/packages/coding-agent/test/sdk-spawn-substrate.test.ts
+++ b/packages/coding-agent/test/sdk-spawn-substrate.test.ts
@@ -150,7 +150,9 @@ describe("Broker spawn substrate provider", () => {
 		});
 	});
 
-	it("returns a typed proof failure after managed tagging or identity failure without falling back to headless", async () => {
+	it("falls back to an exact headless proof after managed substrate launch failure", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-spawn-substrate-"));
+		temporaryDirectories.push(cwd);
 		let headlessStarted = false;
 		const provider = createSpawnSubstrateProvider(
 			managedDependencies({
@@ -163,12 +165,30 @@ describe("Broker spawn substrate provider", () => {
 				},
 			}),
 		);
+		await expect(provider.launch(launchSpec(cwd))).resolves.toMatchObject({
+			ok: true,
+			proof: { substrateKind: "headless", pid: 999 },
+		});
+		expect(headlessStarted).toBeTrue();
+	});
+
+	it("preserves both substrate diagnostics when every substrate fails", async () => {
+		const provider = createSpawnSubstrateProvider(
+			managedDependencies({
+				launchManaged: () => {
+					throw new Error("planned_spawn_failed: fork failed");
+				},
+				startHeadless: () => {
+					throw new Error("headless unavailable");
+				},
+			}),
+		);
 		await expect(provider.launch(launchSpec())).resolves.toEqual({
 			ok: false,
-			code: "substrate_proof_failed",
-			message: "The selected spawn substrate could not be proven exactly.",
+			code: "substrate_unavailable",
+			message:
+				"tmux substrate launch failed: planned_spawn_failed: fork failed; headless substrate failed: No safe spawn substrate is available.",
 		});
-		expect(headlessStarted).toBeFalse();
 	});
 
 	it("reports a reused pane PID with a different OS incarnation as a mismatch", async () => {


### PR DESCRIPTION
## What

Make SDK spawn fall back from a failed managed tmux allocation to the exact headless substrate, preserve diagnostics, and scope SessionRouter warnings to affected sessions.

## Why

A host can have tmux installed while PTY allocation is exhausted; the old path failed terminally, discarded the cause, and ignored a working headless substrate. Unrelated legacy locator warnings also disabled healthy peer routing. Fixes #5128.

## Testing

- `bun test packages/coding-agent/test/sdk-spawn-substrate.test.ts packages/coding-agent/test/sdk-session-router-authority.test.ts`
- `bun test packages/coding-agent/test/sdk-spawn-authority.test.ts packages/coding-agent/test/sdk-broker.test.ts packages/coding-agent/test/sdk-broker-spawn-log.test.ts packages/coding-agent/test/sdk-spawn-cli.test.ts`
- `bun --cwd=packages/coding-agent run check:types`

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

```text
gajae.pr-review-verdict.v1 merge-self-approved sha256:a795b4f81cefc04a2a99d068046353f17941ba8ad1d4825aef2580de039871dc reviewer:critic reviewer-id:Yeachan-Heo evidence:local-tests
```

---

- [x] Target branch is `dev`
- [x] Tested locally
- [ ] `bun check` passes (pre-existing unrelated Biome findings)
- [x] CHANGELOG updated (not user-facing documentation)
- [x] Verdict above matches the exact PR head
- [x] Risk classification above matches the actual review path taken

gajae.pr-self-review.v1 verdict:merge-self-approved base:7dfab8bdc0d5ef01ae8f723597ccb0e527108bd1 head:68943b931c9ce7e174cb18f56f5ab2665c1dc409 sha256:2871b445f9b09f16f02d67418081ba1c60f7f68650fdd8712332744edddd768d reviewer-id:Yeachan-Heo risk:low-risk extra:none evidence:local-tests
self-review-signature: sha256:b486a8245dc29e3afa3e42ceacca51415a33a0ae95d39bf73b9bd4cf9b238355
Signed-off-by: gaebal-gajae (clawdbot) 🦞