### PR TITLE
fix(sdk): accept headless close after proof unlink

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Headless SDK substrate close now reports success when exact teardown observes the recorded process gone even if cleanup unlinks the durable proof first; live or identity-ambiguous substrates still report `substrate_mismatch`. (#5130)
+
 - Windows session-state locks now drain late terminal reconciliation writes before disposal returns and safely reclaim valid dead transition claims during resume. (#5102)
 
 - Deferred MCP startup now releases queued idle yields as soon as readiness settles without bypassing prompt admission. Barrier extensions remain gated, rejected startup drops the wake without prompting, settled sessions retain the normal idle merge window, and readiness stays session-local. (#5085)

--- a/packages/coding-agent/src/sdk/broker/spawn-substrate.ts
+++ b/packages/coding-agent/src/sdk/broker/spawn-substrate.ts
@@ -518,20 +518,26 @@ export function createSpawnSubstrateProvider(
 			}
 			if (!isPositiveInteger(proof.pid) || !isNonEmptyString(proof.processIncarnation))
 				return { ok: false, code: "substrate_mismatch" };
+			const pid = proof.pid;
 			const closeFailure = (verdict: "verified" | "mismatch" | "gone") => ({
 				ok: false,
 				code: verdict === "verified" ? "substrate_close_pending" : `substrate_${verdict}`,
 			});
+			const verifyAfterSignal = async (): Promise<"verified" | "mismatch" | "gone"> => {
+				const verdict = await provider.verify(proof);
+				if (verdict === "mismatch" && readIncarnation(pid) === undefined && isGone(pid)) return "gone";
+				return verdict;
+			};
 			// Delivery starts shutdown; only a later exact proof of absence completes it.
 			if (!signalHeadless(proof.pid, proof.processIncarnation, platform, "SIGTERM")) {
-				const afterSignalFailure = await provider.verify(proof);
+				const afterSignalFailure = await verifyAfterSignal();
 				return afterSignalFailure === "gone" ? { ok: true } : closeFailure(afterSignalFailure);
 			}
 			const afterTerm = await waitForHeadlessExit(proof, provider.verify, sleep);
 			if (afterTerm === "gone") return { ok: true };
 			if (afterTerm !== "verified") return closeFailure(afterTerm);
 			if (!signalHeadless(proof.pid, proof.processIncarnation, platform, "SIGKILL")) {
-				const afterSignalFailure = await provider.verify(proof);
+				const afterSignalFailure = await verifyAfterSignal();
 				return afterSignalFailure === "gone" ? { ok: true } : closeFailure(afterSignalFailure);
 			}
 			const afterKill = await waitForHeadlessExit(proof, provider.verify, sleep);

--- a/packages/coding-agent/test/sdk-spawn-substrate.test.ts
+++ b/packages/coding-agent/test/sdk-spawn-substrate.test.ts
@@ -293,6 +293,34 @@ describe("Broker spawn substrate provider", () => {
 		expect(await provider.verify(launched.proof)).toBe("gone");
 	});
 
+	it("accepts a gone headless process when teardown unlinks its proof first", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gjc-spawn-substrate-"));
+		temporaryDirectories.push(cwd);
+		let live = true;
+		let stateFile: string | undefined;
+		const provider = createSpawnSubstrateProvider({
+			platform: "darwin",
+			selectMultiplexer: () => "none",
+			startHeadless: () => ({ pid: 994, terminate() {} }),
+			processIncarnation: () => (live ? "darwin:994" : undefined),
+			isProcessGone: () => !live,
+			signalHeadless: () => {
+				live = false;
+				if (stateFile) void fs.rm(stateFile, { force: true });
+				return true;
+			},
+			sleep: async () => {
+				await Bun.sleep(0);
+			},
+		});
+		const launched = await provider.launch(launchSpec(cwd));
+		expect(launched.ok).toBeTrue();
+		if (!launched.ok) throw new Error("headless substrate did not launch");
+		const candidateStateFile = launched.proof.stateFileProof?.stateFile;
+		stateFile = typeof candidateStateFile === "string" ? candidateStateFile : undefined;
+		expect(await provider.close(launched.proof)).toEqual({ ok: true });
+	});
+
 	it("closes only the requested exact sibling proof", async () => {
 		const first = managedProof();
 		const sibling = managedProof({


### PR DESCRIPTION
## What

Fix issue #5130: a headless substrate that was exactly verified, signalled by this provider, and observed gone now closes successfully even when teardown unlinks the durable proof before the post-signal verification read.

`substrate_mismatch` remains reserved for a live or identity-ambiguous substrate.

## Why

The state-file cleanup can race the process-exit observation. The old post-signal verification returned `mismatch` as soon as the proof file disappeared, despite the recorded process incarnation being gone and the exact teardown signal having been delivered.

## Testing

- `bun test packages/coding-agent/test/sdk-spawn-substrate.test.ts`
- `bun test packages/coding-agent/test/sdk-spawn-substrate.test.ts packages/coding-agent/test/sdk-spawn-authority.test.ts packages/coding-agent/test/sdk-broker.test.ts packages/coding-agent/test/sdk-broker-spawn-log.test.ts packages/coding-agent/test/sdk-spawn-cli.test.ts packages/coding-agent/test/sdk-session-router-authority.test.ts`
- `bun --cwd=packages/coding-agent run check:types`
- `bun run build:native`

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

gajae.pr-review-verdict.v1 merge-self-approved sha256:363d5ab797ee0ebba86c153c1df5cfa3e824bcae786846daaa0747b81459779d reviewer:critic reviewer-id:Yeachan-Heo evidence:focused-sdk-tests-and-exact-head-ci-requested

---

- [x] Target branch is `dev`
- [x] Tested locally
- [x] CHANGELOG updated (not user-facing documentation)
- [x] Verdict above matches the exact PR head
- [x] Risk classification above matches the actual review path taken

Fixes #5130.

Contract refreshed for exact current Dev base and head.