### PR TITLE
fix(crash): exclude eval and test-harness exceptions

### DIFF
--- a/packages/coding-agent/src/crash/index-store.ts
+++ b/packages/coding-agent/src/crash/index-store.ts
@@ -613,6 +613,7 @@ export function applyCrashEvent(index: CrashIndex, event: CrashEvent, now: numbe
 	}
 
 	// occurrence
+	if (event.provenance === "eval" || event.provenance === "bun_test") return false;
 	// Clear before deduplication: a replayed occurrence after main-index publish
 	// but before retirement-sidecar publish must still supersede a stale tombstone.
 	index.retiredFingerprints = index.retiredFingerprints.filter(fingerprint => fingerprint !== event.fingerprint);
@@ -698,6 +699,7 @@ async function recoverAndRecomputeRetainedCounts(index: CrashIndex, crashLogPath
 	const recordsByFingerprint = new Map<string, LoadedCrashRecord[]>();
 	const seenRecordIds = new Set<string>();
 	for (const record of parseRecoverableCrashRecords(contents)) {
+		if (record.provenance === "eval" || record.provenance === "bun_test") continue;
 		if (seenRecordIds.has(record.recordId)) continue;
 		seenRecordIds.add(record.recordId);
 		const records = recordsByFingerprint.get(record.fingerprint) ?? [];

--- a/packages/coding-agent/src/crash/record-loader.ts
+++ b/packages/coding-agent/src/crash/record-loader.ts
@@ -15,6 +15,7 @@ import {
 	CRASH_FINGERPRINT_VERSION,
 	CRASH_RECORD_MARKER,
 	type CrashFingerprint,
+	type CrashProvenance,
 	computeCrashFingerprint,
 	parseCrashRecordMarker,
 } from "@gajae-code/utils";
@@ -33,6 +34,7 @@ export interface LoadedCrashRecord {
 	readonly body: string;
 	/** The `Name: message` part of the header line. */
 	readonly headline: string;
+	readonly provenance?: CrashProvenance;
 }
 
 interface ParsedCrashRecord {
@@ -78,6 +80,7 @@ function parseCandidates(contents: string): ParsedCrashRecord[] {
 	let at = 0;
 	let buffer: string[] = [];
 	let started = false;
+	let provenance: CrashProvenance | undefined;
 	let pending: ParsedCrashRecord | undefined;
 	for (const line of contents.split("\n")) {
 		if (pending) {
@@ -92,6 +95,12 @@ function parseCandidates(contents: string): ParsedCrashRecord[] {
 				continue;
 			}
 			headline = header[2] ?? "";
+			const label = line.slice(line.indexOf("[") + 1, line.indexOf("]"));
+			const provenanceValue = label
+				.split(";")
+				.find(part => part.startsWith("provenance="))
+				?.slice(11);
+			provenance = provenanceValue === "eval" || provenanceValue === "bun_test" ? provenanceValue : undefined;
 			at = parsedAt;
 			buffer = [];
 			started = true;
@@ -116,6 +125,7 @@ function parseCandidates(contents: string): ParsedCrashRecord[] {
 						messageClass: fingerprint?.messageClass ?? "",
 						body: lines.join("\n").trimEnd(),
 						headline,
+						...(provenance === undefined ? {} : { provenance }),
 					},
 					complete: false,
 					bound: marker.version === CRASH_FINGERPRINT_VERSION && fingerprint !== undefined,

--- a/packages/coding-agent/test/crash-index-store.test.ts
+++ b/packages/coding-agent/test/crash-index-store.test.ts
@@ -17,6 +17,7 @@ import {
 	type CrashSignatureEntry,
 	type CrashStatePaths,
 	compactCrashIndex,
+	emptyCrashIndex,
 	listCrashSignatures,
 	parseCrashIndex,
 	readCrashIndex,
@@ -89,6 +90,20 @@ describe("compactCrashIndex", () => {
 		// Re-running with an empty journal must not change counts.
 		const again = await compactCrashIndex({ paths, now: NOW });
 		expect(again.signatures[fingerprintFor(1)]?.lifetimeCount).toBe(8);
+	});
+
+	it("excludes eval and Bun test occurrences without changing legacy or product events", () => {
+		const index = emptyCrashIndex();
+		expect(applyCrashEvent(index, { ...occurrence(fingerprintFor(90), recordId(90)), provenance: "eval" }, NOW)).toBe(
+			false,
+		);
+		expect(
+			applyCrashEvent(index, { ...occurrence(fingerprintFor(91), recordId(91)), provenance: "bun_test" }, NOW),
+		).toBe(false);
+		expect(applyCrashEvent(index, occurrence(fingerprintFor(92), recordId(92)), NOW)).toBe(true);
+		expect(index.signatures[fingerprintFor(90)]).toBeUndefined();
+		expect(index.signatures[fingerprintFor(91)]).toBeUndefined();
+		expect(index.signatures[fingerprintFor(92)]?.lifetimeCount).toBe(1);
 	});
 
 	it("keeps a maximum-sized legacy entry readable after a later occurrence compaction", async () => {

--- a/packages/utils/src/crash-journal.ts
+++ b/packages/utils/src/crash-journal.ts
@@ -22,6 +22,24 @@ export const CRASH_EVENT_KIND = "gjc-crash-event.v1";
 /** Preview cap for the message class carried by an event. */
 export const CRASH_EVENT_MESSAGE_MAX_BYTES = 256;
 
+/** Bounded execution provenance carried only on newly written occurrences. */
+export type CrashProvenance = "product" | "eval" | "bun_test";
+
+/**
+ * Classify only process-level harness modes that are explicit and stable.
+ * Everything else is product provenance, including source checkouts, CLI
+ * invocations, SDK/ACP hosts, and native-loader failures.
+ */
+export function detectCrashProvenance(
+	argv: readonly string[] = process.argv,
+	env: NodeJS.ProcessEnv = process.env,
+	execArgv: readonly string[] = process.execArgv,
+): CrashProvenance {
+	if (env.BUN_TEST !== undefined) return "bun_test";
+	if (execArgv[0] === "-e" || execArgv[0] === "--eval" || argv[0] === "-e" || argv[0] === "--eval") return "eval";
+	return "product";
+}
+
 export type CrashEvent =
 	| CrashOccurrenceEvent
 	| CrashRefusedEvent
@@ -38,6 +56,8 @@ export interface CrashOccurrenceEvent {
 	readonly at: number;
 	readonly errorName: string;
 	readonly messageClass: string;
+	/** Legacy events omit this and are treated as product crashes. */
+	readonly provenance?: CrashProvenance;
 }
 
 export interface CrashRefusedEvent {
@@ -109,6 +129,7 @@ export function formatCrashEventLine(event: CrashEvent): string {
 						id: event.recordId,
 						at: event.at,
 						n: sanitizeEventText(truncateUtf8(event.errorName, 64)),
+						...(event.provenance && event.provenance !== "product" ? { p: event.provenance } : {}),
 						...(messageClass === undefined ? {} : { m: messageClass }),
 					}
 				: event.kind === "reported"
@@ -181,7 +202,19 @@ export function parseCrashEventLine(line: string): CrashEvent | undefined {
 			if (typeof body.fpv !== "number" || !Number.isSafeInteger(body.fpv) || body.fpv < 1) return undefined;
 			const errorName = typeof body.n === "string" ? sanitizeEventText(body.n) : "Error";
 			const messageClass = typeof body.m === "string" ? sanitizeEventText(body.m) : "";
-			return { kind: "occurrence", fingerprint, fpv: body.fpv, recordId: body.id, at, errorName, messageClass };
+			const provenance = body.p === undefined ? undefined : body.p;
+			if (provenance !== undefined && provenance !== "product" && provenance !== "eval" && provenance !== "bun_test")
+				return undefined;
+			return {
+				kind: "occurrence",
+				fingerprint,
+				fpv: body.fpv,
+				recordId: body.id,
+				at,
+				errorName,
+				messageClass,
+				...(provenance === undefined ? {} : { provenance }),
+			};
 		}
 		case "reported": {
 			if (!fingerprint) return undefined;

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -13,7 +13,8 @@ import * as path from "node:path";
 import { isMainThread } from "node:worker_threads";
 import { BROKEN_PIPE_EXIT_CODE, createProcessStdoutEpipeClassifier } from "./broken-pipe";
 import { type CrashFingerprint, computeCrashFingerprint, formatCrashRecordMarker } from "./crash-fingerprint";
-import { appendCrashEvent, appendFatalCrashEvent } from "./crash-journal";
+import type { CrashProvenance } from "./crash-journal";
+import { appendCrashEvent, appendFatalCrashEvent, detectCrashProvenance } from "./crash-journal";
 import { redactCrashSecrets } from "./crash-redaction";
 import { getCrashEventsPath, getCrashLogPath, getHandledErrorEventsPath, getHandledErrorLogPath } from "./dirs";
 import * as logger from "./logger";
@@ -460,7 +461,8 @@ function boundCrashRecord(report: string, maxBytes: number = CRASH_RECORD_MAX_BY
  * `process.exit`. Returns the path written, or `undefined` on failure.
  */
 export function recordFatalCrash(label: string, reason: unknown, options: CrashRecordOptions = {}): string | undefined {
-	const written = writeCrashRecord(label, describeFatal(reason), options);
+	const provenance = detectCrashProvenance();
+	const written = writeCrashRecord(label, describeFatal(reason), { ...options, provenance });
 	if (!written) return undefined;
 	appendFatalCrashEvent(
 		{
@@ -471,11 +473,18 @@ export function recordFatalCrash(label: string, reason: unknown, options: CrashR
 			at: written.now.getTime(),
 			errorName: written.fingerprint.errorName,
 			messageClass: written.fingerprint.messageClass,
+			provenance,
 		},
 		getCrashEventsTarget(written.target, options.path),
 	);
 	return written.target;
 }
+
+/**
+ * Classify only process-level harness modes that are explicit and stable.
+ * Everything else is product provenance, including source checkouts, CLI
+ * invocations, SDK/ACP hosts, and native-loader failures.
+ */
 
 const handledErrorFingerprints = new Set<string>();
 const HANDLED_ERROR_FINGERPRINT_LIMIT = 256;
@@ -552,6 +561,7 @@ export function resetHandledErrorDedupeForTest(): void {
 interface CrashRecordOptions {
 	path?: string;
 	now?: Date;
+	provenance?: CrashProvenance;
 }
 
 interface WrittenCrashRecord {
@@ -591,7 +601,7 @@ function writeCrashRecord(
 		// The marker is the record's identity, so it is budgeted first and appended
 		// after truncation: an oversized body can never evict it.
 		const body = boundCrashRecord(
-			`${now.toISOString()} pid=${process.pid} [${label}] ` +
+			`${now.toISOString()} pid=${process.pid} [${label}${options.provenance && options.provenance !== "product" ? `;provenance=${options.provenance}` : ""}] ` +
 				`${redactCrashSecrets(fatal.name)}: ${redactCrashSecrets(fatal.message)}\n` +
 				`${stack}${payload}`,
 			CRASH_RECORD_MAX_BYTES - Buffer.byteLength(markerLine, "utf8") - 1,

--- a/packages/utils/test/crash-journal.test.ts
+++ b/packages/utils/test/crash-journal.test.ts
@@ -7,6 +7,7 @@ import {
 	appendCrashEvent,
 	CRASH_EVENT_MAX_BYTES,
 	type CrashOccurrenceEvent,
+	detectCrashProvenance,
 	formatCrashEventLine,
 	parseCrashEventLine,
 } from "../src/crash-journal";
@@ -32,9 +33,21 @@ function occurrence(overrides: Partial<CrashOccurrenceEvent> = {}): CrashOccurre
 }
 
 describe("crash event line", () => {
+	it("classifies explicit eval and inherited Bun test children without changing product defaults", () => {
+		expect(detectCrashProvenance([], {}, ["-e", "throw new Error()"])).toBe("eval");
+		expect(detectCrashProvenance(["gjc"], { BUN_TEST: "1" }, ["script.ts"])).toBe("bun_test");
+		expect(detectCrashProvenance(["gjc", "launch"], {}, ["script.ts"])).toBe("product");
+	});
+
 	it("round-trips an occurrence", () => {
 		const line = formatCrashEventLine(occurrence());
 		expect(parseCrashEventLine(line)).toEqual(occurrence());
+	});
+
+	it("round-trips non-product provenance while legacy events remain unchanged", () => {
+		const event = occurrence({ provenance: "bun_test" });
+		expect(parseCrashEventLine(formatCrashEventLine(event))).toEqual(event);
+		expect(parseCrashEventLine(formatCrashEventLine(occurrence()))).toEqual(occurrence());
 	});
 
 	it("keeps a hostile oversized message inside the 512-byte line budget", () => {
@@ -104,6 +117,34 @@ describe("appendCrashEvent", () => {
 });
 
 describe("recordFatalCrash identity", () => {
+	it("marks eval and inherited Bun test children while leaving a CLI script as product", () => {
+		const dir = tempDir();
+		const modulePath = path.resolve(import.meta.dir, "../src/postmortem.ts");
+		const run = (args: string[], env: Record<string, string>, suffix: string) => {
+			const target = path.join(dir, `${suffix}.log`);
+			const journal = path.join(dir, "gjc-crash-events.jsonl");
+			const source =
+				`import { recordFatalCrash } from ${JSON.stringify(modulePath)};\n` +
+				`recordFatalCrash("Uncaught Exception", new Error("${suffix}"), { path: ${JSON.stringify(target)} });\n`;
+			const script = path.join(dir, `${suffix}.ts`);
+			fs.writeFileSync(script, source);
+			const spawned = Bun.spawnSync({
+				cmd: args.length === 0 ? [process.execPath, script] : [process.execPath, ...args],
+				env,
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			expect(spawned.exitCode).toBe(0);
+			const event = parseCrashEventLine(fs.readFileSync(journal, "utf8").split("\n").filter(Boolean).at(-1) ?? "");
+			return event?.kind === "occurrence" ? event.provenance : undefined;
+		};
+		const cleanEnv = { ...process.env } as Record<string, string>;
+		delete cleanEnv.BUN_TEST;
+		expect(run(["-e", `await import(${JSON.stringify(path.join(dir, "eval.ts"))})`], cleanEnv, "eval")).toBe("eval");
+		expect(run([], { ...cleanEnv, BUN_TEST: "1" }, "bun-test")).toBe("bun_test");
+		expect(run([], cleanEnv, "cli")).toBeUndefined();
+	});
+
 	it("appends a parseable identity line and journals the occurrence beside the log", () => {
 		const dir = tempDir();
 		const target = path.join(dir, "gjc-crash.log");


### PR DESCRIPTION
## Summary
- classify explicit Bun eval and inherited Bun test child crashes with bounded provenance
- keep eval/test-harness occurrences out of the normal crash index, nudge, and report candidate path
- preserve legacy journal events and genuine product CLI/runtime crashes

Closes #5137

## Risk classification
- [x] `low-risk`
- [ ] `regression-risk`
- [ ] `high-risk`

gajae.pr-review-verdict.v1 merge-self-approved sha256:71b2c709a8cc7000f161cd4562525e83501a19bc25da864c83142067a03eb8b5 reviewer:human reviewer-id:Yeachan-Heo evidence:bounded crash provenance filtering with deterministic eval, Bun test child, product CLI, and legacy coverage

## Verification
- `bun test packages/utils/test/crash-journal.test.ts packages/utils/test/postmortem-crash-log.test.ts packages/coding-agent/test/crash-index-store.test.ts packages/coding-agent/test/crash-record-loader.test.ts packages/coding-agent/test/crash-nudge.test.ts packages/coding-agent/test/crash-report-flow.test.ts`
- 107 passing, 0 failing
- `bun --cwd=packages/utils run check:types`
- `bun --cwd=packages/coding-agent run check:types`
- `bunx biome check` on all changed files

No private crash journal contents are included. Provenance evidence is deterministic test output only.