### PR TITLE
fix(tmux): stop owner-isolation CLI parser crash

### DIFF
--- a/packages/coding-agent/src/gjc-runtime/tmux-owner-isolation-cli.ts
+++ b/packages/coding-agent/src/gjc-runtime/tmux-owner-isolation-cli.ts
@@ -201,12 +201,9 @@ export async function runTmuxOwnerIsolationCliFromStdin(): Promise<void> {
 	const stdin = await readOneBoundedJsonLine();
 	const output = stdin === null ? cliFailure("invalid_json_line") : await runTmuxOwnerIsolationCli(stdin);
 	process.stdout.write(`${output}\n`);
-	const request = stdin === null ? null : parseOwnerIsolationRequest(stdin);
-	if (request?.op === "bootstrap") {
-		try {
-			if (JSON.parse(output).ok !== true) process.exitCode = 1;
-		} catch {
-			process.exitCode = 1;
-		}
+	try {
+		if (JSON.parse(output).ok === false) process.exitCode = 1;
+	} catch {
+		process.exitCode = 1;
 	}
 }

--- a/packages/coding-agent/test/gjc-runtime/tmux-owner-isolation.test.ts
+++ b/packages/coding-agent/test/gjc-runtime/tmux-owner-isolation.test.ts
@@ -213,7 +213,7 @@ describe("tmux owner isolation", () => {
 			const privateMarker = "private-payload-must-not-appear";
 			const result = await runOwnerIsolationEntry(command, `{"private":"${privateMarker}"}\n`);
 			expect(result).toEqual({
-				exitCode: 0,
+				exitCode: 1,
 				stdout: invalidJsonLineResponse,
 				stderr: "",
 			});
@@ -317,7 +317,7 @@ describe("tmux owner isolation", () => {
 			'{"private":"private-payload-must-not-appear"}\nextra\n',
 		);
 		expect(result).toEqual({
-			exitCode: 0,
+			exitCode: 1,
 			stdout: invalidJsonLineResponse,
 			stderr: "",
 		});
@@ -329,7 +329,7 @@ describe("tmux owner isolation", () => {
 			`${"x".repeat(TMUX_OWNER_ISOLATION_MAX_LINE_BYTES + 1)}\n`,
 		);
 		expect(result).toEqual({
-			exitCode: 0,
+			exitCode: 1,
 			stdout: invalidJsonLineResponse,
 			stderr: "",
 		});


### PR DESCRIPTION
## What
Fix the tmux owner-isolation stdin entrypoint so it derives process status from the bounded structured response rather than parsing the request a second time.

## Why
Closes #5136. The owner-isolation CLI must return a bounded structured failure for malformed input without an uncaught parser crash.

## Testing
- `bun test packages/coding-agent/test/gjc-runtime/tmux-owner-isolation.test.ts` — 51 pass, 0 fail.
- Source CLI, packaged `bin/gjc.js`, and direct `main.ts` malformed-input replays returned the structured invalid-json response with exit code 1.
- Native addon built locally for the focused production-entrypoint suite.

## Risk classification
- [x] `low-risk` — ordinary fix/maintenance; exact-head self-review authorization is used.
- [ ] `regression-risk`
- [ ] `high-risk`

## GJC verdict
gajae.pr-review-verdict.v1 merge-self-approved sha256:fd9f9f96ba8d997c3cc58e135c30ad8ab3de14b9dcccb35a181701b94c3da77f reviewer:human reviewer-id:Yeachan-Heo evidence:https://github.com/Yeachan-Heo/gajae-code/pull/5141

- [x] Target branch is `dev`
- [x] Tested locally
- [x] Verdict above matches exact PR head 84ced614083daf072972bfc07d753c462a0ecf09
- [ ] CHANGELOG updated (not user-facing)