### PR TITLE
docs(readme): add community desktop app link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/devswha/gajae-code-app"><strong>🖥️ Desktop app (experimental, community-built)</strong></a> — a third-party, community-built desktop interface for Gajae-Code. Not an official first-party app; use at your own discretion.
+</p>
+
+<p align="center">
   <a href="#quick-start">Quick Start</a> ·
   <a href="#why-gajae-code">Why</a> ·
   <a href="#bring-your-coding-plan">Coding Plans</a> ·


### PR DESCRIPTION
## What

Adds a prominent link to the community-built desktop app (https://github.com/devswha/gajae-code-app) near the top of the English README, right after the badges row and before the nav links.

## Why

Fixes #5135 by improving discoverability for the community-built desktop interface. The wording explicitly says it is experimental and community-built, not an official first-party app.

## Testing

- `bun test scripts/install-tests/install-docs-contract.test.ts scripts/verify-g002-gates.ts scripts/check-node20-baseline.test.ts scripts/check-public-version-sync.test.ts` — 38 pass; the combined command's gate script is blocked by the pre-existing missing `packages/coding-agent/src/internal-urls/docs-index.generated.ts` on exact current `dev`.
- `bun test scripts/install-tests/install-docs-contract.test.ts` — 1 pass.
- `git diff --check 527c3da8d6c26dd7580f8ed330700f35c352742f...8320f2c9409dbd214dd568a55fa4335855eedbb2` — passed.

## Risk classification

- [x] `low-risk` — ordinary docs-only README maintenance; no product code touched.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict

gajae.pr-review-verdict.v1 merge-self-approved sha256:483f9fbc33b4fd48b7dcd41f4d3ce86c8308d9b6db52f95c82b390504bf7f331 reviewer:human reviewer-id:Yeachan-Heo evidence:exact-head 527c3da8d6c26dd7580f8ed330700f35c352742f...8320f2c9409dbd214dd568a55fa4335855eedbb2; narrow docs verification passed; signed self-review comment updated

---

- [x] Target branch is `dev`
- [ ] `bun check` passes (not run; docs-only scope)
- [x] Tested locally
- [ ] CHANGELOG updated (not applicable to a README-only link)
- [x] Verdict above matches the exact PR head 8320f2c9409dbd214dd568a55fa4335855eedbb2 and base 527c3da8d6c26dd7580f8ed330700f35c352742f
- [x] Risk classification above matches the actual review path taken

Closes #5135