### PR TITLE
fix(sdk): apply headless exit handling during polling

### DIFF
--- a/packages/coding-agent/src/sdk/broker/spawn-substrate.ts
+++ b/packages/coding-agent/src/sdk/broker/spawn-substrate.ts
@@ -533,14 +533,14 @@ export function createSpawnSubstrateProvider(
 				const afterSignalFailure = await verifyAfterSignal();
 				return afterSignalFailure === "gone" ? { ok: true } : closeFailure(afterSignalFailure);
 			}
-			const afterTerm = await waitForHeadlessExit(proof, provider.verify, sleep);
+			const afterTerm = await waitForHeadlessExit(proof, verifyAfterSignal, sleep);
 			if (afterTerm === "gone") return { ok: true };
 			if (afterTerm !== "verified") return closeFailure(afterTerm);
 			if (!signalHeadless(proof.pid, proof.processIncarnation, platform, "SIGKILL")) {
 				const afterSignalFailure = await verifyAfterSignal();
 				return afterSignalFailure === "gone" ? { ok: true } : closeFailure(afterSignalFailure);
 			}
-			const afterKill = await waitForHeadlessExit(proof, provider.verify, sleep);
+			const afterKill = await waitForHeadlessExit(proof, verifyAfterSignal, sleep);
 			return afterKill === "gone" ? { ok: true } : closeFailure(afterKill);
 		},
 	};

--- a/packages/coding-agent/test/sdk-spawn-substrate.test.ts
+++ b/packages/coding-agent/test/sdk-spawn-substrate.test.ts
@@ -306,11 +306,10 @@ describe("Broker spawn substrate provider", () => {
 			isProcessGone: () => !live,
 			signalHeadless: () => {
 				live = false;
-				if (stateFile) void fs.rm(stateFile, { force: true });
 				return true;
 			},
 			sleep: async () => {
-				await Bun.sleep(0);
+				if (stateFile) await fs.rm(stateFile, { force: true });
 			},
 		});
 		const launched = await provider.launch(launchSpec(cwd));


### PR DESCRIPTION
## What

Follow-up to merged PR #5132 for issue #5130. Apply the unlink-aware post-signal verifier to both SIGTERM and SIGKILL polling paths, not only the signal-failure branches.

The first #5132 repair could still return `substrate_mismatch` when a successful signal was followed by proof unlink during `waitForHeadlessExit`.

## Testing

- `bun test packages/coding-agent/test/sdk-spawn-substrate.test.ts`
- `bun --cwd=packages/coding-agent run check:types`

## Risk classification

- [x] `low-risk` — ordinary fix/maintenance; the repository owner may use the explicit `merge-self-approved` solo verdict.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

gajae.pr-review-verdict.v1 merge-self-approved sha256:fb32484cb47718549631dc75a6718564fbd23ea380dc3e04d464df1ac0f1dc29 reviewer:critic reviewer-id:Yeachan-Heo evidence:focused-follow-up-test-and-exact-head-ci

---

- [x] Target branch is `dev`
- [x] Tested locally
- [x] CHANGELOG already updated by #5132
- [x] Verdict above matches the exact PR head
- [x] Risk classification above matches the actual review path taken

Fixes #5130.